### PR TITLE
fix(webtab): rewrite upstream redirect Location into the tab prefix (#1843)

### DIFF
--- a/daemon/webtab_proxy.go
+++ b/daemon/webtab_proxy.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -224,6 +225,11 @@ func (cs *controlServer) webTabProxyHandler(w http.ResponseWriter, r *http.Reque
 			// host) so the cookie lands on the right path and coexists with the
 			// daemon's token cookie.
 			rewriteSetCookiePaths(resp.Header, tabPathPrefix)
+			// Send the app's own redirects back through the prefix rather than out
+			// to the daemon's origin, which is where a bare "/login" would otherwise
+			// land (#1843).
+			rewriteRedirectLocation(resp, tabPathPrefix, targetURL)
+			rewriteRefreshURL(resp.Header, tabPathPrefix, targetURL)
 			return nil
 		},
 		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, err error) {
@@ -290,6 +296,162 @@ func rewriteSetCookiePaths(h http.Header, prefix string) {
 	for _, v := range rewritten {
 		h.Add("Set-Cookie", v)
 	}
+}
+
+// rewriteRedirectLocation sends an upstream redirect back through this tab's
+// proxy prefix, so the browser follows it to the proxied app rather than to the
+// daemon's own origin (#1843). A dev app that 302s to "/login" would otherwise
+// navigate the iframe to the daemon's /login — a 404 — breaking every login and
+// post-action redirect flow, which is the primary reason the proxy exists.
+//
+// Only 3xx Location is rewritten. On a redirect the header is NAVIGATIONAL: the
+// browser follows it, so it must name a browser-reachable path. On a 2xx (201
+// Created, say) it instead IDENTIFIES a resource — the app's own JS may compare it
+// against a canonical id it already holds, and prefixing it would corrupt that
+// comparison for no navigational gain.
+func rewriteRedirectLocation(resp *http.Response, prefix string, target *url.URL) {
+	if resp.StatusCode < 300 || resp.StatusCode >= 400 {
+		return
+	}
+	loc := resp.Header.Get("Location")
+	if loc == "" { // 304, or a 3xx that carries none
+		return
+	}
+	if dest, ok := rewriteUpstreamRef(loc, prefix, target); ok {
+		resp.Header.Set("Location", dest)
+	}
+}
+
+// rewriteRefreshURL rewrites the url= of a Refresh header ("5; url=/login"), which
+// some dev apps and frameworks use as a delayed redirect. It escapes the prefix
+// exactly the way a Location does, and it is the same rewrite, so it is fixed
+// alongside. Refresh is not status-gated: it is a meta-refresh equivalent and
+// normally rides a 200.
+//
+// A Refresh without a url= re-fetches the current URL, which is already correct
+// under the prefix, so it is left alone.
+func rewriteRefreshURL(h http.Header, prefix string, target *url.URL) {
+	v := h.Get("Refresh")
+	if v == "" {
+		return
+	}
+	delay, rest, ok := strings.Cut(v, ";")
+	if !ok {
+		return
+	}
+	const urlKey = "url="
+	trimmed := strings.TrimSpace(rest)
+	if len(trimmed) < len(urlKey) || !strings.EqualFold(trimmed[:len(urlKey)], urlKey) {
+		return
+	}
+	raw := strings.TrimSpace(trimmed[len(urlKey):])
+	// The value may be quoted; keep whichever quoting the app chose.
+	quote := ""
+	if len(raw) >= 2 && (raw[0] == '"' || raw[0] == '\'') && raw[len(raw)-1] == raw[0] {
+		quote = string(raw[0])
+		raw = raw[1 : len(raw)-1]
+	}
+	dest, ok := rewriteUpstreamRef(raw, prefix, target)
+	if !ok {
+		return
+	}
+	h.Set("Refresh", strings.TrimSpace(delay)+"; url="+quote+dest+quote)
+}
+
+// rewriteUpstreamRef maps a URL reference the upstream app emitted into this tab's
+// proxy prefix, reporting false when the reference must be passed through
+// untouched. It is the shared rule behind Location and Refresh.
+//
+// Because the browser path MIRRORS the upstream path, the mapping is the same pure
+// prefix-prepend that re-scopes cookies:
+//
+//	/app/                      -> /v1/webtab/s/t/app/          (absolute path: prepend)
+//	http://localhost:3000/app/ -> /v1/webtab/s/t/app/          (same upstream: strip origin, keep path)
+//	app/x                      -> unchanged                    (relative: already at mirrored depth)
+//	https://example.com/x      -> unchanged                    (foreign host)
+//
+// A RELATIVE reference needs no help: the browser resolves it against the current
+// proxied URL, which sits at the same depth as the upstream one, so it lands on the
+// right path by construction — the same property that makes relative sub-resource
+// links work.
+//
+// A FOREIGN host is passed through verbatim: it is a real off-site redirect (an
+// OAuth provider, say) that must leave the frame. Rewriting it would both point the
+// browser at a prefix the daemon would then refuse to proxy (only loopback targets
+// are proxied) and silently rehost someone else's origin under ours.
+//
+// The path is carried VERBATIM, in the upstream's own encoding: Path and RawPath are
+// prefixed together so url.String() reproduces the app's escaping rather than
+// re-canonicalizing it (a literal %2F in a redirect target stays %2F).
+func rewriteUpstreamRef(ref, prefix string, target *url.URL) (string, bool) {
+	u, err := url.Parse(strings.TrimSpace(ref))
+	if err != nil {
+		return "", false // unparseable: pass through rather than mangle
+	}
+	switch {
+	case u.Scheme != "" || u.Host != "":
+		// Absolute, or protocol-relative (//host/path). Ours to rewrite only if it
+		// names the very server we proxy; anything else (including mailto:/data:,
+		// which carry no host) leaves untouched.
+		if !sameUpstreamHost(u, target) {
+			return "", false
+		}
+		u.Scheme, u.Host, u.User = "", "", nil
+	case !strings.HasPrefix(u.Path, "/"):
+		return "", false // relative — already mirrored
+	}
+	if u.Path == "" { // origin-only, e.g. http://localhost:3000?x=1
+		u.Path = "/"
+	}
+	escaped := u.EscapedPath()
+	u.Path = joinURLPath(prefix, u.Path)
+	u.RawPath = joinURLPath(prefix, escaped)
+	return u.String(), true // query and fragment ride along untouched
+}
+
+// sameUpstreamHost reports whether ref names the same origin as the tab's proxied
+// target, and so is a self-redirect the proxy should keep inside its prefix.
+//
+// Loopback ALIASES are deliberately not treated as equal: a target of
+// localhost:3000 and a redirect to 127.0.0.1:3000 are the same server in almost
+// every setup, but "almost" is what #1810 already paid for here. Binding a frame to
+// a server it never named is the failure this file exists to prevent, so an alias
+// mismatch degrades to an honest un-rewritten redirect instead. The realistic case
+// costs nothing: the Rewrite hook sends the upstream its own Host, so a
+// self-redirect echoes the target's host string verbatim.
+//
+// Scheme must match too. An http->https self-redirect is the app upgrading an origin
+// the proxy does not speak; rewriting it would strip the upgrade and hand the
+// request straight back to the http upstream, which would redirect again — an
+// infinite loop in the frame rather than a visible failure.
+func sameUpstreamHost(ref, target *url.URL) bool {
+	if ref.Host == "" {
+		return false
+	}
+	scheme := ref.Scheme
+	if scheme == "" {
+		scheme = target.Scheme // protocol-relative inherits the upstream hop's scheme
+	}
+	if !strings.EqualFold(scheme, target.Scheme) {
+		return false
+	}
+	return normalizedHostPort(ref.Host, scheme) == normalizedHostPort(target.Host, target.Scheme)
+}
+
+// normalizedHostPort renders host:port lowercased with the scheme's default port
+// made explicit, so "localhost" and "localhost:80" compare equal under http.
+func normalizedHostPort(host, scheme string) string {
+	h := strings.ToLower(host)
+	if _, _, err := net.SplitHostPort(h); err == nil {
+		return h // already carries a port ("[::1]:3000" included)
+	}
+	switch strings.ToLower(scheme) {
+	case "http":
+		return h + ":80"
+	case "https":
+		return h + ":443"
+	}
+	return h
 }
 
 // stripFrameAncestors removes the frame-ancestors directive from any

--- a/daemon/webtab_proxy_test.go
+++ b/daemon/webtab_proxy_test.go
@@ -699,6 +699,176 @@ func TestWebTabProxy_StripsFramingHeaders(t *testing.T) {
 	}
 }
 
