### PR TITLE
docs(readme): correct tab-capability, autostart, and daemon-spawn claims (#1887 follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,17 @@ Three ideas carry the whole tool.
   git artifact you can diff, push, or open a PR from. Pass `--here` when you
   deliberately want the agent in your current checkout instead.
 - **Tabs — more than one thing per session.** Every session has its agent tab,
-  and you can open more beside it in the same worktree: a shell with `t`, or —
-  via `af sessions tab-create` — a long-running command, a web view, or a
-  VS Code editor.
+  and a local session can open more beside it in the same worktree: a shell with
+  `t`, or — via `af sessions tab-create` — a long-running command, a web view, or
+  a VS Code editor. Sessions on the docker, ssh, and hook backends run off-box,
+  so their tab list is fixed by the runtime; adding tabs to them isn't supported
+  yet.
 - **Daemon — the thing that actually owns state.** A background daemon runs the
   sessions, schedules tasks, serves the web UI, and is the single source of
-  truth. Any `af` command starts it. The TUI, the browser, and the CLI are all
-  thin clients reading the same state, so they never disagree.
+  truth. Opening the TUI starts one, as do autoyes mode and any enabled task;
+  read-only commands like `af config list` and `af tasks list` leave it down. The
+  TUI, the browser, and the CLI are all thin clients reading the same state, so
+  they never disagree.
 
 ## Three ways to drive it
 
@@ -128,7 +132,10 @@ claude = "/home/me/.local/bin/claude --dangerously-skip-permissions"
 
 Linux and macOS are supported; Windows works through WSL2 (keep repos on the
 Linux filesystem). Native Windows is not a target. tmux is required everywhere.
-The daemon autostarts via systemd on Linux and launchd on macOS.
+A fresh install has no autostart unit — run `af daemon install` to register one
+(a systemd user service on Linux, a launchd agent on macOS) so tasks keep firing
+and the web UI stays up across logouts and reboots. `af daemon status` reports
+whether it's installed.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -133,9 +133,10 @@ claude = "/home/me/.local/bin/claude --dangerously-skip-permissions"
 Linux and macOS are supported; Windows works through WSL2 (keep repos on the
 Linux filesystem). Native Windows is not a target. tmux is required everywhere.
 A fresh install has no autostart unit — run `af daemon install` to register one
-(a systemd user service on Linux, a launchd agent on macOS) so tasks keep firing
-and the web UI stays up across logouts and reboots. `af daemon status` reports
-whether it's installed.
+(a systemd user service on Linux, a launchd agent on macOS) so the daemon starts
+at login and task schedules keep running across reboots. Both are user-level
+units, so they cover login and reboot, not running while you are logged out.
+`af daemon status` reports whether one is installed.
 
 ## Documentation
 


### PR DESCRIPTION
Follow-up to #1887. The README rewrite merged with four codex inline findings unaddressed. All four are real — the README is the front door for external users, and CLAUDE.md's mandate is to keep it honest. Every claim below was re-verified against the code rather than taken from the review text.

## The findings

**1 + 4 (P2 + P3, both at line ~71) — tab creation is local-only.** Docker, SSH, and hook sessions embed `remoteAgentBackend`, which reports `TabManagement: false` (`session/backend_remote_agent.go:23`): the AgentServer tab API is data-plane only and cannot create the daemon-side git worktree a new tab requires. That flag gates *both* paths the README documents — `af sessions tab-create` (`daemon/manager_tabs.go:88`) and the `t` shell tab (`app/handle_actions.go:830`). The unqualified "Every session can add…" wording sent users of the backends promoted a few bullets below to a workflow that can only fail. Now scoped to local sessions, with an explicit note that off-box tab lists are runtime-fixed and remote tab creation isn't implemented yet.

**2 (P3, line ~131) — autostart is not automatic.** `InstallAutostart()` has exactly one caller: `af daemon install` (`commands/daemoncmd.go:73`). Neither `install.sh` nor `dev-install.sh` invokes it, so a fresh install has no unit and `af daemon status` reports `not installed`. The old line ("The daemon autostarts via systemd on Linux and launchd on macOS") would lead anyone setting up a cron task to assume it survives a reboot. Now states the requirement and points at `af daemon status`.

**3 (P3, line ~75) — not every command starts the daemon.** `af config list` never dials one (`commands/configcmd.go` mentions the daemon only in config-key names and help text); task list/get take a non-spawning read path with a disk fallback (`api/tasks.go:23-28`), as do session snapshots (`api/sessions.go:39-43`). Only the TUI, autoyes, enabled tasks, and daemon-backed writes guarantee a live daemon — and therefore a reachable web UI. Reworded so nobody expects the scheduler running after an arbitrary subcommand. This also brings the README in line with the daemon's own help text, which already calls out `af config list` as the standalone case.

## Note for reviewers: the review's citations are stale

Finding 1 cited `session/backend_docker.go:485-490`, `backend_ssh.go:748-753`, and `backend_hook_backend.go:235-240`. Those line ranges no longer declare the capability — 3833756 (#1913) consolidated all three backends into the shared `remoteAgentBackend` after the review was written. The **conclusion is unchanged** (all three still embed it and still report `TabManagement: false`); only the declaration site moved. Flagging it so the next reader doesn't chase the old citations.

## Scope & gates

Docs-only — no code changes, and the rewrite's voice and structure are preserved. These are surgical corrections, not another rewrite.

- `gofmt -l .` — clean (no-op, no Go files touched)
- `go build ./...` — green (sanity)
- `scripts/gen-docs.sh` — not applicable; it does not read `README.md`, and no doc mirrors the corrected sentences

Held as **draft** pending review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)