### PR TITLE
fix(bugreport): redact tmux_name/session_name on the fallback path so titles do not leak (#1680)

### DIFF
--- a/bugreport/bugreport_test.go
+++ b/bugreport/bugreport_test.go
@@ -266,6 +266,106 @@ func TestRedactInstancesFallbackRedactsOnDecodeFailure(t *testing.T) {
 	}
 }
 
+// TestRedactInstancesFallbackRedactsTmuxNameAndSessionName is the #1680
+// regression guard: a legacy/corrupt record that fails the typed decode (here
+// `status` is a string) must still have tmux_name and worktree.session_name and
+// tabs[].tmux_name redacted on the fallback path — each carries the session
+// title. Before the fix these keys were absent from sensitiveJSONKeys, so they
+// passed through unredacted and the title leaked into the shared bundle.
+func TestRedactInstancesFallbackRedactsTmuxNameAndSessionName(t *testing.T) {
+	r := &redactor{}
+	raw := json.RawMessage(`[{"id":"leg-1","status":"legacy-string-status","tmux_name":"af_0f8fc14c_confidential-session-title","title":"confidential session title","worktree":{"session_name":"confidential session title","branch":"feature/test"},"tabs":[{"tmux_name":"af_0f8fc14c_confidential-session-title"}]}]`)
+	out := string(r.redactInstancesJSON(raw))
+	for _, leak := range []string{"confidential-session-title", "confidential session title"} {
+		if strings.Contains(out, leak) {
+			t.Errorf("fallback path leaked: %q\n%s", leak, out)
+		}
+	}
+}
+
+// TestRedactInstancesFallbackRedactsAllNestedTitleFields proves each of the four
+// title-bearing locations — top-level tmux_name, worktree.session_name, and the
+// nested tabs[].tmux_name (two tabs) — is individually redacted on the fallback
+// path, not just the top-level one. The typed decode is forced to fail with a
+// string `status` (the field is an int), and every field uses a distinct
+// sentinel so a surviving value pinpoints exactly which nested location leaked.
+func TestRedactInstancesFallbackRedactsAllNestedTitleFields(t *testing.T) {
+	r := &redactor{}
+	raw := json.RawMessage(`[{
+		"id": "leg-1",
+		"status": "legacy-string-status",
+		"tmux_name": "af_0f8fc14c_toplevel-secret-title",
+		"worktree": {"session_name": "worktree-secret-title", "branch": "feature/test"},
+		"tabs": [
+			{"tmux_name": "af_0f8fc14c_tab-one-secret-title"},
+			{"tmux_name": "af_0f8fc14c_tab-two-secret-title"}
+		]
+	}]`)
+
+	out := string(r.redactInstancesJSON(raw))
+
+	// None of the four distinct secret values may survive.
+	for _, leak := range []string{
+		"toplevel-secret-title",
+		"worktree-secret-title",
+		"tab-one-secret-title",
+		"tab-two-secret-title",
+	} {
+		if strings.Contains(out, leak) {
+			t.Errorf("fallback path leaked %q:\n%s", leak, out)
+		}
+	}
+	// All four title-bearing fields must be replaced with the marker: the two
+	// tab tmux_names, the top-level tmux_name, and worktree.session_name.
+	if got := strings.Count(out, redactedMarker); got < 4 {
+		t.Errorf("expected >= 4 redaction markers (one per title field), got %d:\n%s", got, out)
+	}
+	// Structural fields still survive the fallback walk.
+	if !strings.Contains(out, "leg-1") || !strings.Contains(out, "legacy-string-status") ||
+		!strings.Contains(out, "feature/test") {
+		t.Errorf("fallback dropped safe structural fields:\n%s", out)
+	}
+}
+
+// TestRedactInstancesTypedPathRedactsTmuxAndSessionName confirms the typed path
+// is unchanged: the same shape as the fallback test but VALID as
+// []InstanceData (int status) still redacts tmux_name, worktree.session_name,
+// and tabs[].tmux_name via redactInstanceData. (redactInstanceData is also
+// covered directly by TestRedactInstanceDataKeepsStructuralDropsFreeText; this
+// asserts the end-to-end redactInstancesJSON typed branch.)
+func TestRedactInstancesTypedPathRedactsTmuxAndSessionName(t *testing.T) {
+	r := &redactor{}
+	raw, err := json.Marshal([]session.InstanceData{{
+		ID:       "abc123",
+		Status:   session.Status(1),
+		Program:  "claude",
+		TmuxName: "af_0f8fc14c_confidential-session-title",
+		Title:    "confidential session title",
+		Worktree: session.GitWorktreeData{
+			SessionName: "confidential session title",
+			BranchName:  "feature/test",
+		},
+		Tabs: []session.TabData{{TmuxName: "af_0f8fc14c_confidential-session-title"}},
+	}})
+	if err != nil {
+		t.Fatalf("marshal test instance: %v", err)
+	}
+
+	out := string(r.redactInstancesJSON(raw))
+	for _, leak := range []string{"confidential-session-title", "confidential session title"} {
+		if strings.Contains(out, leak) {
+			t.Errorf("typed path leaked: %q\n%s", leak, out)
+		}
+	}
+	if !strings.Contains(out, redactedMarker) {
+		t.Errorf("expected redaction marker on the typed path:\n%s", out)
+	}
+	// Structural fields survive.
+	if !strings.Contains(out, "abc123") || !strings.Contains(out, "feature/test") {
+		t.Errorf("typed path dropped structural fields:\n%s", out)
+	}
+}
+
 // TestRedactInstancesInvalidJSONOmitted confirms that a payload which is not
 // even valid JSON surfaces nothing — the contents are omitted with a note.
 func TestRedactInstancesInvalidJSONOmitted(t *testing.T) {

--- a/bugreport/redact.go
+++ b/bugreport/redact.go
@@ -331,6 +331,13 @@ var sensitiveJSONKeys = map[string]bool{
 	"private_key": true, "url": true,
 	"path": true, "home": true, "repo_path": true, "worktree_path": true,
 	"remote_meta": true,
+	// tmux_name and session_name mirror the typed-path redaction
+	// (redactInstanceData drops TmuxName, Worktree.SessionName, and
+	// Tabs[].TmuxName): each carries the free-text session title. Without
+	// them the fallback path leaked titles the typed path already scrubs,
+	// including the nested tabs[].tmux_name and worktree.session_name the
+	// recursive walk below reaches (#1680).
+	"tmux_name": true, "session_name": true,
 }
 
 // redactUnknownJSON recursively rebuilds a decoded JSON value, blanking any


### PR DESCRIPTION
## The bug

`redactInstancesJSON` (`bugreport/redact.go`) has two paths:

- **Typed path** — decode the payload into `[]session.InstanceData` and redact per-field via `redactInstanceData`, which drops `TmuxName`, `Worktree.SessionName`, and `Tabs[].TmuxName` (all of which carry the free-text session title).
- **Fallback path** — when the payload does *not* decode as `[]InstanceData` (corrupt/legacy/truncated `instances.json`, e.g. a field whose type has since changed), the typed field-level policy can't apply, so it blanks every value under a known-sensitive key using the `sensitiveJSONKeys` map, walked recursively by `redactUnknownJSON`.

The inconsistency: `sensitiveJSONKeys` was **missing** `"tmux_name"` and `"session_name"`. So on the fallback path those title-bearing fields — including nested `tabs[].tmux_name` and `worktree.session_name` — passed through **unredacted**, and session titles leaked into the publicly shared bug-report bundle. Introduced in #1541.

## The fix

Add `"tmux_name": true` and `"session_name": true` to `sensitiveJSONKeys`, mirroring the typed-path redaction. `redactUnknownJSON` is already fully recursive over both objects (`map[string]any`) and arrays (`[]any`), so the nested `tabs[].tmux_name` and `worktree.session_name` locations are caught with **no further change** to the walk.

The **typed path (`redactInstanceData`) is unchanged.**

## Tests

Cover both paths in `bugreport/bugreport_test.go`:

- `TestRedactInstancesFallbackRedactsTmuxNameAndSessionName` — the exact failing repro from the issue (string `status` forces the fallback; asserts neither the sanitized name nor the raw title survives).
- `TestRedactInstancesFallbackRedactsAllNestedTitleFields` — stronger coverage: forced fallback with **distinct sentinel values** per location (top-level `tmux_name`, `worktree.session_name`, and two `tabs[].tmux_name`), asserting each of the four is individually redacted (no secret survives; ≥4 `[redacted]` markers) while structural fields (`id`, `status`, `branch`) survive.
- `TestRedactInstancesTypedPathRedactsTmuxAndSessionName` — the same shape but **valid** as `[]InstanceData` (int status) still redacts `tmux_name` / `worktree.session_name` / `tabs[].tmux_name` via the untouched typed path. (`redactInstanceData` itself remains covered directly by `TestRedactInstanceDataKeepsStructuralDropsFreeText`.)

## Gates

`go build ./...`, `gofmt -l .`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...`, `make test-container` (full suite green), and `make tui-driver-selftest` (25/25) all clean.

Fixes #1680

— Captain Claude