### PR TITLE
fix(bugreport): redact bare session titles in historical logs when instances.json is corrupt (#1790)

### DIFF
--- a/bugreport/bugreport_test.go
+++ b/bugreport/bugreport_test.go
@@ -327,6 +327,62 @@ func TestRedactInstancesFallbackRedactsAllNestedTitleFields(t *testing.T) {
 	}
 }
 
+// TestRedactInstancesFallbackNotesTitlesForLogScrub is the #1790 regression
+// guard. #1680 taught the fallback path to redact the title-bearing keys out of
+// the JSON section, but the fallback still never recorded those titles for
+// scrubLog the way the typed path does via noteSession. So when instances.json
+// failed the typed decode, the bundle redacted the JSON section while the
+// verbatim log tail kept printing the same titles bare — the #1584 leak class,
+// reachable through a single corrupt record.
+//
+// The log lines here quote titles bare (no af_<hash>_ name), so the
+// afTmuxSessionName shape regex cannot reach them: only titles collected off the
+// fallback payload can.
+func TestRedactInstancesFallbackNotesTitlesForLogScrub(t *testing.T) {
+	r := &redactor{}
+	// Typed decode fails (`status` is a string, the field is an int), forcing the
+	// generic fallback. Each title-bearing location carries a distinct sentinel so
+	// a surviving value pinpoints which one was not noted.
+	raw := json.RawMessage(`[{
+		"id": "leg-1",
+		"status": "legacy-string-status",
+		"title": "ConfidentialProjectAlpha",
+		"tmux_name": "af_ConfidentialProjectAlpha",
+		"worktree": {"session_name": "WorktreeSecretTitle", "branch": "feature/test"}
+	}]`)
+
+	// Runs first, exactly as collectInstances does before collectLog.
+	if out := string(r.redactInstancesJSON(raw)); strings.Contains(out, "ConfidentialProjectAlpha") {
+		t.Fatalf("fallback path leaked the title in the JSON section:\n%s", out)
+	}
+
+	in := strings.Join([]string{
+		`task cron-123 started successfully as instance ConfidentialProjectAlpha`,
+		`recover: rebuilt session "WorktreeSecretTitle" at /path from ` + testSHA,
+		`tmux session af_ConfidentialProjectAlpha is gone; status monitor going silent`,
+	}, "\n")
+
+	out := r.scrubLog(in)
+
+	for _, leaked := range []string{"ConfidentialProjectAlpha", "WorktreeSecretTitle"} {
+		if strings.Contains(out, leaked) {
+			t.Errorf("title from a corrupt instances.json leaked through the log scrub: %q\n%s", leaked, out)
+		}
+	}
+	// The non-hashed af_<title> name is redacted to the prefix marker, matching
+	// what the typed path produces for the same name.
+	if !strings.Contains(out, tmuxPrefixMarker) {
+		t.Errorf("expected the non-hashed af_ name to collapse to the prefix marker:\n%s", out)
+	}
+	// Structural context around the redacted titles survives so the log stays
+	// triageable.
+	if !strings.Contains(out, "started successfully as instance") ||
+		!strings.Contains(out, "status monitor going silent") ||
+		!strings.Contains(out, testSHA) {
+		t.Errorf("structural log context should survive:\n%s", out)
+	}
+}
+
 // TestRedactInstancesTypedPathRedactsTmuxAndSessionName confirms the typed path
 // is unchanged: the same shape as the fallback test but VALID as
 // []InstanceData (int status) still redacts tmux_name, worktree.session_name,

