### PR TITLE
fix(task): persist ProjectPath through the patch-based task save (#1836)

### DIFF
--- a/task/task.go
+++ b/task/task.go
@@ -425,6 +425,7 @@ type TaskUpdate struct {
 	CronExpr      *string `json:"cron_expr,omitempty"`
 	WatchCmd      *string `json:"watch_cmd,omitempty"`
 	TargetSession *string `json:"target_session,omitempty"`
+	ProjectPath   *string `json:"project_path,omitempty"`
 	Program       *string `json:"program,omitempty"`
 	Enabled       *bool   `json:"enabled,omitempty"`
 }
@@ -451,7 +452,8 @@ func (u *TaskUpdate) GobDecode(data []byte) error {
 // writes nothing new.
 func (u TaskUpdate) IsEmpty() bool {
 	return u.Name == nil && u.Prompt == nil && u.CronExpr == nil &&
-		u.WatchCmd == nil && u.TargetSession == nil && u.Program == nil && u.Enabled == nil
+		u.WatchCmd == nil && u.TargetSession == nil && u.ProjectPath == nil &&
+		u.Program == nil && u.Enabled == nil
 }
 
 // apply merges the non-nil fields of u onto t and returns the result. It never
@@ -472,6 +474,9 @@ func (u TaskUpdate) apply(t Task) Task {
 	}
 	if u.TargetSession != nil {
 		t.TargetSession = *u.TargetSession
+	}
+	if u.ProjectPath != nil {
+		t.ProjectPath = *u.ProjectPath
 	}
 	if u.Program != nil {
 		t.Program = *u.Program
@@ -510,6 +515,9 @@ func DiffTask(old, cur Task) TaskUpdate {
 	}
 	if cur.TargetSession != old.TargetSession {
 		u.TargetSession = &cur.TargetSession
+	}
+	if cur.ProjectPath != old.ProjectPath {
+		u.ProjectPath = &cur.ProjectPath
 	}
 	if cur.Program != old.Program {
 		u.Program = &cur.Program

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -256,6 +256,41 @@ func TestUpdateTaskFieldLevelDoesNotClobber(t *testing.T) {
 	assert.Equal(t, "orig", got.Name)
 }
 
+// TestDiffTaskAndUpdatePersistProjectPath is the regression guard for #1836.
+// The TUI edit form lets a user retarget a task at another repo, and its save
+// path ships a DiffTask patch. While ProjectPath was missing from TaskUpdate the
+// diff came back empty, so the edit was dropped with no error and the old path
+// reappeared on reload — data loss the user had no way to see fail.
+func TestDiffTaskAndUpdatePersistProjectPath(t *testing.T) {
+	setupTestTasks(t, []Task{
+		{ID: "p1", Name: "orig", Prompt: "p", CronExpr: "0 9 * * *", ProjectPath: "/repos/old", Program: "claude", Enabled: true},
+	})
+
+	loaded, err := GetTask("p1")
+	require.NoError(t, err)
+	old := *loaded
+	cur := old
+	cur.ProjectPath = "/repos/new"
+
+	// A ProjectPath-only edit must diff to a real patch; an empty one is the bug.
+	patch := DiffTask(old, cur)
+	require.False(t, patch.IsEmpty(), "a ProjectPath-only edit must produce a non-empty patch")
+	require.NotNil(t, patch.ProjectPath, "the patch must carry the retargeted path")
+	assert.Equal(t, "/repos/new", *patch.ProjectPath)
+
+	merged, err := UpdateTask("p1", patch)
+	require.NoError(t, err)
+	assert.Equal(t, "/repos/new", merged.ProjectPath)
+
+	// What the user sees after saving and reloading.
+	got, err := GetTask("p1")
+	require.NoError(t, err)
+	assert.Equal(t, "/repos/new", got.ProjectPath, "the retargeted path must survive a reload")
+	// Fields the patch never mentioned stay as-stored.
+	assert.Equal(t, "orig", got.Name)
+	assert.Equal(t, "0 9 * * *", got.CronExpr)
+}
+
 // TestTaskUpdateGobRoundTripPreservesZeroPointers guards the net/rpc control
 // socket (the CLI transport): gob elides a struct field at its zero value and
 // follows a *bool→false / *string→"" down to that zero and drops it, decoding the

--- a/ui/task_pane_test.go
+++ b/ui/task_pane_test.go
@@ -95,6 +95,41 @@ func TestTaskPaneConsumeDirtyTracksOnlyEditedTasks(t *testing.T) {
 	assert.Empty(t, tp.ConsumeDirty(), "ConsumeDirty must clear the dirty set")
 }
 
+// TestTaskPaneEditSavesProjectPath is the pane-level regression guard for
+// #1836. Retargeting a task at another repo through the edit form must reach
+// the save path as a real patch. The form set ProjectPath on the in-memory task
+// and marked it dirty, so the new path showed in the TUI, but the emitted patch
+// dropped the field — the edit was silently lost on the next reload.
+func TestTaskPaneEditSavesProjectPath(t *testing.T) {
+	oldRepo, newRepo := newGitRepo(t), newGitRepo(t)
+	tp := NewTaskPane()
+	tp.SetTasks([]task.Task{{
+		ID:          "abc",
+		Name:        "nightly",
+		Prompt:      "do it",
+		CronExpr:    "* * * * *",
+		ProjectPath: oldRepo,
+		Program:     "claude",
+		Enabled:     true,
+	}})
+	tp.SetFocus(true)
+	tp.EnterEditSelected()
+	require.True(t, tp.IsEditing())
+
+	// Retarget at the other repo and save from a non-prompt field (Enter on the
+	// prompt inserts a newline instead of submitting).
+	tp.editPath.SetValue(newRepo)
+	require.True(t, tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter}))
+	assert.Empty(t, tp.editError, "a valid repo path must not fail validation")
+	assert.False(t, tp.IsEditing(), "a successful save closes the form")
+
+	dirty := tp.ConsumeDirty()
+	require.Len(t, dirty, 1, "the retargeted task must be dirty")
+	assert.Equal(t, "abc", dirty[0].ID)
+	require.NotNil(t, dirty[0].Update.ProjectPath, "the patch must carry the retargeted project path")
+	assert.Equal(t, newRepo, *dirty[0].Update.ProjectPath)
+}
+
 // TestTaskPaneConsumeDirtyExcludesDeletedTask verifies that a task edited and
 // then deleted is not returned by ConsumeDirty — deletion is handled by
 // ConsumeDeleted, and updating a just-removed task would log a spurious


### PR DESCRIPTION
Fixes #1836.

## The bug

Editing a task's project path through the TUI edit form appears to save — the new path renders immediately and no error is shown — but the old path is back after a reload. Silent data loss, and the user has no signal that the save failed.

Verified reproducing on current master before fixing (a `ProjectPath`-only edit diffs to `IsEmpty() == true`, and the merged record keeps the old path).

## Root cause

A regression from #1703 (a4b26c6), which moved task saves from full-struct writes to field-level patches. The old full-struct write persisted `ProjectPath` by construction:

```go
tasks[i] = t  // whole struct, ProjectPath included
```

The patch pipeline never carried it, because `TaskUpdate` (`task/task.go:422`) has no `ProjectPath` field — so `DiffTask` (`task/task.go:497`) produced no entry and `apply` (`task/task.go:460`) never wrote it.

The TUI edit form was not updated to match: `ui/task_pane_edit.go:136` still sets `ProjectPath` on the in-memory task and marks it dirty. That is why the change is visible in the session — `ConsumeDirty` then diffs it into an empty patch, which the save path skips as a well-formed no-op.

## The fix

Add `ProjectPath` to the patch pipeline — `TaskUpdate`, `IsEmpty`, `apply`, `DiffTask` — mirroring the `Task` struct's field order.

Two deliberate scoping calls:

- **No new validation.** `AddTask` does not check that `ProjectPath` is a git repo either; the TUI form does that at the point of edit (`ui/task_pane_edit.go:58`). `UpdateTask` stays consistent with the create path rather than growing a check its sibling lacks.
- **No new CLI flag.** `af tasks update --project-path` would be a separate CLI-contract decision. This PR restores the pre-regression behavior and nothing more.

The JSON-backed gob codec already covers the new pointer field, so the CLI control socket carries it losslessly (the #1700 zero-pointer-elision hazard is handled).

I audited the adjacent field enumerations for the same omission: `bugreport/redact.go` already projects `ProjectPath`, so the patch pipeline was the only gap.

## Tests

Both are real regression guards — verified failing before the change and passing after:

- `task.TestDiffTaskAndUpdatePersistProjectPath` — a path-only edit must diff to a non-empty patch and survive a reload. Also pins `IsEmpty`, which is what silently swallowed the edit.
- `ui.TestTaskPaneEditSavesProjectPath` — drives the real edit form end-to-end (two throwaway git repos, retarget, Enter to save) and asserts the emitted patch carries the new path.

## Gates

- `make test-container` — green, full suite
- `make tui-driver-selftest` — 33/33 steps green
- `go build ./...` — clean
- `gofmt -l .` — no output
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — no output
- `scripts/lint-file-length.sh` — passed

Not merging — flagging for review.

Co-authored-by: Captain Claude <noreply@anthropic.com>