### PR TITLE
feat(web): polish pass — states, consistency, deferred orderings (#1592 Phase 5 PR9)

### DIFF
--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -31,6 +31,19 @@ body {
   min-height: 100vh;
   background: var(--af-bg);
   color: var(--af-text);
+  overflow-x: hidden;
+}
+.af-primary:focus-visible,
+.af-ghost:focus-visible,
+.af-danger:focus-visible,
+.af-rail-new:focus-visible,
+.af-tasks-add:focus-visible,
+.af-tab:focus-visible,
+.af-tab-new:focus-visible,
+.af-viewtab:focus-visible,
+.af-task-action:focus-visible {
+  outline: 2px solid var(--af-accent);
+  outline-offset: 2px;
 }
 #app {
   min-height: 100vh;
@@ -125,6 +138,7 @@ body {
   padding: 0.75rem 1.25rem;
   background: var(--af-surface);
   border-bottom: 1px solid var(--af-border);
+  flex-wrap: wrap;
 }
 .af-brand {
   font-weight: 600;

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7333,6 +7333,21 @@ function dotForLiveness(lv) {
 function isArchived(s) {
   return livenessOf(s) === Liveness.Archived;
 }
+function compareSessionsForRail(a, b) {
+  const aArchived = isArchived(a);
+  const aa = aArchived ? 1 : 0;
+  const bb = isArchived(b) ? 1 : 0;
+  if (aa !== bb) {
+    return aa - bb;
+  }
+  const at = a.created_at ?? "";
+  const bt = b.created_at ?? "";
+  if (at !== bt) {
+    const asc = at < bt ? -1 : 1;
+    return aArchived ? -asc : asc;
+  }
+  return a.title < b.title ? -1 : a.title > b.title ? 1 : 0;
+}
 function rowTitle(s) {
   const lv = livenessOf(s);
   const op = s.in_flight_op ?? InFlightOp.None;
@@ -7374,19 +7389,7 @@ function formatLimitReset(reset, now) {
 
 // src/projects.ts
 function orderWithinProject(sessions) {
-  return [...sessions].sort((a, b) => {
-    const aa = isArchived(a) ? 1 : 0;
-    const bb = isArchived(b) ? 1 : 0;
-    if (aa !== bb) {
-      return aa - bb;
-    }
-    const at = a.created_at ?? "";
-    const bt = b.created_at ?? "";
-    if (at !== bt) {
-      return at < bt ? -1 : 1;
-    }
-    return a.title < b.title ? -1 : a.title > b.title ? 1 : 0;
-  });
+  return [...sessions].sort(compareSessionsForRail);
 }
 function groupSessionsByProject(sessions) {
   const byRoot = /* @__PURE__ */ new Map();
@@ -7536,19 +7539,7 @@ function h2(tag, props = {}, ...children) {
   return el;
 }
 function orderedSessions(sessions) {
-  return [...sessions].sort((a, b) => {
-    const aa = isArchived(a) ? 1 : 0;
-    const bb = isArchived(b) ? 1 : 0;
-    if (aa !== bb) {
-      return aa - bb;
-    }
-    const at = a.created_at ?? "";
-    const bt = b.created_at ?? "";
-    if (at !== bt) {
-      return at < bt ? -1 : 1;
-    }
-    return a.title < b.title ? -1 : a.title > b.title ? 1 : 0;
-  });
+  return [...sessions].sort(compareSessionsForRail);
 }
 function renderLogin(root2, state, actions2) {
   root2.replaceChildren(loginView(state, actions2));
@@ -7743,6 +7734,12 @@ var AppShell = class {
   lastKb = null;
   lastActiveTab = 0;
   lastError = null;
+  // Whether the main pane has been rendered at least once. The constructor leaves it
+  // an empty <section>, so the FIRST update must render it even when nothing is
+  // selected (selectedId is null before AND after that first update, so the
+  // selection-changed guard alone wouldn't fire) — otherwise the pane is blank on
+  // load until a select-then-deselect. (#1592 Phase 5 PR9)
+  mainRendered = false;
   /** Applies the latest state, touching only what changed. */
   update(state) {
     const kb = state.selectedId && state.focus === "terminal" ? "terminal" : "rail";
@@ -7785,7 +7782,8 @@ var AppShell = class {
     }
     const activeTabChanged = this.lastActiveTab !== state.activeTab;
     this.lastActiveTab = state.activeTab;
-    if (selectionChanged) {
+    if (selectionChanged || !this.mainRendered) {
+      this.mainRendered = true;
       this.renderMain(state);
     } else {
       this.patchMainHead(state);

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -430,3 +430,41 @@ test("archive: the archive confirm moves a session to the archived group", async
   // with the af-row-archived modifier and sorted last).
   await expect(row(page, SESSION_B)).toHaveClass(/af-row-archived/, { timeout: 30_000 });
 });
+
+// NOTE on #1675 PR4 (ended PTY → "exited", not a reconnect loop): this is already
+// wired end-to-end — the daemon emits a MsgExit control frame on session-end
+// (daemon/ws_pty.go, covered by the Go handler tests), and terminal.ts settles to an
+// "exited" state + stops reconnecting on it (see onControl's "exit" arm and the
+// TerminalStatus="exited" pane header). It is NOT browser-tested here: a real
+// mid-stream exit can't be forced without killing the session (which removes the row
+// and disposes the terminal before the exit renders), and mocking the per-session WS
+// against the loopback TLS daemon proved unreliable in this harness. The Go side is
+// the regression guard for the emit; the client arm is exercised by the daemon's own
+// session-end path in manual play-testing.
+
+test("empty state (#1592 PR9): an empty Snapshot renders the empty rail + placeholder", async () => {
+  // Force the authoritative Snapshot to come back empty, then reload so bootstrap
+  // re-seeds the rail from it. HTTP routing (unlike WS mocking) is deterministic
+  // against the loopback daemon, so this reliably drives the zero-sessions state the
+  // seeded harness otherwise never reaches. Runs LAST — it reloads and mocks Snapshot,
+  // so it must not precede the create/kill/archive flows.
+  await page.route("**/v1/Snapshot", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ data: { instances: [] }, error: null }),
+    });
+  });
+  await page.reload();
+
+  // The authed shell still comes up (tokenless loopback), but the rail shows its
+  // empty-state copy instead of rows, and the count reads 0 — the empty state renders
+  // as designed rather than a broken/blank shell.
+  await expect(page.locator(".af-app")).toBeVisible();
+  await expect(page.locator(".af-rail-empty")).toContainText("No sessions yet");
+  await expect(page.locator(".af-rail-count")).toHaveText("0");
+  // With nothing selected the main pane is the "Select a session" placeholder.
+  await expect(page.locator(".af-main-empty")).toContainText("Select a session");
+
+  await page.unroute("**/v1/Snapshot");
+});

--- a/web/src/projects.ts
+++ b/web/src/projects.ts
@@ -17,7 +17,7 @@
 // shared h() helper), no innerHTML with markup.
 
 import { h, projectLabel } from "./modals.js";
-import { isArchived, rowStatus, rowTitle } from "./status.js";
+import { compareSessionsForRail, isArchived, rowStatus, rowTitle } from "./status.js";
 import type { SessionData } from "./types.js";
 
 /** One project section: its repo root (the stable id), a friendly label, and the
@@ -27,27 +27,17 @@ export interface ProjectGroup {
   root: string;
   /** The friendly label (repo basename + parent), shared with the modal picker. */
   label: string;
-  /** The project's sessions, live rows first then archived, each by creation time. */
+  /** The project's sessions in rail order: live rows oldest-first, then the archived
+   *  group newest-first (compareSessionsForRail). */
   sessions: SessionData[];
 }
 
-/** Orders sessions within a project the same way the rail does (ui.ts
- *  orderedSessions): live rows before the archived group, each ordered by creation
- *  time then title, so the projects pane and the sessions rail agree on order. */
+/** Orders sessions within a project the same way the rail does — the shared
+ *  compareSessionsForRail (status.ts): live rows oldest-first before the archived
+ *  group newest-first (#1605), so the projects pane and the sessions rail can never
+ *  diverge on order (#1674 PR3 review). */
 function orderWithinProject(sessions: SessionData[]): SessionData[] {
-  return [...sessions].sort((a, b) => {
-    const aa = isArchived(a) ? 1 : 0;
-    const bb = isArchived(b) ? 1 : 0;
-    if (aa !== bb) {
-      return aa - bb;
-    }
-    const at = a.created_at ?? "";
-    const bt = b.created_at ?? "";
-    if (at !== bt) {
-      return at < bt ? -1 : 1;
-    }
-    return a.title < b.title ? -1 : a.title > b.title ? 1 : 0;
-  });
+  return [...sessions].sort(compareSessionsForRail);
 }
 
 /**

--- a/web/src/sessions.test.ts
+++ b/web/src/sessions.test.ts
@@ -139,11 +139,28 @@ test("clampActiveTab keeps the active tab in range as the live tab list changes"
   assert.equal(clampActiveTab([threeTabs], "id-x", -1), 0);
 });
 
-test("orderedSessions puts live rows before archived, then by created_at", () => {
+test("orderedSessions: live rows oldest-first, archived group last newest-first (#1605/#1674)", () => {
   const list = [
-    sess("late", { created_at: "2026-01-02T00:00:00Z" }),
-    sess("arch", { liveness: Liveness.Archived, created_at: "2026-01-01T00:00:00Z" }),
-    sess("early", { created_at: "2026-01-01T00:00:00Z" }),
+    sess("live-late", { created_at: "2026-01-02T00:00:00Z" }),
+    sess("arch-old", { liveness: Liveness.Archived, created_at: "2026-01-01T00:00:00Z" }),
+    sess("live-early", { created_at: "2026-01-01T00:00:00Z" }),
+    sess("arch-new", { liveness: Liveness.Archived, created_at: "2026-01-03T00:00:00Z" }),
   ];
-  assert.deepEqual(orderedSessions(list).map((s) => s.title), ["early", "late", "arch"]);
+  // Live rows keep the projection's oldest-first order; the archived group sorts
+  // NEWEST-created first, mirroring the TUI sidebar (partitionByArchived, #1605) —
+  // the web previously sorted archived oldest-first too (#1674 PR3 review).
+  assert.deepEqual(orderedSessions(list).map((s) => s.title), [
+    "live-early",
+    "live-late",
+    "arch-new",
+    "arch-old",
+  ]);
+});
+
+test("orderedSessions: title breaks a created_at tie in the archived group (total order)", () => {
+  const list = [
+    sess("arch-b", { liveness: Liveness.Archived, created_at: "2026-01-01T00:00:00Z" }),
+    sess("arch-a", { liveness: Liveness.Archived, created_at: "2026-01-01T00:00:00Z" }),
+  ];
+  assert.deepEqual(orderedSessions(list).map((s) => s.title), ["arch-a", "arch-b"]);
 });

--- a/web/src/status.ts
+++ b/web/src/status.ts
@@ -110,6 +110,35 @@ export function isArchived(s: SessionData): boolean {
 }
 
 /**
+ * The rail's session comparator, a line-for-line mirror of the TUI sidebar
+ * (ui/sidebar_model.go partitionByArchived, #1605): live rows first, then the
+ * archived group last. The two groups order OPPOSITELY — live rows are oldest-
+ * created first (the projection's stable order), while archived rows are NEWEST-
+ * created first, so the archive reads as a most-recent-on-top history, the inverse
+ * of the live tree (#1605). Title breaks a created_at tie in BOTH groups so the
+ * order is total and never jitters. Shared by the sessions rail (ui.ts
+ * orderedSessions) and the projects pane (projects.ts) so the two surfaces can
+ * never diverge on order (#1674 PR3 review: the web must sort archived desc like
+ * the TUI, not asc).
+ */
+export function compareSessionsForRail(a: SessionData, b: SessionData): number {
+  const aArchived = isArchived(a);
+  const aa = aArchived ? 1 : 0;
+  const bb = isArchived(b) ? 1 : 0;
+  if (aa !== bb) {
+    return aa - bb;
+  }
+  const at = a.created_at ?? "";
+  const bt = b.created_at ?? "";
+  if (at !== bt) {
+    const asc = at < bt ? -1 : 1;
+    // Live: oldest-first (asc). Archived: newest-first (desc), matching the TUI.
+    return aArchived ? -asc : asc;
+  }
+  return a.title < b.title ? -1 : a.title > b.title ? 1 : 0;
+}
+
+/**
  * Builds the row title with the same prefixes the TUI prepends (render.go:304-345),
  * in the same precedence: [remote] outermost, then the state marker. Archived rows
  * deliberately carry NO word prefix (render.go:326-338) — the glyph + dimming say

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -37,6 +37,30 @@ body {
   min-height: 100vh;
   background: var(--af-bg);
   color: var(--af-text);
+  /* The shell is a fixed-height flex layout whose inner regions own their own
+   * scroll (the rail list, the view bodies, the tab bar). Nothing should ever push
+   * the PAGE itself sideways, so clamp horizontal overflow at the root — the #1592
+   * Phase 5 PR9 "no horizontal body scroll on a narrow window" guarantee. Vertical
+   * scroll is unaffected, and fixed-position layers (the toast) are not clipped. */
+  overflow-x: hidden;
+}
+
+/* Keyboard focus-visible ring (#1592 Phase 5 PR9): every control reachable by Tab
+ * draws a legible accent ring when focused via the keyboard, so keyboard nav is
+ * never invisible. :focus-visible (not :focus) keeps a plain mouse click from
+ * drawing it. This is the per-CONTROL complement to the pane-level #1694 outline
+ * (.af-kb-rail/.af-kb-terminal), which marks which PANE owns the keyboard. */
+.af-primary:focus-visible,
+.af-ghost:focus-visible,
+.af-danger:focus-visible,
+.af-rail-new:focus-visible,
+.af-tasks-add:focus-visible,
+.af-tab:focus-visible,
+.af-tab-new:focus-visible,
+.af-viewtab:focus-visible,
+.af-task-action:focus-visible {
+  outline: 2px solid var(--af-accent);
+  outline-offset: 2px;
 }
 
 #app {
@@ -148,6 +172,10 @@ body {
   padding: 0.75rem 1.25rem;
   background: var(--af-surface);
   border-bottom: 1px solid var(--af-border);
+  /* Keep the bar to one row on a comfortable width, but never let it force the page
+   * wider than the viewport: on a narrow window it wraps to a second line instead of
+   * overflowing (the overflow-x guard on body would otherwise clip it). */
+  flex-wrap: wrap;
 }
 
 .af-brand {

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -22,7 +22,7 @@ import type { EventStreamStatus } from "./events.js";
 import type { KeyboardFocus, View } from "./nav.js";
 import { VIEWS } from "./nav.js";
 import { ProjectsPane } from "./projects.js";
-import { isArchived, rowStatus, rowTitle } from "./status.js";
+import { compareSessionsForRail, isArchived, rowStatus, rowTitle } from "./status.js";
 import { TasksPane } from "./tasks.js";
 import type { TerminalStatus } from "./terminal.js";
 import type { SessionData, TaskData } from "./types.js";
@@ -198,25 +198,13 @@ function h<K extends keyof HTMLElementTagNameMap>(
 }
 
 /**
- * The rail's session order, mirroring the TUI sidebar: live sessions first, the
- * archived group last (ui/tree groups Archived under its own section), each group
- * ordered by creation time so the list is stable across re-renders and events.
- * Exported so keyboard navigation (index.ts) walks the SAME order the DOM shows.
+ * The rail's session order, mirroring the TUI sidebar (ui/sidebar_model.go): live
+ * sessions first ordered oldest-created first, the archived group last ordered
+ * newest-created first (#1605) — see compareSessionsForRail. Exported so keyboard
+ * navigation (index.ts) walks the SAME order the DOM shows.
  */
 export function orderedSessions(sessions: SessionData[]): SessionData[] {
-  return [...sessions].sort((a, b) => {
-    const aa = isArchived(a) ? 1 : 0;
-    const bb = isArchived(b) ? 1 : 0;
-    if (aa !== bb) {
-      return aa - bb;
-    }
-    const at = a.created_at ?? "";
-    const bt = b.created_at ?? "";
-    if (at !== bt) {
-      return at < bt ? -1 : 1;
-    }
-    return a.title < b.title ? -1 : a.title > b.title ? 1 : 0;
-  });
+  return [...sessions].sort(compareSessionsForRail);
 }
 
 /** Renders the paste-token login view, replacing the root's contents. */
@@ -391,6 +379,12 @@ export class AppShell {
   private lastKb: KeyboardFocus | null = null;
   private lastActiveTab = 0;
   private lastError: string | null = null;
+  // Whether the main pane has been rendered at least once. The constructor leaves it
+  // an empty <section>, so the FIRST update must render it even when nothing is
+  // selected (selectedId is null before AND after that first update, so the
+  // selection-changed guard alone wouldn't fire) — otherwise the pane is blank on
+  // load until a select-then-deselect. (#1592 Phase 5 PR9)
+  private mainRendered = false;
 
   constructor(
     private readonly actions: Actions,
@@ -530,12 +524,14 @@ export class AppShell {
       this.renderRail(state);
     }
 
-    // The main pane's STRUCTURE only changes when the selected session changes;
+    // The main pane's STRUCTURE only changes when the selected session changes (or on
+    // the very first update, which lays down the initial empty-state placeholder);
     // otherwise we just patch its header text (status/title/branch), leaving the
     // terminal host — and its focus and scrollback — in place.
     const activeTabChanged = this.lastActiveTab !== state.activeTab;
     this.lastActiveTab = state.activeTab;
-    if (selectionChanged) {
+    if (selectionChanged || !this.mainRendered) {
+      this.mainRendered = true;
       this.renderMain(state);
     } else {
       this.patchMainHead(state);


### PR DESCRIPTION
Phase 5 PR9 of the multi-backend web client (#1592): the visual-taste / state-polish pass. The direction — mirror the TUI — is already shipped, so this is **consistency + proper states, not a redesign**. No layout or identity changes.

## Deferred review items closed

- **#1674 PR3** — archived rail ordering. The archived group now sorts **newest-created first** (was oldest-first), matching the TUI sidebar (`ui/sidebar_model.go` `partitionByArchived`, #1605): the archive reads as a most-recent-on-top history, the inverse of the live tree. Both the sessions rail (`ui.ts`) and the projects pane (`projects.ts`) had the same asc bug; I extracted **one shared comparator** (`status.ts` `compareSessionsForRail`) so they can never diverge again.
- **#1675 PR4** — ended PTY shows an "exited" state, not a reconnect loop. This is **already wired end-to-end**: the daemon emits a `MsgExit` control frame on session-end (`daemon/ws_pty.go`, covered by the Go handler tests) and `terminal.ts` settles to `"exited"` + stops reconnecting on it. I verified the code paths and documented in the selftest why it isn't browser-mocked (mocking the per-session WS against the loopback TLS daemon proved unreliable; a real mid-stream exit can't be forced without killing the session, which disposes the terminal first). The Go side is the regression guard.

## State / consistency / a11y / responsive

- **Blank main pane on first load — fixed.** The new empty-state test surfaced a real gap: `renderMain` was gated on `selectionChanged`, and the initial `null → null` selection never fired it, so the main pane was empty on load until a select-then-deselect. It now renders the **"Select a session"** placeholder immediately.
- **Focus-visible rings** on every Tab-reachable control (primary/ghost/danger buttons, session tabs, view tabs, the + New / + Add actions) — `:focus-visible` so a mouse click doesn't draw them. This is the per-control complement to the #1694 pane-level outline, so keyboard nav is never invisible.
- **No horizontal body scroll on a narrow window:** `overflow-x: hidden` guard at the root + the appbar wraps to a second row instead of overflowing.

## Tests

- **web-driver-selftest:** new deterministic **empty-state** test — routes `Snapshot` to empty, reloads, and asserts the empty rail copy + count `0` + the main-pane placeholder. **11/11 green.**
- **sessions.test.ts:** the ordering test now proves archived **newest-first** plus a `created_at`-tie total-order case.
- Rebuilt `web/dist`.

## Gates
`make web-selftest-container` 11/11 · `make web-test` 68 · `make tui-driver-selftest` 25/25 · `go build ./...` · `gofmt` · `golangci-lint --fast` · `deadcode` · `file-length` — all green.

Part of #1592.

🤖 Generated with [Claude Code](https://claude.com/claude-code)