### PR TITLE
fix(session): record the pushed branch before sandbox teardown so Lost-restore recovers the right branch (#1781)

### DIFF
--- a/session/archive_sandbox.go
+++ b/session/archive_sandbox.go
@@ -58,18 +58,34 @@ func (i *Instance) ArchiveSandbox() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to push branch for session %q before archive: %w", i.Title, err)
 	}
-	// 2. Tear the in-sandbox workspace down over REST and reap the sandbox itself
+	// 2. Record the branch the INSTANT it is durable on origin — before the teardown
+	//    below, which can fail (#1781). Durable-on-origin is the point of no return:
+	//    from here the branch is the only handle on the user's work, so it belongs on
+	//    the record whatever happens to the sandbox afterwards. Recording it only on
+	//    the all-succeeded path loses it exactly when it matters most — a sandbox
+	//    session's daemon-side i.Branch is otherwise EMPTY (the only other writer,
+	//    backend_local.go's provision, runs INSIDE the sandbox and never mutates this
+	//    Instance; the branch reaches the daemon solely as this Archive() return), and
+	//    a failed Kill sends the session to Lost + recovery-eligible via the caller's
+	//    AbortArchiveToLost (daemon/archive.go). The Lost-restore loop then re-provisions
+	//    from i.Branch (reprovisionRemote → ProvisionSpec.RestoreBranch), and an empty
+	//    RestoreBranch makes the docker/ssh runtimes SKIP the restore fetch and clone the
+	//    repo's DEFAULT branch — a "successful" recovery onto the wrong branch that
+	//    silently strands the work this push just made durable.
+	i.mu.Lock()
+	i.Branch = branch
+	i.mu.Unlock()
+	// 3. Tear the in-sandbox workspace down over REST and reap the sandbox itself
 	//    (container rm / remote dir cleanup + tunnel close) — the branch is durable,
 	//    the sandbox is disposable.
 	if err := as.Kill(); err != nil {
 		return branch, fmt.Errorf("pushed branch %q but failed to tear the sandbox down for session %q: %w", branch, i.Title, err)
 	}
-	// 3. Drop the dead remote wiring so the instance is an inert archived record
+	// 4. Drop the dead remote wiring so the instance is an inert archived record
 	//    until restore re-provisions it. The backend stays (its Type()/Capabilities
 	//    keep the session classified as a remote sandbox for load + restore).
 	i.resetRemoteRuntime()
 	i.mu.Lock()
-	i.Branch = branch
 	i.started = false
 	i.mu.Unlock()
 	return branch, nil

--- a/session/archive_sandbox_test.go
+++ b/session/archive_sandbox_test.go
@@ -250,6 +250,130 @@ func TestArchiveSandbox_RejectsNonSandbox(t *testing.T) {
 	}
 }
 
