### PR TITLE
fix(cli): surface remote daemon errors instead of masking them with local-disk fallback (#1679, #1681)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -10,12 +10,41 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sachiniyer/agent-factory/apiclient"
 	"github.com/sachiniyer/agent-factory/apiproto"
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
+
+// snapshotRead runs the non-spawning daemon snapshot and reports whether the
+// caller may fall back to a local disk scan. It is the single seam every
+// daemon→disk read path (listSessions, getSessionByTitle, whoamiSession,
+// getSessionByTitleInScope) routes through so the "remote reads never fall back
+// to disk" contract cannot be silently reintroduced at a new read site (#1679,
+// #1681). On daemon success it returns (data, false, nil). On error it returns:
+//   - remote target: (nil, false, err) — surface the real error; a remote daemon
+//     has no local disk to fall back to, and a bad token must not be masked by a
+//     same-machine disk read (docs/remote-tcp-auth.md, #1592 Phase 3 PR4).
+//   - local target:  (nil, true, err)  — the caller runs its own disk scan.
+//
+// Callers switch on err == nil for the success path and, on error, consult the
+// fallBackToDisk flag before touching disk. This keeps each caller's exact local
+// disk-fallback behavior (diskListSessions / diskWhoami / findInstanceByTitle,
+// including their distinct not-found and corrupt-repo errors) while centralizing
+// the one decision that must never regress: whether disk may be read at all.
+func snapshotRead(req daemon.SnapshotRequest) (data []session.InstanceData, fallBackToDisk bool, err error) {
+	data, err = snapshotViaDaemon(req)
+	if err == nil {
+		return data, false, nil
+	}
+	if apiclient.IsRemoteTarget() {
+		return nil, false, err
+	}
+	return nil, true, err
+}
 
 // Shared flags
 var (

--- a/api/sessions.go
+++ b/api/sessions.go
@@ -56,13 +56,11 @@ var (
 // is reachable (#1029 PR 2). Both paths return the same shape sorted by
 // (repoID, title), so scripts see a consistent order regardless of source.
 func listSessions(repoID string) ([]session.InstanceData, error) {
-	data, err := snapshotViaDaemon(daemon.SnapshotRequest{RepoID: repoID})
+	data, fallBack, err := snapshotRead(daemon.SnapshotRequest{RepoID: repoID})
 	if err == nil {
 		return data, nil
 	}
-	// A remote daemon has no local disk to fall back to, and a bad token must not
-	// be masked by a same-machine disk read — surface the error (#1592 Phase 3 PR4).
-	if apiclient.IsRemoteTarget() {
+	if !fallBack {
 		return nil, err
 	}
 	return diskListSessions(repoID)
@@ -73,7 +71,7 @@ func listSessions(repoID string) ([]session.InstanceData, error) {
 // reachable (#1029 PR 2). When a live snapshot is available the daemon is
 // authoritative: a miss returns not-found without re-reading disk.
 func getSessionByTitle(title string) (*session.InstanceData, error) {
-	data, err := snapshotViaDaemon(daemon.SnapshotRequest{})
+	data, fallBack, err := snapshotRead(daemon.SnapshotRequest{})
 	if err == nil {
 		for i := range data {
 			if data[i].Title == title {
@@ -83,8 +81,8 @@ func getSessionByTitle(title string) (*session.InstanceData, error) {
 		// Mirror findInstanceByTitle's clean-miss error so output is unchanged.
 		return nil, fmt.Errorf("instance %q %w", title, errTitleNotFound)
 	}
-	// Remote target: no local disk fallback; surface the error (see listSessions).
-	if apiclient.IsRemoteTarget() {
+	// Remote target: no local disk fallback; surface the error (see snapshotRead).
+	if !fallBack {
 		return nil, err
 	}
 	got, _, err := findInstanceByTitle(title)
@@ -95,13 +93,19 @@ func getSessionByTitle(title string) (*session.InstanceData, error) {
 // the daemon's live snapshot and falling back to the disk scan when no daemon
 // is reachable (#1029 PR 2).
 func whoamiSession(tmuxName string) (*session.InstanceData, error) {
-	if data, err := snapshotViaDaemon(daemon.SnapshotRequest{}); err == nil {
+	data, fallBack, err := snapshotRead(daemon.SnapshotRequest{})
+	if err == nil {
 		for i := range data {
 			if data[i].TmuxName == tmuxName {
 				return &data[i], nil
 			}
 		}
 		return nil, fmt.Errorf("no Agent Factory session found for tmux session %q", tmuxName)
+	}
+	// Remote target: no local disk fallback; surface the daemon error (e.g. a 401
+	// from a bad token) instead of masking it with a same-machine disk scan (#1681).
+	if !fallBack {
+		return nil, err
 	}
 	return diskWhoami(tmuxName)
 }

--- a/api/sessions_snapshot_test.go
+++ b/api/sessions_snapshot_test.go
@@ -6,10 +6,21 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sachiniyer/agent-factory/apiclient"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/session"
 )
+
+// remoteTarget points the CLI read path at a remote daemon for the duration of a
+// test (so apiclient.IsRemoteTarget() reports true) and restores the prior value
+// on cleanup. Without a daemonURL the read path is a LOCAL unix-socket target.
+func remoteTarget(t *testing.T) {
+	t.Helper()
+	prev := apiclient.FlagDaemonURL
+	apiclient.FlagDaemonURL = "wss://remote.example.com"
+	t.Cleanup(func() { apiclient.FlagDaemonURL = prev })
+}
 
 // stubSnapshot swaps snapshotViaDaemon for the duration of a test so the
 // list/get/whoami read paths can be exercised against a canned daemon snapshot
@@ -258,6 +269,203 @@ func TestWhoamiSession_DiskFallback(t *testing.T) {
 	got, err := whoamiSession("af_mine_agent")
 	if err != nil {
 		t.Fatalf("whoamiSession disk fallback: %v", err)
+	}
+	if got.Title != "mine" {
+		t.Fatalf("got %q, want mine", got.Title)
+	}
+}
+
+// --- Remote-target error surfacing (#1679, #1681) ------------------------------
+//
+// These lock in the contract from docs/remote-tcp-auth.md: when targeting a
+// remote daemon, a snapshot error (bad token → 401, or unreachable daemon →
+// network error) is surfaced verbatim rather than being masked by a
+// same-machine disk scan (there is no local disk on the other end). The disk is
+// deliberately seeded with a MATCHING session so a passing test proves the
+// error won over the misleading local hit. Local (unix-socket) targets keep
+// today's disk-fallback behavior unchanged — the paired *_LocalDiskFallback*
+// tests prove that.
+
+// TestSnapshotRead_RemoteVsLocalBranch is a direct test of the shared seam:
+// remote → surface err, no disk; local → signal disk fallback; success → data.
+func TestSnapshotRead_RemoteVsLocalBranch(t *testing.T) {
+	snapErr := errors.New("boom")
+
+	t.Run("remote surfaces error, forbids disk", func(t *testing.T) {
+		remoteTarget(t)
+		stubSnapshot(t, func(daemon.SnapshotRequest) ([]session.InstanceData, error) { return nil, snapErr })
+		data, fallBack, err := snapshotRead(daemon.SnapshotRequest{})
+		if !errors.Is(err, snapErr) {
+			t.Fatalf("want snapErr surfaced, got %v", err)
+		}
+		if fallBack {
+			t.Fatal("remote target must NOT permit disk fallback")
+		}
+		if data != nil {
+			t.Fatalf("want nil data on error, got %v", data)
+		}
+	})
+
+	t.Run("local permits disk fallback", func(t *testing.T) {
+		stubSnapshot(t, func(daemon.SnapshotRequest) ([]session.InstanceData, error) { return nil, snapErr })
+		_, fallBack, err := snapshotRead(daemon.SnapshotRequest{})
+		if !errors.Is(err, snapErr) {
+			t.Fatalf("want snapErr returned, got %v", err)
+		}
+		if !fallBack {
+			t.Fatal("local target must permit disk fallback")
+		}
+	})
+
+	t.Run("success returns data and forbids disk", func(t *testing.T) {
+		live := []session.InstanceData{{Title: "live"}}
+		stubSnapshot(t, func(daemon.SnapshotRequest) ([]session.InstanceData, error) { return live, nil })
+		data, fallBack, err := snapshotRead(daemon.SnapshotRequest{})
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if fallBack {
+			t.Fatal("success must not trigger disk fallback")
+		}
+		if len(data) != 1 || data[0].Title != "live" {
+			t.Fatalf("want live snapshot, got %v", data)
+		}
+	})
+}
+
+// TestGetSessionByTitleInScope_RemoteTargetSurfacesError verifies a remote 401
+// surfaces even though a matching session sits on local disk (#1679, #1681).
+func TestGetSessionByTitleInScope_RemoteTargetSurfacesError(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	remoteTarget(t)
+
+	authErr := errors.New("unauthorized: invalid bearer token")
+	stubSnapshot(t, func(daemon.SnapshotRequest) ([]session.InstanceData, error) { return nil, authErr })
+
+	diskJSON, err := json.Marshal([]session.InstanceData{{Title: "test-session"}})
+	if err != nil {
+		t.Fatalf("marshal disk: %v", err)
+	}
+	if err := config.SaveRepoInstances("some-repo-id", diskJSON); err != nil {
+		t.Fatalf("save disk: %v", err)
+	}
+
+	got, err := getSessionByTitleInScope("some-repo-id", "test-session")
+	if err == nil {
+		t.Fatalf("expected error from daemon auth failure, got session %+v (disk fallback masked it)", got)
+	}
+	if !errors.Is(err, authErr) {
+		t.Fatalf("expected daemon auth error to surface, got: %v", err)
+	}
+}
+
+// TestGetSessionByTitleInScope_RemoteTargetSurfacesNetworkError verifies an
+// unreachable remote daemon surfaces its network error, not "instance not found".
+func TestGetSessionByTitleInScope_RemoteTargetSurfacesNetworkError(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	remoteTarget(t)
+
+	netErr := errors.New("dial tcp 10.0.0.1:443: connect: connection refused")
+	stubSnapshot(t, func(daemon.SnapshotRequest) ([]session.InstanceData, error) { return nil, netErr })
+
+	diskJSON, _ := json.Marshal([]session.InstanceData{{Title: "test-session"}})
+	if err := config.SaveRepoInstances("some-repo-id", diskJSON); err != nil {
+		t.Fatalf("save disk: %v", err)
+	}
+
+	_, err := getSessionByTitleInScope("some-repo-id", "test-session")
+	if !errors.Is(err, netErr) {
+		t.Fatalf("expected network error to surface, got: %v", err)
+	}
+	if errors.Is(err, errTitleNotFound) {
+		t.Fatal("network error must not be masked as instance-not-found")
+	}
+}
+
+// TestGetSessionByTitleInScope_LocalDiskFallbackUnchanged proves the local
+// (unix-socket) target still falls back to disk on snapshot error exactly as
+// before — the fix must not disturb local behavior.
+func TestGetSessionByTitleInScope_LocalDiskFallbackUnchanged(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	// FlagDaemonURL empty => local target.
+	stubSnapshot(t, daemonUnavailable)
+
+	diskJSON, _ := json.Marshal([]session.InstanceData{{Title: "test-session"}})
+	if err := config.SaveRepoInstances("some-repo-id", diskJSON); err != nil {
+		t.Fatalf("save disk: %v", err)
+	}
+
+	got, err := getSessionByTitleInScope("some-repo-id", "test-session")
+	if err != nil {
+		t.Fatalf("local disk fallback should succeed: %v", err)
+	}
+	if got.Title != "test-session" {
+		t.Fatalf("got %q, want test-session", got.Title)
+	}
+}
+
+// TestWhoamiSession_RemoteTargetSurfacesError verifies whoami surfaces a remote
+// 401 even though a matching TmuxName sits on local disk (#1681).
+func TestWhoamiSession_RemoteTargetSurfacesError(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	remoteTarget(t)
+
+	authErr := errors.New("unauthorized: invalid bearer token")
+	stubSnapshot(t, func(daemon.SnapshotRequest) ([]session.InstanceData, error) { return nil, authErr })
+
+	diskJSON, _ := json.Marshal([]session.InstanceData{{Title: "mine", TmuxName: "af_mine_agent"}})
+	if err := config.SaveRepoInstances("repo-x", diskJSON); err != nil {
+		t.Fatalf("save disk: %v", err)
+	}
+
+	got, err := whoamiSession("af_mine_agent")
+	if err == nil {
+		t.Fatalf("expected error from daemon auth failure, got session %+v (disk fallback masked it)", got)
+	}
+	if !errors.Is(err, authErr) {
+		t.Fatalf("expected daemon auth error to surface, got: %v", err)
+	}
+}
+
+// TestWhoamiSession_RemoteTargetSurfacesNetworkError verifies an unreachable
+// remote daemon surfaces its network error from whoami, not "no session found".
+func TestWhoamiSession_RemoteTargetSurfacesNetworkError(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	remoteTarget(t)
+
+	netErr := errors.New("dial tcp 10.0.0.1:443: connect: connection refused")
+	stubSnapshot(t, func(daemon.SnapshotRequest) ([]session.InstanceData, error) { return nil, netErr })
+
+	diskJSON, _ := json.Marshal([]session.InstanceData{{Title: "mine", TmuxName: "af_mine_agent"}})
+	if err := config.SaveRepoInstances("repo-x", diskJSON); err != nil {
+		t.Fatalf("save disk: %v", err)
+	}
+
+	_, err := whoamiSession("af_mine_agent")
+	if !errors.Is(err, netErr) {
+		t.Fatalf("expected network error to surface, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "no Agent Factory session found") {
+		t.Fatal("network error must not be masked as no-session-found")
+	}
+}
+
+// TestWhoamiSession_LocalDiskFallbackUnchanged proves the local target still
+// resolves whoami from disk on snapshot error (mirrors TestWhoamiSession_DiskFallback,
+// paired here with the remote cases to document the intended contrast).
+func TestWhoamiSession_LocalDiskFallbackUnchanged(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	// FlagDaemonURL empty => local target.
+	stubSnapshot(t, daemonUnavailable)
+
+	diskJSON, _ := json.Marshal([]session.InstanceData{{Title: "mine", TmuxName: "af_mine_agent"}})
+	if err := config.SaveRepoInstances("repo-x", diskJSON); err != nil {
+		t.Fatalf("save disk: %v", err)
+	}
+
+	got, err := whoamiSession("af_mine_agent")
+	if err != nil {
+		t.Fatalf("local disk fallback should succeed: %v", err)
 	}
 	if got.Title != "mine" {
 		t.Fatalf("got %q, want mine", got.Title)

--- a/api/sessions_watch.go
+++ b/api/sessions_watch.go
@@ -190,17 +190,18 @@ func getSessionByTitleInScope(repoID, title string) (*session.InstanceData, erro
 	if repoID == "" {
 		return getSessionByTitle(title)
 	}
-	if data, err := snapshotViaDaemon(daemon.SnapshotRequest{RepoID: repoID}); err == nil {
-		for i := range data {
-			if data[i].Title == title {
-				return &data[i], nil
-			}
-		}
-		return nil, fmt.Errorf("instance %q %w", title, errTitleNotFound)
-	}
-	data, err := diskListSessions(repoID)
+	data, fallBack, err := snapshotRead(daemon.SnapshotRequest{RepoID: repoID})
 	if err != nil {
-		return nil, err
+		// Remote target: no local disk fallback; surface the daemon error (e.g. a
+		// 401 from a bad token) instead of masking it as "instance not found" via a
+		// same-machine disk scan (#1679).
+		if !fallBack {
+			return nil, err
+		}
+		data, err = diskListSessions(repoID)
+		if err != nil {
+			return nil, err
+		}
 	}
 	for i := range data {
 		if data[i].Title == title {


### PR DESCRIPTION
## Root cause

PR #1655 added remote-daemon targeting (`--daemon-url` / `AF_DAEMON_URL`, `apiclient.IsRemoteTarget()`) and, per `docs/remote-tcp-auth.md`, established the contract:

> An invalid or missing token is rejected with a **401** … **a remote read surfaces that error rather than silently falling back to a local disk scan** (there is no local disk on the other end).

#1655 applied the `IsRemoteTarget()` guard to `listSessions` and `getSessionByTitle` (api/sessions.go) but **missed two sibling helpers that share the exact same "try daemon snapshot; on ANY error fall back to a local disk scan" shape**:

- `whoamiSession` (api/sessions.go) — used by `af sessions whoami` / `archive --self`.
- `getSessionByTitleInScope` (api/sessions_watch.go) — used by `af sessions watch`; landed 2 days earlier in a5d3aad, so the #1655 sweep didn't cover it.

Against a **remote** daemon with a bad/missing token (401) or an unreachable daemon (network error), the unconditional disk fallback masked the real error as **"instance not found" / "no session found"**, reading stale/misleading same-machine disk data instead. Broken-config only, but it violates documented behavior and makes remote debugging painful.

## Structural fix (not a per-site patch)

Per the standing mandate to design away the bug class rather than patch site-by-site, I extracted **one shared seam** that encodes the "remote reads never fall back to disk" decision, in `api/api.go` next to the disk primitives it complements:

```go
func snapshotRead(req daemon.SnapshotRequest) (data []session.InstanceData, fallBackToDisk bool, err error) {
	data, err = snapshotViaDaemon(req)
	if err == nil {
		return data, false, nil          // success: data, no disk
	}
	if apiclient.IsRemoteTarget() {
		return nil, false, err           // remote: surface the real error, NEVER disk
	}
	return nil, true, err                // local: caller runs its own disk scan
}
```

**All four** daemon→disk read paths now route through it: `listSessions`, `getSessionByTitle`, `whoamiSession`, `getSessionByTitleInScope`. The single decision that must never regress — *may disk be read at all?* — lives in exactly one place, so a new read site that uses the seam inherits the guarantee.

**Why this shape (a `fallBackToDisk` bool) and not the slice-returning `snapshotOrDisk(req, disk func() ([]InstanceData, error))` sketched in the issue:** the two single-result callers keep local fallbacks with distinct, load-bearing error semantics — `whoamiSession` → `diskWhoami` (its own corrupt-repo suffix message), `getSessionByTitle` → `findInstanceByTitle` (its own not-found wrapping). Forcing them through a slice-returning helper would have **changed their exact local disk-fallback behavior** (the corrupt-repo message in particular), which the requirement forbids. A generic helper would preserve behavior but the codebase uses Go generics in only one file (`doctor/doctor.go`), so it would be non-idiomatic here. The `snapshotRead` seam centralizes the guard while each caller keeps its own success-match and disk-fallback code verbatim — local behavior is byte-for-byte unchanged.

## Sites audited (`grep -rn 'snapshotViaDaemon\|diskListSessions\|diskWhoami\|SnapshotNoSpawn\|IsRemoteTarget' api/ cmd/`)

| Site | Shape | Status |
|------|-------|--------|
| `listSessions` (sessions.go) | daemon→disk | **Rerouted through `snapshotRead`** (behavior identical; already guarded) |
| `getSessionByTitle` (sessions.go) | daemon→disk | **Rerouted through `snapshotRead`** (behavior identical; already guarded) |
| `whoamiSession` (sessions.go) | daemon→disk | **FIXED (#1681)** — now surfaces remote err; local still uses `diskWhoami` |
| `getSessionByTitleInScope` (sessions_watch.go) | daemon→disk | **FIXED (#1679, #1681)** — now surfaces remote err; local still uses `diskListSessions` |
| `apiclient.SnapshotNoSpawn` (apiclient/sessions.go) | the snapshot itself | Confirmed correct — already returns the raw error for remote and `ErrDaemonUnavailable` for local |
| attach path `if !IsRemoteTarget() { EnsureDaemon() }` (sessions.go ~line 949) | local-daemon lifecycle | Confirmed unchanged/correct — gates only the *local* daemon spawn |
| attach `findLiveInstanceByTitleInScope` (sessions.go) | **pure** local-disk restore | **Exempt** — not a daemon→disk fallback; it restores an `*Instance` from disk to build the object, then the remote auth error still surfaces at the subsequent `AttachStream` WS handshake. Different shape, out of scope for this class. |
| `findInstanceByTitle` / `findInstanceByTitleInScope` / `instanceTitleExistsInScope` / `diskListSessions` / `diskWhoami` (api.go) | **pure** disk primitives | **Exempt** — never consult the daemon, so they cannot *mask* a daemon error. They are the disk fallbacks the seam routes to for local targets. |

No other `snapshotViaDaemon` callers exist; all four are now routed through the seam.

## Tests (api/sessions_snapshot_test.go)

Added, all adapted to the existing `stubSnapshot` helper + `apiclient.FlagDaemonURL`. Verified load-bearing: they **fail** with the guards removed (disk masks the error) and **pass** with the fix.

- `TestSnapshotRead_RemoteVsLocalBranch` — direct test of the seam: remote→surface err+no disk; local→permit disk; success→data.
- `TestGetSessionByTitleInScope_RemoteTargetSurfacesError` — remote 401 + matching session on disk ⇒ `errors.Is(err, authErr)`, not the disk hit (the ready-to-adapt test from #1681).
- `TestGetSessionByTitleInScope_RemoteTargetSurfacesNetworkError` — remote unreachable ⇒ network error surfaces, not `errTitleNotFound`.
- `TestGetSessionByTitleInScope_LocalDiskFallbackUnchanged` — local + snapshot error + disk match ⇒ disk session returned (local behavior unchanged).
- `TestWhoamiSession_RemoteTargetSurfacesError` — remote 401 + matching TmuxName on disk ⇒ auth error surfaces, not the disk hit.
- `TestWhoamiSession_RemoteTargetSurfacesNetworkError` — remote unreachable ⇒ network error surfaces, not "no session found".
- `TestWhoamiSession_LocalDiskFallbackUnchanged` — local disk fallback still resolves whoami (paired with the existing `TestWhoamiSession_DiskFallback`).

## Gate results (run from the worktree, per docs/container-testing.md)

```
make test-container        => PASS — every package ok (api 1.258s, apiclient 4.167s,
                              daemon 101.323s, integration 46.458s, app 71.891s, … all ok)
make tui-driver-selftest   => === SELF-TEST PASSED — 25/25 steps green ===
go build ./...             => ok
gofmt -l .                 => (no output)
golangci-lint run --timeout=3m --fast => exit 0 (no findings)
deadcode -test ./...       => (no output)
scripts/lint-file-length.sh => file-length lint passed (589 Go files checked; 0 grandfathered)
```

Note: `snapshotRead` was placed in `api/api.go` (alongside the disk primitives) rather than `sessions.go` because adding it to `sessions.go` pushed that file to 1014 lines, over the 1000-line file-length limit; `api.go` is its more natural, cohesive home anyway.

Closes #1679
Closes #1681

— Captain Claude
