### PR TITLE
fix(daemon): webtab proxy serves path-bearing target URLs (#user-report)

### DIFF
--- a/daemon/webtab_proxy.go
+++ b/daemon/webtab_proxy.go
@@ -129,7 +129,7 @@ func (cs *controlServer) webTabProxyHandler(w http.ResponseWriter, r *http.Reque
 			pr.Out.URL.Scheme = targetURL.Scheme
 			pr.Out.URL.Host = targetURL.Host
 			pr.Out.Host = targetURL.Host
-			pr.Out.URL.Path = joinURLPath(targetURL.Path, "/"+rest)
+			pr.Out.URL.Path, pr.Out.URL.RawPath = resolveUpstreamPath(targetURL, rest)
 			// Never leak the daemon credential upstream: drop the Authorization
 			// header and the daemon's own token cookie, but FORWARD the dev app's
 			// cookies so cookie-backed dev servers work in the iframe.
@@ -252,9 +252,41 @@ func stripFrameAncestors(h http.Header) {
 	}
 }
 
+// resolveUpstreamPath computes the upstream path (and its escaped form) for a
+// proxied web-tab request whose remainder under the tab's prefix is rest.
+//
+// The target is treated as a DOCUMENT reference and rest is resolved against it
+// exactly as a browser resolves a link on that page (RFC 3986 §5.3):
+//
+//	target /viewer.html     + rest ""             -> /viewer.html
+//	target /viewer.html     + rest "assets/x.css" -> /assets/x.css
+//	target /app/viewer.html + rest "assets/x.css" -> /app/assets/x.css
+//	target /app/            + rest "assets/x.css" -> /app/assets/x.css
+//	target / (or "")        + rest "assets/x.css" -> /assets/x.css
+//
+// A root request therefore fetches the target path EXACTLY — appending a trailing
+// slash to a file target ("/viewer.html/") makes a static file server (python
+// -m http.server, and most dev servers) 404 the page the tab points at — while a
+// relative sub-resource still lands next to the document it came from.
+//
+// rest arrives percent-DECODED from the ServeMux "{rest...}" wildcard, so it is
+// assigned as the reference's Path rather than parsed with url.Parse: parsing
+// would misread a literal "?" or "#" in a filename as a query/fragment, and a
+// "//host"-style reference would try to swap the upstream host. Leading slashes
+// are trimmed so rest is always relative to the target document.
+func resolveUpstreamPath(target *url.URL, rest string) (path, rawPath string) {
+	resolved := target.ResolveReference(&url.URL{Path: strings.TrimLeft(rest, "/")})
+	if resolved.Path == "" {
+		// Host-only target ("http://localhost:8899") fetched at its root.
+		return "/", ""
+	}
+	return resolved.Path, resolved.RawPath
+}
+
 // joinURLPath joins a base path and a sub path with exactly one slash between
-// them, so a target with its own base path ("/app") composes with the proxied
-// remainder correctly.
+// them. Used to re-scope an upstream cookie's Path under the tab's proxy prefix,
+// which is a true directory join (unlike the upstream URL, where the target is a
+// document — see resolveUpstreamPath).
 func joinURLPath(base, sub string) string {
 	if base == "" || base == "/" {
 		return sub

--- a/daemon/webtab_proxy_test.go
+++ b/daemon/webtab_proxy_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/sachiniyer/agent-factory/config"
@@ -61,6 +62,103 @@ func TestWebTabProxy_ServesLoopbackTarget(t *testing.T) {
 		// prefix — proof the prefix was stripped before forwarding.
 		if got := string(body); !contains(got, "path=/"+sub) {
 			t.Fatalf("GET sub=%q: upstream saw wrong path in %q", sub, got)
+		}
+	}
+}
+
+// newStaticFileUpstream starts an upstream that behaves like a static file server
+// (python -m http.server): it serves exactly /viewer.html and /assets/x.css and
+// 404s every other path — including the "/viewer.html/" that a directory-style
+// join of a file target would produce.
+func newStaticFileUpstream(t *testing.T, viewerBody, cssBody string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/viewer.html":
+			fmt.Fprint(w, viewerBody)
+		case "/assets/x.css":
+			fmt.Fprint(w, cssBody)
+		default:
+			http.Error(w, "404 File not found: "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestWebTabProxy_ServesPathBearingTarget is the regression test for the
+// user-reported 404: a web tab whose target carries a PATH (http://…/viewer.html)
+// must proxy that document at the tab's root, rather than fetching
+// "/viewer.html/" (which a static file server 404s), and must resolve a relative
+// sub-resource next to the document so its assets load.
+func TestWebTabProxy_ServesPathBearingTarget(t *testing.T) {
+	const viewerBody = "AF_VIEWER_DOC"
+	const cssBody = "AF_VIEWER_CSS"
+	upstream := newStaticFileUpstream(t, viewerBody, cssBody)
+	mux, id, idx := newWebTabProxyFixture(t, upstream.URL+"/viewer.html")
+
+	cases := []struct {
+		name string
+		sub  string
+		want string
+	}{
+		// The proxy root must fetch the target path EXACTLY — no trailing slash
+		// appended, nothing dropped.
+		{name: "proxy root serves the target document", sub: "", want: viewerBody},
+		// A relative asset resolves against the target document's directory.
+		{name: "relative asset resolves beside the document", sub: "assets/x.css", want: cssBody},
+		// A sibling document (what an in-page link produces) resolves too.
+		{name: "sibling document resolves", sub: "viewer.html", want: viewerBody},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/v1/webtab/%s/%d/%s", id, idx, tc.sub), nil)
+			mux.ServeHTTP(rec, req)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("GET sub=%q: status = %d, want 200 (body: %s)", tc.sub, rec.Code, rec.Body.String())
+			}
+			if got := rec.Body.String(); !contains(got, tc.want) {
+				t.Fatalf("GET sub=%q: body = %q, want it to contain %q", tc.sub, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveUpstreamPath pins the document-reference semantics the proxy resolves
+// upstream paths with, including the root-URL target's unchanged behavior.
+func TestResolveUpstreamPath(t *testing.T) {
+	cases := []struct {
+		target string
+		rest   string
+		want   string
+	}{
+		// Path-bearing (file) target: root fetches it exactly; relatives resolve
+		// against its directory.
+		{target: "http://localhost:8899/viewer.html", rest: "", want: "/viewer.html"},
+		{target: "http://localhost:8899/viewer.html", rest: "assets/x.css", want: "/assets/x.css"},
+		{target: "http://localhost:8899/viewer.html", rest: "style.css", want: "/style.css"},
+		{target: "http://localhost:8899/app/viewer.html", rest: "assets/x.css", want: "/app/assets/x.css"},
+		// Directory-style target (trailing slash): relatives nest beneath it.
+		{target: "http://localhost:8899/app/", rest: "", want: "/app/"},
+		{target: "http://localhost:8899/app/", rest: "assets/x.css", want: "/app/assets/x.css"},
+		// Root-URL targets keep their existing behavior.
+		{target: "http://localhost:8899", rest: "", want: "/"},
+		{target: "http://localhost:8899", rest: "assets/x.css", want: "/assets/x.css"},
+		{target: "http://localhost:8899/", rest: "", want: "/"},
+		{target: "http://localhost:8899/", rest: "assets/x.css", want: "/assets/x.css"},
+		// A leading slash on the remainder never escapes to another host: it stays
+		// a path on the target.
+		{target: "http://localhost:8899/viewer.html", rest: "/assets/x.css", want: "/assets/x.css"},
+	}
+	for _, tc := range cases {
+		u, err := url.Parse(tc.target)
+		if err != nil {
+			t.Fatalf("url.Parse(%q): %v", tc.target, err)
+		}
+		got, _ := resolveUpstreamPath(u, tc.rest)
+		if got != tc.want {
+			t.Errorf("resolveUpstreamPath(%q, %q) = %q, want %q", tc.target, tc.rest, got, tc.want)
 		}
 	}
 }

--- a/docs/web.md
+++ b/docs/web.md
@@ -393,6 +393,13 @@ UI or open in a browser") — a terminal can't render a browser. Tab navigation
     trailing slash (`http://localhost:8899/app/` → `assets/x.css` becomes
     `/app/assets/x.css`).
 
+    The target's **directory** is what the tab's root maps onto, so a target
+    nested in a subdirectory (`…/app/viewer.html`) reaches its siblings and
+    descendants but **not its parents**: a `../shared.css` link, or a cookie the
+    app scopes to `Path=/app`, resolves above the tab's root and won't find the
+    proxy. Point the tab at a target whose directory contains everything the page
+    needs (commonly the server root) if the preview needs either.
+
     Over a **token-protected** network listener, iframe sub-resource requests are
     kept authorized via a path-scoped cookie; if a preview loads only partially
     over a direct network listener, prefer an **SSH-forwarded loopback** port

--- a/docs/web.md
+++ b/docs/web.md
@@ -350,6 +350,9 @@ af sessions tab-create <title> --kind web --port 5173
 # any URL (localhost or external)
 af sessions tab-create <title> --kind web --url http://localhost:3000
 af sessions tab-create <title> --kind web --url https://example.com/docs
+
+# a target may point at a specific page, not just a server root
+af sessions tab-create <title> --kind web --url http://localhost:8899/viewer.html
 ```
 
 How the target is rendered depends on whether it is **local** or **external**:
@@ -381,6 +384,14 @@ UI or open in a browser") — a terminal can't render a browser. Tab navigation
     them through the proxy — configure the dev server with a matching base path
     (e.g. Vite's `base`) or serve relative asset URLs. WebSocket-based hot reload
     is proxied on a best-effort basis.
+
+    A target that carries a **path** (`http://localhost:8899/viewer.html`) is
+    treated as a **document**, exactly as a browser treats the page a link points
+    at: the tab's root serves that page, and its relative assets resolve next to
+    it (`style.css` → `/style.css`, `assets/x.css` → `/assets/x.css`). To make
+    relative assets resolve *beneath* a directory instead, give the target a
+    trailing slash (`http://localhost:8899/app/` → `assets/x.css` becomes
+    `/app/assets/x.css`).
 
     Over a **token-protected** network listener, iframe sub-resource requests are
     kept authorized via a path-scoped cookie; if a preview loads only partially


### PR DESCRIPTION
## The bug (user-reported, live)

A web tab whose target URL carries a **path** 404s through the daemon's reverse proxy.

Repro: a tab pointing at `http://localhost:8899/viewer.html` (`python -m http.server` serving that file — a direct `curl` returns 200). `GET /v1/webtab/<sid>/<idx>/` returns the **upstream's own 404 page** — proof the proxy forwards fine but constructs the upstream path wrong. Subpath requests 404 too. Root-URL targets (`http://localhost:8443`) work, which is why this went unnoticed.

## Root cause

`joinURLPath` (`daemon/webtab_proxy.go`) treated the target path as a **directory** to join the proxied remainder under:

```go
pr.Out.URL.Path = joinURLPath(targetURL.Path, "/"+rest)
```

For target `/viewer.html`, the tab's root request (`rest == ""`) became `/viewer.html/` and a sub-resource became `/viewer.html/assets/x.css`. A static file server 404s both. The target is a **document**, not a directory.

## The fix

Resolve the remainder against the target as a document reference (RFC 3986 §5.3) with `url.ResolveReference` — the same way a browser resolves a link on that page. Built with `net/url` joining, no string concat:

| target | rest | upstream |
|---|---|---|
| `/viewer.html` | `""` | `/viewer.html` |
| `/viewer.html` | `assets/x.css` | `/assets/x.css` |
| `/app/viewer.html` | `assets/x.css` | `/app/assets/x.css` |
| `/app/` | `assets/x.css` | `/app/assets/x.css` |
| `/` or `""` | `assets/x.css` | `/assets/x.css` (unchanged) |

An empty reference resolving to the base path gives the "root fetches the target **exactly** — no trailing slash appended, nothing dropped" case for free. Root-URL targets keep their existing behavior.

`joinURLPath` stays: it still backs the Set-Cookie path re-scoping, which *is* a true directory join. Its doc comment now says which of the two it is.

### Security notes

- `rest` is assigned as the reference's `Path`, **not** parsed with `url.Parse`. It arrives percent-**decoded** from the `{rest...}` wildcard, so parsing would misread a literal `?`/`#` in a filename as a query/fragment, and a `//host`-style reference would try to swap the upstream host. Leading slashes are trimmed so `rest` is always relative to the target.
- The existing `..` rejection and the loopback-only guard are untouched; `ResolveReference` also removes dot segments.

## Behavior change worth flagging

A target with a **non-slash-terminated** path (`--url http://localhost:3000/app`) previously joined as a directory (`/app/x`); it now resolves as a document (`/x`), per the requested browser semantics. Anyone relying on the old nesting should give the target a trailing slash (`/app/`), which the docs note now spells out. This was never a security boundary — a root target already proxies the whole loopback origin.

Target-URL **query strings** are still dropped upstream (pre-existing, unchanged) — out of scope for this path fix.

## Tests (load-bearing)

- `TestWebTabProxy_ServesPathBearingTarget` — an httptest upstream serving only `/viewer.html` + `/assets/x.css` and 404ing everything else, mirroring `python -m http.server`. Covers proxy-root → `viewer.html` (200, correct body), subpath `assets/x.css` → `/assets/x.css` (200), and a sibling document.
- `TestResolveUpstreamPath` — table test pinning the full resolution matrix, including root-URL targets and a leading-slash remainder.
- `TestWebTabProxy_ServesLoopbackTarget` (pre-existing, unchanged) — the root-URL-target-still-works gate.

**Verified red → green**: with the old join restored, the new test fails with the exact reported upstream 404s (`404 File not found: /viewer.html/`, `.../viewer.html/viewer.html`); with the fix, all 8 proxy tests pass.

## Docs

`docs/web.md` didn't claim path targets work — it was silent on them. Now that they do, the web-tab section documents the document-vs-directory semantics and adds a path-bearing example.

## Gates

| gate | result |
|---|---|
| `make test-container` | ✅ full suite green |
| `make web-selftest-container` | ✅ 30/30 |
| `make tui-driver-selftest` | ✅ **31/31** (suite has grown past 25) |
| `go build ./...` | ✅ |
| `gofmt -l .` | ✅ clean |
| `golangci-lint run --fast` | ✅ clean |
| `deadcode -test ./...` | ✅ clean |
| `scripts/lint-file-length.sh` | ✅ 611 files |

Not merging — flagged for review as requested.

Co-authored-by: Captain Claude <noreply@anthropic.com>