### PR TITLE
fix(session): read remoteClient/runtimeTeardown under i.mu to close AgentServer restore race (#1729)

### DIFF
--- a/session/agentserver_local.go
+++ b/session/agentserver_local.go
@@ -48,28 +48,37 @@ type localAgentServer struct {
 // every other session gets the local in-process impl over tmux — the default,
 // unchanged. The client was validated at construction, so this stays infallible.
 func (i *Instance) AgentServer() AgentServer {
-	// remoteClient/runtimeTeardown are owned by i.mu (they are rebound under it on
-	// restore/recover by bindProvisionResult/resetRemoteRuntime); agentSrvMu guards
-	// ONLY the i.agentSrv cache (#1729). Snapshot the i.mu-owned fields into locals
-	// FIRST, releasing i.mu before taking agentSrvMu, so the two locks are never
-	// held nested here. That fixes the lock order at i.mu → agentSrvMu; the only
-	// other agentSrvMu holders (bindProvisionResult, resetRemoteRuntime) release
-	// agentSrvMu before touching i.mu, so nothing ever takes them in the opposite
-	// order — no deadlock. Reading remoteClient under agentSrvMu (the pre-#1729 bug)
-	// raced the i.mu writer across two unrelated mutexes.
+	// i.mu is the SOLE owner of BOTH the runtime-selection fields
+	// (remoteClient/runtimeTeardown) AND the derived i.agentSrv cache (#1729).
+	// Guarding a cache and the fields it is derived from under ONE mutex is what
+	// keeps them consistent: restore/recover (bindProvisionResult/
+	// resetRemoteRuntime) clears the cache and swaps the fields in a SINGLE i.mu
+	// section, so AgentServer() can never rebuild the cache from a pre-restore
+	// snapshot of the fields. The earlier two-mutex split (agentSrvMu for the cache,
+	// i.mu for the fields) caused both the original data race AND a stale-cache
+	// TOCTOU — a rebuild from an OLD snapshot that pinned a torn-down endpoint.
+	//
+	// Fast path: a warm cache is returned under a read lock. Slow path:
+	// double-checked under the write lock, building + storing the cache from the
+	// fields read in the SAME critical section. The server values are trivial struct
+	// literals — they don't re-enter i.mu at construction — so building under i.mu is
+	// safe. Callers must not already hold i.mu (the returned server's methods
+	// re-acquire it), the same invariant tabTmuxSession relies on.
 	i.mu.RLock()
-	rc := i.remoteClient
-	teardown := i.runtimeTeardown
+	if as := i.agentSrv; as != nil {
+		i.mu.RUnlock()
+		return as
+	}
 	i.mu.RUnlock()
 
-	i.agentSrvMu.Lock()
-	defer i.agentSrvMu.Unlock()
+	i.mu.Lock()
+	defer i.mu.Unlock()
 	if i.agentSrv == nil {
-		if rc != nil {
+		if i.remoteClient != nil {
 			// teardown reaps the sandbox this session runs in (docker rm -f) after
 			// the remote Kill tears the in-sandbox workspace down — nil for the PR2
 			// out-of-process case (no sandbox to reap), set for a docker session.
-			i.agentSrv = &remoteAgentServer{rc: rc, teardown: teardown}
+			i.agentSrv = &remoteAgentServer{rc: i.remoteClient, teardown: i.runtimeTeardown}
 		} else {
 			i.agentSrv = &localAgentServer{inst: i}
 		}

--- a/session/agentserver_local.go
+++ b/session/agentserver_local.go
@@ -48,14 +48,28 @@ type localAgentServer struct {
 // every other session gets the local in-process impl over tmux — the default,
 // unchanged. The client was validated at construction, so this stays infallible.
 func (i *Instance) AgentServer() AgentServer {
+	// remoteClient/runtimeTeardown are owned by i.mu (they are rebound under it on
+	// restore/recover by bindProvisionResult/resetRemoteRuntime); agentSrvMu guards
+	// ONLY the i.agentSrv cache (#1729). Snapshot the i.mu-owned fields into locals
+	// FIRST, releasing i.mu before taking agentSrvMu, so the two locks are never
+	// held nested here. That fixes the lock order at i.mu → agentSrvMu; the only
+	// other agentSrvMu holders (bindProvisionResult, resetRemoteRuntime) release
+	// agentSrvMu before touching i.mu, so nothing ever takes them in the opposite
+	// order — no deadlock. Reading remoteClient under agentSrvMu (the pre-#1729 bug)
+	// raced the i.mu writer across two unrelated mutexes.
+	i.mu.RLock()
+	rc := i.remoteClient
+	teardown := i.runtimeTeardown
+	i.mu.RUnlock()
+
 	i.agentSrvMu.Lock()
 	defer i.agentSrvMu.Unlock()
 	if i.agentSrv == nil {
-		if i.remoteClient != nil {
+		if rc != nil {
 			// teardown reaps the sandbox this session runs in (docker rm -f) after
 			// the remote Kill tears the in-sandbox workspace down — nil for the PR2
 			// out-of-process case (no sandbox to reap), set for a docker session.
-			i.agentSrv = &remoteAgentServer{rc: i.remoteClient, teardown: i.runtimeTeardown}
+			i.agentSrv = &remoteAgentServer{rc: rc, teardown: teardown}
 		} else {
 			i.agentSrv = &localAgentServer{inst: i}
 		}

--- a/session/agentserver_restore_race_test.go
+++ b/session/agentserver_restore_race_test.go
@@ -3,15 +3,19 @@ package session
 import (
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestAgentServer_RestoreRace_NoDataRace is the -race regression for #1729: the
 // daemon poll calls Instance.AgentServer() (which reads remoteClient/
 // runtimeTeardown to pick the impl) concurrently with a restore/recover that
-// rebinds those fields via bindProvisionResult. Before the fix AgentServer() read
+// rebinds those fields via bindProvisionResult. Originally AgentServer() read
 // remoteClient under agentSrvMu while bindProvisionResult wrote it under i.mu —
-// two unrelated mutexes, a Go-memory-model data race. `go test -race` flags it on
-// the pre-fix code and passes clean after AgentServer() moved the read under i.mu.
+// two unrelated mutexes, a Go-memory-model data race. Both the cache and its
+// source fields now live under i.mu, so `go test -race` flags the original code
+// and passes clean here.
 //
 // It is written to hit the read even on a cache miss: bindProvisionResult clears
 // the agentSrv cache every iteration, so AgentServer() re-enters its build branch
@@ -58,4 +62,81 @@ func TestAgentServer_RestoreRace_NoDataRace(t *testing.T) {
 	}()
 
 	wg.Wait()
+}
+
+// TestAgentServer_RestoreCacheConsistency is the regression for the stale-cache
+// TOCTOU #1729's first fix introduced (and this structural fix removes): with the
+// cache (agentSrv) and its source fields (remoteClient/runtimeTeardown) under
+// SEPARATE mutexes, AgentServer() could snapshot the OLD remoteClient, then — after
+// a restore cleared the cache and swapped in a NEW client — rebuild the cache from
+// that stale snapshot, pinning the torn-down endpoint until the next cache clear.
+//
+// The invariant that must hold once cache + fields share i.mu: whenever the cached
+// agentSrv is a remoteAgentServer, it is bound to the CURRENT remoteClient. A
+// checker reads both under one i.mu critical section (a consistent snapshot) while
+// the poll builds the cache and restore rebinds a FRESH client each round; any
+// stale cache violates rc == remoteClient. It also asserts the FINAL cached server
+// reflects the last rebind, never a superseded runtime. Runs under -race too.
+func TestAgentServer_RestoreCacheConsistency(t *testing.T) {
+	ep := AgentServerEndpoint{URL: "wss://127.0.0.1:9", Token: "tok", Fingerprint: validFingerprint}
+	newRes := func() ProvisionResult {
+		return ProvisionResult{
+			Backend:  &dockerBackend{containerID: "c"},
+			Endpoint: &ep,
+			Teardown: func() error { return nil },
+		}
+	}
+
+	i := &Instance{Title: "consistency", backend: &dockerBackend{containerID: "c0"}}
+	require.NoError(t, i.bindProvisionResult(newRes()))
+
+	const iters = 3000
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	// Restore/recover: rebinds a FRESH remote client (a distinct pointer) each round,
+	// clearing the cache in the same i.mu section.
+	go func() {
+		defer wg.Done()
+		for n := 0; n < iters; n++ {
+			if err := i.bindProvisionResult(newRes()); err != nil {
+				t.Errorf("bindProvisionResult: %v", err)
+				return
+			}
+		}
+	}()
+	// Daemon poll: builds/returns the cached agent-server.
+	go func() {
+		defer wg.Done()
+		for n := 0; n < iters; n++ {
+			_ = i.AgentServer()
+		}
+	}()
+	// Invariant checker: the cached agentSrv, when a remoteAgentServer, MUST be bound
+	// to the current remoteClient. rc is set once at construction and never mutated,
+	// so reading it outside i.mu is safe; agentSrv/remoteClient are read together
+	// under i.mu for a consistent snapshot.
+	go func() {
+		defer wg.Done()
+		for n := 0; n < iters; n++ {
+			i.mu.RLock()
+			as := i.agentSrv
+			rc := i.remoteClient
+			i.mu.RUnlock()
+			if r, ok := as.(*remoteAgentServer); ok && r.rc != rc {
+				t.Errorf("stale agent-server cache: bound to %p but current remoteClient is %p", r.rc, rc)
+				return
+			}
+		}
+	}()
+	wg.Wait()
+
+	// Final rebind to a fresh runtime, then AgentServer() must reflect exactly it.
+	require.NoError(t, i.bindProvisionResult(newRes()))
+	r, ok := i.AgentServer().(*remoteAgentServer)
+	require.True(t, ok, "expected a remote agent-server")
+	i.mu.RLock()
+	wantRC := i.remoteClient
+	i.mu.RUnlock()
+	assert.Same(t, wantRC, r.rc, "AgentServer must reflect the final rebound runtime, never a stale one")
 }

--- a/session/agentserver_restore_race_test.go
+++ b/session/agentserver_restore_race_test.go
@@ -1,0 +1,61 @@
+package session
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestAgentServer_RestoreRace_NoDataRace is the -race regression for #1729: the
+// daemon poll calls Instance.AgentServer() (which reads remoteClient/
+// runtimeTeardown to pick the impl) concurrently with a restore/recover that
+// rebinds those fields via bindProvisionResult. Before the fix AgentServer() read
+// remoteClient under agentSrvMu while bindProvisionResult wrote it under i.mu —
+// two unrelated mutexes, a Go-memory-model data race. `go test -race` flags it on
+// the pre-fix code and passes clean after AgentServer() moved the read under i.mu.
+//
+// It is written to hit the read even on a cache miss: bindProvisionResult clears
+// the agentSrv cache every iteration, so AgentServer() re-enters its build branch
+// (the only place the pre-fix code touched remoteClient) each loop.
+func TestAgentServer_RestoreRace_NoDataRace(t *testing.T) {
+	ep := AgentServerEndpoint{URL: "wss://127.0.0.1:9", Token: "tok", Fingerprint: validFingerprint}
+	newRes := func() ProvisionResult {
+		return ProvisionResult{
+			Backend:  &dockerBackend{containerID: "c"},
+			Endpoint: &ep,
+			Teardown: func() error { return nil },
+		}
+	}
+
+	i := &Instance{Title: "race", backend: &dockerBackend{containerID: "c0"}}
+	// Seed a live remote binding so the very first AgentServer() reads a non-nil
+	// remoteClient (the racy branch), matching a restored sandbox mid-poll.
+	if err := i.bindProvisionResult(newRes()); err != nil {
+		t.Fatalf("seed bindProvisionResult: %v", err)
+	}
+
+	const iters = 2000
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Reader: the daemon poll's refreshInstanceStatus -> instance.AgentServer().
+	go func() {
+		defer wg.Done()
+		for n := 0; n < iters; n++ {
+			_ = i.AgentServer()
+		}
+	}()
+
+	// Writer: restore/recover's reprovisionRemote -> bindProvisionResult, rebinding
+	// remoteClient/runtimeTeardown and clearing the cache each time.
+	go func() {
+		defer wg.Done()
+		for n := 0; n < iters; n++ {
+			if err := i.bindProvisionResult(newRes()); err != nil {
+				t.Errorf("bindProvisionResult: %v", err)
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+}

--- a/session/archive_sandbox.go
+++ b/session/archive_sandbox.go
@@ -164,11 +164,12 @@ func (i *Instance) bindProvisionResult(res ProvisionResult) error {
 			return err
 		}
 	}
-	i.agentSrvMu.Lock()
-	i.agentSrv = nil
-	i.agentSrvMu.Unlock()
-
+	// Clear the cached agent-server AND swap the runtime fields in ONE i.mu section
+	// (#1729): AgentServer() reads the cache and the fields under the same i.mu, so
+	// doing the rebind atomically means the poll can never rebuild the cache from a
+	// pre-restore snapshot of remoteClient — no stale/torn-down endpoint pinned.
 	i.mu.Lock()
+	i.agentSrv = nil
 	i.backend = res.Backend
 	i.remoteClient = rc
 	i.runtimeTeardown = res.Teardown
@@ -181,11 +182,10 @@ func (i *Instance) bindProvisionResult(res ProvisionResult) error {
 // classifies it as a remote sandbox (#1592 Phase 4 PR6). A subsequent restore
 // rebuilds the wiring via bindProvisionResult.
 func (i *Instance) resetRemoteRuntime() {
-	i.agentSrvMu.Lock()
-	i.agentSrv = nil
-	i.agentSrvMu.Unlock()
-
+	// Clear the cache and the runtime fields together under i.mu (#1729), so a
+	// concurrent AgentServer() never rebuilds against a half-cleared state.
 	i.mu.Lock()
+	i.agentSrv = nil
 	i.remoteClient = nil
 	i.runtimeTeardown = nil
 	i.mu.Unlock()

--- a/session/archive_sandbox_test.go
+++ b/session/archive_sandbox_test.go
@@ -144,10 +144,10 @@ func TestReprovisionRemote_RebindsInstance(t *testing.T) {
 	require.NotNil(t, gotClient, "remote agent-server client built from the new endpoint")
 	require.NotNil(t, gotTeardown, "teardown rebound to the fresh sandbox")
 	// The cached agent-server is discarded so AgentServer() rebuilds against the
-	// new client.
-	i.agentSrvMu.Lock()
+	// new client (cache + fields share i.mu since #1729).
+	i.mu.RLock()
 	assert.Nil(t, i.agentSrv)
-	i.agentSrvMu.Unlock()
+	i.mu.RUnlock()
 	assert.False(t, toreDown, "a successful bind does not tear the new sandbox down")
 }
 

--- a/session/instance.go
+++ b/session/instance.go
@@ -169,13 +169,15 @@ type Instance struct {
 	// rather than reconstructed per call because its data plane holds stateful
 	// pieces — the PTY output ring buffer and the fan-out subscriber set — that
 	// must persist across calls; a fresh server each call would drop subscribers
-	// and lose the replay buffer. Lazily built by AgentServer(), guarded by
-	// agentSrvMu (a dedicated mutex, not i.mu, so building the server never
-	// contends with the session-state fields i.mu guards). Interface-typed since
-	// #1592 Phase 4 PR2: AgentServer() returns the local in-process impl by
+	// and lose the replay buffer. Lazily built by AgentServer() and guarded by i.mu,
+	// the SAME lock as remoteClient/runtimeTeardown (the fields that select which
+	// impl it is): a cache and its source fields must share one mutex so a restore
+	// that swaps the fields and clears the cache is atomic wrt the poll — a
+	// dedicated agentSrvMu split them and let AgentServer() rebuild the cache from a
+	// pre-restore snapshot, pinning a torn-down endpoint (#1729). Interface-typed
+	// since #1592 Phase 4 PR2: AgentServer() returns the local in-process impl by
 	// default, or a remoteAgentServer when remoteClient is set.
-	agentSrv   AgentServer
-	agentSrvMu sync.Mutex
+	agentSrv AgentServer
 	// remoteClient is the runtime handle selecting the REMOTE agent-server impl
 	// (#1592 Phase 4 PR2): when non-nil, AgentServer() returns a remoteAgentServer
 	// driving the `af agent-server` this points at, instead of the local in-process


### PR DESCRIPTION
## Summary

Closes the cross-mutex data race reported in #1729 (introduced in #1666).

`Instance.AgentServer()` read `i.remoteClient` / `i.runtimeTeardown` while holding `agentSrvMu`, but the restore/recover rebind path (`bindProvisionResult`, `resetRemoteRuntime`) **writes** those same fields under `i.mu` — a Go-memory-model data race between the daemon poll (`refreshInstanceStatus` → `AgentServer`) and `RestoreArchived` / Lost-restore.

## Fix (structural — unify under one mutex)

The root cause is that a **derived cache** (`i.agentSrv`) and the **source fields it is built from** (`remoteClient`/`runtimeTeardown`) were guarded by *different* mutexes. This PR makes `i.mu` the sole owner of **both**:

- `AgentServer()` reads the fields and builds+stores the cache in **one `i.mu` critical section** (double-checked: `RLock` fast path for a warm cache, `Lock` to build). The server values are trivial struct literals, so there's no `i.mu` re-entry at construction.
- `bindProvisionResult` / `resetRemoteRuntime` clear the cache **and** swap the fields in a single `i.mu` section, so a restore is atomic with respect to the poll.
- `agentSrvMu` is **deleted entirely** (grep-confirmed nothing else used it).

### Why not the first (snapshot-then-rebuild) approach

The initial fix snapshotted the fields under `i.mu`, released it, then rebuilt the cache under `agentSrvMu`. Greptile correctly caught that this has a **stale-cache TOCTOU**: if a restore runs in the gap (clears the cache, swaps in a NEW client), `AgentServer()` rebuilds the cache from the OLD snapshot — pinning the torn-down endpoint until the next cache clear. Unifying both under `i.mu` removes the two-mutex split that caused **both** the original race and this stale-cache bug.

### Lock ordering / deadlock

With `agentSrvMu` gone there is no lock-ordering question. `AgentServer()` may be called only when `i.mu` is not already held — the same invariant the returned server's methods (and `tabTmuxSession`) already rely on.

### Adjacent-site audit

Every read of `remoteClient` / `runtimeTeardown` across the `session` package now goes through `i.mu`; `AgentServer()` was the sole offender. `backend` (a sibling field written by `bindProvisionResult`) has a broad `i.backend.*` read pattern that predates this bug — out of scope for #1729.

## Tests

- `TestAgentServer_RestoreRace_NoDataRace` — runs `AgentServer()` concurrently with the `bindProvisionResult` rebind path; flags the original data race under `-race`, clean here.
- `TestAgentServer_RestoreCacheConsistency` — an invariant checker asserting the cached `remoteAgentServer` is always bound to the *current* `remoteClient` while poll + restore run concurrently, plus a final-rebind assertion. **Verified it reports the stale cache (`bound to X but current remoteClient is Y`) and `-race` fires on the first-fix code**, and passes clean after the structural fix.

## Gates

- `go test -race ./session/` (bounded `GOFLAGS='-p=1' -parallel 2`): clean; both #1729 tests green ×3
- `make test-container`: 29 packages ok, no FAIL/panic
- `make tui-driver-selftest`: 25/25
- `go build ./...`, `gofmt -l .`, `golangci-lint run --fast`, `deadcode -test ./...`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
