### PR TITLE
fix(daemon): debounce remote Lost + bound confirmation probe (#1794 codex follow-up)

### DIFF
--- a/daemon/agentserver_headless.go
+++ b/daemon/agentserver_headless.go
@@ -314,7 +314,17 @@ type agentAliveResponse struct {
 }
 
 func (hs *headlessServer) Alive(_ struct{}, resp *agentAliveResponse) error {
-	resp.Alive = hs.as.Alive()
+	alive, err := hs.as.Alive()
+	if err != nil {
+		// Propagate rather than answering a confident `alive:false`. This is the
+		// SERVER end of the probe the daemon uses to decide whether to re-provision
+		// a sandbox, and the caller must be able to tell "the agent is gone" from
+		// "nobody could tell" — reporting the latter as the former is what
+		// re-provisions over live work (#1794). In practice the in-sandbox server
+		// probes its own tmux in-process and never errors.
+		return err
+	}
+	resp.Alive = alive
 	return nil
 }
 

--- a/daemon/agentserver_headless_test.go
+++ b/daemon/agentserver_headless_test.go
@@ -50,7 +50,7 @@ func (f *fakeHeadlessAgentServer) Snapshot() (session.Observation, error) {
 	return session.Observation{Updated: true, HasPrompt: false, Content: f.snapshotText}, nil
 }
 func (f *fakeHeadlessAgentServer) Preview(int, bool) (string, error) { return "preview-body", nil }
-func (f *fakeHeadlessAgentServer) Alive() bool                       { return true }
+func (f *fakeHeadlessAgentServer) Alive() (bool, error)              { return true, nil }
 func (f *fakeHeadlessAgentServer) Archive() (string, error)          { return "session/fake", nil }
 func (f *fakeHeadlessAgentServer) SendPrompt(p string) error {
 	f.mu.Lock()

--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -251,12 +251,18 @@ func (m *Manager) restoreRemoteSession(repoID string, instance *session.Instance
 		m.persistInstance(repoID, instance)
 		return "", fmt.Errorf("failed to restore remote session %q (re-provisioning its sandbox): %w", title, err)
 	}
-	m.persistInstance(repoID, instance)
 	// A FRESH sandbox now backs this session, so its accumulated remote-loss
-	// failures describe a sandbox that is gone (#1794). The instance keeps the
-	// same ID across the re-provision — same session, new runtime — so nothing
-	// else can notice; only this site knows the runtime was replaced.
+	// failures describe a sandbox that is gone (#1794). Reset BEFORE the persist
+	// and log below, not after: RestoreFromArchive has already flipped the session
+	// live and dropped OpRestoring, and the poll goroutine neither takes the
+	// op-lock nor checks killsInFlight — so it can probe the new sandbox while
+	// this call is still writing to disk, and a blip in that window would be
+	// judged against the OLD sandbox's threshold-satisfying count and mark the
+	// fresh runtime Lost. The instance keeps the same ID across the re-provision
+	// (same session, new runtime), so nothing else can notice the swap; only this
+	// site knows it happened.
 	m.noteRuntimeReplaced(repoID, instance)
+	m.persistInstance(repoID, instance)
 	log.InfoLog.Printf("restored remote session %q (repo %s): fresh sandbox provisioned, branch cloned back, agent relaunched", title, repoID)
 	return title, nil
 }

--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -252,6 +252,11 @@ func (m *Manager) restoreRemoteSession(repoID string, instance *session.Instance
 		return "", fmt.Errorf("failed to restore remote session %q (re-provisioning its sandbox): %w", title, err)
 	}
 	m.persistInstance(repoID, instance)
+	// A FRESH sandbox now backs this session, so its accumulated remote-loss
+	// failures describe a sandbox that is gone (#1794). The instance keeps the
+	// same ID across the re-provision — same session, new runtime — so nothing
+	// else can notice; only this site knows the runtime was replaced.
+	m.noteRuntimeReplaced(repoID, instance)
 	log.InfoLog.Printf("restored remote session %q (repo %s): fresh sandbox provisioned, branch cloned back, agent relaunched", title, repoID)
 	return title, nil
 }

--- a/daemon/limit.go
+++ b/daemon/limit.go
@@ -273,7 +273,7 @@ func (m *Manager) resumeFromLimitLocked(repoID, key string, instance *session.In
 		}
 		// The runtime this session's failure history was about is gone; the fresh
 		// sandbox must not inherit it (#1794).
-		m.clearRemoteLoss(remoteLossKey(repoID, instance))
+		m.noteRuntimeReplaced(repoID, instance)
 		// Re-fetch: a REMOTE respawn re-provisions a FRESH sandbox and rebinds the
 		// instance to its endpoint (bindProvisionResult swaps remoteClient and clears
 		// the cached agent-server), so the `as` captured above is a client pinned to

--- a/daemon/limit.go
+++ b/daemon/limit.go
@@ -235,9 +235,8 @@ func (m *Manager) resumeFromLimitLocked(repoID, key string, instance *session.In
 		return fmt.Errorf("session %q cannot be resumed", requestedTitle)
 	}
 
-	// Re-spawn only when the agent's tmux session actually exited while blocked
-	// (the edge case where the agent dropped to a shell / the pane vanished). A
-	// live stall — the common claude/codex case — just needs the un-stall prompt.
+	// Re-spawn only when the agent's session actually exited while blocked (the
+	// edge case where the agent dropped to a shell / the pane vanished).
 	//
 	// Respawn, NOT Recover: the session is LiveLimitReached, and Recover's !Lost
 	// guard rejects any non-Lost liveness, so routing a limit retry through Recover
