### PR TITLE
fix(daemon): persist the respawn's worktree state before the resume's SendPrompt (#1854)

### DIFF
--- a/daemon/limit.go
+++ b/daemon/limit.go
@@ -281,6 +281,21 @@ func (m *Manager) resumeFromLimitLocked(repoID, key string, instance *session.In
 		// endpoint and the resume could never clear the limit (#1786). Inert for local
 		// sessions, whose localAgentServer resolves i.backend per call.
 		as = instance.AgentServer()
+		// Write the respawn's durable state NOW, not at the end of the happy path
+		// (#1854). Respawn shares LocalBackend.respawn, so reaching this line can mean
+		// it rebuilt a vanished worktree — recreating the branch, flipping
+		// branchCreatedByUs and rewriting baseCommitSHA. The SendPrompt below can
+		// fail, and its early return would drop all of that: a restart would reload a
+		// record with no rebuilt branch recorded, and kill would orphan the branch af
+		// itself created (#1841's outcome, same class). The poll does not cover it
+		// either — the respawn already left the instance live, so persistPollChange
+		// sees no liveness change and skips the write.
+		//
+		// AFTER noteRuntimeReplaced, never before: the #1794/#1804 rule keeps every
+		// statement — a disk write above all — out of the window between the runtime
+		// swap and the debounce reset, so a blip there is not judged against the dead
+		// runtime. restore.go resolves the same ordering the same way.
+		m.persistInstance(repoID, instance)
 	}
 
 	prompt := strings.TrimSpace(instance.Prompt)
@@ -294,12 +309,9 @@ func (m *Manager) resumeFromLimitLocked(repoID, key string, instance *session.In
 	}
 	instance.ClearLimitReached()
 
-	repoStartLock := m.startLockForRepo(repoID)
-	repoStartLock.Lock()
-	perr := persistInstanceData(repoID, instance.ToInstanceData())
-	repoStartLock.Unlock()
-	if perr != nil {
-		log.WarningLog.Printf("daemon failed to persist resume for %q: %v", instance.Title, perr)
-	}
+	// The cleared limit is itself durable state worth a checkpoint. On the respawn
+	// arm this is the second write; that is deliberate — the first one is what
+	// survives a failed SendPrompt, this one records the resume that landed.
+	m.persistInstance(repoID, instance)
 	return nil
 }

--- a/daemon/limit_resume_test.go
+++ b/daemon/limit_resume_test.go
@@ -1,12 +1,16 @@
 package daemon
 
 import (
+	"errors"
 	"fmt"
+	"os/exec"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/sachiniyer/agent-factory/session"
+	sessiongit "github.com/sachiniyer/agent-factory/session/git"
 )
 
 // limitResumeBackend is a FakeBackend instrumented for the usage-limit manual-
