### PR TITLE
refactor(session): share remote AgentServer backend behavior

### DIFF
--- a/session/backend_docker.go
+++ b/session/backend_docker.go
@@ -206,7 +206,7 @@ func (p *dockerProvisioner) provision() (ProvisionResult, error) {
 	teardown := p.reap
 	log.InfoLog.Printf("docker runtime: session %q running in container %s, agent-server at %s", p.spec.Title, p.shortID(), endpoint.URL)
 	return ProvisionResult{
-		Backend:  &dockerBackend{containerID: p.containerID, reap: teardown},
+		Backend:  &dockerBackend{containerID: p.containerID, remoteAgentBackend: remoteAgentBackend{reap: teardown}},
 		Endpoint: endpoint,
 		Teardown: teardown,
 	}, nil
@@ -451,152 +451,14 @@ func originRemoteURL(repoRoot string) string {
 // to the container. Its ONE local responsibility is reaping the container, which
 // it shares (via the same idempotent closure) with the AgentServer Kill path.
 //
-// The daemon's observation/delivery paths speak to a session ONLY through
-// Instance.AgentServer() (the remoteAgentServer), so most of these methods exist
-// for interface completeness + the create flow (which drives Preview/SendPrompt
-// through the Instance→backend wrappers). None re-enters the backend: the docker
-// instance's AgentServer() is the REMOTE client, not localAgentServer, so a
-// backend→AgentServer call is a network hop, never a loop.
+// Its shared remote-AgentServer behavior lives in remoteAgentBackend; this type
+// retains only Docker-specific provisioning, container identity, and the
+// serialized backend discriminator.
 type dockerBackend struct {
+	remoteAgentBackend
 	containerID string
-	// reap removes the container; shared with the runtime's Teardown / the
-	// AgentServer Kill path, and idempotent (a sync.Once behind the closure).
-	reap func() error
 }
 
 var _ Backend = (*dockerBackend)(nil)
 
 func (b *dockerBackend) Type() string { return "docker" }
-
-// Capabilities advertises docker's parity (#1592 Phase 4 PR6, epic §5): the
-// workspace is off-box, but attach/preview/liveness/prompt work through the
-// in-container agent-server, and Archive/Recover work by pushing the branch to
-// GitHub and re-provisioning a fresh container that clones it back (§5.1) — no
-// ErrRecoverUnsupported and no locality special-case.
-//
-// TabManagement is false (#1874). It is the ONE capability the in-container
-// agent-server does not yet service: the agent-server's tab surface is data
-// plane only (Subscribe/Input/Resize address an EXISTING tab by index or stable
-// id) — there is no create/close tab RPC, so every Add*Tab path still requires a
-// daemon-side git worktree this runtime does not have. Advertising it true
-// offered tab affordances (the web menu's new-tab/VS Code items, the TUI `t`/`w`
-// keys) that could only ever fail. The honest bit is false until tab creation
-// routes through the agent-server; see #1874 for what that needs.
-func (b *dockerBackend) Capabilities() Capabilities {
-	return Capabilities{
-		Workspace:        WorkspaceRemote,
-		Archive:          true,
-		Recover:          true,
-		TabManagement:    false,
-		TerminalTab:      true,
-		InteractiveInput: true,
-	}
-}
-
-// Start provisions then launches the in-container workspace. The container +
-// agent-server were established by the runtime (during NewInstance); Start drives
-// the agent-server's own provision/launch over REST, so the in-container LOCAL
-// backend creates the git worktree + branch and spawns the agent.
-func (b *dockerBackend) Start(i *Instance, firstTimeSetup bool) error {
-	if err := b.Provision(i, firstTimeSetup); err != nil {
-		return err
-	}
-	return b.Launch(i, firstTimeSetup)
-}
-
-// Provision drives the in-container agent-server's Provision over the wire (clone
-// is already done by the runtime; this creates the in-container git worktree).
-func (b *dockerBackend) Provision(i *Instance, firstTimeSetup bool) error {
-	return i.AgentServer().Provision(firstTimeSetup)
-}
-
-// Launch drives the in-container agent-server's Launch (spawn the agent), sets the
-// started flag, and seeds the daemon-side tab model with the agent tab (the
-// container owns the real tabs; the daemon-side list mirrors the agent tab so the
-// UI renders it, matching the remote-hook baseline).
-func (b *dockerBackend) Launch(i *Instance, firstTimeSetup bool) error {
-	if err := i.AgentServer().Launch(firstTimeSetup); err != nil {
-		return err
-	}
-	i.mu.Lock()
-	i.started = true
-	if len(i.Tabs) == 0 {
-		i.Tabs = []*Tab{newRemoteAgentTab()}
-	}
-	i.mu.Unlock()
-	return nil
-}
-
-// Kill reaps the container. Instance.Kill routes through the AgentServer (which
-// tears the in-container workspace down over REST and then runs the same reap), so
-// this is normally reached only if something calls backend.Kill directly; the
-// shared idempotent reap makes either path safe.
-func (b *dockerBackend) Kill(i *Instance) error {
-	i.mu.Lock()
-	i.started = false
-	i.mu.Unlock()
-	if b.reap != nil {
-		return b.reap()
-	}
-	return nil
-}
-
-// CloseAttachOnly discards this instance's local view WITHOUT reaping the
-// container — used to drop a duplicate Instance built from disk that lost a race
-// to the canonical one (#867). Reaping here would tear down the container the
-// canonical Instance shares, so it must not run.
-func (b *dockerBackend) CloseAttachOnly(i *Instance) error {
-	i.mu.Lock()
-	i.started = false
-	i.mu.Unlock()
-	return nil
-}
-
-func (b *dockerBackend) Preview(i *Instance) (string, error) {
-	return i.AgentServer().Preview(0, false)
-}
-
-func (b *dockerBackend) PreviewFullHistory(i *Instance) (string, error) {
-	return i.AgentServer().Preview(0, true)
-}
-
-func (b *dockerBackend) HasUpdated(i *Instance) (updated bool, hasPrompt bool, content string) {
-	obs, err := i.AgentServer().Snapshot()
-	if err != nil {
-		return false, false, ""
-	}
-	return obs.Updated, obs.HasPrompt, obs.Content
-}
-
-func (b *dockerBackend) SendPromptCommand(i *Instance, prompt string) error {
-	return i.AgentServer().SendPrompt(prompt)
-}
-
-func (b *dockerBackend) IsAlive(i *Instance) bool {
-	// Backend.IsAlive is bool by contract, so an unanswerable probe collapses to
-	// "not alive" here. That is safe ONLY because this method's callers
-	// (Instance.TmuxAlive, for TUI affordance checks) merely gray out a control.
-	// The daemon's destructive paths — Lost/re-provision/respawn — must NOT come
-	// through here; they call AgentServer().Alive() directly and branch on the
-	// error, because for them "unreachable" and "dead" are not the same (#1794).
-	alive, _ := i.AgentServer().Alive()
-	return alive
-}
-
-// CheckAndHandleTrustPrompt is a daemon-side no-op: the in-container agent-server
-// dismisses trust/permission prompts itself on every Snapshot (its localAgentServer
-// runs CheckAndHandleTrustPrompt before reading the pane), so there is nothing for
-// the daemon to do over the wire.
-func (b *dockerBackend) CheckAndHandleTrustPrompt(*Instance) bool { return false }
-
-func (b *dockerBackend) TapEnter(i *Instance) { i.AgentServer().TapEnter() }
-
-// Recover/Respawn re-establish a docker session by RE-PROVISIONING a fresh
-// container that clones the session's branch back from origin, then relaunching
-// the agent (#1592 Phase 4 PR6). Both share recoverSandbox with the ssh runtime
-// (written once against the Runtime interface): a disposable container has no
-// in-place session to reconnect, so recovery is always a fresh provision + clone
-// of the durable branch on GitHub. Only the pushed state survives — a session
-// that went Lost without ever pushing recovers to whatever origin last held.
-func (b *dockerBackend) Recover(i *Instance) error { return recoverSandbox(i) }
-func (b *dockerBackend) Respawn(i *Instance) error { return recoverSandbox(i) }

--- a/session/backend_hook_backend.go
+++ b/session/backend_hook_backend.go
@@ -115,7 +115,7 @@ func (p *hookProvisioner) provision() (ProvisionResult, error) {
 	teardown := p.reap
 	log.InfoLog.Printf("hook runtime: session %q provisioned via launch_cmd, agent-server at %s", p.spec.Title, ep.URL)
 	return ProvisionResult{
-		Backend:  &HookBackend{reap: teardown},
+		Backend:  &HookBackend{remoteAgentBackend: remoteAgentBackend{reap: teardown}},
 		Endpoint: ep,
 		Teardown: teardown,
 	}, nil
@@ -210,142 +210,9 @@ func (p *hookProvisioner) reap() error {
 // FromInstanceData rebuilds for a "remote" record loaded from disk and what
 // restore replaces wholesale via a fresh hookRuntime.Provision.
 type HookBackend struct {
-	// reap runs delete_cmd to tear down the provisioned sandbox; shared with the
-	// runtime's Teardown / the AgentServer Kill path, and idempotent (a sync.Once
-	// behind the closure). nil for an inert backend loaded from disk.
-	reap func() error
+	remoteAgentBackend
 }
 
 var _ Backend = (*HookBackend)(nil)
 
 func (b *HookBackend) Type() string { return "remote" }
-
-// Capabilities advertises the remote-hook backend's parity (#1592 Phase 4 PR7,
-// epic §5) — identical to docker/ssh: the workspace is off-box, but
-// attach/preview/liveness/prompt work through the user-provisioned agent-server,
-// and Archive/Recover work by pushing the branch to GitHub and re-running
-// launch_cmd to re-provision a fresh sandbox that clones it back (§5.1). No
-// ErrRecoverUnsupported, and no per-config TerminalTab gating (the in-sandbox
-// agent-server drives the terminal surface, so the old terminal_cmd bit is gone).
-//
-// TabManagement is false (#1874), for the same reason as docker/ssh: the
-// agent-server's tab surface is data plane only, so every Add*Tab path still
-// requires a daemon-side git worktree this runtime does not have. See
-// dockerBackend.Capabilities.
-func (b *HookBackend) Capabilities() Capabilities {
-	return Capabilities{
-		Workspace:        WorkspaceRemote,
-		Archive:          true,
-		Recover:          true,
-		TabManagement:    false,
-		TerminalTab:      true,
-		InteractiveInput: true,
-	}
-}
-
-// Start provisions then launches the remote workspace. The sandbox +
-// agent-server were established by the runtime (during NewInstance); Start drives
-// the agent-server's own provision/launch over REST, so the in-sandbox LOCAL
-// backend creates the git worktree + branch and spawns the agent.
-func (b *HookBackend) Start(i *Instance, firstTimeSetup bool) error {
-	if err := b.Provision(i, firstTimeSetup); err != nil {
-		return err
-	}
-	return b.Launch(i, firstTimeSetup)
-}
-
-// Provision drives the remote agent-server's Provision over the wire (the clone
-// is already done by launch_cmd; this creates the in-sandbox git worktree).
-func (b *HookBackend) Provision(i *Instance, firstTimeSetup bool) error {
-	return i.AgentServer().Provision(firstTimeSetup)
-}
-
-// Launch drives the remote agent-server's Launch (spawn the agent), sets the
-// started flag, and seeds the daemon-side tab model with the agent tab (the
-// sandbox owns the real tabs; the daemon-side list mirrors the agent tab so the
-// UI renders it, matching the docker/ssh baseline).
-func (b *HookBackend) Launch(i *Instance, firstTimeSetup bool) error {
-	if err := i.AgentServer().Launch(firstTimeSetup); err != nil {
-		return err
-	}
-	i.mu.Lock()
-	i.started = true
-	if len(i.Tabs) == 0 {
-		i.Tabs = []*Tab{newRemoteAgentTab()}
-	}
-	i.mu.Unlock()
-	return nil
-}
-
-// Kill runs the delete_cmd reap. Instance.Kill routes through the AgentServer
-// (which tears the in-sandbox workspace down over REST and then runs the same
-// reap), so this is normally reached only if something calls backend.Kill
-// directly; the shared idempotent reap makes either path safe.
-func (b *HookBackend) Kill(i *Instance) error {
-	i.mu.Lock()
-	i.started = false
-	i.mu.Unlock()
-	if b.reap != nil {
-		return b.reap()
-	}
-	return nil
-}
-
-// CloseAttachOnly discards this instance's local view WITHOUT running delete_cmd
-// — used to drop a duplicate Instance built from disk that lost a race to the
-// canonical one (#867). Reaping here would tear down the sandbox the canonical
-// Instance shares, so it must not run.
-func (b *HookBackend) CloseAttachOnly(i *Instance) error {
-	i.mu.Lock()
-	i.started = false
-	i.mu.Unlock()
-	return nil
-}
-
-func (b *HookBackend) Preview(i *Instance) (string, error) {
-	return i.AgentServer().Preview(0, false)
-}
-
-func (b *HookBackend) PreviewFullHistory(i *Instance) (string, error) {
-	return i.AgentServer().Preview(0, true)
-}
-
-func (b *HookBackend) HasUpdated(i *Instance) (updated bool, hasPrompt bool, content string) {
-	obs, err := i.AgentServer().Snapshot()
-	if err != nil {
-		return false, false, ""
-	}
-	return obs.Updated, obs.HasPrompt, obs.Content
-}
-
-func (b *HookBackend) SendPromptCommand(i *Instance, prompt string) error {
-	return i.AgentServer().SendPrompt(prompt)
-}
-
-func (b *HookBackend) IsAlive(i *Instance) bool {
-	// Backend.IsAlive is bool by contract, so an unanswerable probe collapses to
-	// "not alive" here. That is safe ONLY because this method's callers
-	// (Instance.TmuxAlive, for TUI affordance checks) merely gray out a control.
-	// The daemon's destructive paths — Lost/re-provision/respawn — must NOT come
-	// through here; they call AgentServer().Alive() directly and branch on the
-	// error, because for them "unreachable" and "dead" are not the same (#1794).
-	alive, _ := i.AgentServer().Alive()
-	return alive
-}
-
-// CheckAndHandleTrustPrompt is a daemon-side no-op: the in-sandbox agent-server
-// dismisses trust/permission prompts itself on every Snapshot (its localAgentServer
-// runs CheckAndHandleTrustPrompt before reading the pane), so there is nothing for
-// the daemon to do over the wire.
-func (b *HookBackend) CheckAndHandleTrustPrompt(*Instance) bool { return false }
-
-func (b *HookBackend) TapEnter(i *Instance) { i.AgentServer().TapEnter() }
-
-// Recover/Respawn re-establish a hook session by RE-PROVISIONING via launch_cmd
-// (which clones the session's branch back from origin), then relaunching the
-// agent (#1592 Phase 4 PR7) — the same recoverSandbox docker/ssh use (written
-// once against the Runtime interface). The old HookBackend returned
-// ErrRecoverUnsupported here; provision-and-expose makes recovery a fresh
-// re-provision of the durable branch on GitHub, so hook reaches parity.
-func (b *HookBackend) Recover(i *Instance) error { return recoverSandbox(i) }
-func (b *HookBackend) Respawn(i *Instance) error { return recoverSandbox(i) }

--- a/session/backend_remote_agent.go
+++ b/session/backend_remote_agent.go
@@ -1,0 +1,113 @@
+package session
+
+// remoteAgentBackend is the common backend behavior for workspaces whose data
+// plane is an AgentServer reached through the daemon. Docker, SSH, and hook
+// runtimes differ only in how they provision and reap that workspace; after
+// provisioning, their lifecycle and agent-facing operations must stay identical.
+type remoteAgentBackend struct {
+	// reap tears down the provisioned workspace. It is shared with the runtime's
+	// Teardown / AgentServer Kill path and is idempotent behind the closure. A nil
+	// reap marks an inert backend rebuilt from disk.
+	reap func() error
+}
+
+// Capabilities reports the common off-box runtime contract. Tab management is
+// false because the AgentServer's tab API is data-plane only: it can drive an
+// existing tab but cannot create the daemon-side git worktree required for a
+// new one (#1874).
+func (b *remoteAgentBackend) Capabilities() Capabilities {
+	return Capabilities{
+		Workspace:        WorkspaceRemote,
+		Archive:          true,
+		Recover:          true,
+		TabManagement:    false,
+		TerminalTab:      true,
+		InteractiveInput: true,
+	}
+}
+
+// Start provisions then launches the remote workspace through its AgentServer.
+func (b *remoteAgentBackend) Start(i *Instance, firstTimeSetup bool) error {
+	if err := b.Provision(i, firstTimeSetup); err != nil {
+		return err
+	}
+	return b.Launch(i, firstTimeSetup)
+}
+
+func (b *remoteAgentBackend) Provision(i *Instance, firstTimeSetup bool) error {
+	return i.AgentServer().Provision(firstTimeSetup)
+}
+
+// Launch starts the remote agent and seeds the daemon-side mirror with its
+// agent tab, if it does not already have one.
+func (b *remoteAgentBackend) Launch(i *Instance, firstTimeSetup bool) error {
+	if err := i.AgentServer().Launch(firstTimeSetup); err != nil {
+		return err
+	}
+	i.mu.Lock()
+	i.started = true
+	if len(i.Tabs) == 0 {
+		i.Tabs = []*Tab{newRemoteAgentTab()}
+	}
+	i.mu.Unlock()
+	return nil
+}
+
+func (b *remoteAgentBackend) Kill(i *Instance) error {
+	i.mu.Lock()
+	i.started = false
+	i.mu.Unlock()
+	if b.reap != nil {
+		return b.reap()
+	}
+	return nil
+}
+
+// CloseAttachOnly discards a duplicate instance's local view without reaping
+// the remote workspace its canonical instance still owns.
+func (b *remoteAgentBackend) CloseAttachOnly(i *Instance) error {
+	i.mu.Lock()
+	i.started = false
+	i.mu.Unlock()
+	return nil
+}
+
+func (b *remoteAgentBackend) Preview(i *Instance) (string, error) {
+	return i.AgentServer().Preview(0, false)
+}
+
+func (b *remoteAgentBackend) PreviewFullHistory(i *Instance) (string, error) {
+	return i.AgentServer().Preview(0, true)
+}
+
+func (b *remoteAgentBackend) HasUpdated(i *Instance) (updated bool, hasPrompt bool, content string) {
+	obs, err := i.AgentServer().Snapshot()
+	if err != nil {
+		return false, false, ""
+	}
+	return obs.Updated, obs.HasPrompt, obs.Content
+}
+
+func (b *remoteAgentBackend) SendPromptCommand(i *Instance, prompt string) error {
+	return i.AgentServer().SendPrompt(prompt)
+}
+
+// IsAlive intentionally collapses an unanswerable AgentServer probe to false:
+// its callers only use it for non-destructive TUI affordances. Destructive
+// recovery paths call AgentServer.Alive directly so they can distinguish an
+// unreachable remote from a dead one (#1794).
+func (b *remoteAgentBackend) IsAlive(i *Instance) bool {
+	alive, _ := i.AgentServer().Alive()
+	return alive
+}
+
+// CheckAndHandleTrustPrompt is a daemon-side no-op: each remote AgentServer
+// handles it before returning a snapshot.
+func (b *remoteAgentBackend) CheckAndHandleTrustPrompt(*Instance) bool { return false }
+
+func (b *remoteAgentBackend) TapEnter(i *Instance) { i.AgentServer().TapEnter() }
+
+// Recover and Respawn both re-provision a disposable remote workspace from the
+// session branch, then launch it again.
+func (b *remoteAgentBackend) Recover(i *Instance) error { return recoverSandbox(i) }
+func (b *remoteAgentBackend) Respawn(i *Instance) error { return recoverSandbox(i) }

--- a/session/backend_ssh.go
+++ b/session/backend_ssh.go
@@ -221,7 +221,7 @@ func (p *sshProvisioner) provision() (ProvisionResult, error) {
 	teardown := p.reap
 	log.InfoLog.Printf("ssh runtime: session %q running on %s (remote dir %s), agent-server tunneled at %s", p.spec.Title, p.cfg.Host, p.sessionDir, endpoint.URL)
 	return ProvisionResult{
-		Backend:  &sshBackend{reap: teardown},
+		Backend:  &sshBackend{remoteAgentBackend: remoteAgentBackend{reap: teardown}},
 		Endpoint: endpoint,
 		Teardown: teardown,
 	}, nil
@@ -718,147 +718,12 @@ func expandUserPath(path string) string {
 // agent-server, remove the session dir, close the tunnel), which it shares via the
 // same idempotent closure with the AgentServer Kill path.
 //
-// It parallels dockerBackend deliberately (the two runtimes are independent per the
-// plan — either can ship first); the cross-cutting dedup of the two remote backends
-// belongs to PR6, where archive/restore is written once against the Runtime
-// interface. The daemon's observation/delivery paths speak to a session ONLY
-// through Instance.AgentServer() (the remoteAgentServer), so a backend→AgentServer
-// call here is a network hop over the tunnel, never a loop back into the backend.
+// Its shared remote-AgentServer behavior lives in remoteAgentBackend; this type
+// retains only SSH-specific provisioning and the serialized backend discriminator.
 type sshBackend struct {
-	// reap kills the remote agent-server, removes the remote session dir, and
-	// closes the tunnel + ssh connection; shared with the runtime's Teardown / the
-	// AgentServer Kill path, and idempotent (a sync.Once behind the closure).
-	reap func() error
+	remoteAgentBackend
 }
 
 var _ Backend = (*sshBackend)(nil)
 
 func (b *sshBackend) Type() string { return "ssh" }
-
-// Capabilities advertises ssh's parity (#1592 Phase 4 PR6, epic §5): the
-// workspace is off-box, but attach/preview/liveness/prompt work through the
-// remote agent-server over the tunnel, and Archive/Recover work by pushing the
-// branch to GitHub and re-provisioning a fresh remote that clones it back (§5.1)
-// — no ErrRecoverUnsupported and no locality special-case.
-//
-// TabManagement is false (#1874), for the same reason as docker: the remote
-// agent-server's tab surface is data plane only (Subscribe/Input/Resize address
-// an EXISTING tab), so every Add*Tab path still requires a daemon-side git
-// worktree this runtime does not have. See dockerBackend.Capabilities.
-func (b *sshBackend) Capabilities() Capabilities {
-	return Capabilities{
-		Workspace:        WorkspaceRemote,
-		Archive:          true,
-		Recover:          true,
-		TabManagement:    false,
-		TerminalTab:      true,
-		InteractiveInput: true,
-	}
-}
-
-// Start provisions then launches the remote workspace. The remote host +
-// agent-server were established by the runtime (during NewInstance); Start drives
-// the agent-server's own provision/launch over REST, so the remote LOCAL backend
-// creates the git worktree + branch and spawns the agent.
-func (b *sshBackend) Start(i *Instance, firstTimeSetup bool) error {
-	if err := b.Provision(i, firstTimeSetup); err != nil {
-		return err
-	}
-	return b.Launch(i, firstTimeSetup)
-}
-
-// Provision drives the remote agent-server's Provision over the wire (clone is
-// already done by the runtime; this creates the remote git worktree).
-func (b *sshBackend) Provision(i *Instance, firstTimeSetup bool) error {
-	return i.AgentServer().Provision(firstTimeSetup)
-}
-
-// Launch drives the remote agent-server's Launch (spawn the agent), sets the
-// started flag, and seeds the daemon-side tab model with the agent tab (the remote
-// owns the real tabs; the daemon-side list mirrors the agent tab so the UI renders
-// it, matching the docker/remote-hook baseline).
-func (b *sshBackend) Launch(i *Instance, firstTimeSetup bool) error {
-	if err := i.AgentServer().Launch(firstTimeSetup); err != nil {
-		return err
-	}
-	i.mu.Lock()
-	i.started = true
-	if len(i.Tabs) == 0 {
-		i.Tabs = []*Tab{newRemoteAgentTab()}
-	}
-	i.mu.Unlock()
-	return nil
-}
-
-// Kill runs the runtime teardown. Instance.Kill routes through the AgentServer
-// (which tears the remote workspace down over REST and then runs the same reap), so
-// this is normally reached only if something calls backend.Kill directly; the
-// shared idempotent reap makes either path safe.
-func (b *sshBackend) Kill(i *Instance) error {
-	i.mu.Lock()
-	i.started = false
-	i.mu.Unlock()
-	if b.reap != nil {
-		return b.reap()
-	}
-	return nil
-}
-
-// CloseAttachOnly discards this instance's local view WITHOUT tearing the remote
-// down — used to drop a duplicate Instance built from disk that lost a race to the
-// canonical one (#867). Reaping here would tear down the remote workspace the
-// canonical Instance shares, so it must not run.
-func (b *sshBackend) CloseAttachOnly(i *Instance) error {
-	i.mu.Lock()
-	i.started = false
-	i.mu.Unlock()
-	return nil
-}
-
-func (b *sshBackend) Preview(i *Instance) (string, error) {
-	return i.AgentServer().Preview(0, false)
-}
-
-func (b *sshBackend) PreviewFullHistory(i *Instance) (string, error) {
-	return i.AgentServer().Preview(0, true)
-}
-
-func (b *sshBackend) HasUpdated(i *Instance) (updated bool, hasPrompt bool, content string) {
-	obs, err := i.AgentServer().Snapshot()
-	if err != nil {
-		return false, false, ""
-	}
-	return obs.Updated, obs.HasPrompt, obs.Content
-}
-
-func (b *sshBackend) SendPromptCommand(i *Instance, prompt string) error {
-	return i.AgentServer().SendPrompt(prompt)
-}
-
-func (b *sshBackend) IsAlive(i *Instance) bool {
-	// Backend.IsAlive is bool by contract, so an unanswerable probe collapses to
-	// "not alive" here. That is safe ONLY because this method's callers
-	// (Instance.TmuxAlive, for TUI affordance checks) merely gray out a control.
-	// The daemon's destructive paths — Lost/re-provision/respawn — must NOT come
-	// through here; they call AgentServer().Alive() directly and branch on the
-	// error, because for them "unreachable" and "dead" are not the same (#1794).
-	alive, _ := i.AgentServer().Alive()
-	return alive
-}
-
-// CheckAndHandleTrustPrompt is a daemon-side no-op: the remote agent-server
-// dismisses trust/permission prompts itself on every Snapshot (its localAgentServer
-// runs CheckAndHandleTrustPrompt before reading the pane), so there is nothing for
-// the daemon to do over the wire.
-func (b *sshBackend) CheckAndHandleTrustPrompt(*Instance) bool { return false }
-
-func (b *sshBackend) TapEnter(i *Instance) { i.AgentServer().TapEnter() }
-
-// Recover/Respawn re-establish an ssh session by RE-PROVISIONING a fresh remote
-// that clones the session's branch back from origin, then relaunching the agent
-// (#1592 Phase 4 PR6) — the same recoverSandbox the docker runtime uses (written
-// once). A disposable remote dir has no in-place session to reconnect, so
-// recovery is always a fresh provision + clone of the durable branch on GitHub;
-// only the pushed state survives.
-func (b *sshBackend) Recover(i *Instance) error { return recoverSandbox(i) }
-func (b *sshBackend) Respawn(i *Instance) error { return recoverSandbox(i) }


### PR DESCRIPTION
## What changed

Docker, SSH, and hook backends now embed one `remoteAgentBackend` for their identical AgentServer-backed lifecycle and data-plane operations. Each concrete backend retains its own provisioning implementation, teardown closure, container identity where applicable, and serialized `Type`.

## Why this is behavior-preserving

The extracted methods are unchanged: they call the same `AgentServer` operations, set the same instance state, retain the same nil-reap behavior for inert backends, and use the same `recoverSandbox` recovery path. This removes three paths that were required to remain identical without changing any backend-specific behavior.

## Validation

- `go build ./...`
- `golangci-lint run --fast` (equivalent installed CLI syntax)
- `gofmt -l .` (empty)
- `deadcode -test ./...`
- `make lint-file-length`
- `make test-container` (isolated container suite)

Relates to #1241 and #1195.

— Captain Claude