### PR TITLE
fix(apiclient): timeout stalled remote TLS handshake / request instead of hanging (#1730)

### DIFF
--- a/apiclient/client.go
+++ b/apiclient/client.go
@@ -95,15 +95,17 @@ type Client struct {
 	// wsBase is the WS scheme+authority: localWSBase ("ws://unix") for the unix
 	// socket, "wss://host:port" for a remote daemon.
 	wsBase string
-	// requestTimeout is the overall deadline applied to each REST call()
+	// requestTimeout is the SINGLE overall deadline applied to each REST call()
 	// round-trip via the request context. It is set only for a REMOTE target
-	// (NewRemote), so a half-open or wedged remote daemon surfaces as a timeout
-	// error instead of hanging forever (#1730). It is 0 for the local unix socket,
-	// which keeps its blocking-read semantics (the socket is either there or not,
-	// bounded by dialTimeout, and the in-memory snapshot returns promptly). WS
-	// stream dials never consult this field — they are bounded only by the
-	// transport's handshake/response-header timeouts so a long-lived stream is
-	// never severed by an overall deadline.
+	// (NewRemote), so a daemon that completes TLS but then never responds surfaces
+	// as a timeout instead of hanging forever (#1730) — the sole REST wait-bound,
+	// deliberately generous so a synchronous mutating RPC (a remote docker/ssh
+	// CreateSession) is not severed mid-provision. It is 0 for the local unix
+	// socket, which keeps its blocking-read semantics (the socket is either there
+	// or not, bounded by dialTimeout, and the in-memory snapshot returns promptly).
+	// WS stream dials never consult this field — they are bounded only by the
+	// transport's dial + handshake timeouts, so a long-lived stream is never
+	// severed by an overall deadline.
 	requestTimeout time.Duration
 }
 
@@ -153,9 +155,11 @@ func (c *Client) call(method string, req any, resp any) error {
 		return fmt.Errorf("apiclient: marshal request: %w", err)
 	}
 
-	// A remote target bounds the whole round-trip with an overall deadline so a
-	// wedged daemon times out instead of hanging (#1730); the local socket leaves
-	// requestTimeout zero and blocks on the in-memory snapshot as before.
+	// A remote target bounds the whole round-trip with a single overall deadline so
+	// a wedged daemon (TLS up, never responds) times out instead of hanging
+	// (#1730); the deadline is generous so a slow synchronous create is not
+	// severed. The local socket leaves requestTimeout zero and blocks on the
+	// in-memory snapshot as before.
 	ctx := context.Background()
 	if c.requestTimeout > 0 {
 		var cancel context.CancelFunc

--- a/apiclient/client.go
+++ b/apiclient/client.go
@@ -95,6 +95,16 @@ type Client struct {
 	// wsBase is the WS scheme+authority: localWSBase ("ws://unix") for the unix
 	// socket, "wss://host:port" for a remote daemon.
 	wsBase string
+	// requestTimeout is the overall deadline applied to each REST call()
+	// round-trip via the request context. It is set only for a REMOTE target
+	// (NewRemote), so a half-open or wedged remote daemon surfaces as a timeout
+	// error instead of hanging forever (#1730). It is 0 for the local unix socket,
+	// which keeps its blocking-read semantics (the socket is either there or not,
+	// bounded by dialTimeout, and the in-memory snapshot returns promptly). WS
+	// stream dials never consult this field — they are bounded only by the
+	// transport's handshake/response-header timeouts so a long-lived stream is
+	// never severed by an overall deadline.
+	requestTimeout time.Duration
 }
 
 // New returns a Client dialing the daemon HTTP socket resolved from the current
@@ -143,7 +153,16 @@ func (c *Client) call(method string, req any, resp any) error {
 		return fmt.Errorf("apiclient: marshal request: %w", err)
 	}
 
-	httpReq, err := http.NewRequest(http.MethodPost, c.httpBase+"/v1/"+method, bytes.NewReader(reqBody))
+	// A remote target bounds the whole round-trip with an overall deadline so a
+	// wedged daemon times out instead of hanging (#1730); the local socket leaves
+	// requestTimeout zero and blocks on the in-memory snapshot as before.
+	ctx := context.Background()
+	if c.requestTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, c.requestTimeout)
+		defer cancel()
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.httpBase+"/v1/"+method, bytes.NewReader(reqBody))
 	if err != nil {
 		return fmt.Errorf("apiclient: build request: %w", err)
 	}

