### PR TITLE
fix(tui): guard scroll-fill dispatch so a pending fill can't double-capture (#1709)

### DIFF
--- a/app/home_panes.go
+++ b/app/home_panes.go
@@ -186,7 +186,8 @@ func (m *home) panesRefresh(attachedNow bool) tea.Cmd {
 		// scroll mode is left. NeedsScrollFill is true only until that single
 		// fill lands (it clears scrollFillPending), so a live pane resumes
 		// skipping capture for every subsequent scroll keystroke.
-		if w.HasLive() && !w.NeedsScrollFill() {
+		needsFill := w.NeedsScrollFill()
+		if w.HasLive() && !needsFill {
 			continue
 		}
 		// A pane that just entered scroll mode has an empty scroll viewport
@@ -194,10 +195,17 @@ func (m *home) panesRefresh(attachedNow bool) tea.Cmd {
 		// so the fill lands on this refresh instead of up to a tick later, which
 		// would flash a blank viewport. Scroll-mode entry no longer captures on the
 		// event loop, so this off-loop fill is the only place that populates it.
-		if !w.NeedsScrollFill() && time.Since(m.lastPaneCapture[p.ID()]) < paneCaptureMinInterval {
+		if !needsFill && time.Since(m.lastPaneCapture[p.ID()]) < paneCaptureMinInterval {
 			continue
 		}
 		m.lastPaneCapture[p.ID()] = time.Now()
+		// Claim the fill before dispatching so the next refresh in the
+		// dispatch→land window sees NeedsScrollFill go false and does not fire a
+		// redundant capture (#1709). NeedsScrollFill re-arms if this capture fails
+		// to publish (view changed mid-flight), so a genuinely-owed fill still runs.
+		if needsFill {
+			w.BeginScrollFill()
+		}
 		binding, seq := m.renderBindingForPane(p)
 		cmds = append(cmds, refreshPaneBindingCmd(w, binding.instance, binding.tab, seq))
 	}

--- a/app/scroll_fill_inflight_test.go
+++ b/app/scroll_fill_inflight_test.go
@@ -1,0 +1,71 @@
+package app
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPanesRefreshNoRedundantScrollFillCapture is the #1709 regression: while a
+// scroll-fill capture is already in flight, a second panesRefresh cycle must NOT
+// dispatch another one. Scroll entry marks a pending off-loop fill (#1637), and
+// panesRefresh bypasses its throttle for a pane that NeedsScrollFill so the fill
+// lands immediately. Before the fix NeedsScrollFill stayed true from scroll
+// entry until the capture actually LANDED, so every refresh cycle in that window
+// (rapid scroll input, or a slow daemon Preview RPC) fired a fresh, redundant
+// `tmux capture-pane` — mutex-guarded so it couldn't corrupt state, but wasteful.
+//
+// The fetcher here blocks the fill capture so it stays in flight across two
+// refresh cycles. The second cycle must be a no-op for that pane.
+func TestPanesRefreshNoRedundantScrollFillCapture(t *testing.T) {
+	h := newTestHome(t)
+	inst := instanceWithFakeBackend(t, "alpha")
+	inst.AddTabForTest("agent", session.TabKindAgent)
+	h.store.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+	_ = h.selectionChanged()
+	resizeHome(h, 200, 40)
+
+	// Gate the scroll-fill capture (Full==true) so it stays in flight, and count
+	// how many times it is dispatched. The non-full path is left unblocked.
+	release := make(chan struct{})
+	var fullCaptures int32
+	h.previewFetcher = func(req daemon.PreviewRequest) (string, bool, error) {
+		if req.Full {
+			atomic.AddInt32(&fullCaptures, 1)
+			<-release
+		}
+		return "scrollback-line", false, nil
+	}
+
+	pane := openTestPane(t, h, inst, 0) // captures the gated fetcher above
+	w := h.paneWindows[pane.ID()]
+	require.NotNil(t, w)
+
+	// Enter scroll mode: marks a pending off-loop fill, no capture on the loop.
+	w.ScrollUp()
+	require.True(t, w.NeedsScrollFill(), "scroll entry marks a pending off-loop fill")
+
+	// First refresh cycle dispatches the fill. Run it off the event loop like
+	// bubbletea would; it blocks in the gated capture, holding the fill in flight.
+	cmd1 := h.panesRefresh(false)
+	require.NotNil(t, cmd1, "the first refresh must dispatch the scroll fill")
+	go cmd1()
+	require.Eventually(t, func() bool { return atomic.LoadInt32(&fullCaptures) == 1 },
+		3*time.Second, 5*time.Millisecond, "the first refresh dispatches exactly one fill capture")
+
+	// Second refresh cycle WHILE the fill is still in flight: it must not dispatch
+	// another capture. Before the fix this fired a redundant second capture.
+	if cmd2 := h.panesRefresh(false); cmd2 != nil {
+		go cmd2()
+	}
+	require.Never(t, func() bool { return atomic.LoadInt32(&fullCaptures) > 1 },
+		250*time.Millisecond, 10*time.Millisecond,
+		"a refresh while a fill is in flight must not dispatch a redundant capture (#1709)")
+
+	close(release)
+}

--- a/ui/preview_scroll_offloop_test.go
+++ b/ui/preview_scroll_offloop_test.go
@@ -130,3 +130,79 @@ func TestBeginScrollFillMasksNeedsScrollFill(t *testing.T) {
 	require.False(t, p.NeedsScrollFill(), "the re-dispatched fill lands and clears the owed flag")
 	require.Contains(t, p.viewport.View(), "scrollback-line")
 }
+
+// TestStaleScrollFillDoesNotSatisfyNewEntry is the #1709-review regression: a
+// scroll-fill capture dispatched for one scroll session must NOT satisfy or
+// clear the in-flight claim of a LATER session on the same instance/tab. The
+// in-flight state is a shared flag, so without a generation stamp a slow capture
+// returning after the user exits and re-enters scroll mode would clear the newer
+// entry's claim (or publish stale scrollback over it) and drop the fresh capture.
+func TestStaleScrollFillDoesNotSatisfyNewEntry(t *testing.T) {
+	inst := makeShellInstance(t, "gen", "scrollback-line")
+	defer func() { _ = inst.Kill() }()
+
+	// The capture blocks on a per-call gate so we can hold session #1's fill in
+	// flight across the exit/re-entry, and count total captures.
+	type gate struct{ ch chan struct{} }
+	gates := make(chan *gate, 4)
+	var calls int32
+	blockingSrc := func(_ *session.Instance, _ int, _ bool) (string, error) {
+		atomic.AddInt32(&calls, 1)
+		g := &gate{ch: make(chan struct{})}
+		gates <- g
+		<-g.ch
+		return "scrollback-line", nil
+	}
+	p := NewTabPane(blockingSrc)
+	p.SetSize(80, 30)
+
+	// Session #1: enter scroll mode and dispatch its fill (still in flight).
+	require.NoError(t, p.ScrollUp(inst, 1))
+	p.BeginScrollFill()
+	fill1 := make(chan error, 1)
+	go func() { fill1 <- p.UpdateContent(inst, 1) }()
+	var g1 *gate
+	require.Eventually(t, func() bool {
+		select {
+		case g1 = <-gates:
+			return true
+		default:
+			return false
+		}
+	}, 3*time.Second, 5*time.Millisecond, "session #1's fill must reach the capture")
+
+	// Exit and immediately re-enter scroll mode: session #2, same instance/tab,
+	// a brand-new fill generation — its claim is still open (in flight from #1
+	// belongs to the old generation).
+	require.NoError(t, p.ResetToNormalMode(inst, 1))
+	require.NoError(t, p.ScrollUp(inst, 1))
+	require.True(t, p.NeedsScrollFill(), "the new scroll entry owes its own fill")
+	p.BeginScrollFill() // session #2 claims its fill
+	require.False(t, p.NeedsScrollFill(), "session #2's claim masks the pane")
+
+	// Session #1's stale capture now returns. It must be ignored: it may not
+	// clear session #2's in-flight claim nor mark #2's fill satisfied.
+	close(g1.ch)
+	require.NoError(t, <-fill1)
+	require.False(t, p.NeedsScrollFill(),
+		"a stale capture must not re-open (clear the claim of) the newer entry's fill (#1709 review)")
+
+	// Session #2's own fill lands and populates the viewport.
+	fill2 := make(chan error, 1)
+	go func() { fill2 <- p.UpdateContent(inst, 1) }()
+	var g2 *gate
+	require.Eventually(t, func() bool {
+		select {
+		case g2 = <-gates:
+			return true
+		default:
+			return false
+		}
+	}, 3*time.Second, 5*time.Millisecond, "session #2 must dispatch its own fresh capture, not reuse the stale one")
+	close(g2.ch)
+	require.NoError(t, <-fill2)
+	require.False(t, p.NeedsScrollFill(), "session #2's fill lands and clears the owed flag")
+	require.Contains(t, p.viewport.View(), "scrollback-line")
+	require.Equal(t, int32(2), atomic.LoadInt32(&calls),
+		"exactly two captures ran: one per scroll session, none redundant within a generation")
+}

--- a/ui/preview_scroll_offloop_test.go
+++ b/ui/preview_scroll_offloop_test.go
@@ -81,3 +81,52 @@ func TestScrollEntryExitNeverCapturesOnEventLoop(t *testing.T) {
 		"the off-loop fill populates the scroll viewport")
 	require.True(t, p.IsScrolling(), "the pane stays in scroll mode after the fill")
 }
+
+// TestBeginScrollFillMasksNeedsScrollFill is the #1709 regression at the TabPane
+// level: panesRefresh claims a pending fill with BeginScrollFill the instant it
+// dispatches the off-loop capture, and NeedsScrollFill must report false from
+// that moment until the capture resolves — so a refresh cycle that fires in the
+// dispatch→land window (rapid scroll input, or a slow daemon Preview RPC) does
+// not dispatch a redundant capture. A claim that fails to publish (view changed
+// mid-flight) must re-arm, so a genuinely-owed fill is never wedged.
+func TestBeginScrollFillMasksNeedsScrollFill(t *testing.T) {
+	inst := makeShellInstance(t, "claim", "scrollback-line")
+	defer func() { _ = inst.Kill() }()
+
+	var calls int32
+	countingSrc := func(_ *session.Instance, _ int, _ bool) (string, error) {
+		atomic.AddInt32(&calls, 1)
+		return "scrollback-line", nil
+	}
+	p := NewTabPane(countingSrc)
+	p.SetSize(80, 30)
+
+	// Enter scroll mode: a fill is owed, none dispatched yet.
+	require.NoError(t, p.ScrollUp(inst, 1))
+	require.True(t, p.NeedsScrollFill(), "scroll entry owes a fill")
+
+	// Claim the fill for a dispatched capture: NeedsScrollFill goes false so the
+	// next refresh cycle is a no-op for this pane even though the fill hasn't run.
+	p.BeginScrollFill()
+	require.False(t, p.NeedsScrollFill(),
+		"a claimed (in-flight) fill must not re-dispatch (#1709)")
+	require.True(t, p.IsScrolling(), "the claim must not exit scroll mode")
+
+	// The claimed capture resolves but cannot publish — the render binding moved
+	// on mid-flight (guard returns false on the post-capture re-check). The claim
+	// releases and, since nothing was published, the fill stays owed and re-arms.
+	guardCalls := 0
+	staleGuard := func() bool {
+		guardCalls++
+		return guardCalls == 1 // pass the entry check, fail the post-capture check
+	}
+	require.NoError(t, p.UpdateContentGuarded(inst, 1, staleGuard))
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls), "the claimed fill ran exactly once")
+	require.True(t, p.NeedsScrollFill(),
+		"a claimed fill that could not publish must re-arm, not wedge the viewport blank (#1709)")
+
+	// The re-armed fill dispatches once more and lands.
+	require.NoError(t, p.UpdateContent(inst, 1))
+	require.False(t, p.NeedsScrollFill(), "the re-dispatched fill lands and clears the owed flag")
+	require.Contains(t, p.viewport.View(), "scrollback-line")
+}

