### PR TITLE
fix(session): tear down re-provisioned sandbox when agent Start fails on restore (#1726)

### DIFF
--- a/session/archive_sandbox.go
+++ b/session/archive_sandbox.go
@@ -85,7 +85,14 @@ func (i *Instance) RestoreSandbox() error {
 	if err := i.reprovisionRemote(); err != nil {
 		return err
 	}
-	return i.Start(true)
+	if err := i.Start(true); err != nil {
+		// The sandbox is up but the agent failed to launch on it — reap the
+		// freshly provisioned sandbox and clear its wiring so a retry re-provisions
+		// from a clean state instead of stranding a container/remote (#1726).
+		i.teardownAfterStartFailure()
+		return err
+	}
+	return nil
 }
 
 // recoverSandbox re-establishes a Lost/restoring sandbox session in place: it
@@ -101,6 +108,11 @@ func recoverSandbox(i *Instance) error {
 		return err
 	}
 	if err := i.Start(true); err != nil {
+		// Same leak guard as RestoreSandbox: reap the fresh sandbox and reset the
+		// remote wiring on a Start failure so the Lost-restore loop's next retry
+		// re-provisions cleanly rather than stacking a second sandbox on the first
+		// still-running one (#1726).
+		i.teardownAfterStartFailure()
 		return err
 	}
 	_ = i.Transition(ConfirmLive())
@@ -189,6 +201,26 @@ func (i *Instance) resetRemoteRuntime() {
 	i.remoteClient = nil
 	i.runtimeTeardown = nil
 	i.mu.Unlock()
+}
+
+// teardownAfterStartFailure reaps a freshly re-provisioned sandbox after the
+// agent Start failed on the restore/recover path, then clears the remote-runtime
+// wiring (#1726). It mirrors reprovisionRemote's bind-failure discipline —
+// run the stored Teardown so the container/remote is reclaimed — and reuses the
+// SAME i.mu ownership as bindProvisionResult/resetRemoteRuntime (#1729): the
+// teardown is read under i.mu.RLock and invoked OUTSIDE the lock (it may block on
+// docker/ssh I/O), then resetRemoteRuntime clears remoteClient/runtimeTeardown/
+// agentSrv together so a retry starts from a clean, unbound state and never
+// stacks a second sandbox on the first. runtimeTeardown is sync.Once-guarded, so
+// a later Kill re-running it is a harmless no-op.
+func (i *Instance) teardownAfterStartFailure() {
+	i.mu.RLock()
+	teardown := i.runtimeTeardown
+	i.mu.RUnlock()
+	if teardown != nil {
+		_ = teardown()
+	}
+	i.resetRemoteRuntime()
 }
 
 // isSandboxBackendType reports whether a persisted backend Type() names a

--- a/session/archive_sandbox_test.go
+++ b/session/archive_sandbox_test.go
@@ -1,11 +1,153 @@
 package session
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// failingStartBackend stands in for a freshly re-provisioned sandbox whose agent
+// Start fails: it embeds FakeBackend for the full interface and overrides Start to
+// error immediately, plus Type() so the instance stays classified as its sandbox
+// runtime. Used to drive the #1726 Start-failure leak guard on restore/recover.
+type failingStartBackend struct {
+	*FakeBackend
+	typ string
+}
+
+func (b *failingStartBackend) Start(*Instance, bool) error { return fmt.Errorf("start failed") }
+func (b *failingStartBackend) Type() string                { return b.typ }
+
+// countingRuntime is a Runtime that provisions a failing-Start sandbox and tracks
+// how many sandboxes are live at once, so a test can prove the Start-failure guard
+// reaps each sandbox before a retry provisions the next — never stacking two
+// (#1726). Its Teardown decrements the live count; Provision records the peak.
+type countingRuntime struct {
+	endpoint   *AgentServerEndpoint
+	typ        string
+	provisions int
+	live       int
+	maxLive    int
+}
+
+func (r *countingRuntime) Provision(ProvisionSpec) (ProvisionResult, error) {
+	r.provisions++
+	r.live++
+	if r.live > r.maxLive {
+		r.maxLive = r.live
+	}
+	return ProvisionResult{
+		Backend:  &failingStartBackend{FakeBackend: NewFakeBackend(), typ: r.typ},
+		Endpoint: r.endpoint,
+		Teardown: func() error { r.live--; return nil },
+	}, nil
+}
+
+// assertRemoteRuntimeReset pins that the Start-failure teardown left the instance
+// unbound (no half-bound remote wiring), so a retry re-provisions from clean state.
+func assertRemoteRuntimeReset(t *testing.T, i *Instance) {
+	t.Helper()
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	assert.Nil(t, i.remoteClient, "remoteClient cleared after Start-failure teardown")
+	assert.Nil(t, i.runtimeTeardown, "runtimeTeardown cleared after Start-failure teardown")
+	assert.Nil(t, i.agentSrv, "cached agent-server cleared after Start-failure teardown")
+}
+
+// TestRecoverSandbox_TeardownOnStartFailure proves the #1726 fix in recoverSandbox:
+// when reprovisionRemote succeeds but Start fails, the freshly provisioned sandbox
+// is torn down (its Teardown IS called) and the remote runtime state is reset, so
+// the container/remote is reclaimed rather than leaked.
+func TestRecoverSandbox_TeardownOnStartFailure(t *testing.T) {
+	var tornDown bool
+	ep := &AgentServerEndpoint{URL: "wss://127.0.0.1:9", Token: "tok", Fingerprint: validFingerprint}
+	fake := fakeRuntime{res: ProvisionResult{
+		Backend:  &failingStartBackend{FakeBackend: NewFakeBackend(), typ: "docker"},
+		Endpoint: ep,
+		Teardown: func() error { tornDown = true; return nil },
+	}}
+
+	prev := runtimeRegistry[BackendDocker]
+	runtimeRegistry[BackendDocker] = func() Runtime { return fake }
+	defer func() { runtimeRegistry[BackendDocker] = prev }()
+
+	i := &Instance{
+		Title:    "s",
+		Path:     t.TempDir(),
+		Branch:   "root/s",
+		backend:  newInertSandboxBackend("docker"),
+		liveness: LiveArchived,
+	}
+
+	err := recoverSandbox(i)
+	require.Error(t, err, "Start must fail for this test")
+	assert.Contains(t, err.Error(), "start failed", "error from failingStartBackend")
+	assert.True(t, tornDown, "Teardown must be called when Start fails after reprovisionRemote succeeds")
+	assertRemoteRuntimeReset(t, i)
+}
+
+// TestRestoreSandbox_TeardownOnStartFailure proves the same #1726 fix in
+// RestoreSandbox (the archive-restore mechanic).
+func TestRestoreSandbox_TeardownOnStartFailure(t *testing.T) {
+	var tornDown bool
+	ep := &AgentServerEndpoint{URL: "wss://127.0.0.1:9", Token: "tok", Fingerprint: validFingerprint}
+	fake := fakeRuntime{res: ProvisionResult{
+		Backend:  &failingStartBackend{FakeBackend: NewFakeBackend(), typ: "docker"},
+		Endpoint: ep,
+		Teardown: func() error { tornDown = true; return nil },
+	}}
+
+	prev := runtimeRegistry[BackendDocker]
+	runtimeRegistry[BackendDocker] = func() Runtime { return fake }
+	defer func() { runtimeRegistry[BackendDocker] = prev }()
+
+	i := &Instance{
+		Title:    "s",
+		Path:     t.TempDir(),
+		Branch:   "root/s",
+		backend:  newInertSandboxBackend("docker"),
+		liveness: LiveArchived,
+	}
+
+	err := i.RestoreSandbox()
+	require.Error(t, err, "Start must fail for this test")
+	assert.Contains(t, err.Error(), "start failed", "error from failingStartBackend")
+	assert.True(t, tornDown, "Teardown must be called when Start fails after reprovisionRemote succeeds")
+	assertRemoteRuntimeReset(t, i)
+}
+
+// TestRecoverSandbox_RetryDoesNotStackSandboxes proves the retry half of #1726:
+// after a Start-failure reaps the first sandbox and resets the wiring, a second
+// recover attempt provisions a fresh sandbox WITHOUT the first still running — the
+// Lost-restore loop never stacks two sandboxes. The countingRuntime asserts at most
+// one sandbox is ever live at once across both attempts.
+func TestRecoverSandbox_RetryDoesNotStackSandboxes(t *testing.T) {
+	rt := &countingRuntime{
+		endpoint: &AgentServerEndpoint{URL: "wss://127.0.0.1:9", Token: "tok", Fingerprint: validFingerprint},
+		typ:      "docker",
+	}
+	prev := runtimeRegistry[BackendDocker]
+	runtimeRegistry[BackendDocker] = func() Runtime { return rt }
+	defer func() { runtimeRegistry[BackendDocker] = prev }()
+
+	i := &Instance{
+		Title:    "s",
+		Path:     t.TempDir(),
+		Branch:   "root/s",
+		backend:  newInertSandboxBackend("docker"),
+		liveness: LiveArchived,
+	}
+
+	require.Error(t, recoverSandbox(i), "first attempt: Start fails")
+	assertRemoteRuntimeReset(t, i)
+	require.Error(t, recoverSandbox(i), "retry: Start fails again")
+
+	assert.Equal(t, 2, rt.provisions, "each attempt provisions a fresh sandbox")
+	assert.Equal(t, 0, rt.live, "no sandbox left running after both attempts")
+	assert.Equal(t, 1, rt.maxLive, "the first sandbox is reaped before the retry provisions the second — never two at once")
+}
 
 // TestBackendKindForType pins the persisted-type → runtime-kind mapping the
 // re-provision path keys on: the off-box runtimes are re-provisionable


### PR DESCRIPTION
Fixes #1726 (Detail bug — sandbox resource leak on the restore path, introduced in #1666 / commit 15441ce6).

## The leak
`recoverSandbox(i)` and `(i *Instance) RestoreSandbox()` in `session/archive_sandbox.go` both:
1. `reprovisionRemote()` — provision a FRESH docker/ssh/hook sandbox and store its `Teardown` via `bindProvisionResult`, then
2. `i.Start(true)` — relaunch the agent on it.

If **Start fails**, they returned the error **without tearing down the just-provisioned sandbox** — its `Teardown` was never called, so the container / remote directory leaked. Worse: the daemon's Lost-restore retry loop then provisioned a **second** sandbox while the first was still running.

`reprovisionRemote` already reaps on `bindProvisionResult` failure (`if res.Teardown != nil { _ = res.Teardown() }`) — this applies the **same discipline** to the later Start-failure path.

## The fix
Both paths now reap the fresh sandbox on Start failure via a shared helper `teardownAfterStartFailure`:
- runs the stored `runtimeTeardown` (idempotent — sync.Once-guarded), then
- `resetRemoteRuntime()` clears `remoteClient` / `runtimeTeardown` / `agentSrv` together, so a **retry re-provisions from clean, unbound state** instead of double-provisioning.

Respects the **#1739** `i.mu` ownership of the remote-runtime fields: the teardown is read under `i.mu.RLock`, invoked **outside** the lock (it may block on docker/ssh I/O), then `resetRemoteRuntime` clears the fields atomically. No cross-mutex access reintroduced.

## Adjacent-site audit
The only other provision-then-Start site is the **create** path (`NewInstance` + `finishCreateStart` in `daemon/manager_create.go`), which already reaps via `instance.Kill()` on Start failure. The in-sandbox headless workspace (`daemon/agentserver_headless.go`) uses `BackendLocal` — nothing off-box to leak. No other leak sites.

## Tests (load-bearing)
`session/archive_sandbox_test.go`:
- `TestRecoverSandbox_TeardownOnStartFailure` — Start fails after a successful re-provision → asserts `Teardown` **is** invoked and the remote runtime state is reset.
- `TestRestoreSandbox_TeardownOnStartFailure` — same for `RestoreSandbox`.
- `TestRecoverSandbox_RetryDoesNotStackSandboxes` — two recover attempts; a `countingRuntime` asserts **at most one sandbox is ever live at once** (the first is reaped before the retry provisions the second).

All three **fail without the fix** (verified via `git stash`), pass with it.

## Gates
- `go build ./...` ✅
- `gofmt -l .` clean ✅
- `golangci-lint run --timeout=3m --fast` ✅
- `deadcode -test ./...` clean ✅
- `go test -race` session pkg ✅
- `make test-container` (full suite) ✅
- `make tui-driver-selftest` 25/25 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)