### PR TITLE
fix(tui): auto-clear pane auto-hide notice on mouse/preview focus (#1685)

### DIFF
--- a/app/handle_panes.go
+++ b/app/handle_panes.go
@@ -131,24 +131,29 @@ func (m *home) openOrFocusPane(instance *session.Instance, tab int) (tea.Model, 
 			return m, nil
 		}
 	}
-	statusCmd := m.focusOpenPane(p)
+	m.focusOpenPane(p)
 	selectionCmd := m.selectionChanged()
+	// Consume AFTER selectionChanged so this catch-all drains an auto-hide
+	// status produced by ANY relayout in this open-or-focus operation — the
+	// focusOpenPane above or a preview relayout inside selectionChanged (#1685).
+	statusCmd := m.consumePaneAutoHideStatus()
 	return m, tea.Batch(selectionCmd, statusCmd)
 }
 
 // focusOpenPane stamps an existing pane as recently focused, makes it visible
 // if pane-count fitting had hidden it, and moves the focus ring onto it. Its
-// relayout can auto-hide a previously visible pane (§2.6 fitting), so it returns
-// the consume cmd that starts that notice's 3s auto-clear timer — callers MUST
-// dispatch it, or the "N hidden" guidance lingers forever (#1685).
-func (m *home) focusOpenPane(p *store.OpenPane) tea.Cmd {
+// relayout can auto-hide a previously visible pane (§2.6 fitting), which sets a
+// pending auto-hide status; callers MUST run consumePaneAutoHideStatus()
+// afterwards to start that notice's 3s auto-clear timer (#1685). openOrFocusPane
+// does so via its trailing consume; the mouse/preview path does so in
+// updatePanePreview.
+func (m *home) focusOpenPane(p *store.OpenPane) {
 	if p == nil {
-		return nil
+		return
 	}
 	m.store.TouchOpenPane(p)
 	m.relayout()
 	m.focusRegion(layout.PaneRegion(p.ID()))
-	return m.consumePaneAutoHideStatus()
 }
 
 // handleSplitPane dispatches the `S` key: commit the active preview alongside

--- a/app/handle_panes.go
+++ b/app/handle_panes.go
@@ -131,21 +131,24 @@ func (m *home) openOrFocusPane(instance *session.Instance, tab int) (tea.Model, 
 			return m, nil
 		}
 	}
-	m.focusOpenPane(p)
+	statusCmd := m.focusOpenPane(p)
 	selectionCmd := m.selectionChanged()
-	statusCmd := m.consumePaneAutoHideStatus()
 	return m, tea.Batch(selectionCmd, statusCmd)
 }
 
 // focusOpenPane stamps an existing pane as recently focused, makes it visible