+// stubAgentServer is an inert AgentServer stand-in for driving the ArchiveSandbox
+// mechanic with no sandbox behind it (#1781). Only Archive and Kill carry
+// behavior — the two calls ArchiveSandbox makes — scripted per test; the rest
+// satisfy the interface as no-ops. It is installed by pinning i.agentSrv, which is
+// the seam AgentServer() honors: its fast path returns a non-nil cache as-is
+// (agentserver_local.go), so the archive runs the REAL code path against this stub
+// rather than building a remoteAgentServer over a dead endpoint.
+type stubAgentServer struct {
+	branch    string
+	killErr   error
+	killCalls int
+}
+
+func (s *stubAgentServer) Archive() (string, error) { return s.branch, nil }
+func (s *stubAgentServer) Kill() error              { s.killCalls++; return s.killErr }
+
+func (s *stubAgentServer) Provision(bool) error                        { return nil }
+func (s *stubAgentServer) Launch(bool) error                           { return nil }
+func (s *stubAgentServer) Expose() (StreamEndpoint, error)             { return StreamEndpoint{}, nil }
+func (s *stubAgentServer) Snapshot() (Observation, error)              { return Observation{}, nil }
+func (s *stubAgentServer) Preview(int, bool) (string, error)           { return "", nil }
+func (s *stubAgentServer) Alive() bool                                 { return false }
+func (s *stubAgentServer) SendPrompt(string) error                     { return nil }
+func (s *stubAgentServer) TapEnter()                                   {}
+func (s *stubAgentServer) Subscribe(int, Seq) (PTYSubscription, error) { return nil, nil }
+func (s *stubAgentServer) Input(int, []byte) error                     { return nil }
+func (s *stubAgentServer) Resize(int, uint16, uint16) error            { return nil }
+
+// newStubbedSandboxInstance builds an inert docker-classified instance whose
+// archive drives `as`: remoteClient is set only to satisfy ArchiveSandbox's
+// isRemote guard (nothing dials it — agentSrv short-circuits the build).
+func newStubbedSandboxInstance(as AgentServer) *Instance {
+	return &Instance{
+		Title:        "s",
+		backend:      newInertSandboxBackend("docker"),
+		remoteClient: &remoteAgentClient{title: "s"},
+		agentSrv:     as,
+	}
+}
+
+// TestArchiveSandbox_RecordsBranchOnKillFailure pins the #1781 invariant: once
+// as.Archive() has pushed the branch to origin the branch is DURABLE, so it must be
+// on the instance record even though the teardown that follows fails. Before the
+// fix i.Branch was only assigned on the all-succeeded path, so this partial failure
+// left a Lost, recovery-eligible session with an EMPTY Branch — and the Lost-restore
+// loop re-provisions from i.Branch, so an empty one silently recovers the session
+// onto the repo's default branch and hides the work that was just pushed.
+func TestArchiveSandbox_RecordsBranchOnKillFailure(t *testing.T) {
+	as := &stubAgentServer{branch: "root/s", killErr: fmt.Errorf("container rm failed")}
+	i := newStubbedSandboxInstance(as)
+
+	branch, err := i.ArchiveSandbox()
+
+	require.Error(t, err, "the teardown failure must still surface to the caller")
+	assert.Equal(t, "root/s", branch, "the pushed branch is returned even on a partial failure")
+	assert.Contains(t, err.Error(), `pushed branch "root/s"`, "error names the branch that IS durable")
+	assert.Contains(t, err.Error(), "failed to tear the sandbox down", "error names the half that failed")
+	assert.Equal(t, 1, as.killCalls, "the teardown was attempted")
+
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	assert.Equal(t, "root/s", i.Branch,
+		"the durable branch must be recorded despite the teardown failure — Lost-restore re-provisions from i.Branch (#1781)")
+}
+
+// TestArchiveSandbox_RecordsBranchOnSuccess pins that moving the assignment earlier
+// (#1781) did not drop it from the success path, alongside the archive's other
+// post-conditions: the wiring is reset and the session is no longer started.
+func TestArchiveSandbox_RecordsBranchOnSuccess(t *testing.T) {
+	i := newStubbedSandboxInstance(&stubAgentServer{branch: "root/s"})
+	i.started = true
+
+	branch, err := i.ArchiveSandbox()
+
+	require.NoError(t, err)
+	assert.Equal(t, "root/s", branch)
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	assert.Equal(t, "root/s", i.Branch, "the pushed branch is recorded on the success path")
+	assert.False(t, i.started, "an archived session is not started")
+	assert.Nil(t, i.remoteClient, "the dead remote wiring is cleared")
+}
+
+// specCapturingRuntime records the ProvisionSpec it was handed, so a test can
+// assert what reprovisionRemote actually asks for (fakeRuntime discards the spec).
+type specCapturingRuntime struct {
+	res  ProvisionResult
+	spec ProvisionSpec
+}
+
+func (r *specCapturingRuntime) Provision(s ProvisionSpec) (ProvisionResult, error) {
+	r.spec = s
+	return r.res, nil
+}
+
+// TestArchiveSandbox_PartialFailureReprovisionsOnPushedBranch proves the CONSEQUENCE
+// the #1781 fix buys, end-to-end across the two halves that were disconnected: after
+// a partial archive (push OK, teardown failed) the instance the daemon persists as
+// Lost is one whose subsequent re-provision — the exact call the Lost-restore loop
+// makes via Recover → recoverSandbox → reprovisionRemote — carries the PUSHED branch
+// as RestoreBranch. That is what makes the docker/ssh runtimes fetch the branch back
+// (backend_docker.go: an empty RestoreBranch skips the fetch and lands on the repo's
+// default branch) instead of silently recovering onto the wrong one.
+func TestArchiveSandbox_PartialFailureReprovisionsOnPushedBranch(t *testing.T) {
+	i := newStubbedSandboxInstance(&stubAgentServer{branch: "root/s", killErr: fmt.Errorf("container rm failed")})
+	i.Path = t.TempDir()
+
+	_, err := i.ArchiveSandbox()
+	require.Error(t, err, "this test is about the PARTIAL failure path")
+
+	rt := &specCapturingRuntime{res: ProvisionResult{
+		Backend:  &dockerBackend{containerID: "fresh"},
+		Endpoint: &AgentServerEndpoint{URL: "http://127.0.0.1:9", Token: "tok"},
+		Teardown: func() error { return nil },
+	}}
+	prev := runtimeRegistry[BackendDocker]
+	runtimeRegistry[BackendDocker] = func() Runtime { return rt }
+	defer func() { runtimeRegistry[BackendDocker] = prev }()
+
+	require.NoError(t, i.reprovisionRemote())
+	assert.Equal(t, "root/s", rt.spec.RestoreBranch,
+		"recovery after a partial archive must clone the pushed branch back, not fall through to the default branch (#1781)")
+}
+
 // TestReprovisionRemote_RebindsInstance drives the restore re-provision wiring
 // without a real sandbox (#1592 Phase 4 PR6): a fakeRuntime swapped into the
 // registry returns a fresh backend + authed endpoint + teardown, and


