### PR TITLE
fix(session): stop advertising TabManagement on off-box backends (#1874)

### DIFF
--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -828,7 +828,7 @@ func (m *home) handleNewTab() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	if !selected.Capabilities().TabManagement {
-		return m, m.handleError(fmt.Errorf("remote sessions don't support new process tabs; their terminal tab comes from remote_hooks.terminal_cmd and arbitrary remote processes aren't supported"))
+		return m, m.handleError(fmt.Errorf("only local sessions support new tabs — this session's workspace runs off-box (docker/ssh/remote), so there is no local worktree to spawn a tab in"))
 	}
 
 	name, err := createShellTabThroughDaemon(selected.Title, m.repoID)
@@ -876,7 +876,7 @@ func (m *home) handleCloseTab() (tea.Model, tea.Cmd) {
 		return m, m.handleError(fmt.Errorf("the agent tab can't be closed; use D to kill the session"))
 	}
 	if !selected.Capabilities().TabManagement {
-		return m, m.handleError(fmt.Errorf("remote session tabs can't be closed"))
+		return m, m.handleError(fmt.Errorf("this session's tab list is fixed by its runtime and can't be edited"))
 	}
 	tabs := selected.GetTabs()
 	if idx >= len(tabs) {

--- a/app/sync.go
+++ b/app/sync.go
@@ -634,9 +634,12 @@ func (m *home) updateInstanceFromSnapshot(inst *session.Instance, d session.Inst
 			changed = true
 		}
 	}
-	// Backends without user-managed tabs (remote hook sessions) derive their tabs
-	// from config (terminal_cmd), not the snapshot, so the backend owns them —
-	// skip the tab reconcile.
+	// Backends without user-managed tabs (the off-box docker/ssh/hook runtimes)
+	// have a tab list their runtime owns — a single agent tab, fixed at Launch —
+	// so there is nothing for the snapshot to reconcile against. Skipping is a
+	// no-op rather than a behavior change: ReconcileTabsFromData already returns
+	// early for an instance with no local worktree, which is every sandbox
+	// instance (#1874).
 	if inst.Capabilities().TabManagement {
 		// Capture the slot→name list before the tab reconcile mutates it: an
 		// out-of-band tab removal (another client, `af sessions tab-delete`,

--- a/daemon/close_tab_test.go
+++ b/daemon/close_tab_test.go
@@ -274,12 +274,7 @@ func TestCloseTab_RejectsRemoteInstance(t *testing.T) {
 	manager.mu.Unlock()
 
 	_, err = manager.CloseTab(CloseTabRequest{Title: "rem", RepoID: repo.ID, TabName: "shell"})
-	if err == nil {
-		t.Fatal("expected error for remote instance, got nil")
-	}
-	if !strings.Contains(err.Error(), "remote") {
-		t.Fatalf("expected remote-rejection error, got: %v", err)
-	}
+	assertTabRejection(t, err, "fixed by its runtime")
 }
 
 func closeBlockingTabExec(alive map[string]bool, blockedKillName string, killStarted chan<- struct{}, releaseKill <-chan struct{}) (cmd_test.MockCmdExec, func(string) bool) {

--- a/daemon/create_tab_test.go
+++ b/daemon/create_tab_test.go
@@ -97,6 +97,24 @@ func (remoteTypeBackend) Capabilities() session.Capabilities {
 	return session.Capabilities{Workspace: session.WorkspaceRemote}
 }
 
+// assertTabRejection pins the copy of the no-tab-management rejection (#1874).
+// A bare Contains(err, "remote") passed for years while the message pointed at
+// remote_hooks.terminal_cmd — a knob #1592 Phase 4 PR7 deleted — so match the
+// rule the user can actually act on, and fail loudly if the deleted knob ever
+// comes back into user-facing copy.
+func assertTabRejection(t *testing.T, err error, want string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected a rejection error for an off-box instance, got nil")
+	}
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("expected the rejection to say %q, got: %v", want, err)
+	}
+	if strings.Contains(err.Error(), "terminal_cmd") {
+		t.Fatalf("rejection points at the deleted remote_hooks.terminal_cmd knob: %v", err)
+	}
+}
+
 // startedLocalTabInstance builds a started local instance whose agent tab is a
 // mock-backed tmux session, registers it in the manager, and seeds a matching
 // on-disk record so the manager's refresh keeps the live in-memory instance.
@@ -169,12 +187,7 @@ func TestCreateTab_RejectsRemoteInstance(t *testing.T) {
 	manager.mu.Unlock()
 
 	_, err = manager.CreateTab(CreateTabRequest{Title: "rem", RepoID: repo.ID, Command: "btop"})
-	if err == nil {
-		t.Fatal("expected error for remote instance, got nil")
-	}
-	if !strings.Contains(err.Error(), "remote") {
-		t.Fatalf("expected remote-rejection error, got: %v", err)
-	}
+	assertTabRejection(t, err, "only local sessions support user-managed tabs")
 }
 
 // TestCreateTab_SpawnsPersistsAndReturnsName is the headline daemon test: a
@@ -324,10 +337,5 @@ func TestCreateTab_ShellRejectsRemoteInstance(t *testing.T) {
 	manager.mu.Unlock()
 
 	_, err = manager.CreateTab(CreateTabRequest{Title: "rem", RepoID: repo.ID, Shell: true})
-	if err == nil {
-		t.Fatal("expected error for remote instance, got nil")
-	}
-	if !strings.Contains(err.Error(), "remote") {
-		t.Fatalf("expected remote-rejection error, got: %v", err)
-	}
+	assertTabRejection(t, err, "only local sessions support user-managed tabs")
 }

--- a/daemon/manager_tabs.go
+++ b/daemon/manager_tabs.go
@@ -82,8 +82,11 @@ func (m *Manager) CreateTab(req CreateTabRequest) (string, error) {
 	if instance == nil {
 		return "", fmt.Errorf("failed to restore instance %q", title)
 	}
+	// The message names the real reason rather than the old
+	// remote_hooks.terminal_cmd knob, which #1592 Phase 4 PR7 deleted — pointing a
+	// user at a setting that no longer exists is worse than no advice (#1874).
 	if !instance.Capabilities().TabManagement {
-		return "", fmt.Errorf("cannot create a tab on remote session %q: remote sessions have no local worktree and the hook protocol can't run arbitrary commands; their terminal tab comes from remote_hooks.terminal_cmd", title)
+		return "", fmt.Errorf("cannot create a tab on session %q: only local sessions support user-managed tabs — this session's workspace runs off-box (docker/ssh/remote), so there is no local worktree to spawn a tab in", title)
 	}
 
 	// Serialize the tab spawn against an archive/kill/restore teardown+move for
@@ -187,7 +190,7 @@ func (m *Manager) CloseTab(req CloseTabRequest) (string, error) {
 		return "", fmt.Errorf("failed to restore instance %q", title)
 	}
 	if !instance.Capabilities().TabManagement {
-		return "", fmt.Errorf("cannot close a tab on remote session %q: its tabs are fixed by remote_hooks config, not user-managed", title)
+		return "", fmt.Errorf("cannot close a tab on session %q: its tab list is fixed by its runtime, not user-managed — this session's workspace runs off-box (docker/ssh/remote)", title)
 	}
 	// An archived session's tabs are not editable (#1809 follow-up). Archive
 	// preserves web tabs so a restore can render them again; without this guard a

--- a/integration/backend_capability_matrix_test.go
+++ b/integration/backend_capability_matrix_test.go
@@ -15,9 +15,13 @@ import (
 // exercise the full matrix and not just the happy-path round-trip.
 //
 // It proves, for a live instance:
-//   - Descriptor parity: a remote workspace, every optional capability TRUE (no
-//     locality special-case, no unsupported bit) — the same end-state the host
-//     matrix pins, but read off the REAL provisioned backend.
+//   - Descriptor parity: a remote workspace with every optional capability TRUE
+//     (no locality special-case, no unsupported bit) EXCEPT TabManagement, which
+//     is false — the same end-state the host matrix pins, but read off the REAL
+//     provisioned backend. TabManagement is serviced below as a rejection: the
+//     agent-server has no create-tab RPC, so a live sandbox genuinely cannot
+//     spawn one (#1874). It sat in this list as a TRUE bit that nothing here
+//     ever exercised over the wire, which is how the contradiction survived.
 //   - Attach + InteractiveInput serviced: typed input reaches the sandbox agent
 //     and echoes back over the WS PTY stream the client attaches on (a remote
 //     workspace attaches client-side over that stream; #1852 deleted the backend
@@ -45,7 +49,6 @@ func assertLiveCapabilityMatrix(t *testing.T, label string, inst *session.Instan
 	}{
 		{"Archive", caps.Archive},
 		{"Recover", caps.Recover},
-		{"TabManagement", caps.TabManagement},
 		{"TerminalTab", caps.TerminalTab},
 		{"InteractiveInput", caps.InteractiveInput},
 	}
@@ -53,6 +56,18 @@ func assertLiveCapabilityMatrix(t *testing.T, label string, inst *session.Instan
 		if !o.ok {
 			t.Errorf("%s: live backend must advertise capability %s at full parity (#1592 Phase 4 end-state)", label, o.name)
 		}
+	}
+
+	// TabManagement is the one bit that must be FALSE off-box, and it is serviced
+	// here rather than merely asserted: the live sandbox must actually refuse the
+	// spawn. Advertising true while every Add*Tab path needs a daemon-side
+	// worktree is exactly the drift #1874 fixed, so pin BOTH halves — if a future
+	// agent-server grows a create-tab RPC, both flip together in one change.
+	if caps.TabManagement {
+		t.Errorf("%s: live backend advertises TabManagement, but tab creation needs a daemon-side worktree an off-box workspace does not have (#1874)", label)
+	}
+	if _, err := inst.AddShellTab(); err == nil {
+		t.Errorf("%s: AddShellTab unexpectedly succeeded on an off-box workspace; if the agent-server now services tab creation, flip TabManagement true with it (#1874)", label)
 	}
 
 	// Service the streamable capabilities over the wire against the live sandbox:

--- a/session/backend_docker.go
+++ b/session/backend_docker.go
@@ -468,17 +468,26 @@ var _ Backend = (*dockerBackend)(nil)
 
 func (b *dockerBackend) Type() string { return "docker" }
 
-// Capabilities advertises FULL parity for docker (#1592 Phase 4 PR6, epic §5):
-// the workspace is off-box, but attach/preview/liveness/prompt/tabs work through
-// the in-container agent-server, and Archive/Recover work by pushing the branch
-// to GitHub and re-provisioning a fresh container that clones it back (§5.1) — so
-// every capability is true, no ErrRecoverUnsupported and no locality special-case.
+// Capabilities advertises docker's parity (#1592 Phase 4 PR6, epic §5): the
+// workspace is off-box, but attach/preview/liveness/prompt work through the
+// in-container agent-server, and Archive/Recover work by pushing the branch to
+// GitHub and re-provisioning a fresh container that clones it back (§5.1) — no
+// ErrRecoverUnsupported and no locality special-case.
+//
+// TabManagement is false (#1874). It is the ONE capability the in-container
+// agent-server does not yet service: the agent-server's tab surface is data
+// plane only (Subscribe/Input/Resize address an EXISTING tab by index or stable
+// id) — there is no create/close tab RPC, so every Add*Tab path still requires a
+// daemon-side git worktree this runtime does not have. Advertising it true
+// offered tab affordances (the web menu's new-tab/VS Code items, the TUI `t`/`w`
+// keys) that could only ever fail. The honest bit is false until tab creation
+// routes through the agent-server; see #1874 for what that needs.
 func (b *dockerBackend) Capabilities() Capabilities {
 	return Capabilities{
 		Workspace:        WorkspaceRemote,
 		Archive:          true,
 		Recover:          true,
-		TabManagement:    true,
+		TabManagement:    false,
 		TerminalTab:      true,
 		InteractiveInput: true,
 	}

--- a/session/backend_hook_backend.go
+++ b/session/backend_hook_backend.go
@@ -220,20 +220,24 @@ var _ Backend = (*HookBackend)(nil)
 
 func (b *HookBackend) Type() string { return "remote" }
 
-// Capabilities advertises FULL parity for the remote-hook backend (#1592 Phase 4
-// PR7, epic §5) — identical to docker/ssh: the workspace is off-box, but
-// attach/preview/liveness/prompt/tabs work through the user-provisioned
-// agent-server, and Archive/Recover work by pushing the branch to GitHub and
-// re-running launch_cmd to re-provision a fresh sandbox that clones it back
-// (§5.1). Every capability is true — no ErrRecoverUnsupported, no per-config
-// TerminalTab gating (the in-sandbox agent-server manages tabs natively, so the
-// old terminal_cmd bit is gone).
+// Capabilities advertises the remote-hook backend's parity (#1592 Phase 4 PR7,
+// epic §5) — identical to docker/ssh: the workspace is off-box, but
+// attach/preview/liveness/prompt work through the user-provisioned agent-server,
+// and Archive/Recover work by pushing the branch to GitHub and re-running
+// launch_cmd to re-provision a fresh sandbox that clones it back (§5.1). No
+// ErrRecoverUnsupported, and no per-config TerminalTab gating (the in-sandbox
+// agent-server drives the terminal surface, so the old terminal_cmd bit is gone).
+//
+// TabManagement is false (#1874), for the same reason as docker/ssh: the
+// agent-server's tab surface is data plane only, so every Add*Tab path still
+// requires a daemon-side git worktree this runtime does not have. See
+// dockerBackend.Capabilities.
 func (b *HookBackend) Capabilities() Capabilities {
 	return Capabilities{
 		Workspace:        WorkspaceRemote,
 		Archive:          true,
 		Recover:          true,
-		TabManagement:    true,
+		TabManagement:    false,
 		TerminalTab:      true,
 		InteractiveInput: true,
 	}

--- a/session/backend_ssh.go
+++ b/session/backend_ssh.go
@@ -735,17 +735,22 @@ var _ Backend = (*sshBackend)(nil)
 
 func (b *sshBackend) Type() string { return "ssh" }
 
-// Capabilities advertises FULL parity for ssh (#1592 Phase 4 PR6, epic §5): the
-// workspace is off-box, but attach/preview/liveness/prompt/tabs work through the
+// Capabilities advertises ssh's parity (#1592 Phase 4 PR6, epic §5): the
+// workspace is off-box, but attach/preview/liveness/prompt work through the
 // remote agent-server over the tunnel, and Archive/Recover work by pushing the
 // branch to GitHub and re-provisioning a fresh remote that clones it back (§5.1)
-// — every capability true, no ErrRecoverUnsupported and no locality special-case.
+// — no ErrRecoverUnsupported and no locality special-case.
+//
+// TabManagement is false (#1874), for the same reason as docker: the remote
+// agent-server's tab surface is data plane only (Subscribe/Input/Resize address
+// an EXISTING tab), so every Add*Tab path still requires a daemon-side git
+// worktree this runtime does not have. See dockerBackend.Capabilities.
 func (b *sshBackend) Capabilities() Capabilities {
 	return Capabilities{
 		Workspace:        WorkspaceRemote,
 		Archive:          true,
 		Recover:          true,
-		TabManagement:    true,
+		TabManagement:    false,
 		TerminalTab:      true,
 		InteractiveInput: true,
 	}

--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -66,15 +66,32 @@ func TestHookBackendType(t *testing.T) {
 // Phase 1). This is the interface-compliance / parity contract: the daemon and
 // UI branch on these bits instead of Type()=="remote", so a regression that
 // silently flips a capability (e.g. a new backend forgetting Archive) is caught
-// here rather than in a lifecycle gate. Since #1592 Phase 4 PR7 the remote-hook
-// backend advertises FULL parity like docker/ssh (its old terminal_cmd-gated
-// TerminalTab and ErrRecoverUnsupported are gone).
+// here rather than in a lifecycle gate.
+//
+// The off-box runtimes (docker/ssh/hook) reach parity on every capability EXCEPT
+// TabManagement, which is false (#1874): the agent-server's tab surface is data
+// plane only, so every Add*Tab path still needs a daemon-side worktree they do
+// not have. See TestSandboxBackendsDoNotAdvertiseTabManagement, which pairs this
+// bit with proof the spawn paths really do reject them.
 func TestBackendCapabilities(t *testing.T) {
 	localCaps := Capabilities{
 		Workspace:        WorkspaceLocalWorktree,
 		Archive:          true,
 		Recover:          true,
 		TabManagement:    true,
+		TerminalTab:      true,
+		InteractiveInput: true,
+	}
+
+	// Every off-box runtime shares one descriptor: a remote workspace with
+	// Archive/Recover via push/pull-branch (no ErrRecoverUnsupported, no locality
+	// special-case) and no user-managed tabs. Shared so a new sandbox runtime
+	// cannot quietly drift from its siblings.
+	sandboxCaps := Capabilities{
+		Workspace:        WorkspaceRemote,
+		Archive:          true,
+		Recover:          true,
+		TabManagement:    false,
 		TerminalTab:      true,
 		InteractiveInput: true,
 	}
@@ -95,48 +112,22 @@ func TestBackendCapabilities(t *testing.T) {
 			want: localCaps,
 		},
 		{
-			// #1592 Phase 4 PR7: the remote-hook backend is migrated to
-			// provision-and-expose and reaches the SAME full parity as docker/ssh —
-			// a remote workspace, but every capability true (Archive/Recover via
-			// push/pull-branch + re-running launch_cmd). No per-config TerminalTab
-			// gating, no ErrRecoverUnsupported.
-			name: "remote hook runtime — full remote parity",
+			// #1592 Phase 4 PR7 migrated the remote-hook backend to
+			// provision-and-expose, reaching the same descriptor as docker/ssh: its
+			// old terminal_cmd-gated TerminalTab and ErrRecoverUnsupported are gone.
+			name: "remote hook runtime — remote parity, no tab management",
 			b:    &HookBackend{},
-			want: Capabilities{
-				Workspace:        WorkspaceRemote,
-				Archive:          true,
-				Recover:          true,
-				TabManagement:    true,
-				TerminalTab:      true,
-				InteractiveInput: true,
-			},
+			want: sandboxCaps,
 		},
 		{
-			// #1592 Phase 4 PR6: the sandbox runtimes reach FULL parity — a remote
-			// workspace, but every capability true (Archive/Recover via
-			// push/pull-branch). No ErrRecoverUnsupported, no locality special-case.
-			name: "docker sandbox runtime — full remote parity",
+			name: "docker sandbox runtime — remote parity, no tab management",
 			b:    &dockerBackend{},
-			want: Capabilities{
-				Workspace:        WorkspaceRemote,
-				Archive:          true,
-				Recover:          true,
-				TabManagement:    true,
-				TerminalTab:      true,
-				InteractiveInput: true,
-			},
+			want: sandboxCaps,
 		},
 		{
-			name: "ssh sandbox runtime — full remote parity",
+			name: "ssh sandbox runtime — remote parity, no tab management",
 			b:    &sshBackend{},
-			want: Capabilities{
-				Workspace:        WorkspaceRemote,
-				Archive:          true,
-				Recover:          true,
-				TabManagement:    true,
-				TerminalTab:      true,
-				InteractiveInput: true,
-			},
+			want: sandboxCaps,
 		},
 	}
 
@@ -181,18 +172,30 @@ func TestBackendComplianceCoversRegistry(t *testing.T) {
 }
 
 // TestBackendCapabilityParity is the epic end-state assertion (#1592 Phase 4,
-// §5.2): EVERY backend implements EVERY optional capability — no backend gates an
+// §5.2): every backend implements every optional capability — no backend gates an
 // operation off behind a "not supported" descriptor bit, and none returns an
 // ErrRecoverUnsupported/ErrArchiveUnsupported sentinel (both are DELETED; a
 // reference would fail to compile). The old locality special-case — a remote
 // backend advertising Archive/Recover=false and returning
-// ErrRecoverUnsupported — is gone. Attach/preview/archive/restore/tab all route
+// ErrRecoverUnsupported — is gone. Attach/preview/archive/restore all route
 // through the uniform agent-server + push/pull-branch contract, so this table
-// asserts the full optional-capability matrix is TRUE for every registered
-// backend. A regression that flips any bit false (re-introducing a locality
-// gap) fails here.
+// asserts those bits are TRUE for every registered backend. A regression that
+// flips any of them false (re-introducing a locality gap) fails here.
 //
-// Attach is NOT in this table: #1860 deleted the bit. It was true for every
+// TabManagement is NOT in this table (#1874). It is the one capability the epic
+// has not actually delivered off-box: the agent-server's tab surface is data
+// plane only (Subscribe/Input/Resize address an EXISTING tab), so there is no
+// create/close tab RPC and every Add*Tab path still requires a daemon-side git
+// worktree the sandbox runtimes do not have. It sat here as an ASPIRATION
+// asserted as fact — the table forced the bit true, the bit made clients offer
+// tab affordances, and every one of them failed. The honest per-runtime split is
+// pinned by TestBackendCapabilities and by
+// TestSandboxBackendsDoNotAdvertiseTabManagement, which pairs each bit with proof
+// the spawn paths agree with it. When tab creation routes through the
+// agent-server, TabManagement returns to this table and those tests flip in the
+// same change.
+//
+// Attach is NOT in this table either: #1860 deleted the bit. It was true for every
 // backend and read by no dispatch, because attach is not gated per-backend at
 // all — the client dials the daemon's WS PTY stream for every runtime. A
 // capability that cannot be false has nothing to assert parity over.
@@ -213,7 +216,6 @@ func TestBackendCapabilityParity(t *testing.T) {
 	}{
 		{"Archive", func(c Capabilities) bool { return c.Archive }},
 		{"Recover", func(c Capabilities) bool { return c.Recover }},
-		{"TabManagement", func(c Capabilities) bool { return c.TabManagement }},
 		{"TerminalTab", func(c Capabilities) bool { return c.TerminalTab }},
 		{"InteractiveInput", func(c Capabilities) bool { return c.InteractiveInput }},
 	}
@@ -227,6 +229,20 @@ func TestBackendCapabilityParity(t *testing.T) {
 					kind, oc.name)
 			}
 		})
+	}
+}
+
+// TestLocalBackendServicesTabManagement keeps the local runtime's TabManagement
+// bit pinned now that it is out of the parity table above. Without this, a
+// regression flipping the LOCAL bit false — which WOULD be a real capability
+// loss, unlike the sandbox runtimes' honest false — would fail no test.
+func TestLocalBackendServicesTabManagement(t *testing.T) {
+	for kind, b := range complianceBackends() {
+		if b.Capabilities().Workspace != WorkspaceLocalWorktree {
+			continue
+		}
+		assert.Truef(t, b.Capabilities().TabManagement,
+			"backend %q has a local worktree and must service TabManagement", kind)
 	}
 }
 

--- a/session/tab_spawn.go
+++ b/session/tab_spawn.go
@@ -7,6 +7,31 @@ import (
 	"github.com/sachiniyer/agent-factory/log"
 )
 
+// tabSpawnPreconditionErr reports why a tab cannot be spawned into this
+// instance's local workspace, or nil when the preconditions hold. Shared by
+// every Add*Tab path so they cannot drift apart.
+//
+// It separates the two causes the old single guard collapsed into one
+// "…instance that is not started" message (#1874). That message was actively
+// misleading for a sandbox (docker/ssh/hook) session: the instance IS started —
+// its workspace is simply off-box, so there is no daemon-side worktree or tmux
+// to spawn into. The distinction matters to the reader, not just to precision:
+// "not started" reads as a transient state worth retrying, while an off-box
+// workspace is a standing fact no amount of waiting changes.
+//
+// Callers reject backends without the TabManagement capability first
+// (daemon/manager_tabs.go), so a user normally sees that gate's message instead;
+// this is the defense-in-depth check for a direct caller, written to stand alone.
+func tabSpawnPreconditionErr(started, hasTmux, hasWorktree bool) error {
+	if !started {
+		return fmt.Errorf("cannot add a tab to a session that is not started")
+	}
+	if !hasWorktree || !hasTmux {
+		return fmt.Errorf("cannot add a tab to a session with no local workspace: its workspace runs off-box, so there is no worktree to spawn the tab in")
+	}
+	return nil
+}
+
 // AddShellTab spawns a new Shell-kind tab running $SHELL in the instance's
 // worktree, appends it to Tabs, and returns it. Local instances only — remote
 // instances have no local worktree, so callers must reject backends without the
@@ -29,8 +54,8 @@ func (i *Instance) AddShellTab() (*Tab, error) {
 	if spawnErr != nil {
 		return nil, spawnErr
 	}
-	if !started || agentTmux == nil || gw == nil {
-		return nil, fmt.Errorf("cannot add a tab to an instance that is not started")
+	if err := tabSpawnPreconditionErr(started, agentTmux != nil, gw != nil); err != nil {
+		return nil, err
 	}
 	if nTabs >= maxTabs {
 		return nil, fmt.Errorf("max %d tabs per session", maxTabs)
@@ -108,8 +133,8 @@ func (i *Instance) AddProcessTab(command, requestedName string) (*Tab, error) {
 	if spawnErr != nil {
 		return nil, spawnErr
 	}
-	if !started || agentTmux == nil || gw == nil {
-		return nil, fmt.Errorf("cannot add a tab to an instance that is not started")
+	if err := tabSpawnPreconditionErr(started, agentTmux != nil, gw != nil); err != nil {
+		return nil, err
 	}
 	if nTabs >= maxTabs {
 		return nil, fmt.Errorf("max %d tabs per session", maxTabs)
@@ -184,8 +209,8 @@ func (i *Instance) AddWebTab(url, requestedName string) (*Tab, error) {
 	if spawnErr := i.tabSpawnBlockedLocked(); spawnErr != nil {
 		return nil, spawnErr
 	}
-	if !i.started || i.tmuxLocked() == nil || i.gitWorktree == nil {
-		return nil, fmt.Errorf("cannot add a tab to an instance that is not started")
+	if err := tabSpawnPreconditionErr(i.started, i.tmuxLocked() != nil, i.gitWorktree != nil); err != nil {
+		return nil, err
 	}
 	if len(i.Tabs) >= maxTabs {
 		return nil, fmt.Errorf("max %d tabs per session", maxTabs)
@@ -216,8 +241,8 @@ func (i *Instance) AddVSCodeTab(requestedName string) (*Tab, error) {
 	if spawnErr := i.tabSpawnBlockedLocked(); spawnErr != nil {
 		return nil, spawnErr
 	}
-	if !i.started || i.tmuxLocked() == nil || i.gitWorktree == nil {
-		return nil, fmt.Errorf("cannot add a tab to an instance that is not started")
+	if err := tabSpawnPreconditionErr(i.started, i.tmuxLocked() != nil, i.gitWorktree != nil); err != nil {
+		return nil, err
 	}
 	if len(i.Tabs) >= maxTabs {
 		return nil, fmt.Errorf("max %d tabs per session", maxTabs)

--- a/session/tab_spawn_capability_test.go
+++ b/session/tab_spawn_capability_test.go
@@ -1,0 +1,97 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #1874: the sandbox runtimes (docker/ssh/hook) declare WorkspaceRemote — their
+// workspace is off-box, so the daemon-side instance has no local git worktree
+// (gitWorktree is assigned only in LocalBackend.Provision and the LOCAL restore
+// branch of FromInstanceData). Every Add*Tab path requires that worktree, so a
+// TabManagement:true on these backends would advertise a capability no code path
+// can service: the web menu would offer "New shell tab"/"Open in VS Code" and
+// the daemon would reject the call.
+//
+// These tests pin the capability to what the implementation can actually do, so
+// the advertisement and the behavior cannot drift apart again. When tab creation
+// is routed through the agent-server (issue #1874 option 1), the assertions flip
+// to "the tab is created" rather than being deleted.
+
+// sandboxBackends is the set of runtimes whose workspace is off-box. Kept as one
+// table so a NEW sandbox runtime is forced through the same contract.
+func sandboxBackends() map[string]Backend {
+	return map[string]Backend{
+		"docker": &dockerBackend{},
+		"ssh":    &sshBackend{},
+		"hook":   &HookBackend{},
+	}
+}
+
+// TestSandboxBackendsDoNotAdvertiseTabManagement is the contract: a backend
+// whose workspace is off-box must not claim user-managed tabs while every
+// Add*Tab path requires a local worktree.
+func TestSandboxBackendsDoNotAdvertiseTabManagement(t *testing.T) {
+	for name, b := range sandboxBackends() {
+		t.Run(name, func(t *testing.T) {
+			caps := b.Capabilities()
+			require.Equal(t, WorkspaceRemote, caps.Workspace,
+				"%s is expected to be an off-box runtime", name)
+			assert.False(t, caps.TabManagement,
+				"%s advertises TabManagement but every Add*Tab path requires a local worktree (#1874)", name)
+		})
+	}
+}
+
+// TestSandboxInstanceTabSpawnRejected pins the other half of the contract: the
+// Add*Tab paths really are unable to service a sandbox instance. If this ever
+// starts passing, the capability above should be flipped to true in the same
+// change — that is what makes the fix decidable rather than a guess.
+func TestSandboxInstanceTabSpawnRejected(t *testing.T) {
+	for name, b := range sandboxBackends() {
+		t.Run(name, func(t *testing.T) {
+			// A started sandbox instance, exactly as Launch leaves it: started,
+			// one remote agent tab, and no local worktree or tmux.
+			newInst := func() *Instance {
+				return &Instance{
+					Title:   "sandbox-inst",
+					backend: b,
+					started: true,
+					Tabs:    []*Tab{newRemoteAgentTab()},
+				}
+			}
+
+			_, shellErr := newInst().AddShellTab()
+			assert.Error(t, shellErr, "AddShellTab must reject a worktree-less sandbox instance")
+
+			_, webErr := newInst().AddWebTab("http://localhost:3000", "")
+			assert.Error(t, webErr, "AddWebTab must reject a worktree-less sandbox instance")
+
+			_, vscodeErr := newInst().AddVSCodeTab("")
+			assert.Error(t, vscodeErr, "AddVSCodeTab must reject a worktree-less sandbox instance")
+
+			_, procErr := newInst().AddProcessTab("echo hi", "")
+			assert.Error(t, procErr, "AddProcessTab must reject a worktree-less sandbox instance")
+		})
+	}
+}
+
+// TestSandboxTabSpawnErrorIsNotMisleading covers the copy half of #1874. The old
+// message was "cannot add a tab to an instance that is not started", which is
+// false on its face: the instance IS started. An error a user cannot act on is
+// the bug, so assert the message names the real reason (no local workspace)
+// rather than a state that is not the cause.
+func TestSandboxTabSpawnErrorIsNotMisleading(t *testing.T) {
+	i := &Instance{
+		Title:   "sandbox-inst",
+		backend: &dockerBackend{},
+		started: true,
+		Tabs:    []*Tab{newRemoteAgentTab()},
+	}
+	_, err := i.AddShellTab()
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "not started",
+		"the instance IS started; the message must name the real reason (#1874)")
+}

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -8641,8 +8641,9 @@ function addTaskModal(projects, defaultProject2, callbacks) {
 
 // src/ui.ts
 var MAX_TABS = 9;
+var OFF_BOX_BACKENDS = /* @__PURE__ */ new Set(["docker", "ssh", "remote"]);
 function supportsTabManagement(s) {
-  return s.backend_type !== "remote";
+  return !OFF_BOX_BACKENDS.has(s.backend_type ?? "local");
 }
 function canManageTabs(s) {
   return supportsTabManagement(s) && !isArchived(s);

--- a/web/src/ui.test.ts
+++ b/web/src/ui.test.ts
@@ -8,7 +8,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { canManageTabs, documentTitle, tabBarSig } from "./ui.js";
+import { canManageTabs, documentTitle, supportsTabManagement, tabBarSig } from "./ui.js";
 import type { AppState } from "./ui.js";
 import { Liveness, type SessionData } from "./types.js";
 
@@ -91,6 +91,28 @@ test("canManageTabs: an archived session is inert — its + / × are withdrawn (
     "an archived session is inert",
   );
   assert.equal(canManageTabs(sess({ backend_type: "remote" })), false, "remote tabs stay config-fixed");
+});
+
+test("supportsTabManagement: every off-box runtime is withdrawn, not just the hook one (#1874)", () => {
+  // This predicate used to read `backend_type !== "remote"`, which named the hook
+  // runtime only — so docker/ssh sessions were offered a + and an "Open in VS
+  // Code" item that could not work: every Add*Tab path needs a daemon-side git
+  // worktree an off-box workspace does not have. The daemon rejects the call, so
+  // the affordance could only ever produce an error toast.
+  for (const backend_type of ["docker", "ssh", "remote"]) {
+    assert.equal(
+      supportsTabManagement(sess({ backend_type })),
+      false,
+      `${backend_type} runs off-box and cannot spawn a tab`,
+    );
+  }
+});
+
+test("supportsTabManagement: local and legacy records keep tab management", () => {
+  assert.equal(supportsTabManagement(sess({ backend_type: "local" })), true, "a local session manages tabs");
+  // backend_type is omitempty, so a pre-#1592 record carries none. It is a local
+  // session; defaulting it to off-box would strip the + from every legacy row.
+  assert.equal(supportsTabManagement(sess({})), true, "a record with no backend_type is local");
 });
 
 test("archiving the selected session changes the sig — the bar must rebuild to drop the × (#1809)", () => {

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -152,11 +152,29 @@ export interface Actions {
  *  hides at the cap so the web never fires a guaranteed-to-fail CreateTab. */
 const MAX_TABS = 9;
 
-/** Whether a session supports user tab management: remote-hook sessions have their
- *  tabs fixed by config (daemon Capabilities().TabManagement), so the web hides
- *  their + / × affordances and gates the `t`/`w` keys. */
+/** The backend types whose workspace lives off-box (session/archive_sandbox.go
+ *  backendKindForType: docker, ssh, and "remote" — the hook runtime). None of
+ *  them can service tab management: every Add*Tab path needs a daemon-side git
+ *  worktree they do not have, so the daemon's Capabilities().TabManagement is
+ *  false for all three (#1874).
+ *
+ *  This list is the ONE place the web names backend types. It exists only because
+ *  the session envelope carries `backend_type` but not the daemon's capability
+ *  bits — the honest fix is to serialize the capability so no client re-derives
+ *  it (see #1874). Until then, a NEW off-box runtime must be added here, which is
+ *  what ui.test.ts pins. */
+const OFF_BOX_BACKENDS = new Set(["docker", "ssh", "remote"]);
+
+/** Whether a session supports user tab management. Off-box sessions (docker/ssh/
+ *  remote-hook) have a tab list their runtime fixes at launch — a single agent
+ *  tab — so the web hides their + / × affordances and gates the `t`/`w` keys,
+ *  mirroring the daemon's Capabilities().TabManagement.
+ *
+ *  A record with no backend_type is a pre-#1592 local session (the field is
+ *  omitempty), so it defaults to local — treating it as off-box would strip tab
+ *  management from every legacy row. */
 export function supportsTabManagement(s: SessionData): boolean {
-  return s.backend_type !== "remote";
+  return !OFF_BOX_BACKENDS.has(s.backend_type ?? "local");
 }
 
 /** Whether the web may offer tab management for a session RIGHT NOW: its backend


### PR DESCRIPTION
Fixes #1874.

## What was wrong

`docker`, `ssh`, and the remote-hook backend all declared `TabManagement: true`
while every `Add*Tab` path requires a daemon-side git worktree they do not have.
`gitWorktree` is assigned only by `LocalBackend.Provision` and the LOCAL branch of
`FromInstanceData`, so for these runtimes it is always nil and every tab-spawn
call fails. The backends claimed a capability no code path could service.

Reproduced before fixing (`session/tab_spawn_capability_test.go`): all three
backends advertise the bit, and all four spawn paths reject them.

## Two corrections to the issue's analysis

**The hook backend has the same contradiction.** The issue names docker/ssh only,
but `backend_hook_backend.go` is byte-identical in shape (`WorkspaceRemote` +
`TabManagement: true`). Fixed all three.

**The web is *not* faithful — it was a real bug.** The issue argues the web UI
correctly mirrors the daemon and that the reviewer's "the web shows VS Code for
sandbox sessions" framing was wrong. It isn't. `ui.ts` read:

```ts
return s.backend_type !== "remote";
```

That names the hook runtime only, so **docker/ssh sessions really were offered a
`+` and an "Open in VS Code" item**. The predicate's comment claimed to mirror
`Capabilities().TabManagement`, but nothing serializes that field — it re-derived
the answer client-side by branching on a type name, the exact anti-pattern the
capability descriptor exists to remove. A Go-only fix would have left the menu
wrong. The original reviewer was right.

## Why (2) and not (1)

Option (1) is not a minimal fix. The `AgentServer` interface has **no create/close
tab RPC**; its tab surface is data plane only (`Subscribe`/`Input`/`Resize` address
an *existing* tab). Servicing tabs off-box also needs an in-sandbox code-server
(vscode tabs exec code-server as a *daemon-local child* against the daemon's own
filesystem), per-session port forwarding (a loopback web tab on a docker session
would proxy to the **af host's** `localhost:3000` — silently rendering the user's
own dev server as the container's), and sandbox tab restore (`instance_data.go`
restores tabs only on the local branch, so a sandbox tab is persisted then
dropped on load). That is a roadmap slice.

This also rules out the per-kind middle ground: an **external-URL** web tab would
genuinely work off-box, but it would silently vanish on restart — trading a bad
menu item for data loss. Not worth it until sandbox tab restore exists.

## Also fixed (the bad-copy half)

- The spawn guard said `"cannot add a tab to an instance that is not started"` for
  a session that **is** started. Split so the message names the real reason, shared
  across all four `Add*Tab` paths.
- The daemon/TUI rejections pointed at `remote_hooks.terminal_cmd` — a knob #1592
  Phase 4 PR7 **deleted**. Pointing a user at a setting that no longer exists is
  worse than no advice.

## Why this survived

Two reasons, both now closed:

1. `daemon`'s `remoteTypeBackend` test double returns `{Workspace: WorkspaceRemote}`
   — zero-valued, so `TabManagement: false`. **The daemon's tests asserted the
   honest behavior all along, against a fake more truthful than production.**
2. `TestBackendCapabilityParity` asserted every capability TRUE for every backend
   as the "#1592 end-state". It was an aspiration asserted as fact, and it *forced*
   the bit true. `TabManagement` leaves that table; the local bit is pinned
   separately (a false there would be a real loss), and the sandbox bits are now
   paired with proof the spawn paths agree. The integration matrix asserted the bit
   over the wire but never exercised tab creation — it now services the rejection.

## Follow-up worth a decision (not taken here)

The web should not name backend types at all. The structural fix is to **serialize
the daemon's capability bits into the session envelope** so no client re-derives
them. I did not do it here: the API serves persisted `InstanceData` directly, so a
derived field would either persist derived state (stale on disk the moment code
changes) or need a new API envelope — a JSON-contract shape choice that deserves
its own review rather than riding along in a bug fix. The type list is quarantined
to one constant with a test pinning all three runtimes.

`ui/tab_pane.go:474` also still names `remote_hooks.terminal_cmd`, but it sits
behind `TerminalTab` (true for every backend), so it is unreachable dead copy —
left alone to keep this focused.

## Gates

All green: `test-container` (all packages, incl. integration), `tui-driver-selftest`
38/38, `web-test` 161/161, `web-selftest-container` 43/43 (incl. the VS Code tab
scenario), `go build`, `gofmt`, `golangci-lint --fast`, `deadcode -test`,
`lint-file-length`. `web/dist/` rebuilt.

Draft pending review.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)