-// if pane-count fitting had hidden it, and moves the focus ring onto it.
-func (m *home) focusOpenPane(p *store.OpenPane) {
+// if pane-count fitting had hidden it, and moves the focus ring onto it. Its
+// relayout can auto-hide a previously visible pane (§2.6 fitting), so it returns
+// the consume cmd that starts that notice's 3s auto-clear timer — callers MUST
+// dispatch it, or the "N hidden" guidance lingers forever (#1685).
+func (m *home) focusOpenPane(p *store.OpenPane) tea.Cmd {
 	if p == nil {
-		return
+		return nil
 	}
 	m.store.TouchOpenPane(p)
 	m.relayout()
 	m.focusRegion(layout.PaneRegion(p.ID()))
+	return m.consumePaneAutoHideStatus()
 }
 
 // handleSplitPane dispatches the `S` key: commit the active preview alongside

--- a/app/home_panes.go
+++ b/app/home_panes.go
@@ -35,7 +35,7 @@ func (m *home) selectionChanged() tea.Cmd {
 	// that happens between attach failures is consistent.
 	attachedNow := m.attached.Load()
 
-	var prFetch tea.Cmd
+	var prFetch, previewCmd tea.Cmd
 	if sel.Kind == ui.SectionInstances && !sel.IsHeader {
 		selected := m.sidebar.GetSelectedInstance()
 		// Track the cursor's instance in the store's display selection — what
@@ -55,7 +55,7 @@ func (m *home) selectionChanged() tea.Cmd {
 			previewTab = sel.TabIndex
 			previewTabSpecific = true
 		}
-		m.updatePanePreview(selected, previewTab, previewTabSpecific, attachedNow)
+		previewCmd = m.updatePanePreview(selected, previewTab, previewTabSpecific, attachedNow)
 		detachTrace(selectionStart, "selectionChanged-instance-branch-built-cmds")
 		// Lazily refresh PR info when the user lands on an instance that
 		// hasn't been fetched recently. fetchPRInfoCmd is a no-op when the
@@ -92,7 +92,7 @@ func (m *home) selectionChanged() tea.Cmd {
 		}
 	}
 
-	return tea.Batch(prFetch, m.panesRefresh(attachedNow))
+	return tea.Batch(prFetch, previewCmd, m.panesRefresh(attachedNow))
 }
 
 // clampSelectionTab bounds the selection's active tab index against the

--- a/app/pane_autohide_status_test.go
+++ b/app/pane_autohide_status_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -35,6 +36,58 @@ func TestPane_OpenHiddenThenResizeWideNoDupNoStaleStatus(t *testing.T) {
 		"every instance is shown by exactly one pane, in order")
 	assert.Equal(t, "", h.errBox.FullError(),
 		"the narrow-width guidance clears once the panes fit again")
+}
+
+// TestPane_AutoHideViaFocusOpenPaneStartsClearTimer is the #1685 regression:
+// focusing an already-open pane through the mouse/preview path (focusOpenPane,
+// reached via selectionChanged → updatePanePreview) can auto-hide another pane
+// via relayout. That notice must start its 3s auto-clear timer just like the
+// resize and open-or-focus paths do — the bug left focusOpenPane's relayout
+// setting the status but never consuming it, so the "N hidden" guidance
+// lingered forever. focusOpenPane now returns the consume cmd; the pending
+// status is drained and a clear-timer cmd is handed back.
+func TestPane_AutoHideViaFocusOpenPaneStartsClearTimer(t *testing.T) {
+	h := paneTestHome(t)
+	resizeHome(h, layout.MultiPaneMinWidth-1, 24) // only one pane fits
+
+	alpha := h.store.GetInstanceByTitle("alpha")
+	beta := h.store.GetInstanceByTitle("beta")
+	require.NotNil(t, alpha)
+	require.NotNil(t, beta)
+
+	// Open both instances' panes; at this width only one fits, so exactly one is
+	// visible and the other is auto-hidden.
+	_, _ = h.openOrFocusPane(alpha, 0)
+	_, _ = h.openOrFocusPane(beta, 0)
+	require.Equal(t, 2, h.store.NumOpenPanes())
+	require.Equal(t, 1, len(h.visiblePanes), "only one pane fits at the narrow width")
+
+	// Grab the currently hidden pane — focusing it will re-hide the visible one.
+	visibleID := h.visiblePanes[0].ID()
+	var hidden *store.OpenPane
+	for _, p := range h.store.OpenPanes() {
+		if p.ID() != visibleID {
+			hidden = p
+		}
+	}
+	require.NotNil(t, hidden, "one pane is auto-hidden at the narrow width")
+
+	// Reset any notice state the open path left behind so the assertion isolates
+	// the focusOpenPane relayout.
+	h.errBox.Clear()
+	h.pendingPaneAutoHideStatus = ""
+	h.paneAutoHideNoticeID = 0
+
+	// Focus the hidden pane the way the mouse/preview path does. This re-hides
+	// the other pane, showing the auto-hide notice — which must be consumed so
+	// the timer runs.
+	cmd := h.focusOpenPane(hidden)
+
+	require.NotEmpty(t, h.errBox.FullError(), "the auto-hide notice is shown on re-hide")
+	assert.Equal(t, "", h.pendingPaneAutoHideStatus,
+		"focusOpenPane consumes the pending status instead of leaving it dangling (#1685)")
+	require.NotNil(t, cmd,
+		"focusOpenPane returns the clear-timer cmd so the notice auto-clears after 3s (#1685)")
 }
 
 // TestPane_OpenPaneWindowIsIdempotent proves the (instance, tab) →

--- a/app/pane_autohide_status_test.go
+++ b/app/pane_autohide_status_test.go
@@ -3,8 +3,8 @@ package app
 import (
 	"testing"
 
+	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/ui/layout"
-	"github.com/sachiniyer/agent-factory/ui/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -38,56 +38,96 @@ func TestPane_OpenHiddenThenResizeWideNoDupNoStaleStatus(t *testing.T) {
 		"the narrow-width guidance clears once the panes fit again")
 }
 