@@ -245,11 +244,36 @@ func (m *Manager) resumeFromLimitLocked(repoID, key string, instance *session.In
 	// (same resumeProgram path: claude --continue, codex resume --last); the
 	// LimitReached/no-tombstone precondition is enforced above under the target
 	// lock.
+	//
+	// The probe decides whether to re-spawn, so an UNANSWERED probe must never
+	// reach that arm (#1794). A remote Respawn is recoverSandbox — provision a
+	// fresh sandbox, clone the branch from origin — so acting on "we could not
+	// tell" re-provisions on a transport blip and orphans a live sandbox with its
+	// unpushed work. This is the poll goroutine and it runs later in the SAME tick
+	// as RefreshStatuses, so it had to be closed here too and not just there: the
+	// poll's debounce protects the Lost path, not this one.
+	//
+	// Note this needs no debounce of its own — it needs the DISTINCTION. A
+	// blip yields probeUnknown and is refused outright; a durable outage is what
+	// the poll's debounce settles to Lost, which drops this session out of
+	// LimitReached and hands it to the Lost-restore loop (the one place remote
+	// re-provision belongs, with its own recheck). What remains is probeDead: the
+	// sandbox answered that its agent exited while blocked — the #1786 case — and
+	// that is authoritative, so it re-spawns at once, exactly as before.
 	as := instance.AgentServer()
-	if !as.Alive() {
+	switch probe := probeLiveness(instance, as); probe {
+	case probeAlive:
+		// A live stall — the common claude/codex case. No re-spawn; the un-stall
+		// prompt below is all it needs.
+	case probeUnknown:
+		return fmt.Errorf("cannot resume %q: its agent-server did not answer the liveness probe; not re-spawning, because re-provisioning a sandbox that may still be running would orphan it and discard its unpushed work", requestedTitle)
+	case probeDead:
 		if rerr := instance.Respawn(); rerr != nil {
 			return fmt.Errorf("failed to re-spawn agent for %q: %w", requestedTitle, rerr)
 		}
+		// The runtime this session's failure history was about is gone; the fresh
+		// sandbox must not inherit it (#1794).
+		m.clearRemoteLoss(remoteLossKey(repoID, instance))
 		// Re-fetch: a REMOTE respawn re-provisions a FRESH sandbox and rebinds the
 		// instance to its endpoint (bindProvisionResult swaps remoteClient and clears
 		// the cached agent-server), so the `as` captured above is a client pinned to

--- a/daemon/limit_remote_resume_test.go
+++ b/daemon/limit_remote_resume_test.go
@@ -100,6 +100,20 @@ func newSandboxBackend() *sandboxBackend {
 
 func (b *sandboxBackend) Type() string { return "docker" }
 
+// Capabilities matches what backend_docker.go actually reports: an off-box
+// workspace that advertises Recover. The embedded FakeBackend claims a LOCAL
+// worktree, which would route this double around the remote-only branches the
+// resume path takes (#1794) and quietly test the wrong runtime.
+func (b *sandboxBackend) Capabilities() session.Capabilities {
+	return session.Capabilities{
+		Workspace:        session.WorkspaceRemote,
+		Attach:           true,
+		Archive:          true,
+		Recover:          true,
+		InteractiveInput: true,
+	}
+}
+
 func (b *sandboxBackend) Start(*session.Instance, bool) error { return nil }
 
 func (b *sandboxBackend) Respawn(i *session.Instance) error {
@@ -232,5 +246,73 @@ func TestResumeFromLimit_RemoteLiveStallKeepsSandbox(t *testing.T) {
 	}
 	if inst.LimitReached() {
 		t.Error("limit liveness must be cleared after resuming a live stall")
+	}
+}
+
+// TestResumeLimitedSessions_RemoteBlipDoesNotRespawn is codex's #3 on PR #1804:
+// the limit-resume path bypassing the remote-loss debounce.
+//
+// The poll's debounce guards the Lost path. It does NOT guard this one, and this
+// one runs LATER IN THE SAME TICK: RunDaemon calls RefreshStatuses, then
+// RestoreLostSessions, then ResumeLimitedSessions. A limit-parked remote session
+// whose sandbox blips is left at LiveLimitReached by the poll (correctly — one
+// unanswered probe is not death), and then auto-resume picks it up, sees its own
+// probe fail, and takes the re-spawn arm. For docker/ssh/hook that Respawn is
+// recoverSandbox: a brand-new sandbox, the branch cloned from origin, and the
+// original container left running and unreferenced with all its unpushed work.
+// So with limit_auto_resume on and the window due, a single blip re-provisioned
+// anyway and the debounce bought nothing.
+//
+// The fix is the DISTINCTION rather than a second debounce: an unanswered probe
+// (probeUnknown) can never reach the re-spawn arm. Here the sandbox stops
+// answering while its container keeps running — it must not be re-provisioned,
+// and the session must stay parked for a later retry.
+func TestResumeLimitedSessions_RemoteBlipDoesNotRespawn(t *testing.T) {
+	oldSandbox := newMockSandbox(t, true) // stalled at the wall, container alive
+	freshSandbox := newMockSandbox(t, true)
+
+	manager, _, inst, backend := newRemoteLimitedSession(t, oldSandbox, freshSandbox, "keep going")
+	manager.cfg.LimitAutoResume = true
+
+	// The blip: the agent-server stops answering. The sandbox is NOT gone — it is
+	// still running, holding commits that were never pushed.
+	oldSandbox.srv.Close()
+
+	manager.ResumeLimitedSessions()
+
+	if got := backend.respawnCount(); got != 0 {
+		t.Fatalf("respawns = %d, want 0 — a single unanswered probe re-provisioned a limit-parked remote, orphaning its live sandbox and every unpushed commit on it (#1794)", got)
+	}
+	if got := freshSandbox.gotPrompts(); len(got) != 0 {
+		t.Fatalf("a replacement sandbox was provisioned and prompted (%v) on the strength of one blip", got)
+	}
+	if !inst.LimitReached() {
+		t.Error("the session must stay parked at the wall so a later tick can retry once the transport recovers, not be silently resolved by a failed probe")
+	}
+}
+
+// TestResumeLimitedSessions_RemoteDeadAgentStillRespawns fences the fix above
+// from becoming "never re-spawn a remote". The #1786 case must still work: the
+// sandbox ANSWERS that its agent exited while blocked at the wall. That is
+// authoritative, not a blip, so the re-spawn fires immediately with no debounce
+// — and the prompt lands on the fresh sandbox.
+func TestResumeLimitedSessions_RemoteDeadAgentStillRespawns(t *testing.T) {
+	oldSandbox := newMockSandbox(t, false) // answers: the agent exited
+	freshSandbox := newMockSandbox(t, true)
+
+	manager, _, inst, backend := newRemoteLimitedSession(t, oldSandbox, freshSandbox, "finish the migration")
+	manager.cfg.LimitAutoResume = true
+
+	manager.ResumeLimitedSessions()
+
+	if got := backend.respawnCount(); got != 1 {
+		t.Fatalf("respawns = %d, want 1 — an ANSWERED dead-agent report is authoritative and must re-spawn at once; the debounce is only for probes that could not be answered", got)
+	}
+	want := []string{"finish the migration"}
+	if got := freshSandbox.gotPrompts(); len(got) != 1 || got[0] != want[0] {
+		t.Fatalf("fresh sandbox prompts = %v, want %v", got, want)
+	}
+	if inst.LimitReached() {
+		t.Error("the limit must be cleared once the resume lands")
 	}
 }

--- a/daemon/lostrestore.go
+++ b/daemon/lostrestore.go
@@ -182,17 +182,19 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 	// answers proves the sandbox is there, so heal the row and let the next poll
 	// settle its real liveness. Bounded, so a genuinely wedged remote cannot
 	// stall the poll loop here either.
-	if isRemoteWorkspace(inst) {
-		if aliveWithin(inst.AgentServer(), remoteLostConfirmTimeout) == probeAlive {
-			log.InfoLog.Printf("not re-provisioning lost remote session %q: its sandbox answers as alive (re-provisioning would orphan it and lose unpushed work) — clearing the Lost mark", inst.Title)
-			_ = inst.Transition(session.ObserveLiveness(session.LiveRunning))
-			m.persistInstance(repoID, inst)
-			m.clearRemoteLoss(remoteLossKey(repoID, inst))
-			m.mu.Lock()
-			delete(m.lostRestoreStates, key)
-			m.mu.Unlock()
-			return
-		}
+	if m.remoteSandboxAnswersAlive(inst) {
+		log.InfoLog.Printf("not re-provisioning lost remote session %q: its sandbox answers as alive (re-provisioning would orphan it and lose unpushed work) — clearing the Lost mark", inst.Title)
+		_ = inst.Transition(session.ObserveLiveness(session.LiveRunning))
+		// Clear before the persist, same ordering rule as the recovery path below:
+		// the answered probe already ended the loss episode, and leaving the stale
+		// count in place across a disk write lets a blip in that window re-mark the
+		// very session we just proved alive.
+		m.clearRemoteLoss(remoteLossKey(repoID, inst))
+		m.persistInstance(repoID, inst)
+		m.mu.Lock()
+		delete(m.lostRestoreStates, key)
+		m.mu.Unlock()
+		return
 	}
 
 	if err := inst.Recover(); err != nil {
@@ -210,16 +212,19 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 		return
 	}
 
-	log.InfoLog.Printf("restored lost session %q (repo %s): agent re-spawned in its workspace", inst.Title, repoID)
-	// Drop the remote-loss debounce along with the retry state (#1794). Recovery
-	// REPLACED the runtime those failures were about — for a remote session the
-	// sandbox behind them no longer exists — so the accumulated count describes a
-	// thing that is gone. Left behind, it stays threshold-satisfying, and the
-	// first transport blip against the FRESH sandbox would immediately re-satisfy
-	// the debounce and re-provision again, orphaning the sandbox we just built:
-	// the debounce defeated at exactly the moment it matters most. Any lifecycle
-	// event that replaces or revalidates the runtime must reset this counter.
+	// Drop the remote-loss debounce FIRST — before the log and the retry-state
+	// bookkeeping below (#1794). Recovery REPLACED the runtime those failures were
+	// about: for a remote session the sandbox behind them no longer exists, so the
+	// accumulated count describes a thing that is gone. Left behind, it stays
+	// threshold-satisfying, and the first transport blip against the FRESH sandbox
+	// would immediately re-satisfy the debounce and re-provision again, orphaning
+	// the sandbox we just built — the debounce defeated at exactly the moment it
+	// matters most. The poll goroutine takes neither this op-lock nor
+	// killsInFlight, and Recover has already cleared the restore fence, so it can
+	// probe the new sandbox the instant Recover returns; every statement between
+	// the swap and this reset widens that window for nothing.
 	m.noteRuntimeReplaced(repoID, inst)
+	log.InfoLog.Printf("restored lost session %q (repo %s): agent re-spawned in its workspace", inst.Title, repoID)
 	m.mu.Lock()
 	delete(m.lostRestoreStates, key)
 	m.mu.Unlock()

--- a/daemon/lostrestore.go
+++ b/daemon/lostrestore.go
@@ -219,7 +219,7 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 	// the debounce and re-provision again, orphaning the sandbox we just built:
 	// the debounce defeated at exactly the moment it matters most. Any lifecycle
 	// event that replaces or revalidates the runtime must reset this counter.
-	m.clearRemoteLoss(remoteLossKey(repoID, inst))
+	m.noteRuntimeReplaced(repoID, inst)
 	m.mu.Lock()
 	delete(m.lostRestoreStates, key)
 	m.mu.Unlock()

--- a/daemon/lostrestore.go
+++ b/daemon/lostrestore.go
@@ -23,6 +23,13 @@ import (
 // at the cap, never a permanent give-up, one ERROR escalation when the cause
 // looks persistent. The user's off-ramp from a permanently failing restore is
 // killing the session (which tombstones it).
+//
+// REMOTE sessions are not "restored in place" and never were: docker/ssh/hook
+// advertise Recover, but theirs is recoverSandbox — provision a NEW sandbox and
+// clone the branch back from origin, so only PUSHED state survives. That makes
+// recovering a remote session destructive if it was not really lost, which is
+// the asymmetry #1794 addresses: the poll debounces the Lost mark, and this loop
+// re-probes the sandbox before acting on it.
 
 // lostRestoreEscalationThreshold mirrors rootEnsureEscalationThreshold: the
 // consecutive-failure count at which one ERROR log marks the cause as
@@ -82,6 +89,14 @@ func (m *Manager) RestoreLostSessions() {
 			delete(m.lostRestoreStates, key)
 		}
 	}
+	// Same unbounded-growth guard for the remote-loss debounce (#1794): a probe
+	// success drops an entry, but a session killed mid-episode never gets that
+	// success, so sweep entries whose instance is gone.
+	for key := range m.remoteLossStates {
+		if _, live := m.instances[key]; !live {
+			delete(m.remoteLossStates, key)
+		}
+	}
 	m.mu.Unlock()
 
 	// Stable order so multi-session recovery after an outage is deterministic
@@ -93,12 +108,17 @@ func (m *Manager) RestoreLostSessions() {
 }
 
 // restoreLostSession attempts recovery of one session when it is eligible:
-// Lost, local, not tombstoned, not the reserved root (EnsureRootAgents owns
-// that), and no kill in flight. Recover runs under the per-session operation
-// lock KillSession takes, so a kill arriving mid-attempt waits for the
-// attempt and then tears down — the two operations never interleave. This
-// side only TryLocks: the poll goroutine must never stall behind a slow
-// teardown, and the next tick retries.
+// Lost, Recover-capable, not tombstoned, not the reserved root
+// (EnsureRootAgents owns that), and no kill in flight. Recover runs under the
+// per-session operation lock KillSession takes, so a kill arriving mid-attempt
+// waits for the attempt and then tears down — the two operations never
+// interleave. This side only TryLocks: the poll goroutine must never stall
+// behind a slow teardown, and the next tick retries.
+//
+// "Recover-capable", NOT "local": docker/ssh/hook all advertise Recover, so
+// remote sessions DO flow through here — and their Recover re-provisions rather
+// than reconnects. That is why this function re-probes a remote sandbox before
+// recovering it (#1794); see the gate below.
 func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance) {
 	// Only a Lost session is recovery-eligible. This gate is also what fences
 	// out an Archived session (#1028): Archived != Lost, and an archived
@@ -157,6 +177,30 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 	m.mu.Unlock()
 	if killing || current != inst || inst.UserKilled() || inst.GetStatus() != session.Lost {
 		return
+	}
+
+	// Last gate before an IRREVERSIBLE step (#1794). A remote session's Recover
+	// is not a reconnect — recoverSandbox provisions a BRAND-NEW sandbox and
+	// clones the branch back from origin, so running it against a sandbox that
+	// is in fact still up orphans that sandbox and abandons everything it never
+	// pushed. The poll's debounce makes a blip-induced Lost unlikely, but this
+	// row may have gone Lost many ticks ago (restore is backoff-throttled out to
+	// 5 minutes) and the transport may have healed since. Re-probe NOW, against
+	// live state, rather than trusting a stale verdict: an agent-server that
+	// answers proves the sandbox is there, so heal the row and let the next poll
+	// settle its real liveness. Bounded, so a genuinely wedged remote cannot
+	// stall the poll loop here either.
+	if isRemoteWorkspace(inst) {
+		if aliveWithin(inst.AgentServer(), remoteLostConfirmTimeout) {
+			log.InfoLog.Printf("not re-provisioning lost remote session %q: its sandbox answers as alive (re-provisioning would orphan it and lose unpushed work) — clearing the Lost mark", inst.Title)
+			_ = inst.Transition(session.ObserveLiveness(session.LiveRunning))
+			m.persistInstance(repoID, inst)
+			m.clearRemoteLoss(key)
+			m.mu.Lock()
+			delete(m.lostRestoreStates, key)
+			m.mu.Unlock()
+			return
+		}
 	}
 
 	if err := inst.Recover(); err != nil {

--- a/daemon/lostrestore.go
+++ b/daemon/lostrestore.go
@@ -89,14 +89,6 @@ func (m *Manager) RestoreLostSessions() {
 			delete(m.lostRestoreStates, key)
 		}
 	}
-	// Same unbounded-growth guard for the remote-loss debounce (#1794): a probe
-	// success drops an entry, but a session killed mid-episode never gets that
-	// success, so sweep entries whose instance is gone.
-	for key := range m.remoteLossStates {
-		if _, live := m.instances[key]; !live {
-			delete(m.remoteLossStates, key)
-		}
-	}
 	m.mu.Unlock()
 
 	// Stable order so multi-session recovery after an outage is deterministic
@@ -191,11 +183,11 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 	// settle its real liveness. Bounded, so a genuinely wedged remote cannot
 	// stall the poll loop here either.
 	if isRemoteWorkspace(inst) {
-		if aliveWithin(inst.AgentServer(), remoteLostConfirmTimeout) {
+		if aliveWithin(inst.AgentServer(), remoteLostConfirmTimeout) == probeAlive {
 			log.InfoLog.Printf("not re-provisioning lost remote session %q: its sandbox answers as alive (re-provisioning would orphan it and lose unpushed work) — clearing the Lost mark", inst.Title)
 			_ = inst.Transition(session.ObserveLiveness(session.LiveRunning))
 			m.persistInstance(repoID, inst)
-			m.clearRemoteLoss(key)
+			m.clearRemoteLoss(remoteLossKey(repoID, inst))
 			m.mu.Lock()
 			delete(m.lostRestoreStates, key)
 			m.mu.Unlock()
@@ -218,7 +210,16 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 		return
 	}
 
-	log.InfoLog.Printf("restored lost session %q (repo %s): tmux re-spawned in its worktree", inst.Title, repoID)
+	log.InfoLog.Printf("restored lost session %q (repo %s): agent re-spawned in its workspace", inst.Title, repoID)
+	// Drop the remote-loss debounce along with the retry state (#1794). Recovery
+	// REPLACED the runtime those failures were about — for a remote session the
+	// sandbox behind them no longer exists — so the accumulated count describes a
+	// thing that is gone. Left behind, it stays threshold-satisfying, and the
+	// first transport blip against the FRESH sandbox would immediately re-satisfy
+	// the debounce and re-provision again, orphaning the sandbox we just built:
+	// the debounce defeated at exactly the moment it matters most. Any lifecycle
+	// event that replaces or revalidates the runtime must reset this counter.
+	m.clearRemoteLoss(remoteLossKey(repoID, inst))
 	m.mu.Lock()
 	delete(m.lostRestoreStates, key)
 	m.mu.Unlock()

--- a/daemon/lostrestore_test.go
+++ b/daemon/lostrestore_test.go
@@ -3,8 +3,11 @@ package daemon
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	stdlog "log"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -619,5 +622,67 @@ func TestRestoreLostSessions_StateCleanedForGoneSessions(t *testing.T) {
 	manager.mu.Unlock()
 	if hasState {
 		t.Fatal("retry state for a gone session must be dropped")
+	}
+}
+
+// TestRestoreLostSessions_AliveRemoteSandboxIsNotReprovisioned is the #1794
+// restore-time guard: the last gate before the irreversible step.
+//
+// A remote Recover is not a reconnect — recoverSandbox provisions a BRAND-NEW
+// sandbox and clones the branch back from origin — so running it against a
+// sandbox that is still up orphans that sandbox and abandons every commit it
+// never pushed. The poll's debounce makes a blip-induced Lost unlikely, but this
+// row may have been marked Lost many ticks ago (restore backs off to 5 minutes)
+// and the transport may have healed since. A stale verdict must not authorize a
+// destructive re-provision, so the loop re-probes against live state first.
+//
+// Here the sandbox answers as alive, so the Lost mark is wrong: no Recover may
+// fire, and the row must heal rather than sit Lost forever.
+func TestRestoreLostSessions_AliveRemoteSandboxIsNotReprovisioned(t *testing.T) {
+	withRemoteLossThresholds(t, 3, time.Minute, time.Second)
+	zeroRestoreBackoff(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/v1/agent/alive" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{"alive": true},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst, backend := registerStartedRemote(t, manager, repoID, repoPath, "remote-lost-but-live", srv.URL, session.Lost)
+
+	manager.RestoreLostSessions()
+
+	if got := backend.recoverCalls(); got != 0 {
+		t.Fatalf("Recover calls = %d, want 0 — the sandbox answered as alive, and re-provisioning over a live sandbox orphans it and destroys its unpushed work (#1794)", got)
+	}
+	if got := inst.GetLiveness(); got == session.LiveLost {
+		t.Fatal("liveness is still LiveLost: a sandbox proven alive must have its Lost mark cleared, not be left stranded in a state the loop refuses to act on")
+	}
+}
+
+// TestRestoreLostSessions_UnreachableRemoteSandboxIsReprovisioned is the
+// companion that keeps the #1794 recheck from becoming a blanket "never restore
+// remote sessions". A genuinely gone sandbox (nothing listening, so the probe is
+// refused outright) must still be re-provisioned — that recovery IS the feature
+// (#1108/#1782), and the recheck only exists to veto it when the sandbox proves
+// it is still there.
+func TestRestoreLostSessions_UnreachableRemoteSandboxIsReprovisioned(t *testing.T) {
+	withRemoteLossThresholds(t, 3, time.Minute, time.Second)
+	zeroRestoreBackoff(t)
+
+	manager, repoID, repoPath := newStatusTestManager(t)
+	_, backend := registerStartedRemote(t, manager, repoID, repoPath, "remote-really-gone", "http://127.0.0.1:1", session.Lost)
+
+	manager.RestoreLostSessions()
+
+	if got := backend.recoverCalls(); got != 1 {
+		t.Fatalf("Recover calls = %d, want 1 — an unreachable sandbox must still be recovered; the recheck is a veto on live sandboxes, not a block on remote restore", got)
 	}
 }

--- a/daemon/manager.go
+++ b/daemon/manager.go
@@ -69,6 +69,12 @@ type Manager struct {
 	// auto-resume scheduler (#1146 PR3), keyed by daemon instance key — the
 	// opt-in sibling of lostRestoreStates. Guarded by m.mu.
 	limitResumeStates map[string]*limitResumeState
+	// remoteLossStates debounces the remote Lost transition (#1794), keyed by
+	// daemon instance key. A remote probe failure is transport-shaped — one
+	// blip fails identically to a dead sandbox — so the poll accumulates
+	// consecutive failures here and only settles Lost once they are durable.
+	// Guarded by m.mu; entries are dropped the moment a probe succeeds.
+	remoteLossStates map[string]*remoteLossState
 	// instanceOpLocks serializes the mutually-exclusive per-session
 	// operations — kill teardown and Lost-recovery — by daemon instance key.
 	// killsInFlight alone is a point-in-time signal; this lock is what makes
@@ -141,6 +147,7 @@ func newManagerShell(cfg *config.Config) (*Manager, error) {
 		killsInFlight:       make(map[string]struct{}),
 		lostRestoreStates:   make(map[string]*lostRestoreState),
 		limitResumeStates:   make(map[string]*limitResumeState),
+		remoteLossStates:    make(map[string]*remoteLossState),
 		instanceOpLocks:     make(map[string]*sync.Mutex),
 		pausedPolls:         make(map[string]time.Time),
 		events:              newEventsHub(),

--- a/daemon/manager_status.go
+++ b/daemon/manager_status.go
@@ -156,6 +156,7 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 	// poll makes no assumption that the session is local tmux. For the local
 	// runtime the agent-server drives tmux in-process.
 	as := instance.AgentServer()
+	key := daemonInstanceKey(repoID, instance.Title)
 	before := instance.GetLiveness()
 	beforeReset, _ := instance.LimitResetAt()
 	// Snapshot dismisses a pending trust prompt then reads the pane in one probe
@@ -170,23 +171,18 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 		// forward, an agent-server crash.
 		//
 		// A failed probe is not by itself proof of death: a transient blip against
-		// a healthy sandbox errors identically. So confirm with the INDEPENDENT
-		// Alive() probe rather than either trusting or ignoring the error outright.
-		// Alive() is a second REST call that reports false on any transport error,
-		// so a genuinely unreachable agent-server fails both and settles to Lost,
-		// while a one-off Snapshot error against a still-reachable server leaves
-		// the status for the next tick — the conservative behaviour the paused /
-		// in-flight-op early returns above keep.
+		// a healthy sandbox errors identically, and acting on one is destructive —
+		// Lost feeds RestoreLostSessions in this same tick, whose remote Recover
+		// RE-PROVISIONS a fresh sandbox and orphans the running one along with its
+		// unpushed commits (#1794). So require DURABLE failure (see remoteloss.go)
+		// before even considering Lost.
 		//
 		// Lost, not Dead (#1108): no kill intent is on record, so the session
 		// vanished out from under a live record and stays recovery-eligible.
 		// Without this the remote session kept its last-known liveness
 		// (Running/Ready) forever while its agent-server was gone, so the TUI
 		// showed a healthy row for a dead session (#1782).
-		if !as.Alive() {
-			_ = instance.Transition(session.ObserveLiveness(session.LiveLost))
-			m.persistPollChange(repoID, instance, before, beforeReset)
-		}
+		m.settleRemoteProbeFailure(repoID, key, instance, before, beforeReset)
 		return
 	}
 	updated, hasPrompt, content := obs.Updated, obs.HasPrompt, obs.Content
@@ -200,13 +196,24 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 		// the next poll — a one-interval AutoYes delay (#992).
 		as.TapEnter()
 	}
+	// The remote-loss debounce (#1794) counts CONSECUTIVE observations that found
+	// no evidence of life, so each branch below that DID find some clears it. Note
+	// what does not clear it: a merely-successful Snapshot. The agent-server
+	// answering proves the transport works, not that the agent is alive — a
+	// container whose agent died while its agent-server keeps serving returns a
+	// clean idle (false,false) snapshot every tick. Clearing on Snapshot success
+	// would reset the count on exactly those ticks and the Alive-false branch could
+	// never accumulate past one, so that session would never be marked Lost at all
+	// — silently regressing #935/#1108 for remote sessions.
 	switch {
 	case updated:
+		m.clearRemoteLoss(key) // fresh output — the agent is demonstrably alive
 		_ = instance.Transition(session.ObserveLiveness(session.LiveRunning))
 	case hasPrompt:
 		// A waiting prompt with otherwise-unchanged output: leave the status for
 		// the next tick to resolve, exactly as runMetadataTick did. The
 		// prompt-tap already fired above regardless of `updated`.
+		m.clearRemoteLoss(key) // a prompt on screen is the agent waiting, not gone
 	case !as.Alive():
 		// Snapshot returned (false,false), which a healthy idle session and a
 		// dead one both produce — indistinguishable on their own. Probe liveness
@@ -216,11 +223,21 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 		// intent on record, so the session vanished out from under a live
 		// record — an outage/reboot casualty that is recovery-eligible, not a
 		// corpse the user wanted gone.
+		//
+		// For a REMOTE session this Alive() is a REST call, so it fails on a
+		// transport blip exactly as the Snapshot path above does — and lands on
+		// the same re-provision-and-orphan hazard. It carries no more authority
+		// here than it does there, so it debounces identically (#1794). A local
+		// tmux probe crosses no network and stays immediate.
+		if isRemoteWorkspace(instance) && !m.noteRemoteProbeFailure(key, instance.Title) {
+			break
+		}
 		_ = instance.Transition(session.ObserveLiveness(session.LiveLost))
 	default:
 		// Idle output: settle to Ready, or LimitReached when the pane shows a
 		// usage-limit banner for a claude/codex session (#1146). content is
 		// HasUpdated's capture (no re-capture); see resolveIdleLiveness.
+		m.clearRemoteLoss(key) // reached only when Alive() answered true
 		m.resolveIdleLiveness(instance, content)
 	}
 

--- a/daemon/manager_status.go
+++ b/daemon/manager_status.go
@@ -84,6 +84,10 @@ func (m *Manager) RefreshStatuses() {
 	}
 	m.mu.Unlock()
 
+	// Drop debounce state for sessions that are gone or replaced, colocated with
+	// the pass that creates it (#1794).
+	m.sweepRemoteLossStates()
+
 	for _, e := range entries {
 		m.refreshInstanceStatus(e.repoID, e.instance)
 	}
@@ -156,7 +160,9 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 	// poll makes no assumption that the session is local tmux. For the local
 	// runtime the agent-server drives tmux in-process.
 	as := instance.AgentServer()
-	key := daemonInstanceKey(repoID, instance.Title)
+	// The debounce is keyed by stable instance ID, never repo/title: a same-title
+	// successor must not inherit a dead predecessor's failures (#1794).
+	key := remoteLossKey(repoID, instance)
 	before := instance.GetLiveness()
 	beforeReset, _ := instance.LimitResetAt()
 	// Snapshot dismisses a pending trust prompt then reads the pane in one probe
@@ -196,25 +202,18 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 		// the next poll — a one-interval AutoYes delay (#992).
 		as.TapEnter()
 	}
-	// The remote-loss debounce (#1794) counts CONSECUTIVE observations that found
-	// no evidence of life, so each branch below that DID find some clears it. Note
-	// what does not clear it: a merely-successful Snapshot. The agent-server
-	// answering proves the transport works, not that the agent is alive — a
-	// container whose agent died while its agent-server keeps serving returns a
-	// clean idle (false,false) snapshot every tick. Clearing on Snapshot success
-	// would reset the count on exactly those ticks and the Alive-false branch could
-	// never accumulate past one, so that session would never be marked Lost at all
-	// — silently regressing #935/#1108 for remote sessions.
+	// The Snapshot answered, so the transport works and any loss episode is over.
+	// This is the ONLY thing the debounce tracks — see remoteloss.go: it counts
+	// unanswerable probes, not "looks dead" observations.
+	m.clearRemoteLoss(key)
 	switch {
 	case updated:
-		m.clearRemoteLoss(key) // fresh output — the agent is demonstrably alive
 		_ = instance.Transition(session.ObserveLiveness(session.LiveRunning))
 	case hasPrompt:
 		// A waiting prompt with otherwise-unchanged output: leave the status for
 		// the next tick to resolve, exactly as runMetadataTick did. The
 		// prompt-tap already fired above regardless of `updated`.
-		m.clearRemoteLoss(key) // a prompt on screen is the agent waiting, not gone
-	case !as.Alive():
+	default:
 		// Snapshot returned (false,false), which a healthy idle session and a
 		// dead one both produce — indistinguishable on their own. Probe liveness
 		// only on this idle branch so a vanished session is marked Lost and
@@ -223,22 +222,36 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 		// intent on record, so the session vanished out from under a live
 		// record — an outage/reboot casualty that is recovery-eligible, not a
 		// corpse the user wanted gone.
-		//
-		// For a REMOTE session this Alive() is a REST call, so it fails on a
-		// transport blip exactly as the Snapshot path above does — and lands on
-		// the same re-provision-and-orphan hazard. It carries no more authority
-		// here than it does there, so it debounces identically (#1794). A local
-		// tmux probe crosses no network and stays immediate.
-		if isRemoteWorkspace(instance) && !m.noteRemoteProbeFailure(key, instance.Title) {
-			break
+		switch probe := probeLiveness(instance, as); probe {
+		case probeDead:
+			// AUTHORITATIVE: the agent-server (or local tmux) was asked and
+			// reports the agent gone. No debounce — the evidence is present and
+			// bad, not absent. #935's immediacy is unchanged for both runtimes.
+			_ = instance.Transition(session.ObserveLiveness(session.LiveLost))
+		case probeUnknown:
+			// A REMOTE probe that never answered. It says nothing about the agent,
+			// and Lost here feeds a re-provision that orphans a possibly-live
+			// sandbox, so it only counts toward the debounce (#1794) — never
+			// settles anything by itself.
+			//
+			// Reaching this means the Snapshot answered on this same tick while the
+			// Alive probe did not: the transport worked a moment ago, so this is a
+			// blip between two calls, and the clear above has already reset the
+			// episode. The count therefore cannot climb here on its own — by
+			// design. A real outage takes Snapshot down too, and that path
+			// (settleRemoteProbeFailure) is where an episode accumulates. Recording
+			// it anyway keeps one honest definition of the counter — "probes that
+			// could not be answered" — so a degrading transport starts its episode
+			// at the first unanswered probe rather than the first failed Snapshot.
+			if m.noteRemoteProbeFailure(key, instance.Title) {
+				_ = instance.Transition(session.ObserveLiveness(session.LiveLost))
+			}
+		case probeAlive:
+			// Idle output: settle to Ready, or LimitReached when the pane shows a
+			// usage-limit banner for a claude/codex session (#1146). content is
+			// HasUpdated's capture (no re-capture); see resolveIdleLiveness.
+			m.resolveIdleLiveness(instance, content)
 		}
-		_ = instance.Transition(session.ObserveLiveness(session.LiveLost))
-	default:
-		// Idle output: settle to Ready, or LimitReached when the pane shows a
-		// usage-limit banner for a claude/codex session (#1146). content is
-		// HasUpdated's capture (no re-capture); see resolveIdleLiveness.
-		m.clearRemoteLoss(key) // reached only when Alive() answered true
-		m.resolveIdleLiveness(instance, content)
 	}
 
 	// Persist a liveness OR usage-limit reset-time change (#1146); see limit.go.

--- a/daemon/manager_status.go
+++ b/daemon/manager_status.go
@@ -118,15 +118,27 @@ func (m *Manager) RefreshStatuses() {
 // the targeted writer persistInstanceData — never a whole-list re-marshal, the
 // dual-writer clobber surface #960 PR 4 retired — so an idle session never churns
 // instances.json.
+//
+// Every early return below SKIPS the probe, and each one therefore breaks the
+// remote-loss debounce's "consecutive" contract: a tick we did not observe tells
+// us nothing, so a failure before the gap and a failure after it are not
+// consecutive and must not be summed (#1794). Each skip clears the episode —
+// a run of unanswerable probes has to be unbroken to mean anything, and the
+// alternative is a stale count that survives an arbitrary blind window and lets
+// ONE later blip tip a healthy session into a destructive re-provision.
 func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instance) {
 	if instance == nil || !instance.Started() {
 		return
 	}
+	// The debounce is keyed by stable instance ID, never repo/title: a same-title
+	// successor must not inherit a dead predecessor's failures (#1794).
+	key := remoteLossKey(repoID, instance)
 	if instance.UserKilled() {
 		// A surviving kill-intent tombstone (#1108) means a previous
 		// KillSession was interrupted after committing to the kill. The only
 		// valid future for this session is finishing that teardown — never
 		// probing it, never marking it Lost, never restoring it.
+		m.clearRemoteLoss(key)
 		m.finishUserKill(repoID, instance)
 		return
 	}
@@ -134,12 +146,15 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 		// An op is mid-flight (archive/restore teardown, create/kill overlay): the
 		// poll must not probe a session whose tmux is being spun up/torn down and
 		// mark it Lost — the op's executor writes the settled liveness. Replaces
-		// the old Loading/Deleting skip (#1195).
+		// the old Loading/Deleting skip (#1195). The op may also be REPLACING the
+		// runtime under us, which is the other reason its failure history dies here.
+		m.clearRemoteLoss(key)
 		return
 	}
 	if instance.GetLiveness() == session.LiveArchived {
 		// Archived (#1028): no tmux to probe, inert (started=false) so already
 		// skipped by !Started above — belt-and-suspenders against a future change.
+		m.clearRemoteLoss(key)
 		return
 	}
 	if m.isPollPaused(repoID, instance.Title) {
@@ -152,6 +167,14 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 		// pause is lease-bounded (statusPollLease), so a crashed TUI that never
 		// sends Resume auto-resumes within one lease and real death is detected
 		// on the next tick — the pause can never permanently blind the daemon.
+		//
+		// The attach is also positive evidence: the client is streaming this
+		// session's PTY off the sandbox, which no dead sandbox can serve. Dropping
+		// the episode here is not merely conservative, it is what the counter's
+		// definition demands — a pause can outlast remoteLostGracePeriod (the TUI
+		// renews it for the whole attach), so a surviving count would let the first
+		// blip after detach re-provision a sandbox the user was just typing into.
+		m.clearRemoteLoss(key)
 		return
 	}
 
@@ -160,9 +183,6 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 	// poll makes no assumption that the session is local tmux. For the local
 	// runtime the agent-server drives tmux in-process.
 	as := instance.AgentServer()
-	// The debounce is keyed by stable instance ID, never repo/title: a same-title
-	// successor must not inherit a dead predecessor's failures (#1794).
-	key := remoteLossKey(repoID, instance)
 	before := instance.GetLiveness()
 	beforeReset, _ := instance.LimitResetAt()
 	// Snapshot dismisses a pending trust prompt then reads the pane in one probe

--- a/daemon/remoteloss.go
+++ b/daemon/remoteloss.go
@@ -147,9 +147,40 @@ func (m *Manager) clearRemoteLoss(key string) {
 	m.mu.Unlock()
 }
 
+// remoteSandboxAnswersAlive reports whether a remote session's sandbox answers
+// as alive right now — the veto every re-provision must clear first.
+//
+// A Lost mark is a claim about the past, and it can be minutes stale: restore
+// backs off to 5 minutes, and a user can hit restore by hand at any moment.
+// Transports heal. Re-provisioning is irreversible and destroys everything the
+// sandbox never pushed, so the question that matters is not "was it lost?" but
+// "is it gone NOW?" — asked against live state, immediately before acting.
+//
+// probeAlive, specifically: an ANSWERED alive is proof the sandbox is there and
+// a re-provision would orphan it. probeDead and probeUnknown both fall through
+// to recovery — a sandbox that answers "my agent is gone", and one that answers
+// nothing at all after the debounce already judged it durably unreachable, are
+// both cases where recovery is what the user wants (#1108/#1782).
+//
+// Bounded, so a wedged remote cannot stall the poll goroutine here either.
+func (m *Manager) remoteSandboxAnswersAlive(instance *session.Instance) bool {
+	if !isRemoteWorkspace(instance) {
+		return false // a local session has no sandbox to orphan
+	}
+	return aliveWithin(instance.AgentServer(), remoteLostConfirmTimeout) == probeAlive
+}
+
 // noteRuntimeReplaced resets a session's remote-loss debounce after a lifecycle
 // event that REPLACED the runtime its failures were about: a Recover, a
 // Respawn, an archive-restore's re-provision.
+//
+// Call it the INSTANT the swap succeeds — before any persist, log, or other
+// work. The poll goroutine does not hold the op-lock and does not skip a session
+// whose restore has already cleared OpRestoring, so it can probe the fresh
+// runtime while the caller is still doing its bookkeeping. A blip inside that
+// window would be judged against the OLD sandbox's threshold-satisfying count
+// and mark the new runtime Lost. The window is milliseconds, but closing it
+// costs nothing but statement order.
 //
 // EVERY such site must call this, and the requirement is not obvious, so it is
 // named for the trigger rather than the effect. The accumulated count describes
@@ -172,12 +203,24 @@ func (m *Manager) noteRuntimeReplaced(repoID string, instance *session.Instance)
 	m.clearRemoteLoss(remoteLossKey(repoID, instance))
 }
 
-// sweepRemoteLossStates drops debounce entries whose instance is no longer live
-// under that identity — killed, archived, or replaced by a same-title session
-// with a fresh ID. Keying by instance ID already stops a new session from
-// READING an old one's failures; this is what stops the map from growing, since
-// a session killed mid-episode never gets the answered probe that would clear it.
-// Called from the poll that populates the map. Guarded by m.mu.
+// sweepRemoteLossStates drops debounce entries that no longer describe anything
+// probeable — killed, archived, or replaced by a same-title session with a fresh
+// ID. Keying by instance ID already stops a new session from READING an old
+// one's failures; this is what stops the map from growing, since a session
+// killed or archived mid-episode never gets the answered probe that would clear
+// it. Called from the poll that populates the map. Guarded by m.mu.
+//
+// "Probeable", not merely "present in m.instances": an ARCHIVED session stays in
+// that map under the same stable ID, so presence alone would keep its entry
+// forever. Archiving a remote session tears its sandbox down (Archive pushes the
+// branch, kills the in-sandbox workspace, and resets the remote wiring), which
+// makes the accumulated count definitionally stale — it describes a sandbox that
+// was deliberately destroyed. The poll never probes an archived row either, so
+// nothing would ever clear it. Hence: unstarted or Archived is not live.
+//
+// This cannot substitute for noteRuntimeReplaced. A re-provision keeps the same
+// ID AND stays started, so the entry legitimately looks live — only the site
+// that swapped the runtime can know it did.
 func (m *Manager) sweepRemoteLossStates() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -186,6 +229,9 @@ func (m *Manager) sweepRemoteLossStates() {
 	}
 	live := make(map[string]struct{}, len(m.instances))
 	for key, inst := range m.instances {
+		if !inst.Started() || inst.GetLiveness() == session.LiveArchived {
+			continue // nothing to probe: its entry can never be cleared by an answer
+		}
 		repoID, _ := splitDaemonInstanceKey(key)
 		live[remoteLossKey(repoID, inst)] = struct{}{}
 	}

--- a/daemon/remoteloss.go
+++ b/daemon/remoteloss.go
@@ -147,6 +147,31 @@ func (m *Manager) clearRemoteLoss(key string) {
 	m.mu.Unlock()
 }
 
+// noteRuntimeReplaced resets a session's remote-loss debounce after a lifecycle
+// event that REPLACED the runtime its failures were about: a Recover, a
+// Respawn, an archive-restore's re-provision.
+//
+// EVERY such site must call this, and the requirement is not obvious, so it is
+// named for the trigger rather than the effect. The accumulated count describes
+// a sandbox that no longer exists. Left behind it stays threshold-satisfying and
+// its firstFailureAt stays long past the grace period, so the very first
+// transport blip against the NEW sandbox re-satisfies the debounce instantly and
+// re-provisions AGAIN — orphaning the sandbox just built, and stranding another
+// live container on every cycle. The debounce is defeated precisely where it
+// matters most.
+//
+// Note the sweep cannot cover this: a re-provision keeps the SAME instance ID
+// (that is the point — same session, new sandbox), so the entry stays "live".
+// Only the site that replaced the runtime knows it happened.
+//
+// Missing the call fails silently in production and is caught only by the
+// "post-<trigger> blip does not re-provision again" tests. Known sites:
+// lostrestore.go (automatic Recover), restore.go (manual Recover RPC),
+// limit.go (limit-resume Respawn), archive.go (archive-restore re-provision).
+func (m *Manager) noteRuntimeReplaced(repoID string, instance *session.Instance) {
+	m.clearRemoteLoss(remoteLossKey(repoID, instance))
+}
+
 // sweepRemoteLossStates drops debounce entries whose instance is no longer live
 // under that identity — killed, archived, or replaced by a same-title session
 // with a fresh ID. Keying by instance ID already stops a new session from

--- a/daemon/remoteloss.go
+++ b/daemon/remoteloss.go
@@ -1,0 +1,185 @@
+package daemon
+
+import (
+	"time"
+
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// Remote-loss debounce (#1794, hardening the #1782 fix).
+//
+// A remote session is observed over REST to its in-sandbox agent-server, so
+// every probe carries the transport's failure modes: a dropped ssh forward, a
+// docker-proxy hiccup, a NAT rebind, a blackholed route. NONE of those are
+// distinguishable from a dead sandbox at the call site — Snapshot() and Alive()
+// both just fail.
+//
+// That indistinguishability is dangerous because of what sits downstream. The
+// poll loop runs RefreshStatuses then RestoreLostSessions in the SAME tick, and
+// docker/ssh/hook backends all advertise Capabilities().Recover — but their
+// Recover is not a reconnect. It is recoverSandbox: provision a BRAND-NEW
+// sandbox and clone the branch back from origin. So a remote row that flips Lost
+// gets a fresh sandbox milliseconds later, the original sandbox keeps running
+// unreferenced, and every commit it never pushed is gone. A single blip must
+// therefore never be sufficient to mark a remote session Lost (#1794).
+//
+// The debounce demands the failure be DURABLE on two independent axes before the
+// poll will settle Lost:
+//
+//   - COUNT (remoteLostFailureThreshold): N consecutive failed probes, so one
+//     bad round-trip is absorbed.
+//   - TIME (remoteLostGracePeriod): the failures must also span a real
+//     wall-clock window. Count alone is not enough — a fast-failing blip
+//     (ECONNREFUSED returns instantly while a forward re-establishes) can burn
+//     N ticks in a couple of seconds, which is exactly the blip this is meant
+//     to survive.
+//
+// The counter tracks consecutive observations that found NO EVIDENCE OF LIFE —
+// not merely consecutive transport errors. Evidence of life (fresh output, a
+// waiting prompt, an Alive() that answers true) clears it; a Snapshot that
+// merely completes does not, because an agent-server can keep serving clean idle
+// snapshots long after the agent inside it died. See the clear sites in
+// refreshInstanceStatus.
+// Both axes must be satisfied, so whichever is slower under the operator's
+// daemon_poll_interval governs — which is the point of having both. At the 1s
+// default the grace period dominates (a durably dead remote surfaces as Lost
+// after ~60s rather than ~3s); at a coarse interval the count does. Either way
+// the ceiling on how long a genuinely dead remote reads healthy is bounded and
+// small, which is the #1782 guarantee — 60s of stale green is a fair price for
+// never re-provisioning over a live sandbox.
+var (
+	// remoteLostFailureThreshold is the consecutive failed-probe count required
+	// before a remote session may be marked Lost. var, not const, so tests can
+	// drive the threshold directly.
+	remoteLostFailureThreshold = 3
+	// remoteLostGracePeriod is the minimum wall-clock span the failures must
+	// persist before Lost is allowed, independent of how many ticks fit in it.
+	remoteLostGracePeriod = 60 * time.Second
+	// remoteLostConfirmTimeout bounds the confirmation Alive() probe. It is
+	// deliberately SHORT and unrelated to remoteAgentCallTimeout (30s): the
+	// failed Snapshot that got us here already spent the full call timeout, and
+	// RefreshStatuses walks instances SERIALLY, so an unbounded second probe
+	// would let one blackholed sandbox add ~2x30s to every poll — stalling
+	// status, root-ensure, lost-restore and limit-resume for EVERY other
+	// session (#1794). The confirmation only has to break a tie the debounce
+	// has already all but settled, so it gets a tight budget.
+	remoteLostConfirmTimeout = 5 * time.Second
+)
+
+// remoteLossState is the per-session debounce state. Guarded by Manager.mu.
+type remoteLossState struct {
+	consecutiveFailures int
+	firstFailureAt      time.Time
+}
+
+// isRemoteWorkspace reports whether an instance's workspace lives off-box, so
+// its probes cross a network and can fail transiently. Branching on the
+// capability rather than the backend's name is the #1592 Phase 1 contract: a new
+// off-box backend inherits the debounce by declaring what it is, not by being
+// added to a list here.
+func isRemoteWorkspace(instance *session.Instance) bool {
+	return instance.Capabilities().Workspace == session.WorkspaceRemote
+}
+
+// noteRemoteProbeFailure records one failed remote probe and reports whether the
+// loss now looks DURABLE — N consecutive failures spanning at least the grace
+// period. Until both hold the caller must leave the session's liveness alone and
+// let the next tick decide.
+func (m *Manager) noteRemoteProbeFailure(key, title string) bool {
+	now := nowFunc()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	st := m.remoteLossStates[key]
+	if st == nil {
+		st = &remoteLossState{firstFailureAt: now}
+		m.remoteLossStates[key] = st
+	}
+	st.consecutiveFailures++
+	if st.consecutiveFailures < remoteLostFailureThreshold {
+		return false
+	}
+	if now.Sub(st.firstFailureAt) < remoteLostGracePeriod {
+		return false
+	}
+	log.WarningLog.Printf("remote session %q has failed %d consecutive agent-server probes over %s; confirming before marking it Lost", title, st.consecutiveFailures, now.Sub(st.firstFailureAt).Round(time.Second))
+	return true
+}
+
+// clearRemoteLoss drops a session's debounce state once the poll has positive
+// evidence the agent is alive. The next episode then starts from zero rather
+// than inheriting a stale count that could tip a later single blip straight over
+// the threshold. Callers must hold evidence of LIFE, not just of reachability —
+// see the switch in refreshInstanceStatus.
+func (m *Manager) clearRemoteLoss(key string) {
+	m.mu.Lock()
+	delete(m.remoteLossStates, key)
+	m.mu.Unlock()
+}
+
+// settleRemoteProbeFailure decides what a failed observation probe means for one
+// instance and writes the outcome. It is the Snapshot-error arm of
+// refreshInstanceStatus, kept here beside the debounce it drives.
+//
+// The order matters. The DEBOUNCE runs first and the confirmation probe only
+// afterwards, so the common transient case — the one this exists for — costs
+// exactly zero extra REST calls, and the confirmation is paid once per episode
+// rather than once per tick. That is also what keeps a wedged sandbox from
+// double-stalling the serial poll: it can no longer spend a full 30s Snapshot
+// AND a full 30s Alive on every single tick (#1794).
+func (m *Manager) settleRemoteProbeFailure(repoID, key string, instance *session.Instance, before session.Liveness, beforeReset time.Time) {
+	if !isRemoteWorkspace(instance) {
+		// A local agent-server's Snapshot never errors; if that ever changes,
+		// an unexplained local error is not evidence of death. Leave it be.
+		return
+	}
+	if before == session.LiveLost {
+		// Already settled where a failing probe would put it. There is nothing to
+		// transition, so don't pay the confirmation round-trip (or re-log the
+		// threshold) on every tick of an outage. The way back is a SUCCESSFUL
+		// Snapshot, which clears the episode in refreshInstanceStatus and lets the
+		// normal branches settle the real liveness.
+		return
+	}
+	if !m.noteRemoteProbeFailure(key, instance.Title) {
+		return // not durable yet — the next tick decides
+	}
+	// Durable failure. Confirm with the INDEPENDENT Alive() probe before the
+	// transition: Snapshot can fail on its own (a capture error from a server
+	// that is up and answering), and Lost is the trigger for a destructive
+	// re-provision, so it is worth one bounded round-trip to be sure.
+	if aliveWithin(instance.AgentServer(), remoteLostConfirmTimeout) {
+		log.InfoLog.Printf("remote session %q failed repeated snapshots but its agent-server answers as alive; leaving its status alone", instance.Title)
+		m.clearRemoteLoss(key)
+		return
+	}
+	log.WarningLog.Printf("remote session %q: agent-server unreachable and confirmed not alive — marking it Lost", instance.Title)
+	_ = instance.Transition(session.ObserveLiveness(session.LiveLost))
+	m.persistPollChange(repoID, instance, before, beforeReset)
+}
+
+// aliveWithin runs a possibly-slow Alive() probe under a hard local deadline,
+// returning false if it cannot answer in time.
+//
+// It bounds the CALLER's wait, not the underlying REST call — AgentServer.Alive
+// takes no context, and threading one through the whole interface to serve this
+// one probe is not worth the blast radius. The orphaned goroutine finishes on
+// its own within remoteAgentCallTimeout and writes to a BUFFERED channel, so it
+// never blocks and nothing leaks past that; at most one such goroutine exists
+// per wedged remote per tick.
+//
+// Timing out reports not-alive, which is correct in position: every caller has
+// already established durable failure, so an agent-server that cannot answer a
+// short liveness ping on top of that is unreachable by any useful definition.
+func aliveWithin(as session.AgentServer, timeout time.Duration) bool {
+	result := make(chan bool, 1)
+	go func() { result <- as.Alive() }()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case alive := <-result:
+		return alive
+	case <-timer.C:
+		return false
+	}
+}

--- a/daemon/remoteloss.go
+++ b/daemon/remoteloss.go
@@ -11,12 +11,12 @@ import (
 //
 // A remote session is observed over REST to its in-sandbox agent-server, so
 // every probe carries the transport's failure modes: a dropped ssh forward, a
-// docker-proxy hiccup, a NAT rebind, a blackholed route. NONE of those are
-// distinguishable from a dead sandbox at the call site — Snapshot() and Alive()
-// both just fail.
+// docker-proxy hiccup, a NAT rebind, a blackholed route. A probe that dies to
+// any of those tells you NOTHING about the agent — but it used to look exactly
+// like a dead sandbox, because Snapshot() and Alive() both merely "failed".
 //
-// That indistinguishability is dangerous because of what sits downstream. The
-// poll loop runs RefreshStatuses then RestoreLostSessions in the SAME tick, and
+// That conflation is dangerous because of what sits downstream. The poll loop
+// runs RefreshStatuses then RestoreLostSessions in the SAME tick, and
 // docker/ssh/hook backends all advertise Capabilities().Recover — but their
 // Recover is not a reconnect. It is recoverSandbox: provision a BRAND-NEW
 // sandbox and clone the branch back from origin. So a remote row that flips Lost
@@ -24,23 +24,31 @@ import (
 // unreferenced, and every commit it never pushed is gone. A single blip must
 // therefore never be sufficient to mark a remote session Lost (#1794).
 //
-// The debounce demands the failure be DURABLE on two independent axes before the
-// poll will settle Lost:
+// The fix is in two layers, and the ORDER of them matters:
 //
-//   - COUNT (remoteLostFailureThreshold): N consecutive failed probes, so one
-//     bad round-trip is absorbed.
+//  1. DISTINGUISH. AgentServer.Alive returns an error, so "the sandbox answered:
+//     the agent is gone" and "the sandbox never answered" stop being the same
+//     `false`. See livenessProbe: probeDead is authoritative and acted on at
+//     once (#935/#1108 immediacy, unchanged); probeUnknown is an absence of
+//     evidence and settles nothing on its own. Most of the safety lives here —
+//     no amount of debouncing rescues a caller that cannot tell the two apart,
+//     which is why the limit-resume path needed the distinction rather than a
+//     debounce of its own.
+//  2. DEBOUNCE what remains. A run of probeUnknown could still be a real outage,
+//     so it must eventually settle Lost (that is #1782's guarantee). This is the
+//     only thing the counter tracks — consecutive UNANSWERABLE probes, never
+//     "looks dead" observations. Any answered probe clears it.
+//
+// The debounce demands the failure be DURABLE on two independent axes:
+//
+//   - COUNT (remoteLostFailureThreshold): N consecutive unanswered probes, so
+//     one bad round-trip is absorbed.
 //   - TIME (remoteLostGracePeriod): the failures must also span a real
 //     wall-clock window. Count alone is not enough — a fast-failing blip
 //     (ECONNREFUSED returns instantly while a forward re-establishes) can burn
 //     N ticks in a couple of seconds, which is exactly the blip this is meant
 //     to survive.
 //
-// The counter tracks consecutive observations that found NO EVIDENCE OF LIFE —
-// not merely consecutive transport errors. Evidence of life (fresh output, a
-// waiting prompt, an Alive() that answers true) clears it; a Snapshot that
-// merely completes does not, because an agent-server can keep serving clean idle
-// snapshots long after the agent inside it died. See the clear sites in
-// refreshInstanceStatus.
 // Both axes must be satisfied, so whichever is slower under the operator's
 // daemon_poll_interval governs — which is the point of having both. At the 1s
 // default the grace period dominates (a durably dead remote surfaces as Lost
@@ -73,6 +81,28 @@ type remoteLossState struct {
 	firstFailureAt      time.Time
 }
 
+// remoteLossKey identifies the debounce entry for an instance.
+//
+// It keys on the STABLE INSTANCE ID (#1195), not the repo/title daemon key, so
+// failure state can never outlive the session that earned it. Titles are reused:
+// kill or archive a remote session and create another with the same title, and a
+// title-keyed entry would hand the NEW session the OLD one's accumulated
+// failures — one blip would then satisfy the threshold instantly and re-provision
+// a sandbox that had never failed a probe in its life. That is the
+// key-by-title-instead-of-identity class from #1723/#1678/#1738, and the ID is
+// exactly the field #1195 minted to tell "same session" from "title reused".
+//
+// Legacy records persisted before #1195 carry no ID; they fall back to the
+// daemon key. No remote session can be one of those — the remote runtime landed
+// in #1592, long after — so the fallback only ever serves local sessions, which
+// never enter the debounce at all.
+func remoteLossKey(repoID string, instance *session.Instance) string {
+	if instance.ID != "" {
+		return instance.ID
+	}
+	return daemonInstanceKey(repoID, instance.Title)
+}
+
 // isRemoteWorkspace reports whether an instance's workspace lives off-box, so
 // its probes cross a network and can fail transiently. Branching on the
 // capability rather than the backend's name is the #1592 Phase 1 contract: a new
@@ -82,10 +112,10 @@ func isRemoteWorkspace(instance *session.Instance) bool {
 	return instance.Capabilities().Workspace == session.WorkspaceRemote
 }
 
-// noteRemoteProbeFailure records one failed remote probe and reports whether the
-// loss now looks DURABLE — N consecutive failures spanning at least the grace
-// period. Until both hold the caller must leave the session's liveness alone and
-// let the next tick decide.
+// noteRemoteProbeFailure records one UNANSWERABLE remote probe and reports
+// whether the loss now looks DURABLE — N consecutive unanswered probes spanning
+// at least the grace period. Until both hold the caller must leave the session's
+// liveness alone and let the next tick decide.
 func (m *Manager) noteRemoteProbeFailure(key, title string) bool {
 	now := nowFunc()
 	m.mu.Lock()
@@ -106,15 +136,39 @@ func (m *Manager) noteRemoteProbeFailure(key, title string) bool {
 	return true
 }
 
-// clearRemoteLoss drops a session's debounce state once the poll has positive
-// evidence the agent is alive. The next episode then starts from zero rather
+// clearRemoteLoss drops a session's debounce state. Callers must have ANSWERED
+// evidence — a completed probe, or a lifecycle event that replaced the runtime
+// the old failures were about. The next episode then starts from zero rather
 // than inheriting a stale count that could tip a later single blip straight over
-// the threshold. Callers must hold evidence of LIFE, not just of reachability —
-// see the switch in refreshInstanceStatus.
+// the threshold.
 func (m *Manager) clearRemoteLoss(key string) {
 	m.mu.Lock()
 	delete(m.remoteLossStates, key)
 	m.mu.Unlock()
+}
+
+// sweepRemoteLossStates drops debounce entries whose instance is no longer live
+// under that identity — killed, archived, or replaced by a same-title session
+// with a fresh ID. Keying by instance ID already stops a new session from
+// READING an old one's failures; this is what stops the map from growing, since
+// a session killed mid-episode never gets the answered probe that would clear it.
+// Called from the poll that populates the map. Guarded by m.mu.
+func (m *Manager) sweepRemoteLossStates() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.remoteLossStates) == 0 {
+		return
+	}
+	live := make(map[string]struct{}, len(m.instances))
+	for key, inst := range m.instances {
+		repoID, _ := splitDaemonInstanceKey(key)
+		live[remoteLossKey(repoID, inst)] = struct{}{}
+	}
+	for key := range m.remoteLossStates {
+		if _, ok := live[key]; !ok {
+			delete(m.remoteLossStates, key)
+		}
+	}
 }
 
 // settleRemoteProbeFailure decides what a failed observation probe means for one
@@ -144,22 +198,66 @@ func (m *Manager) settleRemoteProbeFailure(repoID, key string, instance *session
 	if !m.noteRemoteProbeFailure(key, instance.Title) {
 		return // not durable yet — the next tick decides
 	}
-	// Durable failure. Confirm with the INDEPENDENT Alive() probe before the
-	// transition: Snapshot can fail on its own (a capture error from a server
+	// Durable unreachability. Confirm with the INDEPENDENT Alive() probe before
+	// transitioning: Snapshot can fail on its own (a capture error from a server
 	// that is up and answering), and Lost is the trigger for a destructive
 	// re-provision, so it is worth one bounded round-trip to be sure.
-	if aliveWithin(instance.AgentServer(), remoteLostConfirmTimeout) {
+	switch probe := aliveWithin(instance.AgentServer(), remoteLostConfirmTimeout); probe {
+	case probeAlive:
 		log.InfoLog.Printf("remote session %q failed repeated snapshots but its agent-server answers as alive; leaving its status alone", instance.Title)
 		m.clearRemoteLoss(key)
 		return
+	case probeDead:
+		// The server answered: reachable, agent gone. The snapshots were failing
+		// for some other reason. An answer of any kind ends the transport episode.
+		log.WarningLog.Printf("remote session %q: agent-server reports its agent is gone — marking it Lost", instance.Title)
+		m.clearRemoteLoss(key)
+	case probeUnknown:
+		log.WarningLog.Printf("remote session %q: agent-server unreachable and still unanswerable after %s — marking it Lost", instance.Title, remoteLostGracePeriod)
 	}
-	log.WarningLog.Printf("remote session %q: agent-server unreachable and confirmed not alive — marking it Lost", instance.Title)
 	_ = instance.Transition(session.ObserveLiveness(session.LiveLost))
 	m.persistPollChange(repoID, instance, before, beforeReset)
 }
 
-// aliveWithin runs a possibly-slow Alive() probe under a hard local deadline,
-// returning false if it cannot answer in time.
+// livenessProbe is the outcome of a liveness probe. It is a tri-state, not a
+// bool, because the third case is the one that matters: a probe that never
+// answered tells you nothing about the agent, and treating it as death is what
+// re-provisions over a live sandbox (#1794).
+type livenessProbe int
+
+const (
+	// probeAlive: the agent answered and is running.
+	probeAlive livenessProbe = iota
+	// probeDead: the agent-server answered and reports its agent gone. This is
+	// AUTHORITATIVE — the sandbox is reachable, it looked, and the agent is not
+	// there. Callers may act on it immediately.
+	probeDead
+	// probeUnknown: the probe could not be answered — a transport failure or a
+	// timeout. NOT evidence of death. Only repetition over time (the debounce)
+	// may turn a run of these into a conclusion.
+	probeUnknown
+)
+
+// probeLiveness runs one liveness probe for an instance, bounding the wait for
+// REMOTE instances only. A local probe is in-process (no network to hang on) and
+// its Alive never errors, so it answers directly; wrapping it would spend a
+// goroutine and a timer per idle session per tick for nothing.
+func probeLiveness(instance *session.Instance, as session.AgentServer) livenessProbe {
+	if isRemoteWorkspace(instance) {
+		return aliveWithin(as, remoteLostConfirmTimeout)
+	}
+	alive, err := as.Alive()
+	if err != nil {
+		return probeUnknown
+	}
+	if alive {
+		return probeAlive
+	}
+	return probeDead
+}
+
+// aliveWithin runs a possibly-slow remote Alive() probe under a hard local
+// deadline, reporting probeUnknown if it cannot answer in time.
 //
 // It bounds the CALLER's wait, not the underlying REST call — AgentServer.Alive
 // takes no context, and threading one through the whole interface to serve this
@@ -168,18 +266,32 @@ func (m *Manager) settleRemoteProbeFailure(repoID, key string, instance *session
 // never blocks and nothing leaks past that; at most one such goroutine exists
 // per wedged remote per tick.
 //
-// Timing out reports not-alive, which is correct in position: every caller has
-// already established durable failure, so an agent-server that cannot answer a
-// short liveness ping on top of that is unreachable by any useful definition.
-func aliveWithin(as session.AgentServer, timeout time.Duration) bool {
-	result := make(chan bool, 1)
-	go func() { result <- as.Alive() }()
+// A timeout reports probeUnknown rather than probeDead: a server that cannot
+// answer in time has told us nothing, and the whole point of the tri-state is
+// that we stop inventing a verdict from silence.
+func aliveWithin(as session.AgentServer, timeout time.Duration) livenessProbe {
+	type result struct {
+		alive bool
+		err   error
+	}
+	done := make(chan result, 1) // buffered: the goroutine never blocks, even if we gave up
+	go func() {
+		alive, err := as.Alive()
+		done <- result{alive: alive, err: err}
+	}()
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 	select {
-	case alive := <-result:
-		return alive
+	case r := <-done:
+		switch {
+		case r.err != nil:
+			return probeUnknown
+		case r.alive:
+			return probeAlive
+		default:
+			return probeDead
+		}
 	case <-timer.C:
-		return false
+		return probeUnknown
 	}
 }

--- a/daemon/restore.go
+++ b/daemon/restore.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"fmt"
 
+	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 )
 
@@ -74,19 +75,41 @@ func (m *Manager) restoreLostOrDeadSession(req RestoreSessionRequest, repoID str
 		return "", fmt.Errorf("session %q changed state before restore could start", req.Title)
 	}
 
+	// The same live recheck the automatic loop runs before re-provisioning
+	// (lostrestore.go), for the same reason: a remote Recover is not a reconnect
+	// but a fresh sandbox cloned from origin, and this row's Lost mark may be
+	// minutes stale — the automatic loop backs off to 5 minutes, and the user can
+	// hit restore at any moment, including while the transport is healing.
+	//
+	// Being user-initiated makes the recheck MORE important, not less. "Restore"
+	// asks for a working session; it does not ask to discard a running sandbox and
+	// everything it never pushed. If the sandbox answers, the session was never
+	// really lost and healing the row delivers exactly what was asked for, without
+	// the destruction. A user who genuinely wants a new sandbox kills and
+	// recreates (#1794).
+	if m.remoteSandboxAnswersAlive(instance) {
+		log.InfoLog.Printf("not re-provisioning session %q: its sandbox answers as alive, so it was never lost — clearing the Lost mark instead (re-provisioning would orphan it and discard unpushed work)", req.Title)
+		_ = instance.Transition(session.ObserveLiveness(session.LiveRunning))
+		m.clearRemoteLoss(remoteLossKey(repoID, instance))
+		m.persistInstance(repoID, instance)
+		m.mu.Lock()
+		delete(m.lostRestoreStates, key)
+		m.mu.Unlock()
+		return instance.GetWorktreePath(), nil
+	}
+
 	if err := instance.Recover(); err != nil {
 		m.persistInstance(repoID, instance)
 		return "", err
 	}
-	m.persistInstance(repoID, instance)
-	// Same lifecycle reset as the automatic loop (lostrestore.go): recovery
-	// REPLACED the runtime the debounce's failures were about, so the count now
-	// describes a sandbox that no longer exists. Left behind it stays
-	// threshold-satisfying, and the first transport blip against the sandbox this
-	// restore just provisioned would re-satisfy it instantly and re-provision
-	// AGAIN — orphaning the one the user just asked for. A manual restore is the
-	// same lifecycle event as an automatic one; only the trigger differs (#1794).
+	// Reset FIRST, before the persist below: recovery replaced the runtime the
+	// debounce's failures were about, and the poll goroutine can probe the fresh
+	// sandbox the moment Recover clears the restore fence — while this call is
+	// still writing to disk. A blip in that window would be judged against the
+	// dead sandbox's count. A manual restore is the same lifecycle event as an
+	// automatic one; only the trigger differs (#1794).
 	m.noteRuntimeReplaced(repoID, instance)
+	m.persistInstance(repoID, instance)
 	m.mu.Lock()
 	delete(m.lostRestoreStates, key)
 	m.mu.Unlock()

--- a/daemon/restore.go
+++ b/daemon/restore.go
@@ -79,6 +79,14 @@ func (m *Manager) restoreLostOrDeadSession(req RestoreSessionRequest, repoID str
 		return "", err
 	}
 	m.persistInstance(repoID, instance)
+	// Same lifecycle reset as the automatic loop (lostrestore.go): recovery
+	// REPLACED the runtime the debounce's failures were about, so the count now
+	// describes a sandbox that no longer exists. Left behind it stays
+	// threshold-satisfying, and the first transport blip against the sandbox this
+	// restore just provisioned would re-satisfy it instantly and re-provision
+	// AGAIN — orphaning the one the user just asked for. A manual restore is the
+	// same lifecycle event as an automatic one; only the trigger differs (#1794).
+	m.noteRuntimeReplaced(repoID, instance)
 	m.mu.Lock()
 	delete(m.lostRestoreStates, key)
 	m.mu.Unlock()

--- a/daemon/status_remote_test.go
+++ b/daemon/status_remote_test.go
@@ -678,3 +678,54 @@ func TestSweepRemoteLossStates_DropsArchivedRows(t *testing.T) {
 		t.Fatalf("remoteLossStates still holds %d entry/entries after the row was archived — an archived session keeps its map entry and its stable ID, and is never probed again, so nothing else will ever drop it (#1794)", after)
 	}
 }
+
+// TestRefreshStatuses_AttachBreaksTheDebounceRun is codex's finding on 9555b80:
+// a blind window silently kept a failure run "consecutive".
+//
+// While a TUI is attached the poll is paused (#1160), so no probe happens and
+// the clear after Snapshot is never reached. The count and its firstFailureAt
+// therefore survive the whole attach — which the TUI renews for as long as the
+// user stays, easily outlasting remoteLostGracePeriod. Detach, take one blip,
+// and a count sitting just under the threshold tips over with a grace window
+// long since satisfied: Lost, then re-provisioned, orphaning the sandbox the
+// user was typing into seconds earlier.
+//
+// The attach is the proof that makes it absurd — the client streams the PTY off
+// that sandbox, which no dead sandbox can serve. But the general rule is what is
+// implemented: a tick we did not observe breaks the run, because failures either
+// side of a blind window are not consecutive and summing them is a lie.
+func TestRefreshStatuses_AttachBreaksTheDebounceRun(t *testing.T) {
+	withRemoteLossThresholds(t, 3, time.Minute, time.Second)
+	zeroRestoreBackoff(t)
+	advance := withFrozenClock(t)
+
+	manager, repoID, repoPath := newStatusTestManager(t)
+	const title = "remote-attached"
+	inst, backend := registerStartedRemote(t, manager, repoID, repoPath, title, "http://127.0.0.1:1", session.Running)
+
+	// Two failures: one short of the threshold, and already spread past the
+	// grace period so only the count is holding Lost back.
+	for i := 0; i < remoteLostFailureThreshold-1; i++ {
+		manager.RefreshStatuses()
+		advance(remoteLostGracePeriod)
+	}
+	if got := inst.GetLiveness(); got != session.LiveRunning {
+		t.Fatalf("setup: liveness = %v, want LiveRunning (still under the threshold)", got)
+	}
+
+	// The user attaches. The poll is paused for the duration and observes nothing.
+	manager.PauseStatusPoll(repoID, title)
+	manager.RefreshStatuses()
+	manager.ResumeStatusPoll(repoID, title)
+
+	// One blip after detach.
+	manager.RefreshStatuses()
+	manager.RestoreLostSessions()
+
+	if got := inst.GetLiveness(); got != session.LiveRunning {
+		t.Fatalf("liveness = %v, want LiveRunning — the attach was a blind window, so the failure before it and the blip after it are NOT consecutive; summing them let one blip mark a session Lost that was being typed into (#1794)", got)
+	}
+	if got := backend.recoverCalls(); got != 0 {
+		t.Fatalf("Recover calls = %d, want 0 — a single post-attach blip re-provisioned the sandbox and orphaned it", got)
+	}
+}

--- a/daemon/status_remote_test.go
+++ b/daemon/status_remote_test.go
@@ -370,23 +370,21 @@ func TestRefreshStatuses_ConfirmationProbeIsBounded(t *testing.T) {
 	}
 }
 
-// TestRefreshStatuses_ReachableRemoteWithDeadAgentStillGoesLost guards the trap
-// the #1794 debounce opens if its counter is wired to the wrong signal.
+// TestRefreshStatuses_ReachableRemoteWithDeadAgentGoesLostImmediately fences the
+// debounce from OVER-applying, which is the failure mode a debounce invites.
 //
-// A container can outlive the agent inside it: the sandbox is up, the
-// agent-server keeps serving, but the agent process is gone. Every tick then
-// yields a perfectly successful, perfectly idle (false,false) snapshot, and only
-// the Alive() probe reports the truth. If a successful Snapshot were taken as
-// proof of life and used to clear the debounce, this session's failure count
-// would reset on every one of those ticks, never accumulate past one, and the
-// session would stay green FOREVER — silently regressing #935/#1108 for exactly
-// the sessions #1782 set out to fix.
+// A container outlives the agent inside it: the sandbox is up and its
+// agent-server keeps serving clean idle (false,false) snapshots, but the agent
+// process is gone. Here the probe is ANSWERED — the sandbox was asked, it
+// looked, and it says the agent is not there. That evidence is present and
+// conclusive, so there is nothing to wait for: debouncing it would leave a dead
+// session showing green for a grace period, and if the debounce were keyed on
+// "looks dead" rather than "could not tell" it would never mark it Lost AT ALL,
+// silently regressing #935/#1108 for exactly the sessions #1782 set out to fix.
 //
-// So the debounce must count observations with no evidence of LIFE, not
-// transport errors: reachability is not liveness.
-func TestRefreshStatuses_ReachableRemoteWithDeadAgentStillGoesLost(t *testing.T) {
+// One tick, Lost. The debounce is for absent evidence, not bad evidence.
+func TestRefreshStatuses_ReachableRemoteWithDeadAgentGoesLostImmediately(t *testing.T) {
 	withRemoteLossThresholds(t, 3, time.Minute, time.Second)
-	advance := withFrozenClock(t)
 
 	// The sandbox is healthy and answering. The agent inside it is not.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -409,10 +407,106 @@ func TestRefreshStatuses_ReachableRemoteWithDeadAgentStillGoesLost(t *testing.T)
 	manager, repoID, repoPath := newStatusTestManager(t)
 	registerStartedRemote(t, manager, repoID, repoPath, "remote-agent-dead", srv.URL, session.Running)
 
-	driveDurableRemoteLoss(manager, advance)
+	manager.RefreshStatuses() // exactly one tick
 
 	inst := manager.instances[daemonInstanceKey(repoID, "remote-agent-dead")]
 	if got := inst.GetLiveness(); got != session.LiveLost {
-		t.Fatalf("liveness = %v, want LiveLost — the agent-server answers but reports its agent dead, and a successful snapshot must never be mistaken for evidence of life", got)
+		t.Fatalf("liveness after one tick = %v, want LiveLost — the sandbox ANSWERED that its agent is gone, which is authoritative; the debounce is for probes that could not be answered, not for answers we dislike", got)
+	}
+}
+
+// TestRestoreLostSessions_PostRecoverBlipDoesNotReprovisionAgain is codex's #1
+// on PR #1804: stale debounce state surviving a recovery.
+//
+// A successful Recover REPLACES the runtime — for a remote session the sandbox
+// behind the old failures no longer exists. The threshold-satisfying
+// remoteLossStates entry describes that dead sandbox, so leaving it behind arms
+// a trap: the very first transport blip against the FRESH sandbox re-satisfies
+// the debounce instantly (the count is already past the threshold and
+// firstFailureAt is long past the grace period), marks it Lost, and
+// re-provisions AGAIN — orphaning the sandbox we just built. The debounce would
+// be defeated at precisely the moment it matters most, and each cycle would
+// strand another live container.
+//
+// So: recover, then blip once. Exactly one re-provision may ever happen.
+func TestRestoreLostSessions_PostRecoverBlipDoesNotReprovisionAgain(t *testing.T) {
+	withRemoteLossThresholds(t, 3, time.Minute, time.Second)
+	zeroRestoreBackoff(t)
+	advance := withFrozenClock(t)
+
+	manager, repoID, repoPath := newStatusTestManager(t)
+	// Nothing listening: every probe is refused, so the loss is real and durable.
+	inst, backend := registerStartedRemote(t, manager, repoID, repoPath, "remote-recovered", "http://127.0.0.1:1", session.Running)
+
+	// Durable loss -> Lost -> the restore loop re-provisions once. That part is
+	// the #1108/#1782 feature working correctly.
+	driveDurableRemoteLoss(manager, advance)
+	if got := inst.GetLiveness(); got != session.LiveLost {
+		t.Fatalf("setup: liveness = %v, want LiveLost before the restore pass", got)
+	}
+	manager.RestoreLostSessions()
+	if got := backend.recoverCalls(); got != 1 {
+		t.Fatalf("setup: Recover calls = %d, want 1 (a durably-lost remote must be recovered)", got)
+	}
+
+	// The fresh sandbox now takes ONE transport blip.
+	advance(time.Second)
+	manager.RefreshStatuses()
+	manager.RestoreLostSessions()
+
+	if got := backend.recoverCalls(); got != 1 {
+		t.Fatalf("Recover calls = %d, want still 1 — one blip against the freshly recovered sandbox re-provisioned it again, so the recovery left stale debounce state behind and each blip now orphans another live sandbox (#1794)", got)
+	}
+	if got := inst.GetLiveness(); got == session.LiveLost {
+		t.Fatal("liveness = LiveLost after a single post-recovery blip: the debounce restarted from the dead sandbox's count instead of from zero")
+	}
+}
+
+// TestRefreshStatuses_NewSessionDoesNotInheritDebounceState is codex's #2 on PR
+// #1804: debounce state keyed by identity, not by title.
+//
+// Titles get reused — kill or archive a remote session and make another with the
+// same name. Keyed by repo/title, the successor would inherit its predecessor's
+// accumulated failures: one blip would then satisfy the threshold instantly and
+// re-provision a sandbox that had never failed a probe in its life. This is the
+// key-by-title-instead-of-stable-id class (#1723/#1678/#1738); Instance.ID is
+// the field #1195 minted to tell "same session" from "title reused".
+func TestRefreshStatuses_NewSessionDoesNotInheritDebounceState(t *testing.T) {
+	withRemoteLossThresholds(t, 3, time.Minute, time.Second)
+	advance := withFrozenClock(t)
+
+	manager, repoID, repoPath := newStatusTestManager(t)
+	const title = "reused-title"
+	old, _ := registerStartedRemote(t, manager, repoID, repoPath, title, "http://127.0.0.1:1", session.Running)
+
+	// The doomed predecessor accumulates a threshold-satisfying failure history.
+	driveDurableRemoteLoss(manager, advance)
+	if got := old.GetLiveness(); got != session.LiveLost {
+		t.Fatalf("setup: predecessor liveness = %v, want LiveLost", got)
+	}
+	manager.mu.Lock()
+	stale := len(manager.remoteLossStates)
+	manager.mu.Unlock()
+	if stale == 0 {
+		t.Fatal("setup: expected the predecessor to have left debounce state to inherit")
+	}
+
+	// It is replaced by a NEW session reusing the same repo/title — a distinct
+	// instance with its own stable ID, and its own healthy sandbox.
+	fresh, freshBackend := registerStartedRemote(t, manager, repoID, repoPath, title, "http://127.0.0.1:1", session.Running)
+	if fresh.ID == old.ID {
+		t.Fatal("setup: the replacement must be a distinct instance with its own stable ID")
+	}
+
+	// One blip against the newcomer.
+	advance(time.Second)
+	manager.RefreshStatuses()
+	manager.RestoreLostSessions()
+
+	if got := fresh.GetLiveness(); got != session.LiveRunning {
+		t.Fatalf("new session's liveness = %v, want LiveRunning — it inherited the killed session's failure count through the repo/title key, so its FIRST blip marked it Lost (#1794)", got)
+	}
+	if got := freshBackend.recoverCalls(); got != 0 {
+		t.Fatalf("Recover calls on the new session = %d, want 0 — inherited state re-provisioned a sandbox that had never failed a probe", got)
 	}
 }

--- a/daemon/status_remote_test.go
+++ b/daemon/status_remote_test.go
@@ -4,17 +4,64 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/sachiniyer/agent-factory/session"
 )
 
+// remoteWorkspaceBackend is the faithful stand-in for a docker/ssh backend: an
+// off-box workspace that ALSO advertises Recover, exactly as backend_docker.go
+// and backend_ssh.go do. That pairing is the whole #1794 hazard — Workspace
+// says "no local worktree", Recover says "the restore loop may re-provision me"
+// — so a double that reports only one of the two cannot exercise it. (The older
+// recoverFakeBackend "remote" variant reports Recover=false, which is why the
+// automatic re-provision path went untested.)
+type remoteWorkspaceBackend struct {
+	*session.FakeBackend
+	mu       sync.Mutex
+	recovers int
+}
+
+func (b *remoteWorkspaceBackend) Type() string { return "docker" }
+
+func (b *remoteWorkspaceBackend) Capabilities() session.Capabilities {
+	return session.Capabilities{
+		Workspace:        session.WorkspaceRemote,
+		Attach:           true,
+		Archive:          true,
+		Recover:          true,
+		InteractiveInput: true,
+	}
+}
+
+// Recover stands in for recoverSandbox: the destructive re-provision whose
+// firing against a live sandbox is the data loss #1794 exists to prevent. The
+// tests assert on the COUNT, so a re-provision that should never have happened
+// fails loudly rather than silently succeeding.
+func (b *remoteWorkspaceBackend) Recover(inst *session.Instance) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.recovers++
+	inst.SetStatusForTest(session.Running)
+	return nil
+}
+
+func (b *remoteWorkspaceBackend) recoverCalls() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.recovers
+}
+
 // registerStartedRemote registers a started instance whose agent-server is the
 // REAL remoteAgentServer client (#1592 Phase 4) pointed at `url`, so the daemon
-// poll drives it over actual HTTP exactly as it does a docker/ssh session. The
-// backend is a plain FakeBackend: the remote runtime never consults it, so any
-// liveness the poll settles on came from the REST probes, not a tmux stand-in.
-func registerStartedRemote(t *testing.T, m *Manager, repoID, repoPath, title, url string, status session.Status) *session.Instance {
+// poll drives it over actual HTTP exactly as it does a docker/ssh session. Its
+// backend reports an off-box workspace to match, so the poll's remote-vs-local
+// branching (#1794) sees the same shape production does; liveness still comes
+// only from the REST probes, never from a tmux stand-in.
+func registerStartedRemote(t *testing.T, m *Manager, repoID, repoPath, title, url string, status session.Status) (*session.Instance, *remoteWorkspaceBackend) {
 	t.Helper()
 	inst, err := session.NewInstance(session.InstanceOptions{
 		Title:             title,
@@ -25,37 +72,64 @@ func registerStartedRemote(t *testing.T, m *Manager, repoID, repoPath, title, ur
 	if err != nil {
 		t.Fatalf("NewInstance(remote): %v", err)
 	}
-	inst.SetBackend(session.NewFakeBackend())
+	backend := &remoteWorkspaceBackend{FakeBackend: session.NewFakeBackend()}
+	inst.SetBackend(backend)
 	inst.SetStartedForTest(true)
 	inst.SetStatusForTest(status)
 	seedDiskInstance(t, repoID, title, repoPath)
 	m.mu.Lock()
 	m.instances[daemonInstanceKey(repoID, title)] = inst
 	m.mu.Unlock()
-	return inst
+	return inst, backend
 }
 
-// TestRefreshStatuses_UnreachableRemoteMarkedLost is the #1782 regression. A
-// remote session's agent-server dies (container killed, ssh forward dropped), so
-// every REST probe fails with ECONNREFUSED. The poll used to return on the first
-// Snapshot error before any liveness check ran, leaving the session pinned at its
-// last-known Running/Ready forever — the TUI showed a healthy row for a session
-// that was gone, and only manual intervention surfaced it. The failed Snapshot
-// must now be confirmed with an independent Alive() probe and settle to Lost.
+// withRemoteLossThresholds shrinks the #1794 debounce knobs for one test and
+// restores them after. Tests set them explicitly rather than inheriting the
+// production values so an assertion reads against numbers on the same screen.
+func withRemoteLossThresholds(t *testing.T, count int, grace, confirm time.Duration) {
+	t.Helper()
+	prevCount, prevGrace, prevConfirm := remoteLostFailureThreshold, remoteLostGracePeriod, remoteLostConfirmTimeout
+	remoteLostFailureThreshold, remoteLostGracePeriod, remoteLostConfirmTimeout = count, grace, confirm
+	t.Cleanup(func() {
+		remoteLostFailureThreshold, remoteLostGracePeriod, remoteLostConfirmTimeout = prevCount, prevGrace, prevConfirm
+	})
+}
+
+// driveDurableRemoteLoss runs enough failing ticks, spread over enough fake
+// wall-clock, to satisfy BOTH debounce axes — the "the sandbox really is gone"
+// signal.
+func driveDurableRemoteLoss(m *Manager, advance func(time.Duration)) {
+	for i := 0; i < remoteLostFailureThreshold; i++ {
+		m.RefreshStatuses()
+		advance(remoteLostGracePeriod)
+	}
+	m.RefreshStatuses()
+}
+
+// TestRefreshStatuses_UnreachableRemoteMarkedLost is the #1782 regression, held
+// intact across the #1794 debounce. A remote session's agent-server dies
+// (container killed, ssh forward dropped), so every REST probe fails with
+// ECONNREFUSED. The poll used to return on the first Snapshot error before any
+// liveness check ran, leaving the session pinned at its last-known Running/Ready
+// forever — the TUI showed a healthy row for a session that was gone. A DURABLE
+// unreachability must still settle to Lost; #1794 only changed how much evidence
+// that takes, never the destination.
 //
-// Port 1 on loopback has no listener, so both probes are refused immediately —
+// Port 1 on loopback has no listener, so every probe is refused immediately —
 // the "agent-server is unreachable" shape, with no timeout to wait out.
 func TestRefreshStatuses_UnreachableRemoteMarkedLost(t *testing.T) {
+	withRemoteLossThresholds(t, 3, time.Minute, time.Second)
+	advance := withFrozenClock(t)
 	manager, repoID, repoPath := newStatusTestManager(t)
 	// Start from Running to prove the pass actively transitions it rather than
 	// merely leaving a pre-set status untouched.
 	registerStartedRemote(t, manager, repoID, repoPath, "remote-gone", "http://127.0.0.1:1", session.Running)
 
-	manager.RefreshStatuses()
+	driveDurableRemoteLoss(manager, advance)
 
 	inst := manager.instances[daemonInstanceKey(repoID, "remote-gone")]
 	if got := inst.GetLiveness(); got != session.LiveLost {
-		t.Fatalf("in-memory liveness = %v, want LiveLost (an unreachable agent-server must not keep reading as Running)", got)
+		t.Fatalf("in-memory liveness = %v, want LiveLost (a durably unreachable agent-server must not keep reading as Running)", got)
 	}
 	// Persisted too, so the status survives a daemon reload and the restore loop
 	// can find it — Lost, not Dead: no kill intent, still recovery-eligible (#1108).
@@ -64,19 +138,133 @@ func TestRefreshStatuses_UnreachableRemoteMarkedLost(t *testing.T) {
 	}
 }
 
-// TestRefreshStatuses_RemoteSnapshotErrorButAliveKeepsStatus pins the other half
-// of the #1782 fix: a Snapshot error is not on its own proof of death. Here the
-// agent-server is REACHABLE and reports itself alive, but the snapshot probe
-// fails — a transient blip. The poll must leave the status for the next tick
-// rather than marking a healthy session Lost, which is why the fix confirms with
-// Alive() instead of trusting the Snapshot error outright.
-func TestRefreshStatuses_RemoteSnapshotErrorButAliveKeepsStatus(t *testing.T) {
+// TestRefreshStatuses_SingleRemoteFailureDoesNotMarkLostOrReprovision is the
+// #1794 P1 regression — the data-loss one.
+//
+// A single failed poll against a remote session proves nothing: a two-second ssh
+// forward re-establish fails identically to a destroyed container. Acting on it
+// is catastrophic rather than merely wrong, because Lost is not a display state
+// — RestoreLostSessions runs in the SAME daemon tick, docker/ssh advertise
+// Recover, and their Recover is recoverSandbox: provision a NEW container and
+// clone the branch from origin. So one blip used to mean a fresh sandbox, the
+// original left running and unreferenced, and every unpushed commit on it gone.
+//
+// This drives the exact blip shape (one tick, wholly unreachable) and pins both
+// halves of the guarantee: no Lost, and — the part that actually loses work — no
+// re-provision.
+func TestRefreshStatuses_SingleRemoteFailureDoesNotMarkLostOrReprovision(t *testing.T) {
+	withRemoteLossThresholds(t, 3, time.Minute, time.Second)
+	zeroRestoreBackoff(t) // the restore loop must be free to pounce, as it is in prod
+	manager, repoID, repoPath := newStatusTestManager(t)
+	_, backend := registerStartedRemote(t, manager, repoID, repoPath, "remote-blip", "http://127.0.0.1:1", session.Running)
+
+	// One tick, exactly as the daemon runs it: refresh, then restore.
+	manager.RefreshStatuses()
+	manager.RestoreLostSessions()
+
+	inst := manager.instances[daemonInstanceKey(repoID, "remote-blip")]
+	if got := inst.GetLiveness(); got != session.LiveRunning {
+		t.Fatalf("liveness after ONE failed probe = %v, want LiveRunning left alone — a single transport blip is not proof the sandbox died", got)
+	}
+	if got := backend.recoverCalls(); got != 0 {
+		t.Fatalf("Recover calls = %d, want 0 — re-provisioning on a one-poll blip orphans the still-running sandbox and destroys its unpushed work (#1794)", got)
+	}
+}
+
+// TestRefreshStatuses_RemoteFailuresWithinGraceDoNotMarkLost pins the TIME axis
+// of the debounce, which the failure COUNT alone cannot cover. An unreachable
+// port fails instantly, so a burst of ticks can exhaust the count in
+// milliseconds — precisely the fast-failing blip the debounce exists to absorb.
+// Here the count is well past its threshold but the clock has barely moved, so
+// the session must NOT be Lost.
+func TestRefreshStatuses_RemoteFailuresWithinGraceDoNotMarkLost(t *testing.T) {
+	withRemoteLossThresholds(t, 3, time.Minute, time.Second)
+	advance := withFrozenClock(t)
+	manager, repoID, repoPath := newStatusTestManager(t)
+	registerStartedRemote(t, manager, repoID, repoPath, "remote-fastfail", "http://127.0.0.1:1", session.Running)
+
+	// Ten ticks — triple the count threshold — inside a single second.
+	for i := 0; i < 10; i++ {
+		manager.RefreshStatuses()
+		advance(100 * time.Millisecond)
+	}
+
+	inst := manager.instances[daemonInstanceKey(repoID, "remote-fastfail")]
+	if got := inst.GetLiveness(); got != session.LiveRunning {
+		t.Fatalf("liveness = %v, want LiveRunning: %d fast failures inside 1s of a %s grace period is a blip, not a durable loss", got, 10, remoteLostGracePeriod)
+	}
+}
+
+// TestRefreshStatuses_RemoteProbeSuccessResetsDebounce pins that the debounce
+// counts CONSECUTIVE failures. A reachable agent-server is proof the sandbox is
+// there, so it must reset the episode outright. Without the reset, an unlucky
+// session that blips once an hour would accumulate failures forever and a single
+// later blip would tip a perfectly healthy session over the threshold into a
+// re-provision.
+func TestRefreshStatuses_RemoteProbeSuccessResetsDebounce(t *testing.T) {
+	withRemoteLossThresholds(t, 3, time.Minute, time.Second)
+	advance := withFrozenClock(t)
+
+	var healthy atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/v1/agent/snapshot" && healthy.Load() {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{"updated": true, "has_prompt": false, "content": "working"},
+			})
+			return
+		}
+		// Unhealthy: the capture fails, the shape of a blip.
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{"message": "capture failed"},
+		})
+	}))
+	defer srv.Close()
+
+	manager, repoID, repoPath := newStatusTestManager(t)
+	registerStartedRemote(t, manager, repoID, repoPath, "remote-flappy", srv.URL, session.Running)
+	key := daemonInstanceKey(repoID, "remote-flappy")
+
+	// Fail right up to the count threshold, spread past the grace period...
+	for i := 0; i < remoteLostFailureThreshold-1; i++ {
+		manager.RefreshStatuses()
+		advance(remoteLostGracePeriod)
+	}
+	// ...then one good probe lands.
+	healthy.Store(true)
+	manager.RefreshStatuses()
+	healthy.Store(false)
+
+	manager.mu.Lock()
+	_, tracked := manager.remoteLossStates[key]
+	manager.mu.Unlock()
+	if tracked {
+		t.Fatal("a successful probe must drop the loss state entirely — a stale count would tip a later single blip straight to Lost")
+	}
+
+	// The next failure is now episode-fresh, so it cannot be durable on its own.
+	manager.RefreshStatuses()
+	if got := manager.instances[key].GetLiveness(); got == session.LiveLost {
+		t.Fatal("liveness = LiveLost after one failure following a healthy probe: the debounce restarted from a stale count instead of from zero")
+	}
+}
+
+// TestRefreshStatuses_DurableRemoteFailureButAliveKeepsStatus pins the other
+// half of the #1782 fix, now behind the debounce: a Snapshot error is not on its
+// own proof of death. Here the agent-server stays REACHABLE and reports itself
+// alive while its capture keeps failing — a broken snapshot on a healthy
+// sandbox. Even once the failures are durable enough to clear the debounce, the
+// confirming Alive() probe answers, so the session must NOT be marked Lost. This
+// is the check that separates "the capture is broken" from "the sandbox is gone".
+func TestRefreshStatuses_DurableRemoteFailureButAliveKeepsStatus(t *testing.T) {
+	withRemoteLossThresholds(t, 3, time.Minute, time.Second)
+	advance := withFrozenClock(t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/v1/agent/snapshot":
-			// The blip: an error envelope, exactly as the real agent-server
-			// reports a failed capture.
+			// An error envelope, exactly as the real agent-server reports a
+			// failed capture.
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"error": map[string]any{"message": "capture failed"},
 			})
@@ -91,12 +279,140 @@ func TestRefreshStatuses_RemoteSnapshotErrorButAliveKeepsStatus(t *testing.T) {
 	defer srv.Close()
 
 	manager, repoID, repoPath := newStatusTestManager(t)
-	registerStartedRemote(t, manager, repoID, repoPath, "remote-blip", srv.URL, session.Running)
+	registerStartedRemote(t, manager, repoID, repoPath, "remote-capture-broken", srv.URL, session.Running)
 
-	manager.RefreshStatuses()
+	driveDurableRemoteLoss(manager, advance)
 
-	inst := manager.instances[daemonInstanceKey(repoID, "remote-blip")]
+	inst := manager.instances[daemonInstanceKey(repoID, "remote-capture-broken")]
 	if got := inst.GetLiveness(); got != session.LiveRunning {
-		t.Fatalf("in-memory liveness = %v, want LiveRunning (a still-alive session must not be marked Lost on one failed snapshot)", got)
+		t.Fatalf("liveness = %v, want LiveRunning — an agent-server that answers Alive is not Lost no matter how many snapshots failed", got)
+	}
+}
+
+// TestRefreshStatuses_ConfirmationProbeIsBounded is the #1794 P2 regression: the
+// double-timeout poll stall.
+//
+// The confirmation Alive() is a SECOND full REST call, and the Snapshot that
+// triggered it has already burned the whole remoteAgentCallTimeout (30s). Since
+// RefreshStatuses walks instances SERIALLY, an unbounded confirmation let ONE
+// blackholed sandbox add ~2x30s to every poll — wedging status refresh,
+// root-ensure, lost-restore and limit-resume for every other session in the
+// daemon.
+//
+// The server here is the wedge: it accepts the connection and then never
+// answers, so only a client-side bound can end the call. The assertion is on
+// wall-clock — the confirmation must come in near its own short timeout, not
+// near the 30s call timeout — and it is deliberately loose (a 10x margin) so it
+// measures the bound rather than the machine's load.
+func TestRefreshStatuses_ConfirmationProbeIsBounded(t *testing.T) {
+	const confirmTimeout = 250 * time.Millisecond
+	// session.remoteAgentCallTimeout, which the daemon package cannot name. This
+	// is the ceiling an UNBOUNDED confirmation probe would wait out, and the
+	// number this test exists to stay far below.
+	const remoteCallTimeout = 30 * time.Second
+	withRemoteLossThresholds(t, 3, time.Minute, confirmTimeout)
+	advance := withFrozenClock(t)
+
+	release := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/agent/snapshot" {
+			// Fail FAST, so the elapsed time this test measures is the
+			// confirmation probe's alone and not the snapshot's.
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{"message": "capture failed"},
+			})
+			return
+		}
+		// /v1/agent/alive: the blackhole. Never respond.
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	}))
+	defer srv.Close()
+	// LIFO: this runs BEFORE srv.Close() above, which is what makes the close
+	// possible at all. srv.Close() waits for outstanding handlers, and the
+	// blackholed one only returns when released — and it cannot be released from
+	// t.Cleanup, which runs AFTER every defer. The request context is no escape
+	// either: aliveWithin abandons its goroutine but cannot cancel the in-flight
+	// REST call, so the server would sit wedged for the full 30s call timeout.
+	defer close(release)
+
+	manager, repoID, repoPath := newStatusTestManager(t)
+	registerStartedRemote(t, manager, repoID, repoPath, "remote-wedged", srv.URL, session.Running)
+
+	// Ticks below the threshold must not probe Alive at all — the debounce runs
+	// first precisely so the common case costs no extra round-trip.
+	for i := 0; i < remoteLostFailureThreshold-1; i++ {
+		manager.RefreshStatuses()
+		advance(remoteLostGracePeriod)
+	}
+
+	// This is the tick that clears the debounce and pays for the confirmation.
+	start := time.Now()
+	manager.RefreshStatuses()
+	elapsed := time.Since(start)
+
+	if elapsed > 100*confirmTimeout {
+		t.Fatalf("threshold tick took %s with a %s confirmation bound: the confirmation probe is running unbounded, so a wedged remote stalls the serial poll for every other session (#1794)", elapsed, confirmTimeout)
+	}
+	if elapsed >= remoteCallTimeout {
+		t.Fatalf("threshold tick took %s — it waited out the full %s call timeout instead of the short confirmation bound", elapsed, remoteCallTimeout)
+	}
+	// A wedged agent-server that cannot answer a liveness ping on top of durable
+	// snapshot failure is unreachable by any useful definition — the bound must
+	// resolve it, not just abandon it.
+	inst := manager.instances[daemonInstanceKey(repoID, "remote-wedged")]
+	if got := inst.GetLiveness(); got != session.LiveLost {
+		t.Fatalf("liveness = %v, want LiveLost — a bounded confirmation that times out still has to settle the session", got)
+	}
+}
+
+// TestRefreshStatuses_ReachableRemoteWithDeadAgentStillGoesLost guards the trap
+// the #1794 debounce opens if its counter is wired to the wrong signal.
+//
+// A container can outlive the agent inside it: the sandbox is up, the
+// agent-server keeps serving, but the agent process is gone. Every tick then
+// yields a perfectly successful, perfectly idle (false,false) snapshot, and only
+// the Alive() probe reports the truth. If a successful Snapshot were taken as
+// proof of life and used to clear the debounce, this session's failure count
+// would reset on every one of those ticks, never accumulate past one, and the
+// session would stay green FOREVER — silently regressing #935/#1108 for exactly
+// the sessions #1782 set out to fix.
+//
+// So the debounce must count observations with no evidence of LIFE, not
+// transport errors: reachability is not liveness.
+func TestRefreshStatuses_ReachableRemoteWithDeadAgentStillGoesLost(t *testing.T) {
+	withRemoteLossThresholds(t, 3, time.Minute, time.Second)
+	advance := withFrozenClock(t)
+
+	// The sandbox is healthy and answering. The agent inside it is not.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/agent/snapshot":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{"updated": false, "has_prompt": false, "content": ""},
+			})
+		case "/v1/agent/alive":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{"alive": false},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	manager, repoID, repoPath := newStatusTestManager(t)
+	registerStartedRemote(t, manager, repoID, repoPath, "remote-agent-dead", srv.URL, session.Running)
+
+	driveDurableRemoteLoss(manager, advance)
+
+	inst := manager.instances[daemonInstanceKey(repoID, "remote-agent-dead")]
+	if got := inst.GetLiveness(); got != session.LiveLost {
+		t.Fatalf("liveness = %v, want LiveLost — the agent-server answers but reports its agent dead, and a successful snapshot must never be mistaken for evidence of life", got)
 	}
 }

