### PR TITLE
fix(tui-driver): af_hide_pane false timeout on multi-pane hide (#1822) + af_reset_sandbox leaves task state behind (#1824)

### DIFF
--- a/scripts/tui-driver-selftest.sh
+++ b/scripts/tui-driver-selftest.sh
@@ -107,6 +107,65 @@ _enter_interactive_and_probe_literal_send() {
     sleep "$AF_DRIVER_POLL"
 }
 
+# _expect_multipane_hide — regression proof for #1822. Hiding a pane while
+# ANOTHER pane is still open advances focus to the pane that takes its slot, NOT
+# back to the tree; af_hide_pane waited for the tree menu (`n new`) and so
+# false-timed-out on the first `x` of every multi-pane flow even though the pane
+# was hidden correctly.
+#
+# The multi-pane state needs no wide terminal: below MultiPaneMinWidth (110
+# cols) only ONE pane is visible at a time, so at the driver's default 100x30
+# the second pane is merely auto-hidden — still open, and it takes focus on the
+# next `x`. Two af_open_pane calls reach that state deterministically (the `S`
+# split verb in the #1822 report is just one of several ways in; it additionally
+# depends on a live preview transaction, so it is the wrong lever for a
+# regression gate).
+#
+# Both flows are proven here: hide #1 is the multi-pane case (a pane remains),
+# hide #2 is the single-pane case (the workspace empties and the tree takes
+# focus back).
+# shellcheck disable=SC2317  # dispatched indirectly via step(); not dead code.
+_expect_multipane_hide() {
+    af_select alpha || return 1
+    af_open_pane || return 1
+    af_select beta || return 1
+    af_open_pane || return 1
+
+    # #1822 proper: a pane remains, so focus advances to it.
+    af_hide_pane || return 1
+    # Assert the PREMISE actually held — a pane is still focused. If the tree
+    # menu is up here, only one pane was open and this step would be silently
+    # re-testing the single-pane path that already worked.
+    if af_capture | grep -qE 'n new'; then
+        _af_log "#1822: tree menu is up after hiding one of TWO panes — premise broken"
+        return 1
+    fi
+
+    # Single-pane case: the last pane leaves, focus returns to the tree.
+    af_hide_pane || return 1
+    af_assert_screen 'n new' 'focus back on the tree after the last pane is hidden' || return 1
+}
+
+# _expect_hide_pane_rejects_tree_focus — the NEGATIVE check for af_hide_pane
+# (cf. _expect_resize_rejected). With focus on the TREE, `x` is a no-op — and
+# the old tree-menu marker was ALREADY satisfied, so af_hide_pane returned 0 and
+# reported success for a hide that never happened. It must now fail. A short
+# AF_DRIVER_TIMEOUT keeps the negative probe from burning the full 25s.
+# shellcheck disable=SC2317  # dispatched indirectly via step(); not dead code.
+_expect_hide_pane_rejects_tree_focus() {
+    local saved="$AF_DRIVER_TIMEOUT" rc=0
+    af_ensure_nav
+    af_focus_tree || return 1
+    AF_DRIVER_TIMEOUT=3
+    af_hide_pane >/dev/null 2>&1 || rc=$?
+    AF_DRIVER_TIMEOUT="$saved"
+    if [ "$rc" -eq 0 ]; then
+        _af_log "af_hide_pane wrongly SUCCEEDED with focus on the tree (no pane to hide)"
+        return 1
+    fi
+    return 0
+}
+
 # _expect_pane_text_not_counted_as_tabs — regression proof for the #1561
 # review finding. _af_tab_count must count sidebar tab rows (including
 # custom-named ones) but MUST NOT count tree-like text a shell prints inside a
@@ -246,6 +305,11 @@ step "detach (and prove the attach client was reaped)"      af_detach
 step "assert selection survived attach/detach"              af_expect_selected beta
 step "assert no orphan tmux attach clients"                 af_assert_no_orphan_clients
 step "pane text must not inflate the tab count (#1561 review)" _expect_pane_text_not_counted_as_tabs
+
+# --- #1822 regression: af_hide_pane across the multi-pane and single-pane flows ---
+# Runs last: it deliberately ends with an empty workspace.
+step "hide a pane while another remains, then the last (#1822)" _expect_multipane_hide
+step "af_hide_pane fails loudly with no pane focused (#1822)"  _expect_hide_pane_rejects_tree_focus
 
 printf '\n=== SELF-TEST PASSED — %d/%d steps green ===\n' "$PASS" "$PASS"
 printf 'the #1156 mis-drive is now a deterministic scenario.\n'

--- a/scripts/tui-driver.sh
+++ b/scripts/tui-driver.sh
@@ -262,14 +262,15 @@ af_focus_tree() {
 # Scenario helpers — each encodes the nav/interactive model and self-syncs.
 # ----------------------------------------------------------------------------
 
-# af_reset_sandbox — return the sandbox to a clean, instance-free state so a
-# scenario is deterministic across reruns in a REUSED container (the self-test
-# calls this first). Strictly scoped to the container's own sandbox: it stops
-# the sandbox daemon, kills the af_* instance sessions on THIS
-# container-private tmux server, and wipes the instance store. It never
-# touches the driver's own session and NEVER runs kill-server. Fails closed if
-# AGENT_FACTORY_HOME does not look like a sandbox path, so it can never wipe a
-# real ~/.agent-factory.
+# af_reset_sandbox — return the sandbox to a clean, instance- AND task-free
+# state so a scenario is deterministic across reruns in a REUSED container (the
+# self-test calls this first). Strictly scoped to the container's own sandbox:
+# it stops the sandbox daemon, kills the af_* instance sessions on THIS
+# container-private tmux server, and wipes the session/task state the same way
+# `af reset` defines it (see the rm block below). It never touches the driver's
+# own session and NEVER runs kill-server. Fails closed if AGENT_FACTORY_HOME
+# does not look like a sandbox path, so it can never wipe a real
+# ~/.agent-factory.
 # _af_is_throwaway_sandbox <dir> — POSITIVE proof a path is a disposable driver
 # sandbox before any destructive cleanup runs against it. Fails CLOSED: a real
 # dev checkout (any repo with a remote), or any path missing the scaffolding's
@@ -305,9 +306,38 @@ af_reset_sandbox() {
     for s in $(tmux list-sessions -F '#{session_name}' 2>/dev/null | grep '^af_' || true); do
         tmux kill-session -t "$s" 2>/dev/null || true
     done
-    rm -rf "$AGENT_FACTORY_HOME/instances" 2>/dev/null || true
+    # Session + task state under the sandbox AF home.
+    #
+    # This mirrors `af reset`'s resetWipePaths (commands/reset.go) — the
+    # canonical split between session/task STATE (wiped) and CONFIGURATION
+    # (kept: config.toml, repos/, daemon-token) — plus the daemon runtime files
+    # the sandbox reset owns. `af reset` deliberately preserves daemon.pid/sock
+    # and the token so an already-configured daemon keeps its identity; a
+    # throwaway sandbox has no identity worth keeping, and we just killed its
+    # daemon, so those go too.
+    #
+    # This list used to be just instances/ + state.json, which made the reset a
+    # HALF reset: tasks.json survived it (#1824). The self-test seeds
+    # `selftest-task`, so a REUSED container's second run found that task
+    # already present, `m` dropped into the EDIT form instead of the create
+    # form (#1249/#1757), and af_add_task typed into the existing task and
+    # failed at "seed a task via the create form". One surviving state file is
+    # enough to make a "reset" sandbox non-deterministic — so reset what
+    # `af reset` resets, and keep the two definitions in step.
+    #
+    # The *.lock files (tasks.json.lock, config.toml.lock, daemon-token.lock)
+    # are deliberately kept: they are content-free flock sentinels, they carry
+    # no state that can bleed into the next run, and unlinking one out from
+    # under a starting daemon breaks the lock's mutual exclusion.
+    rm -rf "$AGENT_FACTORY_HOME/instances" \
+           "$AGENT_FACTORY_HOME/worktrees" \
+           "$AGENT_FACTORY_HOME/events" \
+           "$AGENT_FACTORY_HOME/logs" \
+           "$AGENT_FACTORY_HOME/locks" 2>/dev/null || true
     rm -f "$AGENT_FACTORY_HOME/daemon.pid" "$AGENT_FACTORY_HOME/daemon.sock" \
-          "$AGENT_FACTORY_HOME/state.json" 2>/dev/null || true
+          "$AGENT_FACTORY_HOME/state.json" \
+          "$AGENT_FACTORY_HOME/tui-state.json" \
+          "$AGENT_FACTORY_HOME/tasks.json" 2>/dev/null || true
     # Remove leftover instance worktrees + branches in the mock repo, else a
     # re-created instance of the same name collides on the existing branch.
     # DESTRUCTIVE (rm -rf glob + `branch -D` every non-master ref): fail CLOSED,

--- a/scripts/tui-driver.sh
+++ b/scripts/tui-driver.sh
@@ -444,12 +444,65 @@ af_open_pane() {
     af_wait_for 'hide pane' "$AF_DRIVER_TIMEOUT" 'pane opened/focused' || return 1
 }
 
+# _af_pane_header_row — the one screen line that renders EVERY visible pane's
+# identity, or "" when the workspace draws no pane box.
+#
+# Panes are laid out side by side in a SINGLE horizontal row (ui/layout/grid.go
+# Solve), and each pane's frame puts its ` <title> · <tab> ` header on the
+# first line inside the frame — so all visible pane headers share one screen
+# row, immediately below the workspace box's top border. Anchoring on that
+# border (the first `╭` on screen — the sidebar has no left border, so the
+# workspace box owns the first one) and taking the NEXT line yields the whole
+# visible-pane identity set in one string.
+#
+# `╭` is matched as a literal, not a bracket expression: the sandbox runs a
+# C/POSIX locale where a bracket expression would match only the first byte of
+# the 3-byte glyph (cf. _af_tab_count's `(├|└)` alternation note).
+_af_pane_header_row() {
+    af_capture | awk '/╭/ { if ((getline line) > 0) print line; exit }'
+}
+
 # af_hide_pane — hide the focused pane back to the background (nothing is
-# killed). Precondition: a pane is focused. Syncs on focus returning to the
-# tree (`n new`).
+# killed). Precondition: a pane is focused. Syncs on the visible-pane set
+# CHANGING, captured via the pane header row.
+#
+# It used to wait for the tree menu (`n new`), i.e. it assumed hiding a pane
+# always hands focus back to the tree. It does not: hidePane (app/handle_panes.go)
+# lands focus on the pane that takes the hidden one's slot and only falls back
+# to the tree when the LAST pane goes away. So in any multi-pane flow the first
+# `x` hid the pane correctly, focus advanced to the remaining pane, `n new`
+# never appeared, and the driver reported a false TIMEOUT failure (#1822).
+# Multi-pane is not exotic: below MultiPaneMinWidth (110 cols) only one pane is
+# visible at a time, so at the driver's default 100x30 a second open pane is
+# merely auto-hidden — still open, and it takes focus on the next `x`.
+#
+# Waiting for "the tree menu OR the pane menu" would be worse than useless: the
+# pane menu is ALREADY on screen before `x`, so the wait would return on the
+# first poll and pass even if `x` did nothing.
+#
+# The header row is the right marker because hiding the focused pane ALWAYS
+# mutates the visible pane set — another pane takes the slot (its header
+# replaces the hidden one's) or the workspace empties (the row goes blank) —
+# and it is menu-independent, which matters: `x hide pane` is in the menu's
+# hintDropOrder and disappears on narrow terminals, so any marker built on it
+# would false-FAIL exactly where the layout is tightest, whereas `n new` alone
+# false-FAILS whenever a pane remains.
+#
+# It also closes a false PASS the old marker had: with focus on the TREE, `x`
+# is a no-op and `n new` was already showing, so af_hide_pane returned 0
+# immediately and reported success for a hide that never happened. The header
+# row is unchanged in that case, so the call now fails.
 af_hide_pane() {
+    local before; before="$(_af_pane_header_row)"
     af_send x
-    af_wait_for 'n new' "$AF_DRIVER_TIMEOUT" 'pane hidden' || return 1
+    local deadline; deadline=$(( $(_af_now) + AF_DRIVER_TIMEOUT ))
+    while [ "$(_af_pane_header_row)" = "$before" ]; do
+        if [ "$(_af_now)" -ge "$deadline" ]; then
+            _af_fail "pane not hidden (pane header row still '$before'); is a pane focused?"
+            return 1
+        fi
+        sleep "$AF_DRIVER_POLL"
+    done
 }
 
 # af_enter_interactive — enter the focused pane: every subsequent key forwards


### PR DESCRIPTION
Fixes #1822. Fixes #1824.

Two harness-reliability bugs in `scripts/tui-driver.sh`, both of which made the driver lie about what happened.

---

## 1. `af_hide_pane` falsely times out when another pane remains (#1822)

`af_hide_pane` sent `x` and waited for the **tree menu** (`n new`) — it assumed hiding a pane always hands focus back to the instances tree.

It doesn't. `hidePane()` (app/handle_panes.go) lands focus on the pane that takes the hidden one's slot, and only falls back to the tree when the **last** pane goes away:

```go
if pos >= 0 && len(m.visiblePanes) > 0 {
    focusedAfter = m.visiblePanes[pos]
    m.ring.Focus(layout.PaneRegion(focusedAfter.ID()))
} else {
    m.ring.Focus(layout.RegionTree)   // only when nothing remains
}
```

So in any multi-pane flow the first `x` hid the pane correctly, focus advanced to the remaining pane, `n new` never appeared, and the driver reported `TIMEOUT 25s waiting for: pane hidden` for a hide that had **already succeeded**.

Captured in the sandbox, before the fix — the menu is *still* the pane menu after `x`:

```text
before x : │ beta · Agent                          │   ↵ interact │ … │ x hide pane │ …
after  x : │ alpha · Agent · selected: beta · Agent │   ↵ interact │ … │ x hide pane │ …   <- no `n new` -> false TIMEOUT
after  xx: │                                        │   n new • D kill • …                <- tree, finally
```

Multi-pane is **not** exotic: below `MultiPaneMinWidth` (110 cols) only one pane is visible at a time, so at the driver's default 100x30 a second open pane is merely *auto-hidden* — still open, and it takes focus on the next `x`.

### Fix

Sync on the **visible-pane set changing**, read off the pane header row. Panes lay out side by side in a single row and each renders `<title> · <tab>` on the first line inside its frame, so one screen line carries every visible pane's identity. Hiding the focused pane always mutates that row — another pane's header takes the slot, or the workspace empties — so one marker covers both flows.

Two alternatives were rejected:

- **"tree menu OR pane menu"** is worse than useless: the pane menu is *already* on screen before `x`, so the wait returns on the first poll and passes even when `x` does nothing.
- **Any marker built on `x hide pane`** is width-dependent — that hint sits in the menu's `hintDropOrder` and disappears on narrow terminals, so it would false-FAIL exactly where the layout is tightest. The header row needs no menu at all.

The naive reading of "success = the pane count decreased" does **not** work either: at the driver's default width only one pane is ever visible, so the count goes 1 → 1 when a hidden pane swaps in. And "the hidden pane's name is gone" fails too — the surviving pane's header embeds the hidden pane's name as a `selected:` hint (see the capture above). The header-row diff handles both.

### Bonus: a false PASS in the same helper

With focus on the **tree**, `x` is a no-op and `n new` was *already* showing — so `af_hide_pane` returned 0 immediately and reported success for a hide that never happened. The header row is unchanged in that case, so the call now fails. Covered by a negative selftest step (cf. `_expect_resize_rejected`).

---

## 2. `af_reset_sandbox` leaves task state behind (#1824)

`af_reset_sandbox` wiped `instances/` + `state.json` and stopped, so it was a **half** reset — `tasks.json` survived it. The selftest seeds `selftest-task`, so a **reused** container's second run found that task already present, `m` dropped into the **edit** form instead of the create form, and `af_add_task` typed into the existing task:

```text
>>> seed a task via the create form
    │  Edit Task 19e16334                       │
    │  Name:    > selftest-taskn             …  │   <- typed into the EXISTING task
    ✗ FAILED: seed a task via the create form
```

`testbox.sh` documents the opposite ("a pinned reused container stays deterministic"), so the pinned `AF_SELFTEST_NAME` workflow was quietly broken. The default ephemeral path builds a fresh container per run and was unaffected.

### Fix

`tasks.json` was **one of six** survivors, not the whole bug. `af reset` already owns the canonical split between session/task *state* and *configuration* (`commands/reset.go` `resetWipePaths`), and the sandbox reset was missing most of the state half:

| state | `af reset` wipes | `af_reset_sandbox` before |
|---|---|---|
| `tasks.json`, `events/`, `logs/`, `locks/` | yes | **none of it** |
| `instances/`, `state.json` | yes | yes |
| `tui-state.json`, `worktrees/` | yes | **neither** |

Adding only the one filename that happened to bite would have left the same gotcha class live, so the reset now **mirrors `resetWipePaths` and cites it** — the two definitions can drift apart only deliberately.

Deliberate carve-outs:
- **Configuration stays preserved** exactly as `af reset` preserves it (`config.toml`, `repos/`, `daemon-token`).
- **`daemon.pid`/`daemon.sock` are still removed** — `af reset` keeps them so a configured daemon retains its identity; a throwaway sandbox has none worth keeping and its daemon was just killed.
- **`*.lock` flock sentinels are kept** — content-free, so they cannot bleed into the next run, and unlinking one out from under a starting daemon would break the lock's mutual exclusion.
- The **fail-closed `AGENT_FACTORY_HOME` sandbox-path guard is untouched** and still precedes every `rm`, so this can never reach a real `~/.agent-factory`.

---

## Gate

- `make tui-driver-selftest` → **33/33 green** (31 baseline + 2 new steps).
- **Both new steps were verified to FAIL against the old helper** — real regression tests, not decoration.
- **#1824's exact repro**: two consecutive runs in ONE pinned container, both **33/33**, zero task bleed-through (previously run 2 died at step 16).
- #1822's literal `S`/`x` repro now passes in 0s (was a 25s false timeout); the single-pane flow still ends with focus on the tree.
- `shellcheck -x` clean. **No Go touched.**

The regression step reaches the two-open-pane state with two `af_open_pane` calls rather than the report's `S`: `S` additionally depends on a live preview transaction, which makes it the wrong lever for a deterministic gate. The `S` flow is verified separately (above) and exercises the same `hidePane` path.

> Heads-up on the step count: the selftest is **31** steps on master, not 25 — so the gate reads 33/33 with the two new steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
