### PR TITLE
feat(session): allow reusing an archived session's name (auto-rename the archived one)

### DIFF
--- a/daemon/create_reuse_archived_test.go
+++ b/daemon/create_reuse_archived_test.go
@@ -1,0 +1,160 @@
+package daemon
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/session"
+	sessiongit "github.com/sachiniyer/agent-factory/session/git"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedArchivedSession builds a real linked worktree (dir/branch derived from the
+// git-safe slug, so a title carrying spaces/parens still gets a valid branch),
+// registers a started instance for it in the manager and on disk, then archives
+// it. The instance ends inert (LiveArchived) with its worktree relocated to the
+// title-keyed archive dir — the precondition for the reuse-archived-name tests.
+// Returns the archived instance and the stable id it was minted with.
+func seedArchivedSession(t *testing.T, m *Manager, repoID, repoPath, title, slug string) (*session.Instance, string) {
+	t.Helper()
+	wtPath := filepath.Join(filepath.Dir(repoPath), "wt-"+slug)
+	branch := "af/" + slug
+	out, err := exec.Command("git", "-C", repoPath, "worktree", "add", "-b", branch, wtPath).CombinedOutput()
+	require.NoError(t, err, string(out))
+	require.NoError(t, os.WriteFile(filepath.Join(wtPath, "dirty.txt"), []byte("uncommitted-"+slug), 0644))
+
+	gw, err := sessiongit.NewGitWorktreeFromStorage(repoPath, wtPath, title, branch, "", false, true)
+	require.NoError(t, err)
+
+	inst, err := session.NewInstance(session.InstanceOptions{Title: title, Path: repoPath, Program: "claude"})
+	require.NoError(t, err)
+	inst.SetBackend(&recoverFakeBackend{FakeBackend: session.NewFakeBackend()})
+	inst.SetGitWorktreeForTest(gw)
+	inst.SetStartedForTest(true)
+	inst.SetStatusForTest(session.Ready)
+	id := inst.ID
+
+	// appendInstanceData (not seedDiskInstance) so multiple seeded sessions
+	// accumulate on disk instead of clobbering one another.
+	require.NoError(t, appendInstanceData(repoID, session.InstanceData{ID: id, Title: title, Path: repoPath, Status: session.Ready}))
+	m.mu.Lock()
+	m.instances[daemonInstanceKey(repoID, title)] = inst
+	m.mu.Unlock()
+
+	_, _, err = m.ArchiveSession(ArchiveSessionRequest{Title: title, RepoID: repoID})
+	require.NoError(t, err)
+	require.Equal(t, session.Archived, inst.GetStatus())
+	return inst, id
+}
+
+// TestReserveCreate_ReusesArchivedName is the headline case (feat: reuse archived
+// name): archive "foo", then create a NEW "foo" — the create succeeds and the old
+// archived session is renamed to "foo (archived)", keyed and persisted under the
+// new name, its worktree relocated to the new title-keyed archive dir, and still
+// fully restorable (same worktree contents, branch, and stable id).
+func TestReserveCreate_ReusesArchivedName(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	archived, id := seedArchivedSession(t, manager, repoID, repoPath, "foo", "foo")
+	branch := archived.GetBranch()
+
+	_, title, release, renamed, err := manager.reserveCreate(CreateSessionRequest{RepoPath: repoPath, Title: "foo", Program: "claude"})
+	require.NoError(t, err, "creating a new session must succeed when only an archived session holds the name")
+	defer release()
+
+	assert.Equal(t, "foo", title, "the new session takes the freed title verbatim")
+	require.NotNil(t, renamed, "the collision must have renamed the archived session")
+	assert.Equal(t, "foo (archived)", renamed.Title)
+
+	// The archived instance now carries the disambiguated name, re-keyed in the map.
+	assert.Equal(t, "foo (archived)", archived.Title)
+	manager.mu.Lock()
+	_, oldKeyed := manager.instances[daemonInstanceKey(repoID, "foo")]
+	renamedInst, newKeyed := manager.instances[daemonInstanceKey(repoID, "foo (archived)")]
+	manager.mu.Unlock()
+	assert.False(t, oldKeyed, "the archived row must no longer be keyed under the freed name")
+	require.True(t, newKeyed, "the archived row must be keyed under its new name")
+	assert.Same(t, archived, renamedInst, "re-keying preserves the same instance object (stable id)")
+
+	// The archived worktree moved to the new title-keyed archive dir; the old one is gone.
+	oldDir, _ := archivedWorktreePath(repoID, "foo")
+	newDir, _ := archivedWorktreePath(repoID, "foo (archived)")
+	assert.False(t, exists(oldDir), "the pre-rename archive dir must be vacated")
+	assert.True(t, exists(newDir), "the archived worktree must live at the new title-keyed dir")
+
+	// Disk reflects the rename: the old title is gone, the new one carries the
+	// relocated worktree path and the preserved stable id + branch.
+	assert.Nil(t, recordFor(t, repoID, "foo"), "no on-disk record must survive under the freed name")
+	rec := recordFor(t, repoID, "foo (archived)")
+	require.NotNil(t, rec, "the archived record must be persisted under the new name")
+	assert.Equal(t, id, rec.ID, "the stable id must be preserved across the rename")
+	assert.Equal(t, branch, rec.Branch, "the git branch must be preserved across the rename")
+	assert.Equal(t, newDir, rec.Worktree.WorktreePath)
+	assert.Equal(t, session.Archived, rec.Status)
+
+	// The renamed archive is still restorable and brings the original worktree back.
+	restorePath, rerr := manager.RestoreArchived(RestoreArchivedRequest{Title: "foo (archived)", RepoID: repoID})
+	require.NoError(t, rerr, "the renamed archived session must still restore")
+	dirty, drr := os.ReadFile(filepath.Join(restorePath, "dirty.txt"))
+	require.NoError(t, drr, "the original worktree contents must come back on restore")
+	assert.Equal(t, "uncommitted-foo", string(dirty))
+	assert.Equal(t, branch, archived.GetBranch(), "restore preserves the original branch")
+	assert.Equal(t, id, archived.ID, "restore preserves the original stable id")
+}
+
+// TestReserveCreate_ReusesArchivedName_SuffixCollision: with BOTH archived "foo"
+// and archived "foo (archived)" already present, creating a new "foo" renames the
+// old archived "foo" to the next free slot, "foo (archived 2)".
+func TestReserveCreate_ReusesArchivedName_SuffixCollision(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	seedArchivedSession(t, manager, repoID, repoPath, "foo", "foo")
+	seedArchivedSession(t, manager, repoID, repoPath, "foo (archived)", "foo-archived")
+
+	_, title, release, renamed, err := manager.reserveCreate(CreateSessionRequest{RepoPath: repoPath, Title: "foo", Program: "claude"})
+	require.NoError(t, err)
+	defer release()
+
+	assert.Equal(t, "foo", title)
+	require.NotNil(t, renamed)
+	assert.Equal(t, "foo (archived 2)", renamed.Title, "the first suffix is taken, so the rename skips to (archived 2)")
+
+	manager.mu.Lock()
+	_, keyed := manager.instances[daemonInstanceKey(repoID, "foo (archived 2)")]
+	manager.mu.Unlock()
+	assert.True(t, keyed, "the archived row must be keyed under the disambiguated name")
+	assert.NotNil(t, recordFor(t, repoID, "foo (archived)"), "the pre-existing archived (archived) row must be untouched")
+	assert.NotNil(t, recordFor(t, repoID, "foo (archived 2)"))
+}
+
+// TestReserveCreate_LiveNameStillBlocks: a LIVE (non-archived) "foo" still blocks
+// an explicit new "foo" — the reuse-archived rename must NOT fire around a name a
+// live session holds.
+func TestReserveCreate_LiveNameStillBlocks(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	// A live, non-archived session holding "foo".
+	registerArchivable(t, manager, repoID, repoPath, "foo") // status Ready
+
+	_, _, _, renamed, err := manager.reserveCreate(CreateSessionRequest{RepoPath: repoPath, Title: "foo", Program: "claude"})
+	require.Error(t, err, "a live session must still block an explicit same-named create")
+	assert.Contains(t, err.Error(), "already exists")
+	assert.Nil(t, renamed, "no archived rename may happen around a live collision")
+}
+
+// TestReserveCreate_TitleBaseStillAutoSuffixes: the derived-title (title_base)
+// path is unchanged — it auto-suffixes around an existing session (live OR
+// archived) rather than renaming it.
+func TestReserveCreate_TitleBaseStillAutoSuffixes(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	seedArchivedSession(t, manager, repoID, repoPath, "foo", "foo")
+
+	_, title, release, renamed, err := manager.reserveCreate(CreateSessionRequest{RepoPath: repoPath, TitleBase: "foo", Program: "claude"})
+	require.NoError(t, err)
+	defer release()
+
+	assert.Equal(t, "foo-2", title, "title_base auto-suffixes around the archived name instead of reusing it")
+	assert.Nil(t, renamed, "title_base must never trigger the archived rename")
+	assert.NotNil(t, recordFor(t, repoID, "foo"), "the archived session keeps its original name under the title_base path")
+}

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/sachiniyer/agent-factory/agentproto"
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/git"
 	"github.com/sachiniyer/agent-factory/session/tmux"
@@ -27,11 +29,20 @@ func (m *Manager) CreateSession(req CreateSessionRequest) (session.InstanceData,
 			}
 		}
 	}
