### PR TITLE
fix(tmux): dismiss the reworded Claude Code folder-trust prompt (#1714)

### DIFF
--- a/session/tmux/start.go
+++ b/session/tmux/start.go
@@ -99,6 +99,19 @@ func (t *TmuxSession) Start(workDir string) error {
 	return nil
 }
 
+// claudeTrustPromptPresent reports whether captured pane content shows a
+// folder-trust or MCP-server prompt that a single Enter keystroke dismisses.
+// Several phrasings of the folder-trust question are matched so the prompt is
+// dismissed across the Claude Code versions af users run: Claude Code reworded
+// the dialog from "Do you trust the files in this folder?" to "Is this a
+// project you created or one you trust?" (#1714), which the old single-string
+// match missed, leaving fresh worktrees hung on the trust screen.
+func claudeTrustPromptPresent(content string) bool {
+	return strings.Contains(content, "Is this a project you created or one you trust") ||
+		strings.Contains(content, "Do you trust the files in this folder?") ||
+		strings.Contains(content, "new MCP server")
+}
+
 // CheckAndHandleTrustPrompt checks the pane content once for a trust prompt and dismisses it if found.
 // Returns true if the prompt was found and handled.
 func (t *TmuxSession) CheckAndHandleTrustPrompt() bool {
@@ -111,8 +124,7 @@ func (t *TmuxSession) CheckAndHandleTrustPrompt() bool {
 	// substring check would route e.g. /opt/claude-wrapper/run through the
 	// claude branch (#1116 defect class).
 	if DetectAgentFromCommand(t.programCmd()) == ProgramClaude {
-		if strings.Contains(content, "Do you trust the files in this folder?") ||
-			strings.Contains(content, "new MCP server") {
+		if claudeTrustPromptPresent(content) {
 			if err := t.TapEnter(); err != nil {
 				log.ErrorLog.Printf("could not tap enter on trust/MCP screen: %v", err)
 				return false

--- a/session/tmux/start.go
+++ b/session/tmux/start.go
@@ -106,8 +106,17 @@ func (t *TmuxSession) Start(workDir string) error {
 // the dialog from "Do you trust the files in this folder?" to "Is this a
 // project you created or one you trust?" (#1714), which the old single-string
 // match missed, leaving fresh worktrees hung on the trust screen.
+//
+// The reworded phrase is natural language that could appear in ordinary agent
+// output, so — unlike the older, more distinctive strings — it is anchored to a
+// marker the dialog always renders ("❯ 1. Yes, I trust this folder" / "Enter to
+// confirm"). Requiring co-occurrence keeps a stray mention of the phrase from
+// firing a spurious Enter onto whatever is in the pane.
 func claudeTrustPromptPresent(content string) bool {
-	return strings.Contains(content, "Is this a project you created or one you trust") ||
+	rewordedDialog := strings.Contains(content, "Is this a project you created or one you trust") &&
+		(strings.Contains(content, "Yes, I trust this folder") ||
+			strings.Contains(content, "Enter to confirm"))
+	return rewordedDialog ||
 		strings.Contains(content, "Do you trust the files in this folder?") ||
 		strings.Contains(content, "new MCP server")
 }

--- a/session/tmux/start_test.go
+++ b/session/tmux/start_test.go
@@ -40,6 +40,15 @@ func TestClaudeTrustPromptPresent(t *testing.T) {
 			want:    false,
 		},
 		{
+			// The reworded phrase is natural language; seeing it in ordinary agent
+			// output (no dialog markers) must NOT fire a dismissal Enter (#1714 /
+			// #1715 Greptile). Only the real dialog, which co-renders a marker,
+			// dismisses.
+			name:    "reworded phrase in ordinary output without dialog markers",
+			content: "Summary: the gate asks \"Is this a project you created or one you trust\" and then waits.\n❯ ",
+			want:    false,
+		},
+		{
 			name:    "empty",
 			content: "",
 			want:    false,

--- a/session/tmux/start_test.go
+++ b/session/tmux/start_test.go
@@ -1,0 +1,53 @@
+package tmux
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// claudeTrustPromptPresent must recognize every folder-trust / MCP phrasing af
+// dismisses, across Claude Code versions, without firing on the normal input
+// UI. The reworded dialog ("Is this a project you created or one you trust?")
+// is the #1714 regression: matching only the prior wording left fresh worktrees
+// hung on the trust screen, rendering a blank pane.
+func TestClaudeTrustPromptPresent(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name: "current folder-trust wording",
+			content: " Quick safety check: Is this a project you created or one you trust? (Like your\n" +
+				" own code, a well-known open source project, or work from your team).\n" +
+				" ❯ 1. Yes, I trust this folder\n   2. No, exit\n Enter to confirm · Esc to cancel",
+			want: true,
+		},
+		{
+			name:    "prior folder-trust wording",
+			content: "Do you trust the files in this folder?",
+			want:    true,
+		},
+		{
+			name:    "mcp server prompt",
+			content: "New MCP server found. Do you trust this new MCP server?",
+			want:    true,
+		},
+		{
+			name:    "normal claude ui with input box",
+			content: " ▐▛███▜▌   Claude Code v2.1.207\n❯ \n  ⏵⏵ bypass permissions on (shift+tab to cycle)",
+			want:    false,
+		},
+		{
+			name:    "empty",
+			content: "",
+			want:    false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, claudeTrustPromptPresent(tc.content))
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Brand-new `af` sessions render a blank pane with no input prompt. Every session launches Claude in a fresh git worktree — an untrusted directory where Claude Code shows a folder-trust gate that `--dangerously-skip-permissions` does **not** bypass. Claude Code reworded that dialog to:

```
 Quick safety check: Is this a project you created or one you trust?
 ❯ 1. Yes, I trust this folder
   2. No, exit
 Enter to confirm · Esc to cancel
```

The auto-dismissal in `TmuxSession.CheckAndHandleTrustPrompt` (`session/tmux/start.go`) only matched the old `"Do you trust the files in this folder?"` string, so the new wording was never dismissed, `af` never tapped Enter, and the session sat on the trust screen forever. The preview bottom-truncates to the newest lines (#649), so the empty tail of the dialog read as a blank pane. Existing sessions were unaffected (their worktrees were already trusted), which made it look intermittent.

## Fix

- Extract `claudeTrustPromptPresent`, matching the current wording, the prior wording, and the existing `"new MCP server"` prompt, and call it at the dismissal site. Additive — keeping the prior wording preserves auto-dismiss for users on older Claude Code versions.
- Add a table test fed the real captured trust text (plus old wording, MCP prompt, and a normal-input-box negative) so future rewording is caught in CI rather than as a silent runtime regression.

The dismiss action itself is unchanged: the daemon status poll calls `CheckAndHandleTrustPrompt` and `TapEnter` writes `\r`.

## Attribution

Re-implements #1714 by @pradeepiyer on current `master`. The original PR's base predated the #1379 tmux decomposition, so it patched the now-removed `session/tmux/tmux.go`; the dismissal code now lives in `session/tmux/start.go` and the helper/test are ported there.

## Verification

- `go build ./...`, `gofmt -l`, `golangci-lint run --fast`, `deadcode -test ./...` — all clean.
- `make test-container` — full suite green (incl. `session/tmux`).
- `make tui-driver-selftest` — 25/25 (exercises create-instance → the dismissal path).

Co-authored-by: pradeepiyer <pradeepiyer@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)