### PR TITLE
refactor(session): route preview and prompts through AgentServer

### DIFF
--- a/api/sessions.go
+++ b/api/sessions.go
@@ -744,7 +744,7 @@ var sessionsPreviewCmd = &cobra.Command{
 			return jsonError(err)
 		}
 
-		content, err := instance.Preview()
+		content, err := instance.AgentServer().Preview(0, false)
 		if err != nil {
 			return jsonError(fmt.Errorf("failed to get preview: %w", err))
 		}

--- a/app/creation_test.go
+++ b/app/creation_test.go
@@ -132,10 +132,8 @@ func testPreviewFetcher(h *home) func(daemon.PreviewRequest) (string, bool, erro
 		var content string
 		var err error
 		switch {
-		case req.Tab == 0 && req.Full:
-			content, err = inst.PreviewFullHistory()
 		case req.Tab == 0:
-			content, err = inst.Preview()
+			content, err = inst.AgentServer().Preview(req.Tab, req.Full)
 		case req.Full:
 			content, err = inst.PreviewTabFullHistory(req.Tab)
 		default:

--- a/app/e2e_test.go
+++ b/app/e2e_test.go
@@ -114,7 +114,7 @@ func installDirectSessionStarter(t *testing.T) {
 			return nil, err
 		}
 		if req.Prompt != "" {
-			if err := inst.SendPromptCommand(req.Prompt); err != nil {
+			if err := inst.AgentServer().SendPrompt(req.Prompt); err != nil {
 				return nil, err
 			}
 		}

--- a/app/real_e2e_test.go
+++ b/app/real_e2e_test.go
@@ -119,7 +119,7 @@ func TestRealLocalBackend_FullLifecycle(t *testing.T) {
 
 	// Preview should return without erroring (may be empty since cat has
 	// nothing to print — we just want no crash).
-	_, err = inst.Preview()
+	_, err = inst.AgentServer().Preview(0, false)
 	assert.NoError(t, err)
 
 	// Kill should clean up tmux + worktree.

--- a/daemon/outage_e2e_test.go
+++ b/daemon/outage_e2e_test.go
@@ -106,7 +106,7 @@ func TestOutageEndToEnd_LostRestoreAndReplay(t *testing.T) {
 	// The sent text is echoed by the pane's tty line discipline, so the
 	// replayed lines are observable in a real capture of the restored pane.
 	waitUntil(t, 30*time.Second, "queued events to replay into the restored pane in order", func() bool {
-		content, err := inst.Preview()
+		content, err := inst.AgentServer().Preview(0, false)
 		if err != nil {
 			return false
 		}

--- a/session/instance_backend.go
+++ b/session/instance_backend.go
@@ -126,10 +126,6 @@ func (i *Instance) CloseAttachOnly() error {
 	return i.backend.CloseAttachOnly(i)
 }
 
-func (i *Instance) Preview() (string, error) {
-	return i.backend.Preview(i)
-}
-
 // CheckAndHandleTrustPrompt checks for and dismisses the trust prompt for supported programs.
 func (i *Instance) CheckAndHandleTrustPrompt() bool {
 	return i.backend.CheckAndHandleTrustPrompt(i)
@@ -146,17 +142,6 @@ func (i *Instance) Attach() (chan struct{}, error) {
 // closed when the user detaches.
 func (i *Instance) AttachTerminal(tabIdx int) (chan struct{}, error) {
 	return i.backend.AttachTerminal(i, tabIdx)
-}
-
-// SendPromptCommand sends a prompt using a more reliable command-based approach.
-// This is more reliable for headless/scheduled runs where the PTY may not persist.
-func (i *Instance) SendPromptCommand(prompt string) error {
-	return i.backend.SendPromptCommand(i, prompt)
-}
-
-// PreviewFullHistory captures the entire session output including full scrollback history
-func (i *Instance) PreviewFullHistory() (string, error) {
-	return i.backend.PreviewFullHistory(i)
 }
 
 // Capabilities returns the backing runtime's capability descriptor (#1592

--- a/task/runner.go
+++ b/task/runner.go
@@ -200,7 +200,7 @@ func WaitForReady(instance *session.Instance) error {
 			hooksDone, hookGrace = nil, nil
 			timeout = time.After(waitForReadyTimeout)
 		case <-timeout:
-			content, err := instance.Preview()
+			content, err := instance.AgentServer().Preview(0, false)
 			if err != nil {
 				// Mirror the ticker case: ErrSessionGone is a definitive,
 				// non-retryable death, so surface the actionable "session died"
@@ -222,7 +222,7 @@ func WaitForReady(instance *session.Instance) error {
 			log.ErrorLog.Printf("waitForReady timed out. Last pane content: %s", content)
 			return formatWaitForReadyTimeoutError(waitForReadyTimeout, content)
 		case <-ticker.C:
-			content, err := instance.Preview()
+			content, err := instance.AgentServer().Preview(0, false)
 			if err != nil {
 				// ErrSessionGone is a definitive, non-retryable failure: the
 				// tmux session no longer exists, so it can never become ready.

--- a/task/start.go
+++ b/task/start.go
@@ -48,7 +48,7 @@ func StartAndSendPrompt(instance *session.Instance, prompt string) error {
 	}
 
 	if prompt != "" {
-		if err := instance.SendPromptCommand(prompt); err != nil {
+		if err := instance.AgentServer().SendPrompt(prompt); err != nil {
 			return err
 		}
 	}

--- a/ui/preview_test.go
+++ b/ui/preview_test.go
@@ -243,7 +243,7 @@ func TestPreviewScrolling(t *testing.T) {
 	require.False(t, previewPane.isScrolling, "Should not be in scrolling mode initially")
 
 	// Step 2: Check that PreviewFullHistory returns all content
-	fullHistory, err := setup.instance.PreviewFullHistory()
+	fullHistory, err := setup.instance.AgentServer().Preview(0, true)
 	require.NoError(t, err)
 
 	// Verify that the full history contains both the command and early output

--- a/ui/store_helpers_test.go
+++ b/ui/store_helpers_test.go
@@ -12,10 +12,7 @@ import (
 // daemon-backed source instead.
 func previewFromInstance(instance *session.Instance, tab int, full bool) (string, error) {
 	if tab == 0 {
-		if full {
-			return instance.PreviewFullHistory()
-		}
-		return instance.Preview()
+		return instance.AgentServer().Preview(tab, full)
 	}
 	if full {
 		return instance.PreviewTabFullHistory(tab)


### PR DESCRIPTION
## Summary

- Remove the inert `Instance.Preview`, `PreviewFullHistory`, and `SendPromptCommand` forwarders.
- Route CLI preview, task readiness/prompt delivery, and direct test capture through the single `AgentServer` seam.

## Behavior preservation

For local sessions, `AgentServer` delegates to the same backend preview and prompt methods the deleted wrappers invoked. Remote backends already route these operations through `AgentServer`, so this removes a parallel abstraction layer without changing the selected tab, full-history flag, or delivery path.

## Test Plan

- [x] `golangci-lint run --fast`
- [x] `gofmt -l` is empty
- [x] `go build ./...`
- [x] `deadcode -test ./...`
- [x] `make lint-file-length`
- [x] `make test-container` (container-fenced full suite)

Refs #1241

— Captain Claude