### PR TITLE
fix(tmux): bound clientless tmux commands so a stalled tmux can't hang WS PTY subscriptions or capture transitions (#1787)

### DIFF
--- a/session/tmux/bounded.go
+++ b/session/tmux/bounded.go
@@ -1,0 +1,129 @@
+package tmux
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// Bounded tmux control commands (#1787).
+//
+// The clientless WS PTY paths drive tmux with short, purely-local control
+// commands (capture-pane, display-message, pipe-pane). They are sub-100ms when
+// the tmux server is healthy, but `exec.Command` gives them no deadline at all:
+// a wedged tmux server (one stuck under load, blocked on a stalled pane, or
+// hung on its socket) parks the tmux CLIENT forever, and the Go caller blocks
+// with it. Two paths turn that into a user-visible hang:
+//
+//   - The WS stream handler resolves Subscribe() — which snapshots the pane via
+//     CaptureVisiblePaneGrid/CursorPosition — BEFORE websocket.Accept sends the
+//     101, so a stalled capture means the client never gets a socket. The unix
+//     transport has no handshake timeout and the HTTP server deliberately sets
+//     no WriteTimeout, so nothing else bounds it.
+//   - EnablePipePane/DisablePipePane run while the broker holds captureMu. A
+//     stall there strands the mutex, so EVERY later capture start/stop for that
+//     session deadlocks behind it — not just the one that was unlucky.
+//
+// Bounding the commands themselves fixes both: the deadline is what makes the
+// captureMu hold finite, so no lock restructuring is needed. CapturePaneContentContext
+// already established the exec.CommandContext pattern here; this generalizes it
+// for the commands that had no context to thread.
+//
+// A var (not a const) only so tests can shorten it; production never reassigns.
+var tmuxCommandTimeout = 10 * time.Second
+
+// tmuxWaitDelay bounds how long cmd.Wait blocks after the tmux process exits or
+// is killed on the deadline, before the inherited stdout/stderr pipes are
+// force-closed. Killing tmux does not necessarily close the capture pipe: any
+// process that inherited it (tmux runs pipe-pane's shell command through
+// /bin/sh, and a hung server can leave a child holding the fd) keeps the read
+// end open, and Output()/Run() block on pipe EOF until it dies — which would
+// silently defeat the deadline above. Mirrors gitWaitDelay (#856/#896).
+const tmuxWaitDelay = 2 * time.Second
+
+// ErrTmuxTimeout marks a tmux command that was killed on tmuxCommandTimeout
+// rather than failing on its own. Callers distinguish it from ErrSessionGone:
+// a timeout means the server is wedged and the session's real state is UNKNOWN,
+// so it must never be mistaken for "the session is gone" (which would let a
+// caller tear down a session that is merely slow).
+var ErrTmuxTimeout = errors.New("tmux command timed out")
+
+// boundedTmuxCommand builds a tmux command bound to ctx. It runs in its own
+// process group so the deadline tears down the whole tree — tmux plus any child
+// that inherited the capture pipe — rather than SIGKILLing only the tmux client
+// and orphaning a child that still holds the fd (exec.CommandContext's default
+// Cancel kills just the direct process; #610/#769/#856 precedent).
+func boundedTmuxCommand(ctx context.Context, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "tmux", args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		// Negative pid targets the whole group led by cmd.Process.Pid. A group
+		// already gone (ESRCH) maps to os.ErrProcessDone, which Wait ignores
+		// rather than reporting as a command failure.
+		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+			if errors.Is(err, syscall.ESRCH) {
+				return os.ErrProcessDone
+			}
+			return err
+		}
+		return nil
+	}
+	cmd.WaitDelay = tmuxWaitDelay
+	return cmd
+}
+
+// reapTmuxGroup SIGKILLs any process that outlived the tmux client on every exit
+// path — normal completion or timeout — so a wedged server never leaves a
+// pipe-holding child behind. The group is led by tmux, which has already exited,
+// so this is ESRCH (ignored) in the common case. A nil Process means the command
+// never started (a mock executor in tests, or a failed fork), so there is nothing
+// to reap.
+func reapTmuxGroup(cmd *exec.Cmd) {
+	if cmd.Process != nil {
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+}
+
+// runTmuxBounded runs a tmux command under tmuxCommandTimeout, discarding output.
+func (t *TmuxSession) runTmuxBounded(ctx context.Context, args ...string) error {
+	cmd := boundedTmuxCommand(ctx, args...)
+	err := t.cmdExec.Run(cmd)
+	reapTmuxGroup(cmd)
+	return normalizeWaitDelay(err)
+}
+
+// outputTmuxBounded runs a tmux command under tmuxCommandTimeout and returns stdout.
+func (t *TmuxSession) outputTmuxBounded(ctx context.Context, args ...string) ([]byte, error) {
+	cmd := boundedTmuxCommand(ctx, args...)
+	out, err := t.cmdExec.Output(cmd)
+	reapTmuxGroup(cmd)
+	return out, normalizeWaitDelay(err)
+}
+
+// normalizeWaitDelay converts an exec.ErrWaitDelay into success: tmux itself
+// exited cleanly (a non-zero exit surfaces as an ExitError, not ErrWaitDelay)
+// and only an inherited child held the capture pipe open past tmuxWaitDelay —
+// it was just killed by the reap. The command's work is done, so this is not a
+// failure (#676/#914 precedent).
+func normalizeWaitDelay(err error) error {
+	if errors.Is(err, exec.ErrWaitDelay) {
+		return nil
+	}
+	return err
+}
+
+// tmuxTimeoutContext returns the deadline every bounded tmux command runs under.
+//
+// Callers MUST check ctx.Err() before falling back to a DoesSessionExist probe
+// on the error path: the probe spawns ANOTHER tmux command against the same
+// wedged server, so it would hang exactly like the command that just timed out
+// and defeat the bound we came here for. On a tripped deadline the session's
+// real state is unknown, so callers return ErrTmuxTimeout rather than guessing
+// ErrSessionGone (the same reasoning CapturePaneContentContext applies on
+// cancellation, where it skips the probe and returns ctx.Err() directly).
+func tmuxTimeoutContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), tmuxCommandTimeout)
+}

