### PR TITLE
fix(daemon): deleted project's root fails fast, not a 30s "being recreated" wait (#1835)

### DIFF
--- a/daemon/deliver_prompt_test.go
+++ b/daemon/deliver_prompt_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/internal/testguard"
 	"github.com/sachiniyer/agent-factory/session"
+	sessiongit "github.com/sachiniyer/agent-factory/session/git"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
@@ -911,6 +912,74 @@ func TestDeliverPrompt_ReservedRootUnconfiguredStillRejected(t *testing.T) {
 	// It must fail fast (the create path), not wait out the root recreation bound.
 	if elapsed > 5*time.Second {
 		t.Errorf("unconfigured reserved-root delivery took %v; must fail fast, not wait for a root that will never come", elapsed)
+	}
+}
+
+// TestDeliverPrompt_DeletedProjectRootStillRejected pins #1835: a project
+// deleted at runtime suppresses its root agent for the rest of the daemon's
+// life, so a delivery to the reserved "root" title must be treated exactly like
+// the unconfigured case above — fail fast with the reserved-name error. The
+// in-memory root_agents config is immutable and still lists the deleted repo, so
+// consulting it alone would wait out the recreation bound for a root the ensure
+// loop will never bring back, then blame the delay on a recreation that is not
+// happening.
+func TestDeliverPrompt_DeletedProjectRootStillRejected(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	installRecordingBackend(t)
+	repoPath := setupControlRepo(t)
+
+	// Bound the wait well under the real 30s: a regression waits it out in full,
+	// so this is what separates a fast rejection from a pointless wait.
+	origWait := targetDeliverWait
+	targetDeliverWait = 2 * time.Second
+	t.Cleanup(func() { targetDeliverWait = origWait })
+
+	manager, err := NewManager(rootTestConfig(repoPath, config.RootAgentConfig{}))
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	manager.EnsureRootAgents()
+	root := findRootInstance(t, manager, repoPath)
+	if root == nil {
+		t.Fatal("root should materialize before the project is deleted")
+	}
+	// The fake backend skips Provision, which is what attaches the in-place
+	// (external) worktree in production. Restore it so DeleteProject routes the
+	// root down its real tear-down path instead of trying to archive it.
+	gw, _, err := sessiongit.NewGitWorktreeInPlace(repoPath)
+	if err != nil {
+		t.Fatalf("NewGitWorktreeInPlace: %v", err)
+	}
+	root.SetGitWorktreeForTest(gw)
+
+	if _, err := manager.DeleteProject(DeleteProjectRequest{RepoPath: repoPath}); err != nil {
+		t.Fatalf("DeleteProject: %v", err)
+	}
+	if findRootInstance(t, manager, repoPath) != nil {
+		t.Fatal("the deleted project's root should be gone before the delivery under test")
+	}
+
+	start := time.Now()
+	_, err = manager.DeliverPrompt(DeliverPromptRequest{
+		Title:    session.RootSessionTitle,
+		RepoPath: repoPath,
+		Program:  "claude",
+		Prompt:   "monitor-event",
+	})
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected the reserved-name error for a deleted project's root target")
+	}
+	if !strings.Contains(err.Error(), "reserved") {
+		t.Fatalf("expected the reserved-name error, got: %v", err)
+	}
+	// The root is permanently suppressed, not coming back — saying otherwise
+	// sends the user looking for a recreation that will never happen.
+	if strings.Contains(err.Error(), "being recreated") {
+		t.Fatalf("a deleted project's root is not being recreated; error must not claim it is, got: %v", err)
+	}
+	if elapsed > targetDeliverWait/2 {
+		t.Errorf("deleted-project root delivery took %v; must fail fast, not wait out the %v recreation bound", elapsed, targetDeliverWait)
 	}
 }
 

