### PR TITLE
fix(reset): pause the autostart unit around the wipe

### DIFF
--- a/commands/reset.go
+++ b/commands/reset.go
@@ -141,6 +141,17 @@ func init() {
 		"Alias for --yes: skip the typed WIPE confirmation")
 }
 
+// Indirection points so reset tests can exercise runReset's daemon, autostart,
+// and tmux handling without signaling a real daemon, touching the host's
+// systemctl/launchctl unit, or killing real tmux sessions. autostartInstalledFn
+// (daemoncmd.go) is shared.
+var (
+	pauseAutostartUnitFn  = daemon.PauseAutostartUnit
+	resumeAutostartUnitFn = daemon.ResumeAutostartUnit
+	stopDaemonFn          = daemon.StopDaemon
+	cleanupTmuxSessionsFn = func() error { return tmux.CleanupSessions(cmdutil.MakeExecutor()) }
+)
+
 func runReset(cmd *cobra.Command, _ []string) error {
 	log.Initialize(false)
 	defer log.Close()
@@ -171,23 +182,56 @@ func runReset(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	// 4. Stop the daemon before touching its state on disk. StopDaemon only
-	//    finds daemons that wrote a PID file; a pre-1.0.69 daemon leaves none,
-	//    so only claim success when we actually stopped one (#937).
-	stopped, err := daemon.StopDaemon()
+	// 4. Stop the daemon before touching its state on disk — and keep it
+	//    stopped. StopDaemon alone is not enough when the autostart unit is
+	//    installed: the service manager relaunches a daemon that exits
+	//    uncleanly, and a daemon relaunched mid-wipe restores sessions from
+	//    the very records the wipe is deleting — re-spawning their tmux
+	//    sessions and hooks, and holding ghost instances with no storage
+	//    backing. Pause the unit first and resume it once the wipe is done;
+	//    the resumed unit starts the daemon again with the clean state, which
+	//    is the restart the summary promises. A pause failure only warns: the
+	//    wipe is the user's explicit, confirmed intent, and the pre-pause
+	//    behavior it degrades to is a narrow race, not a certain failure.
+	paused := false
+	if autostartInstalledFn() {
+		if err := pauseAutostartUnitFn(); err != nil {
+			fmt.Fprintf(out, "warning: could not pause the daemon autostart unit (%v) — if the daemon restarts mid-reset, re-run `af reset`\n", err)
+		} else {
+			paused = true
+			fmt.Fprintln(out, "Daemon autostart paused for the wipe")
+			defer func() {
+				if err := resumeAutostartUnitFn(); err != nil {
+					fmt.Fprintf(out, "warning: could not resume the daemon autostart unit (%v) — run `af daemon install` to re-arm it\n", err)
+					return
+				}
+				fmt.Fprintln(out, "Daemon autostart resumed")
+			}()
+		}
+	}
+
+	//    StopDaemon covers any daemon the unit did not own (ad hoc, or no unit
+	//    installed). It only finds daemons that wrote a PID file; a pre-1.0.69
+	//    daemon leaves none, so only claim success when we actually stopped
+	//    one (#937).
+	stopped, err := stopDaemonFn()
 	if err != nil {
 		return err
 	}
-	if stopped {
+	switch {
+	case stopped:
 		fmt.Fprintln(out, "daemon has been stopped")
-	} else {
+	case paused:
+		// The unit stop above already took the supervised daemon down; a
+		// no-op StopDaemon is the expected outcome, not a stray-daemon hint.
+	default:
 		fmt.Fprintln(out, "No managed daemon was stopped (no PID file, or the recorded process was already gone). "+
 			"If an old daemon is still running (e.g. one built from source as `agent-factory --daemon`), "+
 			"stop it with: pkill -f -- '--daemon'")
 	}
 
 	// 5. Clean up tmux sessions before deleting the records that name them.
-	if err := tmux.CleanupSessions(cmdutil.MakeExecutor()); err != nil {
+	if err := cleanupTmuxSessionsFn(); err != nil {
 		return fmt.Errorf("failed to cleanup tmux sessions: %w", err)
 	}
 	fmt.Fprintln(out, "Tmux sessions have been cleaned up")

--- a/commands/reset_test.go
+++ b/commands/reset_test.go
@@ -2,15 +2,19 @@ package commands
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/task"
+
+	"github.com/spf13/cobra"
 )
 
 func boolPtr(b bool) *bool { return &b }
@@ -514,6 +518,140 @@ func TestFactoryReset_ResilientPartialFailure(t *testing.T) {
 	}
 	if _, err := executeFactoryReset(plan2); err != nil {
 		t.Fatalf("re-run should complete cleanly, got: %v", err)
+	}
+}
+
+// stubResetDaemonHandling replaces runReset's daemon/tmux/autostart touchpoints
+// with recorders, restoring the production values on cleanup. It returns the
+// recorded event list. The resume recorder also captures whether the wipe had
+// already removed the seeded state file, so tests can pin the ordering
+// "resume runs only after the wipe" — the whole point of pausing.
+func stubResetDaemonHandling(t *testing.T, home string, installed bool, pauseErr error) *[]string {
+	t.Helper()
+	prevInstalled := autostartInstalledFn
+	prevPause := pauseAutostartUnitFn
+	prevResume := resumeAutostartUnitFn
+	prevStop := stopDaemonFn
+	prevTmux := cleanupTmuxSessionsFn
+	t.Cleanup(func() {
+		autostartInstalledFn = prevInstalled
+		pauseAutostartUnitFn = prevPause
+		resumeAutostartUnitFn = prevResume
+		stopDaemonFn = prevStop
+		cleanupTmuxSessionsFn = prevTmux
+	})
+
+	var events []string
+	stateFile := filepath.Join(home, config.StateFileName)
+	wiped := func() string {
+		if _, err := os.Stat(stateFile); os.IsNotExist(err) {
+			return "wiped"
+		}
+		return "unwiped"
+	}
+	autostartInstalledFn = func() bool { return installed }
+	pauseAutostartUnitFn = func() error {
+		events = append(events, "pause:"+wiped())
+		return pauseErr
+	}
+	resumeAutostartUnitFn = func() error {
+		events = append(events, "resume:"+wiped())
+		return nil
+	}
+	stopDaemonFn = func() (bool, error) {
+		events = append(events, "stop:"+wiped())
+		return false, nil
+	}
+	cleanupTmuxSessionsFn = func() error {
+		events = append(events, "tmux:"+wiped())
+		return nil
+	}
+	return &events
+}
+
+// runResetForTest runs runReset with the WIPE prompt force-bypassed against a
+// throwaway cobra command, returning its combined output.
+func runResetForTest(t *testing.T) string {
+	t.Helper()
+	prevForce := resetForceFlag
+	t.Cleanup(func() { resetForceFlag = prevForce })
+	resetForceFlag = true
+
+	var out strings.Builder
+	cmd := &cobra.Command{}
+	cmd.SetOut(&out)
+	if err := runReset(cmd, nil); err != nil {
+		t.Fatalf("runReset: %v\noutput:\n%s", err, out.String())
+	}
+	return out.String()
+}
+
+// TestFactoryReset_PausesAutostartAroundWipe pins the fix for the reset/
+// autostart race: the service manager relaunches a daemon that exits uncleanly,
+// and a daemon relaunched mid-wipe restores sessions from the very records the
+// wipe is deleting, ending up with ghost in-memory instances that have no
+// storage backing. The unit must be paused BEFORE the daemon stop and resumed
+// only AFTER the wipe has finished.
+func TestFactoryReset_PausesAutostartAroundWipe(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	t.Chdir(t.TempDir())
+	writeFile(t, filepath.Join(home, config.StateFileName), `{"schema_version":1}`)
+
+	events := stubResetDaemonHandling(t, home, true, nil)
+	out := runResetForTest(t)
+
+	want := []string{"pause:unwiped", "stop:unwiped", "tmux:unwiped", "resume:wiped"}
+	if !reflect.DeepEqual(*events, want) {
+		t.Errorf("daemon handling order = %v, want %v", *events, want)
+	}
+	// The unit stop already took the supervised daemon down, so the "no managed
+	// daemon" hint (with its pkill suggestion) would be noise here.
+	if strings.Contains(out, "No managed daemon was stopped") {
+		t.Errorf("paused-unit reset must not print the no-managed-daemon hint, got:\n%s", out)
+	}
+}
+
+func TestFactoryReset_NoAutostartUnitInstalled(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	t.Chdir(t.TempDir())
+	writeFile(t, filepath.Join(home, config.StateFileName), `{"schema_version":1}`)
+
+	events := stubResetDaemonHandling(t, home, false, nil)
+	out := runResetForTest(t)
+
+	want := []string{"stop:unwiped", "tmux:unwiped"}
+	if !reflect.DeepEqual(*events, want) {
+		t.Errorf("daemon handling order = %v, want %v", *events, want)
+	}
+	if !strings.Contains(out, "No managed daemon was stopped") {
+		t.Errorf("without a unit, a no-op stop must keep the no-managed-daemon hint, got:\n%s", out)
+	}
+}
+
+// A pause failure must not abort the reset (the wipe is the user's explicit,
+// confirmed intent), must warn, and must not attempt a resume of a unit that
+// was never paused.
+func TestFactoryReset_PauseFailureWarnsAndWipes(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	t.Chdir(t.TempDir())
+	stateFile := filepath.Join(home, config.StateFileName)
+	writeFile(t, stateFile, `{"schema_version":1}`)
+
+	events := stubResetDaemonHandling(t, home, true, errors.New("launchctl went sideways"))
+	out := runResetForTest(t)
+
+	want := []string{"pause:unwiped", "stop:unwiped", "tmux:unwiped"}
+	if !reflect.DeepEqual(*events, want) {
+		t.Errorf("daemon handling order = %v, want %v", *events, want)
+	}
+	if !strings.Contains(out, "launchctl went sideways") {
+		t.Errorf("pause failure must be surfaced as a warning, got:\n%s", out)
+	}
+	if _, err := os.Stat(stateFile); !os.IsNotExist(err) {
+		t.Errorf("wipe must proceed despite a pause failure; %s still exists", stateFile)
 	}
 }
 

--- a/daemon/autostart.go
+++ b/daemon/autostart.go
@@ -318,6 +318,61 @@ func RestartAutostartUnit() error {
 	}
 }
 
+// PauseAutostartUnit stops the daemon autostart unit — `systemctl --user stop`
+// on Linux, `launchctl unload` on macOS — WITHOUT uninstalling it, so the
+// service manager cannot (re)launch the daemon until ResumeAutostartUnit.
+// Stopping the unit also stops the supervised daemon itself. `af reset` wraps
+// its wipe in this pair: the unit relaunches a daemon that exits uncleanly,
+// and a daemon relaunched mid-wipe restores sessions from the very records
+// the wipe is deleting, ending up holding ghost instances with no storage
+// backing.
+func PauseAutostartUnit() error {
+	switch autostartGOOS {
+	case "linux":
+		if out, err := autostartUnitCommand("systemctl", "--user", "stop", autostartUnitName); err != nil {
+			return fmt.Errorf("systemctl --user stop %s failed: %w\n%s", autostartUnitName, err, strings.TrimSpace(string(out)))
+		}
+		return nil
+	case "darwin":
+		dir, err := autostartLaunchAgentsDir()
+		if err != nil {
+			return fmt.Errorf("failed to resolve LaunchAgents directory: %w", err)
+		}
+		plistPath := filepath.Join(dir, autostartLaunchdLabel+".plist")
+		if out, err := autostartUnitCommand("launchctl", "unload", plistPath); err != nil {
+			return fmt.Errorf("launchctl unload %s failed: %w\n%s", plistPath, err, strings.TrimSpace(string(out)))
+		}
+		return nil
+	default:
+		return fmt.Errorf("daemon autostart is not supported on %s", autostartGOOS)
+	}
+}
+
+// ResumeAutostartUnit re-arms the unit PauseAutostartUnit stopped — `systemctl
+// --user start` on Linux, `launchctl load` on macOS — which also starts the
+// daemon again (the launchd agent is RunAtLoad).
+func ResumeAutostartUnit() error {
+	switch autostartGOOS {
+	case "linux":
+		if out, err := autostartUnitCommand("systemctl", "--user", "start", autostartUnitName); err != nil {
+			return fmt.Errorf("systemctl --user start %s failed: %w\n%s", autostartUnitName, err, strings.TrimSpace(string(out)))
+		}
+		return nil
+	case "darwin":
+		dir, err := autostartLaunchAgentsDir()
+		if err != nil {
+			return fmt.Errorf("failed to resolve LaunchAgents directory: %w", err)
+		}
+		plistPath := filepath.Join(dir, autostartLaunchdLabel+".plist")
+		if out, err := autostartUnitCommand("launchctl", "load", plistPath); err != nil {
+			return fmt.Errorf("launchctl load %s failed: %w\n%s", plistPath, err, strings.TrimSpace(string(out)))
+		}
+		return nil
+	default:
+		return fmt.Errorf("daemon autostart is not supported on %s", autostartGOOS)
+	}
+}
+
 // UninstallAutostart removes the daemon autostart unit installed by
 // InstallAutostart. The daemon itself keeps running until it exits or is
 // stopped; it just no longer restarts at login. Returns the path of the

--- a/daemon/autostart_pause_test.go
+++ b/daemon/autostart_pause_test.go
@@ -1,0 +1,92 @@
+package daemon
+
+import (
+	"errors"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// Tests for the pause/resume pair `af reset` wraps around its wipe so the
+// service manager cannot relaunch the daemon mid-wipe. Exercised against the
+// injected GOOS/unit-dir/command-runner from autostart_restart_test.go — they
+// must never touch the host's real systemctl/launchctl unit.
+
+func TestPauseAndResumeAutostartUnitLinux(t *testing.T) {
+	withAutostartTestEnv(t, "linux")
+	calls := stubAutostartUnitCommand(t, nil)
+
+	if err := PauseAutostartUnit(); err != nil {
+		t.Fatalf("PauseAutostartUnit: %v", err)
+	}
+	if err := ResumeAutostartUnit(); err != nil {
+		t.Fatalf("ResumeAutostartUnit: %v", err)
+	}
+
+	want := [][]string{
+		{"systemctl", "--user", "stop", autostartUnitName},
+		{"systemctl", "--user", "start", autostartUnitName},
+	}
+	if !reflect.DeepEqual(*calls, want) {
+		t.Errorf("unit commands = %v, want %v", *calls, want)
+	}
+}
+
+func TestPauseAndResumeAutostartUnitDarwin(t *testing.T) {
+	dir := withAutostartTestEnv(t, "darwin")
+	calls := stubAutostartUnitCommand(t, nil)
+
+	if err := PauseAutostartUnit(); err != nil {
+		t.Fatalf("PauseAutostartUnit: %v", err)
+	}
+	if err := ResumeAutostartUnit(); err != nil {
+		t.Fatalf("ResumeAutostartUnit: %v", err)
+	}
+
+	plist := filepath.Join(dir, autostartLaunchdLabel+".plist")
+	want := [][]string{
+		{"launchctl", "unload", plist},
+		{"launchctl", "load", plist},
+	}
+	if !reflect.DeepEqual(*calls, want) {
+		t.Errorf("unit commands = %v, want %v", *calls, want)
+	}
+}
+
+// A failing service-manager call must surface its captured output in the
+// returned error so the reset warning tells the user what actually failed.
+func TestPauseAndResumeAutostartUnitSurfaceCommandFailure(t *testing.T) {
+	for _, goos := range []string{"linux", "darwin"} {
+		withAutostartTestEnv(t, goos)
+		stubAutostartUnitCommand(t, errors.New("boom"))
+
+		for name, fn := range map[string]func() error{
+			"PauseAutostartUnit":  PauseAutostartUnit,
+			"ResumeAutostartUnit": ResumeAutostartUnit,
+		} {
+			err := fn()
+			if err == nil {
+				t.Fatalf("%s on %s: expected error, got nil", name, goos)
+			}
+			if !strings.Contains(err.Error(), "unit failure detail") {
+				t.Errorf("%s on %s: error %q does not surface the command output", name, goos, err)
+			}
+		}
+	}
+}
+
+func TestPauseAndResumeAutostartUnitUnsupportedGOOS(t *testing.T) {
+	withAutostartTestEnv(t, "windows")
+	calls := stubAutostartUnitCommand(t, nil)
+
+	if err := PauseAutostartUnit(); err == nil {
+		t.Error("PauseAutostartUnit: expected unsupported-platform error, got nil")
+	}
+	if err := ResumeAutostartUnit(); err == nil {
+		t.Error("ResumeAutostartUnit: expected unsupported-platform error, got nil")
+	}
+	if len(*calls) != 0 {
+		t.Errorf("no unit commands expected on an unsupported platform, got %v", *calls)
+	}
+}


### PR DESCRIPTION
## Problem

`af reset` stops the daemon and then wipes AF state — but the autostart unit (launchd `KeepAlive`/`SuccessfulExit=false`, systemd `Restart=on-failure`) relaunches a daemon that exited uncleanly. A daemon relaunched mid-wipe restores sessions from the very records the wipe is deleting: it re-spawns their tmux sessions, re-runs post-worktree hooks, and is left holding ghost in-memory instances with no storage backing, logging

```
daemon preserving in-memory instances for missing repo directory: <repoID>
```

every poll, and `failed to persist status for "<title>": instance not found in storage`. Sessions in that state cannot be durably deleted from the TUI.

Observed in the wild (2026-07-16, v1.0.192): `af reset`'s StopDaemon escalated to SIGKILL (the daemon was wedged in a kill teardown — separate bug), launchd relaunched the daemon **2 seconds later**, and the relaunched daemon re-spawned a session and ran `git pull`/`npm ci` hooks while the wipe was deleting its records. The ghost-instance warning then fired once a second for 15 minutes.

## Fix

- New `daemon.PauseAutostartUnit` / `daemon.ResumeAutostartUnit`: stop/start the unit without uninstalling it — `systemctl --user stop|start` on Linux, `launchctl unload|load` on macOS.
- `runReset` pauses the unit before stopping the daemon and resumes it (deferred, so every early-return path restores supervision) once the wipe is done. The resumed unit starts the daemon again against the clean post-reset state — the restart the reset summary has always promised.
- A pause failure only warns and the wipe proceeds: the wipe is the user's explicit, typed-WIPE intent, and the degraded behavior is the pre-fix narrow race, not a certain failure.
- When the unit was paused, the "No managed daemon was stopped … pkill" hint is suppressed: the unit stop already took the supervised daemon down, so a no-op StopDaemon is the expected outcome there, not a stray-daemon signal.

## Tests

- `daemon/autostart_pause_test.go`: pause/resume issue exactly the right service-manager commands per platform (against the injected runner from `autostart_restart_test.go`), surface command output in errors, and error on unsupported platforms without invoking anything.
- `commands/reset_test.go`: `runReset` ordering is pinned — pause **before** the daemon stop, resume only **after** the wipe has removed state (verified by the resume stub observing the wiped state file); no pause/resume when no unit is installed (hint retained); a pause failure warns, skips the resume, and still wipes.

Validation: `go build ./...`, `gofmt -l` clean, `golangci-lint` (CI-pinned v1.64.8 invocation) clean, `deadcode -test` clean, full suite via `make test-container`.

— Captain Claude