-	repo, title, release, err := m.reserveCreate(req)
+	repo, title, release, renamedArchived, err := m.reserveCreate(req)
 	if err != nil {
 		return session.InstanceData{}, err
 	}
 	defer release()
+
+	// reserveCreate may have renamed a colliding archived session to free this
+	// title (feat: reuse archived name). Publish its new name onto the events plane
+	// so the TUI + web rail relabel the archived row (it stays selectable/restorable
+	// under the new title). Done after reserveCreate released m.mu so the fan-out
+	// never runs under the manager lock.
+	if renamedArchived != nil {
+		m.publishEvent(agentproto.EventSessionUpdated, *renamedArchived)
+	}
 
 	repoStartLock := m.startLockForRepo(repo.ID)
 	repoStartLock.Lock()
@@ -89,38 +100,52 @@ func (m *Manager) CreateSession(req CreateSessionRequest) (session.InstanceData,
 	return data, nil
 }
 
-func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, string, func(), error) {
+func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, string, func(), *session.InstanceData, error) {
 	if req.RepoPath == "" {
-		return nil, "", nil, fmt.Errorf("repo path is required")
+		return nil, "", nil, nil, fmt.Errorf("repo path is required")
 	}
 	repo, err := config.RepoFromPath(req.RepoPath)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, "", nil, nil, err
 	}
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if err := m.refreshLocked(); err != nil {
-		return nil, "", nil, err
+		return nil, "", nil, nil, err
 	}
 
 	diskData, err := loadRepoInstanceData(repo.ID)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, "", nil, nil, err
 	}
 
