### PR TITLE
fix(session): preserve uncommitted work on archive when branch differs from HEAD (#1721)

### DIFF
--- a/session/git/worktree_push.go
+++ b/session/git/worktree_push.go
@@ -25,6 +25,19 @@ const archiveSnapshotMessage = "af: pre-archive snapshot (uncommitted work)"
 // or failing pre-commit hook never blocks an archive. A clean tree skips the
 // commit entirely.
 //
+// The snapshot commit lands on whatever the worktree's HEAD currently is, and we
+// push that HEAD to the session branch on origin (HEAD:refs/heads/<branch>) — NOT
+// a bare `push origin <branch>`. This closes #1721: if an agent switched branches
+// inside the sandbox (git checkout -b …) or left HEAD detached, `git commit`
+// applies to the current HEAD, so pushing the stored g.branchName would push a
+// stale tip that misses the just-committed work and report success — silent data
+// loss once the sandbox is reaped. Pushing HEAD makes the actual working-tree
+// state durable on the session branch regardless of which branch/HEAD the
+// worktree is on. Restore re-clones this branch, so it recovers that state. The
+// push is a plain (non-force) push, so a genuinely divergent HEAD is rejected by
+// origin and surfaces as an error here rather than silently overwriting or losing
+// history.
+//
 // The push runs under the network timeout (a stalled or auth-prompting origin
 // must not hang the archive forever). Credentials are the sandbox image's/host's
 // responsibility — the same `origin` the sandbox cloned from must be pushable
@@ -54,9 +67,15 @@ func (g *GitWorktree) SnapshotAndPushBranch() (string, error) {
 		}
 	}
 
