### PR TITLE
feat(session): delete a project (archive its sessions + remove it, reversibly) (#1735)

### DIFF
--- a/agentproto/message.go
+++ b/agentproto/message.go
@@ -90,6 +90,15 @@ const (
 	EventSessionKilled   EventType = "session.killed"
 	EventSessionArchived EventType = "session.archived"
 	EventSessionRestored EventType = "session.restored"
+	// EventProjectsChanged signals that the set of "active projects" (repos with
+	// live sessions or a root_agents opt-in) changed as a whole — e.g. a
+	// DeleteProject archived a repo's sessions and dropped its opt-in (#1735). It
+	// carries no payload: the project list is a derivation over the session
+	// projection, so a client re-derives it from a fresh Snapshot rather than
+	// patching a single row. Distinct from the per-session archived events the
+	// same delete also emits (those update the rail); this one is the signal a
+	// client keying a projects view resyncs on.
+	EventProjectsChanged EventType = "projects.changed"
 	EventTaskCreated     EventType = "task.created"
 	EventTaskUpdated     EventType = "task.updated"
 	EventTaskRemoved     EventType = "task.removed"

--- a/api/api.go
+++ b/api/api.go
@@ -489,6 +489,10 @@ func init() {
 	SessionsCmd.AddCommand(sessionsAttachCmd)
 	SessionsCmd.AddCommand(sessionsWhoamiCmd)
 
+	// Projects (repo groupings, #1735)
+	ProjectsCmd.PersistentFlags().BoolVar(&envelopeOutput, "json", false, jsonFlagUsage)
+	ProjectsCmd.AddCommand(projectsDeleteCmd)
+
 	// Tasks
 	tasksAddCmd.Flags().StringVar(&taskAddNameFlag, "name", "", "Task name (required)")
 	tasksAddCmd.Flags().StringVar(&taskAddPromptFlag, "prompt", "", "Prompt to send (required for --cron tasks; --watch-cmd tasks default to the emitted line, with {{line}} substituted when present)")

--- a/api/projects.go
+++ b/api/projects.go
@@ -1,0 +1,89 @@
+package api
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+// ProjectsCmd is the top-level command group for project (repo-grouping)
+// management (#1735). A "project" is derived: the set of sessions sharing a repo
+// root. Today the only verb is delete; more can join it as the surface grows.
+var ProjectsCmd = &cobra.Command{
+	Use:   "projects",
+	Short: "Manage projects (repo groupings of sessions)",
+}
+
+// deleteProjectViaDaemon is the daemon seam, overridable in tests.
+var deleteProjectViaDaemon = daemon.DeleteProject
+
+var projectsDeleteCmd = &cobra.Command{
+	Use:   "delete [repo]",
+	Short: "Delete a project: archive its sessions and remove it (reversibly)",
+	Long: `Delete a project — the group of sessions sharing a git repository.
+
+This is ARCHIVE-THEN-REMOVE and reversible. Every live session of the repo is
+archived (its tmux is torn down and its worktree moved to the archive dir, but
+its branch and uncommitted changes are preserved), the project drops out of the
+active projects list, and its always-on root agent (if any) is stopped and its
+root_agents opt-in removed. In-place sessions (the root agent, 'af sessions
+create --here') are torn down instead of archived — their cleanup never touches
+your working tree or branch.
+
+Your real git repository is never touched. To undo a mis-click, restore any
+archived session with 'af sessions restore <title>' — its project reappears.
+
+[repo] is a path inside the repository to delete (default: the current repo).
+Deleting an unknown or already-empty project is a clean no-op. Prints how many
+sessions were archived.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log.Initialize(false)
+		defer log.Close()
+
+		req, name, err := resolveProjectDeleteTarget(args)
+		if err != nil {
+			return jsonError(err)
+		}
+
+		resp, err := deleteProjectViaDaemon(req)
+		if err != nil {
+			return jsonError(err)
+		}
+
+		return jsonOut(map[string]any{
+			"ok":             true,
+			"project":        name,
+			"repo_path":      req.RepoPath,
+			"archived_count": resp.ArchivedCount,
+			"killed_count":   resp.KilledCount,
+		})
+	},
+}
+
+// resolveProjectDeleteTarget turns the optional [repo] arg (default: cwd) into a
+// DeleteProjectRequest and a friendly project name. It resolves the path to its
+// canonical main-repo root when possible so a subdirectory still targets the
+// whole project; a path that no longer resolves to a git repo falls back to the
+// cleaned absolute path, so deleting a moved/removed project is still a clean
+// daemon-side no-op (it archives nothing and sweeps any stale opt-in).
+func resolveProjectDeleteTarget(args []string) (daemon.DeleteProjectRequest, string, error) {
+	path := "."
+	if len(args) == 1 {
+		path = args[0]
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return daemon.DeleteProjectRequest{}, "", fmt.Errorf("failed to resolve project path %q: %w", path, err)
+	}
+	if repo, err := config.RepoFromPath(abs); err == nil {
+		return daemon.DeleteProjectRequest{RepoPath: repo.Root, RepoID: repo.ID}, filepath.Base(repo.Root), nil
+	}
+	cleaned := filepath.Clean(abs)
+	return daemon.DeleteProjectRequest{RepoPath: cleaned}, filepath.Base(cleaned), nil
+}

--- a/apiclient/control.go
+++ b/apiclient/control.go
@@ -49,6 +49,17 @@ func (c *Client) RestoreSession(req daemon.RestoreSessionRequest) (string, error
 	return resp.WorktreePath, nil
 }
 
+// DeleteProject asks the daemon to delete a project (#1735): archive its live
+// sessions (restorable), tear down in-place ones, and drop its root_agents
+// opt-in. Returns the daemon's response (archived/killed counts).
+func (c *Client) DeleteProject(req daemon.DeleteProjectRequest) (daemon.DeleteProjectResponse, error) {
+	var resp daemon.DeleteProjectResponse
+	if err := c.call("DeleteProject", req, &resp); err != nil {
+		return daemon.DeleteProjectResponse{}, err
+	}
+	return resp, nil
+}
+
 // ResumeFromLimit asks the daemon to resume a usage-limit-blocked session
 // (#1146) — the TUI's `c` key. It rides an internal (non-cataloged) route: a
 // client-facing session verb the `af api` catalog does not advertise.

--- a/app/handle_overlay.go
+++ b/app/handle_overlay.go
@@ -144,6 +144,15 @@ func (m *home) handleProjectsFocus(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
 		m.focusRegion(layout.RegionTree)
 		return m, nil, true
 	}
+	// Delete the cursor's project (#1735): archive-then-remove, reversible. Routed
+	// explicitly like `/` so the captive-section no-op below does not swallow it.
+	if key.Matches(msg, keys.GlobalKeyBindings[keys.KeyDeleteProject]) {
+		if proj, ok := m.projects.SelectedProject(); ok {
+			mod, cmd := m.handleDeleteProject(proj)
+			return mod, cmd, true
+		}
+		return m, nil, true
+	}
 	// `/` is the ONLY key that enters search from the Projects section (#1620),
 	// vim-style. Route it explicitly rather than letting it fall through, so the
 	// blanket no-op below can suppress every other key without also swallowing

--- a/app/home_update.go
+++ b/app/home_update.go
@@ -242,6 +242,12 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleInstanceArchived(msg)
 	case instanceRestoredMsg:
 		return m.handleInstanceRestored(msg)
+	case startDeleteProjectMsg:
+		// Delete-project confirmed; run the daemon archive-then-remove off the
+		// event loop (#1735), mirroring the archive dispatch.
+		return m, m.deleteProjectCmd(msg)
+	case projectDeletedMsg:
+		return m.handleProjectDeleted(msg)
 	case limitRetriedMsg:
 		return m.handleLimitRetried(msg)
 	case repaintAfterDetachMsg:

--- a/app/messages.go
+++ b/app/messages.go
@@ -33,6 +33,26 @@ type startArchiveMsg struct {
 	title string
 }
 
+// startDeleteProjectMsg is emitted by the delete-project confirmation (#1735);
+// its handler dispatches deleteProjectCmd to run the daemon archive-then-remove
+// off the event loop, mirroring startArchiveMsg → archiveInstanceCmd.
+type startDeleteProjectMsg struct {
+	root   string
+	repoID string
+	name   string
+}
+
+// projectDeletedMsg reports completion of an async delete-project (#1735). On
+// success the archived rows leave the active list via the next daemon Snapshot
+// reconcile; a non-nil err is surfaced in the error box.
+type projectDeletedMsg struct {
+	root     string
+	repoID   string
+	name     string
+	archived int
+	err      error
+}
+
 // instanceArchivedMsg / instanceRestoredMsg report completion of an async
 // archive / restore (#1028). On success the row's new status arrives via the
 // next daemon Snapshot reconcile (which re-partitions it into / out of the

--- a/app/session_control.go
+++ b/app/session_control.go
@@ -131,6 +131,20 @@ var restoreSessionThroughDaemon = func(title, repoID string) (string, error) {
 	return path, err
 }
 
+// deleteProjectThroughDaemon routes the TUI's delete-project verb (#1735)
+// through the daemon (the single writer): it archives the repo's live sessions
+// (restorable), tears down any in-place ones, and drops its root_agents opt-in.
+// A package var so the app test suite can stub it without dialing a real daemon.
+var deleteProjectThroughDaemon = func(repoRoot, repoID string) (daemon.DeleteProjectResponse, error) {
+	var resp daemon.DeleteProjectResponse
+	err := withDaemonHTTP(func(c *apiclient.Client) error {
+		var e error
+		resp, e = c.DeleteProject(daemon.DeleteProjectRequest{RepoPath: repoRoot, RepoID: repoID})
+		return e
+	})
+	return resp, err
+}
+
 // resumeFromLimitThroughDaemon routes the TUI's `c` (retry usage-limit session)
 // verb (#1146) through the daemon — the single writer (#960) — which re-spawns
 // the agent if it exited, re-delivers the pending prompt, and clears the limit

--- a/app/switch_project.go
+++ b/app/switch_project.go
@@ -8,6 +8,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/task"
@@ -64,6 +65,14 @@ func (m *home) buildProjectListFrom(data []session.InstanceData) []overlay.Proje
 	}
 
 	for _, d := range data {
+		// Only LIVE sessions define an "active project" (#1735): a repo whose
+		// sessions are all archived is not an active project — its archived rows
+		// live in the sidebar's Archived group and are restorable, which brings
+		// the project back. This is what makes delete-project (archive every live
+		// session) drop the repo from the list, and restore re-add it.
+		if session.IsArchivedData(d) {
+			continue
+		}
 		root := d.Worktree.RepoPath
 		if root == "" {
 			continue
@@ -203,6 +212,60 @@ func (m *home) handleAddProject(path string) (tea.Model, tea.Cmd) {
 	}
 	m.closeProjectPicker()
 	return m.switchProject(repo)
+}
+
+// handleDeleteProject opens the reversible delete-project confirmation for the
+// cursor's project in the Projects section (#1735). The copy makes the
+// reversibility explicit: sessions are archived (restorable), the real repo is
+// untouched, and restoring any archived session brings the project back. On
+// confirm it dispatches the async daemon archive-then-remove.
+func (m *home) handleDeleteProject(proj ui.SidebarProject) (tea.Model, tea.Cmd) {
+	repoID := config.RepoIDFromRoot(proj.Root)
+	sessionWord := "sessions"
+	if proj.SessionCount == 1 {
+		sessionWord = "session"
+	}
+	restoreKey := keys.GlobalKeyBindings[keys.KeyRestore].Help().Key
+	message := fmt.Sprintf(
+		"[!] Delete project '%s'?\n\nIts %d %s are archived (tmux torn down, worktrees moved out — branches and uncommitted work preserved) and it is removed from the projects list. Your real git repository is untouched. Restore any archived session (%s, or `af sessions restore`) to bring the project back.",
+		proj.Name, proj.SessionCount, sessionWord, restoreKey,
+	)
+	return m, m.confirmAction(message, func() tea.Msg {
+		return startDeleteProjectMsg{root: proj.Root, repoID: repoID, name: proj.Name}
+	})
+}
+
+// deleteProjectCmd runs the daemon archive-then-remove off the event loop
+// (#1735), mirroring archiveInstanceCmd, and reports completion.
+func (m *home) deleteProjectCmd(msg startDeleteProjectMsg) tea.Cmd {
+	return func() tea.Msg {
+		resp, err := deleteProjectThroughDaemon(msg.root, msg.repoID)
+		return projectDeletedMsg{root: msg.root, repoID: msg.repoID, name: msg.name, archived: resp.ArchivedCount, err: err}
+	}
+}
+
+// handleProjectDeleted finalizes an async delete-project (#1735). On success it
+// drops the local root_agents opt-in mirror (the daemon removed it on disk; a
+// separate attached TUI reflects it on its next launch, matching how
+// RegisterRootAgent's persistence is picked up) and refreshes the Projects
+// section so the now-empty project leaves the list immediately.
+func (m *home) handleProjectDeleted(msg projectDeletedMsg) (tea.Model, tea.Cmd) {
+	if msg.err != nil {
+		return m, m.handleError(fmt.Errorf("failed to delete project '%s': %w", msg.name, msg.err))
+	}
+	if m.appConfig != nil {
+		for path := range m.appConfig.RootAgents {
+			if repo, err := config.RepoFromPath(config.ExpandTilde(path)); err == nil && repo.ID == msg.repoID {
+				delete(m.appConfig.RootAgents, path)
+			}
+		}
+	}
+	m.refreshSidebarProjects()
+	sessionWord := "sessions"
+	if msg.archived == 1 {
+		sessionWord = "session"
+	}
+	return m, m.showTransientMessage(fmt.Sprintf("Deleted project '%s' — archived %d %s (restorable)", msg.name, msg.archived, sessionWord))
 }
 
 func (m *home) closeProjectPicker() {

--- a/commands/root.go
+++ b/commands/root.go
@@ -327,5 +327,6 @@ func init() {
 	rootCmd.AddCommand(tokenCmd)
 	rootCmd.AddCommand(api.SessionsCmd)
 	rootCmd.AddCommand(api.TasksCmd)
+	rootCmd.AddCommand(api.ProjectsCmd)
 	rootCmd.AddCommand(api.APICmd)
 }

--- a/config/rootagent_register.go
+++ b/config/rootagent_register.go
@@ -1,5 +1,7 @@
 package config
 
+import "path/filepath"
+
 // RegisterRootAgent opts repoRoot into the global root_agents list with the
 // default agent profile, unless it is already present. It is the persistence
 // side of the TUI's in-place "+ Add project…" flow (#1461): root_agents is the
@@ -32,4 +34,53 @@ func RegisterRootAgent(repoRoot string) (bool, error) {
 		return false, err
 	}
 	return true, nil
+}
+
+// DeregisterRootAgentsForRepo removes every root_agents opt-in that resolves to
+// repoID and persists the result, returning the config keys it removed. It is
+// the durable half of "delete a project" (#1735): the inverse of
+// RegisterRootAgent, so an emptied project does not linger in the picker as a
+// zero-session opt-in after its sessions are archived, and does not respawn an
+// always-on root on the next daemon start.
+//
+// A root_agents key is a repo path "as written" (a leading ~ is expanded), which
+// may be a subdirectory or a non-canonical spelling of the repo root, so a key
+// matches when its RESOLVED main-repo id equals repoID; when the path no longer
+// resolves to a git repo (moved/removed), it falls back to hashing the expanded,
+// cleaned path so a stale entry for a gone repo can still be swept. The write is
+// load-modify-persist over the whole global config (no other key clobbered) and
+// idempotent: no matching key is a clean no-op returning nil, nil.
+func DeregisterRootAgentsForRepo(repoID string) ([]string, error) {
+	cfg, err := LoadConfig()
+	if err != nil {
+		return nil, err
+	}
+	var removed []string
+	for key := range cfg.RootAgents {
+		if rootAgentKeyMatchesRepo(key, repoID) {
+			removed = append(removed, key)
+		}
+	}
+	if len(removed) == 0 {
+		return nil, nil
+	}
+	for _, key := range removed {
+		delete(cfg.RootAgents, key)
+	}
+	if err := SaveConfig(cfg); err != nil {
+		return nil, err
+	}
+	return removed, nil
+}
+
+// rootAgentKeyMatchesRepo reports whether a root_agents config key names the
+// repo identified by repoID. It prefers resolving the key to its main-repo id
+// (so a subdirectory or worktree spelling still matches), and falls back to
+// hashing the expanded/cleaned path when the repo no longer resolves.
+func rootAgentKeyMatchesRepo(key, repoID string) bool {
+	expanded := ExpandTilde(key)
+	if repo, err := RepoFromPath(expanded); err == nil {
+		return repo.ID == repoID
+	}
+	return RepoIDFromRoot(filepath.Clean(expanded)) == repoID
 }

--- a/config/rootagent_register_test.go
+++ b/config/rootagent_register_test.go
@@ -50,3 +50,41 @@ func TestRegisterRootAgentPreservesExistingEntries(t *testing.T) {
 	require.Contains(t, cfg.RootAgents, "/repos/existing")
 	require.Contains(t, cfg.RootAgents, "/repos/added")
 }
+
+func TestDeregisterRootAgentsForRepoRemovesMatchAndPreservesOthers(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	// Two opt-ins for gone repos (RepoFromPath won't resolve, so matching falls
+	// back to hashing the cleaned path) plus an unrelated config key to prove the
+	// write preserves it.
+	seed := DefaultConfig()
+	seed.DefaultProgram = "codex"
+	seed.RootAgents = map[string]RootAgentConfig{"/repos/gone": {}, "/repos/keep": {}}
+	require.NoError(t, SaveConfig(seed))
+
+	removed, err := DeregisterRootAgentsForRepo(RepoIDFromRoot("/repos/gone"))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/repos/gone"}, removed)
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	assert.NotContains(t, cfg.RootAgents, "/repos/gone", "the matched opt-in must be removed")
+	assert.Contains(t, cfg.RootAgents, "/repos/keep", "an unrelated opt-in must survive")
+	assert.Equal(t, "codex", cfg.DefaultProgram, "an unrelated config key must survive the write")
+}
+
+func TestDeregisterRootAgentsForRepoUnknownIsNoOp(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	seed := DefaultConfig()
+	seed.RootAgents = map[string]RootAgentConfig{"/repos/keep": {}}
+	require.NoError(t, SaveConfig(seed))
+
+	removed, err := DeregisterRootAgentsForRepo(RepoIDFromRoot("/repos/never-registered"))
+	require.NoError(t, err)
+	assert.Nil(t, removed, "deregistering an unknown repo removes nothing")
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	assert.Contains(t, cfg.RootAgents, "/repos/keep")
+}

--- a/daemon/control_client.go
+++ b/daemon/control_client.go
@@ -240,6 +240,17 @@ func RestoreSession(req RestoreSessionRequest) (string, error) {
 	return resp.WorktreePath, nil
 }
 
+// DeleteProject asks the daemon to delete a project (#1735): archive its live
+// sessions (restorable), tear down any in-place ones, and drop its root_agents
+// opt-in. Returns how many sessions were archived and how many were torn down.
+func DeleteProject(req DeleteProjectRequest) (DeleteProjectResponse, error) {
+	var resp DeleteProjectResponse
+	if err := callDaemon("DeleteProject", req, &resp); err != nil {
+		return DeleteProjectResponse{}, err
+	}
+	return resp, nil
+}
+
 // SendPrompt asks the daemon to send a prompt to an existing session.
 func SendPrompt(req SendPromptRequest) error {
 	var resp SendPromptResponse

--- a/daemon/control_server.go
+++ b/daemon/control_server.go
@@ -358,6 +358,40 @@ func (s *controlServer) SendPrompt(req SendPromptRequest, resp *SendPromptRespon
 	return nil
 }
 
+// DeleteProject deletes a project (a repo grouping of sessions, #1735):
+// archive-then-remove, reversible. The manager archives every live session
+// (restorable), tears down in-place sessions (repo untouched), and drops the
+// repo's root_agents opt-in. It publishes one archived/killed event per affected
+// session — so every client's rail moves the sessions exactly as a per-session
+// archive/kill would — plus a projects-changed signal for clients keying a
+// projects view. On a partial failure it still publishes what DID happen before
+// surfacing the error, so the rail never lags reality.
+func (s *controlServer) DeleteProject(req DeleteProjectRequest, resp *DeleteProjectResponse) error {
+	if err := s.requireManagerReady(); err != nil {
+		return err
+	}
+	if err := validateRPCRepoID(req.RepoID); err != nil {
+		return err
+	}
+	result, err := s.manager.DeleteProject(req)
+	for _, a := range result.Archived {
+		s.manager.publishEvent(agentproto.EventSessionArchived, session.InstanceData{ID: a.ID, Title: a.Title})
+	}
+	for _, k := range result.Killed {
+		s.manager.publishEvent(agentproto.EventSessionKilled, session.InstanceData{ID: k.ID, Title: k.Title})
+	}
+	if len(result.Archived) > 0 || len(result.Killed) > 0 {
+		s.manager.publishEvent(agentproto.EventProjectsChanged, nil)
+	}
+	if err != nil {
+		return err
+	}
+	resp.OK = true
+	resp.ArchivedCount = len(result.Archived)
+	resp.KilledCount = len(result.Killed)
+	return nil
+}
+
 // validateRPCRepoID enforces the RepoID shape for RPC requests that allow an
 // empty value to mean "search all repos". A non-empty RepoID must satisfy
 // config.ValidateRepoID so it cannot escape the per-repo file scope through

--- a/daemon/control_types.go
+++ b/daemon/control_types.go
@@ -110,6 +110,32 @@ type RestoreSessionResponse struct {
 	WorktreePath string `json:"worktree_path"`
 }
 
+// DeleteProjectRequest asks the daemon to delete a project — a repo grouping of
+// sessions (#1735). The delete is ARCHIVE-THEN-REMOVE and reversible: every live
+// session of the repo is archived (worktree relocated, branch/state preserved,
+// restorable via RestoreArchived), the repo's root_agents opt-in is dropped, and
+// the always-on root agent (if any) is stopped — the user's real git repo is
+// never touched. Restoring any archived session brings the project back.
+//
+// RepoPath is the repo root (the stable project id clients group by:
+// worktree.repo_path). RepoID is the precomputed id; when empty the daemon
+// derives it from RepoPath. At least one must be set. Deleting an unknown or
+// already-empty project is a clean no-op, not an error.
+type DeleteProjectRequest struct {
+	RepoPath string `json:"repo_path"`
+	RepoID   string `json:"repo_id"`
+}
+
+type DeleteProjectResponse struct {
+	OK bool `json:"ok"`
+	// ArchivedCount is how many live sessions were archived (restorable).
+	ArchivedCount int `json:"archived_count"`
+	// KilledCount is how many live sessions could not be archived and were torn
+	// down instead — only in-place/external worktrees (the root agent, `--here`
+	// sessions), whose kill never touches the user's tree or branch.
+	KilledCount int `json:"killed_count"`
+}
+
 type SendPromptRequest struct {
 	Title  string `json:"title"`
 	RepoID string `json:"repo_id"`

--- a/daemon/deleteproject.go
+++ b/daemon/deleteproject.go
@@ -12,6 +12,11 @@ import (
 	"github.com/sachiniyer/agent-factory/session"
 )
 
+// deregisterRootAgents is the durable root_agents removal DeleteProject runs. A
+// package var so tests can force a persist failure in isolation (exercising the
+// #1740-review fatal-on-config-failure path) without disturbing the real config.
+var deregisterRootAgents = config.DeregisterRootAgentsForRepo
+
 // DeleteProjectResult reports what DeleteProject did so the control server can
 // publish one archived/killed event per affected session (plus a
 // projects-changed signal), and the CLI/TUI can report the counts.
@@ -52,7 +57,19 @@ func (m *Manager) DeleteProject(req DeleteProjectRequest) (DeleteProjectResult, 
 		if root == "" {
 			return DeleteProjectResult{}, fmt.Errorf("delete project: repo_id or repo_path is required")
 		}
-		repoID = config.RepoIDFromRoot(filepath.Clean(root))
+		// Canonicalize the path the SAME way the daemon keys repos everywhere:
+		// resolve it to the main-repo root (git toplevel) and hash THAT, so a
+		// symlinked / trailing-slash / relative / subdirectory / ".."-laden form of
+		// a REAL project still resolves to its sessions' repo id — never a silent
+		// miss. Only when the path does not resolve to a git repo (a moved/removed/
+		// typo'd project) fall back to hashing the cleaned path: that yields no
+		// match, which is the clean idempotent no-op deleting an unknown project
+		// must be (Sachin's locked semantics), not a wrong-project hit.
+		if repo, rerr := config.RepoFromPath(root); rerr == nil {
+			repoID = repo.ID
+		} else {
+			repoID = config.RepoIDFromRoot(filepath.Clean(root))
+		}
 	}
 	result := DeleteProjectResult{RepoID: repoID}
 
@@ -61,6 +78,19 @@ func (m *Manager) DeleteProject(req DeleteProjectRequest) (DeleteProjectResult, 
 	// teardown guarantees no poll tick can respawn a root we are about to remove
 	// (#1735).
 	m.suppressRootAgent(repoID)
+
+	// Drop the repo's root_agents opt-in on disk BEFORE archiving, and treat a
+	// failed write as FATAL to the whole delete (#1740 review): if this durable
+	// removal fails, a daemon restart would re-register the root and the project
+	// would REAPPEAR — so reporting success would be a lie. Aborting here (before
+	// any session is archived) also keeps the failure clean: nothing is torn down,
+	// the project is intact, and the returned error tells the caller to retry. A
+	// project with no opt-in is a nil, nil no-op that falls straight through.
+	if removed, cfgErr := deregisterRootAgents(repoID); cfgErr != nil {
+		return result, fmt.Errorf("delete project %s: could not durably remove its root_agents opt-in — the project would reappear on daemon restart, so nothing was archived; retry: %w", repoID, cfgErr)
+	} else if len(removed) > 0 {
+		log.InfoLog.Printf("delete project %s: removed %d root_agents opt-in(s): %v", repoID, len(removed), removed)
+	}
 
 	// Snapshot the repo's LIVE (non-archived) sessions under the lock, then act
 	// with the lock released — ArchiveSession/KillSession take their own
@@ -104,16 +134,6 @@ func (m *Manager) DeleteProject(req DeleteProjectRequest) (DeleteProjectResult, 
 			continue
 		}
 		result.Archived = append(result.Archived, session.InstanceData{ID: archived.ID, Title: archived.Title})
-	}
-
-	// Drop the repo's root_agents opt-in on disk so a restart forgets it too
-	// (the in-memory suppression above already holds for this daemon's life).
-	// Non-fatal: the sessions are already archived either way.
-	removed, cfgErr := config.DeregisterRootAgentsForRepo(repoID)
-	if cfgErr != nil {
-		log.WarningLog.Printf("delete project %s: archived %d session(s) but failed to remove its root_agents opt-in from config: %v", repoID, len(result.Archived), cfgErr)
-	} else if len(removed) > 0 {
-		log.InfoLog.Printf("delete project %s: removed %d root_agents opt-in(s): %v", repoID, len(removed), removed)
 	}
 
 	if len(errs) > 0 {

--- a/daemon/deleteproject.go
+++ b/daemon/deleteproject.go
@@ -1,0 +1,139 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// DeleteProjectResult reports what DeleteProject did so the control server can
+// publish one archived/killed event per affected session (plus a
+// projects-changed signal), and the CLI/TUI can report the counts.
+type DeleteProjectResult struct {
+	RepoID string
+	// Archived carries the {ID, Title} of every session archived (restorable via
+	// RestoreArchived). Killed carries the {ID, Title} of every in-place/external
+	// session torn down instead (archive can't relocate an external worktree; its
+	// kill never touches the user's tree/branch).
+	Archived []session.InstanceData
+	Killed   []session.InstanceData
+}
+
+// DeleteProject deletes a project — a repo grouping of sessions (#1735) — with
+// ARCHIVE-THEN-REMOVE, reversible semantics, under the single-writer daemon:
+//
+//   - Every LIVE session of the repo is ARCHIVED (tmux torn down, worktree moved
+//     to the archive dir, branch + state preserved) so it stays restorable via
+//     RestoreArchived. Already-archived rows are left untouched — they are the
+//     restorable state this delete preserves.
+//   - An in-place/external worktree session (the always-on root agent, or an
+//     `af sessions create --here` session) cannot be archived — archive relocates
+//     the worktree, unsupported for the user's own checkout — so it is torn down
+//     instead. That teardown never touches the user's tree or branch (#1107).
+//   - The repo's root_agents opt-in is dropped (in-memory suppression for this
+//     daemon's life + removed from config on disk) so the project does not linger
+//     empty in the picker and no always-on root respawns.
+//
+// The user's real git repository is never touched. Because the active-projects
+// list is derived from LIVE sessions, archiving them all removes the project from
+// it; restoring any archived session brings the project back — the reversible
+// contract. Idempotent: deleting an unknown or already-empty project archives
+// nothing, drops no opt-in, and returns a zero-count success.
+func (m *Manager) DeleteProject(req DeleteProjectRequest) (DeleteProjectResult, error) {
+	repoID := strings.TrimSpace(req.RepoID)
+	if repoID == "" {
+		root := strings.TrimSpace(req.RepoPath)
+		if root == "" {
+			return DeleteProjectResult{}, fmt.Errorf("delete project: repo_id or repo_path is required")
+		}
+		repoID = config.RepoIDFromRoot(filepath.Clean(root))
+	}
+	result := DeleteProjectResult{RepoID: repoID}
+
+	// Suppress the always-on root FIRST (in-memory, instant): m.cfg is immutable
+	// after start, so this is what stops the ensure loop, and doing it before any
+	// teardown guarantees no poll tick can respawn a root we are about to remove
+	// (#1735).
+	m.suppressRootAgent(repoID)
+
+	// Snapshot the repo's LIVE (non-archived) sessions under the lock, then act
+	// with the lock released — ArchiveSession/KillSession take their own
+	// per-session locks and would deadlock if called while holding m.mu.
+	type target struct {
+		title    string
+		external bool
+	}
+	var targets []target
+	m.mu.Lock()
+	for key, inst := range m.instances {
+		rid, title := splitDaemonInstanceKey(key)
+		if rid != repoID || inst == nil {
+			continue
+		}
+		if inst.GetLiveness() == session.LiveArchived {
+			continue
+		}
+		targets = append(targets, target{title: title, external: inst.IsExternalWorktree()})
+	}
+	m.mu.Unlock()
+
+	// Deterministic order so a partial failure + retry is stable and the logs read
+	// consistently.
+	sort.Slice(targets, func(i, j int) bool { return targets[i].title < targets[j].title })
+
+	var errs []error
+	for _, t := range targets {
+		if t.external {
+			killed, err := m.KillSession(KillSessionRequest{Title: t.title, RepoID: repoID})
+			if err != nil {
+				errs = append(errs, fmt.Errorf("session %q: %w", t.title, err))
+				continue
+			}
+			result.Killed = append(result.Killed, session.InstanceData{ID: killed.ID, Title: killed.Title})
+			continue
+		}
+		_, archived, err := m.ArchiveSession(ArchiveSessionRequest{Title: t.title, RepoID: repoID})
+		if err != nil {
+			errs = append(errs, fmt.Errorf("session %q: %w", t.title, err))
+			continue
+		}
+		result.Archived = append(result.Archived, session.InstanceData{ID: archived.ID, Title: archived.Title})
+	}
+
+	// Drop the repo's root_agents opt-in on disk so a restart forgets it too
+	// (the in-memory suppression above already holds for this daemon's life).
+	// Non-fatal: the sessions are already archived either way.
+	removed, cfgErr := config.DeregisterRootAgentsForRepo(repoID)
+	if cfgErr != nil {
+		log.WarningLog.Printf("delete project %s: archived %d session(s) but failed to remove its root_agents opt-in from config: %v", repoID, len(result.Archived), cfgErr)
+	} else if len(removed) > 0 {
+		log.InfoLog.Printf("delete project %s: removed %d root_agents opt-in(s): %v", repoID, len(removed), removed)
+	}
+
+	if len(errs) > 0 {
+		// Partial: some sessions were busy or errored mid-teardown. The delete is
+		// idempotent, so re-running it finishes the rest. Report what did happen.
+		return result, fmt.Errorf("delete project %s: archived %d, tore down %d, but %d session(s) could not be removed (retry to finish): %w",
+			repoID, len(result.Archived), len(result.Killed), len(errs), errors.Join(errs...))
+	}
+	log.InfoLog.Printf("deleted project %s: archived %d session(s), tore down %d in-place session(s)", repoID, len(result.Archived), len(result.Killed))
+	return result, nil
+}
+
+// suppressRootAgent marks repoID's project as deleted for the rest of this
+// daemon's life so the ensure loop stops (re-)creating its always-on root agent,
+// and clears the kill-grace record so no stale grace window survives (#1735). The
+// ensure loop is keyed by config path, not repoID, so the deletedRootRepos check
+// (which resolves each path to its repoID) is where suppression takes effect.
+func (m *Manager) suppressRootAgent(repoID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.deletedRootRepos[repoID] = struct{}{}
+	delete(m.rootKilledAt, repoID)
+}

--- a/daemon/deleteproject.go
+++ b/daemon/deleteproject.go
@@ -57,6 +57,11 @@ func (m *Manager) DeleteProject(req DeleteProjectRequest) (DeleteProjectResult, 
 		if root == "" {
 			return DeleteProjectResult{}, fmt.Errorf("delete project: repo_id or repo_path is required")
 		}
+		// Expand a leading ~ BEFORE canonicalizing: git (RepoFromPath) does not do
+		// tilde expansion — the shell normally would — so a literal "~/repo" request
+		// (a root_agents key spelling, or a hand-typed CLI arg) must be expanded here
+		// or it resolves to nothing and silently misses (#1740 review).
+		root = config.ExpandTilde(root)
 		// Canonicalize the path the SAME way the daemon keys repos everywhere:
 		// resolve it to the main-repo root (git toplevel) and hash THAT, so a
 		// symlinked / trailing-slash / relative / subdirectory / ".."-laden form of
@@ -73,24 +78,25 @@ func (m *Manager) DeleteProject(req DeleteProjectRequest) (DeleteProjectResult, 
 	}
 	result := DeleteProjectResult{RepoID: repoID}
 
-	// Suppress the always-on root FIRST (in-memory, instant): m.cfg is immutable
-	// after start, so this is what stops the ensure loop, and doing it before any
-	// teardown guarantees no poll tick can respawn a root we are about to remove
-	// (#1735).
-	m.suppressRootAgent(repoID)
-
-	// Drop the repo's root_agents opt-in on disk BEFORE archiving, and treat a
-	// failed write as FATAL to the whole delete (#1740 review): if this durable
+	// Durably drop the repo's root_agents opt-in FIRST, before mutating ANY state,
+	// and treat a failed write as FATAL to the whole delete (#1740 review): if this
 	// removal fails, a daemon restart would re-register the root and the project
-	// would REAPPEAR — so reporting success would be a lie. Aborting here (before
-	// any session is archived) also keeps the failure clean: nothing is torn down,
-	// the project is intact, and the returned error tells the caller to retry. A
-	// project with no opt-in is a nil, nil no-op that falls straight through.
+	// would REAPPEAR — so reporting success would be a lie. Persisting before any
+	// in-memory change also keeps the failure ATOMIC: on error nothing is archived
+	// AND no in-memory suppression is left behind, so a failed delete leaves the
+	// project fully intact. A project with no opt-in is a nil, nil no-op.
 	if removed, cfgErr := deregisterRootAgents(repoID); cfgErr != nil {
-		return result, fmt.Errorf("delete project %s: could not durably remove its root_agents opt-in — the project would reappear on daemon restart, so nothing was archived; retry: %w", repoID, cfgErr)
+		return result, fmt.Errorf("delete project %s: could not durably remove its root_agents opt-in — the project would reappear on daemon restart, so nothing was changed; retry: %w", repoID, cfgErr)
 	} else if len(removed) > 0 {
 		log.InfoLog.Printf("delete project %s: removed %d root_agents opt-in(s): %v", repoID, len(removed), removed)
 	}
+
+	// The durable removal succeeded, so now apply the in-memory suppression that
+	// stops the ensure loop re-creating the always-on root (m.cfg is immutable
+	// after start). Doing it before the teardown guarantees no poll tick respawns
+	// the root we are about to tear down; doing it only AFTER the persist means a
+	// failed write above never leaves a dangling suppression (#1740 review).
+	m.suppressRootAgent(repoID)
 
 	// Snapshot the repo's LIVE (non-archived) sessions under the lock, then act
 	// with the lock released — ArchiveSession/KillSession take their own

--- a/daemon/deleteproject_test.go
+++ b/daemon/deleteproject_test.go
@@ -183,4 +183,30 @@ func TestDeleteProject_RootAgentsWriteFailureIsFatal(t *testing.T) {
 	assert.NotEqual(t, session.Archived, inst.GetStatus(), "the session must remain live on a failed delete")
 	assert.True(t, exists(src), "the session's worktree must be untouched on a failed delete")
 	assert.True(t, liveProjectRoots(manager.Snapshot(repoID))[repoPath], "the project must remain in the active list on a failed delete")
+
+	// The failure is atomic: NO in-memory root-agent suppression is left behind, so
+	// a failed delete doesn't silently keep the always-on root from re-registering
+	// (#1740 review). The persist runs before any in-memory mutation.
+	manager.mu.Lock()
+	_, suppressed := manager.deletedRootRepos[repoID]
+	manager.mu.Unlock()
+	assert.False(t, suppressed, "a failed delete must leave no dangling root-agent suppression")
+}
+
+// TestDeleteProject_TildePathMatches: a request whose path is a literal "~/…"
+// (git does not expand tilde; the shell normally would) still resolves to the
+// real project — the daemon expands the tilde before canonicalizing (#1740
+// review), so it is never a silent miss.
+func TestDeleteProject_TildePathMatches(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	registerArchivable(t, manager, repoID, repoPath, "worker")
+
+	// Point HOME at the repo's parent so "~/<basename>" expands to the real repo.
+	t.Setenv("HOME", filepath.Dir(repoPath))
+	tildePath := "~/" + filepath.Base(repoPath)
+
+	result, err := manager.DeleteProject(DeleteProjectRequest{RepoPath: tildePath})
+	require.NoError(t, err)
+	assert.Len(t, result.Archived, 1, "a ~/-prefixed path must resolve to the real project, not silently miss")
+	assert.Empty(t, liveProjectRoots(manager.Snapshot(repoID)))
 }

--- a/daemon/deleteproject_test.go
+++ b/daemon/deleteproject_test.go
@@ -1,0 +1,139 @@
+package daemon
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// liveProjectRoots mirrors the "active projects" derivation the TUI and web use
+// (live-only grouping by repo root): archived sessions do not keep a project in
+// the list, which is what makes delete-project remove it and restore bring it
+// back. Kept in the test so the reversible contract is asserted against the same
+// rule the surfaces derive from.
+func liveProjectRoots(data []session.InstanceData) map[string]bool {
+	roots := map[string]bool{}
+	for _, d := range data {
+		if session.IsArchivedData(d) {
+			continue
+		}
+		if d.Worktree.RepoPath != "" {
+			roots[d.Worktree.RepoPath] = true
+		}
+	}
+	return roots
+}
+
+// TestDeleteProject_ArchivesAllSessionsRestorableRepoUntouched is the core
+// contract (#1735): deleting a project with N live sessions archives all N
+// (restorable), drops the project from the active/derived list, and never
+// touches the user's real git repo; restoring one archived session brings the
+// project back.
+func TestDeleteProject_ArchivesAllSessionsRestorableRepoUntouched(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst1, src1 := registerArchivable(t, manager, repoID, repoPath, "alpha")
+	_, src2 := registerArchivable(t, manager, repoID, repoPath, "beta")
+	// A recover-capable backend so the later restore re-spawns to Running (the
+	// plain FakeBackend's Recover doesn't), mirroring the archive restore test.
+	inst1.SetBackend(&recoverFakeBackend{FakeBackend: session.NewFakeBackend()})
+	// registerArchivable rewrites the per-repo file each call, so persist ALL
+	// in-memory instances together — otherwise the second seed clobbers the first
+	// on disk and the reconcile inside archive drops the in-memory-only session.
+	require.NoError(t, manager.SaveInstances())
+
+	// Precondition: the repo is an active project with 2 live sessions.
+	require.True(t, liveProjectRoots(manager.Snapshot(repoID))[repoPath])
+
+	result, err := manager.DeleteProject(DeleteProjectRequest{RepoID: repoID, RepoPath: repoPath})
+	require.NoError(t, err)
+	assert.Len(t, result.Archived, 2, "both live sessions must be archived")
+	assert.Empty(t, result.Killed, "neither session is in-place, so none is torn down")
+
+	// Both sessions are now inert Archived rows, worktrees relocated out.
+	for _, title := range []string{"alpha", "beta"} {
+		manager.mu.Lock()
+		got := manager.instances[daemonInstanceKey(repoID, title)]
+		manager.mu.Unlock()
+		require.NotNil(t, got, "an archived session is preserved (restorable), not deleted")
+		assert.Equal(t, session.Archived, got.GetStatus())
+	}
+	assert.False(t, exists(src1), "alpha's original worktree must be gone (relocated to the archive)")
+	assert.False(t, exists(src2), "beta's original worktree must be gone (relocated to the archive)")
+
+	// The project is gone from the active/derived list.
+	assert.Empty(t, liveProjectRoots(manager.Snapshot(repoID)), "no live session ⇒ the project drops out of the active list")
+
+	// The user's real git repository is UNTOUCHED.
+	assert.True(t, exists(repoPath), "the real repo directory must survive a project delete")
+	assert.True(t, exists(filepath.Join(repoPath, ".git")), "the real repo's .git must be untouched")
+
+	// Reversible: restoring one archived session brings the project back.
+	_, err = manager.RestoreArchived(RestoreArchivedRequest{Title: "alpha", RepoID: repoID})
+	require.NoError(t, err)
+	assert.Equal(t, session.Running, inst1.GetStatus(), "the restored session is live again")
+	assert.True(t, liveProjectRoots(manager.Snapshot(repoID))[repoPath], "restoring an archived session reconstitutes the project")
+}
+
+// TestDeleteProject_UnknownProjectIsNoOp: deleting a project the daemon knows
+// nothing about archives nothing, drops no opt-in, and returns a zero-count
+// success (idempotent).
+func TestDeleteProject_UnknownProjectIsNoOp(t *testing.T) {
+	manager, _, _ := newStatusTestManager(t)
+
+	result, err := manager.DeleteProject(DeleteProjectRequest{RepoPath: "/no/such/repo"})
+	require.NoError(t, err)
+	assert.Empty(t, result.Archived)
+	assert.Empty(t, result.Killed)
+}
+
+// TestDeleteProject_RemovesRootAgentsOptInAndSuppressesRespawn: when the repo has
+// a persisted root_agents opt-in, delete removes it from config on disk AND
+// suppresses the daemon from re-ensuring the always-on root for the rest of its
+// life; restoring an archived session still reconstitutes the project.
+func TestDeleteProject_RemovesRootAgentsOptInAndSuppressesRespawn(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	registerArchivable(t, manager, repoID, repoPath, "worker")
+
+	// Seed a durable root_agents opt-in for this repo on disk.
+	seed := config.DefaultConfig()
+	seed.RootAgents = map[string]config.RootAgentConfig{repoPath: {}}
+	require.NoError(t, config.SaveConfig(seed))
+
+	result, err := manager.DeleteProject(DeleteProjectRequest{RepoID: repoID, RepoPath: repoPath})
+	require.NoError(t, err)
+	assert.Len(t, result.Archived, 1)
+
+	// The opt-in is gone from disk...
+	cfg, err := config.LoadConfig()
+	require.NoError(t, err)
+	assert.NotContains(t, cfg.RootAgents, repoPath, "the root_agents opt-in must be removed on disk")
+
+	// ...and the running daemon suppresses re-ensuring the root.
+	manager.mu.Lock()
+	_, suppressed := manager.deletedRootRepos[repoID]
+	manager.mu.Unlock()
+	assert.True(t, suppressed, "the ensure loop must be suppressed for the deleted repo")
+
+	// Reversible: restore reconstitutes the project in the active list.
+	_, err = manager.RestoreArchived(RestoreArchivedRequest{Title: "worker", RepoID: repoID})
+	require.NoError(t, err)
+	assert.True(t, liveProjectRoots(manager.Snapshot(repoID))[repoPath], "restore reconstitutes the project")
+}
+
+// TestDeleteProject_DerivesRepoIDFromPath: a request that carries only repo_path
+// (the web/CLI shape) still targets the right sessions — the daemon derives the
+// repo id from the path.
+func TestDeleteProject_DerivesRepoIDFromPath(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	registerArchivable(t, manager, repoID, repoPath, "worker")
+
+	result, err := manager.DeleteProject(DeleteProjectRequest{RepoPath: repoPath})
+	require.NoError(t, err)
+	assert.Len(t, result.Archived, 1, "the session is found via the path-derived repo id")
+	assert.Empty(t, liveProjectRoots(manager.Snapshot(repoID)))
+}

--- a/daemon/deleteproject_test.go
+++ b/daemon/deleteproject_test.go
@@ -1,6 +1,8 @@
 package daemon
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -136,4 +138,49 @@ func TestDeleteProject_DerivesRepoIDFromPath(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, result.Archived, 1, "the session is found via the path-derived repo id")
 	assert.Empty(t, liveProjectRoots(manager.Snapshot(repoID)))
+}
+
+// TestDeleteProject_NonCanonicalPathStillMatches: a path-only request whose path
+// is NOT the canonical repo root (here a subdirectory of the repo — hashing it
+// raw would miss) still targets the right project, because the daemon resolves it
+// to the git toplevel the same way it keys repos everywhere (#1740 review). A
+// silent no-op on a real project must never happen.
+func TestDeleteProject_NonCanonicalPathStillMatches(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	registerArchivable(t, manager, repoID, repoPath, "worker")
+
+	// A subdirectory path: RepoIDFromRoot(subdir) != repoID, so without
+	// canonicalization this would silently match nothing.
+	subdir := filepath.Join(repoPath, "nested", "deep")
+	require.NoError(t, os.MkdirAll(subdir, 0o755))
+	require.NotEqual(t, repoID, config.RepoIDFromRoot(subdir), "precondition: the raw subdir hash differs from the repo id")
+
+	result, err := manager.DeleteProject(DeleteProjectRequest{RepoPath: subdir})
+	require.NoError(t, err)
+	assert.Len(t, result.Archived, 1, "a non-canonical path must still resolve to the real project's sessions")
+	assert.Empty(t, liveProjectRoots(manager.Snapshot(repoID)), "the project is gone, not silently missed")
+}
+
+// TestDeleteProject_RootAgentsWriteFailureIsFatal: if the durable root_agents
+// removal fails, DeleteProject must FAIL (never report success) and, because the
+// write is attempted before any teardown, leave the project intact — otherwise a
+// daemon restart would re-register the root and the "deleted" project would
+// reappear while the caller believed it was gone (#1740 review).
+func TestDeleteProject_RootAgentsWriteFailureIsFatal(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst, src := registerArchivable(t, manager, repoID, repoPath, "worker")
+
+	orig := deregisterRootAgents
+	deregisterRootAgents = func(string) ([]string, error) { return nil, fmt.Errorf("forced config write failure") }
+	t.Cleanup(func() { deregisterRootAgents = orig })
+
+	result, err := manager.DeleteProject(DeleteProjectRequest{RepoID: repoID, RepoPath: repoPath})
+	require.Error(t, err, "a failed root_agents write must surface as an error, not a silent success")
+	assert.Empty(t, result.Archived, "nothing is archived when the durable removal fails")
+
+	// The project is NOT gone: its session is still live and it still appears in
+	// the active list.
+	assert.NotEqual(t, session.Archived, inst.GetStatus(), "the session must remain live on a failed delete")
+	assert.True(t, exists(src), "the session's worktree must be untouched on a failed delete")
+	assert.True(t, liveProjectRoots(manager.Snapshot(repoID))[repoPath], "the project must remain in the active list on a failed delete")
 }

--- a/daemon/httproutes.go
+++ b/daemon/httproutes.go
@@ -102,6 +102,13 @@ var httpRoutes = []HTTPRoute{
 	},
 	{
 		Method:        http.MethodPost,
+		Path:          "/v1/DeleteProject",
+		Description:   "Delete a project (a repo's session grouping): archive its live sessions (restorable), tear down in-place ones, and drop its root_agents opt-in — the real git repo is untouched.",
+		RequestFields: jsonFields(reflect.TypeOf(DeleteProjectRequest{})),
+		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.DeleteProject) },
+	},
+	{
+		Method:        http.MethodPost,
 		Path:          "/v1/DeliverPrompt",
 		Description:   "Deliver a prompt to a session, auto-creating it if it does not exist yet.",
 		RequestFields: jsonFields(reflect.TypeOf(DeliverPromptRequest{})),

--- a/daemon/manager.go
+++ b/daemon/manager.go
@@ -46,6 +46,15 @@ type Manager struct {
 	// rootKillHealDelay, then self-heals a still-configured root (#1223): config
 	// (root_agents), not a runtime kill, decides whether an always-on root runs.
 	rootKilledAt map[string]time.Time
+	// deletedRootRepos records repos (by repo ID) whose project was deleted at
+	// runtime (#1735), so the ensure loop STOPS re-creating their always-on root
+	// agent even though m.cfg is immutable in memory after start. DeleteProject
+	// also removes the repo from root_agents ON DISK, so a daemon restart drops it
+	// for good; this in-memory set is what suppresses the respawn for the rest of
+	// the running daemon's life (matching the existing "root_agents changes take
+	// effect on the next daemon start" contract — a re-added project's root
+	// materializes on restart, not mid-run). Guarded by m.mu.
+	deletedRootRepos map[string]struct{}
 	// killsInFlight marks sessions (by daemon instance key) whose KillSession
 	// teardown is currently running, so the status poll's finish-kill pass for
 	// tombstoned records (#1108) never runs a second concurrent teardown of
@@ -128,6 +137,7 @@ func newManagerShell(cfg *config.Config) (*Manager, error) {
 		targetLocks:         make(map[string]*sync.Mutex),
 		rootEnsureStates:    make(map[string]*rootEnsureState),
 		rootKilledAt:        make(map[string]time.Time),
+		deletedRootRepos:    make(map[string]struct{}),
 		killsInFlight:       make(map[string]struct{}),
 		lostRestoreStates:   make(map[string]*lostRestoreState),
 		limitResumeStates:   make(map[string]*limitResumeState),

--- a/daemon/rootagent.go
+++ b/daemon/rootagent.go
@@ -111,6 +111,18 @@ func (m *Manager) ensureRootAgent(path string, rc config.RootAgentConfig) {
 		return
 	}
 
+	// A project deleted at runtime (#1735) is suppressed for the rest of this
+	// daemon's life: DeleteProject already stopped its root and removed it from
+	// root_agents on disk, so respawning it here from the still-immutable
+	// in-memory m.cfg would resurrect the project the user just deleted.
+	m.mu.Lock()
+	_, deleted := m.deletedRootRepos[repo.ID]
+	m.mu.Unlock()
+	if deleted {
+		m.rootEnsureSucceeded(st)
+		return
+	}
+
 	key := daemonInstanceKey(repo.ID, session.RootSessionTitle)
 	m.mu.Lock()
 	killedAt, killed := m.rootKilledAt[repo.ID]

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -20,6 +20,7 @@ Request fields are the JSON keys of each route's request body; a `—` means the
 | `POST` | `/v1/RestoreArchived` | `title`, `repo_id` | Restore an archived session: move its worktree back next to the repo and re-spawn the agent. |
 | `POST` | `/v1/RestoreSession` | `title`, `repo_id` | Restore an archived, Lost, or Dead session. |
 | `POST` | `/v1/SendPrompt` | `title`, `repo_id`, `prompt`, `id` | Send a prompt to an existing session's agent. |
+| `POST` | `/v1/DeleteProject` | `repo_path`, `repo_id` | Delete a project (a repo's session grouping): archive its live sessions (restorable), tear down in-place ones, and drop its root_agents opt-in — the real git repo is untouched. |
 | `POST` | `/v1/DeliverPrompt` | `title`, `repo_path`, `program`, `prompt`, `auto_yes`, `defer_while_attached` | Deliver a prompt to a session, auto-creating it if it does not exist yet. |
 | `POST` | `/v1/CreateTab` | `title`, `repo_id`, `command`, `name`, `shell`, `id` | Spawn a tab (process or shell) in a session's worktree. |
 | `POST` | `/v1/CloseTab` | `title`, `repo_id`, `tab_name`, `tab_index`, `id` | Close a non-agent tab of a session (the agent tab cannot be closed). |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -29,6 +29,8 @@ Run `af <command> --help` for the same information at the terminal. For a narrat
 - [`af debug`](#af-debug) — Print debug information like config paths
 - [`af doctor`](#af-doctor) — Diagnose setup, daemon health, and leaked session resources
 - [`af keys`](#af-keys) — Show the effective TUI key bindings (defaults plus [keys] rebinds)
+- [`af projects`](#af-projects) — Manage projects (repo groupings of sessions)
+- [`af projects delete`](#af-projects-delete) — Delete a project: archive its sessions and remove it (reversibly)
 - [`af reset`](#af-reset) — Reset all stored instances
 - [`af sessions`](#af-sessions) — Manage sessions
 - [`af sessions archive`](#af-sessions-archive) — Finish with a session by archiving it for later restore
@@ -90,6 +92,7 @@ af [flags]
 - [`af debug`](#af-debug) — Print debug information like config paths
 - [`af doctor`](#af-doctor) — Diagnose setup, daemon health, and leaked session resources
 - [`af keys`](#af-keys) — Show the effective TUI key bindings (defaults plus [keys] rebinds)
+- [`af projects`](#af-projects) — Manage projects (repo groupings of sessions)
 - [`af reset`](#af-reset) — Reset all stored instances
 - [`af sessions`](#af-sessions) — Manage sessions
 - [`af tasks`](#af-tasks) — Manage tasks
@@ -757,6 +760,66 @@ af keys
 | Flag | Type | Description |
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+
+## af projects
+
+Manage projects (repo groupings of sessions)
+
+```
+af projects
+```
+
+**Subcommands**
+
+- [`af projects delete`](#af-projects-delete) — Delete a project: archive its sessions and remove it (reversibly)
+
+**Flags**
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
+
+**Global flags**
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+
+## af projects delete
+
+Delete a project: archive its sessions and remove it (reversibly)
+
+Delete a project — the group of sessions sharing a git repository.
+
+This is ARCHIVE-THEN-REMOVE and reversible. Every live session of the repo is
+archived (its tmux is torn down and its worktree moved to the archive dir, but
+its branch and uncommitted changes are preserved), the project drops out of the
+active projects list, and its always-on root agent (if any) is stopped and its
+root_agents opt-in removed. In-place sessions (the root agent, 'af sessions
+create --here') are torn down instead of archived — their cleanup never touches
+your working tree or branch.
+
+Your real git repository is never touched. To undo a mis-click, restore any
+archived session with 'af sessions restore <title>' — its project reappears.
+
+[repo] is a path inside the repository to delete (default: the current repo).
+Deleting an unknown or already-empty project is a clean no-op. Prints how many
+sessions were archived.
+
+```
+af projects delete [repo]
+```
+
+**Global flags**
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
+| `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
 | `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
 | `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
 

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -85,6 +85,11 @@ const (
 	// (handleProjectsFocus), so this name never appears in GlobalKeyStringsMap.
 	KeySwitchProjectRow
 
+	// KeyDeleteProject deletes the cursor's project from the focused Projects
+	// section (#1735): archive-then-remove, reversible. Dispatch is root-routed
+	// (handleProjectsFocus), so this name never appears in GlobalKeyStringsMap.
+	KeyDeleteProject
+
 	// Interactive mode (#1089, RFC §2.3): Enter on a live pane enters it —
 	// every subsequent keystroke (including Tab) forwards to the agent/shell
 	// in-pane, no full-screen takeover. KeyAttach keeps the full-screen tmux
@@ -154,6 +159,7 @@ var specs = []spec{
 	{name: KeyTaskList, configKey: "tasks", keys: []string{"m"}, desc: "tasks", dispatch: true},
 	{name: KeyManageAutomations, keys: []string{"enter"}, desc: "manage"},
 	{name: KeySwitchProjectRow, keys: []string{"enter"}, desc: "switch"},
+	{name: KeyDeleteProject, keys: []string{"D"}, desc: "delete project"},
 	{name: KeyOpenPane, configKey: "open_pane", keys: []string{"s"}, desc: "open pane", dispatch: true},
 	{name: KeySplitPane, configKey: "split_pane", keys: []string{"S"}, desc: "split pane", dispatch: true},
 	{name: KeyHidePane, configKey: "hide_pane", keys: []string{"x"}, desc: "hide pane", dispatch: true},

--- a/session/liveness.go
+++ b/session/liveness.go
@@ -391,3 +391,14 @@ func livenessFromData(data InstanceData) Liveness {
 	}
 	return lv
 }
+
+// IsArchivedData reports whether a serialized session record is archived,
+// resolving its effective liveness with the same rollforward livenessFromData
+// applies (so a pre-#1195 record with only a legacy status still classifies
+// correctly). It is the []InstanceData analogue of Instance.ShownArchived for
+// callers that iterate the daemon Snapshot rather than live instances — e.g. the
+// "active projects" derivation, which counts only non-archived sessions so a
+// project whose sessions are all archived drops out of the active list (#1735).
+func IsArchivedData(data InstanceData) bool {
+	return livenessFromData(data) == LiveArchived
+}

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -100,7 +100,7 @@ var automationsMenuOptions = []keys.KeyName{
 // verbs here (as the pre-#1620 fall-through footer did) would advertise keys that
 // do nothing.
 var projectsMenuOptions = []keys.KeyName{
-	keys.KeySwitchProjectRow, keys.KeySearch, keys.KeyTab, keys.KeyHelp, keys.KeyQuit,
+	keys.KeySwitchProjectRow, keys.KeyDeleteProject, keys.KeySearch, keys.KeyTab, keys.KeyHelp, keys.KeyQuit,
 }
 
 // interactiveMenuOptions is the whole bar while interactive (#1089, RFC

--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -723,10 +723,15 @@ body {
 }
 .af-project-head {
   display: grid;
-  grid-template-columns: 1fr auto;
+  grid-template-columns: 1fr auto auto;
   align-items: baseline;
   gap: 0.5rem;
   padding: 0.5rem 0.6rem 0.35rem;
+}
+.af-project-delete {
+  font-size: 0.7rem;
+  padding: 0.1rem 0.4rem;
+  align-self: center;
 }
 .af-project-name {
   font-size: 0.85rem;

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -6213,6 +6213,9 @@ async function killSession(id, title, token2) {
 async function archiveSession(id, title, token2) {
   await af("ArchiveSession", { id, title, repo_id: "" }, token2);
 }
+async function deleteProject(root2, token2) {
+  return af("DeleteProject", { repo_path: root2, repo_id: "" }, token2);
+}
 function requireSessionID(id, action) {
   if (id === "") {
     throw new ApiError(0, `cannot ${action}: this session has no stable id to target safely`);
@@ -6521,6 +6524,28 @@ function confirmModal(opts) {
   });
   return handle;
 }
+function confirmDeleteProjectModal(opts) {
+  const word = opts.sessionCount === 1 ? "session" : "sessions";
+  const { handle, body } = modalChrome({
+    title: `Delete project ${opts.projectLabel}?`,
+    confirmLabel: "Delete project",
+    confirmClass: "af-danger",
+    onCancel: opts.onCancel
+  });
+  body.append(
+    h(
+      "p",
+      { class: "af-modal-text" },
+      `Archive ${opts.sessionCount} ${word} and remove this project. Archived sessions stay restorable and your real git repo is untouched \u2014 restore any of them to bring the project back.`
+    )
+  );
+  const card = handle.el.firstElementChild;
+  asForm(card, () => {
+    handle.setError(null);
+    opts.onConfirm();
+  });
+  return handle;
+}
 function field(label, control) {
   return h("label", { class: "af-modal-field" }, h("span", { class: "af-modal-label" }, label), control);
 }
@@ -6630,6 +6655,8 @@ function applyEvent(list, ev) {
       return { sessions: list, needsResync: false };
     case "session.archived":
     case "session.restored":
+      return { sessions: list, needsResync: true };
+    case "projects.changed":
       return { sessions: list, needsResync: true };
     default:
       return { sessions: list, needsResync: false };
@@ -7394,6 +7421,9 @@ function orderWithinProject(sessions) {
 function groupSessionsByProject(sessions) {
   const byRoot = /* @__PURE__ */ new Map();
   for (const s of sessions) {
+    if (isArchived(s)) {
+      continue;
+    }
     const root2 = s.worktree?.repo_path;
     if (!root2) {
       continue;
@@ -7407,9 +7437,11 @@ function groupSessionsByProject(sessions) {
 var ProjectsPane = class {
   /** onOpen selects + attaches a session by its stable id (index.ts switches to the
    *  sessions view and hands the terminal the keyboard), so a project's session row
-   *  is a jump-to-session affordance. */
-  constructor(onOpen) {
+   *  is a jump-to-session affordance. onDeleteProject deletes a project by its repo
+   *  root (#1735) — index.ts confirms first, then calls the DeleteProject RPC. */
+  constructor(onOpen, onDeleteProject) {
     this.onOpen = onOpen;
+    this.onDeleteProject = onDeleteProject;
     this.el = h("section", { class: "af-projects" });
     this.el.setAttribute("aria-label", "Projects");
   }
@@ -7450,11 +7482,16 @@ var ProjectsPane = class {
     this.el.replaceChildren(head, h("div", { class: "af-projects-list" }, ...sections));
   }
   projectSection(group, selectedId) {
+    const deleteBtn = h("button", { type: "button", class: "af-ghost af-project-delete" }, "Delete");
+    deleteBtn.setAttribute("title", `Delete project ${group.label} (archives its sessions, restorable)`);
+    deleteBtn.setAttribute("aria-label", `Delete project ${group.label}`);
+    deleteBtn.addEventListener("click", () => this.onDeleteProject(group.root, group.label, group.sessions.length));
     const header = h(
       "div",
       { class: "af-project-head" },
       h("span", { class: "af-project-name" }, group.label),
-      h("span", { class: "af-project-count" }, `${group.sessions.length}`)
+      h("span", { class: "af-project-count" }, `${group.sessions.length}`),
+      deleteBtn
     );
     header.append(h("div", { class: "af-project-path" }, group.root));
     const rows = group.sessions.map((s) => this.sessionRow(s, s.id === selectedId));
@@ -7690,7 +7727,10 @@ var AppShell = class {
     const rail = h2("nav", { class: "af-rail" }, railHead, this.railList);
     this.main = h2("section", { class: "af-main" });
     this.sessionsBody = h2("div", { class: "af-body" }, rail, this.main);
-    this.projectsPane = new ProjectsPane((id) => this.actions.open(id));
+    this.projectsPane = new ProjectsPane(
+      (id) => this.actions.open(id),
+      (root2, label, count) => this.actions.deleteProject(root2, label, count)
+    );
     this.tasksPane = new TasksPane({
       add: () => this.actions.addTask(),
       toggle: (task) => this.actions.toggleTask(task),
@@ -8194,6 +8234,27 @@ function openConfirm(action) {
     })
   );
 }
+function openDeleteProject(root2, label, sessionCount) {
+  openModal(
+    confirmDeleteProjectModal({
+      projectLabel: label,
+      sessionCount,
+      onConfirm: () => {
+        const tok = token;
+        if (tok === null || !modal) {
+          return;
+        }
+        const m = modal;
+        m.setBusy(true);
+        void deleteProject(root2, tok).then(closeModal).catch((e) => {
+          m.setBusy(false);
+          m.setError(describeError(e));
+        });
+      },
+      onCancel: closeModal
+    })
+  );
+}
 function selectedSessionData() {
   const { sessions, selectedId } = store.get();
   return sessions.find((s) => s.id === selectedId) ?? null;
@@ -8339,7 +8400,8 @@ var actions = {
   addTask: openAddTask,
   toggleTask,
   triggerTask: doTriggerTask,
-  removeTask: doRemoveTask
+  removeTask: doRemoveTask,
+  deleteProject: openDeleteProject
 };
 function syncTerminal(state) {
   const selId = state.selectedId;

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -453,6 +453,35 @@ test("archive: the archive confirm moves a session to the archived group", async
   await expect(row(page, SESSION_B)).toHaveClass(/af-row-archived/, { timeout: 30_000 });
 });
 
+test("delete project (#1735): the delete confirm archives the repo's sessions and removes the project row", async () => {
+  // Switch to the projects view: the seeded mock repo shows as one project with
+  // its remaining LIVE session (SESSION_A — SESSION_B was archived above, and the
+  // projects view is live-only, so it lists only SESSION_A now).
+  await page.locator('.af-viewtab[data-view="projects"]').click();
+  const projects = page.locator(".af-projects");
+  await expect(projects).toBeVisible();
+  const project = projects.locator(".af-project");
+  await expect(project).toHaveCount(1);
+
+  // Click the reversible Delete control on the project header, then confirm. The
+  // copy makes the reversibility explicit ("restorable").
+  await project.locator("button.af-project-delete").click();
+  const modal = page.locator(".af-modal-card");
+  await expect(modal).toBeVisible();
+  await expect(modal).toContainText("restorable");
+  await modal.locator("button.af-danger").click();
+
+  // The project row disappears from the projects view: archiving its last live
+  // session leaves it with none, so it drops out of the (live-only) derivation.
+  await expect(projects.locator(".af-project")).toHaveCount(0, { timeout: 30_000 });
+
+  // Its sessions moved to the archived group: back on the sessions view, the
+  // formerly-live SESSION_A now renders archived (restorable), the real repo
+  // untouched.
+  await page.locator('.af-viewtab[data-view="sessions"]').click();
+  await expect(row(page, SESSION_A)).toHaveClass(/af-row-archived/, { timeout: 30_000 });
+});
+
 // NOTE on #1675 PR4 (ended PTY → "exited", not a reconnect loop): this is already
 // wired end-to-end — the daemon emits a MsgExit control frame on session-end
 // (daemon/ws_pty.go, covered by the Go handler tests), and terminal.ts settles to an

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -214,6 +214,23 @@ export async function archiveSession(id: string, title: string, token: string): 
   await af("ArchiveSession", { id, title, repo_id: "" }, token);
 }
 
+/** The daemon's DeleteProject response: how many sessions it archived vs tore
+ *  down (in-place ones that can't be archived). */
+export interface DeleteProjectResult {
+  ok: boolean;
+  archived_count: number;
+  killed_count: number;
+}
+
+/** Deletes a project (mirrors `af projects delete`) — archive-then-remove and
+ *  reversible: the repo's live sessions are archived (restorable), it drops out
+ *  of the projects view, and its real git repo is untouched. `root` is the repo
+ *  path (worktree.repo_path, the stable project id). The per-session archived
+ *  events + the projects.changed event trigger a rail/projects resync. */
+export async function deleteProject(root: string, token: string): Promise<DeleteProjectResult> {
+  return af("DeleteProject", { repo_path: root, repo_id: "" }, token);
+}
+
 // --- tab mutations (#1592 Phase 5 PR7) -------------------------------------
 //
 // The web tab bar's write verbs, mirroring the TUI's `t`/`w` keys: `t` creates a

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -20,6 +20,7 @@ import {
   createSession,
   type CreateSessionInput,
   createTab,
+  deleteProject,
   fetchSnapshot,
   killSession,
   listTasks,
@@ -33,7 +34,7 @@ import {
   updateTask,
 } from "./api.js";
 import { EventStream, type EventStreamStatus } from "./events.js";
-import { confirmModal, type ModalHandle, newSessionModal, promptModal } from "./modals.js";
+import { confirmDeleteProjectModal, confirmModal, type ModalHandle, newSessionModal, promptModal } from "./modals.js";
 import { decideKey, type KeyboardFocus, type View } from "./nav.js";
 import { applyEvent, clampActiveTab, pickSelection, upsertSession } from "./sessions.js";
 import { Store } from "./store.js";
@@ -449,6 +450,34 @@ function openConfirm(action: "kill" | "archive"): void {
   );
 }
 
+/** Opens the reversible delete-project confirm for a project row (#1735). On
+ *  confirm it archives the repo's live sessions via DeleteProject; the archived
+ *  events + projects.changed resync the rail and drop the project from the view. */
+function openDeleteProject(root: string, label: string, sessionCount: number): void {
+  openModal(
+    confirmDeleteProjectModal({
+      projectLabel: label,
+      sessionCount,
+      onConfirm: () => {
+        const tok = token;
+        // `=== null` not `!tok`: "" is the authorized-tokenless credential (#1696).
+        if (tok === null || !modal) {
+          return;
+        }
+        const m = modal;
+        m.setBusy(true);
+        void deleteProject(root, tok)
+          .then(closeModal)
+          .catch((e) => {
+            m.setBusy(false);
+            m.setError(describeError(e));
+          });
+      },
+      onCancel: closeModal,
+    }),
+  );
+}
+
 // --- tab management (#1592 Phase 5 PR7) ------------------------------------
 
 /** The full projection of the selected session, or null — the source of its tab
@@ -681,6 +710,7 @@ const actions = {
   toggleTask,
   triggerTask: doTriggerTask,
   removeTask: doRemoveTask,
+  deleteProject: openDeleteProject,
 };
 
 // --- attach terminal wiring ------------------------------------------------

--- a/web/src/modals.ts
+++ b/web/src/modals.ts
@@ -265,6 +265,37 @@ export function confirmModal(
   return handle;
 }
 
+/** A reversible delete-project confirm modal (#1735): a normal confirm (NOT a
+ *  typed-name gate) because the action is reversible — the project's live
+ *  sessions are archived (restorable) and its real git repo is untouched. */
+export function confirmDeleteProjectModal(
+  opts: { projectLabel: string; sessionCount: number; onConfirm: () => void; onCancel: () => void },
+): ModalHandle {
+  const word = opts.sessionCount === 1 ? "session" : "sessions";
+  const { handle, body } = modalChrome({
+    title: `Delete project ${opts.projectLabel}?`,
+    confirmLabel: "Delete project",
+    confirmClass: "af-danger",
+    onCancel: opts.onCancel,
+  });
+
+  body.append(
+    h(
+      "p",
+      { class: "af-modal-text" },
+      `Archive ${opts.sessionCount} ${word} and remove this project. Archived sessions stay restorable and your real git repo is untouched — restore any of them to bring the project back.`,
+    ),
+  );
+
+  const card = handle.el.firstElementChild as HTMLElement;
+  asForm(card, () => {
+    handle.setError(null);
+    opts.onConfirm();
+  });
+
+  return handle;
+}
+
 /** A labeled field row: a caption above its control. */
 export function field(label: string, control: HTMLElement): HTMLElement {
   return h("label", { class: "af-modal-field" }, h("span", { class: "af-modal-label" }, label), control);

--- a/web/src/projects.test.ts
+++ b/web/src/projects.test.ts
@@ -1,0 +1,55 @@
+// Tests for the projects-view derivation (#1735). groupSessionsByProject must
+// group only LIVE sessions by repo root — archived sessions belong to the rail's
+// Archived group, not the projects view — so archiving a repo's sessions (what
+// delete-project does) drops its project row, and restoring one brings it back.
+// This mirrors the TUI's live-only buildProjectListFrom.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { groupSessionsByProject } from "./projects.js";
+import { Liveness, type SessionData } from "./types.js";
+
+function sess(title: string, over: Partial<SessionData> = {}): SessionData {
+  return { title, branch: "b", liveness: Liveness.Ready, ...over };
+}
+
+test("groups live sessions by repo root, sorted by path", () => {
+  const groups = groupSessionsByProject([
+    sess("a", { id: "1", worktree: { repo_path: "/repos/b" } }),
+    sess("c", { id: "2", worktree: { repo_path: "/repos/a" } }),
+    sess("d", { id: "3", worktree: { repo_path: "/repos/b" } }),
+  ]);
+  assert.deepEqual(
+    groups.map((g) => g.root),
+    ["/repos/a", "/repos/b"],
+  );
+  assert.equal(groups[1]?.sessions.length, 2, "both /repos/b sessions grouped");
+});
+
+test("archived sessions do NOT define a project (live-only)", () => {
+  const groups = groupSessionsByProject([
+    sess("live", { id: "1", worktree: { repo_path: "/repos/keep" }, liveness: Liveness.Ready }),
+    sess("shelved", { id: "2", worktree: { repo_path: "/repos/gone" }, liveness: Liveness.Archived }),
+  ]);
+  assert.deepEqual(
+    groups.map((g) => g.root),
+    ["/repos/keep"],
+    "a repo whose only session is archived drops out of the projects view",
+  );
+});
+
+test("a project with a live and an archived session shows only the live one", () => {
+  const groups = groupSessionsByProject([
+    sess("live", { id: "1", worktree: { repo_path: "/repos/x" }, liveness: Liveness.Running }),
+    sess("shelved", { id: "2", worktree: { repo_path: "/repos/x" }, liveness: Liveness.Archived }),
+  ]);
+  assert.equal(groups.length, 1);
+  assert.equal(groups[0]?.sessions.length, 1, "the archived row is excluded from the project group");
+  assert.equal(groups[0]?.sessions[0]?.id, "1");
+});
+
+test("sessions without a repo_path are skipped", () => {
+  const groups = groupSessionsByProject([sess("orphan", { id: "1" })]);
+  assert.equal(groups.length, 0);
+});

--- a/web/src/projects.ts
+++ b/web/src/projects.ts
@@ -50,6 +50,14 @@ function orderWithinProject(sessions: SessionData[]): SessionData[] {
 export function groupSessionsByProject(sessions: SessionData[]): ProjectGroup[] {
   const byRoot = new Map<string, SessionData[]>();
   for (const s of sessions) {
+    // Only LIVE sessions define an "active project" (#1735): an archived session
+    // belongs to the sessions rail's Archived group, not the projects view. This
+    // is what makes delete-project (archive every live session) drop the project
+    // row, and restoring an archived session bring it back — the reversible
+    // contract. It mirrors the TUI's live-only buildProjectListFrom.
+    if (isArchived(s)) {
+      continue;
+    }
     const root = s.worktree?.repo_path;
     if (!root) {
       continue;
@@ -76,8 +84,12 @@ export class ProjectsPane {
 
   /** onOpen selects + attaches a session by its stable id (index.ts switches to the
    *  sessions view and hands the terminal the keyboard), so a project's session row
-   *  is a jump-to-session affordance. */
-  constructor(private readonly onOpen: (id: string) => void) {
+   *  is a jump-to-session affordance. onDeleteProject deletes a project by its repo
+   *  root (#1735) — index.ts confirms first, then calls the DeleteProject RPC. */
+  constructor(
+    private readonly onOpen: (id: string) => void,
+    private readonly onDeleteProject: (root: string, label: string, sessionCount: number) => void,
+  ) {
     this.el = h("section", { class: "af-projects" });
     this.el.setAttribute("aria-label", "Projects");
   }
@@ -118,11 +130,18 @@ export class ProjectsPane {
   }
 
   private projectSection(group: ProjectGroup, selectedId: string | null): HTMLElement {
+    // The reversible delete-project control (#1735): a ghost button on the header,
+    // mirroring the terminal-head Archive button. index.ts pops the confirm modal.
+    const deleteBtn = h("button", { type: "button", class: "af-ghost af-project-delete" }, "Delete");
+    deleteBtn.setAttribute("title", `Delete project ${group.label} (archives its sessions, restorable)`);
+    deleteBtn.setAttribute("aria-label", `Delete project ${group.label}`);
+    deleteBtn.addEventListener("click", () => this.onDeleteProject(group.root, group.label, group.sessions.length));
     const header = h(
       "div",
       { class: "af-project-head" },
       h("span", { class: "af-project-name" }, group.label),
       h("span", { class: "af-project-count" }, `${group.sessions.length}`),
+      deleteBtn,
     );
     header.append(h("div", { class: "af-project-path" }, group.root));
     const rows = group.sessions.map((s) => this.sessionRow(s, s.id === selectedId));

--- a/web/src/sessions.ts
+++ b/web/src/sessions.ts
@@ -84,6 +84,11 @@ export function applyEvent(list: SessionData[], ev: WireEvent): ApplyResult {
     case "session.archived":
     case "session.restored":
       return { sessions: list, needsResync: true };
+    case "projects.changed":
+      // A project was deleted as a whole (#1735): the per-session archived events
+      // already flip each row, but resync so the derived projects view (and any
+      // dropped root_agents opt-in) settle against authoritative state.
+      return { sessions: list, needsResync: true };
     default:
       return { sessions: list, needsResync: false };
   }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -912,10 +912,16 @@ body {
 
 .af-project-head {
   display: grid;
-  grid-template-columns: 1fr auto;
+  grid-template-columns: 1fr auto auto;
   align-items: baseline;
   gap: 0.5rem;
   padding: 0.5rem 0.6rem 0.35rem;
+}
+
+.af-project-delete {
+  font-size: 0.7rem;
+  padding: 0.1rem 0.4rem;
+  align-self: center;
 }
 
 .af-project-name {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -174,6 +174,7 @@ export type EventType =
   | "session.killed"
   | "session.archived"
   | "session.restored"
+  | "projects.changed"
   | "task.created"
   | "task.updated"
   | "task.removed";

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -111,6 +111,9 @@ export interface Actions {
   triggerTask(task: TaskData): void;
   /** Removes a task via RemoveTask. */
   removeTask(task: TaskData): void;
+  /** Opens the reversible delete-project confirm for a project row (#1735); on
+   *  confirm index.ts calls DeleteProject, which archives its live sessions. */
+  deleteProject(root: string, label: string, sessionCount: number): void;
 }
 
 /** The soft cap on tabs per session (session/tab.go maxTabs): the agent tab plus
@@ -445,7 +448,10 @@ export class AppShell {
     // The projects + tasks views are peers of the sessions body inside one viewport;
     // update() shows exactly one and hides the others by `state.view`. They own their
     // own subtrees so a task.* / rail event patches only the active pane.
-    this.projectsPane = new ProjectsPane((id: string) => this.actions.open(id));
+    this.projectsPane = new ProjectsPane(
+      (id: string) => this.actions.open(id),
+      (root: string, label: string, count: number) => this.actions.deleteProject(root, label, count),
+    );
     this.tasksPane = new TasksPane({
       add: () => this.actions.addTask(),
       toggle: (task: TaskData) => this.actions.toggleTask(task),


### PR DESCRIPTION
Closes #1735.

Adds the ability to **delete a project** from Agent Factory. A "project" is a
repo grouping of sessions (derived client-side; there is no daemon-side Project
entity). Deleting one is **archive-then-remove and reversible** — the semantics
Sachin locked:

- Every **live** session of the repo is **archived** (tmux torn down, worktree
  moved to the archive dir, **branch + uncommitted work preserved**), so each
  stays restorable via `af sessions restore`.
- The project drops out of the **active projects list**, and its `root_agents`
  opt-in (if any) is removed so it doesn't linger empty or respawn an always-on
  root.
- The user's **real git repository is never touched**. Restoring any archived
  session brings the project back — the reversible contract.

### Why the active-projects list is now live-only

Projects are derived from the session projection. To make "archive every live
session ⇒ project disappears" true (and "restore ⇒ it reappears"), the derivation
now counts **only non-archived** sessions, in both the TUI (`buildProjectListFrom`)
and web (`groupSessionsByProject`). Archived sessions still live in the sidebar's
Archived group and are fully restorable — they just no longer keep a project in
the *active* list. This matches the locked contract and is what the tests assert.

### The always-on root agent

A repo's root agent (and any `--here` session) is an in-place/external worktree
that archive can't relocate. DeleteProject tears those down instead — an in-place
kill never touches the working tree or branch (#1107) — and suppresses the ensure
loop from respawning the root (the in-memory `m.cfg` is immutable after start, so
a `deletedRootRepos` set holds the suppression for the daemon's life while the
disk `root_agents` entry is removed for the next restart).

### Surfaces (all mirror existing conventions)

- **Daemon RPC** `DeleteProject(repo_path|repo_id)` — single-writer, idempotent
  (unknown/empty project = clean no-op). Publishes a `session.archived`/`killed`
  event per affected session **plus** a new `projects.changed` event so TUI + web
  reflect it live. Returns the archived count.
- **CLI** `af projects delete [repo]` (new `projects` group) with `--json`
  envelope; prints how many sessions were archived.
- **Web** projects view: a reversible **Delete** control on each project row →
  normal confirm ("Archive N session(s)… Archived sessions stay restorable…") →
  the RPC. Row disappears; sessions move to the archived group.
- **TUI** projects section: `D` deletes the selected project with the same
  reversible confirm (nav unchanged; the section stays captive).

### Tests

- `daemon/deleteproject_test.go`: N live sessions → all archived + restorable,
  project gone from the derived list, **real repo dir + .git untouched**; restore
  one → project reappears; unknown/empty → no-op; `root_agents` opt-in removed +
  ensure-loop suppressed + restore reconstitutes; path-only request resolves.
- `config/rootagent_register_test.go`: `DeregisterRootAgentsForRepo` removes the
  match, preserves others, unknown = no-op.
- `web/src/projects.test.ts`: live-only grouping (archived-only repo drops out;
  live+archived shows only the live one).
- `web/selftest/web-driver.spec.ts`: Playwright — click Delete on a project row →
  confirm → the project row disappears and its session moves to archived.

### Gates

`go build ./...`, `gofmt -l .`, `golangci-lint run --fast`, `deadcode -test ./...`,
`scripts/lint-file-length.sh`, `scripts/gen-docs.sh` (CLI + API docs regenerated),
web `npm run typecheck`/`test` (76 pass), web/dist rebuilt, `make test-container`,
`make web-selftest-container`, `make tui-driver-selftest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