--- a/daemon/status_remote_test.go
+++ b/daemon/status_remote_test.go
@@ -510,3 +510,93 @@ func TestRefreshStatuses_NewSessionDoesNotInheritDebounceState(t *testing.T) {
 		t.Fatalf("Recover calls on the new session = %d, want 0 — inherited state re-provisioned a sandbox that had never failed a probe", got)
 	}
 }
+
+// TestRestoreSession_PostManualRecoverBlipDoesNotReprovision is the manual-path
+// twin of TestRestoreLostSessions_PostRecoverBlipDoesNotReprovisionAgain.
+//
+// The RestoreSession RPC (`af sessions restore`, the TUI's restore action) runs
+// its own Recover, separate from the automatic loop's. Clearing the debounce in
+// only one of them leaves the other armed with the same trap: recovery replaces
+// the runtime, the stale threshold-satisfying count outlives it, and the first
+// blip against the sandbox the USER just asked for re-provisions it away.
+// Recovery is the lifecycle event that must reset the counter — which trigger
+// pulled it is irrelevant.
+func TestRestoreSession_PostManualRecoverBlipDoesNotReprovision(t *testing.T) {
+	withRemoteLossThresholds(t, 3, time.Minute, time.Second)
+	zeroRestoreBackoff(t)
+	advance := withFrozenClock(t)
+
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst, backend := registerStartedRemote(t, manager, repoID, repoPath, "remote-manual", "http://127.0.0.1:1", session.Running)
+
+	// A durable outage parks it at Lost with a threshold-satisfying history.
+	driveDurableRemoteLoss(manager, advance)
+	if got := inst.GetLiveness(); got != session.LiveLost {
+		t.Fatalf("setup: liveness = %v, want LiveLost", got)
+	}
+
+	// The user restores it by hand.
+	if _, err := manager.RestoreSession(RestoreSessionRequest{Title: "remote-manual", RepoID: repoID}); err != nil {
+		t.Fatalf("RestoreSession: %v", err)
+	}
+	if got := backend.recoverCalls(); got != 1 {
+		t.Fatalf("setup: Recover calls = %d, want 1", got)
+	}
+
+	// One blip against the sandbox that restore just built.
+	advance(time.Second)
+	manager.RefreshStatuses()
+	manager.RestoreLostSessions()
+
+	if got := backend.recoverCalls(); got != 1 {
+		t.Fatalf("Recover calls = %d, want still 1 — a manual restore left stale debounce state behind, so one blip threw away the sandbox the user just asked for and orphaned it (#1794)", got)
+	}
+	if got := inst.GetLiveness(); got == session.LiveLost {
+		t.Fatal("liveness = LiveLost after a single post-restore blip: the debounce resumed from the dead sandbox's count instead of from zero")
+	}
+}
+
+// TestRestoreArchived_RemoteReprovisionClearsDebounce is the fourth and last
+// re-provision trigger: the archive-restore path.
+//
+// It is the one the sweep provably cannot cover. Kill or archive a session and
+// the sweep drops its entry — but an archive-RESTORE re-provisions onto the SAME
+// instance ID (same session, new sandbox, by design), so the entry stays "live"
+// and perfectly inheritable while the sandbox it describes is destroyed. Only
+// the site that replaced the runtime can know, which is why noteRuntimeReplaced
+// is named for the trigger and why every such site must call it.
+func TestRestoreArchived_RemoteReprovisionClearsDebounce(t *testing.T) {
+	withRemoteLossThresholds(t, 3, time.Minute, time.Second)
+	zeroRestoreBackoff(t)
+	advance := withFrozenClock(t)
+
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst, backend := registerStartedRemote(t, manager, repoID, repoPath, "remote-archived", "http://127.0.0.1:1", session.Running)
+
+	// A durable outage leaves a threshold-satisfying history on the record.
+	driveDurableRemoteLoss(manager, advance)
+	manager.mu.Lock()
+	stale := len(manager.remoteLossStates)
+	manager.mu.Unlock()
+	if stale == 0 {
+		t.Fatal("setup: expected accumulated debounce state to survive into the archive")
+	}
+
+	// It is archived, then restored — which re-provisions a fresh sandbox.
+	inst.SetStatusForTest(session.Archived)
+	if _, err := manager.RestoreArchived(RestoreArchivedRequest{Title: "remote-archived", RepoID: repoID}); err != nil {
+		t.Fatalf("RestoreArchived: %v", err)
+	}
+	if got := backend.recoverCalls(); got != 1 {
+		t.Fatalf("setup: Recover calls = %d, want 1 (the archive-restore must re-provision once)", got)
+	}
+
+	// One blip against the sandbox the restore just provisioned.
+	advance(time.Second)
+	manager.RefreshStatuses()
+	manager.RestoreLostSessions()
+
+	if got := backend.recoverCalls(); got != 1 {
+		t.Fatalf("Recover calls = %d, want still 1 — the archive-restore left the pre-archive failure count in place, so one blip re-provisioned the restored sandbox away and orphaned it (#1794)", got)
+	}
+}

