### PR TITLE
fix(cli): help/error hygiene + project vocabulary (#1749)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -120,7 +120,7 @@ var errTitleNotFound = errors.New("not found")
 func findInstanceByTitle(title string) (*session.InstanceData, string, error) {
 	allInstances, err := config.LoadAllRepoInstances()
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to load instances: %w", err)
+		return nil, "", fmt.Errorf("failed to load sessions: %w", err)
 	}
 
 	var corrupted []string
@@ -141,11 +141,11 @@ func findInstanceByTitle(title string) (*session.InstanceData, string, error) {
 		}
 	}
 	if len(corrupted) > 0 {
-		return nil, "", fmt.Errorf("instance %q not found; %s", title, corruptedReposSuffix(corrupted))
+		return nil, "", fmt.Errorf("session %q not found; %s", title, corruptedReposSuffix(corrupted))
 	}
 	// Wrap the sentinel so a clean miss stays distinguishable from a
 	// corruption-tainted miss (#861); the user-facing text is unchanged.
-	return nil, "", fmt.Errorf("instance %q %w", title, errTitleNotFound)
+	return nil, "", fmt.Errorf("session %q %w", title, errTitleNotFound)
 }
 
 // corruptedReposSuffix builds a sorted, human-readable clause naming the repos
@@ -179,7 +179,7 @@ func diskListSessions(repoID string) ([]session.InstanceData, error) {
 		}
 		var data []session.InstanceData
 		if err := json.Unmarshal(raw, &data); err != nil {
-			return nil, fmt.Errorf("failed to parse instances: %w", err)
+			return nil, fmt.Errorf("failed to parse sessions: %w", err)
 		}
 		// Single repo: the (repoID, title) key reduces to title order.
 		sort.Slice(data, func(i, j int) bool { return data[i].Title < data[j].Title })
@@ -232,7 +232,7 @@ func diskListSessions(repoID string) ([]session.InstanceData, error) {
 func diskWhoami(tmuxName string) (*session.InstanceData, error) {
 	allInstances, err := config.LoadAllRepoInstances()
 	if err != nil {
-		return nil, fmt.Errorf("failed to load instances: %w", err)
+		return nil, fmt.Errorf("failed to load sessions: %w", err)
 	}
 	var corrupted []string
 	for repoID, raw := range allInstances {
@@ -270,11 +270,11 @@ func repoHasInstanceTitle(repoID, title string) (bool, error) {
 func loadRepoInstanceData(repoID string) ([]session.InstanceData, error) {
 	raw, err := config.LoadRepoInstances(repoID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load instances for repo %s: %w", repoID, err)
+		return nil, fmt.Errorf("failed to load sessions for repo %s: %w", repoID, err)
 	}
 	var instances []session.InstanceData
 	if err := json.Unmarshal(raw, &instances); err != nil {
-		return nil, fmt.Errorf("failed to parse instances for repo %s: %w", repoID, err)
+		return nil, fmt.Errorf("failed to parse sessions for repo %s: %w", repoID, err)
 	}
 	return instances, nil
 }
@@ -287,7 +287,7 @@ func findLiveInstanceByTitle(title string) (*session.Instance, string, error) {
 	}
 	instance, err := session.FromInstanceData(*data)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to restore instance %q: %w", title, err)
+		return nil, "", fmt.Errorf("failed to restore session %q: %w", title, err)
 	}
 	return instance, repoID, nil
 }
@@ -312,7 +312,7 @@ func findInstanceByTitleInScope(repoID, title string) (*session.InstanceData, st
 	}
 	// Wrap the sentinel so a scoped clean miss stays distinguishable from a
 	// corruption-tainted miss, mirroring findInstanceByTitle (#861).
-	return nil, "", fmt.Errorf("instance %q %w", title, errTitleNotFound)
+	return nil, "", fmt.Errorf("session %q %w", title, errTitleNotFound)
 }
 
 // findLiveInstanceByTitleInScope finds an instance by title within the resolved
@@ -327,7 +327,7 @@ func findLiveInstanceByTitleInScope(repoID, title string) (*session.Instance, st
 	}
 	instance, err := session.FromInstanceData(*data)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to restore instance %q: %w", title, err)
+		return nil, "", fmt.Errorf("failed to restore session %q: %w", title, err)
 	}
 	return instance, repoID, nil
 }
