### PR TITLE
fix(bugreport): redact conversation ids on the generic-JSON fallback path (#1839)

### DIFF
--- a/bugreport/bugreport_test.go
+++ b/bugreport/bugreport_test.go
@@ -327,6 +327,55 @@ func TestRedactInstancesFallbackRedactsAllNestedTitleFields(t *testing.T) {
 	}
 }
 
+// TestRedactInstancesFallbackRedactsConversationIDs is the #1839 regression
+// guard. The typed path clears Tabs[].Conversation.ID and
+// AgentConversation.ID (asserted in TestRedactInstanceData) because a provider
+// conversation id resumes an agent session and must not ship in a publicly
+// shared bundle. Before the fix neither `conversation` nor `agent_conversation`
+// was in sensitiveJSONKeys, and `id` is deliberately absent (it is a structural
+// key that must survive), so a record failing the typed decode leaked both ids
+// verbatim.
+//
+// The variants below pin the reason the whole object is dropped rather than
+// just its "id": this path runs precisely because the shape did NOT parse, so
+// a legacy record may carry the id as a bare string or under a different key,
+// and an id-only rule would miss those.
+func TestRedactInstancesFallbackRedactsConversationIDs(t *testing.T) {
+	r := &redactor{}
+	raw := json.RawMessage(`[{
+		"id": "leg-1",
+		"status": "legacy-string-status",
+		"program": "claude",
+		"agent_conversation": {"agent": "claude", "id": "instance-convid-secret"},
+		"worktree": {"branch": "feature/test"},
+		"tabs": [
+			{"conversation": {"agent": "claude", "id": "tab-convid-secret"}},
+			{"conversation": "bare-string-convid-secret"},
+			{"conversation": {"nested": {"session_id": "nested-convid-secret"}}}
+		]
+	}]`)
+
+	out := string(r.redactInstancesJSON(raw))
+
+	// Each id uses a distinct sentinel so a survivor pinpoints the shape that leaked.
+	for _, leak := range []string{
+		"instance-convid-secret",    // top-level agent_conversation.id
+		"tab-convid-secret",         // nested tabs[].conversation.id
+		"bare-string-convid-secret", // legacy shape: conversation is a string
+		"nested-convid-secret",      // legacy shape: id under a different key
+	} {
+		if strings.Contains(out, leak) {
+			t.Errorf("fallback path leaked conversation id %q:\n%s", leak, out)
+		}
+	}
+	// Structural triage fields must still survive: `id` is NOT sensitive, and
+	// blanket-redacting it to fix this bug would gut the bundle's usefulness.
+	if !strings.Contains(out, "leg-1") || !strings.Contains(out, "legacy-string-status") ||
+		!strings.Contains(out, "claude") || !strings.Contains(out, "feature/test") {
+		t.Errorf("fallback dropped safe structural fields:\n%s", out)
+	}
+}
+
 // TestRedactInstancesFallbackNotesTitlesForLogScrub is the #1790 regression
 // guard. #1680 taught the fallback path to redact the title-bearing keys out of
 // the JSON section, but the fallback still never recorded those titles for

--- a/bugreport/redact.go
+++ b/bugreport/redact.go
@@ -387,6 +387,17 @@ var sensitiveJSONKeys = map[string]bool{
 	// including the nested tabs[].tmux_name and worktree.session_name the
 	// recursive walk below reaches (#1680).
 	"tmux_name": true, "session_name": true,
+	// conversation and agent_conversation mirror the typed-path redaction
+	// (redactInstanceData clears Tabs[].Conversation.ID and
+	// AgentConversation.ID): the provider conversation id resumes an agent
+	// session and must not ship in a publicly shared bundle. The whole object
+	// is dropped rather than just its "id" — on this path the shape is by
+	// definition one we could not parse, so a legacy record may carry the id
+	// as a bare string, under a differently-named key, or nested deeper, and
+	// an id-only rule would miss every such variant. The surviving typed
+	// fields (agent, captured_at) are not worth reconstructing a shape
+	// contract for here (#1839).
+	"conversation": true, "agent_conversation": true,
 }
 
 // redactUnknownJSON recursively rebuilds a decoded JSON value, blanking any


