### PR TITLE
fix(daemon,task): field-level UpdateTask so a single-field edit cannot clobber concurrent edits (#1700)

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -36,6 +36,13 @@ var (
 	daemonTriggerTask      = daemon.TriggerTask
 )
 
+// strPtr / boolPtr build the pointer fields of a task.TaskUpdate patch. The CLI
+// sends a field-level patch (#1700): only the flags the user actually passed
+// become non-nil fields, so `af tasks update --enabled false` ships just Enabled
+// and can never clobber a concurrent edit to the prompt/trigger/target.
+func strPtr(s string) *string { return &s }
+func boolPtr(b bool) *bool    { return &b }
+
 // listTasks returns the full task list, preferring the daemon's authoritative
 // snapshot and falling back to a disk read when no daemon is reachable (#1029
 // PR 3). It never spawns a daemon, so `af tasks list` keeps working with none
@@ -272,13 +279,24 @@ var tasksUpdateCmd = &cobra.Command{
 			return jsonError(err)
 		}
 
+		// Load the current record for the cross-field pre-checks below (the
+		// switch-to-cron-needs-a-prompt rule reads the stored prompt/trigger).
+		// This is a client-side nicety only — the WRITE ships a field-level
+		// patch, never this whole struct, so an out-of-band edit to a field the
+		// user is not changing survives (#1700). The daemon re-validates the
+		// merged result authoritatively.
 		s, err := task.GetTask(args[0])
 		if err != nil {
 			return jsonError(fmt.Errorf("failed to get task: %w", err))
 		}
 
+		// Accumulate only the fields the user actually passed. Each flag that is
+		// set becomes one non-nil patch field; everything else stays nil and is
+		// left as-stored by the daemon.
+		var patch task.TaskUpdate
+
 		if taskUpdateNameFlag != "" {
-			s.Name = taskUpdateNameFlag
+			patch.Name = strPtr(taskUpdateNameFlag)
 		}
 		if taskUpdatePromptFlag != "" {
 			// Partial-update semantics keep `--prompt ""` as "leave
@@ -290,6 +308,7 @@ var tasksUpdateCmd = &cobra.Command{
 				return jsonError(errors.New("prompt must be non-empty"))
 			}
 			s.Prompt = taskUpdatePromptFlag
+			patch.Prompt = strPtr(taskUpdatePromptFlag)
 		}
 
 		if taskUpdateCronFlag != "" && taskUpdateWatchCmdFlag != "" {
@@ -332,21 +351,26 @@ var tasksUpdateCmd = &cobra.Command{
 			}
 			// Setting one trigger clears the other so the exactly-one rule
 			// holds when switching a watch task back to a schedule.
-			s.CronExpr = strings.TrimSpace(taskUpdateCronFlag)
-			s.WatchCmd = ""
+			patch.CronExpr = strPtr(strings.TrimSpace(taskUpdateCronFlag))
+			patch.WatchCmd = strPtr("")
 		}
 		if taskUpdateWatchCmdFlag != "" {
-			s.WatchCmd = strings.TrimSpace(taskUpdateWatchCmdFlag)
-			s.CronExpr = ""
+			patch.WatchCmd = strPtr(strings.TrimSpace(taskUpdateWatchCmdFlag))
+			patch.CronExpr = strPtr("")
 		}
 		// --target-session "" is a meaningful value (revert to
 		// create-a-session-per-run), so distinguish "flag not given" from
 		// "given as empty" instead of treating "" as unchanged.
 		if cmd.Flags().Changed("target-session") {
-			s.TargetSession = taskUpdateTargetSessionFlag
+			patch.TargetSession = strPtr(taskUpdateTargetSessionFlag)
 		}
 
-		s.Enabled = updatedEnabled
+		// Only patch Enabled when --enabled was passed: an absent flag must
+		// leave the stored value untouched, not re-assert the copy this client
+		// read.
+		if taskUpdateEnabledFlag != "" {
+			patch.Enabled = boolPtr(updatedEnabled)
+		}
 
 		// Partial-update semantics: "" means "leave unchanged" (mirroring
 		// --name and the add path's taskAddProgramFlag != "" guard). There is
@@ -358,13 +382,14 @@ var tasksUpdateCmd = &cobra.Command{
 			if err := config.ValidateProgramEnum("--program flag", "--program flag", taskUpdateProgramFlag, ""); err != nil {
 				return jsonError(err)
 			}
-			s.Program = taskUpdateProgramFlag
+			patch.Program = strPtr(taskUpdateProgramFlag)
 		}
 
-		if err := daemonUpdateTask(*s); err != nil {
+		updated, err := daemonUpdateTask(args[0], patch)
+		if err != nil {
 			return jsonError(fmt.Errorf("failed to update task: %w", err))
 		}
 
-		return jsonOut(s)
+		return jsonOut(updated)
 	},
 }

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -30,6 +30,10 @@ type daemonCalls struct {
 	removeErr error
 	triggered []string
 	runErr    error
+	// lastUpdate records the field-level patch the CLI sent on the most recent
+	// UpdateTask dispatch (#1700), so tests can assert `af tasks update` ships
+	// ONLY the flags the user passed and never a full-struct copy.
+	lastUpdate task.TaskUpdate
 }
 
 // stubDaemon swaps the daemon task-RPC indirections for in-memory stubs and
@@ -60,15 +64,17 @@ func stubDaemon(t *testing.T) *daemonCalls {
 		calls.writes++
 		return nil
 	}
