### PR TITLE
fix(ci): skip auto-gate when the PR is closed or merged (#1876)

### DIFF
--- a/.github/workflows/auto-gate.yml
+++ b/.github/workflows/auto-gate.yml
@@ -24,6 +24,11 @@ jobs:
   auto-gate:
     name: Evaluate auto-merge gate
     runs-on: ubuntu-latest
+    # Late review comments on a merged/closed PR keep re-triggering the gate
+    # against a stale head (#1876). Events that carry no pull_request payload
+    # (check_suite, status) resolve the PR by head SHA and already filter to
+    # open PRs, so they must not be skipped here.
+    if: github.event.pull_request == null || github.event.pull_request.state == 'open'
     steps:
       - name: Check out gate logic
         uses: actions/checkout@v6


### PR DESCRIPTION
Fixes #1876.

## Problem

Late review comments on an already-merged PR emit `pull_request_review` events, re-running Auto Gate against a stale head. PR #1817 drew **13 back-to-back runs at 23:04**, roughly 1.5 hours after it merged at 21:28 — pure CI waste plus failure spam.

Root cause is in `.github/scripts/auto-gate.js`: `findPullRequestNumber()` returns `payload.pull_request.number` immediately with no state check, while the head-SHA path used by `check_suite`/`status` already filters to `state === "open"` (line 183). `evaluate()` never re-checks state either, so review events on merged PRs sail straight through.

## Fix

One job-level guard in `auto-gate.yml`:

```yaml
if: github.event.pull_request == null || github.event.pull_request.state == 'open'
```

Events that carry a `pull_request` payload (`pull_request_review`, `pull_request: [labeled]`) must be open. Events that don't (`check_suite`, `status`) are unaffected — they resolve the PR by head SHA and already filter to open PRs. Behavior for open PRs is identical.

## Verification

`actionlint` clean. CI green.

The `null` comparison is load-bearing: if an absent `github.event.pull_request` did *not* compare equal to `null`, this guard would silently disable auto-gate for every `check_suite`/`status` event. Rather than trust the casting docs, I pushed a temporary probe workflow to this branch, confirmed the semantics on a real runner, and removed it — the diff here is the single `auto-gate.yml` guard.

Probe results ([run 29457683281](https://github.com/sachiniyer/agent-factory/actions/runs/29457683281)), all as expected:

| Job | Expression | Expected | Actual |
|---|---|---|---|
| 1 | full guard, open PR | run | ran |
| 2 | `github.event.check_suite == null` (absent object) | run | ran |
| 3 | `github.event.pull_request == null` (present object) | skip | skipped |
| 4 | observed `pull_request.state` | `open` | `state=[open]` |

Job 2 exercises the exact cast the `check_suite`/`status` path depends on, confirming those events are not skipped.

The closed-PR skip itself cannot be exercised pre-merge: `pull_request_review` and `check_suite` always run the workflow file from the default branch, so the guard only takes effect once this is on `master`. The next late review on a merged PR is the real proof.

Held as draft pending review.

— Captain Claude
