### PR TITLE
fix(tui): unbreak three post-rail-migration nav dead-ends (#1704, #1705, #1706)

### DIFF
--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -45,14 +45,14 @@ func (m *home) handleDefaultKeyPress(msg tea.KeyMsg, name keys.KeyName) (tea.Mod
 		m.sidebar.ExpandSection()
 		m.focusTreeForNav()
 		return m, m.selectionChanged()
+	// `]` / `[` jump between the focusable SECTIONS — the instances tree and the
+	// automations / projects rails — skipping workspace panes (#1706). Since
+	// automations/projects moved out of the sidebar into their own rail regions,
+	// this steps the focus ring rather than walking sidebar headers.
 	case keys.KeyNextSection:
-		m.sidebar.JumpNextSection()
-		m.focusTreeForNav()
-		return m, m.selectionChanged()
+		return m, m.focusAdjacentSection(false)
 	case keys.KeyPrevSection:
-		m.sidebar.JumpPrevSection()
-		m.focusTreeForNav()
-		return m, m.selectionChanged()
+		return m, m.focusAdjacentSection(true)
 
 	// Instance creation
 	case keys.KeyNewRemote:

--- a/app/home_model.go
+++ b/app/home_model.go
@@ -697,10 +697,22 @@ func (m *home) focusRegion(region string) {
 // only inside the tasks overlay, which saves on close (handleStateTasks) —
 // the in-rail automations section is read-only, so no save is needed here.
 func (m *home) cycleFocus(back bool) tea.Cmd {
+	// A live pane preview is transient chrome, not a focus stop. Tab / Shift-Tab
+	// must DISMISS it and still advance the ring one step — never swallow the
+	// keystroke (#1705). Earlier this early-returned after cancelling the
+	// preview, so with a preview live (which the idle tick creates whenever the
+	// tree cursor names a tab the owner pane isn't bound to) reverse traversal
+	// out of a pane was impossible: the ring never moved.
+	//
+	// The step anchors on ring.Active() — cancelPanePreview(false), NOT
+	// cancelPanePreview(true) — so a Tab pressed from the tree while a
+	// background preview happens to be owned by some pane still steps from the
+	// tree, not from that pane.
+	var refresh tea.Cmd
 	if m.panePreviewTxn != nil {
 		m.suppressActivePanePreview()
-		m.cancelPanePreview(true)
-		return m.panesRefresh(m.attached.Load())
+		m.cancelPanePreview(false)
+		refresh = m.panesRefresh(m.attached.Load())
 	}
 	if back {
 		m.ring.Prev()
@@ -708,7 +720,44 @@ func (m *home) cycleFocus(back bool) tea.Cmd {
 		m.ring.Next()
 	}
 	m.relayout()
-	return nil
+	return refresh
+}
+
+// focusAdjacentSection moves focus to the next / previous SECTION region — the
+// non-pane focus-ring stops: the instances tree, the automations rail, and the
+// projects rail. Workspace panes are skipped (Tab steps through those, 1-9 jump
+// to tabs). This is what the `]` / `[` "next / prev section" bindings drive
+// (#1706): automations and projects became their own Tab-focusable rail
+// sections (#1470 / #1588 / #1590) rather than sidebar section headers, so the
+// old header-walking JumpNextSection could never reach them — from an instance
+// row `]` was a silent no-op. Stepping the real focus ring makes `]` land on
+// Automations (dropping the instance-only `D kill` from the footer) exactly as
+// the binding advertises, and `[` walks back.
+func (m *home) focusAdjacentSection(back bool) tea.Cmd {
+	// Mirror cycleFocus: a live preview is transient chrome and must be
+	// dismissed without swallowing the keystroke (#1705 class).
+	var refresh tea.Cmd
+	if m.panePreviewTxn != nil {
+		m.suppressActivePanePreview()
+		m.cancelPanePreview(false)
+		refresh = m.panesRefresh(m.attached.Load())
+	}
+	// Step the ring, skipping workspace panes, until it rests on a section
+	// region. The tree is always a visible non-pane stop, so this always
+	// terminates; bound the loop by the ring size as a backstop.
+	for i := 0; i < len(m.visiblePanes)+3; i++ {
+		var id string
+		if back {
+			id = m.ring.Prev()
+		} else {
+			id = m.ring.Next()
+		}
+		if id == "" || !layout.IsPaneRegion(id) {
+			break
+		}
+	}
+	m.relayout()
+	return refresh
 }
 
 func (m *home) Init() tea.Cmd {

--- a/app/home_panes.go
+++ b/app/home_panes.go
@@ -177,7 +177,16 @@ func (m *home) panesRefresh(attachedNow bool) tea.Cmd {
 		// capture-pane (#1089): the attach client already streams the same
 		// content, tmux-flow-limited. Capture resumes the tick after the
 		// attachment closes.
-		if w.HasLive() {
+		//
+		// EXCEPT when it just entered scroll mode (#1704): scroll mode stops
+		// rendering the live terminal and shows the capture viewport instead
+		// (String()'s liveShowing gate is false while IsScrolling), so the
+		// one-shot off-loop scrollback fill MUST run even for a live pane —
+		// otherwise the viewport stays empty and the pane renders blank until
+		// scroll mode is left. NeedsScrollFill is true only until that single
+		// fill lands (it clears scrollFillPending), so a live pane resumes
+		// skipping capture for every subsequent scroll keystroke.
+		if w.HasLive() && !w.NeedsScrollFill() {
 			continue
 		}
 		// A pane that just entered scroll mode has an empty scroll viewport

--- a/app/live_termpane_test.go
+++ b/app/live_termpane_test.go
@@ -108,6 +108,37 @@ func TestSyncLiveTermPaneBindsFocusedPane(t *testing.T) {
 	assert.NotContains(t, h.lastPaneCapture, p.ID(), "live pane must not capture-poll")
 }
 
+// TestLivePaneScrollFillCapturesDespiteLiveSkip is the #1704 regression. When a
+// live pane enters scroll mode (Ctrl+U) it stops rendering the streamed live
+// grid and shows the capture viewport instead — which is EMPTY until the
+// off-loop scrollback fill runs. panesRefresh normally skips capture for a live
+// pane, but that skip must NOT apply while a scroll fill is pending, or the
+// viewport stays blank forever and Ctrl+D can never restore it. Before the fix
+// `if w.HasLive() { continue }` swallowed the fill; now it is gated on
+// !NeedsScrollFill so the one-shot fill lands.
+func TestLivePaneScrollFillCapturesDespiteLiveSkip(t *testing.T) {
+	h, _ := liveTestHome(t)
+	_, _ = stubLiveTermFactory(t)
+	h.syncLiveTermPane()
+
+	p := h.focusedOpenPane()
+	require.NotNil(t, p)
+	w := h.paneWindows[p.ID()]
+	require.True(t, w.HasLive(), "pane renders through the live attachment")
+
+	// Ctrl+U enters scroll mode: the live render is replaced by the capture
+	// viewport, empty with a pending fill.
+	w.ScrollUp()
+	require.True(t, w.NeedsScrollFill(), "scroll entry leaves a pending scrollback fill")
+
+	// The pending fill MUST get a capture dispatched even though the pane is live
+	// — otherwise the viewport renders blank until scroll mode is left (#1704).
+	h.lastPaneCapture = map[int]time.Time{}
+	_ = h.panesRefresh(false)
+	assert.Contains(t, h.lastPaneCapture, p.ID(),
+		"a live pane with a pending scroll fill must capture the scrollback (#1704)")
+}
+
 func TestSyncLiveTermPaneSurvivesFocusOnTree(t *testing.T) {
 	h, _ := liveTestHome(t)
 	fakes, _ := stubLiveTermFactory(t)

--- a/app/pane_focus_ring_test.go
+++ b/app/pane_focus_ring_test.go
@@ -148,3 +148,78 @@ func TestPane_SnapshotFetchDoesNotStealFocusFromOtherPane(t *testing.T) {
 	require.Equal(t, layout.PaneRegion(pane2.ID()), h.ring.Active(),
 		"background snapshot reconciliation must not steal focus from pane2 (beta) to pane1 (alpha)")
 }
+
+// TestPane_ShiftTabReverseTraversalDismissesLivePreview is the #1705 regression.
+// A live pane preview must NOT swallow a focus-ring keystroke: Shift+Tab from a
+// focused pane while a preview is active must dismiss the preview AND still step
+// the ring back one stop (to the tree). Before the fix, cycleFocus early-returned
+// after cancelling the preview, so the ring never moved — and because the idle
+// preview tick creates a preview whenever the tree cursor names a tab the owner
+// pane isn't bound to, reverse traversal out of a pane was effectively dead.
+func TestPane_ShiftTabReverseTraversalDismissesLivePreview(t *testing.T) {
+	h := paneTestHome(t)
+	alpha := h.store.GetInstanceByTitle("alpha")
+	setPreviewText(alpha, "alpha-body")
+	beta := h.store.GetInstanceByTitle("beta")
+	setPreviewText(beta, "beta-body")
+
+	// Open a pane on alpha, then select beta so alpha's pane previews beta — a
+	// live preview txn, exactly as the running TUI holds when the tree cursor
+	// rests on a not-yet-open tab.
+	pressKey(t, h, "s")
+	pane := h.store.OpenPanes()[0]
+	h.sidebar.SetSelectedInstance(1)
+	_ = h.selectionChanged()
+	require.NotNil(t, h.panePreviewTxn, "a cross-instance selection creates a live preview")
+
+	// Focus the pane, then Shift+Tab.
+	h.focusRegion(layout.PaneRegion(pane.ID()))
+	require.Equal(t, layout.PaneRegion(pane.ID()), h.ring.Active())
+	pressTab(t, h, true)
+
+	require.Nil(t, h.panePreviewTxn, "Shift+Tab dismisses the transient preview")
+	require.Equal(t, layout.RegionTree, h.ring.Active(),
+		"#1705: Shift+Tab reverse-traverses out of the pane to the tree, not swallowed")
+}
+
+// TestSectionNav_JumpsAcrossRailSections is the #1706 regression. `]` / `[`
+// ("next / prev section") must reach the automations and projects rail sections,
+// which moved out of the sidebar (#1470 / #1588 / #1590) into their own
+// Tab-focusable regions. Before the fix the binding walked sidebar section
+// headers only, so from the instances tree it was a silent no-op — Automations
+// was unreachable via `]`.
+func TestSectionNav_JumpsAcrossRailSections(t *testing.T) {
+	h := paneTestHome(t)
+	h.focusRegion(layout.RegionTree)
+	require.Equal(t, layout.RegionTree, h.ring.Active())
+
+	// `]` from an instance row reaches the Automations section (drops D kill).
+	pressKey(t, h, "]")
+	require.Equal(t, layout.RegionAutomations, h.ring.Active(),
+		"#1706: ] from the instances tree must reach the Automations section")
+
+	// `]` again → Projects; again → wraps back to the tree.
+	pressKey(t, h, "]")
+	require.Equal(t, layout.RegionProjects, h.ring.Active())
+	pressKey(t, h, "]")
+	require.Equal(t, layout.RegionTree, h.ring.Active())
+
+	// `[` walks back the other way.
+	pressKey(t, h, "[")
+	require.Equal(t, layout.RegionProjects, h.ring.Active(),
+		"#1706: [ walks the sections in reverse")
+}
+
+// TestSectionNav_SkipsWorkspacePanes proves `]` jumps SECTION to SECTION, not
+// through the open workspace panes (those are Tab's / 1-9's job): with a pane
+// open, `]` from the tree lands on Automations, skipping the pane region.
+func TestSectionNav_SkipsWorkspacePanes(t *testing.T) {
+	h := paneTestHome(t)
+	pressKey(t, h, "s") // open a pane on alpha
+	require.Equal(t, 1, h.store.NumOpenPanes())
+	h.focusRegion(layout.RegionTree)
+
+	pressKey(t, h, "]")
+	require.Equal(t, layout.RegionAutomations, h.ring.Active(),
+		"#1706: ] skips the workspace pane and lands on the next section")
+}

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -589,48 +589,53 @@ func TestPanePreviewSplitFocusesAlreadyOpenTarget(t *testing.T) {
 	assert.Equal(t, layout.PaneRegion(paneB.ID()), h.ring.Active(), "existing target pane takes focus")
 }
 
-func TestPanePreviewTabAndEscCancelToOwnerPane(t *testing.T) {
-	for _, tc := range []struct {
-		name string
-		run  func(*home) tea.Cmd
-	}{
-		{
-			name: "Tab",
-			run: func(h *home) tea.Cmd {
-				_, cmd := h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyTab}, keys.KeyTab)
-				return cmd
-			},
-		},
-		{
-			name: "Esc",
-			run: func(h *home) tea.Cmd {
-				_, cmd := h.Update(tea.KeyMsg{Type: tea.KeyEsc})
-				return cmd
-			},
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			h := paneTestHome(t)
-			alpha := h.store.GetInstanceByTitle("alpha")
+// TestPanePreviewEscCancelsToOwnerPane: Esc dismisses a live preview and leaves
+// focus on the owner pane — "escape the preview, stay put". (Tab, by contrast,
+// dismisses AND advances the ring — see TestPanePreviewTabDismissesAndAdvances.)
+func TestPanePreviewEscCancelsToOwnerPane(t *testing.T) {
+	h := paneTestHome(t)
+	alpha := h.store.GetInstanceByTitle("alpha")
 
-			pressKey(t, h, "s")
-			paneA := h.store.OpenPanes()[0]
-			h.sidebar.SetSelectedInstance(1)
-			_ = h.selectionChanged()
-			require.NotNil(t, h.panePreviewTxn)
+	pressKey(t, h, "s")
+	paneA := h.store.OpenPanes()[0]
+	h.sidebar.SetSelectedInstance(1)
+	_ = h.selectionChanged()
+	require.NotNil(t, h.panePreviewTxn)
 
-			cmd := tc.run(h)
+	_, cmd := h.Update(tea.KeyMsg{Type: tea.KeyEsc})
 
-			require.NotNil(t, cmd, "cancel should schedule an owner-pane refresh")
-			require.Nil(t, h.panePreviewTxn)
-			assert.Same(t, alpha, paneA.Instance())
-			assert.Equal(t, 0, paneA.Tab())
-			assert.Equal(t, layout.PaneRegion(paneA.ID()), h.ring.Active())
-			view := h.View()
-			assert.Contains(t, view, "alpha · Agent · selected: beta · Agent")
-			assert.NotContains(t, view, "PREVIEW")
-		})
-	}
+	require.NotNil(t, cmd, "cancel should schedule an owner-pane refresh")
+	require.Nil(t, h.panePreviewTxn)
+	assert.Same(t, alpha, paneA.Instance())
+	assert.Equal(t, 0, paneA.Tab())
+	assert.Equal(t, layout.PaneRegion(paneA.ID()), h.ring.Active())
+	view := h.View()
+	assert.Contains(t, view, "alpha · Agent · selected: beta · Agent")
+	assert.NotContains(t, view, "PREVIEW")
+}
+
+// TestPanePreviewTabDismissesAndAdvances: Tab over a live preview must dismiss
+// the preview AND still step the focus ring — never swallow the keystroke to sit
+// on the owner pane (the #1705 class, in the forward direction). With paneA the
+// only pane and focus on it, forward Tab lands on the next section (Automations).
+func TestPanePreviewTabDismissesAndAdvances(t *testing.T) {
+	h := paneTestHome(t)
+	alpha := h.store.GetInstanceByTitle("alpha")
+
+	pressKey(t, h, "s")
+	paneA := h.store.OpenPanes()[0]
+	require.Equal(t, layout.PaneRegion(paneA.ID()), h.ring.Active())
+	h.sidebar.SetSelectedInstance(1)
+	_ = h.selectionChanged()
+	require.NotNil(t, h.panePreviewTxn)
+
+	pressTab(t, h, false)
+
+	require.Nil(t, h.panePreviewTxn, "Tab dismisses the transient preview")
+	assert.Same(t, alpha, paneA.Instance(), "owner pane reverts to its real binding")
+	assert.Equal(t, layout.RegionAutomations, h.ring.Active(),
+		"Tab advances the ring off the pane rather than swallowing the keystroke")
+	assert.NotContains(t, h.View(), "PREVIEW")
 }
 
 func TestPanePreviewEnterBlocksUncommittableTargets(t *testing.T) {

--- a/app/switch_project_test.go
+++ b/app/switch_project_test.go
@@ -212,10 +212,11 @@ func TestSwitchProjectWithArchivedSection(t *testing.T) {
 	// Repo A: a live session plus an archived one, with the archived folder
 	// expanded and the cursor driven into it.
 	h.store.AddInstance(newSnapshotTestInstance(t, "repoA-live"))
-	h.store.AddInstance(archiveActionInstance(t, "repoA-archived", session.Archived))
+	archivedA := archiveActionInstance(t, "repoA-archived", session.Archived)
+	h.store.AddInstance(archivedA)
 	h.sidebar.ExpandSection()
-	h.sidebar.JumpNextSection() // move toward the archived folder
-	_ = h.sidebar.String()      // exercises the archived render + auto-collapse path
+	h.sidebar.SelectInstance(archivedA) // drive the cursor into the archived folder
+	_ = h.sidebar.String()              // exercises the archived render + auto-collapse path
 	require.NotNil(t, findSidebarInstance(h, "repoA-archived"))
 
 	repoBRoot := t.TempDir()

--- a/ui/sidebar_nav.go
+++ b/ui/sidebar_nav.go
@@ -612,28 +612,6 @@ func (s *Sidebar) moveCursorToInstanceRow(instIdx int) {
 	}
 }
 
-// JumpNextSection jumps to the next section header.
-func (s *Sidebar) JumpNextSection() {
-	s.syncFromStore()
-	for i := s.selectedIdx + 1; i < len(s.visibleItems); i++ {
-		if s.visibleItems[i].IsHeader {
-			s.selectedIdx = i
-			return
-		}
-	}
-}
-
-// JumpPrevSection jumps to the previous section header.
-func (s *Sidebar) JumpPrevSection() {
-	s.syncFromStore()
-	for i := s.selectedIdx - 1; i >= 0; i-- {
-		if s.visibleItems[i].IsHeader {
-			s.selectedIdx = i
-			return
-		}
-	}
-}
-
 // GetSelectedInstance returns the instance under the cursor — including when
 // the cursor rests on one of its tab rows — or nil when the cursor rests on a
 // section header. Note this is the cursor-derived selection; the store's

--- a/ui/sidebar_test.go
+++ b/ui/sidebar_test.go
@@ -148,31 +148,6 @@ func TestSidebarToggleSection(t *testing.T) {
 	assert.True(t, s.sections[0].Expanded)
 }
 
-func TestSidebarJumpSections(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false, store.NewProjection())
-
-	inst, _ := session.NewInstance(session.InstanceOptions{
-		Title: "inst", Path: t.TempDir(), Program: "test",
-	})
-	addTestInstance(s, inst)
-
-	// Start on Instances header
-	sel := s.GetSelection()
-	assert.Equal(t, SectionInstances, sel.Kind)
-
-	// With Instances the only section (#1024 PR 4), the section-jump keys
-	// no-op forward and return the cursor to the header from a tab row.
-	s.JumpNextSection()
-	assert.Equal(t, sel, s.GetSelection(), "no next section to jump to")
-
-	s.Down() // onto the instance's Agent tab
-	s.JumpPrevSection()
-	sel = s.GetSelection()
-	assert.True(t, sel.IsHeader)
-	assert.Equal(t, SectionInstances, sel.Kind)
-}
-
 func TestSidebarCollapseFromChild(t *testing.T) {
 	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
 	s := NewSidebar(&spin, false, store.NewProjection())


### PR DESCRIPTION
Fixes the three TUI navigation/scroll findings from the daily play-test. All
three are a keystroke silently swallowed or a pane blanked in a specific
focus/pane state, but each has a **distinct root cause** — investigated together
because they cluster in the same pane/focus-ring subsystem and touch overlapping
files. One PR; they share the focus-ring/preview code and the regression-test
files.

Closes #1704
Closes #1705
Closes #1706

## Root causes & fixes

### #1705 — Shift+Tab does not cycle focus back from an embedded pane
`cycleFocus` early-returned after cancelling an active `panePreviewTxn`, so it
never advanced the ring. The idle preview tick creates a preview whenever the
tree cursor names a tab the owner pane isn't bound to, so reverse traversal out
of a pane was frequently dead — the keystroke was consumed cancelling the
preview and focus never moved (pre-fix it actually *dumped* focus onto the owner
pane). Now `cycleFocus` dismisses the preview with `cancelPanePreview(false)`
(anchoring the step on `ring.Active()`, not the preview owner) **and still steps
the ring**. The same swallow existed for forward Tab and is fixed by symmetry.
- `app/home_model.go` (`cycleFocus`)

### #1706 — `]` next-section is a silent no-op from an instance row
Automations and Projects moved out of the sidebar into their own Tab-focusable
**rail regions** (#1470/#1588/#1590); the sidebar now holds only Instances +
Archived. The old `JumpNextSection` walked sidebar section *headers*, so it could
never reach the rails — from an instance row `]` had nowhere to go. `]` / `[`
now step the **focus ring** across the section regions (tree → automations →
projects), skipping workspace panes, so `]` lands on Automations exactly as the
binding advertises and drops the instance-only `D kill`. The now-unused
`JumpNextSection`/`JumpPrevSection` are removed.
- `app/handle_actions.go`, `app/home_model.go` (`focusAdjacentSection`), `ui/sidebar_nav.go`

### #1704 — Ctrl+U blanks a live pane, Ctrl+D can't restore it
`panesRefresh` skips capture for a live pane (the WS attach already streams it).
But scroll mode stops rendering the live grid and shows the **capture viewport**,
which is empty until the off-loop scrollback fill runs — and the `HasLive()`
skip swallowed that one-shot fill, leaving the viewport permanently blank (the
data was never lost; a full-screen attach still showed it). The skip is now
gated on `!NeedsScrollFill()`, so the fill lands and subsequent scroll
keystrokes resume skipping capture.
- `app/home_panes.go` (`panesRefresh`)

## Regression assessment
- **#1704** and **#1706** are **regressions** from recent phase work — #1704
  from the live-panes-over-WS attach (#1627/#1089), #1706 from the
  automations/projects rail migration (#1470/#1588/#1590).
- **#1705** is **long-standing**, dating to the #1321 pane-preview transaction
  work (the preview-cancel early-return in `cycleFocus`).

## Reproduced before → after (playtest container)
Same driver script run against pre-fix `af` and the patched build:

| Check | Pre-fix (`master`) | Patched |
|---|---|---|
| #1706 `]` from instance row | ❌ `D kill` still in footer (cursor stuck) | ✅ leaves the instance row |
| #1705 Shift+Tab over a live preview | ❌ swallowed onto the owner pane | ✅ steps the ring off the tree |
| #1704 Ctrl+U / Ctrl+D scroll | ❌ pane blank | ✅ scrollback shown, restores |

Pre-fix: 3 failing. Patched: 4/4 green.

## Tests
Deterministic model-level regression tests (each fails on pre-fix source, passes
after):
- `TestPane_ShiftTabReverseTraversalDismissesLivePreview` + `TestPanePreviewTabDismissesAndAdvances` (#1705)
- `TestSectionNav_JumpsAcrossRailSections` + `TestSectionNav_SkipsWorkspacePanes` (#1706)
- `TestLivePaneScrollFillCapturesDespiteLiveSkip` (#1704)

`TestPanePreviewTabAndEscCancelToOwnerPane` was split: Esc still cancels to the
owner pane; Tab now dismisses **and** advances (the corrected #1705 contract).

## Gates
`go build ./...` · `gofmt -l` clean · `golangci-lint --fast` (0) · `deadcode -test` clean ·
file-length lint · `make tui-driver-selftest` **25/25** · `make test-container` **all green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)