### PR TITLE
feat(web): design-token system + first-class light/dark theming (redesign PR1)

### DIFF
--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -801,13 +801,15 @@ body {
   flex-direction: column;
   height: 100%;
   min-height: 0;
+  background: var(--af-bg-term);
 }
 .af-webpane-bar {
   display: flex;
   align-items: center;
   gap: var(--af-sp-2);
   padding: var(--af-sp-1) 0.4rem;
-  border-bottom: 1px solid var(--af-border);
+  background: var(--af-bg-surface);
+  border-bottom: 1px solid var(--af-border-subtle);
   font-size: var(--af-fs-sm);
 }
 .af-webpane-reload {
@@ -844,7 +846,7 @@ body {
   min-height: 0;
   width: 100%;
   border: 0;
-  background: var(--af-bg-surface);
+  background: var(--af-bg-term);
 }
 .af-webpane-fallback {
   display: flex;
@@ -855,7 +857,7 @@ body {
   flex: 1 1 0;
   padding: var(--af-sp-4);
   text-align: center;
-  color: var(--af-text);
+  color: var(--af-text-2);
 }
 .af-webpane-fallback[hidden] {
   display: none;

--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -1,27 +1,183 @@
 /* src/styles.css */
 :root {
-  --af-bg: #0d1117;
-  --af-surface: #161b22;
-  --af-border: #30363d;
-  --af-text: #e6edf3;
-  --af-muted: #8b949e;
-  --af-accent: #2f81f7;
-  --af-accent-text: #ffffff;
-  --af-error: #f85149;
-  --af-radius: 8px;
+  color-scheme: light;
+  --af-font-ui:
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI Variable",
+    "Segoe UI",
+    Roboto,
+    Ubuntu,
+    "Helvetica Neue",
+    sans-serif;
+  --af-font-mono:
+    ui-monospace,
+    "SF Mono",
+    SFMono-Regular,
+    "Cascadia Code",
+    "JetBrains Mono",
+    Menlo,
+    Consolas,
+    monospace;
+  --af-fs-2xs: 0.6875rem;
+  --af-fs-xs: 0.75rem;
+  --af-fs-sm: 0.8125rem;
+  --af-fs-md: 0.875rem;
+  --af-fs-lg: 1rem;
+  --af-fs-xl: 1.25rem;
+  --af-track: 0.07em;
+  --af-sp-1: 0.25rem;
+  --af-sp-2: 0.5rem;
+  --af-sp-3: 0.75rem;
+  --af-sp-4: 1rem;
+  --af-sp-5: 1.5rem;
+  --af-sp-6: 2rem;
+  --af-r-sm: 4px;
+  --af-r-md: 6px;
+  --af-r-lg: 10px;
+  --af-r-full: 999px;
+  --af-bg-canvas: #f4f6f9;
+  --af-bg-surface: #ffffff;
+  --af-bg-inset: #eceff4;
+  --af-bg-raised: #ffffff;
+  --af-bg-term: #fdfefe;
+  --af-border: #d8dee8;
+  --af-border-subtle: #e6eaf1;
+  --af-border-strong: #b9c2cf;
+  --af-text: #17202e;
+  --af-text-2: #56627a;
+  --af-text-3: #8792a3;
+  --af-accent: #2f5fd8;
+  --af-accent-hover: #2a53be;
+  --af-accent-subtle: rgba(47, 95, 216, 0.09);
+  --af-accent-tint: rgba(47, 95, 216, 0.16);
+  --af-on-accent: #ffffff;
+  --af-danger: #c9372c;
+  --af-danger-subtle: rgba(201, 55, 44, 0.09);
+  --af-dot-ready: #257a3e;
+  --af-dot-lost: #93650a;
+  --af-dot-dead: #6e7887;
+  --af-dot-archived: #6e7887;
+  --af-dot-limit: #b13d33;
+  --af-dot-working: #17202e;
+  --af-term-green: #1f7a33;
+  --af-term-amber: #93650a;
+  --af-term-blue: #2f5fd8;
+  --af-term-dim: #8792a3;
+  --af-shadow-1: 0 1px 2px rgba(16, 24, 40, 0.05), 0 1px 3px rgba(16, 24, 40, 0.08);
+  --af-shadow-2: 0 4px 10px rgba(16, 24, 40, 0.08), 0 2px 4px rgba(16, 24, 40, 0.06);
+  --af-shadow-overlay: 0 16px 48px rgba(16, 24, 40, 0.22), 0 4px 12px rgba(16, 24, 40, 0.12);
+  --af-backdrop: rgba(23, 32, 46, 0.42);
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: dark;
+    --af-bg-canvas: #0e1218;
+    --af-bg-surface: #141a22;
+    --af-bg-inset: #0b0f15;
+    --af-bg-raised: #1a212b;
+    --af-bg-term: #0c1016;
+    --af-border: #262e3a;
+    --af-border-subtle: #1d242e;
+    --af-border-strong: #39434f;
+    --af-text: #e7ecf3;
+    --af-text-2: #98a3b3;
+    --af-text-3: #626d7d;
+    --af-accent: #7aa2f7;
+    --af-accent-hover: #91b3f9;
+    --af-accent-subtle: rgba(122, 162, 247, 0.12);
+    --af-accent-tint: rgba(122, 162, 247, 0.2);
+    --af-on-accent: #0e1218;
+    --af-danger: #f0655c;
+    --af-danger-subtle: rgba(240, 101, 92, 0.12);
+    --af-dot-ready: #7f9f7f;
+    --af-dot-lost: #f0dfaf;
+    --af-dot-dead: #989890;
+    --af-dot-archived: #989890;
+    --af-dot-limit: #cc9393;
+    --af-dot-working: #e7ecf3;
+    --af-term-green: #7f9f7f;
+    --af-term-amber: #f0dfaf;
+    --af-term-blue: #7aa2f7;
+    --af-term-dim: #626d7d;
+    --af-shadow-1: 0 1px 2px rgba(0, 0, 0, 0.4);
+    --af-shadow-2: 0 4px 10px rgba(0, 0, 0, 0.45);
+    --af-shadow-overlay: 0 16px 48px rgba(0, 0, 0, 0.6), 0 0 0 1px rgba(255, 255, 255, 0.04);
+    --af-backdrop: rgba(4, 7, 12, 0.66);
+  }
+}
+:root[data-theme=light] {
+  color-scheme: light;
+  --af-bg-canvas: #f4f6f9;
+  --af-bg-surface: #ffffff;
+  --af-bg-inset: #eceff4;
+  --af-bg-raised: #ffffff;
+  --af-bg-term: #fdfefe;
+  --af-border: #d8dee8;
+  --af-border-subtle: #e6eaf1;
+  --af-border-strong: #b9c2cf;
+  --af-text: #17202e;
+  --af-text-2: #56627a;
+  --af-text-3: #8792a3;
+  --af-accent: #2f5fd8;
+  --af-accent-hover: #2a53be;
+  --af-accent-subtle: rgba(47, 95, 216, 0.09);
+  --af-accent-tint: rgba(47, 95, 216, 0.16);
+  --af-on-accent: #ffffff;
+  --af-danger: #c9372c;
+  --af-danger-subtle: rgba(201, 55, 44, 0.09);
+  --af-dot-ready: #257a3e;
+  --af-dot-lost: #93650a;
+  --af-dot-dead: #6e7887;
+  --af-dot-archived: #6e7887;
+  --af-dot-limit: #b13d33;
+  --af-dot-working: #17202e;
+  --af-term-green: #1f7a33;
+  --af-term-amber: #93650a;
+  --af-term-blue: #2f5fd8;
+  --af-term-dim: #8792a3;
+  --af-shadow-1: 0 1px 2px rgba(16, 24, 40, 0.05), 0 1px 3px rgba(16, 24, 40, 0.08);
+  --af-shadow-2: 0 4px 10px rgba(16, 24, 40, 0.08), 0 2px 4px rgba(16, 24, 40, 0.06);
+  --af-shadow-overlay: 0 16px 48px rgba(16, 24, 40, 0.22), 0 4px 12px rgba(16, 24, 40, 0.12);
+  --af-backdrop: rgba(23, 32, 46, 0.42);
+}
+:root[data-theme=dark] {
+  color-scheme: dark;
+  --af-bg-canvas: #0e1218;
+  --af-bg-surface: #141a22;
+  --af-bg-inset: #0b0f15;
+  --af-bg-raised: #1a212b;
+  --af-bg-term: #0c1016;
+  --af-border: #262e3a;
+  --af-border-subtle: #1d242e;
+  --af-border-strong: #39434f;
+  --af-text: #e7ecf3;
+  --af-text-2: #98a3b3;
+  --af-text-3: #626d7d;
+  --af-accent: #7aa2f7;
+  --af-accent-hover: #91b3f9;
+  --af-accent-subtle: rgba(122, 162, 247, 0.12);
+  --af-accent-tint: rgba(122, 162, 247, 0.2);
+  --af-on-accent: #0e1218;
+  --af-danger: #f0655c;
+  --af-danger-subtle: rgba(240, 101, 92, 0.12);
   --af-dot-ready: #7f9f7f;
   --af-dot-lost: #f0dfaf;
   --af-dot-dead: #989890;
   --af-dot-archived: #989890;
   --af-dot-limit: #cc9393;
-  --af-dot-working: #e6edf3;
-  font-family:
-    ui-monospace,
-    SFMono-Regular,
-    "SF Mono",
-    Menlo,
-    Consolas,
-    monospace;
+  --af-dot-working: #e7ecf3;
+  --af-term-green: #7f9f7f;
+  --af-term-amber: #f0dfaf;
+  --af-term-blue: #7aa2f7;
+  --af-term-dim: #626d7d;
+  --af-shadow-1: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --af-shadow-2: 0 4px 10px rgba(0, 0, 0, 0.45);
+  --af-shadow-overlay: 0 16px 48px rgba(0, 0, 0, 0.6), 0 0 0 1px rgba(255, 255, 255, 0.04);
+  --af-backdrop: rgba(4, 7, 12, 0.66);
+}
+:root {
+  font-family: var(--af-font-ui);
 }
 * {
   box-sizing: border-box;
@@ -29,9 +185,26 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background: var(--af-bg);
+  background: var(--af-bg-canvas);
   color: var(--af-text);
   overflow-x: hidden;
+}
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--af-border-strong) transparent;
+}
+*::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+*::-webkit-scrollbar-thumb {
+  background: var(--af-border-strong);
+  border-radius: var(--af-r-full);
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+*::-webkit-scrollbar-track {
+  background: transparent;
 }
 .af-primary:focus-visible,
 .af-ghost:focus-visible,
@@ -41,6 +214,7 @@ body {
 .af-tab:focus-visible,
 .af-tab-new:focus-visible,
 .af-viewtab:focus-visible,
+.af-theme-opt:focus-visible,
 .af-task-action:focus-visible {
   outline: 2px solid var(--af-accent);
   outline-offset: 2px;
@@ -53,32 +227,34 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 1.5rem;
+  padding: var(--af-sp-5);
 }
 .af-card {
   width: 100%;
   max-width: 26rem;
-  background: var(--af-surface);
+  background: var(--af-bg-surface);
   border: 1px solid var(--af-border);
-  border-radius: var(--af-radius);
-  padding: 2rem;
+  border-radius: var(--af-r-lg);
+  box-shadow: var(--af-shadow-2);
+  padding: var(--af-sp-6);
 }
 .af-title {
-  margin: 0 0 0.5rem;
-  font-size: 1.4rem;
+  margin: 0 0 var(--af-sp-2);
+  font-size: var(--af-fs-xl);
   font-weight: 600;
 }
 .af-subtitle {
-  margin: 0 0 1.5rem;
-  color: var(--af-muted);
-  font-size: 0.85rem;
+  margin: 0 0 var(--af-sp-5);
+  color: var(--af-text-2);
+  font-size: var(--af-fs-md);
   line-height: 1.5;
 }
 .af-subtitle code {
+  font-family: var(--af-font-mono);
   color: var(--af-text);
-  background: var(--af-bg);
+  background: var(--af-bg-inset);
   padding: 0.1rem 0.35rem;
-  border-radius: 4px;
+  border-radius: var(--af-r-sm);
 }
 .af-login-form {
   display: flex;
@@ -86,20 +262,20 @@ body {
   gap: 0.6rem;
 }
 .af-field-label {
-  font-size: 0.75rem;
-  color: var(--af-muted);
+  font-size: var(--af-fs-xs);
+  color: var(--af-text-2);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: var(--af-track);
 }
 .af-login-form input {
   width: 100%;
-  padding: 0.65rem 0.75rem;
-  background: var(--af-bg);
+  padding: 0.65rem var(--af-sp-3);
+  background: var(--af-bg-inset);
   border: 1px solid var(--af-border);
-  border-radius: 6px;
+  border-radius: var(--af-r-md);
   color: var(--af-text);
   font: inherit;
-  font-size: 0.9rem;
+  font-size: var(--af-fs-md);
 }
 .af-login-form input:focus {
   outline: none;
@@ -107,23 +283,26 @@ body {
 }
 .af-primary {
   margin-top: 0.4rem;
-  padding: 0.65rem 0.75rem;
+  padding: 0.65rem var(--af-sp-3);
   background: var(--af-accent);
-  color: var(--af-accent-text);
+  color: var(--af-on-accent);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--af-r-md);
   font: inherit;
   font-weight: 600;
   cursor: pointer;
+}
+.af-primary:hover {
+  background: var(--af-accent-hover);
 }
 .af-primary:disabled {
   opacity: 0.6;
   cursor: default;
 }
 .af-error {
-  margin: 1rem 0 0;
-  color: var(--af-error);
-  font-size: 0.8rem;
+  margin: var(--af-sp-4) 0 0;
+  color: var(--af-danger);
+  font-size: var(--af-fs-sm);
   line-height: 1.4;
 }
 .af-app {
@@ -134,14 +313,15 @@ body {
 .af-appbar {
   display: flex;
   align-items: center;
-  gap: 1rem;
-  padding: 0.75rem 1.25rem;
-  background: var(--af-surface);
+  gap: var(--af-sp-4);
+  padding: var(--af-sp-3) var(--af-sp-5);
+  background: var(--af-bg-surface);
   border-bottom: 1px solid var(--af-border);
   flex-wrap: wrap;
 }
 .af-brand {
   font-weight: 600;
+  letter-spacing: var(--af-track);
 }
 .af-appbar .af-live {
   margin-left: auto;
@@ -150,14 +330,14 @@ body {
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
-  font-size: 0.75rem;
-  color: var(--af-muted);
+  font-size: var(--af-fs-xs);
+  color: var(--af-text-2);
 }
 .af-live-pip {
   width: 0.55rem;
   height: 0.55rem;
   border-radius: 50%;
-  background: var(--af-muted);
+  background: var(--af-text-3);
 }
 .af-live-pip.af-live-open {
   background: var(--af-dot-ready);
@@ -168,18 +348,46 @@ body {
   animation: af-pulse 1.2s ease-in-out infinite;
 }
 .af-ghost {
-  padding: 0.4rem 0.75rem;
+  padding: 0.4rem var(--af-sp-3);
   background: transparent;
-  color: var(--af-muted);
+  color: var(--af-text-2);
   border: 1px solid var(--af-border);
-  border-radius: 6px;
+  border-radius: var(--af-r-md);
   font: inherit;
-  font-size: 0.8rem;
+  font-size: var(--af-fs-sm);
   cursor: pointer;
 }
 .af-ghost:hover {
   color: var(--af-text);
-  border-color: var(--af-muted);
+  border-color: var(--af-border-strong);
+}
+.af-theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.1rem;
+  padding: 0.15rem;
+  background: var(--af-bg-inset);
+  border: 1px solid var(--af-border);
+  border-radius: var(--af-r-full);
+}
+.af-theme-opt {
+  padding: 0.2rem 0.55rem;
+  background: transparent;
+  color: var(--af-text-2);
+  border: none;
+  border-radius: var(--af-r-full);
+  font: inherit;
+  font-size: var(--af-fs-2xs);
+  line-height: 1.4;
+  cursor: pointer;
+}
+.af-theme-opt:hover {
+  color: var(--af-text);
+}
+.af-theme-opt-active {
+  background: var(--af-accent-subtle);
+  color: var(--af-accent);
+  font-weight: 600;
 }
 .af-body {
   flex: 1;
@@ -190,7 +398,7 @@ body {
   width: 18rem;
   flex: 0 0 18rem;
   border-right: 1px solid var(--af-border);
-  background: var(--af-surface);
+  background: var(--af-bg-surface);
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -211,18 +419,18 @@ body {
   box-shadow: inset 0 0 0 1px var(--af-accent);
 }
 .af-rail-title {
-  font-size: 0.7rem;
+  font-size: var(--af-fs-xs);
   text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--af-muted);
+  letter-spacing: var(--af-track);
+  color: var(--af-text-2);
 }
 .af-rail-count {
-  font-size: 0.75rem;
-  color: var(--af-muted);
-  background: var(--af-bg);
+  font-size: var(--af-fs-xs);
+  color: var(--af-text-2);
+  background: var(--af-bg-inset);
   border: 1px solid var(--af-border);
-  border-radius: 999px;
-  padding: 0.05rem 0.5rem;
+  border-radius: var(--af-r-full);
+  padding: 0.05rem var(--af-sp-2);
 }
 .af-rail-list {
   list-style: none;
@@ -232,30 +440,31 @@ body {
   flex: 1;
 }
 .af-rail-empty {
-  padding: 1rem 0.75rem;
-  color: var(--af-muted);
-  font-size: 0.8rem;
+  padding: var(--af-sp-4) var(--af-sp-3);
+  color: var(--af-text-2);
+  font-size: var(--af-fs-sm);
   line-height: 1.5;
 }
 .af-rail-empty code {
+  font-family: var(--af-font-mono);
   color: var(--af-text);
 }
 .af-row {
   display: flex;
   align-items: flex-start;
-  gap: 0.5rem;
-  padding: 0.5rem 0.6rem;
-  border-radius: 6px;
+  gap: var(--af-sp-2);
+  padding: var(--af-sp-2) 0.6rem;
+  border-radius: var(--af-r-md);
   cursor: pointer;
 }
 .af-row:hover {
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--af-bg-inset);
 }
 .af-row-selected {
-  background: rgba(47, 129, 247, 0.16);
+  background: var(--af-accent-subtle);
 }
 .af-row-selected:hover {
-  background: rgba(47, 129, 247, 0.22);
+  background: var(--af-accent-tint);
 }
 .af-row-archived {
   opacity: 0.55;
@@ -265,15 +474,15 @@ body {
   flex: 1;
 }
 .af-row-title {
-  font-size: 0.85rem;
+  font-size: var(--af-fs-md);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 .af-row-branch {
   margin-top: 0.15rem;
-  font-size: 0.72rem;
-  color: var(--af-muted);
+  font-size: var(--af-fs-xs);
+  color: var(--af-text-2);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -284,7 +493,7 @@ body {
 .af-dot {
   flex: 0 0 auto;
   line-height: 1.4;
-  font-size: 0.8rem;
+  font-size: var(--af-fs-sm);
 }
 .af-dot-ready {
   color: var(--af-dot-ready);
@@ -325,17 +534,17 @@ body {
   align-items: center;
   justify-content: center;
   gap: 0.4rem;
-  padding: 2rem;
+  padding: var(--af-sp-6);
   text-align: center;
 }
 .af-empty-title {
   margin: 0;
-  font-size: 1.1rem;
+  font-size: var(--af-fs-lg);
 }
 .af-empty-hint {
   margin: 0;
-  color: var(--af-muted);
-  font-size: 0.85rem;
+  color: var(--af-text-2);
+  font-size: var(--af-fs-md);
 }
 .af-main-term {
   min-height: 0;
@@ -345,9 +554,9 @@ body {
   align-items: center;
   justify-content: space-between;
   gap: 0.6rem;
-  padding: 0.5rem 0.9rem;
+  padding: var(--af-sp-2) 0.9rem;
   border-bottom: 1px solid var(--af-border);
-  background: var(--af-surface);
+  background: var(--af-bg-surface);
 }
 .af-term-head-main {
   display: flex;
@@ -363,18 +572,18 @@ body {
 }
 .af-term-action {
   padding: 0.3rem 0.6rem;
-  font-size: 0.75rem;
+  font-size: var(--af-fs-xs);
 }
 .af-term-title {
-  font-size: 0.85rem;
+  font-size: var(--af-fs-md);
   font-weight: 600;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 .af-term-meta {
-  font-size: 0.72rem;
-  color: var(--af-muted);
+  font-size: var(--af-fs-xs);
+  color: var(--af-text-2);
   white-space: nowrap;
 }
 .af-term-meta.af-term-open {
@@ -392,7 +601,7 @@ body {
   align-items: stretch;
   gap: 0.15rem;
   padding: 0 0.6rem;
-  background: var(--af-surface);
+  background: var(--af-bg-surface);
   border-bottom: 1px solid var(--af-border);
   overflow-x: auto;
   scrollbar-width: thin;
@@ -403,12 +612,12 @@ body {
   gap: 0.35rem;
   padding: 0.35rem 0.6rem;
   background: transparent;
-  color: var(--af-muted);
+  color: var(--af-text-2);
   border: none;
   border-bottom: 2px solid transparent;
   border-radius: 0;
   font: inherit;
-  font-size: 0.75rem;
+  font-size: var(--af-fs-xs);
   white-space: nowrap;
   cursor: pointer;
 }
@@ -440,14 +649,14 @@ body {
   justify-content: center;
   width: 1.1em;
   height: 1.1em;
-  border-radius: 3px;
-  color: var(--af-muted);
-  font-size: 0.9rem;
+  border-radius: var(--af-r-sm);
+  color: var(--af-text-2);
+  font-size: var(--af-fs-md);
   line-height: 1;
 }
 .af-tab-close:hover {
-  color: var(--af-error);
-  background: rgba(248, 81, 73, 0.14);
+  color: var(--af-danger);
+  background: var(--af-danger-subtle);
 }
 .af-tab-new {
   padding: 0.35rem 0.55rem;
@@ -456,7 +665,7 @@ body {
   border: none;
   border-radius: 0;
   font: inherit;
-  font-size: 0.85rem;
+  font-size: var(--af-fs-md);
   font-weight: 600;
   line-height: 1;
   cursor: pointer;
@@ -466,18 +675,18 @@ body {
 }
 .af-toast {
   position: fixed;
-  right: 1.25rem;
-  bottom: 1.25rem;
+  right: var(--af-sp-5);
+  bottom: var(--af-sp-5);
   max-width: 24rem;
   padding: 0.6rem 0.85rem;
-  background: var(--af-surface);
+  background: var(--af-bg-raised);
   color: var(--af-text);
-  border: 1px solid var(--af-error);
+  border: 1px solid var(--af-danger);
   border-left-width: 3px;
-  border-radius: 6px;
-  font-size: 0.8rem;
+  border-radius: var(--af-r-md);
+  font-size: var(--af-fs-sm);
   line-height: 1.4;
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--af-shadow-2);
   opacity: 0;
   transform: translateY(0.4rem);
   transition: opacity 0.15s ease, transform 0.15s ease;
@@ -492,7 +701,7 @@ body {
   flex: 1;
   min-height: 0;
   display: flex;
-  background: var(--af-bg);
+  background: var(--af-bg-term);
   overflow: hidden;
 }
 .af-split {
@@ -548,35 +757,35 @@ body {
   align-items: center;
   justify-content: space-between;
   gap: 0.4rem;
-  padding: 0.15rem 0.5rem;
-  background: var(--af-surface);
+  padding: 0.15rem var(--af-sp-2);
+  background: var(--af-bg-surface);
   border-bottom: 1px solid var(--af-border);
 }
 .af-pane-multi .af-pane-head {
   display: flex;
 }
 .af-pane-label {
-  font-size: 0.68rem;
-  color: var(--af-muted);
+  font-size: var(--af-fs-2xs);
+  color: var(--af-text-2);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 .af-pane-close {
   flex: 0 0 auto;
-  padding: 0 0.25rem;
+  padding: 0 var(--af-sp-1);
   background: transparent;
-  color: var(--af-muted);
+  color: var(--af-text-2);
   border: none;
-  border-radius: 3px;
+  border-radius: var(--af-r-sm);
   font: inherit;
-  font-size: 0.85rem;
+  font-size: var(--af-fs-md);
   line-height: 1;
   cursor: pointer;
 }
 .af-pane-close:hover {
-  color: var(--af-error);
-  background: rgba(248, 81, 73, 0.14);
+  color: var(--af-danger);
+  background: var(--af-danger-subtle);
 }
 .af-pane-host {
   flex: 1;
@@ -596,10 +805,10 @@ body {
 .af-webpane-bar {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.25rem 0.4rem;
+  gap: var(--af-sp-2);
+  padding: var(--af-sp-1) 0.4rem;
   border-bottom: 1px solid var(--af-border);
-  font-size: 0.8rem;
+  font-size: var(--af-fs-sm);
 }
 .af-webpane-reload {
   flex: 0 0 auto;
@@ -607,7 +816,7 @@ body {
   background: transparent;
   color: var(--af-text);
   border: 1px solid var(--af-border);
-  border-radius: var(--af-radius);
+  border-radius: var(--af-r-md);
   padding: 0 0.4rem;
   line-height: 1.4;
 }
@@ -620,7 +829,7 @@ body {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: var(--af-muted);
+  color: var(--af-text-2);
 }
 .af-webpane-open {
   flex: 0 0 auto;
@@ -635,16 +844,16 @@ body {
   min-height: 0;
   width: 100%;
   border: 0;
-  background: #fff;
+  background: var(--af-bg-surface);
 }
 .af-webpane-fallback {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 0.75rem;
+  gap: var(--af-sp-3);
   flex: 1 1 0;
-  padding: 1rem;
+  padding: var(--af-sp-4);
   text-align: center;
   color: var(--af-text);
 }
@@ -665,7 +874,7 @@ body {
 .af-drop-overlay {
   position: absolute;
   display: none;
-  background: rgba(47, 129, 247, 0.28);
+  background: var(--af-accent-tint);
   border: 1px solid var(--af-accent);
   pointer-events: none;
   z-index: 5;
@@ -701,32 +910,32 @@ body {
   height: 50%;
 }
 .af-rail-new {
-  padding: 0.25rem 0.55rem;
+  padding: var(--af-sp-1) 0.55rem;
   background: transparent;
   color: var(--af-accent);
   border: 1px solid var(--af-accent);
-  border-radius: 6px;
+  border-radius: var(--af-r-md);
   font: inherit;
-  font-size: 0.72rem;
+  font-size: var(--af-fs-2xs);
   font-weight: 600;
   cursor: pointer;
 }
 .af-rail-new:hover {
-  background: rgba(47, 129, 247, 0.12);
+  background: var(--af-accent-subtle);
 }
 .af-danger {
-  padding: 0.4rem 0.75rem;
+  padding: 0.4rem var(--af-sp-3);
   background: transparent;
-  color: var(--af-error);
-  border: 1px solid var(--af-error);
-  border-radius: 6px;
+  color: var(--af-danger);
+  border: 1px solid var(--af-danger);
+  border-radius: var(--af-r-md);
   font: inherit;
-  font-size: 0.8rem;
+  font-size: var(--af-fs-sm);
   font-weight: 600;
   cursor: pointer;
 }
 .af-danger:hover {
-  background: rgba(248, 81, 73, 0.12);
+  background: var(--af-danger-subtle);
 }
 .af-danger:disabled {
   opacity: 0.6;
@@ -739,11 +948,11 @@ body {
 .af-modal-backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(1, 4, 9, 0.7);
+  background: var(--af-backdrop);
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 1.5rem;
+  padding: var(--af-sp-5);
   z-index: 20;
 }
 .af-modal-card {
@@ -751,17 +960,18 @@ body {
   max-width: 30rem;
   max-height: 90vh;
   overflow-y: auto;
-  background: var(--af-surface);
+  background: var(--af-bg-raised);
   border: 1px solid var(--af-border);
-  border-radius: var(--af-radius);
-  padding: 1.5rem;
+  border-radius: var(--af-r-lg);
+  box-shadow: var(--af-shadow-overlay);
+  padding: var(--af-sp-5);
 }
 .af-modal-busy {
   opacity: 0.8;
 }
 .af-modal-title {
-  margin: 0 0 1rem;
-  font-size: 1.05rem;
+  margin: 0 0 var(--af-sp-4);
+  font-size: var(--af-fs-lg);
   font-weight: 600;
   white-space: nowrap;
   overflow: hidden;
@@ -771,7 +981,7 @@ body {
 .af-modal-body {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: var(--af-sp-3);
 }
 .af-modal-field {
   display: flex;
@@ -779,20 +989,20 @@ body {
   gap: 0.3rem;
 }
 .af-modal-label {
-  font-size: 0.72rem;
-  color: var(--af-muted);
+  font-size: var(--af-fs-xs);
+  color: var(--af-text-2);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: var(--af-track);
 }
 .af-input {
   width: 100%;
   padding: 0.55rem 0.7rem;
-  background: var(--af-bg);
+  background: var(--af-bg-inset);
   border: 1px solid var(--af-border);
-  border-radius: 6px;
+  border-radius: var(--af-r-md);
   color: var(--af-text);
   font: inherit;
-  font-size: 0.88rem;
+  font-size: var(--af-fs-md);
 }
 .af-input:focus {
   outline: none;
@@ -805,28 +1015,28 @@ body {
 .af-check-row {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  font-size: 0.82rem;
-  color: var(--af-muted);
+  gap: var(--af-sp-2);
+  font-size: var(--af-fs-sm);
+  color: var(--af-text-2);
   cursor: pointer;
 }
 .af-modal-text {
   margin: 0;
-  color: var(--af-muted);
-  font-size: 0.85rem;
+  color: var(--af-text-2);
+  font-size: var(--af-fs-md);
   line-height: 1.5;
 }
 .af-modal-error {
   margin: 0;
-  color: var(--af-error);
-  font-size: 0.8rem;
+  color: var(--af-danger);
+  font-size: var(--af-fs-sm);
   line-height: 1.4;
 }
 .af-modal-foot {
   display: flex;
   justify-content: flex-end;
   gap: 0.6rem;
-  margin-top: 0.25rem;
+  margin-top: var(--af-sp-1);
 }
 .af-modal-foot .af-primary,
 .af-modal-foot .af-danger {
@@ -835,18 +1045,18 @@ body {
 .af-viewnav {
   display: inline-flex;
   align-items: stretch;
-  gap: 0.25rem;
-  margin-left: 0.5rem;
+  gap: var(--af-sp-1);
+  margin-left: var(--af-sp-2);
 }
 .af-viewtab {
   padding: 0.3rem 0.7rem;
   background: transparent;
-  color: var(--af-muted);
+  color: var(--af-text-2);
   border: none;
   border-bottom: 2px solid transparent;
   border-radius: 0;
   font: inherit;
-  font-size: 0.78rem;
+  font-size: var(--af-fs-sm);
   cursor: pointer;
 }
 .af-viewtab:hover {
@@ -880,55 +1090,56 @@ body {
   display: flex;
   align-items: center;
   gap: 0.6rem;
-  padding: 0.6rem 1rem;
+  padding: 0.6rem var(--af-sp-4);
   border-bottom: 1px solid var(--af-border);
-  background: var(--af-surface);
+  background: var(--af-bg-surface);
   position: sticky;
   top: 0;
   z-index: 1;
 }
 .af-projects-title,
 .af-tasks-title {
-  font-size: 0.7rem;
+  font-size: var(--af-fs-xs);
   text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--af-muted);
+  letter-spacing: var(--af-track);
+  color: var(--af-text-2);
 }
 .af-view-count {
-  font-size: 0.75rem;
-  color: var(--af-muted);
-  background: var(--af-bg);
+  font-size: var(--af-fs-xs);
+  color: var(--af-text-2);
+  background: var(--af-bg-inset);
   border: 1px solid var(--af-border);
-  border-radius: 999px;
-  padding: 0.05rem 0.5rem;
+  border-radius: var(--af-r-full);
+  padding: 0.05rem var(--af-sp-2);
 }
 .af-tasks-add {
   margin-left: auto;
-  padding: 0.25rem 0.55rem;
+  padding: var(--af-sp-1) 0.55rem;
   background: transparent;
   color: var(--af-accent);
   border: 1px solid var(--af-accent);
-  border-radius: 6px;
+  border-radius: var(--af-r-md);
   font: inherit;
-  font-size: 0.72rem;
+  font-size: var(--af-fs-2xs);
   font-weight: 600;
   cursor: pointer;
 }
 .af-tasks-add:hover {
-  background: rgba(47, 129, 247, 0.12);
+  background: var(--af-accent-subtle);
 }
 .af-projects-empty,
 .af-tasks-empty {
-  padding: 1.25rem 1rem;
-  color: var(--af-muted);
-  font-size: 0.85rem;
+  padding: var(--af-sp-5) var(--af-sp-4);
+  color: var(--af-text-2);
+  font-size: var(--af-fs-md);
   line-height: 1.5;
 }
 .af-projects-empty code {
+  font-family: var(--af-font-mono);
   color: var(--af-text);
 }
 .af-projects-list {
-  padding: 0.5rem 0.75rem 1.5rem;
+  padding: var(--af-sp-2) 0.75rem var(--af-sp-5);
 }
 .af-project {
   margin-bottom: 0.75rem;
@@ -937,29 +1148,29 @@ body {
   display: grid;
   grid-template-columns: 1fr auto auto;
   align-items: baseline;
-  gap: 0.5rem;
-  padding: 0.5rem 0.6rem 0.35rem;
+  gap: var(--af-sp-2);
+  padding: var(--af-sp-2) 0.6rem 0.35rem;
 }
 .af-project-delete {
-  font-size: 0.7rem;
+  font-size: var(--af-fs-2xs);
   padding: 0.1rem 0.4rem;
   align-self: center;
 }
 .af-project-name {
-  font-size: 0.85rem;
+  font-size: var(--af-fs-md);
   font-weight: 600;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 .af-project-count {
-  font-size: 0.72rem;
-  color: var(--af-muted);
+  font-size: var(--af-fs-xs);
+  color: var(--af-text-2);
 }
 .af-project-path {
   grid-column: 1 / -1;
-  font-size: 0.7rem;
-  color: var(--af-muted);
+  font-size: var(--af-fs-xs);
+  color: var(--af-text-2);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -975,7 +1186,7 @@ body {
 .af-tasks-list {
   list-style: none;
   margin: 0;
-  padding: 0.5rem 0.75rem 1.5rem;
+  padding: var(--af-sp-2) 0.75rem var(--af-sp-5);
 }
 .af-task-row {
   display: flex;
@@ -986,8 +1197,8 @@ body {
 }
 .af-task-enabled {
   flex: 0 0 auto;
-  font-size: 0.78rem;
-  color: var(--af-muted);
+  font-size: var(--af-fs-sm);
+  color: var(--af-text-2);
   line-height: 1.5;
 }
 .af-task-enabled.af-task-on {
@@ -998,7 +1209,7 @@ body {
   min-width: 0;
 }
 .af-task-name {
-  font-size: 0.85rem;
+  font-size: var(--af-fs-md);
   font-weight: 600;
   white-space: nowrap;
   overflow: hidden;
@@ -1006,7 +1217,7 @@ body {
 }
 .af-task-trigger {
   margin-top: 0.15rem;
-  font-size: 0.75rem;
+  font-size: var(--af-fs-xs);
   color: var(--af-text);
   white-space: nowrap;
   overflow: hidden;
@@ -1014,8 +1225,8 @@ body {
 }
 .af-task-meta {
   margin-top: 0.1rem;
-  font-size: 0.72rem;
-  color: var(--af-muted);
+  font-size: var(--af-fs-xs);
+  color: var(--af-text-2);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1028,7 +1239,7 @@ body {
 }
 .af-task-action {
   padding: 0.3rem 0.55rem;
-  font-size: 0.72rem;
+  font-size: var(--af-fs-xs);
 }
 @media (max-width: 640px) {
   .af-body {

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -6889,16 +6889,61 @@ function decode(raw) {
   }
 }
 
-// src/terminal.ts
-var BACKOFF_BASE_MS2 = 500;
-var BACKOFF_MAX_MS2 = 1e4;
-var RESIZE_DEBOUNCE_MS = 120;
-var THEME = {
-  background: "#0d1117",
-  foreground: "#e6edf3",
-  cursor: "#e6edf3",
-  cursorAccent: "#0d1117",
-  selectionBackground: "rgba(47, 129, 247, 0.30)",
+// src/theme.ts
+var THEME_CHOICES = ["auto", "light", "dark"];
+var STORAGE_KEY = "af-theme";
+function isChoice(v) {
+  return v === "auto" || v === "light" || v === "dark";
+}
+function readThemeChoice() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (isChoice(raw)) {
+      return raw;
+    }
+  } catch {
+  }
+  return "auto";
+}
+function persistThemeChoice(choice) {
+  try {
+    localStorage.setItem(STORAGE_KEY, choice);
+  } catch {
+  }
+}
+function stampTheme(choice) {
+  const root2 = document.documentElement;
+  if (choice === "auto") {
+    root2.removeAttribute("data-theme");
+  } else {
+    root2.setAttribute("data-theme", choice);
+  }
+}
+function bootStampTheme() {
+  const choice = readThemeChoice();
+  stampTheme(choice);
+  return choice;
+}
+function prefersDark() {
+  try {
+    return window.matchMedia("(prefers-color-scheme: dark)").matches;
+  } catch {
+    return false;
+  }
+}
+function currentMode() {
+  const attr = document.documentElement.getAttribute("data-theme");
+  if (attr === "light" || attr === "dark") {
+    return attr;
+  }
+  return prefersDark() ? "dark" : "light";
+}
+var DARK_XTERM = {
+  background: "#0c1016",
+  foreground: "#e7ecf3",
+  cursor: "#e7ecf3",
+  cursorAccent: "#0c1016",
+  selectionBackground: "rgba(122, 162, 247, 0.2)",
   black: "#484f58",
   red: "#ff7b72",
   green: "#3fb950",
@@ -6916,6 +6961,40 @@ var THEME = {
   brightCyan: "#56d4dd",
   brightWhite: "#f0f6fc"
 };
+var LIGHT_XTERM = {
+  background: "#fdfefe",
+  foreground: "#17202e",
+  cursor: "#17202e",
+  cursorAccent: "#fdfefe",
+  selectionBackground: "rgba(47, 95, 216, 0.16)",
+  black: "#24292f",
+  red: "#cf222e",
+  green: "#1a7f37",
+  yellow: "#9a6700",
+  blue: "#0969da",
+  magenta: "#8250df",
+  cyan: "#1b7c83",
+  white: "#6e7781",
+  brightBlack: "#57606a",
+  brightRed: "#a40e26",
+  brightGreen: "#116329",
+  brightYellow: "#7d4e00",
+  brightBlue: "#0550ae",
+  brightMagenta: "#6639ba",
+  brightCyan: "#3192aa",
+  brightWhite: "#8c959f"
+};
+function xtermTheme(mode) {
+  return mode === "dark" ? DARK_XTERM : LIGHT_XTERM;
+}
+function currentXtermTheme() {
+  return xtermTheme(currentMode());
+}
+
+// src/terminal.ts
+var BACKOFF_BASE_MS2 = 500;
+var BACKOFF_MAX_MS2 = 1e4;
+var RESIZE_DEBOUNCE_MS = 120;
 function wsScheme2() {
   return window.location.protocol === "https:" ? "wss:" : "ws:";
 }
@@ -6930,7 +7009,9 @@ var AttachTerminal = class {
       cursorBlink: true,
       fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
       fontSize: 13,
-      theme: THEME,
+      // Born in the active theme (theme.ts derives the xterm palette from the same
+      // tokens as the CSS chrome); setTheme() re-applies live on a toggle.
+      theme: currentXtermTheme(),
       // The stream is the source of truth; local echo/scrollback beyond the ring is
       // fine but the server never sees our convert-eol, so leave it raw.
       scrollback: 5e3
@@ -7002,6 +7083,12 @@ var AttachTerminal = class {
    *  navigation gets the keys again — the Escape/back-to-nav half of #1693. */
   blur() {
     this.term.blur();
+  }
+  /** Re-applies an xterm palette live (a theme toggle): xterm repaints the canvas
+   *  from the new ITheme, so an open terminal switches light/dark without a
+   *  reconnect or losing scrollback. */
+  setTheme(theme) {
+    this.term.options.theme = theme;
   }
   // --- socket lifecycle ------------------------------------------------------
   connect() {
@@ -7328,6 +7415,15 @@ var SplitView = class {
   blur() {
     for (const pane of this.panes.values()) {
       pane.term?.blur();
+    }
+  }
+  /** Re-applies the active xterm theme to every live pane (a theme toggle). New
+   *  panes already pick it up via terminal.ts's currentXtermTheme(); this repaints
+   *  the ones already open, including split panes. */
+  applyTheme() {
+    const theme = currentXtermTheme();
+    for (const pane of this.panes.values()) {
+      pane.term?.setTheme(theme);
     }
   }
   /** Moves pane focus by `delta` (wrapping) and attaches the newly focused pane. */
@@ -8323,6 +8419,16 @@ function viewLabel(view) {
       return "Tasks";
   }
 }
+function themeLabel(choice) {
+  switch (choice) {
+    case "auto":
+      return "Auto";
+    case "light":
+      return "Light";
+    case "dark":
+      return "Dark";
+  }
+}
 function h2(tag, props = {}, ...children) {
   const el2 = document.createElement(tag);
   for (const [key, value] of Object.entries(props)) {
@@ -8454,6 +8560,17 @@ var AppShell = class {
     live.setAttribute("role", "status");
     const disconnect2 = h2("button", { type: "button", class: "af-ghost" }, "Disconnect");
     disconnect2.addEventListener("click", () => this.actions.disconnect());
+    const themeToggle = h2("div", { class: "af-theme-toggle" });
+    themeToggle.setAttribute("role", "group");
+    themeToggle.setAttribute("aria-label", "Theme");
+    for (const choice of THEME_CHOICES) {
+      const opt = h2("button", { type: "button", class: "af-theme-opt" }, themeLabel(choice));
+      opt.setAttribute("data-theme-opt", choice);
+      opt.setAttribute("title", `${themeLabel(choice)} theme`);
+      opt.addEventListener("click", () => this.actions.setTheme(choice));
+      this.themeOpts.set(choice, opt);
+      themeToggle.append(opt);
+    }
     const viewNav = h2("div", { class: "af-viewnav" });
     viewNav.setAttribute("role", "tablist");
     viewNav.setAttribute("aria-label", "Views");
@@ -8471,6 +8588,7 @@ var AppShell = class {
       h2("span", { class: "af-brand" }, "Agent Factory"),
       viewNav,
       live,
+      themeToggle,
       disconnect2
     );
     this.railCount = h2("span", { class: "af-rail-count" }, "0");
@@ -8517,6 +8635,10 @@ var AppShell = class {
   // stays mounted while another view shows — hidden, not destroyed — so switching
   // views never tears down the focused terminal or its scrollback.
   viewTabs = /* @__PURE__ */ new Map();
+  // The appbar theme toggle (redesign PR1): one button per Auto/Light/Dark choice,
+  // the active one highlighted in update().
+  themeOpts = /* @__PURE__ */ new Map();
+  lastThemeChoice = null;
   sessionsBody;
   projectsPane;
   tasksPane;
@@ -8568,6 +8690,14 @@ var AppShell = class {
       for (const [v, tab] of this.viewTabs) {
         tab.classList.toggle("af-viewtab-active", v === state.view);
         tab.setAttribute("aria-selected", v === state.view ? "true" : "false");
+      }
+    }
+    if (this.lastThemeChoice !== state.themeChoice) {
+      this.lastThemeChoice = state.themeChoice;
+      for (const [choice, opt] of this.themeOpts) {
+        const active = choice === state.themeChoice;
+        opt.classList.toggle("af-theme-opt-active", active);
+        opt.setAttribute("aria-pressed", active ? "true" : "false");
       }
     }
     this.projectsPane.update(state.sessions, state.selectedId);
@@ -8746,6 +8876,7 @@ function sessionRow(s, selected, actions2) {
 }
 
 // src/index.ts
+var initialThemeChoice = bootStampTheme();
 var store = new Store({
   phase: "login",
   view: "sessions",
@@ -8765,7 +8896,8 @@ var store = new Store({
   activeTab: 0,
   shownTabs: [0],
   tabError: null,
-  tasks: []
+  tasks: [],
+  themeChoice: initialThemeChoice
 });
 var token = null;
 var stream = null;
@@ -8799,6 +8931,7 @@ function mount() {
   store.subscribe(rerender);
   rerender();
   document.addEventListener("keydown", onKeydown, true);
+  watchSystemTheme();
   void bootstrap();
 }
 async function bootstrap() {
@@ -9169,6 +9302,33 @@ function doRemoveTask(task) {
   }
   void removeTask(task.id, tok).then(refreshTasks).catch((e) => surfaceTabError(e));
 }
+function setTheme(choice) {
+  if (store.get().themeChoice === choice) {
+    return;
+  }
+  persistThemeChoice(choice);
+  stampTheme(choice);
+  store.set({ themeChoice: choice });
+  splitView.applyTheme();
+}
+function watchSystemTheme() {
+  let mql;
+  try {
+    mql = window.matchMedia("(prefers-color-scheme: dark)");
+  } catch {
+    return;
+  }
+  const onChange = () => {
+    if (store.get().themeChoice === "auto") {
+      splitView.applyTheme();
+    }
+  };
+  if (typeof mql.addEventListener === "function") {
+    mql.addEventListener("change", onChange);
+  } else if (typeof mql.addListener === "function") {
+    mql.addListener(onChange);
+  }
+}
 var actions = {
   connect,
   disconnect,
@@ -9186,7 +9346,8 @@ var actions = {
   toggleTask,
   triggerTask: doTriggerTask,
   removeTask: doRemoveTask,
-  deleteProject: openDeleteProject
+  deleteProject: openDeleteProject,
+  setTheme
 };
 function syncSplit(state) {
   const selId = state.selectedId;

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -851,6 +851,11 @@ async function bgColor(p: Page, selector: string): Promise<string> {
   }, selector);
 }
 
+/** The resolved value of a CSS custom property on :root, for a token-flip diff. */
+async function cssVar(p: Page, name: string): Promise<string> {
+  return p.evaluate((n) => getComputedStyle(document.documentElement).getPropertyValue(n).trim(), name);
+}
+
 test("theme (redesign PR1): a saved dark choice is stamped before the app mounts — no flash", async () => {
   // Persist a dark choice, then install a document-start trap on #app.replaceChildren
   // (how index.ts mounts its content into #app) that records data-theme AT THE EXACT
@@ -893,6 +898,10 @@ test("theme (redesign PR1): toggling Light vs Dark changes token-driven colors l
   await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
   const darkRail = await bgColor(page, ".af-rail");
   const darkBody = await bgColor(page, "body");
+  // The web/iframe-pane tokens (fixed in this PR to match the terminal pane) resolve
+  // to their dark values.
+  const darkTerm = await cssVar(page, "--af-bg-term");
+  const darkBorderSubtle = await cssVar(page, "--af-border-subtle");
 
   // Toggle to Light: the SAME selectors resolve to different token values, proving the
   // chrome is driven by the CSS custom properties, not hardcoded colors.
@@ -900,9 +909,15 @@ test("theme (redesign PR1): toggling Light vs Dark changes token-driven colors l
   await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
   const lightRail = await bgColor(page, ".af-rail");
   const lightBody = await bgColor(page, "body");
+  const lightTerm = await cssVar(page, "--af-bg-term");
+  const lightBorderSubtle = await cssVar(page, "--af-border-subtle");
 
   expect(lightRail).not.toBe(darkRail);
   expect(lightBody).not.toBe(darkBody);
+  // The web-pane canvas + separator tokens flip too, so the embedded web pane reads
+  // correctly in both themes (the dark-mode regression this PR fixes).
+  expect(lightTerm).not.toBe(darkTerm);
+  expect(lightBorderSubtle).not.toBe(darkBorderSubtle);
   // The light rail surface is the white token (#ffffff → rgb(255, 255, 255)).
   expect(lightRail).toBe("rgb(255, 255, 255)");
   await expect(page.locator('.af-theme-opt[data-theme-opt="light"]')).toHaveClass(/af-theme-opt-active/);

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -834,3 +834,84 @@ test("empty state (#1592 PR9): an empty Snapshot renders the empty rail + placeh
 
   await page.unroute("**/v1/Snapshot");
 });
+
+// --- theme (redesign PR1): design tokens + light/dark ----------------------
+//
+// These run LAST: the first reloads with a persisted dark choice (to prove the boot
+// stamp beats first paint), and both mutate localStorage + data-theme. They assert on
+// the chrome (data-theme + token-driven computed colors), not on session state, so
+// the earlier flows are undisturbed. The final test resets to Auto + clears the saved
+// choice so the page is left in its default theme.
+
+/** The computed background color of a selector, for a token-driven-color diff. */
+async function bgColor(p: Page, selector: string): Promise<string> {
+  return p.evaluate((sel) => {
+    const node = document.querySelector(sel);
+    return node ? getComputedStyle(node).backgroundColor : "";
+  }, selector);
+}
+
+test("theme (redesign PR1): a saved dark choice is stamped before the app mounts — no flash", async () => {
+  // Persist a dark choice, then install a document-start trap on #app.replaceChildren
+  // (how index.ts mounts its content into #app) that records data-theme AT THE EXACT
+  // synchronous instant the app first mounts. Because the boot stamp runs at index.ts
+  // module top — earlier in the SAME synchronous module turn than mount() — the trap
+  // must see data-theme already "dark". This is race-free (no rAF/microtask timing),
+  // unlike a paint- or observer-based probe.
+  await page.evaluate(() => localStorage.setItem("af-theme", "dark"));
+  await page.addInitScript(() => {
+    interface ThemeProbe {
+      __afMountTheme?: string | null;
+    }
+    const w = window as unknown as ThemeProbe;
+    w.__afMountTheme = "__unset__";
+    const orig = Element.prototype.replaceChildren;
+    Element.prototype.replaceChildren = function (this: Element, ...args: (Node | string)[]): void {
+      if (this.id === "app" && w.__afMountTheme === "__unset__") {
+        w.__afMountTheme = document.documentElement.getAttribute("data-theme");
+      }
+      return orig.apply(this, args);
+    };
+  });
+  await page.reload();
+  await expect(page.locator(".af-app")).toBeVisible();
+
+  const atMount = await page.evaluate(
+    () => (window as unknown as { __afMountTheme?: string | null }).__afMountTheme,
+  );
+  // data-theme was already "dark" the instant the app mounted: no light→dark flash.
+  expect(atMount).toBe("dark");
+  // And it stuck: <html data-theme="dark"> after the app is up.
+  expect(await page.evaluate(() => document.documentElement.getAttribute("data-theme"))).toBe("dark");
+  // The dark theme option reads active in the appbar toggle.
+  await expect(page.locator('.af-theme-opt[data-theme-opt="dark"]')).toHaveClass(/af-theme-opt-active/);
+});
+
+test("theme (redesign PR1): toggling Light vs Dark changes token-driven colors live", async () => {
+  // Force Dark and capture a token-driven color (the rail surface).
+  await page.locator('.af-theme-opt[data-theme-opt="dark"]').click();
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+  const darkRail = await bgColor(page, ".af-rail");
+  const darkBody = await bgColor(page, "body");
+
+  // Toggle to Light: the SAME selectors resolve to different token values, proving the
+  // chrome is driven by the CSS custom properties, not hardcoded colors.
+  await page.locator('.af-theme-opt[data-theme-opt="light"]').click();
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+  const lightRail = await bgColor(page, ".af-rail");
+  const lightBody = await bgColor(page, "body");
+
+  expect(lightRail).not.toBe(darkRail);
+  expect(lightBody).not.toBe(darkBody);
+  // The light rail surface is the white token (#ffffff → rgb(255, 255, 255)).
+  expect(lightRail).toBe("rgb(255, 255, 255)");
+  await expect(page.locator('.af-theme-opt[data-theme-opt="light"]')).toHaveClass(/af-theme-opt-active/);
+
+  // Reset to Auto and clear the saved choice so the page is left in its default theme.
+  // Auto removes data-theme entirely (follow prefers-color-scheme).
+  await page.locator('.af-theme-opt[data-theme-opt="auto"]').click();
+  await expect
+    .poll(() => page.evaluate(() => document.documentElement.hasAttribute("data-theme")))
+    .toBe(false);
+  await page.evaluate(() => localStorage.removeItem("af-theme"));
+});

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -39,6 +39,7 @@ import { decideKey, type KeyboardFocus, type View } from "./nav.js";
 import { applyEvent, clampActiveTab, pickSelection, upsertSession } from "./sessions.js";
 import { SplitView } from "./split.js";
 import { Store } from "./store.js";
+import { bootStampTheme, persistThemeChoice, stampTheme, type ThemeChoice } from "./theme.js";
 import { addTaskModal, type AddTaskInput, buildTask } from "./tasks.js";
 import type { TerminalStatus } from "./terminal.js";
 import {
@@ -52,6 +53,12 @@ import {
   type AppState,
 } from "./ui.js";
 import type { SessionData, TaskData, WireEvent } from "./types.js";
+
+// Boot stamp (redesign PR1): apply the saved theme choice to <html> BEFORE the app
+// mounts (before first paint), so an explicit light/dark choice shows no flash. This
+// is the CSP-safe stamp — it ships in the same-origin bundle, not an inline <script>
+// the daemon's `default-src 'self'` would block. Runs at module top, above the store.
+const initialThemeChoice = bootStampTheme();
 
 const store = new Store<AppState>({
   phase: "login",
@@ -73,6 +80,7 @@ const store = new Store<AppState>({
   shownTabs: [0],
   tabError: null,
   tasks: [],
+  themeChoice: initialThemeChoice,
 });
 
 // The credential and the push stream are process-local singletons: one token
@@ -146,6 +154,9 @@ function mount(): void {
   // Escape, which we swallow here (stopPropagation) so detaching never leaks a
   // stray ESC byte into the PTY.
   document.addEventListener("keydown", onKeydown, true);
+
+  // Follow the OS theme while the choice is Auto (redesign PR1).
+  watchSystemTheme();
 
   void bootstrap();
 }
@@ -714,6 +725,45 @@ function doRemoveTask(task: TaskData): void {
 }
 
 /** The action callbacks the shell + login view invoke. */
+// --- theme (redesign PR1) --------------------------------------------------
+
+/** Applies a theme choice: persist it, stamp data-theme on <html> (the CSS resolves
+ *  the right token layer synchronously), reflect it in the store so the appbar toggle
+ *  highlights it, and re-theme the live terminals (xterm can't read CSS vars, so it's
+ *  repainted from theme.ts's derived palette). */
+function setTheme(choice: ThemeChoice): void {
+  if (store.get().themeChoice === choice) {
+    return;
+  }
+  persistThemeChoice(choice);
+  stampTheme(choice);
+  store.set({ themeChoice: choice });
+  splitView.applyTheme();
+}
+
+/** While the choice is Auto, follow the OS: a prefers-color-scheme flip re-themes the
+ *  terminals to match (the CSS chrome already reacts via the media query). An explicit
+ *  Light/Dark choice ignores the OS. */
+function watchSystemTheme(): void {
+  let mql: MediaQueryList;
+  try {
+    mql = window.matchMedia("(prefers-color-scheme: dark)");
+  } catch {
+    return; // no matchMedia (very old / headless): nothing to follow
+  }
+  const onChange = (): void => {
+    if (store.get().themeChoice === "auto") {
+      splitView.applyTheme();
+    }
+  };
+  if (typeof mql.addEventListener === "function") {
+    mql.addEventListener("change", onChange);
+  } else if (typeof mql.addListener === "function") {
+    // Safari < 14 fallback.
+    mql.addListener(onChange);
+  }
+}
+
 const actions = {
   connect,
   disconnect,
@@ -732,6 +782,7 @@ const actions = {
   triggerTask: doTriggerTask,
   removeTask: doRemoveTask,
   deleteProject: openDeleteProject,
+  setTheme,
 };
 
 // --- attach terminal wiring ------------------------------------------------

--- a/web/src/split.ts
+++ b/web/src/split.ts
@@ -39,6 +39,7 @@ import {
   validate,
 } from "./layout.js";
 import { AttachTerminal, type TerminalStatus } from "./terminal.js";
+import { currentXtermTheme } from "./theme.js";
 import { TabKind } from "./types.js";
 
 /** How close (as a fraction of the pane) to an edge the pointer must be for the drop
@@ -236,6 +237,16 @@ export class SplitView {
   blur(): void {
     for (const pane of this.panes.values()) {
       pane.term?.blur();
+    }
+  }
+
+  /** Re-applies the active xterm theme to every live pane (a theme toggle). New
+   *  panes already pick it up via terminal.ts's currentXtermTheme(); this repaints
+   *  the ones already open, including split panes. */
+  applyTheme(): void {
+    const theme = currentXtermTheme();
+    for (const pane of this.panes.values()) {
+      pane.term?.setTheme(theme);
     }
   }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -995,12 +995,16 @@ body {
   height: 100%;
 }
 
-/* A web/iframe tab: fills the pane host with a thin control bar above the frame. */
+/* A web/iframe tab: fills the pane host with a thin control bar above the frame. It
+ * matches the terminal pane's treatment — the pane canvas is --af-bg-term (so the
+ * .af-pane-host inset gutter blends seamlessly in both themes), with a raised
+ * --af-bg-surface control bar over it, like the .af-pane-head strip. */
 .af-webpane {
   display: flex;
   flex-direction: column;
   height: 100%;
   min-height: 0;
+  background: var(--af-bg-term);
 }
 
 .af-webpane-bar {
@@ -1008,7 +1012,8 @@ body {
   align-items: center;
   gap: var(--af-sp-2);
   padding: var(--af-sp-1) 0.4rem;
-  border-bottom: 1px solid var(--af-border);
+  background: var(--af-bg-surface);
+  border-bottom: 1px solid var(--af-border-subtle);
   font-size: var(--af-fs-sm);
 }
 
@@ -1051,10 +1056,15 @@ body {
   min-height: 0;
   width: 100%;
   border: 0;
-  background: var(--af-bg-surface);
+  /* The backing shown before the framed page paints (or for a transparent page):
+   * the pane canvas token, so a load reads as the theme's terminal surface rather
+   * than a mismatched light box in dark mode. */
+  background: var(--af-bg-term);
 }
 
-/* Shown when a direct external frame is blocked from embedding (best-effort). */
+/* Shown when a direct external frame is blocked from embedding (best-effort), or for
+ * a URL-less tab. It fills the pane canvas (--af-bg-term via .af-webpane) with themed
+ * text, so it reads correctly in both light and dark. */
 .af-webpane-fallback {
   display: flex;
   flex-direction: column;
@@ -1064,7 +1074,7 @@ body {
   flex: 1 1 0;
   padding: var(--af-sp-4);
   text-align: center;
-  color: var(--af-text);
+  color: var(--af-text-2);
 }
 
 .af-webpane-fallback[hidden] {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1,31 +1,204 @@
-/* Web client shell styles (#1592 Phase 5 PR2). Imported by index.ts so esbuild
- * extracts it — together with xterm's bundled CSS (PR4) — into dist/af-web.css,
- * which index.html links same-origin: every stylesheet is fetched from the origin,
- * never a CDN. (xterm's DOM renderer also injects dynamic <style> at runtime, which
- * the served `style-src 'self' 'unsafe-inline'` permits; see daemon/webserve.go.)
- * The palette leans on the TUI's dark terminal aesthetic (design: "base the
- * website pretty heavily on the TUI"); the full visual pass is a later play-test
- * PR, so this is a clean, restrained baseline. */
+/* Web client shell styles. Imported by index.ts so esbuild extracts it — together
+ * with xterm's bundled CSS — into dist/af-web.css, which index.html links
+ * same-origin: every stylesheet is fetched from the origin, never a CDN. (xterm's
+ * DOM renderer also injects dynamic <style> at runtime, which the served
+ * `style-src 'self' 'unsafe-inline'` permits; see daemon/webserve.go.)
+ *
+ * DESIGN-TOKEN SYSTEM + first-class light/dark theming (redesign PR1). Every visible
+ * color/space/radius/shadow on the chrome resolves from a --af-* custom property, so
+ * the whole UI is themeable from one place. LIGHT is the :root default; a dark layer
+ * follows the OS via @media (prefers-color-scheme: dark); and explicit
+ * :root[data-theme="light"] / [data-theme="dark"] blocks DUPLICATE the light/dark
+ * values so a user toggle (theme.ts stamps data-theme on <html>) WINS over the media
+ * query in both directions. The dark status-dot hues are exact TUI (zenburn) parity
+ * so the web reads the same as the TUI at a glance. */
+
+/* --- Design tokens: LIGHT (the default) ---------------------------------- */
+:root {
+  color-scheme: light;
+
+  /* Type */
+  --af-font-ui: -apple-system, BlinkMacSystemFont, "Segoe UI Variable", "Segoe UI", Roboto, Ubuntu, "Helvetica Neue",
+    sans-serif;
+  --af-font-mono: ui-monospace, "SF Mono", SFMono-Regular, "Cascadia Code", "JetBrains Mono", Menlo, Consolas, monospace;
+  --af-fs-2xs: 0.6875rem;
+  --af-fs-xs: 0.75rem;
+  --af-fs-sm: 0.8125rem;
+  --af-fs-md: 0.875rem;
+  --af-fs-lg: 1rem;
+  --af-fs-xl: 1.25rem;
+  --af-track: 0.07em;
+
+  /* Spacing (4px scale) */
+  --af-sp-1: 0.25rem;
+  --af-sp-2: 0.5rem;
+  --af-sp-3: 0.75rem;
+  --af-sp-4: 1rem;
+  --af-sp-5: 1.5rem;
+  --af-sp-6: 2rem;
+
+  /* Radius */
+  --af-r-sm: 4px;
+  --af-r-md: 6px;
+  --af-r-lg: 10px;
+  --af-r-full: 999px;
+
+  /* Color */
+  --af-bg-canvas: #f4f6f9;
+  --af-bg-surface: #ffffff;
+  --af-bg-inset: #eceff4;
+  --af-bg-raised: #ffffff;
+  --af-bg-term: #fdfefe;
+  --af-border: #d8dee8;
+  --af-border-subtle: #e6eaf1;
+  --af-border-strong: #b9c2cf;
+  --af-text: #17202e;
+  --af-text-2: #56627a;
+  --af-text-3: #8792a3;
+  --af-accent: #2f5fd8;
+  --af-accent-hover: #2a53be;
+  --af-accent-subtle: rgba(47, 95, 216, 0.09);
+  --af-accent-tint: rgba(47, 95, 216, 0.16);
+  --af-on-accent: #ffffff;
+  --af-danger: #c9372c;
+  --af-danger-subtle: rgba(201, 55, 44, 0.09);
+
+  /* Status dots */
+  --af-dot-ready: #257a3e;
+  --af-dot-lost: #93650a;
+  --af-dot-dead: #6e7887;
+  --af-dot-archived: #6e7887;
+  --af-dot-limit: #b13d33;
+  --af-dot-working: #17202e;
+
+  /* Terminal hues */
+  --af-term-green: #1f7a33;
+  --af-term-amber: #93650a;
+  --af-term-blue: #2f5fd8;
+  --af-term-dim: #8792a3;
+
+  /* Elevation */
+  --af-shadow-1: 0 1px 2px rgba(16, 24, 40, 0.05), 0 1px 3px rgba(16, 24, 40, 0.08);
+  --af-shadow-2: 0 4px 10px rgba(16, 24, 40, 0.08), 0 2px 4px rgba(16, 24, 40, 0.06);
+  --af-shadow-overlay: 0 16px 48px rgba(16, 24, 40, 0.22), 0 4px 12px rgba(16, 24, 40, 0.12);
+  --af-backdrop: rgba(23, 32, 46, 0.42);
+}
+
+/* --- Design tokens: DARK via OS preference (Auto) ------------------------ */
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: dark;
+    --af-bg-canvas: #0e1218;
+    --af-bg-surface: #141a22;
+    --af-bg-inset: #0b0f15;
+    --af-bg-raised: #1a212b;
+    --af-bg-term: #0c1016;
+    --af-border: #262e3a;
+    --af-border-subtle: #1d242e;
+    --af-border-strong: #39434f;
+    --af-text: #e7ecf3;
+    --af-text-2: #98a3b3;
+    --af-text-3: #626d7d;
+    --af-accent: #7aa2f7;
+    --af-accent-hover: #91b3f9;
+    --af-accent-subtle: rgba(122, 162, 247, 0.12);
+    --af-accent-tint: rgba(122, 162, 247, 0.2);
+    --af-on-accent: #0e1218;
+    --af-danger: #f0655c;
+    --af-danger-subtle: rgba(240, 101, 92, 0.12);
+    --af-dot-ready: #7f9f7f;
+    --af-dot-lost: #f0dfaf;
+    --af-dot-dead: #989890;
+    --af-dot-archived: #989890;
+    --af-dot-limit: #cc9393;
+    --af-dot-working: #e7ecf3;
+    --af-term-green: #7f9f7f;
+    --af-term-amber: #f0dfaf;
+    --af-term-blue: #7aa2f7;
+    --af-term-dim: #626d7d;
+    --af-shadow-1: 0 1px 2px rgba(0, 0, 0, 0.4);
+    --af-shadow-2: 0 4px 10px rgba(0, 0, 0, 0.45);
+    --af-shadow-overlay: 0 16px 48px rgba(0, 0, 0, 0.6), 0 0 0 1px rgba(255, 255, 255, 0.04);
+    --af-backdrop: rgba(4, 7, 12, 0.66);
+  }
+}
+
+/* --- Design tokens: explicit LIGHT (toggle wins over the media query) ---- */
+:root[data-theme="light"] {
+  color-scheme: light;
+  --af-bg-canvas: #f4f6f9;
+  --af-bg-surface: #ffffff;
+  --af-bg-inset: #eceff4;
+  --af-bg-raised: #ffffff;
+  --af-bg-term: #fdfefe;
+  --af-border: #d8dee8;
+  --af-border-subtle: #e6eaf1;
+  --af-border-strong: #b9c2cf;
+  --af-text: #17202e;
+  --af-text-2: #56627a;
+  --af-text-3: #8792a3;
+  --af-accent: #2f5fd8;
+  --af-accent-hover: #2a53be;
+  --af-accent-subtle: rgba(47, 95, 216, 0.09);
+  --af-accent-tint: rgba(47, 95, 216, 0.16);
+  --af-on-accent: #ffffff;
+  --af-danger: #c9372c;
+  --af-danger-subtle: rgba(201, 55, 44, 0.09);
+  --af-dot-ready: #257a3e;
+  --af-dot-lost: #93650a;
+  --af-dot-dead: #6e7887;
+  --af-dot-archived: #6e7887;
+  --af-dot-limit: #b13d33;
+  --af-dot-working: #17202e;
+  --af-term-green: #1f7a33;
+  --af-term-amber: #93650a;
+  --af-term-blue: #2f5fd8;
+  --af-term-dim: #8792a3;
+  --af-shadow-1: 0 1px 2px rgba(16, 24, 40, 0.05), 0 1px 3px rgba(16, 24, 40, 0.08);
+  --af-shadow-2: 0 4px 10px rgba(16, 24, 40, 0.08), 0 2px 4px rgba(16, 24, 40, 0.06);
+  --af-shadow-overlay: 0 16px 48px rgba(16, 24, 40, 0.22), 0 4px 12px rgba(16, 24, 40, 0.12);
+  --af-backdrop: rgba(23, 32, 46, 0.42);
+}
+
+/* --- Design tokens: explicit DARK (toggle wins over the media query) ----- */
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --af-bg-canvas: #0e1218;
+  --af-bg-surface: #141a22;
+  --af-bg-inset: #0b0f15;
+  --af-bg-raised: #1a212b;
+  --af-bg-term: #0c1016;
+  --af-border: #262e3a;
+  --af-border-subtle: #1d242e;
+  --af-border-strong: #39434f;
+  --af-text: #e7ecf3;
+  --af-text-2: #98a3b3;
+  --af-text-3: #626d7d;
+  --af-accent: #7aa2f7;
+  --af-accent-hover: #91b3f9;
+  --af-accent-subtle: rgba(122, 162, 247, 0.12);
+  --af-accent-tint: rgba(122, 162, 247, 0.2);
+  --af-on-accent: #0e1218;
+  --af-danger: #f0655c;
+  --af-danger-subtle: rgba(240, 101, 92, 0.12);
+  --af-dot-ready: #7f9f7f;
+  --af-dot-lost: #f0dfaf;
+  --af-dot-dead: #989890;
+  --af-dot-archived: #989890;
+  --af-dot-limit: #cc9393;
+  --af-dot-working: #e7ecf3;
+  --af-term-green: #7f9f7f;
+  --af-term-amber: #f0dfaf;
+  --af-term-blue: #7aa2f7;
+  --af-term-dim: #626d7d;
+  --af-shadow-1: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --af-shadow-2: 0 4px 10px rgba(0, 0, 0, 0.45);
+  --af-shadow-overlay: 0 16px 48px rgba(0, 0, 0, 0.6), 0 0 0 1px rgba(255, 255, 255, 0.04);
+  --af-backdrop: rgba(4, 7, 12, 0.66);
+}
 
 :root {
-  --af-bg: #0d1117;
-  --af-surface: #161b22;
-  --af-border: #30363d;
-  --af-text: #e6edf3;
-  --af-muted: #8b949e;
-  --af-accent: #2f81f7;
-  --af-accent-text: #ffffff;
-  --af-error: #f85149;
-  --af-radius: 8px;
-  /* Status-dot colors mirror ui/tree/render.go's lipgloss styles exactly, so the
-   * web reads the same as the TUI at a glance (design §2.1, §7.2 item 3). */
-  --af-dot-ready: #7f9f7f; /* readyStyle  — green   */
-  --af-dot-lost: #f0dfaf; /* lostStyle   — amber   */
-  --af-dot-dead: #989890; /* deadStyle   — gray    */
-  --af-dot-archived: #989890; /* archivedStyle — gray */
-  --af-dot-limit: #cc9393; /* limitStyle  — red-orange */
-  --af-dot-working: #e6edf3; /* spinner default foreground */
-  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-family: var(--af-font-ui);
 }
 
 * {
@@ -35,21 +208,42 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background: var(--af-bg);
+  background: var(--af-bg-canvas);
   color: var(--af-text);
   /* The shell is a fixed-height flex layout whose inner regions own their own
    * scroll (the rail list, the view bodies, the tab bar). Nothing should ever push
-   * the PAGE itself sideways, so clamp horizontal overflow at the root — the #1592
-   * Phase 5 PR9 "no horizontal body scroll on a narrow window" guarantee. Vertical
+   * the PAGE itself sideways, so clamp horizontal overflow at the root. Vertical
    * scroll is unaffected, and fixed-position layers (the toast) are not clipped. */
   overflow-x: hidden;
 }
 
-/* Keyboard focus-visible ring (#1592 Phase 5 PR9): every control reachable by Tab
- * draws a legible accent ring when focused via the keyboard, so keyboard nav is
- * never invisible. :focus-visible (not :focus) keeps a plain mouse click from
- * drawing it. This is the per-CONTROL complement to the pane-level #1694 outline
- * (.af-kb-rail/.af-kb-terminal), which marks which PANE owns the keyboard. */
+/* Themed scrollbars so the inner scroll regions match the active theme rather than
+ * the OS default (which can read wrong in the opposite theme). */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--af-border-strong) transparent;
+}
+
+*::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+*::-webkit-scrollbar-thumb {
+  background: var(--af-border-strong);
+  border-radius: var(--af-r-full);
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+/* Keyboard focus-visible ring: every control reachable by Tab draws a legible accent
+ * ring when focused via the keyboard, so keyboard nav is never invisible.
+ * :focus-visible (not :focus) keeps a plain mouse click from drawing it. This is the
+ * per-CONTROL complement to the pane-level #1694 outline. */
 .af-primary:focus-visible,
 .af-ghost:focus-visible,
 .af-danger:focus-visible,
@@ -58,6 +252,7 @@ body {
 .af-tab:focus-visible,
 .af-tab-new:focus-visible,
 .af-viewtab:focus-visible,
+.af-theme-opt:focus-visible,
 .af-task-action:focus-visible {
   outline: 2px solid var(--af-accent);
   outline-offset: 2px;
@@ -73,36 +268,38 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 1.5rem;
+  padding: var(--af-sp-5);
 }
 
 .af-card {
   width: 100%;
   max-width: 26rem;
-  background: var(--af-surface);
+  background: var(--af-bg-surface);
   border: 1px solid var(--af-border);
-  border-radius: var(--af-radius);
-  padding: 2rem;
+  border-radius: var(--af-r-lg);
+  box-shadow: var(--af-shadow-2);
+  padding: var(--af-sp-6);
 }
 
 .af-title {
-  margin: 0 0 0.5rem;
-  font-size: 1.4rem;
+  margin: 0 0 var(--af-sp-2);
+  font-size: var(--af-fs-xl);
   font-weight: 600;
 }
 
 .af-subtitle {
-  margin: 0 0 1.5rem;
-  color: var(--af-muted);
-  font-size: 0.85rem;
+  margin: 0 0 var(--af-sp-5);
+  color: var(--af-text-2);
+  font-size: var(--af-fs-md);
   line-height: 1.5;
 }
 
 .af-subtitle code {
+  font-family: var(--af-font-mono);
   color: var(--af-text);
-  background: var(--af-bg);
+  background: var(--af-bg-inset);
   padding: 0.1rem 0.35rem;
-  border-radius: 4px;
+  border-radius: var(--af-r-sm);
 }
 
 .af-login-form {
@@ -112,21 +309,21 @@ body {
 }
 
 .af-field-label {
-  font-size: 0.75rem;
-  color: var(--af-muted);
+  font-size: var(--af-fs-xs);
+  color: var(--af-text-2);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: var(--af-track);
 }
 
 .af-login-form input {
   width: 100%;
-  padding: 0.65rem 0.75rem;
-  background: var(--af-bg);
+  padding: 0.65rem var(--af-sp-3);
+  background: var(--af-bg-inset);
   border: 1px solid var(--af-border);
-  border-radius: 6px;
+  border-radius: var(--af-r-md);
   color: var(--af-text);
   font: inherit;
-  font-size: 0.9rem;
+  font-size: var(--af-fs-md);
 }
 
 .af-login-form input:focus {
@@ -136,14 +333,18 @@ body {
 
 .af-primary {
   margin-top: 0.4rem;
-  padding: 0.65rem 0.75rem;
+  padding: 0.65rem var(--af-sp-3);
   background: var(--af-accent);
-  color: var(--af-accent-text);
+  color: var(--af-on-accent);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--af-r-md);
   font: inherit;
   font-weight: 600;
   cursor: pointer;
+}
+
+.af-primary:hover {
+  background: var(--af-accent-hover);
 }
 
 .af-primary:disabled {
@@ -152,13 +353,13 @@ body {
 }
 
 .af-error {
-  margin: 1rem 0 0;
-  color: var(--af-error);
-  font-size: 0.8rem;
+  margin: var(--af-sp-4) 0 0;
+  color: var(--af-danger);
+  font-size: var(--af-fs-sm);
   line-height: 1.4;
 }
 
-/* Authed app shell: appbar over a rail + main body (the terminal lands in PR4). */
+/* Authed app shell: appbar over a rail + main body. */
 .af-app {
   height: 100vh;
   display: flex;
@@ -168,9 +369,9 @@ body {
 .af-appbar {
   display: flex;
   align-items: center;
-  gap: 1rem;
-  padding: 0.75rem 1.25rem;
-  background: var(--af-surface);
+  gap: var(--af-sp-4);
+  padding: var(--af-sp-3) var(--af-sp-5);
+  background: var(--af-bg-surface);
   border-bottom: 1px solid var(--af-border);
   /* Keep the bar to one row on a comfortable width, but never let it force the page
    * wider than the viewport: on a narrow window it wraps to a second line instead of
@@ -180,9 +381,11 @@ body {
 
 .af-brand {
   font-weight: 600;
+  letter-spacing: var(--af-track);
 }
 
-/* Push the disconnect button to the far right; the live pip sits beside it. */
+/* Push the disconnect button / theme toggle to the far right; the live pip sits
+ * beside them. */
 .af-appbar .af-live {
   margin-left: auto;
 }
@@ -191,15 +394,15 @@ body {
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
-  font-size: 0.75rem;
-  color: var(--af-muted);
+  font-size: var(--af-fs-xs);
+  color: var(--af-text-2);
 }
 
 .af-live-pip {
   width: 0.55rem;
   height: 0.55rem;
   border-radius: 50%;
-  background: var(--af-muted);
+  background: var(--af-text-3);
 }
 
 .af-live-pip.af-live-open {
@@ -213,19 +416,54 @@ body {
 }
 
 .af-ghost {
-  padding: 0.4rem 0.75rem;
+  padding: 0.4rem var(--af-sp-3);
   background: transparent;
-  color: var(--af-muted);
+  color: var(--af-text-2);
   border: 1px solid var(--af-border);
-  border-radius: 6px;
+  border-radius: var(--af-r-md);
   font: inherit;
-  font-size: 0.8rem;
+  font-size: var(--af-fs-sm);
   cursor: pointer;
 }
 
 .af-ghost:hover {
   color: var(--af-text);
-  border-color: var(--af-muted);
+  border-color: var(--af-border-strong);
+}
+
+/* Theme toggle: a compact Auto/Light/Dark segmented control in the appbar. The
+ * active option carries an accent-tinted chip; theme.ts persists the choice and
+ * stamps data-theme on <html>. */
+.af-theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.1rem;
+  padding: 0.15rem;
+  background: var(--af-bg-inset);
+  border: 1px solid var(--af-border);
+  border-radius: var(--af-r-full);
+}
+
+.af-theme-opt {
+  padding: 0.2rem 0.55rem;
+  background: transparent;
+  color: var(--af-text-2);
+  border: none;
+  border-radius: var(--af-r-full);
+  font: inherit;
+  font-size: var(--af-fs-2xs);
+  line-height: 1.4;
+  cursor: pointer;
+}
+
+.af-theme-opt:hover {
+  color: var(--af-text);
+}
+
+.af-theme-opt-active {
+  background: var(--af-accent-subtle);
+  color: var(--af-accent);
+  font-weight: 600;
 }
 
 /* Body: fixed-width rail + flexible main content. */
@@ -239,7 +477,7 @@ body {
   width: 18rem;
   flex: 0 0 18rem;
   border-right: 1px solid var(--af-border);
-  background: var(--af-surface);
+  background: var(--af-bg-surface);
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -269,19 +507,19 @@ body {
 }
 
 .af-rail-title {
-  font-size: 0.7rem;
+  font-size: var(--af-fs-xs);
   text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--af-muted);
+  letter-spacing: var(--af-track);
+  color: var(--af-text-2);
 }
 
 .af-rail-count {
-  font-size: 0.75rem;
-  color: var(--af-muted);
-  background: var(--af-bg);
+  font-size: var(--af-fs-xs);
+  color: var(--af-text-2);
+  background: var(--af-bg-inset);
   border: 1px solid var(--af-border);
-  border-radius: 999px;
-  padding: 0.05rem 0.5rem;
+  border-radius: var(--af-r-full);
+  padding: 0.05rem var(--af-sp-2);
 }
 
 .af-rail-list {
@@ -293,35 +531,36 @@ body {
 }
 
 .af-rail-empty {
-  padding: 1rem 0.75rem;
-  color: var(--af-muted);
-  font-size: 0.8rem;
+  padding: var(--af-sp-4) var(--af-sp-3);
+  color: var(--af-text-2);
+  font-size: var(--af-fs-sm);
   line-height: 1.5;
 }
 
 .af-rail-empty code {
+  font-family: var(--af-font-mono);
   color: var(--af-text);
 }
 
 .af-row {
   display: flex;
   align-items: flex-start;
-  gap: 0.5rem;
-  padding: 0.5rem 0.6rem;
-  border-radius: 6px;
+  gap: var(--af-sp-2);
+  padding: var(--af-sp-2) 0.6rem;
+  border-radius: var(--af-r-md);
   cursor: pointer;
 }
 
 .af-row:hover {
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--af-bg-inset);
 }
 
 .af-row-selected {
-  background: rgba(47, 129, 247, 0.16);
+  background: var(--af-accent-subtle);
 }
 
 .af-row-selected:hover {
-  background: rgba(47, 129, 247, 0.22);
+  background: var(--af-accent-tint);
 }
 
 .af-row-archived {
@@ -334,7 +573,7 @@ body {
 }
 
 .af-row-title {
-  font-size: 0.85rem;
+  font-size: var(--af-fs-md);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -342,8 +581,8 @@ body {
 
 .af-row-branch {
   margin-top: 0.15rem;
-  font-size: 0.72rem;
-  color: var(--af-muted);
+  font-size: var(--af-fs-xs);
+  color: var(--af-text-2);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -358,7 +597,7 @@ body {
 .af-dot {
   flex: 0 0 auto;
   line-height: 1.4;
-  font-size: 0.8rem;
+  font-size: var(--af-fs-sm);
 }
 
 .af-dot-ready {
@@ -399,7 +638,7 @@ body {
   }
 }
 
-/* Main content area — an empty state, or the live attach terminal (PR4). */
+/* Main content area — an empty state, or the live attach terminal. */
 .af-main {
   flex: 1;
   min-width: 0;
@@ -411,19 +650,19 @@ body {
   align-items: center;
   justify-content: center;
   gap: 0.4rem;
-  padding: 2rem;
+  padding: var(--af-sp-6);
   text-align: center;
 }
 
 .af-empty-title {
   margin: 0;
-  font-size: 1.1rem;
+  font-size: var(--af-fs-lg);
 }
 
 .af-empty-hint {
   margin: 0;
-  color: var(--af-muted);
-  font-size: 0.85rem;
+  color: var(--af-text-2);
+  font-size: var(--af-fs-md);
 }
 
 /* Terminal pane: a slim header (session title + connection status) over the xterm
@@ -437,9 +676,9 @@ body {
   align-items: center;
   justify-content: space-between;
   gap: 0.6rem;
-  padding: 0.5rem 0.9rem;
+  padding: var(--af-sp-2) 0.9rem;
   border-bottom: 1px solid var(--af-border);
-  background: var(--af-surface);
+  background: var(--af-bg-surface);
 }
 
 .af-term-head-main {
@@ -458,11 +697,11 @@ body {
 
 .af-term-action {
   padding: 0.3rem 0.6rem;
-  font-size: 0.75rem;
+  font-size: var(--af-fs-xs);
 }
 
 .af-term-title {
-  font-size: 0.85rem;
+  font-size: var(--af-fs-md);
   font-weight: 600;
   white-space: nowrap;
   overflow: hidden;
@@ -470,8 +709,8 @@ body {
 }
 
 .af-term-meta {
-  font-size: 0.72rem;
-  color: var(--af-muted);
+  font-size: var(--af-fs-xs);
+  color: var(--af-text-2);
   white-space: nowrap;
 }
 
@@ -499,7 +738,7 @@ body {
   align-items: stretch;
   gap: 0.15rem;
   padding: 0 0.6rem;
-  background: var(--af-surface);
+  background: var(--af-bg-surface);
   border-bottom: 1px solid var(--af-border);
   overflow-x: auto;
   scrollbar-width: thin;
@@ -511,12 +750,12 @@ body {
   gap: 0.35rem;
   padding: 0.35rem 0.6rem;
   background: transparent;
-  color: var(--af-muted);
+  color: var(--af-text-2);
   border: none;
   border-bottom: 2px solid transparent;
   border-radius: 0;
   font: inherit;
-  font-size: 0.75rem;
+  font-size: var(--af-fs-xs);
   white-space: nowrap;
   cursor: pointer;
 }
@@ -564,15 +803,15 @@ body {
   justify-content: center;
   width: 1.1em;
   height: 1.1em;
-  border-radius: 3px;
-  color: var(--af-muted);
-  font-size: 0.9rem;
+  border-radius: var(--af-r-sm);
+  color: var(--af-text-2);
+  font-size: var(--af-fs-md);
   line-height: 1;
 }
 
 .af-tab-close:hover {
-  color: var(--af-error);
-  background: rgba(248, 81, 73, 0.14);
+  color: var(--af-danger);
+  background: var(--af-danger-subtle);
 }
 
 /* The + new-tab button: the tab-bar analogue of the rail's "+ New". */
@@ -583,7 +822,7 @@ body {
   border: none;
   border-radius: 0;
   font: inherit;
-  font-size: 0.85rem;
+  font-size: var(--af-fs-md);
   font-weight: 600;
   line-height: 1;
   cursor: pointer;
@@ -598,18 +837,18 @@ body {
  * create/close failure surfaces instead of being swallowed. */
 .af-toast {
   position: fixed;
-  right: 1.25rem;
-  bottom: 1.25rem;
+  right: var(--af-sp-5);
+  bottom: var(--af-sp-5);
   max-width: 24rem;
   padding: 0.6rem 0.85rem;
-  background: var(--af-surface);
+  background: var(--af-bg-raised);
   color: var(--af-text);
-  border: 1px solid var(--af-error);
+  border: 1px solid var(--af-danger);
   border-left-width: 3px;
-  border-radius: 6px;
-  font-size: 0.8rem;
+  border-radius: var(--af-r-md);
+  font-size: var(--af-fs-sm);
   line-height: 1.4;
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--af-shadow-2);
   opacity: 0;
   transform: translateY(0.4rem);
   transition: opacity 0.15s ease, transform 0.15s ease;
@@ -630,7 +869,7 @@ body {
   flex: 1;
   min-height: 0;
   display: flex;
-  background: var(--af-bg);
+  background: var(--af-bg-term);
   overflow: hidden;
 }
 
@@ -708,8 +947,8 @@ body {
   align-items: center;
   justify-content: space-between;
   gap: 0.4rem;
-  padding: 0.15rem 0.5rem;
-  background: var(--af-surface);
+  padding: 0.15rem var(--af-sp-2);
+  background: var(--af-bg-surface);
   border-bottom: 1px solid var(--af-border);
 }
 
@@ -718,8 +957,8 @@ body {
 }
 
 .af-pane-label {
-  font-size: 0.68rem;
-  color: var(--af-muted);
+  font-size: var(--af-fs-2xs);
+  color: var(--af-text-2);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -727,20 +966,20 @@ body {
 
 .af-pane-close {
   flex: 0 0 auto;
-  padding: 0 0.25rem;
+  padding: 0 var(--af-sp-1);
   background: transparent;
-  color: var(--af-muted);
+  color: var(--af-text-2);
   border: none;
-  border-radius: 3px;
+  border-radius: var(--af-r-sm);
   font: inherit;
-  font-size: 0.85rem;
+  font-size: var(--af-fs-md);
   line-height: 1;
   cursor: pointer;
 }
 
 .af-pane-close:hover {
-  color: var(--af-error);
-  background: rgba(248, 81, 73, 0.14);
+  color: var(--af-danger);
+  background: var(--af-danger-subtle);
 }
 
 /* The xterm mount: fills the pane below its (optional) head. The small padding keeps
@@ -767,10 +1006,10 @@ body {
 .af-webpane-bar {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.25rem 0.4rem;
+  gap: var(--af-sp-2);
+  padding: var(--af-sp-1) 0.4rem;
   border-bottom: 1px solid var(--af-border);
-  font-size: 0.8rem;
+  font-size: var(--af-fs-sm);
 }
 
 .af-webpane-reload {
@@ -779,7 +1018,7 @@ body {
   background: transparent;
   color: var(--af-text);
   border: 1px solid var(--af-border);
-  border-radius: var(--af-radius);
+  border-radius: var(--af-r-md);
   padding: 0 0.4rem;
   line-height: 1.4;
 }
@@ -794,7 +1033,7 @@ body {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: var(--af-muted);
+  color: var(--af-text-2);
 }
 
 .af-webpane-open {
@@ -812,7 +1051,7 @@ body {
   min-height: 0;
   width: 100%;
   border: 0;
-  background: #fff;
+  background: var(--af-bg-surface);
 }
 
 /* Shown when a direct external frame is blocked from embedding (best-effort). */
@@ -821,9 +1060,9 @@ body {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 0.75rem;
+  gap: var(--af-sp-3);
   flex: 1 1 0;
-  padding: 1rem;
+  padding: var(--af-sp-4);
   text-align: center;
   color: var(--af-text);
 }
@@ -856,7 +1095,7 @@ body {
 .af-drop-overlay {
   position: absolute;
   display: none;
-  background: rgba(47, 129, 247, 0.28);
+  background: var(--af-accent-tint);
   border: 1px solid var(--af-accent);
   pointer-events: none;
   z-index: 5;
@@ -901,37 +1140,37 @@ body {
 /* Rail "+ New" button (#1592 Phase 5 PR5): a compact accent-outlined action in
  * the rail header, beside the session count. */
 .af-rail-new {
-  padding: 0.25rem 0.55rem;
+  padding: var(--af-sp-1) 0.55rem;
   background: transparent;
   color: var(--af-accent);
   border: 1px solid var(--af-accent);
-  border-radius: 6px;
+  border-radius: var(--af-r-md);
   font: inherit;
-  font-size: 0.72rem;
+  font-size: var(--af-fs-2xs);
   font-weight: 600;
   cursor: pointer;
 }
 
 .af-rail-new:hover {
-  background: rgba(47, 129, 247, 0.12);
+  background: var(--af-accent-subtle);
 }
 
 /* Destructive action button (kill/confirm-kill): outlined in the error color, and
  * solid on the confirm modal's primary slot. */
 .af-danger {
-  padding: 0.4rem 0.75rem;
+  padding: 0.4rem var(--af-sp-3);
   background: transparent;
-  color: var(--af-error);
-  border: 1px solid var(--af-error);
-  border-radius: 6px;
+  color: var(--af-danger);
+  border: 1px solid var(--af-danger);
+  border-radius: var(--af-r-md);
   font: inherit;
-  font-size: 0.8rem;
+  font-size: var(--af-fs-sm);
   font-weight: 600;
   cursor: pointer;
 }
 
 .af-danger:hover {
-  background: rgba(248, 81, 73, 0.12);
+  background: var(--af-danger-subtle);
 }
 
 .af-danger:disabled {
@@ -950,11 +1189,11 @@ body {
 .af-modal-backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(1, 4, 9, 0.7);
+  background: var(--af-backdrop);
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 1.5rem;
+  padding: var(--af-sp-5);
   z-index: 20;
 }
 
@@ -963,10 +1202,11 @@ body {
   max-width: 30rem;
   max-height: 90vh;
   overflow-y: auto;
-  background: var(--af-surface);
+  background: var(--af-bg-raised);
   border: 1px solid var(--af-border);
-  border-radius: var(--af-radius);
-  padding: 1.5rem;
+  border-radius: var(--af-r-lg);
+  box-shadow: var(--af-shadow-overlay);
+  padding: var(--af-sp-5);
 }
 
 .af-modal-busy {
@@ -974,8 +1214,8 @@ body {
 }
 
 .af-modal-title {
-  margin: 0 0 1rem;
-  font-size: 1.05rem;
+  margin: 0 0 var(--af-sp-4);
+  font-size: var(--af-fs-lg);
   font-weight: 600;
   white-space: nowrap;
   overflow: hidden;
@@ -986,7 +1226,7 @@ body {
 .af-modal-body {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: var(--af-sp-3);
 }
 
 .af-modal-field {
@@ -996,21 +1236,21 @@ body {
 }
 
 .af-modal-label {
-  font-size: 0.72rem;
-  color: var(--af-muted);
+  font-size: var(--af-fs-xs);
+  color: var(--af-text-2);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: var(--af-track);
 }
 
 .af-input {
   width: 100%;
   padding: 0.55rem 0.7rem;
-  background: var(--af-bg);
+  background: var(--af-bg-inset);
   border: 1px solid var(--af-border);
-  border-radius: 6px;
+  border-radius: var(--af-r-md);
   color: var(--af-text);
   font: inherit;
-  font-size: 0.88rem;
+  font-size: var(--af-fs-md);
 }
 
 .af-input:focus {
@@ -1026,23 +1266,23 @@ body {
 .af-check-row {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  font-size: 0.82rem;
-  color: var(--af-muted);
+  gap: var(--af-sp-2);
+  font-size: var(--af-fs-sm);
+  color: var(--af-text-2);
   cursor: pointer;
 }
 
 .af-modal-text {
   margin: 0;
-  color: var(--af-muted);
-  font-size: 0.85rem;
+  color: var(--af-text-2);
+  font-size: var(--af-fs-md);
   line-height: 1.5;
 }
 
 .af-modal-error {
   margin: 0;
-  color: var(--af-error);
-  font-size: 0.8rem;
+  color: var(--af-danger);
+  font-size: var(--af-fs-sm);
   line-height: 1.4;
 }
 
@@ -1050,7 +1290,7 @@ body {
   display: flex;
   justify-content: flex-end;
   gap: 0.6rem;
-  margin-top: 0.25rem;
+  margin-top: var(--af-sp-1);
 }
 
 .af-modal-foot .af-primary,
@@ -1064,19 +1304,19 @@ body {
 .af-viewnav {
   display: inline-flex;
   align-items: stretch;
-  gap: 0.25rem;
-  margin-left: 0.5rem;
+  gap: var(--af-sp-1);
+  margin-left: var(--af-sp-2);
 }
 
 .af-viewtab {
   padding: 0.3rem 0.7rem;
   background: transparent;
-  color: var(--af-muted);
+  color: var(--af-text-2);
   border: none;
   border-bottom: 2px solid transparent;
   border-radius: 0;
   font: inherit;
-  font-size: 0.78rem;
+  font-size: var(--af-fs-sm);
   cursor: pointer;
 }
 
@@ -1123,9 +1363,9 @@ body {
   display: flex;
   align-items: center;
   gap: 0.6rem;
-  padding: 0.6rem 1rem;
+  padding: 0.6rem var(--af-sp-4);
   border-bottom: 1px solid var(--af-border);
-  background: var(--af-surface);
+  background: var(--af-bg-surface);
   position: sticky;
   top: 0;
   z-index: 1;
@@ -1133,56 +1373,57 @@ body {
 
 .af-projects-title,
 .af-tasks-title {
-  font-size: 0.7rem;
+  font-size: var(--af-fs-xs);
   text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--af-muted);
+  letter-spacing: var(--af-track);
+  color: var(--af-text-2);
 }
 
 /* The projects/tasks count badge, styled like the rail's session count (a distinct
  * class so the sessions rail's .af-rail-count selector stays unambiguous). */
 .af-view-count {
-  font-size: 0.75rem;
-  color: var(--af-muted);
-  background: var(--af-bg);
+  font-size: var(--af-fs-xs);
+  color: var(--af-text-2);
+  background: var(--af-bg-inset);
   border: 1px solid var(--af-border);
-  border-radius: 999px;
-  padding: 0.05rem 0.5rem;
+  border-radius: var(--af-r-full);
+  padding: 0.05rem var(--af-sp-2);
 }
 
 /* The tasks "+ Add" button, styled like the rail's "+ New" and pushed to the far
  * right of its header (its own class so the rail's .af-rail-new stays unambiguous). */
 .af-tasks-add {
   margin-left: auto;
-  padding: 0.25rem 0.55rem;
+  padding: var(--af-sp-1) 0.55rem;
   background: transparent;
   color: var(--af-accent);
   border: 1px solid var(--af-accent);
-  border-radius: 6px;
+  border-radius: var(--af-r-md);
   font: inherit;
-  font-size: 0.72rem;
+  font-size: var(--af-fs-2xs);
   font-weight: 600;
   cursor: pointer;
 }
 
 .af-tasks-add:hover {
-  background: rgba(47, 129, 247, 0.12);
+  background: var(--af-accent-subtle);
 }
 
 .af-projects-empty,
 .af-tasks-empty {
-  padding: 1.25rem 1rem;
-  color: var(--af-muted);
-  font-size: 0.85rem;
+  padding: var(--af-sp-5) var(--af-sp-4);
+  color: var(--af-text-2);
+  font-size: var(--af-fs-md);
   line-height: 1.5;
 }
 
 .af-projects-empty code {
+  font-family: var(--af-font-mono);
   color: var(--af-text);
 }
 
 .af-projects-list {
-  padding: 0.5rem 0.75rem 1.5rem;
+  padding: var(--af-sp-2) 0.75rem var(--af-sp-5);
 }
 
 .af-project {
@@ -1193,18 +1434,18 @@ body {
   display: grid;
   grid-template-columns: 1fr auto auto;
   align-items: baseline;
-  gap: 0.5rem;
-  padding: 0.5rem 0.6rem 0.35rem;
+  gap: var(--af-sp-2);
+  padding: var(--af-sp-2) 0.6rem 0.35rem;
 }
 
 .af-project-delete {
-  font-size: 0.7rem;
+  font-size: var(--af-fs-2xs);
   padding: 0.1rem 0.4rem;
   align-self: center;
 }
 
 .af-project-name {
-  font-size: 0.85rem;
+  font-size: var(--af-fs-md);
   font-weight: 600;
   white-space: nowrap;
   overflow: hidden;
@@ -1212,14 +1453,14 @@ body {
 }
 
 .af-project-count {
-  font-size: 0.72rem;
-  color: var(--af-muted);
+  font-size: var(--af-fs-xs);
+  color: var(--af-text-2);
 }
 
 .af-project-path {
   grid-column: 1 / -1;
-  font-size: 0.7rem;
-  color: var(--af-muted);
+  font-size: var(--af-fs-xs);
+  color: var(--af-text-2);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1240,7 +1481,7 @@ body {
 .af-tasks-list {
   list-style: none;
   margin: 0;
-  padding: 0.5rem 0.75rem 1.5rem;
+  padding: var(--af-sp-2) 0.75rem var(--af-sp-5);
 }
 
 .af-task-row {
@@ -1253,8 +1494,8 @@ body {
 
 .af-task-enabled {
   flex: 0 0 auto;
-  font-size: 0.78rem;
-  color: var(--af-muted);
+  font-size: var(--af-fs-sm);
+  color: var(--af-text-2);
   line-height: 1.5;
 }
 
@@ -1268,7 +1509,7 @@ body {
 }
 
 .af-task-name {
-  font-size: 0.85rem;
+  font-size: var(--af-fs-md);
   font-weight: 600;
   white-space: nowrap;
   overflow: hidden;
@@ -1277,7 +1518,7 @@ body {
 
 .af-task-trigger {
   margin-top: 0.15rem;
-  font-size: 0.75rem;
+  font-size: var(--af-fs-xs);
   color: var(--af-text);
   white-space: nowrap;
   overflow: hidden;
@@ -1286,8 +1527,8 @@ body {
 
 .af-task-meta {
   margin-top: 0.1rem;
-  font-size: 0.72rem;
-  color: var(--af-muted);
+  font-size: var(--af-fs-xs);
+  color: var(--af-text-2);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1302,7 +1543,7 @@ body {
 
 .af-task-action {
   padding: 0.3rem 0.55rem;
-  font-size: 0.72rem;
+  font-size: var(--af-fs-xs);
 }
 
 /* Narrow viewport: stack the rail above the main pane (design §7.2 item 7 —

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -37,9 +37,10 @@
 // daemon/webserve.go.)
 
 import { FitAddon } from "@xterm/addon-fit";
-import { Terminal } from "@xterm/xterm";
+import { type ITheme, Terminal } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
 import { decode, encode, inputFrame, Op, resizeFrame } from "./frame.js";
+import { currentXtermTheme } from "./theme.js";
 
 /** The attach terminal's connection state, surfaced for a small status line. */
 export type TerminalStatus = "connecting" | "open" | "reconnecting" | "exited";
@@ -58,32 +59,6 @@ const BACKOFF_MAX_MS = 10_000;
 // Debounce the fit→OpResize send so dragging a window edge sends one resize on
 // settle, not one per animation frame. The server echoes the winning size back.
 const RESIZE_DEBOUNCE_MS = 120;
-
-/** xterm theme mirroring the app's GitHub-dark palette (styles.css) and the TUI's
- *  terminal aesthetic, so the browser terminal reads like the rest of the shell. */
-const THEME = {
-  background: "#0d1117",
-  foreground: "#e6edf3",
-  cursor: "#e6edf3",
-  cursorAccent: "#0d1117",
-  selectionBackground: "rgba(47, 129, 247, 0.30)",
-  black: "#484f58",
-  red: "#ff7b72",
-  green: "#3fb950",
-  yellow: "#d29922",
-  blue: "#58a6ff",
-  magenta: "#bc8cff",
-  cyan: "#39c5cf",
-  white: "#b1bac4",
-  brightBlack: "#6e7681",
-  brightRed: "#ffa198",
-  brightGreen: "#56d364",
-  brightYellow: "#e3b341",
-  brightBlue: "#79c0ff",
-  brightMagenta: "#d2a8ff",
-  brightCyan: "#56d4dd",
-  brightWhite: "#f0f6fc",
-} as const;
 
 /** ws: under http:, wss: under the TLS TCP listener the SPA is normally served
  *  from — matching the page origin so the stream rides the same authed transport. */
@@ -137,7 +112,9 @@ export class AttachTerminal {
       cursorBlink: true,
       fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
       fontSize: 13,
-      theme: THEME,
+      // Born in the active theme (theme.ts derives the xterm palette from the same
+      // tokens as the CSS chrome); setTheme() re-applies live on a toggle.
+      theme: currentXtermTheme(),
       // The stream is the source of truth; local echo/scrollback beyond the ring is
       // fine but the server never sees our convert-eol, so leave it raw.
       scrollback: 5000,
@@ -205,6 +182,13 @@ export class AttachTerminal {
    *  navigation gets the keys again — the Escape/back-to-nav half of #1693. */
   blur(): void {
     this.term.blur();
+  }
+
+  /** Re-applies an xterm palette live (a theme toggle): xterm repaints the canvas
+   *  from the new ITheme, so an open terminal switches light/dark without a
+   *  reconnect or losing scrollback. */
+  setTheme(theme: ITheme): void {
+    this.term.options.theme = theme;
   }
 
   // --- socket lifecycle ------------------------------------------------------

--- a/web/src/theme.ts
+++ b/web/src/theme.ts
@@ -1,0 +1,171 @@
+// Theme system (redesign PR1): first-class light/dark theming for the web client.
+//
+// The design tokens live in styles.css as CSS custom properties, with LIGHT as the
+// :root default, a dark layer via @media (prefers-color-scheme: dark), and explicit
+// :root[data-theme="light"] / [data-theme="dark"] blocks that let a user toggle WIN
+// over the media query in both directions. This module owns the small runtime half:
+//
+//   - the persisted Auto/Light/Dark CHOICE (localStorage, best-effort),
+//   - stamping `data-theme` on <html> so the CSS resolves the right layer, and
+//   - deriving the xterm.js ITheme (which cannot read CSS vars) from the resolved
+//     concrete mode, keyed to the same token values so the terminal matches chrome.
+//
+// The boot stamp (bootStampTheme) runs at the very top of index.ts BEFORE the app
+// mounts, so an explicit dark/light choice is applied before first paint — no
+// light/dark flash. It is CSP-safe: it ships inside the same-origin bundle, not as
+// an inline <script> (the daemon's `default-src 'self'` blocks inline script).
+
+import type { ITheme } from "@xterm/xterm";
+
+/** The persisted user preference: Auto follows the OS, Light/Dark force a mode. */
+export type ThemeChoice = "auto" | "light" | "dark";
+/** The resolved concrete mode Auto collapses to for xterm + any JS that needs it. */
+export type ThemeMode = "light" | "dark";
+
+/** The Auto/Light/Dark cycle order, for the appbar toggle. */
+export const THEME_CHOICES: readonly ThemeChoice[] = ["auto", "light", "dark"];
+
+const STORAGE_KEY = "af-theme";
+
+function isChoice(v: unknown): v is ThemeChoice {
+  return v === "auto" || v === "light" || v === "dark";
+}
+
+/** Reads the saved choice, defaulting to Auto (follow the OS) when unset or when
+ *  localStorage is unavailable (private mode / blocked). */
+export function readThemeChoice(): ThemeChoice {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (isChoice(raw)) {
+      return raw;
+    }
+  } catch {
+    // storage blocked — fall through to the Auto default
+  }
+  return "auto";
+}
+
+/** Persists the choice (best-effort; a blocked store is a silent no-op). */
+export function persistThemeChoice(choice: ThemeChoice): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, choice);
+  } catch {
+    // storage blocked — the choice still applies this session, just not persisted
+  }
+}
+
+/** Stamps `data-theme` on <html> for a choice: an explicit light/dark sets the
+ *  attribute so its :root[data-theme=…] block wins over the media query; Auto
+ *  removes the attribute so the media query decides. */
+export function stampTheme(choice: ThemeChoice): void {
+  const root = document.documentElement;
+  if (choice === "auto") {
+    root.removeAttribute("data-theme");
+  } else {
+    root.setAttribute("data-theme", choice);
+  }
+}
+
+/** The earliest boot stamp: read the saved choice and apply it before first paint
+ *  so an explicit theme shows no light/dark flash. Returns the choice so the caller
+ *  can seed its state without re-reading storage. Called at index.ts module top. */
+export function bootStampTheme(): ThemeChoice {
+  const choice = readThemeChoice();
+  stampTheme(choice);
+  return choice;
+}
+
+function prefersDark(): boolean {
+  try {
+    return window.matchMedia("(prefers-color-scheme: dark)").matches;
+  } catch {
+    // No matchMedia (very old / headless): the CSS :root default is LIGHT, so match
+    // it here rather than guessing dark.
+    return false;
+  }
+}
+
+/** The concrete mode the DOM is actually rendering: the stamped explicit attribute
+ *  wins, else the OS preference (Auto). Reads the live DOM so it's always in sync
+ *  with what CSS resolved, without threading the choice through every caller. */
+export function currentMode(): ThemeMode {
+  const attr = document.documentElement.getAttribute("data-theme");
+  if (attr === "light" || attr === "dark") {
+    return attr;
+  }
+  return prefersDark() ? "dark" : "light";
+}
+
+// --- xterm themes ----------------------------------------------------------
+//
+// xterm.js paints on a canvas and cannot read CSS custom properties, so its ITheme
+// is derived here from the SAME token values styles.css uses. background/foreground
+// are the term surface + primary text tokens; the ANSI palette is tuned per mode so
+// agent output stays legible (dark: a GitHub-dark-ish palette on the deep term bg;
+// light: darker, saturated hues that read on a near-white background).
+
+/** Dark xterm theme: background = --af-bg-term (dark), foreground = --af-text (dark),
+ *  selection = --af-accent-tint (dark). */
+export const DARK_XTERM: ITheme = {
+  background: "#0c1016",
+  foreground: "#e7ecf3",
+  cursor: "#e7ecf3",
+  cursorAccent: "#0c1016",
+  selectionBackground: "rgba(122, 162, 247, 0.2)",
+  black: "#484f58",
+  red: "#ff7b72",
+  green: "#3fb950",
+  yellow: "#d29922",
+  blue: "#58a6ff",
+  magenta: "#bc8cff",
+  cyan: "#39c5cf",
+  white: "#b1bac4",
+  brightBlack: "#6e7681",
+  brightRed: "#ffa198",
+  brightGreen: "#56d364",
+  brightYellow: "#e3b341",
+  brightBlue: "#79c0ff",
+  brightMagenta: "#d2a8ff",
+  brightCyan: "#56d4dd",
+  brightWhite: "#f0f6fc",
+};
+
+/** Light xterm theme: background = --af-bg-term (light), foreground = --af-text
+ *  (light), selection = --af-accent-tint (light). The ANSI palette uses GitHub-light
+ *  hues — darker and more saturated than the dark palette so colored agent output
+ *  stays readable on a near-white terminal. */
+export const LIGHT_XTERM: ITheme = {
+  background: "#fdfefe",
+  foreground: "#17202e",
+  cursor: "#17202e",
+  cursorAccent: "#fdfefe",
+  selectionBackground: "rgba(47, 95, 216, 0.16)",
+  black: "#24292f",
+  red: "#cf222e",
+  green: "#1a7f37",
+  yellow: "#9a6700",
+  blue: "#0969da",
+  magenta: "#8250df",
+  cyan: "#1b7c83",
+  white: "#6e7781",
+  brightBlack: "#57606a",
+  brightRed: "#a40e26",
+  brightGreen: "#116329",
+  brightYellow: "#7d4e00",
+  brightBlue: "#0550ae",
+  brightMagenta: "#6639ba",
+  brightCyan: "#3192aa",
+  brightWhite: "#8c959f",
+};
+
+/** The xterm ITheme for a resolved mode. */
+export function xtermTheme(mode: ThemeMode): ITheme {
+  return mode === "dark" ? DARK_XTERM : LIGHT_XTERM;
+}
+
+/** The xterm ITheme matching whatever the DOM is currently rendering, so a freshly
+ *  constructed terminal (terminal.ts) is born in the active theme without the caller
+ *  needing to know the mode. */
+export function currentXtermTheme(): ITheme {
+  return xtermTheme(currentMode());
+}

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -25,6 +25,7 @@ import { TAB_DND_MIME } from "./layout.js";
 import { ProjectsPane } from "./projects.js";
 import { compareSessionsForRail, isArchived, rowStatus, rowTitle } from "./status.js";
 import { TasksPane } from "./tasks.js";
+import { type ThemeChoice, THEME_CHOICES } from "./theme.js";
 import type { TerminalStatus } from "./terminal.js";
 import type { SessionData, TaskData } from "./types.js";
 
@@ -77,6 +78,10 @@ export interface AppState {
   tabError: string | null;
   /** the live task projection (ListTasks + task.* events), the tasks view's data. */
   tasks: TaskData[];
+  /** the persisted theme preference (redesign PR1): Auto follows the OS, Light/Dark
+   *  force a mode. The appbar toggle sets it; theme.ts stamps data-theme on <html>
+   *  and re-themes the live terminals. */
+  themeChoice: ThemeChoice;
 }
 
 /** Callbacks the shell invokes; index.ts owns the real behavior. */
@@ -121,6 +126,9 @@ export interface Actions {
   /** Opens the reversible delete-project confirm for a project row (#1735); on
    *  confirm index.ts calls DeleteProject, which archives its live sessions. */
   deleteProject(root: string, label: string, sessionCount: number): void;
+  /** Sets the theme preference (redesign PR1): persists it, stamps data-theme on
+   *  <html>, and re-themes the live terminals. */
+  setTheme(choice: ThemeChoice): void;
 }
 
 /** The soft cap on tabs per session (session/tab.go maxTabs): the agent tab plus
@@ -195,6 +203,18 @@ function viewLabel(view: View): string {
       return "Projects";
     case "tasks":
       return "Tasks";
+  }
+}
+
+/** The appbar label for a theme choice (redesign PR1). */
+function themeLabel(choice: ThemeChoice): string {
+  switch (choice) {
+    case "auto":
+      return "Auto";
+    case "light":
+      return "Light";
+    case "dark":
+      return "Dark";
   }
 }
 
@@ -381,6 +401,10 @@ export class AppShell {
   // stays mounted while another view shows — hidden, not destroyed — so switching
   // views never tears down the focused terminal or its scrollback.
   private readonly viewTabs = new Map<View, HTMLElement>();
+  // The appbar theme toggle (redesign PR1): one button per Auto/Light/Dark choice,
+  // the active one highlighted in update().
+  private readonly themeOpts = new Map<ThemeChoice, HTMLElement>();
+  private lastThemeChoice: ThemeChoice | null = null;
   private readonly sessionsBody: HTMLElement;
   private readonly projectsPane: ProjectsPane;
   private readonly tasksPane: TasksPane;
@@ -423,6 +447,20 @@ export class AppShell {
     const disconnect = h("button", { type: "button", class: "af-ghost" }, "Disconnect");
     disconnect.addEventListener("click", () => this.actions.disconnect());
 
+    // The theme toggle: a compact Auto/Light/Dark segmented control. A click routes
+    // through actions.setTheme, which persists the choice and re-themes the terminals.
+    const themeToggle = h("div", { class: "af-theme-toggle" });
+    themeToggle.setAttribute("role", "group");
+    themeToggle.setAttribute("aria-label", "Theme");
+    for (const choice of THEME_CHOICES) {
+      const opt = h("button", { type: "button", class: "af-theme-opt" }, themeLabel(choice));
+      opt.setAttribute("data-theme-opt", choice);
+      opt.setAttribute("title", `${themeLabel(choice)} theme`);
+      opt.addEventListener("click", () => this.actions.setTheme(choice));
+      this.themeOpts.set(choice, opt);
+      themeToggle.append(opt);
+    }
+
     // The view switcher: one tab per top-level view, left-to-right in the [ / ] cycle
     // order (nav.ts VIEWS), the active one highlighted in update(). A click routes
     // through actions.switchView, exactly like the keyboard path.
@@ -444,6 +482,7 @@ export class AppShell {
       h("span", { class: "af-brand" }, "Agent Factory"),
       viewNav,
       live,
+      themeToggle,
       disconnect,
     );
 
@@ -527,6 +566,16 @@ export class AppShell {
       for (const [v, tab] of this.viewTabs) {
         tab.classList.toggle("af-viewtab-active", v === state.view);
         tab.setAttribute("aria-selected", v === state.view ? "true" : "false");
+      }
+    }
+
+    // Highlight the active theme option (redesign PR1) when the choice changes.
+    if (this.lastThemeChoice !== state.themeChoice) {
+      this.lastThemeChoice = state.themeChoice;
+      for (const [choice, opt] of this.themeOpts) {
+        const active = choice === state.themeChoice;
+        opt.classList.toggle("af-theme-opt-active", active);
+        opt.setAttribute("aria-pressed", active ? "true" : "false");
       }
     }
 


### PR DESCRIPTION
## What

**PR1 of the approved web-UI redesign.** Sachin approved the direction ("the UI for the website looks great"). This PR does the **design-token system + first-class light/dark theming** and converts today's UI to be token-driven and themeable, keeping the current layout/structure unchanged.

- **PR1 (this):** tokens + theming + toggle + theme-aware xterm.
- **PR2 (next):** single-project IA (top-right switcher / rail rescoping).
- **PR3 (later):** the prettier component restructure.

The web client had **zero theming** and a hardcoded GitHub-dark xterm theme; this makes it light/dark capable from one place.

## Changes

- **`web/src/styles.css`** — define the `--af-*` design tokens (type, spacing, radius, color, status dots, terminal hues, elevation) at `:root` (LIGHT default), a dark layer via `@media (prefers-color-scheme: dark)`, and explicit `:root[data-theme="light"|"dark"]` blocks that **duplicate** the light/dark values so an explicit toggle **wins over the media query in both directions**. Every visible component (rail, appbar, tabbar, term-host/pane/split, rows, modals, buttons, toast, inputs, scrollbars) now consumes `var(--af-*)` — **no hardcoded hex left on visible chrome**. Dark status-dot hues keep **exact TUI (zenburn) parity**.
- **`web/src/theme.ts` (new)** — persisted Auto/Light/Dark choice (localStorage, best-effort), `data-theme` stamping, and light/dark **xterm `ITheme`** derivation keyed to the same tokens (xterm can't read CSS vars). `bootStampTheme()` is a **CSP-safe boot stamp** (ships in the same-origin bundle, not an inline `<script>` the daemon's `default-src 'self'` would block).
- **`web/src/index.ts`** — stamp the saved theme **before the app mounts** (no light/dark flash), a `setTheme` action that persists + re-themes the live terminals, and follow the OS while the choice is Auto.
- **`web/src/ui.ts`** — a compact **Auto/Light/Dark segmented toggle** in the appbar.
- **`web/src/terminal.ts` / `web/src/split.ts`** — terminals are born in the active theme and **re-theme live** (including split panes) on toggle.
- **`web/selftest/web-driver.spec.ts`** — assert `data-theme` is stamped **before the app mounts** (no flash, via a race-free `#app.replaceChildren` trap) and that toggling Light vs Dark **changes token-driven computed colors** (the light rail resolves to `#fff`); existing flows still pass in the default theme.
- **`web/dist/`** — rebuilt bundle committed.

## Gates (all green)

- `make web-selftest-container` — **22/22** (20 pre-existing + 2 new theme tests)
- `make web-test` — typecheck + **86** unit tests
- `make tui-driver-selftest` — **25/25**
- `go build ./...`, `gofmt -l .`, `golangci-lint run --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)