### PR TITLE
fix(task): a ready-at-deadline agent counts as ready, not a timeout-kill (#1783)

### DIFF
--- a/task/runner.go
+++ b/task/runner.go
@@ -303,6 +303,18 @@ func WaitForReady(ctx context.Context, instance *session.Instance) error {
 			if perr := limitParkError(detector, content, agent); perr != nil {
 				return perr
 			}
+			// The deadline firing is not itself proof of failure — only the pane
+			// is. The pane is sampled every waitForReadyPollInterval, so an agent
+			// that renders its prompt during the final poll gap is first observed
+			// HERE, and at the exact boundary the runtime may pick this branch over
+			// an equally-ready ticker tick. Either way the capture above already
+			// shows the agent is up, so honor it exactly as the ticker branch does:
+			// reporting a timeout would make the create path kill a healthy, ready
+			// session (#1783). Checked after limitParkError, mirroring the ticker
+			// branch's ordering.
+			if isReadyContent(content, agent) {
+				return nil
+			}
 			log.ErrorLog.Printf("waitForReady timed out. Last pane content: %s", content)
 			return formatWaitForReadyTimeoutError(waitForReadyTimeout, content)
 		case <-ticker.C:

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -264,6 +264,39 @@ func TestWaitForReadyNonAgentBecomesReadyOnAnyOutput(t *testing.T) {
 	}
 }
 
+// TestWaitForReadyReadyAtTimeoutBoundaryIsReady pins #1783: an agent whose ready
+// prompt is on the pane when the readiness deadline fires must be reported READY,
+// not timed out. The timeout branch captures the pane just like the ticker branch
+// does, so it must honor the same readiness signal — otherwise a session that IS
+// ready gets a timeout error, and the create path reacts by killing it (data loss).
+//
+// The window is real at production timings: the pane is only sampled every
+// waitForReadyPollInterval (500ms), so an agent that renders its prompt during the
+// final poll gap is first observed by the timeout branch. Pinning poll > timeout
+// makes that ordering deterministic instead of racing the boundary: the ticker can
+// never fire, so the timeout branch is the only branch that ever sees the pane —
+// and it sees a pane that is unambiguously ready.
+func TestWaitForReadyReadyAtTimeoutBoundaryIsReady(t *testing.T) {
+	defer setWaitForReadyTimingForTest(50*time.Millisecond, time.Hour)()
+	defer setWaitLimitForTest(NewLimitDetector(nil), time.Now)()
+
+	inst := newPreviewInstance(t, func() (string, error) {
+		return "claude ready\n❯ ", nil // claude's ready glyph is already on the pane
+	})
+
+	done := make(chan error, 1)
+	go func() { done <- WaitForReady(context.Background(), inst) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("a pane showing the ready prompt when the deadline fires must be READY, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("WaitForReady never returned")
+	}
+}
+
 // setWaitForReadyTimingForTest shrinks the poll/timeout knobs so the polling
 // loop runs in milliseconds, and returns a restore func.
 func setWaitForReadyTimingForTest(timeout, poll time.Duration) func() {


### PR DESCRIPTION
Fixes #1783.

## Verified, not assumed

The report reproduces on current master. `WaitForReady`'s timeout branch captures the pane, checks it for a usage-limit banner, then returns a timeout error **without ever asking whether the captured content shows the ready prompt** — a check the ticker branch (`task/runner.go:336`) has always done.

The pre-fix failure is self-incriminating — the timeout error quotes the ready glyph back in its own message:

```
a pane showing the ready prompt when the deadline fires must be READY,
got timed out waiting for program to start (50ms)
last pane content:
  claude ready
  ❯
```

## Why it matters

This is data loss, not a cosmetic error message. The create path treats any startup error as fatal:

```go
if serr := finishCreateStart(...); serr != nil {
    _ = instance.Kill()   // a ready session, destroyed
```

The window is wider than "exact boundary": the pane is sampled every `waitForReadyPollInterval` (500ms) against a 60s budget, so **any** agent that renders its prompt during the final poll gap is first observed by the timeout branch. At the exact boundary the runtime may additionally pick `timeout` over an equally-ready `ticker.C`. In both cases the branch held proof the agent was up and discarded it.

## Fix

Mirror the ticker branch — check `isReadyContent` after `limitParkError`, same ordering. 12 lines, 10 of them comment.

## Regression test

`TestWaitForReadyReadyAtTimeoutBoundaryIsReady` pins the boundary **deterministically** rather than racing it: with `poll > timeout` the ticker can never fire, so the timeout branch is the only branch that ever sees the pane — and it sees one that is unambiguously ready. Fails pre-fix, passes after, 30/30 runs stable.

## Adjacent-site audit

`session/tmux/start.go:48` has the same `case <-timeout:` shape but is **not** the same anti-pattern: its loop guard `for !t.DoesSessionExist()` re-evaluates live state each iteration, so it never holds proof-of-success and discards it. Left alone.

## History

Introduced in 1399266d. Survived #979/#989/#1146, which mirrored `ErrSessionGone` and limit-park into *both* branches but never the readiness check itself.

## Gates

| Gate | Result |
|---|---|
| `make test-container` | green (all packages) |
| `make tui-driver-selftest` | 31/31 steps green |
| `go build ./...` | clean |
| `gofmt -l .` | clean |
| `golangci-lint run --fast` | clean |
| `deadcode -test ./...` | clean |
| `scripts/lint-file-length.sh` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)