### PR TITLE
fix(bug-report): always file to sachiniyer/agent-factory + actually carry diagnostics in the report

### DIFF
--- a/bugreport/bugreport.go
+++ b/bugreport/bugreport.go
@@ -231,16 +231,37 @@ const logElidedNote = "\n_Earlier lines elided to fit the issue URL — the atta
 // collection errors, the newest log lines) in a <details> block, and still
 // points at the complete bundle on disk.
 //
+// THE INVARIANT: nothing may change the body's encoded length after the budget
+// is computed.
+//
+// Three separate bugs in this change were one shape — measure, then mutate.
+// Collection errors were written into the head before the budget was computed;
+// the bundle path was substituted after the body was measured; the final scrub
+// expanded prose after the log tail had already spent the budget. Each was
+// "something changes the body after we decided it fits", and patching them one
+// at a time just moved the next one somewhere else.
+//
+// So the order below is the invariant, not a convention:
+//
+//  1. Build every piece.
+//  2. Scrub every piece — head, foot, log, and the log chrome. Nothing reaches
+//     the body unscrubbed, so this doubles as the redaction chokepoint.
+//  3. Measure the scrubbed pieces and hand the log tail the remainder.
+//  4. Concatenate. No transformation runs over the finished body.
+//
+// Step 2 before step 3 is what makes it structurally true rather than checked:
+// there is no later pass left that could grow anything. The returned body is a
+// fixed point of the redactor — scrubbing it again is a no-op — which is exactly
+// the property a test can assert, and does.
+//
 // REDACTION. This body is a SECOND EXIT out of the bundle: unlike the text and
 // JSON renderers it never passes through Build's final catch-all scrub, so
 // anything reaching it must be redacted on the way in — a collector that
 // "usually" scrubs is not enough, and one that missed an exit leaked a real
-// $HOME path into a public draft (the no-log message; see collectLog). Two
-// defenses, deliberately overlapping: every component is scrubbed at the point
-// of inlining (which also keeps the size budget exact, since a scrub that runs
-// later could change lengths), and the assembled body is scrubbed once more at
-// the bottom so a future inline that forgets cannot leak. The second pass is a
-// no-op today precisely because the first exists — scrub is idempotent.
+// $HOME path into a public draft (the no-log message; see collectLog). Step 2
+// above is that guarantee: it scrubs the assembled head/foot wholesale, so an
+// inline that forgets cannot leak, while the per-component scrubs keep the
+// sub-budgets honest.
 //
 // b.bundlePath is measured INTO the body rather than substituted afterwards by
 // the caller: a placeholder swapped out post-measurement made the final body
@@ -266,59 +287,75 @@ func buildIssueDraft(r *redactor, b Bundle) (title, body string) {
 		daemonHuman += "\n" + truncatedNote
 	}
 
-	var head strings.Builder
-	fmt.Fprintf(&head, "<!-- Opened by `af bug-report`. This is a DRAFT — review it, attach the bundle below, then submit. -->\n\n")
-	fmt.Fprintf(&head, "## Environment\n")
-	fmt.Fprintf(&head, "- af: %s\n", r.scrub(b.Versions.AF))
-	fmt.Fprintf(&head, "- go: %s\n", r.scrub(b.Versions.Go))
-	fmt.Fprintf(&head, "- os/arch: %s/%s\n", b.Versions.OS, b.Versions.Arch)
-	fmt.Fprintf(&head, "- daemon: %s\n", daemonState)
-	fmt.Fprintf(&head, "- sessions: %d across %d repo(s)\n", countInstances(b.Instances), len(b.Instances))
-	fmt.Fprintf(&head, "- tasks: %d\n\n", len(b.Tasks))
-	fmt.Fprintf(&head, "## What happened\n<!-- Describe the bug. -->\n\n")
-	fmt.Fprintf(&head, "## What you expected\n\n")
-	fmt.Fprintf(&head, "## Steps to reproduce\n\n")
-	fmt.Fprintf(&head, "---\n\n")
-	fmt.Fprintf(&head, "<details>\n<summary>%s</summary>\n\n", issueSummaryLabel)
-	writeFenced(&head, "### Daemon status", daemonHuman)
-	writeErrors(&head, r, b.Errors)
+	var headRaw strings.Builder
+	fmt.Fprintf(&headRaw, "<!-- Opened by `af bug-report`. This is a DRAFT — review it, attach the bundle below, then submit. -->\n\n")
+	fmt.Fprintf(&headRaw, "## Environment\n")
+	fmt.Fprintf(&headRaw, "- af: %s\n", b.Versions.AF)
+	fmt.Fprintf(&headRaw, "- go: %s\n", b.Versions.Go)
+	fmt.Fprintf(&headRaw, "- os/arch: %s/%s\n", b.Versions.OS, b.Versions.Arch)
+	fmt.Fprintf(&headRaw, "- daemon: %s\n", daemonState)
+	fmt.Fprintf(&headRaw, "- sessions: %d across %d repo(s)\n", countInstances(b.Instances), len(b.Instances))
+	fmt.Fprintf(&headRaw, "- tasks: %d\n\n", len(b.Tasks))
+	fmt.Fprintf(&headRaw, "## What happened\n<!-- Describe the bug. -->\n\n")
+	fmt.Fprintf(&headRaw, "## What you expected\n\n")
+	fmt.Fprintf(&headRaw, "## Steps to reproduce\n\n")
+	fmt.Fprintf(&headRaw, "---\n\n")
+	fmt.Fprintf(&headRaw, "<details>\n<summary>%s</summary>\n\n", issueSummaryLabel)
+	writeFenced(&headRaw, "### Daemon status", daemonHuman)
+	writeErrors(&headRaw, r, b.Errors)
 
