### PR TITLE
fix(ui): unify voice and glyphs across the TUI and web panes (#1826)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,3 +143,18 @@ new files to dodge the limit — split them. See `docs/file-length-lint.md`.
 - Keep PRs focused and small
 - Run `go build ./...` and `go test ./...` before submitting
 - Version is stored in `main.go` (`version` var) and auto-bumped by CI
+
+## Copy & glyph conventions
+
+Every user-facing surface (TUI, web, CLI help) follows these. New surfaces drift
+otherwise — see #1826.
+
+- **Sentence case** for titles, labels, buttons, and empty states ("Search
+  sessions", not "Search Sessions"). Proper nouns keep their case.
+- **`…`** in literal strings, never `...` ("Setting up workspace…").
+- **` · `** is the separator when joining fragments on one line; `—` sets off a
+  clause.
+- **No caps-shouting** for emphasis — write the emphasis into the sentence. CAPS
+  are reserved for env vars (`AF_HOME`) and literal flag/command names.
+- **No animated indicators** (spinners, blink, pulse) — state reads from a static
+  glyph (#1766).

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -223,7 +223,7 @@ func TestPanePreviewInvalidatesStaleContentSynchronously(t *testing.T) {
 
 	view := h.View()
 	assert.Contains(t, view, "PREVIEW beta · Agent (original alpha · Agent)")
-	assert.Contains(t, view, "Loading preview...")
+	assert.Contains(t, view, "Loading preview…")
 	assert.NotContains(t, view, "ALPHA_PREVIEW_CONTENT",
 		"retargeting preview must clear the original content before async beta capture returns")
 	assert.Same(t, alpha, paneA.Instance(), "preview must not mutate the committed pane binding")
@@ -276,7 +276,7 @@ func TestPanePreviewFastScrollLatestWins(t *testing.T) {
 	require.IsType(t, panesRefreshedMsg{}, refreshPaneBindingCmd(w, beta, 0, betaSeq)())
 	view := h.View()
 	assert.Contains(t, view, "PREVIEW gamma · Agent (original alpha · Agent)")
-	assert.Contains(t, view, "Loading preview...")
+	assert.Contains(t, view, "Loading preview…")
 	assert.NotContains(t, view, "BETA_PREVIEW_CONTENT",
 		"late beta capture must not overwrite the newer gamma preview target")
 

--- a/app/pane_preview.go
+++ b/app/pane_preview.go
@@ -109,7 +109,7 @@ func (m *home) updatePanePreview(selected *session.Instance, targetTab int, tabS
 		seq:         seq,
 	}
 	if changed {
-		w.InvalidateContent(target.instance, target.tab, "Loading preview...")
+		w.InvalidateContent(target.instance, target.tab, "Loading preview…")
 		m.lastPaneCapture[owner.ID()] = time.Time{}
 	}
 	return nil
@@ -125,7 +125,7 @@ func (m *home) cancelPanePreview(focusOwner bool) {
 	m.panePreviewTxn = nil
 	if w := m.paneWindows[txn.ownerPaneID]; w != nil {
 		w.ClearPreview()
-		w.InvalidateContent(txn.original.instance, txn.original.tab, "Loading pane...")
+		w.InvalidateContent(txn.original.instance, txn.original.tab, "Loading pane…")
 		m.lastPaneCapture[txn.ownerPaneID] = time.Time{}
 	}
 	if focusOwner {
@@ -201,7 +201,7 @@ func (m *home) commitPanePreviewReplace() (*store.OpenPane, tea.Cmd) {
 	m.panePreviewTxn = nil
 	if w != nil {
 		w.ClearPreview()
-		w.InvalidateContent(txn.target.instance, txn.target.tab, "Loading pane...")
+		w.InvalidateContent(txn.target.instance, txn.target.tab, "Loading pane…")
 	}
 	if !m.store.RebindOpenPane(owner, txn.target.instance, txn.target.tab) {
 		return nil, nil

--- a/app/tinyclip_overlay_test.go
+++ b/app/tinyclip_overlay_test.go
@@ -55,7 +55,7 @@ func TestTinyClipSearchOverlayFitsAtSmallSizes(t *testing.T) {
 			view := h.View()
 			requireViewSized(t, view, size[0], size[1])
 			plain := xansi.Strip(view)
-			assert.Contains(t, plain, "Search Sessions")
+			assert.Contains(t, plain, "Search sessions")
 			assert.Contains(t, plain, "gamma")
 			assert.Contains(t, plain, "esc close")
 		})

--- a/ui/caret.go
+++ b/ui/caret.go
@@ -1,0 +1,34 @@
+package ui
+
+import (
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+)
+
+// caretStyle draws the caret cell in reverse video, so it picks up the terminal's
+// own foreground/background rather than a hardcoded colour and stays legible under
+// every theme.
+var caretStyle = lipgloss.NewStyle().Reverse(true)
+
+// asciiCaret is the caret for terminals that render no SGR at all. A left half
+// block needs no styling to be visible, and the TUI already assumes this glyph
+// range elsewhere (the ● / ◌ / ○ / ◆ status icons).
+const asciiCaret = "▌"
+
+// InputCaret is the insertion point for the TUI's inline text inputs — the search
+// query, the project-picker path, and the hooks-pane command editor. Callers append
+// it after the styled text they have already rendered.
+//
+// It is a reverse-video cell rather than a literal "_" because an underscore is
+// indistinguishable from a typed one, and it is STATIC: no blink, per the
+// no-animation doctrine #1766 set for the status indicators. Either form is exactly
+// one cell wide, so the caret never shifts the text it trails.
+func InputCaret() string {
+	// termenv drops EVERY sequence — reverse included — under the Ascii profile
+	// (TERM=dumb, NO_COLOR), which would render the styled caret as a bare space:
+	// an invisible insertion point. Degrade to a glyph that stands on its own.
+	if lipgloss.ColorProfile() == termenv.Ascii {
+		return asciiCaret
+	}
+	return caretStyle.Render(" ")
+}

--- a/ui/caret_test.go
+++ b/ui/caret_test.go
@@ -1,0 +1,97 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+)
+
+// The caret is the reverse-video SGR (ESC[7m) wrapping a single cell. Asserting on
+// the sequence rather than a rendered glyph keeps the test honest about what makes
+// the caret visible in a terminal.
+const reverseVideoSGR = "\x1b[7m"
+
+// forceProfile pins the lipgloss colour profile for one test. Rendering is
+// profile-dependent (termenv emits no sequences under Ascii) and the profile is
+// process-wide, so it must be restored.
+func forceProfile(t *testing.T, p termenv.Profile) {
+	t.Helper()
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(p)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+}
+
+// TestInputCaretIsStaticReverseVideo covers #1826 item 7. The inline inputs used to
+// append a literal "_", which is indistinguishable from a typed underscore. The
+// replacement is a reverse-video cell — and it is STATIC: no blink, per the
+// no-animation doctrine of #1766.
+func TestInputCaretIsStaticReverseVideo(t *testing.T) {
+	forceProfile(t, termenv.TrueColor)
+
+	caret := InputCaret()
+	if !strings.Contains(caret, reverseVideoSGR) {
+		t.Errorf("want a reverse-video caret, got %q", caret)
+	}
+	if strings.Contains(caret, "_") {
+		t.Errorf("the literal underscore caret must be gone, got %q", caret)
+	}
+	// Same input, same output: nothing frame-dependent to animate it.
+	if InputCaret() != caret {
+		t.Error("InputCaret must be static; it rendered two different values")
+	}
+}
+
+// TestInputCaretVisibleWithoutColor guards the degradation. Under the Ascii profile
+// termenv emits no SGR at all, so a reverse-video space would collapse to a bare
+// space and the caret would silently vanish on a TERM=dumb / NO_COLOR terminal.
+func TestInputCaretVisibleWithoutColor(t *testing.T) {
+	forceProfile(t, termenv.Ascii)
+
+	if caret := InputCaret(); strings.TrimSpace(caret) == "" {
+		t.Errorf("the caret must stay visible without colour support, got %q", caret)
+	}
+}
+
+// TestInputCaretIsOneCell keeps the caret from shifting the text it trails, under
+// either profile.
+func TestInputCaretIsOneCell(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		profile termenv.Profile
+	}{
+		{"colour", termenv.TrueColor},
+		{"ascii", termenv.Ascii},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			forceProfile(t, tc.profile)
+			// lipgloss.Width measures rendered cells, discounting the SGR wrapper.
+			if w := lipgloss.Width(InputCaret()); w != 1 {
+				t.Errorf("want a 1-cell caret, got %d", w)
+			}
+		})
+	}
+}
+
+// TestHooksPaneRendersCaretNotUnderscore checks the caret reaches the hooks-pane
+// editor rather than only existing as a helper.
+func TestHooksPaneRendersCaretNotUnderscore(t *testing.T) {
+	forceProfile(t, termenv.TrueColor)
+
+	h := NewHooksPane()
+	// String() fits its block to the pane size; unsized it collapses to blank lines.
+	h.SetSize(60, 12)
+	h.SetCommands([]string{"make test"})
+	h.SetFocus(true)
+	h.editing = true
+	h.editBuffer = "make lint"
+
+	out := h.String()
+	if !strings.Contains(out, reverseVideoSGR) {
+		t.Errorf("want the edit line to carry a reverse-video caret, got %q", out)
+	}
+	if strings.Contains(out, "make lint_") {
+		t.Errorf("the edit buffer must not carry a literal _ caret, got %q", out)
+	}
+}

--- a/ui/err.go
+++ b/ui/err.go
@@ -52,7 +52,7 @@ func (e *ErrBox) String() string {
 }
 
 func (e *ErrBox) statusLine() string {
-	line := strings.Join(strings.Split(e.FullError(), "\n"), "//")
+	line := strings.Join(strings.Split(e.FullError(), "\n"), " · ")
 	if runewidth.StringWidth(line) <= e.width {
 		return line
 	}

--- a/ui/err_test.go
+++ b/ui/err_test.go
@@ -229,3 +229,23 @@ func stripANSI(s string) string {
 	}
 	return b.String()
 }
+
+// TestErrBoxJoinsMultiLineErrorsWithSeparator covers the #1826 voice sweep. A
+// multi-line error was flattened onto the status line with "//", which reads as a
+// commented-out fragment or a URL remnant rather than a break between two
+// sentences. " · " is the repo's separator glyph, already used by the pane header
+// and the web term meta.
+func TestErrBoxJoinsMultiLineErrorsWithSeparator(t *testing.T) {
+	e := NewErrBox()
+	// Wide enough that statusLine returns the joined line untruncated.
+	e.SetSize(120, 3)
+	e.SetError(errors.New("push failed\nremote rejected the branch"))
+
+	line := e.statusLine()
+	if !strings.Contains(line, "push failed · remote rejected the branch") {
+		t.Errorf("want the two lines joined by ' · ', got %q", line)
+	}
+	if strings.Contains(line, "//") {
+		t.Errorf("the // joiner must be gone, got %q", line)
+	}
+}

--- a/ui/hooks_pane.go
+++ b/ui/hooks_pane.go
@@ -175,7 +175,7 @@ func (h *HooksPane) String() string {
 	for i, cmd := range h.commands {
 		isSelected := i == h.selectedIdx
 		if h.editing && isSelected {
-			b.WriteString(editStyle.Render("▸ " + h.editBuffer + "_"))
+			b.WriteString(editStyle.Render("▸ "+h.editBuffer) + InputCaret())
 		} else if isSelected && h.hasFocus {
 			b.WriteString(selectedStyle.Render("▸ " + cmd))
 		} else {
@@ -185,7 +185,7 @@ func (h *HooksPane) String() string {
 	}
 
 	if h.adding {
-		b.WriteString(editStyle.Render("▸ " + h.editBuffer + "_"))
+		b.WriteString(editStyle.Render("▸ "+h.editBuffer) + InputCaret())
 		b.WriteString("\n")
 	}
 

--- a/ui/overlay/caret_test.go
+++ b/ui/overlay/caret_test.go
@@ -1,0 +1,72 @@
+package overlay
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+
+	"github.com/sachiniyer/agent-factory/ui"
+)
+
+// forceProfile pins the process-wide lipgloss colour profile for one test, so the
+// caret renders its styled form rather than the no-colour fallback.
+func forceProfile(t *testing.T, p termenv.Profile) {
+	t.Helper()
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(p)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+}
+
+// TestSearchOverlayRendersCaretNotUnderscore covers #1826 item 7 at the search
+// overlay: the query line trailed a literal "_", which read as a typed character.
+func TestSearchOverlayRendersCaretNotUnderscore(t *testing.T) {
+	forceProfile(t, termenv.TrueColor)
+
+	s := NewSearchOverlay(nil)
+	s.query = "gamma"
+
+	out := s.Render()
+	if !strings.Contains(out, ui.InputCaret()) {
+		t.Errorf("want the query line to carry the shared caret, got %q", out)
+	}
+	if strings.Contains(out, "gamma_") {
+		t.Errorf("the query must not carry a literal _ caret, got %q", out)
+	}
+}
+
+// TestProjectPickerRendersCaretNotUnderscore covers the same for the picker's
+// add-project path input.
+func TestProjectPickerRendersCaretNotUnderscore(t *testing.T) {
+	forceProfile(t, termenv.TrueColor)
+
+	p := NewProjectPickerOverlay(nil, "")
+	p.adding = true
+	p.pathInput = "/home/u/code/repo"
+
+	out := p.Render()
+	if !strings.Contains(out, ui.InputCaret()) {
+		t.Errorf("want the path line to carry the shared caret, got %q", out)
+	}
+	if strings.Contains(out, "repo_") {
+		t.Errorf("the path input must not carry a literal _ caret, got %q", out)
+	}
+}
+
+// The two overlays are the same KIND of input, so they must not drift apart again:
+// both take their caret from the one helper rather than open-coding a marker.
+func TestOverlayCaretsAreTheSameGlyph(t *testing.T) {
+	forceProfile(t, termenv.TrueColor)
+
+	s := NewSearchOverlay(nil)
+	s.query = "q"
+	p := NewProjectPickerOverlay(nil, "")
+	p.adding = true
+	p.pathInput = "q"
+
+	caret := ui.InputCaret()
+	if !strings.Contains(s.Render(), caret) || !strings.Contains(p.Render(), caret) {
+		t.Error("both overlays must render the shared ui.InputCaret")
+	}
+}

--- a/ui/overlay/projectPickerOverlay.go
+++ b/ui/overlay/projectPickerOverlay.go
@@ -219,12 +219,12 @@ func (p *ProjectPickerOverlay) Render() string {
 	cw := textRect.W
 
 	var lines []string
-	lines = append(lines, truncateOverlayLine(titleStyle.Render("Switch Project"), cw))
+	lines = append(lines, truncateOverlayLine(titleStyle.Render("Switch project"), cw))
 	lines = append(lines, "")
 
 	if p.adding {
 		lines = append(lines, truncateOverlayLine(normalStyle.Render("Add project — enter a repo path:"), cw))
-		lines = append(lines, truncateOverlayLine("  "+queryStyle.Render(p.pathInput+"_"), cw))
+		lines = append(lines, truncateOverlayLine("  "+queryStyle.Render(p.pathInput)+ui.InputCaret(), cw))
 		if p.addErr != "" {
 			lines = append(lines, truncateOverlayLine(errStyle.Render("  "+p.addErr), cw))
 		}
@@ -242,13 +242,13 @@ func (p *ProjectPickerOverlay) Render() string {
 	}
 	start, end := p.visibleWindow(avail)
 	if start > 0 {
-		lines = append(lines, truncateOverlayLine(normalStyle.Render(fmt.Sprintf("    ... %d more above", start)), cw))
+		lines = append(lines, truncateOverlayLine(normalStyle.Render(fmt.Sprintf("    … %d more above", start)), cw))
 	}
 	for i := start; i < end; i++ {
 		lines = append(lines, truncateOverlayLine(p.renderRow(i, selectedStyle, normalStyle, countStyle, addStyle), cw))
 	}
 	if end < p.rowCount() {
-		lines = append(lines, truncateOverlayLine(normalStyle.Render(fmt.Sprintf("    ... and %d more below", p.rowCount()-end)), cw))
+		lines = append(lines, truncateOverlayLine(normalStyle.Render(fmt.Sprintf("    … and %d more below", p.rowCount()-end)), cw))
 	}
 
 	lines = append(lines, "")

--- a/ui/overlay/searchOverlay.go
+++ b/ui/overlay/searchOverlay.go
@@ -311,18 +311,18 @@ func (s *SearchOverlay) Render() string {
 	plan := s.renderPlan(style)
 
 	var lines []string
-	lines = append(lines, truncateOverlayLine(titleStyle.Render("Search Sessions"), plan.contentWidth))
+	lines = append(lines, truncateOverlayLine(titleStyle.Render("Search sessions"), plan.contentWidth))
 	if !plan.compact {
 		lines = append(lines, "")
 	}
-	lines = append(lines, truncateOverlayLine("/ "+queryStyle.Render(s.query+"_"), plan.contentWidth))
+	lines = append(lines, truncateOverlayLine("/ "+queryStyle.Render(s.query)+ui.InputCaret(), plan.contentWidth))
 	if !plan.compact {
 		lines = append(lines, "")
 	}
 
 	if len(s.results) == 0 {
 		if s.query == "" {
-			lines = append(lines, truncateOverlayLine(normalStyle.Render("  type to search..."), plan.contentWidth))
+			lines = append(lines, truncateOverlayLine(normalStyle.Render("  type to search…"), plan.contentWidth))
 		} else {
 			lines = append(lines, truncateOverlayLine(normalStyle.Render("  no matches found"), plan.contentWidth))
 		}
@@ -330,7 +330,7 @@ func (s *SearchOverlay) Render() string {
 
 	if plan.showAbove {
 		lines = append(lines, truncateOverlayLine(normalStyle.Render(
-			fmt.Sprintf("    ... %d more above", plan.startIdx)), plan.contentWidth))
+			fmt.Sprintf("    … %d more above", plan.startIdx)), plan.contentWidth))
 	}
 
 	for i := plan.startIdx; i < plan.endIdx; i++ {
@@ -384,7 +384,7 @@ func (s *SearchOverlay) Render() string {
 	if plan.showBelow {
 		remaining := len(s.results) - plan.endIdx
 		lines = append(lines, truncateOverlayLine(normalStyle.Render(
-			fmt.Sprintf("    ... and %d more below", remaining)), plan.contentWidth))
+			fmt.Sprintf("    … and %d more below", remaining)), plan.contentWidth))
 	}
 
 	if !plan.compact {

--- a/ui/overlay/selectionOverlay.go
+++ b/ui/overlay/selectionOverlay.go
@@ -121,7 +121,7 @@ func (s *SelectionOverlay) Render() string {
 	}
 	start, end := selectionWindow(s.selectedIdx, len(s.items), availableItems)
 	if start > 0 {
-		lines = append(lines, truncateOverlayLine(normalStyle.Render("  ... more above"), textRect.W))
+		lines = append(lines, truncateOverlayLine(normalStyle.Render("  … more above"), textRect.W))
 	}
 	for i := start; i < end; i++ {
 		item := s.items[i]
@@ -132,7 +132,7 @@ func (s *SelectionOverlay) Render() string {
 		}
 	}
 	if end < len(s.items) {
-		lines = append(lines, truncateOverlayLine(normalStyle.Render("  ... more below"), textRect.W))
+		lines = append(lines, truncateOverlayLine(normalStyle.Render("  … more below"), textRect.W))
 	}
 
 	if !compact {

--- a/ui/preview_scroll_fallback_test.go
+++ b/ui/preview_scroll_fallback_test.go
@@ -44,7 +44,7 @@ func enterScrollWithStaleViewport(p *TabPane, inst *session.Instance) {
 }
 
 // TestPreviewScrollModeThenDeletingFallback: a same-instance Running → Deleting
-// transition while scrolling must show "Tearing down session...", not the
+// transition while scrolling must show "Tearing down session…", not the
 // stale viewport (#940 / #920).
 func TestPreviewScrollModeThenDeletingFallback(t *testing.T) {
 	log.Initialize(false)
@@ -71,7 +71,7 @@ func TestPreviewScrollModeThenDeletingFallback(t *testing.T) {
 		"stale viewport content must be cleared on fallback")
 
 	rendered := p.String()
-	require.Contains(t, rendered, "Tearing down session...",
+	require.Contains(t, rendered, "Tearing down session…",
 		"rendered frame must show the teardown fallback, not stale scroll content")
 	require.NotContains(t, rendered, staleScrollMarker,
 		"rendered frame must not be the stale viewport")
@@ -107,7 +107,7 @@ func TestPreviewScrollModeThenNilInstanceFallback(t *testing.T) {
 }
 
 // TestPreviewScrollModeThenLoadingFallback: a Loading instance while scrolling
-// must show "Setting up workspace...", not the stale viewport.
+// must show "Setting up workspace…", not the stale viewport.
 func TestPreviewScrollModeThenLoadingFallback(t *testing.T) {
 	log.Initialize(false)
 	defer log.Close()
@@ -131,7 +131,7 @@ func TestPreviewScrollModeThenLoadingFallback(t *testing.T) {
 	require.NotContains(t, p.viewport.View(), staleScrollMarker)
 
 	rendered := p.String()
-	require.Contains(t, rendered, "Setting up workspace...",
+	require.Contains(t, rendered, "Setting up workspace…",
 		"rendered frame must show the Loading fallback, not stale scroll content")
 	require.NotContains(t, rendered, staleScrollMarker)
 }
@@ -156,10 +156,10 @@ func TestPreviewScrollEntryDeletingShowsTeardownFallback(t *testing.T) {
 		"deleting agent tab must not enter empty scroll mode")
 	require.True(t, p.content.fallback,
 		"deleting agent tab must enter fallback state when scrolling starts")
-	require.Contains(t, p.content.text, "Tearing down session...")
+	require.Contains(t, p.content.text, "Tearing down session…")
 	require.NotContains(t, p.viewport.View(), scrollFooter(),
 		"scroll footer must not be the only visible content")
-	require.Contains(t, p.String(), "Tearing down session...",
+	require.Contains(t, p.String(), "Tearing down session…",
 		"rendered frame must show the teardown fallback")
 }
 

--- a/ui/preview_test.go
+++ b/ui/preview_test.go
@@ -530,7 +530,7 @@ func TestPreviewResetToNormalModeNilInstance(t *testing.T) {
 // {fallback:false, text:""} into previewState — Preview() returns empty
 // content while the workspace is still being set up — so the pane rendered
 // completely blank for at least one frame until the next async UpdateContent
-// tick. ResetToNormalMode must keep the same "Setting up workspace..."
+// tick. ResetToNormalMode must keep the same "Setting up workspace…"
 // fallback that UpdateContent shows for Loading instances.
 func TestPreviewResetToNormalModeLoadingShowsFallback(t *testing.T) {
 	log.Initialize(false)
@@ -557,9 +557,9 @@ func TestPreviewResetToNormalModeLoadingShowsFallback(t *testing.T) {
 		"isScrolling must be false after ResetToNormalMode")
 	require.True(t, p.content.fallback,
 		"exiting scroll mode on a Loading instance must keep the fallback state")
-	require.Contains(t, p.content.text, "Setting up workspace...",
+	require.Contains(t, p.content.text, "Setting up workspace…",
 		"fallback text must be the Loading message")
-	require.Contains(t, p.String(), "Setting up workspace...",
+	require.Contains(t, p.String(), "Setting up workspace…",
 		"rendered frame must show the Loading fallback, not a blank pane")
 }
 
@@ -570,7 +570,7 @@ func TestPreviewResetToNormalModeLoadingShowsFallback(t *testing.T) {
 // Preview() == ("", nil) and Started() == false — fell through to the generic
 // "Please enter a name for the instance." fallback. That message is misleading
 // during teardown and, for remote sessions, can persist for the whole 10-60s
-// delete. UpdateContent must show the "Tearing down session..." fallback for a
+// delete. UpdateContent must show the "Tearing down session…" fallback for a
 // Deleting instance instead.
 func TestPreviewUpdateContentDeletingShowsTeardownFallback(t *testing.T) {
 	log.Initialize(false)
@@ -595,11 +595,11 @@ func TestPreviewUpdateContentDeletingShowsTeardownFallback(t *testing.T) {
 
 	require.True(t, p.content.fallback,
 		"Deleting instance must render a fallback")
-	require.Contains(t, p.content.text, "Tearing down session...",
+	require.Contains(t, p.content.text, "Tearing down session…",
 		"Deleting instance must show the teardown fallback")
 	require.NotContains(t, p.content.text, "Please enter a name",
 		"Deleting instance must NOT show the not-started fallback (#920)")
-	require.Contains(t, p.String(), "Tearing down session...",
+	require.Contains(t, p.String(), "Tearing down session…",
 		"rendered frame must show the teardown fallback")
 }
 
@@ -904,7 +904,7 @@ func TestResetToNormalModeDoesNotClearFallbackFlag(t *testing.T) {
 	// fallback. setFallbackState is the production path that gets us into
 	// fallback==true; isScrolling/viewport mimic ScrollUp's side effects
 	// without depending on tmux capture-pane behavior here.
-	p.setFallbackState("Setting up workspace...")
+	p.setFallbackState("Setting up workspace…")
 	require.True(t, p.content.fallback,
 		"precondition: fallback should be true after setFallbackState")
 	p.isScrolling = true

--- a/ui/tab_pane.go
+++ b/ui/tab_pane.go
@@ -287,14 +287,14 @@ func (p *TabPane) updateAgent(instance *session.Instance, guard contentGuard) er
 		p.mu.Unlock()
 		return nil
 	case instance.IsCreating():
-		p.setFallbackState("Setting up workspace...")
+		p.setFallbackState("Setting up workspace…")
 		p.mu.Unlock()
 		return nil
 	case instance.IsTearingDown():
 		// Mirror the creating case for a teardown op (#920/#1195): during
 		// teardown Preview() returns ("", nil) and Started()==false, so without
 		// this the generic name fallback below would claim throughout the delete.
-		p.setFallbackState("Tearing down session...")
+		p.setFallbackState("Tearing down session…")
 		p.mu.Unlock()
 		return nil
 	case instance.GetLiveness() == session.LiveDead:
@@ -399,7 +399,7 @@ func (p *TabPane) updateAgent(instance *session.Instance, guard contentGuard) er
 // cannot render: the target URL plus a pointer to where it can be viewed. Shared
 // by updateShell and enterScrollModeLocked so the two never diverge.
 func webTabPlaceholder(url string) string {
-	return fmt.Sprintf("%s\n\nweb tab — view in the web UI or open in a browser", url)
+	return fmt.Sprintf("%s\n\nWeb tab — view in the web UI or open in a browser", url)
 }
 
 // updateShell reproduces the former TerminalPane.UpdateContent for the
@@ -420,7 +420,7 @@ func (p *TabPane) updateShell(instance *session.Instance, activeTab int, guard c
 	// this it would fall through to the "not started yet" fallback — misleading
 	// while the session is going away (#920/#1195).
 	if instance.IsTearingDown() {
-		p.setFallbackState("Tearing down session...")
+		p.setFallbackState("Tearing down session…")
 		p.mu.Unlock()
 		return nil
 	}
@@ -634,7 +634,7 @@ func (p *TabPane) ScrollDown(instance *session.Instance, activeTab int) error {
 // must hold p.mu. Validation uses in-memory state only, never I/O.
 func (p *TabPane) enterScrollModeLocked(instance *session.Instance, activeTab int) error {
 	if instance.IsTearingDown() {
-		p.setFallbackState("Tearing down session...")
+		p.setFallbackState("Tearing down session…")
 		return nil
 	}
 	// A web tab has no scrollback (no PTY): keep the placeholder rather than
@@ -703,9 +703,9 @@ func (p *TabPane) ResetToNormalMode(instance *session.Instance, activeTab int) e
 	// through to its live screen rather than a fallback.
 	switch {
 	case instance.IsCreating():
-		p.setFallbackState("Setting up workspace...")
+		p.setFallbackState("Setting up workspace…")
 	case instance.IsTearingDown():
-		p.setFallbackState("Tearing down session...")
+		p.setFallbackState("Tearing down session…")
 	case instance.GetLiveness() == session.LiveDead:
 		p.setFallbackState("Session no longer running.")
 	case instance.GetLiveness() == session.LiveLost:

--- a/ui/tabbed_window_test.go
+++ b/ui/tabbed_window_test.go
@@ -84,7 +84,7 @@ func TestTabbedWindowResetPreviewScrollUsesCommittedBinding(t *testing.T) {
 	require.True(t, w.JumpToTab(1), "precondition: original pane is alpha's terminal tab")
 
 	w.SetPreview(beta, 0, "alpha · Terminal")
-	w.InvalidateContent(beta, 0, "Loading preview...")
+	w.InvalidateContent(beta, 0, "Loading preview…")
 	w.ScrollUp()
 	require.True(t, w.IsInScrollMode(), "precondition: preview target is scrolled")
 

--- a/ui/task_pane_edit.go
+++ b/ui/task_pane_edit.go
@@ -261,7 +261,7 @@ func (s *TaskPane) renderEditMode() string {
 	if s.editTriggerIsWatch {
 		s.editPrompt.Placeholder = "(optional) {{line}} expands to the event line"
 	} else {
-		s.editPrompt.Placeholder = "Enter task prompt..."
+		s.editPrompt.Placeholder = "Enter task prompt…"
 	}
 
 	label := func(text string) string {

--- a/ui/terminal_test.go
+++ b/ui/terminal_test.go
@@ -155,7 +155,7 @@ func TestTabPaneShellFallbackStates(t *testing.T) {
 	})
 
 	// #920: a Deleting instance reports Started()==false during teardown. It
-	// must show "Tearing down session..." rather than the not-started fallback.
+	// must show "Tearing down session…" rather than the not-started fallback.
 	t.Run("deleting instance", func(t *testing.T) {
 		inst, err := session.NewInstance(session.InstanceOptions{
 			Title: "deleting", Path: t.TempDir(), Program: "bash",
@@ -167,7 +167,7 @@ func TestTabPaneShellFallbackStates(t *testing.T) {
 		require.NoError(t, p.UpdateContent(inst, 1))
 		p.mu.Lock()
 		require.True(t, p.content.fallback)
-		require.Contains(t, p.content.text, "Tearing down session...")
+		require.Contains(t, p.content.text, "Tearing down session…")
 		require.NotContains(t, p.content.text, "not started",
 			"deleting instance must NOT show the not-started fallback (#920)")
 		p.mu.Unlock()

--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -951,18 +951,15 @@ body {
   border-bottom: 1px solid var(--af-border-subtle);
   font-size: var(--af-fs-sm);
 }
-.af-webpane-reload {
+.af-webpane-reload,
+.af-webpane-open {
   flex: 0 0 auto;
-  cursor: pointer;
-  background: transparent;
-  color: var(--af-text);
-  border: 1px solid var(--af-border);
-  border-radius: var(--af-r-md);
-  padding: 0 0.4rem;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.1rem 0.4rem;
+  font-size: var(--af-fs-xs);
   line-height: 1.4;
-}
-.af-webpane-reload:hover {
-  border-color: var(--af-accent);
+  text-decoration: none;
 }
 .af-webpane-url {
   flex: 1 1 auto;
@@ -971,14 +968,8 @@ body {
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--af-text-2);
-}
-.af-webpane-open {
-  flex: 0 0 auto;
-  color: var(--af-accent);
-  text-decoration: none;
-}
-.af-webpane-open:hover {
-  text-decoration: underline;
+  font-family: var(--af-font-mono);
+  font-size: var(--af-fs-xs);
 }
 .af-webframe {
   flex: 1 1 0;

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -8003,7 +8003,7 @@ var SplitView = class {
     const bar = el("div", "af-webpane-bar");
     const reload = document.createElement("button");
     reload.type = "button";
-    reload.className = "af-webpane-reload";
+    reload.className = "af-ghost af-webpane-reload";
     reload.title = "Reload";
     reload.setAttribute("aria-label", "Reload web tab");
     reload.textContent = "\u21BB";
@@ -8011,11 +8011,11 @@ var SplitView = class {
     urlText.textContent = target || "(no URL)";
     urlText.title = target;
     const open = document.createElement("a");
-    open.className = "af-webpane-open";
+    open.className = "af-ghost af-webpane-open";
     open.href = openHref;
     open.target = "_blank";
     open.rel = "noopener noreferrer";
-    open.textContent = "open \u2197";
+    open.textContent = "Open \u2197";
     bar.append(reload, urlText, open);
     const frame = document.createElement("iframe");
     frame.className = "af-webframe";
@@ -8859,14 +8859,28 @@ var AppShell = class {
   lastLive = null;
   lastKb = null;
   lastError = null;
+  // The last value written to document.title, so an unrelated update doesn't
+  // reassign it (see syncDocumentTitle).
+  lastDocTitle = null;
   // Whether the main pane has been rendered at least once. The constructor leaves it
   // an empty <section>, so the FIRST update must render it even when nothing is
   // selected (selectedId is null before AND after that first update, so the
   // selection-changed guard alone wouldn't fire) — otherwise the pane is blank on
   // load until a select-then-deselect. (#1592 Phase 5 PR9)
   mainRendered = false;
+  /** Points the browser tab at what is on screen, so a pinned/backgrounded tab and the
+   *  history entry name the session and project rather than a static "Agent Factory".
+   *  Assigns only on a real change (a rename, a selection, or a project switch). */
+  syncDocumentTitle(state) {
+    const title = documentTitle(state);
+    if (this.lastDocTitle !== title) {
+      this.lastDocTitle = title;
+      document.title = title;
+    }
+  }
   /** Applies the latest state, touching only what changed. */
   update(state) {
+    this.syncDocumentTitle(state);
     const kb = state.selectedId && state.focus === "terminal" ? "terminal" : "rail";
     if (this.lastKb !== kb) {
       this.lastKb = kb;
@@ -9154,6 +9168,20 @@ var AppShell = class {
     this.headMeta.className = `af-term-meta af-term-${state.termStatus}`;
   }
 };
+var APP_NAME = "Agent Factory";
+function documentTitle(state) {
+  const sel = selectedSession(state);
+  const root2 = sel?.worktree?.repo_path ?? state.selectedProject;
+  const parts = [];
+  if (sel && sel.title !== "") {
+    parts.push(sel.title);
+  }
+  if (root2) {
+    parts.push(projectName(root2));
+  }
+  const lead = parts.join(" \u2014 ");
+  return lead === "" ? APP_NAME : `${lead} \xB7 ${APP_NAME}`;
+}
 function selectedSession(state) {
   return state.selectedId ? state.sessions.find((s) => s.id === state.selectedId) ?? null : null;
 }

--- a/web/src/split.ts
+++ b/web/src/split.ts
@@ -535,7 +535,11 @@ export class SplitView {
     const bar = el("div", "af-webpane-bar");
     const reload = document.createElement("button");
     reload.type = "button";
-    reload.className = "af-webpane-reload";
+    // Reload and open are the same KIND of control — a quiet secondary action on a
+    // thin bar — so they share the app's ghost idiom (.af-ghost, as used by the
+    // modal/terminal/task actions) and differ only in their glyph. The semantic
+    // .af-webpane-* class stays as the identity hook for CSS and the driver test.
+    reload.className = "af-ghost af-webpane-reload";
     reload.title = "Reload";
     reload.setAttribute("aria-label", "Reload web tab");
     reload.textContent = "↻"; // ↻
@@ -543,11 +547,11 @@ export class SplitView {
     urlText.textContent = target || "(no URL)";
     urlText.title = target;
     const open = document.createElement("a");
-    open.className = "af-webpane-open";
+    open.className = "af-ghost af-webpane-open";
     open.href = openHref;
     open.target = "_blank";
     open.rel = "noopener noreferrer";
-    open.textContent = "open ↗"; // ↗
+    open.textContent = "Open ↗"; // ↗
     bar.append(reload, urlText, open);
 
     const frame = document.createElement("iframe");

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1189,21 +1189,22 @@ body {
   font-size: var(--af-fs-sm);
 }
 
-.af-webpane-reload {
+/* The bar's two controls are both quiet secondary actions, so they take the shared
+ * .af-ghost treatment and only tighten it for the thin bar. The anchor also needs the
+ * button resets .af-ghost assumes (no underline, centered content). */
+.af-webpane-reload,
+.af-webpane-open {
   flex: 0 0 auto;
-  cursor: pointer;
-  background: transparent;
-  color: var(--af-text);
-  border: 1px solid var(--af-border);
-  border-radius: var(--af-r-md);
-  padding: 0 0.4rem;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.1rem 0.4rem;
+  font-size: var(--af-fs-xs);
   line-height: 1.4;
+  text-decoration: none;
 }
 
-.af-webpane-reload:hover {
-  border-color: var(--af-accent);
-}
-
+/* The URL is machine text, not prose: mono at the bar's smallest step, and the one
+ * element that flexes so a long URL ellipsizes instead of pushing Open off the bar. */
 .af-webpane-url {
   flex: 1 1 auto;
   min-width: 0;
@@ -1211,16 +1212,8 @@ body {
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--af-text-2);
-}
-
-.af-webpane-open {
-  flex: 0 0 auto;
-  color: var(--af-accent);
-  text-decoration: none;
-}
-
-.af-webpane-open:hover {
-  text-decoration: underline;
+  font-family: var(--af-font-mono);
+  font-size: var(--af-fs-xs);
 }
 
 .af-webframe {

--- a/web/src/ui.test.ts
+++ b/web/src/ui.test.ts
@@ -8,7 +8,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { tabBarSig } from "./ui.js";
+import { documentTitle, tabBarSig } from "./ui.js";
 import type { AppState } from "./ui.js";
 import { Liveness, type SessionData } from "./types.js";
 
@@ -98,4 +98,49 @@ test("the signature is delimiter-safe: a name mimicking the field separators sti
   // active/shown/manageability combination.
   const tricky = state({ sessions: [sess({ tabs: [{ name: 't"::0::[0]::true', kind: 1 }] })] });
   assert.notEqual(tabBarSig(plain), tabBarSig(tricky));
+});
+
+// Unit coverage for documentTitle (#1826 item 2). The browser tab was a static
+// "Agent Factory" on every screen, so a pinned or backgrounded tab said nothing about
+// what it held. The title names the selected session and its project, and degrades
+// cleanly when there is no selection.
+
+/** A session rooted in a repo, the shape documentTitle reads. */
+function inRepo(title: string, root: string): SessionData {
+  return { id: title, title, branch: "b", worktree: { repo_path: root } };
+}
+
+test("documentTitle: a selected session names itself and its project", () => {
+  const s = state({
+    selectedId: "api",
+    sessions: [inRepo("api", "/home/u/code/agent-factory")],
+    selectedProject: "/home/u/code/agent-factory",
+  });
+  assert.equal(documentTitle(s), "api — agent-factory · Agent Factory");
+});
+
+test("documentTitle: with no selection the scoped project still qualifies the tab", () => {
+  const s = state({
+    selectedId: null,
+    sessions: [inRepo("api", "/home/u/code/agent-factory")],
+    selectedProject: "/home/u/code/agent-factory",
+  });
+  assert.equal(documentTitle(s), "agent-factory · Agent Factory");
+});
+
+test("documentTitle: with neither a selection nor a project it is the bare app name", () => {
+  const s = state({ selectedId: null, sessions: [], selectedProject: null });
+  assert.equal(documentTitle(s), "Agent Factory");
+});
+
+// The title must name the project the session actually LIVES in. The two only differ
+// transiently (a selection surviving a project switch), but naming the scope there
+// would caption the session with a repo it isn't in.
+test("documentTitle: the session's own repo wins over the scoped project", () => {
+  const s = state({
+    selectedId: "api",
+    sessions: [inRepo("api", "/home/u/code/agent-factory")],
+    selectedProject: "/home/u/code/other-repo",
+  });
+  assert.equal(documentTitle(s), "api — agent-factory · Agent Factory");
 });

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -465,6 +465,9 @@ export class AppShell {
   private lastLive: EventStreamStatus | null = null;
   private lastKb: KeyboardFocus | null = null;
   private lastError: string | null = null;
+  // The last value written to document.title, so an unrelated update doesn't
+  // reassign it (see syncDocumentTitle).
+  private lastDocTitle: string | null = null;
   // Whether the main pane has been rendered at least once. The constructor leaves it
   // an empty <section>, so the FIRST update must render it even when nothing is
   // selected (selectedId is null before AND after that first update, so the
@@ -599,8 +602,20 @@ export class AppShell {
     this.el = h("main", { class: "af-app" }, header, viewport, this.toast, this.modalHost);
   }
 
+  /** Points the browser tab at what is on screen, so a pinned/backgrounded tab and the
+   *  history entry name the session and project rather than a static "Agent Factory".
+   *  Assigns only on a real change (a rename, a selection, or a project switch). */
+  private syncDocumentTitle(state: AppState): void {
+    const title = documentTitle(state);
+    if (this.lastDocTitle !== title) {
+      this.lastDocTitle = title;
+      document.title = title;
+    }
+  }
+
   /** Applies the latest state, touching only what changed. */
   update(state: AppState): void {
+    this.syncDocumentTitle(state);
     // The keyboard-focus indicator (#1693): a modifier class on the app root that
     // CSS turns into an accent border on whichever pane owns the keyboard. The
     // terminal only "holds" it while a session is actually selected; with none
@@ -1001,6 +1016,33 @@ export class AppShell {
     this.headMeta.textContent = parts.join(" · ");
     this.headMeta.className = `af-term-meta af-term-${state.termStatus}`;
   }
+}
+
+/** The product name, and the browser-tab title when there is nothing to qualify it. */
+const APP_NAME = "Agent Factory";
+
+/**
+ * The browser-tab title for a state: "‹session› — ‹project› · Agent Factory" while a
+ * session is selected, degrading to "‹project› · Agent Factory" when only a project is
+ * scoped and to the bare app name when neither is. It reads the SELECTED session's own
+ * repo root rather than the scoped project, so the title always names the project the
+ * session actually lives in.
+ *
+ * Pure (state in, string out) and exported so it is unit-testable without a DOM;
+ * AppShell.syncDocumentTitle owns the assignment.
+ */
+export function documentTitle(state: AppState): string {
+  const sel = selectedSession(state);
+  const root = sel?.worktree?.repo_path ?? state.selectedProject;
+  const parts: string[] = [];
+  if (sel && sel.title !== "") {
+    parts.push(sel.title);
+  }
+  if (root) {
+    parts.push(projectName(root));
+  }
+  const lead = parts.join(" — ");
+  return lead === "" ? APP_NAME : `${lead} · ${APP_NAME}`;
 }
 
 /** The currently selected session row, or null. */


### PR DESCRIPTION
Fixes items 1, 2, 4, 5, 6, 7 of #1826, plus the structural convention that stops the drift recurring.

The diagnosis in the issue is right: each new surface shipped its own capitalization, glyph, and emphasis habits. This fixes the instances **and** adds the shared convention.

## Web

**1. The web-pane control bar read as three ad-hoc elements.** Reload and Open are the same *kind* of control — a quiet secondary action on a thin bar — so they now share the app's `.af-ghost` idiom (as used by the modal / terminal / task actions) and differ only in their glyph. The semantic `.af-webpane-*` classes stay as the identity hooks for CSS and the driver test, so this is a re-skin, not a rename. `open ↗` → sentence-case `Open ↗`. The URL is machine text, so it is `--af-font-mono` at `--af-fs-xs`, and it stays the only element that flexes — a long URL ellipsizes instead of pushing Open off the bar.

**2. The browser tab was a static "Agent Factory"** on every screen, so a pinned or backgrounded tab said nothing about what it held. It now reads `‹session› — ‹project› · Agent Factory`, degrading to `‹project› · Agent Factory` when only a project is scoped and to the bare app name when neither is.

Two deliberate choices there:
- The title reads the **selected session's own repo root**, not the scoped project. The two only differ transiently, but naming the scope would caption a session with a repo it isn't in.
- Derivation is a **pure exported `documentTitle(state)`**; `AppShell.syncDocumentTitle` owns the assignment. The web tests run under `node:test` with no DOM, so purity is what makes it testable.

## TUI

**4.** `ui/err.go` joined multi-line errors with `//`, which reads as a commented-out fragment or a URL remnant rather than a break between two sentences. Now ` · `, already the separator in the pane header and the web term meta.

**5.** Finished the `…` sweep in literal strings across every pointer in the issue. The sweep also turned up **`app/pane_preview.go`** (`"Loading preview..."`, `"Loading pane..."`) — the same anti-pattern at an adjacent site, not in the issue's list. Folded in rather than left to drift. The remaining `...` hits in `ui/` are code comments and a JSON example, not user-facing.

**6.** Sentence case: `Search sessions`, `Switch project`, and the web-tab placeholder (`Web tab — view in the web UI…`).

**7.** The inline inputs appended a literal `_` — indistinguishable from a typed underscore. All four call-sites (`searchOverlay`, `projectPickerOverlay`, and both `hooks_pane` editors) now share one `ui.InputCaret()`: a **static** reverse-video cell, no blink, honoring the #1766 no-animation doctrine. One definition, in the package both `ui` and `ui/overlay` can reach — the same class of drift this issue is about.

### One thing worth flagging

The caret **degrades deliberately.** termenv emits no SGR at all under the `Ascii` profile (`TERM=dumb`, `NO_COLOR`) — a reverse-video space would collapse to a bare space and the caret would *silently vanish* for those users, which is worse than the underscore it replaces. It falls back to `▌`, a glyph that needs no styling. Both forms are exactly one cell, so the caret never shifts the text it trails. This repo has a known history of `TERM=dumb`/`SHELL`-unset sensitivity, hence the guard and its test.

## Structural

Added a ~10-line **"Copy & glyph conventions"** section to `CLAUDE.md`: sentence case; `…`; ` · `; no caps-shouting (caps reserved for env vars); no animated indicators. This is the part that stops item 5 from being re-filed in a month.

## Tests

- `ui/caret_test.go` — reverse-video, static, one cell, the no-colour fallback, and the caret actually reaching the hooks-pane editor.
- `ui/overlay/caret_test.go` — both overlays render it, and render the *same* glyph (so they can't drift apart again).
- `ui/err_test.go` — the ` · ` join, and that `//` is gone.
- `web/src/ui.test.ts` — the four `documentTitle` cases, including session-repo-wins-over-scope.
- Updated the 19 existing assertions that pinned the old literals.
- `web/dist` rebuilt and committed.

## Gates

| Gate | Result |
|---|---|
| `make test-container` | ✅ all packages ok |
| `make tui-driver-selftest` | ✅ **33/33** steps green |
| `make web-selftest-container` | ✅ **31 passed** |
| `make web-test` | ✅ **147 pass**, typecheck clean |
| `go build ./...` | ✅ |
| `gofmt -l .` | ✅ no output |
| `golangci-lint run --fast` | ✅ clean |
| `deadcode -test ./...` | ✅ no output |
| `scripts/lint-file-length.sh` | ✅ 616 files, 0 grandfathered |
| `web/dist` rebuilt | ✅ |

The driver selftest is **33/33**, not the 25/25 named when the issue was filed — the suite has grown since.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)