--- a/bugreport/redact.go
+++ b/bugreport/redact.go
@@ -228,24 +228,68 @@ func isWordByte(b byte) bool {
 // redacted, so scrubLog can strip them from the log tail. Called on each record
 // while collecting instances, i.e. before collectLog runs.
 func (r *redactor) noteSession(d *session.InstanceData) {
-	if r.tmuxNames == nil {
-		r.tmuxNames = make(map[string]struct{})
+	r.noteTmuxName(d.TmuxName)
+	r.noteTitle(d.Title)
+	r.noteTitle(d.Worktree.SessionName)
+	for _, tab := range d.Tabs {
+		r.noteTmuxName(tab.TmuxName)
+	}
+}
+
+// noteTitle records one raw session title for scrubLog, skipping blanks.
+func (r *redactor) noteTitle(title string) {
+	if strings.TrimSpace(title) == "" {
+		return
 	}
 	if r.titles == nil {
 		r.titles = make(map[string]struct{})
 	}
-	if d.TmuxName != "" {
-		r.tmuxNames[d.TmuxName] = struct{}{}
+	r.titles[title] = struct{}{}
+}
+
+// noteTmuxName records one raw tmux session name for scrubLog, skipping blanks.
+func (r *redactor) noteTmuxName(name string) {
+	if name == "" {
+		return
 	}
-	if strings.TrimSpace(d.Title) != "" {
-		r.titles[d.Title] = struct{}{}
+	if r.tmuxNames == nil {
+		r.tmuxNames = make(map[string]struct{})
 	}
-	if strings.TrimSpace(d.Worktree.SessionName) != "" {
-		r.titles[d.Worktree.SessionName] = struct{}{}
-	}
-	for _, tab := range d.Tabs {
-		if tab.TmuxName != "" {
-			r.tmuxNames[tab.TmuxName] = struct{}{}
+	r.tmuxNames[name] = struct{}{}
+}
+
+// titleJSONKeys are the object keys whose string value is a raw session title on
+// the generic fallback path, mirroring the fields noteSession reads off a typed
+// record (InstanceData.Title and Worktree.SessionName). `tmux_name` is handled
+// separately — it is a name derived from the title, not the title itself.
+var titleJSONKeys = map[string]bool{"title": true, "session_name": true}
+
+// noteUnknownJSON walks a decoded-but-unparseable instances.json payload and
+// records every title/tmux-name it carries, so scrubLog can strip them from the
+// log tail exactly as it does for records that decoded typed (#1790). It must
+// run BEFORE redactUnknownJSON blanks those same values.
+//
+// The walk is key-driven and shape-agnostic, so it reaches nested title-bearing
+// locations (worktree.session_name, tabs[].tmux_name) without assuming the
+// record layout the typed decode already rejected.
+func (r *redactor) noteUnknownJSON(v any) {
+	switch t := v.(type) {
+	case map[string]any:
+		for k, val := range t {
+			s, isString := val.(string)
+			key := strings.ToLower(k)
+			switch {
+			case !isString:
+				r.noteUnknownJSON(val)
+			case titleJSONKeys[key]:
+				r.noteTitle(s)
+			case key == "tmux_name":
+				r.noteTmuxName(s)
+			}
+		}
+	case []any:
+		for _, e := range t {
+			r.noteUnknownJSON(e)
 		}
 	}
 }
@@ -304,6 +348,11 @@ func (r *redactor) redactInstancesJSON(raw json.RawMessage) json.RawMessage {
 	if err := json.Unmarshal(raw, &generic); err != nil {
 		return json.RawMessage(unparsedInstancesNote)
 	}
+	// Record the titles this payload carries before blanking them, so scrubLog
+	// strips them from the log tail too — the typed path above does this via
+	// noteSession, and without it a corrupt instances.json redacted the JSON
+	// section while leaving bare titles in the bundled log (#1790).
+	r.noteUnknownJSON(generic)
 	out, err := json.MarshalIndent(redactUnknownJSON(generic), "", "  ")
 	if err != nil {
 		return json.RawMessage(unparsedInstancesNote)


### PR DESCRIPTION
Fixes #1790.

## Verified first

Reproduced on master before writing any fix. A record that fails the typed
decode (`status` is a string; the field is an int) gets its JSON section
redacted correctly, but `r.titles` comes back empty and the log line leaks:

```
json out:  { "id": "leg-1", "title": "[redacted]", "tmux_name": "[redacted]" }
titles:    map[]
LEAK:      task abc123 started successfully as instance ConfidentialProjectAlpha
```

## Root cause

`redactInstancesJSON` has two paths. The typed one calls `noteSession` per
record, which populates `r.titles` — the set `scrubLog` uses to strip **bare**
titles (titles not embedded in an `af_<hash>_<title>` tmux name, which the
shape regex catches on its own) out of the verbatim daemon log tail.

The generic fallback — taken when instances.json fails the typed decode —
only redacted the JSON body and never called `noteSession`. `r.titles` stayed
empty, so `collectLog` (which runs after `collectInstances`, and depends on it
having seeded the title set) could not scrub bare titles. A single corrupt
record reintroduced the #1584 leak class through the bundled log. #1680 closed
this same gap for the JSON section; the log side was left open.

## Fix

Walk the decoded generic payload before `redactUnknownJSON` blanks it,
recording `title`/`session_name` values as titles and `tmux_name` values as
tmux names — the same fields `noteSession` reads off a typed record. The walk
is key-driven and shape-agnostic, so it reaches nested title-bearing locations
(`worktree.session_name`, `tabs[].tmux_name`) without assuming the layout the
typed decode already rejected. `noteSession` is factored into
`noteTitle`/`noteTmuxName` so both paths share one recording policy rather than
drifting apart again.

Direction of the change is fail-safe, consistent with the fallback's existing
policy: a `title` key anywhere (e.g. `pr_info.title`) is now scrubbed from the
log too. Over-redacting the shared bundle beats leaking.

**Known limit, unchanged:** if instances.json is not valid JSON *at all*, the
contents are omitted with a note and there is nothing to extract titles from,
so bare titles in the log still can't be noted. Hashed `af_<hash>_<title>` names
are still redacted there by the shape regex; only bare titles are out of reach.

## Regression test

`TestRedactInstancesFallbackNotesTitlesForLogScrub` drives the real
`redactInstancesJSON` → `scrubLog` order, with log lines quoting titles bare so
the shape regex cannot reach them — only collected titles can. Verified it
**fails on the unfixed `redact.go`** (both sentinels leak) and passes with the
fix, so it guards the actual behavior rather than restating it.

## Gates

- `make test-container` — full suite green, zero failures (`bugreport` included)
- `make tui-driver-selftest` — 31/31 steps green
- `go build ./...` — clean
- `gofmt -l .` — no output
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — no output
- `scripts/lint-file-length.sh` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)