### PR TITLE
fix(config): insert new key at end of comment-only TOML sections, below their comments (#1687)

### DIFF
--- a/config/configset.go
+++ b/config/configset.go
@@ -293,9 +293,11 @@ var (
 // dotted key (section.leaf = …) — and edits whichever is present, so a
 // hand-edited dotted-key file is never left with a duplicate. If the key is
 // absent it is inserted with minimal disturbance — appended to the end of its
-// section's block (or, for a root key, the pre-section block); if the section
-// itself is absent a new [section] block is appended. section == "" targets the
-// root block.
+// section's content block, i.e. after the section's last non-blank line
+// (comments included) and before any trailing blanks preceding the next section
+// or EOF (#1687), or for a root key the pre-section block; if the section itself
+// is absent a new [section] block is appended. section == "" targets the root
+// block.
 func setTOMLScalar(content, section, leaf, encoded string) string {
 	newLine := leaf + " = " + encoded
 
@@ -328,7 +330,15 @@ func setTOMLScalar(content, section, leaf, encoded string) string {
 	curSection := ""
 	firstHeaderIdx := -1
 	targetHeaderIdx := -1
-	lastLineIdxInTarget := -1
+	// lastContentIdxInTarget tracks the last non-blank line of the target
+	// section INCLUDING comment lines, so a missing key is appended at the END
+	// of the section's content block (the documented contract). Tracking only
+	// key=value lines (the pre-#1687 behavior) left it at -1 for a comment-only
+	// section, which inserted the new key immediately after the [section] header
+	// and ABOVE the section's comments (#1687). Blank lines never update it, so
+	// trailing blanks before the next header / EOF are excluded and the insert
+	// lands at the end of the content, not spilling past it.
+	lastContentIdxInTarget := -1
 
 	rebuild := func() string {
 		out := strings.Join(ls, "\n")
@@ -367,9 +377,8 @@ func setTOMLScalar(content, section, leaf, encoded string) string {
 			ls[i] = m[1] + encoded + comment
 			return rebuild()
 		}
-		trimmed := strings.TrimSpace(line)
-		if trimmed != "" && !strings.HasPrefix(trimmed, "#") {
-			lastLineIdxInTarget = i
+		if strings.TrimSpace(line) != "" {
+			lastContentIdxInTarget = i
 		}
 	}
 
@@ -383,8 +392,8 @@ func setTOMLScalar(content, section, leaf, encoded string) string {
 	switch {
 	case section == "":
 		switch {
-		case lastLineIdxInTarget != -1:
-			insertAt(lastLineIdxInTarget+1, newLine)
+		case lastContentIdxInTarget != -1:
+			insertAt(lastContentIdxInTarget+1, newLine)
 		case firstHeaderIdx != -1:
 			insertAt(firstHeaderIdx, newLine)
 		default:
@@ -397,8 +406,8 @@ func setTOMLScalar(content, section, leaf, encoded string) string {
 		}
 		ls = append(ls, "["+section+"]", newLine)
 	default:
-		if lastLineIdxInTarget != -1 {
-			insertAt(lastLineIdxInTarget+1, newLine)
+		if lastContentIdxInTarget != -1 {
+			insertAt(lastContentIdxInTarget+1, newLine)
 		} else {
 			insertAt(targetHeaderIdx+1, newLine)
 		}

--- a/config/configset_test.go
+++ b/config/configset_test.go
@@ -41,6 +41,78 @@ func TestSetTOMLScalarInsertIntoExistingSection(t *testing.T) {
 	}
 }
 
+// TestSetTOMLScalarInsertIntoCommentOnlySection is the #1687 regression: a
+// section that holds ONLY comments (no key=value pairs) must get a new key
+// appended at the END of the section — AFTER its comments — not jammed between
+// the [section] header and its first comment.
+func TestSetTOMLScalarInsertIntoCommentOnlySection(t *testing.T) {
+	in := "[program_overrides]\n# This section stores program overrides\n# Another helpful comment\n"
+	got := setTOMLScalar(in, "program_overrides", "claude", "'/bin/claude'")
+	want := "[program_overrides]\n# This section stores program overrides\n# Another helpful comment\nclaude = '/bin/claude'\n"
+	if got != want {
+		t.Fatalf("comment-only section insert wrong.\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// TestSetTOMLScalarInsertAfterTrailingComment covers a section that has an
+// existing key followed by a trailing comment: per the contract the new key
+// goes at the end of the section's content block, i.e. after the comment.
+func TestSetTOMLScalarInsertAfterTrailingComment(t *testing.T) {
+	in := "[program_overrides]\nclaude = 'x'\n# trailing note about overrides\n"
+	got := setTOMLScalar(in, "program_overrides", "codex", "'/usr/bin/codex'")
+	want := "[program_overrides]\nclaude = 'x'\n# trailing note about overrides\ncodex = '/usr/bin/codex'\n"
+	if got != want {
+		t.Fatalf("trailing-comment insert wrong.\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// TestSetTOMLScalarInsertBeforeTrailingBlank guards that a trailing blank line
+// separating the target section from the next section (or EOF) is preserved:
+// the key is inserted at the end of the section's CONTENT, before the blank, and
+// never spills into the following section.
+func TestSetTOMLScalarInsertBeforeTrailingBlank(t *testing.T) {
+	in := "[program_overrides]\n# comment only\n\n[limit_patterns]\nclaude = 'rate'\n"
+	got := setTOMLScalar(in, "program_overrides", "claude", "'/bin/claude'")
+	want := "[program_overrides]\n# comment only\nclaude = '/bin/claude'\n\n[limit_patterns]\nclaude = 'rate'\n"
+	if got != want {
+		t.Fatalf("trailing-blank insert wrong.\n got: %q\nwant: %q", got, want)
+	}
+
+	// Same, but the section already has a key, then a comment, then a blank line
+	// before the next section.
+	in2 := "[program_overrides]\nclaude = 'x'\n# note\n\n[limit_patterns]\nclaude = 'rate'\n"
+	got2 := setTOMLScalar(in2, "program_overrides", "codex", "'y'")
+	want2 := "[program_overrides]\nclaude = 'x'\n# note\ncodex = 'y'\n\n[limit_patterns]\nclaude = 'rate'\n"
+	if got2 != want2 {
+		t.Fatalf("keyed trailing-blank insert wrong.\n got: %q\nwant: %q", got2, want2)
+	}
+}
+
+// TestSetTOMLScalarCommentOnlySectionIdempotentAndPreserving proves the #1687
+// insert is idempotent (re-setting the same value only replaces the value's
+// bytes) and leaves every unrelated section, comment, and blank line untouched.
+func TestSetTOMLScalarCommentOnlySectionIdempotentAndPreserving(t *testing.T) {
+	in := "# top-of-file note\ndefault_program = 'claude'\n\n" +
+		"[program_overrides]\n# overrides live here\n# keep both comments\n\n" +
+		"[limit_patterns]\nclaude = 'rate.*limit'  # keep me\n"
+
+	once := setTOMLScalar(in, "program_overrides", "claude", "'/bin/claude'")
+	wantOnce := "# top-of-file note\ndefault_program = 'claude'\n\n" +
+		"[program_overrides]\n# overrides live here\n# keep both comments\nclaude = '/bin/claude'\n\n" +
+		"[limit_patterns]\nclaude = 'rate.*limit'  # keep me\n"
+	if once != wantOnce {
+		t.Fatalf("first insert wrong.\n got: %q\nwant: %q", once, wantOnce)
+	}
+
+	// Re-setting the same key to a new value replaces only the value; the layout
+	// stays put (idempotent placement).
+	twice := setTOMLScalar(once, "program_overrides", "claude", "'/bin/claude2'")
+	wantTwice := strings.Replace(wantOnce, "claude = '/bin/claude'", "claude = '/bin/claude2'", 1)
+	if twice != wantTwice {
+		t.Fatalf("re-set not idempotent in placement.\n got: %q\nwant: %q", twice, wantTwice)
+	}
+}
+
 func TestSetTOMLScalarAppendsNewSection(t *testing.T) {
 	in := "default_program = 'claude'\n"
 	got := setTOMLScalar(in, "limit_patterns", "claude", "'rate.*limit'")


### PR DESCRIPTION
Fixes #1687. Introduced in #1208.

## The bug

`config/configset.go` `setTOMLScalar` decides where to insert a missing key from `lastLineIdxInTarget`, but that index was only advanced past **non-comment, non-blank** lines. In a section that contains **only comments** (no `key = value` pairs), it stayed `-1`, so the new key was inserted at `targetHeaderIdx+1` — right after the `[section]` header and **above** the section's comments.

This breaks the documented contract that a missing key is appended at the **end** of its section's block with every comment, blank line, and ordering preserved.

```toml
# before: `af config set program_overrides.claude /bin/claude`
[program_overrides]
# This section stores program overrides
# Another helpful comment
```
Old (wrong) result inserted `claude = '/bin/claude'` **above** the two comments; it now appends **after** them.

## The fix

Track the last non-blank line of the target section **including comment lines** (`lastContentIdxInTarget`) and insert after it. Blank lines never advance the tracker, so trailing blanks before the next section / EOF are excluded and the key lands at the end of the section's *content* — not spilling into the next section.

Sections with existing keys are unaffected, except a key followed by a trailing comment now correctly appends **after** the comment (end of the block), matching the contract.

## Tests

- comment-only section → new key appended **after** both comments (the #1687 repro)
- section with a key + trailing comment → new key at end of block, below the comment
- trailing blank before the next section (comment-only and keyed) → key inserted before the blank/next header, at end of content
- idempotent placement + byte-for-byte preservation of unrelated sections/comments

## Gates
- `make test-container` — full suite green
- `make tui-driver-selftest` — 25/25
- `go build ./...`, `gofmt -l .` clean, `golangci-lint run --fast`, `deadcode -test ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)