### PR TITLE
fix(daemon): mark remote sessions Lost when the agent-server is unreachable (#1782)

### DIFF
--- a/daemon/manager_status.go
+++ b/daemon/manager_status.go
@@ -101,6 +101,9 @@ func (m *Manager) RefreshStatuses() {
 //     repainted Ready, the #935 invariant the hollow status-dot rendering
 //     relies on; Lost rather than Dead since #1108 — no kill intent on record
 //     means the session is recovery-eligible), a live idle one → Ready;
+//   - a failed observation probe (only a remote agent-server can error) →
+//     Lost when a second, independent Alive() probe also fails, so an
+//     unreachable sandbox stops reading as healthy (#1782);
 //   - a session carrying the kill-intent tombstone (#1108) short-circuits all
 //     of the above: its interrupted teardown is finished instead.
 //
@@ -161,10 +164,29 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 	// usage-limit detector (#1146) without a second capture-pane.
 	obs, err := as.Snapshot()
 	if err != nil {
-		// A future remote runtime's observation channel failed: leave the status
-		// for the next tick rather than misreading it. The local agent-server
-		// never errors here, so this is inert today — it mirrors the paused /
-		// in-flight-op early returns above (never mark Lost on a failed probe).
+		// The observation probe failed. The local agent-server never errors here,
+		// so this is the REMOTE runtime's path (#1592 Phase 4): the REST call to
+		// the in-sandbox agent-server failed — a dead container, a dropped ssh
+		// forward, an agent-server crash.
+		//
+		// A failed probe is not by itself proof of death: a transient blip against
+		// a healthy sandbox errors identically. So confirm with the INDEPENDENT
+		// Alive() probe rather than either trusting or ignoring the error outright.
+		// Alive() is a second REST call that reports false on any transport error,
+		// so a genuinely unreachable agent-server fails both and settles to Lost,
+		// while a one-off Snapshot error against a still-reachable server leaves
+		// the status for the next tick — the conservative behaviour the paused /
+		// in-flight-op early returns above keep.
+		//
+		// Lost, not Dead (#1108): no kill intent is on record, so the session
+		// vanished out from under a live record and stays recovery-eligible.
+		// Without this the remote session kept its last-known liveness
+		// (Running/Ready) forever while its agent-server was gone, so the TUI
+		// showed a healthy row for a dead session (#1782).
+		if !as.Alive() {
+			_ = instance.Transition(session.ObserveLiveness(session.LiveLost))
+			m.persistPollChange(repoID, instance, before, beforeReset)
+		}
 		return
 	}
 	updated, hasPrompt, content := obs.Updated, obs.HasPrompt, obs.Content

--- a/daemon/status_remote_test.go
+++ b/daemon/status_remote_test.go
@@ -1,0 +1,102 @@
+package daemon
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// registerStartedRemote registers a started instance whose agent-server is the
+// REAL remoteAgentServer client (#1592 Phase 4) pointed at `url`, so the daemon
+// poll drives it over actual HTTP exactly as it does a docker/ssh session. The
+// backend is a plain FakeBackend: the remote runtime never consults it, so any
+// liveness the poll settles on came from the REST probes, not a tmux stand-in.
+func registerStartedRemote(t *testing.T, m *Manager, repoID, repoPath, title, url string, status session.Status) *session.Instance {
+	t.Helper()
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title:             title,
+		Path:              repoPath,
+		Program:           "claude",
+		RemoteAgentServer: &session.AgentServerEndpoint{URL: url, Token: "test-token"},
+	})
+	if err != nil {
+		t.Fatalf("NewInstance(remote): %v", err)
+	}
+	inst.SetBackend(session.NewFakeBackend())
+	inst.SetStartedForTest(true)
+	inst.SetStatusForTest(status)
+	seedDiskInstance(t, repoID, title, repoPath)
+	m.mu.Lock()
+	m.instances[daemonInstanceKey(repoID, title)] = inst
+	m.mu.Unlock()
+	return inst
+}
+
+// TestRefreshStatuses_UnreachableRemoteMarkedLost is the #1782 regression. A
+// remote session's agent-server dies (container killed, ssh forward dropped), so
+// every REST probe fails with ECONNREFUSED. The poll used to return on the first
+// Snapshot error before any liveness check ran, leaving the session pinned at its
+// last-known Running/Ready forever — the TUI showed a healthy row for a session
+// that was gone, and only manual intervention surfaced it. The failed Snapshot
+// must now be confirmed with an independent Alive() probe and settle to Lost.
+//
+// Port 1 on loopback has no listener, so both probes are refused immediately —
+// the "agent-server is unreachable" shape, with no timeout to wait out.
+func TestRefreshStatuses_UnreachableRemoteMarkedLost(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	// Start from Running to prove the pass actively transitions it rather than
+	// merely leaving a pre-set status untouched.
+	registerStartedRemote(t, manager, repoID, repoPath, "remote-gone", "http://127.0.0.1:1", session.Running)
+
+	manager.RefreshStatuses()
+
+	inst := manager.instances[daemonInstanceKey(repoID, "remote-gone")]
+	if got := inst.GetLiveness(); got != session.LiveLost {
+		t.Fatalf("in-memory liveness = %v, want LiveLost (an unreachable agent-server must not keep reading as Running)", got)
+	}
+	// Persisted too, so the status survives a daemon reload and the restore loop
+	// can find it — Lost, not Dead: no kill intent, still recovery-eligible (#1108).
+	if got := persistedStatus(t, repoID, "remote-gone"); got != session.Lost {
+		t.Fatalf("persisted status = %v, want Lost", got)
+	}
+}
+
+// TestRefreshStatuses_RemoteSnapshotErrorButAliveKeepsStatus pins the other half
+// of the #1782 fix: a Snapshot error is not on its own proof of death. Here the
+// agent-server is REACHABLE and reports itself alive, but the snapshot probe
+// fails — a transient blip. The poll must leave the status for the next tick
+// rather than marking a healthy session Lost, which is why the fix confirms with
+// Alive() instead of trusting the Snapshot error outright.
+func TestRefreshStatuses_RemoteSnapshotErrorButAliveKeepsStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/agent/snapshot":
+			// The blip: an error envelope, exactly as the real agent-server
+			// reports a failed capture.
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{"message": "capture failed"},
+			})
+		case "/v1/agent/alive":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{"alive": true},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	manager, repoID, repoPath := newStatusTestManager(t)
+	registerStartedRemote(t, manager, repoID, repoPath, "remote-blip", srv.URL, session.Running)
+
+	manager.RefreshStatuses()
+
+	inst := manager.instances[daemonInstanceKey(repoID, "remote-blip")]
+	if got := inst.GetLiveness(); got != session.LiveRunning {
+		t.Fatalf("in-memory liveness = %v, want LiveRunning (a still-alive session must not be marked Lost on one failed snapshot)", got)
+	}
+}