--- a/session/tmux/bounded_test.go
+++ b/session/tmux/bounded_test.go
@@ -1,0 +1,123 @@
+package tmux
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/cmd"
+)
+
+// stallingTmuxOnPath puts a `tmux` earlier on PATH that never exits, standing in
+// for a wedged tmux server: EVERY tmux invocation — including the
+// DoesSessionExist probe the error paths would otherwise fall back to — hangs.
+// The script sleeps in a CHILD process, so it also covers the case that makes a
+// naive deadline useless: killing only the direct tmux process leaves the child
+// holding the inherited capture pipe, and Output()/Run() block on pipe EOF until
+// it dies. Passing therefore requires the process-group kill AND tmuxWaitDelay,
+// not just exec.CommandContext.
+func stallingTmuxOnPath(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	script := "#!/bin/sh\nsleep 300 &\nwait\n"
+	if err := os.WriteFile(filepath.Join(dir, "tmux"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// shortTmuxTimeout shortens the production deadline so the test asserts in
+// milliseconds instead of tmuxCommandTimeout's generous production value.
+func shortTmuxTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	prev := tmuxCommandTimeout
+	tmuxCommandTimeout = d
+	t.Cleanup(func() { tmuxCommandTimeout = prev })
+}
+
+// TestBoundedTmuxCommandsDoNotHang is the #1787 regression: a stalled tmux must
+// not hang the WS PTY subscribe path (CaptureVisiblePaneGrid / CursorPosition,
+// which run before the 101 upgrade) or the capture transitions
+// (EnablePipePane / DisablePipePane, which run while the broker holds captureMu).
+// Before the fix each of these blocked forever on `exec.Command`; now each is
+// bound by tmuxCommandTimeout and reports ErrTmuxTimeout.
+func TestBoundedTmuxCommandsDoNotHang(t *testing.T) {
+	cases := []struct {
+		name string
+		call func(ts *TmuxSession) error
+	}{
+		{"CaptureVisiblePaneGrid", func(ts *TmuxSession) error { _, err := ts.CaptureVisiblePaneGrid(); return err }},
+		{"CursorPosition", func(ts *TmuxSession) error { _, _, err := ts.CursorPosition(); return err }},
+		{"EnablePipePane", func(ts *TmuxSession) error { return ts.EnablePipePane("dd of=/dev/null") }},
+		{"DisablePipePane", func(ts *TmuxSession) error { return ts.DisablePipePane() }},
+		// Not named in #1787, but the same unbounded pattern on the same WS data
+		// path — covered so the whole clientless channel keeps the invariant.
+		{"SendRawKeys", func(ts *TmuxSession) error { return ts.SendRawKeys([]byte("hi")) }},
+		{"ResizeWindow", func(ts *TmuxSession) error { return ts.ResizeWindow(80, 24) }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stallingTmuxOnPath(t)
+			shortTmuxTimeout(t, 200*time.Millisecond)
+			ts := NewTmuxSessionWithDeps("bounded-1787", "sh", MakePtyFactory(), cmd.MakeExecutor())
+
+			done := make(chan error, 1)
+			go func() { done <- tc.call(ts) }()
+
+			// Generous relative to the 200ms deadline, but far below the fake
+			// tmux's 300s sleep: only a real bound can land inside it.
+			select {
+			case err := <-done:
+				if !errors.Is(err, ErrTmuxTimeout) {
+					t.Fatalf("want ErrTmuxTimeout against a stalled tmux, got %v", err)
+				}
+				// A timeout means the server is wedged and the session's state is
+				// unknown — it must never be reported as a confirmed-gone session.
+				if errors.Is(err, ErrSessionGone) {
+					t.Fatalf("timeout must not be reported as ErrSessionGone: %v", err)
+				}
+			case <-time.After(30 * time.Second):
+				t.Fatalf("%s hung against a stalled tmux (#1787): no return within 30s", tc.name)
+			}
+		})
+	}
+}
+
+// TestBoundedTmuxCommandsSucceedWhenTmuxIsHealthy guards the other direction: the
+// deadline must not break the normal path. A fake tmux that answers immediately
+// stands in for a healthy server, so a regression that always trips the timeout
+// (or that mis-reads a fast exit as a deadline) fails here.
+func TestBoundedTmuxCommandsSucceedWhenTmuxIsHealthy(t *testing.T) {
+	dir := t.TempDir()
+	// display-message drives CursorPosition, which parses "row col"; every other
+	// command just needs a clean exit.
+	script := "#!/bin/sh\nif [ \"$1\" = \"display-message\" ]; then echo '3 7'; else echo 'pane line'; fi\n"
+	if err := os.WriteFile(filepath.Join(dir, "tmux"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	shortTmuxTimeout(t, 10*time.Second)
+	ts := NewTmuxSessionWithDeps("healthy-1787", "sh", MakePtyFactory(), cmd.MakeExecutor())
+
+	if got, err := ts.CaptureVisiblePaneGrid(); err != nil || got != "pane line\n" {
+		t.Fatalf("CaptureVisiblePaneGrid: got %q err %v", got, err)
+	}
+	row, col, err := ts.CursorPosition()
+	if err != nil || row != 3 || col != 7 {
+		t.Fatalf("CursorPosition: got (%d,%d) err %v, want (3,7)", row, col, err)
+	}
+	if err := ts.EnablePipePane("dd of=/dev/null"); err != nil {
+		t.Fatalf("EnablePipePane: %v", err)
+	}
+	if err := ts.DisablePipePane(); err != nil {
+		t.Fatalf("DisablePipePane: %v", err)
+	}
+	if err := ts.SendRawKeys([]byte("hi")); err != nil {
+		t.Fatalf("SendRawKeys: %v", err)
+	}
+	if err := ts.ResizeWindow(80, 24); err != nil {
+		t.Fatalf("ResizeWindow: %v", err)
+	}
+}

--- a/session/tmux/bounded_test.go
+++ b/session/tmux/bounded_test.go
@@ -3,11 +3,14 @@ package tmux
 import (
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"syscall"
 	"testing"
 	"time"
 
 	"github.com/sachiniyer/agent-factory/cmd"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
 )
 
 // stallingTmuxOnPath puts a `tmux` earlier on PATH that never exits, standing in
@@ -121,3 +124,59 @@ func TestBoundedTmuxCommandsSucceedWhenTmuxIsHealthy(t *testing.T) {
 		t.Fatalf("ResizeWindow: %v", err)
 	}
 }
+
+// TestRealPipePaneStreamsPastTheReap pins the invariant that makes the reap in
+// runTmuxBounded/outputTmuxBounded safe: boundedTmuxCommand puts each tmux
+// command in its OWN process group and SIGKILLs that group on every exit path —
+// including SUCCESS — to collect any child holding the capture pipe. That is
+// only correct because `pipe-pane`'s shell command (the broker's `dd`) is
+// spawned by the tmux SERVER, not by the short-lived tmux CLIENT we exec, so it
+// is not in the group we kill. If it ever were, EnablePipePane would destroy its
+// own pipe the instant it succeeded and the WS stream would silently go dead —
+// a far worse regression than the hang this all fixes, and one no mock can
+// catch. So this drives a REAL tmux, on a private server (IsolateTmux) so it
+// cannot touch the developer's sessions.
+func TestRealPipePaneStreamsPastTheReap(t *testing.T) {
+	testguard.IsolateTmux(t)
+
+	const name = "af1787-reap-pipe"
+	ex := cmd.MakeExecutor()
+	if err := ex.Run(exec.Command("tmux", "new-session", "-d", "-s", name, "sh")); err != nil {
+		t.Fatalf("new-session: %v", err)
+	}
+	t.Cleanup(func() { _ = ex.Run(exec.Command("tmux", "kill-session", "-t", "="+name)) })
+
+	ts := NewTmuxSessionFromSanitizedNameWithDeps(name, "sh", MakePtyFactory(), ex)
+	fifo := filepath.Join(t.TempDir(), "pane.out")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+	// O_RDWR so the read end stays valid before tmux's writer opens, mirroring
+	// tmuxClientlessChannel.StartCapture.
+	rc, err := os.OpenFile(fifo, os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatalf("open fifo: %v", err)
+	}
+	t.Cleanup(func() { _ = rc.Close() })
+
+	if err := ts.EnablePipePane("dd of=" + shellQuoteForTest(fifo) + " bs=4096 2>/dev/null"); err != nil {
+		t.Fatalf("EnablePipePane: %v", err)
+	}
+	// Produce output AFTER the pipe is up: pipe-pane only streams future bytes.
+	if err := ts.SendRawKeys([]byte("echo AF1787MARKER\n")); err != nil {
+		t.Fatalf("SendRawKeys: %v", err)
+	}
+	buf := make([]byte, 4096)
+	if err := rc.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		t.Fatalf("set deadline: %v", err)
+	}
+	n, err := rc.Read(buf)
+	if err != nil || n == 0 {
+		t.Fatalf("no bytes streamed after EnablePipePane — did the reap kill pipe-pane's own dd? err=%v n=%d", err, n)
+	}
+	if err := ts.DisablePipePane(); err != nil {
+		t.Fatalf("DisablePipePane: %v", err)
+	}
+}
+
+func shellQuoteForTest(s string) string { return "'" + s + "'" }

--- a/session/tmux/clientless.go
+++ b/session/tmux/clientless.go
@@ -1,9 +1,6 @@
 package tmux
 
-import (
-	"fmt"
-	"os/exec"
-)
+import "fmt"
 
 // Clientless control channel (#1592 Phase 2 PR5). These primitives capture pane
 // output and drive input/size WITHOUT a `tmux attach-session` render client:
@@ -27,9 +24,19 @@ import (
 // `tmux pipe-pane -O` (output only). tmux runs shellCommand through /bin/sh, so
 // the broker passes e.g. `cat >> <fifo>`. A pane may hold only one pipe at a
 // time; DisablePipePane closes it.
+//
+// Bounded by tmuxCommandTimeout (#1787). The broker calls this while holding
+// captureMu, so an unbounded stall would strand that mutex and deadlock every
+// LATER capture start/stop for the session — the deadline is what keeps the
+// lock hold finite. On a tripped deadline it returns ErrTmuxTimeout without
+// probing DoesSessionExist — see tmuxTimeoutContext.
 func (t *TmuxSession) EnablePipePane(shellCommand string) error {
-	cmd := exec.Command("tmux", "pipe-pane", "-O", "-t", exactTarget(t.sanitizedName), shellCommand)
-	if err := t.cmdExec.Run(cmd); err != nil {
+	ctx, cancel := tmuxTimeoutContext()
+	defer cancel()
+	if err := t.runTmuxBounded(ctx, "pipe-pane", "-O", "-t", exactTarget(t.sanitizedName), shellCommand); err != nil {
+		if ctx.Err() != nil {
+			return fmt.Errorf("%w: pipe-pane after %s", ErrTmuxTimeout, tmuxCommandTimeout)
+		}
 		if !t.DoesSessionExist() {
 			return fmt.Errorf("%w: pipe-pane", ErrSessionGone)
 		}
@@ -41,9 +48,20 @@ func (t *TmuxSession) EnablePipePane(shellCommand string) error {
 // DisablePipePane closes the pane's current output pipe. `tmux pipe-pane` with no
 // shell-command closes the active pipe (tmux man page); a missing session is a
 // no-op success since the pipe is already gone with it.
+//
+// Bounded by tmuxCommandTimeout (#1787), for the same captureMu reason as
+// EnablePipePane — this runs on the teardown half of the transition. A tripped
+// deadline reports ErrTmuxTimeout rather than the missing-session no-op success:
+// the server is wedged, so whether the pipe is actually closed is UNKNOWN, and
+// silently claiming success would let the broker believe it had torn down a pipe
+// that may still be writing.
 func (t *TmuxSession) DisablePipePane() error {
-	cmd := exec.Command("tmux", "pipe-pane", "-t", exactTarget(t.sanitizedName))
-	if err := t.cmdExec.Run(cmd); err != nil {
+	ctx, cancel := tmuxTimeoutContext()
+	defer cancel()
+	if err := t.runTmuxBounded(ctx, "pipe-pane", "-t", exactTarget(t.sanitizedName)); err != nil {
+		if ctx.Err() != nil {
+			return fmt.Errorf("%w: pipe-pane after %s", ErrTmuxTimeout, tmuxCommandTimeout)
+		}
 		if !t.DoesSessionExist() {
 			return nil
 		}
@@ -56,6 +74,13 @@ func (t *TmuxSession) DisablePipePane() error {
 // (hex-encoded), so arbitrary control bytes (arrow keys, Ctrl sequences) land
 // exactly as typed — the interactive multi-writer input path. Empty input is a
 // no-op.
+//
+// Bounded by tmuxCommandTimeout (#1787). This runs on the WS reader goroutine,
+// which holds no broker lock, so a stall here is milder than the pipe-pane pair
+// above — it strands one connection's input loop rather than the session's
+// capture transitions. It is bounded anyway to keep ONE invariant over the whole
+// clientless channel — no tmux command on the WS data path is unbounded — rather
+// than leaving a second, subtler way for a wedged server to park a goroutine.
 func (t *TmuxSession) SendRawKeys(b []byte) error {
 	if len(b) == 0 {
 		return nil
@@ -65,8 +90,12 @@ func (t *TmuxSession) SendRawKeys(b []byte) error {
 	for _, c := range b {
 		args = append(args, fmt.Sprintf("%02x", c))
 	}
-	cmd := exec.Command("tmux", args...)
-	if err := t.cmdExec.Run(cmd); err != nil {
+	ctx, cancel := tmuxTimeoutContext()
+	defer cancel()
+	if err := t.runTmuxBounded(ctx, args...); err != nil {
+		if ctx.Err() != nil {
+			return fmt.Errorf("%w: send-keys after %s", ErrTmuxTimeout, tmuxCommandTimeout)
+		}
 		if !t.DoesSessionExist() {
 			return fmt.Errorf("%w: send-keys", ErrSessionGone)
 		}
@@ -78,10 +107,19 @@ func (t *TmuxSession) SendRawKeys(b []byte) error {
 // ResizeWindow sets the window to cols×rows with `resize-window -x -y`, which
 // switches the window to a manual size so it no longer tracks an attached
 // client's dimensions — the clientless last-resize-wins size the broker applies.
+//
+// Bounded by tmuxCommandTimeout (#1787), for the same whole-channel invariant as
+// SendRawKeys. The broker already applies the size best-effort (it broadcasts its
+// authoritative resize echo regardless of whether this succeeds), so a wedged
+// server costs the pane resize, never the echo clients reflow on.
 func (t *TmuxSession) ResizeWindow(cols, rows int) error {
-	cmd := exec.Command("tmux", "resize-window", "-t", exactTarget(t.sanitizedName),
-		"-x", fmt.Sprintf("%d", cols), "-y", fmt.Sprintf("%d", rows))
-	if err := t.cmdExec.Run(cmd); err != nil {
+	ctx, cancel := tmuxTimeoutContext()
+	defer cancel()
+	if err := t.runTmuxBounded(ctx, "resize-window", "-t", exactTarget(t.sanitizedName),
+		"-x", fmt.Sprintf("%d", cols), "-y", fmt.Sprintf("%d", rows)); err != nil {
+		if ctx.Err() != nil {
+			return fmt.Errorf("%w: resize-window after %s", ErrTmuxTimeout, tmuxCommandTimeout)
+		}
 		if !t.DoesSessionExist() {
 			return fmt.Errorf("%w: resize-window", ErrSessionGone)
 		}

--- a/session/tmux/io.go
+++ b/session/tmux/io.go
@@ -189,10 +189,19 @@ func (t *TmuxSession) CapturePaneContentContext(ctx context.Context) (string, er
 // width, so a client wider or narrower than the pane shifts the rows out from under
 // the absolute cursor move. Wraps ErrSessionGone when the session has vanished,
 // mirroring CapturePaneContent (#496, #1006).
+//
+// Bounded by tmuxCommandTimeout (#1787): this runs on the WS subscribe path
+// BEFORE the 101 upgrade, so an unbounded stall here means the client never
+// receives a socket at all. On a tripped deadline it returns ErrTmuxTimeout
+// without probing DoesSessionExist — see tmuxTimeoutContext.
 func (t *TmuxSession) CaptureVisiblePaneGrid() (string, error) {
-	cmd := exec.Command("tmux", "capture-pane", "-p", "-e", "-t", exactTarget(t.sanitizedName))
-	output, err := t.cmdExec.Output(cmd)
+	ctx, cancel := tmuxTimeoutContext()
+	defer cancel()
+	output, err := t.outputTmuxBounded(ctx, "capture-pane", "-p", "-e", "-t", exactTarget(t.sanitizedName))
 	if err != nil {
+		if ctx.Err() != nil {
+			return "", fmt.Errorf("%w: capture-pane grid after %s", ErrTmuxTimeout, tmuxCommandTimeout)
+		}
 		if !t.DoesSessionExist() {
 			return "", fmt.Errorf("%w: capture-pane: %v", ErrSessionGone, err)
 		}
@@ -207,10 +216,19 @@ func (t *TmuxSession) CaptureVisiblePaneGrid() (string, error) {
 // cursor actually is, so a fresh subscriber's redraw does not orphan a stale copy
 // of the line at the top (the duplicated-prompt artifact). `=` forces an exact
 // session match, mirroring CapturePaneContent (#1006).
+//
+// Bounded by tmuxCommandTimeout (#1787): like CaptureVisiblePaneGrid it runs on
+// the WS subscribe path before the 101 upgrade. The broker already treats a
+// cursor-read failure as best-effort (degrading to a screen-only repaint), so a
+// wedged server costs the cursor restore rather than the whole subscription.
 func (t *TmuxSession) CursorPosition() (row, col int, err error) {
-	cmd := exec.Command("tmux", "display-message", "-p", "-t", exactTarget(t.sanitizedName), "#{cursor_y} #{cursor_x}")
-	output, err := t.cmdExec.Output(cmd)
+	ctx, cancel := tmuxTimeoutContext()
+	defer cancel()
+	output, err := t.outputTmuxBounded(ctx, "display-message", "-p", "-t", exactTarget(t.sanitizedName), "#{cursor_y} #{cursor_x}")
 	if err != nil {
+		if ctx.Err() != nil {
+			return 0, 0, fmt.Errorf("%w: display-message after %s", ErrTmuxTimeout, tmuxCommandTimeout)
+		}
 		return 0, 0, fmt.Errorf("failed to read tmux cursor position: %v", err)
 	}
 	if _, err := fmt.Sscanf(strings.TrimSpace(string(output)), "%d %d", &row, &col); err != nil {


### PR DESCRIPTION
Fixes #1787.

## Verified, not assumed

Reproduced on current master before changing anything. A fake `tmux` on `PATH` that never exits stands in for a wedged server; every clientless primitive blocked indefinitely:

```
HANG REPRODUCED: CaptureVisiblePaneGrid did not return within 5s against a stalled tmux
HANG REPRODUCED: CursorPosition        did not return within 5s against a stalled tmux
HANG REPRODUCED: EnablePipePane        did not return within 5s against a stalled tmux
HANG REPRODUCED: DisablePipePane       did not return within 5s against a stalled tmux
```

The report is accurate: the whole chain checks out in code — `daemon/ws_pty.go:95` calls `Subscribe` before `websocket.Accept` (line 107) → `localAgentServer.Subscribe` → `ptybroker.subscribe` → `ch.Snapshot()` → `CaptureVisiblePaneGrid`/`CursorPosition`; and `ensureCaptureStarted`/`maybeStopCapture` hold `captureMu` across `StartCapture`/`StopCapture` → `EnablePipePane`/`DisablePipePane`.

## The bug

These paths drove tmux with `exec.Command`, which has no deadline. A wedged tmux server parks the tmux *client* forever and the Go caller blocks with it:

- **WS subscribe hangs before the 101.** The stream handler resolves `Subscribe()` — which snapshots the pane — *before* `websocket.Accept` sends the upgrade, so a stalled capture means the client never gets a socket at all. The unix transport has no handshake timeout and the HTTP server deliberately sets no `WriteTimeout`, so nothing else bounded it.
- **Capture transitions deadlock.** `EnablePipePane`/`DisablePipePane` run while the broker holds `captureMu`. A stall stranded the mutex, deadlocking **every later** capture start/stop for that session — not just the unlucky one.

## The fix

Bound the commands themselves. The deadline is what makes the `captureMu` hold finite, so **no lock restructuring is needed**. `CapturePaneContentContext` already established the `exec.CommandContext` pattern here; this generalizes it to the commands that had no context to thread.

**`exec.CommandContext` alone is not enough — and fails silently.** I verified this: a naive context-only fix still hangs, because it SIGKILLs only the tmux client while a child that inherited the capture pipe keeps it open, and `Output()` blocks on pipe EOF until that child dies. So commands run in their **own process group** (killed as a tree) with a **`WaitDelay`** bound — mirroring the `runGitCommandContext` precedent (#856/#896). The regression test fails against the naive version, so this can't quietly rot back.

Two deliberate error-path decisions:
- On a tripped deadline, callers **skip the `DoesSessionExist` probe** — it spawns another tmux against the same wedged server and would hang exactly like the command that just timed out, defeating the bound.
- A timeout returns `ErrTmuxTimeout`, **never `ErrSessionGone`**. The server is wedged, so the session's real state is *unknown*; claiming "gone" would let a caller tear down a session that is merely slow.

## Scope note (beyond the issue)

`SendRawKeys`/`ResizeWindow` are bounded too. They aren't named in #1787 and are genuinely milder — they hold no broker lock, so a stall strands one connection's input loop rather than the session's capture transitions — but they're the same unbounded pattern on the same WS data path. Bounding them gives one invariant over the whole clientless channel (no unbounded tmux command on the WS data path) instead of leaving the next Detail bug queued. `clientless.go` no longer imports `os/exec` at all.

`DoesSessionExist`/`sessionExists` are deliberately **not** bounded: they're reachable here only via error paths that now skip them on a deadline, and giving them a timeout would make a slow server look like a *missing* session to every liveness caller — a worse failure than the one being fixed.

## Gates

| Gate | Result |
|---|---|
| `make test-container` | green (full suite) |
| `make tui-driver-selftest` | **31/31** steps green |
| `go build ./...` | clean |
| `gofmt -l .` | clean |
| `golangci-lint run --fast` | clean |
| `deadcode -test ./...` | clean |
| `scripts/lint-file-length.sh` | passed |

Three tests, each pinning a different failure mode:

- **`TestBoundedTmuxCommandsDoNotHang`** — the #1787 regression. Drives a real stalled tmux (a fake `tmux` on PATH sleeping in a **child**, so it covers the inherited-pipe case) and asserts each primitive returns `ErrTmuxTimeout` instead of hanging. Verified to fail on master, and against the naive context-only fix.
- **`TestBoundedTmuxCommandsSucceedWhenTmuxIsHealthy`** — guards the normal path, so a regression that always trips the deadline (or misreads a fast exit as one) fails too.
- **`TestRealPipePaneStreamsPastTheReap`** — pins the invariant that makes the reap safe. The group-kill fires on *every* exit path including success, which is only correct because `pipe-pane`'s `dd` is spawned by the tmux **server**, not the client we exec. Verified against a real tmux (bytes stream fine), and pinned here: if that ever changed, `EnablePipePane` would destroy its own pipe the instant it succeeded and the WS stream would silently go dead — worse than the hang being fixed, and invisible to mock executors. Runs on a private tmux server (`testguard.IsolateTmux`) so it cannot touch a developer's real sessions.

Not merging — flagged green for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