--- a/daemon/rootagent.go
+++ b/daemon/rootagent.go
@@ -233,14 +233,28 @@ func (m *Manager) deliverToReemergingRoot(repo *config.RepoContext, req DeliverP
 
 // repoRootAgentWillMaterialize reports whether the daemon's ensure loop is
 // responsible for (re-)creating the reserved "root" session for this repo: the
-// repo is opted into root_agents. Config is the single source of truth for
-// "root should be running" — a root that is Dead, Lost, or even explicitly
-// killed self-heals (the kill only delays re-creation by rootKillHealDelay,
-// #1223), so a configured root always materializes eventually and a delivery to
-// a momentarily-absent one should wait for the ensure loop rather than
-// auto-create it (which the reserved-name guard would reject). Config is
-// immutable after daemon start, so this needs no lock.
+// repo is opted into root_agents and its project has not been deleted at
+// runtime. Config is the single source of truth for "root should be running" —
+// a root that is Dead, Lost, or even explicitly killed self-heals (the kill only
+// delays re-creation by rootKillHealDelay, #1223), so a configured root always
+// materializes eventually and a delivery to a momentarily-absent one should wait
+// for the ensure loop rather than auto-create it (which the reserved-name guard
+// would reject).
+//
+// A deleted project (#1735) is the one case where the still-immutable m.cfg
+// outlives the truth: DeleteProject removed the opt-in from disk but this
+// in-memory copy keeps listing the repo, and ensureRootAgent skips it for the
+// rest of the daemon's life. Answering from config alone would make callers wait
+// out targetDeliverWait for a root that can never come back, then blame a
+// recreation that is not happening (#1835), so deletion is checked with the same
+// lock+lookup ensureRootAgent uses.
 func (m *Manager) repoRootAgentWillMaterialize(repoID string) bool {
+	m.mu.Lock()
+	_, deleted := m.deletedRootRepos[repoID]
+	m.mu.Unlock()
+	if deleted {
+		return false
+	}
 	for path := range m.cfg.RootAgents {
 		repo, err := config.RepoFromPath(config.ExpandTilde(path))
 		if err != nil {


### PR DESCRIPTION
Fixes #1835.

## The bug

After deleting a project whose repo is opted into `root_agents`, any delivery to its reserved `root` session — a cron or watch task firing at it — hung for the full 30s `targetDeliverWait`, then failed with:

```
root agent for "/path/to/repo" is being recreated (tmux momentarily absent);
event not delivered this attempt: timed out waiting for target session "root" to be created
```

The root is **not** being recreated. `DeleteProject` suppresses it for the rest of the daemon's life, so the message sends the user looking for a recovery that will never happen — and every automated delivery pays 30s of latency to be told so.

## Root cause

`DeleteProject` records the deletion in `m.deletedRootRepos`, and `ensureRootAgent` (`daemon/rootagent.go:119`) treats that map as authoritative: it skips root creation for a deleted repo permanently. The on-disk opt-in is removed, but the in-memory `m.cfg` is immutable after daemon start and keeps listing the repo.

`repoRootAgentWillMaterialize` (`daemon/rootagent.go:243`) — the query `deliverToReemergingRoot` uses to decide whether waiting for a re-emerging root is worthwhile — answered from `m.cfg.RootAgents` alone and never learned about the runtime suppression. So it claimed a deleted project's root would materialize, and delivery waited out the bound for a session that could not come back.

The two functions disagreed about the same question: the creation path said "never", the query path said "yes, wait".

## The fix

Check `m.deletedRootRepos` at the top of `repoRootAgentWillMaterialize`, with the same lock+lookup `ensureRootAgent` uses. A deleted project's root now falls through to the reserved-name guard, which rejects it immediately with actionable guidance ("root" is reserved) instead of a misleading wait — exactly how an *unconfigured* root already behaves.

**Locking:** `DeliverPrompt` holds only the per-target lock (`lockTarget`), not `m.mu`, and already calls `targetSessionState`/`deferWhileAttached` which take `m.mu` internally — so the new acquisition cannot deadlock. Verified with `-race`.

**Adjacent call-sites audited** (per repo convention): the only other daemon reader of `m.cfg.RootAgents` is the ensure loop itself, which already delegates to the correctly-guarded `ensureRootAgent`. No other site needs the check.

## Test

`TestDeliverPrompt_DeletedProjectRootStillRejected` drives the real `DeleteProject` → `DeliverPrompt` path and asserts the delivery fails fast, says "reserved", and never claims "being recreated".

Verified to genuinely reproduce **before** the fix — on unmodified master it waits out the bound and returns the misleading error:

```
expected the reserved-name error, got: root agent for "..." is being recreated
(tmux momentarily absent); event not delivered this attempt: timed out waiting
for target session "root" to be created
--- FAIL: TestDeliverPrompt_DeletedProjectRootStillRejected (3.73s)
```

...and passes after.

One test-harness note worth flagging for review: the fake backend skips `Provision`, which in production attaches the in-place (external) worktree. Without restoring it, `DeleteProject` misroutes the root to the archive path (which rejects the reserved title) rather than its real teardown path. The test sets a real `NewGitWorktreeInPlace` worktree so it exercises the production route. This is a fake-backend artifact only — production roots are created `InPlace: true` and always carry an external worktree.

## Gates

- `make test-container` — all packages green (incl. `daemon`, `integration`)
- `make test-container GOTESTARGS="-race ./daemon/..."` — race-clean
- `make tui-driver-selftest` — 33/33 steps green
- `go build ./...`, `gofmt -l .`, `golangci-lint run --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