@@ -16,13 +20,20 @@ import (
 // the real backend. Respawn — the guard-free re-spawn core the fix uses instead —
 // and SendPromptCommand record their calls so the test can assert which path ran
 // and what prompt was re-delivered.
+//
+// onRespawn stands in for the durable worktree mutation a real respawn can make
+// (RebuildFreshFromRecordedBase recreating the branch); sendPromptErr fails the
+// prompt delivery that follows it. Both are the #1854 fixture and default to
+// inert, so the tests predating it are unaffected.
 type limitResumeBackend struct {
 	*session.FakeBackend
-	mu           sync.Mutex
-	alive        bool
-	recoverCalls int
-	respawnCalls int
-	sentPrompts  []string
+	mu            sync.Mutex
+	alive         bool
+	recoverCalls  int
+	respawnCalls  int
+	sentPrompts   []string
+	onRespawn     func(*session.Instance)
+	sendPromptErr error
 }
 
 func (b *limitResumeBackend) IsAlive(*session.Instance) bool {
@@ -48,7 +59,13 @@ func (b *limitResumeBackend) Recover(i *session.Instance) error {
 func (b *limitResumeBackend) Respawn(i *session.Instance) error {
 	b.mu.Lock()
 	b.respawnCalls++
+	mutate := b.onRespawn
 	b.mu.Unlock()
+	// A real respawn can rebuild the worktree on its way to success, mutating
+	// durable state before anything downstream runs (#1854).
+	if mutate != nil {
+		mutate(i)
+	}
 	// The guard-free core: re-spawn regardless of liveness (matches the real
 	// LocalBackend.respawn, which ends by marking the session live).
 	_ = i.Transition(session.ConfirmLive())
@@ -57,8 +74,11 @@ func (b *limitResumeBackend) Respawn(i *session.Instance) error {
 
 func (b *limitResumeBackend) SendPromptCommand(_ *session.Instance, prompt string) error {
 	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.sendPromptErr != nil {
+		return b.sendPromptErr
+	}
 	b.sentPrompts = append(b.sentPrompts, prompt)
-	b.mu.Unlock()
 	return nil
 }
 
@@ -100,6 +120,68 @@ func TestResumeFromLimit_ExitedAgent_RespawnsNotRecover(t *testing.T) {
 	}
 	if len(prompts) != 1 || prompts[0] != "finish the migration" {
 		t.Fatalf("re-delivered prompts = %v, want [\"finish the migration\"] (a task session resumes its stored prompt)", prompts)
+	}
+}
+
+// TestResumeFromLimit_PersistsRespawnMutationsWhenSendPromptFails is the
+// regression for #1854, the adjacent call-site of #1841: Respawn shares
+// LocalBackend.respawn, so it can rebuild a vanished worktree — recreating the
+// branch, flipping branchCreatedByUs true and rewriting baseCommitSHA — on its
+// way to SUCCESS. resumeFromLimit persisted only at the very end, so a
+// SendPrompt failure after that rebuild returned early and dropped the mutation:
+// a daemon restart reloaded a record with no rebuilt branch recorded and the
+// branch af itself created was orphaned, never cleaned up on kill.
+//
+// The poll does not paper over it — persistPollChange writes only when the
+// liveness or reset time changed, and the respawn already left the instance
+// LiveRunning, so the next tick compares LiveRunning → LiveRunning and skips.
+func TestResumeFromLimit_PersistsRespawnMutationsWhenSendPromptFails(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+
+	// The worktree the rebuild leaves behind, with branchCreatedByUs=true. The
+	// seeded disk record carries no worktree data at all, so anything the respawn
+	// rebuilt exists only in memory until something writes it back.
+	wtPath := filepath.Join(filepath.Dir(repoPath), "repo-1854")
+	branch := "af/persist-1854"
+	if out, err := exec.Command("git", "-C", repoPath, "worktree", "add", "-b", branch, wtPath).CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add: %v\n%s", err, out)
+	}
+	rebuilt, err := sessiongit.NewGitWorktreeFromStorage(repoPath, wtPath, "persist-1854", branch, "", false, true)
+	if err != nil {
+		t.Fatalf("NewGitWorktreeFromStorage: %v", err)
+	}
+
+	// alive=false → probeDead → the respawn arm. The respawn rebuilds the worktree
+	// and succeeds; the SendPrompt that follows it fails.
+	backend := &limitResumeBackend{
+		FakeBackend:   session.NewFakeBackend(),
+		alive:         false,
+		onRespawn:     func(i *session.Instance) { i.SetGitWorktreeForTest(rebuilt) },
+		sendPromptErr: errors.New("agent-server refused the prompt"),
+	}
+	inst := registerStarted(t, manager, repoID, repoPath, "persist-1854", backend, true, session.Running)
+	inst.Prompt = "finish the migration"
+	inst.SetLimitReached(time.Time{})
+
+	if err := manager.resumeFromLimit(ResumeFromLimitRequest{Title: "persist-1854", RepoID: repoID}); err == nil {
+		t.Fatal("resumeFromLimit returned nil; a failed SendPrompt must still surface to the caller")
+	}
+
+	if _, respawnCalls, _ := backend.snapshot(); respawnCalls != 1 {
+		t.Fatalf("Respawn called %d times, want 1 (the fixture must reach the rebuild arm)", respawnCalls)
+	}
+
+	rec := recordFor(t, repoID, "persist-1854")
+	if rec == nil {
+		t.Fatal("record must still exist after a failed resume")
+	}
+	if rec.Worktree.BranchCreatedByUs == nil || !*rec.Worktree.BranchCreatedByUs {
+		t.Fatalf("persisted branchCreatedByUs = %v, want true (the rebuild's flag must survive a failed SendPrompt)", rec.Worktree.BranchCreatedByUs)
+	}
+	// The branch name matters as much as the flag: a restart that reloads a record
+	// with no branch recorded cannot clean up what the rebuild created.
+	if rec.Worktree.BranchName != branch {
+		t.Fatalf("persisted branch = %q, want %q (the rebuilt branch must be recorded or kill orphans it)", rec.Worktree.BranchName, branch)
 	}
 }
 


### PR DESCRIPTION
## Summary

`resumeFromLimit` persisted only at the very end of its happy path, but the `probeDead` arm's `instance.Respawn()` can mutate durable worktree state on its way to **success**. A `SendPrompt` failure after that returned early and dropped the mutation.

**Reproduced on `master` before fixing** — the issue filed this as a code-read finding, so the first commit-worthy step was proving it real. It is: the new test fails pre-fix with the same signature #1853 hit.

```
persisted branchCreatedByUs = <nil>, want true
```

## Root cause

`Recover()` and `Respawn()` both route through `LocalBackend.respawn`, so both can rebuild a vanished worktree — `RebuildFreshFromRecordedBase` recreates the branch, flips `branchCreatedByUs` true and rewrites `baseCommitSHA` — and then **succeed**. `resumeFromLimit` wrote to disk only after `SendPrompt` had landed:

```go
case probeDead:
    if rerr := instance.Respawn(); rerr != nil { ... }   // may rebuild the worktree
    m.noteRuntimeReplaced(repoID, instance)
...
if serr := as.SendPrompt(prompt); serr != nil {
    return ...   // early return — skips the persist below
}
```

**The poll does not cover it.** `persistPollChange` writes only when the liveness or the limit-reset time changed; the respawn's `ConfirmLive` already moved the instance live, so the next tick compares live → live and returns without writing.

A daemon restart then reloads a record with **no rebuilt branch recorded at all**, so `kill` never deletes the branch af itself created and it is **orphaned** — the #1841 outcome, narrower path.

## Fix

Persist right after the respawn, matching the rule #1841 established: any path that can mutate durable worktree state writes it back regardless of what fails downstream — persist-at-mutation, not persist-at-happy-path-end.

### Ordering is load-bearing

The write goes **after** `noteRuntimeReplaced`, never before. The #1794/#1804 rule keeps every statement out of the window between the runtime swap and the debounce reset ("every statement between the swap and this reset widens that window for nothing") — and a disk write is exactly such a statement. `restore.go:111-112` resolves the same ordering the same way, as does #1853.

Both persists now share the existing best-effort `persistInstance` helper (`archive.go`) instead of re-inlining the start-lock dance — its doc ("a checkpoint the next poll/tick will re-attempt") describes this case exactly. Nothing asserted the old inline log text.

## Test

`TestResumeFromLimit_PersistsRespawnMutationsWhenSendPromptFails`: a `probeDead` session whose respawn rebuilds the worktree, then a failing `SendPrompt`. Asserts the rebuild's `branchCreatedByUs` **and** the rebuilt branch name reach disk — a restart that reloads a record with no branch recorded cannot clean up what the respawn created.

Verified it gates the fix: reverting just the new persist call fails this test and only this test, with the identical pre-fix signature.

The `limitResumeBackend` fixture gained two optional hooks (`onRespawn`, `sendPromptErr`), both inert by default, so the tests predating it are untouched.

## Adjacent call-site audit

Per the repo rule that spun this issue out of #1841 in the first place — all three `Recover()`/`Respawn()` callers outside `session/`:

| Site | State |
|---|---|
| `restore.go:101` (manual restore) | Already correct — persists on **both** outcomes |
| `lostrestore.go:200` (Lost-restore) | The #1841 gap — **owned by #1853**, deliberately untouched here |
| `limit.go:271` (limit resume) | **Fixed by this PR** |

The class is fully covered once #1853 lands.

## Coordination with #1853

No overlap and no rebase needed: #1853 touches `daemon/lostrestore.go` + `daemon/lostrestore_test.go`, this PR touches `daemon/limit.go` + `daemon/limit_resume_test.go`. Base is `master`, not stacked. #1853's tests are green in the runs below (the `daemon` package includes them), and either PR can merge first.

## Gates

All run against the final tree.

| Gate | Result |
|---|---|
| `make test-container` | 0 failures, all packages ok |
| `make tui-driver-selftest` | 33/33 green |
| `go build ./...` | clean |
| `gofmt -l .` | clean |
| `golangci-lint run --fast` | clean |
| `deadcode -test ./...` | clean |
| `scripts/lint-file-length.sh` | clean |

Fixes #1854

🤖 Generated with [Claude Code](https://claude.com/claude-code)
