### PR TITLE
fix(cli): reject daemon/agent-server URLs with empty hostname at validation (#1784)

### DIFF
--- a/apiclient/remote.go
+++ b/apiclient/remote.go
@@ -106,6 +106,13 @@ func NewRemote(daemonURL, token string) (*Client, error) {
 // clear HTTP-only error — af removed TLS, so a client pointed at a wss:// URL is
 // almost certainly a stale config from the old pinned-TLS listener. Only the
 // scheme and authority are used; any path or query on the URL is ignored.
+//
+// The host check tests u.Hostname(), not u.Host: net/url parses `http://:8443`
+// into a NON-empty Host (":8443") with an empty Hostname, so a u.Host check
+// admits a hostless URL and defers the failure to an opaque `dial tcp :8443:
+// connect: connection refused` (#1784). That form is what an unset variable
+// expands to (`AF_DAEMON_URL="http://${DAEMON_HOST}:8443"`), so it is the case
+// most worth naming precisely.
 func parseDaemonURL(daemonURL string) (httpBase, wsBase string, err error) {
 	u, err := url.Parse(strings.TrimSpace(daemonURL))
 	if err != nil {
@@ -121,8 +128,9 @@ func parseDaemonURL(daemonURL string) (httpBase, wsBase string, err error) {
 	default:
 		return "", "", fmt.Errorf("--daemon-url %q must be an http:// or ws:// URL", daemonURL)
 	}
-	if u.Host == "" {
-		return "", "", fmt.Errorf("--daemon-url %q has no host:port", daemonURL)
+	if u.Hostname() == "" {
+		return "", "", fmt.Errorf("invalid --daemon-url %q: missing host; use http://HOST:PORT "+
+			"(if this URL came from a variable, it likely expanded empty)", daemonURL)
 	}
 	return "http://" + u.Host, "ws://" + u.Host, nil
 }

--- a/apiclient/remote_test.go
+++ b/apiclient/remote_test.go
@@ -57,6 +57,32 @@ func TestParseDaemonURL_AcceptsHTTPSchemesRejectsTLS(t *testing.T) {
 	}
 }
 
+// TestParseDaemonURL_RejectsEmptyHost pins the #1784 contract: a URL carrying a
+// scheme but no host is rejected at VALIDATION with the actionable "missing host"
+// message, not admitted and left to fail later as `dial tcp :8443: connect:
+// connection refused`. The `:8443` / `:` forms are the regression that matters —
+// net/url gives them a non-empty Host, so the old u.Host check waved them
+// through; they are exactly what `http://${DAEMON_HOST}:8443` expands to when the
+// variable is unset.
+func TestParseDaemonURL_RejectsEmptyHost(t *testing.T) {
+	for _, in := range []string{"http://:8443", "ws://:8443", "http://:", "http:///path", "ws://", "http://"} {
+		_, _, err := parseDaemonURL(in)
+		if err == nil {
+			t.Fatalf("parseDaemonURL(%q): want error, got nil", in)
+		}
+		if !strings.Contains(err.Error(), "missing host") {
+			t.Fatalf("parseDaemonURL(%q): want actionable missing-host error, got %v", in, err)
+		}
+	}
+	// A real host — including the IPv6 literal whose brackets Hostname() strips —
+	// still parses, so the check narrows nothing it shouldn't.
+	for _, in := range []string{"http://host:8443", "http://[::1]:8443"} {
+		if _, _, err := parseDaemonURL(in); err != nil {
+			t.Fatalf("parseDaemonURL(%q): unexpected error %v", in, err)
+		}
+	}
+}
+
 // clearTargetEnv unsets every AF_DAEMON_* env var (and any bound flag) so a test's
 // remote-target resolution starts from a known-empty state, then restores the flag
 // vars on cleanup. Env vars are cleared via t.Setenv, which auto-restores.

--- a/session/agentserver_remote.go
+++ b/session/agentserver_remote.go
@@ -556,7 +556,9 @@ func (c *remoteAgentClient) dialStream(ctx context.Context, tab int) (*websocket
 // on one HTTP listener) and rejects the TLS schemes wss/https — the agent-server
 // is HTTP-only (af terminates no TLS; the sandbox is reached over a private hop).
 // Only scheme+authority are used. It mirrors apiclient's parseDaemonURL but with
-// agent-server-appropriate error text.
+// agent-server-appropriate error text — including its u.Hostname() host check,
+// which (unlike u.Host) rejects the hostless `http://:8443` form instead of
+// deferring it to an opaque dial error (#1784).
 func splitHTTPBaseURL(raw string) (httpBase, wsBase string, err error) {
 	u, err := url.Parse(strings.TrimSpace(raw))
 	if err != nil {
@@ -569,8 +571,8 @@ func splitHTTPBaseURL(raw string) (httpBase, wsBase string, err error) {
 	default:
 		return "", "", fmt.Errorf("agent-server URL %q must be an http:// or ws:// URL", raw)
 	}
-	if u.Host == "" {
-		return "", "", fmt.Errorf("agent-server URL %q has no host:port", raw)
+	if u.Hostname() == "" {
+		return "", "", fmt.Errorf("invalid agent-server URL %q: missing host; use http://HOST:PORT", raw)
 	}
 	return "http://" + u.Host, "ws://" + u.Host, nil
 }

--- a/session/agentserver_remote_test.go
+++ b/session/agentserver_remote_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -51,6 +52,7 @@ func TestNewRemoteAgentServer_ValidatesEndpoint(t *testing.T) {
 		{"tls scheme wss", AgentServerEndpoint{URL: "wss://host:1"}, "t"},
 		{"tls scheme https", AgentServerEndpoint{URL: "https://host:1"}, "t"},
 		{"no host", AgentServerEndpoint{URL: "http://"}, "t"},
+		{"port but no host", AgentServerEndpoint{URL: "http://:8443"}, "t"},
 		{"empty title", AgentServerEndpoint{URL: "http://host:1"}, ""},
 	}
 	for _, tc := range cases {
@@ -70,6 +72,28 @@ func TestNewRemoteAgentServer_ValidatesEndpoint(t *testing.T) {
 		}
 		if _, ok := as.(*remoteAgentServer); !ok {
 			t.Fatalf("expected *remoteAgentServer, got %T", as)
+		}
+	}
+}
+
+// TestSplitHTTPBaseURL_RejectsEmptyHost is the agent-server half of the #1784
+// contract, mirroring apiclient's TestParseDaemonURL_RejectsEmptyHost: a hostless
+// URL fails at validation with an actionable message rather than at dial time. The
+// `:8443` / `:` forms are the regression — net/url leaves their Host non-empty, so
+// the old u.Host check admitted them.
+func TestSplitHTTPBaseURL_RejectsEmptyHost(t *testing.T) {
+	for _, in := range []string{"http://:8443", "ws://:8443", "http://:", "http:///path", "ws://", "http://"} {
+		_, _, err := splitHTTPBaseURL(in)
+		if err == nil {
+			t.Fatalf("splitHTTPBaseURL(%q): want error, got nil", in)
+		}
+		if !strings.Contains(err.Error(), "missing host") {
+			t.Fatalf("splitHTTPBaseURL(%q): want actionable missing-host error, got %v", in, err)
+		}
+	}
+	for _, in := range []string{"http://host:8443", "http://[::1]:8443"} {
+		if _, _, err := splitHTTPBaseURL(in); err != nil {
+			t.Fatalf("splitHTTPBaseURL(%q): unexpected error %v", in, err)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #1784.

## The bug (verified, reproduces)

A daemon or agent-server URL with a scheme but **no host** passed validation and failed much later with an error pointing at the wrong layer:

```
$ af sessions list --daemon-url "http://:8443"
{"error":"Post \"http://:8443/v1/Snapshot\": dial tcp :8443: connect: connection refused"}
```

`net/url` parses `http://:8443` into a **non-empty** `Host` (`":8443"`) with an **empty** `Hostname()`, so the `u.Host == ""` guard in `parseDaemonURL` (`apiclient/remote.go`) and `splitHTTPBaseURL` (`session/agentserver_remote.go`) waved it through.

That form is exactly what an unset variable expands to — `AF_DAEMON_URL="http://${DAEMON_HOST}:8443"` — which is precisely when a user most needs to be told the host is missing rather than handed a connection error.

**Narrower than the issue title suggests.** The fully-hostless forms (`http://`, `ws://`, `http:///path`) were *already* rejected — their `Host` is genuinely empty. Only the `:port`-without-host forms slipped through. I verified each case before changing anything.

## The fix

Both validators now check `u.Hostname()` and reject with an actionable message:

```
$ af sessions list --daemon-url "http://:8443"
{"error":"invalid --daemon-url \"http://:8443\": missing host; use http://HOST:PORT (if this URL came from a variable, it likely expanded empty)"}
```

The already-rejected forms now share the clearer message. Valid URLs are unaffected — including IPv6 literals, whose brackets `Hostname()` strips (`http://[::1]:8443` still resolves and dials).

## Adjacent sites audited

Grepped every `url.Parse` validation site; the two fixed here were the complete set:

| Site | Status |
|---|---|
| `apiclient/remote.go` `parseDaemonURL` | **fixed** |
| `session/agentserver_remote.go` `splitHTTPBaseURL` | **fixed** |
| `session/weburl.go` | already `Hostname()` — the precedent the issue cites |
| `commands/bugreport_github.go` | already `Hostname()` |
| `daemon/webtab_proxy.go` | parses only behind `IsLoopbackWebTarget`, which fails closed on an empty host |

## Verification

Tests pin the regression at both sites — I confirmed they **fail** against the old `u.Host` guard and pass with the fix, so they'd catch a reintroduction:

```
parseDaemonURL("http://:8443"): want error, got nil          # pre-fix
splitHTTPBaseURL("http://:8443"): want error, got nil        # pre-fix
```

Also exercised the real binary end-to-end, including the reported env-var trigger and the valid-URL/IPv6 paths (reaching dial, not rejected).

Gates: `make test-container` all packages green · `make tui-driver-selftest` 31/31 · `go build ./...` · `gofmt -l .` clean · `golangci-lint --fast` clean · `deadcode -test ./...` clean · file-length lint passed.

Not merging — flagging for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)