### PR TITLE
fix(daemon,auth): serialize + atomic token generation/rotation (#1720, #1722)

### DIFF
--- a/daemon/tlsmaterial.go
+++ b/daemon/tlsmaterial.go
@@ -104,6 +104,15 @@ func ResolveTLSMaterial(dir, userCert, userKey string) (TLSMaterial, error) {
 // the pair to validate it and only reuse it when it pairs; otherwise we fall
 // through and regenerate a fresh matching pair (still under the lock).
 func ensureSelfSignedCert(certPath, keyPath string) error {
+	// Pre-create the AF home 0700 BEFORE taking the lock: config.WithFileLock's
+	// internal MkdirAll uses 0755 (it is shared by non-secret callers), and on a
+	// cert-first fresh run it would otherwise create the AF home world-readable
+	// before generateSelfSignedCert's own 0700 MkdirAll runs. The home holds
+	// secrets (daemon-tls.key is owner-only), so it must not be traversable by
+	// other local users. MkdirAll never loosens an existing dir.
+	if err := os.MkdirAll(filepath.Dir(certPath), 0o700); err != nil {
+		return fmt.Errorf("create tls directory: %w", err)
+	}
 	return config.WithFileLock(certPath, func() error {
 		_, certErr := os.Stat(certPath)
 		_, keyErr := os.Stat(keyPath)

--- a/daemon/tlsmaterial_test.go
+++ b/daemon/tlsmaterial_test.go
@@ -320,6 +320,29 @@ func TestEnsureSelfSignedCertRegeneratesMismatchedPair(t *testing.T) {
 	}
 }
 
+// TestResolveTLSMaterialCreatesHome0700 is the adjacent twin of
+// TestEnsureTokenCreatesHome0700: on a cert-first fresh run the AF home must be
+// created 0700 (daemon-tls.key is a secret). ensureSelfSignedCert routes
+// creation through config.WithFileLock (MkdirAll 0755), so it must pre-create
+// the parent 0700 before the lock. On the pre-follow-up head the parent was
+// 0755.
+func TestResolveTLSMaterialCreatesHome0700(t *testing.T) {
+	// Parent AF-home dir does NOT exist yet; ResolveTLSMaterial must create it.
+	home := filepath.Join(t.TempDir(), "af-home")
+
+	if _, err := ResolveTLSMaterial(home, "", ""); err != nil {
+		t.Fatalf("ResolveTLSMaterial: %v", err)
+	}
+
+	info, err := os.Stat(home)
+	if err != nil {
+		t.Fatalf("stat AF home: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o700 {
+		t.Fatalf("AF home perms after first-run cert generation = %o, want 0700", perm)
+	}
+}
+
 func TestCertFingerprintNonCert(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "notacert.pem")

--- a/daemon/token.go
+++ b/daemon/token.go
@@ -19,6 +19,27 @@ import (
 // `af token rotate` takes effect without a restart. The unix control socket
 // stays unauthenticated (filesystem 0600 perms are the local auth, #1029) and
 // never reads this token.
+//
+// Two concurrency guarantees mirror the TLS-material fix (#1690):
+//
+//   - Generation is serialized under an exclusive file lock (config.WithFileLock,
+//     the sibling daemon-token.lock). Before this, EnsureToken's LoadToken-miss →
+//     generateToken → writeToken sequence was a TOCTOU race (#1720): two callers
+//     (e.g. daemon startup and `af token show`) could both observe "no token" and
+//     both generate, racing to persist different tokens. The lock makes the
+//     first caller win and later callers observe its token, so every caller
+//     agrees.
+//   - The write is atomic (config.AtomicWriteFile: temp file + rename). Before
+//     this, writeToken used os.WriteFile (O_TRUNC), so a rotation left a window
+//     where the file was truncated-but-not-yet-rewritten. The withAuth gate
+//     re-reads the token per request (authorize → expectedToken → LoadToken), so
+//     a request landing in that window saw an empty file, LoadToken errored, and
+//     the gate failed closed => a spurious 401 (#1722). An atomic rename lets a
+//     reader observe only the whole old or whole new token, never a partial.
+//
+// Readers (the auth gate) deliberately do NOT take the lock: they do a plain
+// LoadToken so rotation stays live per request, and the atomic write is what
+// keeps that lock-free read from ever seeing a torn value.
 
 const (
 	// daemonTokenFileName is the bearer token file in the af home. 0600 —
@@ -50,20 +71,16 @@ func generateToken() (string, error) {
 	return base64.RawURLEncoding.EncodeToString(buf), nil
 }
 
-// writeToken persists tok to path with 0600 permissions, creating the parent
-// af home directory if needed. It writes then chmods so the mode is exactly
-// 0600 regardless of the process umask.
+// writeToken persists tok to path atomically with 0600 permissions, creating
+// the parent af home directory if needed. It writes to a temp file and renames
+// it into place (config.AtomicWriteFile), so a concurrent reader never observes
+// a truncated/empty token file mid-write (the #1722 rotation-401 window).
+// AtomicWriteFile applies perm exactly via tmp.Chmod, so the token lands 0600
+// regardless of the process umask, and it MkdirAll's the parent dir itself —
+// no separate MkdirAll/Chmod needed.
 func writeToken(path, tok string) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-		return fmt.Errorf("create token directory: %w", err)
-	}
-	if err := os.WriteFile(path, []byte(tok+"\n"), 0o600); err != nil {
+	if err := config.AtomicWriteFile(path, []byte(tok+"\n"), 0o600); err != nil {
 		return fmt.Errorf("write token: %w", err)
-	}
-	// WriteFile only applies the mode on create and masks it by the umask;
-	// force 0600 so a pre-existing file with looser perms is tightened too.
-	if err := os.Chmod(path, 0o600); err != nil {
-		return fmt.Errorf("chmod token: %w", err)
 	}
 	return nil
 }
@@ -85,40 +102,64 @@ func LoadToken(path string) (string, error) {
 }
 
 // EnsureToken returns the bearer token at path, generating and persisting one
-// (0600) if the file does not yet exist. It is idempotent: a second call
-// returns the same token. This is the generate-if-absent entry point behind
-// `af token show`, so the token exists before the TCP listener is ever
-// enabled.
+// (0600) if the file does not yet exist. It is idempotent even under concurrent
+// callers: the check-then-generate-then-write runs under an exclusive file lock
+// (config.WithFileLock), so two callers racing on a missing token (e.g. daemon
+// startup and `af token show`) can no longer both generate — the first inside
+// the lock writes it, the rest observe it and return the same value (#1720).
+// This is the generate-if-absent entry point behind `af token show`, so the
+// token exists before the TCP listener is ever enabled.
 func EnsureToken(path string) (string, error) {
-	if tok, err := LoadToken(path); err == nil {
-		return tok, nil
-	} else if !os.IsNotExist(err) {
-		return "", err
-	}
-	tok, err := generateToken()
+	var resolved string
+	err := config.WithFileLock(path, func() error {
+		if tok, err := LoadToken(path); err == nil {
+			resolved = tok
+			return nil
+		} else if !os.IsNotExist(err) {
+			return err
+		}
+		tok, err := generateToken()
+		if err != nil {
+			return err
+		}
+		if err := writeToken(path, tok); err != nil {
+			return err
+		}
+		resolved = tok
+		return nil
+	})
 	if err != nil {
 		return "", err
 	}
-	if err := writeToken(path, tok); err != nil {
-		return "", err
-	}
-	return tok, nil
+	return resolved, nil
 }
 
 // RotateToken generates a fresh bearer token, persists it (0600) over any
-// existing one, and returns it. Because the auth gate re-reads the token file
-// per auth event (§1.3), rotation takes effect for new connections
-// immediately without a daemon RPC; existing streams keep running until they
-// reconnect.
+// existing one, and returns it. The generate+write runs under the same
+// exclusive file lock as EnsureToken (config.WithFileLock) so a rotation
+// serializes against a concurrent first-time generation — the two can't
+// interleave and clobber each other (mirrors the cert template, #1690).
+// Because the auth gate re-reads the token file per auth event (§1.3) and the
+// write is atomic, rotation takes effect for new connections immediately
+// without a daemon RPC and no reader ever sees a partial token; existing
+// streams keep running until they reconnect.
 func RotateToken(path string) (string, error) {
-	tok, err := generateToken()
+	var resolved string
+	err := config.WithFileLock(path, func() error {
+		tok, err := generateToken()
+		if err != nil {
+			return err
+		}
+		if err := writeToken(path, tok); err != nil {
+			return err
+		}
+		resolved = tok
+		return nil
+	})
 	if err != nil {
 		return "", err
 	}
-	if err := writeToken(path, tok); err != nil {
-		return "", err
-	}
-	return tok, nil
+	return resolved, nil
 }
 
 // ConstantTimeEqual reports whether got equals want without leaking, through

--- a/daemon/token.go
+++ b/daemon/token.go
@@ -110,6 +110,15 @@ func LoadToken(path string) (string, error) {
 // This is the generate-if-absent entry point behind `af token show`, so the
 // token exists before the TCP listener is ever enabled.
 func EnsureToken(path string) (string, error) {
+	// Pre-create the AF home 0700 BEFORE taking the lock: config.WithFileLock's
+	// internal MkdirAll uses 0755 (it is shared by non-secret callers), and on a
+	// token-first fresh run it would otherwise create the AF home world-readable.
+	// The home holds secrets (daemon-token, daemon-tls.key, state.json), so it
+	// must be owner-only. MkdirAll never loosens an existing dir, so the lock's
+	// later 0755 MkdirAll no-ops once this has run.
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return "", fmt.Errorf("create token directory: %w", err)
+	}
 	var resolved string
 	err := config.WithFileLock(path, func() error {
 		if tok, err := LoadToken(path); err == nil {
@@ -144,6 +153,11 @@ func EnsureToken(path string) (string, error) {
 // without a daemon RPC and no reader ever sees a partial token; existing
 // streams keep running until they reconnect.
 func RotateToken(path string) (string, error) {
+	// Pre-create the AF home 0700 before the lock, same reason as EnsureToken:
+	// WithFileLock's MkdirAll is 0755 and the home holds secrets.
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return "", fmt.Errorf("create token directory: %w", err)
+	}
 	var resolved string
 	err := config.WithFileLock(path, func() error {
 		tok, err := generateToken()

--- a/daemon/token_test.go
+++ b/daemon/token_test.go
@@ -1,8 +1,10 @@
 package daemon
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 )
 
@@ -119,6 +121,154 @@ func TestRotateTokenChangesValueAndPersists(t *testing.T) {
 	}
 	if perm := info.Mode().Perm(); perm != 0o600 {
 		t.Fatalf("rotated token file perms = %o, want 0600", perm)
+	}
+}
+
+// TestEnsureTokenConcurrent proves the #1720 TOCTOU is gone: many goroutines
+// racing on a fresh (missing) token path must all agree on one token, and that
+// token must be the one persisted. On the pre-fix code (LoadToken-miss →
+// generate → os.WriteFile with no lock) concurrent callers each generated a
+// different token and clobbered each other, so the goroutines disagreed and/or
+// the persisted file differed from what a given caller returned.
+func TestEnsureTokenConcurrent(t *testing.T) {
+	const iterations = 100
+	const goroutines = 12
+
+	for i := 0; i < iterations; i++ {
+		// Fresh path per iteration so every run starts from "no token".
+		path := filepath.Join(t.TempDir(), "daemon-token")
+
+		var start sync.WaitGroup
+		start.Add(1)
+		var done sync.WaitGroup
+		results := make([]string, goroutines)
+		errs := make([]error, goroutines)
+
+		for g := 0; g < goroutines; g++ {
+			done.Add(1)
+			go func(idx int) {
+				defer done.Done()
+				start.Wait() // released together for maximum contention
+				tok, err := EnsureToken(path)
+				results[idx] = tok
+				errs[idx] = err
+			}(g)
+		}
+
+		start.Done() // release the barrier
+		done.Wait()
+
+		want := results[0]
+		for g := 0; g < goroutines; g++ {
+			if errs[g] != nil {
+				t.Fatalf("iter %d goroutine %d: EnsureToken error: %v", i, g, errs[g])
+			}
+			if results[g] == "" {
+				t.Fatalf("iter %d goroutine %d: EnsureToken returned empty token", i, g)
+			}
+			if results[g] != want {
+				t.Fatalf("iter %d: goroutines disagree on token: %q != %q (TOCTOU race)", i, results[g], want)
+			}
+		}
+
+		// The persisted file must match the token every caller agreed on.
+		loaded, err := LoadToken(path)
+		if err != nil {
+			t.Fatalf("iter %d: LoadToken after concurrent EnsureToken: %v", i, err)
+		}
+		if loaded != want {
+			t.Fatalf("iter %d: persisted token %q != agreed token %q", i, loaded, want)
+		}
+
+		// Perms must stay 0600 through the concurrent generate path.
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("iter %d: stat token file: %v", i, err)
+		}
+		if perm := info.Mode().Perm(); perm != 0o600 {
+			t.Fatalf("iter %d: token file perms = %o, want 0600", i, perm)
+		}
+	}
+}
+
+// TestRotateTokenConcurrentReaderNeverEmpty proves the #1722 rotation-401
+// window is gone: while one goroutine rotates the token many times, reader
+// goroutines tight-loop LoadToken and must NEVER observe an error or a
+// malformed token — every read returns a well-formed 43-char token (the whole
+// old or whole new value). On the pre-fix code (os.WriteFile O_TRUNC) a reader
+// could catch the file truncated-but-not-rewritten and LoadToken returned the
+// "token file ... is empty" error, which is exactly the spurious 401 the auth
+// gate produced.
+func TestRotateTokenConcurrentReaderNeverEmpty(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "daemon-token")
+
+	if _, err := EnsureToken(path); err != nil {
+		t.Fatalf("EnsureToken: %v", err)
+	}
+
+	const rotations = 300
+	const readers = 4
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	var readErr error
+	var readErrOnce sync.Once
+	recordErr := func(err error) {
+		readErrOnce.Do(func() { readErr = err })
+	}
+
+	for r := 0; r < readers; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				tok, err := LoadToken(path)
+				if err != nil {
+					recordErr(err)
+					return
+				}
+				if len(tok) != 43 {
+					recordErr(fmt.Errorf("reader saw malformed token %q (len %d)", tok, len(tok)))
+					return
+				}
+			}
+		}()
+	}
+
+	for i := 0; i < rotations; i++ {
+		if _, err := RotateToken(path); err != nil {
+			close(stop)
+			wg.Wait()
+			t.Fatalf("RotateToken iteration %d: %v", i, err)
+		}
+	}
+	close(stop)
+	wg.Wait()
+
+	if readErr != nil {
+		t.Fatalf("concurrent reader observed a bad token during rotation: %v", readErr)
+	}
+
+	// After all the churn the file must still be a valid 0600 token.
+	loaded, err := LoadToken(path)
+	if err != nil {
+		t.Fatalf("LoadToken after rotations: %v", err)
+	}
+	if len(loaded) != 43 {
+		t.Fatalf("final token malformed: %q (len %d)", loaded, len(loaded))
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("token file perms after rotation = %o, want 0600", perm)
 	}
 }
 

--- a/daemon/token_test.go
+++ b/daemon/token_test.go
@@ -272,6 +272,31 @@ func TestRotateTokenConcurrentReaderNeverEmpty(t *testing.T) {
 	}
 }
 
+// TestEnsureTokenCreatesHome0700 is the Greptile-follow-up regression guard: on
+// a fresh machine where token generation is the first thing to touch the AF
+// home, the home dir must be created 0700 (owner-only) — it holds secrets
+// (daemon-token, daemon-tls.key, state.json). The serialize+atomic fix routes
+// creation through config.WithFileLock, whose MkdirAll is 0755 (correct for its
+// non-secret callers), so EnsureToken must pre-create the parent 0700 before the
+// lock. On the pre-follow-up head the parent landed 0755.
+func TestEnsureTokenCreatesHome0700(t *testing.T) {
+	// Parent AF-home dir does NOT exist yet; EnsureToken must create it.
+	home := filepath.Join(t.TempDir(), "af-home")
+	path := filepath.Join(home, "daemon-token")
+
+	if _, err := EnsureToken(path); err != nil {
+		t.Fatalf("EnsureToken: %v", err)
+	}
+
+	info, err := os.Stat(home)
+	if err != nil {
+		t.Fatalf("stat AF home: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o700 {
+		t.Fatalf("AF home perms after first-run EnsureToken = %o, want 0700", perm)
+	}
+}
+
 func TestConstantTimeEqual(t *testing.T) {
 	cases := []struct {
 		name      string


### PR DESCRIPTION
## Two token-file races (same class as the TLS-cert fix in #1690)

The daemon's bearer token (`daemon/token.go`) had the exact concurrency/atomicity bugs the TLS material had before #1690, so this mirrors that fix (`config.WithFileLock` + `config.AtomicWriteFile`) for the token.

### #1720 — `EnsureToken` TOCTOU (not idempotent under concurrency)
`EnsureToken`'s `LoadToken`-miss → `generateToken` → `writeToken` ran with no lock. Two concurrent callers — e.g. daemon startup (`daemon/tcpserver.go:94`) and `af token show` (`commands/tokencmd.go:92`) — could both observe "no token" and both generate, racing to persist **different** tokens. Fixed by wrapping the check-then-generate-then-write in `config.WithFileLock(path, …)`: the first caller inside the lock writes the token, later callers observe it and return the same value.

### #1722 — rotation intermittently returns 401
`writeToken` used `os.WriteFile` (`O_TRUNC`), so mid-rotation the file was truncated-but-not-yet-rewritten. The auth gate re-reads the token **per request** (`daemon/httpauth.go` `authorize` → `expectedToken` → `LoadToken`, and `daemon/tcpserver.go:100`); a request landing in that window saw an empty file, `LoadToken` errored, and the gate failed closed → spurious 401. `af token rotate` (`commands/tokencmd.go:129` → `daemon.RotateToken`) triggered it. Fixed by switching `writeToken` to `config.AtomicWriteFile` (temp file + rename, perm applied exactly via `tmp.Chmod` so it lands 0600 regardless of umask). A reader now only ever observes the whole old or whole new token. `RotateToken` also runs under `config.WithFileLock` so a rotation serializes against a concurrent `EnsureToken` generation (consistent with the cert template).

**Why no restart is needed:** the `withAuth` gate re-reads the token per request. Serialized generation closes the TOCTOU and the atomic write closes the reader-sees-partial window, so both fixes take effect live. Readers deliberately do **not** take the lock — they keep doing a plain `LoadToken` so rotation stays live; the atomic write is what keeps that lock-free read from ever tearing. The lock file `daemon-token.lock` appears next to `daemon-token`, mirroring the cert's `daemon-tls.crt.lock`.

The persisted file is **0600** after both concurrent `EnsureToken` and rotation (asserted in the new tests).

## Proving both races (required)

Each new test **fails on the pre-fix code** and passes after. Reverting only `daemon/token.go` (keeping the new tests) and running them:

```
--- FAIL: TestEnsureTokenConcurrent (0.00s)
    token_test.go:164: iter 0 goroutine 1: EnsureToken error: token file .../daemon-token is empty
--- FAIL: TestRotateTokenConcurrentReaderNeverEmpty (0.11s)
    token_test.go:255: concurrent reader observed a bad token during rotation: token file .../daemon-token is empty
FAIL	github.com/sachiniyer/agent-factory/daemon	0.185s
```

After restoring the fix, `go test -run 'Token|ConstantTimeEqual' -race ./daemon/` is green.

New tests in `daemon/token_test.go`:
- **TestEnsureTokenConcurrent** — 100 iterations × 12 goroutines released by a shared start barrier calling `EnsureToken` on a fresh `t.TempDir()` path; asserts no errors, all goroutines agree on one token, the persisted file equals it, and perms are 0600.
- **TestRotateTokenConcurrentReaderNeverEmpty** — 4 reader goroutines tight-loop `LoadToken` while another rotates 300×; asserts readers never see an error/malformed token (every read is a well-formed 43-char old-or-new value), and the file stays 0600.

Existing tests are unchanged (not weakened).

## Gate results (all green)

```
gofmt -l .                        (no output)
golangci-lint run --timeout=3m --fast   EXIT=0
deadcode -test ./...              (no output)
scripts/lint-file-length.sh       file-length lint passed (584 files; 0 grandfathered)
make test-container               all packages ok (daemon 58.5s, integration 45.6s, app 71.0s)
make tui-driver-selftest          SELF-TEST PASSED — 25/25 steps green
```

## Greptile follow-up: first-run AF-home 0700 permissions fix

Greptile flagged a security regression the serialize+atomic work introduced (kept the concurrency work + all its tests; this is additive).

**The regression.** The old `writeToken` did `os.MkdirAll(filepath.Dir(path), 0o700)`, so on a fresh machine where token generation is the first thing to touch the AF home, the home (`~/.agent-factory` / `$AGENT_FACTORY_HOME`) was created **0700** (owner-only). The new code takes `config.WithFileLock(path, …)` first, and `WithFileLock`'s internal `MkdirAll` is **0755** (`config/filelock.go:19`), so on a token-first fresh run the home was created world-readable/traversable before any secret-write MkdirAll ran. The AF home holds secrets (`daemon-token`, `daemon-tls.key`, `state.json`, `instances`), so 0755 lets any local user list/traverse it.

**The scoped fix.** `EnsureToken`, `RotateToken`, and `ensureSelfSignedCert` now `os.MkdirAll(parent, 0o700)` **before** taking the lock. `MkdirAll` never loosens an existing dir, so the lock's later 0755 MkdirAll no-ops. The token file itself still lands 0600 via `AtomicWriteFile` — only the parent dir needed pre-creating.

**Why not the shared helpers.** `config.WithFileLock` / `config.AtomicWriteFile` are shared by many non-secret callers that legitimately want 0755 — the `af` binary install dir (`commands/autoupdate.go`, `commands/upgrade.go`, `~/.local/bin`) and in-repo `.agent-factory/` config (`config/repo_config.go`, `config/inrepo.go`). So `config/filelock.go` is untouched; the 0700 is scoped to the AF-home creation on the secret-write paths.

**Adjacent twin also fixed (audit-adjacent-callsites).** `ensureSelfSignedCert` (`daemon/tlsmaterial.go`) had the identical latent regression — it took the lock before `generateSelfSignedCert`'s own 0700 MkdirAll, so a cert-first fresh run created the home 0755. `daemon-tls.key` is equally a secret, so it got the same pre-lock 0700 MkdirAll.

**Proven on this PR head.** Two new tests generate into a not-yet-existing home and assert the parent is 0700: `TestEnsureTokenCreatesHome0700`, `TestResolveTLSMaterialCreatesHome0700`. Both fail on the pre-follow-up head with the observed mode **0755**, and pass after:
```
--- FAIL: TestResolveTLSMaterialCreatesHome0700
    AF home perms after first-run cert generation = 755, want 0700
--- FAIL: TestEnsureTokenCreatesHome0700
    AF home perms after first-run EnsureToken = 755, want 0700
```

**Out of scope (pre-existing, separate concern).** `config/state.go` and `config/config_save.go` also `MkdirAll` the home 0755; that pre-existing inconsistency is not introduced by this PR and is not touched here — this change only restores the prior first-run 0700 **creation** on the secret-write paths, and does not chmod-tighten a home some other writer already created 0755.

All gates re-run green after the follow-up: `gofmt` clean, `golangci-lint --fast` exit 0, `deadcode` clean, file-length passed, `make test-container` all packages ok, `make tui-driver-selftest` 25/25.

Closes #1720
Closes #1722

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)

