### PR TITLE
fix(daemon,web): publish session.updated on tab create/delete so open web clients see out-of-band tabs (#1812, #1818)

### DIFF
--- a/daemon/manager_tabs.go
+++ b/daemon/manager_tabs.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/sachiniyer/agent-factory/agentproto"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/git"
@@ -107,7 +108,8 @@ func (m *Manager) CreateTab(req CreateTabRequest) (string, error) {
 	// clobber-safe single-writer direction of #960 — rather than a whole-list
 	// SaveInstances, which would re-serialize the manager's entire view and was
 	// the dual-writer clobber surface PR 4 retires. Mirrors CloseTab/SetPRInfo.
-	if err := persistInstanceData(repoID, instance.ToInstanceData()); err != nil {
+	data := instance.ToInstanceData()
+	if err := persistInstanceData(repoID, data); err != nil {
 		// Roll back the just-spawned tab so a persist failure does not leave a
 		// live tmux session that vanishes from the tab list on restart.
 		if closeErr := instance.CloseTab(instance.TabCount() - 1); closeErr != nil {
@@ -115,6 +117,23 @@ func (m *Manager) CreateTab(req CreateTabRequest) (string, error) {
 		}
 		return "", fmt.Errorf("failed to persist new tab: %w", err)
 	}
+
+	// Announce the grown roster (#1812). A tab created by an agent, the CLI, the
+	// TUI, or another browser window is a state change like any other, and
+	// without this an already-open web client never learns of it: it only
+	// re-Snapshots after its OWN mutation, so a quiet session's tab bar stays
+	// stale indefinitely. That silently broke the web tab's stated purpose —
+	// letting an agent inject a live browser view into the user's screen.
+	//
+	// The refreshed InstanceData rides on session.updated rather than a new tab.*
+	// event: it already carries the full Tabs roster, and every client re-projects
+	// the whole session from it (web's upsertSession, the TUI's
+	// ReconcileTabsFromData), so this needs no client change. Published after the
+	// persist so no client can observe a tab that isn't durable yet, and while
+	// still holding the repo start lock so concurrent tab mutations announce in
+	// the same order they persisted. publishEvent is non-blocking (drop-slow), so
+	// a wedged subscriber can't stall the mutation.
+	m.publishEvent(agentproto.EventSessionUpdated, data)
 	return tab.Name, nil
 }
 
@@ -210,9 +229,16 @@ func (m *Manager) CloseTab(req CloseTabRequest) (string, error) {
 		return "", err
 	}
 
-	if err := persistInstanceData(repoID, instance.ToInstanceData()); err != nil {
+	data := instance.ToInstanceData()
+	if err := persistInstanceData(repoID, data); err != nil {
 		return "", fmt.Errorf("failed to persist tab close: %w", err)
 	}
+
+	// Announce the shrunk roster (#1812) — the close-side counterpart of
+	// CreateTab's publish; see there for why this rides on session.updated. A tab
+	// closed out-of-band must disappear from every open client, not just the one
+	// that closed it.
+	m.publishEvent(agentproto.EventSessionUpdated, data)
 	return name, nil
 }
 

--- a/daemon/tab_event_test.go
+++ b/daemon/tab_event_test.go
@@ -1,0 +1,151 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/agentproto"
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// The #1812 regression tests: a tab-set mutation is a state change like any
+// other, so CreateTab/CloseTab must announce it on the events plane. Before the
+// fix both persisted the roster silently, so a tab created by an agent, the CLI,
+// the TUI, or a second browser window never reached an already-open web client —
+// the session's tab bar stayed stale until an *unrelated* session.updated
+// happened to repair it as a side-effect (or the user reloaded). On a quiet
+// session no such event ever arrives.
+//
+// The refreshed InstanceData rides on session.updated rather than a new tab.*
+// type: InstanceData already carries the full Tabs roster and every client
+// (web's upsertSession, the TUI's ReconcileTabsFromData) already re-projects the
+// whole session from it, so the existing event both fixes the bug and needs no
+// client change. This mirrors limit.go's choke-point publish.
+
+// tabEventSession builds a manager holding one started, tab-capable local
+// session and returns the manager plus its repo context.
+func tabEventSession(t *testing.T, title string) (*Manager, *config.RepoContext) {
+	t.Helper()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	startedLocalTabInstance(t, manager, repo.ID, repoPath, title, "af_"+title+"_agent")
+	return manager, repo
+}
+
+// tabNamed reports whether data's roster contains a tab called name.
+func tabNamed(data session.InstanceData, name string) bool {
+	for _, tab := range data.Tabs {
+		if tab.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// snapshotTabs returns the roster the daemon would hand a re-Snapshotting client
+// for title — the projection a web client rebuilds from after an event.
+func snapshotTabs(t *testing.T, m *Manager, repoID, title string) session.InstanceData {
+	t.Helper()
+	for _, data := range m.Snapshot(repoID) {
+		if data.Title == title {
+			return data
+		}
+	}
+	t.Fatalf("session %q missing from snapshot", title)
+	return session.InstanceData{}
+}
+
+// TestCreateTab_WebPublishesSessionUpdated: the headline #1812 case — an agent
+// injecting a live browser view (`tab-create --kind web`) into the user's screen.
+// A subscriber must see the tab on the events plane, and a fresh Snapshot must
+// agree.
+func TestCreateTab_WebPublishesSessionUpdated(t *testing.T) {
+	const title = "webevt"
+	manager, repo := tabEventSession(t, title)
+
+	_, ch := manager.events.subscribe()
+	name, err := manager.CreateTab(CreateTabRequest{
+		Title: title, RepoID: repo.ID, Kind: "web", URL: "http://localhost:5173", Name: "livepreview",
+	})
+	if err != nil {
+		t.Fatalf("CreateTab(web): %v", err)
+	}
+
+	got := drainNextSessionEvent(t, ch, agentproto.EventSessionUpdated)
+	if got.Title != title {
+		t.Fatalf("event Title = %q, want %q", got.Title, title)
+	}
+	if !tabNamed(got, name) {
+		t.Fatalf("session.updated roster %v is missing the new web tab %q", got.Tabs, name)
+	}
+	if !tabNamed(snapshotTabs(t, manager, repo.ID, title), name) {
+		t.Fatalf("a fresh Snapshot is missing the new web tab %q", name)
+	}
+}
+
+// TestCreateTab_ProcessPublishesSessionUpdated: the process-kind counterpart —
+// a PTY-backed tab (`tab-create --command`) must announce itself too.
+func TestCreateTab_ProcessPublishesSessionUpdated(t *testing.T) {
+	const title = "procevt"
+	manager, repo := tabEventSession(t, title)
+
+	_, ch := manager.events.subscribe()
+	name, err := manager.CreateTab(CreateTabRequest{
+		Title: title, RepoID: repo.ID, Command: "sleep 600", Name: "worker",
+	})
+	if err != nil {
+		t.Fatalf("CreateTab(process): %v", err)
+	}
+
+	got := drainNextSessionEvent(t, ch, agentproto.EventSessionUpdated)
+	if !tabNamed(got, name) {
+		t.Fatalf("session.updated roster %v is missing the new process tab %q", got.Tabs, name)
+	}
+	if !tabNamed(snapshotTabs(t, manager, repo.ID, title), name) {
+		t.Fatalf("a fresh Snapshot is missing the new process tab %q", name)
+	}
+}
+
+// TestCloseTab_PublishesSessionUpdated: the delete side. A tab closed
+// out-of-band must vanish from every open client, so the event carries the
+// SHRUNK roster (the tab absent), and the agent tab survives.
+func TestCloseTab_PublishesSessionUpdated(t *testing.T) {
+	const title = "closeevt"
+	manager, repo := tabEventSession(t, title)
+
+	name, err := manager.CreateTab(CreateTabRequest{
+		Title: title, RepoID: repo.ID, Kind: "web", URL: "http://localhost:5173", Name: "doomed",
+	})
+	if err != nil {
+		t.Fatalf("CreateTab(web): %v", err)
+	}
+
+	// Subscribe only after the create so the close's event is unambiguous.
+	_, ch := manager.events.subscribe()
+	closed, err := manager.CloseTab(CloseTabRequest{Title: title, RepoID: repo.ID, TabName: name})
+	if err != nil {
+		t.Fatalf("CloseTab: %v", err)
+	}
+	if closed != name {
+		t.Fatalf("CloseTab returned %q, want %q", closed, name)
+	}
+
+	got := drainNextSessionEvent(t, ch, agentproto.EventSessionUpdated)
+	if tabNamed(got, name) {
+		t.Fatalf("session.updated roster %v still contains the closed tab %q", got.Tabs, name)
+	}
+	if len(got.Tabs) != 1 {
+		t.Fatalf("roster after close = %v, want just the agent tab", got.Tabs)
+	}
+	if tabNamed(snapshotTabs(t, manager, repo.ID, title), name) {
+		t.Fatalf("a fresh Snapshot still contains the closed tab %q", name)
+	}
+}

--- a/scripts/container/web-selftest-entry.sh
+++ b/scripts/container/web-selftest-entry.sh
@@ -54,6 +54,9 @@ TASK3_NAME=mock3-task
 WEBTAB_PORT=8890
 WEBTAB_LOCAL_MARKER=AF_WEBTAB_LOCAL_OK
 WEBTAB_EXTERNAL_URL=https://blocked.example.test/
+# The malformed/older web-tab record (a web tab with NO target url) the harness
+# seeds straight into the daemon's store, since no API can mint one (#1818).
+NOURL_TAB=nourl
 export AGENT_FACTORY_HOME="$HOME_DIR"
 # A container binary is built at the branch version (typically behind the latest
 # release); without this it would self-update on boot and restart the daemon
@@ -103,9 +106,35 @@ for repo in "$MOCK" "$MOCK2" "$MOCK3"; do
 done
 
 # --- start the daemon + wait for the HTTP listener --------------------------
+# Both are functions because the harness restarts the daemon once, to seed a record
+# no API can mint (see the URL-less web tab below); the restart must reuse this exact
+# readiness poll rather than a second, drifting copy of it.
+start_daemon() {
+    "$BIN" --daemon >>/work/daemon.log 2>&1 &
+    DAEMON_PID=$!
+}
+
+# Poll the HTTP port until it serves the SPA shell (200). Once it binds, the token
+# file exists (EnsureToken runs before the port opens).
+wait_for_listener() {
+    for i in $(seq 1 60); do
+        if curl -s -o /dev/null -w '%{http_code}' "$BASE_URL/" 2>/dev/null | grep -q '^200$'; then
+            return 0
+        fi
+        if ! kill -0 "$DAEMON_PID" 2>/dev/null; then
+            echo "daemon exited before binding the listener; see log:" >&2
+            cat /work/daemon.log >&2
+            exit 1
+        fi
+        sleep 1
+    done
+    echo "timed out waiting for $BASE_URL" >&2
+    cat /work/daemon.log >&2
+    exit 1
+}
+
 echo ">>> starting af daemon (listen_addr=$LISTEN) ..."
-"$BIN" --daemon >/work/daemon.log 2>&1 &
-DAEMON_PID=$!
+start_daemon
 WEBTAB_SERVER_PID=""
 
 cleanup() {
@@ -124,25 +153,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Poll the HTTP port until it serves the SPA shell (200). Once it binds, the token
-# file exists (EnsureToken runs before the port opens).
 echo ">>> waiting for the HTTP listener ..."
-for i in $(seq 1 60); do
-    if curl -s -o /dev/null -w '%{http_code}' "$BASE_URL/" 2>/dev/null | grep -q '^200$'; then
-        break
-    fi
-    if ! kill -0 "$DAEMON_PID" 2>/dev/null; then
-        echo "daemon exited before binding the listener; see log:" >&2
-        cat /work/daemon.log >&2
-        exit 1
-    fi
-    sleep 1
-    if [ "$i" -eq 60 ]; then
-        echo "timed out waiting for $BASE_URL" >&2
-        cat /work/daemon.log >&2
-        exit 1
-    fi
-done
+wait_for_listener
 
 # The token file still exists (EnsureToken runs before the port opens) even though
 # the loopback browser never uses it — read it purely as a daemon-health signal.
@@ -218,6 +230,70 @@ done
 "$BIN" sessions tab-create --repo "$MOCK" "$SESSION_WEB" --kind web --port "$WEBTAB_PORT" --name preview >/dev/null
 "$BIN" sessions tab-create --repo "$MOCK" "$SESSION_WEB" --kind web --url "$WEBTAB_EXTERNAL_URL" --name external >/dev/null
 
+# --- seed the URL-less web tab through the daemon's OWN store (#1818) -------
+# A web tab with no target is a MALFORMED/older record, and three live guards
+# refuse to mint one (CreateTab's "requires a target", NormalizeWebTabURL, and
+# AddWebTab's "requires a non-empty URL"), so there is no API/CLI call that can
+# stage it — and weakening a real user-facing validation to let a test in would be
+# the wrong trade. The honest way to stage a legacy record is to write it the way an
+# older version would have and let the daemon load it: `url` is omitempty, so a tab
+# record with no url field IS that shape, and restoreLocalTabs backfills its stable
+# id on load.
+#
+# Seeding it in the daemon's own store — rather than rewriting a Snapshot inside the
+# browser, which is what this used to do — is the point of #1818. The daemon then
+# serves the tab on BOTH planes, so the Snapshot and every session.updated agree
+# about it. The old browser-side mock only patched the Snapshot, so any
+# session.updated (which tab changes now emit, #1812) overwrote the projection with
+# the real roster and silently deleted the injected tab mid-test: a flake. There is
+# nothing left to race here, and no sleep or retry propping it up.
+#
+# The daemon is the single writer of instances.json (#960), so it must be stopped
+# before the file is touched and restarted to pick the record up. `wait` blocks until
+# it is really gone — no sleep. Nothing else is in flight at this point (all seeding
+# is done, Playwright has not started), so this cannot race session creation the way
+# an auto-update restart once did (#1596).
+echo ">>> seeding the URL-less web tab ($NOURL_TAB) into the daemon's store ..."
+kill "$DAEMON_PID" 2>/dev/null || true
+wait "$DAEMON_PID" 2>/dev/null || true
+
+cat >/work/seed-nourl.js <<'EOF'
+const fs = require("fs");
+const path = require("path");
+const [home, title, tab] = process.argv.slice(2);
+// Per-repo store: $AGENT_FACTORY_HOME/instances/<repoID>/instances.json. Find the
+// file holding the session by title rather than deriving the repo id.
+const dir = path.join(home, "instances");
+let patched = false;
+for (const repoID of fs.readdirSync(dir)) {
+  const file = path.join(dir, repoID, "instances.json");
+  if (!fs.existsSync(file)) continue;
+  const raw = JSON.parse(fs.readFileSync(file, "utf8"));
+  // v1 is an envelope ({schema_version, instances}); v0 was a bare array. Keep
+  // whichever shape is on disk so the daemon's own migrator still sees what it wrote.
+  const instances = Array.isArray(raw) ? raw : raw.instances;
+  for (const inst of instances ?? []) {
+    if (inst.title !== title) continue;
+    // kind 3 = TabKindWeb. No `url` key at all — the legacy shape, not url:"".
+    (inst.tabs = inst.tabs ?? []).push({ name: tab, kind: 3 });
+    patched = true;
+  }
+  if (patched) {
+    fs.writeFileSync(file, JSON.stringify(raw));
+    break;
+  }
+}
+if (!patched) {
+  console.error(`seed-nourl: no session titled ${title} under ${dir}`);
+  process.exit(1);
+}
+EOF
+node /work/seed-nourl.js "$HOME_DIR" "$SESSION_WEB" "$NOURL_TAB"
+
+echo ">>> restarting the daemon so it loads the seeded record ..."
+start_daemon
+wait_for_listener
+
 # --- run the Playwright harness ---------------------------------------------
 echo ">>> installing web deps + running the Playwright harness ..."
 cd /work/web
@@ -236,5 +312,12 @@ export AF_WEB_TASK_NAME="$SEEDED_TASK"
 export AF_WEB_TASK3_NAME="$TASK3_NAME"
 export AF_WEBTAB_LOCAL_MARKER="$WEBTAB_LOCAL_MARKER"
 export AF_WEBTAB_EXTERNAL_URL="$WEBTAB_EXTERNAL_URL"
+export AF_WEBTAB_NOURL_NAME="$NOURL_TAB"
+# The af CLI + the mock repo it targets, so a test can mutate state OUT-OF-BAND —
+# as an agent or a script does, from outside the browser — and assert the open SPA
+# reacts to the daemon's event (#1812). AGENT_FACTORY_HOME is already exported
+# above, so the CLI resolves the same throwaway home as the daemon under test.
+export AF_BIN="$BIN"
+export AF_MOCK_REPO="$MOCK"
 
 npx playwright test

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7700,6 +7700,9 @@ var SplitView = class {
   tabKinds = [];
   tree = null;
   focusedId = null;
+  // Counts explicit layout/focus mutations, for the stale-async guard — see
+  // layoutGeneration(), which is the documented contract.
+  layoutGen = 0;
   // Debounces the "focus left every pane" report so a click that moves focus A→B
   // (blur A, then focus B) doesn't flap the nav mode through rail and back.
   blurTimer = null;
@@ -7827,9 +7830,26 @@ var SplitView = class {
     this.lastShown = "";
     this.lastPaneCount = 0;
   }
+  /** How many EXPLICIT layout/focus mutations have been committed — a tab rebind
+   *  (a 1-9 key or a tab-bar click), a drag-drop split, a pane close. Deliberately
+   *  NOT bumped by setSession's roster reconcile, which only remaps each pane to
+   *  follow its own tab and expresses no user intent.
+   *
+   *  That split is the point: an async caller which computes a tab index from a
+   *  PRE-await snapshot (see index.ts closeSessionTab) captures this first and
+   *  applies its result only if the value still matches. A slow close then can't
+   *  clobber a tab the user selected while it was in flight — their newer intent
+   *  wins — while the roster event that races the same close still passes the
+   *  guard, because it bumps nothing. */
+  layoutGeneration() {
+    return this.layoutGen;
+  }
   // --- internal: mutation commit --------------------------------------------
-  /** Persists the current tree for the session, re-renders, and reports the layout. */
+  /** Persists the current tree for the session, re-renders, and reports the layout.
+   *  Every explicit layout/focus mutation funnels through here, which is what makes
+   *  it the one place to count them (see layoutGeneration). */
   commit() {
+    this.layoutGen++;
     if (this.sessionId && this.tree) {
       this.trees.set(this.sessionId, this.tree);
     }
@@ -9572,13 +9592,16 @@ function closeSessionTab(index) {
   }
   clearTabError();
   const selId = sel.id ?? "";
+  const cur = store.get().activeTab;
+  const gen = splitView.layoutGeneration();
   void closeTab(selId, sel.title, target.name, tok).then(() => fetchSnapshot(tok)).then((sessions) => {
-    const cur = store.get().activeTab;
     const shrunk = sessions.find((s) => s.id === selId);
     const n = shrunk ? sessionTabs(shrunk).length : 1;
     const next = Math.min(Math.max(index <= cur ? cur - 1 : cur, 0), n - 1);
     store.set({ sessions, selectedId: pickSelection(sessions, store.get().selectedId) });
-    splitView.setFocusedTab(next);
+    if (splitView.layoutGeneration() === gen && store.get().selectedId === selId) {
+      splitView.setFocusedTab(next);
+    }
   }).catch((e) => surfaceTabError(e));
 }
 function surfaceTabError(e) {

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -58,6 +58,10 @@ const READY_MARKER = process.env.AF_WEB_READY_MARKER ?? "AF_SELFTEST_READY";
 // tab named "preview" pointing at a loopback server the daemon proxies, and an
 // EXTERNAL web tab named "external" whose host this test intercepts.
 const SESSION_WEB = process.env.AF_WEB_SESSION_WEB ?? "probe-web";
+// The malformed/older web tab (kind=web, no target url) the harness seeds directly
+// into the daemon's store, because every API path refuses to mint one (#1818). It is
+// part of probe-web's REAL roster for the whole run, not a per-test mock.
+const NOURL_TAB = process.env.AF_WEBTAB_NOURL_NAME ?? "nourl";
 const WEBTAB_LOCAL_MARKER = process.env.AF_WEBTAB_LOCAL_MARKER ?? "AF_WEBTAB_LOCAL_OK";
 const WEBTAB_EXTERNAL_URL = process.env.AF_WEBTAB_EXTERNAL_URL ?? "https://blocked.example.test/";
 
@@ -799,31 +803,22 @@ test("web tab (feat): an external URL is iframed directly and shows a fallback w
 });
 
 test("web tab (feat): a tab with no target URL renders a clean fallback, not a blank pane", async () => {
-  // The CLI/API refuse to create a URL-less web tab, so this malformed/older-record
-  // case is injected by rewriting the Snapshot to append a web tab (kind 3) with an
-  // empty url to the web-tab session. The pane must render the fallback, not blank.
-  await page.route("**/v1/Snapshot", async (route) => {
-    const resp = await route.fetch();
-    const body = await resp.json();
-    // The Snapshot envelope is { data: { instances: SessionData[] } }.
-    const snap = body?.data as { instances?: Array<{ title: string; tabs?: Array<{ name: string; kind: number; url?: string }> }> };
-    const web = snap?.instances?.find((s) => s.title === SESSION_WEB);
-    if (web) {
-      web.tabs = web.tabs ?? [];
-      web.tabs.push({ name: "nourl", kind: 3, url: "" });
-    }
-    // Fulfill with a freshly-serialized body — the fetched APIResponse has already
-    // been consumed by .json(), so it can't be reused as `response`.
-    await route.fulfill({ status: resp.status(), contentType: "application/json", body: JSON.stringify(body) });
-  });
-  await page.reload();
-  await expect(page.locator(".af-app")).toBeVisible();
-  await expect(row(page, SESSION_WEB)).toBeVisible({ timeout: 15_000 });
-
+  // The URL-less web tab is a malformed/older record that no API can mint — three
+  // guards refuse an empty target — so the harness writes it the way an older version
+  // would have, straight into the daemon's own store before it boots
+  // (web-selftest-entry.sh). It is therefore REAL here: the daemon serves it on the
+  // Snapshot AND on every session.updated, so nothing can contradict it mid-test.
+  //
+  // This used to rewrite the Snapshot in the browser to inject the tab. That mock
+  // patched only ONE plane, so any session.updated — which a tab change now emits
+  // (#1812) — replaced the projection with the real roster and deleted the injected
+  // tab out from under the assertion below: an intermittent, entirely fictional
+  // failure (#1818). Seeding it for real is what removes the race; there is no reload,
+  // no route, and no retry left to prop it up.
   await row(page, SESSION_WEB).click();
   await expect(page.locator(".af-main.af-main-term")).toBeVisible();
   const tabbar = page.locator(".af-tabbar");
-  const nourlTab = tabbar.locator(".af-tab", { hasText: "nourl" });
+  const nourlTab = tabbar.locator(".af-tab", { hasText: NOURL_TAB });
   await expect(nourlTab).toHaveCount(1, { timeout: 15_000 });
   await nourlTab.click();
 
@@ -831,10 +826,6 @@ test("web tab (feat): a tab with no target URL renders a clean fallback, not a b
   const fallback = page.locator(".af-term-host .af-pane-host .af-webpane-fallback");
   await expect(fallback).toBeVisible({ timeout: 10_000 });
   await expect(fallback).toContainText("no URL");
-
-  await page.unroute("**/v1/Snapshot");
-  await page.reload();
-  await expect(page.locator(".af-app")).toBeVisible();
 });
 
 test("web tab (feat): a surviving web tab that only SHIFTS ordinal is followed, not remounted (#1779)", async () => {
@@ -875,7 +866,11 @@ test("web tab (feat): a surviving web tab that only SHIFTS ordinal is followed, 
   await tabbar.locator(".af-tab", { hasText: "preview" }).locator(".af-tab-close").click();
   await expect(tabbar.locator(".af-tab", { hasText: "preview" })).toHaveCount(0, { timeout: 30_000 });
   // The shift really happened — without this the assertion below would prove nothing.
-  await expect(tabbar.locator(".af-tab")).toHaveCount(2, { timeout: 30_000 });
+  // The roster is [Agent, preview, external, nourl] before the close and [Agent,
+  // external, nourl] after: the seeded URL-less tab (#1818) is part of probe-web's
+  // real tab list now, so the surviving count is 3, not 2. "external" still shifts
+  // 2 → 1, which is what this test turns on.
+  await expect(tabbar.locator(".af-tab")).toHaveCount(3, { timeout: 30_000 });
 
   // The pane still shows the SAME tab, through the SAME iframe element.
   await expect(frame).toHaveCount(1);
@@ -1416,4 +1411,123 @@ test("theme (redesign PR1): toggling Light vs Dark changes token-driven colors l
     .poll(() => page.evaluate(() => document.documentElement.hasAttribute("data-theme")))
     .toBe(false);
   await page.evaluate(() => localStorage.removeItem("af-theme"));
+});
+
+// The #1812 regression guard: a tab created or deleted by ANY actor other than
+// this browser window — an agent running `af sessions tab-create` inside its own
+// session, the TUI, a script, a second window — must reach an already-open client
+// live. Before the fix the daemon persisted the roster silently, so the SPA (which
+// only re-Snapshots after its OWN mutation, and never polls) stayed stale until the
+// user reloaded or an unrelated session.updated happened to repair it as a
+// side-effect. On a quiet session that repair never comes — which broke the web
+// tab's stated purpose: letting an agent inject a live browser view into the user's
+// screen.
+//
+// The mutation is driven through the real `af` CLI over the control socket, not the
+// HTTP API the SPA uses, so this also proves the event reaches the browser
+// regardless of which transport drove the change (both mutate one Manager).
+test("#1812: a tab created/deleted out-of-band reaches the open client with no reload", async () => {
+  const afBin = process.env.AF_BIN;
+  const mockRepo = process.env.AF_MOCK_REPO;
+  test.skip(!afBin || !mockRepo, "AF_BIN/AF_MOCK_REPO are set only by web-selftest-entry.sh");
+  const { execFileSync } = await import("node:child_process");
+  const af = (...args: string[]): void => {
+    execFileSync(afBin as string, ["--repo", mockRepo as string, ...args], { stdio: "pipe" });
+  };
+  const OOB_TAB = "livepreview";
+
+  await row(page, SESSION_A).click();
+  const tabbar = page.locator(".af-tabbar");
+  await expect(tabbar).toBeVisible();
+  const oob = tabbar.locator(".af-tab", { hasText: OOB_TAB });
+  await expect(oob).toHaveCount(0);
+
+  // Stamp the live document. A reload wipes this, so asserting it survives is what
+  // makes "WITHOUT a reload" a real claim rather than an assumption — the whole
+  // point of #1812 is that the user must not have to refresh.
+  await page.evaluate(() => {
+    (window as Window & { __af1812?: boolean }).__af1812 = true;
+  });
+  const notReloaded = (): Promise<boolean> =>
+    page.evaluate(() => (window as Window & { __af1812?: boolean }).__af1812 === true);
+
+  // Repro A: an agent injects a live browser view mid-work. The tab must land in
+  // this window, which did not create it.
+  af("sessions", "tab-create", SESSION_A, "--kind", "web", "--port", "3200", "--name", OOB_TAB);
+  await expect(oob, "a tab created out-of-band must appear without a reload").toHaveCount(1, {
+    timeout: 15_000,
+  });
+  expect(await notReloaded(), "the tab must arrive on the LIVE page, not via a reload").toBe(true);
+
+  // The delete side: the tab must vanish from a window that did not close it.
+  af("sessions", "tab-delete", SESSION_A, "--name", OOB_TAB);
+  await expect(oob, "a tab deleted out-of-band must disappear without a reload").toHaveCount(0, {
+    timeout: 15_000,
+  });
+  expect(await notReloaded()).toBe(true);
+});
+
+// The #1812 review guard (Codex): a close is async, and `next` is computed from the
+// index that was active when it was ISSUED. A slow CloseTab leaves a window in which
+// the user can select another tab — and re-pointing the pane from that stale index
+// afterwards would yank their selection away. The user's newer intent must win. The
+// roster event races the same window and must still be free to pass the guard, which
+// is why it keys off explicit layout mutations rather than the tab index itself.
+test("#1812 review: a close held in flight must not clobber a tab the user picks meanwhile", async () => {
+  const afBin = process.env.AF_BIN;
+  const mockRepo = process.env.AF_MOCK_REPO;
+  test.skip(!afBin || !mockRepo, "AF_BIN/AF_MOCK_REPO are set only by web-selftest-entry.sh");
+  const { execFileSync } = await import("node:child_process");
+  const af = (...args: string[]): void => {
+    execFileSync(afBin as string, ["--repo", mockRepo as string, ...args], { stdio: "pipe" });
+  };
+
+  await row(page, SESSION_A).click();
+  const tabbar = page.locator(".af-tabbar");
+  await expect(tabbar).toBeVisible();
+  const active = page.locator(".af-tab.af-tab-active .af-tab-label");
+
+  // Two named tabs: "doomed" is closed, "keeper" is focused when the close is issued
+  // (so the stale `next` would point back at it). Named via the CLI so neither the
+  // labels nor the ordinals depend on what earlier tests left behind.
+  af("sessions", "tab-create", SESSION_A, "--kind", "web", "--url", WEBTAB_EXTERNAL_URL, "--name", "doomed");
+  af("sessions", "tab-create", SESSION_A, "--kind", "web", "--url", WEBTAB_EXTERNAL_URL, "--name", "keeper");
+  const doomed = tabbar.locator(".af-tab", { hasText: "doomed" });
+  const keeper = tabbar.locator(".af-tab", { hasText: "keeper" });
+  await expect(doomed).toHaveCount(1, { timeout: 15_000 });
+  await expect(keeper).toHaveCount(1, { timeout: 15_000 });
+
+  await keeper.click();
+  await expect(active).toHaveText("keeper");
+
+  // Hold CloseTab open so the mid-flight window is deterministic rather than a race
+  // against a fast local daemon.
+  let releaseClose: (() => void) | undefined;
+  const closeHeld = new Promise<void>((resolve) => {
+    releaseClose = resolve;
+  });
+  let closeInFlight = false;
+  await page.unroute("**/v1/CloseTab");
+  await page.route("**/v1/CloseTab", async (route) => {
+    closeInFlight = true;
+    await closeHeld;
+    await route.continue();
+  });
+
+  await doomed.locator(".af-tab-close").click();
+  await expect.poll(() => closeInFlight, { timeout: 15_000 }).toBe(true);
+
+  // Mid-flight: the user picks the agent tab. This is the intent the close must respect.
+  await tabbar.locator(".af-tab", { hasText: "Agent" }).first().click();
+  await expect(active).toHaveText("Agent");
+
+  // Let the close land. Its `next` was computed against "keeper" — applying it now
+  // would snap the pane back to "keeper" and lose the user's choice.
+  releaseClose?.();
+  await expect(doomed).toHaveCount(0, { timeout: 15_000 });
+  await expect(active, "the user's mid-flight selection must survive the close").toHaveText("Agent");
+
+  await page.unroute("**/v1/CloseTab");
+  af("sessions", "tab-delete", SESSION_A, "--name", "keeper");
+  await expect(keeper).toHaveCount(0, { timeout: 15_000 });
 });

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -562,10 +562,13 @@ function openTab(index: number): void {
 }
 
 /** Creates a $SHELL tab on the selected session (the `t` key / + button), then
- *  resyncs to pull the grown tab list (the daemon emits no event for a tab change),
- *  selects the new tab, and attaches it — mirroring the TUI's `t`, which opens the
- *  fresh tab as a pane. Errors (e.g. a remote session, or the tab cap) surface on
- *  the pane header's status line. */
+ *  resyncs to pull the grown tab list, selects the new tab, and attaches it —
+ *  mirroring the TUI's `t`, which opens the fresh tab as a pane. The resync is
+ *  kept for THIS window's own mutation because it must select+attach the new tab
+ *  synchronously, which needs the tab in hand rather than an event later; a tab
+ *  changed by any OTHER actor now arrives on its own, since CreateTab/CloseTab
+ *  publish session.updated with the refreshed roster (#1812). Errors (e.g. a
+ *  remote session, or the tab cap) surface on the pane header's status line. */
 function createSessionTab(): void {
   const sel = selectedSessionData();
   const tok = token;
@@ -608,20 +611,40 @@ function closeSessionTab(index: number): void {
   }
   clearTabError();
   const selId = sel.id ?? "";
+  // Read the active index BEFORE the close, not after the awaits: `next` below is
+  // computed RELATIVE to the PRE-close list, so it is only correct against the index
+  // as it stood when this close was issued. The daemon's tab event (#1812) can land
+  // while these awaits are in flight — rerendering with the shrunk roster, which
+  // remaps each pane to follow its own tab and writes the ALREADY-shifted index back
+  // as activeTab. Reading it afterwards would then subtract the shift a SECOND time
+  // and re-point the pane one tab too far left — tearing down a surviving web tab's
+  // iframe to show its neighbour instead (the #1779 guarantee).
+  //
+  // Taking a pre-await snapshot means `next` can go STALE the other way, so pin what
+  // it assumes: this session, and no explicit layout/focus mutation since. A slow
+  // close leaves a wide window in which the user can select another tab, and
+  // re-pointing the pane from an index computed against the old selection would yank
+  // it back (the same stale-async hazard the #1777 scroll-fill token guards). The
+  // roster event races the same window but bumps no generation, so it still passes.
+  const cur = store.get().activeTab;
+  const gen = splitView.layoutGeneration();
   void closeTab(selId, sel.title, target.name, tok)
     .then(() => fetchSnapshot(tok))
     .then((sessions) => {
       // The close shifts every higher tab down by one: if the closed tab was at or
       // before the active one, the active index moves left to keep showing the same
       // tab (or its left neighbor when the active tab itself was closed).
-      const cur = store.get().activeTab;
       const shrunk = sessions.find((s) => s.id === selId);
       const n = shrunk ? sessionTabs(shrunk).length : 1;
       const next = Math.min(Math.max(index <= cur ? cur - 1 : cur, 0), n - 1);
       // Commit the shrunk tab list first (rerender → syncSplit re-validates the tree,
-      // clamping any pane past the new end), then re-point the focused pane.
+      // clamping any pane past the new end), then re-point the focused pane — but only
+      // if `next` still describes anything real: the user must not have moved focus or
+      // switched away to another session while the close was in flight.
       store.set({ sessions, selectedId: pickSelection(sessions, store.get().selectedId) });
-      splitView.setFocusedTab(next);
+      if (splitView.layoutGeneration() === gen && store.get().selectedId === selId) {
+        splitView.setFocusedTab(next);
+      }
     })
     .catch((e) => surfaceTabError(e));
 }

--- a/web/src/split.ts
+++ b/web/src/split.ts
@@ -130,6 +130,10 @@ export class SplitView {
   private tree: LayoutNode | null = null;
   private focusedId: string | null = null;
 
+  // Counts explicit layout/focus mutations, for the stale-async guard — see
+  // layoutGeneration(), which is the documented contract.
+  private layoutGen = 0;
+
   // Debounces the "focus left every pane" report so a click that moves focus A→B
   // (blur A, then focus B) doesn't flap the nav mode through rail and back.
   private blurTimer: number | null = null;
@@ -304,10 +308,28 @@ export class SplitView {
     this.lastPaneCount = 0;
   }
 
+  /** How many EXPLICIT layout/focus mutations have been committed — a tab rebind
+   *  (a 1-9 key or a tab-bar click), a drag-drop split, a pane close. Deliberately
+   *  NOT bumped by setSession's roster reconcile, which only remaps each pane to
+   *  follow its own tab and expresses no user intent.
+   *
+   *  That split is the point: an async caller which computes a tab index from a
+   *  PRE-await snapshot (see index.ts closeSessionTab) captures this first and
+   *  applies its result only if the value still matches. A slow close then can't
+   *  clobber a tab the user selected while it was in flight — their newer intent
+   *  wins — while the roster event that races the same close still passes the
+   *  guard, because it bumps nothing. */
+  layoutGeneration(): number {
+    return this.layoutGen;
+  }
+
   // --- internal: mutation commit --------------------------------------------
 
-  /** Persists the current tree for the session, re-renders, and reports the layout. */
+  /** Persists the current tree for the session, re-renders, and reports the layout.
+   *  Every explicit layout/focus mutation funnels through here, which is what makes
+   *  it the one place to count them (see layoutGeneration). */
   private commit(): void {
+    this.layoutGen++;
     if (this.sessionId && this.tree) {
       this.trees.set(this.sessionId, this.tree);
     }


### PR DESCRIPTION
Fixes #1812. Fixes #1818.

## The bug

`Manager.CreateTab`/`CloseTab` persisted the tab roster but announced nothing on
the events plane. The web client never polls — it is purely event-driven, and
only re-Snapshots after its **own** mutation — so a tab created by any other
actor (an agent running `af sessions tab-create` inside its own session, the
TUI, a script, a second browser window) never reached an open window. The roster
was repaired only as a **side-effect** of an unrelated `session.updated`, so on a
quiet session an open window stayed stale indefinitely.

That silently broke the web tab's stated purpose — from `tab-create --help`:
*"an agent injects a live browser view into the user's screen."* The agent
injected it; the user's screen didn't show it. The common agent pattern (create
the preview tab as the final act, then go idle) is exactly the case with no
follow-on activity to piggyback on.

**Repro verified before fixing:** the three new daemon tests fail on `master`
with `no session.updated event published within the deadline`.

## The fix

`CreateTab`/`CloseTab` publish `session.updated` carrying the refreshed
`InstanceData` after a successful persist.

The refreshed projection rides on the existing `session.updated` rather than a
new `tab.*` event type because `InstanceData` **already** carries the full `Tabs`
roster, and every client already re-projects the whole session from it (web's
`upsertSession`, the TUI's `ReconcileTabsFromData`). Issue #1812's own Repro B is
the proof: an unrelated `session.updated` *already* healed the roster, so the
client path works today and the daemon was the only broken half. This is also the
choke-point pattern `daemon/limit.go` already uses. A new event type would have
needed an `agentproto` const plus client handling in the web SPA and the TUI —
more surface, more conflict with #1805, no benefit.

Publish placement: **after** the persist, so no client can observe a tab that
isn't durable yet (and the `CreateTab` rollback path returns before publishing);
still **under** the repo start lock, so concurrent tab mutations announce in the
order they persisted. `publishEvent` is non-blocking (drop-slow), so a wedged
subscriber can't stall a daemon mutation.

## Scope

`CreateTab`/`CloseTab` are the **only** daemon-side tab-set mutations —
`AddWebTab`/`AddShellTab`/`AddProcessTab` are reached solely through `CreateTab`,
and `DropClosedTab`/`AttachShellTab` are TUI-local. A web tab's URL is immutable
once created (no `SetWebTabURL` surface), so there is no third mutation to cover.

**The TUI was already fine** — verified, not assumed: it polls Snapshot every
750ms (`app/sync.go:102`) and reconciles through `ReconcileTabsFromData`, whose
existing comment already covers "an out-of-band tab removal (another client, `af
sessions tab-delete`, daemon-side)". That is why #1812 is web-only. No TUI change
needed; `tui-driver-selftest` confirms no regression.

## Tests

- `daemon/tab_event_test.go` (new) — with a subscriber connected: `CreateTab`
  (**web** and **process** kinds) and `CloseTab` each publish `session.updated`
  whose roster contains/omits the tab, and a fresh `Snapshot` agrees. All three
  fail on `master`, pass here.
- `web/selftest/web-driver.spec.ts` — with the SPA open, a tab is created and
  then deleted **out-of-band via the real `af` CLI** (the control socket, not the
  HTTP API the SPA uses — so this also proves the event reaches the browser
  whichever transport drove the change). The tab appears and disappears live. The
  test stamps `window.__af1812` and asserts it survives, so "**without a reload**"
  is a checked claim rather than an assumption.
- `web/selftest/web-driver.spec.ts` — the review guard: `CloseTab` is **held open**
  (so the mid-flight window is deterministic, not a race against a fast local
  daemon), the user selects another tab while it is pending, and the close is then
  released. The user's selection must survive.

## The client bug the event exposed

Publishing the event surfaced a latent bug in `closeSessionTab`, caught by
#1805's own `#1779` selftest (which **fails on this branch without the second
fix, and passes on pristine master** — I ran the baseline to attribute it rather
than assume):

It hand-compensates for a close shifting higher tabs down, and read `activeTab`
**after** its `await`s. That was only safe while the client's own resync was the
sole roster updater. With the event landing first, `remapByIdentity` has already
followed each pane to its tab and written the shifted index back — so
subtracting the shift again re-pointed the pane one tab too far left, tearing
down a surviving web tab's iframe to show its neighbour (`iframe count: 0`) and
breaking the #1779 "followed, not remounted" guarantee.

The index is now read **before** the close — the value the relative computation
was always meant to use, and a no-op when no event arrives (so master's
semantics are unchanged). `createSessionTab` needed no change: it derives its
index absolutely from the fresh snapshot, so it was already immune.

The own-mutation resync is deliberately **kept**: it selects+attaches the new tab
synchronously, which needs the tab in hand rather than an event round-trip later.
`web/src/index.ts:564` also asserted outright that "the daemon emits no event for
a tab change" — now false, so the comment is corrected.

This is worth flagging for review: the daemon half is trivially correct, but the
class of bug it exposes is *"client code that assumes it is the only actor
mutating tabs"* — which is precisely what #1812 is about. `closeSessionTab` was
the only such site I found.

### The stale-async race in that same fix (Codex review, #1815)

Moving the read *before* the awaits fixed the double-shift but introduced the
mirror-image staleness Codex caught: if the close RPC is slow and the user picks
another tab while it is in flight, `next` — computed against the *old* selection —
would yank the pane back. (The original post-await read had the opposite bug: it
handled this case and broke on the event. Both must hold at once.)

So the post-await adjustment is now guarded by a **layout generation**
(`SplitView.layoutGeneration()`), plus a check that we are still on the same
session (a mid-close session switch would otherwise apply `next` to the wrong
session's pane).

The generation is bumped in `SplitView.commit()` — the single choke point every
**explicit** layout/focus mutation funnels through (tab rebind via click/1-9,
drag-drop split, pane close) — and **never** by `setSession`'s roster reconcile,
which only remaps panes to follow their own tabs and expresses no user intent.
That is what makes the guard discriminate correctly: a newer user selection bails
the stale index, while the roster event racing the same window still passes (it
bumps nothing), so the #1779 fix above keeps working. No false bails.

**Proven, not assumed** — I ran a negative control with the guard removed:

```
✘ 33 › #1812 review: a close held in flight must not clobber a tab the user picks meanwhile
    Expected: "Agent"
    Received: "keeper"     <-- the stale index snapped the pane back
  32 passed
```

Exactly one test fails without the guard and 33/33 pass with it, so the test
isolates this bug and nothing else.

## The harness flake this feature's blast radius exposed (#1818)

The URL-less web-tab selftest injected its subject by **rewriting the Snapshot in
the browser** — patching ONE plane while the events plane kept publishing the real
roster. `upsertSession` replaces a session record wholesale, so any
`session.updated` (which tab changes now emit) deleted the injected tab mid-test.
An intermittent, entirely fictional failure — it cost me a full
investigate-and-attribute cycle to rule out as a real web-pane bug.

**Seeded for real instead.** Note the tab cannot be created via the API/CLI:
`CreateTab`, `NormalizeWebTabURL` and `AddWebTab` all refuse an empty target, and
weakening a real user-facing validation to let a test in would be the wrong trade.
But the thing being simulated is a **malformed/older record**, so the harness now
writes exactly that — `url` is `omitempty`, so a tab record with no `url` field is
the legacy shape, and `restoreLocalTabs` backfills its stable id — straight into
the daemon's own store, then restarts the daemon to load it.

The daemon now serves the tab on **both** planes, so the Snapshot and every
`session.updated` agree. The test drops its route and both reloads: no mock, no
reload, no sleep, no retry — the divergence that caused the race is gone rather
than papered over. It also buys real coverage the mock never had: the daemon
faithfully round-tripping a legacy record through `restoreLocalTabs`.

Mechanics: the daemon is the single writer of `instances.json` (#960), so it is
stopped before the file is touched and restarted after; `wait` blocks on the real
exit rather than sleeping. The restart happens at a quiescent point (all seeding
done, Playwright not started), so it cannot race session creation the way the
auto-update restart once did (#1596). `start_daemon`/`wait_for_listener` are
factored out so the restart reuses the exact readiness poll instead of a second,
drifting copy.

**The #1779 test is now the proof the flake is dead:** its surviving-tab count
moves 2 → 3 (the seeded tab is part of probe-web's real roster), and its close
emits a `session.updated` for probe-web — the very event that used to wipe the
injected tab — which the seeded tab now survives. `external` still shifts 2 → 1,
which is what that test turns on.

## Out of scope

#1810 (ordinal-keyed iframe `src` re-minting on a roster re-render) is filed
separately and owned by #1805's stable-id work.

## Gates

All green, re-run **after** rebasing onto master (#1805 landed mid-run and
touches the same `index.ts`/spec, so the earlier greens were re-verified rather
than trusted):

| Gate | Result |
| --- | --- |
| `make test-container` | green, all packages |
| `make web-selftest-container` | **33/33** (incl. #1779 and both new #1812 tests) |
| `make web-test` | 143/143 + typecheck |
| `make tui-driver-selftest` | 31/31 steps green (the baseline has grown past 25) |
| `go build ./...` / `gofmt -l .` | clean |
| `golangci-lint run --fast` / `deadcode -test ./...` | clean |
| `scripts/lint-file-length.sh` | clean |
| `web/dist` | rebuilt and committed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
