### PR TITLE
feat(web): projects + tasks views mirroring the TUI (#1592 Phase 5 PR8)

### DIFF
--- a/scripts/container/web-selftest-entry.sh
+++ b/scripts/container/web-selftest-entry.sh
@@ -30,6 +30,7 @@ BASE_URL="https://${LISTEN}"
 READY_MARKER=AF_SELFTEST_READY
 SESSION_A=probe-a
 SESSION_B=probe-b
+SEEDED_TASK=probe-task
 export AGENT_FACTORY_HOME="$HOME_DIR"
 # A container binary is built at the branch version (typically behind the latest
 # release); without this it would self-update on boot and restart the daemon
@@ -138,6 +139,13 @@ for i in $(seq 1 30); do
     sleep 1
 done
 
+# --- seed a scheduled task (#1592 Phase 5 PR8) ------------------------------
+# So the tasks view is non-empty on load. A cron task needs a prompt (there is no
+# event line to fall back to); the schedule never actually fires in the test window,
+# it just has to exist for the list + the enable/disable/trigger/remove flows.
+echo ">>> seeding task $SEEDED_TASK ..."
+"$BIN" tasks add --repo "$MOCK" --name "$SEEDED_TASK" --prompt "echo scheduled" --cron "0 9 * * *" >/dev/null
+
 # --- run the Playwright harness ---------------------------------------------
 echo ">>> installing web deps + running the Playwright harness ..."
 cd /work/web
@@ -150,5 +158,6 @@ export AF_WEB_BASE_URL="$BASE_URL"
 export AF_WEB_SESSION_A="$SESSION_A"
 export AF_WEB_SESSION_B="$SESSION_B"
 export AF_WEB_READY_MARKER="$READY_MARKER"
+export AF_WEB_TASK_NAME="$SEEDED_TASK"
 
 npx playwright test

--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -606,6 +606,199 @@ body {
 .af-modal-foot .af-danger {
   margin-top: 0;
 }
+.af-viewnav {
+  display: inline-flex;
+  align-items: stretch;
+  gap: 0.25rem;
+  margin-left: 0.5rem;
+}
+.af-viewtab {
+  padding: 0.3rem 0.7rem;
+  background: transparent;
+  color: var(--af-muted);
+  border: none;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+  font: inherit;
+  font-size: 0.78rem;
+  cursor: pointer;
+}
+.af-viewtab:hover {
+  color: var(--af-text);
+}
+.af-viewtab-active {
+  color: var(--af-text);
+  border-bottom-color: var(--af-accent);
+}
+.af-viewport {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+.af-viewport > [hidden] {
+  display: none;
+}
+.af-viewport > * {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+}
+.af-projects,
+.af-tasks {
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
+.af-projects-head,
+.af-tasks-head {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.6rem 1rem;
+  border-bottom: 1px solid var(--af-border);
+  background: var(--af-surface);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+.af-projects-title,
+.af-tasks-title {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--af-muted);
+}
+.af-view-count {
+  font-size: 0.75rem;
+  color: var(--af-muted);
+  background: var(--af-bg);
+  border: 1px solid var(--af-border);
+  border-radius: 999px;
+  padding: 0.05rem 0.5rem;
+}
+.af-tasks-add {
+  margin-left: auto;
+  padding: 0.25rem 0.55rem;
+  background: transparent;
+  color: var(--af-accent);
+  border: 1px solid var(--af-accent);
+  border-radius: 6px;
+  font: inherit;
+  font-size: 0.72rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+.af-tasks-add:hover {
+  background: rgba(47, 129, 247, 0.12);
+}
+.af-projects-empty,
+.af-tasks-empty {
+  padding: 1.25rem 1rem;
+  color: var(--af-muted);
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+.af-projects-empty code {
+  color: var(--af-text);
+}
+.af-projects-list {
+  padding: 0.5rem 0.75rem 1.5rem;
+}
+.af-project {
+  margin-bottom: 0.75rem;
+}
+.af-project-head {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: baseline;
+  gap: 0.5rem;
+  padding: 0.5rem 0.6rem 0.35rem;
+}
+.af-project-name {
+  font-size: 0.85rem;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.af-project-count {
+  font-size: 0.72rem;
+  color: var(--af-muted);
+}
+.af-project-path {
+  grid-column: 1 / -1;
+  font-size: 0.7rem;
+  color: var(--af-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.af-project-sessions {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.af-project-row {
+  padding: 0.4rem 0.6rem;
+}
+.af-tasks-list {
+  list-style: none;
+  margin: 0;
+  padding: 0.5rem 0.75rem 1.5rem;
+}
+.af-task-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  padding: 0.6rem 0.6rem;
+  border-bottom: 1px solid var(--af-border);
+}
+.af-task-enabled {
+  flex: 0 0 auto;
+  font-size: 0.78rem;
+  color: var(--af-muted);
+  line-height: 1.5;
+}
+.af-task-enabled.af-task-on {
+  color: var(--af-dot-ready);
+}
+.af-task-main {
+  flex: 1;
+  min-width: 0;
+}
+.af-task-name {
+  font-size: 0.85rem;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.af-task-trigger {
+  margin-top: 0.15rem;
+  font-size: 0.75rem;
+  color: var(--af-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.af-task-meta {
+  margin-top: 0.1rem;
+  font-size: 0.72rem;
+  color: var(--af-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.af-task-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex: 0 0 auto;
+}
+.af-task-action {
+  padding: 0.3rem 0.55rem;
+  font-size: 0.72rem;
+}
 @media (max-width: 640px) {
   .af-body {
     flex-direction: column;

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -6231,6 +6231,30 @@ async function closeTab(id, title, tabName, token2) {
   requireSessionID(id, "close a tab");
   await af("CloseTab", { id, title, repo_id: "", tab_name: tabName, tab_index: 0 }, token2);
 }
+async function listTasks(token2) {
+  const resp = await af("ListTasks", {}, token2);
+  return resp.tasks ?? [];
+}
+function requireTaskID(id, action) {
+  if (id === "") {
+    throw new ApiError(0, `cannot ${action}: this task has no stable id to target safely`);
+  }
+}
+async function addTask(task, token2) {
+  await af("AddTask", { task }, token2);
+}
+async function updateTask(task, token2) {
+  requireTaskID(task.id, "update a task");
+  await af("UpdateTask", { task }, token2);
+}
+async function triggerTask(id, token2) {
+  requireTaskID(id, "trigger a task");
+  await af("TriggerTask", { id }, token2);
+}
+async function removeTask(id, token2) {
+  requireTaskID(id, "remove a task");
+  await af("RemoveTask", { id }, token2);
+}
 
 // src/events.ts
 var BACKOFF_BASE_MS = 500;
@@ -6508,6 +6532,12 @@ function projectLabel(root2) {
 }
 
 // src/nav.ts
+var VIEWS = ["sessions", "projects", "tasks"];
+function cycleView(current, delta) {
+  const i = VIEWS.indexOf(current);
+  const n = VIEWS.length;
+  return VIEWS[(i + delta + n) % n];
+}
 function nextSelection(orderedIds, selectedId, delta) {
   if (orderedIds.length === 0) {
     return null;
@@ -6527,6 +6557,15 @@ function decideKey(key, ctx) {
   }
   if (ctx.focus === "terminal") {
     return key === "Escape" ? { kind: "toRail" } : { kind: "none" };
+  }
+  if (key === "[") {
+    return { kind: "switchView", view: cycleView(ctx.view, -1) };
+  }
+  if (key === "]") {
+    return { kind: "switchView", view: cycleView(ctx.view, 1) };
+  }
+  if (ctx.view !== "sessions") {
+    return { kind: "none" };
   }
   if (key === "Enter") {
     return ctx.selectedId ? { kind: "attach" } : { kind: "none" };
@@ -6640,6 +6679,213 @@ var Store = class {
     };
   }
 };
+
+// src/tasks.ts
+function genTaskId() {
+  const b = new Uint8Array(4);
+  crypto.getRandomValues(b);
+  return [...b].map((x) => x.toString(16).padStart(2, "0")).join("");
+}
+function buildTask(input) {
+  return {
+    id: genTaskId(),
+    name: input.name,
+    prompt: input.prompt,
+    cron_expr: input.trigger === "cron" ? input.cron : "",
+    watch_cmd: input.trigger === "watch" ? input.watchCmd : "",
+    target_session: input.targetSession,
+    project_path: input.projectPath,
+    program: input.program,
+    enabled: true,
+    created_at: (/* @__PURE__ */ new Date()).toISOString()
+  };
+}
+function triggerSummary(t) {
+  if (t.watch_cmd && t.watch_cmd.trim() !== "") {
+    return `watch: ${t.watch_cmd}`;
+  }
+  if (t.cron_expr && t.cron_expr.trim() !== "") {
+    return `cron: ${t.cron_expr}`;
+  }
+  return "no trigger";
+}
+function canTrigger(t) {
+  return t.enabled && !!t.cron_expr && t.cron_expr.trim() !== "" && !(t.watch_cmd && t.watch_cmd.trim() !== "");
+}
+function lastRunSummary(t) {
+  if (!t.last_run_at) {
+    return "never run";
+  }
+  const status = t.last_run_status ? ` (${t.last_run_status})` : "";
+  return `last run ${t.last_run_at}${status}`;
+}
+var TasksPane = class {
+  constructor(actions2) {
+    this.actions = actions2;
+    this.el = h("section", { class: "af-tasks" });
+    this.el.setAttribute("aria-label", "Tasks");
+  }
+  el;
+  lastTasks = null;
+  update(tasks) {
+    if (this.lastTasks === tasks) {
+      return;
+    }
+    this.lastTasks = tasks;
+    this.render(tasks);
+  }
+  render(tasks) {
+    const addBtn = h("button", { type: "button", class: "af-tasks-add", title: "Add task" }, "+ Add");
+    addBtn.addEventListener("click", () => this.actions.add());
+    const head = h(
+      "div",
+      { class: "af-tasks-head" },
+      h("span", { class: "af-tasks-title" }, "Tasks"),
+      h("span", { class: "af-view-count" }, String(tasks.length)),
+      addBtn
+    );
+    if (tasks.length === 0) {
+      this.el.replaceChildren(
+        head,
+        h(
+          "p",
+          { class: "af-tasks-empty" },
+          "No scheduled tasks yet. Add one to deliver a prompt on a cron schedule."
+        )
+      );
+      return;
+    }
+    const rows = [...tasks].sort((a, b) => a.created_at < b.created_at ? -1 : a.created_at > b.created_at ? 1 : 0).map((t) => this.taskRow(t));
+    this.el.replaceChildren(head, h("ul", { class: "af-tasks-list" }, ...rows));
+  }
+  taskRow(t) {
+    const glyph = t.enabled ? "[\u2713]" : "[ ]";
+    const enabledDot = h("span", { class: `af-task-enabled${t.enabled ? " af-task-on" : ""}` }, glyph);
+    enabledDot.setAttribute("aria-hidden", "true");
+    const name = h("div", { class: "af-task-name" }, t.name && t.name.trim() !== "" ? t.name : "(unnamed task)");
+    const trigger = h("div", { class: "af-task-trigger" }, triggerSummary(t));
+    const metaParts = [];
+    if (t.target_session && t.target_session.trim() !== "") {
+      metaParts.push(`\u2192 ${t.target_session}`);
+    }
+    metaParts.push(lastRunSummary(t));
+    const meta = h("div", { class: "af-task-meta" }, metaParts.join("  \xB7  "));
+    const main = h("div", { class: "af-task-main" }, name, trigger, meta);
+    const toggleBtn = h(
+      "button",
+      { type: "button", class: "af-ghost af-task-action" },
+      t.enabled ? "Disable" : "Enable"
+    );
+    toggleBtn.addEventListener("click", () => this.actions.toggle(t));
+    const actionEls = [toggleBtn];
+    if (canTrigger(t)) {
+      const triggerBtn = h("button", { type: "button", class: "af-ghost af-task-action" }, "Trigger");
+      triggerBtn.addEventListener("click", () => this.actions.trigger(t));
+      actionEls.push(triggerBtn);
+    }
+    const removeBtn = h("button", { type: "button", class: "af-danger af-task-action" }, "Remove");
+    removeBtn.addEventListener("click", () => this.actions.remove(t));
+    actionEls.push(removeBtn);
+    const actions2 = h("div", { class: "af-task-actions" }, ...actionEls);
+    return h("li", { class: "af-task-row" }, enabledDot, main, actions2);
+  }
+};
+function addTaskModal(projects, callbacks) {
+  const { handle, body, confirmBtn } = modalChrome({
+    title: "Add task",
+    confirmLabel: "Add",
+    confirmClass: "af-primary",
+    onCancel: callbacks.onCancel
+  });
+  const nameInput = h("input", { type: "text", class: "af-input", placeholder: "Task name", autocomplete: "off" });
+  nameInput.setAttribute("aria-label", "Task name");
+  const projectSelect = h("select", { class: "af-input" });
+  projectSelect.setAttribute("aria-label", "Project");
+  if (projects.length === 0) {
+    const opt = h("option", { value: "" }, "No projects yet \u2014 create a session first");
+    opt.disabled = true;
+    opt.selected = true;
+    projectSelect.append(opt);
+    confirmBtn.disabled = true;
+  } else {
+    for (const p of projects) {
+      projectSelect.append(h("option", { value: p }, projectLabel(p)));
+    }
+  }
+  const triggerSelect = h("select", { class: "af-input" });
+  triggerSelect.setAttribute("aria-label", "Trigger type");
+  triggerSelect.append(h("option", { value: "cron" }, "Cron schedule"));
+  triggerSelect.append(h("option", { value: "watch" }, "Watch command"));
+  const cronInput = h("input", { type: "text", class: "af-input", placeholder: "0 9 * * *", autocomplete: "off" });
+  cronInput.setAttribute("aria-label", "Cron expression");
+  const cronField = field("Cron expression", cronInput);
+  const watchInput = h("input", { type: "text", class: "af-input", placeholder: "tail -F events.log", autocomplete: "off" });
+  watchInput.setAttribute("aria-label", "Watch command");
+  const watchField = field("Watch command", watchInput);
+  watchField.hidden = true;
+  triggerSelect.addEventListener("change", () => {
+    const isWatch = triggerSelect.value === "watch";
+    cronField.hidden = isWatch;
+    watchField.hidden = !isWatch;
+  });
+  const promptArea = h("textarea", { class: "af-input af-textarea", placeholder: "Prompt to deliver ({{line}} for the watch line)", rows: 3 });
+  promptArea.setAttribute("aria-label", "Prompt");
+  const targetInput = h("input", { type: "text", class: "af-input", placeholder: "Target session (optional)", autocomplete: "off" });
+  targetInput.setAttribute("aria-label", "Target session");
+  const programSelect = h("select", { class: "af-input" });
+  programSelect.setAttribute("aria-label", "Program");
+  programSelect.append(h("option", { value: "" }, "Repo default"));
+  for (const prog of ["claude", "codex", "aider", "gemini", "amp"]) {
+    programSelect.append(h("option", { value: prog }, prog));
+  }
+  body.append(
+    field("Name", nameInput),
+    field("Project", projectSelect),
+    field("Trigger", triggerSelect),
+    cronField,
+    watchField,
+    field("Prompt", promptArea),
+    field("Target session", targetInput),
+    field("Program", programSelect)
+  );
+  const card = handle.el.firstElementChild;
+  asForm(card, () => {
+    const trigger = triggerSelect.value === "watch" ? "watch" : "cron";
+    const name = nameInput.value.trim();
+    const cron = cronInput.value.trim();
+    const watchCmd = watchInput.value.trim();
+    const prompt = promptArea.value.trim();
+    if (name === "" || projectSelect.value === "") {
+      handle.setError("A name and a project are required.");
+      return;
+    }
+    if (trigger === "cron" && cron === "") {
+      handle.setError("A cron expression is required for a cron task.");
+      return;
+    }
+    if (trigger === "cron" && prompt === "") {
+      handle.setError("A prompt is required for a cron task.");
+      return;
+    }
+    if (trigger === "watch" && watchCmd === "") {
+      handle.setError("A watch command is required for a watch task.");
+      return;
+    }
+    handle.setError(null);
+    callbacks.onSubmit({
+      name,
+      projectPath: projectSelect.value,
+      trigger,
+      cron,
+      watchCmd,
+      prompt: promptArea.value,
+      targetSession: targetInput.value.trim(),
+      program: programSelect.value
+    });
+  });
+  queueMicrotask(() => nameInput.focus());
+  return handle;
+}
 
 // src/terminal.ts
 var import_addon_fit = __toESM(require_addon_fit(), 1);
@@ -7126,6 +7372,115 @@ function formatLimitReset(reset, now) {
   return `${months[reset.getMonth()]} ${reset.getDate()} ${clock}`;
 }
 
+// src/projects.ts
+function orderWithinProject(sessions) {
+  return [...sessions].sort((a, b) => {
+    const aa = isArchived(a) ? 1 : 0;
+    const bb = isArchived(b) ? 1 : 0;
+    if (aa !== bb) {
+      return aa - bb;
+    }
+    const at = a.created_at ?? "";
+    const bt = b.created_at ?? "";
+    if (at !== bt) {
+      return at < bt ? -1 : 1;
+    }
+    return a.title < b.title ? -1 : a.title > b.title ? 1 : 0;
+  });
+}
+function groupSessionsByProject(sessions) {
+  const byRoot = /* @__PURE__ */ new Map();
+  for (const s of sessions) {
+    const root2 = s.worktree?.repo_path;
+    if (!root2) {
+      continue;
+    }
+    const arr = byRoot.get(root2) ?? [];
+    arr.push(s);
+    byRoot.set(root2, arr);
+  }
+  return [...byRoot.keys()].sort().map((root2) => ({ root: root2, label: projectLabel(root2), sessions: orderWithinProject(byRoot.get(root2) ?? []) }));
+}
+var ProjectsPane = class {
+  /** onOpen selects + attaches a session by its stable id (index.ts switches to the
+   *  sessions view and hands the terminal the keyboard), so a project's session row
+   *  is a jump-to-session affordance. */
+  constructor(onOpen) {
+    this.onOpen = onOpen;
+    this.el = h("section", { class: "af-projects" });
+    this.el.setAttribute("aria-label", "Projects");
+  }
+  el;
+  lastSessions = null;
+  lastSelectedId = null;
+  /** Re-renders when the session list or the selection changed. */
+  update(sessions, selectedId) {
+    if (this.lastSessions === sessions && this.lastSelectedId === selectedId) {
+      return;
+    }
+    this.lastSessions = sessions;
+    this.lastSelectedId = selectedId;
+    this.render(sessions, selectedId);
+  }
+  render(sessions, selectedId) {
+    const groups = groupSessionsByProject(sessions);
+    const head = h(
+      "div",
+      { class: "af-projects-head" },
+      h("span", { class: "af-projects-title" }, "Projects"),
+      h("span", { class: "af-view-count" }, String(groups.length))
+    );
+    if (groups.length === 0) {
+      this.el.replaceChildren(
+        head,
+        h(
+          "p",
+          { class: "af-projects-empty" },
+          "No projects yet. Create a session in a repo (the TUI or ",
+          h("code", {}, "af sessions create"),
+          ") and it appears here."
+        )
+      );
+      return;
+    }
+    const sections = groups.map((g) => this.projectSection(g, selectedId));
+    this.el.replaceChildren(head, h("div", { class: "af-projects-list" }, ...sections));
+  }
+  projectSection(group, selectedId) {
+    const header = h(
+      "div",
+      { class: "af-project-head" },
+      h("span", { class: "af-project-name" }, group.label),
+      h("span", { class: "af-project-count" }, `${group.sessions.length}`)
+    );
+    header.append(h("div", { class: "af-project-path" }, group.root));
+    const rows = group.sessions.map((s) => this.sessionRow(s, s.id === selectedId));
+    return h("section", { class: "af-project" }, header, h("ul", { class: "af-project-sessions" }, ...rows));
+  }
+  /** One session row under a project: the same status dot + prefixed title the rail
+   *  row carries (status.ts), keyed by the stable id. Clicking opens it (→ sessions
+   *  view). A row with no id (never from a live Snapshot) renders but is inert. */
+  sessionRow(s, selected) {
+    const status = rowStatus(s);
+    const dot = h(
+      "span",
+      { class: `af-dot af-dot-${status.kind}${status.spinning ? " af-dot-spin" : ""}` },
+      status.glyph
+    );
+    dot.setAttribute("aria-hidden", "true");
+    const title = h("div", { class: "af-row-title" }, rowTitle(s));
+    const cls = `af-row af-project-row${selected ? " af-row-selected" : ""}${isArchived(s) ? " af-row-archived" : ""}`;
+    const row = h("li", { class: cls }, dot, h("div", { class: "af-row-main" }, title));
+    row.setAttribute("role", "button");
+    row.setAttribute("title", `${s.title} \u2014 ${status.label}`);
+    if (s.id) {
+      const id = s.id;
+      row.addEventListener("click", () => this.onOpen(id));
+    }
+    return row;
+  }
+};
+
 // src/ui.ts
 var MAX_TABS = 9;
 function supportsTabManagement(s) {
@@ -7155,6 +7510,16 @@ function deriveProjects(sessions) {
     }
   }
   return [...roots].sort();
+}
+function viewLabel(view) {
+  switch (view) {
+    case "sessions":
+      return "Sessions";
+    case "projects":
+      return "Projects";
+    case "tasks":
+      return "Tasks";
+  }
 }
 function h2(tag, props = {}, ...children) {
   const el = document.createElement(tag);
@@ -7299,10 +7664,22 @@ var AppShell = class {
     live.setAttribute("role", "status");
     const disconnect2 = h2("button", { type: "button", class: "af-ghost" }, "Disconnect");
     disconnect2.addEventListener("click", () => this.actions.disconnect());
+    const viewNav = h2("div", { class: "af-viewnav" });
+    viewNav.setAttribute("role", "tablist");
+    viewNav.setAttribute("aria-label", "Views");
+    for (const v of VIEWS) {
+      const tab = h2("button", { type: "button", class: "af-viewtab" }, viewLabel(v));
+      tab.setAttribute("role", "tab");
+      tab.setAttribute("data-view", v);
+      tab.addEventListener("click", () => this.actions.switchView(v));
+      this.viewTabs.set(v, tab);
+      viewNav.append(tab);
+    }
     const header = h2(
       "header",
       { class: "af-appbar" },
       h2("span", { class: "af-brand" }, "Agent Factory"),
+      viewNav,
       live,
       disconnect2
     );
@@ -7321,10 +7698,18 @@ var AppShell = class {
     this.railList.setAttribute("aria-label", "Sessions");
     const rail = h2("nav", { class: "af-rail" }, railHead, this.railList);
     this.main = h2("section", { class: "af-main" });
-    const body = h2("div", { class: "af-body" }, rail, this.main);
+    this.sessionsBody = h2("div", { class: "af-body" }, rail, this.main);
+    this.projectsPane = new ProjectsPane((id) => this.actions.open(id));
+    this.tasksPane = new TasksPane({
+      add: () => this.actions.addTask(),
+      toggle: (task) => this.actions.toggleTask(task),
+      trigger: (task) => this.actions.triggerTask(task),
+      remove: (task) => this.actions.removeTask(task)
+    });
+    const viewport = h2("div", { class: "af-viewport" }, this.sessionsBody, this.projectsPane.el, this.tasksPane.el);
     this.toast = h2("div", { class: "af-toast" });
     this.toast.setAttribute("role", "alert");
-    this.el = h2("main", { class: "af-app" }, header, body, this.toast, this.modalHost);
+    this.el = h2("main", { class: "af-app" }, header, viewport, this.toast, this.modalHost);
   }
   el;
   pip;
@@ -7334,6 +7719,16 @@ var AppShell = class {
   main;
   // A transient toast for failed tab ops (create/close), shown/hidden by `tabError`.
   toast;
+  // The top-level view switcher (#1592 Phase 5 PR8): the appbar tabs (by view) and
+  // the three body surfaces they toggle between. The sessions body (rail+terminal)
+  // stays mounted while another view shows — hidden, not destroyed — so switching
+  // views never tears down the focused terminal or its scrollback.
+  viewTabs = /* @__PURE__ */ new Map();
+  sessionsBody;
+  projectsPane;
+  tasksPane;
+  lastView = null;
+  lastTasks = null;
   // Header text nodes for the selected pane, (re)created per selection.
   headTitle = null;
   headMeta = null;
@@ -7365,6 +7760,21 @@ var AppShell = class {
       this.lastLive = state.live;
       this.pip.className = `af-live-pip af-live-${state.live}`;
       this.pipLabel.textContent = state.live === "open" ? "Live" : state.live === "connecting" ? "Connecting\u2026" : "Reconnecting\u2026";
+    }
+    if (this.lastView !== state.view) {
+      this.lastView = state.view;
+      this.sessionsBody.hidden = state.view !== "sessions";
+      this.projectsPane.el.hidden = state.view !== "projects";
+      this.tasksPane.el.hidden = state.view !== "tasks";
+      for (const [v, tab] of this.viewTabs) {
+        tab.classList.toggle("af-viewtab-active", v === state.view);
+        tab.setAttribute("aria-selected", v === state.view ? "true" : "false");
+      }
+    }
+    this.projectsPane.update(state.sessions, state.selectedId);
+    if (this.lastTasks !== state.tasks) {
+      this.lastTasks = state.tasks;
+      this.tasksPane.update(state.tasks);
     }
     const sessionsChanged = this.lastSessions !== state.sessions;
     const selectionChanged = this.lastSelectedId !== state.selectedId;
@@ -7524,6 +7934,7 @@ function sessionRow(s, selected, actions2) {
 // src/index.ts
 var store = new Store({
   phase: "login",
+  view: "sessions",
   authRequired: true,
   // Start in the connecting state: mount() immediately probes /v1/auth-info, and
   // showing the paste form before that resolves would flash a token field a
@@ -7538,11 +7949,13 @@ var store = new Store({
   termStatus: "connecting",
   focus: "rail",
   activeTab: 0,
-  tabError: null
+  tabError: null,
+  tasks: []
 });
 var token = null;
 var stream = null;
 var resyncTimer = null;
+var taskResyncTimer = null;
 var tabErrorTimer = null;
 var TAB_ERROR_MS = 6e3;
 var shell = null;
@@ -7622,6 +8035,7 @@ async function connect(candidate) {
   }
   store.set({
     phase: "app",
+    view: "sessions",
     connecting: false,
     loginError: null,
     sessions,
@@ -7629,9 +8043,11 @@ async function connect(candidate) {
     live: "connecting",
     focus: "rail",
     activeTab: 0,
-    tabError: null
+    tabError: null,
+    tasks: []
   });
   startStream(candidate);
+  refreshTasks();
 }
 function disconnect() {
   stopStream();
@@ -7640,6 +8056,7 @@ function disconnect() {
   clearToken();
   store.set({
     phase: "login",
+    view: "sessions",
     connecting: false,
     loginError: null,
     sessions: [],
@@ -7647,7 +8064,8 @@ function disconnect() {
     live: "connecting",
     focus: "rail",
     activeTab: 0,
-    tabError: null
+    tabError: null,
+    tasks: []
   });
 }
 function moveSelection(id) {
@@ -7655,6 +8073,9 @@ function moveSelection(id) {
   store.set({ selectedId: id, focus: "rail", activeTab: 0 });
 }
 function openFromRail(id) {
+  if (store.get().view !== "sessions") {
+    store.set({ view: "sessions" });
+  }
   moveSelection(id);
   focusTerminal();
 }
@@ -7669,6 +8090,19 @@ function focusRail() {
   store.set({ focus: "rail" });
   if (terminal) {
     terminal.blur();
+  }
+}
+function switchView(view) {
+  if (store.get().view === view) {
+    return;
+  }
+  clearTabError();
+  if (view !== "sessions" && terminal) {
+    terminal.blur();
+  }
+  store.set({ view, focus: "rail" });
+  if (view === "tasks") {
+    refreshTasks();
   }
 }
 function selectedSession2() {
@@ -7830,6 +8264,67 @@ function clearTabError() {
     store.set({ tabError: null });
   }
 }
+function refreshTasks() {
+  const tok = token;
+  if (tok === null) {
+    return;
+  }
+  void listTasks(tok).then((tasks) => store.set({ tasks })).catch(() => {
+  });
+}
+function requestTaskResync() {
+  if (taskResyncTimer !== null) {
+    return;
+  }
+  taskResyncTimer = window.setTimeout(() => {
+    taskResyncTimer = null;
+    refreshTasks();
+  }, 150);
+}
+function openAddTask() {
+  const projects = deriveProjects(store.get().sessions);
+  openModal(
+    addTaskModal(projects, {
+      onSubmit: (input) => {
+        const tok = token;
+        if (tok === null || !modal) {
+          return;
+        }
+        const m = modal;
+        m.setBusy(true);
+        void addTask(buildTask(input), tok).then(() => {
+          closeModal();
+          refreshTasks();
+        }).catch((e) => {
+          m.setBusy(false);
+          m.setError(describeError(e));
+        });
+      },
+      onCancel: closeModal
+    })
+  );
+}
+function toggleTask(task) {
+  const tok = token;
+  if (tok === null) {
+    return;
+  }
+  void updateTask({ ...task, enabled: !task.enabled }, tok).then(refreshTasks).catch((e) => surfaceTabError(e));
+}
+function doTriggerTask(task) {
+  const tok = token;
+  if (tok === null) {
+    return;
+  }
+  void triggerTask(task.id, tok).then(refreshTasks).catch((e) => surfaceTabError(e));
+}
+function doRemoveTask(task) {
+  const tok = token;
+  if (tok === null) {
+    return;
+  }
+  void removeTask(task.id, tok).then(refreshTasks).catch((e) => surfaceTabError(e));
+}
 var actions = {
   connect,
   disconnect,
@@ -7841,7 +8336,12 @@ var actions = {
   switchTab,
   openTab,
   newTab: createSessionTab,
-  closeTab: closeSessionTab
+  closeTab: closeSessionTab,
+  switchView,
+  addTask: openAddTask,
+  toggleTask,
+  triggerTask: doTriggerTask,
+  removeTask: doRemoveTask
 };
 function syncTerminal(state) {
   const selId = state.selectedId;
@@ -7886,12 +8386,20 @@ function stopStream() {
     window.clearTimeout(resyncTimer);
     resyncTimer = null;
   }
+  if (taskResyncTimer !== null) {
+    window.clearTimeout(taskResyncTimer);
+    taskResyncTimer = null;
+  }
   if (stream) {
     stream.stop();
     stream = null;
   }
 }
 function onEvent(ev) {
+  if (ev.type === "task.created" || ev.type === "task.updated" || ev.type === "task.removed") {
+    requestTaskResync();
+    return;
+  }
   const { sessions, needsResync } = applyEvent(store.get().sessions, ev);
   applySessions(sessions);
   if (needsResync) {
@@ -7936,11 +8444,12 @@ function onKeydown(e) {
   if (!inTerminal && e.key !== "Escape" && isNativeControl(target)) {
     return;
   }
-  const focus = terminal ? state.focus : "rail";
+  const focus = terminal && state.view === "sessions" ? state.focus : "rail";
   const selected = selectedSessionData();
   const action = decideKey(e.key, {
     focus,
     modalOpen: modal !== null,
+    view: state.view,
     orderedIds: orderedSessions(state.sessions).map((s) => s.id ?? "").filter((id) => id !== ""),
     selectedId: state.selectedId,
     tabCount: selected ? sessionTabs(selected).length : 1,
@@ -7973,6 +8482,9 @@ function onKeydown(e) {
       break;
     case "closeTab":
       closeSessionTab(store.get().activeTab);
+      break;
+    case "switchView":
+      switchView(action.view);
       break;
   }
 }

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -31,6 +31,9 @@ import { expect, type Locator, type Page, test } from "@playwright/test";
 
 const SESSION_A = process.env.AF_WEB_SESSION_A ?? "probe-a";
 const SESSION_B = process.env.AF_WEB_SESSION_B ?? "probe-b";
+// The name of the task the harness seeds (web-selftest-entry.sh) so the tasks list
+// is non-empty on load.
+const SEEDED_TASK = process.env.AF_WEB_TASK_NAME ?? "probe-task";
 // The marker the seeded fake agent prints on launch (web-selftest-entry.sh), so
 // "the terminal shows live output" is a deterministic string assertion.
 const READY_MARKER = process.env.AF_WEB_READY_MARKER ?? "AF_SELFTEST_READY";
@@ -230,6 +233,115 @@ test("tabs: create a shell tab, switch to it, see its distinct output, close it 
 
   await page.unroute("**/v1/CreateTab");
   await page.unroute("**/v1/CloseTab");
+});
+
+test("projects view (#1592 PR8): the seeded repo groups its sessions; a row jumps to it", async () => {
+  // Switch to the projects view via its appbar tab (the [ / ] keyboard path is
+  // covered by the nav unit tests). The projects pane replaces the sessions body.
+  await page.locator('.af-viewtab[data-view="projects"]').click();
+  await expect(page.locator('.af-viewtab[data-view="projects"]')).toHaveClass(/af-viewtab-active/);
+  const projects = page.locator(".af-projects");
+  await expect(projects).toBeVisible();
+
+  // The two seeded sessions live in ONE mock repo, so exactly one project section
+  // renders — proof the grouping is derived from the live projection's repo roots
+  // (not an invented client id). Its friendly label + full repo path both show.
+  const project = projects.locator(".af-project");
+  await expect(project).toHaveCount(1);
+  await expect(project.locator(".af-project-name")).toContainText("mock-repo");
+  await expect(project.locator(".af-project-path")).toContainText("mock-repo");
+
+  // Both seeded sessions are grouped under the project.
+  const grouped = project.locator(".af-project-sessions .af-row");
+  await expect(grouped.filter({ hasText: SESSION_A })).toHaveCount(1);
+  await expect(grouped.filter({ hasText: SESSION_B })).toHaveCount(1);
+
+  // Clicking a project's session row is the jump-to-session affordance: it returns
+  // to the sessions view AND attaches that session's terminal.
+  await project.locator(".af-project-sessions .af-row", { hasText: SESSION_A }).click();
+  await expect(page.locator('.af-viewtab[data-view="sessions"]')).toHaveClass(/af-viewtab-active/);
+  await expect(page.locator(".af-main.af-main-term")).toBeVisible();
+});
+
+test("tasks view (#1592 PR8): list the seeded task; add / trigger / remove round-trips", async () => {
+  // Capture the task-mutation request bodies so we can prove every mutation carries
+  // the STABLE task id — the add mints it client-side, and trigger/remove must send
+  // that SAME id, never the (non-unique) name (the #1678 id-scoping class, PR8).
+  let addedTaskId: string | undefined;
+  let triggerId: string | undefined;
+  let removeId: string | undefined;
+  await page.route("**/v1/AddTask", async (route) => {
+    addedTaskId = route.request().postDataJSON()?.task?.id;
+    await route.continue();
+  });
+  await page.route("**/v1/TriggerTask", async (route) => {
+    triggerId = route.request().postDataJSON()?.id;
+    await route.continue();
+  });
+  await page.route("**/v1/RemoveTask", async (route) => {
+    removeId = route.request().postDataJSON()?.id;
+    await route.continue();
+  });
+
+  // Switch to the tasks view. The seeded cron task is listed on load — proof the
+  // pane is driven by the daemon's ListTasks, not a static list.
+  await page.locator('.af-viewtab[data-view="tasks"]').click();
+  await expect(page.locator('.af-viewtab[data-view="tasks"]')).toHaveClass(/af-viewtab-active/);
+  const tasks = page.locator(".af-tasks");
+  await expect(tasks).toBeVisible();
+  const seeded = tasks.locator(".af-task-row", { hasText: SEEDED_TASK });
+  await expect(seeded).toHaveCount(1);
+  await expect(seeded.locator(".af-task-trigger")).toContainText("0 9 * * *");
+
+  // Add a cron task via the + Add modal. The project picker auto-selects the only
+  // project; a cron task requires a prompt (the daemon rejects an empty one).
+  const added = `probe-task-${Date.now().toString(36)}`;
+  await tasks.locator(".af-tasks-add").click();
+  const modal = page.locator(".af-modal-card");
+  await expect(modal).toBeVisible();
+  await modal.locator('input[aria-label="Task name"]').fill(added);
+  await modal.locator('input[aria-label="Cron expression"]').fill("*/5 * * * *");
+  await modal.locator('textarea[aria-label="Prompt"]').fill("echo scheduled-web");
+  await modal.locator("button.af-primary").click();
+
+  // The new task's row appears (AddTask succeeded; the list refetched).
+  const addedRow = tasks.locator(".af-task-row", { hasText: added });
+  await expect(addedRow).toBeVisible({ timeout: 30_000 });
+  await expect(modal).toBeHidden();
+  expect(addedTaskId, "AddTask must mint + send a stable task id").toBeTruthy();
+
+  // Enable/disable round-trips via UpdateTask: the new task is enabled (Disable
+  // shown). Disabling flips it, and re-enabling flips it back — proof the toggle
+  // rides UpdateTask keyed by the task's id.
+  await addedRow.locator("button", { hasText: "Disable" }).click();
+  await expect(addedRow.locator("button", { hasText: "Enable" })).toBeVisible({ timeout: 30_000 });
+  await addedRow.locator("button", { hasText: "Enable" }).click();
+  await expect(addedRow.locator("button", { hasText: "Disable" })).toBeVisible({ timeout: 30_000 });
+
+  // Trigger-now round-trips via TriggerTask (enabled cron tasks only). Await the RPC
+  // response and assert the envelope carries no error — the daemon fired it — and the
+  // id sent matches the one AddTask minted (id-stability, not the name).
+  const [triggerResp] = await Promise.all([
+    page.waitForResponse("**/v1/TriggerTask"),
+    addedRow.locator("button", { hasText: "Trigger" }).click(),
+  ]);
+  expect((await triggerResp.json()).error, "TriggerTask must succeed (no envelope error)").toBeNull();
+  expect(triggerId, "TriggerTask must send the same stable id AddTask minted").toBe(addedTaskId);
+
+  // Remove round-trips via RemoveTask: the row disappears, and the id sent is again
+  // the stable one (never the name).
+  await addedRow.locator("button", { hasText: "Remove" }).click();
+  await expect(tasks.locator(".af-task-row", { hasText: added })).toHaveCount(0, { timeout: 30_000 });
+  expect(removeId, "RemoveTask must send the same stable id").toBe(addedTaskId);
+
+  await page.unroute("**/v1/AddTask");
+  await page.unroute("**/v1/TriggerTask");
+  await page.unroute("**/v1/RemoveTask");
+
+  // Return to the sessions view so the subsequent create/kill/archive flows drive the
+  // rail (which is hidden while the tasks view shows).
+  await page.locator('.af-viewtab[data-view="sessions"]').click();
+  await expect(page.locator(".af-rail-list")).toBeVisible();
 });
 
 test("create: the + New modal creates a session and its row appears", async () => {

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -7,7 +7,18 @@
 import { test, afterEach } from "node:test";
 import assert from "node:assert/strict";
 
-import { ApiError, archiveSession, closeTab, createTab, killSession, sendPrompt } from "./api.js";
+import {
+  ApiError,
+  archiveSession,
+  closeTab,
+  createTab,
+  killSession,
+  removeTask,
+  sendPrompt,
+  triggerTask,
+  updateTask,
+} from "./api.js";
+import type { TaskData } from "./types.js";
 
 interface Captured {
   url: string;
@@ -100,4 +111,63 @@ test("createTab / closeTab FAIL CLOSED on a missing id — no title-scoped reque
     "closeTab with an empty id must reject",
   );
   assert.equal(cap.calls, 0, "no request may be issued for a tab op with a missing id");
+});
+
+// --- task mutations (#1592 Phase 5 PR8) ------------------------------------
+
+/** A minimal valid TaskData for the mutation tests; `id` is overridden per case. */
+function task(id: string): TaskData {
+  return {
+    id,
+    name: "nightly",
+    prompt: "do the thing",
+    cron_expr: "0 9 * * *",
+    project_path: "/repo",
+    program: "claude",
+    enabled: true,
+    created_at: "2026-07-13T00:00:00Z",
+  };
+}
+
+test("updateTask posts the task keyed by its stable id", async () => {
+  const cap = stubFetch();
+  await updateTask({ ...task("t-abc123"), enabled: false }, "tok");
+  assert.equal(cap.url, "/v1/UpdateTask");
+  assert.equal(cap.auth, "Bearer tok");
+  const sent = cap.body.task as Record<string, unknown>;
+  assert.equal(sent.id, "t-abc123", "the daemon resolves the task by its unique id, not its name");
+  assert.equal(sent.enabled, false, "the enable/disable toggle rides UpdateTask");
+});
+
+test("triggerTask / removeTask post the stable id", async () => {
+  const cap = stubFetch();
+  await triggerTask("t-abc123", "tok");
+  assert.equal(cap.url, "/v1/TriggerTask");
+  assert.equal(cap.body.id, "t-abc123");
+
+  await removeTask("t-abc123", "tok");
+  assert.equal(cap.url, "/v1/RemoveTask");
+  assert.equal(cap.body.id, "t-abc123");
+});
+
+test("updateTask / triggerTask / removeTask FAIL CLOSED on a missing task id", async () => {
+  const cap = stubFetch();
+  // A task with no id must NOT be mutated by a daemon first-match on another task —
+  // the task analogue of the #1678 id-scoping class. Each refuses BEFORE any request.
+  await assert.rejects(
+    () => updateTask(task(""), "tok"),
+    (e: unknown) => e instanceof ApiError && /no stable id/.test((e as ApiError).message),
+    "updateTask with an empty id must reject",
+  );
+  await assert.rejects(
+    () => triggerTask("", "tok"),
+    (e: unknown) => e instanceof ApiError && /no stable id/.test((e as ApiError).message),
+    "triggerTask with an empty id must reject",
+  );
+  await assert.rejects(
+    () => removeTask("", "tok"),
+    (e: unknown) => e instanceof ApiError && /no stable id/.test((e as ApiError).message),
+    "removeTask with an empty id must reject",
+  );
+  assert.equal(cap.calls, 0, "no request may be issued for a task mutation with a missing id");
 });

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -11,7 +11,7 @@
 // request. The WS `?access_token=` fallback (browsers cannot set WS headers) is
 // used by the /v1/events subscriber (events.ts) and, in PR4, the PTY stream.
 
-import type { SessionData, SnapshotResponse } from "./types.js";
+import type { SessionData, SnapshotResponse, TaskData, TasksResponse } from "./types.js";
 
 const TOKEN_KEY = "af.token";
 
@@ -260,4 +260,69 @@ export async function createTab(id: string, title: string, token: string): Promi
 export async function closeTab(id: string, title: string, tabName: string, token: string): Promise<void> {
   requireSessionID(id, "close a tab");
   await af("CloseTab", { id, title, repo_id: "", tab_name: tabName, tab_index: 0 }, token);
+}
+
+// --- task mutations (#1592 Phase 5 PR8) ------------------------------------
+//
+// The tasks-view write verbs, mirroring `af tasks add/update/remove/trigger`. They
+// are thin POSTs to the daemon's task-CRUD RPCs the CLI/TUI already speak (#1029
+// PR3): the daemon is the SOLE writer of tasks.json and re-arms its own scheduler
+// in-process, so these calls never touch local state — the resulting task.* event
+// flows back over /v1/events and the tasks list refetches.
+//
+// Every MUTATION keys off the task's globally-unique `id`, NEVER the (optional,
+// non-unique) name: UpdateTask/TriggerTask/RemoveTask all resolve the target task
+// by id first-match on the daemon, so sending anything but the real id could hit the
+// wrong task. Like the session tab ops, they FAIL CLOSED on a missing id
+// (requireTaskID) — refusing BEFORE the request rather than letting an empty id fall
+// through to the daemon's first-match, the task analogue of the #1678 id-scoping
+// class the session write-path fixed.
+
+/** Fetches every task across all repos (mirrors `af tasks list`). Returns [] for an
+ *  empty daemon (never null); throws ApiError on transport/auth failure so callers
+ *  share one error path. The read side of the task single-writer model (#1029 PR3). */
+export async function listTasks(token: string): Promise<TaskData[]> {
+  const resp = await af<TasksResponse>("ListTasks", {}, token);
+  return resp.tasks ?? [];
+}
+
+/** Refuses a task mutation that has no stable task id to target, before any request
+ *  is issued — so a missing id can never fall through to the daemon's first-match on
+ *  another task. The task analogue of requireSessionID (the #1678 id-scoping class);
+ *  every task from ListTasks carries an id, so this only trips on a malformed record
+ *  a client somehow built without one. */
+function requireTaskID(id: string, action: string): void {
+  if (id === "") {
+    throw new ApiError(0, `cannot ${action}: this task has no stable id to target safely`);
+  }
+}
+
+/** Adds a task (mirrors `af tasks add`). The daemon re-validates (trigger, program)
+ *  and owns the write; the created task also arrives via a task.created event. */
+export async function addTask(task: TaskData, token: string): Promise<void> {
+  await af("AddTask", { task }, token);
+}
+
+/** Updates a task (mirrors `af tasks update`) — the edit + enable/disable path. The
+ *  daemon preserves the scheduler-owned fields (last_run_*, created_at) from the
+ *  freshly-loaded record under its file lock, so a stale client copy never clobbers
+ *  them. Refuses a task with no stable id, before issuing the request. */
+export async function updateTask(task: TaskData, token: string): Promise<void> {
+  requireTaskID(task.id, "update a task");
+  await af("UpdateTask", { task }, token);
+}
+
+/** Fires a task NOW (mirrors `af tasks trigger`). The daemon runs it through the same
+ *  scheduler path it uses for a scheduled fire, and refuses disabled + watch tasks.
+ *  Refuses a task with no stable id, before issuing the request. */
+export async function triggerTask(id: string, token: string): Promise<void> {
+  requireTaskID(id, "trigger a task");
+  await af("TriggerTask", { id }, token);
+}
+
+/** Removes a task by id (mirrors `af tasks remove`). Refuses a task with no stable
+ *  id, before issuing the request. */
+export async function removeTask(id: string, token: string): Promise<void> {
+  requireTaskID(id, "remove a task");
+  await af("RemoveTask", { id }, token);
 }

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -12,6 +12,7 @@
 
 import "./styles.css";
 import {
+  addTask,
   ApiError,
   archiveSession,
   clearToken,
@@ -21,17 +22,22 @@ import {
   createTab,
   fetchSnapshot,
   killSession,
+  listTasks,
   loadToken,
   probeAuthRequired,
   probeToken,
+  removeTask,
   sendPrompt,
   storeToken,
+  triggerTask,
+  updateTask,
 } from "./api.js";
 import { EventStream, type EventStreamStatus } from "./events.js";
 import { confirmModal, type ModalHandle, newSessionModal, promptModal } from "./modals.js";
-import { decideKey, type KeyboardFocus } from "./nav.js";
+import { decideKey, type KeyboardFocus, type View } from "./nav.js";
 import { applyEvent, clampActiveTab, pickSelection, upsertSession } from "./sessions.js";
 import { Store } from "./store.js";
+import { addTaskModal, type AddTaskInput, buildTask } from "./tasks.js";
 import { AttachTerminal, type TerminalStatus } from "./terminal.js";
 import {
   AppShell,
@@ -42,10 +48,11 @@ import {
   supportsTabManagement,
   type AppState,
 } from "./ui.js";
-import type { SessionData, WireEvent } from "./types.js";
+import type { SessionData, TaskData, WireEvent } from "./types.js";
 
 const store = new Store<AppState>({
   phase: "login",
+  view: "sessions",
   authRequired: true,
   // Start in the connecting state: mount() immediately probes /v1/auth-info, and
   // showing the paste form before that resolves would flash a token field a
@@ -61,6 +68,7 @@ const store = new Store<AppState>({
   focus: "rail",
   activeTab: 0,
   tabError: null,
+  tasks: [],
 });
 
 // The credential and the push stream are process-local singletons: one token
@@ -78,6 +86,9 @@ let stream: EventStream | null = null;
 // Debounces the re-Snapshot that archived/restored events and reconnects trigger,
 // so a burst of events collapses into a single authoritative refetch.
 let resyncTimer: number | null = null;
+// Debounces the ListTasks refetch that task.* events trigger (#1592 Phase 5 PR8),
+// so a burst of task deltas collapses into one authoritative refetch.
+let taskResyncTimer: number | null = null;
 // The auto-dismiss timer for the tab-error toast, and how long it shows.
 let tabErrorTimer: number | null = null;
 const TAB_ERROR_MS = 6000;
@@ -201,6 +212,7 @@ async function connect(candidate: string): Promise<void> {
   }
   store.set({
     phase: "app",
+    view: "sessions",
     connecting: false,
     loginError: null,
     sessions,
@@ -209,8 +221,13 @@ async function connect(candidate: string): Promise<void> {
     focus: "rail",
     activeTab: 0,
     tabError: null,
+    tasks: [],
   });
   startStream(candidate);
+  // Seed the tasks view alongside the rail: one ListTasks fetch so the tasks pane is
+  // populated the moment the user switches to it. Task deltas then arrive via the
+  // task.* events plane (onEvent), which triggers a debounced refetch.
+  refreshTasks();
 }
 
 /** Forgets the token, tears down the push stream + terminal, and returns to login. */
@@ -221,6 +238,7 @@ function disconnect(): void {
   clearToken();
   store.set({
     phase: "login",
+    view: "sessions",
     connecting: false,
     loginError: null,
     sessions: [],
@@ -229,6 +247,7 @@ function disconnect(): void {
     focus: "rail",
     activeTab: 0,
     tabError: null,
+    tasks: [],
   });
 }
 
@@ -247,8 +266,13 @@ function moveSelection(id: string): void {
 
 /** The click/Enter path: selects the session AND hands the keyboard to its terminal
  *  (attach). moveSelection rebuilds the terminal synchronously (via rerender), so
- *  focusTerminal then focuses the fresh instance. */
+ *  focusTerminal then focuses the fresh instance. Also switches to the sessions view:
+ *  this is the projects pane's jump-to-session affordance too (a project's session
+ *  row calls open), so opening a session always lands on the sessions view. */
 function openFromRail(id: string): void {
+  if (store.get().view !== "sessions") {
+    store.set({ view: "sessions" });
+  }
   moveSelection(id);
   focusTerminal();
 }
@@ -270,6 +294,27 @@ function focusRail(): void {
   store.set({ focus: "rail" });
   if (terminal) {
     terminal.blur();
+  }
+}
+
+// --- top-level view switching (#1592 Phase 5 PR8) --------------------------
+
+/** Switches the top-level view (sessions | projects | tasks). Leaving the sessions
+ *  view hands the keyboard back to the rail AND blurs the (still-live but now hidden)
+ *  terminal, so a stray key in the projects/tasks view never leaks to the agent — the
+ *  view switch composes with the #1694 focus model instead of fighting it. Switching
+ *  INTO the tasks view refreshes the task list so it is current on arrival. */
+function switchView(view: View): void {
+  if (store.get().view === view) {
+    return;
+  }
+  clearTabError();
+  if (view !== "sessions" && terminal) {
+    terminal.blur();
+  }
+  store.set({ view, focus: "rail" });
+  if (view === "tasks") {
+    refreshTasks();
   }
 }
 
@@ -518,6 +563,103 @@ function clearTabError(): void {
   }
 }
 
+// --- task actions (#1592 Phase 5 PR8) --------------------------------------
+
+/** Refetches the authoritative task list and commits it to the store. Failures are
+ *  swallowed: the events plane / a later action retries, exactly like the Snapshot
+ *  resync. `=== null` not `!tok`: "" is the authorized-tokenless credential (#1696). */
+function refreshTasks(): void {
+  const tok = token;
+  if (tok === null) {
+    return;
+  }
+  void listTasks(tok)
+    .then((tasks) => store.set({ tasks }))
+    .catch(() => {
+      // Transport/auth failure: leave the last-known list up; a task.* event or the
+      // next mutation refetches. Nothing to surface here.
+    });
+}
+
+/** Debounced task refetch for a burst of task.* events, mirroring requestResync. */
+function requestTaskResync(): void {
+  if (taskResyncTimer !== null) {
+    return;
+  }
+  taskResyncTimer = window.setTimeout(() => {
+    taskResyncTimer = null;
+    refreshTasks();
+  }, 150);
+}
+
+/** Opens the add-task modal, its project picker seeded from the live projects. On
+ *  submit it builds a task.Task (a fresh id, exactly one trigger) and POSTs AddTask;
+ *  the created task also arrives via a task.created event, and a refetch reconciles.
+ *  Errors (a bad cron expression, a duplicate) surface in the modal for a retry. */
+function openAddTask(): void {
+  const projects = deriveProjects(store.get().sessions);
+  openModal(
+    addTaskModal(projects, {
+      onSubmit: (input: AddTaskInput) => {
+        const tok = token;
+        // `=== null` not `!tok`: "" is the authorized-tokenless credential (#1696).
+        if (tok === null || !modal) {
+          return;
+        }
+        const m = modal;
+        m.setBusy(true);
+        void addTask(buildTask(input), tok)
+          .then(() => {
+            closeModal();
+            refreshTasks();
+          })
+          .catch((e) => {
+            m.setBusy(false);
+            m.setError(describeError(e));
+          });
+      },
+      onCancel: closeModal,
+    }),
+  );
+}
+
+/** Enables/disables a task (UpdateTask with `enabled` flipped), then refetches. A
+ *  failure surfaces as the shared transient toast (task ops have no modal). Keys off
+ *  the task's stable id — requireTaskID in the api layer refuses a missing one. */
+function toggleTask(task: TaskData): void {
+  const tok = token;
+  if (tok === null) {
+    return;
+  }
+  void updateTask({ ...task, enabled: !task.enabled }, tok)
+    .then(refreshTasks)
+    .catch((e) => surfaceTabError(e));
+}
+
+/** Fires a task now (TriggerTask), then refetches to pick up the new last-run. The
+ *  tasks pane only offers this for enabled cron tasks (the daemon refuses disabled +
+ *  watch tasks); a failure still surfaces as a toast. */
+function doTriggerTask(task: TaskData): void {
+  const tok = token;
+  if (tok === null) {
+    return;
+  }
+  void triggerTask(task.id, tok)
+    .then(refreshTasks)
+    .catch((e) => surfaceTabError(e));
+}
+
+/** Removes a task (RemoveTask), then refetches. Keys off the stable id. */
+function doRemoveTask(task: TaskData): void {
+  const tok = token;
+  if (tok === null) {
+    return;
+  }
+  void removeTask(task.id, tok)
+    .then(refreshTasks)
+    .catch((e) => surfaceTabError(e));
+}
+
 /** The action callbacks the shell + login view invoke. */
 const actions = {
   connect,
@@ -531,6 +673,11 @@ const actions = {
   openTab,
   newTab: createSessionTab,
   closeTab: closeSessionTab,
+  switchView,
+  addTask: openAddTask,
+  toggleTask,
+  triggerTask: doTriggerTask,
+  removeTask: doRemoveTask,
 };
 
 // --- attach terminal wiring ------------------------------------------------
@@ -593,6 +740,10 @@ function stopStream(): void {
     window.clearTimeout(resyncTimer);
     resyncTimer = null;
   }
+  if (taskResyncTimer !== null) {
+    window.clearTimeout(taskResyncTimer);
+    taskResyncTimer = null;
+  }
   if (stream) {
     stream.stop();
     stream = null;
@@ -607,6 +758,15 @@ function stopStream(): void {
  * terminal down for.
  */
 function onEvent(ev: WireEvent): void {
+  // Task deltas (#1592 Phase 5 PR8) don't touch the session list; the daemon owns
+  // tasks.json, so a task.created/updated/removed event just triggers a debounced
+  // ListTasks refetch (the authoritative task projection). The session reducer
+  // no-ops these, so run both: the reducer for session.* and the task refetch for
+  // task.*.
+  if (ev.type === "task.created" || ev.type === "task.updated" || ev.type === "task.removed") {
+    requestTaskResync();
+    return;
+  }
   const { sessions, needsResync } = applyEvent(store.get().sessions, ev);
   applySessions(sessions);
   if (needsResync) {
@@ -686,16 +846,19 @@ function onKeydown(e: KeyboardEvent): void {
   if (!inTerminal && e.key !== "Escape" && isNativeControl(target)) {
     return;
   }
-  // The mode is "terminal" only when a terminal actually exists to own the keyboard;
-  // a since-disposed terminal (e.g. the selected session was killed) can leave the
-  // stored focus stale, so we never honor terminal mode without one. The pure state
-  // machine (nav.ts) decides the rest; index.ts only performs the effect.
-  const focus: KeyboardFocus = terminal ? state.focus : "rail";
+  // The mode is "terminal" only when a terminal actually exists to own the keyboard
+  // AND the sessions view is showing it; a since-disposed terminal (the selected
+  // session was killed) or a switch to the projects/tasks view (which hides the
+  // terminal) must not leave the stored focus stale, so we never honor terminal mode
+  // without a live, visible terminal. The pure state machine (nav.ts) decides the
+  // rest; index.ts only performs the effect.
+  const focus: KeyboardFocus = terminal && state.view === "sessions" ? state.focus : "rail";
   // The selected session's tab shape drives the nav-mode tab keys (1-9 / t / w).
   const selected = selectedSessionData();
   const action = decideKey(e.key, {
     focus,
     modalOpen: modal !== null,
+    view: state.view,
     orderedIds: orderedSessions(state.sessions)
       .map((s) => s.id ?? "")
       .filter((id) => id !== ""),
@@ -733,6 +896,9 @@ function onKeydown(e: KeyboardEvent): void {
       break;
     case "closeTab":
       closeSessionTab(store.get().activeTab);
+      break;
+    case "switchView":
+      switchView(action.view);
       break;
   }
 }

--- a/web/src/modals.ts
+++ b/web/src/modals.ts
@@ -27,7 +27,10 @@ export interface ModalHandle {
   close(): void;
 }
 
-function h<K extends keyof HTMLElementTagNameMap>(
+/** Minimal hyperscript (shared by the modal builders and the projects/tasks panes,
+ *  #1592 Phase 5 PR8): create an element, apply props, append children — CSP-safe
+ *  createElement, no innerHTML. */
+export function h<K extends keyof HTMLElementTagNameMap>(
   tag: K,
   props: Partial<HTMLElementTagNameMap[K]> & { class?: string } = {},
   ...children: (Node | string)[]
@@ -50,7 +53,7 @@ function h<K extends keyof HTMLElementTagNameMap>(
  *  error line, and a footer with a cancel + a primary action button. Returns the
  *  pieces the specific modals wire their behavior onto. Clicking the backdrop or
  *  pressing Escape cancels; Enter is left to the form's own submit. */
-function modalChrome(opts: {
+export function modalChrome(opts: {
   title: string;
   confirmLabel: string;
   confirmClass: string;
@@ -113,7 +116,7 @@ function modalChrome(opts: {
 
 /** Wraps the card's content in a <form> so Enter submits and the browser handles
  *  focus, calling onSubmit with preventDefault already applied. */
-function asForm(card: HTMLElement, onSubmit: () => void): void {
+export function asForm(card: HTMLElement, onSubmit: () => void): void {
   // The card children were appended directly; re-parent them under a form so a
   // native submit (Enter / the primary button) is captured once.
   const form = h("form", { class: "af-modal-form" });
@@ -263,12 +266,12 @@ export function confirmModal(
 }
 
 /** A labeled field row: a caption above its control. */
-function field(label: string, control: HTMLElement): HTMLElement {
+export function field(label: string, control: HTMLElement): HTMLElement {
   return h("label", { class: "af-modal-field" }, h("span", { class: "af-modal-label" }, label), control);
 }
 
 /** A friendly project label: the repo's basename with its parent for context. */
-function projectLabel(root: string): string {
+export function projectLabel(root: string): string {
   const parts = root.replace(/\/+$/, "").split("/");
   const base = parts[parts.length - 1] || root;
   const parent = parts.length >= 2 ? parts[parts.length - 2] : "";

--- a/web/src/nav.test.ts
+++ b/web/src/nav.test.ts
@@ -7,7 +7,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { type NavContext, decideKey, nextSelection } from "./nav.js";
+import { type NavContext, cycleView, decideKey, nextSelection } from "./nav.js";
 
 const IDS = ["a", "b", "c"];
 
@@ -15,6 +15,7 @@ function ctx(over: Partial<NavContext> = {}): NavContext {
   return {
     focus: "rail",
     modalOpen: false,
+    view: "sessions",
     orderedIds: IDS,
     selectedId: "b",
     tabCount: 1,
@@ -109,4 +110,47 @@ test("terminal mode: tab keys reach the agent, not the tab bar", () => {
   assert.deepEqual(decideKey("2", t), { kind: "none" }, "a digit reaches the shell, not the tab bar");
   assert.deepEqual(decideKey("t", t), { kind: "none" }, "t reaches the agent");
   assert.deepEqual(decideKey("w", ctx({ focus: "terminal", tabCount: 2, activeTab: 1 })), { kind: "none" });
+});
+
+// --- view switching (#1592 Phase 5 PR8) ------------------------------------
+
+test("cycleView: ] advances and [ reverses, wrapping the sessions/projects/tasks cycle", () => {
+  assert.equal(cycleView("sessions", 1), "projects");
+  assert.equal(cycleView("projects", 1), "tasks");
+  assert.equal(cycleView("tasks", 1), "sessions", "] past the last view wraps to the first");
+  assert.equal(cycleView("sessions", -1), "tasks", "[ before the first view wraps to the last");
+  assert.equal(cycleView("tasks", -1), "projects");
+});
+
+test("view switch: ] / [ cycle the top-level view in rail mode of any view", () => {
+  assert.deepEqual(decideKey("]", ctx({ view: "sessions" })), { kind: "switchView", view: "projects" });
+  assert.deepEqual(decideKey("[", ctx({ view: "sessions" })), { kind: "switchView", view: "tasks" });
+  assert.deepEqual(decideKey("]", ctx({ view: "projects" })), { kind: "switchView", view: "tasks" });
+  assert.deepEqual(decideKey("]", ctx({ view: "tasks" })), { kind: "switchView", view: "sessions" });
+});
+
+test("view switch: a focused terminal / an open modal own the keyboard — [ and ] fall through", () => {
+  // Terminal mode forwards everything but Escape to the agent, so [ / ] reach the
+  // shell (a shell needs brackets) rather than switching views.
+  assert.deepEqual(decideKey("]", ctx({ focus: "terminal" })), { kind: "none" });
+  assert.deepEqual(decideKey("[", ctx({ focus: "terminal" })), { kind: "none" });
+  // A modal owns the keyboard: brackets type into the form, they don't switch views.
+  assert.deepEqual(decideKey("]", ctx({ modalOpen: true })), { kind: "none" });
+});
+
+test("non-sessions views: the session keys pass through, only view switching is ours", () => {
+  // In the projects view the body is a mouse-driven browse surface: j/k/Enter and
+  // the tab keys are NOT ours (they'd have no terminal to act on), but ] still
+  // switches views.
+  const proj = ctx({ view: "projects", tabCount: 3, activeTab: 0 });
+  assert.deepEqual(decideKey("j", proj), { kind: "none" }, "j is not a projects-view key");
+  assert.deepEqual(decideKey("Enter", proj), { kind: "none" }, "Enter attaches only in the sessions view");
+  assert.deepEqual(decideKey("t", proj), { kind: "none" }, "no tab management outside the sessions view");
+  assert.deepEqual(decideKey("2", proj), { kind: "none" });
+  assert.deepEqual(decideKey("]", proj), { kind: "switchView", view: "tasks" });
+  // The tasks view is likewise button-driven: only the view-switch keys are ours.
+  const tasksView = ctx({ view: "tasks" });
+  assert.deepEqual(decideKey("j", tasksView), { kind: "none" });
+  assert.deepEqual(decideKey("Enter", tasksView), { kind: "none" });
+  assert.deepEqual(decideKey("[", tasksView), { kind: "switchView", view: "projects" });
 });

--- a/web/src/nav.ts
+++ b/web/src/nav.ts
@@ -19,12 +19,36 @@
  *  on attach (Enter / click) and hands back on Escape. */
 export type KeyboardFocus = "rail" | "terminal";
 
+/** The app's top-level view (#1592 Phase 5 PR8), mirroring the TUI's rail sections:
+ *  the live sessions rail, the projects (repo grouping) pane, and the tasks
+ *  (scheduled automations) pane. It is a HIGHER-level switch than keyboard focus —
+ *  it selects which surface the body shows — so it composes with the nav-vs-terminal
+ *  model rather than replacing it. */
+export type View = "sessions" | "projects" | "tasks";
+
+/** The view cycle order for the [ / ] view-switch keys, left-to-right the same as
+ *  the appbar's view tabs. */
+export const VIEWS: readonly View[] = ["sessions", "projects", "tasks"];
+
+/** The view `delta` steps from `current`, wrapping around the cycle (so ] past the
+ *  last view returns to the first, and [ before the first wraps to the last). */
+export function cycleView(current: View, delta: 1 | -1): View {
+  const i = VIEWS.indexOf(current);
+  const n = VIEWS.length;
+  return VIEWS[(i + delta + n) % n];
+}
+
 /** The state the key decision reads: the current mode, whether a modal is up, the
  *  rail order + selection needed to compute the next selected row, and the selected
  *  session's tab shape for the nav-mode tab keys (#1592 Phase 5 PR7). */
 export interface NavContext {
   focus: KeyboardFocus;
   modalOpen: boolean;
+  /** The current top-level view (#1592 Phase 5 PR8). The rail-mode session keys
+   *  (Enter/attach, j/k, 1-9/t/w) apply only in the "sessions" view — the projects
+   *  and tasks views are mouse/button-driven browse/list surfaces — while the
+   *  [ / ] view-switch keys apply in EVERY view's rail mode. */
+  view: View;
   /** The rail's session ids in DISPLAY order (the same order the DOM shows). */
   orderedIds: string[];
   selectedId: string | null;
@@ -49,7 +73,8 @@ export type NavAction =
   | { kind: "toRail" }
   | { kind: "switchTab"; index: number }
   | { kind: "newTab" }
-  | { kind: "closeTab" };
+  | { kind: "closeTab" }
+  | { kind: "switchView"; view: View };
 
 /** The next selected id after moving `delta` rows, clamped to the ends. From no
  *  selection, a downward move lands on the first row and an upward move on the last
@@ -82,6 +107,25 @@ export function decideKey(key: string, ctx: NavContext): NavAction {
   // hatch back to rail navigation (mirrors the TUI detach); nothing else is ours.
   if (ctx.focus === "terminal") {
     return key === "Escape" ? { kind: "toRail" } : { kind: "none" };
+  }
+  // View switching (#1592 Phase 5 PR8): [ / ] cycle the top-level view. Rail-mode
+  // ONLY — a modal owns the keyboard (handled above) and a focused terminal forwards
+  // them to the agent (also above), so switching views composes with the #1694 focus
+  // model instead of fighting it. Shared across every view, unlike the session keys
+  // below.
+  if (key === "[") {
+    return { kind: "switchView", view: cycleView(ctx.view, -1) };
+  }
+  if (key === "]") {
+    return { kind: "switchView", view: cycleView(ctx.view, 1) };
+  }
+  // The remaining rail keys (Enter/attach, j/k selection, 1-9/t/w tabs) are the
+  // SESSIONS view's model: they act on the live session list + the selected
+  // session's terminal. The projects and tasks views are mouse/button-driven browse
+  // and list surfaces with no terminal, so those keys pass through there — only the
+  // view-switch keys above are ours outside the sessions view.
+  if (ctx.view !== "sessions") {
+    return { kind: "none" };
   }
   // Rail navigation (the default). Enter attaches the current selection to the
   // terminal and hands it the keyboard; j/k and the arrows move the selection.

--- a/web/src/projects.ts
+++ b/web/src/projects.ts
@@ -1,0 +1,164 @@
+// The PROJECTS view of the web client (#1592 Phase 5 PR8): the browser analogue of
+// the TUI's projects pane (ui/projects.go). It groups the live session projection by
+// repo root — one section per project af has seen — so the browser reads the repo
+// grouping the same way the TUI does. Projects key by REPO PATH (the stable project
+// id, mirroring app/switch_project.go buildProjectListFrom); the derivation is the
+// same distinct-repo-roots walk the new-session picker uses (ui.ts deriveProjects),
+// never an invented client id.
+//
+// It is a read-and-jump surface, not a mutation one: clicking a session under its
+// project opens it — which switches back to the sessions view and attaches its
+// terminal (index.ts onOpen) — so the projects pane doubles as a per-project session
+// switcher. It is patched in place (build once, re-render on a sessions/selection
+// change) like the rest of the shell, and scrolls rather than wrapping so a long
+// project list never pushes content off-screen (the #1620 vim-scrollable behavior).
+//
+// CSP-safe like the rest of the client: createElement + addEventListener only (the
+// shared h() helper), no innerHTML with markup.
+
+import { h, projectLabel } from "./modals.js";
+import { isArchived, rowStatus, rowTitle } from "./status.js";
+import type { SessionData } from "./types.js";
+
+/** One project section: its repo root (the stable id), a friendly label, and the
+ *  sessions grouped under it in rail order. */
+export interface ProjectGroup {
+  /** The repo root — the stable project id every project keys by. */
+  root: string;
+  /** The friendly label (repo basename + parent), shared with the modal picker. */
+  label: string;
+  /** The project's sessions, live rows first then archived, each by creation time. */
+  sessions: SessionData[];
+}
+
+/** Orders sessions within a project the same way the rail does (ui.ts
+ *  orderedSessions): live rows before the archived group, each ordered by creation
+ *  time then title, so the projects pane and the sessions rail agree on order. */
+function orderWithinProject(sessions: SessionData[]): SessionData[] {
+  return [...sessions].sort((a, b) => {
+    const aa = isArchived(a) ? 1 : 0;
+    const bb = isArchived(b) ? 1 : 0;
+    if (aa !== bb) {
+      return aa - bb;
+    }
+    const at = a.created_at ?? "";
+    const bt = b.created_at ?? "";
+    if (at !== bt) {
+      return at < bt ? -1 : 1;
+    }
+    return a.title < b.title ? -1 : a.title > b.title ? 1 : 0;
+  });
+}
+
+/**
+ * Groups the live sessions by their repo root (project), sorted by path for a
+ * stable menu — the browser analogue of buildProjectListFrom. A session with no
+ * repo_path is skipped: it can't be attributed to a project (the same rows the
+ * new-session picker omits). Exported so index.ts can flatten the SAME order for
+ * anything that needs it, and unit tests can pin the grouping.
+ */
+export function groupSessionsByProject(sessions: SessionData[]): ProjectGroup[] {
+  const byRoot = new Map<string, SessionData[]>();
+  for (const s of sessions) {
+    const root = s.worktree?.repo_path;
+    if (!root) {
+      continue;
+    }
+    const arr = byRoot.get(root) ?? [];
+    arr.push(s);
+    byRoot.set(root, arr);
+  }
+  return [...byRoot.keys()]
+    .sort()
+    .map((root) => ({ root, label: projectLabel(root), sessions: orderWithinProject(byRoot.get(root) ?? []) }));
+}
+
+/**
+ * The projects pane: build once (its `el` mounts into the app body beside the
+ * sessions body), then update(sessions, selectedId) re-renders on a change. Kept as
+ * a small stateful class like the terminal/tab bar so a live rail event patches only
+ * this subtree, never the sibling terminal host.
+ */
+export class ProjectsPane {
+  readonly el: HTMLElement;
+  private lastSessions: SessionData[] | null = null;
+  private lastSelectedId: string | null = null;
+
+  /** onOpen selects + attaches a session by its stable id (index.ts switches to the
+   *  sessions view and hands the terminal the keyboard), so a project's session row
+   *  is a jump-to-session affordance. */
+  constructor(private readonly onOpen: (id: string) => void) {
+    this.el = h("section", { class: "af-projects" });
+    this.el.setAttribute("aria-label", "Projects");
+  }
+
+  /** Re-renders when the session list or the selection changed. */
+  update(sessions: SessionData[], selectedId: string | null): void {
+    if (this.lastSessions === sessions && this.lastSelectedId === selectedId) {
+      return;
+    }
+    this.lastSessions = sessions;
+    this.lastSelectedId = selectedId;
+    this.render(sessions, selectedId);
+  }
+
+  private render(sessions: SessionData[], selectedId: string | null): void {
+    const groups = groupSessionsByProject(sessions);
+    const head = h(
+      "div",
+      { class: "af-projects-head" },
+      h("span", { class: "af-projects-title" }, "Projects"),
+      h("span", { class: "af-view-count" }, String(groups.length)),
+    );
+    if (groups.length === 0) {
+      this.el.replaceChildren(
+        head,
+        h(
+          "p",
+          { class: "af-projects-empty" },
+          "No projects yet. Create a session in a repo (the TUI or ",
+          h("code", {}, "af sessions create"),
+          ") and it appears here.",
+        ),
+      );
+      return;
+    }
+    const sections = groups.map((g) => this.projectSection(g, selectedId));
+    this.el.replaceChildren(head, h("div", { class: "af-projects-list" }, ...sections));
+  }
+
+  private projectSection(group: ProjectGroup, selectedId: string | null): HTMLElement {
+    const header = h(
+      "div",
+      { class: "af-project-head" },
+      h("span", { class: "af-project-name" }, group.label),
+      h("span", { class: "af-project-count" }, `${group.sessions.length}`),
+    );
+    header.append(h("div", { class: "af-project-path" }, group.root));
+    const rows = group.sessions.map((s) => this.sessionRow(s, s.id === selectedId));
+    return h("section", { class: "af-project" }, header, h("ul", { class: "af-project-sessions" }, ...rows));
+  }
+
+  /** One session row under a project: the same status dot + prefixed title the rail
+   *  row carries (status.ts), keyed by the stable id. Clicking opens it (→ sessions
+   *  view). A row with no id (never from a live Snapshot) renders but is inert. */
+  private sessionRow(s: SessionData, selected: boolean): HTMLElement {
+    const status = rowStatus(s);
+    const dot = h(
+      "span",
+      { class: `af-dot af-dot-${status.kind}${status.spinning ? " af-dot-spin" : ""}` },
+      status.glyph,
+    );
+    dot.setAttribute("aria-hidden", "true");
+    const title = h("div", { class: "af-row-title" }, rowTitle(s));
+    const cls = `af-row af-project-row${selected ? " af-row-selected" : ""}${isArchived(s) ? " af-row-archived" : ""}`;
+    const row = h("li", { class: cls }, dot, h("div", { class: "af-row-main" }, title));
+    row.setAttribute("role", "button");
+    row.setAttribute("title", `${s.title} — ${status.label}`);
+    if (s.id) {
+      const id = s.id;
+      row.addEventListener("click", () => this.onOpen(id));
+    }
+    return row;
+  }
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -751,6 +751,247 @@ body {
   margin-top: 0;
 }
 
+/* View switcher (#1592 Phase 5 PR8): appbar tabs for the top-level views (Sessions /
+ * Projects / Tasks), mirroring the TUI's rail sections. The active tab is
+ * accent-underlined, the tab-row analogue of the session tab bar. */
+.af-viewnav {
+  display: inline-flex;
+  align-items: stretch;
+  gap: 0.25rem;
+  margin-left: 0.5rem;
+}
+
+.af-viewtab {
+  padding: 0.3rem 0.7rem;
+  background: transparent;
+  color: var(--af-muted);
+  border: none;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+  font: inherit;
+  font-size: 0.78rem;
+  cursor: pointer;
+}
+
+.af-viewtab:hover {
+  color: var(--af-text);
+}
+
+.af-viewtab-active {
+  color: var(--af-text);
+  border-bottom-color: var(--af-accent);
+}
+
+/* The viewport holds the three view bodies; exactly one shows at a time (the others
+ * carry the `hidden` attribute). The explicit rule beats the bodies' own
+ * `display:flex`, which would otherwise keep a hidden body visible (author styles
+ * outrank the UA `[hidden]` rule). */
+.af-viewport {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+
+.af-viewport > [hidden] {
+  display: none;
+}
+
+.af-viewport > * {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+}
+
+/* Projects view: a scrollable column of project sections, each a repo root with its
+ * sessions grouped under it (the browser analogue of ui/projects.go). */
+.af-projects,
+.af-tasks {
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
+
+.af-projects-head,
+.af-tasks-head {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.6rem 1rem;
+  border-bottom: 1px solid var(--af-border);
+  background: var(--af-surface);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.af-projects-title,
+.af-tasks-title {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--af-muted);
+}
+
+/* The projects/tasks count badge, styled like the rail's session count (a distinct
+ * class so the sessions rail's .af-rail-count selector stays unambiguous). */
+.af-view-count {
+  font-size: 0.75rem;
+  color: var(--af-muted);
+  background: var(--af-bg);
+  border: 1px solid var(--af-border);
+  border-radius: 999px;
+  padding: 0.05rem 0.5rem;
+}
+
+/* The tasks "+ Add" button, styled like the rail's "+ New" and pushed to the far
+ * right of its header (its own class so the rail's .af-rail-new stays unambiguous). */
+.af-tasks-add {
+  margin-left: auto;
+  padding: 0.25rem 0.55rem;
+  background: transparent;
+  color: var(--af-accent);
+  border: 1px solid var(--af-accent);
+  border-radius: 6px;
+  font: inherit;
+  font-size: 0.72rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.af-tasks-add:hover {
+  background: rgba(47, 129, 247, 0.12);
+}
+
+.af-projects-empty,
+.af-tasks-empty {
+  padding: 1.25rem 1rem;
+  color: var(--af-muted);
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.af-projects-empty code {
+  color: var(--af-text);
+}
+
+.af-projects-list {
+  padding: 0.5rem 0.75rem 1.5rem;
+}
+
+.af-project {
+  margin-bottom: 0.75rem;
+}
+
+.af-project-head {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: baseline;
+  gap: 0.5rem;
+  padding: 0.5rem 0.6rem 0.35rem;
+}
+
+.af-project-name {
+  font-size: 0.85rem;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.af-project-count {
+  font-size: 0.72rem;
+  color: var(--af-muted);
+}
+
+.af-project-path {
+  grid-column: 1 / -1;
+  font-size: 0.7rem;
+  color: var(--af-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.af-project-sessions {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.af-project-row {
+  padding: 0.4rem 0.6rem;
+}
+
+/* Tasks view: a scrollable list of scheduled tasks, each with its trigger + last-run
+ * and the enable/disable · trigger · remove actions (mirrors ui/automations.go). */
+.af-tasks-list {
+  list-style: none;
+  margin: 0;
+  padding: 0.5rem 0.75rem 1.5rem;
+}
+
+.af-task-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  padding: 0.6rem 0.6rem;
+  border-bottom: 1px solid var(--af-border);
+}
+
+.af-task-enabled {
+  flex: 0 0 auto;
+  font-size: 0.78rem;
+  color: var(--af-muted);
+  line-height: 1.5;
+}
+
+.af-task-enabled.af-task-on {
+  color: var(--af-dot-ready);
+}
+
+.af-task-main {
+  flex: 1;
+  min-width: 0;
+}
+
+.af-task-name {
+  font-size: 0.85rem;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.af-task-trigger {
+  margin-top: 0.15rem;
+  font-size: 0.75rem;
+  color: var(--af-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.af-task-meta {
+  margin-top: 0.1rem;
+  font-size: 0.72rem;
+  color: var(--af-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.af-task-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex: 0 0 auto;
+}
+
+.af-task-action {
+  padding: 0.3rem 0.55rem;
+  font-size: 0.72rem;
+}
+
 /* Narrow viewport: stack the rail above the main pane (design §7.2 item 7 —
  * usable-but-not-optimized on a phone). */
 @media (max-width: 640px) {

--- a/web/src/tasks.ts
+++ b/web/src/tasks.ts
@@ -1,0 +1,310 @@
+// The TASKS view of the web client (#1592 Phase 5 PR8): the browser analogue of the
+// TUI's automations / task pane (ui/task_pane.go, ui/automations.go). It lists the
+// scheduled tasks the daemon owns — name, cron/watch trigger, enabled, target
+// session, last-run + status — and drives their lifecycle from the browser: add,
+// enable/disable (UpdateTask), trigger-now (TriggerTask), and remove (RemoveTask).
+//
+// Every row-level MUTATION keys off the task's globally-unique `id`, never its
+// (optional, non-unique) name — the api layer's requireTaskID fails a missing id
+// closed, so this view only ever hands the daemon a real target (#1592 PR8, the
+// #1678 id-scoping class). The daemon is the single writer (#1029 PR3): these
+// callbacks POST the RPC and let the refreshed ListTasks / task.* event update the
+// list, so the pane holds no source of truth of its own.
+//
+// It is patched in place like the rest of the shell and CSP-safe (createElement +
+// addEventListener via the shared h() helper, no innerHTML with markup).
+
+import { asForm, field, h, modalChrome, type ModalHandle, projectLabel } from "./modals.js";
+import type { TaskData } from "./types.js";
+
+/** The add-task form's inputs (a subset of task.Task the browser fills; the daemon
+ *  re-validates). Exactly one of cron / watchCmd is meaningful, per `trigger`. */
+export interface AddTaskInput {
+  name: string;
+  projectPath: string;
+  trigger: "cron" | "watch";
+  cron: string;
+  watchCmd: string;
+  prompt: string;
+  targetSession: string;
+  program: string;
+}
+
+/** The row-level actions the tasks pane invokes; index.ts owns the real behavior
+ *  (the daemon RPC + list refresh). Each mutation is handed the whole task so the
+ *  handler has its stable id AND its current fields (UpdateTask needs the full task). */
+export interface TaskActions {
+  /** Opens the add-task modal. */
+  add(): void;
+  /** Flips enabled via UpdateTask. */
+  toggle(task: TaskData): void;
+  /** Fires the task now via TriggerTask (enabled cron tasks only). */
+  trigger(task: TaskData): void;
+  /** Removes the task via RemoveTask. */
+  remove(task: TaskData): void;
+}
+
+/** A random 8-char (4-byte) hex task id, matching task.GenerateID's shape and the
+ *  [a-zA-Z0-9_-] id class (task.ValidateTaskID). Generated CLIENT-side because the
+ *  daemon's AddTask validates a non-empty id on the incoming task (it does not mint
+ *  one), exactly like the CLI's `af tasks add`. Web Crypto keeps it same-origin —
+ *  no fetch, so the daemon's CSP holds. */
+function genTaskId(): string {
+  const b = new Uint8Array(4);
+  crypto.getRandomValues(b);
+  return [...b].map((x) => x.toString(16).padStart(2, "0")).join("");
+}
+
+/** Builds a task.Task from the add-form input: a fresh id + created_at, exactly one
+ *  trigger set per `trigger`, and enabled=true (a new task is armed). The daemon
+ *  re-validates the trigger/prompt/program contract (task.AddTask). */
+export function buildTask(input: AddTaskInput): TaskData {
+  return {
+    id: genTaskId(),
+    name: input.name,
+    prompt: input.prompt,
+    cron_expr: input.trigger === "cron" ? input.cron : "",
+    watch_cmd: input.trigger === "watch" ? input.watchCmd : "",
+    target_session: input.targetSession,
+    project_path: input.projectPath,
+    program: input.program,
+    enabled: true,
+    created_at: new Date().toISOString(),
+  };
+}
+
+/** The task's trigger as a one-line summary, mirroring the TUI's row detail
+ *  (ui/automations.go rowDetail): the cron expression, or `watch: <cmd>`. */
+function triggerSummary(t: TaskData): string {
+  if (t.watch_cmd && t.watch_cmd.trim() !== "") {
+    return `watch: ${t.watch_cmd}`;
+  }
+  if (t.cron_expr && t.cron_expr.trim() !== "") {
+    return `cron: ${t.cron_expr}`;
+  }
+  return "no trigger";
+}
+
+/** Whether a task is a fire-now candidate: TriggerTask refuses disabled and watch
+ *  tasks (they have no manual fire), so the Trigger action shows only for an enabled
+ *  cron task — the same guard the daemon enforces, surfaced as UI. */
+function canTrigger(t: TaskData): boolean {
+  return t.enabled && !!t.cron_expr && t.cron_expr.trim() !== "" && !(t.watch_cmd && t.watch_cmd.trim() !== "");
+}
+
+/** The last-run line, or a dim placeholder before the first run. */
+function lastRunSummary(t: TaskData): string {
+  if (!t.last_run_at) {
+    return "never run";
+  }
+  const status = t.last_run_status ? ` (${t.last_run_status})` : "";
+  return `last run ${t.last_run_at}${status}`;
+}
+
+/**
+ * The tasks pane: build once (its `el` mounts into the app body), then
+ * update(tasks) re-renders on a change. A small stateful class like the projects
+ * pane so a task.* event patches only this subtree.
+ */
+export class TasksPane {
+  readonly el: HTMLElement;
+  private lastTasks: TaskData[] | null = null;
+
+  constructor(private readonly actions: TaskActions) {
+    this.el = h("section", { class: "af-tasks" });
+    this.el.setAttribute("aria-label", "Tasks");
+  }
+
+  update(tasks: TaskData[]): void {
+    if (this.lastTasks === tasks) {
+      return;
+    }
+    this.lastTasks = tasks;
+    this.render(tasks);
+  }
+
+  private render(tasks: TaskData[]): void {
+    const addBtn = h("button", { type: "button", class: "af-tasks-add", title: "Add task" }, "+ Add");
+    addBtn.addEventListener("click", () => this.actions.add());
+    const head = h(
+      "div",
+      { class: "af-tasks-head" },
+      h("span", { class: "af-tasks-title" }, "Tasks"),
+      h("span", { class: "af-view-count" }, String(tasks.length)),
+      addBtn,
+    );
+    if (tasks.length === 0) {
+      this.el.replaceChildren(
+        head,
+        h(
+          "p",
+          { class: "af-tasks-empty" },
+          "No scheduled tasks yet. Add one to deliver a prompt on a cron schedule.",
+        ),
+      );
+      return;
+    }
+    const rows = [...tasks]
+      .sort((a, b) => (a.created_at < b.created_at ? -1 : a.created_at > b.created_at ? 1 : 0))
+      .map((t) => this.taskRow(t));
+    this.el.replaceChildren(head, h("ul", { class: "af-tasks-list" }, ...rows));
+  }
+
+  private taskRow(t: TaskData): HTMLElement {
+    const glyph = t.enabled ? "[✓]" : "[ ]";
+    const enabledDot = h("span", { class: `af-task-enabled${t.enabled ? " af-task-on" : ""}` }, glyph);
+    enabledDot.setAttribute("aria-hidden", "true");
+
+    const name = h("div", { class: "af-task-name" }, t.name && t.name.trim() !== "" ? t.name : "(unnamed task)");
+    const trigger = h("div", { class: "af-task-trigger" }, triggerSummary(t));
+    const metaParts: string[] = [];
+    if (t.target_session && t.target_session.trim() !== "") {
+      metaParts.push(`→ ${t.target_session}`);
+    }
+    metaParts.push(lastRunSummary(t));
+    const meta = h("div", { class: "af-task-meta" }, metaParts.join("  ·  "));
+    const main = h("div", { class: "af-task-main" }, name, trigger, meta);
+
+    const toggleBtn = h(
+      "button",
+      { type: "button", class: "af-ghost af-task-action" },
+      t.enabled ? "Disable" : "Enable",
+    );
+    toggleBtn.addEventListener("click", () => this.actions.toggle(t));
+
+    const actionEls: HTMLElement[] = [toggleBtn];
+    if (canTrigger(t)) {
+      const triggerBtn = h("button", { type: "button", class: "af-ghost af-task-action" }, "Trigger");
+      triggerBtn.addEventListener("click", () => this.actions.trigger(t));
+      actionEls.push(triggerBtn);
+    }
+    const removeBtn = h("button", { type: "button", class: "af-danger af-task-action" }, "Remove");
+    removeBtn.addEventListener("click", () => this.actions.remove(t));
+    actionEls.push(removeBtn);
+
+    const actions = h("div", { class: "af-task-actions" }, ...actionEls);
+    return h("li", { class: "af-task-row" }, enabledDot, main, actions);
+  }
+}
+
+/**
+ * The add-task modal (mirrors the TUI's task editor + `af tasks add`): name,
+ * project, a cron/watch trigger toggle with its value, a prompt, an optional target
+ * session, and the agent program. onSubmit fires with the collected input; the caller
+ * builds the task (buildTask) and POSTs AddTask. A cron task requires a prompt (the
+ * daemon rejects an empty one — there is no event line to fall back to); a watch task
+ * requires its command and may omit the prompt.
+ */
+export function addTaskModal(
+  projects: string[],
+  callbacks: { onSubmit: (input: AddTaskInput) => void; onCancel: () => void },
+): ModalHandle {
+  const { handle, body, confirmBtn } = modalChrome({
+    title: "Add task",
+    confirmLabel: "Add",
+    confirmClass: "af-primary",
+    onCancel: callbacks.onCancel,
+  });
+
+  const nameInput = h("input", { type: "text", class: "af-input", placeholder: "Task name", autocomplete: "off" });
+  nameInput.setAttribute("aria-label", "Task name");
+
+  const projectSelect = h("select", { class: "af-input" });
+  projectSelect.setAttribute("aria-label", "Project");
+  if (projects.length === 0) {
+    const opt = h("option", { value: "" }, "No projects yet — create a session first");
+    opt.disabled = true;
+    opt.selected = true;
+    projectSelect.append(opt);
+    confirmBtn.disabled = true;
+  } else {
+    for (const p of projects) {
+      projectSelect.append(h("option", { value: p }, projectLabel(p)));
+    }
+  }
+
+  const triggerSelect = h("select", { class: "af-input" });
+  triggerSelect.setAttribute("aria-label", "Trigger type");
+  triggerSelect.append(h("option", { value: "cron" }, "Cron schedule"));
+  triggerSelect.append(h("option", { value: "watch" }, "Watch command"));
+
+  const cronInput = h("input", { type: "text", class: "af-input", placeholder: "0 9 * * *", autocomplete: "off" });
+  cronInput.setAttribute("aria-label", "Cron expression");
+  const cronField = field("Cron expression", cronInput);
+
+  const watchInput = h("input", { type: "text", class: "af-input", placeholder: "tail -F events.log", autocomplete: "off" });
+  watchInput.setAttribute("aria-label", "Watch command");
+  const watchField = field("Watch command", watchInput);
+  watchField.hidden = true;
+
+  // Show only the field for the selected trigger; the other is hidden (its value is
+  // ignored by buildTask, and the daemon rejects a task with both set).
+  triggerSelect.addEventListener("change", () => {
+    const isWatch = triggerSelect.value === "watch";
+    cronField.hidden = isWatch;
+    watchField.hidden = !isWatch;
+  });
+
+  const promptArea = h("textarea", { class: "af-input af-textarea", placeholder: "Prompt to deliver ({{line}} for the watch line)", rows: 3 });
+  promptArea.setAttribute("aria-label", "Prompt");
+
+  const targetInput = h("input", { type: "text", class: "af-input", placeholder: "Target session (optional)", autocomplete: "off" });
+  targetInput.setAttribute("aria-label", "Target session");
+
+  const programSelect = h("select", { class: "af-input" });
+  programSelect.setAttribute("aria-label", "Program");
+  programSelect.append(h("option", { value: "" }, "Repo default"));
+  for (const prog of ["claude", "codex", "aider", "gemini", "amp"]) {
+    programSelect.append(h("option", { value: prog }, prog));
+  }
+
+  body.append(
+    field("Name", nameInput),
+    field("Project", projectSelect),
+    field("Trigger", triggerSelect),
+    cronField,
+    watchField,
+    field("Prompt", promptArea),
+    field("Target session", targetInput),
+    field("Program", programSelect),
+  );
+
+  const card = handle.el.firstElementChild as HTMLElement;
+  asForm(card, () => {
+    const trigger = triggerSelect.value === "watch" ? "watch" : "cron";
+    const name = nameInput.value.trim();
+    const cron = cronInput.value.trim();
+    const watchCmd = watchInput.value.trim();
+    const prompt = promptArea.value.trim();
+    if (name === "" || projectSelect.value === "") {
+      handle.setError("A name and a project are required.");
+      return;
+    }
+    if (trigger === "cron" && cron === "") {
+      handle.setError("A cron expression is required for a cron task.");
+      return;
+    }
+    if (trigger === "cron" && prompt === "") {
+      handle.setError("A prompt is required for a cron task.");
+      return;
+    }
+    if (trigger === "watch" && watchCmd === "") {
+      handle.setError("A watch command is required for a watch task.");
+      return;
+    }
+    handle.setError(null);
+    callbacks.onSubmit({
+      name,
+      projectPath: projectSelect.value,
+      trigger,
+      cron,
+      watchCmd,
+      prompt: promptArea.value,
+      targetSession: targetInput.value.trim(),
+      program: programSelect.value,
+    });
+  });
+
+  queueMicrotask(() => nameInput.focus());
+  return handle;
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -110,6 +110,45 @@ export interface SnapshotResponse {
   delivery_alarms?: unknown[];
 }
 
+/**
+ * The subset of task.Task (task/task.go) the tasks view reads and mutates (#1592
+ * Phase 5 PR8). Field names and JSON tags match the Go struct EXACTLY so this
+ * decodes the daemon's ListTasks projection as-is and round-trips through
+ * AddTask/UpdateTask unchanged. `id` is globally unique — the stable key every
+ * mutation (UpdateTask/TriggerTask/RemoveTask) resolves by, NEVER the name (which
+ * is optional and non-unique). Optional fields carry Go's `omitempty` semantics:
+ * exactly one of `cron_expr` / `watch_cmd` is set on an enabled task, and the
+ * `last_run_*` fields are absent until the task first runs.
+ */
+export interface TaskData {
+  id: string;
+  name?: string;
+  prompt: string;
+  /** Time trigger (cron schedule); exactly one of cron_expr / watch_cmd on an
+   *  enabled task (task.ValidateTrigger). */
+  cron_expr?: string;
+  /** Event trigger: a long-lived watch command whose stdout lines fire the task. */
+  watch_cmd?: string;
+  /** Route deliveries into this session by title (empty ⇒ a fresh session per run). */
+  target_session?: string;
+  /** The repo root the task belongs to — the project it groups under. */
+  project_path: string;
+  /** The agent program; empty resolves the repo default at run time. */
+  program: string;
+  enabled: boolean;
+  /** RFC3339 creation time. */
+  created_at: string;
+  /** RFC3339 last-run time (absent until the task first runs). */
+  last_run_at?: string;
+  /** The outcome of the last run (scheduler-owned; absent until first run). */
+  last_run_status?: string;
+}
+
+/** The ListTasks RPC response (daemon/control_types.go: ListTasksResponse). */
+export interface TasksResponse {
+  tasks: TaskData[] | null;
+}
+
 /** agentproto.EventType (agentproto/message.go): the /v1/events discriminators. */
 export type EventType =
   | "session.created"

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -19,15 +19,22 @@
 // session changes (a deliberate user act that rebuilds the terminal anyway).
 
 import type { EventStreamStatus } from "./events.js";
-import type { KeyboardFocus } from "./nav.js";
+import type { KeyboardFocus, View } from "./nav.js";
+import { VIEWS } from "./nav.js";
+import { ProjectsPane } from "./projects.js";
 import { isArchived, rowStatus, rowTitle } from "./status.js";
+import { TasksPane } from "./tasks.js";
 import type { TerminalStatus } from "./terminal.js";
-import type { SessionData } from "./types.js";
+import type { SessionData, TaskData } from "./types.js";
 
 /** The whole client state: which view to show, the login details, and — once
  *  authed — the live session projection plus the current selection. */
 export interface AppState {
   phase: "login" | "app";
+  /** the top-level view (#1592 Phase 5 PR8): the live sessions rail+terminal, the
+   *  projects (repo grouping) pane, or the tasks (scheduled automations) pane. The
+   *  appbar view tabs and the [ / ] keys switch it; it selects which body shows. */
+  view: View;
   /** whether THIS client must present a bearer token, from the /v1/auth-info probe
    *  (#1696). false ⇒ the daemon exempts this peer (loopback, or require_token=false),
    *  so the login view offers a one-click tokenless connect instead of the paste form.
@@ -57,10 +64,12 @@ export interface AppState {
    *  the selection changes. */
   activeTab: number;
   /** an actionable message shown as a transient toast when a tab op (create/close)
-   *  fails, or null when there is none. Tab ops have no modal to surface an error
-   *  in (unlike create/kill/archive), so the failure is shown here instead of being
-   *  silently swallowed (#1592 Phase 5 PR7). */
+   *  or a task op (toggle/trigger/remove) fails, or null when there is none. These
+   *  ops have no modal to surface an error in (unlike create/kill/archive), so the
+   *  failure is shown here instead of being silently swallowed (#1592 Phase 5 PR7/PR8). */
   tabError: string | null;
+  /** the live task projection (ListTasks + task.* events), the tasks view's data. */
+  tasks: TaskData[];
 }
 
 /** Callbacks the shell invokes; index.ts owns the real behavior. */
@@ -90,6 +99,18 @@ export interface Actions {
   /** Closes the tab at `index` of the selected session (the `w` key / × button);
    *  the agent tab (index 0) is unclosable. */
   closeTab(index: number): void;
+  /** Switches the top-level view (#1592 Phase 5 PR8): the appbar view tabs and the
+   *  [ / ] keys route here; index.ts flips the store and hands the keyboard back to
+   *  the rail (blurring the terminal) when leaving the sessions view. */
+  switchView(view: View): void;
+  /** Opens the add-task modal (#1592 Phase 5 PR8). */
+  addTask(): void;
+  /** Enables/disables a task via UpdateTask. */
+  toggleTask(task: TaskData): void;
+  /** Fires a task now via TriggerTask (enabled cron tasks). */
+  triggerTask(task: TaskData): void;
+  /** Removes a task via RemoveTask. */
+  removeTask(task: TaskData): void;
 }
 
 /** The soft cap on tabs per session (session/tab.go maxTabs): the agent tab plus
@@ -140,6 +161,18 @@ export function deriveProjects(sessions: SessionData[]): string[] {
     }
   }
   return [...roots].sort();
+}
+
+/** The appbar label for a top-level view (#1592 Phase 5 PR8). */
+function viewLabel(view: View): string {
+  switch (view) {
+    case "sessions":
+      return "Sessions";
+    case "projects":
+      return "Projects";
+    case "tasks":
+      return "Tasks";
+  }
 }
 
 /** Minimal hyperscript: create an element, apply props, append children. Keeps the
@@ -332,6 +365,17 @@ export class AppShell {
   // A transient toast for failed tab ops (create/close), shown/hidden by `tabError`.
   private readonly toast: HTMLElement;
 
+  // The top-level view switcher (#1592 Phase 5 PR8): the appbar tabs (by view) and
+  // the three body surfaces they toggle between. The sessions body (rail+terminal)
+  // stays mounted while another view shows — hidden, not destroyed — so switching
+  // views never tears down the focused terminal or its scrollback.
+  private readonly viewTabs = new Map<View, HTMLElement>();
+  private readonly sessionsBody: HTMLElement;
+  private readonly projectsPane: ProjectsPane;
+  private readonly tasksPane: TasksPane;
+  private lastView: View | null = null;
+  private lastTasks: TaskData[] | null = null;
+
   // Header text nodes for the selected pane, (re)created per selection.
   private headTitle: HTMLElement | null = null;
   private headMeta: HTMLElement | null = null;
@@ -362,10 +406,26 @@ export class AppShell {
     const disconnect = h("button", { type: "button", class: "af-ghost" }, "Disconnect");
     disconnect.addEventListener("click", () => this.actions.disconnect());
 
+    // The view switcher: one tab per top-level view, left-to-right in the [ / ] cycle
+    // order (nav.ts VIEWS), the active one highlighted in update(). A click routes
+    // through actions.switchView, exactly like the keyboard path.
+    const viewNav = h("div", { class: "af-viewnav" });
+    viewNav.setAttribute("role", "tablist");
+    viewNav.setAttribute("aria-label", "Views");
+    for (const v of VIEWS) {
+      const tab = h("button", { type: "button", class: "af-viewtab" }, viewLabel(v));
+      tab.setAttribute("role", "tab");
+      tab.setAttribute("data-view", v);
+      tab.addEventListener("click", () => this.actions.switchView(v));
+      this.viewTabs.set(v, tab);
+      viewNav.append(tab);
+    }
+
     const header = h(
       "header",
       { class: "af-appbar" },
       h("span", { class: "af-brand" }, "Agent Factory"),
+      viewNav,
       live,
       disconnect,
     );
@@ -386,14 +446,27 @@ export class AppShell {
     const rail = h("nav", { class: "af-rail" }, railHead, this.railList);
 
     this.main = h("section", { class: "af-main" });
-    const body = h("div", { class: "af-body" }, rail, this.main);
+    this.sessionsBody = h("div", { class: "af-body" }, rail, this.main);
+
+    // The projects + tasks views are peers of the sessions body inside one viewport;
+    // update() shows exactly one and hides the others by `state.view`. They own their
+    // own subtrees so a task.* / rail event patches only the active pane.
+    this.projectsPane = new ProjectsPane((id: string) => this.actions.open(id));
+    this.tasksPane = new TasksPane({
+      add: () => this.actions.addTask(),
+      toggle: (task: TaskData) => this.actions.toggleTask(task),
+      trigger: (task: TaskData) => this.actions.triggerTask(task),
+      remove: (task: TaskData) => this.actions.removeTask(task),
+    });
+    const viewport = h("div", { class: "af-viewport" }, this.sessionsBody, this.projectsPane.el, this.tasksPane.el);
+
     // A transient toast for failed tab ops: a fixed-position banner that fades in
     // only while `tabError` is set (index.ts clears it on a timer / selection change).
     this.toast = h("div", { class: "af-toast" });
     this.toast.setAttribute("role", "alert");
     // The modal host is a persistent overlay layer index.ts mounts modals into; it
     // sits above the app body and is empty except while a modal is open.
-    this.el = h("main", { class: "af-app" }, header, body, this.toast, this.modalHost);
+    this.el = h("main", { class: "af-app" }, header, viewport, this.toast, this.modalHost);
   }
 
   /** Applies the latest state, touching only what changed. */
@@ -420,6 +493,30 @@ export class AppShell {
       this.pip.className = `af-live-pip af-live-${state.live}`;
       this.pipLabel.textContent =
         state.live === "open" ? "Live" : state.live === "connecting" ? "Connecting…" : "Reconnecting…";
+    }
+
+    // View switching (#1592 Phase 5 PR8): show the active view's body, hide the
+    // others, and highlight its appbar tab. The sessions body is only HIDDEN (never
+    // removed), so the terminal host inside it — and its focus/scrollback — survives
+    // a round trip to another view.
+    if (this.lastView !== state.view) {
+      this.lastView = state.view;
+      this.sessionsBody.hidden = state.view !== "sessions";
+      this.projectsPane.el.hidden = state.view !== "projects";
+      this.tasksPane.el.hidden = state.view !== "tasks";
+      for (const [v, tab] of this.viewTabs) {
+        tab.classList.toggle("af-viewtab-active", v === state.view);
+        tab.setAttribute("aria-selected", v === state.view ? "true" : "false");
+      }
+    }
+
+    // The projects pane mirrors the live session grouping; the tasks pane mirrors the
+    // task projection. Each self-guards on an unchanged reference, so these are cheap
+    // no-ops when their data didn't change (and when their view isn't showing).
+    this.projectsPane.update(state.sessions, state.selectedId);
+    if (this.lastTasks !== state.tasks) {
+      this.lastTasks = state.tasks;
+      this.tasksPane.update(state.tasks);
     }
 
     const sessionsChanged = this.lastSessions !== state.sessions;


### PR DESCRIPTION
## What & why

Phase 5 PR8 of the multi-backend rewrite (#1592): give the **web client** the
TUI's **PROJECTS** and **TASKS** surfaces. Following PR7 (session tabs), this is a
pure **rendering-client** change — it reuses the daemon's existing `/v1` API the
TUI/CLI already speak and adds **no new daemon routes**.

## What it adds

- **Top-level view switch, wired through `nav.ts`.** A `view`
  (`sessions | projects | tasks`) is added to the pure `decideKey` state machine
  as a *higher-level* switch, so `[` / `]` (and the appbar view tabs) **compose**
  with the #1694 focus model rather than fight it: the `modal → terminal → rail`
  precedence and "j/k always navigate the rail" are untouched. The session keys
  (Enter/attach, j/k, `1-9`/`t`/`w`) stay scoped to the sessions view; the
  view-switch keys work in every view's rail mode. New transitions are
  unit-tested in `nav.test.ts`.
- **PROJECTS view** (`web/src/projects.ts`) — the live session projection grouped
  by **repo root**, mirroring `ui/projects.go`. Projects key by **repo path** (the
  stable project id, like the TUI's `buildProjectListFrom`); a project's session
  row is a jump-to-session affordance (→ sessions view + attach). Scrollable.
- **TASKS view** (`web/src/tasks.ts`) — the daemon's `ListTasks` (name, cron/watch
  trigger, enabled, target session, last-run + status) with **add** / **enable-
  disable** (`UpdateTask`) / **trigger-now** (`TriggerTask`) / **remove**
  (`RemoveTask`), mirroring `ui/automations.go` + `af tasks`.
- **API methods** (`web/src/api.ts`) — `listTasks/addTask/updateTask/triggerTask/
  removeTask`, thin POSTs to the **existing** `/v1/ListTasks|AddTask|UpdateTask|
  RemoveTask|TriggerTask` routes.

## id-stability (the class that bit PR7 three times)

Every task **mutation** keys off the task's globally-unique `id`, never its
optional/non-unique name, and **fails closed on a missing id** — a new
`requireTaskID(id, action)` refuses *before* issuing the request, the exact
precedent of `requireSessionID` (the #1678 id-scoping class). `api.test.ts` pins
the fail-closed behavior for `updateTask/triggerTask/removeTask`.

## Tests

- **`web/selftest/web-driver.spec.ts`** extended (the harness now seeds a task):
  the PROJECTS list renders the seeded repo + groups its sessions, and the TASKS
  view lists the seeded task and **add / enable-disable / trigger / remove
  round-trips** — every mutation asserted to carry the stable id. **10/10 green**.
- **Unit tests**: `nav.test.ts` (view-switch transitions + `cycleView`) and
  `api.test.ts` (`requireTaskID` fail-closed). **67/67 green**.

## Gates (all green)

- `make web-selftest-container` — 10/10 (both new view steps included)
- `make web-test` — 67/67 (nav, api, sessions, …) + `tsc` clean
- `make tui-driver-selftest` — 25/25 (no Go touched)
- `go build ./...` clean · `gofmt -l .` empty · `golangci-lint --fast` clean ·
  `deadcode -test ./...` empty · `scripts/lint-file-length.sh` clean
- `web/dist` rebuilt + committed (reproducible — rebuild yields identical bytes)

No new daemon `/v1` routes — every route already existed (verified). New TS split
into `web/src/projects.ts` / `web/src/tasks.ts` so no file crosses the length
limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Signed-off-by: Captain Claude