### PR TITLE
feat(web): session tabs mirroring the TUI (#1592 Phase 5 PR7)

### DIFF
--- a/daemon/action_id_resolution_test.go
+++ b/daemon/action_id_resolution_test.go
@@ -216,6 +216,54 @@ func TestSendPromptByIDTargetsRightSession(t *testing.T) {
 	}
 }
 
+// TestCreateCloseTabByIDTargetsRightSession pins id-first targeting for the tab
+// mutations (#1592 Phase 5 PR7): with two same-title sessions in different repos,
+// a web-shaped CreateTab/CloseTab addressed by id (empty repo_id) must grow/shrink
+// the ADDRESSED session's tab list and leave the other same-title session's tabs
+// untouched — where a title-only request could resolve to either.
+func TestCreateCloseTabByIDTargetsRightSession(t *testing.T) {
+	manager, repoA, _, repoB, dataB := createDuplicateTitleSessions(t, "feature")
+	cs := &controlServer{manager: manager}
+
+	tabCount := func(repoID string) int {
+		inst, _, _, err := manager.findSession("feature", repoID)
+		if err != nil {
+			t.Fatalf("findSession(%s): %v", repoID, err)
+		}
+		return inst.TabCount()
+	}
+	if got := tabCount(repoA.ID); got != 1 {
+		t.Fatalf("session A starts with %d tabs, want 1", got)
+	}
+	if got := tabCount(repoB.ID); got != 1 {
+		t.Fatalf("session B starts with %d tabs, want 1", got)
+	}
+
+	// CreateTab addressed by id B (empty repo) lands the shell tab on B, not A.
+	var cResp CreateTabResponse
+	if err := cs.CreateTab(CreateTabRequest{ID: dataB.ID, Title: "feature", RepoID: "", Shell: true}, &cResp); err != nil {
+		t.Fatalf("CreateTab by id B: %v", err)
+	}
+	if got := tabCount(repoB.ID); got != 2 {
+		t.Fatalf("session B has %d tabs after CreateTab, want 2", got)
+	}
+	if got := tabCount(repoA.ID); got != 1 {
+		t.Fatalf("session A tab count changed to %d; CreateTab hit the wrong session", got)
+	}
+
+	// CloseTab addressed by id B removes the shell tab from B; A stays untouched.
+	var xResp CloseTabResponse
+	if err := cs.CloseTab(CloseTabRequest{ID: dataB.ID, Title: "feature", RepoID: "", TabName: cResp.Name}, &xResp); err != nil {
+		t.Fatalf("CloseTab by id B: %v", err)
+	}
+	if got := tabCount(repoB.ID); got != 1 {
+		t.Fatalf("session B has %d tabs after CloseTab, want 1", got)
+	}
+	if got := tabCount(repoA.ID); got != 1 {
+		t.Fatalf("session A tab count changed to %d; CloseTab hit the wrong session", got)
+	}
+}
+
 // TestActionWithStaleIDErrorsRatherThanRetargeting is the missing coverage Greptile
 // flagged (the residual stale-id leg): with two same-title/different-id sessions, a
 // web-shaped Kill/Archive/SendPrompt carrying a STALE non-empty id (naming a session

