### PR TITLE
fix(daemon): arm the root kill grace window when finishing an interrupted kill (#1844)

### DIFF
--- a/daemon/rootagent_test.go
+++ b/daemon/rootagent_test.go
@@ -379,6 +379,72 @@ func TestEnsureRootAgentsUserKillHealsAfterGraceWindow(t *testing.T) {
 	}
 }
 
+// TestFinishUserKillArmsRootGraceWindow pins #1844: a root kill interrupted
+// after its tombstone write (daemon crash, or a teardown that errored) is
+// completed by the status poll's finish-kill pass, which must arm the same
+// grace window KillSession does. Otherwise the ensure loop, seeing no
+// rootKilledAt, re-creates the root on the very next tick and the user's stop
+// is never honored at all.
+func TestFinishUserKillArmsRootGraceWindow(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	seen := installOptionsRecordingBackend(t)
+	repoPath := setupControlRepo(t)
+	cfg := rootTestConfig(repoPath, config.RootAgentConfig{})
+
+	base := time.Unix(1_700_000_000, 0)
+	clock := base
+	origNow := nowFunc
+	nowFunc = func() time.Time { return clock }
+	t.Cleanup(func() { nowFunc = origNow })
+
+	manager, err := NewManager(cfg)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	manager.EnsureRootAgents()
+	if len(*seen) != 1 {
+		t.Fatalf("expected initial create, got %d", len(*seen))
+	}
+
+	// Model the #1108 crash window: KillSession persisted the kill-intent
+	// tombstone and then died before it could record the grace window. The
+	// surviving record is provably a user kill, so the poll's finish pass owns
+	// the rest of the teardown.
+	root := findRootInstance(t, manager, repoPath)
+	if root == nil {
+		t.Fatal("root instance must exist before the interrupted kill")
+	}
+	root.MarkUserKilled()
+
+	manager.RefreshStatuses()
+	if findRootInstance(t, manager, repoPath) != nil {
+		t.Fatal("the finish-kill pass must drop the tombstoned root")
+	}
+
+	// Inside the grace window the user's stop is honored, exactly as it is when
+	// KillSession runs to completion uninterrupted.
+	clock = base.Add(rootKillHealDelay - time.Second)
+	manager.EnsureRootAgents()
+	manager.EnsureRootAgents()
+	if len(*seen) != 1 {
+		t.Fatalf("a crash-recovered root kill must honor the grace window, got %d creates", len(*seen))
+	}
+	if findRootInstance(t, manager, repoPath) != nil {
+		t.Fatal("root must stay down inside the grace window")
+	}
+
+	// ...and still self-heals once the window elapses: an explicit kill delays
+	// re-creation, it is never a permanent stop (#1223).
+	clock = base.Add(rootKillHealDelay + time.Second)
+	manager.EnsureRootAgents()
+	if len(*seen) != 2 {
+		t.Fatalf("configured root must self-heal after the grace window, got %d creates", len(*seen))
+	}
+	if findRootInstance(t, manager, repoPath) == nil {
+		t.Fatal("root instance must be back after self-heal")
+	}
+}
+
 // TestKillDeadRootDoesNotDeleteSelfHealedRoot pins #1266: a KillSession that
 // resolved dead root-A must not delete a newly self-healed root-B that reused
 // the reserved title while the stale kill was waiting on the session op lock.