### PR DESCRIPTION
Closes #1781.

## The bug

`ArchiveSandbox` (`session/archive_sandbox.go`) archives a docker/ssh sandbox session by pushing its branch to origin and then reaping the sandbox. On a **partial failure** — `as.Archive()` succeeds (the branch is durable on origin) but `as.Kill()` fails — it returned early and **never recorded the pushed branch on the instance**. `i.Branch = branch` sat below the `Kill()` error return, on the full-success path only.

The user's work is safely on `origin/<session-branch>`, but auto-recovery silently reprovisions on the repo's **default branch**, so the work is invisible.

## Why that is load-bearing (verified chain)

1. For a docker/ssh sandbox session the daemon-side `i.Branch` is **empty**. The only non-test writers are `session/backend_local.go:168` — which runs *inside* the container and never mutates the daemon's `Instance` — and `session/archive_sandbox.go`. `dockerBackend.Provision` (`session/backend_docker.go:501-503`) just delegates over the wire and nothing plumbs the branch back; `session/agentserver_remote.go:232-238` returns the branch **only** from the `Archive()` call. So that `Archive()` return is the sole path by which the branch ever reaches the daemon.
2. `daemon/archive.go:212-219` — on an `ArchiveSandbox` error it calls `AbortArchiveToLost()` + `persistInstance(...)`, persisting a **Lost, recovery-eligible** instance with `Branch: ""`.
3. `daemon/lostrestore.go:131` gates on `Capabilities().Recover`, which is `true` for docker (`backend_docker.go:481`) and ssh (`backend_ssh.go:748`), so line 162 calls `inst.Recover()` → `recoverSandbox` → `reprovisionRemote` (`archive_sandbox.go`) with `ProvisionSpec{RestoreBranch: i.Branch}`.
4. `session/backend_docker.go:270` (and `backend_ssh.go:445`): `if branch := strings.TrimSpace(p.spec.RestoreBranch); branch != "" { return p.fetchRestoreBranch(branch) }` — **empty means the fetch is skipped** and the fresh sandbox provisions on the default branch. The loop then reports success and `ConfirmLive`s it.

## The fix

Record the branch the instant it is durable on origin — immediately after a successful `as.Archive()`, before `as.Kill()` — under `i.mu`, and drop the now-redundant assignment from the success block. Durable-on-origin is the point of no return: from there the branch is the only handle on the user's work, so it belongs on the record regardless of what happens to the sandbox afterwards.

No other behavior, error strings, return values, or lock discipline changed (`i.started = false` and `resetRemoteRuntime()` are untouched).

## Test evidence (fails before, passes after)

Three tests added to `session/archive_sandbox_test.go`, driving the **real** `ArchiveSandbox` code path — the production code was not weakened or spied. A local `stubAgentServer` is installed by pinning `i.agentSrv`, the cache `AgentServer()` honors (its fast path returns a non-nil cache as-is, `agentserver_local.go`).

