### PR TITLE
fix: post-merge codex findings on #1815

### DIFF
--- a/daemon/limit.go
+++ b/daemon/limit.go
@@ -75,6 +75,13 @@ func (m *Manager) resolveIdleLiveness(instance *session.Instance, content string
 	}
 }
 
+// testHookPollBeforePublish runs immediately before persistPollChange announces
+// its session.updated, inside the repo start lock it persisted under. Tests
+// substitute it to prove the publish really is in that critical section — the
+// property that keeps an older whole-session payload from landing after a newer
+// tab roster. No-op in production.
+var testHookPollBeforePublish = func() {}
+
 // persistPollChange writes an instance's state to disk when the poll changed
 // something durable this tick (the #960 targeted writer): its LIVENESS
 // transitioned, OR — evaluated INDEPENDENTLY — its usage-limit reset time changed
@@ -108,14 +115,26 @@ func (m *Manager) persistPollChange(repoID string, instance *session.Instance, b
 	repoStartLock.Lock()
 	data := instance.ToInstanceData()
 	err := persistInstanceData(repoID, data)
+	// Push the change onto the events plane (#1592 PR5): this is the single choke
+	// point every liveness/limit transition already flows through, so one publish
+	// here covers session.updated without threading it through each caller.
+	//
+	// Published while STILL HOLDING the repo start lock, in the same critical section
+	// as the persist that produced `data` — matching CreateTab/CloseTab. session.updated
+	// carries a WHOLE InstanceData and every client re-projects the session wholesale
+	// from it, so publish order is not cosmetic: it decides which snapshot wins. Publishing
+	// after the unlock let this poll capture a roster, release the lock, and be preempted
+	// by a tab create/delete that persisted AND announced the grown roster first — then
+	// this older payload landed last and clients re-projected the tab right back out of
+	// existence, until some later update happened to repair it (post-merge Codex finding
+	// on #1815). Serializing publish with persist makes the last event the newest state.
+	// publishEvent is non-blocking (drop-slow), so a wedged subscriber can't stall the poll.
+	testHookPollBeforePublish()
+	m.publishEvent(agentproto.EventSessionUpdated, data)
 	repoStartLock.Unlock()
 	if err != nil {
 		log.WarningLog.Printf("daemon failed to persist status for %q: %v", instance.Title, err)
 	}
-	// Push the change onto the events plane (#1592 PR5): this is the single choke
-	// point every liveness/limit transition already flows through, so one publish
-	// here covers session.updated without threading it through each caller.
-	m.publishEvent(agentproto.EventSessionUpdated, data)
 }
 
 // This file is the daemon side of the usage-limit manual-retry action (#1146

--- a/daemon/tab_event_order_test.go
+++ b/daemon/tab_event_order_test.go
@@ -1,0 +1,112 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/agentproto"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// The post-merge Codex findings on #1815, ordering side.
+//
+// session.updated carries a WHOLE InstanceData, and every client re-projects the
+// session wholesale from it (web's upsertSession, the TUI's
+// ReconcileTabsFromData). That makes publish ORDER load-bearing: the last event to
+// land is the state the client shows. CreateTab/CloseTab publish inside the repo
+// start lock they persisted under, but persistPollChange used to snapshot and
+// persist under that lock, RELEASE it, and only then publish. A poll preempted in
+// that window could capture the pre-tab roster, let a tab create/delete persist and
+// announce the fresh roster, and then land its older payload last — re-projecting
+// the just-created tab out of existence (or a just-closed one back in) until some
+// later update happened to repair it. On a quiet session that repair never comes,
+// which is the exact failure #1815 set out to fix.
+//
+// These lock the invariant in from both ends: the poll publishes inside the
+// critical section, and its payload is the state as of that section.
+
+// TestPersistPollChange_PublishesUnderRepoLock is the discriminating test: at the
+// moment the poll publishes, it must still hold the repo start lock.
+//
+// The window between unlock and publish is only a few instructions wide, so racing
+// two goroutines would almost never catch a regression — a probabilistic test that
+// passes on broken code is worse than none. Instead this asserts the property
+// directly at the seam (testHookPollBeforePublish, mirroring
+// testHookSpawnPingPassed): TryLock from inside the hook must FAIL, because this
+// goroutine already owns the mutex. Move the publish back after the Unlock and the
+// TryLock succeeds — nobody holds it — and this test goes red deterministically.
+func TestPersistPollChange_PublishesUnderRepoLock(t *testing.T) {
+	const title = "pollunderlock"
+	manager, repo := tabEventSession(t, title)
+	instance := manager.instances[daemonInstanceKey(repo.ID, title)]
+	if instance == nil {
+		t.Fatalf("session %q missing from the manager", title)
+	}
+
+	lock := manager.startLockForRepo(repo.ID)
+	probed := false
+	heldAtPublish := false
+	testHookPollBeforePublish = func() {
+		probed = true
+		// Non-reentrant: acquiring here can only mean the poll has ALREADY released
+		// the lock it persisted under, i.e. the publish escaped the critical section.
+		if lock.TryLock() {
+			lock.Unlock()
+			return
+		}
+		heldAtPublish = true
+	}
+	t.Cleanup(func() { testHookPollBeforePublish = func() {} })
+
+	// A liveness that differs from the instance's own makes the poll treat this tick
+	// as a real transition, which is what drives it to persist + publish at all.
+	manager.persistPollChange(repo.ID, instance, otherLiveness(instance.GetLiveness()), time.Time{})
+
+	if !probed {
+		t.Fatal("the poll never reached its publish: persistPollChange returned without announcing a change")
+	}
+	if !heldAtPublish {
+		t.Fatal("persistPollChange published session.updated after releasing the repo start lock; " +
+			"an older whole-session payload can then land after a newer tab roster and undo it (#1815 follow-up)")
+	}
+}
+
+// TestPersistPollChange_PublishesRosterAsOfItsLock: the payload half of the same
+// invariant. A poll that acquires the lock AFTER a tab create must publish the
+// roster INCLUDING that tab — never the roster as it looked before it blocked.
+// Snapshot and publish therefore have to sit in one critical section together;
+// hoisting the snapshot out would reintroduce a stale payload by another route.
+func TestPersistPollChange_PublishesRosterAsOfItsLock(t *testing.T) {
+	const title = "pollroster"
+	manager, repo := tabEventSession(t, title)
+	instance := manager.instances[daemonInstanceKey(repo.ID, title)]
+	if instance == nil {
+		t.Fatalf("session %q missing from the manager", title)
+	}
+
+	name, err := manager.CreateTab(CreateTabRequest{
+		Title: title, RepoID: repo.ID, Kind: "web", URL: "http://localhost:5173", Name: "livepreview",
+	})
+	if err != nil {
+		t.Fatalf("CreateTab(web): %v", err)
+	}
+
+	// Subscribe after the create so the only event drained is the poll's.
+	_, ch := manager.events.subscribe()
+	manager.persistPollChange(repo.ID, instance, otherLiveness(instance.GetLiveness()), time.Time{})
+
+	got := drainNextSessionEvent(t, ch, agentproto.EventSessionUpdated)
+	if !tabNamed(got, name) {
+		t.Fatalf("the poll published roster %v without the already-created tab %q: "+
+			"a status tick would re-project it out of every open client", got.Tabs, name)
+	}
+}
+
+// otherLiveness returns any liveness value that is not `l`, so a caller can force
+// persistPollChange's changed-liveness branch without reaching into the poller.
+func otherLiveness(l session.Liveness) session.Liveness {
+	if l == session.LiveRunning {
+		return session.LiveReady
+	}
+	return session.LiveRunning
+}