--- a/apiclient/remote.go
+++ b/apiclient/remote.go
@@ -24,10 +24,37 @@ import (
 // cert by SHA-256 fingerprint (TOFU, §1.2) or, when no fingerprint is given,
 // verifies a real CA cert against the system trust store.
 
-// remoteDialTimeout bounds the TCP connect to a remote daemon. Unlike the local
-// unix socket (a quarter second — it is either there or not), a remote dial
-// crosses a real network, so it is given a longer, network-appropriate budget.
-const remoteDialTimeout = 10 * time.Second
+// Timeouts bounding a remote round-trip. Unlike the local unix socket (a quarter
+// second — it is either there or not), a remote target crosses a real network and
+// a half-open or wedged daemon must surface as a clear timeout error instead of
+// hanging forever (#1730). Each is chosen to bound a STALL, not to race a
+// legitimately slow call:
+//
+//   - remoteDialTimeout — the TCP connect.
+//   - remoteTLSHandshakeTimeout — the TLS handshake. Its absence was the #1730
+//     hang: a peer that accepts the TCP connection but never completes the
+//     handshake blocked every REST and WS call indefinitely. 10s matches Go's
+//     http.DefaultTransport default.
+//   - remoteResponseHeaderTimeout — the wait for the server's response headers
+//     after the request is written. This bounds a daemon that completes TLS but
+//     never answers (REST) or never returns the WS 101 (a stalled handshake on
+//     the WS path). It is stream-SAFE: it caps only the time to the response
+//     headers, never a live stream's subsequent reads, so a long-lived PTY
+//     subscription is untouched.
+//   - remoteRequestTimeout — the overall deadline on a single REST call()
+//     round-trip (applied via the request context, remote-only). WS/stream dials
+//     are deliberately EXEMPT from this overall cap — they carry only the two
+//     transport bounds above so a long-lived stream is never severed mid-flight.
+//
+// They are vars (not consts) only so a test can shrink them to prove the bound
+// fires without waiting the full budget — the same pattern attach.go's
+// attachDrainTimeout/attachWriteTimeout use.
+var (
+	remoteDialTimeout           = 10 * time.Second
+	remoteTLSHandshakeTimeout   = 10 * time.Second
+	remoteResponseHeaderTimeout = 30 * time.Second
+	remoteRequestTimeout        = 60 * time.Second
+)
 
 // NewRemote returns a Client that dials the remote daemon at daemonURL over
 // TCP+TLS, threading `token` on every REST call and WS handshake. daemonURL is a
@@ -52,14 +79,22 @@ func NewRemote(daemonURL, token, fingerprint string) (*Client, error) {
 	dialer := &net.Dialer{Timeout: remoteDialTimeout}
 	return &Client{
 		httpClient: &http.Client{
+			// No http.Client.Timeout: it would fire on the whole request lifetime,
+			// which for the WS handshake path means the established stream itself —
+			// coder/websocket explicitly warns against it. The remote round-trip is
+			// bounded instead by the transport's handshake/response-header timeouts
+			// (stream-safe) plus a per-call context deadline on the REST path only.
 			Transport: &http.Transport{
-				DialContext:     dialer.DialContext,
-				TLSClientConfig: tlsCfg,
+				DialContext:           dialer.DialContext,
+				TLSClientConfig:       tlsCfg,
+				TLSHandshakeTimeout:   remoteTLSHandshakeTimeout,
+				ResponseHeaderTimeout: remoteResponseHeaderTimeout,
 			},
 		},
-		token:    token,
-		httpBase: httpBase,
-		wsBase:   wsBase,
+		token:          token,
+		httpBase:       httpBase,
+		wsBase:         wsBase,
+		requestTimeout: remoteRequestTimeout,
 	}, nil
 }
 

--- a/apiclient/remote.go
+++ b/apiclient/remote.go
@@ -26,34 +26,42 @@ import (
 
 // Timeouts bounding a remote round-trip. Unlike the local unix socket (a quarter
 // second — it is either there or not), a remote target crosses a real network and
-// a half-open or wedged daemon must surface as a clear timeout error instead of
-// hanging forever (#1730). Each is chosen to bound a STALL, not to race a
-// legitimately slow call:
+// a half-open or wedged daemon must surface as a clear error instead of hanging
+// forever (#1730). There are exactly two connection-level bounds plus ONE overall
+// REST deadline — no per-layer split, so there is a single number to reason about:
 //
 //   - remoteDialTimeout — the TCP connect.
 //   - remoteTLSHandshakeTimeout — the TLS handshake. Its absence was the #1730
 //     hang: a peer that accepts the TCP connection but never completes the
 //     handshake blocked every REST and WS call indefinitely. 10s matches Go's
-//     http.DefaultTransport default.
-//   - remoteResponseHeaderTimeout — the wait for the server's response headers
-//     after the request is written. This bounds a daemon that completes TLS but
-//     never answers (REST) or never returns the WS 101 (a stalled handshake on
-//     the WS path). It is stream-SAFE: it caps only the time to the response
-//     headers, never a live stream's subsequent reads, so a long-lived PTY
-//     subscription is untouched.
-//   - remoteRequestTimeout — the overall deadline on a single REST call()
-//     round-trip (applied via the request context, remote-only). WS/stream dials
-//     are deliberately EXEMPT from this overall cap — they carry only the two
-//     transport bounds above so a long-lived stream is never severed mid-flight.
+//     http.DefaultTransport default. These two catch the common unreachable /
+//     wedged-at-connect cases FAST, for both REST and WS.
+//   - remoteRequestTimeout — the single overall deadline on one REST call()
+//     round-trip (applied via the request context, remote-only). It is the sole
+//     REST wait-bound: a daemon that completes TLS but then never sends a response
+//     surfaces here instead of hanging. It is deliberately GENEROUS, not snappy,
+//     because a mutating RPC runs SYNCHRONOUSLY inside the request — a remote
+//     docker/ssh CreateSession (#1592 Phase 4) can spend minutes provisioning
+//     (image pull, ssh spin-up) before the daemon writes response headers, and a
+//     tight deadline would sever a create that is actually succeeding server-side
+//     and orphan it. The value clears realistic provisioning; a truly wedged
+//     connection is still bounded (just not instantly), and the fast-fail cases
+//     are already covered by dial + handshake above.
+//
+// Notably there is NO transport-level ResponseHeaderTimeout and NO
+// http.Client.Timeout: a shared ResponseHeaderTimeout would fire mid-provision on
+// a slow synchronous create (Greptile #1734), and http.Client.Timeout would
+// additionally kill an established WS stream (coder/websocket warns against it).
+// WS/stream dials are EXEMPT from the overall deadline entirely — they carry only
+// the dial + handshake bounds, so a long-lived PTY subscription is never severed.
 //
 // They are vars (not consts) only so a test can shrink them to prove the bound
 // fires without waiting the full budget — the same pattern attach.go's
 // attachDrainTimeout/attachWriteTimeout use.
 var (
-	remoteDialTimeout           = 10 * time.Second
-	remoteTLSHandshakeTimeout   = 10 * time.Second
-	remoteResponseHeaderTimeout = 30 * time.Second
-	remoteRequestTimeout        = 60 * time.Second
+	remoteDialTimeout         = 10 * time.Second
+	remoteTLSHandshakeTimeout = 10 * time.Second
+	remoteRequestTimeout      = 5 * time.Minute
 )
 
 // NewRemote returns a Client that dials the remote daemon at daemonURL over
@@ -79,16 +87,15 @@ func NewRemote(daemonURL, token, fingerprint string) (*Client, error) {
 	dialer := &net.Dialer{Timeout: remoteDialTimeout}
 	return &Client{
 		httpClient: &http.Client{
-			// No http.Client.Timeout: it would fire on the whole request lifetime,
-			// which for the WS handshake path means the established stream itself —
-			// coder/websocket explicitly warns against it. The remote round-trip is
-			// bounded instead by the transport's handshake/response-header timeouts
-			// (stream-safe) plus a per-call context deadline on the REST path only.
+			// No http.Client.Timeout: it fires on the whole request lifetime, which
+			// for the WS handshake path is the established stream itself
+			// (coder/websocket warns against it). The overall REST bound is applied
+			// per-call as a request-context deadline instead (call(), remote-only),
+			// so WS/stream dials stay exempt.
 			Transport: &http.Transport{
-				DialContext:           dialer.DialContext,
-				TLSClientConfig:       tlsCfg,
-				TLSHandshakeTimeout:   remoteTLSHandshakeTimeout,
-				ResponseHeaderTimeout: remoteResponseHeaderTimeout,
+				DialContext:         dialer.DialContext,
+				TLSClientConfig:     tlsCfg,
+				TLSHandshakeTimeout: remoteTLSHandshakeTimeout,
 			},
 		},
 		token:          token,

--- a/apiclient/remote_test.go
+++ b/apiclient/remote_test.go
@@ -212,13 +212,12 @@ func stallingTLSListener(t *testing.T) string {
 // these vars) rather than a hand-rolled client.
 func withShrunkRemoteTimeouts(t *testing.T) {
 	t.Helper()
-	od, oh, or, oq := remoteDialTimeout, remoteTLSHandshakeTimeout, remoteResponseHeaderTimeout, remoteRequestTimeout
+	od, oh, or := remoteDialTimeout, remoteTLSHandshakeTimeout, remoteRequestTimeout
 	remoteDialTimeout = 500 * time.Millisecond
 	remoteTLSHandshakeTimeout = 500 * time.Millisecond
-	remoteResponseHeaderTimeout = 500 * time.Millisecond
-	remoteRequestTimeout = 500 * time.Millisecond
+	remoteRequestTimeout = 2 * time.Second
 	t.Cleanup(func() {
-		remoteDialTimeout, remoteTLSHandshakeTimeout, remoteResponseHeaderTimeout, remoteRequestTimeout = od, oh, or, oq
+		remoteDialTimeout, remoteTLSHandshakeTimeout, remoteRequestTimeout = od, oh, or
 	})
 }
 
@@ -280,6 +279,88 @@ func TestDialStream_StalledTLSHandshakeTimesOut(t *testing.T) {
 		}
 	case <-time.After(10 * time.Second):
 		t.Fatal("HANG: DialStream did not return on a stalled TLS handshake (#1730 regression)")
+	}
+}
+
+// TestNewRemote_NeverRespondsAfterConnectTimesOut proves the OTHER stall the fix
+// must catch: a daemon that completes the TLS handshake but then never sends a
+// response. The single overall request deadline bounds it, so the REST call
+// returns a timeout ("context deadline exceeded") instead of hanging.
+func TestNewRemote_NeverRespondsAfterConnectTimesOut(t *testing.T) {
+	withShrunkRemoteTimeouts(t)
+	// release lets cleanup unblock the handler: the client aborting on its request
+	// deadline does not promptly cancel the server-side request context, so without
+	// this srv.Close would wait on the parked handler.
+	release := make(chan struct{})
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/Snapshot", func(w http.ResponseWriter, r *http.Request) {
+		select { // handshake done, but the response headers never come
+		case <-release:
+		case <-r.Context().Done():
+		}
+	})
+	srv := httptest.NewTLSServer(mux)
+	t.Cleanup(srv.Close)                 // runs LAST (LIFO): a clean close after...
+	t.Cleanup(func() { close(release) }) // ...this unparks the handler first
+	pin := agentproto.CertFingerprint(srv.Certificate().Raw)
+
+	c, err := NewRemote(srv.URL, "tok", pin)
+	if err != nil {
+		t.Fatalf("NewRemote: %v", err)
+	}
+	errc := make(chan error, 1)
+	go func() {
+		_, e := c.Snapshot(daemon.SnapshotRequest{})
+		errc <- e
+	}()
+	select {
+	case e := <-errc:
+		if e == nil {
+			t.Fatal("daemon that never responds: want a timeout error, got nil")
+		}
+		if !strings.Contains(e.Error(), "timeout") && !strings.Contains(e.Error(), "deadline exceeded") {
+			t.Fatalf("want a timeout error, got %v", e)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("HANG: Snapshot did not return when the daemon never responded (#1730 regression)")
+	}
+}
+
+// TestNewRemote_SlowButProgressingResponseNotKilled is the Greptile correctness
+// guard for a slow SYNCHRONOUS create: a valid RPC whose server does real work for
+// a while and answers JUST UNDER the overall deadline (like a remote docker/ssh
+// CreateSession provisioning) must SUCCEED, not be severed early. It proves the
+// single deadline is a wedged-connection backstop, not a race against slow work.
+func TestNewRemote_SlowButProgressingResponseNotKilled(t *testing.T) {
+	withShrunkRemoteTimeouts(t) // remoteRequestTimeout is now 2s
+	// The daemon takes a substantial slice of the deadline before responding — well
+	// past what a snappy read would need — yet lands comfortably before it. Sized
+	// off the live var so it stays under the deadline if the value ever changes.
+	serverWork := remoteRequestTimeout / 2
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/Snapshot", func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-time.After(serverWork):
+		case <-r.Context().Done():
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = apiproto.WriteEnvelope(w, apiproto.Success(daemon.SnapshotResponse{Instances: richInstances()}))
+	})
+	srv := httptest.NewTLSServer(mux)
+	t.Cleanup(srv.Close)
+	pin := agentproto.CertFingerprint(srv.Certificate().Raw)
+
+	c, err := NewRemote(srv.URL, "tok", pin)
+	if err != nil {
+		t.Fatalf("NewRemote: %v", err)
+	}
+	got, err := c.Snapshot(daemon.SnapshotRequest{})
+	if err != nil {
+		t.Fatalf("slow-but-progressing response must NOT be timed out, got %v", err)
+	}
+	if len(got) != len(richInstances()) || got[0].Title != "alpha" {
+		t.Fatalf("slow response decoded wrong: %+v", got)
 	}
 }
 

