### PR TITLE
fix: post-merge codex findings on #1816

### DIFF
--- a/daemon/close_tab_test.go
+++ b/daemon/close_tab_test.go
@@ -169,6 +169,79 @@ func TestCloseTab_RejectsArchivedSession(t *testing.T) {
 	}
 }
 
+// TestCloseTab_ArchiveWinningOpLockRaceKeepsWebTab closes the hole the plain
+// archived gate leaves open: that gate runs BEFORE the op-lock, so it only sees a
+// session that was already archived when the close arrived. ArchiveSession holds
+// the same op-lock, commits the archive under it, and leaves the SAME instance in
+// m.instances (an archived row stays tracked — it is still listed and restorable).
+// So a close that resolves a live session and then queues behind an archive finds
+// current == instance and UserKilled() false: every pre-existing post-lock check
+// passes, and it would go on to delete the web tab the archive just preserved and
+// persist the loss — the #1809 URL loss reached through the race rather than the
+// front door.
+func TestCloseTab_ArchiveWinningOpLockRaceKeepsWebTab(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	const title = "worker"
+	inst := startedLocalTabInstance(t, manager, repo.ID, repoPath, title, "af_"+title+"_agent")
+	const target = "http://localhost:3000"
+	if _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Kind: "web", URL: target, Name: "webpreview"}); err != nil {
+		t.Fatalf("CreateTab(web): %v", err)
+	}
+
+	key := daemonInstanceKey(repo.ID, title)
+	opLock := manager.opLockFor(key)
+	opLock.Lock()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := manager.CloseTab(CloseTabRequest{Title: title, RepoID: repo.ID, TabIndex: 1})
+		done <- err
+	}()
+
+	// The close must PARK on the op-lock rather than return: that is what proves it
+	// passed the pre-lock archived check while the session was still live, which is
+	// the only interleaving that can reach the post-lock gate. Without this the test
+	// would pass on the pre-lock check alone and prove nothing.
+	select {
+	case err := <-done:
+		opLock.Unlock()
+		t.Fatalf("CloseTab returned while the op-lock was held (it never raced the archive): %v", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	// The archive commits under the op-lock, leaving the same pointer tracked —
+	// exactly what ArchiveSession does between BeginArchive and releasing the lock.
+	inst.SetStatusForTest(session.Archived)
+	opLock.Unlock()
+
+	err = <-done
+	if err == nil {
+		t.Fatal("CloseTab queued behind an archive returned nil: it deleted the web tab the archive had just preserved")
+	}
+	if !strings.Contains(err.Error(), "archived") {
+		t.Fatalf("CloseTab lost-the-race error = %v, want the same actionable archived rejection an up-front close gets", err)
+	}
+
+	// The preserved URL survived the race — this is the whole point of #1809.
+	tabs := inst.GetTabs()
+	if len(tabs) != 2 {
+		t.Fatalf("archived session tabs = %d, want 2 (agent + the preserved web tab)", len(tabs))
+	}
+	if tabs[1].Kind != session.TabKindWeb || tabs[1].URL != target {
+		t.Fatalf("preserved web tab = {kind:%v url:%q}, want the web tab at %q intact", tabs[1].Kind, tabs[1].URL, target)
+	}
+}
+
 // TestCloseTab_RejectsAgentTabByName verifies the agent tab is unclosable when
 // targeted by its name too, not just by index 0 — the name path is the one
 // `af sessions tab-delete --name` drives (#1021).

--- a/daemon/manager_tabs.go
+++ b/daemon/manager_tabs.go
@@ -154,6 +154,14 @@ func (m *Manager) CreateTab(req CreateTabRequest) (string, error) {
 	return tab.Name, nil
 }
 
+// errCloseTabArchived is the refusal CloseTab returns for an archived session.
+// It is shared by the pre-lock fast path and the post-lock gate so a close that
+// loses the race to an archive is indistinguishable — to a CLI user or the web ×
+// — from one that arrived after it: same refusal, same advice, tab intact.
+func errCloseTabArchived(title string) error {
+	return fmt.Errorf("cannot close a tab on archived session %q; restore it first (af sessions restore)", title)
+}
+
 // CloseTab closes a non-agent tab of the target session, kills its tmux
 // session, and persists the shrunk tab list (#960 PR 1). It is the close-side
 // counterpart of CreateTab and mirrors its discipline: find the session, run
@@ -196,8 +204,13 @@ func (m *Manager) CloseTab(req CloseTabRequest) (string, error) {
 	// exact loss the preservation exists to prevent, just moved later. This mirrors
 	// the AddTab side (TabSpawnBlocked), which has refused archived sessions since
 	// #1196: archive is inert in BOTH directions.
+	//
+	// This is the FAST path only — it rejects an already-archived session without
+	// making the caller wait on the op-lock. It is not the real gate: the session
+	// can still archive between here and the lock. The authoritative check is the
+	// post-lock one below.
 	if instance.IsArchived() {
-		return "", fmt.Errorf("cannot close a tab on archived session %q; restore it first (af sessions restore)", title)
+		return "", errCloseTabArchived(title)
 	}
 
 	// Serialize the tab close against archive/kill/restore teardown for this
@@ -218,6 +231,17 @@ func (m *Manager) CloseTab(req CloseTabRequest) (string, error) {
 	m.mu.Unlock()
 	if current != instance || instance.UserKilled() {
 		return "", fmt.Errorf("session %q changed state before tab close could start", title)
+	}
+	// Re-check archived UNDER the lock, because the pointer check above cannot see
+	// an archive: ArchiveSession holds this same op-lock, commits LiveArchived, and
+	// leaves the SAME instance in m.instances (an archived row stays tracked — it is
+	// still listed and restorable). So a close that resolved a live session and then
+	// queued behind an archive arrives here with current == instance and
+	// UserKilled() false — both checks pass — and would delete the web tab the
+	// archive just preserved, then persist the loss. That is the #1809 URL loss
+	// exactly, reached through the race instead of through the front door.
+	if instance.IsArchived() {
+		return "", errCloseTabArchived(title)
 	}
 
 	// Serialize against other create/tab mutations on this repo, mirroring

--- a/daemon/webtab_proxy.go
+++ b/daemon/webtab_proxy.go
@@ -64,18 +64,25 @@ func (m *Manager) WebTabTarget(sessionID, tabID string) (string, session.TabKind
 	// created: the dev server behind it is long gone, and the port may now host
 	// something else entirely. Proxying it would make an archived session reach into
 	// a live port on the daemon's machine — the opposite of inert. The tab starts
-	// resolving again the moment a restore flips liveness back.
+	// resolving again the moment a restore begins (its worktree is home by then).
+	//
+	// WebTabServeBlocked, not the settled IsArchived: the fence has to go up when
+	// the archive STARTS, not when it finishes. BeginArchive raises OpArchiving and
+	// only then tears tmux down and moves the worktree, so a gate on LiveArchived
+	// alone would let an already-open iframe keep proxying through that whole
+	// teardown. This route is not serialized with ArchiveSession (a proxied request
+	// must not block behind a worktree move), so the fence lives on the instance.
 	//
 	// Checked before the tab lookup: it is a property of the SESSION, so it holds
 	// however the tab is addressed.
 	//
 	// It fences a VSCODE tab too, for a different reason with the same conclusion:
 	// serving one SPAWNS an editor, and an archived session's worktree has been
-	// moved out to the archive dir. (ensureVSCodeServer refuses archived sessions on
-	// its own as well — this just refuses earlier, before any kind lookup.) The
+	// moved out to the archive dir. (ensureVSCodeServer refuses on its own via
+	// TabSpawnBlocked — this just refuses earlier, before any kind lookup.) The
 	// message stays kind-agnostic because this runs before the kind is known.
-	if instance.IsArchived() {
-		return "", 0, fmt.Errorf("cannot open the tab of archived session %q: it is inert until restored (af sessions restore)", sessionID)
+	if blocked := instance.WebTabServeBlocked(); blocked != nil {
+		return "", 0, fmt.Errorf("cannot open the tab of session %q: %w", sessionID, blocked)
 	}
 	idx, ok := instance.TabIndexByID(tabID)
 	if !ok {

--- a/daemon/webtab_proxy_test.go
+++ b/daemon/webtab_proxy_test.go
@@ -137,6 +137,92 @@ func TestWebTabProxy_RejectsArchivedSession(t *testing.T) {
 	}
 }
 
+// TestWebTabProxy_RejectsWhileArchiveInFlight covers the window the settled
+// LiveArchived gate misses. BeginArchive raises OpArchiving and only THEN tears
+// tmux down and moves the worktree; liveness stays live until CommitArchive lands
+// at the very end. A gate reading only the settled state would keep proxying the
+// preserved loopback URL for the whole teardown, so an iframe left open when the
+// user hit archive goes on reaching a port on the daemon's machine while its
+// session is being dismantled. Terminal streams fence this window via
+// killsInFlight; the proxy route is not serialized with ArchiveSession at all, so
+// the fence has to live on the instance.
+func TestWebTabProxy_RejectsWhileArchiveInFlight(t *testing.T) {
+	const marker = "AF_WEBTAB_ARCHIVING_GATE"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, marker)
+	}))
+	defer upstream.Close()
+
+	mux, inst, id, tabID := newWebTabProxyFixtureWithInstance(t, upstream.URL)
+
+	// Live: proxies through — the control.
+	if rec := proxyGet(t, mux, id, tabID, ""); rec.Code != http.StatusOK {
+		t.Fatalf("live web tab: status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	// Mid-archive: liveness is still live, only the op has moved. This is the state
+	// ArchiveSession sits in while tmux comes down and the worktree moves.
+	if err := inst.Transition(session.BeginArchive()); err != nil {
+		t.Fatalf("BeginArchive: %v", err)
+	}
+	if inst.IsArchived() {
+		t.Fatal("fixture invalid: a mid-archive session must not read as settled-archived, or this test proves nothing")
+	}
+	rec := proxyGet(t, mux, id, tabID, "")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("mid-archive web tab: status = %d, want 404", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), marker) {
+		t.Fatal("mid-archive web tab: the upstream was proxied; archive must be inert from the moment it starts, not only once it commits")
+	}
+
+	// Committed: still refused, now on the settled state.
+	if err := inst.Transition(session.CommitArchive()); err != nil {
+		t.Fatalf("CommitArchive: %v", err)
+	}
+	rec = proxyGet(t, mux, id, tabID, "")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("archived web tab: status = %d, want 404", rec.Code)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "archived") {
+		t.Fatalf("archived web tab: body = %q, want an actionable archived message", body)
+	}
+}
+
+// TestWebTabProxy_ServesDuringRestore pins the deliberate other half of the
+// serve gate: a restore is NOT inert. BeginRestore moves the session to
+// LiveLost + OpRestoring, but both callers (RestoreArchived, undoCommittedArchive)
+// move the worktree home BEFORE that transition, so there is no mid-move window to
+// protect — and the tab served here is the same one the session serves a moment
+// later when the restore completes. Gating it would only blank a pane that is
+// about to work, so the inert predicate stops at archive/kill.
+func TestWebTabProxy_ServesDuringRestore(t *testing.T) {
+	const marker = "AF_WEBTAB_RESTORE_SERVES"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, marker)
+	}))
+	defer upstream.Close()
+
+	mux, inst, id, tabID := newWebTabProxyFixtureWithInstance(t, upstream.URL)
+
+	inst.SetStatusForTest(session.Archived)
+	if rec := proxyGet(t, mux, id, tabID, ""); rec.Code != http.StatusNotFound {
+		t.Fatalf("archived web tab: status = %d, want 404", rec.Code)
+	}
+
+	// Restore in flight: liveness Lost + OpRestoring, worktree already home.
+	if err := inst.Transition(session.BeginRestore()); err != nil {
+		t.Fatalf("BeginRestore: %v", err)
+	}
+	rec := proxyGet(t, mux, id, tabID, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("restoring web tab: status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), marker) {
+		t.Fatalf("restoring web tab: body = %q, want the upstream content", rec.Body.String())
+	}
+}
+
 // TestWebTabProxy_ServesLoopbackTarget is the headline proxy test: a web tab
 // pointing at a loopback HTTP server is reverse-proxied by the daemon, so a
 // same-origin GET /v1/webtab/{id}/{tabId}/ returns the server's content.

