### PR TITLE
fix(doctor): --fix must fail closed when the fix-time process snapshot fails (#1728)

### DIFF
--- a/doctor/checks.go
+++ b/doctor/checks.go
@@ -574,10 +574,27 @@ func staleTempHomeRemoveFix(ctx *scanContext, dir string) func() error {
 			return fmt.Errorf("refusing to remove %s: it no longer looks like an agent-factory home", dir)
 		}
 
+		// Re-take the process snapshot at fix time: a home that looked
+		// abandoned during detection may have been claimed since. When the
+		// recheck fails, how we react depends on whether detection had a
+		// working snapshot at all:
+		//   - detection got one (ctx.snap != nil): the process guard was live
+		//     protection we now can't reproduce, and ctx.snap is stale. Fail
+		//     closed rather than delete on stale data — a process that started
+		//     using dir after detection would otherwise lose its home.
+		//   - detection had none (ctx.snap == nil, e.g. no /proc on macOS):
+		//     the process guard is unavailable on this platform and was a
+		//     no-op at detection too. Keep snap nil and fall through to the
+		//     daemon.pid + tmux guards, exactly as before — otherwise --fix
+		//     could never clean a stale temp home on such platforms.
 		snap := ctx.snap
 		if ctx.opts.snapshot != nil {
-			if fresh, err := ctx.opts.snapshot(); err == nil {
+			fresh, err := ctx.opts.snapshot()
+			switch {
+			case err == nil:
 				snap = fresh
+			case ctx.snap != nil:
+				return fmt.Errorf("refusing to remove %s: process snapshot failed: %w", dir, err)
 			}
 		}
 		if reason := tempHomeInUseReason(dir, processReferencedHomes(snap), liveTmuxHomes(ctx)); reason != "" {

--- a/doctor/temp_home_liveness_test.go
+++ b/doctor/temp_home_liveness_test.go
@@ -156,3 +156,47 @@ func TestStaleTempHomeFixRechecksDaemonBeforeRemove(t *testing.T) {
 	require.Contains(t, err.Error(), "daemon pid is live")
 	require.DirExists(t, dir, "fix must re-check and refuse to remove a newly active temp home")
 }
+
+// TestStaleTempHomeFixFailsClosedWhenSnapshotFailsAtFixTime is the #1728
+// regression: detection got a working process snapshot (so the home was
+// flagged stale on genuinely-empty data), but the fix-time recheck fails
+// (transient /proc error). The detection snapshot is now stale — a one-off
+// command with no daemon.pid and no tmux marker could have claimed the home
+// in between — so the fix must fail closed rather than delete on stale data.
+// Before the fix, the snapshot error was swallowed and the home deleted.
+func TestStaleTempHomeFixFailsClosedWhenSnapshotFailsAtFixTime(t *testing.T) {
+	tempRoot := t.TempDir()
+	dir := makeOldTempAFHome(t, tempRoot, "tmp.snapshot-race")
+
+	opts := testOptions(t, true)
+	opts.TempDir = tempRoot
+	// No live tmux session references the home.
+	opts.Exec = cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error { return nil },
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+			return nil, fmt.Errorf("no tmux")
+		},
+	}
+	// Detection (call 1) sees a clean, non-nil snapshot so the home is flagged
+	// stale; the fix-time recheck (call 2+) fails, mirroring a transient /proc
+	// error between detection and remediation.
+	var calls int
+	opts.snapshot = func() (map[int]proctree.Process, error) {
+		calls++
+		if calls == 1 {
+			return map[int]proctree.Process{}, nil
+		}
+		return nil, fmt.Errorf("snapshot unavailable at fix time")
+	}
+
+	report, err := Run(opts)
+	require.NoError(t, err)
+
+	findings := findByCheck(report, "stale-temp-home")
+	require.Len(t, findings, 1, "home must be detected as stale")
+	require.GreaterOrEqual(t, calls, 2, "fix must re-take the snapshot at fix time")
+	require.False(t, findings[0].Fixed, "fix must fail closed when the fix-time snapshot fails")
+	require.Error(t, findings[0].FixErr)
+	require.Contains(t, findings[0].FixErr.Error(), "process snapshot failed")
+	require.DirExists(t, dir, "an in-use home must never be deleted when liveness cannot be verified")
+}


### PR DESCRIPTION
## Summary

Fixes #1728 — a data-loss bug where `doctor --fix` could delete an **in-use** temp home when the fix-time process-snapshot recheck fails.

`staleTempHomeRemoveFix` (`doctor/checks.go`) re-takes the `/proc` process snapshot at fix time to re-verify that a home flagged stale during detection is *still* unused before `os.RemoveAll`. The old code swallowed a snapshot error and silently fell back to the **detection-time** `ctx.snap`:

```go
snap := ctx.snap
if ctx.opts.snapshot != nil {
    if fresh, err := ctx.opts.snapshot(); err == nil { // err ignored → stale ctx.snap
        snap = fresh
    }
}
```

That fallback data is stale. A one-off command (a script, CI job, or `af session send-prompt`) with **no `daemon.pid` and no live tmux marker** could have claimed the home *after* detection — the live process snapshot is the only guard that would catch it. So the fix proceeded to delete a home that was actively in use.

This differs from detection-time behavior (`doctor.go`), where a failed snapshot leaves `ctx.snap == nil` and the process check safely no-ops.

## Fix

Fail closed when the fix-time recheck fails — but **only when detection actually had a working snapshot** (`ctx.snap != nil`):

- **`ctx.snap != nil`** (detection got a snapshot): the process guard was live protection we can no longer reproduce and `ctx.snap` is stale → refuse the delete with `process snapshot failed`.
- **`ctx.snap == nil`** (snapshot unavailable platform-wide, e.g. no `/proc` on macOS): it was a no-op at detection too → keep `snap` nil and fall through to the existing `daemon.pid` + tmux guards. This is important: the naive "always error on snapshot failure" fix would make `doctor --fix` **never** able to clean a stale temp home on macOS, and would break `TestStaleTempHomeFixRechecksDaemonBeforeRemove`.

## Test

Adds `TestStaleTempHomeFixFailsClosedWhenSnapshotFailsAtFixTime`: detection sees a clean non-nil snapshot (home flagged stale), the fix-time recheck errors → the fix must fail closed and preserve the directory. **Fails before this change** (home deleted, `Fixed == true`), **passes after**.

## Gates

- `go build ./...` ✓
- `gofmt -l .` clean ✓
- `golangci-lint run --timeout=3m --fast` ✓
- `deadcode -test ./...` clean ✓
- `make test-container` — all packages green ✓
- `make tui-driver-selftest` — 25/25 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)