+	var renamedArchived *session.InstanceData
 	title := req.Title
 	if title == "" {
 		base := req.TitleBase
 		if base == "" {
-			return nil, "", nil, fmt.Errorf("session title is required")
+			return nil, "", nil, nil, fmt.Errorf("session title is required")
 		}
+		// A derived title_base keeps auto-suffixing around every existing session,
+		// archived rows included — the archived-name-reuse rename is reserved for an
+		// EXPLICIT title the caller asked for by name (below).
 		title, err = m.nextAvailableTitleLocked(repo.ID, repo.Root, base, req.Program, req.ForceRemote, diskData)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, "", nil, nil, err
 		}
-	} else if err := m.validateTitleAvailableLocked(repo.ID, repo.Root, title, req.Program, req.ForceRemote, req.allowReserved, diskData); err != nil {
-		return nil, "", nil, err
+	} else {
+		// When the requested title is held ONLY by an archived session, rename that
+		// archived session out of the way so the new session can take the name
+		// (feat: reuse archived name). A LIVE collision is left untouched, so
+		// validateTitleAvailableLocked below still rejects it exactly as before.
+		renamedArchived, err = m.renameArchivedForReuseLocked(repo.ID, repo.Root, title, req.Program, &diskData)
+		if err != nil {
+			return nil, "", nil, nil, err
+		}
+		if err := m.validateTitleAvailableLocked(repo.ID, repo.Root, title, req.Program, req.ForceRemote, req.allowReserved, diskData); err != nil {
+			return nil, "", nil, nil, err
+		}
 	}
 
 	key := daemonInstanceKey(repo.ID, title)
