### PR TITLE
fix(reset): stop ALL af daemons + clear stale sockets on factory reset

### DIFF
--- a/commands/reset.go
+++ b/commands/reset.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	cmdutil "github.com/sachiniyer/agent-factory/cmd"
@@ -42,8 +43,13 @@ var resetForceFlag bool
 //     re-register from config on the next start).
 //   - repos/ — per-repo config (e.g. remote_hooks provisioner commands), which
 //     is user configuration, not session state.
-//   - daemon.pid/sock, daemon-token, daemon-tls.* — daemon runtime identity;
-//     wiping them would needlessly break already-configured remote clients.
+//   - daemon-token, daemon-tls.* — daemon runtime IDENTITY; wiping it would
+//     needlessly break already-configured remote clients.
+//
+// The daemon SOCKETS are not listed here but are still removed — in runReset,
+// not this list. They are ORDERED, not unordered: they may only be unlinked
+// once every daemon is stopped (#767), whereas everything in this list can be
+// removed at any point in the wipe.
 //
 // NOTE: "archived" is deliberately NOT here — archived worktrees are removed
 // per-repo (removeArchivedDirs) so a preserved (corrupt/unreadable) record is
@@ -122,6 +128,13 @@ Removes every AF-created resource — all sessions (live and archived), all
 scheduled cron/watch tasks, all AF worktrees, the AF session branches AF
 created, and all stored state — returning AF to a clean slate.
 
+Stops every af daemon running for this AF home — the managed one and any
+orphan left behind by an upgrade or a source build — and removes the daemon
+sockets, so a stale daemon or socket cannot serve the next af you start. Only
+daemons owned by you AND using this AGENT_FACTORY_HOME are stopped, and the
+autostart unit is only paused when it serves this AGENT_FACTORY_HOME; a daemon
+or unit for a different AF home is never touched.
+
 KEEPS your real git repositories (working tree, .git, and your own branches),
 and KEEPS the daemon configuration (config.toml: listen_addr, defaults,
 root_agents, update_channel, and per-repo config). After the wipe the
