### PR TITLE
fix(config): serialize config.toml read-modify-write under the file lock (#1838)

### DIFF
--- a/config/config_save.go
+++ b/config/config_save.go
@@ -8,11 +8,86 @@ import (
 	"github.com/pelletier/go-toml/v2"
 )
 
-// saveConfig saves the configuration to disk as config.toml — the canonical
-// global config since #1030. It writes only the TOML file: writing config.json
-// would resurrect the "both files exist" shadow state that conversion exists
-// to retire.
-func saveConfig(config *Config) error {
+// globalConfigTomlPath returns the absolute path of the canonical global
+// config.toml (#1030). It is also the lock target every config.toml writer
+// shares, so they serialize against each other.
+func globalConfigTomlPath() (string, error) {
+	configDir, err := GetConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get config directory: %w", err)
+	}
+	return filepath.Join(configDir, TomlConfigFileName), nil
+}
+
+// withGlobalConfigLock runs fn holding the exclusive config.toml file lock —
+// the same lock SetGlobalConfigValue (`af config set`) takes — so a whole
+// load-modify-persist sequence over the global config is atomic against other
+// processes (#1838).
+//
+// The lock has to span the read as well as the write. AtomicWriteFile alone
+// makes each write all-or-nothing, but two racing read-modify-write sequences
+// still resolve to "last writer wins": both snapshot the file, both re-marshal
+// the entire Config, and the second rename silently drops the first writer's
+// changes. Locking only the write serializes the writes without making the
+// sequences atomic, so it does not fix that.
+//
+// LoadConfig runs BEFORE the lock is taken, deliberately: it is the call that
+// converts a legacy config.json and materializes first-run defaults, and those
+// paths take this very lock. WithFileLock is not reentrant — flock is tied to
+// the open file description, so a second acquisition from the same process
+// blocks forever instead of recursing — so fn must never call LoadConfig.
+// Re-read the config inside fn with loadConfigLocked instead.
+func withGlobalConfigLock(fn func() error) error {
+	// Force any conversion/materialization to happen outside the lock, and
+	// fail early on a config that does not load rather than under the lock.
+	if _, err := LoadConfig(); err != nil {
+		return err
+	}
+	tomlPath, err := globalConfigTomlPath()
+	if err != nil {
+		return err
+	}
+	return WithFileLock(tomlPath, fn)
+}
+
+// loadConfigLocked re-reads config.toml from inside the config file lock
+// without taking it, mirroring the raw read SetGlobalConfigValue does under the
+// same lock. Callers MUST already hold the lock (withGlobalConfigLock is the
+// only intended way in); the re-read is what lets a load-modify-persist
+// sequence see the writes that landed before it won the lock.
+//
+// withGlobalConfigLock's pre-lock LoadConfig has already converted/materialized
+// and validated the file, so a config.toml that is missing or contentless here
+// means it was removed in the window between the two — the same pathological
+// case LoadConfig answers with defaults, answered the same way.
+func loadConfigLocked() (*Config, error) {
+	tomlPath, err := globalConfigTomlPath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(tomlPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return DefaultConfig(), nil
+		}
+		return nil, fmt.Errorf("failed to read config file %s: %w", prettyHomePath(tomlPath), err)
+	}
+	if isEffectivelyEmptyToml(data) {
+		return DefaultConfig(), nil
+	}
+	return parseConfigTOML(data, prettyHomePath(tomlPath))
+}
+
+// saveConfigLocked saves the configuration to disk as config.toml WITHOUT
+// taking the config file lock. Callers must already hold it — use SaveConfig
+// for a standalone write, or withGlobalConfigLock when the write is the tail of
+// a read-modify-write sequence. Re-locking from the same process deadlocks
+// rather than recursing (see withGlobalConfigLock).
+//
+// It writes only the TOML file — the canonical global config since #1030:
+// writing config.json would resurrect the "both files exist" shadow state that
+// conversion exists to retire.
+func saveConfigLocked(config *Config) error {
 	configDir, err := GetConfigDir()
 	if err != nil {
 		return fmt.Errorf("failed to get config directory: %w", err)
@@ -32,7 +107,25 @@ func saveConfig(config *Config) error {
 	return AtomicWriteFile(tomlPath, data, 0644)
 }
 
-// SaveConfig exports the saveConfig function for use by other packages
+// SaveConfig persists the whole global config under the config file lock, so a
+// standalone write serializes against `af config set` and the root-agent
+// registration writes instead of racing them (#1838).
+//
+// This is a blind whole-file write: it clobbers whatever another writer changed
+// since the caller's snapshot. Only use it when the config being written is
+// authoritative (first-run seeding, tests). To change one part of an existing
+// config, do the read and the write inside a single withGlobalConfigLock body
+// so no concurrent change is lost — RegisterRootAgent is the model.
+//
+// Must NOT be called from inside a withGlobalConfigLock body: the lock is not
+// reentrant, so the nested acquisition would deadlock. Use saveConfigLocked
+// there.
 func SaveConfig(config *Config) error {
-	return saveConfig(config)
+	tomlPath, err := globalConfigTomlPath()
+	if err != nil {
+		return err
+	}
+	return WithFileLock(tomlPath, func() error {
+		return saveConfigLocked(config)
+	})
 }

--- a/config/rootagent_register.go
+++ b/config/rootagent_register.go
@@ -14,27 +14,51 @@ import "path/filepath"
 // key is the repo's absolute main-worktree root (callers resolve it via
 // RepoFromPath first), matching how EnsureRootAgents resolves the map keys.
 //
+// The whole sequence runs under the config file lock (#1838): the persist
+// re-marshals the entire Config, so reading outside the lock would let a
+// concurrent `af config set` land between this load and this write and be
+// silently reverted by our stale snapshot.
+//
 // Registering here does not itself spawn an always-on root agent: the daemon
 // reads root_agents at startup, so the always-ensure behavior only takes effect
 // on the next daemon start. Switching to the repo works immediately regardless,
 // because Snapshot/CreateSession resolve any repo path live.
 func RegisterRootAgent(repoRoot string) (bool, error) {
-	cfg, err := LoadConfig()
+	var added bool
+	err := withGlobalConfigLock(func() error {
+		cfg, err := loadConfigLocked()
+		if err != nil {
+			return err
+		}
+		if _, exists := cfg.RootAgents[repoRoot]; exists {
+			return nil
+		}
+		if cfg.RootAgents == nil {
+			cfg.RootAgents = map[string]RootAgentConfig{}
+		}
+		cfg.RootAgents[repoRoot] = RootAgentConfig{}
+		if rootAgentSaveRaceHookForTest != nil {
+			rootAgentSaveRaceHookForTest()
+		}
+		if err := saveConfigLocked(cfg); err != nil {
+			return err
+		}
+		added = true
+		return nil
+	})
 	if err != nil {
 		return false, err
 	}
-	if _, exists := cfg.RootAgents[repoRoot]; exists {
-		return false, nil
-	}
-	if cfg.RootAgents == nil {
-		cfg.RootAgents = map[string]RootAgentConfig{}
-	}
-	cfg.RootAgents[repoRoot] = RootAgentConfig{}
-	if err := SaveConfig(cfg); err != nil {
-		return false, err
-	}
-	return true, nil
+	return added, nil
 }
+
+// rootAgentSaveRaceHookForTest, when non-nil, runs inside the config file-lock
+// body of RegisterRootAgent, between the re-read and the persist — the window
+// in which an unlocked writer used to be able to land a whole-file write that
+// this function's stale snapshot then reverted (#1838). Tests use it to drive a
+// concurrent `af config set` into exactly that window and pin that the lock now
+// holds it off until the persist completes.
+var rootAgentSaveRaceHookForTest func()
 
 // DeregisterRootAgentsForRepo removes every root_agents opt-in that resolves to
 // repoID and persists the result, returning the config keys it removed. It is
@@ -50,24 +74,34 @@ func RegisterRootAgent(repoRoot string) (bool, error) {
 // cleaned path so a stale entry for a gone repo can still be swept. The write is
 // load-modify-persist over the whole global config (no other key clobbered) and
 // idempotent: no matching key is a clean no-op returning nil, nil.
+//
+// Like RegisterRootAgent, the whole sequence runs under the config file lock
+// (#1838) so a concurrent config writer cannot be reverted by our snapshot. The
+// key→repo resolution runs under the lock too: it decides which keys the write
+// drops, so resolving it against a pre-lock snapshot could drop an entry a
+// racing writer had just added.
 func DeregisterRootAgentsForRepo(repoID string) ([]string, error) {
-	cfg, err := LoadConfig()
-	if err != nil {
-		return nil, err
-	}
 	var removed []string
-	for key := range cfg.RootAgents {
-		if rootAgentKeyMatchesRepo(key, repoID) {
-			removed = append(removed, key)
+	err := withGlobalConfigLock(func() error {
+		cfg, err := loadConfigLocked()
+		if err != nil {
+			return err
 		}
-	}
-	if len(removed) == 0 {
-		return nil, nil
-	}
-	for _, key := range removed {
-		delete(cfg.RootAgents, key)
-	}
-	if err := SaveConfig(cfg); err != nil {
+		removed = nil
+		for key := range cfg.RootAgents {
+			if rootAgentKeyMatchesRepo(key, repoID) {
+				removed = append(removed, key)
+			}
+		}
+		if len(removed) == 0 {
+			return nil
+		}
+		for _, key := range removed {
+			delete(cfg.RootAgents, key)
+		}
+		return saveConfigLocked(cfg)
+	})
+	if err != nil {
 		return nil, err
 	}
 	return removed, nil

--- a/config/rootagent_register_test.go
+++ b/config/rootagent_register_test.go
@@ -1,7 +1,10 @@
 package config
 
 import (
+	"fmt"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -87,4 +90,83 @@ func TestDeregisterRootAgentsForRepoUnknownIsNoOp(t *testing.T) {
 	cfg, err := LoadConfig()
 	require.NoError(t, err)
 	assert.Contains(t, cfg.RootAgents, "/repos/keep")
+}
+
+// TestRegisterRootAgentConcurrentRegistrationsAllPersist pins that the
+// load-modify-persist sequence is atomic (#1838). Each call re-marshals the
+// whole Config, so when the read is not inside the same lock as the write, the
+// registrations interleave and all but the last writer's entry is lost.
+func TestRegisterRootAgentConcurrentRegistrationsAllPersist(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	require.NoError(t, SaveConfig(DefaultConfig()))
+
+	const registrations = 8
+	errs := make([]error, registrations)
+	var wg sync.WaitGroup
+	for i := 0; i < registrations; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, errs[i] = RegisterRootAgent(fmt.Sprintf("/repos/p%d", i))
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		require.NoErrorf(t, err, "registration %d", i)
+	}
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	for i := 0; i < registrations; i++ {
+		assert.Containsf(t, cfg.RootAgents, fmt.Sprintf("/repos/p%d", i),
+			"registration %d was lost to a concurrent write", i)
+	}
+	assert.Len(t, cfg.RootAgents, registrations)
+}
+
+// TestRegisterRootAgentDoesNotClobberConcurrentConfigSet pins the reported
+// #1838 scenario end to end: the TUI's "+ Add project…" write (RegisterRootAgent)
+// racing `af config set` (SetGlobalConfigValue). The hook drives the config set
+// into the exact window between this registration's read and its write, which
+// is where the CLI's change used to be reverted by the TUI's stale snapshot.
+func TestRegisterRootAgentDoesNotClobberConcurrentConfigSet(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	seed := DefaultConfig()
+	seed.DefaultProgram = "claude"
+	require.NoError(t, SaveConfig(seed))
+
+	var setErr error
+	setDone := make(chan struct{})
+	rootAgentSaveRaceHookForTest = func() {
+		go func() {
+			defer close(setDone)
+			_, setErr = SetGlobalConfigValue("default_program", "codex")
+		}()
+		// Give the racing writer every chance to land its write before we
+		// persist. Holding the config lock, it cannot: it blocks until we
+		// release and then edits the file we wrote. Without the lock it
+		// completes here and our stale snapshot reverts it.
+		select {
+		case <-setDone:
+		case <-time.After(250 * time.Millisecond):
+		}
+	}
+	t.Cleanup(func() { rootAgentSaveRaceHookForTest = nil })
+
+	added, err := RegisterRootAgent("/repos/added")
+	require.NoError(t, err)
+	require.True(t, added)
+
+	select {
+	case <-setDone:
+	case <-time.After(30 * time.Second):
+		t.Fatal("the concurrent `af config set` never completed")
+	}
+	require.NoError(t, setErr)
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	assert.Contains(t, cfg.RootAgents, "/repos/added", "the registration must persist")
+	assert.Equal(t, "codex", cfg.DefaultProgram, "the concurrent `af config set` must not be reverted")
 }


### PR DESCRIPTION
Fixes #1838.

## Reproduced first

Confirmed on current master before changing anything. Two throwaway repros, both failing:

- **8 concurrent `RegisterRootAgent` calls → only 2 entries survived** (6 lost).
- **The reported CLI-vs-TUI narrative**: a TUI "+ Add project…" write reverted a concurrent `af config set default_program codex` back to `claude`.

## The issue's recommended fix does not work

#1838 recommends wrapping the marshal + `AtomicWriteFile` inside `saveConfig` in `WithFileLock`. I applied exactly that and re-ran the repro: **8 concurrent registrations collapsed to 1 entry** — no better.

`AtomicWriteFile` already makes each write all-or-nothing via temp+rename, so the file is never torn. Locking only the write serializes the *writes* but leaves the *read-modify-write sequences* interleaved, and they still resolve to last-writer-wins. The issue's own Explanation section says this ("`AtomicWriteFile` … does not prevent two processes from performing a read-modify-write sequence concurrently") but the Recommended Fix does not follow from it. **The lock has to span the read as well as the write.**

## Root cause

`RegisterRootAgent` and `DeregisterRootAgentsForRepo` (`config/rootagent_register.go`) both did `LoadConfig()` → modify → `SaveConfig()` with no lock held, and the persist re-marshals the *entire* `Config`. `SetGlobalConfigValue` (`config/configset.go:207`) does lock, but that only protects it from itself — an unlocked whole-file writer clobbers it anyway. These two are the only `saveConfig` callers in the repo.

## Fix

`withGlobalConfigLock` runs a whole load-modify-persist sequence under the same `config.toml` lock `SetGlobalConfigValue` takes; both root-agent writers now use it.

Two reentrancy hazards worth flagging for review, both deliberate:

1. **`LoadConfig` runs before the lock, not inside it.** It is the call that converts a legacy `config.json` (`convertJSONToTOML`) and materializes first-run defaults — and those paths take this very lock. `flock` is tied to the open file description, so a second acquisition from the same process blocks forever rather than recursing. Calling `LoadConfig` under the lock would deadlock. This mirrors what `SetGlobalConfigValue` already does for the same reason.
2. **The in-lock re-read goes through `loadConfigLocked`**, a raw read + parse that never takes the lock — mirroring the `os.ReadFile` `SetGlobalConfigValue` does inside its own lock body. A missing/contentless file there (removed in the window) falls back to defaults, matching `LoadConfig` semantics.

`SaveConfig` keeps a lock around standalone writes (this is the issue's literal recommendation, and it is correct for a blind authoritative write), documented as unsafe to call from inside a lock body. After this change every `config.toml` writer is lock-protected: `writeConfigIfMissing` is `O_EXCL` create-if-absent and cannot clobber.

## Regression tests

Both fail before, pass after (verified by neutering the lock while keeping the tests compiled):

- `TestRegisterRootAgentConcurrentRegistrationsAllPersist` — 8 concurrent registrations; **lost 7 of 8 without the lock**.
- `TestRegisterRootAgentDoesNotClobberConcurrentConfigSet` — drives `af config set` into the exact window between the read and the write via a test hook (matching the existing `convertRaceHookForTest` / `materializeRaceHookForTest` precedent); **reverted the config set without the lock**.

10 consecutive runs green under `-race` — no flake in the passing direction.

## Gates

- `make test-container` — full suite green
- `make tui-driver-selftest` — 33/33 green
- `go build ./...`, `gofmt -l .` clean, `golangci-lint run --fast` clean, `deadcode -test ./...` clean, file-length lint clean
- `go test ./config/ -race` green

Not merging — flagged for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)