### PR TITLE
fix: post-merge codex findings on #1833

### DIFF
--- a/apiclient/attach_test.go
+++ b/apiclient/attach_test.go
@@ -235,6 +235,37 @@ func TestAttachStream_EncodedDetachKeyFlushesPrecedingInput(t *testing.T) {
 	waitClosed(t, done)
 }
 
+// TestAttachStream_BatchedKittyEventsDoNotLeakTheDetachKey guards the swallow
+// contract when a pane program turns on kitty's report-event-types flag: one tap
+// of ctrl+w is reported as a press AND a release, and a single stdin read can
+// batch both.
+//
+// The detach key must not reach the agent on its way out. Suffix-matching alone
+// sees only the trailing release, so the press half was forwarded as INPUT first
+// — the swallowed key still mutating the pane (a word-erase in claude) at the
+// moment the user leaves. The whole tap belongs to the detach.
+func TestAttachStream_BatchedKittyEventsDoNotLeakTheDetachKey(t *testing.T) {
+	server, stdinW, _, done := startDriver(t)
+
+	// One tap, batched: press then release, as a terminal with event reporting on
+	// delivers it.
+	if _, err := stdinW.Write([]byte("\x1b[119;5:1u\x1b[119;5:3u")); err != nil {
+		t.Fatalf("write batched press+release: %v", err)
+	}
+	// The very first frame must be the detach: anything before it is the detach
+	// key leaking into the pane.
+	msg := readServerMsg(t, server)
+	if msg.Binary && msg.Frame.Op == agentproto.OpInput {
+		t.Fatalf("the press half of the detach tap leaked to the agent as INPUT %q; "+
+			"one tap is one keypress and must be swallowed whole", msg.Frame.Data)
+	}
+	if typ, _ := agentproto.MessageTypeOf(msg.Text); msg.Binary || typ != agentproto.MsgDetach {
+		t.Fatalf("expected MsgDetach for the batched tap, got %+v", msg)
+	}
+	_ = server.Close(websocket.StatusNormalClosure, "")
+	waitClosed(t, done)
+}
+
 // TestAttachStream_EncodedNonDetachKeyForwards is the other half of the contract:
 // widening detection must not start swallowing keys the agent needs. ctrl+shift+w
 // under the same kitty encoding differs from the detach key only in its modifier

--- a/apiclient/detachkey.go
+++ b/apiclient/detachkey.go
@@ -65,33 +65,51 @@ const (
 	kbEventRelease = 3
 )
 
