### PR TITLE
fix(pty): recovery must not replay dead-pane bytes after the repaint (#1840)

### DIFF
--- a/session/ptybroker.go
+++ b/session/ptybroker.go
@@ -323,7 +323,9 @@ func (b *ptyBroker) maybeStopCapture() {
 //
 //  1. Stops the stale capture — unblocking and JOINING the parked readLoop (no
 //     goroutine leak) — and clears the capturing latch.
-//  2. If subscribers are STILL attached (a web/TUI client that stayed connected
+//  2. Discards the dead pane's still-buffered ring bytes, so a subscriber that was
+//     lagging at recovery cannot be handed them after the repaint (#1840).
+//  3. If subscribers are STILL attached (a web/TUI client that stayed connected
 //     across the respawn — the common case), restarts the capture against the fresh
 //     pane and re-seeds each subscriber with a repaint of the recovered screen, so it
 //     resumes output on its OWN rather than hanging until some unrelated later
@@ -355,9 +357,25 @@ func (b *ptyBroker) resetCapture() {
 		stop()
 	}
 
+	// Discard the dead pane's buffered output (#1840). This is the ONLY point where
+	// that is race-free: the old readLoop has been joined by the stop above and the
+	// fresh one is not started until below, so the ring provably holds dead-pane bytes
+	// and nothing else, and no feed can interleave. Dropping the bytes while KEEPING
+	// the seq monotonic (base jumps to head over an emptied ring) means a lagging
+	// subscriber — one whose WS write blocked while the dying pane kept producing —
+	// hits the existing `cursor < base` eviction clamp in NextEvent and fast-forwards
+	// to the live tail. Without this it would take the recovery repaint and THEN the
+	// pre-recovery bytes, overwriting the recovered screen with the dead pane's
+	// content. Nothing needs to touch subscriber cursors directly; the clamp is the
+	// same mechanism a ring overflow already uses.
+	//
+	// Unconditional, including when nobody is attached: a later Subscribe(since) would
+	// otherwise replay the dead pane's tail into a fresh client.
+	b.mu.Lock()
+	b.base = b.headLocked()
+	b.buf = nil
 	// Re-read the subscriber count AFTER the teardown drained: nobody left → just the
 	// lazy re-arm, the next Subscribe restarts a fresh capture.
-	b.mu.Lock()
 	resume := !b.closed && len(b.subs) != 0
 	b.mu.Unlock()
 	if !resume {

--- a/session/ptybroker_recovery_test.go
+++ b/session/ptybroker_recovery_test.go
@@ -197,3 +197,77 @@ func TestPTYBrokerResetCaptureJoinsParkedReadLoop(t *testing.T) {
 		t.Fatal("resetCapture blocked — parked readLoop never joined (goroutine leak)")
 	}
 }
+
+// waitRingHead blocks until the broker's ring head reaches want — i.e. feed() has
+// actually appended the emitted bytes. emit()'s Write returns once the readLoop's
+// Read consumed the bytes, which is one step SHORT of them landing in the ring, so a
+// test that must observe a lagging cursor has to synchronise on the ring itself
+// rather than on the write.
+func waitRingHead(t *testing.T, br *ptyBroker, want Seq) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		br.mu.Lock()
+		head := br.headLocked()
+		br.mu.Unlock()
+		if head >= want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("ring head never reached %d", want)
+}
+
+// TestPTYBrokerRecoveryDoesNotReplayStaleBytes is the #1840 regression: a subscriber
+// that is BEHIND at recovery time must not receive the dead pane's buffered bytes
+// after the recovery repaint.
+//
+// The setup the existing recovery tests never hit: every one of them drains each
+// event as it lands, so the subscriber's cursor is always at the live tail when
+// resetCapture runs and the ring holds nothing to replay. In production a subscriber
+// falls behind whenever its WS write blocks (up to the write timeout) while the pane
+// keeps producing — so at recovery its cursor sits below head with dead-pane bytes in
+// between.
+//
+// Fail-before/pass-after: before the fix, reseed injects the repaint but leaves the
+// ring and cursors untouched, so NextEvent returns the repaint and then — seeing
+// cursor < head — hands back the dead pane's bytes, which overwrite the freshly
+// repainted screen. After the fix resetCapture discards the dead pane's ring bytes at
+// the recovery boundary, so the repaint is the last thing A sees until the re-spawned
+// pane produces real output.
+func TestPTYBrokerRecoveryDoesNotReplayStaleBytes(t *testing.T) {
+	ch := &fakeClientlessChannel{snapshot: []byte("SCREEN-BEFORE-DEATH")}
+	br := newPTYBroker(ch)
+
+	a, err := br.subscribe(0)
+	if err != nil {
+		t.Fatalf("subscribe A: %v", err)
+	}
+	mustRepaintContains(t, a, "SCREEN-BEFORE-DEATH")
+
+	// A falls behind: the dying pane emits bytes A never consumes (its WS write was
+	// blocked). They sit in the ring with A's cursor still behind head.
+	const stale = "STALE-BYTES-FROM-DEAD-PANE"
+	ch.emit(t, []byte(stale))
+	waitRingHead(t, br, Seq(len(stale)))
+
+	// tmux dies and the daemon re-spawns it; the recovered pane shows a new screen.
+	ch.mu.Lock()
+	ch.snapshot = []byte("SCREEN-AFTER-RECOVERY")
+	ch.mu.Unlock()
+	br.resetCapture()
+
+	// A repaints the recovered screen...
+	mustRepaintContains(t, a, "SCREEN-AFTER-RECOVERY")
+
+	// ...and must NOT then be handed the dead pane's bytes on top of it.
+	if ev, err := nextWithin(t, a, 250*time.Millisecond); err == nil {
+		t.Fatalf("after the recovery repaint A got Kind=%d Data=%q, want no event: "+
+			"dead-pane bytes must not overwrite the recovered screen", ev.Kind, ev.Data)
+	}
+
+	// The recovered pane still streams: discarding the dead bytes must not wedge the
+	// ring or strand A's cursor above head.
+	ch.emit(t, []byte("post-recovery-output"))
+	mustData(t, a, "post-recovery-output")
+}


### PR DESCRIPTION
Fixes #1840.

## Verified, not taken on faith

The report reproduces on current master. Before touching production code, the regression test returns the dead pane's bytes right after the recovery repaint:

```
--- FAIL: TestPTYBrokerRecoveryDoesNotReplayStaleBytes
    after the recovery repaint A got Kind=0 Data="STALE-BYTES-FROM-DEAD-PANE",
    want no event: dead-pane bytes must not overwrite the recovered screen
```

## Root cause

`resetCapture` (`session/ptybroker.go`) recovers the broker onto a re-spawned tmux pane, but `reseedSubscribersLocked` only injects a `pendingRepaint` — it leaves the ring buffer holding the **dead** pane's output and every subscriber cursor where it was.

A subscriber only trips this if it is *behind* at recovery time (`cursor < head`), which happens in production whenever its WebSocket write blocks (up to the write timeout) while the dying pane keeps producing. `NextEvent` then returns the repaint first, and on the next call sees `cursor < head` and hands back the pre-recovery bytes — so the recovered screen is overwritten with the dead pane's content.

Introduced by b143d257 (#1691), which added the recovery re-arm for #1682.

Every existing recovery test drains each event as it lands, so the cursor is always at the live tail when `resetCapture` runs and the ring has nothing to replay — which is why the gap survived.

## The fix

Discard the dead pane's ring bytes in `resetCapture`, **between the stale capture's stop and the fresh capture's start**.

That placement is the point of the change. It is the only race-free moment: the old `readLoop` has been joined by the stop and the new one has not started, so the ring provably holds dead-pane bytes and nothing else, and no `feed` can interleave. I deliberately did **not** take the issue's recommended fix (clear the ring inside `reseedSubscribersLocked`) — that runs *after* `ensureCaptureStartedLocked`, so the new pane's readLoop is already feeding the ring and any bytes landing between `Snapshot()` and the lock would be silently dropped. That would trade a display-corruption bug for a byte-loss bug.

`base` jumps to `head` over an emptied ring, so:
- the seq stays **monotonic**, preserving the `?since` replay contract;
- a lagging cursor fast-forwards through the existing `cursor < base` eviction clamp in `NextEvent` — the same mechanism a ring overflow already uses, so no subscriber cursor needs touching directly.

The discard is unconditional (even with nobody attached), since a later `Subscribe(since)` would otherwise replay the dead pane's tail into a fresh client.

## Gates

- `make test-container` — green, all packages `ok`
- `make tui-driver-selftest` — 33/33 steps green
- `go build ./...`, `gofmt -l .`, `golangci-lint run --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh` — all clean
- `go test ./session/ -race -count=5` — no flakes

Regression test fails before / passes after (verified by stashing the production change with the test in place). Scope is 2 files: the fix and its test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)