### PR TITLE
fix(tui): failed project switch must not leave the repo context changed (#1788)

### DIFF
--- a/app/switch_project.go
+++ b/app/switch_project.go
@@ -286,6 +286,18 @@ func (m *home) switchProject(repo *config.RepoContext) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	// Fetch the INCOMING project's snapshot FIRST, while the outgoing project is
+	// still fully intact. Everything below this point is unconditional mutation
+	// with no way back — the panes are torn down and the projection reset — so a
+	// fetch failure (a wedged or unreachable daemon, common against a remote
+	// target) must abort here, leaving the current project exactly as it was,
+	// rather than stranding the TUI on the new repoID with an empty sidebar
+	// (#1788).
+	data, err := m.fetchColdStartSnapshot(repo.ID)
+	if err != nil {
+		return m, m.handleError(fmt.Errorf("failed to load sessions for %s: %w", filepath.Base(repo.Root), err))
+	}
+
 	// Persist the OUTGOING project's pane/selection state under its still-current
 	// repoID before anything changes.
 	m.flushTUIViewStateBestEffort()
@@ -322,12 +334,11 @@ func (m *home) switchProject(repo *config.RepoContext) (tea.Model, tea.Cmd) {
 		m.hooksPane.SetCommands(nil)
 	}
 
-	// Re-prime the projection from the new project's snapshot (scoped to the new
+	// Re-prime the projection from the snapshot fetched above (scoped to the new
 	// repoID by the daemon — no cross-repo bleed). Persisted remote-hook sessions
-	// arrive on this snapshot too.
-	if err := m.coldStartFromSnapshot(); err != nil {
-		return m, m.handleError(fmt.Errorf("failed to load sessions for %s: %w", filepath.Base(repo.Root), err))
-	}
+	// arrive on this snapshot too. Materializing cannot fail as a whole: an
+	// unrestorable record is skipped, so the switch is committed from here on.
+	m.materializeSnapshot(data)
 
 	if tasks, err := task.LoadTasksForRepo(repo.Root); err != nil {
 		log.WarningLog.Printf("switch project: failed to load tasks for %s: %v", repo.Root, err)

--- a/app/switch_project_test.go
+++ b/app/switch_project_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -253,6 +254,57 @@ func TestSwitchProjectSameRepoIsNoop(t *testing.T) {
 	h.switchProject(same)
 
 	require.NotNil(t, findSidebarInstance(h, "existing"), "a same-repo switch must not wipe the sidebar")
+}
+
+// TestSwitchProjectFailedSnapshotLeavesProjectIntact is the #1788 guarantee: a
+// switch whose snapshot fetch fails (a wedged or unreachable daemon — most
+// likely against a remote target) must be a no-op, not a half-applied switch.
+// Before the fix the model was re-scoped to the incoming repo and the projection
+// reset BEFORE the fetch ran, so a failure stranded the TUI on the new
+// repoID/repoRoot with an empty sidebar: background polls and any new session
+// then targeted a project the user could not see.
+func TestSwitchProjectFailedSnapshotLeavesProjectIntact(t *testing.T) {
+	h := newTestHome(t)
+	h.sidebar.SetSize(40, 20)
+	t.Cleanup(SetInstanceBuilderForTest(func(d session.InstanceData) (*session.Instance, error) {
+		return newSnapshotTestInstance(t, d.Title), nil
+	}))
+
+	// Give repo A a concrete root and an open session, as a live TUI would have.
+	repoARoot := t.TempDir()
+	h.repoRoot = repoARoot
+	h.sidebar.SetProjectName(filepath.Base(repoARoot))
+	repoAID := h.repoID
+	h.store.AddInstance(newSnapshotTestInstance(t, "repoA-session"))
+	require.NotNil(t, findSidebarInstance(h, "repoA-session"))
+
+	repoBRoot := t.TempDir()
+	repoB := &config.RepoContext{Root: repoBRoot, ID: config.RepoIDFromRoot(repoBRoot)}
+
+	// Repo B's snapshot is unavailable; repo A's would still succeed.
+	h.snapshotFetcher = func(repoID string) (daemon.SnapshotResponse, error) {
+		if repoID == repoB.ID {
+			return daemon.SnapshotResponse{}, errors.New("daemon unavailable")
+		}
+		return daemon.SnapshotResponse{}, nil
+	}
+
+	h.switchProject(repoB)
+
+	// The repo context never moved, so polls and new sessions stay on repo A.
+	assert.Equal(t, repoAID, h.repoID, "a failed switch must not re-scope repoID")
+	assert.Equal(t, repoARoot, h.repoRoot, "a failed switch must not re-scope repoRoot")
+
+	// Repo A's sidebar survived rather than being cleared for a switch that
+	// never landed.
+	require.NotNil(t, findSidebarInstance(h, "repoA-session"), "the current project's sessions must survive a failed switch")
+	assert.Contains(t, h.sidebar.String(), filepath.Base(repoARoot), "the sidebar must still name the current project")
+
+	// The user-visible payoff: a session created after the failed switch still
+	// targets the project the sidebar is showing.
+	h.startNewInstance(false)
+	require.NotNil(t, h.namingInstance)
+	assert.Equal(t, repoARoot, h.namingInstance.Path, "new sessions must still target the current project after a failed switch")
 }
 
 // TestSwitchProjectClearsHooksWhenConfigResolveFails is the #1686 guarantee:

--- a/app/sync.go
+++ b/app/sync.go
@@ -158,10 +158,20 @@ var coldStartWarmupWait = 2 * time.Minute
 // (non-warming) daemon failure, which newHome surfaces and exits on — there is
 // no standalone fallback anymore (#960 PR 6 dropped no-daemon mode).
 func (m *home) coldStartFromSnapshot() error {
-	data, err := m.fetchColdStartSnapshot()
+	data, err := m.fetchColdStartSnapshot(m.repoID)
 	if err != nil {
 		return err
 	}
+	m.materializeSnapshot(data)
+	return nil
+}
+
+// materializeSnapshot builds each snapshot record into a live instance and adds
+// it to the projection. Split out of coldStartFromSnapshot so switchProject can
+// fetch a target project's snapshot up front — while the outgoing project is
+// still intact — and only materialize it once the fetch has succeeded (#1788).
+// A single unrestorable record is logged and skipped, never aborting the batch.
+func (m *home) materializeSnapshot(data []session.InstanceData) {
 	for _, d := range data {
 		inst, err := buildInstanceFromSnapshot(d)
 		if err != nil {
@@ -173,7 +183,6 @@ func (m *home) coldStartFromSnapshot() error {
 		m.store.AddInstance(inst)()
 		inst.SetAutoYes(m.autoYes)
 	}
-	return nil
 }
 
 // fetchColdStartSnapshot fetches the cold-start snapshot, tolerating a warming
@@ -183,11 +192,13 @@ func (m *home) coldStartFromSnapshot() error {
 // session list rather than an empty sidebar that looks like a fresh install
 // (#766/#868). On a hard error the daemon is unavailable and the launch aborts —
 // post-#782 the daemon is always-on, so there is no degraded standalone path.
-func (m *home) fetchColdStartSnapshot() ([]session.InstanceData, error) {
+// The repoID is passed explicitly rather than read from m.repoID so switchProject
+// can fetch the INCOMING project's snapshot before it re-scopes the model (#1788).
+func (m *home) fetchColdStartSnapshot(repoID string) ([]session.InstanceData, error) {
 	deadline := time.Now().Add(coldStartWarmupWait)
 	announced := false
 	for {
-		resp, err := m.snapshotFetcher(m.repoID)
+		resp, err := m.snapshotFetcher(repoID)
 		if err == nil {
 			return resp.Instances, nil
 		}


### PR DESCRIPTION
Fixes #1788.

## Reproduced first

The report is accurate. Dropping its failing test onto current master (`0708fe4`) fails exactly as described — `repoID`/`repoRoot` move to the target project, and the sidebar is left empty:

```
expected: "test-repo-001"
actual  : "82e9c449a66b"
Messages: repoID should remain on original project after snapshot failure
```

## Root cause

`switchProject` (added in #1547) does its destructive work in the wrong order. It closes the outgoing project's panes, calls `store.ResetInstances()`, and re-scopes `m.repoID`/`m.repoRoot` — and only *then* calls `coldStartFromSnapshot()`. The error path returns via `handleError` with no rollback, so a failed fetch strands the TUI on the new repo context with a cleared sidebar. Background polls and any newly created session then target a project the user cannot see; recovery means manually re-selecting the original project via `ctrl+p`.

The fetch is genuinely fallible — `fetchColdStartSnapshot` surfaces any non-warming daemon error, which is most likely against a remote daemon target where `EnsureDaemon` is skipped.

## Fix

Fetch the incoming project's snapshot **first**, while the outgoing project is still fully intact, and abort there on failure. A failed switch is now a no-op instead of a half-applied one. Materializing the fetched records cannot fail as a whole (an unrestorable record is logged and skipped, unchanged), so once the fetch succeeds the switch runs to completion — there is no longer a failure point after the first mutation.

I chose ordering over the rollback the issue suggests. By the time the fetch runs, the panes are already closed and the projection reset; restoring them would mean re-fetching the *outgoing* project's snapshot, which is itself fallible — and a failure there would leave no intact project at all. Not breaking the state is strictly better than trying to reassemble it.

Supporting changes, both behavior-preserving at startup:
- `fetchColdStartSnapshot` takes an explicit `repoID` — it read `m.repoID`, which is precisely the field that must not move yet.
- The materialize half of `coldStartFromSnapshot` is split into `materializeSnapshot` so both callers share it.

## Regression test

`TestSwitchProjectFailedSnapshotLeavesProjectIntact` — repo B's snapshot fails while repo A's would succeed. Asserts `repoID`/`repoRoot` never move, repo A's session and project name survive in the sidebar, and (the user-visible payoff) a session created after the failed switch still targets repo A. Verified it fails on the unfixed code for the right reasons and passes with the fix.

## Gates

All green:

- `make test-container` — full suite, `app` included
- `make tui-driver-selftest` — 31/31 steps
- `go build ./...`
- `gofmt -l .` — clean
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean
- `scripts/lint-file-length.sh` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)