@@ -128,7 +153,7 @@ func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, 
 	if req.ForceRemote {
 		remoteName = session.Slugify(title)
 		if _, ok := m.reservedRemoteNames[remoteName]; ok {
-			return nil, "", nil, fmt.Errorf("remote hook name %q is already reserved", remoteName)
+			return nil, "", nil, nil, fmt.Errorf("remote hook name %q is already reserved", remoteName)
 		}
 	}
 
@@ -145,7 +170,124 @@ func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, 
 		}
 	}
 
-	return repo, title, release, nil
+	return repo, title, release, renamedArchived, nil
+}
+
+// renameArchivedForReuseLocked frees `title` for a new session when the ONLY thing
+// holding it is an archived session, by renaming that archived session to a
+// disambiguated "<title> (archived[ N])" (feat: reuse archived name). It returns
+// the renamed archived session's data (for a session.updated event) or nil when no
+// rename happened — no archived collision, or a LIVE/reserved session also holds
+// the name, in which case the create is left to fail in validateTitleAvailableLocked
+// exactly as before. Runs under m.mu.
+func (m *Manager) renameArchivedForReuseLocked(repoID, repoPath, title, program string, diskData *[]session.InstanceData) (*session.InstanceData, error) {
+	archived, oldKey := m.findArchivedOnlyCollisionLocked(repoID, title)
+	if archived == nil {
+		return nil, nil
+	}
+	oldTitle := archived.Title
+	newTitle, err := m.uniqueArchivedTitleLocked(repoID, repoPath, oldTitle, program, *diskData)
+	if err != nil {
+		return nil, err
+	}
+	newDest, err := archivedWorktreePath(repoID, newTitle)
+	if err != nil {
+		return nil, err
+	}
+	origDest, err := archivedWorktreePath(repoID, oldTitle)
+	if err != nil {
+		return nil, err
+	}
+
+	// Relocate the archived worktree + update the title atomically on the instance.
+	if err := archived.RenameArchived(newTitle, newDest); err != nil {
+		return nil, fmt.Errorf("cannot free the archived name %q for reuse: failed to relocate its worktree: %w", oldTitle, err)
+	}
+	// Re-key the manager map so the archived row is addressable under its new title.
+	newKey := daemonInstanceKey(repoID, newTitle)
+	delete(m.instances, oldKey)
+	m.instances[newKey] = archived
+
+	// Persist the rename durably. On failure, roll the worktree + in-memory identity
+	// back so disk and reality stay consistent (mirrors the archive commit rollback,
+	// #1538): otherwise the on-disk record would point at the pre-rename path that no
+	// longer exists, stranding the archive after a daemon restart.
+	renamed := archived.ToInstanceData()
+	if perr := renameInstanceDataTitle(repoID, oldTitle, renamed); perr != nil {
+		if rbErr := archived.RenameArchived(oldTitle, origDest); rbErr != nil {
+			// Could not move the worktree home: leave it re-keyed under the new title
+			// (the bytes live at newDest) and surface both failures so the operator can
+			// recover it. The new session create aborts.
+			m.persistInstance(repoID, archived)
+			return nil, fmt.Errorf("failed to durably rename archived session %q and could not roll it back (%v); it may need manual recovery: %w", oldTitle, rbErr, perr)
+		}
+		delete(m.instances, newKey)
+		m.instances[oldKey] = archived
+		return nil, fmt.Errorf("failed to durably rename archived session %q to free the name; rolled it back: %w", oldTitle, perr)
+	}
+
+	// Reflect the rename in the caller's diskData snapshot so the subsequent
+	// title-availability check for the NEW session no longer sees the old record.
+	for i := range *diskData {
+		if (*diskData)[i].Title == oldTitle {
+			(*diskData)[i] = renamed
+			break
+		}
+	}
+	log.InfoLog.Printf("renamed archived session %q -> %q (repo %s) to free the name for a new session", oldTitle, newTitle, repoID)
+	return &renamed, nil
+}
+
+// findArchivedOnlyCollisionLocked returns the archived instance whose title
+// collides with `title`, together with its manager-map key — but ONLY when nothing
+// else claims the name: no LIVE (non-archived) instance and no in-flight
+// reservation collide with it. A live or reserved collision returns nil, so the
+// archived-name-reuse rename never runs around a name a real session still holds.
+// Runs under m.mu.
+func (m *Manager) findArchivedOnlyCollisionLocked(repoID, title string) (*session.Instance, string) {
+	for key := range m.reservedTitles {
+		rid, existing := splitDaemonInstanceKey(key)
+		if rid == repoID && m.titlesCollide(existing, title) {
+			// A concurrent create is reserving a colliding name; let the
+			// availability check reject with errConcurrentCreate.
+			return nil, ""
+		}
+	}
+	var archived *session.Instance
+	var archivedKey string
+	for key, inst := range m.instances {
+		rid, _ := splitDaemonInstanceKey(key)
+		if rid != repoID || inst == nil {
+			continue
+		}
+		if !m.titlesCollide(inst.Title, title) {
+			continue
+		}
+		if inst.GetLiveness() != session.LiveArchived {
+			// A live session still holds the name — do not rename around it.
+			return nil, ""
+		}
+		archived = inst
+		archivedKey = key
+	}
+	return archived, archivedKey
+}
+
+// uniqueArchivedTitleLocked returns the first free disambiguated title for an
+// archived session being renamed out of the way: "<base> (archived)", then
+// "<base> (archived 2)", "(archived 3)", … skipping any that collide with an
+// existing live or archived session (feat: reuse archived name). Runs under m.mu.
+func (m *Manager) uniqueArchivedTitleLocked(repoID, repoPath, base, program string, diskData []session.InstanceData) (string, error) {
+	for i := 1; i <= 10000; i++ {
+		candidate := fmt.Sprintf("%s (archived)", base)
+		if i > 1 {
+			candidate = fmt.Sprintf("%s (archived %d)", base, i)
+		}
+		if err := m.validateTitleAvailableLocked(repoID, repoPath, candidate, program, false, false, diskData); err == nil {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("could not find an available archived name for %q", base)
 }
 
 func (m *Manager) nextAvailableTitleLocked(repoID, repoPath, baseTitle, program string, remote bool, diskData []session.InstanceData) (string, error) {

--- a/daemon/manager_persist.go
+++ b/daemon/manager_persist.go
@@ -77,6 +77,48 @@ func persistInstanceData(repoID string, data session.InstanceData) error {
 	return nil
 }
 
+// renameInstanceDataTitle rewrites the on-disk record currently stored under
+// oldTitle to newData, which carries the session's NEW title and relocated
+// worktree path (feat: reuse archived name). It matches the record by oldTitle and
+// — when both records carry one — the stable ID, so a title reused elsewhere can't
+// misdirect the rewrite. It refuses to proceed if newData.Title already names a
+// DIFFERENT record, keeping the rename from clobbering an unrelated session. Errors
+// when no record under oldTitle exists (the caller resolved a live archived
+// instance, so a missing disk record means storage drifted out from under us).
+func renameInstanceDataTitle(repoID, oldTitle string, newData session.InstanceData) error {
+	newData = newData.ForStorage()
+	found := false
+	if err := config.UpdateRepoInstances(repoID, func(raw json.RawMessage) (json.RawMessage, error) {
+		var existing []session.InstanceData
+		if err := json.Unmarshal(raw, &existing); err != nil {
+			return nil, fmt.Errorf("failed to parse existing instances: %w", err)
+		}
+		for i := range existing {
+			if existing[i].Title == newData.Title && !stableIDMatchesForDaemon(existing[i].ID, newData.ID) {
+				return nil, fmt.Errorf("cannot rename archived session to %q: another session already holds that title", newData.Title)
+			}
+		}
+		for i := range existing {
+			if existing[i].Title != oldTitle {
+				continue
+			}
+			if !stableIDMatchesForDaemon(existing[i].ID, newData.ID) {
+				continue
+			}
+			existing[i] = newData
+			found = true
+			return json.MarshalIndent(existing, "", "  ")
+		}
+		return raw, nil
+	}); err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf("archived instance %q not found in storage", oldTitle)
+	}
+	return nil
+}
+
 func loadRepoInstanceData(repoID string) ([]session.InstanceData, error) {
 	raw, err := config.LoadRepoInstances(repoID)
 	if err != nil {

--- a/session/instance_backend.go
+++ b/session/instance_backend.go
@@ -84,6 +84,39 @@ func (i *Instance) RestoreArchivedWorktree(dest string) error {
 	return gw.RestoreWorktreeTo(dest)
 }
 
+// RenameArchived atomically relocates an archived instance's worktree to dest (a
+// new title-keyed archive dir) and updates its Title, so a fresh session can reuse
+// the archived session's name (feat: reuse archived name). Both mutations happen
+// under i.mu so a concurrent Snapshot/ToInstanceData never observes a torn state
+// (new title paired with the old worktree path, or vice versa). Archived instances
+// are inert — no async Start/Recover goroutine touches them — so holding i.mu
+// across the git move only blocks a brief Snapshot RLock, never a live operation.
+//
+// The stable id, git branch, and worktree contents are preserved: only the on-disk
+// directory + git's two-way registration move, and only the display title changes.
+// On a relocation failure the worktree and title are left untouched and the error
+// is surfaced, so the caller can abort the reuse without having half-renamed the
+// archived session.
+func (i *Instance) RenameArchived(newTitle, dest string) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.liveness != LiveArchived {
+		return fmt.Errorf("cannot rename session %q: it is not archived", i.Title)
+	}
+	gw := i.gitWorktree
+	if gw == nil {
+		return fmt.Errorf("cannot rename archived session %q: it has no worktree to relocate", i.Title)
+	}
+	// MoveWorktree relocates the bytes + repairs git's registration and, on success,
+	// updates gw's stored worktree path — all under i.mu here, matching how
+	// ToInstanceData reads the worktree path under i.mu.RLock.
+	if err := gw.MoveWorktree(dest); err != nil {
+		return err
+	}
+	i.Title = newTitle
+	return nil
+}
+
 // RestoreFromArchive re-spawns an archived instance's agent after its worktree
 // has been moved back into place (#1028), flipping it live. It marks the
 // instance started + Lost so the Recover re-spawn path is eligible (the same


### PR DESCRIPTION
## What

Lets you **create a session with the same title as an archived session** in the same repo. Today that's rejected: an archived session stays in the manager map (and on disk) as an inert row that keeps its title, so `validateTitleAvailableLocked` treats it as a collision — even though nothing live holds the name.

## Behavior change (archived-collision → rename)

When a requested **explicit** title is held **only** by an archived session (no live session collides), `reserveCreate` renames that archived session out of the way, then lets the new session take the freed name:

- **Unique disambiguated title** — `"<title> (archived)"`, then `"(archived 2)"`, `"(archived 3)"`, … looping until one is free against every live *and* archived title.
- **Atomic relocate + retitle** — `Instance.RenameArchived` moves the archived worktree to the new title-keyed archive dir (`archived/<repoID>/<newTitle>/`) and updates the title under the instance lock, so a concurrent `Snapshot`/`ToInstanceData` never observes a torn (new-title / old-path) state.
- **Durable, roll-back-safe persist** — re-keys the manager map and rewrites the on-disk record (`renameInstanceDataTitle`). On a persist failure it moves the worktree home and reverts the identity, so disk and reality stay consistent (mirrors the #1538 archive-commit rollback).
- **Preserves** the archived session's stable id, git branch, worktree contents, and restorability — only the display title and archive dir move. `RestoreArchived` of the renamed session brings the original worktree/branch/id back.
- **Publishes `session.updated`** so the TUI + web rail relabel the archived row in place (the web reducer upserts by stable id, which the rename preserves).

## What's unchanged

- A **live** (non-archived) session still blocks an explicit same-named create.
- The derived **`title_base`** path still auto-suffixes around existing sessions (archived included) instead of renaming them — the rename is reserved for an explicit title the caller asked for by name.
- Cross-repo was already fine (the archive dir is namespaced per `repoID`).

## Tests

`daemon/create_reuse_archived_test.go`:
- archive `foo` → create new `foo` succeeds; old archived one becomes `foo (archived)`; `RestoreArchived` of `foo (archived)` brings back the original worktree/branch/id.
- suffix collision: archived `foo` **and** `foo (archived)` present → new `foo` renames the old to `foo (archived 2)`.
- a live `foo` still blocks an explicit new `foo`.
- `title_base` still auto-suffixes to `foo-2` around an archived `foo` (no rename).

## Gates

- `go build ./...`, `gofmt -l .`, `golangci-lint run --fast`, `deadcode -test ./...` — clean
- `make tui-driver-selftest` — 25/25
- `make test-container` — full suite green
- No CLI/API/doc surface changed, so no gen-docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)