--- a/daemon/rootkill.go
+++ b/daemon/rootkill.go
@@ -58,9 +58,12 @@ func (m *Manager) persistKillTombstone(repoID string, instance *session.Instance
 // finishUserKill completes the teardown of a session whose record carries the
 // kill-intent tombstone (#1108): the previous KillSession was interrupted by a
 // daemon crash or a teardown error after the tombstone write. Mirrors the tail
-// of KillSession — best-effort Kill, targeted record delete, map removal — and
-// retries on the next poll if the record delete fails. Skips while an explicit
-// KillSession for the same session is still in flight.
+// of KillSession — best-effort Kill, targeted record delete, map removal, and
+// the root kill grace window (#1844) — and retries on the next poll if the
+// record delete fails. Skips while an explicit KillSession for the same session
+// is still in flight. Anything KillSession's tail learns to do after the
+// tombstone write belongs here too: the tombstone means the user's kill is
+// already committed, so the two paths must reach the same end state.
 func (m *Manager) finishUserKill(repoID string, instance *session.Instance) {
 	key := daemonInstanceKey(repoID, instance.Title)
 	m.mu.Lock()
@@ -116,6 +119,18 @@ func (m *Manager) finishUserKill(repoID string, instance *session.Instance) {
 	m.mu.Lock()
 	if m.instances[key] == instance {
 		delete(m.instances, key)
+	}
+	if session.IsReservedTitle(instance.Title) {
+		// Arm the grace window the interrupted KillSession never reached
+		// (#1844). Without this the ensure loop sees no rootKilledAt and
+		// re-creates the root on the next tick, so a kill that happened to be
+		// interrupted is honored for zero seconds while an uninterrupted one is
+		// honored for rootKillHealDelay. Timed from the finish, not the
+		// original kill: the tombstone records intent, not when it was formed,
+		// and re-arming here is what the surviving intent is owed. Still only a
+		// delay — the loop self-heals a configured root afterwards (#1223).
+		m.rootKilledAt[repoID] = nowFunc()
+		log.InfoLog.Printf("root agent for repo %s: finished an interrupted user kill; the ensure loop will re-create it in ~%s unless the repo is removed from root_agents", repoID, rootKillHealDelay)
 	}
 	m.mu.Unlock()
 }


### PR DESCRIPTION
Fixes #1844.

## Verified on master first

The report reproduces. Its own "failing test" section showed both tests *passing* — those were characterization tests asserting the buggy behavior, so I wrote a real repro before touching anything. Against unmodified production code (test-only diff):

```
--- FAIL: TestFinishUserKillArmsRootGraceWindow (4.39s)
    rootagent_test.go:430: a crash-recovered root kill must honor the grace window, got 2 creates
```

Two creates = the root agent was instantly resurrected inside its grace window. The control (`TestEnsureRootAgentsUserKillHealsAfterGraceWindow`, the uninterrupted path) passes on the same commit, which is what makes this an inconsistency between two paths rather than a broken expectation.

## Root cause

`KillSession` persists the #1108 kill-intent tombstone before teardown, then records `rootKilledAt` so the ensure loop honors the user's stop for `rootKillHealDelay` before self-healing a still-configured root (#1223).

When a kill is interrupted after the tombstone write, the status poll's finish-kill pass (`finishUserKill`) completes it instead. That pass mirrors `KillSession`'s tail but was never updated when the grace window landed 2 days later in #1237 — so it tore the root down **without** arming `rootKilledAt`. The ensure loop saw no kill on record and re-created the root on the next tick. An interrupted kill was honored for zero seconds; an identical uninterrupted one for 2 minutes.

**Broader than the report claims:** `rootKilledAt` is in-memory, so no crash is required. A live daemon whose teardown errors after the tombstone write reaches the same finish pass and loses the window with no restart involved.

## Fix

Mirror the reserved-title branch from `KillSession`'s tail — 12 lines.

The window is timed from the finish, not the original kill: the tombstone records *that* the user committed to the kill, not *when*, and re-arming is what that surviving intent is owed. It remains only a delay — a configured root still self-heals afterwards (#1223).

I also updated `finishUserKill`'s doc comment, which enumerates what it mirrors from `KillSession`. That enumeration is exactly what let this bug hide for 10 days, so it now names the grace window and states the general contract: anything `KillSession`'s tail learns to do after the tombstone write belongs here too.

## Adjacent call-site audit

Every site that mutates `rootKilledAt`:

| Site | Behavior | Verdict |
|---|---|---|
| `KillSession` | arms | correct |
| `finishUserKill` | **now arms** | the bug |
| `reapDeadRoot` | deliberately does not arm | correct — daemon self-heal, not a user decision (documented at `rootagent.go:260`) |
| `DeleteProject` | clears | correct |
| ensure loop post-grace | clears | correct |

`finishUserKill` was the only gap.

## Gates

- `make test-container` — all packages green, incl. `daemon` (118s)
- `make tui-driver-selftest` — **33/33** green (baseline has grown past the 25 in the ticket)
- `go build ./...`, `gofmt -l .`, `golangci-lint run --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh` — all clean

Not merging — flagging for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)