### PR TITLE
fix(selftest): the web gate stops lying — vscode fixture binds the socket, status-dots is deterministic, and one red no longer blinds the suite (#1895, #1898)

### DIFF
--- a/daemon/vscode_selftest_fixture_test.go
+++ b/daemon/vscode_selftest_fixture_test.go
@@ -1,0 +1,128 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The web-selftest harness installs a FAKE code-server on PATH
+// (scripts/container/web-selftest-entry.sh) and the daemon spawns it through the
+// ordinary detection path, exactly as it would a real install. That makes the
+// fake's argv parser a silent dependency of vscodeArgs — a test fixture that has
+// to track production argv, with nothing but review connecting them.
+//
+// They drifted, and #1895 is what it cost: #1873 moved the editor onto a unix
+// socket, the fake kept demanding the --bind-addr of the old TCP transport and
+// exit(2)'d on every spawn, and BOTH changes were green on their own. The symptom
+// was as far from the cause as it gets — the fake's error went nowhere (startOne
+// discards the child's output, deliberately), so the only evidence was the vscode
+// tab timing out 30s into a 3-minute container run. The suite is serial, so that
+// one red also hid every test behind it and master's web gate went blind.
+//
+// These tests are the guard that keeps the next drift from hiding: they derive the
+// contract from vscodeArgs itself and fail in `go test`, in milliseconds, naming
+// the flag. Nothing here re-tests the fixture's behavior — the container run does
+// that. It only tests that the fixture is still parsing the argv the daemon sends.
+
+// fakeEditorScript is the harness fixture that must track vscodeArgs.
+const fakeEditorScript = "../scripts/container/web-selftest-entry.sh"
+
+// fixtureValueFlagsPattern captures the fake's value-flag set: the flags it knows
+// consume the NEXT argv word. It is the fake's whole parsing contract — a flag
+// missing from it does not just go unread, it shifts the parse, and the flag's
+// value is mistaken for the positional worktree.
+var fixtureValueFlagsPattern = regexp.MustCompile(`const valueFlags = new Set\(\[([^\]]*)\]\)`)
+
+var fixtureFlagPattern = regexp.MustCompile(`"(--[a-z-]+)"`)
+
+func readFakeEditorFixture(t *testing.T) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.FromSlash(fakeEditorScript))
+	if err != nil {
+		t.Fatalf("reading the web-selftest fixture %s failed: %v", fakeEditorScript, err)
+	}
+	return string(b)
+}
+
+// valueTakingArgs reports which flags in args consume the next word.
+//
+// Derived from the argv rather than listed, so this cannot itself go stale: the
+// final element is the positional worktree, and in what remains a flag followed by
+// a non-flag is exactly a flag with a value. (--disable-workspace-trust sits last
+// among the flags precisely because the worktree follows it, so dropping the
+// positional first is what keeps it from reading as a value flag.)
+func valueTakingArgs(args []string) []string {
+	if len(args) == 0 {
+		return nil
+	}
+	rest := args[:len(args)-1] // drop the positional worktree
+	var out []string
+	for i := 0; i < len(rest); i++ {
+		if !strings.HasPrefix(rest[i], "--") {
+			continue
+		}
+		if i+1 < len(rest) && !strings.HasPrefix(rest[i+1], "--") {
+			out = append(out, rest[i])
+			i++ // skip the value; it is not a flag
+		}
+	}
+	return out
+}
+
+// TestWebSelftestFakeEditorParsesEveryValueFlag is the #1895 guard.
+//
+// Every flag the daemon passes WITH a value must be one the fake knows takes one.
+// Miss one and the fake misparses in two ways at once: the flag's value is read as
+// the positional worktree (so the #folder assertion reads a socket path), and the
+// real worktree may never be seen at all.
+func TestWebSelftestFakeEditorParsesEveryValueFlag(t *testing.T) {
+	script := readFakeEditorFixture(t)
+
+	m := fixtureValueFlagsPattern.FindStringSubmatch(script)
+	if m == nil {
+		t.Fatalf("no `const valueFlags = new Set([...])` in %s: the fake's argv parser was "+
+			"restructured, so this guard no longer reads its contract — update the guard with it", fakeEditorScript)
+	}
+	got := map[string]bool{}
+	for _, f := range fixtureFlagPattern.FindAllStringSubmatch(m[1], -1) {
+		got[f[1]] = true
+	}
+
+	// The fixture installs the fake under the name "code-server", so the daemon
+	// infers the code-server dialect (flavorForBinary) and sends this argv.
+	args := vscodeArgs(flavorCodeServer, "/tmp/af-vscode-guard.sock", "/tmp/af-worktree")
+	for _, flag := range valueTakingArgs(args) {
+		if !got[flag] {
+			t.Errorf("the daemon passes %s with a value, but the web-selftest fake code-server (%s) "+
+				"does not list it in valueFlags: it will read %s's value as the positional worktree. "+
+				"Add it there — a fixture that misparses the daemon's argv fails as a 30s iframe "+
+				"timeout in the container, not as this test", flag, fakeEditorScript, flag)
+		}
+	}
+}
+
+// TestWebSelftestFakeEditorBindsTheDaemonsSocket pins the transport itself.
+//
+// The value-flag check above proves the fake READS --socket; this proves it
+// LISTENS on it. Both are needed: a fake that parses the socket path perfectly and
+// binds anything else is spawned, detected, and never reachable — which is #1895's
+// exact shape. The daemon dials the socket it named and nothing else
+// (newVSCodeTransport), so the fixture binding that path is the whole contract.
+func TestWebSelftestFakeEditorBindsTheDaemonsSocket(t *testing.T) {
+	script := readFakeEditorFixture(t)
+
+	args := vscodeArgs(flavorCodeServer, "/tmp/af-vscode-guard.sock", "/tmp/af-worktree")
+	if !strings.Contains(strings.Join(args, " "), "--socket ") {
+		t.Fatalf("vscodeArgs no longer passes --socket for the code-server flavor: the fake "+
+			"code-server in %s binds whatever --socket names, so it must be updated to match "+
+			"the new transport", fakeEditorScript)
+	}
+	if !strings.Contains(script, "server.listen(socketPath") {
+		t.Errorf("the web-selftest fake code-server (%s) does not listen on the --socket path the "+
+			"daemon named: the proxy dials that socket and only that socket, so the vscode tab "+
+			"will time out with no error anywhere", fakeEditorScript)
+	}
+}

