### PR TITLE
fix(doctor): take a fresh process snapshot at temp-home fix time (#1785)

### DIFF
--- a/doctor/checks.go
+++ b/doctor/checks.go
@@ -588,14 +588,17 @@ func staleTempHomeRemoveFix(ctx *scanContext, dir string) func() error {
 		//     daemon.pid + tmux guards, exactly as before — otherwise --fix
 		//     could never clean a stale temp home on such platforms.
 		snap := ctx.snap
-		if ctx.opts.snapshot != nil {
-			fresh, err := ctx.opts.snapshot()
-			switch {
-			case err == nil:
-				snap = fresh
-			case ctx.snap != nil:
-				return fmt.Errorf("refusing to remove %s: process snapshot failed: %w", dir, err)
-			}
+		if ctx.opts.snapshot == nil {
+			// Unreachable via Run (applyDefaults always installs one). Fail
+			// closed rather than delete on the stale detection snapshot.
+			return fmt.Errorf("refusing to remove %s: no process snapshot available", dir)
+		}
+		fresh, err := ctx.opts.snapshot()
+		switch {
+		case err == nil:
+			snap = fresh
+		case ctx.snap != nil:
+			return fmt.Errorf("refusing to remove %s: process snapshot failed: %w", dir, err)
 		}
 		if reason := tempHomeInUseReason(dir, processReferencedHomes(snap), liveTmuxHomes(ctx)); reason != "" {
 			return fmt.Errorf("refusing to remove %s: %s", dir, reason)

--- a/doctor/doctor.go
+++ b/doctor/doctor.go
@@ -159,34 +159,62 @@ type scanContext struct {
 	selfAncestors map[int]bool
 }
 
-// Run executes all checks and (when opts.Fix) applies the safe remediations.
-func Run(opts Options) (*Report, error) {
-	if opts.ConfigDir == "" {
+// applyDefaults resolves every zero-valued option to its production default.
+// It must run to completion before the Options are copied into a scanContext:
+// a default applied afterwards would land on this copy only and never reach
+// the checks, silently disabling whatever it guards (see #1785).
+func (o *Options) applyDefaults() error {
+	if o.ConfigDir == "" {
 		dir, err := config.GetConfigDir()
 		if err != nil {
-			return nil, fmt.Errorf("resolving agent-factory home: %w", err)
+			return fmt.Errorf("resolving agent-factory home: %w", err)
 		}
-		opts.ConfigDir = dir
+		o.ConfigDir = dir
 	}
-	if opts.TempDir == "" {
-		opts.TempDir = tempDirDefault()
+	if o.TempDir == "" {
+		o.TempDir = tempDirDefault()
 	}
-	if opts.Exec == nil {
-		opts.Exec = cmd.MakeExecutor()
+	if o.Exec == nil {
+		o.Exec = cmd.MakeExecutor()
 	}
-	if opts.MinTempHomeAge == 0 {
-		opts.MinTempHomeAge = 7 * 24 * time.Hour
+	if o.MinTempHomeAge == 0 {
+		o.MinTempHomeAge = 7 * 24 * time.Hour
 	}
-	if opts.killGrace == 0 {
-		opts.killGrace = 2 * time.Second
+	if o.killGrace == 0 {
+		o.killGrace = 2 * time.Second
 	}
-	if opts.killTermWait == 0 {
-		opts.killTermWait = 2 * time.Second
+	if o.killTermWait == 0 {
+		o.killTermWait = 2 * time.Second
+	}
+	if o.snapshot == nil {
+		o.snapshot = proctree.Snapshot
+	}
+	return nil
+}
+
+// newScanContext defaults the options and seals them into the run's context.
+// Every caller must go through here: scanContext holds its own copy of the
+// Options, so this is the one place where defaulting is guaranteed to happen
+// before that copy is taken.
+func newScanContext(opts Options) (*scanContext, error) {
+	if err := opts.applyDefaults(); err != nil {
+		return nil, err
+	}
+	return &scanContext{opts: opts, selfAncestors: map[int]bool{}}, nil
+}
+
+// Run executes all checks and (when opts.Fix) applies the safe remediations.
+// Past the constructor, ctx.opts is the only source of truth for the run's
+// options — reading or mutating the `opts` argument here would diverge from
+// what the checks actually see (#1785).
+func Run(opts Options) (*Report, error) {
+	ctx, err := newScanContext(opts)
+	if err != nil {
+		return nil, err
 	}
 
-	ctx := &scanContext{opts: opts, selfAncestors: map[int]bool{}}
 	report := &Report{}
-	if opts.Setup {
+	if ctx.opts.Setup {
 		checkSetup(ctx, report)
 		return report, nil
 	}
@@ -194,11 +222,7 @@ func Run(opts Options) (*Report, error) {
 	cfg := checkConfigAndStorage(ctx, report)
 	checkEnvironment(ctx, report, cfg)
 
-	if opts.snapshot == nil {
-		opts.snapshot = proctree.Snapshot
-	}
-
-	if snap, err := opts.snapshot(); err == nil {
+	if snap, err := ctx.opts.snapshot(); err == nil {
 		ctx.snap = snap
 		for pid := range selfAndAncestors(snap) {
 			ctx.selfAncestors[pid] = true
@@ -213,7 +237,7 @@ func Run(opts Options) (*Report, error) {
 	checkForeignDaemons(ctx, report)
 	checkRemoteSetup(ctx, report)
 
-	if opts.Fix {
+	if ctx.opts.Fix {
 		for i := range report.Findings {
 			f := &report.Findings[i]
 			if f.fix == nil {

--- a/doctor/temp_home_liveness_test.go
+++ b/doctor/temp_home_liveness_test.go
@@ -104,6 +104,67 @@ func TestTempHomeDaemonUncertainLivenessSparesHome(t *testing.T) {
 	require.True(t, okContains(report, "daemon.pid liveness is uncertain"))
 }
 
+// TestScanContextDefaultsSnapshot pins the invariant broken by #1785: the
+// context the checks read must carry a snapshot func even when the caller
+// supplied none. Defaulting after the scanContext copies the Options left
+// ctx.opts.snapshot nil in production, quietly turning the fix-time process
+// recheck in staleTempHomeRemoveFix into dead code that only tests reached.
+func TestScanContextDefaultsSnapshot(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	// Production shape: no injected snapshot, exactly as `af doctor` calls it.
+	ctx, err := newScanContext(Options{TempDir: t.TempDir()})
+	require.NoError(t, err)
+	require.NotNil(t, ctx.opts.snapshot,
+		"scan context must carry a snapshot func, else the fix-time process recheck is unreachable")
+}
+
+// TestStaleTempHomeRefusesWithoutSnapshotFunc pins the fail-closed branch: a
+// context with no snapshot func cannot recheck for live processes, so it must
+// refuse rather than delete on the stale detection snapshot.
+func TestStaleTempHomeRefusesWithoutSnapshotFunc(t *testing.T) {
+	tempRoot := t.TempDir()
+	dir := makeOldTempAFHome(t, tempRoot, "tmp.no-snapshot-func")
+	ctx := &scanContext{opts: Options{TempDir: tempRoot, ConfigDir: t.TempDir()}}
+
+	err := staleTempHomeRemoveFix(ctx, dir)()
+	require.ErrorContains(t, err, "no process snapshot available")
+	require.DirExists(t, dir, "an un-recheckable home must fail closed, not be removed")
+}
+
+// TestStaleTempHomeClaimedAfterDetectionIsSpared is the behavioral contract the
+// fix-time recheck exists for: a home that looked abandoned during detection but
+// was claimed by a process before --fix ran must survive. The snapshot func hides
+// the claimer from the detection pass and reveals it at fix time, standing in for
+// a process that started in between.
+func TestStaleTempHomeClaimedAfterDetectionIsSpared(t *testing.T) {
+	tempRoot := t.TempDir()
+	dir := makeOldTempAFHome(t, tempRoot, "tmp.claimed-late")
+
+	claimer := spawnWithEnv(t, "sh", nil, map[string]string{"AGENT_FACTORY_HOME": dir})
+
+	opts := macLikeTempHomeOptions(t, tempRoot, true)
+	var calls int
+	opts.snapshot = func() (map[int]proctree.Process, error) {
+		calls++
+		if calls == 1 {
+			// Detection: the claimer has not started yet.
+			return map[int]proctree.Process{}, nil
+		}
+		// Fix time: the claimer now holds the home.
+		return map[int]proctree.Process{claimer.PID: claimer}, nil
+	}
+
+	report, err := Run(opts)
+	require.NoError(t, err)
+	require.Greater(t, calls, 1, "fix must re-take the process snapshot, not reuse the detection one")
+
+	findings := findByCheck(report, "stale-temp-home")
+	require.Len(t, findings, 1, "detection saw an abandoned home and proposed removing it")
+	require.False(t, findings[0].Fixed)
+	require.ErrorContains(t, findings[0].FixErr, "live process references it")
+	require.DirExists(t, dir, "a home claimed between detection and fix must not be removed")
+}
+
 func TestTempHomeWithLiveTmuxSessionMarkerSparesHomeWithoutProc(t *testing.T) {
 	tempRoot := t.TempDir()
 	dir := makeOldTempAFHome(t, tempRoot, "tmp.live-session")


### PR DESCRIPTION
Fixes #1785.

## Verified, not assumed

The report is accurate. Reproduced on current master (`57a1ce2`) before touching anything, with a throwaway test mirroring `Run`'s exact ordering:

```
--- FAIL: TestRepro1785
    REPRO #1785: ctx.opts.snapshot nil in production -> fix-time fresh snapshot recheck unreachable
```

## Root cause

`doctor/doctor.go:187` copied `Options` into the `scanContext` **before** `doctor/doctor.go:197-199` defaulted `opts.snapshot` to `proctree.Snapshot`. `scanContext.opts` is a value, so the later assignment landed on `Run`'s local only — `ctx.opts.snapshot` stayed nil in every production run.

The fix-time recheck in `staleTempHomeRemoveFix` (`doctor/checks.go:591`) is guarded by `ctx.opts.snapshot != nil`, so it never ran outside tests. `af doctor --fix` rechecked tmux and daemon liveness live, but evaluated the **process** guard against the stale detection snapshot — the one case the recheck was added for in #1308.

Coverage looked healthy because `testOptions()` injects a non-nil `snapshot`, so tests exercised a branch production could not reach.

Introduced by 5605e13c (`--setup`), which moved `ctx` construction above the snapshot defaulting to support the early return.

## Impact

A temp home claimed by a process that started **after** the scan could be removed out from under it. Narrow (needs an old, otherwise-abandoned home claimed mid-run) but it is the exact silent-data-loss case the recheck was written to prevent, and the process guard was the only one degraded.

## The fix — structural, not a one-line patch

Rather than propagate the field into the existing copy (the report's suggested `ctx.opts.snapshot = opts.snapshot`), this removes the shape that allowed it:

- All defaulting moves into `Options.applyDefaults`, and **`newScanContext` is the single constructor** that defaults *then* seals the copy. The bad ordering can no longer be expressed at the call site.
- `Run` reads `ctx.opts` exclusively past construction, deleting the dual source of truth between the local `opts` and the context's copy.
- The `snapshot == nil` case in `staleTempHomeRemoveFix` now **fails closed** with a clear refusal instead of silently falling back to stale data — a hand-rolled `scanContext` is safe by default, consistent with #1728.

The `--setup` early return is unaffected: `checkSetup`/`checkEnvironment` never touch `snapshot`, verified by grep and by running `af doctor --setup` against the patched binary.

## Cleanup safety

Unchanged where it matters: on a platform with no `/proc` (macOS), a failed fresh snapshot with `ctx.snap == nil` still falls through to the `daemon.pid` + tmux guards, so `--fix` can still clean stale temp homes there. The only behavior change is that the process guard now actually runs.

## Regression tests

| Test | Pins |
|---|---|
| `TestScanContextDefaultsSnapshot` | The broken invariant — **fails against the old ordering** (verified by reintroducing it) |
| `TestStaleTempHomeRefusesWithoutSnapshotFunc` | The fail-closed branch: no snapshot func ⇒ refuse, don't delete |
| `TestStaleTempHomeClaimedAfterDetectionIsSpared` | The behavioral contract: a home claimed between detection and fix survives `--fix`, with `FixErr` = `live process references it` |

## Adjacent call-sites

Swept the repo for the same copy-then-default shape. Only four value-typed options fields exist; the three `ProvisionSpec` cases (docker/ssh/hook backends) default at `session/instance_factory.go:86` *before* `Provision(spec)` at `:88` and are unaffected. Every other config carrier is a pointer, making the bug structurally impossible. No other instances.

## Gates

- `make test-container` — green, all packages
- `make tui-driver-selftest` — **31/31** green (harness has grown past 25)
- `go build ./...` — clean
- `gofmt -l .` — clean
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean
- `scripts/lint-file-length.sh` — clean
- Ran the patched binary: `af doctor` and `af doctor --setup` both behave normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)