### PR TITLE
fix(tui): clear hooks pane on project-switch config-resolve failure (#1686)

### DIFF
--- a/app/switch_project.go
+++ b/app/switch_project.go
@@ -313,6 +313,13 @@ func (m *home) switchProject(repo *config.RepoContext) (tea.Model, tea.Cmd) {
 		m.hooksPane.SetCommands(resolved.PostWorktreeCommands)
 	} else {
 		log.WarningLog.Printf("switch project: failed to resolve config for %s: %v", repo.Root, err)
+		// Clear the hooks pane so the OUTGOING project's hooks cannot leak into
+		// the new project. m.repoRoot already points at the new project, so a save
+		// from a stale pane would write the previous project's hooks into this
+		// project's in-repo config (#1686). At startup the pane starts empty, so
+		// this only matters on an in-place switch.
+		m.store.SetHookCount(0)
+		m.hooksPane.SetCommands(nil)
 	}
 
 	// Re-prime the projection from the new project's snapshot (scoped to the new

--- a/app/switch_project_test.go
+++ b/app/switch_project_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -252,6 +253,44 @@ func TestSwitchProjectSameRepoIsNoop(t *testing.T) {
 	h.switchProject(same)
 
 	require.NotNil(t, findSidebarInstance(h, "existing"), "a same-repo switch must not wipe the sidebar")
+}
+
+// TestSwitchProjectClearsHooksWhenConfigResolveFails is the #1686 guarantee:
+// when config.ResolveConfig fails for the incoming project (e.g. the global
+// config is unreadable/corrupt), the switch must clear the hooks pane rather
+// than leave the OUTGOING project's hooks in it. m.repoRoot already points at
+// the new project by this point, so a save from a stale pane would write the
+// previous project's hooks into the new project's in-repo config.
+func TestSwitchProjectClearsHooksWhenConfigResolveFails(t *testing.T) {
+	h := newTestHome(t)
+	h.snapshotFetcher = func(string) (daemon.SnapshotResponse, error) {
+		return daemon.SnapshotResponse{}, nil
+	}
+
+	// The outgoing project (A) has hooks loaded into the pane.
+	projectAHooks := []string{"echo 'project-a-hook-1'", "echo 'project-a-hook-2'"}
+	h.hooksPane.SetCommands(projectAHooks)
+	h.store.SetHookCount(len(projectAHooks))
+	require.Equal(t, projectAHooks, h.hooksPane.GetCommands())
+
+	// The incoming project (B) is a real, distinct git repo.
+	projectBRoot := initTestGitRepo(t)
+	repoB := &config.RepoContext{Root: projectBRoot, ID: config.RepoIDFromRoot(projectBRoot)}
+
+	// Corrupt the global config so ResolveConfig fails on the switch. newTestHome
+	// redirects AGENT_FACTORY_HOME to a tempdir, so this only affects the test.
+	configDir, err := config.GetConfigDir()
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(configDir, 0o755))
+	globalConfigPath := filepath.Join(configDir, "config.toml")
+	require.NoError(t, os.WriteFile(globalConfigPath, []byte("invalid toml {{{\n[broken"), 0o644))
+	_, err = config.ResolveConfig(projectBRoot)
+	require.Error(t, err, "precondition: ResolveConfig must fail with the corrupt global config")
+
+	h.switchProject(repoB)
+
+	assert.Equal(t, projectBRoot, h.repoRoot, "repoRoot must be re-scoped to the new project")
+	assert.Empty(t, h.hooksPane.GetCommands(), "stale hooks from the previous project must be cleared, not carried over")
 }
 
 // TestBuildProjectListUnionsSourcesWithCounts: the picker list unions the


### PR DESCRIPTION
Fixes #1686.

## Problem

During an in-place project switch, `switchProject()` (`app/switch_project.go`)
sets `m.repoRoot` to the **new** project *before* calling
`config.ResolveConfig(repo.Root)`. When that call fails — e.g. the global
config is corrupt or permission-denied — the code only logged a warning and
left the **outgoing** project's hooks in `m.hooksPane` (and its count in the
store).

Because `m.repoRoot` already points at the new project, a subsequent hooks
save writes the *previous* project's `post_worktree_commands` into the *new*
project's `.agent-factory/config.toml` — cross-project data contamination.

(Startup uses the same "log-and-leave" pattern but is safe there: the pane
starts empty, so there's nothing stale to leak. Only the in-place switch path
is affected.)

## Fix

On resolve failure, clear the hooks pane and reset the hook count so no stale
hooks can survive the switch:

```go
} else {
    log.WarningLog.Printf("switch project: failed to resolve config for %s: %v", repo.Root, err)
    m.store.SetHookCount(0)
    m.hooksPane.SetCommands(nil)
}
```

## Test

`TestSwitchProjectClearsHooksWhenConfigResolveFails` loads project A's hooks
into the pane, corrupts the global config so `ResolveConfig` fails, switches to
project B, and asserts the pane is cleared. Fails before the fix (pane still
holds project A's hooks), passes after.

## Gates

- `make test-container` — full suite green
- `make tui-driver-selftest` — 31/31 green
- `go build ./...` — clean
- `gofmt -l .` — clean
- `golangci-lint run --fast` — clean
- `deadcode -test ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)