### PR DESCRIPTION
Fixes #1782.

## Problem

When a remote session's agent-server becomes unreachable — container killed, ssh forward dropped, agent-server crash — the daemon's status poll left the session pinned at its **last-known liveness (Running/Ready) forever**. The TUI kept rendering a healthy row for a session that was gone, and the only way to notice was manual intervention.

`refreshInstanceStatus` probes via `as.Snapshot()` and returned on any error:

```go
obs, err := as.Snapshot()
if err != nil {
    // ...never mark Lost on a failed probe.
    return   // <-- exits before any liveness check
}
```

That early return short-circuits the `case !as.Alive(): → LiveLost` branch further down, so the transition never ran. The comment called the path "inert today" because `localAgentServer.Snapshot()` cannot error — true when it was written (#1622), but `remoteAgentServer.Snapshot()` does a REST call to the in-sandbox agent-server and errors on every poll once that server is gone. The dormant path went live with the remote runtime, and only remote sessions hit it.

## Fix

A failed Snapshot is **not on its own proof of death** — a transient blip against a healthy sandbox errors identically — so the error is neither trusted nor ignored outright. It's confirmed with the independent `Alive()` probe, a second REST call that reports false on any transport error:

```go
if err != nil {
    if !as.Alive() {
        _ = instance.Transition(session.ObserveLiveness(session.LiveLost))
        m.persistPollChange(repoID, instance, before, beforeReset)
    }
    return
}
```

- **Unreachable agent-server** → both probes fail → settles to **Lost**.
- **One-off Snapshot error, server still alive** → status left for the next tick, the conservative behaviour the paused / in-flight-op early returns keep.

**Lost, not Dead** (#1108): no kill intent is on record, so the session stays recovery-eligible. `persistPollChange` is the same choke point the main path uses — it no-ops unless the liveness actually changed, and publishes `session.updated`, so the TUI/web repaint the Lost row live.

Local sessions are untouched: `localAgentServer.Snapshot()` never errors, so this branch stays unreachable for them.

## Tests

`daemon/status_remote_test.go` drives the **real** `remoteAgentServer` client over actual HTTP, so the poll exercises the same path a docker/ssh session does.

- **`TestRefreshStatuses_UnreachableRemoteMarkedLost`** — the regression. Points a started, Running remote session at `127.0.0.1:1` (no listener → immediate ECONNREFUSED, no timeout to wait out) and asserts in-memory **and persisted** status settle to Lost. **Fails on master** (`liveness = 1`, Running), passes with the fix.
- **`TestRefreshStatuses_RemoteSnapshotErrorButAliveKeepsStatus`** — guards the other half against over-correction: an `httptest` agent-server that errors `/v1/agent/snapshot` but reports `alive: true` must leave the status alone. Passes both before and after by design; it pins the conservative behaviour so a future change can't turn a blip into a spurious Lost.

## Gates

- `make test-container` — all packages green
- `make tui-driver-selftest` — 31/31 steps green
- `go build ./...`, `gofmt -l .`, `golangci-lint run --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)