### PR TITLE
fix(daemon): resume a remote session against its respawned sandbox (#1786)

### DIFF
--- a/daemon/limit.go
+++ b/daemon/limit.go
@@ -250,6 +250,13 @@ func (m *Manager) resumeFromLimitLocked(repoID, key string, instance *session.In
 		if rerr := instance.Respawn(); rerr != nil {
 			return fmt.Errorf("failed to re-spawn agent for %q: %w", requestedTitle, rerr)
 		}
+		// Re-fetch: a REMOTE respawn re-provisions a FRESH sandbox and rebinds the
+		// instance to its endpoint (bindProvisionResult swaps remoteClient and clears
+		// the cached agent-server), so the `as` captured above is a client pinned to
+		// the sandbox Respawn just tore down — SendPrompt below would target a dead
+		// endpoint and the resume could never clear the limit (#1786). Inert for local
+		// sessions, whose localAgentServer resolves i.backend per call.
+		as = instance.AgentServer()
 	}
 
 	prompt := strings.TrimSpace(instance.Prompt)

--- a/daemon/limit_remote_resume_test.go
+++ b/daemon/limit_remote_resume_test.go
@@ -1,0 +1,236 @@
+package daemon
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// The #1786 regression: a REMOTE session that hits a usage-limit wall and whose
+// agent exits while blocked must resume against the sandbox its respawn
+// PROVISIONED, not the one the respawn tore down.
+//
+// The local runtime cannot express this bug — localAgentServer resolves
+// i.backend on every call, so a stale capture still lands on the live backend —
+// which is why the existing limit tests (limit_resume_test.go) pass either way.
+// A remote session's agent-server is an HTTP client PINNED to one sandbox URL at
+// construction, so holding one across a respawn silently addresses a dead host.
+// These tests therefore drive two mock sandboxes and assert WHICH one the prompt
+// reaches.
+
+// mockSandbox stands in for an `af agent-server` in a sandbox: it serves the two
+// control routes the limit-resume path drives (/v1/agent/alive to pick the
+// respawn arm, /v1/agent/send-prompt to re-deliver the prompt) in the apiproto
+// {data,error} envelope the remote client decodes, and records every prompt it
+// received so a test can prove the resume targeted it.
+type mockSandbox struct {
+	srv *httptest.Server
+
+	mu      sync.Mutex
+	alive   bool
+	prompts []string
+}
+
+func newMockSandbox(t *testing.T, alive bool) *mockSandbox {
+	t.Helper()
+	s := &mockSandbox{alive: alive}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/agent/alive", func(w http.ResponseWriter, _ *http.Request) {
+		s.mu.Lock()
+		resp := map[string]any{"alive": s.alive}
+		s.mu.Unlock()
+		writeSandboxEnvelope(t, w, resp)
+	})
+	mux.HandleFunc("/v1/agent/send-prompt", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Prompt string `json:"prompt"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("mock sandbox: decode send-prompt: %v", err)
+		}
+		s.mu.Lock()
+		s.prompts = append(s.prompts, req.Prompt)
+		s.mu.Unlock()
+		writeSandboxEnvelope(t, w, struct{}{})
+	})
+	s.srv = httptest.NewServer(mux)
+	t.Cleanup(s.srv.Close)
+	return s
+}
+
+func writeSandboxEnvelope(t *testing.T, w http.ResponseWriter, data any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]any{"data": data}); err != nil {
+		t.Errorf("mock sandbox: encode envelope: %v", err)
+	}
+}
+
+func (s *mockSandbox) endpoint() session.AgentServerEndpoint {
+	return session.AgentServerEndpoint{URL: s.srv.URL, Token: "tok"}
+}
+
+func (s *mockSandbox) gotPrompts() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.prompts...)
+}
+
+// sandboxBackend impersonates a re-provisionable sandbox backend (docker/ssh/
+// hook). Type() reports "docker" so reprovisionRemote resolves the docker
+// Runtime — which the test swaps for a mock via session.SetRuntimeForTest — and
+// Respawn re-provisions + rebinds through the exported RestoreSandbox, the same
+// reprovisionRemote-then-Start core the real backends reach via recoverSandbox.
+// Start is overridden because the embedded FakeBackend's Start blocks until the
+// test releases it, while the respawn here must run to completion inline.
+type sandboxBackend struct {
+	*session.FakeBackend
+	respawns int32
+	mu       sync.Mutex
+}
+
+func newSandboxBackend() *sandboxBackend {
+	return &sandboxBackend{FakeBackend: session.NewFakeBackend()}
+}
+
+func (b *sandboxBackend) Type() string { return "docker" }
+
+func (b *sandboxBackend) Start(*session.Instance, bool) error { return nil }
+
+func (b *sandboxBackend) Respawn(i *session.Instance) error {
+	b.mu.Lock()
+	b.respawns++
+	b.mu.Unlock()
+	if err := i.RestoreSandbox(); err != nil {
+		return err
+	}
+	_ = i.Transition(session.ConfirmLive())
+	return nil
+}
+
+func (b *sandboxBackend) respawnCount() int32 {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.respawns
+}
+
+// mockRuntime provisions the REPLACEMENT sandbox: the endpoint a respawn rebinds
+// the instance onto.
+type mockRuntime struct {
+	backend  session.Backend
+	endpoint session.AgentServerEndpoint
+}
+
+func (r mockRuntime) Provision(session.ProvisionSpec) (session.ProvisionResult, error) {
+	ep := r.endpoint
+	return session.ProvisionResult{Backend: r.backend, Endpoint: &ep}, nil
+}
+
+// newRemoteLimitedSession builds a remote session parked at a usage-limit wall
+// whose agent has exited (old sandbox reports alive=false), registers it with the
+// manager, and wires a respawn that re-provisions onto `fresh`. Returns the
+// manager, repoID, the parked instance, and the backend that records respawns.
+func newRemoteLimitedSession(t *testing.T, old, fresh *mockSandbox, prompt string) (*Manager, string, *session.Instance, *sandboxBackend) {
+	t.Helper()
+	manager, repoID, repoPath := newStatusTestManager(t)
+
+	oldBackend := newSandboxBackend()
+	freshBackend := newSandboxBackend()
+
+	// The respawn's re-provision resolves the docker Runtime out of the registry;
+	// point it at the fresh mock sandbox instead of a real container.
+	t.Cleanup(session.SetRuntimeForTest(session.BackendDocker, func() session.Runtime {
+		return mockRuntime{backend: freshBackend, endpoint: fresh.endpoint()}
+	}))
+	// Build the session against the OLD sandbox: the backend factory supplies the
+	// sandbox backend, RemoteAgentServer pins its agent-server at the old endpoint.
+	restoreFactory := session.SetBackendFactoryForTest(func(session.InstanceOptions, string) (session.Backend, error) {
+		return oldBackend, nil
+	})
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title:             "limited-remote",
+		Path:              repoPath,
+		Program:           "claude",
+		RemoteAgentServer: &session.AgentServerEndpoint{URL: old.srv.URL, Token: "tok"},
+	})
+	restoreFactory()
+	if err != nil {
+		t.Fatalf("NewInstance: %v", err)
+	}
+
+	inst.SetStartedForTest(true)
+	inst.SetStatusForTest(session.Running)
+	inst.Prompt = prompt
+	inst.SetLimitReached(time.Now().Add(-time.Hour))
+
+	seedDiskInstance(t, repoID, inst.Title, repoPath)
+	manager.mu.Lock()
+	manager.instances[daemonInstanceKey(repoID, inst.Title)] = inst
+	manager.mu.Unlock()
+	return manager, repoID, inst, oldBackend
+}
+
+// TestResumeFromLimit_RemoteRespawnTargetsFreshSandbox is the #1786 regression.
+// The agent exited while blocked at the limit wall, so resume takes the respawn
+// arm; the respawn re-provisions a FRESH sandbox and rebinds the instance to its
+// endpoint. The prompt must reach that fresh sandbox. Pre-fix, resumeFromLimit
+// captured the agent-server BEFORE the respawn and reused it after, so the prompt
+// went to the torn-down sandbox and the limit was never cleared.
+func TestResumeFromLimit_RemoteRespawnTargetsFreshSandbox(t *testing.T) {
+	oldSandbox := newMockSandbox(t, false) // agent exited while blocked
+	freshSandbox := newMockSandbox(t, true)
+
+	manager, repoID, inst, backend := newRemoteLimitedSession(t, oldSandbox, freshSandbox, "finish the migration")
+
+	if err := manager.resumeFromLimit(ResumeFromLimitRequest{Title: inst.Title, RepoID: repoID}); err != nil {
+		t.Fatalf("resumeFromLimit: %v", err)
+	}
+
+	if got := backend.respawnCount(); got != 1 {
+		t.Fatalf("a dead remote agent must be re-spawned exactly once, got %d", got)
+	}
+	if got := oldSandbox.gotPrompts(); len(got) != 0 {
+		t.Errorf("prompt went to the torn-down sandbox (#1786 stale agent-server): %v", got)
+	}
+	want := []string{"finish the migration"}
+	if got := freshSandbox.gotPrompts(); len(got) != 1 || got[0] != want[0] {
+		t.Errorf("re-provisioned sandbox prompts = %v, want %v", got, want)
+	}
+	if inst.LimitReached() {
+		t.Error("limit liveness must be cleared once the resume lands on the fresh sandbox")
+	}
+}
+
+// TestResumeFromLimit_RemoteLiveStallKeepsSandbox is the other arm: a remote
+// agent that is merely STALLED at the wall (still alive) needs no respawn, so the
+// prompt must go to its existing sandbox. It fences the fix — re-fetching the
+// agent-server must not disturb the no-respawn path.
+func TestResumeFromLimit_RemoteLiveStallKeepsSandbox(t *testing.T) {
+	liveSandbox := newMockSandbox(t, true) // stalled, but the agent is up
+	freshSandbox := newMockSandbox(t, true)
+
+	manager, repoID, inst, backend := newRemoteLimitedSession(t, liveSandbox, freshSandbox, "keep going")
+
+	if err := manager.resumeFromLimit(ResumeFromLimitRequest{Title: inst.Title, RepoID: repoID}); err != nil {
+		t.Fatalf("resumeFromLimit: %v", err)
+	}
+
+	if got := backend.respawnCount(); got != 0 {
+		t.Fatalf("a live stall needs no re-spawn, got %d", got)
+	}
+	if got := freshSandbox.gotPrompts(); len(got) != 0 {
+		t.Errorf("a live stall must not re-provision a sandbox, but one got prompts: %v", got)
+	}
+	want := []string{"keep going"}
+	if got := liveSandbox.gotPrompts(); len(got) != 1 || got[0] != want[0] {
+		t.Errorf("live sandbox prompts = %v, want %v", got, want)
+	}
+	if inst.LimitReached() {
+		t.Error("limit liveness must be cleared after resuming a live stall")
+	}
+}

--- a/session/runtime.go
+++ b/session/runtime.go
@@ -137,6 +137,25 @@ var runtimeRegistry = map[BackendKind]func() Runtime{
 	BackendSSH:    func() Runtime { return sshRuntime{} },
 }
 
+// SetRuntimeForTest replaces the Runtime registered for kind with ctor and
+// returns a restore function. It is the exported form of the registry swap the
+// in-package sandbox tests already do by hand, so tests OUTSIDE this package (the
+// daemon's remote limit-resume regression, #1786) can drive the real
+// re-provision path — reprovisionRemote resolves the runtime through this
+// registry — against a mock sandbox instead of a real docker/ssh host. Mirrors
+// the SetBackendFactoryForTest / SetDockerSelfBinaryForTest seam pattern.
+func SetRuntimeForTest(kind BackendKind, ctor func() Runtime) func() {
+	prev, had := runtimeRegistry[kind]
+	runtimeRegistry[kind] = ctor
+	return func() {
+		if had {
+			runtimeRegistry[kind] = prev
+			return
+		}
+		delete(runtimeRegistry, kind)
+	}
+}
+
 // ResolveRuntime returns the Runtime registered for kind, or an error naming the
 // unknown backend. Every registered kind is constructible.
 func ResolveRuntime(kind BackendKind) (Runtime, error) {


### PR DESCRIPTION
Fixes #1786.

## Problem
`resumeFromLimitLocked` captured the agent-server **before** respawning the agent and reused it after:

```go
as := instance.AgentServer()
if !as.Alive() {
    if rerr := instance.Respawn(); rerr != nil { ... }
}
...
if serr := as.SendPrompt(prompt); serr != nil { ... }
```

For a **remote** session (docker/ssh/hook), `Respawn()` routes through `recoverSandbox` → `reprovisionRemote` → `bindProvisionResult`, which provisions a **fresh** sandbox, swaps in a new `remoteClient`, and clears the cached agent-server. The captured `as` is a `remoteAgentServer` pinned to the **old** sandbox's URL/token, so `SendPrompt` hit the endpoint the respawn had just torn down. The call failed with a network error, `ClearLimitReached()` was never reached, and the session stayed stuck — unresumable by both the `c` manual retry and the auto-resume scheduler.

Local sessions were never affected: `localAgentServer` resolves `i.backend` on every call, so a stale capture still lands on the live backend. That asymmetry is exactly why the existing limit tests missed this.

Introduced in #1592 Phase 2 (c6d2572), which added the `AgentServer` interface.

## Fix
Re-fetch the agent-server after a successful `Respawn()`, so the prompt targets the sandbox the respawn actually provisioned. Inert for local sessions; load-bearing for remote.

## Adjacent call-site audit
Every other `AgentServer()` capture was checked for the same pattern — `limit.go` was the only site holding one across a rebind:

| Site | Verdict |
|---|---|
| `daemon/manager_status.go`, `task/runner.go`, `session/archive_sandbox.go` | Capture and use with no respawn in between |
| `daemon/agentserver_headless.go` | Forces `BackendLocal`, which resolves per call |

## Test
`daemon/limit_remote_resume_test.go` drives the real `resumeFromLimit` against two mock `af agent-server` sandboxes and asserts **which** one the prompt reaches:

- **Exited agent** → respawn re-provisions → the prompt must reach the fresh sandbox. This fails on pre-fix code with `prompt went to the torn-down sandbox (#1786 stale agent-server): [finish the migration]`, and passes with the fix.
- **Live stall** → no respawn → the prompt stays on the existing sandbox, fencing the fix against disturbing the no-respawn arm.

`session.SetRuntimeForTest` exports the runtime-registry swap the in-package sandbox tests already do by hand, so the daemon test can drive the real re-provision path against a mock instead of a real docker/ssh host. It mirrors the existing `SetBackendFactoryForTest` seam.

## Gates
- `make test-container` — all packages green
- `make tui-driver-selftest` — 31/31 steps green
- `go build ./...`, `gofmt -l .`, `golangci-lint run --fast`, `deadcode -test ./...`, file-length lint — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)