### PR TITLE
fix(cli): expand a leading ~ in repo-path inputs (#1842)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -61,7 +60,7 @@ var (
 // path is not a git repository" so callers never mislabel a provided-but-invalid
 // --repo as missing (#892). Only call when repoFlag != "".
 func repoFromFlag() (*config.RepoContext, error) {
-	absPath, err := filepath.Abs(repoFlag)
+	absPath, err := config.ResolveUserPath(repoFlag)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve --repo path %q: %w", repoFlag, err)
 	}

--- a/api/projects.go
+++ b/api/projects.go
@@ -77,7 +77,7 @@ func resolveProjectDeleteTarget(args []string) (daemon.DeleteProjectRequest, str
 	if len(args) == 1 {
 		path = args[0]
 	}
-	abs, err := filepath.Abs(path)
+	abs, err := config.ResolveUserPath(path)
 	if err != nil {
 		return daemon.DeleteProjectRequest{}, "", fmt.Errorf("failed to resolve project path %q: %w", path, err)
 	}

--- a/api/tilde_paths_test.go
+++ b/api/tilde_paths_test.go
@@ -1,0 +1,134 @@
+package api
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #1842: the CLI resolved user-supplied repo paths with a bare filepath.Abs,
+// which treats "~" as an ordinary directory name. Whenever the shell did not
+// expand the tilde first — a single-quoted '~/repo', or a "$VAR" holding
+// "~/repo" — the path was silently rewritten to "<cwd>/~/repo", surfacing as a
+// confusing "not a valid git repository: <cwd>/~/repo" error on sessions/tasks
+// and as a wrong target for projects delete. These tests pin every CLI repo-path
+// entry point against that regression.
+
+// initRepoUnderHome points HOME at a temp dir and git-inits a repo inside it, so
+// "~/<name>" is a real repository only reachable when the tilde is expanded.
+func initRepoUnderHome(t *testing.T, name string) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	repoRoot := filepath.Join(home, name)
+	if out, err := exec.Command("git", "init", repoRoot).CombinedOutput(); err != nil {
+		t.Fatalf("git init %s: %v (%s)", repoRoot, err, out)
+	}
+	return repoRoot
+}
+
+// canonical resolves symlinks so comparisons survive platforms where the temp
+// dir is itself a symlink (git reports the resolved form).
+func canonical(t *testing.T, path string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return filepath.Clean(path)
+	}
+	return resolved
+}
+
+// assertNoTildeSegment fails if a resolved path kept a literal "~" component —
+// the exact shape of the #1842 corruption.
+func assertNoTildeSegment(t *testing.T, in, got string) {
+	t.Helper()
+	for _, seg := range strings.Split(got, string(filepath.Separator)) {
+		if seg == "~" {
+			t.Errorf("resolved %q to %q; kept a literal %q segment (the #1842 corruption)", in, got, "~")
+		}
+	}
+}
+
+// TestRepoFromFlagExpandsTilde covers `--repo '~/repo'` on sessions/tasks.
+func TestRepoFromFlagExpandsTilde(t *testing.T) {
+	repoRoot := initRepoUnderHome(t, "myrepo")
+
+	prev := repoFlag
+	t.Cleanup(func() { repoFlag = prev })
+	repoFlag = "~/myrepo"
+
+	repo, err := repoFromFlag()
+	if err != nil {
+		t.Fatalf("repoFromFlag() with --repo %q returned error: %v\nthe tilde was left unexpanded (#1842)", repoFlag, err)
+	}
+	assertNoTildeSegment(t, repoFlag, repo.Root)
+	if got, want := canonical(t, repo.Root), canonical(t, repoRoot); got != want {
+		t.Errorf("repoFromFlag() with --repo %q resolved to %q, want %q", repoFlag, got, want)
+	}
+}
+
+// TestRepoFromFlagBareTilde pins that a bare "~" resolves to the home directory
+// rather than "<cwd>/~".
+func TestRepoFromFlagBareTilde(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if out, err := exec.Command("git", "init", home).CombinedOutput(); err != nil {
+		t.Fatalf("git init %s: %v (%s)", home, err, out)
+	}
+
+	prev := repoFlag
+	t.Cleanup(func() { repoFlag = prev })
+	repoFlag = "~"
+
+	repo, err := repoFromFlag()
+	if err != nil {
+		t.Fatalf("repoFromFlag() with --repo %q returned error: %v (#1842)", repoFlag, err)
+	}
+	assertNoTildeSegment(t, repoFlag, repo.Root)
+	if got, want := canonical(t, repo.Root), canonical(t, home); got != want {
+		t.Errorf("repoFromFlag() with --repo %q resolved to %q, want home %q", repoFlag, got, want)
+	}
+}
+
+// TestResolveProjectDeleteTargetExpandsTilde covers `projects delete '~/proj'`.
+// Targeting is destructive, so a corrupted path here does not merely error — it
+// aims the request at the wrong project.
+func TestResolveProjectDeleteTargetExpandsTilde(t *testing.T) {
+	repoRoot := initRepoUnderHome(t, "proj")
+
+	req, name, err := resolveProjectDeleteTarget([]string{"~/proj"})
+	if err != nil {
+		t.Fatalf("resolveProjectDeleteTarget([\"~/proj\"]) returned error: %v (#1842)", err)
+	}
+	assertNoTildeSegment(t, "~/proj", req.RepoPath)
+	if got, want := canonical(t, req.RepoPath), canonical(t, repoRoot); got != want {
+		t.Errorf("resolveProjectDeleteTarget([\"~/proj\"]) targeted %q, want %q", got, want)
+	}
+	if name != "proj" {
+		t.Errorf("resolveProjectDeleteTarget([\"~/proj\"]) named the project %q, want %q", name, "proj")
+	}
+	if req.RepoID == "" {
+		t.Error("resolveProjectDeleteTarget([\"~/proj\"]) left RepoID empty; the path did not resolve to a git repo")
+	}
+}
+
+// TestResolveProjectDeleteTargetTildeNonRepoFallback pins the non-repo fallback
+// (a moved/removed project). It must still expand the tilde: the fallback path
+// is what the daemon sweeps, so "<cwd>/~/gone" would sweep the wrong entry.
+func TestResolveProjectDeleteTargetTildeNonRepoFallback(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	req, name, err := resolveProjectDeleteTarget([]string{"~/gone"})
+	if err != nil {
+		t.Fatalf("resolveProjectDeleteTarget([\"~/gone\"]) returned error: %v (#1842)", err)
+	}
+	assertNoTildeSegment(t, "~/gone", req.RepoPath)
+	if want := filepath.Join(home, "gone"); req.RepoPath != want {
+		t.Errorf("resolveProjectDeleteTarget([\"~/gone\"]) targeted %q, want %q", req.RepoPath, want)
+	}
+	if name != "gone" {
+		t.Errorf("resolveProjectDeleteTarget([\"~/gone\"]) named the project %q, want %q", name, "gone")
+	}
+}

