### PR TITLE
fix(cli): calm the help copy and trim the root Long to pointers (#1826)

### DIFF
--- a/commands/agentservercmd.go
+++ b/commands/agentservercmd.go
@@ -31,16 +31,16 @@ var (
 
 var agentServerCmd = &cobra.Command{
 	Use:   "agent-server",
-	Short: "Run a headless single-workspace backend (NOT the web UI — that is 'af daemon')",
+	Short: "Run a headless single-workspace backend (not the web UI — that is 'af daemon')",
 	Long: `Run a headless agent-server for exactly one session's workspace, served over
 the same REST + WebSocket protocol the daemon speaks, behind a plain-HTTP
 listener that requires a bearer token on every request.
 
-This does NOT start the web UI, and serves no frontend at all — opening its port
+This does not start the web UI, and serves no frontend at all — opening its port
 in a browser returns a 404 saying so. If you want the browser app, run the
 daemon — any 'af' command starts it — and open http://localhost:8443. The web UI
 is bundled into the daemon and served from its listen_addr; agent-server is only
-the headless per-workspace BACKEND that a daemon drives, and it exists to be
+the headless per-workspace backend that a daemon drives, and it exists to be
 consumed by a daemon rather than opened by a person.
 
 This is the process that runs inside a docker container or on an ssh remote
@@ -50,8 +50,8 @@ to host one workspace as a backend for a daemon on another machine.
 
 The listener always requires the token and serves plain HTTP (no TLS) — reach it
 over a private network or a tunnel (the docker/ssh runtimes forward a loopback
-port). Its token is mandatory for every peer and is NOT affected by the global
-require_token key, which governs only the daemon's own web listener. On startup
+port). Its token is mandatory for every peer, whatever the global require_token
+key says: that key governs only the daemon's own web listener. On startup
 it prints one JSON line to stdout carrying the bound address and the bearer
 token. On SIGINT/SIGTERM it tears the workspace down (kills tmux, removes the
 worktree) — durability of in-progress work is the driving daemon's job (push the

--- a/commands/daemoncmd.go
+++ b/commands/daemoncmd.go
@@ -25,7 +25,7 @@ var daemonCmd = &cobra.Command{
 	Use:   "daemon",
 	Short: "Manage the background daemon: serves the web UI and schedules tasks",
 	Long: `The agent-factory daemon runs task cron schedules in-process, supervises
-watch-task scripts, drives autoyes mode, and serves the bundled WEB UI.
+watch-task scripts, drives autoyes mode, and serves the bundled web UI.
 
 The web UI is part of the daemon — there is no separate web command — so it is
 served whenever the daemon is running. Running af starts one: the TUI reads
@@ -40,12 +40,21 @@ With af running, open:
 
 It needs no token by default, so the page connects as soon as it loads. Set
 listen_addr to change the address (or to "" to turn the web server off).
-require_token = true demands a bearer token ('af token show') from NETWORK
+require_token = true demands a bearer token ('af token show') from network
 peers; on the default loopback listener same-host callers stay exempt, so the
 UI keeps opening with no login on this machine. Add require_loopback_token =
 true to require the token from localhost as well.
-Note 'af agent-server' does NOT serve the web UI: it is the headless
+Note that 'af agent-server' does not serve the web UI: it is the headless
 per-workspace backend a daemon drives on a remote machine.
+
+Clients reach the daemon over a local Unix socket by default. To drive one from
+another machine, either ssh to that host and run 'af' there, or give listen_addr
+a routable address and point a client at it with the persistent --daemon-url and
+--token flags. Auth is off unless you turn it on: without require_token = true a
+routable listener is open to anyone who can reach it. That listener speaks plain
+HTTP, so put it behind a reverse proxy or a private network (Tailscale/VPN) if
+you need TLS.
+Full guide: https://sachiniyer.github.io/agent-factory/remote-http-auth/
 
 Install the daemon as a user-level autostart unit (systemd user service on
 Linux, launchd agent on macOS) so tasks keep firing and the web UI stays up

--- a/commands/root.go
+++ b/commands/root.go
@@ -34,24 +34,11 @@ var (
 		Long: `Run 'af' with no arguments to open the TUI. The subcommands below drive the
 same daemon non-interactively (` + "`af sessions`, `af tasks`" + ` emit JSON).
 
-WEB UI: the daemon serves a browser client with the same rail, terminals, tabs,
-projects, and tasks. Start the daemon (any 'af' command does) and open
-
-    http://localhost:8443
-
-It needs no token by default, so the page just connects. The web UI is part of
-the daemon — 'af agent-server' does NOT serve it (that is the headless
-per-workspace backend a daemon drives on a remote machine).
-
-By default 'af' talks to a daemon on the local machine over a Unix socket. To
-drive a daemon on ANOTHER machine, SSH to the host and run 'af' there, or expose
-the TCP listener to the network (set a routable listen_addr) and point a client
-at it with the persistent --daemon-url/--token flags. Auth is OPT-IN: set
-require_token = true so network peers must present a token (see 'af token' for
-the credential), otherwise a routable listener is open to anyone who can reach
-it. The listener is plain HTTP — put it behind a reverse proxy or a private
-network (Tailscale/VPN) if you need TLS.
-Full guide: https://sachiniyer.github.io/agent-factory/remote-http-auth/`,
+The daemon also serves the web UI — the same sessions in a browser — at
+http://localhost:8443, which needs no token by default. See 'af daemon --help'
+for the web UI, the listener and its auth, and autostart; to drive a daemon on
+another machine, start with the remote guide:
+https://sachiniyer.github.io/agent-factory/remote-http-auth/`,
 		// A runtime (RunE) failure should print as one calm line, not a usage
 		// dump. Silencing usage here — after flag parsing has already succeeded —
 		// keeps the usage/flag help on flag-PARSE errors (which fail before this

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -9,7 +9,7 @@ Run `af <command> --help` for the same information at the terminal. For a narrat
 ## Commands
 
 - [`af`](#af) — Agent Factory - Manage multiple AI agents like Claude Code, Aider, Codex, Gemini, and Amp.
-- [`af agent-server`](#af-agent-server) — Run a headless single-workspace backend (NOT the web UI — that is 'af daemon')
+- [`af agent-server`](#af-agent-server) — Run a headless single-workspace backend (not the web UI — that is 'af daemon')
 - [`af api`](#af-api) — Show the daemon-hosted HTTP/JSON API catalog
 - [`af bug-report`](#af-bug-report) — Bundle logs, versions, tasks, and redacted state for a bug report
 - [`af completion`](#af-completion) — Generate the autocompletion script for the specified shell
@@ -69,24 +69,11 @@ Agent Factory - Manage multiple AI agents like Claude Code, Aider, Codex, Gemini
 Run 'af' with no arguments to open the TUI. The subcommands below drive the
 same daemon non-interactively (`af sessions`, `af tasks` emit JSON).
 
-WEB UI: the daemon serves a browser client with the same rail, terminals, tabs,
-projects, and tasks. Start the daemon (any 'af' command does) and open
-
-    http://localhost:8443
-
-It needs no token by default, so the page just connects. The web UI is part of
-the daemon — 'af agent-server' does NOT serve it (that is the headless
-per-workspace backend a daemon drives on a remote machine).
-
-By default 'af' talks to a daemon on the local machine over a Unix socket. To
-drive a daemon on ANOTHER machine, SSH to the host and run 'af' there, or expose
-the TCP listener to the network (set a routable listen_addr) and point a client
-at it with the persistent --daemon-url/--token flags. Auth is OPT-IN: set
-require_token = true so network peers must present a token (see 'af token' for
-the credential), otherwise a routable listener is open to anyone who can reach
-it. The listener is plain HTTP — put it behind a reverse proxy or a private
-network (Tailscale/VPN) if you need TLS.
-Full guide: https://sachiniyer.github.io/agent-factory/remote-http-auth/
+The daemon also serves the web UI — the same sessions in a browser — at
+http://localhost:8443, which needs no token by default. See 'af daemon --help'
+for the web UI, the listener and its auth, and autostart; to drive a daemon on
+another machine, start with the remote guide:
+https://sachiniyer.github.io/agent-factory/remote-http-auth/
 
 ```
 af [flags]
@@ -94,7 +81,7 @@ af [flags]
 
 **Subcommands**
 
-- [`af agent-server`](#af-agent-server) — Run a headless single-workspace backend (NOT the web UI — that is 'af daemon')
+- [`af agent-server`](#af-agent-server) — Run a headless single-workspace backend (not the web UI — that is 'af daemon')
 - [`af api`](#af-api) — Show the daemon-hosted HTTP/JSON API catalog
 - [`af bug-report`](#af-bug-report) — Bundle logs, versions, tasks, and redacted state for a bug report
 - [`af completion`](#af-completion) — Generate the autocompletion script for the specified shell
@@ -122,17 +109,17 @@ af [flags]
 
 ## af agent-server
 
-Run a headless single-workspace backend (NOT the web UI — that is 'af daemon')
+Run a headless single-workspace backend (not the web UI — that is 'af daemon')
 
 Run a headless agent-server for exactly one session's workspace, served over
 the same REST + WebSocket protocol the daemon speaks, behind a plain-HTTP
 listener that requires a bearer token on every request.
 
-This does NOT start the web UI, and serves no frontend at all — opening its port
+This does not start the web UI, and serves no frontend at all — opening its port
 in a browser returns a 404 saying so. If you want the browser app, run the
 daemon — any 'af' command starts it — and open http://localhost:8443. The web UI
 is bundled into the daemon and served from its listen_addr; agent-server is only
-the headless per-workspace BACKEND that a daemon drives, and it exists to be
+the headless per-workspace backend that a daemon drives, and it exists to be
 consumed by a daemon rather than opened by a person.
 
 This is the process that runs inside a docker container or on an ssh remote
@@ -142,8 +129,8 @@ to host one workspace as a backend for a daemon on another machine.
 
 The listener always requires the token and serves plain HTTP (no TLS) — reach it
 over a private network or a tunnel (the docker/ssh runtimes forward a loopback
-port). Its token is mandatory for every peer and is NOT affected by the global
-require_token key, which governs only the daemon's own web listener. On startup
+port). Its token is mandatory for every peer, whatever the global require_token
+key says: that key governs only the daemon's own web listener. On startup
 it prints one JSON line to stdout carrying the bound address and the bearer
 token. On SIGINT/SIGTERM it tears the workspace down (kills tmux, removes the
 worktree) — durability of in-progress work is the driving daemon's job (push the
@@ -560,7 +547,7 @@ af config set <key> <value> [flags]
 Manage the background daemon: serves the web UI and schedules tasks
 
 The agent-factory daemon runs task cron schedules in-process, supervises
-watch-task scripts, drives autoyes mode, and serves the bundled WEB UI.
+watch-task scripts, drives autoyes mode, and serves the bundled web UI.
 
 The web UI is part of the daemon — there is no separate web command — so it is
 served whenever the daemon is running. Running af starts one: the TUI reads
@@ -575,12 +562,21 @@ With af running, open:
 
 It needs no token by default, so the page connects as soon as it loads. Set
 listen_addr to change the address (or to "" to turn the web server off).
-require_token = true demands a bearer token ('af token show') from NETWORK
+require_token = true demands a bearer token ('af token show') from network
 peers; on the default loopback listener same-host callers stay exempt, so the
 UI keeps opening with no login on this machine. Add require_loopback_token =
 true to require the token from localhost as well.
-Note 'af agent-server' does NOT serve the web UI: it is the headless
+Note that 'af agent-server' does not serve the web UI: it is the headless
 per-workspace backend a daemon drives on a remote machine.
+
+Clients reach the daemon over a local Unix socket by default. To drive one from
+another machine, either ssh to that host and run 'af' there, or give listen_addr
+a routable address and point a client at it with the persistent --daemon-url and
+--token flags. Auth is off unless you turn it on: without require_token = true a
+routable listener is open to anyone who can reach it. That listener speaks plain
+HTTP, so put it behind a reverse proxy or a private network (Tailscale/VPN) if
+you need TLS.
+Full guide: https://sachiniyer.github.io/agent-factory/remote-http-auth/
 
 Install the daemon as a user-level autostart unit (systemd user service on
 Linux, launchd agent on macOS) so tasks keep firing and the web UI stays up


### PR DESCRIPTION
Fixes items **8** and **9** of #1826. Copy-only — no behavior change.

## 8. Caps-as-emphasis → calm sentence emphasis

The #1802-era help shouted for emphasis that the sentence can carry on its own: `WEB UI:`, `does NOT serve it`, `ANOTHER machine`, `Auth is OPT-IN`, `NETWORK peers`, `per-workspace BACKEND`, `NOT the web UI`. All rewritten so the emphasis lives in the wording. Caps are now reserved for env vars and literal flag/config names.

Swept `commands/*.go` for the same pattern rather than only the three files named in the issue. One hit is **deliberately left alone**: `commands/reset.go`'s `"remove ALL AF sessions…"`. It's outside this issue's scope, and it's a destructive-command warning whose semantics are owner-locked — not something to reword in a drive-by copy PR. Happy to do it separately if wanted.

## 9. Root help trimmed from a manual to pointers

`af --help` had grown into three paragraphs restating `af daemon --help` nearly verbatim — the web UI, the URL, the listener, the token, and the agent-server disclaimer all appeared in both places. Root is now four lines of body: the TUI default, plus one pointer each for the web UI and for remote. The daemon keeps the detail.

**Before** (root Long): 20 lines, 3 paragraphs. **After**: 8 lines including the URL and the guide link.

### Two judgment calls worth your attention

**#1802 deliberately put the URL in root, and I kept it.** `TestRootHelpAdvertisesTheWebUI` pins that `rootCmd.Long` contains `web ui`, `http://localhost:8443`, **and** `no token by default` — on the explicit grounds that "'af --help' is the first place a user looks… without reading any docs." A naive trim-to-pointers would have deleted all three and forced me to weaken that test. Instead the trim keeps those facts in a **single line**, so **the test passes unchanged**. The duplication goes; the discoverability stays. That unmodified test is the evidence the trim didn't undo #1802's intent.

**The remote paragraph was not actually duplicated — it moved rather than died.** Everything else in the root Long was restated in `af daemon --help`, but the remote/auth/TLS paragraph was not. Deleting it would have silently lost two real caveats:
- a routable `listen_addr` without `require_token = true` is open to anyone who can reach it
- that listener speaks plain HTTP — put it behind a reverse proxy or a private network for TLS

Those are security-relevant, so they moved into the daemon Long, which already owns `listen_addr` and `require_token`. Net: `af daemon --help` gained the remote story, root points at it.

## Docs

`scripts/gen-docs.sh` regenerated `docs/reference/cli.md` (CI fails on drift, `.github/workflows/docs.yml`). No caps-shouting survives in the generated reference.

## Gates

| Gate | Result |
|---|---|
| `make test-container` | ✅ all packages ok |
| `go test ./commands/...` | ✅ ok — **unmodified**, incl. the #1802 help tests |
| `go build ./...` | ✅ |
| `gofmt -l .` | ✅ no output |
| `golangci-lint run --fast` | ✅ clean |
| `deadcode -test ./...` | ✅ no output |
| `scripts/lint-file-length.sh` | ✅ |
| `scripts/gen-docs.sh` | ✅ committed |

Both help surfaces were rendered and read end-to-end, not just diffed.

The convention that stops this recurring ("Copy & glyph conventions" in `CLAUDE.md`) ships in the sibling PR #1827; this PR is the CLI half of #1826 and is independent of it — both branch off `master`.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)