### PR TITLE
docs(daemon): correct daemon-start + require_token help (#1802 codex follow-up)

### DIFF
--- a/commands/daemoncmd.go
+++ b/commands/daemoncmd.go
@@ -14,12 +14,12 @@ import (
 )
 
 // The daemon is the single always-on host for task schedules (cron and watch
-// scripts) and autoyes mode (#782), and serves the web UI. The af root path
-// starts it only for autoyes or when an enabled task exists
-// (ensureDaemonForTasks), so a fresh install with no enabled tasks has no
-// daemon and no web listener; `af daemon install` registers a user-level
-// autostart unit so schedules and the web UI survive logouts and reboots
-// without ever opening af.
+// scripts) and autoyes mode (#782), and serves the web UI. Launching the TUI
+// starts it: the cold start reads session state through the daemon
+// (coldStartFromSnapshot -> withDaemonHTTP -> daemon.EnsureDaemon), and autoyes
+// and ensureDaemonForTasks cover the other root-path cases. `af daemon install`
+// registers a user-level autostart unit so schedules and the web UI survive
+// logouts and reboots without ever opening af.
 
 var daemonCmd = &cobra.Command{
 	Use:   "daemon",
@@ -28,14 +28,13 @@ var daemonCmd = &cobra.Command{
 watch-task scripts, drives autoyes mode, and serves the bundled WEB UI.
 
 The web UI is part of the daemon — there is no separate web command — so it is
-reachable only while the daemon is running. Merely running af does not start
-one: the daemon comes up for autoyes mode, or when an enabled task exists. On a
-fresh install with no enabled tasks, 'af config list' and the TUI leave the web
-listener down and http://localhost:8443 refuses the connection. To bring it up,
-install the autostart unit (below) or take a daemon-backed action such as
-creating a session.
+served whenever the daemon is running. Running af starts one: the TUI reads
+session state through the daemon and spawns it if none is up, so simply opening
+af serves the web UI. Autoyes mode and any enabled task start one too. Only
+standalone commands that never talk to the daemon (such as 'af config list')
+leave it down.
 
-Once the daemon is running, open:
+With af running, open:
 
     http://localhost:8443
 

--- a/commands/daemoncmd.go
+++ b/commands/daemoncmd.go
@@ -14,32 +14,45 @@ import (
 )
 
 // The daemon is the single always-on host for task schedules (cron and watch
-// scripts) and autoyes mode (#782). It starts automatically whenever af runs
-// and an enabled task exists; `af daemon install` additionally registers a
-// user-level autostart unit so schedules survive logouts and reboots without
-// ever opening af.
+// scripts) and autoyes mode (#782), and serves the web UI. The af root path
+// starts it only for autoyes or when an enabled task exists
+// (ensureDaemonForTasks), so a fresh install with no enabled tasks has no
+// daemon and no web listener; `af daemon install` registers a user-level
+// autostart unit so schedules and the web UI survive logouts and reboots
+// without ever opening af.
 
 var daemonCmd = &cobra.Command{
 	Use:   "daemon",
 	Short: "Manage the background daemon: serves the web UI and schedules tasks",
 	Long: `The agent-factory daemon runs task cron schedules in-process, supervises
-watch-task scripts, drives autoyes mode, and serves the bundled WEB UI. It
-starts automatically when you run af.
+watch-task scripts, drives autoyes mode, and serves the bundled WEB UI.
 
-The web UI is part of the daemon — there is no separate web command. Once the
-daemon is running, open:
+The web UI is part of the daemon — there is no separate web command — so it is
+reachable only while the daemon is running. Merely running af does not start
+one: the daemon comes up for autoyes mode, or when an enabled task exists. On a
+fresh install with no enabled tasks, 'af config list' and the TUI leave the web
+listener down and http://localhost:8443 refuses the connection. To bring it up,
+install the autostart unit (below) or take a daemon-backed action such as
+creating a session.
+
+Once the daemon is running, open:
 
     http://localhost:8443
 
 It needs no token by default, so the page connects as soon as it loads. Set
-listen_addr to change the address (or to "" to turn the web server off), and
-require_token = true to put the UI behind a bearer token ('af token show').
+listen_addr to change the address (or to "" to turn the web server off).
+require_token = true demands a bearer token ('af token show') from NETWORK
+peers; on the default loopback listener same-host callers stay exempt, so the
+UI keeps opening with no login on this machine. Add require_loopback_token =
+true to require the token from localhost as well.
 Note 'af agent-server' does NOT serve the web UI: it is the headless
 per-workspace backend a daemon drives on a remote machine.
 
 Install the daemon as a user-level autostart unit (systemd user service on
 Linux, launchd agent on macOS) so tasks keep firing and the web UI stays up
-after reboots, even when af is never opened.`,
+after reboots, even when af is never opened:
+
+    af daemon install`,
 }
 
 var daemonInstallCmd = &cobra.Command{

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -563,14 +563,13 @@ The agent-factory daemon runs task cron schedules in-process, supervises
 watch-task scripts, drives autoyes mode, and serves the bundled WEB UI.
 
 The web UI is part of the daemon — there is no separate web command — so it is
-reachable only while the daemon is running. Merely running af does not start
-one: the daemon comes up for autoyes mode, or when an enabled task exists. On a
-fresh install with no enabled tasks, 'af config list' and the TUI leave the web
-listener down and http://localhost:8443 refuses the connection. To bring it up,
-install the autostart unit (below) or take a daemon-backed action such as
-creating a session.
+served whenever the daemon is running. Running af starts one: the TUI reads
+session state through the daemon and spawns it if none is up, so simply opening
+af serves the web UI. Autoyes mode and any enabled task start one too. Only
+standalone commands that never talk to the daemon (such as 'af config list')
+leave it down.
 
-Once the daemon is running, open:
+With af running, open:
 
     http://localhost:8443
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -560,23 +560,34 @@ af config set <key> <value> [flags]
 Manage the background daemon: serves the web UI and schedules tasks
 
 The agent-factory daemon runs task cron schedules in-process, supervises
-watch-task scripts, drives autoyes mode, and serves the bundled WEB UI. It
-starts automatically when you run af.
+watch-task scripts, drives autoyes mode, and serves the bundled WEB UI.
 
-The web UI is part of the daemon — there is no separate web command. Once the
-daemon is running, open:
+The web UI is part of the daemon — there is no separate web command — so it is
+reachable only while the daemon is running. Merely running af does not start
+one: the daemon comes up for autoyes mode, or when an enabled task exists. On a
+fresh install with no enabled tasks, 'af config list' and the TUI leave the web
+listener down and http://localhost:8443 refuses the connection. To bring it up,
+install the autostart unit (below) or take a daemon-backed action such as
+creating a session.
+
+Once the daemon is running, open:
 
     http://localhost:8443
 
 It needs no token by default, so the page connects as soon as it loads. Set
-listen_addr to change the address (or to "" to turn the web server off), and
-require_token = true to put the UI behind a bearer token ('af token show').
+listen_addr to change the address (or to "" to turn the web server off).
+require_token = true demands a bearer token ('af token show') from NETWORK
+peers; on the default loopback listener same-host callers stay exempt, so the
+UI keeps opening with no login on this machine. Add require_loopback_token =
+true to require the token from localhost as well.
 Note 'af agent-server' does NOT serve the web UI: it is the headless
 per-workspace backend a daemon drives on a remote machine.
 
 Install the daemon as a user-level autostart unit (systemd user service on
 Linux, launchd agent on macOS) so tasks keep firing and the web UI stays up
-after reboots, even when af is never opened.
+after reboots, even when af is never opened:
+
+    af daemon install
 
 ```
 af daemon


### PR DESCRIPTION
Follow-up to #1802. Codex flagged two `af daemon --help` lines that #1802
introduced as misleading; a second codex pass then caught my first fix
over-correcting. Both rounds are in this PR, verified against the code.
Help/comment text only — no behavior change.

## 1. `require_token` does not gate the loopback UI

`webListenerPolicy` (`daemon/tcpserver.go:114`) grants a loopback exemption:

```go
loopbackExempt: isLoopbackListenAddr(cfg.ListenAddr) && !cfg.RequireLoopbackToken,
```

and `defaultListenAddr` is `127.0.0.1:8443` (`config/config_types.go:33`). So on
the default bind, `require_token = true` alone leaves the same-machine UI open
with **no login** — the opposite of what someone hardening a shared box would
conclude from the old wording ("require_token = true to put the UI behind a
bearer token").

The help now states that `require_token` gates **network** peers with loopback
exempt, and points at `require_loopback_token = true` to require the token from
localhost too.

## 2. The daemon-start wording (corrected twice)

The original #1802 line — "It starts automatically when you run af" — was flagged
as implying every `af` invocation starts the daemon. My first fix swung too far
the other way, claiming "Merely running af does not start one" and that the TUI
leaves the listener down. **That was wrong**, and codex caught it: launching the
TUI *does* start the daemon, on every launch:

```
newHome (app/home_model.go:395)   snapshotFetcher: snapshotThroughDaemon
  -> coldStartFromSnapshot        (app/home_model.go:418)
  -> snapshotThroughDaemon        (app/session_control.go:277)
  -> withDaemonHTTP               (app/session_control.go:43)
  -> daemon.EnsureDaemon()        (app/session_control.go:47-48, local targets)
```

It isn't best-effort either — `coldStartFromSnapshot` failing is fatal
(`os.Exit(1)`), so a running TUI implies a running daemon, which implies the web
listener is up on the default `listen_addr`.

Final wording: running af starts the daemon and serves the UI at
http://localhost:8443; autoyes and the enabled-task path (`ensureDaemonForTasks`)
start one too; only standalone commands that never talk to the daemon leave it
down. `af config list` is a true example of that — `commands/configcmd.go`
contains no `EnsureDaemon`/`withDaemonHTTP`.

## Also

- Corrects the file-top comment the same way (it originally omitted the autoyes
  start path, then inherited my over-correction).
- `docs/reference/cli.md` regenerated via `scripts/gen-docs.sh`; the diff is
  exactly the help change, no drift.
- The rest of #1802 is untouched: token-off default, real login errors, and
  `af agent-server` is not the frontend.

**Scope note:** the prose docs were already accurate — `docs/web.md:132`
documents "loopback stays exempt" and `docs/tasks.md:5` includes the
enabled-task condition — so the inaccuracy was confined to the command help. No
adjacent doc fixes were needed.

## Gates (re-run after the round-2 fix)

| Gate | Result |
|---|---|
| `make test-container` | green, 0 failures |
| `make tui-driver-selftest` | 31/31 steps green |
| `go build ./...` | clean |
| `gofmt -l .` | no output |
| `golangci-lint run --fast` | clean |
| `deadcode -test ./...` | no output |
| `scripts/lint-file-length.sh` | passed (611 files) |
| `scripts/gen-docs.sh` | regenerated, committed |

Note: the selftest harness reports **31/31** steps, not the 25/25 in the
original ask — it has grown since. All steps green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
