### PR TITLE
fix(tui): task editor goes full-screen instead of shredding the rail at 60x20 (#1821)

### DIFF
--- a/app/render.go
+++ b/app/render.go
@@ -126,13 +126,75 @@ func (m *home) tasksOverlayContentRect() layout.Rect {
 	return m.modalContentRect(hooksOverlayStyle, m.preferredOverlayWidth(52), m.preferredOverlayHeight())
 }
 
+// modalContentRect sizes a pane-hosted modal — the tasks manager and the hooks
+// editor, the two overlays that frame an existing pane instead of being a
+// ui/overlay type.
+//
+// Presentation is deliberately two-mode (#1821):
+//
+//   - Beside the rail (default): the modal keeps its preferred size and
+//     PlaceOverlay centers it over the frame, exactly like every other modal.
+//   - Full-screen: when the modal can no longer fit beside the rail, it takes
+//     the whole terminal instead.
+//
+// The width floor is what forces the switch. preferredOverlayWidth never
+// yields below its minimum, because a task form narrower than that stops being
+// usable — but that floor ignores the terminal, so on a narrow one the box
+// ends up wider than the workspace, the centered modal lands ON the rail, and
+// the only rail left showing is an unreadable sliver down the side. At 60x20 a
+// 54-column box centers at x=3 over a 22-column rail: 19 of its 22 columns are
+// painted over and the survivors are stubs like `▸`, `Au`, `Pr` (#1821).
+// Full-screen is the deliberate presentation the issue asks for instead — the
+// rail is covered cleanly and completely, no fragments, and the form gets
+// every column the terminal has.
+//
+// Rail-AWARE placement (keeping the modal strictly right of the rail at every
+// size) is deliberately NOT what this does. No overlay here is rail-aware:
+// PlaceOverlay centers over the whole frame, so every modal overlaps the rail
+// once it is wide enough — the narrow ones just don't get wide enough to show
+// it. Making this one modal dodge the rail would single it out for no gain the
+// issue asked for.
 func (m *home) modalContentRect(style lipgloss.Style, preferredW, preferredH int) layout.Rect {
+	if m.modalGoesFullScreen(style, preferredW) {
+		// A non-positive preferred dimension means "use all available space",
+		// so the frame lands on exactly termWidth x termHeight.
+		preferredW, preferredH = 0, 0
+	}
 	return layout.FitContentRect(
 		layout.Rect{W: preferredW, H: preferredH},
 		layout.Rect{W: m.termWidth, H: m.termHeight},
 		style.GetHorizontalBorderSize(),
 		style.GetVerticalBorderSize(),
 	)
+}
+
+// modalGoesFullScreen reports whether the terminal is too narrow for this modal
+// and the rail to COEXIST: whether the modal's floored outer box (content +
+// border) still fits in the workspace the rail leaves behind.
+//
+// This is a narrowness test, not a placement promise. Placement stays centered
+// over the whole frame — a modal that passes this test is NOT moved to sit
+// beside the rail, and at mid widths it still clips the rail's right edge
+// exactly as every other modal does. What the test buys is the point where that
+// stops being a clipped rail and becomes a useless sliver: once the box cannot
+// fit in the workspace at all, centering it can only ever leave fragments, so
+// the modal takes the whole terminal instead.
+//
+// It reads the workspace from the solved layout rather than recomputing
+// termWidth - railWidth, so the rail's own sizing rule (clamped 25%, see
+// Grid.Solve) stays in exactly one place. relayout assigns m.lastLayout before
+// it sizes the overlays, and returns early in Fallback mode (where View()
+// renders the too-small banner and no overlay at all), so the workspace here is
+// always the live one.
+func (m *home) modalGoesFullScreen(style lipgloss.Style, preferredW int) bool {
+	if m.termWidth <= 0 || m.termHeight <= 0 {
+		return false
+	}
+	workspaceW := m.lastLayout.Workspace.W
+	if workspaceW <= 0 {
+		return false
+	}
+	return preferredW+style.GetHorizontalBorderSize() > workspaceW
 }
 
 func (m *home) preferredOverlayWidth(minWidth int) int {

--- a/app/tinyclip_overlay_test.go
+++ b/app/tinyclip_overlay_test.go
@@ -2,12 +2,14 @@ package app
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
 	xansi "github.com/charmbracelet/x/ansi"
 	"github.com/sachiniyer/agent-factory/task"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTinyClipConfirmationOverlaysFit(t *testing.T) {
@@ -96,5 +98,98 @@ func TestTinyClipTasksOverlayFits(t *testing.T) {
 	plain := xansi.Strip(view)
 	assert.Contains(t, plain, "tiny-task")
 	assert.Contains(t, plain, "esc cancel")
-	assert.Contains(t, plain, "↑ more")
+	// The form still WINDOWS and still flags the fields it is hiding — the
+	// #1431 property this test pins. The marker is `↓ more` rather than the
+	// `↑ more` this asserted before #1821: at 40x10 the overlay is now
+	// full-screen, so the form has the terminal's whole height instead of 60%
+	// of it, and the top of the form (New Task / Essentials / the focused Name
+	// field) now fits without scrolling off the top. Strictly more of the form
+	// is visible; the hidden remainder moved below the window, so the marker
+	// moved with it. `↑`/`↓` marker semantics are pinned directly, and
+	// independently of the overlay's geometry, in ui/task_pane_test.go.
+	assert.Contains(t, plain, "↓ more")
+}
+
+// railFragments are strings only the rail ever renders — its title chip, its
+// section headers, and an instance row's title. None of them appear in the task
+// overlay's own chrome, so finding one in a full-screen frame means the rail
+// bled through.
+var railFragments = []string{"Agent Factory", "Instances", "Automations", "Projects", "rail-inst"}
+
+// TestTasksOverlayNarrowIsFullScreenWithoutRailBleed is the #1821 regression.
+//
+// The task editor's width floor (52) ignores the terminal, so on a narrow one
+// the box came out wider than the workspace and the CENTERED modal landed on
+// top of the rail — at 60x20, a 54-column box centered at x=3 over a 22-column
+// rail painted over 19 of its 22 columns and left `▸`, `Au`, `Pr` stubs down
+// the side, with the frame drawn straight through them.
+//
+// Narrow geometry now switches to the deliberate full-screen presentation
+// (#1821's own suggestion): the modal takes the whole terminal, so the rail is
+// covered cleanly and completely instead of being shredded into fragments.
+//
+// 60x20 is the reported size; 40x12 is the floor — minimal mode (< MinimalWidth
+// 60) but still above the HardMin 40x10 fallback banner, so a real overlay is
+// composed at both.
+func TestTasksOverlayNarrowIsFullScreenWithoutRailBleed(t *testing.T) {
+	for _, size := range [][2]int{{60, 20}, {40, 12}} {
+		t.Run(fmt.Sprintf("%dx%d", size[0], size[1]), func(t *testing.T) {
+			w, hgt := size[0], size[1]
+			h := newTestHome(t)
+			h.store.SetTasks([]task.Task{})
+			addTreeInstance(t, h, "rail-inst")
+			resizeHome(h, w, hgt)
+
+			_, _ = h.showTasksOverlay()
+
+			view := h.View()
+			// No clipping: the composed frame is still exactly the terminal.
+			requireViewSized(t, view, w, hgt)
+			plain := xansi.Strip(view)
+
+			// No overlap: nothing of the rail survives to bleed into the editor.
+			for _, frag := range railFragments {
+				assert.NotContainsf(t, plain, frag,
+					"rail fragment %q bled into the full-screen task overlay at %dx%d", frag, w, hgt)
+			}
+
+			// The overlay owns every row edge-to-edge — this is what rules out
+			// the stub sliver, which requireViewSized alone cannot see.
+			for i, line := range strings.Split(plain, "\n") {
+				require.Truef(t, strings.HasPrefix(line, "╭") || strings.HasPrefix(line, "│") ||
+					strings.HasPrefix(line, "╰"),
+					"row %d must start at the overlay's own left border, got %q", i, line)
+				require.Truef(t, strings.HasSuffix(line, "╮") || strings.HasSuffix(line, "│") ||
+					strings.HasSuffix(line, "╯"),
+					"row %d must end at the overlay's own right border, got %q", i, line)
+			}
+
+			// …and it is still legible, not merely bounded.
+			assert.Contains(t, plain, "Tasks")
+			assert.Contains(t, plain, "r run now")
+		})
+	}
+}
+
+// TestTasksOverlayWideKeepsRailAndCenteredModal pins the OTHER side of the
+// #1821 switch: full-screen is for narrow terminals only. At a roomy size the
+// modal must still be the centered box it has always been, with the rail beside
+// it — so the fix cannot quietly turn every task overlay full-screen.
+func TestTasksOverlayWideKeepsRailAndCenteredModal(t *testing.T) {
+	h := newTestHome(t)
+	h.store.SetTasks([]task.Task{})
+	addTreeInstance(t, h, "rail-inst")
+	resizeHome(h, 100, 30)
+
+	_, _ = h.showTasksOverlay()
+
+	assert.False(t, h.modalGoesFullScreen(hooksOverlayStyle, h.preferredOverlayWidth(52)),
+		"a 100x30 terminal has room for the modal beside the rail; it must not go full-screen")
+
+	view := h.View()
+	requireViewSized(t, view, 100, 30)
+	plain := xansi.Strip(view)
+	assert.Contains(t, plain, "Agent Factory", "the rail must still render beside a centered modal")
+	assert.Contains(t, plain, "rail-inst", "the rail's instance row must still render")
+	assert.Contains(t, plain, "Tasks")
 }


### PR DESCRIPTION
Fixes #1821.

## The bug

At 60x20 the task editor drew straight through the left rail, leaving it as unreadable stubs down the side — the issue's capture, reproduced exactly in a test:

```text
                      ╭────────────────────────────────────╮
 Agent Factory        │                                    │
 ▼ Instances (1)      │                                    │
   ╭────────────────────────────────────────────────────╮  │
  ▸│                                                    │  │
   │  Tasks                                             │  │
   │    No tasks. Press n to create one.                │  │
   │                                                    │e…│
───│                                                    │  │
 Au│                                                    │  │
 Pr╰────────────────────────────────────────────────────╯  │
```

`preferredOverlayWidth` floors the task editor at **52 columns**, because a form narrower than that stops being usable — but the floor ignores the terminal. `modalContentRect` only ever clamped to `termWidth`, so at 60 columns:

| | |
|---|---|
| preferred width | `max(int(60*0.6)=36, 52)` = **52** |
| outer box | 52 + 2 border = **54** |
| fits in 60? | yes — so nothing clamped |
| `PlaceOverlay` centers at | `(60-54)/2` = **x=3** |
| rail width | `clamp(60*25/100, 22, 36)` = **22** |

The box spans columns 3–56, so **19 of the rail's 22 columns are painted over** and the survivors are the 3-column stubs `▸`, `Au`, `Pr`, with the editor's frame drawn through them.

## The fix

Narrow geometry switches to the **deliberate full-screen presentation** the issue itself suggests ("or switch to a deliberate compact/full-screen presentation"). When the modal's floored box can no longer fit in the workspace the rail leaves behind, it takes the whole terminal:

```text
╭──────────────────────────────────────────────────────────╮
│                                                          │
│  Edit Task f63cd367                                      │
│                                                          │
│  Essentials                                              │
│  Name:    > flow-task                                 …  │
│  Trigger: ▸ cron    watch                                │
│  Cron:    > 0 3 * * *                                 …  │
│  Prompt:                                                 │
│  selftest prompt                                         │
│                                                          │
│  Delivery                                                │
│  Target:  > (new session per run)                     …  │
│    ↓ more                                                │
│  r run now • x toggle • D delete • esc list • q quit     │
╰──────────────────────────────────────────────────────────╯
```

*(captured from the real binary at 60x20 in the play-test sandbox — not a mock-up)*

The rail is covered cleanly and completely rather than shredded, and the form gets **every column the terminal has** (58 at 60x20, vs 52 before) instead of being squeezed.

### Why not make it rail-aware?

Confining the modal beside the rail was considered and rejected. **No overlay in this codebase is rail-aware**: `PlaceOverlay` centers over the whole frame, so *every* modal overlaps the rail once it's wide enough — the search/confirm/selection overlays just never get wide enough to show it. Singling this one out would diverge from every other modal, and at 40x12 the workspace is only **18 columns**, so it would need a full-screen fallback anyway.

**Wide terminals are untouched.** At 100x30 the modal is the same centered box beside the same rail it has always been — pinned by a test, so the fix can't quietly turn every task overlay full-screen.

### Adjacent call-site

The fix lands in the **shared `modalContentRect`**, so the hooks editor — the other pane-hosted modal, floored at 50 — is fixed by the same change rather than being left as the next report.

## Tests

`TestTasksOverlayNarrowIsFullScreenWithoutRailBleed` at **60x20** (the reported size) and **40x12** (minimal mode, above the 40x10 fallback banner) asserts:

1. the composed frame is exactly terminal-sized (no clipping),
2. every row starts *and* ends on the overlay's own border — this is what rules out the stub sliver, which `requireViewSized` alone cannot see,
3. no rail fragment survives, and
4. the overlay is still legible, not merely bounded.

**All of it fails against the old sizing** (verified by reverting the fix — the failure output is the capture above), so it's a real regression test. `TestTasksOverlayWideKeepsRailAndCenteredModal` pins the 100x30 side.

### One existing test changed

`TestTinyClipTasksOverlayFits` asserted `↑ more` at 40x10. The overlay now has the terminal's full height there, so the top of the form (New Task / Essentials / the focused Name field) fits without scrolling off and the marker moved to `↓ more`. Strictly *more* of the form is visible; the #1431 windowing property it pins is still asserted, and `↑`/`↓` marker semantics stay pinned independently of overlay geometry in `ui/task_pane_test.go`.

## Gates

- `make test-container` — **green**, 29 packages, 0 failures
- `make tui-driver-selftest` — **31/31 green** (its 5 task-overlay steps exercise this code)
- `go build ./...`, `gofmt -l .`, `golangci-lint run --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh` — all clean
- Real-binary visual check at 60x20 in the sandbox (capture above)
- Rebased onto current master (`1220cb2`) and re-verified after #1826's glyph/voice pass touched this test file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
