### PR TITLE
fix: post-merge codex findings on #1865

### DIFF
--- a/daemon/webtab_proxy.go
+++ b/daemon/webtab_proxy.go
@@ -482,8 +482,10 @@ func rewriteRefreshURL(h http.Header, prefix string, target *url.URL) {
 //
 //	/app/                      -> /v1/webtab/s/t/app/          (absolute path: prepend)
 //	http://localhost:3000/app/ -> /v1/webtab/s/t/app/          (same upstream: strip origin, keep path)
+//	/../login                  -> /v1/webtab/s/t/login         (dot segments resolved first)
 //	app/x                      -> unchanged                    (relative: already at mirrored depth)
 //	https://example.com/x      -> unchanged                    (foreign host)
+//	///example.com/x           -> unchanged                    (foreign host, network-path spelling)
 //
 // A RELATIVE reference needs no help: the browser resolves it against the current
 // proxied URL, which sits at the same depth as the upstream one, so it lands on the
@@ -495,11 +497,19 @@ func rewriteRefreshURL(h http.Header, prefix string, target *url.URL) {
 // browser at a prefix the daemon would then refuse to proxy (only loopback targets
 // are proxied) and silently rehost someone else's origin under ours.
 //
-// The path is carried VERBATIM, in the upstream's own encoding: Path and RawPath are
-// prefixed together so url.String() reproduces the app's escaping rather than
-// re-canonicalizing it (a literal %2F in a redirect target stays %2F).
+// Everything here is decided the way the BROWSER will read the header, which is not
+// always the way net/url parses it. Two spellings diverge, and both are handled
+// before the prefix goes on: a network-path reference net/url hands back as a plain
+// path (isNetworkPathRef), and dot segments that would otherwise eat the prefix
+// after the browser normalizes them (normalizeEscapedPath).
+//
+// The path is carried VERBATIM, in the upstream's own encoding: the prefix is
+// prepended to the ESCAPED path and the result re-parsed, so url.String() reproduces
+// the app's escaping rather than re-canonicalizing it (a literal %2F in a redirect
+// target stays %2F, leading or not).
 func rewriteUpstreamRef(ref, prefix string, target *url.URL) (string, bool) {
-	u, err := url.Parse(strings.TrimSpace(ref))
+	raw := strings.TrimSpace(ref)
+	u, err := url.Parse(raw)
 	if err != nil {
 		return "", false // unparseable: pass through rather than mangle
 	}
@@ -514,14 +524,111 @@ func rewriteUpstreamRef(ref, prefix string, target *url.URL) (string, bool) {
 		u.Scheme, u.Host, u.User = "", "", nil
 	case !strings.HasPrefix(u.Path, "/"):
 		return "", false // relative — already mirrored
+	case isNetworkPathRef(raw):
+		// A foreign host in a spelling net/url reported as a local path. Same rule
+		// as any other foreign host: pass it through untouched.
+		return "", false
 	}
 	if u.Path == "" { // origin-only, e.g. http://localhost:3000?x=1
 		u.Path = "/"
 	}
-	escaped := u.EscapedPath()
-	u.Path = joinURLPath(prefix, u.Path)
-	u.RawPath = joinURLPath(prefix, escaped)
+	// Prefix the escaped form and re-parse it, rather than prefixing Path and RawPath
+	// separately: the two must stay consistent or url.String() silently drops RawPath
+	// and re-canonicalizes, and a re-parse is what net/url itself uses to keep them so.
+	final := strings.TrimRight(prefix, "/") + normalizeEscapedPath(u.EscapedPath())
+	if isNetworkPathRef(final) {
+		// Unreachable for a real tab prefix (always "/v1/webtab/<sid>/<tab>"), which
+		// is exactly why it is asserted rather than assumed: an empty prefix plus an
+		// upstream "/..//evil.com" would otherwise emit a Location the browser reads
+		// as an off-site host — this proxy handing out an open redirect.
+		return "", false
+	}
+	p, err := url.Parse(final)
+	if err != nil {
+		return "", false
+	}
+	u.Path, u.RawPath = p.Path, p.RawPath
 	return u.String(), true // query and fragment ride along untouched
+}
+
+// isAuthoritySlash reports whether c is a slash the browser's URL parser accepts as
+// an authority delimiter for an http(s) URL. Backslash counts: the WHATWG parser
+// folds "\" to "/" for these "special" schemes, so "/\host/x" reaches the same
+// authority state "//host/x" does.
+func isAuthoritySlash(c byte) bool { return c == '/' || c == '\\' }
+
+// isNetworkPathRef reports whether a BROWSER would read ref as naming a HOST rather
+// than a path on the current origin — RFC 3986's network-path reference, which the
+// browser enters on a leading "//" and, for http(s), on any leading run of slashes
+// or backslashes: "///example.com/x" and "/\example.com/x" both navigate to
+// example.com.
+//
+// net/url recognizes only the exact two-slash spelling, filling in Host for it; the
+// longer runs it hands back with an EMPTY host and the whole reference as Path. So
+// an absolute-path test alone sees a local path and prefixes it, turning an upstream
+// "Location: ///accounts.example.com/oauth" into a path on the dev server and
+// stranding an OAuth handoff inside the frame.
+//
+// The test reads the RAW header value because that is the byte string the browser
+// parses. A percent-escape is an ordinary path character to it, not a delimiter, so
+// "/%2Ffoo" is deliberately NOT a network path here even though net/url decodes its
+// Path to "//foo".
+func isNetworkPathRef(ref string) bool {
+	return len(ref) >= 2 && isAuthoritySlash(ref[0]) && isAuthoritySlash(ref[1])
+}
+
+// isSingleDotSegment and isDoubleDotSegment recognize dot segments in the forms a
+// BROWSER resolves. The WHATWG URL parser decodes %2e before classifying a segment,
+// so "%2e%2e" walks up exactly like ".." does. Neither url.ResolveReference nor
+// path.Clean knows that — they compare the literal segment — which is why the rule
+// is spelled out here instead of delegated.
+func isSingleDotSegment(seg string) bool {
+	return seg == "." || strings.EqualFold(seg, "%2e")
+}
+
+func isDoubleDotSegment(seg string) bool {
+	return seg == ".." || strings.EqualFold(seg, ".%2e") ||
+		strings.EqualFold(seg, "%2e.") || strings.EqualFold(seg, "%2e%2e")
+}
+
+// normalizeEscapedPath resolves the "." and ".." segments of an absolute escaped
+// path, the way the browser resolves them when it follows the rewritten header.
+//
+// Doing it BEFORE the prefix goes on is what stops a dot segment from eating the
+// prefix. An upstream "Location: /../login" prefixed verbatim yields
+// "/v1/webtab/<sid>/<tab>/../login"; the browser normalizes that to
+// "/v1/webtab/<sid>/login", which names a different tab — or, far more often, a 404
+// — instead of the upstream's "/login". Normalizing first sends "/login" through
+// the prefix, which is what the upstream meant and what an unproxied browser would
+// have fetched.
+//
+// It walks the ESCAPED path, so a %2F stays an ordinary path character rather than
+// becoming a segment separator.
+func normalizeEscapedPath(escaped string) string {
+	if !strings.HasPrefix(escaped, "/") {
+		return escaped
+	}
+	segments := strings.Split(escaped[1:], "/")
+	out := make([]string, 0, len(segments))
+	for i, seg := range segments {
+		last := i == len(segments)-1
+		switch {
+		case isSingleDotSegment(seg):
+			if last {
+				out = append(out, "") // "/a/." names the directory: keep its slash
+			}
+		case isDoubleDotSegment(seg):
+			if len(out) > 0 {
+				out = out[:len(out)-1] // at root already: ".." has nothing to pop
+			}
+			if last {
+				out = append(out, "")
+			}
+		default:
+			out = append(out, seg)
+		}
+	}
+	return "/" + strings.Join(out, "/")
 }
 
 // sameUpstreamHost reports whether ref names the same origin as the tab's proxied

--- a/daemon/webtab_proxy_test.go
+++ b/daemon/webtab_proxy_test.go
@@ -774,6 +774,80 @@ func TestWebTabProxy_ForeignRedirectPassesThrough(t *testing.T) {
 	}
 }
 
+// TestWebTabProxy_NetworkPathRedirectPassesThrough is the OAuth case in the spelling
+// net/url does not read as a host. "///accounts.example.com/oauth" is a navigation to
+// accounts.example.com in every browser, but Go parses it with an empty Host and the
+// whole reference as a path — so the absolute-path rule captured it into the tab and
+// sent the user to the dev server's /accounts.example.com/oauth instead of to the
+// identity provider.
+func TestWebTabProxy_NetworkPathRedirectPassesThrough(t *testing.T) {
+	const foreign = "///accounts.example.com/oauth"
+	upstream := redirectingUpstream(t, http.StatusFound, foreign)
+	mux, id, tabID := newWebTabProxyFixture(t, upstream.URL)
+
+	rec := proxyGet(t, mux, id, tabID, "login")
+
+	if got := rec.Header().Get("Location"); got != foreign {
+		t.Fatalf("Location = %q, want %q untouched (a network-path redirect is a foreign host)", got, foreign)
+	}
+}
+
+// TestWebTabProxy_RedirectDotSegmentsNormalized pins the dot-segment rule end to end.
+// The browser resolves "/../login" AFTER reading the header, so prefixing it verbatim
+// yields ".../<tab>/../login" — which normalizes to /v1/webtab/<sid>/login, a path
+// naming no tab at all. The upstream meant /login; that is what must ride the prefix.
+func TestWebTabProxy_RedirectDotSegmentsNormalized(t *testing.T) {
+	upstream := redirectingUpstream(t, http.StatusFound, "/../login")
+	mux, id, tabID := newWebTabProxyFixture(t, upstream.URL)
+
+	rec := proxyGet(t, mux, id, tabID, "deep/page")
+
+	want := fmt.Sprintf("/v1/webtab/%s/%s/login", id, tabID)
+	if got := rec.Header().Get("Location"); got != want {
+		t.Fatalf("Location = %q, want %q (a dot segment ate the tab prefix)", got, want)
+	}
+}
+
+// TestWebTabProxy_RedirectKeepsLeadingEncodedSlash is the encoding half of the same
+// header: %2F is a literal path character, not a separator, and an app that redirects
+// to /%2Ffoo names a different resource than /foo. Prefixing Path and RawPath
+// independently desynced them, and url.String() answers a desync by dropping RawPath.
+func TestWebTabProxy_RedirectKeepsLeadingEncodedSlash(t *testing.T) {
+	upstream := redirectingUpstream(t, http.StatusFound, "/%2Ffoo")
+	mux, id, tabID := newWebTabProxyFixture(t, upstream.URL)
+
+	rec := proxyGet(t, mux, id, tabID, "x")
+
+	want := fmt.Sprintf("/v1/webtab/%s/%s/%%2Ffoo", id, tabID)
+	if got := rec.Header().Get("Location"); got != want {
+		t.Fatalf("Location = %q, want %q (the escaped slash was decoded away)", got, want)
+	}
+}
+
+// TestRewriteUpstreamRefNeverEmitsNetworkPath guards the one way this rewrite could
+// hand out an OPEN REDIRECT. A real tab prefix is always "/v1/webtab/<sid>/<tab>", so
+// the prefixed path can never begin "//" — but normalization can produce a leading
+// "//" from an upstream "/..//evil.com/x", and with no prefix in front of it that is
+// a Location the browser reads as a foreign host. The rewrite must refuse instead.
+func TestRewriteUpstreamRefNeverEmitsNetworkPath(t *testing.T) {
+	target, err := url.Parse("http://localhost:3000")
+	if err != nil {
+		t.Fatalf("parse target: %v", err)
+	}
+	for _, prefix := range []string{"", "/"} {
+		got, ok := rewriteUpstreamRef("/..//evil.com/x", prefix, target)
+		if ok {
+			t.Fatalf("rewriteUpstreamRef(prefix=%q) = %q, true; want pass-through, not a network-path Location",
+				prefix, got)
+		}
+	}
+	// With a real prefix in front the same reference is an ordinary local path.
+	want := "/v1/webtab/sess/tab-1//evil.com/x"
+	if got, ok := rewriteUpstreamRef("/..//evil.com/x", "/v1/webtab/sess/tab-1", target); !ok || got != want {
+		t.Fatalf("rewriteUpstreamRef = %q, %v; want %q, true", got, ok, want)
+	}
+}
+
 // TestWebTabProxy_RefreshHeaderRewritten covers the delayed-redirect spelling of the
 // same escape.
 func TestWebTabProxy_RefreshHeaderRewritten(t *testing.T) {
@@ -836,6 +910,40 @@ func TestRewriteUpstreamRef(t *testing.T) {
 		{name: "relative stays relative", ref: "next/page"},
 		{name: "dot relative stays relative", ref: "../up"},
 		{name: "foreign host", ref: "https://example.com/x"},
+		// The spellings whose BROWSER reading diverges from net/url's parse. Each
+		// one reached master rewriting to something the browser would not follow
+		// where the upstream pointed.
+		//
+		// A LEADING %2F decodes to a second slash in Path but not in RawPath, so
+		// prefixing the two independently desynced them and url.String() dropped the
+		// encoding — silently renaming the resource the app named.
+		{name: "leading encoded slash keeps its encoding", ref: "/%2Ffoo", want: prefix + "/%2Ffoo"},
+		{name: "leading encoded slash on a same-origin absolute",
+			ref: "http://localhost:3000/%2Ffoo", want: prefix + "/%2Ffoo"},
+		{name: "real double slash in a same-origin path survives",
+			ref: "http://localhost:3000//foo", want: prefix + "//foo"},
+		// DOT SEGMENTS are resolved by the browser AFTER it reads the header, so an
+		// un-normalized one eats the prefix it was just given and escapes the tab.
+		{name: "dot segments resolved before prefixing", ref: "/../login", want: prefix + "/login"},
+		{name: "encoded dot segments resolved too", ref: "/%2e%2e/login", want: prefix + "/login"},
+		{name: "encoded dot segments are case insensitive", ref: "/%2E%2E/login", want: prefix + "/login"},
+		{name: "dot segments cannot climb past root", ref: "/../../x", want: prefix + "/x"},
+		{name: "interior dot segments resolved", ref: "/a/b/../c", want: prefix + "/a/c"},
+		{name: "single dot segment resolved", ref: "/a/./b", want: prefix + "/a/b"},
+		{name: "trailing single dot keeps the directory slash", ref: "/a/.", want: prefix + "/a/"},
+		{name: "trailing double dot keeps the directory slash", ref: "/a/..", want: prefix + "/"},
+		{name: "dot segments in the query are left alone", ref: "/x?q=/../y", want: prefix + "/x?q=/../y"},
+		// A NETWORK-PATH reference names a host to the browser, but net/url reports
+		// the longer slash runs as a plain local path. Foreign is foreign: pass it
+		// through, or an OAuth handoff gets stranded in the frame.
+		{name: "triple-slash network path is foreign", ref: "///accounts.example.com/oauth"},
+		{name: "backslash network path is foreign", ref: "/\\accounts.example.com/oauth"},
+		// Even when it names the upstream: the browser would leave the proxy for the
+		// loopback origin, which a remote viewer cannot reach. sameUpstreamHost's rule
+		// applies — an ambiguous spelling degrades to an honest un-rewritten redirect
+		// rather than a frame bound to a server it never named.
+		{name: "triple-slash naming the upstream is still not ours to claim",
+			ref: "///localhost:3000/x"},
 		{name: "loopback alias is not the same host", ref: "http://127.0.0.1:3000/x"},
 		{name: "different port", ref: "http://localhost:3001/x"},
 		{name: "scheme upgrade is not ours", ref: "https://localhost:3000/x"},


### PR DESCRIPTION
Codex reviewed #1865 after it merged. Three P2 findings on the Location rewrite, all valid, all reproduced on master, all fixed here with regression tests.

The common root cause: the rewrite decided using **net/url's parse** of the header, but a `Location` is followed by the **browser**, and the two disagree on exactly these spellings.

## The findings

**1. Escaped slashes drop their encoding** ([comment](https://github.com/sachiniyer/agent-factory/pull/1865#discussion_r3590839800))

`/%2Ffoo` parses to `Path: "//foo"` + `RawPath: "/%2Ffoo"`. `joinURLPath` trims leading slashes off each independently, desyncing them — and `url.String()` answers a desync by dropping `RawPath` and re-canonicalizing. The tab followed `/foo`: a different resource than the app named, and a direct contradiction of the rule the function's own doc states ("a literal %2F in a redirect target stays %2F"). The non-leading case (`/a%2Fb`) already worked, which is why it survived review.

Fixed by prepending the prefix to the *escaped* path and re-parsing the result — how net/url keeps the pair consistent internally. This also restores a real `//foo` in a same-origin path (`http://localhost:3000//foo` → master collapses it to `/foo`), an unreported fourth instance of the same `TrimLeft`.

**2. Dot segments escape the tab** ([comment](https://github.com/sachiniyer/agent-factory/pull/1865#discussion_r3590839805))

The browser normalizes `/../login` *after* reading the header, so the verbatim prefix produced `/v1/webtab/<sid>/<tab>/../login` → resolving to `/v1/webtab/<sid>/login`, which names a different tab or (far more often) a 404, instead of the upstream's `/login`. Dot segments are now resolved before the prefix goes on.

Codex's `/%2e%2e/login` case needed more than delegating to `url.ResolveReference` or `path.Clean`: both compare the literal segment, while the WHATWG parser decodes `%2e` *before* classifying, so `%2e%2e` walks up exactly like `..`. The rule is spelled out for that reason. Normalization walks the escaped path, so a `%2F` stays a path character rather than becoming a separator — which is what keeps finding 1's fix and this one from fighting.

**3. Network-path redirects get captured** ([comment](https://github.com/sachiniyer/agent-factory/pull/1865#discussion_r3590839807))

`///accounts.example.com/oauth` navigates to accounts.example.com in every browser (the URL parser consumes any leading run of slashes into the authority), but net/url reports it with an **empty Host** and the whole reference as a Path — so the absolute-path rule prefixed it and stranded the OAuth handoff inside the frame. It is foreign like any other foreign host and now passes through untouched.

Two notes on scope. Backslash rides along (`/\host/x`), since browsers fold `\` to `/` for http(s) — same class, same one-line rule. And `///localhost:3000/x`, which names the upstream, *also* passes through: that follows `sameUpstreamHost`'s existing precedent that an ambiguous spelling degrades to an honest un-rewritten redirect rather than binding the frame to a server it never named. The two-slash form (`//host/x`) was already correct — net/url parses that one's Host.

No new exposure from passing these through: `//evil.com` and `https://evil.com` already pass through untouched today. This applies the existing foreign rule to a spelling Go's parser spells differently.

## Open-redirect guard

Asserted rather than assumed. A real prefix is always `/v1/webtab/<sid>/<tab>`, so the output can't begin `//` — but normalization *can* produce a leading `//` from an upstream `/..//evil.com/x`, and with no prefix in front of it that is a Location the browser reads as a foreign host. The rewrite refuses instead of emitting it.

## Tests

Per finding, at both levels — the rewrite rule (`TestRewriteUpstreamRef` table) and the proxy's actual `Location` header. **Verified each one fails on master and passes here**, rather than trusting that they cover the bug.

## Gates

`make test-container` (full suite green) · `make tui-driver-selftest` (38/38) · `go build ./...` · `gofmt -l .` · `golangci-lint run --fast` · `deadcode -test ./...` · file-length lint. No web files touched, so web gates don't apply.

Not merging — flagged for review per the follow-up brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)