--- a/apiclient/remote_test.go
+++ b/apiclient/remote_test.go
@@ -2,6 +2,7 @@ package apiclient
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -170,6 +171,115 @@ func TestNewRemote_NoPinRejectsSelfSigned(t *testing.T) {
 	}
 	if _, err := c.Snapshot(daemon.SnapshotRequest{}); err == nil {
 		t.Fatal("want TLS verification failure against an un-pinned self-signed cert, got nil")
+	}
+}
+
+// stallingTLSListener accepts TCP connections but NEVER completes (or even reads)
+// the TLS handshake — it holds every accepted conn open and idle. A client dialing
+// it gets a completed TCP connect and then blocks waiting for a ServerHello that
+// never comes: the exact half-open condition that hung every remote call before
+// #1730. It returns the listen address; the listener and its held conns close on
+// cleanup.
+func stallingTLSListener(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	conns := make(chan net.Conn, 16)
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				close(conns)
+				return
+			}
+			conns <- conn // hold it open, never read/write — stall the handshake
+		}
+	}()
+	t.Cleanup(func() {
+		_ = ln.Close()
+		for c := range conns {
+			_ = c.Close()
+		}
+	})
+	return ln.Addr().String()
+}
+
+// withShrunkRemoteTimeouts temporarily shrinks the remote round-trip timeouts so a
+// stall test proves the bound FIRES without waiting the full multi-second budget,
+// restoring them on cleanup. It exercises the real NewRemote wiring (which reads
+// these vars) rather than a hand-rolled client.
+func withShrunkRemoteTimeouts(t *testing.T) {
+	t.Helper()
+	od, oh, or, oq := remoteDialTimeout, remoteTLSHandshakeTimeout, remoteResponseHeaderTimeout, remoteRequestTimeout
+	remoteDialTimeout = 500 * time.Millisecond
+	remoteTLSHandshakeTimeout = 500 * time.Millisecond
+	remoteResponseHeaderTimeout = 500 * time.Millisecond
+	remoteRequestTimeout = 500 * time.Millisecond
+	t.Cleanup(func() {
+		remoteDialTimeout, remoteTLSHandshakeTimeout, remoteResponseHeaderTimeout, remoteRequestTimeout = od, oh, or, oq
+	})
+}
+
+// TestNewRemote_StalledTLSHandshakeTimesOut is the #1730 regression: a remote
+// daemon that accepts the TCP connection but never completes the TLS handshake
+// must make a REST call return a timeout error within the configured budget, not
+// hang forever. Before the fix (no TLSHandshakeTimeout on the transport, no
+// request-context deadline) this call blocked indefinitely.
+func TestNewRemote_StalledTLSHandshakeTimesOut(t *testing.T) {
+	withShrunkRemoteTimeouts(t)
+	addr := stallingTLSListener(t)
+
+	c, err := NewRemote("https://"+addr, "tok", "sha256:"+strings.Repeat("ab", 32))
+	if err != nil {
+		t.Fatalf("NewRemote: %v", err)
+	}
+
+	errc := make(chan error, 1)
+	go func() {
+		_, e := c.Snapshot(daemon.SnapshotRequest{})
+		errc <- e
+	}()
+	select {
+	case e := <-errc:
+		if e == nil {
+			t.Fatal("stalled TLS handshake: want a timeout error, got nil")
+		}
+		if !strings.Contains(e.Error(), "timeout") && !strings.Contains(e.Error(), "deadline exceeded") {
+			t.Fatalf("stalled TLS handshake: want a timeout error, got %v", e)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("HANG: Snapshot did not return on a stalled TLS handshake (#1730 regression)")
+	}
+}
+
+// TestDialStream_StalledTLSHandshakeTimesOut proves the WS path is bounded too:
+// the same stalled handshake makes DialStream error out (via the transport's
+// TLS-handshake timeout) instead of hanging, even though the WS dial is exempt
+// from the REST overall-request deadline. This covers the attach call site that
+// passes context.Background() (no caller-side deadline).
+func TestDialStream_StalledTLSHandshakeTimesOut(t *testing.T) {
+	withShrunkRemoteTimeouts(t)
+	addr := stallingTLSListener(t)
+
+	c, err := NewRemote("https://"+addr, "tok", "sha256:"+strings.Repeat("ab", 32))
+	if err != nil {
+		t.Fatalf("NewRemote: %v", err)
+	}
+
+	errc := make(chan error, 1)
+	go func() {
+		_, e := c.DialStream(context.Background(), "alpha", "", 0, 0)
+		errc <- e
+	}()
+	select {
+	case e := <-errc:
+		if e == nil {
+			t.Fatal("stalled TLS handshake on WS dial: want an error, got nil")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("HANG: DialStream did not return on a stalled TLS handshake (#1730 regression)")
 	}
 }
 


### PR DESCRIPTION
Fixes #1730.

## Problem

The remote daemon client (`NewRemote`, added in #1592 Phase 3 PR4 / #1655) built its `http.Transport` with only a dial timeout — **no `TLSHandshakeTimeout`** — and the REST `call()` path used `http.NewRequest` with **no context and no `http.Client.Timeout`**. A remote peer that accepts the TCP connection but never completes the TLS handshake (a half-open or wedged daemon) made **every** remote REST and WS call hang **indefinitely**, with no error — only SIGINT could break out.

## Reproduce (before)

A listener that accepts TCP but never completes the TLS handshake, pointed at by `NewRemote`, hung forever (the cutoff below is the test giving up):

```
--- FAIL: TestReproStalledTLSHangs (20.02s)
    HANG: Snapshot did not return within 20s on a stalled TLS handshake
```

## After the fix

```
call returned in time with error: Post "https://127.0.0.1:.../v1/Snapshot": net/http: TLS handshake timeout
--- PASS
```

## Fix — bound stalls, one REST deadline

Connection-level bounds that catch the common unreachable / wedged-at-connect cases **fast**, for both REST and WS:

- **`TLSHandshakeTimeout` (10s, Go's `DefaultTransport` default)** on the transport — the direct #1730 fix.
- **Dial timeout (10s)** — unchanged.

REST overall bound — a **single** mechanism:

- **One per-call request-context deadline** is the sole REST wait-bound. A daemon that completes TLS but then never responds surfaces as a timeout here (no infinite hang), at a single documented value.
- **No transport-level `ResponseHeaderTimeout`** and **no `http.Client.Timeout`.**
- **WS/stream dials are exempt** from the overall deadline — they carry only the dial + handshake bounds, so a long-lived PTY stream is never severed (`http.Client.Timeout` would kill it — coder/websocket warns against it).

### Design note (per Greptile #1734 correctness review)

The first cut paired a shared-transport `ResponseHeaderTimeout` (30s) with a per-call context deadline (60s). That was both an **inconsistency** (a call could fail at 30s while the "overall" deadline was 60s) and a **correctness bug**: the daemon runs `CreateSession` -> `finishCreateStart` / `StartAndSendPrompt` **synchronously inside the REST request**, so a remote docker/ssh create (#1592 Phase 4) can spend well over 30s provisioning (image pull, ssh spin-up) *before* it writes response headers. A 30s `ResponseHeaderTimeout` would sever a create that is actually succeeding server-side and orphan it.

So the REST wait-bound is collapsed to **one generous deadline (5m)**, chosen over a per-RPC timeout map deliberately: a single number to reason about, nothing to maintain as RPCs are added, and it clears realistic provisioning. A truly wedged connection is still bounded (just not instantly); the fast-fail cases are already covered by dial + handshake. Local unix-socket behavior is unchanged (`requestTimeout = 0`, blocking read as before).

## Regression tests

- `TestNewRemote_StalledTLSHandshakeTimesOut` / `TestDialStream_StalledTLSHandshakeTimesOut` — stalled TLS handshake -> REST and WS bounded **fast** by `TLSHandshakeTimeout`, not a hang (WS test uses `context.Background()`, the vulnerable attach call site).
- `TestNewRemote_NeverRespondsAfterConnectTimesOut` — daemon completes TLS but never sends headers -> bounded by the **single overall deadline** (`context deadline exceeded`), no hang, no 30-vs-60 ambiguity.
- `TestNewRemote_SlowButProgressingResponseNotKilled` — a slow synchronous create that answers **just under** the deadline -> **succeeds**, proving the deadline is a wedged-connection backstop, not a race against real work.

Fast (timeout vars temporarily shrunk, exercising the real `NewRemote` wiring — same var-tunable pattern as `attach.go`'s `attachDrainTimeout`).

## Gates
- `go build ./...` OK
- `gofmt -l` clean
- `golangci-lint run --fast` OK
- `deadcode -test ./...` clean
- `make test-container` — all packages green
- `make tui-driver-selftest` — 25/25

🤖 Generated with [Claude Code](https://claude.com/claude-code)