--- a/daemon/status_remote_test.go
+++ b/daemon/status_remote_test.go
@@ -600,3 +600,81 @@ func TestRestoreArchived_RemoteReprovisionClearsDebounce(t *testing.T) {
 		t.Fatalf("Recover calls = %d, want still 1 — the archive-restore left the pre-archive failure count in place, so one blip re-provisioned the restored sandbox away and orphaned it (#1794)", got)
 	}
 }
+
+// TestRestoreSession_AliveRemoteSandboxIsNotReprovisioned is codex's P1 on
+// 2ec7b52: the manual restore path lacked the live recheck the automatic loop
+// has.
+//
+// I had scoped the recheck to the automatic loop on the reasoning that a manual
+// restore is explicit user intent. That reasoning was wrong. "Restore" asks for
+// a working session; it does not ask to destroy a running sandbox and every
+// commit it never pushed. Being user-initiated makes the recheck MORE important,
+// not less — the user is the one most likely to fire it while a transport is
+// healing, precisely because they watched the row go red. And the row's Lost
+// mark can be minutes stale, since the automatic loop backs off to 5 minutes.
+//
+// A sandbox that answers is not lost: heal the row, deliver what was asked for,
+// destroy nothing.
+func TestRestoreSession_AliveRemoteSandboxIsNotReprovisioned(t *testing.T) {
+	withRemoteLossThresholds(t, 3, time.Minute, time.Second)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/v1/agent/alive" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"alive": true}})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	manager, repoID, repoPath := newStatusTestManager(t)
+	// Marked Lost during an outage; the transport has since healed.
+	inst, backend := registerStartedRemote(t, manager, repoID, repoPath, "remote-healed", srv.URL, session.Lost)
+
+	if _, err := manager.RestoreSession(RestoreSessionRequest{Title: "remote-healed", RepoID: repoID}); err != nil {
+		t.Fatalf("RestoreSession: %v", err)
+	}
+
+	if got := backend.recoverCalls(); got != 0 {
+		t.Fatalf("Recover calls = %d, want 0 — the sandbox answered as alive, so a manual restore must heal the row rather than provision a replacement over a live sandbox and discard its unpushed work (#1794)", got)
+	}
+	if got := inst.GetLiveness(); got == session.LiveLost {
+		t.Fatal("liveness is still LiveLost: a restore that proves the sandbox alive must clear the mark, not leave the row stranded")
+	}
+}
+
+// TestSweepRemoteLossStates_DropsArchivedRows is codex's P3 on 2ec7b52.
+//
+// The sweep took presence in m.instances as proof of liveness, but an archived
+// session stays in that map under the same stable ID — so its entry was kept
+// forever, contradicting the doc. Archiving a remote session tears its sandbox
+// down (branch pushed, in-sandbox workspace killed, remote wiring reset), which
+// makes the count definitionally stale, and the poll never probes an archived
+// row, so nothing would ever clear it.
+func TestSweepRemoteLossStates_DropsArchivedRows(t *testing.T) {
+	withRemoteLossThresholds(t, 3, time.Minute, time.Second)
+	advance := withFrozenClock(t)
+
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst, _ := registerStartedRemote(t, manager, repoID, repoPath, "remote-shelved", "http://127.0.0.1:1", session.Running)
+
+	driveDurableRemoteLoss(manager, advance)
+	manager.mu.Lock()
+	before := len(manager.remoteLossStates)
+	manager.mu.Unlock()
+	if before == 0 {
+		t.Fatal("setup: expected accumulated debounce state before the archive")
+	}
+
+	// Archived: the sandbox those failures were about is deliberately destroyed.
+	inst.SetStatusForTest(session.Archived)
+	manager.RefreshStatuses() // runs the sweep
+
+	manager.mu.Lock()
+	after := len(manager.remoteLossStates)
+	manager.mu.Unlock()
+	if after != 0 {
+		t.Fatalf("remoteLossStates still holds %d entry/entries after the row was archived — an archived session keeps its map entry and its stable ID, and is never probed again, so nothing else will ever drop it (#1794)", after)
+	}
+}