### PR DESCRIPTION
Fixes #1839.

## Verified the report first

Reproduces on current master (`c0043f7`). Confirmed end-to-end through the real `af bug-report` CLI, against an isolated `AGENT_FACTORY_HOME` holding a corrupt `instances.json` — **3 conversation ids in the shared bundle before, 0 after**:

```
# BEFORE                                  # AFTER
"agent_conversation": {                   "agent_conversation": "[redacted]",
  "agent": "claude",                      "tabs": [
  "id": "e2e-INSTANCE-CONVID-9f2c"          {"conversation": "[redacted]", "name": "agent"},
},                                          {"conversation": "[redacted]", "name": "legacy"}
"tabs": [                                 ]
  {"conversation": {"id": "e2e-TAB-CONVID-7a1b"}, ...},
  {"conversation": "e2e-BARESTRING-CONVID-3d4e", ...}
]
```

## Root cause

`instances.json` is redacted two ways (`bugreport/redact.go:333`):

- **Typed path** — `redactInstanceData` clears `Tabs[].Conversation.ID` and `AgentConversation.ID` (`redact.go:444-450`), asserted by `TestRedactInstanceDataKeepsStructuralDropsFreeText`.
- **Fallback path** — when the payload does not decode as `[]InstanceData` (corrupt/legacy shape), `redactUnknownJSON` blanks only values whose key is in `sensitiveJSONKeys`.

Neither `conversation` nor `agent_conversation` was in that map, so a record failing the typed decode shipped both provider conversation ids verbatim into a bundle explicitly meant to be shared publicly. Same typed-vs-fallback parity gap as #1680 (tmux_name/session_name) and #1790.

## One correction to the report

The issue's inline annotation reads `"id" is not treated as sensitive` — but **adding `id` to `sensitiveJSONKeys` would be the wrong fix**. `id` is a structural triage key the fallback deliberately keeps (the doc comment says so, and `TestRedactInstancesFallbackRedactsOnDecodeFailure` asserts `leg-1` survives). Blanket-redacting it would gut the bundle. The fix keys off the conversation *objects* instead — which is what the issue's own "Recommended Fix" section says.

## Fix

Add `conversation` and `agent_conversation` to `sensitiveJSONKeys` (2 lines + rationale comment).

**Why drop the whole object rather than just its `id`:** this path runs *precisely because the shape did not parse*, so an id-only rule would assume shape on the one path that cannot. A legacy record may carry the id as a bare string, under a differently-named key, or nested deeper — all missed by an id-only rule, all covered by the key-level drop. This matches the fallback's documented fail-safe stance ("redact MORE, not less… under-including beats leaking"). Cost is `agent`/`captured_at` on the fallback path only; the fallback already over-redacts vs. typed (e.g. `path`, `title`).

## Adjacent call-site audit

Diffed every field `redactInstanceData` clears against `sensitiveJSONKeys` — `title`, `prompt`, `session_name`, `tmux_name`, `command`, `url` all have counterparts. `conversation`/`agent_conversation` were the **only** gaps of this class; no others outstanding.

## Test

`TestRedactInstancesFallbackRedactsConversationIDs` — **fails before / passes after** (verified by stashing the fix: all 4 sentinels leak). Pins all three corrupt shapes (object-with-id, bare string, renamed nested key) with distinct sentinels so a survivor pinpoints the leaking shape, plus the structural-fields-survive half.

## Gates

| Gate | Result |
|---|---|
| `make test-container` | green — 27 pkgs, 0 fail |
| `make tui-driver-selftest` | **33/33** green (harness has grown past the 25 steps in the ask) |
| `go build ./...` | clean |
| `gofmt -l .` | clean |
| `golangci-lint --fast` | clean |
| `deadcode -test ./...` | clean |
| `scripts/lint-file-length.sh` | clean |

Not merging — flagged for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)