### PR TITLE
feat(tui): project switcher navigates like the instances list (drop search) (#1461 follow-up)

### DIFF
--- a/app/switch_project.go
+++ b/app/switch_project.go
@@ -17,10 +17,11 @@ import (
 	"github.com/sachiniyer/agent-factory/ui/store"
 )
 
-// showProjectPickerOverlay opens the searchable project switcher (#1461): every
-// repo af has seen — the current project, repos with tracked sessions, and the
-// root_agents opt-ins — each with its session count, plus a "+ Add project…"
-// affordance for registering a new repo on the fly.
+// showProjectPickerOverlay opens the project switcher (#1461): every repo af has
+// seen — the current project, repos with tracked sessions, and the root_agents
+// opt-ins — each with its session count, plus a "+ Add project…" affordance for
+// registering a new repo on the fly. The picker navigates like the instances
+// rail (up/k, down/j over the full list); there is no search.
 func (m *home) showProjectPickerOverlay() (tea.Model, tea.Cmd) {
 	projects := m.buildProjectList()
 	m.projectPickerOverlay = overlay.NewProjectPickerOverlay(projects, m.repoRoot)

--- a/ui/overlay/projectPickerOverlay.go
+++ b/ui/overlay/projectPickerOverlay.go
@@ -20,18 +20,16 @@ type Project struct {
 	SessionCount int
 }
 
-// ProjectPickerOverlay is the searchable project switcher (#1461). It mirrors
-// SearchOverlay's idiom — a hand-rolled query buffer, fuzzy filter, windowed
-// list, Enter/Esc handling — and adds an "+ Add project…" affordance: selecting
-// the trailing add row switches the overlay into add mode, where the query line
-// becomes a repo-path input. Path validation and registration happen app-side
-// (this package must not shell out to git), so add mode reports the entered path
-// back to the caller, which validates and either switches or feeds an inline
-// error back via SetAddError.
+// ProjectPickerOverlay is the project switcher (#1461). It navigates like the
+// instances rail — a windowed list over ALL projects with up/k and down/j
+// cursor movement, Enter to switch, Esc to cancel; there is no search. It adds a
+// trailing "+ Add project…" affordance: selecting the add row switches the
+// overlay into add mode, where a repo-path input line appears. Path validation
+// and registration happen app-side (this package must not shell out to git), so
+// add mode reports the entered path back to the caller, which validates and
+// either switches or feeds an inline error back via SetAddError.
 type ProjectPickerOverlay struct {
-	all     []Project
-	results []Project
-	query   string
+	all []Project
 
 	selectedIdx int
 	width       int
@@ -61,8 +59,7 @@ func NewProjectPickerOverlay(projects []Project, currentRoot string) *ProjectPic
 		all:   projects,
 		width: 60,
 	}
-	p.updateResults()
-	for i, proj := range p.results {
+	for i, proj := range p.all {
 		if proj.Root == currentRoot {
 			p.selectedIdx = i
 			break
@@ -85,18 +82,18 @@ func (p *ProjectPickerOverlay) IsSubmitted() bool { return p.submitted }
 
 // SelectedProject returns the project the user chose, or false when none was.
 func (p *ProjectPickerOverlay) SelectedProject() (Project, bool) {
-	if p.submitted && p.selectedIdx >= 0 && p.selectedIdx < len(p.results) {
-		return p.results[p.selectedIdx], true
+	if p.submitted && p.selectedIdx >= 0 && p.selectedIdx < len(p.all) {
+		return p.all[p.selectedIdx], true
 	}
 	return Project{}, false
 }
 
-// rowCount is the number of navigable rows: the filtered projects plus the
-// trailing "+ Add project…" row, which is always present.
-func (p *ProjectPickerOverlay) rowCount() int { return len(p.results) + 1 }
+// rowCount is the number of navigable rows: every project plus the trailing
+// "+ Add project…" row, which is always present.
+func (p *ProjectPickerOverlay) rowCount() int { return len(p.all) + 1 }
 
 // addRowSelected reports whether the cursor is on the "+ Add project…" row.
-func (p *ProjectPickerOverlay) addRowSelected() bool { return p.selectedIdx == len(p.results) }
+func (p *ProjectPickerOverlay) addRowSelected() bool { return p.selectedIdx == len(p.all) }
 
 // TakeAddRequest returns a submitted add-mode path once, clearing the pending
 // flag so the caller validates it exactly once. The caller registers + switches
@@ -123,40 +120,31 @@ func (p *ProjectPickerOverlay) HandleKeyPress(msg tea.KeyMsg) bool {
 }
 
 func (p *ProjectPickerOverlay) handleListKey(msg tea.KeyMsg) bool {
-	switch msg.Type {
-	case tea.KeyEsc, tea.KeyCtrlC:
+	// The picker navigates like the instances rail: up/k and down/j move the
+	// cursor over the full list (clamped, no wrap), Enter switches, Esc cancels.
+	// There is no search — any other key (typed letters, etc.) is ignored.
+	switch msg.String() {
+	case "esc", "ctrl+c":
 		p.canceled = true
 		return true
-	case tea.KeyEnter:
+	case "enter":
 		if p.addRowSelected() {
 			p.adding = true
 			p.addErr = ""
 			return false
 		}
-		if len(p.results) > 0 {
+		if len(p.all) > 0 {
 			p.submitted = true
 			return true
 		}
-	case tea.KeyUp:
+	case "up", "k":
 		if p.selectedIdx > 0 {
 			p.selectedIdx--
 		}
-	case tea.KeyDown:
+	case "down", "j":
 		if p.selectedIdx < p.rowCount()-1 {
 			p.selectedIdx++
 		}
-	case tea.KeyBackspace:
-		if len(p.query) > 0 {
-			runes := []rune(p.query)
-			p.query = string(runes[:len(runes)-1])
-			p.updateResults()
-		}
-	case tea.KeySpace:
-		p.query += " "
-		p.updateResults()
-	case tea.KeyRunes:
-		p.query += string(msg.Runes)
-		p.updateResults()
 	}
 	return false
 }
@@ -188,29 +176,6 @@ func (p *ProjectPickerOverlay) handleAddKey(msg tea.KeyMsg) bool {
 		p.addErr = ""
 	}
 	return false
-}
-
-func (p *ProjectPickerOverlay) updateResults() {
-	p.results = nil
-	for _, proj := range p.all {
-		if p.matches(proj, p.query) {
-			p.results = append(p.results, proj)
-		}
-	}
-	// Clamp selection into the row range (projects + add row).
-	if p.selectedIdx >= p.rowCount() {
-		p.selectedIdx = p.rowCount() - 1
-	}
-	if p.selectedIdx < 0 {
-		p.selectedIdx = 0
-	}
-}
-
-func (p *ProjectPickerOverlay) matches(proj Project, query string) bool {
-	if query == "" {
-		return true
-	}
-	return fuzzyMatch(query, proj.Name) || fuzzyMatch(query, proj.Root)
 }
 
 // visibleWindow returns the [start, end) window over the navigable rows Render
@@ -269,12 +234,9 @@ func (p *ProjectPickerOverlay) Render() string {
 		return finishRender(style, fit, textRect, lines)
 	}
 
-	lines = append(lines, truncateOverlayLine("/ "+queryStyle.Render(p.query+"_"), cw))
-	lines = append(lines, "")
-
-	// Reserve rows for the fixed chrome (title, blank, query, blank, blank,
-	// hint) and window the navigable rows into what remains.
-	avail := textRect.H - 6
+	// Reserve rows for the fixed chrome (title, blank, blank, hint) and window
+	// the navigable rows into what remains.
+	avail := textRect.H - 4
 	if avail < 1 {
 		avail = 1
 	}
@@ -290,9 +252,9 @@ func (p *ProjectPickerOverlay) Render() string {
 	}
 
 	lines = append(lines, "")
-	hint := "↑/↓ navigate • enter switch • esc close"
+	hint := "j/k navigate • enter switch • esc cancel"
 	if lipgloss.Width(hint) > cw {
-		hint = "↑/↓ • enter • esc"
+		hint = "j/k • enter • esc"
 	}
 	lines = append(lines, truncateOverlayLine(hintStyle.Render(hint), cw))
 
@@ -303,14 +265,14 @@ func (p *ProjectPickerOverlay) Render() string {
 // "+ Add project…" affordance, highlighting the selected one.
 func (p *ProjectPickerOverlay) renderRow(i int, selectedStyle, normalStyle, countStyle, addStyle lipgloss.Style) string {
 	selected := i == p.selectedIdx
-	if i == len(p.results) {
+	if i == len(p.all) {
 		text := "+ Add project…"
 		if selected {
 			return "  " + selectedStyle.Render("▸ "+text)
 		}
 		return "    " + addStyle.Render(text)
 	}
-	proj := p.results[i]
+	proj := p.all[i]
 	count := countStyle.Render(fmt.Sprintf(" (%d)", proj.SessionCount))
 	if selected {
 		return "  " + selectedStyle.Render("▸ "+proj.Name) + count

--- a/ui/overlay/projectPickerOverlay_test.go
+++ b/ui/overlay/projectPickerOverlay_test.go
@@ -18,72 +18,98 @@ func pickerFixture() *ProjectPickerOverlay {
 	return NewProjectPickerOverlay(projects, "/repos/widgets")
 }
 
+// keyRune builds the KeyMsg for a typed rune (e.g. the vim nav keys j/k), which
+// arrive as KeyRunes and stringify to the bare character.
+func keyRune(r rune) tea.KeyMsg { return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}} }
+
 func typeRunes(p *ProjectPickerOverlay, s string) {
 	for _, r := range s {
 		if r == ' ' {
 			p.HandleKeyPress(tea.KeyMsg{Type: tea.KeySpace})
 			continue
 		}
-		p.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		p.HandleKeyPress(keyRune(r))
 	}
-}
-
-func resultNames(p *ProjectPickerOverlay) []string {
-	names := make([]string, len(p.results))
-	for i, r := range p.results {
-		names[i] = r.Name
-	}
-	return names
 }
 
 func TestProjectPickerCurrentRootPreselected(t *testing.T) {
 	p := pickerFixture()
-	// widgets sorts after agent-factory/afterburner; results are sorted by name:
-	// afterburner(0), agent-factory(1), widgets(2). currentRoot=/repos/widgets.
+	// widgets sorts after agent-factory/afterburner; the list is shown in the
+	// caller's order: afterburner(0), agent-factory(1), widgets(2).
+	// currentRoot=/repos/widgets, so the cursor starts on widgets (idx 2).
 	proj, ok := p.selectedProjectForTest()
 	if !ok || proj.Root != "/repos/widgets" {
 		t.Fatalf("expected the current project preselected, got %+v (ok=%v)", proj, ok)
 	}
 }
 
-func TestProjectPickerFuzzyAndSubstringFilter(t *testing.T) {
+func TestProjectPickerNavigatesFullListNoFilter(t *testing.T) {
 	p := pickerFixture()
-	// "af" is a subsequence of both "agent-factory" and "afterburner" but not
-	// "widgets".
-	typeRunes(p, "af")
-	got := resultNames(p)
-	if len(got) != 2 {
-		t.Fatalf("filter 'af' = %v, want 2 matches", got)
+	// Preselected on widgets (idx 2). The navigable rows are the FULL list plus
+	// the trailing add row: afterburner(0), agent-factory(1), widgets(2), add(3).
+	if p.selectedIdx != 2 {
+		t.Fatalf("expected preselect on widgets (idx 2), got %d", p.selectedIdx)
 	}
-	for _, n := range got {
-		if n == "widgets" {
-			t.Fatalf("filter 'af' should not match widgets: %v", got)
+
+	// down/j walks onto the add row and clamps there (no wrap), matching the rail.
+	p.HandleKeyPress(tea.KeyMsg{Type: tea.KeyDown})
+	if p.selectedIdx != 3 || !p.addRowSelected() {
+		t.Fatalf("Down should move onto the add row (idx 3); got %d addRow=%v", p.selectedIdx, p.addRowSelected())
+	}
+	p.HandleKeyPress(keyRune('j'))
+	if p.selectedIdx != 3 {
+		t.Fatalf("j at the bottom should clamp, got %d", p.selectedIdx)
+	}
+
+	// k walks back up across every project — the whole list, unfiltered:
+	// add(3) -> widgets(2) -> agent-factory(1) -> afterburner(0).
+	for _, want := range []int{2, 1, 0} {
+		p.HandleKeyPress(keyRune('k'))
+		if p.selectedIdx != want {
+			t.Fatalf("k should move to idx %d, got %d", want, p.selectedIdx)
 		}
 	}
-}
+	// up at the top clamps (no wrap).
+	p.HandleKeyPress(tea.KeyMsg{Type: tea.KeyUp})
+	if p.selectedIdx != 0 {
+		t.Fatalf("Up at the top should clamp, got %d", p.selectedIdx)
+	}
 
-func TestProjectPickerFilterMatchesPath(t *testing.T) {
-	p := pickerFixture()
-	typeRunes(p, "repos/widg")
-	if got := resultNames(p); len(got) != 1 || got[0] != "widgets" {
-		t.Fatalf("path filter = %v, want [widgets]", got)
+	// The full project list is intact — navigation never filters.
+	if len(p.all) != 3 {
+		t.Fatalf("navigation must not change the list; len(all)=%d", len(p.all))
 	}
 }
 
-func TestProjectPickerAddRowAlwaysNavigableAndLast(t *testing.T) {
+func TestProjectPickerTypingDoesNotFilter(t *testing.T) {
 	p := pickerFixture()
-	// Filter to a single project: rows are [widgets, +Add]. The add row is the
-	// last navigable index and is always reachable, even when the filter empties
-	// the project list.
-	typeRunes(p, "zzz-no-match")
-	if len(p.results) != 0 {
-		t.Fatalf("expected no project matches, got %v", resultNames(p))
+	before := p.selectedIdx
+	// Typed letters do nothing in list mode: no filtering, no cursor movement,
+	// no accidental add-mode entry.
+	typeRunes(p, "af repos/widg zzz")
+	if len(p.all) != 3 {
+		t.Fatalf("typing must not filter the list; len(all)=%d", len(p.all))
 	}
-	if p.rowCount() != 1 {
-		t.Fatalf("add row must remain navigable with an empty filter; rowCount=%d", p.rowCount())
+	if p.selectedIdx != before {
+		t.Fatalf("typing must not move the cursor; got %d want %d", p.selectedIdx, before)
+	}
+	if p.adding {
+		t.Fatalf("typing must not enter add mode")
+	}
+}
+
+func TestProjectPickerAddRowAlwaysLastAndReachable(t *testing.T) {
+	p := pickerFixture()
+	// The add row is the last navigable index, one past the projects.
+	if p.rowCount() != len(p.all)+1 {
+		t.Fatalf("rowCount should be projects+1; got %d for %d projects", p.rowCount(), len(p.all))
+	}
+	// Jumping down past the last project lands on the add row.
+	for i := 0; i < 5; i++ {
+		p.HandleKeyPress(keyRune('j'))
 	}
 	if !p.addRowSelected() {
-		t.Fatalf("with no project matches the cursor should land on the add row")
+		t.Fatalf("Down past the last project should land on the add row; idx=%d", p.selectedIdx)
 	}
 }
 
@@ -170,7 +196,7 @@ func TestProjectPickerEscCancels(t *testing.T) {
 	}
 }
 
-func TestProjectPickerRenderShowsCounts(t *testing.T) {
+func TestProjectPickerRenderShowsCountsAndNavHint(t *testing.T) {
 	p := pickerFixture()
 	p.SetMaxSize(80, 24)
 	out := p.Render()
@@ -180,13 +206,17 @@ func TestProjectPickerRenderShowsCounts(t *testing.T) {
 	if !strings.Contains(out, "Add project") {
 		t.Fatalf("render should show the add-project affordance; got:\n%s", out)
 	}
+	// The footer advertises rail-style navigation, not search.
+	if !strings.Contains(out, "navigate") || !strings.Contains(out, "switch") {
+		t.Fatalf("render should show the j/k navigate hint; got:\n%s", out)
+	}
 }
 
 // selectedProjectForTest returns the row under the cursor as a Project without
 // requiring submission, for assertions on the initial highlight.
 func (p *ProjectPickerOverlay) selectedProjectForTest() (Project, bool) {
-	if p.selectedIdx >= 0 && p.selectedIdx < len(p.results) {
-		return p.results[p.selectedIdx], true
+	if p.selectedIdx >= 0 && p.selectedIdx < len(p.all) {
+		return p.all[p.selectedIdx], true
 	}
 	return Project{}, false
 }


### PR DESCRIPTION
## What

Makes the ctrl+p project switcher (`ProjectPickerOverlay`, #1461) navigate **exactly like the instances/sidebar rail** — no search.

Previously the picker had a fuzzy **search**: a query buffer, an `updateResults()` filter over `all -> results`, and typed characters narrowed the list. Sachin asked for it to be navigated like the instances list instead.

## Changes

- **List mode shows ALL projects** (`p.all`) directly. `up`/`k` and `down`/`j` move the cursor over the full list, **clamped at the ends (no wrap)** — matching `ui/sidebar_nav.go` `Up()`/`Down()` and `ProjectsPane`. `Enter` switches, `Esc` cancels (both unchanged). Typed letters are ignored in list mode.
- **Dropped** the `query` buffer, `updateResults()`, `results[]`, and the picker-local `matches()` fuzzy helper. The shared `fuzzyMatch` (still used by the instance search overlay) is untouched, so `deadcode` stays clean.
- **"+ Add project…" row and add mode are UNCHANGED**: the add-mode path input is data entry (a new repo path), *not* search, so it stays — along with the `SetAddError` / `TakeAddRequest` validation flow. Selecting the add row still enters add mode.
- **Render** drops the `/ query_` search line + hint; the footer now reads `j/k navigate • enter switch • esc cancel` (with a short `j/k • enter • esc` fallback for narrow rails).
- `currentRoot` **pre-selection** still highlights the active project row.
- Updated the stale "searchable project switcher" doc comment in `app/switch_project.go`. The app-facing API (`HandleKeyPress`, `SelectedProject`, `TakeAddRequest`, `SetAddError`) is unchanged, so `switch_project.go` behavior is preserved.

## Tests

`ui/overlay/projectPickerOverlay_test.go` rewritten:
- `j`/`k` and `up`/`down` move over the **full** list with **no filtering** (and clamp at the ends).
- Typed letters do **not** filter the list or move the cursor, and do not enter add mode.
- `Enter` on a project row switches (`SelectedProject` returns it); `Esc` cancels.
- The "+ Add project…" row stays last/reachable and its path-input add flow (`TakeAddRequest` + `SetAddError`) still works.
- `currentRoot` pre-selection still highlights the active project.

## Gates (all green)

- `go build ./...` ✓
- `gofmt -l .` clean ✓
- `golangci-lint run --fast` ✓
- `deadcode -test ./...` clean ✓
- `make tui-driver-selftest` → 25/25 ✓
- `make test-container` → all packages ok ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)