### PR TITLE
fix(cli): --backend help said ssh is not implemented; it is (#1888)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -586,7 +586,7 @@ func init() {
 	sessionsCreateCmd.Flags().StringVar(&createProgramFlag, "program", "", "Program to run (one of: "+tmux.SupportedProgramsString()+"; defaults to config default)")
 	sessionsCreateCmd.Flags().BoolVar(&createHereFlag, "here", false, "Run in the repo's existing working tree at its current branch (no new worktree/branch; kill preserves both)")
 	sessionsCreateCmd.Flags().BoolVar(&createInPlaceFlag, "in-place", false, "Alias for --here")
-	sessionsCreateCmd.Flags().StringVar(&createBackendFlag, "backend", "", "Runtime to run the session on (one of: "+config.BackendLocal+", "+config.BackendDocker+", "+config.BackendSSH+", "+config.BackendHook+"; defaults to the repo's backend config, or local). docker runs the session in a container (set docker.image in the repo config); ssh is not yet implemented")
+	sessionsCreateCmd.Flags().StringVar(&createBackendFlag, "backend", "", "Runtime to run the session on (one of: "+config.BackendLocal+", "+config.BackendDocker+", "+config.BackendSSH+", "+config.BackendHook+"; defaults to the repo's backend config, or local). docker runs the session in a container (set docker.image in the repo config); ssh runs it on a remote host (set ssh.host in the repo config)")
 	sessionsCreateCmd.MarkFlagRequired("name")
 
 	sessionsSendPromptCmd.Flags().BoolVar(&sendPromptCreateFlag, "create", false, "Auto-create the session if it doesn't exist")

--- a/commands/configcmd.go
+++ b/commands/configcmd.go
@@ -38,12 +38,13 @@ func jsonWrapError(cmd *cobra.Command, jsonMode bool, err error) error {
 	return err
 }
 
-// The `af config` group is a read-only view over the global config
-// (~/.agent-factory/config.toml) so users and scripts can discover the current
-// settings without hand-parsing the TOML (#1192). Writing from the CLI (`config
-// set`) is deliberately not implemented yet: it needs a settable-key allowlist,
-// validation reuse (ValidateProgramEnum et al.), and a comment-preserving TOML
-// write that go-toml/v2's Marshal cannot do — a design pass tracked on #1192.
+// The `af config` group reads and writes the global config
+// (~/.agent-factory/config.toml) so users and scripts can inspect and change
+// settings without hand-parsing the TOML (#1192). `get`/`list` are the read
+// side. `set` is the write side: the settable-key allowlist, the loader's own
+// validation (ValidateProgramEnum et al.), and the surgical in-place edit that
+// preserves comments and ordering (go-toml/v2's Marshal cannot) all live in
+// config/configset.go.
 
 // configJSONFlag switches `af config get/list` from human output to the shared
 // {data,error} envelope. Local to this group (like `af api`'s --json) since

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -993,7 +993,7 @@ af sessions create [flags]
 
 | Flag | Type | Description |
 |------|------|-------------|
-| `--backend` | `string` | Runtime to run the session on (one of: local, docker, ssh, hook; defaults to the repo's backend config, or local). docker runs the session in a container (set docker.image in the repo config); ssh is not yet implemented |
+| `--backend` | `string` | Runtime to run the session on (one of: local, docker, ssh, hook; defaults to the repo's backend config, or local). docker runs the session in a container (set docker.image in the repo config); ssh runs it on a remote host (set ssh.host in the repo config) |
 | `--here` |  | Run in the repo's existing working tree at its current branch (no new worktree/branch; kill preserves both) |
 | `--in-place` |  | Alias for --here |
 | `--name` | `string` | Session name (required) |


### PR DESCRIPTION
Fixes #1888. Held as a **draft** pending review (the auto-gate merges non-drafts).

## The claim was false

`af sessions create --help` ended its `--backend` description with `; ssh is not yet implemented`. Verified against the code rather than taking the issue's word for it — every one of its pointers holds:

- `sshRuntime` is registered in the runtime registry beside `local`, `docker`, and `hook` — `session/runtime.go:137`, which the comment there calls "the single source of truth for which runtimes exist"
- `sshRuntime.Provision` is the real lifecycle — `session/backend_ssh.go` (864 lines): dial → mkdir → configure git → clone → copy the `af` binary → start agent-server → read banner → open the tunnel
- `SSHConfig` is a full config surface with `Host`/`User`/`Port`/`IdentityFile`/`KnownHosts`, host-key verification always on — `config/backend.go:36-64`
- `integration/backend_ssh_test.go` round-trips it, and `session/instance_factory.go` treats `BackendSSH` as a first-class off-box runtime

So the help denied a shipped feature, and `scripts/gen-docs.sh` republished the denial to `docs/reference/cli.md` — the honesty problem CLAUDE.md makes an explicit obligation, and a direct contradiction of #1887, which documents ssh as working.

## The fix

Took the issue's suggested wording, mirroring the existing `docker.image` mention:

> `… docker runs the session in a container (set docker.image in the repo config); ssh runs it on a remote host (set ssh.host in the repo config)`

The enumeration itself (`local, docker, ssh, hook`) is built from the `config.Backend*` constants and already matched the registry exactly, so only the trailing clause was wrong. Regenerated `docs/reference/cli.md`; `api.md` was unchanged.

Rendered from the built binary, not just read off the diff:

```
--backend string   Runtime to run the session on (one of: local, docker, ssh, hook; defaults to
                   the repo's backend config, or local). docker runs the session in a container
                   (set docker.image in the repo config); ssh runs it on a remote host (set
                   ssh.host in the repo config)
```

## One adjacent site, same bug class

The mandated grep for stale "not implemented" claims turned up one more. The `af config` group comment (`commands/configcmd.go:41`) called itself "a read-only view" whose `config set` was "deliberately not implemented yet: it needs a settable-key allowlist, validation reuse (ValidateProgramEnum et al.), and a comment-preserving TOML write that go-toml/v2's Marshal cannot do".

All three of those landed in `config/configset.go` — `resolveSettable` is the allowlist, the loader's own validators are reused, and the write is a surgical in-place edit preserving comments and ordering — and `configSetCmd` has shipped since #1402. Rewrote the comment to describe the code that exists. It's a comment, not user-facing text, but it's the same false-claim class and it would mislead the next reader of that file.

The other three `not implemented` hits are legitimate and untouched: `session/agentserver_remote.go:120` (browser-dials-sandbox, genuinely absent), `docs/design/tui-rewrite.md:210` (design doc), and this is not exhaustive beyond the backend/CLI surface the issue scopes.

## Gates

| Gate | Result |
|---|---|
| `make test-container` | green — all 22 packages `ok` |
| `make tui-driver-selftest` | 41/41 steps green |
| `go build ./...` | clean |
| `gofmt -l .` | no output |
| `golangci-lint run --fast` | clean |
| `deadcode -test ./...` | no output |
| `scripts/lint-file-length.sh` | passed (641 files) |
| `scripts/gen-docs.sh` | regenerated, committed, no drift |

No test added: the change is a help string with no behavior to assert, and the gen-docs CI check already fails on drift between the flag and the published docs — which is the regression that would matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)