### PR TITLE
fix(daemon): serialize SetPRInfo + key persist by stable id to stop kill/recreate identity corruption (#1723)

### DIFF
--- a/daemon/manager_persist.go
+++ b/daemon/manager_persist.go
@@ -43,33 +43,54 @@ func appendInstanceData(repoID string, data session.InstanceData) error {
 // persistInstanceData replaces the on-disk record for data.Title in repoID's
 // instances file with data, under the per-repo file lock, leaving every other
 // record untouched. It is the targeted, clobber-safe persist primitive for
-// in-place mutations of an existing session (CloseTab, SetPRInfo) — the
-// single-writer direction of #960 — analogous to appendInstanceData for
-// creates and storage.DeleteInstance for kills. It deliberately does NOT use a
-// whole-list SaveInstances, which would re-serialize the manager's entire view
-// and reintroduce the dual-writer clobber surface #960 is retiring. Errors when
-// no record with that title exists (the caller already resolved a live
-// instance, so a missing disk record means storage drifted out from under us).
+// in-place mutations of an existing session (CloseTab, SetPRInfo, status/limit
+// polls, archive) — the single-writer direction of #960 — analogous to
+// appendInstanceData for creates and storage.DeleteInstance for kills. It
+// deliberately does NOT use a whole-list SaveInstances, which would re-serialize
+// the manager's entire view and reintroduce the dual-writer clobber surface #960
+// is retiring.
+//
+// It matches the row to overwrite by title AND stable id (#1723, the same
+// "key by stable id, not title/ordinal" class as #1678/#1738): if a record with
+// the same title carries a DIFFERENT stable id, a kill/recreate has replaced the
+// session out from under this writer, so it REFUSES to write rather than clobber
+// the new instance's identity with the caller's stale data. stableIDMatchesForDaemon
+// treats an empty id on either side as a match, so legacy records without a
+// stored id, and callers whose in-memory instance predates the id, still persist.
+// Errors when no record with that title exists (the caller already resolved a
+// live instance, so a missing disk record means storage drifted out from under
+// us).
 func persistInstanceData(repoID string, data session.InstanceData) error {
 	data = data.ForStorage()
 	found := false
+	sameTitleDifferentID := false
 	if err := config.UpdateRepoInstances(repoID, func(raw json.RawMessage) (json.RawMessage, error) {
 		var existing []session.InstanceData
 		if err := json.Unmarshal(raw, &existing); err != nil {
 			return nil, fmt.Errorf("failed to parse existing instances: %w", err)
 		}
 		for i := range existing {
-			if existing[i].Title == data.Title {
-				existing[i] = data
-				found = true
-				return json.MarshalIndent(existing, "", "  ")
+			if existing[i].Title != data.Title {
+				continue
 			}
+			if !stableIDMatchesForDaemon(existing[i].ID, data.ID) {
+				// A same-titled record with a different stable id belongs to a
+				// different (newer) session; never overwrite its identity.
+				sameTitleDifferentID = true
+				return raw, nil
+			}
+			existing[i] = data
+			found = true
+			return json.MarshalIndent(existing, "", "  ")
 		}
 		// Leave the file unchanged when the record is absent; the caller turns
 		// !found into an error below.
 		return raw, nil
 	}); err != nil {
 		return err
+	}
+	if sameTitleDifferentID {
+		return fmt.Errorf("instance %q identity changed in storage", data.Title)
 	}
 	if !found {
 		return fmt.Errorf("instance %q not found in storage", data.Title)

--- a/daemon/manager_persist.go
+++ b/daemon/manager_persist.go
@@ -69,27 +69,36 @@ func persistInstanceData(repoID string, data session.InstanceData) error {
 		if err := json.Unmarshal(raw, &existing); err != nil {
 			return nil, fmt.Errorf("failed to parse existing instances: %w", err)
 		}
+		// Prefer the row whose stable id matches; only if NO same-titled row
+		// shares this id do we treat it as an identity change. Scanning the whole
+		// slice (rather than deciding on the first title hit) keeps a stray
+		// duplicate-title row — a foreign id ordered before the real one — from
+		// masking the legitimate write and failing a live caller (Greptile P1).
+		match := -1
 		for i := range existing {
 			if existing[i].Title != data.Title {
 				continue
 			}
-			if !stableIDMatchesForDaemon(existing[i].ID, data.ID) {
-				// A same-titled record with a different stable id belongs to a
-				// different (newer) session; never overwrite its identity.
-				sameTitleDifferentID = true
-				return raw, nil
+			if stableIDMatchesForDaemon(existing[i].ID, data.ID) {
+				match = i
+				break
 			}
-			existing[i] = data
+			// A same-titled record with a different stable id belongs to a
+			// different (newer) session; never overwrite its identity.
+			sameTitleDifferentID = true
+		}
+		if match >= 0 {
+			existing[match] = data
 			found = true
 			return json.MarshalIndent(existing, "", "  ")
 		}
-		// Leave the file unchanged when the record is absent; the caller turns
-		// !found into an error below.
+		// Leave the file unchanged when no matching-id record exists; the caller
+		// turns !found / sameTitleDifferentID into an error below.
 		return raw, nil
 	}); err != nil {
 		return err
 	}
-	if sameTitleDifferentID {
+	if !found && sameTitleDifferentID {
 		return fmt.Errorf("instance %q identity changed in storage", data.Title)
 	}
 	if !found {

--- a/daemon/manager_tabs.go
+++ b/daemon/manager_tabs.go
@@ -185,11 +185,17 @@ func (m *Manager) CloseTab(req CloseTabRequest) (string, error) {
 
 // SetPRInfo records (or clears) the GitHub PR info for the target session and
 // persists it (#960 PR 1). A zero-value PRInfo (Number 0) clears the recorded
-// info. It mirrors CreateTab's discipline — find, mutate+persist under the
-// per-repo start lock, persist through the targeted writer (persistInstanceData)
-// — and rolls the in-memory value back on persist failure so memory and disk
-// stay consistent. This is the daemon-side write the TUI performs today via
-// prInfoUpdatedMsg + a full-list save (#921); the TUI is switched to it in PR 2.
+// info. It mirrors CloseTab's discipline — find, take the per-session op-lock so
+// a concurrent kill/archive teardown can't replace the session out from under
+// us, re-verify the tracked instance hasn't been swapped for a same-titled
+// recreate, then mutate+persist under the per-repo start lock through the
+// targeted writer (persistInstanceData) — and rolls the in-memory value back on
+// persist failure so memory and disk stay consistent. Without the op-lock and
+// stale-instance check a SetPRInfo racing KillSession+CreateSession wrote the
+// old instance's data (including its stale stable id) over the new instance's
+// disk record, corrupting the persisted identity (#1723). This is the
+// daemon-side write the TUI performs today via prInfoUpdatedMsg + a full-list
+// save (#921); the TUI is switched to it in PR 2.
 func (m *Manager) SetPRInfo(req SetPRInfoRequest) error {
 	instance, repoID, _, err := m.findSession(req.Title, req.RepoID)
 	if err != nil {
@@ -197,6 +203,24 @@ func (m *Manager) SetPRInfo(req SetPRInfoRequest) error {
 	}
 	if instance == nil {
 		return fmt.Errorf("failed to restore instance %q", req.Title)
+	}
+
+	// Serialize against an archive/kill/restore teardown for this session and,
+	// after winning the lock, confirm the session we resolved is still the tracked
+	// current one — a kill/recreate can replace it (same title, DIFFERENT stable
+	// id) in the window between findSession and this lock. Take the op-lock before
+	// the per-repo start lock, matching the kill/archive persist ordering.
+	title := instance.Title
+	key := daemonInstanceKey(repoID, title)
+	opLock := m.opLockFor(key)
+	opLock.Lock()
+	defer opLock.Unlock()
+
+	m.mu.Lock()
+	current := m.instances[key]
+	m.mu.Unlock()
+	if current != instance || instance.UserKilled() {
+		return fmt.Errorf("session %q changed state before PR info could be recorded", title)
 	}
 
 	repoStartLock := m.startLockForRepo(repoID)

--- a/daemon/rootkill.go
+++ b/daemon/rootkill.go
@@ -1,9 +1,6 @@
 package daemon
 
 import (
-	"encoding/json"
-	"fmt"
-
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
@@ -51,7 +48,7 @@ func (m *Manager) persistKillTombstone(repoID string, instance *session.Instance
 	}
 	repoStartLock := m.startLockForRepo(repoID)
 	repoStartLock.Lock()
-	err := persistInstanceDataByStableID(repoID, d)
+	err := persistInstanceData(repoID, d)
 	repoStartLock.Unlock()
 	if err != nil {
 		log.WarningLog.Printf("failed to persist kill tombstone for %q: %v", d.Title, err)
@@ -121,38 +118,4 @@ func (m *Manager) finishUserKill(repoID string, instance *session.Instance) {
 		delete(m.instances, key)
 	}
 	m.mu.Unlock()
-}
-
-func persistInstanceDataByStableID(repoID string, data session.InstanceData) error {
-	data = data.ForStorage()
-	found := false
-	sameTitleDifferentID := false
-	if err := config.UpdateRepoInstances(repoID, func(raw json.RawMessage) (json.RawMessage, error) {
-		var existing []session.InstanceData
-		if err := json.Unmarshal(raw, &existing); err != nil {
-			return nil, fmt.Errorf("failed to parse existing instances: %w", err)
-		}
-		for i := range existing {
-			if existing[i].Title != data.Title {
-				continue
-			}
-			if !stableIDMatchesForDaemon(existing[i].ID, data.ID) {
-				sameTitleDifferentID = true
-				return raw, nil
-			}
-			existing[i] = data
-			found = true
-			return json.MarshalIndent(existing, "", "  ")
-		}
-		return raw, nil
-	}); err != nil {
-		return err
-	}
-	if sameTitleDifferentID {
-		return fmt.Errorf("instance %q identity changed in storage", data.Title)
-	}
-	if !found {
-		return fmt.Errorf("instance %q not found in storage", data.Title)
-	}
-	return nil
 }

--- a/daemon/set_prinfo_race_test.go
+++ b/daemon/set_prinfo_race_test.go
@@ -73,6 +73,67 @@ func TestPersistInstanceData_RefusesCrossIdentityClobber(t *testing.T) {
 	}
 }
 
+// TestPersistInstanceData_UpdatesIDMatchedRowDespiteEarlierTitleCollision
+// guards the row-selection edge (Greptile P1): the shared writer keys on the
+// stable id, so a stray earlier row that shares the title but carries a
+// DIFFERENT id must not mask the legitimate write to the later id-matched row.
+// The transient kill/recreate window this whole fix targets is exactly when two
+// same-title rows can momentarily coexist, so a valid id-matched persist must
+// still land — updating the correct row and leaving the unrelated one untouched.
+func TestPersistInstanceData_UpdatesIDMatchedRowDespiteEarlierTitleCollision(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+
+	const title = "worker"
+	// Two same-title rows: a stray/foreign one first, the real one (id-current)
+	// second.
+	seed, err := json.Marshal([]session.InstanceData{
+		{ID: "id-stray", Title: title, Path: repoPath, Status: session.Running, PRInfo: session.PRInfoData{Number: 1, State: "MERGED"}},
+		{ID: "id-current", Title: title, Path: repoPath, Status: session.Running, PRInfo: session.PRInfoData{Number: 2, State: "OPEN"}},
+	})
+	if err != nil {
+		t.Fatalf("marshal seed: %v", err)
+	}
+	if err := config.LoadState().SaveInstances(repo.ID, seed); err != nil {
+		t.Fatalf("seed disk: %v", err)
+	}
+
+	// Persist an update whose stable id matches the LATER row.
+	update := session.InstanceData{
+		ID: "id-current", Title: title, Path: repoPath, Status: session.Running,
+		PRInfo: session.PRInfoData{Number: 99, State: "OPEN"},
+	}
+	if err := persistInstanceData(repo.ID, update); err != nil {
+		t.Fatalf("persistInstanceData rejected a valid id-matched update behind an earlier same-title row: %v", err)
+	}
+
+	raw, err := config.LoadRepoInstances(repo.ID)
+	if err != nil {
+		t.Fatalf("LoadRepoInstances: %v", err)
+	}
+	var got []session.InstanceData
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal instances: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 persisted instances, got %d: %+v", len(got), got)
+	}
+	byID := map[string]session.InstanceData{}
+	for _, d := range got {
+		byID[d.ID] = d
+	}
+	if cur := byID["id-current"]; cur.PRInfo.Number != 99 {
+		t.Fatalf("id-current row not updated: PR = %+v, want #99", cur.PRInfo)
+	}
+	if stray := byID["id-stray"]; stray.PRInfo.Number != 1 || stray.PRInfo.State != "MERGED" {
+		t.Fatalf("earlier same-title row was clobbered: %+v, want PR #1 MERGED intact", stray.PRInfo)
+	}
+}
+
 // TestSetPRInfo_RaceKillRecreateNeverCorruptsIdentity is the load-bearing -race
 // regression test for #1723. It races SetPRInfo against KillSession+CreateSession
 // on the same title. Without the per-session op-lock and stale-instance re-check,

--- a/daemon/set_prinfo_race_test.go
+++ b/daemon/set_prinfo_race_test.go
@@ -1,0 +1,168 @@
+package daemon
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// TestPersistInstanceData_RefusesCrossIdentityClobber is the direct regression
+// test for the disk-write half of #1723. persistInstanceData used to locate the
+// row to overwrite by TITLE ONLY, so persisting a stale instance A over a
+// same-titled but different-identity instance B silently reverted B's persisted
+// stable id (and every other field) to A's — corrupting the identity the daemon
+// reconciles on (#1195). The fixed writer keys the match on the stable id too and
+// REFUSES to write when the on-disk row's id differs from the instance being
+// persisted. Here A and B share the title "worker" but carry different ids;
+// persisting A must error and leave B's row untouched.
+func TestPersistInstanceData_RefusesCrossIdentityClobber(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+
+	const title = "worker"
+	// Seed the disk with instance B — the freshly recreated session that a
+	// concurrent kill/recreate has just written.
+	seed, err := json.Marshal([]session.InstanceData{{
+		ID:     "id-new",
+		Title:  title,
+		Path:   repoPath,
+		Status: session.Running,
+		PRInfo: session.PRInfoData{Number: 100, State: "OPEN"},
+	}})
+	if err != nil {
+		t.Fatalf("marshal seed: %v", err)
+	}
+	if err := config.LoadState().SaveInstances(repo.ID, seed); err != nil {
+		t.Fatalf("seed disk: %v", err)
+	}
+
+	// Attempt to persist instance A — the killed session, same title, DIFFERENT
+	// stable id. This is exactly what a stale SetPRInfo would flush.
+	stale := session.InstanceData{
+		ID:     "id-old",
+		Title:  title,
+		Path:   repoPath,
+		Status: session.Running,
+		PRInfo: session.PRInfoData{Number: 1, State: "MERGED"},
+	}
+	if err := persistInstanceData(repo.ID, stale); err == nil {
+		t.Fatal("persistInstanceData overwrote a same-titled row with a different stable id (identity corruption); expected refusal")
+	}
+
+	// B's row must still carry B's identity and data, untouched.
+	raw, err := config.LoadRepoInstances(repo.ID)
+	if err != nil {
+		t.Fatalf("LoadRepoInstances: %v", err)
+	}
+	var got []session.InstanceData
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal instances: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 persisted instance, got %d: %+v", len(got), got)
+	}
+	if got[0].ID != "id-new" || got[0].PRInfo.Number != 100 || got[0].PRInfo.State != "OPEN" {
+		t.Fatalf("cross-identity clobber: disk record = %+v, want id-new with PR #100 OPEN intact", got[0])
+	}
+}
+
+// TestSetPRInfo_RaceKillRecreateNeverCorruptsIdentity is the load-bearing -race
+// regression test for #1723. It races SetPRInfo against KillSession+CreateSession
+// on the same title. Without the per-session op-lock and stale-instance re-check,
+// SetPRInfo could resolve the OLD (about-to-be-killed) instance, then flush its
+// data — including its stale stable id — over the row the recreated NEW instance
+// just wrote, reverting the persisted identity.
+//
+// The invariant checked after every round is that the persisted stable id equals
+// the currently-tracked instance's id: SetPRInfo must either target the correct
+// current instance or fail cleanly without writing. A violation (persisted id !=
+// tracked id) is the corruption. Run under -race, this also proves SetPRInfo's
+// instance-map and disk access are properly synchronized against the lifecycle
+// ops.
+func TestSetPRInfo_RaceKillRecreateNeverCorruptsIdentity(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	installInstantBackend(t)
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	const title = "worker"
+	key := daemonInstanceKey(repo.ID, title)
+
+	if _, err := manager.CreateSession(CreateSessionRequest{
+		Title: title, RepoPath: repoPath, Program: "claude", AutoYes: true,
+	}); err != nil {
+		t.Fatalf("initial CreateSession: %v", err)
+	}
+
+	// Several SetPRInfo callers per round widen the chance one is mid-flight
+	// (resolved the OLD instance, awaiting its persist) exactly as the recreate
+	// writes the NEW row — the interleaving that corrupts the identity on the
+	// unfixed code.
+	const setters = 6
+	for i := 0; i < 80; i++ {
+		var wg sync.WaitGroup
+		wg.Add(setters + 1)
+		for s := 0; s < setters; s++ {
+			go func() {
+				defer wg.Done()
+				// Errors are expected and correct when the instance was replaced
+				// mid-flight — the point is that no stale write lands.
+				_ = manager.SetPRInfo(SetPRInfoRequest{
+					Title: title, RepoID: repo.ID,
+					PRInfo: session.PRInfoData{Number: 7, Title: "feat", URL: "https://example/pr/7", State: "OPEN"},
+				})
+			}()
+		}
+		go func() {
+			defer wg.Done()
+			_, _ = manager.KillSession(KillSessionRequest{Title: title, RepoID: repo.ID})
+			_, _ = manager.CreateSession(CreateSessionRequest{
+				Title: title, RepoPath: repoPath, Program: "claude", AutoYes: true,
+			})
+		}()
+		wg.Wait()
+
+		manager.mu.Lock()
+		current := manager.instances[key]
+		manager.mu.Unlock()
+		if current == nil {
+			t.Fatalf("iter %d: no tracked instance after kill+recreate", i)
+		}
+
+		raw, err := config.LoadRepoInstances(repo.ID)
+		if err != nil {
+			t.Fatalf("iter %d LoadRepoInstances: %v", i, err)
+		}
+		var stored []session.InstanceData
+		if err := json.Unmarshal(raw, &stored); err != nil {
+			t.Fatalf("iter %d unmarshal instances: %v", i, err)
+		}
+		var rec *session.InstanceData
+		for j := range stored {
+			if stored[j].Title == title {
+				rec = &stored[j]
+				break
+			}
+		}
+		if rec == nil {
+			t.Fatalf("iter %d: title %q missing from storage after kill+recreate", i, title)
+		}
+		if rec.ID != current.ID {
+			t.Fatalf("iter %d: persisted stable id %q != tracked instance id %q — kill/recreate identity corruption (#1723)", i, rec.ID, current.ID)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #1723.

## The race (introduced in #961)

`daemon/manager_tabs.go` `SetPRInfo()` mutated an instance and persisted it **without the per-session op-lock** and **without re-verifying the resolved instance was still current** — unlike every other session mutation (`CloseTab`, `CreateTab`, conversation capture, kill/archive).

Racing `KillSession`+`CreateSession` on the same title, it could:
1. resolve the OLD (about-to-be-killed) instance via `findSession`,
2. while a concurrent kill removes it and a recreate writes a NEW instance (same title, **different stable id**) to disk,
3. then flush the OLD instance's data — including its stale stable id — over the NEW instance's row.

Two compounding faults let step 3 corrupt the persisted identity that the daemon reconciles on (#1195):

- **`SetPRInfo`** operated on the now-stale instance (no op-lock, no replaced-check).
- **`persistInstanceData`** located the row to overwrite by **title only** (`existing[i].Title == data.Title`), so it clobbered the NEW row with OLD's data even though the ids differed.

## The fix

1. **`SetPRInfo`** now takes the per-session op-lock and, after winning it, re-checks the tracked instance hasn't been replaced (`current == instance && !UserKilled`) before mutating/persisting — mirroring `CloseTab`. A replaced session aborts cleanly with an error, never a stale write.

2. **`persistInstanceData`** now matches the row by title **AND stable id** and **refuses** to overwrite a row whose id differs (the same "key by stable id, not title/ordinal" class as #1678/#1738). This hardens **every** in-place writer — `CloseTab`, `CreateTab`, conversation capture, limit poll/resume, archive, kill tombstone — not just `SetPRInfo`. `persistInstanceDataByStableID` (kill/tombstone path) was byte-identical to the hardened writer and is folded away; `persistKillTombstone` calls `persistInstanceData` directly.

## Adjacent-writer audit

- `persistInstanceData` — **fixed** (now id-keyed); protects all callers.
- `appendInstanceData` — matches by title to enforce **create-time** title uniqueness (Loading-ghost overwrite); there is no prior same-id row to protect, so id-keying is inapplicable. **Excluded, justified.**
- `renameInstanceDataTitle`, kill's `DeleteInstanceByStableID` — already id-keyed. OK.
- `findInstanceDataByTitle`, `repoHasSessionTitle`, `findSession`, `stableIDFor` — read-only lookups; their mutations are op-lock + replaced-check guarded downstream. OK.

## Tests (`-race`)

- `TestPersistInstanceData_RefusesCrossIdentityClobber` — direct proof: persisting instance A must not overwrite instance B's row when titles match but ids differ. **Deterministically fails on the pre-fix title-only writer, passes after** (verified by reverting locally).
- `TestSetPRInfo_RaceKillRecreateNeverCorruptsIdentity` — races `SetPRInfo` against `KillSession`+`CreateSession` and asserts, every round, that the persisted stable id equals the currently-tracked instance's id (SetPRInfo either targets the correct current instance or fails cleanly). Passes under `-race`.

## Gates

- `make test-container` — all packages green (incl. `daemon`)
- `make tui-driver-selftest` — 25/25
- focused `-race` daemon run (`GOFLAGS='-p=1' -parallel 2`) — green
- `go build ./...`, `gofmt -l .`, `golangci-lint run --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)