+// redirectingUpstream serves a redirect to loc with the given status on every
+// request, for the Location-rewrite tests (#1843).
+func redirectingUpstream(t *testing.T, status int, loc string) *httptest.Server {
+	t.Helper()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", loc)
+		w.WriteHeader(status)
+	}))
+	t.Cleanup(upstream.Close)
+	return upstream
+}
+
+// TestWebTabProxy_RedirectLocationStaysInPrefix is the #1843 repro: a dev app that
+// 302s to an absolute path (the shape every login flow uses) must land back inside
+// the tab prefix. Un-rewritten, the browser follows "/login" to the daemon's own
+// origin and 404s.
+func TestWebTabProxy_RedirectLocationStaysInPrefix(t *testing.T) {
+	upstream := redirectingUpstream(t, http.StatusFound, "/app/")
+	mux, id, tabID := newWebTabProxyFixture(t, upstream.URL)
+
+	rec := proxyGet(t, mux, id, tabID, "some/path")
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want 302", rec.Code)
+	}
+	want := fmt.Sprintf("/v1/webtab/%s/%s/app/", id, tabID)
+	if got := rec.Header().Get("Location"); got != want {
+		t.Fatalf("Location = %q, want %q (the redirect escaped the tab prefix)", got, want)
+	}
+}
+
+// TestWebTabProxy_AbsoluteSelfRedirectRewritten covers the app redirecting to its
+// OWN absolute URL — equally common, and equally unreachable for a remote viewer,
+// since the upstream origin is loopback on the daemon's machine. The path is kept
+// verbatim (mirror-path model) and the query rides along.
+func TestWebTabProxy_AbsoluteSelfRedirectRewritten(t *testing.T) {
+	// selfURL is read only from inside the handler, which cannot run until the
+	// server is up and the assignment below has happened.
+	var selfURL string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", selfURL+"/dash/?tab=1")
+		w.WriteHeader(http.StatusMovedPermanently)
+	}))
+	defer upstream.Close()
+	selfURL = upstream.URL
+	mux, id, tabID := newWebTabProxyFixture(t, upstream.URL)
+
+	rec := proxyGet(t, mux, id, tabID, "x")
+
+	if rec.Code != http.StatusMovedPermanently {
+		t.Fatalf("status = %d, want 301", rec.Code)
+	}
+	want := fmt.Sprintf("/v1/webtab/%s/%s/dash/?tab=1", id, tabID)
+	if got := rec.Header().Get("Location"); got != want {
+		t.Fatalf("Location = %q, want %q (absolute self-redirect must be re-pathed into the prefix)", got, want)
+	}
+}
+
+// TestWebTabProxy_ForeignRedirectPassesThrough is the other half of the rule: an
+// off-site redirect (an OAuth provider, say) is a REAL navigation away from the
+// frame. Rewriting it would point the browser at a prefix the daemon then refuses
+// to proxy — only loopback targets are proxied — and rehost a foreign origin under
+// ours.
+func TestWebTabProxy_ForeignRedirectPassesThrough(t *testing.T) {
+	const foreign = "https://accounts.example.com/oauth?client_id=abc"
+	upstream := redirectingUpstream(t, http.StatusFound, foreign)
+	mux, id, tabID := newWebTabProxyFixture(t, upstream.URL)
+
+	rec := proxyGet(t, mux, id, tabID, "login")
+
+	if got := rec.Header().Get("Location"); got != foreign {
+		t.Fatalf("Location = %q, want %q untouched", got, foreign)
+	}
+}
+
+// TestWebTabProxy_RefreshHeaderRewritten covers the delayed-redirect spelling of the
+// same escape.
+func TestWebTabProxy_RefreshHeaderRewritten(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Refresh", "5; url=/app/done")
+		fmt.Fprint(w, "ok")
+	}))
+	defer upstream.Close()
+	mux, id, tabID := newWebTabProxyFixture(t, upstream.URL)
+
+	rec := proxyGet(t, mux, id, tabID, "start")
+
+	want := fmt.Sprintf("5; url=/v1/webtab/%s/%s/app/done", id, tabID)
+	if got := rec.Header().Get("Refresh"); got != want {
+		t.Fatalf("Refresh = %q, want %q", got, want)
+	}
+}
+
+// TestWebTabProxy_NonRedirectLocationUntouched pins the status gate: a 2xx Location
+// IDENTIFIES a resource rather than naming somewhere to navigate, so prefixing it
+// would corrupt an id the app's own JS may compare against.
+func TestWebTabProxy_NonRedirectLocationUntouched(t *testing.T) {
+	upstream := redirectingUpstream(t, http.StatusCreated, "/api/items/5")
+	mux, id, tabID := newWebTabProxyFixture(t, upstream.URL)
+
+	rec := proxyGet(t, mux, id, tabID, "api/items")
+
+	if got := rec.Header().Get("Location"); got != "/api/items/5" {
+		t.Fatalf("Location = %q, want %q untouched on a 201", got, "/api/items/5")
+	}
+}
+
+// TestRewriteUpstreamRef pins the rewrite rule itself — the cases the proxy tests
+// above can only reach one at a time.
+func TestRewriteUpstreamRef(t *testing.T) {
+	const prefix = "/v1/webtab/sess/tab-1"
+	const dflt = "http://localhost:3000"
+	cases := []struct {
+		name   string
+		target string // upstream the tab proxies; defaults to dflt
+		ref    string
+		want   string // "" means: passed through untouched
+	}{
+		{name: "absolute path", ref: "/login", want: prefix + "/login"},
+		{name: "absolute path with query and fragment", ref: "/a?b=c#d", want: prefix + "/a?b=c#d"},
+		{name: "root", ref: "/", want: prefix + "/"},
+		{name: "same origin", ref: "http://localhost:3000/app/", want: prefix + "/app/"},
+		{name: "same origin, origin only", ref: "http://localhost:3000?x=1", want: prefix + "/?x=1"},
+		{name: "same origin, host case-insensitive", ref: "http://LOCALHOST:3000/x", want: prefix + "/x"},
+		{name: "protocol relative, same host", ref: "//localhost:3000/x", want: prefix + "/x"},
+		{name: "encoded path kept verbatim", ref: "/a%2Fb", want: prefix + "/a%2Fb"},
+		// The default port is implicit on one side and explicit on the other; they
+		// name the same server either way.
+		{name: "default port explicit matches implicit target",
+			target: "http://localhost", ref: "http://localhost:80/x", want: prefix + "/x"},
+		{name: "implicit ref port matches explicit default target",
+			target: "http://localhost:80", ref: "http://localhost/x", want: prefix + "/x"},
+		{name: "ipv6 loopback same origin",
+			target: "http://[::1]:3000", ref: "http://[::1]:3000/x", want: prefix + "/x"},
+		{name: "relative stays relative", ref: "next/page"},
+		{name: "dot relative stays relative", ref: "../up"},
+		{name: "foreign host", ref: "https://example.com/x"},
+		{name: "loopback alias is not the same host", ref: "http://127.0.0.1:3000/x"},
+		{name: "different port", ref: "http://localhost:3001/x"},
+		{name: "scheme upgrade is not ours", ref: "https://localhost:3000/x"},
+		{name: "mailto", ref: "mailto:dev@example.com"},
+		{name: "empty", ref: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw := tc.target
+			if raw == "" {
+				raw = dflt
+			}
+			target, err := url.Parse(raw)
+			if err != nil {
+				t.Fatalf("parse target %q: %v", raw, err)
+			}
+			got, ok := rewriteUpstreamRef(tc.ref, prefix, target)
+			if tc.want == "" {
+				if ok {
+					t.Fatalf("rewriteUpstreamRef(%q) = %q, true; want pass-through", tc.ref, got)
+				}
+				return
+			}
+			if !ok {
+				t.Fatalf("rewriteUpstreamRef(%q) = _, false; want %q", tc.ref, tc.want)
+			}
+			if got != tc.want {
+				t.Fatalf("rewriteUpstreamRef(%q) = %q, want %q", tc.ref, got, tc.want)
+			}
+		})
+	}
+}
+
 // cookieNamed returns the named cookie from a recorded response, or nil.
 func cookieNamed(rec *httptest.ResponseRecorder, name string) *http.Cookie {
 	for _, c := range rec.Result().Cookies() {


### PR DESCRIPTION
Fixes #1843. Small additive follow-up on the just-merged #1858 mirror-path proxy.

## The bug

`ModifyResponse` rewrote `Set-Cookie` paths but passed upstream redirects through untouched. A dev app that `302`s to `/login` sent the iframe to the **daemon's** `/login` — a 404 — because the browser resolves an absolute-path `Location` against the daemon origin, not the proxied prefix. That breaks every login and post-action redirect flow for remote viewers, which is the primary case the proxy exists for.

## The fix

Rewrite `Location` on 3xx (and the `url=` of a `Refresh`, the delayed-redirect spelling of the same escape) using the mirror-path model #1858 established. Because the browser path mirrors the upstream path, the mapping is the same pure prefix-prepend that already re-scopes cookies:

| Upstream emits | Browser gets |
|---|---|
| `/app/` (absolute path) | `/v1/webtab/<sid>/<t>/app/` |
| `http://localhost:3000/app/` (same upstream) | `/v1/webtab/<sid>/<t>/app/` |
| `app/x` (relative) | unchanged — already at mirrored depth |
| `https://example.com/x` (foreign) | unchanged — a real off-site nav |

Query and fragment ride along, and the path is carried verbatim in the upstream's own encoding (`Path` and `RawPath` are prefixed together, so a literal `%2F` stays `%2F`).

Additive by construction: the rewrite only fires where the response previously escaped the prefix.

## Design calls

Three deliberately conservative boundaries, each documented at its function:

- **Loopback aliases are not same-origin.** `localhost:3000` and `127.0.0.1:3000` are the same server in almost every setup, but "almost" is what #1810 already paid for in this file. An alias mismatch degrades to an honest un-rewritten redirect rather than binding a frame to a server it never named. Realistically free: the `Rewrite` hook sends the upstream its own `Host`, so a self-redirect echoes the target's host verbatim.
- **Scheme upgrades pass through.** Rewriting an http→https self-redirect would strip the upgrade and hand the request back to the http upstream, which would redirect again — an infinite loop in the frame rather than a visible failure.
- **2xx `Location` is left alone.** On a redirect the header is navigational; on a `201 Created` it identifies a resource the app's own JS may compare against, so prefixing it would corrupt that for no navigational gain. `Refresh` is not status-gated — it's a meta-refresh equivalent that normally rides a 200.

Default port normalization means `localhost` and `localhost:80` compare equal under http.

## Tests

The issue's three required cases, plus the pass-through cases that keep the rewrite from over-reaching:

- `RedirectLocationStaysInPrefix` — the #1843 repro: 302 → `/app/` lands at `/v1/webtab/<sid>/<id>/app/`
- `AbsoluteSelfRedirectRewritten` — absolute same-host URL re-pathed, query preserved
- `ForeignRedirectPassesThrough` — foreign host untouched
- `RefreshHeaderRewritten`, `NonRedirectLocationUntouched`
- `TestRewriteUpstreamRef` — 19 table cases pinning the rule (encoding, protocol-relative, IPv6, aliases, ports, `mailto:`, relative refs)

**Verified the repro is real:** with the two `ModifyResponse` calls disabled, the three rewrite tests fail (`Location = "/app/"` vs the prefixed path) and pass with the fix. The two pass-through tests correctly hold either way, since they assert *non*-rewriting.

## Gates

All green: `make test-container` (29 pkgs ok, 0 FAIL — `daemon` included), `make web-selftest-container` (42/42), `make tui-driver-selftest` (38/38), `go build ./...`, `gofmt -l .`, `golangci-lint --fast`, `deadcode -test ./...`, `lint-file-length.sh`.

Single `httputil.ReverseProxy` call-site in the repo, so there's no adjacent site carrying the same anti-pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)