**Before** (production fix stashed, tests at this PR's version):

```
=== RUN   TestArchiveSandbox_RecordsBranchOnKillFailure
    archive_sandbox_test.go:314:
        	Error:      	Not equal:
        	            	expected: "root/s"
        	            	actual  : ""
        	Messages:   	the durable branch must be recorded despite the teardown failure — Lost-restore re-provisions from i.Branch (#1781)
--- FAIL: TestArchiveSandbox_RecordsBranchOnKillFailure (0.00s)
=== RUN   TestArchiveSandbox_RecordsBranchOnSuccess
--- PASS: TestArchiveSandbox_RecordsBranchOnSuccess (0.00s)
=== RUN   TestArchiveSandbox_PartialFailureReprovisionsOnPushedBranch
    archive_sandbox_test.go:373:
        	Error:      	Not equal:
        	            	expected: "root/s"
        	            	actual  : ""
        	Messages:   	recovery after a partial archive must clone the pushed branch back, not fall through to the default branch (#1781)
--- FAIL: TestArchiveSandbox_PartialFailureReprovisionsOnPushedBranch (0.00s)
FAIL
```

**After** (fix restored):

```
=== RUN   TestArchiveSandbox_RejectsNonSandbox
--- PASS: TestArchiveSandbox_RejectsNonSandbox (0.00s)
=== RUN   TestArchiveSandbox_RecordsBranchOnKillFailure
--- PASS: TestArchiveSandbox_RecordsBranchOnKillFailure (0.00s)
=== RUN   TestArchiveSandbox_RecordsBranchOnSuccess
--- PASS: TestArchiveSandbox_RecordsBranchOnSuccess (0.00s)
=== RUN   TestArchiveSandbox_PartialFailureReprovisionsOnPushedBranch
--- PASS: TestArchiveSandbox_PartialFailureReprovisionsOnPushedBranch (0.01s)
PASS
ok  	github.com/sachiniyer/agent-factory/session	0.028s
```

What each pins:

- **`TestArchiveSandbox_RecordsBranchOnKillFailure`** (the primary regression test) — after `Archive()` succeeds and `Kill()` fails: the pushed branch is still returned, the error names both halves (`pushed branch "root/s"` + `failed to tear the sandbox down`), and critically `inst.Branch == "root/s"`.
- **`TestArchiveSandbox_PartialFailureReprovisionsOnPushedBranch`** — proves the *consequence* end-to-end across the two halves that were disconnected: after a partial archive, the subsequent `reprovisionRemote` (the exact call the Lost-restore loop makes via `Recover` → `recoverSandbox`) carries `RestoreBranch: "root/s"` rather than `""`. Uses the existing `runtimeRegistry` seam with a small spec-capturing runtime (`fakeRuntime` discards the spec).
- **`TestArchiveSandbox_RecordsBranchOnSuccess`** — a guard that moving the assignment earlier did not drop it from the success path. Correctly passes both before and after (it is coverage for the moved line, not a regression test).

## Gates

| Gate | Result |
| --- | --- |
| `go build ./...` | pass |
| `gofmt -l .` | clean (no output) |
| `golangci-lint run --timeout=3m --fast` | pass |
| `deadcode -test ./...` | clean (no output) |
| `scripts/lint-file-length.sh` | pass (605 files, 0 grandfathered) |
| `make test-container` (full suite) | pass — all packages green |
| `make tui-driver-selftest` | 31/31 steps green |

## Follow-up (separate, NOT fixed here)

A docker/ssh session that has **never been archived** also has `Branch == ""`, because the branch is never plumbed back from the sandbox at *provision* time (`dockerBackend.Provision` delegates over the wire and drops it; only `Archive()` ever returns it).

To be precise about what that does and does not mean — the obvious "daemon restart" version of this is **not** reachable, and this PR does not claim it is. A non-archived sandbox loads inert with `started=false` (`session/instance_data.go:215-225`), and the Lost-restore loop short-circuits on `!inst.Started()` (`daemon/lostrestore.go:108`) before it ever reaches `Recover()`. So a reloaded sandbox is not auto-recovered onto the default branch; restoring it is an explicit user action.

What #1781 fixes is specifically the path where `started` is still `true` — `ArchiveSandbox` returns on the `Kill()` failure *before* `i.started = false`, and `AbortArchiveToLost` leaves `started` untouched (`session/transition.go`: only `CommitArchive` clears it), so the instance sits Lost + started=true and the loop does fire.

The residual question worth its own issue: a *live* sandbox (started=true, `Branch == ""`) whose container dies mid-session is marked Lost by the status poll and would then recover with an empty `RestoreBranch`. Its work was never pushed, so nothing is recoverable either way — but the loop would `ConfirmLive` a fresh default-branch sandbox as a "successful" restore rather than surfacing the loss. That is a design gap in the provision path, not a missing assignment, and it is **unverified** — deliberately out of scope here.

Co-Authored-By: Captain Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
