### PR TITLE
fix(tui): mouse wheel scrolls pane scrollback unless the program enabled mouse reporting

### DIFF
--- a/app/handle_mouse.go
+++ b/app/handle_mouse.go
@@ -275,9 +275,29 @@ func (m *home) forwardInteractiveMouse(msg tea.MouseMsg) bool {
 		return false
 	}
 	if kind == zones.PaneKindTerm {
+		// The wheel belongs to the inner app ONLY when it has enabled mouse
+		// reporting (tmux semantics): otherwise it falls through to handleWheel so
+		// the wheel scrolls the pane scrollback instead of being swallowed by a
+		// program sitting at a prompt (#1024 wheel fix). Clicks/motion/release stay
+		// forwarded regardless — this narrows the change to the wheel alone.
+		if isWheelButton(msg.Button) && !lt.MouseTrackingEnabled() {
+			return false
+		}
 		lt.SendMouse(msg, local.X, local.Y)
 	}
 	return true
+}
+
+// isWheelButton reports whether b is any mouse-wheel button. Wheel events are the
+// only ones the interactive router hands back to the host when the inner app has
+// not enabled mouse reporting (#1024 wheel fix).
+func isWheelButton(b tea.MouseButton) bool {
+	switch b {
+	case tea.MouseButtonWheelUp, tea.MouseButtonWheelDown,
+		tea.MouseButtonWheelLeft, tea.MouseButtonWheelRight:
+		return true
+	}
+	return false
 }
 
 // handleWheel scrolls the region UNDER THE CURSOR (RFC §2.5) — before this

--- a/app/live_termpane.go
+++ b/app/live_termpane.go
@@ -45,6 +45,11 @@ type liveTermAttachment interface {
 	// in-pane mouse path (#1024 R4). The emulator is mode-aware: the event reaches
 	// the inner app only if it enabled mouse tracking, and is dropped otherwise.
 	SendMouse(msg tea.MouseMsg, x, y int) bool
+	// MouseTrackingEnabled reports whether the inner app has requested mouse
+	// reporting (a mouse-tracking DECMode is active). The router uses it to decide
+	// wheel ownership: an app that has not enabled tracking leaves the wheel to
+	// pane scrollback rather than swallowing it (#1024 wheel fix).
+	MouseTrackingEnabled() bool
 }
 
 // newLiveTermPaneFn is the attachment creation seam. Production dials the daemon

--- a/app/live_termpane_test.go
+++ b/app/live_termpane_test.go
@@ -24,6 +24,10 @@ type fakeLiveTerm struct {
 	// mice records every event forwarded through SendMouse with its grid-local
 	// coordinates (#1024 R4 interactive forwarding).
 	mice []forwardedMouse
+	// mouseTracking is what MouseTrackingEnabled reports — the fake's stand-in for
+	// the inner app having requested mouse reporting (#1024 wheel fix). Off by
+	// default: a program sitting at a prompt owns no wheel.
+	mouseTracking bool
 }
 
 // forwardedMouse is one SendMouse call as the fake recorded it.
@@ -46,6 +50,8 @@ func (f *fakeLiveTerm) SendMouse(msg tea.MouseMsg, x, y int) bool {
 	f.mice = append(f.mice, forwardedMouse{msg: msg, x: x, y: y})
 	return true
 }
+
+func (f *fakeLiveTerm) MouseTrackingEnabled() bool { return f.mouseTracking }
 
 // stubLiveTermFactory points the attachment seam at fake attachments and returns
 // the created fakes + the session titles they were created for.

--- a/app/mouse_test.go
+++ b/app/mouse_test.go
@@ -759,8 +759,11 @@ func TestMouse_InteractiveForwardsGridEvents(t *testing.T) {
 	assert.Equal(t, tea.MouseButtonLeft, fake.mice[0].msg.Button)
 	assert.True(t, h.interactive, "a forwarded press must not leave the mode")
 
+	// The wheel forwards ONLY when the inner app enabled mouse reporting (#1024
+	// wheel fix). With tracking on it owns the wheel, exactly like a click.
+	fake.mouseTracking = true
 	wheel(h, term.X+5, term.Y+3, true)
-	require.Len(t, fake.mice, 2, "the wheel forwards too — the inner app owns scroll (§2.5)")
+	require.Len(t, fake.mice, 2, "with tracking enabled the inner app owns the wheel (§2.5)")
 	assert.Equal(t, tea.MouseButtonWheelUp, fake.mice[1].msg.Button)
 	assert.False(t, h.paneWindows[h.focusedOpenPane().ID()].IsInScrollMode(),
 		"a forwarded wheel must not flip the live pane into host capture scroll")
@@ -769,6 +772,29 @@ func TestMouse_InteractiveForwardsGridEvents(t *testing.T) {
 		X: term.X + 5, Y: term.Y + 3, Action: tea.MouseActionRelease, Button: tea.MouseButtonLeft,
 	})
 	require.Len(t, fake.mice, 3, "releases forward so the inner app sees complete clicks")
