### PR TITLE
fix(attach): route remote sessions to the WS PTY stream, not backend.Attach (#1837)

### DIFF
--- a/api/sessions.go
+++ b/api/sessions.go
@@ -874,19 +874,14 @@ var sessionsAttachCmd = &cobra.Command{
 			return jsonError(err)
 		}
 
-		// A remote session attaches its hook attach_cmd PTY in-process; a local
-		// session attaches CLIENT-side over the daemon's WS PTY stream (#1592
-		// Phase 2 PR7), the same path the TUI uses. Ensure a daemon is up first —
-		// it owns the local session's clientless broker — then dial it.
-		if instance.Capabilities().Workspace == session.WorkspaceRemote {
-			detached, err := instance.Attach()
-			if err != nil {
-				return jsonError(fmt.Errorf("failed to attach: %w", err))
-			}
-			<-detached
-			return nil
-		}
-
+		// EVERY session — local or remote — attaches CLIENT-side over the daemon's
+		// WS PTY stream (#1592 Phase 2 PR7), the same path the TUI uses: the daemon
+		// resolves the byte source via instance.AgentServer() (a local broker, or a
+		// remoteAgentServer proxy for docker/ssh/hook). A prior
+		// Capabilities().Workspace == WorkspaceRemote branch called
+		// instance.Attach() here, but every remote backend's Attach returns a
+		// routing-invariant error, so it broke remote attach outright (#1837).
+		//
 		// EnsureDaemon spawns the LOCAL daemon that owns a local session's
 		// clientless broker; a remote target's daemon is already running on the
 		// other machine, so skip the local spawn and dial it directly (#1592

--- a/app/attach_routing_test.go
+++ b/app/attach_routing_test.go
@@ -1,0 +1,131 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/stretchr/testify/require"
+)
+
+// backendAttachSpy mirrors the REAL docker/ssh/hook backends: since #1592 Phase
+// 4 PR7 provisioned remote runtimes and exposed them as agent-servers, every
+// remote backend's Attach/AttachTerminal returns a routing-invariant error
+// rather than a PTY. The spy records the calls so a test can pin that the client
+// attach dispatch never reaches them.
+//
+// The plain FakeBackend cannot stand in here: its Attach SUCCEEDS (a pre-closed
+// channel), so a test using it would pass while the dispatch routed to a backend
+// that errors in production — exactly the gap that let #1837 ship.
+type backendAttachSpy struct {
+	*session.FakeBackend
+	attachCalls         atomic.Int32
+	attachTerminalCalls atomic.Int32
+}
+
+func (b *backendAttachSpy) Attach(*session.Instance) (chan struct{}, error) {
+	b.attachCalls.Add(1)
+	return nil, fmt.Errorf("sessions attach client-side over the WS PTY stream, not through the backend")
+}
+
+func (b *backendAttachSpy) AttachTerminal(*session.Instance, int) (chan struct{}, error) {
+	b.attachTerminalCalls.Add(1)
+	return nil, fmt.Errorf("terminal tabs attach client-side over the WS PTY stream, not through the backend")
+}
+
+func (b *backendAttachSpy) backendCalls() int32 {
+	return b.attachCalls.Load() + b.attachTerminalCalls.Load()
+}
+
+// remoteAttachSpy reports WorkspaceRemote (a bare remote hook backend's
+// capabilities) on top of the erroring attach surface.
+type remoteAttachSpy struct{ *backendAttachSpy }
+
+func (remoteAttachSpy) Type() string { return "remote" }
+
+func (remoteAttachSpy) Capabilities() session.Capabilities {
+	return (&session.HookBackend{}).Capabilities()
+}
+
+// TestAttachInstanceTab_RoutesEverySessionToStream is the regression guard for
+// #1837. The full-screen attach byte source is the daemon's WS PTY stream for
+// EVERY session — local or remote, agent tab or terminal tab — because the
+// daemon resolves locality itself via instance.AgentServer() (a local broker, or
+// a remoteAgentServer proxy for docker/ssh/hook).
+//
+// The bug: attachInstanceTab branched on Capabilities().Workspace and sent a
+// remote session to m.store.AttachInstance (-> backend.Attach) for the agent tab
+// and ui.AttachTerminalTab (-> backend.AttachTerminal) for a terminal tab. Every
+// remote backend's Attach/AttachTerminal returns an error, so remote attach
+// failed outright — and silently, since attachOverlayCallback only logs the
+// error and returns a nil cmd.
+//
+// Pre-fix, the two remote cases route to the backend: backendCalls() is 1 and
+// the stream is never dialed, so this fails. Post-fix all four cases dial the
+// stream and never touch the backend.
+func TestAttachInstanceTab_RoutesEverySessionToStream(t *testing.T) {
+	cases := []struct {
+		name       string
+		remote     bool
+		tabIdx     int
+		wantTabIdx int
+	}{
+		{"remote/agent tab (#1837)", true, 0, 0},
+		{"remote/terminal tab (#1837)", true, 1, 1},
+		{"local/agent tab", false, 0, 0},
+		{"local/terminal tab", false, 1, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetDetachWatchdog(t)
+
+			h := newTestHome(t)
+			// Skip the first-time attach help overlay so the deferred attach callback
+			// runs synchronously inside attachInstanceTab (see showHelpScreen).
+			require.NoError(t, h.appState.SetHelpScreensSeen(helpTypeInstanceAttach{}.mask()))
+
+			inst := instanceWithFakeBackend(t, "inst")
+			spy := &backendAttachSpy{FakeBackend: session.NewFakeBackend()}
+			if tc.remote {
+				inst.SetBackend(remoteAttachSpy{spy})
+			} else {
+				inst.SetBackend(spy)
+			}
+			inst.SetStatusForTest(session.Running)
+			require.Equal(t, tc.remote, inst.Capabilities().Workspace == session.WorkspaceRemote,
+				"precondition: instance remote-ness must match the case under test")
+
+			h.store.AddInstance(inst)
+			h.sidebar.SetSelectedInstance(0)
+
+			// Observe the stream dial instead of standing up a daemon; detach
+			// immediately so the post-detach lifecycle runs synchronously.
+			var streamCalls atomic.Int32
+			var gotTitle string
+			var gotTabIdx int
+			t.Cleanup(SetAttachStreamFnForTest(func(_ context.Context, title, _, _ string, tabIdx int) (chan struct{}, error) {
+				streamCalls.Add(1)
+				gotTitle, gotTabIdx = title, tabIdx
+				ch := make(chan struct{})
+				close(ch)
+				return ch, nil
+			}))
+
+			_, cmd := h.attachInstanceTab(inst, tc.tabIdx, "agent", "terminal")
+			_ = runAttachTransitionCmd(t, h, cmd)
+			endDetachWatchdog()
+
+			require.Zero(t, spy.backendCalls(),
+				"attach must NEVER reach backend.Attach/AttachTerminal — every remote "+
+					"backend's implementation returns a routing-invariant error, so a "+
+					"backend-routed attach fails outright (#1837)")
+			require.Equal(t, int32(1), streamCalls.Load(),
+				"attach must dial the daemon's WS PTY stream exactly once — the sole "+
+					"byte source for local and remote sessions alike (#1837)")
+			require.Equal(t, inst.Title, gotTitle, "the stream must target the captured instance (#716)")
+			require.Equal(t, tc.wantTabIdx, gotTabIdx, "the stream must target the captured tab (#716)")
+		})
+	}
+}

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -7,7 +7,6 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/sachiniyer/agent-factory/apiclient"
 	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
