### PR TITLE
fix(tabs): finish stable-id addressing — no ordinal fallback, refuse stale ids (#1779 codex follow-up)

### DIFF
--- a/app/live_termpane.go
+++ b/app/live_termpane.go
@@ -281,10 +281,16 @@ func (m *home) liveBindCandidate(p *store.OpenPane) (key, title, repoID, tabID s
 	inst := p.Instance()
 	// Address the stream by the tab's STABLE id (#1738) so a reorder/close can't
 	// misroute it; empty (a just-created tab whose daemon id hasn't synced yet)
-	// falls back to the ordinal in DialStream. The bind key still carries the
-	// ordinal + tmux name, so a positional shift still forces a rebind.
+	// falls back to the ordinal in DialStream.
 	tabID, _ = inst.TabIDAt(tab)
-	return fmt.Sprintf("%d/%d/%s", p.ID(), tab, name), inst.Title, m.repoID, tabID, tab, true
+	// The id is part of the bind key, not just the stream coordinates (#1779).
+	// AttachShellTab opens a pane BEFORE the daemon id exists, so that pane connects
+	// positionally; when the next snapshot adopts the real id, nothing else in the
+	// key changes, so without the id here the pane would keep its old ORDINAL
+	// connection forever and could send keystrokes to a different tab after another
+	// client reorders/closes a lower one. Keying on the id makes id adoption itself
+	// a rebind, so the pane reconnects with ?tab_id= the moment one is known.
+	return fmt.Sprintf("%d/%d/%s/%s", p.ID(), tab, name, tabID), inst.Title, m.repoID, tabID, tab, true
 }
 
 // liveSessionName resolves an (instance, tab) to the tmux session a live

--- a/app/live_termpane_test.go
+++ b/app/live_termpane_test.go
@@ -266,3 +266,54 @@ func TestQuitClosesLiveAttachment(t *testing.T) {
 	assert.True(t, (*fakes)[0].closed, "quit must not orphan a stream goroutine")
 	assert.Empty(t, h.liveTerms)
 }
+
+// TestLiveBindKeyIncludesTabID is the regression test for the id-adoption rebind
+// (#1779). AttachShellTab opens a pane BEFORE the daemon has minted the tab's
+// stable id, so that pane necessarily connects positionally (?tab=). When the next
+// snapshot adopts the real id, nothing else about the pane changes — same pane id,
+// same ordinal, same tmux name — so a bind key built only from those would be
+// unchanged and the pane would keep its ORDINAL connection for life. It could then
+// send keystrokes to a DIFFERENT tab once another client closes a lower one. The id
+// must therefore be part of the key, so adoption itself forces the rebind that
+// reconnects with ?tab_id=.
+func TestLiveBindKeyIncludesTabID(t *testing.T) {
+	h, inst := liveTestHome(t)
+	p := openTestPane(t, h, inst, 1)
+
+	// The just-created tab whose daemon id has not synced yet: bound positionally.
+	inst.Tabs[1].ID = ""
+	keyBefore, _, _, tabIDBefore, _, ok := h.liveBindCandidate(p)
+	require.True(t, ok)
+	assert.Empty(t, tabIDBefore, "a tab with no adopted id streams by ordinal")
+
+	// The snapshot adopts the daemon-minted id. NOTHING else about the pane changed.
+	inst.Tabs[1].ID = "adopted-stable-id"
+	keyAfter, _, _, tabIDAfter, _, ok := h.liveBindCandidate(p)
+	require.True(t, ok)
+	assert.Equal(t, "adopted-stable-id", tabIDAfter)
+
+	assert.NotEqual(t, keyBefore, keyAfter,
+		"adopting a tab's stable id must change the bind key, or the pane keeps its stale ordinal-addressed connection")
+}
+
+// TestLiveBindKeyChangesWhenTabIdentitySwapsAtSameOrdinal: the same guarantee for
+// the close+recreate case. A different tab arriving at the SAME ordinal (another
+// client closed this one and made a new one) shares the pane id, the ordinal, and
+// even the tmux name — only the stable id differs. The key must still change, or
+// the pane stays attached to the tab that no longer exists.
+func TestLiveBindKeyChangesWhenTabIdentitySwapsAtSameOrdinal(t *testing.T) {
+	h, inst := liveTestHome(t)
+	p := openTestPane(t, h, inst, 1)
+
+	inst.Tabs[1].ID = "tab-a"
+	keyA, _, _, _, _, ok := h.liveBindCandidate(p)
+	require.True(t, ok)
+
+	// Tab a was closed and replaced at the same ordinal by a different tab.
+	inst.Tabs[1].ID = "tab-b"
+	keyB, _, _, _, _, ok := h.liveBindCandidate(p)
+	require.True(t, ok)
+
+	assert.NotEqual(t, keyA, keyB,
+		"a different tab identity at the same ordinal must force a rebind")
+}

--- a/daemon/agentserver_headless.go
+++ b/daemon/agentserver_headless.go
@@ -398,7 +398,7 @@ func (hs *headlessServer) streamHandler(w http.ResponseWriter, r *http.Request) 
 	// remoteAgentServer has already resolved any stable ?tab_id= to an index before
 	// forwarding it here (#1738), and a sandbox's tab set is fixed for its lifetime,
 	// so there is nothing to re-resolve — pin the ordinal.
-	servePTYStream(hs.as, staticTabResolver(tab), sub, conn)
+	servePTYStream(ordinalTabBinding{as: hs.as, tab: tab}, sub, conn)
 }
 
 // streamInfoHandler answers GET /v1/sessions/{id}/stream-info with where the

--- a/daemon/preview.go
+++ b/daemon/preview.go
@@ -59,12 +59,22 @@ func (s *controlServer) Preview(req PreviewRequest, resp *PreviewResponse) error
 	if err != nil {
 		return err
 	}
-	// Prefer the stable tab id (#1738): resolve it to the tab's CURRENT ordinal so
-	// a capture addresses the right tab after a reorder/close. Fall back to the
-	// ordinal Tab when no id is given or it no longer resolves (legacy clients /
-	// a since-closed tab).
+	// Address the capture by the stable tab id (#1738) when the client gives one:
+	// resolve it to the tab's CURRENT ordinal so a capture follows the tab across a
+	// reorder/close. A non-empty id that no longer resolves is REFUSED as gone —
+	// NOT fallen back to req.Tab (#1779). The fallback previewed whatever tab had
+	// shifted into the stale ordinal, which is precisely the misroute the stable id
+	// exists to prevent. Gone (rather than an error) is the honest answer and the
+	// shape the TUI already degrades on: the addressed tab is genuinely no longer
+	// there. The ordinal is used ONLY when no id was supplied at all — a legacy
+	// client, for which positional addressing is all there ever was.
 	tab := req.Tab
