### PR TITLE
fix(web): reconcile activeTab with the visible pane on (re)selection (#1855)

### DIFF
--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7756,6 +7756,25 @@ var SplitView = class {
     this.reconcile();
     this.report();
   }
+  /** The tab `sessionId` will actually be shown on once selected: the focused pane's
+   *  tab for the session already on screen, the retained layout's first pane for one
+   *  shown before (setSession focuses exactly that leaf), and 0 for a session never
+   *  shown — it gets a fresh single leaf.
+   *
+   *  Selection asks this instead of asserting 0. Trees are RETAINED across session
+   *  switches, so "reset activeTab to 0 on select" states something about a pane that
+   *  already disagrees — and report(), the only writer of activeTab, dedups on the
+   *  focused tab, so a re-entry that settles on the SAME index never corrects it. The
+   *  bar then highlights Agent over a pane showing tab N, and the next close computes
+   *  its shift from the stale 0 and yanks the pane to Agent (#1855). Reading the
+   *  settled tab keeps the store's claim and the pane's binding the same statement. */
+  settledTab(sessionId) {
+    if (sessionId === this.sessionId) {
+      return this.tree && this.focusedId ? findLeaf(this.tree, this.focusedId)?.tab ?? 0 : 0;
+    }
+    const retained = this.trees.get(sessionId);
+    return retained ? leaves(retained)[0]?.tab ?? 0 : 0;
+  }
   /** Rebinds the FOCUSED pane to show `tab` (a 1-9 key or a tab-bar click on the
    *  focused pane). No-op without a focused pane. Does not steal DOM focus. */
   setFocusedTab(tab) {
@@ -9406,7 +9425,13 @@ function disconnect() {
 }
 function moveSelection(id) {
   clearTabError();
-  store.set({ selectedId: id, focus: "rail", activeTab: 0 });
+  store.set({
+    selectedId: id,
+    focus: "rail",
+    // Clamped like syncSplit's initialTab, so the store's claim and the pane's binding
+    // are the same statement even if the roster shrank since the tree was retained.
+    activeTab: clampActiveTab(store.get().sessions, id, splitView.settledTab(id))
+  });
 }
 function openFromRail(id) {
   if (store.get().view !== "sessions") {
@@ -9445,7 +9470,12 @@ function switchProject(root2) {
   const sel = selectedSessionData();
   const keep = sel && sel.worktree?.repo_path === root2 ? store.get().selectedId : null;
   splitView.blur();
-  store.set({ selectedProject: root2, selectedId: keep, focus: "rail", activeTab: 0 });
+  store.set({
+    selectedProject: root2,
+    selectedId: keep,
+    focus: "rail",
+    activeTab: keep ? clampActiveTab(store.get().sessions, keep, splitView.settledTab(keep)) : 0
+  });
 }
 function selectedSession2() {
   const { sessions, selectedId } = store.get();
@@ -9801,7 +9831,8 @@ function applySessions(sessions) {
       selectedId = null;
     }
   }
-  const activeTab = selectedId === prevSel ? clampActiveTab(sessions, selectedId, store.get().activeTab) : 0;
+  const settled = selectedId === prevSel ? store.get().activeTab : splitView.settledTab(selectedId ?? "");
+  const activeTab = clampActiveTab(sessions, selectedId, settled);
   store.set({ sessions, selectedProject, selectedId, activeTab });
 }
 function requestResync() {

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -1049,6 +1049,89 @@ test("web tab (feat): a surviving web tab that only SHIFTS ordinal is followed, 
   expect(stamp).toBe("af-not-remounted");
 });
 
+// Ordering note: the #1779 test above consumed probe-web's "preview" tab, so the
+// session's tabs here are [Agent, external] and "external" is the non-agent tab these
+// two use as the retained pane.
+
+test("tabs (#1855): re-selecting the SAME session leaves the bar on the tab the pane shows, not Agent", async () => {
+  // Selecting a session asserted `activeTab: 0` about a layout it had already retained:
+  // the tree still pointed at tab N, so the bar highlighted Agent while the pane kept
+  // showing N. Re-selecting the session you are ALREADY on is the shortest proof —
+  // setSession's same-session branch finds nothing changed, so report() (the only
+  // writer of activeTab) never fires and the reset is never undone.
+  await row(page, SESSION_WEB).click();
+  await expect(page.locator(".af-main.af-main-term")).toBeVisible();
+  const tabbar = page.locator(".af-tabbar");
+  const frame = page.locator(".af-term-host .af-pane-host iframe.af-webframe");
+
+  // Park the pane on "external" (index 1) via a REAL index change (0 then 1): clicking
+  // the tab you are already on is itself a no-op report, so it could not establish this
+  // precondition on a desynced store.
+  await tabbar.locator(".af-tab", { hasText: "Agent" }).click();
+  await expect(page.locator(".af-tab.af-tab-active .af-tab-label")).toHaveText("Agent");
+  await tabbar.locator(".af-tab", { hasText: "external" }).click();
+  await expect(page.locator(".af-tab.af-tab-active .af-tab-label")).toHaveText("external");
+  await expect(frame).toHaveCount(1, { timeout: 15_000 });
+
+  // Click the row that is already selected. The pane is untouched (same session, same
+  // tree) — so the bar must still name the tab it is showing.
+  await row(page, SESSION_WEB).click();
+  await expect(frame).toHaveCount(1);
+  await expect(frame).toHaveAttribute("src", WEBTAB_EXTERNAL_URL);
+  await expect(page.locator(".af-tab.af-tab-active .af-tab-label")).toHaveText("external");
+});
+
+test("tabs (#1855): switching away and back keeps activeTab on the visible pane — and the next close doesn't yank it to Agent", async () => {
+  // The issue's own repro. It needs the re-entry to settle on the SAME focused index the
+  // last report carried: report() dedups on (focusedTab, shownTabs, paneCount), so an
+  // identical index makes it early-return and the `activeTab: 0` reset stands
+  // uncorrected. probe-web is re-entered on tab 1 ("external"), so probe-b is parked on
+  // ITS tab 1 to collide.
+  const tabbar = page.locator(".af-tabbar");
+  const frame = page.locator(".af-term-host .af-pane-host iframe.af-webframe");
+
+  // A throwaway terminal tab on probe-web, so there is a tab to close later that is
+  // NEITHER the agent tab nor the active one — closing it must not move the pane.
+  await row(page, SESSION_WEB).click();
+  await expect(page.locator(".af-main.af-main-term")).toBeVisible();
+  await tabbar.locator(".af-tab-new").click();
+  await expect(tabbar.locator(".af-tab")).toHaveCount(3, { timeout: 30_000 });
+
+  // Park probe-web on "external" (index 1) — an index change, so the store is truthful
+  // going in.
+  await tabbar.locator(".af-tab", { hasText: "external" }).click();
+  await expect(page.locator(".af-tab.af-tab-active .af-tab-label")).toHaveText("external");
+  await expect(frame).toHaveCount(1, { timeout: 15_000 });
+
+  // Switch away, and leave probe-b focused on its own tab 1 (+ creates AND attaches),
+  // so the last reported focused tab is 1 — the collision.
+  await row(page, SESSION_B).click();
+  await expect(page.locator(".af-main.af-main-term")).toBeVisible();
+  await tabbar.locator(".af-tab-new").click();
+  await expect(tabbar.locator(".af-tab")).toHaveCount(2, { timeout: 30_000 });
+  await expect(page.locator(".af-tab.af-tab-active .af-tab-label")).toHaveText("Terminal");
+
+  // Back to probe-web: the retained pane still shows "external", so the bar must too.
+  await row(page, SESSION_WEB).click();
+  await expect(frame).toHaveCount(1, { timeout: 15_000 });
+  await expect(frame).toHaveAttribute("src", WEBTAB_EXTERNAL_URL);
+  await expect(page.locator(".af-tab.af-tab-active .af-tab-label")).toHaveText("external");
+
+  // Closing an UNRELATED tab (the throwaway, to the RIGHT of the active one) leaves the
+  // pane where it was. With a stale activeTab the close arithmetic read 0 and re-pointed
+  // the pane at Agent, tearing down the live iframe.
+  await tabbar.locator(".af-tab", { hasText: "Terminal" }).locator(".af-tab-close").click();
+  await expect(tabbar.locator(".af-tab")).toHaveCount(2, { timeout: 30_000 });
+  await expect(page.locator(".af-tab.af-tab-active .af-tab-label")).toHaveText("external");
+  await expect(frame).toHaveCount(1);
+
+  // Restore probe-b's tab set for the flows that follow.
+  await row(page, SESSION_B).click();
+  await expect(tabbar.locator(".af-tab", { hasText: "Terminal" })).toHaveCount(1);
+  await tabbar.locator(".af-tab", { hasText: "Terminal" }).locator(".af-tab-close").click();
+  await expect(tabbar.locator(".af-tab")).toHaveCount(1, { timeout: 30_000 });
+});
+
 test("split panes (feat): logout clears retained trees — a fresh login shows the single-leaf default", async () => {
   // Split A into two panes.
   await row(page, SESSION_A).click();

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -302,11 +302,18 @@ function disconnect(): void {
  *  rail-nav mode. This is the keyboard path (j/k): selecting a row never steals the
  *  keyboard into the terminal — you attach explicitly with Enter. Resetting focus to
  *  "rail" here also clears any stale "terminal" mode left by a since-disposed
- *  terminal, so j/k keep working after the selected session goes away. Selecting a
- *  session always resets the active tab to its agent tab (index 0). */
+ *  terminal, so j/k keep working after the selected session goes away. The active tab
+ *  follows the layout the split view will actually show (settledTab) — a session shown
+ *  before keeps its retained pane, and only one never shown starts on its agent tab. */
 function moveSelection(id: string): void {
   clearTabError();
-  store.set({ selectedId: id, focus: "rail", activeTab: 0 });
+  store.set({
+    selectedId: id,
+    focus: "rail",
+    // Clamped like syncSplit's initialTab, so the store's claim and the pane's binding
+    // are the same statement even if the roster shrank since the tree was retained.
+    activeTab: clampActiveTab(store.get().sessions, id, splitView.settledTab(id)),
+  });
 }
 
 /** The click/Enter path: selects the session AND hands the keyboard to its terminal
@@ -373,7 +380,14 @@ function switchProject(root: string): void {
   const sel = selectedSessionData();
   const keep = sel && sel.worktree?.repo_path === root ? store.get().selectedId : null;
   splitView.blur();
-  store.set({ selectedProject: root, selectedId: keep, focus: "rail", activeTab: 0 });
+  // A KEPT selection keeps its pane too, so its active tab is whatever that pane shows
+  // — not 0, which would desync the bar from it (#1855, same as moveSelection).
+  store.set({
+    selectedProject: root,
+    selectedId: keep,
+    focus: "rail",
+    activeTab: keep ? clampActiveTab(store.get().sessions, keep, splitView.settledTab(keep)) : 0,
+  });
 }
 
 // --- lifecycle actions (modals) --------------------------------------------
@@ -942,7 +956,11 @@ function applySessions(sessions: SessionData[]): void {
       selectedId = null;
     }
   }
-  const activeTab = selectedId === prevSel ? clampActiveTab(sessions, selectedId, store.get().activeTab) : 0;
+  // An unchanged selection keeps its active tab; one the snapshot MOVED (the selected
+  // session was archived/killed, so pickSelection landed elsewhere) takes the tab its
+  // retained layout will settle on rather than asserting 0 (#1855, as moveSelection).
+  const settled = selectedId === prevSel ? store.get().activeTab : splitView.settledTab(selectedId ?? "");
+  const activeTab = clampActiveTab(sessions, selectedId, settled);
   store.set({ sessions, selectedProject, selectedId, activeTab });
 }
 

--- a/web/src/split.ts
+++ b/web/src/split.ts
@@ -223,6 +223,26 @@ export class SplitView {
     this.report();
   }
 
+  /** The tab `sessionId` will actually be shown on once selected: the focused pane's
+   *  tab for the session already on screen, the retained layout's first pane for one
+   *  shown before (setSession focuses exactly that leaf), and 0 for a session never
+   *  shown — it gets a fresh single leaf.
+   *
+   *  Selection asks this instead of asserting 0. Trees are RETAINED across session
+   *  switches, so "reset activeTab to 0 on select" states something about a pane that
+   *  already disagrees — and report(), the only writer of activeTab, dedups on the
+   *  focused tab, so a re-entry that settles on the SAME index never corrects it. The
+   *  bar then highlights Agent over a pane showing tab N, and the next close computes
+   *  its shift from the stale 0 and yanks the pane to Agent (#1855). Reading the
+   *  settled tab keeps the store's claim and the pane's binding the same statement. */
+  settledTab(sessionId: string): number {
+    if (sessionId === this.sessionId) {
+      return this.tree && this.focusedId ? (findLeaf(this.tree, this.focusedId)?.tab ?? 0) : 0;
+    }
+    const retained = this.trees.get(sessionId);
+    return retained ? (leaves(retained)[0]?.tab ?? 0) : 0;
+  }
+
   /** Rebinds the FOCUSED pane to show `tab` (a 1-9 key or a tab-bar click on the
    *  focused pane). No-op without a focused pane. Does not steal DOM focus. */
   setFocusedTab(tab: number): void {


### PR DESCRIPTION
## Summary

Re-selecting a session left the store's `activeTab` **desynced from the pane the split view was actually showing**. The tab bar highlighted **Agent** while the pane showed tab N — and the next tab close **yanked the pane to Agent**, discarding a live web preview or a terminal's scrollback.

Fixes #1855.

**Verified reproducing on `master` before fixing.** The pane assertions passed while the bar assertion failed — the desync itself, caught in the harness:

```
✘ tabs (#1855): re-selecting the SAME session leaves the bar on the tab the pane shows, not Agent

  await expect(frame).toHaveCount(1);                       ✓  the pane IS showing the web tab
  await expect(frame).toHaveAttribute("src", EXTERNAL_URL); ✓
  await expect(...af-tab-active...).toHaveText("external");

  Expected: "external"
  Received: "Agent"        <-- the bar lies
```

## Root cause

Selection reset `activeTab: 0` while the split view **retained** the session's layout tree. The reset asserted something about a pane that already disagreed: the tree still pointed at tab N.

`report()` — the only writer of `activeTab` — dedups on `(focusedTab, shownTabs, paneCount)`, so a re-entry that settles on the **same** focused index early-returns and never corrects the store. That is also why clicking the tab you are already on can't fix it: `openTab(N)` → `setFocusedTab(N)` is a no-op report.

Two ways in, one root:

| Path | Why the store is never corrected |
|---|---|
| Re-select the session you're already on | `setSession`'s same-session branch finds nothing changed, so `report()` is never called |
| Switch away and back | `report()` fires but **early-returns** when the re-entry settles on the same focused index |

## The fix

Stop letting the two diverge. The split view is the single source of truth for "which tab is focused", so selection **asks** it rather than guessing `0`:

```ts
splitView.settledTab(id)  // focused pane's tab (session on screen)
                          // → retained tree's first leaf (shown before)
                          // → 0 (never shown — it gets a fresh single leaf)
```

The result is clamped exactly as `validate()` clamps the tree (`tabCount - 1`), so the store's claim and the pane's binding are the same statement even when the roster shrank since the tree was retained.

`closeSessionTab`'s arithmetic is **untouched** — the issue is right that it was correct all along; only its input was stale. With `cur` honest, `next` lands on the tab the user was on.

## Adjacent sites

The same lie lived at every site that re-points selection over a retained tree, so all three now read the settled tab:

- **`moveSelection`** — the j/k + click path the issue names.
- **`switchProject`** — a KEPT selection keeps its pane too.
- **`applySessions`** — a snapshot that MOVES the selection (the selected session was archived/killed, so `pickSelection` landed elsewhere) landed on another session's retained tree.

`createSession` still resets to `0`, correctly: a brand-new session id has no retained tree, so `0` **is** its settled tab.

## Tests

Two Playwright cases in `web-driver.spec.ts`, both **red on master** and green here:

1. **Re-selecting the SAME session** leaves the bar on the tab the pane shows — the shortest proof, since the same-session reconcile changes nothing and `report()` never fires.
2. **The issue's own repro** — park probe-web on a web tab, switch away (probe-b parked on a *colliding* focused index so `report()` early-returns), re-select, then close an unrelated tab and assert the pane does **not** yank to Agent.

Both establish their precondition via a real index change, because clicking the tab you're already on is itself a no-op report — it could not set up the state on a desynced store. They restore the tab sets they borrow, so the serial suite that follows is unaffected.

## Coordination with #1815

#1815 is open against the same files. This diff is **disjoint** from it and does not duplicate it:

- #1815 moves `cur` to a pre-await snapshot and guards with `layoutGeneration()` — a **stale-async** fix. It still reads `store.get().activeTab`, so it does not fix #1855; the two are complementary (it fixes *when* the input is read, this fixes *whether the input is true*).
- No overlapping hunks: #1815 touches `openTab`/`closeSessionTab` and inserts at `split.ts` ~308 and at the **end** of the spec. This touches `moveSelection`/`switchProject`/`applySessions`, inserts `settledTab` next to `setFocusedTab`, and adds its tests mid-file.

## Gates

| Gate | Result |
|---|---|
| `make web-selftest-container` | **36/36 green** |
| `make web-test` | 147/147 |
| `make tui-driver-selftest` | 33/33 green |
| `go build` / `gofmt` / `golangci-lint --fast` / `deadcode` | clean |
| `web/dist` | rebuilt |

Rebased on `master` (v1.0.186). **Not merging** — flagged for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)