-	var foot strings.Builder
-	fmt.Fprintf(&foot, "</details>\n\n---\n\n")
-	fmt.Fprintf(&foot, "The summary above is a bounded excerpt. The COMPLETE best-effort **redacted** "+
+	var footRaw strings.Builder
+	fmt.Fprintf(&footRaw, "</details>\n\n---\n\n")
+	fmt.Fprintf(&footRaw, "The summary above is a bounded excerpt. The COMPLETE best-effort **redacted** "+
 		"bundle (full log tail, sessions, tasks, config) was written to:\n\n")
-	fmt.Fprintf(&foot, "    %s\n\n", r.scrub(b.bundlePath))
-	fmt.Fprintf(&foot, "**Attach that file to this issue** (drag-and-drop) before submitting. "+
+	fmt.Fprintf(&footRaw, "    %s\n\n", b.bundlePath)
+	fmt.Fprintf(&footRaw, "**Attach that file to this issue** (drag-and-drop) before submitting. "+
 		"Open and review it first — redaction is best-effort and cannot catch everything.\n")
 
-	// Size the log fence from the WHOLE tail before budgeting. A fence is closed
-	// by any run of at least its own length, so it must outrun every backtick run
-	// in the text it wraps — but its own cost has to be reserved before the text
-	// is fitted. Sizing it against the full tail sidesteps that circularity: the
-	// fitted tail is a subset, so its longest run can only be shorter, and the
-	// fence stays valid while the budget stays exact.
-	fence := fenceFor(b.Log.Contents)
-	logHeader := "### Daemon log tail (newest lines, redacted)\n\n" + fence + "\n"
-	logFooter := "\n" + fence + "\n\n"
-	budget := maxIssueBodyEncodedBytes -
-		encodedLen(head.String()) - encodedLen(foot.String()) -
-		encodedLen(logHeader) - encodedLen(logFooter) - encodedLen(logElidedNote)
+	// ---- Scrub EVERY piece, then measure. See the invariant note above. ----
+	//
+	// The wholesale head/foot pass is the single redaction chokepoint: it covers
+	// the static template as well as every component, so an inline that forgets
+	// to scrub cannot leak. It runs HERE, before the budget, rather than over the
+	// finished body — over the body it could grow text the budget had already
+	// spent (a username of "the" expands every "the" in the prose above to
+	// "[user]"), and the draft would blow the cap it had just been checked
+	// against. Scrubbing components individually as well keeps the per-section
+	// sub-budgets honest; that is free, because scrub is idempotent.
+	head := r.scrub(headRaw.String())
+	foot := r.scrub(footRaw.String())
+	logAll := r.scrubLog(b.Log.Contents)
 
+	// Size the log fence from the WHOLE (scrubbed) tail before budgeting. A fence
+	// is closed by any run of at least its own length, so it must outrun every
+	// backtick run in the text it wraps — but its own cost has to be reserved
+	// before the text is fitted. Sizing it against the full tail sidesteps that
+	// circularity: the fitted tail is a subset of it, so its longest run can only
+	// be shorter, and the fence stays valid while the budget stays exact.
+	fence := fenceFor(logAll)
+	logHeader := r.scrub("### Daemon log tail (newest lines, redacted)\n\n" + fence + "\n")
+	logFooter := r.scrub("\n" + fence + "\n\n")
+	elidedNote := r.scrub(logElidedNote)
+
+	budget := maxIssueBodyEncodedBytes -
+		encodedLen(head) - encodedLen(foot) -
+		encodedLen(logHeader) - encodedLen(logFooter) - encodedLen(elidedNote)
+	logText, elided := fitLogTail(logAll, issueLogMaxLines, budget)
+
+	// ---- Assembly is pure concatenation of finished pieces. Nothing below may
+	// transform the body: every byte here has already been scrubbed and counted.
 	var sb strings.Builder
-	sb.WriteString(head.String())
-	// Scrubbed here as well as in collectLog: this exit skips the final render
-	// pass, so it must not depend on a collector having covered every path.
-	logText, elided := fitLogTail(r.scrubLog(b.Log.Contents), issueLogMaxLines, budget)
+	sb.WriteString(head)
 	if logText != "" {
 		sb.WriteString(logHeader)
 		sb.WriteString(logText)
 		sb.WriteString(logFooter)
 	}
 	if elided {
-		sb.WriteString(logElidedNote)
+		sb.WriteString(elidedNote)
 	}
-	sb.WriteString(foot.String())
-	return title, r.scrub(sb.String())
+	sb.WriteString(foot)
+	return title, sb.String()
 }
 
 // truncatedNote marks a section the budget cut short, so a trimmed block never

--- a/bugreport/bugreport.go
+++ b/bugreport/bugreport.go
@@ -19,7 +19,6 @@ import (
 	"runtime"
 	"sort"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/sachiniyer/agent-factory/config"
 	aflog "github.com/sachiniyer/agent-factory/log"
@@ -58,6 +57,11 @@ type Inputs struct {
 	// DaemonHuman is the pre-rendered human `af daemon status` text for the
 	// text bundle's daemon section.
 	DaemonHuman string
+	// BundlePath is where the caller will write the text bundle. It is resolved
+	// BEFORE the build so the issue draft can measure the real path into the
+	// body it size-checks, instead of carrying a placeholder the caller swaps
+	// for a longer string afterwards. It is redacted here, not by the caller.
+	BundlePath string
 }
 
 // Versions is the version/platform block of the bundle.
@@ -108,6 +112,10 @@ type Bundle struct {
 	// text renderer. Unexported so it never appears in the JSON manifest (the
 	// structured Daemon snapshot is the machine-readable form there).
 	daemonHuman string
+	// bundlePath is where the caller will write the text bundle, for the issue
+	// draft's attach instructions. Unexported: it is a local path, of no use to
+	// a --json consumer, and the draft is its only reader.
+	bundlePath string
 }
 
 // Result is what Build returns: a rendered text bundle (the file the user
@@ -117,18 +125,14 @@ type Bundle struct {
 // facts + a static template) and bounded to fit an issues/new URL — the FULL
 // bundle still never rides in the URL, but a bounded excerpt of the key
 // diagnostics does, so a submitted draft carries triage signal even when the
-// user never attaches the file. Body carries BundlePathPlaceholder for the
-// command layer to replace with the written bundle's path.
+// user never attaches the file. Body is FINAL: it needs no post-processing by
+// the caller, so nothing can grow it past the size it was checked against.
 type Result struct {
 	Text  string
 	JSON  []byte
 	Title string
 	Body  string
 }
-
-// BundlePathPlaceholder marks where in the issue-draft body the command layer
-// substitutes the written bundle's path (known only once the file is written).
-const BundlePathPlaceholder = "{{BUNDLE_PATH}}"
 
 // Build collects, redacts, and renders the bundle. It never fails on a missing
 // or unreadable section — those are recorded in Bundle.Errors and rendering
@@ -146,6 +150,7 @@ func Build(in Inputs) (Result, error) {
 		},
 		Daemon:      in.DaemonStatus,
 		daemonHuman: in.DaemonHuman,
+		bundlePath:  in.BundlePath,
 	}
 
 	b.Tasks, b.Errors = collectTasks(b.Errors)
@@ -183,15 +188,27 @@ func Build(in Inputs) (Result, error) {
 // ~2KB of the ~8KB for the scheme, host, path, and the encoded title.
 const maxIssueBodyEncodedBytes = 6000
 
+// Per-section sub-budgets. EVERY variable-length section is bounded by ENCODED
+// length before it is written, not after: a section measured only once it is
+// already in the body cannot be un-written, so an unbounded one (a broken
+// install's collection errors, a verbose daemon status) would blow the total cap
+// no matter how hard the log tail is trimmed afterwards. Together with the fixed
+// template these leave the log tail the remainder, and head+foot alone can never
+// reach maxIssueBodyEncodedBytes.
 const (
-	// issueDaemonMaxBytes bounds the daemon-status block. The human status is
-	// ~6 lines today; the cap is a guard against a future verbose status
-	// crowding out the log tail, not an expected trim.
-	issueDaemonMaxBytes = 700
-	// issueErrorsMax bounds how many collection errors inline. The errors
-	// section is the highest-signal part of a broken-install report, so it is
-	// inlined before the log tail claims the remaining budget.
-	issueErrorsMax = 10
+	// issueDaemonEncodedBudget bounds the daemon-status block. The human status
+	// is ~6 lines today; this guards a future verbose status crowding out the
+	// log tail.
+	issueDaemonEncodedBudget = 900
+	// issueErrorsEncodedBudget bounds the whole collection-errors block. The
+	// errors are the highest-signal part of a broken-install report, so they are
+	// fitted before the log tail claims what is left — but a broken install is
+	// exactly where errors are long (unreadable config paths, parser messages),
+	// so the block is bounded, not merely counted.
+	issueErrorsEncodedBudget = 800
+	// issueErrorEncodedMax bounds ONE error, so a single pathological message
+	// cannot consume the whole errors block.
+	issueErrorEncodedMax = 200
 	// issueLogMaxLines bounds the inlined log tail by lines as well as bytes:
 	// the byte budget alone would inline hundreds of short lines, which reads
 	// as noise in an issue. The full tail is in the attached bundle.
@@ -204,25 +221,30 @@ const (
 const logElidedNote = "\n_Earlier lines elided to fit the issue URL — the attached bundle has the full tail._\n"
 
 // buildIssueDraft renders the pre-filled GitHub issue-draft title and body from
-// the already-redacted Bundle.
+// the Bundle.
 //
 // The full bundle (a megabyte of log + session state) cannot inline in an
 // issues/new URL, and before #1914 that meant the draft carried NO diagnostics
 // at all — only counts plus a path to a file on the reporter's own machine,
 // which is useless to a triager unless the user hand-attaches it. So the body
-// now embeds a BOUNDED excerpt of the highest-signal sections (daemon status,
+// embeds a BOUNDED excerpt of the highest-signal sections (daemon status,
 // collection errors, the newest log lines) in a <details> block, and still
 // points at the complete bundle on disk.
 //
-// Everything inlined is scrubbed HERE, at the point of inlining: the Bundle's
-// own log/config/instances arrive pre-redacted from their collectors, but
-// daemonHuman and Errors come straight from the caller/collection and are only
-// scrubbed by the text renderer's final pass — which this body never goes
-// through. Scrubbing each component also keeps the byte budget exact, since
-// nothing downstream can grow the assembled body (a whole-body re-scrub could:
-// "[user]" is longer than the username it replaced).
+// REDACTION. This body is a SECOND EXIT out of the bundle: unlike the text and
+// JSON renderers it never passes through Build's final catch-all scrub, so
+// anything reaching it must be redacted on the way in — a collector that
+// "usually" scrubs is not enough, and one that missed an exit leaked a real
+// $HOME path into a public draft (the no-log message; see collectLog). Two
+// defenses, deliberately overlapping: every component is scrubbed at the point
+// of inlining (which also keeps the size budget exact, since a scrub that runs
+// later could change lengths), and the assembled body is scrubbed once more at
+// the bottom so a future inline that forgets cannot leak. The second pass is a
+// no-op today precisely because the first exists — scrub is idempotent.
 //
-// BundlePathPlaceholder marks the attach-path the command layer fills in.
+// b.bundlePath is measured INTO the body rather than substituted afterwards by
+// the caller: a placeholder swapped out post-measurement made the final body
+// longer than the one that was checked against the cap.
 func buildIssueDraft(r *redactor, b Bundle) (title, body string) {
 	title = fmt.Sprintf("af bug-report: %s on %s/%s", b.Versions.AF, b.Versions.OS, b.Versions.Arch)
 
@@ -239,12 +261,16 @@ func buildIssueDraft(r *redactor, b Bundle) (title, body string) {
 	case strings.Contains(strings.ToLower(daemonHuman), "not running"):
 		daemonState = "not running"
 	}
+	daemonHuman, daemonTruncated := truncateEncoded(daemonHuman, issueDaemonEncodedBudget)
+	if daemonTruncated {
+		daemonHuman += "\n" + truncatedNote
+	}
 
 	var head strings.Builder
 	fmt.Fprintf(&head, "<!-- Opened by `af bug-report`. This is a DRAFT — review it, attach the bundle below, then submit. -->\n\n")
 	fmt.Fprintf(&head, "## Environment\n")
-	fmt.Fprintf(&head, "- af: %s\n", b.Versions.AF)
-	fmt.Fprintf(&head, "- go: %s\n", b.Versions.Go)
+	fmt.Fprintf(&head, "- af: %s\n", r.scrub(b.Versions.AF))
+	fmt.Fprintf(&head, "- go: %s\n", r.scrub(b.Versions.Go))
 	fmt.Fprintf(&head, "- os/arch: %s/%s\n", b.Versions.OS, b.Versions.Arch)
 	fmt.Fprintf(&head, "- daemon: %s\n", daemonState)
 	fmt.Fprintf(&head, "- sessions: %d across %d repo(s)\n", countInstances(b.Instances), len(b.Instances))
@@ -254,38 +280,35 @@ func buildIssueDraft(r *redactor, b Bundle) (title, body string) {
 	fmt.Fprintf(&head, "## Steps to reproduce\n\n")
 	fmt.Fprintf(&head, "---\n\n")
 	fmt.Fprintf(&head, "<details>\n<summary>%s</summary>\n\n", issueSummaryLabel)
-	fmt.Fprintf(&head, "### Daemon status\n\n```\n%s\n```\n\n", truncateBytes(daemonHuman, issueDaemonMaxBytes))
-	if len(b.Errors) > 0 {
-		fmt.Fprintf(&head, "### Collection errors\n\n")
-		for i, e := range b.Errors {
-			if i == issueErrorsMax {
-				fmt.Fprintf(&head, "- …and %d more (see the attached bundle)\n", len(b.Errors)-issueErrorsMax)
-				break
-			}
-			fmt.Fprintf(&head, "- %s\n", r.scrub(e))
-		}
-		head.WriteByte('\n')
-	}
+	writeFenced(&head, "### Daemon status", daemonHuman)
+	writeErrors(&head, r, b.Errors)
 
 	var foot strings.Builder
 	fmt.Fprintf(&foot, "</details>\n\n---\n\n")
 	fmt.Fprintf(&foot, "The summary above is a bounded excerpt. The COMPLETE best-effort **redacted** "+
 		"bundle (full log tail, sessions, tasks, config) was written to:\n\n")
-	fmt.Fprintf(&foot, "    %s\n\n", BundlePathPlaceholder)
+	fmt.Fprintf(&foot, "    %s\n\n", r.scrub(b.bundlePath))
 	fmt.Fprintf(&foot, "**Attach that file to this issue** (drag-and-drop) before submitting. "+
 		"Open and review it first — redaction is best-effort and cannot catch everything.\n")
 
-	// Hand the log tail whatever encoded budget the rest of the body leaves,
-	// always reserving the elision note so appending it can't bust the cap.
-	logHeader := "### Daemon log tail (newest lines, redacted)\n\n```\n"
-	logFooter := "\n```\n\n"
+	// Size the log fence from the WHOLE tail before budgeting. A fence is closed
+	// by any run of at least its own length, so it must outrun every backtick run
+	// in the text it wraps — but its own cost has to be reserved before the text
+	// is fitted. Sizing it against the full tail sidesteps that circularity: the
+	// fitted tail is a subset, so its longest run can only be shorter, and the
+	// fence stays valid while the budget stays exact.
+	fence := fenceFor(b.Log.Contents)
+	logHeader := "### Daemon log tail (newest lines, redacted)\n\n" + fence + "\n"
+	logFooter := "\n" + fence + "\n\n"
 	budget := maxIssueBodyEncodedBytes -
 		encodedLen(head.String()) - encodedLen(foot.String()) -
 		encodedLen(logHeader) - encodedLen(logFooter) - encodedLen(logElidedNote)
 
 	var sb strings.Builder
 	sb.WriteString(head.String())
-	logText, elided := fitLogTail(b.Log.Contents, issueLogMaxLines, budget)
+	// Scrubbed here as well as in collectLog: this exit skips the final render
+	// pass, so it must not depend on a collector having covered every path.
+	logText, elided := fitLogTail(r.scrubLog(b.Log.Contents), issueLogMaxLines, budget)
 	if logText != "" {
 		sb.WriteString(logHeader)
 		sb.WriteString(logText)
@@ -295,7 +318,71 @@ func buildIssueDraft(r *redactor, b Bundle) (title, body string) {
 		sb.WriteString(logElidedNote)
 	}
 	sb.WriteString(foot.String())
-	return title, sb.String()
+	return title, r.scrub(sb.String())
+}
+
+// truncatedNote marks a section the budget cut short, so a trimmed block never
+// reads as complete.
+const truncatedNote = "…(truncated; see the attached bundle)"
+
+// writeErrors writes the collection-errors block, fitted to
+// issueErrorsEncodedBudget. Each error is scrubbed and individually capped, and
+// whatever did not fit is counted rather than dropped silently.
+func writeErrors(sb *strings.Builder, r *redactor, errs []string) {
+	if len(errs) == 0 {
+		return
+	}
+	var block strings.Builder
+	remaining := issueErrorsEncodedBudget
+	shown := 0
+	for _, e := range errs {
+		line, _ := truncateEncoded(r.scrub(e), issueErrorEncodedMax)
+		line = "- " + strings.ReplaceAll(line, "\n", " ") + "\n"
+		cost := encodedLen(line)
+		if cost > remaining {
+			break
+		}
+		block.WriteString(line)
+		remaining -= cost
+		shown++
+	}
+	fmt.Fprintf(sb, "### Collection errors\n\n")
+	sb.WriteString(block.String())
+	if shown < len(errs) {
+		fmt.Fprintf(sb, "- …and %d more (see the attached bundle)\n", len(errs)-shown)
+	}
+	sb.WriteByte('\n')
+}
+
+// writeFenced writes a titled code block whose fence outruns any backtick run in
+// body, so nothing in body can close it early.
+func writeFenced(sb *strings.Builder, title, body string) {
+	fence := fenceFor(body)
+	fmt.Fprintf(sb, "%s\n\n%s\n%s\n%s\n\n", title, fence, body, fence)
+}
+
+// fenceFor returns a backtick fence long enough that nothing in s can close it:
+// CommonMark closes a fence only on a run of at least the same length, so the
+// fence has to outrun the longest run in the content. A log line can carry a
+// literal ``` (a hook echoing its own markdown output), which against a fixed
+// three-backtick fence ended the block early and rendered the rest of the
+// draft — the closing </details> and the attach instructions — as code.
+func fenceFor(s string) string {
+	longest, run := 0, 0
+	for _, c := range s {
+		if c == '`' {
+			run++
+			if run > longest {
+				longest = run
+			}
+			continue
+		}
+		run = 0
+	}
+	if longest < 3 {
+		return "```"
+	}
+	return strings.Repeat("`", longest+1)
 }
 
 // issueSummaryLabel names the collapsible diagnostics block. Tests key on it to
@@ -339,17 +426,24 @@ func fitLogTail(contents string, maxLines, budget int) (text string, elided bool
 // issues/new query string — the only length that matters for the URL cap.
 func encodedLen(s string) int { return len(url.QueryEscape(s)) }
 
-// truncateBytes caps s at max bytes on a rune boundary, marking the cut so a
-// trimmed block never reads as complete.
-func truncateBytes(s string, max int) string {
-	if len(s) <= max {
-		return s
+// truncateEncoded caps s at budget ENCODED bytes, cutting on a rune boundary and
+// reporting whether anything was dropped. It walks runes and accumulates their
+// encoded cost because that cost is wildly uneven — an ASCII letter is 1 byte, a
+// newline 3, a multi-byte rune up to 12 — so a raw-length cap says nothing about
+// how much of the URL budget a string actually spends.
+func truncateEncoded(s string, budget int) (string, bool) {
+	if encodedLen(s) <= budget {
+		return s, false
 	}
-	cut := s[:max]
-	for len(cut) > 0 && !utf8.ValidString(cut) {
-		cut = cut[:len(cut)-1]
+	used := 0
+	for i, c := range s {
+		cost := encodedLen(string(c))
+		if used+cost > budget {
+			return s[:i], true
+		}
+		used += cost
 	}
-	return cut + "\n…(truncated; see the attached bundle)"
+	return s, false
 }
 
 // countInstances totals the session records across every repo's redacted
@@ -433,6 +527,14 @@ func collectConfig(r *redactor, errs []string) (*configSection, []string) {
 }
 
 // collectLog reads and scrubs the bounded tail of the production log.
+//
+// EVERY exit must leave Contents redacted, not just the one that carries log
+// text. The no-log message below interpolates the resolved log path — a real
+// $HOME/config path — and used to be stored raw, surviving only because the text
+// and JSON renderers happened to scrub once more at the end. The issue draft
+// inlines Contents directly and never goes through that final pass, so the raw
+// path reached a PUBLIC prefilled draft. The field is documented as redacted;
+// it now is, on every path, for every consumer.
 func collectLog(r *redactor, errs []string) (logSection, []string) {
 	path := aflog.LogFilePath()
 	sec := logSection{Path: path}
@@ -442,7 +544,7 @@ func collectLog(r *redactor, errs []string) (logSection, []string) {
 	data, truncated, err := tailFile(path, logTailMaxBytes)
 	if err != nil {
 		if os.IsNotExist(err) {
-			sec.Contents = "(no log file at " + path + ")"
+			sec.Contents = r.scrub("(no log file at " + path + ")")
 			return sec, errs
 		}
 		return sec, append(errs, fmt.Sprintf("log %s: %v", path, err))

--- a/bugreport/bugreport.go
+++ b/bugreport/bugreport.go
@@ -13,11 +13,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
 	"sort"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/sachiniyer/agent-factory/config"
 	aflog "github.com/sachiniyer/agent-factory/log"
@@ -111,11 +113,12 @@ type Bundle struct {
 // Result is what Build returns: a rendered text bundle (the file the user
 // attaches), the JSON manifest payload (the `--json` data member), and the
 // pre-filled GitHub issue-draft title/body the default flow opens in the
-// browser. Title/Body are short, already-redacted (built only from redacted
-// Bundle facts + a static template), and safe to inline in an issues/new URL —
-// the full bundle never rides in the URL; it reaches the issue as the attached
-// file. Body carries BundlePathPlaceholder for the command layer to replace with
-// the written bundle's path.
+// browser. Title/Body are already-redacted (built only from redacted Bundle
+// facts + a static template) and bounded to fit an issues/new URL — the FULL
+// bundle still never rides in the URL, but a bounded excerpt of the key
+// diagnostics does, so a submitted draft carries triage signal even when the
+// user never attaches the file. Body carries BundlePathPlaceholder for the
+// command layer to replace with the written bundle's path.
 type Result struct {
 	Text  string
 	JSON  []byte
@@ -161,42 +164,192 @@ func Build(in Inputs) (Result, error) {
 	jsonBytes = []byte(r.scrub(string(jsonBytes)))
 
 	text := r.scrub(renderText(b))
-	title, body := buildIssueDraft(b)
+	title, body := buildIssueDraft(r, b)
 
 	return Result{Text: text, JSON: jsonBytes, Title: title, Body: body}, nil
 }
 
+// Issue-draft size budget.
+//
+// The draft reaches GitHub as an issues/new URL — built by the command layer,
+// or by `gh --web`, which constructs the same URL — and GitHub rejects one past
+// roughly 8KB. The body rides in the query string, so what has to fit is the
+// PERCENT-ENCODED body, not its raw length: a newline costs 3 bytes encoded and
+// a log tail is newline-dense, so a raw cap would silently overshoot the URL.
+//
+// url.QueryEscape maps each byte independently, so encoded length is additive
+// over concatenation — the fixed template can be measured first and the log tail
+// handed exactly the remainder (see fitLogTail). maxIssueBodyEncodedBytes leaves
+// ~2KB of the ~8KB for the scheme, host, path, and the encoded title.
+const maxIssueBodyEncodedBytes = 6000
+
+const (
+	// issueDaemonMaxBytes bounds the daemon-status block. The human status is
+	// ~6 lines today; the cap is a guard against a future verbose status
+	// crowding out the log tail, not an expected trim.
+	issueDaemonMaxBytes = 700
+	// issueErrorsMax bounds how many collection errors inline. The errors
+	// section is the highest-signal part of a broken-install report, so it is
+	// inlined before the log tail claims the remaining budget.
+	issueErrorsMax = 10
+	// issueLogMaxLines bounds the inlined log tail by lines as well as bytes:
+	// the byte budget alone would inline hundreds of short lines, which reads
+	// as noise in an issue. The full tail is in the attached bundle.
+	issueLogMaxLines = 40
+)
+
+// logElidedNote is appended to the inlined log tail whenever lines were dropped
+// to fit the budget. Its cost is always reserved, so the note can never be what
+// pushes the body over the cap.
+const logElidedNote = "\n_Earlier lines elided to fit the issue URL — the attached bundle has the full tail._\n"
+
 // buildIssueDraft renders the pre-filled GitHub issue-draft title and body from
-// the already-redacted Bundle. It is deliberately short (the full 2MiB bundle
-// cannot inline in an issues/new URL — it reaches the issue as the attached
-// file) and carries only redacted, structural facts plus a bug-report template
-// stub. BundlePathPlaceholder marks the attach-path the command layer fills in.
-func buildIssueDraft(b Bundle) (title, body string) {
+// the already-redacted Bundle.
+//
+// The full bundle (a megabyte of log + session state) cannot inline in an
+// issues/new URL, and before #1914 that meant the draft carried NO diagnostics
+// at all — only counts plus a path to a file on the reporter's own machine,
+// which is useless to a triager unless the user hand-attaches it. So the body
+// now embeds a BOUNDED excerpt of the highest-signal sections (daemon status,
+// collection errors, the newest log lines) in a <details> block, and still
+// points at the complete bundle on disk.
+//
+// Everything inlined is scrubbed HERE, at the point of inlining: the Bundle's
+// own log/config/instances arrive pre-redacted from their collectors, but
+// daemonHuman and Errors come straight from the caller/collection and are only
+// scrubbed by the text renderer's final pass — which this body never goes
+// through. Scrubbing each component also keeps the byte budget exact, since
+// nothing downstream can grow the assembled body (a whole-body re-scrub could:
+// "[user]" is longer than the username it replaced).
+//
+// BundlePathPlaceholder marks the attach-path the command layer fills in.
+func buildIssueDraft(r *redactor, b Bundle) (title, body string) {
 	title = fmt.Sprintf("af bug-report: %s on %s/%s", b.Versions.AF, b.Versions.OS, b.Versions.Arch)
 
-	daemon := "running"
-	if strings.Contains(strings.ToLower(b.daemonHuman), "not running") {
-		daemon = "not running"
+	// The daemon state is read off the human status text the command layer
+	// pre-renders. With no status text there is nothing to read, so say so
+	// rather than defaulting to "running" and asserting a health the bundle
+	// never established.
+	daemonHuman := strings.TrimSpace(r.scrub(b.daemonHuman))
+	daemonState := "running"
+	switch {
+	case daemonHuman == "":
+		daemonState = "unknown"
+		daemonHuman = "(status unavailable)"
+	case strings.Contains(strings.ToLower(daemonHuman), "not running"):
+		daemonState = "not running"
 	}
 
-	var sb strings.Builder
-	fmt.Fprintf(&sb, "<!-- Opened by `af bug-report`. This is a DRAFT — review it, attach the bundle below, then submit. -->\n\n")
-	fmt.Fprintf(&sb, "## Environment\n")
-	fmt.Fprintf(&sb, "- af: %s\n", b.Versions.AF)
-	fmt.Fprintf(&sb, "- go: %s\n", b.Versions.Go)
-	fmt.Fprintf(&sb, "- os/arch: %s/%s\n", b.Versions.OS, b.Versions.Arch)
-	fmt.Fprintf(&sb, "- daemon: %s\n", daemon)
-	fmt.Fprintf(&sb, "- sessions: %d across %d repo(s)\n", countInstances(b.Instances), len(b.Instances))
-	fmt.Fprintf(&sb, "- tasks: %d\n\n", len(b.Tasks))
-	fmt.Fprintf(&sb, "## What happened\n<!-- Describe the bug. -->\n\n")
-	fmt.Fprintf(&sb, "## What you expected\n\n")
-	fmt.Fprintf(&sb, "## Steps to reproduce\n\n")
-	fmt.Fprintf(&sb, "---\n")
-	fmt.Fprintf(&sb, "A best-effort **redacted** diagnostics bundle was written to:\n\n")
-	fmt.Fprintf(&sb, "    %s\n\n", BundlePathPlaceholder)
-	fmt.Fprintf(&sb, "**Attach that file to this issue** (drag-and-drop) before submitting. "+
+	var head strings.Builder
+	fmt.Fprintf(&head, "<!-- Opened by `af bug-report`. This is a DRAFT — review it, attach the bundle below, then submit. -->\n\n")
+	fmt.Fprintf(&head, "## Environment\n")
+	fmt.Fprintf(&head, "- af: %s\n", b.Versions.AF)
+	fmt.Fprintf(&head, "- go: %s\n", b.Versions.Go)
+	fmt.Fprintf(&head, "- os/arch: %s/%s\n", b.Versions.OS, b.Versions.Arch)
+	fmt.Fprintf(&head, "- daemon: %s\n", daemonState)
+	fmt.Fprintf(&head, "- sessions: %d across %d repo(s)\n", countInstances(b.Instances), len(b.Instances))
+	fmt.Fprintf(&head, "- tasks: %d\n\n", len(b.Tasks))
+	fmt.Fprintf(&head, "## What happened\n<!-- Describe the bug. -->\n\n")
+	fmt.Fprintf(&head, "## What you expected\n\n")
+	fmt.Fprintf(&head, "## Steps to reproduce\n\n")
+	fmt.Fprintf(&head, "---\n\n")
+	fmt.Fprintf(&head, "<details>\n<summary>%s</summary>\n\n", issueSummaryLabel)
+	fmt.Fprintf(&head, "### Daemon status\n\n```\n%s\n```\n\n", truncateBytes(daemonHuman, issueDaemonMaxBytes))
+	if len(b.Errors) > 0 {
+		fmt.Fprintf(&head, "### Collection errors\n\n")
+		for i, e := range b.Errors {
+			if i == issueErrorsMax {
+				fmt.Fprintf(&head, "- …and %d more (see the attached bundle)\n", len(b.Errors)-issueErrorsMax)
+				break
+			}
+			fmt.Fprintf(&head, "- %s\n", r.scrub(e))
+		}
+		head.WriteByte('\n')
+	}
+
+	var foot strings.Builder
+	fmt.Fprintf(&foot, "</details>\n\n---\n\n")
+	fmt.Fprintf(&foot, "The summary above is a bounded excerpt. The COMPLETE best-effort **redacted** "+
+		"bundle (full log tail, sessions, tasks, config) was written to:\n\n")
+	fmt.Fprintf(&foot, "    %s\n\n", BundlePathPlaceholder)
+	fmt.Fprintf(&foot, "**Attach that file to this issue** (drag-and-drop) before submitting. "+
 		"Open and review it first — redaction is best-effort and cannot catch everything.\n")
+
+	// Hand the log tail whatever encoded budget the rest of the body leaves,
+	// always reserving the elision note so appending it can't bust the cap.
+	logHeader := "### Daemon log tail (newest lines, redacted)\n\n```\n"
+	logFooter := "\n```\n\n"
+	budget := maxIssueBodyEncodedBytes -
+		encodedLen(head.String()) - encodedLen(foot.String()) -
+		encodedLen(logHeader) - encodedLen(logFooter) - encodedLen(logElidedNote)
+
+	var sb strings.Builder
+	sb.WriteString(head.String())
+	logText, elided := fitLogTail(b.Log.Contents, issueLogMaxLines, budget)
+	if logText != "" {
+		sb.WriteString(logHeader)
+		sb.WriteString(logText)
+		sb.WriteString(logFooter)
+	}
+	if elided {
+		sb.WriteString(logElidedNote)
+	}
+	sb.WriteString(foot.String())
 	return title, sb.String()
+}
+
+// issueSummaryLabel names the collapsible diagnostics block. Tests key on it to
+// assert the summary actually reached the draft.
+const issueSummaryLabel = "Diagnostics summary (auto-generated, redacted, bounded excerpt)"
+
+// fitLogTail returns the newest lines of the (already redacted) log tail that
+// fit within both maxLines and budget encoded bytes, reporting whether any
+// earlier line was dropped. It walks from the END because the lines nearest the
+// failure are the ones that explain a bug, and stops at the first line that
+// would overflow — a hard cap, never a best-effort overshoot. A budget too small
+// for even one line yields no tail at all (elided=true) rather than a truncated,
+// misleading fragment.
+func fitLogTail(contents string, maxLines, budget int) (text string, elided bool) {
+	contents = strings.TrimRight(contents, "\n")
+	if strings.TrimSpace(contents) == "" {
+		return "", false
+	}
+	lines := strings.Split(contents, "\n")
+	if len(lines) > maxLines {
+		lines = lines[len(lines)-maxLines:]
+		elided = true
+	}
+	used, kept := 0, 0
+	for i := len(lines) - 1; i >= 0; i-- {
+		cost := encodedLen(lines[i]) + encodedLen("\n")
+		if used+cost > budget {
+			elided = true
+			break
+		}
+		used += cost
+		kept++
+	}
+	if kept == 0 {
+		return "", true
+	}
+	return strings.Join(lines[len(lines)-kept:], "\n"), elided
+}
+
+// encodedLen reports how many bytes s costs once percent-encoded into the
+// issues/new query string — the only length that matters for the URL cap.
+func encodedLen(s string) int { return len(url.QueryEscape(s)) }
+
+// truncateBytes caps s at max bytes on a rune boundary, marking the cut so a
+// trimmed block never reads as complete.
+func truncateBytes(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	cut := s[:max]
+	for len(cut) > 0 && !utf8.ValidString(cut) {
+		cut = cut[:len(cut)-1]
+	}
+	return cut + "\n…(truncated; see the attached bundle)"
 }
 
 // countInstances totals the session records across every repo's redacted

--- a/bugreport/bugreport_test.go
+++ b/bugreport/bugreport_test.go
@@ -628,6 +628,66 @@ func TestScrubDoesNotSkipSecretsThatResembleMarkers(t *testing.T) {
 	}
 }
 
+// TestScrubMarkerFastPathCoversEveryValueForm is the case-by-case proof that a
+// value which merely BEGINS with a marker cannot reach the already-redacted
+// fast-path — for every one of the six value forms the fast-path recognizes.
+//
+// This is the shape that got through three times: the bare-value regex used to
+// stop before `]`, so `api_key=[redacted-secret]actualcredential` was captured as
+// just `[redacted-secret` — indistinguishable from a marker this redactor wrote —
+// and the credential rode out behind it. The comparison was never the problem;
+// the capture boundary was. Each form below is asserted twice: the genuine marker
+// (with a real terminator) survives untouched, and the same marker followed by a
+// credential is redacted with nothing of the tail surviving.
+func TestScrubMarkerFastPathCoversEveryValueForm(t *testing.T) {
+	const tail = "actualcredential"
+	forms := []struct {
+		name string
+		// redacted is a value this redactor genuinely emitted: it must be left
+		// exactly as-is (idempotence).
+		redacted string
+		// impostor is a real credential that merely begins with that marker: it
+		// must be redacted, tail and all.
+		impostor string
+	}{
+		{"bare secret marker", "api_key=" + secretMarker, "api_key=" + secretMarker + tail},
+		{"bare redacted marker", "api_key=" + redactedMarker, "api_key=" + redactedMarker + tail},
+		{"double-quoted secret marker", `api_key="` + secretMarker + `"`, `api_key="` + secretMarker + tail + `"`},
+		{"single-quoted secret marker", `api_key='` + secretMarker + `'`, `api_key='` + secretMarker + tail + `'`},
+		{"double-quoted redacted marker", `api_key="` + redactedMarker + `"`, `api_key="` + redactedMarker + tail + `"`},
+		{"single-quoted redacted marker", `api_key='` + redactedMarker + `'`, `api_key='` + redactedMarker + tail + `'`},
+	}
+	r := &redactor{home: "/home/tester", users: []string{"tester"}}
+
+	for _, tc := range forms {
+		t.Run(tc.name+"/genuine marker survives", func(t *testing.T) {
+			if got := r.scrub(tc.redacted); got != tc.redacted {
+				t.Errorf("already-redacted value was re-wrapped:\n  in:  %q\n  out: %q", tc.redacted, got)
+			}
+		})
+		t.Run(tc.name+"/impostor is redacted", func(t *testing.T) {
+			got := r.scrub(tc.impostor)
+			if strings.Contains(got, tail) {
+				t.Errorf("CREDENTIAL LEAKED past the fast-path:\n  in:  %q\n  out: %q", tc.impostor, got)
+			}
+			if !strings.Contains(got, secretMarker) {
+				t.Errorf("value not redacted:\n  in:  %q\n  out: %q", tc.impostor, got)
+			}
+		})
+	}
+
+	// A marker sitting mid-value is not a marker this redactor wrote either.
+	for _, in := range []string{
+		"password = hunter2" + secretMarker,
+		"password = hunter2" + redactedMarker + "more",
+		`password = "hunter2` + secretMarker + `"`,
+	} {
+		if got := r.scrub(in); strings.Contains(got, "hunter2") {
+			t.Errorf("mid-value marker let a credential through:\n  in:  %q\n  out: %q", in, got)
+		}
+	}
+}
+
 // TestScrubIsIdempotent pins the property the fast-path exists for: scrub runs
 // over the same text more than once by design (per section, again over the
 // assembled text/JSON, and again on each component the issue draft inlines), so

--- a/bugreport/bugreport_test.go
+++ b/bugreport/bugreport_test.go
@@ -970,6 +970,82 @@ func TestBuildIssueDraftAccountsForBundlePathInBudget(t *testing.T) {
 	mustNotContain(t, "body", body, "{{", "/home/tester")
 }
 
+// TestBuildIssueDraftBodyIsFinalAfterBudgeting pins THE invariant: nothing may
+// change the body's encoded length after the budget is computed.
+//
+// The failure it locks: the final scrub used to run over the FINISHED body, so a
+// username that collides with a word in the static template — a home basename of
+// "the" expands every "the" in the prose to "[user]" — grew the body after the
+// log tail had already spent the budget. With a near-cap elided tail the emitted
+// draft then blew the cap, GitHub rejected the URL, and the user got an error
+// instead of a bug report.
+//
+// This is the third "measure, then mutate" bug in this change, so the assertion
+// is the general property rather than the instance: the returned body is a fixed
+// point of the redactor, meaning no later pass exists that could grow it.
+func TestBuildIssueDraftBodyIsFinalAfterBudgeting(t *testing.T) {
+	// Every one of these usernames collides with a word in the static template
+	// prose ("…attach the bundle below…", "…the attached bundle has the full
+	// tail…"), so a scrub that runs after budgeting expands prose the budget has
+	// already been spent against.
+	for _, user := range []string{"the", "bundle", "and", "issue"} {
+		t.Run("username="+user, func(t *testing.T) {
+			r := &redactor{home: "/tmp/" + user, users: []string{user}}
+
+			// Sweep the log line length. Each collision only grows the body by a
+			// few bytes, while the fitted tail leaves 0..one-line of slack under
+			// the cap — so ANY single log shape overflows only by luck, and a test
+			// pinned to one shape would pass against the broken ordering and prove
+			// nothing. Sweeping makes the near-cap case deterministic: some shape
+			// lands flush against the cap, where the growth has nowhere to go.
+			// Lines are realistically long so the BYTE budget binds rather than
+			// issueLogMaxLines, which would cap the body at ~4.3KB and make every
+			// assertion vacuous.
+			nearCap := 0
+			for lineLen := 60; lineLen <= 260; lineLen += 2 {
+				var log strings.Builder
+				for i := 0; i < 120; i++ {
+					line := fmt.Sprintf("[DAEMON] INFO:2026/07/16 05:03:33 taskrun.go:100: task %06d reconciled session ", i)
+					for len(line) < lineLen {
+						line += "x"
+					}
+					log.WriteString(line[:lineLen] + "\n")
+				}
+				b := Bundle{
+					Versions:   Versions{AF: "9.9.9", Go: "go1.25.0", OS: "linux", Arch: "amd64"},
+					Log:        logSection{Contents: log.String()},
+					bundlePath: "/tmp/" + user + "/af-bug-report-20260716-080519.txt",
+				}
+
+				_, body := buildIssueDraft(r, b)
+
+				if n := encodedLen(body); n > maxIssueBodyEncodedBytes {
+					t.Errorf("lineLen=%d: encoded body is %d bytes, past the %d cap — "+
+						"something changed the body after the budget was computed",
+						lineLen, n, maxIssueBodyEncodedBytes)
+				}
+				// The general invariant, asserted per shape: the returned body is a
+				// fixed point of the redactor, so no later pass — the one that used
+				// to run here, or any a future change adds — can grow it.
+				if again := r.scrub(body); again != body {
+					t.Errorf("lineLen=%d: body is not a redactor fixed point: a further scrub "+
+						"would change it (%d -> %d encoded bytes), so its measured size is not final",
+						lineLen, encodedLen(body), encodedLen(again))
+				}
+				if encodedLen(body) > maxIssueBodyEncodedBytes-40 {
+					nearCap++
+				}
+			}
+			// Proof the sweep actually reached the boundary, so the assertions above
+			// were exercised where they bite rather than passing on slack.
+			if nearCap == 0 {
+				t.Errorf("no log shape landed within 40 bytes of the %d cap — the sweep never "+
+					"reached the boundary, so it is not testing the overflow", maxIssueBodyEncodedBytes)
+			}
+		})
+	}
+}
+
 // TestBuildIssueDraftFenceSurvivesBackticksInLog is the #4 regression: a log line
 // carrying a literal ``` (a failing hook echoing its own output) closed the fixed
 // three-backtick fence early, so the rest of the draft — the closing </details>

--- a/bugreport/bugreport_test.go
+++ b/bugreport/bugreport_test.go
@@ -583,6 +583,77 @@ func TestScrubLogRedactsTitlesEndingInNonWordChars(t *testing.T) {
 	}
 }
 
+// TestScrubDoesNotSkipSecretsThatResembleMarkers is the regression for a leak the
+// idempotence fast-path introduced: it treated any value STARTING WITH the marker
+// text as already-redacted, so a real credential that merely began with those
+// characters was emitted verbatim — into the bundle and into the public issue
+// draft. The fast-path must recognize exactly what the redactor emits, never a
+// prefix or a substring.
+func TestScrubDoesNotSkipSecretsThatResembleMarkers(t *testing.T) {
+	r := &redactor{home: "/home/tester", users: []string{"tester"}}
+	cases := []struct {
+		name, in, secret string
+	}{
+		{
+			name:   "value merely starting with the marker text",
+			in:     "api_key=[redactedButActualSecret]",
+			secret: "redactedButActualSecret",
+		},
+		{
+			name:   "quoted value starting with the marker text",
+			in:     `github_token = "[redacted-secretly-this-is-real]"`,
+			secret: "redacted-secretly-this-is-real",
+		},
+		{
+			name:   "value carrying the marker text mid-string",
+			in:     "password = hunter2[redacted]",
+			secret: "hunter2",
+		},
+		{
+			name:   "value that is nearly the marker",
+			in:     "api_key=[redacted-secretz",
+			secret: "[redacted-secretz",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := r.scrub(tc.in)
+			if strings.Contains(got, tc.secret) {
+				t.Errorf("SECRET LEAKED past the already-redacted fast-path:\n  in:  %q\n  out: %q", tc.in, got)
+			}
+			if !strings.Contains(got, secretMarker) {
+				t.Errorf("value was not redacted at all:\n  in:  %q\n  out: %q", tc.in, got)
+			}
+		})
+	}
+}
+
+// TestScrubIsIdempotent pins the property the fast-path exists for: scrub runs
+// over the same text more than once by design (per section, again over the
+// assembled text/JSON, and again on each component the issue draft inlines), so
+// a second pass must be a no-op. It was not — the bare-value alternative
+// re-matched the marker's own text and grew a bracket per pass, and a real
+// bundle shipped 28 `[redacted-secret]]`.
+func TestScrubIsIdempotent(t *testing.T) {
+	r := &redactor{home: "/home/tester", users: []string{"tester"}}
+	for _, in := range []string{
+		"bearer token: sk-ABCDEFGHIJKLMNOP0123",       // bare marker after one pass
+		`github_token = "ghp_AAAAAAAAAAAAAAAAAAAA"`,   // double-quoted marker
+		"internal_api_key = 'company-internal-value'", // single-quoted marker
+		"path /home/tester/x by tester",               // home + username
+		"nothing sensitive here",
+	} {
+		once := r.scrub(in)
+		twice := r.scrub(once)
+		if once != twice {
+			t.Errorf("scrub is not idempotent:\n  in:    %q\n  once:  %q\n  twice: %q", in, once, twice)
+		}
+		if strings.Contains(twice, secretMarker+"]") {
+			t.Errorf("marker grew a bracket on re-scrub: %q", twice)
+		}
+	}
+}
+
 // TestIssueDraftCollapsesBundlePath guards the fix for the raw-home-path leak:
 // the bundle path inlined into the (public) GitHub issue-draft body must have
 // $HOME collapsed to ~ so it never leaks the user's home/username. The draft

--- a/bugreport/bugreport_test.go
+++ b/bugreport/bugreport_test.go
@@ -583,20 +583,19 @@ func TestScrubLogRedactsTitlesEndingInNonWordChars(t *testing.T) {
 	}
 }
 
-// TestRedactPathCollapsesHome guards the fix for the raw-home-path leak: the
-// bundle path inlined into the (public) GitHub issue-draft body must have $HOME
-// collapsed to ~ so it never leaks the user's home/username.
-func TestRedactPathCollapsesHome(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	p := filepath.Join(home, "af-bug-report-20260710-120000.txt")
-	out := RedactPath(p)
-	if strings.Contains(out, home) {
-		t.Errorf("home path not collapsed in draft-body path: %q -> %q", p, out)
-	}
-	if !strings.HasPrefix(out, "~/") {
-		t.Errorf("expected the redacted path to start with ~/: %q", out)
-	}
+// TestIssueDraftCollapsesBundlePath guards the fix for the raw-home-path leak:
+// the bundle path inlined into the (public) GitHub issue-draft body must have
+// $HOME collapsed to ~ so it never leaks the user's home/username. The draft
+// redacts the path itself — it is measured into the size-checked body rather
+// than substituted in afterwards, so the caller has no chance to inline it raw.
+func TestIssueDraftCollapsesBundlePath(t *testing.T) {
+	r := &redactor{home: "/home/tester", users: []string{"tester"}}
+	b := Bundle{bundlePath: "/home/tester/af-bug-report-20260710-120000.txt"}
+
+	_, body := buildIssueDraft(r, b)
+
+	mustNotContain(t, "draft body", body, "/home/tester", "tester")
+	mustContain(t, "draft body", body, "~/af-bug-report-20260710-120000.txt")
 }
 
 // TestBuildEndToEnd plants a full temp home with a secret and a home path in
@@ -667,6 +666,7 @@ func TestBuildEndToEnd(t *testing.T) {
 		GeneratedAt:  "2026-07-05 00:00:00 +0000",
 		DaemonStatus: map[string]any{"running": false, "control_socket": home + "/.agent-factory/daemon.sock"},
 		DaemonHuman:  "daemon: not running\n  control socket: " + home + "/.agent-factory/daemon.sock (absent)\n",
+		BundlePath:   filepath.Join(home, "af-bug-report-test.txt"),
 	})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
@@ -704,11 +704,11 @@ func TestBuildEndToEnd(t *testing.T) {
 	// --- GitHub issue-draft assertions ---
 	// The title is a short, templated, redacted summary line.
 	mustContain(t, "draft title", res.Title, "af bug-report:", "9.9.9", "/")
-	// The body carries the environment summary + the attach-path placeholder the
-	// command layer fills in, and never inlines a secret or a session title.
+	// The body carries the environment summary + the redacted path of the bundle
+	// to attach, and never inlines a secret or a session title.
 	mustContain(t, "draft body", res.Body,
-		"## Environment", "af: 9.9.9", "sessions:", "tasks:", BundlePathPlaceholder,
-		"Attach that file")
+		"## Environment", "af: 9.9.9", "sessions:", "tasks:",
+		"~/af-bug-report-test.txt", "Attach that file")
 	// #1914: the body must carry the bounded diagnostics excerpt ITSELF — before
 	// the fix it only named a file on the reporter's own machine, so a filed
 	// issue arrived with no diagnostics unless the user hand-attached ~1MB.
@@ -738,6 +738,154 @@ func TestBuildEndToEnd(t *testing.T) {
 	mustContain(t, "json", string(res.JSON), "abc123", "9.9.9", testSHA)
 }
 
+// TestMissingLogMessageIsRedactedBeforeInlining is the leak regression: when the
+// log file does not exist (logging fell back to stderr because the config dir
+// could not be created — exactly the broken install that files a bug report),
+// collectLog stored "(no log file at <path>)" raw. That message interpolates a
+// real $HOME/config path, and the issue draft inlines log contents directly
+// WITHOUT the final scrub the text/JSON renderers apply, so the path reached a
+// prefilled PUBLIC GitHub draft.
+//
+// Driven through Build (not collectLog) because the leak is a property of the
+// draft body, which is where the scrub was missing.
+func TestMissingLogMessageIsRedactedBeforeInlining(t *testing.T) {
+	home := t.TempDir()
+	afHome := filepath.Join(home, ".agent-factory")
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_FACTORY_HOME", afHome)
+	if err := os.MkdirAll(afHome, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Deliberately write no log file: collectLog takes the IsNotExist exit.
+
+	res, err := Build(Inputs{
+		AFVersion:   "9.9.9",
+		GeneratedAt: "2026-07-05 00:00:00 +0000",
+		BundlePath:  filepath.Join(home, "af-bug-report-test.txt"),
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	// The message must still be there — this asserts redaction, not omission.
+	mustContain(t, "draft body", res.Body, "no log file at")
+	// …and it must not carry the raw home path or username into a public draft.
+	mustNotContain(t, "draft body", res.Body, home, filepath.Base(home))
+	// Same for the file bundle and the JSON manifest.
+	mustNotContain(t, "text", res.Text, home)
+	mustNotContain(t, "json", string(res.JSON), home)
+}
+
+// TestBuildIssueDraftBoundsBodyToURLCapWithBrokenInstall is the #2 regression: a
+// broken install's collection errors are long (unreadable config/log paths,
+// parser messages), and they were written into the body in full BEFORE the
+// budget was computed — only the log tail was trimmed afterwards, so the errors
+// alone could push the URL past the cap. Everything variable-length must be
+// fitted by encoded length before it is written.
+func TestBuildIssueDraftBoundsBodyToURLCapWithBrokenInstall(t *testing.T) {
+	r := &redactor{home: "/home/tester", users: []string{"tester"}}
+	longPath := "/var/lib/really/deeply/nested/config/location/" + strings.Repeat("segment/", 20)
+	b := Bundle{
+		Versions:   Versions{AF: "9.9.9", Go: "go1.25.0", OS: "linux", Arch: "amd64"},
+		bundlePath: "/home/tester/af-bug-report-20260716-080519.txt",
+		// No log at all: the errors alone must not bust the cap.
+	}
+	for i := 0; i < 40; i++ {
+		b.Errors = append(b.Errors, fmt.Sprintf(
+			"config %s%d/config.toml: could not be parsed: unexpected token at line %d: %s",
+			longPath, i, i, strings.Repeat("detail ", 30)))
+	}
+
+	_, body := buildIssueDraft(r, b)
+
+	if n := encodedLen(body); n > maxIssueBodyEncodedBytes {
+		t.Errorf("encoded body is %d bytes, past the %d cap (errors were not fitted)", n, maxIssueBodyEncodedBytes)
+	}
+	// Bounded, but the reader is told what was dropped.
+	mustContain(t, "body", body, "### Collection errors", "more (see the attached bundle)")
+}
+
+// TestBuildIssueDraftAccountsForBundlePathInBudget is the #3 regression: the body
+// used to carry a short placeholder that the CALLER swapped for the real path
+// after the size check, so what reached GitHub was longer than what was measured.
+// The path is now measured into the body, leaving nothing to substitute.
+//
+// The path here is long enough to make the overflow deterministic. In the default
+// flow the path is always ~/af-bug-report-<ts>.txt, where substitution grew the
+// body by only ~14 encoded bytes — which still broke the cap whenever the fitted
+// tail landed within 14 bytes of it, as a real run did at 5989/6000.
+func TestBuildIssueDraftAccountsForBundlePathInBudget(t *testing.T) {
+	r := &redactor{home: "/home/tester", users: []string{"tester"}}
+	var hugeLog strings.Builder
+	for i := 0; i < 5000; i++ {
+		fmt.Fprintf(&hugeLog, "2026-01-01 12:00:00 daemon: reconciled session %d, state=Ready\n", i)
+	}
+	nested := strings.Repeat("nested/", 30)
+	b := Bundle{
+		Versions:   Versions{AF: "9.9.9", Go: "go1.25.0", OS: "linux", Arch: "amd64"},
+		Log:        logSection{Contents: hugeLog.String()},
+		bundlePath: "/home/tester/" + nested + "af-bug-report-20260716-080519.txt",
+	}
+
+	_, body := buildIssueDraft(r, b)
+
+	if n := encodedLen(body); n > maxIssueBodyEncodedBytes {
+		t.Errorf("encoded body is %d bytes, past the %d cap (the bundle path was not budgeted for)",
+			n, maxIssueBodyEncodedBytes)
+	}
+	// The real, redacted path is IN the measured body — no placeholder is left
+	// for a caller to swap in afterwards.
+	mustContain(t, "body", body, "~/"+nested+"af-bug-report-20260716-080519.txt")
+	mustNotContain(t, "body", body, "{{", "/home/tester")
+}
+
+// TestBuildIssueDraftFenceSurvivesBackticksInLog is the #4 regression: a log line
+// carrying a literal ``` (a failing hook echoing its own output) closed the fixed
+// three-backtick fence early, so the rest of the draft — the closing </details>
+// and the attach instructions — rendered as code.
+func TestBuildIssueDraftFenceSurvivesBackticksInLog(t *testing.T) {
+	r := &redactor{home: "/home/tester", users: []string{"tester"}}
+	b := Bundle{
+		Versions:   Versions{AF: "9.9.9", Go: "go1.25.0", OS: "linux", Arch: "amd64"},
+		bundlePath: "/home/tester/af-bug-report-test.txt",
+		Log: logSection{Contents: "hook failed, output follows:\n" +
+			"```\nsome fenced output the hook printed\n```\nrun complete\n"},
+	}
+
+	_, body := buildIssueDraft(r, b)
+
+	// The log content rode in verbatim…
+	mustContain(t, "body", body, "some fenced output the hook printed")
+	// …inside a fence that outruns it, so the block cannot close early.
+	if !strings.Contains(body, "````") {
+		t.Errorf("log fence did not outrun the ``` run in the tail:\n%s", body)
+	}
+	// Everything after the log block must still be prose, not code: an unbalanced
+	// fence shows up as an odd number of fence delimiters.
+	if n := strings.Count(body, "\n````"); n%2 != 0 {
+		t.Errorf("unbalanced log fence (%d delimiters):\n%s", n, body)
+	}
+	mustContain(t, "body", body, "</details>", "Attach that file")
+}
+
+// TestFenceForOutrunsLongestRun pins the fence sizing rule directly: a fence is
+// closed by any run of at least its own length, so it must be longer than the
+// longest run in the content it wraps.
+func TestFenceForOutrunsLongestRun(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"plain text", "```"},
+		{"a `code` span", "```"},
+		{"a ``double`` span", "```"},
+		{"fenced ``` block", "````"},
+		{"longer ````` run", "``````"},
+	}
+	for _, tc := range cases {
+		if got := fenceFor(tc.in); got != tc.want {
+			t.Errorf("fenceFor(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
 // TestBuildIssueDraftBoundsBodyToURLCap is the guard on the inline summary's
 // core risk: the draft reaches GitHub as an issues/new URL, and a body past the
 // cap yields a dead link (or a 414) instead of a draft. A pathological bundle —
@@ -756,6 +904,7 @@ func TestBuildIssueDraftBoundsBodyToURLCap(t *testing.T) {
 		Versions:    Versions{AF: "9.9.9", Go: "go1.25.0", OS: "linux", Arch: "amd64"},
 		daemonHuman: strings.Repeat("daemon: running with a very verbose status line\n", 200),
 		Log:         logSection{Contents: hugeLog.String()},
+		bundlePath:  "/home/tester/af-bug-report-20260716-080519.txt",
 	}
 	for i := 0; i < 50; i++ {
 		b.Errors = append(b.Errors, fmt.Sprintf("section %d: could not be collected", i))
@@ -766,11 +915,11 @@ func TestBuildIssueDraftBoundsBodyToURLCap(t *testing.T) {
 	if n := encodedLen(body); n > maxIssueBodyEncodedBytes {
 		t.Errorf("encoded body is %d bytes, past the %d cap", n, maxIssueBodyEncodedBytes)
 	}
-	// Capped hard — but never silently: the elision is stated, and the reader is
-	// pointed at the complete bundle.
+	// Capped hard — but never silently: every elision is stated, and the reader
+	// is pointed at the complete bundle.
 	mustContain(t, "capped body", body,
-		"Earlier lines elided", "…(truncated; see the attached bundle)",
-		"and 40 more (see the attached bundle)", BundlePathPlaceholder)
+		"Earlier lines elided", truncatedNote,
+		"more (see the attached bundle)", "~/af-bug-report-20260716-080519.txt")
 	// The newest lines are what explain a bug, so those are the ones kept.
 	mustContain(t, "capped body", body, "session 19999 of many")
 	mustNotContain(t, "capped body", body, "session 0 of many")

--- a/bugreport/bugreport_test.go
+++ b/bugreport/bugreport_test.go
@@ -2,6 +2,7 @@ package bugreport
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -708,6 +709,20 @@ func TestBuildEndToEnd(t *testing.T) {
 	mustContain(t, "draft body", res.Body,
 		"## Environment", "af: 9.9.9", "sessions:", "tasks:", BundlePathPlaceholder,
 		"Attach that file")
+	// #1914: the body must carry the bounded diagnostics excerpt ITSELF — before
+	// the fix it only named a file on the reporter's own machine, so a filed
+	// issue arrived with no diagnostics unless the user hand-attached ~1MB.
+	mustContain(t, "draft body", res.Body,
+		"<details>", issueSummaryLabel,
+		"### Daemon status", "daemon: not running",
+		"### Daemon log tail",
+		"~/.agent-factory/daemon.sock", // daemon status inlined, home collapsed
+		testSHA,                        // the real log tail rode in (and stayed structural)
+	)
+	// The redaction assertion below is only meaningful because the planted log
+	// line and daemon status actually reached the body — assert the scrubbed
+	// forms of both, so this can't pass by inlining nothing.
+	mustContain(t, "draft body", res.Body, "boot at ~/Desktop", "[redacted-secret]")
 	mustNotContain(t, "draft body", res.Body, planted...)
 
 	// --- json manifest assertions ---
@@ -721,6 +736,78 @@ func TestBuildEndToEnd(t *testing.T) {
 	mustNotContain(t, "json", string(res.JSON), planted...)
 	// Structural fields survive into the manifest too.
 	mustContain(t, "json", string(res.JSON), "abc123", "9.9.9", testSHA)
+}
+
+// TestBuildIssueDraftBoundsBodyToURLCap is the guard on the inline summary's
+// core risk: the draft reaches GitHub as an issues/new URL, and a body past the
+// cap yields a dead link (or a 414) instead of a draft. A pathological bundle —
+// a megabyte of log, a verbose daemon status, a pile of collection errors — must
+// still produce a body that fits ONCE PERCENT-ENCODED, which is the length that
+// actually matters: these log lines are newline- and space-dense, so the encoded
+// form is far larger than the raw one.
+func TestBuildIssueDraftBoundsBodyToURLCap(t *testing.T) {
+	r := &redactor{home: "/home/tester", users: []string{"tester"}}
+
+	var hugeLog strings.Builder
+	for i := 0; i < 20000; i++ {
+		fmt.Fprintf(&hugeLog, "2026-01-01 12:00:00 daemon: reconciled session %d of many, state=Ready\n", i)
+	}
+	b := Bundle{
+		Versions:    Versions{AF: "9.9.9", Go: "go1.25.0", OS: "linux", Arch: "amd64"},
+		daemonHuman: strings.Repeat("daemon: running with a very verbose status line\n", 200),
+		Log:         logSection{Contents: hugeLog.String()},
+	}
+	for i := 0; i < 50; i++ {
+		b.Errors = append(b.Errors, fmt.Sprintf("section %d: could not be collected", i))
+	}
+
+	_, body := buildIssueDraft(r, b)
+
+	if n := encodedLen(body); n > maxIssueBodyEncodedBytes {
+		t.Errorf("encoded body is %d bytes, past the %d cap", n, maxIssueBodyEncodedBytes)
+	}
+	// Capped hard — but never silently: the elision is stated, and the reader is
+	// pointed at the complete bundle.
+	mustContain(t, "capped body", body,
+		"Earlier lines elided", "…(truncated; see the attached bundle)",
+		"and 40 more (see the attached bundle)", BundlePathPlaceholder)
+	// The newest lines are what explain a bug, so those are the ones kept.
+	mustContain(t, "capped body", body, "session 19999 of many")
+	mustNotContain(t, "capped body", body, "session 0 of many")
+}
+
+// TestFitLogTailKeepsNewestWithinBudget pins the tail-fitting rules: newest
+// lines win, both caps bind, and a budget too small for even one line yields
+// nothing rather than a misleading fragment.
+func TestFitLogTailKeepsNewestWithinBudget(t *testing.T) {
+	contents := "alpha\nbravo\ncharlie\ndelta\n"
+
+	// Roomy budget, line cap binds: keep the newest 2.
+	text, elided := fitLogTail(contents, 2, 10000)
+	if text != "charlie\ndelta" || !elided {
+		t.Errorf("line cap: got %q elided=%v, want newest 2 + elided", text, elided)
+	}
+
+	// Roomy caps: everything fits, nothing elided.
+	if text, elided := fitLogTail(contents, 100, 10000); text != "alpha\nbravo\ncharlie\ndelta" || elided {
+		t.Errorf("roomy: got %q elided=%v, want all + not elided", text, elided)
+	}
+
+	// Byte budget binds before the line cap.
+	text, elided = fitLogTail(contents, 100, encodedLen("delta\n"))
+	if text != "delta" || !elided {
+		t.Errorf("byte budget: got %q elided=%v, want newest line only + elided", text, elided)
+	}
+
+	// Not even one line fits: no fragment.
+	if text, elided := fitLogTail(contents, 100, 1); text != "" || !elided {
+		t.Errorf("tiny budget: got %q elided=%v, want empty + elided", text, elided)
+	}
+
+	// An empty log is not an elision.
+	if text, elided := fitLogTail("   \n", 10, 100); text != "" || elided {
+		t.Errorf("empty log: got %q elided=%v, want empty + not elided", text, elided)
+	}
 }
 
 func writeFile(t *testing.T, path, content string) {

--- a/bugreport/redact.go
+++ b/bugreport/redact.go
@@ -313,13 +313,34 @@ func redactKeyValueSecret(match string) string {
 	return prefix + secretMarker
 }
 
-// isRedactionMarker reports whether a matched value is (the start of) a marker a
-// previous scrub pass wrote — `[redacted]`, `[redacted-secret]`, or either still
-// wrapped in the quotes the value carried. The prefix test is deliberate: the
-// bare-value alternative stops at the marker's closing `]`, so the value seen
-// here is the marker minus its final bracket.
+// redactionMarkerValues are the EXACT value forms this redactor emits, and
+// nothing else. isRedactionMarker is a fast-path AROUND the scrub, and a
+// fast-path around a redactor is sound only if it recognizes precisely what that
+// redactor produces — anything looser is a way for a real credential to reach a
+// public bundle unscrubbed. A prefix test was exactly that mistake:
+// `api_key=[redactedButActualSecret]` merely started with the marker text, so it
+// was waved through verbatim.
+//
+// The bare entries carry no closing bracket on purpose: the bare-value
+// alternative excludes `]`, so what the regex hands back for `key =
+// [redacted-secret]` is `[redacted-secret`. The quoted alternatives capture the
+// whole literal, quotes included. Both are derived from the markers themselves so
+// they cannot drift if a marker is ever reworded.
+var redactionMarkerValues = map[string]bool{
+	strings.TrimSuffix(secretMarker, "]"):   true, // bare `[redacted-secret`
+	strings.TrimSuffix(redactedMarker, "]"): true, // bare `[redacted`
+	`"` + secretMarker + `"`:                true,
+	`'` + secretMarker + `'`:                true,
+	`"` + redactedMarker + `"`:              true,
+	`'` + redactedMarker + `'`:              true,
+}
+
+// isRedactionMarker reports whether value is EXACTLY a marker an earlier scrub
+// pass wrote, so re-scrubbing it would only re-wrap it. Exact match, never a
+// prefix or substring: a value that merely starts with or contains the marker
+// text is a value this redactor did not write, and must take the normal path.
 func isRedactionMarker(value string) bool {
-	return strings.HasPrefix(strings.Trim(value, `"'`), "[redacted")
+	return redactionMarkerValues[value]
 }
 
 // unparsedInstancesNote is emitted (as a JSON string) when instances.json is

--- a/bugreport/redact.go
+++ b/bugreport/redact.go
@@ -95,15 +95,6 @@ func newRedactor() *redactor {
 	return &redactor{home: home, users: users}
 }
 
-// RedactPath collapses $HOME to ~ and the username to [user] in a single path,
-// using the same rules as the bundle redactor. The command layer runs the
-// written bundle's path through it before inlining the path into the GitHub
-// issue-draft body, so the (public) draft can't leak $HOME/username even though
-// the bundle itself is redacted.
-func RedactPath(p string) string {
-	return newRedactor().scrub(p)
-}
-
 // appendUserToken adds a username token to the scrub list, skipping empties,
 // path-ish junk, and tokens under 3 chars (too short to replace safely without
 // mangling unrelated substrings).
@@ -301,6 +292,18 @@ func redactKeyValueSecret(match string) string {
 	}
 	prefix := match[idx[2]:idx[3]]
 	value := match[idx[3]:]
+	// A value an earlier pass already redacted must survive untouched. scrub is
+	// applied more than once to the same text by design — per section, again
+	// over the assembled text/JSON, and again on each component the issue draft
+	// inlines — so it has to be idempotent. It was not: the bare-value
+	// alternative re-matches the marker's own text (the class excludes `]`, not
+	// `[`, so `[redacted-secret]` re-matches as `[redacted-secret`), and every
+	// extra pass re-wrapped it and grew a bracket. A real bundle shipped 28
+	// `[redacted-secret]]`. Returning the match verbatim leaves the marker — and
+	// the `]` just past it — exactly as the first pass wrote them.
+	if isRedactionMarker(value) {
+		return match
+	}
 	if len(value) >= 2 && value[0] == '"' && value[len(value)-1] == '"' {
 		return prefix + `"` + secretMarker + `"`
 	}
@@ -308,6 +311,15 @@ func redactKeyValueSecret(match string) string {
 		return prefix + `'` + secretMarker + `'`
 	}
 	return prefix + secretMarker
+}
+
+// isRedactionMarker reports whether a matched value is (the start of) a marker a
+// previous scrub pass wrote — `[redacted]`, `[redacted-secret]`, or either still
+// wrapped in the quotes the value carried. The prefix test is deliberate: the
+// bare-value alternative stops at the marker's closing `]`, so the value seen
+// here is the marker minus its final bracket.
+func isRedactionMarker(value string) bool {
+	return strings.HasPrefix(strings.Trim(value, `"'`), "[redacted")
 }
 
 // unparsedInstancesNote is emitted (as a JSON string) when instances.json is

--- a/bugreport/redact.go
+++ b/bugreport/redact.go
@@ -43,8 +43,23 @@ var secretPatterns = []*regexp.Regexp{
 // a prefix (github_token, x-api-key, client_secret) and optional quotes. The
 // value half recognizes TOML/JSON-style double-quoted strings, TOML literal
 // single-quoted strings, and bare token-like values.
+//
+// THE BARE CLASS MUST NOT EXCLUDE `]`. It used to, which meant a bare value
+// stopped BEFORE a `]` instead of at a real terminator — so the captured text
+// was not the value, only a prefix of it. Everything downstream inherited that
+// lie: `api_key=[redacted-secret]actualcredential` captured just
+// `[redacted-secret`, which looks exactly like a marker this redactor wrote, and
+// the credential rode out untouched behind it. The bug was never in the
+// comparison, so no guard on top of the capture could fix it.
+//
+// The value now ends only at a genuine terminator — whitespace, a quote, `,`,
+// `}`, or end of text — so what the regex hands back IS the whole bare value,
+// and comparing it to a marker is a real comparison. Values carrying structural
+// characters are covered by the quoted alternatives, which consume their own
+// delimiters. Dropping `]` also errs toward MORE redaction (a `]` adjacent to a
+// bare value is absorbed rather than left behind), which is the safe direction.
 var keyValueSecret = regexp.MustCompile(
-	`(?i)(["']?[a-z0-9_-]*(?:api[_-]?key|secret|token|password|passwd|pwd|auth|access[_-]?token|refresh[_-]?token|client[_-]?secret|bearer|credential|private[_-]?key)s?["']?\s*[:=]\s*)(?:"(?:\\.|[^"\\\r\n])*"|'[^'\r\n]*'|[^\s"',}\]]{6,})`)
+	`(?i)(["']?[a-z0-9_-]*(?:api[_-]?key|secret|token|password|passwd|pwd|auth|access[_-]?token|refresh[_-]?token|client[_-]?secret|bearer|credential|private[_-]?key)s?["']?\s*[:=]\s*)(?:"(?:\\.|[^"\\\r\n])*"|'[^'\r\n]*'|[^\s"',}]{6,})`)
 
 // privateKeyBlock matches a PEM private-key block in its entirety.
 var privateKeyBlock = regexp.MustCompile(`(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----`)
@@ -293,14 +308,15 @@ func redactKeyValueSecret(match string) string {
 	prefix := match[idx[2]:idx[3]]
 	value := match[idx[3]:]
 	// A value an earlier pass already redacted must survive untouched. scrub is
-	// applied more than once to the same text by design — per section, again
-	// over the assembled text/JSON, and again on each component the issue draft
-	// inlines — so it has to be idempotent. It was not: the bare-value
-	// alternative re-matches the marker's own text (the class excludes `]`, not
-	// `[`, so `[redacted-secret]` re-matches as `[redacted-secret`), and every
-	// extra pass re-wrapped it and grew a bracket. A real bundle shipped 28
-	// `[redacted-secret]]`. Returning the match verbatim leaves the marker — and
-	// the `]` just past it — exactly as the first pass wrote them.
+	// applied more than once to the same text by design — per section, again over
+	// the assembled text/JSON, and again on each component the issue draft inlines
+	// — so it has to be idempotent. It was not: re-scrubbing a marker re-wrapped
+	// it and grew a bracket per pass, and a real bundle shipped 28
+	// `[redacted-secret]]`.
+	//
+	// This skip is only safe because `value` is the COMPLETE value; see
+	// redactionMarkerValues for why, and keyValueSecret for the boundary that
+	// makes it true.
 	if isRedactionMarker(value) {
 		return match
 	}
@@ -313,32 +329,42 @@ func redactKeyValueSecret(match string) string {
 	return prefix + secretMarker
 }
 
-// redactionMarkerValues are the EXACT value forms this redactor emits, and
-// nothing else. isRedactionMarker is a fast-path AROUND the scrub, and a
+// redactionMarkerValues are the EXACT, COMPLETE value forms this redactor emits,
+// and nothing else. isRedactionMarker is a fast-path AROUND the scrub, and a
 // fast-path around a redactor is sound only if it recognizes precisely what that
 // redactor produces — anything looser is a way for a real credential to reach a
-// public bundle unscrubbed. A prefix test was exactly that mistake:
-// `api_key=[redactedButActualSecret]` merely started with the marker text, so it
-// was waved through verbatim.
+// public bundle unscrubbed.
 //
-// The bare entries carry no closing bracket on purpose: the bare-value
-// alternative excludes `]`, so what the regex hands back for `key =
-// [redacted-secret]` is `[redacted-secret`. The quoted alternatives capture the
-// whole literal, quotes included. Both are derived from the markers themselves so
-// they cannot drift if a marker is ever reworded.
+// Every entry is a whole value, which is what makes the comparison sound. That
+// is a property of keyValueSecret, not of this map: each alternative in its value
+// half now ends at a genuine terminator (see the regex comment), so the captured
+// text is the entire value —
+//
+//	bare      `[redacted-secret]`   ends at whitespace/quote/`,`/`}`/EOS
+//	bare      `[redacted]`          ditto
+//	quoted    `"[redacted-secret]"` the alternative consumes both quotes
+//	quoted    `'[redacted-secret]'` ditto
+//	quoted    `"[redacted]"`        ditto
+//	quoted    `'[redacted]'`        ditto
+//
+// — so a value that merely BEGINS with a marker (`[redacted-secret]hunter2`,
+// `"[redacted-secret]hunter2"`) is captured in full, matches no entry here, and
+// takes the normal redacting path. It cannot reach the unchanged path.
+//
+// Derived from the marker constants so they cannot drift if a marker is reworded.
 var redactionMarkerValues = map[string]bool{
-	strings.TrimSuffix(secretMarker, "]"):   true, // bare `[redacted-secret`
-	strings.TrimSuffix(redactedMarker, "]"): true, // bare `[redacted`
-	`"` + secretMarker + `"`:                true,
-	`'` + secretMarker + `'`:                true,
-	`"` + redactedMarker + `"`:              true,
-	`'` + redactedMarker + `'`:              true,
+	secretMarker:               true,
+	redactedMarker:             true,
+	`"` + secretMarker + `"`:   true,
+	`'` + secretMarker + `'`:   true,
+	`"` + redactedMarker + `"`: true,
+	`'` + redactedMarker + `'`: true,
 }
 
 // isRedactionMarker reports whether value is EXACTLY a marker an earlier scrub
-// pass wrote, so re-scrubbing it would only re-wrap it. Exact match, never a
-// prefix or substring: a value that merely starts with or contains the marker
-// text is a value this redactor did not write, and must take the normal path.
+// pass wrote, so re-scrubbing it would only re-wrap it. Exact match against a
+// COMPLETE value — never a prefix, never a substring, and never a truncated
+// capture: a value this redactor did not write must take the normal path.
 func isRedactionMarker(value string) bool {
 	return redactionMarkerValues[value]
 }

--- a/commands/bugreport_github.go
+++ b/commands/bugreport_github.go
@@ -32,12 +32,25 @@ import (
 // always leaves the bundle on disk.
 
 const (
+	// afIssueRepoHost is the host the project lives on. It is part of the target,
+	// not an assumption: gh resolves a bare OWNER/REPO against GH_HOST, so on a
+	// GitHub Enterprise install a hostless slug silently retargets the draft at
+	// the employer's tracker — and this command, having no repo context, has
+	// nothing to correct it with. If that host happens to carry a matching repo
+	// or mirror, `gh --web` SUCCEEDS against the wrong issue tracker, the browser
+	// fallback never runs, and a diagnostics bundle meant for a public project
+	// lands somewhere it was never meant to go.
+	afIssueRepoHost = "github.com"
 	// afIssueRepoOwner / afIssueRepoName are the agent-factory project repo —
 	// where `af bug-report` files, always.
 	afIssueRepoOwner = "sachiniyer"
 	afIssueRepoName  = "agent-factory"
-	// afIssueRepoSlug is the owner/repo form gh's --repo flag takes.
+	// afIssueRepoSlug is the owner/repo form, for display and URL building.
 	afIssueRepoSlug = afIssueRepoOwner + "/" + afIssueRepoName
+	// afIssueRepoTarget is the FULLY-QUALIFIED [HOST/]OWNER/REPO form gh's --repo
+	// flag takes. Always pass this to gh, never afIssueRepoSlug: the host is what
+	// makes the documented target enforceable regardless of the environment.
+	afIssueRepoTarget = afIssueRepoHost + "/" + afIssueRepoSlug
 )
 
 // Test seams for the opener SIDE EFFECTS. Production wires these to the real
@@ -60,17 +73,19 @@ func githubIssueNewURL(owner, repo, title, body string) string {
 	q := url.Values{}
 	q.Set("title", title)
 	q.Set("body", body)
-	return fmt.Sprintf("https://github.com/%s/%s/issues/new?%s", owner, repo, q.Encode())
+	return fmt.Sprintf("https://%s/%s/%s/issues/new?%s", afIssueRepoHost, owner, repo, q.Encode())
 }
 
 // ghIssueCreateWebArgs builds the `gh` arguments that open a pre-filled browser
-// draft. `--repo <owner/repo>` pins the target so gh cannot resolve to the wrong
-// repo via GH_REPO / a stray gh remote config; `--web` is what keeps this
-// draft-only: gh constructs the issues/new URL and opens the browser instead of
-// creating the issue over the API, so there is no auto-submit and no
-// confirmation flag.
-func ghIssueCreateWebArgs(repoSlug, title, body string) []string {
-	return []string{"issue", "create", "--repo", repoSlug, "--web", "--title", title, "--body", body}
+// draft. `--repo <HOST/OWNER/REPO>` pins the target so gh cannot resolve it
+// elsewhere via GH_REPO, GH_HOST, or a stray gh remote config — pass the
+// fully-qualified afIssueRepoTarget, since a hostless slug is resolved against
+// GH_HOST and would follow an enterprise install to the wrong tracker. `--web` is
+// what keeps this draft-only: gh constructs the issues/new URL and opens the
+// browser instead of creating the issue over the API, so there is no auto-submit
+// and no confirmation flag.
+func ghIssueCreateWebArgs(repoTarget, title, body string) []string {
+	return []string{"issue", "create", "--repo", repoTarget, "--web", "--title", title, "--body", body}
 }
 
 // openGitHubIssueDraft opens a pre-filled, DRAFT-ONLY GitHub issue against the
@@ -89,7 +104,7 @@ func openGitHubIssueDraft(title, body string) (opened bool, reason string) {
 
 	// Prefer gh when present — it opens a clean, repo-pinned browser draft.
 	if _, err := draftLookPath("gh"); err == nil {
-		opened, ghReason := openDraftViaGh(afIssueRepoSlug, title, body)
+		opened, ghReason := openDraftViaGh(afIssueRepoTarget, title, body)
 		if opened {
 			return true, ""
 		}

--- a/commands/bugreport_github.go
+++ b/commands/bugreport_github.go
@@ -6,65 +6,56 @@ import (
 	"fmt"
 	"net/url"
 	"os/exec"
-	"regexp"
 	"runtime"
 	"strings"
 	"time"
 )
 
 // The GitHub issue-draft flow for `af bug-report`: after the redacted bundle is
-// written, open a PRE-FILLED new-issue draft in the browser for the current
-// repo. It NEVER auto-creates the issue — it opens `issues/new` (or `gh issue
-// create --web`) with a templated title/body for the user to review and submit
-// by hand. The full redacted bundle never rides in the URL (it is far past
-// GitHub's ~8KB query cap); it reaches the issue as the file the user attaches.
+// written, open a PRE-FILLED new-issue draft in the browser AGAINST THE AGENT
+// FACTORY PROJECT REPO. It NEVER auto-creates the issue — it opens `issues/new`
+// (or `gh issue create --web`) with a templated title/body for the user to
+// review and submit by hand. The full redacted bundle never rides in the URL (it
+// is far past GitHub's ~8KB query cap); a bounded, redacted excerpt of the key
+// diagnostics does (see bugreport.buildIssueDraft), and the complete bundle
+// reaches the issue as the file the user attaches.
 //
-// Every helper here is best-effort and side-effect-scoped: if no github.com
-// origin remote exists, or no browser/gh opener is available, openGitHubIssueDraft
-// reports (false, reason) and the caller falls back to file-only — the command
-// always succeeds and always leaves the bundle on disk.
+// The target is a CONSTANT, deliberately independent of the user's cwd and git
+// remotes. It used to be resolved from `.`'s origin remote, which assumed the
+// reporter was sitting inside a clone of agent-factory: every external user
+// running `af` inside their own project got a bug-report draft filed against
+// THEIR repo (#1914). A bug in af is a bug in af no matter where it is reported
+// from, so there is nothing about the local checkout worth consulting.
+//
+// The remaining fallback is opener-only: gh, then the browser, then (if neither
+// works) the caller degrades to file-only — the command always succeeds and
+// always leaves the bundle on disk.
 
-// scpLikeRemote matches the scp-style git remote form git@host:owner/repo(.git).
-var scpLikeRemote = regexp.MustCompile(`^[A-Za-z0-9._-]+@([A-Za-z0-9._-]+):(.+)$`)
+const (
+	// afIssueRepoOwner / afIssueRepoName are the agent-factory project repo —
+	// where `af bug-report` files, always.
+	afIssueRepoOwner = "sachiniyer"
+	afIssueRepoName  = "agent-factory"
+	// afIssueRepoSlug is the owner/repo form gh's --repo flag takes.
+	afIssueRepoSlug = afIssueRepoOwner + "/" + afIssueRepoName
+)
 
-// parseGitHubRepo extracts owner/repo from a git remote URL, returning ok=false
-// for anything that is not a github.com remote (enterprise hosts and other
-// forges fall back to the file-only path). It handles the scp-like
-// (git@github.com:owner/repo.git), https, and ssh:// forms.
-func parseGitHubRepo(remote string) (owner, repo string, ok bool) {
-	remote = strings.TrimSpace(remote)
-	if remote == "" {
-		return "", "", false
-	}
-
-	var host, path string
-	if m := scpLikeRemote.FindStringSubmatch(remote); m != nil {
-		host, path = m[1], m[2]
-	} else {
-		u, err := url.Parse(remote)
-		if err != nil || u.Hostname() == "" {
-			return "", "", false
-		}
-		host, path = u.Hostname(), u.Path
-	}
-
-	host = strings.TrimPrefix(strings.ToLower(host), "www.")
-	if host != "github.com" {
-		return "", "", false
-	}
-
-	path = strings.TrimSuffix(strings.Trim(path, "/"), ".git")
-	parts := strings.Split(path, "/")
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return "", "", false
-	}
-	return parts[0], parts[1], true
-}
+// Test seams for the opener SIDE EFFECTS. Production wires these to the real
+// exec/browser calls; tests swap in recorders so the draft flow can be exercised
+// without spawning gh or launching a browser. Only the side effects are
+// injectable — the target repo is a constant and deliberately is not, so no test
+// can pass by pointing the draft somewhere other than agent-factory.
+var (
+	draftLookPath      = exec.LookPath
+	openDraftViaGh     = openViaGh
+	openDraftInBrowser = openInBrowser
+)
 
 // githubIssueNewURL builds a pre-filled issues/new URL. The title/body are
-// query-encoded; the caller keeps the body short so the URL stays under
-// GitHub's length cap. Opening this URL only DRAFTS the issue — GitHub does not
-// submit it until the user clicks the button.
+// query-encoded; the body arrives pre-bounded to fit GitHub's ~8KB URL cap —
+// bugreport.buildIssueDraft budgets it against the ENCODED length, which is what
+// lands here. Opening this URL only DRAFTS the issue — GitHub does not submit it
+// until the user clicks the button.
 func githubIssueNewURL(owner, repo, title, body string) string {
 	q := url.Values{}
 	q.Set("title", title)
@@ -82,30 +73,33 @@ func ghIssueCreateWebArgs(repoSlug, title, body string) []string {
 	return []string{"issue", "create", "--repo", repoSlug, "--web", "--title", title, "--body", body}
 }
 
-// openGitHubIssueDraft opens a pre-filled, DRAFT-ONLY GitHub issue for the repo
-// at repoPath. It prefers `gh issue create --web` (a clean browser draft) and
-// falls back to opening the issues/new URL directly. It returns opened=false
-// with a human-readable reason when there is no github.com origin remote or no
-// working opener, so the caller can degrade to the file-only path. It never
-// creates the issue.
-func openGitHubIssueDraft(repoPath, title, body string) (opened bool, reason string) {
-	remote, err := gitRemoteURL(repoPath, "origin")
-	if err != nil || strings.TrimSpace(remote) == "" {
-		return false, "no 'origin' git remote for this repo"
-	}
-	owner, repo, ok := parseGitHubRepo(remote)
-	if !ok {
-		return false, "origin remote is not a github.com repository"
-	}
+// openGitHubIssueDraft opens a pre-filled, DRAFT-ONLY GitHub issue against the
+// agent-factory project repo, regardless of where the user ran `af`. It prefers
+// `gh issue create --web` (a clean browser draft) and falls back to opening the
+// issues/new URL directly. It returns opened=false with a human-readable reason
+// only when NO opener works at all, so the caller can degrade to the file-only
+// path. It never creates the issue.
+//
+// The gh failure now falls through to the browser rather than giving up: with
+// the target pinned to a constant, a gh that is installed-but-unauthenticated
+// says nothing about whether the plain issues/new URL would open, and the URL
+// path needs no auth at all.
+func openGitHubIssueDraft(title, body string) (opened bool, reason string) {
+	var reasons []string
 
 	// Prefer gh when present — it opens a clean, repo-pinned browser draft.
-	if _, err := exec.LookPath("gh"); err == nil {
-		return openViaGh(repoPath, owner+"/"+repo, title, body)
+	if _, err := draftLookPath("gh"); err == nil {
+		opened, ghReason := openDraftViaGh(afIssueRepoSlug, title, body)
+		if opened {
+			return true, ""
+		}
+		reasons = append(reasons, ghReason)
 	}
 
-	// gh absent: open the pre-filled issues/new URL in the browser directly.
-	if err := openInBrowser(githubIssueNewURL(owner, repo, title, body)); err != nil {
-		return false, fmt.Sprintf("no browser opener available (%v)", err)
+	// No gh, or gh could not open one: open the pre-filled issues/new URL directly.
+	if err := openDraftInBrowser(githubIssueNewURL(afIssueRepoOwner, afIssueRepoName, title, body)); err != nil {
+		reasons = append(reasons, fmt.Sprintf("no browser opener available (%v)", err))
+		return false, strings.Join(reasons, "; ")
 	}
 	return true, ""
 }
@@ -114,15 +108,17 @@ func openGitHubIssueDraft(repoPath, title, body string) (opened bool, reason str
 // actually exits 0. `--web` builds the issues/new URL and launches the browser
 // without waiting, so gh returns promptly; we wait (not fire-and-forget) so an
 // auth/remote/browser failure surfaces as opened=false — letting the caller fall
-// back to the file path — instead of a false "draft opened". A timeout guards
+// back to the browser path — instead of a false "draft opened". A timeout guards
 // the (unexpected) case where gh blocks, and nil stdin means any prompt EOFs out
 // rather than hanging.
-func openViaGh(repoPath, repoSlug, title, body string) (opened bool, reason string) {
+//
+// No working directory is set: --repo pins the target, so gh needs no local
+// repo context and must not pick any up from one.
+func openViaGh(repoSlug, title, body string) (opened bool, reason string) {
 	ctx, cancel := context.WithTimeout(context.Background(), ghDraftTimeout)
 	defer cancel()
 
 	c := exec.CommandContext(ctx, "gh", ghIssueCreateWebArgs(repoSlug, title, body)...)
-	c.Dir = repoPath
 	var errBuf bytes.Buffer
 	c.Stderr = &errBuf
 	if err := c.Run(); err != nil {
@@ -146,15 +142,6 @@ func firstLine(s string) string {
 		return s[:i]
 	}
 	return s
-}
-
-// gitRemoteURL returns the configured URL of the named remote in repoPath.
-func gitRemoteURL(repoPath, name string) (string, error) {
-	out, err := exec.Command("git", "-C", repoPath, "remote", "get-url", name).Output()
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(out)), nil
 }
 
 // openInBrowser launches the platform browser opener for target and reaps it so

--- a/commands/bugreportcmd.go
+++ b/commands/bugreportcmd.go
@@ -47,11 +47,17 @@ var bugReportCmd = &cobra.Command{
 
 By default the redacted bundle is written to a single text file
 (~/af-bug-report-<ts>.txt) and a pre-filled GitHub issue DRAFT is opened in your
-browser for this repo — with a templated title and body. The draft is never
-submitted for you: review it, drag the bundle file onto the issue, and click
-Submit yourself. If this repo has no github.com remote, or no browser/gh is
-available, the command falls back to just writing the bundle file and printing
-where it is so you can attach it to an issue by hand.
+browser. The draft ALWAYS targets the agent-factory project
+(github.com/sachiniyer/agent-factory) — never whatever repo you happen to be
+in — because it reports a bug in af itself.
+
+The draft body carries a bounded, redacted summary of the key diagnostics
+(versions, daemon status, counts, and the newest log lines) so the report is
+useful even as filed; the complete bundle is too large for a URL, so it stays on
+disk for you to attach. The draft is never submitted for you: review it, drag the
+bundle file onto the issue, and click Submit yourself. If neither gh nor a
+browser opener is available, the command falls back to just writing the bundle
+file and printing where it is so you can attach it to an issue by hand.
 
 Use -o/--output <path> or --file to skip GitHub and only write the bundle file.
 
@@ -109,13 +115,15 @@ envelope) to stdout instead of writing a file or opening a draft.`,
 			return nil
 		}
 
-		// Default: open a pre-filled GitHub issue DRAFT for this repo. The bundle
-		// is attached by the user; nothing is submitted automatically. The path is
-		// redacted ($HOME→~ / username→[user]) before it goes into the draft body
-		// so the public draft can't leak it, while stdout still prints the real
-		// local path.
+		// Default: open a pre-filled GitHub issue DRAFT against the agent-factory
+		// project repo — never the user's own repo, wherever they ran `af` from.
+		// The body carries a bounded, redacted diagnostics excerpt; the complete
+		// bundle is attached by the user. Nothing is submitted automatically. The
+		// path is redacted ($HOME→~ / username→[user]) before it goes into the
+		// draft body so the public draft can't leak it, while stdout still prints
+		// the real local path.
 		body := strings.Replace(result.Body, bugreport.BundlePathPlaceholder, bugreport.RedactPath(outPath), 1)
-		opened, reason := openGitHubIssueDraft(".", result.Title, body)
+		opened, reason := openGitHubIssueDraft(result.Title, body)
 		if !opened {
 			fmt.Fprintf(w, "Couldn't open a GitHub issue draft (%s).\n", reason)
 			fmt.Fprintf(w, "Wrote the redacted bug-report bundle to %s\n", outPath)

--- a/commands/bugreportcmd.go
+++ b/commands/bugreportcmd.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/sachiniyer/agent-factory/apiproto"
@@ -80,11 +79,23 @@ envelope) to stdout instead of writing a file or opening a draft.`,
 		humanCmd.SetOut(&daemonHuman)
 		printDaemonStatusHuman(humanCmd, info)
 
+		// Resolve the output path BEFORE building. The issue draft has to fit a
+		// URL length cap, and it names this path — so the builder must measure
+		// the real path into the body it size-checks. Substituting it afterwards
+		// made the body that actually reached GitHub longer than the one that was
+		// checked. Resolving first costs nothing: the path depends on flags and
+		// the clock, never on the bundle.
+		outPath, err := resolveBugReportPath(bugReportOutput)
+		if err != nil {
+			return err
+		}
+
 		result, err := bugreport.Build(bugreport.Inputs{
 			AFVersion:    version,
 			GeneratedAt:  time.Now().Format("2006-01-02 15:04:05 -0700"),
 			DaemonStatus: info,
 			DaemonHuman:  daemonHuman.String(),
+			BundlePath:   outPath,
 		})
 		if err != nil {
 			return err
@@ -97,10 +108,6 @@ envelope) to stdout instead of writing a file or opening a draft.`,
 		// The redacted bundle is always written to disk — in the default flow it
 		// is the file the user drags onto the GitHub draft; in file-only mode it
 		// is the whole output.
-		outPath, err := resolveBugReportPath(bugReportOutput)
-		if err != nil {
-			return err
-		}
 		if err := os.WriteFile(outPath, []byte(result.Text), 0600); err != nil {
 			return fmt.Errorf("write bug report: %w", err)
 		}
@@ -118,12 +125,12 @@ envelope) to stdout instead of writing a file or opening a draft.`,
 		// Default: open a pre-filled GitHub issue DRAFT against the agent-factory
 		// project repo — never the user's own repo, wherever they ran `af` from.
 		// The body carries a bounded, redacted diagnostics excerpt; the complete
-		// bundle is attached by the user. Nothing is submitted automatically. The
-		// path is redacted ($HOME→~ / username→[user]) before it goes into the
-		// draft body so the public draft can't leak it, while stdout still prints
-		// the real local path.
-		body := strings.Replace(result.Body, bugreport.BundlePathPlaceholder, bugreport.RedactPath(outPath), 1)
-		opened, reason := openGitHubIssueDraft(result.Title, body)
+		// bundle is attached by the user. Nothing is submitted automatically.
+		//
+		// result.Body is used verbatim: it is already redacted (including the
+		// bundle path it names, so the public draft can't leak $HOME/username)
+		// and already size-checked. stdout still prints the real local path.
+		opened, reason := openGitHubIssueDraft(result.Title, result.Body)
 		if !opened {
 			fmt.Fprintf(w, "Couldn't open a GitHub issue draft (%s).\n", reason)
 			fmt.Fprintf(w, "Wrote the redacted bug-report bundle to %s\n", outPath)

--- a/commands/bugreportcmd_test.go
+++ b/commands/bugreportcmd_test.go
@@ -3,11 +3,15 @@ package commands
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/sachiniyer/agent-factory/bugreport"
 )
 
 // TestBugReportCmdWritesFile drives the command end-to-end against a fresh temp
@@ -80,35 +84,138 @@ func TestBugReportCmdJSON(t *testing.T) {
 	}
 }
 
-// TestParseGitHubRepo covers the remote-URL forms the draft flow must recognize
-// and the non-github.com remotes it must reject (so the caller falls back to
-// file-only).
-func TestParseGitHubRepo(t *testing.T) {
-	cases := []struct {
-		remote            string
-		wantOwner, wantRe string
-		wantOK            bool
-	}{
-		{"git@github.com:sachiniyer/agent-factory.git", "sachiniyer", "agent-factory", true},
-		{"git@github.com:sachiniyer/agent-factory", "sachiniyer", "agent-factory", true},
-		{"https://github.com/sachiniyer/agent-factory.git", "sachiniyer", "agent-factory", true},
-		{"https://github.com/sachiniyer/agent-factory", "sachiniyer", "agent-factory", true},
-		{"https://www.github.com/sachiniyer/agent-factory", "sachiniyer", "agent-factory", true},
-		{"ssh://git@github.com/sachiniyer/agent-factory.git", "sachiniyer", "agent-factory", true},
-		{"https://github.com/sachiniyer/agent-factory/", "sachiniyer", "agent-factory", true},
-		// Rejected: other forges / enterprise hosts / malformed.
-		{"git@gitlab.com:owner/repo.git", "", "", false},
-		{"https://example.com/owner/repo.git", "", "", false},
-		{"https://github.enterprise.com/owner/repo.git", "", "", false},
-		{"https://github.com/onlyowner", "", "", false},
-		{"", "", "", false},
-	}
-	for _, tc := range cases {
-		owner, repo, ok := parseGitHubRepo(tc.remote)
-		if ok != tc.wantOK || owner != tc.wantOwner || repo != tc.wantRe {
-			t.Errorf("parseGitHubRepo(%q) = (%q, %q, %v), want (%q, %q, %v)",
-				tc.remote, owner, repo, ok, tc.wantOwner, tc.wantRe, tc.wantOK)
+// draftRecorder captures what the draft flow tried to open, so the tests can
+// assert the target without spawning gh or a browser.
+type draftRecorder struct {
+	ghSlug     string
+	ghCalled   bool
+	browserURL string
+	browserHit bool
+}
+
+// stubDraftOpeners swaps the opener seams for recorders. ghOK/browserOK choose
+// whether each "succeeds"; ghPresent controls whether gh looks installed.
+func stubDraftOpeners(t *testing.T, ghPresent, ghOK, browserOK bool) *draftRecorder {
+	t.Helper()
+	rec := &draftRecorder{}
+	oldLook, oldGh, oldBrowser := draftLookPath, openDraftViaGh, openDraftInBrowser
+	t.Cleanup(func() { draftLookPath, openDraftViaGh, openDraftInBrowser = oldLook, oldGh, oldBrowser })
+
+	draftLookPath = func(string) (string, error) {
+		if ghPresent {
+			return "/usr/bin/gh", nil
 		}
+		return "", errors.New("not found")
+	}
+	openDraftViaGh = func(repoSlug, _, _ string) (bool, string) {
+		rec.ghCalled, rec.ghSlug = true, repoSlug
+		if ghOK {
+			return true, ""
+		}
+		return false, "gh could not open a draft: not authenticated"
+	}
+	openDraftInBrowser = func(target string) error {
+		rec.browserHit, rec.browserURL = true, target
+		if browserOK {
+			return nil
+		}
+		return errors.New("exec: xdg-open: not found")
+	}
+	return rec
+}
+
+// initRepo makes a temp git repo with the given origin remote ("" = no remote)
+// and chdirs into it, mimicking a user running `af bug-report` from their own
+// project.
+func initRepo(t *testing.T, origin string) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := exec.Command("git", "-C", dir, "init", "-q").Run(); err != nil {
+		t.Skipf("git unavailable: %v", err)
+	}
+	if origin != "" {
+		if err := exec.Command("git", "-C", dir, "remote", "add", "origin", origin).Run(); err != nil {
+			t.Fatalf("git remote add: %v", err)
+		}
+	}
+	t.Chdir(dir)
+}
+
+// TestOpenGitHubIssueDraftAlwaysTargetsAgentFactory is the #1914 regression lock:
+// a bug in af is a bug in af no matter where it is reported from, so the draft
+// must target the agent-factory project regardless of the cwd's origin remote.
+// The flow used to read `.`'s origin, filing external users' reports against
+// THEIR OWN repo — and a repo with no github.com remote got no draft at all.
+func TestOpenGitHubIssueDraftAlwaysTargetsAgentFactory(t *testing.T) {
+	origins := []struct{ name, origin string }{
+		{"user's own github repo", "git@github.com:acme-corp/secret-product.git"},
+		{"user's https github repo", "https://github.com/acme-corp/secret-product.git"},
+		{"a non-github forge", "git@gitlab.com:acme-corp/secret-product.git"},
+		{"an enterprise github host", "https://github.enterprise.com/acme/thing.git"},
+		// Before the fix this fell back to file-only and opened nothing.
+		{"no remote at all", ""},
+	}
+	for _, tc := range origins {
+		t.Run(tc.name, func(t *testing.T) {
+			initRepo(t, tc.origin)
+
+			// gh path.
+			rec := stubDraftOpeners(t, true, true, true)
+			opened, reason := openGitHubIssueDraft("t", "b")
+			if !opened {
+				t.Fatalf("no draft opened from a repo with origin %q: %s", tc.origin, reason)
+			}
+			if rec.ghSlug != afIssueRepoSlug {
+				t.Errorf("gh targeted %q, want %q (origin %q must not influence the target)",
+					rec.ghSlug, afIssueRepoSlug, tc.origin)
+			}
+
+			// Browser path (no gh installed).
+			rec = stubDraftOpeners(t, false, false, true)
+			if opened, reason := openGitHubIssueDraft("t", "b"); !opened {
+				t.Fatalf("no browser draft from a repo with origin %q: %s", tc.origin, reason)
+			}
+			u, err := url.Parse(rec.browserURL)
+			if err != nil {
+				t.Fatalf("browser URL does not parse: %v", err)
+			}
+			if want := "/" + afIssueRepoSlug + "/issues/new"; u.Host != "github.com" || u.Path != want {
+				t.Errorf("browser draft targeted %s%s, want github.com%s (origin %q)",
+					u.Host, u.Path, want, tc.origin)
+			}
+		})
+	}
+}
+
+// TestOpenGitHubIssueDraftFallsBackToBrowserWhenGhFails covers the opener chain:
+// with the target pinned to a constant, an installed-but-unauthenticated gh says
+// nothing about whether the plain issues/new URL would open, so a gh failure must
+// fall through to the browser rather than degrade to file-only.
+func TestOpenGitHubIssueDraftFallsBackToBrowserWhenGhFails(t *testing.T) {
+	rec := stubDraftOpeners(t, true, false, true)
+	opened, _ := openGitHubIssueDraft("t", "b")
+	if !opened {
+		t.Fatal("a failing gh must fall through to the browser, not to file-only")
+	}
+	if !rec.ghCalled || !rec.browserHit {
+		t.Errorf("expected gh then browser; gh=%v browser=%v", rec.ghCalled, rec.browserHit)
+	}
+	if !strings.Contains(rec.browserURL, afIssueRepoSlug) {
+		t.Errorf("browser fallback lost the AF target: %s", rec.browserURL)
+	}
+}
+
+// TestOpenGitHubIssueDraftFallsBackToFileOnly confirms the remaining file-only
+// path is opener-only: it triggers when NO opener works (no gh AND no browser),
+// never because of what the local repo's remote looks like.
+func TestOpenGitHubIssueDraftFallsBackToFileOnly(t *testing.T) {
+	stubDraftOpeners(t, false, false, false)
+	opened, reason := openGitHubIssueDraft("t", "b")
+	if opened {
+		t.Fatal("must not report a draft when no opener works")
+	}
+	if reason == "" {
+		t.Error("expected a human-readable fallback reason")
 	}
 }
 
@@ -172,17 +279,76 @@ func TestGhIssueCreateWebArgs(t *testing.T) {
 	}
 }
 
-// TestOpenGitHubIssueDraftFallsBackWithoutRemote confirms the graceful fallback:
-// a directory with no origin remote yields opened=false + a reason, never a
-// browser launch, so the caller can degrade to file-only.
-func TestOpenGitHubIssueDraftFallsBackWithoutRemote(t *testing.T) {
-	dir := t.TempDir() // not a git repo, so no origin remote
-	opened, reason := openGitHubIssueDraft(dir, "t", "b")
-	if opened {
-		t.Fatal("must not open a draft without a github.com origin remote")
+// TestBugReportDefaultFlowCarriesDiagnostics drives the DEFAULT flow (no
+// -o/--file) through the command's own RunE — the path that was broken — rather
+// than calling the draft builder directly, which would skip the command gate
+// that decides what actually reaches GitHub.
+//
+// #1914: the default flow wrote the bundle to a local file and handed the draft
+// a body that only NAMED that file. The path is on the reporter's machine, so
+// unless they hand-attached a ~1MB file the filed issue carried no diagnostics
+// at all. The body must now carry a bounded, redacted excerpt itself, AND still
+// write + reference the complete bundle.
+func TestBugReportDefaultFlowCarriesDiagnostics(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_FACTORY_HOME", filepath.Join(home, ".agent-factory"))
+	initRepo(t, "git@github.com:acme-corp/secret-product.git")
+
+	// Capture the body the command hands the opener — what GitHub would receive.
+	var gotBody string
+	oldLook, oldGh, oldBrowser := draftLookPath, openDraftViaGh, openDraftInBrowser
+	t.Cleanup(func() { draftLookPath, openDraftViaGh, openDraftInBrowser = oldLook, oldGh, oldBrowser })
+	draftLookPath = func(string) (string, error) { return "/usr/bin/gh", nil }
+	openDraftViaGh = func(_, _, body string) (bool, string) { gotBody = body; return true, "" }
+	openDraftInBrowser = func(string) error { return errors.New("no browser in tests") }
+
+	t.Cleanup(func() { bugReportJSON, bugReportOutput, bugReportFile = false, "", false })
+	bugReportJSON, bugReportOutput, bugReportFile = false, "", false
+
+	var buf bytes.Buffer
+	bugReportCmd.SetOut(&buf)
+	if err := bugReportCmd.RunE(bugReportCmd, nil); err != nil {
+		t.Fatalf("RunE: %v", err)
 	}
-	if reason == "" {
-		t.Error("expected a human-readable fallback reason")
+
+	// 1. The full bundle is still written to disk.
+	matches, _ := filepath.Glob(filepath.Join(home, "af-bug-report-*.txt"))
+	if len(matches) != 1 {
+		t.Fatalf("default flow must write exactly one bundle file, got %v", matches)
+	}
+	data, err := os.ReadFile(matches[0])
+	if err != nil {
+		t.Fatalf("bundle unreadable: %v", err)
+	}
+	if !strings.Contains(string(data), "AGENT FACTORY BUG REPORT") {
+		t.Error("bundle on disk is not a complete report")
+	}
+
+	// 2. The draft body carries the bounded diagnostics summary itself.
+	if !strings.Contains(gotBody, "<details>") || !strings.Contains(gotBody, "Diagnostics summary") {
+		t.Errorf("issue body carries no inline diagnostics summary:\n%s", gotBody)
+	}
+	for _, want := range []string{"### Daemon status", "## Environment"} {
+		if !strings.Contains(gotBody, want) {
+			t.Errorf("issue body missing %q:\n%s", want, gotBody)
+		}
+	}
+
+	// 3. The body still references the complete bundle, by its REDACTED path.
+	if strings.Contains(gotBody, bugreport.BundlePathPlaceholder) {
+		t.Error("bundle-path placeholder was never substituted")
+	}
+	if !strings.Contains(gotBody, "af-bug-report-") || !strings.Contains(gotBody, "Attach that file") {
+		t.Errorf("issue body does not reference the full bundle to attach:\n%s", gotBody)
+	}
+	if strings.Contains(gotBody, home) {
+		t.Errorf("issue body leaks the real home path:\n%s", gotBody)
+	}
+
+	// 4. The body fits the issues/new URL cap once percent-encoded.
+	if n := len(url.QueryEscape(gotBody)); n > 6000 {
+		t.Errorf("encoded issue body is %d bytes, past the URL budget", n)
 	}
 }
 

--- a/commands/bugreportcmd_test.go
+++ b/commands/bugreportcmd_test.go
@@ -164,9 +164,9 @@ func TestOpenGitHubIssueDraftAlwaysTargetsAgentFactory(t *testing.T) {
 			if !opened {
 				t.Fatalf("no draft opened from a repo with origin %q: %s", tc.origin, reason)
 			}
-			if rec.ghSlug != afIssueRepoSlug {
+			if rec.ghSlug != afIssueRepoTarget {
 				t.Errorf("gh targeted %q, want %q (origin %q must not influence the target)",
-					rec.ghSlug, afIssueRepoSlug, tc.origin)
+					rec.ghSlug, afIssueRepoTarget, tc.origin)
 			}
 
 			// Browser path (no gh installed).
@@ -181,6 +181,48 @@ func TestOpenGitHubIssueDraftAlwaysTargetsAgentFactory(t *testing.T) {
 			if want := "/" + afIssueRepoSlug + "/issues/new"; u.Host != "github.com" || u.Path != want {
 				t.Errorf("browser draft targeted %s%s, want github.com%s (origin %q)",
 					u.Host, u.Path, want, tc.origin)
+			}
+		})
+	}
+}
+
+// TestOpenGitHubIssueDraftIgnoresGHHost pins the target against the environment.
+// gh resolves a bare OWNER/REPO against GH_HOST, so on a GitHub Enterprise
+// install a hostless slug silently retargets the draft at the employer's tracker
+// — and if that host carries a matching repo or mirror, `gh --web` SUCCEEDS
+// there, the browser fallback never runs, and the diagnostics bundle goes with
+// it. The target must be fully qualified so the documented destination holds
+// whatever the environment says.
+func TestOpenGitHubIssueDraftIgnoresGHHost(t *testing.T) {
+	for _, host := range []string{"github.enterprise.example", "ghe.acme-corp.internal"} {
+		t.Run(host, func(t *testing.T) {
+			t.Setenv("GH_HOST", host)
+			t.Setenv("GH_REPO", "acme-corp/secret-product")
+			initRepo(t, "https://"+host+"/acme-corp/secret-product.git")
+
+			rec := stubDraftOpeners(t, true, true, true)
+			if opened, reason := openGitHubIssueDraft("t", "b"); !opened {
+				t.Fatalf("no draft opened with GH_HOST=%s: %s", host, reason)
+			}
+			if rec.ghSlug != afIssueRepoTarget {
+				t.Errorf("GH_HOST=%s retargeted gh to %q, want %q", host, rec.ghSlug, afIssueRepoTarget)
+			}
+			// The host must be carried IN the target, not left for gh to infer.
+			if !strings.HasPrefix(rec.ghSlug, "github.com/") {
+				t.Errorf("gh target is not fully qualified, so GH_HOST can still resolve it: %q", rec.ghSlug)
+			}
+
+			// The browser path builds its own absolute URL; it must not drift either.
+			rec = stubDraftOpeners(t, false, false, true)
+			if opened, reason := openGitHubIssueDraft("t", "b"); !opened {
+				t.Fatalf("no browser draft with GH_HOST=%s: %s", host, reason)
+			}
+			u, err := url.Parse(rec.browserURL)
+			if err != nil {
+				t.Fatalf("browser URL does not parse: %v", err)
+			}
+			if u.Host != "github.com" {
+				t.Errorf("GH_HOST=%s moved the browser draft to %q", host, u.Host)
 			}
 		})
 	}
@@ -253,7 +295,7 @@ func TestGithubIssueNewURL(t *testing.T) {
 // with the templated title/body, and must NOT carry any non-interactive submit
 // flag.
 func TestGhIssueCreateWebArgs(t *testing.T) {
-	args := ghIssueCreateWebArgs("sachiniyer/agent-factory", "my title", "my body")
+	args := ghIssueCreateWebArgs(afIssueRepoTarget, "my title", "my body")
 	joined := strings.Join(args, " ")
 
 	if args[0] != "issue" || args[1] != "create" {
@@ -263,8 +305,10 @@ func TestGhIssueCreateWebArgs(t *testing.T) {
 		t.Errorf("draft flow must use --web (browser draft, no auto-submit): %v", args)
 	}
 	// The target repo must be pinned so gh can't resolve to the wrong repo.
-	if !containsArgValue(args, "--repo", "sachiniyer/agent-factory") {
-		t.Errorf("gh target not pinned to the parsed repo: %v", args)
+	// Fully qualified, not a bare slug: gh resolves a hostless OWNER/REPO
+	// against GH_HOST, which on an enterprise install is the wrong tracker.
+	if !containsArgValue(args, "--repo", "github.com/sachiniyer/agent-factory") {
+		t.Errorf("gh target not pinned to the fully-qualified AF repo: %v", args)
 	}
 	if !containsArgValue(args, "--title", "my title") || !containsArgValue(args, "--body", "my body") {
 		t.Errorf("title/body not templated into gh args: %v", args)

--- a/commands/bugreportcmd_test.go
+++ b/commands/bugreportcmd_test.go
@@ -4,14 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/sachiniyer/agent-factory/bugreport"
 )
 
 // TestBugReportCmdWritesFile drives the command end-to-end against a fresh temp
@@ -291,9 +290,25 @@ func TestGhIssueCreateWebArgs(t *testing.T) {
 // write + reference the complete bundle.
 func TestBugReportDefaultFlowCarriesDiagnostics(t *testing.T) {
 	home := t.TempDir()
+	afHome := filepath.Join(home, ".agent-factory")
 	t.Setenv("HOME", home)
-	t.Setenv("AGENT_FACTORY_HOME", filepath.Join(home, ".agent-factory"))
+	t.Setenv("AGENT_FACTORY_HOME", afHome)
 	initRepo(t, "git@github.com:acme-corp/secret-product.git")
+
+	// Plant a log big enough that the excerpt fills the URL budget. Without it
+	// the body sits near-empty and every size assertion below passes vacuously —
+	// including the one guarding the bundle path, whose whole failure mode is a
+	// body that was already at the cap.
+	if err := os.MkdirAll(afHome, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var log bytes.Buffer
+	for i := 0; i < 4000; i++ {
+		fmt.Fprintf(&log, "2026-07-16 08:00:00 daemon: reconciled session %d, state=Ready\n", i)
+	}
+	if err := os.WriteFile(filepath.Join(afHome, "agent-factory.log"), log.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	// Capture the body the command hands the opener — what GitHub would receive.
 	var gotBody string
@@ -336,9 +351,6 @@ func TestBugReportDefaultFlowCarriesDiagnostics(t *testing.T) {
 	}
 
 	// 3. The body still references the complete bundle, by its REDACTED path.
-	if strings.Contains(gotBody, bugreport.BundlePathPlaceholder) {
-		t.Error("bundle-path placeholder was never substituted")
-	}
 	if !strings.Contains(gotBody, "af-bug-report-") || !strings.Contains(gotBody, "Attach that file") {
 		t.Errorf("issue body does not reference the full bundle to attach:\n%s", gotBody)
 	}
@@ -346,9 +358,19 @@ func TestBugReportDefaultFlowCarriesDiagnostics(t *testing.T) {
 		t.Errorf("issue body leaks the real home path:\n%s", gotBody)
 	}
 
-	// 4. The body fits the issues/new URL cap once percent-encoded.
-	if n := len(url.QueryEscape(gotBody)); n > 6000 {
-		t.Errorf("encoded issue body is %d bytes, past the URL budget", n)
+	// 4. The body the opener ACTUALLY receives fits the issues/new URL cap once
+	// percent-encoded. This asserts the FINAL body, not an intermediate one: the
+	// bundle path used to be substituted in after the size check, so the body
+	// that reached gh/the browser was longer than the one that was measured.
+	encoded := len(url.QueryEscape(gotBody))
+	if encoded > 6000 {
+		t.Errorf("encoded issue body is %d bytes, past the URL budget", encoded)
+	}
+	// …and the budget is actually being spent, so the assertion above is not
+	// passing merely because the body is small.
+	if encoded < 4000 {
+		t.Errorf("encoded body is only %d bytes — the planted log should fill the budget, "+
+			"so the cap assertion is not exercising anything", encoded)
 	}
 }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -143,6 +143,15 @@ before sharing it publicly**. It is read-only and local (like `af doctor`): it
 never dials the daemon or the network, and is not part of the HTTP `af api`
 surface.
 
+By default it also opens a pre-filled GitHub issue **draft** in your browser,
+always against the agent-factory project — never whatever repo you happen to be
+in, since the report is about `af` itself. The draft body carries a bounded,
+redacted excerpt of the key diagnostics (versions, daemon status, counts, and the
+newest log lines) so the report is useful as filed; the complete bundle is far
+too large for a URL, so it stays on disk for you to attach. Nothing is submitted
+for you — review the draft, drag the bundle onto it, and click Submit yourself.
+Use `-o/--output` or `--file` to skip GitHub and only write the file.
+
 `af doctor --setup` is the first-run profile: it checks AF home/config/state/log
 writability, git and git identity, tmux, configured agent commands, daemon
 health, and remote-hook setup for the current repo when configured.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -204,11 +204,17 @@ Collect a single, shareable diagnostics bundle for triage:
 
 By default the redacted bundle is written to a single text file
 (~/af-bug-report-<ts>.txt) and a pre-filled GitHub issue DRAFT is opened in your
-browser for this repo — with a templated title and body. The draft is never
-submitted for you: review it, drag the bundle file onto the issue, and click
-Submit yourself. If this repo has no github.com remote, or no browser/gh is
-available, the command falls back to just writing the bundle file and printing
-where it is so you can attach it to an issue by hand.
+browser. The draft ALWAYS targets the agent-factory project
+(github.com/sachiniyer/agent-factory) — never whatever repo you happen to be
+in — because it reports a bug in af itself.
+
+The draft body carries a bounded, redacted summary of the key diagnostics
+(versions, daemon status, counts, and the newest log lines) so the report is
+useful even as filed; the complete bundle is too large for a URL, so it stays on
+disk for you to attach. The draft is never submitted for you: review it, drag the
+bundle file onto the issue, and click Submit yourself. If neither gh nor a
+browser opener is available, the command falls back to just writing the bundle
+file and printing where it is so you can attach it to an issue by hand.
 
 Use -o/--output <path> or --file to skip GitHub and only write the bundle file.
 


### PR DESCRIPTION
Two defects in the `af bug-report` **default** (GitHub) flow, both reported by Sachin. Held as **draft** — bug 2 makes a user-facing design choice worth eyeballing before merge.

## Repro (default flow, no `-o`)

In a throwaway repo whose origin is `git@github.com:acme-corp/secret-product.git`, with a stub `gh` that records its argv:

```
$ af bug-report
Wrote the redacted bug-report bundle to ~/af-bug-report-20260716-075603.txt
Opened a pre-filled GitHub issue draft in your browser — it is NOT submitted.

gh argv:  issue create --repo acme-corp/secret-product --web --title ... --body ...
body:     585 bytes
bundle:   1.1 MB on disk, never referenced by anything GitHub can reach
```

## Bug 1 — the draft was filed against the user's repo

`openGitHubIssueDraft(".", …)` resolved the target from `.`'s `origin` remote via `gitRemoteURL`/`parseGitHubRepo`. That assumed the reporter was sitting inside a clone of agent-factory. Every external user running `af` inside their own project got a bug-report draft against **their** repo — and a repo with no `github.com` remote got **no draft at all** (silent file-only fallback).

**Fix.** The target is now the constant `sachiniyer/agent-factory`, independent of cwd and remotes. A bug in `af` is a bug in `af` no matter where it is reported from, so there is nothing about the local checkout worth consulting. `parseGitHubRepo`/`gitRemoteURL`/`scpLikeRemote` are deleted (no other callers; `deadcode` would flag them).

Two consequences, both intended:
- **A no-remote repo now gets the AF draft.** It used to fall back to file-only. Verified end-to-end.
- **A failing `gh` now falls through to the browser** instead of degrading to file-only. With the target pinned to a constant, an installed-but-unauthenticated `gh` says nothing about whether the plain `issues/new` URL would open — and that URL needs no auth. File-only is now reached only when *no opener works at all* (no gh **and** no browser).

## Bug 2 — the filed report carried no diagnostics

The bundle **builder is fine** and the write is fine: the default flow does write the complete bundle (1.1 MB here), and no error short-circuits it. The defect is that **the bundle never reaches the issue**. The body only *named* the file — at a path on the reporter's own machine, which is meaningless to a triager. `gh --web` / `issues/new` cannot attach a file, and 1.1 MB is orders of magnitude past the URL cap. So unless the user hand-attached it, the issue arrived with versions and three counts. From the reporter's POV: "you are not actually creating the diagnostics bundle."

### Design

The full bundle genuinely cannot inline, so the draft carries a **bounded, redacted excerpt** and still points at the complete file:

- **Inlined** in a collapsible `<details>` block: daemon status, collection errors, and the **newest** log lines (the ones nearest a failure). Environment/counts stay in the body proper.
- **Budgeted against the PERCENT-ENCODED length**, not the raw length. This is the constraint that actually bites: the body rides in a query string, a newline costs 3 bytes encoded, and a log tail is newline-dense — a raw cap would silently overshoot into a dead link. `url.QueryEscape` maps each byte independently, so encoded length is additive: the fixed template is measured first and the log tail is handed exactly the remainder.
- **Capped hard, never silently.** Elided lines, a truncated daemon block, and dropped errors each say so and point at the attached bundle.
- **Redacted at the point of inlining.** The Bundle's log/config/instances arrive pre-redacted from their collectors, but `daemonHuman` and `Errors` do **not** — they were only scrubbed by the text renderer's final pass, which the issue body never goes through. Both are scrubbed explicitly. Scrubbing per-component also keeps the budget exact: a whole-body re-scrub could *grow* the body (`[user]` is longer than the username it replaces).
- **Draft-not-auto-submit contract preserved** — `--web` only, no submit/confirm flag.

### Before / after (real state, 351 sessions, 1.1 MB bundle)

| | before | after |
|---|---|---|
| target repo | `acme-corp/secret-product` | `sachiniyer/agent-factory` |
| no-remote repo | no draft (file-only) | AF draft |
| issue body | 585 B, counts only | 4869 B raw / **5989 B encoded** (cap 6000) |
| total URL | — | **6099 B** (GitHub 414s past ~8192) |
| diagnostics in issue | none | daemon status + 25 newest log lines + errors |
| bundle on disk | written, unreferenced by GitHub | written, referenced by redacted path |

Redaction held on real data: session titles → `[redacted]`, daemon bearer token → `[redacted-secret]`, `$HOME` → `~`.

## Tests

Both regression tests were **watched failing against the reintroduced bug**, reproducing the reported symptoms exactly:

- `TestOpenGitHubIssueDraftAlwaysTargetsAgentFactory` — table over origins (user's repo, https form, gitlab, enterprise host, **no remote**); each asserts both the `gh --repo` arg and the browser URL target AF. Against the old remote-derived code: `gh targeted "acme-corp/secret-product", want "sachiniyer/agent-factory"`.
- `TestBugReportDefaultFlowCarriesDiagnostics` — drives the command's own `RunE` (the prod gate that decides what reaches GitHub), **not** the draft builder directly. Asserts the bundle is written **and** the body carries the summary, references the full bundle by redacted path, and fits the encoded cap. Against the old body: `issue body carries no inline diagnostics summary`.
- `TestBuildIssueDraftBoundsBodyToURLCap` — pathological bundle (20k log lines, verbose status, 50 errors) still fits encoded; elisions stated; newest lines kept.
- `TestFitLogTailKeepsNewestWithinBudget`, plus the existing `TestBuildEndToEnd` redaction guard, now extended to assert the **scrubbed** log tail and daemon status actually reached the body — so it can't pass by inlining nothing.

The opener side effects are behind test seams so no test spawns `gh` or a browser. The **target is a constant and deliberately not injectable** — no test can pass by pointing the draft elsewhere.

## Gates

`make test-container` (29 packages, 0 failures) · `go build ./...` · `gofmt -l .` · `golangci-lint run --fast` · `deadcode -test ./...` · `scripts/lint-file-length.sh` · `scripts/gen-docs.sh` (the `--help` Long text changed; `docs/reference/cli.md` regenerated, and `docs/cli.md` gained the default-flow paragraph it never had).

Not dev-installed, per instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Redaction: why the marker fast-path is now sound (P1)

**The boundary was the bug, three times over.** `keyValueSecret`'s bare-value class excluded `]`:

```
[^\s"',}\]]{6,}      // before
[^\s"',}]{6,}        // after
```

So a bare value stopped *before* a bracket rather than at a terminator, and **the captured text was never the value — only a prefix of it.** `api_key=[redacted-secret]actualcredential` captured `[redacted-secret`, which is byte-identical to a marker this redactor writes. Every guard I layered on top inherited that lie, because each one compared against a capture that had already been truncated. Fixing the comparison could never work.

A bare value now ends only at a genuine terminator — whitespace, `"`, `'`, `,`, `}`, or end of text — so the capture **is** the whole value, and comparing it to a marker is a real comparison. Values containing structural characters are covered by the quoted alternatives, which consume their own delimiters. Dropping `]` also errs toward *more* redaction (a `]` adjacent to a bare value is absorbed rather than left behind), which is the safe direction.

### Per-form proof

For each of the six forms the fast-path recognizes: what the regex captures, whether that capture is the complete value, and therefore whether a value that merely *begins* with a marker can reach the unchanged path.

| # | form | captured | complete? | impostor `…marker+hunter2` reaches unchanged path? |
|---|---|---|---|---|
| 1 | bare `[redacted-secret]` | `[redacted-secret]` — ends at ws/`"`/`'`/`,`/`}`/EOS | ✅ now | **No** — captures `[redacted-secret]hunter2`, matches no entry → redacted |
| 2 | bare `[redacted]` | `[redacted]` — same | ✅ now | **No** — same |
| 3 | `"[redacted-secret]"` | whole literal, both quotes | ✅ always | **No** — captures `"[redacted-secret]hunter2"` → redacted |
| 4 | `'[redacted-secret]'` | whole literal | ✅ always | **No** — same |
| 5 | `"[redacted]"` | whole literal | ✅ always | **No** — same |
| 6 | `'[redacted]'` | whole literal | ✅ always | **No** — same |

Forms 3–6 were **never** truncated — the quoted alternatives consume their own delimiters, so exact-matching their capture was always exact-matching the value. That is precisely why, when the new test runs against the old boundary, **only forms 1 and 2 fail**:

```
--- FAIL: …/bare_secret_marker/impostor_is_redacted
    CREDENTIAL LEAKED past the fast-path:
      in:  "api_key=[redacted-secret]actualcredential"
      out: "api_key=[redacted-secret]actualcredential"
--- FAIL: …/bare_redacted_marker/impostor_is_redacted
      in:  "api_key=[redacted]actualcredential"
      out: "api_key=[redacted]actualcredential"
```

and after the fix `api_key=[redacted-secret]actualcredential` → `api_key=[redacted-secret]`, tail gone.

**Known boundary of the bare grammar** (pre-existing, stated rather than glossed): a bare value stops at `,` / `}` / a quote, so a bare, *unquoted* value containing one of those is only partially matched. In the grammars this redactor handles, such values are quoted — and the quoted alternatives capture them whole. This is a property of the bare form, not of the fast-path.

## gh target (P2)

`--repo` now receives the fully-qualified `github.com/sachiniyer/agent-factory`. A hostless slug is resolved against `GH_HOST`, so on a GitHub Enterprise install the draft retargeted at the employer's tracker — and if that host carried a matching repo or mirror, `gh --web` **succeeded** there, so the browser fallback never ran and the bundle went with it. The host is now part of the constant. `githubIssueNewURL` was already absolute; it now derives its host from the same constant so the two cannot drift.
---

## The body-size invariant (the "measure, then mutate" class)

Three bugs in this PR were one shape:

1. collection errors written into the head **before** the budget was computed
2. the bundle path substituted **after** the body was measured
3. the final scrub expanding prose **after** the log tail had spent the budget

Each is *something changes the body after we decided it fits*. Patching them individually just moved the next one somewhere else, so this is fixed as an ordering, not as three checks.

**The invariant: nothing may change the body's encoded length after the budget is computed.**

`buildIssueDraft` enforces it by construction — this order **is** the invariant:

1. **Build** every piece.
2. **Scrub** every piece — head, foot, log, and the log chrome. Nothing reaches the body unscrubbed.
3. **Measure** the scrubbed pieces; hand the log tail the remainder.
4. **Concatenate.** No transformation runs over the finished body.

Step 2 before step 3 is what makes it structural rather than checked: there is no later pass left that *could* grow anything. The returned body is a **fixed point of the redactor** — scrubbing it again is a no-op — and the test asserts exactly that, alongside the cap.

This also folds in the redaction backstop rather than trading it away. The wholesale head/foot scrub covers the static template *and* every component, so an inline that forgets to scrub still cannot leak — it just runs before the measurement instead of after. The per-component scrubs stay, because they keep the per-section sub-budgets honest; that is free, since scrub is idempotent.

### Why the test sweeps

A single fixture could not reproduce this, and a test pinned to one shape would have passed against the broken ordering and proved nothing. Each collision grows the body by only a few bytes, while the fitted tail leaves anywhere from 0 to one full line of slack under the cap — so any one log shape overflows only by luck. The test sweeps log line lengths (60→260) so some shape lands flush against the cap, where the growth has nowhere to go, and asserts the sweep actually reached the boundary. Against the old ordering: **9 overflows, up to 6015/6000**. After: zero.

```
lineLen=132: encoded body is 6015 bytes, past the 6000 cap
lineLen=148: encoded body is 6004 bytes, past the 6000 cap
lineLen=194: encoded body is 6002 bytes, past the 6000 cap
```
