### PR TITLE
feat(ui): status shows a static green dot only when waiting; no spinner/animation (TUI + web)

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -131,9 +130,8 @@ func TestConfirmationModalStateTransitions(t *testing.T) {
 
 // TestConfirmationModalKeyHandling tests the actual key handling in confirmation state
 func TestConfirmationModalKeyHandling(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
 	proj := store.NewProjection()
-	sidebar := ui.NewSidebar(&spin, false, proj)
+	sidebar := ui.NewSidebar(false, proj)
 
 	// Create enough of home struct to test handleKeyPress in confirmation state
 	h := &home{
@@ -253,9 +251,8 @@ func TestConfirmationMessageFormatting(t *testing.T) {
 
 // TestConfirmationFlowSimulation tests the confirmation flow by simulating the state changes
 func TestConfirmationFlowSimulation(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
 	proj := store.NewProjection()
-	sidebar := ui.NewSidebar(&spin, false, proj)
+	sidebar := ui.NewSidebar(false, proj)
 
 	// Add test instance
 	instance, err := session.NewInstance(session.InstanceOptions{
@@ -464,9 +461,8 @@ func TestMultipleConfirmationsDontInterfere(t *testing.T) {
 // its handler can run (e.g. selectionChanged updating the content pane after a
 // session is killed). Regression test for #259.
 func TestConfirmActionForwardsNonErrorMsg(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
 	proj := store.NewProjection()
-	sidebar := ui.NewSidebar(&spin, false, proj)
+	sidebar := ui.NewSidebar(false, proj)
 
 	h := &home{
 		ctx:       context.Background(),

--- a/app/creation_test.go
+++ b/app/creation_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/daemon"
@@ -74,7 +73,6 @@ func newTestHome(t *testing.T) *home {
 	}
 	t.Cleanup(func() { newLiveTermPaneFn = origLiveTerm })
 
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
 	proj := store.NewProjection()
 
 	state := config.DefaultState()
@@ -105,7 +103,6 @@ func newTestHome(t *testing.T) *home {
 		pauseStatusPoll:  func(string, string) error { return nil },
 		resumeStatusPoll: func(string, string) error { return nil },
 		store:            proj,
-		spinner:          spin,
 		repoID:           repoID,
 	}
 	// Content capture routes through the daemon Preview RPC since #1592 PR6.
@@ -115,7 +112,7 @@ func newTestHome(t *testing.T) *home {
 	// so the source captures it.
 	h.previewFetcher = testPreviewFetcher(h)
 
-	h.sidebar = ui.NewSidebar(&h.spinner, false, proj)
+	h.sidebar = ui.NewSidebar(false, proj)
 	wireTestPanes(h, proj)
 	return h
 }

--- a/app/home_model.go
+++ b/app/home_model.go
@@ -8,7 +8,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/daemon"
@@ -304,8 +303,6 @@ type home struct {
 	// whose events are failing to reach their target session. Fed each poll by
 	// applyDeliveryAlarms from the snapshot's DeliveryAlarms projection.
 	alarmBanner *ui.AlarmBanner
-	// global spinner instance. we plumb this down to where it's needed
-	spinner spinner.Model
 	// textOverlay displays text information
 	textOverlay *overlay.TextOverlay
 	// textOverlayDismissAnyKey keeps the one-shot intro/created overlays as
@@ -381,7 +378,6 @@ func newHome(ctx context.Context, program string, autoYes bool, repo *config.Rep
 	h := &home{
 		alarmBanner:      ui.NewAlarmBanner(),
 		ctx:              ctx,
-		spinner:          spinner.New(spinner.WithSpinner(spinner.MiniDot)),
 		store:            proj,
 		menu:             menu,
 		errBox:           errBox,
@@ -408,7 +404,7 @@ func newHome(ctx context.Context, program string, autoYes bool, repo *config.Rep
 		state:            stateDefault,
 		appState:         appState,
 	}
-	h.sidebar = ui.NewSidebar(&h.spinner, autoYes, proj)
+	h.sidebar = ui.NewSidebar(autoYes, proj)
 	h.wireZoneRegistry()
 	// No panes are open at startup: the focus ring is tree → automations →
 	// projects until the first pane opens (relayout rebuilds the ring's pane
@@ -762,7 +758,6 @@ func (m *home) focusAdjacentSection(back bool) tea.Cmd {
 
 func (m *home) Init() tea.Cmd {
 	return tea.Batch(
-		m.spinner.Tick,
 		func() tea.Msg {
 			time.Sleep(100 * time.Millisecond)
 			return previewTickMsg{}

--- a/app/home_update.go
+++ b/app/home_update.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/log"
@@ -377,10 +376,6 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.showHelpScreen(helpStart(started), nil)
 
 		return m, tea.Batch(tea.WindowSize(), m.selectionChanged())
-	case spinner.TickMsg:
-		var cmd tea.Cmd
-		m.spinner, cmd = m.spinner.Update(msg)
-		return m, cmd
 	}
 	return m, nil
 }

--- a/app/tui_state.go
+++ b/app/tui_state.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
@@ -288,7 +287,7 @@ func (m *home) persistTUIViewStateAfter(msg tea.Msg) {
 
 func shouldPersistTUIViewStateAfter(msg tea.Msg) bool {
 	switch msg.(type) {
-	case previewTickMsg, panesRefreshedMsg, repaintAfterDetachMsg, spinner.TickMsg, keyupMsg, hideErrMsg:
+	case previewTickMsg, panesRefreshedMsg, repaintAfterDetachMsg, keyupMsg, hideErrMsg:
 		return false
 	default:
 		return true

--- a/ui/layout_height_test.go
+++ b/ui/layout_height_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/sachiniyer/agent-factory/task"
@@ -148,9 +147,8 @@ func requireExactRect(t *testing.T, out string, r layout.Rect, name string) {
 // The content window is unbound (nil pane): the rect/clamp contract under test
 // is binding-independent.
 func newTestWorkspace() (*Sidebar, *TabbedWindow, *AutomationsPane, *StatusBar) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
 	proj := store.NewProjection()
-	sidebar := NewSidebar(&spin, false, proj)
+	sidebar := NewSidebar(false, proj)
 	paneA := NewTabbedWindow(NewTabPane(previewFromInstance), nil)
 	automations := NewAutomationsPane(proj)
 	statusBar := NewStatusBar(NewMenu(), NewErrBox())

--- a/ui/sidebar_archived_test.go
+++ b/ui/sidebar_archived_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -89,8 +88,7 @@ func TestPartitionByArchived_EqualCreatedAtTieBreaksByTitle(t *testing.T) {
 // (collapsed by default, so its row is hidden until expanded). The counts in the
 // two headers reflect the partition.
 func TestSidebar_ArchivedPartitionedIntoFolder(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false, store.NewProjection())
+	s := NewSidebar(false, store.NewProjection())
 
 	addTestInstance(s, archTestInstance(t, "live-one", session.Ready))
 	addTestInstance(s, archTestInstance(t, "put-away", session.Archived))
@@ -126,8 +124,7 @@ func TestSidebar_ArchivedPartitionedIntoFolder(t *testing.T) {
 // restore. Its liveness deliberately stays Archived so the snapshot reconcile
 // still sees the Archived→live transition and runs its rebuild/re-Start (#1203).
 func TestSidebar_RestoringRowRehomedToInstances(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false, store.NewProjection())
+	s := NewSidebar(false, store.NewProjection())
 
 	restoring := archTestInstance(t, "coming-back", session.Archived)
 	restoring.SetInFlightOpForTest(session.OpRestoring)
@@ -149,8 +146,7 @@ func TestSidebar_RestoringRowRehomedToInstances(t *testing.T) {
 // TestSidebar_NoArchivedFolderWhenEmpty (#1028): with nothing archived, the
 // Archived folder header is not shown at all.
 func TestSidebar_NoArchivedFolderWhenEmpty(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false, store.NewProjection())
+	s := NewSidebar(false, store.NewProjection())
 	addTestInstance(s, archTestInstance(t, "live-one", session.Ready))
 	s.SetSize(40, 40)
 
@@ -166,8 +162,7 @@ func TestSidebar_NoArchivedFolderWhenEmpty(t *testing.T) {
 // folder reveals the archived row, and GetSelectedInstance resolves it (so the
 // restore action and the Enter fence can read the selected archived session).
 func TestSidebar_ArchivedRowSelectableWhenExpanded(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false, store.NewProjection())
+	s := NewSidebar(false, store.NewProjection())
 	addTestInstance(s, archTestInstance(t, "put-away", session.Archived))
 	s.SetSize(40, 40)
 
@@ -204,8 +199,7 @@ func TestSidebar_ArchivedRowSelectableWhenExpanded(t *testing.T) {
 }
 
 func TestSidebar_MoveCursorToArchivedInstance(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false, store.NewProjection())
+	s := NewSidebar(false, store.NewProjection())
 
 	liveInst := archTestInstance(t, "live-one", session.Ready)
 	archivedInst := archTestInstance(t, "put-away", session.Archived)
@@ -231,8 +225,7 @@ func TestSidebar_MoveCursorToArchivedInstance(t *testing.T) {
 }
 
 func TestSidebar_NavCrossesBetweenLiveTabsAndArchivedRows(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false, store.NewProjection())
+	s := NewSidebar(false, store.NewProjection())
 
 	liveInst := archTestInstance(t, "live-one", session.Ready)
 	addAgentShellTabs(liveInst)
@@ -273,8 +266,7 @@ func TestSidebar_NavCrossesBetweenLiveTabsAndArchivedRows(t *testing.T) {
 // auto-open: Down at the live tail auto-expands the Archived folder, and Up back
 // into the live instances auto-collapses it again.
 func TestSidebar_NavUpFromArchivedAutoCollapses(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false, store.NewProjection())
+	s := NewSidebar(false, store.NewProjection())
 
 	liveInst := archTestInstance(t, "live-one", session.Ready)
 	addAgentShellTabs(liveInst)
@@ -303,8 +295,7 @@ func TestSidebar_NavUpFromArchivedAutoCollapses(t *testing.T) {
 }
 
 func TestSidebar_NavSkipsNonExpandableLiveRowsBeforeArchived(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false, store.NewProjection())
+	s := NewSidebar(false, store.NewProjection())
 
 	liveInst := archTestInstance(t, "live-one", session.Ready)
 	addAgentShellTabs(liveInst)
@@ -382,8 +373,7 @@ func archivedRowVisible(s *Sidebar) bool {
 // toggles the right folder), and — once expanded — an archived row registers a
 // clickable TreeInstance zone so the mouse can select/act on it.
 func TestSidebar_ArchivedZonesRegistered(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false, store.NewProjection())
+	s := NewSidebar(false, store.NewProjection())
 	reg := zones.NewRegistry()
 	s.SetZoneRegistry(reg)
 	s.SetRect(layout.Rect{X: 0, Y: 0, W: 40, H: 40})
@@ -422,8 +412,7 @@ func TestSidebar_ArchivedZonesRegistered(t *testing.T) {
 // Archived header must collapse/expand the Archived folder ONLY, leaving the
 // Instances section untouched — the behavior the distinct header zones enable.
 func TestSidebar_ClickHeaderKindTogglesCorrectFolder(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false, store.NewProjection())
+	s := NewSidebar(false, store.NewProjection())
 	addTestInstance(s, archTestInstance(t, "live-one", session.Ready))
 	addTestInstance(s, archTestInstance(t, "put-away", session.Archived))
 	s.SetSize(40, 40)

--- a/ui/sidebar_model.go
+++ b/ui/sidebar_model.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sachiniyer/agent-factory/ui/store"
 	"github.com/sachiniyer/agent-factory/ui/tree"
 
-	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
@@ -190,7 +189,7 @@ type Sidebar struct {
 }
 
 // NewSidebar creates a new sidebar rendering the given projection.
-func NewSidebar(spin *spinner.Model, autoYes bool, proj *store.Projection) *Sidebar {
+func NewSidebar(autoYes bool, proj *store.Projection) *Sidebar {
 	s := &Sidebar{
 		proj: proj,
 		sections: []SidebarSection{
@@ -200,7 +199,7 @@ func NewSidebar(spin *spinner.Model, autoYes bool, proj *store.Projection) *Side
 			// folder).
 			{Kind: SectionArchived, Title: "Archived", Expanded: false},
 		},
-		renderer:      tree.NewInstanceRenderer(spin),
+		renderer:      tree.NewInstanceRenderer(),
 		autoyes:       autoYes,
 		lastCursorTab: -1,
 	}

--- a/ui/sidebar_test.go
+++ b/ui/sidebar_test.go
@@ -11,14 +11,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSidebarInitialState(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false, store.NewProjection())
+	s := NewSidebar(false, store.NewProjection())
 
 	// The rail holds the Instances tree plus the Archived folder (#1028). The
 	// Archived section always exists so its collapse state persists, but it is
@@ -44,8 +42,7 @@ func TestSidebarInitialState(t *testing.T) {
 }
 
 func TestSidebarNavigation(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false, store.NewProjection())
+	s := NewSidebar(false, store.NewProjection())
 
 	// Add some instances, each with a real agent + shell tab pair so the tree
 	// walk below has two child rows per instance (#1100: no padded slots).
@@ -111,8 +108,7 @@ func TestSidebarNavigation(t *testing.T) {
 }
 
 func TestSidebarExpandCollapse(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false, store.NewProjection())
+	s := NewSidebar(false, store.NewProjection())
 
 	inst, _ := session.NewInstance(session.InstanceOptions{
 		Title: "inst", Path: t.TempDir(), Program: "test",
@@ -137,8 +133,7 @@ func TestSidebarExpandCollapse(t *testing.T) {
 }
 
 func TestSidebarToggleSection(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false, store.NewProjection())
+	s := NewSidebar(false, store.NewProjection())
 
 	// Toggle Instances (starts expanded)
 	s.ToggleSection()
@@ -149,8 +144,7 @@ func TestSidebarToggleSection(t *testing.T) {
 }
 
 func TestSidebarCollapseFromChild(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false, store.NewProjection())
+	s := NewSidebar(false, store.NewProjection())
 
 	inst, _ := session.NewInstance(session.InstanceOptions{
 		Title: "inst", Path: t.TempDir(), Program: "test",
@@ -179,8 +173,7 @@ func TestSidebarCollapseFromChild(t *testing.T) {
 }
 
 func TestSidebarInstanceManagement(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false, store.NewProjection())
+	s := NewSidebar(false, store.NewProjection())
 
 	assert.Equal(t, 0, s.proj.NumInstances())
 
@@ -202,8 +195,7 @@ func TestSidebarInstanceManagement(t *testing.T) {
 // gone session.
 
 func TestSidebarSelectInstance(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false, store.NewProjection())
+	s := NewSidebar(false, store.NewProjection())
 
 	inst1, _ := session.NewInstance(session.InstanceOptions{
 		Title: "first", Path: t.TempDir(), Program: "test",
@@ -229,8 +221,7 @@ func TestSidebarSelectInstance(t *testing.T) {
 // SetSelectedInstance while the Instances section is collapsed transparently
 // expands the section and selects the target instance (regression for #275).
 func TestSetSelectedInstanceExpandsCollapsedSection(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false, store.NewProjection())
+	s := NewSidebar(false, store.NewProjection())
 
 	inst1, _ := session.NewInstance(session.InstanceOptions{
 		Title: "first", Path: t.TempDir(), Program: "test",
@@ -268,8 +259,7 @@ func TestSetSelectedInstanceExpandsCollapsedSection(t *testing.T) {
 }
 
 func TestSidebarTaskData(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false, store.NewProjection())
+	s := NewSidebar(false, store.NewProjection())
 
 	tasks := []task.Task{
 		{ID: "1", Prompt: "backup", CronExpr: "0 0 * * *", Enabled: true, CreatedAt: time.Now()},
@@ -282,8 +272,7 @@ func TestSidebarTaskData(t *testing.T) {
 }
 
 func TestSidebarRender(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false, store.NewProjection())
+	s := NewSidebar(false, store.NewProjection())
 	s.SetSize(40, 20)
 
 	inst, _ := session.NewInstance(session.InstanceOptions{
@@ -319,8 +308,7 @@ func indicatorArrows(out string) (up, down bool) {
 // the selected instance contributes two tab child rows (#1100: no padded slots).
 func newWindowingSidebar(t *testing.T, n int) *Sidebar {
 	t.Helper()
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false, store.NewProjection())
+	s := NewSidebar(false, store.NewProjection())
 	dir := t.TempDir()
 	for i := 0; i < n; i++ {
 		inst, err := session.NewInstance(session.InstanceOptions{
@@ -479,8 +467,7 @@ func newRepoInstance(t *testing.T, title, repoName string) *session.Instance {
 // otherwise a kill+recreate that moves a session to another repo leaves a stale
 // repo entry and shows a phantom multi-repo indicator (#971).
 func TestReplaceInstanceRepoTrackingStaleEntry(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false, store.NewProjection())
+	s := NewSidebar(false, store.NewProjection())
 
 	a := newRepoInstance(t, "a", "repo-A")
 	c := newRepoInstance(t, "c", "repo-C")
@@ -501,8 +488,7 @@ func TestReplaceInstanceRepoTrackingStaleEntry(t *testing.T) {
 // DIFFERENT repo must register the incoming instance's repo — otherwise the new
 // repo is invisible to the multi-repo indicator until the next full reload (#971).
 func TestReplaceInstanceRepoTrackingMissingNew(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false, store.NewProjection())
+	s := NewSidebar(false, store.NewProjection())
 
 	a := newRepoInstance(t, "a", "repo-A")
 	addTestInstance(s, a)()

--- a/ui/sidebar_tree_test.go
+++ b/ui/sidebar_tree_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,8 +20,7 @@ import (
 // Since #1100 the slot list mirrors the real tabs — there is no padding.
 func newTreeSidebar(t *testing.T, n int) *Sidebar {
 	t.Helper()
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false, store.NewProjection())
+	s := NewSidebar(false, store.NewProjection())
 	dir := t.TempDir()
 	for i := 0; i < n; i++ {
 		inst, err := session.NewInstance(session.InstanceOptions{
@@ -82,8 +80,7 @@ func TestSidebarTreeRendersTabChildren(t *testing.T) {
 // one child row — no phantom "Terminal" row for a tab that doesn't exist —
 // and the on-demand shell tab (`t`) grows it to two.
 func TestSidebarTreeFreshInstanceSingleTabRow(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false, store.NewProjection())
+	s := NewSidebar(false, store.NewProjection())
 	inst, err := session.NewInstance(session.InstanceOptions{
 		Title: "fresh", Path: t.TempDir(), Program: "test",
 	})
@@ -389,8 +386,7 @@ func TestSidebarTreeWindowingWithTabRows(t *testing.T) {
 func TestSidebarUltraNarrowNoOverflow(t *testing.T) {
 	for _, autoyes := range []bool{false, true} {
 		for _, w := range []int{8, 9, 10, 11, 12} {
-			spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-			s := NewSidebar(&spin, autoyes, store.NewProjection())
+			s := NewSidebar(autoyes, store.NewProjection())
 			dir := t.TempDir()
 			for i := 0; i < 12; i++ {
 				inst, err := session.NewInstance(session.InstanceOptions{
@@ -416,8 +412,7 @@ func TestSidebarUltraNarrowNoOverflow(t *testing.T) {
 // instance's children render — collapse-by-default bounds the row count), full
 // String() per iteration at a typical sidebar allocation.
 func BenchmarkSidebarTreeRender(b *testing.B) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false, store.NewProjection())
+	s := NewSidebar(false, store.NewProjection())
 	dir := b.TempDir()
 	for i := 0; i < 50; i++ {
 		inst, err := session.NewInstance(session.InstanceOptions{

--- a/ui/tree/arrow_test.go
+++ b/ui/tree/arrow_test.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/mattn/go-runewidth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,13 +27,12 @@ func runeAtCell(line string, col int) rune {
 // target for the ▸/▾ glyph (#1024 R4) — against Render's actual output, so a
 // prefix layout change moves the hit target with it or fails here.
 func TestArrowCellMatchesRenderedArrow(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
 	inst, err := session.NewInstance(session.InstanceOptions{
 		Title: "arrow-pin", Path: t.TempDir(), Program: "test",
 	})
 	require.NoError(t, err)
 
-	r := NewInstanceRenderer(&spin)
+	r := NewInstanceRenderer()
 	r.SetWidth(30)
 
 	x, y, ok := ArrowCell(30)

--- a/ui/tree/limit_render_test.go
+++ b/ui/tree/limit_render_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sachiniyer/agent-factory/session"
@@ -14,8 +13,7 @@ import (
 // renderClean renders an instance and returns its output with ANSI stripped.
 func renderClean(t *testing.T, inst *session.Instance) string {
 	t.Helper()
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	r := NewInstanceRenderer(&spin)
+	r := NewInstanceRenderer()
 	r.SetWidth(80)
 	out := r.Render(inst, 1, false, false, false)
 	return ansiEscape.ReplaceAllString(out, "")

--- a/ui/tree/render.go
+++ b/ui/tree/render.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/mattn/go-runewidth"
 
@@ -14,6 +13,12 @@ import (
 )
 
 const readyIcon = "● "
+
+// blankIcon fills the status cell for a working/busy row, which shows no status
+// glyph (#1765: only a waiting/Ready session gets the green dot). Its two cells
+// match the width every status glyph occupies (glyph + trailing pad space) so a
+// dot-less row keeps the title/branch columns aligned with its neighbors.
+const blankIcon = "  "
 
 // Theme is the subset of the TUI palette the tree renderer needs. It is
 // supplied by ui.ApplyTheme so this subpackage does not import ui.
@@ -201,16 +206,15 @@ func ApplyTheme(t Theme) {
 // InstanceRenderer renders the tree's rows: session.Instance rows (absorbed
 // from ui/list.go) and their tab child rows.
 type InstanceRenderer struct {
-	spinner *spinner.Model
 	// width is the effective content width — the caller passes the sidebar's
 	// usable column (its rect minus row padding), keeping the layout math in
 	// one place outside this package.
 	width int
 }
 
-// NewInstanceRenderer creates a renderer sharing the app-wide spinner.
-func NewInstanceRenderer(spin *spinner.Model) *InstanceRenderer {
-	return &InstanceRenderer{spinner: spin}
+// NewInstanceRenderer creates a renderer.
+func NewInstanceRenderer() *InstanceRenderer {
+	return &InstanceRenderer{}
 }
 
 // SetWidth sets the effective content width rows render into.
@@ -269,21 +273,23 @@ func (r *InstanceRenderer) Render(i *session.Instance, _ int, selected bool, has
 		descS = listDescStyle
 	}
 
-	// Status dot / spinner. Read the two axes directly (#1195): a row with any
-	// in-flight op (create/kill/archive) keeps the spinner ("busy"); otherwise
-	// the daemon-owned liveness picks the dot. The liveness switch is TOTAL — every
-	// value is rendered explicitly, no silent default — so adding a Liveness value
-	// (LimitReached landed this way, #1146) forces a deliberate choice here.
+	// Status glyph. Read the two axes directly (#1195): a row with any in-flight
+	// op (create/kill/archive) is a working/busy state and shows NO status glyph
+	// (#1765); otherwise the daemon-owned liveness picks the glyph. The liveness
+	// switch is TOTAL — every value is rendered explicitly, no silent default — so
+	// adding a Liveness value (LimitReached landed this way, #1146) forces a
+	// deliberate choice here. Only a waiting/Ready session gets a (green) dot;
+	// every working/busy state renders blankIcon so the columns stay aligned.
 	liveness := i.GetLiveness()
 	op := i.GetInFlightOp()
 	var join string
 	switch {
 	case op != session.OpNone:
-		join = fmt.Sprintf("%s ", r.spinner.View())
+		join = blankIcon
 	default:
 		switch liveness {
 		case session.LiveRunning:
-			join = fmt.Sprintf("%s ", r.spinner.View())
+			join = blankIcon
 		case session.LiveReady:
 			join = readyStyle.Render(readyIcon)
 		case session.LiveDead:
@@ -295,9 +301,9 @@ func (r *InstanceRenderer) Render(i *session.Instance, _ int, selected bool, has
 		case session.LiveLimitReached:
 			join = limitStyle.Render(limitIcon)
 		case session.LivenessUnset:
-			// Serialization sentinel, never a live in-memory value; render like
-			// Running so a stray zero never blanks the dot.
-			join = fmt.Sprintf("%s ", r.spinner.View())
+			// Serialization sentinel, never a live in-memory value; treated as
+			// working — no status glyph.
+			join = blankIcon
 		}
 	}
 
@@ -306,8 +312,9 @@ func (r *InstanceRenderer) Render(i *session.Instance, _ int, selected bool, has
 	if i.Capabilities().Workspace == session.WorkspaceRemote {
 		titleText = "[remote] " + titleText
 	}
-	// A deleting row keeps spinning but is explicitly marked and dimmed so it
-	// reads as "going away", not "busy working" (#844).
+	// A deleting row shows no status glyph (like any working row) but is
+	// explicitly marked and dimmed so it reads as "going away", not "busy
+	// working" (#844).
 	// A lost row is explicitly marked so "tmux vanished under it, no kill on
 	// record" (#1108) is readable without decoding the amber dot; the title
 	// keeps full contrast — unlike deleting/dead treatments, the session is

--- a/ui/tree/render.go
+++ b/ui/tree/render.go
@@ -15,7 +15,7 @@ import (
 const readyIcon = "● "
 
 // blankIcon fills the status cell for a working/busy row, which shows no status
-// glyph (#1765: only a waiting/Ready session gets the green dot). Its two cells
+// glyph (#1766: only a waiting/Ready session gets the green dot). Its two cells
 // match the width every status glyph occupies (glyph + trailing pad space) so a
 // dot-less row keeps the title/branch columns aligned with its neighbors.
 const blankIcon = "  "
@@ -275,7 +275,7 @@ func (r *InstanceRenderer) Render(i *session.Instance, _ int, selected bool, has
 
 	// Status glyph. Read the two axes directly (#1195): a row with any in-flight
 	// op (create/kill/archive) is a working/busy state and shows NO status glyph
-	// (#1765); otherwise the daemon-owned liveness picks the glyph. The liveness
+	// (#1766); otherwise the daemon-owned liveness picks the glyph. The liveness
 	// switch is TOTAL — every value is rendered explicitly, no silent default — so
 	// adding a Liveness value (LimitReached landed this way, #1146) forces a
 	// deliberate choice here. Only a waiting/Ready session gets a (green) dot;

--- a/ui/tree/render.go
+++ b/ui/tree/render.go
@@ -273,18 +273,27 @@ func (r *InstanceRenderer) Render(i *session.Instance, _ int, selected bool, has
 		descS = listDescStyle
 	}
 
-	// Status glyph. Read the two axes directly (#1195): a row with any in-flight
-	// op (create/kill/archive) is a working/busy state and shows NO status glyph
-	// (#1766); otherwise the daemon-owned liveness picks the glyph. The liveness
-	// switch is TOTAL — every value is rendered explicitly, no silent default — so
-	// adding a Liveness value (LimitReached landed this way, #1146) forces a
-	// deliberate choice here. Only a waiting/Ready session gets a (green) dot;
-	// every working/busy state renders blankIcon so the columns stay aligned.
+	// Status glyph. Read the two axes directly (#1195): a row with ANY in-flight op
+	// — create, restore, kill, or archive — is a working/busy state and shows NO
+	// status glyph (#1766); otherwise the daemon-owned liveness picks the glyph. The
+	// liveness switch is TOTAL — every value is rendered explicitly, no silent
+	// default — so adding a Liveness value (LimitReached landed this way, #1146)
+	// forces a deliberate choice here. Only a waiting/Ready session gets a (green)
+	// dot; every working/busy state renders blankIcon so the columns stay aligned.
 	liveness := i.GetLiveness()
 	op := i.GetInFlightOp()
 	var join string
 	switch {
 	case op != session.OpNone:
+		// The op axis is checked FIRST and DELIBERATELY masks the liveness glyph:
+		// an in-flight create/restore is a loading state (nothing, not a spinner —
+		// #1766), and this ordering is load-bearing for two cases in particular:
+		//   - OpRestoring on a still-Archived instance (rehomed into the live
+		//     section, #1210) must NOT draw the ▧ archived glyph — it draws blank.
+		//   - a completing op whose liveness already flipped to Ready must NOT draw
+		//     the green dot prematurely — the dot appears only once the op clears.
+		// Kill/archive keep their [deleting] title prefix below (create/restore add
+		// no prefix — a bare, clean loading row).
 		join = blankIcon
 	default:
 		switch liveness {

--- a/ui/tree/render_test.go
+++ b/ui/tree/render_test.go
@@ -17,7 +17,7 @@ import (
 var ansiEscape = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 
 // brailleFrame matches any Braille-pattern glyph — the shape the (now removed)
-// bubbles spinner animated the status cell through. After #1765 no status cell
+// bubbles spinner animated the status cell through. After #1766 no status cell
 // may contain one: a working/busy row shows nothing, never an animated frame.
 var brailleFrame = regexp.MustCompile(`[\x{2800}-\x{28FF}]`)
 
@@ -255,7 +255,7 @@ func TestInstanceRendererLimitReachedMarker(t *testing.T) {
 	assert.Contains(t, out, "throttled", "the title must remain visible")
 }
 
-// TestInstanceRendererStatusGlyphs pins the #1765 status-cell contract, the same
+// TestInstanceRendererStatusGlyphs pins the #1766 status-cell contract, the same
 // (Liveness, InFlightOp)→glyph mapping the web mirrors (web/src/status.ts): only a
 // waiting/Ready session shows the green ● dot; every working/busy state — LiveRunning
 // or any in-flight op (kill/archive) — shows NO status glyph and NO animated spinner

--- a/ui/tree/render_test.go
+++ b/ui/tree/render_test.go
@@ -1,11 +1,11 @@
 package tree
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 	"testing"
 
-	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/termenv"
 	"github.com/stretchr/testify/assert"
@@ -16,13 +16,17 @@ import (
 
 var ansiEscape = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 
+// brailleFrame matches any Braille-pattern glyph — the shape the (now removed)
+// bubbles spinner animated the status cell through. After #1765 no status cell
+// may contain one: a working/busy row shows nothing, never an animated frame.
+var brailleFrame = regexp.MustCompile(`[\x{2800}-\x{28FF}]`)
+
 // TestInstanceRendererRemoteBadge pins the sidebar "[remote]" title badge to the
 // backend's WorkspaceRemote capability rather than a Type()=="remote" check
 // (#1592 Phase 1 PR2): a hook-backed (remote-workspace) instance is prefixed,
 // a local one is not.
 func TestInstanceRendererRemoteBadge(t *testing.T) {
-	spin := spinner.New()
-	r := NewInstanceRenderer(&spin)
+	r := NewInstanceRenderer()
 	r.SetWidth(60)
 
 	render := func(t *testing.T, remote bool) string {
@@ -59,7 +63,7 @@ func effectiveWidth(width int) int {
 // returns the number of leading whitespace cells in front of the branch icon.
 // Instance indices are no longer rendered (#1494), so secondary-row indentation
 // must not change as idx crosses power-of-10 boundaries.
-func branchLineIndent(t *testing.T, idx int, spin *spinner.Model) int {
+func branchLineIndent(t *testing.T, idx int) int {
 	t.Helper()
 	inst, err := session.NewInstance(session.InstanceOptions{
 		Title:   "feature",
@@ -68,7 +72,7 @@ func branchLineIndent(t *testing.T, idx int, spin *spinner.Model) int {
 	})
 	require.NoError(t, err)
 
-	r := NewInstanceRenderer(spin)
+	r := NewInstanceRenderer()
 	r.SetWidth(60) // wide enough to render the full branch line
 
 	out := r.Render(inst, idx, false, false, false)
@@ -86,7 +90,6 @@ func branchLineIndent(t *testing.T, idx int, spin *spinner.Model) int {
 // still carry tree arrows and state glyphs, but it must not render a leading
 // "1. title" / "42. title" instance index.
 func TestInstanceRendererOmitsInstanceIndex(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
 	inst, err := session.NewInstance(session.InstanceOptions{
 		Title:   "feature",
 		Path:    t.TempDir(),
@@ -94,7 +97,7 @@ func TestInstanceRendererOmitsInstanceIndex(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	r := NewInstanceRenderer(&spin)
+	r := NewInstanceRenderer()
 	r.SetWidth(60)
 	indexPrefix := regexp.MustCompile(`\b\d+\.\s+feature`)
 	for _, idx := range []int{1, 9, 10, 99, 100, 10000} {
@@ -111,11 +114,10 @@ func TestInstanceRendererOmitsInstanceIndex(t *testing.T) {
 // indentation stable now that idx is display-only input rather than a rendered
 // prefix component.
 func TestInstanceRendererSecondaryIndentIgnoresIndex(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
 
-	base := branchLineIndent(t, 1, &spin)
+	base := branchLineIndent(t, 1)
 	for _, idx := range []int{9, 10, 11, 99, 100, 101, 999, 1000, 1001, 9999, 10000} {
-		got := branchLineIndent(t, idx, &spin)
+		got := branchLineIndent(t, idx)
 		require.Equalf(t, base, got,
 			"branch line indent at idx=%d (%d) must match idx=1 (%d); idx leaked into display",
 			idx, got, base)
@@ -126,10 +128,10 @@ func TestInstanceRendererSecondaryIndentIgnoresIndex(t *testing.T) {
 // from the given terminal width, and returns the rendered title line. The
 // renderer wraps each section in lipgloss padding, so the visible title
 // content sits on line 1 (after the top-padding line).
-func renderForTerminal(t *testing.T, terminalW int, inst *session.Instance, spin *spinner.Model) (titleLine string, sidebarW int) {
+func renderForTerminal(t *testing.T, terminalW int, inst *session.Instance) (titleLine string, sidebarW int) {
 	t.Helper()
 	sidebarW = int(float32(terminalW) * 0.3)
-	r := NewInstanceRenderer(spin)
+	r := NewInstanceRenderer()
 	r.SetWidth(effectiveWidth(sidebarW))
 	out := r.Render(inst, 1, false, false, false)
 	lines := strings.Split(out, "\n")
@@ -143,7 +145,6 @@ func renderForTerminal(t *testing.T, terminalW int, inst *session.Instance, spin
 // row ended with a "..." artifact that pushed the rendered line one cell past
 // the sidebar container width.
 func TestInstanceRendererNarrowTerminalNoOverflow(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
 	inst, err := session.NewInstance(session.InstanceOptions{
 		Title:   "long-feature",
 		Path:    t.TempDir(),
@@ -189,7 +190,7 @@ func TestInstanceRendererNarrowTerminalNoOverflow(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			titleLine, sidebarW := renderForTerminal(t, tc.terminalW, inst, &spin)
+			titleLine, sidebarW := renderForTerminal(t, tc.terminalW, inst)
 			w := lipgloss.Width(titleLine)
 
 			if tc.expectFullTitle {
@@ -218,9 +219,8 @@ func TestInstanceRendererNarrowTerminalNoOverflow(t *testing.T) {
 
 // TestInstanceRendererDeletingMarker pins the #844 sidebar treatment: a row
 // whose teardown is running in the background must carry an explicit
-// "[deleting]" marker (the spinner alone reads as "busy working").
+// "[deleting]" marker (a bare working row shows no status glyph).
 func TestInstanceRendererDeletingMarker(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
 	inst, err := session.NewInstance(session.InstanceOptions{
 		Title:   "going-away",
 		Path:    t.TempDir(),
@@ -229,11 +229,11 @@ func TestInstanceRendererDeletingMarker(t *testing.T) {
 	require.NoError(t, err)
 
 	inst.SetStatusForTest(session.Ready)
-	before, _ := renderForTerminal(t, 120, inst, &spin)
+	before, _ := renderForTerminal(t, 120, inst)
 	assert.NotContains(t, before, "[deleting]")
 
 	inst.SetStatusForTest(session.Deleting)
-	after, _ := renderForTerminal(t, 120, inst, &spin)
+	after, _ := renderForTerminal(t, 120, inst)
 	assert.Contains(t, after, "[deleting]", "deleting rows must be explicitly marked")
 	assert.Contains(t, after, "going-away", "the title must remain visible while deleting")
 }
@@ -242,7 +242,6 @@ func TestInstanceRendererDeletingMarker(t *testing.T) {
 // requirement for #1146: a LimitReached liveness renders its own explicit marker
 // (no silent default / blank dot). #1204 refines the label + reset time on top.
 func TestInstanceRendererLimitReachedMarker(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
 	inst, err := session.NewInstance(session.InstanceOptions{
 		Title:   "throttled",
 		Path:    t.TempDir(),
@@ -251,9 +250,95 @@ func TestInstanceRendererLimitReachedMarker(t *testing.T) {
 	require.NoError(t, err)
 
 	_ = inst.Transition(session.ObserveLiveness(session.LiveLimitReached))
-	out, _ := renderForTerminal(t, 120, inst, &spin)
+	out, _ := renderForTerminal(t, 120, inst)
 	assert.Contains(t, out, "[limit]", "a usage-limit-reached row must be explicitly marked (#1146)")
 	assert.Contains(t, out, "throttled", "the title must remain visible")
+}
+
+// TestInstanceRendererStatusGlyphs pins the #1765 status-cell contract, the same
+// (Liveness, InFlightOp)→glyph mapping the web mirrors (web/src/status.ts): only a
+// waiting/Ready session shows the green ● dot; every working/busy state — LiveRunning
+// or any in-flight op (kill/archive) — shows NO status glyph and NO animated spinner
+// frame; the terminal/error states keep their STATIC glyphs (◌/○/◆/▧).
+func TestInstanceRendererStatusGlyphs(t *testing.T) {
+	newInst := func(t *testing.T, title string) *session.Instance {
+		t.Helper()
+		inst, err := session.NewInstance(session.InstanceOptions{
+			Title: title, Path: t.TempDir(), Program: "test",
+		})
+		require.NoError(t, err)
+		return inst
+	}
+	// cell renders inst at a wide width and returns the ANSI-stripped title line —
+	// the row's status glyph sits at its trailing edge.
+	cell := func(t *testing.T, inst *session.Instance) string {
+		t.Helper()
+		title, _ := renderForTerminal(t, 120, inst)
+		return ansiEscape.ReplaceAllString(title, "")
+	}
+	// allGlyphs is every positive/terminal status glyph; a working row must show none.
+	allGlyphs := []string{"●", "○", "◌", "▧", "◆"}
+
+	t.Run("ready shows the green dot", func(t *testing.T) {
+		inst := newInst(t, "waiting")
+		require.NoError(t, inst.Transition(session.ObserveLiveness(session.LiveReady)))
+		clean := cell(t, inst)
+		assert.Contains(t, clean, "●", "a waiting/Ready row must show the green ● dot")
+		assert.NotRegexp(t, brailleFrame, clean, "the ready dot is static, never an animated frame")
+	})
+
+	t.Run("running shows no status glyph", func(t *testing.T) {
+		inst := newInst(t, "busy")
+		require.NoError(t, inst.Transition(session.ObserveLiveness(session.LiveRunning)))
+		clean := cell(t, inst)
+		assert.NotRegexp(t, brailleFrame, clean, "a working row must not render a spinner frame")
+		for _, g := range allGlyphs {
+			assert.NotContainsf(t, clean, g, "a working row must not show the %s status glyph", g)
+		}
+	})
+
+	for _, op := range []session.InFlightOp{session.OpKilling, session.OpArchiving} {
+		op := op
+		t.Run(fmt.Sprintf("in-flight op %v shows no glyph but stays [deleting]", op), func(t *testing.T) {
+			inst := newInst(t, "going")
+			require.NoError(t, inst.Transition(session.ObserveLiveness(session.LiveRunning)))
+			inst.SetInFlightOpForTest(op)
+			clean := cell(t, inst)
+			assert.Contains(t, clean, "[deleting]", "a kill/archive row keeps its [deleting] prefix")
+			assert.NotRegexp(t, brailleFrame, clean, "an in-flight-op row must not render a spinner frame")
+			for _, g := range allGlyphs {
+				assert.NotContainsf(t, clean, g, "an in-flight-op row must not show the %s status glyph", g)
+			}
+		})
+	}
+
+	statics := []struct {
+		name  string
+		lv    session.Liveness
+		glyph string
+	}{
+		{"lost", session.LiveLost, "◌"},
+		{"dead", session.LiveDead, "○"},
+		{"limit", session.LiveLimitReached, "◆"},
+	}
+	for _, tc := range statics {
+		tc := tc
+		t.Run(tc.name+" shows its static glyph", func(t *testing.T) {
+			inst := newInst(t, "x")
+			require.NoError(t, inst.Transition(session.ObserveLiveness(tc.lv)))
+			clean := cell(t, inst)
+			assert.Containsf(t, clean, tc.glyph, "%s row must show its static %s glyph", tc.name, tc.glyph)
+			assert.NotRegexpf(t, brailleFrame, clean, "%s row must render a static glyph, no spinner", tc.name)
+		})
+	}
+
+	t.Run("archived shows its static glyph", func(t *testing.T) {
+		inst := newInst(t, "filed")
+		inst.SetArchived()
+		clean := cell(t, inst)
+		assert.Contains(t, clean, "▧", "an archived row must show its static ▧ glyph")
+		assert.NotRegexp(t, brailleFrame, clean, "an archived row must render a static glyph, no spinner")
+	})
 }
 
 // TestInstanceRendererArchivedShowsName pins #1225: an archived row must show
@@ -262,7 +347,6 @@ func TestInstanceRendererLimitReachedMarker(t *testing.T) {
 // The archived state is conveyed by the ▧ glyph + dimming + section header, so
 // the title cell is spent on the identifier, exactly like a live row.
 func TestInstanceRendererArchivedShowsName(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
 	inst, err := session.NewInstance(session.InstanceOptions{
 		Title:   "one",
 		Path:    t.TempDir(),
@@ -272,7 +356,7 @@ func TestInstanceRendererArchivedShowsName(t *testing.T) {
 	inst.SetArchived()
 
 	for _, terminalW := range []int{100, 80} {
-		title, _ := renderForTerminal(t, terminalW, inst, &spin)
+		title, _ := renderForTerminal(t, terminalW, inst)
 		clean := ansiEscape.ReplaceAllString(title, "")
 		assert.Containsf(t, clean, "one",
 			"archived row must show its name at %d cols; got %q", terminalW, clean)
@@ -282,7 +366,6 @@ func TestInstanceRendererArchivedShowsName(t *testing.T) {
 }
 
 func TestInstanceRendererCreatingRowShowsBareName(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
 	inst, err := session.NewInstance(session.InstanceOptions{
 		Title:   "alpha",
 		Path:    t.TempDir(),
@@ -291,7 +374,7 @@ func TestInstanceRendererCreatingRowShowsBareName(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, inst.Transition(session.BeginCreate()))
 
-	r := NewInstanceRenderer(&spin)
+	r := NewInstanceRenderer()
 	r.SetWidth(40)
 
 	title := strings.Split(ansiEscape.ReplaceAllString(r.Render(inst, 1, true, false, false), ""), "\n")[1]
@@ -318,7 +401,6 @@ func TestInstanceRendererDeletingDimsSelectedRow(t *testing.T) {
 		lipgloss.SetHasDarkBackground(prevDark)
 	})
 
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
 	inst, err := session.NewInstance(session.InstanceOptions{
 		Title:   "going-away",
 		Path:    t.TempDir(),
@@ -329,7 +411,7 @@ func TestInstanceRendererDeletingDimsSelectedRow(t *testing.T) {
 	// SGR foreground params of the default Zenburn deleting gray.
 	dimFG := termenv.RGBColor("#989890").Sequence(false)
 
-	r := NewInstanceRenderer(&spin)
+	r := NewInstanceRenderer()
 	r.SetWidth(effectiveWidth(36))
 
 	renderLines := func() []string {
@@ -356,7 +438,6 @@ func TestInstanceRendererDeletingDimsSelectedRow(t *testing.T) {
 // (#1024 PR 3): an expandable instance carries ▸ collapsed / ▾ expanded, and a
 // transient (Loading/Deleting) row — never expandable — renders neither.
 func TestInstanceRendererTreeArrow(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
 	inst, err := session.NewInstance(session.InstanceOptions{
 		Title:   "arrowed",
 		Path:    t.TempDir(),
@@ -364,7 +445,7 @@ func TestInstanceRendererTreeArrow(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	r := NewInstanceRenderer(&spin)
+	r := NewInstanceRenderer()
 	r.SetWidth(40)
 
 	collapsed := strings.Split(r.Render(inst, 1, false, false, false), "\n")[1]
@@ -386,8 +467,7 @@ func TestInstanceRendererTreeArrow(t *testing.T) {
 // slot number matching the 1-9 jump keys, the tmux-style " *" marker on the
 // active tab, and hard truncation at narrow widths.
 func TestRenderTabRows(t *testing.T) {
-	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	r := NewInstanceRenderer(&spin)
+	r := NewInstanceRenderer()
 	r.SetWidth(30)
 
 	mid := ansiEscape.ReplaceAllString(r.RenderTab("Agent", 1, false, false, true), "")

--- a/ui/tree/render_test.go
+++ b/ui/tree/render_test.go
@@ -258,8 +258,11 @@ func TestInstanceRendererLimitReachedMarker(t *testing.T) {
 // TestInstanceRendererStatusGlyphs pins the #1766 status-cell contract, the same
 // (Liveness, InFlightOp)→glyph mapping the web mirrors (web/src/status.ts): only a
 // waiting/Ready session shows the green ● dot; every working/busy state — LiveRunning
-// or any in-flight op (kill/archive) — shows NO status glyph and NO animated spinner
-// frame; the terminal/error states keep their STATIC glyphs (◌/○/◆/▧).
+// or ANY in-flight op (create/restore/kill/archive) — shows NO status glyph and NO
+// animated spinner frame; the terminal/error states keep their STATIC glyphs (◌/○/◆/▧).
+// An in-flight create/restore is a LOADING state that draws a clean blank cell — no
+// dot, no spinner, no stale glyph — and the op axis deliberately masks the liveness
+// glyph so a restoring-but-still-Archived row never leaks the ▧ nor a premature dot.
 func TestInstanceRendererStatusGlyphs(t *testing.T) {
 	newInst := func(t *testing.T, title string) *session.Instance {
 		t.Helper()
@@ -311,6 +314,52 @@ func TestInstanceRendererStatusGlyphs(t *testing.T) {
 			}
 		})
 	}
+
+	// An in-flight create is a LOADING state: no glyph, and (unlike kill/archive) NO
+	// title prefix — a bare, clean loading row (#1766). The green dot appears only once
+	// the op clears and the agent is Ready (the progression test below).
+	t.Run("creating (OpCreating) shows no glyph and no prefix", func(t *testing.T) {
+		inst := newInst(t, "spawning")
+		inst.SetInFlightOpForTest(session.OpCreating)
+		clean := cell(t, inst)
+		assert.NotRegexp(t, brailleFrame, clean, "a creating row must not render a spinner frame")
+		for _, g := range allGlyphs {
+			assert.NotContainsf(t, clean, g, "a creating row must not show the %s status glyph", g)
+		}
+		assert.NotContains(t, clean, "[deleting]", "create adds no going-away prefix")
+		assert.Contains(t, clean, "spawning", "a creating row still shows its name")
+	})
+
+	// An in-flight restore of an ARCHIVED instance is rehomed into the live section
+	// (#1210) while its liveness is still LiveArchived. The op axis is checked FIRST, so
+	// it must render a BLANK status cell — NOT the ▧ archived glyph and NOT the green
+	// dot — until the restore completes (#1766).
+	t.Run("restoring (OpRestoring) on an archived instance shows no glyph", func(t *testing.T) {
+		inst := newInst(t, "coming-back")
+		inst.SetArchived()
+		inst.SetInFlightOpForTest(session.OpRestoring)
+		require.False(t, inst.ShownArchived(), "a restoring instance is rehomed into the live section")
+		clean := cell(t, inst)
+		assert.NotRegexp(t, brailleFrame, clean, "a restoring row must not render a spinner frame")
+		for _, g := range allGlyphs {
+			assert.NotContainsf(t, clean, g, "a restoring row must not show the %s status glyph (not ▧, not ●)", g)
+		}
+	})
+
+	// The loading → ready progression: a create shows nothing while in flight, then the
+	// green dot appears the instant the op clears and the agent reaches Ready (#1766).
+	t.Run("a cleared create at Ready shows the green dot", func(t *testing.T) {
+		inst := newInst(t, "born")
+		inst.SetInFlightOpForTest(session.OpCreating)
+		for _, g := range allGlyphs {
+			assert.NotContainsf(t, cell(t, inst), g, "while creating, no %s glyph", g)
+		}
+		inst.SetInFlightOpForTest(session.OpNone)
+		require.NoError(t, inst.Transition(session.ObserveLiveness(session.LiveReady)))
+		clean := cell(t, inst)
+		assert.Contains(t, clean, "●", "once Ready with no op, the green dot appears")
+		assert.NotRegexp(t, brailleFrame, clean, "the ready dot is static")
+	})
 
 	statics := []struct {
 		name  string

--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -59,7 +59,6 @@
   --af-dot-dead: #6e7887;
   --af-dot-archived: #6e7887;
   --af-dot-limit: #b13d33;
-  --af-dot-working: #17202e;
   --af-term-green: #1f7a33;
   --af-term-amber: #93650a;
   --af-term-blue: #2f5fd8;
@@ -95,7 +94,6 @@
     --af-dot-dead: #989890;
     --af-dot-archived: #989890;
     --af-dot-limit: #cc9393;
-    --af-dot-working: #e7ecf3;
     --af-term-green: #7f9f7f;
     --af-term-amber: #f0dfaf;
     --af-term-blue: #7aa2f7;
@@ -131,7 +129,6 @@
   --af-dot-dead: #6e7887;
   --af-dot-archived: #6e7887;
   --af-dot-limit: #b13d33;
-  --af-dot-working: #17202e;
   --af-term-green: #1f7a33;
   --af-term-amber: #93650a;
   --af-term-blue: #2f5fd8;
@@ -166,7 +163,6 @@
   --af-dot-dead: #989890;
   --af-dot-archived: #989890;
   --af-dot-limit: #cc9393;
-  --af-dot-working: #e7ecf3;
   --af-term-green: #7f9f7f;
   --af-term-amber: #f0dfaf;
   --af-term-blue: #7aa2f7;
@@ -658,12 +654,6 @@ body {
 }
 .af-dot-limit {
   color: var(--af-dot-limit);
-}
-.af-dot-working {
-  color: var(--af-dot-working);
-}
-.af-dot-spin {
-  animation: af-pulse 1.1s ease-in-out infinite;
 }
 @keyframes af-pulse {
   0%, 100% {

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -6679,14 +6679,16 @@ var DEAD_GLYPH = "\u25CB";
 var LOST_GLYPH = "\u25CC";
 var ARCHIVED_GLYPH = "\u25A7";
 var LIMIT_GLYPH = "\u25C6";
-var WORKING_GLYPH = "\u25CF";
-var WORKING = { glyph: WORKING_GLYPH, kind: "working", spinning: true, label: "Working" };
+var WORKING = { glyph: "", kind: null, label: "Working" };
 function rowStatus(s) {
   const op = s.in_flight_op ?? InFlightOp.None;
   if (op !== InFlightOp.None) {
     return WORKING;
   }
   return dotForLiveness(livenessOf(s));
+}
+function isWorking(s) {
+  return rowStatus(s).kind === null;
 }
 function livenessOf(s) {
   const lv = s.liveness ?? Liveness.Unset;
@@ -6711,15 +6713,15 @@ function livenessOf(s) {
 function dotForLiveness(lv) {
   switch (lv) {
     case Liveness.Ready:
-      return { glyph: READY_GLYPH, kind: "ready", spinning: false, label: "Ready" };
+      return { glyph: READY_GLYPH, kind: "ready", label: "Ready" };
     case Liveness.Lost:
-      return { glyph: LOST_GLYPH, kind: "lost", spinning: false, label: "Lost" };
+      return { glyph: LOST_GLYPH, kind: "lost", label: "Lost" };
     case Liveness.Dead:
-      return { glyph: DEAD_GLYPH, kind: "dead", spinning: false, label: "Dead" };
+      return { glyph: DEAD_GLYPH, kind: "dead", label: "Dead" };
     case Liveness.Archived:
-      return { glyph: ARCHIVED_GLYPH, kind: "archived", spinning: false, label: "Archived" };
+      return { glyph: ARCHIVED_GLYPH, kind: "archived", label: "Archived" };
     case Liveness.LimitReached:
-      return { glyph: LIMIT_GLYPH, kind: "limit", spinning: false, label: "Limit reached" };
+      return { glyph: LIMIT_GLYPH, kind: "limit", label: "Limit reached" };
     // LiveRunning and LivenessUnset both render as working (render.go:285, 297).
     case Liveness.Running:
     case Liveness.Unset:
@@ -6821,7 +6823,7 @@ function projectSummaries(sessions, tasks) {
   return [...roots].sort().map((root2) => {
     const rows = byRoot.get(root2) ?? [];
     const live = rows.filter((s) => !isArchived(s));
-    const working = live.filter((s) => rowStatus(s).spinning).length;
+    const working = live.filter((s) => isWorking(s)).length;
     return {
       root: root2,
       name: projectName(root2),
@@ -9020,12 +9022,6 @@ function tabButton(tab, index, active, shown, canManage, tabIds, actions2) {
 }
 function sessionRow(s, selected, actions2) {
   const status = rowStatus(s);
-  const dot = h2(
-    "span",
-    { class: `af-dot af-dot-${status.kind}${status.spinning ? " af-dot-spin" : ""}` },
-    status.glyph
-  );
-  dot.setAttribute("aria-hidden", "true");
   const title = h2("div", { class: "af-row-title" }, rowTitle(s));
   const branch = h2(
     "div",
@@ -9034,8 +9030,15 @@ function sessionRow(s, selected, actions2) {
     " ",
     s.branch || "\u2014"
   );
+  const main = h2("div", { class: "af-row-main" }, title, branch);
   const cls = `af-row${selected ? " af-row-selected" : ""}${isArchived(s) ? " af-row-archived" : ""}`;
-  const row = h2("li", { class: cls }, dot, h2("div", { class: "af-row-main" }, title, branch));
+  const row = h2("li", { class: cls });
+  if (status.kind) {
+    const dot = h2("span", { class: `af-dot af-dot-${status.kind}` }, status.glyph);
+    dot.setAttribute("aria-hidden", "true");
+    row.append(dot);
+  }
+  row.append(main);
   row.setAttribute("role", "option");
   row.setAttribute("aria-selected", selected ? "true" : "false");
   row.setAttribute("title", `${s.title} \u2014 ${status.label}`);

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -194,7 +194,7 @@ test("sidebar lists the seeded sessions from the Snapshot/events plane", async (
   await expect(page.locator(".af-live-pip.af-live-open")).toBeVisible();
 });
 
-test("status dots (#1765): waiting shows a green dot, working shows none, error states are static — no spin anywhere", async () => {
+test("status dots (#1766): waiting shows a green dot, working shows none, error states are static — no spin anywhere", async () => {
   // The daemon can't be coerced to Running/Lost/Dead/Limit on demand, so pin the
   // states by rewriting the Snapshot: the two real rows get Running (working) and
   // Ready (waiting); synthetic rows cloned into the same project cover the static
@@ -973,7 +973,7 @@ test("archive: the archive confirm moves a session to the archived group", async
   // with the af-row-archived modifier and sorted last).
   await expect(row(page, SESSION_B)).toHaveClass(/af-row-archived/, { timeout: 30_000 });
   // The archived row carries the static ▧ archived dot (no spinner) — proof the
-  // error/terminal states keep their static glyphs (#1765).
+  // error/terminal states keep their static glyphs (#1766).
   const archivedDot = row(page, SESSION_B).locator(".af-dot");
   await expect(archivedDot).toHaveClass(/af-dot-archived/);
   await expect(archivedDot).toHaveText("▧");

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -194,6 +194,75 @@ test("sidebar lists the seeded sessions from the Snapshot/events plane", async (
   await expect(page.locator(".af-live-pip.af-live-open")).toBeVisible();
 });
 
+test("status dots (#1765): waiting shows a green dot, working shows none, error states are static — no spin anywhere", async () => {
+  // The daemon can't be coerced to Running/Lost/Dead/Limit on demand, so pin the
+  // states by rewriting the Snapshot: the two real rows get Running (working) and
+  // Ready (waiting); synthetic rows cloned into the same project cover the static
+  // error glyphs. The events plane only pushes future deltas, so the reloaded rail
+  // reflects this Snapshot (the same route-transform pattern the no-url / empty-state
+  // tests use).
+  await page.route("**/v1/Snapshot", async (route) => {
+    const resp = await route.fetch();
+    const body = await resp.json();
+    const snap = body?.data as { instances?: Array<Record<string, unknown> & { title: string }> };
+    const list = snap?.instances ?? [];
+    const proto = { ...(list.find((s) => s.title === SESSION_A) ?? {}) };
+    for (const s of list) {
+      if (s.title === SESSION_A) {
+        s.liveness = 1; // Running → working → no dot
+        s.in_flight_op = 0;
+      }
+      if (s.title === SESSION_B) {
+        s.liveness = 2; // Ready → waiting → green dot
+        s.in_flight_op = 0;
+      }
+    }
+    // Clone SESSION_A's record (same worktree/repo_path, so they land in this project's
+    // scoped rail) into inert synthetic rows for the static error glyphs. Give each a
+    // distinct branch so their rendered branch line never contains "probe-a"/"probe-b"
+    // (the row() locator matches row text by substring).
+    const synth = (title: string, liveness: number) => ({
+      ...proto,
+      id: `synth-${title}`,
+      title,
+      branch: `synth-${title}`,
+      liveness,
+      in_flight_op: 0,
+    });
+    list.push(synth("probe-lost", 3), synth("probe-dead", 4), synth("probe-limit", 6));
+    if (snap) {
+      snap.instances = list;
+    }
+    await route.fulfill({ status: resp.status(), contentType: "application/json", body: JSON.stringify(body) });
+  });
+  await page.reload();
+  await expect(page.locator(".af-app")).toBeVisible();
+  await expect(row(page, SESSION_A)).toBeVisible({ timeout: 15_000 });
+
+  // Working row (A): NO status dot at all — the dot span is omitted entirely.
+  await expect(row(page, SESSION_A).locator(".af-dot")).toHaveCount(0);
+  // Waiting row (B): the static green ● dot, in the ready color bucket, never spinning.
+  const readyDot = row(page, SESSION_B).locator(".af-dot");
+  await expect(readyDot).toHaveClass(/af-dot-ready/);
+  await expect(readyDot).toHaveText("●");
+  await expect(readyDot).not.toHaveClass(/af-dot-spin/);
+  // Error/terminal states keep their STATIC glyphs (◌/○/◆), copied from the TUI.
+  await expect(row(page, "probe-lost").locator(".af-dot")).toHaveText("◌");
+  await expect(row(page, "probe-lost").locator(".af-dot")).toHaveClass(/af-dot-lost/);
+  await expect(row(page, "probe-dead").locator(".af-dot")).toHaveText("○");
+  await expect(row(page, "probe-limit").locator(".af-dot")).toHaveText("◆");
+  // The animation class is gone from every status row, and the removed "working" dot
+  // kind never renders anywhere.
+  await expect(page.locator(".af-dot-spin")).toHaveCount(0);
+  await expect(page.locator(".af-dot-working")).toHaveCount(0);
+
+  // Restore the real projection for the following flows.
+  await page.unroute("**/v1/Snapshot");
+  await page.reload();
+  await expect(page.locator(".af-app")).toBeVisible();
+  await expect(row(page, SESSION_A)).toBeVisible({ timeout: 15_000 });
+});
+
 test("click-to-attach opens the xterm terminal and shows live output", async () => {
   await row(page, SESSION_A).click();
 
@@ -903,6 +972,12 @@ test("archive: the archive confirm moves a session to the archived group", async
   // B is not killed — it stays in the rail, but in the archived group (rendered
   // with the af-row-archived modifier and sorted last).
   await expect(row(page, SESSION_B)).toHaveClass(/af-row-archived/, { timeout: 30_000 });
+  // The archived row carries the static ▧ archived dot (no spinner) — proof the
+  // error/terminal states keep their static glyphs (#1765).
+  const archivedDot = row(page, SESSION_B).locator(".af-dot");
+  await expect(archivedDot).toHaveClass(/af-dot-archived/);
+  await expect(archivedDot).toHaveText("▧");
+  await expect(archivedDot).not.toHaveClass(/af-dot-spin/);
 });
 
 test("delete project (#1735, redesign PR2, Fix 2): deleting an archived-only-bound project makes it go away — not a no-op", async () => {

--- a/web/src/project.ts
+++ b/web/src/project.ts
@@ -35,7 +35,7 @@ export interface ProjectSummary {
   path: string;
   /** Live (non-archived) sessions in this project — the "active work" count. */
   liveCount: number;
-  /** Live sessions currently working (no status dot, #1765) — the glance signal. */
+  /** Live sessions currently working (no status dot, #1766) — the glance signal. */
   workingCount: number;
   /** Total sessions (live + archived) attributed to the project's repo root. */
   totalCount: number;

--- a/web/src/project.ts
+++ b/web/src/project.ts
@@ -14,7 +14,7 @@
 // as sessions.ts / nav.ts are.
 
 import { projectLabel } from "./modals.js";
-import { isArchived, rowStatus } from "./status.js";
+import { isArchived, isWorking } from "./status.js";
 import type { SessionData, TaskData } from "./types.js";
 
 /** localStorage key for the persisted selected-project root (the repo path). Kept in
@@ -35,7 +35,7 @@ export interface ProjectSummary {
   path: string;
   /** Live (non-archived) sessions in this project — the "active work" count. */
   liveCount: number;
-  /** Live sessions currently working (a spinning status dot) — the glance signal. */
+  /** Live sessions currently working (no status dot, #1765) — the glance signal. */
   workingCount: number;
   /** Total sessions (live + archived) attributed to the project's repo root. */
   totalCount: number;
@@ -104,7 +104,7 @@ export function projectSummaries(sessions: SessionData[], tasks: TaskData[]): Pr
   return [...roots].sort().map((root) => {
     const rows = byRoot.get(root) ?? [];
     const live = rows.filter((s) => !isArchived(s));
-    const working = live.filter((s) => rowStatus(s).spinning).length;
+    const working = live.filter((s) => isWorking(s)).length;
     return {
       root,
       name: projectName(root),

--- a/web/src/status.test.ts
+++ b/web/src/status.test.ts
@@ -15,7 +15,7 @@ function sess(over: Partial<SessionData> = {}): SessionData {
 }
 
 test("liveness → dot kind mirrors render.go's TOTAL switch", () => {
-  // Working (LiveRunning / the Unset sentinel) shows NO dot (#1765): null kind, empty
+  // Working (LiveRunning / the Unset sentinel) shows NO dot (#1766): null kind, empty
   // glyph. Ready is the only positive/green dot; the error states keep static glyphs.
   const cases: Array<[number, DotKind | null, string]> = [
     [Liveness.Ready, "ready", "●"],
@@ -33,7 +33,7 @@ test("liveness → dot kind mirrors render.go's TOTAL switch", () => {
   }
 });
 
-test("a working row has no dot; Ready/error states do (#1765)", () => {
+test("a working row has no dot; Ready/error states do (#1766)", () => {
   const running = rowStatus(sess({ liveness: Liveness.Running }));
   assert.equal(running.kind, null, "Running is working → no dot");
   assert.equal(running.glyph, "", "a working row draws no glyph");

--- a/web/src/status.test.ts
+++ b/web/src/status.test.ts
@@ -7,7 +7,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { isArchived, rowStatus, rowTitle } from "./status.js";
+import { type DotKind, isArchived, isWorking, rowStatus, rowTitle } from "./status.js";
 import { InFlightOp, Liveness, Status, type SessionData } from "./types.js";
 
 function sess(over: Partial<SessionData> = {}): SessionData {
@@ -15,14 +15,16 @@ function sess(over: Partial<SessionData> = {}): SessionData {
 }
 
 test("liveness → dot kind mirrors render.go's TOTAL switch", () => {
-  const cases: Array<[number, string, string]> = [
+  // Working (LiveRunning / the Unset sentinel) shows NO dot (#1765): null kind, empty
+  // glyph. Ready is the only positive/green dot; the error states keep static glyphs.
+  const cases: Array<[number, DotKind | null, string]> = [
     [Liveness.Ready, "ready", "●"],
     [Liveness.Lost, "lost", "◌"],
     [Liveness.Dead, "dead", "○"],
     [Liveness.Archived, "archived", "▧"],
     [Liveness.LimitReached, "limit", "◆"],
-    [Liveness.Running, "working", "●"],
-    [Liveness.Unset, "working", "●"], // stray zero renders like Running (render.go:297)
+    [Liveness.Running, null, ""],
+    [Liveness.Unset, null, ""], // stray zero renders like Running (render.go:297)
   ];
   for (const [lv, kind, glyph] of cases) {
     const st = rowStatus(sess({ liveness: lv }));
@@ -31,18 +33,24 @@ test("liveness → dot kind mirrors render.go's TOTAL switch", () => {
   }
 });
 
-test("only Ready/Running/Unset spin like the TUI (Ready is a settled dot)", () => {
-  assert.equal(rowStatus(sess({ liveness: Liveness.Running })).spinning, true);
-  assert.equal(rowStatus(sess({ liveness: Liveness.Ready })).spinning, false);
-  assert.equal(rowStatus(sess({ liveness: Liveness.Lost })).spinning, false);
+test("a working row has no dot; Ready/error states do (#1765)", () => {
+  const running = rowStatus(sess({ liveness: Liveness.Running }));
+  assert.equal(running.kind, null, "Running is working → no dot");
+  assert.equal(running.glyph, "", "a working row draws no glyph");
+  assert.equal(isWorking(sess({ liveness: Liveness.Running })), true);
+  assert.equal(isWorking(sess({ liveness: Liveness.Unset })), true);
+  assert.equal(isWorking(sess({ liveness: Liveness.Ready })), false);
+  assert.equal(isWorking(sess({ liveness: Liveness.Lost })), false);
+  assert.notEqual(rowStatus(sess({ liveness: Liveness.Ready })).kind, null, "Ready keeps its dot");
 });
 
-test("any in-flight op overlays the liveness and wins the working dot", () => {
+test("any in-flight op overlays the liveness and reads as working (no dot)", () => {
   for (const op of [InFlightOp.Creating, InFlightOp.Killing, InFlightOp.Archiving, InFlightOp.Restoring]) {
     // Even a Ready liveness reads as working while an op is in flight (render.go:280).
     const st = rowStatus(sess({ liveness: Liveness.Ready, in_flight_op: op }));
-    assert.equal(st.kind, "working", `op ${op} → working`);
-    assert.equal(st.spinning, true);
+    assert.equal(st.kind, null, `op ${op} → working (no dot)`);
+    assert.equal(st.glyph, "", `op ${op} draws no glyph`);
+    assert.equal(isWorking(sess({ liveness: Liveness.Ready, in_flight_op: op })), true);
   }
 });
 
@@ -51,7 +59,7 @@ test("liveness absent falls back to the legacy status int", () => {
   assert.equal(rowStatus(sess({ status: Status.Lost })).kind, "lost");
   assert.equal(rowStatus(sess({ status: Status.Dead })).kind, "dead");
   assert.equal(rowStatus(sess({ status: Status.Archived })).kind, "archived");
-  assert.equal(rowStatus(sess({ status: Status.Running })).kind, "working");
+  assert.equal(rowStatus(sess({ status: Status.Running })).kind, null);
 });
 
 test("title prefixes match render.go precedence", () => {

--- a/web/src/status.ts
+++ b/web/src/status.ts
@@ -15,14 +15,14 @@ import { InFlightOp, Liveness, Status, type SessionData } from "./types.js";
 
 /** The visual kind of a status dot, one per color bucket the TUI paints. Drives
  *  the .af-dot-<kind> CSS class whose color matches render.go's lipgloss styles.
- *  A working/busy row has no dot (#1765), so there is no "working" bucket. */
+ *  A working/busy row has no dot (#1766), so there is no "working" bucket. */
 export type DotKind = "ready" | "lost" | "dead" | "archived" | "limit";
 
 /** A fully-resolved status descriptor for one row: the dot to draw and the
  *  human label (used for the row's aria/title so the state is legible to a
  *  screen reader, not only by color — the same intent as the TUI's text prefixes). */
 export interface RowStatus {
-  /** The glyph to draw, or "" for a working/busy row which shows no dot (#1765). */
+  /** The glyph to draw, or "" for a working/busy row which shows no dot (#1766). */
   glyph: string;
   /** The dot's color bucket, or null for a working row (the dot is omitted). */
   kind: DotKind | null;
@@ -38,7 +38,7 @@ const LOST_GLYPH = "◌";
 const ARCHIVED_GLYPH = "▧";
 const LIMIT_GLYPH = "◆";
 
-// A working/busy row shows NO status dot (#1765): the TUI renders a blank status
+// A working/busy row shows NO status dot (#1766): the TUI renders a blank status
 // cell for LiveRunning / any in-flight op, and the web omits the dot entirely.
 // Kept as a resolved status (empty glyph, null kind) so rowStatus stays total and
 // callers can still detect the working state (isWorking, the project glance count).
@@ -46,7 +46,7 @@ const WORKING: RowStatus = { glyph: "", kind: null, label: "Working" };
 
 /**
  * Resolves a session's status dot from its two axes, mirroring render.go exactly:
- * any in-flight op is a working/busy state and shows no dot (#1765); otherwise the
+ * any in-flight op is a working/busy state and shows no dot (#1766); otherwise the
  * liveness picks the dot. Falls back to the legacy `status` int only when `liveness`
  * is absent (a pre-#1195 record — never emitted by the daemon's live Snapshot, but
  * handled so a stray zero renders as working, matching render.go's LivenessUnset arm).
@@ -63,7 +63,7 @@ export function rowStatus(s: SessionData): RowStatus {
 }
 
 /** True when the row is a working/busy session — the state that shows NO status
- *  dot (#1765). Kept exported so the project switcher's per-project "working"
+ *  dot (#1766). Kept exported so the project switcher's per-project "working"
  *  glance count (project.ts) stays derivable now that the dot itself is gone. */
 export function isWorking(s: SessionData): boolean {
   return rowStatus(s).kind === null;

--- a/web/src/status.ts
+++ b/web/src/status.ts
@@ -14,17 +14,18 @@
 import { InFlightOp, Liveness, Status, type SessionData } from "./types.js";
 
 /** The visual kind of a status dot, one per color bucket the TUI paints. Drives
- *  the .af-dot-<kind> CSS class whose color matches render.go's lipgloss styles. */
-export type DotKind = "working" | "ready" | "lost" | "dead" | "archived" | "limit";
+ *  the .af-dot-<kind> CSS class whose color matches render.go's lipgloss styles.
+ *  A working/busy row has no dot (#1765), so there is no "working" bucket. */
+export type DotKind = "ready" | "lost" | "dead" | "archived" | "limit";
 
 /** A fully-resolved status descriptor for one row: the dot to draw and the
  *  human label (used for the row's aria/title so the state is legible to a
  *  screen reader, not only by color — the same intent as the TUI's text prefixes). */
 export interface RowStatus {
+  /** The glyph to draw, or "" for a working/busy row which shows no dot (#1765). */
   glyph: string;
-  kind: DotKind;
-  /** Whether the dot should animate (the TUI shows a spinner for working). */
-  spinning: boolean;
+  /** The dot's color bucket, or null for a working row (the dot is omitted). */
+  kind: DotKind | null;
   /** Accessible one-word state label, e.g. "Ready", "Working", "Lost". */
   label: string;
 }
@@ -36,27 +37,36 @@ const DEAD_GLYPH = "○";
 const LOST_GLYPH = "◌";
 const ARCHIVED_GLYPH = "▧";
 const LIMIT_GLYPH = "◆";
-// Working has no fixed glyph in the TUI (a bubbles spinner); the web draws a
-// filled dot and animates it via .af-dot-working (styles.css).
-const WORKING_GLYPH = "●";
 
-const WORKING: RowStatus = { glyph: WORKING_GLYPH, kind: "working", spinning: true, label: "Working" };
+// A working/busy row shows NO status dot (#1765): the TUI renders a blank status
+// cell for LiveRunning / any in-flight op, and the web omits the dot entirely.
+// Kept as a resolved status (empty glyph, null kind) so rowStatus stays total and
+// callers can still detect the working state (isWorking, the project glance count).
+const WORKING: RowStatus = { glyph: "", kind: null, label: "Working" };
 
 /**
  * Resolves a session's status dot from its two axes, mirroring render.go exactly:
- * any in-flight op keeps the spinner ("busy"); otherwise the liveness picks the
- * dot. Falls back to the legacy `status` int only when `liveness` is absent (a
- * pre-#1195 record — never emitted by the daemon's live Snapshot, but handled so
- * a stray zero never blanks the dot, matching render.go's LivenessUnset arm).
+ * any in-flight op is a working/busy state and shows no dot (#1765); otherwise the
+ * liveness picks the dot. Falls back to the legacy `status` int only when `liveness`
+ * is absent (a pre-#1195 record — never emitted by the daemon's live Snapshot, but
+ * handled so a stray zero renders as working, matching render.go's LivenessUnset arm).
  */
 export function rowStatus(s: SessionData): RowStatus {
   const op = s.in_flight_op ?? InFlightOp.None;
-  // An in-flight op overlays the liveness and wins the dot (render.go:280-282):
-  // the [deleting] title prefix, added below, distinguishes kill/archive.
+  // An in-flight op overlays the liveness and reads as working (render.go:280-282),
+  // so it shows no dot; the [deleting] title prefix (rowTitle) distinguishes
+  // kill/archive.
   if (op !== InFlightOp.None) {
     return WORKING;
   }
   return dotForLiveness(livenessOf(s));
+}
+
+/** True when the row is a working/busy session — the state that shows NO status
+ *  dot (#1765). Kept exported so the project switcher's per-project "working"
+ *  glance count (project.ts) stays derivable now that the dot itself is gone. */
+export function isWorking(s: SessionData): boolean {
+  return rowStatus(s).kind === null;
 }
 
 /** The daemon always emits `liveness`; this only guards a pre-#1195 record by
@@ -86,15 +96,15 @@ function livenessOf(s: SessionData): number {
 function dotForLiveness(lv: number): RowStatus {
   switch (lv) {
     case Liveness.Ready:
-      return { glyph: READY_GLYPH, kind: "ready", spinning: false, label: "Ready" };
+      return { glyph: READY_GLYPH, kind: "ready", label: "Ready" };
     case Liveness.Lost:
-      return { glyph: LOST_GLYPH, kind: "lost", spinning: false, label: "Lost" };
+      return { glyph: LOST_GLYPH, kind: "lost", label: "Lost" };
     case Liveness.Dead:
-      return { glyph: DEAD_GLYPH, kind: "dead", spinning: false, label: "Dead" };
+      return { glyph: DEAD_GLYPH, kind: "dead", label: "Dead" };
     case Liveness.Archived:
-      return { glyph: ARCHIVED_GLYPH, kind: "archived", spinning: false, label: "Archived" };
+      return { glyph: ARCHIVED_GLYPH, kind: "archived", label: "Archived" };
     case Liveness.LimitReached:
-      return { glyph: LIMIT_GLYPH, kind: "limit", spinning: false, label: "Limit reached" };
+      return { glyph: LIMIT_GLYPH, kind: "limit", label: "Limit reached" };
     // LiveRunning and LivenessUnset both render as working (render.go:285, 297).
     case Liveness.Running:
     case Liveness.Unset:

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -799,7 +799,7 @@ body {
 
 /* af-pulse is retained for the connection live-pip (.af-live-connecting /
  * .af-live-reconnecting / .af-term-connecting); the session status dot no longer
- * animates — a working row shows no dot at all (#1765). */
+ * animates — a working row shows no dot at all (#1766). */
 @keyframes af-pulse {
   0%,
   100% {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -69,7 +69,6 @@
   --af-dot-dead: #6e7887;
   --af-dot-archived: #6e7887;
   --af-dot-limit: #b13d33;
-  --af-dot-working: #17202e;
 
   /* Terminal hues */
   --af-term-green: #1f7a33;
@@ -111,7 +110,6 @@
     --af-dot-dead: #989890;
     --af-dot-archived: #989890;
     --af-dot-limit: #cc9393;
-    --af-dot-working: #e7ecf3;
     --af-term-green: #7f9f7f;
     --af-term-amber: #f0dfaf;
     --af-term-blue: #7aa2f7;
@@ -149,7 +147,6 @@
   --af-dot-dead: #6e7887;
   --af-dot-archived: #6e7887;
   --af-dot-limit: #b13d33;
-  --af-dot-working: #17202e;
   --af-term-green: #1f7a33;
   --af-term-amber: #93650a;
   --af-term-blue: #2f5fd8;
@@ -186,7 +183,6 @@
   --af-dot-dead: #989890;
   --af-dot-archived: #989890;
   --af-dot-limit: #cc9393;
-  --af-dot-working: #e7ecf3;
   --af-term-green: #7f9f7f;
   --af-term-amber: #f0dfaf;
   --af-term-blue: #7aa2f7;
@@ -801,14 +797,9 @@ body {
   color: var(--af-dot-limit);
 }
 
-.af-dot-working {
-  color: var(--af-dot-working);
-}
-
-.af-dot-spin {
-  animation: af-pulse 1.1s ease-in-out infinite;
-}
-
+/* af-pulse is retained for the connection live-pip (.af-live-connecting /
+ * .af-live-reconnecting / .af-term-connecting); the session status dot no longer
+ * animates — a working row shows no dot at all (#1765). */
 @keyframes af-pulse {
   0%,
   100% {

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -966,12 +966,6 @@ function tabButton(
  *  row lacking an id (never expected from a live Snapshot) is rendered but inert. */
 function sessionRow(s: SessionData, selected: boolean, actions: Actions): HTMLElement {
   const status = rowStatus(s);
-  const dot = h(
-    "span",
-    { class: `af-dot af-dot-${status.kind}${status.spinning ? " af-dot-spin" : ""}` },
-    status.glyph,
-  );
-  dot.setAttribute("aria-hidden", "true");
 
   const title = h("div", { class: "af-row-title" }, rowTitle(s));
   const branch = h(
@@ -981,9 +975,19 @@ function sessionRow(s: SessionData, selected: boolean, actions: Actions): HTMLEl
     " ",
     s.branch || "—",
   );
+  const main = h("div", { class: "af-row-main" }, title, branch);
 
   const cls = `af-row${selected ? " af-row-selected" : ""}${isArchived(s) ? " af-row-archived" : ""}`;
-  const row = h("li", { class: cls }, dot, h("div", { class: "af-row-main" }, title, branch));
+  const row = h("li", { class: cls });
+  // A working/busy row shows NO status dot (#1765) — only Ready/error states draw
+  // one. When there is no dot the span is omitted entirely (kind is null), matching
+  // the TUI's blank status cell.
+  if (status.kind) {
+    const dot = h("span", { class: `af-dot af-dot-${status.kind}` }, status.glyph);
+    dot.setAttribute("aria-hidden", "true");
+    row.append(dot);
+  }
+  row.append(main);
   row.setAttribute("role", "option");
   row.setAttribute("aria-selected", selected ? "true" : "false");
   row.setAttribute("title", `${s.title} — ${status.label}`);

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -979,7 +979,7 @@ function sessionRow(s: SessionData, selected: boolean, actions: Actions): HTMLEl
 
   const cls = `af-row${selected ? " af-row-selected" : ""}${isArchived(s) ? " af-row-archived" : ""}`;
   const row = h("li", { class: cls });
-  // A working/busy row shows NO status dot (#1765) — only Ready/error states draw
+  // A working/busy row shows NO status dot (#1766) — only Ready/error states draw
   // one. When there is no dot the span is omitted entirely (kind is null), matching
   // the TUI's blank status cell.
   if (status.kind) {


### PR DESCRIPTION
## What

The session status indicator now shows a **static green dot only when the agent is waiting** (idle / ready for input). Working shows **nothing** — no glyph, no spinner, no pulse, no dot. The terminal/error states remain **static** glyphs. **All animation is removed** from the status indicators on both surfaces (TUI + web), and they stay consistent: same state → same treatment.

### State → glyph (existing Liveness / InFlightOp model — no new states)

| State | Glyph | Notes |
|---|---|---|
| WAITING / READY (`LiveReady`) | `●` static **green** | the only positive/green indicator |
| WORKING / RUNNING (`LiveRunning`, any in-flight op `OpKilling`/`OpArchiving`/create, `LivenessUnset` sentinel) | *(nothing)* | no glyph, no spinner, no dot |
| LOST (`LiveLost`) | `◌` static | |
| DEAD (`LiveDead`) | `○` static | |
| LIMIT (`LiveLimitReached`) | `◆` static | |
| ARCHIVED (`LiveArchived`) | `▧` static | |

The `[deleting]` / `[lost]` / `[limit]` / `[remote]` **title prefixes and dimming are unchanged** — only the leading status glyph changed. A kill/archive row still reads as "going away" via its `[deleting]` prefix + dimming; it just no longer carries a spinner.

## TUI — `ui/tree/render.go`

- The `WORKING`/`RUNNING`/in-flight-op/`LivenessUnset` arms now render a blank status cell (`blankIcon`, two cells wide) instead of a spinner, so the title/branch columns stay aligned when there is no dot. The liveness switch stays **TOTAL** (every value handled).
- The bubbles spinner is **fully removed** now that it is unused: the `spinner *spinner.Model` field + `NewInstanceRenderer` param, `NewSidebar`'s `spin` param, the app-wide `spinner.Model`, its `Tick` in `Init`, the `spinner.TickMsg` handler, the `tui_state` skip-list entry, and every `bubbles/spinner` import across `app/` and `ui/`. `deadcode -test ./...` is the hard gate that forced this.
- The green `readyIcon`/`readyStyle` and the lost/dead/limit/archived icons + styles are untouched.

## Web — `web/src/{status.ts,ui.ts,project.ts,styles.css}`

- `status.ts`: the working `RowStatus` now has an **empty glyph + `null` kind**; the `spinning` field, `WORKING_GLYPH`, and the `"working"` `DotKind` are removed. Added an exported `isWorking()` predicate so the project switcher's per-project "working" glance count stays derivable now that the dot is gone.
- `ui.ts`: the row renderer **omits the `.af-dot` span entirely** when the status has no glyph (`kind === null`), keeping aria/title behavior sensible.
- `styles.css`: removed `.af-dot-spin` (the status-dot animation class) and `.af-dot-working` + `--af-dot-working`. **`@keyframes af-pulse` is kept** — it is still used by the connection live-pip (`.af-live-connecting`/`.af-live-reconnecting`/`.af-term-connecting`), which is a separate indicator.
- `web/dist` rebuilt (`make web-build`) and committed; the built CSS no longer contains `af-dot-spin`/`af-dot-working`.

## Tests

- **TUI** (`ui/tree/render_test.go`): new `TestInstanceRendererStatusGlyphs` — Ready shows `●`; Running and in-flight-op (`OpKilling`/`OpArchiving`, still `[deleting]`) show **no glyph** and **no Braille spinner frame**; Lost/Dead/Limit/Archived show their static glyphs.
- **Web unit** (`web/src/status.test.ts`): Running/Unset → `null` kind + empty glyph; in-flight ops read as working (no dot); `isWorking` assertions; static glyphs preserved.
- **Web driver** (`web/selftest/web-driver.spec.ts`): a working row has **no `.af-dot`**; a waiting row shows the green `●` `af-dot-ready`; lost/dead/limit/archived show static glyphs; `.af-dot-spin`/`.af-dot-working` never appear anywhere.

## Gate results (all green)

| Gate | Result |
|---|---|
| `make tui-driver-selftest` | ✅ **25/25 steps green** |
| `make web-selftest-container` | ✅ **25 passed** (incl. new status-dots test) |
| `make web-test` | ✅ **98 pass**, typecheck clean |
| `make test-container` | ✅ all packages ok |
| `go build ./...` | ✅ ok |
| `gofmt -l .` | ✅ no output |
| `golangci-lint run --timeout=3m --fast` | ✅ clean |
| `deadcode -test ./...` | ✅ no output |
| `web/dist` rebuilt + committed | ✅ |

The two surfaces are consistent: Ready = green dot on both, Working = nothing on both, lost/dead/limit/archived = the same static glyph on both.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)