### PR TITLE
fix(state): refuse to downgrade a newer-schema state.json (#1725)

### DIFF
--- a/config/state.go
+++ b/config/state.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/sachiniyer/agent-factory/log"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/sachiniyer/agent-factory/log"
 )
 
 const (
@@ -142,11 +144,15 @@ func SaveState(state *State) error {
 	})
 }
 
-// refuseStateDowngrade returns an UnsupportedSchemaVersionError when the file at
-// statePath was written by a newer af (schema_version > StateSchemaVersion), so
-// the caller must not overwrite it. A missing file (first run), an unreadable
-// file, or one whose schema_version cannot be detected does not block the write:
-// those recover to a freshly-written default rather than wedging saves forever.
+// refuseStateDowngrade blocks a save that would downgrade/clobber a state.json
+// this binary must not overwrite. It fails closed on ambiguity: the write is
+// only allowed when the on-disk schema is definitively same-or-older (or
+// absent/legacy). A missing file (first run) or a structurally-corrupt file
+// recovers to a freshly-written default rather than wedging saves forever, but a
+// schema_version that is PRESENT yet cannot be parsed/interpreted as a version
+// this binary understands (non-integer, out of range, wrong type) is treated as
+// "possibly newer" and refused — a value we cannot read might come from a newer
+// af, so we must not clobber it (#1725).
 func refuseStateDowngrade(statePath string) error {
 	data, err := os.ReadFile(statePath)
 	if err != nil {
@@ -155,20 +161,64 @@ func refuseStateDowngrade(statePath string) error {
 		}
 		return nil
 	}
-	version, err := DetectJSONSchemaVersion(data)
-	if err != nil {
-		log.WarningLog.Printf("could not detect schema version of %s before saving state; overwriting: %v", statePath, err)
+
+	present, version, verr := onDiskStateSchemaVersion(data)
+	switch {
+	case !present:
+		// Absent field, legacy array-root, or a structurally-corrupt file: none
+		// of these is a newer schema. Legacy files upgrade in place; corrupt
+		// files recover to a default on write.
+		if verr != nil {
+			log.WarningLog.Printf("could not detect schema version of %s before saving state; overwriting: %v", statePath, verr)
+		}
 		return nil
-	}
-	if version > StateSchemaVersion {
+	case verr != nil:
+		// schema_version is present but uninterpretable — fail closed.
+		return fmt.Errorf("%s has an unrecognizable schema_version (%v); this binary supports up to %d and will not overwrite it, as it may have been written by a newer af — upgrade af",
+			describeSchemaStore(StateFileName, statePath), verr, StateSchemaVersion)
+	case version > StateSchemaVersion:
 		return &UnsupportedSchemaVersionError{
 			StoreName:        StateFileName,
 			Path:             statePath,
 			FileVersion:      version,
 			SupportedVersion: StateSchemaVersion,
 		}
+	default:
+		return nil
 	}
-	return nil
+}
+
+// onDiskStateSchemaVersion reports whether a state.json blob carries a
+// schema_version field and, if so, how it parses. present is false for a
+// structurally-corrupt blob (not a JSON object), a JSON array (legacy), or an
+// object lacking the field — with verr carrying the parse failure for the
+// corrupt case. present is true when the field exists; verr is then non-nil iff
+// the value could not be interpreted as a version integer.
+func onDiskStateSchemaVersion(data []byte) (present bool, version int, verr error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	var root any
+	if err := decoder.Decode(&root); err != nil {
+		return false, LegacySchemaVersion, err
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		return false, LegacySchemaVersion, fmt.Errorf("trailing data after JSON value")
+	}
+	obj, ok := root.(map[string]any)
+	if !ok {
+		// Arrays are legacy v0; any other scalar root is corrupt. Neither is newer.
+		if _, isArray := root.([]any); isArray {
+			return false, LegacySchemaVersion, nil
+		}
+		return false, LegacySchemaVersion, fmt.Errorf("JSON root must be an object, got %T", root)
+	}
+	value, ok := obj[SchemaVersionField]
+	if !ok {
+		return false, LegacySchemaVersion, nil
+	}
+	version, verr = schemaVersionFromValue(value)
+	return true, version, verr
 }
 
 // Per-repo instance file functions

--- a/config/state.go
+++ b/config/state.go
@@ -110,7 +110,14 @@ func LoadState() *State {
 	return state
 }
 
-// SaveState saves the state to disk
+// SaveState saves the state to disk.
+//
+// The write is refused when the on-disk state.json carries a schema_version
+// newer than this binary understands: an older af must never clobber (and thus
+// downgrade/corrupt) state written by a newer af. This mirrors the save-blocking
+// guard config.toml and tui-state.json already enforce (#1725). Same- or
+// older-schema saves proceed unchanged; a missing or unreadable/corrupt file
+// does not block the write.
 func SaveState(state *State) error {
 	configDir, err := GetConfigDir()
 	if err != nil {
@@ -122,13 +129,46 @@ func SaveState(state *State) error {
 	}
 
 	statePath := filepath.Join(configDir, StateFileName)
-	state.SchemaVersion = StateSchemaVersion
-	data, err := json.MarshalIndent(state, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal state: %w", err)
-	}
+	return WithFileLock(statePath, func() error {
+		if err := refuseStateDowngrade(statePath); err != nil {
+			return err
+		}
+		state.SchemaVersion = StateSchemaVersion
+		data, err := json.MarshalIndent(state, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal state: %w", err)
+		}
+		return AtomicWriteFile(statePath, data, 0644)
+	})
+}
 
-	return AtomicWriteFile(statePath, data, 0644)
+// refuseStateDowngrade returns an UnsupportedSchemaVersionError when the file at
+// statePath was written by a newer af (schema_version > StateSchemaVersion), so
+// the caller must not overwrite it. A missing file (first run), an unreadable
+// file, or one whose schema_version cannot be detected does not block the write:
+// those recover to a freshly-written default rather than wedging saves forever.
+func refuseStateDowngrade(statePath string) error {
+	data, err := os.ReadFile(statePath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.WarningLog.Printf("could not read %s before saving state; overwriting: %v", statePath, err)
+		}
+		return nil
+	}
+	version, err := DetectJSONSchemaVersion(data)
+	if err != nil {
+		log.WarningLog.Printf("could not detect schema version of %s before saving state; overwriting: %v", statePath, err)
+		return nil
+	}
+	if version > StateSchemaVersion {
+		return &UnsupportedSchemaVersionError{
+			StoreName:        StateFileName,
+			Path:             statePath,
+			FileVersion:      version,
+			SupportedVersion: StateSchemaVersion,
+		}
+	}
+	return nil
 }
 
 // Per-repo instance file functions

--- a/config/state_downgrade_test.go
+++ b/config/state_downgrade_test.go
@@ -116,6 +116,38 @@ func TestSaveState_LegacySchemaSaveWorks(t *testing.T) {
 	assert.Equal(t, float64(8), saved["help_screens_seen"])
 }
 
+// Fail-closed edge (Greptile #1778): a state.json whose schema_version is
+// PRESENT but cannot be parsed/interpreted as a version this binary understands
+// (non-integer, string, out-of-range, negative) is ambiguous — it might come
+// from a newer af — so the write must be refused and the file preserved, not
+// clobbered.
+func TestSaveState_PresentButUnparseableSchemaRefused(t *testing.T) {
+	cases := map[string]string{
+		"string_value": `{"schema_version":"2","help_screens_seen":42}`,
+		"non_integer":  `{"schema_version":1.5,"help_screens_seen":42}`,
+		"overflow_int": `{"schema_version":99999999999999999999999,"help_screens_seen":42}`,
+		"negative":     `{"schema_version":-3,"help_screens_seen":42}`,
+		"bool_value":   `{"schema_version":true,"help_screens_seen":42}`,
+		"null_value":   `{"schema_version":null,"help_screens_seen":42}`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			tempHome := t.TempDir()
+			t.Setenv("AGENT_FACTORY_HOME", tempHome)
+			statePath := filepath.Join(tempHome, StateFileName)
+			require.NoError(t, os.WriteFile(statePath, []byte(body), 0644))
+
+			err := SaveState(&State{HelpScreensSeen: 1})
+			require.Error(t, err, "write over unparseable schema_version must be refused")
+
+			// The file must be byte-for-byte preserved.
+			after, err := os.ReadFile(statePath)
+			require.NoError(t, err)
+			assert.Equal(t, body, string(after))
+		})
+	}
+}
+
 // A corrupt/unreadable state.json must not wedge saves forever: the guard lets
 // the write recover the file to a valid default.
 func TestSaveState_CorruptFileDoesNotBlockSave(t *testing.T) {

--- a/config/state_downgrade_test.go
+++ b/config/state_downgrade_test.go
@@ -1,0 +1,132 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeFutureState plants a state.json written by a hypothetical newer af
+// (schema_version above what this binary supports) and returns its path.
+func writeFutureState(t *testing.T, tempHome string) string {
+	t.Helper()
+	futureData, err := json.Marshal(map[string]any{
+		"schema_version":    StateSchemaVersion + 1,
+		"help_screens_seen": 42,
+	})
+	require.NoError(t, err)
+	statePath := filepath.Join(tempHome, StateFileName)
+	require.NoError(t, os.WriteFile(statePath, futureData, 0644))
+	return statePath
+}
+
+// A newer-schema state.json must be read without crashing: LoadState degrades to
+// defaults rather than panicking or erroring (#1725).
+func TestLoadState_NewerSchemaDoesNotCrash(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tempHome)
+	writeFutureState(t, tempHome)
+
+	state := LoadState()
+
+	require.NotNil(t, state)
+	assert.Equal(t, StateSchemaVersion, state.SchemaVersion)
+	assert.Equal(t, uint32(0), state.HelpScreensSeen)
+}
+
+// The core downgrade guard: an older binary must refuse to overwrite a
+// newer-schema state.json, and the newer file must survive untouched on disk
+// (#1725).
+func TestSaveState_RefusesToDowngradeNewerSchema(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tempHome)
+	statePath := writeFutureState(t, tempHome)
+
+	state := LoadState()
+	require.Equal(t, uint32(0), state.HelpScreensSeen)
+
+	// SetHelpScreensSeen -> SaveState must be refused, not silently downgraded.
+	err := state.SetHelpScreensSeen(1)
+	require.Error(t, err)
+	var newer *UnsupportedSchemaVersionError
+	require.True(t, errors.As(err, &newer), "want UnsupportedSchemaVersionError, got %T: %v", err, err)
+	assert.Equal(t, StateSchemaVersion+1, newer.FileVersion)
+	assert.Equal(t, StateSchemaVersion, newer.SupportedVersion)
+
+	// The on-disk file must be exactly what the newer binary wrote — no clobber.
+	savedData, err := os.ReadFile(statePath)
+	require.NoError(t, err)
+	var saved map[string]any
+	require.NoError(t, json.Unmarshal(savedData, &saved))
+	assert.Equal(t, float64(StateSchemaVersion+1), saved["schema_version"])
+	assert.Equal(t, float64(42), saved["help_screens_seen"])
+}
+
+// Direct SaveState (not via SetHelpScreensSeen) over a newer file is likewise
+// refused, and the passed-in state's SchemaVersion is not stamped down.
+func TestSaveState_DirectWriteOverNewerSchemaRefused(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tempHome)
+	writeFutureState(t, tempHome)
+
+	err := SaveState(&State{HelpScreensSeen: 9})
+	require.Error(t, err)
+	var newer *UnsupportedSchemaVersionError
+	assert.True(t, errors.As(err, &newer))
+}
+
+// Same-schema saves are unaffected by the guard.
+func TestSaveState_SameSchemaSaveWorks(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tempHome)
+
+	require.NoError(t, SaveState(&State{HelpScreensSeen: 3}))
+	// A second save over the same-schema file also works.
+	require.NoError(t, SaveState(&State{HelpScreensSeen: 5}))
+
+	loaded := LoadState()
+	assert.Equal(t, StateSchemaVersion, loaded.SchemaVersion)
+	assert.Equal(t, uint32(5), loaded.HelpScreensSeen)
+}
+
+// A legacy (pre-schema_version) state.json is an older schema and must save
+// normally, upgrading in place rather than being refused.
+func TestSaveState_LegacySchemaSaveWorks(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tempHome)
+
+	statePath := filepath.Join(tempHome, StateFileName)
+	require.NoError(t, os.WriteFile(statePath, []byte(`{"help_screens_seen":7}`), 0644))
+
+	loaded := LoadState()
+	assert.Equal(t, uint32(7), loaded.HelpScreensSeen)
+
+	require.NoError(t, loaded.SetHelpScreensSeen(8))
+
+	savedData, err := os.ReadFile(statePath)
+	require.NoError(t, err)
+	var saved map[string]any
+	require.NoError(t, json.Unmarshal(savedData, &saved))
+	assert.Equal(t, float64(StateSchemaVersion), saved["schema_version"])
+	assert.Equal(t, float64(8), saved["help_screens_seen"])
+}
+
+// A corrupt/unreadable state.json must not wedge saves forever: the guard lets
+// the write recover the file to a valid default.
+func TestSaveState_CorruptFileDoesNotBlockSave(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tempHome)
+
+	statePath := filepath.Join(tempHome, StateFileName)
+	require.NoError(t, os.WriteFile(statePath, []byte("{not json"), 0644))
+
+	require.NoError(t, SaveState(&State{HelpScreensSeen: 4}))
+
+	loaded := LoadState()
+	assert.Equal(t, uint32(4), loaded.HelpScreensSeen)
+}


