### PR TITLE
fix(daemon): exclusive per-home startup lock — only one daemon per AF home (no split-brain)

### DIFF
--- a/daemon/control_client.go
+++ b/daemon/control_client.go
@@ -75,7 +75,14 @@ func ensureDaemonWithLauncher(launch func() error) error {
 
 	// A previous daemon version may have a PID file but no control socket. Stop
 	// it before launching the control-plane daemon so we do not run duplicate
-	// AutoYes loops.
+	// AutoYes loops. StopDaemon is also how an alive-but-unreachable daemon
+	// (its control socket removed/corrupted) is reclaimed: it SIGTERMs the
+	// holder, which releases the per-home lock on exit, so the launch below
+	// acquires a free lock. That reclaim-then-respawn is what keeps auto-start
+	// within the singleton invariant — the freshly spawned daemon binds only
+	// once the previous one is gone. A spurious spawn that races a still-live
+	// holder can never become a second daemon: the child fails fast on the
+	// exclusive startup lock (see RunDaemon / acquireHomeLock).
 	if _, err := StopDaemon(); err != nil {
 		log.WarningLog.Printf("failed to stop stale daemon before launch: %v", err)
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -50,6 +50,27 @@ func RunDaemon(cfg *config.Config) error {
 		return nil
 	}
 
+	// Acquire the exclusive per-home lock BEFORE touching the socket, PID file,
+	// or any state. This is the singleton guarantee (#960 split-brain): only the
+	// lock holder ever binds the control socket or writes state, so a second
+	// daemon can never clobber a live one — even if the ping above transiently
+	// failed under load and let it slip past. The flock is held for the whole
+	// daemon lifetime and auto-releases if the process dies, so a crashed
+	// daemon's lock frees automatically with no stale-lock pid guessing.
+	//
+	// A held lock means another live daemon owns this home (the top ping only
+	// misses it during the sub-millisecond window between its flock and its
+	// socket bind, or if it is wedged): fail fast, non-zero, WITHOUT removing
+	// the socket / rewriting the PID file, so the live daemon is left intact.
+	lock, err := acquireHomeLock()
+	if err != nil {
+		if isDaemonLockHeldErr(err) {
+			log.InfoLog.Printf("%v", err)
+		}
+		return err
+	}
+	defer lock.release()
+
 	// Shell only — no restore yet, so the bind below happens within
 	// milliseconds of process start.
 	manager, err := newManagerShell(cfg)

--- a/daemon/singleton_lock.go
+++ b/daemon/singleton_lock.go
@@ -1,0 +1,104 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+// daemonLockFileName is the per-home advisory lock file. A single daemon holds
+// an exclusive flock on it for its whole lifetime, making it the source of
+// truth for "is a daemon already running for this home" — stronger than the
+// PID file, which readers can only heuristically validate (#960 split-brain).
+const daemonLockFileName = "daemon.lock"
+
+// daemonLockPath returns <home>/daemon.lock.
+func daemonLockPath() (string, error) {
+	dir, err := config.GetConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, daemonLockFileName), nil
+}
+
+// homeLock is a held exclusive advisory lock on the per-home daemon lock file.
+// The open fd MUST stay open for the daemon's whole lifetime: the flock is tied
+// to the fd, so closing it — or the process dying, including a SIGKILL/crash —
+// releases the lock. That auto-release is what makes a stale lock impossible:
+// there is no pid-liveness guessing, a dead daemon's lock is simply gone.
+type homeLock struct {
+	f *os.File
+}
+
+// daemonLockHeldError reports that another live daemon already holds the
+// per-home lock. It carries the holder's PID (best-effort, read from the PID
+// file) purely for a human-readable message.
+type daemonLockHeldError struct {
+	holderPID int
+}
+
+func (e *daemonLockHeldError) Error() string {
+	if e.holderPID > 0 {
+		return fmt.Sprintf(
+			"an af daemon is already running for this home (pid %d); refusing to start a second",
+			e.holderPID,
+		)
+	}
+	return "an af daemon is already running for this home; refusing to start a second"
+}
+
+// isDaemonLockHeldErr reports whether err is the "another daemon holds the
+// lock" case (as opposed to an I/O error opening the lock file).
+func isDaemonLockHeldErr(err error) bool {
+	var held *daemonLockHeldError
+	return errors.As(err, &held)
+}
+
+// acquireHomeLock takes the exclusive per-home advisory lock without blocking.
+// On success the returned homeLock's fd is held open; the caller MUST keep it
+// for the daemon's lifetime and release() it on exit. If another live daemon
+// already holds the lock it returns a *daemonLockHeldError (checkable with
+// isDaemonLockHeldErr) so the caller can fail fast with a clear message; any
+// other error is an I/O failure opening the lock file.
+func acquireHomeLock() (*homeLock, error) {
+	path, err := daemonLockPath()
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return nil, fmt.Errorf("failed to create daemon lock directory: %w", err)
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open daemon lock file %s: %w", path, err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = f.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) {
+			holderPID := 0
+			if pid, ok := readPIDFromFile(); ok {
+				holderPID = pid
+			}
+			return nil, &daemonLockHeldError{holderPID: holderPID}
+		}
+		return nil, fmt.Errorf("failed to acquire daemon lock on %s: %w", path, err)
+	}
+	return &homeLock{f: f}, nil
+}
+
+// release drops the flock and closes the fd. Safe on a nil receiver. flock also
+// auto-releases when the process exits, so this is only needed for a graceful
+// shutdown that keeps the process alive afterward (tests) — but calling it is
+// cheap and makes the lifetime explicit.
+func (l *homeLock) release() {
+	if l == nil || l.f == nil {
+		return
+	}
+	_ = syscall.Flock(int(l.f.Fd()), syscall.LOCK_UN)
+	_ = l.f.Close()
+	l.f = nil
+}