--- a/scripts/container/web-selftest-entry.sh
+++ b/scripts/container/web-selftest-entry.sh
@@ -263,29 +263,48 @@ WEBTAB_SERVER_PID=$!
 
 # --- install the fake code-server (feat: VS Code tabs) ----------------------
 # Named "code-server" on PATH so the daemon DETECTS it exactly as it would a real
-# install. It honors the flags the daemon actually passes (--bind-addr, and the
-# positional worktree) and serves a deterministic marker, so the Playwright test
-# proves the daemon spawned it on loopback, rooted at the session's worktree, and
-# reverse-proxied it into the pane.
+# install. It honors the flags the daemon actually passes (--socket/--socket-mode,
+# and the positional worktree) and serves a deterministic marker, so the Playwright
+# test proves the daemon spawned it on ITS socket, rooted at the session's
+# worktree, and reverse-proxied it into the pane.
+#
+# THE SOCKET IS THE CONTRACT, and it is the one thing this fake must not get wrong.
+# The daemon reaches an editor by DIALING the unix socket it named on the child's
+# argv (daemon/vscode_socket.go): a fake that binds anything else is spawned,
+# detected, and never reachable — the proxy dials a socket nobody created and the
+# pane times out 30s later with no error anywhere, because startOne discards the
+# child's stdout/stderr. That is exactly how this fixture broke in #1895: it still
+# demanded the --bind-addr of the pre-#1873 TCP transport and exit(2)'d on a
+# socket-bound spawn, turning a green product into a red gate.
+#
+# So: keep vscodeArgs (daemon/vscode_server.go) and this parser in lockstep. That
+# is not left to review — daemon/vscode_selftest_fixture_test.go derives the
+# contract from vscodeArgs and fails in `go test`, in milliseconds, naming the
+# flag. (The exit(2) below cannot: its message goes to the discarded stderr, which
+# is precisely why #1895 surfaced only as a timeout.)
 echo ">>> installing the fake code-server on PATH ..."
 cat >/usr/local/bin/code-server <<EOF
 #!/usr/bin/env node
 const http = require("http");
-const args = process.argv.slice(2);
+const fs = require("fs");
 // Only these flags take a value; a bare word after a boolean flag is the folder.