--- a/integration/agent_server_remote_test.go
+++ b/integration/agent_server_remote_test.go
@@ -163,7 +163,7 @@ func TestRemoteAgentServerRoundTrip(t *testing.T) {
 	}
 
 	// --- Alive reports the remote workspace is running ----------------------
-	if !as.Alive() {
+	if alive, err := as.Alive(); err != nil || !alive {
 		t.Fatal("expected the remote workspace to report Alive")
 	}
 
@@ -172,6 +172,7 @@ func TestRemoteAgentServerRoundTrip(t *testing.T) {
 		t.Fatalf("Kill over the wire: %v", err)
 	}
 	waitUntil(t, 10*time.Second, "remote workspace reports not-Alive after Kill", func() bool {
-		return !as.Alive()
+		alive, err := as.Alive()
+		return err != nil || !alive
 	})
 }

--- a/integration/backend_capability_matrix_test.go
+++ b/integration/backend_capability_matrix_test.go
@@ -63,7 +63,7 @@ func assertLiveCapabilityMatrix(t *testing.T, label string, inst *session.Instan
 	if _, err := as.Preview(0, false); err != nil {
 		t.Errorf("%s: Preview over the wire failed (capability not serviced): %v", label, err)
 	}
-	if !as.Alive() {
+	if alive, err := as.Alive(); err != nil || !alive {
 		t.Errorf("%s: live sandbox reports not Alive (liveness not serviced)", label)
 	}
 	t.Logf("%s capability matrix ✓ full remote parity advertised + attach/input/preview/liveness serviced over the wire", label)

--- a/integration/backend_docker_test.go
+++ b/integration/backend_docker_test.go
@@ -160,7 +160,7 @@ func TestDockerBackendRoundTrip(t *testing.T) {
 	if !strings.Contains(preview, marker) {
 		t.Fatalf("Preview did not reflect the typed input: %q", preview)
 	}
-	if !as.Alive() {
+	if alive, err := as.Alive(); err != nil || !alive {
 		t.Fatal("expected the in-container workspace to report Alive")
 	}
 	t.Logf("preview/liveness reflect the in-container workspace over the wire")

--- a/integration/backend_ssh_test.go
+++ b/integration/backend_ssh_test.go
@@ -186,7 +186,7 @@ func TestSSHBackendRoundTrip(t *testing.T) {
 	if !strings.Contains(preview, marker) {
 		t.Fatalf("Preview did not reflect the typed input: %q", preview)
 	}
-	if !as.Alive() {
+	if alive, err := as.Alive(); err != nil || !alive {
 		t.Fatal("expected the remote workspace to report Alive")
 	}
 	t.Logf("preview/liveness reflect the remote workspace over the tunnel")

--- a/integration/remote_roundtrip_test.go
+++ b/integration/remote_roundtrip_test.go
@@ -168,7 +168,7 @@ func TestRemoteHookRoundTripMockRemote(t *testing.T) {
 	if !strings.Contains(preview, marker) {
 		t.Fatalf("Preview did not reflect the typed input: %q", preview)
 	}
-	if !as.Alive() {
+	if alive, err := as.Alive(); err != nil || !alive {
 		t.Fatal("expected the workspace to report Alive")
 	}
 	t.Logf("preview/liveness reflect the workspace over the wire")

--- a/session/agentserver.go
+++ b/session/agentserver.go
@@ -52,11 +52,27 @@ type AgentServer interface {
 	// can't stream live (remote/hook sessions, scroll-mode scrollback, the transient
 	// preview target) — the TUI no longer captures tmux itself (#1592 Phase 2 PR6).
 	Preview(tab int, full bool) (string, error)
-	// Alive reports whether the underlying session process is still running. Kept
-	// separate from Snapshot (rather than folded into Observation) so the daemon
-	// probes liveness ONLY on the idle branch, exactly as before — folding it in
-	// would add a liveness probe to every non-idle tick.
-	Alive() bool
+	// Alive reports whether the underlying session process is still running, and
+	// whether the probe could be ANSWERED at all. Kept separate from Snapshot
+	// (rather than folded into Observation) so the daemon probes liveness ONLY on
+	// the idle branch, exactly as before — folding it in would add a liveness
+	// probe to every non-idle tick.
+	//
+	// A non-nil error means UNKNOWN, not dead: the probe itself failed. For the
+	// remote runtime that is a REST call to the sandbox's agent-server that never
+	// completed — a dropped ssh forward, a docker-proxy hiccup, a blackholed
+	// route. The local runtime probes in-process and never errors.
+	//
+	// The distinction is load-bearing, which is why the error is on the signature
+	// rather than swallowed into a bare bool. "Unreachable" and "reachable, and
+	// the agent is gone" are the same `false` but demand OPPOSITE responses: the
+	// first may be a transient blip that must be waited out, the second is an
+	// authoritative answer that may be acted on at once. Collapsing them is what
+	// let a single transport blip re-provision a live sandbox and destroy its
+	// unpushed work (#1794) — so callers that act destructively on `false` MUST
+	// branch on the error. Callers for whom both cases warrant the same response
+	// may ignore it.
+	Alive() (bool, error)
 
 	// SendPrompt delivers a prompt over the reliable command path (tmux send-keys
 	// for the local runtime) — the path automated/scheduled deliveries use, which

--- a/session/agentserver_local.go
+++ b/session/agentserver_local.go
@@ -157,8 +157,12 @@ func (s *localAgentServer) PreviewContext(ctx context.Context, tab int, full boo
 	return s.Preview(tab, full)
 }
 
-func (s *localAgentServer) Alive() bool {
-	return s.inst.backend.IsAlive(s.inst)
+// Alive probes the local backend in-process, so the answer is always definitive
+// and the error is always nil — there is no transport between here and the tmux
+// server that could leave liveness UNKNOWN. The error exists for the remote
+// runtime; see the AgentServer interface.
+func (s *localAgentServer) Alive() (bool, error) {
+	return s.inst.backend.IsAlive(s.inst), nil
 }
 
 func (s *localAgentServer) SendPrompt(prompt string) error {

--- a/session/agentserver_local_test.go
+++ b/session/agentserver_local_test.go
@@ -93,7 +93,7 @@ func TestLocalAgentServerTapEnter(t *testing.T) {
 
 func TestLocalAgentServerAlive(t *testing.T) {
 	inst, _ := newProbeInstance(t)
-	if inst.AgentServer().Alive() {
+	if alive, _ := inst.AgentServer().Alive(); alive {
 		t.Error("Alive must route to Backend.IsAlive (probe returns false)")
 	}
 }

--- a/session/agentserver_remote.go
+++ b/session/agentserver_remote.go
@@ -134,12 +134,18 @@ func (s *remoteAgentServer) Preview(tab int, full bool) (string, error) {
 	return s.rc.preview(tab, full)
 }
 
-func (s *remoteAgentServer) Alive() bool {
+// Alive asks the in-sandbox agent-server whether its agent is running. The error
+// is the whole point of the signature here: this is a REST call across a real
+// network hop, so it distinguishes "the sandbox answered: the agent is gone"
+// (false, nil — authoritative) from "the sandbox never answered" (false, err —
+// UNKNOWN). Swallowing the error into a bare false made a transport blip
+// indistinguishable from a dead agent, and callers re-provisioned on it (#1794).
+func (s *remoteAgentServer) Alive() (bool, error) {
 	var resp agentAliveResp
 	if err := s.rc.call("/v1/agent/alive", struct{}{}, &resp); err != nil {
-		return false
+		return false, err
 	}
-	return resp.Alive
+	return resp.Alive, nil
 }
 
 func (s *remoteAgentServer) SendPrompt(prompt string) error {

--- a/session/archive_sandbox_test.go
+++ b/session/archive_sandbox_test.go
@@ -271,7 +271,7 @@ func (s *stubAgentServer) Launch(bool) error                           { return 
 func (s *stubAgentServer) Expose() (StreamEndpoint, error)             { return StreamEndpoint{}, nil }
 func (s *stubAgentServer) Snapshot() (Observation, error)              { return Observation{}, nil }
 func (s *stubAgentServer) Preview(int, bool) (string, error)           { return "", nil }
-func (s *stubAgentServer) Alive() bool                                 { return false }
+func (s *stubAgentServer) Alive() (bool, error)                        { return false, nil }
 func (s *stubAgentServer) SendPrompt(string) error                     { return nil }
 func (s *stubAgentServer) TapEnter()                                   {}
 func (s *stubAgentServer) Subscribe(int, Seq) (PTYSubscription, error) { return nil, nil }

--- a/session/backend_docker.go
+++ b/session/backend_docker.go
@@ -578,7 +578,14 @@ func (b *dockerBackend) SendPromptCommand(i *Instance, prompt string) error {
 }
 
 func (b *dockerBackend) IsAlive(i *Instance) bool {
-	return i.AgentServer().Alive()
+	// Backend.IsAlive is bool by contract, so an unanswerable probe collapses to
+	// "not alive" here. That is safe ONLY because this method's callers
+	// (Instance.TmuxAlive, for TUI affordance checks) merely gray out a control.
+	// The daemon's destructive paths — Lost/re-provision/respawn — must NOT come
+	// through here; they call AgentServer().Alive() directly and branch on the
+	// error, because for them "unreachable" and "dead" are not the same (#1794).
+	alive, _ := i.AgentServer().Alive()
+	return alive
 }
 
 // CheckAndHandleTrustPrompt is a daemon-side no-op: the in-container agent-server

--- a/session/backend_hook_backend.go
+++ b/session/backend_hook_backend.go
@@ -333,7 +333,14 @@ func (b *HookBackend) SendPromptCommand(i *Instance, prompt string) error {
 }
 
 func (b *HookBackend) IsAlive(i *Instance) bool {
-	return i.AgentServer().Alive()
+	// Backend.IsAlive is bool by contract, so an unanswerable probe collapses to
+	// "not alive" here. That is safe ONLY because this method's callers
+	// (Instance.TmuxAlive, for TUI affordance checks) merely gray out a control.
+	// The daemon's destructive paths — Lost/re-provision/respawn — must NOT come
+	// through here; they call AgentServer().Alive() directly and branch on the
+	// error, because for them "unreachable" and "dead" are not the same (#1794).
+	alive, _ := i.AgentServer().Alive()
+	return alive
 }
 
 // CheckAndHandleTrustPrompt is a daemon-side no-op: the in-sandbox agent-server

--- a/session/backend_ssh.go
+++ b/session/backend_ssh.go
@@ -845,7 +845,14 @@ func (b *sshBackend) SendPromptCommand(i *Instance, prompt string) error {
 }
 
 func (b *sshBackend) IsAlive(i *Instance) bool {
-	return i.AgentServer().Alive()
+	// Backend.IsAlive is bool by contract, so an unanswerable probe collapses to
+	// "not alive" here. That is safe ONLY because this method's callers
+	// (Instance.TmuxAlive, for TUI affordance checks) merely gray out a control.
+	// The daemon's destructive paths — Lost/re-provision/respawn — must NOT come
+	// through here; they call AgentServer().Alive() directly and branch on the
+	// error, because for them "unreachable" and "dead" are not the same (#1794).
+	alive, _ := i.AgentServer().Alive()
+	return alive
 }
 
 // CheckAndHandleTrustPrompt is a daemon-side no-op: the remote agent-server


### PR DESCRIPTION
Follow-up to #1794 (merged), which made an unreachable remote session settle to `Lost`. Codex flagged two real issues in how it did that. Both are fixed here; #1782's guarantee is unchanged.

## P1 — data-loss regression

A **single** failed poll marked a remote session `Lost`. A brief ssh-forward / NAT / docker-proxy blip fails identically to a dead sandbox, so one bad round-trip was indistinguishable from death.

That mattered because `Lost` is not a display state. `RunDaemon` runs `RefreshStatuses` → `RestoreLostSessions` in the **same tick**; docker (`backend_docker.go:481`), ssh (`:748`) and hook (`:236`) all advertise `Capabilities().Recover`, so the `!Recover` skip at `lostrestore.go:131` never fenced them out. Their `Recover` is **not** a reconnect — it's `recoverSandbox`: provision a **brand-new** sandbox and clone the branch back from origin. Net effect of a two-second blip:

> fresh sandbox provisioned → original sandbox left running and unreferenced → **every unpushed commit on it gone**.

**Fix — require durable failure on two independent axes** before a remote session may go `Lost`:

| axis | knob | why it alone is insufficient |
|---|---|---|
| count | `remoteLostFailureThreshold` (3) | an unreachable port fails *instantly*, so N ticks can burn in milliseconds — exactly the blip being absorbed |
| time | `remoteLostGracePeriod` (60s) | a coarse `daemon_poll_interval` makes a count trivially slow to reach |

Both must hold, so whichever is slower under the operator's poll interval governs.

Two further guards:

- **The idle `!as.Alive()` branch had the identical one-probe defect** for remote (`manager_status.go:210`) — that `Alive()` is also a REST call, lands on the same re-provision hazard, and now debounces identically. Local tmux probes cross no network and stay immediate.
- **Restore-time recheck** (defense in depth): a `Lost` mark can be minutes stale (restore backs off to 5m) and the transport may have healed since. The loop re-probes immediately before the irreversible step and vetoes the re-provision if the sandbox answers.

### A trap worth naming

The counter tracks **consecutive observations with no evidence of life**, *not* consecutive transport errors. A container outlives the agent inside it: the agent-server keeps serving clean idle `(false,false)` snapshots forever while the agent is gone. Had a successful `Snapshot` been treated as proof of life and used to clear the debounce, that session's count would reset every tick, never accumulate past one, and it **could never be marked Lost at all** — silently regressing #935/#1108 for exactly the sessions #1782 set out to fix. I hit this mid-implementation; it's pinned by `TestRefreshStatuses_ReachableRemoteWithDeadAgentStillGoesLost`.

## P2 — double timeout / poll stall

The confirmation `Alive()` after a failed `Snapshot()` started a **second** full REST call, while `Snapshot()` had already consumed the entire `remoteAgentCallTimeout` (30s, `agentserver_remote.go:410`). `RefreshStatuses` processes instances **serially**, so one blackholed remote added ~2×30s to *every* poll — stalling status, root-ensure, lost-restore and limit-resume for **all** sessions.

**Fix:** the confirmation is bounded to 5s, and because the **debounce runs first** it's paid once per *episode* rather than once per *tick*. The common transient case now costs **zero** extra round-trips. `aliveWithin` bounds the caller's wait rather than threading a `context` through the whole `AgentServer` interface for one probe; the orphaned goroutine self-terminates within the call timeout and writes to a buffered channel, so nothing leaks or blocks.

Measured by `TestRefreshStatuses_ConfirmationProbeIsBounded` against a server that accepts and never answers:

| | threshold tick |
|---|---|
| before | **30.04s** (the full call timeout) |
| after | **0.28s** |

## Tests

Every new test was **mutation-checked** — reverted to the pre-fix behavior and confirmed to fail:

| mutation | tests that caught it |
|---|---|
| remove debounce | `SingleRemoteFailureDoesNotMarkLostOrReprovision`, `RemoteFailuresWithinGraceDoNotMarkLost` |
| remove restore recheck | `AliveRemoteSandboxIsNotReprovisioned` |
| unbound confirm probe | `ConfirmationProbeIsBounded` (30.87s → fail) |
| clear debounce on Snapshot success | `ReachableRemoteWithDeadAgentStillGoesLost` |

Also: `UnreachableRemoteMarkedLost` keeps #1782 intact (durable → `Lost`, persisted), `UnreachableRemoteSandboxIsReprovisioned` keeps remote recovery working so the recheck can't become a blanket "never restore remote", and `RemoteProbeSuccessResetsDebounce` pins the consecutive-ness.

`registerStartedRemote` now installs a backend reporting `WorkspaceRemote` **and** `Recover: true`, matching real docker/ssh. The pre-existing `recoverFakeBackend` "remote" double reports `Recover: false` — which is precisely why the automatic re-provision path went untested and this shipped.

Stale docs corrected: `lostrestore.go` described the loop as restoring "local" sessions, untrue since docker/ssh gained `Recover`.

## Gates

`make test-container` ✅ (full suite) · `make tui-driver-selftest` ✅ **31/31** · `go build` ✅ · `gofmt` ✅ · `golangci-lint --fast` ✅ · `deadcode` ✅ · file-length lint ✅ · `-race` on daemon ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)