### PR TITLE
fix: post-merge codex findings on #1845

### DIFF
--- a/agentproto/frame.go
+++ b/agentproto/frame.go
@@ -31,16 +31,25 @@ const (
 	// is not part of the shared ring's monotonic seq, so counting it would desync the
 	// ?since arithmetic.
 	OpRepaint Opcode = 0x03
-	// OpHello (server → client) is the FIRST frame on every new subscription: an
-	// 8-byte big-endian uint64 carrying the subscription's starting seq. It delivers
-	// in-band the same value the X-Af-Stream-Seq handshake header carries, because a
-	// browser WebSocket cannot read 101-handshake response headers and so cannot
-	// otherwise learn its absolute cursor to seed ?since replay (#1592 Phase 5 PR1,
-	// design §4.3). It carries no PTY bytes and is NOT counted toward the replay
-	// cursor. Strictly additive: appended after OpRepaint, existing ops unchanged.
-	// Stream consumers that don't handle it (the TUI/apiclient path) ignore it — the
-	// opcode decodes cleanly, so ReadMessage never errors and their frame switch
-	// simply skips it (unknown-op tolerance without any client change).
+	// OpHello (server → client) carries the subscription's AUTHORITATIVE output
+	// cursor: an 8-byte big-endian uint64 the client adopts verbatim as its replay
+	// cursor. It is the FIRST frame on every new subscription, delivering in-band the
+	// same value the X-Af-Stream-Seq handshake header carries, because a browser
+	// WebSocket cannot read 101-handshake response headers and so cannot otherwise
+	// learn its absolute cursor to seed ?since replay (#1592 Phase 5 PR1, design
+	// §4.3).
+	//
+	// The server ALSO re-sends it mid-stream whenever it moves that cursor
+	// non-contiguously — a ring eviction or the #1840 recovery discard fast-forwarding
+	// the subscriber over bytes that no longer exist (session.PTYCursor). A client
+	// derives its cursor as start + bytes-received, which cannot see a server-side
+	// jump; left unannounced, its next reconnect asks for a ?since below the broker's
+	// base, gets clamped back up, and is re-sent bytes it already rendered (duplicated
+	// output). So a client MUST treat every hello as "your cursor is now exactly this",
+	// not as a one-shot greeting.
+	//
+	// It carries no PTY bytes and is NOT itself counted toward the replay cursor.
+	// Strictly additive: appended after OpRepaint, existing ops unchanged.
 	OpHello Opcode = 0x04
 )
 

--- a/app/live_stream.go
+++ b/app/live_stream.go
@@ -69,8 +69,9 @@ func streamDialer(title, repoID, tabID string, tab int) termpane.Dialer {
 }
 
 // apiStream adapts an apiclient.StreamConn to termpane.Stream using agentproto's
-// codec: PTY_OUT binary frames become EventData, the authoritative resize control
-// frame becomes EventResize, and INPUT/RESIZE go out as binary frames.
+// codec: PTY_OUT binary frames become EventData, HELLO becomes EventCursor, the
+// authoritative resize control frame becomes EventResize, and INPUT/RESIZE go out as
+// binary frames.
 type apiStream struct {
 	sc *apiclient.StreamConn
 }
@@ -94,6 +95,12 @@ func (s *apiStream) Recv(ctx context.Context) (termpane.Event, error) {
 				return termpane.Event{Kind: termpane.EventData, Data: msg.Frame.Data}, nil
 			case agentproto.OpRepaint:
 				return termpane.Event{Kind: termpane.EventRepaint, Data: msg.Frame.Data}, nil
+			case agentproto.OpHello:
+				// The server's authoritative cursor. The opening hello merely restates the
+				// X-Af-Stream-Seq header the pane already adopted (harmlessly idempotent);
+				// a MID-STREAM one is load-bearing — it reports a jump the server made over
+				// evicted/discarded bytes, which our byte-counting cursor cannot see.
+				return termpane.Event{Kind: termpane.EventCursor, Seq: msg.Frame.Seq}, nil
 			}
 			continue // INPUT/RESIZE are client→server; ignore any echoed back
 		}

--- a/daemon/ws_pty.go
+++ b/daemon/ws_pty.go
@@ -314,6 +314,14 @@ func writePTYStream(ctx context.Context, sub session.PTYSubscription, conn *webs
 			err = agentproto.WriteFrame(wctx, conn, agentproto.PTYOutFrame(ev.Data))
 		case session.PTYRepaint:
 			err = agentproto.WriteFrame(wctx, conn, agentproto.RepaintFrame(ev.Data))
+		case session.PTYCursor:
+			// The broker fast-forwarded this subscriber over bytes that no longer exist
+			// (a ring eviction or the #1840 recovery discard). Re-seed the client's
+			// cursor with the same OpHello frame the subscription opened with, so its
+			// next ?since matches the server's true position instead of the stale
+			// start + bytes-received arithmetic (which would replay already-rendered
+			// bytes on reconnect — the #1845 follow-up).
+			err = agentproto.WriteFrame(wctx, conn, agentproto.HelloFrame(uint64(ev.Seq)))
 		case session.PTYResize:
 			err = agentproto.WriteControl(wctx, conn, agentproto.NewResizeMessage(ev.Rows, ev.Cols))
 		}

