### PR TITLE
fix(tui): drop PR info fetched for a project we switched away from (#1780)

### DIFF
--- a/app/daemon_mutation_routing_test.go
+++ b/app/daemon_mutation_routing_test.go
@@ -109,7 +109,7 @@ func TestPrInfoUpdatedMsg_RoutesWriteThroughDaemon(t *testing.T) {
 	defer restore()
 
 	info := &sessiongit.PRInfo{Number: 42, Title: "add feature", URL: "https://x/42", State: "OPEN"}
-	_, _ = h.Update(prInfoUpdatedMsg{instance: inst, info: info})
+	_, _ = h.Update(prInfoUpdatedMsg{instance: inst, repoID: h.repoID, info: info})
 
 	require.Equal(t, inst.Title, gotTitle, "SetPRInfo must target the resolved session")
 	require.Equal(t, h.repoID, gotRepo, "SetPRInfo must be scoped to the TUI's repo")
@@ -143,7 +143,7 @@ func TestPrInfoUpdatedMsg_BranchMismatchSkipsDaemon(t *testing.T) {
 
 	info := &sessiongit.PRInfo{Number: 99, Title: "wrong branch", State: "OPEN"}
 	// The fetch was kicked off for a different branch than the instance now has.
-	_, _ = h.Update(prInfoUpdatedMsg{instance: inst, branch: "feature-y", info: info})
+	_, _ = h.Update(prInfoUpdatedMsg{instance: inst, branch: "feature-y", repoID: h.repoID, info: info})
 
 	require.False(t, called, "a branch mismatch must not write PR info to the daemon")
 	require.Nil(t, inst.GetPRInfo(), "a branch mismatch must not apply the badge")

--- a/app/home_panes.go
+++ b/app/home_panes.go
@@ -61,7 +61,7 @@ func (m *home) selectionChanged() tea.Cmd {
 		// hasn't been fetched recently. fetchPRInfoCmd is a no-op when the
 		// data is still fresh, so rapid Up/Down navigation doesn't hammer gh.
 		if !attachedNow && selected != nil && selected.Started() {
-			prFetch = fetchPRInfoCmd(selected, false)
+			prFetch = fetchPRInfoCmd(selected, m.repoID, false)
 		}
 	} else {
 		// Header row: the menu drops the instance-specific hints; the open

--- a/app/home_update.go
+++ b/app/home_update.go
@@ -76,9 +76,19 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tickUpdatePRInfoCmd
 		}
 		selected := m.sidebar.GetSelectedInstance()
-		return m, tea.Batch(tickUpdatePRInfoCmd, fetchPRInfoCmd(selected, true))
+		return m, tea.Batch(tickUpdatePRInfoCmd, fetchPRInfoCmd(selected, m.repoID, true))
 	case prInfoUpdatedMsg:
 		detachTraceMark("prInfoUpdatedMsg-handler-entry")
+		// Drop PR info fetched for a repo we have since switched away from
+		// (#1780). An in-place project switch (#1461) resets the store and swaps
+		// m.repoID, so the title-only re-resolution below can land the previous
+		// project's result on a same-title session in the new project — and the
+		// branch guard misses it when both sessions share a branch name. Gate on
+		// the captured repo first, mirroring snapshotFetchedMsg. No tick re-arm
+		// here: the PR-info tick re-arms itself in tickUpdatePRInfoMessage.
+		if msg.repoID != m.repoID {
+			return m, nil
+		}
 		// msg.instance is the pointer captured when the async gh fetch kicked
 		// off. A background refresh can swap it out of the sidebar while the
 		// fetch is in flight — RemoveInstanceByTitle + a rebuilt

--- a/app/pr_info_test.go
+++ b/app/pr_info_test.go
@@ -63,8 +63,8 @@ func newStartedInstance(t *testing.T, title string) *session.Instance {
 // ----------------------------------------------------------------------------
 
 func TestFetchPRInfoCmd_NilInstance_ReturnsNil(t *testing.T) {
-	assert.Nil(t, fetchPRInfoCmd(nil, false))
-	assert.Nil(t, fetchPRInfoCmd(nil, true))
+	assert.Nil(t, fetchPRInfoCmd(nil, "", false))
+	assert.Nil(t, fetchPRInfoCmd(nil, "", true))
 }
 
 // TestFetchPRInfoCmd_RemoteInstance_ReturnsNil — remote sessions have no
@@ -74,8 +74,8 @@ func TestFetchPRInfoCmd_RemoteInstance_ReturnsNil(t *testing.T) {
 	inst.SetBackend(&session.HookBackend{})
 	require.True(t, inst.Capabilities().Workspace == session.WorkspaceRemote, "sanity: instance should report as remote")
 
-	assert.Nil(t, fetchPRInfoCmd(inst, false))
-	assert.Nil(t, fetchPRInfoCmd(inst, true), "force must not override the remote guard")
+	assert.Nil(t, fetchPRInfoCmd(inst, "", false))
+	assert.Nil(t, fetchPRInfoCmd(inst, "", true), "force must not override the remote guard")
 }
 
 // TestFetchPRInfoCmd_NotStarted_ReturnsNil — FetchPRInfoSnapshot returns an
@@ -88,8 +88,8 @@ func TestFetchPRInfoCmd_NotStarted_ReturnsNil(t *testing.T) {
 	require.NoError(t, err)
 	// started is false — no SetStartedForTest call.
 
-	assert.Nil(t, fetchPRInfoCmd(inst, false))
-	assert.Nil(t, fetchPRInfoCmd(inst, true))
+	assert.Nil(t, fetchPRInfoCmd(inst, "", false))
+	assert.Nil(t, fetchPRInfoCmd(inst, "", true))
 }
 
 // TestFetchPRInfoCmd_NoGitWorktree_ReturnsNil — started instance but no
@@ -100,7 +100,7 @@ func TestFetchPRInfoCmd_NoGitWorktree_ReturnsNil(t *testing.T) {
 	// gitWorktree is nil — no way to set it without a real repo. The snapshot
 	// guard catches this.
 
-	assert.Nil(t, fetchPRInfoCmd(inst, false))
+	assert.Nil(t, fetchPRInfoCmd(inst, "", false))
 }
 
 // TestFetchPRInfoCmd_DetachedHead_ReturnsNil — a detached-HEAD worktree has a
@@ -119,7 +119,7 @@ func TestFetchPRInfoCmd_DetachedHead_ReturnsNil(t *testing.T) {
 	})
 	defer restore()
 
-	assert.Nil(t, fetchPRInfoCmd(inst, true),
+	assert.Nil(t, fetchPRInfoCmd(inst, "", true),
 		"detached-HEAD instance must not schedule a fetch")
 	assert.Equal(t, int32(0), atomic.LoadInt32(&calls),
 		"fetcher must not be invoked for an empty branch (no gh pr view \"\")")
@@ -132,7 +132,7 @@ func TestFetchPRInfoCmd_Fresh_NotForced_DebouncesFetch(t *testing.T) {
 	// Set fresh PR info — bumps prInfoLastFetched to now.
 	inst.SetPRInfo(&git.PRInfo{Number: 1, Title: "fresh"})
 
-	assert.Nil(t, fetchPRInfoCmd(inst, false),
+	assert.Nil(t, fetchPRInfoCmd(inst, "", false),
 		"no fetch should be scheduled while the cached PR info is still fresh")
 }
 
@@ -188,7 +188,7 @@ func TestPrInfoUpdatedMsg_Success_AppliesInfoAndBumpsTimestamp(t *testing.T) {
 	assert.Nil(t, inst.GetPRInfo(), "precondition: no cached PR info")
 
 	info := &git.PRInfo{Number: 42, Title: "add feature", URL: "https://x/42", State: "OPEN"}
-	_, _ = h.Update(prInfoUpdatedMsg{instance: inst, info: info})
+	_, _ = h.Update(prInfoUpdatedMsg{instance: inst, repoID: h.repoID, info: info})
 
 	got := inst.GetPRInfo()
 	require.NotNil(t, got)
@@ -212,7 +212,7 @@ func TestPrInfoUpdatedMsg_Error_PreservesCacheAndDebounces(t *testing.T) {
 	// Simulate the prInfoLastFetched timestamp being old by clearing it via
 	// a fresh SetPRInfo with the same cached value, then waiting would be
 	// flaky — instead rely on MarkPRInfoFetched behavior to check debounce.
-	_, _ = h.Update(prInfoUpdatedMsg{instance: inst, err: errors.New("gh timeout")})
+	_, _ = h.Update(prInfoUpdatedMsg{instance: inst, repoID: h.repoID, err: errors.New("gh timeout")})
 
 	assert.Same(t, cached, inst.GetPRInfo(),
 		"transient fetch error must not clobber cached PR info")
@@ -278,12 +278,12 @@ func TestFetchPRInfoCmd_MarksFetchAtKickoff_DebouncesConcurrentCalls(t *testing.
 	require.Greater(t, inst.PRInfoAge(), 365*24*time.Hour,
 		"precondition: a freshly-restored instance reports a very large age")
 
-	cmd1 := fetchPRInfoCmd(inst, false)
+	cmd1 := fetchPRInfoCmd(inst, "", false)
 	require.NotNil(t, cmd1, "first call should dispatch a fetch")
 	assert.Less(t, inst.PRInfoAge(), time.Second,
 		"kickoff must bump prInfoLastFetched so the next tick is debounced")
 
-	cmd2 := fetchPRInfoCmd(inst, false)
+	cmd2 := fetchPRInfoCmd(inst, "", false)
 	assert.Nil(t, cmd2,
 		"second non-forced call within the stale window must be a no-op, "+
 			"even while the first fetch is still in flight")
@@ -316,8 +316,8 @@ func TestFetchPRInfoCmd_Force_StillRunsWhileFetchInFlight(t *testing.T) {
 	})
 	t.Cleanup(restore)
 
-	require.NotNil(t, fetchPRInfoCmd(inst, false), "first lazy call dispatches")
-	assert.NotNil(t, fetchPRInfoCmd(inst, true),
+	require.NotNil(t, fetchPRInfoCmd(inst, "", false), "first lazy call dispatches")
+	assert.NotNil(t, fetchPRInfoCmd(inst, "", true),
 		"force=true must bypass the kickoff-debounce the previous call set")
 }
 
@@ -349,7 +349,7 @@ func TestPrInfoUpdatedMsg_InstanceSwappedDuringFetch_AppliesToLiveInstance(t *te
 	require.NotSame(t, orphan, live, "sanity: swap must produce a distinct pointer")
 
 	info := &git.PRInfo{Number: 42, Title: "add feature", URL: "https://x/42", State: "OPEN"}
-	_, _ = h.Update(prInfoUpdatedMsg{instance: orphan, info: info})
+	_, _ = h.Update(prInfoUpdatedMsg{instance: orphan, repoID: h.repoID, info: info})
 
 	got := live.GetPRInfo()
 	require.NotNil(t, got, "PR info must be applied to the live sidebar instance")
@@ -369,7 +369,7 @@ func TestPrInfoUpdatedMsg_InstanceGoneDuringFetch_DropsUpdate(t *testing.T) {
 	h.store.RemoveInstanceByTitle("gone")
 
 	info := &git.PRInfo{Number: 7, Title: "lost", State: "OPEN"}
-	_, cmd := h.Update(prInfoUpdatedMsg{instance: orphan, info: info})
+	_, cmd := h.Update(prInfoUpdatedMsg{instance: orphan, repoID: h.repoID, info: info})
 
 	assert.Nil(t, cmd)
 	assert.Nil(t, orphan.GetPRInfo(),
@@ -392,7 +392,7 @@ func TestPrInfoUpdatedMsg_Error_SwappedDuringFetch_MarksLiveInstance(t *testing.
 	require.Greater(t, live.PRInfoAge(), 365*24*time.Hour,
 		"precondition: live instance is never-fetched")
 
-	_, _ = h.Update(prInfoUpdatedMsg{instance: orphan, err: errors.New("gh timeout")})
+	_, _ = h.Update(prInfoUpdatedMsg{instance: orphan, repoID: h.repoID, err: errors.New("gh timeout")})
 
 	assert.Less(t, live.PRInfoAge(), time.Second,
 		"the live instance must be marked fetched to debounce retries")
@@ -433,7 +433,7 @@ func TestPrInfoUpdatedMsg_BranchMismatch_DropsUpdate(t *testing.T) {
 	h.store.AddInstance(recreated)
 
 	info := &git.PRInfo{Number: 42, Title: "branch X PR", State: "OPEN"}
-	_, cmd := h.Update(prInfoUpdatedMsg{instance: orphan, branch: "feature/x", info: info})
+	_, cmd := h.Update(prInfoUpdatedMsg{instance: orphan, branch: "feature/x", repoID: h.repoID, info: info})
 
 	assert.Nil(t, cmd)
 	assert.Nil(t, recreated.GetPRInfo(),
@@ -460,12 +460,122 @@ func TestPrInfoUpdatedMsg_BranchMatch_AppliesUpdate(t *testing.T) {
 	require.NotSame(t, orphan, live, "sanity: swap must produce a distinct pointer")
 
 	info := &git.PRInfo{Number: 42, Title: "branch X PR", State: "OPEN"}
-	_, _ = h.Update(prInfoUpdatedMsg{instance: orphan, branch: "feature/x", info: info})
+	_, _ = h.Update(prInfoUpdatedMsg{instance: orphan, branch: "feature/x", repoID: h.repoID, info: info})
 
 	got := live.GetPRInfo()
 	require.NotNil(t, got, "matching-branch update must apply to the live instance")
 	assert.Equal(t, 42, got.Number)
 	assert.Nil(t, orphan.GetPRInfo(), "the orphaned pointer must not receive the update")
+}
+
+// ----------------------------------------------------------------------------
+// Regression tests for issue #1780 (sachiniyer/agent-factory):
+// "PR info from a previous project can be applied after switching projects
+// mid-fetch". Same staleness class as #1723, one level up: an in-place project
+// switch (#1461) resets the store and swaps m.repoID while a gh fetch for the
+// OLD project is still in flight. The handler's title-only re-resolution then
+// lands the old project's PR info on a same-title session in the NEW project,
+// and the #921 branch guard misses it whenever both sessions share a branch
+// name (common: "main", or the same feature branch across two checkouts). The
+// result is persisted under the new project's repoID, and the snapshot
+// reconcile mirrors it back — making the bleed durable. The fetch captures the
+// repoID at kickoff, and the handler must drop any result whose repoID no
+// longer matches, mirroring snapshotFetchedMsg's guard.
+// ----------------------------------------------------------------------------
+
+// TestPrInfoUpdatedMsg_ProjectSwitch_DropsUpdate — a fetch kicked off in project
+// A completes after the user switched to project B, which has a same-title
+// session on the same branch. The stale PR info must be neither applied in
+// memory nor persisted through the daemon.
+func TestPrInfoUpdatedMsg_ProjectSwitch_DropsUpdate(t *testing.T) {
+	h := newTestHome(t)
+	projectARepoID := h.repoID
+
+	// Project A: session "worker" on branch feature/x, PR fetch in flight.
+	orphan := newStartedInstance(t, "worker")
+	orphan.Branch = "feature/x"
+	h.store.AddInstance(orphan)
+
+	// The user switches projects in place (#1461): the store is reset and the
+	// active repo swapped, mirroring switchProject.
+	h.store.ResetInstances()
+	h.repoID = projectARepoID + "-project-b"
+
+	// Project B happens to have a same-title session on the same branch — the
+	// case the #921 branch guard cannot distinguish.
+	repoBWorker := newStartedInstance(t, "worker")
+	repoBWorker.Branch = "feature/x"
+	h.store.AddInstance(repoBWorker)
+
+	var persisted bool
+	restore := SetPRInfoSetterForTest(func(title, repoID string, info session.PRInfoData) error {
+		persisted = true
+		return nil
+	})
+	defer restore()
+
+	info := &git.PRInfo{Number: 42, Title: "project A PR", State: "OPEN"}
+	_, cmd := h.Update(prInfoUpdatedMsg{
+		instance: orphan, branch: "feature/x", repoID: projectARepoID, info: info,
+	})
+
+	assert.Nil(t, cmd)
+	assert.False(t, persisted,
+		"a fetch for project A must not persist PR info under project B's repoID")
+	assert.Nil(t, repoBWorker.GetPRInfo(),
+		"project A's PR info must not land on project B's same-title, same-branch session")
+	assert.Nil(t, orphan.GetPRInfo(), "the orphaned pointer must not receive the update either")
+}
+
+// TestPrInfoUpdatedMsg_ProjectSwitch_ErrorDropsUpdate — the error path runs
+// after the repo guard too: a failed project-A fetch must not debounce project
+// B's same-title session, which would suppress its own first real fetch.
+func TestPrInfoUpdatedMsg_ProjectSwitch_ErrorDropsUpdate(t *testing.T) {
+	h := newTestHome(t)
+	projectARepoID := h.repoID
+
+	orphan := newStartedInstance(t, "worker")
+	orphan.Branch = "feature/x"
+	h.store.AddInstance(orphan)
+
+	h.store.ResetInstances()
+	h.repoID = projectARepoID + "-project-b"
+
+	repoBWorker := newStartedInstance(t, "worker")
+	repoBWorker.Branch = "feature/x"
+	h.store.AddInstance(repoBWorker)
+	require.Greater(t, repoBWorker.PRInfoAge(), 365*24*time.Hour,
+		"precondition: project B's session is never-fetched")
+
+	_, _ = h.Update(prInfoUpdatedMsg{
+		instance: orphan, branch: "feature/x", repoID: projectARepoID,
+		err: errors.New("gh timeout"),
+	})
+
+	assert.Greater(t, repoBWorker.PRInfoAge(), 365*24*time.Hour,
+		"a project-A fetch error must not mark project B's session as fetched")
+}
+
+// TestFetchPRInfoCmd_StampsRepoIDAtKickoff — the guard above only works if the
+// fetch actually carries the repo it was scoped to. Drive the real cmd with a
+// stubbed fetcher and assert the emitted message carries the repoID captured on
+// the event loop, alongside the #921 branch.
+func TestFetchPRInfoCmd_StampsRepoIDAtKickoff(t *testing.T) {
+	inst := newStartedInstanceWithWorktree(t, "stamped")
+
+	restore := SetPRInfoFetcherForTest(func(repoPath, branch string) (*git.PRInfo, error) {
+		return &git.PRInfo{Number: 7, State: "OPEN"}, nil
+	})
+	defer restore()
+
+	cmd := fetchPRInfoCmd(inst, "repo-a", true)
+	require.NotNil(t, cmd, "a started local instance with a branch must schedule a fetch")
+
+	msg, ok := cmd().(prInfoUpdatedMsg)
+	require.True(t, ok, "the cmd must emit a prInfoUpdatedMsg")
+	assert.Equal(t, "repo-a", msg.repoID,
+		"the fetch must carry the repoID captured at kickoff so the handler can drop it after a project switch")
+	assert.Equal(t, inst.GetBranch(), msg.branch)
 }
 
 // sanity: exercise config.DefaultConfig / AppState wiring so a compile

--- a/app/single_writer_test.go
+++ b/app/single_writer_test.go
@@ -42,6 +42,7 @@ func TestTUIHasNoInstancesWritePath(t *testing.T) {
 	_, _ = h.Update(prInfoUpdatedMsg{
 		instance: inst,
 		branch:   inst.GetBranch(),
+		repoID:   h.repoID,
 		info:     &sessiongit.PRInfo{Number: 5, State: "OPEN"},
 	})
 

--- a/app/sync.go
+++ b/app/sync.go
@@ -71,8 +71,17 @@ type snapshotFetchedMsg struct {
 type prInfoUpdatedMsg struct {
 	instance *session.Instance
 	branch   string
-	info     *git.PRInfo
-	err      error
+	// repoID is the repo the fetch was scoped to, captured at kickoff. The
+	// handler drops the message when it no longer matches m.repoID: an in-place
+	// project switch (#1461) resets the store and swaps the active repo while a
+	// fetch launched for the previous one is still in flight, and the handler's
+	// title-only re-resolution would otherwise land the old project's PR info on
+	// a same-title, same-branch session in the NEW project — then persist it
+	// under the new repoID, where the snapshot reconcile mirrors it back and
+	// makes the bleed durable (#1780). Mirrors snapshotFetchedMsg's guard.
+	repoID string
+	info   *git.PRInfo
+	err    error
 }
 
 // -- Ticker commands --
@@ -225,8 +234,10 @@ func SetPRInfoFetcherForTest(f func(repoPath, branch string) (*git.PRInfo, error
 // background goroutine and emits a prInfoUpdatedMsg. Returns nil when the
 // instance is not eligible for a fetch (nil / not started / remote / already
 // fresh / fetch already in flight). Using force=true ignores the freshness
-// check — for tick-driven refreshes of the selected instance.
-func fetchPRInfoCmd(inst *session.Instance, force bool) tea.Cmd {
+// check — for tick-driven refreshes of the selected instance. repoID is the
+// caller's active repo, read on the event loop and carried on the result so the
+// handler can drop a fetch that outlived a project switch (#1780).
+func fetchPRInfoCmd(inst *session.Instance, repoID string, force bool) tea.Cmd {
 	// PR info comes from a local git branch (`gh pr view`), so it only applies to
 	// a backend with a local worktree.
 	if inst == nil || inst.Capabilities().Workspace != session.WorkspaceLocalWorktree {
@@ -261,7 +272,7 @@ func fetchPRInfoCmd(inst *session.Instance, force bool) tea.Cmd {
 		detachTraceMark("fetchPRInfoCmd-goroutine-entry")
 		info, err := fetch(repoPath, branch)
 		detachTrace(fetchStart, "fetchPRInfoCmd-prInfoFetcher-returned")
-		return prInfoUpdatedMsg{instance: inst, branch: branch, info: info, err: err}
+		return prInfoUpdatedMsg{instance: inst, branch: branch, repoID: repoID, info: info, err: err}
 	}
 }
 


### PR DESCRIPTION
Fixes #1780.

## Verified the bug first

Reproduced on current master before touching anything — the reported failure is real, not a false positive:

```
--- FAIL: TestRepro1780_PrInfoProjectSwitch
    Error: Should be empty, but was worker
    Messages: daemon persistence must NOT be called for stale cross-project PR info
    Error: Should be empty, but was test-repo-project-b
    Error: Expected nil, but got: &git.PRInfo{Number:42, Title:"Project A PR", State:"OPEN"}
    Messages: PR info from Project A must NOT be applied to Project B's same-title session
```

## Root cause

An in-place project switch (#1461) resets the session store and swaps `m.repoID`, but a `gh pr view` fetch launched for the previous project can still be in flight.

- `app/sync.go:71` — `prInfoUpdatedMsg` carried `instance`, `branch`, `info`, `err`, but **no `repoID`**.
- `app/home_update.go:92` — the handler re-resolves its target by title (`GetInstanceByTitle`, from the #808/#862 orphan-pointer fix), so a stale project-A result can resolve to a same-title session in project B.
- `app/home_update.go:105` — the #921 branch guard is the only staleness check, and it **misses the cross-project case whenever both sessions share a branch name** (`main`, or the same feature branch in two checkouts).

The wrong PR info was then persisted through the daemon under the *new* project's `repoID` (`home_update.go:131`), and the next snapshot reconcile mirrored it back — so the corruption is durable, not a transient badge glitch.

`snapshotFetchedMsg` already guards exactly this class with a `repoID` captured at spawn (`home_update.go:160`). `prInfoUpdatedMsg` was never given the same treatment when #1461 landed. Same class as #1723, one level up.

## Fix

Minimal and symmetric with the existing snapshot guard:

1. `prInfoUpdatedMsg` gains a `repoID` field.
2. `fetchPRInfoCmd` takes the caller's `repoID`, read **on the event loop** at kickoff (same discipline as `fetchSnapshotCmd`'s `repoID`/fetcher capture — no field access from the cmd goroutine), and stamps it on the result.
3. The handler drops any message whose `repoID != m.repoID`, before the title re-resolution can run.

The guard sits ahead of the error path too, so a failed project-A fetch can't `MarkPRInfoFetched` on project B's session and suppress its own first real fetch. No tick re-arm needed (unlike `snapshotFetchedMsg`): the PR-info tick re-arms itself in `tickUpdatePRInfoMessage`.

## Adjacent call-site audit

Swept every `GetInstanceByTitle` site for the same anti-pattern. `prInfoUpdatedMsg` is the only async handler that both re-resolves by title **and** persists; `snapshotFetchedMsg` (`sync.go:524`/`578`) is already repo-guarded, and the `handle_mouse.go` / `tui_state.go` sites are synchronous with no in-flight window. No other instances to fix.

## Regression tests

Three new tests in `app/pr_info_test.go`, all verified **failing before the guard, passing after**:

- `TestPrInfoUpdatedMsg_ProjectSwitch_DropsUpdate` — cross-project result is applied to neither memory nor the daemon.
- `TestPrInfoUpdatedMsg_ProjectSwitch_ErrorDropsUpdate` — the error path doesn't debounce the new project's session.
- `TestFetchPRInfoCmd_StampsRepoIDAtKickoff` — drives the real cmd through a stubbed fetcher and asserts the emitted message carries the captured `repoID` (without this the guard would silently no-op).

Existing `prInfoUpdatedMsg` tests now carry `repoID: h.repoID`; `TestPrInfoUpdatedMsg_BranchMatch_AppliesUpdate` doubles as the positive control proving the guard isn't over-broad.

## Gates

- `make test-container` — green (25 packages, 0 failures)
- `make tui-driver-selftest` — **31/31 steps green** (harness has grown past the 25 steps in the issue ask)
- `go build ./...` — clean
- `gofmt -l .` — no output
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — no output
- `scripts/lint-file-length.sh` — passed (604 files, 0 grandfathered)

Not merging — flagging for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)