-	// Push the branch to origin under the network timeout. A "src refspec ..."
-	// or auth failure surfaces here with git's stderr folded in.
-	if out, err := g.runGitNetworkCommand(g.worktreePath, "push", "origin", branch); err != nil {
+	// Push the CURRENT HEAD (which now carries the snapshot commit, if any) to the
+	// session branch on origin, under the network timeout. Pushing HEAD rather than
+	// the stored branch name means the actual working-tree state is what becomes
+	// durable even if the agent left HEAD on a different branch or detached (#1721);
+	// a non-fast-forward divergence is rejected by origin and surfaces here rather
+	// than silently dropping the work. A "src refspec ..." or auth failure surfaces
+	// here too, with git's stderr folded in.
+	refspec := "HEAD:refs/heads/" + branch
+	if out, err := g.runGitNetworkCommand(g.worktreePath, "push", "origin", refspec); err != nil {
 		return "", fmt.Errorf("failed to push branch %q to origin (archive stores durable state on GitHub): %s: %w",
 			branch, strings.TrimSpace(out), err)
 	}

--- a/session/git/worktree_push_test.go
+++ b/session/git/worktree_push_test.go
@@ -115,6 +115,52 @@ func TestSnapshotAndPushBranch_CleanTreeJustPushes(t *testing.T) {
 	assert.Equal(t, tip, branchTip(t, bare, "refs/heads/root/clean"))
 }
 
+// TestSnapshotAndPushBranch_PreservesWorkWhenHeadOnOtherBranch is the #1721
+// regression: an agent switched branches inside the sandbox (git checkout -b …),
+// so the worktree HEAD is no longer on g.branchName. The snapshot commit lands on
+// the current HEAD; archive must still make that uncommitted work durable on the
+// session branch (by pushing HEAD, not the stale stored branch), or it is lost
+// when the sandbox is reaped.
+func TestSnapshotAndPushBranch_PreservesWorkWhenHeadOnOtherBranch(t *testing.T) {
+	sandboxHome(t)
+	gw, bare := pushTestRepo(t, "root/session")
+	wt := gw.GetWorktreePath()
+
+	// Agent switched to a different branch, then left uncommitted work.
+	runGit(t, wt, "checkout", "-b", "agent-scratch")
+	require.NoError(t, os.WriteFile(filepath.Join(wt, "work.txt"), []byte("precious"), 0644))
+
+	got, err := gw.SnapshotAndPushBranch()
+	require.NoError(t, err)
+	assert.Equal(t, "root/session", got, "the pushed/returned branch is the session branch, not the scratch branch")
+
+	// Origin's session branch — the one restore re-clones — must carry the work.
+	pushed := runGitOut(t, bare, "ls-tree", "-r", "--name-only", "refs/heads/root/session")
+	assert.Contains(t, pushed, "work.txt",
+		"uncommitted work committed on the detoured HEAD must survive on the session branch")
+}
+
+// TestSnapshotAndPushBranch_PreservesWorkWhenHeadDetached is the #1721 regression
+// for a detached HEAD: the snapshot commit is created off any branch, and archive
+// must still push it onto the session branch so it survives sandbox teardown.
+func TestSnapshotAndPushBranch_PreservesWorkWhenHeadDetached(t *testing.T) {
+	sandboxHome(t)
+	gw, bare := pushTestRepo(t, "root/session")
+	wt := gw.GetWorktreePath()
+
+	// Detach HEAD, then leave uncommitted work.
+	runGit(t, wt, "checkout", "--detach", "HEAD")
+	require.NoError(t, os.WriteFile(filepath.Join(wt, "work.txt"), []byte("precious"), 0644))
+
+	got, err := gw.SnapshotAndPushBranch()
+	require.NoError(t, err)
+	assert.Equal(t, "root/session", got)
+
+	pushed := runGitOut(t, bare, "ls-tree", "-r", "--name-only", "refs/heads/root/session")
+	assert.Contains(t, pushed, "work.txt",
+		"uncommitted work committed on a detached HEAD must survive on the session branch")
+}
+
 // TestSnapshotAndPushBranch_RejectsExternalWorktree pins that an in-place/external
 // worktree (the user's own tree) is never pushed by the archive primitive.
 func TestSnapshotAndPushBranch_RejectsExternalWorktree(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #1721 — **silent data loss on archive** when the sandbox worktree's `HEAD` is not on the session branch.

`SnapshotAndPushBranch` (`session/git/worktree_push.go`, the archive-side primitive for docker/ssh sandboxes) snapshots uncommitted work with `git commit`, which always targets the current `HEAD`, then pushed the *stored* `g.branchName`. If an agent switched branches inside the sandbox (`git checkout -b …`) or left `HEAD` detached, the snapshot commit landed on the detoured `HEAD` while a **stale** `g.branchName` was pushed. Archive returned success, the sandbox was reaped (`ArchiveSandbox` → `AgentServer.Kill`), and the only copy of the work was destroyed.

## Reproduction (before)

A regression harness on current master: session branch `root/session`, agent does `git checkout -b agent-scratch`, leaves an uncommitted `work.txt`, then archive runs.

```
SnapshotAndPushBranch returned branch="root/session" err=<nil>
pushed branch "root/session" contains:      <-- EMPTY
DATA LOSS: archive reported success but pushed branch "root/session"
           does not contain the uncommitted work
--- FAIL
```

The commit went to `agent-scratch` (current HEAD); the pushed `root/session` was stale. After teardown, gone.

## Fix

Push the current `HEAD` to the session branch ref on origin (`HEAD:refs/heads/<branch>`) instead of the bare stored branch name. The snapshot commit already lands on `HEAD`; pushing `HEAD` makes the **actual working-tree state** durable on the branch that restore re-clones, regardless of which branch/HEAD the worktree is on. The push stays **non-force**, so a genuinely divergent `HEAD` is rejected by origin and surfaces as an error here rather than silently dropping work (satisfying the issue's "push the correct branch *or* error out" expectation).

### After

```
SnapshotAndPushBranch returned branch="root/session" err=<nil>
pushed branch "root/session" contains:
work.txt
--- PASS
```

## Tests

Two regression tests in `worktree_push_test.go`, both proving the uncommitted work survives on the pushed session branch:
- `TestSnapshotAndPushBranch_PreservesWorkWhenHeadOnOtherBranch` — agent switched to a scratch branch
- `TestSnapshotAndPushBranch_PreservesWorkWhenHeadDetached` — detached HEAD

Existing snapshot tests (committed-work push, uncommitted snapshot, clean-tree, external-worktree rejection) unchanged and green.

## Gates
- `gofmt -l` clean · `golangci-lint run --fast` clean · `deadcode -test ./...` clean · file-length lint pass
- `make test-container` — full suite green
- `make tui-driver-selftest` — 25/25

🤖 Generated with [Claude Code](https://claude.com/claude-code)