### PR TITLE
fix(tui-driver): af_select boundary check + task-overlay run-action sync (#1759, #1757)

### DIFF
--- a/scripts/tui-driver-selftest.sh
+++ b/scripts/tui-driver-selftest.sh
@@ -222,7 +222,7 @@ step "af_select evaluates the boundary step (#1759)"        _expect_af_select_bo
 step "seed a task via the create form"                      af_add_task selftest-task
 step "close the tasks overlay after create"                 af_close_tasks
 step "reopen tasks — edit-mode overlay recognized (#1757)"  af_open_tasks
-step "assert the task editor shows the run action"          af_assert_screen 'r run( |$)' 'task-overlay run action'
+step "assert the task editor shows the run action"          af_assert_screen "$_AF_TASKS_RUN_HINT" 'task-overlay run action'
 step "close the tasks overlay"                              af_close_tasks
 
 step "open beta's tab as a pane"                            af_open_pane

--- a/scripts/tui-driver-selftest.sh
+++ b/scripts/tui-driver-selftest.sh
@@ -144,6 +144,35 @@ SCREEN
     return 0
 }
 
+# _expect_af_select_boundary — regression proof for #1759. af_select must
+# evaluate its ready condition AFTER the final downward `j`, not only before it.
+# Drive af_select against stubbed send/capture (no live TUI, no real sleeps) in
+# a subshell so nothing leaks: a counter tracks `j` presses, and the row is
+# rendered actionable (▾ + `D kill`) ONLY once the count reaches 40 — exactly
+# the loop boundary. The old loop pressed the 40th `j` and exited without a
+# trailing capture, so it never saw the actionable frame and returned non-zero
+# here; the fixed loop checks the post-`j` state and returns 0.
+# shellcheck disable=SC2317  # dispatched indirectly via step(); not dead code.
+_expect_af_select_boundary() {
+    (
+        _AF_BOUNDARY_JCOUNT=0
+        # Stubs local to this subshell; the sourced af_select resolves them
+        # dynamically when it calls them.
+        af_ensure_nav() { :; }
+        af_focus_tree() { return 0; }
+        sleep() { :; }
+        af_send() { [ "${1:-}" = j ] && _AF_BOUNDARY_JCOUNT=$((_AF_BOUNDARY_JCOUNT + 1)); return 0; }
+        af_capture() {
+            if [ "$_AF_BOUNDARY_JCOUNT" -ge 40 ]; then
+                printf '%s\n' ' ▾ target                       │ menu: D kill'
+            else
+                printf '%s\n' ' ▸ target                       │ menu: n new'
+            fi
+        }
+        af_select target
+    )
+}
+
 printf '=== tui-driver self-test (#1161) ===\n'
 printf 'session=%s size=%sx%s home=%s\n' \
     "$AF_DRIVER_SESSION" "$AF_DRIVER_COLS" "$AF_DRIVER_ROWS" "$AGENT_FACTORY_HOME"
@@ -180,6 +209,21 @@ step "select alpha"                                         af_select alpha
 step "assert alpha is selected"                             af_expect_selected alpha
 step "select beta"                                          af_select beta
 step "assert beta is selected"                              af_expect_selected beta
+
+# --- #1759 regression: af_select must check AFTER the final scan step ---
+# A row that only becomes actionable on the loop's boundary `j` used to be
+# missed (false selection failure). Deterministic stub proof — no live TUI.
+step "af_select evaluates the boundary step (#1759)"        _expect_af_select_boundary
+
+# --- #1757 regression: the task-overlay run action ---
+# `m` drops straight into the selected task's EDIT form when a task exists, and
+# at 80x24 its footer collapses `r run now` to `r run`. af_open_tasks used to
+# wait for the stale `run now` and time out here; it now syncs on `r run`.
+step "seed a task via the create form"                      af_add_task selftest-task
+step "close the tasks overlay after create"                 af_close_tasks
+step "reopen tasks — edit-mode overlay recognized (#1757)"  af_open_tasks
+step "assert the task editor shows the run action"          af_assert_screen 'r run( |$)' 'task-overlay run action'
+step "close the tasks overlay"                              af_close_tasks
 
 step "open beta's tab as a pane"                            af_open_pane
 step "enter interactive mode and probe literal send"         _enter_interactive_and_probe_literal_send

