### PR TITLE
fix(daemon): log the watcher replay summary on every drain exit (#1789)

### DIFF
--- a/daemon/eventqueue_test.go
+++ b/daemon/eventqueue_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	aflog "github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/task"
 )
 
@@ -676,6 +678,63 @@ func TestWatcherDrainExpiresAgedEvents(t *testing.T) {
 	})
 	if got := fd.delivered(); len(got) != 1 {
 		t.Fatalf("stale events must never be delivered, got %v", got)
+	}
+}
+
+// TestWatcherDrainLogsExpiryCountWhenStoppedMidBackoff (#1789): the drain loop
+// expires aged events by advancing the cursor past them — irreversibly, since
+// the advance is persisted and no later session re-sees them. So the expiry
+// count must be logged on EVERY exit, not just the queue-drained one. Here the
+// drainer expires two events and then parks retrying an undeliverable third;
+// stopping it mid-backoff must still account for the two.
+func TestWatcherDrainLogsExpiryCountWhenStoppedMidBackoff(t *testing.T) {
+	dir := t.TempDir()
+	s, _ := newTestSupervisor(t, staticTasks(watchTask("ab178901", `sleep 60`, dir)))
+	// Never heals: once the stale head is expired, the fresh event's delivery
+	// fails forever, so the drainer sits in the stop-aware backoff sleep — the
+	// exact window the stop has to land in.
+	var attempts atomic.Int64
+	s.deliver = func(taskID, line string) error {
+		attempts.Add(1)
+		return errors.New("target unreachable (outage)")
+	}
+	s.queueMaxAge = 5 * time.Second
+	queueDir, _ := s.queueDir()
+
+	seed := newEventQueue(queueDir, "ab178901")
+	seed.now = func() time.Time { return time.Now().Add(-time.Hour) }
+	for _, line := range []string{"stale-1", "stale-2"} {
+		if err := seed.enqueue(line); err != nil {
+			t.Fatalf("seed enqueue: %v", err)
+		}
+	}
+	seed.now = time.Now
+	if err := seed.enqueue("fresh"); err != nil {
+		t.Fatalf("seed enqueue fresh: %v", err)
+	}
+
+	var info bytes.Buffer
+	prevInfo := aflog.InfoLog.Writer()
+	aflog.InfoLog.SetOutput(&info)
+	t.Cleanup(func() { aflog.InfoLog.SetOutput(prevInfo) })
+
+	if err := s.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+
+	// A delivery attempt proves the drainer is past both stale events: replay is
+	// strictly FIFO, so nothing reaches deliver until the head has expired.
+	waitUntil(t, 10*time.Second, "the drainer to expire the stale head and park on delivery backoff", func() bool {
+		return attempts.Load() > 0
+	})
+
+	// Stop lands in sleepStopAware (or at the loop-top stop check) — either way
+	// the loop exits without reaching the queue-drained summary branch. Stop
+	// waits on the drainer's wg slot, so the log is flushed once it returns.
+	s.Stop()
+
+	if got := info.String(); !strings.Contains(got, "expired 2") {
+		t.Fatalf("expiries went unlogged when the drainer stopped mid-backoff (#1789):\n%s", got)
 	}
 }
 