--- a/integration/ws_pty_test.go
+++ b/integration/ws_pty_test.go
@@ -164,15 +164,21 @@ func TestWSPTYSessionKillEmitsExit(t *testing.T) {
 // wsClient is a test subscriber: a coder/websocket connection with a read pump
 // accumulating PTY_OUT bytes and resize echoes.
 type wsClient struct {
-	conn    *websocket.Conn
-	baseSeq uint64
-	ctx     context.Context
-	cancel  context.CancelFunc
+	conn   *websocket.Conn
+	ctx    context.Context
+	cancel context.CancelFunc
 
 	mu      sync.Mutex
 	out     []byte
 	resizes []agentproto.ResizeMessage
 	exited  bool
+	// cursor is the absolute replay cursor, tracked the way a real client tracks it
+	// (ui/termpane, web/src/terminal.ts): seeded from the handshake seq, ADOPTED from
+	// every HELLO frame, and advanced by each PTY_OUT byte. Deliberately NOT
+	// handshake+len(out): the server re-seeds mid-stream when it moves the cursor over
+	// bytes it discarded, and a client that ignored that would reconnect on a stale
+	// ?since and be re-sent bytes it already rendered (the #1845 follow-up).
+	cursor uint64
 }
 
 // dialWS opens a subscriber and starts its read pump.
@@ -180,7 +186,7 @@ func (h *harness) dialWS(t *testing.T, path string) *wsClient {
 	t.Helper()
 	conn, base := h.dialWSConn(t, path)
 	ctx, cancel := context.WithCancel(context.Background())
-	c := &wsClient{conn: conn, baseSeq: base, ctx: ctx, cancel: cancel}
+	c := &wsClient{conn: conn, cursor: base, ctx: ctx, cancel: cancel}
 	go c.readPump()
 	return c
 }
@@ -191,7 +197,7 @@ func (h *harness) dialWSRaw(t *testing.T, path string) *wsClient {
 	t.Helper()
 	conn, base := h.dialWSConn(t, path)
 	ctx, cancel := context.WithCancel(context.Background())
-	return &wsClient{conn: conn, baseSeq: base, ctx: ctx, cancel: cancel}
+	return &wsClient{conn: conn, cursor: base, ctx: ctx, cancel: cancel}
 }
 
 func (h *harness) dialWSConn(t *testing.T, path string) (*websocket.Conn, uint64) {
@@ -218,8 +224,15 @@ func (c *wsClient) readPump() {
 		}
 		c.mu.Lock()
 		if msg.Binary {
-			if msg.Frame.Op == agentproto.OpPTYOut {
+			switch msg.Frame.Op {
+			case agentproto.OpPTYOut:
 				c.out = append(c.out, msg.Frame.Data...)
+				c.cursor += uint64(len(msg.Frame.Data))
+			case agentproto.OpHello:
+				// The server's authoritative cursor — the opening seed, or a mid-stream
+				// re-seed announcing that it moved us over bytes it discarded. Adopt it
+				// verbatim; our own byte count cannot see that jump.
+				c.cursor = msg.Frame.Seq
 			}
 		} else if typ, _ := agentproto.MessageTypeOf(msg.Text); typ == agentproto.MsgResize {
 			var rm agentproto.ResizeMessage
@@ -265,12 +278,13 @@ func (c *wsClient) sawExit() bool {
 	return c.exited
 }
 
-// sinceCursor is the absolute seq this client has consumed: its handshake base
-// seq plus every output byte it has received.
+// sinceCursor is the absolute seq this client has consumed — what it would send as
+// ?since on reconnect. See wsClient.cursor for why it is tracked rather than derived
+// from len(out).
 func (c *wsClient) sinceCursor() uint64 {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return c.baseSeq + uint64(len(c.out))
+	return c.cursor
 }
 
 func (c *wsClient) lastResize() (agentproto.ResizeMessage, bool) {

--- a/session/agentserver.go
+++ b/session/agentserver.go
@@ -220,10 +220,20 @@ const (
 	// subscriber, mapped to an OpRepaint frame — rendered like output but NOT
 	// counted toward the client's replay cursor (it is not part of the ring seq).
 	PTYRepaint
+	// PTYCursor carries this subscription's authoritative cursor (Seq) after the
+	// SERVER moved it non-contiguously — a ring eviction, or the #1840 recovery
+	// discard, fast-forwarded the subscriber over bytes that no longer exist. A
+	// client derives its own replay cursor as start + bytes-received, which silently
+	// desyncs across such a jump: it would then reconnect with a ?since BELOW the
+	// broker's base, get clamped back up, and be re-sent bytes it already rendered
+	// (duplicated output). Mapped to an OpHello frame — the same in-band cursor seed
+	// the subscription opens with — so the client re-seeds instead of counting on.
+	// Carries no PTY bytes and is not itself part of the ring seq.
+	PTYCursor
 )
 
-// PTYEvent is one event delivered to a subscriber: either output bytes or the
-// authoritative resize echo, selected by Kind.
+// PTYEvent is one event delivered to a subscriber: output bytes, the authoritative
+// resize echo, a screen repaint, or a cursor re-seed, selected by Kind.
 type PTYEvent struct {
 	Kind PTYEventKind
 	// Data is the verbatim PTY output, valid only when Kind == PTYData.
@@ -231,4 +241,7 @@ type PTYEvent struct {
 	// Rows/Cols are the authoritative size, valid only when Kind == PTYResize.
 	Rows uint16
 	Cols uint16
+	// Seq is the subscription's authoritative output cursor, valid only when
+	// Kind == PTYCursor.
+	Seq Seq
 }

--- a/session/ptybroker.go
+++ b/session/ptybroker.go
@@ -143,30 +143,43 @@ func (b *ptyBroker) subscribe(since Seq) (*ptySub, error) {
 		return nil, fmt.Errorf("pty broker closed")
 	}
 	head := b.headLocked()
-	cursor := since
-	// since == 0 means "from the live tail" (the documented default); a real
-	// replay cursor is clamped into the retained window [base, head].
-	if cursor == 0 || cursor > head {
-		cursor = head
-	}
-	if cursor < b.base {
-		cursor = b.base
-	}
-	// A repaint is owed when the stream CANNOT rebuild this client's screen from
-	// `cursor` alone: a fresh subscriber (since == 0 — pipe-pane carries no history),
-	// or a reconnect asking for bytes BELOW the retained window, which are provably
-	// gone (#1845 follow-up). The second case is the post-recovery reconnect: the
-	// recovery discard drops the dead pane's ring and advances base past the cursor the
-	// client left on, so the replay it asked for cannot be served. Clamping it up to
-	// base silently would hand it neither the replay nor a repaint — leaving the
-	// pre-death screen frozen on-screen until some unrelated later output arrives. A
-	// ring eviction reaches this the same way, and wants the same repaint.
+	// A repaint is owed when a ring replay CANNOT rebuild this client's screen: a fresh
+	// subscriber (since == 0 — pipe-pane carries no history), or a reconnect asking for
+	// bytes BELOW the retained window, which are provably gone (#1845 follow-up). The
+	// second case is the post-recovery reconnect: the recovery discard drops the dead
+	// pane's ring and advances base past the cursor the client left on, so the replay it
+	// asked for cannot be served — without a repaint its pre-death screen stays frozen
+	// until some unrelated later output arrives. A ring eviction reaches this the same
+	// way, and wants the same repaint.
 	//
 	// Deliberately NOT keyed on "cursor was clamped at all": a `since` PAST head also
 	// clamps (down, to the live tail), but that client is not missing any byte the
 	// broker holds, and repainting it would add flicker to the documented
 	// clamp-to-tail path. Only a cursor below base means bytes are missing.
 	needRepaint := since == 0 || since < b.base
+	var cursor Seq
+	if needRepaint {
+		// Start at the live tail, NOT at base. The repaint below reconstructs the WHOLE
+		// current screen, so every retained ring byte [base, head) is ALREADY baked into
+		// it. Starting the replay at base would make NextEvent send the repaint and THEN
+		// replay those same bytes on top of it — duplicating output: a command/prompt
+		// appended twice, up to the entire retained ring on an eviction or post-recovery
+		// reconnect (#1872 P1). The tail cursor is exactly what a since == 0 fresh
+		// subscriber already gets; the two paths now share it. Bytes fed between this head
+		// read and the snapshot below land in both the snapshot and the replayed tail —
+		// the same tiny, bounded double-render a fresh subscribe already accepts — never
+		// dropped. The client learns this cursor from the handshake seq / OpHello, so its
+		// ?since stays consistent.
+		cursor = head
+	} else {
+		// A seamless reconnect: since is inside the retained window, so the client's
+		// screen is current up to `since` and replaying [since, head) brings it forward
+		// with no repaint flicker. A since past head clamps down to the live tail.
+		cursor = since
+		if cursor > head {
+			cursor = head
+		}
+	}
 	b.nextSubID++
 	sub := &ptySub{
 		br:         b,

--- a/session/ptybroker.go
+++ b/session/ptybroker.go
@@ -152,6 +152,21 @@ func (b *ptyBroker) subscribe(since Seq) (*ptySub, error) {
 	if cursor < b.base {
 		cursor = b.base
 	}
+	// A repaint is owed when the stream CANNOT rebuild this client's screen from
+	// `cursor` alone: a fresh subscriber (since == 0 — pipe-pane carries no history),
+	// or a reconnect asking for bytes BELOW the retained window, which are provably
+	// gone (#1845 follow-up). The second case is the post-recovery reconnect: the
+	// recovery discard drops the dead pane's ring and advances base past the cursor the
+	// client left on, so the replay it asked for cannot be served. Clamping it up to
+	// base silently would hand it neither the replay nor a repaint — leaving the
+	// pre-death screen frozen on-screen until some unrelated later output arrives. A
+	// ring eviction reaches this the same way, and wants the same repaint.
+	//
+	// Deliberately NOT keyed on "cursor was clamped at all": a `since` PAST head also
+	// clamps (down, to the live tail), but that client is not missing any byte the
+	// broker holds, and repainting it would add flicker to the documented
+	// clamp-to-tail path. Only a cursor below base means bytes are missing.
+	needRepaint := since == 0 || since < b.base
 	b.nextSubID++
 	sub := &ptySub{
 		br:         b,
@@ -173,14 +188,15 @@ func (b *ptyBroker) subscribe(since Seq) (*ptySub, error) {
 		return nil, err
 	}
 
-	// A fresh subscriber (since == 0, the live tail) gets an initial repaint of the
-	// current screen — pipe-pane only streams future output, so without this a
-	// just-opened pane renders blank until the next byte. A reconnecting client
-	// (since > 0) resumes via ?since replay instead, so it is left seamless.
+	// Paint the current screen for a subscriber the replay stream can't reconstruct
+	// (see needRepaint): a fresh one (pipe-pane only streams FUTURE output, so without
+	// this a just-opened pane renders blank until the next byte) or a reconnect whose
+	// cursor was clamped over discarded bytes. A reconnect that lands inside the
+	// retained window resumes via ?since replay instead, so it is left seamless.
 	// Captured AFTER registration (register-first) so no output can slip in between
 	// the snapshot and the cursor: bytes in that tiny window are simply in both the
 	// snapshot and the replayed tail (a harmless double-render), never dropped.
-	if since == 0 {
+	if needRepaint {
 		if snap, err := b.ch.Snapshot(); err == nil && len(snap.Screen) > 0 {
 			rp := buildRepaint(snap)
 			b.mu.Lock()
@@ -370,7 +386,10 @@ func (b *ptyBroker) resetCapture() {
 	// same mechanism a ring overflow already uses.
 	//
 	// Unconditional, including when nobody is attached: a later Subscribe(since) would
-	// otherwise replay the dead pane's tail into a fresh client.
+	// otherwise replay the dead pane's tail into a fresh client. That no-subscriber path
+	// is why subscribe() repaints a reconnect whose `since` lands below base — the
+	// discard leaves it a cursor that can never be replayed, and with nobody attached
+	// there is no re-seed here to cover it.
 	b.mu.Lock()
 	b.base = b.headLocked()
 	b.buf = nil
@@ -600,7 +619,21 @@ func (s *ptySub) NextEvent(ctx context.Context) (PTYEvent, error) {
 		}
 		head := s.br.headLocked()
 		if s.cursor < s.br.base {
-			s.cursor = s.br.base // fell behind eviction: skip the lost gap
+			// Fell behind eviction, or the #1840 recovery discard dropped the dead pane's
+			// ring: the bytes between the cursor and base provably no longer exist, so
+			// skip the lost gap. TELL the client where its cursor landed (#1845
+			// follow-up) — the jump is the SERVER's, and a client that derives its cursor
+			// as start + bytes-received cannot see it. Left silent, the client keeps
+			// counting from its stale cursor, and its next reconnect asks for a ?since
+			// below base, gets clamped back up, and is re-sent bytes it already rendered
+			// — duplicated output on a screen that was correct. Delivered as its own
+			// event (rather than riding the next PTYData) so the re-seed reaches the
+			// client even when the recovered pane stays silent afterward. The clamp is
+			// idempotent — cursor == base now, so this fires once per jump.
+			s.cursor = s.br.base
+			ev := PTYEvent{Kind: PTYCursor, Seq: s.cursor}
+			s.br.mu.Unlock()
+			return ev, nil
 		}
 		if s.cursor < head {
 			off := int(s.cursor - s.br.base)

--- a/session/ptybroker_recovery_test.go
+++ b/session/ptybroker_recovery_test.go
@@ -391,6 +391,66 @@ func TestPTYBrokerReconnectAfterRecoveryDoesNotReplayRenderedBytes(t *testing.T)
 	}
 }
 
+// TestPTYBrokerReconnectDoesNotReplayBytesTheRepaintAlreadyShows is the codex P1 on
+// #1872: a reconnect owed a repaint must NOT then be replayed the retained ring the
+// repaint already reflects.
+//
+// The #1845 follow-up (repaint when since < base) captures a snapshot of the CURRENT
+// screen — which already reflects every retained ring byte [base, head). If the new
+// subscription still starts its replay at base, NextEvent sends the repaint and THEN
+// hands back [base, head) on top of it, rendering that output twice: a command/prompt
+// appended again, up to the whole retained ring on an eviction or post-recovery
+// reconnect.
+//
+// Fail-before/pass-after: before the fix the reconnect's cursor is clamped to base, so
+// after the repaint it receives the retained tail as PTYData (the duplicate); after the
+// fix the cursor starts at the live tail, so the repaint is the last thing it sees until
+// genuinely new output arrives.
+func TestPTYBrokerReconnectDoesNotReplayBytesTheRepaintAlreadyShows(t *testing.T) {
+	ch := &fakeClientlessChannel{snapshot: []byte("CURRENT-SCREEN")}
+	br := newPTYBroker(ch)
+	br.maxBytes = 4 // tiny ring so base advances past 0 while the ring stays NONEMPTY
+
+	a, err := br.subscribe(0)
+	if err != nil {
+		t.Fatalf("subscribe A: %v", err)
+	}
+	mustRepaintContains(t, a, "CURRENT-SCREEN")
+
+	// Fill then overflow the ring: "AAAA" is evicted by "BBBB", so base advances to 4
+	// while the ring still holds [4,8)="BBBB". A stays attached to keep the capture up.
+	ch.emit(t, []byte("AAAA"))
+	mustData(t, a, "AAAA")
+	ch.emit(t, []byte("BBBB"))
+	mustData(t, a, "BBBB")
+	waitRingHead(t, br, 8)
+
+	// A client reconnects with a cursor BELOW base (it fell far behind): the bytes it
+	// asked for are gone, so it is owed a repaint. The repaint reconstructs the whole
+	// current screen, which already reflects the retained ring — so [4,8) must NOT be
+	// replayed on top of it.
+	b, err := br.subscribe(2) // since = 2 < base = 4, ring nonempty
+	if err != nil {
+		t.Fatalf("reconnect subscribe: %v", err)
+	}
+	// The reconnect starts at the live tail, so its ?since seed is head, not base.
+	if got := b.Seq(); got != 8 {
+		t.Fatalf("reconnect cursor = %d, want 8 (the live tail, so the retained ring is not replayed)", got)
+	}
+	mustRepaintContains(t, b, "CURRENT-SCREEN")
+
+	// No PTYData replay of the retained ring after the repaint.
+	if ev, err := nextWithin(t, b, 250*time.Millisecond); err == nil {
+		t.Fatalf("after the repaint B got Kind=%d Data=%q, want no event: the repaint "+
+			"already reflects the retained ring, so replaying it duplicates output",
+			ev.Kind, ev.Data)
+	}
+
+	// Genuinely new output past the snapshot still streams to the reconnect.
+	ch.emit(t, []byte("CCCC"))
+	mustData(t, b, "CCCC")
+}
+
 // TestPTYBrokerReconnectRepaintsWhenRecoveryDiscardedItsCursor is the second codex P2
 // on the merged #1845: a reconnect whose cursor the recovery discard skipped must be
 // repainted, because it can get no replay.

--- a/session/ptybroker_recovery_test.go
+++ b/session/ptybroker_recovery_test.go
@@ -260,7 +260,20 @@ func TestPTYBrokerRecoveryDoesNotReplayStaleBytes(t *testing.T) {
 	// A repaints the recovered screen...
 	mustRepaintContains(t, a, "SCREEN-AFTER-RECOVERY")
 
-	// ...and must NOT then be handed the dead pane's bytes on top of it.
+	// ...then learns where the discard left its cursor. A was BEHIND at recovery, so
+	// the discard fast-forwarded it over the dead bytes; that jump is the server's and
+	// A's client cannot infer it, so it must be announced (#1845 follow-up) or A's next
+	// reconnect asks to replay bytes it has already rendered.
+	ev, err := nextWithin(t, a, 2*time.Second)
+	if err != nil {
+		t.Fatalf("NextEvent (want the cursor re-seed): %v", err)
+	}
+	if ev.Kind != PTYCursor || ev.Seq != Seq(len(stale)) {
+		t.Fatalf("event = %+v, want PTYCursor Seq=%d (base advanced over the discarded ring)", ev, len(stale))
+	}
+
+	// ...and must NOT be handed the dead pane's bytes on top of the repaint. The
+	// discard dropped them; it did not merely defer them.
 	if ev, err := nextWithin(t, a, 250*time.Millisecond); err == nil {
 		t.Fatalf("after the recovery repaint A got Kind=%d Data=%q, want no event: "+
 			"dead-pane bytes must not overwrite the recovered screen", ev.Kind, ev.Data)
@@ -270,4 +283,165 @@ func TestPTYBrokerRecoveryDoesNotReplayStaleBytes(t *testing.T) {
 	// ring or strand A's cursor above head.
 	ch.emit(t, []byte("post-recovery-output"))
 	mustData(t, a, "post-recovery-output")
+}
+
+// clientCursor models what a REAL client does with the events it receives — the same
+// arithmetic ui/termpane's readStream and web/src/terminal.ts run: adopt the server's
+// cursor whenever it announces one, advance it by each PTYData byte count, and ignore
+// repaints (per-subscriber, outside the ring seq).
+//
+// Modelling it is the point of the tests below: a client knows only what it was TOLD.
+// It cannot see the broker's base/head, so a cursor the SERVER moves without saying so
+// desyncs it silently — and the damage only surfaces one reconnect later, which is
+// exactly why the broker-internal assertions in the other tests missed it.
+type clientCursor struct{ seq Seq }
+
+// applyAll drains every event available within d, folds each into the client's cursor
+// the way a real client would, and returns the PTY bytes the client rendered.
+func (c *clientCursor) applyAll(t *testing.T, sub PTYSubscription, d time.Duration) []byte {
+	t.Helper()
+	var rendered []byte
+	for {
+		ev, err := nextWithin(t, sub, d)
+		if err != nil {
+			return rendered // drained: no event within d
+		}
+		switch ev.Kind {
+		case PTYCursor:
+			c.seq = ev.Seq
+		case PTYData:
+			c.seq += Seq(len(ev.Data))
+			rendered = append(rendered, ev.Data...)
+		}
+	}
+}
+
+// TestPTYBrokerReconnectAfterRecoveryDoesNotReplayRenderedBytes is the first codex P2
+// on the merged #1845: a subscriber that saw post-recovery output and THEN reconnects
+// must not be re-sent the bytes it already rendered.
+//
+// #1845 advances `base` over the discarded dead-pane ring, which fast-forwards a
+// lagging subscriber's server-side cursor through the eviction clamp. That jump is
+// invisible to the client, which derives its own cursor as start + bytes-received: it
+// keeps counting from the pre-recovery value, so its cursor sits BELOW the broker's new
+// base. On reconnect that stale ?since is clamped back up to base and the broker
+// replays post-recovery bytes the client already has — duplicated/corrupt terminal
+// output until something forces a full repaint.
+//
+// Fail-before/pass-after: without the PTYCursor re-seed the client's cursor and the
+// server's diverge by the discarded gap (the first assert), and the reconnect replays
+// POST-RECOVERY-OUTPUT a second time (the last assert).
+func TestPTYBrokerReconnectAfterRecoveryDoesNotReplayRenderedBytes(t *testing.T) {
+	const drain = 250 * time.Millisecond
+	ch := &fakeClientlessChannel{snapshot: []byte("SCREEN-BEFORE-DEATH")}
+	br := newPTYBroker(ch)
+
+	a, err := br.subscribe(0)
+	if err != nil {
+		t.Fatalf("subscribe A: %v", err)
+	}
+	// The client seeds from the opening hello / X-Af-Stream-Seq header, then drains the
+	// initial repaint.
+	client := &clientCursor{seq: a.Seq()}
+	client.applyAll(t, a, drain)
+
+	// A falls behind: its WS write blocked while the dying pane kept producing, so
+	// these bytes sit unread in the ring with A's cursor below head.
+	const stale = "STALE-BYTES-FROM-DEAD-PANE"
+	ch.emit(t, []byte(stale))
+	waitRingHead(t, br, Seq(len(stale)))
+
+	// tmux dies and the daemon re-spawns it: the #1845 discard drops the dead pane's
+	// bytes and advances base over A's cursor.
+	ch.mu.Lock()
+	ch.snapshot = []byte("SCREEN-AFTER-RECOVERY")
+	ch.mu.Unlock()
+	br.resetCapture()
+
+	// A's write unblocks and it drains the recovery repaint + the cursor re-seed.
+	client.applyAll(t, a, drain)
+
+	// The re-spawned pane produces real output, which A receives and renders.
+	const post = "POST-RECOVERY-OUTPUT"
+	ch.emit(t, []byte(post))
+	if got := client.applyAll(t, a, drain); string(got) != post {
+		t.Fatalf("A rendered %q after recovery, want %q", got, post)
+	}
+
+	// The invariant: what the client believes its cursor to be IS what the server knows
+	// it to be. Everything below follows from this.
+	if client.seq != a.Seq() {
+		t.Fatalf("client cursor = %d, server cursor = %d: the recovery jump was never "+
+			"announced, so the client's next ?since is stale by the discarded gap",
+			client.seq, a.Seq())
+	}
+
+	// The user-visible consequence, end to end: A's socket drops and it reconnects with
+	// the cursor it tracked. It has rendered every byte the broker holds, so it must be
+	// handed nothing to replay.
+	_ = a.Close()
+	b, err := br.subscribe(client.seq)
+	if err != nil {
+		t.Fatalf("reconnect subscribe: %v", err)
+	}
+	if ev, err := nextWithin(t, b, drain); err == nil {
+		t.Fatalf("reconnect at cursor %d replayed Kind=%d Data=%q, want no event: the "+
+			"client already rendered those bytes and would render them twice",
+			client.seq, ev.Kind, ev.Data)
+	}
+}
+
+// TestPTYBrokerReconnectRepaintsWhenRecoveryDiscardedItsCursor is the second codex P2
+// on the merged #1845: a reconnect whose cursor the recovery discard skipped must be
+// repainted, because it can get no replay.
+//
+// The path is recovery with NOBODY attached (the last client's keepalive had already
+// lapsed, or it dropped just after `resume` was computed): resetCapture discards the
+// ring and advances base unconditionally, but takes the no-subscriber branch, so no
+// re-seed fans out. The client then reconnects with the cursor it left on — now below
+// base. subscribe clamps it up to base, which yields no replay, and the repaint
+// injection used to be keyed on `since == 0`, so a reconnect got none either. The
+// client is left rendering its pre-death screen until the re-spawned pane happens to
+// emit something on its own.
+//
+// Fail-before/pass-after: before the fix the reconnect receives NO event at all and
+// mustRepaintContains times out.
+func TestPTYBrokerReconnectRepaintsWhenRecoveryDiscardedItsCursor(t *testing.T) {
+	ch := &fakeClientlessChannel{snapshot: []byte("SCREEN-BEFORE-DEATH")}
+	br := newPTYBroker(ch)
+
+	a, err := br.subscribe(0)
+	if err != nil {
+		t.Fatalf("subscribe A: %v", err)
+	}
+	mustRepaintContains(t, a, "SCREEN-BEFORE-DEATH")
+
+	// The client renders some output, so it holds a real (non-zero) replay cursor —
+	// NOT the `since == 0` fresh-subscriber sentinel, which would repaint anyway.
+	ch.emit(t, []byte("seen"))
+	mustData(t, a, "seen")
+	cursor := a.Seq()
+
+	// It then falls behind on bytes it never renders and its socket drops, leaving its
+	// cursor below head. The last subscriber leaving also stops the capture.
+	const unseen = "NEVER-RENDERED"
+	ch.emit(t, []byte(unseen))
+	waitRingHead(t, br, cursor+Seq(len(unseen)))
+	_ = a.Close()
+
+	// tmux dies and is re-spawned while nobody is attached: the discard advances base
+	// past the client's cursor, and there is no subscriber to re-seed.
+	ch.mu.Lock()
+	ch.snapshot = []byte("SCREEN-AFTER-RECOVERY")
+	ch.mu.Unlock()
+	br.resetCapture()
+
+	// The client reconnects on the cursor it left on. The broker cannot serve that
+	// replay — those bytes are gone — so a repaint of the RECOVERED screen is the only
+	// thing that can resync it.
+	b, err := br.subscribe(cursor)
+	if err != nil {
+		t.Fatalf("reconnect subscribe: %v", err)
+	}
+	mustRepaintContains(t, b, "SCREEN-AFTER-RECOVERY")
 }

--- a/session/ptybroker_test.go
+++ b/session/ptybroker_test.go
@@ -535,9 +535,21 @@ func TestPTYBrokerEvictionFastForwards(t *testing.T) {
 		t.Fatalf("subscribe: %v", err)
 	}
 	ch.emit(t, []byte("abcdefgh"))
-	// The ring retains only the last 4 bytes; the cursor fast-forwards past the
-	// lost gap to the oldest retained byte rather than replaying evicted data.
+	// The eviction fast-forwarded this cursor over the lost gap — a jump the SERVER
+	// made, which the client (counting the bytes it received) cannot see. So the gap is
+	// announced as a cursor re-seed BEFORE the retained tail, rather than silently
+	// (#1845 follow-up): a client that kept counting from its stale cursor would
+	// reconnect with a ?since below base and be re-sent bytes it already rendered.
 	ev, err := nextWithin(t, b, 2*time.Second)
+	if err != nil {
+		t.Fatalf("NextEvent (want the cursor re-seed): %v", err)
+	}
+	if ev.Kind != PTYCursor || ev.Seq != 4 {
+		t.Fatalf("event = %+v, want PTYCursor Seq=4 (the oldest retained byte)", ev)
+	}
+	// Then the retained tail: the cursor resumes at the oldest retained byte rather
+	// than replaying evicted data.
+	ev, err = nextWithin(t, b, 2*time.Second)
 	if err != nil {
 		t.Fatalf("NextEvent: %v", err)
 	}

--- a/ui/termpane/termpane.go
+++ b/ui/termpane/termpane.go
@@ -58,7 +58,8 @@ const (
 	reconnectMaxBackoff = 3 * time.Second
 )
 
-// EventKind discriminates a stream Event between output bytes and a resize echo.
+// EventKind discriminates a stream Event between output bytes, a resize echo, a
+// screen repaint, and a cursor re-seed.
 type EventKind int
 
 const (
@@ -72,15 +73,24 @@ const (
 	// output) that must NOT advance the replay cursor — it is per-subscriber and not
 	// part of the server's ring seq, so counting it would desync ?since.
 	EventRepaint
+	// EventCursor carries the server's authoritative replay cursor (Seq), which the
+	// pane adopts verbatim. The server sends it when IT moved the cursor
+	// non-contiguously (a ring eviction or a recovery discard skipped bytes that no
+	// longer exist) — a jump our own start + bytes-received arithmetic cannot see, and
+	// which would otherwise make the next reconnect replay already-rendered bytes.
+	EventCursor
 )
 
-// Event is one inbound stream event: output bytes (Data, when Kind==EventData) or
-// the authoritative size echo (Rows/Cols, when Kind==EventResize).
+// Event is one inbound stream event, selected by Kind: output bytes or a repaint
+// (Data), the authoritative size echo (Rows/Cols), or a cursor re-seed (Seq).
 type Event struct {
 	Kind EventKind
 	Data []byte
 	Rows uint16
 	Cols uint16
+	// Seq is the server's authoritative replay cursor, valid only when
+	// Kind == EventCursor.
+	Seq uint64
 }
 
 // Stream is one open connection to a session tab's PTY stream. The concrete
@@ -266,6 +276,14 @@ func (t *TermPane) readStream(stream Stream) {
 			t.gridMu.Lock()
 			_, _ = t.emu.Write(ev.Data)
 			t.gridMu.Unlock()
+		case EventCursor:
+			// The server moved our cursor over bytes it no longer holds (an eviction or
+			// a recovery discard). Adopt its position verbatim — our own
+			// start + bytes-received count is now stale, and reconnecting on it would ask
+			// to replay bytes we already rendered (§ EventCursor).
+			t.connMu.Lock()
+			t.cursor = ev.Seq
+			t.connMu.Unlock()
 		case EventResize:
 			// Authoritative echo: reflow the emulator to the server's size. We drive
 			// the size, so this normally matches wantCols/wantRows; applying it

--- a/ui/termpane/termpane_test.go
+++ b/ui/termpane/termpane_test.go
@@ -75,6 +75,10 @@ func (s *fakeStream) feed(b string) { s.events <- Event{Kind: EventData, Data: [
 // rendered like output but must NOT advance the replay cursor.
 func (s *fakeStream) feedRepaint(b string) { s.events <- Event{Kind: EventRepaint, Data: []byte(b)} }
 
+// feedCursor pushes a cursor re-seed (a server → client OpHello frame): the server
+// announcing that it moved this subscription's cursor over bytes it no longer holds.
+func (s *fakeStream) feedCursor(seq uint64) { s.events <- Event{Kind: EventCursor, Seq: seq} }
+
 func (s *fakeStream) sentInput() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -270,6 +274,43 @@ func TestRepaintRendersWithoutAdvancingCursor(t *testing.T) {
 	second, ok := d.sinceAt(1)
 	require.True(t, ok)
 	assert.Equal(t, uint64(len("AAA")), second, "a repaint must not advance the replay cursor")
+}
+
+// TestCursorEventReseedsReplayCursor pins the client half of the #1845 follow-up: when
+// the SERVER moves this subscription's cursor — a ring eviction, or the post-recovery
+// discard of a dead pane's ring — the pane must adopt the announced cursor VERBATIM
+// rather than keep counting from its own start + bytes-received total, which cannot see
+// a jump it did not receive bytes for.
+//
+// Fail-before/pass-after: without the EventCursor case the pane ignores the
+// announcement and keeps its stale count, so the reconnect requests ?since=6 (3 + 3)
+// instead of 503 — a cursor below the broker's base, which clamps it back up and
+// re-sends bytes the pane already rendered (duplicated terminal output).
+func TestCursorEventReseedsReplayCursor(t *testing.T) {
+	s1 := newFakeStream(0)
+	// s2 replays from the re-seeded cursor plus the bytes rendered since it.
+	s2 := newFakeStream(503)
+	d := &queueDialer{streams: []*fakeStream{s1, s2}}
+	tp := New(d.dial, 40, 6)
+	t.Cleanup(func() { _ = tp.Close() })
+
+	s1.feed("AAA") // EventData: advances the cursor 0 → 3
+	waitForRender(t, tp, 40, 6, "AAA")
+
+	// The server discards its ring and fast-forwards this subscriber to 500 — every
+	// byte below that is gone. It announces the jump; our local count (3) is now stale.
+	s1.feedCursor(500)
+	s1.feed("BBB") // EventData: advances the ADOPTED cursor 500 → 503
+	waitForRender(t, tp, 40, 6, "AAABBB")
+
+	// Drop → reconnect. ?since must be the announced cursor plus what we rendered after
+	// it (500 + 3), not our own byte count (3 + 3).
+	_ = s1.Close()
+	s2.feed("CCC")
+	waitForRender(t, tp, 40, 6, "AAABBBCCC")
+	second, ok := d.sinceAt(1)
+	require.True(t, ok)
+	assert.Equal(t, uint64(503), second, "the pane must adopt the server's announced cursor, not its own byte count")
 }
 
 // TestReconnectReassertsDesiredSize pins that a pane resized while disconnected

--- a/web/src/frame.ts
+++ b/web/src/frame.ts
@@ -17,10 +17,13 @@ export enum Op {
   /** server → client: one-shot fresh-subscriber repaint; rendered but NOT counted
    *  toward the replay cursor. */
   Repaint = 0x03,
-  /** server → client: the subscription's starting seq as a big-endian uint64, sent
-   *  as the FIRST frame so a browser — which cannot read the X-Af-Stream-Seq
-   *  handshake header — learns its absolute cursor to seed `?since` replay
-   *  (#1592 Phase 5 PR1, design §4.3). NOT counted toward the replay cursor. */
+  /** server → client: the subscription's authoritative cursor as a big-endian
+   *  uint64, adopted verbatim. Sent as the FIRST frame so a browser — which cannot
+   *  read the X-Af-Stream-Seq handshake header — learns its absolute cursor to seed
+   *  `?since` replay (#1592 Phase 5 PR1, design §4.3), and RE-sent whenever the
+   *  server moves that cursor over bytes it no longer holds (a ring eviction or a
+   *  recovery discard) — a jump a client counting received bytes cannot otherwise
+   *  see. NOT counted toward the replay cursor. */
   Hello = 0x04,
 }
 


### PR DESCRIPTION
Post-merge follow-up to #1845. Codex's review landed after that PR merged; both
of its P2 findings are **valid on current master**, and both are the same root
cause. Neither is stale.

## The shared root cause

A client derives its own replay cursor as `start + bytes-received`
(`ui/termpane` `readStream`, `web/src/terminal.ts`). That is only correct while
the cursor moves contiguously. **The server can move it non-contiguously, and
never said so** — #1845's recovery discard advances `base` over the dead pane's
ring, which fast-forwards a lagging subscriber through the eviction clamp in
`NextEvent`.

So the client's cursor silently desyncs, and the damage surfaces one reconnect
later. That delay is exactly why #1845's tests missed it: they assert from
*inside* the broker, where the clamp looks correct. It is only wrong from where
the client stands.

## Finding 1 (P2) — reconnect replays already-rendered bytes

A subscriber lagging at recovery (its WS write blocked while the dying pane
produced) keeps counting from its pre-recovery cursor, so its cursor sits below
the new `base`. It renders post-recovery output correctly, then reconnects with
a stale `?since` — which `subscribe` clamps back up to `base`, replaying bytes
it already rendered. Duplicated/corrupt output until something forces a repaint.

**The ring-eviction clamp has had this same silent-jump bug since PR5**; the
recovery discard just made it reachable without a 256 KiB backlog. One fix
closes both.

**Fix:** the clamp emits a `PTYCursor` event carrying the authoritative cursor,
mapped onto the `OpHello` frame the subscription already opens with. No new
opcode: `OpHello` already means "your absolute cursor is X", and a jump is just
a new one. The web client already adopts *every* hello — its comment reads
"Seed (or re-seed) the absolute cursor… absorbs a ring eviction" — so this is
the shape it was written for and it needs **no change**. The Go TUI path
ignored `OpHello` entirely (it reads the start cursor off the handshake header)
and now adopts it too.

## Finding 2 (P2) — a discarded reconnect gets neither replay nor repaint

When recovery runs with **nobody attached**, `resetCapture` discards the ring
and advances `base`, but takes the no-subscriber branch, so no re-seed fans
out. The reconnect's `?since` is clamped up to `base` (no replay), and the
repaint injection was keyed on `since == 0`, so it got no repaint either. The
client sits on its **pre-death screen** until the re-spawned pane happens to
emit something on its own.

**Fix:** repaint when `since < base` — the requested bytes are provably gone,
which is precisely when replay cannot resync the screen.

Deliberately **not** "repaint whenever the cursor was clamped at all": a
`since` past `head` also clamps (down, to the live tail), but that client is
missing no byte the broker holds, and repainting it would add flicker to the
documented clamp-to-tail path (`TestPTYBrokerInitialRepaint` pins it).

## Verified, not taken on faith

Each regression test was verified **fail-before/pass-after** by reverting its
production change with the test in place:

| Test | Fail-before |
|---|---|
| `…ReconnectAfterRecoveryDoesNotReplayRenderedBytes` | `client cursor = 20, server cursor = 46` — then the reconnect replays `POST-RECOVERY-OUTPUT` a second time |
| `…ReconnectRepaintsWhenRecoveryDiscardedItsCursor` | `NextEvent (want repaint "SCREEN-AFTER-RECOVERY"): context deadline exceeded` |
| `TestCursorEventReseedsReplayCursor` (termpane) | `expected: 0x1f7, actual: 0x6` — the pane's own stale byte count |

The first test models the **real client's arithmetic** rather than asserting on
broker internals — the only vantage point from which this bug is visible.

## Two existing tests moved (deliberately, and are stronger)

Both now receive the cursor re-seed where they previously expected silence or
data. Each keeps its original guarantee and adds the re-seed assertion — neither
was weakened to fit:

- `TestPTYBrokerRecoveryDoesNotReplayStaleBytes` (#1840): still asserts **no
  stale bytes** after the repaint; now also pins `PTYCursor Seq=26`.
- `TestPTYBrokerEvictionFastForwards`: still asserts the retained tail `efgh`;
  now also pins the `PTYCursor Seq=4` that must precede it.

The integration harness's `wsClient` computed `baseSeq + len(out)` — it modelled
the *buggy* client. It now tracks a cursor the way a real client does, so the
end-to-end harness is faithful to the contract.

## Scope

5 production files, ~15 lines of real logic. `web/src/frame.ts` is a
**comment-only** change (the enum said hello was only ever the FIRST frame);
the rebuilt bundle is byte-identical.

## Gates

- `make test-container` — every package `ok` (incl. `integration`)
- `make tui-driver-selftest` — 38/38 green
- `make web-test` — 159 pass · `make web-selftest-container` — 43 passed
- `make web-build` — dist byte-identical (comment-only change)
- `go build ./...`, `gofmt -l .`, `golangci-lint run --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh` — all clean

Not merging — flagged for review per the dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
