### PR TITLE
fix(tmux): dismiss reworded Claude Code folder-trust prompt

### DIFF
--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -270,6 +270,16 @@ func (t *TmuxSession) Start(workDir string) error {
 	return nil
 }
 
+// claudeTrustPromptPresent reports whether captured pane content shows a
+// folder-trust or MCP-server prompt that a single Enter keystroke dismisses.
+// Several phrasings of the folder-trust question are matched so the prompt is
+// dismissed across the Claude Code versions af users run.
+func claudeTrustPromptPresent(content string) bool {
+	return strings.Contains(content, "Is this a project you created or one you trust") ||
+		strings.Contains(content, "Do you trust the files in this folder?") ||
+		strings.Contains(content, "new MCP server")
+}
+
 // CheckAndHandleTrustPrompt checks the pane content once for a trust prompt and dismisses it if found.
 // Returns true if the prompt was found and handled.
 func (t *TmuxSession) CheckAndHandleTrustPrompt() bool {
@@ -279,8 +289,7 @@ func (t *TmuxSession) CheckAndHandleTrustPrompt() bool {
 	}
 
 	if strings.Contains(t.program, ProgramClaude) {
-		if strings.Contains(content, "Do you trust the files in this folder?") ||
-			strings.Contains(content, "new MCP server") {
+		if claudeTrustPromptPresent(content) {
 			if err := t.TapEnter(); err != nil {
 				log.ErrorLog.Printf("could not tap enter on trust/MCP screen: %v", err)
 				return false

--- a/session/tmux/tmux_test.go
+++ b/session/tmux/tmux_test.go
@@ -454,3 +454,44 @@ func TestSetDetachedSizeReturnsErrSessionGoneWhenPtmxNil(t *testing.T) {
 	err := session.SetDetachedSize(80, 24)
 	require.ErrorIs(t, err, ErrSessionGone)
 }
+
+func TestClaudeTrustPromptPresent(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name: "current folder-trust wording",
+			content: " Quick safety check: Is this a project you created or one you trust? (Like your\n" +
+				" own code, a well-known open source project, or work from your team).\n" +
+				" ❯ 1. Yes, I trust this folder\n   2. No, exit\n Enter to confirm · Esc to cancel",
+			want: true,
+		},
+		{
+			name:    "prior folder-trust wording",
+			content: "Do you trust the files in this folder?",
+			want:    true,
+		},
+		{
+			name:    "mcp server prompt",
+			content: "New MCP server found. Do you trust this new MCP server?",
+			want:    true,
+		},
+		{
+			name:    "normal claude ui with input box",
+			content: " ▐▛███▜▌   Claude Code v2.1.207\n❯ \n  ⏵⏵ bypass permissions on (shift+tab to cycle)",
+			want:    false,
+		},
+		{
+			name:    "empty",
+			content: "",
+			want:    false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, claudeTrustPromptPresent(tc.content))
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Brand-new `af` sessions render a blank/empty pane with no input prompt — both in the preview and when attached.

**Root cause:** Every new session launches Claude in a fresh git worktree, an untrusted directory where Claude Code shows a folder-trust gate that `--dangerously-skip-permissions` does **not** bypass:

```
 Quick safety check: Is this a project you created or one you trust?
 ❯ 1. Yes, I trust this folder
   2. No, exit
 Enter to confirm · Esc to cancel
```

`TmuxSession.CheckAndHandleTrustPrompt` (`session/tmux/tmux.go`) auto-dismisses trust prompts, but the Claude branch matched only the string `"Do you trust the files in this folder?"`. Claude Code reworded the dialog to `"Is this a project you created or one you trust?"`, so the match failed, `af` never tapped Enter, and the session sat on the trust screen forever. The preview bottom-truncates to the newest lines (#649), so the empty tail of the dialog read as a blank pane.

Existing sessions were unaffected because their directories were already in Claude's trusted-folders list — the regression only bit fresh worktrees, making it look intermittent.

## Fix

- Extract the match into a pure `claudeTrustPromptPresent` helper matching the current wording, the prior wording, and the existing `"new MCP server"` prompt. Keeping the prior wording preserves auto-dismiss for users on older Claude Code versions.
- Add a unit test fed the real captured trust text (plus old wording, MCP prompt, and negatives) so future rewording is caught in CI rather than as a silent runtime regression.

The dismiss action itself is unchanged: `runMetadataTick` already calls `CheckAndHandleTrustPrompt` every 500ms and `TapEnter` writes `\r` — verified in a live tmux repro that Enter clears the new prompt and reveals the input box.

## Verification

- `go test ./session/tmux/` — new `TestClaudeTrustPromptPresent` passes.
- `go build ./...`, `gofmt -l .` clean.
- Live repro: fresh untrusted dir + `af`'s exact launch flags → trust prompt → Enter dismisses → `❯` input box appears.

Co-authored-by: Captain Claude <noreply@anthropic.com>