-const valueFlags = new Set(["--bind-addr", "--auth", "--config"]);
-let addr = "";
+// --socket/--socket-mode MUST be listed: unlisted, their values parse as the
+// positional worktree and the folder assertion reads a socket path.
+const valueFlags = new Set(["--socket", "--socket-mode", "--auth", "--config"]);
+const args = process.argv.slice(2);
+let socketPath = "";
+let socketMode = "";
 let folder = "";
 for (let i = 0; i < args.length; i++) {
   if (valueFlags.has(args[i])) {
-    if (args[i] === "--bind-addr") { addr = args[i + 1]; }
+    if (args[i] === "--socket") { socketPath = args[i + 1]; }
+    if (args[i] === "--socket-mode") { socketMode = args[i + 1]; }
     i++;
     continue;
   }
   if (!args[i].startsWith("--")) { folder = args[i]; }
 }
-if (!addr) { console.error("fake code-server: no --bind-addr"); process.exit(2); }
-const [host, port] = [addr.slice(0, addr.lastIndexOf(":")), addr.slice(addr.lastIndexOf(":") + 1)];
+if (!socketPath) { console.error("fake code-server: no --socket"); process.exit(2); }
 const server = http.createServer((req, res) => {
   res.setHeader("content-type", "text/html");
   res.end(
@@ -295,8 +314,14 @@ const server = http.createServer((req, res) => {
 });
 // code-server upgrades WebSockets on every path; mirror that so the proxy's WS
 // relay is exercised rather than 404'd.
-server.on("upgrade", (req, socket) => { socket.destroy(); });
-server.listen(Number(port), host);
+server.on("upgrade", (req, sock) => { sock.destroy(); });
+// Bind the socket the daemon named. The daemon unlinked it first (startOne), so
+// there is nothing to clear here; the mode is applied AFTER listen because that is
+// when the file exists — the same order real code-server uses, and the reason the
+// daemon forces 0600 itself rather than trusting the child (vscode_socket.go).
+server.listen(socketPath, () => {
+  if (socketMode) { fs.chmodSync(socketPath, parseInt(socketMode, 8)); }
+});
 EOF
 chmod +x /usr/local/bin/code-server
 # A VITE-SHAPED app: a document under /app/ whose assets are referenced the three

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -2239,9 +2239,9 @@ test("#1815 review: a retained layout follows its tab when the roster changes wh
 test("vscode tab (feat): the ▾ menu creates a VS Code tab and the daemon serves it through the proxy", async () => {
   // End to end, with no seeded fixture: pick VS Code from the tab bar's kind menu,
   // and the daemon spawns a code-server (the FAKE one on PATH — no CI box has a
-  // real one) on a loopback port it picks, rooted at THIS session's worktree, and
-  // reverse-proxies it into the pane. Nothing has spawned before this click: the
-  // editor starts lazily on the first render.
+  // real one) on a 0600 unix socket it names, rooted at THIS session's worktree,
+  // and reverse-proxies it into the pane. Nothing has spawned before this click:
+  // the editor starts lazily on the first render.
   //
   // It runs near the end of the file on purpose: it leaves a tab on probe-a, and
   // the earlier tabs test asserts that session's exact tab count.
@@ -2296,8 +2296,8 @@ test("vscode tab (feat): the ▾ menu creates a VS Code tab and the daemon serve
 
   const frame = page.locator(".af-term-host .af-pane-host iframe.af-webframe");
   await expect(frame).toHaveCount(1, { timeout: 15_000 });
-  // A vscode tab is ALWAYS daemon-proxied: its code-server is loopback-only, so the
-  // proxy path is the only address a (possibly remote) browser can reach.
+  // A vscode tab is ALWAYS daemon-proxied: its code-server listens on a unix socket
+  // no browser can address, so the proxy path is the only route to it (#1873).
   await expect(frame).toHaveAttribute("src", /\/v1\/webtab\//);
   // It is an editor pane, not a terminal.
   await expect(page.locator(".af-term-host .af-pane-host .xterm")).toHaveCount(0);

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -246,12 +246,37 @@ async function openTokenless(page: Page): Promise<void> {
   await expect(page.locator("#af-token")).toHaveCount(0);
 }
 
-// The flows share one daemon and mutate its session set (create/kill/archive), so
-// they must run in order against a single page.
-test.describe.configure({ mode: "serial" });
+// NO file-wide serial mode, deliberately (#1898).
+//
+// The flows do share one daemon and one page, and they must run IN ORDER — but
+// order is not what serial mode buys. `fullyParallel: false` + `workers: 1`
+// (playwright.config.ts) already run every test sequentially, in declaration
+// order, in one worker. With `retries: 0`, the ONLY thing a file-wide
+// `mode: "serial"` added was this: when any test fails, skip every test after it.
+//
+// That is a gate that blinds itself. A failure is exactly when the rest of the
+// suite most needs to run, and the cost is not hypothetical — a single flake in
+// the status-dots test (#1898) skipped 41 tests, and #1895's fixture drift skipped
+// every test behind it on the branch that found it. A regression in any of them
+// would have been invisible behind an unrelated red.
+//
+// Ordinary test isolation replaces it. Playwright discards the worker process
+// after a failure and starts a new one, so beforeAll re-runs and the next test
+// gets a fresh page, a fresh login, and fresh module state — the page-level
+// pollution serial mode was protecting against cannot cross a failure. What
+// survives a restart is the DAEMON's state, which is why the few tests that hand
+// state to each other are grouped into their own small serial describe (see
+// "create → kill" below): the blast radius of a failure is that group, not the
+// file.
+//
+// So: a new test belongs at the top level unless it consumes state another test
+// produced. If it does, put the pair in their own serial describe — never reach
+// for a file-wide one.
 
 let page: Page;
-// The title of the session the create flow makes, handed to the kill flow.
+// The title of the session the create flow makes, handed to the kill flow. It is
+// module state, so a worker restart resets it — which is exactly why the two flows
+// that share it live in one serial describe rather than at the top level.
 let createdTitle = "";
 
 test.beforeAll(async ({ browser }) => {
@@ -382,33 +407,43 @@ test("sidebar lists the seeded sessions from the Snapshot/events plane", async (
   await expect(page.locator(".af-live-pip.af-live-open")).toBeVisible();
 });
 
-test("status dots (#1766): waiting shows a green dot, working shows none, error states are static — no spin anywhere", async () => {
+test("status dots (#1766): waiting shows a green dot, working shows none, error states are static — no spin anywhere", async ({
+  browser,
+}) => {
   // The daemon can't be coerced to Running/Lost/Dead/Limit on demand, so pin the
-  // states by rewriting the Snapshot: the two real rows get Running (working) and
-  // Ready (waiting); synthetic rows cloned into the same project cover the static
-  // error glyphs. The events plane only pushes future deltas, so the reloaded rail
-  // reflects this Snapshot (the same route-transform pattern the no-url / empty-state
-  // tests use).
-  await page.route("**/v1/Snapshot", async (route) => {
+  // states by rewriting the Snapshot. Every asserted row is SYNTHETIC, and that is
+  // the whole point rather than a convenience (#1898).
+  //
+  // A REAL row cannot be pinned. The Snapshot fixes its liveness exactly once, at
+  // load; the events plane then keeps pushing `session.updated` deltas for it, and
+  // applyEvent upserts them in place with NO resync (web/src/sessions.ts) — so the
+  // daemon's truth lands straight on top of the fixture. The seeded fake agent
+  // prints its marker and then `exec cat`s, so the daemon's pane-churn liveness
+  // flips LiveRunning→LiveReady a beat after seeding. Whenever that beat fell inside
+  // this test, probe-a's pinned "working" row acquired a real green dot and the
+  // "working shows none" assertion failed — a flake that, under the old global
+  // serial mode, took the whole suite behind it down with it.
+  //
+  // A synthetic id the daemon has never heard of receives no deltas, so the pinned
+  // state is the only state there will ever be. That makes this deterministic by
+  // construction rather than by out-waiting a race. It costs nothing in coverage:
+  // the dot is a pure function of liveness, and these rows drive that render path
+  // through exactly the same code.
+  //
+  // Its own context, too: routing Snapshot on the shared page meant a reload in,
+  // a reload out, and a window where a leaked route could color another test.
+  const ctx = await browser.newContext();
+  const p = await ctx.newPage();
+  await p.route("**/v1/Snapshot", async (route) => {
     const resp = await route.fetch();
     const body = await resp.json();
     const snap = body?.data as { instances?: Array<Record<string, unknown> & { title: string }> };
     const list = snap?.instances ?? [];
-    const proto = { ...(list.find((s) => s.title === SESSION_A) ?? {}) };
-    for (const s of list) {
-      if (s.title === SESSION_A) {
-        s.liveness = 1; // Running → working → no dot
-        s.in_flight_op = 0;
-      }
-      if (s.title === SESSION_B) {
-        s.liveness = 2; // Ready → waiting → green dot
-        s.in_flight_op = 0;
-      }
-    }
-    // Clone SESSION_A's record (same worktree/repo_path, so they land in this project's
-    // scoped rail) into inert synthetic rows for the static error glyphs. Give each a
-    // distinct branch so their rendered branch line never contains "probe-a"/"probe-b"
+    // Clone a REAL record (same worktree/repo_path, so the synthetic rows land in
+    // this project's scoped rail) and vary only what the dot reads. Each gets a
+    // distinct branch so its rendered branch line never contains another row's name
     // (the row() locator matches row text by substring).
+    const proto = { ...(list.find((s) => s.title === SESSION_A) ?? {}) };
     const synth = (title: string, liveness: number) => ({
       ...proto,
       id: `synth-${title}`,
@@ -417,38 +452,42 @@ test("status dots (#1766): waiting shows a green dot, working shows none, error 
       liveness,
       in_flight_op: 0,
     });
-    list.push(synth("probe-lost", 3), synth("probe-dead", 4), synth("probe-limit", 6));
+    list.push(
+      synth("probe-working", 1), // Running → working → no dot
+      synth("probe-waiting", 2), // Ready → waiting → green dot
+      synth("probe-lost", 3),
+      synth("probe-dead", 4),
+      synth("probe-limit", 6),
+    );
     if (snap) {
       snap.instances = list;
     }
     await route.fulfill({ status: resp.status(), contentType: "application/json", body: JSON.stringify(body) });
   });
-  await page.reload();
-  await expect(page.locator(".af-app")).toBeVisible();
-  await expect(row(page, SESSION_A)).toBeVisible({ timeout: 15_000 });
+  await p.goto("/");
+  await expect(p.locator(".af-app")).toBeVisible();
 
-  // Working row (A): NO status dot at all — the dot span is omitted entirely.
-  await expect(row(page, SESSION_A).locator(".af-dot")).toHaveCount(0);
-  // Waiting row (B): the static green ● dot, in the ready color bucket, never spinning.
-  const readyDot = row(page, SESSION_B).locator(".af-dot");
+  // Working row: NO status dot at all — the dot span is omitted entirely. The row
+  // must be asserted present FIRST: toHaveCount(0) on a row that never rendered
+  // would pass for the wrong reason.
+  await expect(row(p, "probe-working")).toBeVisible({ timeout: 15_000 });
+  await expect(row(p, "probe-working").locator(".af-dot")).toHaveCount(0);
+  // Waiting row: the static green ● dot, in the ready color bucket, never spinning.
+  const readyDot = row(p, "probe-waiting").locator(".af-dot");
   await expect(readyDot).toHaveClass(/af-dot-ready/);
   await expect(readyDot).toHaveText("●");
   await expect(readyDot).not.toHaveClass(/af-dot-spin/);
   // Error/terminal states keep their STATIC glyphs (◌/○/◆), copied from the TUI.
-  await expect(row(page, "probe-lost").locator(".af-dot")).toHaveText("◌");
-  await expect(row(page, "probe-lost").locator(".af-dot")).toHaveClass(/af-dot-lost/);
-  await expect(row(page, "probe-dead").locator(".af-dot")).toHaveText("○");
-  await expect(row(page, "probe-limit").locator(".af-dot")).toHaveText("◆");
+  await expect(row(p, "probe-lost").locator(".af-dot")).toHaveText("◌");
+  await expect(row(p, "probe-lost").locator(".af-dot")).toHaveClass(/af-dot-lost/);
+  await expect(row(p, "probe-dead").locator(".af-dot")).toHaveText("○");
+  await expect(row(p, "probe-limit").locator(".af-dot")).toHaveText("◆");
   // The animation class is gone from every status row, and the removed "working" dot
   // kind never renders anywhere.
-  await expect(page.locator(".af-dot-spin")).toHaveCount(0);
-  await expect(page.locator(".af-dot-working")).toHaveCount(0);
+  await expect(p.locator(".af-dot-spin")).toHaveCount(0);
+  await expect(p.locator(".af-dot-working")).toHaveCount(0);
 
-  // Restore the real projection for the following flows.
-  await page.unroute("**/v1/Snapshot");
-  await page.reload();
-  await expect(page.locator(".af-app")).toBeVisible();
-  await expect(row(page, SESSION_A)).toBeVisible({ timeout: 15_000 });
+  await ctx.close();
 });
 
 test("click-to-attach opens the xterm terminal and shows live output", async () => {
@@ -1640,75 +1679,87 @@ test("tasks view (#1592 PR8): list the seeded task; add / trigger / remove round
   await expect(page.locator(".af-rail-list")).toBeVisible();
 });
 
-test("create: the + New modal creates a session and its row appears", async () => {
-  const created = `probe-created-${Date.now().toString(36)}`;
+test.describe("create → kill (one session, two flows)", () => {
+  // The ONE genuine ordering dependency in this file, and the only place serial
+  // mode is warranted: create stashes the title it invented and kill consumes it,
+  // so kill cannot run — or mean anything — on its own. Serial keeps the pair
+  // honest: if create fails, kill SKIPS rather than failing a second time for a
+  // reason that is not its own.
+  //
+  // Scoped to these two tests on purpose. This is the blast radius of a failure
+  // here: two tests, not the 41 a file-wide serial took down in #1898.
+  test.describe.configure({ mode: "serial" });
 
-  // Regression guard (#1592 PR7 review): first move the CURRENT session onto a
-  // NON-agent tab, so a create path that wrongly preserved activeTab would build a
-  // ?tab=1 stream URL for the brand-new session (which has only the agent tab).
-  await row(page, SESSION_A).click();
-  await expect(page.locator(".af-main.af-main-term")).toBeVisible();
-  await page.locator(".af-tabbar .af-tab-new").click();
-  await expect(page.locator(".af-tabbar .af-tab")).toHaveCount(2, { timeout: 30_000 });
-  await expect(page.locator(".af-tab.af-tab-active .af-tab-label")).toHaveText("Terminal");
+  test("create: the + New modal creates a session and its row appears", async () => {
+    const created = `probe-created-${Date.now().toString(36)}`;
 
-  // Capture every PTY stream WebSocket opened from here on, so we can assert the
-  // new session's stream carries NO stale tab= selector.
-  const streamUrls: string[] = [];
-  page.on("websocket", (ws) => {
-    if (ws.url().includes("/stream")) {
-      streamUrls.push(ws.url());
-    }
+    // Regression guard (#1592 PR7 review): first move the CURRENT session onto a
+    // NON-agent tab, so a create path that wrongly preserved activeTab would build a
+    // ?tab=1 stream URL for the brand-new session (which has only the agent tab).
+    await row(page, SESSION_A).click();
+    await expect(page.locator(".af-main.af-main-term")).toBeVisible();
+    await page.locator(".af-tabbar .af-tab-new").click();
+    await expect(page.locator(".af-tabbar .af-tab")).toHaveCount(2, { timeout: 30_000 });
+    await expect(page.locator(".af-tab.af-tab-active .af-tab-label")).toHaveText("Terminal");
+
+    // Capture every PTY stream WebSocket opened from here on, so we can assert the
+    // new session's stream carries NO stale tab= selector.
+    const streamUrls: string[] = [];
+    page.on("websocket", (ws) => {
+      if (ws.url().includes("/stream")) {
+        streamUrls.push(ws.url());
+      }
+    });
+
+    await page.locator("button.af-rail-new").click();
+    const modal = page.locator(".af-modal-card");
+    await expect(modal).toBeVisible();
+
+    // Title is required; the project picker defaults to the scoped project (redesign
+    // PR2 — the first mock repo A/B live in), so the created session lands there and is
+    // visible in the scoped rail. Program is left at "Repo default" (claude → the fake
+    // agent). Submit with the modal's Create button.
+    await modal.locator('input[aria-label="Session title"]').fill(created);
+    await modal.locator("button.af-primary").click();
+
+    // The created row lands in the rail (createSession returns the full projection,
+    // which index.ts upserts + selects immediately).
+    await expect(row(page, created)).toBeVisible({ timeout: 30_000 });
+    await expect(modal).toBeHidden();
+
+    // The new session is auto-selected AND attached at its AGENT tab (index 0), not
+    // the tab-2 we were on: its tab bar has just the agent tab, and its terminal
+    // shows the fake agent's ready marker — which it could not if the stream had
+    // dialed a ?tab=<n> the session has no tab for.
+    await expect(page.locator(".af-tabbar .af-tab")).toHaveCount(1);
+    await expect(page.locator(".af-tab.af-tab-active .af-tab-label")).toHaveText("Agent");
+    await expect(page.locator(".af-term-host")).toContainText(READY_MARKER, { timeout: 30_000 });
+
+    // And the new session's stream URL carries no stale tab= selector (the agent tab
+    // is the default, sent only for a non-agent tab).
+    const lastStream = streamUrls[streamUrls.length - 1];
+    expect(lastStream, "a PTY stream WS should have opened for the new session").toBeTruthy();
+    expect(lastStream).not.toContain("tab=");
+
+    // Stash it for the kill flow.
+    createdTitle = created;
   });
 
-  await page.locator("button.af-rail-new").click();
-  const modal = page.locator(".af-modal-card");
-  await expect(modal).toBeVisible();
+  test("kill: the kill confirm removes the session's row", async () => {
+    expect(createdTitle).not.toBe("");
+    // The created session is the current selection, so the pane header shows its
+    // actions. Kill it and confirm.
+    await row(page, createdTitle).click();
+    await expect(page.locator(".af-main.af-main-term")).toBeVisible();
+    await page.locator(".af-term-head button.af-danger").click();
 
-  // Title is required; the project picker defaults to the scoped project (redesign
-  // PR2 — the first mock repo A/B live in), so the created session lands there and is
-  // visible in the scoped rail. Program is left at "Repo default" (claude → the fake
-  // agent). Submit with the modal's Create button.
-  await modal.locator('input[aria-label="Session title"]').fill(created);
-  await modal.locator("button.af-primary").click();
+    const modal = page.locator(".af-modal-card");
+    await expect(modal).toBeVisible();
+    await modal.locator("button.af-danger").click();
 
-  // The created row lands in the rail (createSession returns the full projection,
-  // which index.ts upserts + selects immediately).
-  await expect(row(page, created)).toBeVisible({ timeout: 30_000 });
-  await expect(modal).toBeHidden();
-
-  // The new session is auto-selected AND attached at its AGENT tab (index 0), not
-  // the tab-2 we were on: its tab bar has just the agent tab, and its terminal
-  // shows the fake agent's ready marker — which it could not if the stream had
-  // dialed a ?tab=<n> the session has no tab for.
-  await expect(page.locator(".af-tabbar .af-tab")).toHaveCount(1);
-  await expect(page.locator(".af-tab.af-tab-active .af-tab-label")).toHaveText("Agent");
-  await expect(page.locator(".af-term-host")).toContainText(READY_MARKER, { timeout: 30_000 });
-
-  // And the new session's stream URL carries no stale tab= selector (the agent tab
-  // is the default, sent only for a non-agent tab).
-  const lastStream = streamUrls[streamUrls.length - 1];
-  expect(lastStream, "a PTY stream WS should have opened for the new session").toBeTruthy();
-  expect(lastStream).not.toContain("tab=");
-
-  // Stash it for the kill flow.
-  createdTitle = created;
-});
-
-test("kill: the kill confirm removes the session's row", async () => {
-  expect(createdTitle).not.toBe("");
-  // The created session is the current selection, so the pane header shows its
-  // actions. Kill it and confirm.
-  await row(page, createdTitle).click();
-  await expect(page.locator(".af-main.af-main-term")).toBeVisible();
-  await page.locator(".af-term-head button.af-danger").click();
-
-  const modal = page.locator(".af-modal-card");
-  await expect(modal).toBeVisible();
-  await modal.locator("button.af-danger").click();
-
-  // The killed row disappears from the rail (the killed event removes it).
-  await expect(row(page, createdTitle)).toHaveCount(0, { timeout: 30_000 });
+    // The killed row disappears from the rail (the killed event removes it).
+    await expect(row(page, createdTitle)).toHaveCount(0, { timeout: 30_000 });
+  });
 });
 
 test("archive: the archive confirm moves a session to the archived group", async () => {


### PR DESCRIPTION
Fixes #1895. Fixes #1898. **Held as a draft** (the auto-gate merges non-drafts, and this PR touches the gate itself).

`make web-selftest-container` was RED on a clean master, and its serial mode meant that red hid everything behind it. Three fixes, one theme: **the gate should report what is actually true.**

---

## 1. The red: the fake code-server never bound the socket (#1895)

**The product is fine. The test fixture drifted.**

#1883 moved both editor flavors onto a 0600 unix socket, so `vscodeArgs` now spawns code-server with `--socket <path> --socket-mode 0600` — `--bind-addr` is gone entirely. The web-selftest's fake code-server (installed on PATH under the real binary's name, so the daemon detects and spawns it exactly as it would a real install) still demanded the flag of the pre-#1873 TCP transport:

```js
if (!addr) { console.error("fake code-server: no --bind-addr"); process.exit(2); }
```

Every spawn `exit(2)`'d before binding anything. The daemon dialed a socket nobody had created; the iframe timed out 30s later. Both PRs were green in isolation — only their intersection is red. Same class as #1863.

The symptom sat maximally far from the cause: `startOne` discards the child's stdout/stderr (deliberately — a chatty editor must not wedge on a full pipe), so the fake's error message went **nowhere**. The only evidence was a blank pane.

**Fix:** the fake binds the socket the daemon named, honors `--socket-mode` after listen (the order real code-server uses), and lists `--socket`/`--socket-mode` as value-taking flags — unlisted, their values parse as the positional worktree and the `#folder` assertion reads a socket path.

**The proxy and the 0600 socket are untouched.** That posture is the thing under test; weakening it to make a test pass would invert the point of #1873.

**Guard:** the fake's argv parser was a silent dependency of `vscodeArgs` with nothing but review connecting them. `daemon/vscode_selftest_fixture_test.go` **derives** the contract from `vscodeArgs` rather than restating it, and fails in `go test` in milliseconds naming the flag — instead of as a 30s timeout inside a 3-minute container run.

## 2. The flake: status-dots asserted on rows the daemon kept overwriting (#1898)

The test pinned liveness by rewriting the Snapshot, then asserted on the **real** probe-a/probe-b rows. A real row cannot be pinned: the Snapshot fixes it once, at load, and the events plane keeps pushing `session.updated` deltas that `applyEvent` upserts **in place with no resync**. The seeded fake agent prints its marker then `exec cat`s, so the daemon's pane-churn liveness flips `LiveRunning`→`LiveReady` a beat after seeding — landing, when the timing lined up, on top of probe-a's pinned "working" row and putting a green dot where the test asserts none.

**Fix:** every asserted row is now **synthetic**. An id the daemon has never heard of receives no deltas, so the pinned state is the only state there will ever be — deterministic *by construction*, not by out-waiting a race. No sleeps, no retries, no timeout bumps. The dot is a pure function of liveness, so coverage is unchanged. The test also takes its own context, retiring the route-in/reload-out dance on the shared page.

## 3. The structural bug: serial mode blinded the gate

The suite was `test.describe.configure({ mode: "serial" })` file-wide, so **any** failure skipped every test after it. A gate that stops looking the moment it finds a problem reports "1 known red" while an unbounded number of real regressions ride in behind it.

Serial mode was not buying what it appeared to. Order comes from `fullyParallel: false` + `workers: 1`, which already run every test sequentially in declaration order. With `retries: 0`, serial's **only** effect was skip-on-failure — the blinding itself.

Ordinary Playwright isolation replaces it: the worker process is discarded after a failure, so `beforeAll` re-runs and the next test gets a fresh page, login, and module state. Page-level pollution cannot cross a failure. The one genuine dependency — create stashes a title, kill consumes it — now lives in its **own two-test serial describe**, so its blast radius is the pair, not the file.

---

## Proof the cascade-blinding is gone

Test #6 deliberately broken (the exact #1898 flake), then reverted:

| | before (file-wide serial) | after (this PR) |
|---|---|---|
| failed | 1 | 1 |
| **did not run** | **41** | **0** |
| passed | 5 | **46** |

The failure **reports only itself**. Every other test ran *and passed* — the worker restart means no collateral damage either — including the last test in the file. That is the whole ask: one red can no longer hide a regression.

## Verification

Watched each fix fail first, then pass:

| tree | result |
|---|---|
| vscode fixture reverted to master | 46 passed, **1 failed**, rc=1 — the reported symptom |
| vscode fixture fixed | **47 passed**; the vscode test 30s timeout → **391ms** |
| guard test vs broken fixture | fails naming `--socket`; passes once fixed |
| test #6 deliberately broken | 1 failed, **46 passed, 0 skipped** (was 5 passed, 41 skipped) |
| final tree | **47/47 green, 3× consecutively** |

Gates: `web-selftest-container` green ×3, `web-test` 175/175, `go build`, `gofmt`, `golangci-lint`, `deadcode`, file-length — all clean. `web/dist` verified in sync with `src`, so the harness served real code rather than a stale bundle.

## One correction to #1895's premise, for the record

The issue reported "5 tests did not run". On master that is not reproducible — the vscode test is the **last** test in the file, so its failure hid **zero** tests (46 + 1 = 47 = the whole suite). The 5 skipped came from the reporter's own #1894 branch, which had added tests after it.

The fragility was entirely real, though — it just needed an *early* test to trigger it, which is what #1898's flake did to 41 tests. Both are fixed here.

## Note on test count

This suite has **47** tests, not 52. 46 passed + 1 failed = 47 accounts for the whole file; there is no second spec. The 52 figure appears to count the reporter's branch-local additions.