@@ -431,8 +431,13 @@ func jsonOut(v any) error {
 // the opt-in --json flag it emits the shared failure Envelope instead. The
 // original error is always returned so exit codes are unchanged.
 func jsonError(err error) error {
+	// jsonError always prints the error itself — the bare {"error":...} or the
+	// envelope — so tell cobra not to re-print it (as "Error: ...") or dump
+	// usage. Without this a single runtime error prints two or three times
+	// (#1749). Flag-parse errors never reach here, so their usage help is
+	// unaffected.
+	silenceCobraOutput()
 	if envelopeOutput {
-		silenceEnvelopeCobra()
 		log.CloseQuiet()
 		_ = apiproto.WriteEnvelope(os.Stderr, apiproto.Failure(err.Error()))
 		return err
@@ -442,7 +447,10 @@ func jsonError(err error) error {
 	return err
 }
 
-func silenceEnvelopeCobra() {
+// silenceCobraOutput suppresses cobra's own error line and usage dump on the
+// sessions/tasks command trees (and their shared root) so a command that has
+// already reported its failure does not have it re-printed (#1749).
+func silenceCobraOutput() {
 	SessionsCmd.SilenceUsage = true
 	SessionsCmd.SilenceErrors = true
 	TasksCmd.SilenceUsage = true
@@ -458,9 +466,11 @@ func silenceEnvelopeCobra() {
 }
 
 func init() {
-	// --repo flag on each top-level subcommand
-	SessionsCmd.PersistentFlags().StringVar(&repoFlag, "repo", "", "Path to git repository")
-	TasksCmd.PersistentFlags().StringVar(&repoFlag, "repo", "", "Path to git repository")
+	// --repo flag on each top-level subcommand. The flag name stays --repo (a
+	// technical git term), but the help reads "project" — the user-facing noun
+	// the TUI and web share for a repo's session grouping (#1749).
+	SessionsCmd.PersistentFlags().StringVar(&repoFlag, "repo", "", "Path to the project's git repository")
+	TasksCmd.PersistentFlags().StringVar(&repoFlag, "repo", "", "Path to the project's git repository")
 
 	// Opt-in envelope output. Defaults OFF so existing scripts keep parsing the
 	// bare payload; --json wraps stdout/stderr in the {data,error} Envelope that

--- a/api/apicmd.go
+++ b/api/apicmd.go
@@ -103,7 +103,11 @@ func printAPICatalogHuman(w io.Writer, socketPath string, routes []daemon.HTTPRo
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Examples:")
 	for _, rt := range routes {
-		fmt.Fprintf(w, "  # %s\n", rt.Description)
+		// The table above already carries each endpoint's full description;
+		// repeating it verbatim here doubled the catalog's length. A short
+		// operation name (the last path segment, e.g. "# CreateSession") is
+		// enough to anchor the curl beneath it (#1749).
+		fmt.Fprintf(w, "  # %s\n", routeName(rt))
 		fmt.Fprintf(w, "  %s\n", curlExample(socketPath, rt))
 		if len(rt.RequestFields) > 0 {
 			fmt.Fprintf(w, "  # request fields: %s\n", strings.Join(rt.RequestFields, ", "))
@@ -111,6 +115,15 @@ func printAPICatalogHuman(w io.Writer, socketPath string, routes []daemon.HTTPRo
 		fmt.Fprintln(w)
 	}
 	return nil
+}
+
+// routeName is the short operation label for a route: the last segment of its
+// path (e.g. "/v1/CreateSession" -> "CreateSession", "/v1/health" -> "health").
+func routeName(rt daemon.HTTPRoute) string {
+	if i := strings.LastIndex(rt.Path, "/"); i >= 0 && i+1 < len(rt.Path) {
+		return rt.Path[i+1:]
+	}
+	return rt.Path
 }
 
 // curlExample builds a ready-to-run curl invocation for a route. GET routes

--- a/api/apicmd_test.go
+++ b/api/apicmd_test.go
@@ -53,6 +53,43 @@ func TestAPICmd_ListsEveryRegisteredEndpoint(t *testing.T) {
 	assert.Contains(t, out, "0600")
 }
 
+// TestAPICmd_ExamplesUseShortRouteNames covers #1749 item 12: the Examples
+// section anchors each curl with a short "# <RouteName>" comment (the last path
+// segment) rather than repeating the endpoint's full description verbatim — the
+// description already appears once in the table above.
+func TestAPICmd_ExamplesUseShortRouteNames(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	out := runAPICmd(t, false)
+
+	idx := strings.Index(out, "Examples:")
+	require.GreaterOrEqual(t, idx, 0, "human catalog must have an Examples section")
+	examples := out[idx:]
+
+	for _, rt := range daemon.HTTPRoutes() {
+		assert.Containsf(t, examples, "# "+routeName(rt),
+			"examples must anchor %s with its short route name", rt.Path)
+		// The verbose description is table-only; it must not be echoed as a
+		// comment in the examples anymore.
+		if rt.Description != routeName(rt) {
+			assert.NotContainsf(t, examples, "# "+rt.Description,
+				"examples must not repeat the full description for %s", rt.Path)
+		}
+	}
+}
+
+// TestRouteName pins the short-label derivation used by the examples section.
+func TestRouteName(t *testing.T) {
+	cases := map[string]string{
+		"/v1/CreateSession": "CreateSession",
+		"/v1/health":        "health",
+		"noslash":           "noslash",
+	}
+	for path, want := range cases {
+		assert.Equalf(t, want, routeName(daemon.HTTPRoute{Path: path}),
+			"routeName(%q)", path)
+	}
+}
+
 // TestAPICmd_JSONEmitsEnvelopeCatalog covers `af api --json`: the output is the
 // shared {data,error} envelope wrapping the endpoint catalog, and the endpoints
 // match daemon.HTTPRoutes exactly.

--- a/api/sessions.go
+++ b/api/sessions.go
@@ -79,7 +79,7 @@ func getSessionByTitle(title string) (*session.InstanceData, error) {
 			}
 		}
 		// Mirror findInstanceByTitle's clean-miss error so output is unchanged.
-		return nil, fmt.Errorf("instance %q %w", title, errTitleNotFound)
+		return nil, fmt.Errorf("session %q %w", title, errTitleNotFound)
 	}
 	// Remote target: no local disk fallback; surface the error (see snapshotRead).
 	if !fallBack {
@@ -407,7 +407,7 @@ results.`,
 			return jsonError(err)
 		}
 		if !exists {
-			return jsonError(fmt.Errorf("instance %q not found. Use --create to auto-create the session, or run: af sessions create --name %q --prompt <prompt>", title, title))
+			return jsonError(fmt.Errorf("session %q not found. Use --create to auto-create the session, or run: af sessions create --name %q --prompt <prompt>", title, title))
 		}
 
 		if err := sendPromptViaDaemon(daemon.SendPromptRequest{Title: title, RepoID: repoID, Prompt: prompt}); err != nil {
@@ -971,7 +971,7 @@ var sessionsAttachCmd = &cobra.Command{
 var sessionsWhoamiCmd = &cobra.Command{
 	Use:   "whoami",
 	Short: "Identify the current Agent Factory session",
-	Long:  "Returns the session info for the current tmux session by matching the tmux session name against stored instances.",
+	Long:  "Returns the session info for the current tmux session by matching the tmux session name against stored sessions.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Initialize(false)
 		defer log.Close()

--- a/api/sessions_watch.go
+++ b/api/sessions_watch.go
@@ -208,7 +208,7 @@ func getSessionByTitleInScope(repoID, title string) (*session.InstanceData, erro
 			return &data[i], nil
 		}
 	}
-	return nil, fmt.Errorf("instance %q %w", title, errTitleNotFound)
+	return nil, fmt.Errorf("session %q %w", title, errTitleNotFound)
 }
 
 var sessionsWatchCmd = &cobra.Command{

--- a/commands/reset.go
+++ b/commands/reset.go
@@ -260,7 +260,7 @@ func planFactoryReset() (*resetPlan, error) {
 
 	all, err := state.GetAllInstances()
 	if err != nil {
-		return nil, fmt.Errorf("failed to read stored instances: %w", err)
+		return nil, fmt.Errorf("failed to read stored sessions: %w", err)
 	}
 	for repoID, raw := range all {
 		if len(raw) == 0 || string(raw) == "[]" || string(raw) == "null" {
@@ -333,7 +333,7 @@ func planFactoryReset() (*resetPlan, error) {
 				continue
 			}
 			if _, ok := seen[e.Name()]; !ok {
-				log.WarningLog.Printf("reset: leaving repo %s intact: unreadable instance records", e.Name())
+				log.WarningLog.Printf("reset: leaving repo %s intact: unreadable session records", e.Name())
 				plan.corruptRepoIDs = append(plan.corruptRepoIDs, e.Name())
 			}
 		}
@@ -426,7 +426,7 @@ func executeFactoryReset(plan *resetPlan) (*resetSummary, error) {
 	// orphan that branch.
 	if len(plan.corruptRepoIDs) == 0 {
 		if err := plan.storage.DeleteAllInstances(); err != nil {
-			errs = append(errs, fmt.Errorf("reset instance storage: %w", err))
+			errs = append(errs, fmt.Errorf("reset session storage: %w", err))
 		}
 	} else {
 		for _, rid := range plan.processedRepoIDs {
@@ -519,7 +519,7 @@ func printResetPlan(out io.Writer, plan *resetPlan) {
 	fmt.Fprintf(out, "  • %d scheduled task(s)\n", plan.tasks)
 	fmt.Fprintf(out, "  • %d AF worktree(s) across %d repo(s)\n", plan.worktrees, len(plan.repoRoots))
 	fmt.Fprintf(out, "  • %d AF-created session branch(es)\n", plan.branchCount())
-	fmt.Fprintln(out, "  • all AF state (instances, archived sessions, events, logs, locks)")
+	fmt.Fprintln(out, "  • all AF state (live sessions, archived sessions, events, logs, locks)")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "WILL KEEP:")
 	fmt.Fprintln(out, "  • your git repositories (working tree, .git, and your own branches)")

--- a/commands/root.go
+++ b/commands/root.go
@@ -41,6 +41,14 @@ there, or expose the TLS+token TCP listener to the network (set a routable
 listen_addr) and point a client at it with the persistent
 --daemon-url/--token/--tls-fingerprint flags (see 'af token' for the credentials).
 Full guide: https://sachiniyer.github.io/agent-factory/remote-tcp-auth/`,
+		// A runtime (RunE) failure should print as one calm line, not a usage
+		// dump. Silencing usage here — after flag parsing has already succeeded —
+		// keeps the usage/flag help on flag-PARSE errors (which fail before this
+		// hook runs) while suppressing it for genuine runtime errors across every
+		// subcommand, since cobra checks the root command's SilenceUsage (#1749).
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			cmd.Root().SilenceUsage = true
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			log.Initialize(daemonFlag)
@@ -70,7 +78,7 @@ Full guide: https://sachiniyer.github.io/agent-factory/remote-tcp-auth/`,
 
 			repo, err := config.CurrentRepo()
 			if err != nil {
-				return fmt.Errorf("failed to determine repo context: %w", err)
+				return fmt.Errorf("failed to determine project context: %w", err)
 			}
 
 			// Resolve the effective config for this repo: app defaults ->
@@ -188,17 +196,23 @@ Full guide: https://sachiniyer.github.io/agent-factory/remote-tcp-auth/`,
 				return err
 			}
 
+			// SOURCE only annotates the rows that carry information: fixed
+			// (structural, un-rebindable) and rebound (with the default shown).
+			// The old DESCRIPTION column restated ACTION, and a SOURCE of
+			// "default" on every plain binding said nothing — both dropped so
+			// the table reads at a glance (#1749). A blank SOURCE means the
+			// action is on its built-in default.
 			w := tabwriter.NewWriter(cmd.OutOrStdout(), 2, 0, 3, ' ', 0)
-			fmt.Fprintln(w, "ACTION\tKEYS\tDESCRIPTION\tSOURCE")
+			fmt.Fprintln(w, "ACTION\tKEYS\tSOURCE")
 			for _, info := range infos {
-				action, source := info.Action, "default"
+				action, source := info.Action, ""
 				switch {
 				case info.Action == "":
 					action, source = "-", "fixed"
 				case info.Rebound:
 					source = fmt.Sprintf("rebound (default: %s)", strings.Join(info.Default, ", "))
 				}
-				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", action, strings.Join(info.Keys, ", "), info.Desc, source)
+				fmt.Fprintf(w, "%s\t%s\t%s\n", action, strings.Join(info.Keys, ", "), source)
 			}
 			return w.Flush()
 		},
@@ -213,6 +227,13 @@ func NewRootCommand(opts Options) *cobra.Command {
 	if opts.Version != "" {
 		version = opts.Version
 	}
+	// Setting Version makes cobra provide `af --version` (and -v) for free,
+	// instead of erroring with a usage dump (#1749). The `version` subcommand is
+	// kept; both share this format so they never drift.
+	rootCmd.Version = version
+	rootCmd.SetVersionTemplate(
+		"agent-factory version {{.Version}}\n" +
+			"https://github.com/sachiniyer/agent-factory/releases/tag/v{{.Version}}\n")
 	return rootCmd
 }
 
@@ -220,10 +241,10 @@ func init() {
 	// The --program flag is validated as an enum (bare agent name) via
 	// tmux.SupportedPrograms, so advertise exactly those accepted values.
 	rootCmd.Flags().StringVarP(&programFlag, "program", "p", "",
-		fmt.Sprintf("Program to run in new instances (one of: %s)",
+		fmt.Sprintf("Program to run in new sessions (one of: %s)",
 			tmux.SupportedProgramsString()))
 	rootCmd.Flags().BoolVarP(&autoYesFlag, "autoyes", "y", false,
-		"[experimental] If enabled, all instances will automatically accept prompts")
+		"[experimental] If enabled, all sessions will automatically accept prompts")
 	rootCmd.Flags().BoolVar(&daemonFlag, "daemon", false, "Run the background daemon that schedules"+
 		" tasks and runs autoyes mode on all sessions.")
 
@@ -241,12 +262,16 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&apiclient.FlagDaemonURL, "daemon-url", "",
 		"Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket "+
 			"(env: AF_DAEMON_URL). Requires --token.")
+	// NOTE: no backticks in these usage strings. pflag's UnquoteUsage treats the
+	// first backticked span as the flag's arg-name placeholder, so `af token
+	// show` would render "--token af token show" instead of "--token string" on
+	// every help screen (#1749). Use plain quotes for inline example commands.
 	rootCmd.PersistentFlags().StringVar(&apiclient.FlagDaemonToken, "token", "",
 		"Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). "+
-			"Get it with `af token show` on the daemon host.")
+			"Get it with 'af token show' on the daemon host.")
 	rootCmd.PersistentFlags().StringVar(&apiclient.FlagTLSFingerprint, "tls-fingerprint", "",
 		"Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert "+
-			"(env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`.")
+			"(env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'.")
 
 	rootCmd.AddCommand(debugCmd)
 	rootCmd.AddCommand(keysCmd)

--- a/commands/root_test.go
+++ b/commands/root_test.go
@@ -1,0 +1,55 @@
+package commands
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestVersionFlag covers #1749 item 7: `af --version` prints the version and
+// release URL instead of erroring with a usage dump. cobra provides the flag
+// (and -v) for free once rootCmd.Version is set in NewRootCommand.
+func TestVersionFlag(t *testing.T) {
+	origVersion := version
+	t.Cleanup(func() {
+		version = origVersion
+		rootCmd.Version = origVersion
+		rootCmd.SetArgs(nil)
+	})
+
+	cmd := NewRootCommand(Options{Version: "9.9.9"})
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--version"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("af --version returned error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "agent-factory version 9.9.9") {
+		t.Fatalf("--version output missing version string: %q", out)
+	}
+	if !strings.Contains(out, "releases/tag/v9.9.9") {
+		t.Fatalf("--version output missing release URL: %q", out)
+	}
+}
+
+// TestPersistentPreRunSilencesUsage covers #1749 item 2: after flag parsing has
+// succeeded (the point at which PersistentPreRun fires), the root command is set
+// to SilenceUsage so a runtime RunE error prints as one calm line instead of a
+// usage dump. Flag-PARSE errors fail before this hook runs, so their usage help
+// is preserved.
+func TestPersistentPreRunSilencesUsage(t *testing.T) {
+	origSilence := rootCmd.SilenceUsage
+	t.Cleanup(func() { rootCmd.SilenceUsage = origSilence })
+
+	rootCmd.SilenceUsage = false
+	if rootCmd.PersistentPreRun == nil {
+		t.Fatal("rootCmd.PersistentPreRun must be set to silence usage on runtime errors")
+	}
+	rootCmd.PersistentPreRun(rootCmd, nil)
+	if !rootCmd.SilenceUsage {
+		t.Fatal("PersistentPreRun did not set root SilenceUsage")
+	}
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -104,11 +104,11 @@ af [flags]
 
 | Flag | Type | Description |
 |------|------|-------------|
-| `-y`, `--autoyes` |  | [experimental] If enabled, all instances will automatically accept prompts |
+| `-y`, `--autoyes` |  | [experimental] If enabled, all sessions will automatically accept prompts |
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
-| `-p`, `--program` | `string` | Program to run in new instances (one of: claude, codex, aider, gemini, amp) |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `-p`, `--program` | `string` | Program to run in new sessions (one of: claude, codex, aider, gemini, amp) |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af agent-server
 
@@ -149,8 +149,8 @@ af agent-server [flags]
 | Flag | Type | Description |
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af api
 
@@ -182,8 +182,8 @@ af api [flags]
 | Flag | Type | Description |
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af bug-report
 
@@ -234,8 +234,8 @@ af bug-report [flags]
 | Flag | Type | Description |
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af completion
 
@@ -260,8 +260,8 @@ af completion
 | Flag | Type | Description |
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af completion bash
 
@@ -303,8 +303,8 @@ af completion bash
 | Flag | Type | Description |
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af completion fish
 
@@ -337,8 +337,8 @@ af completion fish [flags]
 | Flag | Type | Description |
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af completion powershell
 
@@ -368,8 +368,8 @@ af completion powershell [flags]
 | Flag | Type | Description |
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af completion zsh
 
@@ -413,8 +413,8 @@ af completion zsh [flags]
 | Flag | Type | Description |
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af config
 
@@ -444,8 +444,8 @@ af config
 | Flag | Type | Description |
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af config get
 
@@ -471,8 +471,8 @@ af config get <key> [flags]
 | Flag | Type | Description |
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af config list
 
@@ -493,8 +493,8 @@ af config list [flags]
 | Flag | Type | Description |
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af config set
 
@@ -545,8 +545,8 @@ af config set <key> <value> [flags]
 | Flag | Type | Description |
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af daemon
 
@@ -574,8 +574,8 @@ af daemon
 | Flag | Type | Description |
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af daemon install
 
@@ -590,8 +590,8 @@ af daemon install
 | Flag | Type | Description |
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af daemon restart
 
@@ -616,8 +616,8 @@ af daemon restart [flags]
 | Flag | Type | Description |
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af daemon status
 
@@ -648,8 +648,8 @@ af daemon status [flags]
 | Flag | Type | Description |
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af daemon uninstall
 
@@ -664,8 +664,8 @@ af daemon uninstall
 | Flag | Type | Description |
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af debug
 
@@ -680,8 +680,8 @@ af debug
 | Flag | Type | Description |
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af doctor
 
@@ -738,8 +738,8 @@ af doctor [flags]
 | Flag | Type | Description |
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af keys
 
@@ -760,8 +760,8 @@ af keys
 | Flag | Type | Description |
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af projects
 
@@ -786,8 +786,8 @@ af projects
 | Flag | Type | Description |
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af projects delete
 
@@ -820,8 +820,8 @@ af projects delete [repo]
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
 | `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af reset
 
@@ -859,8 +859,8 @@ af reset [flags]
 | Flag | Type | Description |
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af sessions
 
@@ -892,15 +892,15 @@ af sessions
 | Flag | Type | Description |
 |------|------|-------------|
 | `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
-| `--repo` | `string` | Path to git repository |
+| `--repo` | `string` | Path to the project's git repository |
 
 **Global flags**
 
 | Flag | Type | Description |
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af sessions archive
 
@@ -937,9 +937,9 @@ af sessions archive [title] [flags]
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
 | `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
-| `--repo` | `string` | Path to git repository |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--repo` | `string` | Path to the project's git repository |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af sessions attach
 
@@ -957,9 +957,9 @@ af sessions attach <title>
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
 | `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
-| `--repo` | `string` | Path to git repository |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--repo` | `string` | Path to the project's git repository |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af sessions create
 
@@ -994,9 +994,9 @@ af sessions create [flags]
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
 | `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
-| `--repo` | `string` | Path to git repository |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--repo` | `string` | Path to the project's git repository |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af sessions get
 
@@ -1012,9 +1012,9 @@ af sessions get <title>
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
 | `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
-| `--repo` | `string` | Path to git repository |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--repo` | `string` | Path to the project's git repository |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af sessions kill
 
@@ -1047,9 +1047,9 @@ af sessions kill <title> [flags]
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
 | `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
-| `--repo` | `string` | Path to git repository |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--repo` | `string` | Path to the project's git repository |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af sessions list
 
@@ -1065,9 +1065,9 @@ af sessions list
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
 | `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
-| `--repo` | `string` | Path to git repository |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--repo` | `string` | Path to the project's git repository |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af sessions preview
 
@@ -1083,9 +1083,9 @@ af sessions preview <title>
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
 | `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
-| `--repo` | `string` | Path to git repository |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--repo` | `string` | Path to the project's git repository |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af sessions restore
 
@@ -1111,9 +1111,9 @@ af sessions restore <title>
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
 | `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
-| `--repo` | `string` | Path to git repository |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--repo` | `string` | Path to the project's git repository |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af sessions send-prompt
 
@@ -1156,9 +1156,9 @@ af sessions send-prompt <title> <prompt> [flags]
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
 | `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
-| `--repo` | `string` | Path to git repository |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--repo` | `string` | Path to the project's git repository |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af sessions tab-create
 
@@ -1192,9 +1192,9 @@ af sessions tab-create <title> [flags]
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
 | `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
-| `--repo` | `string` | Path to git repository |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--repo` | `string` | Path to the project's git repository |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af sessions tab-delete
 
@@ -1228,9 +1228,9 @@ af sessions tab-delete <title> [flags]
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
 | `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
-| `--repo` | `string` | Path to git repository |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--repo` | `string` | Path to the project's git repository |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af sessions tabs
 
@@ -1257,9 +1257,9 @@ af sessions tabs
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
 | `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
-| `--repo` | `string` | Path to git repository |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--repo` | `string` | Path to the project's git repository |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af sessions tabs create
 
@@ -1284,9 +1284,9 @@ af sessions tabs create <title> [flags]
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
 | `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
-| `--repo` | `string` | Path to git repository |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--repo` | `string` | Path to the project's git repository |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af sessions tabs delete
 
@@ -1310,9 +1310,9 @@ af sessions tabs delete <title> [flags]
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
 | `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
-| `--repo` | `string` | Path to git repository |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--repo` | `string` | Path to the project's git repository |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af sessions watch
 
@@ -1350,15 +1350,15 @@ af sessions watch <title> [flags]
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
 | `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
-| `--repo` | `string` | Path to git repository |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--repo` | `string` | Path to the project's git repository |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af sessions whoami
 
 Identify the current Agent Factory session
 
-Returns the session info for the current tmux session by matching the tmux session name against stored instances.
+Returns the session info for the current tmux session by matching the tmux session name against stored sessions.
 
 ```
 af sessions whoami
@@ -1370,9 +1370,9 @@ af sessions whoami
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
 | `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
-| `--repo` | `string` | Path to git repository |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--repo` | `string` | Path to the project's git repository |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af tasks
 
@@ -1396,15 +1396,15 @@ af tasks
 | Flag | Type | Description |
 |------|------|-------------|
 | `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
-| `--repo` | `string` | Path to git repository |
+| `--repo` | `string` | Path to the project's git repository |
 
 **Global flags**
 
 | Flag | Type | Description |
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af tasks add
 
@@ -1431,9 +1431,9 @@ af tasks add [flags]
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
 | `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
-| `--repo` | `string` | Path to git repository |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--repo` | `string` | Path to the project's git repository |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af tasks get
 
@@ -1449,9 +1449,9 @@ af tasks get <id>
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
 | `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
-| `--repo` | `string` | Path to git repository |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--repo` | `string` | Path to the project's git repository |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af tasks list
 
@@ -1467,9 +1467,9 @@ af tasks list
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
 | `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
-| `--repo` | `string` | Path to git repository |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--repo` | `string` | Path to the project's git repository |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af tasks remove
 
@@ -1485,9 +1485,9 @@ af tasks remove <id>
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
 | `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
-| `--repo` | `string` | Path to git repository |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--repo` | `string` | Path to the project's git repository |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af tasks trigger
 
@@ -1503,9 +1503,9 @@ af tasks trigger <id>
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
 | `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
-| `--repo` | `string` | Path to git repository |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--repo` | `string` | Path to the project's git repository |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af tasks update
 
@@ -1533,9 +1533,9 @@ af tasks update <id> [flags]
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
 | `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
-| `--repo` | `string` | Path to git repository |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--repo` | `string` | Path to the project's git repository |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af token
 
@@ -1563,8 +1563,8 @@ af token
 | Flag | Type | Description |
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af token rotate
 
@@ -1592,8 +1592,8 @@ af token rotate [flags]
 | Flag | Type | Description |
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af token show
 
@@ -1622,8 +1622,8 @@ af token show [flags]
 | Flag | Type | Description |
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af upgrade
 
@@ -1652,8 +1652,8 @@ af upgrade [flags]
 | Flag | Type | Description |
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 
 ## af version
 
@@ -1668,6 +1668,6 @@ af version
 | Flag | Type | Description |
 |------|------|-------------|
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
-| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
-| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From 'af token show'. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
 

--- a/log/log.go
+++ b/log/log.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/pelletier/go-toml/v2"
@@ -30,6 +31,24 @@ var (
 	InfoLog    *log.Logger
 	ErrorLog   *log.Logger
 )
+
+// dirty is set the first time anything is written at WARNING or ERROR level in
+// the current run. Close only prints the "wrote logs to ..." note when the run
+// is dirty (something worth looking at was recorded) — a clean, successful
+// command ends with its own output instead of that bookkeeping line (#1749).
+// Initialize resets it so each logical run (the daemon reinitializes per task
+// trigger) starts fresh.
+var dirty atomic.Bool
+
+// dirtyWriter marks the run dirty on its first write, then delegates. It wraps
+// only the WARNING and ERROR sinks, so an INFO-only run (the common successful
+// case) stays clean.
+type dirtyWriter struct{ w io.Writer }
+
+func (d dirtyWriter) Write(p []byte) (int, error) {
+	dirty.Store(true)
+	return d.w.Write(p)
+}
 
 // Default the package-level loggers to discard sinks so callers that reach a
 // log call before Initialize do not nil-panic. Initialize replaces these with
@@ -394,6 +413,10 @@ func Initialize(daemon bool) {
 	mu.Lock()
 	defer mu.Unlock()
 
+	// Each run starts clean; only a WARNING/ERROR write makes Close report the
+	// log path (#1749).
+	dirty.Store(false)
+
 	logFileName = resolveLogPath()
 
 	// Close any previously opened log file to avoid leaking file descriptors
@@ -434,8 +457,8 @@ func Initialize(daemon bool) {
 			fmtS = "[DAEMON] %s"
 		}
 		InfoLog = log.New(os.Stderr, fmt.Sprintf(fmtS, "INFO:"), log.Ldate|log.Ltime|log.Lshortfile)
-		WarningLog = log.New(os.Stderr, fmt.Sprintf(fmtS, "WARNING:"), log.Ldate|log.Ltime|log.Lshortfile)
-		ErrorLog = log.New(os.Stderr, fmt.Sprintf(fmtS, "ERROR:"), log.Ldate|log.Ltime|log.Lshortfile)
+		WarningLog = log.New(dirtyWriter{os.Stderr}, fmt.Sprintf(fmtS, "WARNING:"), log.Ldate|log.Ltime|log.Lshortfile)
+		ErrorLog = log.New(dirtyWriter{os.Stderr}, fmt.Sprintf(fmtS, "ERROR:"), log.Ldate|log.Ltime|log.Lshortfile)
 		return
 	}
 
@@ -452,8 +475,8 @@ func Initialize(daemon bool) {
 		fmtS = "[DAEMON] %s"
 	}
 	InfoLog = log.New(w, fmt.Sprintf(fmtS, "INFO:"), log.Ldate|log.Ltime|log.Lshortfile)
-	WarningLog = log.New(w, fmt.Sprintf(fmtS, "WARNING:"), log.Ldate|log.Ltime|log.Lshortfile)
-	ErrorLog = log.New(w, fmt.Sprintf(fmtS, "ERROR:"), log.Ldate|log.Ltime|log.Lshortfile)
+	WarningLog = log.New(dirtyWriter{w}, fmt.Sprintf(fmtS, "WARNING:"), log.Ldate|log.Ltime|log.Lshortfile)
+	ErrorLog = log.New(dirtyWriter{w}, fmt.Sprintf(fmtS, "ERROR:"), log.Ldate|log.Ltime|log.Lshortfile)
 
 	globalLogFile = w
 }
@@ -496,7 +519,12 @@ func closeWithReport(report bool) {
 		_ = globalLogFile.Close()
 		globalLogFile = nil
 	}
-	if fileWasOpened && report {
+	// Only point the user at the log when the run actually recorded something
+	// worth reading (a WARNING/ERROR write set the dirty flag). A clean,
+	// successful command ends with its own result, not this bookkeeping line;
+	// and when nothing was logged there is nothing in the file to point at
+	// anyway, so suppressing it on a quiet non-zero exit loses nothing (#1749).
+	if fileWasOpened && report && dirty.Load() {
 		fmt.Fprintln(os.Stderr, "wrote logs to "+logFileName)
 	}
 }

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -222,16 +222,34 @@ func TestCloseClaimsFileOnlyWhenOpened(t *testing.T) {
 		}
 	})
 