--- a/daemon/watcher_drain.go
+++ b/daemon/watcher_drain.go
@@ -32,6 +32,17 @@ func (w *taskWatcher) drainLoop() {
 	defer w.wg.Done()
 	backoff := w.sup.drainBaseBackoff
 	replayed, expired := 0, 0
+	// Account for the replay on EVERY exit, not just the drained-empty one
+	// (#1789). Expiring advances the cursor irreversibly — the record is gone
+	// and no later session can report it — so a stop landing in one of the
+	// stop-aware waits, or a parked queue error, must still say what was
+	// consumed. Deferred after wg.Done's registration, so it runs before it:
+	// a stop's Wait cannot return until the summary is out.
+	defer func() {
+		if replayed > 0 || expired > 0 {
+			log.InfoLog.Printf("watch task %s: replayed %d queued event(s), expired %d older than %s", w.taskID, replayed, expired, w.sup.queueMaxAge)
+		}
+	}()
 	for {
 		if w.stopRequested() {
 			w.stopDraining()
@@ -47,7 +58,7 @@ func (w *taskWatcher) drainLoop() {
 			// Retention (#1129): an event older than the age bound is expired
 			// instead of delivered — a prompt about a days-old notification is
 			// noise, and re-sweepable sources re-emit on their next poll.
-			// Counted and logged below, never silent.
+			// Counted here and logged by the exit summary above, never silent.
 			advanced, err := w.queue.advance(cursor)
 			if err != nil {
 				log.ErrorLog.Printf("watch task %s: failed to expire aged queued event; replay parked until the next reload: %v", w.taskID, err)
@@ -61,9 +72,6 @@ func (w *taskWatcher) drainLoop() {
 			continue
 		}
 		if !ok {
-			if replayed > 0 || expired > 0 {
-				log.InfoLog.Printf("watch task %s: replayed %d queued event(s), expired %d older than %s", w.taskID, replayed, expired, w.sup.queueMaxAge)
-			}
 			w.stopDraining()
 			// Close the wake-up race: an event enqueued after the empty peek
 			// but before draining cleared would otherwise strand until the


### PR DESCRIPTION
## What

Fixes #1789 — the watcher drain loop could silently lose the expired-event count when stopped mid-backoff.

## Verified it reproduces first

Confirmed on `master` before touching anything. `expired` is a loop-local counter in `drainLoop`, incremented at `watcher_drain.go:60`, but the only log site was inside the queue-drained (`!ok`) branch at line 65. Six other return paths discard it:

- the loop-top `stopRequested()` check
- the `peek()` error park
- the expire-`advance()` error park
- all three stop-aware sleeps (rate-limit window, `errTargetBusy` deferral, delivery backoff)

The new regression test fails on master:

```
eventqueue_test.go:737: expiries went unlogged when the drainer stopped mid-backoff (#1789):
    INFO: watch task ab178901: watch command terminated during stop/reload ...
--- FAIL: TestWatcherDrainLogsExpiryCountWhenStoppedMidBackoff
```

Two events were expired and the summary never appeared.

## Why it matters beyond a missing log line

This isn't cosmetic. Expiring an event **advances the queue cursor and persists it** — the record is gone for good, and no later session can re-see or report it. `eventqueue.go:52` documents the contract unconditionally: *"Expiries are logged with a count, never silent."* The drain loop can sit in those stop-aware waits for 10s–5min, so a daemon stop or reload landing in that window is an ordinary occurrence, not a corner case.

## The fix

Move the summary into a deferred log-on-exit block, per the issue's own recommendation, so every return path accounts for what the replay consumed. One detail worth noting: the defer is registered *after* `wg.Done`'s, so it runs *before* it — a stop's `Wait` cannot return until the summary is out. That's what makes the accounting deterministic for the test, and it flushes the log before daemon shutdown completes.

`replayed` was lost on the same paths and is covered by the same block.

## Adjacent call-sites audited

Per repo convention I grepped for the same counter-lost-on-early-return shape:

- `q.dropped` (`eventqueue.go:343`) — struct field, logged at drop time under the one-warning-per-minute pattern. Accumulates; can't be lost.
- `discarded` (`watcher.go:688`) — logged in the same block, no early return between count and log.

`drainLoop` was the only site with this shape.

## Gates

| Gate | Result |
|---|---|
| `make test-container` | green (all packages, `daemon` 106s) |
| `make tui-driver-selftest` | 31/31 steps green |
| `go build ./...` | clean |
| `gofmt -l .` | clean |
| `golangci-lint run --fast` | exit 0, no findings |
| `deadcode -test ./...` | clean |
| `scripts/lint-file-length.sh` | passed |

New test also run `-count=20` and under `-race -count=5` to check the stop-window timing isn't flaky.

Not merging — flagging for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)