@@ -762,44 +761,34 @@ func (m *home) attachSelected(selected *session.Instance) (tea.Model, tea.Cmd) {
 }
 
 // attachInstanceTab runs the full-screen attach flow for a captured
-// instance+tab binding. The terminal tab attaches a local tmux session for
-// local instances, but a remote instance's terminal_cmd PTY for remote ones
-// (#843), so the post-detach handling must key off the instance's real
-// remote-ness (#889). Callers pass the tab index captured at keypress time
+// instance+tab binding. Callers pass the tab index captured at keypress time
 // (#716), before help-overlay deferral can let selection or active tab drift.
 func (m *home) attachInstanceTab(instance *session.Instance, tabIdx int, agentLabel, terminalLabel string) (tea.Model, tea.Cmd) {
-	remote := instance.Capabilities().Workspace == session.WorkspaceRemote
 	label := agentLabel
 	if tabIdx != 0 {
 		label = terminalLabel
 	}
-	// Pick the attach byte source by LOCALITY — a capability check, not a
-	// concrete-backend type assertion (#1592 Phase 1). A local session (agent tab
-	// 0 or a shell/process tab) attaches CLIENT-side as a WS PTY subscriber over
-	// the daemon socket (apiclient.AttachStream, #1592 Phase 2 PR7), replacing the
-	// retired tmux-server-mediated attach driver. A remote session attaches its
-	// hook attach_cmd (agent tab) / terminal_cmd (terminal tab) PTY in-process
-	// through the uniform Backend interface. Both return a chan closed on detach,
-	// and both now scribble the terminal (see attachOverlayCallback's uniform
-	// reassert). instance + repoID are captured here at keypress so a deferred
-	// attach (help overlay open) targets the captured session, not a drifted
-	// selection (#716).
+	// EVERY session — local or remote, agent tab 0 or a shell/process tab —
+	// attaches CLIENT-side as a WS PTY subscriber over the daemon socket
+	// (apiclient.AttachStream, #1592 Phase 2 PR7). The daemon resolves the byte
+	// source via instance.AgentServer(), which is a local broker for a local
+	// session and a remoteAgentServer proxy for a docker/ssh/hook one, so
+	// locality is the DAEMON's concern and the client needs no branch on it.
+	//
+	// Do not reintroduce a Capabilities().Workspace branch that routes remote
+	// sessions through the Backend (m.store.AttachInstance / ui.AttachTerminalTab
+	// -> backend.Attach): since #1592 Phase 4 PR7 provisioned remote runtimes and
+	// exposed them as agent-servers, every remote backend's Attach/AttachTerminal
+	// returns a routing-invariant error, so that branch broke remote attach
+	// outright (#1837). instance + repoID are captured here at keypress so a
+	// deferred attach (help overlay open) targets the captured session, not a
+	// drifted selection (#716).
 	repoID := m.repoID
 	attach := func() (chan struct{}, error) {
-		if remote {
-			if tabIdx != 0 {
-				return ui.AttachTerminalTab(instance, tabIdx)
-			}
-			return m.store.AttachInstance(instance)
-		}
-		c, err := apiclient.NewTargeted()
-		if err != nil {
-			return nil, err
-		}
 		// Address the attach by the tab's stable id (#1738) so a reorder/close can't
 		// misroute the full-screen stream; empty falls back to the ordinal.
 		tabID, _ := instance.TabIDAt(tabIdx)
-		return c.AttachStream(context.Background(), instance.Title, repoID, tabID, tabIdx)
+		return attachStreamFn(context.Background(), instance.Title, repoID, tabID, tabIdx)
 	}
 	return m.showHelpScreen(helpTypeInstanceAttach{}, func() tea.Cmd {
 		return m.beginAttachTransition(func() tea.Cmd {

--- a/app/home_attach.go
+++ b/app/home_attach.go
@@ -1,11 +1,13 @@
 package app
 
 import (
+	"context"
 	"io"
 	"os"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/sachiniyer/agent-factory/apiclient"
 	"github.com/sachiniyer/agent-factory/log"
 )
 
@@ -74,6 +76,26 @@ func (m *home) beginAttachTransition(run func() tea.Cmd) tea.Cmd {
 // it to substitute a hermetic attach func (no real WS PTY stream or remote
 // terminal_cmd PTY) while preserving the call-site behaviour.
 var attachOverlayCallbackFn = (*home).attachOverlayCallback
+
+// attachStreamFn is the indirection attachInstanceTab dials the daemon's WS PTY
+// stream through — the SOLE full-screen attach byte source for every session,
+// local or remote (#1837). Production points it at apiclient; tests swap it to
+// observe the routing without standing up a daemon.
+var attachStreamFn = func(ctx context.Context, title, repoID, tabID string, tabIdx int) (chan struct{}, error) {
+	c, err := apiclient.NewTargeted()
+	if err != nil {
+		return nil, err
+	}
+	return c.AttachStream(ctx, title, repoID, tabID, tabIdx)
+}
+
+// SetAttachStreamFnForTest swaps the WS PTY stream dial and returns a restore
+// func, so a test can pin which attach source attachInstanceTab routes to.
+func SetAttachStreamFnForTest(fn func(context.Context, string, string, string, int) (chan struct{}, error)) func() {
+	prev := attachStreamFn
+	attachStreamFn = fn
+	return func() { attachStreamFn = prev }
+}
 
 // attachOverlayCallback runs the attach-overlay onDismiss lifecycle: emits
 // the detach-trace markers, invokes attach, arms the attached flag for the


### PR DESCRIPTION
Fixes #1837.

## Verified the bug first

Reproduced on current master before touching anything. Both remote attach paths reach an erroring backend:

```
--- FAIL: TestRepro1837/agent_tab     backend.Attach calls=1
--- FAIL: TestRepro1837/terminal_tab  backend.AttachTerminal calls=1
```

## Root cause

#1592 Phase 4 PR7 moved remote runtimes to the provision-and-expose agent-server model, making every remote backend's `Attach`/`AttachTerminal` return a routing-invariant error instead of a PTY (`session/backend_docker.go:560`, `session/backend_ssh.go:827`, `session/backend_hook_backend.go:315`). It did not update the client attach dispatch, which still branched on `Capabilities().Workspace` and aimed remote sessions at exactly that erroring surface:

- `app/handle_actions.go:789` — agent tab → `m.store.AttachInstance` → `instance.Attach()` → `backend.Attach()`; terminal tab → `ui.AttachTerminalTab` → `backend.AttachTerminal()`.
- `api/sessions.go:881` — a `WorkspaceRemote` special case calling `instance.Attach()`.

The backends' own doc comments already asserted the correct invariant — *"the client's attach dispatch branches on Capabilities().Workspace and **never reaches the backend**"* — the dispatch simply violated it.

In the TUI this failed **silently**: `attachOverlayCallback` (`app/home_attach.go:110`) logs the error and returns a nil cmd, so Enter on a remote session looked like a no-op rather than an error.

## Fix

Locality is the daemon's concern, not the client's. `daemon/manager_sessions.go:239` already resolves the byte source via `instance.AgentServer()` — a local broker for a local session, a `remoteAgentServer` proxy for docker/ssh/hook. So both branches are dropped and every session routes through the WS PTY stream. This is the issue's recommended fix.

## Regression test

`TestAttachInstanceTab_RoutesEverySessionToStream` drives the real dispatch across the (remote|local) x (agent|terminal) matrix and asserts the attach dials the stream exactly once and never touches the backend. Verified **fails before / passes after** — with the pre-fix routing restored, both remote cases fail (backend reached, stream never dialed).

Two reasons the existing tests missed this, both addressed:
1. They swap the attach closure wholesale, so the routing decision had **zero** coverage. Added a small `attachStreamFn` seam (matching the existing `attachOverlayCallbackFn` seam) so a test can observe the dial without a daemon.
2. The plain `FakeBackend`'s `Attach` **succeeds**, so a double-based test passes while production errors. The new spy errors like the real remote backends do.

## Gates

- `make test-container` — green, no failures (incl. `app`, `api`)
- `make tui-driver-selftest` — 33/33 steps green
- `go build ./...`, `gofmt -l .`, `golangci-lint run --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh` — all clean

## Follow-up (not in this PR)

Kept minimal per the brief. This removes the last production callers of `Instance.Attach()`, so the whole backend attach surface (`Backend.Attach`/`AttachTerminal` x6 impls, `Instance.Attach`/`AttachTerminal`, `Projection.AttachInstance`, `ui.AttachTerminalTab`) is now dead in production and alive only via tests — `deadcode` stays clean, so it does not block. Deleting it would kill this bug class structurally, but it would also delete the tripwire the regression test relies on, so I'll file a separate issue.

Do not merge on my account — flagged green for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)