+}
+
+// TestMouse_InteractiveWheelWithoutTrackingScrollsScrollback: over the FOCUSED
+// live pane, a wheel from a program that has NOT enabled mouse reporting must
+// fall through to the host wheel handler and scroll the pane scrollback (tmux
+// semantics) — the #1024 regression where the wheel was swallowed at a prompt.
+func TestMouse_InteractiveWheelWithoutTrackingScrollsScrollback(t *testing.T) {
+	h, fake, region := interactiveMouseHome(t)
+	require.False(t, fake.mouseTracking, "the inner app owns no wheel until it enables tracking")
+
+	term := zoneRect(t, h, zones.PaneTerm(region))
+	wheel(h, term.X+5, term.Y+3, true)
+
+	assert.Empty(t, fake.mice, "an untracked wheel must not forward into the inner app")
+	assert.True(t, h.paneWindows[h.focusedOpenPane().ID()].IsInScrollMode(),
+		"an untracked wheel scrolls the pane scrollback instead of being swallowed")
+	assert.True(t, h.interactive, "scrolling scrollback must not leave interactive mode")
+
+	// A click still forwards (the fix is scoped to the wheel), proving the pane is
+	// still the interactive input target.
+	press(h, term.X+5, term.Y+3)
+	require.Len(t, fake.mice, 1, "clicks forward unchanged — only the wheel falls through")
+	assert.Equal(t, tea.MouseButtonLeft, fake.mice[0].msg.Button)
 }
 
 func TestMouse_InteractiveTabDragConsumesTerminalMotionAndDrop(t *testing.T) {

--- a/ui/termpane/mouse.go
+++ b/ui/termpane/mouse.go
@@ -2,6 +2,7 @@ package termpane
 
 import (
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/charmbracelet/x/vt"
 )
 
@@ -40,6 +41,36 @@ func (t *TermPane) SendMouse(msg tea.MouseMsg, x, y int) bool {
 	}
 	t.emu.SendMouse(ev)
 	return true
+}
+
+// MouseTrackingEnabled reports whether the inner application has requested mouse
+// reporting — i.e. it has a mouse-tracking DECMode active (X10 9, normal 1000,
+// highlight 1001, button-event 1002, or any-event 1003). This is exactly the set
+// emu.SendMouse consults before it encodes anything, so a true here means a
+// forwarded event would actually reach the program. The host uses it to decide
+// who owns the mouse WHEEL (tmux semantics): a program that has NOT enabled
+// tracking leaves the wheel to pane scrollback (#1024 wheel fix). The read is
+// under the same lock the mode-change callbacks write beneath.
+func (t *TermPane) MouseTrackingEnabled() bool {
+	t.gridMu.RLock()
+	defer t.gridMu.RUnlock()
+	return len(t.mouseModes) > 0
+}
+
+// isMouseTrackingMode reports whether mode is one of the DECModes that makes the
+// terminal report mouse events to the inner app. It mirrors the tracking-mode
+// list emu.SendMouse iterates; the SGR encoding mode (1006) is deliberately
+// excluded — it only changes how reports are encoded, not whether they happen.
+func isMouseTrackingMode(mode ansi.Mode) bool {
+	switch mode {
+	case ansi.ModeMouseX10,
+		ansi.ModeMouseNormal,
+		ansi.ModeMouseHighlight,
+		ansi.ModeMouseButtonEvent,
+		ansi.ModeMouseAnyEvent:
+		return true
+	}
+	return false
 }
 
 // translateMouse maps a bubbletea v1 mouse message to the emulator's event

