### PR TITLE
fix(daemon): persist recovered state after a successful Lost-restore (#1841)

### DIFF
--- a/daemon/lostrestore.go
+++ b/daemon/lostrestore.go
@@ -224,6 +224,17 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 	// probe the new sandbox the instant Recover returns; every statement between
 	// the swap and this reset widens that window for nothing.
 	m.noteRuntimeReplaced(repoID, inst)
+	// Then persist, same as the manual restore path (restore.go): Recover mutates
+	// durable worktree state on the way to SUCCESS too, not only before a failure
+	// — a fresh rebuild from the recorded base recreates the branch and flips
+	// branchCreatedByUs, and the orphaned-branch consequence is the one spelled
+	// out on the failure path above (#1841). The poll loop does NOT cover this:
+	// Recover's ConfirmLive already left the instance LiveRunning, so the next
+	// tick compares LiveRunning against LiveRunning and persistPollChange skips
+	// the write for as long as the agent stays busy. Ordering is load-bearing —
+	// this write goes AFTER noteRuntimeReplaced, never before, since a disk write
+	// is exactly the kind of statement the rule above keeps out of that window.
+	m.persistInstance(repoID, inst)
 	log.InfoLog.Printf("restored lost session %q (repo %s): agent re-spawned in its workspace", inst.Title, repoID)
 	m.mu.Lock()
 	delete(m.lostRestoreStates, key)

--- a/daemon/lostrestore_test.go
+++ b/daemon/lostrestore_test.go
@@ -247,6 +247,60 @@ func TestRestoreLostSessions_PersistsAfterFailedRecover(t *testing.T) {
 	}
 }
 
