### PR TITLE
feat(web): drag-and-drop tabs into a split-pane layout within an instance

### DIFF
--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -419,6 +419,16 @@ body {
   color: var(--af-text);
   border-bottom-color: var(--af-accent);
 }
+.af-tab-shown {
+  color: var(--af-text);
+  border-bottom-color: var(--af-border);
+}
+.af-tab {
+  cursor: grab;
+}
+.af-tab:active {
+  cursor: grabbing;
+}
 .af-tab-label {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -481,12 +491,147 @@ body {
 .af-term-host {
   flex: 1;
   min-height: 0;
-  padding: 0.4rem 0.6rem;
+  display: flex;
   background: var(--af-bg);
   overflow: hidden;
 }
-.af-term-host .xterm {
+.af-split {
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+.af-split-row {
+  flex-direction: row;
+}
+.af-split-column {
+  flex-direction: column;
+}
+.af-divider {
+  flex: 0 0 auto;
+  background: var(--af-border);
+  transition: background 0.1s ease;
+}
+.af-divider:hover,
+.af-resizing-col .af-divider-row,
+.af-resizing-row .af-divider-column {
+  background: var(--af-accent);
+}
+.af-divider-row {
+  width: 4px;
+  cursor: col-resize;
+}
+.af-divider-column {
+  height: 4px;
+  cursor: row-resize;
+}
+.af-resizing-col,
+.af-resizing-col * {
+  cursor: col-resize !important;
+  user-select: none;
+}
+.af-resizing-row,
+.af-resizing-row * {
+  cursor: row-resize !important;
+  user-select: none;
+}
+.af-pane {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+.af-pane-head {
+  display: none;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.4rem;
+  padding: 0.15rem 0.5rem;
+  background: var(--af-surface);
+  border-bottom: 1px solid var(--af-border);
+}
+.af-pane-multi .af-pane-head {
+  display: flex;
+}
+.af-pane-label {
+  font-size: 0.68rem;
+  color: var(--af-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.af-pane-close {
+  flex: 0 0 auto;
+  padding: 0 0.25rem;
+  background: transparent;
+  color: var(--af-muted);
+  border: none;
+  border-radius: 3px;
+  font: inherit;
+  font-size: 0.85rem;
+  line-height: 1;
+  cursor: pointer;
+}
+.af-pane-close:hover {
+  color: var(--af-error);
+  background: rgba(248, 81, 73, 0.14);
+}
+.af-pane-host {
+  flex: 1;
+  min-height: 0;
+  padding: 0.4rem 0.6rem;
+  overflow: hidden;
+}
+.af-pane-host .xterm {
   height: 100%;
+}
+.af-kb-terminal .af-split-multi .af-pane-focused {
+  outline: 2px solid var(--af-accent);
+  outline-offset: -2px;
+}
+.af-dragging-tab .af-pane {
+  outline: 1px dashed var(--af-border);
+  outline-offset: -1px;
+}
+.af-drop-overlay {
+  position: absolute;
+  display: none;
+  background: rgba(47, 129, 247, 0.28);
+  border: 1px solid var(--af-accent);
+  pointer-events: none;
+  z-index: 5;
+}
+.af-drop-overlay.af-drop-show {
+  display: block;
+}
+.af-drop-center {
+  inset: 0;
+}
+.af-drop-left {
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 50%;
+}
+.af-drop-right {
+  top: 0;
+  bottom: 0;
+  right: 0;
+  width: 50%;
+}
+.af-drop-top {
+  left: 0;
+  right: 0;
+  top: 0;
+  height: 50%;
+}
+.af-drop-bottom {
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 50%;
 }
 .af-rail-new {
   padding: 0.25rem 0.55rem;

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7261,12 +7261,19 @@ var SplitView = class {
   isSplit() {
     return this.tree ? leafCount(this.tree) > 1 : false;
   }
-  /** Tears down every live terminal and clears the host (logout / deselect). The
-   *  retained trees survive so a re-selection restores the split. */
+  /** Tears down every live terminal, clears the host, AND drops the retained
+   *  per-instance trees (logout). Keeping the trees across a logout would leave them
+   *  pointing at torn-down panes, so a re-login would resurrect a stale split instead
+   *  of the single-leaf default — so a fresh login starts clean. (Instance→instance
+   *  switches never call this; they go through setSession, which keeps the trees.) */
   dispose() {
     this.teardown();
+    this.trees.clear();
     this.sessionId = null;
     this.tree = null;
+    this.lastFocusedTab = -1;
+    this.lastShown = "";
+    this.lastPaneCount = 0;
   }
   // --- internal: mutation commit --------------------------------------------
   /** Persists the current tree for the session, re-renders, and reports the layout. */
@@ -7452,7 +7459,7 @@ var SplitView = class {
       this.hideZone(pane);
       const raw = e.dataTransfer?.getData(TAB_DND_MIME);
       const tab = raw ? Number.parseInt(raw, 10) : Number.NaN;
-      if (Number.isNaN(tab) || !this.tree) {
+      if (Number.isNaN(tab) || tab < 0 || tab >= this.tabCount || !this.tree) {
         return;
       }
       const zone = this.zoneAt(pane.container, e.clientX, e.clientY);

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7153,6 +7153,12 @@ function el(tag, cls) {
   node.className = cls;
   return node;
 }
+function sameTabs(a, b) {
+  if (a.length !== b.length) {
+    return false;
+  }
+  return a.every((v, i) => v === b[i]);
+}
 var SplitView = class {
   constructor(host, cb) {
     this.host = host;
@@ -7165,6 +7171,10 @@ var SplitView = class {
   sessionId = null;
   token = null;
   tabCount = 1;
+  // The instance's ordered tab identities (ui.tabIdentity), kept current on every
+  // store update. A drop compares its drag-time snapshot against this to detect a
+  // mid-drag tab-set change (concurrent close/create/reorder) and cancel.
+  tabIds = [];
   tree = null;
   focusedId = null;
   // Debounces the "focus left every pane" report so a click that moves focus A→B
@@ -7181,8 +7191,10 @@ var SplitView = class {
    * fresh single leaf bound to `initialTab`); the SAME session only re-validates the
    * tree against the current tab list (a tab closed elsewhere). Cheap on a no-op.
    */
-  setSession(sessionId, token2, tabCount, initialTab) {
+  setSession(sessionId, token2, tabIds, initialTab) {
     this.token = token2;
+    this.tabIds = tabIds;
+    const tabCount = tabIds.length > 0 ? tabIds.length : 1;
     if (sessionId === null || token2 === null) {
       this.teardown();
       this.sessionId = null;
@@ -7432,6 +7444,23 @@ var SplitView = class {
     return divider;
   }
   // --- internal: drag-and-drop ----------------------------------------------
+  /** Parses a drag payload from the dataTransfer, or null if it is absent/malformed
+   *  (a foreign drag, or a corrupt payload → the drop is a no-op). */
+  parseDrag(raw) {
+    if (!raw) {
+      return null;
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return null;
+    }
+    if (typeof parsed === "object" && parsed !== null && typeof parsed.index === "number" && Array.isArray(parsed.tabs)) {
+      return parsed;
+    }
+    return null;
+  }
   wireDrop(pane) {
     const isTabDrag = (e) => e.dataTransfer?.types.includes(TAB_DND_MIME) ?? false;
     pane.container.addEventListener("dragover", (e) => {
@@ -7457,9 +7486,15 @@ var SplitView = class {
       }
       e.preventDefault();
       this.hideZone(pane);
-      const raw = e.dataTransfer?.getData(TAB_DND_MIME);
-      const tab = raw ? Number.parseInt(raw, 10) : Number.NaN;
-      if (Number.isNaN(tab) || tab < 0 || tab >= this.tabCount || !this.tree) {
+      const drag = this.parseDrag(e.dataTransfer?.getData(TAB_DND_MIME));
+      if (!drag || !this.tree) {
+        return;
+      }
+      const tab = drag.index;
+      if (tab < 0 || tab >= this.tabCount) {
+        return;
+      }
+      if (!sameTabs(drag.tabs, this.tabIds)) {
         return;
       }
       const zone = this.zoneAt(pane.container, e.clientX, e.clientY);
@@ -8051,6 +8086,9 @@ function sessionTabs(s) {
   }
   return [{ name: "agent", kind: 0 }];
 }
+function tabIdentity(tab) {
+  return `${tab.kind}:${tab.name}`;
+}
 function tabLabel(tab) {
   if (tab.kind === 0) {
     return "Agent";
@@ -8416,8 +8454,9 @@ var AppShell = class {
     const canManage = supportsTabManagement(selected);
     const active = Math.min(Math.max(state.activeTab, 0), tabs.length - 1);
     const shown = new Set(state.shownTabs);
+    const tabIds = tabs.map(tabIdentity);
     const children = tabs.map(
-      (tab, i) => tabButton(tab, i, i === active, shown.has(i), canManage, this.actions)
+      (tab, i) => tabButton(tab, i, i === active, shown.has(i), canManage, tabIds, this.actions)
     );
     if (canManage && tabs.length < MAX_TABS) {
       const add = h2("button", { type: "button", class: "af-tab-new", title: "New tab" }, "+");
@@ -8443,7 +8482,7 @@ var AppShell = class {
 function selectedSession(state) {
   return state.selectedId ? state.sessions.find((s) => s.id === state.selectedId) ?? null : null;
 }
-function tabButton(tab, index, active, shown, canManage, actions2) {
+function tabButton(tab, index, active, shown, canManage, tabIds, actions2) {
   const cls = `af-tab${active ? " af-tab-active" : ""}${shown && !active ? " af-tab-shown" : ""}`;
   const btn = h2("button", { type: "button", class: cls, draggable: true });
   btn.setAttribute("role", "tab");
@@ -8454,7 +8493,7 @@ function tabButton(tab, index, active, shown, canManage, actions2) {
     if (!e.dataTransfer) {
       return;
     }
-    e.dataTransfer.setData(TAB_DND_MIME, String(index));
+    e.dataTransfer.setData(TAB_DND_MIME, JSON.stringify({ index, tabs: tabIds }));
     e.dataTransfer.effectAllowed = "move";
     document.body.classList.add("af-dragging-tab");
   });
@@ -8924,8 +8963,8 @@ function syncSplit(state) {
   const tok = token;
   const initialTab = clampActiveTab(state.sessions, selId, state.activeTab);
   const selected = selId ? state.sessions.find((s) => s.id === selId) : null;
-  const tabCount = selected ? sessionTabs(selected).length : 1;
-  splitView.setSession(tok !== null ? selId : null, tok, tabCount, initialTab);
+  const tabIds = selected ? sessionTabs(selected).map(tabIdentity) : ["0:"];
+  splitView.setSession(tok !== null ? selId : null, tok, tabIds, initialTab);
 }
 function disposeSplit() {
   splitView.dispose();

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -6351,18 +6351,18 @@ var EventStream = class {
 
 // src/modals.ts
 function h(tag, props = {}, ...children) {
-  const el = document.createElement(tag);
+  const el2 = document.createElement(tag);
   for (const [key, value] of Object.entries(props)) {
     if (key === "class") {
-      el.className = value;
+      el2.className = value;
     } else {
-      el[key] = value;
+      el2[key] = value;
     }
   }
   for (const child of children) {
-    el.append(child);
+    el2.append(child);
   }
-  return el;
+  return el2;
 }
 function modalChrome(opts) {
   const body = h("div", { class: "af-modal-body" });
@@ -6551,9 +6551,21 @@ function nextSelection(orderedIds, selectedId, delta) {
   }
   return orderedIds[next] ?? null;
 }
-function decideKey(key, ctx) {
+function decideKey(key, ctx, mods = {}) {
   if (ctx.modalOpen) {
     return key === "Escape" ? { kind: "closeModal" } : { kind: "none" };
+  }
+  if (mods.alt === true && (key === "j" || key === "k" || key === "w")) {
+    if (ctx.view !== "sessions" || !ctx.selectedId) {
+      return { kind: "none" };
+    }
+    if (key === "j") {
+      return { kind: "cyclePane", delta: 1 };
+    }
+    if (key === "k") {
+      return { kind: "cyclePane", delta: -1 };
+    }
+    return { kind: "closePane" };
   }
   if (ctx.focus === "terminal") {
     return key === "Escape" ? { kind: "toRail" } : { kind: "none" };
@@ -6653,238 +6665,123 @@ function clampActiveTab(list, selectedId, activeTab) {
   return Math.min(Math.max(activeTab, 0), n - 1);
 }
 
-// src/store.ts
-var Store = class {
-  state;
-  listeners = /* @__PURE__ */ new Set();
-  constructor(initial) {
-    this.state = initial;
-  }
-  /** The current immutable snapshot of state. */
-  get() {
-    return this.state;
-  }
-  /** Merges a partial update and notifies every subscriber with the new state. */
-  set(patch) {
-    this.state = { ...this.state, ...patch };
-    for (const listener of this.listeners) {
-      listener(this.state);
-    }
-  }
-  /** Registers a listener and returns an unsubscribe function. */
-  subscribe(listener) {
-    this.listeners.add(listener);
-    return () => {
-      this.listeners.delete(listener);
-    };
-  }
-};
-
-// src/tasks.ts
-function genTaskId() {
-  const b = new Uint8Array(4);
-  crypto.getRandomValues(b);
-  return [...b].map((x) => x.toString(16).padStart(2, "0")).join("");
+// src/layout.ts
+var TAB_DND_MIME = "application/x-af-tab";
+var idSeq = 0;
+function nextId(prefix) {
+  idSeq += 1;
+  return `${prefix}${idSeq}`;
 }
-function buildTask(input) {
-  return {
-    id: genTaskId(),
-    name: input.name,
-    prompt: input.prompt,
-    cron_expr: input.trigger === "cron" ? input.cron : "",
-    watch_cmd: input.trigger === "watch" ? input.watchCmd : "",
-    target_session: input.targetSession,
-    project_path: input.projectPath,
-    program: input.program,
-    enabled: true,
-    created_at: (/* @__PURE__ */ new Date()).toISOString()
+function singleLeaf(tab) {
+  return { kind: "leaf", id: nextId("leaf"), tab };
+}
+function leaves(node) {
+  if (node.kind === "leaf") {
+    return [node];
+  }
+  return [...leaves(node.a), ...leaves(node.b)];
+}
+function leafCount(node) {
+  return leaves(node).length;
+}
+function findLeaf(node, id) {
+  if (node.kind === "leaf") {
+    return node.id === id ? node : null;
+  }
+  return findLeaf(node.a, id) ?? findLeaf(node.b, id);
+}
+function mapLeaf(node, id, fn) {
+  if (node.kind === "leaf") {
+    return node.id === id ? fn(node) : node;
+  }
+  return { ...node, a: mapLeaf(node.a, id, fn), b: mapLeaf(node.b, id, fn) };
+}
+function mapAllLeaves(node, fn) {
+  if (node.kind === "leaf") {
+    return fn(node);
+  }
+  const a = mapAllLeaves(node.a, fn);
+  const b = mapAllLeaves(node.b, fn);
+  if (a === node.a && b === node.b) {
+    return node;
+  }
+  return { ...node, a, b };
+}
+function closeLeaf(root2, leafId) {
+  const remove = (node) => {
+    if (node.kind === "leaf") {
+      return node.id === leafId ? null : node;
+    }
+    const a = remove(node.a);
+    const b = remove(node.b);
+    if (a === null) {
+      return b;
+    }
+    if (b === null) {
+      return a;
+    }
+    if (a === node.a && b === node.b) {
+      return node;
+    }
+    return { ...node, a, b };
   };
+  return remove(root2);
 }
-function triggerSummary(t) {
-  if (t.watch_cmd && t.watch_cmd.trim() !== "") {
-    return `watch: ${t.watch_cmd}`;
+function dedupeExcept(root2, tab, keepId) {
+  const dupes = leaves(root2).filter((l) => l.tab === tab && l.id !== keepId);
+  let cur = root2;
+  for (const d of dupes) {
+    cur = closeLeaf(cur, d.id) ?? cur;
   }
-  if (t.cron_expr && t.cron_expr.trim() !== "") {
-    return `cron: ${t.cron_expr}`;
-  }
-  return "no trigger";
+  return cur;
 }
-function canTrigger(t) {
-  return t.enabled && !!t.cron_expr && t.cron_expr.trim() !== "" && !(t.watch_cmd && t.watch_cmd.trim() !== "");
-}
-function lastRunSummary(t) {
-  if (!t.last_run_at) {
-    return "never run";
+function splitLeaf(root2, leafId, edge, tab) {
+  if (edge === "center") {
+    return replaceTab(root2, leafId, tab);
   }
-  const status = t.last_run_status ? ` (${t.last_run_status})` : "";
-  return `last run ${t.last_run_at}${status}`;
-}
-var TasksPane = class {
-  constructor(actions2) {
-    this.actions = actions2;
-    this.el = h("section", { class: "af-tasks" });
-    this.el.setAttribute("aria-label", "Tasks");
-  }
-  el;
-  lastTasks = null;
-  update(tasks) {
-    if (this.lastTasks === tasks) {
-      return;
-    }
-    this.lastTasks = tasks;
-    this.render(tasks);
-  }
-  render(tasks) {
-    const addBtn = h("button", { type: "button", class: "af-tasks-add", title: "Add task" }, "+ Add");
-    addBtn.addEventListener("click", () => this.actions.add());
-    const head = h(
-      "div",
-      { class: "af-tasks-head" },
-      h("span", { class: "af-tasks-title" }, "Tasks"),
-      h("span", { class: "af-view-count" }, String(tasks.length)),
-      addBtn
-    );
-    if (tasks.length === 0) {
-      this.el.replaceChildren(
-        head,
-        h(
-          "p",
-          { class: "af-tasks-empty" },
-          "No scheduled tasks yet. Add one to deliver a prompt on a cron schedule."
-        )
-      );
-      return;
-    }
-    const rows = [...tasks].sort((a, b) => a.created_at < b.created_at ? -1 : a.created_at > b.created_at ? 1 : 0).map((t) => this.taskRow(t));
-    this.el.replaceChildren(head, h("ul", { class: "af-tasks-list" }, ...rows));
-  }
-  taskRow(t) {
-    const glyph = t.enabled ? "[\u2713]" : "[ ]";
-    const enabledDot = h("span", { class: `af-task-enabled${t.enabled ? " af-task-on" : ""}` }, glyph);
-    enabledDot.setAttribute("aria-hidden", "true");
-    const name = h("div", { class: "af-task-name" }, t.name && t.name.trim() !== "" ? t.name : "(unnamed task)");
-    const trigger = h("div", { class: "af-task-trigger" }, triggerSummary(t));
-    const metaParts = [];
-    if (t.target_session && t.target_session.trim() !== "") {
-      metaParts.push(`\u2192 ${t.target_session}`);
-    }
-    metaParts.push(lastRunSummary(t));
-    const meta = h("div", { class: "af-task-meta" }, metaParts.join("  \xB7  "));
-    const main = h("div", { class: "af-task-main" }, name, trigger, meta);
-    const toggleBtn = h(
-      "button",
-      { type: "button", class: "af-ghost af-task-action" },
-      t.enabled ? "Disable" : "Enable"
-    );
-    toggleBtn.addEventListener("click", () => this.actions.toggle(t));
-    const actionEls = [toggleBtn];
-    if (canTrigger(t)) {
-      const triggerBtn = h("button", { type: "button", class: "af-ghost af-task-action" }, "Trigger");
-      triggerBtn.addEventListener("click", () => this.actions.trigger(t));
-      actionEls.push(triggerBtn);
-    }
-    const removeBtn = h("button", { type: "button", class: "af-danger af-task-action" }, "Remove");
-    removeBtn.addEventListener("click", () => this.actions.remove(t));
-    actionEls.push(removeBtn);
-    const actions2 = h("div", { class: "af-task-actions" }, ...actionEls);
-    return h("li", { class: "af-task-row" }, enabledDot, main, actions2);
-  }
-};
-function addTaskModal(projects, callbacks) {
-  const { handle, body, confirmBtn } = modalChrome({
-    title: "Add task",
-    confirmLabel: "Add",
-    confirmClass: "af-primary",
-    onCancel: callbacks.onCancel
+  const dir = edge === "left" || edge === "right" ? "row" : "column";
+  const newFirst = edge === "left" || edge === "top";
+  const fresh = { kind: "leaf", id: nextId("leaf"), tab };
+  const grown = mapLeaf(root2, leafId, (leaf) => {
+    const [a, b] = newFirst ? [fresh, leaf] : [leaf, fresh];
+    return { kind: "split", id: nextId("split"), dir, ratio: 0.5, a, b };
   });
-  const nameInput = h("input", { type: "text", class: "af-input", placeholder: "Task name", autocomplete: "off" });
-  nameInput.setAttribute("aria-label", "Task name");
-  const projectSelect = h("select", { class: "af-input" });
-  projectSelect.setAttribute("aria-label", "Project");
-  if (projects.length === 0) {
-    const opt = h("option", { value: "" }, "No projects yet \u2014 create a session first");
-    opt.disabled = true;
-    opt.selected = true;
-    projectSelect.append(opt);
-    confirmBtn.disabled = true;
-  } else {
-    for (const p of projects) {
-      projectSelect.append(h("option", { value: p }, projectLabel(p)));
+  return dedupeExcept(grown, tab, fresh.id);
+}
+function replaceTab(root2, leafId, tab) {
+  const target = findLeaf(root2, leafId);
+  if (!target || target.tab === tab) {
+    return dedupeExcept(root2, tab, leafId);
+  }
+  const updated = mapLeaf(root2, leafId, (leaf) => ({ ...leaf, tab }));
+  return dedupeExcept(updated, tab, leafId);
+}
+function setRatio(root2, splitId, ratio) {
+  const clamped = Math.min(0.9, Math.max(0.1, ratio));
+  const rec = (node) => {
+    if (node.kind === "leaf") {
+      return node;
+    }
+    if (node.id === splitId) {
+      return { ...node, ratio: clamped };
+    }
+    return { ...node, a: rec(node.a), b: rec(node.b) };
+  };
+  return rec(root2);
+}
+function validate(root2, tabCount) {
+  const max = Math.max(0, tabCount - 1);
+  const clamped = mapAllLeaves(root2, (leaf) => leaf.tab > max ? { ...leaf, tab: max } : leaf);
+  const seen = /* @__PURE__ */ new Set();
+  let cur = clamped;
+  for (const l of leaves(clamped)) {
+    if (seen.has(l.tab)) {
+      cur = closeLeaf(cur, l.id) ?? cur;
+    } else {
+      seen.add(l.tab);
     }
   }
-  const triggerSelect = h("select", { class: "af-input" });
-  triggerSelect.setAttribute("aria-label", "Trigger type");
-  triggerSelect.append(h("option", { value: "cron" }, "Cron schedule"));
-  triggerSelect.append(h("option", { value: "watch" }, "Watch command"));
-  const cronInput = h("input", { type: "text", class: "af-input", placeholder: "0 9 * * *", autocomplete: "off" });
-  cronInput.setAttribute("aria-label", "Cron expression");
-  const cronField = field("Cron expression", cronInput);
-  const watchInput = h("input", { type: "text", class: "af-input", placeholder: "tail -F events.log", autocomplete: "off" });
-  watchInput.setAttribute("aria-label", "Watch command");
-  const watchField = field("Watch command", watchInput);
-  watchField.hidden = true;
-  triggerSelect.addEventListener("change", () => {
-    const isWatch = triggerSelect.value === "watch";
-    cronField.hidden = isWatch;
-    watchField.hidden = !isWatch;
-  });
-  const promptArea = h("textarea", { class: "af-input af-textarea", placeholder: "Prompt to deliver ({{line}} for the watch line)", rows: 3 });
-  promptArea.setAttribute("aria-label", "Prompt");
-  const targetInput = h("input", { type: "text", class: "af-input", placeholder: "Target session (optional)", autocomplete: "off" });
-  targetInput.setAttribute("aria-label", "Target session");
-  const programSelect = h("select", { class: "af-input" });
-  programSelect.setAttribute("aria-label", "Program");
-  programSelect.append(h("option", { value: "" }, "Repo default"));
-  for (const prog of ["claude", "codex", "aider", "gemini", "amp"]) {
-    programSelect.append(h("option", { value: prog }, prog));
-  }
-  body.append(
-    field("Name", nameInput),
-    field("Project", projectSelect),
-    field("Trigger", triggerSelect),
-    cronField,
-    watchField,
-    field("Prompt", promptArea),
-    field("Target session", targetInput),
-    field("Program", programSelect)
-  );
-  const card = handle.el.firstElementChild;
-  asForm(card, () => {
-    const trigger = triggerSelect.value === "watch" ? "watch" : "cron";
-    const name = nameInput.value.trim();
-    const cron = cronInput.value.trim();
-    const watchCmd = watchInput.value.trim();
-    const prompt = promptArea.value.trim();
-    if (name === "" || projectSelect.value === "") {
-      handle.setError("A name and a project are required.");
-      return;
-    }
-    if (trigger === "cron" && cron === "") {
-      handle.setError("A cron expression is required for a cron task.");
-      return;
-    }
-    if (trigger === "cron" && prompt === "") {
-      handle.setError("A prompt is required for a cron task.");
-      return;
-    }
-    if (trigger === "watch" && watchCmd === "") {
-      handle.setError("A watch command is required for a watch task.");
-      return;
-    }
-    handle.setError(null);
-    callbacks.onSubmit({
-      name,
-      projectPath: projectSelect.value,
-      trigger,
-      cron,
-      watchCmd,
-      prompt: promptArea.value,
-      targetSession: targetInput.value.trim(),
-      program: programSelect.value
-    });
-  });
-  queueMicrotask(() => nameInput.focus());
-  return handle;
+  return cur;
 }
 
 // src/terminal.ts
@@ -7249,6 +7146,658 @@ var AttachTerminal = class {
   }
 };
 
+// src/split.ts
+var EDGE_BAND = 0.3;
+function el(tag, cls) {
+  const node = document.createElement(tag);
+  node.className = cls;
+  return node;
+}
+var SplitView = class {
+  constructor(host, cb) {
+    this.host = host;
+    this.cb = cb;
+  }
+  // Retained layout per session id (in-memory; a nice-to-have to persist across
+  // reload is out of scope for v1). Keyed by the stable session id.
+  trees = /* @__PURE__ */ new Map();
+  panes = /* @__PURE__ */ new Map();
+  sessionId = null;
+  token = null;
+  tabCount = 1;
+  tree = null;
+  focusedId = null;
+  // Debounces the "focus left every pane" report so a click that moves focus A→B
+  // (blur A, then focus B) doesn't flap the nav mode through rail and back.
+  blurTimer = null;
+  // Last values reported via onLayout, so a no-op reconcile never re-fires it (which
+  // would re-enter the store→rerender→setSession loop).
+  lastFocusedTab = -1;
+  lastShown = "";
+  lastPaneCount = 0;
+  /**
+   * Shows `sessionId`'s layout, building/rebuilding terminals as needed. Called on
+   * every selection/tab change: a NEW session rebuilds from its retained tree (or a
+   * fresh single leaf bound to `initialTab`); the SAME session only re-validates the
+   * tree against the current tab list (a tab closed elsewhere). Cheap on a no-op.
+   */
+  setSession(sessionId, token2, tabCount, initialTab) {
+    this.token = token2;
+    if (sessionId === null || token2 === null) {
+      this.teardown();
+      this.sessionId = null;
+      this.tree = null;
+      this.report();
+      return;
+    }
+    if (sessionId === this.sessionId) {
+      this.tabCount = tabCount;
+      const before = this.tree;
+      this.tree = validate(this.tree ?? singleLeaf(initialTab), tabCount);
+      if (this.trees.get(sessionId) !== this.tree) {
+        this.trees.set(sessionId, this.tree);
+      }
+      if (before !== this.tree) {
+        this.reconcile();
+        this.report();
+      }
+      return;
+    }
+    this.teardown();
+    this.sessionId = sessionId;
+    this.tabCount = tabCount;
+    const retained = this.trees.get(sessionId);
+    this.tree = validate(retained ?? singleLeaf(initialTab), tabCount);
+    this.trees.set(sessionId, this.tree);
+    this.focusedId = leaves(this.tree)[0]?.id ?? null;
+    this.reconcile();
+    this.report();
+  }
+  /** Rebinds the FOCUSED pane to show `tab` (a 1-9 key or a tab-bar click on the
+   *  focused pane). No-op without a focused pane. Does not steal DOM focus. */
+  setFocusedTab(tab) {
+    if (!this.tree || !this.focusedId) {
+      return;
+    }
+    this.tree = replaceTab(this.tree, this.focusedId, tab);
+    this.commit();
+  }
+  /** Gives the keyboard to the focused pane's terminal (attach). */
+  focus() {
+    const pane = this.focusedId ? this.panes.get(this.focusedId) : null;
+    pane?.term?.focus();
+  }
+  /** Takes the keyboard away from every pane (back to rail nav). */
+  blur() {
+    for (const pane of this.panes.values()) {
+      pane.term?.blur();
+    }
+  }
+  /** Moves pane focus by `delta` (wrapping) and attaches the newly focused pane. */
+  cyclePane(delta) {
+    if (!this.tree) {
+      return;
+    }
+    const ids = leaves(this.tree).map((l) => l.id);
+    if (ids.length <= 1) {
+      this.focus();
+      return;
+    }
+    const cur = this.focusedId ? ids.indexOf(this.focusedId) : -1;
+    const next = ids[(cur + delta + ids.length) % ids.length];
+    if (next) {
+      this.focusPane(next);
+      this.focus();
+    }
+  }
+  /** Closes the focused pane, collapsing its split. No-op when it is the only pane
+   *  (a session always shows at least one terminal — close the TAB instead). */
+  closeFocusedPane() {
+    if (this.focusedId) {
+      this.closePane(this.focusedId);
+    }
+  }
+  /** Whether the layout currently has more than one pane. */
+  isSplit() {
+    return this.tree ? leafCount(this.tree) > 1 : false;
+  }
+  /** Tears down every live terminal and clears the host (logout / deselect). The
+   *  retained trees survive so a re-selection restores the split. */
+  dispose() {
+    this.teardown();
+    this.sessionId = null;
+    this.tree = null;
+  }
+  // --- internal: mutation commit --------------------------------------------
+  /** Persists the current tree for the session, re-renders, and reports the layout. */
+  commit() {
+    if (this.sessionId && this.tree) {
+      this.trees.set(this.sessionId, this.tree);
+    }
+    this.reconcile();
+    this.report();
+  }
+  closePane(leafId) {
+    if (!this.tree) {
+      return;
+    }
+    const next = closeLeaf(this.tree, leafId);
+    if (next === null) {
+      return;
+    }
+    this.tree = next;
+    if (this.focusedId === leafId) {
+      this.focusedId = leaves(this.tree)[0]?.id ?? null;
+    }
+    this.commit();
+    this.focus();
+  }
+  // --- internal: reconcile tree → DOM + terminals ---------------------------
+  teardown() {
+    for (const pane of this.panes.values()) {
+      pane.term?.dispose();
+    }
+    this.panes.clear();
+    this.host.replaceChildren();
+    this.host.classList.remove("af-split-multi");
+    this.focusedId = null;
+  }
+  /** Brings the live panes + DOM in line with the current tree: disposes gone panes,
+   *  (re)creates terminals whose tab changed, rebuilds the split wrappers (reusing
+   *  the persistent pane containers so surviving xterms are only reparented, never
+   *  recreated), and refreshes focus/head chrome. */
+  reconcile() {
+    if (!this.tree || !this.sessionId || this.token === null) {
+      return;
+    }
+    const desired = leaves(this.tree);
+    const wanted = new Set(desired.map((l) => l.id));
+    for (const [id, pane] of this.panes) {
+      if (!wanted.has(id)) {
+        pane.term?.dispose();
+        this.panes.delete(id);
+      }
+    }
+    for (const leaf of desired) {
+      if (!this.panes.has(leaf.id)) {
+        this.panes.set(leaf.id, this.createPane(leaf));
+      }
+    }
+    if (!this.focusedId || !wanted.has(this.focusedId)) {
+      this.focusedId = desired[0]?.id ?? null;
+    }
+    const rootEl = this.buildNode(this.tree);
+    rootEl.style.flex = "1 1 0";
+    this.host.replaceChildren(rootEl);
+    const multi = desired.length > 1;
+    this.host.classList.toggle("af-split-multi", multi);
+    for (const leaf of desired) {
+      const pane = this.panes.get(leaf.id);
+      if (!pane) {
+        continue;
+      }
+      if (!pane.term || pane.tab !== leaf.tab) {
+        pane.term?.dispose();
+        pane.host.replaceChildren();
+        pane.tab = leaf.tab;
+        pane.status = "connecting";
+        pane.term = new AttachTerminal(pane.host, this.sessionId, this.token, leaf.tab, {
+          onStatus: (s) => this.onPaneStatus(leaf.id, s),
+          onFocusChange: (f) => this.onPaneFocus(leaf.id, f)
+        });
+      }
+      pane.container.classList.toggle("af-pane-multi", multi);
+      pane.label.textContent = `Tab ${leaf.tab + 1}`;
+    }
+    this.applyFocusClass();
+  }
+  createPane(leaf) {
+    const container = el("div", "af-pane");
+    container.setAttribute("data-leaf", leaf.id);
+    const head = el("div", "af-pane-head");
+    const label = el("span", "af-pane-label");
+    const closeBtn = document.createElement("button");
+    closeBtn.type = "button";
+    closeBtn.className = "af-pane-close";
+    closeBtn.title = "Close pane";
+    closeBtn.setAttribute("aria-label", "Close pane");
+    closeBtn.textContent = "\xD7";
+    closeBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this.closePane(leaf.id);
+    });
+    head.append(label, closeBtn);
+    const paneHost = el("div", "af-pane-host");
+    const overlay = el("div", "af-drop-overlay");
+    container.append(head, paneHost, overlay);
+    container.addEventListener("mousedown", () => this.focusPane(leaf.id));
+    const pane = { leafId: leaf.id, container, host: paneHost, label, overlay, term: null, tab: -1, status: "connecting" };
+    this.wireDrop(pane);
+    return pane;
+  }
+  buildNode(node) {
+    if (node.kind === "leaf") {
+      return this.panes.get(node.id)?.container ?? el("div", "af-pane");
+    }
+    const a = this.buildNode(node.a);
+    const b = this.buildNode(node.b);
+    a.style.flex = `${node.ratio} 1 0`;
+    b.style.flex = `${1 - node.ratio} 1 0`;
+    const divider = this.buildDivider(node, a, b);
+    const wrap = el("div", `af-split af-split-${node.dir}`);
+    wrap.append(a, divider, b);
+    return wrap;
+  }
+  buildDivider(node, aEl, bEl) {
+    const divider = el("div", `af-divider af-divider-${node.dir}`);
+    divider.setAttribute("role", "separator");
+    divider.addEventListener("pointerdown", (e) => {
+      e.preventDefault();
+      const parent = divider.parentElement;
+      if (!parent) {
+        return;
+      }
+      divider.setPointerCapture(e.pointerId);
+      document.body.classList.add(node.dir === "row" ? "af-resizing-col" : "af-resizing-row");
+      const rect = parent.getBoundingClientRect();
+      const onMove = (ev) => {
+        const ratio = node.dir === "row" ? (ev.clientX - rect.left) / rect.width : (ev.clientY - rect.top) / rect.height;
+        const clamped = Math.min(0.9, Math.max(0.1, ratio));
+        node.ratio = clamped;
+        aEl.style.flex = `${clamped} 1 0`;
+        bEl.style.flex = `${1 - clamped} 1 0`;
+      };
+      const onUp = (ev) => {
+        divider.releasePointerCapture(ev.pointerId);
+        divider.removeEventListener("pointermove", onMove);
+        divider.removeEventListener("pointerup", onUp);
+        document.body.classList.remove("af-resizing-col", "af-resizing-row");
+        if (this.tree) {
+          this.tree = setRatio(this.tree, node.id, node.ratio);
+          if (this.sessionId) {
+            this.trees.set(this.sessionId, this.tree);
+          }
+        }
+      };
+      divider.addEventListener("pointermove", onMove);
+      divider.addEventListener("pointerup", onUp);
+    });
+    return divider;
+  }
+  // --- internal: drag-and-drop ----------------------------------------------
+  wireDrop(pane) {
+    const isTabDrag = (e) => e.dataTransfer?.types.includes(TAB_DND_MIME) ?? false;
+    pane.container.addEventListener("dragover", (e) => {
+      if (!isTabDrag(e)) {
+        return;
+      }
+      e.preventDefault();
+      if (e.dataTransfer) {
+        e.dataTransfer.dropEffect = "move";
+      }
+      this.showZone(pane, this.zoneAt(pane.container, e.clientX, e.clientY));
+    });
+    pane.container.addEventListener("dragleave", (e) => {
+      const to = e.relatedTarget;
+      if (to && pane.container.contains(to)) {
+        return;
+      }
+      this.hideZone(pane);
+    });
+    pane.container.addEventListener("drop", (e) => {
+      if (!isTabDrag(e)) {
+        return;
+      }
+      e.preventDefault();
+      this.hideZone(pane);
+      const raw = e.dataTransfer?.getData(TAB_DND_MIME);
+      const tab = raw ? Number.parseInt(raw, 10) : Number.NaN;
+      if (Number.isNaN(tab) || !this.tree) {
+        return;
+      }
+      const zone = this.zoneAt(pane.container, e.clientX, e.clientY);
+      this.tree = zone === "center" ? replaceTab(this.tree, pane.leafId, tab) : splitLeaf(this.tree, pane.leafId, zone, tab);
+      const landed = leaves(this.tree).find((l) => l.tab === tab);
+      if (landed) {
+        this.focusedId = landed.id;
+      }
+      this.commit();
+      this.focus();
+    });
+  }
+  /** The drop zone for a pointer position over a pane: an edge (outer band) or the
+   *  center. */
+  zoneAt(container, x, y) {
+    const r = container.getBoundingClientRect();
+    if (r.width === 0 || r.height === 0) {
+      return "center";
+    }
+    const fx = (x - r.left) / r.width;
+    const fy = (y - r.top) / r.height;
+    const d = { left: fx, right: 1 - fx, top: fy, bottom: 1 - fy };
+    const min = Math.min(d.left, d.right, d.top, d.bottom);
+    if (min > EDGE_BAND) {
+      return "center";
+    }
+    if (min === d.left) {
+      return "left";
+    }
+    if (min === d.right) {
+      return "right";
+    }
+    if (min === d.top) {
+      return "top";
+    }
+    return "bottom";
+  }
+  showZone(pane, zone) {
+    pane.overlay.className = `af-drop-overlay af-drop-show af-drop-${zone}`;
+  }
+  hideZone(pane) {
+    pane.overlay.className = "af-drop-overlay";
+  }
+  // --- internal: focus + status ---------------------------------------------
+  focusPane(leafId) {
+    if (this.focusedId === leafId) {
+      return;
+    }
+    this.focusedId = leafId;
+    this.applyFocusClass();
+    const pane = this.panes.get(leafId);
+    if (pane) {
+      this.cb.onStatus(pane.status);
+    }
+    this.report();
+  }
+  applyFocusClass() {
+    for (const [id, pane] of this.panes) {
+      pane.container.classList.toggle("af-pane-focused", id === this.focusedId);
+    }
+  }
+  onPaneStatus(leafId, status) {
+    const pane = this.panes.get(leafId);
+    if (pane) {
+      pane.status = status;
+    }
+    if (leafId === this.focusedId) {
+      this.cb.onStatus(status);
+    }
+  }
+  onPaneFocus(leafId, focused) {
+    if (focused) {
+      if (this.blurTimer !== null) {
+        window.clearTimeout(this.blurTimer);
+        this.blurTimer = null;
+      }
+      if (this.focusedId !== leafId) {
+        this.focusPane(leafId);
+      }
+      this.cb.onFocusChange(true);
+      return;
+    }
+    if (this.blurTimer !== null) {
+      window.clearTimeout(this.blurTimer);
+    }
+    this.blurTimer = window.setTimeout(() => {
+      this.blurTimer = null;
+      const active = document.activeElement;
+      const stillInPane = active ? [...this.panes.values()].some((p) => p.host.contains(active)) : false;
+      if (!stillInPane) {
+        this.cb.onFocusChange(false);
+      }
+    }, 0);
+  }
+  /** Fires onLayout when the focused tab, the shown-tab set, or the pane count
+   *  changed — never on a no-op, so writing the store from it can't loop. */
+  report() {
+    const shownTabs = this.tree ? leaves(this.tree).map((l) => l.tab) : [];
+    const focusedTab = this.focusedId ? findLeaf(this.tree ?? { kind: "leaf", id: "", tab: 0 }, this.focusedId)?.tab ?? 0 : 0;
+    const paneCount = shownTabs.length;
+    const shownKey = shownTabs.join(",");
+    if (focusedTab === this.lastFocusedTab && shownKey === this.lastShown && paneCount === this.lastPaneCount) {
+      return;
+    }
+    this.lastFocusedTab = focusedTab;
+    this.lastShown = shownKey;
+    this.lastPaneCount = paneCount;
+    this.cb.onLayout({ focusedTab, shownTabs, paneCount });
+  }
+};
+
+// src/store.ts
+var Store = class {
+  state;
+  listeners = /* @__PURE__ */ new Set();
+  constructor(initial) {
+    this.state = initial;
+  }
+  /** The current immutable snapshot of state. */
+  get() {
+    return this.state;
+  }
+  /** Merges a partial update and notifies every subscriber with the new state. */
+  set(patch) {
+    this.state = { ...this.state, ...patch };
+    for (const listener of this.listeners) {
+      listener(this.state);
+    }
+  }
+  /** Registers a listener and returns an unsubscribe function. */
+  subscribe(listener) {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+};
+
+// src/tasks.ts
+function genTaskId() {
+  const b = new Uint8Array(4);
+  crypto.getRandomValues(b);
+  return [...b].map((x) => x.toString(16).padStart(2, "0")).join("");
+}
+function buildTask(input) {
+  return {
+    id: genTaskId(),
+    name: input.name,
+    prompt: input.prompt,
+    cron_expr: input.trigger === "cron" ? input.cron : "",
+    watch_cmd: input.trigger === "watch" ? input.watchCmd : "",
+    target_session: input.targetSession,
+    project_path: input.projectPath,
+    program: input.program,
+    enabled: true,
+    created_at: (/* @__PURE__ */ new Date()).toISOString()
+  };
+}
+function triggerSummary(t) {
+  if (t.watch_cmd && t.watch_cmd.trim() !== "") {
+    return `watch: ${t.watch_cmd}`;
+  }
+  if (t.cron_expr && t.cron_expr.trim() !== "") {
+    return `cron: ${t.cron_expr}`;
+  }
+  return "no trigger";
+}
+function canTrigger(t) {
+  return t.enabled && !!t.cron_expr && t.cron_expr.trim() !== "" && !(t.watch_cmd && t.watch_cmd.trim() !== "");
+}
+function lastRunSummary(t) {
+  if (!t.last_run_at) {
+    return "never run";
+  }
+  const status = t.last_run_status ? ` (${t.last_run_status})` : "";
+  return `last run ${t.last_run_at}${status}`;
+}
+var TasksPane = class {
+  constructor(actions2) {
+    this.actions = actions2;
+    this.el = h("section", { class: "af-tasks" });
+    this.el.setAttribute("aria-label", "Tasks");
+  }
+  el;
+  lastTasks = null;
+  update(tasks) {
+    if (this.lastTasks === tasks) {
+      return;
+    }
+    this.lastTasks = tasks;
+    this.render(tasks);
+  }
+  render(tasks) {
+    const addBtn = h("button", { type: "button", class: "af-tasks-add", title: "Add task" }, "+ Add");
+    addBtn.addEventListener("click", () => this.actions.add());
+    const head = h(
+      "div",
+      { class: "af-tasks-head" },
+      h("span", { class: "af-tasks-title" }, "Tasks"),
+      h("span", { class: "af-view-count" }, String(tasks.length)),
+      addBtn
+    );
+    if (tasks.length === 0) {
+      this.el.replaceChildren(
+        head,
+        h(
+          "p",
+          { class: "af-tasks-empty" },
+          "No scheduled tasks yet. Add one to deliver a prompt on a cron schedule."
+        )
+      );
+      return;
+    }
+    const rows = [...tasks].sort((a, b) => a.created_at < b.created_at ? -1 : a.created_at > b.created_at ? 1 : 0).map((t) => this.taskRow(t));
+    this.el.replaceChildren(head, h("ul", { class: "af-tasks-list" }, ...rows));
+  }
+  taskRow(t) {
+    const glyph = t.enabled ? "[\u2713]" : "[ ]";
+    const enabledDot = h("span", { class: `af-task-enabled${t.enabled ? " af-task-on" : ""}` }, glyph);
+    enabledDot.setAttribute("aria-hidden", "true");
+    const name = h("div", { class: "af-task-name" }, t.name && t.name.trim() !== "" ? t.name : "(unnamed task)");
+    const trigger = h("div", { class: "af-task-trigger" }, triggerSummary(t));
+    const metaParts = [];
+    if (t.target_session && t.target_session.trim() !== "") {
+      metaParts.push(`\u2192 ${t.target_session}`);
+    }
+    metaParts.push(lastRunSummary(t));
+    const meta = h("div", { class: "af-task-meta" }, metaParts.join("  \xB7  "));
+    const main = h("div", { class: "af-task-main" }, name, trigger, meta);
+    const toggleBtn = h(
+      "button",
+      { type: "button", class: "af-ghost af-task-action" },
+      t.enabled ? "Disable" : "Enable"
+    );
+    toggleBtn.addEventListener("click", () => this.actions.toggle(t));
+    const actionEls = [toggleBtn];
+    if (canTrigger(t)) {
+      const triggerBtn = h("button", { type: "button", class: "af-ghost af-task-action" }, "Trigger");
+      triggerBtn.addEventListener("click", () => this.actions.trigger(t));
+      actionEls.push(triggerBtn);
+    }
+    const removeBtn = h("button", { type: "button", class: "af-danger af-task-action" }, "Remove");
+    removeBtn.addEventListener("click", () => this.actions.remove(t));
+    actionEls.push(removeBtn);
+    const actions2 = h("div", { class: "af-task-actions" }, ...actionEls);
+    return h("li", { class: "af-task-row" }, enabledDot, main, actions2);
+  }
+};
+function addTaskModal(projects, callbacks) {
+  const { handle, body, confirmBtn } = modalChrome({
+    title: "Add task",
+    confirmLabel: "Add",
+    confirmClass: "af-primary",
+    onCancel: callbacks.onCancel
+  });
+  const nameInput = h("input", { type: "text", class: "af-input", placeholder: "Task name", autocomplete: "off" });
+  nameInput.setAttribute("aria-label", "Task name");
+  const projectSelect = h("select", { class: "af-input" });
+  projectSelect.setAttribute("aria-label", "Project");
+  if (projects.length === 0) {
+    const opt = h("option", { value: "" }, "No projects yet \u2014 create a session first");
+    opt.disabled = true;
+    opt.selected = true;
+    projectSelect.append(opt);
+    confirmBtn.disabled = true;
+  } else {
+    for (const p of projects) {
+      projectSelect.append(h("option", { value: p }, projectLabel(p)));
+    }
+  }
+  const triggerSelect = h("select", { class: "af-input" });
+  triggerSelect.setAttribute("aria-label", "Trigger type");
+  triggerSelect.append(h("option", { value: "cron" }, "Cron schedule"));
+  triggerSelect.append(h("option", { value: "watch" }, "Watch command"));
+  const cronInput = h("input", { type: "text", class: "af-input", placeholder: "0 9 * * *", autocomplete: "off" });
+  cronInput.setAttribute("aria-label", "Cron expression");
+  const cronField = field("Cron expression", cronInput);
+  const watchInput = h("input", { type: "text", class: "af-input", placeholder: "tail -F events.log", autocomplete: "off" });
+  watchInput.setAttribute("aria-label", "Watch command");
+  const watchField = field("Watch command", watchInput);
+  watchField.hidden = true;
+  triggerSelect.addEventListener("change", () => {
+    const isWatch = triggerSelect.value === "watch";
+    cronField.hidden = isWatch;
+    watchField.hidden = !isWatch;
+  });
+  const promptArea = h("textarea", { class: "af-input af-textarea", placeholder: "Prompt to deliver ({{line}} for the watch line)", rows: 3 });
+  promptArea.setAttribute("aria-label", "Prompt");
+  const targetInput = h("input", { type: "text", class: "af-input", placeholder: "Target session (optional)", autocomplete: "off" });
+  targetInput.setAttribute("aria-label", "Target session");
+  const programSelect = h("select", { class: "af-input" });
+  programSelect.setAttribute("aria-label", "Program");
+  programSelect.append(h("option", { value: "" }, "Repo default"));
+  for (const prog of ["claude", "codex", "aider", "gemini", "amp"]) {
+    programSelect.append(h("option", { value: prog }, prog));
+  }
+  body.append(
+    field("Name", nameInput),
+    field("Project", projectSelect),
+    field("Trigger", triggerSelect),
+    cronField,
+    watchField,
+    field("Prompt", promptArea),
+    field("Target session", targetInput),
+    field("Program", programSelect)
+  );
+  const card = handle.el.firstElementChild;
+  asForm(card, () => {
+    const trigger = triggerSelect.value === "watch" ? "watch" : "cron";
+    const name = nameInput.value.trim();
+    const cron = cronInput.value.trim();
+    const watchCmd = watchInput.value.trim();
+    const prompt = promptArea.value.trim();
+    if (name === "" || projectSelect.value === "") {
+      handle.setError("A name and a project are required.");
+      return;
+    }
+    if (trigger === "cron" && cron === "") {
+      handle.setError("A cron expression is required for a cron task.");
+      return;
+    }
+    if (trigger === "cron" && prompt === "") {
+      handle.setError("A prompt is required for a cron task.");
+      return;
+    }
+    if (trigger === "watch" && watchCmd === "") {
+      handle.setError("A watch command is required for a watch task.");
+      return;
+    }
+    handle.setError(null);
+    callbacks.onSubmit({
+      name,
+      projectPath: projectSelect.value,
+      trigger,
+      cron,
+      watchCmd,
+      prompt: promptArea.value,
+      targetSession: targetInput.value.trim(),
+      program: programSelect.value
+    });
+  });
+  queueMicrotask(() => nameInput.focus());
+  return handle;
+}
+
 // src/types.ts
 var Liveness = {
   Unset: 0,
@@ -7525,18 +8074,18 @@ function viewLabel(view) {
   }
 }
 function h2(tag, props = {}, ...children) {
-  const el = document.createElement(tag);
+  const el2 = document.createElement(tag);
   for (const [key, value] of Object.entries(props)) {
     if (key === "class") {
-      el.className = value;
+      el2.className = value;
     } else {
-      el[key] = value;
+      el2[key] = value;
     }
   }
   for (const child of children) {
-    el.append(child);
+    el2.append(child);
   }
-  return el;
+  return el2;
 }
 function orderedSessions(sessions) {
   return [...sessions].sort(compareSessionsForRail);
@@ -7859,7 +8408,10 @@ var AppShell = class {
     const tabs = sessionTabs(selected);
     const canManage = supportsTabManagement(selected);
     const active = Math.min(Math.max(state.activeTab, 0), tabs.length - 1);
-    const children = tabs.map((tab, i) => tabButton(tab, i, i === active, canManage, this.actions));
+    const shown = new Set(state.shownTabs);
+    const children = tabs.map(
+      (tab, i) => tabButton(tab, i, i === active, shown.has(i), canManage, this.actions)
+    );
     if (canManage && tabs.length < MAX_TABS) {
       const add = h2("button", { type: "button", class: "af-tab-new", title: "New tab" }, "+");
       add.addEventListener("click", () => this.actions.newTab());
@@ -7884,12 +8436,22 @@ var AppShell = class {
 function selectedSession(state) {
   return state.selectedId ? state.sessions.find((s) => s.id === state.selectedId) ?? null : null;
 }
-function tabButton(tab, index, active, canManage, actions2) {
-  const btn = h2("button", { type: "button", class: `af-tab${active ? " af-tab-active" : ""}` });
+function tabButton(tab, index, active, shown, canManage, actions2) {
+  const cls = `af-tab${active ? " af-tab-active" : ""}${shown && !active ? " af-tab-shown" : ""}`;
+  const btn = h2("button", { type: "button", class: cls, draggable: true });
   btn.setAttribute("role", "tab");
   btn.setAttribute("aria-selected", active ? "true" : "false");
   btn.append(h2("span", { class: "af-tab-label" }, tabLabel(tab)));
   btn.addEventListener("click", () => actions2.openTab(index));
+  btn.addEventListener("dragstart", (e) => {
+    if (!e.dataTransfer) {
+      return;
+    }
+    e.dataTransfer.setData(TAB_DND_MIME, String(index));
+    e.dataTransfer.effectAllowed = "move";
+    document.body.classList.add("af-dragging-tab");
+  });
+  btn.addEventListener("dragend", () => document.body.classList.remove("af-dragging-tab"));
   if (index > 0 && canManage) {
     const close = h2("span", { class: "af-tab-close", title: "Close tab" }, "\xD7");
     close.setAttribute("aria-hidden", "true");
@@ -7947,6 +8509,7 @@ var store = new Store({
   termStatus: "connecting",
   focus: "rail",
   activeTab: 0,
+  shownTabs: [0],
   tabError: null,
   tasks: []
 });
@@ -7962,9 +8525,17 @@ termHost.className = "af-term-host";
 var modalHost = document.createElement("div");
 modalHost.className = "af-modal-host";
 var modal = null;
-var terminal = null;
-var terminalId = null;
-var terminalTab = 0;
+var splitView = new SplitView(termHost, {
+  onStatus: (s) => store.set({ termStatus: s }),
+  // Keep the nav-vs-terminal mode (#1693) in sync with real xterm focus across every
+  // pane, so a click straight into a pane enters terminal mode (and clicking/tabbing
+  // away from all panes returns to rail mode) without going through Enter/Escape.
+  onFocusChange: (focused) => store.set({ focus: focused ? "terminal" : "rail" }),
+  // Mirror the layout into the store so the tab bar can highlight the focused pane's
+  // tab (activeTab) and flag which tabs are shown across panes (shownTabs). Fired only
+  // on a real change, so this write never loops back through rerender → syncSplit.
+  onLayout: ({ focusedTab, shownTabs }) => store.set({ activeTab: focusedTab, shownTabs })
+});
 var root = null;
 function mount() {
   root = document.getElementById("app");
@@ -8005,7 +8576,7 @@ function rerender() {
     if (shell) {
       shell = null;
     }
-    disposeTerminal();
+    disposeSplit();
     closeModal();
     renderLogin(root, state, actions);
     return;
@@ -8015,7 +8586,7 @@ function rerender() {
     root.replaceChildren(shell.el);
   }
   shell.update(state);
-  syncTerminal(state);
+  syncSplit(state);
 }
 async function connect(candidate) {
   store.set({ connecting: true, loginError: null });
@@ -8041,6 +8612,7 @@ async function connect(candidate) {
     live: "connecting",
     focus: "rail",
     activeTab: 0,
+    shownTabs: [0],
     tabError: null,
     tasks: []
   });
@@ -8062,6 +8634,7 @@ function disconnect() {
     live: "connecting",
     focus: "rail",
     activeTab: 0,
+    shownTabs: [0],
     tabError: null,
     tasks: []
   });
@@ -8078,25 +8651,20 @@ function openFromRail(id) {
   focusTerminal();
 }
 function focusTerminal() {
-  if (!terminal) {
-    return;
-  }
   store.set({ focus: "terminal" });
-  terminal.focus();
+  splitView.focus();
 }
 function focusRail() {
   store.set({ focus: "rail" });
-  if (terminal) {
-    terminal.blur();
-  }
+  splitView.blur();
 }
 function switchView(view) {
   if (store.get().view === view) {
     return;
   }
   clearTabError();
-  if (view !== "sessions" && terminal) {
-    terminal.blur();
+  if (view !== "sessions") {
+    splitView.blur();
   }
   store.set({ view, focus: "rail" });
   if (view === "tasks") {
@@ -8199,10 +8767,11 @@ function selectedSessionData() {
   return sessions.find((s) => s.id === selectedId) ?? null;
 }
 function switchTab(index) {
-  store.set({ activeTab: index, focus: "rail" });
+  splitView.setFocusedTab(index);
+  store.set({ focus: "rail" });
 }
 function openTab(index) {
-  store.set({ activeTab: index });
+  splitView.setFocusedTab(index);
   focusTerminal();
 }
 function createSessionTab() {
@@ -8216,7 +8785,8 @@ function createSessionTab() {
   void createTab(selId, sel.title, tok).then(() => fetchSnapshot(tok)).then((sessions) => {
     const grown = sessions.find((s) => s.id === selId);
     const newIdx = grown ? sessionTabs(grown).length - 1 : store.get().activeTab;
-    store.set({ sessions, selectedId: pickSelection(sessions, store.get().selectedId), activeTab: newIdx });
+    store.set({ sessions, selectedId: pickSelection(sessions, store.get().selectedId) });
+    splitView.setFocusedTab(newIdx);
     focusTerminal();
   }).catch((e) => surfaceTabError(e));
 }
@@ -8238,7 +8808,8 @@ function closeSessionTab(index) {
     const shrunk = sessions.find((s) => s.id === selId);
     const n = shrunk ? sessionTabs(shrunk).length : 1;
     const next = Math.min(Math.max(index <= cur ? cur - 1 : cur, 0), n - 1);
-    store.set({ sessions, selectedId: pickSelection(sessions, store.get().selectedId), activeTab: next });
+    store.set({ sessions, selectedId: pickSelection(sessions, store.get().selectedId) });
+    splitView.setFocusedTab(next);
   }).catch((e) => surfaceTabError(e));
 }
 function surfaceTabError(e) {
@@ -8341,33 +8912,16 @@ var actions = {
   triggerTask: doTriggerTask,
   removeTask: doRemoveTask
 };
-function syncTerminal(state) {
+function syncSplit(state) {
   const selId = state.selectedId;
-  const tab = clampActiveTab(state.sessions, selId, state.activeTab);
-  if (selId === terminalId && tab === terminalTab) {
-    return;
-  }
-  disposeTerminal();
-  terminalId = selId;
-  terminalTab = tab;
   const tok = token;
-  if (selId && tok !== null) {
-    terminal = new AttachTerminal(termHost, selId, tok, tab, {
-      onStatus: (s) => store.set({ termStatus: s }),
-      // Keep the nav-vs-terminal mode (#1693) in sync with real xterm focus, so a
-      // click straight into the terminal enters terminal mode (and tabbing/click
-      // away returns to rail mode) without going through Enter/Escape.
-      onFocusChange: (focused) => store.set({ focus: focused ? "terminal" : "rail" })
-    });
-  }
+  const initialTab = clampActiveTab(state.sessions, selId, state.activeTab);
+  const selected = selId ? state.sessions.find((s) => s.id === selId) : null;
+  const tabCount = selected ? sessionTabs(selected).length : 1;
+  splitView.setSession(tok !== null ? selId : null, tok, tabCount, initialTab);
 }
-function disposeTerminal() {
-  if (terminal) {
-    terminal.dispose();
-    terminal = null;
-  }
-  terminalId = null;
-  terminalTab = 0;
+function disposeSplit() {
+  splitView.dispose();
   termHost.replaceChildren();
 }
 function startStream(tok) {
@@ -8426,11 +8980,11 @@ function requestResync() {
     });
   }, 150);
 }
-function isNativeControl(el) {
-  if (!el) {
+function isNativeControl(el2) {
+  if (!el2) {
     return false;
   }
-  return el.tagName === "BUTTON" || el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.tagName === "SELECT" || el.tagName === "A";
+  return el2.tagName === "BUTTON" || el2.tagName === "INPUT" || el2.tagName === "TEXTAREA" || el2.tagName === "SELECT" || el2.tagName === "A";
 }
 function onKeydown(e) {
   const state = store.get();
@@ -8442,18 +8996,22 @@ function onKeydown(e) {
   if (!inTerminal && e.key !== "Escape" && isNativeControl(target)) {
     return;
   }
-  const focus = terminal && state.view === "sessions" ? state.focus : "rail";
+  const focus = state.selectedId && state.view === "sessions" ? state.focus : "rail";
   const selected = selectedSessionData();
-  const action = decideKey(e.key, {
-    focus,
-    modalOpen: modal !== null,
-    view: state.view,
-    orderedIds: orderedSessions(state.sessions).map((s) => s.id ?? "").filter((id) => id !== ""),
-    selectedId: state.selectedId,
-    tabCount: selected ? sessionTabs(selected).length : 1,
-    activeTab: state.activeTab,
-    tabManagement: selected ? supportsTabManagement(selected) : false
-  });
+  const action = decideKey(
+    e.key,
+    {
+      focus,
+      modalOpen: modal !== null,
+      view: state.view,
+      orderedIds: orderedSessions(state.sessions).map((s) => s.id ?? "").filter((id) => id !== ""),
+      selectedId: state.selectedId,
+      tabCount: selected ? sessionTabs(selected).length : 1,
+      activeTab: state.activeTab,
+      tabManagement: selected ? supportsTabManagement(selected) : false
+    },
+    { alt: e.altKey }
+  );
   if (action.kind === "none") {
     return;
   }
@@ -8483,6 +9041,12 @@ function onKeydown(e) {
       break;
     case "switchView":
       switchView(action.view);
+      break;
+    case "cyclePane":
+      splitView.cyclePane(action.delta);
+      break;
+    case "closePane":
+      splitView.closeFocusedPane();
       break;
   }
 }

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -85,19 +85,20 @@ async function dragTabToPane(page: Page, tabText: string, edge: "left" | "right"
 }
 
 /**
- * Dispatches a drop carrying an ARBITRARY tab index onto the (single) current pane —
- * bypassing the real tab buttons so a stale / out-of-range index can be injected. Used
- * to prove the drop handler validates the payload against the live tab count and
- * no-ops an invalid one instead of binding a pane to a nonexistent tab.
+ * Dispatches a drop carrying a HAND-CRAFTED drag payload ({index, tabs}) onto the
+ * (single) current pane — bypassing the real tab buttons so a stale / out-of-range /
+ * mid-drag-reorder snapshot can be injected. Used to prove the drop handler validates
+ * the payload (range + drag-time tab-set snapshot vs live) and no-ops an invalid one
+ * instead of binding a pane to the wrong / a nonexistent tab.
  */
-async function dropRawTabIndexOnPane(page: Page, tabIndex: number): Promise<void> {
-  await page.evaluate((tabIndex) => {
+async function dropSnapshotOnPane(page: Page, payload: { index: number; tabs: string[] }): Promise<void> {
+  await page.evaluate((payload) => {
     const pane = document.querySelector(".af-term-host .af-pane");
     if (!pane) {
       throw new Error("no pane to drop on");
     }
     const dt = new DataTransfer();
-    dt.setData("application/x-af-tab", String(tabIndex));
+    dt.setData("application/x-af-tab", JSON.stringify(payload));
     const r = pane.getBoundingClientRect();
     const init = {
       bubbles: true,
@@ -108,7 +109,7 @@ async function dropRawTabIndexOnPane(page: Page, tabIndex: number): Promise<void
     };
     pane.dispatchEvent(new DragEvent("dragover", init));
     pane.dispatchEvent(new DragEvent("drop", init));
-  }, tabIndex);
+  }, payload);
 }
 
 /** Opens the app on the loopback daemon and asserts the tokenless auto-connect
@@ -381,15 +382,46 @@ test("split panes (feat): an out-of-range dropped tab is ignored — no broken p
   await expect(page.locator(".af-main.af-main-term")).toBeVisible();
   await expect(page.locator(".af-term-host .af-pane")).toHaveCount(1);
 
-  // Drop a stale / out-of-range tab index (9) on the pane's edge. The drop handler
-  // validates it against the live tab count and no-ops it — no split is created, so
-  // no pane can bind to a nonexistent tab and break its stream.
-  await dropRawTabIndexOnPane(page, 9);
-  // Give the (rejected) drop a beat, then assert the layout is unchanged.
+  // Drop an out-of-range tab index (99) on the pane's edge. The drop handler validates
+  // it against the live tab count and no-ops it — no split is created, so no pane can
+  // bind to a nonexistent tab and break its stream.
+  await dropSnapshotOnPane(page, { index: 99, tabs: ["0:x"] });
   await expect(page.locator(".af-term-host .af-pane")).toHaveCount(1);
   await expect(page.locator(".af-term-host .xterm")).toHaveCount(1);
   // The one pane still shows the live agent output — it was never disturbed.
   await expect(page.locator(".af-term-host")).toContainText(READY_MARKER);
+});
+
+test("split panes (feat): a mid-drag tab-set change cancels the drop — no misbinding (#1738 repro)", async () => {
+  // Attach to A and give it a second tab, so a drop index of 1 is IN RANGE (2 tabs).
+  // This is the T-Rex reproduction: the index is valid, but the tab set changed since
+  // the drag began, so binding by index alone would attach the new pane to the WRONG
+  // live tab.
+  await row(page, SESSION_A).click();
+  await expect(page.locator(".af-main.af-main-term")).toBeVisible();
+  const tabbar = page.locator(".af-tabbar");
+  await tabbar.locator(".af-tab-new").click();
+  await expect(tabbar.locator(".af-tab")).toHaveCount(2, { timeout: 30_000 });
+  await expect(page.locator(".af-term-host .af-pane")).toHaveCount(1);
+
+  // Drop an IN-RANGE index (1) whose drag-time snapshot (2 entries — count matches the
+  // live 2 tabs, so neither the range nor a count check would catch it) does NOT match
+  // the live tab identities. Only the snapshot-vs-live comparison can reject this, and
+  // it must: the layout stays a single pane, no split bound to the wrong tab.
+  await dropSnapshotOnPane(page, { index: 1, tabs: ["0:stale-agent", "1:stale-shell"] });
+  await expect(page.locator(".af-term-host .af-pane")).toHaveCount(1);
+  await expect(page.locator(".af-term-host .xterm")).toHaveCount(1);
+
+  // A well-formed drag with the LIVE snapshot still splits (the happy path is intact) —
+  // proven here to show the cancel above was the stale check, not a broken drop path.
+  await dragTabToPane(page, "Agent", "right");
+  await expect(page.locator(".af-term-host .af-pane")).toHaveCount(2, { timeout: 15_000 });
+
+  // Clean up: collapse back to one pane and restore A to a single tab.
+  await page.locator(".af-term-host .af-pane", { hasText: READY_MARKER }).locator(".af-pane-close").click();
+  await expect(page.locator(".af-term-host .af-pane")).toHaveCount(1, { timeout: 15_000 });
+  await tabbar.locator(".af-tab", { hasText: "Terminal" }).locator(".af-tab-close").click();
+  await expect(tabbar.locator(".af-tab")).toHaveCount(1, { timeout: 30_000 });
 });
 
 test("split panes (feat): logout clears retained trees — a fresh login shows the single-leaf default", async () => {

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -84,6 +84,33 @@ async function dragTabToPane(page: Page, tabText: string, edge: "left" | "right"
   );
 }
 
+/**
+ * Dispatches a drop carrying an ARBITRARY tab index onto the (single) current pane —
+ * bypassing the real tab buttons so a stale / out-of-range index can be injected. Used
+ * to prove the drop handler validates the payload against the live tab count and
+ * no-ops an invalid one instead of binding a pane to a nonexistent tab.
+ */
+async function dropRawTabIndexOnPane(page: Page, tabIndex: number): Promise<void> {
+  await page.evaluate((tabIndex) => {
+    const pane = document.querySelector(".af-term-host .af-pane");
+    if (!pane) {
+      throw new Error("no pane to drop on");
+    }
+    const dt = new DataTransfer();
+    dt.setData("application/x-af-tab", String(tabIndex));
+    const r = pane.getBoundingClientRect();
+    const init = {
+      bubbles: true,
+      cancelable: true,
+      dataTransfer: dt,
+      clientX: r.right - 6, // aim at the right edge → a split, if it were allowed
+      clientY: r.top + r.height / 2,
+    };
+    pane.dispatchEvent(new DragEvent("dragover", init));
+    pane.dispatchEvent(new DragEvent("drop", init));
+  }, tabIndex);
+}
+
 /** Opens the app on the loopback daemon and asserts the tokenless auto-connect
  *  (#1696): the SPA learns via /v1/auth-info that this loopback client needs no
  *  token, skips the paste-token login entirely, and renders the authed shell with
@@ -346,6 +373,57 @@ test("split panes (feat): drag a tab to a pane edge splits into two live panes; 
   // Restore A to a single tab for the later create/kill/archive flows.
   await tabbar.locator(".af-tab", { hasText: "Terminal" }).locator(".af-tab-close").click();
   await expect(tabbar.locator(".af-tab")).toHaveCount(1, { timeout: 30_000 });
+});
+
+test("split panes (feat): an out-of-range dropped tab is ignored — no broken pane", async () => {
+  // Attach to A (a single agent tab, so tab index 1+ does not exist).
+  await row(page, SESSION_A).click();
+  await expect(page.locator(".af-main.af-main-term")).toBeVisible();
+  await expect(page.locator(".af-term-host .af-pane")).toHaveCount(1);
+
+  // Drop a stale / out-of-range tab index (9) on the pane's edge. The drop handler
+  // validates it against the live tab count and no-ops it — no split is created, so
+  // no pane can bind to a nonexistent tab and break its stream.
+  await dropRawTabIndexOnPane(page, 9);
+  // Give the (rejected) drop a beat, then assert the layout is unchanged.
+  await expect(page.locator(".af-term-host .af-pane")).toHaveCount(1);
+  await expect(page.locator(".af-term-host .xterm")).toHaveCount(1);
+  // The one pane still shows the live agent output — it was never disturbed.
+  await expect(page.locator(".af-term-host")).toContainText(READY_MARKER);
+});
+
+test("split panes (feat): logout clears retained trees — a fresh login shows the single-leaf default", async () => {
+  // Split A into two panes.
+  await row(page, SESSION_A).click();
+  await expect(page.locator(".af-main.af-main-term")).toBeVisible();
+  const tabbar = page.locator(".af-tabbar");
+  await tabbar.locator(".af-tab-new").click();
+  await expect(tabbar.locator(".af-tab")).toHaveCount(2, { timeout: 30_000 });
+  await dragTabToPane(page, "Agent", "right");
+  await expect(page.locator(".af-term-host .af-pane")).toHaveCount(2, { timeout: 15_000 });
+
+  // Log out, then reconnect (tokenless loopback: the no-auth login offers a single
+  // Connect button, no token to paste).
+  await page.locator(".af-appbar button", { hasText: "Disconnect" }).click();
+  await expect(page.locator(".af-login")).toBeVisible();
+  await page.locator(".af-login button.af-primary").click();
+  await expect(page.locator(".af-app")).toBeVisible();
+  await expect(page.locator(".af-live-pip.af-live-open")).toBeVisible();
+
+  // Re-select A: the retained split was cleared on logout, so it opens as a SINGLE
+  // pane (the zero-config default), not the previous two-pane split.
+  await row(page, SESSION_A).click();
+  await expect(page.locator(".af-main.af-main-term")).toBeVisible();
+  await expect(page.locator(".af-term-host .af-pane")).toHaveCount(1);
+
+  // Restore A to a single tab (the shell tab survived on the daemon; only the pane
+  // was gone) for the later create/kill/archive flows.
+  const bar = page.locator(".af-tabbar");
+  const shellTab = bar.locator(".af-tab", { hasText: "Terminal" });
+  if ((await shellTab.count()) > 0) {
+    await shellTab.locator(".af-tab-close").click();
+    await expect(bar.locator(".af-tab")).toHaveCount(1, { timeout: 30_000 });
+  }
 });
 
 test("projects view (#1592 PR8): the seeded repo groups its sessions; a row jumps to it", async () => {

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -43,6 +43,47 @@ function row(page: Page, title: string): Locator {
   return page.locator(".af-rail-list .af-row", { hasText: title });
 }
 
+/**
+ * Simulates dragging the tab labelled `tabText` from the tab bar onto an `edge` of
+ * the (single) current pane. Playwright's mouse-based dragTo doesn't drive HTML5
+ * drag-and-drop reliably, so we dispatch the drag events ourselves with a shared
+ * DataTransfer — the same object across dragstart/dragover/drop makes getData work,
+ * exactly as a real drag would — and aim the drop at the edge band so the pane splits
+ * in that direction (see split.ts zoneAt). A center drop uses the middle instead.
+ */
+async function dragTabToPane(page: Page, tabText: string, edge: "left" | "right" | "top" | "bottom" | "center"): Promise<void> {
+  await page.evaluate(
+    ({ tabText, edge }) => {
+      const tab = [...document.querySelectorAll(".af-tabbar .af-tab")].find((t) => t.textContent?.includes(tabText));
+      const pane = document.querySelector(".af-term-host .af-pane");
+      if (!tab || !pane) {
+        throw new Error("drag source or target pane not found");
+      }
+      const dt = new DataTransfer();
+      tab.dispatchEvent(new DragEvent("dragstart", { bubbles: true, cancelable: true, dataTransfer: dt }));
+      const r = pane.getBoundingClientRect();
+      let x = r.left + r.width / 2;
+      let y = r.top + r.height / 2;
+      const m = 6;
+      if (edge === "left") {
+        x = r.left + m;
+      } else if (edge === "right") {
+        x = r.right - m;
+      } else if (edge === "top") {
+        y = r.top + m;
+      } else if (edge === "bottom") {
+        y = r.bottom - m;
+      }
+      const init = { bubbles: true, cancelable: true, dataTransfer: dt, clientX: x, clientY: y };
+      pane.dispatchEvent(new DragEvent("dragenter", init));
+      pane.dispatchEvent(new DragEvent("dragover", init));
+      pane.dispatchEvent(new DragEvent("drop", init));
+      tab.dispatchEvent(new DragEvent("dragend", { bubbles: true, dataTransfer: dt }));
+    },
+    { tabText, edge },
+  );
+}
+
 /** Opens the app on the loopback daemon and asserts the tokenless auto-connect
  *  (#1696): the SPA learns via /v1/auth-info that this loopback client needs no
  *  token, skips the paste-token login entirely, and renders the authed shell with
@@ -255,6 +296,56 @@ test("tabs: create a shell tab, switch to it, see its distinct output, close it 
 
   await page.unroute("**/v1/CreateTab");
   await page.unroute("**/v1/CloseTab");
+});
+
+test("split panes (feat): drag a tab to a pane edge splits into two live panes; close collapses back", async () => {
+  // Attach to A and give it a second tab, so there is a distinct tab to drag into a
+  // split (dragging the only tab onto itself just moves it — no split).
+  await row(page, SESSION_A).click();
+  await expect(page.locator(".af-main.af-main-term")).toBeVisible();
+  await expect(page.locator(".af-term-host")).toContainText(READY_MARKER);
+
+  const tabbar = page.locator(".af-tabbar");
+  await tabbar.locator(".af-tab-new").click();
+  await expect(tabbar.locator(".af-tab")).toHaveCount(2, { timeout: 30_000 });
+  await expect(page.locator(".af-term-meta")).toContainText("Live");
+
+  // A single pane so far — today's zero-config default.
+  await expect(page.locator(".af-term-host .af-pane")).toHaveCount(1);
+
+  // Drag the Agent tab (index 0) onto the RIGHT edge → the pane splits into two, the
+  // new right pane bound to the agent tab with its OWN live WS stream.
+  await dragTabToPane(page, "Agent", "right");
+  await expect(page.locator(".af-term-host .af-pane")).toHaveCount(2, { timeout: 15_000 });
+  // Two concurrent xterm instances now render side by side, each with per-pane chrome.
+  await expect(page.locator(".af-term-host .xterm")).toHaveCount(2);
+  await expect(page.locator(".af-term-host .af-pane.af-pane-multi")).toHaveCount(2);
+
+  // BOTH panes show live output. The new agent pane streams the ready marker over its
+  // own stream — identify it by that marker.
+  await expect(page.locator(".af-term-host")).toContainText(READY_MARKER, { timeout: 15_000 });
+  const agentPane = page.locator(".af-term-host .af-pane", { hasText: READY_MARKER });
+  const shellPane = page.locator(".af-term-host .af-pane", { hasNotText: READY_MARKER });
+  await expect(agentPane).toHaveCount(1);
+  await expect(shellPane).toHaveCount(1);
+  // The other pane (the shell tab) is an independent live PTY — focus it and type, and
+  // its echo comes back over its own stream, proving both panes are live at once.
+  await shellPane.locator(".af-pane-host").click();
+  await expect(page.locator(".af-term-meta")).toContainText("Live");
+  await page.keyboard.type("echo AF_SPLIT_OK");
+  await page.keyboard.press("Enter");
+  await expect(shellPane).toContainText("AF_SPLIT_OK", { timeout: 15_000 });
+
+  // Close the agent pane via its × — the split collapses and the shell pane fills the
+  // whole area (one pane again), without closing the underlying tab.
+  await agentPane.locator(".af-pane-close").click();
+  await expect(page.locator(".af-term-host .af-pane")).toHaveCount(1, { timeout: 15_000 });
+  // The tab list is unchanged — only the pane closed, not the underlying tab.
+  await expect(tabbar.locator(".af-tab")).toHaveCount(2);
+
+  // Restore A to a single tab for the later create/kill/archive flows.
+  await tabbar.locator(".af-tab", { hasText: "Terminal" }).locator(".af-tab-close").click();
+  await expect(tabbar.locator(".af-tab")).toHaveCount(1, { timeout: 30_000 });
 });
 
 test("projects view (#1592 PR8): the seeded repo groups its sessions; a row jumps to it", async () => {

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -47,6 +47,7 @@ import {
   renderLogin,
   sessionTabs,
   supportsTabManagement,
+  tabIdentity,
   type AppState,
 } from "./ui.js";
 import type { SessionData, TaskData, WireEvent } from "./types.js";
@@ -718,10 +719,12 @@ function syncSplit(state: AppState): void {
   // stale index can never bind a pane to a tab that doesn't exist.
   const initialTab = clampActiveTab(state.sessions, selId, state.activeTab);
   const selected = selId ? state.sessions.find((s) => s.id === selId) : null;
-  const tabCount = selected ? sessionTabs(selected).length : 1;
+  // The ordered tab identities, so the split view can (a) know the live tab count and
+  // (b) reject a drop whose drag-time snapshot no longer matches (a mid-drag reorder).
+  const tabIds = selected ? sessionTabs(selected).map(tabIdentity) : ["0:"];
   // `tok !== null` not `tok`: "" is the authorized-tokenless credential (#1696), so a
   // loopback client still attaches its live panes.
-  splitView.setSession(tok !== null ? selId : null, tok, tabCount, initialTab);
+  splitView.setSession(tok !== null ? selId : null, tok, tabIds, initialTab);
 }
 
 function disposeSplit(): void {

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -36,9 +36,10 @@ import { EventStream, type EventStreamStatus } from "./events.js";
 import { confirmModal, type ModalHandle, newSessionModal, promptModal } from "./modals.js";
 import { decideKey, type KeyboardFocus, type View } from "./nav.js";
 import { applyEvent, clampActiveTab, pickSelection, upsertSession } from "./sessions.js";
+import { SplitView } from "./split.js";
 import { Store } from "./store.js";
 import { addTaskModal, type AddTaskInput, buildTask } from "./tasks.js";
-import { AttachTerminal, type TerminalStatus } from "./terminal.js";
+import type { TerminalStatus } from "./terminal.js";
 import {
   AppShell,
   deriveProjects,
@@ -67,6 +68,7 @@ const store = new Store<AppState>({
   termStatus: "connecting",
   focus: "rail",
   activeTab: 0,
+  shownTabs: [0],
   tabError: null,
   tasks: [],
 });
@@ -95,7 +97,9 @@ const TAB_ERROR_MS = 6000;
 
 // The app-phase DOM (built once per login) and the persistent terminal host that
 // lives inside it. Keeping the host stable across renders is what lets the focused
-// xterm survive rail updates (see ui.ts AppShell).
+// xterm survive rail updates (see ui.ts AppShell). The host now holds a SPLIT LAYOUT
+// (split.ts) rather than a single xterm: one leaf by default (today's behavior), or
+// multiple concurrent panes when the user drags tabs into splits.
 let shell: AppShell | null = null;
 const termHost = document.createElement("div");
 termHost.className = "af-term-host";
@@ -108,11 +112,21 @@ const modalHost = document.createElement("div");
 modalHost.className = "af-modal-host";
 let modal: ModalHandle | null = null;
 
-// The one live attach terminal and the (session id, tab index) it is bound to.
-// Rebuilt when either changes; disposed on deselect/logout.
-let terminal: AttachTerminal | null = null;
-let terminalId: string | null = null;
-let terminalTab = 0;
+// The split-pane view bound to termHost: it owns the per-instance layout tree and one
+// live AttachTerminal per pane, rebuilt/reconciled as the selection, tab list, or
+// layout changes (see syncSplit). It diffs the session internally, so syncSplit can
+// call setSession on every store change without tearing down unchanged panes.
+const splitView = new SplitView(termHost, {
+  onStatus: (s: TerminalStatus) => store.set({ termStatus: s }),
+  // Keep the nav-vs-terminal mode (#1693) in sync with real xterm focus across every
+  // pane, so a click straight into a pane enters terminal mode (and clicking/tabbing
+  // away from all panes returns to rail mode) without going through Enter/Escape.
+  onFocusChange: (focused: boolean) => store.set({ focus: focused ? "terminal" : "rail" }),
+  // Mirror the layout into the store so the tab bar can highlight the focused pane's
+  // tab (activeTab) and flag which tabs are shown across panes (shownTabs). Fired only
+  // on a real change, so this write never loops back through rerender → syncSplit.
+  onLayout: ({ focusedTab, shownTabs }) => store.set({ activeTab: focusedTab, shownTabs }),
+});
 
 let root: HTMLElement | null = null;
 
@@ -178,7 +192,7 @@ function rerender(): void {
     if (shell) {
       shell = null; // dropped from the tree by renderLogin below
     }
-    disposeTerminal();
+    disposeSplit();
     closeModal();
     renderLogin(root, state, actions);
     return;
@@ -188,7 +202,7 @@ function rerender(): void {
     root.replaceChildren(shell.el);
   }
   shell.update(state);
-  syncTerminal(state);
+  syncSplit(state);
 }
 
 /** Validates the token (Snapshot probe), and on success persists it, seeds the rail
@@ -220,6 +234,7 @@ async function connect(candidate: string): Promise<void> {
     live: "connecting",
     focus: "rail",
     activeTab: 0,
+    shownTabs: [0],
     tabError: null,
     tasks: [],
   });
@@ -246,6 +261,7 @@ function disconnect(): void {
     live: "connecting",
     focus: "rail",
     activeTab: 0,
+    shownTabs: [0],
     tabError: null,
     tasks: [],
   });
@@ -277,24 +293,19 @@ function openFromRail(id: string): void {
   focusTerminal();
 }
 
-/** Gives the keyboard to the selected session's terminal (attach): keys now reach
+/** Gives the keyboard to the selected session's FOCUSED pane (attach): keys now reach
  *  the agent. The xterm focus event echoes back through onFocusChange and confirms
  *  the "terminal" mode; setting it here first keeps the indicator immediate. */
 function focusTerminal(): void {
-  if (!terminal) {
-    return;
-  }
   store.set({ focus: "terminal" });
-  terminal.focus();
+  splitView.focus();
 }
 
-/** Returns the keyboard to the rail (Escape / detach): blurs the terminal so
+/** Returns the keyboard to the rail (Escape / detach): blurs every pane so
  *  document-level j/k navigate again. */
 function focusRail(): void {
   store.set({ focus: "rail" });
-  if (terminal) {
-    terminal.blur();
-  }
+  splitView.blur();
 }
 
 // --- top-level view switching (#1592 Phase 5 PR8) --------------------------
@@ -309,8 +320,8 @@ function switchView(view: View): void {
     return;
   }
   clearTabError();
-  if (view !== "sessions" && terminal) {
-    terminal.blur();
+  if (view !== "sessions") {
+    splitView.blur();
   }
   store.set({ view, focus: "rail" });
   if (view === "tasks") {
@@ -458,18 +469,20 @@ function selectedSessionData(): SessionData | null {
   return sessions.find((s) => s.id === selectedId) ?? null;
 }
 
-/** Switches the active tab WITHOUT attaching (the 1-9 keys). syncTerminal rebuilds
- *  the terminal for the new tab on the store update; the keyboard stays in rail
- *  mode, mirroring how j/k select a row without attaching. */
+/** Points the FOCUSED pane at `index` WITHOUT attaching (the 1-9 keys). The split
+ *  view rebuilds that pane's terminal and mirrors the new focused tab back into the
+ *  store (onLayout → activeTab); the keyboard stays in rail mode, mirroring how j/k
+ *  select a row without attaching. */
 function switchTab(index: number): void {
-  store.set({ activeTab: index, focus: "rail" });
+  splitView.setFocusedTab(index);
+  store.set({ focus: "rail" });
 }
 
-/** Switches to a tab AND attaches its terminal (a tab-bar click). The store update
- *  rebuilds the terminal synchronously (via rerender → syncTerminal), so
- *  focusTerminal then focuses the fresh instance — the same pattern as openFromRail. */
+/** Points the focused pane at a tab AND attaches it (a tab-bar click). The split view
+ *  rebuilds that pane's terminal synchronously, so focusTerminal then focuses the
+ *  fresh instance — the same pattern as openFromRail. */
 function openTab(index: number): void {
-  store.set({ activeTab: index });
+  splitView.setFocusedTab(index);
   focusTerminal();
 }
 
@@ -493,7 +506,11 @@ function createSessionTab(): void {
     .then((sessions) => {
       const grown = sessions.find((s) => s.id === selId);
       const newIdx = grown ? sessionTabs(grown).length - 1 : store.get().activeTab;
-      store.set({ sessions, selectedId: pickSelection(sessions, store.get().selectedId), activeTab: newIdx });
+      // Commit the grown tab list first (rerender → syncSplit sees the new tabCount),
+      // then point the focused pane at the fresh tab and attach it — mirroring the
+      // TUI's `t`, which opens the new tab as the active pane.
+      store.set({ sessions, selectedId: pickSelection(sessions, store.get().selectedId) });
+      splitView.setFocusedTab(newIdx);
       focusTerminal();
     })
     .catch((e) => surfaceTabError(e));
@@ -526,7 +543,10 @@ function closeSessionTab(index: number): void {
       const shrunk = sessions.find((s) => s.id === selId);
       const n = shrunk ? sessionTabs(shrunk).length : 1;
       const next = Math.min(Math.max(index <= cur ? cur - 1 : cur, 0), n - 1);
-      store.set({ sessions, selectedId: pickSelection(sessions, store.get().selectedId), activeTab: next });
+      // Commit the shrunk tab list first (rerender → syncSplit re-validates the tree,
+      // clamping any pane past the new end), then re-point the focused pane.
+      store.set({ sessions, selectedId: pickSelection(sessions, store.get().selectedId) });
+      splitView.setFocusedTab(next);
     })
     .catch((e) => surfaceTabError(e));
 }
@@ -685,45 +705,28 @@ const actions = {
 
 // --- attach terminal wiring ------------------------------------------------
 
-/** Opens/closes the attach terminal to match the current selection AND active tab.
- *  Rebuilds only when the selected id OR the active tab actually changes, so a live
- *  rail event never disturbs an open, focused terminal — but switching tabs
- *  (1-9 / a tab-bar click) re-points the stream to the new tab (#1592 Phase 5 PR7). */
-function syncTerminal(state: AppState): void {
+/** Syncs the split view to the current selection: shows the selected session's layout
+ *  (its retained tree, or a fresh single leaf), reconciling live terminals. Called on
+ *  every store change, it is cheap on a no-op — the split view only rebuilds terminals
+ *  when the session changes or the tab list shrinks/grows, so a live rail event never
+ *  disturbs an open, focused pane. */
+function syncSplit(state: AppState): void {
   const selId = state.selectedId;
-  // Clamp to the selected session's live tab list as a last line of defense: any
-  // path that leaves activeTab stale relative to the selection (a smaller new
-  // session, an out-of-band tab close) can never build a ?tab=<n> URL for a tab
-  // this session doesn't have — the terminal always attaches a real tab.
-  const tab = clampActiveTab(state.sessions, selId, state.activeTab);
-  if (selId === terminalId && tab === terminalTab) {
-    return;
-  }
-  disposeTerminal();
-  terminalId = selId; // set before constructing so the onStatus re-render is a no-op
-  terminalTab = tab;
   const tok = token;
-  // `tok !== null` not `tok`: "" is the authorized-tokenless credential (#1696),
-  // so a loopback client still attaches its live terminal.
-  if (selId && tok !== null) {
-    terminal = new AttachTerminal(termHost, selId, tok, tab, {
-      onStatus: (s: TerminalStatus) => store.set({ termStatus: s }),
-      // Keep the nav-vs-terminal mode (#1693) in sync with real xterm focus, so a
-      // click straight into the terminal enters terminal mode (and tabbing/click
-      // away returns to rail mode) without going through Enter/Escape.
-      onFocusChange: (focused: boolean) => store.set({ focus: focused ? "terminal" : "rail" }),
-    });
-  }
+  // The initial tab for a session shown for the first time: the store's activeTab
+  // (reset to 0 on a fresh selection), clamped to the session's real tab list so a
+  // stale index can never bind a pane to a tab that doesn't exist.
+  const initialTab = clampActiveTab(state.sessions, selId, state.activeTab);
+  const selected = selId ? state.sessions.find((s) => s.id === selId) : null;
+  const tabCount = selected ? sessionTabs(selected).length : 1;
+  // `tok !== null` not `tok`: "" is the authorized-tokenless credential (#1696), so a
+  // loopback client still attaches its live panes.
+  splitView.setSession(tok !== null ? selId : null, tok, tabCount, initialTab);
 }
 
-function disposeTerminal(): void {
-  if (terminal) {
-    terminal.dispose();
-    terminal = null;
-  }
-  terminalId = null;
-  terminalTab = 0;
-  termHost.replaceChildren(); // clear any leftover xterm DOM
+function disposeSplit(): void {
+  splitView.dispose();
+  termHost.replaceChildren(); // clear any leftover pane DOM
 }
 
 // --- events plane wiring ---------------------------------------------------
@@ -849,27 +852,30 @@ function onKeydown(e: KeyboardEvent): void {
   if (!inTerminal && e.key !== "Escape" && isNativeControl(target)) {
     return;
   }
-  // The mode is "terminal" only when a terminal actually exists to own the keyboard
-  // AND the sessions view is showing it; a since-disposed terminal (the selected
-  // session was killed) or a switch to the projects/tasks view (which hides the
-  // terminal) must not leave the stored focus stale, so we never honor terminal mode
-  // without a live, visible terminal. The pure state machine (nav.ts) decides the
-  // rest; index.ts only performs the effect.
-  const focus: KeyboardFocus = terminal && state.view === "sessions" ? state.focus : "rail";
+  // The mode is "terminal" only when a session is selected (so a pane exists to own
+  // the keyboard) AND the sessions view is showing it; a killed selection or a switch
+  // to the projects/tasks view (which hides the panes) must not leave the stored focus
+  // stale, so we never honor terminal mode without a live, visible pane. The pure state
+  // machine (nav.ts) decides the rest; index.ts only performs the effect.
+  const focus: KeyboardFocus = state.selectedId && state.view === "sessions" ? state.focus : "rail";
   // The selected session's tab shape drives the nav-mode tab keys (1-9 / t / w).
   const selected = selectedSessionData();
-  const action = decideKey(e.key, {
-    focus,
-    modalOpen: modal !== null,
-    view: state.view,
-    orderedIds: orderedSessions(state.sessions)
-      .map((s) => s.id ?? "")
-      .filter((id) => id !== ""),
-    selectedId: state.selectedId,
-    tabCount: selected ? sessionTabs(selected).length : 1,
-    activeTab: state.activeTab,
-    tabManagement: selected ? supportsTabManagement(selected) : false,
-  });
+  const action = decideKey(
+    e.key,
+    {
+      focus,
+      modalOpen: modal !== null,
+      view: state.view,
+      orderedIds: orderedSessions(state.sessions)
+        .map((s) => s.id ?? "")
+        .filter((id) => id !== ""),
+      selectedId: state.selectedId,
+      tabCount: selected ? sessionTabs(selected).length : 1,
+      activeTab: state.activeTab,
+      tabManagement: selected ? supportsTabManagement(selected) : false,
+    },
+    { alt: e.altKey },
+  );
   if (action.kind === "none") {
     return;
   }
@@ -902,6 +908,12 @@ function onKeydown(e: KeyboardEvent): void {
       break;
     case "switchView":
       switchView(action.view);
+      break;
+    case "cyclePane":
+      splitView.cyclePane(action.delta);
+      break;
+    case "closePane":
+      splitView.closeFocusedPane();
       break;
   }
 }

--- a/web/src/layout.test.ts
+++ b/web/src/layout.test.ts
@@ -1,0 +1,165 @@
+// Tests for the pure split-layout tree (feat(web): drag-and-drop split tabs). These
+// pin the tree transforms the Playwright selftest exercises through the DOM — split,
+// replace, close-collapse, resize, and the one-tab-one-pane dedupe — with no DOM and
+// no daemon, exactly as nav.test.ts pins the keyboard state machine.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  closeLeaf,
+  findLeaf,
+  type LayoutNode,
+  leafCount,
+  leaves,
+  replaceTab,
+  resetIds,
+  setRatio,
+  singleLeaf,
+  splitLeaf,
+  validate,
+} from "./layout.js";
+
+/** The tabs each leaf shows, in visual order. */
+function tabs(node: LayoutNode): number[] {
+  return leaves(node).map((l) => l.tab);
+}
+
+test("singleLeaf: the default layout is one pane bound to the given tab", () => {
+  resetIds();
+  const root = singleLeaf(0);
+  assert.equal(root.kind, "leaf");
+  assert.equal(leafCount(root), 1);
+  assert.deepEqual(tabs(root), [0]);
+});
+
+test("splitLeaf: left/right make a row; the new pane lands on the dragged edge", () => {
+  resetIds();
+  const root = singleLeaf(0);
+  const right = splitLeaf(root, root.id, "right", 1);
+  assert.equal(right.kind, "split");
+  if (right.kind === "split") {
+    assert.equal(right.dir, "row");
+    assert.equal(right.ratio, 0.5);
+  }
+  // right edge → existing pane first (a), new tab second (b).
+  assert.deepEqual(tabs(right), [0, 1]);
+
+  resetIds();
+  const base = singleLeaf(0);
+  const left = splitLeaf(base, base.id, "left", 1);
+  // left edge → new tab first.
+  assert.deepEqual(tabs(left), [1, 0]);
+});
+
+test("splitLeaf: top/bottom make a column", () => {
+  resetIds();
+  const root = singleLeaf(0);
+  const down = splitLeaf(root, root.id, "bottom", 2);
+  assert.equal(down.kind, "split");
+  if (down.kind === "split") {
+    assert.equal(down.dir, "column");
+  }
+  assert.deepEqual(tabs(down), [0, 2]);
+});
+
+test("splitLeaf center is a replace, not a split", () => {
+  resetIds();
+  const root = singleLeaf(0);
+  const replaced = splitLeaf(root, root.id, "center", 3);
+  assert.equal(replaced.kind, "leaf");
+  assert.deepEqual(tabs(replaced), [3]);
+});
+
+test("one tab, one pane: dragging a shown tab MOVES it instead of duplicating", () => {
+  resetIds();
+  // Two panes: tab 0 | tab 1.
+  const root = singleLeaf(0);
+  const two = splitLeaf(root, root.id, "right", 1);
+  const leftId = leaves(two)[0].id;
+  // Drag tab 1 (already shown) onto the left pane's bottom edge: it moves there, and
+  // its old pane collapses — still exactly two panes, no duplicate tab 1.
+  const moved = splitLeaf(two, leftId, "bottom", 1);
+  assert.equal(leafCount(moved), 2);
+  const shown = tabs(moved).slice().sort((a, b) => a - b);
+  assert.deepEqual(shown, [0, 1]);
+});
+
+test("replaceTab: rebinds a pane and dedupes the tab from elsewhere", () => {
+  resetIds();
+  const root = singleLeaf(0);
+  const two = splitLeaf(root, root.id, "right", 1); // 0 | 1
+  const rightId = leaves(two)[1].id;
+  // Replace the right pane (tab 1) with tab 0: the left pane (also tab 0) collapses,
+  // leaving a single pane showing tab 0.
+  const result = replaceTab(two, rightId, 0);
+  assert.equal(leafCount(result), 1);
+  assert.deepEqual(tabs(result), [0]);
+});
+
+test("closeLeaf: removing a pane collapses its split so the sibling fills", () => {
+  resetIds();
+  const root = singleLeaf(0);
+  const two = splitLeaf(root, root.id, "right", 1); // 0 | 1
+  const rightId = leaves(two)[1].id;
+  const collapsed = closeLeaf(two, rightId);
+  assert.ok(collapsed);
+  assert.equal(collapsed?.kind, "leaf");
+  assert.deepEqual(collapsed ? tabs(collapsed) : [], [0]);
+});
+
+test("closeLeaf: the last pane cannot be closed (returns null)", () => {
+  resetIds();
+  const root = singleLeaf(0);
+  assert.equal(closeLeaf(root, root.id), null);
+});
+
+test("closeLeaf: a nested split collapses correctly", () => {
+  resetIds();
+  // 0 | (1 / 2): split root right→1, then split the right pane bottom→2.
+  const root = singleLeaf(0);
+  const two = splitLeaf(root, root.id, "right", 1);
+  const rightId = leaves(two)[1].id;
+  const three = splitLeaf(two, rightId, "bottom", 2);
+  assert.equal(leafCount(three), 3);
+  // Close the middle pane (tab 1): its split collapses to tab 2, leaving 0 | 2.
+  const midId = leaves(three).find((l) => l.tab === 1)?.id ?? "";
+  const after = closeLeaf(three, midId);
+  assert.ok(after);
+  assert.equal(after ? leafCount(after) : 0, 2);
+  assert.deepEqual(after ? tabs(after).slice().sort() : [], [0, 2]);
+});
+
+test("setRatio: sets a split's ratio, clamped to [0.1, 0.9]", () => {
+  resetIds();
+  const root = singleLeaf(0);
+  const two = splitLeaf(root, root.id, "right", 1);
+  assert.equal(two.kind, "split");
+  const splitId = two.kind === "split" ? two.id : "";
+  const ratioOf = (n: LayoutNode) => (n.kind === "split" ? n.ratio : Number.NaN);
+  assert.equal(ratioOf(setRatio(two, splitId, 0.7)), 0.7);
+  assert.equal(ratioOf(setRatio(two, splitId, 0.02)), 0.1, "clamped low");
+  assert.equal(ratioOf(setRatio(two, splitId, 0.99)), 0.9, "clamped high");
+});
+
+test("validate: clamps out-of-range tabs and dedupes the collapse", () => {
+  resetIds();
+  // 0 | 1 | 3 across three panes, then the session shrinks to 2 tabs (0,1).
+  const root = singleLeaf(0);
+  const two = splitLeaf(root, root.id, "right", 1);
+  const rightId = leaves(two)[1].id;
+  const three = splitLeaf(two, rightId, "right", 3);
+  const clamped = validate(three, 2);
+  // tab 3 clamps to 1, which duplicates the existing tab-1 pane → collapses. Left with
+  // 0 and 1.
+  assert.deepEqual(tabs(clamped).slice().sort(), [0, 1]);
+});
+
+test("findLeaf: locates a leaf by id, or null", () => {
+  resetIds();
+  const root = singleLeaf(0);
+  const two = splitLeaf(root, root.id, "right", 1);
+  const id = leaves(two)[1].id;
+  assert.equal(findLeaf(two, id)?.tab, 1);
+  assert.equal(findLeaf(two, "nope"), null);
+});

--- a/web/src/layout.ts
+++ b/web/src/layout.ts
@@ -1,0 +1,228 @@
+// The pure split-layout tree model for the web client's per-instance split panes
+// (feat(web): drag-and-drop split tabs). A layout is a binary tree: each LEAF binds
+// one of the instance's tabs to a pane; each SPLIT divides its area into two
+// children — side by side ("row", a vertical divider) or stacked ("column", a
+// horizontal divider) — at a resize ratio. The DEFAULT layout is a single leaf, so
+// a user who never splits sees exactly today's one-tab-at-a-time behavior and
+// nothing regresses.
+//
+// One tab lives in at most ONE pane: dragging a tab that is already shown elsewhere
+// MOVES it (VS-Code-style), which also sidesteps two panes fighting over the same
+// tab's PTY resize (the multi-writer stream is last-resize-wins, but showing one tab
+// at two sizes would still look janky).
+//
+// Kept pure — no DOM, no I/O — so the tree transforms are unit-tested
+// (layout.test.ts) independently of the imperative view (split.ts), exactly as
+// nav.ts and sessions.ts separate their pure logic from index.ts's wiring.
+
+/** The dataTransfer MIME the tab bar (ui.ts) stamps a dragged tab index into, and the
+ *  panes (split.ts) read on drop. A private type keeps a page's other drags out. It
+ *  lives here — the css-free pure module — so ui.ts can import it without dragging in
+ *  the xterm/terminal (and its CSS) that split.ts pulls in. */
+export const TAB_DND_MIME = "application/x-af-tab";
+
+/** A split's orientation: "row" lays its two children left→right (a vertical
+ *  divider between them); "column" lays them top→bottom (a horizontal divider). */
+export type SplitDir = "row" | "column";
+
+/** Where a dragged tab lands on a pane: an edge splits in that direction with the
+ *  new pane on that side; "center" replaces the pane's bound tab. */
+export type Edge = "left" | "right" | "top" | "bottom" | "center";
+
+/** A pane: one of the instance's tabs rendered as a live terminal. */
+export interface LeafNode {
+  kind: "leaf";
+  id: string;
+  tab: number;
+}
+
+/** An internal split of one area into two children at `ratio` (the first child's
+ *  fraction of the axis, in [0.1, 0.9]). */
+export interface SplitNode {
+  kind: "split";
+  id: string;
+  dir: SplitDir;
+  ratio: number;
+  a: LayoutNode;
+  b: LayoutNode;
+}
+
+export type LayoutNode = LeafNode | SplitNode;
+
+// A monotonic id source for freshly created nodes. A module counter (not
+// Math.random) keeps split/close deterministic for the unit tests; resetIds() lets a
+// test pin the sequence.
+let idSeq = 0;
+
+/** Test hook: reset the node-id counter so a test sees a deterministic sequence. */
+export function resetIds(): void {
+  idSeq = 0;
+}
+
+function nextId(prefix: string): string {
+  idSeq += 1;
+  return `${prefix}${idSeq}`;
+}
+
+/** The default single-pane layout bound to `tab` (today's behavior). */
+export function singleLeaf(tab: number): LeafNode {
+  return { kind: "leaf", id: nextId("leaf"), tab };
+}
+
+/** Every leaf in visual order (a-child before b-child, i.e. left/top first) — the
+ *  order pane-focus cycling walks. */
+export function leaves(node: LayoutNode): LeafNode[] {
+  if (node.kind === "leaf") {
+    return [node];
+  }
+  return [...leaves(node.a), ...leaves(node.b)];
+}
+
+/** The number of panes in the layout. */
+export function leafCount(node: LayoutNode): number {
+  return leaves(node).length;
+}
+
+/** The leaf with the given id, or null. */
+export function findLeaf(node: LayoutNode, id: string): LeafNode | null {
+  if (node.kind === "leaf") {
+    return node.id === id ? node : null;
+  }
+  return findLeaf(node.a, id) ?? findLeaf(node.b, id);
+}
+
+/** Returns a new tree with the leaf `id` replaced by `fn(leaf)` (which may be a
+ *  leaf or a split); structure elsewhere is shared. */
+function mapLeaf(node: LayoutNode, id: string, fn: (leaf: LeafNode) => LayoutNode): LayoutNode {
+  if (node.kind === "leaf") {
+    return node.id === id ? fn(node) : node;
+  }
+  return { ...node, a: mapLeaf(node.a, id, fn), b: mapLeaf(node.b, id, fn) };
+}
+
+/** Maps every leaf through `fn`, PRESERVING the node reference when nothing changed
+ *  (fn returns the same leaf and both children are unchanged). Reference stability is
+ *  load-bearing: setSession re-validates on every store update, and a validate() that
+ *  always produced a fresh tree would reconcile — and rebuild terminals — on every
+ *  status tick, re-entering itself to a stack overflow. */
+function mapAllLeaves(node: LayoutNode, fn: (leaf: LeafNode) => LeafNode): LayoutNode {
+  if (node.kind === "leaf") {
+    return fn(node);
+  }
+  const a = mapAllLeaves(node.a, fn);
+  const b = mapAllLeaves(node.b, fn);
+  if (a === node.a && b === node.b) {
+    return node;
+  }
+  return { ...node, a, b };
+}
+
+/**
+ * Removes the leaf `leafId`, collapsing its parent split so the sibling fills the
+ * freed space. Returns the new tree, or null if `leafId` is the only pane (the last
+ * pane can't be closed — a session always shows at least one terminal).
+ */
+export function closeLeaf(root: LayoutNode, leafId: string): LayoutNode | null {
+  const remove = (node: LayoutNode): LayoutNode | null => {
+    if (node.kind === "leaf") {
+      return node.id === leafId ? null : node;
+    }
+    const a = remove(node.a);
+    const b = remove(node.b);
+    // A split has a single target at most, so at most one side collapses to null;
+    // return the surviving sibling in that case (the collapse).
+    if (a === null) {
+      return b;
+    }
+    if (b === null) {
+      return a;
+    }
+    if (a === node.a && b === node.b) {
+      return node;
+    }
+    return { ...node, a, b };
+  };
+  // remove(root) is null only when root itself is the target leaf.
+  return remove(root);
+}
+
+/** Drops every leaf bound to `tab` except the one with id `keepId`, collapsing each
+ *  removal. Enforces the one-tab-one-pane invariant after a split/replace. */
+function dedupeExcept(root: LayoutNode, tab: number, keepId: string): LayoutNode {
+  const dupes = leaves(root).filter((l) => l.tab === tab && l.id !== keepId);
+  let cur = root;
+  for (const d of dupes) {
+    cur = closeLeaf(cur, d.id) ?? cur;
+  }
+  return cur;
+}
+
+/**
+ * Splits the leaf `leafId` along `edge`, placing a NEW pane bound to `tab` on that
+ * edge's side (left/right → a row; top/bottom → a column). If `tab` is already shown
+ * in another pane it is MOVED here (the one-tab-one-pane invariant). A "center" edge
+ * is not a split — it replaces the pane's tab (see replaceTab).
+ */
+export function splitLeaf(root: LayoutNode, leafId: string, edge: Edge, tab: number): LayoutNode {
+  if (edge === "center") {
+    return replaceTab(root, leafId, tab);
+  }
+  const dir: SplitDir = edge === "left" || edge === "right" ? "row" : "column";
+  const newFirst = edge === "left" || edge === "top";
+  const fresh: LeafNode = { kind: "leaf", id: nextId("leaf"), tab };
+  const grown = mapLeaf(root, leafId, (leaf) => {
+    const [a, b] = newFirst ? [fresh, leaf] : [leaf, fresh];
+    return { kind: "split", id: nextId("split"), dir, ratio: 0.5, a, b };
+  });
+  return dedupeExcept(grown, tab, fresh.id);
+}
+
+/** Rebinds the pane `leafId` to show `tab` (a center-drop, a tab-bar click, or a 1-9
+ *  key on the focused pane). Moves the tab here if it was shown elsewhere. */
+export function replaceTab(root: LayoutNode, leafId: string, tab: number): LayoutNode {
+  const target = findLeaf(root, leafId);
+  if (!target || target.tab === tab) {
+    // No-op when the pane is gone or already shows this tab — but still dedupe in
+    // case the same tab lingers in another pane.
+    return dedupeExcept(root, tab, leafId);
+  }
+  const updated = mapLeaf(root, leafId, (leaf) => ({ ...leaf, tab }));
+  return dedupeExcept(updated, tab, leafId);
+}
+
+/** Sets the split `splitId`'s divider ratio, clamped to [0.1, 0.9] so a pane can be
+ *  shrunk but never collapsed to nothing by a drag. */
+export function setRatio(root: LayoutNode, splitId: string, ratio: number): LayoutNode {
+  const clamped = Math.min(0.9, Math.max(0.1, ratio));
+  const rec = (node: LayoutNode): LayoutNode => {
+    if (node.kind === "leaf") {
+      return node;
+    }
+    if (node.id === splitId) {
+      return { ...node, ratio: clamped };
+    }
+    return { ...node, a: rec(node.a), b: rec(node.b) };
+  };
+  return rec(root);
+}
+
+/**
+ * Reconciles a layout against the session's current tab list: clamps every leaf's
+ * tab into [0, tabCount-1] (a tab closed elsewhere would otherwise stream a
+ * nonexistent tab) and drops the resulting duplicate panes, keeping the first. Used
+ * when another client grows/shrinks the tab list out from under a split.
+ */
+export function validate(root: LayoutNode, tabCount: number): LayoutNode {
+  const max = Math.max(0, tabCount - 1);
+  const clamped = mapAllLeaves(root, (leaf) => (leaf.tab > max ? { ...leaf, tab: max } : leaf));
+  const seen = new Set<number>();
+  let cur = clamped;
+  for (const l of leaves(clamped)) {
+    if (seen.has(l.tab)) {
+      cur = closeLeaf(cur, l.id) ?? cur;
+    } else {
+      seen.add(l.tab);
+    }
+  }
+  return cur;
+}

--- a/web/src/nav.test.ts
+++ b/web/src/nav.test.ts
@@ -97,6 +97,30 @@ test("nav mode: t creates a tab; w closes the active non-agent tab", () => {
   assert.deepEqual(decideKey("w", ctx({ tabCount: 2, activeTab: 1 })), { kind: "closeTab" });
 });
 
+test("split panes: Alt+j/k cycle pane focus, Alt+w closes the focused pane", () => {
+  // The Alt chord fires in BOTH modes — a split is only meaningful while attached, and
+  // a bare j/k/w must still reach the agent in terminal mode.
+  assert.deepEqual(decideKey("j", ctx(), { alt: true }), { kind: "cyclePane", delta: 1 });
+  assert.deepEqual(decideKey("k", ctx(), { alt: true }), { kind: "cyclePane", delta: -1 });
+  assert.deepEqual(decideKey("w", ctx(), { alt: true }), { kind: "closePane" });
+  assert.deepEqual(
+    decideKey("j", ctx({ focus: "terminal" }), { alt: true }),
+    { kind: "cyclePane", delta: 1 },
+    "the Alt chord works while attached, unlike a bare j",
+  );
+});
+
+test("split panes: the Alt chord needs a selection in the sessions view, and yields to a modal", () => {
+  // No selection → nothing to split.
+  assert.deepEqual(decideKey("j", ctx({ selectedId: null }), { alt: true }), { kind: "none" });
+  // Another view has no panes.
+  assert.deepEqual(decideKey("j", ctx({ view: "tasks" }), { alt: true }), { kind: "none" });
+  // A modal still owns the keyboard.
+  assert.deepEqual(decideKey("w", ctx({ modalOpen: true }), { alt: true }), { kind: "none" });
+  // Without Alt these stay their normal rail actions (no accidental pane ops).
+  assert.deepEqual(decideKey("j", ctx()), { kind: "select", id: "c" });
+});
+
 test("nav mode: remote sessions can't manage tabs (t/w pass through) but can still switch", () => {
   const remote = ctx({ tabManagement: false, tabCount: 2, activeTab: 0 });
   assert.deepEqual(decideKey("t", remote), { kind: "none" }, "no new tab on a remote session");

--- a/web/src/nav.ts
+++ b/web/src/nav.ts
@@ -74,7 +74,15 @@ export type NavAction =
   | { kind: "switchTab"; index: number }
   | { kind: "newTab" }
   | { kind: "closeTab" }
-  | { kind: "switchView"; view: View };
+  | { kind: "switchView"; view: View }
+  | { kind: "cyclePane"; delta: 1 | -1 }
+  | { kind: "closePane" };
+
+/** Modifier flags the split keybinds read. Only Alt is consulted; the rest are
+ *  ignored so the split chords never shadow a browser/OS shortcut. */
+export interface KeyMods {
+  alt?: boolean;
+}
 
 /** The next selected id after moving `delta` rows, clamped to the ends. From no
  *  selection, a downward move lands on the first row and an upward move on the last
@@ -97,11 +105,33 @@ export function nextSelection(orderedIds: string[], selectedId: string | null, d
  *  the store — the caller (index.ts onKeydown) performs the effect for the returned
  *  action. Precedence is modal → terminal → rail, so an open modal and a focused
  *  terminal never leak keys to the rail. */
-export function decideKey(key: string, ctx: NavContext): NavAction {
+export function decideKey(key: string, ctx: NavContext, mods: KeyMods = {}): NavAction {
   // A modal owns the keyboard while open: Escape cancels it; everything else falls
   // through to the form (a normal keystroke into its input), never the rail.
   if (ctx.modalOpen) {
     return key === "Escape" ? { kind: "closeModal" } : { kind: "none" };
+  }
+  // Split-pane keys (feat: drag-and-drop split tabs), an Alt chord over the j/k/w
+  // movement vocabulary so they read as "same motion, on PANES not the rail": Alt+j/k
+  // cycle pane focus, Alt+w closes the focused pane. They fire in EITHER mode (a split
+  // is only meaningful while attached, and in terminal mode a bare j/k/w must still
+  // reach the agent — the Alt guard is what keeps them from leaking there) but only in
+  // the sessions view with a selection. Handled before the terminal branch so terminal
+  // mode doesn't swallow them.
+  if (mods.alt === true && (key === "j" || key === "k" || key === "w")) {
+    // Consume the chord even with no selection / outside the sessions view, so Alt+j
+    // never falls through to a rail navigation (a pane action with no panes is just a
+    // no-op, not a selection move).
+    if (ctx.view !== "sessions" || !ctx.selectedId) {
+      return { kind: "none" };
+    }
+    if (key === "j") {
+      return { kind: "cyclePane", delta: 1 };
+    }
+    if (key === "k") {
+      return { kind: "cyclePane", delta: -1 };
+    }
+    return { kind: "closePane" };
   }
   // The terminal owns the keyboard: keys go to the agent. Escape is the escape
   // hatch back to rail navigation (mirrors the TUI detach); nothing else is ours.

--- a/web/src/split.ts
+++ b/web/src/split.ts
@@ -1,0 +1,553 @@
+// The split-pane view (feat(web): drag-and-drop split tabs) — the imperative half of
+// the per-instance split layout, the way terminal.ts is the imperative half of the
+// single attach terminal it generalizes. It owns:
+//
+//   - a per-instance layout TREE (layout.ts): which tabs are shown, split how, at
+//     what ratios. The default is a single leaf, so a session that is never split
+//     renders exactly like the pre-split single terminal.
+//   - one live AttachTerminal PER LEAF: multiple concurrent xterms, each with its own
+//     WS to /v1/sessions/{id}/stream?tab=<idx>, each self-healing + fit/resizing
+//     independently. The daemon's ptyBroker already supports N concurrent
+//     subscribers, so this is purely a client-side layout feature.
+//   - drag-and-drop splitting: dropping a tab (dragged from the tab bar) on a pane's
+//     edge splits in that direction with the dragged tab in the new pane; dropping on
+//     the center replaces the pane's tab. Drop zones are shown on dragover.
+//   - a draggable divider per split to resize (persists the ratio), a × to close a
+//     pane (collapsing its split so the sibling fills), and click-to-focus.
+//
+// Focus is per-pane and feeds the #1694 nav model: the FOCUSED pane owns the keyboard
+// (its status shows in the pane header, keys go to it), and index.ts wires an Alt+j/k
+// cycle + Alt+w close through here. Retained layouts are kept per session in memory,
+// so switching instances shows each instance's own split; the live terminals exist
+// only for the currently-shown instance (rebuilt from the retained tree on return),
+// mirroring how the single terminal was disposed+rebuilt on every selection change.
+
+import {
+  closeLeaf,
+  type Edge,
+  findLeaf,
+  type LayoutNode,
+  type LeafNode,
+  leafCount,
+  leaves,
+  replaceTab,
+  setRatio,
+  singleLeaf,
+  type SplitNode,
+  splitLeaf,
+  TAB_DND_MIME,
+  validate,
+} from "./layout.js";
+import { AttachTerminal, type TerminalStatus } from "./terminal.js";
+
+/** How close (as a fraction of the pane) to an edge the pointer must be for the drop
+ *  to split rather than replace — the outer 30% band on each side is an edge zone. */
+const EDGE_BAND = 0.3;
+
+export interface SplitCallbacks {
+  /** The FOCUSED pane's connection state, for the pane-header status line. */
+  onStatus(status: TerminalStatus): void;
+  /** Real DOM focus of any pane's terminal, for the nav-vs-terminal mode (#1693):
+   *  true when a pane's xterm gains the keyboard, false when focus leaves every pane. */
+  onFocusChange(focused: boolean): void;
+  /** The layout mirror the store keeps for the tab bar: which tab the focused pane
+   *  shows (activeTab), which tabs are shown across all panes, and the pane count.
+   *  Fired only on a real change, so it can safely write the store without looping. */
+  onLayout(info: { focusedTab: number; shownTabs: number[]; paneCount: number }): void;
+}
+
+/** One live pane: its persistent DOM (reused across tree re-renders so the xterm is
+ *  never torn down by a sibling's split) and the terminal bound to its current tab. */
+interface Pane {
+  leafId: string;
+  container: HTMLElement;
+  host: HTMLElement;
+  label: HTMLElement;
+  overlay: HTMLElement;
+  term: AttachTerminal | null;
+  tab: number;
+  status: TerminalStatus;
+}
+
+function el(tag: string, cls: string): HTMLElement {
+  const node = document.createElement(tag);
+  node.className = cls;
+  return node;
+}
+
+export class SplitView {
+  // Retained layout per session id (in-memory; a nice-to-have to persist across
+  // reload is out of scope for v1). Keyed by the stable session id.
+  private readonly trees = new Map<string, LayoutNode>();
+  private readonly panes = new Map<string, Pane>();
+
+  private sessionId: string | null = null;
+  private token: string | null = null;
+  private tabCount = 1;
+  private tree: LayoutNode | null = null;
+  private focusedId: string | null = null;
+
+  // Debounces the "focus left every pane" report so a click that moves focus A→B
+  // (blur A, then focus B) doesn't flap the nav mode through rail and back.
+  private blurTimer: number | null = null;
+
+  // Last values reported via onLayout, so a no-op reconcile never re-fires it (which
+  // would re-enter the store→rerender→setSession loop).
+  private lastFocusedTab = -1;
+  private lastShown = "";
+  private lastPaneCount = 0;
+
+  constructor(
+    private readonly host: HTMLElement,
+    private readonly cb: SplitCallbacks,
+  ) {}
+
+  /**
+   * Shows `sessionId`'s layout, building/rebuilding terminals as needed. Called on
+   * every selection/tab change: a NEW session rebuilds from its retained tree (or a
+   * fresh single leaf bound to `initialTab`); the SAME session only re-validates the
+   * tree against the current tab list (a tab closed elsewhere). Cheap on a no-op.
+   */
+  setSession(sessionId: string | null, token: string | null, tabCount: number, initialTab: number): void {
+    this.token = token;
+    if (sessionId === null || token === null) {
+      this.teardown();
+      this.sessionId = null;
+      this.tree = null;
+      this.report();
+      return;
+    }
+    if (sessionId === this.sessionId) {
+      // Same session: reconcile the retained tree against a possibly-changed tab list.
+      this.tabCount = tabCount;
+      const before = this.tree;
+      this.tree = validate(this.tree ?? singleLeaf(initialTab), tabCount);
+      if (this.trees.get(sessionId) !== this.tree) {
+        this.trees.set(sessionId, this.tree);
+      }
+      if (before !== this.tree) {
+        this.reconcile();
+        this.report();
+      }
+      return;
+    }
+    // A different session: drop the old session's live terminals (its tree stays
+    // retained) and build the new one's.
+    this.teardown();
+    this.sessionId = sessionId;
+    this.tabCount = tabCount;
+    const retained = this.trees.get(sessionId);
+    this.tree = validate(retained ?? singleLeaf(initialTab), tabCount);
+    this.trees.set(sessionId, this.tree);
+    // Focus the first pane of the newly shown session by default.
+    this.focusedId = leaves(this.tree)[0]?.id ?? null;
+    this.reconcile();
+    this.report();
+  }
+
+  /** Rebinds the FOCUSED pane to show `tab` (a 1-9 key or a tab-bar click on the
+   *  focused pane). No-op without a focused pane. Does not steal DOM focus. */
+  setFocusedTab(tab: number): void {
+    if (!this.tree || !this.focusedId) {
+      return;
+    }
+    this.tree = replaceTab(this.tree, this.focusedId, tab);
+    this.commit();
+  }
+
+  /** Gives the keyboard to the focused pane's terminal (attach). */
+  focus(): void {
+    const pane = this.focusedId ? this.panes.get(this.focusedId) : null;
+    pane?.term?.focus();
+  }
+
+  /** Takes the keyboard away from every pane (back to rail nav). */
+  blur(): void {
+    for (const pane of this.panes.values()) {
+      pane.term?.blur();
+    }
+  }
+
+  /** Moves pane focus by `delta` (wrapping) and attaches the newly focused pane. */
+  cyclePane(delta: 1 | -1): void {
+    if (!this.tree) {
+      return;
+    }
+    const ids = leaves(this.tree).map((l) => l.id);
+    if (ids.length <= 1) {
+      this.focus();
+      return;
+    }
+    const cur = this.focusedId ? ids.indexOf(this.focusedId) : -1;
+    const next = ids[(cur + delta + ids.length) % ids.length];
+    if (next) {
+      this.focusPane(next);
+      this.focus();
+    }
+  }
+
+  /** Closes the focused pane, collapsing its split. No-op when it is the only pane
+   *  (a session always shows at least one terminal — close the TAB instead). */
+  closeFocusedPane(): void {
+    if (this.focusedId) {
+      this.closePane(this.focusedId);
+    }
+  }
+
+  /** Whether the layout currently has more than one pane. */
+  isSplit(): boolean {
+    return this.tree ? leafCount(this.tree) > 1 : false;
+  }
+
+  /** Tears down every live terminal and clears the host (logout / deselect). The
+   *  retained trees survive so a re-selection restores the split. */
+  dispose(): void {
+    this.teardown();
+    this.sessionId = null;
+    this.tree = null;
+  }
+
+  // --- internal: mutation commit --------------------------------------------
+
+  /** Persists the current tree for the session, re-renders, and reports the layout. */
+  private commit(): void {
+    if (this.sessionId && this.tree) {
+      this.trees.set(this.sessionId, this.tree);
+    }
+    this.reconcile();
+    this.report();
+  }
+
+  private closePane(leafId: string): void {
+    if (!this.tree) {
+      return;
+    }
+    const next = closeLeaf(this.tree, leafId);
+    if (next === null) {
+      return; // the last pane can't be closed
+    }
+    this.tree = next;
+    // Re-point focus if the closed pane held it.
+    if (this.focusedId === leafId) {
+      this.focusedId = leaves(this.tree)[0]?.id ?? null;
+    }
+    this.commit();
+    this.focus();
+  }
+
+  // --- internal: reconcile tree → DOM + terminals ---------------------------
+
+  private teardown(): void {
+    for (const pane of this.panes.values()) {
+      pane.term?.dispose();
+    }
+    this.panes.clear();
+    this.host.replaceChildren();
+    this.host.classList.remove("af-split-multi");
+    this.focusedId = null;
+  }
+
+  /** Brings the live panes + DOM in line with the current tree: disposes gone panes,
+   *  (re)creates terminals whose tab changed, rebuilds the split wrappers (reusing
+   *  the persistent pane containers so surviving xterms are only reparented, never
+   *  recreated), and refreshes focus/head chrome. */
+  private reconcile(): void {
+    if (!this.tree || !this.sessionId || this.token === null) {
+      return;
+    }
+    const desired = leaves(this.tree);
+    const wanted = new Set(desired.map((l) => l.id));
+
+    // Drop panes no longer in the tree.
+    for (const [id, pane] of this.panes) {
+      if (!wanted.has(id)) {
+        pane.term?.dispose();
+        this.panes.delete(id);
+      }
+    }
+
+    // Ensure a container exists for every desired leaf (DOM only, no terminal yet).
+    for (const leaf of desired) {
+      if (!this.panes.has(leaf.id)) {
+        this.panes.set(leaf.id, this.createPane(leaf));
+      }
+    }
+
+    // Keep a valid focus.
+    if (!this.focusedId || !wanted.has(this.focusedId)) {
+      this.focusedId = desired[0]?.id ?? null;
+    }
+
+    // Rebuild the split wrappers, inserting the persistent containers. Containers now
+    // in the live DOM have real dimensions for the FitAddon.
+    const rootEl = this.buildNode(this.tree);
+    rootEl.style.flex = "1 1 0";
+    this.host.replaceChildren(rootEl);
+
+    const multi = desired.length > 1;
+    this.host.classList.toggle("af-split-multi", multi);
+
+    // (Re)create terminals for panes whose bound tab changed (or are brand new).
+    for (const leaf of desired) {
+      const pane = this.panes.get(leaf.id);
+      if (!pane) {
+        continue;
+      }
+      if (!pane.term || pane.tab !== leaf.tab) {
+        pane.term?.dispose();
+        pane.host.replaceChildren();
+        pane.tab = leaf.tab;
+        pane.status = "connecting";
+        pane.term = new AttachTerminal(pane.host, this.sessionId, this.token, leaf.tab, {
+          onStatus: (s) => this.onPaneStatus(leaf.id, s),
+          onFocusChange: (f) => this.onPaneFocus(leaf.id, f),
+        });
+      }
+      pane.container.classList.toggle("af-pane-multi", multi);
+      pane.label.textContent = `Tab ${leaf.tab + 1}`;
+    }
+
+    this.applyFocusClass();
+  }
+
+  private createPane(leaf: LeafNode): Pane {
+    const container = el("div", "af-pane");
+    container.setAttribute("data-leaf", leaf.id);
+    const head = el("div", "af-pane-head");
+    const label = el("span", "af-pane-label");
+    const closeBtn = document.createElement("button");
+    closeBtn.type = "button";
+    closeBtn.className = "af-pane-close";
+    closeBtn.title = "Close pane";
+    closeBtn.setAttribute("aria-label", "Close pane");
+    closeBtn.textContent = "×";
+    closeBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this.closePane(leaf.id);
+    });
+    head.append(label, closeBtn);
+
+    const paneHost = el("div", "af-pane-host");
+    const overlay = el("div", "af-drop-overlay");
+    container.append(head, paneHost, overlay);
+
+    // Click-to-focus (#1694): mousedown fires before xterm's textarea focus, so the
+    // pane is the focused one by the time keys flow.
+    container.addEventListener("mousedown", () => this.focusPane(leaf.id));
+
+    const pane: Pane = { leafId: leaf.id, container, host: paneHost, label, overlay, term: null, tab: -1, status: "connecting" };
+    this.wireDrop(pane);
+    return pane;
+  }
+
+  private buildNode(node: LayoutNode): HTMLElement {
+    if (node.kind === "leaf") {
+      return this.panes.get(node.id)?.container ?? el("div", "af-pane");
+    }
+    const a = this.buildNode(node.a);
+    const b = this.buildNode(node.b);
+    a.style.flex = `${node.ratio} 1 0`;
+    b.style.flex = `${1 - node.ratio} 1 0`;
+    const divider = this.buildDivider(node, a, b);
+    const wrap = el("div", `af-split af-split-${node.dir}`);
+    wrap.append(a, divider, b);
+    return wrap;
+  }
+
+  private buildDivider(node: SplitNode, aEl: HTMLElement, bEl: HTMLElement): HTMLElement {
+    const divider = el("div", `af-divider af-divider-${node.dir}`);
+    divider.setAttribute("role", "separator");
+    divider.addEventListener("pointerdown", (e: PointerEvent) => {
+      e.preventDefault();
+      const parent = divider.parentElement;
+      if (!parent) {
+        return;
+      }
+      divider.setPointerCapture(e.pointerId);
+      document.body.classList.add(node.dir === "row" ? "af-resizing-col" : "af-resizing-row");
+      const rect = parent.getBoundingClientRect();
+      const onMove = (ev: PointerEvent) => {
+        const ratio =
+          node.dir === "row" ? (ev.clientX - rect.left) / rect.width : (ev.clientY - rect.top) / rect.height;
+        const clamped = Math.min(0.9, Math.max(0.1, ratio));
+        // Mutate the live node's ratio (the tree is not in the store, so an in-place
+        // update is fine) and reflect it immediately; the terminals' ResizeObservers
+        // re-fit on their own as the flex basis changes.
+        node.ratio = clamped;
+        aEl.style.flex = `${clamped} 1 0`;
+        bEl.style.flex = `${1 - clamped} 1 0`;
+      };
+      const onUp = (ev: PointerEvent) => {
+        divider.releasePointerCapture(ev.pointerId);
+        divider.removeEventListener("pointermove", onMove);
+        divider.removeEventListener("pointerup", onUp);
+        document.body.classList.remove("af-resizing-col", "af-resizing-row");
+        // Persist the final ratio into the retained tree by id.
+        if (this.tree) {
+          this.tree = setRatio(this.tree, node.id, node.ratio);
+          if (this.sessionId) {
+            this.trees.set(this.sessionId, this.tree);
+          }
+        }
+      };
+      divider.addEventListener("pointermove", onMove);
+      divider.addEventListener("pointerup", onUp);
+    });
+    return divider;
+  }
+
+  // --- internal: drag-and-drop ----------------------------------------------
+
+  private wireDrop(pane: Pane): void {
+    const isTabDrag = (e: DragEvent) => e.dataTransfer?.types.includes(TAB_DND_MIME) ?? false;
+    pane.container.addEventListener("dragover", (e: DragEvent) => {
+      if (!isTabDrag(e)) {
+        return;
+      }
+      e.preventDefault(); // allow the drop
+      if (e.dataTransfer) {
+        e.dataTransfer.dropEffect = "move";
+      }
+      this.showZone(pane, this.zoneAt(pane.container, e.clientX, e.clientY));
+    });
+    pane.container.addEventListener("dragleave", (e: DragEvent) => {
+      // Ignore leave events that only cross into a child of the pane.
+      const to = e.relatedTarget as Node | null;
+      if (to && pane.container.contains(to)) {
+        return;
+      }
+      this.hideZone(pane);
+    });
+    pane.container.addEventListener("drop", (e: DragEvent) => {
+      if (!isTabDrag(e)) {
+        return;
+      }
+      e.preventDefault();
+      this.hideZone(pane);
+      const raw = e.dataTransfer?.getData(TAB_DND_MIME);
+      const tab = raw ? Number.parseInt(raw, 10) : Number.NaN;
+      if (Number.isNaN(tab) || !this.tree) {
+        return;
+      }
+      const zone = this.zoneAt(pane.container, e.clientX, e.clientY);
+      this.tree = zone === "center" ? replaceTab(this.tree, pane.leafId, tab) : splitLeaf(this.tree, pane.leafId, zone, tab);
+      // Focus the pane now showing the dropped tab (VS Code focuses the new split).
+      const landed = leaves(this.tree).find((l) => l.tab === tab);
+      if (landed) {
+        this.focusedId = landed.id;
+      }
+      this.commit();
+      this.focus();
+    });
+  }
+
+  /** The drop zone for a pointer position over a pane: an edge (outer band) or the
+   *  center. */
+  private zoneAt(container: HTMLElement, x: number, y: number): Edge {
+    const r = container.getBoundingClientRect();
+    if (r.width === 0 || r.height === 0) {
+      return "center";
+    }
+    const fx = (x - r.left) / r.width;
+    const fy = (y - r.top) / r.height;
+    const d = { left: fx, right: 1 - fx, top: fy, bottom: 1 - fy };
+    const min = Math.min(d.left, d.right, d.top, d.bottom);
+    if (min > EDGE_BAND) {
+      return "center";
+    }
+    if (min === d.left) {
+      return "left";
+    }
+    if (min === d.right) {
+      return "right";
+    }
+    if (min === d.top) {
+      return "top";
+    }
+    return "bottom";
+  }
+
+  private showZone(pane: Pane, zone: Edge): void {
+    pane.overlay.className = `af-drop-overlay af-drop-show af-drop-${zone}`;
+  }
+
+  private hideZone(pane: Pane): void {
+    pane.overlay.className = "af-drop-overlay";
+  }
+
+  // --- internal: focus + status ---------------------------------------------
+
+  private focusPane(leafId: string): void {
+    if (this.focusedId === leafId) {
+      return;
+    }
+    this.focusedId = leafId;
+    this.applyFocusClass();
+    // The focused pane's status becomes the header status.
+    const pane = this.panes.get(leafId);
+    if (pane) {
+      this.cb.onStatus(pane.status);
+    }
+    this.report();
+  }
+
+  private applyFocusClass(): void {
+    for (const [id, pane] of this.panes) {
+      pane.container.classList.toggle("af-pane-focused", id === this.focusedId);
+    }
+  }
+
+  private onPaneStatus(leafId: string, status: TerminalStatus): void {
+    const pane = this.panes.get(leafId);
+    if (pane) {
+      pane.status = status;
+    }
+    if (leafId === this.focusedId) {
+      this.cb.onStatus(status);
+    }
+  }
+
+  private onPaneFocus(leafId: string, focused: boolean): void {
+    if (focused) {
+      if (this.blurTimer !== null) {
+        window.clearTimeout(this.blurTimer);
+        this.blurTimer = null;
+      }
+      // A click straight into a pane makes it the focused one.
+      if (this.focusedId !== leafId) {
+        this.focusPane(leafId);
+      }
+      this.cb.onFocusChange(true);
+      return;
+    }
+    // A blur: only report "focus left the terminal" once we know no OTHER pane
+    // grabbed it (the A→B handoff blurs A before focusing B).
+    if (this.blurTimer !== null) {
+      window.clearTimeout(this.blurTimer);
+    }
+    this.blurTimer = window.setTimeout(() => {
+      this.blurTimer = null;
+      const active = document.activeElement;
+      const stillInPane = active ? [...this.panes.values()].some((p) => p.host.contains(active)) : false;
+      if (!stillInPane) {
+        this.cb.onFocusChange(false);
+      }
+    }, 0);
+  }
+
+  /** Fires onLayout when the focused tab, the shown-tab set, or the pane count
+   *  changed — never on a no-op, so writing the store from it can't loop. */
+  private report(): void {
+    const shownTabs = this.tree ? leaves(this.tree).map((l) => l.tab) : [];
+    const focusedTab = this.focusedId ? (findLeaf(this.tree ?? { kind: "leaf", id: "", tab: 0 }, this.focusedId)?.tab ?? 0) : 0;
+    const paneCount = shownTabs.length;
+    const shownKey = shownTabs.join(",");
+    if (focusedTab === this.lastFocusedTab && shownKey === this.lastShown && paneCount === this.lastPaneCount) {
+      return;
+    }
+    this.lastFocusedTab = focusedTab;
+    this.lastShown = shownKey;
+    this.lastPaneCount = paneCount;
+    this.cb.onLayout({ focusedTab, shownTabs, paneCount });
+  }
+}

--- a/web/src/split.ts
+++ b/web/src/split.ts
@@ -199,12 +199,21 @@ export class SplitView {
     return this.tree ? leafCount(this.tree) > 1 : false;
   }
 
-  /** Tears down every live terminal and clears the host (logout / deselect). The
-   *  retained trees survive so a re-selection restores the split. */
+  /** Tears down every live terminal, clears the host, AND drops the retained
+   *  per-instance trees (logout). Keeping the trees across a logout would leave them
+   *  pointing at torn-down panes, so a re-login would resurrect a stale split instead
+   *  of the single-leaf default — so a fresh login starts clean. (Instance→instance
+   *  switches never call this; they go through setSession, which keeps the trees.) */
   dispose(): void {
     this.teardown();
+    this.trees.clear();
     this.sessionId = null;
     this.tree = null;
+    // Reset the onLayout dedup trackers so the first select after a fresh login always
+    // re-reports its (single-leaf) layout to the store.
+    this.lastFocusedTab = -1;
+    this.lastShown = "";
+    this.lastPaneCount = 0;
   }
 
   // --- internal: mutation commit --------------------------------------------
@@ -426,7 +435,12 @@ export class SplitView {
       this.hideZone(pane);
       const raw = e.dataTransfer?.getData(TAB_DND_MIME);
       const tab = raw ? Number.parseInt(raw, 10) : Number.NaN;
-      if (Number.isNaN(tab) || !this.tree) {
+      // Validate the dropped tab against the instance's LIVE tab count before mutating
+      // the layout: a payload that went stale mid-drag (the tab was closed) or is
+      // otherwise out of range must not bind a pane to a nonexistent tab (same
+      // stale-index discipline as the tab-op fixes in #1698/#1710). An invalid drop is
+      // a no-op — the layout is left exactly as it was.
+      if (Number.isNaN(tab) || tab < 0 || tab >= this.tabCount || !this.tree) {
         return;
       }
       const zone = this.zoneAt(pane.container, e.clientX, e.clientY);

--- a/web/src/split.ts
+++ b/web/src/split.ts
@@ -75,6 +75,22 @@ function el(tag: string, cls: string): HTMLElement {
   return node;
 }
 
+/** Whether two ordered tab-identity lists are element-wise equal (the mid-drag
+ *  tab-set-change check). */
+function sameTabs(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  return a.every((v, i) => v === b[i]);
+}
+
+/** The drag payload a tab-bar drag stamps into the dataTransfer (ui.ts): the dragged
+ *  tab index plus a snapshot of the instance's ordered tab identities at drag time. */
+interface DragPayload {
+  index: number;
+  tabs: string[];
+}
+
 export class SplitView {
   // Retained layout per session id (in-memory; a nice-to-have to persist across
   // reload is out of scope for v1). Keyed by the stable session id.
@@ -84,6 +100,10 @@ export class SplitView {
   private sessionId: string | null = null;
   private token: string | null = null;
   private tabCount = 1;
+  // The instance's ordered tab identities (ui.tabIdentity), kept current on every
+  // store update. A drop compares its drag-time snapshot against this to detect a
+  // mid-drag tab-set change (concurrent close/create/reorder) and cancel.
+  private tabIds: string[] = [];
   private tree: LayoutNode | null = null;
   private focusedId: string | null = null;
 
@@ -108,8 +128,10 @@ export class SplitView {
    * fresh single leaf bound to `initialTab`); the SAME session only re-validates the
    * tree against the current tab list (a tab closed elsewhere). Cheap on a no-op.
    */
-  setSession(sessionId: string | null, token: string | null, tabCount: number, initialTab: number): void {
+  setSession(sessionId: string | null, token: string | null, tabIds: string[], initialTab: number): void {
     this.token = token;
+    this.tabIds = tabIds;
+    const tabCount = tabIds.length > 0 ? tabIds.length : 1;
     if (sessionId === null || token === null) {
       this.teardown();
       this.sessionId = null;
@@ -407,6 +429,29 @@ export class SplitView {
 
   // --- internal: drag-and-drop ----------------------------------------------
 
+  /** Parses a drag payload from the dataTransfer, or null if it is absent/malformed
+   *  (a foreign drag, or a corrupt payload → the drop is a no-op). */
+  private parseDrag(raw: string | undefined): DragPayload | null {
+    if (!raw) {
+      return null;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return null;
+    }
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      typeof (parsed as DragPayload).index === "number" &&
+      Array.isArray((parsed as DragPayload).tabs)
+    ) {
+      return parsed as DragPayload;
+    }
+    return null;
+  }
+
   private wireDrop(pane: Pane): void {
     const isTabDrag = (e: DragEvent) => e.dataTransfer?.types.includes(TAB_DND_MIME) ?? false;
     pane.container.addEventListener("dragover", (e: DragEvent) => {
@@ -433,14 +478,24 @@ export class SplitView {
       }
       e.preventDefault();
       this.hideZone(pane);
-      const raw = e.dataTransfer?.getData(TAB_DND_MIME);
-      const tab = raw ? Number.parseInt(raw, 10) : Number.NaN;
-      // Validate the dropped tab against the instance's LIVE tab count before mutating
-      // the layout: a payload that went stale mid-drag (the tab was closed) or is
-      // otherwise out of range must not bind a pane to a nonexistent tab (same
-      // stale-index discipline as the tab-op fixes in #1698/#1710). An invalid drop is
-      // a no-op — the layout is left exactly as it was.
-      if (Number.isNaN(tab) || tab < 0 || tab >= this.tabCount || !this.tree) {
+      const drag = this.parseDrag(e.dataTransfer?.getData(TAB_DND_MIME));
+      if (!drag || !this.tree) {
+        return;
+      }
+      const tab = drag.index;
+      // Reject an out-of-range index (a stale payload / a tab closed mid-drag): a pane
+      // must never bind to a nonexistent tab (same stale-index discipline as the tab-op
+      // fixes in #1698/#1710).
+      if (tab < 0 || tab >= this.tabCount) {
+        return;
+      }
+      // Reject an IN-RANGE-but-STALE drop (#1738 repro): if the instance's tab set
+      // changed since dragstart — a concurrent client closed/created/reordered a tab —
+      // the dragged index now points at a DIFFERENT live tab than the user grabbed, so
+      // splitting would silently bind the new pane to the wrong tab's stream. Compare
+      // the drag-time snapshot to the live identities and cancel on any mismatch; the
+      // user simply re-drags. (The full stable-tab-id fix is daemon-wide, in #1738.)
+      if (!sameTabs(drag.tabs, this.tabIds)) {
         return;
       }
       const zone = this.zoneAt(pane.container, e.clientX, e.clientY);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -532,6 +532,24 @@ body {
   border-bottom-color: var(--af-accent);
 }
 
+/* A tab shown in a (non-focused) pane while the layout is split: brighter than an
+ * idle tab, with a muted underline, so it reads as "already open" without competing
+ * with the focused tab's accent underline. */
+.af-tab-shown {
+  color: var(--af-text);
+  border-bottom-color: var(--af-border);
+}
+
+/* The tab is a drag source (feat: split tabs): a grab cursor cues that it can be
+ * dragged into a pane to split. */
+.af-tab {
+  cursor: grab;
+}
+
+.af-tab:active {
+  cursor: grabbing;
+}
+
 .af-tab-label {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -604,19 +622,200 @@ body {
   transform: translateY(0);
 }
 
-/* The persistent xterm host: fills the pane, and xterm's own .xterm fills it. The
- * small padding is inside the terminal background so the scrollback isn't flush to
- * the edges. */
+/* The persistent split host (feat: drag-and-drop split tabs): a flex container that
+ * holds the layout tree — one pane by default (today's behavior), or nested splits
+ * with dividers. It fills the pane below the tab bar; padding now lives on each pane
+ * so a divider reaches the host edges. */
 .af-term-host {
   flex: 1;
   min-height: 0;
-  padding: 0.4rem 0.6rem;
+  display: flex;
   background: var(--af-bg);
   overflow: hidden;
 }
 
-.af-term-host .xterm {
+/* A split node: two children laid out along its axis with a divider between them.
+ * The children carry their flex-basis inline (from the tree's ratio). */
+.af-split {
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.af-split-row {
+  flex-direction: row;
+}
+
+.af-split-column {
+  flex-direction: column;
+}
+
+/* The drag handle between two split children. A thin hit target with a hover accent;
+ * dragging it resizes the split (split.ts persists the ratio). */
+.af-divider {
+  flex: 0 0 auto;
+  background: var(--af-border);
+  transition: background 0.1s ease;
+}
+
+.af-divider:hover,
+.af-resizing-col .af-divider-row,
+.af-resizing-row .af-divider-column {
+  background: var(--af-accent);
+}
+
+.af-divider-row {
+  width: 4px;
+  cursor: col-resize;
+}
+
+.af-divider-column {
+  height: 4px;
+  cursor: row-resize;
+}
+
+/* While a divider drag is live, force the resize cursor everywhere and suppress text
+ * selection so the drag stays smooth over the terminals. */
+.af-resizing-col,
+.af-resizing-col * {
+  cursor: col-resize !important;
+  user-select: none;
+}
+
+.af-resizing-row,
+.af-resizing-row * {
+  cursor: row-resize !important;
+  user-select: none;
+}
+
+/* A pane: one leaf of the layout, a live terminal. position:relative anchors its drop
+ * overlay; it stacks an optional head (shown only when split) over the xterm host. */
+.af-pane {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+/* The per-pane head: shown only when the layout has >1 pane, so a single pane reads
+ * exactly like the pre-split terminal (zero-config default). It carries the pane's
+ * tab label and a × to close just that pane (collapsing its split). */
+.af-pane-head {
+  display: none;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.4rem;
+  padding: 0.15rem 0.5rem;
+  background: var(--af-surface);
+  border-bottom: 1px solid var(--af-border);
+}
+
+.af-pane-multi .af-pane-head {
+  display: flex;
+}
+
+.af-pane-label {
+  font-size: 0.68rem;
+  color: var(--af-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.af-pane-close {
+  flex: 0 0 auto;
+  padding: 0 0.25rem;
+  background: transparent;
+  color: var(--af-muted);
+  border: none;
+  border-radius: 3px;
+  font: inherit;
+  font-size: 0.85rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.af-pane-close:hover {
+  color: var(--af-error);
+  background: rgba(248, 81, 73, 0.14);
+}
+
+/* The xterm mount: fills the pane below its (optional) head. The small padding keeps
+ * scrollback off the edges, as the single terminal host did before. */
+.af-pane-host {
+  flex: 1;
+  min-height: 0;
+  padding: 0.4rem 0.6rem;
+  overflow: hidden;
+}
+
+.af-pane-host .xterm {
   height: 100%;
+}
+
+/* The focused pane, marked only when the layout is split (a single pane already reads
+ * as focused via the whole-pane .af-kb-terminal outline). An inner accent ring shows
+ * which pane the keyboard, Alt+w close, and a tab-bar click act on. */
+.af-kb-terminal .af-split-multi .af-pane-focused {
+  outline: 2px solid var(--af-accent);
+  outline-offset: -2px;
+}
+
+/* While a tab is being dragged, every pane hints it can receive the drop. */
+.af-dragging-tab .af-pane {
+  outline: 1px dashed var(--af-border);
+  outline-offset: -1px;
+}
+
+/* The drop-zone overlay: an accent wash over the region a drop would fill — an edge
+ * half for a split, or the whole pane for a replace. pointer-events:none so the drag
+ * keeps hitting the pane, not the overlay. */
+.af-drop-overlay {
+  position: absolute;
+  display: none;
+  background: rgba(47, 129, 247, 0.28);
+  border: 1px solid var(--af-accent);
+  pointer-events: none;
+  z-index: 5;
+}
+
+.af-drop-overlay.af-drop-show {
+  display: block;
+}
+
+.af-drop-center {
+  inset: 0;
+}
+
+.af-drop-left {
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 50%;
+}
+
+.af-drop-right {
+  top: 0;
+  bottom: 0;
+  right: 0;
+  width: 50%;
+}
+
+.af-drop-top {
+  left: 0;
+  right: 0;
+  top: 0;
+  height: 50%;
+}
+
+.af-drop-bottom {
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 50%;
 }
 
 /* Rail "+ New" button (#1592 Phase 5 PR5): a compact accent-outlined action in

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -21,6 +21,7 @@
 import type { EventStreamStatus } from "./events.js";
 import type { KeyboardFocus, View } from "./nav.js";
 import { VIEWS } from "./nav.js";
+import { TAB_DND_MIME } from "./layout.js";
 import { ProjectsPane } from "./projects.js";
 import { compareSessionsForRail, isArchived, rowStatus, rowTitle } from "./status.js";
 import { TasksPane } from "./tasks.js";
@@ -61,8 +62,14 @@ export interface AppState {
   /** the selected session's active tab index (#1592 Phase 5 PR7): 0 is the agent
    *  tab, 1-8 the user-created shell/process tabs. The attach terminal streams
    *  /stream?tab=<activeTab>, and the tab bar highlights it. Reset to 0 whenever
-   *  the selection changes. */
+   *  the selection changes. With split panes (feat: drag-and-drop split tabs) this
+   *  tracks the FOCUSED pane's tab, so the tab bar highlights the tab the keyboard
+   *  is on. */
   activeTab: number;
+  /** the tabs currently shown across ALL panes of the selected session (split.ts's
+   *  layout mirror), so the tab bar can flag which tabs are already open in a pane.
+   *  Defaults to [activeTab] — one pane — for the unsplit case. */
+  shownTabs: number[];
   /** an actionable message shown as a transient toast when a tab op (create/close)
    *  or a task op (toggle/trigger/remove) fails, or null when there is none. These
    *  ops have no modal to surface an error in (unlike create/kill/archive), so the
@@ -628,8 +635,13 @@ export class AppShell {
     // The active index is clamped: a resync that shrank the list must not leave the
     // highlight (and the streamed tab) pointing past the end.
     const active = Math.min(Math.max(state.activeTab, 0), tabs.length - 1);
+    // Which tabs are currently rendered in a pane (feat: split tabs), so the bar can
+    // mark an already-open tab distinctly from the focused one.
+    const shown = new Set(state.shownTabs);
 
-    const children: HTMLElement[] = tabs.map((tab, i) => tabButton(tab, i, i === active, canManage, this.actions));
+    const children: HTMLElement[] = tabs.map((tab, i) =>
+      tabButton(tab, i, i === active, shown.has(i), canManage, this.actions),
+    );
     if (canManage && tabs.length < MAX_TABS) {
       const add = h("button", { type: "button", class: "af-tab-new", title: "New tab" }, "+");
       add.addEventListener("click", () => this.actions.newTab());
@@ -658,22 +670,39 @@ function selectedSession(state: AppState): SessionData | null {
   return state.selectedId ? (state.sessions.find((s) => s.id === state.selectedId) ?? null) : null;
 }
 
-/** One tab-bar button: its label, an active-state highlight, and — for a closable
- *  (non-agent) tab of a tab-managed session — a × that closes it. Clicking the
- *  button switches to the tab AND attaches (like a session-row click); clicking
- *  the × closes it without attaching (stopPropagation so it isn't also a switch). */
+/** One tab-bar button: its label, an active-state highlight, a "shown in a pane"
+ *  marker, and — for a closable (non-agent) tab of a tab-managed session — a × that
+ *  closes it. Clicking the button points the focused pane at the tab AND attaches
+ *  (like a session-row click); clicking the × closes the tab without attaching
+ *  (stopPropagation so it isn't also a switch).
+ *
+ *  The button is also a DRAG SOURCE (feat: drag-and-drop split tabs): dragging it
+ *  onto a pane edge splits that pane with this tab; onto a pane center replaces it.
+ *  The dragged tab index rides the dataTransfer under a private MIME the panes read. */
 function tabButton(
   tab: { name: string; kind: number },
   index: number,
   active: boolean,
+  shown: boolean,
   canManage: boolean,
   actions: Actions,
 ): HTMLElement {
-  const btn = h("button", { type: "button", class: `af-tab${active ? " af-tab-active" : ""}` });
+  const cls = `af-tab${active ? " af-tab-active" : ""}${shown && !active ? " af-tab-shown" : ""}`;
+  const btn = h("button", { type: "button", class: cls, draggable: true });
   btn.setAttribute("role", "tab");
   btn.setAttribute("aria-selected", active ? "true" : "false");
   btn.append(h("span", { class: "af-tab-label" }, tabLabel(tab)));
   btn.addEventListener("click", () => actions.openTab(index));
+  // Drag source: stamp the tab index and flag the body so panes can show drop hints.
+  btn.addEventListener("dragstart", (e) => {
+    if (!e.dataTransfer) {
+      return;
+    }
+    e.dataTransfer.setData(TAB_DND_MIME, String(index));
+    e.dataTransfer.effectAllowed = "move";
+    document.body.classList.add("af-dragging-tab");
+  });
+  btn.addEventListener("dragend", () => document.body.classList.remove("af-dragging-tab"));
   // The agent tab (index 0) is unclosable — killing the session tears it down.
   if (index > 0 && canManage) {
     const close = h("span", { class: "af-tab-close", title: "Close tab" }, "×");

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -142,6 +142,16 @@ export function sessionTabs(s: SessionData): { name: string; kind: number }[] {
   return [{ name: "agent", kind: 0 }];
 }
 
+/** A stable-ish client-side IDENTITY for a tab (feat: split tabs), used to detect a
+ *  tab set that changed mid-drag. It is NOT a daemon tab id (there is none yet — the
+ *  full stable-id fix is #1738); it is the best identity the client has: the tab's
+ *  kind + name. The ordered list of these is snapshotted at dragstart and re-checked
+ *  at drop, so a concurrent close/create/reorder cancels the drop instead of binding a
+ *  pane to the wrong live tab. */
+export function tabIdentity(tab: { name: string; kind: number }): string {
+  return `${tab.kind}:${tab.name}`;
+}
+
 /** The label a tab reads as, mirroring the TUI's labelForTab (ui/tree/labels.go):
  *  the agent tab is "Agent", a shell tab is "Terminal", a process tab shows its
  *  name. Keeps the web tab bar TUI-faithful. */
@@ -638,9 +648,12 @@ export class AppShell {
     // Which tabs are currently rendered in a pane (feat: split tabs), so the bar can
     // mark an already-open tab distinctly from the focused one.
     const shown = new Set(state.shownTabs);
+    // The ordered tab identities at THIS render, snapshotted into a dragged tab's
+    // payload so the drop can detect a mid-drag tab-set change and cancel.
+    const tabIds = tabs.map(tabIdentity);
 
     const children: HTMLElement[] = tabs.map((tab, i) =>
-      tabButton(tab, i, i === active, shown.has(i), canManage, this.actions),
+      tabButton(tab, i, i === active, shown.has(i), canManage, tabIds, this.actions),
     );
     if (canManage && tabs.length < MAX_TABS) {
       const add = h("button", { type: "button", class: "af-tab-new", title: "New tab" }, "+");
@@ -685,6 +698,7 @@ function tabButton(
   active: boolean,
   shown: boolean,
   canManage: boolean,
+  tabIds: string[],
   actions: Actions,
 ): HTMLElement {
   const cls = `af-tab${active ? " af-tab-active" : ""}${shown && !active ? " af-tab-shown" : ""}`;
@@ -693,12 +707,15 @@ function tabButton(
   btn.setAttribute("aria-selected", active ? "true" : "false");
   btn.append(h("span", { class: "af-tab-label" }, tabLabel(tab)));
   btn.addEventListener("click", () => actions.openTab(index));
-  // Drag source: stamp the tab index and flag the body so panes can show drop hints.
+  // Drag source: stamp the dragged index PLUS a snapshot of the instance's ordered
+  // tab identities at drag time, so the drop can cancel if the tab set changed
+  // mid-drag (a concurrent close/create/reorder — see split.ts). Flag the body so
+  // panes can show drop hints.
   btn.addEventListener("dragstart", (e) => {
     if (!e.dataTransfer) {
       return;
     }
-    e.dataTransfer.setData(TAB_DND_MIME, String(index));
+    e.dataTransfer.setData(TAB_DND_MIME, JSON.stringify({ index, tabs: tabIds }));
     e.dataTransfer.effectAllowed = "move";
     document.body.classList.add("af-dragging-tab");
   });


### PR DESCRIPTION
## What

Drag a tab from the tab bar and drop it on a pane's edge to split the terminal area, so multiple of an instance's tabs render **side by side as live panes** instead of one at a time — VS-Code / tmux style. The old single attach terminal is now just the zero-config default (a single-leaf tree), so nothing changes for users who never split.

## Layout model

A per-instance **binary split tree** (`web/src/layout.ts`, pure + unit-tested):

- Each internal node splits its area into two children — a **row** (vertical divider) or **column** (horizontal divider) — at a resize ratio.
- Each **leaf** binds one tab to a pane, rendered as its own live `AttachTerminal` (xterm + WS to `/v1/sessions/{id}/stream?tab=<idx>`), self-healing and fit/resizing independently. **No daemon change** — the `ptyBroker` already supports N concurrent subscribers.
- **One tab, one pane:** dragging a tab already shown elsewhere *moves* it, which also avoids two panes fighting over one tab's PTY resize.

## DnD + pane management

- Tab-bar buttons are HTML5 drag sources (no DnD library). Drop on a pane's **left/right/top/bottom** edge to split in that direction; drop on the **center** to replace the pane's tab. Drop zones highlight on dragover.
- A **draggable divider** resizes each split (ratio persisted); a per-pane **×** closes a pane (collapsing its split so the sibling fills); **clicking** a pane focuses it.

## Keyboard (composes with the #1694 nav model)

The focused pane owns the keyboard. **Alt+j / Alt+k** cycle pane focus and **Alt+w** closes the focused pane — an Alt chord over the existing `j/k/w` movement vocabulary that fires in either mode without leaking to the agent. `j/k` rail nav and Enter/Esc are untouched.

## Scope

Split is **per-instance**; switching instances shows each instance's own in-memory layout (persisting across reload is a nice-to-have, not in v1).

## Verification (all gates green)

- **web-selftest-container: 13/13** — extended the Playwright driver: drag a tab to a pane edge → assert **two panes render and both show live output** → close one → assert it collapses back.
- **web-test** — `layout.ts` + `nav.ts` unit tests (82 total) + typecheck.
- **tui-driver-selftest: 25/25**, `go build ./...`, `gofmt`, `golangci-lint --fast`, `deadcode`, file-length lint — all clean.
- Rebuilt `web/dist` committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)