### PR TITLE
ci(auto-gate): skip cleanly on open draft PRs + gate the gate's own tests (#1907)

### DIFF
--- a/.github/scripts/auto-gate.test.js
+++ b/.github/scripts/auto-gate.test.js
@@ -168,6 +168,37 @@ test("merge pins the squash merge to the evaluated head SHA", async () => {
   assert.equal(github.mergedWith.sha, "sha-that-passed");
 });
 
+// The workflow-level guard skips drafts for events carrying a pull_request
+// payload, but check_suite/status events carry none and still reach the helper,
+// so this block is the only thing stopping a draft from auto-merging (#1907).
+test("an otherwise-mergeable PR is blocked for being a draft", async () => {
+  const result = await autoGate.evaluate({
+    github: fakeMergeGithub({ headSha: "abc123", isDraft: true }),
+    context: fakeContext(),
+    core: fakeCore(),
+    prNumber: 1465,
+    setOutputs: false,
+  });
+
+  assert.equal(result.shouldMerge, false);
+  assert.match(result.reasons.join("\n"), /PR is a draft/);
+});
+
+// Pins the control: the same fixture merges when isDraft flips off, so the test
+// above can only fail for the draft reason and not some unrelated block.
+test("the same PR is mergeable once it is not a draft", async () => {
+  const result = await autoGate.evaluate({
+    github: fakeMergeGithub({ headSha: "abc123", isDraft: false }),
+    context: fakeContext(),
+    core: fakeCore(),
+    prNumber: 1465,
+    setOutputs: false,
+  });
+
+  assert.deepEqual(result.reasons, []);
+  assert.equal(result.shouldMerge, true);
+});
+
 function fakeGithub({ checkRuns, issueComments, reviewComments }) {
   const listForRef = function listForRef() {};
   const listComments = function listComments() {};
@@ -188,7 +219,7 @@ function fakeGithub({ checkRuns, issueComments, reviewComments }) {
   };
 }
 
