### PR TITLE
feat(tabs): stable tab identity end-to-end — address streams/DnD by id not ordinal (#1738)

### DIFF
--- a/api/sessions.go
+++ b/api/sessions.go
@@ -809,7 +809,10 @@ var sessionsAttachCmd = &cobra.Command{
 		if err != nil {
 			return jsonError(err)
 		}
-		detached, err := client.AttachStream(cmd.Context(), instance.Title, repoID, 0)
+		// The CLI attaches the agent tab (index 0), which is structurally always
+		// first and never shifts, so a positional address is unambiguous — no stable
+		// tab id needed here (#1738).
+		detached, err := client.AttachStream(cmd.Context(), instance.Title, repoID, "", 0)
 		if err != nil {
 			return jsonError(fmt.Errorf("failed to attach: %w", err))
 		}

--- a/apiclient/attach.go
+++ b/apiclient/attach.go
@@ -61,8 +61,8 @@ var attachDrainTimeout = 2 * time.Second
 // and restores the terminal on exit. The signature matches the attach seam
 // (app.attachOverlayCallback's `func() (chan struct{}, error)`), so local
 // full-screen attach drops in where the tmux driver used to be.
-func (c *Client) AttachStream(ctx context.Context, title, repoID string, tab int) (chan struct{}, error) {
-	sc, err := c.DialStream(ctx, title, repoID, tab, 0) // 0 = live tail
+func (c *Client) AttachStream(ctx context.Context, title, repoID, tabID string, tab int) (chan struct{}, error) {
+	sc, err := c.DialStream(ctx, title, repoID, tabID, tab, 0) // 0 = live tail
 	if err != nil {
 		return nil, err
 	}

--- a/apiclient/attach_test.go
+++ b/apiclient/attach_test.go
@@ -86,7 +86,7 @@ func startDriver(t *testing.T) (srvConn *websocket.Conn, stdinW *io.PipeWriter, 
 	c, connCh := attachWSServer(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	t.Cleanup(cancel)
-	sc, err := c.DialStream(ctx, "alpha", "", 0, 0)
+	sc, err := c.DialStream(ctx, "alpha", "", "", 0, 0)
 	if err != nil {
 		t.Fatalf("DialStream: %v", err)
 	}

--- a/apiclient/remote_test.go
+++ b/apiclient/remote_test.go
@@ -257,7 +257,7 @@ func TestDialStream_StalledHandshakeTimesOut(t *testing.T) {
 
 	errc := make(chan error, 1)
 	go func() {
-		_, e := c.DialStream(context.Background(), "alpha", "", 0, 0)
+		_, e := c.DialStream(context.Background(), "alpha", "", "", 0, 0)
 		errc <- e
 	}()
 	select {
@@ -332,7 +332,7 @@ func TestDialStream_RemoteThreadsTokenHeaderAndQuery(t *testing.T) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	sc, err := c.DialStream(ctx, "alpha", "", 0, 0)
+	sc, err := c.DialStream(ctx, "alpha", "", "", 0, 0)
 	if err != nil {
 		t.Fatalf("DialStream over HTTP: %v", err)
 	}

--- a/apiclient/stream.go
+++ b/apiclient/stream.go
@@ -36,16 +36,21 @@ type StreamConn struct {
 // StartSeq + bytesReceived and reconnects with ?since=<that> to replay a drop.
 func (s *StreamConn) StartSeq() uint64 { return s.startSeq }
 
-// DialStream opens a WS subscription to tab `tab` of the session (title, optional
-// repoID) starting at output cursor `since` (0 = the live tail). The read/write
-// framing is agentproto's; this only establishes the connection and reports the
-// server's starting cursor. The caller owns Conn and must Close it.
-func (c *Client) DialStream(ctx context.Context, title, repoID string, tab int, since uint64) (*StreamConn, error) {
+// DialStream opens a WS subscription to a tab of the session (title, optional
+// repoID) starting at output cursor `since` (0 = the live tail). The tab is
+// addressed by its stable id (#1738) when tabID is non-empty — so a reorder/close
+// can't misroute the stream — and by the ordinal `tab` otherwise (legacy
+// positional path). The read/write framing is agentproto's; this only establishes
+// the connection and reports the server's starting cursor. The caller owns Conn
+// and must Close it.
+func (c *Client) DialStream(ctx context.Context, title, repoID, tabID string, tab int, since uint64) (*StreamConn, error) {
 	q := url.Values{}
 	if repoID != "" {
 		q.Set("repo_id", repoID)
 	}
-	if tab != 0 {
+	if tabID != "" {
+		q.Set("tab_id", tabID)
+	} else if tab != 0 {
 		q.Set("tab", strconv.Itoa(tab))
 	}
 	if since != 0 {

--- a/apiclient/stream_test.go
+++ b/apiclient/stream_test.go
@@ -110,7 +110,7 @@ func TestDialStream_HandshakeCarriesQueryAndStartSeq(t *testing.T) {
 	c := NewWithSocket(sockPath)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	sc, err := c.DialStream(ctx, "alpha", "repo-x", 3, 7)
+	sc, err := c.DialStream(ctx, "alpha", "repo-x", "", 3, 7)
 	if err != nil {
 		t.Fatalf("DialStream: %v", err)
 	}

--- a/app/creation_test.go
+++ b/app/creation_test.go
@@ -68,7 +68,7 @@ func newTestHome(t *testing.T) *home {
 	// (mock-backed instances answer has-session) binds harmlessly instead of
 	// dialing the daemon. Tests exercising the live path swap in a recording fake.
 	origLiveTerm := newLiveTermPaneFn
-	newLiveTermPaneFn = func(title, repoID string, tab, width, height int) liveTermAttachment {
+	newLiveTermPaneFn = func(title, repoID, tabID string, tab, width, height int) liveTermAttachment {
 		return newFakeLiveTerm()
 	}
 	t.Cleanup(func() { newLiveTermPaneFn = origLiveTerm })

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -796,7 +796,10 @@ func (m *home) attachInstanceTab(instance *session.Instance, tabIdx int, agentLa
 		if err != nil {
 			return nil, err
 		}
-		return c.AttachStream(context.Background(), instance.Title, repoID, tabIdx)
+		// Address the attach by the tab's stable id (#1738) so a reorder/close can't
+		// misroute the full-screen stream; empty falls back to the ordinal.
+		tabID, _ := instance.TabIDAt(tabIdx)
+		return c.AttachStream(context.Background(), instance.Title, repoID, tabID, tabIdx)
 	}
 	return m.showHelpScreen(helpTypeInstanceAttach{}, func() tea.Cmd {
 		return m.beginAttachTransition(func() tea.Cmd {

--- a/app/live_stream.go
+++ b/app/live_stream.go
@@ -28,7 +28,11 @@ func (m *home) newTabPaneSource() ui.PreviewSource {
 		if instance == nil || fetch == nil {
 			return "", nil
 		}
-		content, gone, err := fetch(daemon.PreviewRequest{Title: instance.Title, RepoID: repoID, Tab: tab, Full: full})
+		// Address the capture by the tab's stable id (#1738) so it can't grab the
+		// wrong tab after a reorder/close; the daemon falls back to the ordinal Tab
+		// when the id is empty or no longer resolves.
+		tabID, _ := instance.TabIDAt(tab)
+		content, gone, err := fetch(daemon.PreviewRequest{Title: instance.Title, RepoID: repoID, Tab: tab, TabID: tabID, Full: full})
 		if err != nil {
 			return "", err
 		}
@@ -50,13 +54,13 @@ func (m *home) newTabPaneSource() ui.PreviewSource {
 // tab). The returned dialer opens a fresh apiclient WS subscription starting at
 // the requested replay cursor; the termpane run loop calls it on connect and on
 // every reconnect.
-func streamDialer(title, repoID string, tab int) termpane.Dialer {
+func streamDialer(title, repoID, tabID string, tab int) termpane.Dialer {
 	return func(ctx context.Context, since uint64) (termpane.Stream, error) {
 		c, err := apiclient.NewTargeted()
 		if err != nil {
 			return nil, err
 		}
-		sc, err := c.DialStream(ctx, title, repoID, tab, since)
+		sc, err := c.DialStream(ctx, title, repoID, tabID, tab, since)
 		if err != nil {
 			return nil, err
 		}

--- a/app/live_termpane.go
+++ b/app/live_termpane.go
@@ -55,8 +55,8 @@ type liveTermAttachment interface {
 // newLiveTermPaneFn is the attachment creation seam. Production dials the daemon
 // WS PTY stream for (title, repoID, tab); tests swap in a fake factory. Read on
 // the event loop only.
-var newLiveTermPaneFn = func(title, repoID string, tab, width, height int) liveTermAttachment {
-	return termpane.New(streamDialer(title, repoID, tab), width, height)
+var newLiveTermPaneFn = func(title, repoID, tabID string, tab, width, height int) liveTermAttachment {
+	return termpane.New(streamDialer(title, repoID, tabID, tab), width, height)
 }
 
 // syncLiveTermPane reconciles the live attachments with current focus, pane
@@ -102,7 +102,7 @@ func (m *home) reconcileLiveTermPanes() {
 		if m.paneIsPreviewing(p) {
 			continue
 		}
-		key, title, repoID, tab, ok := m.liveBindCandidate(p)
+		key, title, repoID, tabID, tab, ok := m.liveBindCandidate(p)
 		if !ok {
 			continue
 		}
@@ -131,7 +131,7 @@ func (m *home) reconcileLiveTermPanes() {
 			continue
 		}
 		m.closeLiveTermPaneFor(p.ID())
-		tp := newLiveTermPaneFn(title, repoID, tab, width, height)
+		tp := newLiveTermPaneFn(title, repoID, tabID, tab, width, height)
 		m.liveTerms[p.ID()] = tp
 		m.liveKeys[p.ID()] = key
 		w.SetLive(tp)
@@ -269,17 +269,22 @@ func (m *home) focusedLiveTerm() (liveTermAttachment, *store.OpenPane) {
 // (remote instances, not-started/transitional/dead instances, tabs with no
 // session). The key changes whenever the pane, its tab index, or the underlying
 // session name changes, which is exactly when a rebind is needed.
-func (m *home) liveBindCandidate(p *store.OpenPane) (key, title, repoID string, tab int, ok bool) {
+func (m *home) liveBindCandidate(p *store.OpenPane) (key, title, repoID, tabID string, tab int, ok bool) {
 	if p == nil {
-		return "", "", "", 0, false
+		return "", "", "", "", 0, false
 	}
 	tab = p.Tab()
 	name := liveSessionName(p.Instance(), tab)
 	if name == "" {
-		return "", "", "", 0, false
+		return "", "", "", "", 0, false
 	}
 	inst := p.Instance()
-	return fmt.Sprintf("%d/%d/%s", p.ID(), tab, name), inst.Title, m.repoID, tab, true
+	// Address the stream by the tab's STABLE id (#1738) so a reorder/close can't
+	// misroute it; empty (a just-created tab whose daemon id hasn't synced yet)
+	// falls back to the ordinal in DialStream. The bind key still carries the
+	// ordinal + tmux name, so a positional shift still forces a rebind.
+	tabID, _ = inst.TabIDAt(tab)
+	return fmt.Sprintf("%d/%d/%s", p.ID(), tab, name), inst.Title, m.repoID, tabID, tab, true
 }
 
 // liveSessionName resolves an (instance, tab) to the tmux session a live

--- a/app/live_termpane_test.go
+++ b/app/live_termpane_test.go
@@ -60,7 +60,7 @@ func stubLiveTermFactory(t *testing.T) (created *[]*fakeLiveTerm, titles *[]stri
 	var fakes []*fakeLiveTerm
 	var names []string
 	orig := newLiveTermPaneFn
-	newLiveTermPaneFn = func(title, repoID string, tab, width, height int) liveTermAttachment {
+	newLiveTermPaneFn = func(title, repoID, tabID string, tab, width, height int) liveTermAttachment {
 		f := newFakeLiveTerm()
 		fakes = append(fakes, f)
 		names = append(names, title)

--- a/daemon/agentserver_headless.go
+++ b/daemon/agentserver_headless.go
@@ -394,7 +394,11 @@ func (hs *headlessServer) streamHandler(w http.ResponseWriter, r *http.Request) 
 		_ = sub.Close()
 		return
 	}
-	servePTYStream(hs.as, tab, sub, conn)
+	// The in-sandbox headless server is addressed by ordinal only: the orchestrator's
+	// remoteAgentServer has already resolved any stable ?tab_id= to an index before
+	// forwarding it here (#1738), and a sandbox's tab set is fixed for its lifetime,
+	// so there is nothing to re-resolve — pin the ordinal.
+	servePTYStream(hs.as, staticTabResolver(tab), sub, conn)
 }
 
 // streamInfoHandler answers GET /v1/sessions/{id}/stream-info with where the

--- a/daemon/manager_sessions.go
+++ b/daemon/manager_sessions.go
@@ -215,13 +215,13 @@ func shellQuoteArg(s string) string {
 // collision — a title alone can name two sessions in two repos, an id names
 // exactly one. Both paths return the tracked instance's cached agent-server
 // singleton whose ring buffer/subscribers persist.
-func (m *Manager) agentServerForStream(idOrTitle, repoID string) (session.AgentServer, error) {
+func (m *Manager) agentServerForStream(idOrTitle, repoID string) (session.AgentServer, *session.Instance, error) {
 	instance, resolvedRepoID, title, err := m.resolveStreamSession(idOrTitle, repoID)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if instance == nil {
-		return nil, fmt.Errorf("session %q not found", idOrTitle)
+		return nil, nil, fmt.Errorf("session %q not found", idOrTitle)
 	}
 	// Reject a new subscription while a kill is in flight for this session, the
 	// same killsInFlight gate SendPrompt checks (#1632). Streaming previously
@@ -234,9 +234,9 @@ func (m *Manager) agentServerForStream(idOrTitle, repoID string) (session.AgentS
 	_, killing := m.killsInFlight[key]
 	m.mu.Unlock()
 	if killing {
-		return nil, fmt.Errorf("session %q is being deleted", title)
+		return nil, nil, fmt.Errorf("session %q is being deleted", title)
 	}
-	return instance.AgentServer(), nil
+	return instance.AgentServer(), instance, nil
 }
 
 // resolveStreamSession resolves a stream target by the session's stable id first

--- a/daemon/preview.go
+++ b/daemon/preview.go
@@ -26,7 +26,13 @@ type PreviewRequest struct {
 	Title  string `json:"title"`
 	RepoID string `json:"repo_id"`
 	Tab    int    `json:"tab"`
-	Full   bool   `json:"full"`
+	// TabID addresses the tab by its stable id (#1738) rather than its ordinal
+	// Tab. When set and it resolves against the session's live tab list it wins
+	// over Tab, so a capture can't grab the wrong tab after a reorder/close; when
+	// empty (or it no longer resolves) the handler falls back to the ordinal Tab
+	// for backward compatibility.
+	TabID string `json:"tab_id,omitempty"`
+	Full  bool   `json:"full"`
 }
 
 // PreviewResponse carries the captured content, or Gone=true when the session's
@@ -49,11 +55,19 @@ func (s *controlServer) Preview(req PreviewRequest, resp *PreviewResponse) error
 	if err := validateRPCRepoID(req.RepoID); err != nil {
 		return err
 	}
-	as, err := s.manager.agentServerForStream(req.Title, req.RepoID)
+	as, instance, err := s.manager.agentServerForStream(req.Title, req.RepoID)
 	if err != nil {
 		return err
 	}
-	content, err := as.Preview(req.Tab, req.Full)
+	// Prefer the stable tab id (#1738): resolve it to the tab's CURRENT ordinal so
+	// a capture addresses the right tab after a reorder/close. Fall back to the
+	// ordinal Tab when no id is given or it no longer resolves (legacy clients /
+	// a since-closed tab).
+	tab := req.Tab
+	if idx, ok := instance.TabIndexByID(req.TabID); ok {
+		tab = idx
+	}
+	content, err := as.Preview(tab, req.Full)
 	if err != nil {
 		if errors.Is(err, tmux.ErrSessionGone) {
 			resp.Gone = true

--- a/daemon/ws_pty.go
+++ b/daemon/ws_pty.go
@@ -87,10 +87,28 @@ func (cs *controlServer) streamHandler(w http.ResponseWriter, r *http.Request) {
 		writeHTTPError(w, http.StatusBadRequest, err)
 		return
 	}
-	as, err := cs.manager.agentServerForStream(id, repoID)
+	as, instance, err := cs.manager.agentServerForStream(id, repoID)
 	if err != nil {
 		writeHTTPError(w, http.StatusNotFound, err)
 		return
+	}
+	// Address the tab by its STABLE id (#1738) when the client supplies ?tab_id=:
+	// resolveTab maps the id to the tab's CURRENT ordinal on EVERY operation
+	// (initial Subscribe and each later Input/Resize), so a reorder/close on another
+	// client can never make this connection's captured position refer to a different
+	// tab. Without a ?tab_id= (legacy client) it pins the ?tab= ordinal, preserving
+	// the old positional behavior. A ?tab_id= that names no live tab is a 404 up
+	// front rather than a silent fall-through to a stale ordinal.
+	tabID := r.URL.Query().Get("tab_id")
+	resolveTab := staticTabResolver(tab)
+	if tabID != "" {
+		idx, ok := instance.TabIndexByID(tabID)
+		if !ok {
+			writeHTTPError(w, http.StatusNotFound, fmt.Errorf("session %q has no tab with id %q", id, tabID))
+			return
+		}
+		tab = idx
+		resolveTab = func() (int, bool) { return instance.TabIndexByID(tabID) }
 	}
 	sub, err := as.Subscribe(tab, since)
 	if err != nil {
@@ -109,21 +127,29 @@ func (cs *controlServer) streamHandler(w http.ResponseWriter, r *http.Request) {
 		_ = sub.Close()
 		return // Accept already wrote the error response.
 	}
-	servePTYStream(as, tab, sub, conn)
+	servePTYStream(as, resolveTab, sub, conn)
+}
+
+// staticTabResolver returns a resolver that always yields the fixed ordinal idx.
+// It is the legacy ?tab=<idx> path: without a stable ?tab_id= there is nothing to
+// re-resolve, so Input/Resize keep addressing the same ordinal for the
+// connection's life (the pre-#1738 positional behavior).
+func staticTabResolver(idx int) func() (int, bool) {
+	return func() (int, bool) { return idx, true }
 }
 
 // servePTYStream runs the three loops of one subscriber's connection until any of
 // them ends: the writer (ring → PTY_OUT / resize-echo), the reader (INPUT/RESIZE/
 // detach → agent-server), and the keepalive pinger. It owns closing the
 // subscription and the socket.
-func servePTYStream(as session.AgentServer, tab int, sub session.PTYSubscription, conn *websocket.Conn) {
+func servePTYStream(as session.AgentServer, resolveTab func() (int, bool), sub session.PTYSubscription, conn *websocket.Conn) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	defer func() { _ = sub.Close() }()
 
 	var wg sync.WaitGroup
 	wg.Add(2)
-	go func() { defer wg.Done(); defer cancel(); readPTYClient(ctx, as, tab, conn) }()
+	go func() { defer wg.Done(); defer cancel(); readPTYClient(ctx, as, resolveTab, conn) }()
 	go func() { defer wg.Done(); defer cancel(); keepalivePTY(ctx, conn) }()
 
 	writePTYStream(ctx, sub, conn)
@@ -193,13 +219,22 @@ func writePTYStream(ctx context.Context, sub session.PTYSubscription, conn *webs
 // readPTYClient handles client → server frames: INPUT and RESIZE are applied to
 // the agent-server (multi-writer, from any subscriber); a detach control frame or
 // any read error ends the connection.
-func readPTYClient(ctx context.Context, as session.AgentServer, tab int, conn *websocket.Conn) {
+func readPTYClient(ctx context.Context, as session.AgentServer, resolveTab func() (int, bool), conn *websocket.Conn) {
 	for {
 		msg, err := agentproto.ReadMessage(ctx, conn)
 		if err != nil {
 			return
 		}
 		if msg.Binary {
+			// Re-resolve the tab ordinal per frame (#1738): for a ?tab_id= connection
+			// this maps the stable id to wherever the tab now sits, so a keystroke or
+			// resize can't land on a different tab after a mid-connection reorder/close.
+			// A tab that has since been closed no longer resolves — drop the frame
+			// rather than routing it to whatever tab now holds the old ordinal.
+			tab, ok := resolveTab()
+			if !ok {
+				continue
+			}
 			switch msg.Frame.Op {
 			case agentproto.OpInput:
 				_ = as.Input(tab, msg.Frame.Data)
@@ -255,7 +290,7 @@ func (cs *controlServer) streamInfoHandler(w http.ResponseWriter, r *http.Reques
 	}
 	id := r.PathValue("id")
 	repoID := r.URL.Query().Get("repo_id")
-	as, err := cs.manager.agentServerForStream(id, repoID)
+	as, _, err := cs.manager.agentServerForStream(id, repoID)
 	if err != nil {
 		writeHTTPError(w, http.StatusNotFound, err)
 		return

--- a/session/agentserver_kill_leak_test.go
+++ b/session/agentserver_kill_leak_test.go
@@ -34,7 +34,7 @@ func TestInstanceKillClosesOpenStream(t *testing.T) {
 		t.Fatalf("subscribe: %v", err)
 	}
 	las.mu.Lock()
-	las.brokers = map[int]*ptyBroker{0: br}
+	las.brokers = map[string]*ptyBroker{"agent": br}
 	las.mu.Unlock()
 
 	if ch.starts != 1 {

--- a/session/agentserver_local.go
+++ b/session/agentserver_local.go
@@ -27,10 +27,16 @@ type localAgentServer struct {
 	inst *Instance
 
 	mu sync.Mutex
-	// brokers holds one lazy ptyBroker per tab index (#1592 Phase 2 PR6, tab-aware
-	// streaming): the agent tab (0) and each shell/process tab (>0) have their own
-	// clientless capture + ring buffer so a pane bound to any tab streams over WS.
-	brokers map[int]*ptyBroker
+	// brokers holds one lazy ptyBroker per tab, keyed by the tab's STABLE id
+	// (#1738), not its ordinal index (#1592 Phase 2 PR6, tab-aware streaming): the
+	// agent tab and each shell/process tab have their own clientless capture + ring
+	// buffer so a pane bound to any tab streams over WS. Keying on the stable id
+	// (resolved from the caller's index at ensureBroker time) means a broker follows
+	// its tab across a reorder/close — after tab 1 of [agent,A,B] closes, B's broker
+	// is still found under B's id even though B is now at index 1, so a new
+	// subscriber for B never lands on A's stale (dead-tmux) broker the way an
+	// index-keyed map would.
+	brokers map[string]*ptyBroker
 	// closed latches once Kill has run. A Subscribe/Input/Resize that races the
 	// kill must NOT lazily resurrect a broker (which would start a fresh clientless
 	// capture goroutine on a session that is already being torn down and never gets
@@ -172,23 +178,29 @@ func (s *localAgentServer) TapEnter() {
 // a remote runtime with no tmux session, or an out-of-range tab) rather than
 // panicking.
 func (s *localAgentServer) ensureBroker(tab int) (*ptyBroker, error) {
+	// Resolve the caller's ordinal to the tab's STABLE id (#1738) and the tmux it
+	// currently backs, under the instance lock, BEFORE taking s.mu — so the broker
+	// map key is the identity that follows the tab across a reorder/close, not the
+	// shifting ordinal. tabTmuxSession and TabIDAt each take i.mu; call them before
+	// s.mu (never nest s.mu → i.mu).
+	id, ok := s.inst.TabIDAt(tab)
+	ts := s.inst.tabTmuxSession(tab)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.closed {
 		return nil, fmt.Errorf("session %q is being terminated", s.inst.Title)
 	}
-	if br := s.brokers[tab]; br != nil {
-		return br, nil
-	}
-	ts := s.inst.tabTmuxSession(tab)
-	if ts == nil {
+	if !ok || ts == nil {
 		return nil, fmt.Errorf("session %q tab %d has no local PTY to stream", s.inst.Title, tab)
 	}
+	if br := s.brokers[id]; br != nil {
+		return br, nil
+	}
 	if s.brokers == nil {
-		s.brokers = make(map[int]*ptyBroker)
+		s.brokers = make(map[string]*ptyBroker)
 	}
 	br := newPTYBroker(newTmuxClientlessChannel(ts))
-	s.brokers[tab] = br
+	s.brokers[id] = br
 	return br, nil
 }
 

--- a/session/instance.go
+++ b/session/instance.go
@@ -251,6 +251,39 @@ func (i *Instance) tabTmuxAtLocked(idx int) *tmux.TmuxSession {
 	return i.Tabs[idx].tmux
 }
 
+// TabIDAt returns the stable id (#1738) of the tab at ordinal idx, and whether
+// idx is in range. It is the index→id direction the data plane keys its per-tab
+// broker on, so a broker follows its tab across a reorder/close instead of being
+// pinned to a shifting ordinal.
+func (i *Instance) TabIDAt(idx int) (string, bool) {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	if idx < 0 || idx >= len(i.Tabs) {
+		return "", false
+	}
+	return i.Tabs[idx].ID, true
+}
+
+// TabIndexByID returns the CURRENT ordinal of the tab with stable id (#1738),
+// and whether such a tab exists. It is the id→index resolution the stream
+// endpoint runs per operation: a client addresses a tab by its stable id and the
+// daemon maps it to wherever that tab now sits, so a reorder/close on another
+// client can never make the client's captured position refer to a different tab.
+// An empty id never matches (a legacy/absent id is not addressable by id).
+func (i *Instance) TabIndexByID(id string) (int, bool) {
+	if id == "" {
+		return 0, false
+	}
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	for idx, t := range i.Tabs {
+		if t.ID == id {
+			return idx, true
+		}
+	}
+	return 0, false
+}
+
 // PreviewTab captures the detached content of the tab at idx. Returns ("", nil)
 // when the instance is not started or the tab has no live session, and
 // tmux.ErrSessionGone when the session vanished — mirroring Instance.Preview for
@@ -395,6 +428,11 @@ func (i *Instance) AttachShellTab(name string) (*Tab, error) {
 
 	tab := newShellTab(shellTmux)
 	tab.Name = name
+	// The daemon owns this tab's stable id (#1738) — it minted and persisted one in
+	// its CreateTab. Don't invent a competing local id: leave it empty so the tab is
+	// addressed positionally (safe: the TUI just created it, single-client) until the
+	// next snapshot's ReconcileTabsFromData adopts the daemon's authoritative id.
+	tab.ID = ""
 	i.mu.Lock()
 	// Re-check started under the write lock before appending, mirroring
 	// AddShellTab: Kill is not serialized against attach and can have flipped
@@ -525,7 +563,11 @@ func (i *Instance) ReconcileTabsFromData(target []TabData) (bool, error) {
 			}
 			continue
 		}
-		tab := &Tab{Name: td.Name, Kind: kind, Command: td.Command, tmux: ts}
+		id := td.ID
+		if id == "" {
+			id = newTabID()
+		}
+		tab := &Tab{ID: id, Name: td.Name, Kind: kind, Command: td.Command, tmux: ts}
 		i.mu.Lock()
 		// Re-check under the write lock: a concurrent reconcile/AddTab may have
 		// added this name while we reconnected outside the lock.
@@ -542,6 +584,27 @@ func (i *Instance) ReconcileTabsFromData(target []TabData) (bool, error) {
 		}
 		i.mu.Unlock()
 	}
+
+	// Adopt the daemon's authoritative stable tab id (#1738) for every name-matched
+	// local tab. The daemon is the single owner of tab identity (#960); a local tab
+	// materialized out-of-band — AttachShellTab leaves its id empty on purpose, and
+	// a legacy record may carry an id minted on an earlier load — must key on the
+	// daemon's id so a TUI-side stream/pane binding addresses the SAME id the daemon
+	// resolves. Names are unique per instance, so name is a safe join key. Not
+	// counted as a visible change: the id is internal addressing, not display state.
+	i.mu.Lock()
+	for _, td := range target {
+		if td.ID == "" {
+			continue
+		}
+		for _, t := range i.Tabs {
+			if t.Name == td.Name && t.ID != td.ID {
+				t.ID = td.ID
+			}
+		}
+	}
+	i.mu.Unlock()
+
 	return changed, firstErr
 }
 

--- a/session/instance_data.go
+++ b/session/instance_data.go
@@ -56,7 +56,7 @@ func (i *Instance) ToInstanceData() InstanceData {
 	// config (syncRemoteTabs) rather than from this serialized list, so a
 	// terminal_cmd added or removed while af was down is honored.
 	for _, tab := range i.Tabs {
-		td := TabData{Name: tab.Name, Kind: tab.Kind, Command: tab.Command, URL: tab.URL}
+		td := TabData{ID: tab.ID, Name: tab.Name, Kind: tab.Kind, Command: tab.Command, URL: tab.URL}
 		if tab.tmux != nil {
 			td.TmuxName = tab.tmux.SanitizedName()
 		}
@@ -259,7 +259,15 @@ func restoreLocalTabs(instance *Instance, data InstanceData) {
 			} else if idx == 0 && data.AgentConversation != nil {
 				conversation = *data.AgentConversation
 			}
+			// Backfill a stable id for a legacy tab persisted before #1738 (no id):
+			// mint one now so the restored tab is addressable by a stable id from
+			// this load forward (rollforward, mirroring the InstanceData.ID backfill).
+			id := td.ID
+			if id == "" {
+				id = newTabID()
+			}
 			instance.Tabs = append(instance.Tabs, &Tab{
+				ID:           id,
 				Name:         td.Name,
 				Kind:         kind,
 				Command:      td.Command,

--- a/session/ptybroker_recovery_test.go
+++ b/session/ptybroker_recovery_test.go
@@ -142,7 +142,7 @@ func TestLocalAgentServerResetBrokerCaptures(t *testing.T) {
 	}
 	mustRepaintContains(t, a1, "tab1-screen")
 
-	s := &localAgentServer{brokers: map[int]*ptyBroker{0: br0, 1: br1}}
+	s := &localAgentServer{brokers: map[string]*ptyBroker{"tab0": br0, "tab1": br1}}
 	s.resetBrokerCaptures()
 
 	for name, ch := range map[string]*fakeClientlessChannel{"tab0": ch0, "tab1": ch1} {

--- a/session/storage.go
+++ b/session/storage.go
@@ -93,6 +93,13 @@ func (d InstanceData) ForStorage() InstanceData {
 // precedent: instances.json written before #930 PR 2 simply has no Tabs, and
 // FromInstanceData synthesizes [agent, shell] from the legacy TmuxName/Program.
 type TabData struct {
+	// ID is the tab's stable identity (#1738), minted at creation and never
+	// reused. It is the collision-proof key the PTY stream (?tab_id=) and the web
+	// DnD/pane bindings address the tab by, so a reorder/close can't misroute.
+	// omitempty + additive, mirroring the InstanceData.ID / BranchCreatedByUs
+	// rollforward precedent: a record written before #1738 has no id, and
+	// restoreLocalTabs backfills a fresh one on load.
+	ID       string  `json:"id,omitempty"`
 	Name     string  `json:"name"`
 	Kind     TabKind `json:"kind"`
 	Command  string  `json:"command,omitempty"`

--- a/session/tab.go
+++ b/session/tab.go
@@ -1,6 +1,31 @@
 package session
 
-import "github.com/sachiniyer/agent-factory/session/tmux"
+import (
+	"crypto/rand"
+	"fmt"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// newTabID mints a stable, collision-free identity for a tab (#1738). Unlike a
+// tab's ordinal position (which shifts on a reorder/close) or its display name
+// (which is reused on close+recreate — a fresh "shell" after the old one is
+// gone), this id is minted once at creation, persisted, and never reused, so a
+// stream or pane binding keyed on it can never misroute to a different tab after
+// the tab list changes. It is a package var so tests can inject deterministic
+// ids. crypto/rand is the entropy source; on the (near-impossible) read failure
+// it falls back to a timestamp-derived value so tab creation never blocks on
+// entropy — still unique per call in practice. 16 hex chars (64 bits) is ample
+// for the handful of tabs an instance ever holds and keeps the id compact in a
+// ?tab_id= query string.
+var newTabID = func() string {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("t-%d", time.Now().UnixNano())
+	}
+	return fmt.Sprintf("%x", b[:])
+}
 
 // agentTabName is the display label of the default Agent tab.
 const agentTabName = "agent"
@@ -59,6 +84,12 @@ const (
 // (create/close) and per-tab persistence land in later PRs; PR 1 keeps the
 // on-disk format and all behavior unchanged.
 type Tab struct {
+	// ID is the tab's stable identity (#1738), minted at creation and persisted.
+	// It is the collision-proof key streams and pane bindings address the tab by —
+	// unlike the ordinal position (shifts on reorder/close) or the display name
+	// (reused on close+recreate). Empty only for a legacy persisted tab written
+	// before #1738, which restoreLocalTabs backfills with a fresh id on load.
+	ID string
 	// Name is the display label (e.g. "agent").
 	Name string
 	// Kind selects the tab's process behavior.
@@ -84,7 +115,7 @@ type Tab struct {
 // newAgentTab returns the single Agent-kind tab that wraps an instance's tmux
 // session.
 func newAgentTab(ts *tmux.TmuxSession) *Tab {
-	return &Tab{Name: agentTabName, Kind: TabKindAgent, tmux: ts}
+	return &Tab{ID: newTabID(), Name: agentTabName, Kind: TabKindAgent, tmux: ts}
 }
 
 // newShellTab returns a Shell-kind tab named "shell" wrapping the given tmux
@@ -93,7 +124,7 @@ func newAgentTab(ts *tmux.TmuxSession) *Tab {
 // (#1100); the only automatic use is setupTabs replacing a persisted shell tab
 // that restored dead (#991).
 func newShellTab(ts *tmux.TmuxSession) *Tab {
-	return &Tab{Name: shellTabName, Kind: TabKindShell, tmux: ts}
+	return &Tab{ID: newTabID(), Name: shellTabName, Kind: TabKindShell, tmux: ts}
 }
 
 // newRemoteAgentTab returns the Agent tab for a remote/hook-backed instance
@@ -102,14 +133,14 @@ func newShellTab(ts *tmux.TmuxSession) *Tab {
 // tmux session. It lets remote instances be tab-driven through the same Tabs
 // list as local ones.
 func newRemoteAgentTab() *Tab {
-	return &Tab{Name: agentTabName, Kind: TabKindAgent}
+	return &Tab{ID: newTabID(), Name: agentTabName, Kind: TabKindAgent}
 }
 
 // newWebTab returns a TabKindWeb tab pointing at url. It carries no tmux
 // session (web tabs have no PTY): the target is rendered as an iframe in the web
 // UI and as a placeholder in the TUI. The caller sets a unique display name.
 func newWebTab(url string) *Tab {
-	return &Tab{Name: webTabName, Kind: TabKindWeb, URL: url}
+	return &Tab{ID: newTabID(), Name: webTabName, Kind: TabKindWeb, URL: url}
 }
 
 // tabKindForData clamps a persisted TabKind to a known value, defaulting to

--- a/session/tab_spawn.go
+++ b/session/tab_spawn.go
@@ -129,7 +129,7 @@ func (i *Instance) AddProcessTab(command, requestedName string) (*Tab, error) {
 		return nil, fmt.Errorf("failed to start process tab: %w", err)
 	}
 
-	tab := &Tab{Name: displayName, Kind: TabKindProcess, Command: command, tmux: procTmux}
+	tab := &Tab{ID: newTabID(), Name: displayName, Kind: TabKindProcess, Command: command, tmux: procTmux}
 	i.mu.Lock()
 	// Re-check started AND status under the write lock before appending (see
 	// AddShellTab): Kill can have flipped started=false and snapshotted Tabs for

--- a/session/tab_stable_id_test.go
+++ b/session/tab_stable_id_test.go
@@ -1,0 +1,185 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/log"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The stable-tab-identity contract (#1738): a tab is minted with a stable id at
+// creation, persisted, and never reused, so a stream/pane binding addressed by
+// that id can never misroute after the ordinal list shifts under a reorder/close.
+// These tests pin the id itself (unique, persisted, backfilled) and the id→index
+// resolution the daemon stream endpoint runs — the concrete "reorder/close does
+// not misroute an id-addressed stream" guarantee.
+
+// TestTabsMintUniqueStableIDs: every tab constructor mints a non-empty id, and
+// spawning several tabs never collides — the property a stable key needs.
+func TestTabsMintUniqueStableIDs(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst, _ := raceMockInstance(t, "af_stable_mint", func() {})
+	shell, err := inst.AddShellTab()
+	require.NoError(t, err)
+	proc, err := inst.AddProcessTab("btop", "")
+	require.NoError(t, err)
+
+	agentID, ok := inst.TabIDAt(0)
+	require.True(t, ok)
+	assert.NotEmpty(t, agentID, "the agent tab must carry a stable id")
+	assert.NotEmpty(t, shell.ID, "a shell tab must carry a stable id")
+	assert.NotEmpty(t, proc.ID, "a process tab must carry a stable id")
+
+	ids := map[string]bool{agentID: true}
+	for _, id := range []string{shell.ID, proc.ID} {
+		assert.False(t, ids[id], "tab ids must be unique within an instance")
+		ids[id] = true
+	}
+}
+
+// TestTabIndexByID_ResolvesAfterClose is the core misroute-prevention proof: with
+// [agent, A, B, C], closing the MIDDLE tab A shifts B and C down by one ordinal,
+// yet each surviving tab's STABLE id still resolves to the tab the user meant —
+// B and C to their NEW ordinals, the closed A to nothing. A client that captured
+// B's id before the close therefore still streams B afterward, where a captured
+// ordinal (2) would now address C.
+func TestTabIndexByID_ResolvesAfterClose(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst, _ := raceMockInstance(t, "af_stable_close", func() {})
+	a, err := inst.AddProcessTab("a", "a")
+	require.NoError(t, err)
+	b, err := inst.AddProcessTab("b", "b")
+	require.NoError(t, err)
+	c, err := inst.AddProcessTab("c", "c")
+	require.NoError(t, err)
+
+	// Baseline: [agent, a, b, c] at ordinals 0..3.
+	requireIndex(t, inst, b.ID, 2)
+	requireIndex(t, inst, c.ID, 3)
+
+	// Close the middle tab a (ordinal 1); b and c shift down by one.
+	require.NoError(t, inst.CloseTab(1))
+
+	// b and c still resolve to the tab the user grabbed, now at their NEW ordinals.
+	requireIndex(t, inst, b.ID, 1)
+	requireIndex(t, inst, c.ID, 2)
+
+	// The captured ordinal 2, which named b before the close, now names c — the
+	// exact positional misroute a stable id prevents.
+	name, ok := inst.TabIDAt(2)
+	require.True(t, ok)
+	assert.Equal(t, c.ID, name, "ordinal 2 now names c (proving the ordinal drifted)")
+
+	// The closed tab's id resolves to nothing — a stream addressed by it is a clean
+	// miss, not a silent bind to whatever now sits at its old ordinal.
+	_, ok = inst.TabIndexByID(a.ID)
+	assert.False(t, ok, "a closed tab's id must resolve to no live tab")
+}
+
+// TestTabIndexByID_EmptyNeverResolves: an empty id (a legacy tab not yet
+// backfilled, or the no-tab_id path) never matches a real tab, so the daemon
+// falls back to the ordinal rather than binding id "" to Tabs[0].
+func TestTabIndexByID_EmptyNeverResolves(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst, _ := raceMockInstance(t, "af_stable_empty", func() {})
+	_, ok := inst.TabIndexByID("")
+	assert.False(t, ok, "an empty id must never resolve to a tab")
+}
+
+// TestTabStableID_PersistRoundTrip: a tab's stable id round-trips through
+// ToInstanceData → restoreLocalTabs unchanged, so a stream keyed on it survives a
+// daemon/af restart. A legacy record with no id is backfilled with a fresh one on
+// load (rollforward), so every restored tab is addressable by a stable id.
+func TestTabStableID_PersistRoundTrip(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst, _ := raceMockInstance(t, "af_stable_persist", func() {})
+	shell, err := inst.AddShellTab()
+	require.NoError(t, err)
+
+	data := inst.ToInstanceData()
+	require.Len(t, data.Tabs, 2)
+	agentID, _ := inst.TabIDAt(0)
+	assert.Equal(t, agentID, data.Tabs[0].ID, "the agent tab id must be serialized")
+	assert.Equal(t, shell.ID, data.Tabs[1].ID, "the shell tab id must be serialized")
+
+	// Restore into a fresh instance: ids are preserved verbatim.
+	restored := &Instance{Title: inst.Title, Program: inst.Program}
+	restoreLocalTabs(restored, data)
+	require.Len(t, restored.Tabs, 2)
+	assert.Equal(t, agentID, restored.Tabs[0].ID)
+	assert.Equal(t, shell.ID, restored.Tabs[1].ID)
+
+	// A legacy record (ids cleared) is backfilled with fresh, non-empty ids.
+	legacy := data
+	legacy.Tabs = make([]TabData, len(data.Tabs))
+	copy(legacy.Tabs, data.Tabs)
+	for i := range legacy.Tabs {
+		legacy.Tabs[i].ID = ""
+	}
+	backfilled := &Instance{Title: inst.Title, Program: inst.Program}
+	restoreLocalTabs(backfilled, legacy)
+	require.Len(t, backfilled.Tabs, 2)
+	for i, tab := range backfilled.Tabs {
+		assert.NotEmpty(t, tab.ID, "legacy tab %d must be backfilled with a stable id", i)
+	}
+}
+
+// TestEnsureBrokerFollowsTabAcrossClose proves the data-plane half of the fix: the
+// localAgentServer keys its per-tab PTY broker by the tab's STABLE id, not its
+// ordinal. So when the middle tab closes and a later tab shifts down, ensuring a
+// broker for that tab's NEW ordinal returns the SAME broker (bound to the same
+// live tmux) — never the closed tab's stale, dead-tmux broker the way an
+// ordinal-keyed map would after the shift.
+func TestEnsureBrokerFollowsTabAcrossClose(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst, _ := raceMockInstance(t, "af_stable_broker", func() {})
+	_, err := inst.AddProcessTab("a", "a")
+	require.NoError(t, err)
+	b, err := inst.AddProcessTab("b", "b")
+	require.NoError(t, err)
+
+	las := inst.AgentServer().(*localAgentServer)
+
+	// Bind a broker to b at its current ordinal (2). It is stored under b's id.
+	brBefore, err := las.ensureBroker(2)
+	require.NoError(t, err)
+	las.mu.Lock()
+	_, keyedByID := las.brokers[b.ID]
+	nBrokers := len(las.brokers)
+	las.mu.Unlock()
+	assert.True(t, keyedByID, "the broker must be keyed by the tab's stable id, not its ordinal")
+	assert.Equal(t, 1, nBrokers)
+
+	// Close the middle tab a (ordinal 1); b shifts to ordinal 1.
+	require.NoError(t, inst.CloseTab(1))
+	requireIndex(t, inst, b.ID, 1)
+
+	// Ensuring a broker for b's NEW ordinal returns the SAME broker — it followed the
+	// tab by id — and no stale duplicate is created.
+	brAfter, err := las.ensureBroker(1)
+	require.NoError(t, err)
+	assert.Same(t, brBefore, brAfter, "the broker must follow its tab across the ordinal shift")
+	las.mu.Lock()
+	nAfter := len(las.brokers)
+	las.mu.Unlock()
+	assert.Equal(t, 1, nAfter, "no stale second broker may be created for the shifted ordinal")
+}
+
+func requireIndex(t *testing.T, inst *Instance, id string, want int) {
+	t.Helper()
+	idx, ok := inst.TabIndexByID(id)
+	require.Truef(t, ok, "tab id %q must resolve to a live tab", id)
+	assert.Equalf(t, want, idx, "tab id %q must resolve to ordinal %d", id, want)
+}

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7286,9 +7286,10 @@ function wsScheme2() {
   return window.location.protocol === "https:" ? "wss:" : "ws:";
 }
 var AttachTerminal = class {
-  constructor(container, sessionId, token2, tab, cb) {
+  constructor(container, sessionId, token2, tabId, tab, cb) {
     this.sessionId = sessionId;
     this.token = token2;
+    this.tabId = tabId;
     this.tab = tab;
     this.cb = cb;
     this.term = new import_xterm.Terminal({
@@ -7386,7 +7387,9 @@ var AttachTerminal = class {
     const base = `${wsScheme2()}//${window.location.host}/v1/sessions/${encodeURIComponent(this.sessionId)}/stream`;
     const params = new URLSearchParams();
     params.set("access_token", this.token);
-    if (this.tab > 0) {
+    if (this.tabId !== "") {
+      params.set("tab_id", this.tabId);
+    } else if (this.tab > 0) {
       params.set("tab", String(this.tab));
     }
     if (this.seeded) {
@@ -7597,6 +7600,11 @@ var SplitView = class {
   // terminal tab. Parallel to the tab list, refreshed on every setSession, so
   // reconcile can mount an iframe for a web leaf without extra plumbing.
   tabTargets = [];
+  // The kind of each tab, parallel to tabIds — kept because the tab identity is now
+  // the opaque stable id (#1738), which no longer encodes the kind the way the old
+  // "kind:name" identity did. webTargetAt reads it to tell a web/iframe tab from a
+  // terminal one.
+  tabKinds = [];
   tree = null;
   focusedId = null;
   // Debounces the "focus left every pane" report so a click that moves focus A→B
@@ -7613,10 +7621,11 @@ var SplitView = class {
    * fresh single leaf bound to `initialTab`); the SAME session only re-validates the
    * tree against the current tab list (a tab closed elsewhere). Cheap on a no-op.
    */
-  setSession(sessionId, token2, tabIds, initialTab, tabTargets = []) {
+  setSession(sessionId, token2, tabIds, initialTab, tabTargets = [], tabKinds = []) {
     this.token = token2;
     this.tabIds = tabIds;
     this.tabTargets = tabTargets;
+    this.tabKinds = tabKinds;
     const tabCount = tabIds.length > 0 ? tabIds.length : 1;
     if (sessionId === null || token2 === null) {
       this.teardown();
@@ -7808,7 +7817,7 @@ var SplitView = class {
         pane.host.replaceChildren();
         pane.tab = leaf.tab;
         pane.status = "connecting";
-        pane.term = new AttachTerminal(pane.host, this.sessionId, this.token, leaf.tab, {
+        pane.term = new AttachTerminal(pane.host, this.sessionId, this.token, this.tabIds[leaf.tab] ?? "", leaf.tab, {
           onStatus: (s) => this.onPaneStatus(leaf.id, s),
           onFocusChange: (f) => this.onPaneFocus(leaf.id, f)
         });
@@ -7854,15 +7863,14 @@ var SplitView = class {
     return pane;
   }
   /** The iframe target for the tab at `idx`, or null when it is not a web tab.
-   *  Confirms the kind from tabIds (the "kind:name" identity) so a stale/mismatched
-   *  tabTargets entry can never turn a terminal tab into an iframe. */
+   *  Confirms the kind from the parallel tabKinds list (the identity is now the
+   *  opaque stable id, #1738) so a stale/mismatched tabTargets entry can never turn a
+   *  terminal tab into an iframe. */
   webTargetAt(idx) {
-    const identity = this.tabIds[idx];
-    if (!identity) {
+    if (idx < 0 || idx >= this.tabIds.length) {
       return null;
     }
-    const kind = Number.parseInt(identity.split(":", 1)[0] ?? "", 10);
-    if (kind !== TabKind.Web) {
+    if (this.tabKinds[idx] !== TabKind.Web) {
       return null;
     }
     return this.tabTargets[idx] ?? "";
@@ -8023,7 +8031,8 @@ var SplitView = class {
       return null;
     }
     if (typeof parsed === "object" && parsed !== null && typeof parsed.index === "number" && Array.isArray(parsed.tabs)) {
-      return parsed;
+      const p = parsed;
+      return { id: typeof p.id === "string" ? p.id : void 0, index: p.index, tabs: p.tabs };
     }
     return null;
   }
@@ -8056,12 +8065,17 @@ var SplitView = class {
       if (!drag || !this.tree) {
         return;
       }
-      const tab = drag.index;
-      if (tab < 0 || tab >= this.tabCount) {
-        return;
-      }
-      if (!sameTabs(drag.tabs, this.tabIds)) {
-        return;
+      let tab;
+      if (drag.id) {
+        tab = this.tabIds.indexOf(drag.id);
+        if (tab < 0) {
+          return;
+        }
+      } else {
+        tab = drag.index;
+        if (tab < 0 || tab >= this.tabCount || !sameTabs(drag.tabs, this.tabIds)) {
+          return;
+        }
       }
       const zone = this.zoneAt(pane.container, e.clientX, e.clientY);
       this.tree = zone === "center" ? replaceTab(this.tree, pane.leafId, tab) : splitLeaf(this.tree, pane.leafId, zone, tab);
@@ -8427,7 +8441,7 @@ function sessionTabs(s) {
   return [{ name: "agent", kind: 0 }];
 }
 function tabIdentity(tab) {
-  return `${tab.kind}:${tab.name}`;
+  return tab.id && tab.id !== "" ? tab.id : `${tab.kind}:${tab.name}`;
 }
 function tabLabel(tab) {
   if (tab.kind === 0) {
@@ -9000,7 +9014,8 @@ var AppShell = class {
       if (!Number.isInteger(index)) {
         return;
       }
-      e.dataTransfer.setData(TAB_DND_MIME, JSON.stringify({ index, tabs: this.currentTabIds }));
+      const id = this.currentTabIds[index] ?? "";
+      e.dataTransfer.setData(TAB_DND_MIME, JSON.stringify({ id, index, tabs: this.currentTabIds }));
       e.dataTransfer.effectAllowed = "move";
       document.body.classList.add("af-dragging-tab");
     });
@@ -9587,7 +9602,8 @@ function syncSplit(state) {
   const selected = selId ? state.sessions.find((s) => s.id === selId) : null;
   const tabIds = selected ? sessionTabs(selected).map(tabIdentity) : ["0:"];
   const tabTargets = selected ? sessionTabs(selected).map((t) => t.url) : [];
-  splitView.setSession(tok !== null ? selId : null, tok, tabIds, initialTab, tabTargets);
+  const tabKinds = selected ? sessionTabs(selected).map((t) => t.kind) : [];
+  splitView.setSession(tok !== null ? selId : null, tok, tabIds, initialTab, tabTargets, tabKinds);
 }
 function disposeSplit() {
   splitView.dispose();

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -850,9 +850,12 @@ function syncSplit(state: AppState): void {
   // The per-tab iframe target for web tabs (undefined for terminal tabs), parallel
   // to tabIds, so the split view can iframe a web leaf.
   const tabTargets = selected ? sessionTabs(selected).map((t) => t.url) : [];
+  // The kind of each tab, parallel to tabIds — the split view reads it to tell a web
+  // tab from a terminal one now that the identity is the opaque stable id (#1738).
+  const tabKinds = selected ? sessionTabs(selected).map((t) => t.kind) : [];
   // `tok !== null` not `tok`: "" is the authorized-tokenless credential (#1696), so a
   // loopback client still attaches its live panes.
-  splitView.setSession(tok !== null ? selId : null, tok, tabIds, initialTab, tabTargets);
+  splitView.setSession(tok !== null ? selId : null, tok, tabIds, initialTab, tabTargets, tabKinds);
 }
 
 function disposeSplit(): void {

--- a/web/src/split.ts
+++ b/web/src/split.ts
@@ -124,8 +124,11 @@ function webFallbackMs(): number {
 }
 
 /** The drag payload a tab-bar drag stamps into the dataTransfer (ui.ts): the dragged
- *  tab index plus a snapshot of the instance's ordered tab identities at drag time. */
+ *  tab's STABLE id (#1738) — what the drop resolves to a current ordinal, so a
+ *  mid-drag reorder/close can't misroute — plus the ordinal index and an ordered
+ *  identity snapshot as a legacy fallback for a tab with no id. */
 interface DragPayload {
+  id?: string;
   index: number;
   tabs: string[];
 }
@@ -147,6 +150,11 @@ export class SplitView {
   // terminal tab. Parallel to the tab list, refreshed on every setSession, so
   // reconcile can mount an iframe for a web leaf without extra plumbing.
   private tabTargets: (string | undefined)[] = [];
+  // The kind of each tab, parallel to tabIds — kept because the tab identity is now
+  // the opaque stable id (#1738), which no longer encodes the kind the way the old
+  // "kind:name" identity did. webTargetAt reads it to tell a web/iframe tab from a
+  // terminal one.
+  private tabKinds: number[] = [];
   private tree: LayoutNode | null = null;
   private focusedId: string | null = null;
 
@@ -177,10 +185,12 @@ export class SplitView {
     tabIds: string[],
     initialTab: number,
     tabTargets: (string | undefined)[] = [],
+    tabKinds: number[] = [],
   ): void {
     this.token = token;
     this.tabIds = tabIds;
     this.tabTargets = tabTargets;
+    this.tabKinds = tabKinds;
     const tabCount = tabIds.length > 0 ? tabIds.length : 1;
     if (sessionId === null || token === null) {
       this.teardown();
@@ -408,7 +418,10 @@ export class SplitView {
         pane.host.replaceChildren();
         pane.tab = leaf.tab;
         pane.status = "connecting";
-        pane.term = new AttachTerminal(pane.host, this.sessionId, this.token, leaf.tab, {
+        // Address the stream by the tab's STABLE id (#1738) at this ordinal, so a
+        // reorder/close resolves to the right PTY server-side; empty (a legacy tab
+        // without an id) makes AttachTerminal fall back to the ordinal ?tab=.
+        pane.term = new AttachTerminal(pane.host, this.sessionId, this.token, this.tabIds[leaf.tab] ?? "", leaf.tab, {
           onStatus: (s) => this.onPaneStatus(leaf.id, s),
           onFocusChange: (f) => this.onPaneFocus(leaf.id, f),
         });
@@ -462,15 +475,14 @@ export class SplitView {
   }
 
   /** The iframe target for the tab at `idx`, or null when it is not a web tab.
-   *  Confirms the kind from tabIds (the "kind:name" identity) so a stale/mismatched
-   *  tabTargets entry can never turn a terminal tab into an iframe. */
+   *  Confirms the kind from the parallel tabKinds list (the identity is now the
+   *  opaque stable id, #1738) so a stale/mismatched tabTargets entry can never turn a
+   *  terminal tab into an iframe. */
   private webTargetAt(idx: number): string | null {
-    const identity = this.tabIds[idx];
-    if (!identity) {
+    if (idx < 0 || idx >= this.tabIds.length) {
       return null;
     }
-    const kind = Number.parseInt(identity.split(":", 1)[0] ?? "", 10);
-    if (kind !== TabKind.Web) {
+    if (this.tabKinds[idx] !== TabKind.Web) {
       return null;
     }
     return this.tabTargets[idx] ?? "";
@@ -670,7 +682,8 @@ export class SplitView {
       typeof (parsed as DragPayload).index === "number" &&
       Array.isArray((parsed as DragPayload).tabs)
     ) {
-      return parsed as DragPayload;
+      const p = parsed as DragPayload;
+      return { id: typeof p.id === "string" ? p.id : undefined, index: p.index, tabs: p.tabs };
     }
     return null;
   }
@@ -705,21 +718,25 @@ export class SplitView {
       if (!drag || !this.tree) {
         return;
       }
-      const tab = drag.index;
-      // Reject an out-of-range index (a stale payload / a tab closed mid-drag): a pane
-      // must never bind to a nonexistent tab (same stale-index discipline as the tab-op
-      // fixes in #1698/#1710).
-      if (tab < 0 || tab >= this.tabCount) {
-        return;
-      }
-      // Reject an IN-RANGE-but-STALE drop (#1738 repro): if the instance's tab set
-      // changed since dragstart — a concurrent client closed/created/reordered a tab —
-      // the dragged index now points at a DIFFERENT live tab than the user grabbed, so
-      // splitting would silently bind the new pane to the wrong tab's stream. Compare
-      // the drag-time snapshot to the live identities and cancel on any mismatch; the
-      // user simply re-drags. (The full stable-tab-id fix is daemon-wide, in #1738.)
-      if (!sameTabs(drag.tabs, this.tabIds)) {
-        return;
+      // Resolve the dragged tab by its STABLE id (#1738) to its CURRENT ordinal: this
+      // is the misroute fix. Even if a concurrent client reordered/closed tabs
+      // mid-drag, indexOf lands on wherever the SAME tab now sits (or -1 if it was
+      // closed → cancel), so the drop can never bind the new pane to a different live
+      // tab the way a trusted drag-time index could.
+      let tab: number;
+      if (drag.id) {
+        tab = this.tabIds.indexOf(drag.id);
+        if (tab < 0) {
+          return; // the dragged tab was closed mid-drag — nothing to bind
+        }
+      } else {
+        // Legacy fallback for a payload with no stable id (pre-#1738 tab): trust the
+        // drag-time index but keep the #1737 mid-drag guard — reject if the tab set
+        // changed since dragstart, and reject an out-of-range index.
+        tab = drag.index;
+        if (tab < 0 || tab >= this.tabCount || !sameTabs(drag.tabs, this.tabIds)) {
+          return;
+        }
       }
       const zone = this.zoneAt(pane.container, e.clientX, e.clientY);
       this.tree = zone === "center" ? replaceTab(this.tree, pane.leafId, tab) : splitLeaf(this.tree, pane.leafId, zone, tab);

--- a/web/src/tab_identity.test.ts
+++ b/web/src/tab_identity.test.ts
@@ -1,0 +1,28 @@
+// Unit coverage for the stable tab identity (#1738). tabIdentity is what the tab
+// bar snapshots at dragstart and the drop resolves against: it must now be the
+// daemon-minted STABLE id (never reused across a close+recreate), retiring the old
+// "kind:name" identity — whose one gap was two tabs sharing a kind:name. The legacy
+// kind:name is kept only as a fallback for a record with no id.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { tabIdentity } from "./ui.js";
+
+test("tabIdentity is the daemon stable id when present", () => {
+  assert.equal(tabIdentity({ id: "deadbeefcafef00d", name: "shell", kind: 1 }), "deadbeefcafef00d");
+});
+
+test("tabIdentity distinguishes two tabs that share a kind:name once they carry ids", () => {
+  // The exact residual #1738 closes: a "shell" closed and a fresh "shell" created
+  // share kind:name, but their stable ids differ — so the drag guard can no longer
+  // be fooled into binding a pane to the replacement.
+  const a = tabIdentity({ id: "id-old", name: "shell", kind: 1 });
+  const b = tabIdentity({ id: "id-new", name: "shell", kind: 1 });
+  assert.notEqual(a, b);
+});
+
+test("tabIdentity falls back to kind:name for a legacy tab with no id", () => {
+  assert.equal(tabIdentity({ name: "shell", kind: 1 }), "1:shell");
+  assert.equal(tabIdentity({ id: "", name: "agent", kind: 0 }), "0:agent");
+});

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -105,6 +105,7 @@ export class AttachTerminal {
     container: HTMLElement,
     private readonly sessionId: string,
     private readonly token: string,
+    private readonly tabId: string,
     private readonly tab: number,
     private readonly cb: TerminalCallbacks,
   ) {
@@ -204,9 +205,14 @@ export class AttachTerminal {
     const base = `${wsScheme()}//${window.location.host}/v1/sessions/${encodeURIComponent(this.sessionId)}/stream`;
     const params = new URLSearchParams();
     params.set("access_token", this.token);
-    // Select the bound tab (parseTab in daemon/ws_pty.go: empty/absent = 0 = the
-    // agent tab). Sent only for a non-agent tab so the agent-tab URL is unchanged.
-    if (this.tab > 0) {
+    // Address the bound tab by its STABLE id (#1738) so a reorder/close server-side
+    // resolves to the right PTY — the daemon maps ?tab_id= to the tab's current
+    // ordinal. Fall back to the ordinal ?tab= for a legacy tab with no id (parseTab
+    // in daemon/ws_pty.go: empty/absent = 0 = the agent tab), keeping the agent-tab
+    // URL unchanged when neither is needed.
+    if (this.tabId !== "") {
+      params.set("tab_id", this.tabId);
+    } else if (this.tab > 0) {
       params.set("tab", String(this.tab));
     }
     if (this.seeded) {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -96,6 +96,11 @@ export interface SessionData {
  *  display name and the kind (index 0 / TabKind.Agent is the unclosable agent
  *  tab). Field names match the Go JSON tags so this decodes the projection as-is. */
 export interface TabData {
+  /** The tab's stable id (session/storage.go TabData.ID, #1738): minted at
+   *  creation and never reused, so the web addresses a tab's stream (?tab_id=) and
+   *  its DnD/pane binding by this id rather than the ordinal, which shifts on a
+   *  reorder/close. Absent only for a legacy record written before #1738. */
+  id?: string;
   name: string;
   kind: number;
   command?: string;

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -156,21 +156,22 @@ export function supportsTabManagement(s: SessionData): boolean {
 /** The selected session's tabs, always non-empty: a pre-#930 record with no tabs
  *  is shown as a single implicit agent tab so the bar (and index math) never sees
  *  an empty list. */
-export function sessionTabs(s: SessionData): { name: string; kind: number; url?: string }[] {
+export function sessionTabs(s: SessionData): { id?: string; name: string; kind: number; url?: string }[] {
   if (s.tabs && s.tabs.length > 0) {
     return s.tabs;
   }
   return [{ name: "agent", kind: 0 }];
 }
 
-/** A stable-ish client-side IDENTITY for a tab (feat: split tabs), used to detect a
- *  tab set that changed mid-drag. It is NOT a daemon tab id (there is none yet — the
- *  full stable-id fix is #1738); it is the best identity the client has: the tab's
- *  kind + name. The ordered list of these is snapshotted at dragstart and re-checked
- *  at drop, so a concurrent close/create/reorder cancels the drop instead of binding a
- *  pane to the wrong live tab. */
-export function tabIdentity(tab: { name: string; kind: number }): string {
-  return `${tab.kind}:${tab.name}`;
+/** The STABLE IDENTITY for a tab (#1738): the daemon-minted, never-reused tab id
+ *  (session.TabData.ID). It is what a stream (?tab_id=) and a DnD/pane binding
+ *  address the tab by, so a reorder/close can't misroute — the drop resolves this
+ *  id to the tab's CURRENT ordinal instead of trusting the drag-time position. Falls
+ *  back to the legacy kind:name for a record written before #1738 (no id): still a
+ *  per-tab string, just not collision-proof against a close+recreate of the same
+ *  name — the exact residual #1738 closes once every record carries an id. */
+export function tabIdentity(tab: { id?: string; name: string; kind: number }): string {
+  return tab.id && tab.id !== "" ? tab.id : `${tab.kind}:${tab.name}`;
 }
 
 /** The label a tab reads as, mirroring the TUI's labelForTab (ui/tree/labels.go):
@@ -929,7 +930,12 @@ export class AppShell {
       if (!Number.isInteger(index)) {
         return;
       }
-      e.dataTransfer.setData(TAB_DND_MIME, JSON.stringify({ index, tabs: this.currentTabIds }));
+      // Stamp the dragged tab's STABLE id (#1738) so the drop resolves it to the
+      // tab's CURRENT ordinal — correct even if a concurrent client reordered/closed
+      // tabs mid-drag. index + the identity snapshot ride along as a legacy fallback
+      // for a tab without an id (pre-#1738 record).
+      const id = this.currentTabIds[index] ?? "";
+      e.dataTransfer.setData(TAB_DND_MIME, JSON.stringify({ id, index, tabs: this.currentTabIds }));
       e.dataTransfer.effectAllowed = "move";
       document.body.classList.add("af-dragging-tab");
     });


### PR DESCRIPTION
## What & why

Closes #1738. Tabs were addressed **by ordinal index** everywhere — the PTY stream (`/v1/sessions/{id}/stream?tab=<idx>`), the web drag-and-drop payload, and the web/TUI pane bindings. Because the address was positional, an index captured at one moment could silently refer to a **different** tab after a reorder/close (the same "key by ordinal, not stable id" class as the cross-repo-title collision #1678). #1737's mid-drag web guard *mitigated* the symptom; its one inherent gap — a mid-drag replacement by a tab with an identical `kind:name` — is only closable with a real **stable tab id**, which this PR delivers end-to-end.

The goal: **a tab reorder/close never misroutes a stream or a pane binding.**

## Design — one stable identity, resolved at the edge

Each tab gets a stable `ID`, minted at creation, persisted, and never reused (mirrors the instance-`ID` / `BranchCreatedByUs` rollforward precedent). Streams and bindings address the tab by that id; the **daemon resolves id → current ordinal on every operation**, so a shift under another client can't make a captured position refer to a different tab. The `AgentServer` interface keeps its `tab int` (the agent-server-local address, correctly resolved per call) — id resolution lives in the daemon/client layer that owns the tab list.

### (a) Daemon + session model
- `session.Tab.ID` (+ `TabData.ID`, `json:"id,omitempty"`): minted in every tab constructor, serialized in `ToInstanceData`, restored verbatim, and **backfilled with a fresh id** for a legacy record written before this change.
- `Instance.TabIDAt(idx)` / `TabIndexByID(id)`: the index↔id resolution.
- **Brokers keyed by stable id.** `localAgentServer.brokers` is now `map[string]*ptyBroker` keyed by the tab's id (resolved from the caller's index in `ensureBroker`). A broker follows its tab across a reorder/close — after tab 1 of `[agent,A,B]` closes, `B`'s broker is still found under `B`'s id even though `B` is now at index 1, so a new subscriber for `B` never lands on `A`'s stale (dead-tmux) broker the way an index-keyed map would.
- **Stream endpoint** (`/v1/sessions/{id}/stream`) accepts `?tab_id=<id>` (preferred) and keeps `?tab=<idx>` as the compatibility fallback. The connection holds the id and **re-resolves per frame** (initial `Subscribe` and each `Input`/`Resize`), so a keystroke/resize can't land on a different tab after a mid-connection shift; a since-closed tab no longer resolves and the frame is dropped rather than misrouted. A `?tab_id=` that names no live tab is a clean 404, not a silent fall-through to a stale ordinal.
- `Preview` RPC gains `TabID` (prefers it, falls back to the ordinal).
- The in-sandbox headless agent-server stays ordinal-addressed: the orchestrator resolves the id before forwarding over the remote hop, and a sandbox's tab set is fixed for its lifetime.

### (b) Web
- `TabData.id` added; **`tabIdentity` is now the real stable id** (retiring the `kind:name` stopgap; falls back to `kind:name` only for a legacy id-less record).
- **DnD binds by id.** The drag payload carries the dragged tab's stable id; the drop resolves it to the tab's *current* ordinal (`indexOf`) — correct even after a concurrent reorder, and a clean cancel if the tab was closed. The legacy index + `sameTabs` guard remains only for an id-less payload.
- The pane's `AttachTerminal` streams `?tab_id=` for its bound tab.
- `web/dist` rebuilt.

### (c) TUI
- `DialStream`/`AttachStream`/the Preview source thread the pane's stable tab id (from `TabIDAt`); empty falls back to the ordinal. The daemon is authoritative for tab ids — `ReconcileTabsFromData` adopts the daemon's id into name-matched local tabs, and `AttachShellTab` leaves its id empty (positional, safe) until that sync, so a TUI-created tab never invents a competing id.

## Tests
- `session/tab_stable_id_test.go`: ids are unique + non-empty; **`TabIndexByID` resolves the right tab after a middle-tab close** (the ordinal drifts, the id doesn't); empty id never resolves; persistence round-trips ids and backfills legacy; **the broker follows its tab across a close** (id-keyed, no stale duplicate).
- `web/src/tab_identity.test.ts`: `tabIdentity` is the stable id, distinguishes two tabs that share a `kind:name`, and falls back to `kind:name` when id-less.
- Existing broker/stream/attach tests migrated to the id-keyed map / new signatures.

## Gates
`go build`, `gofmt`, `go vet`, `golangci-lint --fast`, `deadcode`, file-length lint, `make docs` (no diff), `make web-test` (110), `make test-container`, `make web-selftest-container`, `make tui-driver-selftest` — all green. `web/dist` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