### PR DESCRIPTION
Fixes #1725.

## Problem
An **older** `af` binary could silently overwrite a `state.json` written by a **newer** `af`, corrupting/downgrading it. `state.json` carries a `schema_version`, but:

- `LoadState()` fell back to `DefaultState()` when it saw a newer schema (fine for reading), and
- `SaveState()` then wrote `schema_version = StateSchemaVersion` **unconditionally**.

So a downgrade (newer file + older binary) reset the user's `help_screens_seen` bitmask to 0 and stamped `schema_version` back down on disk. `config.toml` and `tui-state.json` already block this; `state.json` was the inconsistent outlier (introduced in #1316).

## Fix — refuse to downgrade
`SaveState()` now runs under the state file lock and, before writing, checks the on-disk `schema_version`. If it is **newer** than this binary supports, the write is refused with `UnsupportedSchemaVersionError` (`"state.json has schema_version N, but this binary supports up to M; upgrade af…"`) and the newer file is left **untouched** — an old binary can never clobber new-schema state. This mirrors the guard `config.toml`/`tui-state.json` use.

Unchanged paths:
- **Same-/older-schema saves** proceed exactly as before (legacy files upgrade in place).
- A **missing** file (first run) or a **corrupt/unreadable** one does not wedge saves — it recovers to a freshly-written default.
- **Newer-schema reads** still degrade to defaults without crashing.

The one caller of `SetHelpScreensSeen` (`app/help.go`) already logs-and-continues on error, so a refusal degrades gracefully in the TUI.

## Tests
`config/state_downgrade_test.go`:
- newer-schema read does not crash → defaults
- `SaveState`/`SetHelpScreensSeen` over a newer file → refused, on-disk file byte-preserved (`schema_version` and `help_screens_seen` intact)
- same-schema save works; legacy save upgrades in place; corrupt file does not block save

## Gates
- `make test-container` — full suite green
- `make tui-driver-selftest` — 31/31
- `go build ./...`, `gofmt -l .`, `golangci-lint run --fast`, `deadcode -test ./...` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)