-// TestPane_AutoHideViaFocusOpenPaneStartsClearTimer is the #1685 regression:
-// focusing an already-open pane through the mouse/preview path (focusOpenPane,
-// reached via selectionChanged → updatePanePreview) can auto-hide another pane
-// via relayout. That notice must start its 3s auto-clear timer just like the
-// resize and open-or-focus paths do — the bug left focusOpenPane's relayout
-// setting the status but never consuming it, so the "N hidden" guidance
-// lingered forever. focusOpenPane now returns the consume cmd; the pending
-// status is drained and a clear-timer cmd is handed back.
-func TestPane_AutoHideViaFocusOpenPaneStartsClearTimer(t *testing.T) {
-	h := paneTestHome(t)
-	resizeHome(h, layout.MultiPaneMinWidth-1, 24) // only one pane fits
-
+// openPanesForBothAndReturnHidden opens alpha's and beta's panes at a width
+// where only one fits, then returns (visible instance, hidden instance) for the
+// resulting split — which pane wins visibility is a store detail the callers
+// don't care about, only that exactly one is hidden.
+func openPanesForBothAndReturnHidden(t *testing.T, h *home) (visible, hidden *session.Instance) {
+	t.Helper()
 	alpha := h.store.GetInstanceByTitle("alpha")
 	beta := h.store.GetInstanceByTitle("beta")
 	require.NotNil(t, alpha)
 	require.NotNil(t, beta)
-
-	// Open both instances' panes; at this width only one fits, so exactly one is
-	// visible and the other is auto-hidden.
 	_, _ = h.openOrFocusPane(alpha, 0)
 	_, _ = h.openOrFocusPane(beta, 0)
 	require.Equal(t, 2, h.store.NumOpenPanes())
 	require.Equal(t, 1, len(h.visiblePanes), "only one pane fits at the narrow width")
-
-	// Grab the currently hidden pane — focusing it will re-hide the visible one.
-	visibleID := h.visiblePanes[0].ID()
-	var hidden *store.OpenPane
-	for _, p := range h.store.OpenPanes() {
-		if p.ID() != visibleID {
-			hidden = p
-		}
+	visible = h.visiblePanes[0].Instance()
+	hidden = alpha
+	if visible == alpha {
+		hidden = beta
 	}
-	require.NotNil(t, hidden, "one pane is auto-hidden at the narrow width")
+	return visible, hidden
+}
+
+// TestPane_AutoHideViaPreviewFocusStartsClearTimer is the #1685 regression:
+// landing on an already-open-but-hidden pane through the mouse/preview path
+// (selectionChanged → updatePanePreview → focusOpenPane) auto-hides the visible
+// pane via relayout. That notice must start its 3s auto-clear timer just like
+// the resize and open-or-focus paths do — the bug left updatePanePreview's
+// focusOpenPane relayout setting the status but never consuming it, so the
+// "N hidden" guidance lingered forever. updatePanePreview now consumes it and
+// returns the clear-timer cmd, which selectionChanged batches to the event loop.
+func TestPane_AutoHideViaPreviewFocusStartsClearTimer(t *testing.T) {
+	h := paneTestHome(t)
+	resizeHome(h, layout.MultiPaneMinWidth-1, 24) // only one pane fits
+
+	_, hidden := openPanesForBothAndReturnHidden(t, h)
 
 	// Reset any notice state the open path left behind so the assertion isolates
-	// the focusOpenPane relayout.
+	// the preview-focus relayout.
 	h.errBox.Clear()
 	h.pendingPaneAutoHideStatus = ""
 	h.paneAutoHideNoticeID = 0
 
-	// Focus the hidden pane the way the mouse/preview path does. This re-hides
-	// the other pane, showing the auto-hide notice — which must be consumed so
-	// the timer runs.
-	cmd := h.focusOpenPane(hidden)
+	// Drive the mouse/preview path directly: landing on the hidden instance
+	// focuses its pane, re-hiding the visible one and showing the auto-hide
+	// notice — which must be consumed so the timer runs.
+	cmd := h.updatePanePreview(hidden, 0, false, false)
 
 	require.NotEmpty(t, h.errBox.FullError(), "the auto-hide notice is shown on re-hide")
 	assert.Equal(t, "", h.pendingPaneAutoHideStatus,
-		"focusOpenPane consumes the pending status instead of leaving it dangling (#1685)")
+		"the preview-focus path consumes the pending status instead of leaving it dangling (#1685)")
 	require.NotNil(t, cmd,
-		"focusOpenPane returns the clear-timer cmd so the notice auto-clears after 3s (#1685)")
+		"updatePanePreview returns the clear-timer cmd so the notice auto-clears after 3s (#1685)")
+}
+
+// TestPane_OpenFocusRefreshProducedStatusStillClears guards the Greptile edge on
+// PR #1771: a status produced by the SUBSEQUENT selectionChanged refresh during
+// an open-or-focus must still be drained + timed. Here focusOpenPane on the
+// already-visible pane hides nothing, but the refresh reads the sidebar cursor
+// (parked on the hidden instance), re-focuses that pane, and auto-hides the
+// visible one — producing the status LATE. openOrFocusPane's consume runs AFTER
+// selectionChanged precisely so that late status never lingers with no timer.
+func TestPane_OpenFocusRefreshProducedStatusStillClears(t *testing.T) {
+	h := paneTestHome(t)
+	resizeHome(h, layout.MultiPaneMinWidth-1, 24) // only one pane fits
+
+	visible, hidden := openPanesForBothAndReturnHidden(t, h)
+
+	// Park the sidebar cursor on the hidden instance so the refresh inside the
+	// next openOrFocusPane re-focuses it (and auto-hides the visible pane).
+	hiddenIdx := 0
+	for i, inst := range h.store.GetInstances() {
+		if inst == hidden {
+			hiddenIdx = i
+		}
+	}
+	h.sidebar.SetSelectedInstance(hiddenIdx)
+
+	h.errBox.Clear()
+	h.pendingPaneAutoHideStatus = ""
+	h.paneAutoHideNoticeID = 0
+
+	// Open/focus the currently-visible instance. Its own focusOpenPane hides
+	// nothing; the auto-hide status is produced by the refresh that follows.
+	_, cmd := h.openOrFocusPane(visible, 0)
+
+	require.NotEmpty(t, h.errBox.FullError(), "the refresh-produced auto-hide notice is shown")
+	assert.Equal(t, "", h.pendingPaneAutoHideStatus,
+		"a status produced by the refresh during open/focus is still drained (#1685)")
+	require.NotNil(t, cmd,
+		"openOrFocusPane returns a clear-timer cmd so the late notice auto-clears (#1685)")
 }
 
 // TestPane_OpenPaneWindowIsIdempotent proves the (instance, tab) →

