### PR TITLE
fix(tui): don't advertise an always-failing "run now" for watch tasks (#1758)

### DIFF
--- a/ui/task_pane.go
+++ b/ui/task_pane.go
@@ -378,6 +378,14 @@ func (s *TaskPane) selectedTaskInRange() bool {
 	return s.selectedIdx >= 0 && s.selectedIdx < len(s.tasks)
 }
 
+// selectedTaskIsWatch reports whether the currently-selected task is a watch
+// task. Watch tasks fire from their watch command's stdout and cannot be
+// manually triggered (RunTask refuses them), so the "run now" affordance is
+// suppressed for them (#1758).
+func (s *TaskPane) selectedTaskIsWatch() bool {
+	return s.selectedTaskInRange() && s.tasks[s.selectedIdx].IsWatch()
+}
+
 func (s *TaskPane) toggleSelectedTask() {
 	if !s.selectedTaskInRange() {
 		return
@@ -407,6 +415,15 @@ func (s *TaskPane) runSelectedTask() {
 	if !s.selectedTaskInRange() {
 		s.pendingTrigger = true
 		s.pendingTriggerID = ""
+		return
+	}
+	// Watch tasks fire from their watch command's stdout; a manual trigger has
+	// no event line to render the prompt, so the daemon refuses them (RunTask).
+	// Don't queue a doomed run — surface the reason inline (shown in edit mode)
+	// and keep the "run now" affordance out of the hints for watch tasks (#1758).
+	if s.tasks[s.selectedIdx].IsWatch() {
+		s.editError = "watch tasks run on their watch command's output, not on manual trigger"
+		s.editErrorField = taskFocusTrigger
 		return
 	}
 	s.pendingTrigger = true
@@ -569,8 +586,15 @@ func (s *TaskPane) renderListMode() string {
 	b.WriteString("\n")
 	if s.hasFocus {
 		hint := "↑/↓ select • n new • enter edit • r run now • x toggle • D delete • esc back"
+		short := "r run now • ↑/↓ • n new • enter • esc"
+		// A watch task can't be manually run (#1758): drop "r run now" so the
+		// hint never advertises an action that always fails.
+		if s.selectedTaskIsWatch() {
+			hint = "↑/↓ select • n new • enter edit • x toggle • D delete • esc back"
+			short = "↑/↓ • n new • enter • esc"
+		}
 		if s.width > 0 && lipgloss.Width(hint) > s.width {
-			hint = "r run now • ↑/↓ • n new • enter • esc"
+			hint = short
 		}
 		b.WriteString(hintStyle.Render(fitLine(hint, s.width)))
 	} else {

--- a/ui/task_pane_edit.go
+++ b/ui/task_pane_edit.go
@@ -317,6 +317,9 @@ func (s *TaskPane) renderEditMode() string {
 	b.WriteString(label("Trigger:"))
 	b.WriteString(s.renderTriggerSelector())
 	b.WriteString("\n")
+	// A watch task's "run now" is refused by the daemon (#1758); pressing r
+	// lands its explanation here, under the trigger-type selector.
+	b.WriteString(fieldErr(taskFocusTrigger))
 	markEnd(taskFocusTrigger)
 	markStart(taskFocusTriggerValue)
 	if s.editTriggerIsWatch {
@@ -389,8 +392,15 @@ func (s *TaskPane) renderEditMode() string {
 		b.WriteString(hintStyle.Render(fitLine(hint, s.width)))
 		b.WriteString("\n")
 		actions := "r run now • x toggle • D delete • esc list • " + quitHint
+		short := "r run • x toggle • D del • esc • " + quitHint
+		// A watch task can't be manually run (#1758): drop "r run" so the
+		// editor never advertises an action that always fails.
+		if s.selectedTaskIsWatch() {
+			actions = "x toggle • D delete • esc list • " + quitHint
+			short = "x toggle • D del • esc • " + quitHint
+		}
 		if s.width > 0 && lipgloss.Width(actions) > s.width {
-			actions = "r run • x toggle • D del • esc • " + quitHint
+			actions = short
 		}
 		b.WriteString(hintStyle.Render(fitLine(actions, s.width)))
 	}

--- a/ui/task_pane_test.go
+++ b/ui/task_pane_test.go
@@ -206,6 +206,81 @@ func TestTaskPaneListModeRunNowWithoutSelectionQueuesNoTask(t *testing.T) {
 	assert.Nil(t, tp.ConsumePendingTrigger())
 }
 
+// TestTaskPaneWatchTaskRunNowIsSuppressed pins #1758: a watch task cannot be
+// manually triggered (the daemon's RunTask refuses it), so pressing `r` must
+// NOT queue a doomed run — it surfaces the reason inline instead.
+func TestTaskPaneWatchTaskRunNowIsSuppressed(t *testing.T) {
+	tp := NewTaskPane()
+	tp.SetTasks([]task.Task{
+		{ID: "cronny", Name: "cronny", CronExpr: "0 0 * * *"},
+		{ID: "watchy", Name: "watchy", WatchCmd: "tail -f log"},
+	})
+	tp.SetFocus(true)
+	tp.SelectTask(1)
+
+	assert.True(t, tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")}))
+	assert.False(t, tp.HasPendingTrigger(),
+		"r on a watch task must not queue a run that RunTask will refuse")
+
+	// The cron task in the same list is unaffected: r still queues its run.
+	tp.SelectTask(0)
+	assert.True(t, tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")}))
+	require.True(t, tp.HasPendingTrigger(), "r must still queue a cron task's run-now")
+	pending := tp.ConsumePendingTrigger()
+	require.NotNil(t, pending)
+	assert.Equal(t, "cronny", pending.ID)
+}
+
+// TestTaskPaneWatchTaskListFooterOmitsRunNow pins #1758: the task-list footer
+// must not advertise "r run now" when the selected task is a watch task.
+func TestTaskPaneWatchTaskListFooterOmitsRunNow(t *testing.T) {
+	tp := NewTaskPane()
+	tp.SetSize(80, 12)
+	tp.SetFocus(true)
+	tp.SetTasks([]task.Task{{
+		ID:       "watchy",
+		Name:     "watchy",
+		Prompt:   "do it",
+		WatchCmd: "tail -f log",
+		Program:  "claude",
+		Enabled:  true,
+	}})
+
+	lines := strings.Split(tp.String(), "\n")
+	footer := lines[len(lines)-1]
+	assert.NotContains(t, footer, "run now",
+		"watch-task list footer must not advertise a manual run that always fails")
+}
+
+// TestTaskPaneWatchTaskEditFooterOmitsRunNow pins #1758 at the editor surface
+// named in the issue repro: editing a watch task must not advertise "r run".
+func TestTaskPaneWatchTaskEditFooterOmitsRunNow(t *testing.T) {
+	tp := NewTaskPane()
+	tp.SetSize(80, 12)
+	tp.SetTasks([]task.Task{{
+		ID:          "watchy",
+		Name:        "watchy",
+		Prompt:      "do it",
+		WatchCmd:    "tail -f log",
+		ProjectPath: newGitRepo(t),
+		Program:     "claude",
+		Enabled:     true,
+	}})
+	tp.SetFocus(true)
+	tp.EnterEditSelected()
+
+	out := tp.String()
+	assert.NotContains(t, out, "r run",
+		"watch-task editor must not advertise a manual run that always fails")
+
+	// Pressing r inside the editor surfaces the reason inline rather than
+	// queuing a doomed run.
+	assert.True(t, tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")}))
+	assert.False(t, tp.HasPendingTrigger())
+	assert.Contains(t, tp.String(), "not on manual trigger",
+		"r on a watch task must explain why manual run is unavailable")
+}
+
 func TestTaskPaneNormalModeAllowsQuitKeysToPropagate(t *testing.T) {
 	tp := NewTaskPane()
 	tp.SetFocus(true)


### PR DESCRIPTION
Closes #1758.

## Problem
The TUI task editor (and list) advertised **`r run now`** for every task. But a watch task can't be manually triggered: the daemon's `RunTask` refuses it (`daemon/taskrun.go:171`) because a watch task's prompt is rendered from its watch command's event line — a manual trigger has no such line. So pressing `r` on a watch task **always failed**, and at 80 columns the daemon's error (`task ... is a watch task; it fires when its watch command emits output, not on manual trigger`) was truncated, hiding the reason.

## Fix
Suppress the affordance for watch tasks rather than firing a doomed run:

- `runSelectedTask()` no longer queues a trigger for a watch task; it lands a short, non-truncated explanation inline, under the trigger-type selector (`ui/task_pane.go`, `ui/task_pane_edit.go`).
- The **list-mode** and **edit-mode** footers drop `r run now` / `r run` when the selected/edited task is a watch task, so the hint never advertises an action that always fails.

Cron tasks are unaffected — `r` still queues their run-now exactly as before.

## Tests
New regression tests in `ui/task_pane_test.go` cover both surfaces (list + edit) and the cron-still-works path. They **fail before** this change and **pass after** (verified by stashing the source edits).

## Gates
- `make test-container` — all packages green
- `make tui-driver-selftest` — 31/31 green
- `go build ./...` — clean
- `gofmt -l .` — clean
- `golangci-lint run --fast` — clean
- `deadcode -test ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)