### PR TITLE
feat(cli): make `af reset` a complete, confirmed factory reset (wipe all AF resources, keep repos+config) (#1736)

### DIFF
--- a/commands/reset.go
+++ b/commands/reset.go
@@ -44,8 +44,11 @@ var resetForceFlag bool
 //     is user configuration, not session state.
 //   - daemon.pid/sock, daemon-token, daemon-tls.* — daemon runtime identity;
 //     wiping them would needlessly break already-configured remote clients.
+//
+// NOTE: "archived" is deliberately NOT here — archived worktrees are removed
+// per-repo (removeArchivedDirs) so a preserved (corrupt/unreadable) record is
+// never left pointing at a deleted archive.
 var resetWipePaths = []string{
-	"archived",              // relocated archived-session worktrees
 	"worktrees",             // AF-managed worktree parent dir (residue after cleanup)
 	"events",                // daemon event queue
 	"logs",                  // per-task run logs
@@ -248,6 +251,10 @@ func planFactoryReset() (*resetPlan, error) {
 	}
 	for repoID, raw := range all {
 		if len(raw) == 0 || string(raw) == "[]" || string(raw) == "null" {
+			// A cleanly-readable empty record set: nothing to plan, but it IS a
+			// processed (deletable) repo — mark it so the disk cross-check below
+			// does not mistake it for an unreadable one.
+			plan.processedRepoIDs = append(plan.processedRepoIDs, repoID)
 			continue
 		}
 		var recs []session.InstanceData
@@ -416,6 +423,12 @@ func executeFactoryReset(plan *resetPlan) (*resetSummary, error) {
 		}
 	}
 
+	// Remove archived-session worktree dirs PER REPO, skipping any preserved
+	// (corrupt/unreadable) repo — its records still point at those archives, so
+	// deleting them would leave a dangling reference. A whole-tree wipe would do
+	// exactly that; keep preserved records and their archives consistent.
+	errs = append(errs, removeArchivedDirs(plan.configDir, plan.corruptRepoIDs)...)
+
 	// Delete the task store (removes <AF_HOME>/tasks.json).
 	if err := task.DeleteAllTasks(); err != nil {
 		errs = append(errs, fmt.Errorf("reset tasks: %w", err))
@@ -444,6 +457,47 @@ func executeFactoryReset(plan *resetPlan) (*resetSummary, error) {
 	return summary, nil
 }
 
+// removeArchivedDirs removes each per-repo archived-worktree tree under
+// <AF_HOME>/archived/<repoID>/, EXCEPT for repos in preserve (the corrupt/
+// unreadable ones). Those repos' records survive the reset and still point at
+// their archives, so removing the archives would leave a dangling reference.
+// Archived dirs for deleted repos — and orphaned dirs with no record at all —
+// are removed. Returns any per-dir removal errors (best-effort, non-fatal).
+func removeArchivedDirs(configDir string, preserve []string) []error {
+	archivedRoot := filepath.Join(configDir, "archived")
+	entries, err := os.ReadDir(archivedRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return []error{fmt.Errorf("read %s: %w", archivedRoot, err)}
+	}
+
+	keep := make(map[string]struct{}, len(preserve))
+	for _, id := range preserve {
+		keep[id] = struct{}{}
+	}
+
+	var errs []error
+	for _, e := range entries {
+		if _, preserved := keep[e.Name()]; preserved {
+			continue // preserved repo — keep its archives consistent with its record
+		}
+		p := filepath.Join(archivedRoot, e.Name())
+		if err := os.RemoveAll(p); err != nil {
+			errs = append(errs, fmt.Errorf("remove %s: %w", p, err))
+		}
+	}
+	// If nothing is preserved, the archived/ root is now empty — drop it too so a
+	// clean reset leaves no stray dir behind.
+	if len(preserve) == 0 {
+		if err := os.RemoveAll(archivedRoot); err != nil {
+			errs = append(errs, fmt.Errorf("remove %s: %w", archivedRoot, err))
+		}
+	}
+	return errs
+}
+
 func printResetPlan(out io.Writer, plan *resetPlan) {
 	fmt.Fprintln(out, "af reset — factory reset (IRREVERSIBLE)")
 	fmt.Fprintln(out)
@@ -468,8 +522,9 @@ func printResetSummary(out io.Writer, s *resetSummary) {
 	fmt.Fprintf(out, "  worktrees: %d\n", s.worktrees)
 	fmt.Fprintf(out, "  branches:  %d\n", s.branches)
 	if s.corrupt > 0 {
-		fmt.Fprintf(out, "  NOTE: %d repo(s) had unreadable records and were LEFT INTACT "+
-			"(their branches were NOT pruned). Fix or remove those instances.json files and re-run.\n", s.corrupt)
+		fmt.Fprintf(out, "  NEEDS ATTENTION: %d repo(s) had unreadable records and were LEFT INTACT "+
+			"— their records, branches, and archived worktrees were all KEPT (nothing dangling). "+
+			"Fix or remove those instances.json files and re-run to finish.\n", s.corrupt)
 	}
 	fmt.Fprintln(out, "Preserved: your git repositories and daemon config (config.toml).")
 	fmt.Fprintln(out, "The supervised daemon will restart with empty session/task state and the same config.")

--- a/commands/reset.go
+++ b/commands/reset.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -67,6 +68,15 @@ type resetPlan struct {
 	worktrees int                 // AF-managed worktrees (excludes external --here trees)
 	repoRoots map[string]struct{} // repos to run worktree cleanup across
 	branches  map[string][]string // repoRoot -> AF-created branch names to prune
+
+	// processedRepoIDs are the repos whose instances.json parsed cleanly and
+	// are therefore safe to delete. corruptRepoIDs are repos whose records
+	// could not be read: we cannot tell which branches AF created, so we leave
+	// their records AND branches intact and report them rather than erasing a
+	// record while orphaning its branch (or guessing and deleting a user's
+	// branch). A re-run after the file is fixed/removed finishes the job.
+	processedRepoIDs []string
+	corruptRepoIDs   []string
 }
 
 func (p *resetPlan) branchCount() int {
@@ -84,6 +94,7 @@ type resetSummary struct {
 	tasks     int
 	worktrees int
 	branches  int // branches actually deleted (<= plan.branchCount())
+	corrupt   int // repos left intact because their records were unreadable
 }
 
 var resetCmd = &cobra.Command{
@@ -165,14 +176,19 @@ func runReset(cmd *cobra.Command, _ []string) error {
 	}
 	fmt.Fprintln(out, "Tmux sessions have been cleaned up")
 
-	// 6. Execute the destructive wipe.
-	summary, err := executeFactoryReset(plan)
-	if err != nil {
-		return err
-	}
+	// 6. Execute the destructive wipe. Resilient: it continues past per-item
+	//    failures and returns them joined rather than aborting half-applied.
+	summary, resetErr := executeFactoryReset(plan)
 
-	// 7. Report what was removed and what was preserved.
+	// 7. Report what was removed and what was preserved — even on partial
+	//    failure, so the user sees exactly where the reset got to.
 	printResetSummary(out, summary)
+	if resetErr != nil {
+		fmt.Fprintln(out, "\nSome items could not be removed; the reset is PARTIAL. "+
+			"Every step is idempotent — re-run `af reset` to finish. Details:")
+		fmt.Fprintln(out, resetErr)
+		return resetErr
+	}
 	return nil
 }
 
@@ -237,10 +253,16 @@ func planFactoryReset() (*resetPlan, error) {
 		var recs []session.InstanceData
 		if err := json.Unmarshal(raw, &recs); err != nil {
 			// One repo's corrupted instances.json must not abort the reset:
-			// skip-and-warn and keep planning the others (#869).
-			log.WarningLog.Printf("reset: skipping repo %s: corrupted instances.json: %v", repoID, err)
+			// skip-and-warn and keep planning the others (#869). We CANNOT
+			// determine BranchCreatedByUs for these records, so we neither prune
+			// their branches nor delete their records — conservatively leaving
+			// both intact (and reporting the repo) rather than orphaning a
+			// branch or deleting a user's branch by guessing.
+			log.WarningLog.Printf("reset: leaving repo %s intact: corrupted instances.json: %v", repoID, err)
+			plan.corruptRepoIDs = append(plan.corruptRepoIDs, repoID)
 			continue
 		}
+		plan.processedRepoIDs = append(plan.processedRepoIDs, repoID)
 		for _, r := range recs {
 			if session.IsArchivedData(r) {
 				plan.archived++
@@ -265,6 +287,30 @@ func planFactoryReset() (*resetPlan, error) {
 			// record (the user's own master/main/feature branches).
 			if branchCreatedByAF(r.Worktree) && r.Worktree.BranchName != "" {
 				plan.branches[root] = append(plan.branches[root], r.Worktree.BranchName)
+			}
+		}
+	}
+
+	// Cross-check the instances/ dir: any repoID directory GetAllInstances did
+	// NOT surface (e.g. an unsupported newer schema version it skipped upstream)
+	// is a record we cannot read. Treat it like a corrupt one — leave it and its
+	// branches intact rather than erasing it wholesale — so an unreadable record
+	// never has its branch orphaned or deleted by guessing.
+	seen := make(map[string]struct{}, len(plan.processedRepoIDs)+len(plan.corruptRepoIDs))
+	for _, id := range plan.processedRepoIDs {
+		seen[id] = struct{}{}
+	}
+	for _, id := range plan.corruptRepoIDs {
+		seen[id] = struct{}{}
+	}
+	if entries, derr := os.ReadDir(filepath.Join(dir, "instances")); derr == nil {
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			if _, ok := seen[e.Name()]; !ok {
+				log.WarningLog.Printf("reset: leaving repo %s intact: unreadable instance records", e.Name())
+				plan.corruptRepoIDs = append(plan.corruptRepoIDs, e.Name())
 			}
 		}
 	}
@@ -298,12 +344,18 @@ func branchCreatedByAF(w session.GitWorktreeData) bool {
 // executeFactoryReset performs the destructive wipe described by plan. It is
 // separated from the daemon/tmux teardown and the interactive prompt so it can
 // be exercised directly against a throwaway AF home + mock repo in tests.
+//
+// It is RESILIENT: one repo's cleanup failure (or one un-removable path) does
+// NOT abort the reset. Every step runs, per-item errors are collected, and the
+// wipe still reaches a consistent end state (records/tasks/state cleared where
+// possible). Any collected errors are returned joined so the caller reports
+// them and exits non-zero; because every step is idempotent, a re-run finishes
+// whatever a transient failure left behind.
 func executeFactoryReset(plan *resetPlan) (*resetSummary, error) {
-	// Snapshot which AF-created branches exist up front, so the final count
-	// reflects branches removed by EITHER pass below: CleanupWorktreesForRepo
-	// deletes the branch of each still-registered worktree, while DeleteLocalBranch
-	// handles the survivors (archived sessions). Counting only the second pass
-	// would under-report the branches a live session's worktree cleanup removed.
+	var errs []error
+
+	// Snapshot which AF-created branches exist up front, so the final count is
+	// accurate even though branch deletion happens AFTER worktree removal.
 	type branchRef struct{ root, name string }
 	var planned []branchRef
 	existedBefore := make(map[branchRef]bool)
@@ -315,27 +367,31 @@ func executeFactoryReset(plan *resetPlan) (*resetSummary, error) {
 		}
 	}
 
-	// Clean worktrees across every repo with stored state. This removes the
-	// live worktree dirs and deletes the branch of each worktree still
-	// registered with git.
+	// Remove worktree DIRECTORIES across every repo with stored state, deleting
+	// NO branches here: the bulk pass cannot tell an AF-created branch from one
+	// a session merely reused, so letting it run `git branch -D` would destroy a
+	// user's branch (#1736). Branch deletion is funneled entirely through the
+	// BranchCreatedByUs-guarded pass below. Resilient: a per-repo failure is
+	// collected, not fatal.
 	for root := range plan.repoRoots {
-		if err := git.CleanupWorktreesForRepo(root); err != nil {
-			return nil, fmt.Errorf("failed to cleanup worktrees for %s: %w", root, err)
+		if _, err := git.RemoveWorktreesForRepo(root); err != nil {
+			errs = append(errs, fmt.Errorf("cleanup worktrees for %s: %w", root, err))
 		}
 	}
 
-	// Prune the AF-created session branches that survive worktree cleanup —
-	// archived sessions, whose worktree was relocated to <AF_HOME>/archived/
-	// and is no longer a live worktree of the repo. Best-effort: a single
-	// branch failure is logged, not fatal, so the rest of the reset completes.
+	// Delete ONLY the branches AF created for its own sessions (live and
+	// archived), gated on BranchCreatedByUs at plan time. After worktree removal
+	// + prune above, a live session's branch is no longer checked out, so
+	// `git branch -D` succeeds. Best-effort per branch.
 	for _, ref := range planned {
 		if _, err := git.DeleteLocalBranch(ref.root, ref.name); err != nil {
 			log.WarningLog.Printf("reset: %v", err)
+			errs = append(errs, fmt.Errorf("delete branch %s in %s: %w", ref.name, ref.root, err))
 		}
 	}
 
 	// A planned branch that existed before and is gone now was removed by this
-	// reset (via either pass).
+	// reset.
 	branchesDeleted := 0
 	for _, ref := range planned {
 		if existedBefore[ref] && !git.LocalBranchExists(ref.root, ref.name) {
@@ -343,14 +399,26 @@ func executeFactoryReset(plan *resetPlan) (*resetSummary, error) {
 		}
 	}
 
-	// Delete instance storage (removes <AF_HOME>/instances/ and every record).
-	if err := plan.storage.DeleteAllInstances(); err != nil {
-		return nil, fmt.Errorf("failed to reset instance storage: %w", err)
+	// Delete instance records. With no corrupt repos, remove the whole
+	// <AF_HOME>/instances/ tree. With corrupt repos present, delete ONLY the
+	// repos we could parse and LEAVE the corrupt ones (and their branches)
+	// intact — erasing a record whose branch we deliberately did not prune would
+	// orphan that branch.
+	if len(plan.corruptRepoIDs) == 0 {
+		if err := plan.storage.DeleteAllInstances(); err != nil {
+			errs = append(errs, fmt.Errorf("reset instance storage: %w", err))
+		}
+	} else {
+		for _, rid := range plan.processedRepoIDs {
+			if err := config.DeleteRepoInstances(rid); err != nil {
+				errs = append(errs, fmt.Errorf("delete instances for repo %s: %w", rid, err))
+			}
+		}
 	}
 
 	// Delete the task store (removes <AF_HOME>/tasks.json).
 	if err := task.DeleteAllTasks(); err != nil {
-		return nil, fmt.Errorf("failed to reset tasks: %w", err)
+		errs = append(errs, fmt.Errorf("reset tasks: %w", err))
 	}
 
 	// Remove the remaining AF state trees/files, leaving config (config.toml,
@@ -358,17 +426,22 @@ func executeFactoryReset(plan *resetPlan) (*resetSummary, error) {
 	for _, name := range resetWipePaths {
 		p := filepath.Join(plan.configDir, name)
 		if err := os.RemoveAll(p); err != nil {
-			return nil, fmt.Errorf("failed to remove %s: %w", p, err)
+			errs = append(errs, fmt.Errorf("remove %s: %w", p, err))
 		}
 	}
 
-	return &resetSummary{
+	summary := &resetSummary{
 		sessions:  plan.sessions,
 		archived:  plan.archived,
 		tasks:     plan.tasks,
 		worktrees: plan.worktrees,
 		branches:  branchesDeleted,
-	}, nil
+		corrupt:   len(plan.corruptRepoIDs),
+	}
+	if len(errs) > 0 {
+		return summary, errors.Join(errs...)
+	}
+	return summary, nil
 }
 
 func printResetPlan(out io.Writer, plan *resetPlan) {
@@ -394,6 +467,10 @@ func printResetSummary(out io.Writer, s *resetSummary) {
 	fmt.Fprintf(out, "  tasks:     %d\n", s.tasks)
 	fmt.Fprintf(out, "  worktrees: %d\n", s.worktrees)
 	fmt.Fprintf(out, "  branches:  %d\n", s.branches)
+	if s.corrupt > 0 {
+		fmt.Fprintf(out, "  NOTE: %d repo(s) had unreadable records and were LEFT INTACT "+
+			"(their branches were NOT pruned). Fix or remove those instances.json files and re-run.\n", s.corrupt)
+	}
 	fmt.Fprintln(out, "Preserved: your git repositories and daemon config (config.toml).")
 	fmt.Fprintln(out, "The supervised daemon will restart with empty session/task state and the same config.")
 }

--- a/commands/reset.go
+++ b/commands/reset.go
@@ -1,0 +1,399 @@
+package commands
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	cmdutil "github.com/sachiniyer/agent-factory/cmd"
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/git"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+	"github.com/sachiniyer/agent-factory/task"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+// wipeConfirmWord is the exact, case-sensitive token the user must type at the
+// interactive prompt before `af reset` destroys anything (#1736).
+const wipeConfirmWord = "WIPE"
+
+// resetForceFlag is bound to both --yes and --force: either bypasses the typed
+// WIPE confirmation for non-interactive/scripted use.
+var resetForceFlag bool
+
+// resetWipePaths are the state trees/files under the AF home directory that a
+// factory reset removes wholesale (in addition to instances/, handled by
+// DeleteAllInstances, and tasks.json, handled by task.DeleteAllTasks).
+//
+// Deliberately absent — these are PRESERVED so a fresh daemon comes back with
+// the same identity and configuration:
+//   - config.toml / config.json(.bak) — daemon config: listen_addr, defaults,
+//     root_agents, update_channel (#1736 keeps these; root_agents legitimately
+//     re-register from config on the next start).
+//   - repos/ — per-repo config (e.g. remote_hooks provisioner commands), which
+//     is user configuration, not session state.
+//   - daemon.pid/sock, daemon-token, daemon-tls.* — daemon runtime identity;
+//     wiping them would needlessly break already-configured remote clients.
+var resetWipePaths = []string{
+	"archived",              // relocated archived-session worktrees
+	"worktrees",             // AF-managed worktree parent dir (residue after cleanup)
+	"events",                // daemon event queue
+	"logs",                  // per-task run logs
+	"locks",                 // per-task run locks
+	config.StateFileName,    // state.json (help-screen bitmask etc.)
+	config.TUIStateFileName, // tui-state.json (TUI layout state)
+}
+
+// resetPlan is the pre-computed, non-destructive picture of what a factory
+// reset will remove. It is gathered BEFORE anything is touched so the
+// destructive summary shown to the user (and the typed-WIPE gate) reflect the
+// real scope, and so branch/worktree targets survive the DeleteAllInstances
+// that erases the records they came from.
+type resetPlan struct {
+	configDir string
+	storage   *session.Storage
+	sessions  int                 // live (non-archived) session records
+	archived  int                 // archived session records
+	tasks     int                 // scheduled cron/watch tasks
+	worktrees int                 // AF-managed worktrees (excludes external --here trees)
+	repoRoots map[string]struct{} // repos to run worktree cleanup across
+	branches  map[string][]string // repoRoot -> AF-created branch names to prune
+}
+
+func (p *resetPlan) branchCount() int {
+	n := 0
+	for _, names := range p.branches {
+		n += len(names)
+	}
+	return n
+}
+
+// resetSummary is what a factory reset actually removed, printed on completion.
+type resetSummary struct {
+	sessions  int
+	archived  int
+	tasks     int
+	worktrees int
+	branches  int // branches actually deleted (<= plan.branchCount())
+}
+
+var resetCmd = &cobra.Command{
+	Use:   "reset",
+	Short: "Factory-reset Agent Factory: remove ALL AF sessions, tasks, worktrees, and state (keeps your repos + config)",
+	Long: `Factory-reset Agent Factory.
+
+Removes every AF-created resource — all sessions (live and archived), all
+scheduled cron/watch tasks, all AF worktrees, the AF session branches AF
+created, and all stored state — returning AF to a clean slate.
+
+KEEPS your real git repositories (working tree, .git, and your own branches),
+and KEEPS the daemon configuration (config.toml: listen_addr, defaults,
+root_agents, update_channel, and per-repo config). After the wipe the
+supervised daemon restarts with empty session/task state and the same config;
+root_agents in config re-register, which is intended.
+
+This is IRREVERSIBLE. You will be asked to type WIPE to confirm. Pass --yes
+(or --force) to skip the prompt for scripted use; when stdin is not a terminal
+the prompt is skipped automatically so existing scripted callers do not hang.`,
+	RunE: runReset,
+}
+
+func init() {
+	resetCmd.Flags().BoolVarP(&resetForceFlag, "yes", "y", false,
+		"Skip the typed WIPE confirmation (for non-interactive/scripted use)")
+	resetCmd.Flags().BoolVar(&resetForceFlag, "force", false,
+		"Alias for --yes: skip the typed WIPE confirmation")
+}
+
+func runReset(cmd *cobra.Command, _ []string) error {
+	log.Initialize(false)
+	defer log.Close()
+
+	out := cmd.OutOrStdout()
+
+	// 1. Plan the wipe (non-destructive) so the summary and confirmation
+	//    reflect the real scope, and branch/worktree targets outlive the
+	//    record deletion.
+	plan, err := planFactoryReset()
+	if err != nil {
+		return err
+	}
+
+	// 2. Echo exactly what will be removed and what will be preserved.
+	printResetPlan(out, plan)
+
+	// 3. Typed-WIPE gate. --yes/--force bypasses; a non-TTY stdin skips the
+	//    prompt (but the summary above still printed) so scripted callers do
+	//    not hang.
+	isTTY := term.IsTerminal(int(os.Stdin.Fd()))
+	proceed, err := resetConfirmed(resetForceFlag, isTTY, os.Stdin, out)
+	if err != nil {
+		return err
+	}
+	if !proceed {
+		fmt.Fprintln(out, "Aborted. Nothing was removed.")
+		return nil
+	}
+
+	// 4. Stop the daemon before touching its state on disk. StopDaemon only
+	//    finds daemons that wrote a PID file; a pre-1.0.69 daemon leaves none,
+	//    so only claim success when we actually stopped one (#937).
+	stopped, err := daemon.StopDaemon()
+	if err != nil {
+		return err
+	}
+	if stopped {
+		fmt.Fprintln(out, "daemon has been stopped")
+	} else {
+		fmt.Fprintln(out, "No managed daemon was stopped (no PID file, or the recorded process was already gone). "+
+			"If an old daemon is still running (e.g. one built from source as `agent-factory --daemon`), "+
+			"stop it with: pkill -f -- '--daemon'")
+	}
+
+	// 5. Clean up tmux sessions before deleting the records that name them.
+	if err := tmux.CleanupSessions(cmdutil.MakeExecutor()); err != nil {
+		return fmt.Errorf("failed to cleanup tmux sessions: %w", err)
+	}
+	fmt.Fprintln(out, "Tmux sessions have been cleaned up")
+
+	// 6. Execute the destructive wipe.
+	summary, err := executeFactoryReset(plan)
+	if err != nil {
+		return err
+	}
+
+	// 7. Report what was removed and what was preserved.
+	printResetSummary(out, summary)
+	return nil
+}
+
+// resetConfirmed decides whether the destructive wipe may proceed.
+//
+//   - force (--yes/--force): proceed without prompting.
+//   - non-interactive stdin (!isTTY): proceed without prompting so scripted
+//     callers do not hang; the destructive summary was already printed.
+//   - interactive: require the user to type the exact, case-sensitive WIPE
+//     token; anything else aborts.
+//
+// It takes force/isTTY/in explicitly (rather than reading os.Stdin) so the
+// decision is unit-testable without a real terminal.
+func resetConfirmed(force, isTTY bool, in io.Reader, out io.Writer) (bool, error) {
+	if force {
+		return true, nil
+	}
+	if !isTTY {
+		fmt.Fprintln(out, "stdin is not a terminal; proceeding without an interactive confirmation "+
+			"(pass --yes to silence this notice, or run in a terminal to be prompted).")
+		return true, nil
+	}
+	fmt.Fprintf(out, "\nThis is IRREVERSIBLE. Type %s to proceed, anything else to abort: ", wipeConfirmWord)
+	line, err := bufio.NewReader(in).ReadString('\n')
+	if err != nil && line == "" {
+		return false, nil
+	}
+	return strings.TrimSpace(line) == wipeConfirmWord, nil
+}
+
+// planFactoryReset gathers the full, non-destructive picture of what a reset
+// will remove. It reads instance records across ALL repos (matching the
+// all-repo scope of DeleteAllInstances) and the task store, and derives the
+// exact set of worktree repos and AF-created branches to clean.
+func planFactoryReset() (*resetPlan, error) {
+	dir, err := config.GetConfigDir()
+	if err != nil {
+		return nil, err
+	}
+
+	state := config.LoadState()
+	storage, err := session.NewStorage(state, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize storage: %w", err)
+	}
+
+	plan := &resetPlan{
+		configDir: dir,
+		storage:   storage,
+		repoRoots: make(map[string]struct{}),
+		branches:  make(map[string][]string),
+	}
+
+	all, err := state.GetAllInstances()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read stored instances: %w", err)
+	}
+	for repoID, raw := range all {
+		if len(raw) == 0 || string(raw) == "[]" || string(raw) == "null" {
+			continue
+		}
+		var recs []session.InstanceData
+		if err := json.Unmarshal(raw, &recs); err != nil {
+			// One repo's corrupted instances.json must not abort the reset:
+			// skip-and-warn and keep planning the others (#869).
+			log.WarningLog.Printf("reset: skipping repo %s: corrupted instances.json: %v", repoID, err)
+			continue
+		}
+		for _, r := range recs {
+			if session.IsArchivedData(r) {
+				plan.archived++
+			} else {
+				plan.sessions++
+			}
+			// Count only AF-managed worktrees; an external (--here) session
+			// IS the user's live tree and is never removed.
+			if r.Worktree.WorktreePath != "" && !r.Worktree.ExternalWorktree {
+				plan.worktrees++
+			}
+			root := r.Worktree.RepoPath
+			if root == "" {
+				root = r.Path
+			}
+			if root == "" {
+				continue
+			}
+			plan.repoRoots[root] = struct{}{}
+			// Prune ONLY branches AF created for its sessions — never a branch
+			// the session merely reused (--here), and never a branch with no
+			// record (the user's own master/main/feature branches).
+			if branchCreatedByAF(r.Worktree) && r.Worktree.BranchName != "" {
+				plan.branches[root] = append(plan.branches[root], r.Worktree.BranchName)
+			}
+		}
+	}
+
+	// Ensure the current repo is cleaned even when it has no stored instances,
+	// matching prior `af reset` behavior.
+	if cwd, cwdErr := os.Getwd(); cwdErr == nil {
+		if root, rerr := config.ResolveMainRepoRoot(cwd); rerr == nil {
+			plan.repoRoots[root] = struct{}{}
+		}
+	}
+
+	tasks, err := task.LoadTasks()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read tasks: %w", err)
+	}
+	plan.tasks = len(tasks)
+
+	return plan, nil
+}
+
+// branchCreatedByAF reports whether AF created this session's branch itself.
+// A nil BranchCreatedByUs means the record predates the flag; those were always
+// AF-created branches, so nil is treated as true (rollforward). An explicit
+// false means the session reused a pre-existing branch, which must NOT be
+// pruned.
+func branchCreatedByAF(w session.GitWorktreeData) bool {
+	return w.BranchCreatedByUs == nil || *w.BranchCreatedByUs
+}
+
+// executeFactoryReset performs the destructive wipe described by plan. It is
+// separated from the daemon/tmux teardown and the interactive prompt so it can
+// be exercised directly against a throwaway AF home + mock repo in tests.
+func executeFactoryReset(plan *resetPlan) (*resetSummary, error) {
+	// Snapshot which AF-created branches exist up front, so the final count
+	// reflects branches removed by EITHER pass below: CleanupWorktreesForRepo
+	// deletes the branch of each still-registered worktree, while DeleteLocalBranch
+	// handles the survivors (archived sessions). Counting only the second pass
+	// would under-report the branches a live session's worktree cleanup removed.
+	type branchRef struct{ root, name string }
+	var planned []branchRef
+	existedBefore := make(map[branchRef]bool)
+	for root, names := range plan.branches {
+		for _, b := range names {
+			ref := branchRef{root, b}
+			planned = append(planned, ref)
+			existedBefore[ref] = git.LocalBranchExists(root, b)
+		}
+	}
+
+	// Clean worktrees across every repo with stored state. This removes the
+	// live worktree dirs and deletes the branch of each worktree still
+	// registered with git.
+	for root := range plan.repoRoots {
+		if err := git.CleanupWorktreesForRepo(root); err != nil {
+			return nil, fmt.Errorf("failed to cleanup worktrees for %s: %w", root, err)
+		}
+	}
+
+	// Prune the AF-created session branches that survive worktree cleanup —
+	// archived sessions, whose worktree was relocated to <AF_HOME>/archived/
+	// and is no longer a live worktree of the repo. Best-effort: a single
+	// branch failure is logged, not fatal, so the rest of the reset completes.
+	for _, ref := range planned {
+		if _, err := git.DeleteLocalBranch(ref.root, ref.name); err != nil {
+			log.WarningLog.Printf("reset: %v", err)
+		}
+	}
+
+	// A planned branch that existed before and is gone now was removed by this
+	// reset (via either pass).
+	branchesDeleted := 0
+	for _, ref := range planned {
+		if existedBefore[ref] && !git.LocalBranchExists(ref.root, ref.name) {
+			branchesDeleted++
+		}
+	}
+
+	// Delete instance storage (removes <AF_HOME>/instances/ and every record).
+	if err := plan.storage.DeleteAllInstances(); err != nil {
+		return nil, fmt.Errorf("failed to reset instance storage: %w", err)
+	}
+
+	// Delete the task store (removes <AF_HOME>/tasks.json).
+	if err := task.DeleteAllTasks(); err != nil {
+		return nil, fmt.Errorf("failed to reset tasks: %w", err)
+	}
+
+	// Remove the remaining AF state trees/files, leaving config (config.toml,
+	// config.json, repos/) and daemon identity untouched.
+	for _, name := range resetWipePaths {
+		p := filepath.Join(plan.configDir, name)
+		if err := os.RemoveAll(p); err != nil {
+			return nil, fmt.Errorf("failed to remove %s: %w", p, err)
+		}
+	}
+
+	return &resetSummary{
+		sessions:  plan.sessions,
+		archived:  plan.archived,
+		tasks:     plan.tasks,
+		worktrees: plan.worktrees,
+		branches:  branchesDeleted,
+	}, nil
+}
+
+func printResetPlan(out io.Writer, plan *resetPlan) {
+	fmt.Fprintln(out, "af reset — factory reset (IRREVERSIBLE)")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "WILL REMOVE:")
+	fmt.Fprintf(out, "  • %d session(s) and %d archived session(s)\n", plan.sessions, plan.archived)
+	fmt.Fprintf(out, "  • %d scheduled task(s)\n", plan.tasks)
+	fmt.Fprintf(out, "  • %d AF worktree(s) across %d repo(s)\n", plan.worktrees, len(plan.repoRoots))
+	fmt.Fprintf(out, "  • %d AF-created session branch(es)\n", plan.branchCount())
+	fmt.Fprintln(out, "  • all AF state (instances, archived sessions, events, logs, locks)")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "WILL KEEP:")
+	fmt.Fprintln(out, "  • your git repositories (working tree, .git, and your own branches)")
+	fmt.Fprintln(out, "  • daemon config: config.toml (listen_addr, defaults, root_agents, update_channel) and per-repo config")
+}
+
+func printResetSummary(out io.Writer, s *resetSummary) {
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Factory reset complete. Removed:")
+	fmt.Fprintf(out, "  sessions:  %d\n", s.sessions)
+	fmt.Fprintf(out, "  archived:  %d\n", s.archived)
+	fmt.Fprintf(out, "  tasks:     %d\n", s.tasks)
+	fmt.Fprintf(out, "  worktrees: %d\n", s.worktrees)
+	fmt.Fprintf(out, "  branches:  %d\n", s.branches)
+	fmt.Fprintln(out, "Preserved: your git repositories and daemon config (config.toml).")
+	fmt.Fprintln(out, "The supervised daemon will restart with empty session/task state and the same config.")
+}

--- a/commands/reset.go
+++ b/commands/reset.go
@@ -69,8 +69,14 @@ type resetPlan struct {
 	archived  int                 // archived session records
 	tasks     int                 // scheduled cron/watch tasks
 	worktrees int                 // AF-managed worktrees (excludes external --here trees)
-	repoRoots map[string]struct{} // repos to run worktree cleanup across
+	repoRoots map[string]struct{} // distinct repos with AF records (display only)
 	branches  map[string][]string // repoRoot -> AF-created branch names to prune
+
+	// worktreeTargets are the SPECIFIC worktree dirs AF created for its sessions
+	// (from the records), each paired with its repo root. Reset removes exactly
+	// these — never a blind per-repo bulk pass, which would delete the user's own
+	// manually-created linked worktrees (#1736).
+	worktreeTargets []worktreeTarget
 
 	// processedRepoIDs are the repos whose instances.json parsed cleanly and
 	// are therefore safe to delete. corruptRepoIDs are repos whose records
@@ -80,6 +86,13 @@ type resetPlan struct {
 	// branch). A re-run after the file is fixed/removed finishes the job.
 	processedRepoIDs []string
 	corruptRepoIDs   []string
+}
+
+// worktreeTarget is one AF-created worktree directory to remove, with the repo
+// root git needs to operate on it.
+type worktreeTarget struct {
+	root string
+	path string
 }
 
 func (p *resetPlan) branchCount() int {
@@ -271,19 +284,23 @@ func planFactoryReset() (*resetPlan, error) {
 		}
 		plan.processedRepoIDs = append(plan.processedRepoIDs, repoID)
 		for _, r := range recs {
+			root := r.Worktree.RepoPath
+			if root == "" {
+				root = r.Path
+			}
 			if session.IsArchivedData(r) {
 				plan.archived++
 			} else {
 				plan.sessions++
 			}
-			// Count only AF-managed worktrees; an external (--here) session
-			// IS the user's live tree and is never removed.
-			if r.Worktree.WorktreePath != "" && !r.Worktree.ExternalWorktree {
+			// Target ONLY the worktree dirs AF created for its sessions. An
+			// external (--here) session IS the user's live tree, so it is never a
+			// target. This record-driven list is why reset never removes the
+			// user's own manually-created linked worktrees.
+			if r.Worktree.WorktreePath != "" && !r.Worktree.ExternalWorktree && root != "" {
 				plan.worktrees++
-			}
-			root := r.Worktree.RepoPath
-			if root == "" {
-				root = r.Path
+				plan.worktreeTargets = append(plan.worktreeTargets,
+					worktreeTarget{root: root, path: r.Worktree.WorktreePath})
 			}
 			if root == "" {
 				continue
@@ -322,13 +339,10 @@ func planFactoryReset() (*resetPlan, error) {
 		}
 	}
 
-	// Ensure the current repo is cleaned even when it has no stored instances,
-	// matching prior `af reset` behavior.
-	if cwd, cwdErr := os.Getwd(); cwdErr == nil {
-		if root, rerr := config.ResolveMainRepoRoot(cwd); rerr == nil {
-			plan.repoRoots[root] = struct{}{}
-		}
-	}
+	// NOTE: there is deliberately NO current-repo fallback. The pre-#1736 reset
+	// forced the cwd's repo into a bulk worktree cleanup even when it had no AF
+	// records — which would delete the user's own manually-created linked
+	// worktrees. If a repo has no AF records, AF created nothing there to remove.
 
 	tasks, err := task.LoadTasks()
 	if err != nil {
@@ -374,15 +388,14 @@ func executeFactoryReset(plan *resetPlan) (*resetSummary, error) {
 		}
 	}
 
-	// Remove worktree DIRECTORIES across every repo with stored state, deleting
-	// NO branches here: the bulk pass cannot tell an AF-created branch from one
-	// a session merely reused, so letting it run `git branch -D` would destroy a
-	// user's branch (#1736). Branch deletion is funneled entirely through the
-	// BranchCreatedByUs-guarded pass below. Resilient: a per-repo failure is
-	// collected, not fatal.
-	for root := range plan.repoRoots {
-		if _, err := git.RemoveWorktreesForRepo(root); err != nil {
-			errs = append(errs, fmt.Errorf("cleanup worktrees for %s: %w", root, err))
+	// Remove ONLY the specific worktree DIRECTORIES AF created for its sessions
+	// (from the records), never a blind per-repo bulk pass — that would delete
+	// the user's own manually-created linked worktrees. Deletes NO branch here;
+	// branch deletion is funneled through the BranchCreatedByUs-guarded pass
+	// below. Resilient: a per-worktree failure is collected, not fatal.
+	for _, wt := range plan.worktreeTargets {
+		if _, err := git.RemoveWorktreeDir(wt.root, wt.path); err != nil {
+			errs = append(errs, fmt.Errorf("remove worktree %s: %w", wt.path, err))
 		}
 	}
 

--- a/commands/reset_test.go
+++ b/commands/reset_test.go
@@ -38,9 +38,11 @@ func branchExists(dir, branch string) bool {
 
 // seedMockRepo builds a real git repo with master, an AF live-session worktree
 // (branch af-session-1), an AF-created archived-session branch (af-session-2),
-// and a user branch (my-feature) that an AF --here session reused. It returns
-// the repo root and the live worktree path.
-func seedMockRepo(t *testing.T, home string) (repo, liveWT string) {
+// a user branch (my-feature) that an AF --here session reused, and a user
+// branch (reused-linked) checked out in a LINKED worktree by a session that
+// reused it (BranchCreatedByUs=false). It returns the repo root and the two
+// linked worktree paths.
+func seedMockRepo(t *testing.T, home string) (repo, liveWT, reusedWT string) {
 	t.Helper()
 	repo = t.TempDir()
 	runGit(t, repo, "init", "-q")
@@ -50,18 +52,25 @@ func seedMockRepo(t *testing.T, home string) (repo, liveWT string) {
 	runGit(t, repo, "add", "-A")
 	runGit(t, repo, "commit", "-q", "-m", "init")
 	runGit(t, repo, "branch", "-M", "master")
-	runGit(t, repo, "branch", "my-feature")   // user branch (reused by a --here session)
-	runGit(t, repo, "branch", "af-session-2") // AF-created, archived (no live worktree)
+	runGit(t, repo, "branch", "my-feature")    // user branch (reused by a --here session)
+	runGit(t, repo, "branch", "reused-linked") // user branch (reused in a linked worktree)
+	runGit(t, repo, "branch", "af-session-2")  // AF-created, archived (no live worktree)
 
 	liveWT = filepath.Join(home, "worktrees", "live")
 	runGit(t, repo, "worktree", "add", "-q", "-b", "af-session-1", liveWT)
-	return repo, liveWT
+
+	// A linked worktree that CHECKS OUT an existing user branch (no -b): the
+	// session reused it, so BranchCreatedByUs=false. The old bulk-cleanup path
+	// would have `git branch -D`'d this — the critical #1 regression to guard.
+	reusedWT = filepath.Join(home, "worktrees", "reused")
+	runGit(t, repo, "worktree", "add", "-q", reusedWT, "reused-linked")
+	return repo, liveWT, reusedWT
 }
 
 // seedAFState writes instance records, tasks, archived dirs, state files, and a
 // preserved config into the throwaway AF home. Returns the config.toml bytes so
 // callers can assert they are untouched.
-func seedAFState(t *testing.T, home, repo, liveWT string) []byte {
+func seedAFState(t *testing.T, home, repo, liveWT, reusedWT string) []byte {
 	t.Helper()
 	repoID := config.RepoIDFromRoot(repo)
 
@@ -91,6 +100,16 @@ func seedAFState(t *testing.T, home, repo, liveWT string) []byte {
 			Worktree: session.GitWorktreeData{
 				RepoPath: repo, WorktreePath: repo, ExternalWorktree: true,
 				BranchName: "my-feature", BranchCreatedByUs: boolPtr(false),
+			},
+		},
+		{ // session that reused a user branch in a LINKED worktree — the worktree
+			// is removed but the branch must NOT be pruned via ANY path (#1 fix).
+			Title:    "reused",
+			Path:     repo,
+			Liveness: session.LiveReady,
+			Worktree: session.GitWorktreeData{
+				RepoPath: repo, WorktreePath: reusedWT, ExternalWorktree: false,
+				BranchName: "reused-linked", BranchCreatedByUs: boolPtr(false),
 			},
 		},
 	}
@@ -167,8 +186,8 @@ func TestFactoryReset_WipesEverythingKeepsRepoAndConfig(t *testing.T) {
 	// seeded mock repo (never the repo the test binary runs from).
 	t.Chdir(t.TempDir())
 
-	repo, liveWT := seedMockRepo(t, home)
-	cfgBytes := seedAFState(t, home, repo, liveWT)
+	repo, liveWT, reusedWT := seedMockRepo(t, home)
+	cfgBytes := seedAFState(t, home, repo, liveWT, reusedWT)
 	repoID := config.RepoIDFromRoot(repo)
 
 	// --- Plan reflects the real scope ---
@@ -176,8 +195,8 @@ func TestFactoryReset_WipesEverythingKeepsRepoAndConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("planFactoryReset: %v", err)
 	}
-	if plan.sessions != 2 {
-		t.Errorf("sessions = %d, want 2", plan.sessions)
+	if plan.sessions != 3 {
+		t.Errorf("sessions = %d, want 3 (live, here, reused)", plan.sessions)
 	}
 	if plan.archived != 1 {
 		t.Errorf("archived = %d, want 1", plan.archived)
@@ -185,11 +204,14 @@ func TestFactoryReset_WipesEverythingKeepsRepoAndConfig(t *testing.T) {
 	if plan.tasks != 2 {
 		t.Errorf("tasks = %d, want 2", plan.tasks)
 	}
-	if plan.worktrees != 2 {
-		t.Errorf("worktrees = %d, want 2 (external --here tree excluded)", plan.worktrees)
+	if plan.worktrees != 3 {
+		t.Errorf("worktrees = %d, want 3 (live, arch, reused; external --here excluded)", plan.worktrees)
 	}
 	if plan.branchCount() != 2 {
-		t.Errorf("branchCount = %d, want 2 (my-feature excluded)", plan.branchCount())
+		t.Errorf("branchCount = %d, want 2 (my-feature + reused-linked excluded)", plan.branchCount())
+	}
+	if len(plan.corruptRepoIDs) != 0 {
+		t.Errorf("corruptRepoIDs = %v, want none", plan.corruptRepoIDs)
 	}
 	if _, ok := plan.repoRoots[repo]; !ok || len(plan.repoRoots) != 1 {
 		t.Errorf("repoRoots = %v, want exactly {%s}", plan.repoRoots, repo)
@@ -200,9 +222,9 @@ func TestFactoryReset_WipesEverythingKeepsRepoAndConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("executeFactoryReset: %v", err)
 	}
-	if summary.sessions != 2 || summary.archived != 1 || summary.tasks != 2 ||
-		summary.worktrees != 2 || summary.branches != 2 {
-		t.Errorf("summary = %+v, want {2 1 2 2 2}", *summary)
+	if summary.sessions != 3 || summary.archived != 1 || summary.tasks != 2 ||
+		summary.worktrees != 3 || summary.branches != 2 || summary.corrupt != 0 {
+		t.Errorf("summary = %+v, want {3 1 2 3 2 0}", *summary)
 	}
 
 	// --- Everything AF is gone ---
@@ -215,6 +237,7 @@ func TestFactoryReset_WipesEverythingKeepsRepoAndConfig(t *testing.T) {
 	assertGone(t, filepath.Join(home, config.TUIStateFileName))
 	assertGone(t, filepath.Join(home, "tasks.json"))
 	assertGone(t, liveWT)
+	assertGone(t, reusedWT)
 
 	tasks, err := task.LoadTasks()
 	if err != nil {
@@ -232,7 +255,10 @@ func TestFactoryReset_WipesEverythingKeepsRepoAndConfig(t *testing.T) {
 		t.Error("af-session-2 (AF archived) should be deleted")
 	}
 	if !branchExists(repo, "my-feature") {
-		t.Error("my-feature (user branch, reused) must be preserved")
+		t.Error("my-feature (user branch, reused by --here) must be preserved")
+	}
+	if !branchExists(repo, "reused-linked") {
+		t.Error("reused-linked (user branch reused in a LINKED worktree) must be preserved — the #1 fix")
 	}
 	if !branchExists(repo, "master") {
 		t.Error("master must be preserved")
@@ -285,6 +311,137 @@ func assertGone(t *testing.T, path string) {
 	t.Helper()
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Errorf("expected %s to be removed, stat err = %v", path, err)
+	}
+}
+
+// TestFactoryReset_CorruptRecordLeftIntact proves that when a repo's
+// instances.json is unreadable (so BranchCreatedByUs is unknown), reset leaves
+// BOTH the record and its branch intact and reports it — rather than erasing
+// the record while orphaning the branch (Greptile #2).
+func TestFactoryReset_CorruptRecordLeftIntact(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	t.Chdir(t.TempDir())
+
+	repo := t.TempDir()
+	runGit(t, repo, "init", "-q")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("hi"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "add", "-A")
+	runGit(t, repo, "commit", "-q", "-m", "init")
+	runGit(t, repo, "branch", "-M", "master")
+	runGit(t, repo, "branch", "orphan-candidate") // referenced by the unreadable record
+
+	repoID := config.RepoIDFromRoot(repo)
+	instPath, err := config.RepoInstancesPath(repoID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, instPath, "{ this is not valid json for instances")
+
+	cfgBytes := []byte("listen_addr = \"127.0.0.1:9000\"\n")
+	writeFileBytes(t, filepath.Join(home, "config.toml"), cfgBytes)
+
+	plan, err := planFactoryReset()
+	if err != nil {
+		t.Fatalf("planFactoryReset: %v", err)
+	}
+	if len(plan.corruptRepoIDs) != 1 || plan.corruptRepoIDs[0] != repoID {
+		t.Fatalf("corruptRepoIDs = %v, want [%s]", plan.corruptRepoIDs, repoID)
+	}
+	if plan.branchCount() != 0 {
+		t.Errorf("branchCount = %d, want 0 (no branches pruned from unreadable records)", plan.branchCount())
+	}
+
+	summary, err := executeFactoryReset(plan)
+	if err != nil {
+		t.Fatalf("executeFactoryReset: %v", err)
+	}
+	if summary.corrupt != 1 {
+		t.Errorf("summary.corrupt = %d, want 1", summary.corrupt)
+	}
+
+	// The unreadable record file is NOT erased.
+	if _, err := os.Stat(instPath); err != nil {
+		t.Errorf("corrupt instances.json was erased: %v", err)
+	}
+	// Its branch is NOT orphaned/deleted.
+	if !branchExists(repo, "orphan-candidate") {
+		t.Error("branch of an unreadable record must be preserved (not orphaned or deleted)")
+	}
+	if !branchExists(repo, "master") {
+		t.Error("master must be preserved")
+	}
+	// Config still intact.
+	if got, _ := os.ReadFile(filepath.Join(home, "config.toml")); string(got) != string(cfgBytes) {
+		t.Error("config.toml changed")
+	}
+}
+
+// TestFactoryReset_ResilientPartialFailure proves that a worktree-cleanup error
+// on one repo does NOT abort the reset: the other repo's worktree is still
+// removed, state/tasks are still cleared, and the error is surfaced (Greptile
+// #3). A follow-up run with the bad root removed completes cleanly.
+func TestFactoryReset_ResilientPartialFailure(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	t.Chdir(t.TempDir())
+
+	repo, liveWT, reusedWT := seedMockRepo(t, home)
+	seedAFState(t, home, repo, liveWT, reusedWT)
+
+	state := config.LoadState()
+	storage, err := session.NewStorage(state, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Inject a failing repo root ("" errors in RemoveWorktreesForRepo) alongside
+	// the real one, to force the collect-and-continue path deterministically.
+	plan := &resetPlan{
+		configDir: home,
+		storage:   storage,
+		sessions:  3, archived: 1, tasks: 2, worktrees: 3,
+		repoRoots: map[string]struct{}{"": {}, repo: {}},
+		branches:  map[string][]string{repo: {"af-session-1", "af-session-2"}},
+	}
+
+	summary, err := executeFactoryReset(plan)
+	if err == nil {
+		t.Fatal("expected a joined error from the failing repo root, got nil")
+	}
+	if !strings.Contains(err.Error(), "cleanup worktrees") {
+		t.Errorf("error should name the worktree-cleanup failure: %v", err)
+	}
+
+	// Despite the failure, the reset reached a consistent end state.
+	assertGone(t, liveWT)
+	assertGone(t, reusedWT)
+	assertGone(t, filepath.Join(home, "instances"))
+	assertGone(t, filepath.Join(home, config.StateFileName))
+	assertGone(t, filepath.Join(home, "tasks.json"))
+	if tasks, _ := task.LoadTasks(); len(tasks) != 0 {
+		t.Errorf("tasks not cleared despite partial failure: %d", len(tasks))
+	}
+	// The good repo's AF branches were still pruned; user branches preserved.
+	if branchExists(repo, "af-session-1") || branchExists(repo, "af-session-2") {
+		t.Error("AF branches should be pruned even when another repo failed")
+	}
+	if !branchExists(repo, "reused-linked") || !branchExists(repo, "my-feature") {
+		t.Error("user branches must be preserved")
+	}
+	if summary.branches != 2 {
+		t.Errorf("branches = %d, want 2", summary.branches)
+	}
+
+	// A clean re-run (no bad root) is a no-op that succeeds.
+	plan2, err := planFactoryReset()
+	if err != nil {
+		t.Fatalf("re-run planFactoryReset: %v", err)
+	}
+	if _, err := executeFactoryReset(plan2); err != nil {
+		t.Fatalf("re-run should complete cleanly, got: %v", err)
 	}
 }
 

--- a/commands/reset_test.go
+++ b/commands/reset_test.go
@@ -340,6 +340,17 @@ func TestFactoryReset_CorruptRecordLeftIntact(t *testing.T) {
 	}
 	writeFile(t, instPath, "{ this is not valid json for instances")
 
+	// The corrupt repo also has archived worktrees on disk: its preserved
+	// record points at them, so they must survive too (no dangling reference).
+	corruptArchive := filepath.Join(home, "archived", repoID, "sess")
+	writeFile(t, filepath.Join(corruptArchive, "keep"), "x")
+
+	// A DELETED repo's archived worktrees (an orphaned archive with no readable
+	// record) must still be removed.
+	deletedRepoID := config.RepoIDFromRoot(t.TempDir())
+	deletedArchive := filepath.Join(home, "archived", deletedRepoID, "sess")
+	writeFile(t, filepath.Join(deletedArchive, "gone"), "x")
+
 	cfgBytes := []byte("listen_addr = \"127.0.0.1:9000\"\n")
 	writeFileBytes(t, filepath.Join(home, "config.toml"), cfgBytes)
 
@@ -366,6 +377,12 @@ func TestFactoryReset_CorruptRecordLeftIntact(t *testing.T) {
 	if _, err := os.Stat(instPath); err != nil {
 		t.Errorf("corrupt instances.json was erased: %v", err)
 	}
+	// The preserved record's archived worktree is KEPT (no dangling reference).
+	if _, err := os.Stat(corruptArchive); err != nil {
+		t.Errorf("preserved record's archived worktree was deleted (dangling reference): %v", err)
+	}
+	// A deleted/orphaned repo's archive IS removed.
+	assertGone(t, filepath.Join(home, "archived", deletedRepoID))
 	// Its branch is NOT orphaned/deleted.
 	if !branchExists(repo, "orphan-candidate") {
 		t.Error("branch of an unreadable record must be preserved (not orphaned or deleted)")

--- a/commands/reset_test.go
+++ b/commands/reset_test.go
@@ -1,0 +1,326 @@
+package commands
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/task"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@example.com",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@example.com",
+		"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v in %s failed: %v\n%s", args, dir, err, out)
+	}
+	return string(out)
+}
+
+func branchExists(dir, branch string) bool {
+	cmd := exec.Command("git", "-C", dir, "show-ref", "--verify", "--quiet", "refs/heads/"+branch)
+	return cmd.Run() == nil
+}
+
+// seedMockRepo builds a real git repo with master, an AF live-session worktree
+// (branch af-session-1), an AF-created archived-session branch (af-session-2),
+// and a user branch (my-feature) that an AF --here session reused. It returns
+// the repo root and the live worktree path.
+func seedMockRepo(t *testing.T, home string) (repo, liveWT string) {
+	t.Helper()
+	repo = t.TempDir()
+	runGit(t, repo, "init", "-q")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("hi"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "add", "-A")
+	runGit(t, repo, "commit", "-q", "-m", "init")
+	runGit(t, repo, "branch", "-M", "master")
+	runGit(t, repo, "branch", "my-feature")   // user branch (reused by a --here session)
+	runGit(t, repo, "branch", "af-session-2") // AF-created, archived (no live worktree)
+
+	liveWT = filepath.Join(home, "worktrees", "live")
+	runGit(t, repo, "worktree", "add", "-q", "-b", "af-session-1", liveWT)
+	return repo, liveWT
+}
+
+// seedAFState writes instance records, tasks, archived dirs, state files, and a
+// preserved config into the throwaway AF home. Returns the config.toml bytes so
+// callers can assert they are untouched.
+func seedAFState(t *testing.T, home, repo, liveWT string) []byte {
+	t.Helper()
+	repoID := config.RepoIDFromRoot(repo)
+
+	recs := []session.InstanceData{
+		{ // live AF session — AF created af-session-1, live worktree present
+			Title:    "live",
+			Path:     repo,
+			Liveness: session.LiveReady,
+			Worktree: session.GitWorktreeData{
+				RepoPath: repo, WorktreePath: liveWT,
+				BranchName: "af-session-1", BranchCreatedByUs: boolPtr(true),
+			},
+		},
+		{ // archived AF session — AF created af-session-2, worktree relocated
+			Title:    "arch",
+			Path:     repo,
+			Liveness: session.LiveArchived,
+			Worktree: session.GitWorktreeData{
+				RepoPath: repo, WorktreePath: filepath.Join(home, "archived", repoID, "arch"),
+				BranchName: "af-session-2", BranchCreatedByUs: boolPtr(true),
+			},
+		},
+		{ // --here session that reused the user's branch — must NOT be pruned
+			Title:    "here",
+			Path:     repo,
+			Liveness: session.LiveReady,
+			Worktree: session.GitWorktreeData{
+				RepoPath: repo, WorktreePath: repo, ExternalWorktree: true,
+				BranchName: "my-feature", BranchCreatedByUs: boolPtr(false),
+			},
+		},
+	}
+	raw, err := json.Marshal(recs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := config.SaveRepoInstances(repoID, raw); err != nil {
+		t.Fatal(err)
+	}
+
+	// Archived worktree dir on disk (its record is the only pointer to it).
+	archDir := filepath.Join(home, "archived", repoID, "arch")
+	if err := os.MkdirAll(archDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(archDir, "keep"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Two scheduled tasks.
+	for _, id := range []string{"task-one", "task-two"} {
+		if err := task.AddTask(task.Task{
+			ID: id, CronExpr: "* * * * *", Prompt: "do", Enabled: true, ProjectPath: repo,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// State files and daemon-runtime dirs that must be wiped.
+	writeFile(t, filepath.Join(home, config.StateFileName), `{"schema_version":1,"help_screens_seen":7}`)
+	writeFile(t, filepath.Join(home, config.TUIStateFileName), `{}`)
+	mkdir(t, filepath.Join(home, "events"))
+	mkdir(t, filepath.Join(home, "logs"))
+	mkdir(t, filepath.Join(home, "locks"))
+
+	// Config that must be PRESERVED.
+	cfgBytes := []byte("listen_addr = \"127.0.0.1:9876\"\n[defaults]\nprogram = \"codex\"\n")
+	writeFileBytes(t, filepath.Join(home, "config.toml"), cfgBytes)
+	// Per-repo config (remote_hooks etc.) is user config, also preserved.
+	mkdir(t, filepath.Join(home, "repos", repoID))
+	writeFile(t, filepath.Join(home, "repos", repoID, "config.json"), `{"remote_hooks":{}}`)
+
+	return cfgBytes
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	writeFileBytes(t, path, []byte(content))
+}
+
+func writeFileBytes(t *testing.T, path string, content []byte) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mkdir(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFactoryReset_WipesEverythingKeepsRepoAndConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	// Neutralize the cwd-repo injection in planFactoryReset: chdir to a non-git
+	// dir so ResolveMainRepoRoot adds nothing, keeping the wipe scoped to our
+	// seeded mock repo (never the repo the test binary runs from).
+	t.Chdir(t.TempDir())
+
+	repo, liveWT := seedMockRepo(t, home)
+	cfgBytes := seedAFState(t, home, repo, liveWT)
+	repoID := config.RepoIDFromRoot(repo)
+
+	// --- Plan reflects the real scope ---
+	plan, err := planFactoryReset()
+	if err != nil {
+		t.Fatalf("planFactoryReset: %v", err)
+	}
+	if plan.sessions != 2 {
+		t.Errorf("sessions = %d, want 2", plan.sessions)
+	}
+	if plan.archived != 1 {
+		t.Errorf("archived = %d, want 1", plan.archived)
+	}
+	if plan.tasks != 2 {
+		t.Errorf("tasks = %d, want 2", plan.tasks)
+	}
+	if plan.worktrees != 2 {
+		t.Errorf("worktrees = %d, want 2 (external --here tree excluded)", plan.worktrees)
+	}
+	if plan.branchCount() != 2 {
+		t.Errorf("branchCount = %d, want 2 (my-feature excluded)", plan.branchCount())
+	}
+	if _, ok := plan.repoRoots[repo]; !ok || len(plan.repoRoots) != 1 {
+		t.Errorf("repoRoots = %v, want exactly {%s}", plan.repoRoots, repo)
+	}
+
+	// --- Execute ---
+	summary, err := executeFactoryReset(plan)
+	if err != nil {
+		t.Fatalf("executeFactoryReset: %v", err)
+	}
+	if summary.sessions != 2 || summary.archived != 1 || summary.tasks != 2 ||
+		summary.worktrees != 2 || summary.branches != 2 {
+		t.Errorf("summary = %+v, want {2 1 2 2 2}", *summary)
+	}
+
+	// --- Everything AF is gone ---
+	assertGone(t, filepath.Join(home, "instances"))
+	assertGone(t, filepath.Join(home, "archived"))
+	assertGone(t, filepath.Join(home, "events"))
+	assertGone(t, filepath.Join(home, "logs"))
+	assertGone(t, filepath.Join(home, "locks"))
+	assertGone(t, filepath.Join(home, config.StateFileName))
+	assertGone(t, filepath.Join(home, config.TUIStateFileName))
+	assertGone(t, filepath.Join(home, "tasks.json"))
+	assertGone(t, liveWT)
+
+	tasks, err := task.LoadTasks()
+	if err != nil {
+		t.Fatalf("LoadTasks after reset: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Errorf("tasks after reset = %d, want 0", len(tasks))
+	}
+
+	// --- AF branches pruned, user branches untouched ---
+	if branchExists(repo, "af-session-1") {
+		t.Error("af-session-1 (AF live) should be deleted")
+	}
+	if branchExists(repo, "af-session-2") {
+		t.Error("af-session-2 (AF archived) should be deleted")
+	}
+	if !branchExists(repo, "my-feature") {
+		t.Error("my-feature (user branch, reused) must be preserved")
+	}
+	if !branchExists(repo, "master") {
+		t.Error("master must be preserved")
+	}
+
+	// --- Real repo + .git intact ---
+	if _, err := os.Stat(filepath.Join(repo, ".git")); err != nil {
+		t.Errorf("repo .git missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(repo, "README.md")); err != nil {
+		t.Errorf("repo working tree file missing: %v", err)
+	}
+
+	// --- Config preserved byte-for-byte; per-repo config preserved ---
+	got, err := os.ReadFile(filepath.Join(home, "config.toml"))
+	if err != nil {
+		t.Fatalf("config.toml missing after reset: %v", err)
+	}
+	if string(got) != string(cfgBytes) {
+		t.Errorf("config.toml changed:\n got %q\nwant %q", got, cfgBytes)
+	}
+	if _, err := os.Stat(filepath.Join(home, "repos", repoID, "config.json")); err != nil {
+		t.Errorf("per-repo config removed: %v", err)
+	}
+
+	// --- Idempotent: a second reset is a clean no-op ---
+	plan2, err := planFactoryReset()
+	if err != nil {
+		t.Fatalf("second planFactoryReset: %v", err)
+	}
+	if plan2.sessions != 0 || plan2.archived != 0 || plan2.tasks != 0 || plan2.branchCount() != 0 {
+		t.Errorf("second plan not empty: %+v", *plan2)
+	}
+	summary2, err := executeFactoryReset(plan2)
+	if err != nil {
+		t.Fatalf("second executeFactoryReset: %v", err)
+	}
+	if summary2.sessions != 0 || summary2.archived != 0 || summary2.tasks != 0 ||
+		summary2.worktrees != 0 || summary2.branches != 0 {
+		t.Errorf("second summary not empty: %+v", *summary2)
+	}
+	// Config still intact after the second run.
+	got2, _ := os.ReadFile(filepath.Join(home, "config.toml"))
+	if string(got2) != string(cfgBytes) {
+		t.Errorf("config.toml changed on second reset")
+	}
+}
+
+func assertGone(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("expected %s to be removed, stat err = %v", path, err)
+	}
+}
+
+func TestResetConfirmed(t *testing.T) {
+	tests := []struct {
+		name     string
+		force    bool
+		isTTY    bool
+		input    string
+		want     bool
+		wantNote bool // prints the non-TTY notice
+	}{
+		{name: "force bypasses prompt", force: true, isTTY: true, want: true},
+		{name: "force bypasses even non-tty", force: true, isTTY: false, want: true},
+		{name: "non-tty skips prompt but proceeds", isTTY: false, want: true, wantNote: true},
+		{name: "tty exact WIPE proceeds", isTTY: true, input: "WIPE\n", want: true},
+		{name: "tty WIPE with spaces proceeds", isTTY: true, input: "  WIPE  \n", want: true},
+		{name: "tty lowercase aborts", isTTY: true, input: "wipe\n", want: false},
+		{name: "tty wrong word aborts", isTTY: true, input: "yes\n", want: false},
+		{name: "tty empty aborts", isTTY: true, input: "\n", want: false},
+		{name: "tty EOF aborts", isTTY: true, input: "", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var out strings.Builder
+			got, err := resetConfirmed(tc.force, tc.isTTY, strings.NewReader(tc.input), &out)
+			if err != nil {
+				t.Fatalf("resetConfirmed: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("proceed = %v, want %v", got, tc.want)
+			}
+			hasNote := strings.Contains(out.String(), "stdin is not a terminal")
+			if hasNote != tc.wantNote {
+				t.Errorf("non-tty notice printed = %v, want %v (out=%q)", hasNote, tc.wantNote, out.String())
+			}
+		})
+	}
+}

--- a/commands/reset_test.go
+++ b/commands/reset_test.go
@@ -396,10 +396,68 @@ func TestFactoryReset_CorruptRecordLeftIntact(t *testing.T) {
 	}
 }
 
-// TestFactoryReset_ResilientPartialFailure proves that a worktree-cleanup error
-// on one repo does NOT abort the reset: the other repo's worktree is still
-// removed, state/tasks are still cleared, and the error is surfaced (Greptile
-// #3). A follow-up run with the bad root removed completes cleanly.
+// TestFactoryReset_PreservesUserWorktreesWithNoAFRecords proves the reset never
+// removes the user's own manually-created linked worktrees: a repo with a
+// user-created worktree and NO AF records is left entirely alone, even when it
+// is the current directory (the pre-#1736 cwd fallback would have bulk-removed
+// it). AF-created worktrees are still removed (covered by the end-to-end test).
+func TestFactoryReset_PreservesUserWorktreesWithNoAFRecords(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+
+	repo := t.TempDir()
+	runGit(t, repo, "init", "-q")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("hi"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "add", "-A")
+	runGit(t, repo, "commit", "-q", "-m", "init")
+	runGit(t, repo, "branch", "-M", "master")
+
+	// A worktree the USER created by hand, OUTSIDE the AF home, with no AF record.
+	userWT := filepath.Join(t.TempDir(), "user-wt")
+	runGit(t, repo, "worktree", "add", "-q", "-b", "user-branch", userWT)
+
+	writeFileBytes(t, filepath.Join(home, "config.toml"), []byte("listen_addr = \"127.0.0.1:9000\"\n"))
+
+	// chdir INTO the repo: the removed cwd fallback would have grabbed it here.
+	t.Chdir(repo)
+
+	plan, err := planFactoryReset()
+	if err != nil {
+		t.Fatalf("planFactoryReset: %v", err)
+	}
+	if len(plan.worktreeTargets) != 0 {
+		t.Errorf("worktreeTargets = %v, want none (no AF records)", plan.worktreeTargets)
+	}
+	if _, ok := plan.repoRoots[repo]; ok {
+		t.Error("a repo with no AF records must not be pulled in (cwd fallback dropped)")
+	}
+
+	if _, err := executeFactoryReset(plan); err != nil {
+		t.Fatalf("executeFactoryReset: %v", err)
+	}
+
+	// The user's worktree, its contents, and its branch are untouched.
+	if _, err := os.Stat(filepath.Join(userWT, "README.md")); err != nil {
+		t.Errorf("user-created worktree was removed: %v", err)
+	}
+	if !branchExists(repo, "user-branch") {
+		t.Error("user-branch must be preserved")
+	}
+	if !branchExists(repo, "master") {
+		t.Error("master must be preserved")
+	}
+	// The worktree is still registered and functional.
+	if out := runGit(t, repo, "worktree", "list", "--porcelain"); !strings.Contains(out, userWT) {
+		t.Errorf("user worktree no longer registered:\n%s", out)
+	}
+}
+
+// TestFactoryReset_ResilientPartialFailure proves a mid-reset step failure does
+// NOT abort the wipe: worktrees are still removed, AF branches still pruned,
+// state still cleared, and the error is surfaced (Greptile #3). A follow-up run
+// after the failure is cleared completes cleanly.
 func TestFactoryReset_ResilientPartialFailure(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("AGENT_FACTORY_HOME", home)
@@ -408,42 +466,36 @@ func TestFactoryReset_ResilientPartialFailure(t *testing.T) {
 	repo, liveWT, reusedWT := seedMockRepo(t, home)
 	seedAFState(t, home, repo, liveWT, reusedWT)
 
-	state := config.LoadState()
-	storage, err := session.NewStorage(state, "")
+	// Plan while everything is well-formed.
+	plan, err := planFactoryReset()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("planFactoryReset: %v", err)
 	}
 
-	// Inject a failing repo root ("" errors in RemoveWorktreesForRepo) alongside
-	// the real one, to force the collect-and-continue path deterministically.
-	plan := &resetPlan{
-		configDir: home,
-		storage:   storage,
-		sessions:  3, archived: 1, tasks: 2, worktrees: 3,
-		repoRoots: map[string]struct{}{"": {}, repo: {}},
-		branches:  map[string][]string{repo: {"af-session-1", "af-session-2"}},
+	// Inject a deterministic, uid-independent failure into a mid-reset step:
+	// replace tasks.json with a NON-EMPTY directory, so DeleteAllTasks's
+	// os.Remove fails with ENOTEMPTY (which not even root can rmdir).
+	tasksPath := filepath.Join(home, "tasks.json")
+	if err := os.Remove(tasksPath); err != nil {
+		t.Fatal(err)
 	}
+	mkdir(t, filepath.Join(tasksPath, "x"))
 
 	summary, err := executeFactoryReset(plan)
 	if err == nil {
-		t.Fatal("expected a joined error from the failing repo root, got nil")
+		t.Fatal("expected a joined error from the failing task-delete step, got nil")
 	}
-	if !strings.Contains(err.Error(), "cleanup worktrees") {
-		t.Errorf("error should name the worktree-cleanup failure: %v", err)
+	if !strings.Contains(err.Error(), "reset tasks") {
+		t.Errorf("error should name the failing step: %v", err)
 	}
 
-	// Despite the failure, the reset reached a consistent end state.
+	// Despite the failure, everything else reached a consistent end state.
 	assertGone(t, liveWT)
 	assertGone(t, reusedWT)
 	assertGone(t, filepath.Join(home, "instances"))
 	assertGone(t, filepath.Join(home, config.StateFileName))
-	assertGone(t, filepath.Join(home, "tasks.json"))
-	if tasks, _ := task.LoadTasks(); len(tasks) != 0 {
-		t.Errorf("tasks not cleared despite partial failure: %d", len(tasks))
-	}
-	// The good repo's AF branches were still pruned; user branches preserved.
 	if branchExists(repo, "af-session-1") || branchExists(repo, "af-session-2") {
-		t.Error("AF branches should be pruned even when another repo failed")
+		t.Error("AF branches should be pruned even when a later step failed")
 	}
 	if !branchExists(repo, "reused-linked") || !branchExists(repo, "my-feature") {
 		t.Error("user branches must be preserved")
@@ -452,7 +504,10 @@ func TestFactoryReset_ResilientPartialFailure(t *testing.T) {
 		t.Errorf("branches = %d, want 2", summary.branches)
 	}
 
-	// A clean re-run (no bad root) is a no-op that succeeds.
+	// Clear the injected failure and re-run: a clean run completes.
+	if err := os.RemoveAll(tasksPath); err != nil {
+		t.Fatal(err)
+	}
 	plan2, err := planFactoryReset()
 	if err != nil {
 		t.Fatalf("re-run planFactoryReset: %v", err)

--- a/commands/root.go
+++ b/commands/root.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 	"text/tabwriter"
@@ -12,12 +11,10 @@ import (
 	"github.com/sachiniyer/agent-factory/api"
 	"github.com/sachiniyer/agent-factory/apiclient"
 	"github.com/sachiniyer/agent-factory/app"
-	cmdutil "github.com/sachiniyer/agent-factory/cmd"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/log"
-	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/git"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 
@@ -128,73 +125,8 @@ Full guide: https://sachiniyer.github.io/agent-factory/remote-tcp-auth/`,
 		},
 	}
 
-	resetCmd = &cobra.Command{
-		Use:   "reset",
-		Short: "Reset all stored instances",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			log.Initialize(false)
-			defer log.Close()
-
-			// Kill any daemon that's running first. StopDaemon only finds
-			// daemons that wrote a PID file; a pre-1.0.69 daemon leaves none,
-			// so only claim success when we actually stopped one (#937).
-			stopped, err := daemon.StopDaemon()
-			if err != nil {
-				return err
-			}
-			if stopped {
-				fmt.Println("daemon has been stopped")
-			} else {
-				fmt.Println("No managed daemon was stopped (no PID file, or the recorded process was already gone). " +
-					"If an old daemon is still running (e.g. one built from source as `agent-factory --daemon`), " +
-					"stop it with: pkill -f -- '--daemon'")
-			}
-
-			// Clean up resources before deleting storage records
-			if err := tmux.CleanupSessions(cmdutil.MakeExecutor()); err != nil {
-				return fmt.Errorf("failed to cleanup tmux sessions: %w", err)
-			}
-			fmt.Println("Tmux sessions have been cleaned up")
-
-			// Clean worktrees across ALL repos with stored instances, not
-			// just the current repo. Storage is global (DeleteAllInstances
-			// removes records for every repo), so worktree cleanup must match
-			// that scope — otherwise repos we don't run reset from are left
-			// with orphaned worktrees/branches (issue #265).
-			state := config.LoadState()
-			storage, err := session.NewStorage(state, "")
-			if err != nil {
-				return fmt.Errorf("failed to initialize storage: %w", err)
-			}
-
-			repoRoots, err := storage.CollectRepoRoots()
-			if err != nil {
-				return fmt.Errorf("failed to collect repo roots: %w", err)
-			}
-			// Ensure the current repo (if any) is cleaned even when it has
-			// no stored instances, matching prior behavior.
-			if cwd, cwdErr := os.Getwd(); cwdErr == nil {
-				if root, rerr := config.ResolveMainRepoRoot(cwd); rerr == nil {
-					repoRoots[root] = struct{}{}
-				}
-			}
-
-			for root := range repoRoots {
-				if err := git.CleanupWorktreesForRepo(root); err != nil {
-					return fmt.Errorf("failed to cleanup worktrees for %s: %w", root, err)
-				}
-			}
-			fmt.Println("Worktrees have been cleaned up")
-
-			// Delete storage last, after resources are cleaned up
-			if err := storage.DeleteAllInstances(); err != nil {
-				return fmt.Errorf("failed to reset storage: %w", err)
-			}
-			fmt.Println("Storage has been reset successfully")
-
-			return nil
-		},
-	}
+	// resetCmd lives in reset.go (the factory-reset flow is substantial: typed
+	// confirmation, plan/summary, task+archive+branch wipe).
 
 	debugCmd = &cobra.Command{
 		Use:   "debug",

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -31,7 +31,7 @@ Run `af <command> --help` for the same information at the terminal. For a narrat
 - [`af keys`](#af-keys) — Show the effective TUI key bindings (defaults plus [keys] rebinds)
 - [`af projects`](#af-projects) — Manage projects (repo groupings of sessions)
 - [`af projects delete`](#af-projects-delete) — Delete a project: archive its sessions and remove it (reversibly)
-- [`af reset`](#af-reset) — Reset all stored instances
+- [`af reset`](#af-reset) — Factory-reset Agent Factory: remove ALL AF sessions, tasks, worktrees, and state (keeps your repos + config)
 - [`af sessions`](#af-sessions) — Manage sessions
 - [`af sessions archive`](#af-sessions-archive) — Finish with a session by archiving it for later restore
 - [`af sessions attach`](#af-sessions-attach) — Attach to a session's terminal
@@ -93,7 +93,7 @@ af [flags]
 - [`af doctor`](#af-doctor) — Diagnose setup, daemon health, and leaked session resources
 - [`af keys`](#af-keys) — Show the effective TUI key bindings (defaults plus [keys] rebinds)
 - [`af projects`](#af-projects) — Manage projects (repo groupings of sessions)
-- [`af reset`](#af-reset) — Reset all stored instances
+- [`af reset`](#af-reset) — Factory-reset Agent Factory: remove ALL AF sessions, tasks, worktrees, and state (keeps your repos + config)
 - [`af sessions`](#af-sessions) — Manage sessions
 - [`af tasks`](#af-tasks) — Manage tasks
 - [`af token`](#af-token) — Manage the daemon's bearer token for the direct-TCP API
@@ -825,11 +825,34 @@ af projects delete [repo]
 
 ## af reset
 
-Reset all stored instances
+Factory-reset Agent Factory: remove ALL AF sessions, tasks, worktrees, and state (keeps your repos + config)
+
+Factory-reset Agent Factory.
+
+Removes every AF-created resource — all sessions (live and archived), all
+scheduled cron/watch tasks, all AF worktrees, the AF session branches AF
+created, and all stored state — returning AF to a clean slate.
+
+KEEPS your real git repositories (working tree, .git, and your own branches),
+and KEEPS the daemon configuration (config.toml: listen_addr, defaults,
+root_agents, update_channel, and per-repo config). After the wipe the
+supervised daemon restarts with empty session/task state and the same config;
+root_agents in config re-register, which is intended.
+
+This is IRREVERSIBLE. You will be asked to type WIPE to confirm. Pass --yes
+(or --force) to skip the prompt for scripted use; when stdin is not a terminal
+the prompt is skipped automatically so existing scripted callers do not hang.
 
 ```
-af reset
+af reset [flags]
 ```
+
+**Flags**
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--force` |  | Alias for --yes: skip the typed WIPE confirmation |
+| `-y`, `--yes` |  | Skip the typed WIPE confirmation (for non-interactive/scripted use) |
 
 **Global flags**
 

--- a/session/git/branch_prune.go
+++ b/session/git/branch_prune.go
@@ -1,0 +1,54 @@
+package git
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// LocalBranchExists reports whether `branch` exists as a local ref in the repo
+// at `repoRoot`. A missing repo, a non-git path, or an empty argument all
+// report false (there is simply no such branch to act on).
+func LocalBranchExists(repoRoot, branch string) bool {
+	if repoRoot == "" || branch == "" {
+		return false
+	}
+	if _, err := os.Stat(repoRoot); err != nil {
+		return false
+	}
+	check := exec.Command("git", "-C", repoRoot, "show-ref", "--verify", "--quiet", "refs/heads/"+branch)
+	return check.Run() == nil
+}
+
+// DeleteLocalBranch force-deletes the local branch `branch` in the repo at
+// `repoRoot`, but only if it currently exists. It reports whether a branch was
+// actually deleted.
+//
+// It exists for the factory-reset path (`af reset`, #1736): CleanupWorktreesForRepo
+// prunes only the branches of worktrees still registered with git, so an
+// ARCHIVED session's branch — whose worktree was relocated out to
+// <AF_HOME>/archived/ and is no longer a live worktree of the repo — survives
+// that pass. The caller enumerates exactly the branches AF created for its own
+// sessions (GitWorktreeData.BranchCreatedByUs) and deletes each here, so the
+// user's own branches (master/main/their feature branches, and any branch a
+// session merely reused) are never touched.
+//
+// A missing branch is not an error (idempotent: a second `af reset` is a
+// clean no-op), and neither is a non-git or missing repo path — those are
+// logged-and-skipped by the caller's surrounding cleanup and there is simply
+// nothing to prune. `git branch -D` force-deletes regardless of merge state,
+// which is intended: AF session branches may be unmerged work the reset is
+// deliberately discarding.
+func DeleteLocalBranch(repoRoot, branch string) (bool, error) {
+	// Only delete a branch that exists, so a missing ref (already pruned by
+	// worktree cleanup, or never created) is a silent no-op rather than a
+	// `git branch -D` error.
+	if !LocalBranchExists(repoRoot, branch) {
+		return false, nil
+	}
+	del := exec.Command("git", "-C", repoRoot, "branch", "-D", branch)
+	if out, err := del.CombinedOutput(); err != nil {
+		return false, fmt.Errorf("git branch -D %s in %s: %w: %s", branch, repoRoot, err, string(out))
+	}
+	return true, nil
+}

--- a/session/git/branch_prune.go
+++ b/session/git/branch_prune.go
@@ -25,8 +25,8 @@ func LocalBranchExists(repoRoot, branch string) bool {
 // actually deleted.
 //
 // It is the SOLE branch-deletion path of the factory reset (`af reset`, #1736):
-// reset removes worktree directories via RemoveWorktreesForRepo, which deletes
-// no branches, and then deletes branches ONLY through here. The caller
+// reset removes worktree directories via RemoveWorktreeDir, which deletes no
+// branches, and then deletes branches ONLY through here. The caller
 // enumerates exactly the branches AF created for its own sessions — live and
 // archived — gated on GitWorktreeData.BranchCreatedByUs, so the user's own
 // branches (master/main/their feature branches, and any branch a session merely

--- a/session/git/branch_prune.go
+++ b/session/git/branch_prune.go
@@ -24,14 +24,14 @@ func LocalBranchExists(repoRoot, branch string) bool {
 // `repoRoot`, but only if it currently exists. It reports whether a branch was
 // actually deleted.
 //
-// It exists for the factory-reset path (`af reset`, #1736): CleanupWorktreesForRepo
-// prunes only the branches of worktrees still registered with git, so an
-// ARCHIVED session's branch — whose worktree was relocated out to
-// <AF_HOME>/archived/ and is no longer a live worktree of the repo — survives
-// that pass. The caller enumerates exactly the branches AF created for its own
-// sessions (GitWorktreeData.BranchCreatedByUs) and deletes each here, so the
-// user's own branches (master/main/their feature branches, and any branch a
-// session merely reused) are never touched.
+// It is the SOLE branch-deletion path of the factory reset (`af reset`, #1736):
+// reset removes worktree directories via RemoveWorktreesForRepo, which deletes
+// no branches, and then deletes branches ONLY through here. The caller
+// enumerates exactly the branches AF created for its own sessions — live and
+// archived — gated on GitWorktreeData.BranchCreatedByUs, so the user's own
+// branches (master/main/their feature branches, and any branch a session merely
+// reused) are never touched, even for a session whose worktree was still
+// registered with git.
 //
 // A missing branch is not an error (idempotent: a second `af reset` is a
 // clean no-op), and neither is a non-git or missing repo path — those are

--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -410,40 +410,63 @@ func (g *GitWorktree) Prune() error {
 	return nil
 }
 
+// RemoveWorktreeDir removes a SINGLE worktree directory that AF created for a
+// session in the repo at repoRoot, and prunes the registry. It deletes NO
+// branch. It reports whether a directory was actually removed.
+//
+// This is the factory reset's only worktree-removal path (`af reset`, #1736):
+// reset must remove ONLY the worktrees AF created — identified by the paths in
+// AF's own session records — and NEVER the user's manually-created linked
+// worktrees, so there is deliberately no per-repo bulk pass. It also refuses to
+// touch the main worktree: a worktreePath that resolves to repoRoot (an
+// external `--here` session's tree) is a no-op. Branch deletion is handled
+// separately, gated on BranchCreatedByUs, so this never removes a branch either.
+//
+// A missing directory is not an error (idempotent: a second reset is a clean
+// no-op); the registry is still pruned so a stale entry cannot later block a
+// `git branch -D`.
+func RemoveWorktreeDir(repoRoot, worktreePath string) (bool, error) {
+	if repoRoot == "" || worktreePath == "" {
+		return false, nil
+	}
+	// Never remove the main repo/working tree (e.g. an external --here session
+	// whose worktree path IS the user's repo).
+	if filepath.Clean(repoRoot) == filepath.Clean(worktreePath) {
+		return false, nil
+	}
+
+	// If the directory is already gone, just prune any stale registry entry so a
+	// later branch delete isn't blocked, and report nothing removed.
+	if _, err := os.Stat(worktreePath); os.IsNotExist(err) {
+		_ = exec.Command("git", "-C", repoRoot, "worktree", "prune").Run()
+		return false, nil
+	}
+
+	// Remove the worktree FIRST (git refuses to delete a branch checked out in a
+	// worktree). Fall back to a manual directory removal if git can't (e.g. the
+	// worktree was relocated to the archive and is no longer registered).
+	if err := exec.Command("git", "-C", repoRoot, "worktree", "remove", "-f", worktreePath).Run(); err != nil {
+		log.ErrorLog.Printf("failed to remove worktree %s: %v", worktreePath, err)
+		if rmErr := os.RemoveAll(worktreePath); rmErr != nil {
+			return false, fmt.Errorf("remove worktree dir %s: %w", worktreePath, rmErr)
+		}
+	}
+
+	// Prune stale metadata so a subsequent `git branch -D` for this session's
+	// branch isn't blocked by a lingering worktree registration.
+	if err := exec.Command("git", "-C", repoRoot, "worktree", "prune").Run(); err != nil {
+		log.ErrorLog.Printf("failed to prune worktrees for %s: %v", repoRoot, err)
+	}
+	return true, nil
+}
+
 // CleanupWorktreesForRepo removes all worktrees and their associated branches
 // for the given repo root. The main worktree (the repo itself) is preserved.
 // The repoRoot must be the main repo path; callers should resolve linked
 // worktree paths to the main repo root before invoking this function.
 func CleanupWorktreesForRepo(repoRoot string) error {
-	_, err := cleanupWorktreesForRepo(repoRoot, true)
-	return err
-}
-
-// RemoveWorktreesForRepo removes every linked worktree DIRECTORY of the given
-// repo root (never the main worktree) and prunes the registry, but deletes NO
-// branches. It returns the number of worktree directories removed.
-//
-// It exists for the factory reset (`af reset`, #1736): reset must NEVER delete
-// a branch AF did not create, so branch deletion is funneled entirely through
-// the BranchCreatedByUs-guarded path (session/git.DeleteLocalBranch), and this
-// bulk worktree pass is forbidden from touching any branch. A session that
-// reused a pre-existing user branch has a linked worktree here but
-// BranchCreatedByUs=false; letting the bulk `git branch -D` run (as
-// CleanupWorktreesForRepo does) would delete the user's branch — the data-loss
-// bug this split closes.
-func RemoveWorktreesForRepo(repoRoot string) (int, error) {
-	return cleanupWorktreesForRepo(repoRoot, false)
-}
-
-// cleanupWorktreesForRepo lists and removes every linked worktree of repoRoot
-// (never the main worktree, which is index 0). When deleteBranches is true it
-// also force-deletes each removed worktree's branch (the historical
-// CleanupWorktreesForRepo behavior); when false it removes only the directories
-// and prunes, leaving every branch intact. Returns the count of worktree
-// directories removed.
-func cleanupWorktreesForRepo(repoRoot string, deleteBranches bool) (int, error) {
 	if repoRoot == "" {
-		return 0, fmt.Errorf("repo root is empty")
+		return fmt.Errorf("repo root is empty")
 	}
 
 	// Skip cleanup if the repo path no longer exists on disk. `af reset`
@@ -452,9 +475,9 @@ func cleanupWorktreesForRepo(repoRoot string, deleteBranches bool) (int, error) 
 	// the entire reset before subsequent repos (and DeleteAllInstances) ran.
 	if _, err := os.Stat(repoRoot); os.IsNotExist(err) {
 		log.WarningLog.Printf("skipping cleanup for deleted repo: %s", repoRoot)
-		return 0, nil
+		return nil
 	} else if err != nil {
-		return 0, fmt.Errorf("failed to access repo path: %w", err)
+		return fmt.Errorf("failed to access repo path: %w", err)
 	}
 
 	// List all worktrees from the repo. If the path exists but is no longer a
@@ -465,7 +488,7 @@ func cleanupWorktreesForRepo(repoRoot string, deleteBranches bool) (int, error) 
 	output, err := cmd.Output()
 	if err != nil {
 		log.WarningLog.Printf("skipping cleanup for non-git path: %s", repoRoot)
-		return 0, nil
+		return nil
 	}
 
 	// Parse output to get (worktreePath, branchName) pairs.
@@ -498,7 +521,6 @@ func cleanupWorktreesForRepo(repoRoot string, deleteBranches bool) (int, error) 
 	}
 
 	// Skip the first entry (the main worktree / repo itself)
-	removed := 0
 	if len(worktrees) > 1 {
 		for _, wt := range worktrees[1:] {
 			// Remove the worktree FIRST (git refuses to delete a branch checked out in a worktree)
@@ -514,7 +536,6 @@ func cleanupWorktreesForRepo(repoRoot string, deleteBranches bool) (int, error) 
 					log.ErrorLog.Printf("failed to remove worktree directory %s: %v", wt.path, err)
 				}
 			}
-			removed++
 
 			// Prune stale worktree metadata (best-effort) BEFORE deleting the
 			// branch. When the `git worktree remove -f` above fails and we fall
@@ -525,13 +546,8 @@ func cleanupWorktreesForRepo(repoRoot string, deleteBranches bool) (int, error) 
 				log.ErrorLog.Printf("failed to prune worktree metadata before deleting branch %s: %v", wt.branch, err)
 			}
 
-			// THEN delete the branch — but ONLY when the caller opted in. The
-			// factory reset (RemoveWorktreesForRepo, deleteBranches=false) must
-			// not let this unguarded bulk path delete a branch: it can't tell an
-			// AF-created branch from one the session merely reused, so it would
-			// destroy the user's branch. Reset deletes branches separately, gated
-			// on BranchCreatedByUs (#1736).
-			if deleteBranches && wt.branch != "" {
+			// THEN delete the branch
+			if wt.branch != "" {
 				deleteCmd := exec.Command("git", "-C", repoRoot, "branch", "-D", wt.branch)
 				if err := deleteCmd.Run(); err != nil {
 					log.ErrorLog.Printf("failed to delete branch %s: %v", wt.branch, err)
@@ -543,8 +559,8 @@ func cleanupWorktreesForRepo(repoRoot string, deleteBranches bool) (int, error) 
 	// Prune worktree references
 	pruneCmd := exec.Command("git", "-C", repoRoot, "worktree", "prune")
 	if _, err := pruneCmd.Output(); err != nil {
-		return removed, fmt.Errorf("failed to prune worktrees: %w", err)
+		return fmt.Errorf("failed to prune worktrees: %w", err)
 	}
 
-	return removed, nil
+	return nil
 }

--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -415,8 +415,35 @@ func (g *GitWorktree) Prune() error {
 // The repoRoot must be the main repo path; callers should resolve linked
 // worktree paths to the main repo root before invoking this function.
 func CleanupWorktreesForRepo(repoRoot string) error {
+	_, err := cleanupWorktreesForRepo(repoRoot, true)
+	return err
+}
+
+// RemoveWorktreesForRepo removes every linked worktree DIRECTORY of the given
+// repo root (never the main worktree) and prunes the registry, but deletes NO
+// branches. It returns the number of worktree directories removed.
+//
+// It exists for the factory reset (`af reset`, #1736): reset must NEVER delete
+// a branch AF did not create, so branch deletion is funneled entirely through
+// the BranchCreatedByUs-guarded path (session/git.DeleteLocalBranch), and this
+// bulk worktree pass is forbidden from touching any branch. A session that
+// reused a pre-existing user branch has a linked worktree here but
+// BranchCreatedByUs=false; letting the bulk `git branch -D` run (as
+// CleanupWorktreesForRepo does) would delete the user's branch — the data-loss
+// bug this split closes.
+func RemoveWorktreesForRepo(repoRoot string) (int, error) {
+	return cleanupWorktreesForRepo(repoRoot, false)
+}
+
+// cleanupWorktreesForRepo lists and removes every linked worktree of repoRoot
+// (never the main worktree, which is index 0). When deleteBranches is true it
+// also force-deletes each removed worktree's branch (the historical
+// CleanupWorktreesForRepo behavior); when false it removes only the directories
+// and prunes, leaving every branch intact. Returns the count of worktree
+// directories removed.
+func cleanupWorktreesForRepo(repoRoot string, deleteBranches bool) (int, error) {
 	if repoRoot == "" {
-		return fmt.Errorf("repo root is empty")
+		return 0, fmt.Errorf("repo root is empty")
 	}
 
 	// Skip cleanup if the repo path no longer exists on disk. `af reset`
@@ -425,9 +452,9 @@ func CleanupWorktreesForRepo(repoRoot string) error {
 	// the entire reset before subsequent repos (and DeleteAllInstances) ran.
 	if _, err := os.Stat(repoRoot); os.IsNotExist(err) {
 		log.WarningLog.Printf("skipping cleanup for deleted repo: %s", repoRoot)
-		return nil
+		return 0, nil
 	} else if err != nil {
-		return fmt.Errorf("failed to access repo path: %w", err)
+		return 0, fmt.Errorf("failed to access repo path: %w", err)
 	}
 
 	// List all worktrees from the repo. If the path exists but is no longer a
@@ -438,7 +465,7 @@ func CleanupWorktreesForRepo(repoRoot string) error {
 	output, err := cmd.Output()
 	if err != nil {
 		log.WarningLog.Printf("skipping cleanup for non-git path: %s", repoRoot)
-		return nil
+		return 0, nil
 	}
 
 	// Parse output to get (worktreePath, branchName) pairs.
@@ -471,6 +498,7 @@ func CleanupWorktreesForRepo(repoRoot string) error {
 	}
 
 	// Skip the first entry (the main worktree / repo itself)
+	removed := 0
 	if len(worktrees) > 1 {
 		for _, wt := range worktrees[1:] {
 			// Remove the worktree FIRST (git refuses to delete a branch checked out in a worktree)
@@ -486,6 +514,7 @@ func CleanupWorktreesForRepo(repoRoot string) error {
 					log.ErrorLog.Printf("failed to remove worktree directory %s: %v", wt.path, err)
 				}
 			}
+			removed++
 
 			// Prune stale worktree metadata (best-effort) BEFORE deleting the
 			// branch. When the `git worktree remove -f` above fails and we fall
@@ -496,8 +525,13 @@ func CleanupWorktreesForRepo(repoRoot string) error {
 				log.ErrorLog.Printf("failed to prune worktree metadata before deleting branch %s: %v", wt.branch, err)
 			}
 
-			// THEN delete the branch
-			if wt.branch != "" {
+			// THEN delete the branch — but ONLY when the caller opted in. The
+			// factory reset (RemoveWorktreesForRepo, deleteBranches=false) must
+			// not let this unguarded bulk path delete a branch: it can't tell an
+			// AF-created branch from one the session merely reused, so it would
+			// destroy the user's branch. Reset deletes branches separately, gated
+			// on BranchCreatedByUs (#1736).
+			if deleteBranches && wt.branch != "" {
 				deleteCmd := exec.Command("git", "-C", repoRoot, "branch", "-D", wt.branch)
 				if err := deleteCmd.Run(); err != nil {
 					log.ErrorLog.Printf("failed to delete branch %s: %v", wt.branch, err)
@@ -509,8 +543,8 @@ func CleanupWorktreesForRepo(repoRoot string) error {
 	// Prune worktree references
 	pruneCmd := exec.Command("git", "-C", repoRoot, "worktree", "prune")
 	if _, err := pruneCmd.Output(); err != nil {
-		return fmt.Errorf("failed to prune worktrees: %w", err)
+		return removed, fmt.Errorf("failed to prune worktrees: %w", err)
 	}
 
-	return nil
+	return removed, nil
 }

--- a/task/task.go
+++ b/task/task.go
@@ -263,6 +263,28 @@ func RemoveTask(id string) error {
 	})
 }
 
+// DeleteAllTasks removes the entire task store, leaving zero scheduled
+// cron/watch tasks. It is the wipe primitive for `af reset` (#1736): the whole
+// file is removed rather than emptied, and LoadTasks treats a missing file as
+// an empty list, so the next daemon start comes up with no schedules.
+// Idempotent — a missing store is a clean no-op, so a second `af reset` does
+// not error.
+//
+// The caller (`af reset`) stops the daemon first, so no live writer holds the
+// store; taking the file lock still guards against a concurrent CLI writer.
+func DeleteAllTasks() error {
+	path, err := getTasksPathFn()
+	if err != nil {
+		return err
+	}
+	return config.WithFileLock(path, func() error {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to remove tasks file: %w", err)
+		}
+		return nil
+	})
+}
+
 func GetTask(id string) (*Task, error) {
 	if err := ValidateTaskID(id); err != nil {
 		return nil, err


### PR DESCRIPTION
Closes #1736.

Extends the existing `af reset` command from a partial, **unconfirmed**
"delete stored instances" into a **complete, guarded factory reset** that
returns Agent Factory to a clean slate. This extends the command in place
(no new duplicate command).

## Removed (in addition to what `af reset` already did)

`af reset` previously stopped the daemon, cleaned tmux, cleaned live
worktrees + their branches, and deleted instance records. It now **also**:

- **All archived sessions** — the `archived/<repoID>/` worktree dirs and
  their records (previously orphaned on disk).
- **All scheduled tasks** — new `task.DeleteAllTasks()` removes `tasks.json`
  (cron + watch tasks).
- **AF-created session branches that survived worktree cleanup** — an
  archived session's worktree is relocated out of the repo, so
  `CleanupWorktreesForRepo` never prunes its branch. We prune those, driven
  by each record's `GitWorktreeData.BranchCreatedByUs`, so **only branches
  AF created for its own sessions** are deleted.
- **Remaining AF state** — `instances/`, `events/`, `logs/`, `locks/`,
  `state.json`, `tui-state.json`.

## Preserved (must NOT be touched)

- **Your real git repositories** — working tree, `.git`, and your own
  branches (master/main/feature). A branch a session merely *reused*
  (`--here`, `BranchCreatedByUs=false`) and any branch with no record are
  never pruned.
- **Daemon config** — `config.toml` (`listen_addr`, `defaults`,
  `root_agents`, `update_channel`) and per-repo config (`repos/`, e.g.
  `remote_hooks`). `root_agents` legitimately re-register from config on the
  next daemon start — that's config, not state.
- **Daemon identity** — token/TLS material is left intact so already-configured
  remote clients keep working.

## Confirmation (typed WIPE)

Before anything destructive, `af reset` prints a summary of exactly what
will be removed vs preserved, then requires the user to type **`WIPE`**
(exact, case-sensitive) at an interactive prompt.

- `--yes` / `--force` bypasses the prompt for scripted use.
- A **non-TTY stdin skips the prompt automatically** (but still prints the
  summary) so existing scripted `af reset` callers do not hang.
- **Idempotent** — a second run is a clean no-op.

On completion it prints counts of what was removed (N sessions, archived,
tasks, worktrees, branches) and what was preserved.

## Daemon

As before, the daemon is stopped first; after the wipe the supervised
daemon restarts with empty session/task state and the **same config**.

## Structure / tests

The reset flow moves to `commands/reset.go`, with the destructive core
(`planFactoryReset` / `executeFactoryReset`) split from the daemon/tmux
teardown and the interactive prompt so it is unit-testable. Tests
(`commands/reset_test.go`) isolate to a throwaway `$AGENT_FACTORY_HOME` +
mock git repo (never the real home or this repo) and cover:

- seeded sessions + archived + tasks + worktrees + AF branches → all
  removed, state empty;
- the real repo dir + `.git` + the user's own branches (`master`,
  reused `my-feature`) **untouched**;
- `config.toml` unchanged byte-for-byte, per-repo config preserved;
- typed-WIPE required interactively, `--yes`/`--force` bypasses, non-TTY
  skips the prompt but still wipes;
- running twice = clean no-op.

## Scope

CLI-first, as requested. No destructive "wipe everything" control added to
the TUI/web in this PR — a factory-reset button is dangerous and not
clearly requested; a guarded UI affordance is noted as possible future
work.

## Gates

`make test-container` (all packages green), `make tui-driver-selftest`
(25/25), `go build ./...`, `gofmt -l .` clean, `golangci-lint run --fast`,
`deadcode -test ./...`, `scripts/gen-docs.sh` (regenerated), and
`scripts/lint-file-length.sh` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)