### PR TITLE
fix(tui): Ctrl+C in hooks edit form quits the app (#1727)

### DIFF
--- a/app/handle_overlay.go
+++ b/app/handle_overlay.go
@@ -300,7 +300,7 @@ func (m *home) showHooksOverlay() (tea.Model, tea.Cmd) {
 // configured quit key is root-routed before the pane can type it into an edit
 // field, and ctrl+c still quits from normal mode.
 func (m *home) handleStateHooks(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if key.Matches(msg, keys.GlobalKeyBindings[keys.KeyQuit]) {
+	if msg.String() == "ctrl+c" || key.Matches(msg, keys.GlobalKeyBindings[keys.KeyQuit]) {
 		return m.handleQuit()
 	}
 

--- a/app/handle_overlay_test.go
+++ b/app/handle_overlay_test.go
@@ -77,6 +77,37 @@ func TestPaneOverlaysQuitWithReboundKeyBeforeEditFieldsConsumeIt(t *testing.T) {
 	})
 }
 
+// TestHooksOverlayQuitKeysBypassFocusedEditForm is the regression guard for
+// #1727: in the hooks add/edit form the pane consumes ctrl+c as "cancel form",
+// so handleStateHooks must route ctrl+c (and the configured quit key) to the
+// hard-quit path before the pane sees it — matching handleStateTasks.
+func TestHooksOverlayQuitKeysBypassFocusedEditForm(t *testing.T) {
+	require.NoError(t, keys.ApplyOverrides(nil))
+	t.Cleanup(func() { require.NoError(t, keys.ApplyOverrides(nil)) })
+
+	for _, tc := range []struct {
+		name string
+		msg  tea.KeyMsg
+	}{
+		{name: "configured quit", msg: tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")}},
+		{name: "ctrl+c hard quit", msg: tea.KeyMsg{Type: tea.KeyCtrlC}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHome(t)
+			h.hooksPane.SetFocus(true)
+			h.state = stateHooks
+
+			// Enter the add form and type into it, then attempt to quit.
+			_, _ = h.handleStateHooks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
+			_, _ = h.handleStateHooks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("draft")})
+			_, cmd := h.handleStateHooks(tc.msg)
+
+			assert.True(t, reachesQuit(cmd), "%s must quit before the hooks form consumes it", tc.name)
+			assert.True(t, h.hooksPane.HasFocus(), "quit routing must not first cancel the form and drop focus")
+		})
+	}
+}
+
 func TestTaskOverlayQuitKeysBypassFocusedCreateForm(t *testing.T) {
 	require.NoError(t, keys.ApplyOverrides(nil))
 	t.Cleanup(func() { require.NoError(t, keys.ApplyOverrides(nil)) })


### PR DESCRIPTION
## Summary

Fixes #1727. In the TUI hooks add/edit overlay, pressing `Ctrl+C` cancelled the form and left the app running instead of hard-quitting — the behavior explicitly fixed for the parallel tasks overlay in #1489.

## Root cause

`handleStateHooks` (`app/handle_overlay.go`) only routed the *configured* quit keybinding to the hard-quit path before handing the key to the hooks pane. It relied on a trailing `!consumed` fallback to catch `ctrl+c`:

```go
if key.Matches(msg, keys.GlobalKeyBindings[keys.KeyQuit]) { // ctrl+c NOT checked here
    return m.handleQuit()
}
consumed := m.hooksPane.HandleKeyPress(msg)
// ...
if !consumed {
    if msg.String() == "ctrl+c" || ... { return m.handleQuit() } // never reached in edit mode
}
```

But in the add/edit form the pane's `handleEditMode` (`ui/hooks_pane.go:134`) consumes `tea.KeyCtrlC` as "cancel form", so `consumed` is `true` and the fallback never runs. In *normal* mode the pane returns `false` for ctrl+c, which is why the bug only manifested inside the form.

`handleStateTasks` already does the right thing (`app/handle_overlay.go:240`): it checks `ctrl+c` at the top, before the pane can consume it.

## Fix

One-line change: route `ctrl+c` through the quit path at the top of `handleStateHooks`, matching `handleStateTasks`.

## Test

Added `TestHooksOverlayQuitKeysBypassFocusedEditForm` (mirrors the existing task-overlay guard). It enters the hooks add form, types into it, then presses the quit key — asserting the quit path is reached and the form is not cancelled first. Fails before the fix (ctrl+c case), passes after.

## Gates
- `go build ./...` ✓
- `gofmt -l .` clean ✓
- `golangci-lint run --fast` ✓
- `deadcode -test ./...` clean ✓
- `make test-container` ✓ (full suite green)
- `make tui-driver-selftest` ✓ 25/25

🤖 Generated with [Claude Code](https://claude.com/claude-code)