-	daemonUpdateTask = func(tk task.Task) error {
+	daemonUpdateTask = func(id string, update task.TaskUpdate) (task.Task, error) {
 		if calls.updateErr != nil {
-			return calls.updateErr
+			return task.Task{}, calls.updateErr
 		}
-		if err := task.UpdateTask(tk); err != nil {
-			return err
+		merged, err := task.UpdateTask(id, update)
+		if err != nil {
+			return task.Task{}, err
 		}
 		calls.writes++
-		return nil
+		calls.lastUpdate = update
+		return merged, nil
 	}
 	daemonRemoveTask = func(id string) error {
 		if calls.removeErr != nil {

--- a/apiclient/control.go
+++ b/apiclient/control.go
@@ -99,9 +99,16 @@ func (c *Client) AddTask(t task.Task) error {
 	return c.call("AddTask", daemon.AddTaskRequest{Task: t}, &daemon.AddTaskResponse{})
 }
 
-// UpdateTask asks the daemon to persist an edited task and re-arm its schedule.
-func (c *Client) UpdateTask(t task.Task) error {
-	return c.call("UpdateTask", daemon.UpdateTaskRequest{Task: t}, &daemon.UpdateTaskResponse{})
+// UpdateTask asks the daemon to apply a field-level patch to the task with the
+// given id and re-arm its schedule, returning the merged record (#1700). Only
+// the patch's non-nil fields are written, so a single-field edit never clobbers
+// a concurrent edit another client made to a different field.
+func (c *Client) UpdateTask(id string, update task.TaskUpdate) (task.Task, error) {
+	var resp daemon.UpdateTaskResponse
+	if err := c.call("UpdateTask", daemon.UpdateTaskRequest{ID: id, Update: update}, &resp); err != nil {
+		return task.Task{}, err
+	}
+	return resp.Task, nil
 }
 
 // RemoveTask asks the daemon to delete a task and re-arm its schedule.

--- a/app/content_persistence.go
+++ b/app/content_persistence.go
@@ -100,13 +100,17 @@ func (m *home) saveContentPaneState() error {
 	// its schedule refresh are one atomic daemon call (removing the old
 	// double-reload).
 	//
-	// Persist ONLY the tasks the user actually edited (ConsumeDirty), not the
-	// whole pane: an unmodified task changed out-of-band (CLI, daemon) while the
-	// pane was open must not be clobbered by the pane's stale copy — #1213.
-	for _, tsk := range sp.ConsumeDirty() {
-		if err := updateTaskThroughDaemon(tsk); err != nil {
+	// Persist ONLY the tasks the user actually edited (ConsumeDirty), and only
+	// the FIELDS they changed: each edit carries a field-level patch (diffed
+	// against the copy the pane loaded), so a save of one field never rewrites a
+	// field another writer (CLI/daemon) changed out-of-band while the pane was
+	// open — the #1700 clobber, of which #1213's whole-task guard was only a
+	// partial fix. A patch that turns out empty (edited then reverted) is a
+	// harmless no-op the daemon still validates.
+	for _, edit := range sp.ConsumeDirty() {
+		if err := updateTaskThroughDaemon(edit.ID, edit.Update); err != nil {
 			log.ErrorLog.Printf("failed to update task: %v", err)
-			saveErr = errors.Join(saveErr, fmt.Errorf("failed to save task %q: %w", tsk.Name, err))
+			saveErr = errors.Join(saveErr, fmt.Errorf("failed to save task %q: %w", edit.ID, err))
 		}
 	}
 	for _, tsk := range sp.ConsumeDeleted() {

--- a/app/creation_test.go
+++ b/app/creation_test.go
@@ -39,7 +39,12 @@ func newTestHome(t *testing.T) *home {
 	// after driving the handlers) keep exercising the save orchestration
 	// unchanged. Tests asserting the daemon-dispatch itself swap in a recorder.
 	t.Cleanup(SetTaskAdderForTest(task.AddTask))
-	t.Cleanup(SetTaskUpdaterForTest(task.UpdateTask))
+	// task.UpdateTask returns the merged record; the seam only needs the error,
+	// so adapt it to the field-level updater signature (#1700).
+	t.Cleanup(SetTaskUpdaterForTest(func(id string, update task.TaskUpdate) error {
+		_, err := task.UpdateTask(id, update)
+		return err
+	}))
 	t.Cleanup(SetTaskRemoverForTest(task.RemoveTask))
 	t.Cleanup(SetLocalSessionPreflightForTest(func(*config.Config, string) error { return nil }))
 

--- a/app/handle_overlay_test.go
+++ b/app/handle_overlay_test.go
@@ -418,7 +418,7 @@ func TestHandleStateTasks_FailedCreateDoesNotDuplicateOnReopen(t *testing.T) {
 
 	// Force the pre-create flush to fail, so the create is submitted but
 	// handleTaskCreate never runs and pendingCreate is stranded.
-	restoreUpdater := SetTaskUpdaterForTest(func(task.Task) error {
+	restoreUpdater := SetTaskUpdaterForTest(func(string, task.TaskUpdate) error {
 		return fmt.Errorf("daemon RPC failure")
 	})
 
@@ -558,9 +558,12 @@ func TestSaveContentPaneState_RoutesThroughDaemonRPC(t *testing.T) {
 
 	// Swap the write seams for recorders AFTER seeding (the seed used the direct
 	// writer); the save-on-close must now dispatch through these instead of disk.
-	var updated []task.Task
+	var updated []task.TaskEdit
 	var removed []string
-	t.Cleanup(SetTaskUpdaterForTest(func(tk task.Task) error { updated = append(updated, tk); return nil }))
+	t.Cleanup(SetTaskUpdaterForTest(func(id string, update task.TaskUpdate) error {
+		updated = append(updated, task.TaskEdit{ID: id, Update: update})
+		return nil
+	}))
 	t.Cleanup(SetTaskRemoverForTest(func(id string) error { removed = append(removed, id); return nil }))
 
 	// Toggle the first task (keep) off — dirty, not yet persisted.
@@ -579,10 +582,11 @@ func TestSaveContentPaneState_RoutesThroughDaemonRPC(t *testing.T) {
 	require.Len(t, removed, 1, "delete must route through the remove RPC")
 	assert.Equal(t, "gone-1029", removed[0])
 	var sawToggledKeep bool
-	for _, tk := range updated {
-		if tk.ID == "keep-1029" {
+	for _, edit := range updated {
+		if edit.ID == "keep-1029" {
 			sawToggledKeep = true
-			assert.False(t, tk.Enabled, "the toggled state must be dispatched to the update RPC")
+			require.NotNil(t, edit.Update.Enabled, "the toggle must ship the Enabled field")
+			assert.False(t, *edit.Update.Enabled, "the toggled state must be dispatched to the update RPC")
 		}
 	}
 	assert.True(t, sawToggledKeep, "the surviving task must route through the update RPC")
@@ -647,9 +651,9 @@ func TestSaveContentPaneState_DoesNotClobberUneditedTask(t *testing.T) {
 	require.True(t, tp.IsDirty(), "toggling A must mark the pane dirty")
 
 	// The CLI changes Task B on disk while the pane is open, holding a stale B.
-	cliB := taskB
-	cliB.Prompt = "CLI MODIFIED"
-	require.NoError(t, task.UpdateTask(cliB))
+	newPrompt := "CLI MODIFIED"
+	_, err = task.UpdateTask("task-b-1213", task.TaskUpdate{Prompt: &newPrompt})
+	require.NoError(t, err)
 
 	// Esc releases focus → the overlay closes and saveContentPaneState runs.
 	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyEsc})

--- a/app/session_control.go
+++ b/app/session_control.go
@@ -182,8 +182,11 @@ var (
 	addTaskThroughDaemon = func(t task.Task) error {
 		return withDaemonHTTP(func(c *apiclient.Client) error { return c.AddTask(t) })
 	}
-	updateTaskThroughDaemon = func(t task.Task) error {
-		return withDaemonHTTP(func(c *apiclient.Client) error { return c.UpdateTask(t) })
+	updateTaskThroughDaemon = func(id string, update task.TaskUpdate) error {
+		return withDaemonHTTP(func(c *apiclient.Client) error {
+			_, err := c.UpdateTask(id, update)
+			return err
+		})
 	}
 	removeTaskThroughDaemon = func(id string) error {
 		return withDaemonHTTP(func(c *apiclient.Client) error { return c.RemoveTask(id) })
@@ -344,7 +347,7 @@ func SetTaskAdderForTest(f func(task.Task) error) func() {
 	return func() { addTaskThroughDaemon = prev }
 }
 
-func SetTaskUpdaterForTest(f func(task.Task) error) func() {
+func SetTaskUpdaterForTest(f func(id string, update task.TaskUpdate) error) func() {
 	prev := updateTaskThroughDaemon
 	updateTaskThroughDaemon = f
 	return func() { updateTaskThroughDaemon = prev }

--- a/daemon/control_client.go
+++ b/daemon/control_client.go
@@ -286,10 +286,16 @@ func AddTask(t task.Task) error {
 	return callDaemon("AddTask", AddTaskRequest{Task: t}, &resp)
 }
 
-// UpdateTask asks the daemon to persist an edited task and re-arm its schedule.
-func UpdateTask(t task.Task) error {
+// UpdateTask asks the daemon to apply a field-level patch to the task with the
+// given id and re-arm its schedule, returning the merged record (#1700). Only
+// the patch's non-nil fields are written, so a single-field edit never clobbers
+// a concurrent edit another client made to a different field.
+func UpdateTask(id string, update task.TaskUpdate) (task.Task, error) {
 	var resp UpdateTaskResponse
-	return callDaemon("UpdateTask", UpdateTaskRequest{Task: t}, &resp)
+	if err := callDaemon("UpdateTask", UpdateTaskRequest{ID: id, Update: update}, &resp); err != nil {
+		return task.Task{}, err
+	}
+	return resp.Task, nil
 }
 
 // RemoveTask asks the daemon to delete a task and re-arm its schedule.

--- a/daemon/control_server.go
+++ b/daemon/control_server.go
@@ -123,14 +123,18 @@ func (s *controlServer) AddTask(req AddTaskRequest, resp *AddTaskResponse) error
 }
 
 func (s *controlServer) UpdateTask(req UpdateTaskRequest, resp *UpdateTaskResponse) error {
-	if err := task.UpdateTask(req.Task); err != nil {
+	merged, err := task.UpdateTask(req.ID, req.Update)
+	if err != nil {
 		return err
 	}
 	if err := s.reloadTaskSchedules(); err != nil {
 		return err
 	}
 	resp.OK = true
-	s.manager.publishEvent(agentproto.EventTaskUpdated, req.Task)
+	resp.Task = merged
+	// Publish the merged record — the authoritative post-edit task — not the
+	// partial patch, so subscribers (TUI/web) receive the full updated task.
+	s.manager.publishEvent(agentproto.EventTaskUpdated, merged)
 	return nil
 }
 

--- a/daemon/control_types.go
+++ b/daemon/control_types.go
@@ -297,15 +297,26 @@ type AddTaskResponse struct {
 	OK bool `json:"ok"`
 }
 
-// UpdateTaskRequest carries the edited task.Task to persist. task.UpdateTask
-// preserves the scheduler-owned fields (LastRunAt/LastRunStatus/CreatedAt) from
-// the freshly-loaded record under the file lock, so a stale client copy never
-// clobbers them.
+// UpdateTaskRequest carries a FIELD-LEVEL patch (#1700): the ID of the task to
+// edit and a task.TaskUpdate holding only the field(s) the caller intends to
+// change. The daemon merges the patch onto the freshly-loaded record under the
+// file lock, leaving every unspecified field as-stored — so a single-field edit
+// (the enable/disable toggle sends just Enabled) cannot clobber a concurrent
+// edit another client made to a different field. This replaces the prior
+// full-struct read-modify-write, which re-applied every user field from the
+// caller's possibly-stale copy. Scheduler-owned fields (LastRunAt/LastRunStatus/
+// CreatedAt) are never patchable — UpdateTaskStatus stays their writer.
 type UpdateTaskRequest struct {
-	Task task.Task `json:"task"`
+	ID     string          `json:"id"`
+	Update task.TaskUpdate `json:"update"`
 }
+
+// UpdateTaskResponse returns the merged record the write produced, so the CLI
+// can print the authoritative post-edit task and the daemon publishes the full
+// task (not the partial patch) on its EventTaskUpdated.
 type UpdateTaskResponse struct {
-	OK bool `json:"ok"`
+	OK   bool      `json:"ok"`
+	Task task.Task `json:"task"`
 }
 
 type RemoveTaskRequest struct {

--- a/daemon/httproutes.go
+++ b/daemon/httproutes.go
@@ -147,7 +147,7 @@ var httpRoutes = []HTTPRoute{
 	{
 		Method:        http.MethodPost,
 		Path:          "/v1/UpdateTask",
-		Description:   "Update an existing task, preserving scheduler-owned fields.",
+		Description:   "Apply a field-level patch to a task (only the fields in `update` are changed), preserving every unspecified field and the scheduler-owned fields.",
 		RequestFields: jsonFields(reflect.TypeOf(UpdateTaskRequest{})),
 		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.UpdateTask) },
 	},

--- a/daemon/scheduler_test.go
+++ b/daemon/scheduler_test.go
@@ -76,9 +76,8 @@ func TestSchedulerReloadFollowsTaskCRUD(t *testing.T) {
 	}
 
 	// Disable one.
-	disabled := mk("bbbb0001")
-	disabled.Enabled = false
-	if err := task.UpdateTask(disabled); err != nil {
+	disabledEnabled := false
+	if _, err := task.UpdateTask("bbbb0001", task.TaskUpdate{Enabled: &disabledEnabled}); err != nil {
 		t.Fatalf("UpdateTask: %v", err)
 	}
 	if err := s.Reload(); err != nil {

--- a/daemon/task_rpc_test.go
+++ b/daemon/task_rpc_test.go
@@ -72,12 +72,12 @@ func TestControlUpdateTask_WritesAndRearms(t *testing.T) {
 	require.NoError(t, task.AddTask(enabledCronTask("cccc0001", "")))
 
 	srv := &controlServer{scheduler: newTaskScheduler()}
-	edited := enabledCronTask("cccc0001", "")
-	edited.CronExpr = "30 6 * * 1"
+	newCron := "30 6 * * 1"
 
 	var resp UpdateTaskResponse
-	require.NoError(t, srv.UpdateTask(UpdateTaskRequest{Task: edited}, &resp))
+	require.NoError(t, srv.UpdateTask(UpdateTaskRequest{ID: "cccc0001", Update: task.TaskUpdate{CronExpr: &newCron}}, &resp))
 	assert.True(t, resp.OK)
+	assert.Equal(t, "30 6 * * 1", resp.Task.CronExpr, "the response carries the merged record")
 
 	got, err := task.GetTask("cccc0001")
 	require.NoError(t, err)

--- a/daemon/watcher_test.go
+++ b/daemon/watcher_test.go
@@ -516,8 +516,8 @@ func TestDeliverWatchEvent_RendersTemplateAndRecordsStatus(t *testing.T) {
 
 	// An event for a task that was disabled after the watcher spawned must
 	// not deliver.
-	got.Enabled = false
-	if err := task.UpdateTask(*got); err != nil {
+	disabled := false
+	if _, err := task.UpdateTask("cafe0001", task.TaskUpdate{Enabled: &disabled}); err != nil {
 		t.Fatalf("disable task: %v", err)
 	}
 	if err := deliverWatchEvent("cafe0001", "late event"); err == nil {

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -140,10 +140,16 @@ so they are documented here. `CreateSession` returns `{ "instance": <session> }`
 `RestoreArchived` returns `{ "ok": true, "worktree_path": "…" }`;
 `DeliverPrompt` returns `{ "status": "started" | "sent" }`; `CreateTab` /
 `CloseTab` return `{ "name": "<resolved-tab-name>" }`; `ListTasks` returns
-`{ "tasks": [<task>…] }`; the rest return `{ "ok": true }`. The `task` field of
-`AddTask` / `UpdateTask` is a full task object — the CLI/TUI build and validate
-it, and the daemon re-validates and owns the write. See [tasks.md](tasks.md) for
-the task shape.
+`{ "tasks": [<task>…] }`; `UpdateTask` returns `{ "ok": true, "task": <task> }`
+(the merged record); the rest return `{ "ok": true }`. The `task` field of
+`AddTask` is a full task object — the CLI/TUI build and validate it, and the
+daemon re-validates and owns the write. `UpdateTask` instead takes a target `id`
+and a FIELD-LEVEL `update` patch carrying only the fields to change (e.g.
+`{ "id": "ab12cd34", "update": { "enabled": false } }`): the daemon merges the
+patch onto the freshly-loaded record under its file lock and leaves every
+unspecified field — and the scheduler-owned fields — as-stored, so a single-field
+edit cannot clobber a concurrent edit another client made (#1700). See
+[tasks.md](tasks.md) for the task shape.
 
 ## Examples
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -26,7 +26,7 @@ Request fields are the JSON keys of each route's request body; a `—` means the
 | `POST` | `/v1/SetPRInfo` | `title`, `repo_id`, `pr_info` | Record or clear the GitHub PR info for a session. |
 | `POST` | `/v1/ListTasks` | — | List every task across all repos. |
 | `POST` | `/v1/AddTask` | `task` | Append a new task and re-arm the scheduler. |
-| `POST` | `/v1/UpdateTask` | `task` | Update an existing task, preserving scheduler-owned fields. |
+| `POST` | `/v1/UpdateTask` | `id`, `update` | Apply a field-level patch to a task (only the fields in `update` are changed), preserving every unspecified field and the scheduler-owned fields. |
 | `POST` | `/v1/RemoveTask` | `id` | Remove a task by ID. |
 | `POST` | `/v1/TriggerTask` | `id` | Fire a cron task now through the daemon's scheduler path (refuses disabled and watch tasks). |
 

--- a/task/task.go
+++ b/task/task.go
@@ -380,28 +380,151 @@ func UpdateTaskStatus(taskID string, lastRunAt *time.Time, lastRunStatus string)
 	})
 }
 
-func UpdateTask(t Task) error {
-	if err := ValidateTaskID(t.ID); err != nil {
-		return err
+// TaskUpdate is a field-level patch for UpdateTask (#1700). Each non-nil field
+// replaces that field on the freshly-loaded record under the file lock; a nil
+// field is left exactly as stored. Because the write carries ONLY the fields the
+// caller changed — never a full, possibly-stale copy — a single-field edit (the
+// enable/disable toggle sends just Enabled) is structurally incapable of
+// clobbering a concurrent edit another client made to a different field.
+//
+// Only the user-editable fields are patchable. The scheduler-owned LastRunAt/
+// LastRunStatus and the immutable CreatedAt never appear here — UpdateTaskStatus
+// stays their canonical writer (#731/#1215), and preserving them is now inherent
+// to the merge (the record starts from the on-disk copy).
+//
+// The json tags define the HTTP JSON body shape for the daemon's /v1/UpdateTask
+// route; a nil pointer serializes as an absent key (omitempty), so the wire form
+// carries exactly the changed fields. The net/rpc gob control socket the CLI
+// uses goes through the same JSON encoding via GobEncode/GobDecode below — see
+// there for why plain gob would be lossy for this type.
+type TaskUpdate struct {
+	Name          *string `json:"name,omitempty"`
+	Prompt        *string `json:"prompt,omitempty"`
+	CronExpr      *string `json:"cron_expr,omitempty"`
+	WatchCmd      *string `json:"watch_cmd,omitempty"`
+	TargetSession *string `json:"target_session,omitempty"`
+	Program       *string `json:"program,omitempty"`
+	Enabled       *bool   `json:"enabled,omitempty"`
+}
+
+// GobEncode/GobDecode route TaskUpdate through JSON on the net/rpc gob control
+// socket the CLI uses (daemon.UpdateTask → callDaemon). This is REQUIRED for
+// correctness, not an optimization: gob elides a struct field holding its zero
+// value, and — fatally here — a *bool pointing at false (or a *string at "") is
+// followed to that zero and dropped, so the pointer decodes back as nil. That
+// would silently turn `af tasks update --enabled false` and the trigger-clearing
+// WatchCmd:"" / CronExpr:"" patches into no-ops. JSON preserves the exact
+// nil-vs-non-nil-zero-pointer distinction (omitempty omits ONLY a nil pointer, so
+// a non-nil &false serializes as `false`), so this round-trip is lossless.
+func (u TaskUpdate) GobEncode() ([]byte, error) {
+	return json.Marshal(u)
+}
+
+func (u *TaskUpdate) GobDecode(data []byte) error {
+	return json.Unmarshal(data, u)
+}
+
+// IsEmpty reports whether the patch changes no field. An empty patch is a
+// well-formed no-op: UpdateTask still validates and returns the record but
+// writes nothing new.
+func (u TaskUpdate) IsEmpty() bool {
+	return u.Name == nil && u.Prompt == nil && u.CronExpr == nil &&
+		u.WatchCmd == nil && u.TargetSession == nil && u.Program == nil && u.Enabled == nil
+}
+
+// apply merges the non-nil fields of u onto t and returns the result. It never
+// touches CreatedAt/LastRunAt/LastRunStatus, so a merge onto the freshly-loaded
+// record preserves those scheduler-owned values automatically.
+func (u TaskUpdate) apply(t Task) Task {
+	if u.Name != nil {
+		t.Name = *u.Name
 	}
-	if err := t.ValidateTrigger(); err != nil {
-		return err
+	if u.Prompt != nil {
+		t.Prompt = *u.Prompt
 	}
-	// Empty Program means "fall back to the configured default_program at
-	// run time"; only validate when an explicit per-task override was set.
-	if t.Program != "" {
-		if err := config.ValidateProgramEnum("task program", "task program", t.Program, ""); err != nil {
-			return err
-		}
+	if u.CronExpr != nil {
+		t.CronExpr = *u.CronExpr
+	}
+	if u.WatchCmd != nil {
+		t.WatchCmd = *u.WatchCmd
+	}
+	if u.TargetSession != nil {
+		t.TargetSession = *u.TargetSession
+	}
+	if u.Program != nil {
+		t.Program = *u.Program
+	}
+	if u.Enabled != nil {
+		t.Enabled = *u.Enabled
+	}
+	return t
+}
+
+// TaskEdit pairs a task ID with the field-level patch to apply to it. The TUI's
+// task pane emits one per edited task (see DiffTask) so a save sends only the
+// fields the user actually changed.
+type TaskEdit struct {
+	ID     string
+	Update TaskUpdate
+}
+
+// DiffTask returns a TaskUpdate holding exactly the user-editable fields that
+// differ between old and cur. The TUI uses it to turn an in-place edit of a
+// cached task into a minimal patch, so saving one field never rewrites another
+// that changed out-of-band while the editor was open (#1700/#1213).
+func DiffTask(old, cur Task) TaskUpdate {
+	var u TaskUpdate
+	if cur.Name != old.Name {
+		u.Name = &cur.Name
+	}
+	if cur.Prompt != old.Prompt {
+		u.Prompt = &cur.Prompt
+	}
+	if cur.CronExpr != old.CronExpr {
+		u.CronExpr = &cur.CronExpr
+	}
+	if cur.WatchCmd != old.WatchCmd {
+		u.WatchCmd = &cur.WatchCmd
+	}
+	if cur.TargetSession != old.TargetSession {
+		u.TargetSession = &cur.TargetSession
+	}
+	if cur.Program != old.Program {
+		u.Program = &cur.Program
+	}
+	if cur.Enabled != old.Enabled {
+		u.Enabled = &cur.Enabled
+	}
+	return u
+}
+
+// UpdateTask applies a field-level patch to the task with the given id under the
+// file lock and returns the merged record. Only the patch's non-nil fields are
+// written; every other field — including a value a concurrent writer committed
+// after the caller read its copy — is preserved from the freshly-loaded record.
+// This closes the full-struct read-modify-write clobber (#1700): an enable/
+// disable toggle patches only Enabled and cannot revert another client's edit to
+// the prompt, trigger, target session, or program.
+//
+// The merged task is validated (ValidateTrigger, plus the program enum when the
+// patch sets Program) before it is written, so a patch that would leave the task
+// in an invalid state is rejected. Scheduler-owned fields (LastRunAt/
+// LastRunStatus) and CreatedAt are never patchable — UpdateTaskStatus remains
+// their canonical writer (#731/#1215). Returns the not-found error when no task
+// with the given id exists.
+func UpdateTask(id string, update TaskUpdate) (Task, error) {
+	if err := ValidateTaskID(id); err != nil {
+		return Task{}, err
 	}
 	path, err := getTasksPathFn()
 	if err != nil {
-		return err
+		return Task{}, err
 	}
 	if err := ensureTasksSchemaMigrated(path); err != nil {
-		return err
+		return Task{}, err
 	}
-	return config.WithFileLock(path, func() error {
+	var merged Task
+	lockErr := config.WithFileLock(path, func() error {
 		tasks, err := loadTasksLocked(path)
 		if err != nil {
 			return err
@@ -409,29 +532,34 @@ func UpdateTask(t Task) error {
 
 		found := false
 		for i, existing := range tasks {
-			if existing.ID == t.ID {
-				// Preserve scheduler/system-managed fields from the freshly
-				// loaded record. UpdateTask is a user-edit path (name, prompt,
-				// cron/watch_cmd, target_session, program, enabled); its caller may carry a stale copy of
-				// LastRunAt/LastRunStatus read before a concurrent scheduler run
-				// or manual trigger updated them (TOCTOU via GetTask outside the
-				// lock, or a stale TUI cache). Re-applying the caller's struct
-				// wholesale would clobber those fresher values. CreatedAt is
-				// immutable. UpdateTaskStatus remains the canonical path for the
-				// scheduler-owned status fields. See #731.
-				t.LastRunAt = existing.LastRunAt
-				t.LastRunStatus = existing.LastRunStatus
-				t.CreatedAt = existing.CreatedAt
-				tasks[i] = t
+			if existing.ID == id {
+				merged = update.apply(existing)
+				if err := merged.ValidateTrigger(); err != nil {
+					return err
+				}
+				// Validate the program ONLY when the patch sets it: a toggle or
+				// an unrelated field edit must not fail on a pre-existing Program
+				// value that would no longer pass current enum validation (the
+				// same tolerance UpdateTaskStatus applies to legacy records).
+				if update.Program != nil && merged.Program != "" {
+					if err := config.ValidateProgramEnum("task program", "task program", merged.Program, ""); err != nil {
+						return err
+					}
+				}
+				tasks[i] = merged
 				found = true
 				break
 			}
 		}
 
 		if !found {
-			return fmt.Errorf("task with id %q not found", t.ID)
+			return fmt.Errorf("task with id %q not found", id)
 		}
 
 		return saveTasks(tasks)
 	})
+	if lockErr != nil {
+		return Task{}, lockErr
+	}
+	return merged, nil
 }

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -1,6 +1,8 @@
 package task
 
 import (
+	"bytes"
+	"encoding/gob"
 	"encoding/json"
 	"errors"
 	"os"
@@ -194,15 +196,26 @@ func TestGetTaskNotFound(t *testing.T) {
 	assert.Contains(t, err.Error(), "not found")
 }
 
+// ptr returns the address of v, for building the pointer fields of a TaskUpdate
+// patch in tests.
+func ptr[T any](v T) *T { return &v }
+
 func TestUpdateTask(t *testing.T) {
 	tasks := []Task{
 		{ID: "u1", Name: "Old Name", Prompt: "old prompt", CronExpr: "0 * * * *", Enabled: true},
 	}
 	setupTestTasks(t, tasks)
 
-	updated := Task{ID: "u1", Name: "New Name", Prompt: "new prompt", CronExpr: "0 0 * * *", Enabled: false}
-	err := UpdateTask(updated)
+	merged, err := UpdateTask("u1", TaskUpdate{
+		Name:     ptr("New Name"),
+		Prompt:   ptr("new prompt"),
+		CronExpr: ptr("0 0 * * *"),
+		Enabled:  ptr(false),
+	})
 	assert.NoError(t, err)
+	// UpdateTask returns the authoritative merged record.
+	assert.Equal(t, "New Name", merged.Name)
+	assert.Equal(t, "0 0 * * *", merged.CronExpr)
 
 	s, err := GetTask("u1")
 	assert.NoError(t, err)
@@ -212,10 +225,65 @@ func TestUpdateTask(t *testing.T) {
 	assert.False(t, s.Enabled)
 }
 
+// TestUpdateTaskFieldLevelDoesNotClobber is the core regression guard for #1700:
+// a single-field patch (here disabling the task) must leave every field the
+// patch does NOT mention exactly as-stored — including a value a concurrent
+// client committed after this caller last read the record. The old full-struct
+// read-modify-write reverted those fields; the field-level merge cannot.
+func TestUpdateTaskFieldLevelDoesNotClobber(t *testing.T) {
+	setupTestTasks(t, []Task{
+		{ID: "t1", Name: "orig", Prompt: "orig prompt", CronExpr: "0 * * * *", TargetSession: "sess-a", Program: "claude", Enabled: true},
+	})
+
+	// Client B changes the cron and target session out-of-band.
+	_, err := UpdateTask("t1", TaskUpdate{CronExpr: ptr("30 6 * * 1"), TargetSession: ptr("sess-b")})
+	require.NoError(t, err)
+
+	// Client A, holding a copy from BEFORE B's edit, only toggles Enabled off.
+	// It ships just that one field.
+	merged, err := UpdateTask("t1", TaskUpdate{Enabled: ptr(false)})
+	require.NoError(t, err)
+	assert.False(t, merged.Enabled)
+
+	got, err := GetTask("t1")
+	require.NoError(t, err)
+	assert.False(t, got.Enabled, "A's toggle must apply")
+	// B's concurrent edits survive — A's toggle carried no cron/target field.
+	assert.Equal(t, "30 6 * * 1", got.CronExpr, "B's concurrent cron edit must NOT be clobbered by A's toggle")
+	assert.Equal(t, "sess-b", got.TargetSession, "B's concurrent target-session edit must survive")
+	// Fields neither client touched are untouched.
+	assert.Equal(t, "orig prompt", got.Prompt)
+	assert.Equal(t, "orig", got.Name)
+}
+
+// TestTaskUpdateGobRoundTripPreservesZeroPointers guards the net/rpc control
+// socket (the CLI transport): gob elides a struct field at its zero value and
+// follows a *bool→false / *string→"" down to that zero and drops it, decoding the
+// pointer back as nil. TaskUpdate's JSON-backed gob codec must defeat that, or
+// `af tasks update --enabled false` and the trigger-clearing "" patches would
+// silently become no-ops over the socket (#1700).
+func TestTaskUpdateGobRoundTripPreservesZeroPointers(t *testing.T) {
+	in := TaskUpdate{Enabled: ptr(false), WatchCmd: ptr(""), CronExpr: ptr("0 9 * * *")}
+	var buf bytes.Buffer
+	require.NoError(t, gob.NewEncoder(&buf).Encode(in))
+	var out TaskUpdate
+	require.NoError(t, gob.NewDecoder(&buf).Decode(&out))
+
+	require.NotNil(t, out.Enabled, "a disable patch (&false) must survive gob, not decode to nil")
+	assert.False(t, *out.Enabled)
+	require.NotNil(t, out.WatchCmd, "a trigger-clearing (&\"\") patch must survive gob, not decode to nil")
+	assert.Equal(t, "", *out.WatchCmd)
+	require.NotNil(t, out.CronExpr)
+	assert.Equal(t, "0 9 * * *", *out.CronExpr)
+	// An unset field stays nil (absent), never a spurious zero.
+	assert.Nil(t, out.Name)
+	assert.Nil(t, out.Prompt)
+}
+
 func TestUpdateTaskNotFound(t *testing.T) {
 	setupTestTasks(t, []Task{})
 
-	err := UpdateTask(Task{ID: "missing"})
+	_, err := UpdateTask("missing", TaskUpdate{Name: ptr("x")})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }
@@ -238,10 +306,16 @@ func TestUpdateTaskPreservesSchedulerOwnedFields(t *testing.T) {
 	t2 := time.Date(2026, 2, 2, 0, 0, 0, 0, time.UTC)
 	require.NoError(t, UpdateTaskStatus("u1", &t2, "completed"))
 
-	// User edit carries a STALE copy: LastRunAt=t1, LastRunStatus="started",
-	// plus an attempt to mutate CreatedAt. None of these should win.
-	stale := Task{ID: "u1", Name: "New Name", Prompt: "new prompt", CronExpr: "0 0 * * *", Enabled: false, CreatedAt: time.Time{}, LastRunAt: &t1, LastRunStatus: "started"}
-	require.NoError(t, UpdateTask(stale))
+	// A user edit patches only user-editable fields; the scheduler-owned status
+	// fields and immutable CreatedAt are not part of TaskUpdate, so they can
+	// never regress to a stale value — preservation is inherent to the merge.
+	_, err := UpdateTask("u1", TaskUpdate{
+		Name:     ptr("New Name"),
+		Prompt:   ptr("new prompt"),
+		CronExpr: ptr("0 0 * * *"),
+		Enabled:  ptr(false),
+	})
+	require.NoError(t, err)
 
 	s, err := GetTask("u1")
 	require.NoError(t, err)
@@ -323,9 +397,8 @@ func TestUpdateTaskPersistsProgram(t *testing.T) {
 	}
 	setupTestTasks(t, tasks)
 
-	updated := tasks[0]
-	updated.Program = "amp"
-	require.NoError(t, UpdateTask(updated))
+	_, err := UpdateTask("p1", TaskUpdate{Program: ptr("amp")})
+	require.NoError(t, err)
 
 	got, err := GetTask("p1")
 	require.NoError(t, err)
@@ -419,7 +492,7 @@ func TestRemoveTask_RejectsInvalidID(t *testing.T) {
 func TestUpdateTask_RejectsInvalidID(t *testing.T) {
 	setupTestTasks(t, []Task{{ID: "real"}})
 
-	err := UpdateTask(Task{ID: "../etc/passwd"})
+	_, err := UpdateTask("../etc/passwd", TaskUpdate{Name: ptr("x")})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid task id")
 }
@@ -493,9 +566,7 @@ func TestUpdateTask_RejectsBadProgram(t *testing.T) {
 	}
 	setupTestTasks(t, stored)
 
-	bad := stored[0]
-	bad.Program = "/home/foo/bin/claude"
-	err := UpdateTask(bad)
+	_, err := UpdateTask("edit1", TaskUpdate{Program: ptr("/home/foo/bin/claude")})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "task program")
 }
@@ -573,9 +644,10 @@ func TestAddTask_EnforcesTriggerContract(t *testing.T) {
 	watch := Task{ID: "bbbb0003", WatchCmd: "tail -f x", Enabled: true, CreatedAt: time.Now()}
 	require.NoError(t, AddTask(watch))
 
-	// Updating the watch task to also carry a cron must be refused.
-	watch.CronExpr = "0 3 * * *"
-	require.Error(t, UpdateTask(watch))
+	// Patching the watch task to ALSO carry a cron (without clearing watch) must
+	// be refused — the merged record would set both triggers.
+	_, err := UpdateTask("bbbb0003", TaskUpdate{CronExpr: ptr("0 3 * * *")})
+	require.Error(t, err)
 }
 
 // TestWatchFieldsJSONRoundTrip pins the wire contract: the new fields are

--- a/ui/task_pane.go
+++ b/ui/task_pane.go
@@ -94,8 +94,14 @@ type TaskPane struct {
 	// open — the lost-update in #1213. Deletions stay tracked separately in
 	// `deleted` (mirrors ConsumeDeleted).
 	dirtyIDs map[string]bool
-	deleted  []task.Task
-	hasFocus bool
+	// originals holds the task record as loaded (keyed by ID) so ConsumeDirty
+	// can diff each edited task against the copy the pane started from and emit a
+	// FIELD-LEVEL patch (task.DiffTask). Sending only the changed fields — not
+	// the whole task — means a save of one field can never clobber a field
+	// another writer changed out-of-band while the editor was open (#1700).
+	originals map[string]task.Task
+	deleted   []task.Task
+	hasFocus  bool
 }
 
 // NewTaskPane creates a new task pane.

--- a/ui/task_pane_state.go
+++ b/ui/task_pane_state.go
@@ -12,6 +12,14 @@ func (s *TaskPane) SetTasks(tasks []task.Task) {
 	s.tasks = tasks
 	s.dirty = false
 	s.dirtyIDs = nil
+	// Snapshot the loaded records so ConsumeDirty can diff an edit against the
+	// copy the pane started from and emit a field-level patch (#1700). Task is a
+	// value type (its only pointer field, LastRunAt, is scheduler-owned and never
+	// diffed), so a by-value copy is a sufficient baseline.
+	s.originals = make(map[string]task.Task, len(tasks))
+	for _, t := range tasks {
+		s.originals[t.ID] = t
+	}
 	s.deleted = nil
 	s.editing = false
 	// A reload replaces the create-form buffers a pending create was captured
@@ -60,27 +68,35 @@ func (s *TaskPane) markTaskDirty(id string) {
 	s.dirty = true
 }
 
-// ConsumeDirty returns the tasks the user actually edited since the pane was
-// loaded and clears the per-task dirty set. saveContentPaneState persists only
-// these — never the full task list — so saving an edit to one task can't write
-// a stale pane copy of an UNMODIFIED task back over a change another writer
-// (CLI/daemon) committed while the pane was open (#1213). Mirrors the
-// per-task tracking that ConsumeDeleted already does for deletions. The
-// pane-wide dirty flag is left to ConsumeDeleted to clear so a save that has
-// both edits and deletions still processes both.
-func (s *TaskPane) ConsumeDirty() []task.Task {
+// ConsumeDirty returns a field-level patch for each task the user actually
+// edited since the pane was loaded and clears the per-task dirty set. Each edit
+// carries ONLY the fields that differ from the copy the pane loaded (diffed via
+// task.DiffTask against the originals snapshot), so saving an edit to one field
+// can't write a stale pane copy of an UNCHANGED field back over a change another
+// writer (CLI/daemon) committed while the pane was open — the #1700 clobber (of
+// which #1213's per-task tracking was only a partial fix). An edit whose diff is
+// empty (a value toggled and reverted) is dropped: there is nothing to persist.
+// Mirrors the per-task tracking ConsumeDeleted does for deletions; the pane-wide
+// dirty flag is left to ConsumeDeleted to clear so a save with both edits and
+// deletions still processes both.
+func (s *TaskPane) ConsumeDirty() []task.TaskEdit {
 	if len(s.dirtyIDs) == 0 {
 		s.dirtyIDs = nil
 		return nil
 	}
-	var modified []task.Task
+	var edits []task.TaskEdit
 	for _, t := range s.tasks {
-		if s.dirtyIDs[t.ID] {
-			modified = append(modified, t)
+		if !s.dirtyIDs[t.ID] {
+			continue
 		}
+		update := task.DiffTask(s.originals[t.ID], t)
+		if update.IsEmpty() {
+			continue
+		}
+		edits = append(edits, task.TaskEdit{ID: t.ID, Update: update})
 	}
 	s.dirtyIDs = nil
-	return modified
+	return edits
 }
 
 // ConsumeDeleted returns the tasks pending deletion and clears the pane's

--- a/ui/task_pane_test.go
+++ b/ui/task_pane_test.go
@@ -84,7 +84,12 @@ func TestTaskPaneConsumeDirtyTracksOnlyEditedTasks(t *testing.T) {
 	dirty := tp.ConsumeDirty()
 	require.Len(t, dirty, 1, "only the toggled task must be dirty")
 	assert.Equal(t, "a", dirty[0].ID)
-	assert.False(t, dirty[0].Enabled, "the dirty task carries the toggled value")
+	// The edit is a field-level patch carrying ONLY the toggled field (#1700):
+	// Enabled is set to the new value and no other field is present.
+	require.NotNil(t, dirty[0].Update.Enabled, "the patch must carry the toggled Enabled field")
+	assert.False(t, *dirty[0].Update.Enabled, "the patch carries the toggled value")
+	assert.Nil(t, dirty[0].Update.Name, "a toggle must not patch any other field")
+	assert.Nil(t, dirty[0].Update.Prompt, "a toggle must not patch any other field")
 
 	// ConsumeDirty clears the set: a second call returns nothing.
 	assert.Empty(t, tp.ConsumeDirty(), "ConsumeDirty must clear the dirty set")

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -6243,9 +6243,9 @@ function requireTaskID(id, action) {
 async function addTask(task, token2) {
   await af("AddTask", { task }, token2);
 }
-async function updateTask(task, token2) {
-  requireTaskID(task.id, "update a task");
-  await af("UpdateTask", { task }, token2);
+async function updateTask(id, update, token2) {
+  requireTaskID(id, "update a task");
+  await af("UpdateTask", { id, update }, token2);
 }
 async function triggerTask(id, token2) {
   requireTaskID(id, "trigger a task");
@@ -8307,7 +8307,7 @@ function toggleTask(task) {
   if (tok === null) {
     return;
   }
-  void updateTask({ ...task, enabled: !task.enabled }, tok).then(refreshTasks).catch((e) => surfaceTabError(e));
+  void updateTask(task.id, { enabled: !task.enabled }, tok).then(refreshTasks).catch((e) => surfaceTabError(e));
 }
 function doTriggerTask(task) {
   const tok = token;

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -18,7 +18,6 @@ import {
   triggerTask,
   updateTask,
 } from "./api.js";
-import type { TaskData } from "./types.js";
 
 interface Captured {
   url: string;
@@ -115,28 +114,17 @@ test("createTab / closeTab FAIL CLOSED on a missing id — no title-scoped reque
 
 // --- task mutations (#1592 Phase 5 PR8) ------------------------------------
 
-/** A minimal valid TaskData for the mutation tests; `id` is overridden per case. */
-function task(id: string): TaskData {
-  return {
-    id,
-    name: "nightly",
-    prompt: "do the thing",
-    cron_expr: "0 9 * * *",
-    project_path: "/repo",
-    program: "claude",
-    enabled: true,
-    created_at: "2026-07-13T00:00:00Z",
-  };
-}
-
-test("updateTask posts the task keyed by its stable id", async () => {
+test("updateTask posts a field-level patch keyed by the stable id", async () => {
   const cap = stubFetch();
-  await updateTask({ ...task("t-abc123"), enabled: false }, "tok");
+  await updateTask("t-abc123", { enabled: false }, "tok");
   assert.equal(cap.url, "/v1/UpdateTask");
   assert.equal(cap.auth, "Bearer tok");
-  const sent = cap.body.task as Record<string, unknown>;
-  assert.equal(sent.id, "t-abc123", "the daemon resolves the task by its unique id, not its name");
-  assert.equal(sent.enabled, false, "the enable/disable toggle rides UpdateTask");
+  assert.equal(cap.body.id, "t-abc123", "the daemon resolves the task by its unique id, not its name");
+  const sent = cap.body.update as Record<string, unknown>;
+  assert.equal(sent.enabled, false, "the enable/disable toggle rides UpdateTask as an `enabled`-only patch");
+  // A toggle must carry ONLY the flipped field — never the rest of a cached task
+  // that could clobber a concurrent edit (#1700).
+  assert.deepEqual(Object.keys(sent), ["enabled"], "the toggle patch carries only the enabled field");
 });
 
 test("triggerTask / removeTask post the stable id", async () => {
@@ -155,7 +143,7 @@ test("updateTask / triggerTask / removeTask FAIL CLOSED on a missing task id", a
   // A task with no id must NOT be mutated by a daemon first-match on another task —
   // the task analogue of the #1678 id-scoping class. Each refuses BEFORE any request.
   await assert.rejects(
-    () => updateTask(task(""), "tok"),
+    () => updateTask("", { enabled: false }, "tok"),
     (e: unknown) => e instanceof ApiError && /no stable id/.test((e as ApiError).message),
     "updateTask with an empty id must reject",
   );

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -11,7 +11,7 @@
 // request. The WS `?access_token=` fallback (browsers cannot set WS headers) is
 // used by the /v1/events subscriber (events.ts) and, in PR4, the PTY stream.
 
-import type { SessionData, SnapshotResponse, TaskData, TasksResponse } from "./types.js";
+import type { SessionData, SnapshotResponse, TaskData, TasksResponse, TaskUpdate } from "./types.js";
 
 const TOKEN_KEY = "af.token";
 
@@ -303,13 +303,16 @@ export async function addTask(task: TaskData, token: string): Promise<void> {
   await af("AddTask", { task }, token);
 }
 
-/** Updates a task (mirrors `af tasks update`) — the edit + enable/disable path. The
- *  daemon preserves the scheduler-owned fields (last_run_*, created_at) from the
- *  freshly-loaded record under its file lock, so a stale client copy never clobbers
- *  them. Refuses a task with no stable id, before issuing the request. */
-export async function updateTask(task: TaskData, token: string): Promise<void> {
-  requireTaskID(task.id, "update a task");
-  await af("UpdateTask", { task }, token);
+/** Updates a task (mirrors `af tasks update`) — the edit + enable/disable path.
+ *  Sends a FIELD-LEVEL patch (#1700): only the fields in `update` are changed, so
+ *  a toggle shipping just `{ enabled }` can never clobber a concurrent edit another
+ *  client made to a different field. The daemon merges the patch onto the
+ *  freshly-loaded record under its file lock and leaves scheduler-owned fields
+ *  (last_run_*, created_at) untouched. Refuses a task with no stable id, before
+ *  issuing the request. */
+export async function updateTask(id: string, update: TaskUpdate, token: string): Promise<void> {
+  requireTaskID(id, "update a task");
+  await af("UpdateTask", { id, update }, token);
 }
 
 /** Fires a task NOW (mirrors `af tasks trigger`). The daemon runs it through the same

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -631,7 +631,10 @@ function toggleTask(task: TaskData): void {
   if (tok === null) {
     return;
   }
-  void updateTask({ ...task, enabled: !task.enabled }, tok)
+  // Ship ONLY the flipped bit as a field-level patch (#1700): the toggle must
+  // not carry the rest of this (possibly-stale) cached task, or it could revert a
+  // concurrent edit another client made to the prompt/trigger/target.
+  void updateTask(task.id, { enabled: !task.enabled }, tok)
     .then(refreshTasks)
     .catch((e) => surfaceTabError(e));
 }

--- a/web/src/tasks.ts
+++ b/web/src/tasks.ts
@@ -32,7 +32,8 @@ export interface AddTaskInput {
 
 /** The row-level actions the tasks pane invokes; index.ts owns the real behavior
  *  (the daemon RPC + list refresh). Each mutation is handed the whole task so the
- *  handler has its stable id AND its current fields (UpdateTask needs the full task). */
+ *  handler has its stable id and current state; the toggle turns that into a
+ *  field-level `{ enabled }` patch (UpdateTask), never a full-struct write (#1700). */
 export interface TaskActions {
   /** Opens the add-task modal. */
   add(): void;

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -144,6 +144,24 @@ export interface TaskData {
   last_run_status?: string;
 }
 
+/**
+ * A FIELD-LEVEL patch for UpdateTask (task.TaskUpdate, #1700): only the fields
+ * present are changed; the daemon leaves every omitted field as-stored, merging
+ * the patch onto the freshly-loaded record under its file lock. So the
+ * enable/disable toggle sends just `{ enabled }` and can never clobber a
+ * concurrent edit another client made to a different field. Field names/JSON tags
+ * match the Go TaskUpdate struct EXACTLY (the daemon rejects unknown keys).
+ */
+export interface TaskUpdate {
+  name?: string;
+  prompt?: string;
+  cron_expr?: string;
+  watch_cmd?: string;
+  target_session?: string;
+  program?: string;
+  enabled?: boolean;
+}
+
 /** The ListTasks RPC response (daemon/control_types.go: ListTasksResponse). */
 export interface TasksResponse {
   tasks: TaskData[] | null;


### PR DESCRIPTION
Fixes #1700.

## Problem

`UpdateTask` was a full-struct read-modify-write. A client loaded a task, edited one field, and shipped the **whole** struct back. The daemon preserved the scheduler-owned fields (`LastRunAt`/`LastRunStatus`/`CreatedAt`, #731) but re-applied every user field (`name`/`prompt`/`cron_expr`/`watch_cmd`/`target_session`/`program`/`enabled`) from the caller's copy. So a single-field edit made against a **stale** cached task silently reverted a concurrent edit another client made to a *different* field. The enable/disable toggle — which only means to flip one bit — was the common trigger, and it hit the TUI, CLI, and web tasks view (#1699) identically.

## Fix (Option A, at the single-writer daemon)

Make `UpdateTask` a **field-level** update. It now takes a task id and a `task.TaskUpdate` patch (one pointer per user-editable field; `nil` = leave as-stored). The daemon merges **only the patch's set fields** onto the freshly-loaded record under its existing file lock, so an unspecified field is never rewritten — the clobber is impossible by construction. The #731 scheduler-owned-field preservation now falls out of the merge for free (the merged record starts from the on-disk copy), and the merged result is validated (`ValidateTrigger`, plus the program enum only when the patch sets `program`) before the write.

Clean break per the no-backcompat mandate — the contract changed and all three callers migrated to send **only what they change**:

- **CLI** (`af tasks update`): builds a patch from the flags the user actually passed. `--enabled false` ships just `enabled`.
- **TUI** (task pane save/toggle): the pane snapshots the records it loaded and diffs each edited task against that snapshot (`task.DiffTask`), so a save carries only the fields the user changed. Extends #1213's per-task tracking to per-field.
- **Web** (tasks toggle): posts `{ id, update: { enabled } }`.

`UpdateTask` returns the merged record, so the daemon publishes the full post-edit task on `EventTaskUpdated` and the CLI prints the authoritative result.

### The gob gotcha (why `TaskUpdate` has a JSON-backed gob codec)

The CLI control socket is `net/rpc` **gob**, and gob elides a struct field holding its zero value — including following a `*bool`→`false` (or `*string`→`""`) down to that zero and dropping it, so the pointer decodes back as `nil`. Left unhandled, that would have silently turned `af tasks update --enabled false` and the trigger-clearing `WatchCmd:""`/`CronExpr:""` patches into **no-ops** over the socket. `TaskUpdate.GobEncode/GobDecode` route through JSON, which preserves the nil-vs-non-nil-zero-pointer distinction losslessly. (The TUI/web go over HTTP+JSON and were already fine.) Guarded by a dedicated round-trip test.

## Tests

- `task`: the core concurrent-edit scenario — B changes `cron_expr`+`target_session`, then A (holding a pre-edit copy) toggles `enabled` off shipping only that field → **B's edits survive, A's toggle applies**; the gob zero-pointer round-trip; migrated the existing #731 / program / trigger-contract cases to the patch API.
- `daemon`: `UpdateTask` RPC returns the merged record and re-arms the schedule.
- `api` (CLI): per-flag paths + a recorder asserting the CLI ships only the passed flags.
- `app`/`ui` (TUI): the #1213 don't-clobber-unedited-task test now proves a toggle patch carries **only** `enabled`; pane diff emits field-level edits.
- `web`: the toggle posts an `enabled`-only patch keyed by id, and fails closed on a missing id.

## Gates

`gofmt` clean · `golangci-lint --fast` clean · `deadcode` clean · file-length lint · `make test-container` green (incl. `daemon` 57s) · `make tui-driver-selftest` 25/25 · `make web-test` 68/68 (typecheck + tests) · `gen-docs` regenerated (`/v1/UpdateTask` now `id`, `update`) · `web/dist` rebuilt.

Rebased onto latest `master` (on top of PR9 #1701, which also touched the web tasks caller) and `web/dist` rebuilt against the merged `web/src`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