-	t.Run("file opened: wrote-logs claim present", func(t *testing.T) {
+	t.Run("file opened and dirtied: wrote-logs claim present", func(t *testing.T) {
+		// #1749: the claim is printed only when the run actually logged
+		// something at WARNING/ERROR level (a WarningLog write dirties the run).
 		logPathOverride = filepath.Join(t.TempDir(), "agent-factory.log")
 		globalLogFile = nil
 		out := captureStderr(t, func() {
 			Initialize(false)
+			WarningLog.Print("something worth reporting")
 			Close()
 		})
 		want := "wrote logs to " + logFileName
 		if !strings.Contains(out, want) {
 			t.Fatalf("expected Close() to print %q; stderr: %q", want, out)
+		}
+	})
+
+	t.Run("file opened but clean: no wrote-logs claim", func(t *testing.T) {
+		// #1749: a successful command that logged nothing at WARNING/ERROR ends
+		// with its own output — Close() must not append the bookkeeping line.
+		logPathOverride = filepath.Join(t.TempDir(), "agent-factory.log")
+		globalLogFile = nil
+		out := captureStderr(t, func() {
+			Initialize(false)
+			InfoLog.Print("routine chatter does not dirty the run")
+			Close()
+		})
+		if strings.Contains(out, "wrote logs to") {
+			t.Fatalf("Close() claimed logs were written on a clean run; stderr: %q", out)
 		}
 	})
 }


### PR DESCRIPTION
Focused, low-risk CLI-hygiene slice from the designer audit (#1749). The color system, command grouping, `Example:` blocks, `config list` rendering, and `status_label` are intentionally **not** here — they're the separate follow-ups tracked in the issue.

## Items done (from #1749)

1. **[bug] Backtick flag-placeholder corruption on every help screen.** `--token`/`--tls-fingerprint` usage strings contained a backticked `` `af token show` `` span; pflag's `UnquoteUsage` treats the first backticked span as the flag's arg name, so help rendered `--token af token show`. Backticks removed → all ~20 help screens now show `--token string` / `--tls-fingerprint string`.
2. **Runtime errors triple-print → one calm line.** A root `PersistentPreRun` sets `SilenceUsage` *after* flag parsing succeeds (flag-PARSE errors still show usage, since they fail before the hook runs), and `jsonError` now silences cobra's duplicate `Error:` line on both the bare and `--json` envelope paths.
5. **Silence trailing `wrote logs to …` on success.** A WARNING/ERROR dirty-bit in the `log` pkg gates the note: it prints only when the run actually recorded something worth reading. Clean successful commands end with their result.
7. **`af --version` missing.** Set `rootCmd.Version` + a version template (version string + release URL); cobra now provides `--version`/`-v` for free. The `version` subcommand is kept.
8. **"instance" → "session"** in user-facing errors/help across `api/` and `commands/` (e.g. `session "x" not found`, `--program`/`--autoyes` help, reset summary). Internal Go types/vars and the real `instances.json` filename are untouched.
11. **`keys` table dead column.** Dropped the DESCRIPTION column (it restated ACTION) and omit the noise-only `default` SOURCE, so the table only annotates `fixed`/`rebound` rows.
12. **`af api` examples repeated each description verbatim.** Each curl is now anchored with a short `# CreateSession`-style comment (last path segment); the full description still appears once in the table above.
14. **Vocabulary → "project".** User-facing "repo/repository" wording reads "project" (`--repo` help is now "Path to the project's git repository"). The `--repo` flag name and all JSON fields are unchanged.

## Not in this PR (per #1749)
Color/weight system, root command grouping, broad short/long rewrites, `Example:` blocks, `config list` rendering, `status_label`.

## Verification
- `af --help` + several `af <cmd> --help` show correct `--token string` placeholders (no `af token show` leak).
- `af sessions get doesnotexist` → single line `{"error":"session \"doesnotexist\" not found"}`, no usage dump, no `wrote logs to`.
- Flag-parse error (`af sessions get --badflag`) still shows usage.
- Successful command (`af keys`) prints no `wrote logs to`.
- `af --version`, `af -v`, and `af version` all work.

## Gates (all green)
- `make test-container` — full suite ok
- `make tui-driver-selftest` — 25/25
- `go build ./...`, `gofmt -l .` clean, `golangci-lint run --fast`, `deadcode -test ./...` clean
- `scripts/gen-docs.sh` re-run → `docs/reference/cli.md` regenerated

New/adjusted tests: log dirty-bit (clean vs dirty run), `af --version`, the usage-silencing hook, and `af api` short-name/`routeName`.

Closes #1749 is **not** set — this is one slice of that issue; the remaining follow-ups stay tracked there.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)