### PR TITLE
test(web-selftest): assert probe-web tabs by name/ordinal, not roster totals (#1863)

### DIFF
--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -1026,11 +1026,15 @@ test("web tab (feat): a surviving web tab that only SHIFTS ordinal is followed, 
   await tabbar.locator(".af-tab", { hasText: "preview" }).locator(".af-tab-close").click();
   await expect(tabbar.locator(".af-tab", { hasText: "preview" })).toHaveCount(0, { timeout: 30_000 });
   // The shift really happened — without this the assertion below would prove nothing.
-  // The roster is [Agent, preview, external, nourl] before the close and [Agent,
-  // external, nourl] after: the seeded URL-less tab (#1818) is part of probe-web's
-  // real tab list now, so the surviving count is 3, not 2. "external" still shifts
-  // 2 → 1, which is what this test turns on.
-  await expect(tabbar.locator(".af-tab")).toHaveCount(3, { timeout: 30_000 });
+  // Asserted as "external now sits at ordinal 1", not as a roster total (#1863): probe-web
+  // permanently carries the seeded URL-less tab (#1818), and any tab mutation republishes
+  // the roster (#1812), so a total is both bigger than it looks and free to move under the
+  // assertion. The ordinal is the thing this test actually turns on — [Agent, preview,
+  // external, nourl] before the close, [Agent, external, nourl] after, so "external"
+  // shifts 2 → 1. data-tab-index is the roster index the bar rendered it at.
+  await expect(tabbar.locator('.af-tab[data-tab-index="1"] .af-tab-label')).toHaveText("external", {
+    timeout: 30_000,
+  });
 
   // The pane still shows the SAME tab, through the SAME iframe element.
   await expect(frame).toHaveCount(1);
@@ -1087,10 +1091,21 @@ test("tabs (#1855): switching away and back keeps activeTab on the visible pane 
 
   // A throwaway terminal tab on probe-web, so there is a tab to close later that is
   // NEITHER the agent tab nor the active one — closing it must not move the pane.
+  //
+  // Waited on BY NAME, never by a roster total (#1863). probe-web permanently carries the
+  // seeded URL-less tab (#1818), so its roster here is [Agent, external, nourl] and the
+  // old "3 tabs" wait was ALREADY satisfied before the + click even landed — it passed
+  // instantly against the pre-create roster and let the test race ahead of the
+  // precondition it was there to establish. The tab's own name can't be true early, and
+  // it stays true across the session.updated rebuild the create publishes (#1812).
   await row(page, SESSION_WEB).click();
   await expect(page.locator(".af-main.af-main-term")).toBeVisible();
   await tabbar.locator(".af-tab-new").click();
-  await expect(tabbar.locator(".af-tab")).toHaveCount(3, { timeout: 30_000 });
+  const throwaway = tabbar.locator(".af-tab", { hasText: "Terminal" });
+  await expect(throwaway).toHaveCount(1, { timeout: 30_000 });
+  // The create attaches the new tab, so the pane is on it — which is what makes the
+  // "external" click below the real index change this test needs going in.
+  await expect(throwaway).toHaveClass(/af-tab-active/, { timeout: 30_000 });
 
   // Park probe-web on "external" (index 1) — an index change, so the store is truthful
   // going in.
@@ -1115,8 +1130,12 @@ test("tabs (#1855): switching away and back keeps activeTab on the visible pane 
   // Closing an UNRELATED tab (the throwaway, to the RIGHT of the active one) leaves the
   // pane where it was. With a stale activeTab the close arithmetic read 0 and re-pointed
   // the pane at Agent, tearing down the live iframe.
-  await tabbar.locator(".af-tab", { hasText: "Terminal" }).locator(".af-tab-close").click();
-  await expect(tabbar.locator(".af-tab")).toHaveCount(2, { timeout: 30_000 });
+  // (The bar always renders the SELECTED session, and probe-web is selected here, so
+  // `throwaway` resolves against probe-web's Terminal — not the one probe-b grew above.)
+  await throwaway.locator(".af-tab-close").click();
+  // Again by name (#1863): the disappearance of THIS tab is the event being waited on,
+  // and the seeded nourl tab means the surviving total is 3, not 2.
+  await expect(throwaway).toHaveCount(0, { timeout: 30_000 });
   await expect(page.locator(".af-tab.af-tab-active .af-tab-label")).toHaveText("external");
   await expect(frame).toHaveCount(1);
 


### PR DESCRIPTION
## Summary

`master`'s web-selftest is **red** — a semantic conflict between two individually-green merges, not a bug in either feature.

- **#1815** made the seeded `nourl` web tab a **permanent** member of `probe-web`'s roster, and republishes the roster on every tab mutation (#1812).
- **#1862**'s #1855 test counts `probe-web`'s tabs as **absolute totals**.

Neither is wrong on its own. The totals are.

Fixes #1863.

## The failure

`probe-web`'s roster entering the #1855 test is `[Agent, external, nourl]` — 3 tabs, because #1779 above it consumes `preview`. So:

| assertion | intent | what actually happened |
|---|---|---|
| pre-create `toHaveCount(3)` | wait for the new tab | **already true before the `+` click landed** — passed instantly against the pre-create roster and let the test race ahead of the precondition it existed to establish |
| post-close `toHaveCount(2)` | the throwaway is gone | saw the surviving **3** and failed — the red on master |

The second one is the reported symptom; the first is the quieter problem, and it's why the count "moves as the event lands."

## The fix — the test, not either feature

Neither #1815's seeding nor #1862's behavior is touched. This is a **test-only** diff. Every `probe-web` tab assertion now names the tab it actually cares about:

- **#1855**: wait for the throwaway `Terminal` tab **by name** on create, and on its disappearance after the close. A name can't be satisfied early by the pre-create roster, and Playwright's auto-retry rides out the `session.updated` rebuild — **no sleeps**. Also asserts the new tab takes focus, making the "real index change" precondition explicit rather than assumed.
- **#1779**: assert the shift **directly** — "external now sits at ordinal 1", via the `data-tab-index` the bar already stamps — instead of inferring it from a roster size. Strictly stronger than the old count: it names the 2 → 1 shift the test turns on.

## Sweep

Grepped the spec for other absolute tab-count totals on `probe-web`: **#1779 and #1855 were the only two.** The remaining `.af-tab` totals are on `probe-a` / `probe-b`, whose rosters the permanent fixture never touches — those are stable invariants and are left alone.

## Verified NOT declawed

The real risk in "fix the red test" is relaxing it into vacuity. So I checked the other direction: with **#1862's source fix reverted** (`web/src/index.ts`, `web/src/split.ts` back to `62721fc^`, bundle rebuilt) and the **hardened test in place**, the #1855 test **still fails** — and on the right assertion:

```
Locator:  locator('.af-tab.af-tab-active .af-tab-label')
Expected: "external"
Received: "Agent"
```

That's the #1855 desync itself. It remains a real regression test. (Serial mode aborts at the first failure, so this needed a temporary non-serial run to reach test 24 — reverted, the spec ships `mode: "serial"` unchanged.)

## Gates

- `make web-selftest-container` — **38/38 green, rc=0** (including the #1855 test and #1815's out-of-band #1812 test)
- `make web-test` — 147/147
- `go build ./...`, `gofmt -l .`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh` — all clean

No Go source is touched by this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)