### PR TITLE
docs+test(web): accurate post-Phase-5 doc cleanup + [/] view-cycle selftest coverage (supersedes #1710/#1712)

### DIFF
--- a/config/config_types.go
+++ b/config/config_types.go
@@ -181,7 +181,7 @@ type Config struct {
 	// CORSAllowedOrigins is the exact-match allow-list of browser origins
 	// permitted to call the API cross-origin (#1592 Phase 3, §1.5), e.g.
 	// ["https://af.example.com"]. Empty ⇒ no Access-Control-Allow-Origin is
-	// emitted, so no cross-origin browser can reach the API (the future web
+	// emitted, so no cross-origin browser can reach the API (the web
 	// client's only Phase-3 dependency). Non-browser clients (TUI/CLI, curl)
 	// are unaffected. Global-only, like listen_addr.
 	CORSAllowedOrigins []string `json:"cors_allowed_origins,omitempty" toml:"cors_allowed_origins,omitempty"`

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -61,7 +61,7 @@ anything. Do not proxy this socket to a network interface.
 
 !!! note "Reaching the daemon from another machine"
 
-    To drive the daemon from a **different host** — a remote TUI, or the future
+    To drive the daemon from a **different host** — a remote TUI, or the
     browser web client — don't proxy this socket. SSH to the host and run `af`
     there, or enable the opt-in TLS+token TCP listener. Both are covered in
     [Remote daemon access](remote-tcp-auth.md).

--- a/docs/remote-tcp-auth.md
+++ b/docs/remote-tcp-auth.md
@@ -7,8 +7,8 @@ port and no shared secret — anyone who can read the socket already runs as you
 user.
 
 Sometimes you want a client on **another machine** to drive that daemon: your
-laptop's TUI pointed at a workstation, a script on a build box, or (in the
-future) a browser web client. There are two ways to do that, and **they are not
+laptop's TUI pointed at a workstation, a script on a build box, or a browser
+web client. There are two ways to do that, and **they are not
 equal on security** — pick the first one unless you have a specific reason not
 to.
 

--- a/docs/web-selftest.md
+++ b/docs/web-selftest.md
@@ -41,7 +41,8 @@ Against the live SPA served over the daemon's TLS listener:
 | **Login** | Pasting the daemon token into the login form renders the authed app. |
 | **Sidebar** | The rail lists the seeded sessions from the Snapshot/events plane, and the live pip reads "Live". |
 | **Attach** | Click-to-attach opens the xterm terminal and shows the fake agent's live output (a real binary PTY frame decoded by the TS codec and painted in the browser). |
-| **Keyboard (#1694)** | In rail mode `j`/`k` navigate the rail; `Enter` attaches the selection; `Escape` returns to the rail. |
+| **Keyboard (#1694)** | In the sessions view's rail mode `j`/`k` navigate the rail; `Enter` attaches the selection; `Escape` returns to the rail. |
+| **View cycling (#1694/PR8)** | In rail mode `]` cycles the top-level view forward (sessions → projects → tasks) and `[` cycles it back (tasks → projects → sessions), the active view tab following each step. |
 | **Tabs (#1592 PR7)** | The tab bar creates a shell tab (`+` / `t`), switches to it (click / `1`-`9`) and shows its distinct PTY output, and closes it (`×` / `w`) — the agent tab stays unclosable. |
 | **Create** | The **+ New** modal creates a session and its row appears in the rail. |
 | **Kill** | The kill confirm removes the session's row. |

--- a/session/agentserver_remote.go
+++ b/session/agentserver_remote.go
@@ -118,8 +118,8 @@ func (s *remoteAgentServer) Expose() (StreamEndpoint, error) {
 	// from a TUI's perspective the stream is still reachable at the daemon's local
 	// path — the daemon relays. Returning Local=true keeps the daemon's stream
 	// handler on its proxy path and the TUI unchanged. The stream-info-returns-a-URL
-	// indirection (a browser dialing the sandbox directly) is a Phase-5 concern that
-	// also needs the sandbox token handed to the browser; PR2 does not flip it.
+	// indirection (a browser dialing the sandbox directly) is not implemented —
+	// browsers proxy through the daemon instead.
 	return StreamEndpoint{Local: true}, nil
 }
 

--- a/session/ptystream.go
+++ b/session/ptystream.go
@@ -14,9 +14,13 @@ import (
 // it by running attach_cmd/terminal_cmd under a PTY; the local runtime's tmux
 // client attach is its own PTYStream-shaped equivalent (kept behind tmux's
 // server-mediated detach semantics for now, see TmuxSession.Attach). This is the
-// seam a future agent-server / web client (Phase 2) reads and writes over a
-// WebSocket instead of local stdio — the transport changes, the primitive does
-// not.
+// LOCAL full-screen attach seam (Backend.AttachTerminal): the driver copies it
+// over the local process's stdio. The browser web client does NOT read or write
+// over this interface — it gets its terminal from the daemon's WebSocket PTY
+// broker (daemon/ws_pty.go), which fans the agent-server's ring buffer of raw
+// PTY bytes to WS subscribers and applies their input/resize back
+// (AgentServer.Subscribe/Input/Resize). Same idea — a byte stream plus resize —
+// over a different seam and transport.
 type PTYStream interface {
 	io.ReadWriteCloser
 

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -142,6 +142,28 @@ test("the #1694 keyboard model: j/k navigate, Enter attaches, Escape returns to 
   await expect(page.locator(".af-app.af-kb-rail")).toBeVisible();
 });
 
+test("the #1694 keyboard model: [ / ] cycle the top-level view (PR8)", async () => {
+  // Rail mode from the previous flow. [ / ] cycle the top-level view; they fire in
+  // rail mode only (a modal or focused terminal would swallow them). After Escape
+  // the active element is document.body, so the document-level capture-phase keydown
+  // listener (index.ts) handles the press.
+  const active = (view: string) =>
+    expect(page.locator(`.af-viewtab[data-view="${view}"]`)).toHaveClass(/af-viewtab-active/);
+  await active("sessions");
+  // ] steps forward through the cycle: sessions -> projects -> tasks.
+  await page.keyboard.press("]");
+  await active("projects");
+  await page.keyboard.press("]");
+  await active("tasks");
+  // [ steps back: tasks -> projects -> sessions, returning to the start view so the
+  // following rail-driven flows still see the sessions rail.
+  await page.keyboard.press("[");
+  await active("projects");
+  await page.keyboard.press("[");
+  await active("sessions");
+  await expect(page.locator(".af-rail-list")).toBeVisible();
+});
+
 test("tabs: create a shell tab, switch to it, see its distinct output, close it (#1592 PR7)", async () => {
   // Capture the tab-mutation request bodies so we can assert they carry the stable
   // session id (#1592 PR7 fix 1 — the daemon must resolve by id, not the cross-repo


### PR DESCRIPTION
Redoes two closed Detail-bot doc PRs correctly. Both #1710 and #1712 were closed because the mechanical bot got architecture/coverage details wrong. This is one consolidated, accuracy-corrected PR.

## 1. `session/ptystream.go` docstring — fix the misattribution (the reason #1712 was closed)

The old comment claimed PTYStream is "the seam a future agent-server / web client (Phase 2) reads and writes over a WebSocket". **That is wrong.** PTYStream is the **LOCAL** full-screen attach seam — its only real consumers are `Backend.AttachTerminal` (local shell tabs) and the remote-hook runtime's `attach_cmd`/`terminal_cmd`. `grep -rn "PTYStream"` shows no agent-server/daemon-WS code reads or writes this interface.

The docstring now correctly attributes the browser web terminal to the **daemon's WebSocket PTY broker** (`daemon/ws_pty.go`), which fans the **agent-server's ring buffer of raw PTY bytes** to WS subscribers and applies their input/resize back via `AgentServer.Subscribe`/`Input`/`Resize` — a separate seam and transport from `PTYStream`. (`daemon/ws_pty.go`'s `servePTYStream` is a differently-named broker function, not this interface.)

## 2. `[ / ]` view-cycle selftest coverage — make the doc honest (the reason #1710 was closed)

#1710 added a doc claim that the selftest covers `[ / ]` view cycling, but `web/selftest/web-driver.spec.ts` never pressed those keys. Instead of a doc note saying it's *not* exercised, this adds a **real Playwright assertion**: a new test presses `]` to cycle sessions → projects → tasks and `[` to reverse, asserting the active `.af-viewtab` follows each step. It's inserted after the `j/k` keyboard test (sessions view, rail mode) and ends back on the sessions view so the following rail-driven flows still see the rail.

`docs/web-selftest.md`'s "What it asserts" table gains a **View cycling** row describing exactly what the new test does, and keeps #1710's accurate tweak scoping the `j`/`k` Keyboard row to the sessions view's rail mode.

## 3. Four accurate stale "future web client" removals (the correct parts of #1712)

The web client shipped (#1592 Phase 5, #1702, v1.0.182), so these are now stale — comment/doc-only, zero behavior change:

- `config/config_types.go` — `the future web client's only Phase-3 dependency` → `the web client's only Phase-3 dependency`
- `docs/http-api.md` — `a remote TUI, or the future browser web client` → `...the browser web client`
- `docs/remote-tcp-auth.md` — `...or (in the future) a browser web client.` → `...or a browser web client.`
- `session/agentserver_remote.go` `Expose()` — the "Phase-5 concern" line → an accurate statement that direct-dial is **not implemented** and browsers proxy through the daemon (confirmed: `Expose()` still returns `StreamEndpoint{Local: true}`, i.e. the daemon relays).

## Gates (all green)

- `make web-selftest-container` — **12 passed** (incl. the new `[ / ]` view-cycle test)
- `make web-test` — 68/68 pass
- `make tui-driver-selftest` — **25/25** green
- `go build ./...` — ok
- `gofmt -l .` — no output
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — no output
- `make docs` (gen-docs) — no drift

No behavior changes; docs/comments/test only.

Supersedes #1710, #1712.

🤖 Generated with [Claude Code](https://claude.com/claude-code)