--- a/session/instance.go
+++ b/session/instance.go
@@ -528,7 +528,10 @@ func (i *Instance) DropClosedTab(idx int) error {
 // daemon added out-of-band (present in target, absent locally) are reconnected
 // to their EXACT persisted tmux session by name — like restoreLocalTabs — and
 // appended, so an out-of-band tab appears in the running TUI and is immediately
-// previewable/attachable (the #959 "live display" fix); tabs the daemon closed
+// previewable/attachable (the #959 "live display" fix). A tmux-less kind (web,
+// vscode — see TabKind.HasTmux) has no session to reconnect and is appended
+// directly, so it lands in the TUI as its placeholder pane rather than being
+// mistaken for a tab whose tmux session went missing; tabs the daemon closed
 // (absent from target) are dropped locally WITHOUT re-killing their tmux session
 // (the daemon already tore it down — killing again would error on the gone
 // session). The agent tab (index 0) is never added or dropped: it is the
@@ -580,30 +583,42 @@ func (i *Instance) ReconcileTabsFromData(target []TabData) (bool, error) {
 		if td.Kind == TabKindAgent || localNames[td.Name] {
 			continue
 		}
-		if td.TmuxName == "" || worktreePath == "" {
-			continue
-		}
 		kind := tabKindForData(td.Kind)
-		// The sibling inherits the agent session's PTY factory / executor (real
-		// in production, mock in tests), binding to the EXACT persisted name.
-		// ATTACH-ONLY: pass empty workDir so a missing session errors instead of
-		// re-spawning (#1152). Like AttachShellTab, this is a pure TUI-side
-		// projection of daemon-owned tabs; the daemon is the single writer that
-		// owns every spawn (#960). If the daemon killed the session in the race
-		// window, re-spawning here would orphan a tmux session over the deleted
-		// worktree. Skip the tab on failure and let the next snapshot reconcile it.
-		ts := agentTmux.NewSiblingSession(td.TmuxName, tabProgram(kind, td.Command, program))
-		if err := ts.Restore(""); err != nil {
-			if firstErr == nil {
-				firstErr = fmt.Errorf("failed to reconnect tab %q: %w", td.Name, err)
+		// A tmux-less kind (web, vscode) is materialized by the append alone — there
+		// is no session to reconnect, exactly as restoreLocalTabs builds it on load.
+		// Skipping it on its empty TmuxName (as this loop once did) read "" as a
+		// missing session rather than a kind that never has one, so a web/vscode tab
+		// created out-of-band stayed invisible in a running TUI until a full rebuild
+		// — even though #1815 now delivers the roster that carries it, and even though
+		// the DROP side above already removed such a tab by name. See TabKind.HasTmux.
+		var ts *tmux.TmuxSession
+		if kind.HasTmux() {
+			if td.TmuxName == "" || worktreePath == "" {
+				continue
 			}
-			continue
+			// The sibling inherits the agent session's PTY factory / executor (real
+			// in production, mock in tests), binding to the EXACT persisted name.
+			// ATTACH-ONLY: pass empty workDir so a missing session errors instead of
+			// re-spawning (#1152). Like AttachShellTab, this is a pure TUI-side
+			// projection of daemon-owned tabs; the daemon is the single writer that
+			// owns every spawn (#960). If the daemon killed the session in the race
+			// window, re-spawning here would orphan a tmux session over the deleted
+			// worktree. Skip the tab on failure and let the next snapshot reconcile it.
+			ts = agentTmux.NewSiblingSession(td.TmuxName, tabProgram(kind, td.Command, program))
+			if err := ts.Restore(""); err != nil {
+				if firstErr == nil {
+					firstErr = fmt.Errorf("failed to reconnect tab %q: %w", td.Name, err)
+				}
+				continue
+			}
 		}
 		id := td.ID
 		if id == "" {
 			id = newTabID()
 		}
-		tab := &Tab{ID: id, Name: td.Name, Kind: kind, Command: td.Command, tmux: ts}
+		// URL rides along for a web tab (a vscode tab has none by design — its target
+		// is resolved at proxy time), or the pane would have nothing to iframe.
+		tab := &Tab{ID: id, Name: td.Name, Kind: kind, Command: td.Command, URL: td.URL, tmux: ts}
 		i.mu.Lock()
 		// Re-check under the write lock: a concurrent reconcile/AddTab may have
 		// added this name while we reconnected outside the lock.

--- a/session/snapshot_reconcile_test.go
+++ b/session/snapshot_reconcile_test.go
@@ -107,6 +107,80 @@ func TestReconcileTabsFromData_DropsClosedTab(t *testing.T) {
 	assert.Equal(t, TabKindAgent, inst.GetTabs()[0].Kind, "the agent tab is never dropped")
 }
 
+// TestReconcileTabsFromData_AddsTmuxlessWebTab is the post-merge Codex finding on
+// #1815: a web tab holds NO tmux session by design, and this loop used to skip
+// every target tab with an empty TmuxName — reading "" as "this tab's session is
+// missing" rather than "this kind never had one". So the headline #1815 case (an
+// agent injecting a live browser view with `tab-create --kind web`) published a
+// roster the TUI then silently discarded: the tab stayed invisible until a full
+// rebuild, even though the DROP side already removed such a tab by name.
+func TestReconcileTabsFromData_AddsTmuxlessWebTab(t *testing.T) {
+	const agentName = "af_snap_web"
+	inst, _ := newReconcileTestInstance(t, agentName, map[string]bool{agentName: true})
+
+	const url = "http://localhost:5173"
+	target := []TabData{
+		{Name: inst.GetTabs()[0].Name, Kind: TabKindAgent, TmuxName: agentName},
+		{Name: "livepreview", Kind: TabKindWeb, URL: url},
+	}
+
+	changed, err := inst.ReconcileTabsFromData(target)
+	require.NoError(t, err)
+	assert.True(t, changed, "an out-of-band web tab is a change")
+
+	tabs := inst.GetTabs()
+	require.Len(t, tabs, 2, "a web tab created out-of-band must appear on the live instance")
+	assert.Equal(t, TabKindWeb, tabs[1].Kind)
+	assert.Equal(t, url, tabs[1].URL, "the web tab's URL must survive the reconcile, or the pane has nothing to show")
+	assert.Nil(t, tabs[1].tmux, "a web tab holds no tmux session")
+	assert.NotEmpty(t, tabs[1].ID, "the reconciled tab must be addressable by a stable id (#1738)")
+
+	changedAgain, err := inst.ReconcileTabsFromData(target)
+	require.NoError(t, err)
+	assert.False(t, changedAgain, "an unchanged snapshot must not report a change")
+	assert.Len(t, inst.GetTabs(), 2, "no duplicate web tab on a repeat reconcile")
+}
+
+// TestReconcileTabsFromData_AddsTmuxlessVSCodeTab: the same gap covered the vscode
+// kind (#1817), which is tmux-less for the same reason and was skipped by the same
+// branch. It carries no URL by design — its code-server target is resolved at proxy
+// time — so an empty URL here is correct, not a dropped field.
+func TestReconcileTabsFromData_AddsTmuxlessVSCodeTab(t *testing.T) {
+	const agentName = "af_snap_code"
+	inst, _ := newReconcileTestInstance(t, agentName, map[string]bool{agentName: true})
+
+	target := []TabData{
+		{Name: inst.GetTabs()[0].Name, Kind: TabKindAgent, TmuxName: agentName},
+		{Name: "vscode", Kind: TabKindVSCode},
+	}
+
+	changed, err := inst.ReconcileTabsFromData(target)
+	require.NoError(t, err)
+	assert.True(t, changed, "an out-of-band vscode tab is a change")
+
+	tabs := inst.GetTabs()
+	require.Len(t, tabs, 2, "a vscode tab created out-of-band must appear on the live instance")
+	assert.Equal(t, TabKindVSCode, tabs[1].Kind)
+	assert.Nil(t, tabs[1].tmux, "a vscode tab holds no tmux session")
+}
+
+// TestReconcileTabsFromData_SkipsTmuxfulTabWithNoSession pins the other half of
+// TabKind.HasTmux: the empty-TmuxName skip must SURVIVE for a kind that is
+// supposed to own a PTY. Such a record is not reconstructable, and materializing
+// it would put a terminal tab with no process behind it in the TUI.
+func TestReconcileTabsFromData_SkipsTmuxfulTabWithNoSession(t *testing.T) {
+	const agentName = "af_snap_noname"
+	inst, _ := newReconcileTestInstance(t, agentName, map[string]bool{agentName: true})
+
+	changed, err := inst.ReconcileTabsFromData([]TabData{
+		{Name: inst.GetTabs()[0].Name, Kind: TabKindAgent, TmuxName: agentName},
+		{Name: "shell", Kind: TabKindShell}, // a PTY kind with no session to bind
+	})
+	require.NoError(t, err)
+	assert.False(t, changed, "a tmux-ful tab with no session must be skipped, not materialized")
+	assert.Len(t, inst.GetTabs(), 1)
+}
+
 // TestReconcileTabsFromData_NotStartedIsNoOp guards the not-started branch: an
 // unstarted instance (e.g. a Loading placeholder) must never attempt a reconnect.
 func TestReconcileTabsFromData_NotStartedIsNoOp(t *testing.T) {

--- a/session/tab.go
+++ b/session/tab.go
@@ -99,6 +99,30 @@ const (
 	TabKindVSCode
 )
 
+// HasTmux reports whether a tab of this kind owns a tmux PTY session — i.e.
+// whether its persisted TmuxName is expected to be non-empty.
+//
+// Agent, shell, and process tabs run a real process behind a PTY. Web and vscode
+// tabs are pure PROJECTIONS (an iframe target; a daemon-managed per-session
+// code-server resolved at proxy time) and deliberately hold none. That property
+// was stated only in the prose above, so every site that meets a tmux-less tab had
+// to re-derive it from an empty TmuxName — and reading "" as "this tab's session
+// is missing" rather than "this kind never had one" is what made an out-of-band
+// web tab invisible in a running TUI (post-merge Codex finding on #1815). This is
+// the single place that answers it.
+//
+// An unrecognized kind answers true: a tab claiming a process whose session can't
+// be found is skipped by its caller, which is the conservative failure (a tab that
+// doesn't show) rather than materializing a terminal tab with no PTY behind it.
+func (k TabKind) HasTmux() bool {
+	switch k {
+	case TabKindWeb, TabKindVSCode:
+		return false
+	default:
+		return true
+	}
+}
+
 // Tab is one process running in an instance's worktree, backed by a single tmux
 // session. It is an internal wrapper introduced in PR 1 of #930: an instance
 // holds exactly one Agent tab that wraps today's single tmux session, and the

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7026,6 +7026,10 @@ function clampActiveTab(list, selectedId, activeTab) {
   const n = sel.tabs && sel.tabs.length > 0 ? sel.tabs.length : 1;
   return Math.min(Math.max(activeTab, 0), n - 1);
 }
+function tabToKeepOnClose(ids, closedIndex, activeIndex) {
+  const keepIndex = closedIndex === activeIndex ? activeIndex - 1 : activeIndex;
+  return ids[keepIndex] ?? "";
+}
 
 // src/layout.ts
 var TAB_DND_MIME = "application/x-af-tab";
@@ -7778,9 +7782,7 @@ var SplitView = class {
       const before = this.tree;
       const settled = remapByIdentity(this.tree ?? singleLeaf(initialTab), prevIds, tabIds);
       this.tree = validate(settled, tabCount);
-      if (this.trees.get(sessionId) !== this.tree) {
-        this.trees.set(sessionId, this.tree);
-      }
+      this.retain(sessionId, this.tree, tabIds);
       const rebound = tabsRebound(prevIds, prevKinds, prevTargets, tabIds, tabKinds, tabTargets);
       if (before !== this.tree || rebound || archivedChanged) {
         this.reconcile();
@@ -7791,9 +7793,8 @@ var SplitView = class {
     this.teardown();
     this.sessionId = sessionId;
     this.tabCount = tabCount;
-    const retained = this.trees.get(sessionId);
-    this.tree = validate(retained ?? singleLeaf(initialTab), tabCount);
-    this.trees.set(sessionId, this.tree);
+    this.tree = validate(this.retainedTree(sessionId, tabIds) ?? singleLeaf(initialTab), tabCount);
+    this.retain(sessionId, this.tree, tabIds);
     this.focusedId = leaves(this.tree)[0]?.id ?? null;
     this.reconcile();
     this.report();
@@ -7810,12 +7811,25 @@ var SplitView = class {
    *  bar then highlights Agent over a pane showing tab N, and the next close computes
    *  its shift from the stale 0 and yanks the pane to Agent (#1855). Reading the
    *  settled tab keeps the store's claim and the pane's binding the same statement. */
-  settledTab(sessionId) {
+  settledTab(sessionId, tabIds) {
     if (sessionId === this.sessionId) {
       return this.tree && this.focusedId ? findLeaf(this.tree, this.focusedId)?.tab ?? 0 : 0;
     }
-    const retained = this.trees.get(sessionId);
+    const retained = this.retainedTree(sessionId, tabIds);
     return retained ? leaves(retained)[0]?.tab ?? 0 : 0;
+  }
+  /** The retained tree for `sessionId`, remapped onto `tabIds` — the only supported
+   *  way to read one. Returns null for a session never shown. */
+  retainedTree(sessionId, tabIds) {
+    const rec = this.trees.get(sessionId);
+    if (!rec) {
+      return null;
+    }
+    return remapByIdentity(rec.tree, rec.ids, tabIds);
+  }
+  /** Retains `tree` for `sessionId` together with the identities it is bound against. */
+  retain(sessionId, tree, ids) {
+    this.trees.set(sessionId, { tree, ids });
   }
   /** Rebinds the FOCUSED pane to show `tab` (a 1-9 key or a tab-bar click on the
    *  focused pane). No-op without a focused pane. Does not steal DOM focus. */
@@ -7889,7 +7903,8 @@ var SplitView = class {
     this.lastPaneCount = 0;
   }
   /** How many EXPLICIT layout/focus mutations have been committed — a tab rebind
-   *  (a 1-9 key or a tab-bar click), a drag-drop split, a pane close. Deliberately
+   *  (a 1-9 key or a tab-bar click), a drag-drop split, a pane close, or a change
+   *  of WHICH PANE is focused (a click into another pane, Alt+j/k). Deliberately
    *  NOT bumped by setSession's roster reconcile, which only remaps each pane to
    *  follow its own tab and expresses no user intent.
    *
@@ -7898,7 +7913,12 @@ var SplitView = class {
    *  applies its result only if the value still matches. A slow close then can't
    *  clobber a tab the user selected while it was in flight — their newer intent
    *  wins — while the roster event that races the same close still passes the
-   *  guard, because it bumps nothing. */
+   *  guard, because it bumps nothing.
+   *
+   *  Pane focus counts because the guarded write (setFocusedTab) targets the
+   *  FOCUSED pane: an index computed against the pane that issued the close is
+   *  meaningless once a different pane holds focus, and applying it there would
+   *  rebind the pane the user just picked (post-merge Codex finding on #1815). */
   layoutGeneration() {
     return this.layoutGen;
   }
@@ -7909,7 +7929,7 @@ var SplitView = class {
   commit() {
     this.layoutGen++;
     if (this.sessionId && this.tree) {
-      this.trees.set(this.sessionId, this.tree);
+      this.retain(this.sessionId, this.tree, this.tabIds);
     }
     this.reconcile();
     this.report();
@@ -8226,7 +8246,7 @@ var SplitView = class {
         if (this.tree) {
           this.tree = setRatio(this.tree, node.id, node.ratio);
           if (this.sessionId) {
-            this.trees.set(this.sessionId, this.tree);
+            this.retain(this.sessionId, this.tree, this.tabIds);
           }
         }
       };
@@ -8334,6 +8354,7 @@ var SplitView = class {
       return;
     }
     this.focusedId = leafId;
+    this.layoutGen++;
     this.applyFocusClass();
     const pane = this.panes.get(leafId);
     if (pane) {
@@ -9587,6 +9608,10 @@ function disconnect() {
     tasks: []
   });
 }
+function tabIdsOf(list, id) {
+  const s = id ? list.find((x) => x.id === id) : null;
+  return s ? sessionTabs(s).map(tabIdentity) : [];
+}
 function moveSelection(id) {
   clearTabError();
   store.set({
@@ -9594,7 +9619,7 @@ function moveSelection(id) {
     focus: "rail",
     // Clamped like syncSplit's initialTab, so the store's claim and the pane's binding
     // are the same statement even if the roster shrank since the tree was retained.
-    activeTab: clampActiveTab(store.get().sessions, id, splitView.settledTab(id))
+    activeTab: clampActiveTab(store.get().sessions, id, splitView.settledTab(id, tabIdsOf(store.get().sessions, id)))
   });
 }
 function openFromRail(id) {
@@ -9638,7 +9663,7 @@ function switchProject(root2) {
     selectedProject: root2,
     selectedId: keep,
     focus: "rail",
-    activeTab: keep ? clampActiveTab(store.get().sessions, keep, splitView.settledTab(keep)) : 0
+    activeTab: keep ? clampActiveTab(store.get().sessions, keep, splitView.settledTab(keep, tabIdsOf(store.get().sessions, keep))) : 0
   });
 }
 function selectedSession2() {
@@ -9795,14 +9820,13 @@ function closeSessionTab(index) {
   }
   clearTabError();
   const selId = sel.id ?? "";
-  const cur = store.get().activeTab;
+  const keepId = tabToKeepOnClose(tabs.map(tabIdentity), index, store.get().activeTab);
   const gen = splitView.layoutGeneration();
   void closeTab(selId, sel.title, target.name, tok).then(() => fetchSnapshot(tok)).then((sessions) => {
     const shrunk = sessions.find((s) => s.id === selId);
-    const n = shrunk ? sessionTabs(shrunk).length : 1;
-    const next = Math.min(Math.max(index <= cur ? cur - 1 : cur, 0), n - 1);
+    const next = shrunk ? sessionTabs(shrunk).map(tabIdentity).indexOf(keepId) : -1;
     store.set({ sessions, selectedId: pickSelection(sessions, store.get().selectedId) });
-    if (splitView.layoutGeneration() === gen && store.get().selectedId === selId) {
+    if (next >= 0 && splitView.layoutGeneration() === gen && store.get().selectedId === selId) {
       splitView.setFocusedTab(next);
     }
   }).catch((e) => surfaceTabError(e));
@@ -10000,7 +10024,7 @@ function applySessions(sessions) {
       selectedId = null;
     }
   }
-  const settled = selectedId === prevSel ? store.get().activeTab : splitView.settledTab(selectedId ?? "");
+  const settled = selectedId === prevSel ? store.get().activeTab : splitView.settledTab(selectedId ?? "", tabIdsOf(sessions, selectedId));
   const activeTab = clampActiveTab(sessions, selectedId, settled);
   store.set({ sessions, selectedProject, selectedId, activeTab });
 }

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -1983,6 +1983,209 @@ test("#1812 review: a close held in flight must not clobber a tab the user picks
   await expect(keeper).toHaveCount(0, { timeout: 15_000 });
 });
 
+// The post-merge Codex findings on #1815. All three are the same shape: #1815 made
+// out-of-band roster changes reach an open client LIVE, which turned three latent
+// ordinal-vs-identity assumptions into reachable misroutes. Each drives the exact
+// scenario Codex described and asserts on the tab the user is actually looking at.
+
+test("#1815 review: a concurrent out-of-band close cannot re-point the pane to a neighbour", async () => {
+  const afBin = process.env.AF_BIN;
+  const mockRepo = process.env.AF_MOCK_REPO;
+  test.skip(!afBin || !mockRepo, "AF_BIN/AF_MOCK_REPO are set only by web-selftest-entry.sh");
+  const { execFileSync } = await import("node:child_process");
+  const af = (...args: string[]): void => {
+    execFileSync(afBin as string, ["--repo", mockRepo as string, "sessions", ...args], { stdio: "pipe" });
+  };
+
+  await row(page, SESSION_A).click();
+  const tabbar = page.locator(".af-tabbar");
+  await expect(tabbar).toBeVisible();
+  const active = page.locator(".af-tab.af-tab-active .af-tab-label");
+  // Earlier flows leave their own tabs on this session, so every count here is
+  // relative to what is already on the bar rather than an absolute the next test to
+  // leave a tab behind would break.
+  const baseline = await tabbar.locator(".af-tab").count();
+
+  // Codex's scenario: this window closes t3 while ANOTHER client closes the LOWER t1
+  // first. The old code re-pointed the pane by subtracting its own close's shift from
+  // the pre-close ordinal — but t1's removal had already shifted t4 down underneath
+  // it, so the result named t5, the neighbour, and the pane the user was reading was
+  // torn down to show the wrong tab.
+  // One at a time, each awaited: the events hub DROPS a publish for a subscriber that
+  // is behind rather than blocking the daemon (clients re-Snapshot to resync), so a
+  // burst of CLI mutations can outrun the browser and lose a roster. Real actors don't
+  // burst, and this test is about ordering, not backpressure.
+  for (const name of ["t1", "t2", "t3", "t4", "t5"]) {
+    af("tab-create", SESSION_A, "--kind", "web", "--url", WEBTAB_EXTERNAL_URL, "--name", name);
+    await expect(tabbar.locator(".af-tab", { hasText: name })).toHaveCount(1, { timeout: 15_000 });
+  }
+
+  // Click the LABEL, not the button. A bar this crowded shrinks each tab until the
+  // button's CENTRE — where a bare .click() lands — is its × rather than its label,
+  // so clicking the button would close the tab instead of selecting it. The label's
+  // click still bubbles to the button's handler, which is the real select path.
+  await tabbar.locator(".af-tab", { hasText: "t4" }).locator(".af-tab-label").click();
+  await expect(active).toHaveText("t4");
+
+  let releaseClose: (() => void) | undefined;
+  const closeHeld = new Promise<void>((resolve) => {
+    releaseClose = resolve;
+  });
+  let closeInFlight = false;
+  await page.unroute("**/v1/CloseTab");
+  await page.route("**/v1/CloseTab", async (route) => {
+    closeInFlight = true;
+    await closeHeld;
+    await route.continue();
+  });
+
+  await tabbar.locator(".af-tab", { hasText: "t3" }).locator(".af-tab-close").click();
+  await expect.poll(() => closeInFlight, { timeout: 15_000 }).toBe(true);
+
+  // The other client closes a LOWER tab mid-flight. Waiting for it to leave the bar
+  // proves the #1815 event landed and the roster shifted BEFORE the close resolves —
+  // which is the whole point: this is the race #1815 itself made reachable.
+  af("tab-delete", SESSION_A, "--name", "t1");
+  await expect(tabbar.locator(".af-tab", { hasText: "t1" })).toHaveCount(0, { timeout: 15_000 });
+
+  releaseClose?.();
+  await expect(tabbar.locator(".af-tab", { hasText: "t3" })).toHaveCount(0, { timeout: 15_000 });
+  await expect(active, "the pane must still show the tab the user was on, not its neighbour").toHaveText("t4");
+
+  await page.unroute("**/v1/CloseTab");
+  for (const name of ["t2", "t4", "t5"]) {
+    af("tab-delete", SESSION_A, "--name", name);
+    await expect(tabbar.locator(".af-tab", { hasText: name })).toHaveCount(0, { timeout: 15_000 });
+  }
+  await expect(tabbar.locator(".af-tab")).toHaveCount(baseline, { timeout: 15_000 });
+});
+
+test("#1815 review: a pane focused mid-close keeps its own tab", async () => {
+  const afBin = process.env.AF_BIN;
+  const mockRepo = process.env.AF_MOCK_REPO;
+  test.skip(!afBin || !mockRepo, "AF_BIN/AF_MOCK_REPO are set only by web-selftest-entry.sh");
+  const { execFileSync } = await import("node:child_process");
+  const af = (...args: string[]): void => {
+    execFileSync(afBin as string, ["--repo", mockRepo as string, "sessions", ...args], { stdio: "pipe" });
+  };
+
+  await row(page, SESSION_A).click();
+  await expect(page.locator(".af-main.af-main-term")).toBeVisible();
+  const tabbar = page.locator(".af-tabbar");
+  const active = page.locator(".af-tab.af-tab-active .af-tab-label");
+
+  // The guard keyed off layoutGeneration, which counted tab rebinds and splits but
+  // NOT a change of which PANE holds focus — and the guarded write (setFocusedTab)
+  // targets the focused pane. So a close held in flight could rebind the pane the
+  // user had just clicked, using an index computed for the pane that issued it.
+  // PROCESS tabs, not web tabs: this test has to move focus BETWEEN panes by clicking
+  // them, and a web tab's pane is an iframe that swallows the mousedown the pane's
+  // focus handler listens for. A PTY pane is the surface a user actually clicks
+  // between, which is the gesture the guard has to survive.
+  const baseline = await tabbar.locator(".af-tab").count();
+  for (const name of ["k1", "k2"]) {
+    af("tab-create", SESSION_A, "--command", "sleep 300", "--name", name);
+    await expect(tabbar.locator(".af-tab", { hasText: name })).toHaveCount(1, { timeout: 30_000 });
+  }
+
+  await tabbar.locator(".af-tab", { hasText: "k2" }).locator(".af-tab-label").click();
+  await expect(active).toHaveText("k2");
+
+  // Split, so there are two panes and "which pane is focused" is a real question. The
+  // agent pane is the one streaming the ready marker; the other is k2's.
+  await dragTabToPane(page, "Agent", "right");
+  await expect(page.locator(".af-term-host .af-pane")).toHaveCount(2, { timeout: 15_000 });
+  await expect(page.locator(".af-term-host")).toContainText(READY_MARKER, { timeout: 15_000 });
+  const agentPane = page.locator(".af-term-host .af-pane", { hasText: READY_MARKER });
+  const k2Pane = page.locator(".af-term-host .af-pane", { hasNotText: READY_MARKER });
+  await expect(agentPane).toHaveCount(1);
+  await expect(k2Pane).toHaveCount(1);
+
+  // Focus the k2 pane — this is the pane the close is issued from, and the one whose
+  // index the close's `next` is computed against.
+  await k2Pane.locator(".af-pane-host").click();
+  await expect(active).toHaveText("k2");
+
+  let releaseClose: (() => void) | undefined;
+  const closeHeld = new Promise<void>((resolve) => {
+    releaseClose = resolve;
+  });
+  let closeInFlight = false;
+  await page.unroute("**/v1/CloseTab");
+  await page.route("**/v1/CloseTab", async (route) => {
+    closeInFlight = true;
+    await closeHeld;
+    await route.continue();
+  });
+
+  await tabbar.locator(".af-tab", { hasText: "k1" }).locator(".af-tab-close").click();
+  await expect.poll(() => closeInFlight, { timeout: 15_000 }).toBe(true);
+
+  // Mid-flight the user clicks the OTHER pane. That is a deliberate move of focus, and
+  // the close's stale index means nothing for the pane they just chose.
+  await agentPane.locator(".af-pane-host").click();
+  await expect(active).toHaveText("Agent");
+
+  releaseClose?.();
+  await expect(tabbar.locator(".af-tab", { hasText: "k1" })).toHaveCount(0, { timeout: 15_000 });
+  await expect(active, "the pane the user focused mid-close must keep its own tab").toHaveText("Agent");
+
+  // Collapse the split and restore A's single-tab baseline for the later flows.
+  await page.unroute("**/v1/CloseTab");
+  await agentPane.locator(".af-pane-close").click();
+  await expect(page.locator(".af-term-host .af-pane")).toHaveCount(1, { timeout: 15_000 });
+  af("tab-delete", SESSION_A, "--name", "k2");
+  await expect(tabbar.locator(".af-tab")).toHaveCount(baseline, { timeout: 15_000 });
+});
+
+test("#1815 review: a retained layout follows its tab when the roster changes while away", async () => {
+  const afBin = process.env.AF_BIN;
+  const mockRepo = process.env.AF_MOCK_REPO;
+  test.skip(!afBin || !mockRepo, "AF_BIN/AF_MOCK_REPO are set only by web-selftest-entry.sh");
+  const { execFileSync } = await import("node:child_process");
+  const af = (...args: string[]): void => {
+    execFileSync(afBin as string, ["--repo", mockRepo as string, "sessions", ...args], { stdio: "pipe" });
+  };
+
+  const tabbar = page.locator(".af-tabbar");
+  const active = page.locator(".af-tab.af-tab-active .af-tab-label");
+
+  // The split view retains a layout per session, but only ever remapped the SHOWN
+  // session's panes onto a changed roster; a session the user had navigated away from
+  // was merely clamped on return. Its leaves hold ORDINALS, so an out-of-band close
+  // while away — which #1815 now delivers live — silently rebound them to whatever
+  // slid into the slot. Tabs [Agent,r1,r2,r3] with the pane on r2 (index 2): drop r1
+  // and the stale ordinal 2 is r3, an entirely different tab.
+  await row(page, SESSION_A).click();
+  await expect(tabbar).toBeVisible();
+  const baseline = await tabbar.locator(".af-tab").count();
+  for (const name of ["r1", "r2", "r3"]) {
+    af("tab-create", SESSION_A, "--kind", "web", "--url", WEBTAB_EXTERNAL_URL, "--name", name);
+    await expect(tabbar.locator(".af-tab", { hasText: name })).toHaveCount(1, { timeout: 15_000 });
+  }
+  await tabbar.locator(".af-tab", { hasText: "r2" }).locator(".af-tab-label").click();
+  await expect(active).toHaveText("r2");
+
+  // Navigate away, so A's layout is only RETAINED — not the live one being reconciled.
+  await row(page, SESSION_B).click();
+  await expect(page.locator(".af-main.af-main-term")).toBeVisible();
+
+  af("tab-delete", SESSION_A, "--name", "r1");
+
+  // Back to A: its pane must still be on r2, which is now index 1.
+  await row(page, SESSION_A).click();
+  await expect(tabbar.locator(".af-tab", { hasText: "r1" })).toHaveCount(0, { timeout: 15_000 });
+  await expect(active, "a retained pane must follow its TAB across an out-of-band close, not its slot").toHaveText(
+    "r2",
+  );
+
+  for (const name of ["r2", "r3"]) {
+    af("tab-delete", SESSION_A, "--name", name);
+    await expect(tabbar.locator(".af-tab", { hasText: name })).toHaveCount(0, { timeout: 15_000 });
+  }
+  await expect(tabbar.locator(".af-tab")).toHaveCount(baseline, { timeout: 15_000 });
+});
+
 test("vscode tab (feat): the ▾ menu creates a VS Code tab and the daemon serves it through the proxy", async () => {
   // End to end, with no seeded fixture: pick VS Code from the tab bar's kind menu,
   // and the daemon spawns a code-server (the FAKE one on PATH — no CI box has a

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -39,7 +39,7 @@ import { EventStream, type EventStreamStatus } from "./events.js";
 import { confirmDeleteProjectModal, confirmModal, type ModalHandle, newSessionModal, promptModal } from "./modals.js";
 import { decideKey, type KeyboardFocus, type View } from "./nav.js";
 import { loadProjectChoice, persistProjectChoice, pickerProjects, reconcileProject, scopeToProject } from "./project.js";
-import { applyEvent, clampActiveTab, pickSelection, upsertSession } from "./sessions.js";
+import { applyEvent, clampActiveTab, pickSelection, tabToKeepOnClose, upsertSession } from "./sessions.js";
 import { SplitView } from "./split.js";
 import { isArchived } from "./status.js";
 import { Store } from "./store.js";
@@ -301,6 +301,14 @@ function disconnect(): void {
 
 // --- keyboard focus (nav vs terminal, #1693) -------------------------------
 
+/** The ordered tab identities of `id` in `list` — the list a retained layout's leaf
+ *  ordinals mean something relative to. Empty for a session that isn't there (a
+ *  never-shown or just-removed one), which reads as "nothing to remap against". */
+function tabIdsOf(list: SessionData[], id: string | null): string[] {
+  const s = id ? list.find((x) => x.id === id) : null;
+  return s ? sessionTabs(s).map(tabIdentity) : [];
+}
+
 /** Moves the rail selection to a session by its stable id and puts the keyboard in
  *  rail-nav mode. This is the keyboard path (j/k): selecting a row never steals the
  *  keyboard into the terminal — you attach explicitly with Enter. Resetting focus to
@@ -315,7 +323,7 @@ function moveSelection(id: string): void {
     focus: "rail",
     // Clamped like syncSplit's initialTab, so the store's claim and the pane's binding
     // are the same statement even if the roster shrank since the tree was retained.
-    activeTab: clampActiveTab(store.get().sessions, id, splitView.settledTab(id)),
+    activeTab: clampActiveTab(store.get().sessions, id, splitView.settledTab(id, tabIdsOf(store.get().sessions, id))),
   });
 }
 
@@ -389,7 +397,9 @@ function switchProject(root: string): void {
     selectedProject: root,
     selectedId: keep,
     focus: "rail",
-    activeTab: keep ? clampActiveTab(store.get().sessions, keep, splitView.settledTab(keep)) : 0,
+    activeTab: keep
+      ? clampActiveTab(store.get().sessions, keep, splitView.settledTab(keep, tabIdsOf(store.get().sessions, keep)))
+      : 0,
   });
 }
 
@@ -629,38 +639,44 @@ function closeSessionTab(index: number): void {
   }
   clearTabError();
   const selId = sel.id ?? "";
-  // Read the active index BEFORE the close, not after the awaits: `next` below is
-  // computed RELATIVE to the PRE-close list, so it is only correct against the index
-  // as it stood when this close was issued. The daemon's tab event (#1812) can land
-  // while these awaits are in flight — rerendering with the shrunk roster, which
-  // remaps each pane to follow its own tab and writes the ALREADY-shifted index back
-  // as activeTab. Reading it afterwards would then subtract the shift a SECOND time
-  // and re-point the pane one tab too far left — tearing down a surviving web tab's
-  // iframe to show its neighbour instead (the #1779 guarantee).
+  // Decide WHICH TAB the pane should end on by IDENTITY, not by arithmetic on an
+  // index. Closing tab N shifts every higher tab down by one, and the tempting fix is
+  // to subtract that shift — but an ordinal only names a tab relative to one roster,
+  // and this close spans two. Both directions of that arithmetic are wrong:
   //
-  // Taking a pre-await snapshot means `next` can go STALE the other way, so pin what
-  // it assumes: this session, and no explicit layout/focus mutation since. A slow
-  // close leaves a wide window in which the user can select another tab, and
-  // re-pointing the pane from an index computed against the old selection would yank
-  // it back (the same stale-async hazard the #1777 scroll-fill token guards). The
-  // roster event races the same window but bumps no generation, so it still passes.
-  const cur = store.get().activeTab;
+  //  - Reading activeTab AFTER the awaits double-subtracts. The daemon's tab event
+  //    (#1812) can land mid-flight, rerendering with the shrunk roster, remapping each
+  //    pane to follow its own tab (#1779) and writing the ALREADY-shifted index back —
+  //    so subtracting again lands a tab too far left.
+  //  - Subtracting from a PRE-await snapshot instead goes stale the other way: another
+  //    client closing a LOWER tab in the same window shifts the roster underneath, and
+  //    the pre-computed ordinal then names a neighbour. (Roster events deliberately
+  //    bump no generation, so the guard below can't catch that one.)
+  //
+  // Naming the tab itself sidesteps both: whatever the roster does meanwhile, the pane
+  // follows the tab the user was actually looking at — the same principle #1779 put in
+  // the layout tree, applied to the store's index. See sessions.tabToKeepOnClose, which
+  // holds the decision as a pure function so both directions above are unit-tested.
+  const keepId = tabToKeepOnClose(tabs.map(tabIdentity), index, store.get().activeTab);
+  // Pin what the rebind assumes: this session, and no explicit layout/focus mutation
+  // since. A slow close leaves a wide window in which the user can select another tab
+  // or focus another pane, and re-pointing from an intent formed before that would
+  // yank it back (the same stale-async hazard the #1777 scroll-fill token guards).
   const gen = splitView.layoutGeneration();
   void closeTab(selId, sel.title, target.name, tok)
     .then(() => fetchSnapshot(tok))
     .then((sessions) => {
-      // The close shifts every higher tab down by one: if the closed tab was at or
-      // before the active one, the active index moves left to keep showing the same
-      // tab (or its left neighbor when the active tab itself was closed).
+      // Resolve the kept tab's CURRENT ordinal in the post-close roster.
       const shrunk = sessions.find((s) => s.id === selId);
-      const n = shrunk ? sessionTabs(shrunk).length : 1;
-      const next = Math.min(Math.max(index <= cur ? cur - 1 : cur, 0), n - 1);
+      const next = shrunk ? sessionTabs(shrunk).map(tabIdentity).indexOf(keepId) : -1;
       // Commit the shrunk tab list first (rerender → syncSplit re-validates the tree,
       // clamping any pane past the new end), then re-point the focused pane — but only
-      // if `next` still describes anything real: the user must not have moved focus or
-      // switched away to another session while the close was in flight.
+      // if the rebind still describes anything real: the user must not have moved focus
+      // or switched away while the close was in flight, and the kept tab must still
+      // exist (a concurrent close can take it too, in which case syncSplit's remap has
+      // already settled the pane somewhere sane and guessing again would only misroute).
       store.set({ sessions, selectedId: pickSelection(sessions, store.get().selectedId) });
-      if (splitView.layoutGeneration() === gen && store.get().selectedId === selId) {
+      if (next >= 0 && splitView.layoutGeneration() === gen && store.get().selectedId === selId) {
         splitView.setFocusedTab(next);
       }
     })
@@ -990,7 +1006,10 @@ function applySessions(sessions: SessionData[]): void {
   // An unchanged selection keeps its active tab; one the snapshot MOVED (the selected
   // session was archived/killed, so pickSelection landed elsewhere) takes the tab its
   // retained layout will settle on rather than asserting 0 (#1855, as moveSelection).
-  const settled = selectedId === prevSel ? store.get().activeTab : splitView.settledTab(selectedId ?? "");
+  const settled =
+    selectedId === prevSel
+      ? store.get().activeTab
+      : splitView.settledTab(selectedId ?? "", tabIdsOf(sessions, selectedId));
   const activeTab = clampActiveTab(sessions, selectedId, settled);
   store.set({ sessions, selectedProject, selectedId, activeTab });
 }

--- a/web/src/sessions.test.ts
+++ b/web/src/sessions.test.ts
@@ -8,7 +8,15 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { applyEvent, clampActiveTab, pickSelection, removeSession, sessionKey, upsertSession } from "./sessions.js";
+import {
+  applyEvent,
+  clampActiveTab,
+  pickSelection,
+  removeSession,
+  sessionKey,
+  tabToKeepOnClose,
+  upsertSession,
+} from "./sessions.js";
 import { orderedSessions } from "./ui.js";
 import { Liveness, type SessionData, type WireEvent } from "./types.js";
 
@@ -163,4 +171,63 @@ test("orderedSessions: title breaks a created_at tie in the archived group (tota
     sess("arch-a", { liveness: Liveness.Archived, created_at: "2026-01-01T00:00:00Z" }),
   ];
   assert.deepEqual(orderedSessions(list).map((s) => s.title), ["arch-a", "arch-b"]);
+});
+
+// --- tabToKeepOnClose: a pane follows a TAB, never a slot -------------------
+//
+// The post-merge Codex finding on #1815. closeSessionTab used to re-point the pane
+// by subtracting the close's shift from the active index. That arithmetic is only
+// valid if the roster it was computed against is the roster it lands on — and #1815
+// made the opposite reachable, by delivering another client's tab changes live and
+// mid-flight. These pin the decision against both rosters.
+
+test("closing a LOWER tab keeps the active tab, by identity", () => {
+  // [Agent, A, B] with B active; A closes. B survives, so the pane follows B —
+  // wherever the shrunk roster puts it.
+  assert.equal(tabToKeepOnClose(["id-agent", "id-a", "id-b"], 1, 2), "id-b");
+});
+
+test("closing a HIGHER tab keeps the active tab, by identity", () => {
+  assert.equal(tabToKeepOnClose(["id-agent", "id-a", "id-b"], 2, 1), "id-a");
+});
+
+test("closing the ACTIVE tab falls back to its LEFT NEIGHBOUR in the pre-close list", () => {
+  // Nothing to follow: the tab the pane was on is the one going away. The neighbour
+  // is named from the pre-close roster, where "left of the closed tab" still means
+  // something — the post-close list no longer contains the closed tab to count from.
+  assert.equal(tabToKeepOnClose(["id-agent", "id-a", "id-b"], 2, 2), "id-a");
+});
+
+test("closing the tab right above Agent falls back to Agent", () => {
+  assert.equal(tabToKeepOnClose(["id-agent", "id-a"], 1, 1), "id-agent");
+});
+
+test("a concurrent out-of-band close cannot re-point the pane to a neighbour (#1815 follow-up)", () => {
+  // Codex's exact scenario: tabs [Agent,A,B,C,D,E,F] with E active; this window
+  // closes D while ANOTHER client closes B first. The old code computed next from
+  // the stale ordinal (cur=5 → 4) and applied it to the post-close roster, landing on
+  // F — a tab the user never picked, tearing down E's pane to show its neighbour.
+  const before = ["id-agent", "id-a", "id-b", "id-c", "id-d", "id-e", "id-f"];
+  const keep = tabToKeepOnClose(before, 4, 5);
+  assert.equal(keep, "id-e");
+
+  // The roster after BOTH closes (B out-of-band, then D). Resolving the identity —
+  // what closeSessionTab does with this value — follows E to its real new index.
+  const after = ["id-agent", "id-a", "id-c", "id-e", "id-f"];
+  assert.equal(after.indexOf(keep), 3, "the pane must follow E, not land on the old ordinal");
+  assert.notEqual(after.indexOf(keep), 4, "index 4 is F — the neighbour the ordinal arithmetic picked");
+});
+
+test("a kept tab closed out-of-band mid-flight resolves to -1, not a guess", () => {
+  // The caller treats -1 as "leave the pane where the roster remap already settled
+  // it": re-pointing from a dead identity could only misroute.
+  const keep = tabToKeepOnClose(["id-agent", "id-a", "id-b"], 1, 2);
+  assert.equal(["id-agent", "id-a"].indexOf(keep), -1);
+});
+
+test("an out-of-range active index yields no tab to follow", () => {
+  assert.equal(tabToKeepOnClose(["id-agent"], 1, 5), "");
+  // Identities are never empty (ui.tabIdentity synthesizes a kind:name fallback), so
+  // "" can't accidentally match a real tab when the caller resolves it.
+  assert.equal(["id-agent", "id-a"].indexOf(""), -1);
 });

--- a/web/src/sessions.ts
+++ b/web/src/sessions.ts
@@ -124,3 +124,27 @@ export function clampActiveTab(list: SessionData[], selectedId: string | null, a
   const n = sel.tabs && sel.tabs.length > 0 ? sel.tabs.length : 1;
   return Math.min(Math.max(activeTab, 0), n - 1);
 }
+
+/** The IDENTITY of the tab a pane should end on once the tab at `closedIndex` is
+ *  closed, given the roster (`ids`, from ui.tabIdentity) and active index as they
+ *  stand when the close is ISSUED. Returns "" when there is nothing to follow.
+ *
+ *  Closing a tab shifts every higher tab down by one, and the tempting way to
+ *  re-point the pane is to subtract that shift from the active index. But an
+ *  ordinal only names a tab relative to ONE roster, and a close spans two — the
+ *  pre-close list it is computed against and the post-close list it is applied to.
+ *  Anything else that moves the roster in between (a concurrent close from another
+ *  client, now delivered live by #1815) invalidates the arithmetic silently, and the
+ *  pane lands on a neighbour. Naming the TAB instead survives any reshuffle: the
+ *  caller resolves this identity to its current ordinal in the post-close roster,
+ *  and a -1 there is the honest "it's gone too" rather than a wrong guess.
+ *
+ *  This is the store-side twin of layout.remapByIdentity, which does the same for
+ *  the pane tree (#1779): a pane follows a TAB, never a slot. */
+export function tabToKeepOnClose(ids: string[], closedIndex: number, activeIndex: number): string {
+  // Closing the ACTIVE tab: there is no surviving tab to follow, so fall back to its
+  // left neighbour — picked from the PRE-close list, the only roster in which "the
+  // tab left of the one being closed" is still a well-defined statement.
+  const keepIndex = closedIndex === activeIndex ? activeIndex - 1 : activeIndex;
+  return ids[keepIndex] ?? "";
+}

--- a/web/src/split.ts
+++ b/web/src/split.ts
@@ -113,10 +113,26 @@ function webFallbackMs(): number {
   return typeof override === "number" ? override : 2500;
 }
 
+/** A retained layout, plus the tab identities its leaf ordinals were bound against.
+ *
+ *  The two are inseparable, which is why they are one record. A leaf holds an
+ *  ORDINAL, and an ordinal only names a tab RELATIVE to the identity list current
+ *  when it was bound. Retaining the tree alone leaves a value that silently decays:
+ *  once that session's roster shifts, every ordinal in it points somewhere new.
+ *  The shown session was already remapped on each setSession (#1779), but a session
+ *  the user isn't looking at had no such path — and #1815 made an out-of-band close
+ *  reach the client live, so its retained panes could be rebound to a neighbouring
+ *  tab on return (post-merge Codex finding). Keeping the ids with the tree makes
+ *  "remap before you read it" checkable rather than remembered. */
+interface RetainedLayout {
+  tree: LayoutNode;
+  ids: string[];
+}
+
 export class SplitView {
   // Retained layout per session id (in-memory; a nice-to-have to persist across
   // reload is out of scope for v1). Keyed by the stable session id.
-  private readonly trees = new Map<string, LayoutNode>();
+  private readonly trees = new Map<string, RetainedLayout>();
   private readonly panes = new Map<string, Pane>();
 
   private sessionId: string | null = null;
@@ -218,9 +234,10 @@ export class SplitView {
       // streaming untouched; only a genuinely replaced tab rebuilds.
       const settled = remapByIdentity(this.tree ?? singleLeaf(initialTab), prevIds, tabIds);
       this.tree = validate(settled, tabCount);
-      if (this.trees.get(sessionId) !== this.tree) {
-        this.trees.set(sessionId, this.tree);
-      }
+      // Always re-retain: `ids` must track the roster even when the remap left the
+      // tree identical, or the record would claim ordinals were bound against a list
+      // that has since moved on — the decay the record exists to prevent.
+      this.retain(sessionId, this.tree, tabIds);
       // Reconcile on a changed tab IDENTITY, not just a changed tree (#1779) — see
       // tabsRebound. reconcile() is a no-op per pane whose identity still matches,
       // so an unrelated snapshot still costs nothing. An archive/restore flip (#1809)
@@ -238,9 +255,14 @@ export class SplitView {
     this.teardown();
     this.sessionId = sessionId;
     this.tabCount = tabCount;
-    const retained = this.trees.get(sessionId);
-    this.tree = validate(retained ?? singleLeaf(initialTab), tabCount);
-    this.trees.set(sessionId, this.tree);
+    // Remap the retained tree onto the CURRENT roster before validating it. Its
+    // ordinals were bound against the tab list as it stood when the user last looked
+    // at this session; anything that changed the roster since (an agent's tab-create,
+    // another window's close — now delivered live by #1815) moved the tabs out from
+    // under them. validate() alone only clamps a too-high ordinal, so a pane would
+    // come back bound to whatever tab slid into its slot.
+    this.tree = validate(this.retainedTree(sessionId, tabIds) ?? singleLeaf(initialTab), tabCount);
+    this.retain(sessionId, this.tree, tabIds);
     // Focus the first pane of the newly shown session by default.
     this.focusedId = leaves(this.tree)[0]?.id ?? null;
     this.reconcile();
@@ -259,12 +281,31 @@ export class SplitView {
    *  bar then highlights Agent over a pane showing tab N, and the next close computes
    *  its shift from the stale 0 and yanks the pane to Agent (#1855). Reading the
    *  settled tab keeps the store's claim and the pane's binding the same statement. */
-  settledTab(sessionId: string): number {
+  settledTab(sessionId: string, tabIds: string[]): number {
     if (sessionId === this.sessionId) {
       return this.tree && this.focusedId ? (findLeaf(this.tree, this.focusedId)?.tab ?? 0) : 0;
     }
-    const retained = this.trees.get(sessionId);
+    // Read the REMAPPED tree, exactly as setSession will: this answers "which tab will
+    // that pane show once selected?", and the two must agree or the bar highlights one
+    // tab while the pane binds another (#1855). Passing the same ids setSession gets is
+    // what keeps the answers identical.
+    const retained = this.retainedTree(sessionId, tabIds);
     return retained ? (leaves(retained)[0]?.tab ?? 0) : 0;
+  }
+
+  /** The retained tree for `sessionId`, remapped onto `tabIds` — the only supported
+   *  way to read one. Returns null for a session never shown. */
+  private retainedTree(sessionId: string, tabIds: string[]): LayoutNode | null {
+    const rec = this.trees.get(sessionId);
+    if (!rec) {
+      return null;
+    }
+    return remapByIdentity(rec.tree, rec.ids, tabIds);
+  }
+
+  /** Retains `tree` for `sessionId` together with the identities it is bound against. */
+  private retain(sessionId: string, tree: LayoutNode, ids: string[]): void {
+    this.trees.set(sessionId, { tree, ids });
   }
 
   /** Rebinds the FOCUSED pane to show `tab` (a 1-9 key or a tab-bar click on the
@@ -349,7 +390,8 @@ export class SplitView {
   }
 
   /** How many EXPLICIT layout/focus mutations have been committed — a tab rebind
-   *  (a 1-9 key or a tab-bar click), a drag-drop split, a pane close. Deliberately
+   *  (a 1-9 key or a tab-bar click), a drag-drop split, a pane close, or a change
+   *  of WHICH PANE is focused (a click into another pane, Alt+j/k). Deliberately
    *  NOT bumped by setSession's roster reconcile, which only remaps each pane to
    *  follow its own tab and expresses no user intent.
    *
@@ -358,7 +400,12 @@ export class SplitView {
    *  applies its result only if the value still matches. A slow close then can't
    *  clobber a tab the user selected while it was in flight — their newer intent
    *  wins — while the roster event that races the same close still passes the
-   *  guard, because it bumps nothing. */
+   *  guard, because it bumps nothing.
+   *
+   *  Pane focus counts because the guarded write (setFocusedTab) targets the
+   *  FOCUSED pane: an index computed against the pane that issued the close is
+   *  meaningless once a different pane holds focus, and applying it there would
+   *  rebind the pane the user just picked (post-merge Codex finding on #1815). */
   layoutGeneration(): number {
     return this.layoutGen;
   }
@@ -371,7 +418,7 @@ export class SplitView {
   private commit(): void {
     this.layoutGen++;
     if (this.sessionId && this.tree) {
-      this.trees.set(this.sessionId, this.tree);
+      this.retain(this.sessionId, this.tree, this.tabIds);
     }
     this.reconcile();
     this.report();
@@ -842,7 +889,7 @@ export class SplitView {
         if (this.tree) {
           this.tree = setRatio(this.tree, node.id, node.ratio);
           if (this.sessionId) {
-            this.trees.set(this.sessionId, this.tree);
+            this.retain(this.sessionId, this.tree, this.tabIds);
           }
         }
       };
@@ -967,6 +1014,12 @@ export class SplitView {
       return;
     }
     this.focusedId = leafId;
+    // A focus move is an explicit mutation for the stale-async guard, so count it
+    // (see layoutGeneration). Not via commit(): the TREE is untouched here, and
+    // reconciling/re-persisting it would be wasted work on every pane click. The
+    // early return above means only a REAL change counts — re-focusing the pane
+    // that already holds focus must not invalidate an in-flight close.
+    this.layoutGen++;
     this.applyFocusClass();
     // The focused pane's status becomes the header status.
     const pane = this.panes.get(leafId);


### PR DESCRIPTION
Codex reviewed #1815 **after** it merged, across several rounds — 15 inline comments on `daemon/manager_tabs.go`, `web/src/index.ts`, `web/src/split.ts` and the selftest spec. They collapse to **6 distinct findings**, triaged here against the merged head (`f055f7b`): **5 valid and fixed**, **1 invalid and answered on its thread**.

Do not merge yet — opening as a draft for review.

## Why they cluster

All five accepted findings are one root shape, which is why the review surfaced them together. #1815 made an out-of-band roster change reach a **live** client, and that turned two latent assumptions into reachable misroutes:

- **An ordinal only names a tab relative to one roster.** #1779 already established that a pane follows a *tab*, never a slot — but that principle lived only in the layout tree. The store's active index and the retained layouts still did arithmetic on slots.
- **A whole-session payload only means something in the order it was persisted.** `session.updated` carries a full `InstanceData` and every client re-projects wholesale from it, so publish order decides which snapshot wins.

## Accepted (5)

| # | Finding | Fix |
|---|---------|-----|
| 1 | `focusPane()` reported a new `activeTab` but never bumped `layoutGeneration`, so the stale-close guard passed after the user clicked another pane — and the guarded write targets the **focused** pane, so it rebound the pane they'd just chosen. The generation's own doc already claimed to count focus. | Count focus moves in the generation (not via `commit()` — the tree is untouched). |
| 2 | `closeSessionTab` re-pointed the pane by subtracting the close's shift from an ordinal. That spans two rosters; a concurrent out-of-band close of a **lower** tab shifts it underneath and the result names a neighbour. | New pure `sessions.tabToKeepOnClose`, keyed on tab **identity** and resolved against the post-close roster. `-1` = the kept tab is gone too → leave the pane where the remap settled it, rather than guess. |
| 3 | `persistPollChange` snapshotted + persisted under the repo start lock, **released it**, then published. A poll preempted in that window lands its older payload after a newer tab roster — re-projecting a just-created tab out of existence until some later update repairs it. On a quiet session that repair never comes. | Publish inside the same critical section as its persist, matching `CreateTab`/`CloseTab`. |
| 4 | Retained layouts were identity-remapped only for the **shown** session; an inactive one was merely `validate()`-clamped on return, so its panes rebound to whatever slid into their slot. | A retained tree and the identities it was bound against are now **one record**, remapped on every read. `settledTab` reads the remapped tree, so the bar's claim and the pane's binding stay the same statement (#1855). |
| 5 | `ReconcileTabsFromData` skipped every target tab with an empty `TmuxName` — reading `""` as *"this tab's session is missing"* rather than *"this kind never has one"*. Web tabs created out-of-band stayed invisible in a running TUI, though the drop side already removed them by name. | `TabKind.HasTmux()` states the property once; the reconcile appends tmux-less kinds directly, as `restoreLocalTabs` already did on load. |

**Finding 5 went wider than reported.** Codex named only `--kind web`; `--kind vscode` (#1817) is tmux-less for the same reason and hit the same branch. Both are fixed and tested.

## Rejected (1)

**"Pass `--repo` after the sessions subcommand"** (2 comments) — replied on the thread. The claim is that `af --repo X sessions …` dies as an unknown root flag. It doesn't: cobra resolves the subcommand first and parses the whole arg vector against *its* flag set, which includes `SessionsCmd`'s persistent `--repo`. Verified against the real binary (exit 0). Had this been right, the #1812 selftest could never have gone green in the first place — it drives every out-of-band mutation through that helper.

## Tests

Every accepted finding has a regression test **verified to fail on the pre-fix code** and pass after — I reverted each fix individually to confirm, rather than trusting that a green test proves anything.

- `web/src/sessions.test.ts` — 7 unit tests on `tabToKeepOnClose`, including Codex's exact `[Agent,A,B,C,D,E,F]` concurrent-close example.
- `web/selftest/web-driver.spec.ts` — 3 Playwright tests driving the real scenarios: a concurrent out-of-band close mid-flight, a pane focused mid-close, and a retained layout whose roster changed while away.
- `daemon/tab_event_order_test.go` — the publish/persist ordering. The unlock→publish window is a few instructions wide, so racing goroutines would almost never catch a regression; a probabilistic test that passes on broken code is worse than none. It asserts the property **directly** at a seam (`testHookPollBeforePublish`, mirroring the existing `testHookSpawnPingPassed`): `TryLock` from inside the hook must fail, because the poll owns the mutex. Move the publish back after the `Unlock` and it goes red deterministically.
- `session/snapshot_reconcile_test.go` — tmux-less web + vscode reconcile, plus a guard that the empty-`TmuxName` skip **survives** for a kind that *should* own a PTY.

Two selftest fixes worth flagging, both my own test bugs rather than product bugs: a crowded tab bar shrinks each button until its centre (where a bare `.click()` lands) is the `×`, so those clicks target `.af-tab-label`; and counts are now relative to a captured baseline, since earlier flows leave their own tabs on `probe-a`.

## Gates

`make test-container` · `make tui-driver-selftest` (38/38) · `make web-selftest-container` (46/46) · `make web-test` (166) · `go build` · `gofmt` · `golangci-lint` · `deadcode` · `lint-file-length`. `web/dist` rebuilt and committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