--- a/scripts/tui-driver.sh
+++ b/scripts/tui-driver.sh
@@ -585,11 +585,21 @@ _af_tab_count() {
 # open. `m` drops STRAIGHT into the selected task's edit form when a task exists
 # (#1249), whose narrow-width footer collapses `r run now` to `r run` — so the
 # old `run now` marker matched the empty-list view but MISSED the edit view at
-# 80x24 and af_open_tasks reported a false timeout (#1757). `r run` is the one
-# run affordance common to every list/edit × wide/narrow variant. The
-# `( |$)` tail keeps it from matching a pane's "Session no longer running."
-# fallback text ("longe`r run`ning") — that has no space/EOL after `r run`.
-: "${_AF_TASKS_RUN_HINT:=r run( |\$)}"
+# 80x24 and af_open_tasks reported a false timeout (#1757). `r run[ now]` is the
+# one run affordance common to every list/edit × wide/narrow variant.
+#
+# ANCHOR it on BOTH sides of the `r` key hint so it can only match the overlay's
+# own menu line, never arbitrary visible pane text that happens to contain the
+# substring `r run` (Greptile, PR #1769):
+#   * LEFT — `(^|[^[:alnum:]])`: the `r` must start a token (line start, or a
+#     non-alphanumeric like the frame padding / a `• ` separator before it), so
+#     the trailing `r` of a word does NOT count ("serve`r run` •", "you`r run`").
+#   * RIGHT — ` •` (U+2022): the run action is ALWAYS followed by the menu's
+#     space-and-bullet separator (`r run now • …` / `r run • …`), which no shell
+#     output line ("no longe`r run`ning.", "you`r run` finished") carries.
+# The bullet is matched as a literal byte sequence, not a bracket expression, so
+# it works under the sandbox's C/POSIX locale (cf. _af_tab_count).
+: "${_AF_TASKS_RUN_HINT:=(^|[^[:alnum:]])r run( now)? •}"
 
 # af_open_tasks — open the task-manager overlay (`m`). Syncs on the overlay's
 # `r run` run-action hint, present whether it opens in list or edit mode.

--- a/scripts/tui-driver.sh
+++ b/scripts/tui-driver.sh
@@ -403,21 +403,31 @@ af_new_instance() {
 # GetSelectedInstance()), so requiring it forces `j` past the header/title rows
 # until the cursor truly lands on an actionable tab row.
 af_select() {
-    local name="$1" _ screen name_re
+    local name="$1" i screen name_re
     [ -n "$name" ] || { _af_fail "af_select: name required"; return 1; }
     name_re="$(_af_regex_escape "$name")"
     af_ensure_nav
     af_focus_tree || return 1
-    for _ in $(seq 1 30); do af_send k; done
+    for i in $(seq 1 30); do af_send k; done
     sleep "$AF_DRIVER_POLL"
-    for _ in $(seq 1 40); do
+    # Scan down from the anchored top tab stop, evaluating the ready condition
+    # AFTER every `j` — including the final one. The old loop captured, checked,
+    # THEN pressed `j`, so the state produced by the 40th (boundary) `j` was
+    # never evaluated: a row that only became actionable on that last step was
+    # missed and af_select reported a false selection failure (#1759). `seq 0 40`
+    # checks the anchored position first (i=0, no `j`), then re-checks after each
+    # of the 40 downward steps, with a settle poll between the `j` and the
+    # capture so the post-`j` frame is the one we inspect.
+    for i in $(seq 0 40); do
+        if [ "$i" -gt 0 ]; then
+            af_send j
+            sleep "$AF_DRIVER_POLL"
+        fi
         screen="$(af_capture)"
         if printf '%s\n' "$screen" | grep -qE -- "▾[[:space:]]+${name_re}([[:space:]]|\$)" \
            && printf '%s\n' "$screen" | grep -qE -- 'D kill'; then
             return 0
         fi
-        af_send j
-        sleep "$AF_DRIVER_POLL"
     done
     _af_log "could not select '${name}' (need ▾ on its parent row AND cursor-on-tab, i.e. 'D kill' in the menu)"
     printf '%s\n' "$screen" >&2
@@ -571,29 +581,67 @@ _af_tab_count() {
     af_capture | grep -cE '^[[:space:]]*(├|└)[[:space:]]+[0-9]+[[:space:]]+[^[:space:]]' || true
 }
 
+# _AF_TASKS_RUN_HINT — the run-action affordance that marks the task overlay as
+# open. `m` drops STRAIGHT into the selected task's edit form when a task exists
+# (#1249), whose narrow-width footer collapses `r run now` to `r run` — so the
+# old `run now` marker matched the empty-list view but MISSED the edit view at
+# 80x24 and af_open_tasks reported a false timeout (#1757). `r run` is the one
+# run affordance common to every list/edit × wide/narrow variant. The
+# `( |$)` tail keeps it from matching a pane's "Session no longer running."
+# fallback text ("longe`r run`ning") — that has no space/EOL after `r run`.
+: "${_AF_TASKS_RUN_HINT:=r run( |\$)}"
+
 # af_open_tasks — open the task-manager overlay (`m`). Syncs on the overlay's
-# unique `r run now` hint line.
+# `r run` run-action hint, present whether it opens in list or edit mode.
 af_open_tasks() {
     af_ensure_nav
     af_send m
-    af_wait_for 'run now' "$AF_DRIVER_TIMEOUT" 'tasks overlay' || return 1
+    af_wait_for "$_AF_TASKS_RUN_HINT" "$AF_DRIVER_TIMEOUT" 'tasks overlay' || return 1
 }
 
-# af_close_tasks — dismiss the tasks overlay (Escape).
+# af_close_tasks — dismiss the tasks overlay (Escape). When the overlay opened
+# in edit mode the first Escape drops back to the list (still showing the run
+# hint), so a second Escape closes it; both cases sync on the run hint going
+# away.
 af_close_tasks() {
     local deadline screen
     af_send Escape
     deadline=$(( $(_af_now) + 4 ))
     while :; do
         screen="$(af_capture)"
-        if ! printf '%s\n' "$screen" | grep -qE -- 'run now'; then
+        if ! printf '%s\n' "$screen" | grep -qE -- "$_AF_TASKS_RUN_HINT"; then
             return 0
         fi
         [ "$(_af_now)" -ge "$deadline" ] && break
         sleep "$AF_DRIVER_POLL"
     done
     af_send Escape
-    af_wait_gone 'run now' 8 'tasks overlay closed' || return 1
+    af_wait_gone "$_AF_TASKS_RUN_HINT" 8 'tasks overlay closed' || return 1
+}
+
+# af_add_task <name> — seed a minimal valid cron task through the overlay's
+# create form, so a later af_open_tasks lands on the EDIT-mode overlay whose
+# narrow footer shows `r run` (the #1757 flow). Opens the tasks overlay (list
+# mode when empty), fills name + cron expression + prompt (the path field
+# pre-fills with the launch repo, a valid git repo), submits, and waits for the
+# new task's row to appear. Leaves the overlay open in list mode.
+af_add_task() {
+    local name="${1:-selftest-task}" name_re
+    name_re="$(_af_regex_escape "$name")"
+    af_open_tasks || return 1
+    af_send n
+    # Sync on the form title, not the footer: the footer's "enter create" hint
+    # collapses away at a narrow overlay width, but "New Task" is always shown.
+    af_wait_for 'New Task' "$AF_DRIVER_TIMEOUT" 'task create form' || return 1
+    af_send_literal "$name"
+    af_send Tab                    # name -> trigger selector (cron is default)
+    af_send Tab                    # -> trigger value (cron expression)
+    af_send_literal '0 3 * * *'
+    af_send Tab                    # -> prompt (Enter here inserts a newline)
+    af_send_literal 'selftest prompt'
+    af_send Tab                    # -> target; Enter from here submits the form
+    af_send Enter
+    af_wait_for "${name_re}" "$AF_DRIVER_TIMEOUT" "task '${name}' created" || return 1
 }
 
 # af_click <x> <y> — inject an SGR left click at 1-based screen cell (x,y).


### PR DESCRIPTION
Fixes two `scripts/tui-driver.sh` harness bugs that made the selftest gate report false failures.

## #1759 — af_select missed a row at the scan boundary
`af_select()` sends `30 k` to anchor at the top tab stop, then scans down. The old loop **captured, checked the ready condition, then pressed `j`** — so the state produced by the 40th (final) `j` was never evaluated. A row that only became actionable on that boundary step (▾ on its parent + `D kill` in the menu) was missed, and the helper reported a false selection failure even though one more `j` exposed the actionable row.

**Fix:** restructured the loop (`seq 0 40`) to evaluate the ready condition first at the anchored position, then **after every `j` including the last**, with a settle poll between the `j` and the capture so the post-`j` frame is the one inspected. The contract (reliably land on the row) now holds at the boundary.

## #1757 — task-overlay helper synced on a stale run action
`m` drops straight into the selected task's **edit form** when a task exists (#1249). At 80×24 that form's footer collapses `r run now` → `r run` (`ui/task_pane_edit.go`), so `af_open_tasks` — which waited for the literal `run now` — timed out even though the overlay was open. The empty-list view still showed `r run now`, so the bug only surfaced with a task present.

**Fix:** sync on `r run` — the one run affordance common to **every** list/edit × wide/narrow variant — via a shared `_AF_TASKS_RUN_HINT` used by both `af_open_tasks` and `af_close_tasks`. The `( |$)` tail keeps it from matching a pane's `Session no longer running.` fallback text (`longe`**`r run`**`ning`).

## Coverage
- `_expect_af_select_boundary`: a deterministic stub proof (no live TUI) that the row becomes actionable *only* on the 40th `j`. Verified it **passes on the fix and fails on the pre-fix loop**.
- `af_add_task`: new driver helper that seeds a cron task through the create form, so the selftest exercises the edit-mode task overlay end-to-end: create → close → reopen (edit mode) → assert the run action visible → close.

Selftest grew from 25 → **31/31 steps** (the 6 new steps cover both fixes).

## Gates
- `make tui-driver-selftest` → **31/31 green**
- `make test-container` → all packages ok
- `go build ./...` ✓ · `gofmt -l .` clean ✓ · `golangci-lint run --fast` (0) ✓ · `deadcode -test ./...` (0) ✓ · `scripts/lint-file-length.sh` ✓
- `shellcheck -x` both scripts ✓

Closes #1759, closes #1757.

🤖 Generated with [Claude Code](https://claude.com/claude-code)