@@ -146,13 +159,17 @@ func init() {
 // systemctl/launchctl unit, or killing real tmux sessions. autostartInstalledFn
 // (daemoncmd.go) is shared.
 var (
-	pauseAutostartUnitFn  = daemon.PauseAutostartUnit
-	resumeAutostartUnitFn = daemon.ResumeAutostartUnit
-	stopDaemonFn          = daemon.StopDaemon
-	cleanupTmuxSessionsFn = func() error { return tmux.CleanupSessions(cmdutil.MakeExecutor()) }
+	pauseAutostartUnitFn      = daemon.PauseAutostartUnit
+	resumeAutostartUnitFn     = daemon.ResumeAutostartUnit
+	autostartUnitServesHomeFn = daemon.AutostartUnitServesHome
+	stopDaemonFn              = daemon.StopDaemon
+	stopOrphanDaemonsFn       = daemon.StopOrphanDaemons
+	assertNoLiveDaemonFn      = daemon.AssertNoLiveDaemon
+	removeRuntimeSocketFn     = daemon.RemoveRuntimeSockets
+	cleanupTmuxSessionsFn     = func() error { return tmux.CleanupSessions(cmdutil.MakeExecutor()) }
 )
 
-func runReset(cmd *cobra.Command, _ []string) error {
+func runReset(cmd *cobra.Command, _ []string) (err error) {
 	log.Initialize(false)
 	defer log.Close()
 
@@ -193,30 +210,25 @@ func runReset(cmd *cobra.Command, _ []string) error {
 	//    is the restart the summary promises. A pause failure only warns: the
 	//    wipe is the user's explicit, confirmed intent, and the pre-pause
 	//    behavior it degrades to is a narrow race, not a certain failure.
-	paused := false
-	if autostartInstalledFn() {
-		if err := pauseAutostartUnitFn(); err != nil {
-			fmt.Fprintf(out, "warning: could not pause the daemon autostart unit (%v) — if the daemon restarts mid-reset, re-run `af reset`\n", err)
-		} else {
-			paused = true
-			fmt.Fprintln(out, "Daemon autostart paused for the wipe")
-			defer func() {
-				if err := resumeAutostartUnitFn(); err != nil {
-					fmt.Fprintf(out, "warning: could not resume the daemon autostart unit (%v) — run `af daemon install` to re-arm it\n", err)
-					return
-				}
-				fmt.Fprintln(out, "Daemon autostart resumed")
-			}()
-		}
+	//
+	//    The unit is only ever touched when it serves THE HOME BEING RESET.
+	//    Gating on "a unit file exists" would make a reset of a throwaway
+	//    AGENT_FACTORY_HOME stop the developer's real daemon, because the unit
+	//    bakes its own home at install time and has nothing to do with ours.
+	paused, resumeUnit := pauseAutostartForReset(out, plan.configDir)
+	if paused {
+		// Deferred so the unit is re-armed on EVERY exit — including the abort
+		// below. A reset that bails must leave the machine as it found it.
+		defer resumeUnit(&err)
 	}
 
 	//    StopDaemon covers any daemon the unit did not own (ad hoc, or no unit
 	//    installed). It only finds daemons that wrote a PID file; a pre-1.0.69
 	//    daemon leaves none, so only claim success when we actually stopped
 	//    one (#937).
-	stopped, err := stopDaemonFn()
-	if err != nil {
-		return err
+	stopped, stopErr := stopDaemonFn()
+	if stopErr != nil {
+		return stopErr
 	}
 	switch {
 	case stopped:
@@ -225,9 +237,62 @@ func runReset(cmd *cobra.Command, _ []string) error {
 		// The unit stop above already took the supervised daemon down; a
 		// no-op StopDaemon is the expected outcome, not a stray-daemon hint.
 	default:
-		fmt.Fprintln(out, "No managed daemon was stopped (no PID file, or the recorded process was already gone). "+
-			"If an old daemon is still running (e.g. one built from source as `agent-factory --daemon`), "+
-			"stop it with: pkill -f -- '--daemon'")
+		fmt.Fprintln(out, "No managed daemon was stopped (no PID file, or the recorded process was already gone)")
+	}
+
+	// 4b. Wait for the shutdown to COMPLETE, not merely to be requested. The
+	//     daemon persists its whole in-memory session set on the way out
+	//     (RunDaemon's final SaveInstances) and only closes the control socket
+	//     afterwards, on the deferred teardown — so a socket that still answers
+	//     is a daemon that may still flush. Deleting instances.json while that
+	//     is pending is how a "factory reset" hands the user their sessions
+	//     back.
+	if waitErr := waitForShutdownCompletionFn(); waitErr != nil {
+		err = fmt.Errorf("the daemon did not finish shutting down: %w", waitErr)
+		fmt.Fprintln(out, "\nNothing was removed.")
+		return err
+	}
+
+	// 4c. Stop daemons the PID file never knew about — the leftover old binary
+	//     after an upgrade, a second daemon that lost the singleton race, a
+	//     source-built `agent-factory --daemon`. Scoped to this uid AND this
+	//     home, for the same reason the unit is: a reset of one home must never
+	//     stop another home's daemon.
+	stoppedPIDs, unverified, orphanErr := stopOrphanDaemonsFn(plan.configDir)
+	if orphanErr != nil {
+		fmt.Fprintf(out, "Some daemons could not be stopped (%v).\n", orphanErr)
+	}
+	if len(stoppedPIDs) > 0 {
+		fmt.Fprintf(out, "Stopped %d additional af daemon(s) for this AF home: %s\n",
+			len(stoppedPIDs), formatPIDs(stoppedPIDs))
+	}
+	if len(unverified) > 0 {
+		// Never signaled: we could not prove these serve THIS home, and a reset
+		// must not kill another home's daemon. Name them so the user can act.
+		fmt.Fprintf(out, "Left %d af daemon process(es) running because their AF home could not be verified: %s\n",
+			len(unverified), formatPIDs(unverified))
+	}
+
+	// 4d. Prove the field is clear. Everything above reports rather than fails;
+	//     THIS is the gate. The daemon is the single writer (#960), so a wipe
+	//     that races one does not half-work — the daemon re-persists from memory
+	//     and the reset silently undoes itself. Aborting costs the user one
+	//     command; guessing costs them a half-wiped home.
+	if assertErr := assertNoLiveDaemonFn(plan.configDir); assertErr != nil {
+		err = fmt.Errorf("refusing to wipe: %w", assertErr)
+		fmt.Fprintln(out, "\nNothing was removed.")
+		return err
+	}
+
+	// 4e. Sockets, now that nothing is left to be serving them. A socket that
+	//     outlives its daemon points the next client at a dead endpoint; but
+	//     unlinking a LIVE daemon's socket is the #767 failure, which the assert
+	//     above has just ruled out.
+	switch removed, sockErr := removeRuntimeSocketFn(plan.configDir); {
+	case sockErr != nil:
+		fmt.Fprintf(out, "Could not remove the daemon sockets (%v).\n", sockErr)
+	case len(removed) > 0:
+		fmt.Fprintf(out, "Removed %d stale daemon socket(s): %s\n", len(removed), strings.Join(removed, ", "))
 	}
 
 	// 5. Clean up tmux sessions before deleting the records that name them.
@@ -250,6 +315,86 @@ func runReset(cmd *cobra.Command, _ []string) error {
 		return resetErr
 	}
 	return nil
+}
+
+// autostartResumeAttempts is how many times a resume is retried before the
+// reset gives up and shouts. A pause that is never resumed leaves a REAL daemon
+// stopped — the supervisor will not bring it back until the next login — so one
+// failed systemctl call must not be the end of the story.
+const autostartResumeAttempts = 3
+
+// pauseAutostartForReset stops the autostart unit for the duration of the wipe,
+// but ONLY when that unit serves configDir — the home actually being reset.
+//
+// The gate is the point (#1916 P2). The unit bakes its AGENT_FACTORY_HOME at
+// install time, so it has no relationship to the AGENT_FACTORY_HOME the current
+// process carries. Pausing on "a unit file exists" means
+// `AGENT_FACTORY_HOME=/tmp/sandbox af reset` reaches out and stops the
+// developer's real daemon — a reset of a throwaway home taking down a live one
+// it was never asked to touch. Same bug class as signalling a daemon without
+// checking whose home it serves; both are gated the same way here.
+//
+// Returns whether the unit was paused, and the resume to defer.
+func pauseAutostartForReset(out io.Writer, configDir string) (bool, func(*error)) {
+	noop := func(*error) {}
+	if !autostartInstalledFn() {
+		return false, noop
+	}
+
+	serves, _, err := autostartUnitServesHomeFn(configDir)
+	if err != nil {
+		// Cannot tell whose unit it is → do not touch it. Same rule as an
+		// unverifiable daemon: "I could not tell" never resolves to "stop it".
+		fmt.Fprintf(out, "warning: could not determine which AF home the autostart unit serves (%v); "+
+			"leaving it alone. If a supervised daemon for this home restarts mid-reset, re-run `af reset`\n", err)
+		return false, noop
+	}
+	if !serves {
+		fmt.Fprintln(out, "Autostart unit serves a different AF home — leaving it running")
+		return false, noop
+	}
+
+	if err := pauseAutostartUnitFn(); err != nil {
+		fmt.Fprintf(out, "warning: could not pause the daemon autostart unit (%v) — if the daemon restarts mid-reset, re-run `af reset`\n", err)
+		return false, noop
+	}
+	fmt.Fprintln(out, "Daemon autostart paused for the wipe")
+
+	return true, func(errp *error) {
+		var lastErr error
+		for i := 0; i < autostartResumeAttempts; i++ {
+			if lastErr = resumeAutostartUnitFn(); lastErr == nil {
+				fmt.Fprintln(out, "Daemon autostart resumed")
+				return
+			}
+		}
+		// We stopped a real, supervised daemon and could not start it back.
+		// Saying this quietly would leave the user's daemon down until their
+		// next login with only a warning line to explain it, so it is loud AND
+		// it fails the command: a scripted caller must see a non-zero exit.
+		fmt.Fprintf(out, "\nACTION REQUIRED: the daemon autostart unit was paused for the wipe and could NOT be "+
+			"resumed after %d attempts (%v).\nYour daemon is STOPPED. Run `systemctl --user start %s` "+
+			"(or `af daemon install`) to bring it back.\n", autostartResumeAttempts, lastErr, daemonUnitName)
+		if errp != nil && *errp == nil {
+			*errp = fmt.Errorf("the daemon autostart unit was paused but could not be resumed: %w", lastErr)
+		}
+	}
+}
+
+// daemonUnitName is the systemd unit the resume hint names. It is duplicated
+// from the daemon package rather than exported: the string is user-facing copy
+// in a recovery hint, not a contract between the packages.
+const daemonUnitName = "agent-factory-daemon.service"
+
+// formatPIDs renders PIDs for the reset's user-facing report. Reset prints the
+// PIDs it signalled rather than a count alone: it is the only record the user
+// has of what an irreversible command did to their process table.
+func formatPIDs(pids []int) string {
+	parts := make([]string, len(pids))
+	for i, p := range pids {
+		parts[i] = strconv.Itoa(p)
+	}
+	return strings.Join(parts, ", ")
 }
 
 // resetConfirmed decides whether the destructive wipe may proceed.

--- a/commands/reset_daemon_test.go
+++ b/commands/reset_daemon_test.go
@@ -1,0 +1,463 @@
+package commands
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/daemon"
+
+	"github.com/spf13/cobra"
+)
+
+// These tests cover the ordering contract of a factory reset — that the daemon
+// is provably gone before a single byte of state is deleted, and that the
+// autostart supervisor is disarmed before anything is signalled.
+//
+// EVERY destructive boundary is faked. Nothing here starts, signals, or scans
+// for a real daemon, and nothing touches the real tmux server or the real AF
+// home: the daemon scan is host-wide and the teardown is destructive, so a test
+// that exercised the real thing would stop the developer's own daemon and bounce
+// their live sessions. The seams in reset.go exist for this reason. If you add a
+// case here, fake the boundary — never reach for the real one.
+
+// daemonFlushDelay is how long the fake daemon takes to reach its final
+// SaveInstances after acknowledging the stop. It models the real gap the wait
+// exists to cover; the tests synchronise on the flush rather than sleeping for
+// it, so the delay only has to be long enough that a wipe which does NOT wait
+// would win the race and be caught.
+const daemonFlushDelay = 150 * time.Millisecond
+
+// fakeDaemonSeams neutralises every daemon/tmux boundary of the reset, so a
+// test opts IN to the behaviour it wants to model rather than inheriting a live
+// one. Restoration is automatic.
+func fakeDaemonSeams(t *testing.T) {
+	t.Helper()
+	origInstalled := autostartInstalledFn
+	origServes := autostartUnitServesHomeFn
+	origPause := pauseAutostartUnitFn
+	origResume := resumeAutostartUnitFn
+	origStop := stopDaemonFn
+	origWait := waitForShutdownCompletionFn
+	origOrphans := stopOrphanDaemonsFn
+	origAssert := assertNoLiveDaemonFn
+	origSockets := removeRuntimeSocketFn
+	origTmux := cleanupTmuxSessionsFn
+	origForce := resetForceFlag
+	t.Cleanup(func() {
+		autostartInstalledFn = origInstalled
+		autostartUnitServesHomeFn = origServes
+		pauseAutostartUnitFn = origPause
+		resumeAutostartUnitFn = origResume
+		stopDaemonFn = origStop
+		waitForShutdownCompletionFn = origWait
+		stopOrphanDaemonsFn = origOrphans
+		assertNoLiveDaemonFn = origAssert
+		removeRuntimeSocketFn = origSockets
+		cleanupTmuxSessionsFn = origTmux
+		resetForceFlag = origForce
+	})
+
+	// Default to "no unit installed" so a test that forgets to say otherwise
+	// can never reach the real systemctl/launchctl.
+	autostartInstalledFn = func() bool { return false }
+	autostartUnitServesHomeFn = func(string) (bool, bool, error) { return false, false, nil }
+	pauseAutostartUnitFn = func() error { t.Fatal("pauseAutostartUnitFn called without a fake"); return nil }
+	resumeAutostartUnitFn = func() error { t.Fatal("resumeAutostartUnitFn called without a fake"); return nil }
+	stopDaemonFn = func() (bool, error) { return false, nil }
+	waitForShutdownCompletionFn = func() error { return nil }
+	stopOrphanDaemonsFn = func(string) ([]int, []int, error) { return nil, nil, nil }
+	assertNoLiveDaemonFn = func(string) error { return nil }
+	removeRuntimeSocketFn = func(string) ([]string, error) { return nil, nil }
+	cleanupTmuxSessionsFn = func() error { return nil }
+	// The typed-WIPE gate is covered by TestResetConfirmed; bypass it here so
+	// these tests exercise the teardown order rather than the prompt.
+	resetForceFlag = true
+}
+
+// runResetCapture drives the real runReset and returns its output AND error.
+// reset_test.go's runResetForTest fatals on error; the abort paths here are the
+// behaviour under test, so they need the error back.
+func runResetCapture(t *testing.T) (string, error) {
+	t.Helper()
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&buf)
+	err := runReset(cmd, nil)
+	return buf.String(), err
+}
+
+// seedResetHome builds a throwaway AF home with a mock repo and AF records, and
+// returns the home plus the path of the instances file the daemon would flush.
+// resetHomeUnderTest is the AF home the most recent seedResetHome created, so a
+// test can assert the reset scoped its daemon work to exactly that home.
+var resetHomeUnderTest string
+
+func seedResetHome(t *testing.T) (home, instancesPath string) {
+	t.Helper()
+	home = t.TempDir()
+	resetHomeUnderTest = home
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	// Keep the wipe scoped to the seeded mock repo, never the repo the test
+	// binary runs from (mirrors TestFactoryReset_WipesEverythingKeepsRepoAndConfig).
+	t.Chdir(t.TempDir())
+
+	repo, liveWT, reusedWT := seedMockRepo(t, home)
+	seedAFState(t, home, repo, liveWT, reusedWT)
+	repoID := config.RepoIDFromRoot(repo)
+	return home, filepath.Join(home, "instances", repoID, "instances.json")
+}
+
+// TestFactoryReset_WaitsForDaemonFlushBeforeWipe is the regression lock for the
+// resurrection race: the daemon is the single writer (#960) and persists its
+// whole in-memory session set on the way out (RunDaemon's final SaveInstances),
+// so a reset that deletes instances.json while that flush is still pending gets
+// the old sessions written straight back — a "factory reset" that hands the user
+// their sessions back.
+//
+// The fake models the real shutdown shape: the stop is acknowledged
+// immediately, the flush lands a moment later, and the control socket only
+// stops answering afterwards (RunDaemon closes the listener on its deferred
+// teardown, AFTER SaveInstances — which is exactly why waiting on the socket is
+// a sufficient barrier for the flush).
+//
+// To watch it fail: delete the waitForShutdownCompletionFn call from
+// stopDaemonsForReset. The wipe then runs before the flush, the flush recreates
+// instances.json, and this test catches it.
+func TestFactoryReset_WaitsForDaemonFlushBeforeWipe(t *testing.T) {
+	_, instancesPath := seedResetHome(t)
+
+	// What the daemon is holding in memory and will write back out.
+	flushBytes, err := os.ReadFile(instancesPath)
+	if err != nil {
+		t.Fatalf("read seeded instances: %v", err)
+	}
+
+	fakeDaemonSeams(t)
+	flushed := make(chan struct{})
+	stopDaemonFn = func() (bool, error) {
+		go func() {
+			defer close(flushed)
+			time.Sleep(daemonFlushDelay)
+			if err := os.MkdirAll(filepath.Dir(instancesPath), 0o700); err != nil {
+				return
+			}
+			_ = os.WriteFile(instancesPath, flushBytes, 0o600)
+		}()
+		return true, nil // signal delivered; the process has NOT exited yet
+	}
+	waitForShutdownCompletionFn = func() error {
+		select {
+		case <-flushed:
+			return nil
+		case <-time.After(10 * time.Second):
+			return errors.New("fake daemon never finished shutting down")
+		}
+	}
+
+	if _, err := runResetCapture(t); err != nil {
+		t.Fatalf("runReset: %v", err)
+	}
+
+	// Sync on the flush so the assertion is about ordering, not timing: by here
+	// the daemon has definitely written whatever it was going to write.
+	select {
+	case <-flushed:
+	case <-time.After(10 * time.Second):
+		t.Fatal("fake daemon flush never ran")
+	}
+
+	if _, err := os.Stat(instancesPath); !os.IsNotExist(err) {
+		t.Fatalf("instances.json is back at %s after the reset (err=%v): the wipe ran before the "+
+			"daemon's shutdown flush, so the daemon resurrected the sessions the reset deleted",
+			instancesPath, err)
+	}
+}
+
+// TestFactoryReset_DisarmsSupervisorBeforeStoppingDaemons locks vector B: the
+// autostart supervisor respawns a daemon that dies badly (systemd
+// Restart=on-failure on the SIGKILL escalation; launchd KeepAlive on any death
+// by signal). If reset signals daemons before stopping the unit, the supervisor
+// can start a fresh daemon into the middle of the wipe, which then re-persists
+// the state being deleted. Stopping the unit FIRST is what closes that window,
+// and supervision must be handed back afterwards.
+func TestFactoryReset_DisarmsSupervisorBeforeStoppingDaemons(t *testing.T) {
+	seedResetHome(t)
+	fakeDaemonSeams(t)
+
+	var order []string
+	autostartInstalledFn = func() bool { return true }
+	pauseAutostartUnitFn = func() error { order = append(order, "pause-unit"); return nil }
+	resumeAutostartUnitFn = func() error { order = append(order, "resume-unit"); return nil }
+	stopDaemonFn = func() (bool, error) { order = append(order, "stop-daemon"); return true, nil }
+	autostartUnitServesHomeFn = func(string) (bool, bool, error) { return true, true, nil }
+	stopOrphanDaemonsFn = func(string) ([]int, []int, error) {
+		order = append(order, "stop-orphans")
+		return []int{4242}, nil, nil
+	}
+	assertNoLiveDaemonFn = func(string) error { order = append(order, "assert-clear"); return nil }
+	removeRuntimeSocketFn = func(string) ([]string, error) { order = append(order, "sockets"); return nil, nil }
+
+	out, err := runResetCapture(t)
+	if err != nil {
+		t.Fatalf("runReset: %v", err)
+	}
+
+	want := []string{"pause-unit", "stop-daemon", "stop-orphans", "assert-clear", "sockets", "resume-unit"}
+	if strings.Join(order, ",") != strings.Join(want, ",") {
+		t.Errorf("teardown order = %v, want %v", order, want)
+	}
+	// The PIDs reset signalled are the only record the user has of what an
+	// irreversible command did to their process table.
+	if !strings.Contains(out, "4242") {
+		t.Errorf("reset output does not name the stopped daemon PID 4242:\n%s", out)
+	}
+}
+
+// TestFactoryReset_AbortsWhenShutdownDoesNotComplete covers the daemon that
+// refuses to exit within the grace. Wiping under a live single-writer daemon
+// does not half-work — the daemon wins and re-persists — so an unprovable
+// shutdown must abort rather than delete. Aborting costs the user one command;
+// guessing costs them a half-wiped home.
+func TestFactoryReset_AbortsWhenShutdownDoesNotComplete(t *testing.T) {
+	_, instancesPath := seedResetHome(t)
+	fakeDaemonSeams(t)
+
+	stopDaemonFn = func() (bool, error) { return true, nil }
+	waitForShutdownCompletionFn = func() error {
+		return errors.New("daemon control socket still answering 5s after shutdown was acknowledged")
+	}
+	wiped := false
+	removeRuntimeSocketFn = func(string) ([]string, error) { wiped = true; return nil, nil }
+
+	out, err := runResetCapture(t)
+	if err == nil {
+		t.Fatal("runReset returned nil; want an abort when the daemon has not finished shutting down")
+	}
+	if !strings.Contains(err.Error(), "did not finish shutting down") {
+		t.Errorf("abort error = %v, want it to name the incomplete shutdown", err)
+	}
+	if wiped {
+		t.Error("reset removed sockets after failing to confirm the daemon was gone")
+	}
+	if _, statErr := os.Stat(instancesPath); statErr != nil {
+		t.Errorf("instances.json was touched by an aborted reset: %v", statErr)
+	}
+	if !strings.Contains(out, "Nothing was removed") {
+		t.Errorf("aborted reset did not tell the user nothing was removed:\n%s", out)
+	}
+}
+
+// TestFactoryReset_AbortsWhenDaemonStillRunning covers the final gate: a daemon
+// that survived every stop above (a supervisor we could not disarm respawned
+// one, or an orphan refused to die). The reset must abort with the PIDs named —
+// and must hand supervision back, because an aborted reset has to leave the
+// machine exactly as it found it.
+func TestFactoryReset_AbortsWhenDaemonStillRunning(t *testing.T) {
+	_, instancesPath := seedResetHome(t)
+	fakeDaemonSeams(t)
+
+	autostartInstalledFn = func() bool { return true }
+	autostartUnitServesHomeFn = func(string) (bool, bool, error) { return true, true, nil }
+	pauseAutostartUnitFn = func() error { return nil }
+	resumed := false
+	resumeAutostartUnitFn = func() error { resumed = true; return nil }
+	assertNoLiveDaemonFn = func(string) error {
+		return errors.New("af daemon(s) still running for this AF home: 7777")
+	}
+	wiped := false
+	removeRuntimeSocketFn = func(string) ([]string, error) { wiped = true; return nil, nil }
+
+	_, err := runResetCapture(t)
+	if err == nil {
+		t.Fatal("runReset returned nil; want an abort while a daemon is still running")
+	}
+	if !strings.Contains(err.Error(), "refusing to wipe") || !strings.Contains(err.Error(), "7777") {
+		t.Errorf("abort error = %v, want it to refuse the wipe and name PID 7777", err)
+	}
+	if wiped {
+		t.Error("reset proceeded to the wipe with a daemon still running")
+	}
+	if _, statErr := os.Stat(instancesPath); statErr != nil {
+		t.Errorf("instances.json was touched by an aborted reset: %v", statErr)
+	}
+	if !resumed {
+		t.Error("an aborted reset left the autostart unit paused; supervision must be handed back")
+	}
+}
+
+// TestFactoryReset_StopsUnverifiableDaemonsNever guards the scoping promise the
+// help text makes: a daemon whose AF home cannot be established is REPORTED,
+// never signalled. Killing another home's daemon would be a far worse bug than
+// the stale daemon reset is cleaning up, so "I could not tell" must resolve to
+// "leave it alone".
+func TestFactoryReset_StopsUnverifiableDaemonsNever(t *testing.T) {
+	seedResetHome(t)
+	fakeDaemonSeams(t)
+
+	stopOrphanDaemonsFn = func(string) ([]int, []int, error) {
+		return nil, []int{9191}, nil // one unverifiable daemon, none stopped
+	}
+
+	out, err := runResetCapture(t)
+	if err != nil {
+		t.Fatalf("runReset: %v", err)
+	}
+	if !strings.Contains(out, "9191") || !strings.Contains(out, "could not be verified") {
+		t.Errorf("reset did not report the unverifiable daemon it left running:\n%s", out)
+	}
+}
+
+// TestRemoveRuntimeSockets_NamesEveryDaemonSocket pins the socket set a reset
+// clears. A socket that outlives its daemon points the next client at a dead
+// endpoint, which is the failure this change exists to remove.
+func TestRemoveRuntimeSockets_NamesEveryDaemonSocket(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+
+	// The two daemon sockets, plus a VS Code editor socket matching the name
+	// shape the daemon mints, plus a file that must survive.
+	mustWrite := func(rel string) string {
+		p := filepath.Join(home, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	sock := mustWrite("daemon.sock")
+	httpSock := mustWrite("daemon-http.sock")
+	keep := mustWrite("config.toml")
+
+	removed, err := daemon.RemoveRuntimeSockets(home)
+	if err != nil {
+		t.Fatalf("RemoveRuntimeSockets: %v", err)
+	}
+	for _, p := range []string{sock, httpSock} {
+		if _, statErr := os.Stat(p); !os.IsNotExist(statErr) {
+			t.Errorf("%s survived the socket sweep", p)
+		}
+	}
+	if len(removed) != 2 {
+		t.Errorf("removed = %v, want the two daemon sockets", removed)
+	}
+	if _, statErr := os.Stat(keep); statErr != nil {
+		t.Errorf("the socket sweep removed config.toml: %v", statErr)
+	}
+
+	// Idempotent: a second sweep is a clean no-op, matching the reset's
+	// re-runnable contract.
+	again, err := daemon.RemoveRuntimeSockets(home)
+	if err != nil {
+		t.Fatalf("second RemoveRuntimeSockets: %v", err)
+	}
+	if len(again) != 0 {
+		t.Errorf("second sweep removed %v, want nothing", again)
+	}
+}
+
+// TestFactoryReset_LeavesOtherHomesAutostartUnitAlone is the regression lock for
+// the #1916 P2: the autostart pause was gated on the unit FILE existing, not on
+// the unit serving the home being reset.
+//
+// The unit bakes its own AGENT_FACTORY_HOME at install time, so it has no
+// relationship to the AGENT_FACTORY_HOME the resetting process carries. Gated on
+// file existence alone, `AGENT_FACTORY_HOME=/tmp/sandbox af reset` reaches out
+// and stops the developer's REAL daemon — and if the deferred resume then fails,
+// leaves it stopped. On a shared box that is an outage caused by a sandbox.
+//
+// To watch it fail: this reproduces against master (ddb72aa), where runReset
+// pauses on `if autostartInstalledFn()` with no home check.
+func TestFactoryReset_LeavesOtherHomesAutostartUnitAlone(t *testing.T) {
+	seedResetHome(t) // we are resetting a throwaway sandbox home
+	fakeDaemonSeams(t)
+
+	// A unit file EXISTS on this machine — it just belongs to a different home.
+	autostartInstalledFn = func() bool { return true }
+	autostartUnitServesHomeFn = func(string) (bool, bool, error) { return false, true, nil }
+	pauseAutostartUnitFn = func() error {
+		t.Fatal("reset paused an autostart unit that serves a DIFFERENT AF home — " +
+			"this stops the real daemon on a shared box (#1916 P2)")
+		return nil
+	}
+	resumeAutostartUnitFn = func() error {
+		t.Fatal("reset resumed an autostart unit it should never have touched")
+		return nil
+	}
+	// Nor may it stop that home's daemons: same bug class, same gate.
+	stopOrphanDaemonsFn = func(configDir string) ([]int, []int, error) {
+		if configDir != resetHomeUnderTest {
+			t.Errorf("orphan scan scoped to %q, want the home being reset %q", configDir, resetHomeUnderTest)
+		}
+		return nil, nil, nil
+	}
+
+	out, err := runResetCapture(t)
+	if err != nil {
+		t.Fatalf("runReset: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "different AF home") {
+		t.Errorf("reset did not report leaving the other home's unit alone:\n%s", out)
+	}
+}
+
+// TestFactoryReset_ResumeFailureIsLoudAndFails covers the other half of the P2's
+// blast radius: we stopped a REAL supervised daemon, so failing to start it back
+// must never be a quiet warning. The unit stays down until the next login, and a
+// scripted caller must see a non-zero exit.
+func TestFactoryReset_ResumeFailureIsLoudAndFails(t *testing.T) {
+	seedResetHome(t)
+	fakeDaemonSeams(t)
+
+	autostartInstalledFn = func() bool { return true }
+	autostartUnitServesHomeFn = func(string) (bool, bool, error) { return true, true, nil }
+	pauseAutostartUnitFn = func() error { return nil }
+	attempts := 0
+	resumeAutostartUnitFn = func() error {
+		attempts++
+		return errors.New("systemctl --user start failed: unit not found")
+	}
+
+	out, err := runResetCapture(t)
+	if attempts != autostartResumeAttempts {
+		t.Errorf("resume attempted %d times, want %d retries before giving up", attempts, autostartResumeAttempts)
+	}
+	if !strings.Contains(out, "ACTION REQUIRED") || !strings.Contains(out, "STOPPED") {
+		t.Errorf("a failed resume did not shout about the stopped daemon:\n%s", out)
+	}
+	if err == nil {
+		t.Error("runReset returned nil after leaving the daemon stopped; a scripted caller would never notice")
+	}
+}
+
+// TestFactoryReset_UnknownUnitHomeIsLeftAlone: if we cannot establish which home
+// the unit serves, we must not touch it. "I could not tell" never resolves to
+// "stop it" — the same rule the daemon scan follows.
+func TestFactoryReset_UnknownUnitHomeIsLeftAlone(t *testing.T) {
+	seedResetHome(t)
+	fakeDaemonSeams(t)
+
+	autostartInstalledFn = func() bool { return true }
+	autostartUnitServesHomeFn = func(string) (bool, bool, error) {
+		return false, true, errors.New("unit file is unreadable")
+	}
+	pauseAutostartUnitFn = func() error {
+		t.Fatal("reset paused a unit whose AF home it could not establish")
+		return nil
+	}
+
+	out, err := runResetCapture(t)
+	if err != nil {
+		t.Fatalf("runReset: %v", err)
+	}
+	if !strings.Contains(out, "could not determine which AF home") {
+		t.Errorf("reset did not report the unverifiable unit:\n%s", out)
+	}
+}

--- a/commands/reset_test.go
+++ b/commands/reset_test.go
@@ -528,18 +528,11 @@ func TestFactoryReset_ResilientPartialFailure(t *testing.T) {
 // "resume runs only after the wipe" — the whole point of pausing.
 func stubResetDaemonHandling(t *testing.T, home string, installed bool, pauseErr error) *[]string {
 	t.Helper()
-	prevInstalled := autostartInstalledFn
-	prevPause := pauseAutostartUnitFn
-	prevResume := resumeAutostartUnitFn
-	prevStop := stopDaemonFn
-	prevTmux := cleanupTmuxSessionsFn
-	t.Cleanup(func() {
-		autostartInstalledFn = prevInstalled
-		pauseAutostartUnitFn = prevPause
-		resumeAutostartUnitFn = prevResume
-		stopDaemonFn = prevStop
-		cleanupTmuxSessionsFn = prevTmux
-	})
+	// fakeDaemonSeams neutralises EVERY daemon/autostart/tmux boundary (and
+	// restores them), so the seams this helper does not care about can never
+	// fall through to the real thing — notably stopOrphanDaemonsFn, which
+	// otherwise runs a host-wide process scan from a unit test.
+	fakeDaemonSeams(t)
 
 	var events []string
 	stateFile := filepath.Join(home, config.StateFileName)
@@ -550,6 +543,9 @@ func stubResetDaemonHandling(t *testing.T, home string, installed bool, pauseErr
 		return "unwiped"
 	}
 	autostartInstalledFn = func() bool { return installed }
+	// The unit under test is the one for THIS home; the cross-home case has its
+	// own test (TestFactoryReset_LeavesOtherHomesAutostartUnitAlone).
+	autostartUnitServesHomeFn = func(string) (bool, bool, error) { return installed, installed, nil }
 	pauseAutostartUnitFn = func() error {
 		events = append(events, "pause:"+wiped())
 		return pauseErr

--- a/config/config_types.go
+++ b/config/config_types.go
@@ -85,7 +85,24 @@ func ResolveUserPath(path string) (string, error) {
 // If AGENT_FACTORY_HOME is set, it is used as the config directory.
 // Otherwise, defaults to ~/.agent-factory.
 func GetConfigDir() (string, error) {
-	if envDir := os.Getenv("AGENT_FACTORY_HOME"); envDir != "" {
+	return ConfigDirFor(os.Getenv("AGENT_FACTORY_HOME"))
+}
+
+// ConfigDirFor resolves the AF home for an explicit AGENT_FACTORY_HOME value,
+// applying exactly the rules GetConfigDir applies to our own environment. An
+// empty envDir means unset — which GetConfigDir has always treated identically
+// to empty — and resolves to the default ~/.agent-factory.
+//
+// It is separate from GetConfigDir because one caller must resolve a home it
+// did NOT inherit: `af reset` reads AGENT_FACTORY_HOME out of another daemon's
+// /proc/<pid>/environ to decide whether that daemon serves THIS home before it
+// signals it (see daemon.StopOrphanDaemons). Routing that through the same
+// resolver is what keeps the two from drifting apart — a private copy of the
+// tilde handling here would eventually disagree, and disagreeing means either
+// missing the stale daemon we came to kill or signaling a daemon belonging to a
+// different home.
+func ConfigDirFor(envDir string) (string, error) {
+	if envDir != "" {
 		// "~user" forms are unresolvable; reject them explicitly rather than
 		// treating "~user" as a literal directory name.
 		if strings.HasPrefix(envDir, "~") && envDir != "~" && !strings.HasPrefix(envDir, "~/") {

--- a/daemon/autostart.go
+++ b/daemon/autostart.go
@@ -293,6 +293,130 @@ func AutostartInstalled() bool {
 	return err == nil
 }
 
+// AutostartUnitServesHome reports whether the INSTALLED autostart unit's daemon
+// would serve configDir. installed is false when no unit file is present.
+//
+// This is the gate every unit operation a reset performs must pass, and it
+// exists because "a unit file exists" and "that unit is the one I am resetting"
+// are different questions (#1916 P2). The unit bakes its AGENT_FACTORY_HOME at
+// install time (InstallAutostart captures os.Getenv), so a developer's unit
+// serves their real home no matter what AGENT_FACTORY_HOME the CURRENT process
+// happens to carry. Gating on file existence alone means `AGENT_FACTORY_HOME=/tmp/sandbox
+// af reset` stops the maintainer's real daemon — the reset of a throwaway home
+// reaching out and taking down a completely unrelated one.
+//
+// A unit installed with NO AGENT_FACTORY_HOME serves the DEFAULT home, which is
+// exactly what ConfigDirFor("") resolves — so the absent case is not "unknown",
+// it is the common case and must compare equal to a default-home reset.
+func AutostartUnitServesHome(configDir string) (serves bool, installed bool, err error) {
+	path, err := autostartUnitFilePath()
+	if err != nil {
+		return false, false, err
+	}
+	if path == "" {
+		return false, false, nil // autostart unsupported on this platform
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, false, nil
+		}
+		return false, false, fmt.Errorf("failed to read the autostart unit %s: %w", path, err)
+	}
+
+	var baked string
+	switch autostartGOOS {
+	case "linux":
+		baked, _ = systemdUnitEnvValue(string(data), "AGENT_FACTORY_HOME")
+	case "darwin":
+		baked, _ = launchdPlistEnvValue(string(data), "AGENT_FACTORY_HOME")
+	default:
+		return false, false, nil
+	}
+
+	// baked == "" means the unit captured no AGENT_FACTORY_HOME → default home.
+	unitHome, err := config.ConfigDirFor(baked)
+	if err != nil {
+		return false, true, fmt.Errorf("the autostart unit's AGENT_FACTORY_HOME %q is unusable: %w", baked, err)
+	}
+	unitCanonical, err := canonicalDir(unitHome)
+	if err != nil {
+		return false, true, err
+	}
+	wantCanonical, err := canonicalDir(configDir)
+	if err != nil {
+		return false, true, err
+	}
+	return unitCanonical == wantCanonical, true, nil
+}
+
+// systemdUnitEnvValue extracts name's value from the unit's Environment= lines.
+//
+// It is the exact inverse of formatSystemdEnvLine and MUST stay in lockstep
+// with it — a renderer change that this does not follow silently turns a
+// same-home reset into a different-home one, which is the bug the gate exists
+// to prevent. TestAutostartUnitHomeRoundTrip pins the pair together.
+func systemdUnitEnvValue(content, name string) (string, bool) {
+	for _, line := range strings.Split(content, "\n") {
+		rest, ok := strings.CutPrefix(strings.TrimSpace(line), "Environment=")
+		if !ok {
+			continue
+		}
+		// formatSystemdEnvLine wraps the WHOLE assignment in quotes when the
+		// value needs it, C-escaping \ and " inside.
+		if len(rest) >= 2 && strings.HasPrefix(rest, `"`) && strings.HasSuffix(rest, `"`) {
+			rest = unescapeSystemdValue(rest[1 : len(rest)-1])
+		}
+		key, value, found := strings.Cut(rest, "=")
+		if !found || key != name {
+			continue
+		}
+		// '%' is doubled unconditionally by the renderer (it is a systemd
+		// specifier), and is not backslash-escaped, so it un-doubles last.
+		return strings.ReplaceAll(value, "%%", "%"), true
+	}
+	return "", false
+}
+
+// unescapeSystemdValue reverses the C-style \\ and \" escaping applied inside a
+// quoted Environment= assignment. It walks the string once rather than running
+// two ReplaceAll passes, which would mis-handle a value containing a literal
+// backslash followed by a quote.
+func unescapeSystemdValue(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+1 < len(s) {
+			i++
+			b.WriteByte(s[i])
+			continue
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
+
+// launchdPlistEnvValue extracts name's value from the plist's
+// EnvironmentVariables dict: the <string> immediately following <key>name</key>.
+// The inverse of launchdAutostartPlist's html.EscapeString; kept in lockstep by
+// the same round-trip test.
+func launchdPlistEnvValue(content, name string) (string, bool) {
+	idx := strings.Index(content, "<key>"+name+"</key>")
+	if idx < 0 {
+		return "", false
+	}
+	rest := content[idx:]
+	start := strings.Index(rest, "<string>")
+	if start < 0 {
+		return "", false
+	}
+	rest = rest[start+len("<string>"):]
+	end := strings.Index(rest, "</string>")
+	if end < 0 {
+		return "", false
+	}
+	return html.UnescapeString(rest[:end]), true
+}
+
 // RestartAutostartUnit restarts the daemon through the OS service manager —
 // `systemctl --user restart` on Linux, `launchctl kickstart -k` on macOS — so
 // the daemon stays supervised. Used by the upgrade/auto-update respawn path

--- a/daemon/autostart_home_test.go
+++ b/daemon/autostart_home_test.go
@@ -1,0 +1,117 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestAutostartUnitHomeRoundTrip pins the unit renderers and their parsers
+// together. AutostartUnitServesHome decides whether `af reset` may stop the
+// supervised daemon, and it decides it by READING BACK the AGENT_FACTORY_HOME
+// that InstallAutostart wrote. Those are two independent pieces of escaping
+// (systemd's quote-aware Environment= grammar, launchd's XML), so a renderer
+// change that the parser does not follow does not fail loudly — it silently
+// reports the wrong home, and the gate either stops a daemon it must not touch
+// or fails to stop the one it must.
+//
+// The awkward values are the point: a spaced install path (#1214), a '%'
+// systemd specifier, and quote/backslash characters are exactly what the
+// escaping exists for.
+func TestAutostartUnitHomeRoundTrip(t *testing.T) {
+	homes := []string{
+		"/home/u/.agent-factory",
+		"/tmp/sandbox-home",
+		"/home/John Smith/af home",
+		`/tmp/pct%home`,
+		`/tmp/quote"home`,
+		`/tmp/back\slash`,
+	}
+	for _, home := range homes {
+		t.Run(home, func(t *testing.T) {
+			unit := systemdAutostartUnit("/usr/local/bin/af", "/usr/bin:/bin", "/bin/zsh", home)
+			got, found := systemdUnitEnvValue(unit, "AGENT_FACTORY_HOME")
+			if !found {
+				t.Fatalf("systemd unit for home %q exposes no AGENT_FACTORY_HOME:\n%s", home, unit)
+			}
+			if got != home {
+				t.Errorf("systemd round trip = %q, want %q\nunit:\n%s", got, home, unit)
+			}
+
+			plist := launchdAutostartPlist("/usr/local/bin/af", "/usr/bin:/bin", "/bin/zsh", home, "/tmp/af.log")
+			got, found = launchdPlistEnvValue(plist, "AGENT_FACTORY_HOME")
+			if !found {
+				t.Fatalf("launchd plist for home %q exposes no AGENT_FACTORY_HOME:\n%s", home, plist)
+			}
+			if got != home {
+				t.Errorf("launchd round trip = %q, want %q", got, home)
+			}
+		})
+	}
+}
+
+// TestAutostartUnitHome_AbsentMeansDefault: a unit installed WITHOUT
+// AGENT_FACTORY_HOME serves the DEFAULT home. Reporting that as "no home found"
+// and treating it as unknown would make the gate skip the ordinary supervised
+// daemon — the one a normal `af reset` is supposed to pause.
+func TestAutostartUnitHome_AbsentMeansDefault(t *testing.T) {
+	unit := systemdAutostartUnit("/usr/local/bin/af", "/usr/bin", "/bin/zsh", "")
+	if v, found := systemdUnitEnvValue(unit, "AGENT_FACTORY_HOME"); found {
+		t.Errorf("unit installed with no AGENT_FACTORY_HOME exposes %q; want absent", v)
+	}
+	// PATH must still round-trip — the absence must be specific to the home, not
+	// a parser that cannot see Environment= lines at all.
+	if v, found := systemdUnitEnvValue(unit, "PATH"); !found || v != "/usr/bin" {
+		t.Errorf("PATH round trip = %q found=%v, want /usr/bin", v, found)
+	}
+}
+
+// TestAutostartUnitServesHome_GatesOnHome is the daemon-side lock for the #1916
+// P2. A unit installed for one home must not be reported as serving another —
+// that report is what lets `af reset` stop a daemon it was never asked to touch.
+func TestAutostartUnitServesHome_GatesOnHome(t *testing.T) {
+	dir := withAutostartTestEnv(t, "linux")
+	realHome := t.TempDir()
+	sandbox := t.TempDir()
+
+	unit := systemdAutostartUnit("/usr/local/bin/af", "/usr/bin", "/bin/zsh", realHome)
+	if err := os.WriteFile(filepath.Join(dir, autostartUnitName), []byte(unit), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Its own home: serves.
+	serves, installed, err := AutostartUnitServesHome(realHome)
+	if err != nil {
+		t.Fatalf("AutostartUnitServesHome(realHome): %v", err)
+	}
+	if !installed || !serves {
+		t.Errorf("unit for its OWN home: serves=%v installed=%v, want both true", serves, installed)
+	}
+
+	// A different home: installed, but must NOT be reported as serving it.
+	serves, installed, err = AutostartUnitServesHome(sandbox)
+	if err != nil {
+		t.Fatalf("AutostartUnitServesHome(sandbox): %v", err)
+	}
+	if !installed {
+		t.Error("installed = false; the unit file exists")
+	}
+	if serves {
+		t.Error("a unit installed for a DIFFERENT AF home reported as serving the sandbox — " +
+			"this is what lets a sandbox reset stop the real daemon (#1916 P2)")
+	}
+}
+
+// TestAutostartUnitServesHome_NoUnit: no unit file means nothing to gate on, and
+// crucially not an error — a machine that never ran `af daemon install` is the
+// common case.
+func TestAutostartUnitServesHome_NoUnit(t *testing.T) {
+	withAutostartTestEnv(t, "linux")
+	serves, installed, err := AutostartUnitServesHome(t.TempDir())
+	if err != nil {
+		t.Fatalf("AutostartUnitServesHome: %v", err)
+	}
+	if serves || installed {
+		t.Errorf("no unit file: serves=%v installed=%v, want both false", serves, installed)
+	}
+}

--- a/daemon/fake_daemon_test.go
+++ b/daemon/fake_daemon_test.go
@@ -31,6 +31,24 @@ func shSingleQuote(s string) string {
 // group.
 func spawnFakeDaemonProc(t *testing.T, argv0, script string, extraArgs ...string) *exec.Cmd {
 	t.Helper()
+	cmd := fakeDaemonCmd(t, argv0, script, extraArgs...)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start fake daemon proc: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		_, _ = cmd.Process.Wait()
+	})
+	return cmd
+}
+
+// fakeDaemonCmd builds (but does not start) the fake-daemon command described
+// by spawnFakeDaemonProc. It is split out so a caller that must set the child's
+// ENVIRONMENT before it execs can do so: AF-home scoping reads a daemon's
+// AGENT_FACTORY_HOME from /proc/<pid>/environ, which is fixed at exec and
+// cannot be set afterwards.
+func fakeDaemonCmd(t *testing.T, argv0, script string, extraArgs ...string) *exec.Cmd {
+	t.Helper()
 	if _, err := exec.LookPath("bash"); err != nil {
 		t.Skipf("bash not available: %v", err)
 	}
@@ -41,15 +59,8 @@ func spawnFakeDaemonProc(t *testing.T, argv0, script string, extraArgs ...string
 		parts = append(parts, shSingleQuote(a))
 	}
 	cmd := exec.Command("bash", "-c", strings.Join(parts, " "))
-	// Put the process (and its children) in their own group so cleanup reaps
-	// any orphaned `sleep` child left behind when bash dies by signal.
+	// Put the process (and its children) in their own group so cleanup can reap
+	// the whole tree — bash dies by signal, orphaning any `sleep` child.
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	if err := cmd.Start(); err != nil {
-		t.Fatalf("start fake daemon proc: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
-		_, _ = cmd.Process.Wait()
-	})
 	return cmd
 }

--- a/daemon/stopall.go
+++ b/daemon/stopall.go
@@ -1,0 +1,362 @@
+package daemon
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"syscall"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+// This file backs the daemon half of `af reset` (#1913 follow-up): a factory
+// reset that leaves a daemon running has not reset anything the daemon holds in
+// memory, and the daemon a reset misses is precisely the one that causes the
+// failure reset is meant to cure — an OLD binary left over from an upgrade,
+// still bound to the control socket, rejecting a NEW client's requests with
+// "unknown field tab_id".
+//
+// StopDaemon alone cannot do this. It follows daemon.pid, so it finds exactly
+// one daemon: the managed one. A daemon started before the PID file existed
+// (pre-1.0.69), a second daemon that lost the singleton race, or a source-built
+// `agent-factory --daemon` all leave no PID file to follow and survive.
+
+// scopedDaemonScanFn is the candidate-scan entry point used by
+// StopOrphanDaemons. It is a function var for the same reason
+// scanDaemonCandidatesFn is (#793): the underlying scan is HOST-WIDE, so on any
+// machine running the supervised daemon a test would find that real daemon
+// among its candidates. The uid+home filter below is what makes this safe in
+// production, and the seam is what makes it safe to test the signalling path
+// without depending on that filter being perfect.
+var scopedDaemonScanFn = scanDaemonCandidatesFn
+
+// StopOrphanDaemons stops every af daemon that belongs to THIS user and THIS AF
+// home, and returns the PIDs it actually stopped, ascending.
+//
+// It is the second half of the reset teardown, run AFTER StopDaemon: StopDaemon
+// handles the PID-file daemon, this handles every daemon that never wrote one.
+// By the time it runs the managed daemon is normally already gone, so it
+// usually finds nothing; the case it exists for is the leftover that reset
+// previously only printed a `pkill` hint about.
+//
+// SCOPE IS THE WHOLE DESIGN HERE. This function sends SIGTERM/SIGKILL to
+// processes it discovered by scanning the process table, so every filter is
+// load-bearing and each one narrows a way to hit the wrong process:
+//
+//   - an af/agent-factory binary carrying a discrete --daemon token
+//     (argsAreDaemonBinary + argsHaveDaemonFlag, reused from the PID-file path
+//     so both agree — #1004), never a substring match on some other project's
+//     `--daemonize`;
+//   - owned by OUR uid, so a shared box never has one user's reset touch
+//     another's daemon (load-bearing only when running as root, where a foreign
+//     environ is readable — see verifyScopedDaemon);
+//   - serving OUR AF home, so a reset of one AGENT_FACTORY_HOME never stops the
+//     daemon of another. Running several homes side by side is a supported,
+//     documented setup; a reset that killed all of them would be a far worse
+//     bug than the stale daemon it was cleaning up.
+//
+// A candidate whose home CANNOT be established is left alone and reported to
+// the caller rather than signaled. "I could not tell" must never resolve to
+// "kill it": the cost of skipping is a leftover daemon and a printed warning,
+// while the cost of guessing wrong is killing a working daemon that reset was
+// never asked to touch.
+//
+// Errors stopping individual daemons are joined and returned alongside whatever
+// was stopped — a reset reports how far it got rather than aborting.
+func StopOrphanDaemons(configDir string) (stopped []int, unverified []int, err error) {
+	ours, unverified, err := ScanScopedDaemons(configDir)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	uid := os.Getuid()
+	wantHome, homeErr := canonicalDir(configDir)
+	if homeErr != nil {
+		return nil, nil, fmt.Errorf("failed to resolve the af home %q: %w", configDir, homeErr)
+	}
+
+	var errs []error
+	for _, pid := range ours {
+		// Re-verify at signal time. A PID is a reusable kernel handle, so a
+		// candidate can exit and its number be recycled between the scan and
+		// this line; re-reading argv is the same TOCTOU narrowing StopDaemon
+		// applies to a stale PID file.
+		if verifyScopedDaemon(pid, uid, wantHome) != daemonOurs {
+			continue
+		}
+		// signalAndWait is SIGTERM, poll, then SIGKILL only if the grace expires
+		// — the same escalation StopDaemon uses, so a daemon stopped here still
+		// gets to run its SaveInstances() handler (#571). It returns only once
+		// the process is GONE, which is the property the reset depends on: a
+		// daemon still running its shutdown flush would write instances.json
+		// back out after the wipe deleted it.
+		if err := signalAndWait(pid); err != nil {
+			errs = append(errs, fmt.Errorf("stop daemon pid %d: %w", pid, err))
+			continue
+		}
+		stopped = append(stopped, pid)
+	}
+	sort.Ints(stopped)
+	return stopped, unverified, errors.Join(errs...)
+}
+
+// ScanScopedDaemons returns the live af daemons that belong to this user and
+// this AF home (ours), and the af daemon processes whose home could NOT be
+// established (unverified). It is the shared basis for both stopping orphans
+// and asserting that nothing is left running.
+func ScanScopedDaemons(configDir string) (ours []int, unverified []int, err error) {
+	wantHome, err := canonicalDir(configDir)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to resolve the af home %q: %w", configDir, err)
+	}
+
+	candidates, err := scopedDaemonScanFn()
+	if err != nil {
+		// A missing pgrep is not a reset failure by itself, but it DOES mean we
+		// cannot prove the field is clear. Report it as a scan error and let the
+		// caller decide — reset treats "cannot verify" as a reason to abort
+		// rather than wipe under a daemon it cannot see.
+		if errors.Is(err, errPgrepUnavailable) {
+			return nil, nil, fmt.Errorf("cannot scan for running daemons: %w", err)
+		}
+		return nil, nil, fmt.Errorf("failed to scan for running daemons: %w", err)
+	}
+
+	uid := os.Getuid()
+	self := os.Getpid()
+	for _, pid := range candidates {
+		if pid <= 1 || pid == self {
+			continue
+		}
+		switch verifyScopedDaemon(pid, uid, wantHome) {
+		case daemonOurs:
+			ours = append(ours, pid)
+		case daemonUnverifiable:
+			unverified = append(unverified, pid)
+		case daemonForeign:
+		}
+	}
+	sort.Ints(ours)
+	sort.Ints(unverified)
+	return ours, unverified, nil
+}
+
+// AssertNoLiveDaemon returns an error naming what is still running if ANY af
+// daemon for this home is alive, or if anything still answers on the control
+// socket.
+//
+// This is the barrier `af reset` must clear before it deletes a single byte of
+// state, and it is the reason the reset is safe rather than merely careful. The
+// daemon is the SINGLE WRITER of session state (#960): it holds every instance
+// in memory and persists them on a tick and again on its shutdown path
+// (RunDaemon's final SaveInstances). A wipe that races a live daemon does not
+// half-work — it loses. The daemon writes instances.json back out from memory
+// after the delete, and the "factory reset" hands the user their old sessions
+// back, which is precisely the resurrection this whole change exists to stop.
+//
+// So the rule is: prove the field is clear, or do not wipe. A reset that aborts
+// with an explanation leaves the user exactly where they started and costs them
+// one command; a reset that guesses wrong leaves them with a half-deleted home
+// and a daemon writing into it.
+func AssertNoLiveDaemon(configDir string) error {
+	if err := pingDaemon(); err == nil {
+		return errors.New("a daemon is still answering on the control socket")
+	}
+	ours, unverified, err := ScanScopedDaemons(configDir)
+	if err != nil {
+		return err
+	}
+	if len(ours) > 0 {
+		return fmt.Errorf("af daemon(s) still running for this AF home: %s", formatPIDList(ours))
+	}
+	if len(unverified) > 0 {
+		return fmt.Errorf("af daemon process(es) whose AF home could not be verified are still running: %s; "+
+			"if one of these serves this AF home, stop it before resetting", formatPIDList(unverified))
+	}
+	return nil
+}
+
+// daemonScope is the outcome of deciding whether a scanned PID is a daemon this
+// reset owns.
+type daemonScope int
+
+const (
+	// daemonOurs is an af daemon owned by this uid and serving this AF home.
+	daemonOurs daemonScope = iota
+	// daemonForeign provably is not ours — a different uid, a different AF
+	// home, or no longer an af daemon at all.
+	daemonForeign
+	// daemonUnverifiable is an af daemon whose home could not be established,
+	// so it is neither ours nor provably foreign. Never signaled.
+	daemonUnverifiable
+)
+
+// verifyScopedDaemon decides whether pid is a daemon this reset may stop. It is
+// called immediately before signalling as well as during the scan: a PID is a
+// reusable kernel handle, so a candidate can exit and its number be recycled by
+// an unrelated process in the window between the two. Re-reading argv at signal
+// time is the same TOCTOU narrowing StopDaemon applies to a stale PID file.
+func verifyScopedDaemon(pid, uid int, wantHome string) daemonScope {
+	// Still an af daemon? Re-read argv rather than trusting the scan: this is
+	// the check that stops a recycled PID from being signaled.
+	if !isAgentFactoryDaemon(pid) {
+		return daemonForeign
+	}
+	if isTestBinaryArgs(daemonArgs(pid)) {
+		return daemonForeign
+	}
+
+	owner, ok := processUID(pid)
+	if !ok {
+		return daemonUnverifiable
+	}
+	if owner != uid {
+		return daemonForeign
+	}
+
+	env, readable := daemonHomeEnv(pid)
+	if !readable {
+		return daemonUnverifiable
+	}
+	home, err := config.ConfigDirFor(env)
+	if err != nil {
+		// The daemon holds an AGENT_FACTORY_HOME we cannot resolve. Unresolvable
+		// is not "not ours" — say so instead of guessing.
+		log.WarningLog.Printf("reset: cannot resolve AGENT_FACTORY_HOME=%q for daemon pid %d: %v", env, pid, err)
+		return daemonUnverifiable
+	}
+	got, err := canonicalDir(home)
+	if err != nil {
+		return daemonUnverifiable
+	}
+	if got != wantHome {
+		return daemonForeign
+	}
+	return daemonOurs
+}
+
+// canonicalDir renders a directory path in a form two independently-resolved
+// paths can be compared with. AF homes reach us from different places — ours
+// from GetConfigDir, a daemon's from its environ — and may differ textually
+// while naming the same directory: relative vs absolute (GetConfigDir does not
+// absolutize — #1873), or through a symlink (/tmp vs /private/tmp on macOS).
+//
+// EvalSymlinks is best-effort: it fails on a path that does not exist, which is
+// legitimate here (an AF home that has not been created yet), so a failure
+// falls back to the lexical form rather than failing the comparison.
+func canonicalDir(dir string) (string, error) {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return "", err
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		return resolved, nil
+	}
+	return filepath.Clean(abs), nil
+}
+
+// processUID returns the uid owning pid. The second return is false when
+// ownership cannot be determined (no /proc, or the process exited), which
+// callers must treat as "unknown", never as "ours".
+func processUID(pid int) (int, bool) {
+	fi, err := os.Stat(fmt.Sprintf("/proc/%d", pid))
+	if err != nil {
+		return 0, false
+	}
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, false
+	}
+	return int(st.Uid), true
+}
+
+// daemonHomeEnv reports the AGENT_FACTORY_HOME a running process was started
+// with. The second return distinguishes the two cases that a plain lookup
+// conflates, and getting that distinction wrong breaks the reset in one
+// direction or the other:
+//
+//   - (value, true): the environ was READ. An empty value means the variable is
+//     genuinely absent, so the daemon resolved the DEFAULT home — this is the
+//     COMMON case, since almost nobody sets AGENT_FACTORY_HOME, and treating it
+//     as "unknown" would skip exactly the everyday stale daemon reset exists to
+//     kill.
+//   - ("", false): the environ was UNREADABLE — no /proc (macOS), a foreign
+//     uid, or the process exited. We cannot tell which home it serves, and
+//     must not guess it is the default.
+//
+// The environ is fixed at exec and cannot be shed, so what it says about the
+// home a daemon resolved at startup stays true for the life of the process.
+func daemonHomeEnv(pid int) (string, bool) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/environ", pid))
+	if err != nil {
+		return "", false
+	}
+	const key = "AGENT_FACTORY_HOME="
+	for _, kv := range bytes.Split(data, []byte{0}) {
+		if bytes.HasPrefix(kv, []byte(key)) {
+			return string(kv[len(key):]), true
+		}
+	}
+	return "", true
+}
+
+// RemoveRuntimeSockets unlinks the Unix sockets under the AF home that a client
+// could otherwise dial into a dead endpoint: the gob control socket
+// (daemon.sock), the HTTP/JSON socket (daemon-http.sock), and the per-session
+// VS Code editor sockets (vscode/*.sock). It returns the paths it removed.
+//
+// It MUST run only after every daemon has been stopped, and it enforces that
+// itself rather than trusting the caller: if anything still ANSWERS on the
+// control socket, it removes nothing and says so. Unlinking a LIVE daemon's
+// socket is the #767 failure — the daemon keeps serving an inode with no name,
+// every dial against the path fails, and the next EnsureDaemon spawns a second
+// daemon while the first leaks forever. That is strictly worse than the stale
+// socket this function exists to clear, so "a daemon answered" is a reason to
+// stop, not a race to win.
+func RemoveRuntimeSockets(dir string) ([]string, error) {
+	if err := pingDaemon(); err == nil {
+		return nil, errors.New("a daemon is still answering on the control socket; " +
+			"refusing to remove the sockets it is serving (removing a live daemon's socket " +
+			"strands it and leaks a second one — #767)")
+	}
+
+	var removed []string
+	var errs []error
+	remove := func(path string) {
+		err := os.Remove(path)
+		switch {
+		case err == nil:
+			removed = append(removed, path)
+		case os.IsNotExist(err):
+			// Already gone: the daemon's own teardown unlinks its socket, so the
+			// happy path lands here. Nothing to report.
+		default:
+			errs = append(errs, fmt.Errorf("remove %s: %w", path, err))
+		}
+	}
+
+	remove(filepath.Join(dir, daemonSocketFileName))
+	remove(filepath.Join(dir, daemonHTTPSocketFileName))
+
+	// Editor sockets are swept with the daemon's OWN recognizer rather than a
+	// "*.sock" glob: an operator can point AGENT_FACTORY_HOME at a directory
+	// already in use, and reset must not delete a file it did not mint. See
+	// isAbandonedVSCodeSocket for why name AND socket-ness are both checked.
+	sockDir := filepath.Join(dir, vscodeSocketDirName)
+	entries, err := os.ReadDir(sockDir)
+	if err != nil && !os.IsNotExist(err) {
+		errs = append(errs, fmt.Errorf("read %s: %w", sockDir, err))
+	}
+	for _, e := range entries {
+		if isAbandonedVSCodeSocket(sockDir, e) {
+			remove(filepath.Join(sockDir, e.Name()))
+		}
+	}
+
+	sort.Strings(removed)
+	return removed, errors.Join(errs...)
+}

--- a/daemon/stopall_test.go
+++ b/daemon/stopall_test.go
@@ -1,0 +1,225 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+// These tests cover the scoping that makes `af reset` safe to point at a
+// process table: reset SIGTERMs (and escalates to SIGKILL on) daemons it
+// discovers by scanning, so a filter that is too loose kills someone else's
+// daemon.
+//
+// The classification tests never signal anything — they spawn a fake and ask
+// verifyScopedDaemon what it thinks. The one test that DOES signal injects
+// scopedDaemonScanFn so only its own fake's PID is ever a candidate: the real
+// scan is host-wide, and a developer running these must never have their own
+// daemon stopped (#793).
+
+// spawnFakeDaemonWithHome starts a fake `af --daemon` whose environ carries the
+// given AGENT_FACTORY_HOME. Passing env=nil starts it with NO AGENT_FACTORY_HOME
+// at all, which is the common real-world shape — almost nobody sets it — and the
+// case a naive "read the env var and compare" filter gets wrong.
+func spawnFakeDaemonWithHome(t *testing.T, home string) int {
+	t.Helper()
+	argv0 := filepath.Join(fakeBinDir(t), "af")
+
+	script := "sleep 300; :" // compound so bash does not exec-optimize the argv away
+	cmd := fakeDaemonCmd(t, argv0, script, "--daemon")
+	env := []string{"PATH=" + os.Getenv("PATH")}
+	if home != "" {
+		env = append(env, "AGENT_FACTORY_HOME="+home)
+	}
+	cmd.Env = env
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start fake daemon: %v", err)
+	}
+	pid := cmd.Process.Pid
+	t.Cleanup(func() {
+		_ = syscall.Kill(-pid, syscall.SIGKILL)
+		_, _ = cmd.Process.Wait()
+	})
+	waitForArgv(t, pid, argv0)
+	return pid
+}
+
+// fakeBinDir returns a temp dir for a fake daemon binary that is NOT under
+// /tmp/Test..., which t.TempDir() would give us.
+//
+// That distinction is the difference between testing the filter and fooling it:
+// isTestBinaryArgs deliberately rejects any argv living under /tmp/Test* or
+// /tmp/go-build*, so a fake whose argv0 came from t.TempDir() is classified
+// foreign because it looks like a Go test binary — never reaching the uid or
+// AF-home checks these tests exist to exercise. It makes a "must be rejected"
+// assertion pass for entirely the wrong reason.
+func fakeBinDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "af-fake-daemon")
+	if err != nil {
+		t.Fatalf("make fake bin dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+// waitForArgv blocks until pid's argv is the one the fake was built to expose,
+// i.e. argv[0] == argv0.
+//
+// Waiting for a merely NON-EMPTY argv is a race that silently inverts these
+// tests. spawnFakeDaemonProc runs `bash -c "exec -a <argv0> bash ..."`, so the
+// outer bash has a perfectly readable argv — ["bash", "-c", ...] — for a
+// moment BEFORE it execs into the crafted one. Classify it in that window and
+// argsAreDaemonBinary sees "bash", returns false, and the daemon is written off
+// as foreign: an assertion that should fail passes, and one that should pass
+// fails, both for a reason that has nothing to do with the code under test.
+func waitForArgv(t *testing.T, pid int, argv0 string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if args := daemonArgs(pid); len(args) > 0 && args[0] == argv0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("fake daemon pid %d never exec'd into argv0 %q (argv=%q)", pid, argv0, daemonArgs(pid))
+}
+
+func TestVerifyScopedDaemon_MatchesOnlyOurHome(t *testing.T) {
+	if _, err := os.Stat("/proc"); err != nil {
+		t.Skip("scoping by AF home needs /proc")
+	}
+	ourHome := t.TempDir()
+	otherHome := t.TempDir()
+	uid := os.Getuid()
+
+	want, err := canonicalDir(ourHome)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ours := spawnFakeDaemonWithHome(t, ourHome)
+	if got := verifyScopedDaemon(ours, uid, want); got != daemonOurs {
+		t.Errorf("daemon for our home classified %v, want daemonOurs", got)
+	}
+
+	// The invariant that matters most: a daemon serving a DIFFERENT AF home is
+	// never ours to stop. Running several homes side by side is supported, and a
+	// reset that killed all of them would be worse than the stale daemon it came
+	// to clean up.
+	foreign := spawnFakeDaemonWithHome(t, otherHome)
+	if got := verifyScopedDaemon(foreign, uid, want); got != daemonForeign {
+		t.Errorf("daemon for a different AF home classified %v, want daemonForeign", got)
+	}
+}
+
+// TestVerifyScopedDaemon_UnsetHomeMeansDefaultHome pins the trap in scoping by
+// environ: a daemon started WITHOUT AGENT_FACTORY_HOME is not "unknown", it
+// resolved the DEFAULT home. That is the overwhelmingly common case, so reading
+// the variable and skipping when it is absent would skip exactly the everyday
+// stale daemon reset exists to kill — while still, correctly, not matching when
+// we ourselves are pointed at some other home.
+func TestVerifyScopedDaemon_UnsetHomeMeansDefaultHome(t *testing.T) {
+	if _, err := os.Stat("/proc"); err != nil {
+		t.Skip("scoping by AF home needs /proc")
+	}
+	uid := os.Getuid()
+	bare := spawnFakeDaemonWithHome(t, "") // no AGENT_FACTORY_HOME in its environ
+
+	// We are pointed at a temp home; the bare daemon serves the default home.
+	tempHome, err := canonicalDir(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := verifyScopedDaemon(bare, uid, tempHome); got != daemonForeign {
+		t.Errorf("bare daemon vs a temp home classified %v, want daemonForeign", got)
+	}
+
+	// Now resolve the default home the same way the daemon did, and it matches.
+	defHome, err := config.ConfigDirFor("")
+	if err != nil {
+		t.Skipf("cannot resolve the default af home here: %v", err)
+	}
+	wantDefault, err := canonicalDir(defHome)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := verifyScopedDaemon(bare, uid, wantDefault); got != daemonOurs {
+		t.Errorf("bare daemon vs the default home classified %v, want daemonOurs "+
+			"(a daemon with no AGENT_FACTORY_HOME resolved the default home)", got)
+	}
+}
+
+// TestVerifyScopedDaemon_NonDaemonNeverMatches guards the other direction: the
+// scan matches on a `--daemon` token, so anything that is not an af binary — or
+// is a Go test binary — must be rejected before it is ever signalled.
+func TestVerifyScopedDaemon_NonDaemonNeverMatches(t *testing.T) {
+	if _, err := os.Stat("/proc"); err != nil {
+		t.Skip("needs /proc")
+	}
+	uid := os.Getuid()
+	home := t.TempDir()
+	want, err := canonicalDir(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// An unrelated program carrying a --daemon token. Its path must not look
+	// like a Go test binary, or it would be rejected for that reason instead of
+	// the one under test (see fakeBinDir).
+	argv0 := filepath.Join(fakeBinDir(t), "some-other-tool")
+	cmd := fakeDaemonCmd(t, argv0, "sleep 300; :", "--daemon")
+	cmd.Env = []string{"PATH=" + os.Getenv("PATH"), "AGENT_FACTORY_HOME=" + home}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	pid := cmd.Process.Pid
+	t.Cleanup(func() {
+		_ = syscall.Kill(-pid, syscall.SIGKILL)
+		_, _ = cmd.Process.Wait()
+	})
+	waitForArgv(t, pid, argv0)
+
+	if got := verifyScopedDaemon(pid, uid, want); got != daemonForeign {
+		t.Errorf("non-af binary carrying --daemon classified %v, want daemonForeign", got)
+	}
+}
+
+// TestStopOrphanDaemons_StopsOnlyScopedDaemon is the only test here that
+// signals. scopedDaemonScanFn is injected so the candidate list is EXACTLY our
+// two fakes — the real scan is host-wide and must never be run from a test.
+func TestStopOrphanDaemons_StopsOnlyScopedDaemon(t *testing.T) {
+	if _, err := os.Stat("/proc"); err != nil {
+		t.Skip("scoping by AF home needs /proc")
+	}
+	ourHome := t.TempDir()
+	otherHome := t.TempDir()
+
+	ours := spawnFakeDaemonWithHome(t, ourHome)
+	foreign := spawnFakeDaemonWithHome(t, otherHome)
+
+	origScan := scopedDaemonScanFn
+	t.Cleanup(func() { scopedDaemonScanFn = origScan })
+	scopedDaemonScanFn = func() ([]int, error) { return []int{ours, foreign}, nil }
+
+	stopped, unverified, err := StopOrphanDaemons(ourHome)
+	if err != nil {
+		t.Fatalf("StopOrphanDaemons: %v", err)
+	}
+	if len(unverified) != 0 {
+		t.Errorf("unverified = %v, want none", unverified)
+	}
+	if len(stopped) != 1 || stopped[0] != ours {
+		t.Fatalf("stopped = %v, want exactly [%d] (our home's daemon)", stopped, ours)
+	}
+	if pidLooksAlive(ours) {
+		t.Errorf("our daemon pid %d is still alive after StopOrphanDaemons", ours)
+	}
+	if !pidLooksAlive(foreign) {
+		t.Fatalf("StopOrphanDaemons killed pid %d, a daemon for a DIFFERENT AF home", foreign)
+	}
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -849,6 +849,13 @@ Removes every AF-created resource — all sessions (live and archived), all
 scheduled cron/watch tasks, all AF worktrees, the AF session branches AF
 created, and all stored state — returning AF to a clean slate.
 
+Stops every af daemon running for this AF home — the managed one and any
+orphan left behind by an upgrade or a source build — and removes the daemon
+sockets, so a stale daemon or socket cannot serve the next af you start. Only
+daemons owned by you AND using this AGENT_FACTORY_HOME are stopped, and the
+autostart unit is only paused when it serves this AGENT_FACTORY_HOME; a daemon
+or unit for a different AF home is never touched.
+
 KEEPS your real git repositories (working tree, .git, and your own branches),
 and KEEPS the daemon configuration (config.toml: listen_addr, defaults,
 root_agents, update_channel, and per-repo config). After the wipe the


### PR DESCRIPTION
Rebased onto master (ddb72aa). Builds on #1916 and **fixes the #1916 P2 (ungated autostart pause across homes)**.

#1916 already landed the pause/resume-around-the-wipe, so my redundant version of that is **dropped** — its shape is kept as-is.

## What's unique here

**1. Vector A — the daemon must stay DOWN for the whole wipe.**
The daemon is the **single writer** (#960): it persists its in-memory sessions on a tick and again on its shutdown path — `RunDaemon`'s final `SaveInstances()`, which runs *before* the deferred `closeControl()`. `StopDaemon` returning does not mean the flush landed. Reset now **waits for shutdown to COMPLETE**, then stops orphans, then **asserts no af daemon is alive — and aborts rather than wiping**. A wipe that races a live single-writer daemon doesn't half-work, it *loses*: the daemon writes `instances.json` back from memory and the reset silently undoes itself.

**2. Stop ALL af daemons for this user + home**, not just the PID-file one. Before, an orphan/second/source-built `agent-factory --daemon` survived and reset merely *printed* `pkill -f -- '--daemon'`.

**3. Clear stale sockets** — `daemon.sock`, `daemon-http.sock`, `vscode/*.sock` — after the daemons are gone (unlinking a *live* daemon's socket is #767).

## Fixes the #1916 P2 (ungated autostart pause across homes)

The pause was gated on the unit **file existing**, not on the unit serving the home being reset. The unit bakes its `AGENT_FACTORY_HOME` **at install time** (`autostart.go:181` systemd / `:214` launchd), so it has no relationship to the resetting process's home. Result: `AGENT_FACTORY_HOME=/tmp/sandbox af reset` **stops the maintainer's real daemon** — and leaves it stopped if the deferred resume fails. On a shared box that's an outage caused by a sandbox.

Now:
- new `daemon.AutostartUnitServesHome(configDir)` reads the **installed unit's** baked home (absent env == **default home**, the common case) and the unit is touched **only** when it serves `plan.configDir`;
- an unresolvable unit home → **left alone** ("I could not tell" never resolves to "stop it");
- resume is **robust**: retries `autostartResumeAttempts`, then prints `ACTION REQUIRED … Your daemon is STOPPED` **and fails the command**, so a scripted caller sees a non-zero exit instead of a quiet warning.

**Same gate applied to my own stop-ALL logic** — this is the same bug class, so it isn't reproduced: `StopOrphanDaemons` / `AssertNoLiveDaemon` / `RemoveRuntimeSockets` all take the home being reset **explicitly**. Only `af`/`agent-factory` binaries with a discrete `--daemon` token, owned by our uid, resolving *that* home are signalled; a daemon whose home can't be established is **reported, never killed**.

## Tests — watched failing first

| lock | reproduces against |
|---|---|
| `LeavesOtherHomesAutostartUnitAlone` / `UnknownUnitHomeIsLeftAlone` | **master ddb72aa** — "reset paused an autostart unit that serves a DIFFERENT AF home" |
| `WaitsForDaemonFlushBeforeWipe` | wait removed — "instances.json is back … the daemon resurrected the sessions the reset deleted" |
| `VerifyScopedDaemon` / `StopOrphanDaemons` | home check removed — kills a **different home's** daemon |

Plus `ResumeFailureIsLoudAndFails`, ordering (`pause → stop → orphans → assert → sockets → resume`), abort-on-incomplete-shutdown, abort-on-live-daemon (supervision restored), unverifiable-never-signalled, and a unit-home **round-trip** test (systemd `Environment=` quoting + launchd XML, incl. spaced / `%` / quote / backslash homes) so the render/parse pair can't drift.

**Isolation:** #1916's `stubResetDaemonHandling` now delegates to the full fake — otherwise its tests fell through to a **real host-wide pgrep scan** in `stopOrphanDaemonsFn`, protected only by the home filter. Every daemon/autostart/tmux boundary is faked, every home is a temp dir, and unfaked pause/resume `t.Fatal` rather than reaching real systemctl. All reset/daemon runs were **container-only**.

## Gates

`make test-container` (EXIT=0, 29 pkgs) · `go build ./...` · `gofmt -l .` · `golangci-lint run --fast` · `deadcode -test ./...` · `scripts/lint-file-length.sh` · `scripts/gen-docs.sh`

Held **draft** pending review. Not dev-installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