--- a/daemon/singleton_lock_test.go
+++ b/daemon/singleton_lock_test.go
@@ -1,0 +1,250 @@
+package daemon
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+// TestAcquireHomeLock_SecondFailsFastAndFreesOnRelease pins the core singleton
+// invariant: only one holder at a time. A second acquire on the same home fails
+// fast with the "already running" *daemonLockHeldError (never blocks), and the
+// lock frees the instant the first holder releases.
+func TestAcquireHomeLock_SecondFailsFastAndFreesOnRelease(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	first, err := acquireHomeLock()
+	if err != nil {
+		t.Fatalf("first acquireHomeLock: %v", err)
+	}
+
+	// A second acquire while the first is held must fail fast (LOCK_NB) with the
+	// typed held error. flock is per open-file-description, so two acquires in one
+	// process contend exactly like two processes (see #718 bind test).
+	start := time.Now()
+	second, err := acquireHomeLock()
+	if err == nil {
+		second.release()
+		t.Fatal("second acquireHomeLock succeeded while the first was held; expected it to fail")
+	}
+	if !isDaemonLockHeldErr(err) {
+		t.Fatalf("second acquireHomeLock returned %v; want a *daemonLockHeldError", err)
+	}
+	if !strings.Contains(err.Error(), "already running for this home") {
+		t.Fatalf("held error message %q missing the clear 'already running for this home' text", err.Error())
+	}
+	if time.Since(start) > time.Second {
+		t.Fatalf("second acquireHomeLock blocked for %s; must be non-blocking", time.Since(start))
+	}
+
+	// Release the first holder; the lock must now be free.
+	first.release()
+	third, err := acquireHomeLock()
+	if err != nil {
+		t.Fatalf("acquireHomeLock after release: %v; lock did not free", err)
+	}
+	third.release()
+}
+
+// TestRunDaemon_SecondStartFailsFastWithoutTouchingRuntimeFiles simulates a
+// live daemon A (holds the lock) and proves a second RunDaemon on the same home
+// fails fast with the clear error and does NOT clobber A's socket or PID file —
+// the split-brain fix (#960). Holding the lock in-process stands in for daemon
+// A: flock contends across open-file-descriptions the same in one process as
+// across two.
+func TestRunDaemon_SecondStartFailsFastWithoutTouchingRuntimeFiles(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+
+	// Daemon A holds the lock and owns its runtime files.
+	lockA, err := acquireHomeLock()
+	if err != nil {
+		t.Fatalf("daemon A acquireHomeLock: %v", err)
+	}
+	defer lockA.release()
+
+	socketPath, err := DaemonSocketPath()
+	if err != nil {
+		t.Fatalf("DaemonSocketPath: %v", err)
+	}
+	// Sentinels standing in for A's live runtime files. The socket is a plain
+	// file (not a listener) so the pre-lock ping in RunDaemon fails and it
+	// proceeds to the lock guard, exactly as a second start would when A's real
+	// listener momentarily does not answer.
+	const socketSentinel = "A-socket"
+	if err := os.WriteFile(socketPath, []byte(socketSentinel), 0600); err != nil {
+		t.Fatalf("write sentinel socket: %v", err)
+	}
+	pidPath := filepath.Join(home, "daemon.pid")
+	if err := os.WriteFile(pidPath, []byte("424242"), 0600); err != nil {
+		t.Fatalf("write sentinel PID file: %v", err)
+	}
+
+	// Second start.
+	runErr := RunDaemon(config.DefaultConfig())
+	if runErr == nil {
+		t.Fatal("second RunDaemon returned nil; expected it to refuse to start")
+	}
+	if !isDaemonLockHeldErr(runErr) {
+		t.Fatalf("second RunDaemon returned %v; want a *daemonLockHeldError", runErr)
+	}
+	if !strings.Contains(runErr.Error(), "424242") {
+		t.Fatalf("held error %q should name the holder pid from the PID file", runErr.Error())
+	}
+
+	// A's runtime files must be untouched.
+	gotSocket, err := os.ReadFile(socketPath)
+	if err != nil {
+		t.Fatalf("read socket after refused start: %v", err)
+	}
+	if string(gotSocket) != socketSentinel {
+		t.Fatalf("second start clobbered the socket file: got %q want %q", gotSocket, socketSentinel)
+	}
+	gotPID, err := os.ReadFile(pidPath)
+	if err != nil {
+		t.Fatalf("read PID file after refused start: %v", err)
+	}
+	if string(gotPID) != "424242" {
+		t.Fatalf("second start rewrote the PID file: got %q want %q", gotPID, "424242")
+	}
+}
+
+// TestHomeLock_FreesAfterHolderKilledDashNine proves the auto-release guarantee
+// across a real process boundary: a child process acquires the lock, is SIGKILLed
+// (kill -9, no chance to clean up), and the lock is then free for a new start —
+// no stale-lock pid guessing needed. This is the crash-recovery path.
+func TestHomeLock_FreesAfterHolderKilledDashNine(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+
+	// Spawn a child (this test binary re-invoked) that acquires the lock, writes
+	// its PID, prints READY, and blocks until killed. The child's own TestMain
+	// re-sandboxes AGENT_FACTORY_HOME, so we hand it this home explicitly via
+	// AF_HELPER_HOME and it re-points at it before acquiring.
+	cmd := exec.Command(os.Args[0], "-test.run=TestHelperHoldsHomeLock")
+	cmd.Env = append(os.Environ(), "AF_HELPER_HOLD_LOCK=1", "AF_HELPER_HOME="+home)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("StdoutPipe: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper: %v", err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	}()
+
+	// Wait for the child to signal it holds the lock.
+	scanner := bufio.NewScanner(stdout)
+	ready := make(chan struct{})
+	go func() {
+		for scanner.Scan() {
+			if strings.TrimSpace(scanner.Text()) == "READY" {
+				close(ready)
+				return
+			}
+		}
+	}()
+	select {
+	case <-ready:
+	case <-time.After(10 * time.Second):
+		t.Fatal("helper never signaled it holds the lock")
+	}
+
+	// While the child holds it, our acquire must fail with the held error.
+	if _, err := acquireHomeLock(); !isDaemonLockHeldErr(err) {
+		t.Fatalf("acquireHomeLock while child holds it = %v; want *daemonLockHeldError", err)
+	}
+
+	// kill -9: the child gets no chance to release the lock explicitly.
+	if err := cmd.Process.Signal(syscall.SIGKILL); err != nil {
+		t.Fatalf("SIGKILL helper: %v", err)
+	}
+	_, _ = cmd.Process.Wait()
+
+	// The kernel releases the flock on process death. A new acquire must succeed
+	// within a short bound (teardown is not perfectly instantaneous).
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		lock, err := acquireHomeLock()
+		if err == nil {
+			lock.release()
+			return
+		}
+		if !isDaemonLockHeldErr(err) {
+			t.Fatalf("acquireHomeLock after kill -9: %v", err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("lock never freed after the holder was SIGKILLed")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// helperLockHold keeps the child process's lock reachable for its whole life so
+// the GC never finalizes the *os.File and closes the fd (which would release the
+// flock early). A package var is always reachable.
+var helperLockHold *homeLock
+
+// TestHelperHoldsHomeLock is not a real test: it is the child process spawned by
+// TestHomeLock_FreesAfterHolderKilledDashNine. Guarded by an env var so it is a
+// no-op under a normal `go test` run.
+func TestHelperHoldsHomeLock(t *testing.T) {
+	if os.Getenv("AF_HELPER_HOLD_LOCK") != "1" {
+		return
+	}
+	// The package TestMain sandboxed AGENT_FACTORY_HOME to a throwaway dir;
+	// re-point at the home the parent handed us so we lock the same file.
+	if h := os.Getenv("AF_HELPER_HOME"); h != "" {
+		_ = os.Setenv("AGENT_FACTORY_HOME", h)
+	}
+	lock, err := acquireHomeLock()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "helper acquireHomeLock: %v\n", err)
+		os.Exit(1)
+	}
+	helperLockHold = lock
+	// Write our PID so the parent's held-error message can name us, mirroring a
+	// real daemon writing its PID file after acquiring the lock.
+	dir, err := config.GetConfigDir()
+	if err != nil {
+		os.Exit(1)
+	}
+	_ = os.WriteFile(filepath.Join(dir, "daemon.pid"), []byte(strconv.Itoa(os.Getpid())), 0600)
+	fmt.Println("READY")
+	// Block until the parent kills us.
+	select {}
+}
+
+// TestEnsureDaemon_NoSpawnWhenLiveDaemonServes covers the common case: a live
+// daemon is already serving the socket, so EnsureDaemon returns immediately
+// without launching a second one.
+func TestEnsureDaemon_NoSpawnWhenLiveDaemonServes(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	startTestControlServer(t)
+	if err := pingDaemon(); err != nil {
+		t.Fatalf("control server not answering: %v", err)
+	}
+
+	launched := false
+	if err := ensureDaemonWithLauncher(func() error {
+		launched = true
+		return nil
+	}); err != nil {
+		t.Fatalf("ensureDaemonWithLauncher against a live daemon: %v", err)
+	}
+	if launched {
+		t.Fatal("EnsureDaemon launched a second daemon while one was already serving")
+	}
+}


### PR DESCRIPTION
## Problem

`af` allowed **multiple daemons to serve the same `AGENT_FACTORY_HOME`**, causing split-brain: a session/tab created on one daemon is invisible in the web UI served by the other, state diverges, and the #960 single-writer model is violated.

The daemon wrote a PID file (`writeDaemonPIDFile`) but took **no exclusive lock**. The startup ping guard + spawn-lock (`bindControlServerExclusive`) close the common races, but a second daemon whose pre-bind ping *transiently* fails under load (a 250ms dial timeout) still slips past, and `startControlServer` does `os.Remove(socket)` then rebinds — orphaning the first daemon (alive, looping, still writing state) while the second serves the socket. Both write; state diverges.

## Fix — exclusive advisory lock, held for the daemon's lifetime

- **`RunDaemon` acquires `syscall.Flock(LOCK_EX|LOCK_NB)` on `<home>/daemon.lock` BEFORE binding the control socket or writing the PID file**, and holds the fd for the whole process lifetime. Only the lock holder ever binds the socket or writes state, so a second daemon can never clobber a live one — even if the ping slipped past.
- **If the lock is already held, fail fast**: return/log the clear error `an af daemon is already running for this home (pid N); refusing to start a second` and exit non-zero **without** touching the socket, PID file, or state. The live daemon is left fully intact.
- **`flock` auto-releases when the process dies** (graceful exit, SIGTERM, SIGKILL, or crash), so a dead daemon's lock frees automatically with **no stale-lock PID guessing**. The PID file stays for tooling; the flock is now the source of truth for "is a daemon running".

## Auto-start behaviour

The auto-start / ensure-daemon path already respects the invariant, so no behavioural change was needed there (only a clarifying comment):

- When a daemon **answers**, `EnsureDaemon` dials it and never spawns (top ping).
- When a daemon is **alive but unreachable** (socket removed/corrupted), `StopDaemon` SIGTERMs it — which releases the per-home lock on exit — and then exactly **one** replacement is launched. Reclaim-then-respawn, never a second concurrent daemon.
- A spurious spawn that races a still-live holder **self-limits**: the child fails fast on the startup lock and exits without binding/writing.

I initially added a lock-probe to skip spawning when the lock was held, but that broke the legitimate "recover from a removed/corrupted socket" path (`TestDaemonLifecycleRecoversFromStaleSocketAndDeadDaemon`) — the alive-but-unreachable daemon must be reclaimed, not waited on. Reverted; the `RunDaemon` flock alone is the singleton guarantee.

## Tests (`daemon/singleton_lock_test.go`)

- A second `acquireHomeLock` on a held home **fails fast** (non-blocking) with the clear `already running for this home` error, and frees the instant the holder releases.
- A second `RunDaemon` on a home a daemon already holds **refuses to start** and leaves the socket + PID file **byte-for-byte untouched**.
- The lock **frees after the holder is `kill -9`'d** (real cross-process helper) so a new start succeeds — the crash-recovery path, no stale-lock handling needed.
- Auto-start does **not** spawn a second daemon when one is already serving.

## Gates

- `make test-container` — all packages green (incl. `daemon` + `integration`)
- `make tui-driver-selftest` — 25/25 green
- `go build ./...`, `gofmt -l .` clean, `golangci-lint run --fast`, `deadcode -test ./...` — all clean

Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)