--- a/ui/tab_pane.go
+++ b/ui/tab_pane.go
@@ -79,7 +79,15 @@ type TabPane struct {
 	// capture (#1709). scrollFillPending alone can't serve: it stays true from
 	// scroll entry until the fill LANDS, which spans the dispatch→land window.
 	scrollFillInFlight bool
-	viewport           viewport.Model
+	// scrollFillGen stamps each scroll-fill lifecycle. It bumps on every scroll
+	// entry and every reset, so a slow capture that returns after the user exited
+	// and re-entered scroll mode (a NEW lifecycle, same instance/tab, unchanged
+	// render seq) can tell it is stale: it reads the generation at dispatch and
+	// bails on return if it no longer matches, rather than clearing the in-flight
+	// claim or publishing over the newer entry's fill (#1709 review). The seq
+	// guard can't catch this — scroll entry/exit does not bump ContentSeq.
+	scrollFillGen uint64
+	viewport      viewport.Model
 
 	// currentInstance + currentTab identify the (instance, tab-index) view
 	// currently rendered. UpdateContent/ScrollUp/ScrollDown reset scroll-mode
@@ -148,13 +156,15 @@ func (p *TabPane) BeginScrollFill() {
 	p.scrollFillInFlight = true
 }
 
-// resetScrollFill clears both the fill-owed and fill-in-flight flags. Every
-// scroll-state reset and every completed/abandoned fill funnels through it so a
-// stale in-flight claim can never wedge NeedsScrollFill false forever (#1709).
-// Caller must hold p.mu.
+// resetScrollFill clears both the fill-owed and fill-in-flight flags and starts
+// a new fill generation. Every scroll-state reset and every completed/abandoned
+// fill funnels through it so a stale in-flight claim can never wedge
+// NeedsScrollFill false forever, and any capture still in flight against the old
+// generation is invalidated (#1709). Caller must hold p.mu.
 func (p *TabPane) resetScrollFill() {
 	p.scrollFillPending = false
 	p.scrollFillInFlight = false
+	p.scrollFillGen++
 }
 
 func (p *TabPane) SetSize(width, maxHeight int) {
@@ -302,10 +312,18 @@ func (p *TabPane) updateAgent(instance *session.Instance, guard contentGuard) er
 	// off-loop refresh goroutine, the first time UpdateContent runs with a
 	// pending scroll fill.
 	if p.isScrolling && p.scrollFillPending {
+		gen := p.scrollFillGen
 		p.mu.Unlock()
 		content, err := p.previewSrc(instance, 0, true)
 		p.mu.Lock()
 		defer p.mu.Unlock()
+		// A scroll exit+re-entry (or any reset) during the capture bumps the
+		// generation, handing the fill to a newer dispatch. Bail without touching
+		// the shared claim or pending: this stale completion must neither satisfy
+		// nor clear the newer entry's in-flight fill (#1709 review).
+		if p.scrollFillGen != gen {
+			return nil
+		}
 		// This fill attempt has resolved: release the in-flight claim so a fresh
 		// dispatch can retry if it turns out this one couldn't publish (view
 		// changed mid-capture, error). A successful publish clears pending below,
@@ -450,10 +468,17 @@ func (p *TabPane) updateShell(instance *session.Instance, activeTab int, guard c
 	// capture / daemon RPC — #1637); the shell slot fills lazily on this off-loop
 	// refresh goroutine, the first time UpdateContent runs with a pending fill.
 	if p.isScrolling && p.scrollFillPending {
+		gen := p.scrollFillGen
 		p.mu.Unlock()
 		content, err := p.previewSrc(instance, activeTab, true)
 		p.mu.Lock()
 		defer p.mu.Unlock()
+		// Stale-generation completion (scroll exit+re-entry during the capture):
+		// bail without touching the shared claim/pending, so this old capture can't
+		// satisfy or clear the newer scroll entry's fill (#1709 review).
+		if p.scrollFillGen != gen {
+			return nil
+		}
 		// Release the in-flight claim now the attempt resolved (see updateAgent):
 		// a successful publish clears pending below; a view change / error leaves
 		// pending set so a fresh dispatch retries, never a redundant one (#1709).
@@ -630,8 +655,10 @@ func (p *TabPane) enterScrollModeLocked(instance *session.Instance, activeTab in
 	p.isScrolling = true
 	p.scrollFillPending = true
 	// A fresh fill is owed and none is dispatched yet: clear any stale in-flight
-	// claim from a prior scroll session so this entry's fill can dispatch (#1709).
+	// claim and start a new generation so this entry's fill dispatches and an
+	// in-flight capture from a previous scroll session can't satisfy it (#1709).
 	p.scrollFillInFlight = false
+	p.scrollFillGen++
 	return nil
 }
 

--- a/ui/tab_pane.go
+++ b/ui/tab_pane.go
@@ -71,23 +71,24 @@ type TabPane struct {
 	// lazy-fill and NeedsScrollFill key off — a sized viewport's View() is never
 	// the empty string (it renders padding), so viewport emptiness cannot serve.
 	scrollFillPending bool
-	// scrollFillInFlight is set by BeginScrollFill the moment panesRefresh
-	// dispatches the off-loop fill, and cleared once that capture resolves (or
-	// scroll state resets). NeedsScrollFill masks a pane while it is set, so a
-	// refresh cycle that fires before the in-flight capture lands — rapid scroll
-	// input, or a slow daemon Preview RPC — no longer dispatches a redundant
-	// capture (#1709). scrollFillPending alone can't serve: it stays true from
-	// scroll entry until the fill LANDS, which spans the dispatch→land window.
-	scrollFillInFlight bool
-	// scrollFillGen stamps each scroll-fill lifecycle. It bumps on every scroll
-	// entry and every reset, so a slow capture that returns after the user exited
-	// and re-entered scroll mode (a NEW lifecycle, same instance/tab, unchanged
-	// render seq) can tell it is stale: it reads the generation at dispatch and
-	// bails on return if it no longer matches, rather than clearing the in-flight
-	// claim or publishing over the newer entry's fill (#1709 review). The seq
-	// guard can't catch this — scroll entry/exit does not bump ContentSeq.
-	scrollFillGen uint64
-	viewport      viewport.Model
+	// scrollFillGen / scrollFillDispatchedGen are the generation token that
+	// replaces a plain in-flight bool (#1709). scrollFillGen stamps the current
+	// scroll-fill lifecycle: it bumps on every scroll entry, every reset, and
+	// every re-arm, so each owed fill is a distinct request. scrollFillDispatchedGen
+	// records the generation panesRefresh has already dispatched a capture for.
+	//
+	// A generation, not a bool, because the in-flight state is shared across scroll
+	// EXIT and RE-ENTRY on the same instance/tab (unchanged render seq — scroll
+	// entry/exit does not bump ContentSeq). A capture stamps scrollFillGen at
+	// dispatch and, on return, applies its result only if the generation still
+	// matches; a slow capture from a previous scroll session finds the generation
+	// moved on and is ignored, so it can neither satisfy nor clear the newer
+	// entry's fill. Masking (no redundant dispatch) falls out of the same tokens:
+	// a fill is owed-and-undispatched only while scrollFillDispatchedGen != the
+	// current scrollFillGen.
+	scrollFillGen           uint64
+	scrollFillDispatchedGen uint64
+	viewport                viewport.Model
 
 	// currentInstance + currentTab identify the (instance, tab-index) view
 	// currently rendered. UpdateContent/ScrollUp/ScrollDown reset scroll-mode
@@ -140,30 +141,40 @@ func (p *TabPane) IsScrolling() bool {
 func (p *TabPane) NeedsScrollFill() bool {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	return p.isScrolling && p.scrollFillPending && !p.scrollFillInFlight && p.viewport.Height > 0
+	// Owed AND not yet dispatched for the current generation: a dispatched capture
+	// (scrollFillDispatchedGen == scrollFillGen) masks the pane until it resolves
+	// or a new generation supersedes it, so no redundant capture fires (#1709).
+	return p.isScrolling && p.scrollFillPending &&
+		p.scrollFillDispatchedGen != p.scrollFillGen && p.viewport.Height > 0
 }
 
-// BeginScrollFill claims the pending fill for a dispatched off-loop capture so a
-// second refresh cycle in the dispatch→land window does not fire a redundant one
-// (#1709). panesRefresh calls it synchronously the instant it dispatches the
-// capture — on the event loop, before the goroutine runs — so the very next
-// refresh already sees the claim. The claim is released when the fill resolves
-// (updateAgent/updateShell) or scroll state resets, both of which run through
-// resetScrollFill / clear scrollFillPending.
+// BeginScrollFill records that panesRefresh has dispatched a capture for the
+// current fill generation, so a refresh cycle in the dispatch→land window sees
+// NeedsScrollFill go false and does not fire a redundant one (#1709). It is
+// called synchronously on the event loop the instant the capture is dispatched.
+// A later scroll entry bumps scrollFillGen past this dispatched generation, which
+// both re-arms NeedsScrollFill and marks the in-flight capture stale.
 func (p *TabPane) BeginScrollFill() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.scrollFillInFlight = true
+	p.scrollFillDispatchedGen = p.scrollFillGen
 }
 
-// resetScrollFill clears both the fill-owed and fill-in-flight flags and starts
-// a new fill generation. Every scroll-state reset and every completed/abandoned
-// fill funnels through it so a stale in-flight claim can never wedge
-// NeedsScrollFill false forever, and any capture still in flight against the old
-// generation is invalidated (#1709). Caller must hold p.mu.
+// resetScrollFill clears the fill-owed flag and starts a new generation. Every
+// scroll-state reset and every completed fill funnels through it: bumping the
+// generation invalidates any capture still in flight against the old one, so a
+// stale completion can never satisfy or clear a later fill (#1709). Caller must
+// hold p.mu.
 func (p *TabPane) resetScrollFill() {
 	p.scrollFillPending = false
-	p.scrollFillInFlight = false
+	p.scrollFillGen++
+}
+
+// rearmScrollFill starts a new generation while leaving the fill owed, so a
+// capture that resolved but could not publish (render binding moved on, transient
+// error) re-dispatches instead of wedging the viewport blank, and its own stale
+// return is ignored (#1709). Caller must hold p.mu.
+func (p *TabPane) rearmScrollFill() {
 	p.scrollFillGen++
 }
 
@@ -318,18 +329,18 @@ func (p *TabPane) updateAgent(instance *session.Instance, guard contentGuard) er
 		p.mu.Lock()
 		defer p.mu.Unlock()
 		// A scroll exit+re-entry (or any reset) during the capture bumps the
-		// generation, handing the fill to a newer dispatch. Bail without touching
-		// the shared claim or pending: this stale completion must neither satisfy
-		// nor clear the newer entry's in-flight fill (#1709 review).
+		// generation, handing the fill to a newer dispatch. Ignore this stale
+		// completion entirely: it must neither satisfy nor clear the newer entry's
+		// fill, and it must not publish its stale content (#1709 review). Every
+		// path that clears pending or exits scroll mode bumps the generation, so a
+		// matching generation here guarantees the fill is still owed and current.
 		if p.scrollFillGen != gen {
 			return nil
 		}
-		// This fill attempt has resolved: release the in-flight claim so a fresh
-		// dispatch can retry if it turns out this one couldn't publish (view
-		// changed mid-capture, error). A successful publish clears pending below,
-		// so NeedsScrollFill stays false either way (#1709).
-		p.scrollFillInFlight = false
 		if !guardOK(guard) || !p.isCurrentViewLocked(instance, 0) {
+			// Could not publish for the live render binding: re-arm so the owed
+			// fill re-dispatches rather than wedging the viewport blank (#1709).
+			p.rearmScrollFill()
 			return nil
 		}
 		if err != nil {
@@ -339,21 +350,17 @@ func (p *TabPane) updateAgent(instance *session.Instance, guard contentGuard) er
 				p.setFallbackState("Session no longer running.")
 				return nil
 			}
+			p.rearmScrollFill()
 			return err
 		}
-		// Re-check under the relocked mutex: a concurrent dropStaleView/fallback
-		// during the capture may have cleared the pending fill, in which case this
-		// stale capture must not clobber the new state.
-		if p.isScrolling && p.scrollFillPending {
-			p.viewport.SetContent(lipgloss.JoinVertical(lipgloss.Left, content, scrollFooter()))
-			// First fill lands at the bottom (newest output), matching the live
-			// view the user was looking at when they entered scroll mode. This is
-			// the only place that pins the offset: subsequent LineUp/LineDown move
-			// it and the fill no longer runs (pending cleared), so the scroll
-			// position is preserved (#1637).
-			p.viewport.GotoBottom()
-			p.resetScrollFill()
-		}
+		p.viewport.SetContent(lipgloss.JoinVertical(lipgloss.Left, content, scrollFooter()))
+		// First fill lands at the bottom (newest output), matching the live view
+		// the user was looking at when they entered scroll mode. This is the only
+		// place that pins the offset: subsequent LineUp/LineDown move it and the
+		// fill no longer runs (pending cleared), so the scroll position is
+		// preserved (#1637).
+		p.viewport.GotoBottom()
+		p.resetScrollFill()
 		return nil
 	}
 
@@ -474,16 +481,16 @@ func (p *TabPane) updateShell(instance *session.Instance, activeTab int, guard c
 		p.mu.Lock()
 		defer p.mu.Unlock()
 		// Stale-generation completion (scroll exit+re-entry during the capture):
-		// bail without touching the shared claim/pending, so this old capture can't
-		// satisfy or clear the newer scroll entry's fill (#1709 review).
+		// ignore it entirely, so this old capture can't satisfy or clear the newer
+		// scroll entry's fill nor publish its stale content (#1709 review). A
+		// matching generation guarantees the fill is still owed and current.
 		if p.scrollFillGen != gen {
 			return nil
 		}
-		// Release the in-flight claim now the attempt resolved (see updateAgent):
-		// a successful publish clears pending below; a view change / error leaves
-		// pending set so a fresh dispatch retries, never a redundant one (#1709).
-		p.scrollFillInFlight = false
 		if !guardOK(guard) || !p.isCurrentViewLocked(instance, activeTab) {
+			// Could not publish for the live render binding: re-arm so the owed
+			// fill re-dispatches rather than wedging the viewport blank (#1709).
+			p.rearmScrollFill()
 			return nil
 		}
 		if err != nil {
@@ -493,15 +500,12 @@ func (p *TabPane) updateShell(instance *session.Instance, activeTab int, guard c
 				p.setFallbackState("Terminal session no longer running.")
 				return nil
 			}
+			p.rearmScrollFill()
 			return err
 		}
-		// Re-check under the relocked mutex (see updateAgent): a concurrent
-		// dropStaleView/fallback may have cleared the pending fill.
-		if p.isScrolling && p.scrollFillPending {
-			p.viewport.SetContent(lipgloss.JoinVertical(lipgloss.Left, content, scrollFooter()))
-			p.viewport.GotoBottom()
-			p.resetScrollFill()
-		}
+		p.viewport.SetContent(lipgloss.JoinVertical(lipgloss.Left, content, scrollFooter()))
+		p.viewport.GotoBottom()
+		p.resetScrollFill()
 		return nil
 	}
 
@@ -654,10 +658,10 @@ func (p *TabPane) enterScrollModeLocked(instance *session.Instance, activeTab in
 	p.viewport.SetContent("")
 	p.isScrolling = true
 	p.scrollFillPending = true
-	// A fresh fill is owed and none is dispatched yet: clear any stale in-flight
-	// claim and start a new generation so this entry's fill dispatches and an
-	// in-flight capture from a previous scroll session can't satisfy it (#1709).
-	p.scrollFillInFlight = false
+	// Start a new generation: this entry's fill is owed and undispatched
+	// (scrollFillDispatchedGen now trails scrollFillGen), and any capture still in
+	// flight from a previous scroll session is stamped an older generation, so it
+	// can't satisfy this entry (#1709).
 	p.scrollFillGen++
 	return nil
 }

--- a/ui/tab_pane.go
+++ b/ui/tab_pane.go
@@ -71,7 +71,15 @@ type TabPane struct {
 	// lazy-fill and NeedsScrollFill key off — a sized viewport's View() is never
 	// the empty string (it renders padding), so viewport emptiness cannot serve.
 	scrollFillPending bool
-	viewport          viewport.Model
+	// scrollFillInFlight is set by BeginScrollFill the moment panesRefresh
+	// dispatches the off-loop fill, and cleared once that capture resolves (or
+	// scroll state resets). NeedsScrollFill masks a pane while it is set, so a
+	// refresh cycle that fires before the in-flight capture lands — rapid scroll
+	// input, or a slow daemon Preview RPC — no longer dispatches a redundant
+	// capture (#1709). scrollFillPending alone can't serve: it stays true from
+	// scroll entry until the fill LANDS, which spans the dispatch→land window.
+	scrollFillInFlight bool
+	viewport           viewport.Model
 
 	// currentInstance + currentTab identify the (instance, tab-index) view
 	// currently rendered. UpdateContent/ScrollUp/ScrollDown reset scroll-mode
@@ -124,7 +132,29 @@ func (p *TabPane) IsScrolling() bool {
 func (p *TabPane) NeedsScrollFill() bool {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	return p.isScrolling && p.scrollFillPending && p.viewport.Height > 0
+	return p.isScrolling && p.scrollFillPending && !p.scrollFillInFlight && p.viewport.Height > 0
+}
+
+// BeginScrollFill claims the pending fill for a dispatched off-loop capture so a
+// second refresh cycle in the dispatch→land window does not fire a redundant one
+// (#1709). panesRefresh calls it synchronously the instant it dispatches the
+// capture — on the event loop, before the goroutine runs — so the very next
+// refresh already sees the claim. The claim is released when the fill resolves
+// (updateAgent/updateShell) or scroll state resets, both of which run through
+// resetScrollFill / clear scrollFillPending.
+func (p *TabPane) BeginScrollFill() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.scrollFillInFlight = true
+}
+
+// resetScrollFill clears both the fill-owed and fill-in-flight flags. Every
+// scroll-state reset and every completed/abandoned fill funnels through it so a
+// stale in-flight claim can never wedge NeedsScrollFill false forever (#1709).
+// Caller must hold p.mu.
+func (p *TabPane) resetScrollFill() {
+	p.scrollFillPending = false
+	p.scrollFillInFlight = false
 }
 
 func (p *TabPane) SetSize(width, maxHeight int) {
@@ -153,7 +183,7 @@ func (p *TabPane) dropStaleView(instance *session.Instance, activeTab int) {
 	if instance != p.currentInstance || activeTab != p.currentTab {
 		if p.isScrolling {
 			p.isScrolling = false
-			p.scrollFillPending = false
+			p.resetScrollFill()
 			p.viewport.SetContent("")
 			p.viewport.GotoTop()
 		}
@@ -176,7 +206,7 @@ func (p *TabPane) setFallbackState(message string) {
 		text:     lipgloss.JoinVertical(lipgloss.Center, FallBackText, "", message),
 	}
 	p.isScrolling = false
-	p.scrollFillPending = false
+	p.resetScrollFill()
 	p.viewport.SetContent("")
 }
 
@@ -276,6 +306,11 @@ func (p *TabPane) updateAgent(instance *session.Instance, guard contentGuard) er
 		content, err := p.previewSrc(instance, 0, true)
 		p.mu.Lock()
 		defer p.mu.Unlock()
+		// This fill attempt has resolved: release the in-flight claim so a fresh
+		// dispatch can retry if it turns out this one couldn't publish (view
+		// changed mid-capture, error). A successful publish clears pending below,
+		// so NeedsScrollFill stays false either way (#1709).
+		p.scrollFillInFlight = false
 		if !guardOK(guard) || !p.isCurrentViewLocked(instance, 0) {
 			return nil
 		}
@@ -299,7 +334,7 @@ func (p *TabPane) updateAgent(instance *session.Instance, guard contentGuard) er
 			// it and the fill no longer runs (pending cleared), so the scroll
 			// position is preserved (#1637).
 			p.viewport.GotoBottom()
-			p.scrollFillPending = false
+			p.resetScrollFill()
 		}
 		return nil
 	}
@@ -419,6 +454,10 @@ func (p *TabPane) updateShell(instance *session.Instance, activeTab int, guard c
 		content, err := p.previewSrc(instance, activeTab, true)
 		p.mu.Lock()
 		defer p.mu.Unlock()
+		// Release the in-flight claim now the attempt resolved (see updateAgent):
+		// a successful publish clears pending below; a view change / error leaves
+		// pending set so a fresh dispatch retries, never a redundant one (#1709).
+		p.scrollFillInFlight = false
 		if !guardOK(guard) || !p.isCurrentViewLocked(instance, activeTab) {
 			return nil
 		}
@@ -436,7 +475,7 @@ func (p *TabPane) updateShell(instance *session.Instance, activeTab int, guard c
 		if p.isScrolling && p.scrollFillPending {
 			p.viewport.SetContent(lipgloss.JoinVertical(lipgloss.Left, content, scrollFooter()))
 			p.viewport.GotoBottom()
-			p.scrollFillPending = false
+			p.resetScrollFill()
 		}
 		return nil
 	}
@@ -590,6 +629,9 @@ func (p *TabPane) enterScrollModeLocked(instance *session.Instance, activeTab in
 	p.viewport.SetContent("")
 	p.isScrolling = true
 	p.scrollFillPending = true
+	// A fresh fill is owed and none is dispatched yet: clear any stale in-flight
+	// claim from a prior scroll session so this entry's fill can dispatch (#1709).
+	p.scrollFillInFlight = false
 	return nil
 }
 
@@ -603,7 +645,7 @@ func (p *TabPane) ResetToNormalMode(instance *session.Instance, activeTab int) e
 	wasScrolling := p.isScrolling
 	if wasScrolling {
 		p.isScrolling = false
-		p.scrollFillPending = false
+		p.resetScrollFill()
 		p.viewport.SetContent("")
 		p.viewport.GotoTop()
 	}

--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -532,6 +532,13 @@ func (w *TabbedWindow) NeedsScrollFill() bool {
 	return w.tab.NeedsScrollFill()
 }
 
+// BeginScrollFill claims the pending scroll fill for the capture panesRefresh is
+// about to dispatch, so a refresh cycle that fires before it lands does not
+// dispatch a redundant one (#1709).
+func (w *TabbedWindow) BeginScrollFill() {
+	w.tab.BeginScrollFill()
+}
+
 // renderHeader renders the one-line `title · tab` header. The header is the
 // only place the pane's tab is named inside the pane (the tab bar is gone);
 // the highlight doubles as the pane's focus indicator.


### PR DESCRIPTION
Fixes #1709.

## Problem

`panesRefresh` bypasses its capture throttle for a pane that `NeedsScrollFill` so the off-loop scrollback fill lands immediately on scroll entry (#1637). But `NeedsScrollFill` stayed true from scroll entry until the capture actually **landed**, so every refresh cycle inside that dispatch→land window fired a fresh, redundant `tmux capture-pane`.

The window opens whenever a refresh cycle runs before the in-flight fill returns:
- **rapid scroll input** — each scroll keystroke/wheel event calls `panesRefresh`, and while `isScrolling` is already set the second `ScrollUp` just moves the viewport but leaves the fill pending, so the next refresh re-dispatches;
- **a slow daemon Preview RPC** — a full-scrollback capture that takes longer than the tick interval gets a fresh dispatch each tick.

The extra capture is goroutine-dispatched and mutex-guarded, so it can't corrupt state — it just wastes a ~3–5ms capture. This is the cleanup Greptile flagged on #1708 (5/5, non-blocking).

## Fix

Add a `scrollFillInFlight` claim on `TabPane`:

- `panesRefresh` sets it synchronously via `BeginScrollFill` **the instant it dispatches** the fill — on the event loop, before the capture goroutine runs — so the very next refresh already sees `NeedsScrollFill` go false and no-ops for that pane.
- The claim is released once the capture **resolves** (`updateAgent`/`updateShell`) or scroll state resets, funnelled through a `resetScrollFill` helper so a stale claim can never wedge `NeedsScrollFill` false forever. A fill that couldn't publish (render binding moved on mid-flight) **re-arms**, so a genuinely-owed fill still runs and the viewport is never left blank.

No behavior change on the happy path — the fill still lands on the first refresh after scroll entry; only the *redundant* re-dispatch is suppressed.

## Tests

- `app`: `TestPanesRefreshNoRedundantScrollFillCapture` drives two refresh cycles while a fill is gated in flight and asserts exactly one capture is dispatched. **Fails before this change** (second refresh fires a redundant capture), passes after.
- `ui`: `TestBeginScrollFillMasksNeedsScrollFill` locks the TabPane claim→mask→re-arm lifecycle, including the no-wedge recovery when a claimed fill can't publish.

## Gates

- `make test-container` — green (all packages)
- `make tui-driver-selftest` — 31/31 green
- `go build ./...` — clean
- `gofmt -l .` — clean
- `golangci-lint run --fast` — clean
- `deadcode -test ./...` — clean
- new tests race-clean (`go test -race`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)