--- a/app/home_tasks.go
+++ b/app/home_tasks.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -36,10 +35,10 @@ func (m *home) handleTaskCreate() tea.Cmd {
 			return m.handleError(fmt.Errorf("invalid cron: %v", err))
 		}
 	}
-	// Expand a leading ~ before resolving to absolute — filepath.Abs does not
-	// expand "~", so "~/project" would otherwise become "<cwd>/~/project"
-	// (#924). validateForm already normalized the field, so this is idempotent.
-	absPath, err := filepath.Abs(config.ExpandTilde(projectPath))
+	// ResolveUserPath expands a leading ~ before absolutizing — filepath.Abs
+	// alone would turn "~/project" into "<cwd>/~/project" (#924). validateForm
+	// already normalized the field, so this is idempotent.
+	absPath, err := config.ResolveUserPath(projectPath)
 	if err != nil {
 		return m.handleError(fmt.Errorf("invalid path: %v", err))
 	}

--- a/commands/agentservercmd.go
+++ b/commands/agentservercmd.go
@@ -1,8 +1,10 @@
 package commands
 
 import (
+	"fmt"
 	"os"
 
+	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/log"
 
@@ -61,13 +63,9 @@ branch before shutdown), not this server's.`,
 		log.Initialize(false)
 		defer log.Close()
 