-// detachKeyEncoding is how the configured detach key looks once the terminal has
-// left legacy mode: the key codes that identify it, and whether shift may appear
-// alongside ctrl.
-//
-// Both fields exist because the C0 byte a binding parses to is NOT what an
-// upgraded terminal reports. ctrl-w's byte 0x17 collapses key and modifier into
-// one value; kitty reports them separately, as the key the user physically
-// pressed plus a modifier set. For ctrl-^ and ctrl-_ they come apart entirely: on
-// a US layout those characters are typed as Ctrl+Shift+6 and Ctrl+Shift+-, and
-// kitty reports the UNSHIFTED key code with the shift bit set — never codepoint
-// 94/95 with ctrl alone.
-type detachKeyEncoding struct {
-	// codes are the codepoints that can name this key: the character the binding
-	// is written with, plus the unshifted key code for characters that need shift
-	// to type. A terminal reporting either one means the same physical keypress.
-	codes []int
-	// shiftOK admits the shift modifier next to ctrl. It is set only for bindings
-	// whose character REQUIRES shift, where a terminal reporting the unshifted key
-	// code has nowhere else to put it. For every other binding shift is a genuine
-	// modifier difference: ctrl+shift+w is not the ctrl-w detach key.
-	shiftOK bool
+// shiftRule says how the shift modifier relates to one key code. It is a
+// property of the CODE, not of the binding: ctrl-_ is reported as '_' (shift
+// irrelevant — some layouts have it as a base key) or as the unshifted '-' key,
+// which is only the detach key WITH shift, because Ctrl+- unshifted is a
+// different key the pane should receive.
+type shiftRule int
+
+const (
+	// shiftForbidden: the character needs no shift, so a shift bit means the user
+	// pressed something else. ctrl+shift+w is not the ctrl-w detach key.
+	shiftForbidden shiftRule = iota
+	// shiftOptional: the code IS the binding's character, however it was typed —
+	// modifyOtherKeys reports '_' with shift, a layout with underscore as a base
+	// key reports it without.
+	shiftOptional
+	// shiftRequired: the code is the unshifted physical key, which only produces
+	// the binding's character when shifted. Ctrl+Shift+- is ctrl-_; Ctrl+- is not.
+	shiftRequired
+)
+
+// detachKeyCode is one key code that can name the detach key, with the shift
+// rule that makes it that key rather than a neighbouring one.
+type detachKeyCode struct {
+	code  int
+	shift shiftRule
 }
 
-// matches reports whether code names this detach key.
-func (e detachKeyEncoding) matches(code int) bool {
+// detachKeyEncoding is how the configured detach key looks once the terminal has
+// left legacy mode: the codes that identify it, each with its own shift rule.
+//
+// This exists because the C0 byte a binding parses to is NOT what an upgraded
+// terminal reports. ctrl-w's byte 0x17 collapses key and modifier into one value;
+// kitty reports them separately, as the key the user physically pressed plus a
+// modifier set. For ctrl-^ and ctrl-_ they come apart entirely: on a US layout
+// those characters are typed as Ctrl+Shift+6 and Ctrl+Shift+-, and kitty reports
+// the UNSHIFTED key code with the shift bit set — never codepoint 94/95 with ctrl
+// alone.
+type detachKeyEncoding struct {
+	codes []detachKeyCode
+}
+
+// matches reports whether code, pressed with mods, is this detach key.
+func (e detachKeyEncoding) matches(code, mods int, maskLocks bool) bool {
 	for _, c := range e.codes {
-		if code == c {
+		if c.code == code && modsMatch(mods, c.shift, maskLocks) {
 			return true
 		}
 	}
@@ -108,29 +126,42 @@ func (e detachKeyEncoding) matches(code int) bool {
 // CSI 91;5u and bare Esc as CSI 27u, so matching '[' here detaches on the real
 // binding without ever hijacking the Esc the agent needs.
 func detachKeyEncodingFor(b byte) (detachKeyEncoding, bool) {
+	plain := func(code int) (detachKeyEncoding, bool) {
+		return detachKeyEncoding{codes: []detachKeyCode{{code, shiftForbidden}}}, true
+	}
+	// shifted describes a binding whose character needs shift on a US layout:
+	// the character itself (however typed) or the physical key it lives on, which
+	// is only this binding when shifted.
+	shifted := func(char, key int) (detachKeyEncoding, bool) {
+		return detachKeyEncoding{codes: []detachKeyCode{
+			{char, shiftOptional},
+			{key, shiftRequired},
+		}}, true
+	}
+
 	switch {
 	case b >= 1 && b <= 26:
-		return detachKeyEncoding{codes: []int{int(b) + 'a' - 1}}, true // ctrl-a..ctrl-z
+		return plain(int(b) + 'a' - 1) // ctrl-a..ctrl-z
 	case b == 27:
-		return detachKeyEncoding{codes: []int{'['}}, true
+		return plain('[')
 	case b == 28:
-		return detachKeyEncoding{codes: []int{'\\'}}, true
+		return plain('\\')
 	case b == 29:
-		return detachKeyEncoding{codes: []int{']'}}, true
+		return plain(']')
 	case b == 30:
-		return detachKeyEncoding{codes: []int{'^', '6'}, shiftOK: true}, true
+		return shifted('^', '6') // Ctrl+Shift+6 — Ctrl+6 alone is a different key
 	case b == 31:
-		return detachKeyEncoding{codes: []int{'_', '-'}, shiftOK: true}, true
+		return shifted('_', '-') // Ctrl+Shift+- — Ctrl+- alone is a different key
 	default:
 		return detachKeyEncoding{}, false
 	}
 }
 
-// modsMatch reports whether an encoded modifier param is this key's modifier set:
-// ctrl, plus shift where the binding needs it, and nothing else once lock state
-// is masked away. Any other bit (alt, super, hyper, meta) makes it a different
-// key the agent may want, so it must not detach.
-func modsMatch(param int, enc detachKeyEncoding, maskLocks bool) bool {
+// modsMatch reports whether an encoded modifier param is the modifier set for a
+// key code with this shift rule: ctrl, shift exactly as the rule demands, and
+// nothing else once lock state is masked away. Any other bit (alt, super, hyper,
+// meta) makes it a different key the agent may want, so it must not detach.
+func modsMatch(param int, rule shiftRule, maskLocks bool) bool {
 	if param < 1 {
 		return false
 	}
@@ -138,11 +169,18 @@ func modsMatch(param int, enc detachKeyEncoding, maskLocks bool) bool {
 	if maskLocks {
 		bits &^= kbModLockMsk
 	}
-	allowed := kbModCtrl
-	if enc.shiftOK {
-		allowed |= kbModShift
+	if bits&kbModCtrl == 0 || bits&^(kbModCtrl|kbModShift) != 0 {
+		return false
 	}
-	return bits&kbModCtrl != 0 && bits&^allowed == 0
+	hasShift := bits&kbModShift != 0
+	switch rule {
+	case shiftForbidden:
+		return !hasShift
+	case shiftRequired:
+		return hasShift
+	default: // shiftOptional
+		return true
+	}
 }
 
 // csiParams splits the parameter bytes of a CSI sequence into top-level params,
@@ -201,16 +239,17 @@ func matchesEncodedDetachKey(seq []byte, enc detachKeyEncoding) bool {
 	switch final {
 	case 'u':
 		// kitty: CSI <key>[:<shifted>[:<base-layout>]] ; <mods>[:<event>] u
-		if len(params) != 2 || !modsMatch(csiSub(params, 1, 0), enc, true) {
+		if len(params) != 2 {
 			return false
 		}
+		mods := csiSub(params, 1, 0)
 		// Any slot naming the key counts. The base-layout slot is the point: it
 		// reports the PC-101 key for the physical press, and it is the ONLY slot
 		// carrying 'w' for a user typing ctrl+w on a Cyrillic layout, where the
 		// primary slot holds that layout's own codepoint. The shifted slot is what
 		// carries '^' when the user presses Ctrl+Shift+6.
 		for _, code := range params[0] {
-			if enc.matches(code) {
+			if enc.matches(code, mods, true) {
 				return true
 			}
 		}
@@ -221,8 +260,7 @@ func matchesEncodedDetachKey(seq []byte, enc detachKeyEncoding) bool {
 			return false
 		}
 		return csiSub(params, 0, 0) == 27 &&
-			enc.matches(csiSub(params, 2, 0)) &&
-			modsMatch(csiSub(params, 1, 0), enc, false)
+			enc.matches(csiSub(params, 2, 0), csiSub(params, 1, 0), false)
 	default:
 		return false
 	}

--- a/apiclient/detachkey.go
+++ b/apiclient/detachkey.go
@@ -37,6 +37,12 @@ import (
 // Detection stays a SUFFIX test on the read chunk, preserving the #975 rule: a
 // terminal delivers one keypress in one write, and batched leading bytes are
 // forwarded as INPUT before the detach fires.
+//
+// The encodings are not one-to-one with the binding's character, so matching is a
+// small set of (key code, modifier set) pairs per binding rather than a single
+// codepoint — see detachKeyEncodingFor. Once the detach fires,
+// tmux.NeutralTerminalRestore drops the negotiated modes back to legacy, so the
+// terminal the user lands back in reports Ctrl keys normally again.
 
 // kitty modifier bits (spec: the encoded param is bits+1). caps_lock and
 // num_lock are *state* bits the terminal may OR in at any time, so they are
@@ -51,28 +57,80 @@ const (
 	kbModLockMsk = kbModCapsOn | kbModNumOn
 )
 
-// detachKeyCodepoint maps the detach key's C0 control byte to the Unicode
-// codepoint of the key the user physically presses — what the CSI u and
-// modifyOtherKeys encodings report. config.ParseDetachKey only ever produces
-// ctrl-<letter> (1..26) or ctrl-\ ] ^ _ (28..31).
+// kitty event types, reported as a sub-param of the modifier param when the pane
+// program turns on the "report event types" progressive-enhancement flag.
+const (
+	kbEventPress   = 1
+	kbEventRepeat  = 2
+	kbEventRelease = 3
+)
+
+// detachKeyEncoding is how the configured detach key looks once the terminal has
+// left legacy mode: the key codes that identify it, and whether shift may appear
+// alongside ctrl.
 //
-// 27 (ctrl-[) is deliberately unmapped: it IS Esc, which the kitty protocol
-// reports specially, and treating a bare Esc as "detach" would hijack a key the
-// agent needs. A ctrl-[ detach key keeps legacy-only matching.
-func detachKeyCodepoint(b byte) (int, bool) {
+// Both fields exist because the C0 byte a binding parses to is NOT what an
+// upgraded terminal reports. ctrl-w's byte 0x17 collapses key and modifier into
+// one value; kitty reports them separately, as the key the user physically
+// pressed plus a modifier set. For ctrl-^ and ctrl-_ they come apart entirely: on
+// a US layout those characters are typed as Ctrl+Shift+6 and Ctrl+Shift+-, and
+// kitty reports the UNSHIFTED key code with the shift bit set — never codepoint
+// 94/95 with ctrl alone.
+type detachKeyEncoding struct {
+	// codes are the codepoints that can name this key: the character the binding
+	// is written with, plus the unshifted key code for characters that need shift
+	// to type. A terminal reporting either one means the same physical keypress.
+	codes []int
+	// shiftOK admits the shift modifier next to ctrl. It is set only for bindings
+	// whose character REQUIRES shift, where a terminal reporting the unshifted key
+	// code has nowhere else to put it. For every other binding shift is a genuine
+	// modifier difference: ctrl+shift+w is not the ctrl-w detach key.
+	shiftOK bool
+}
+
+// matches reports whether code names this detach key.
+func (e detachKeyEncoding) matches(code int) bool {
+	for _, c := range e.codes {
+		if code == c {
+			return true
+		}
+	}
+	return false
+}
+
+// detachKeyEncodingFor maps the detach key's C0 control byte to its encoded
+// forms. config.ParseDetachKey only ever produces ctrl-<letter> (1..26),
+// ctrl-[ (27), or ctrl-\ ] ^ _ (28..31).
+//
+// ctrl-[ is byte 27 — the same byte as Esc, which is why the LEGACY match cannot
+// tell the two apart and a ctrl-[ user accepts that bare Esc detaches. The
+// encoded forms have no such ambiguity: kitty reports the physical Ctrl+[ as
+// CSI 91;5u and bare Esc as CSI 27u, so matching '[' here detaches on the real
+// binding without ever hijacking the Esc the agent needs.
+func detachKeyEncodingFor(b byte) (detachKeyEncoding, bool) {
 	switch {
 	case b >= 1 && b <= 26:
-		return int(b) + 'a' - 1, true // ctrl-a..ctrl-z -> 'a'..'z'
-	case b >= 28 && b <= 31:
-		return int(b) + 64, true // ctrl-\ ] ^ _ -> '\' ']' '^' '_'
+		return detachKeyEncoding{codes: []int{int(b) + 'a' - 1}}, true // ctrl-a..ctrl-z
+	case b == 27:
+		return detachKeyEncoding{codes: []int{'['}}, true
+	case b == 28:
+		return detachKeyEncoding{codes: []int{'\\'}}, true
+	case b == 29:
+		return detachKeyEncoding{codes: []int{']'}}, true
+	case b == 30:
+		return detachKeyEncoding{codes: []int{'^', '6'}, shiftOK: true}, true
+	case b == 31:
+		return detachKeyEncoding{codes: []int{'_', '-'}, shiftOK: true}, true
 	default:
-		return 0, false
+		return detachKeyEncoding{}, false
 	}
 }
 
-// ctrlOnly reports whether an encoded modifier param means "ctrl, and nothing
-// else" once lock state is masked away.
-func ctrlOnly(param int, maskLocks bool) bool {
+// modsMatch reports whether an encoded modifier param is this key's modifier set:
+// ctrl, plus shift where the binding needs it, and nothing else once lock state
+// is masked away. Any other bit (alt, super, hyper, meta) makes it a different
+// key the agent may want, so it must not detach.
+func modsMatch(param int, enc detachKeyEncoding, maskLocks bool) bool {
 	if param < 1 {
 		return false
 	}
@@ -80,46 +138,59 @@ func ctrlOnly(param int, maskLocks bool) bool {
 	if maskLocks {
 		bits &^= kbModLockMsk
 	}
-	return bits == kbModCtrl
+	allowed := kbModCtrl
+	if enc.shiftOK {
+		allowed |= kbModShift
+	}
+	return bits&kbModCtrl != 0 && bits&^allowed == 0
 }
 
 // csiParams splits the parameter bytes of a CSI sequence into top-level params,
-// keeping only each param's FIRST sub-parameter (kitty appends ":<event-type>"
-// / ":<alternate-key>" sub-params when those progressive-enhancement flags are
-// on). An empty param yields -1 ("default"), matching terminal convention.
-func csiParams(b []byte) []int {
+// each with its own sub-parameters. An empty field yields -1 ("default"),
+// matching terminal convention; a non-numeric field makes the whole sequence
+// unparseable and returns nil.
+//
+// Sub-params are kept rather than dropped because kitty puts load-bearing values
+// there: the key param carries ":<shifted-key>:<base-layout-key>" when the
+// report-alternate-keys flag is on, and the modifier param carries
+// ":<event-type>" when event reporting is on.
+func csiParams(b []byte) [][]int {
 	if len(b) == 0 {
 		return nil
 	}
-	var out []int
+	var out [][]int
 	for _, field := range bytes.Split(b, []byte{';'}) {
-		if i := bytes.IndexByte(field, ':'); i >= 0 {
-			field = field[:i]
-		}
-		if len(field) == 0 {
-			out = append(out, -1)
-			continue
-		}
-		n := 0
-		ok := true
-		for _, c := range field {
-			if c < '0' || c > '9' {
-				ok = false
-				break
+		var subs []int
+		for _, s := range bytes.Split(field, []byte{':'}) {
+			if len(s) == 0 {
+				subs = append(subs, -1)
+				continue
 			}
-			n = n*10 + int(c-'0')
+			n := 0
+			for _, c := range s {
+				if c < '0' || c > '9' {
+					return nil
+				}
+				n = n*10 + int(c-'0')
+			}
+			subs = append(subs, n)
 		}
-		if !ok {
-			return nil
-		}
-		out = append(out, n)
+		out = append(out, subs)
 	}
 	return out
 }
 
+// csiSub returns param i's sub-param j, or -1 when either is absent.
+func csiSub(params [][]int, i, j int) int {
+	if i < 0 || i >= len(params) || j < 0 || j >= len(params[i]) {
+		return -1
+	}
+	return params[i][j]
+}
+
 // matchesEncodedDetachKey reports whether seq — a complete escape sequence
 // starting at ESC — is the detach key in either negotiated encoding.
-func matchesEncodedDetachKey(seq []byte, cp int) bool {
+func matchesEncodedDetachKey(seq []byte, enc detachKeyEncoding) bool {
 	// Both encodings are CSI sequences: ESC [ <params> <final>.
 	if len(seq) < 4 || seq[0] != 0x1b || seq[1] != '[' {
 		return false
@@ -129,20 +200,46 @@ func matchesEncodedDetachKey(seq []byte, cp int) bool {
 
 	switch final {
 	case 'u':
-		// kitty: CSI <codepoint> ; <modifiers> u
-		if len(params) != 2 {
+		// kitty: CSI <key>[:<shifted>[:<base-layout>]] ; <mods>[:<event>] u
+		if len(params) != 2 || !modsMatch(csiSub(params, 1, 0), enc, true) {
 			return false
 		}
-		return params[0] == cp && ctrlOnly(params[1], true)
+		// Any slot naming the key counts. The base-layout slot is the point: it
+		// reports the PC-101 key for the physical press, and it is the ONLY slot
+		// carrying 'w' for a user typing ctrl+w on a Cyrillic layout, where the
+		// primary slot holds that layout's own codepoint. The shifted slot is what
+		// carries '^' when the user presses Ctrl+Shift+6.
+		for _, code := range params[0] {
+			if enc.matches(code) {
+				return true
+			}
+		}
+		return false
 	case '~':
-		// xterm modifyOtherKeys=2: CSI 27 ; <modifiers> ; <codepoint> ~
+		// xterm modifyOtherKeys=2: CSI 27 ; <mods> ; <codepoint> ~
 		if len(params) != 3 {
 			return false
 		}
-		return params[0] == 27 && params[2] == cp && ctrlOnly(params[1], false)
+		return csiSub(params, 0, 0) == 27 &&
+			enc.matches(csiSub(params, 2, 0)) &&
+			modsMatch(csiSub(params, 1, 0), enc, false)
 	default:
 		return false
 	}
+}
+
+// detachKeyEventType reports the kitty event type of an encoded key sequence. It
+// defaults to press: the event-type sub-param is absent unless the pane program
+// turned on kitty's event-reporting flag, and modifyOtherKeys has no such
+// concept.
+func detachKeyEventType(seq []byte) int {
+	if len(seq) < 4 || seq[0] != 0x1b || seq[1] != '[' || seq[len(seq)-1] != 'u' {
+		return kbEventPress
+	}
+	if ev := csiSub(csiParams(seq[2:len(seq)-1]), 1, 1); ev > 0 {
+		return ev
+	}
+	return kbEventPress
 }
 
 // trailingDetachKeyLen reports how many bytes at the END of buf encode the
@@ -167,17 +264,40 @@ func trailingDetachKeyLen(buf []byte) int {
 	if buf[len(buf)-1] == tmux.DetachKeyByte {
 		return 1
 	}
-	cp, ok := detachKeyCodepoint(tmux.DetachKeyByte)
+	enc, ok := detachKeyEncodingFor(tmux.DetachKeyByte)
 	if !ok {
 		return 0
 	}
 	// A trailing escape sequence starts at the last ESC in the chunk.
-	i := bytes.LastIndexByte(buf, 0x1b)
-	if i < 0 {
+	start := bytes.LastIndexByte(buf, 0x1b)
+	if start < 0 || !matchesEncodedDetachKey(buf[start:], enc) {
 		return 0
 	}
-	if matchesEncodedDetachKey(buf[i:], cp) {
-		return len(buf) - i
+	// With kitty's event-type flag on, ONE tap of the key reports twice — a press
+	// (...;5:1u) then a release (...;5:3u) — and a single read can batch both. The
+	// suffix test above sees only the release, so reporting just its length would
+	// forward the press half of the very key being swallowed to the agent as
+	// input, letting the detach key mutate the pane on its way out.
+	//
+	// Walk back over the earlier halves of THIS tap only, stopping at its press.
+	// An earlier tap is a separate keypress, and #975's rule is that batched
+	// leading input is forwarded rather than swallowed.
+	if detachKeyEventType(buf[start:]) == kbEventRelease {
+		for {
+			prev := bytes.LastIndexByte(buf[:start], 0x1b)
+			if prev < 0 || !matchesEncodedDetachKey(buf[prev:start], enc) {
+				break
+			}
+			ev := detachKeyEventType(buf[prev:start])
+			if ev != kbEventPress && ev != kbEventRepeat {
+				break
+			}
+			start = prev
+			if ev == kbEventPress {
+				break // the press opens the tap; anything before it is earlier input
+			}
+			// A repeat is mid-tap (the key was held): the press is earlier still.
+		}
 	}
-	return 0
+	return len(buf) - start
 }

--- a/apiclient/detachkey_test.go
+++ b/apiclient/detachkey_test.go
@@ -168,6 +168,18 @@ func TestTrailingDetachKeyLen_RebindableKey(t *testing.T) {
 				t.Fatalf("%q must not detach when ctrl-^ is bound: got %d", in, got)
 			}
 		}
+		// The shift rule belongs to the CODE, not the binding. '6' is the detach
+		// key only WITH shift: unshifted Ctrl+6 is a different key, and swallowing
+		// it would steal a keypress the pane should receive.
+		for _, in := range []string{
+			"\x1b[54;5u",    // kitty: Ctrl+6, no shift
+			"\x1b[27;5;54~", // modifyOtherKeys: Ctrl+6, no shift
+		} {
+			if got := trailingDetachKeyLen([]byte(in)); got != 0 {
+				t.Fatalf("unshifted Ctrl+6 %q must reach the pane, not detach, "+
+					"when ctrl-^ is bound: got %d", in, got)
+			}
+		}
 	})
 
 	t.Run("ctrl-_ matches its shifted physical encoding", func(t *testing.T) {
@@ -176,10 +188,24 @@ func TestTrailingDetachKeyLen_RebindableKey(t *testing.T) {
 			"\x1b[45;6u",    // kitty: unshifted '-' + ctrl|shift
 			"\x1b[45:95;6u", // kitty with report-alternate-keys: shifted slot is '_'
 			"\x1b[95;5u",    // a layout where '_' needs no shift
+			"\x1b[95;6u",    // ...and the same layout with shift held
 			"\x1b[27;6;95~", // modifyOtherKeys: the '_' character + ctrl|shift
 		} {
 			if got := trailingDetachKeyLen([]byte(in)); got != len(in) {
 				t.Fatalf("ctrl-_ encoding %q not matched: got %d, want %d", in, got, len(in))
+			}
+		}
+		// Ctrl+- with no shift is NOT ctrl-_ — it is a distinct keypress (font-size
+		// shortcuts live there) and must reach the pane. Making shift optional for
+		// every code of the binding swallowed it.
+		for _, in := range []string{
+			"\x1b[45;5u",    // kitty: Ctrl+-, no shift
+			"\x1b[27;5;45~", // modifyOtherKeys: Ctrl+-, no shift
+			"\x1b[45;133u",  // Ctrl+- with num-lock on: still no shift
+		} {
+			if got := trailingDetachKeyLen([]byte(in)); got != 0 {
+				t.Fatalf("unshifted Ctrl+- %q must reach the pane, not detach, "+
+					"when ctrl-_ is bound: got %d", in, got)
 			}
 		}
 		if got := trailingDetachKeyLen([]byte("\x1b[54;6u")); got != 0 {

--- a/apiclient/detachkey_test.go
+++ b/apiclient/detachkey_test.go
@@ -44,9 +44,21 @@ func TestTrailingDetachKeyLen(t *testing.T) {
 		{"kitty with caps-lock on", "\x1b[119;69u", len("\x1b[119;69u")},
 		{"kitty with both locks on", "\x1b[119;197u", len("\x1b[119;197u")},
 
-		// kitty appends sub-params (event type / alternate key) when those
-		// progressive-enhancement flags are on; only the first sub-param counts.
+		// kitty appends sub-params to the modifier param (event type) and the key
+		// param (shifted / base-layout alternates) when those
+		// progressive-enhancement flags are on. Every event type of the key means
+		// the user pressed it.
 		{"kitty with event-type sub-param", "\x1b[119;5:1u", len("\x1b[119;5:1u")},
+		{"kitty repeat event", "\x1b[119;5:2u", len("\x1b[119;5:2u")},
+		{"kitty release event", "\x1b[119;5:3u", len("\x1b[119;5:3u")},
+
+		// The report-alternate-keys flag reports the current layout's codepoint
+		// first and the PC-101 key in the base-layout slot. On a Cyrillic layout
+		// the physical ctrl+w key is 1094 (ц), and 119 appears ONLY as the
+		// base-layout alternate — matching just the primary slot forwarded the
+		// user's detach key to the agent.
+		{"kitty base-layout alternate key", "\x1b[1094::119;5u", len("\x1b[1094::119;5u")},
+		{"kitty alternates naming a different key", "\x1b[1094::120;5u", 0},
 
 		// #975: a read that batches typed bytes with the detach key detaches,
 		// and reports only the key's own length so the rest is forwarded.
@@ -103,15 +115,136 @@ func TestTrailingDetachKeyLen_RebindableKey(t *testing.T) {
 		}
 	})
 
-	// ctrl-[ IS Esc, which the kitty protocol reports specially; hijacking a bare
-	// Esc would steal a key the agent needs, so it stays legacy-only.
-	t.Run("ctrl-[ has no encoded form", func(t *testing.T) {
+	// ctrl-[ and Esc are the same BYTE, which is why the legacy match cannot tell
+	// them apart. The encoded forms can: kitty reports the physical Ctrl+[ as
+	// CSI 91;5u and bare Esc as CSI 27u. Matching '[' detaches on the real binding
+	// without hijacking the Esc the agent needs — treating byte 27 as legacy-only
+	// left ctrl-[ users unable to detach at all once a pane upgraded the terminal.
+	t.Run("ctrl-[ matches its encoded form, not Esc", func(t *testing.T) {
 		withDetachKey(t, 27, "ctrl-[")
+		if got := trailingDetachKeyLen([]byte("\x1b[91;5u")); got != len("\x1b[91;5u") {
+			t.Fatalf("ctrl-[ kitty encoding not matched: got %d", got)
+		}
+		if got := trailingDetachKeyLen([]byte("\x1b[27;5;91~")); got != len("\x1b[27;5;91~") {
+			t.Fatalf("ctrl-[ modifyOtherKeys encoding not matched: got %d", got)
+		}
+		if got := trailingDetachKeyLen([]byte("\x1b[27u")); got != 0 {
+			t.Fatalf("bare Esc (CSI 27u) must never be hijacked as detach: got %d", got)
+		}
 		if got := trailingDetachKeyLen([]byte("\x1b[27;5u")); got != 0 {
-			t.Fatalf("ctrl-[ must not match an encoded form: got %d", got)
+			t.Fatalf("ctrl+Esc is not ctrl+[: got %d", got)
 		}
 		if got := trailingDetachKeyLen([]byte{27}); got != 1 {
 			t.Fatalf("ctrl-[ legacy byte must still detach: got %d", got)
 		}
 	})
+
+	// ctrl-^ and ctrl-_ are the two bindings whose character needs SHIFT to type
+	// on a US layout (Ctrl+Shift+6, Ctrl+Shift+-). kitty reports the unshifted key
+	// code with the shift bit rather than codepoint 94/95 with ctrl alone, so a
+	// ctrl-only match never fired and these supported bindings could not detach.
+	t.Run("ctrl-^ matches its shifted physical encoding", func(t *testing.T) {
+		withDetachKey(t, 30, "ctrl-^") // '^' = 94, typed as Ctrl+Shift+6 ('6' = 54)
+		for _, in := range []string{
+			"\x1b[54;6u",    // kitty: unshifted '6' + ctrl|shift
+			"\x1b[54:94;6u", // kitty with report-alternate-keys: shifted slot is '^'
+			"\x1b[94;5u",    // a layout where '^' needs no shift
+			"\x1b[27;6;94~", // modifyOtherKeys: the '^' character + ctrl|shift
+			"\x1b[54;134u",  // ctrl|shift with num-lock OR-ed in
+		} {
+			if got := trailingDetachKeyLen([]byte(in)); got != len(in) {
+				t.Fatalf("ctrl-^ encoding %q not matched: got %d, want %d", in, got, len(in))
+			}
+		}
+		// Shift is admitted because it is how the character is typed — not as a
+		// licence for any other modifier, and not for a different key.
+		for _, in := range []string{
+			"\x1b[54;7u",    // ctrl+alt+6 is a different key
+			"\x1b[54;2u",    // shift+6 alone is just '^' text
+			"\x1b[55;6u",    // ctrl+shift+7 is a different key
+			"\x1b[27;6;95~", // that is ctrl-_, not ctrl-^
+		} {
+			if got := trailingDetachKeyLen([]byte(in)); got != 0 {
+				t.Fatalf("%q must not detach when ctrl-^ is bound: got %d", in, got)
+			}
+		}
+	})
+
+	t.Run("ctrl-_ matches its shifted physical encoding", func(t *testing.T) {
+		withDetachKey(t, 31, "ctrl-_") // '_' = 95, typed as Ctrl+Shift+- ('-' = 45)
+		for _, in := range []string{
+			"\x1b[45;6u",    // kitty: unshifted '-' + ctrl|shift
+			"\x1b[45:95;6u", // kitty with report-alternate-keys: shifted slot is '_'
+			"\x1b[95;5u",    // a layout where '_' needs no shift
+			"\x1b[27;6;95~", // modifyOtherKeys: the '_' character + ctrl|shift
+		} {
+			if got := trailingDetachKeyLen([]byte(in)); got != len(in) {
+				t.Fatalf("ctrl-_ encoding %q not matched: got %d, want %d", in, got, len(in))
+			}
+		}
+		if got := trailingDetachKeyLen([]byte("\x1b[54;6u")); got != 0 {
+			t.Fatalf("ctrl+shift+6 must not detach when ctrl-_ is bound: got %d", got)
+		}
+	})
+
+	// Shift stays a genuine modifier difference for every OTHER binding: the
+	// character needs no shift to type, so a shift bit means the user pressed
+	// something else.
+	t.Run("shift is not admitted for keys that do not need it", func(t *testing.T) {
+		withDetachKey(t, 29, "ctrl-]")
+		if got := trailingDetachKeyLen([]byte("\x1b[93;6u")); got != 0 {
+			t.Fatalf("ctrl+shift+] must not detach when ctrl-] is bound: got %d", got)
+		}
+	})
+}
+
+// TestTrailingDetachKeyLen_BatchedEventTypes pins the swallow contract when a
+// pane program turns on kitty's report-event-types flag: ONE tap of the detach
+// key is reported as a press and a release (and, held down, repeats between
+// them), which a single stdin read can batch.
+//
+// The suffix test sees only the trailing release, so reporting just its length
+// would forward the press half of the very key being swallowed to the agent as
+// input — the detach key mutating the pane on its way out. All halves of the
+// tap must be consumed together.
+//
+// The boundary is the tap, not the chunk: an EARLIER tap batched into the same
+// read is a separate keypress and stays subject to #975's rule that batched
+// leading input is forwarded rather than swallowed.
+func TestTrailingDetachKeyLen_BatchedEventTypes(t *testing.T) {
+	withDetachKey(t, 23, "ctrl-w")
+
+	const (
+		press   = "\x1b[119;5:1u"
+		repeat  = "\x1b[119;5:2u"
+		release = "\x1b[119;5:3u"
+	)
+
+	for _, tc := range []struct {
+		name string
+		in   string
+		want int
+	}{
+		{"one tap: press and release are swallowed together", press + release, len(press + release)},
+		{"held key: press, repeats and release are one tap", press + repeat + repeat + release, len(press + repeat + repeat + release)},
+		{"typed input before a tap is still forwarded", "abc" + press + release, len(press + release)},
+
+		// Two distinct taps in one read: only the last is swallowed, so the first
+		// reaches the agent as input exactly as the legacy double-tap does (#975).
+		{"earlier tap is forwarded, not swallowed", press + release + press + release, len(press + release)},
+
+		// A press arriving alone detaches on its own; the release lands after the
+		// stdin pump is gone. Nothing to walk back over.
+		{"lone press", press, len(press)},
+		{"lone release", release, len(release)},
+
+		// The walk-back must not reach past a sequence that is not this key.
+		{"different key before the tap is forwarded", "\x1b[120;5:1u" + press + release, len(press + release)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := trailingDetachKeyLen([]byte(tc.in)); got != tc.want {
+				t.Fatalf("trailingDetachKeyLen(%q) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
 }

--- a/docs/tui-manual-testing.md
+++ b/docs/tui-manual-testing.md
@@ -109,6 +109,12 @@ just the legacy control byte: an agent CLI that turns on the kitty keyboard
 protocol or `modifyOtherKeys` makes the terminal send `Ctrl-W` as an escape
 sequence instead (#1832). `af_detach` takes an optional raw sequence so a
 scenario can drive those encodings without that terminal.
+
+Detaching also drops those negotiated modes back to legacy, so the terminal you
+land back in reports `Ctrl` keys normally again. On a real kitty terminal this is
+the check the driver cannot make for you: attach to a claude session, detach, and
+confirm `Ctrl-]` and friends still work in the TUI — a terminal left upgraded
+needs a manual reset to recover.
 `←`/`→` switch panes only when a workspace pane has focus; with tree focus they
 keep the tree's collapse/expand behavior.
 

--- a/scripts/tui-driver-selftest.sh
+++ b/scripts/tui-driver-selftest.sh
@@ -321,6 +321,14 @@ step "attach full-screen (#1832 modifyOtherKeys encoding)"  af_attach
 step "detach via the modifyOtherKeys ctrl+w encoding (#1832)" af_detach $'\e[27;5;119~'
 step "assert selection survived the encoded detaches (#1832)" af_expect_selected beta
 
+# A pane program that also turns on kitty's event-type reporting makes ONE tap of
+# ctrl+w report twice — a press then a release — which a single read batches. Both
+# halves are the same keypress, so the tap must detach and must not leak its press
+# half into the pane on the way out.
+step "attach full-screen (batched kitty press+release tap)" af_attach
+step "detach via a batched press+release ctrl+w tap"        af_detach $'\e[119;5:1u\e[119;5:3u'
+step "assert selection survived the batched tap"            af_expect_selected beta
+
 # --- #1822 regression: af_hide_pane across the multi-pane and single-pane flows ---
 # Runs last: it deliberately ends with an empty workspace.
 step "hide a pane while another remains, then the last (#1822)" _expect_multipane_hide

--- a/session/tmux/terminal_restore.go
+++ b/session/tmux/terminal_restore.go
@@ -31,6 +31,17 @@ package tmux
 // and idempotent, and it clobbers nothing — bubbletea v1 does not speak the
 // kitty protocol, and the TUI re-asserts its own modes afterwards regardless.
 //
+// They are zeroed on BOTH sides of the 1049l switch because the kitty spec
+// mandates it: "Terminals must maintain separate stacks for the main and
+// alternate screens", so that an editor can change the mode on the alt screen
+// "without affecting the mode in the main screen or even knowing what that mode
+// is". Zeroing only the buffer we are leaving therefore fixes nothing for a
+// program that enabled the protocol on the MAIN screen before its 1049h — the
+// main buffer stays enhanced across the switch back and Ctrl keys keep arriving
+// as CSI sequences, which is the whole bug. modifyOtherKeys is re-issued
+// alongside it for the same defensive reason the scroll region is: it costs six
+// bytes and no spec promises us it is screen-independent everywhere.
+//
 // It is deliberately caller-agnostic: it serves the TUI (which re-asserts its own
 // bubbletea modes afterwards — see app.attachOverlayCallback) and the plain
 // `af sessions attach` CLI (for which this neutral state is exactly right).
@@ -39,20 +50,23 @@ package tmux
 //
 // Order matters: reporting modes off first (so nothing new arrives while we
 // restore), then keyboard modes, then geometry, then the buffer switch, and
-// finally cosmetics on the buffer we land on. The scroll region is reset on both
-// sides of the 1049l switch because emulators disagree on whether DECSTBM margins
-// are shared or per-buffer.
+// finally cosmetics on the buffer we land on. The scroll region and the keyboard
+// modes are reset on both sides of the 1049l switch — the scroll region because
+// emulators disagree on whether DECSTBM margins are shared or per-buffer, the
+// keyboard modes because kitty specifies them as per-screen.
 const NeutralTerminalRestore = "" +
 	"\x1b[?1003l\x1b[?1002l\x1b[?1000l" + // all mouse tracking variants off
 	"\x1b[?1015l\x1b[?1006l\x1b[?1005l" + // all mouse encoding extensions off
 	"\x1b[?1004l" + // focus reporting off
 	"\x1b[?2004l" + // bracketed paste off
-	"\x1b[=0;1u" + // kitty keyboard protocol: all enhancement flags off
+	"\x1b[=0;1u" + // kitty keyboard protocol off (this buffer's stack)
 	"\x1b[>4;0m" + // xterm modifyOtherKeys off
 	"\x1b[?1l\x1b>" + // cursor keys and keypad back to normal mode
 	"\x1b[?7h" + // autowrap back on (xterm default)
 	"\x1b[r" + // scroll region = full screen (current buffer)
 	"\x1b[?1049l" + // back to the main screen buffer (no-op if already there)
 	"\x1b[r" + // scroll region again on the main buffer
+	"\x1b[=0;1u" + // kitty keyboard protocol off again: the main buffer has its own stack
+	"\x1b[>4;0m" + // modifyOtherKeys again, in case it too is per-buffer
 	"\x1b[0m" + // SGR attributes reset
 	"\x1b[?25h" // cursor visible

--- a/session/tmux/terminal_restore.go
+++ b/session/tmux/terminal_restore.go
@@ -3,7 +3,7 @@ package tmux
 // NeutralTerminalRestore is written to stdout after an interactive raw-PTY
 // stream ends, returning the terminal to the neutral state a well-behaved
 // full-screen program leaves behind on exit: main screen, cursor visible, no
-// scroll region, no mouse/focus/paste reporting.
+// scroll region, no mouse/focus/paste reporting, and legacy keyboard encoding.
 //
 // A raw attach stream — the remote hook's attach_cmd PTY, or (since #1592 Phase
 // 2 PR7) the local session's clientless WS PTY stream — is copied byte-for-byte
@@ -14,6 +14,22 @@ package tmux
 // resets those modes — a caller that then repaints into the terminal inherits a
 // stale scroll region and screen buffer, the "messed up UI until I resize" of
 // #845. Both drivers write this on every exit path.
+//
+// The keyboard-encoding modes matter for the same reason and were missed until
+// #1833 made them reachable: a modern agent CLI negotiates the kitty keyboard
+// protocol or xterm modifyOtherKeys at startup (see apiclient/detachkey.go), and
+// the raw stream sets those on the REAL terminal. Until #1833 the detach key was
+// unrecognizable in those modes, so this path was never reached from an upgraded
+// terminal; now that detach works there, leaving the modes set would hand the
+// user back a terminal that still reports Ctrl keys as escape sequences — host
+// shortcuts like Ctrl-] break until a manual reset.
+//
+// The kitty flags are forced to zero rather than popped: the pane program may
+// have pushed any number of stack entries, or used the set form and pushed none,
+// so there is no pop depth that is right in every case, and an over-pop would
+// discard a saved entry we never pushed. Zeroing the flags is depth-independent
+// and idempotent, and it clobbers nothing — bubbletea v1 does not speak the
+// kitty protocol, and the TUI re-asserts its own modes afterwards regardless.
 //
 // It is deliberately caller-agnostic: it serves the TUI (which re-asserts its own
 // bubbletea modes afterwards — see app.attachOverlayCallback) and the plain
@@ -31,6 +47,8 @@ const NeutralTerminalRestore = "" +
 	"\x1b[?1015l\x1b[?1006l\x1b[?1005l" + // all mouse encoding extensions off
 	"\x1b[?1004l" + // focus reporting off
 	"\x1b[?2004l" + // bracketed paste off
+	"\x1b[=0;1u" + // kitty keyboard protocol: all enhancement flags off
+	"\x1b[>4;0m" + // xterm modifyOtherKeys off
 	"\x1b[?1l\x1b>" + // cursor keys and keypad back to normal mode
 	"\x1b[?7h" + // autowrap back on (xterm default)
 	"\x1b[r" + // scroll region = full screen (current buffer)

--- a/session/tmux/terminal_restore_test.go
+++ b/session/tmux/terminal_restore_test.go
@@ -30,17 +30,51 @@ func TestNeutralTerminalRestore_ResetsKeyboardEncoding(t *testing.T) {
 	}
 }
 
+// TestNeutralTerminalRestore_ResetsKeyboardOnBothBuffers is the per-screen half.
+// The kitty spec is explicit — "Terminals must maintain separate stacks for the
+// main and alternate screens", precisely so an alt-screen editor can change the
+// mode "without affecting the mode in the main screen".
+//
+// So a reset written only before `?1049l` zeroes the buffer we are LEAVING. A
+// pane program that turned the protocol on while still on the main screen (before
+// its own `?1049h`) leaves the main buffer enhanced, and switching back to it
+// restores that state: Ctrl keys keep arriving as CSI sequences on the buffer the
+// user is actually left looking at. Resetting the alt screen we are abandoning
+// fixes nothing there. The reset has to happen on both sides of the switch.
+func TestNeutralTerminalRestore_ResetsKeyboardOnBothBuffers(t *testing.T) {
+	switchIdx := strings.Index(NeutralTerminalRestore, "\x1b[?1049l")
+	if switchIdx < 0 {
+		t.Fatal("restore is missing the main-buffer switch")
+	}
+	for _, tc := range []struct{ esc, what string }{
+		{"\x1b[=0;1u", "kitty keyboard flags"},
+		{"\x1b[>4;0m", "modifyOtherKeys"},
+	} {
+		before := strings.Index(NeutralTerminalRestore, tc.esc)
+		after := strings.LastIndex(NeutralTerminalRestore, tc.esc)
+		if before < 0 || before > switchIdx {
+			t.Errorf("%s (%q) must be reset before the ?1049l switch, on the buffer being left",
+				tc.what, tc.esc)
+		}
+		if after <= switchIdx {
+			t.Errorf("%s (%q) must ALSO be reset after the ?1049l switch: the main screen "+
+				"keeps its own stack, so a program that enabled the protocol there before "+
+				"its ?1049h leaves it enhanced across the switch back", tc.what, tc.esc)
+		}
+	}
+}
+
 // TestNeutralTerminalRestore_Ordering pins the ordering contract the constant's
 // doc comment states, since the sequences are only correct as a sequence:
 // reporting modes go quiet first so nothing new arrives mid-restore, then the
-// keyboard encoding drops to legacy, and only then the screen buffer switches
-// back — a mode reset written after 1049l would land on the wrong buffer in
-// emulators that scope modes per buffer.
+// keyboard encoding drops to legacy on the buffer being left, and only then the
+// screen buffer switches back.
 func TestNeutralTerminalRestore_Ordering(t *testing.T) {
 	for _, tc := range []struct{ first, then, why string }{
 		{"\x1b[?2004l", "\x1b[=0;1u", "reporting modes go quiet before the keyboard encoding changes"},
 		{"\x1b[=0;1u", "\x1b[?1l", "the kitty flags drop before cursor-key mode is normalized"},
 		{"\x1b[>4;0m", "\x1b[?1049l", "keyboard modes are reset before the buffer switch"},
+		{"\x1b[?1049l", "\x1b[0m", "cosmetics are applied to the buffer we land on"},
 	} {
 		i, j := strings.Index(NeutralTerminalRestore, tc.first), strings.Index(NeutralTerminalRestore, tc.then)
 		if i < 0 || j < 0 {

--- a/session/tmux/terminal_restore_test.go
+++ b/session/tmux/terminal_restore_test.go
@@ -1,0 +1,53 @@
+package tmux
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestNeutralTerminalRestore_ResetsKeyboardEncoding pins the half of the neutral
+// restore that #1833 made reachable. A modern agent CLI negotiates the kitty
+// keyboard protocol and/or xterm modifyOtherKeys at startup, and the raw attach
+// proxy sets those modes on the REAL terminal. Until #1833 the detach key was
+// unrecognizable in those modes — the user could not leave the attach at all —
+// so this restore never ran from an upgraded terminal and the omission was
+// invisible.
+//
+// Now that an encoded detach works, restoring everything EXCEPT the keyboard
+// encoding hands the user back a terminal that still reports Ctrl keys as escape
+// sequences: host shortcuts like Ctrl-] break until a manual reset. The neutral
+// state this constant promises includes legacy keyboard reporting.
+func TestNeutralTerminalRestore_ResetsKeyboardEncoding(t *testing.T) {
+	for _, tc := range []struct{ esc, what string }{
+		{"\x1b[=0;1u", "zero the kitty keyboard progressive-enhancement flags"},
+		{"\x1b[>4;0m", "turn xterm modifyOtherKeys off"},
+	} {
+		if !strings.Contains(NeutralTerminalRestore, tc.esc) {
+			t.Errorf("neutral restore must %s (%q): a pane program can leave the real "+
+				"terminal in that mode, and after #1833 the detach that lands the user "+
+				"back here no longer resets it", tc.what, tc.esc)
+		}
+	}
+}
+
+// TestNeutralTerminalRestore_Ordering pins the ordering contract the constant's
+// doc comment states, since the sequences are only correct as a sequence:
+// reporting modes go quiet first so nothing new arrives mid-restore, then the
+// keyboard encoding drops to legacy, and only then the screen buffer switches
+// back — a mode reset written after 1049l would land on the wrong buffer in
+// emulators that scope modes per buffer.
+func TestNeutralTerminalRestore_Ordering(t *testing.T) {
+	for _, tc := range []struct{ first, then, why string }{
+		{"\x1b[?2004l", "\x1b[=0;1u", "reporting modes go quiet before the keyboard encoding changes"},
+		{"\x1b[=0;1u", "\x1b[?1l", "the kitty flags drop before cursor-key mode is normalized"},
+		{"\x1b[>4;0m", "\x1b[?1049l", "keyboard modes are reset before the buffer switch"},
+	} {
+		i, j := strings.Index(NeutralTerminalRestore, tc.first), strings.Index(NeutralTerminalRestore, tc.then)
+		if i < 0 || j < 0 {
+			t.Fatalf("restore is missing %q or %q", tc.first, tc.then)
+		}
+		if i > j {
+			t.Errorf("%q must come before %q: %s", tc.first, tc.then, tc.why)
+		}
+	}
+}


### PR DESCRIPTION
#1833 merged before its codex review arrived. All six inline comments (five
distinct findings — the keyboard-mode reset was filed twice, on `attach.go:191`
and `attach.go:195`) were triaged against current master. **All five reproduce**;
none were stale. No commit has touched these files since the merge, so the code
reviewed is the code shipped.

Every finding is a way the detach path still misbehaves once a pane program has
upgraded the terminal's keyboard encoding — the #1832 class #1833 opened up but
did not finish.

## P1 — the terminal is left upgraded after detach

`NeutralTerminalRestore` resets mouse/focus/paste/cursor/keypad but never the
kitty CSI-u flags or xterm `modifyOtherKeys`. This was invisible until now:
before #1833 the detach key was unrecognizable in those modes, so the restore
was unreachable from an upgraded terminal. Now that an encoded detach works, it
hands the user back a terminal still reporting Ctrl keys as escape sequences —
`Ctrl-]` and friends break until a manual `reset`.

The flags are **zeroed, not popped**. The pane may have pushed any number of
stack entries, or used the set form and pushed none, so no pop depth is right in
every case and an over-pop would discard an entry we never pushed. Zeroing is
depth-independent and idempotent, and clobbers nothing: bubbletea v1.3.5 does not
speak the kitty protocol, and the TUI re-asserts its own modes afterwards.

They are zeroed on **both sides of the `?1049l` switch**, because the kitty spec
mandates it: *"Terminals must maintain separate stacks for the main and alternate
screens"*, precisely so an alt-screen editor can change the mode *"without
affecting the mode in the main screen"*. Resetting only before the switch zeroes
the buffer being **left** — a pane program that enabled the protocol on the main
screen before its own `?1049h` leaves the main buffer enhanced across the switch
back, which is the whole stuck-terminal bug. The scroll region already resets on
both sides for a weaker reason (emulators disagree); this one is specified.

## P2 — a batched tap leaks its press half into the pane

With kitty's event-type flag on, one `Ctrl-W` tap reports twice (`…5:1u` press,
then `…5:3u` release) and a single read batches both. The suffix test saw only
the release and forwarded the press to the agent — the supposedly swallowed
detach key still word-erasing the pane on its way out.

The walk-back consumes the whole tap and stops at its press. The boundary is the
tap, not the chunk: an *earlier* tap is a separate keypress and stays subject to
#975's rule that batched leading input is forwarded rather than swallowed.

## P2 — `ctrl-[` could not detach when encoded

Byte 27 is Esc, which is why the **legacy** match cannot tell them apart (and a
`ctrl-[` user accepts that bare Esc detaches). The encoded forms have no such
ambiguity: kitty reports the physical `Ctrl+[` as `CSI 91;5u` and bare Esc as
`CSI 27u`. Matching `'['` detaches the real binding without ever hijacking the
Esc the agent needs. The original comment's reasoning held for the legacy byte
and was over-applied to the encoded path.

## P2 — `ctrl-^` and `ctrl-_` could not detach when encoded

Both need shift to type on a US layout (`Ctrl+Shift+6`, `Ctrl+Shift+-`), and
kitty reports the unshifted key code with the shift bit — never codepoint 94/95
with ctrl alone, which is all `ctrlOnly` accepted.

The shift rule belongs to the **code, not the binding**. The character code
(`'_'`, `'^'`) is *optional*-shift: modifyOtherKeys reports it with shift, and a
layout where underscore is a base key reports it without. The unshifted physical
key (`'-'`, `'6'`) is *required*-shift: it only produces the binding's character
when shifted, so plain `Ctrl+-` is a distinct keypress (font-size shortcuts live
there) that must reach the pane rather than detach. Letters and `\` `]` stay
shift-*forbidden* — `ctrl+shift+w` is still not `ctrl-w`, and there is a new
guard for `ctrl+shift+]`.

## P2 — alternate-key subparams were dropped

`csiParams` truncated at the first colon, so with kitty's report-alternate-keys
flag on, a Cyrillic-layout user's `ctrl+w` arrives as `CSI 1094::119;5u` and 119
exists **only** in the base-layout slot. Params now keep their subfields and any
slot naming the key counts. No false-positive surface: the shifted slot is only
present when shift is in the modifiers (which ctrl-only bindings already reject),
and a base-layout slot of `119` means the physical key *is* `w`.

## Shape of the fix

Matching is now a small set of (key code, shift rule) pairs per binding rather
than a single codepoint, because the C0 byte a binding parses to is not what an
upgraded terminal reports — for `ctrl-^` the key and the modifier come apart
entirely, and each code needs its own shift rule to stay distinct from the key
next to it. That is `detachKeyEncodingFor`, and it is what makes the `ctrl-[`
and `ctrl-^`/`ctrl-_` findings one change rather than two special cases.

## Tests

Regression coverage per accepted finding, and **each new test was verified to
fail against the pre-fix logic** rather than pass vacuously — disabling the
walk-back reproduces codex's exact claim:

> the press half of the detach tap leaked to the agent as INPUT `"\x1b[119;5:1u"`

- `apiclient/detachkey_test.go` — encoded `ctrl-[` vs. bare Esc; `ctrl-^`/`ctrl-_`
  shifted physical encodings, with negative cases for ctrl+alt, neighbouring keys,
  and **unshifted `Ctrl+-` / `Ctrl+6` forwarding rather than detaching**;
  base-layout alternates; every event type.
- `apiclient/detachkey_test.go` — batched press/release/repeat taps, including
  the two-tap case that must still forward the first (#975).
- `apiclient/attach_test.go` — driver-level proof the press half never reaches
  the agent: the first frame after a batched tap must be the detach.
- `session/tmux/terminal_restore_test.go` — the restore drops both keyboard
  modes, on **both buffers**, in an order that survives the switch.
- `scripts/tui-driver-selftest.sh` — a batched press+release tap detaches.

Docs note the one claim the driver cannot check for you: on a real kitty
terminal, Ctrl keys must still work in the TUI after detaching from claude.

## Gates

`make test-container` ✅ · `make tui-driver-selftest` ✅ · `go build ./...` ✅ ·
`gofmt -l .` ✅ · `golangci-lint run --timeout=3m --fast` ✅ · `deadcode -test ./...` ✅ ·
`scripts/lint-file-length.sh` ✅

Web gates skipped — no web files touched.

Closes the #1833 review. Not merging; flagging for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