-	if idx, ok := instance.TabIndexByID(req.TabID); ok {
+	if req.TabID != "" {
+		idx, ok := instance.TabIndexByID(req.TabID)
+		if !ok {
+			resp.Gone = true
+			return nil
+		}
 		tab = idx
 	}
 	content, err := as.Preview(tab, req.Full)

--- a/daemon/tab_id_addressing_test.go
+++ b/daemon/tab_id_addressing_test.go
@@ -1,0 +1,241 @@
+package daemon
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// The daemon half of the stable-tab-id addressing contract (#1738, completed in
+// #1779): once a client addresses a tab by its STABLE id, no daemon path may fall
+// back to a POSITIONAL tab. A stale or unknown id is refused — reported gone —
+// because the tab that now sits at the old ordinal is a DIFFERENT tab, and
+// serving it is the precise misroute the stable id was introduced to prevent.
+//
+// These cover the two entry points that took an id and could silently degrade to
+// an ordinal: the Preview control RPC and the WS PTY stream's tab binding.
+
+// TestPreview_RefusesStaleTabID is the regression test for the ordinal fallback
+// (#1779): with [agent, a, b], closing `a` shifts `b` into a's old ordinal. A
+// Preview still addressed by a's id must report GONE — not capture b, which is
+// what leaving the request's stale ordinal in place used to do.
+func TestPreview_RefusesStaleTabID(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	const title = "worker"
+	inst := startedLocalTabInstance(t, manager, repo.ID, repoPath, title, "af_"+title+"_agent")
+	a, err := inst.AddProcessTab("a", "")
+	if err != nil {
+		t.Fatalf("AddProcessTab a: %v", err)
+	}
+	b, err := inst.AddProcessTab("b", "")
+	if err != nil {
+		t.Fatalf("AddProcessTab b: %v", err)
+	}
+
+	// Close a (ordinal 1); b shifts down into ordinal 1.
+	if _, err := manager.CloseTab(CloseTabRequest{Title: title, RepoID: repo.ID, TabName: "a"}); err != nil {
+		t.Fatalf("CloseTab: %v", err)
+	}
+	if idx, ok := inst.TabIndexByID(b.ID); !ok || idx != 1 {
+		t.Fatalf("tab b must have shifted to ordinal 1, got idx=%d ok=%v", idx, ok)
+	}
+
+	cs := &controlServer{manager: manager}
+	// The client still holds a's id AND its captured ordinal (1) — which now names b.
+	// The id is the authority: a is gone, so the capture is refused.
+	var resp PreviewResponse
+	if err := cs.Preview(PreviewRequest{Title: title, RepoID: repo.ID, TabID: a.ID, Tab: 1}, &resp); err != nil {
+		t.Fatalf("Preview with a stale tab id must not error, it must report gone: %v", err)
+	}
+	if !resp.Gone {
+		t.Fatal("Preview addressed by a CLOSED tab's id must report gone, not fall back to the ordinal")
+	}
+	if resp.Content != "" {
+		t.Fatalf("a refused Preview must capture nothing, got %q — it previewed the tab at the stale ordinal", resp.Content)
+	}
+
+	// An id that was never minted is likewise gone rather than a positional capture.
+	resp = PreviewResponse{}
+	if err := cs.Preview(PreviewRequest{Title: title, RepoID: repo.ID, TabID: "never-minted", Tab: 0}, &resp); err != nil {
+		t.Fatalf("Preview with an unknown tab id must not error: %v", err)
+	}
+	if !resp.Gone {
+		t.Fatal("Preview addressed by an UNKNOWN tab id must report gone, not capture tab 0")
+	}
+}
+
+// TestPreview_NoTabIDStillUsesOrdinal pins the legacy path the refusal must not
+// break: a client that supplies NO tab id (pre-#1738) has only ever addressed
+// tabs positionally, so its ?tab= ordinal is still honored. The refusal keys on a
+// non-empty-but-unresolvable id, not on "no id".
+func TestPreview_NoTabIDStillUsesOrdinal(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	const title = "worker"
+	inst := startedLocalTabInstance(t, manager, repo.ID, repoPath, title, "af_"+title+"_agent")
+	if _, err := inst.AddProcessTab("a", ""); err != nil {
+		t.Fatalf("AddProcessTab: %v", err)
+	}
+
+	cs := &controlServer{manager: manager}
+	var resp PreviewResponse
+	if err := cs.Preview(PreviewRequest{Title: title, RepoID: repo.ID, Tab: 1}, &resp); err != nil {
+		t.Fatalf("Preview without a tab id must still capture by ordinal: %v", err)
+	}
+	if resp.Gone {
+		t.Fatal("a legacy no-tab_id Preview must capture by ordinal, not report gone")
+	}
+}
+
+// TestBindTab_RefusesStaleID: the WS stream's tab binding refuses a stale/unknown
+// stable id up front (404), rather than binding whatever tab now holds the old
+// ordinal. This is the subscribe-path half of the same guarantee.
+func TestBindTab_RefusesStaleID(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	const title = "worker"
+	inst := startedLocalTabInstance(t, manager, repo.ID, repoPath, title, "af_"+title+"_agent")
+	a, err := inst.AddProcessTab("a", "")
+	if err != nil {
+		t.Fatalf("AddProcessTab a: %v", err)
+	}
+	b, err := inst.AddProcessTab("b", "")
+	if err != nil {
+		t.Fatalf("AddProcessTab b: %v", err)
+	}
+	if _, err := manager.CloseTab(CloseTabRequest{Title: title, RepoID: repo.ID, TabName: "a"}); err != nil {
+		t.Fatalf("CloseTab: %v", err)
+	}
+
+	cs := &controlServer{manager: manager}
+	as := inst.AgentServer()
+
+	// The local runtime binds the id-native plane, so bindTab itself succeeds and the
+	// refusal surfaces at the atomic subscribe — the point where the id is resolved.
+	binding, err := cs.bindTab(as, inst, a.ID, 1)
+	if err == nil {
+		if _, serr := binding.subscribe(0); serr == nil {
+			t.Fatal("subscribing by a CLOSED tab's id must be refused, not bound to the tab at its old ordinal")
+		} else if !errors.Is(serr, session.ErrTabGone) {
+			t.Fatalf("a stale tab id must be refused with ErrTabGone, got %v", serr)
+		} else if got := httpStatusForTab(serr); got != 404 {
+			t.Fatalf("a stale tab id must map to HTTP 404, got %d", got)
+		}
+	} else if !errors.Is(err, session.ErrTabGone) {
+		t.Fatalf("a stale tab id must be refused with ErrTabGone, got %v", err)
+	}
+
+	// The surviving tab's own id still binds and subscribes.
+	binding, err = cs.bindTab(as, inst, b.ID, 0)
+	if err != nil {
+		t.Fatalf("a live tab's stable id must bind: %v", err)
+	}
+	sub, err := binding.subscribe(0)
+	if err != nil {
+		t.Fatalf("a live tab's stable id must subscribe: %v", err)
+	}
+	_ = sub.Close()
+}
+
+// TestBindTab_NoTabIDPinsOrdinal: a legacy client that supplies no ?tab_id= keeps
+// the pre-#1738 positional behavior — the binding pins the ordinal it asked for
+// and never consults the id map.
+func TestBindTab_NoTabIDPinsOrdinal(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	const title = "worker"
+	inst := startedLocalTabInstance(t, manager, repo.ID, repoPath, title, "af_"+title+"_agent")
+	if _, err := inst.AddProcessTab("a", ""); err != nil {
+		t.Fatalf("AddProcessTab: %v", err)
+	}
+
+	cs := &controlServer{manager: manager}
+	binding, err := cs.bindTab(inst.AgentServer(), inst, "", 1)
+	if err != nil {
+		t.Fatalf("a legacy no-tab_id bind must succeed: %v", err)
+	}
+	ord, ok := binding.(ordinalTabBinding)
+	if !ok {
+		t.Fatalf("no ?tab_id= must pin the ordinal binding, got %T", binding)
+	}
+	if ord.tab != 1 {
+		t.Fatalf("the legacy binding must pin the requested ordinal 1, got %d", ord.tab)
+	}
+}
+
+// TestBindTab_LiveIDBindsIDNativePlane: with a ?tab_id= against a runtime that has
+// an id-native plane (the local agent-server), the binding must be the ID one —
+// NOT an ordinal binding derived by resolving the id up front. Resolving to an
+// ordinal here is what reopened the race (#1779): a close between the resolution
+// and the subscribe shifts a different tab under the captured index.
+func TestBindTab_LiveIDBindsIDNativePlane(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	const title = "worker"
+	inst := startedLocalTabInstance(t, manager, repo.ID, repoPath, title, "af_"+title+"_agent")
+	b, err := inst.AddProcessTab("b", "")
+	if err != nil {
+		t.Fatalf("AddProcessTab: %v", err)
+	}
+
+	cs := &controlServer{manager: manager}
+	binding, err := cs.bindTab(inst.AgentServer(), inst, b.ID, 0)
+	if err != nil {
+		t.Fatalf("bindTab: %v", err)
+	}
+	idb, ok := binding.(idTabBinding)
+	if !ok {
+		t.Fatalf("a ?tab_id= against an id-native runtime must bind by id, got %T — an ordinal binding reintroduces the resolve-then-subscribe race", binding)
+	}
+	if idb.tabID != b.ID {
+		t.Fatalf("the binding must carry the stable id %q, got %q", b.ID, idb.tabID)
+	}
+}

--- a/daemon/tab_id_addressing_test.go
+++ b/daemon/tab_id_addressing_test.go
@@ -140,19 +140,23 @@ func TestBindTab_RefusesStaleID(t *testing.T) {
 	cs := &controlServer{manager: manager}
 	as := inst.AgentServer()
 
-	// The local runtime binds the id-native plane, so bindTab itself succeeds and the
-	// refusal surfaces at the atomic subscribe — the point where the id is resolved.
+	// bindTab never resolves an id up front — the refusal surfaces at the operation,
+	// which is the point where the id is resolved atomically.
 	binding, err := cs.bindTab(as, inst, a.ID, 1)
-	if err == nil {
-		if _, serr := binding.subscribe(0); serr == nil {
-			t.Fatal("subscribing by a CLOSED tab's id must be refused, not bound to the tab at its old ordinal")
-		} else if !errors.Is(serr, session.ErrTabGone) {
-			t.Fatalf("a stale tab id must be refused with ErrTabGone, got %v", serr)
-		} else if got := httpStatusForTab(serr); got != 404 {
-			t.Fatalf("a stale tab id must map to HTTP 404, got %d", got)
-		}
-	} else if !errors.Is(err, session.ErrTabGone) {
-		t.Fatalf("a stale tab id must be refused with ErrTabGone, got %v", err)
+	if err != nil {
+		t.Fatalf("bindTab: %v", err)
+	}
+	if _, serr := binding.subscribe(0); serr == nil {
+		t.Fatal("subscribing by a CLOSED tab's id must be refused, not bound to the tab at its old ordinal")
+	} else if !errors.Is(serr, session.ErrTabGone) {
+		t.Fatalf("a stale tab id must be refused with ErrTabGone, got %v", serr)
+	} else if got := httpStatusForTab(serr); got != 404 {
+		t.Fatalf("a stale tab id must map to HTTP 404, got %d", got)
+	}
+	// The WRITE half is refused too — a keystroke must never reach the tab that
+	// inherited the closed tab's ordinal.
+	if werr := binding.input([]byte("x")); !errors.Is(werr, session.ErrTabGone) {
+		t.Fatalf("input to a stale tab id must be refused with ErrTabGone, got %v", werr)
 	}
 
 	// The surviving tab's own id still binds and subscribes.
@@ -239,3 +243,72 @@ func TestBindTab_LiveIDBindsIDNativePlane(t *testing.T) {
 		t.Fatalf("the binding must carry the stable id %q, got %q", b.ID, idb.tabID)
 	}
 }
+
+// TestBindTab_IDAddressedNeverPinsAnOrdinal is the invariant behind the whole
+// follow-up, asserted at the seam where it could regress: an id-addressed
+// connection must NEVER end up on ordinalTabBinding, whatever the runtime shape.
+// A runtime with an id-native plane binds by id; one without (the ordinal-shaped
+// remote wire protocol) re-resolves per operation. Pinning an ordinal at bind time
+// — which an earlier revision of this change did for the remote path — means a tab
+// that shifts mid-connection sends later input to whatever now holds the old index
+// (#1779).
+func TestBindTab_IDAddressedNeverPinsAnOrdinal(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	const title = "worker"
+	inst := startedLocalTabInstance(t, manager, repo.ID, repoPath, title, "af_"+title+"_agent")
+	b, err := inst.AddProcessTab("b", "")
+	if err != nil {
+		t.Fatalf("AddProcessTab: %v", err)
+	}
+	cs := &controlServer{manager: manager}
+
+	// The id-native runtime.
+	binding, err := cs.bindTab(inst.AgentServer(), inst, b.ID, 0)
+	if err != nil {
+		t.Fatalf("bindTab: %v", err)
+	}
+	if _, pinned := binding.(ordinalTabBinding); pinned {
+		t.Fatal("an id-addressed connection must never pin a fixed ordinal")
+	}
+
+	// A runtime with NO id-native plane must re-resolve, not pin.
+	binding, err = cs.bindTab(ordinalOnlyServer{}, inst, b.ID, 0)
+	if err != nil {
+		t.Fatalf("bindTab (ordinal-only runtime): %v", err)
+	}
+	if _, pinned := binding.(ordinalTabBinding); pinned {
+		t.Fatal("an id-addressed connection to an ordinal-shaped runtime must re-resolve per op, not pin the bind-time ordinal")
+	}
+	rb, ok := binding.(resolvingTabBinding)
+	if !ok {
+		t.Fatalf("expected a re-resolving binding for an ordinal-only runtime, got %T", binding)
+	}
+	if rb.tabID != b.ID {
+		t.Fatalf("the re-resolving binding must carry the stable id %q, got %q", b.ID, rb.tabID)
+	}
+
+	// It resolves the id to the tab's CURRENT ordinal on every op — so a shift is
+	// followed, not misrouted — and refuses an id that names no live tab.
+	if idx, rerr := rb.resolve(); rerr != nil || idx != 1 {
+		t.Fatalf("re-resolve = (%d, %v), want (1, nil)", idx, rerr)
+	}
+	gone := resolvingTabBinding{as: ordinalOnlyServer{}, instance: inst, tabID: "never-minted"}
+	if _, rerr := gone.resolve(); !errors.Is(rerr, session.ErrTabGone) {
+		t.Fatalf("an unknown id must re-resolve to ErrTabGone, got %v", rerr)
+	}
+}
+
+// ordinalOnlyServer is an AgentServer with NO id-native plane — the shape of the
+// remote agent-server, whose wire protocol is ordinal-keyed. It exists to pin
+// bindTab's runtime-shape branch; none of its methods are driven.
+type ordinalOnlyServer struct{ session.AgentServer }

--- a/daemon/ws_pty.go
+++ b/daemon/ws_pty.go
@@ -156,10 +156,7 @@ func (b idTabBinding) resize(rows, cols uint16) error { return b.as.ResizeTab(b.
 
 // ordinalTabBinding is the legacy ?tab=<idx> path: without a stable ?tab_id= there
 // is nothing to re-resolve, so every op addresses the same fixed ordinal for the
-// connection's life (the pre-#1738 positional behavior). It also carries a
-// ?tab_id= connection to a runtime with no id-native plane (the remote
-// agent-server, whose wire protocol is ordinal-shaped) — there the id is resolved
-// once, up front, by bindTab.
+// connection's life (the pre-#1738 positional behavior).
 type ordinalTabBinding struct {
 	as  session.AgentServer
 	tab int
@@ -173,12 +170,62 @@ func (b ordinalTabBinding) resize(rows, cols uint16) error {
 	return b.as.Resize(b.tab, rows, cols)
 }
 
+// resolvingTabBinding carries an id-addressed connection to a runtime with NO
+// id-native plane — the remote agent-server, whose wire protocol is ordinal-shaped
+// (its brokers and channels are keyed by index), so the id cannot be pushed all the
+// way down the way it can locally.
+//
+// It re-resolves the id to a CURRENT ordinal on every operation rather than pinning
+// the one it saw at bind time. Pinning would mean that if the addressed tab shifts
+// mid-connection, later input/resize keep hitting the old index — the positional
+// misroute the stable id exists to prevent, reintroduced on this path (#1779). This
+// still has a narrow window the local path does not (the resolve and the remote
+// server's own ordinal→broker lookup are not one atomic step), but it is the best
+// an ordinal-shaped protocol allows and is strictly better than a fixed ordinal. A
+// tab that no longer resolves is ErrTabGone — the op is refused, not re-pointed.
+type resolvingTabBinding struct {
+	as       session.AgentServer
+	instance *session.Instance
+	tabID    string
+}
+
+func (b resolvingTabBinding) resolve() (int, error) {
+	idx, ok := b.instance.TabIndexByID(b.tabID)
+	if !ok {
+		return 0, fmt.Errorf("session %q tab id %q: %w", b.instance.Title, b.tabID, session.ErrTabGone)
+	}
+	return idx, nil
+}
+
+func (b resolvingTabBinding) subscribe(since session.Seq) (session.PTYSubscription, error) {
+	idx, err := b.resolve()
+	if err != nil {
+		return nil, err
+	}
+	return b.as.Subscribe(idx, since)
+}
+
+func (b resolvingTabBinding) input(p []byte) error {
+	idx, err := b.resolve()
+	if err != nil {
+		return err
+	}
+	return b.as.Input(idx, p)
+}
+
+func (b resolvingTabBinding) resize(rows, cols uint16) error {
+	idx, err := b.resolve()
+	if err != nil {
+		return err
+	}
+	return b.as.Resize(idx, rows, cols)
+}
+
 // bindTab chooses how this connection addresses its tab. A ?tab_id= binds the
 // id-native plane when the runtime has one (the local agent-server), which is the
-// race-free path. A runtime without one (remote, ordinal-shaped wire protocol)
-// resolves the id ONCE here and refuses a stale one — strictly better than a
-// silent ordinal fall-through, and the best its protocol allows. No ?tab_id= at
-// all is a legacy client: pin the ordinal it asked for.
+// race-free path; a runtime without one re-resolves the id per operation. Either
+// way an id-addressed connection NEVER pins an ordinal. No ?tab_id= at all is a
+// legacy client: pin the ordinal it asked for, exactly as before #1738.
 func (cs *controlServer) bindTab(as session.AgentServer, instance *session.Instance, tabID string, tab int) (ptyTabBinding, error) {
 	if tabID == "" {
 		return ordinalTabBinding{as: as, tab: tab}, nil
@@ -186,11 +233,7 @@ func (cs *controlServer) bindTab(as session.AgentServer, instance *session.Insta
 	if ta, ok := as.(session.TabAddressableServer); ok {
 		return idTabBinding{as: ta, tabID: tabID}, nil
 	}
-	idx, ok := instance.TabIndexByID(tabID)
-	if !ok {
-		return nil, fmt.Errorf("session %q tab id %q: %w", instance.Title, tabID, session.ErrTabGone)
-	}
-	return ordinalTabBinding{as: as, tab: idx}, nil
+	return resolvingTabBinding{as: as, instance: instance, tabID: tabID}, nil
 }
 
 // httpStatusForTab maps a tab-addressing failure to its status: a stale/unknown

--- a/daemon/ws_pty.go
+++ b/daemon/ws_pty.go
@@ -92,27 +92,24 @@ func (cs *controlServer) streamHandler(w http.ResponseWriter, r *http.Request) {
 		writeHTTPError(w, http.StatusNotFound, err)
 		return
 	}
-	// Address the tab by its STABLE id (#1738) when the client supplies ?tab_id=:
-	// resolveTab maps the id to the tab's CURRENT ordinal on EVERY operation
-	// (initial Subscribe and each later Input/Resize), so a reorder/close on another
-	// client can never make this connection's captured position refer to a different
-	// tab. Without a ?tab_id= (legacy client) it pins the ?tab= ordinal, preserving
-	// the old positional behavior. A ?tab_id= that names no live tab is a 404 up
-	// front rather than a silent fall-through to a stale ordinal.
-	tabID := r.URL.Query().Get("tab_id")
-	resolveTab := staticTabResolver(tab)
-	if tabID != "" {
-		idx, ok := instance.TabIndexByID(tabID)
-		if !ok {
-			writeHTTPError(w, http.StatusNotFound, fmt.Errorf("session %q has no tab with id %q", id, tabID))
-			return
-		}
-		tab = idx
-		resolveTab = func() (int, bool) { return instance.TabIndexByID(tabID) }
-	}
-	sub, err := as.Subscribe(tab, since)
+	// Address the tab by its STABLE id (#1738) when the client supplies ?tab_id=.
+	// The binding resolves the id atomically on EVERY operation — the initial
+	// Subscribe and each later Input/Resize — so a reorder/close on another client
+	// can never make this connection address a different tab. Crucially the id is
+	// NOT converted to an ordinal here: doing that and letting the agent-server map
+	// the ordinal back to an id reopened the very race the id closes, because a
+	// concurrent close between the two steps shifts a different tab under the
+	// ordinal (#1779). Without a ?tab_id= (legacy client) the binding pins the
+	// ?tab= ordinal, preserving the pre-#1738 positional behavior.
+	binding, err := cs.bindTab(as, instance, r.URL.Query().Get("tab_id"), tab)
 	if err != nil {
-		writeHTTPError(w, http.StatusInternalServerError, err)
+		writeHTTPError(w, httpStatusForTab(err), err)
+		return
+	}
+	sub, err := binding.subscribe(since)
+	if err != nil {
+		// A stale/unknown id is a 404 refusal, never a fall back to a positional tab.
+		writeHTTPError(w, httpStatusForTab(err), err)
 		return
 	}
 	// Announce the subscription's starting cursor on the handshake response so the
@@ -127,29 +124,97 @@ func (cs *controlServer) streamHandler(w http.ResponseWriter, r *http.Request) {
 		_ = sub.Close()
 		return // Accept already wrote the error response.
 	}
-	servePTYStream(as, resolveTab, sub, conn)
+	servePTYStream(binding, sub, conn)
 }
 
-// staticTabResolver returns a resolver that always yields the fixed ordinal idx.
-// It is the legacy ?tab=<idx> path: without a stable ?tab_id= there is nothing to
-// re-resolve, so Input/Resize keep addressing the same ordinal for the
-// connection's life (the pre-#1738 positional behavior).
-func staticTabResolver(idx int) func() (int, bool) {
-	return func() (int, bool) { return idx, true }
+// ptyTabBinding is how ONE connection addresses its tab for the whole of its
+// life. It exists so the addressing decision — stable id (#1738) vs legacy
+// ordinal — is made exactly once, at bind time, instead of being re-derived (and
+// re-raced) at each operation. Every op re-resolves through the same binding, so
+// the initial Subscribe and every later Input/Resize agree on which tab they mean.
+type ptyTabBinding interface {
+	subscribe(since session.Seq) (session.PTYSubscription, error)
+	input(b []byte) error
+	resize(rows, cols uint16) error
+}
+
+// idTabBinding addresses the tab by its STABLE id through the agent-server's
+// id-native plane. The id is resolved to a tmux target atomically inside each
+// operation, so no window exists in which a concurrent close/reorder can shift a
+// different tab under this connection. A closed tab yields ErrTabGone — the op is
+// refused, never re-pointed at whatever tab took its place.
+type idTabBinding struct {
+	as    session.TabAddressableServer
+	tabID string
+}
+
+func (b idTabBinding) subscribe(since session.Seq) (session.PTYSubscription, error) {
+	return b.as.SubscribeTab(b.tabID, since)
+}
+func (b idTabBinding) input(p []byte) error           { return b.as.InputTab(b.tabID, p) }
+func (b idTabBinding) resize(rows, cols uint16) error { return b.as.ResizeTab(b.tabID, rows, cols) }
+
+// ordinalTabBinding is the legacy ?tab=<idx> path: without a stable ?tab_id= there
+// is nothing to re-resolve, so every op addresses the same fixed ordinal for the
+// connection's life (the pre-#1738 positional behavior). It also carries a
+// ?tab_id= connection to a runtime with no id-native plane (the remote
+// agent-server, whose wire protocol is ordinal-shaped) — there the id is resolved
+// once, up front, by bindTab.
+type ordinalTabBinding struct {
+	as  session.AgentServer
+	tab int
+}
+
+func (b ordinalTabBinding) subscribe(since session.Seq) (session.PTYSubscription, error) {
+	return b.as.Subscribe(b.tab, since)
+}
+func (b ordinalTabBinding) input(p []byte) error { return b.as.Input(b.tab, p) }
+func (b ordinalTabBinding) resize(rows, cols uint16) error {
+	return b.as.Resize(b.tab, rows, cols)
+}
+
+// bindTab chooses how this connection addresses its tab. A ?tab_id= binds the
+// id-native plane when the runtime has one (the local agent-server), which is the
+// race-free path. A runtime without one (remote, ordinal-shaped wire protocol)
+// resolves the id ONCE here and refuses a stale one — strictly better than a
+// silent ordinal fall-through, and the best its protocol allows. No ?tab_id= at
+// all is a legacy client: pin the ordinal it asked for.
+func (cs *controlServer) bindTab(as session.AgentServer, instance *session.Instance, tabID string, tab int) (ptyTabBinding, error) {
+	if tabID == "" {
+		return ordinalTabBinding{as: as, tab: tab}, nil
+	}
+	if ta, ok := as.(session.TabAddressableServer); ok {
+		return idTabBinding{as: ta, tabID: tabID}, nil
+	}
+	idx, ok := instance.TabIndexByID(tabID)
+	if !ok {
+		return nil, fmt.Errorf("session %q tab id %q: %w", instance.Title, tabID, session.ErrTabGone)
+	}
+	return ordinalTabBinding{as: as, tab: idx}, nil
+}
+
+// httpStatusForTab maps a tab-addressing failure to its status: a stale/unknown
+// stable id is a 404 (the tab is GONE — the client should stop addressing it), any
+// other bind/subscribe failure stays a 500.
+func httpStatusForTab(err error) int {
+	if errors.Is(err, session.ErrTabGone) {
+		return http.StatusNotFound
+	}
+	return http.StatusInternalServerError
 }
 
 // servePTYStream runs the three loops of one subscriber's connection until any of
 // them ends: the writer (ring → PTY_OUT / resize-echo), the reader (INPUT/RESIZE/
 // detach → agent-server), and the keepalive pinger. It owns closing the
 // subscription and the socket.
-func servePTYStream(as session.AgentServer, resolveTab func() (int, bool), sub session.PTYSubscription, conn *websocket.Conn) {
+func servePTYStream(binding ptyTabBinding, sub session.PTYSubscription, conn *websocket.Conn) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	defer func() { _ = sub.Close() }()
 
 	var wg sync.WaitGroup
 	wg.Add(2)
-	go func() { defer wg.Done(); defer cancel(); readPTYClient(ctx, as, resolveTab, conn) }()
+	go func() { defer wg.Done(); defer cancel(); readPTYClient(ctx, binding, conn) }()
 	go func() { defer wg.Done(); defer cancel(); keepalivePTY(ctx, conn) }()
 
 	writePTYStream(ctx, sub, conn)
@@ -219,27 +284,23 @@ func writePTYStream(ctx context.Context, sub session.PTYSubscription, conn *webs
 // readPTYClient handles client → server frames: INPUT and RESIZE are applied to
 // the agent-server (multi-writer, from any subscriber); a detach control frame or
 // any read error ends the connection.
-func readPTYClient(ctx context.Context, as session.AgentServer, resolveTab func() (int, bool), conn *websocket.Conn) {
+func readPTYClient(ctx context.Context, binding ptyTabBinding, conn *websocket.Conn) {
 	for {
 		msg, err := agentproto.ReadMessage(ctx, conn)
 		if err != nil {
 			return
 		}
 		if msg.Binary {
-			// Re-resolve the tab ordinal per frame (#1738): for a ?tab_id= connection
-			// this maps the stable id to wherever the tab now sits, so a keystroke or
-			// resize can't land on a different tab after a mid-connection reorder/close.
-			// A tab that has since been closed no longer resolves — drop the frame
-			// rather than routing it to whatever tab now holds the old ordinal.
-			tab, ok := resolveTab()
-			if !ok {
-				continue
-			}
+			// The binding re-resolves the tab per frame (#1738): for a ?tab_id=
+			// connection each keystroke/resize lands on wherever THAT tab now sits, so a
+			// mid-connection reorder/close can't misroute it. A tab that has since been
+			// closed no longer resolves — the op errors (ErrTabGone) and the frame is
+			// dropped rather than routed to whatever tab now holds the old ordinal.
 			switch msg.Frame.Op {
 			case agentproto.OpInput:
-				_ = as.Input(tab, msg.Frame.Data)
+				_ = binding.input(msg.Frame.Data)
 			case agentproto.OpResize:
-				_ = as.Resize(tab, msg.Frame.Rows, msg.Frame.Cols)
+				_ = binding.resize(msg.Frame.Rows, msg.Frame.Cols)
 			}
 			continue
 		}

--- a/session/agentserver.go
+++ b/session/agentserver.go
@@ -2,8 +2,41 @@ package session
 
 import (
 	"context"
+	"errors"
 	"io"
 )
+
+// ErrTabGone reports that a stable tab id (#1738) names no live tab — it was
+// closed, or it never existed. It is the REFUSAL the id-addressed data plane
+// returns instead of falling back to a positional tab: once a client addresses a
+// tab by its stable id, silently serving whatever tab now sits at some ordinal is
+// the misroute the id exists to prevent (#1779). Callers map it to a 404/gone.
+var ErrTabGone = errors.New("no tab with that id")
+
+// TabAddressableServer is implemented by an agent-server whose data plane can be
+// addressed by a tab's STABLE id (#1738) instead of a shifting ordinal. It is the
+// id-native half of AgentServer's ordinal data plane: the ordinal methods stay for
+// legacy clients that never supplied a ?tab_id=, while a client that DID supply one
+// binds through here, so the id is resolved exactly ONCE — atomically, at the
+// moment the operation binds — and never round-trips through an ordinal that a
+// concurrent close/reorder can shift underneath it (#1779).
+//
+// The local runtime implements it (its brokers are already keyed by stable id, so
+// id-addressing is strictly simpler than the ordinal round-trip it replaces). A
+// runtime whose wire protocol is ordinal-shaped — the remote agent-server, whose
+// sessions stream through the daemon's Preview capture rather than this WS plane —
+// does not, and the handler falls back to the ordinal path for it.
+type TabAddressableServer interface {
+	// SubscribeTab is Subscribe addressed by stable tab id. ErrTabGone when the id
+	// names no live tab.
+	SubscribeTab(tabID string, since Seq) (PTYSubscription, error)
+	// InputTab is Input addressed by stable tab id. ErrTabGone when the id names no
+	// live tab.
+	InputTab(tabID string, b []byte) error
+	// ResizeTab is Resize addressed by stable tab id. ErrTabGone when the id names
+	// no live tab.
+	ResizeTab(tabID string, rows, cols uint16) error
+}
 
 // AgentServer is the uniform contract the daemon speaks to a session's runtime,
 // regardless of where that runtime physically lives (#1592 Phase 2 — the

--- a/session/agentserver_local.go
+++ b/session/agentserver_local.go
@@ -229,6 +229,62 @@ func (s *localAgentServer) resetBrokerCaptures() {
 	}
 }
 
+// ensureBrokerByID is ensureBroker addressed by a tab's STABLE id (#1738) — the
+// id-native binding path (TabAddressableServer). It resolves the id to the tmux it
+// currently backs ATOMICALLY (TabTmuxByID, one lock), so unlike the ordinal path
+// there is no window in which a concurrent close/reorder can shift a different tab
+// under the caller's address (#1779). The broker map is already id-keyed, so this
+// is the direct route: no ordinal is involved at any point. A stale/unknown id is
+// ErrTabGone — a refusal, never a fall back to a positional tab.
+func (s *localAgentServer) ensureBrokerByID(tabID string) (*ptyBroker, error) {
+	// Resolve under i.mu BEFORE taking s.mu (never nest s.mu → i.mu).
+	ts, ok := s.inst.TabTmuxByID(tabID)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil, fmt.Errorf("session %q is being terminated", s.inst.Title)
+	}
+	if !ok {
+		return nil, fmt.Errorf("session %q tab id %q: %w", s.inst.Title, tabID, ErrTabGone)
+	}
+	if ts == nil {
+		return nil, fmt.Errorf("session %q tab id %q has no local PTY to stream", s.inst.Title, tabID)
+	}
+	if br := s.brokers[tabID]; br != nil {
+		return br, nil
+	}
+	if s.brokers == nil {
+		s.brokers = make(map[string]*ptyBroker)
+	}
+	br := newPTYBroker(newTmuxClientlessChannel(ts))
+	s.brokers[tabID] = br
+	return br, nil
+}
+
+func (s *localAgentServer) SubscribeTab(tabID string, since Seq) (PTYSubscription, error) {
+	br, err := s.ensureBrokerByID(tabID)
+	if err != nil {
+		return nil, err
+	}
+	return br.subscribe(since)
+}
+
+func (s *localAgentServer) InputTab(tabID string, b []byte) error {
+	br, err := s.ensureBrokerByID(tabID)
+	if err != nil {
+		return err
+	}
+	return br.input(b)
+}
+
+func (s *localAgentServer) ResizeTab(tabID string, rows, cols uint16) error {
+	br, err := s.ensureBrokerByID(tabID)
+	if err != nil {
+		return err
+	}
+	return br.resize(rows, cols)
+}
+
 func (s *localAgentServer) Subscribe(tab int, since Seq) (PTYSubscription, error) {
 	br, err := s.ensureBroker(tab)
 	if err != nil {

--- a/session/agentserver_local.go
+++ b/session/agentserver_local.go
@@ -238,13 +238,17 @@ func (s *localAgentServer) resetBrokerCaptures() {
 // ErrTabGone — a refusal, never a fall back to a positional tab.
 func (s *localAgentServer) ensureBrokerByID(tabID string) (*ptyBroker, error) {
 	// Resolve under i.mu BEFORE taking s.mu (never nest s.mu → i.mu).
-	ts, ok := s.inst.TabTmuxByID(tabID)
+	ts, exists := s.inst.TabTmuxByID(tabID)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.closed {
 		return nil, fmt.Errorf("session %q is being terminated", s.inst.Title)
 	}
-	if !ok {
+	// GONE and NOT-YET-STREAMABLE are different answers. Only an id that names no
+	// tab is ErrTabGone (the client should stop addressing it); a real tab with no
+	// local PTY — not started, or a remote runtime — keeps the ordinal path's
+	// message, so a client isn't told a tab that may still come up is gone.
+	if !exists {
 		return nil, fmt.Errorf("session %q tab id %q: %w", s.inst.Title, tabID, ErrTabGone)
 	}
 	if ts == nil {

--- a/session/instance.go
+++ b/session/instance.go
@@ -265,27 +265,36 @@ func (i *Instance) TabIDAt(idx int) (string, bool) {
 }
 
 // TabTmuxByID resolves a tab's stable id (#1738) DIRECTLY to the tmux session it
-// currently backs, under a SINGLE lock acquisition, and reports whether such a
-// live tab exists. It is the atomic primitive the id-addressed data plane binds
-// on: resolving an id to an ordinal and then that ordinal to a tmux session takes
-// i.mu twice, and a concurrent close/reorder between the two makes the second
-// lookup land on a DIFFERENT tab — exactly the misroute the stable id exists to
-// prevent (#1779). Resolving both under one lock closes that window. Returns
-// (nil, false) when the instance is not started, the id names no tab, or the tab
-// has no local tmux (a remote runtime).
-func (i *Instance) TabTmuxByID(id string) (*tmux.TmuxSession, bool) {
+// currently backs, under a SINGLE lock acquisition. It is the atomic primitive the
+// id-addressed data plane binds on: resolving an id to an ordinal and then that
+// ordinal to a tmux session takes i.mu twice, and a concurrent close/reorder
+// between the two makes the second lookup land on a DIFFERENT tab — exactly the
+// misroute the stable id exists to prevent (#1779). Resolving both under one lock
+// closes that window.
+//
+// The two return values answer two DIFFERENT questions, and callers must not
+// conflate them:
+//
+//   - exists=false — the id names no tab at all: it was closed, or never minted.
+//     This is the "gone" the id-addressed plane refuses on.
+//   - exists=true, ts=nil — the tab is real but has no local PTY right now: the
+//     instance has not started, or it is a remote runtime with no local tmux. NOT
+//     gone; a caller must not report it as such, since a not-yet-started tab may
+//     still come up and a client should keep addressing it.
+func (i *Instance) TabTmuxByID(id string) (ts *tmux.TmuxSession, exists bool) {
 	if id == "" {
 		return nil, false
 	}
 	i.mu.RLock()
 	defer i.mu.RUnlock()
-	if !i.started {
-		return nil, false
-	}
 	for idx, t := range i.Tabs {
-		if t.ID == id {
-			return i.tabTmuxAtLocked(idx), true
+		if t.ID != id {
+			continue
 		}
+		if !i.started {
+			return nil, true // the tab exists; it just has no live PTY yet
+		}
+		return i.tabTmuxAtLocked(idx), true
 	}
 	return nil, false
 }

--- a/session/instance.go
+++ b/session/instance.go
@@ -264,6 +264,32 @@ func (i *Instance) TabIDAt(idx int) (string, bool) {
 	return i.Tabs[idx].ID, true
 }
 
+// TabTmuxByID resolves a tab's stable id (#1738) DIRECTLY to the tmux session it
+// currently backs, under a SINGLE lock acquisition, and reports whether such a
+// live tab exists. It is the atomic primitive the id-addressed data plane binds
+// on: resolving an id to an ordinal and then that ordinal to a tmux session takes
+// i.mu twice, and a concurrent close/reorder between the two makes the second
+// lookup land on a DIFFERENT tab — exactly the misroute the stable id exists to
+// prevent (#1779). Resolving both under one lock closes that window. Returns
+// (nil, false) when the instance is not started, the id names no tab, or the tab
+// has no local tmux (a remote runtime).
+func (i *Instance) TabTmuxByID(id string) (*tmux.TmuxSession, bool) {
+	if id == "" {
+		return nil, false
+	}
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	if !i.started {
+		return nil, false
+	}
+	for idx, t := range i.Tabs {
+		if t.ID == id {
+			return i.tabTmuxAtLocked(idx), true
+		}
+	}
+	return nil, false
+}
+
 // TabIndexByID returns the CURRENT ordinal of the tab with stable id (#1738),
 // and whether such a tab exists. It is the id→index resolution the stream
 // endpoint runs per operation: a client addresses a tab by its stable id and the

--- a/session/tab_stable_id_test.go
+++ b/session/tab_stable_id_test.go
@@ -233,6 +233,33 @@ func TestTabTmuxByID_RefusesStaleAndEmpty(t *testing.T) {
 	assert.False(t, ok, "an empty id must resolve to no tmux")
 }
 
+// TestTabTmuxByID_NotStartedIsNotGone pins the distinction the refusal must NOT
+// over-reach into: a tab on a not-yet-started instance is real — it simply has no
+// live PTY yet. It must report exists=true with a nil tmux, so the data plane
+// answers "nothing to stream" rather than ErrTabGone. Calling it gone would 404 the
+// client, telling it to stop addressing a tab that is about to come up.
+func TestTabTmuxByID_NotStartedIsNotGone(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst, _ := raceMockInstance(t, "af_stable_notstarted", func() {})
+	b, err := inst.AddProcessTab("b", "b")
+	require.NoError(t, err)
+
+	inst.SetStartedForTest(false)
+
+	ts, exists := inst.TabTmuxByID(b.ID)
+	assert.True(t, exists, "a real tab on a not-started instance EXISTS — it is not gone")
+	assert.Nil(t, ts, "a not-started instance has no live tmux to stream")
+
+	// And the data plane must not call it gone.
+	las := inst.AgentServer().(*localAgentServer)
+	_, err = las.SubscribeTab(b.ID, 0)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrTabGone,
+		"a not-started tab must not be reported gone — that would 404 a client off a tab that may still come up")
+}
+
 // TestSubscribeTab_RefusesStaleID: the id-native data plane REFUSES a stale/unknown
 // tab id with ErrTabGone instead of serving a positional tab (#1779). Subscribing
 // by a closed tab's id must not hand back the broker of whatever tab shifted into

--- a/session/tab_stable_id_test.go
+++ b/session/tab_stable_id_test.go
@@ -177,6 +177,127 @@ func TestEnsureBrokerFollowsTabAcrossClose(t *testing.T) {
 	assert.Equal(t, 1, nAfter, "no stale second broker may be created for the shifted ordinal")
 }
 
+// TestTabTmuxByID_ResolvesTargetAtomically pins the atomic primitive the id-native
+// data plane binds on (#1779): a stable id resolves DIRECTLY to the tmux its tab
+// currently backs, and keeps resolving to that same tmux after an unrelated close
+// shifts the tab's ordinal. Resolving id→ordinal→tmux in two steps is what let a
+// concurrent close land the second step on a different tab; this is the one-step
+// route that has no such window.
+func TestTabTmuxByID_ResolvesTargetAtomically(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst, _ := raceMockInstance(t, "af_stable_tmuxbyid", func() {})
+	_, err := inst.AddProcessTab("a", "a")
+	require.NoError(t, err)
+	b, err := inst.AddProcessTab("b", "b")
+	require.NoError(t, err)
+
+	// b sits at ordinal 2; its id resolves to the tmux backing b.
+	tsBefore, ok := inst.TabTmuxByID(b.ID)
+	require.True(t, ok, "a live tab's id must resolve to its tmux")
+	require.NotNil(t, tsBefore)
+
+	// Close the middle tab a; b shifts down to ordinal 1.
+	require.NoError(t, inst.CloseTab(1))
+	requireIndex(t, inst, b.ID, 1)
+
+	// b's id STILL resolves to b's own tmux — it followed the tab, not the ordinal.
+	tsAfter, ok := inst.TabTmuxByID(b.ID)
+	require.True(t, ok)
+	assert.Same(t, tsBefore, tsAfter, "a tab id must resolve to the same tmux across an ordinal shift")
+}
+
+// TestTabTmuxByID_RefusesStaleAndEmpty: an id that names no live tab — closed, or
+// never minted — resolves to nothing rather than to whatever tab now holds its old
+// ordinal. This is the refusal the whole #1779 follow-up rests on: once a caller
+// addresses a tab by id, "gone" must be an answer the plane can give.
+func TestTabTmuxByID_RefusesStaleAndEmpty(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst, _ := raceMockInstance(t, "af_stable_tmuxstale", func() {})
+	a, err := inst.AddProcessTab("a", "a")
+	require.NoError(t, err)
+	_, err = inst.AddProcessTab("b", "b")
+	require.NoError(t, err)
+
+	// Close a (ordinal 1). Tab b shifts into the ordinal a used to hold.
+	require.NoError(t, inst.CloseTab(1))
+
+	_, ok := inst.TabTmuxByID(a.ID)
+	assert.False(t, ok, "a closed tab's id must resolve to no tmux, not to the tab that took its ordinal")
+	_, ok = inst.TabTmuxByID("nonexistent-id")
+	assert.False(t, ok, "an unknown id must resolve to no tmux")
+	_, ok = inst.TabTmuxByID("")
+	assert.False(t, ok, "an empty id must resolve to no tmux")
+}
+
+// TestSubscribeTab_RefusesStaleID: the id-native data plane REFUSES a stale/unknown
+// tab id with ErrTabGone instead of serving a positional tab (#1779). Subscribing
+// by a closed tab's id must not hand back the broker of whatever tab shifted into
+// its old ordinal — that misroute is exactly what the stable id exists to prevent.
+func TestSubscribeTab_RefusesStaleID(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst, _ := raceMockInstance(t, "af_stable_subrefuse", func() {})
+	a, err := inst.AddProcessTab("a", "a")
+	require.NoError(t, err)
+	b, err := inst.AddProcessTab("b", "b")
+	require.NoError(t, err)
+
+	las := inst.AgentServer().(*localAgentServer)
+
+	// Close a (ordinal 1); b shifts down into ordinal 1.
+	require.NoError(t, inst.CloseTab(1))
+	requireIndex(t, inst, b.ID, 1)
+
+	// Subscribing by the CLOSED tab's id is refused as gone...
+	_, err = las.SubscribeTab(a.ID, 0)
+	require.Error(t, err, "a stale tab id must be refused, not resolved positionally")
+	assert.ErrorIs(t, err, ErrTabGone)
+	// ...and it did NOT bind b's broker (the tab now at a's old ordinal).
+	las.mu.Lock()
+	_, boundB := las.brokers[b.ID]
+	las.mu.Unlock()
+	assert.False(t, boundB, "refusing a stale id must not bind the tab that took its ordinal")
+
+	// An unknown id is likewise gone, and the live tab's own id still works.
+	_, err = las.SubscribeTab("never-minted", 0)
+	assert.ErrorIs(t, err, ErrTabGone)
+	_, err = las.SubscribeTab("", 0)
+	assert.ErrorIs(t, err, ErrTabGone, "an empty id is not addressable by id")
+
+	sub, err := las.SubscribeTab(b.ID, 0)
+	require.NoError(t, err, "a live tab's stable id must still subscribe")
+	require.NotNil(t, sub)
+	_ = sub.Close()
+}
+
+// TestInputResizeTab_RefuseStaleID: the refusal covers the WRITE half of the plane
+// too. A keystroke or resize addressed to a closed tab's id is dropped, never
+// delivered to the tab that inherited its ordinal — the misroute with the worst
+// consequence, since it types into the wrong terminal.
+func TestInputResizeTab_RefuseStaleID(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst, _ := raceMockInstance(t, "af_stable_writerefuse", func() {})
+	a, err := inst.AddProcessTab("a", "a")
+	require.NoError(t, err)
+	_, err = inst.AddProcessTab("b", "b")
+	require.NoError(t, err)
+
+	las := inst.AgentServer().(*localAgentServer)
+	require.NoError(t, inst.CloseTab(1)) // close a; b takes ordinal 1
+
+	assert.ErrorIs(t, las.InputTab(a.ID, []byte("rm -rf /\n")), ErrTabGone,
+		"input to a closed tab's id must be refused, not typed into the tab at its old ordinal")
+	assert.ErrorIs(t, las.ResizeTab(a.ID, 40, 100), ErrTabGone,
+		"a resize addressed to a closed tab's id must be refused")
+}
+
 func requireIndex(t *testing.T, inst *Instance, id string, want int) {
 	t.Helper()
 	idx, ok := inst.TabIndexByID(id)

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7185,6 +7185,27 @@ function resolveDragTab(drag, tabRealIds, tabIds, tabCount) {
   return tab;
 }
 
+// src/tabaddr.ts
+function isLoopbackWebUrl(raw) {
+  try {
+    let host = new URL(raw).hostname.toLowerCase();
+    host = host.replace(/^\[|\]$/g, "");
+    return host === "localhost" || host === "::1" || host === "127.0.0.1" || host.startsWith("127.");
+  } catch {
+    return false;
+  }
+}
+function webProxyPath(sessionId, tabIdx, token2) {
+  const base = `/v1/webtab/${encodeURIComponent(sessionId)}/${tabIdx}/`;
+  return token2 ? `${base}?access_token=${encodeURIComponent(token2)}` : base;
+}
+function paneAddressUsesOrdinal(webTarget, realId) {
+  if (webTarget !== null) {
+    return webTarget !== "" && isLoopbackWebUrl(webTarget);
+  }
+  return realId === "";
+}
+
 // src/terminal.ts
 var import_addon_fit = __toESM(require_addon_fit(), 1);
 var import_xterm = __toESM(require_xterm(), 1);
@@ -7644,19 +7665,6 @@ function el(tag, cls) {
   node.className = cls;
   return node;
 }
-function isLoopbackWebUrl(raw) {
-  try {
-    let host = new URL(raw).hostname.toLowerCase();
-    host = host.replace(/^\[|\]$/g, "");
-    return host === "localhost" || host === "::1" || host === "127.0.0.1" || host.startsWith("127.");
-  } catch {
-    return false;
-  }
-}
-function webProxyPath(sessionId, tabIdx, token2) {
-  const base = `/v1/webtab/${encodeURIComponent(sessionId)}/${tabIdx}/`;
-  return token2 ? `${base}?access_token=${encodeURIComponent(token2)}` : base;
-}
 function webFallbackMs() {
   const override = globalThis.__afWebtabFallbackMs;
   return typeof override === "number" ? override : 2500;
@@ -7891,8 +7899,11 @@ var SplitView = class {
       }
       const webTarget = this.webTargetAt(leaf.tab);
       const identity = this.tabIds[leaf.tab] ?? "";
+      const realId = this.tabRealIds[leaf.tab] ?? "";
+      const moved = pane.tab !== leaf.tab;
+      const staleAddress = pane.identity !== identity || moved && paneAddressUsesOrdinal(webTarget, realId);
       if (webTarget !== null) {
-        if (pane.term || pane.webUrl !== webTarget || pane.tab !== leaf.tab || pane.identity !== identity) {
+        if (pane.term || pane.webUrl !== webTarget || staleAddress) {
           pane.term?.dispose();
           pane.term = null;
           pane.webDispose?.();
@@ -7902,8 +7913,10 @@ var SplitView = class {
           this.mountWebPane(pane, webTarget);
           pane.status = "open";
           this.onPaneStatus(leaf.id, "open");
+        } else if (moved) {
+          pane.tab = leaf.tab;
         }
-      } else if (!pane.term || pane.tab !== leaf.tab || pane.identity !== identity) {
+      } else if (!pane.term || staleAddress) {
         pane.term?.dispose();
         pane.webDispose?.();
         pane.webUrl = null;
@@ -7911,11 +7924,12 @@ var SplitView = class {
         pane.tab = leaf.tab;
         pane.identity = identity;
         pane.status = "connecting";
-        const realId = this.tabRealIds[leaf.tab] ?? "";
         pane.term = new AttachTerminal(pane.host, this.sessionId, this.token, realId, leaf.tab, {
           onStatus: (s) => this.onPaneStatus(leaf.id, s),
           onFocusChange: (f) => this.onPaneFocus(leaf.id, f)
         });
+      } else if (moved) {
+        pane.tab = leaf.tab;
       }
       pane.container.classList.toggle("af-pane-multi", multi);
       pane.label.textContent = `Tab ${leaf.tab + 1}`;

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7130,6 +7130,29 @@ function validate(root2, tabCount) {
   }
   return cur;
 }
+function sameTabs(a, b) {
+  if (a.length !== b.length) {
+    return false;
+  }
+  return a.every((v, i) => v === b[i]);
+}
+function tabsRebound(prevIds, prevKinds, prevTargets, ids, kinds, targets) {
+  return !sameTabs(prevIds, ids) || !sameTabs(prevKinds.map(String), kinds.map(String)) || !sameTabs(
+    prevTargets.map((t) => t ?? ""),
+    targets.map((t) => t ?? "")
+  );
+}
+function resolveDragTab(drag, tabRealIds, tabIds, tabCount) {
+  if (drag.id) {
+    const tab2 = tabRealIds.indexOf(drag.id);
+    return tab2 < 0 ? null : tab2;
+  }
+  const tab = drag.index;
+  if (tab < 0 || tab >= tabCount || !sameTabs(drag.tabs, tabIds)) {
+    return null;
+  }
+  return tab;
+}
 
 // src/terminal.ts
 var import_addon_fit = __toESM(require_addon_fit(), 1);
@@ -7590,12 +7613,6 @@ function el(tag, cls) {
   node.className = cls;
   return node;
 }
-function sameTabs(a, b) {
-  if (a.length !== b.length) {
-    return false;
-  }
-  return a.every((v, i) => v === b[i]);
-}
 function isLoopbackWebUrl(raw) {
   try {
     let host = new URL(raw).hostname.toLowerCase();
@@ -7629,6 +7646,10 @@ var SplitView = class {
   // store update. A drop compares its drag-time snapshot against this to detect a
   // mid-drag tab-set change (concurrent close/create/reorder) and cancel.
   tabIds = [];
+  // The REAL daemon tab ids ("" where a tab has none), parallel to tabIds. Kept
+  // apart from the identity list because only these may cross the wire as a
+  // ?tab_id= or be trusted as a collision-proof identity (#1779) — see ui.tabRealId.
+  tabRealIds = [];
   // Per-tab-index iframe target for web tabs (TabKind.Web); undefined for a
   // terminal tab. Parallel to the tab list, refreshed on every setSession, so
   // reconcile can mount an iframe for a web leaf without extra plumbing.
@@ -7654,9 +7675,13 @@ var SplitView = class {
    * fresh single leaf bound to `initialTab`); the SAME session only re-validates the
    * tree against the current tab list (a tab closed elsewhere). Cheap on a no-op.
    */
-  setSession(sessionId, token2, tabIds, initialTab, tabTargets = [], tabKinds = []) {
+  setSession(sessionId, token2, tabIds, initialTab, tabTargets = [], tabKinds = [], tabRealIds = []) {
     this.token = token2;
+    const prevIds = this.tabIds;
+    const prevKinds = this.tabKinds;
+    const prevTargets = this.tabTargets;
     this.tabIds = tabIds;
+    this.tabRealIds = tabRealIds;
     this.tabTargets = tabTargets;
     this.tabKinds = tabKinds;
     const tabCount = tabIds.length > 0 ? tabIds.length : 1;
@@ -7674,7 +7699,8 @@ var SplitView = class {
       if (this.trees.get(sessionId) !== this.tree) {
         this.trees.set(sessionId, this.tree);
       }
-      if (before !== this.tree) {
+      const rebound = tabsRebound(prevIds, prevKinds, prevTargets, tabIds, tabKinds, tabTargets);
+      if (before !== this.tree || rebound) {
         this.reconcile();
         this.report();
       }
@@ -7832,25 +7858,29 @@ var SplitView = class {
         continue;
       }
       const webTarget = this.webTargetAt(leaf.tab);
+      const identity = this.tabIds[leaf.tab] ?? "";
       if (webTarget !== null) {
-        if (pane.term || pane.webUrl !== webTarget || pane.tab !== leaf.tab) {
+        if (pane.term || pane.webUrl !== webTarget || pane.tab !== leaf.tab || pane.identity !== identity) {
           pane.term?.dispose();
           pane.term = null;
           pane.webDispose?.();
           pane.host.replaceChildren();
           pane.tab = leaf.tab;
+          pane.identity = identity;
           this.mountWebPane(pane, webTarget);
           pane.status = "open";
           this.onPaneStatus(leaf.id, "open");
         }
-      } else if (!pane.term || pane.tab !== leaf.tab) {
+      } else if (!pane.term || pane.tab !== leaf.tab || pane.identity !== identity) {
         pane.term?.dispose();
         pane.webDispose?.();
         pane.webUrl = null;
         pane.host.replaceChildren();
         pane.tab = leaf.tab;
+        pane.identity = identity;
         pane.status = "connecting";
-        pane.term = new AttachTerminal(pane.host, this.sessionId, this.token, this.tabIds[leaf.tab] ?? "", leaf.tab, {
+        const realId = this.tabRealIds[leaf.tab] ?? "";
+        pane.term = new AttachTerminal(pane.host, this.sessionId, this.token, realId, leaf.tab, {
           onStatus: (s) => this.onPaneStatus(leaf.id, s),
           onFocusChange: (f) => this.onPaneFocus(leaf.id, f)
         });
@@ -7888,6 +7918,8 @@ var SplitView = class {
       overlay,
       term: null,
       tab: -1,
+      // No tab bound yet; tab:-1 already forces the first reconcile to build one.
+      identity: "",
       status: "connecting",
       webUrl: null,
       webDispose: null
@@ -8098,17 +8130,9 @@ var SplitView = class {
       if (!drag || !this.tree) {
         return;
       }
-      let tab;
-      if (drag.id) {
-        tab = this.tabIds.indexOf(drag.id);
-        if (tab < 0) {
-          return;
-        }
-      } else {
-        tab = drag.index;
-        if (tab < 0 || tab >= this.tabCount || !sameTabs(drag.tabs, this.tabIds)) {
-          return;
-        }
+      const tab = resolveDragTab(drag, this.tabRealIds, this.tabIds, this.tabCount);
+      if (tab === null) {
+        return;
       }
       const zone = this.zoneAt(pane.container, e.clientX, e.clientY);
       this.tree = zone === "center" ? replaceTab(this.tree, pane.leafId, tab) : splitLeaf(this.tree, pane.leafId, zone, tab);
@@ -8476,6 +8500,9 @@ function sessionTabs(s) {
 function tabIdentity(tab) {
   return tab.id && tab.id !== "" ? tab.id : `${tab.kind}:${tab.name}`;
 }
+function tabRealId(tab) {
+  return tab.id && tab.id !== "" ? tab.id : "";
+}
 function tabLabel(tab) {
   if (tab.kind === 0) {
     return "Agent";
@@ -8773,6 +8800,10 @@ var AppShell = class {
   // dragged tab's payload by the delegated dragstart so a drop can detect a mid-drag
   // tab-set change and cancel (see split.ts). Kept live by renderTabBar.
   currentTabIds = [];
+  // The REAL daemon tab ids drawn in the bar at its last render ("" for a tab with
+  // none), parallel to currentTabIds. Separate because only a real id may be
+  // treated as a stable identity by a drop (#1779) — see tabRealId.
+  currentTabRealIds = [];
   // A signature of everything the bar DRAWS (see tabBarSig): the bar is rebuilt only
   // when this changes, so an unrelated status snapshot never churns its DOM (#1737).
   lastTabBarSig = "";
@@ -9018,6 +9049,7 @@ var AppShell = class {
     const active = Math.min(Math.max(state.activeTab, 0), tabs.length - 1);
     const shown = new Set(state.shownTabs);
     this.currentTabIds = tabs.map(tabIdentity);
+    this.currentTabRealIds = tabs.map(tabRealId);
     const children = tabs.map(
       (tab, i) => tabButton(tab, i, i === active, shown.has(i), canManage, this.actions)
     );
@@ -9047,7 +9079,7 @@ var AppShell = class {
       if (!Number.isInteger(index)) {
         return;
       }
-      const id = this.currentTabIds[index] ?? "";
+      const id = this.currentTabRealIds[index] ?? "";
       e.dataTransfer.setData(TAB_DND_MIME, JSON.stringify({ id, index, tabs: this.currentTabIds }));
       e.dataTransfer.effectAllowed = "move";
       document.body.classList.add("af-dragging-tab");
@@ -9634,9 +9666,10 @@ function syncSplit(state) {
   const initialTab = clampActiveTab(state.sessions, selId, state.activeTab);
   const selected = selId ? state.sessions.find((s) => s.id === selId) : null;
   const tabIds = selected ? sessionTabs(selected).map(tabIdentity) : ["0:"];
+  const tabRealIds = selected ? sessionTabs(selected).map(tabRealId) : [""];
   const tabTargets = selected ? sessionTabs(selected).map((t) => t.url) : [];
   const tabKinds = selected ? sessionTabs(selected).map((t) => t.kind) : [];
-  splitView.setSession(tok !== null ? selId : null, tok, tabIds, initialTab, tabTargets, tabKinds);
+  splitView.setSession(tok !== null ? selId : null, tok, tabIds, initialTab, tabTargets, tabKinds, tabRealIds);
 }
 function disposeSplit() {
   splitView.dispose();

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7142,6 +7142,37 @@ function tabsRebound(prevIds, prevKinds, prevTargets, ids, kinds, targets) {
     targets.map((t) => t ?? "")
   );
 }
+function remapByIdentity(root2, prevIds, ids) {
+  if (prevIds.length === 0) {
+    return root2;
+  }
+  const moved = /* @__PURE__ */ new Map();
+  const claimed = /* @__PURE__ */ new Set();
+  for (const leaf of leaves(root2)) {
+    const identity = prevIds[leaf.tab];
+    if (identity === void 0 || identity === "") {
+      continue;
+    }
+    const next = ids.indexOf(identity);
+    if (next >= 0) {
+      moved.set(leaf.id, next);
+      claimed.add(next);
+    }
+  }
+  if (moved.size === 0) {
+    return root2;
+  }
+  let cur = mapAllLeaves(root2, (leaf) => {
+    const next = moved.get(leaf.id);
+    return next === void 0 || next === leaf.tab ? leaf : { ...leaf, tab: next };
+  });
+  for (const leaf of leaves(cur)) {
+    if (!moved.has(leaf.id) && claimed.has(leaf.tab)) {
+      cur = closeLeaf(cur, leaf.id) ?? cur;
+    }
+  }
+  return cur;
+}
 function resolveDragTab(drag, tabRealIds, tabIds, tabCount) {
   if (drag.id) {
     const tab2 = tabRealIds.indexOf(drag.id);
@@ -7695,7 +7726,8 @@ var SplitView = class {
     if (sessionId === this.sessionId) {
       this.tabCount = tabCount;
       const before = this.tree;
-      this.tree = validate(this.tree ?? singleLeaf(initialTab), tabCount);
+      const settled = remapByIdentity(this.tree ?? singleLeaf(initialTab), prevIds, tabIds);
+      this.tree = validate(settled, tabCount);
       if (this.trees.get(sessionId) !== this.tree) {
         this.trees.set(sessionId, this.tree);
       }
@@ -8882,6 +8914,16 @@ var AppShell = class {
         this.renderTabBar(state);
       }
     }
+    this.syncTabIdentityCaches(state);
+  }
+  /** Refreshes the ordered tab identity + REAL-id caches the delegated dragstart
+   *  stamps into a payload. Cheap (two maps over ≤9 tabs) and pure bookkeeping — it
+   *  touches no DOM, so it is safe to run on every snapshot. */
+  syncTabIdentityCaches(state) {
+    const selected = selectedSession(state);
+    const tabs = selected ? sessionTabs(selected) : [];
+    this.currentTabIds = tabs.map(tabIdentity);
+    this.currentTabRealIds = tabs.map(tabRealId);
   }
   /** Renders the rail SCOPED to the selected project (redesign PR2): only that
    *  project's sessions, never the whole projection. Three states: no project at all
@@ -9048,8 +9090,6 @@ var AppShell = class {
     const canManage = supportsTabManagement(selected);
     const active = Math.min(Math.max(state.activeTab, 0), tabs.length - 1);
     const shown = new Set(state.shownTabs);
-    this.currentTabIds = tabs.map(tabIdentity);
-    this.currentTabRealIds = tabs.map(tabRealId);
     const children = tabs.map(
       (tab, i) => tabButton(tab, i, i === active, shown.has(i), canManage, this.actions)
     );

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -837,6 +837,58 @@ test("web tab (feat): a tab with no target URL renders a clean fallback, not a b
   await expect(page.locator(".af-app")).toBeVisible();
 });
 
+test("web tab (feat): a surviving web tab that only SHIFTS ordinal is followed, not remounted (#1779)", async () => {
+  // Ordering note: this consumes probe-web's "preview" tab, so it must stay AFTER the
+  // web-tab tests above that rely on it.
+  //
+  // A pane shows the EXTERNAL web tab (index 2). A lower tab is closed, so the tab it
+  // shows shifts to index 1. Nothing about that tab changed — and an external tab's
+  // iframe src is the target URL, which encodes no ordinal — so the frame must be
+  // FOLLOWED in place. Remounting would reload it and drop its in-page state.
+  //
+  // (A PROXIED tab is the opposite case and MUST remount: its src is
+  // /v1/webtab/{session}/{ordinal}/, so following it in place would silently proxy
+  // whichever tab took the old index. paneAddressUsesOrdinal draws that line; the unit
+  // tests pin both sides.)
+  await row(page, SESSION_WEB).click();
+  await expect(page.locator(".af-main.af-main-term")).toBeVisible();
+  const tabbar = page.locator(".af-tabbar");
+  await expect(tabbar.locator(".af-tab", { hasText: "preview" })).toHaveCount(1, { timeout: 15_000 });
+
+  await tabbar.locator(".af-tab", { hasText: "external" }).click();
+  const frame = page.locator(".af-term-host .af-pane-host iframe.af-webframe");
+  await expect(frame).toHaveCount(1, { timeout: 15_000 });
+  await expect(frame).toHaveAttribute("src", WEBTAB_EXTERNAL_URL);
+
+  // Stamp the live iframe. An expando rides the DOM node itself, so it survives if and
+  // only if this exact element is still mounted — a remount builds a fresh one.
+  await page.evaluate(() => {
+    const f = document.querySelector(".af-term-host .af-pane-host iframe.af-webframe") as
+      | (HTMLIFrameElement & { __afStamp?: string })
+      | null;
+    if (f) {
+      f.__afStamp = "af-not-remounted";
+    }
+  });
+
+  // Close the LOWER "preview" tab: the shown external tab shifts from index 2 to 1.
+  await tabbar.locator(".af-tab", { hasText: "preview" }).locator(".af-tab-close").click();
+  await expect(tabbar.locator(".af-tab", { hasText: "preview" })).toHaveCount(0, { timeout: 30_000 });
+  // The shift really happened — without this the assertion below would prove nothing.
+  await expect(tabbar.locator(".af-tab")).toHaveCount(2, { timeout: 30_000 });
+
+  // The pane still shows the SAME tab, through the SAME iframe element.
+  await expect(frame).toHaveCount(1);
+  await expect(frame).toHaveAttribute("src", WEBTAB_EXTERNAL_URL);
+  const stamp = await page.evaluate(() => {
+    const f = document.querySelector(".af-term-host .af-pane-host iframe.af-webframe") as
+      | (HTMLIFrameElement & { __afStamp?: string })
+      | null;
+    return f?.__afStamp ?? null;
+  });
+  expect(stamp).toBe("af-not-remounted");
+});
+
 test("split panes (feat): logout clears retained trees — a fresh login shows the single-leaf default", async () => {
   // Split A into two panes.
   await row(page, SESSION_A).click();

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -51,6 +51,7 @@ import {
   sessionTabs,
   supportsTabManagement,
   tabIdentity,
+  tabRealId,
   type AppState,
 } from "./ui.js";
 import type { SessionData, TaskData, WireEvent } from "./types.js";
@@ -848,6 +849,11 @@ function syncSplit(state: AppState): void {
   // The ordered tab identities, so the split view can (a) know the live tab count and
   // (b) reject a drop whose drag-time snapshot no longer matches (a mid-drag reorder).
   const tabIds = selected ? sessionTabs(selected).map(tabIdentity) : ["0:"];
+  // The REAL daemon ids ("" where a tab has none), parallel to tabIds. The split view
+  // needs BOTH: tabIds is its local identity/change-detection key (always non-empty,
+  // synthesized when needed), while these are the only values it may send as a
+  // ?tab_id= or trust as collision-proof (#1779).
+  const tabRealIds = selected ? sessionTabs(selected).map(tabRealId) : [""];
   // The per-tab iframe target for web tabs (undefined for terminal tabs), parallel
   // to tabIds, so the split view can iframe a web leaf.
   const tabTargets = selected ? sessionTabs(selected).map((t) => t.url) : [];
@@ -856,7 +862,7 @@ function syncSplit(state: AppState): void {
   const tabKinds = selected ? sessionTabs(selected).map((t) => t.kind) : [];
   // `tok !== null` not `tok`: "" is the authorized-tokenless credential (#1696), so a
   // loopback client still attaches its live panes.
-  splitView.setSession(tok !== null ? selId : null, tok, tabIds, initialTab, tabTargets, tabKinds);
+  splitView.setSession(tok !== null ? selId : null, tok, tabIds, initialTab, tabTargets, tabKinds, tabRealIds);
 }
 
 function disposeSplit(): void {

--- a/web/src/layout.ts
+++ b/web/src/layout.ts
@@ -268,6 +268,63 @@ export function tabsRebound(
   );
 }
 
+/** Re-points every leaf at wherever ITS OWN tab now sits, given the tab identity
+ *  list before and after a resync (#1779).
+ *
+ *  A leaf stores an ORDINAL, but what the user put in that pane is a TAB. Those
+ *  agree only until the tab list shifts underneath: if a pane shows tab B at index 2
+ *  and another client closes a lower tab A and creates C, B is now at index 1 while
+ *  the leaf still says 2 — which is C. Reconciling from the leaf's stale ordinal
+ *  therefore rebinds the pane to C: a misroute, and precisely the one the stable id
+ *  exists to prevent. Detecting that the tab set changed is not enough; the leaves
+ *  have to be MOVED before anything reads them.
+ *
+ *  Surviving tabs follow their identity. A leaf whose identity is gone (its tab was
+ *  really closed) keeps its ordinal and lets reconcile rebuild it against whatever
+ *  now occupies that slot — the same degradation as a plain tab-count shrink. The one
+ *  conflict is a dead leaf sitting on an ordinal a survivor has just claimed: the
+ *  survivor wins (it is the pane that actually holds that tab) and the dead leaf is
+ *  closed, since the tab it was showing no longer exists. That priority matters —
+ *  validate() also drops duplicates, but it keeps the FIRST leaf in visual order,
+ *  which would just as easily evict the survivor and keep the pane whose tab died.
+ *
+ *  Node references are preserved when nothing moves, so the common no-op resync does
+ *  not churn a rebuild. */
+export function remapByIdentity(root: LayoutNode, prevIds: string[], ids: string[]): LayoutNode {
+  if (prevIds.length === 0) {
+    return root; // nothing was bound yet — no leaf can be stale
+  }
+  // Where each surviving leaf's tab moved to. An identity absent from `ids` is a tab
+  // that is really gone and gets no claim.
+  const moved = new Map<string, number>();
+  const claimed = new Set<number>();
+  for (const leaf of leaves(root)) {
+    const identity = prevIds[leaf.tab];
+    if (identity === undefined || identity === "") {
+      continue;
+    }
+    const next = ids.indexOf(identity);
+    if (next >= 0) {
+      moved.set(leaf.id, next);
+      claimed.add(next);
+    }
+  }
+  if (moved.size === 0) {
+    return root;
+  }
+  let cur = mapAllLeaves(root, (leaf) => {
+    const next = moved.get(leaf.id);
+    return next === undefined || next === leaf.tab ? leaf : { ...leaf, tab: next };
+  });
+  // Drop a dead-identity leaf that now collides with a survivor's claim.
+  for (const leaf of leaves(cur)) {
+    if (!moved.has(leaf.id) && claimed.has(leaf.tab)) {
+      cur = closeLeaf(cur, leaf.id) ?? cur;
+    }
+  }
+  return cur;
+}
+
 /** Resolves a dropped tab payload to the ordinal it should bind, or null to CANCEL
  *  the drop (#1738/#1779).
  *

--- a/web/src/layout.ts
+++ b/web/src/layout.ts
@@ -226,3 +226,90 @@ export function validate(root: LayoutNode, tabCount: number): LayoutNode {
   }
   return cur;
 }
+
+
+/** Whether two ordered tab-identity lists are element-wise equal (the mid-drag
+ *  tab-set-change check). */
+function sameTabs(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  return a.every((v, i) => v === b[i]);
+}
+
+/** Whether the tab list was REBOUND between two snapshots — i.e. whether any pane
+ *  might now be showing a different tab than it was built for (#1779).
+ *
+ *  The subtle case this exists for: a resync can change WHICH tab lives at an index
+ *  without changing the tab COUNT, when another client closes a tab and creates a
+ *  replacement before this browser fetches. The layout tree validates on count
+ *  alone, so it comes back structurally identical and a tree-only check concludes
+ *  there is nothing to do — leaving a terminal attached to a tab_id that no longer
+ *  exists, or an iframe pointed at a dead target. Comparing identity/kind/target
+ *  element-wise is what catches it.
+ *
+ *  Exported for direct unit coverage: it is pure, and it is the guard the
+ *  stale-pane bug turns on. */
+export function tabsRebound(
+  prevIds: string[],
+  prevKinds: number[],
+  prevTargets: (string | undefined)[],
+  ids: string[],
+  kinds: number[],
+  targets: (string | undefined)[],
+): boolean {
+  return (
+    !sameTabs(prevIds, ids) ||
+    !sameTabs(prevKinds.map(String), kinds.map(String)) ||
+    !sameTabs(
+      prevTargets.map((t) => t ?? ""),
+      targets.map((t) => t ?? ""),
+    )
+  );
+}
+
+/** Resolves a dropped tab payload to the ordinal it should bind, or null to CANCEL
+ *  the drop (#1738/#1779).
+ *
+ *  Two branches, and which one runs is decided by whether the dragged tab HAS a
+ *  real daemon id — never by whether some identity string happens to be non-empty:
+ *
+ *  - A real stable id is looked up in the CURRENT real-id list. Wherever that exact
+ *    tab now sits is where the pane binds; if it was closed mid-drag it resolves to
+ *    nothing and the drop cancels. A concurrent reorder cannot misroute it.
+ *  - No id (a legacy/pre-#1738 tab) has no collision-proof handle, so its drag-time
+ *    index is only trusted when the whole tab-set snapshot still matches (#1737).
+ *    That guard is the ONLY protection such a tab has, which is why a synthesized
+ *    `kind:name` must never reach the branch above and skip it: a legacy tab closed
+ *    and recreated under the same kind/name mid-drag would otherwise resolve
+ *    straight onto its replacement.
+ *
+ *  Exported for direct unit coverage: it is pure, and it is the misroute fix. */
+export function resolveDragTab(
+  drag: { id?: string; index: number; tabs: string[] },
+  tabRealIds: string[],
+  tabIds: string[],
+  tabCount: number,
+): number | null {
+  if (drag.id) {
+    const tab = tabRealIds.indexOf(drag.id);
+    return tab < 0 ? null : tab; // resolved to nothing → the tab was closed mid-drag
+  }
+  const tab = drag.index;
+  if (tab < 0 || tab >= tabCount || !sameTabs(drag.tabs, tabIds)) {
+    return null;
+  }
+  return tab;
+}
+
+/** The drag payload a tab-bar drag stamps into the dataTransfer (ui.ts): the dragged
+ *  tab's REAL daemon id when it has one (#1738) — what the drop resolves to a current
+ *  ordinal, so a mid-drag reorder/close can't misroute — plus the ordinal index and an
+ *  ordered identity snapshot, the guarded legacy fallback for a tab with no id. `id`
+ *  is EMPTY for an id-less tab and never carries a synthesized identity (#1779): see
+ *  resolveDragTab. */
+export interface DragPayload {
+  id?: string;
+  index: number;
+  tabs: string[];
+}

--- a/web/src/split.ts
+++ b/web/src/split.ts
@@ -31,6 +31,7 @@ import {
   type LeafNode,
   leafCount,
   leaves,
+  remapByIdentity,
   replaceTab,
   resolveDragTab,
   setRatio,
@@ -204,7 +205,20 @@ export class SplitView {
       // Same session: reconcile the retained tree against a possibly-changed tab list.
       this.tabCount = tabCount;
       const before = this.tree;
-      this.tree = validate(this.tree ?? singleLeaf(initialTab), tabCount);
+      // Move each leaf to wherever ITS tab now sits BEFORE anything reads the tree
+      // (#1779). A leaf holds an ordinal, but the pane holds a TAB; once the list
+      // shifts, reconciling from the stale ordinal would rebind the pane to whatever
+      // tab took that slot — the misroute this whole change exists to close. A pane
+      // whose tab merely MOVED then finds its identity already matching and is left
+      // streaming untouched; only a genuinely replaced tab rebuilds.
+      // Move each leaf to wherever ITS tab now sits BEFORE anything reads the tree
+      // (#1779). A leaf holds an ordinal, but the pane holds a TAB; once the list
+      // shifts, reconciling from the stale ordinal would rebind the pane to whatever
+      // tab took that slot — the misroute this whole change exists to close. A pane
+      // whose tab merely MOVED then finds its identity already matching and is left
+      // streaming untouched; only a genuinely replaced tab rebuilds.
+      const settled = remapByIdentity(this.tree ?? singleLeaf(initialTab), prevIds, tabIds);
+      this.tree = validate(settled, tabCount);
       if (this.trees.get(sessionId) !== this.tree) {
         this.trees.set(sessionId, this.tree);
       }

--- a/web/src/split.ts
+++ b/web/src/split.ts
@@ -24,6 +24,7 @@
 
 import {
   closeLeaf,
+  type DragPayload,
   type Edge,
   findLeaf,
   type LayoutNode,
@@ -31,11 +32,13 @@ import {
   leafCount,
   leaves,
   replaceTab,
+  resolveDragTab,
   setRatio,
   singleLeaf,
   type SplitNode,
   splitLeaf,
   TAB_DND_MIME,
+  tabsRebound,
   validate,
 } from "./layout.js";
 import { AttachTerminal, type TerminalStatus } from "./terminal.js";
@@ -68,6 +71,12 @@ interface Pane {
   overlay: HTMLElement;
   term: AttachTerminal | null;
   tab: number;
+  // The tab IDENTITY this pane's terminal/iframe was actually built against. The
+  // ordinal alone is not enough to tell whether a pane is still showing the tab it
+  // was built for: a close+create elsewhere can swap a DIFFERENT tab into the same
+  // index, leaving the pane attached to a dead tab_id (#1779). Reconcile compares
+  // this against the current identity at pane.tab and rebuilds on a mismatch.
+  identity: string;
   status: TerminalStatus;
   // A web/iframe pane (TabKind.Web) has no AttachTerminal: it mounts an iframe in
   // `host` instead. webUrl is the target currently mounted (so reconcile can tell
@@ -81,15 +90,6 @@ function el(tag: string, cls: string): HTMLElement {
   const node = document.createElement(tag);
   node.className = cls;
   return node;
-}
-
-/** Whether two ordered tab-identity lists are element-wise equal (the mid-drag
- *  tab-set-change check). */
-function sameTabs(a: string[], b: string[]): boolean {
-  if (a.length !== b.length) {
-    return false;
-  }
-  return a.every((v, i) => v === b[i]);
 }
 
 /** Whether a web-tab target points at a loopback host (localhost/127.x/::1) — the
@@ -123,16 +123,6 @@ function webFallbackMs(): number {
   return typeof override === "number" ? override : 2500;
 }
 
-/** The drag payload a tab-bar drag stamps into the dataTransfer (ui.ts): the dragged
- *  tab's STABLE id (#1738) — what the drop resolves to a current ordinal, so a
- *  mid-drag reorder/close can't misroute — plus the ordinal index and an ordered
- *  identity snapshot as a legacy fallback for a tab with no id. */
-interface DragPayload {
-  id?: string;
-  index: number;
-  tabs: string[];
-}
-
 export class SplitView {
   // Retained layout per session id (in-memory; a nice-to-have to persist across
   // reload is out of scope for v1). Keyed by the stable session id.
@@ -146,6 +136,10 @@ export class SplitView {
   // store update. A drop compares its drag-time snapshot against this to detect a
   // mid-drag tab-set change (concurrent close/create/reorder) and cancel.
   private tabIds: string[] = [];
+  // The REAL daemon tab ids ("" where a tab has none), parallel to tabIds. Kept
+  // apart from the identity list because only these may cross the wire as a
+  // ?tab_id= or be trusted as a collision-proof identity (#1779) — see ui.tabRealId.
+  private tabRealIds: string[] = [];
   // Per-tab-index iframe target for web tabs (TabKind.Web); undefined for a
   // terminal tab. Parallel to the tab list, refreshed on every setSession, so
   // reconcile can mount an iframe for a web leaf without extra plumbing.
@@ -186,9 +180,16 @@ export class SplitView {
     initialTab: number,
     tabTargets: (string | undefined)[] = [],
     tabKinds: number[] = [],
+    tabRealIds: string[] = [],
   ): void {
     this.token = token;
+    // Snapshot what the panes are currently bound to BEFORE overwriting it, so the
+    // same-session branch can tell an identity change from a no-op (#1779).
+    const prevIds = this.tabIds;
+    const prevKinds = this.tabKinds;
+    const prevTargets = this.tabTargets;
     this.tabIds = tabIds;
+    this.tabRealIds = tabRealIds;
     this.tabTargets = tabTargets;
     this.tabKinds = tabKinds;
     const tabCount = tabIds.length > 0 ? tabIds.length : 1;
@@ -207,7 +208,11 @@ export class SplitView {
       if (this.trees.get(sessionId) !== this.tree) {
         this.trees.set(sessionId, this.tree);
       }
-      if (before !== this.tree) {
+      // Reconcile on a changed tab IDENTITY, not just a changed tree (#1779) — see
+      // tabsRebound. reconcile() is a no-op per pane whose identity still matches,
+      // so an unrelated snapshot still costs nothing.
+      const rebound = tabsRebound(prevIds, prevKinds, prevTargets, tabIds, tabKinds, tabTargets);
+      if (before !== this.tree || rebound) {
         this.reconcile();
         this.report();
       }
@@ -397,31 +402,41 @@ export class SplitView {
         continue;
       }
       const webTarget = this.webTargetAt(leaf.tab);
+      // The identity now living at this leaf's ordinal. A pane is stale when it
+      // differs from what the pane was built against — even at the SAME ordinal
+      // (#1779).
+      const identity = this.tabIds[leaf.tab] ?? "";
       if (webTarget !== null) {
         // A web/iframe tab: mount an iframe instead of an xterm. Rebuild only when
-        // the bound tab or its target changed, so a no-op reconcile never reloads
-        // the frame (which would drop the dev server's in-page state).
-        if (pane.term || pane.webUrl !== webTarget || pane.tab !== leaf.tab) {
+        // the bound tab, its identity, or its target changed, so a no-op reconcile
+        // never reloads the frame (which would drop the dev server's in-page state).
+        if (pane.term || pane.webUrl !== webTarget || pane.tab !== leaf.tab || pane.identity !== identity) {
           pane.term?.dispose();
           pane.term = null;
           pane.webDispose?.();
           pane.host.replaceChildren();
           pane.tab = leaf.tab;
+          pane.identity = identity;
           this.mountWebPane(pane, webTarget);
           pane.status = "open";
           this.onPaneStatus(leaf.id, "open");
         }
-      } else if (!pane.term || pane.tab !== leaf.tab) {
+      } else if (!pane.term || pane.tab !== leaf.tab || pane.identity !== identity) {
         pane.term?.dispose();
         pane.webDispose?.();
         pane.webUrl = null;
         pane.host.replaceChildren();
         pane.tab = leaf.tab;
+        pane.identity = identity;
         pane.status = "connecting";
-        // Address the stream by the tab's STABLE id (#1738) at this ordinal, so a
-        // reorder/close resolves to the right PTY server-side; empty (a legacy tab
-        // without an id) makes AttachTerminal fall back to the ordinal ?tab=.
-        pane.term = new AttachTerminal(pane.host, this.sessionId, this.token, this.tabIds[leaf.tab] ?? "", leaf.tab, {
+        // Address the stream by the tab's REAL daemon id (#1738) at this ordinal, so
+        // a reorder/close resolves to the right PTY server-side. It must come from
+        // tabRealIds, NOT tabIds: the identity list carries a synthesized `kind:name`
+        // for an id-less tab, and sending that as ?tab_id= is an unknown id the
+        // daemon 404s — breaking a legacy tab that attaches fine by ordinal (#1779).
+        // "" is the honest "no id", which makes AttachTerminal fall back to ?tab=.
+        const realId = this.tabRealIds[leaf.tab] ?? "";
+        pane.term = new AttachTerminal(pane.host, this.sessionId, this.token, realId, leaf.tab, {
           onStatus: (s) => this.onPaneStatus(leaf.id, s),
           onFocusChange: (f) => this.onPaneFocus(leaf.id, f),
         });
@@ -466,6 +481,8 @@ export class SplitView {
       overlay,
       term: null,
       tab: -1,
+      // No tab bound yet; tab:-1 already forces the first reconcile to build one.
+      identity: "",
       status: "connecting",
       webUrl: null,
       webDispose: null,
@@ -718,25 +735,11 @@ export class SplitView {
       if (!drag || !this.tree) {
         return;
       }
-      // Resolve the dragged tab by its STABLE id (#1738) to its CURRENT ordinal: this
-      // is the misroute fix. Even if a concurrent client reordered/closed tabs
-      // mid-drag, indexOf lands on wherever the SAME tab now sits (or -1 if it was
-      // closed → cancel), so the drop can never bind the new pane to a different live
-      // tab the way a trusted drag-time index could.
-      let tab: number;
-      if (drag.id) {
-        tab = this.tabIds.indexOf(drag.id);
-        if (tab < 0) {
-          return; // the dragged tab was closed mid-drag — nothing to bind
-        }
-      } else {
-        // Legacy fallback for a payload with no stable id (pre-#1738 tab): trust the
-        // drag-time index but keep the #1737 mid-drag guard — reject if the tab set
-        // changed since dragstart, and reject an out-of-range index.
-        tab = drag.index;
-        if (tab < 0 || tab >= this.tabCount || !sameTabs(drag.tabs, this.tabIds)) {
-          return;
-        }
+      // Resolve the dragged tab to the ordinal it should bind — by its STABLE id when
+      // it has one, else the guarded legacy index. See resolveDragTab; null cancels.
+      const tab = resolveDragTab(drag, this.tabRealIds, this.tabIds, this.tabCount);
+      if (tab === null) {
+        return;
       }
       const zone = this.zoneAt(pane.container, e.clientX, e.clientY);
       this.tree = zone === "center" ? replaceTab(this.tree, pane.leafId, tab) : splitLeaf(this.tree, pane.leafId, zone, tab);

--- a/web/src/split.ts
+++ b/web/src/split.ts
@@ -42,6 +42,7 @@ import {
   tabsRebound,
   validate,
 } from "./layout.js";
+import { isLoopbackWebUrl, paneAddressUsesOrdinal, webProxyPath } from "./tabaddr.js";
 import { AttachTerminal, type TerminalStatus } from "./terminal.js";
 import { currentXtermTheme } from "./theme.js";
 import { TabKind } from "./types.js";
@@ -91,30 +92,6 @@ function el(tag: string, cls: string): HTMLElement {
   const node = document.createElement(tag);
   node.className = cls;
   return node;
-}
-
-/** Whether a web-tab target points at a loopback host (localhost/127.x/::1) — the
- *  only targets the daemon reverse-proxies. Mirrors session.IsLoopbackWebTarget
- *  (session/weburl.go). A URL that does not parse is treated as non-loopback. */
-export function isLoopbackWebUrl(raw: string): boolean {
-  try {
-    let host = new URL(raw).hostname.toLowerCase();
-    host = host.replace(/^\[|\]$/g, ""); // strip IPv6 brackets
-    return host === "localhost" || host === "::1" || host === "127.0.0.1" || host.startsWith("127.");
-  } catch {
-    return false;
-  }
-}
-
-/** The same-origin daemon proxy path for a loopback web tab, so the iframe hits
- *  the daemon (which shares the machine with the dev server) rather than the
- *  viewer's own machine. The bearer token rides ?access_token= for network peers
- *  (an iframe src can't set the Authorization header); a loopback/tokenless client
- *  sends none. The trailing slash matters — the route requires it, and it makes
- *  the dev app's RELATIVE asset URLs resolve under the proxy prefix. */
-export function webProxyPath(sessionId: string, tabIdx: number, token: string | null): string {
-  const base = `/v1/webtab/${encodeURIComponent(sessionId)}/${tabIdx}/`;
-  return token ? `${base}?access_token=${encodeURIComponent(token)}` : base;
 }
 
 /** The delay before an unresponsive DIRECT external frame reveals its fallback.
@@ -416,15 +393,25 @@ export class SplitView {
         continue;
       }
       const webTarget = this.webTargetAt(leaf.tab);
-      // The identity now living at this leaf's ordinal. A pane is stale when it
-      // differs from what the pane was built against — even at the SAME ordinal
-      // (#1779).
+      // The identity now living at this leaf's ordinal. remapByIdentity has already
+      // moved the leaf to follow its own tab, so a mismatch here means a genuinely
+      // DIFFERENT tab occupies this pane's slot — not merely that ordinals shifted.
       const identity = this.tabIds[leaf.tab] ?? "";
+      const realId = this.tabRealIds[leaf.tab] ?? "";
+      // Rebuild when what the pane ADDRESSES changes — never merely because its tab's
+      // ordinal moved (#1779). A different tab in the slot always rebuilds; a shifted
+      // ordinal rebuilds only when the pane's address actually embeds that ordinal
+      // (see paneAddressUsesOrdinal), which is exactly when the old address would now
+      // point at another tab.
+      const moved = pane.tab !== leaf.tab;
+      const staleAddress = pane.identity !== identity || (moved && paneAddressUsesOrdinal(webTarget, realId));
       if (webTarget !== null) {
-        // A web/iframe tab: mount an iframe instead of an xterm. Rebuild only when
-        // the bound tab, its identity, or its target changed, so a no-op reconcile
-        // never reloads the frame (which would drop the dev server's in-page state).
-        if (pane.term || pane.webUrl !== webTarget || pane.tab !== leaf.tab || pane.identity !== identity) {
+        // A web/iframe tab: mount an iframe instead of an xterm. Rebuilding reloads
+        // the frame and drops the dev server's in-page state, so it happens only on a
+        // real change: a different tab here, a changed target, or a moved PROXIED tab
+        // (whose src is /v1/webtab/{session}/{ordinal}/ and would otherwise proxy the
+        // tab that took its old index).
+        if (pane.term || pane.webUrl !== webTarget || staleAddress) {
           pane.term?.dispose();
           pane.term = null;
           pane.webDispose?.();
@@ -434,8 +421,12 @@ export class SplitView {
           this.mountWebPane(pane, webTarget);
           pane.status = "open";
           this.onPaneStatus(leaf.id, "open");
+        } else if (moved) {
+          // The same tab, merely at a new ordinal, addressed by a URL that does not
+          // encode one: follow it without touching the live frame.
+          pane.tab = leaf.tab;
         }
-      } else if (!pane.term || pane.tab !== leaf.tab || pane.identity !== identity) {
+      } else if (!pane.term || staleAddress) {
         pane.term?.dispose();
         pane.webDispose?.();
         pane.webUrl = null;
@@ -449,11 +440,15 @@ export class SplitView {
         // for an id-less tab, and sending that as ?tab_id= is an unknown id the
         // daemon 404s — breaking a legacy tab that attaches fine by ordinal (#1779).
         // "" is the honest "no id", which makes AttachTerminal fall back to ?tab=.
-        const realId = this.tabRealIds[leaf.tab] ?? "";
         pane.term = new AttachTerminal(pane.host, this.sessionId, this.token, realId, leaf.tab, {
           onStatus: (s) => this.onPaneStatus(leaf.id, s),
           onFocusChange: (f) => this.onPaneFocus(leaf.id, f),
         });
+      } else if (moved) {
+        // The same tab, merely at a new ordinal, streamed by ?tab_id=: the terminal's
+        // captured ordinal is inert (terminal.ts sends tab_id OR tab, never both), so
+        // follow the tab without tearing down a live stream and its scrollback.
+        pane.tab = leaf.tab;
       }
       pane.container.classList.toggle("af-pane-multi", multi);
       pane.label.textContent = `Tab ${leaf.tab + 1}`;

--- a/web/src/stable_tab_addressing.test.ts
+++ b/web/src/stable_tab_addressing.test.ts
@@ -1,0 +1,126 @@
+// Unit coverage for the web half of the stable-tab-id addressing contract
+// (#1738, completed in #1779).
+//
+// #1738 introduced the stable id but left the web client leaking two ORDINAL /
+// FALLBACK identities back into paths that must key on a real id:
+//
+//  1. tabIdentity synthesizes a `kind:name` for an id-less tab. That synthesized
+//     value is fine as a LOCAL bookkeeping key, but it is not a daemon id — sending
+//     it as ?tab_id= is an unknown id the daemon 404s, and trusting it as
+//     collision-proof re-opens the close+recreate hole the guard exists to catch.
+//  2. Reconcile only ran when the layout TREE changed, so a tab identity swapping
+//     at an unchanged index left the pane attached to a dead tab.
+//
+// These pin the three pure decisions that close both.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { tabIdentity, tabRealId } from "./ui.js";
+import { resolveDragTab, tabsRebound } from "./layout.js";
+
+// --- tabRealId: the real id, never a synthesized one -----------------------
+
+test("tabRealId is the daemon id when the tab has one", () => {
+  assert.equal(tabRealId({ id: "deadbeefcafef00d" }), "deadbeefcafef00d");
+});
+
+test("tabRealId is EMPTY for an id-less tab, where tabIdentity synthesizes", () => {
+  // The whole point of the split: for the same tab, the identity is a usable local
+  // key while the real id is honestly absent. Passing the synthesized value as a
+  // ?tab_id= would 404 a legacy tab that attaches fine by ordinal (#1779).
+  const legacy: { id?: string; name: string; kind: number } = { name: "shell", kind: 1 };
+  assert.equal(tabIdentity(legacy), "1:shell");
+  assert.equal(tabRealId(legacy), "");
+  assert.equal(tabRealId({ id: "" }), "");
+});
+
+// --- resolveDragTab: only a REAL id may skip the legacy guard ---------------
+
+test("a real stable id resolves to the tab's CURRENT ordinal after a mid-drag shift", () => {
+  // The misroute fix: the tab dragged from index 2 now sits at index 1 because a
+  // lower tab closed mid-drag. It binds where the SAME tab is now, not index 2.
+  const drag = { id: "id-b", index: 2, tabs: ["id-agent", "id-a", "id-b"] };
+  const realIds = ["id-agent", "id-b"];
+  assert.equal(resolveDragTab(drag, realIds, realIds, realIds.length), 1);
+});
+
+test("a real stable id whose tab was closed mid-drag cancels the drop", () => {
+  const drag = { id: "id-a", index: 1, tabs: ["id-agent", "id-a"] };
+  const realIds = ["id-agent"];
+  assert.equal(resolveDragTab(drag, realIds, realIds, realIds.length), null);
+});
+
+test("a FALLBACK identity is never treated as a drag id — the legacy guard still runs", () => {
+  // The #1779 hole: an id-less "shell" tab is closed and a NEW "shell" created
+  // mid-drag. Both share the `1:shell` identity, so an id-keyed lookup would happily
+  // resolve the drag onto the REPLACEMENT tab. dragstart stamps "" for such a tab,
+  // which routes it to the guarded branch, where the changed tab-set snapshot
+  // cancels the drop.
+  const drag = { id: "", index: 1, tabs: ["0:agent", "1:shell"] };
+  const identitiesNow = ["0:agent", "1:shell"]; // same STRINGS, but a different tab
+  const realIdsNow = ["", ""]; // still no daemon ids
+  // The tab set "matches" by identity, so the legacy branch permits the drop — that
+  // is the pre-existing legacy behavior and is not what this test pins. What it pins
+  // is that an id-less tab takes the GUARDED branch at all:
+  assert.equal(resolveDragTab(drag, realIdsNow, identitiesNow, 2), 1);
+
+  // ...and when the set HAS visibly changed, the guard cancels — proving the drop
+  // was never id-resolved. Had `1:shell` been accepted as a stable id, indexOf would
+  // have found it at index 1 and bound the replacement regardless of this guard.
+  const changed = { id: "", index: 1, tabs: ["0:agent", "1:shell", "1:extra"] };
+  assert.equal(resolveDragTab(changed, realIdsNow, identitiesNow, 2), null);
+});
+
+test("a synthesized identity in drag.id resolves against REAL ids and cancels, never the identity list", () => {
+  // The precise #1779 hole, and the reason the lookup list matters. A legacy tab has
+  // identity `1:shell` but NO daemon id. If that synthesized identity reaches drag.id
+  // — which is exactly what stamping the identity list at dragstart did — then
+  // resolving it against the IDENTITY list finds it at index 1 and binds the pane,
+  // skipping the sameTabs guard that is a legacy tab's only protection against a
+  // mid-drag close+recreate. Resolving against the REAL ids finds nothing (they hold
+  // "" for such a tab) and cancels.
+  //
+  // The two lists MUST differ here or the assertion proves nothing.
+  const identities = ["0:agent", "1:shell"];
+  const realIds = ["", ""];
+  const drag = { id: "1:shell", index: 1, tabs: ["0:agent", "1:shell"] };
+  assert.equal(resolveDragTab(drag, realIds, identities, 2), null);
+});
+
+test("a legacy drag with an out-of-range index cancels", () => {
+  const drag = { id: "", index: 5, tabs: ["0:agent"] };
+  assert.equal(resolveDragTab(drag, [""], ["0:agent"], 1), null);
+});
+
+// --- tabsRebound: reconcile on IDENTITY change, not just count -------------
+
+test("tabsRebound is false for an identical snapshot (an unrelated resync is a no-op)", () => {
+  assert.equal(tabsRebound(["a", "b"], [0, 1], ["", ""], ["a", "b"], [0, 1], ["", ""]), false);
+});
+
+test("tabsRebound is TRUE when a tab identity swaps at an unchanged index", () => {
+  // The #1779 stale-pane bug: another client closed tab "b" and created "c" before
+  // this browser fetched. The COUNT is unchanged, so the layout tree validates
+  // identically and a tree-only check would find nothing to do — leaving the pane
+  // attached to the dead tab_id "b".
+  assert.equal(tabsRebound(["a", "b"], [0, 1], ["", ""], ["a", "c"], [0, 1], ["", ""]), true);
+});
+
+test("tabsRebound is TRUE when a tab's kind or web target changes at the same index", () => {
+  // Same story for an iframe pane: the identity can hold while the target moves.
+  assert.equal(tabsRebound(["a", "b"], [0, 1], ["", ""], ["a", "b"], [0, 3], ["", ""]), true);
+  assert.equal(
+    tabsRebound(["a", "b"], [0, 3], ["", "http://localhost:3000"], ["a", "b"], [0, 3], ["", "http://localhost:4000"]),
+    true,
+  );
+});
+
+test("tabsRebound treats an undefined target and an empty one as the same", () => {
+  // A terminal tab carries no target; undefined vs "" must not churn a rebuild.
+  assert.equal(tabsRebound(["a"], [0], [undefined], ["a"], [0], [""]), false);
+});
+
+test("tabsRebound is TRUE when the tab count changes", () => {
+  assert.equal(tabsRebound(["a"], [0], [""], ["a", "b"], [0, 1], ["", ""]), true);
+});

--- a/web/src/stable_tab_addressing.test.ts
+++ b/web/src/stable_tab_addressing.test.ts
@@ -16,8 +16,10 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { tabIdentity, tabRealId } from "./ui.js";
-import { resolveDragTab, tabsRebound } from "./layout.js";
+import { tabBarSig, tabIdentity, tabRealId } from "./ui.js";
+import type { AppState } from "./ui.js";
+import type { SessionData } from "./types.js";
+import { leaves, remapByIdentity, resolveDragTab, tabsRebound } from "./layout.js";
 
 // --- tabRealId: the real id, never a synthesized one -----------------------
 
@@ -123,4 +125,110 @@ test("tabsRebound treats an undefined target and an empty one as the same", () =
 
 test("tabsRebound is TRUE when the tab count changes", () => {
   assert.equal(tabsRebound(["a"], [0], [""], ["a", "b"], [0, 1], ["", ""]), true);
+});
+
+// --- the drag-id cache must not hide behind the tab-bar render gate ----------
+
+test("an id backfill does NOT change tabBarSig — so the drag-id cache cannot be refreshed by the bar render", () => {
+  // The constraint that forces syncTabIdentityCaches to run outside the render gate
+  // (#1779). tabBarSig covers only what the bar DRAWS (kind/name/active/shown), so a
+  // snapshot that backfills a just-created tab's stable id is signature-identical and
+  // the bar is NOT rebuilt — correctly, since rebuilding would destroy a button held
+  // mid-drag (#1737). A drag-id cache refreshed only by renderTabBar would therefore
+  // stay stale on exactly the tab that just earned an id.
+  //
+  // If this assertion ever flips, the caches could move back into renderTabBar — but
+  // the #1737 drag regression would be back too, so it should not.
+  const sess = (tabs: SessionData["tabs"]): SessionData => ({ id: "a", title: "s", branch: "b", tabs });
+  const st = (tabs: SessionData["tabs"]): AppState =>
+    ({ selectedId: "a", sessions: [sess(tabs)], activeTab: 0, shownTabs: [0] }) as AppState;
+
+  const beforeAdopt = st([
+    { name: "agent", kind: 0, id: "id-agent" },
+    { name: "shell", kind: 1 }, // just created; no id yet
+  ]);
+  const afterAdopt = st([
+    { name: "agent", kind: 0, id: "id-agent" },
+    { name: "shell", kind: 1, id: "id-shell" }, // the snapshot backfilled it
+  ]);
+
+  assert.equal(tabBarSig(beforeAdopt), tabBarSig(afterAdopt), "an id backfill draws no pixel, so the sig must not change");
+
+  // ...and the real id the drag needs DID change across those two snapshots, which is
+  // exactly what the sig cannot see.
+  assert.equal(tabRealId({ name: "shell", kind: 1 } as { id?: string }), "");
+  assert.equal(tabRealId({ id: "id-shell" }), "id-shell");
+});
+
+// --- remapByIdentity: a pane follows its OWN tab across a shift --------------
+
+test("a pane follows its tab when a lower tab is closed and replaced (the codex #1805 repro)", () => {
+  // A leaf holds an ORDINAL but the user put a TAB in that pane. Pane shows B at
+  // index 2; another client closes A and creates C, so the list goes
+  // [agent,A,B] → [agent,B,C] and B is now at index 1. Reconciling from the leaf's
+  // stale 2 would rebind the pane to C. The leaf must move to 1 instead.
+  const prevIds = ["id-agent", "id-a", "id-b"];
+  const ids = ["id-agent", "id-b", "id-c"];
+  const tree = { kind: "leaf", id: "L1", tab: 2 } as const;
+
+  const out = remapByIdentity(tree, prevIds, ids);
+  assert.equal(leaves(out).length, 1);
+  assert.equal(leaves(out)[0].tab, 1, "the pane must follow tab B to its new ordinal, not stay on 2 (now tab C)");
+});
+
+test("a no-op resync preserves the tree REFERENCE — no churn, no rebuild", () => {
+  // Reference stability is load-bearing: setSession re-validates on every store
+  // update, and a fresh tree each time would reconcile (and rebuild terminals) on
+  // every status tick.
+  const ids = ["id-agent", "id-b"];
+  const tree = { kind: "leaf", id: "L1", tab: 1 } as const;
+  assert.equal(remapByIdentity(tree, ids, ids), tree);
+});
+
+test("a leaf whose tab was really closed keeps its ordinal and rebuilds against what is there", () => {
+  // No survivor claims index 1, so the pane degrades to showing the tab that took the
+  // slot — the same behavior as a plain tab-count shrink.
+  const prevIds = ["id-agent", "id-a"];
+  const ids = ["id-agent", "id-c"];
+  const tree = { kind: "leaf", id: "L1", tab: 1 } as const;
+  assert.equal(leaves(remapByIdentity(tree, prevIds, ids))[0].tab, 1);
+});
+
+test("when a dead leaf collides with a survivor's claim, the SURVIVOR keeps the tab", () => {
+  // Two panes: L1 shows A (index 1), L2 shows B (index 2). A is closed, C created:
+  // [agent,A,B] → [agent,B,C]. B survives and moves 2→1, which is where L1 (dead)
+  // sits. L2 actually holds B, so it must win; L1's tab is gone, so it closes.
+  // Note validate() would resolve this collision the OTHER way — it keeps the FIRST
+  // leaf — which is why remapByIdentity settles it first.
+  const prevIds = ["id-agent", "id-a", "id-b"];
+  const ids = ["id-agent", "id-b", "id-c"];
+  const tree = {
+    kind: "split",
+    id: "S1",
+    dir: "row",
+    ratio: 0.5,
+    a: { kind: "leaf", id: "L1", tab: 1 },
+    b: { kind: "leaf", id: "L2", tab: 2 },
+  } as const;
+
+  const out = remapByIdentity(tree, prevIds, ids);
+  const ls = leaves(out);
+  assert.equal(ls.length, 1, "the pane whose tab was closed must go, not the one that still holds B");
+  assert.equal(ls[0].id, "L2", "L2 is the pane that actually holds tab B");
+  assert.equal(ls[0].tab, 1, "and it follows B to its new ordinal");
+});
+
+test("remapByIdentity is a no-op before anything is bound", () => {
+  const tree = { kind: "leaf", id: "L1", tab: 0 } as const;
+  assert.equal(remapByIdentity(tree, [], ["id-agent"]), tree);
+});
+
+test("a legacy leaf with a synthesized identity still follows a shift", () => {
+  // Identity is all a legacy tab has; `1:shell` moving 2→1 is followed on that basis.
+  // This inherits the known kind:name collision hole, exactly like the DnD legacy
+  // branch — it is not made worse here.
+  const prevIds = ["0:agent", "1:other", "1:shell"];
+  const ids = ["0:agent", "1:shell"];
+  const tree = { kind: "leaf", id: "L1", tab: 2 } as const;
+  assert.equal(leaves(remapByIdentity(tree, prevIds, ids))[0].tab, 1);
 });

--- a/web/src/stable_tab_addressing.test.ts
+++ b/web/src/stable_tab_addressing.test.ts
@@ -20,6 +20,7 @@ import { tabBarSig, tabIdentity, tabRealId } from "./ui.js";
 import type { AppState } from "./ui.js";
 import type { SessionData } from "./types.js";
 import { leaves, remapByIdentity, resolveDragTab, tabsRebound } from "./layout.js";
+import { paneAddressUsesOrdinal } from "./tabaddr.js";
 
 // --- tabRealId: the real id, never a synthesized one -----------------------
 
@@ -231,4 +232,68 @@ test("a legacy leaf with a synthesized identity still follows a shift", () => {
   const ids = ["0:agent", "1:shell"];
   const tree = { kind: "leaf", id: "L1", tab: 2 } as const;
   assert.equal(leaves(remapByIdentity(tree, prevIds, ids))[0].tab, 1);
+});
+
+// --- paneAddressUsesOrdinal: rebuild iff the pane's ADDRESS would change -----
+
+test("an id-addressed terminal's ordinal is inert — a move needs no rebuild", () => {
+  // terminal.ts sends ?tab_id= OR ?tab=, never both, so a real id makes the captured
+  // ordinal dead weight: the daemon resolves the id to wherever the tab now sits.
+  assert.equal(paneAddressUsesOrdinal(null, "id-shell"), false);
+});
+
+test("a LEGACY terminal's ordinal IS its address — a move must rebuild", () => {
+  assert.equal(paneAddressUsesOrdinal(null, ""), true);
+});
+
+test("a PROXIED web tab's ordinal is its address, stable id or not — a move must rebuild", () => {
+  // The correction to the suggested "id-addressed ⇒ never remount" rule. A loopback
+  // preview is fetched through /v1/webtab/{session}/{ordinal}/, which is ordinal-keyed
+  // no matter how stable the tab's id is. Following it without a rebuild would leave
+  // the iframe proxying whatever tab took the old index — trading a cosmetic reload
+  // for an actual misroute.
+  assert.equal(paneAddressUsesOrdinal("http://localhost:3000", "id-web"), true);
+  assert.equal(paneAddressUsesOrdinal("http://127.0.0.1:8080/app", "id-web"), true);
+  assert.equal(paneAddressUsesOrdinal("http://[::1]:5173", "id-web"), true);
+});
+
+test("an EXTERNAL web tab's src encodes no ordinal — a move is followed, not remounted", () => {
+  // This is the case the P3 is really about: the iframe src is the target URL itself,
+  // so a shifted ordinal cannot invalidate it and reloading would drop in-page state
+  // for nothing.
+  assert.equal(paneAddressUsesOrdinal("https://example.com/docs", "id-web"), false);
+  assert.equal(paneAddressUsesOrdinal("https://example.com/docs", ""), false);
+});
+
+test("a web tab with NO target has no ordinal-bearing address", () => {
+  // It renders a fallback, not a proxied frame — nothing to invalidate.
+  assert.equal(paneAddressUsesOrdinal("", "id-web"), false);
+});
+
+test("an unparseable web target is treated as non-loopback (never proxied)", () => {
+  assert.equal(paneAddressUsesOrdinal("not a url", "id-web"), false);
+});
+
+// --- the end-to-end property: a shifted tab is still addressed by ITS id -----
+
+test("after a cross-client close+create, the pane's stream id is still the tab it shows", () => {
+  // The user-visible contract behind remapByIdentity, asserted on the value that
+  // actually reaches the wire: pane shows B; another client closes lower tab A and
+  // creates C; the pane must end up addressing B's stable id — NOT C's, which is what
+  // the pre-fix code bound because it resolved by the leaf's stale ordinal.
+  const prevIds = ["id-agent", "id-a", "id-b"];
+  const ids = ["id-agent", "id-b", "id-c"];
+  const realIdsNow = ["id-agent", "id-b", "id-c"];
+
+  const settled = remapByIdentity({ kind: "leaf", id: "L1", tab: 2 }, prevIds, ids);
+  const leaf = leaves(settled)[0];
+
+  // What reconcile would hand AttachTerminal as ?tab_id= for this pane:
+  assert.equal(realIdsNow[leaf.tab], "id-b", "input must be routed to tab B — the tab the pane shows");
+  assert.notEqual(realIdsNow[leaf.tab], "id-c", "binding C's id here is the misroute this PR ends");
+
+  // And because the identity at the settled ordinal still matches what the pane was
+  // built against, the terminal is FOLLOWED rather than torn down and re-dialled.
+  assert.equal(ids[leaf.tab], "id-b");
+  assert.equal(paneAddressUsesOrdinal(null, realIdsNow[leaf.tab]), false, "an id-addressed pane need not rebuild to follow");
 });

--- a/web/src/tabaddr.ts
+++ b/web/src/tabaddr.ts
@@ -1,0 +1,64 @@
+// How a pane ADDRESSES the tab it shows — the one question that decides whether a
+// tab moving to a new ordinal invalidates what a live pane is pointed at (#1779).
+//
+// Kept in its own css-free module (like layout.ts, and for the same reason): the
+// logic lives beside split.ts's rendering but must be importable — and unit-testable
+// — without dragging in xterm and its CSS, which the node test runner cannot load.
+
+/** Whether a web-tab target points at a loopback host (localhost/127.x/::1) — the
+ *  only targets the daemon reverse-proxies. Mirrors session.IsLoopbackWebTarget
+ *  (session/weburl.go). A URL that does not parse is treated as non-loopback. */
+export function isLoopbackWebUrl(raw: string): boolean {
+  try {
+    let host = new URL(raw).hostname.toLowerCase();
+    host = host.replace(/^\[|\]$/g, ""); // strip IPv6 brackets
+    return host === "localhost" || host === "::1" || host === "127.0.0.1" || host.startsWith("127.");
+  } catch {
+    return false;
+  }
+}
+
+/** The same-origin daemon proxy path for a loopback web tab, so the iframe hits
+ *  the daemon (which shares the machine with the dev server) rather than the
+ *  viewer's own machine. The bearer token rides ?access_token= for network peers
+ *  (an iframe src can't set the Authorization header); a loopback/tokenless client
+ *  sends none. The trailing slash matters — the route requires it, and it makes
+ *  the dev app's RELATIVE asset URLs resolve under the proxy prefix.
+ *
+ *  NOTE the {tabIdx}: this route is ORDINAL-addressed, so unlike a PTY stream a web
+ *  tab cannot be addressed by its stable id. That is why paneAddressUsesOrdinal
+ *  answers true for a proxied tab however stable its id is. */
+export function webProxyPath(sessionId: string, tabIdx: number, token: string | null): string {
+  const base = `/v1/webtab/${encodeURIComponent(sessionId)}/${tabIdx}/`;
+  return token ? `${base}?access_token=${encodeURIComponent(token)}` : base;
+}
+
+/** Whether a pane's live address for its tab EMBEDS that tab's ordinal — i.e. whether
+ *  the tab merely shifting position invalidates what the pane already points at
+ *  (#1779). It decides whether a moved tab must be torn down and rebuilt, or can
+ *  simply be followed.
+ *
+ *  The question is NOT "does this tab have a stable id" — it is "does the address this
+ *  pane already holds still name the right thing". The two come apart:
+ *
+ *  - A terminal streams `?tab_id=<id>` when the tab has a real id and `?tab=<ordinal>`
+ *    otherwise — never both (terminal.ts picks one). So an id-addressed terminal's
+ *    ordinal is inert and a move needs no rebuild, while a legacy one's ordinal IS the
+ *    address.
+ *  - A web tab ignores the tab id entirely. A LOOPBACK preview is fetched through the
+ *    daemon proxy at /v1/webtab/{session}/{ordinal}/ — ordinal-keyed no matter how
+ *    stable the tab's id is — so a moved proxied tab MUST rebuild, or its iframe
+ *    silently proxies whatever tab took its old index. An EXTERNAL tab's src is the
+ *    target URL itself and encodes no ordinal, so it can be followed.
+ *
+ *  Conflating the two either reloads every moved iframe (needless in-page state loss)
+ *  or, worse, leaves a proxied frame pointed at a different tab — the misroute this
+ *  all exists to end.
+ *
+ *  `webTarget` is null for a terminal pane; `realId` is "" for a tab with no daemon id. */
+export function paneAddressUsesOrdinal(webTarget: string | null, realId: string): boolean {
+  if (webTarget !== null) {
+    return webTarget !== "" && isLoopbackWebUrl(webTarget); // proxied → /v1/webtab/…/{ordinal}/
+  }
+  return realId === ""; // a legacy terminal streams by ?tab=<ordinal>
+}

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -174,6 +174,25 @@ export function tabIdentity(tab: { id?: string; name: string; kind: number }): s
   return tab.id && tab.id !== "" ? tab.id : `${tab.kind}:${tab.name}`;
 }
 
+/** The REAL daemon tab id, or "" when the tab has none (#1779).
+ *
+ *  This is deliberately NOT tabIdentity. The two answer different questions and
+ *  conflating them is a bug in both directions:
+ *
+ *  - tabIdentity answers "is this the same tab as before?" for LOCAL bookkeeping
+ *    (reconcile, mid-drag change detection). It must always return something, so
+ *    it synthesizes a `kind:name` fallback for an id-less tab.
+ *  - tabRealId answers "what id may I hand to the DAEMON?" — and a synthesized
+ *    `1:shell` is not an answer. The daemon 404s an unknown non-empty ?tab_id=,
+ *    so passing a fallback breaks a legacy tab that would otherwise attach fine by
+ *    ordinal. "" is the honest "no id" that makes callers fall back to ?tab=.
+ *
+ *  Anything crossing the wire, or claiming an identity is collision-proof, uses
+ *  this; the fallback is only ever a local hint. */
+export function tabRealId(tab: { id?: string }): string {
+  return tab.id && tab.id !== "" ? tab.id : "";
+}
+
 /** The label a tab reads as, mirroring the TUI's labelForTab (ui/tree/labels.go):
  *  the agent tab is "Agent", a shell tab is "Terminal", a process tab shows its
  *  name. Keeps the web tab bar TUI-faithful. */
@@ -432,6 +451,10 @@ export class AppShell {
   // dragged tab's payload by the delegated dragstart so a drop can detect a mid-drag
   // tab-set change and cancel (see split.ts). Kept live by renderTabBar.
   private currentTabIds: string[] = [];
+  // The REAL daemon tab ids drawn in the bar at its last render ("" for a tab with
+  // none), parallel to currentTabIds. Separate because only a real id may be
+  // treated as a stable identity by a drop (#1779) — see tabRealId.
+  private currentTabRealIds: string[] = [];
   // A signature of everything the bar DRAWS (see tabBarSig): the bar is rebuilt only
   // when this changes, so an unrelated status snapshot never churns its DOM (#1737).
   private lastTabBarSig = "";
@@ -892,6 +915,12 @@ export class AppShell {
     // stamp into a dragged tab's payload so the drop can detect a mid-drag tab-set
     // change and cancel (split.ts).
     this.currentTabIds = tabs.map(tabIdentity);
+    // The ordered REAL daemon ids ("" where a tab has none), parallel to
+    // currentTabIds. dragstart stamps from THIS, never from the identity list: a
+    // synthesized `kind:name` in drag.id would make the drop treat a legacy tab as
+    // stable-id-addressed and skip the sameTabs guard that is its only protection
+    // (#1779).
+    this.currentTabRealIds = tabs.map(tabRealId);
 
     const children: HTMLElement[] = tabs.map((tab, i) =>
       tabButton(tab, i, i === active, shown.has(i), canManage, this.actions),
@@ -933,8 +962,10 @@ export class AppShell {
       // Stamp the dragged tab's STABLE id (#1738) so the drop resolves it to the
       // tab's CURRENT ordinal — correct even if a concurrent client reordered/closed
       // tabs mid-drag. index + the identity snapshot ride along as a legacy fallback
-      // for a tab without an id (pre-#1738 record).
-      const id = this.currentTabIds[index] ?? "";
+      // for a tab without an id (pre-#1738 record). The id comes from the REAL-id
+      // list, so a tab without one stamps "" and the drop takes the guarded legacy
+      // branch rather than trusting a synthesized identity (#1779).
+      const id = this.currentTabRealIds[index] ?? "";
       e.dataTransfer.setData(TAB_DND_MIME, JSON.stringify({ id, index, tabs: this.currentTabIds }));
       e.dataTransfer.effectAllowed = "move";
       document.body.classList.add("af-dragging-tab");

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -703,6 +703,28 @@ export class AppShell {
         this.renderTabBar(state);
       }
     }
+
+    // The dragstart caches are refreshed on EVERY snapshot, deliberately outside the
+    // tab-bar's render gate (#1779). The gate keys on tabBarSig, which covers only
+    // what the bar DRAWS — kind/name/active/shown — and so ignores tab IDs. That is
+    // correct for the DOM (an id backfill changes no pixel, and rebuilding the bar
+    // would destroy a button mid-drag, the #1737 regression) but wrong for the
+    // caches: a just-created tab whose id the next snapshot backfills would keep a
+    // stale "" here, and the drag it stamps would fall back to the legacy guard
+    // instead of using the now-known stable id. Adding ids to the signature would fix
+    // the cache by reintroducing exactly the #1737 rebuild — so the cache is synced
+    // independently of the render instead.
+    this.syncTabIdentityCaches(state);
+  }
+
+  /** Refreshes the ordered tab identity + REAL-id caches the delegated dragstart
+   *  stamps into a payload. Cheap (two maps over ≤9 tabs) and pure bookkeeping — it
+   *  touches no DOM, so it is safe to run on every snapshot. */
+  private syncTabIdentityCaches(state: AppState): void {
+    const selected = selectedSession(state);
+    const tabs = selected ? sessionTabs(selected) : [];
+    this.currentTabIds = tabs.map(tabIdentity);
+    this.currentTabRealIds = tabs.map(tabRealId);
   }
 
   /** Renders the rail SCOPED to the selected project (redesign PR2): only that
@@ -911,16 +933,9 @@ export class AppShell {
     // Which tabs are currently rendered in a pane (feat: split tabs), so the bar can
     // mark an already-open tab distinctly from the focused one.
     const shown = new Set(state.shownTabs);
-    // The ordered tab identities at THIS render, kept for the delegated dragstart to
-    // stamp into a dragged tab's payload so the drop can detect a mid-drag tab-set
-    // change and cancel (split.ts).
-    this.currentTabIds = tabs.map(tabIdentity);
-    // The ordered REAL daemon ids ("" where a tab has none), parallel to
-    // currentTabIds. dragstart stamps from THIS, never from the identity list: a
-    // synthesized `kind:name` in drag.id would make the drop treat a legacy tab as
-    // stable-id-addressed and skip the sameTabs guard that is its only protection
-    // (#1779).
-    this.currentTabRealIds = tabs.map(tabRealId);
+    // The dragstart caches are NOT refreshed here: this render is gated on tabBarSig,
+    // which ignores tab ids, so an id backfill would never reach them. update() syncs
+    // them on every snapshot instead — see syncTabIdentityCaches (#1779).
 
     const children: HTMLElement[] = tabs.map((tab, i) =>
       tabButton(tab, i, i === active, shown.has(i), canManage, this.actions),


### PR DESCRIPTION
Follow-up to #1779 (stable tab identity end-to-end, #1738). Codex flagged six P2 gaps: the stable-id implementation still leaked **ordinal / fallback identities**, which reintroduces the misroute #1738 was meant to fix.

**Theme:** once a tab is addressed by its stable id, no path may fall back to positional identity — and a stale/unknown id **errors** rather than mis-resolving to whatever tab now occupies the old ordinal.

## The six gaps

| # | Site | Gap | Fix |
|---|------|-----|-----|
| 1 | `app/live_termpane.go` | Bind key omitted the tab id, so a pane opened before the daemon minted one kept its ordinal connection forever after adoption | Id is part of the key — adoption forces the rebind |
| 2 | `daemon/preview.go` | Stale id fell back to `req.Tab`, capturing the tab that shifted into the stale ordinal | Non-empty unresolvable id ⇒ `Gone`; ordinal only when no id given |
| 3 | `web/src/split.ts` | Passed the synthesized `1:shell` identity as `?tab_id=`, which the daemon 404s | New `ui.tabRealId`; `AttachTerminal` gets real ids only |
| 4 | `daemon/ws_pty.go` | Resolved id→ordinal, then the agent-server mapped ordinal→id — a concurrent close shifts the middle step | Per-connection **tab binding** over an id-native plane, resolved atomically per op |
| 5 | `web/src/split.ts` | Fallback identities were treated as drag ids, skipping the legacy `sameTabs` guard | `drag.id` carries a real id or `""` |
| 6 | `web/src/split.ts` | Reconciled only on tree change, so an identity swap at an unchanged index left a pane on a dead `tab_id` | Panes record their built-against identity; `tabsRebound` compares identity/kind/target |

## Notable design points

**The ws_pty race (gap 4) needed a structural fix, not a patch.** The old path did `id → ordinal → id`; the middle ordinal is precisely what a concurrent close shifts. Rather than re-resolve more carefully, the id now never becomes an ordinal:

- `session.TabAddressableServer` — an id-native data plane (`SubscribeTab`/`InputTab`/`ResizeTab`) implemented by the local runtime, whose brokers were *already* id-keyed (so this is simpler than the round-trip it replaces).
- `Instance.TabTmuxByID` — resolves id→tmux under **one** lock. Two lock acquisitions were the window.
- `session.ErrTabGone` — the refusal sentinel; maps to HTTP 404.
- `ptyTabBinding` — the addressing decision is made **once**, at bind time. Legacy no-`?tab_id=` clients keep the ordinal binding; the ordinal-shaped remote runtime resolves once up front and still refuses a stale id.

**Identity vs real id (gaps 3/5/6).** `tabIdentity` must always return something, so it synthesizes `kind:name`. That is fine for *local* bookkeeping and wrong for anything crossing the wire or claiming collision-proofness. The two are now separate concepts (`tabIdentity` / `tabRealId`) and the lists are kept strictly apart.

**Testability.** `split.ts` transitively imports `xterm.css`, which the node test runner cannot load — which is why it had no unit tests. The two decisions are extracted as pure helpers in the DOM-free `layout.ts` (`tabsRebound`, `resolveDragTab`), making them directly testable.

## Tests

**Every regression test was verified to FAIL against the pre-fix code** (reverted each fix, confirmed red, restored). One test initially passed both ways — it wasn't discriminating between the real-id and identity lookups — and was rewritten until it actually distinguished them.

Covers: stale/unknown id refused on preview + subscribe + input/resize; atomic id→tmux across an ordinal shift; bind-key rebind on id adoption and on an identity swap at the same ordinal; DnD + reconcile keying on the stable id; legacy no-id paths still addressing by ordinal.

## Gates

- `make test-container` — all packages green, 0 failures
- `make web-selftest-container` — 30/30 Playwright
- `make web-test` — 129/129
- `make tui-driver-selftest` — **31/31** (the task named 25/25; the suite has grown since — it passed in full)
- `go build`, `gofmt`, `golangci-lint --fast`, `deadcode`, file-length lint — all clean
- `web/dist` rebuilt and committed

Not merging — flagged green for review per the request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)