-		repo := agentServerRepo
-		if repo == "" {
-			cwd, err := os.Getwd()
-			if err != nil {
-				return err
-			}
-			repo = cwd
+		repo, err := resolveAgentServerRepo(agentServerRepo)
+		if err != nil {
+			return err
 		}
 
 		return daemon.RunAgentServer(daemon.AgentServerOptions{
@@ -78,6 +76,24 @@ branch before shutdown), not this server's.`,
 			AutoYes:    agentServerAutoYes,
 		}, cmd.OutOrStdout())
 	},
+}
+
+// resolveAgentServerRepo resolves the --repo flag to the absolute repository
+// path the workspace runs against, defaulting to the current directory when the
+// flag is unset. A "~/repo" the shell did not expand (single-quoted, or via a
+// variable) would otherwise reach NewInstance verbatim and be absolutized into
+// "<cwd>/~/repo": the server still binds and prints its token, and the corrupted
+// path only surfaces later when the worktree is set up (#1842).
+func resolveAgentServerRepo(repoFlag string) (string, error) {
+	if repoFlag == "" {
+		// os.Getwd is already absolute and cannot contain a leading "~".
+		return os.Getwd()
+	}
+	abs, err := config.ResolveUserPath(repoFlag)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve --repo path %q: %w", repoFlag, err)
+	}
+	return abs, nil
 }
 
 func init() {

--- a/commands/agentservercmd_test.go
+++ b/commands/agentservercmd_test.go
@@ -1,0 +1,77 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestResolveAgentServerRepoExpandsTilde pins `agent-server --repo '~/repo'`
+// against #1842. This entry point failed worse than the others: NewInstance does
+// not validate the repo at construct time, so a corrupted "<cwd>/~/repo" still
+// bound a listener and printed its addr/token, and only blew up later during
+// worktree setup.
+func TestResolveAgentServerRepoExpandsTilde(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"tilde path", "~/repo", filepath.Join(home, "repo")},
+		{"bare tilde", "~", home},
+		{"nested tilde path", "~/a/b", filepath.Join(home, "a", "b")},
+		{"absolute path untouched", "/srv/repo", "/srv/repo"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := resolveAgentServerRepo(c.in)
+			if err != nil {
+				t.Fatalf("resolveAgentServerRepo(%q) returned error: %v", c.in, err)
+			}
+			for _, seg := range strings.Split(got, string(filepath.Separator)) {
+				if seg == "~" {
+					t.Fatalf("resolveAgentServerRepo(%q) = %q; kept a literal %q segment (the #1842 corruption)", c.in, got, "~")
+				}
+			}
+			if got != c.want {
+				t.Errorf("resolveAgentServerRepo(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// TestResolveAgentServerRepoDefaultsToCwd pins the documented default: an unset
+// --repo means the current directory.
+func TestResolveAgentServerRepoDefaultsToCwd(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	got, err := resolveAgentServerRepo("")
+	if err != nil {
+		t.Fatalf("resolveAgentServerRepo(\"\") returned error: %v", err)
+	}
+	if got != cwd {
+		t.Errorf("resolveAgentServerRepo(\"\") = %q, want cwd %q", got, cwd)
+	}
+}
+
+// TestResolveAgentServerRepoRelative pins that relative paths still resolve
+// against the cwd — the tilde fix must not change their meaning.
+func TestResolveAgentServerRepoRelative(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	got, err := resolveAgentServerRepo("sub/repo")
+	if err != nil {
+		t.Fatalf("resolveAgentServerRepo(\"sub/repo\") returned error: %v", err)
+	}
+	if want := filepath.Join(cwd, "sub", "repo"); got != want {
+		t.Errorf("resolveAgentServerRepo(\"sub/repo\") = %q, want %q", got, want)
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1445,32 +1445,3 @@ func TestSaveConfig(t *testing.T) {
 		assert.Equal(t, testConfig.BranchPrefix, loadedConfig.BranchPrefix)
 	})
 }
-
-// TestExpandTilde pins the #924 tilde helper: a bare "~" and "~/x" expand to
-// the home directory (filepath.Abs does not), while absolute paths, relative
-// paths, the empty string, and unresolvable "~user" forms pass through
-// unchanged. The AGENT_FACTORY_HOME inline expansion in GetConfigDir is built
-// on this helper, so the cases below also pin that path's behavior.
-func TestExpandTilde(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-
-	cases := []struct {
-		in   string
-		want string
-	}{
-		{"~", home},
-		{"~/project", filepath.Join(home, "project")},
-		{"~/a/b/c", filepath.Join(home, "a", "b", "c")},
-		{"/abs/path", "/abs/path"},
-		{"relative/path", "relative/path"},
-		{"", ""},
-		{"~user", "~user"},     // Go cannot resolve "~user"; left untouched.
-		{"foo~bar", "foo~bar"}, // a tilde that is not a leading prefix is literal.
-	}
-	for _, c := range cases {
-		if got := ExpandTilde(c.in); got != c.want {
-			t.Errorf("ExpandTilde(%q) = %q, want %q", c.in, got, c.want)
-		}
-	}
-}

--- a/config/config_types.go
+++ b/config/config_types.go
@@ -48,7 +48,8 @@ const (
 // empty string, and "~user" forms (which the Go standard library cannot
 // resolve). If the home directory cannot be determined, path is returned as-is.
 // filepath.Abs does NOT expand "~", so callers resolving user-entered paths
-// must run them through this helper first (#924).
+// must run them through this helper first (#924) — prefer ResolveUserPath,
+// which pairs the two in the right order.
 func ExpandTilde(path string) string {
 	if path != "~" && !strings.HasPrefix(path, "~/") {
 		return path
@@ -61,6 +62,23 @@ func ExpandTilde(path string) string {
 		return homeDir
 	}
 	return filepath.Join(homeDir, path[2:])
+}
+
+// ResolveUserPath turns a user-supplied path (a CLI flag/arg, a TUI text input)
+// into an absolute one, expanding a leading "~" first. It exists because
+// filepath.Abs alone treats "~" as an ordinary directory name and silently
+// rewrites "~/repo" into "<cwd>/~/repo" — a corrupted path that then surfaces as
+// a confusing "not a valid git repository: <cwd>/~/repo" error, or worse, is
+// stored verbatim and only fails later (#1842). The shell normally expands "~"
+// before we ever see it, so this only matters when it could not: a single-quoted
+// '~/repo', a "$VAR" holding "~/repo", or a non-shell caller of the CLI.
+//
+// Always prefer this over filepath.Abs at the boundary where user input first
+// enters — expanding deeper in the stack lets a raw "~" be logged or persisted
+// on the way down. Pair it with ExpandTilde only when a caller needs expansion
+// without absolutization.
+func ResolveUserPath(path string) (string, error) {
+	return filepath.Abs(ExpandTilde(path))
 }
 
 // GetConfigDir returns the path to the application's configuration directory.

--- a/config/userpath_test.go
+++ b/config/userpath_test.go
@@ -1,0 +1,108 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Tests for the user-supplied path helpers (ExpandTilde, ResolveUserPath).
+// Split out of config_test.go to keep it under the file-length limit (#1145).
+
+// TestExpandTilde pins the #924 tilde helper: a bare "~" and "~/x" expand to
+// the home directory (filepath.Abs does not), while absolute paths, relative
+// paths, the empty string, and unresolvable "~user" forms pass through
+// unchanged. The AGENT_FACTORY_HOME inline expansion in GetConfigDir is built
+// on this helper, so the cases below also pin that path's behavior.
+func TestExpandTilde(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"~", home},
+		{"~/project", filepath.Join(home, "project")},
+		{"~/a/b/c", filepath.Join(home, "a", "b", "c")},
+		{"/abs/path", "/abs/path"},
+		{"relative/path", "relative/path"},
+		{"", ""},
+		{"~user", "~user"},     // Go cannot resolve "~user"; left untouched.
+		{"foo~bar", "foo~bar"}, // a tilde that is not a leading prefix is literal.
+	}
+	for _, c := range cases {
+		if got := ExpandTilde(c.in); got != c.want {
+			t.Errorf("ExpandTilde(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestResolveUserPath pins the #1842 helper: user-supplied paths get their
+// leading "~" expanded BEFORE absolutization, so a tilde the shell never
+// expanded (single-quoted '~/repo', or "$VAR" holding it) resolves to the home
+// directory instead of being silently rewritten to "<cwd>/~/repo". Relative
+// paths still resolve against the cwd, and the "~user" form the helper cannot
+// resolve stays literal rather than being guessed at.
+func TestResolveUserPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"bare tilde", "~", home},
+		{"tilde path", "~/repo", filepath.Join(home, "repo")},
+		{"nested tilde path", "~/a/b/c", filepath.Join(home, "a", "b", "c")},
+		{"absolute path untouched", "/abs/path", "/abs/path"},
+		{"relative path resolves against cwd", "repo", filepath.Join(cwd, "repo")},
+		{"dot resolves to cwd", ".", cwd},
+		{"empty resolves to cwd", "", cwd},
+		// Go cannot resolve "~user"; it stays literal and is absolutized as an
+		// ordinary relative name rather than being mistaken for a home dir.
+		{"tilde-user stays literal", "~user", filepath.Join(cwd, "~user")},
+		{"non-leading tilde is literal", "/tmp/foo~bar", "/tmp/foo~bar"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := ResolveUserPath(c.in)
+			if err != nil {
+				t.Fatalf("ResolveUserPath(%q) returned error: %v", c.in, err)
+			}
+			if got != c.want {
+				t.Errorf("ResolveUserPath(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// TestResolveUserPathNeverCorruptsTilde is the direct #1842 regression: the
+// pre-fix code called filepath.Abs on raw input, producing the corrupted
+// "<cwd>/~/..." path that surfaced as a confusing "not a valid git repository"
+// error. No resolved path may ever retain a literal "~" segment.
+func TestResolveUserPathNeverCorruptsTilde(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	for _, in := range []string{"~", "~/repo", "~/a/b"} {
+		got, err := ResolveUserPath(in)
+		if err != nil {
+			t.Fatalf("ResolveUserPath(%q) returned error: %v", in, err)
+		}
+		for _, seg := range strings.Split(got, string(filepath.Separator)) {
+			if seg == "~" {
+				t.Errorf("ResolveUserPath(%q) = %q; kept a literal %q segment (the #1842 corruption)", in, got, "~")
+			}
+		}
+		if !strings.HasPrefix(got, home) {
+			t.Errorf("ResolveUserPath(%q) = %q, want a path under home %q", in, got, home)
+		}
+	}
+}

--- a/ui/task_pane_edit.go
+++ b/ui/task_pane_edit.go
@@ -2,7 +2,6 @@ package ui
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -51,7 +50,7 @@ func (s *TaskPane) validateForm() (string, int) {
 	if rawPath == "" {
 		return "project path is required", taskFocusPath
 	}
-	absPath, err := filepath.Abs(config.ExpandTilde(rawPath))
+	absPath, err := config.ResolveUserPath(rawPath)
 	if err != nil {
 		return fmt.Sprintf("invalid path: %v", err), taskFocusPath
 	}
@@ -122,7 +121,7 @@ func (s *TaskPane) handleEditMode(msg tea.KeyMsg) bool {
 			// relative value behaves the same when the scheduler fires
 			// as it does in the TUI trigger (#641, #924). validateForm
 			// already normalized editPath, so this is idempotent.
-			absPath, err := filepath.Abs(config.ExpandTilde(s.editPath.Value()))
+			absPath, err := config.ResolveUserPath(s.editPath.Value())
 			if err != nil {
 				s.editError = fmt.Sprintf("invalid path: %v", err)
 				s.editErrorField = taskFocusPath


### PR DESCRIPTION
Fixes #1842.

## Verified on master first

Reproduced before touching anything, against a real repo at `~/af-tilde-repro-1842`:

```
$ af sessions list --repo '~/af-tilde-repro-1842'     # quoted — shell does NOT expand
{"error":"--repo \"/home/siyer/Desktop/agent-factory/~/af-tilde-repro-1842\" is not a valid git repository: ..."}

$ af sessions list --repo ~/af-tilde-repro-1842       # unquoted control — shell expands
[]
```

Not a false positive: `filepath.Abs` treats `~` as an ordinary directory name, so any tilde the shell didn't expand (single-quoted `'~/repo'`, or a `"$VAR"` holding `~/repo`) gets rewritten to `<cwd>/~/repo`.

## Root cause

The daemon (`daemon/deleteproject.go`) and TUI (`app/home_tasks.go`, `ui/task_pane_edit.go`) already expand tildes before canonicalizing. Only the CLI layer didn't — and by the time the CLI has rewritten `~/...` into `<cwd>/~/...`, the daemon can't recover it.

## Fix

The issue recommends adding `config.ExpandTilde` at the two named call sites. I added the shared helper instead, because this bug's own history is the argument against sprinkling: the pattern was refactored into `repoFromFlag()` and duplicated into `resolveProjectDeleteTarget()`, and **neither carried the expansion along**. `config.ResolveUserPath` (`Abs ∘ ExpandTilde`) is now the one way to resolve user-supplied paths, applied at every repo-path entry point:

| Entry point | Surface |
|---|---|
| `api/api.go` `repoFromFlag` | `--repo` on sessions/tasks |
| `api/projects.go` `resolveProjectDeleteTarget` | `projects delete <path>`, incl. the non-repo fallback the daemon sweeps |
| `commands/agentservercmd.go` | `agent-server --repo` — **not named in the issue** |

Expansion happens at the boundary where input enters, not deeper in the stack, so a raw `~` can never be logged or persisted on the way down.

### The third entry point

The audit for the same anti-pattern turned up `agent-server --repo`, which the report missed and which fails *worse* than the reported cases. `NewInstance` doesn't validate the repo at construct time, so a corrupted path still bound a listener and printed its addr/token — it looked like it worked:

```
$ af agent-server --repo '~/af-tilde-repro-1842' --title tildetest
{"addr":"127.0.0.1:45915","token":"F6BR...","title":"tildetest"}   # <-- no error!
```

The corruption only surfaced later, at worktree setup. Its resolution is extracted into `resolveAgentServerRepo` so it's unit-testable rather than buried in the `RunE` closure.

The two existing `Abs(ExpandTilde(...))` sites in the TUI converge onto the helper — no behavior change, but the pattern now has one home.

## Tests

Every tilde test was **confirmed to fail against the pre-fix resolution** and pass after — they're pinned to the bug, not to the implementation:

```
--- FAIL: TestResolveProjectDeleteTargetExpandsTilde
    resolved "~/proj" to ".../api/~/proj"; kept a literal "~" segment (the #1842 corruption)
--- FAIL: TestResolveAgentServerRepoExpandsTilde/tilde_path
    resolveAgentServerRepo("~/repo") = ".../commands/~/repo"; kept a literal "~" segment
```

The absolute / relative / cwd / `~user` / non-leading-`~` cases pass both before and after, pinning that the fix doesn't change their meaning.

The `projects delete` coverage includes the non-repo fallback specifically: targeting is destructive there, so a corrupted path doesn't merely error — it aims the daemon's sweep at the wrong entry.

## End-to-end after the fix

```
$ af sessions list --repo '~/af-tilde-repro-1842'   →  []          # matches the control
$ af sessions list --repo .                          →  [ ... ]     # relative still works
$ af sessions list --repo '~/definitely-not-a-repo'  →  error names /home/siyer/definitely-not-a-repo
```

That last one is a bonus: error messages now name the real path instead of a corrupted `<cwd>/~/...` one.

## Gates

- `make test-container` — exit 0, zero FAIL lines
- `make tui-driver-selftest` — exit 0, **33/33** steps green (the selftest has grown past the 25 steps the task named; all pass)
- `go build ./...`, `gofmt -l .`, `golangci-lint run --fast`, `deadcode -test ./...` — all clean
- `scripts/lint-file-length.sh` — clean; the tilde helper tests moved to `config/userpath_test.go` because the additions pushed `config_test.go` past the 1500-line limit (#1145). Split rather than grandfathered, per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)