+// TestRestoreLostSessions_PersistsAfterSuccessfulRecover is the #1841 twin of
+// the failed-recover case above: Recover mutates durable worktree state on the
+// way to SUCCESS too, so the success path must write it back as well.
+//
+// A vanished worktree whose branch is also gone drives Recover into
+// RebuildFreshFromRecordedBase, which recreates the branch and flips
+// branchCreatedByUs true (and rewrites baseCommitSHA) before the tmux spawn
+// succeeds. The poll loop does not cover the gap: Recover's ConfirmLive already
+// left the instance LiveRunning, so a later tick compares LiveRunning against
+// LiveRunning and persistPollChange returns without writing. A daemon restart
+// before an idle transition then reloads a stale branchCreatedByUs=false, the
+// next recovery skips the rebuild (the worktree exists again), and kill never
+// deletes the branch af itself created — leaving it orphaned.
+func TestRestoreLostSessions_PersistsAfterSuccessfulRecover(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	zeroRestoreBackoff(t)
+
+	// Mirrors the failed-recover fixture: the in-memory record carries the
+	// rebuild's branchCreatedByUs=true, while the seeded disk record has no
+	// worktree data at all — so only a persist on the success path can put the
+	// flag on disk.
+	wtPath := filepath.Join(filepath.Dir(repoPath), "repo-1841")
+	branch := "af/persist-1841"
+	if out, err := exec.Command("git", "-C", repoPath, "worktree", "add", "-b", branch, wtPath).CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add: %v\n%s", err, out)
+	}
+	gw, err := sessiongit.NewGitWorktreeFromStorage(repoPath, wtPath, "persist-1841", branch, "", false, true)
+	if err != nil {
+		t.Fatalf("NewGitWorktreeFromStorage: %v", err)
+	}
+
+	backend := &recoverFakeBackend{FakeBackend: session.NewFakeBackend()}
+	inst := registerStarted(t, manager, repoID, repoPath, "persist-1841", backend, true, session.Lost)
+	inst.SetGitWorktreeForTest(gw)
+
+	manager.RestoreLostSessions()
+
+	if got := backend.recoverCalls(); got != 1 {
+		t.Fatalf("recover calls = %d, want 1", got)
+	}
+	rec := recordFor(t, repoID, "persist-1841")
+	if rec == nil {
+		t.Fatal("record must still exist after a successful recover")
+	}
+	if rec.Worktree.BranchCreatedByUs == nil || !*rec.Worktree.BranchCreatedByUs {
+		t.Fatalf("persisted branchCreatedByUs = %v, want true (the rebuild's flag must survive a successful recover)", rec.Worktree.BranchCreatedByUs)
+	}
+	// The recovered branch itself must land on disk too: a restart that reloads a
+	// record with no branch recorded cannot clean up what recovery created.
+	if rec.Worktree.BranchName != branch {
+		t.Fatalf("persisted branch = %q, want %q (a successful recover must persist its worktree record)", rec.Worktree.BranchName, branch)
+	}
+}
+
 type failPtyFactory struct{}
 
 func (failPtyFactory) Start(*exec.Cmd) (*os.File, error) {


### PR DESCRIPTION
## Summary

`restoreLostSession` persisted the instance on the **failure** path (#1532) but never on the **success** path, so durable worktree state mutated by a successful `Recover()` lived only in memory.

Verified reproducing on `master` before fixing — this is a real bug, not a false positive.

## Root cause

`Recover()` mutates durable state on the way to *success*, not only before a failure. When a session's worktree **and** branch have both vanished, `LocalBackend.respawn` falls through:

- `RebuildFromExistingBranch()` fails (the branch is gone), so
- `RebuildFreshFromRecordedBase()` recreates the branch, sets `branchCreatedByUs = true` and rewrites `baseCommitSHA`, then
- the tmux spawn succeeds and `ConfirmLive()` leaves the instance `LiveRunning`.

**The poll loop does not cover this.** `persistPollChange` writes only when liveness or the limit-reset time changed. `ConfirmLive` already moved the instance to `LiveRunning`, so the next tick compares `LiveRunning` → `LiveRunning` and returns without writing — for as long as the agent stays busy.

A daemon restart before an idle transition then reloads a stale `branchCreatedByUs=false`; the next recovery skips the rebuild (the worktree exists again), so `kill` never deletes the branch af itself created and it is **orphaned**.

Reachability check (this is what makes it a real bug rather than a theoretical one): the reload default for `branchCreatedByUs` is `true`, so a stale `false` only bites if `false` is reachable for a *rebuildable* worktree. It is — `instance_data.go` documents that the flag flips false on the normal path when Setup reuses an existing branch, and such a session is not external, so it can reach `RebuildFreshFromRecordedBase`.

## Fix

Persist after a successful `Recover()`, mirroring the manual restore path in `restore.go`, which already persists on **both** outcomes.

### Ordering is load-bearing

The write goes **after** `noteRuntimeReplaced`, **not before it as the issue suggests**. The #1794/#1804 rule keeps every statement out of the window between the runtime swap and the debounce reset ("every statement between the swap and this reset widens that window for nothing") — and a disk write is exactly such a statement. Placing the persist first would regress #1804.

`restore.go:111-112` resolves it the same way (`noteRuntimeReplaced`, then `persist`), as does the `remoteSandboxAnswersAlive` branch in this same function (`clearRemoteLoss`, then `persist`). The issue's recommended snippet contradicts its own cited reference on this point.

## Test

`TestRestoreLostSessions_PersistsAfterSuccessfulRecover` is the success-path twin of the existing `PersistsAfterFailedRecover` fixture. Pre-fix it fails with:

```
persisted branchCreatedByUs = <nil>, want true
```

It also asserts the recovered branch name lands on disk — a restart that reloads a record with no branch recorded cannot clean up what recovery created.

## Adjacent work — not regressed

All green, including the tests guarding the just-merged work:

- **#1804** (remote-loss debounce) — `PostRecoverBlipDoesNotReprovisionAgain`, `PostManualRecoverBlipDoesNotReprovision` pass; the ordering choice above is what preserves this.
- **#1796** (restore branch recording), **#1739/#1726** (restore runtime binding/teardown) — full `daemon` package green.

## Follow-up (not in this PR)

`resumeFromLimit` (`daemon/limit.go`) calls `Respawn()`, which shares the same `LocalBackend.respawn` rebuild path. It persists at the end, but returns early if `SendPrompt` fails — **after** the rebuild already mutated durable state, losing it the same way. Same bug class, narrower path; filing separately to keep this PR focused rather than widening the diff.

## Gates

| Gate | Result |
|---|---|
| `make test-container` | 0 failures, all packages ok |
| `make tui-driver-selftest` | 33/33 green |
| `go build ./...` | clean |
| `gofmt -l .` | clean |
| `golangci-lint run --fast` | clean |
| `deadcode -test ./...` | clean |
| `scripts/lint-file-length.sh` | clean |

Fixes #1841

🤖 Generated with [Claude Code](https://claude.com/claude-code)