### PR TITLE
fix: post-merge codex findings on #1857

### DIFF
--- a/daemon/limit.go
+++ b/daemon/limit.go
@@ -170,6 +170,13 @@ func (s *controlServer) ResumeFromLimit(req ResumeFromLimitRequest, resp *Resume
 // documented). The LimitReached liveness is cleared so the poll re-resolves the
 // real state on the next tick, and the transition is persisted.
 //
+// Delivering that prompt is the ONLY thing that lifts the block: a resume that
+// fails anywhere before the send lands leaves the session parked at the wall,
+// both in memory and on disk, so the manual retry and the auto-resume scheduler
+// (which both gate on the limit still being set) can pick it up again. The
+// respawn arm re-applies the block for that reason — Respawn ends in ConfirmLive,
+// which would otherwise report a session as resumed before its prompt existed.
+//
 // Runs under the per-(repo, title) target lock (like DeliverPrompt) and re-
 // verifies the limit state under it, so it never races a self-recovery, a kill,
 // or a concurrent resume. Rejects a tombstoned / reserved-root session, mirroring
@@ -268,6 +275,12 @@ func (m *Manager) resumeFromLimitLocked(repoID, key string, instance *session.In
 	case probeUnknown:
 		return fmt.Errorf("cannot resume %q: its agent-server did not answer the liveness probe; not re-spawning, because re-provisioning a sandbox that may still be running would orphan it and discard its unpushed work", requestedTitle)
 	case probeDead:
+		// Capture the limit window BEFORE the re-spawn: Respawn ends in ConfirmLive,
+		// which drops both the LiveLimitReached liveness and its reset time, and
+		// LimitResetAt reports (zero, false) once that has happened. Re-applying the
+		// block below has to restore THIS episode's window, not a zeroed one — the
+		// auto-resume scheduler schedules off it (reset + grace).
+		resetAt, _ := instance.LimitResetAt()
 		if rerr := instance.Respawn(); rerr != nil {
 			return fmt.Errorf("failed to re-spawn agent for %q: %w", requestedTitle, rerr)
 		}
@@ -281,6 +294,28 @@ func (m *Manager) resumeFromLimitLocked(repoID, key string, instance *session.In
 		// endpoint and the resume could never clear the limit (#1786). Inert for local
 		// sessions, whose localAgentServer resolves i.backend per call.
 		as = instance.AgentServer()
+		// Re-apply the limit block Respawn's ConfirmLive just cleared. A re-spawned
+		// agent is NOT a resumed one: this session stays parked at the wall until the
+		// SendPrompt below actually delivers its pending prompt, so LiveLimitReached
+		// is the truthful liveness for the whole window between here and there. The
+		// resume's single completion point is ClearLimitReached, after the send lands.
+		//
+		// Without this the arm strands the session on BOTH axes when SendPrompt fails:
+		// in memory the scheduler's `GetLiveness() != LiveLimitReached` guard skips a
+		// LiveRunning row forever, and — since the checkpoint below serializes the
+		// whole instance — that unblocked row reaches disk, so even a restart reloads
+		// it non-limit-blocked and neither the manual `c` retry (its !LimitReached
+		// guard) nor auto-resume ever retries the prompt that never landed. Re-parking
+		// leaves the session exactly where the failed resume found it, which is what
+		// both retry paths already know how to pick up.
+		//
+		// This is also what makes the ClearLimitReached below load-bearing rather than
+		// a no-op on this arm: ConfirmLive used to have already cleared the limit.
+		//
+		// No hot-loop risk from re-parking: the auto-resume scheduler sets its
+		// backoff gate BEFORE firing (limitResumeAttempted), so a resume that keeps
+		// failing here backs off exponentially instead of hammering.
+		instance.SetLimitReached(resetAt)
 		// Write the respawn's durable state NOW, not at the end of the happy path
 		// (#1854). Respawn shares LocalBackend.respawn, so reaching this line can mean
 		// it rebuilt a vanished worktree — recreating the branch, flipping
@@ -288,8 +323,8 @@ func (m *Manager) resumeFromLimitLocked(repoID, key string, instance *session.In
 		// fail, and its early return would drop all of that: a restart would reload a
 		// record with no rebuilt branch recorded, and kill would orphan the branch af
 		// itself created (#1841's outcome, same class). The poll does not cover it
-		// either — the respawn already left the instance live, so persistPollChange
-		// sees no liveness change and skips the write.
+		// either — persistPollChange writes only on a liveness/reset-time change, and
+		// the re-parked row matches the one the poll already knows.
 		//
 		// AFTER noteRuntimeReplaced, never before: the #1794/#1804 rule keeps every
 		// statement — a disk write above all — out of the window between the runtime
@@ -307,11 +342,14 @@ func (m *Manager) resumeFromLimitLocked(repoID, key string, instance *session.In
 	if serr := as.SendPrompt(prompt); serr != nil {
 		return fmt.Errorf("failed to resume %q: %w", requestedTitle, serr)
 	}
+	// The prompt landed: this is the resume's single completion point, and the only
+	// place the limit block is lifted on either arm.
 	instance.ClearLimitReached()
 
 	// The cleared limit is itself durable state worth a checkpoint. On the respawn
-	// arm this is the second write; that is deliberate — the first one is what
-	// survives a failed SendPrompt, this one records the resume that landed.
+	// arm this is the second write; that is deliberate — the first one records the
+	// rebuilt worktree of a session still parked at the wall, this one records the
+	// resume that actually landed.
 	m.persistInstance(repoID, instance)
 	return nil
 }

--- a/daemon/limit_resume_test.go
+++ b/daemon/limit_resume_test.go
@@ -185,6 +185,104 @@ func TestResumeFromLimit_PersistsRespawnMutationsWhenSendPromptFails(t *testing.
 	}
 }
 
+// TestResumeFromLimit_KeepsLimitBlockedWhenSendPromptFails is the post-#1857
+// codex finding. On the probeDead arm Respawn ends in ConfirmLive, so the session
+// reads LiveRunning before its pending prompt has been delivered — and #1857's
+// checkpoint serializes the whole instance right there. A SendPrompt failure (or
+// a crash before the send) therefore left an UNBLOCKED session on both axes while
+// the prompt never landed, and every retry path gates on the limit still being
+// set: resumeFromLimit's own !LimitReached guard, and the auto-resume scheduler's
+// GetLiveness() != LiveLimitReached. Nothing re-delivered the prompt, so the
+// session was stranded — in memory immediately, and after #1857 across a restart
+// too. It must stay parked until the send actually succeeds.
+func TestResumeFromLimit_KeepsLimitBlockedWhenSendPromptFails(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+
+	// A real parsed window, not the zero time: the reset time is what the
+	// auto-resume scheduler schedules off (reset + grace), so it has to survive the
+	// respawn round-trip as well as the block itself.
+	resetAt := time.Now().Add(30 * time.Minute).UTC().Truncate(time.Second)
+
+	// alive=false → probeDead → the respawn arm, whose ConfirmLive drops the limit.
+	// The SendPrompt that follows it fails.
+	backend := &limitResumeBackend{
+		FakeBackend:   session.NewFakeBackend(),
+		alive:         false,
+		sendPromptErr: errors.New("agent-server refused the prompt"),
+	}
+	inst := registerStarted(t, manager, repoID, repoPath, "parked-1857", backend, true, session.Running)
+	inst.Prompt = "finish the migration"
+	inst.SetLimitReached(resetAt)
+
+	if err := manager.resumeFromLimit(ResumeFromLimitRequest{Title: "parked-1857", RepoID: repoID}); err == nil {
+		t.Fatal("resumeFromLimit returned nil; a failed SendPrompt must still surface to the caller")
+	}
+	if _, respawnCalls, _ := backend.snapshot(); respawnCalls != 1 {
+		t.Fatalf("Respawn called %d times, want 1 (the fixture must reach the respawn arm)", respawnCalls)
+	}
+
+	// In memory: the live daemon's auto-resume scheduler reads exactly this, and
+	// skips anything that is not LiveLimitReached.
+	if !inst.LimitReached() {
+		t.Fatal("session is not limit-blocked in memory after a failed resume; auto-resume's LiveLimitReached guard skips such a row forever, so the prompt that never landed would never be re-delivered")
+	}
+	gotReset, ok := inst.LimitResetAt()
+	if !ok || !gotReset.Equal(resetAt) {
+		t.Fatalf("in-memory reset time = (%v, %v), want (%v, true): the scheduler fires at reset+grace, so a zeroed window silently re-dates the retry", gotReset, ok, resetAt)
+	}
+
+	// On disk: what a daemon restart reloads. This is the axis #1857 regressed —
+	// before this fix the checkpoint serialized the post-ConfirmLive LiveRunning.
+	rec := recordFor(t, repoID, "parked-1857")
+	if rec == nil {
+		t.Fatal("record must still exist after a failed resume")
+	}
+	if rec.Liveness != session.LiveLimitReached {
+		t.Fatalf("persisted liveness = %v, want LiveLimitReached: a restart must reload the session still parked, or neither the manual retry nor auto-resume will ever retry it", rec.Liveness)
+	}
+	if !rec.LimitResetAt.Equal(resetAt) {
+		t.Fatalf("persisted reset time = %v, want %v (a reload must schedule off this episode's window)", rec.LimitResetAt, resetAt)
+	}
+}
+
+// TestResumeFromLimit_RespawnArm_ClearsLimitDurablyOnSuccess pins the other half
+// of the post-#1857 fix: re-parking the session across the respawn is TRANSIENT.
+// Once the prompt lands, ClearLimitReached lifts the block and the second
+// checkpoint records it, so a restart reloads a resumed session rather than one
+// wedged at a wall it already cleared. Without this the fix above would trade a
+// stranded-parked bug for a stranded-blocked one.
+func TestResumeFromLimit_RespawnArm_ClearsLimitDurablyOnSuccess(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+
+	// alive=false → probeDead → the respawn arm; SendPrompt succeeds (no error
+	// hook), which is the resume's single completion point.
+	backend := &limitResumeBackend{FakeBackend: session.NewFakeBackend(), alive: false}
+	inst := registerStarted(t, manager, repoID, repoPath, "resumed-1857", backend, true, session.Running)
+	inst.Prompt = "finish the migration"
+	inst.SetLimitReached(time.Now().Add(30 * time.Minute).UTC())
+
+	if err := manager.resumeFromLimit(ResumeFromLimitRequest{Title: "resumed-1857", RepoID: repoID}); err != nil {
+		t.Fatalf("resumeFromLimit returned %v, want nil", err)
+	}
+	if _, respawnCalls, prompts := backend.snapshot(); respawnCalls != 1 || len(prompts) != 1 || prompts[0] != "finish the migration" {
+		t.Fatalf("respawn=%d prompts=%v, want respawn=1 and the stored prompt re-delivered once", respawnCalls, prompts)
+	}
+	if inst.LimitReached() {
+		t.Fatal("limit must be cleared in memory once the prompt landed; the re-park across the respawn is transient, not sticky")
+	}
+
+	rec := recordFor(t, repoID, "resumed-1857")
+	if rec == nil {
+		t.Fatal("record must exist after a successful resume")
+	}
+	if rec.Liveness == session.LiveLimitReached {
+		t.Fatal("persisted liveness is still LiveLimitReached after a successful resume: a restart would reload a resumed session as parked and re-resume it")
+	}
+	if !rec.LimitResetAt.IsZero() {
+		t.Fatalf("persisted reset time = %v, want zero (a cleared limit must not carry a stale window to disk)", rec.LimitResetAt)
+	}
+}
+
 // TestResumeFromLimit_LiveStall_SendsContinueNoRespawn: the common case — the
 // agent is still alive but stalled at the limit wall. No re-spawn is needed (and
 // Recover is never touched); an interactive session with no stored prompt just


### PR DESCRIPTION
## Summary

Post-merge follow-up for #1857. Codex posted two inline reviews (a P1 and a P2) after that PR had already merged; both describe the **same** finding, and it is **valid against current master**. This fixes it with a regression test on each axis.

> **Draft on purpose.** The auto-gate squash-merges green PRs, and this touches only `daemon/` so nothing holds it back. Requested to land review-first, not auto-merge — un-draft when it's cleared.

## The finding

On the `probeDead` arm, `Respawn()` bottoms out in `LocalBackend.respawn`, which ends with `_ = i.Transition(ConfirmLive())` (`backend_local.go:429`). So the instance reads `LiveRunning` **before** the pending prompt has been delivered. #1857 then added a checkpoint right there that serializes the *whole* instance.

The result: a `SendPrompt` failure (or a crash between the two) early-returns and leaves an **unblocked** session — and every retry path gates on the limit still being set:

| Path | Guard | Effect on a `LiveRunning` row |
|---|---|---|
| manual `c` retry | `!instance.LimitReached()` | rejected — "not blocked on a usage limit" |
| auto-resume scheduler | `GetLiveness() != LiveLimitReached` | skipped every tick, forever |

So the prompt that never landed is never re-delivered. `ToInstanceData` also gates `LimitResetAt` on `liveness == LiveLimitReached` (`instance_data.go:46`), so the checkpoint drops the parsed window too.

**Both axes, and #1857 only caused half of it.** The *in-memory* strand predates #1857 — `ConfirmLive` already cleared the limit, which quietly made the `ClearLimitReached()` after a successful send a **no-op** on this arm. #1857's checkpoint pushed that same unblocked state to **disk**, so it began surviving a restart as well. That's why the fix is to make the state truthful rather than to narrow the checkpoint: persisting only worktree fields would have left the in-memory strand in place.

## Fix

Re-apply the block after the respawn, carrying the episode's parsed reset time across `ConfirmLive`:

```go
resetAt, _ := instance.LimitResetAt()   // captured BEFORE Respawn: ConfirmLive zeroes it
...
instance.SetLimitReached(resetAt)       // a re-spawned agent is not a resumed one
m.persistInstance(repoID, instance)
```

A re-spawned agent is not a resumed one — the session **is** still parked until its prompt is delivered, so `LiveLimitReached` is the truthful liveness for that whole window. This makes `ClearLimitReached()` after a successful send the resume's single completion point on both arms, and a failed resume now leaves the session exactly where it found it, which both retry paths already know how to pick up.

Ordering is unchanged and still load-bearing: the re-park and the persist both sit **after** `noteRuntimeReplaced`, per the #1794/#1804 rule that keeps every statement out of the window between the runtime swap and the debounce reset.

**No hot-loop risk from re-parking.** Checked before writing it: the scheduler sets its backoff gate *before* firing (`limitresume.go:195`, `limitResumeAttempted`), so a resume that keeps failing backs off 10s → 5min rather than hammering.

## Tests

Both are new; the #1857 test is untouched and still passes.

- **`TestResumeFromLimit_KeepsLimitBlockedWhenSendPromptFails`** — the finding. Asserts a failed send leaves the session limit-blocked **in memory** and as `LiveLimitReached` **on disk**, with the reset time round-tripping through the respawn.
- **`TestResumeFromLimit_RespawnArm_ClearsLimitDurablyOnSuccess`** — the over-correction guard. Pins the re-park as *transient*: once the prompt lands the block lifts durably, so the fix can't trade a stranded-parked bug for a stranded-blocked one.

**Verified they gate the fix.** Reverting only `instance.SetLimitReached(resetAt)`:

```
--- FAIL: TestResumeFromLimit_KeepsLimitBlockedWhenSendPromptFails
    session is not limit-blocked in memory after a failed resume ...
```

and with the in-memory assertions neutralized, the disk assertion fails on its own — reproducing codex's exact claim (`persisted liveness = 1`, i.e. `LiveRunning`):

```
--- FAIL: TestResumeFromLimit_KeepsLimitBlockedWhenSendPromptFails
    persisted liveness = 1, want LiveLimitReached: a restart must reload the
    session still parked, or neither the manual retry nor auto-resume will ever retry it
```

## Triage of the other comment

The P2 (`3589987448`) and the P1 (`3590179066`) are the same finding on the same line; the P1 is the more precise statement of it. Both are fixed by this change — no invalid findings to rebut.

## Gates

| Gate | Result |
|---|---|
| `make test-container` | all packages ok, 0 failures |
| `make tui-driver-selftest` | 38/38 green |
| `go build ./...` | clean |
| `gofmt -l .` | clean |
| `golangci-lint run --fast` | clean |
| `deadcode -test ./...` | clean |
| `scripts/lint-file-length.sh` | clean (634 files) |

Web gates N/A — no web files touched (`daemon/limit.go`, `daemon/limit_resume_test.go`).

Follow-up to #1857 · Ref #1854

🤖 Generated with [Claude Code](https://claude.com/claude-code)