--- a/session/liveness.go
+++ b/session/liveness.go
@@ -250,15 +250,51 @@ func (i *Instance) ShownArchived() bool {
 // of which had a reason to check for archived before.
 //
 // Unlike ShownArchived (a RENDER predicate, which yields the row to the live
-// section the moment a restore starts, #1210) this reads the liveness axis ALONE,
-// so the gate stays shut across the whole restore window — liveness stays
-// LiveArchived until the reconcile's Archived→live rebuild lands a fresh started
-// instance. A gate that opened at OpRestoring would serve a tab whose worktree is
-// mid-move.
+// section the moment a restore starts, #1210) this reads the liveness axis ALONE.
+// It is therefore SETTLED-state only: it does not cover a session mid-archive
+// (OpArchiving, liveness still live) — see WebTabServeBlocked for the serve-side
+// gate that does.
+//
+// It deliberately opens again the moment a restore begins. BeginRestore moves the
+// session to LiveLost + OpRestoring, but both callers (RestoreArchived and
+// undoCommittedArchive) move the worktree back home BEFORE that transition, so an
+// OpRestoring session's worktree is already in place — there is no mid-move window
+// to protect, and the tab it serves is the same one it will serve a moment later
+// when the restore completes.
 func (i *Instance) IsArchived() bool {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
 	return i.liveness == LiveArchived
+}
+
+// WebTabServeBlocked is the serve-side analogue of TabSpawnBlocked: "may this
+// session's preserved web tab be resolved and proxied right now?" It answers no
+// for a settled archive AND for the teardown window that precedes one. The
+// returned error is a REASON fragment, not a sentence: the proxy prefixes it with
+// the session it could not serve, so the two read as one message.
+//
+// The in-flight ops matter here for the same reason they matter to a tab spawn.
+// BeginArchive raises OpArchiving BEFORE tmux comes down and the worktree moves,
+// and leaves liveness live until CommitArchive lands at the very end (#1195 Phase
+// 2d). A gate reading only the settled LiveArchived would keep proxying a
+// preserved loopback URL throughout that teardown — an iframe that was open when
+// the user hit archive would go on reaching a port on the daemon's machine while
+// the session it belongs to is being dismantled. Terminal streams already fence
+// this window via killsInFlight; the proxy route is not serialized with
+// ArchiveSession at all, so it needs the fence on the instance itself.
+//
+// OpKilling rides along for the same reason: a session being removed must not
+// serve. OpRestoring deliberately does NOT — see IsArchived.
+func (i *Instance) WebTabServeBlocked() error {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	if i.liveness == LiveArchived {
+		return fmt.Errorf("it is archived and inert until restored (af sessions restore)")
+	}
+	if i.inFlightOp == OpArchiving || i.inFlightOp == OpKilling {
+		return fmt.Errorf("it is being archived or removed")
+	}
+	return nil
 }
 
 // IsCreating reports whether a create is in flight (the render/gate replacement

--- a/session/tab_archive_web_test.go
+++ b/session/tab_archive_web_test.go
@@ -111,3 +111,57 @@ func TestArchiveTeardown_AgentOnlyUnchanged(t *testing.T) {
 	assert.Equal(t, TabKindAgent, tabs[0].Kind)
 	assert.NotNil(t, tabs[0].tmux, "the agent tab keeps its tmux name-holder for a rollback Recover")
 }
+
+// TestWebTabServeBlocked_CoversTeardownNotRestore pins the exact shape of the
+// serve-side inert window, both halves of which are deliberate.
+//
+// It is BROADER than the settled LiveArchived on the teardown side: BeginArchive
+// raises OpArchiving before tmux comes down and the worktree moves, and commits
+// the archive only at the end, so a settled-only gate would serve a preserved
+// loopback URL throughout the teardown.
+//
+// It is deliberately NARROWER on the restore side: BeginRestore moves the session
+// to LiveLost + OpRestoring, but both callers move the worktree home BEFORE that
+// transition, so a restoring session's worktree is already in place and the tab it
+// serves is the one it will serve a moment later anyway. Blocking there would only
+// blank a pane that is about to work.
+func TestWebTabServeBlocked_CoversTeardownNotRestore(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	for _, tc := range []struct {
+		name    string
+		arrange func(i *Instance)
+		blocked bool
+		reason  string
+	}{
+		{"live", func(*Instance) {}, false, "a live session serves its web tab"},
+		{"mid-archive", func(i *Instance) {
+			require.NoError(t, i.Transition(BeginArchive()))
+		}, true, "archive must be inert from the moment it starts, not only once it commits"},
+		{"archived", func(i *Instance) {
+			require.NoError(t, i.Transition(BeginArchive()))
+			require.NoError(t, i.Transition(CommitArchive()))
+		}, true, "a settled archive is inert"},
+		{"restoring", func(i *Instance) {
+			require.NoError(t, i.Transition(BeginArchive()))
+			require.NoError(t, i.Transition(CommitArchive()))
+			require.NoError(t, i.Transition(BeginRestore()))
+		}, false, "the worktree is home before OpRestoring is raised, so serving is safe"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			inst := startedMockInstance(t, "af_serve_gate_"+tc.name)
+			_, err := inst.AddWebTab("http://localhost:3000", "webpreview")
+			require.NoError(t, err)
+			tc.arrange(inst)
+
+			err = inst.WebTabServeBlocked()
+			if tc.blocked {
+				require.Error(t, err, tc.reason)
+				assert.Contains(t, err.Error(), "archived", "the refusal must name archive so the proxy message stays actionable")
+			} else {
+				require.NoError(t, err, tc.reason)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Codex's review of #1816 landed *after* it merged. Ten inline comments, which triage into **two real bugs**, **three invalid**, and **two already fixed pre-merge**. This PR fixes the two real ones with regression tests, and corrects the comment that made the invalid three look valid.

Everything below was verified against current `master`, not against the reviewed commits.

## Accepted

**1. `CloseTab` archived gate ran before the op-lock** (5 of the 10 comments — codex flagged this every round)

The gate only saw a session that was *already* archived when the close arrived. `ArchiveSession` holds the same per-session op-lock, commits `LiveArchived` under it, and leaves the **same instance** in `m.instances` (an archived row stays tracked — it's still listed and restorable). So a close that resolved a live session and then queued behind an archive reached the post-lock checks with `current == instance` and `UserKilled()` false — both pass — and went on to delete the web tab the archive had just preserved, then persist the loss. That's the #1809 URL loss, reached through the race instead of the front door.

Fixed by re-checking archived under the lock. The pre-lock check stays as a fast path so a close that never raced still fails without waiting on the lock; both return the same refusal, so losing the race is indistinguishable from arriving late.

**2. Web-tab proxy gated on the settled `LiveArchived` only**

`BeginArchive` raises `OpArchiving` and *only then* tears tmux down and moves the worktree — liveness stays live until `CommitArchive` lands at the very end. So an iframe left open when the user hit archive kept proxying its preserved loopback URL through the entire teardown, reaching a port on the daemon's machine while its session was being dismantled. Terminal streams already fence this via `killsInFlight`; the proxy route isn't serialized with `ArchiveSession` at all, so the fence goes on the instance: `WebTabServeBlocked`, the serve-side analogue of the existing `TabSpawnBlocked`.

## Rejected — restore is deliberately serve-able

Three comments (liveness.go ×2, index.ts ×1) asked for `OpRestoring` to be treated as inert, on the grounds that it would serve "a tab whose worktree is mid-move". It doesn't. **Both** `BeginRestore` callers — `RestoreArchived` and `undoCommittedArchive` — move the worktree home *before* the transition, so a restoring session's worktree is already in place. And the tab served during that window is the same tab the session serves a moment later when the restore completes: restore doesn't restart the user's dev server, so a preserved tab pointing at a stale port is #1809's designed behavior, not a leak the restore window opens. Gating it would only blank a pane that is about to work.

The confusion was ours: `IsArchived`'s comment claimed liveness "stays `LiveArchived` until the reconcile's Archived→live rebuild", which is false — `BeginRestore` sets `LiveLost + OpRestoring`. Codex read the comment, correctly spotted that it contradicted the code, and inferred a hole. The comment is now honest about what the predicate does and why restore is intentionally outside it, and `TestWebTabProxy_ServesDuringRestore` pins the non-gate so it isn't "fixed" into a blank pane later.

Detailed reasoning posted on each thread.

## Already fixed before merge

The two 12:46 comments (on `d496ef1f`) were addressed by `53cba800` later in the same PR — that's where these gates came from. The `CloseTab` one was fixed incompletely, which is finding 1 above.

## Tests

Each was verified to **fail without its fix**, not just pass with it:

- `TestCloseTab_ArchiveWinningOpLockRaceKeepsWebTab` — parks a close on a held op-lock, archives under it, asserts refusal + URL intact. The park itself is asserted, so the test can't pass on the pre-lock check and prove nothing. Without the post-lock gate: *"CloseTab queued behind an archive returned nil: it deleted the web tab the archive had just preserved"*.
- `TestWebTabProxy_RejectsWhileArchiveInFlight` — refused mid-archive, not only once committed. Without the fix: `status = 200, want 404`.
- `TestWebTabProxy_ServesDuringRestore` — pins the deliberate non-gate.
- `TestWebTabServeBlocked_CoversTeardownNotRestore` — table over live / mid-archive / archived / restoring.

## Gates

`make test-container` (all packages ok) · `make tui-driver-selftest` (38/38) · `go build` · `gofmt` · `golangci-lint --fast` · `deadcode` · file-length lint — all green. No web files touched (the only web finding was rejected), so web gates don't apply.

Not merging — flagged for review as asked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)