-function fakeMergeGithub({ headSha }) {
+function fakeMergeGithub({ headSha, isDraft = false }) {
   const listFiles = function listFiles() {};
   const listForRef = function listForRef() {};
   const listComments = function listComments() {};
@@ -223,7 +254,7 @@ function fakeMergeGithub({ headSha }) {
             url: "https://example.invalid/pr/1465",
             baseRefName: "master",
             headRefOid: headSha,
-            isDraft: false,
+            isDraft,
             mergeable: "MERGEABLE",
             mergeStateStatus: "CLEAN",
             author: { login: "sachiniyer" },

--- a/.github/workflows/auto-gate.yml
+++ b/.github/workflows/auto-gate.yml
@@ -25,10 +25,15 @@ jobs:
     name: Evaluate auto-merge gate
     runs-on: ubuntu-latest
     # Late review comments on a merged/closed PR keep re-triggering the gate
-    # against a stale head (#1876). Events that carry no pull_request payload
-    # (check_suite, status) resolve the PR by head SHA and already filter to
-    # open PRs, so they must not be skipped here.
-    if: github.event.pull_request == null || github.event.pull_request.state == 'open'
+    # against a stale head (#1876). Drafts are never merge-eligible, so review
+    # traffic on a held-open draft is pure evaluation waste (#1907) — the helper
+    # blocks them anyway, this just skips before the checkout and API calls.
+    # Events that carry no pull_request payload (check_suite, status) resolve the
+    # PR by head SHA and already filter to open PRs, so they must not be skipped
+    # here; the helper's own isDraft check remains the backstop for those.
+    if: >-
+      github.event.pull_request == null ||
+      (github.event.pull_request.state == 'open' && github.event.pull_request.draft != true)
     steps:
       - name: Check out gate logic
         uses: actions/checkout@v6

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -54,6 +54,15 @@ jobs:
       - name: Check file lengths
         run: scripts/lint-file-length.sh
 
+      # The auto-gate helper decides what auto-merges, but nothing ran its tests
+      # in CI — they only ever ran by hand (#1907). Lives in the Lint job because
+      # Lint is a required check, so this gates from the moment it lands; a
+      # dedicated job would need a ruleset edit before it gated anything. Uses the
+      # runner's preinstalled Node and the built-in node:test — no package.json,
+      # no install step.
+      - name: Test auto-gate helper
+        run: node --test .github/scripts/auto-gate.test.js
+
   test:
     name: Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #1907 — but not for the reason the issue gives. Please read the correction below before treating this as a red-spam fix.

Two commits: the requested draft-skip guard, and CI wiring for the auto-gate helper's own tests (which turned out to be untested in CI *and* not covering the draft path).

## 1. The issue's premise does not reproduce

#1907 reports that the auto-gate *fails* `not-eligible` on open draft PRs and red-spams on every `@codex` review comment, citing 4+ back-to-back runs on #1872. I could not reproduce any part of that:

- **The gate has no failure path for drafts.** `.github/scripts/auto-gate.js:51` already pushes `"PR is a draft"` onto `reasons`, which sets `should_merge=false` and finishes with a `core.notice`. Nothing in `.github/scripts/` or `.github/workflows/` calls `setFailed` at all — the job concludes **green** with a `BLOCKED:` notice.
- **Zero failures in the last 100 Auto Gate runs.** Tally: 90 `success`, 6 `skipped` (that's #1876's guard working as designed), 4 `cancelled`. No `failure`.
- **#1872 is not a draft and never has been.** It is currently `draft=false`, and its issue timeline has no `convert_to_draft` / `ready_for_review` events.
- **The 4 back-to-back runs on #1872 are `cancelled`, not failed** — and that's correct behavior, not a bug. `cancel-in-progress: false` still cancels *pending* runs when a newer one queues in the same concurrency group; that is documented GitHub behavior. The burst of codex review comments queued 8 runs in ~30s and the concurrency group deduped 4 of them. Cancelled runs render greyed-out in the UI, which is the most likely source of the "red spam" report.

So there is no red to fix, and the requested guard fixes no failure.

## 2. The draft-skip guard — CI waste, not failures

Still worth landing, as a smaller and honestly-scoped win. Today a review comment on a held-open draft spins a runner, checks out the default branch, and makes ~6 API round-trips (`getPullRequest`, `listPullRequestFiles`, required-checks, Greptile) purely to conclude "PR is a draft" and stop. With 6 open drafts currently taking codex review traffic, that recurs often. This skips before any of it.

```yaml
if: >-
  github.event.pull_request == null ||
  (github.event.pull_request.state == 'open' && github.event.pull_request.draft != true)
```

Behavior is identical for open non-draft PRs:

| Event | Guard | Change |
|---|---|---|
| `check_suite` / `status` (no `pull_request` payload) | runs | unchanged |
| Open non-draft PR | runs (`draft != true` → true) | **unchanged** |
| Open draft PR | skips | **new** |
| Closed / merged PR | skips | unchanged (#1876) |

The added clause only evaluates once `state == 'open'`, so #1876's guard keeps its exact meaning. `check_suite`/`status` events resolve the PR by head SHA and carry no `pull_request` payload, so they deliberately still run — the guard is intentionally partial there, and the helper's own `isDraft` check remains the backstop.

## 3. The gate's own tests now gate (and actually cover drafts)

`auto-gate.js` decides what auto-merges, but **`auto-gate.test.js` was wired into no workflow** — its 8 tests only ever ran by hand, so the merge gate itself was ungated. Now run from the `Lint` job in `pr.yml`.

**Why `Lint` and not a dedicated job:** required checks aren't hardcoded — the helper reads them from the ruleset (`getRequiredCheckSpecs`), which lists exactly `Lint (app 15368)` and `Build (app 15368)`. A step inside `Lint` therefore gates the moment it lands, whereas a new job would gate *nothing* until someone edited the ruleset separately — which defeats the point. (`Test` isn't directly required either; it gates only transitively, since `build` has `needs: [lint, test]`.) Uses the runner's preinstalled Node and the built-in `node:test` — the repo has no `package.json` and no `setup-node` convention.

**Wiring them up exposed a real hole:** the 8 tests did not cover the draft block at all. Disabling it outright (`if (pr.isDraft)` → `if (false)`) left **all 8 passing**. That block is load-bearing precisely because of §2 — `check_suite`/`status` events carry no `pull_request` payload, so the workflow guard never sees them and the helper is the only thing stopping a draft from auto-merging. So this adds:

- `an otherwise-mergeable PR is blocked for being a draft` — pins the block.
- `the same PR is mergeable once it is not a draft` — the control, asserting `reasons == []` on the identical fixture, so the first test can only fail for the draft reason rather than some unrelated block.

`fakeMergeGithub` gains an `isDraft` param (default `false`, so existing tests are untouched).

## Verification

- `actionlint` on both changed workflows — clean.
- YAML re-parsed to confirm the folded `>-` scalar collapses to the intended single-line expression.
- `node --test .github/scripts/auto-gate.test.js` — **10/10 pass**.
- **Watched the new test fail first:** reverted the draft block to `if (false)` and confirmed test 9 fails with exit 1, while the control still passes; then restored. The tests reproduce the regression rather than passing against broken code.

Held as **draft** per instruction.

— Captain Claude
