### PR TITLE
fix(attach): Ctrl-W detaches when the agent upgrades the keyboard encoding (#1832 external regression)

### DIFF
--- a/apiclient/attach.go
+++ b/apiclient/attach.go
@@ -175,16 +175,22 @@ func driveAttachStream(conn *websocket.Conn, oldState *term.State) {
 
 	// stdin → INPUT, with detach-key detection. stdin.Read can batch the detach
 	// key with preceding bytes in a single read (buffered terminal input), so
-	// check the LAST byte rather than requiring it to be the sole byte, forwarding
-	// any preceding bytes first (#975).
+	// check the END of the chunk rather than requiring the key to be the sole
+	// bytes, forwarding anything before it first (#975).
+	//
+	// The detach key is matched in every encoding the pane program may have
+	// negotiated onto the real terminal, not just the legacy C0 byte: an agent
+	// CLI that turns on the kitty keyboard protocol or modifyOtherKeys makes the
+	// terminal report ctrl+<key> as an escape sequence, and matching 0x17 alone
+	// left the user unable to detach at all (#1832). See detachkey.go.
 	go func() {
 		buf := make([]byte, 32)
 		for {
 			n, err := in.Read(buf)
 			if n > 0 {
-				if buf[n-1] == tmux.DetachKeyByte {
-					if n > 1 {
-						_ = writeFrame(agentproto.InputFrame(buf[:n-1]))
+				if keyLen := trailingDetachKeyLen(buf[:n]); keyLen > 0 {
+					if n > keyLen {
+						_ = writeFrame(agentproto.InputFrame(buf[:n-keyLen]))
 					}
 					detach()
 					return

--- a/apiclient/attach_test.go
+++ b/apiclient/attach_test.go
@@ -180,6 +180,80 @@ func TestAttachStream_BatchedDetachFlushesPrecedingInput(t *testing.T) {
 	waitClosed(t, done)
 }
 
+// TestAttachStream_EncodedDetachKeyDetaches is the #1832 regression guard, at the
+// level the bug actually bit: the whole attach driver, driven from stdin.
+//
+// A raw-proxied attach lets the pane program negotiate a richer keyboard encoding
+// with the REAL terminal (claude emits `CSI > 1 u` and `CSI > 4 ; 2 m` at
+// startup), after which the terminal reports ctrl+w as an escape sequence and
+// NEVER as 0x17. Matching only the legacy byte forwarded the key to the agent —
+// a harmless word-erase — so the user was trapped in the attach with no way back
+// to the TUI. Each encoding here must produce a MsgDetach, not an INPUT frame.
+func TestAttachStream_EncodedDetachKeyDetaches(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		seq  string
+	}{
+		{"kitty CSI u (macOS + kitty + claude, #1832)", "\x1b[119;5u"},
+		{"kitty CSI u with num-lock on", "\x1b[119;133u"},
+		{"xterm modifyOtherKeys=2", "\x1b[27;5;119~"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server, stdinW, _, done := startDriver(t)
+
+			if _, err := stdinW.Write([]byte(tc.seq)); err != nil {
+				t.Fatalf("write encoded detach key: %v", err)
+			}
+			msg := readServerMsg(t, server)
+			if typ, _ := agentproto.MessageTypeOf(msg.Text); msg.Binary || typ != agentproto.MsgDetach {
+				t.Fatalf("encoded detach key %q must detach, not forward as INPUT; got %+v", tc.seq, msg)
+			}
+			_ = server.Close(websocket.StatusNormalClosure, "")
+			waitClosed(t, done)
+		})
+	}
+}
+
+// TestAttachStream_EncodedDetachKeyFlushesPrecedingInput extends the #975 batching
+// rule to the encoded forms: bytes typed just before the detach key still reach
+// the agent, and only the key's own sequence is swallowed.
+func TestAttachStream_EncodedDetachKeyFlushesPrecedingInput(t *testing.T) {
+	server, stdinW, _, done := startDriver(t)
+
+	if _, err := stdinW.Write([]byte("abc\x1b[119;5u")); err != nil {
+		t.Fatalf("write batched encoded detach: %v", err)
+	}
+	in := readServerMsg(t, server)
+	if !in.Binary || in.Frame.Op != agentproto.OpInput || string(in.Frame.Data) != "abc" {
+		t.Fatalf("expected INPUT 'abc' before the encoded detach, got %+v", in)
+	}
+	det := readServerMsg(t, server)
+	if typ, _ := agentproto.MessageTypeOf(det.Text); det.Binary || typ != agentproto.MsgDetach {
+		t.Fatalf("expected MsgDetach after the flushed input, got %+v", det)
+	}
+	_ = server.Close(websocket.StatusNormalClosure, "")
+	waitClosed(t, done)
+}
+
+// TestAttachStream_EncodedNonDetachKeyForwards is the other half of the contract:
+// widening detection must not start swallowing keys the agent needs. ctrl+shift+w
+// under the same kitty encoding differs from the detach key only in its modifier
+// bits, so it is the sharpest available tripwire for an over-broad match.
+func TestAttachStream_EncodedNonDetachKeyForwards(t *testing.T) {
+	server, stdinW, _, done := startDriver(t)
+
+	const ctrlShiftW = "\x1b[119;6u"
+	if _, err := stdinW.Write([]byte(ctrlShiftW)); err != nil {
+		t.Fatalf("write ctrl+shift+w: %v", err)
+	}
+	in := readServerMsg(t, server)
+	if !in.Binary || in.Frame.Op != agentproto.OpInput || string(in.Frame.Data) != ctrlShiftW {
+		t.Fatalf("ctrl+shift+w must forward to the agent verbatim, got %+v", in)
+	}
+	_ = server.Close(websocket.StatusNormalClosure, "")
+	waitClosed(t, done)
+}
+
 // TestAttachStream_InputForwarded: plain keystrokes reach the server as INPUT.
 func TestAttachStream_InputForwarded(t *testing.T) {
 	server, stdinW, _, done := startDriver(t)

--- a/apiclient/detachkey.go
+++ b/apiclient/detachkey.go
@@ -1,0 +1,183 @@
+package apiclient
+
+import (
+	"bytes"
+
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// Detach-key recognition across keyboard-encoding modes (#1832).
+//
+// Full-screen attach is a RAW byte proxy: the pane program's output reaches the
+// real terminal untouched (the same property #845 designs around for
+// alt-screen/mouse modes). That includes the sequences a modern agent CLI emits
+// at startup to negotiate a richer keyboard encoding — claude sends BOTH:
+//
+//	ESC [ > 1 u      kitty keyboard protocol, "disambiguate escape codes"
+//	ESC [ > 4 ; 2 m  xterm modifyOtherKeys level 2
+//
+// A terminal that honors either one STOPS sending ctrl+<key> as a legacy C0
+// control byte. Per the kitty spec, disambiguate mode reports "Esc, alt+key,
+// ctrl+key, ctrl+alt+key, shift+alt+key ... using CSI u sequences instead of
+// legacy ones" (only Enter/Tab/Backspace stay legacy). So on kitty the detach
+// key arrives as ESC [ 119 ; 5 u, and under modifyOtherKeys as
+// ESC [ 27 ; 5 ; 119 ~ — never as 0x17. Matching only the legacy byte silently
+// forwarded it to the agent (where ctrl+w is a harmless word-erase) and the
+// user could never leave the attach: #1832, reported on macOS + kitty + claude.
+//
+// This did not bite before #1592 Phase 2 PR7 (fc6a4d1): local attach ran through
+// a real `tmux attach-session` client, and tmux — a terminal emulator in its own
+// right — consumed the inner program's keyboard-mode requests instead of relaying
+// them to the outer terminal, so the real terminal stayed in legacy mode. The
+// clientless WS proxy has no such buffer.
+//
+// Rather than strip the pane program's negotiated mode (which would silently
+// degrade its key handling — shift+enter and friends — for everyone), the detach
+// key is recognized in every encoding a pane program can put the terminal into.
+// Detection stays a SUFFIX test on the read chunk, preserving the #975 rule: a
+// terminal delivers one keypress in one write, and batched leading bytes are
+// forwarded as INPUT before the detach fires.
+
+// kitty modifier bits (spec: the encoded param is bits+1). caps_lock and
+// num_lock are *state* bits the terminal may OR in at any time, so they are
+// masked off before comparing — a user with num-lock on must still be able to
+// detach.
+const (
+	kbModShift   = 1
+	kbModAlt     = 2
+	kbModCtrl    = 4
+	kbModCapsOn  = 64
+	kbModNumOn   = 128
+	kbModLockMsk = kbModCapsOn | kbModNumOn
+)
+
+// detachKeyCodepoint maps the detach key's C0 control byte to the Unicode
+// codepoint of the key the user physically presses — what the CSI u and
+// modifyOtherKeys encodings report. config.ParseDetachKey only ever produces
+// ctrl-<letter> (1..26) or ctrl-\ ] ^ _ (28..31).
+//
+// 27 (ctrl-[) is deliberately unmapped: it IS Esc, which the kitty protocol
+// reports specially, and treating a bare Esc as "detach" would hijack a key the
+// agent needs. A ctrl-[ detach key keeps legacy-only matching.
+func detachKeyCodepoint(b byte) (int, bool) {
+	switch {
+	case b >= 1 && b <= 26:
+		return int(b) + 'a' - 1, true // ctrl-a..ctrl-z -> 'a'..'z'
+	case b >= 28 && b <= 31:
+		return int(b) + 64, true // ctrl-\ ] ^ _ -> '\' ']' '^' '_'
+	default:
+		return 0, false
+	}
+}
+
+// ctrlOnly reports whether an encoded modifier param means "ctrl, and nothing
+// else" once lock state is masked away.
+func ctrlOnly(param int, maskLocks bool) bool {
+	if param < 1 {
+		return false
+	}
+	bits := param - 1
+	if maskLocks {
+		bits &^= kbModLockMsk
+	}
+	return bits == kbModCtrl
+}
+
+// csiParams splits the parameter bytes of a CSI sequence into top-level params,
+// keeping only each param's FIRST sub-parameter (kitty appends ":<event-type>"
+// / ":<alternate-key>" sub-params when those progressive-enhancement flags are
+// on). An empty param yields -1 ("default"), matching terminal convention.
+func csiParams(b []byte) []int {
+	if len(b) == 0 {
+		return nil
+	}
+	var out []int
+	for _, field := range bytes.Split(b, []byte{';'}) {
+		if i := bytes.IndexByte(field, ':'); i >= 0 {
+			field = field[:i]
+		}
+		if len(field) == 0 {
+			out = append(out, -1)
+			continue
+		}
+		n := 0
+		ok := true
+		for _, c := range field {
+			if c < '0' || c > '9' {
+				ok = false
+				break
+			}
+			n = n*10 + int(c-'0')
+		}
+		if !ok {
+			return nil
+		}
+		out = append(out, n)
+	}
+	return out
+}
+
+// matchesEncodedDetachKey reports whether seq — a complete escape sequence
+// starting at ESC — is the detach key in either negotiated encoding.
+func matchesEncodedDetachKey(seq []byte, cp int) bool {
+	// Both encodings are CSI sequences: ESC [ <params> <final>.
+	if len(seq) < 4 || seq[0] != 0x1b || seq[1] != '[' {
+		return false
+	}
+	final := seq[len(seq)-1]
+	params := csiParams(seq[2 : len(seq)-1])
+
+	switch final {
+	case 'u':
+		// kitty: CSI <codepoint> ; <modifiers> u
+		if len(params) != 2 {
+			return false
+		}
+		return params[0] == cp && ctrlOnly(params[1], true)
+	case '~':
+		// xterm modifyOtherKeys=2: CSI 27 ; <modifiers> ; <codepoint> ~
+		if len(params) != 3 {
+			return false
+		}
+		return params[0] == 27 && params[2] == cp && ctrlOnly(params[1], false)
+	default:
+		return false
+	}
+}
+
+// trailingDetachKeyLen reports how many bytes at the END of buf encode the
+// detach key, or 0 if buf does not end with it. The legacy C0 byte is one byte;
+// a negotiated encoding is a whole trailing escape sequence.
+//
+// Suffix-matching mirrors the long-standing #975 legacy rule and inherits its
+// (accepted) trade-off: a paste whose final bytes happen to spell the detach
+// key detaches. Terminals deliver a keypress as its own write, so this does not
+// arise in practice.
+//
+// An encoded key is multi-byte, so unlike the legacy byte it could in principle
+// straddle two reads (a paste that fills the caller's buffer to exactly
+// mid-sequence) and be missed. This stays stateless rather than buffering a
+// partial sequence: a keypress arrives as its own read, the window is a paste
+// landing on an exact boundary, and the failure mode is one ignored detach —
+// press again — not a wedged attach.
+func trailingDetachKeyLen(buf []byte) int {
+	if len(buf) == 0 {
+		return 0
+	}
+	if buf[len(buf)-1] == tmux.DetachKeyByte {
+		return 1
+	}
+	cp, ok := detachKeyCodepoint(tmux.DetachKeyByte)
+	if !ok {
+		return 0
+	}
+	// A trailing escape sequence starts at the last ESC in the chunk.
+	i := bytes.LastIndexByte(buf, 0x1b)
+	if i < 0 {
+		return 0
+	}
+	if matchesEncodedDetachKey(buf[i:], cp) {
+		return len(buf) - i
+	}
+	return 0
+}

--- a/apiclient/detachkey_test.go
+++ b/apiclient/detachkey_test.go
@@ -1,0 +1,117 @@
+package apiclient
+
+import (
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// withDetachKey pins the process-global detach key for one test and restores it.
+func withDetachKey(t *testing.T, b byte, display string) {
+	t.Helper()
+	prevByte, prevDisplay := tmux.DetachKeyByte, tmux.DetachKeyDisplay
+	tmux.SetDetachKey(b, display)
+	t.Cleanup(func() { tmux.SetDetachKey(prevByte, prevDisplay) })
+}
+
+// TestTrailingDetachKeyLen pins the #1832 contract: the detach key must be
+// recognized in EVERY encoding a pane program can negotiate onto the real
+// terminal, and must NOT be confused with a different key or a different
+// modifier combination. Lengths are computed with len() rather than hand-counted
+// so a test never encodes an off-by-one of its own.
+func TestTrailingDetachKeyLen(t *testing.T) {
+	withDetachKey(t, 23, "ctrl-w") // the default: ctrl-w, codepoint 'w' = 119
+
+	const (
+		legacy  = "\x17"
+		kitty   = "\x1b[119;5u"    // CSI 119 ; 5 u  — kitty disambiguate
+		modOthr = "\x1b[27;5;119~" // CSI 27 ; 5 ; 119 ~ — xterm modifyOtherKeys=2
+	)
+
+	for _, tc := range []struct {
+		name string
+		in   string
+		want int
+	}{
+		// The three encodings that mean "the user pressed the detach key".
+		{"legacy C0 byte", legacy, len(legacy)},
+		{"kitty CSI u", kitty, len(kitty)},
+		{"xterm modifyOtherKeys", modOthr, len(modOthr)},
+
+		// Lock state is OR-ed in by the terminal at will and must not defeat
+		// detach: caps_lock=64, num_lock=128 (encoded as bits+1).
+		{"kitty with num-lock on", "\x1b[119;133u", len("\x1b[119;133u")},
+		{"kitty with caps-lock on", "\x1b[119;69u", len("\x1b[119;69u")},
+		{"kitty with both locks on", "\x1b[119;197u", len("\x1b[119;197u")},
+
+		// kitty appends sub-params (event type / alternate key) when those
+		// progressive-enhancement flags are on; only the first sub-param counts.
+		{"kitty with event-type sub-param", "\x1b[119;5:1u", len("\x1b[119;5:1u")},
+
+		// #975: a read that batches typed bytes with the detach key detaches,
+		// and reports only the key's own length so the rest is forwarded.
+		{"batched legacy", "abc" + legacy, len(legacy)},
+		{"batched kitty", "abc" + kitty, len(kitty)},
+		{"batched modifyOtherKeys", "abc" + modOthr, len(modOthr)},
+
+		// Not the detach key: a real modifier difference must forward, never detach.
+		{"ctrl+shift+w is not the detach key", "\x1b[119;6u", 0},
+		{"alt+w is not the detach key", "\x1b[119;3u", 0},
+		{"unmodified w is not the detach key", "\x1b[119u", 0},
+		{"ctrl+x is a different key", "\x1b[120;5u", 0},
+		{"modifyOtherKeys ctrl+x is a different key", "\x1b[27;5;120~", 0},
+		{"modifyOtherKeys with no ctrl", "\x1b[27;1;119~", 0},
+
+		// Plain text and partial input must never be mistaken for the key.
+		{"plain w", "w", 0},
+		{"empty", "", 0},
+		{"bare escape", "\x1b", 0},
+		{"detach key not at the end", legacy + "abc", 0},
+		{"kitty sequence not at the end", kitty + "abc", 0},
+		{"unrelated CSI (cursor up)", "\x1b[A", 0},
+		{"malformed params", "\x1b[1x9;5u", 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := trailingDetachKeyLen([]byte(tc.in)); got != tc.want {
+				t.Fatalf("trailingDetachKeyLen(%q) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTrailingDetachKeyLen_RebindableKey proves the encoded forms track the
+// CONFIGURED key (config.ParseDetachKey only emits ctrl-<letter> and ctrl-\]^_),
+// rather than hard-coding ctrl-w's codepoint.
+func TestTrailingDetachKeyLen_RebindableKey(t *testing.T) {
+	t.Run("ctrl-a", func(t *testing.T) {
+		withDetachKey(t, 1, "ctrl-a") // codepoint 'a' = 97
+		if got := trailingDetachKeyLen([]byte("\x1b[97;5u")); got != len("\x1b[97;5u") {
+			t.Fatalf("rebound ctrl-a kitty encoding not matched: got %d", got)
+		}
+		if got := trailingDetachKeyLen([]byte("\x1b[119;5u")); got != 0 {
+			t.Fatalf("ctrl-w must not detach when ctrl-a is bound: got %d", got)
+		}
+		if got := trailingDetachKeyLen([]byte{1}); got != 1 {
+			t.Fatalf("rebound legacy byte not matched: got %d", got)
+		}
+	})
+
+	t.Run("ctrl-] maps to its punctuation codepoint", func(t *testing.T) {
+		withDetachKey(t, 29, "ctrl-]") // codepoint ']' = 93
+		if got := trailingDetachKeyLen([]byte("\x1b[93;5u")); got != len("\x1b[93;5u") {
+			t.Fatalf("ctrl-] kitty encoding not matched: got %d", got)
+		}
+	})
+
+	// ctrl-[ IS Esc, which the kitty protocol reports specially; hijacking a bare
+	// Esc would steal a key the agent needs, so it stays legacy-only.
+	t.Run("ctrl-[ has no encoded form", func(t *testing.T) {
+		withDetachKey(t, 27, "ctrl-[")
+		if got := trailingDetachKeyLen([]byte("\x1b[27;5u")); got != 0 {
+			t.Fatalf("ctrl-[ must not match an encoded form: got %d", got)
+		}
+		if got := trailingDetachKeyLen([]byte{27}); got != 1 {
+			t.Fatalf("ctrl-[ legacy byte must still detach: got %d", got)
+		}
+	})
+}

--- a/docs/tui-manual-testing.md
+++ b/docs/tui-manual-testing.md
@@ -103,6 +103,12 @@ it.
 `Enter`, `Tab`, `Shift-Tab`, `Esc`, `Ctrl-]`, and `1`–`9` are **reserved** and
 cannot be rebound (`[keys]` config). `Ctrl-W` is the configurable detach key
 (`detach_keys`); the driver reads it from `AF_DRIVER_DETACH_KEY`.
+
+The detach key is recognized in every encoding a terminal may report it in, not
+just the legacy control byte: an agent CLI that turns on the kitty keyboard
+protocol or `modifyOtherKeys` makes the terminal send `Ctrl-W` as an escape
+sequence instead (#1832). `af_detach` takes an optional raw sequence so a
+scenario can drive those encodings without that terminal.
 `←`/`→` switch panes only when a workspace pane has focus; with tree focus they
 keep the tree's collapse/expand behavior.
 
@@ -157,7 +163,7 @@ compose across `docker exec` invocations.
 | `af_exit_interactive` | `Ctrl-]` | interactive menu gone |
 | `af_send_to_pane <text>` | marker+text,`Enter` | short delivery marker echoes in the pane (then wait for output yourself) |
 | `af_attach` | `o` | TUI chrome gone (full-screen) |
-| `af_detach` | `Ctrl-W` | TUI chrome back **and** the attach client is reaped (guards #1157) |
+| `af_detach [raw_seq]` | `Ctrl-W` (once) | TUI chrome back **and** the attach client is reaped (guards #1157) |
 | `af_new_tab` | `t` | tab-child count rises |
 | `af_close_tab` | `w` | tab-child count falls |
 | `af_open_tasks` / `af_close_tasks` | `m` / `Esc` | tasks overlay (`r run`) appears / gone |

--- a/scripts/tui-driver-selftest.sh
+++ b/scripts/tui-driver-selftest.sh
@@ -306,6 +306,21 @@ step "assert selection survived attach/detach"              af_expect_selected b
 step "assert no orphan tmux attach clients"                 af_assert_no_orphan_clients
 step "pane text must not inflate the tab count (#1561 review)" _expect_pane_text_not_counted_as_tabs
 
+# --- #1832 regression: detach when the pane program has upgraded the keyboard ---
+# Full-screen attach is a raw byte proxy, so an agent CLI that negotiates a
+# richer keyboard encoding with the REAL terminal (claude emits `CSI > 1 u` and
+# `CSI > 4 ; 2 m` at startup) makes it report ctrl+w as an escape sequence rather
+# than 0x17 — and the user was left with no way out of the attach.
+#
+# The sandbox terminal is not kitty, so these steps inject the exact bytes such a
+# terminal sends for ctrl+w. That reproduces #1832 here without needing kitty:
+# before the fix both steps hang in the attach until they time out.
+step "attach full-screen (#1832 kitty encoding)"            af_attach
+step "detach via the kitty CSI u ctrl+w encoding (#1832)"   af_detach $'\e[119;5u'
+step "attach full-screen (#1832 modifyOtherKeys encoding)"  af_attach
+step "detach via the modifyOtherKeys ctrl+w encoding (#1832)" af_detach $'\e[27;5;119~'
+step "assert selection survived the encoded detaches (#1832)" af_expect_selected beta
+
 # --- #1822 regression: af_hide_pane across the multi-pane and single-pane flows ---
 # Runs last: it deliberately ends with an empty workspace.
 step "hide a pane while another remains, then the last (#1822)" _expect_multipane_hide

--- a/scripts/tui-driver.sh
+++ b/scripts/tui-driver.sh
@@ -578,13 +578,22 @@ af_attach() {
     sleep "$AF_DRIVER_POLL"
 }
 
-# af_detach — detach from a full-screen attach (Ctrl-W by default) and, the
+# af_detach [raw_sequence] — detach from a full-screen attach and, the
 # anti-#1157-flake part, wait until the attach client is actually reaped (the
 # count returns to the pre-attach baseline). A leaked client fails here.
+#
+# With no argument it presses the configured detach key ($AF_DRIVER_DETACH_KEY,
+# Ctrl-W) ONCE. Sending it once is the point: the key is pressed once by a real
+# user, so a retry here would paper over exactly the #1832 class of bug (a detach
+# key the client never recognizes) and report it green.
+#
+# With an argument, those raw bytes are injected instead — how a terminal whose
+# keyboard mode the pane program has upgraded actually reports the same
+# keypress. See the #1832 selftest steps.
 af_detach() {
-    af_send "$AF_DRIVER_DETACH_KEY"
-    sleep "$AF_DRIVER_POLL"
-    if ! af_capture | grep -q 'Agent Factory'; then
+    if [ $# -gt 0 ]; then
+        af_send_literal "$1" || return 1
+    else
         af_send "$AF_DRIVER_DETACH_KEY"
     fi
     af_wait_for 'Agent Factory' "$AF_DRIVER_TIMEOUT" 'detached back to TUI' || return 1


### PR DESCRIPTION
Fixes #1832 — an external-user regression (@gauntface, macOS + kitty + claude,
v1.0.184): `o` opens a full-screen attach and `Ctrl-W` no longer backs out of
it. It does nothing, and the user is stuck in the attach.

## Root cause

Full-screen attach is a **raw byte proxy**, so the pane program's output reaches
the real terminal untouched. Claude emits **both** of these at startup —
captured directly from a real `claude` run, not inferred:

```
ESC [ > 1 u        kitty keyboard protocol, "disambiguate escape codes"
ESC [ > 4 ; 2 m    xterm modifyOtherKeys level 2
```

A terminal that honors either one stops sending `ctrl+<key>` as a legacy C0
control byte. Per the [kitty spec][spec], disambiguate mode reports "the Esc,
alt+key, **ctrl+key**, ctrl+alt+key, shift+alt+key keys using `CSI u` sequences
instead of legacy ones" (only Enter/Tab/Backspace stay legacy). So on kitty the
detach key arrives as `ESC [ 119 ; 5 u`, and under modifyOtherKeys as
`ESC [ 27 ; 5 ; 119 ~` — **never** as `0x17`.

The attach input loop matched only `0x17`:

```go
if buf[n-1] == tmux.DetachKeyByte {   // 0x17
```

so the keypress was forwarded to the agent instead — where `ctrl+w` is a
harmless word-erase, which is why it looked like "nothing happens".

**Why it used to work.** Before #1592 Phase 2 PR7 (fc6a4d1), local attach ran
through a real `tmux attach-session` client. tmux is a terminal emulator in its
own right and consumed the inner program's keyboard-mode requests rather than
relaying them to the outer terminal, so the real terminal stayed in legacy mode
and `0x17` was correct. The clientless WS proxy has no such buffer — the same
"raw proxy scribbles the pane program's modes onto the real terminal" hazard
#845 already designs around for alt-screen/mouse, with the keyboard mode
unaccounted for.

This is **not** kitty-only: any terminal honoring either protocol is affected.
It needs an agent that negotiates the mode (claude does; a plain shell does not),
which is why it escaped the sandbox.

## Fix

`apiclient/detachkey.go` recognizes the detach key in every encoding a pane
program can put the terminal into, keeping detection a suffix test on the read
chunk so the #975 batching rule still holds:

- legacy `0x17`
- kitty `CSI <codepoint> ; <mods> u`
- xterm modifyOtherKeys `CSI 27 ; <mods> ; <codepoint> ~`

Encodings are derived from the **configured** key (`detach_keys`), not
hard-coded to `ctrl-w`. caps/num-lock bits are masked off (a terminal ORs them
in at will); a genuine modifier difference like `ctrl+shift+w` still forwards.

I chose this over stripping the pane program's negotiated mode from the output
stream: stripping would silently degrade the agent's own key handling
(shift+enter and friends) for every user, to fix a key af owns.

## Verification

- **Reproduced pre-fix, in-container.** The sandbox terminal isn't kitty, so the
  new driver steps inject the exact bytes such a terminal sends. On the pre-fix
  binary the run **hangs in the attach and fails** at the kitty step; with the
  fix, 38/38 green. That turns #1832 into a deterministic scenario without
  needing a Mac or kitty.
- **Unit + driver tests fail without the fix.** `TestAttachStream_Encoded*`
  drives the real attach driver from stdin and fails on the old detection.
  `TestTrailingDetachKeyLen` pins the encoding matrix, including the
  must-not-match cases.
- `af_detach` now sends the key **once**. It previously retried on failure,
  which is exactly what let a detach key the client never recognizes report
  green — a real user presses it once.

## Gates

`make tui-driver-selftest` 38/38 · `make test-container` · `go build ./...` ·
`gofmt -l .` · `golangci-lint run --fast` · `deadcode -test ./...` ·
`scripts/lint-file-length.sh` · `shellcheck`

[spec]: https://sw.kovidgoyal.net/kitty/keyboard-protocol/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
