### PR TITLE
feat(web): hide archived sessions by default with a Show archived filter

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -194,7 +194,7 @@ the top bar, the **project switcher** (top-right), or the `[` / `]` keys:
 ┌───────────────────────────────────────────────────────────────────────┐
 │  Agent Factory   [ Sessions ]  Tasks       project ▾   ● Live   Disconnect│  ← app bar
 ├──────────────────────┬────────────────────────────────────────────────┤
-│ Sessions        3 +New│  fix-login-flow · Live · fix/login             │  ← pane header
+│ Sessions      3 ▤ +New│  fix-login-flow · Live · fix/login             │  ← pane header
 │                       │ ┌────────────────────────────────────────────┐ │
 │ ● fix-login-flow      │ │ Agent │ Terminal │ +                       │ │  ← tab bar
 │   ⎇ fix/login         │ ├────────────────────────────────────────────┤ │
@@ -231,9 +231,25 @@ the TUI:
 - the **branch** as a secondary `⎇` line.
 
 Rows are ordered exactly like the TUI: live sessions first (oldest created first),
-the archived group last (newest first). The header shows the session count and a
-**`+ New`** button that opens the new-session modal (its project picker is seeded
-from the repos af has seen).
+the archived group last (newest first). The header shows the count of the sessions
+currently **shown**, the **filter** control (below), and a **`+ New`** button that
+opens the new-session modal (its project picker is seeded from the repos af has
+seen).
+
+#### Filtering by state
+
+The rail shows the work you can still act on: **archived sessions are hidden by
+default**, and every other state is shown. The **▤** control in the rail header
+opens a checkbox per state — Working, Ready, Lost, Dead, Limit reached, Archived —
+so you can reveal the archive or narrow to just one group (only what's working, say).
+Archived rows render dimmed when shown, so they read as inactive.
+
+The filter is a **display filter, applied within the selected project**: the daemon
+still sends every session, the rail just draws the ones you asked for. It also
+governs `j`/`k`, which walk exactly the rows on screen. Your choice is remembered
+per browser (localStorage), and the control shows a dot when it differs from the
+default. When a filter hides everything, the rail says so — and tells you how many
+sessions are behind it rather than looking empty.
 
 #### Selecting vs. attaching (the keyboard model)
 

--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -213,6 +213,8 @@ body {
 .af-theme-opt:focus-visible,
 .af-project-switch:focus-visible,
 .af-project-item:focus-visible,
+.af-rail-filter:focus-visible,
+.af-filter-item:focus-visible,
 .af-task-action:focus-visible {
   outline: 2px solid var(--af-accent);
   outline-offset: 2px;
@@ -552,6 +554,128 @@ body {
   border: 1px solid var(--af-border);
   border-radius: var(--af-r-full);
   padding: 0.05rem var(--af-sp-2);
+}
+.af-rail-head-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+.af-rail-filter-wrap {
+  position: relative;
+  display: flex;
+}
+.af-rail-filter {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  padding: var(--af-sp-1) 0.45rem;
+  background: transparent;
+  color: var(--af-text-2);
+  border: 1px solid var(--af-border);
+  border-radius: var(--af-r-md);
+  font: inherit;
+  font-size: var(--af-fs-2xs);
+  cursor: pointer;
+}
+.af-rail-filter:hover {
+  color: var(--af-text);
+  border-color: var(--af-border-strong);
+}
+.af-rail-filter-narrowed {
+  color: var(--af-accent);
+  border-color: var(--af-accent);
+}
+.af-rail-filter-glyph {
+  font-size: 0.9em;
+}
+.af-rail-filter-dot {
+  width: 4px;
+  height: 4px;
+  border-radius: var(--af-r-full);
+  background: transparent;
+}
+.af-rail-filter-dot-on {
+  background: var(--af-accent);
+}
+.af-filter-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  min-width: 13rem;
+  background: var(--af-bg-raised);
+  border: 1px solid var(--af-border);
+  border-radius: var(--af-r-lg);
+  box-shadow: var(--af-shadow-overlay);
+  padding: 0.3rem;
+  z-index: 30;
+}
+.af-filter-menu-label {
+  padding: 0.35rem 0.6rem 0.25rem;
+  font-size: var(--af-fs-2xs);
+  text-transform: uppercase;
+  letter-spacing: var(--af-track);
+  color: var(--af-text-3);
+}
+.af-filter-item {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  width: 100%;
+  padding: 0.35rem 0.6rem;
+  background: transparent;
+  border: none;
+  border-radius: var(--af-r-md);
+  color: var(--af-text-2);
+  font: inherit;
+  font-size: var(--af-fs-sm);
+  text-align: left;
+  cursor: pointer;
+}
+.af-filter-item:hover {
+  background: var(--af-bg-inset);
+  color: var(--af-text);
+}
+.af-filter-item-on {
+  color: var(--af-text);
+}
+.af-filter-check {
+  flex: 0 0 auto;
+  width: 0.8rem;
+  color: var(--af-accent);
+  font-weight: 700;
+}
+.af-filter-item-label {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.af-filter-item-count {
+  flex: 0 0 auto;
+  font-size: var(--af-fs-2xs);
+  color: var(--af-text-3);
+  font-variant-numeric: tabular-nums;
+}
+.af-filter-menu-foot {
+  margin-top: 0.25rem;
+  padding-top: 0.35rem;
+  border-top: 1px solid var(--af-border-subtle);
+  display: flex;
+}
+.af-filter-reset {
+  width: 100%;
+  justify-content: center;
+  font-size: var(--af-fs-xs);
+}
+.af-filter-reset:disabled {
+  color: var(--af-text-3);
+  border-color: var(--af-border-subtle);
+  cursor: default;
+}
+.af-filter-reset:disabled:hover {
+  color: var(--af-text-3);
+  border-color: var(--af-border-subtle);
 }
 .af-rail-list {
   list-style: none;

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -6722,12 +6722,20 @@ var Status = {
 };
 
 // src/status.ts
+var ROW_KIND_LABELS = {
+  ready: "Ready",
+  working: "Working",
+  lost: "Lost",
+  dead: "Dead",
+  limit: "Limit reached",
+  archived: "Archived"
+};
 var READY_GLYPH = "\u25CF";
 var DEAD_GLYPH = "\u25CB";
 var LOST_GLYPH = "\u25CC";
 var ARCHIVED_GLYPH = "\u25A7";
 var LIMIT_GLYPH = "\u25C6";
-var WORKING = { glyph: "", kind: null, label: "Working" };
+var WORKING = { glyph: "", kind: null, label: ROW_KIND_LABELS.working };
 function rowStatus(s) {
   const op = s.in_flight_op ?? InFlightOp.None;
   if (op !== InFlightOp.None) {
@@ -6737,6 +6745,9 @@ function rowStatus(s) {
 }
 function isWorking(s) {
   return rowStatus(s).kind === null;
+}
+function rowKind(s) {
+  return rowStatus(s).kind ?? "working";
 }
 function livenessOf(s) {
   const lv = s.liveness ?? Liveness.Unset;
@@ -6761,15 +6772,15 @@ function livenessOf(s) {
 function dotForLiveness(lv) {
   switch (lv) {
     case Liveness.Ready:
-      return { glyph: READY_GLYPH, kind: "ready", label: "Ready" };
+      return { glyph: READY_GLYPH, kind: "ready", label: ROW_KIND_LABELS.ready };
     case Liveness.Lost:
-      return { glyph: LOST_GLYPH, kind: "lost", label: "Lost" };
+      return { glyph: LOST_GLYPH, kind: "lost", label: ROW_KIND_LABELS.lost };
     case Liveness.Dead:
-      return { glyph: DEAD_GLYPH, kind: "dead", label: "Dead" };
+      return { glyph: DEAD_GLYPH, kind: "dead", label: ROW_KIND_LABELS.dead };
     case Liveness.Archived:
-      return { glyph: ARCHIVED_GLYPH, kind: "archived", label: "Archived" };
+      return { glyph: ARCHIVED_GLYPH, kind: "archived", label: ROW_KIND_LABELS.archived };
     case Liveness.LimitReached:
-      return { glyph: LIMIT_GLYPH, kind: "limit", label: "Limit reached" };
+      return { glyph: LIMIT_GLYPH, kind: "limit", label: ROW_KIND_LABELS.limit };
     // LiveRunning and LivenessUnset both render as working (render.go:285, 297).
     case Liveness.Running:
     case Liveness.Unset:
@@ -6832,6 +6843,77 @@ function formatLimitReset(reset, now) {
   }
   const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
   return `${months[reset.getMonth()]} ${reset.getDate()} ${clock}`;
+}
+
+// src/filter.ts
+var FILTER_KEY = "af-status-filter";
+var FILTER_KINDS = ["working", "ready", "lost", "dead", "limit", "archived"];
+var DEFAULTS = {
+  working: true,
+  ready: true,
+  lost: true,
+  dead: true,
+  limit: true,
+  archived: false
+};
+function defaultFilter() {
+  return { ...DEFAULTS };
+}
+function filterLabel(kind) {
+  return ROW_KIND_LABELS[kind];
+}
+function filterSessions(list, filter) {
+  return list.filter((s) => filter[rowKind(s)]);
+}
+function withKind(filter, kind, on) {
+  return { ...filter, [kind]: on };
+}
+function kindCounts(list) {
+  const counts = { working: 0, ready: 0, lost: 0, dead: 0, limit: 0, archived: 0 };
+  for (const s of list) {
+    counts[rowKind(s)]++;
+  }
+  return counts;
+}
+function isDefaultFilter(filter) {
+  return FILTER_KINDS.every((k) => filter[k] === DEFAULTS[k]);
+}
+function hiddenCount(list, filter) {
+  return list.length - filterSessions(list, filter).length;
+}
+function loadFilter() {
+  const filter = defaultFilter();
+  let raw = null;
+  try {
+    raw = localStorage.getItem(FILTER_KEY);
+  } catch {
+    return filter;
+  }
+  if (!raw) {
+    return filter;
+  }
+  let stored;
+  try {
+    stored = JSON.parse(raw);
+  } catch {
+    return filter;
+  }
+  if (!stored || typeof stored !== "object" || Array.isArray(stored)) {
+    return filter;
+  }
+  const rec = stored;
+  for (const kind of FILTER_KINDS) {
+    if (typeof rec[kind] === "boolean") {
+      filter[kind] = rec[kind];
+    }
+  }
+  return filter;
+}
+function persistFilter(filter) {
+  try {
+    localStorage.setItem(FILTER_KEY, JSON.stringify(filter));
+  } catch {
+  }
 }
 
 // src/project.ts
@@ -8935,12 +9017,35 @@ var AppShell = class {
     this.railCount = h2("span", { class: "af-rail-count" }, "0");
     const newBtn = h2("button", { type: "button", class: "af-rail-new", title: "New session" }, "+ New");
     newBtn.addEventListener("click", () => this.actions.newSession());
+    const filterGlyph = h2("span", { class: "af-rail-filter-glyph" }, "\u25A4");
+    filterGlyph.setAttribute("aria-hidden", "true");
+    this.filterDot = h2("span", { class: "af-rail-filter-dot" });
+    this.filterDot.setAttribute("aria-hidden", "true");
+    this.filterBtn = h2("button", { type: "button", class: "af-rail-filter" }, filterGlyph, this.filterDot);
+    this.filterBtn.setAttribute("aria-haspopup", "true");
+    this.filterBtn.setAttribute("aria-expanded", "false");
+    this.filterBtn.setAttribute("aria-label", "Filter sessions");
+    this.filterBtn.setAttribute("title", "Filter sessions");
+    this.filterBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this.toggleFilterMenu();
+    });
+    this.filterMenu = h2("div", { class: "af-filter-menu" });
+    this.filterMenu.setAttribute("role", "group");
+    this.filterMenu.setAttribute("aria-label", "Filter sessions");
+    this.filterMenu.hidden = true;
+    this.filterWrap = h2("div", { class: "af-rail-filter-wrap" }, this.filterBtn, this.filterMenu);
+    document.addEventListener("click", (e) => {
+      if (this.filterMenuOpen && !this.filterWrap.contains(e.target)) {
+        this.closeFilterMenu();
+      }
+    });
     const railHead = h2(
       "div",
       { class: "af-rail-head" },
       h2("span", { class: "af-rail-title" }, "Sessions"),
       this.railCount,
-      newBtn
+      h2("div", { class: "af-rail-head-actions" }, this.filterWrap, newBtn)
     );
     this.railList = h2("ul", { class: "af-rail-list" });
     this.railList.setAttribute("role", "listbox");
@@ -8996,6 +9101,16 @@ var AppShell = class {
   lastProjectSessions = null;
   lastProjectTasks = null;
   lastSelectedProject = null;
+  // The rail's status filter control (feat: hide archived by default): a rail-head
+  // button + a checkbox menu, one row per session state. Same imperative treatment as
+  // the project switcher above — its open state is UI ephemera, not store state, and
+  // the checked set lives in the store (AppState.statusFilter).
+  filterWrap;
+  filterBtn;
+  filterMenu;
+  filterDot;
+  filterMenuOpen = false;
+  lastStatusFilter = null;
   // Header text nodes for the selected pane, (re)created per selection.
   headTitle = null;
   headMeta = null;
@@ -9091,7 +9206,9 @@ var AppShell = class {
     }
     this.lastSessions = state.sessions;
     this.lastSelectedId = state.selectedId;
-    if (sessionsChanged || selectionChanged || projectChanged) {
+    const filterChanged = this.lastStatusFilter !== state.statusFilter;
+    this.lastStatusFilter = state.statusFilter;
+    if (sessionsChanged || selectionChanged || projectChanged || filterChanged) {
       this.renderRail(state);
     }
     if (selectionChanged || !this.mainRendered) {
@@ -9114,13 +9231,16 @@ var AppShell = class {
     this.currentTabIds = tabs.map(tabIdentity);
     this.currentTabRealIds = tabs.map(tabRealId);
   }
-  /** Renders the rail SCOPED to the selected project (redesign PR2): only that
-   *  project's sessions, never the whole projection. Three states: no project at all
-   *  (nothing created yet) → the "no sessions yet" empty rail; a project with no LIVE
-   *  sessions → the dim one-line per-project empty state; otherwise the scoped rows. */
+  /** Renders the rail SCOPED to the selected project (redesign PR2) and FILTERED by
+   *  the status filter (feat: hide archived by default): only that project's sessions
+   *  in a state the user asked to see, never the whole projection. No project at all
+   *  (nothing created yet) → the "no sessions yet" empty rail; otherwise the visible
+   *  rows, under a notice when there is something worth saying about what's missing. */
   renderRail(state) {
     const scoped = scopeToProject(state.sessions, state.selectedProject);
-    this.railCount.textContent = String(scoped.length);
+    const visible = filterSessions(orderedSessions(scoped), state.statusFilter);
+    this.railCount.textContent = String(visible.length);
+    this.renderFilterMenu(state, scoped);
     const list = this.railList;
     if (!state.selectedProject) {
       list.replaceChildren(
@@ -9134,17 +9254,94 @@ var AppShell = class {
       );
       return;
     }
-    const rows = orderedSessions(scoped).map((s) => sessionRow(s, s.id === state.selectedId, this.actions));
-    const hasLive = scoped.some((s) => !isArchived(s));
-    if (!hasLive) {
-      const name = projectName(state.selectedProject);
+    const rows = visible.map((s) => sessionRow(s, s.id === state.selectedId, this.actions));
+    const notice = this.railNotice(state, scoped, visible);
+    list.replaceChildren(...notice ? [notice, ...rows] : rows);
+  }
+  /**
+   * The dim one-liner above the rows explaining what ISN'T there, or null when the
+   * rail speaks for itself. Three things are worth saying, in precedence order:
+   *
+   *  - the project has no ACTIVE session — the redesign PR2 empty state, now
+   *    accurate about the archive: with archived hidden it names the count sitting
+   *    behind the filter (never silently missing), and offers to reveal it in place.
+   *    It renders ABOVE any archived rows, so "no active sessions" reads as a
+   *    statement about live work, not a contradiction of the rows below.
+   *  - every row is filtered out by a narrowed filter — an honest "nothing matches"
+   *    with the way back, rather than a rail that looks broken.
+   *  - otherwise nothing: rows are showing.
+   */
+  railNotice(state, scoped, visible) {
+    const name = projectName(state.selectedProject ?? "");
+    const hasActive = scoped.some((s) => !isArchived(s));
+    if (!hasActive) {
       const newBtn = h2("button", { type: "button", class: "af-rail-empty-new", title: "New session" }, "+ New");
       newBtn.addEventListener("click", () => this.actions.newSession());
-      const empty = h2("li", { class: "af-rail-empty-project" }, `No sessions in ${name} \u2014 `, newBtn);
-      list.replaceChildren(empty, ...rows);
-      return;
+      const empty = h2("li", { class: "af-rail-empty-project" }, `No active sessions in ${name} \u2014 `, newBtn);
+      const archived = scoped.filter(isArchived).length;
+      if (archived > 0 && !state.statusFilter.archived) {
+        const show = h2("button", { type: "button", class: "af-rail-empty-new af-rail-show-archived" }, "Show archived");
+        show.addEventListener("click", () => this.actions.setStatusFilter("archived", true));
+        empty.append(` \xB7 ${archived} archived hidden `, show);
+      }
+      return empty;
     }
-    list.replaceChildren(...rows);
+    if (visible.length === 0) {
+      const reset = h2("button", { type: "button", class: "af-rail-empty-new af-rail-reset-filter" }, "Reset filter");
+      reset.addEventListener("click", () => this.actions.resetStatusFilter());
+      return h2(
+        "li",
+        { class: "af-rail-empty-project" },
+        `No sessions match the filter \u2014 ${hiddenCount(scoped, state.statusFilter)} hidden `,
+        reset
+      );
+    }
+    return null;
+  }
+  /** (Re)builds the filter menu: one checkbox per session state with its scoped
+   *  count, plus a reset. Counts come from the PROJECT-scoped list (the filter is a
+   *  rail control, and the rail is single-project), so they always describe the rows
+   *  the menu governs. Rebuilt in place — the menu's open state is preserved across
+   *  rebuilds so a live event never snaps it shut mid-narrowing. */
+  renderFilterMenu(state, scoped) {
+    const counts = kindCounts(scoped);
+    const narrowed = !isDefaultFilter(state.statusFilter);
+    this.filterDot.classList.toggle("af-rail-filter-dot-on", narrowed);
+    this.filterBtn.classList.toggle("af-rail-filter-narrowed", narrowed);
+    const children = [h2("div", { class: "af-filter-menu-label" }, "Show sessions")];
+    for (const kind of FILTER_KINDS) {
+      children.push(this.filterItem(kind, state.statusFilter[kind], counts[kind]));
+    }
+    const reset = h2("button", { type: "button", class: "af-ghost af-filter-reset" }, "Reset to default");
+    reset.disabled = !narrowed;
+    reset.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this.actions.resetStatusFilter();
+    });
+    children.push(h2("div", { class: "af-filter-menu-foot" }, reset));
+    this.filterMenu.replaceChildren(...children);
+  }
+  /** One state's checkbox in the filter menu: a check when shown, the state's label
+   *  (the row's own word — status.ts ROW_KIND_LABELS), and how many sessions in this
+   *  project are in it. Clicking toggles just that state and leaves the menu open. */
+  filterItem(kind, on, count) {
+    const check = h2("span", { class: "af-filter-check" }, on ? "\u2713" : "");
+    check.setAttribute("aria-hidden", "true");
+    const item = h2(
+      "button",
+      { type: "button", class: `af-filter-item${on ? " af-filter-item-on" : ""}` },
+      check,
+      h2("span", { class: "af-filter-item-label" }, filterLabel(kind)),
+      h2("span", { class: "af-filter-item-count" }, String(count))
+    );
+    item.dataset.kind = kind;
+    item.setAttribute("role", "checkbox");
+    item.setAttribute("aria-checked", on ? "true" : "false");
+    item.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this.actions.setStatusFilter(kind, !on);
+    });
+    return item;
   }
   /** (Re)builds the project switcher: the button's current-project name and the
    *  dropdown menu of every project with its per-project counts (redesign PR2). The
@@ -9278,6 +9475,19 @@ var AppShell = class {
     });
     wrap.append(add, caret, menu);
     return wrap;
+  }
+  toggleFilterMenu() {
+    this.filterMenuOpen = !this.filterMenuOpen;
+    this.filterMenu.hidden = !this.filterMenuOpen;
+    this.filterBtn.setAttribute("aria-expanded", this.filterMenuOpen ? "true" : "false");
+  }
+  closeFilterMenu() {
+    if (!this.filterMenuOpen) {
+      return;
+    }
+    this.filterMenuOpen = false;
+    this.filterMenu.hidden = true;
+    this.filterBtn.setAttribute("aria-expanded", "false");
   }
   toggleProjectMenu() {
     if (this.projectMenuOpen) {
@@ -9498,7 +9708,12 @@ var store = new Store({
   shownTabs: [0],
   tabError: null,
   tasks: [],
-  themeChoice: initialThemeChoice
+  themeChoice: initialThemeChoice,
+  // Resume the persisted filter (feat: hide archived by default) before first paint,
+  // for the same reason the theme is boot-stamped: rendering the default set first
+  // would flash rows the user has filtered away. Falls back to the default — every
+  // state but archived — when nothing is stored.
+  statusFilter: loadFilter()
 });
 var token = null;
 var stream = null;
@@ -9679,6 +9894,16 @@ function switchView(view) {
   if (view === "tasks") {
     refreshTasks();
   }
+}
+function setStatusFilter(kind, on) {
+  const next = withKind(store.get().statusFilter, kind, on);
+  persistFilter(next);
+  store.set({ statusFilter: next });
+}
+function resetStatusFilter() {
+  const next = defaultFilter();
+  persistFilter(next);
+  store.set({ statusFilter: next });
 }
 function switchProject(root2) {
   if (store.get().selectedProject === root2) {
@@ -9987,6 +10212,8 @@ var actions = {
   closeTab: closeSessionTab,
   switchView,
   switchProject,
+  setStatusFilter,
+  resetStatusFilter,
   addTask: openAddTask,
   toggleTask,
   triggerTask: doTriggerTask,
@@ -10098,9 +10325,16 @@ function onKeydown(e) {
       focus,
       modalOpen: modal !== null,
       view: state.view,
-      // j/k navigate only the SCOPED rail (redesign PR2): the ids in the order the
-      // rail shows them, restricted to the selected project.
-      orderedIds: orderedSessions(scopeToProject(state.sessions, state.selectedProject)).map((s) => s.id ?? "").filter((id) => id !== ""),
+      // j/k navigate only the VISIBLE rail: the ids in the order the rail shows them,
+      // restricted to the selected project (redesign PR2) AND to the states the status
+      // filter shows. Both restrictions are required — j/k must walk exactly the rows
+      // on screen, or the selection lands on a row the user cannot see (the archive is
+      // the whole point: hundreds of hidden rows would otherwise still be in the j/k
+      // path, and holding j would appear to hang on nothing).
+      orderedIds: filterSessions(
+        orderedSessions(scopeToProject(state.sessions, state.selectedProject)),
+        state.statusFilter
+      ).map((s) => s.id ?? "").filter((id) => id !== ""),
       selectedId: state.selectedId,
       tabCount: selected ? sessionTabs(selected).length : 1,
       activeTab: state.activeTab,

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -88,6 +88,46 @@ function row(page: Page, title: string): Locator {
   return page.locator(".af-rail-list .af-row", { hasText: title });
 }
 
+/** One state's checkbox in the rail's filter menu (feat: hide archived by default). */
+function filterItem(page: Page, kind: string): Locator {
+  return page.locator(`.af-filter-item[data-kind="${kind}"]`);
+}
+
+/**
+ * Sets one state's checkbox in the rail filter and closes the menu.
+ *
+ * Idempotent (it clicks only when the box disagrees), because these flows share one
+ * page in serial order and the filter is PERSISTED: a test that assumed a starting
+ * state instead of asserting it would pass or fail on whatever the previous test
+ * left in localStorage. Every test that changes the filter restores it before it
+ * ends, for the same reason.
+ */
+async function setFilter(page: Page, kind: string, on: boolean): Promise<void> {
+  await page.locator(".af-rail-filter").click();
+  const item = filterItem(page, kind);
+  await expect(item).toBeVisible();
+  if ((await item.getAttribute("aria-checked")) !== String(on)) {
+    await item.click();
+  }
+  await expect(item).toHaveAttribute("aria-checked", String(on));
+  // Dismiss by clicking outside the control (the rail title is inert chrome).
+  await page.locator(".af-rail-title").click();
+  await expect(page.locator(".af-filter-menu")).toBeHidden();
+}
+
+/** Restores the default filter — every state but archived — via the menu's own reset,
+ *  so a test leaves the shared page as it found it. */
+async function resetFilter(page: Page): Promise<void> {
+  await page.locator(".af-rail-filter").click();
+  const reset = page.locator(".af-filter-reset");
+  if (await reset.isEnabled()) {
+    await reset.click();
+  }
+  await expect(reset).toBeDisabled();
+  await page.locator(".af-rail-title").click();
+  await expect(page.locator(".af-filter-menu")).toBeHidden();
+}
+
 /** A project switcher menu item by its EXACT repo basename (redesign PR2). Filters on
  *  the name span with an anchored regex so "mock-repo" never also matches
  *  "mock-repo-2" / "mock-repo-3" (they share the prefix). */
@@ -1022,6 +1062,10 @@ test("web tab (#1809 follow-up): an ARCHIVED session's preserved web tab is iner
   // proved the CLI refuses to delete it). Preserving the URL must not make an
   // archived session live again: the target is a loopback address whose dev server
   // is gone and whose port may now host something else.
+  //
+  // Archived rows are hidden by default (feat: hide archived by default), so reveal
+  // them to reach this one — and put the filter back before leaving.
+  await setFilter(page, "archived", true);
   await row(page, SESSION_WEB_SHELVED).click();
   await expect(page.locator(".af-main.af-main-term")).toBeVisible();
 
@@ -1051,6 +1095,8 @@ test("web tab (#1809 follow-up): an ARCHIVED session's preserved web tab is iner
   await expect(page.locator(".af-term-host")).not.toContainText(WEBTAB_LOCAL_MARKER);
   // The "open ↗" escape hatch is withdrawn too: it would only hit the refusing proxy.
   await expect(page.locator(".af-webpane-open:visible")).toHaveCount(0);
+
+  await resetFilter(page);
 });
 
 test("web tab (feat): an external URL is iframed directly and shows a fallback when embedding is blocked", async () => {
@@ -1512,11 +1558,14 @@ test("task-only project (redesign PR2, Fix 1): a repo with a task but no session
   await projectItem(page, "mock-repo-3").click();
   await expect(page.locator(".af-project-switch-name")).toHaveText("mock-repo-3");
 
-  // Its rail is the clean empty state (no sessions), not a blank rail.
+  // Its rail is the clean empty state (no sessions), not a blank rail. It has no
+  // archived sessions either, so the empty state stays a bare one-liner — no
+  // "N archived hidden" hint to explain something that isn't there.
   const empty = page.locator(".af-rail-empty-project");
-  await expect(empty).toContainText("No sessions in");
+  await expect(empty).toContainText("No active sessions in");
   await expect(empty).toContainText("mock-repo-3");
   await expect(empty.locator(".af-rail-empty-new")).toBeVisible();
+  await expect(empty).not.toContainText("archived hidden");
 
   // The delete-project action is DISABLED here — there are no live sessions to archive,
   // so it can never be a silent no-op (Greptile Fix 2). An archived-only repo, by the
@@ -1762,7 +1811,7 @@ test.describe("create → kill (one session, two flows)", () => {
   });
 });
 
-test("archive: the archive confirm moves a session to the archived group", async () => {
+test("archive: the archive confirm retires the session out of the default rail", async () => {
   // Archive session B. Select it (click attaches, which is fine), then archive +
   // confirm.
   await row(page, SESSION_B).click();
@@ -1774,15 +1823,226 @@ test("archive: the archive confirm moves a session to the archived group", async
   await expect(modal).toBeVisible();
   await modal.locator("button.af-primary").click();
 
-  // B is not killed — it stays in the rail, but in the archived group (rendered
-  // with the af-row-archived modifier and sorted last).
+  // B LEAVES the default rail (feat: hide archived by default) — archived sessions are
+  // history, and the rail shows the work you can still act on. This is the real
+  // archive flow, not a filter toggle: the row goes as the daemon's archived event
+  // lands, which is the end-to-end proof the filter reads live projection state.
+  await expect(row(page, SESSION_B)).toHaveCount(0, { timeout: 30_000 });
+
+  // B is NOT killed, though — revealing the archive brings the very same row back,
+  // muted, carrying the static ▧ archived dot (no spinner): the error/terminal states
+  // keep their static glyphs (#1766).
+  await setFilter(page, "archived", true);
   await expect(row(page, SESSION_B)).toHaveClass(/af-row-archived/, { timeout: 30_000 });
-  // The archived row carries the static ▧ archived dot (no spinner) — proof the
-  // error/terminal states keep their static glyphs (#1766).
   const archivedDot = row(page, SESSION_B).locator(".af-dot");
   await expect(archivedDot).toHaveClass(/af-dot-archived/);
   await expect(archivedDot).toHaveText("▧");
   await expect(archivedDot).not.toHaveClass(/af-dot-spin/);
+
+  await resetFilter(page);
+  await expect(row(page, SESSION_B)).toHaveCount(0);
+});
+
+// --- the status filter (feat: hide archived by default) --------------------
+//
+// These run right after the archive flow, which leaves the first project holding both
+// live sessions (A, the web probes) and an archived one (B) — the mix the filter
+// exists to sort out. They restore the default filter before finishing, so the flows
+// that follow see the rail they expect (the filter is persisted, and the page is
+// shared).
+
+test("filter (feat): the default shows every state EXCEPT archived", async () => {
+  // The sane default: archived off, everything else on. Asserted through the menu the
+  // user actually reads, so a default that drifts in filter.ts is caught here too.
+  await page.locator(".af-rail-filter").click();
+  await expect(filterItem(page, "archived")).toHaveAttribute("aria-checked", "false");
+  for (const kind of ["working", "ready", "lost", "dead", "limit"]) {
+    await expect(filterItem(page, kind), `${kind} must be shown by default`).toHaveAttribute("aria-checked", "true");
+  }
+  // The default is NOT a "narrowed" state — it must not nag with an indicator the
+  // user has to go undo, and its reset is inert.
+  await expect(page.locator(".af-rail-filter")).not.toHaveClass(/af-rail-filter-narrowed/);
+  await expect(page.locator(".af-filter-reset")).toBeDisabled();
+  await page.locator(".af-rail-title").click();
+
+  // Live sessions show; the archived one does not.
+  await expect(row(page, SESSION_A)).toBeVisible();
+  await expect(row(page, SESSION_B)).toHaveCount(0);
+  // The count agrees with the rows on screen — it counts what the rail SHOWS, not
+  // what the project holds.
+  const shown = await page.locator(".af-rail-list .af-row").count();
+  await expect(page.locator(".af-rail-count")).toHaveText(String(shown));
+});
+
+test("filter (feat): Show archived reveals the archived row, muted, and hides it again", async () => {
+  await setFilter(page, "archived", true);
+  // The archived row is back and reads as inactive: it reuses the dimmed archived
+  // styling rather than looking like live work.
+  const archived = row(page, SESSION_B);
+  await expect(archived).toBeVisible();
+  await expect(archived).toHaveClass(/af-row-archived/);
+  expect(
+    Number(await archived.evaluate((el) => Number(getComputedStyle(el).opacity))),
+    "the archived row must render de-emphasized",
+  ).toBeLessThan(1);
+  // Revealing the archive IS a departure from the default, so the control says so.
+  await expect(page.locator(".af-rail-filter")).toHaveClass(/af-rail-filter-narrowed/);
+  await expect(page.locator(".af-rail-filter-dot")).toHaveClass(/af-rail-filter-dot-on/);
+
+  // Unchecking puts it away again — the toggle is symmetric, not one-way.
+  await setFilter(page, "archived", false);
+  await expect(row(page, SESSION_B)).toHaveCount(0);
+  await expect(page.locator(".af-rail-filter")).not.toHaveClass(/af-rail-filter-narrowed/);
+});
+
+test("filter (feat): the choice persists across a reload", async () => {
+  await setFilter(page, "archived", true);
+  await expect(row(page, SESSION_B)).toBeVisible();
+
+  await page.reload();
+  await expect(page.locator(".af-app")).toBeVisible();
+
+  // The archived row is there on load with NO interaction — the choice came back from
+  // localStorage, and the menu agrees with what the rail drew.
+  await expect(row(page, SESSION_B)).toHaveClass(/af-row-archived/, { timeout: 30_000 });
+  await page.locator(".af-rail-filter").click();
+  await expect(filterItem(page, "archived")).toHaveAttribute("aria-checked", "true");
+  await page.locator(".af-rail-title").click();
+
+  // ...and so does the default, once restored: the persistence is a round trip, not a
+  // one-way write that can only ever add rows.
+  await resetFilter(page);
+  await page.reload();
+  await expect(page.locator(".af-app")).toBeVisible();
+  await expect(row(page, SESSION_A)).toBeVisible({ timeout: 30_000 });
+  await expect(row(page, SESSION_B)).toHaveCount(0);
+});
+
+test("filter (feat): the default hides ONLY archived, and each state's box hides exactly its own group", async ({
+  browser,
+}) => {
+  // One row per state, SYNTHETIC and in their own context — the #1898 rule: a real
+  // row cannot be pinned to a state (the daemon keeps pushing session.updated deltas
+  // that land straight on top of a Snapshot fixture, and the seeded agent's liveness
+  // flips LiveRunning→LiveReady a beat after seeding). A synthetic id the daemon has
+  // never heard of receives no deltas, so "Ready is unchecked ⇒ the ready row is
+  // gone" is deterministic by construction instead of by out-waiting a race. The
+  // filter is a pure function of the row's state, so these drive the same code path.
+  //
+  // The context is its own for a second reason: the filter is PERSISTED, and toggling
+  // six states on the shared page would leak into the serial flows that follow.
+  const ctx = await browser.newContext();
+  const p = await ctx.newPage();
+  await p.route("**/v1/Snapshot", async (route) => {
+    const resp = await route.fetch();
+    const body = await resp.json();
+    const snap = body?.data as { instances?: Array<Record<string, unknown> & { title: string }> };
+    const list = snap?.instances ?? [];
+    // Clone a REAL record so the synthetic rows land in this project's scoped rail,
+    // and vary only what the filter reads. Distinct branches keep each row's text
+    // free of another's name (row() matches by substring).
+    const proto = { ...(list.find((s) => s.title === SESSION_A) ?? {}) };
+    const synth = (title: string, liveness: number) => ({
+      ...proto,
+      id: `synth-filter-${title}`,
+      title,
+      branch: `synth-filter-${title}`,
+      liveness,
+      in_flight_op: 0,
+    });
+    list.push(
+      synth("filt-working", 1), // LiveRunning
+      synth("filt-ready", 2), // LiveReady
+      synth("filt-lost", 3), // LiveLost
+      synth("filt-dead", 4), // LiveDead
+      synth("filt-archived", 5), // LiveArchived
+      synth("filt-limit", 6), // LiveLimitReached
+    );
+    if (snap) {
+      snap.instances = list;
+    }
+    await route.fulfill({ status: resp.status(), contentType: "application/json", body: JSON.stringify(body) });
+  });
+  await p.goto("/");
+  await expect(p.locator(".af-app")).toBeVisible();
+
+  // Each state's row and the checkbox that governs it, in the menu's own order.
+  const states: Array<{ kind: string; title: string }> = [
+    { kind: "working", title: "filt-working" },
+    { kind: "ready", title: "filt-ready" },
+    { kind: "lost", title: "filt-lost" },
+    { kind: "dead", title: "filt-dead" },
+    { kind: "limit", title: "filt-limit" },
+    { kind: "archived", title: "filt-archived" },
+  ];
+
+  // THE DEFAULT: every state but archived. Asserted per state against a real row, so
+  // a default that hides more than the archive is caught here, not by a user.
+  for (const { kind, title } of states) {
+    const shown = kind !== "archived";
+    await expect(row(p, title), `${title} default visibility`).toHaveCount(shown ? 1 : 0, { timeout: 15_000 });
+  }
+
+  // Each box hides exactly its own group: uncheck it, that row goes and EVERY other
+  // state stays — then recheck and it comes back.
+  for (const { kind, title } of states) {
+    if (kind === "archived") {
+      continue; // already off by default; its reveal is covered above
+    }
+    await setFilter(p, kind, false);
+    await expect(row(p, title), `${kind} unchecked ⇒ its row goes`).toHaveCount(0);
+    for (const other of states) {
+      if (other.kind === kind || other.kind === "archived") {
+        continue;
+      }
+      await expect(row(p, other.title), `${kind} unchecked must not disturb ${other.kind}`).toHaveCount(1);
+    }
+    await setFilter(p, kind, true);
+    await expect(row(p, title), `${kind} rechecked ⇒ its row is back`).toHaveCount(1);
+  }
+
+  // Narrowing to a SINGLE state is the "show me only what's working" case: uncheck
+  // every other state and only that group is left standing.
+  for (const { kind } of states) {
+    if (kind !== "working") {
+      await setFilter(p, kind, false);
+    }
+  }
+  await expect(row(p, "filt-working")).toHaveCount(1);
+  await expect(p.locator(".af-rail-list .af-row-archived")).toHaveCount(0);
+  for (const { kind, title } of states) {
+    if (kind !== "working") {
+      await expect(row(p, title), `${title} must be filtered out`).toHaveCount(0);
+    }
+  }
+
+  await ctx.close();
+});
+
+test("filter (feat): keyboard nav walks the VISIBLE rows — j never lands on a hidden one", async () => {
+  // The rail's j/k order must be the rows on screen. If nav still walked the archived
+  // rows the rail hides, j would select something invisible: the pane would swap to a
+  // session the user cannot see in the rail, with no row highlighted.
+  await setFilter(page, "archived", false);
+  await row(page, SESSION_A).click();
+  await page.keyboard.press("Escape"); // hand the keyboard back to the rail
+
+  const visited: string[] = [];
+  const rows = await page.locator(".af-rail-list .af-row").count();
+  for (let i = 0; i < rows + 2; i++) {
+    await page.keyboard.press("j");
+    const sel = page.locator(".af-row-selected");
+    if ((await sel.count()) === 1) {
+      visited.push((await sel.locator(".af-row-title").innerText()).trim());
+    }
+  }
+  // j walked the rail and never selected the archived session hidden from it.
+  expect(visited.length, "j must move the selection").toBeGreaterThan(0);
+  expect(visited, "j must never select a row the filter hides").not.toContain(SESSION_B);
+  // Every row it did land on is one the rail is actually drawing.
+  for (const title of new Set(visited)) {
+    await expect(row(page, title), `${title} must be a visible row`).toBeVisible();
+  }
 });
 
 test("delete project (#1735, redesign PR2, Fix 2): deleting an archived-only-bound project makes it go away — not a no-op", async () => {
@@ -1867,6 +2127,99 @@ test("empty state (#1592 PR9): an empty Snapshot renders the empty rail + placeh
 
   await page.unroute("**/v1/Snapshot");
   await page.unroute("**/v1/ListTasks");
+});
+
+test("filter (feat): a project whose sessions are ALL archived reads as empty, and the filter still reveals them", async ({
+  browser,
+}) => {
+  // An archived-only project is only reachable when something else keeps the repo a
+  // project: a scheduled task. projectSummaries makes a repo a project if it has a LIVE
+  // session OR a task, so an archived-only repo with no task stops being one and the
+  // switcher drops it entirely (the deliberate #1735 rule — a stale archived-only entry
+  // whose delete is a silent no-op must never list).
+  //
+  // So the fixture is a SYNTHETIC repo: archived sessions + a task to keep it a project.
+  // Synthetic and in its own context for the #1898 reason — flipping the REAL rows to
+  // archived does not hold, because the events plane keeps pushing session.updated for
+  // them and applyEvent lands the daemon's truth straight back on top of the fixture
+  // (an earlier draft of this test did exactly that, and the rail refilled with live
+  // rows before the first assertion). Ids the daemon has never heard of receive no
+  // deltas, so the state is the only state there will ever be.
+  const ARCHIVED_REPO = "/work/mock-archived-only";
+  const ctx = await browser.newContext();
+  const p = await ctx.newPage();
+  await p.route("**/v1/Snapshot", async (route) => {
+    const resp = await route.fetch();
+    const body = await resp.json();
+    const snap = body?.data as { instances?: Array<Record<string, unknown> & { title: string }> };
+    const list = snap?.instances ?? [];
+    const proto = { ...(list.find((s) => s.title === SESSION_A) ?? {}) };
+    const shelved = (title: string) => ({
+      ...proto,
+      id: `synth-shelved-${title}`,
+      title,
+      branch: `synth-shelved-${title}`,
+      liveness: 5, // LiveArchived
+      in_flight_op: 0,
+      worktree: { ...(proto.worktree as Record<string, unknown>), repo_path: ARCHIVED_REPO },
+    });
+    list.push(shelved("shelf-one"), shelved("shelf-two"));
+    if (snap) {
+      snap.instances = list;
+    }
+    await route.fulfill({ status: resp.status(), contentType: "application/json", body: JSON.stringify(body) });
+  });
+  // The task is what keeps the archived-only repo a project at all.
+  await p.route("**/v1/ListTasks", async (route) => {
+    const resp = await route.fetch();
+    const body = await resp.json();
+    const data = body?.data as { tasks?: Array<Record<string, unknown>> };
+    const tasks = data?.tasks ?? [];
+    const proto = { ...(tasks[0] ?? {}) };
+    tasks.push({
+      ...proto,
+      id: "synth-shelved-task",
+      name: "shelf-task",
+      project_path: ARCHIVED_REPO,
+    });
+    if (data) {
+      data.tasks = tasks;
+    }
+    await route.fulfill({ status: resp.status(), contentType: "application/json", body: JSON.stringify(body) });
+  });
+  await p.goto("/");
+  await expect(p.locator(".af-app")).toBeVisible();
+
+  // The archived-only repo IS a project (its task keeps it listed) — select it.
+  await p.locator(".af-project-switch").click();
+  await projectItem(p, "mock-archived-only").click();
+  await expect(p.locator(".af-project-switch-name")).toHaveText("mock-archived-only");
+
+  // The rail is NOT a blank panel: it says the project has no active work, and —
+  // crucially — accounts for what it is hiding rather than leaving the sessions
+  // silently missing.
+  const empty = p.locator(".af-rail-empty-project");
+  await expect(empty).toBeVisible({ timeout: 15_000 });
+  await expect(empty).toContainText("No active sessions in");
+  await expect(empty).toContainText("mock-archived-only");
+  await expect(empty).toContainText("2 archived hidden");
+  await expect(p.locator(".af-rail-list .af-row")).toHaveCount(0);
+  await expect(p.locator(".af-rail-count")).toHaveText("0");
+
+  // The hint's inline "Show archived" is a real control, not decoration: it reveals the
+  // archive in place, from the very empty state that reported it.
+  await empty.locator(".af-rail-show-archived").click();
+  await expect(p.locator(".af-rail-list .af-row")).toHaveCount(2);
+  await expect(p.locator(".af-rail-count")).toHaveText("2");
+  await expect(row(p, "shelf-one")).toHaveClass(/af-row-archived/);
+  await expect(row(p, "shelf-two")).toHaveClass(/af-row-archived/);
+  // The empty state still stands above them, and no longer claims to be hiding
+  // anything: "no active sessions" is a statement about live work, not a claim that
+  // the rail is bare.
+  await expect(empty).toBeVisible();
+  await expect(empty).not.toContainText("archived hidden");
+
+  await ctx.close();
 });
 
 // --- theme (redesign PR1): design tokens + light/dark ----------------------
@@ -2268,8 +2621,13 @@ test("#1815 review: a retained layout follows its tab when the roster changes wh
   await expect(active).toHaveText("r2");
 
   // Navigate away, so A's layout is only RETAINED — not the live one being reconciled.
+  // B is archived by the time this runs, so reveal the archive to reach it (feat: hide
+  // archived by default). B stays the right target for exactly the reason it always
+  // was: an agent-tab-only session no other test has moved off its pane.
+  await setFilter(page, "archived", true);
   await row(page, SESSION_B).click();
   await expect(page.locator(".af-main.af-main-term")).toBeVisible();
+  await resetFilter(page);
 
   af("tab-delete", SESSION_A, "--name", "r1");
 

--- a/web/src/filter.test.ts
+++ b/web/src/filter.test.ts
@@ -1,0 +1,244 @@
+// Tests for the rail's status filter (feat: hide archived by default). They pin the
+// three rules the feature rests on: the DEFAULT hides archived and nothing else, the
+// partition keys on the DISPLAYED status (so an in-flight op filters as Working), and
+// a persisted filter round-trips while defaulting any state it doesn't mention.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  FILTER_KINDS,
+  type StatusFilter,
+  defaultFilter,
+  filterLabel,
+  filterSessions,
+  hiddenCount,
+  isDefaultFilter,
+  kindCounts,
+  loadFilter,
+  persistFilter,
+  withKind,
+} from "./filter.js";
+import { ROW_KIND_LABELS, type RowKind } from "./status.js";
+import { InFlightOp, Liveness, Status, type SessionData } from "./types.js";
+
+function sess(over: Partial<SessionData> = {}): SessionData {
+  return { title: "s", branch: "b", ...over };
+}
+
+/** A session per row kind, so a filter can be exercised against every state at once. */
+const ROWS: Record<RowKind, SessionData> = {
+  working: sess({ title: "working", liveness: Liveness.Running }),
+  ready: sess({ title: "ready", liveness: Liveness.Ready }),
+  lost: sess({ title: "lost", liveness: Liveness.Lost }),
+  dead: sess({ title: "dead", liveness: Liveness.Dead }),
+  limit: sess({ title: "limit", liveness: Liveness.LimitReached }),
+  archived: sess({ title: "archived", liveness: Liveness.Archived }),
+};
+
+const ALL: SessionData[] = FILTER_KINDS.map((k) => ROWS[k]);
+
+/** Installs a fresh in-memory localStorage (node has no DOM) and returns a restore
+ *  fn, so persistence is testable without a browser. */
+function stubStorage(seed: Record<string, string> = {}): () => void {
+  const map = new Map(Object.entries(seed));
+  const prior = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (k: string) => map.get(k) ?? null,
+      setItem: (k: string, v: string) => void map.set(k, v),
+      removeItem: (k: string) => void map.delete(k),
+    },
+  });
+  return () => {
+    if (prior) {
+      Object.defineProperty(globalThis, "localStorage", prior);
+    } else {
+      delete (globalThis as { localStorage?: unknown }).localStorage;
+    }
+  };
+}
+
+test("the default shows every state EXCEPT archived", () => {
+  const f = defaultFilter();
+  assert.equal(f.archived, false);
+  for (const k of FILTER_KINDS) {
+    if (k !== "archived") {
+      assert.equal(f[k], true, `${k} must be shown by default`);
+    }
+  }
+  // The sane default IS the default: it must not read as a filter to go undo.
+  assert.equal(isDefaultFilter(f), true);
+});
+
+test("by default the rail shows the live states and hides only the archived row", () => {
+  const shown = filterSessions(ALL, defaultFilter());
+  assert.deepEqual(
+    shown.map((s) => s.title),
+    ["working", "ready", "lost", "dead", "limit"],
+  );
+  assert.equal(hiddenCount(ALL, defaultFilter()), 1);
+});
+
+test("checking Archived reveals the archived row without disturbing the rest", () => {
+  const f = withKind(defaultFilter(), "archived", true);
+  assert.equal(
+    filterSessions(ALL, f).length,
+    ALL.length,
+    "every state checked ⇒ every row shows",
+  );
+  assert.equal(hiddenCount(ALL, f), 0);
+  assert.equal(isDefaultFilter(f), false, "revealing the archive is a narrowing to indicate");
+});
+
+test("unchecking one state hides exactly that group", () => {
+  const f = withKind(defaultFilter(), "working", false);
+  assert.deepEqual(
+    filterSessions(ALL, f).map((s) => s.title),
+    ["ready", "lost", "dead", "limit"],
+  );
+  // withKind is pure — the caller's filter is untouched (the store swaps references).
+  assert.equal(defaultFilter().working, true);
+});
+
+test("narrowing to a single state shows only it (the only-working case)", () => {
+  const only: StatusFilter = { working: true, ready: false, lost: false, dead: false, limit: false, archived: false };
+  assert.deepEqual(
+    filterSessions(ALL, only).map((s) => s.title),
+    ["working"],
+  );
+});
+
+test("an all-off filter empties the rail rather than falling back to showing everything", () => {
+  // The empty-state copy depends on this being an honest zero: renderRail reports
+  // "no sessions match" instead of quietly ignoring the user's filter.
+  const none: StatusFilter = { working: false, ready: false, lost: false, dead: false, limit: false, archived: false };
+  assert.deepEqual(filterSessions(ALL, none), []);
+  assert.equal(hiddenCount(ALL, none), ALL.length);
+});
+
+test("the filter partitions by the DISPLAYED status: an in-flight op filters as Working", () => {
+  // A session being archived is Ready underneath but RENDERS as working (#1766, no
+  // dot). Unchecking Working must hide it — filtering on the raw liveness instead
+  // would leave a visible dotless row behind and hide it under "Ready" instead.
+  const archiving = sess({ title: "archiving", liveness: Liveness.Ready, in_flight_op: InFlightOp.Archiving });
+  const list = [archiving];
+  assert.deepEqual(filterSessions(list, withKind(defaultFilter(), "working", false)), []);
+  assert.deepEqual(
+    filterSessions(list, withKind(defaultFilter(), "ready", false)).map((s) => s.title),
+    ["archiving"],
+    "it is NOT governed by the Ready checkbox",
+  );
+});
+
+test("a session ARCHIVING is not yet archived — the default keeps it visible", () => {
+  // It still reads as working (the [deleting] row the user is watching), so hiding it
+  // by default would make the row vanish the instant the archive is issued.
+  const archiving = sess({ title: "archiving", liveness: Liveness.Ready, in_flight_op: InFlightOp.Archiving });
+  assert.deepEqual(
+    filterSessions([archiving], defaultFilter()).map((s) => s.title),
+    ["archiving"],
+  );
+});
+
+test("the legacy status fallback is filtered too (a pre-#1195 archived record)", () => {
+  const legacy = sess({ title: "legacy", status: Status.Archived });
+  assert.deepEqual(filterSessions([legacy], defaultFilter()), []);
+  assert.deepEqual(
+    filterSessions([legacy], withKind(defaultFilter(), "archived", true)).map((s) => s.title),
+    ["legacy"],
+  );
+});
+
+test("kindCounts reports every kind, zeros included, for the menu's glance", () => {
+  const counts = kindCounts([ROWS.archived, ROWS.archived, ROWS.ready]);
+  assert.equal(counts.archived, 2);
+  assert.equal(counts.ready, 1);
+  assert.equal(counts.dead, 0, "a kind with no sessions still reports 0, so the menu is stable");
+  for (const k of FILTER_KINDS) {
+    assert.equal(typeof counts[k], "number");
+  }
+});
+
+test("filter labels are the row's own status words — the two surfaces cannot drift", () => {
+  for (const k of FILTER_KINDS) {
+    assert.equal(filterLabel(k), ROW_KIND_LABELS[k]);
+  }
+  assert.equal(filterLabel("limit"), "Limit reached", "sentence case, per the copy convention");
+});
+
+test("a filter round-trips through localStorage", () => {
+  const restore = stubStorage();
+  try {
+    const f = withKind(withKind(defaultFilter(), "archived", true), "dead", false);
+    persistFilter(f);
+    assert.deepEqual(loadFilter(), f);
+  } finally {
+    restore();
+  }
+});
+
+test("a stored filter missing a state defaults it to SHOWN, never silently hidden", () => {
+  // The forward-compat rule: a browser holding a filter written before a state
+  // existed must inherit that state's default, not lose the group. Only `archived`
+  // was stored here — every other state (including a hypothetical future one) shows.
+  const restore = stubStorage({ "af-status-filter": JSON.stringify({ archived: true }) });
+  try {
+    const f = loadFilter();
+    assert.equal(f.archived, true, "the stored choice is honored");
+    for (const k of FILTER_KINDS) {
+      if (k !== "archived") {
+        assert.equal(f[k], true, `${k} was not stored ⇒ defaults to shown`);
+      }
+    }
+  } finally {
+    restore();
+  }
+});
+
+test("corrupt / hostile stored values fall back to the default instead of blanking the rail", () => {
+  for (const raw of ["not json", "null", '"a string"', "[]", "42"]) {
+    const restore = stubStorage({ "af-status-filter": raw });
+    try {
+      assert.deepEqual(loadFilter(), defaultFilter(), `${raw} ⇒ default`);
+    } finally {
+      restore();
+    }
+  }
+});
+
+test("non-boolean flags are ignored, so a truthy 'false' can't hide a group", () => {
+  const restore = stubStorage({
+    "af-status-filter": JSON.stringify({ working: "false", ready: 0, dead: null, archived: true }),
+  });
+  try {
+    const f = loadFilter();
+    assert.equal(f.working, true, "the string 'false' is not a boolean ⇒ default wins");
+    assert.equal(f.ready, true);
+    assert.equal(f.dead, true);
+    assert.equal(f.archived, true);
+  } finally {
+    restore();
+  }
+});
+
+test("filter persistence never throws when storage is unavailable (private mode)", () => {
+  const prior = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    get() {
+      throw new Error("storage blocked");
+    },
+  });
+  try {
+    assert.deepEqual(loadFilter(), defaultFilter());
+    assert.doesNotThrow(() => persistFilter(defaultFilter()));
+  } finally {
+    if (prior) {
+      Object.defineProperty(globalThis, "localStorage", prior);
+    } else {
+      delete (globalThis as { localStorage?: unknown }).localStorage;
+    }
+  }
+});

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -1,0 +1,147 @@
+// The rail's status filter (feat: hide archived by default). The web client now
+// shows the sessions a user is actually working with: every state EXCEPT archived is
+// on by default, and the rail-head control narrows or widens that set — reveal the
+// archive, or focus on just the working sessions.
+//
+// This is a pure CLIENT-SIDE DISPLAY filter over the projection the daemon already
+// sends: archived sessions still arrive in every Snapshot, and nothing here changes
+// the API shape or what the daemon computes (the same discipline project.ts follows
+// for the single-project IA). It is DOM-free and I/O-free bar the localStorage
+// helpers, so the partition + persistence rules are unit-tested (filter.test.ts)
+// independently of the shell wiring, exactly as sessions.ts / project.ts / nav.ts are.
+//
+// The filter keys on RowKind — the status a row DISPLAYS (status.ts rowKind), not the
+// raw liveness — so what the checkbox hides is exactly what the eye sees.
+
+import { ROW_KIND_LABELS, type RowKind, rowKind } from "./status.js";
+import type { SessionData } from "./types.js";
+
+/** localStorage key for the persisted filter. localStorage (not sessionStorage) so
+ *  the choice survives a reload/new tab — a durable UI preference like the theme
+ *  (theme.ts) and the selected project (project.ts). */
+const FILTER_KEY = "af-status-filter";
+
+/** Which states the rail shows, one flag per RowKind. A total record (never a
+ *  partial/Set) so every state is an explicit yes/no: adding a RowKind is then a
+ *  type error here rather than a silently-hidden group. */
+export type StatusFilter = Record<RowKind, boolean>;
+
+/** The filter menu's display order: live states first (the ones you act on), then
+ *  the degraded ones, then the archive last — mirroring the rail's own live-then-
+ *  archived partition (status.ts compareSessionsForRail). */
+export const FILTER_KINDS: readonly RowKind[] = ["working", "ready", "lost", "dead", "limit", "archived"];
+
+/** The default: every state EXCEPT archived. Archived sessions are history — they
+ *  accumulate without bound (a long-lived project carries hundreds) and burying the
+ *  handful of live rows under them is what this feature exists to fix. Every other
+ *  state is a session you might still act on, so it stays visible. */
+const DEFAULTS: StatusFilter = {
+  working: true,
+  ready: true,
+  lost: true,
+  dead: true,
+  limit: true,
+  archived: false,
+};
+
+/** A fresh copy of the default filter (never the shared object — callers own theirs
+ *  and the store swaps references). */
+export function defaultFilter(): StatusFilter {
+  return { ...DEFAULTS };
+}
+
+/** The label for one filter checkbox — the SAME word the row's own status label uses
+ *  (status.ts ROW_KIND_LABELS), so a checkbox and the rows it governs always agree. */
+export function filterLabel(kind: RowKind): string {
+  return ROW_KIND_LABELS[kind];
+}
+
+/** The sessions the rail should show: those whose DISPLAYED status is checked.
+ *  Returns a new array and preserves input order, so callers stay free to sort
+ *  (orderedSessions) before or after filtering. */
+export function filterSessions(list: SessionData[], filter: StatusFilter): SessionData[] {
+  return list.filter((s) => filter[rowKind(s)]);
+}
+
+/** A copy of `filter` with one state flipped — the checkbox's update. */
+export function withKind(filter: StatusFilter, kind: RowKind, on: boolean): StatusFilter {
+  return { ...filter, [kind]: on };
+}
+
+/** How many of `list` each state accounts for, for the menu's per-state glance
+ *  counts. Every kind is present (0 when none), so the menu renders a stable set of
+ *  rows rather than shuffling as sessions come and go. */
+export function kindCounts(list: SessionData[]): Record<RowKind, number> {
+  const counts: Record<RowKind, number> = { working: 0, ready: 0, lost: 0, dead: 0, limit: 0, archived: 0 };
+  for (const s of list) {
+    counts[rowKind(s)]++;
+  }
+  return counts;
+}
+
+/** True when the filter is untouched (the default set). Drives the control's
+ *  "narrowed" indicator: the default — archived hidden — is the normal state and must
+ *  NOT read as a filter the user has to go undo. */
+export function isDefaultFilter(filter: StatusFilter): boolean {
+  return FILTER_KINDS.every((k) => filter[k] === DEFAULTS[k]);
+}
+
+/** How many sessions the filter is hiding from `list` — the number the empty/notice
+ *  copy reports so hidden work is never silently missing. */
+export function hiddenCount(list: SessionData[], filter: StatusFilter): number {
+  return list.length - filterSessions(list, filter).length;
+}
+
+// --- persistence -----------------------------------------------------------
+
+/**
+ * The persisted filter, defaulting any state the stored value doesn't mention.
+ *
+ * Overlaying onto defaultFilter() (rather than trusting the stored object whole) is
+ * what makes a NEW state safe to add: a browser holding a filter written before that
+ * state existed has no flag for it, and inheriting the default (shown) is the only
+ * non-astonishing answer — a missing key must never silently hide a group of
+ * sessions the user has no idea exist. Same reason garbage/corrupt storage falls back
+ * to the default instead of an empty filter that would blank the rail. Never throws:
+ * the choice is a convenience, not load-bearing (private mode / blocked storage).
+ */
+export function loadFilter(): StatusFilter {
+  const filter = defaultFilter();
+  let raw: string | null = null;
+  try {
+    raw = localStorage.getItem(FILTER_KEY);
+  } catch {
+    return filter;
+  }
+  if (!raw) {
+    return filter;
+  }
+  let stored: unknown;
+  try {
+    stored = JSON.parse(raw);
+  } catch {
+    return filter;
+  }
+  if (!stored || typeof stored !== "object" || Array.isArray(stored)) {
+    return filter;
+  }
+  const rec = stored as Record<string, unknown>;
+  for (const kind of FILTER_KINDS) {
+    // Only a real boolean overrides a default — a truthy string ("false"!) or a null
+    // from a hand-edited/older payload must not be coerced into a hide.
+    if (typeof rec[kind] === "boolean") {
+      filter[kind] = rec[kind] as boolean;
+    }
+  }
+  return filter;
+}
+
+/** Persists the filter so a reload resumes it. Swallows storage errors (private mode
+ *  / disabled storage): the choice is a convenience, not load-bearing. */
+export function persistFilter(filter: StatusFilter): void {
+  try {
+    localStorage.setItem(FILTER_KEY, JSON.stringify(filter));
+  } catch {
+    // no-op: persistence is best-effort
+  }
+}

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -38,10 +38,11 @@ import {
 import { EventStream, type EventStreamStatus } from "./events.js";
 import { confirmDeleteProjectModal, confirmModal, type ModalHandle, newSessionModal, promptModal } from "./modals.js";
 import { decideKey, type KeyboardFocus, type View } from "./nav.js";
+import { defaultFilter, filterSessions, loadFilter, persistFilter, withKind } from "./filter.js";
 import { loadProjectChoice, persistProjectChoice, pickerProjects, reconcileProject, scopeToProject } from "./project.js";
 import { applyEvent, clampActiveTab, pickSelection, tabToKeepOnClose, upsertSession } from "./sessions.js";
 import { SplitView } from "./split.js";
-import { isArchived } from "./status.js";
+import { isArchived, type RowKind } from "./status.js";
 import { Store } from "./store.js";
 import { bootStampTheme, persistThemeChoice, stampTheme, type ThemeChoice } from "./theme.js";
 import { addTaskModal, type AddTaskInput, buildTask } from "./tasks.js";
@@ -87,6 +88,11 @@ const store = new Store<AppState>({
   tabError: null,
   tasks: [],
   themeChoice: initialThemeChoice,
+  // Resume the persisted filter (feat: hide archived by default) before first paint,
+  // for the same reason the theme is boot-stamped: rendering the default set first
+  // would flash rows the user has filtered away. Falls back to the default — every
+  // state but archived — when nothing is stored.
+  statusFilter: loadFilter(),
 });
 
 // The credential and the push stream are process-local singletons: one token
@@ -391,6 +397,30 @@ function switchView(view: View): void {
   if (view === "tasks") {
     refreshTasks();
   }
+}
+
+/**
+ * Shows/hides one session state in the rail (feat: hide archived by default) and
+ * persists the whole filter so the choice sticks per browser.
+ *
+ * The SELECTION is deliberately left alone, even when this hides the selected row.
+ * The filter governs what the rail draws, not what you are attached to: a session's
+ * state changes on its own (a Ready agent starts working the moment it is prompted),
+ * so tying detach to visibility would rip the terminal out from under a user who
+ * filtered to "Ready" and then typed into one. The row leaves the rail; the pane
+ * keeps streaming, and the rail re-highlights it when its state is shown again.
+ */
+function setStatusFilter(kind: RowKind, on: boolean): void {
+  const next = withKind(store.get().statusFilter, kind, on);
+  persistFilter(next);
+  store.set({ statusFilter: next });
+}
+
+/** Restores the default filter — every state but archived. */
+function resetStatusFilter(): void {
+  const next = defaultFilter();
+  persistFilter(next);
+  store.set({ statusFilter: next });
 }
 
 /** Switches the active project (redesign PR2): scope the rail + views to `root`,
@@ -897,6 +927,8 @@ const actions = {
   closeTab: closeSessionTab,
   switchView,
   switchProject,
+  setStatusFilter,
+  resetStatusFilter,
   addTask: openAddTask,
   toggleTask,
   triggerTask: doTriggerTask,
@@ -1104,9 +1136,16 @@ function onKeydown(e: KeyboardEvent): void {
       focus,
       modalOpen: modal !== null,
       view: state.view,
-      // j/k navigate only the SCOPED rail (redesign PR2): the ids in the order the
-      // rail shows them, restricted to the selected project.
-      orderedIds: orderedSessions(scopeToProject(state.sessions, state.selectedProject))
+      // j/k navigate only the VISIBLE rail: the ids in the order the rail shows them,
+      // restricted to the selected project (redesign PR2) AND to the states the status
+      // filter shows. Both restrictions are required — j/k must walk exactly the rows
+      // on screen, or the selection lands on a row the user cannot see (the archive is
+      // the whole point: hundreds of hidden rows would otherwise still be in the j/k
+      // path, and holding j would appear to hang on nothing).
+      orderedIds: filterSessions(
+        orderedSessions(scopeToProject(state.sessions, state.selectedProject)),
+        state.statusFilter,
+      )
         .map((s) => s.id ?? "")
         .filter((id) => id !== ""),
       selectedId: state.selectedId,

--- a/web/src/status.ts
+++ b/web/src/status.ts
@@ -18,6 +18,24 @@ import { InFlightOp, Liveness, Status, type SessionData } from "./types.js";
  *  A working/busy row has no dot (#1766), so there is no "working" bucket. */
 export type DotKind = "ready" | "lost" | "dead" | "archived" | "limit";
 
+/** The state bucket a row READS AS — every DotKind plus the dotless working row.
+ *  Unlike DotKind this is TOTAL over sessions (rowKind never returns null), which is
+ *  what makes it the key the status filter (filter.ts) partitions the rail by. */
+export type RowKind = DotKind | "working";
+
+/** The one-word state labels, keyed by RowKind. Single source of truth: the row's
+ *  own aria/title label (rowStatus) and the filter menu's checkbox labels both read
+ *  this map, so the two surfaces cannot drift into calling the same state different
+ *  things. Sentence case per the repo copy convention. */
+export const ROW_KIND_LABELS: Record<RowKind, string> = {
+  ready: "Ready",
+  working: "Working",
+  lost: "Lost",
+  dead: "Dead",
+  limit: "Limit reached",
+  archived: "Archived",
+};
+
 /** A fully-resolved status descriptor for one row: the dot to draw and the
  *  human label (used for the row's aria/title so the state is legible to a
  *  screen reader, not only by color — the same intent as the TUI's text prefixes). */
@@ -42,7 +60,7 @@ const LIMIT_GLYPH = "◆";
 // cell for LiveRunning / any in-flight op, and the web omits the dot entirely.
 // Kept as a resolved status (empty glyph, null kind) so rowStatus stays total and
 // callers can still detect the working state (isWorking, the project glance count).
-const WORKING: RowStatus = { glyph: "", kind: null, label: "Working" };
+const WORKING: RowStatus = { glyph: "", kind: null, label: ROW_KIND_LABELS.working };
 
 /**
  * Resolves a session's status dot from its two axes, mirroring render.go exactly:
@@ -67,6 +85,19 @@ export function rowStatus(s: SessionData): RowStatus {
  *  glance count (project.ts) stays derivable now that the dot itself is gone. */
 export function isWorking(s: SessionData): boolean {
   return rowStatus(s).kind === null;
+}
+
+/**
+ * The state bucket a row READS AS, the key the rail's status filter partitions by
+ * (filter.ts). Deliberately derived from rowStatus — the DISPLAYED status — and not
+ * from the raw liveness, because the two genuinely differ: a session with an
+ * in-flight op renders as Working whatever its liveness is (#1766). Filtering on
+ * liveness would hide a row the user is looking at ("Working" unchecked leaves a
+ * dotless working row on screen) and reveal one they are not — the filter must
+ * partition by what the eye sees, so it stays the single mapping in rowStatus.
+ */
+export function rowKind(s: SessionData): RowKind {
+  return rowStatus(s).kind ?? "working";
 }
 
 /** The daemon always emits `liveness`; this only guards a pre-#1195 record by
@@ -96,15 +127,15 @@ function livenessOf(s: SessionData): number {
 function dotForLiveness(lv: number): RowStatus {
   switch (lv) {
     case Liveness.Ready:
-      return { glyph: READY_GLYPH, kind: "ready", label: "Ready" };
+      return { glyph: READY_GLYPH, kind: "ready", label: ROW_KIND_LABELS.ready };
     case Liveness.Lost:
-      return { glyph: LOST_GLYPH, kind: "lost", label: "Lost" };
+      return { glyph: LOST_GLYPH, kind: "lost", label: ROW_KIND_LABELS.lost };
     case Liveness.Dead:
-      return { glyph: DEAD_GLYPH, kind: "dead", label: "Dead" };
+      return { glyph: DEAD_GLYPH, kind: "dead", label: ROW_KIND_LABELS.dead };
     case Liveness.Archived:
-      return { glyph: ARCHIVED_GLYPH, kind: "archived", label: "Archived" };
+      return { glyph: ARCHIVED_GLYPH, kind: "archived", label: ROW_KIND_LABELS.archived };
     case Liveness.LimitReached:
-      return { glyph: LIMIT_GLYPH, kind: "limit", label: "Limit reached" };
+      return { glyph: LIMIT_GLYPH, kind: "limit", label: ROW_KIND_LABELS.limit };
     // LiveRunning and LivenessUnset both render as working (render.go:285, 297).
     case Liveness.Running:
     case Liveness.Unset:

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -251,6 +251,8 @@ body {
 .af-theme-opt:focus-visible,
 .af-project-switch:focus-visible,
 .af-project-item:focus-visible,
+.af-rail-filter:focus-visible,
+.af-filter-item:focus-visible,
 .af-task-action:focus-visible {
   outline: 2px solid var(--af-accent);
   outline-offset: 2px;
@@ -667,6 +669,163 @@ body {
   border: 1px solid var(--af-border);
   border-radius: var(--af-r-full);
   padding: 0.05rem var(--af-sp-2);
+}
+
+/* The rail head's right-hand controls: the status filter and + New, grouped so the
+ * head stays [title] [count] ......... [filter] [new] at the rail's 18rem. */
+.af-rail-head-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.af-rail-filter-wrap {
+  position: relative;
+  display: flex;
+}
+
+/* The status filter control (feat: hide archived by default). A quiet glyph button —
+ * it sits beside the accent-outlined + New, and two competing outlines in a 18rem
+ * head would read as two primary actions. */
+.af-rail-filter {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  padding: var(--af-sp-1) 0.45rem;
+  background: transparent;
+  color: var(--af-text-2);
+  border: 1px solid var(--af-border);
+  border-radius: var(--af-r-md);
+  font: inherit;
+  font-size: var(--af-fs-2xs);
+  cursor: pointer;
+}
+
+.af-rail-filter:hover {
+  color: var(--af-text);
+  border-color: var(--af-border-strong);
+}
+
+/* Narrowed = the filter differs from the default. The DEFAULT (archived hidden) is
+ * the normal state and deliberately draws no indicator: it is not something the user
+ * has to notice or go undo. */
+.af-rail-filter-narrowed {
+  color: var(--af-accent);
+  border-color: var(--af-accent);
+}
+
+.af-rail-filter-glyph {
+  font-size: 0.9em;
+}
+
+/* A static 4px dot — the #1766 rule: state reads from a static glyph, never motion. */
+.af-rail-filter-dot {
+  width: 4px;
+  height: 4px;
+  border-radius: var(--af-r-full);
+  background: transparent;
+}
+
+.af-rail-filter-dot-on {
+  background: var(--af-accent);
+}
+
+/* The filter menu. Mirrors .af-project-menu's chrome (raised surface, overlay shadow,
+ * same radii/padding) so the two dropdowns read as one system. It hangs from its
+ * button's RIGHT edge and opens leftward, which is what keeps a 13rem menu inside an
+ * 18rem rail — anchored left it would spill across the terminal pane. */
+.af-filter-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  min-width: 13rem;
+  background: var(--af-bg-raised);
+  border: 1px solid var(--af-border);
+  border-radius: var(--af-r-lg);
+  box-shadow: var(--af-shadow-overlay);
+  padding: 0.3rem;
+  z-index: 30;
+}
+
+.af-filter-menu-label {
+  padding: 0.35rem 0.6rem 0.25rem;
+  font-size: var(--af-fs-2xs);
+  text-transform: uppercase;
+  letter-spacing: var(--af-track);
+  color: var(--af-text-3);
+}
+
+.af-filter-item {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  width: 100%;
+  padding: 0.35rem 0.6rem;
+  background: transparent;
+  border: none;
+  border-radius: var(--af-r-md);
+  color: var(--af-text-2);
+  font: inherit;
+  font-size: var(--af-fs-sm);
+  text-align: left;
+  cursor: pointer;
+}
+
+.af-filter-item:hover {
+  background: var(--af-bg-inset);
+  color: var(--af-text);
+}
+
+/* A checked state is the row's normal weight; unchecked stays dimmer, so the shown
+ * set is legible at a glance without reading every check. */
+.af-filter-item-on {
+  color: var(--af-text);
+}
+
+.af-filter-check {
+  flex: 0 0 auto;
+  width: 0.8rem;
+  color: var(--af-accent);
+  font-weight: 700;
+}
+
+.af-filter-item-label {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.af-filter-item-count {
+  flex: 0 0 auto;
+  font-size: var(--af-fs-2xs);
+  color: var(--af-text-3);
+  font-variant-numeric: tabular-nums;
+}
+
+.af-filter-menu-foot {
+  margin-top: 0.25rem;
+  padding-top: 0.35rem;
+  border-top: 1px solid var(--af-border-subtle);
+  display: flex;
+}
+
+.af-filter-reset {
+  width: 100%;
+  justify-content: center;
+  font-size: var(--af-fs-xs);
+}
+
+.af-filter-reset:disabled {
+  color: var(--af-text-3);
+  border-color: var(--af-border-subtle);
+  cursor: default;
+}
+
+.af-filter-reset:disabled:hover {
+  color: var(--af-text-3);
+  border-color: var(--af-border-subtle);
 }
 
 .af-rail-list {

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -22,8 +22,17 @@ import type { EventStreamStatus } from "./events.js";
 import type { KeyboardFocus, View } from "./nav.js";
 import { VIEWS } from "./nav.js";
 import { TAB_DND_MIME } from "./layout.js";
+import {
+  FILTER_KINDS,
+  filterLabel,
+  filterSessions,
+  hiddenCount,
+  isDefaultFilter,
+  kindCounts,
+  type StatusFilter,
+} from "./filter.js";
 import { projectMeta, projectName, type ProjectSummary, projectSummaries, scopeToProject } from "./project.js";
-import { compareSessionsForRail, isArchived, rowStatus, rowTitle } from "./status.js";
+import { compareSessionsForRail, isArchived, type RowKind, rowStatus, rowTitle } from "./status.js";
 import { TasksPane } from "./tasks.js";
 import { type ThemeChoice, THEME_CHOICES } from "./theme.js";
 import type { TerminalStatus } from "./terminal.js";
@@ -93,6 +102,12 @@ export interface AppState {
    *  force a mode. The appbar toggle sets it; theme.ts stamps data-theme on <html>
    *  and re-themes the live terminals. */
   themeChoice: ThemeChoice;
+  /** which session states the rail shows (feat: hide archived by default). A pure
+   *  client-side DISPLAY filter over the projection — archived sessions still arrive
+   *  in every Snapshot, the rail just doesn't draw them unless asked. Defaults to
+   *  every state but archived, is set by the rail's filter menu, and is persisted to
+   *  localStorage (filter.ts) so the choice sticks per browser. */
+  statusFilter: StatusFilter;
 }
 
 /** Callbacks the shell invokes; index.ts owns the real behavior. */
@@ -131,6 +146,12 @@ export interface Actions {
    *  here; index.ts scopes the rail + views to `root`, persists it, and drops a
    *  selection that no longer belongs to the new project. */
   switchProject(root: string): void;
+  /** Shows/hides one session state in the rail (feat: hide archived by default): the
+   *  filter menu's checkboxes and the empty state's inline "Show archived" route
+   *  here; index.ts flips the store and persists the whole filter. */
+  setStatusFilter(kind: RowKind, on: boolean): void;
+  /** Restores the default filter — every state but archived. */
+  resetStatusFilter(): void;
   /** Opens the add-task modal (#1592 Phase 5 PR8). */
   addTask(): void;
   /** Enables/disables a task via UpdateTask. */
@@ -478,6 +499,17 @@ export class AppShell {
   private lastProjectTasks: TaskData[] | null = null;
   private lastSelectedProject: string | null = null;
 
+  // The rail's status filter control (feat: hide archived by default): a rail-head
+  // button + a checkbox menu, one row per session state. Same imperative treatment as
+  // the project switcher above — its open state is UI ephemera, not store state, and
+  // the checked set lives in the store (AppState.statusFilter).
+  private readonly filterWrap: HTMLElement;
+  private readonly filterBtn: HTMLButtonElement;
+  private readonly filterMenu: HTMLElement;
+  private readonly filterDot: HTMLElement;
+  private filterMenuOpen = false;
+  private lastStatusFilter: StatusFilter | null = null;
+
   // Header text nodes for the selected pane, (re)created per selection.
   private headTitle: HTMLElement | null = null;
   private headMeta: HTMLElement | null = null;
@@ -605,12 +637,44 @@ export class AppShell {
     this.railCount = h("span", { class: "af-rail-count" }, "0");
     const newBtn = h("button", { type: "button", class: "af-rail-new", title: "New session" }, "+ New");
     newBtn.addEventListener("click", () => this.actions.newSession());
+
+    // The status filter (feat: hide archived by default). A small ▤ glyph button
+    // rather than a word, so the rail head still fits the count + New at 18rem; the
+    // dot beside it lights only when the filter is NARROWED from the default, so the
+    // normal state (archived hidden) never nags.
+    const filterGlyph = h("span", { class: "af-rail-filter-glyph" }, "▤");
+    filterGlyph.setAttribute("aria-hidden", "true");
+    this.filterDot = h("span", { class: "af-rail-filter-dot" });
+    this.filterDot.setAttribute("aria-hidden", "true");
+    this.filterBtn = h("button", { type: "button", class: "af-rail-filter" }, filterGlyph, this.filterDot);
+    this.filterBtn.setAttribute("aria-haspopup", "true");
+    this.filterBtn.setAttribute("aria-expanded", "false");
+    this.filterBtn.setAttribute("aria-label", "Filter sessions");
+    this.filterBtn.setAttribute("title", "Filter sessions");
+    this.filterBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this.toggleFilterMenu();
+    });
+    this.filterMenu = h("div", { class: "af-filter-menu" });
+    this.filterMenu.setAttribute("role", "group");
+    this.filterMenu.setAttribute("aria-label", "Filter sessions");
+    this.filterMenu.hidden = true;
+    this.filterWrap = h("div", { class: "af-rail-filter-wrap" }, this.filterBtn, this.filterMenu);
+    // Dismiss on any click outside (the button + the checkboxes stopPropagation), so
+    // the menu stays open across several toggles — the common act is narrowing to a
+    // couple of states, not one click.
+    document.addEventListener("click", (e) => {
+      if (this.filterMenuOpen && !this.filterWrap.contains(e.target as Node)) {
+        this.closeFilterMenu();
+      }
+    });
+
     const railHead = h(
       "div",
       { class: "af-rail-head" },
       h("span", { class: "af-rail-title" }, "Sessions"),
       this.railCount,
-      newBtn,
+      h("div", { class: "af-rail-head-actions" }, this.filterWrap, newBtn),
     );
     this.railList = h("ul", { class: "af-rail-list" });
     this.railList.setAttribute("role", "listbox");
@@ -728,10 +792,12 @@ export class AppShell {
     this.lastSessions = state.sessions;
     this.lastSelectedId = state.selectedId;
 
-    // Rebuild the rail when the list, the highlighted row, OR the project scope
-    // changed (switching projects swaps the rail). None touches the terminal host (it
-    // lives in the main pane), so events never blur it.
-    if (sessionsChanged || selectionChanged || projectChanged) {
+    // Rebuild the rail when the list, the highlighted row, the project scope, OR the
+    // status filter changed (each of the four changes which rows show). None touches
+    // the terminal host (it lives in the main pane), so events never blur it.
+    const filterChanged = this.lastStatusFilter !== state.statusFilter;
+    this.lastStatusFilter = state.statusFilter;
+    if (sessionsChanged || selectionChanged || projectChanged || filterChanged) {
       this.renderRail(state);
     }
 
@@ -780,13 +846,19 @@ export class AppShell {
     this.currentTabRealIds = tabs.map(tabRealId);
   }
 
-  /** Renders the rail SCOPED to the selected project (redesign PR2): only that
-   *  project's sessions, never the whole projection. Three states: no project at all
-   *  (nothing created yet) → the "no sessions yet" empty rail; a project with no LIVE
-   *  sessions → the dim one-line per-project empty state; otherwise the scoped rows. */
+  /** Renders the rail SCOPED to the selected project (redesign PR2) and FILTERED by
+   *  the status filter (feat: hide archived by default): only that project's sessions
+   *  in a state the user asked to see, never the whole projection. No project at all
+   *  (nothing created yet) → the "no sessions yet" empty rail; otherwise the visible
+   *  rows, under a notice when there is something worth saying about what's missing. */
   private renderRail(state: AppState): void {
     const scoped = scopeToProject(state.sessions, state.selectedProject);
-    this.railCount.textContent = String(scoped.length);
+    const visible = filterSessions(orderedSessions(scoped), state.statusFilter);
+    // The count is what the rail SHOWS, not what the project holds — a count that
+    // disagrees with the rows under it is just a bug the user has to reconcile. The
+    // filter menu carries the per-state totals for what's hidden.
+    this.railCount.textContent = String(visible.length);
+    this.renderFilterMenu(state, scoped);
     const list = this.railList;
     // No project selected ⇒ there are no projects at all (nothing has been created):
     // the global empty rail, its copy pointing at how to create the first session.
@@ -802,20 +874,97 @@ export class AppShell {
       );
       return;
     }
-    const rows = orderedSessions(scoped).map((s) => sessionRow(s, s.id === state.selectedId, this.actions));
-    // A selected project with no LIVE sessions (all archived / none): a clean, dim
-    // one-liner with a + New affordance rather than a blank rail (redesign PR2). Any
-    // archived rows still render below it so the history stays reachable.
-    const hasLive = scoped.some((s) => !isArchived(s));
-    if (!hasLive) {
-      const name = projectName(state.selectedProject);
+    const rows = visible.map((s) => sessionRow(s, s.id === state.selectedId, this.actions));
+    const notice = this.railNotice(state, scoped, visible);
+    list.replaceChildren(...(notice ? [notice, ...rows] : rows));
+  }
+
+  /**
+   * The dim one-liner above the rows explaining what ISN'T there, or null when the
+   * rail speaks for itself. Three things are worth saying, in precedence order:
+   *
+   *  - the project has no ACTIVE session — the redesign PR2 empty state, now
+   *    accurate about the archive: with archived hidden it names the count sitting
+   *    behind the filter (never silently missing), and offers to reveal it in place.
+   *    It renders ABOVE any archived rows, so "no active sessions" reads as a
+   *    statement about live work, not a contradiction of the rows below.
+   *  - every row is filtered out by a narrowed filter — an honest "nothing matches"
+   *    with the way back, rather than a rail that looks broken.
+   *  - otherwise nothing: rows are showing.
+   */
+  private railNotice(state: AppState, scoped: SessionData[], visible: SessionData[]): HTMLElement | null {
+    const name = projectName(state.selectedProject ?? "");
+    const hasActive = scoped.some((s) => !isArchived(s));
+    if (!hasActive) {
       const newBtn = h("button", { type: "button", class: "af-rail-empty-new", title: "New session" }, "+ New");
       newBtn.addEventListener("click", () => this.actions.newSession());
-      const empty = h("li", { class: "af-rail-empty-project" }, `No sessions in ${name} — `, newBtn);
-      list.replaceChildren(empty, ...rows);
-      return;
+      const empty = h("li", { class: "af-rail-empty-project" }, `No active sessions in ${name} — `, newBtn);
+      const archived = scoped.filter(isArchived).length;
+      if (archived > 0 && !state.statusFilter.archived) {
+        const show = h("button", { type: "button", class: "af-rail-empty-new af-rail-show-archived" }, "Show archived");
+        show.addEventListener("click", () => this.actions.setStatusFilter("archived", true));
+        empty.append(` · ${archived} archived hidden `, show);
+      }
+      return empty;
     }
-    list.replaceChildren(...rows);
+    if (visible.length === 0) {
+      const reset = h("button", { type: "button", class: "af-rail-empty-new af-rail-reset-filter" }, "Reset filter");
+      reset.addEventListener("click", () => this.actions.resetStatusFilter());
+      return h(
+        "li",
+        { class: "af-rail-empty-project" },
+        `No sessions match the filter — ${hiddenCount(scoped, state.statusFilter)} hidden `,
+        reset,
+      );
+    }
+    return null;
+  }
+
+  /** (Re)builds the filter menu: one checkbox per session state with its scoped
+   *  count, plus a reset. Counts come from the PROJECT-scoped list (the filter is a
+   *  rail control, and the rail is single-project), so they always describe the rows
+   *  the menu governs. Rebuilt in place — the menu's open state is preserved across
+   *  rebuilds so a live event never snaps it shut mid-narrowing. */
+  private renderFilterMenu(state: AppState, scoped: SessionData[]): void {
+    const counts = kindCounts(scoped);
+    const narrowed = !isDefaultFilter(state.statusFilter);
+    this.filterDot.classList.toggle("af-rail-filter-dot-on", narrowed);
+    this.filterBtn.classList.toggle("af-rail-filter-narrowed", narrowed);
+    const children: HTMLElement[] = [h("div", { class: "af-filter-menu-label" }, "Show sessions")];
+    for (const kind of FILTER_KINDS) {
+      children.push(this.filterItem(kind, state.statusFilter[kind], counts[kind]));
+    }
+    const reset = h("button", { type: "button", class: "af-ghost af-filter-reset" }, "Reset to default");
+    reset.disabled = !narrowed;
+    reset.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this.actions.resetStatusFilter();
+    });
+    children.push(h("div", { class: "af-filter-menu-foot" }, reset));
+    this.filterMenu.replaceChildren(...children);
+  }
+
+  /** One state's checkbox in the filter menu: a check when shown, the state's label
+   *  (the row's own word — status.ts ROW_KIND_LABELS), and how many sessions in this
+   *  project are in it. Clicking toggles just that state and leaves the menu open. */
+  private filterItem(kind: RowKind, on: boolean, count: number): HTMLElement {
+    const check = h("span", { class: "af-filter-check" }, on ? "✓" : "");
+    check.setAttribute("aria-hidden", "true");
+    const item = h(
+      "button",
+      { type: "button", class: `af-filter-item${on ? " af-filter-item-on" : ""}` },
+      check,
+      h("span", { class: "af-filter-item-label" }, filterLabel(kind)),
+      h("span", { class: "af-filter-item-count" }, String(count)),
+    );
+    item.dataset.kind = kind;
+    item.setAttribute("role", "checkbox");
+    item.setAttribute("aria-checked", on ? "true" : "false");
+    item.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this.actions.setStatusFilter(kind, !on);
+    });
+    return item;
   }
 
   /** (Re)builds the project switcher: the button's current-project name and the
@@ -977,6 +1126,21 @@ export class AppShell {
     });
     wrap.append(add, caret, menu);
     return wrap;
+  }
+
+  private toggleFilterMenu(): void {
+    this.filterMenuOpen = !this.filterMenuOpen;
+    this.filterMenu.hidden = !this.filterMenuOpen;
+    this.filterBtn.setAttribute("aria-expanded", this.filterMenuOpen ? "true" : "false");
+  }
+
+  private closeFilterMenu(): void {
+    if (!this.filterMenuOpen) {
+      return;
+    }
+    this.filterMenuOpen = false;
+    this.filterMenu.hidden = true;
+    this.filterBtn.setAttribute("aria-expanded", "false");
   }
 
   private toggleProjectMenu(): void {


### PR DESCRIPTION
The web rail listed archived sessions alongside live ones, so a long-lived project
buried the handful of sessions you can actually act on under its whole history.

The rail now shows the work that's still live, and a filter control decides the rest.

## What changed

- **Archived sessions are hidden by default.** Every other state — Working, Ready,
  Lost, Dead, Limit reached — is shown, as today.
- **A filter control (▤) in the rail header** opens a checkbox per state, with the
  project's per-state counts. Reveal the archive, or narrow to a single group ("only
  what's working"). Archived rows render dimmed when shown, reusing the existing
  `.af-row-archived` muting.
- **The choice persists per browser** (localStorage), like the theme and the selected
  project.
- **Project-scoped**, consistent with the single-project IA: the filter applies within
  the selected project.

This is a pure client-side display filter over the snapshot the daemon already sends.
**No daemon/API change** — archived sessions still arrive in every Snapshot; the
client just doesn't draw them unless asked.

## Design notes

**The filter keys on the DISPLAYED status, not the raw liveness.** The two genuinely
differ: a session with an in-flight op renders as Working whatever its liveness is
(#1766). Filtering on liveness would leave a visible dotless row behind when you
uncheck Working, and hide it under Ready instead. `status.ts` grows a total `rowKind`
derived from `rowStatus` — the same single mapping the row itself renders through —
plus a `ROW_KIND_LABELS` map both the row's aria label and the filter checkboxes read,
so the two surfaces cannot drift into calling the same state different things.

**Keyboard nav walks the visible rows.** `j`/`k` take the same filtered list the rail
draws (`index.ts`), or the selection would land on rows the user can't see — with the
archive hidden, hundreds of them would still sit in the j/k path.

**Selection survives a filter that hides it.** The filter governs what the rail draws,
not what you're attached to. A session's state changes on its own (a Ready agent
starts working the moment it's prompted), so tying detach to visibility would rip the
terminal out from under someone who narrowed to Ready and then typed into one.

**A missing key in stored state defaults to SHOWN.** `loadFilter` overlays onto the
defaults rather than trusting the stored object whole, so a browser holding a filter
written before a new state existed inherits that state's default instead of silently
losing the group.

**Counts and empty states are honest.** The header count is what the rail *shows*, not
what the project holds. A project with no live sessions reads "No active sessions in
X" and — crucially — accounts for what it's hiding (`· N archived hidden`) with an
inline "Show archived", rather than leaving sessions silently missing. A filter that
hides everything says so, with the way back.

## Tests

`web/src/filter.test.ts` (16 new unit tests) pins the pure core: the default hides only
archived, the partition keys on the displayed status (an in-flight op filters as
Working), and persistence round-trips while defaulting unmentioned states. Corrupt and
hostile stored values fall back to the default instead of blanking the rail.

Playwright (`web/selftest/web-driver.spec.ts`):
- the default hides ONLY archived, and each state's box hides exactly its own group —
  driven by **synthetic rows in their own context**, per the #1898 rule that a real row
  can't be pinned to a state (the daemon's deltas land on top of any Snapshot fixture).
- the real archive flow: confirming Archive retires the row out of the default rail,
  and revealing the archive brings the same row back, muted, with its static ▧ dot.
- the toggle persists across a reload — and so does the default, once restored.
- a project whose sessions are ALL archived reads as empty, accounts for what's hidden,
  and the empty state's own "Show archived" reveals them.
- `j` never lands on a row the filter hides.

Three existing tests needed updating, all of them because they depended on archived rows
being in the default rail: the archived web-tab test and the #1815 retained-layout test
now reveal the archive to reach their (archived) target, and the task-only project's
empty-state copy assertion follows the "No active sessions" rewording.

## Gates

`make web-selftest-container` green, `make web-test` (191 unit tests), `go build`,
`gofmt`, `golangci-lint`, `deadcode`, file-length lint, `web/dist` rebuilt and
committed. Rebased on master post-#1897 so the web gate is honest rather than
pre-existing red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