--- a/app/pane_preview.go
+++ b/app/pane_preview.go
@@ -78,7 +78,12 @@ func (m *home) updatePanePreview(selected *session.Instance, targetTab int, tabS
 		// panes or rest on the tree. From a background refresh the tab being open
 		// elsewhere just means "no preview to show" — leave focus put.
 		if !m.inPreviewTick {
-			return m.focusOpenPane(existing)
+			m.focusOpenPane(existing)
+			// focusOpenPane's relayout can auto-hide a pane; consume the pending
+			// status HERE so its 3s clear timer starts. This is the mouse/preview
+			// path (selectionChanged → updatePanePreview), which — unlike
+			// openOrFocusPane — has no trailing consume to fall back on (#1685).
+			return m.consumePaneAutoHideStatus()
 		}
 		return nil
 	}

--- a/app/pane_preview.go
+++ b/app/pane_preview.go
@@ -32,17 +32,20 @@ func samePaneBinding(a, b paneBinding) bool {
 	return a.instance == b.instance && a.tab == b.tab
 }
 
-func (m *home) updatePanePreview(selected *session.Instance, targetTab int, tabSpecific bool, attachedNow bool) {
+// updatePanePreview returns a tea.Cmd the caller MUST dispatch: the
+// already-open-tab branch focuses that pane via focusOpenPane, whose relayout
+// can auto-hide another pane and hand back the notice's auto-clear timer (#1685).
+func (m *home) updatePanePreview(selected *session.Instance, targetTab int, tabSpecific bool, attachedNow bool) tea.Cmd {
 	defer m.syncSplitPaneHint()
 
 	if attachedNow || m.interactive || selected == nil {
 		m.cancelPanePreview(false)
-		return
+		return nil
 	}
 	owner := m.previewOwnerPane()
 	if owner == nil {
 		m.cancelPanePreview(false)
-		return
+		return nil
 	}
 	if m.panePreviewTxn != nil && m.panePreviewTxn.ownerPaneID != owner.ID() {
 		m.cancelPanePreview(false)
@@ -50,7 +53,7 @@ func (m *home) updatePanePreview(selected *session.Instance, targetTab int, tabS
 	w := m.paneWindows[owner.ID()]
 	if w == nil {
 		m.cancelPanePreview(false)
-		return
+		return nil
 	}
 	original := paneBinding{instance: owner.Instance(), tab: owner.Tab()}
 	if m.panePreviewTxn != nil && m.panePreviewTxn.ownerPaneID == owner.ID() {
@@ -63,7 +66,7 @@ func (m *home) updatePanePreview(selected *session.Instance, targetTab int, tabS
 	if (!tabSpecific && original.instance == target.instance) ||
 		(tabSpecific && samePaneBinding(original, target)) {
 		m.cancelPanePreview(false)
-		return
+		return nil
 	}
 	if existing := m.store.FindOpenPane(target.instance, target.tab); existing != nil && existing != owner {
 		m.cancelPanePreview(false)
@@ -75,13 +78,13 @@ func (m *home) updatePanePreview(selected *session.Instance, targetTab int, tabS
 		// panes or rest on the tree. From a background refresh the tab being open
 		// elsewhere just means "no preview to show" — leave focus put.
 		if !m.inPreviewTick {
-			m.focusOpenPane(existing)
+			return m.focusOpenPane(existing)
 		}
-		return
+		return nil
 	}
 	if m.isPanePreviewSuppressed(original, target) {
 		m.cancelPanePreview(false)
-		return
+		return nil
 	}
 	changed := m.panePreviewTxn == nil ||
 		m.panePreviewTxn.ownerPaneID != owner.ID() ||
@@ -104,6 +107,7 @@ func (m *home) updatePanePreview(selected *session.Instance, targetTab int, tabS
 		w.InvalidateContent(target.instance, target.tab, "Loading preview...")
 		m.lastPaneCapture[owner.ID()] = time.Time{}
 	}
+	return nil
 }
 
 func (m *home) cancelPanePreview(focusOwner bool) {


### PR DESCRIPTION
Fixes #1685.

## Bug (verified reproduces on master)

Focusing an already-open pane through the **mouse / selection-preview** path — click an instance row → `selectionChanged()` → `updatePanePreview()` → `focusOpenPane(existing)` — runs a `relayout()` that can auto-hide a previously visible pane (§2.6 pane-count fitting) and display the `"N hidden: terminal too narrow …"` transient notice.

Unlike the two other paths that auto-hide via `relayout()` — the resize path (`updateHandleWindowSizeEvent` → `consumePaneAutoHideStatus`) and the `s` open-or-focus path (`openOrFocusPane` → `consumePaneAutoHideStatus`) — `focusOpenPane` set the notice but **never consumed the pending status**, so `clearTransientMessageAfterDelay(...)`'s 3-second timer was never started. The notice lingered indefinitely (until the next user action). `clearStaleAutoHideStatus()` doesn't compensate: it returns early whenever hidden panes remain.

Introduced in #1495, which extracted `focusOpenPane()` out of `openOrFocusPane()` but left the `consumePaneAutoHideStatus()` call behind in the caller, and added the user-facing `updatePanePreview()` call site.

## Fix (minimal)

`focusOpenPane` now returns the consume `tea.Cmd` — draining `pendingPaneAutoHideStatus` and starting the clear timer — and its callers thread it to the event loop:
- `openOrFocusPane` batches `focusOpenPane`'s return (dropping its now-redundant explicit `consumePaneAutoHideStatus()`).
- `updatePanePreview` returns the cmd; its sole caller `selectionChanged()` batches it.

This preserves the notice feedback *and* makes it auto-clear after 3s, matching every other auto-hide path.

## Test

`TestPane_AutoHideViaFocusOpenPaneStartsClearTimer` (in `app/pane_autohide_status_test.go`): opens two panes at a width where only one fits, focuses the currently-hidden pane via `focusOpenPane`, and asserts the notice shows, the pending status is drained, and a clear-timer cmd is returned. **Fails before / passes after** (verified by temporarily reverting the consume).

## Gates
- `make test-container` — green
- `make tui-driver-selftest` — 25/25
- `go build ./...` — clean
- `gofmt -l .` — clean
- `golangci-lint run --fast` — clean
- `deadcode -test ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)