--- a/ui/termpane/mouse_test.go
+++ b/ui/termpane/mouse_test.go
@@ -2,6 +2,7 @@ package termpane
 
 import (
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/vt"
@@ -102,4 +103,44 @@ func TestTranslateMouseUnknownButton(t *testing.T) {
 	msg := mouseMsg(tea.MouseActionPress, tea.MouseButton(99), 0, 0)
 	_, ok := translateMouse(msg, 0, 0)
 	assert.False(t, ok)
+}
+
+// waitTrackingEnabled blocks until MouseTrackingEnabled reports want; the DECSET
+// bytes flow through the run goroutine's emu.Write, so the callback lands
+// asynchronously.
+func waitTrackingEnabled(t *testing.T, tp *TermPane, want bool, msg string) {
+	t.Helper()
+	require.Eventuallyf(t, func() bool {
+		return tp.MouseTrackingEnabled() == want
+	}, 2*time.Second, 5*time.Millisecond, msg)
+}
+
+// TestMouseTrackingEnabledReflectsDECSET: MouseTrackingEnabled tracks the inner
+// app's DECSET/DECRST for the mouse-tracking modes (#1024 wheel fix). This is the
+// signal the host router keys wheel ownership off of, so it must go true when the
+// app requests tracking and false when it releases it — and it must ignore the SGR
+// ENCODING mode (1006), which changes how reports are encoded, not whether the app
+// gets them.
+func TestMouseTrackingEnabledReflectsDECSET(t *testing.T) {
+	tp, s := newSingleStreamPane(t, 40, 6)
+	require.False(t, tp.MouseTrackingEnabled(), "a fresh pane has no mouse tracking")
+
+	// The SGR encoding mode alone is not tracking — no reports happen.
+	s.feed("\x1b[?1006h")
+	waitTrackingEnabled(t, tp, false, "1006 (SGR encoding) alone must not enable tracking")
+
+	// Normal mouse tracking on → enabled.
+	s.feed("\x1b[?1000h")
+	waitTrackingEnabled(t, tp, true, "DECSET 1000 must enable tracking")
+
+	// Reset it → back to disabled (the SGR mode is still set but is not tracking).
+	s.feed("\x1b[?1000l")
+	waitTrackingEnabled(t, tp, false, "DECRST 1000 must disable tracking")
+
+	// Button-event tracking on (what an agent CLI/vim requests) → enabled again.
+	s.feed("\x1b[?1002h")
+	waitTrackingEnabled(t, tp, true, "DECSET 1002 (button-event) must enable tracking")
+
+	s.feed("\x1b[?1002l")
+	waitTrackingEnabled(t, tp, false, "DECRST 1002 must disable tracking")
 }

--- a/ui/termpane/mouse_test.go
+++ b/ui/termpane/mouse_test.go
@@ -144,3 +144,22 @@ func TestMouseTrackingEnabledReflectsDECSET(t *testing.T) {
 	s.feed("\x1b[?1002l")
 	waitTrackingEnabled(t, tp, false, "DECRST 1002 must disable tracking")
 }
+
+// TestMouseTrackingEnabledClearedByReset pins the #1748 review hardening: a full
+// terminal RESET (RIS, ESC c — e.g. a program exits or reinitializes the
+// terminal) must clear the tracked mouse state so the wheel doesn't stay stuck
+// forwarding to a program that no longer wants the mouse. The emulator's
+// resetModes re-drives setMode(ModeReset) for every mouse mode, which fires the
+// DisableMode callback, so the tracked set can't persist across a reset.
+func TestMouseTrackingEnabledClearedByReset(t *testing.T) {
+	tp, s := newSingleStreamPane(t, 40, 6)
+
+	// An app enables mouse reporting…
+	s.feed("\x1b[?1000h")
+	waitTrackingEnabled(t, tp, true, "DECSET 1000 must enable tracking")
+
+	// …then the terminal is fully reset (RIS). Tracking must go false again so the
+	// wheel returns to scrolling scrollback.
+	s.feed("\x1bc")
+	waitTrackingEnabled(t, tp, false, "a full reset (RIS) must clear mouse tracking, not leave it stuck on")
+}

--- a/ui/termpane/termpane.go
+++ b/ui/termpane/termpane.go
@@ -127,6 +127,11 @@ type TermPane struct {
 	// gridMu's write lock). MouseTrackingEnabled reads it under the read lock. It
 	// mirrors exactly the set emu.SendMouse consults, so "tracking enabled" means
 	// "a forwarded wheel/click would actually reach the inner app". Starts empty.
+	//
+	// It cannot go stale across a terminal reset: a full reset (RIS) runs the
+	// emulator's resetModes, which re-drives setMode(ModeReset) for every mouse
+	// mode and thus fires DisableMode for each — clearing this set — so the wheel
+	// can never stay stuck forwarding to a program that reset the terminal (#1748).
 	mouseModes    map[ansi.Mode]bool
 	width, height int
 

--- a/ui/termpane/termpane.go
+++ b/ui/termpane/termpane.go
@@ -34,6 +34,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/charmbracelet/x/vt"
 )
 
@@ -120,6 +121,13 @@ type TermPane struct {
 	// emulator's CursorVisibility callback (fired inside emu.Write, under gridMu's
 	// write lock); Render reads it under the read lock. Starts true.
 	cursorVisible bool
+	// mouseModes is the set of mouse-tracking DECModes (X10/normal/highlight/
+	// button-event/any-event) the inner app currently has enabled, maintained by
+	// the emulator's EnableMode/DisableMode callbacks (fired inside emu.Write, under
+	// gridMu's write lock). MouseTrackingEnabled reads it under the read lock. It
+	// mirrors exactly the set emu.SendMouse consults, so "tracking enabled" means
+	// "a forwarded wheel/click would actually reach the inner app". Starts empty.
+	mouseModes    map[ansi.Mode]bool
 	width, height int
 
 	dial Dialer
@@ -146,6 +154,7 @@ func New(dial Dialer, width, height int) *TermPane {
 	t := &TermPane{
 		emu:           vt.NewEmulator(width, height),
 		cursorVisible: true,
+		mouseModes:    make(map[ansi.Mode]bool),
 		width:         width,
 		height:        height,
 		dial:          dial,
@@ -159,6 +168,18 @@ func New(dial Dialer, width, height int) *TermPane {
 	// field write is ordered against Render's locked reads.
 	t.emu.SetCallbacks(vt.Callbacks{
 		CursorVisibility: func(visible bool) { t.cursorVisible = visible },
+		// Track the inner app's mouse-reporting requests so the host can tell
+		// whether the wheel belongs to the program or to pane scrollback (#1024
+		// wheel fix). Both callbacks fire from emu.Write under gridMu's write lock,
+		// ordering these map writes against MouseTrackingEnabled's locked read.
+		EnableMode: func(mode ansi.Mode) {
+			if isMouseTrackingMode(mode) {
+				t.mouseModes[mode] = true
+			}
+		},
+		DisableMode: func(mode ansi.Mode) {
+			delete(t.mouseModes, mode)
+		},
 	})
 
 	t.wg.Add(2)


### PR DESCRIPTION
## Problem

Mouse-wheel scrolling of the agent OUTPUT pane's scrollback worked for some panes but not others / intermittently.

**Root cause:** While interactive (`m.interactive && state==stateDefault`), `forwardInteractiveMouse` forwarded **all** mouse events over the FOCUSED pane's terminal grid — including the wheel — to the pane program via `SendMouse` and returned `true` (consumed). So the wheel was swallowed even when the running program (claude/codex sitting at a prompt) had **not** enabled mouse reporting; it never fell through to `handleWheel()` to scroll the TUI scrollback. A wheel over a **non-focused** pane returned `false` and did scroll — hence "some panes scroll, some don't / sometimes works".

## Fix (tmux semantics)

The wheel belongs to the inner app **only when it has requested mouse reporting** (a mouse-tracking DECMode is active: X10/1000, highlight/1001, button-event/1002, any-event/1003). Otherwise the wheel falls through to `handleWheel()` and scrolls the pane scrollback.

- **`ui/termpane`**: track the inner app's mouse-tracking modes via the emulator's `EnableMode`/`DisableMode` callbacks (same pattern as `cursorVisible`); expose `TermPane.MouseTrackingEnabled()`. The tracked set mirrors exactly what `emu.SendMouse` consults before encoding, and deliberately excludes the SGR **encoding** mode (1006), which changes how reports are encoded, not whether they happen.
- **`app`**: in `forwardInteractiveMouse`, hand wheel buttons back to the host (`return false`) when `MouseTrackingEnabled()` is false, so `handleMouse` proceeds to `handleWheel()`. Click / motion / drag / release forwarding is **unchanged** — the change is scoped to the wheel to minimize risk in this regression-prone input path.

## Tests

- `termpane`: `MouseTrackingEnabled` reflects DECSET/DECRST set→reset across 1000 and 1002; `1006` (SGR encoding) alone does **not** enable tracking.
- `app`: focused untracked pane → wheel scrolls scrollback (`IsInScrollMode`, not `SendMouse`) and stays interactive; focused tracked pane → wheel forwards to the program; clicks still forward/focus unchanged.

## Gates

- `make tui-driver-selftest` — 25/25 green
- `make test-container` — all packages green
- `go build ./...`, `gofmt -l .` clean, `golangci-lint run --fast` clean, `deadcode -test ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)