### PR TITLE
refactor(commands): share token command path

### DIFF
--- a/commands/tokencmd.go
+++ b/commands/tokencmd.go
@@ -24,16 +24,34 @@ import (
 // {data,error} envelope, matching `af config`'s --json.
 var tokenJSONFlag bool
 
-// tokenShowResult is the `af token show` payload: the bearer token clients
+// tokenResult is the `af token show`/`rotate` payload: the bearer token clients
 // present to the HTTP listener.
-type tokenShowResult struct {
+type tokenResult struct {
 	Token string `json:"token"`
 }
 
-// tokenRotateResult is the `af token rotate` payload: the freshly generated
-// token.
-type tokenRotateResult struct {
-	Token string `json:"token"`
+// runTokenCommand performs the shared token command work. Both show and rotate
+// differ only in how they obtain the token; their output and error contracts are
+// intentionally identical.
+func runTokenCommand(cmd *cobra.Command, loadToken func(string) (string, error)) error {
+	log.Initialize(false)
+	defer log.Close()
+
+	tokenPath, err := daemon.TokenPath()
+	if err != nil {
+		return jsonWrapError(cmd, tokenJSONFlag, err)
+	}
+	token, err := loadToken(tokenPath)
+	if err != nil {
+		return jsonWrapError(cmd, tokenJSONFlag, err)
+	}
+
+	result := tokenResult{Token: token}
+	if tokenJSONFlag {
+		return apiproto.WriteEnvelope(cmd.OutOrStdout(), apiproto.Success(result))
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "token: %s\n", result.Token)
+	return nil
 }
 
 var tokenCmd = &cobra.Command{
@@ -61,24 +79,7 @@ before the TCP listener is ever enabled. Present it to a remote daemon with the
 --token flag (or the AF_DAEMON_TOKEN env var).`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		log.Initialize(false)
-		defer log.Close()
-
-		tokenPath, err := daemon.TokenPath()
-		if err != nil {
-			return jsonWrapError(cmd, tokenJSONFlag, err)
-		}
-		token, err := daemon.EnsureToken(tokenPath)
-		if err != nil {
-			return jsonWrapError(cmd, tokenJSONFlag, err)
-		}
-
-		result := tokenShowResult{Token: token}
-		if tokenJSONFlag {
-			return apiproto.WriteEnvelope(cmd.OutOrStdout(), apiproto.Success(result))
-		}
-		fmt.Fprintf(cmd.OutOrStdout(), "token: %s\n", result.Token)
-		return nil
+		return runTokenCommand(cmd, daemon.EnsureToken)
 	},
 }
 
@@ -92,24 +93,7 @@ the token file per request — while any in-flight streams keep running until th
 reconnect.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		log.Initialize(false)
-		defer log.Close()
-
-		tokenPath, err := daemon.TokenPath()
-		if err != nil {
-			return jsonWrapError(cmd, tokenJSONFlag, err)
-		}
-		token, err := daemon.RotateToken(tokenPath)
-		if err != nil {
-			return jsonWrapError(cmd, tokenJSONFlag, err)
-		}
-
-		result := tokenRotateResult{Token: token}
-		if tokenJSONFlag {
-			return apiproto.WriteEnvelope(cmd.OutOrStdout(), apiproto.Success(result))
-		}
-		fmt.Fprintf(cmd.OutOrStdout(), "token: %s\n", result.Token)
-		return nil
+		return runTokenCommand(cmd, daemon.RotateToken)
 	},
 }
 


### PR DESCRIPTION
## Summary

- Route `af token show` and `af token rotate` through one shared command helper.
- Remove duplicate result DTOs and duplicate logging, token-path, error-wrapping, JSON, and human-output code.

## Behavior preservation

The commands still call their same distinct token operations (`EnsureToken` versus `RotateToken`). The shared helper retains the prior log lifecycle, `jsonWrapError` handling, output writer, JSON envelope, human `token: <value>` format, and intentionally ignored human-output write error. Existing command tests cover show generation/idempotence and rotate behavior.

## Validation

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (empty)
- `go build ./...`
- `make test-container` (container-fenced full suite)
- `deadcode -test ./...`
- `make lint-file-length`

Refs #1241. Relates to #1195 structural-health sweep lens.

Review requested; not self-merged.

— Captain Claude