--- a/daemon/control_types.go
+++ b/daemon/control_types.go
@@ -175,6 +175,11 @@ type CreateTabRequest struct {
 	Command string `json:"command"`
 	Name    string `json:"name"`
 	Shell   bool   `json:"shell"`
+	// ID is the session's stable id; see KillSessionRequest.ID. When non-empty
+	// the daemon resolves the target session by id first, so a web tab-create
+	// can't hit the wrong session under a cross-repo title collision (#1592
+	// Phase 5 PR7). TUI/CLI callers omit it and resolve by {Title, RepoID}.
+	ID string `json:"id"`
 }
 
 type CreateTabResponse struct {
@@ -194,6 +199,11 @@ type CloseTabRequest struct {
 	RepoID   string `json:"repo_id"`
 	TabName  string `json:"tab_name"`
 	TabIndex int    `json:"tab_index"`
+	// ID is the session's stable id; see KillSessionRequest.ID. When non-empty
+	// the daemon resolves the target session by id first, so a web tab-close
+	// can't hit the wrong session under a cross-repo title collision (#1592
+	// Phase 5 PR7). TUI/CLI callers omit it and resolve by {Title, RepoID}.
+	ID string `json:"id"`
 }
 
 type CloseTabResponse struct {

--- a/daemon/manager_tabs.go
+++ b/daemon/manager_tabs.go
@@ -26,21 +26,26 @@ func (m *Manager) CreateTab(req CreateTabRequest) (string, error) {
 		return "", fmt.Errorf("a process tab requires a non-empty command (--command)")
 	}
 
-	instance, repoID, _, err := m.findSession(req.Title, req.RepoID)
+	// Resolve by stable id first (req.ID), falling back to {Title, RepoID} — the
+	// same id-preferring resolution kill/archive/prompt use, so a web tab-create
+	// under a cross-repo title collision can't hit the wrong session (#1592 Phase
+	// 5 PR7 / the #1678 class). All downstream lock keys and messages use the
+	// RESOLVED title, not the (possibly ambiguous) request title.
+	instance, repoID, title, _, _, err := m.resolveActionSession(req.ID, req.Title, req.RepoID)
 	if err != nil {
 		return "", err
 	}
 	if instance == nil {
-		return "", fmt.Errorf("failed to restore instance %q", req.Title)
+		return "", fmt.Errorf("failed to restore instance %q", title)
 	}
 	if !instance.Capabilities().TabManagement {
-		return "", fmt.Errorf("cannot create a tab on remote session %q: remote sessions have no local worktree and the hook protocol can't run arbitrary commands; their terminal tab comes from remote_hooks.terminal_cmd", req.Title)
+		return "", fmt.Errorf("cannot create a tab on remote session %q: remote sessions have no local worktree and the hook protocol can't run arbitrary commands; their terminal tab comes from remote_hooks.terminal_cmd", title)
 	}
 
 	// Serialize the tab spawn against an archive/kill/restore teardown+move for
 	// this session and reject if it is archived/mid-archive (#1195); see
 	// archiveExclusiveTabLock for the op-lock ordering and orphan rationale.
-	opLock, err := m.archiveExclusiveTabLock(daemonInstanceKey(repoID, req.Title), instance)
+	opLock, err := m.archiveExclusiveTabLock(daemonInstanceKey(repoID, title), instance)
 	if err != nil {
 		return "", err
 	}
@@ -73,7 +78,7 @@ func (m *Manager) CreateTab(req CreateTabRequest) (string, error) {
 		// Roll back the just-spawned tab so a persist failure does not leave a
 		// live tmux session that vanishes from the tab list on restart.
 		if closeErr := instance.CloseTab(instance.TabCount() - 1); closeErr != nil {
-			log.WarningLog.Printf("CreateTab %q: rolling back unpersisted tab failed: %v", req.Title, closeErr)
+			log.WarningLog.Printf("CreateTab %q: rolling back unpersisted tab failed: %v", title, closeErr)
 		}
 		return "", fmt.Errorf("failed to persist new tab: %w", err)
 	}
@@ -100,15 +105,20 @@ func (m *Manager) CreateTab(req CreateTabRequest) (string, error) {
 // orphan — the in-memory list (tab removed) is the more accurate state, and the
 // stale disk record is harmless (its session is dead and won't reconnect).
 func (m *Manager) CloseTab(req CloseTabRequest) (string, error) {
-	instance, repoID, _, err := m.findSession(req.Title, req.RepoID)
+	// Resolve by stable id first (req.ID), falling back to {Title, RepoID} — the
+	// same id-preferring resolution kill/archive/prompt use, so a web tab-close
+	// under a cross-repo title collision can't hit the wrong session (#1592 Phase
+	// 5 PR7 / the #1678 class). All downstream lock keys and messages use the
+	// RESOLVED title, not the (possibly ambiguous) request title.
+	instance, repoID, title, _, _, err := m.resolveActionSession(req.ID, req.Title, req.RepoID)
 	if err != nil {
 		return "", err
 	}
 	if instance == nil {
-		return "", fmt.Errorf("failed to restore instance %q", req.Title)
+		return "", fmt.Errorf("failed to restore instance %q", title)
 	}
 	if !instance.Capabilities().TabManagement {
-		return "", fmt.Errorf("cannot close a tab on remote session %q: its tabs are fixed by remote_hooks config, not user-managed", req.Title)
+		return "", fmt.Errorf("cannot close a tab on remote session %q: its tabs are fixed by remote_hooks config, not user-managed", title)
 	}
 
 	// Serialize the tab close against archive/kill/restore teardown for this
@@ -116,19 +126,19 @@ func (m *Manager) CloseTab(req CloseTabRequest) (string, error) {
 	// session; without this CloseTab can concurrently call TmuxSession.Close on
 	// the same object (#1434). Take this before the repo start lock, matching
 	// CreateTab and the kill/archive persist ordering.
-	key := daemonInstanceKey(repoID, req.Title)
+	key := daemonInstanceKey(repoID, title)
 	opLock := m.opLockFor(key)
 	opLock.Lock()
 	defer opLock.Unlock()
 
-	// findSession runs before the op-lock is acquired. If a kill/archive won the
-	// lock first, it may have deleted or replaced the tracked instance while we
-	// waited; never mutate or re-persist a stale pointer after teardown.
+	// resolveActionSession runs before the op-lock is acquired. If a kill/archive
+	// won the lock first, it may have deleted or replaced the tracked instance
+	// while we waited; never mutate or re-persist a stale pointer after teardown.
 	m.mu.Lock()
 	current := m.instances[key]
 	m.mu.Unlock()
 	if current != instance || instance.UserKilled() {
-		return "", fmt.Errorf("session %q changed state before tab close could start", req.Title)
+		return "", fmt.Errorf("session %q changed state before tab close could start", title)
 	}
 
 	// Serialize against other create/tab mutations on this repo, mirroring
@@ -151,16 +161,16 @@ func (m *Manager) CloseTab(req CloseTabRequest) (string, error) {
 			}
 		}
 		if idx < 0 {
-			return "", fmt.Errorf("session %q has no tab named %q", req.Title, name)
+			return "", fmt.Errorf("session %q has no tab named %q", title, name)
 		}
 	} else {
 		if idx < 0 || idx >= len(tabs) {
-			return "", fmt.Errorf("session %q has no tab at index %d", req.Title, idx)
+			return "", fmt.Errorf("session %q has no tab at index %d", title, idx)
 		}
 		name = tabs[idx].Name
 	}
 	if idx == 0 {
-		return "", fmt.Errorf("the agent tab of session %q can't be closed; kill the session instead", req.Title)
+		return "", fmt.Errorf("the agent tab of session %q can't be closed; kill the session instead", title)
 	}
 
 	if err := instance.CloseTab(idx); err != nil {

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -21,8 +21,8 @@ Request fields are the JSON keys of each route's request body; a `—` means the
 | `POST` | `/v1/RestoreSession` | `title`, `repo_id` | Restore an archived, Lost, or Dead session. |
 | `POST` | `/v1/SendPrompt` | `title`, `repo_id`, `prompt`, `id` | Send a prompt to an existing session's agent. |
 | `POST` | `/v1/DeliverPrompt` | `title`, `repo_path`, `program`, `prompt`, `auto_yes`, `defer_while_attached` | Deliver a prompt to a session, auto-creating it if it does not exist yet. |
-| `POST` | `/v1/CreateTab` | `title`, `repo_id`, `command`, `name`, `shell` | Spawn a tab (process or shell) in a session's worktree. |
-| `POST` | `/v1/CloseTab` | `title`, `repo_id`, `tab_name`, `tab_index` | Close a non-agent tab of a session (the agent tab cannot be closed). |
+| `POST` | `/v1/CreateTab` | `title`, `repo_id`, `command`, `name`, `shell`, `id` | Spawn a tab (process or shell) in a session's worktree. |
+| `POST` | `/v1/CloseTab` | `title`, `repo_id`, `tab_name`, `tab_index`, `id` | Close a non-agent tab of a session (the agent tab cannot be closed). |
 | `POST` | `/v1/SetPRInfo` | `title`, `repo_id`, `pr_info` | Record or clear the GitHub PR info for a session. |
 | `POST` | `/v1/ListTasks` | — | List every task across all repos. |
 | `POST` | `/v1/AddTask` | `task` | Append a new task and re-arm the scheduler. |

--- a/docs/web-selftest.md
+++ b/docs/web-selftest.md
@@ -42,6 +42,7 @@ Against the live SPA served over the daemon's TLS listener:
 | **Sidebar** | The rail lists the seeded sessions from the Snapshot/events plane, and the live pip reads "Live". |
 | **Attach** | Click-to-attach opens the xterm terminal and shows the fake agent's live output (a real binary PTY frame decoded by the TS codec and painted in the browser). |
 | **Keyboard (#1694)** | In rail mode `j`/`k` navigate the rail; `Enter` attaches the selection; `Escape` returns to the rail. |
+| **Tabs (#1592 PR7)** | The tab bar creates a shell tab (`+` / `t`), switches to it (click / `1`-`9`) and shows its distinct PTY output, and closes it (`×` / `w`) — the agent tab stays unclosable. |
 | **Create** | The **+ New** modal creates a session and its row appears in the rail. |
 | **Kill** | The kill confirm removes the session's row. |
 | **Archive** | The archive confirm moves a session into the archived group. |

--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -373,6 +373,97 @@ body {
 .af-term-meta.af-term-exited {
   color: var(--af-dot-dead);
 }
+.af-tabbar {
+  display: flex;
+  align-items: stretch;
+  gap: 0.15rem;
+  padding: 0 0.6rem;
+  background: var(--af-surface);
+  border-bottom: 1px solid var(--af-border);
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+.af-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.6rem;
+  background: transparent;
+  color: var(--af-muted);
+  border: none;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+  font: inherit;
+  font-size: 0.75rem;
+  white-space: nowrap;
+  cursor: pointer;
+}
+.af-tab:hover {
+  color: var(--af-text);
+}
+.af-tab-active {
+  color: var(--af-text);
+  border-bottom-color: var(--af-accent);
+}
+.af-tab-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 12rem;
+}
+.af-tab-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.1em;
+  height: 1.1em;
+  border-radius: 3px;
+  color: var(--af-muted);
+  font-size: 0.9rem;
+  line-height: 1;
+}
+.af-tab-close:hover {
+  color: var(--af-error);
+  background: rgba(248, 81, 73, 0.14);
+}
+.af-tab-new {
+  padding: 0.35rem 0.55rem;
+  background: transparent;
+  color: var(--af-accent);
+  border: none;
+  border-radius: 0;
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+}
+.af-tab-new:hover {
+  color: var(--af-text);
+}
+.af-toast {
+  position: fixed;
+  right: 1.25rem;
+  bottom: 1.25rem;
+  max-width: 24rem;
+  padding: 0.6rem 0.85rem;
+  background: var(--af-surface);
+  color: var(--af-text);
+  border: 1px solid var(--af-error);
+  border-left-width: 3px;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+  opacity: 0;
+  transform: translateY(0.4rem);
+  transition: opacity 0.15s ease, transform 0.15s ease;
+  pointer-events: none;
+  z-index: 20;
+}
+.af-toast.af-toast-show {
+  opacity: 1;
+  transform: translateY(0);
+}
 .af-term-host {
   flex: 1;
   min-height: 0;

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -6213,6 +6213,24 @@ async function killSession(id, title, token2) {
 async function archiveSession(id, title, token2) {
   await af("ArchiveSession", { id, title, repo_id: "" }, token2);
 }
+function requireSessionID(id, action) {
+  if (id === "") {
+    throw new ApiError(0, `cannot ${action}: this session has no stable id to target safely`);
+  }
+}
+async function createTab(id, title, token2) {
+  requireSessionID(id, "create a tab");
+  const resp = await af(
+    "CreateTab",
+    { id, title, repo_id: "", shell: true, command: "", name: "" },
+    token2
+  );
+  return resp.name;
+}
+async function closeTab(id, title, tabName, token2) {
+  requireSessionID(id, "close a tab");
+  await af("CloseTab", { id, title, repo_id: "", tab_name: tabName, tab_index: 0 }, token2);
+}
 
 // src/events.ts
 var BACKOFF_BASE_MS = 500;
@@ -6513,6 +6531,21 @@ function decideKey(key, ctx) {
   if (key === "Enter") {
     return ctx.selectedId ? { kind: "attach" } : { kind: "none" };
   }
+  if (ctx.selectedId) {
+    if (key.length === 1 && key >= "1" && key <= "9") {
+      const index = key.charCodeAt(0) - "1".charCodeAt(0);
+      if (index < ctx.tabCount && index !== ctx.activeTab) {
+        return { kind: "switchTab", index };
+      }
+      return { kind: "none" };
+    }
+    if (key === "t") {
+      return ctx.tabManagement ? { kind: "newTab" } : { kind: "none" };
+    }
+    if (key === "w") {
+      return ctx.tabManagement && ctx.activeTab > 0 ? { kind: "closeTab" } : { kind: "none" };
+    }
+  }
   let delta;
   if (key === "ArrowDown" || key === "j") {
     delta = 1;
@@ -6568,6 +6601,17 @@ function pickSelection(list, currentId) {
     return currentId;
   }
   return null;
+}
+function clampActiveTab(list, selectedId, activeTab) {
+  if (!selectedId) {
+    return 0;
+  }
+  const sel = list.find((s) => s.id === selectedId);
+  if (!sel) {
+    return 0;
+  }
+  const n = sel.tabs && sel.tabs.length > 0 ? sel.tabs.length : 1;
+  return Math.min(Math.max(activeTab, 0), n - 1);
 }
 
 // src/store.ts
@@ -6706,9 +6750,10 @@ function wsScheme2() {
   return window.location.protocol === "https:" ? "wss:" : "ws:";
 }
 var AttachTerminal = class {
-  constructor(container, sessionId, token2, cb) {
+  constructor(container, sessionId, token2, tab, cb) {
     this.sessionId = sessionId;
     this.token = token2;
+    this.tab = tab;
     this.cb = cb;
     this.term = new import_xterm.Terminal({
       allowProposedApi: true,
@@ -6797,6 +6842,9 @@ var AttachTerminal = class {
     const base = `${wsScheme2()}//${window.location.host}/v1/sessions/${encodeURIComponent(this.sessionId)}/stream`;
     const params = new URLSearchParams();
     params.set("access_token", this.token);
+    if (this.tab > 0) {
+      params.set("tab", String(this.tab));
+    }
     if (this.seeded) {
       params.set("since", this.cursor.toString());
     }
@@ -7079,6 +7127,25 @@ function formatLimitReset(reset, now) {
 }
 
 // src/ui.ts
+var MAX_TABS = 9;
+function supportsTabManagement(s) {
+  return s.backend_type !== "remote";
+}
+function sessionTabs(s) {
+  if (s.tabs && s.tabs.length > 0) {
+    return s.tabs;
+  }
+  return [{ name: "agent", kind: 0 }];
+}
+function tabLabel(tab) {
+  if (tab.kind === 0) {
+    return "Agent";
+  }
+  if (tab.kind === 1) {
+    return "Terminal";
+  }
+  return tab.name || "Tab";
+}
 function deriveProjects(sessions) {
   const roots = /* @__PURE__ */ new Set();
   for (const s of sessions) {
@@ -7255,7 +7322,9 @@ var AppShell = class {
     const rail = h2("nav", { class: "af-rail" }, railHead, this.railList);
     this.main = h2("section", { class: "af-main" });
     const body = h2("div", { class: "af-body" }, rail, this.main);
-    this.el = h2("main", { class: "af-app" }, header, body, this.modalHost);
+    this.toast = h2("div", { class: "af-toast" });
+    this.toast.setAttribute("role", "alert");
+    this.el = h2("main", { class: "af-app" }, header, body, this.toast, this.modalHost);
   }
   el;
   pip;
@@ -7263,14 +7332,22 @@ var AppShell = class {
   railCount;
   railList;
   main;
+  // A transient toast for failed tab ops (create/close), shown/hidden by `tabError`.
+  toast;
   // Header text nodes for the selected pane, (re)created per selection.
   headTitle = null;
   headMeta = null;
+  // The tab bar for the selected session, (re)created per selection and patched in
+  // place when the tab list or active tab changes (#1592 Phase 5 PR7). null when
+  // nothing is selected (the empty state has no tabs).
+  tabBar = null;
   // Last-applied state, for cheap change detection between updates.
   lastSessions = null;
   lastSelectedId = null;
   lastLive = null;
   lastKb = null;
+  lastActiveTab = 0;
+  lastError = null;
   /** Applies the latest state, touching only what changed. */
   update(state) {
     const kb = state.selectedId && state.focus === "terminal" ? "terminal" : "rail";
@@ -7278,6 +7355,11 @@ var AppShell = class {
       this.lastKb = kb;
       this.el.classList.toggle("af-kb-terminal", kb === "terminal");
       this.el.classList.toggle("af-kb-rail", kb === "rail");
+    }
+    if (this.lastError !== state.tabError) {
+      this.lastError = state.tabError;
+      this.toast.textContent = state.tabError ?? "";
+      this.toast.classList.toggle("af-toast-show", state.tabError !== null);
     }
     if (this.lastLive !== state.live) {
       this.lastLive = state.live;
@@ -7291,10 +7373,15 @@ var AppShell = class {
     if (sessionsChanged || selectionChanged) {
       this.renderRail(state);
     }
+    const activeTabChanged = this.lastActiveTab !== state.activeTab;
+    this.lastActiveTab = state.activeTab;
     if (selectionChanged) {
       this.renderMain(state);
     } else {
       this.patchMainHead(state);
+      if (sessionsChanged || activeTabChanged) {
+        this.renderTabBar(state);
+      }
     }
   }
   renderRail(state) {
@@ -7322,6 +7409,7 @@ var AppShell = class {
     if (!selected) {
       this.headTitle = null;
       this.headMeta = null;
+      this.tabBar = null;
       this.main.className = "af-main af-main-empty";
       this.main.replaceChildren(
         h2("p", { class: "af-empty-title" }, "Select a session"),
@@ -7340,9 +7428,36 @@ var AppShell = class {
     killBtn.addEventListener("click", () => this.actions.kill());
     const actions2 = h2("div", { class: "af-term-actions" }, promptBtn, archiveBtn, killBtn);
     const head = h2("div", { class: "af-term-head" }, titleBox, actions2);
+    this.tabBar = h2("div", { class: "af-tabbar" });
+    this.tabBar.setAttribute("role", "tablist");
+    this.tabBar.setAttribute("aria-label", "Session tabs");
     this.main.className = "af-main af-main-term";
-    this.main.replaceChildren(head, this.termHost);
+    this.main.replaceChildren(head, this.tabBar, this.termHost);
+    this.renderTabBar(state);
     this.patchMainHead(state);
+  }
+  /** (Re)builds the tab bar's buttons from the selected session's tabs, with the
+   *  active tab highlighted. Rebuilds only the bar's children, so the sibling
+   *  termHost — and the focused xterm in it — is never touched. */
+  renderTabBar(state) {
+    const bar = this.tabBar;
+    if (!bar) {
+      return;
+    }
+    const selected = selectedSession(state);
+    if (!selected) {
+      return;
+    }
+    const tabs = sessionTabs(selected);
+    const canManage = supportsTabManagement(selected);
+    const active = Math.min(Math.max(state.activeTab, 0), tabs.length - 1);
+    const children = tabs.map((tab, i) => tabButton(tab, i, i === active, canManage, this.actions));
+    if (canManage && tabs.length < MAX_TABS) {
+      const add = h2("button", { type: "button", class: "af-tab-new", title: "New tab" }, "+");
+      add.addEventListener("click", () => this.actions.newTab());
+      children.push(add);
+    }
+    bar.replaceChildren(...children);
   }
   patchMainHead(state) {
     const selected = selectedSession(state);
@@ -7360,6 +7475,23 @@ var AppShell = class {
 };
 function selectedSession(state) {
   return state.selectedId ? state.sessions.find((s) => s.id === state.selectedId) ?? null : null;
+}
+function tabButton(tab, index, active, canManage, actions2) {
+  const btn = h2("button", { type: "button", class: `af-tab${active ? " af-tab-active" : ""}` });
+  btn.setAttribute("role", "tab");
+  btn.setAttribute("aria-selected", active ? "true" : "false");
+  btn.append(h2("span", { class: "af-tab-label" }, tabLabel(tab)));
+  btn.addEventListener("click", () => actions2.openTab(index));
+  if (index > 0 && canManage) {
+    const close = h2("span", { class: "af-tab-close", title: "Close tab" }, "\xD7");
+    close.setAttribute("aria-hidden", "true");
+    close.addEventListener("click", (e) => {
+      e.stopPropagation();
+      actions2.closeTab(index);
+    });
+    btn.append(close);
+  }
+  return btn;
 }
 function sessionRow(s, selected, actions2) {
   const status = rowStatus(s);
@@ -7404,11 +7536,15 @@ var store = new Store({
   selectedId: null,
   live: "connecting",
   termStatus: "connecting",
-  focus: "rail"
+  focus: "rail",
+  activeTab: 0,
+  tabError: null
 });
 var token = null;
 var stream = null;
 var resyncTimer = null;
+var tabErrorTimer = null;
+var TAB_ERROR_MS = 6e3;
 var shell = null;
 var termHost = document.createElement("div");
 termHost.className = "af-term-host";
@@ -7417,6 +7553,7 @@ modalHost.className = "af-modal-host";
 var modal = null;
 var terminal = null;
 var terminalId = null;
+var terminalTab = 0;
 var root = null;
 function mount() {
   root = document.getElementById("app");
@@ -7490,7 +7627,9 @@ async function connect(candidate) {
     sessions,
     selectedId: pickSelection(sessions, store.get().selectedId),
     live: "connecting",
-    focus: "rail"
+    focus: "rail",
+    activeTab: 0,
+    tabError: null
   });
   startStream(candidate);
 }
@@ -7506,11 +7645,14 @@ function disconnect() {
     sessions: [],
     selectedId: null,
     live: "connecting",
-    focus: "rail"
+    focus: "rail",
+    activeTab: 0,
+    tabError: null
   });
 }
 function moveSelection(id) {
-  store.set({ selectedId: id, focus: "rail" });
+  clearTabError();
+  store.set({ selectedId: id, focus: "rail", activeTab: 0 });
 }
 function openFromRail(id) {
   moveSelection(id);
@@ -7560,7 +7702,7 @@ function newSession() {
           closeModal();
           if (created.id) {
             const sessions = upsertSession(store.get().sessions, created);
-            store.set({ sessions, selectedId: created.id });
+            store.set({ sessions, selectedId: created.id, activeTab: 0, tabError: null });
           }
         }).catch((e) => {
           m.setBusy(false);
@@ -7620,6 +7762,74 @@ function openConfirm(action) {
     })
   );
 }
+function selectedSessionData() {
+  const { sessions, selectedId } = store.get();
+  return sessions.find((s) => s.id === selectedId) ?? null;
+}
+function switchTab(index) {
+  store.set({ activeTab: index, focus: "rail" });
+}
+function openTab(index) {
+  store.set({ activeTab: index });
+  focusTerminal();
+}
+function createSessionTab() {
+  const sel = selectedSessionData();
+  const tok = token;
+  if (!sel || tok === null || !supportsTabManagement(sel)) {
+    return;
+  }
+  clearTabError();
+  const selId = sel.id ?? "";
+  void createTab(selId, sel.title, tok).then(() => fetchSnapshot(tok)).then((sessions) => {
+    const grown = sessions.find((s) => s.id === selId);
+    const newIdx = grown ? sessionTabs(grown).length - 1 : store.get().activeTab;
+    store.set({ sessions, selectedId: pickSelection(sessions, store.get().selectedId), activeTab: newIdx });
+    focusTerminal();
+  }).catch((e) => surfaceTabError(e));
+}
+function closeSessionTab(index) {
+  const sel = selectedSessionData();
+  const tok = token;
+  if (!sel || tok === null || index <= 0 || !supportsTabManagement(sel)) {
+    return;
+  }
+  const tabs = sessionTabs(sel);
+  const target = tabs[index];
+  if (!target) {
+    return;
+  }
+  clearTabError();
+  const selId = sel.id ?? "";
+  void closeTab(selId, sel.title, target.name, tok).then(() => fetchSnapshot(tok)).then((sessions) => {
+    const cur = store.get().activeTab;
+    const shrunk = sessions.find((s) => s.id === selId);
+    const n = shrunk ? sessionTabs(shrunk).length : 1;
+    const next = Math.min(Math.max(index <= cur ? cur - 1 : cur, 0), n - 1);
+    store.set({ sessions, selectedId: pickSelection(sessions, store.get().selectedId), activeTab: next });
+  }).catch((e) => surfaceTabError(e));
+}
+function surfaceTabError(e) {
+  const msg = e instanceof ApiError ? e.message : e.message;
+  console.error("af-web: tab operation failed:", msg);
+  if (tabErrorTimer !== null) {
+    window.clearTimeout(tabErrorTimer);
+  }
+  store.set({ tabError: msg });
+  tabErrorTimer = window.setTimeout(() => {
+    tabErrorTimer = null;
+    store.set({ tabError: null });
+  }, TAB_ERROR_MS);
+}
+function clearTabError() {
+  if (tabErrorTimer !== null) {
+    window.clearTimeout(tabErrorTimer);
+    tabErrorTimer = null;
+  }
+  if (store.get().tabError !== null) {
+    store.set({ tabError: null });
+  }
+}
 var actions = {
   connect,
   disconnect,
@@ -7627,18 +7837,24 @@ var actions = {
   newSession,
   sendPrompt: openSendPrompt,
   kill: () => openConfirm("kill"),
-  archive: () => openConfirm("archive")
+  archive: () => openConfirm("archive"),
+  switchTab,
+  openTab,
+  newTab: createSessionTab,
+  closeTab: closeSessionTab
 };
 function syncTerminal(state) {
   const selId = state.selectedId;
-  if (selId === terminalId) {
+  const tab = clampActiveTab(state.sessions, selId, state.activeTab);
+  if (selId === terminalId && tab === terminalTab) {
     return;
   }
   disposeTerminal();
   terminalId = selId;
+  terminalTab = tab;
   const tok = token;
   if (selId && tok !== null) {
-    terminal = new AttachTerminal(termHost, selId, tok, {
+    terminal = new AttachTerminal(termHost, selId, tok, tab, {
       onStatus: (s) => store.set({ termStatus: s }),
       // Keep the nav-vs-terminal mode (#1693) in sync with real xterm focus, so a
       // click straight into the terminal enters terminal mode (and tabbing/click
@@ -7653,6 +7869,7 @@ function disposeTerminal() {
     terminal = null;
   }
   terminalId = null;
+  terminalTab = 0;
   termHost.replaceChildren();
 }
 function startStream(tok) {
@@ -7676,10 +7893,16 @@ function stopStream() {
 }
 function onEvent(ev) {
   const { sessions, needsResync } = applyEvent(store.get().sessions, ev);
-  store.set({ sessions, selectedId: pickSelection(sessions, store.get().selectedId) });
+  applySessions(sessions);
   if (needsResync) {
     requestResync();
   }
+}
+function applySessions(sessions) {
+  const prevSel = store.get().selectedId;
+  const selectedId = pickSelection(sessions, prevSel);
+  const activeTab = selectedId === prevSel ? clampActiveTab(sessions, selectedId, store.get().activeTab) : 0;
+  store.set({ sessions, selectedId, activeTab });
 }
 function requestResync() {
   if (resyncTimer !== null) {
@@ -7692,7 +7915,7 @@ function requestResync() {
       return;
     }
     void fetchSnapshot(tok).then((sessions) => {
-      store.set({ sessions, selectedId: pickSelection(sessions, store.get().selectedId) });
+      applySessions(sessions);
     }).catch(() => {
     });
   }, 150);
@@ -7714,11 +7937,15 @@ function onKeydown(e) {
     return;
   }
   const focus = terminal ? state.focus : "rail";
+  const selected = selectedSessionData();
   const action = decideKey(e.key, {
     focus,
     modalOpen: modal !== null,
     orderedIds: orderedSessions(state.sessions).map((s) => s.id ?? "").filter((id) => id !== ""),
-    selectedId: state.selectedId
+    selectedId: state.selectedId,
+    tabCount: selected ? sessionTabs(selected).length : 1,
+    activeTab: state.activeTab,
+    tabManagement: selected ? supportsTabManagement(selected) : false
   });
   if (action.kind === "none") {
     return;
@@ -7737,6 +7964,15 @@ function onKeydown(e) {
       break;
     case "toRail":
       focusRail();
+      break;
+    case "switchTab":
+      switchTab(action.index);
+      break;
+    case "newTab":
+      createSessionTab();
+      break;
+    case "closeTab":
+      closeSessionTab(store.get().activeTab);
       break;
   }
 }

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -139,8 +139,119 @@ test("the #1694 keyboard model: j/k navigate, Enter attaches, Escape returns to 
   await expect(page.locator(".af-app.af-kb-rail")).toBeVisible();
 });
 
+test("tabs: create a shell tab, switch to it, see its distinct output, close it (#1592 PR7)", async () => {
+  // Capture the tab-mutation request bodies so we can assert they carry the stable
+  // session id (#1592 PR7 fix 1 — the daemon must resolve by id, not the cross-repo
+  // ambiguous title), and let one CloseTab be forced to fail (fix 3 — the error
+  // surfaces as a visible toast).
+  let lastCreateBody: { id?: string } | null = null;
+  let lastCloseBody: { id?: string } | null = null;
+  let failClose = false;
+  await page.route("**/v1/CreateTab", async (route) => {
+    lastCreateBody = route.request().postDataJSON();
+    await route.continue();
+  });
+  await page.route("**/v1/CloseTab", async (route) => {
+    lastCloseBody = route.request().postDataJSON();
+    if (failClose) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ data: null, error: "simulated tab-close failure" }),
+      });
+      return;
+    }
+    await route.continue();
+  });
+
+  // Attach to A so its tab bar renders. A fresh session has exactly one tab — the
+  // unclosable "Agent" tab — and it is active.
+  await row(page, SESSION_A).click();
+  await expect(page.locator(".af-main.af-main-term")).toBeVisible();
+  await expect(page.locator(".af-term-host")).toContainText(READY_MARKER);
+
+  const tabbar = page.locator(".af-tabbar");
+  await expect(tabbar).toBeVisible();
+  await expect(tabbar.locator(".af-tab")).toHaveCount(1);
+  await expect(tabbar.locator(".af-tab.af-tab-active .af-tab-label")).toHaveText("Agent");
+
+  // Create a $SHELL tab via the + button (mirrors the TUI `t`). The tab bar grows
+  // to two tabs, the new "Terminal" tab appears AND becomes active (createSessionTab
+  // attaches it), and the terminal re-points its WS stream to that tab.
+  await tabbar.locator(".af-tab-new").click();
+  await expect(tabbar.locator(".af-tab")).toHaveCount(2, { timeout: 30_000 });
+  const shellTab = tabbar.locator(".af-tab", { hasText: "Terminal" });
+  await expect(shellTab).toHaveClass(/af-tab-active/);
+
+  // Fix 1: the CreateTab request carried the stable session id, not just the title.
+  expect(lastCreateBody?.id, "CreateTab must send the stable session id").toBeTruthy();
+
+  // Distinct output: the shell tab is a FRESH PTY, not the agent's — its pane does
+  // not carry the agent's ready marker (the terminal was rebuilt for the new tab).
+  await expect(page.locator(".af-term-host")).not.toContainText(READY_MARKER);
+  // Wait for the shell tab's stream to be live before typing — keystrokes sent
+  // before the WS opens are dropped by the terminal's send() guard.
+  await expect(page.locator(".af-term-meta")).toContainText("Live");
+  // The + attached the shell tab, so keys reach it: type a marker and see it come
+  // back over the new tab's stream — proof the switch re-pointed to a live PTY.
+  await page.keyboard.type("echo AF_TAB_OUTPUT_OK");
+  await page.keyboard.press("Enter");
+  await expect(page.locator(".af-term-host")).toContainText("AF_TAB_OUTPUT_OK", { timeout: 15_000 });
+
+  // 1-9 switch tabs in rail nav mode: Escape back to the rail, then 1 selects the
+  // agent tab and 2 the shell tab — the active highlight follows the digit.
+  await page.keyboard.press("Escape");
+  await expect(page.locator(".af-app.af-kb-rail")).toBeVisible();
+  await page.keyboard.press("1");
+  await expect(page.locator(".af-tab.af-tab-active .af-tab-label")).toHaveText("Agent");
+  await page.keyboard.press("2");
+  await expect(page.locator(".af-tab.af-tab-active .af-tab-label")).toHaveText("Terminal");
+
+  // Fix 3: a failed close surfaces a visible toast (tab ops have no modal). Force
+  // the next CloseTab to error, click ×, and assert the toast — the tab stays.
+  failClose = true;
+  await shellTab.locator(".af-tab-close").click();
+  await expect(page.locator(".af-toast.af-toast-show")).toContainText("simulated tab-close failure");
+  // A failed close leaves the tab in place.
+  await expect(tabbar.locator(".af-tab")).toHaveCount(2);
+  // The CloseTab request was also id-scoped, at the same session as the create.
+  expect(lastCloseBody?.id, "CloseTab must send the stable session id").toBeTruthy();
+  expect(lastCloseBody?.id).toBe(lastCreateBody?.id);
+
+  // Now let the close succeed via its × (mirrors `w`): the bar shrinks back to the
+  // unclosable agent tab, which becomes active again AND the terminal re-points to
+  // it (fix 2 — the visible tab and the streamed tab stay in sync as the list
+  // shrinks; the agent pane's ready marker is back on screen).
+  failClose = false;
+  await shellTab.locator(".af-tab-close").click();
+  await expect(tabbar.locator(".af-tab")).toHaveCount(1, { timeout: 30_000 });
+  await expect(page.locator(".af-tab.af-tab-active .af-tab-label")).toHaveText("Agent");
+  await expect(page.locator(".af-term-host")).toContainText(READY_MARKER);
+
+  await page.unroute("**/v1/CreateTab");
+  await page.unroute("**/v1/CloseTab");
+});
+
 test("create: the + New modal creates a session and its row appears", async () => {
   const created = `probe-created-${Date.now().toString(36)}`;
+
+  // Regression guard (#1592 PR7 review): first move the CURRENT session onto a
+  // NON-agent tab, so a create path that wrongly preserved activeTab would build a
+  // ?tab=1 stream URL for the brand-new session (which has only the agent tab).
+  await row(page, SESSION_A).click();
+  await expect(page.locator(".af-main.af-main-term")).toBeVisible();
+  await page.locator(".af-tabbar .af-tab-new").click();
+  await expect(page.locator(".af-tabbar .af-tab")).toHaveCount(2, { timeout: 30_000 });
+  await expect(page.locator(".af-tab.af-tab-active .af-tab-label")).toHaveText("Terminal");
+
+  // Capture every PTY stream WebSocket opened from here on, so we can assert the
+  // new session's stream carries NO stale tab= selector.
+  const streamUrls: string[] = [];
+  page.on("websocket", (ws) => {
+    if (ws.url().includes("/stream")) {
+      streamUrls.push(ws.url());
+    }
+  });
 
   await page.locator("button.af-rail-new").click();
   const modal = page.locator(".af-modal-card");
@@ -156,6 +267,20 @@ test("create: the + New modal creates a session and its row appears", async () =
   // which index.ts upserts + selects immediately).
   await expect(row(page, created)).toBeVisible({ timeout: 30_000 });
   await expect(modal).toBeHidden();
+
+  // The new session is auto-selected AND attached at its AGENT tab (index 0), not
+  // the tab-2 we were on: its tab bar has just the agent tab, and its terminal
+  // shows the fake agent's ready marker — which it could not if the stream had
+  // dialed a ?tab=<n> the session has no tab for.
+  await expect(page.locator(".af-tabbar .af-tab")).toHaveCount(1);
+  await expect(page.locator(".af-tab.af-tab-active .af-tab-label")).toHaveText("Agent");
+  await expect(page.locator(".af-term-host")).toContainText(READY_MARKER, { timeout: 30_000 });
+
+  // And the new session's stream URL carries no stale tab= selector (the agent tab
+  // is the default, sent only for a non-agent tab).
+  const lastStream = streamUrls[streamUrls.length - 1];
+  expect(lastStream, "a PTY stream WS should have opened for the new session").toBeTruthy();
+  expect(lastStream).not.toContain("tab=");
 
   // Stash it for the kill flow.
   createdTitle = created;

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -7,19 +7,21 @@
 import { test, afterEach } from "node:test";
 import assert from "node:assert/strict";
 
-import { archiveSession, killSession, sendPrompt } from "./api.js";
+import { ApiError, archiveSession, closeTab, createTab, killSession, sendPrompt } from "./api.js";
 
 interface Captured {
   url: string;
   body: Record<string, unknown>;
   auth: string | undefined;
+  calls: number;
 }
 
-// Stubs global.fetch, capturing the last request and returning a 200 {data,error}
-// envelope. Returns the capture box the test asserts against.
+// Stubs global.fetch, capturing the last request (and a call count) and returning a
+// 200 {data,error} envelope. Returns the capture box the test asserts against.
 function stubFetch(): Captured {
-  const cap: Captured = { url: "", body: {}, auth: undefined };
+  const cap: Captured = { url: "", body: {}, auth: undefined, calls: 0 };
   (globalThis as { fetch: unknown }).fetch = async (url: string, init: RequestInit): Promise<Response> => {
+    cap.calls += 1;
     cap.url = url;
     cap.body = JSON.parse(String(init.body));
     cap.auth = (init.headers as Record<string, string>).Authorization;
@@ -27,7 +29,7 @@ function stubFetch(): Captured {
       ok: true,
       status: 200,
       statusText: "OK",
-      json: async () => ({ data: { ok: true }, error: null }),
+      json: async () => ({ data: { ok: true, name: "shell" }, error: null }),
     } as unknown as Response;
   };
   return cap;
@@ -64,4 +66,38 @@ test("sendPrompt posts the stable id alongside the title and prompt", async () =
   assert.equal(cap.body.title, "feature");
   assert.equal(cap.body.prompt, "do the thing");
   assert.equal(cap.body.repo_id, "");
+});
+
+test("createTab / closeTab post the stable id alongside the title", async () => {
+  const cap = stubFetch();
+  await createTab("id-repoB", "feature", "tok");
+  assert.equal(cap.url, "/v1/CreateTab");
+  assert.equal(cap.body.id, "id-repoB", "CreateTab must resolve by id, not the cross-repo title");
+  assert.equal(cap.body.title, "feature");
+  assert.equal(cap.body.repo_id, "");
+  assert.equal(cap.body.shell, true, "the web `t` creates a $SHELL tab, like the TUI");
+
+  await closeTab("id-repoB", "feature", "shell", "tok");
+  assert.equal(cap.url, "/v1/CloseTab");
+  assert.equal(cap.body.id, "id-repoB");
+  assert.equal(cap.body.tab_name, "shell");
+  assert.equal(cap.body.repo_id, "");
+});
+
+test("createTab / closeTab FAIL CLOSED on a missing id — no title-scoped request", async () => {
+  const cap = stubFetch();
+  // A session with no stable id (a legacy/disk-only row) must NOT be tab-mutated by
+  // an all-repo title match — the #1678 cross-repo landmine. Both refuse BEFORE any
+  // request, so the daemon never sees an empty id to title-resolve.
+  await assert.rejects(
+    () => createTab("", "feature", "tok"),
+    (e: unknown) => e instanceof ApiError && /no stable id/.test((e as ApiError).message),
+    "createTab with an empty id must reject",
+  );
+  await assert.rejects(
+    () => closeTab("", "feature", "shell", "tok"),
+    (e: unknown) => e instanceof ApiError && /no stable id/.test((e as ApiError).message),
+    "closeTab with an empty id must reject",
+  );
+  assert.equal(cap.calls, 0, "no request may be issued for a tab op with a missing id");
 });

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -213,3 +213,51 @@ export async function killSession(id: string, title: string, token: string): Pro
 export async function archiveSession(id: string, title: string, token: string): Promise<void> {
   await af("ArchiveSession", { id, title, repo_id: "" }, token);
 }
+
+// --- tab mutations (#1592 Phase 5 PR7) -------------------------------------
+//
+// The web tab bar's write verbs, mirroring the TUI's `t`/`w` keys: `t` creates a
+// $SHELL tab (Shell=true, exactly like Instance.AddShellTab — no command prompt),
+// and `w` closes a non-agent tab. Both are thin POSTs to the daemon's CreateTab /
+// CloseTab RPCs the TUI/CLI already speak (#930/#960). Both send the session's
+// STABLE id as the primary lookup key alongside the (display) title with an EMPTY
+// repo_id: the daemon resolves by id FIRST (resolveActionSession), so a duplicate
+// title across repos can never make the web create/close a tab on the wrong
+// session (#1592 Phase 5 PR7 / the #1678 id-scoping class).
+//
+// FAIL-CLOSED on a missing id (#1592 PR7 review): the daemon still title-resolves
+// an EMPTY id (the CLI path, `af sessions tab-create <title>`), so the web MUST NOT
+// send one on these destructive-ish ops — an empty id + all-repo title is the
+// cross-repo landmine #1678 eliminated. Every live Snapshot row carries an id, so
+// this only trips on a legacy/disk-only record; it refuses BEFORE the request
+// rather than silently retargeting by title. The daemon emits NO event for a tab
+// change, so callers resync the Snapshot to refresh the rail's tab list.
+
+/** Refuses a tab op that has no stable session id to target, before any request is
+ *  issued — so a missing id can never fall through to the daemon's all-repo title
+ *  match on a cross-repo duplicate title (the #1678 class). */
+function requireSessionID(id: string, action: string): void {
+  if (id === "") {
+    throw new ApiError(0, `cannot ${action}: this session has no stable id to target safely`);
+  }
+}
+
+/** Creates a $SHELL tab on the session (mirrors the TUI `t` key). Returns the
+ *  daemon's resolved, collision-suffixed tab name. Refuses a session with no id. */
+export async function createTab(id: string, title: string, token: string): Promise<string> {
+  requireSessionID(id, "create a tab");
+  const resp = await af<{ name: string }>(
+    "CreateTab",
+    { id, title, repo_id: "", shell: true, command: "", name: "" },
+    token,
+  );
+  return resp.name;
+}
+
+/** Closes a non-agent tab by name (mirrors the TUI `w` key). The agent tab
+ *  (index 0) is refused daemon-side — kill the session to tear it down. Refuses a
+ *  session with no stable id, before issuing the request. */
+export async function closeTab(id: string, title: string, tabName: string, token: string): Promise<void> {
+  requireSessionID(id, "close a tab");
+  await af("CloseTab", { id, title, repo_id: "", tab_name: tabName, tab_index: 0 }, token);
+}

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -15,8 +15,10 @@ import {
   ApiError,
   archiveSession,
   clearToken,
+  closeTab,
   createSession,
   type CreateSessionInput,
+  createTab,
   fetchSnapshot,
   killSession,
   loadToken,
@@ -28,10 +30,18 @@ import {
 import { EventStream, type EventStreamStatus } from "./events.js";
 import { confirmModal, type ModalHandle, newSessionModal, promptModal } from "./modals.js";
 import { decideKey, type KeyboardFocus } from "./nav.js";
-import { applyEvent, pickSelection, upsertSession } from "./sessions.js";
+import { applyEvent, clampActiveTab, pickSelection, upsertSession } from "./sessions.js";
 import { Store } from "./store.js";
 import { AttachTerminal, type TerminalStatus } from "./terminal.js";
-import { AppShell, deriveProjects, orderedSessions, renderLogin, type AppState } from "./ui.js";
+import {
+  AppShell,
+  deriveProjects,
+  orderedSessions,
+  renderLogin,
+  sessionTabs,
+  supportsTabManagement,
+  type AppState,
+} from "./ui.js";
 import type { SessionData, WireEvent } from "./types.js";
 
 const store = new Store<AppState>({
@@ -49,6 +59,8 @@ const store = new Store<AppState>({
   live: "connecting",
   termStatus: "connecting",
   focus: "rail",
+  activeTab: 0,
+  tabError: null,
 });
 
 // The credential and the push stream are process-local singletons: one token
@@ -66,6 +78,9 @@ let stream: EventStream | null = null;
 // Debounces the re-Snapshot that archived/restored events and reconnects trigger,
 // so a burst of events collapses into a single authoritative refetch.
 let resyncTimer: number | null = null;
+// The auto-dismiss timer for the tab-error toast, and how long it shows.
+let tabErrorTimer: number | null = null;
+const TAB_ERROR_MS = 6000;
 
 // The app-phase DOM (built once per login) and the persistent terminal host that
 // lives inside it. Keeping the host stable across renders is what lets the focused
@@ -82,10 +97,11 @@ const modalHost = document.createElement("div");
 modalHost.className = "af-modal-host";
 let modal: ModalHandle | null = null;
 
-// The one live attach terminal and the session id it is bound to. Rebuilt only
-// when the selected id changes; disposed on deselect/logout.
+// The one live attach terminal and the (session id, tab index) it is bound to.
+// Rebuilt when either changes; disposed on deselect/logout.
 let terminal: AttachTerminal | null = null;
 let terminalId: string | null = null;
+let terminalTab = 0;
 
 let root: HTMLElement | null = null;
 
@@ -191,6 +207,8 @@ async function connect(candidate: string): Promise<void> {
     selectedId: pickSelection(sessions, store.get().selectedId),
     live: "connecting",
     focus: "rail",
+    activeTab: 0,
+    tabError: null,
   });
   startStream(candidate);
 }
@@ -209,6 +227,8 @@ function disconnect(): void {
     selectedId: null,
     live: "connecting",
     focus: "rail",
+    activeTab: 0,
+    tabError: null,
   });
 }
 
@@ -218,9 +238,11 @@ function disconnect(): void {
  *  rail-nav mode. This is the keyboard path (j/k): selecting a row never steals the
  *  keyboard into the terminal — you attach explicitly with Enter. Resetting focus to
  *  "rail" here also clears any stale "terminal" mode left by a since-disposed
- *  terminal, so j/k keep working after the selected session goes away. */
+ *  terminal, so j/k keep working after the selected session goes away. Selecting a
+ *  session always resets the active tab to its agent tab (index 0). */
 function moveSelection(id: string): void {
-  store.set({ selectedId: id, focus: "rail" });
+  clearTabError();
+  store.set({ selectedId: id, focus: "rail", activeTab: 0 });
 }
 
 /** The click/Enter path: selects the session AND hands the keyboard to its terminal
@@ -307,7 +329,11 @@ function newSession(): void {
             // complete; the later created event just upserts the same id again.
             if (created.id) {
               const sessions = upsertSession(store.get().sessions, created);
-              store.set({ sessions, selectedId: created.id });
+              // Reset to the agent tab: selecting a DIFFERENT session must show its
+              // tab 0 (a new session has only the agent tab), or a stale activeTab
+              // would stream ?tab=<n> for a tab this session doesn't have. This is
+              // the same invariant moveSelection enforces for the keyboard path.
+              store.set({ sessions, selectedId: created.id, activeTab: 0, tabError: null });
             }
           })
           .catch((e) => {
@@ -378,6 +404,120 @@ function openConfirm(action: "kill" | "archive"): void {
   );
 }
 
+// --- tab management (#1592 Phase 5 PR7) ------------------------------------
+
+/** The full projection of the selected session, or null — the source of its tab
+ *  list and backend type, which the id/title-only selectedSession() omits. */
+function selectedSessionData(): SessionData | null {
+  const { sessions, selectedId } = store.get();
+  return sessions.find((s) => s.id === selectedId) ?? null;
+}
+
+/** Switches the active tab WITHOUT attaching (the 1-9 keys). syncTerminal rebuilds
+ *  the terminal for the new tab on the store update; the keyboard stays in rail
+ *  mode, mirroring how j/k select a row without attaching. */
+function switchTab(index: number): void {
+  store.set({ activeTab: index, focus: "rail" });
+}
+
+/** Switches to a tab AND attaches its terminal (a tab-bar click). The store update
+ *  rebuilds the terminal synchronously (via rerender → syncTerminal), so
+ *  focusTerminal then focuses the fresh instance — the same pattern as openFromRail. */
+function openTab(index: number): void {
+  store.set({ activeTab: index });
+  focusTerminal();
+}
+
+/** Creates a $SHELL tab on the selected session (the `t` key / + button), then
+ *  resyncs to pull the grown tab list (the daemon emits no event for a tab change),
+ *  selects the new tab, and attaches it — mirroring the TUI's `t`, which opens the
+ *  fresh tab as a pane. Errors (e.g. a remote session, or the tab cap) surface on
+ *  the pane header's status line. */
+function createSessionTab(): void {
+  const sel = selectedSessionData();
+  const tok = token;
+  // `tok === null` not `!tok`: "" is the authorized-tokenless credential (#1696),
+  // so a loopback client can still create tabs.
+  if (!sel || tok === null || !supportsTabManagement(sel)) {
+    return;
+  }
+  clearTabError();
+  const selId = sel.id ?? "";
+  void createTab(selId, sel.title, tok)
+    .then(() => fetchSnapshot(tok))
+    .then((sessions) => {
+      const grown = sessions.find((s) => s.id === selId);
+      const newIdx = grown ? sessionTabs(grown).length - 1 : store.get().activeTab;
+      store.set({ sessions, selectedId: pickSelection(sessions, store.get().selectedId), activeTab: newIdx });
+      focusTerminal();
+    })
+    .catch((e) => surfaceTabError(e));
+}
+
+/** Closes the tab at `index` of the selected session (the `w` key / × button),
+ *  then resyncs the shrunk tab list and re-points the active tab. The agent tab
+ *  (index 0) is unclosable. */
+function closeSessionTab(index: number): void {
+  const sel = selectedSessionData();
+  const tok = token;
+  // `tok === null` not `!tok`: "" is the authorized-tokenless credential (#1696).
+  if (!sel || tok === null || index <= 0 || !supportsTabManagement(sel)) {
+    return;
+  }
+  const tabs = sessionTabs(sel);
+  const target = tabs[index];
+  if (!target) {
+    return;
+  }
+  clearTabError();
+  const selId = sel.id ?? "";
+  void closeTab(selId, sel.title, target.name, tok)
+    .then(() => fetchSnapshot(tok))
+    .then((sessions) => {
+      // The close shifts every higher tab down by one: if the closed tab was at or
+      // before the active one, the active index moves left to keep showing the same
+      // tab (or its left neighbor when the active tab itself was closed).
+      const cur = store.get().activeTab;
+      const shrunk = sessions.find((s) => s.id === selId);
+      const n = shrunk ? sessionTabs(shrunk).length : 1;
+      const next = Math.min(Math.max(index <= cur ? cur - 1 : cur, 0), n - 1);
+      store.set({ sessions, selectedId: pickSelection(sessions, store.get().selectedId), activeTab: next });
+    })
+    .catch((e) => surfaceTabError(e));
+}
+
+/** Surfaces a failed tab mutation as a transient toast (there is no modal for tab
+ *  ops, unlike create/kill/archive). The terminal keeps streaming; the message is
+ *  the cue to fix the cause (e.g. the tab cap or a remote session). It auto-clears
+ *  after a few seconds, and a fresh failure resets the timer. */
+function surfaceTabError(e: unknown): void {
+  // The raw error message — NOT describeError, whose "Login failed…/Couldn't reach
+  // the daemon…" framing is for the login probe. A tab op carries the daemon's own
+  // message (e.g. the tab cap) or the fail-closed "no stable id" refusal verbatim.
+  const msg = e instanceof ApiError ? e.message : (e as Error).message;
+  console.error("af-web: tab operation failed:", msg);
+  if (tabErrorTimer !== null) {
+    window.clearTimeout(tabErrorTimer);
+  }
+  store.set({ tabError: msg });
+  tabErrorTimer = window.setTimeout(() => {
+    tabErrorTimer = null;
+    store.set({ tabError: null });
+  }, TAB_ERROR_MS);
+}
+
+/** Clears the tab-error toast and cancels its auto-dismiss timer (on a selection
+ *  change or a fresh successful op). */
+function clearTabError(): void {
+  if (tabErrorTimer !== null) {
+    window.clearTimeout(tabErrorTimer);
+    tabErrorTimer = null;
+  }
+  if (store.get().tabError !== null) {
+    store.set({ tabError: null });
+  }
+}
+
 /** The action callbacks the shell + login view invoke. */
 const actions = {
   connect,
@@ -387,25 +527,36 @@ const actions = {
   sendPrompt: openSendPrompt,
   kill: () => openConfirm("kill"),
   archive: () => openConfirm("archive"),
+  switchTab,
+  openTab,
+  newTab: createSessionTab,
+  closeTab: closeSessionTab,
 };
 
 // --- attach terminal wiring ------------------------------------------------
 
-/** Opens/closes the attach terminal to match the current selection. Rebuilds only
- *  when the selected id actually changes, so a live rail event never disturbs an
- *  open, focused terminal. */
+/** Opens/closes the attach terminal to match the current selection AND active tab.
+ *  Rebuilds only when the selected id OR the active tab actually changes, so a live
+ *  rail event never disturbs an open, focused terminal — but switching tabs
+ *  (1-9 / a tab-bar click) re-points the stream to the new tab (#1592 Phase 5 PR7). */
 function syncTerminal(state: AppState): void {
   const selId = state.selectedId;
-  if (selId === terminalId) {
+  // Clamp to the selected session's live tab list as a last line of defense: any
+  // path that leaves activeTab stale relative to the selection (a smaller new
+  // session, an out-of-band tab close) can never build a ?tab=<n> URL for a tab
+  // this session doesn't have — the terminal always attaches a real tab.
+  const tab = clampActiveTab(state.sessions, selId, state.activeTab);
+  if (selId === terminalId && tab === terminalTab) {
     return;
   }
   disposeTerminal();
   terminalId = selId; // set before constructing so the onStatus re-render is a no-op
+  terminalTab = tab;
   const tok = token;
   // `tok !== null` not `tok`: "" is the authorized-tokenless credential (#1696),
   // so a loopback client still attaches its live terminal.
   if (selId && tok !== null) {
-    terminal = new AttachTerminal(termHost, selId, tok, {
+    terminal = new AttachTerminal(termHost, selId, tok, tab, {
       onStatus: (s: TerminalStatus) => store.set({ termStatus: s }),
       // Keep the nav-vs-terminal mode (#1693) in sync with real xterm focus, so a
       // click straight into the terminal enters terminal mode (and tabbing/click
@@ -421,6 +572,7 @@ function disposeTerminal(): void {
     terminal = null;
   }
   terminalId = null;
+  terminalTab = 0;
   termHost.replaceChildren(); // clear any leftover xterm DOM
 }
 
@@ -456,10 +608,23 @@ function stopStream(): void {
  */
 function onEvent(ev: WireEvent): void {
   const { sessions, needsResync } = applyEvent(store.get().sessions, ev);
-  store.set({ sessions, selectedId: pickSelection(sessions, store.get().selectedId) });
+  applySessions(sessions);
   if (needsResync) {
     requestResync();
   }
+}
+
+/** Commits an externally-derived session list (an event delta or a resync) to the
+ *  store, re-validating the selection AND the active tab against it. If the
+ *  selection survives, the active tab is clamped to the (possibly changed) tab list
+ *  so a tab closed/created out-of-band by another client can't leave the visible
+ *  tab or the streamed tab pointing past the end; if the selection changed (e.g.
+ *  the selected session was killed), the active tab resets to the agent tab. */
+function applySessions(sessions: SessionData[]): void {
+  const prevSel = store.get().selectedId;
+  const selectedId = pickSelection(sessions, prevSel);
+  const activeTab = selectedId === prevSel ? clampActiveTab(sessions, selectedId, store.get().activeTab) : 0;
+  store.set({ sessions, selectedId, activeTab });
 }
 
 /** Re-fetches the authoritative Snapshot (debounced) and replaces the rail — the
@@ -478,7 +643,7 @@ function requestResync(): void {
     }
     void fetchSnapshot(tok)
       .then((sessions) => {
-        store.set({ sessions, selectedId: pickSelection(sessions, store.get().selectedId) });
+        applySessions(sessions);
       })
       .catch(() => {
         // Transport/auth failure: the events stream owns reconnection; a later
@@ -526,6 +691,8 @@ function onKeydown(e: KeyboardEvent): void {
   // stored focus stale, so we never honor terminal mode without one. The pure state
   // machine (nav.ts) decides the rest; index.ts only performs the effect.
   const focus: KeyboardFocus = terminal ? state.focus : "rail";
+  // The selected session's tab shape drives the nav-mode tab keys (1-9 / t / w).
+  const selected = selectedSessionData();
   const action = decideKey(e.key, {
     focus,
     modalOpen: modal !== null,
@@ -533,6 +700,9 @@ function onKeydown(e: KeyboardEvent): void {
       .map((s) => s.id ?? "")
       .filter((id) => id !== ""),
     selectedId: state.selectedId,
+    tabCount: selected ? sessionTabs(selected).length : 1,
+    activeTab: state.activeTab,
+    tabManagement: selected ? supportsTabManagement(selected) : false,
   });
   if (action.kind === "none") {
     return;
@@ -554,6 +724,15 @@ function onKeydown(e: KeyboardEvent): void {
       break;
     case "toRail":
       focusRail();
+      break;
+    case "switchTab":
+      switchTab(action.index);
+      break;
+    case "newTab":
+      createSessionTab();
+      break;
+    case "closeTab":
+      closeSessionTab(store.get().activeTab);
       break;
   }
 }

--- a/web/src/nav.test.ts
+++ b/web/src/nav.test.ts
@@ -12,7 +12,16 @@ import { type NavContext, decideKey, nextSelection } from "./nav.js";
 const IDS = ["a", "b", "c"];
 
 function ctx(over: Partial<NavContext> = {}): NavContext {
-  return { focus: "rail", modalOpen: false, orderedIds: IDS, selectedId: "b", ...over };
+  return {
+    focus: "rail",
+    modalOpen: false,
+    orderedIds: IDS,
+    selectedId: "b",
+    tabCount: 1,
+    activeTab: 0,
+    tabManagement: true,
+    ...over,
+  };
 }
 
 test("nextSelection: j/k move within the list and clamp at the ends", () => {
@@ -64,4 +73,40 @@ test("modal mode: the modal owns the keyboard — only Escape (to cancel) is our
 test("modal precedence: a modal over a focused terminal still routes Escape to the modal", () => {
   const both = ctx({ modalOpen: true, focus: "terminal" });
   assert.deepEqual(decideKey("Escape", both), { kind: "closeModal" }, "modal wins over terminal");
+});
+
+test("nav mode: 1-9 switch to an existing tab of the selected session", () => {
+  const three = ctx({ tabCount: 3, activeTab: 0 });
+  assert.deepEqual(decideKey("2", three), { kind: "switchTab", index: 1 });
+  assert.deepEqual(decideKey("3", three), { kind: "switchTab", index: 2 });
+  // A digit past the last tab is a no-op (passes through).
+  assert.deepEqual(decideKey("4", three), { kind: "none" }, "no 4th tab to switch to");
+  // The already-active tab is a no-op (no needless terminal rebuild).
+  assert.deepEqual(decideKey("1", three), { kind: "none" }, "already on tab 1");
+  // With no selection there is nothing to switch.
+  assert.deepEqual(decideKey("2", ctx({ selectedId: null, tabCount: 3 })), { kind: "none" });
+});
+
+test("nav mode: t creates a tab; w closes the active non-agent tab", () => {
+  // t always works for a tab-managed session (mirrors TUI `t` → AddShellTab).
+  assert.deepEqual(decideKey("t", ctx()), { kind: "newTab" });
+  // w on the agent tab (index 0) is refused — kill the session instead.
+  assert.deepEqual(decideKey("w", ctx({ activeTab: 0 })), { kind: "none" }, "agent tab is unclosable");
+  // w on a non-agent tab closes it.
+  assert.deepEqual(decideKey("w", ctx({ tabCount: 2, activeTab: 1 })), { kind: "closeTab" });
+});
+
+test("nav mode: remote sessions can't manage tabs (t/w pass through) but can still switch", () => {
+  const remote = ctx({ tabManagement: false, tabCount: 2, activeTab: 0 });
+  assert.deepEqual(decideKey("t", remote), { kind: "none" }, "no new tab on a remote session");
+  assert.deepEqual(decideKey("w", ctx({ tabManagement: false, tabCount: 2, activeTab: 1 })), { kind: "none" });
+  // Switching among the fixed tabs of a remote session is still fine.
+  assert.deepEqual(decideKey("2", remote), { kind: "switchTab", index: 1 });
+});
+
+test("terminal mode: tab keys reach the agent, not the tab bar", () => {
+  const t = ctx({ focus: "terminal", tabCount: 3, activeTab: 0 });
+  assert.deepEqual(decideKey("2", t), { kind: "none" }, "a digit reaches the shell, not the tab bar");
+  assert.deepEqual(decideKey("t", t), { kind: "none" }, "t reaches the agent");
+  assert.deepEqual(decideKey("w", ctx({ focus: "terminal", tabCount: 2, activeTab: 1 })), { kind: "none" });
 });

--- a/web/src/nav.ts
+++ b/web/src/nav.ts
@@ -19,14 +19,24 @@
  *  on attach (Enter / click) and hands back on Escape. */
 export type KeyboardFocus = "rail" | "terminal";
 
-/** The state the key decision reads: the current mode, whether a modal is up, and
- *  the rail order + selection needed to compute the next selected row. */
+/** The state the key decision reads: the current mode, whether a modal is up, the
+ *  rail order + selection needed to compute the next selected row, and the selected
+ *  session's tab shape for the nav-mode tab keys (#1592 Phase 5 PR7). */
 export interface NavContext {
   focus: KeyboardFocus;
   modalOpen: boolean;
   /** The rail's session ids in DISPLAY order (the same order the DOM shows). */
   orderedIds: string[];
   selectedId: string | null;
+  /** The selected session's tab count (≥1: at least the agent tab). Bounds the
+   *  1-9 tab-switch keys so a digit past the last tab is a no-op. */
+  tabCount: number;
+  /** The selected session's active tab index (0 = agent). `w` refuses to close
+   *  tab 0, and the 1-9 keys no-op on the already-active tab. */
+  activeTab: number;
+  /** Whether the selected session supports user tab management (false for remote
+   *  sessions, whose tabs are fixed by hook config). Gates `t`/`w`. */
+  tabManagement: boolean;
 }
 
 /** What a keydown resolves to. Anything other than "none" is a handled key the
@@ -36,7 +46,10 @@ export type NavAction =
   | { kind: "closeModal" }
   | { kind: "select"; id: string }
   | { kind: "attach" }
-  | { kind: "toRail" };
+  | { kind: "toRail" }
+  | { kind: "switchTab"; index: number }
+  | { kind: "newTab" }
+  | { kind: "closeTab" };
 
 /** The next selected id after moving `delta` rows, clamped to the ends. From no
  *  selection, a downward move lands on the first row and an upward move on the last
@@ -74,6 +87,30 @@ export function decideKey(key: string, ctx: NavContext): NavAction {
   // terminal and hands it the keyboard; j/k and the arrows move the selection.
   if (key === "Enter") {
     return ctx.selectedId ? { kind: "attach" } : { kind: "none" };
+  }
+  // Tab management, mirroring the TUI's nav-mode tab keys (#930 t/w/1-9). These
+  // only fire in rail mode: in terminal mode the branch above already forwards
+  // them to the agent (a shell needs t/w/digits), exactly like the TUI forwards
+  // everything while interactive. All require a selected session.
+  if (ctx.selectedId) {
+    // 1-9 switch to that tab of the selected session; a digit past the last tab
+    // or onto the already-active tab is a no-op (passes through).
+    if (key.length === 1 && key >= "1" && key <= "9") {
+      const index = key.charCodeAt(0) - "1".charCodeAt(0);
+      if (index < ctx.tabCount && index !== ctx.activeTab) {
+        return { kind: "switchTab", index };
+      }
+      return { kind: "none" };
+    }
+    // t creates a new $SHELL tab (no command prompt, like Instance.AddShellTab);
+    // w closes the active non-agent tab. Both need user tab management (remote
+    // sessions' tabs are fixed), and w refuses the agent tab (index 0).
+    if (key === "t") {
+      return ctx.tabManagement ? { kind: "newTab" } : { kind: "none" };
+    }
+    if (key === "w") {
+      return ctx.tabManagement && ctx.activeTab > 0 ? { kind: "closeTab" } : { kind: "none" };
+    }
   }
   let delta: 1 | -1;
   if (key === "ArrowDown" || key === "j") {

--- a/web/src/sessions.test.ts
+++ b/web/src/sessions.test.ts
@@ -8,7 +8,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { applyEvent, pickSelection, removeSession, sessionKey, upsertSession } from "./sessions.js";
+import { applyEvent, clampActiveTab, pickSelection, removeSession, sessionKey, upsertSession } from "./sessions.js";
 import { orderedSessions } from "./ui.js";
 import { Liveness, type SessionData, type WireEvent } from "./types.js";
 
@@ -114,6 +114,29 @@ test("pickSelection keeps a still-present selection by id, else clears it", () =
   assert.equal(pickSelection(list, "id-y"), "id-y");
   assert.equal(pickSelection(list, "gone"), null);
   assert.equal(pickSelection(list, null), null);
+});
+
+test("clampActiveTab keeps the active tab in range as the live tab list changes", () => {
+  const threeTabs = sess("x", {
+    id: "id-x",
+    tabs: [
+      { name: "agent", kind: 0 },
+      { name: "shell", kind: 1 },
+      { name: "shell-2", kind: 1 },
+    ],
+  });
+  const oneTab = sess("x", { id: "id-x", tabs: [{ name: "agent", kind: 0 }] });
+
+  // In range → unchanged.
+  assert.equal(clampActiveTab([threeTabs], "id-x", 2), 2);
+  // The list shrank under the client (a tab closed out-of-band) → clamp to the last.
+  assert.equal(clampActiveTab([oneTab], "id-x", 2), 0, "vanished tab falls back to the agent tab");
+  // No selection, an unknown selection, or a tab-less record → the agent tab (0).
+  assert.equal(clampActiveTab([threeTabs], null, 2), 0);
+  assert.equal(clampActiveTab([threeTabs], "gone", 2), 0);
+  assert.equal(clampActiveTab([sess("y", { id: "id-y" })], "id-y", 3), 0, "no tabs → one implicit agent tab");
+  // A negative index floors at 0.
+  assert.equal(clampActiveTab([threeTabs], "id-x", -1), 0);
 });
 
 test("orderedSessions puts live rows before archived, then by created_at", () => {

--- a/web/src/sessions.ts
+++ b/web/src/sessions.ts
@@ -99,3 +99,23 @@ export function pickSelection(list: SessionData[], currentId: string | null): st
   }
   return null;
 }
+
+/** Clamps the active tab index to the selected session's LIVE tab list (#1592
+ *  Phase 5 PR7). When the list changes out from under the client — another client
+ *  created/closed a tab, or a tab died — an index past the end falls back to the
+ *  last tab, and a vanished/absent selection falls back to the agent tab (0). This
+ *  keeps the visible tab AND the streamed tab (index.ts syncTerminal reads it) in
+ *  sync with the daemon projection, so the terminal never streams a stale/absent
+ *  tab. The count floors at 1: a pre-#930 record with no tabs is one implicit
+ *  agent tab. */
+export function clampActiveTab(list: SessionData[], selectedId: string | null, activeTab: number): number {
+  if (!selectedId) {
+    return 0;
+  }
+  const sel = list.find((s) => s.id === selectedId);
+  if (!sel) {
+    return 0;
+  }
+  const n = sel.tabs && sel.tabs.length > 0 ? sel.tabs.length : 1;
+  return Math.min(Math.max(activeTab, 0), n - 1);
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -461,6 +461,121 @@ body {
   color: var(--af-dot-dead);
 }
 
+/* Tab bar (#1592 Phase 5 PR7): a slim strip of the session's tabs between the pane
+ * header and the terminal, mirroring the TUI's tab row (ui/tabbed_window.go). The
+ * active tab is accent-underlined; each non-agent tab carries a × close, and a +
+ * adds a shell tab. It scrolls horizontally rather than wrapping so a full row of
+ * tabs never pushes the terminal down. */
+.af-tabbar {
+  display: flex;
+  align-items: stretch;
+  gap: 0.15rem;
+  padding: 0 0.6rem;
+  background: var(--af-surface);
+  border-bottom: 1px solid var(--af-border);
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.af-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.6rem;
+  background: transparent;
+  color: var(--af-muted);
+  border: none;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+  font: inherit;
+  font-size: 0.75rem;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.af-tab:hover {
+  color: var(--af-text);
+}
+
+/* The active tab: accent text + underline, the tab-row analogue of the TUI's
+ * highlighted tab. */
+.af-tab-active {
+  color: var(--af-text);
+  border-bottom-color: var(--af-accent);
+}
+
+.af-tab-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 12rem;
+}
+
+/* The × close affordance on a non-agent tab: dim until hovered, and it must not
+ * also trigger the tab's switch/attach (stopPropagation in ui.ts). */
+.af-tab-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.1em;
+  height: 1.1em;
+  border-radius: 3px;
+  color: var(--af-muted);
+  font-size: 0.9rem;
+  line-height: 1;
+}
+
+.af-tab-close:hover {
+  color: var(--af-error);
+  background: rgba(248, 81, 73, 0.14);
+}
+
+/* The + new-tab button: the tab-bar analogue of the rail's "+ New". */
+.af-tab-new {
+  padding: 0.35rem 0.55rem;
+  background: transparent;
+  color: var(--af-accent);
+  border: none;
+  border-radius: 0;
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.af-tab-new:hover {
+  color: var(--af-text);
+}
+
+/* Tab-op error toast (#1592 Phase 5 PR7): a transient banner pinned bottom-right,
+ * shown only while `tabError` is set. Tab ops have no modal, so this is where a
+ * create/close failure surfaces instead of being swallowed. */
+.af-toast {
+  position: fixed;
+  right: 1.25rem;
+  bottom: 1.25rem;
+  max-width: 24rem;
+  padding: 0.6rem 0.85rem;
+  background: var(--af-surface);
+  color: var(--af-text);
+  border: 1px solid var(--af-error);
+  border-left-width: 3px;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+  opacity: 0;
+  transform: translateY(0.4rem);
+  transition: opacity 0.15s ease, transform 0.15s ease;
+  pointer-events: none;
+  z-index: 20;
+}
+
+.af-toast.af-toast-show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
 /* The persistent xterm host: fills the pane, and xterm's own .xterm fills it. The
  * small padding is inside the terminal background so the scrollback isn't flush to
  * the edges. */

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -93,12 +93,13 @@ function wsScheme(): string {
 
 /**
  * One live attach terminal bound to a container element. Construct it with the
- * bearer token and a session id, and it owns everything from there: the xterm
- * instance, the WS to `/v1/sessions/{id}/stream`, the fit/resize wiring, and a
- * self-healing reconnect loop. Call dispose() to tear it all down (on selection
- * change or logout). One instance per attached session — selecting a different
- * session disposes this and builds a fresh one, so scrollback never bleeds across
- * sessions.
+ * bearer token, a session id, and a tab index, and it owns everything from there:
+ * the xterm instance, the WS to `/v1/sessions/{id}/stream?tab=<idx>`, the
+ * fit/resize wiring, and a self-healing reconnect loop. Call dispose() to tear it
+ * all down (on selection/tab change or logout). One instance per attached
+ * (session, tab) — selecting a different session OR switching tabs disposes this
+ * and builds a fresh one, so scrollback and the replay cursor (which are per-tab
+ * on the broker) never bleed across tabs (#1592 Phase 5 PR7).
  */
 export class AttachTerminal {
   private readonly term: Terminal;
@@ -128,6 +129,7 @@ export class AttachTerminal {
     container: HTMLElement,
     private readonly sessionId: string,
     private readonly token: string,
+    private readonly tab: number,
     private readonly cb: TerminalCallbacks,
   ) {
     this.term = new Terminal({
@@ -217,6 +219,11 @@ export class AttachTerminal {
     const base = `${wsScheme()}//${window.location.host}/v1/sessions/${encodeURIComponent(this.sessionId)}/stream`;
     const params = new URLSearchParams();
     params.set("access_token", this.token);
+    // Select the bound tab (parseTab in daemon/ws_pty.go: empty/absent = 0 = the
+    // agent tab). Sent only for a non-agent tab so the agent-tab URL is unchanged.
+    if (this.tab > 0) {
+      params.set("tab", String(this.tab));
+    }
     if (this.seeded) {
       params.set("since", this.cursor.toString());
     }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -23,6 +23,14 @@ export const Liveness = {
   LimitReached: 6,
 } as const;
 
+/** session.TabKind (session/tab.go): the kind of process a tab hosts. The agent
+ *  tab is always index 0 and is unclosable; shell/process tabs are user-created. */
+export const TabKind = {
+  Agent: 0,
+  Shell: 1,
+  Process: 2,
+} as const;
+
 /** session.InFlightOp (session/liveness.go): the transient client-op axis. */
 export const InFlightOp = {
   None: 0,
@@ -73,6 +81,21 @@ export interface SessionData {
    *  derive the new-session modal's project picker, exactly as the TUI does from
    *  InstanceData.Worktree.RepoPath (app/switch_project.go buildProjectListFrom). */
   worktree?: WorktreeData;
+  /** The session's tabs (session/storage.go InstanceData.Tabs): index 0 is the
+   *  agent tab, followed by up to 9 user-created shell/process tabs (#930). The
+   *  web tab bar renders these and streams a selected tab via /stream?tab=<idx>.
+   *  Absent (→ one implicit agent tab) only on pre-#930 records. */
+  tabs?: TabData[];
+}
+
+/** The subset of session.TabData (session/storage.go) the web tab bar reads: the
+ *  display name and the kind (index 0 / TabKind.Agent is the unclosable agent
+ *  tab). Field names match the Go JSON tags so this decodes the projection as-is. */
+export interface TabData {
+  name: string;
+  kind: number;
+  command?: string;
+  tmux_name?: string;
 }
 
 /** The subset of session.GitWorktreeData (session/storage.go) the web reads: the

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -51,6 +51,16 @@ export interface AppState {
    *  the selection); "terminal" means keys go to the agent until Escape. Drives the
    *  visible focus indicator so the active mode is legible, mirroring the TUI. */
   focus: KeyboardFocus;
+  /** the selected session's active tab index (#1592 Phase 5 PR7): 0 is the agent
+   *  tab, 1-8 the user-created shell/process tabs. The attach terminal streams
+   *  /stream?tab=<activeTab>, and the tab bar highlights it. Reset to 0 whenever
+   *  the selection changes. */
+  activeTab: number;
+  /** an actionable message shown as a transient toast when a tab op (create/close)
+   *  fails, or null when there is none. Tab ops have no modal to surface an error
+   *  in (unlike create/kill/archive), so the failure is shown here instead of being
+   *  silently swallowed (#1592 Phase 5 PR7). */
+  tabError: string | null;
 }
 
 /** Callbacks the shell invokes; index.ts owns the real behavior. */
@@ -69,6 +79,52 @@ export interface Actions {
   kill(): void;
   /** Opens the archive-confirm modal for the current selection. */
   archive(): void;
+  /** Switches the selected session's active tab WITHOUT attaching — the keyboard
+   *  stays in rail nav mode (the 1-9 keys, mirroring the TUI). */
+  switchTab(index: number): void;
+  /** Switches to a tab AND attaches its terminal (a tab-bar click, mirroring how a
+   *  session-row click attaches). */
+  openTab(index: number): void;
+  /** Creates a new $SHELL tab on the selected session (the `t` key / + button). */
+  newTab(): void;
+  /** Closes the tab at `index` of the selected session (the `w` key / × button);
+   *  the agent tab (index 0) is unclosable. */
+  closeTab(index: number): void;
+}
+
+/** The soft cap on tabs per session (session/tab.go maxTabs): the agent tab plus
+ *  up to eight shell/process tabs, matching the 1-9 number-key range. The + button
+ *  hides at the cap so the web never fires a guaranteed-to-fail CreateTab. */
+const MAX_TABS = 9;
+
+/** Whether a session supports user tab management: remote-hook sessions have their
+ *  tabs fixed by config (daemon Capabilities().TabManagement), so the web hides
+ *  their + / × affordances and gates the `t`/`w` keys. */
+export function supportsTabManagement(s: SessionData): boolean {
+  return s.backend_type !== "remote";
+}
+
+/** The selected session's tabs, always non-empty: a pre-#930 record with no tabs
+ *  is shown as a single implicit agent tab so the bar (and index math) never sees
+ *  an empty list. */
+export function sessionTabs(s: SessionData): { name: string; kind: number }[] {
+  if (s.tabs && s.tabs.length > 0) {
+    return s.tabs;
+  }
+  return [{ name: "agent", kind: 0 }];
+}
+
+/** The label a tab reads as, mirroring the TUI's labelForTab (ui/tree/labels.go):
+ *  the agent tab is "Agent", a shell tab is "Terminal", a process tab shows its
+ *  name. Keeps the web tab bar TUI-faithful. */
+function tabLabel(tab: { name: string; kind: number }): string {
+  if (tab.kind === 0) {
+    return "Agent";
+  }
+  if (tab.kind === 1) {
+    return "Terminal";
+  }
+  return tab.name || "Tab";
 }
 
 /** The distinct repo roots the current sessions belong to — the new-session
@@ -273,16 +329,24 @@ export class AppShell {
   private readonly railCount: HTMLElement;
   private readonly railList: HTMLElement;
   private readonly main: HTMLElement;
+  // A transient toast for failed tab ops (create/close), shown/hidden by `tabError`.
+  private readonly toast: HTMLElement;
 
   // Header text nodes for the selected pane, (re)created per selection.
   private headTitle: HTMLElement | null = null;
   private headMeta: HTMLElement | null = null;
+  // The tab bar for the selected session, (re)created per selection and patched in
+  // place when the tab list or active tab changes (#1592 Phase 5 PR7). null when
+  // nothing is selected (the empty state has no tabs).
+  private tabBar: HTMLElement | null = null;
 
   // Last-applied state, for cheap change detection between updates.
   private lastSessions: SessionData[] | null = null;
   private lastSelectedId: string | null = null;
   private lastLive: EventStreamStatus | null = null;
   private lastKb: KeyboardFocus | null = null;
+  private lastActiveTab = 0;
+  private lastError: string | null = null;
 
   constructor(
     private readonly actions: Actions,
@@ -323,9 +387,13 @@ export class AppShell {
 
     this.main = h("section", { class: "af-main" });
     const body = h("div", { class: "af-body" }, rail, this.main);
+    // A transient toast for failed tab ops: a fixed-position banner that fades in
+    // only while `tabError` is set (index.ts clears it on a timer / selection change).
+    this.toast = h("div", { class: "af-toast" });
+    this.toast.setAttribute("role", "alert");
     // The modal host is a persistent overlay layer index.ts mounts modals into; it
     // sits above the app body and is empty except while a modal is open.
-    this.el = h("main", { class: "af-app" }, header, body, this.modalHost);
+    this.el = h("main", { class: "af-app" }, header, body, this.toast, this.modalHost);
   }
 
   /** Applies the latest state, touching only what changed. */
@@ -339,6 +407,12 @@ export class AppShell {
       this.lastKb = kb;
       this.el.classList.toggle("af-kb-terminal", kb === "terminal");
       this.el.classList.toggle("af-kb-rail", kb === "rail");
+    }
+
+    if (this.lastError !== state.tabError) {
+      this.lastError = state.tabError;
+      this.toast.textContent = state.tabError ?? "";
+      this.toast.classList.toggle("af-toast-show", state.tabError !== null);
     }
 
     if (this.lastLive !== state.live) {
@@ -362,10 +436,19 @@ export class AppShell {
     // The main pane's STRUCTURE only changes when the selected session changes;
     // otherwise we just patch its header text (status/title/branch), leaving the
     // terminal host — and its focus and scrollback — in place.
+    const activeTabChanged = this.lastActiveTab !== state.activeTab;
+    this.lastActiveTab = state.activeTab;
     if (selectionChanged) {
       this.renderMain(state);
     } else {
       this.patchMainHead(state);
+      // The tab bar reflects the live tab list and the active-tab highlight; either
+      // can change without a selection change (a resync grows/shrinks the list, or
+      // a 1-9 key moves the highlight). Rebuilding just the bar leaves termHost —
+      // and the focused xterm inside it — untouched.
+      if (sessionsChanged || activeTabChanged) {
+        this.renderTabBar(state);
+      }
     }
   }
 
@@ -395,6 +478,7 @@ export class AppShell {
     if (!selected) {
       this.headTitle = null;
       this.headMeta = null;
+      this.tabBar = null;
       // Detaches the terminal host if it was mounted; index.ts disposes the terminal.
       this.main.className = "af-main af-main-empty";
       this.main.replaceChildren(
@@ -418,11 +502,47 @@ export class AppShell {
     const actions = h("div", { class: "af-term-actions" }, promptBtn, archiveBtn, killBtn);
 
     const head = h("div", { class: "af-term-head" }, titleBox, actions);
+
+    // The tab bar sits between the header and the terminal, mirroring the TUI's
+    // tab row (ui/tabbed_window.go): one button per tab, the active one highlighted,
+    // a × on closable (non-agent) tabs, and a + to add a shell tab.
+    this.tabBar = h("div", { class: "af-tabbar" });
+    this.tabBar.setAttribute("role", "tablist");
+    this.tabBar.setAttribute("aria-label", "Session tabs");
+
     this.main.className = "af-main af-main-term";
     // The persistent terminal host is (re)mounted here; renderMain runs only on a
     // selection change, so this reparent is rare and never happens mid-type.
-    this.main.replaceChildren(head, this.termHost);
+    this.main.replaceChildren(head, this.tabBar, this.termHost);
+    this.renderTabBar(state);
     this.patchMainHead(state);
+  }
+
+  /** (Re)builds the tab bar's buttons from the selected session's tabs, with the
+   *  active tab highlighted. Rebuilds only the bar's children, so the sibling
+   *  termHost — and the focused xterm in it — is never touched. */
+  private renderTabBar(state: AppState): void {
+    const bar = this.tabBar;
+    if (!bar) {
+      return;
+    }
+    const selected = selectedSession(state);
+    if (!selected) {
+      return;
+    }
+    const tabs = sessionTabs(selected);
+    const canManage = supportsTabManagement(selected);
+    // The active index is clamped: a resync that shrank the list must not leave the
+    // highlight (and the streamed tab) pointing past the end.
+    const active = Math.min(Math.max(state.activeTab, 0), tabs.length - 1);
+
+    const children: HTMLElement[] = tabs.map((tab, i) => tabButton(tab, i, i === active, canManage, this.actions));
+    if (canManage && tabs.length < MAX_TABS) {
+      const add = h("button", { type: "button", class: "af-tab-new", title: "New tab" }, "+");
+      add.addEventListener("click", () => this.actions.newTab());
+      children.push(add);
+    }
+    bar.replaceChildren(...children);
   }
 
   private patchMainHead(state: AppState): void {
@@ -443,6 +563,35 @@ export class AppShell {
 /** The currently selected session row, or null. */
 function selectedSession(state: AppState): SessionData | null {
   return state.selectedId ? (state.sessions.find((s) => s.id === state.selectedId) ?? null) : null;
+}
+
+/** One tab-bar button: its label, an active-state highlight, and — for a closable
+ *  (non-agent) tab of a tab-managed session — a × that closes it. Clicking the
+ *  button switches to the tab AND attaches (like a session-row click); clicking
+ *  the × closes it without attaching (stopPropagation so it isn't also a switch). */
+function tabButton(
+  tab: { name: string; kind: number },
+  index: number,
+  active: boolean,
+  canManage: boolean,
+  actions: Actions,
+): HTMLElement {
+  const btn = h("button", { type: "button", class: `af-tab${active ? " af-tab-active" : ""}` });
+  btn.setAttribute("role", "tab");
+  btn.setAttribute("aria-selected", active ? "true" : "false");
+  btn.append(h("span", { class: "af-tab-label" }, tabLabel(tab)));
+  btn.addEventListener("click", () => actions.openTab(index));
+  // The agent tab (index 0) is unclosable — killing the session tears it down.
+  if (index > 0 && canManage) {
+    const close = h("span", { class: "af-tab-close", title: "Close tab" }, "×");
+    close.setAttribute("aria-hidden", "true");
+    close.addEventListener("click", (e) => {
+      e.stopPropagation();
+      actions.closeTab(index);
+    });
+    btn.append(close);
+  }
+  return btn;
 }
 
 /** One session row: a status dot, the (prefixed) title, and the branch line —


### PR DESCRIPTION
## What & why

Phase 5 PR7 of the multi-backend rewrite (#1592): give the **web client** the
TUI's tab model. The selected session now shows a **tab bar** — its agent tab
plus up to 8 shell/process tabs — and you can switch, create, and close tabs
from the browser exactly like the TUI's `1-9` / `t` / `w`.

This is a pure **rendering-client** change: it reuses the daemon surface the
TUI/CLI already speak and adds **no new routes**.

## What it adds

- **Tab bar** (`web/src/ui.ts`) between the pane header and the terminal,
  mirroring the TUI tab row (`ui/tabbed_window.go`): one button per tab, the
  active tab accent-underlined, a `×` on non-agent tabs, and a `+` to add a
  shell tab. It is patched in place, so a live rail event or a tab-list resync
  never disturbs the focused xterm.
- **Switch tab** — clicking a tab (or `1`-`9` in rail mode) re-points the WS
  PTY stream to that tab via the **existing** `/v1/sessions/{id}/stream?tab=<idx>`
  selector (`daemon/ws_pty.go parseTab`). A fresh `AttachTerminal` per
  `(session, tab)` keeps scrollback and the replay cursor from bleeding across
  tabs (`web/src/terminal.ts`).
- **New tab** (`t` / `+`) — a thin POST to the existing `CreateTab` RPC with
  `shell:true`, i.e. a `$SHELL` tab with **no command prompt**, matching the
  TUI's `t` (`Instance.AddShellTab`).
- **Close tab** (`w` / `×`) — a thin POST to the existing `CloseTab` RPC. The
  agent tab (index 0) is unclosable (kill the session instead); remote-hook
  sessions can't manage tabs (their tabs are fixed by config).
- **Keys wired through the nav state machine** (`web/src/nav.ts`, #1693/#1694):
  the tab keys fire **only in rail mode**, so terminal mode still forwards
  `1-9`/`t`/`w` to the agent — a shell needs those keys — exactly like the TUI's
  interactive mode. Pure `decideKey` transitions are unit-tested.
- **Selftest** — extends `web/selftest/web-driver.spec.ts` with a tab flow:
  create a shell tab, switch to it, see its **distinct** PTY output (a typed
  marker echoing back over the new tab's stream), switch with `1`/`2`, and
  close it — asserting the agent tab stays unclosable.

## Note flagged for review

`CreateTab`/`CloseTab` emit **no** `/v1/events`, so — like archive/restore —
the client **resyncs the Snapshot** after a tab write to refresh the rail's tab
list. A tab change made by *another* client (e.g. the TUI) is therefore not
pushed live to the web until the next resync. Emitting a `session.updated` event
on tab create/close would be a small daemon follow-up; kept out of this
rendering-client PR. The tab RPCs are also title-scoped (no stable id), so the
web sends the display title with an empty `repo_id` (the all-repo lookup, like
`af sessions tab-create`) — the existing contract.

## Gates

- `make web-selftest-container` — **7/7 green** (incl. the new tab flow)
- `make web-test` — 57/57 · `tsc --noEmit` clean
- `make tui-driver-selftest` — **25/25**
- `go build ./...` · `gofmt -l .` · `golangci-lint run --fast` · `deadcode -test ./...` · file-length — all clean
- Rebuilt committed `web/dist/`

Part of #1592.

🤖 Generated with [Claude Code](https://claude.com/claude-code)