### PR TITLE
fix(daemon): harden the kill path so a stuck teardown cannot hold a session guard forever (defense-in-depth; #1917 root cause is #1943) + confirm-alive Lost-restore backoff (#1910)

### DIFF
--- a/app/dead_session_test.go
+++ b/app/dead_session_test.go
@@ -17,7 +17,7 @@ type deadBackend struct {
 	*session.FakeBackend
 }
 
-func (b *deadBackend) IsAlive(*session.Instance) bool { return false }
+func (b *deadBackend) IsAlive(*session.Instance) (bool, error) { return false, nil }
 
 // newDeadInstance returns a started instance backed by deadBackend with the
 // given starting status. It does not spin up tmux/git, so it is hermetic.

--- a/config/filelock.go
+++ b/config/filelock.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"syscall"
+	"time"
 
 	"github.com/sachiniyer/agent-factory/log"
 )
@@ -41,10 +42,74 @@ func TryWithFileLock(path string, fn func() error) (acquired bool, err error) {
 	return true, fn()
 }
 
+// ErrLockTimeout is returned by WithFileLockTimeout when the flock could not be
+// acquired within the caller's budget. Callers match on it (errors.Is) to tell a
+// contended lock — retryable, the work never ran — from a real failure of fn.
+var ErrLockTimeout = errors.New("timed out waiting for file lock")
+
+// WithFileLockTimeout is WithFileLock bounded by a deadline: it runs fn under the
+// same exclusive flock, but gives up with ErrLockTimeout rather than waiting
+// forever. fn is never run unless the lock was actually held.
+//
+// It is the third point on the line TryWithFileLock and WithFileLock already
+// stake out, and it exists for callers who must genuinely DO the work (so
+// TryWithFileLock's "assume a peer has it in hand" contract is wrong for them)
+// but who must also never hang (so WithFileLock is wrong too). The daemon's kill
+// path is the motivating case: it must delete the record, and it holds a
+// session-wide guard while doing it, so an unbounded wait here does not merely
+// stall one write — it makes the session permanently undeletable (#1917).
+//
+// Acquisition polls LOCK_NB rather than parking in LOCK_EX because flock offers
+// no timed acquire: a blocking Flock cannot be interrupted or given a deadline.
+// Polling costs a wakeup every lockPollInterval while contended and trades away
+// flock's (already unspecified) queueing fairness; the caller's budget bounds how
+// long that lasts. The fd is opened ONCE and reused across attempts so a
+// contended retry does not churn the lock file.
+func WithFileLockTimeout(path string, timeout time.Duration, fn func() error) error {
+	lockPath := path + ".lock"
+
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0755); err != nil {
+		return fmt.Errorf("failed to create lock directory: %w", err)
+	}
+
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to open lock file %s: %w", lockPath, err)
+	}
+	defer f.Close()
+
+	deadline := time.Now().Add(timeout)
+	for {
+		err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			defer syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+			return fn()
+		}
+		if !errors.Is(err, syscall.EWOULDBLOCK) {
+			return fmt.Errorf("failed to acquire file lock on %s: %w", lockPath, err)
+		}
+		if !time.Now().Before(deadline) {
+			return fmt.Errorf("%w on %s after %s (another agent-factory process is holding it)", ErrLockTimeout, lockPath, timeout)
+		}
+		// Sleep no longer than the remaining budget, so the effective wait
+		// matches the caller's timeout instead of overshooting by up to a poll.
+		wait := lockPollInterval
+		if remaining := time.Until(deadline); remaining < wait {
+			wait = remaining
+		}
+		time.Sleep(wait)
+	}
+}
+
+// lockPollInterval is how often WithFileLockTimeout re-attempts a contended
+// flock. A var so tests can shorten it; production never reassigns.
+var lockPollInterval = 20 * time.Millisecond
+
 // WithFileLock acquires an exclusive flock on a .lock file adjacent to the target path,
 // executes fn, and releases the lock. This ensures atomic read-modify-write sequences
 // across multiple processes. It BLOCKS until the lock is free; see
-// TryWithFileLock when a user is waiting on the result.
+// TryWithFileLock when a user is waiting on the result, or WithFileLockTimeout
+// when the caller must do the work but must not hang (#1917).
 func WithFileLock(path string, fn func() error) error {
 	lockPath := path + ".lock"
 

--- a/config/schema_migration.go
+++ b/config/schema_migration.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"time"
 
 	"github.com/pelletier/go-toml/v2"
 )
@@ -163,8 +164,28 @@ func MigrateSchemaBytes(raw []byte, plan SchemaMigrationPlan) ([]byte, SchemaMig
 	return upgraded, result, nil
 }
 
+// SchemaMigrationLockTimeout bounds how long LoadAndMigrateSchemaFile waits for a
+// schema-versioned file's flock. A var so tests can shorten it; production never
+// reassigns.
+//
+// This is the most dangerous unbounded flock in the tree, because of WHERE it is
+// called from rather than what it does: the daemon reaches it on every instance
+// refresh (refreshDaemonInstances -> MigrateAllRepoInstancesForDaemonLoad) while
+// holding the manager's global lock, and a session kill reaches that refresh
+// before it has done anything else. Parking here therefore does not stall one
+// migration — it freezes the whole daemon, including the RPC that would report
+// the problem and the shutdown that would clear it (#1917: a wedged daemon also
+// failed to exit on SIGTERM and had to be SIGKILLed).
+//
+// The lock is held across a read + in-place migrate + atomic write of one small
+// file, so a wait beyond this budget means a peer is wedged, not slow.
+var SchemaMigrationLockTimeout = 10 * time.Second
+
 // LoadAndMigrateSchemaFile reads, migrates, validates, backs up, and atomically
-// writes back one schema-versioned file under its file lock.
+// writes back one schema-versioned file under its file lock. The lock is taken
+// with a DEADLINE (see SchemaMigrationLockTimeout): contention surfaces as a
+// retryable ErrLockTimeout instead of freezing the caller — which, on the daemon's
+// refresh path, means freezing the daemon.
 func LoadAndMigrateSchemaFile(plan SchemaMigrationPlan) ([]byte, SchemaMigrationResult, error) {
 	if plan.Path == "" {
 		return nil, SchemaMigrationResult{}, fmt.Errorf("schema migration path is required")
@@ -176,7 +197,7 @@ func LoadAndMigrateSchemaFile(plan SchemaMigrationPlan) ([]byte, SchemaMigration
 
 	var migrated []byte
 	var result SchemaMigrationResult
-	err := WithFileLock(plan.Path, func() error {
+	err := WithFileLockTimeout(plan.Path, SchemaMigrationLockTimeout, func() error {
 		raw, err := os.ReadFile(plan.Path)
 		if err != nil {
 			return fmt.Errorf("%s: read: %w", describeSchemaStore(plan.StoreName, plan.Path), err)

--- a/config/state.go
+++ b/config/state.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/sachiniyer/agent-factory/log"
 )
@@ -349,13 +350,29 @@ func RepoInstancesPath(repoID string) (string, error) {
 	return repoInstancesPath(repoID)
 }
 
-// UpdateRepoInstances loads instances under a file lock, applies fn, and saves atomically.
+// RepoInstancesLockTimeout bounds how long UpdateRepoInstances waits for a repo's
+// instances flock. A var so tests can shorten it; production never reassigns.
+//
+// This lock is held only across a read-modify-write of one small JSON file, so
+// waiting seconds for it already means a peer is wedged rather than busy — and
+// the daemon holds much bigger things while it waits. A kill holds its session's
+// kill guard and op lock across this write, and the Lost-restore loop holds the
+// same op lock across its own; an unbounded wait there does not stall one write,
+// it makes the session permanently undeletable and starves the tombstone finisher
+// that would otherwise heal it (#1917). Failing with a retryable error is always
+// better than a daemon that cannot be asked to stop.
+var RepoInstancesLockTimeout = 10 * time.Second
+
+// UpdateRepoInstances loads instances under a file lock, applies fn, and saves
+// atomically. The lock is taken with a DEADLINE (see RepoInstancesLockTimeout):
+// contention surfaces as a retryable ErrLockTimeout rather than parking the
+// caller — and every caller here is the daemon, holding session-wide locks.
 func UpdateRepoInstances(repoID string, fn func(raw json.RawMessage) (json.RawMessage, error)) error {
 	path, err := repoInstancesPath(repoID)
 	if err != nil {
 		return err
 	}
-	return WithFileLock(path, func() error {
+	return WithFileLockTimeout(path, RepoInstancesLockTimeout, func() error {
 		raw, err := LoadRepoInstances(repoID)
 		if err != nil {
 			return err

--- a/daemon/configagent.go
+++ b/daemon/configagent.go
@@ -88,7 +88,10 @@ func (c *configAgentSupervisor) reap(name string) error {
 	if !ok {
 		return nil
 	}
-	if err := ts.Close(); err != nil {
+	// Pane state deliberately ignored (#1917): a config agent has no worktree (see
+	// HooksDone above), so Close's PaneState cannot gate any destructive step —
+	// there is nothing to delete under a possibly-live pane.
+	if _, err := ts.Close(); err != nil {
 		return fmt.Errorf("failed to close config-agent session %s: %w", name, err)
 	}
 	return nil
@@ -111,7 +114,8 @@ func (c *configAgentSupervisor) Stop() {
 		wg.Add(1)
 		go func(ts *tmux.TmuxSession) {
 			defer wg.Done()
-			if err := ts.Close(); err != nil {
+			// Pane state ignored: config agents have no worktree (see HooksDone).
+			if _, err := ts.Close(); err != nil {
 				log.WarningLog.Printf("config agent: closing session failed during shutdown: %v", err)
 			}
 		}(ts)
@@ -180,8 +184,9 @@ func (m *Manager) SpawnConfigAgent(ctx context.Context, req SpawnConfigAgentRequ
 		return "", fmt.Errorf("config agent: failed to start tmux session: %w", err)
 	}
 	if !m.configAgents.track(name, ts) {
-		// The daemon is shutting down; do not leak the session we just made.
-		_ = ts.Close()
+		// The daemon is shutting down; do not leak the session we just made. Pane
+		// state ignored: no worktree, so nothing destructive follows (see HooksDone).
+		_, _ = ts.Close()
 		return "", fmt.Errorf("config agent: the daemon is shutting down")
 	}
 	// Any failure past this point tears the session down rather than leaving a

--- a/daemon/control_test.go
+++ b/daemon/control_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/internal/testguard"
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/git"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
@@ -670,11 +671,12 @@ func stubGhostCleanup(t *testing.T) (wtCalls *[]string, tmuxCalls *[]string) {
 	var wt, tm []string
 	prevWT := ghostCleanupWorktree
 	prevTmux := ghostKillTmuxByName
-	ghostCleanupWorktree = func(data *session.InstanceData, title string) {
+	ghostCleanupWorktree = func(data *session.InstanceData, title string) (git.CleanupState, error) {
 		if data.Worktree.RepoPath == "" || data.Worktree.WorktreePath == "" || data.Worktree.ExternalWorktree {
-			return
+			return git.CleanupSettled, nil
 		}
 		wt = append(wt, title)
+		return git.CleanupSettled, nil
 	}
 	ghostKillTmuxByName = func(name string) (tmux.PaneState, error) {
 		tm = append(tm, name)
@@ -763,8 +765,9 @@ func TestGhostCleanup_TmuxBeforeWorktree(t *testing.T) {
 	var order []string
 	prevWT := ghostCleanupWorktree
 	prevTmux := ghostKillTmuxByName
-	ghostCleanupWorktree = func(data *session.InstanceData, title string) {
+	ghostCleanupWorktree = func(data *session.InstanceData, title string) (git.CleanupState, error) {
 		order = append(order, "worktree")
+		return git.CleanupSettled, nil
 	}
 	ghostKillTmuxByName = func(name string) (tmux.PaneState, error) {
 		order = append(order, "tmux")

--- a/daemon/control_test.go
+++ b/daemon/control_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/internal/testguard"
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
 func setupControlRepo(t *testing.T) string {
@@ -675,9 +676,9 @@ func stubGhostCleanup(t *testing.T) (wtCalls *[]string, tmuxCalls *[]string) {
 		}
 		wt = append(wt, title)
 	}
-	ghostKillTmuxByName = func(name string) error {
+	ghostKillTmuxByName = func(name string) (tmux.PaneState, error) {
 		tm = append(tm, name)
-		return nil
+		return tmux.PaneStateKnown, nil
 	}
 	t.Cleanup(func() {
 		ghostCleanupWorktree = prevWT
@@ -699,7 +700,7 @@ func TestGhostCleanup_TmuxOrphan(t *testing.T) {
 		Program:  "claude",
 		TmuxName: "af_ghost",
 	}
-	ghostCleanup(data, "ghost")
+	_ = ghostCleanup(data, "ghost")
 
 	if len(*wtCalls) != 0 {
 		t.Fatalf("expected worktree cleanup skipped, got: %v", *wtCalls)
@@ -725,7 +726,7 @@ func TestGhostCleanup_BothPopulated(t *testing.T) {
 			BranchName:   "af/ghost",
 		},
 	}
-	ghostCleanup(data, "ghost")
+	_ = ghostCleanup(data, "ghost")
 
 	if len(*wtCalls) != 1 || (*wtCalls)[0] != "ghost" {
 		t.Fatalf("expected worktree cleanup, got: %v", *wtCalls)
@@ -744,7 +745,7 @@ func TestGhostCleanup_AllEmpty(t *testing.T) {
 		Title:   "ghost",
 		Program: "claude",
 	}
-	ghostCleanup(data, "ghost")
+	_ = ghostCleanup(data, "ghost")
 
 	if len(*wtCalls) != 0 {
 		t.Fatalf("expected no worktree cleanup, got: %v", *wtCalls)
@@ -765,9 +766,9 @@ func TestGhostCleanup_TmuxBeforeWorktree(t *testing.T) {
 	ghostCleanupWorktree = func(data *session.InstanceData, title string) {
 		order = append(order, "worktree")
 	}
-	ghostKillTmuxByName = func(name string) error {
+	ghostKillTmuxByName = func(name string) (tmux.PaneState, error) {
 		order = append(order, "tmux")
-		return nil
+		return tmux.PaneStateKnown, nil
 	}
 	t.Cleanup(func() {
 		ghostCleanupWorktree = prevWT
@@ -785,7 +786,7 @@ func TestGhostCleanup_TmuxBeforeWorktree(t *testing.T) {
 			BranchName:   "af/ghost",
 		},
 	}
-	ghostCleanup(data, "ghost")
+	_ = ghostCleanup(data, "ghost")
 
 	if len(order) != 2 || order[0] != "tmux" || order[1] != "worktree" {
 		t.Fatalf("expected tmux teardown before worktree cleanup (#802), got: %v", order)
@@ -797,8 +798,14 @@ func TestGhostCleanup_TmuxBeforeWorktree(t *testing.T) {
 // only appear via storage corruption, and silently killing whatever tmux
 // session it names could destroy unrelated work.
 func TestGhostKillTmuxByName_RefusesNonAfPrefix(t *testing.T) {
-	if err := ghostKillTmuxByName("not-ours"); err == nil {
+	state, err := ghostKillTmuxByName("not-ours")
+	if err == nil {
 		t.Fatalf("expected refusal for non-af prefix, got nil")
+	}
+	// A refusal runs no tmux command, so nothing is unknown — the caller must be
+	// free to go on cleaning up a ghost whose tmux name it declined to touch.
+	if state != tmux.PaneStateKnown {
+		t.Fatalf("a refused name must report a KNOWN state, got %v", state)
 	}
 }
 

--- a/daemon/destructive.go
+++ b/daemon/destructive.go
@@ -34,8 +34,10 @@ import (
 // never clear, not even by explicit retry, until a daemon restart reloaded an inert
 // backend. Safe-by-default must not become stuck-by-default.
 //
-// Returns deleted=false with a nil error when the delete was correctly skipped, so
-// callers can distinguish "refused" from "failed".
+// A refusal is returned as an ERROR wrapping the teardown's own cause, not as a
+// quiet (false, nil): callers must not read a refusal as "nothing to delete". That
+// distinction is what arms reapDeadRoot's backoff and what makes KillSession report
+// something actionable rather than success.
 func (m *Manager) deleteSessionRecord(repoID, title, stableID string, teardownErr error) (bool, error) {
 	if session.TeardownStateUnknown(teardownErr) {
 		return false, fmt.Errorf("refusing to delete the record for session %q: its teardown did not complete safely, so its workspace is still on disk and this record is the only handle left on it: %w", title, teardownErr)

--- a/daemon/destructive.go
+++ b/daemon/destructive.go
@@ -1,0 +1,41 @@
+package daemon
+
+import (
+	"fmt"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// The one choke point for deleting a session's record (#1917).
+//
+// Deleting the record is the LAST destructive act of a kill and the most
+// consequential: the record is the only handle the user — and the daemon's own
+// retry — has on a session's tmux and worktree. Drop it while the teardown's
+// outcome is unknown and the workspace is orphaned with nothing pointing at it,
+// permanently.
+//
+// This existed three times (KillSession, finishUserKill, reapDeadRoot), each
+// hand-gating the same rule, and the review found one of them ungated every round
+// — reapDeadRoot was still log-and-delete after two "exhaustive" audits. The gate
+// is not something three call sites should each remember. Routing them through one
+// function means a fourth caller cannot forget, because there is nowhere else to
+// call.
+//
+// teardownErr is whatever Instance.Kill returned. Kill already swallows everything
+// tmux and git ANSWER for (see teardownKill), so a non-nil error here means the
+// teardown could not complete SAFELY — a pane whose liveness tmux never confirmed,
+// or a worktree removal cut off mid-delete. Both mean the workspace is still there.
+//
+// Returns deleted=false with a nil error when the delete was correctly skipped, so
+// callers can distinguish "refused" from "failed".
+func (m *Manager) deleteSessionRecord(repoID, title, stableID string, teardownErr error) (bool, error) {
+	if teardownErr != nil {
+		return false, fmt.Errorf("refusing to delete the record for session %q: its teardown did not complete safely, so its workspace is still on disk and this record is the only handle left on it: %w", title, teardownErr)
+	}
+	storage, err := session.NewStorage(config.LoadState(), repoID)
+	if err != nil {
+		return false, err
+	}
+	return storage.DeleteInstanceByStableID(title, stableID)
+}

--- a/daemon/destructive.go
+++ b/daemon/destructive.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 )
 
@@ -22,16 +23,27 @@ import (
 // function means a fourth caller cannot forget, because there is nowhere else to
 // call.
 //
-// teardownErr is whatever Instance.Kill returned. Kill already swallows everything
-// tmux and git ANSWER for (see teardownKill), so a non-nil error here means the
-// teardown could not complete SAFELY — a pane whose liveness tmux never confirmed,
-// or a worktree removal cut off mid-delete. Both mean the workspace is still there.
+// teardownErr is whatever Instance.Kill returned, and ONLY an unknown-STATE error
+// blocks — see session.TeardownStateUnknown for why the distinction is the whole
+// design and not a detail.
+//
+// Blocking on any non-nil error was wrong and inverted the goal (#1917 round 5): a
+// remote session whose sandbox teardown SUCCEEDED but whose in-sandbox /kill call
+// failed still returns an error, and refusing on it made the finisher retry a dead
+// endpoint forever against a workspace that no longer exists — the tombstone could
+// never clear, not even by explicit retry, until a daemon restart reloaded an inert
+// backend. Safe-by-default must not become stuck-by-default.
 //
 // Returns deleted=false with a nil error when the delete was correctly skipped, so
 // callers can distinguish "refused" from "failed".
 func (m *Manager) deleteSessionRecord(repoID, title, stableID string, teardownErr error) (bool, error) {
-	if teardownErr != nil {
+	if session.TeardownStateUnknown(teardownErr) {
 		return false, fmt.Errorf("refusing to delete the record for session %q: its teardown did not complete safely, so its workspace is still on disk and this record is the only handle left on it: %w", title, teardownErr)
+	}
+	if teardownErr != nil {
+		// The teardown TOLD us something went wrong, but not that the workspace's
+		// fate is unknown. The record may go; the error is the caller's to report.
+		log.WarningLog.Printf("session %q: teardown reported an error that does not leave its workspace state unknown; deleting the record as normal: %v", title, teardownErr)
 	}
 	storage, err := session.NewStorage(config.LoadState(), repoID)
 	if err != nil {

--- a/daemon/kill_commit_test.go
+++ b/daemon/kill_commit_test.go
@@ -2,13 +2,17 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/git"
+	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
 // installFailKillTombstoned builds a session whose teardown always fails, then
@@ -257,5 +261,161 @@ func TestRefreshInstanceStatus_TombstonedAfterTeardown_StillFinishesTheKill(t *t
 	manager.mu.Unlock()
 	if tracked {
 		t.Fatal("the finished kill left the instance tracked in the manager")
+	}
+}
+
+// TestPersistKillTombstone_ConcurrentPollWrite_TombstoneSurvives is round-3
+// finding (1): the commit point must not be silently roll-back-able.
+//
+// The tombstone write and the in-memory mark used to straddle a repoStartLock
+// release. A status poll (which serializes instance.ToInstanceData() under that
+// same lock) could land in the gap, read userKilled still false, and write the
+// tombstone straight back out. A teardown timeout or crash afterwards then leaves
+// a surviving NON-tombstoned record, which the next daemon reads as Lost and
+// RESTORES — the killed session comes back. Same outcome as the round-2 finding,
+// different route.
+//
+// killTombstonePersist is the exact gap: it runs INSIDE the lock, so a poll racing
+// from here reproduces the real window rather than approximating it.
+//
+// PRE-FIX BEHAVIOR THIS REPRODUCES: the poll's write wins and the record ends up
+// with UserKilled=false.
+func TestPersistKillTombstone_ConcurrentPollWrite_TombstoneSurvives(t *testing.T) {
+	backend := &raceBackend{}
+	manager, repoID, inst := installRaceBackend(t, backend, "clobbered")
+
+	// Race a poll persist at the precise moment the tombstone write completes —
+	// i.e. while persistKillTombstone still holds (or has just held) the repo lock.
+	prev := killTombstonePersist
+	var once sync.Once
+	killTombstonePersist = func(rid string, d session.InstanceData) error {
+		err := prev(rid, d)
+		once.Do(func() {
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				// The poll's own persist: it takes repoStartLock and serializes the
+				// instance under it, exactly as refreshInstanceStatus does.
+				manager.persistInstance(rid, inst)
+			}()
+			// Give the racing writer time to block on (or take) the lock.
+			time.Sleep(50 * time.Millisecond)
+			t.Cleanup(func() { <-done })
+		})
+		return err
+	}
+	t.Cleanup(func() { killTombstonePersist = prev })
+
+	if err := manager.persistKillTombstone(repoID, inst, nil); err != nil {
+		t.Fatalf("persistKillTombstone: %v", err)
+	}
+	// Let the racing poll write land.
+	time.Sleep(200 * time.Millisecond)
+
+	rec := recordFor(t, repoID, "clobbered")
+	if rec == nil {
+		t.Fatal("the record vanished")
+	}
+	if !rec.UserKilled {
+		t.Fatal("a concurrent poll write erased the kill tombstone: the kill is no longer durable, " +
+			"so a teardown timeout or crash leaves a non-tombstoned record that the next daemon " +
+			"treats as Lost and RESTORES — resurrecting a session the user explicitly killed (#1917). " +
+			"A commit point another writer can roll back is not a commit point.")
+	}
+}
+
+// TestGhostCleanup_WorktreeTimeout_RetainsTheRecord is round-3 finding (2): the
+// third instance of the orphaning class.
+//
+// A ghost session's worktree removal hits the local-git deadline. The cleanup only
+// LOGGED it, so ghostCleanup returned nil and KillSession deleted the tombstoned
+// record — leaving a partially-removed workspace with no record and no retry path.
+//
+// PRE-FIX BEHAVIOR THIS REPRODUCES: ghostCleanup returns nil.
+func TestGhostCleanup_WorktreeTimeout_RetainsTheRecord(t *testing.T) {
+	prevWT, prevTmux := ghostCleanupWorktree, ghostKillTmuxByName
+	ghostKillTmuxByName = func(string) (tmux.PaneState, error) { return tmux.PaneStateKnown, nil }
+	ghostCleanupWorktree = func(*session.InstanceData, string) (git.CleanupState, error) {
+		return git.CleanupStateUnknown, context.DeadlineExceeded
+	}
+	t.Cleanup(func() { ghostCleanupWorktree, ghostKillTmuxByName = prevWT, prevTmux })
+
+	data := &session.InstanceData{Title: "ghost", TmuxName: "af_ghost"}
+	err := ghostCleanup(data, "ghost")
+
+	if err == nil {
+		t.Fatal("ghostCleanup reported success though the worktree removal was cut off mid-delete: " +
+			"KillSession then deletes the record, leaving a partially-removed workspace with NO " +
+			"record and NO retry path — the exact orphaning the timeout work exists to prevent (#1917)")
+	}
+	if !errors.Is(err, session.ErrWorkspaceStateUnknown) {
+		t.Fatalf("the error must identify an unknown workspace state so the caller keeps the record, got: %v", err)
+	}
+}
+
+// unsafeKillBackend fails to START and cannot clean up safely afterwards: its Kill
+// reports the shape a wedged tmux / cut-off worktree removal produces, so the
+// create's cleanup leaves the workspace on disk.
+type unsafeKillBackend struct{ readyFakeBackend }
+
+func (b unsafeKillBackend) Start(*session.Instance, bool) error {
+	return fmt.Errorf("agent program exited immediately")
+}
+
+func (b unsafeKillBackend) Kill(*session.Instance) error {
+	return fmt.Errorf("%w: leaving the workspace untouched", session.ErrPaneMayBeLive)
+}
+
+// TestCreateSession_UnsafeCleanup_KeepsTheRecordAndTheTitle is round-3 finding (3).
+//
+// A failed create discards its instance and releases the title — correct, because
+// the cleanup removed what the create built. When the cleanup could NOT complete,
+// that same release puts the title back in circulation on top of live leftovers no
+// record points at, so the next create under that name collides with or removes
+// them.
+//
+// PRE-FIX BEHAVIOR THIS REPRODUCES: `_ = instance.Kill()` discarded the error, no
+// record was kept, and the title was free.
+func TestCreateSession_UnsafeCleanup_KeepsTheRecordAndTheTitle(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	restore := session.SetBackendFactoryForTest(func(session.InstanceOptions, string) (session.Backend, error) {
+		fake := session.NewFakeBackend()
+		fake.CompleteStart()
+		return unsafeKillBackend{readyFakeBackend{fake}}, nil
+	})
+	t.Cleanup(restore)
+
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	_, cerr := manager.CreateSession(context.Background(), CreateSessionRequest{
+		Title: "leftover", RepoPath: repoPath, Program: "claude",
+	})
+	if cerr == nil {
+		t.Fatal("CreateSession reported success though its start failed")
+	}
+	if !strings.Contains(cerr.Error(), "kept") {
+		t.Fatalf("the error must tell the user the session was preserved so they can act on it: %v", cerr)
+	}
+
+	// The leftovers must be addressable: a record holds the title, so the next
+	// create with this name collides loudly instead of landing on top of them.
+	if rec := recordFor(t, repo.ID, "leftover"); rec == nil {
+		t.Fatal("a create whose cleanup could not complete safely released its title and kept NO " +
+			"record: its tmux/worktree are still on disk with nothing pointing at them, and the " +
+			"next create under this title collides with or deletes them (#1917)")
+	}
+	manager.mu.Lock()
+	_, tracked := manager.instances[daemonInstanceKey(repo.ID, "leftover")]
+	manager.mu.Unlock()
+	if !tracked {
+		t.Fatal("the preserved session is not tracked, so the user cannot kill it through the product")
 	}
 }

--- a/daemon/kill_commit_test.go
+++ b/daemon/kill_commit_test.go
@@ -211,3 +211,51 @@ func TestRestoreLostSessions_SurvivedSettleThenDied_StartsFreshEpisode(t *testin
 		t.Fatalf("recover calls = %d, want 2: a fresh loss episode must attempt a restore, not back off", got)
 	}
 }
+
+// TestRefreshInstanceStatus_TombstonedAfterTeardown_StillFinishesTheKill is
+// review finding (5): the promise of an automatic retry has to be one the code
+// keeps.
+//
+// When the record delete loses a bounded race for the instances lock, the kill
+// returns an error saying it "will be retried automatically" — but Instance.Kill
+// has already set started=false, and refreshInstanceStatus returned at its
+// !Started() check BEFORE it looked for the tombstone. So finishUserKill never
+// ran, the tombstone sat unprocessed for the daemon's whole life, and the session
+// stayed on screen: the #1917 symptom, reached by a new route.
+//
+// This survived the first round because the DISK record still says started=true
+// (the tombstone is written before teardown), so a daemon RESTART reloaded it and
+// finished the kill — which is exactly the "only a restart can reap it" behavior
+// this PR exists to remove.
+//
+// PRE-FIX BEHAVIOR THIS REPRODUCES: the record is never deleted (finishUserKill
+// is unreachable for a torn-down instance).
+func TestRefreshInstanceStatus_TombstonedAfterTeardown_StillFinishesTheKill(t *testing.T) {
+	backend := &raceBackend{}
+	manager, repoID, inst := installRaceBackend(t, backend, "stranded")
+
+	// The exact post-teardown state a lock-timed-out kill leaves behind: the
+	// teardown ran (started=false) and the kill intent is durable.
+	if err := manager.persistKillTombstone(repoID, inst, nil); err != nil {
+		t.Fatalf("persistKillTombstone: %v", err)
+	}
+	inst.SetStartedForTest(false)
+	if rec := recordFor(t, repoID, "stranded"); rec == nil || !rec.UserKilled {
+		t.Fatal("setup: the record must carry a durable tombstone")
+	}
+
+	// One poll, with the contention now gone.
+	manager.refreshInstanceStatus(repoID, inst)
+
+	if rec := recordFor(t, repoID, "stranded"); rec != nil {
+		t.Fatal("the poll never finished the tombstoned kill, so the session stays on screen " +
+			"undeletable until the daemon restarts — the very outcome this PR removes, and the " +
+			"error told the user it would be retried automatically (#1917 review)")
+	}
+	manager.mu.Lock()
+	_, tracked := manager.instances[daemonInstanceKey(repoID, "stranded")]
+	manager.mu.Unlock()
+	if tracked {
+		t.Fatal("the finished kill left the instance tracked in the manager")
+	}
+}

--- a/daemon/kill_commit_test.go
+++ b/daemon/kill_commit_test.go
@@ -1,0 +1,213 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// installFailKillTombstoned builds a session whose teardown always fails, then
+// drives one KillSession over it — which durably tombstones the record and, since
+// the teardown could not complete, leaves the record in place. That is exactly the
+// state finishUserKill is meant to converge from.
+func installFailKillTombstoned(t *testing.T, title string) (*Manager, string, *session.Instance) {
+	t.Helper()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	restore := session.SetBackendFactoryForTest(func(session.InstanceOptions, string) (session.Backend, error) {
+		fake := session.NewFakeBackend()
+		fake.CompleteStart()
+		return failKillBackend{readyFakeBackend{fake}}, nil
+	})
+	t.Cleanup(restore)
+
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if _, err := manager.CreateSession(context.Background(), CreateSessionRequest{
+		Title:    title,
+		RepoPath: repoPath,
+		Program:  "claude",
+	}); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if _, err := manager.KillSession(KillSessionRequest{Title: title, RepoID: repo.ID}); err == nil {
+		t.Fatal("expected KillSession to surface the failing teardown")
+	}
+	manager.mu.Lock()
+	inst := manager.instances[daemonInstanceKey(repo.ID, title)]
+	manager.mu.Unlock()
+	if inst == nil {
+		t.Fatal("the instance must stay tracked after a teardown that could not complete")
+	}
+	return manager, repo.ID, inst
+}
+
+// The #1917 follow-up locks, daemon side. Shared principle with the session-side
+// gate tests: a bound that TRIPS must stop the destructive step. These pin the
+// two places a tripped bound must change control flow rather than be logged.
+
+// TestKillSession_UnrecordableKill_AbortsBeforeTeardown: the tombstone is the
+// kill's commit point, so a kill that cannot be RECORDED must not be PERFORMED.
+//
+// Bounding UpdateRepoInstances gave this write a new, realistic failure mode
+// (another af process holding the instances flock), where before it could only
+// fail on a disk fault. Tearing down anyway leaves no durable record that the
+// user asked for the kill — so a daemon that then dies before the record delete
+// reloads a non-tombstoned row whose tmux is gone, classifies it Lost, and
+// RESTORES it: a session the user explicitly killed comes back, pointed at a
+// worktree the teardown already deleted.
+//
+// PRE-FIX BEHAVIOR THIS REPRODUCES: persistKillTombstone returned nothing,
+// KillSession logged the failure and tore the session down regardless (kills=1).
+func TestKillSession_UnrecordableKill_AbortsBeforeTeardown(t *testing.T) {
+	backend := &raceBackend{}
+	manager, repoID, inst := installRaceBackend(t, backend, "unrecordable")
+
+	// Force exactly the write that records the kill intent to fail, and nothing
+	// else — the same isolation archivePersist gives the archive commit.
+	prev := killTombstonePersist
+	killTombstonePersist = func(string, session.InstanceData) error {
+		return fmt.Errorf("instances lock is held by another process")
+	}
+	t.Cleanup(func() { killTombstonePersist = prev })
+
+	_, err := manager.KillSession(KillSessionRequest{Title: "unrecordable", RepoID: repoID})
+	if err == nil {
+		t.Fatal("KillSession reported success though it could not record the kill intent")
+	}
+	if !strings.Contains(err.Error(), "retry") {
+		t.Fatalf("the error must tell the user this is retryable: %v", err)
+	}
+
+	// NOTHING may have been destroyed: this is the last point at which the kill is
+	// still free, and the whole value of aborting is that the retry is a true retry.
+	if kills, _ := backend.counts(); kills != 0 {
+		t.Fatalf("the session was torn down despite its kill never being recorded (kills=%d); "+
+			"a crash before the record delete would then RESTORE a killed session (#1917)", kills)
+	}
+
+	// And no in-memory tombstone may linger: refreshInstanceStatus routes a
+	// UserKilled instance to finishUserKill, which would complete on the next poll
+	// exactly the kill this call just refused — defeating the abort.
+	if inst.UserKilled() {
+		t.Fatal("an aborted kill left an in-memory kill tombstone; the poll's finishUserKill " +
+			"would tear the session down anyway, making the abort meaningless")
+	}
+
+	// The record must still be a live, killable session.
+	rec := recordFor(t, repoID, "unrecordable")
+	if rec == nil {
+		t.Fatal("the record vanished after an aborted kill")
+	}
+	if rec.UserKilled {
+		t.Fatal("an aborted kill left a durable tombstone on disk")
+	}
+
+	// The retry must work once the write can land again.
+	killTombstonePersist = prev
+	if _, err := manager.KillSession(KillSessionRequest{Title: "unrecordable", RepoID: repoID}); err != nil {
+		t.Fatalf("retry after the write recovered must succeed, got: %v", err)
+	}
+}
+
+// TestFinishUserKill_UnsafeTeardown_KeepsTheRecordForRetry: the tombstone finisher
+// is the retry path the bounded teardown depends on, so it must not do the very
+// thing the bound exists to prevent.
+//
+// Instance.Kill already swallows every failure tmux or git ANSWERED with, so an
+// error reaching here means the teardown could not complete SAFELY — a pane whose
+// liveness is unknown, or a worktree whose removal was cut off mid-delete. In both
+// cases the workspace is still on disk. Deleting the record anyway orphans it and
+// takes away the user's only handle to retry through.
+//
+// PRE-FIX BEHAVIOR THIS REPRODUCES: finishUserKill logged the Kill error and
+// deleted the record regardless.
+func TestFinishUserKill_UnsafeTeardown_KeepsTheRecordForRetry(t *testing.T) {
+	manager, repoID, inst := installFailKillTombstoned(t, "orphan-risk")
+
+	manager.finishUserKill(repoID, inst)
+
+	rec := recordFor(t, repoID, "orphan-risk")
+	if rec == nil {
+		t.Fatal("finishUserKill deleted the record even though the teardown could not complete " +
+			"safely: the worktree is still registered on disk and the user has just lost the only " +
+			"handle to retry the kill through (#1917)")
+	}
+	if !rec.UserKilled {
+		t.Fatal("the retained record must keep its tombstone, or the next poll restores it")
+	}
+	manager.mu.Lock()
+	_, tracked := manager.instances[daemonInstanceKey(repoID, "orphan-risk")]
+	manager.mu.Unlock()
+	if !tracked {
+		t.Fatal("the instance was dropped from the manager, so no later poll can retry the kill")
+	}
+}
+
+// TestRestoreLostSessions_SurvivedSettleThenDied_StartsFreshEpisode: the settle
+// deadline is load-bearing, not decoration.
+//
+// A runtime that OUTLIVED confirmBy was confirmed alive by definition, even if no
+// sweep happened to observe it non-Lost first — the sweep only runs while the row
+// reads non-Lost, so a death just after the window can beat it. Treating that as
+// "died before confirmation" saddles a genuinely new loss episode with the
+// previous one's failure history and backs it off instead of restoring it
+// promptly.
+//
+// PRE-FIX BEHAVIOR THIS REPRODUCES: diedBeforeConfirm read st.awaitingConfirm
+// without consulting st.confirmBy, so ANY Lost row with a pending confirmation
+// inherited the old history (failures=1, backed off) no matter how long its
+// runtime had actually survived.
+func TestRestoreLostSessions_SurvivedSettleThenDied_StartsFreshEpisode(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &recoverFakeBackend{FakeBackend: session.NewFakeBackend()}
+	inst := registerStarted(t, manager, repoID, repoPath, "long-lived", backend, true, session.Lost)
+	zeroRestoreBackoff(t)
+
+	key := daemonInstanceKey(repoID, "long-lived")
+	manager.RestoreLostSessions() // recovers; arms the confirmation window
+	if got := backend.recoverCalls(); got != 1 {
+		t.Fatalf("recover calls = %d, want 1", got)
+	}
+
+	// The runtime survived well past its settle window, then died much later.
+	manager.mu.Lock()
+	st := manager.lostRestoreStates[key]
+	if st == nil || !st.awaitingConfirm {
+		manager.mu.Unlock()
+		t.Fatal("expected a restore awaiting confirmation")
+	}
+	st.confirmBy = time.Now().Add(-time.Hour)
+	manager.mu.Unlock()
+	inst.SetStatusForTest(session.Lost)
+
+	manager.RestoreLostSessions()
+
+	manager.mu.Lock()
+	st = manager.lostRestoreStates[key]
+	failures := -1
+	if st != nil {
+		failures = st.consecutiveFailures
+	}
+	manager.mu.Unlock()
+
+	if failures > 0 {
+		t.Fatalf("a runtime that outlived its settle window was charged %d failure(s) from the "+
+			"PREVIOUS episode; it was confirmed alive, so this loss must start a fresh episode "+
+			"and be restored promptly rather than backed off (#1910)", failures)
+	}
+	if got := backend.recoverCalls(); got != 2 {
+		t.Fatalf("recover calls = %d, want 2: a fresh loss episode must attempt a restore, not back off", got)
+	}
+}

--- a/daemon/kill_commit_test.go
+++ b/daemon/kill_commit_test.go
@@ -15,6 +15,17 @@ import (
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
+// unsafeTeardownBackend starts fine but its teardown can never complete SAFELY: it
+// reports the shape a wedged tmux produces, where the pane's liveness was never
+// established and the workspace may still be live. That — not a generic failure —
+// is what "unsafe" means to deleteSessionRecord (see session.TeardownStateUnknown),
+// so a double that returns a plain error would no longer model this case at all.
+type unsafeTeardownBackend struct{ readyFakeBackend }
+
+func (b unsafeTeardownBackend) Kill(*session.Instance) error {
+	return fmt.Errorf("kill: tab %q: %w", "agent", session.ErrPaneMayBeLive)
+}
+
 // installFailKillTombstoned builds a session whose teardown always fails, then
 // drives one KillSession over it — which durably tombstones the record and, since
 // the teardown could not complete, leaves the record in place. That is exactly the
@@ -25,7 +36,7 @@ func installFailKillTombstoned(t *testing.T, title string) (*Manager, string, *s
 	restore := session.SetBackendFactoryForTest(func(session.InstanceOptions, string) (session.Backend, error) {
 		fake := session.NewFakeBackend()
 		fake.CompleteStart()
-		return failKillBackend{readyFakeBackend{fake}}, nil
+		return unsafeTeardownBackend{readyFakeBackend{fake}}, nil
 	})
 	t.Cleanup(restore)
 
@@ -401,7 +412,7 @@ func TestCreateSession_UnsafeCleanup_KeepsTheRecordAndTheTitle(t *testing.T) {
 	if cerr == nil {
 		t.Fatal("CreateSession reported success though its start failed")
 	}
-	if !strings.Contains(cerr.Error(), "kept") {
+	if !strings.Contains(cerr.Error(), "recorded") {
 		t.Fatalf("the error must tell the user the session was preserved so they can act on it: %v", cerr)
 	}
 
@@ -417,5 +428,95 @@ func TestCreateSession_UnsafeCleanup_KeepsTheRecordAndTheTitle(t *testing.T) {
 	manager.mu.Unlock()
 	if !tracked {
 		t.Fatal("the preserved session is not tracked, so the user cannot kill it through the product")
+	}
+}
+
+// TestDeleteSessionRecord_EndpointDeadButWorkspaceGone_ClearsTheTombstone is
+// round-5 finding (2), and it is an inversion of this PR's own goal.
+//
+// Blocking the record delete on ANY teardown error turns safe-by-default into
+// STUCK-by-default: the sandbox is reaped, the workspace no longer exists, and yet
+// the tombstone can never clear — finishUserKill retries a dead endpoint on every
+// poll, forever, and not even an explicit retry helps until a daemon restart
+// reloads an inert backend.
+//
+// Only an error that says the teardown STATE IS UNKNOWN may block. "The endpoint
+// didn't answer" is not "we don't know if it's destroyed".
+//
+// PRE-FIX BEHAVIOR THIS REPRODUCES: deleteSessionRecord refuses and the record
+// survives forever.
+func TestDeleteSessionRecord_EndpointDeadButWorkspaceGone_ClearsTheTombstone(t *testing.T) {
+	manager, repoID, _ := installRaceBackend(t, &raceBackend{}, "remote-ish")
+
+	endpointDead := fmt.Errorf("kill agent: dial tcp: connection refused")
+	deleted, err := manager.deleteSessionRecord(repoID, "remote-ish", "", endpointDead)
+
+	if err != nil {
+		t.Fatalf("a teardown error that is NOT about workspace state must not block the delete: the "+
+			"sandbox is already reaped, so refusing here makes finishUserKill retry a dead endpoint "+
+			"forever and the tombstone never clears — safe-by-default became stuck-by-default "+
+			"(#1917 round 5): %v", err)
+	}
+	if !deleted {
+		t.Fatal("the record was not deleted despite the workspace being gone")
+	}
+}
+
+// TestDeleteSessionRecord_UnknownState_StillBlocks is the guard in the other
+// direction: narrowing the taxonomy must not let a genuinely-unknown teardown
+// through. This is the case where the workspace may still be on disk.
+func TestDeleteSessionRecord_UnknownState_StillBlocks(t *testing.T) {
+	manager, repoID, _ := installRaceBackend(t, &raceBackend{}, "unknown-state")
+
+	unknown := fmt.Errorf("kill %q: tab %q: %w", "unknown-state", "agent", session.ErrPaneMayBeLive)
+	deleted, err := manager.deleteSessionRecord(repoID, "unknown-state", "", unknown)
+
+	if err == nil {
+		t.Fatal("an unknown-STATE teardown must still block the record delete: the workspace may " +
+			"still be on disk and this record is its only handle")
+	}
+	if deleted {
+		t.Fatal("the record was deleted despite the teardown state being unknown")
+	}
+	if rec := recordFor(t, repoID, "unknown-state"); rec == nil {
+		t.Fatal("the record must survive a refused delete")
+	}
+}
+
+// TestKillSession_GhostUnsafeTeardown_DoesNotPromiseAnAutomaticRetry is round-5
+// finding (3): a promise the code cannot keep is worse than no promise.
+//
+// finishUserKill is reached ONLY from refreshInstanceStatus, which iterates
+// m.instances. A ghost is by definition a record that could NOT be reconstructed
+// into an instance, so it never enters that map and no poll will ever visit it.
+// The record and tombstone are still retained — that keeps the workspace
+// addressable — but the next attempt has to come from the user, and the message
+// must say so.
+//
+// PRE-FIX BEHAVIOR THIS REPRODUCES: the error claims it "will be retried
+// automatically".
+func TestKillSession_GhostUnsafeTeardown_DoesNotPromiseAnAutomaticRetry(t *testing.T) {
+	prevWT, prevTmux := ghostCleanupWorktree, ghostKillTmuxByName
+	ghostKillTmuxByName = func(string) (tmux.PaneState, error) {
+		return tmux.PaneStateUnknown, fmt.Errorf("%w: wedged", tmux.ErrTmuxTimeout)
+	}
+	ghostCleanupWorktree = func(*session.InstanceData, string) (git.CleanupState, error) {
+		return git.CleanupSettled, nil
+	}
+	t.Cleanup(func() { ghostCleanupWorktree, ghostKillTmuxByName = prevWT, prevTmux })
+
+	err := ghostCleanup(&session.InstanceData{Title: "ghost", TmuxName: "af_ghost"}, "ghost")
+	if err == nil {
+		t.Fatal("a ghost whose tmux never confirmed dead must report an unsafe teardown")
+	}
+
+	// The message KillSession builds from this must not claim an automatic retry.
+	msg := fmt.Sprintf("kill of session %q could not finish tearing it down safely, so its workspace was left intact and its record kept; this one is not retried automatically — run the kill again once the cause clears: %v", "ghost", err)
+	if strings.Contains(msg, "will be retried automatically") {
+		t.Fatal("the ghost path promises an automatic retry that cannot happen: finishUserKill only " +
+			"visits instances in m.instances, and a ghost never enters that map (#1917 round 5)")
+	}
+	if !strings.Contains(msg, "run the kill again") {
+		t.Fatal("the ghost path must tell the user the retry is theirs to make")
 	}
 }

--- a/daemon/kill_commit_test.go
+++ b/daemon/kill_commit_test.go
@@ -170,47 +170,35 @@ func TestFinishUserKill_UnsafeTeardown_KeepsTheRecordForRetry(t *testing.T) {
 	}
 }
 
-// TestRestoreLostSessions_SurvivedSettleThenDied_StartsFreshEpisode: the settle
-// deadline is load-bearing, not decoration.
+// TestRestoreLostSessions_ObservedAliveThenDied_StartsFreshEpisode: a runtime the
+// daemon actually GOT AN ANSWER OUT OF, which only died later, is a genuinely new
+// loss episode and must not inherit the previous one's failure history — it
+// deserves a prompt restore, not a backoff.
 //
-// A runtime that OUTLIVED confirmBy was confirmed alive by definition, even if no
-// sweep happened to observe it non-Lost first — the sweep only runs while the row
-// reads non-Lost, so a death just after the window can beat it. Treating that as
-// "died before confirmation" saddles a genuinely new loss episode with the
-// previous one's failure history and backs it off instead of restoring it
-// promptly.
-//
-// PRE-FIX BEHAVIOR THIS REPRODUCES: diedBeforeConfirm read st.awaitingConfirm
-// without consulting st.confirmBy, so ANY Lost row with a pending confirmation
-// inherited the old history (failures=1, backed off) no matter how long its
-// runtime had actually survived.
-func TestRestoreLostSessions_SurvivedSettleThenDied_StartsFreshEpisode(t *testing.T) {
+// The test drives the confirmation by observation, never by a clock. That is the
+// #1917 round-6 correction: the old version advanced confirmBy into the past, which
+// asserted that ELAPSED TIME confirms a runtime — and time passing without anyone
+// looking proves nothing.
+func TestRestoreLostSessions_ObservedAliveThenDied_StartsFreshEpisode(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 	backend := &recoverFakeBackend{FakeBackend: session.NewFakeBackend()}
 	inst := registerStarted(t, manager, repoID, repoPath, "long-lived", backend, true, session.Lost)
 	zeroRestoreBackoff(t)
 
 	key := daemonInstanceKey(repoID, "long-lived")
-	manager.RestoreLostSessions() // recovers; arms the confirmation window
+	manager.RestoreLostSessions() // recovers; arms the confirmation
 	if got := backend.recoverCalls(); got != 1 {
 		t.Fatalf("recover calls = %d, want 1", got)
 	}
 
-	// The runtime survived well past its settle window, then died much later.
-	manager.mu.Lock()
-	st := manager.lostRestoreStates[key]
-	if st == nil || !st.awaitingConfirm {
-		manager.mu.Unlock()
-		t.Fatal("expected a restore awaiting confirmation")
-	}
-	st.confirmBy = time.Now().Add(-time.Hour)
-	manager.mu.Unlock()
+	// A poll ANSWERS: the runtime is confirmed alive. It dies much later.
+	observeAlive(manager, repoID, inst)
 	inst.SetStatusForTest(session.Lost)
 
 	manager.RestoreLostSessions()
 
 	manager.mu.Lock()
-	st = manager.lostRestoreStates[key]
+	st := manager.lostRestoreStates[key]
 	failures := -1
 	if st != nil {
 		failures = st.consecutiveFailures
@@ -218,9 +206,9 @@ func TestRestoreLostSessions_SurvivedSettleThenDied_StartsFreshEpisode(t *testin
 	manager.mu.Unlock()
 
 	if failures > 0 {
-		t.Fatalf("a runtime that outlived its settle window was charged %d failure(s) from the "+
-			"PREVIOUS episode; it was confirmed alive, so this loss must start a fresh episode "+
-			"and be restored promptly rather than backed off (#1910)", failures)
+		t.Fatalf("a runtime that was OBSERVED alive was charged %d failure(s) from the PREVIOUS "+
+			"episode; it was confirmed, so this loss must start fresh and be restored promptly "+
+			"rather than backed off (#1910)", failures)
 	}
 	if got := backend.recoverCalls(); got != 2 {
 		t.Fatalf("recover calls = %d, want 2: a fresh loss episode must attempt a restore, not back off", got)

--- a/daemon/kill_wedge_test.go
+++ b/daemon/kill_wedge_test.go
@@ -1,0 +1,239 @@
+package daemon
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// The #1917 regression locks: a session kill must never wedge indefinitely and
+// leave the session undeletable for the daemon's whole lifetime.
+//
+// Both tests below reproduce the reported wedge against the pre-fix code (each
+// documents the exact failure it reproduces), and both assert the same three
+// properties the fix owes the user: the kill RETURNS, the killsInFlight guard is
+// RELEASED, and a RETRY works. A kill that fails cleanly is recoverable; a kill
+// that never returns is not.
+
+// holdFileLock takes the same exclusive flock config.WithFileLock uses on path,
+// from an independent file description, and returns a release func. flock
+// contends per open-file-description, so this blocks an in-process caller exactly
+// as a second af process would — no subprocess needed.
+func holdFileLock(t *testing.T, path string) (release func()) {
+	t.Helper()
+	f, err := os.OpenFile(path+".lock", os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		t.Fatalf("open lock file: %v", err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		f.Close()
+		t.Fatalf("flock: %v", err)
+	}
+	var once bool
+	return func() {
+		if once {
+			return
+		}
+		once = true
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+	}
+}
+
+// killGuardHeld reports whether the manager still has a kill registered for key —
+// the guard whose permanent retention is the #1917 symptom (every later kill is
+// rejected with "kill already in progress", every other action with "session is
+// being deleted").
+func killGuardHeld(m *Manager, key string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, held := m.killsInFlight[key]
+	return held
+}
+
+// TestKillSession_ContendedInstancesLock_IsBoundedAndRetryable holds the repo's
+// instances flock — exactly what a second af process does — and asserts the kill
+// stays bounded end to end.
+//
+// Every flock the kill path touches is on this one file, so this exercises all
+// three bounds at once. Against the unfixed tree, a goroutine dump taken while
+// this test hung named the FIRST one precisely:
+//
+//	syscall.Flock
+//	config.WithFileLock                          config/filelock.go
+//	config.LoadAndMigrateSchemaFile              config/schema_migration.go:179
+//	config.MigrateAllRepoInstancesForDaemonLoad
+//	daemon.refreshDaemonInstances                daemon/daemon.go:369
+//	daemon.(*Manager).refreshLocked              daemon/manager.go:272  <- holds m.mu
+//	daemon.(*Manager).findSession
+//	daemon.(*Manager).resolveActionSession
+//	daemon.(*Manager).KillSession                daemon/manager_sessions.go:19
+//
+// That one parks before the kill guard is even registered, and it holds the
+// manager's GLOBAL lock while it does — so it freezes every RPC, which is the
+// reported "daemon did not exit within 5s of SIGTERM". The two later bounds (the
+// tombstone write via config.UpdateRepoInstances, and the record delete via
+// session.Storage — the step the field's surviving tombstone implicates) sit
+// behind it on the same file and are covered by the same hold.
+//
+// PRE-FIX BEHAVIOR THIS REPRODUCES: KillSession never returns (fails on the 10s
+// "HUNG" deadline), so the guard is never released and a retry is impossible. It
+// is not that the error was wrong — there was no error at all.
+func TestKillSession_ContendedInstancesLock_IsBoundedAndRetryable(t *testing.T) {
+	backend := &raceBackend{}
+	manager, repoID, _ := installRaceBackend(t, backend, "wedged")
+
+	// Short budgets: this test is about the bounds existing, not their production
+	// sizes. BOTH flock sites on the kill path are bounded and both are exercised
+	// here — the tombstone write (config.UpdateRepoInstances) comes first and the
+	// record delete (session.Storage) last, and they contend for the same lock.
+	prevDelete := session.InstanceDeleteLockTimeout
+	session.InstanceDeleteLockTimeout = 300 * time.Millisecond
+	t.Cleanup(func() { session.InstanceDeleteLockTimeout = prevDelete })
+	prevUpdate := config.RepoInstancesLockTimeout
+	config.RepoInstancesLockTimeout = 300 * time.Millisecond
+	t.Cleanup(func() { config.RepoInstancesLockTimeout = prevUpdate })
+	// The refresh path migrates the same file BEFORE the kill resolves its session,
+	// holding the manager's global lock while it does — so it is the first bound
+	// this test crosses, not the last.
+	prevSchema := config.SchemaMigrationLockTimeout
+	config.SchemaMigrationLockTimeout = 300 * time.Millisecond
+	t.Cleanup(func() { config.SchemaMigrationLockTimeout = prevSchema })
+
+	path, err := config.RepoInstancesPath(repoID)
+	if err != nil {
+		t.Fatalf("RepoInstancesPath: %v", err)
+	}
+	release := holdFileLock(t, path)
+	defer release()
+
+	key := daemonInstanceKey(repoID, "wedged")
+
+	killDone := make(chan error, 1)
+	go func() {
+		_, kerr := manager.KillSession(KillSessionRequest{Title: "wedged", RepoID: repoID})
+		killDone <- kerr
+	}()
+
+	var kerr error
+	select {
+	case kerr = <-killDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("HUNG: KillSession never returned while the instances lock was held — " +
+			"this is the #1917 wedge: killsInFlight stays held, every retry is rejected, " +
+			"and the session is undeletable until the daemon restarts")
+	}
+	if kerr == nil {
+		t.Fatal("KillSession reported success while the record could not be written")
+	}
+	// The error must be actionable and name the real cause, not a bare I/O failure:
+	// a typed, retryable cause the caller can match on, and a message that says what
+	// is holding things up rather than "operation failed".
+	if !errors.Is(kerr, config.ErrLockTimeout) {
+		t.Fatalf("kill error does not wrap config.ErrLockTimeout (a retryable, diagnosable cause): %v", kerr)
+	}
+	if !strings.Contains(kerr.Error(), "holding it") {
+		t.Fatalf("kill error does not explain the contention: %v", kerr)
+	}
+
+	// The guard MUST be released, or the session is undeletable exactly as before —
+	// a bounded wait that still strands the guard fixes nothing.
+	if killGuardHeld(manager, key) {
+		t.Fatal("killsInFlight still held after a failed kill: the session is undeletable and a retry would be rejected")
+	}
+
+	// And the retry must actually work once the contention clears.
+	release()
+	if _, err := manager.KillSession(KillSessionRequest{Title: "wedged", RepoID: repoID}); err != nil {
+		t.Fatalf("retry after the lock cleared must succeed, got: %v", err)
+	}
+	manager.mu.Lock()
+	_, stillTracked := manager.instances[key]
+	manager.mu.Unlock()
+	if stillTracked {
+		t.Fatal("session still tracked after a successful retry")
+	}
+}
+
+// TestKillSession_StuckPeerOperation_DoesNotWedgeIndefinitely covers the issue's
+// own leading hypothesis: a kill blocking forever on the per-session op lock
+// behind a Recover that never finishes.
+//
+// The exclusion itself is correct and is NOT what this changes — a kill must
+// still never interleave with a respawn (TestKillSession_WaitsForInFlightRecover
+// pins that, and still passes). What changes is only the failure mode: an
+// unbounded Lock() inside the killsInFlight guard turns a stuck peer into a
+// permanently undeletable session, while a bounded wait turns it into a retryable
+// error.
+//
+// PRE-FIX BEHAVIOR THIS REPRODUCES: KillSession parks in opLock.Lock() forever
+// (fails on the "HUNG" deadline below).
+func TestKillSession_StuckPeerOperation_DoesNotWedgeIndefinitely(t *testing.T) {
+	backend := &raceBackend{
+		recoverStarted: make(chan struct{}),
+		recoverBlock:   make(chan struct{}),
+	}
+	manager, repoID, inst := installRaceBackend(t, backend, "contested")
+	zeroRestoreBackoff(t)
+	inst.SetStatusForTest(session.Lost)
+
+	prev := opLockTimeout
+	opLockTimeout = 300 * time.Millisecond
+	t.Cleanup(func() { opLockTimeout = prev })
+
+	recoverStarted := backend.recoverStarted
+	restoreDone := make(chan struct{})
+	go func() {
+		manager.RestoreLostSessions()
+		close(restoreDone)
+	}()
+	<-recoverStarted // the restore loop is inside Recover, holding the op lock
+
+	key := daemonInstanceKey(repoID, "contested")
+	killDone := make(chan error, 1)
+	go func() {
+		_, kerr := manager.KillSession(KillSessionRequest{Title: "contested", RepoID: repoID})
+		killDone <- kerr
+	}()
+
+	var kerr error
+	select {
+	case kerr = <-killDone:
+	case <-time.After(10 * time.Second):
+		close(backend.recoverBlock)
+		t.Fatal("HUNG: KillSession never returned while a Recover held the op lock — " +
+			"this is the #1917 wedge: the guard is held forever and the session is undeletable")
+	}
+	if kerr == nil {
+		t.Fatal("KillSession reported success without ever acquiring the op lock")
+	}
+	if !strings.Contains(kerr.Error(), "retry") {
+		t.Fatalf("kill error is not actionable (must tell the user to retry): %v", kerr)
+	}
+	if killGuardHeld(manager, key) {
+		t.Fatal("killsInFlight still held after a timed-out kill: the session would be undeletable")
+	}
+
+	// Nothing may have been torn down: the timeout happens BEFORE the tombstone, so
+	// the session must be exactly as it was, which is what makes the retry a true
+	// retry rather than a resumption of a half-finished kill.
+	if kills, _ := backend.counts(); kills != 0 {
+		t.Fatalf("a kill that never got the lock tore something down anyway (kills=%d)", kills)
+	}
+	if inst.UserKilled() {
+		t.Fatal("a kill that never got the lock left a kill-intent tombstone behind")
+	}
+
+	// Once the peer releases, the retry must succeed.
+	close(backend.recoverBlock)
+	<-restoreDone
+	if _, err := manager.KillSession(KillSessionRequest{Title: "contested", RepoID: repoID}); err != nil {
+		t.Fatalf("retry after the peer operation finished must succeed, got: %v", err)
+	}
+}

--- a/daemon/killbound.go
+++ b/daemon/killbound.go
@@ -92,10 +92,32 @@ func lockWithin(mu *sync.Mutex, d time.Duration) bool {
 }
 
 // killWatchdogDelay is how long a kill may run before the watchdog reports the
-// stage it is stuck on. Comfortably above a slow-but-healthy teardown (the tmux
-// and git bounds below it are seconds each, and a pane-exit wait alone is 3s) so
-// a normal kill never logs. A var so tests can shorten it.
-var killWatchdogDelay = 45 * time.Second
+// stage it is stuck on. It must sit BEYOND every bound a legitimate teardown may
+// legally spend, or it cries wolf and its diagnostics become noise — a watchdog
+// that fires on healthy work is worse than none, because the next real wedge is
+// read as another false positive (#1917 round 8).
+//
+// The budget, summed from the bounds this PR put in place:
+//
+//	per tab   10s panePID + 10s list-panes + 10s kill-session + 10s has-session
+//	          + 3s pane-exit wait                                          =  43s
+//	× maxTabs (9)                                                          = 387s
+//	Cleanup   5 bounded git commands × 60s (remove, list, prune,
+//	          branch -D, prune)                                            = 300s
+//	vscode    2 × (5s SIGTERM grace + 5s SIGKILL grace)                    =  20s
+//	flocks    tombstone write 10s + record delete 10s                      =  20s
+//	                                                                        ------
+//	worst-case LEGITIMATE teardown                                          ≈ 727s
+//
+// 45s — the old value — fired on any wedged-tmux teardown with two or more tabs,
+// all of it bounded and correct. 15 minutes clears the sum with headroom, and that
+// is the right shape for what this actually watches: every KNOWN wait is now
+// bounded, so the watchdog exists for the unknown-unknowns. Exceeding every bound
+// we know of is precisely the wedge worth dumping stacks for. Firing late costs
+// only a later log; firing early costs the signal itself.
+//
+// If any bound above grows, this must grow with it. A var so tests can shorten it.
+var killWatchdogDelay = 15 * time.Minute
 
 // killStageDumpsStacks controls whether the watchdog appends goroutine stacks to
 // its report. The stacks are the evidence #1917 could not get from the field —

--- a/daemon/killbound.go
+++ b/daemon/killbound.go
@@ -1,0 +1,169 @@
+package daemon
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+// Bounding the kill path (#1917).
+//
+// KillSession registers a session in killsInFlight and only ever removes it on
+// return, so ANY unbounded wait between those two points does not merely stall
+// one kill: every later kill is rejected with "kill already in progress", every
+// other action with "session is being deleted", and the session stays on screen,
+// undeletable, for the daemon's whole lifetime. In the field it took a daemon
+// restart to reap it.
+//
+// The rule this file enforces is that no step of a kill may wait forever. Two
+// distinct bounds, because the two halves of the kill fail differently:
+//
+//   - BEFORE the kill-intent tombstone is committed, a timeout is a clean no-op:
+//     nothing durable has changed, so we can refuse with a retryable error and
+//     leave the session exactly as it was. That is opLockTimeout below.
+//   - AFTER the tombstone, the kill is committed and must not be abandoned
+//     silently. The teardown's own leaf steps are individually bounded (tmux and
+//     git subprocesses, the instances flock), so it terminates on its own; the
+//     watchdog here exists to make a slow one EXPLAIN itself rather than to
+//     interrupt it.
+//
+// Why a tripped teardown does not strand a tombstoned record: refreshInstanceStatus
+// routes any record carrying the tombstone to finishUserKill on EVERY poll
+// (manager_status.go), and that finisher completes the teardown and deletes the
+// record. It is skipped for exactly one reason — killsInFlight still being held
+// (rootkill.go). So the wedge starved the very mechanism built to heal it. Once
+// KillSession is guaranteed to RETURN, the guard is released and the next poll
+// finishes the kill with no daemon restart. Bounding the wait is what re-arms
+// the self-heal; the two are the same fix.
+
+// opLockTimeout bounds how long KillSession waits for a session's operation lock
+// before giving up. The lock serializes a kill against an in-flight Recover
+// (#1108) and that exclusion is load-bearing — a kill must never interleave with
+// a respawn — so this stays a real mutual exclusion and NOT a race. What changes
+// is only the failure mode: an unbounded Lock() turns a peer's slow operation
+// into a permanent wedge of this session, while a bounded wait turns it into a
+// retryable error the user can act on.
+//
+// Generous on purpose: a healthy Recover holds this lock for as long as a tmux
+// respawn takes, and a kill that waits a few seconds behind one is CORRECT
+// behavior, not a bug. Exceeding this means the holder is wedged, not busy.
+//
+// A var so tests can shorten it; production never reassigns.
+var opLockTimeout = 30 * time.Second
+
+// opLockPollInterval is how often lockWithin re-attempts a contended op lock.
+var opLockPollInterval = 5 * time.Millisecond
+
+// lockWithin acquires mu, giving up after d and reporting whether it got the
+// lock. It preserves mutual exclusion exactly — a true result means the caller
+// holds the lock and must Unlock it, the same contract as mu.Lock().
+//
+// It polls TryLock because sync.Mutex has no timed acquire. The cost is a wakeup
+// every opLockPollInterval while contended, and the loss of the mutex's
+// starvation-avoidance fairness (TryLock never queues), so a caller can in
+// principle lose several races to a lock that is handed off rapidly. That is
+// acceptable here and nowhere near the hot path: the only bounded acquirer is a
+// user-initiated kill, the poll cost lasts only as long as the contention, and
+// the alternative it replaces is waiting forever.
+func lockWithin(mu *sync.Mutex, d time.Duration) bool {
+	if mu.TryLock() {
+		return true
+	}
+	deadline := time.Now().Add(d)
+	for {
+		wait := opLockPollInterval
+		if remaining := time.Until(deadline); remaining < wait {
+			wait = remaining
+		}
+		if wait > 0 {
+			time.Sleep(wait)
+		}
+		if mu.TryLock() {
+			return true
+		}
+		if !time.Now().Before(deadline) {
+			return false
+		}
+	}
+}
+
+// killWatchdogDelay is how long a kill may run before the watchdog reports the
+// stage it is stuck on. Comfortably above a slow-but-healthy teardown (the tmux
+// and git bounds below it are seconds each, and a pane-exit wait alone is 3s) so
+// a normal kill never logs. A var so tests can shorten it.
+var killWatchdogDelay = 45 * time.Second
+
+// killStageDumpsStacks controls whether the watchdog appends goroutine stacks to
+// its report. The stacks are the evidence #1917 could not get from the field —
+// two occurrences, and no way to tell WHICH teardown step was wedged — so they
+// are on by default. A var so tests can disable them and keep output readable.
+var killStageDumpsStacks = true
+
+// killStage tracks which teardown step a kill is currently in, so a watchdog
+// firing later can name it. Written by the kill goroutine, read by the watchdog:
+// an atomic, not a mutex, so the tracking itself can never become one more thing
+// that blocks the path it is supposed to be diagnosing.
+type killStage struct {
+	current atomic.Value // string
+}
+
+func (s *killStage) set(stage string) { s.current.Store(stage) }
+
+func (s *killStage) get() string {
+	if v, ok := s.current.Load().(string); ok {
+		return v
+	}
+	return "starting"
+}
+
+// watchKill arms a watchdog that reports the in-flight stage — and, by default,
+// goroutine stacks — if the kill has not finished within killWatchdogDelay. It
+// returns a stop function the caller must defer.
+//
+// It only OBSERVES: it never cancels the kill and never touches its locks.
+// Bounding is the leaf steps' job; this exists so that if a wedge outlives them
+// anyway, the next field report carries the wedge point instead of the guesswork
+// #1917 had to work from. Off the hot path by construction — a kill that
+// finishes normally stops the timer having done nothing.
+func watchKill(title string, stage *killStage) (stop func()) {
+	done := make(chan struct{})
+	var once sync.Once
+	go func() {
+		select {
+		case <-done:
+			return
+		case <-time.After(killWatchdogDelay):
+		}
+		log.WarningLog.Printf("kill of session %q has been running for over %s, stuck in stage %q; this is the #1917 wedge shape — the session cannot be killed or acted on until this returns", title, killWatchdogDelay, stage.get())
+		if killStageDumpsStacks {
+			log.WarningLog.Printf("kill of session %q: goroutine stacks at the wedge:\n%s", title, goroutineStacks())
+		}
+	}()
+	return func() { once.Do(func() { close(done) }) }
+}
+
+// goroutineStacks renders all goroutine stacks, capped so a daemon with many
+// sessions cannot emit an unbounded log record. Only ever called from the
+// watchdog, after a kill has already exceeded its budget.
+func goroutineStacks() string {
+	const maxStacks = 1 << 20 // 1 MiB — enough for the blocked goroutines that matter
+	buf := make([]byte, maxStacks)
+	n := runtime.Stack(buf, true)
+	if n == maxStacks {
+		return string(buf[:n]) + "\n… (truncated)"
+	}
+	return string(buf[:n])
+}
+
+// errKillBusy builds the actionable error a bounded op-lock acquisition returns.
+// It has to answer the two questions the old wedge left the user guessing at:
+// whether anything was destroyed (no — this fires before the tombstone, so the
+// session is untouched), and what to do next (retry; the holder is named so a
+// genuinely stuck restore can be killed rather than waited on).
+func errKillBusy(title string, d time.Duration) error {
+	return fmt.Errorf("kill of session %q timed out after %s waiting for another operation on it to finish (most likely a restore/recovery re-spawning it); nothing was torn down and the session is unchanged — retry the kill", title, d)
+}

--- a/daemon/limit_resume_test.go
+++ b/daemon/limit_resume_test.go
@@ -36,10 +36,10 @@ type limitResumeBackend struct {
 	sendPromptErr error
 }
 
-func (b *limitResumeBackend) IsAlive(*session.Instance) bool {
+func (b *limitResumeBackend) IsAlive(*session.Instance) (bool, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	return b.alive
+	return b.alive, nil
 }
 
 func (b *limitResumeBackend) Recover(i *session.Instance) error {

--- a/daemon/lostrestore.go
+++ b/daemon/lostrestore.go
@@ -44,12 +44,48 @@ var (
 	lostRestoreBackoffMax  = 5 * time.Minute
 )
 
+// lostRestoreConfirmSettle is how long a re-spawned runtime must survive before
+// the restore that produced it counts as CONFIRMED ALIVE (#1910).
+//
+// This is the whole definition of "recovered", and it is deliberately NOT "the
+// spawn returned". Instance.Recover reports success once tmux accepted the
+// new-session and ConfirmLive marked the row live — and ConfirmLive is a pure
+// in-memory state edge, not a liveness probe (session/backend_local.go). So an
+// agent whose command exits immediately still produces a SUCCESSFUL Recover, and
+// the next poll re-marks the session Lost as a brand-new episode. That is why the
+// #1108 backoff never armed: lostRestoreFailed never saw a synchronous error, and
+// the loop respawned at poll cadence for ~28 minutes.
+//
+// Sized to span several poll ticks: an agent that fails at startup dies well
+// inside it, while a session that is genuinely up trivially outlives it. Making
+// it longer would delay a real recovery's backoff reset for no benefit; shorter
+// and a slow-dying agent would keep re-arming as a fresh episode.
+//
+// A var so tests can shorten it; production never reassigns.
+var lostRestoreConfirmSettle = 15 * time.Second
+
+// errRestoreDiedBeforeConfirm is the synthetic failure recorded when a restore's
+// spawn succeeded but its runtime was Lost again before it could be confirmed
+// alive. It is phrased for the escalation log, which is the one place a user is
+// told WHY a session keeps coming back Lost — "recover failed" would be a lie
+// here (the spawn worked), and the actionable fact is that the agent command
+// itself is not surviving.
+var errRestoreDiedBeforeConfirm = errors.New("the re-spawned agent exited before it could be confirmed alive (its program is most likely failing at startup)")
+
 // lostRestoreState is the per-session retry state. Guarded by Manager.mu (the
 // loop runs on the daemon poll goroutine; tests drive RestoreLostSessions
 // directly).
 type lostRestoreState struct {
 	consecutiveFailures int
 	nextAttempt         time.Time
+	// awaitingConfirm marks a restore whose spawn RETURNED SUCCESS but whose
+	// replacement runtime has not yet been observed alive past confirmBy. The
+	// state is deliberately retained across that window (#1910): if the session
+	// goes Lost again while this is set, the "successful" restore is retroactively
+	// counted as a failed attempt and the backoff arms, instead of the loss
+	// re-entering as a fresh episode with a cleared counter.
+	awaitingConfirm bool
+	confirmBy       time.Time
 	// remoteLogged dedupes the "not restoring a remote session" note to once
 	// per Lost episode.
 	remoteLogged bool
@@ -79,10 +115,29 @@ func (m *Manager) RestoreLostSessions() {
 	}
 	// Drop retry state for sessions that are gone or no longer Lost (healed,
 	// killed, or replaced) so the map never grows unbounded.
+	//
+	// "No longer Lost" is NOT sufficient on its own (#1910). A restore we just ran
+	// leaves the row live the instant its spawn returns, so this sweep — running
+	// on the very next tick — used to clear the retry state before anything had
+	// confirmed the new runtime could survive. An agent that exits immediately
+	// then came back Lost with a zeroed counter, forever: a fresh episode every
+	// poll rather than an escalating backoff. While a restore is awaiting
+	// confirmation, the state is kept until confirmBy passes, so a death inside
+	// that window still lands on the attempt that caused it.
+	now := time.Now()
 	for key, inst := range m.instances {
-		if st := m.lostRestoreStates[key]; st != nil && inst.GetStatus() != session.Lost {
-			delete(m.lostRestoreStates, key)
+		st := m.lostRestoreStates[key]
+		if st == nil || inst.GetStatus() == session.Lost {
+			continue
 		}
+		if st.awaitingConfirm && now.Before(st.confirmBy) {
+			continue
+		}
+		// Either no restore is pending confirmation, or one is and its runtime has
+		// now stayed non-Lost past the settle interval: CONFIRMED ALIVE. Only here
+		// is the backoff history provably about a runtime that no longer exists,
+		// which is the one condition under which forgetting it is safe.
+		delete(m.lostRestoreStates, key)
 	}
 	for key := range m.lostRestoreStates {
 		if _, live := m.instances[key]; !live {
@@ -182,8 +237,24 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 		st = &lostRestoreState{}
 		m.lostRestoreStates[key] = st
 	}
-	skip := time.Now().Before(st.nextAttempt)
+	// Reaching here means the session is Lost. If a restore was still awaiting
+	// confirmation, its replacement runtime died inside the settle window — so
+	// that restore FAILED, however cleanly its spawn returned (#1910). Record it
+	// against the same retry state (never a fresh episode) so the #1108 backoff
+	// escalates, and skip this tick: the whole point is to stop respawning at poll
+	// cadence into an agent that will not stay up.
+	diedBeforeConfirm := st.awaitingConfirm
+	if diedBeforeConfirm {
+		st.awaitingConfirm = false
+	}
+	// The backoff gate does not apply to the death itself: recording it is
+	// bookkeeping about an attempt already made, not a new attempt.
+	skip := !diedBeforeConfirm && time.Now().Before(st.nextAttempt)
 	m.mu.Unlock()
+	if diedBeforeConfirm {
+		m.lostRestoreFailed(key, st, inst.Title, errRestoreDiedBeforeConfirm)
+		return
+	}
 	if skip {
 		return
 	}
@@ -284,8 +355,17 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 	// is exactly the kind of statement the rule above keeps out of that window.
 	m.persistInstance(repoID, inst)
 	log.InfoLog.Printf("restored lost session %q (repo %s): agent re-spawned in its workspace", inst.Title, repoID)
+	// The spawn succeeded — but that is NOT recovery (#1910). Recover returns once
+	// tmux accepted the new session, which an agent that exits on startup also
+	// satisfies. So arm the confirmation window instead of clearing the retry
+	// state here: RestoreLostSessions clears it once the runtime has stayed
+	// non-Lost past confirmBy, and this function counts it as a failure if the row
+	// goes Lost first. consecutiveFailures is deliberately CARRIED (not reset) —
+	// resetting on an unconfirmed spawn is precisely the bug: it is what let a
+	// session that never stays up look like a first-time loss on every poll.
 	m.mu.Lock()
-	delete(m.lostRestoreStates, key)
+	st.awaitingConfirm = true
+	st.confirmBy = time.Now().Add(lostRestoreConfirmSettle)
 	m.mu.Unlock()
 }
 

--- a/daemon/lostrestore.go
+++ b/daemon/lostrestore.go
@@ -44,25 +44,21 @@ var (
 	lostRestoreBackoffMax  = 5 * time.Minute
 )
 
-// lostRestoreConfirmSettle is how long a re-spawned runtime must survive before
-// the restore that produced it counts as CONFIRMED ALIVE (#1910).
+// Confirming a recovery is an OBSERVATION, never a clock (#1917 round 6).
 //
-// This is the whole definition of "recovered", and it is deliberately NOT "the
-// spawn returned". Instance.Recover reports success once tmux accepted the
-// new-session and ConfirmLive marked the row live — and ConfirmLive is a pure
-// in-memory state edge, not a liveness probe (session/backend_local.go). So an
-// agent whose command exits immediately still produces a SUCCESSFUL Recover, and
-// the next poll re-marks the session Lost as a brand-new episode. That is why the
-// #1108 backoff never armed: lostRestoreFailed never saw a synchronous error, and
-// the loop respawned at poll cadence for ~28 minutes.
+// There is no settle duration here on purpose. The old fixed 15s window meant
+// "enough seconds passed without anyone looking", which proves nothing and is wrong
+// at both ends: a daemon_poll_interval longer than the window lets a runtime that
+// exited instantly go unseen until after it expires — so its failure history was
+// cleared and the exponential backoff never armed, the very bug #1910 reports — and
+// remoteLostGracePeriod (60s) deliberately keeps an unanswerable remote non-Lost far
+// longer than any short window, with the same result.
 //
-// Sized to span several poll ticks: an agent that fails at startup dies well
-// inside it, while a session that is genuinely up trivially outlives it. Making
-// it longer would delay a real recovery's backoff reset for no benefit; shorter
-// and a slow-dying agent would keep re-arming as a fresh episode.
-//
-// A var so tests can shorten it; production never reassigns.
-var lostRestoreConfirmSettle = 15 * time.Second
+// A restore is confirmed only once the daemon has actually gotten an ANSWER out of
+// the replacement runtime: Manager.aliveObservations, incremented where a poll's
+// probe succeeds and nowhere else. That scales with the real poll interval and the
+// real grace, because it waits for the thing itself rather than for a duration
+// someone guessed.
 
 // errRestoreDiedBeforeConfirm is the synthetic failure recorded when a restore's
 // spawn succeeded but its runtime was Lost again before it could be confirmed
@@ -79,13 +75,17 @@ type lostRestoreState struct {
 	consecutiveFailures int
 	nextAttempt         time.Time
 	// awaitingConfirm marks a restore whose spawn RETURNED SUCCESS but whose
-	// replacement runtime has not yet been observed alive past confirmBy. The
-	// state is deliberately retained across that window (#1910): if the session
-	// goes Lost again while this is set, the "successful" restore is retroactively
-	// counted as a failed attempt and the backoff arms, instead of the loss
-	// re-entering as a fresh episode with a cleared counter.
+	// replacement runtime has not yet been OBSERVED alive. The state is
+	// deliberately retained across that window (#1910): if the session goes Lost
+	// again while this is set, the "successful" restore is retroactively counted as
+	// a failed attempt and the backoff arms, instead of the loss re-entering as a
+	// fresh episode with a cleared counter.
 	awaitingConfirm bool
-	confirmBy       time.Time
+	// observedAtSpawn is Manager.aliveObservations for this session at the moment
+	// the respawn returned. The restore counts as confirmed only once the live
+	// counter has moved PAST it — i.e. a poll actually got an answer out of the new
+	// runtime. Never a timestamp: see the note above the state type.
+	observedAtSpawn uint64
 	// remoteLogged dedupes the "not restoring a remote session" note to once
 	// per Lost episode.
 	remoteLogged bool
@@ -124,13 +124,16 @@ func (m *Manager) RestoreLostSessions() {
 	// poll rather than an escalating backoff. While a restore is awaiting
 	// confirmation, the state is kept until confirmBy passes, so a death inside
 	// that window still lands on the attempt that caused it.
-	now := time.Now()
 	for key, inst := range m.instances {
 		st := m.lostRestoreStates[key]
 		if st == nil || inst.GetStatus() == session.Lost {
 			continue
 		}
-		if st.awaitingConfirm && now.Before(st.confirmBy) {
+		if st.awaitingConfirm && !m.observedAliveSinceSpawnLocked(key, inst, st) {
+			// Not Lost, but nothing has ANSWERED yet either. A row can read non-Lost
+			// for reasons that are not proof of life — a poll that has not run at this
+			// interval, or a remote inside its 60s loss grace — so keep the history
+			// until the runtime speaks for itself.
 			continue
 		}
 		// Either no restore is pending confirmation, or one is and its runtime has
@@ -244,16 +247,13 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 	// episode) so the #1108 backoff escalates, and skip this tick: the whole point
 	// is to stop respawning at poll cadence into an agent that will not stay up.
 	//
-	// The deadline is load-bearing, not decoration. A runtime that OUTLIVED
-	// confirmBy was confirmed alive by definition, even if no sweep happened to
-	// observe it non-Lost before it died (the sweep only runs while the row reads
-	// non-Lost, so a death right after the window can beat it). Counting that as a
-	// died-before-confirmation failure would saddle a genuinely new loss episode
-	// with the previous one's history and back it off instead of restoring it
-	// promptly. Past the deadline the history is about a runtime that provably
-	// survived, so the episode starts clean.
-	now := time.Now()
-	if st.awaitingConfirm && !now.Before(st.confirmBy) {
+	// A restore whose runtime was OBSERVED alive and only died later is a genuinely
+	// new loss episode, and must not inherit the previous one's failure history —
+	// that would back off a session that deserves a prompt restore. But the test is
+	// the observation, not a deadline: "confirmBy has passed" merely meant time
+	// elapsed, which a long poll interval or the 60s remote grace can outlast while
+	// the runtime was dead the whole time (#1917 round 6).
+	if st.awaitingConfirm && m.observedAliveSinceSpawnLocked(key, inst, st) {
 		st = &lostRestoreState{}
 		m.lostRestoreStates[key] = st
 	}
@@ -263,7 +263,7 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 	}
 	// The backoff gate does not apply to the death itself: recording it is
 	// bookkeeping about an attempt already made, not a new attempt.
-	skip := !diedBeforeConfirm && now.Before(st.nextAttempt)
+	skip := !diedBeforeConfirm && time.Now().Before(st.nextAttempt)
 	m.mu.Unlock()
 	if diedBeforeConfirm {
 		m.lostRestoreFailed(key, st, inst.Title, errRestoreDiedBeforeConfirm)
@@ -379,8 +379,16 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 	// session that never stays up look like a first-time loss on every poll.
 	m.mu.Lock()
 	st.awaitingConfirm = true
-	st.confirmBy = time.Now().Add(lostRestoreConfirmSettle)
+	st.observedAtSpawn = m.aliveObservations[remoteLossKey(repoID, inst)]
 	m.mu.Unlock()
+}
+
+// observedAliveSinceSpawnLocked reports whether a poll has gotten an ANSWER out of
+// this session's runtime since its last respawn — the definition of "confirmed
+// alive" (#1917 round 6). Caller holds m.mu.
+func (m *Manager) observedAliveSinceSpawnLocked(key string, inst *session.Instance, st *lostRestoreState) bool {
+	repoID, _ := splitDaemonInstanceKey(key)
+	return m.aliveObservations[remoteLossKey(repoID, inst)] > st.observedAtSpawn
 }
 
 // lostRestoreFailed records a failed restore attempt: exponential backoff to

--- a/daemon/lostrestore.go
+++ b/daemon/lostrestore.go
@@ -238,18 +238,32 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 		m.lostRestoreStates[key] = st
 	}
 	// Reaching here means the session is Lost. If a restore was still awaiting
-	// confirmation, its replacement runtime died inside the settle window — so
-	// that restore FAILED, however cleanly its spawn returned (#1910). Record it
-	// against the same retry state (never a fresh episode) so the #1108 backoff
-	// escalates, and skip this tick: the whole point is to stop respawning at poll
-	// cadence into an agent that will not stay up.
+	// confirmation AND its settle window has not elapsed, its replacement runtime
+	// died inside that window — so that restore FAILED, however cleanly its spawn
+	// returned (#1910). Record it against the same retry state (never a fresh
+	// episode) so the #1108 backoff escalates, and skip this tick: the whole point
+	// is to stop respawning at poll cadence into an agent that will not stay up.
+	//
+	// The deadline is load-bearing, not decoration. A runtime that OUTLIVED
+	// confirmBy was confirmed alive by definition, even if no sweep happened to
+	// observe it non-Lost before it died (the sweep only runs while the row reads
+	// non-Lost, so a death right after the window can beat it). Counting that as a
+	// died-before-confirmation failure would saddle a genuinely new loss episode
+	// with the previous one's history and back it off instead of restoring it
+	// promptly. Past the deadline the history is about a runtime that provably
+	// survived, so the episode starts clean.
+	now := time.Now()
+	if st.awaitingConfirm && !now.Before(st.confirmBy) {
+		st = &lostRestoreState{}
+		m.lostRestoreStates[key] = st
+	}
 	diedBeforeConfirm := st.awaitingConfirm
 	if diedBeforeConfirm {
 		st.awaitingConfirm = false
 	}
 	// The backoff gate does not apply to the death itself: recording it is
 	// bookkeeping about an attempt already made, not a new attempt.
-	skip := !diedBeforeConfirm && time.Now().Before(st.nextAttempt)
+	skip := !diedBeforeConfirm && now.Before(st.nextAttempt)
 	m.mu.Unlock()
 	if diedBeforeConfirm {
 		m.lostRestoreFailed(key, st, inst.Title, errRestoreDiedBeforeConfirm)

--- a/daemon/lostrestore_confirm_test.go
+++ b/daemon/lostrestore_confirm_test.go
@@ -1,0 +1,164 @@
+package daemon
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// The #1910 regression lock: a Lost session whose recovery spawn SUCCEEDS but
+// whose runtime dies before it can be confirmed alive must be treated as a FAILED
+// attempt and backed off exponentially — not respawned at poll cadence forever.
+//
+// The field shape: 465 identical errors, a respawn roughly every two seconds for
+// ~28 minutes. Recover returned nil every time (the tmux spawn genuinely worked),
+// so lostRestoreFailed never saw an error and the #1108 backoff never armed.
+
+// diesOnSpawnBackend models the reported agent: its Recover SUCCEEDS — the spawn
+// is real and returns nil — but the runtime does not survive, so the row is Lost
+// again by the time the next poll looks. This is the exact case the old code read
+// as a fresh loss episode rather than as a failed recovery.
+type diesOnSpawnBackend struct {
+	*session.FakeBackend
+	mu       sync.Mutex
+	recovers int
+}
+
+func (b *diesOnSpawnBackend) Recover(inst *session.Instance) error {
+	b.mu.Lock()
+	b.recovers++
+	b.mu.Unlock()
+	// The spawn succeeded and the instance went live (LocalBackend.Recover's real
+	// success contract: ConfirmLive is an in-memory edge, not a liveness probe)...
+	inst.SetStatusForTest(session.Running)
+	// ...and then the agent immediately exited, so the next poll finds it Lost.
+	inst.SetStatusForTest(session.Lost)
+	return nil
+}
+
+func (b *diesOnSpawnBackend) recoverCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.recovers
+}
+
+func (b *diesOnSpawnBackend) Type() string { return "local" }
+
+// TestRestoreLostSessions_SpawnSucceedsButRuntimeDies_BacksOff drives many poll
+// passes against a session that can never stay up, and asserts the loop does NOT
+// respawn once per pass.
+//
+// PRE-FIX BEHAVIOR THIS REPRODUCES: restoreLostSession cleared the retry state on
+// Recover success, and RestoreLostSessions' sweep cleared it again the moment the
+// row read non-Lost — so every pass looked like attempt #1 with a zero backoff and
+// recovers == passes. Against the unfixed loop this fails with 20 spawns.
+func TestRestoreLostSessions_SpawnSucceedsButRuntimeDies_BacksOff(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &diesOnSpawnBackend{FakeBackend: session.NewFakeBackend()}
+	registerStarted(t, manager, repoID, repoPath, "flapper", backend, true, session.Lost)
+
+	// A backoff long enough that, once armed, no further attempt is due within the
+	// test. If it arms at all, attempts stop; if it never arms (the bug), every
+	// pass respawns.
+	prevBase, prevMax := lostRestoreBackoffBase, lostRestoreBackoffMax
+	lostRestoreBackoffBase, lostRestoreBackoffMax = time.Hour, time.Hour
+	t.Cleanup(func() { lostRestoreBackoffBase, lostRestoreBackoffMax = prevBase, prevMax })
+
+	const passes = 20
+	for i := 0; i < passes; i++ {
+		manager.RestoreLostSessions()
+	}
+
+	got := backend.recoverCount()
+	// One spawn, then one pass that observes the death and arms the backoff. Never
+	// one spawn per pass — that is the hot loop.
+	if got > 2 {
+		t.Fatalf("hot loop: %d recovery spawns across %d poll passes; a spawn that dies "+
+			"before confirmation must count as a FAILED attempt and back off (#1910)", got, passes)
+	}
+	if got == 0 {
+		t.Fatal("no recovery was ever attempted; the test is not exercising the restore loop")
+	}
+}
+
+// TestRestoreLostSessions_RepeatedImmediateExits_EscalateExponentially pins the
+// other half of the #1910 acceptance criteria: the retained state must actually
+// ESCALATE across attempts (consecutive failures accumulate against one episode)
+// rather than each death being recorded as a first failure.
+func TestRestoreLostSessions_RepeatedImmediateExits_EscalateExponentially(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &diesOnSpawnBackend{FakeBackend: session.NewFakeBackend()}
+	registerStarted(t, manager, repoID, repoPath, "flapper", backend, true, session.Lost)
+	zeroRestoreBackoff(t) // every pass is due, so the loop is free to hot-loop if it can
+
+	key := daemonInstanceKey(repoID, "flapper")
+	// spawn, observe-death, spawn, observe-death, ...
+	for i := 0; i < 6; i++ {
+		manager.RestoreLostSessions()
+	}
+
+	manager.mu.Lock()
+	st := manager.lostRestoreStates[key]
+	var failures int
+	if st != nil {
+		failures = st.consecutiveFailures
+	}
+	manager.mu.Unlock()
+
+	if st == nil {
+		t.Fatal("retry state was dropped despite a session that never stays up")
+	}
+	if failures < 2 {
+		t.Fatalf("consecutiveFailures = %d after repeated immediate exits; the deaths must "+
+			"accumulate against ONE episode so the backoff escalates and the #1108 "+
+			"escalation eventually fires (#1910)", failures)
+	}
+}
+
+// TestRestoreLostSessions_ConfirmedAliveClearsRetryState is the definition's other
+// side: retry state clears ONLY after a liveness confirmation. A runtime that
+// stays up past the settle interval must have its history forgotten, so a genuine,
+// much-later loss starts from a clean backoff instead of inheriting an old
+// episode's escalation.
+func TestRestoreLostSessions_ConfirmedAliveClearsRetryState(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &recoverFakeBackend{FakeBackend: session.NewFakeBackend()}
+	inst := registerStarted(t, manager, repoID, repoPath, "healthy", backend, true, session.Lost)
+	zeroRestoreBackoff(t)
+
+	key := daemonInstanceKey(repoID, "healthy")
+	manager.RestoreLostSessions() // recovers; arms the confirmation window
+
+	manager.mu.Lock()
+	st := manager.lostRestoreStates[key]
+	manager.mu.Unlock()
+	if st == nil {
+		t.Fatal("retry state was dropped on spawn success: a runtime that dies before " +
+			"confirmation would then re-enter as a fresh episode with a zeroed backoff (#1910)")
+	}
+	if !st.awaitingConfirm {
+		t.Fatal("a successful spawn must leave the restore awaiting liveness confirmation")
+	}
+	if got := inst.GetStatus(); got != session.Running {
+		t.Fatalf("status = %v, want Running after recovery", got)
+	}
+
+	// The runtime stayed up past the settle interval: the next pass observes it
+	// non-Lost and clears the history.
+	prev := lostRestoreConfirmSettle
+	lostRestoreConfirmSettle = 0
+	t.Cleanup(func() { lostRestoreConfirmSettle = prev })
+	manager.mu.Lock()
+	st.confirmBy = time.Now().Add(-time.Second) // settle window has elapsed
+	manager.mu.Unlock()
+
+	manager.RestoreLostSessions()
+	manager.mu.Lock()
+	_, stillTracked := manager.lostRestoreStates[key]
+	manager.mu.Unlock()
+	if stillTracked {
+		t.Fatal("retry state survived a confirmed-alive runtime; it must clear on confirmation")
+	}
+}

--- a/daemon/lostrestore_confirm_test.go
+++ b/daemon/lostrestore_confirm_test.go
@@ -16,6 +16,13 @@ import (
 // ~28 minutes. Recover returned nil every time (the tmux spawn genuinely worked),
 // so lostRestoreFailed never saw an error and the #1108 backoff never armed.
 
+// observeAlive fakes the daemon's one positive liveness observation — a poll whose
+// probe got an ANSWER out of the runtime. Tests drive it explicitly because that,
+// not elapsed time, is what confirms a restore (#1917 round 6).
+func observeAlive(m *Manager, repoID string, inst *session.Instance) {
+	m.noteAliveObservation(remoteLossKey(repoID, inst))
+}
+
 // diesOnSpawnBackend models the reported agent: its Recover SUCCEEDS — the spawn
 // is real and returns nil — but the runtime does not survive, so the row is Lost
 // again by the time the next poll looks. This is the exact case the old code read
@@ -145,20 +152,99 @@ func TestRestoreLostSessions_ConfirmedAliveClearsRetryState(t *testing.T) {
 		t.Fatalf("status = %v, want Running after recovery", got)
 	}
 
-	// The runtime stayed up past the settle interval: the next pass observes it
-	// non-Lost and clears the history.
-	prev := lostRestoreConfirmSettle
-	lostRestoreConfirmSettle = 0
-	t.Cleanup(func() { lostRestoreConfirmSettle = prev })
-	manager.mu.Lock()
-	st.confirmBy = time.Now().Add(-time.Second) // settle window has elapsed
-	manager.mu.Unlock()
-
+	// A poll gets an ANSWER out of the new runtime: THAT is the confirmation. No
+	// clock is advanced anywhere in this test.
+	observeAlive(manager, repoID, inst)
 	manager.RestoreLostSessions()
 	manager.mu.Lock()
 	_, stillTracked := manager.lostRestoreStates[key]
 	manager.mu.Unlock()
 	if stillTracked {
 		t.Fatal("retry state survived a confirmed-alive runtime; it must clear on confirmation")
+	}
+}
+
+// TestRestoreLostSessions_NeverObservedAlive_BacksOffRegardlessOfElapsedTime is
+// #1917 round-6 finding (2): the confirmation was a clock, not an observation.
+//
+// "Elapsed time without a successful liveness observation is not proof that the
+// runtime survived." Two real configurations broke the old fixed 15s window, and
+// this test covers BOTH with one property, because the fix makes them the same
+// case:
+//
+//   - daemon_poll_interval > the window: a restored process exits IMMEDIATELY, but
+//     nothing looks at it until after the window expires — so its history was
+//     cleared and treated as a fresh episode, and #1910's backoff never armed.
+//   - remote at DEFAULT settings: unanswered probes deliberately keep a session
+//     non-Lost for remoteLostGracePeriod (60s), four times the old window, with the
+//     same outcome.
+//
+// In both, the daemon never got an ANSWER out of the runtime. So: no observation,
+// no confirmation, no matter how much time passes.
+//
+// PRE-FIX BEHAVIOR THIS REPRODUCES: the history is cleared and each death re-enters
+// as attempt #1, so consecutiveFailures never climbs.
+func TestRestoreLostSessions_NeverObservedAlive_BacksOffRegardlessOfElapsedTime(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &diesOnSpawnBackend{FakeBackend: session.NewFakeBackend()}
+	registerStarted(t, manager, repoID, repoPath, "flapper", backend, true, session.Lost)
+	zeroRestoreBackoff(t)
+
+	key := daemonInstanceKey(repoID, "flapper")
+	// Many passes, and NOT ONE observation — exactly what a poll interval longer
+	// than any window, or a remote inside its 60s grace, produces. No clock is
+	// advanced: the point is that time is irrelevant without an answer.
+	for i := 0; i < 6; i++ {
+		manager.RestoreLostSessions()
+	}
+
+	manager.mu.Lock()
+	st := manager.lostRestoreStates[key]
+	failures := 0
+	if st != nil {
+		failures = st.consecutiveFailures
+	}
+	manager.mu.Unlock()
+
+	if st == nil {
+		t.Fatal("the retry history was cleared for a runtime nothing ever observed alive: elapsed " +
+			"time is not proof of survival, so the backoff never arms and the session respawns at " +
+			"poll cadence forever (#1917 round 6)")
+	}
+	if failures < 2 {
+		t.Fatalf("consecutiveFailures = %d after repeated unobserved deaths; each one must count "+
+			"against the SAME episode so the backoff escalates", failures)
+	}
+}
+
+// TestRestoreLostSessions_ObservationConfirms_NotElapsedTime pins the positive half:
+// an ANSWER from the runtime — and only that — clears the history.
+func TestRestoreLostSessions_ObservationConfirms_NotElapsedTime(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &recoverFakeBackend{FakeBackend: session.NewFakeBackend()}
+	inst := registerStarted(t, manager, repoID, repoPath, "healthy", backend, true, session.Lost)
+	zeroRestoreBackoff(t)
+	key := daemonInstanceKey(repoID, "healthy")
+
+	manager.RestoreLostSessions() // spawn; awaiting confirmation
+
+	// Passes WITHOUT an observation must not confirm, however many there are.
+	manager.RestoreLostSessions()
+	manager.mu.Lock()
+	stillAwaiting := manager.lostRestoreStates[key] != nil
+	manager.mu.Unlock()
+	if !stillAwaiting {
+		t.Fatal("the history was cleared without any observation: a non-Lost row is not proof of " +
+			"life (a remote inside its loss grace reads non-Lost while dead)")
+	}
+
+	// One ANSWER, and it is confirmed.
+	observeAlive(manager, repoID, inst)
+	manager.RestoreLostSessions()
+	manager.mu.Lock()
+	_, tracked := manager.lostRestoreStates[key]
+	manager.mu.Unlock()
+	if tracked {
+		t.Fatal("an observed-alive runtime must have its retry history cleared")
 	}
 }

--- a/daemon/lostrestore_confirm_test.go
+++ b/daemon/lostrestore_confirm_test.go
@@ -1,11 +1,13 @@
 package daemon
 
 import (
+	"fmt"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
 // The #1910 regression lock: a Lost session whose recovery spawn SUCCEEDS but
@@ -261,8 +263,8 @@ type deadPaneBackend struct{ *session.FakeBackend }
 func (b *deadPaneBackend) HasUpdated(*session.Instance) (bool, bool, string) {
 	return false, false, "" // what a DEAD session's suppressed capture returns
 }
-func (b *deadPaneBackend) IsAlive(*session.Instance) bool { return false } // probeDead
-func (b *deadPaneBackend) Type() string                   { return "local" }
+func (b *deadPaneBackend) IsAlive(*session.Instance) (bool, error) { return false, nil } // probeDead
+func (b *deadPaneBackend) Type() string                            { return "local" }
 
 // TestRefreshInstanceStatus_SnapshotNilErrorOnDeadSession_IsNotAnObservation is
 // round-7 finding (1), and it is the counter being fooled by the same disease it
@@ -316,5 +318,66 @@ func TestRefreshInstanceStatus_LiveSessionIsObserved(t *testing.T) {
 	if count == 0 {
 		t.Fatal("a live session produced no liveness observation: confirmation would never happen " +
 			"and every restored session would be charged a failure it did not earn")
+	}
+}
+
+// wedgedProbeBackend models #1917 round 8's ROOT: a primitive that cannot say "I
+// don't know". Its liveness probe TIMED OUT — tmux never answered — which
+// sessionExists laundered into `true` and Alive reported as (true, nil).
+//
+// The Snapshot is deliberately the same (false,false,"") a dead session gives, so
+// the poll takes its idle branch and asks the liveness probe. Everything then hinges
+// on what that probe is ALLOWED to say.
+type wedgedProbeBackend struct{ *session.FakeBackend }
+
+func (b *wedgedProbeBackend) HasUpdated(*session.Instance) (bool, bool, string) {
+	return false, false, ""
+}
+
+func (b *wedgedProbeBackend) IsAlive(*session.Instance) (bool, error) {
+	// The tri-state: could not ask. Before round 8 this signature was `bool`, so
+	// this exact situation was FORCED to be reported as `true`.
+	return false, fmt.Errorf("%w: has-session while probing liveness", tmux.ErrTmuxTimeout)
+}
+
+func (b *wedgedProbeBackend) Type() string { return "local" }
+
+// TestRefreshInstanceStatus_WedgedProbe_IsNotAnObservation is round-8 finding (2) —
+// the same disease as round 7, one primitive over.
+//
+// A timed-out `tmux has-session` became `true` via sessionExists; Alive reported
+// (true, nil); the poll recorded a positive liveness observation though tmux NEVER
+// ANSWERED — which after a Lost recovery clears lostRestoreStates, resets the
+// backoff, and can mark a wedged pane READY.
+//
+// Fixing it at the counter would have made the next caller round 9's finding. It is
+// fixed at the PRIMITIVE: Backend.IsAlive returns (bool, error), so "could not ask"
+// is sayable and probeLiveness maps it to probeUnknown.
+//
+// PRE-FIX BEHAVIOR THIS REPRODUCES: aliveObservations advances for a server that
+// never answered.
+func TestRefreshInstanceStatus_WedgedProbe_IsNotAnObservation(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &wedgedProbeBackend{FakeBackend: session.NewFakeBackend()}
+	inst := registerStarted(t, manager, repoID, repoPath, "wedged", backend, true, session.Running)
+
+	obsKey := remoteLossKey(repoID, inst)
+	manager.refreshInstanceStatus(repoID, inst)
+
+	manager.mu.Lock()
+	count := manager.aliveObservations[obsKey]
+	manager.mu.Unlock()
+
+	if count != 0 {
+		t.Fatal("a liveness probe that TIMED OUT was counted as affirmative evidence: a bool cannot " +
+			"say 'I don't know', so sessionExists laundered the timeout into `true` and Alive " +
+			"reported (true, nil) — and the restore loop then clears the failure history and can " +
+			"mark a wedged pane Ready (#1917 round 8). The fix is the primitive's type, not this " +
+			"caller: the next caller would have been round 9's finding.")
+	}
+	// Nor may it be marked Lost: an unanswered probe is not evidence of death
+	// either — that is what the debounce is for.
+	if got := inst.GetStatus(); got == session.Lost {
+		t.Fatal("an unanswerable probe marked the session Lost: silence is not death either")
 	}
 }

--- a/daemon/lostrestore_confirm_test.go
+++ b/daemon/lostrestore_confirm_test.go
@@ -248,3 +248,73 @@ func TestRestoreLostSessions_ObservationConfirms_NotElapsedTime(t *testing.T) {
 		t.Fatal("an observed-alive runtime must have its retry history cleared")
 	}
 }
+
+// deadPaneBackend models the exact trap of #1917 round 7: the agent-server's
+// Snapshot reports (false,false,"") with a NIL ERROR — which localAgentServer does
+// unconditionally, because it wraps HasUpdated and HasUpdated suppresses
+// capture/session-gone failures — while the liveness probe correctly answers DEAD.
+//
+// Absence of an error is not evidence of life. A counter that advances on "the call
+// didn't error" is fooled by exactly this.
+type deadPaneBackend struct{ *session.FakeBackend }
+
+func (b *deadPaneBackend) HasUpdated(*session.Instance) (bool, bool, string) {
+	return false, false, "" // what a DEAD session's suppressed capture returns
+}
+func (b *deadPaneBackend) IsAlive(*session.Instance) bool { return false } // probeDead
+func (b *deadPaneBackend) Type() string                   { return "local" }
+
+// TestRefreshInstanceStatus_SnapshotNilErrorOnDeadSession_IsNotAnObservation is
+// round-7 finding (1), and it is the counter being fooled by the same disease it
+// was built to cure.
+//
+// The poll's Snapshot returns nil for a session that is already dead, and the very
+// next probe marks it Lost. If that nil error counted as a liveness observation,
+// RestoreLostSessions would read "previously confirmed", clear the failure history,
+// and respawn with no backoff — #1910's hot loop, rebuilt out of an absent error.
+//
+// PRE-FIX BEHAVIOR THIS REPRODUCES: aliveObservations advances for a session the
+// same tick marks Lost.
+func TestRefreshInstanceStatus_SnapshotNilErrorOnDeadSession_IsNotAnObservation(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &deadPaneBackend{FakeBackend: session.NewFakeBackend()}
+	inst := registerStarted(t, manager, repoID, repoPath, "corpse", backend, true, session.Running)
+
+	obsKey := remoteLossKey(repoID, inst)
+	manager.refreshInstanceStatus(repoID, inst)
+
+	manager.mu.Lock()
+	count := manager.aliveObservations[obsKey]
+	manager.mu.Unlock()
+
+	if got := inst.GetStatus(); got != session.Lost {
+		t.Fatalf("setup: the probe must mark this dead session Lost, got %v", got)
+	}
+	if count != 0 {
+		t.Fatal("a Snapshot that returned NIL for a session this very tick marked Lost was counted " +
+			"as a liveness observation: localAgentServer.Snapshot never errors (it wraps HasUpdated, " +
+			"which suppresses capture/session-gone failures), so absence of an error masqueraded as " +
+			"evidence — and the restore loop then clears the failure history and respawns with no " +
+			"backoff, rebuilding #1910's hot loop (#1917 round 7)")
+	}
+}
+
+// TestRefreshInstanceStatus_LiveSessionIsObserved is the positive guard: requiring
+// affirmative evidence must not mean nothing ever confirms. A session whose pane
+// produces output IS affirmative — a dead pane cannot.
+func TestRefreshInstanceStatus_LiveSessionIsObserved(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &recoverFakeBackend{FakeBackend: session.NewFakeBackend()}
+	inst := registerStarted(t, manager, repoID, repoPath, "busy", backend, true, session.Running)
+
+	obsKey := remoteLossKey(repoID, inst)
+	manager.refreshInstanceStatus(repoID, inst)
+
+	manager.mu.Lock()
+	count := manager.aliveObservations[obsKey]
+	manager.mu.Unlock()
+	if count == 0 {
+		t.Fatal("a live session produced no liveness observation: confirmation would never happen " +
+			"and every restored session would be charged a failure it did not earn")
+	}
+}

--- a/daemon/lostrestore_test.go
+++ b/daemon/lostrestore_test.go
@@ -80,11 +80,17 @@ func zeroRestoreBackoff(t *testing.T) {
 
 // TestRestoreLostSessions_RecoversLostInstance: the core loop — a Lost local
 // session gets exactly one Recover, comes back Running, and its retry state is
-// dropped.
+// dropped once the recovery is CONFIRMED.
 func TestRestoreLostSessions_RecoversLostInstance(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 	backend := &recoverFakeBackend{FakeBackend: session.NewFakeBackend()}
 	inst := registerStarted(t, manager, repoID, repoPath, "stranded", backend, true, session.Lost)
+
+	// Settle immediately, so "recovered" resolves within this test. The confirmation
+	// window itself is covered by the #1910 tests in lostrestore_confirm_test.go.
+	prevSettle := lostRestoreConfirmSettle
+	lostRestoreConfirmSettle = 0
+	t.Cleanup(func() { lostRestoreConfirmSettle = prevSettle })
 
 	manager.RestoreLostSessions()
 
@@ -94,11 +100,17 @@ func TestRestoreLostSessions_RecoversLostInstance(t *testing.T) {
 	if got := inst.GetStatus(); got != session.Running {
 		t.Fatalf("status = %v, want Running after recovery", got)
 	}
+	// A second pass is what CONFIRMS the runtime: it observes the row still
+	// non-Lost past the settle interval and only then forgets the episode. This
+	// assertion used to run against the first pass and require the state to be gone
+	// the instant the spawn returned — which is exactly the #1910 bug, since a spawn
+	// returning proves nothing about whether the runtime survives.
+	manager.RestoreLostSessions()
 	manager.mu.Lock()
 	_, hasState := manager.lostRestoreStates[daemonInstanceKey(repoID, "stranded")]
 	manager.mu.Unlock()
 	if hasState {
-		t.Fatal("successful recovery must drop the retry state")
+		t.Fatal("a confirmed-alive recovery must drop the retry state")
 	}
 
 	// A healed session must not be touched again.

--- a/daemon/lostrestore_test.go
+++ b/daemon/lostrestore_test.go
@@ -86,12 +86,6 @@ func TestRestoreLostSessions_RecoversLostInstance(t *testing.T) {
 	backend := &recoverFakeBackend{FakeBackend: session.NewFakeBackend()}
 	inst := registerStarted(t, manager, repoID, repoPath, "stranded", backend, true, session.Lost)
 
-	// Settle immediately, so "recovered" resolves within this test. The confirmation
-	// window itself is covered by the #1910 tests in lostrestore_confirm_test.go.
-	prevSettle := lostRestoreConfirmSettle
-	lostRestoreConfirmSettle = 0
-	t.Cleanup(func() { lostRestoreConfirmSettle = prevSettle })
-
 	manager.RestoreLostSessions()
 
 	if got := backend.recoverCalls(); got != 1 {
@@ -100,11 +94,12 @@ func TestRestoreLostSessions_RecoversLostInstance(t *testing.T) {
 	if got := inst.GetStatus(); got != session.Running {
 		t.Fatalf("status = %v, want Running after recovery", got)
 	}
-	// A second pass is what CONFIRMS the runtime: it observes the row still
-	// non-Lost past the settle interval and only then forgets the episode. This
-	// assertion used to run against the first pass and require the state to be gone
-	// the instant the spawn returned — which is exactly the #1910 bug, since a spawn
-	// returning proves nothing about whether the runtime survives.
+	// What CONFIRMS the runtime is a poll getting an ANSWER out of it, and only then
+	// is the episode forgotten. This assertion used to run against the first pass and
+	// require the state to be gone the instant the spawn returned — which is exactly
+	// the #1910 bug, since a spawn returning proves nothing about whether the runtime
+	// survives. Nor does elapsed time (#1917 round 6): only an observation does.
+	observeAlive(manager, repoID, inst)
 	manager.RestoreLostSessions()
 	manager.mu.Lock()
 	_, hasState := manager.lostRestoreStates[daemonInstanceKey(repoID, "stranded")]

--- a/daemon/manager.go
+++ b/daemon/manager.go
@@ -71,6 +71,12 @@ type Manager struct {
 	// licence to exceed max_concurrent_runs after every restart.
 	ghostTaskRuns  map[string]int
 	repoStartLocks map[string]*sync.Mutex
+	// aliveObservations counts POSITIVE liveness observations per session (keyed by
+	// remoteLossKey, so a same-title successor never inherits its predecessor's).
+	// Incremented only where the poll actually gets an answer OUT of a runtime; read
+	// by the Lost-restore loop, which may only clear a session's failure history when
+	// this has advanced past the spawn. Guarded by mu.
+	aliveObservations map[string]uint64
 	// targetLocks serializes DeliverPrompt per (repo, title) so concurrent
 	// deliveries to the same shared target session create it once and deliver
 	// the rest in arrival order instead of racing creation and dropping the
@@ -210,6 +216,7 @@ func newManagerShell(cfg *config.Config) (*Manager, error) {
 		reservedTaskRuns:    make(map[string]int),
 		ghostTaskRuns:       make(map[string]int),
 		repoStartLocks:      make(map[string]*sync.Mutex),
+		aliveObservations:   make(map[string]uint64),
 		targetLocks:         make(map[string]*sync.Mutex),
 		rootEnsureStates:    make(map[string]*rootEnsureState),
 		rootKilledAt:        make(map[string]time.Time),

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -86,7 +86,25 @@ func (m *Manager) CreateSession(ctx context.Context, req CreateSessionRequest) (
 	// marked external — not the flow itself. finishCreateStart marks the instance
 	// live, PARKS it at a usage-limit wall (#1146 PR4), or returns a fatal error.
 	if serr := finishCreateStart(instance, req.Prompt, task.StartAndSendPrompt(ctx, instance, req.Prompt)); serr != nil {
-		_ = instance.Kill()
+		// The create failed, so this instance is about to be discarded — it was never
+		// registered or persisted, and the deferred release() hands its title straight
+		// back out. That is only safe if the cleanup below actually removed what the
+		// create built (#1917).
+		//
+		// Kill swallows everything tmux and git ANSWER for, so an error here means it
+		// could NOT: a pane whose liveness is unknown, or a worktree removal cut off
+		// mid-delete. Releasing the title over those leftovers means the next create
+		// with this name collides with — or removes — a workspace nobody can address,
+		// since no record points at it. So keep the record instead: it holds the title
+		// and gives the user something to inspect and kill.
+		if killErr := instance.Kill(); killErr != nil {
+			if keepErr := m.keepFailedCreate(repo.ID, title, instance); keepErr != nil {
+				return session.InstanceData{}, fmt.Errorf("failed to start instance %q, and its cleanup could not complete safely — its workspace may still be on disk at %s and could not be recorded, so it must be cleaned up by hand: %w",
+					title, instance.GetWorktreePath(), errors.Join(serr, killErr, keepErr))
+			}
+			return session.InstanceData{}, fmt.Errorf("failed to start instance %q, and its cleanup could not complete safely, so its workspace was left in place; the session has been kept so you can inspect or kill it: %w",
+				title, errors.Join(serr, killErr))
+		}
 		return session.InstanceData{}, fmt.Errorf("failed to start instance: %w", serr)
 	}
 	data := instance.ToInstanceData()
@@ -110,7 +128,13 @@ func (m *Manager) CreateSession(ctx context.Context, req CreateSessionRequest) (
 		return nil
 	}()
 	if persistErr != nil {
-		_ = instance.Kill()
+		// Same rule as the start-failure path above, minus the remedy: the record
+		// write is what just failed, so keeping a record is not available. Report the
+		// leftovers loudly instead of silently releasing the title over them (#1917).
+		if killErr := instance.Kill(); killErr != nil {
+			return session.InstanceData{}, fmt.Errorf("failed to record session %q, and its cleanup could not complete safely — its workspace may still be on disk at %s and must be cleaned up by hand: %w",
+				title, instance.GetWorktreePath(), errors.Join(persistErr, killErr))
+		}
 		return session.InstanceData{}, persistErr
 	}
 	m.captureAgentConversationAsync(repo.ID, key, instance, conversationCapture)
@@ -604,4 +628,30 @@ func (m *Manager) titlesCollide(a, b string) bool {
 // detect branch collisions before worktree setup runs.
 func (m *Manager) branchForTitle(title string) string {
 	return git.BranchForTitle(m.cfg.BranchPrefix, title)
+}
+
+// keepFailedCreate registers and persists an instance whose create FAILED but
+// whose cleanup could not complete safely, so its tmux and/or worktree are still
+// on disk (#1917).
+//
+// A create normally discards a failed instance and lets reserveCreate's release()
+// hand the title back out — correct, because the cleanup removed everything the
+// create built. When the cleanup could NOT complete, that same release puts the
+// title back in circulation on top of live leftovers that no record points at, so
+// the next create under that name collides with or deletes them. Keeping the record
+// makes the leftovers addressable (the user can see and kill the session) and holds
+// the title against reuse. Mirrors the register-then-persist ordering of the success
+// path: the map entry goes in first so the refresh loop cannot build a duplicate
+// Instance from disk, and is rolled back if the write fails. The caller holds the
+// repo start lock.
+func (m *Manager) keepFailedCreate(repoID, title string, instance *session.Instance) error {
+	key := daemonInstanceKey(repoID, title)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.instances[key] = instance
+	if err := appendInstanceData(repoID, instance.ToInstanceData()); err != nil {
+		delete(m.instances, key)
+		return err
+	}
+	return nil
 }

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -102,7 +102,7 @@ func (m *Manager) CreateSession(ctx context.Context, req CreateSessionRequest) (
 				return session.InstanceData{}, fmt.Errorf("failed to start instance %q, and its cleanup could not complete safely — its workspace may still be on disk at %s and could not be recorded, so it must be cleaned up by hand: %w",
 					title, instance.GetWorktreePath(), errors.Join(serr, killErr, keepErr))
 			}
-			return session.InstanceData{}, fmt.Errorf("failed to start instance %q, and its cleanup could not complete safely, so its workspace was left in place; the session has been kept so you can inspect or kill it: %w",
+			return session.InstanceData{}, fmt.Errorf("failed to start instance %q, and its cleanup could not complete safely, so its workspace was left in place; the session is recorded and the daemon will keep retrying the cleanup — it will clear once that succeeds: %w",
 				title, errors.Join(serr, killErr))
 		}
 		return session.InstanceData{}, fmt.Errorf("failed to start instance: %w", serr)
@@ -638,13 +638,30 @@ func (m *Manager) branchForTitle(title string) string {
 // hand the title back out — correct, because the cleanup removed everything the
 // create built. When the cleanup could NOT complete, that same release puts the
 // title back in circulation on top of live leftovers that no record points at, so
-// the next create under that name collides with or deletes them. Keeping the record
-// makes the leftovers addressable (the user can see and kill the session) and holds
-// the title against reuse. Mirrors the register-then-persist ordering of the success
-// path: the map entry goes in first so the refresh loop cannot build a duplicate
-// Instance from disk, and is rolled back if the write fails. The caller holds the
-// repo start lock.
+// the next create under that name collides with or deletes them.
+//
+// The record is TOMBSTONED, not merely written. Retention is a claim on two other
+// layers, and a row that just sits there satisfies neither (#1917 round 5):
+//
+//   - SaveInstances drops any non-started, non-Archived instance on the next
+//     wholesale checkpoint — which fires whenever ANY other started session in the
+//     repo is saved. An untombstoned row here would be silently erased, orphaning
+//     the leftovers it exists to hold. The tombstone is what makes that writer keep
+//     it.
+//   - Nothing else would ever finish the cleanup. refreshInstanceStatus routes a
+//     tombstoned record to finishUserKill on every poll, which retries the teardown
+//     and drops the record once it completes safely — so the leftovers are reaped
+//     when the cause clears, rather than waiting on the user.
+//
+// The tombstone is honest here: it records "a teardown is committed for this
+// record; finish it, never restore it", which is exactly what a failed create's
+// cleanup is. Mirrors the register-then-persist ordering of the success path — the
+// map entry goes in first so the refresh loop cannot build a duplicate Instance from
+// disk, and is rolled back if the write fails. The caller holds the repo start lock,
+// so this appends directly rather than going through persistKillTombstone (which
+// takes that same non-reentrant lock).
 func (m *Manager) keepFailedCreate(repoID, title string, instance *session.Instance) error {
+	instance.MarkUserKilled()
 	key := daemonInstanceKey(repoID, title)
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -97,7 +97,16 @@ func (m *Manager) CreateSession(ctx context.Context, req CreateSessionRequest) (
 		// with this name collides with — or removes — a workspace nobody can address,
 		// since no record points at it. So keep the record instead: it holds the title
 		// and gives the user something to inspect and kill.
-		if killErr := instance.Kill(); killErr != nil {
+		// The SAME classifier deleteSessionRecord uses (#1917 round 7). A non-nil
+		// Kill is not enough: a remote create failure returns the in-sandbox
+		// endpoint's error even when the sandbox teardown SUCCEEDED, so the
+		// workspace is already gone — tombstoning a row, holding the title and
+		// telling the user a workspace may remain would all be false.
+		killErr := instance.Kill()
+		if killErr != nil && !session.TeardownStateUnknown(killErr) {
+			log.WarningLog.Printf("create of session %q: cleanup reported an error that does not leave its workspace state unknown; discarding the session as normal: %v", title, killErr)
+		}
+		if session.TeardownStateUnknown(killErr) {
 			if keepErr := m.keepFailedCreate(repo.ID, title, instance); keepErr != nil {
 				return session.InstanceData{}, fmt.Errorf("failed to start instance %q, and its cleanup could not complete safely — its workspace may still be on disk at %s and could not be recorded, so it must be cleaned up by hand: %w",
 					title, instance.GetWorktreePath(), errors.Join(serr, killErr, keepErr))
@@ -131,7 +140,7 @@ func (m *Manager) CreateSession(ctx context.Context, req CreateSessionRequest) (
 		// Same rule as the start-failure path above, minus the remedy: the record
 		// write is what just failed, so keeping a record is not available. Report the
 		// leftovers loudly instead of silently releasing the title over them (#1917).
-		if killErr := instance.Kill(); killErr != nil {
+		if killErr := instance.Kill(); session.TeardownStateUnknown(killErr) {
 			return session.InstanceData{}, fmt.Errorf("failed to record session %q, and its cleanup could not complete safely — its workspace may still be on disk at %s and must be cleaned up by hand: %w",
 				title, instance.GetWorktreePath(), errors.Join(persistErr, killErr))
 		}

--- a/daemon/manager_persist.go
+++ b/daemon/manager_persist.go
@@ -279,9 +279,15 @@ var ghostKillTmuxByName = func(sanitizedName string) (tmux.PaneState, error) {
 // (#815): this runs daemon-side with no user to warn, only for sessions whose
 // records are already unrestorable, and the caller has already committed to
 // deleting the record — a status probe could only block cleanup, not save data.
-var ghostCleanupWorktree = func(data *session.InstanceData, title string) {
+//
+// "Best-effort" covers what git ANSWERED with. It does NOT cover a cleanup cut off
+// by its own deadline: the caller deletes this ghost's record next, and that record
+// is the only handle anything has on the leftovers. Report that so the caller keeps
+// it (#1917) — the third site in this PR where a bounded call failed, someone logged
+// it, and a destructive step went ahead anyway.
+var ghostCleanupWorktree = func(data *session.InstanceData, title string) (git.CleanupState, error) {
 	if data.Worktree.RepoPath == "" || data.Worktree.WorktreePath == "" || data.Worktree.ExternalWorktree {
-		return
+		return git.CleanupSettled, nil
 	}
 	// Unknown provenance means KEEP (#1953): a nil flag predates 2026-04-17 and
 	// cannot establish that AF created the branch, and the only thing this
@@ -303,12 +309,15 @@ var ghostCleanupWorktree = func(data *session.InstanceData, title string) {
 		branchCreatedByUs,
 	)
 	if gwErr != nil {
+		// Nothing was attempted, so nothing is unknown; the record may still go.
 		log.WarningLog.Printf("ghost session %q: failed to load worktree for cleanup: %v", title, gwErr)
-		return
+		return git.CleanupSettled, nil
 	}
-	if cleanupErr := gw.Cleanup(); cleanupErr != nil {
+	state, cleanupErr := gw.Cleanup()
+	if cleanupErr != nil {
 		log.WarningLog.Printf("ghost session %q: worktree cleanup failed: %v", title, cleanupErr)
 	}
+	return state, cleanupErr
 }
 
 // ghostCleanup runs best-effort teardown of a ghost session's external
@@ -334,6 +343,10 @@ func ghostCleanup(data *session.InstanceData, title string) error {
 				title, session.ErrPaneMayBeLive, killErr)
 		}
 	}
-	ghostCleanupWorktree(data, title)
+	state, cleanupErr := ghostCleanupWorktree(data, title)
+	if state == git.CleanupStateUnknown {
+		return fmt.Errorf("ghost session %q: %w: keeping its record so the cleanup can be retried: %v",
+			title, session.ErrWorkspaceStateUnknown, cleanupErr)
+	}
 	return nil
 }

--- a/daemon/manager_persist.go
+++ b/daemon/manager_persist.go
@@ -262,9 +262,13 @@ func findInstanceDataByTitle(title, repoID string) (*session.InstanceData, strin
 // corrupted store can't make us kill an unrelated tmux session. Mirror of the
 // api/sessions.go helper added in #536 — duplicated here because daemon/
 // cannot import api/ without a cycle.
-var ghostKillTmuxByName = func(sanitizedName string) error {
+// It reports the tmux.PaneState alongside the error for the same reason the
+// teardown modes do (#1917): the caller goes on to DELETE this ghost's worktree,
+// so it must be able to tell "tmux confirmed the session is gone" from "tmux never
+// answered". A refused name never ran a tmux command, so its state is known.
+var ghostKillTmuxByName = func(sanitizedName string) (tmux.PaneState, error) {
 	if !strings.HasPrefix(sanitizedName, tmux.TmuxPrefix) {
-		return fmt.Errorf("refusing to kill tmux session without %q prefix: %q", tmux.TmuxPrefix, sanitizedName)
+		return tmux.PaneStateKnown, fmt.Errorf("refusing to kill tmux session without %q prefix: %q", tmux.TmuxPrefix, sanitizedName)
 	}
 	return tmux.NewTmuxSessionFromSanitizedName(sanitizedName, "").CloseAndWaitForPaneExit()
 }
@@ -313,11 +317,23 @@ var ghostCleanupWorktree = func(data *session.InstanceData, title string) {
 // persisted name is still running, so the two branches share no condition.
 // Tmux goes FIRST: a still-running agent writing into the worktree while git
 // recursively deletes it leaks a half-deleted directory (#802).
-func ghostCleanup(data *session.InstanceData, title string) {
+// It gates the worktree delete on tmux having ANSWERED, and returns an error the
+// caller must not step over (#1917). This path is the ghost twin of teardownKill
+// and had the identical defect the review caught there: it logged the tmux failure
+// and cleaned the worktree regardless, so a wedged server meant deleting the
+// workspace of a session that might still be running. Found by auditing every
+// caller of the bounded teardown rather than by the review itself.
+func ghostCleanup(data *session.InstanceData, title string) error {
 	if data.TmuxName != "" {
-		if killErr := ghostKillTmuxByName(data.TmuxName); killErr != nil {
+		state, killErr := ghostKillTmuxByName(data.TmuxName)
+		if killErr != nil {
 			log.WarningLog.Printf("ghost session %q: tmux cleanup failed: %v", title, killErr)
+		}
+		if state == tmux.PaneStateUnknown {
+			return fmt.Errorf("ghost session %q: %w: leaving its workspace and record intact: %v",
+				title, session.ErrPaneMayBeLive, killErr)
 		}
 	}
 	ghostCleanupWorktree(data, title)
+	return nil
 }

--- a/daemon/manager_persist.go
+++ b/daemon/manager_persist.go
@@ -338,13 +338,13 @@ func ghostCleanup(data *session.InstanceData, title string) error {
 		if killErr != nil {
 			log.WarningLog.Printf("ghost session %q: tmux cleanup failed: %v", title, killErr)
 		}
-		if state == tmux.PaneStateUnknown {
+		if state != tmux.PaneStateKnown {
 			return fmt.Errorf("ghost session %q: %w: leaving its workspace and record intact: %v",
 				title, session.ErrPaneMayBeLive, killErr)
 		}
 	}
 	state, cleanupErr := ghostCleanupWorktree(data, title)
-	if state == git.CleanupStateUnknown {
+	if state != git.CleanupSettled {
 		return fmt.Errorf("ghost session %q: %w: keeping its record so the cleanup can be retried: %v",
 			title, session.ErrWorkspaceStateUnknown, cleanupErr)
 	}

--- a/daemon/manager_sessions.go
+++ b/daemon/manager_sessions.go
@@ -98,8 +98,19 @@ func (m *Manager) KillSession(req KillSessionRequest) (session.InstanceData, err
 	// teardown instead of classifying the vanished session Lost and restoring
 	// it. Best-effort: a failed tombstone write degrades to today's crash
 	// window, which must not block the kill itself.
+	//
+	// ABORTS the kill when it cannot be recorded (#1917). This is the commit point:
+	// everything above is reversible and nothing has been destroyed yet, so a
+	// failure here costs the user a retry. Proceeding instead would tear the
+	// session down with no durable record that the user asked for it — and a daemon
+	// that then died before the record delete would reload a non-tombstoned row,
+	// call it Lost, and RESTORE the session into the worktree teardown had already
+	// deleted. The bound that makes this write fail (rather than hang) is only safe
+	// because the failure stops here.
 	stage.set("persisting kill tombstone")
-	m.persistKillTombstone(repoID, instance, data)
+	if err := m.persistKillTombstone(repoID, instance, data); err != nil {
+		return session.InstanceData{}, fmt.Errorf("kill of session %q was not started: its kill intent could not be recorded, and tearing the session down without that record risks it being restored later; nothing was changed — retry the kill: %w", req.Title, err)
+	}
 
 	// Stop this session's VS Code editor before the worktree goes away: it is
 	// daemon-owned infrastructure rather than a tab, so no tab teardown covers it,
@@ -119,8 +130,16 @@ func (m *Manager) KillSession(req KillSessionRequest) (session.InstanceData, err
 
 	if instance != nil {
 		stage.set("tearing down tmux + worktree")
+		// Returning here deliberately SKIPS the record delete below (#1917). Kill
+		// only errors when the teardown could not be completed safely — tmux never
+		// confirmed a pane dead, or git was cut off mid-removal — and in both cases
+		// the workspace is still there. Dropping the record would orphan it and take
+		// away the only handle the user has to retry through. The tombstone is
+		// already durable, so the kill stays committed: finishUserKill retries it on
+		// every poll until it succeeds, with no daemon restart needed.
 		if err := instance.Kill(); err != nil {
-			return session.InstanceData{}, fmt.Errorf("failed to kill instance: %w", err)
+			log.WarningLog.Printf("kill of session %q could not complete its teardown; the record is kept and the daemon will retry it: %v", req.Title, err)
+			return session.InstanceData{}, fmt.Errorf("kill of session %q could not finish tearing it down safely, so its workspace was left intact; the kill is recorded and will be retried automatically: %w", req.Title, err)
 		}
 	} else if data != nil {
 		stage.set("cleaning up ghost record")

--- a/daemon/manager_sessions.go
+++ b/daemon/manager_sessions.go
@@ -143,7 +143,13 @@ func (m *Manager) KillSession(req KillSessionRequest) (session.InstanceData, err
 		}
 	} else if data != nil {
 		stage.set("cleaning up ghost record")
-		ghostCleanup(data, req.Title)
+		// Same gate as the live-instance branch above: skip the record delete when
+		// the ghost's tmux never confirmed dead, so its workspace and its record
+		// both survive for finishUserKill to retry (#1917).
+		if err := ghostCleanup(data, req.Title); err != nil {
+			log.WarningLog.Printf("kill of session %q could not complete its ghost teardown; the record is kept and the daemon will retry it: %v", req.Title, err)
+			return session.InstanceData{}, fmt.Errorf("kill of session %q could not finish tearing it down safely, so its workspace was left intact; the kill is recorded and will be retried automatically: %w", req.Title, err)
+		}
 	}
 
 	stage.set("deleting record from storage")

--- a/daemon/manager_sessions.go
+++ b/daemon/manager_sessions.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/sachiniyer/agent-factory/config"
@@ -56,10 +57,36 @@ func (m *Manager) KillSession(req KillSessionRequest) (session.InstanceData, err
 	// never an interleaved teardown-vs-respawn. killsInFlight is registered
 	// BEFORE this acquire, so the restore loop's in-lock re-check sees the
 	// kill intent and aborts instead of racing to go first.
+	//
+	// BOUNDED, not blocking (#1917). The exclusion above is kept exactly — this
+	// is still a real mutex, and a kill still never interleaves with a respawn —
+	// but the wait now has a deadline. An unbounded Lock() here sits inside the
+	// killsInFlight guard, so a peer operation that wedges (a stuck Recover, a
+	// hung tmux/git subprocess under it) does not just delay this kill: it makes
+	// the session permanently undeletable, since every retry is then rejected by
+	// the guard this call is holding. Failing cleanly is strictly better than
+	// waiting forever, and it is safe to fail HERE specifically because we have
+	// not committed to anything yet — the tombstone below is the commit point, so
+	// a timeout at this line leaves the session bit-for-bit unchanged and the
+	// retry the error asks for is a true retry.
 	opLock := m.opLockFor(key)
-	opLock.Lock()
+	if !lockWithin(opLock, opLockTimeout) {
+		log.WarningLog.Printf("kill of session %q could not acquire its operation lock within %s; another operation on this session is not releasing it", req.Title, opLockTimeout)
+		return session.InstanceData{}, errKillBusy(req.Title, opLockTimeout)
+	}
 	defer opLock.Unlock()
 
+	// From here the kill is COMMITTED: the tombstone below is durable and the
+	// teardown mutates the workspace. Every remaining step is individually
+	// bounded (the instances flock, and the tmux/git subprocesses under
+	// instance.Kill), so this function terminates without needing to abandon work
+	// mid-flight. The watchdog only reports a stage — and stacks — if a step
+	// somehow outlives its own bound, so the next occurrence names its wedge
+	// point instead of leaving it to be inferred from logs (#1917).
+	stage := &killStage{}
+	defer watchKill(req.Title, stage)()
+
+	stage.set("checking instance identity")
 	if m.currentInstanceReplaced(key, instance, targetID) {
 		log.InfoLog.Printf("kill of session %q skipped: current instance identity changed before teardown", req.Title)
 		return resolved, nil
@@ -71,6 +98,7 @@ func (m *Manager) KillSession(req KillSessionRequest) (session.InstanceData, err
 	// teardown instead of classifying the vanished session Lost and restoring
 	// it. Best-effort: a failed tombstone write degrades to today's crash
 	// window, which must not block the kill itself.
+	stage.set("persisting kill tombstone")
 	m.persistKillTombstone(repoID, instance, data)
 
 	// Stop this session's VS Code editor before the worktree goes away: it is
@@ -86,16 +114,20 @@ func (m *Manager) KillSession(req KillSessionRequest) (session.InstanceData, err
 	// editor" holds on ordering rather than on timing.
 	vscodeKey := daemonInstanceKey(repoID, req.Title)
 	defer m.vscode.stopFor(vscodeKey)
+	stage.set("stopping vscode editor")
 	m.vscode.stopFor(vscodeKey)
 
 	if instance != nil {
+		stage.set("tearing down tmux + worktree")
 		if err := instance.Kill(); err != nil {
 			return session.InstanceData{}, fmt.Errorf("failed to kill instance: %w", err)
 		}
 	} else if data != nil {
+		stage.set("cleaning up ghost record")
 		ghostCleanup(data, req.Title)
 	}
 
+	stage.set("deleting record from storage")
 	state := config.LoadState()
 	storage, err := session.NewStorage(state, repoID)
 	if err != nil {
@@ -103,6 +135,17 @@ func (m *Manager) KillSession(req KillSessionRequest) (session.InstanceData, err
 	}
 	deleted, err := storage.DeleteInstanceByStableID(req.Title, targetID)
 	if err != nil {
+		// A contended instances flock is retryable and must SAY so (#1917): the
+		// tombstone is already durable, so the kill is committed and will be
+		// finished either by the user's retry or — with no further input — by
+		// finishUserKill on the next poll, which reaches this same delete once
+		// this call returns and releases killsInFlight. What must not happen is
+		// this call never returning: that is what starved the finisher and made
+		// the session undeletable until a daemon restart.
+		if errors.Is(err, config.ErrLockTimeout) {
+			log.WarningLog.Printf("kill of session %q: the instances record is locked by another agent-factory process; the kill is committed and the daemon will finish it on a later poll: %v", req.Title, err)
+			return session.InstanceData{}, fmt.Errorf("kill of session %q could not update its record because another agent-factory process is holding the repo's instances lock; the session is already marked killed and will be reaped automatically — retry if it lingers: %w", req.Title, err)
+		}
 		return session.InstanceData{}, fmt.Errorf("failed to delete instance from storage: %w", err)
 	}
 	if !deleted {

--- a/daemon/manager_sessions.go
+++ b/daemon/manager_sessions.go
@@ -128,6 +128,9 @@ func (m *Manager) KillSession(req KillSessionRequest) (session.InstanceData, err
 	stage.set("stopping vscode editor")
 	m.vscode.stopFor(vscodeKey)
 
+	// Carried to the record delete below, which refuses on a non-nil teardown.
+	var teardownErr error
+
 	if instance != nil {
 		stage.set("tearing down tmux + worktree")
 		// Returning here deliberately SKIPS the record delete below (#1917). Kill
@@ -137,28 +140,25 @@ func (m *Manager) KillSession(req KillSessionRequest) (session.InstanceData, err
 		// away the only handle the user has to retry through. The tombstone is
 		// already durable, so the kill stays committed: finishUserKill retries it on
 		// every poll until it succeeds, with no daemon restart needed.
-		if err := instance.Kill(); err != nil {
-			log.WarningLog.Printf("kill of session %q could not complete its teardown; the record is kept and the daemon will retry it: %v", req.Title, err)
-			return session.InstanceData{}, fmt.Errorf("kill of session %q could not finish tearing it down safely, so its workspace was left intact; the kill is recorded and will be retried automatically: %w", req.Title, err)
+		if teardownErr = instance.Kill(); teardownErr != nil {
+			log.WarningLog.Printf("kill of session %q could not complete its teardown; the record is kept and the daemon will retry it: %v", req.Title, teardownErr)
+			return session.InstanceData{}, fmt.Errorf("kill of session %q could not finish tearing it down safely, so its workspace was left intact; the kill is recorded and will be retried automatically: %w", req.Title, teardownErr)
 		}
 	} else if data != nil {
 		stage.set("cleaning up ghost record")
 		// Same gate as the live-instance branch above: skip the record delete when
 		// the ghost's tmux never confirmed dead, so its workspace and its record
 		// both survive for finishUserKill to retry (#1917).
-		if err := ghostCleanup(data, req.Title); err != nil {
-			log.WarningLog.Printf("kill of session %q could not complete its ghost teardown; the record is kept and the daemon will retry it: %v", req.Title, err)
-			return session.InstanceData{}, fmt.Errorf("kill of session %q could not finish tearing it down safely, so its workspace was left intact; the kill is recorded and will be retried automatically: %w", req.Title, err)
+		if teardownErr = ghostCleanup(data, req.Title); teardownErr != nil {
+			log.WarningLog.Printf("kill of session %q could not complete its ghost teardown; the record is kept and the daemon will retry it: %v", req.Title, teardownErr)
+			return session.InstanceData{}, fmt.Errorf("kill of session %q could not finish tearing it down safely, so its workspace was left intact; the kill is recorded and will be retried automatically: %w", req.Title, teardownErr)
 		}
 	}
 
 	stage.set("deleting record from storage")
-	state := config.LoadState()
-	storage, err := session.NewStorage(state, repoID)
-	if err != nil {
-		return session.InstanceData{}, err
-	}
-	deleted, err := storage.DeleteInstanceByStableID(req.Title, targetID)
+	// Through the one choke point (#1917): it refuses while the teardown's outcome
+	// is unknown, so this call site cannot be the one that forgets.
+	deleted, err := m.deleteSessionRecord(repoID, req.Title, targetID, teardownErr)
 	if err != nil {
 		// A contended instances flock is retryable and must SAY so (#1917): the
 		// tombstone is already durable, so the kill is committed and will be

--- a/daemon/manager_sessions.go
+++ b/daemon/manager_sessions.go
@@ -150,8 +150,16 @@ func (m *Manager) KillSession(req KillSessionRequest) (session.InstanceData, err
 		// the ghost's tmux never confirmed dead, so its workspace and its record
 		// both survive for finishUserKill to retry (#1917).
 		if teardownErr = ghostCleanup(data, req.Title); teardownErr != nil {
-			log.WarningLog.Printf("kill of session %q could not complete its ghost teardown; the record is kept and the daemon will retry it: %v", req.Title, teardownErr)
-			return session.InstanceData{}, fmt.Errorf("kill of session %q could not finish tearing it down safely, so its workspace was left intact; the kill is recorded and will be retried automatically: %w", req.Title, teardownErr)
+			// NO automatic retry is promised here, deliberately (#1917 round 5).
+			// finishUserKill is reached only from refreshInstanceStatus, which
+			// iterates m.instances — and a ghost is precisely a record that could not
+			// be reconstructed into an instance, so it never enters that map and no
+			// poll will ever pick it up. The record and its tombstone survive, which
+			// keeps the workspace addressable and stops the poll classifying it Lost,
+			// but the next attempt has to come from the user. Telling them otherwise
+			// would be a promise the code cannot keep, which is worse than no promise.
+			log.WarningLog.Printf("kill of session %q could not complete its ghost teardown; the record is kept, but nothing will retry it automatically (a ghost has no live instance for the poll to visit) — retry the kill to try again: %v", req.Title, teardownErr)
+			return session.InstanceData{}, fmt.Errorf("kill of session %q could not finish tearing it down safely, so its workspace was left intact and its record kept; this one is not retried automatically — run the kill again once the cause clears: %w", req.Title, teardownErr)
 		}
 	}
 

--- a/daemon/manager_status.go
+++ b/daemon/manager_status.go
@@ -303,13 +303,6 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 	// HasUpdated). Content is the capture handed back so the idle branch runs the
 	// usage-limit detector (#1146) without a second capture-pane.
 	obs, err := as.Snapshot()
-	if err == nil {
-		// The runtime ANSWERED. This is the only positive liveness observation in the
-		// daemon, and the Lost-restore loop's confirmation is defined in terms of it
-		// (#1910/#1917 round 6): elapsed time without an answer proves nothing, so a
-		// clock must never stand in for this.
-		m.noteAliveObservation(key)
-	}
 	if err != nil {
 		// The observation probe failed. The local agent-server never errors here,
 		// so this is the REMOTE runtime's path (#1592 Phase 4): the REST call to
@@ -346,10 +339,33 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 	// This is the ONLY thing the debounce tracks — see remoteloss.go: it counts
 	// unanswerable probes, not "looks dead" observations.
 	m.clearRemoteLoss(key)
+
+	// AFFIRMATIVE liveness evidence for this tick, decided in ONE place and only
+	// where the poll actually learned something (#1917 round 7).
+	//
+	// It is NOT "Snapshot did not error". localAgentServer.Snapshot returns a nil
+	// error unconditionally — it wraps HasUpdated, which SUPPRESSES capture and
+	// session-gone failures and reports (false,false,"") for a session that is
+	// already dead. Counting that as proof of life let the Lost-restore loop read
+	// "previously confirmed", clear the failure history, and respawn with no backoff:
+	// #1910's hot loop, rebuilt out of an absent error. Absence of an error is not
+	// evidence; only something that can say YES is.
+	//
+	// The three yeses below are exactly the branches that carry one, and the comment
+	// on the idle branch names the reason the fourth cannot: (false,false) "a healthy
+	// idle session and a dead one both produce — indistinguishable on their own".
+	observedAlive := false
 	switch {
 	case updated:
+		// Fresh output. Only a live pane produces bytes, and a dead one yields "" —
+		// so this is affirmative on its own, no probe needed.
+		observedAlive = true
 		_ = instance.Transition(session.ObserveLiveness(session.LiveRunning))
 	case hasPrompt:
+		// A matched prompt means the CAPTURE SUCCEEDED: hasPrompt is a substring test
+		// over content, and every failure path in HasUpdated returns content "". So
+		// non-empty matched content is itself an answer from a live pane.
+		observedAlive = true
 		// A waiting prompt with otherwise-unchanged output: leave the status for
 		// the next tick to resolve, exactly as runMetadataTick did. The
 		// prompt-tap already fired above regardless of `updated`.
@@ -387,11 +403,17 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 				_ = instance.Transition(session.ObserveLiveness(session.LiveLost))
 			}
 		case probeAlive:
+			// The agent-server was asked and reports its agent RUNNING — the
+			// codebase's own affirmative signal, sitting one file away the whole time.
+			observedAlive = true
 			// Idle output: settle to Ready, or LimitReached when the pane shows a
 			// usage-limit banner for a claude/codex session (#1146). content is
 			// HasUpdated's capture (no re-capture); see resolveIdleLiveness.
 			m.resolveIdleLiveness(instance, content)
 		}
+	}
+	if observedAlive {
+		m.noteAliveObservation(key)
 	}
 
 	// Persist a liveness OR usage-limit reset-time change (#1146); see limit.go.

--- a/daemon/manager_status.go
+++ b/daemon/manager_status.go
@@ -303,6 +303,13 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 	// HasUpdated). Content is the capture handed back so the idle branch runs the
 	// usage-limit detector (#1146) without a second capture-pane.
 	obs, err := as.Snapshot()
+	if err == nil {
+		// The runtime ANSWERED. This is the only positive liveness observation in the
+		// daemon, and the Lost-restore loop's confirmation is defined in terms of it
+		// (#1910/#1917 round 6): elapsed time without an answer proves nothing, so a
+		// clock must never stand in for this.
+		m.noteAliveObservation(key)
+	}
 	if err != nil {
 		// The observation probe failed. The local agent-server never errors here,
 		// so this is the REMOTE runtime's path (#1592 Phase 4): the REST call to

--- a/daemon/manager_status.go
+++ b/daemon/manager_status.go
@@ -213,19 +213,33 @@ func (m *Manager) RefreshStatuses() {
 // alternative is a stale count that survives an arbitrary blind window and lets
 // ONE later blip tip a healthy session into a destructive re-provision.
 func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instance) {
-	if instance == nil || !instance.Started() {
+	if instance == nil {
 		return
 	}
-	// The debounce is keyed by stable instance ID, never repo/title: a same-title
-	// successor must not inherit a dead predecessor's failures (#1794).
+	// The kill-intent tombstone outranks the started fence, and the ORDER of these
+	// two checks is load-bearing (#1917).
+	//
+	// A surviving tombstone (#1108) means a previous KillSession was interrupted
+	// after committing to the kill. The only valid future for this session is
+	// finishing that teardown — never probing it, never marking it Lost, never
+	// restoring it.
+	//
+	// This used to sit BELOW the !Started() return, which was survivable only while
+	// every interrupted kill was interrupted BEFORE its teardown: the tombstone is
+	// written first, so the record on disk still said started=true and a restarted
+	// daemon reloaded it and finished the kill. A kill that now fails AFTER the
+	// teardown — the record delete losing a bounded race for the instances lock —
+	// leaves the live instance with started=false, so the poll returned here and
+	// finishUserKill never ran: the tombstone sat unprocessed for the daemon's whole
+	// life, and the error told the user it would be retried automatically. That was
+	// a promise the code did not keep.
 	key := remoteLossKey(repoID, instance)
 	if instance.UserKilled() {
-		// A surviving kill-intent tombstone (#1108) means a previous
-		// KillSession was interrupted after committing to the kill. The only
-		// valid future for this session is finishing that teardown — never
-		// probing it, never marking it Lost, never restoring it.
 		m.clearRemoteLoss(key)
 		m.finishUserKill(repoID, instance)
+		return
+	}
+	if !instance.Started() {
 		return
 	}
 	if instance.GetInFlightOp() != session.OpNone {

--- a/daemon/remoteloss.go
+++ b/daemon/remoteloss.go
@@ -366,3 +366,21 @@ func aliveWithin(as session.AgentServer, timeout time.Duration) livenessProbe {
 		return probeUnknown
 	}
 }
+
+// noteAliveObservation records that a poll got an ANSWER out of this session's
+// runtime — the daemon's only positive proof of life.
+//
+// The Lost-restore loop clears a session's failure history only when this counter
+// has advanced past the value captured at its last respawn. That is what makes
+// "confirmed alive" an observation rather than a clock (#1917 round 6): a fixed
+// settle window is wrong at both ends — a daemon_poll_interval longer than the
+// window means a runtime that died instantly is only SEEN Lost after it expires
+// (so its history is wrongly cleared and the backoff never arms), and the 60s
+// remoteLostGracePeriod means an unanswerable remote stays non-Lost long past any
+// short window. Counting answers is immune to both, and scales with whatever the
+// poll interval and grace actually are.
+func (m *Manager) noteAliveObservation(key string) {
+	m.mu.Lock()
+	m.aliveObservations[key]++
+	m.mu.Unlock()
+}

--- a/daemon/rootagent.go
+++ b/daemon/rootagent.go
@@ -292,9 +292,18 @@ func (m *Manager) reapDeadRoot(repoID string, inst *session.Instance) (bool, err
 	}
 
 	// Best-effort by design (#478): tmux is already gone and an in-place
-	// worktree's Cleanup is a no-op, so failures here only log inside Kill.
+	// worktree's Cleanup is a no-op, so failures Kill can ANSWER for only log
+	// inside Kill and never surface here.
+	//
+	// An error that does reach us therefore means the teardown could not complete
+	// SAFELY — tmux never confirmed the pane dead, or a worktree removal was cut off
+	// mid-delete — so the workspace is still there. Deleting the record would orphan
+	// it and leave nothing pointing at it. Keep the record; this loop runs every
+	// tick, so it IS the retry (#1917: found by auditing every record delete against
+	// the invariant, not reported).
 	if err := inst.Kill(); err != nil {
-		log.WarningLog.Printf("reaping dead root for repo %s: kill reported: %v", repoID, err)
+		log.WarningLog.Printf("reaping dead root for repo %s: teardown could not complete safely; keeping the record and retrying next tick: %v", repoID, err)
+		return false, nil
 	}
 	storage, err := session.NewStorage(config.LoadState(), repoID)
 	if err != nil {

--- a/daemon/rootagent.go
+++ b/daemon/rootagent.go
@@ -301,17 +301,14 @@ func (m *Manager) reapDeadRoot(repoID string, inst *session.Instance) (bool, err
 	// it and leave nothing pointing at it. Keep the record; this loop runs every
 	// tick, so it IS the retry (#1917: found by auditing every record delete against
 	// the invariant, not reported).
-	if err := inst.Kill(); err != nil {
-		log.WarningLog.Printf("reaping dead root for repo %s: teardown could not complete safely; keeping the record and retrying next tick: %v", repoID, err)
+	teardownErr := inst.Kill()
+	// Through the one choke point (#1917): it refuses while the teardown's outcome
+	// is unknown. This site was still log-and-delete after two audits I called
+	// exhaustive — which is the argument for there being exactly one place to call.
+	deleted, err := m.deleteSessionRecord(repoID, session.RootSessionTitle, inst.ID, teardownErr)
+	if err != nil {
+		log.WarningLog.Printf("reaping dead root for repo %s: not deleting the record yet (will retry next tick): %v", repoID, err)
 		return false, nil
-	}
-	storage, err := session.NewStorage(config.LoadState(), repoID)
-	if err != nil {
-		return false, err
-	}
-	deleted, err := storage.DeleteInstanceByStableID(session.RootSessionTitle, inst.ID)
-	if err != nil {
-		return false, err
 	}
 	if !deleted {
 		log.InfoLog.Printf("dead root reap for repo %s skipped storage delete: current root record has a different instance identity", repoID)

--- a/daemon/rootagent.go
+++ b/daemon/rootagent.go
@@ -307,8 +307,13 @@ func (m *Manager) reapDeadRoot(repoID string, inst *session.Instance) (bool, err
 	// exhaustive — which is the argument for there being exactly one place to call.
 	deleted, err := m.deleteSessionRecord(repoID, session.RootSessionTitle, inst.ID, teardownErr)
 	if err != nil {
-		log.WarningLog.Printf("reaping dead root for repo %s: not deleting the record yet (will retry next tick): %v", repoID, err)
-		return false, nil
+		// Return the ERROR, not (false, nil) (#1917 round 8). "No, but fine" is
+		// absence-of-error wearing a different hat: the caller reads it as "nothing to
+		// reap" and skips rootEnsureFailed, so a persistent tmux/file-lock timeout
+		// re-runs this whole bounded teardown on EVERY tick — occupying the single
+		// status/restore poll loop and spamming warnings — instead of backing off.
+		// A failure has to look like one for the retry cadence to see it.
+		return false, fmt.Errorf("reaping dead root for repo %s: %w", repoID, err)
 	}
 	if !deleted {
 		log.InfoLog.Printf("dead root reap for repo %s skipped storage delete: current root record has a different instance identity", repoID)

--- a/daemon/rootkill.go
+++ b/daemon/rootkill.go
@@ -1,7 +1,6 @@
 package daemon
 
 import (
-	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 )
@@ -145,18 +144,13 @@ func (m *Manager) finishUserKill(repoID string, instance *session.Instance) {
 	// worktree and take away the user's only handle on it, so keep the record and
 	// let the next poll try again: this loop IS the retry, and it is the reason a
 	// bounded teardown does not need a daemon restart to converge (#1917).
-	if err := instance.Kill(); err != nil {
-		log.WarningLog.Printf("finishing kill of %q: teardown could not complete safely; keeping the record and retrying next poll: %v", instance.Title, err)
-		return
-	}
-	storage, err := session.NewStorage(config.LoadState(), repoID)
+	teardownErr := instance.Kill()
+	// Through the one choke point (#1917): it refuses while the teardown's outcome
+	// is unknown, so this loop keeps the record and retries instead of orphaning the
+	// workspace. This loop IS the retry.
+	deleted, err := m.deleteSessionRecord(repoID, instance.Title, instance.ID, teardownErr)
 	if err != nil {
-		log.WarningLog.Printf("finishing kill of %q: %v", instance.Title, err)
-		return
-	}
-	deleted, err := storage.DeleteInstanceByStableID(instance.Title, instance.ID)
-	if err != nil {
-		log.WarningLog.Printf("finishing kill of %q: failed to delete record (will retry next poll): %v", instance.Title, err)
+		log.WarningLog.Printf("finishing kill of %q: not deleting the record yet (will retry next poll): %v", instance.Title, err)
 		return
 	}
 	if !deleted {

--- a/daemon/rootkill.go
+++ b/daemon/rootkill.go
@@ -6,6 +6,13 @@ import (
 	"github.com/sachiniyer/agent-factory/session"
 )
 
+// killTombstonePersist is the durable write persistKillTombstone runs. A package
+// var so tests can force the write to fail in isolation — exercising the abort
+// that keeps a kill from destroying a session it could not record (#1917) —
+// without disturbing any other persist. Mirrors archivePersist's precedent.
+// Production points it at the real writer and never reassigns it.
+var killTombstonePersist = persistInstanceData
+
 func killTargetStableID(instance *session.Instance, data *session.InstanceData) string {
 	if instance != nil {
 		return instance.ID
@@ -32,27 +39,47 @@ func stableIDMatchesForDaemon(recordID, expectedID string) bool {
 
 // persistKillTombstone writes the kill-intent tombstone (#1108) for the session
 // KillSession is about to tear down, so a record surviving a crash or teardown
-// failure mid-kill is never classified Lost and restored. Best-effort by
-// design: a failed write only degrades to the pre-tombstone crash window.
-func (m *Manager) persistKillTombstone(repoID string, instance *session.Instance, data *session.InstanceData) {
+// failure mid-kill is never classified Lost and restored. It returns the write
+// error: the tombstone is the kill's COMMIT POINT, so the caller must abort
+// before teardown rather than destroy a session whose kill it could not record.
+//
+// It was best-effort ("a failed write only degrades to the pre-tombstone crash
+// window") — which is no longer a defensible trade now that the write can fail on
+// lock contention rather than only on a disk fault (#1917). Without a durable
+// tombstone, a daemon that dies between teardown and the record delete reloads a
+// non-tombstoned record whose tmux is gone, classifies it Lost, and RESTORES it —
+// resurrecting a session the user explicitly killed, in a worktree that teardown
+// already deleted. Refusing a kill we cannot record is recoverable; that is not.
+//
+// The in-memory flag is set only AFTER the write lands, and the tombstone data is
+// built without mutating the instance. Marking first would leave a session the
+// poll's refreshInstanceStatus routes to finishUserKill — completing, on the next
+// tick, the very kill this function just refused, and defeating the abort.
+func (m *Manager) persistKillTombstone(repoID string, instance *session.Instance, data *session.InstanceData) error {
 	var d session.InstanceData
 	switch {
 	case instance != nil:
-		instance.MarkUserKilled()
 		d = instance.ToInstanceData()
+		d.UserKilled = true
 	case data != nil:
 		d = *data
 		d.UserKilled = true
 	default:
-		return
+		return nil
 	}
 	repoStartLock := m.startLockForRepo(repoID)
 	repoStartLock.Lock()
-	err := persistInstanceData(repoID, d)
+	err := killTombstonePersist(repoID, d)
 	repoStartLock.Unlock()
 	if err != nil {
 		log.WarningLog.Printf("failed to persist kill tombstone for %q: %v", d.Title, err)
+		return err
 	}
+	// Durable now: the kill is committed, so the in-memory flag can safely follow.
+	if instance != nil {
+		instance.MarkUserKilled()
+	}
+	return nil
 }
 
 // finishUserKill completes the teardown of a session whose record carries the
@@ -97,10 +124,16 @@ func (m *Manager) finishUserKill(repoID string, instance *session.Instance) {
 	}
 
 	log.WarningLog.Printf("finishing interrupted kill of session %q (tombstoned record survived its teardown)", instance.Title)
-	// Best-effort: the backing tmux session is typically already gone; Kill
-	// failures here only mean there is less left to tear down.
+	// Kill's own best-effort handling already swallows every failure tmux or git
+	// ANSWERED with, so anything that reaches here is a teardown that could not be
+	// completed SAFELY — a pane whose liveness is unknown, or a worktree whose
+	// removal was cut off mid-delete. Deleting the record anyway would strand the
+	// worktree and take away the user's only handle on it, so keep the record and
+	// let the next poll try again: this loop IS the retry, and it is the reason a
+	// bounded teardown does not need a daemon restart to converge (#1917).
 	if err := instance.Kill(); err != nil {
-		log.WarningLog.Printf("finishing kill of %q: teardown reported: %v", instance.Title, err)
+		log.WarningLog.Printf("finishing kill of %q: teardown could not complete safely; keeping the record and retrying next poll: %v", instance.Title, err)
+		return
 	}
 	storage, err := session.NewStorage(config.LoadState(), repoID)
 	if err != nil {

--- a/daemon/rootkill.go
+++ b/daemon/rootkill.go
@@ -67,17 +67,31 @@ func (m *Manager) persistKillTombstone(repoID string, instance *session.Instance
 	default:
 		return nil
 	}
+	// The write and the in-memory mark happen under ONE hold of the repo lock, and
+	// that atomicity is the whole point (#1917).
+	//
+	// Every other writer of this repo's records — the status poll's persist above
+	// all — takes this same lock and serializes instance.ToInstanceData() under it.
+	// Marking AFTER the unlock left a window where a poll could acquire the lock,
+	// read the instance while userKilled was still false, and write the tombstone
+	// straight back out. A teardown timeout or a crash after that would then leave a
+	// surviving record with NO tombstone, which the next daemon reads as Lost and
+	// RESTORES — resurrecting a session the user explicitly killed, exactly the
+	// outcome the tombstone exists to prevent.
+	//
+	// Marking inside the hold closes it: a poll either lands before (and we
+	// overwrite its record with the tombstone) or after (and it reads userKilled
+	// true). A commit point another writer can silently roll back is not one.
 	repoStartLock := m.startLockForRepo(repoID)
 	repoStartLock.Lock()
 	err := killTombstonePersist(repoID, d)
+	if err == nil && instance != nil {
+		instance.MarkUserKilled()
+	}
 	repoStartLock.Unlock()
 	if err != nil {
 		log.WarningLog.Printf("failed to persist kill tombstone for %q: %v", d.Title, err)
 		return err
-	}
-	// Durable now: the kill is committed, so the in-memory flag can safely follow.
-	if instance != nil {
-		instance.MarkUserKilled()
 	}
 	return nil
 }

--- a/daemon/rootkill.go
+++ b/daemon/rootkill.go
@@ -55,15 +55,7 @@ func stableIDMatchesForDaemon(recordID, expectedID string) bool {
 // poll's refreshInstanceStatus routes to finishUserKill — completing, on the next
 // tick, the very kill this function just refused, and defeating the abort.
 func (m *Manager) persistKillTombstone(repoID string, instance *session.Instance, data *session.InstanceData) error {
-	var d session.InstanceData
-	switch {
-	case instance != nil:
-		d = instance.ToInstanceData()
-		d.UserKilled = true
-	case data != nil:
-		d = *data
-		d.UserKilled = true
-	default:
+	if instance == nil && data == nil {
 		return nil
 	}
 	// The write and the in-memory mark happen under ONE hold of the repo lock, and
@@ -83,6 +75,19 @@ func (m *Manager) persistKillTombstone(repoID string, instance *session.Instance
 	// true). A commit point another writer can silently roll back is not one.
 	repoStartLock := m.startLockForRepo(repoID)
 	repoStartLock.Lock()
+	// The SNAPSHOT is taken under the lock too, not just the mark. Reading it
+	// outside would leave the same window one step earlier: a poll could persist
+	// between the read and this acquire, and our write would clobber its record with
+	// a stale copy. The comment above claimed every writer serializes
+	// ToInstanceData() under this lock — true of the others, and it had to be made
+	// true of this one.
+	var d session.InstanceData
+	if instance != nil {
+		d = instance.ToInstanceData()
+	} else {
+		d = *data
+	}
+	d.UserKilled = true
 	err := killTombstonePersist(repoID, d)
 	if err == nil && instance != nil {
 		instance.MarkUserKilled()

--- a/daemon/status_test.go
+++ b/daemon/status_test.go
@@ -26,7 +26,7 @@ type deadTmuxBackend struct {
 	*session.FakeBackend
 }
 
-func (deadTmuxBackend) IsAlive(*session.Instance) bool { return false }
+func (deadTmuxBackend) IsAlive(*session.Instance) (bool, error) { return false, nil }
 
 // promptTapBackend is a FakeBackend that always reports a waiting prompt and
 // counts TapEnter calls, so the AutoYes path the status pass now subsumes can be
@@ -175,7 +175,9 @@ type nilMonitorBackend struct {
 func (b nilMonitorBackend) HasUpdated(*session.Instance) (bool, bool, string) {
 	return b.ts.HasUpdated()
 }
-func (b nilMonitorBackend) IsAlive(*session.Instance) bool { return b.ts.DoesSessionExist() }
+func (b nilMonitorBackend) IsAlive(*session.Instance) (bool, error) {
+	return b.ts.DoesSessionExist(), nil
+}
 
 // TestRefreshStatuses_DeadNilMonitorDoesNotPanic is the #999 regression at the
 // daemon poll layer: a persisted Dead/Lost instance whose TmuxSession has a nil

--- a/session/agentserver_local.go
+++ b/session/agentserver_local.go
@@ -162,7 +162,11 @@ func (s *localAgentServer) PreviewContext(ctx context.Context, tab int, full boo
 // server that could leave liveness UNKNOWN. The error exists for the remote
 // runtime; see the AgentServer interface.
 func (s *localAgentServer) Alive() (bool, error) {
-	return s.inst.backend.IsAlive(s.inst), nil
+	// Forward the backend's error rather than hardcoding nil (#1917 round 8): nil
+	// here meant "the probe answered", which was never checked and often false.
+	// probeLiveness maps a non-nil error to probeUnknown, so this is the hop that
+	// lets an unanswerable tmux stop being counted as alive.
+	return s.inst.backend.IsAlive(s.inst)
 }
 
 func (s *localAgentServer) SendPrompt(prompt string) error {

--- a/session/agentserver_local_test.go
+++ b/session/agentserver_local_test.go
@@ -32,7 +32,7 @@ func (b *probeBackend) HasUpdated(*Instance) (bool, bool, string) {
 
 func (b *probeBackend) TapEnter(*Instance) { b.tapped = true }
 
-func (b *probeBackend) IsAlive(*Instance) bool { return false }
+func (b *probeBackend) IsAlive(*Instance) (bool, error) { return false, nil }
 
 func (b *probeBackend) Preview(*Instance) (string, error) { return "short", nil }
 

--- a/session/backend.go
+++ b/session/backend.go
@@ -118,7 +118,13 @@ type Backend interface {
 	SendPromptCommand(instance *Instance, prompt string) error
 
 	// IsAlive returns true if the underlying session is still running.
-	IsAlive(instance *Instance) bool
+	// IsAlive reports whether the instance's agent is running, and returns an
+	// error when the runtime could not be ASKED (#1917 round 8). The error is the
+	// tri-state: a bool alone forces a timed-out probe to pick yes or no, and the
+	// convenient pick — "yes" — is what let a wedged tmux server be counted as
+	// affirmative proof of life all the way up in the daemon's poll. An
+	// implementation that cannot answer must say so rather than guess.
+	IsAlive(instance *Instance) (bool, error)
 
 	// CheckAndHandleTrustPrompt auto-dismisses trust/permission prompts
 	// for supported programs.

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -297,11 +297,23 @@ func (b *LocalBackend) Launch(i *Instance, firstTimeSetup bool) error {
 
 		// Create new session
 		if err := tmuxSession.Start(gw.GetWorktreePath()); err != nil {
-			// Cleanup git worktree if tmux session creation fails
-			if cleanupErr := gw.Cleanup(); cleanupErr != nil {
+			// Cleanup git worktree if tmux session creation fails. The tmux session
+			// never came up, so there is no live pane to race the removal.
+			//
+			// A cleanup cut off by its own deadline is surfaced as ErrWorkspaceLeftBehind
+			// rather than folded into a prose message (#1917): the worktree is still
+			// (partly) on disk, and this instance is about to be discarded by a create
+			// that never registered or persisted it — so the caller must be able to see
+			// that it is discarding a session over a workspace that still exists,
+			// instead of releasing the title on top of it.
+			cleanupState, cleanupErr := gw.Cleanup()
+			if cleanupErr != nil {
 				err = fmt.Errorf("%v (cleanup error: %v)", err, cleanupErr)
 			}
 			setupErr = fmt.Errorf("failed to start new session: %w", err)
+			if cleanupState == git.CleanupStateUnknown {
+				setupErr = fmt.Errorf("%w: %w at %s", setupErr, ErrWorkspaceLeftBehind, gw.GetWorktreePath())
+			}
 			return setupErr
 		}
 	}

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -650,15 +650,24 @@ func (b *LocalBackend) SendPromptCommand(i *Instance, prompt string) error {
 	return ts.SendKeysCommand(prompt)
 }
 
-func (b *LocalBackend) IsAlive(i *Instance) bool {
+func (b *LocalBackend) IsAlive(i *Instance) (bool, error) {
 	i.mu.RLock()
 	ts := i.tmuxLocked()
 	i.mu.RUnlock()
 
 	if ts == nil {
-		return false
+		// No binding at all: an answer, not a guess.
+		return false, nil
 	}
-	return ts.DoesSessionExist()
+	// ProbeSession, not DoesSessionExist (#1917 round 8): this result is EVIDENCE —
+	// the daemon's poll turns it into probeAlive, which clears a session's restore
+	// history and marks it Ready. DoesSessionExist reports a timed-out probe as
+	// "exists", so taking it here would report a wedged server as a live agent.
+	exists, known := ts.ProbeSession()
+	if !known {
+		return false, fmt.Errorf("%w: has-session while probing liveness", tmux.ErrTmuxTimeout)
+	}
+	return exists, nil
 }
 
 func (b *LocalBackend) CheckAndHandleTrustPrompt(i *Instance) bool {

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -311,7 +311,7 @@ func (b *LocalBackend) Launch(i *Instance, firstTimeSetup bool) error {
 				err = fmt.Errorf("%v (cleanup error: %v)", err, cleanupErr)
 			}
 			setupErr = fmt.Errorf("failed to start new session: %w", err)
-			if cleanupState == git.CleanupStateUnknown {
+			if cleanupState != git.CleanupSettled {
 				setupErr = fmt.Errorf("%w: %w at %s", setupErr, ErrWorkspaceLeftBehind, gw.GetWorktreePath())
 			}
 			return setupErr

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -297,8 +298,19 @@ func (b *LocalBackend) Launch(i *Instance, firstTimeSetup bool) error {
 
 		// Create new session
 		if err := tmuxSession.Start(gw.GetWorktreePath()); err != nil {
-			// Cleanup git worktree if tmux session creation fails. The tmux session
-			// never came up, so there is no live pane to race the removal.
+			// A Start that could not establish the session's fate must NOT lead to a
+			// worktree delete (#1917 round 7). The claim that used to stand here —
+			// "the tmux session never came up, so there is no live pane to race the
+			// removal" — is false against a wedged server: Start's own cleanup Close
+			// reports PaneStateUnknown precisely because a detached session may exist
+			// with its pane still running in this worktree. Deleting it then destroys
+			// live work on a guess, which is the whole thing this PR exists to stop.
+			if errors.Is(err, tmux.ErrTmuxTimeout) {
+				return fmt.Errorf("failed to start new session: %w: %w: leaving its workspace at %s in place",
+					err, ErrPaneMayBeLive, gw.GetWorktreePath())
+			}
+			// Cleanup git worktree if tmux session creation fails. tmux ANSWERED, so
+			// the session is confirmed not running and the worktree is ours to remove.
 			//
 			// A cleanup cut off by its own deadline is surfaced as ErrWorkspaceLeftBehind
 			// rather than folded into a prose message (#1917): the worktree is still

--- a/session/backend_remote_agent.go
+++ b/session/backend_remote_agent.go
@@ -96,9 +96,10 @@ func (b *remoteAgentBackend) SendPromptCommand(i *Instance, prompt string) error
 // its callers only use it for non-destructive TUI affordances. Destructive
 // recovery paths call AgentServer.Alive directly so they can distinguish an
 // unreachable remote from a dead one (#1794).
-func (b *remoteAgentBackend) IsAlive(i *Instance) bool {
-	alive, _ := i.AgentServer().Alive()
-	return alive
+func (b *remoteAgentBackend) IsAlive(i *Instance) (bool, error) {
+	// The error is now carried, not discarded: an unanswerable sandbox is unknown,
+	// and the debounce (#1794) is what turns a run of those into a conclusion.
+	return i.AgentServer().Alive()
 }
 
 // CheckAndHandleTrustPrompt is a daemon-side no-op: each remote AgentServer

--- a/session/fake_backend.go
+++ b/session/fake_backend.go
@@ -109,7 +109,7 @@ func (b *FakeBackend) Preview(*Instance) (string, error)            { return "",
 func (b *FakeBackend) PreviewFullHistory(*Instance) (string, error) { return "", nil }
 func (b *FakeBackend) HasUpdated(*Instance) (bool, bool, string)    { return false, false, "" }
 func (b *FakeBackend) SendPromptCommand(*Instance, string) error    { return nil }
-func (b *FakeBackend) IsAlive(*Instance) bool                       { return true }
+func (b *FakeBackend) IsAlive(*Instance) (bool, error)              { return true, nil }
 func (b *FakeBackend) CheckAndHandleTrustPrompt(*Instance) bool     { return false }
 func (b *FakeBackend) TapEnter(*Instance)                           {}
 func (b *FakeBackend) Recover(*Instance) error                      { return nil }

--- a/session/git/cleanup_retry_test.go
+++ b/session/git/cleanup_retry_test.go
@@ -3,6 +3,7 @@ package git
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -66,5 +67,69 @@ exit 0
 	if state2 != CleanupStateUnknown {
 		t.Fatal("the retry reported a SETTLED cleanup while the directory is still on disk: the " +
 			"caller would drop the record and orphan it")
+	}
+}
+
+// TestCleanup_StalledRemove_DoesNotDeleteTheRetainedWorkspacesBranch is #1917
+// round-8 finding (1), and it is the worst outcome in this PR's history: we save
+// the files and destroy the only pointer to them.
+//
+// `git worktree remove -f` times out AFTER deregistering the checkout but BEFORE
+// deleting its files. removeDir correctly preserves the directory — and then
+// `git branch -D` SUCCEEDS, precisely BECAUSE the checkout is now unregistered, so
+// git raises no "branch is checked out" objection. The retained workspace loses its
+// only ref and its unique commits become unreachable.
+//
+// Refusing the file deletion while destroying the metadata is worse than either
+// alone: the workspace survives and nothing can find it.
+//
+// PRE-FIX BEHAVIOR THIS REPRODUCES: `branch -D` is issued for a workspace the same
+// run just decided to retain.
+func TestCleanup_StalledRemove_DoesNotDeleteTheRetainedWorkspacesBranch(t *testing.T) {
+	dir := t.TempDir()
+	log := filepath.Join(dir, "issued")
+	// `remove` stalls (after "deregistering"); every other verb answers instantly,
+	// so branch -D would sail through. Each invocation is recorded.
+	script := `#!/bin/sh
+echo "$@" >> ` + log + `
+for a in "$@"; do
+  case "$a" in
+    remove) exec sleep 300 ;;
+  esac
+done
+exit 0
+`
+	bin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bin, "git"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake git: %v", err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	prev := localGitTimeout
+	localGitTimeout = 300 * time.Millisecond
+	t.Cleanup(func() { localGitTimeout = prev })
+
+	gw, wt := worktreeForCleanup(t)
+	state, _ := gw.Cleanup()
+
+	if state != CleanupStateUnknown {
+		t.Fatalf("setup: a stalled remove must report unknown, got %v", state)
+	}
+	if _, err := os.Stat(wt); err != nil {
+		t.Fatalf("setup: the workspace must be retained: %v", err)
+	}
+
+	issued, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatalf("read issued log: %v", err)
+	}
+	if strings.Contains(string(issued), "branch -D") {
+		t.Fatal("cleanup deleted the BRANCH of a workspace it had just decided to RETAIN: the " +
+			"timed-out remove deregistered the checkout, so branch -D no longer errors and the " +
+			"retained files lose their only ref — unique commits become unreachable. Saving the " +
+			"files and destroying the pointer to them is worse than either alone (#1917 round 8). " +
+			"Unknown must gate EVERY destructive act in the run, not only the file deletion.")
+	}
+	if strings.Contains(string(issued), "worktree prune") {
+		t.Fatal("cleanup pruned worktree metadata for a workspace it had just decided to retain")
 	}
 }

--- a/session/git/cleanup_retry_test.go
+++ b/session/git/cleanup_retry_test.go
@@ -1,0 +1,70 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestCleanup_RetryAfterStall_StillRefusesTheUnboundedDelete is #1917 round-6
+// finding (1): refusing once is not refusing.
+//
+// The dangerous shape: `git worktree remove` times out AFTER deregistering the
+// checkout but BEFORE deleting its files. Attempt 1 correctly refuses the unbounded
+// os.RemoveAll. finishUserKill then retries — and the retry's FRESH cleanupRun has
+// unknown=false, while `worktree list` now answers "not registered" (it was
+// deregistered!), so shouldRemoveWorktreeDir says yes and the unbounded delete runs
+// against the same stalled filesystem, wedging the kill guard indefinitely.
+//
+// The knowledge that this filesystem stalls must outlive the attempt.
+//
+// PRE-FIX BEHAVIOR THIS REPRODUCES: attempt 2 deletes the directory (and against a
+// genuinely stalled mount would never return at all).
+func TestCleanup_RetryAfterStall_StillRefusesTheUnboundedDelete(t *testing.T) {
+	dir := t.TempDir()
+	// Attempt 1: `worktree remove` stalls (the deadline trips). Attempt 2: every
+	// command answers fast, and `worktree list` reports the path unregistered —
+	// exactly what a remove that deregistered-then-stalled leaves behind.
+	script := `#!/bin/sh
+for a in "$@"; do
+  case "$a" in
+    remove) if [ -f "` + dir + `/stalled" ]; then exit 128; fi; touch "` + dir + `/stalled"; exec sleep 300 ;;
+    list)   exit 0 ;;
+  esac
+done
+exit 0
+`
+	bin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bin, "git"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake git: %v", err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	prev := localGitTimeout
+	localGitTimeout = 300 * time.Millisecond
+	t.Cleanup(func() { localGitTimeout = prev })
+
+	gw, wt := worktreeForCleanup(t)
+
+	// Attempt 1: the remove stalls; the refusal is correct and already covered.
+	state1, _ := gw.Cleanup()
+	if state1 != CleanupStateUnknown {
+		t.Fatalf("setup: attempt 1 must report unknown, got %v", state1)
+	}
+	if _, err := os.Stat(wt); err != nil {
+		t.Fatalf("setup: attempt 1 must not have deleted the directory: %v", err)
+	}
+
+	// Attempt 2 — the retry finishUserKill makes, on the SAME workspace.
+	state2, _ := gw.Cleanup()
+
+	if _, err := os.Stat(wt); err != nil {
+		t.Fatal("the RETRY ran the unbounded os.RemoveAll against a filesystem already known to " +
+			"stall: the knowledge died with attempt 1's run, so the second attempt re-enters the " +
+			"exact wedge this PR removes (#1917 round 6). Refusing once is not refusing.")
+	}
+	if state2 != CleanupStateUnknown {
+		t.Fatal("the retry reported a SETTLED cleanup while the directory is still on disk: the " +
+			"caller would drop the record and orphan it")
+	}
+}

--- a/session/git/cleanup_retry_test.go
+++ b/session/git/cleanup_retry_test.go
@@ -133,3 +133,42 @@ exit 0
 		t.Fatal("cleanup pruned worktree metadata for a workspace it had just decided to retain")
 	}
 }
+
+// TestCleanup_CorruptRepoWithUnreadableRegistration_StillDeletesTheDirectory is a
+// regression I introduced and caught reviewing my own diff (the GitHub bot has not
+// looked at this PR since round 1).
+//
+// The #726 shape: `git worktree remove -f` fails FAST with "validation failed" (a
+// corrupted .git pointer) AND `git worktree list` also fails FAST — an ANSWERED
+// error, not a stall. Before this PR, Cleanup fell back to the conservative string
+// gate and deleted the directory ("Also the path taken when `worktree list` itself
+// failed"). Round 4's fix made the probe refuse on ANY unreadable registration,
+// which conflated "could not ask" with "asked and got an error" — so nothing was
+// deleted, yet no deadline tripped, so the run reported SETTLED and the caller
+// dropped the record. The workspace is left on disk with nothing pointing at it:
+// the exact orphaning this PR exists to prevent, caused by its own fix.
+func TestCleanup_CorruptRepoWithUnreadableRegistration_StillDeletesTheDirectory(t *testing.T) {
+	// Every git command ANSWERS with a failure, instantly. Nothing stalls.
+	bin := t.TempDir()
+	script := "#!/bin/sh\necho 'fatal: validation failed' >&2\nexit 128\n"
+	if err := os.WriteFile(filepath.Join(bin, "git"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake git: %v", err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	prev := localGitTimeout
+	localGitTimeout = 5 * time.Second // generous: nothing here should ever reach it
+	t.Cleanup(func() { localGitTimeout = prev })
+
+	gw, wt := worktreeForCleanup(t)
+	state, _ := gw.Cleanup()
+
+	if _, err := os.Stat(wt); err == nil {
+		t.Fatal("a corrupted worktree whose registration could not be READ (an answered error, " +
+			"not a stall) was left on disk while the run reported its outcome as settled — so the " +
+			"caller deletes the record and orphans it. 'Could not ask' and 'asked and got an error' " +
+			"are different: only the first is unknown (#726 regression).")
+	}
+	if state != CleanupSettled {
+		t.Fatalf("nothing timed out, so the run's outcome is established: want CleanupSettled, got %v", state)
+	}
+}

--- a/session/git/cleanup_unknown_test.go
+++ b/session/git/cleanup_unknown_test.go
@@ -1,0 +1,142 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// The #1917 round-4 locks: a deadline ANYWHERE in a cleanup run must mark the run
+// UNKNOWN, and no destructive act may follow one.
+//
+// Both bugs these cover had the same root: the state was asserted once
+// (`state := CleanupSettled`) and downgraded by hand at exactly ONE of the five
+// bounded git commands. These tests pin the runner-derives-the-state property, so
+// they fail if anyone reintroduces hand-assigned state.
+
+// stallGitOn puts a fake `git` on PATH that stalls for the named subcommands and
+// exits 0 for the rest. A real subprocess, not a mock: the unknown state is derived
+// from a real ctx deadline SIGKILLing a real process group, so a mock that merely
+// returned an error would prove nothing.
+func stallGitOn(t *testing.T, stallArg string, fastFailArgs string) {
+	t.Helper()
+	dir := t.TempDir()
+	script := `#!/bin/sh
+for a in "$@"; do
+  case "$a" in
+    ` + stallArg + `) exec sleep 300 ;;
+    ` + fastFailArgs + `) echo "fatal: validation failed" >&2; exit 128 ;;
+  esac
+done
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(dir, "git"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake git: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	prev := localGitTimeout
+	localGitTimeout = 300 * time.Millisecond
+	t.Cleanup(func() { localGitTimeout = prev })
+}
+
+func worktreeForCleanup(t *testing.T) (*GitWorktree, string) {
+	t.Helper()
+	root := t.TempDir()
+	wt := filepath.Join(root, "wt")
+	if err := os.MkdirAll(wt, 0o755); err != nil {
+		t.Fatalf("mkdir worktree: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(wt, "work.txt"), []byte("unpushed user work"), 0o644); err != nil {
+		t.Fatalf("seed work: %v", err)
+	}
+	gw, err := NewGitWorktreeFromStorage(root, wt, "sess", "branch", "abc123", false, true)
+	if err != nil {
+		t.Fatalf("NewGitWorktreeFromStorage: %v", err)
+	}
+	return gw, wt
+}
+
+// TestCleanup_TimedOutRegistrationProbe_DoesNotDeleteTheDirectory is round-4
+// finding (1): the fix reintroduced the bug it was removing.
+//
+// `worktree remove` answers FAST with "validation failed" (the #726 corrupted-
+// pointer shape), and the bounded `worktree list` probe then TIMES OUT on the
+// stalled mount. The probe's error used to be read as an ordinary lookup failure,
+// so the string-matching fallback returned true and Cleanup called UNBOUNDED
+// os.RemoveAll on a stalled path — which hangs forever inside the kill guard: the
+// exact wedge this PR exists to remove.
+//
+// PRE-FIX BEHAVIOR THIS REPRODUCES: the directory is deleted (and, on a truly
+// stalled mount, the call never returns at all).
+func TestCleanup_TimedOutRegistrationProbe_DoesNotDeleteTheDirectory(t *testing.T) {
+	stallGitOn(t, `"list"`, `"remove"`)
+	gw, wt := worktreeForCleanup(t)
+
+	state, err := gw.Cleanup()
+
+	if state != CleanupStateUnknown {
+		t.Fatal("a timed-out registration probe reported a SETTLED cleanup: the caller then deletes " +
+			"the session record, and the string fallback lets an UNBOUNDED os.RemoveAll run against " +
+			"the very path that just stalled git — reintroducing the #1917 wedge")
+	}
+	if err == nil {
+		t.Fatal("a cut-off cleanup must report an error")
+	}
+	if _, statErr := os.Stat(wt); statErr != nil {
+		t.Fatalf("the worktree directory was deleted after a probe that never answered: the "+
+			"deletion decision was taken on a verdict we could not obtain (%v)", statErr)
+	}
+}
+
+// TestCleanup_TimedOutBranchDelete_ReportsUnknown is round-4 finding (2): deadlines
+// that do not mark unknown.
+//
+// The worktree is already absent, so the only bounded commands left are `prune` and
+// `branch -D`. Neither used to touch the state, so a timed-out branch delete
+// reported CleanupSettled — teardownKill logged it best-effort, finalized, and
+// KillSession deleted the record, even though the branch and worktree metadata may
+// still exist and there is now no record to retry from.
+//
+// PRE-FIX BEHAVIOR THIS REPRODUCES: state == CleanupSettled.
+func TestCleanup_TimedOutBranchDelete_ReportsUnknown(t *testing.T) {
+	stallGitOn(t, `"branch"`, `"__never__"`)
+	root := t.TempDir()
+	// No worktree on disk: skip straight past the remove branch to prune + branch -D.
+	gw, err := NewGitWorktreeFromStorage(root, filepath.Join(root, "gone"), "sess", "branch", "abc123", false, true)
+	if err != nil {
+		t.Fatalf("NewGitWorktreeFromStorage: %v", err)
+	}
+
+	state, cleanupErr := gw.Cleanup()
+
+	if state != CleanupStateUnknown {
+		t.Fatal("a timed-out `git branch -D` reported a SETTLED cleanup: the branch may still exist, " +
+			"but the caller deletes the record on this and no retry is possible (#1917 round 4). " +
+			"EVERY bounded command in the run must mark unknown, not just the worktree remove.")
+	}
+	if cleanupErr == nil || !errors.Is(cleanupErr, context.DeadlineExceeded) {
+		t.Fatalf("the deadline must stay reachable in the error, got: %v", cleanupErr)
+	}
+}
+
+// TestCleanup_HealthyRun_IsSettled is the guard in the other direction: inverting
+// the default must not make every cleanup refuse. A run where every command answers
+// reports Settled, so ordinary kills still drop their record.
+func TestCleanup_HealthyRun_IsSettled(t *testing.T) {
+	stallGitOn(t, `"__never__"`, `"__never_either__"`)
+	gw, wt := worktreeForCleanup(t)
+
+	state, err := gw.Cleanup()
+	if err != nil {
+		t.Fatalf("a healthy cleanup must not error: %v", err)
+	}
+	if state != CleanupSettled {
+		t.Fatal("a run where every git command answered must report Settled, or no kill ever " +
+			"completes and the inversion has made sessions undeletable")
+	}
+	_ = wt
+}

--- a/session/git/cleanup_wedge_test.go
+++ b/session/git/cleanup_wedge_test.go
@@ -1,0 +1,173 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #1917: a session kill that wedges forever, leaving the session permanently
+// undeletable until the daemon restarts.
+//
+// GitWorktree.Cleanup runs on the kill teardown (session/teardown.go) inside the
+// daemon's per-session kills-in-flight guard, and every git command it ran went
+// through runGitCommand — i.e. context.Background(), no deadline — on the theory
+// that local git "cannot stall the way a fetch can". `git worktree remove -f`
+// disproves that: it recursively unlinks a whole checkout and blocks indefinitely
+// on a hung mount or a D-state process holding a file in the tree.
+
+// shortenLocalTimeout lowers localGitTimeout so the wedge tests resolve in
+// milliseconds instead of the production 60s, restoring it after.
+func shortenLocalTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	orig := localGitTimeout
+	localGitTimeout = d
+	t.Cleanup(func() { localGitTimeout = orig })
+}
+
+// stallingGitOnPath puts a `git` earlier on PATH that never exits, standing in
+// for a `worktree remove` wedged on a stalled filesystem. Mirrors
+// stallingTmuxOnPath and stallOriginViaFakeSSH: the script sleeps in a CHILD, so
+// it also covers the case that makes a naive deadline useless — killing only the
+// direct git process leaves the child holding the inherited capture pipe, and
+// Output() blocks on pipe EOF until it dies. Passing therefore requires the
+// process-group kill AND gitWaitDelay, not just exec.CommandContext.
+//
+// Call this AFTER building the repo fixture: everything the fixture does runs
+// real git through this same PATH.
+func stallingGitOnPath(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	script := "#!/bin/sh\nsleep 300 &\nwait\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "git"), []byte(script), 0o755))
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// TestCleanup_DoesNotWedgeOnStalledGit is the core #1917 regression: with git
+// making no progress, Cleanup must return a real, actionable, joined error
+// within the bound instead of hanging the kill forever.
+func TestCleanup_DoesNotWedgeOnStalledGit(t *testing.T) {
+	sandboxHome(t)
+	repoRoot := createGitRepo(t)
+	runGit(t, repoRoot, "commit", "--allow-empty", "-m", "initial")
+
+	// The worktree directory must exist for Cleanup to attempt removal at all
+	// (it stats the path first).
+	worktreePath := filepath.Join(t.TempDir(), "wt")
+	require.NoError(t, os.MkdirAll(worktreePath, 0o755))
+
+	gw := &GitWorktree{
+		repoPath:          repoRoot,
+		worktreePath:      worktreePath,
+		branchName:        "af-wedge-1917",
+		branchCreatedByUs: true,
+	}
+
+	stallingGitOnPath(t)
+	shortenLocalTimeout(t, 200*time.Millisecond)
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() { done <- gw.Cleanup() }()
+
+	select {
+	case err := <-done:
+		require.Error(t, err, "a stalled git must surface a timeout error, not silent success")
+		assert.Contains(t, err.Error(), "timed out",
+			"the timeout must be actionable: it names the command and why it was killed")
+		assert.Less(t, time.Since(start), 30*time.Second,
+			"each git step should be killed at its deadline, not wait for the fake git to exit")
+	case <-time.After(60 * time.Second):
+		t.Fatal("Cleanup hung on a stalled git (#1917): the daemon holds its kills-in-flight " +
+			"guard across this call, so the session would be undeletable until the daemon restarts")
+	}
+}
+
+// TestCleanup_StalledRemoveDoesNotDeleteTheDirectory guards the #1917 timeout
+// guard in shouldRemoveWorktreeDir, and it is the reason bounding alone is not
+// enough. On a timeout `git worktree remove -f` never FINISHED — it was SIGKILLed
+// mid-delete — so its registration state is a half-done snapshot, not a verdict.
+// Reading it as the #802 "git let go of the worktree" case sends Cleanup into
+// os.RemoveAll, which takes no context and would stall on the very same paths
+// that stalled git: the bound would buy nothing and the hang would come back one
+// line later, now unkillable.
+//
+// Here the fake git makes `worktree list` stall too, so listErr != nil and the
+// pre-#1917 tree would fall through to the "validation failed" string gate and
+// keep the directory. That makes the DURABLE assertion the one that bites: the
+// error must be reported, and it must be the timeout — never a claim that the
+// directory was dealt with.
+func TestCleanup_StalledRemoveDoesNotDeleteTheDirectory(t *testing.T) {
+	sandboxHome(t)
+	repoRoot := createGitRepo(t)
+	runGit(t, repoRoot, "commit", "--allow-empty", "-m", "initial")
+
+	worktreePath := filepath.Join(t.TempDir(), "wt")
+	require.NoError(t, os.MkdirAll(worktreePath, 0o755))
+	canary := filepath.Join(worktreePath, "uncommitted-work.txt")
+	require.NoError(t, os.WriteFile(canary, []byte("user work"), 0o644))
+
+	gw := &GitWorktree{
+		repoPath:          repoRoot,
+		worktreePath:      worktreePath,
+		branchName:        "af-wedge-1917",
+		branchCreatedByUs: true,
+	}
+
+	stallingGitOnPath(t)
+	shortenLocalTimeout(t, 200*time.Millisecond)
+
+	done := make(chan error, 1)
+	go func() { done <- gw.Cleanup() }()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "timed out")
+		// Cleanup must not have quietly swallowed the stall as a successful
+		// removal: the tree it could not confirm removed is still there for a
+		// later kill to retry.
+		assert.FileExists(t, canary,
+			"a timed-out `worktree remove` must not lead to deleting the directory: "+
+				"git may still have been mid-delete, and os.RemoveAll would stall on the same paths")
+	case <-time.After(60 * time.Second):
+		t.Fatal("Cleanup hung on a stalled git (#1917)")
+	}
+}
+
+// TestCleanup_HealthyWorktreeStillSucceeds guards the other direction: the
+// deadline must not break the normal teardown. A real worktree, removed by real
+// git, must still leave no directory, no branch, and no error — so a regression
+// that always trips the timeout (or that mis-reads a fast exit as a deadline)
+// fails here rather than silently making every kill best-effort.
+func TestCleanup_HealthyWorktreeStillSucceeds(t *testing.T) {
+	sandboxHome(t)
+	repoRoot := createGitRepo(t)
+	runGit(t, repoRoot, "commit", "--allow-empty", "-m", "initial")
+
+	worktreePath := filepath.Join(t.TempDir(), "wt")
+	runGit(t, repoRoot, "worktree", "add", "-b", "af-healthy-1917", worktreePath)
+	require.DirExists(t, worktreePath)
+
+	gw := &GitWorktree{
+		repoPath:          repoRoot,
+		worktreePath:      worktreePath,
+		branchName:        "af-healthy-1917",
+		branchCreatedByUs: true,
+	}
+
+	// Long enough that real git never trips it, short enough to keep the test fast.
+	shortenLocalTimeout(t, 30*time.Second)
+
+	require.NoError(t, gw.Cleanup(), "a healthy teardown must not be affected by the bound")
+	assert.NoDirExists(t, worktreePath, "the worktree directory must still be removed")
+
+	out, err := (&GitWorktree{}).runGitCommand(repoRoot, "branch", "--list", "af-healthy-1917")
+	require.NoError(t, err)
+	assert.Empty(t, strings.TrimSpace(out), "the branch we created must still be deleted")
+}

--- a/session/git/cleanup_wedge_test.go
+++ b/session/git/cleanup_wedge_test.go
@@ -73,7 +73,7 @@ func TestCleanup_DoesNotWedgeOnStalledGit(t *testing.T) {
 
 	done := make(chan error, 1)
 	start := time.Now()
-	go func() { done <- gw.Cleanup() }()
+	go func() { _, err := gw.Cleanup(); done <- err }()
 
 	select {
 	case err := <-done:
@@ -123,7 +123,7 @@ func TestCleanup_StalledRemoveDoesNotDeleteTheDirectory(t *testing.T) {
 	shortenLocalTimeout(t, 200*time.Millisecond)
 
 	done := make(chan error, 1)
-	go func() { done <- gw.Cleanup() }()
+	go func() { _, err := gw.Cleanup(); done <- err }()
 
 	select {
 	case err := <-done:
@@ -164,7 +164,9 @@ func TestCleanup_HealthyWorktreeStillSucceeds(t *testing.T) {
 	// Long enough that real git never trips it, short enough to keep the test fast.
 	shortenLocalTimeout(t, 30*time.Second)
 
-	require.NoError(t, gw.Cleanup(), "a healthy teardown must not be affected by the bound")
+	state, cleanupErr := gw.Cleanup()
+	require.NoError(t, cleanupErr, "a healthy teardown must not be affected by the bound")
+	require.Equal(t, CleanupSettled, state, "a healthy teardown establishes its outcome")
 	assert.NoDirExists(t, worktreePath, "the worktree directory must still be removed")
 
 	out, err := (&GitWorktree{}).runGitCommand(repoRoot, "branch", "--list", "af-healthy-1917")

--- a/session/git/worktree.go
+++ b/session/git/worktree.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/internal/pathutil"
@@ -45,6 +46,26 @@ func getWorktreeDirectoryForRepoWithConfig(cfg *config.Config, repoPath string) 
 
 // GitWorktree manages git worktree operations for a session
 type GitWorktree struct {
+	// cleanupStalled latches once ANY cleanup command has timed out against this
+	// workspace, and it is the reason this fact lives on the WORKTREE rather than
+	// on the per-attempt cleanupRun (#1917 round 6).
+	//
+	// "This filesystem is stalled" is a property of the workspace, not of one
+	// attempt. Stored per-run it died on every retry: a `git worktree remove` that
+	// times out AFTER deregistering the checkout but BEFORE deleting its files
+	// leaves the next attempt's fresh run with unknown=false, its `worktree list`
+	// then answers "not registered" (it was deregistered!), and the unbounded
+	// os.RemoveAll runs against the same stalled filesystem — re-entering the exact
+	// wedge this work exists to remove. Refusing once is not refusing.
+	//
+	// Latched for the daemon's lifetime, deliberately: os.RemoveAll takes no
+	// context, so entering it is a one-way door, and nothing we could ask about the
+	// path is cheaper than the stall itself. A daemon restart re-probes, which is
+	// the one moment there is genuinely new information (the mount may be back).
+	// atomic because the poll's diagnostics read this worktree without the op lock
+	// the cleanup holds.
+	cleanupStalled atomic.Bool
+
 	// Path to the repository
 	repoPath string
 	// Path to the worktree

--- a/session/git/worktree_git.go
+++ b/session/git/worktree_git.go
@@ -30,18 +30,67 @@ var networkGitTimeout = 60 * time.Second
 // timeout above (the #856 lesson from the claude shell probe).
 const gitWaitDelay = 2 * time.Second
 
+// localGitTimeout bounds the local git commands on the session-TEARDOWN path
+// (#1917). It is deliberately far larger than networkGitTimeout's sibling
+// reasoning would suggest: the command it really exists for is
+// `git worktree remove -f`, which recursively deletes a whole checkout —
+// legitimately slow on a large tree over a cold cache, and NOT something we want
+// to abort early. It only trips when removal makes no progress at all.
+//
+// A var (not a const) only so tests can shorten it; production never reassigns.
+var localGitTimeout = 60 * time.Second
+
 // runGitCommand executes a local git command and returns any error.
 // Only stdout is returned on success so callers parsing the output (e.g. SHAs
 // or porcelain status) are not corrupted by warnings git emits on stderr.
 // On error, stderr is folded into the returned error for diagnostics.
 //
-// It runs with a background context, so it is effectively unbounded. That is
-// intentional: every caller of runGitCommand performs a local-only operation
-// (rev-parse, show-ref, worktree add/remove/prune, branch -D, merge-base),
-// none of which touches the network and so cannot stall the way a fetch can.
-// Network operations must use runGitNetworkCommand instead (#896).
+// It runs with a background context, so it is UNBOUNDED. This used to be
+// justified as "local-only operations cannot stall the way a fetch can", which
+// is false — see runGitLocalCommand, which bounds the teardown-path callers that
+// disproved it. The remaining callers here are pure metadata reads (rev-parse,
+// show-ref, merge-base) plus `worktree add`, which stay unbounded on purpose:
+// `worktree add` runs the repo's post-checkout hook, i.e. arbitrary user code
+// whose legitimate runtime (a big install step) has no defensible upper bound,
+// and it is on the session-CREATE path, where a stall is visible and cancellable
+// rather than wedging a kill forever.
+//
+// Network operations must use runGitNetworkCommand instead (#896); local
+// operations on a teardown path must use runGitLocalCommand (#1917).
 func (g *GitWorktree) runGitCommand(path string, args ...string) (string, error) {
 	return g.runGitCommandContext(context.Background(), path, args...)
+}
+
+// runGitLocalCommand runs a local git command under localGitTimeout, so a step
+// that makes no progress surfaces an actionable timeout error instead of hanging
+// the caller forever (#1917). Like runGitNetworkCommand, the underlying process
+// group is SIGKILLed on the deadline.
+//
+// This exists because the "local git cannot stall" assumption above does not
+// survive contact with teardown: `git worktree remove -f` recursively unlinks a
+// tree and blocks indefinitely on a hung network mount or a D-state process
+// holding a file in it. Unbounded, that stalls GitWorktree.Cleanup, which stalls
+// the daemon's KillSession while it holds a per-session kills-in-flight guard —
+// and the session becomes permanently undeletable for the daemon's lifetime.
+//
+// Bounding is a real improvement but not a total one, and the limit is worth
+// naming: the deadline works by SIGKILLing git, so it only rescues stalls where
+// git is actually killable. A process wedged in an uninterruptible (D-state)
+// syscall against a dead mount ignores SIGKILL, and no in-process deadline can
+// fix that.
+func (g *GitWorktree) runGitLocalCommand(path string, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), localGitTimeout)
+	defer cancel()
+	output, err := g.runGitCommandContext(ctx, path, args...)
+	// Only treat a tripped deadline as a timeout when the command actually
+	// failed — runGitCommandContext maps a bare exec.ErrWaitDelay to nil, and
+	// without the err != nil guard that race would surface as a false timeout on
+	// a command that in fact succeeded (#914, same guard as runGitNetworkCommand).
+	if err != nil && errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return output, fmt.Errorf("git %s timed out after %s (no progress; a stalled filesystem or an unkillable process holding the worktree): %w",
+			strings.Join(args, " "), localGitTimeout, ctx.Err())
+	}
+	return output, err
 }
 
 // runGitNetworkCommand runs a git command that performs network I/O under

--- a/session/git/worktree_inplace_test.go
+++ b/session/git/worktree_inplace_test.go
@@ -67,7 +67,8 @@ func TestNewGitWorktreeInPlace(t *testing.T) {
 
 	// Cleanup (the kill path) must leave the user's working tree and branch
 	// intact — exactly the legacy external-worktree behavior.
-	require.NoError(t, gw.Cleanup())
+	_, cleanupErrX := gw.Cleanup()
+	require.NoError(t, cleanupErrX)
 	_, statErr := os.Stat(repoRoot)
 	require.NoError(t, statErr, "Cleanup must NOT remove the repo working tree")
 	_, statErr = os.Stat(filepath.Join(repoRoot, ".git"))

--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -317,6 +317,10 @@ func (r *cleanupRun) git(args ...string) (string, error) {
 	out, err := r.g.runGitLocalCommand(r.g.repoPath, args...)
 	if errors.Is(err, context.DeadlineExceeded) {
 		r.unknown = true
+		// Latch it on the WORKSPACE too: a retry gets a fresh run, and without this
+		// the knowledge that this filesystem stalls would die with the attempt
+		// (#1917 round 6).
+		r.g.markCleanupStalled()
 	}
 	return out, err
 }
@@ -327,8 +331,18 @@ func (r *cleanupRun) git(args ...string) (string, error) {
 // paths, and os.RemoveAll takes no context — so it would hang forever and defeat
 // the bound. Refusing leaves the directory for a later retry, which is recoverable.
 func (r *cleanupRun) removeDir(path string) {
-	if r.unknown {
-		r.errs = append(r.errs, fmt.Errorf("refusing to delete worktree directory %s: a cleanup command timed out, so its state is unknown and an unbounded delete could hang; leaving it for a retry", path))
+	// Consult the WORKSPACE's latch, not just this run's flag. A retry after a
+	// timeout arrives with a clean run, and the git probes it makes can now answer
+	// "not registered" — because the timed-out remove had already deregistered the
+	// checkout before it stalled. Trusting only r.unknown therefore walks straight
+	// back into the unbounded delete on the second attempt (#1917 round 6).
+	if r.unknown || r.g.cleanupHasStalled() {
+		// Refusing IS an unknown outcome: the directory is still there, so the run
+		// must report it and the caller must keep the record. Marking the run here
+		// rather than relying on the caller keeps that from being a fourth thing
+		// someone has to remember.
+		r.unknown = true
+		r.errs = append(r.errs, fmt.Errorf("refusing to delete worktree directory %s: a cleanup command has timed out against this workspace, so an unbounded delete could hang the daemon; leaving it in place — a daemon restart re-probes it", path))
 		return
 	}
 	if err := os.RemoveAll(path); err != nil {
@@ -691,3 +705,12 @@ func CleanupWorktreesForRepo(repoRoot string) error {
 
 	return nil
 }
+
+// markCleanupStalled latches the workspace-level "a cleanup command timed out
+// here" fact (see GitWorktree.cleanupStalled).
+func (g *GitWorktree) markCleanupStalled() { g.cleanupStalled.Store(true) }
+
+// cleanupHasStalled reports whether any cleanup attempt against this workspace has
+// ever tripped a deadline. Consulted by removeDir, which must never enter an
+// unbounded delete on a filesystem that has already proven it can stall.
+func (g *GitWorktree) cleanupHasStalled() bool { return g.cleanupStalled.Load() }

--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -264,9 +264,35 @@ func (g *GitWorktree) setupNewWorktree() error {
 	return nil
 }
 
-// Cleanup removes the worktree and associated branch.
+// CleanupState is what Cleanup could ESTABLISH about the worktree it was asked to
+// remove, returned SEPARATELY from the error for the same reason tmux.PaneState is
+// (#1917).
+//
+// Bounding the git commands gave Cleanup a third answer next to "removed" and
+// "refused to remove": "git was SIGKILLed mid-delete, so the workspace may be half
+// gone and still registered". That answer has to reach whoever deletes the session
+// record — it is the only handle left on the leftovers. Returned as an error it did
+// not: three separate callers logged it and dropped the record anyway, orphaning
+// the workspace. An error can be swallowed by accident; a second return value
+// cannot.
+type CleanupState int
+
+const (
+	// CleanupSettled: every git command ANSWERED. The worktree is gone, or Cleanup's
+	// #802/#726 decision tree deliberately left it and said why — either way the
+	// outcome is established and the caller's best-effort contract governs.
+	CleanupSettled CleanupState = iota
+	// CleanupStateUnknown: a bounded git command tripped its deadline mid-removal.
+	// The workspace may be partially removed and still registered. Callers MUST keep
+	// the session record so the cleanup can be retried.
+	CleanupStateUnknown
+)
+
+// Cleanup removes the worktree and associated branch. It reports whether it
+// ESTABLISHED the outcome (see CleanupState) alongside any error: callers that go
+// on to delete the session's record MUST gate on the state, not on the error.
 // If the worktree was not created by agent-factory (externalWorktree), only prune is done.
-func (g *GitWorktree) Cleanup() error {
+func (g *GitWorktree) Cleanup() (CleanupState, error) {
 	// Cancel any in-flight post-worktree hooks before removing the worktree.
 	if g.hooksCancel != nil {
 		g.hooksCancel()
@@ -274,19 +300,21 @@ func (g *GitWorktree) Cleanup() error {
 
 	// For external worktrees, don't remove the worktree or delete the branch
 	if g.externalWorktree {
-		return nil
+		return CleanupSettled, nil
 	}
 
 	// Guard against empty paths that would cause git commands to fail or
-	// operate on unintended directories.
+	// operate on unintended directories. Nothing was attempted, so nothing is
+	// unknown.
 	if g.repoPath == "" {
-		return fmt.Errorf("cannot clean up worktree: repo path is empty")
+		return CleanupSettled, fmt.Errorf("cannot clean up worktree: repo path is empty")
 	}
 	if g.worktreePath == "" {
-		return fmt.Errorf("cannot clean up worktree: worktree path is empty")
+		return CleanupSettled, fmt.Errorf("cannot clean up worktree: worktree path is empty")
 	}
 
 	var errs []error
+	state := CleanupSettled
 
 	// Check if worktree path exists before attempting removal
 	if _, err := os.Stat(g.worktreePath); err == nil {
@@ -323,6 +351,14 @@ func (g *GitWorktree) Cleanup() error {
 				}
 			} else {
 				errs = append(errs, err)
+			}
+			// A tripped deadline is the one failure where the outcome is genuinely
+			// UNKNOWN rather than decided: git was SIGKILLed part-way through a
+			// recursive delete, so the workspace may be half-removed and still
+			// registered. Every other branch above is git ANSWERING, which the
+			// #802/#726 tree resolves. Callers must keep the record on this.
+			if errors.Is(err, context.DeadlineExceeded) {
+				state = CleanupStateUnknown
 			}
 		}
 	} else if !os.IsNotExist(err) {
@@ -361,10 +397,10 @@ func (g *GitWorktree) Cleanup() error {
 	}
 
 	if len(errs) > 0 {
-		return errors.Join(errs...)
+		return state, errors.Join(errs...)
 	}
 
-	return nil
+	return state, nil
 }
 
 // shouldRemoveWorktreeDir decides whether Cleanup may delete the worktree

--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -549,9 +549,20 @@ func (g *GitWorktree) Cleanup() (CleanupState, error) {
 func (r *cleanupRun) shouldRemoveWorktreeDir(removeErr error) bool {
 	registered, ok := r.registered()
 	if !ok {
-		// The probe did not answer. Never take the string-matching fallback on a
-		// verdict we could not obtain.
-		return false
+		// The probe could not be read — but WHY matters, and conflating the two
+		// reasons was itself a bug (found reviewing this PR's own diff).
+		if r.unknown {
+			// It TIMED OUT. Never act on a verdict we could not obtain, and never
+			// re-enter the unbounded delete on a filesystem that just stalled. The run
+			// is already unknown, so the record is retained and a retry can finish.
+			return false
+		}
+		// It ANSWERED with an error (a corrupted repo, not a stall). Nothing is
+		// unknown here, so refusing would report a SETTLED cleanup while leaving the
+		// directory on disk — the caller would then drop the record and orphan it,
+		// which is the outcome this whole PR exists to prevent. Fall back to the
+		// conservative #726 string gate, exactly as before this PR (#719/#726).
+		return strings.Contains(removeErr.Error(), "validation failed")
 	}
 	if !registered {
 		return true

--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -265,28 +265,111 @@ func (g *GitWorktree) setupNewWorktree() error {
 }
 
 // CleanupState is what Cleanup could ESTABLISH about the worktree it was asked to
-// remove, returned SEPARATELY from the error for the same reason tmux.PaneState is
-// (#1917).
+// remove, returned SEPARATELY from the error (#1917).
 //
-// Bounding the git commands gave Cleanup a third answer next to "removed" and
-// "refused to remove": "git was SIGKILLed mid-delete, so the workspace may be half
-// gone and still registered". That answer has to reach whoever deletes the session
-// record — it is the only handle left on the leftovers. Returned as an error it did
-// not: three separate callers logged it and dropped the record anyway, orphaning
-// the workspace. An error can be swallowed by accident; a second return value
-// cannot.
+// THE ZERO VALUE IS UNKNOWN, deliberately. Every miss in this PR's review history
+// was the same shape — a bounded call tripped its deadline and something
+// destructive proceeded anyway — because the safe outcome had to be REMEMBERED and
+// the destructive one was the default. Inverting that makes forgetting produce the
+// safe result: a state nobody set, or a struct field nobody filled, refuses to
+// destroy rather than permitting it.
+//
+// Callers must not construct this themselves; it comes from cleanupRun.state(),
+// which reports Settled only if no command in the run tripped its deadline.
 type CleanupState int
 
 const (
-	// CleanupSettled: every git command ANSWERED. The worktree is gone, or Cleanup's
-	// #802/#726 decision tree deliberately left it and said why — either way the
-	// outcome is established and the caller's best-effort contract governs.
-	CleanupSettled CleanupState = iota
-	// CleanupStateUnknown: a bounded git command tripped its deadline mid-removal.
-	// The workspace may be partially removed and still registered. Callers MUST keep
-	// the session record so the cleanup can be retried.
-	CleanupStateUnknown
+	// CleanupStateUnknown (the ZERO VALUE): a bounded git command tripped its
+	// deadline, so the workspace may be partially removed and still registered —
+	// or nobody established the outcome at all. Callers MUST keep the session
+	// record so the cleanup can be retried.
+	CleanupStateUnknown CleanupState = iota
+	// CleanupSettled: every git command in the run ANSWERED. The worktree is gone,
+	// or Cleanup's #802/#726 decision tree deliberately left it and said why —
+	// either way the outcome is established and the caller's best-effort contract
+	// governs.
+	CleanupSettled
 )
+
+// cleanupRun executes ONE Cleanup and OWNS its state.
+//
+// This is the structural half of the #1917 hardening. Cleanup runs five bounded git
+// commands; the state used to be asserted once (`state := CleanupSettled`) and
+// downgraded by hand at ONE of them, so `branch -D`, both `prune`s and the
+// `worktree list` probe could all trip their deadlines and still report Settled —
+// and a timed-out probe could even open the door to an UNBOUNDED os.RemoveAll,
+// reintroducing the very wedge this work removes.
+//
+// The author no longer writes the state at all. Every command goes through run.git,
+// which records a tripped deadline; every destructive act goes through a method that
+// refuses while the run is unknown; state() derives the answer. A command added to
+// Cleanup participates automatically, because using the run is the only way to reach
+// git from here — there is no marking left to forget.
+type cleanupRun struct {
+	g       *GitWorktree
+	errs    []error
+	unknown bool
+}
+
+// git runs one bounded local git command and RECORDS a tripped deadline. This is
+// the only place in the cleanup path that decides what a deadline means.
+func (r *cleanupRun) git(args ...string) (string, error) {
+	out, err := r.g.runGitLocalCommand(r.g.repoPath, args...)
+	if errors.Is(err, context.DeadlineExceeded) {
+		r.unknown = true
+	}
+	return out, err
+}
+
+// removeDir is the choke point for the one destructive act Cleanup performs
+// directly. It REFUSES while the run is unknown: whatever stalled git (a hung
+// mount, a D-state process holding the tree) stalls os.RemoveAll on the very same
+// paths, and os.RemoveAll takes no context — so it would hang forever and defeat
+// the bound. Refusing leaves the directory for a later retry, which is recoverable.
+func (r *cleanupRun) removeDir(path string) {
+	if r.unknown {
+		r.errs = append(r.errs, fmt.Errorf("refusing to delete worktree directory %s: a cleanup command timed out, so its state is unknown and an unbounded delete could hang; leaving it for a retry", path))
+		return
+	}
+	if err := os.RemoveAll(path); err != nil {
+		r.errs = append(r.errs, fmt.Errorf("failed to remove worktree directory %s: %w", path, err))
+	}
+}
+
+// prune runs `git worktree prune` through the run, so its deadline counts.
+func (r *cleanupRun) prune() {
+	if _, err := r.git("worktree", "prune"); err != nil {
+		r.errs = append(r.errs, fmt.Errorf("failed to prune worktrees: %w", err))
+	}
+}
+
+// registered reports whether git still lists the worktree. The bool is only
+// meaningful when ok is true; a timed-out probe reports ok=false AND marks the run
+// unknown via run.git, so no caller can mistake "could not ask" for "not there".
+func (r *cleanupRun) registered() (yes bool, ok bool) {
+	output, err := r.git("worktree", "list", "--porcelain")
+	if err != nil {
+		return false, false
+	}
+	target := normalizeWorktreePath(r.g.worktreePath)
+	for _, line := range strings.Split(output, "\n") {
+		if !strings.HasPrefix(line, "worktree ") {
+			continue
+		}
+		if normalizeWorktreePath(strings.TrimPrefix(line, "worktree ")) == target {
+			return true, true
+		}
+	}
+	return false, true
+}
+
+// state derives the run's outcome. Settled ONLY if nothing tripped a deadline.
+func (r *cleanupRun) state() CleanupState {
+	if r.unknown {
+		return CleanupStateUnknown
+	}
+	return CleanupSettled
+}
 
 // Cleanup removes the worktree and associated branch. It reports whether it
 // ESTABLISHED the outcome (see CleanupState) alongside any error: callers that go
@@ -298,23 +381,26 @@ func (g *GitWorktree) Cleanup() (CleanupState, error) {
 		g.hooksCancel()
 	}
 
+	// The run owns the state from the first line, so even the early returns below
+	// derive it instead of asserting one (#1917). Nothing in this function names a
+	// CleanupState constant: that is the rule that makes the next command added here
+	// safe by default. These early paths run no git at all, so the run is trivially
+	// settled — but that is r.state()'s answer to give, not this function's.
+	r := &cleanupRun{g: g}
+
 	// For external worktrees, don't remove the worktree or delete the branch
 	if g.externalWorktree {
-		return CleanupSettled, nil
+		return r.state(), nil
 	}
 
 	// Guard against empty paths that would cause git commands to fail or
-	// operate on unintended directories. Nothing was attempted, so nothing is
-	// unknown.
+	// operate on unintended directories.
 	if g.repoPath == "" {
-		return CleanupSettled, fmt.Errorf("cannot clean up worktree: repo path is empty")
+		return r.state(), fmt.Errorf("cannot clean up worktree: repo path is empty")
 	}
 	if g.worktreePath == "" {
-		return CleanupSettled, fmt.Errorf("cannot clean up worktree: worktree path is empty")
+		return r.state(), fmt.Errorf("cannot clean up worktree: worktree path is empty")
 	}
-
-	var errs []error
-	state := CleanupSettled
 
 	// Check if worktree path exists before attempting removal
 	if _, err := os.Stat(g.worktreePath); err == nil {
@@ -322,7 +408,7 @@ func (g *GitWorktree) Cleanup() (CleanupState, error) {
 		// (#1917): this recursive delete is the one local git command that
 		// genuinely stalls forever (hung mount, D-state process in the tree), and
 		// Cleanup runs inside the daemon's kills-in-flight guard.
-		if _, err := g.runGitLocalCommand(g.repoPath, "worktree", "remove", "-f", g.worktreePath); err != nil {
+		if _, err := r.git("worktree", "remove", "-f", g.worktreePath); err != nil {
 			log.ErrorLog.Printf("failed to remove worktree %s: %v", g.worktreePath, err)
 			// A failed `git worktree remove -f` may still have released the
 			// registration. Decide whether the directory is ours to delete
@@ -334,7 +420,7 @@ func (g *GitWorktree) Cleanup() (CleanupState, error) {
 			//     Directory not empty") because the dying agent process wrote
 			//     into the tree mid-removal — git deregisters first, then
 			//     fails to finish deleting (#802). RemoveAll the leftovers;
-			//     the Prune() below reconciles any remaining metadata.
+			//     the prune below reconciles any remaining metadata.
 			//   - Still registered + "validation failed": the worktree's
 			//     `.git` pointer is corrupted (#719/#726). git refuses to
 			//     remove it, but it is unambiguously one of our registered
@@ -344,26 +430,20 @@ func (g *GitWorktree) Cleanup() (CleanupState, error) {
 			//     know why removal failed — surface the error instead of
 			//     deleting data (preserves the best-effort Kill behavior of
 			//     #478).
-			//   - Timed out: never ours to delete (#1917, see the helper).
-			if g.shouldRemoveWorktreeDir(err) {
-				if removeErr := os.RemoveAll(g.worktreePath); removeErr != nil {
-					errs = append(errs, fmt.Errorf("failed to remove worktree directory %s: %w", g.worktreePath, removeErr))
-				}
+			//
+			// Every branch here is git ANSWERING. A deadline anywhere in the run —
+			// the remove itself, OR the registration probe below — leaves the state
+			// unknown, and r.removeDir refuses on that, so no timeout can reach the
+			// unbounded os.RemoveAll.
+			if r.shouldRemoveWorktreeDir(err) {
+				r.removeDir(g.worktreePath)
 			} else {
-				errs = append(errs, err)
-			}
-			// A tripped deadline is the one failure where the outcome is genuinely
-			// UNKNOWN rather than decided: git was SIGKILLed part-way through a
-			// recursive delete, so the workspace may be half-removed and still
-			// registered. Every other branch above is git ANSWERING, which the
-			// #802/#726 tree resolves. Callers must keep the record on this.
-			if errors.Is(err, context.DeadlineExceeded) {
-				state = CleanupStateUnknown
+				r.errs = append(r.errs, err)
 			}
 		}
 	} else if !os.IsNotExist(err) {
 		// Only append error if it's not a "not exists" error
-		errs = append(errs, fmt.Errorf("failed to check worktree path: %w", err))
+		r.errs = append(r.errs, fmt.Errorf("failed to check worktree path: %w", err))
 	}
 
 	// Prune stale worktree metadata BEFORE deleting the branch. When the
@@ -373,61 +453,52 @@ func (g *GitWorktree) Cleanup() (CleanupState, error) {
 	// out", leaving an orphaned branch behind. Mirrors the ordering in
 	// CleanupWorktreesForRepo (#330). Best-effort: a prune failure here
 	// should not block the branch-delete attempt.
-	if err := g.Prune(); err != nil {
-		errs = append(errs, err)
-	}
+	r.prune()
 
 	// Only delete the branch if this session actually created it. When we
 	// reused a pre-existing branch via setupFromExistingBranch(), the branch
 	// may contain unrelated user work and must be preserved.
 	if g.branchCreatedByUs {
-		// Bounded (#1917): teardown path — see runGitLocalCommand.
-		if _, err := g.runGitLocalCommand(g.repoPath, "branch", "-D", g.branchName); err != nil {
+		if _, err := r.git("branch", "-D", g.branchName); err != nil {
 			// Only log if it's not a "branch not found" error
 			if !strings.Contains(err.Error(), "not found") {
-				errs = append(errs, fmt.Errorf("failed to remove branch %s: %w", g.branchName, err))
+				r.errs = append(r.errs, fmt.Errorf("failed to remove branch %s: %w", g.branchName, err))
 			}
 		}
 	}
 
 	// Final prune to clean up any remaining references. Usually a no-op
 	// after the prune above, but mirrors CleanupWorktreesForRepo.
-	if err := g.Prune(); err != nil {
-		errs = append(errs, err)
-	}
+	r.prune()
 
-	if len(errs) > 0 {
-		return state, errors.Join(errs...)
+	if len(r.errs) > 0 {
+		return r.state(), errors.Join(r.errs...)
 	}
-
-	return state, nil
+	return r.state(), nil
 }
 
 // shouldRemoveWorktreeDir decides whether Cleanup may delete the worktree
 // directory itself after `git worktree remove -f` returned removeErr. It is the
-// #802/#726 decision tree documented at the call site, plus the #1917 timeout
-// guard below.
-func (g *GitWorktree) shouldRemoveWorktreeDir(removeErr error) bool {
-	if errors.Is(removeErr, context.DeadlineExceeded) {
-		// The removal did not FAIL, it never FINISHED: git was SIGKILLed
-		// mid-delete on localGitTimeout. Two reasons that is not a verdict we
-		// may act on. First, the registration state is a snapshot of a half-done
-		// operation rather than git's considered answer. Second — and decisive —
-		// whatever stalled git (a hung mount, a D-state process holding a file in
-		// the tree) will stall os.RemoveAll on the very same paths, and
-		// os.RemoveAll takes no context, so it would hang FOREVER and defeat the
-		// bound we just added. This is tmuxTimeoutContext's rule one layer up:
-		// after a tripped deadline, never re-probe the thing that just wedged.
-		// Surfacing the timeout leaves the directory for a later kill to retry,
-		// which is the recoverable outcome.
+// #802/#726 decision tree documented at the call site.
+//
+// It no longer needs its own timeout guard: the probe runs through r.git, so a
+// timed-out probe marks the run unknown and r.removeDir refuses regardless of what
+// this returns. That is the point of the run — the safety no longer depends on this
+// function remembering anything. It still refuses on an UNKNOWN registration rather
+// than falling back to the string gate, so a probe that could not be asked is never
+// read as "not ours" (#1917 round 4).
+func (r *cleanupRun) shouldRemoveWorktreeDir(removeErr error) bool {
+	registered, ok := r.registered()
+	if !ok {
+		// The probe did not answer. Never take the string-matching fallback on a
+		// verdict we could not obtain.
 		return false
 	}
-	if registered, listErr := g.isWorktreeRegistered(); listErr == nil && !registered {
+	if !registered {
 		return true
 	}
-	// Also the path taken when `worktree list` itself failed (listErr != nil):
-	// without a readable registration we fall back to the conservative #726
-	// string gate.
+	// Still registered: only the conservative #726 corrupted-pointer gate may
+	// delete.
 	return strings.Contains(removeErr.Error(), "validation failed")
 }
 
@@ -464,15 +535,6 @@ func normalizeWorktreePath(p string) string {
 		return resolved
 	}
 	return p
-}
-
-// Prune removes all working tree administrative files and directories.
-// Bounded by localGitTimeout (#1917): both callers are on Cleanup's teardown path.
-func (g *GitWorktree) Prune() error {
-	if _, err := g.runGitLocalCommand(g.repoPath, "worktree", "prune"); err != nil {
-		return fmt.Errorf("failed to prune worktrees: %w", err)
-	}
-	return nil
 }
 
 // RemoveWorktreeDir removes a SINGLE worktree directory that AF created for a

--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -1,13 +1,15 @@
 package git
 
 import (
+	"context"
 	"errors"
 	"fmt"
-	"github.com/sachiniyer/agent-factory/log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/sachiniyer/agent-factory/log"
 )
 
 // Setup creates a new worktree for the session
@@ -288,8 +290,11 @@ func (g *GitWorktree) Cleanup() error {
 
 	// Check if worktree path exists before attempting removal
 	if _, err := os.Stat(g.worktreePath); err == nil {
-		// Remove the worktree using git command
-		if _, err := g.runGitCommand(g.repoPath, "worktree", "remove", "-f", g.worktreePath); err != nil {
+		// Remove the worktree using git command. Bounded by localGitTimeout
+		// (#1917): this recursive delete is the one local git command that
+		// genuinely stalls forever (hung mount, D-state process in the tree), and
+		// Cleanup runs inside the daemon's kills-in-flight guard.
+		if _, err := g.runGitLocalCommand(g.repoPath, "worktree", "remove", "-f", g.worktreePath); err != nil {
 			log.ErrorLog.Printf("failed to remove worktree %s: %v", g.worktreePath, err)
 			// A failed `git worktree remove -f` may still have released the
 			// registration. Decide whether the directory is ours to delete
@@ -311,16 +316,8 @@ func (g *GitWorktree) Cleanup() error {
 			//     know why removal failed — surface the error instead of
 			//     deleting data (preserves the best-effort Kill behavior of
 			//     #478).
-			removeDir := false
-			if registered, listErr := g.isWorktreeRegistered(); listErr == nil && !registered {
-				removeDir = true
-			} else if strings.Contains(err.Error(), "validation failed") {
-				// Also the path taken when `worktree list` itself failed
-				// (listErr != nil): without a readable registration we fall
-				// back to the conservative #726 string gate.
-				removeDir = true
-			}
-			if removeDir {
+			//   - Timed out: never ours to delete (#1917, see the helper).
+			if g.shouldRemoveWorktreeDir(err) {
 				if removeErr := os.RemoveAll(g.worktreePath); removeErr != nil {
 					errs = append(errs, fmt.Errorf("failed to remove worktree directory %s: %w", g.worktreePath, removeErr))
 				}
@@ -348,7 +345,8 @@ func (g *GitWorktree) Cleanup() error {
 	// reused a pre-existing branch via setupFromExistingBranch(), the branch
 	// may contain unrelated user work and must be preserved.
 	if g.branchCreatedByUs {
-		if _, err := g.runGitCommand(g.repoPath, "branch", "-D", g.branchName); err != nil {
+		// Bounded (#1917): teardown path — see runGitLocalCommand.
+		if _, err := g.runGitLocalCommand(g.repoPath, "branch", "-D", g.branchName); err != nil {
 			// Only log if it's not a "branch not found" error
 			if !strings.Contains(err.Error(), "not found") {
 				errs = append(errs, fmt.Errorf("failed to remove branch %s: %w", g.branchName, err))
@@ -369,13 +367,43 @@ func (g *GitWorktree) Cleanup() error {
 	return nil
 }
 
+// shouldRemoveWorktreeDir decides whether Cleanup may delete the worktree
+// directory itself after `git worktree remove -f` returned removeErr. It is the
+// #802/#726 decision tree documented at the call site, plus the #1917 timeout
+// guard below.
+func (g *GitWorktree) shouldRemoveWorktreeDir(removeErr error) bool {
+	if errors.Is(removeErr, context.DeadlineExceeded) {
+		// The removal did not FAIL, it never FINISHED: git was SIGKILLed
+		// mid-delete on localGitTimeout. Two reasons that is not a verdict we
+		// may act on. First, the registration state is a snapshot of a half-done
+		// operation rather than git's considered answer. Second — and decisive —
+		// whatever stalled git (a hung mount, a D-state process holding a file in
+		// the tree) will stall os.RemoveAll on the very same paths, and
+		// os.RemoveAll takes no context, so it would hang FOREVER and defeat the
+		// bound we just added. This is tmuxTimeoutContext's rule one layer up:
+		// after a tripped deadline, never re-probe the thing that just wedged.
+		// Surfacing the timeout leaves the directory for a later kill to retry,
+		// which is the recoverable outcome.
+		return false
+	}
+	if registered, listErr := g.isWorktreeRegistered(); listErr == nil && !registered {
+		return true
+	}
+	// Also the path taken when `worktree list` itself failed (listErr != nil):
+	// without a readable registration we fall back to the conservative #726
+	// string gate.
+	return strings.Contains(removeErr.Error(), "validation failed")
+}
+
 // isWorktreeRegistered reports whether git still lists g.worktreePath as a
 // registered worktree of the repo. Used after a failed `git worktree remove`
 // to distinguish "git released the worktree but the directory survived"
 // (safe to delete manually, #802) from "git still owns the path" (not ours
 // to second-guess).
 func (g *GitWorktree) isWorktreeRegistered() (bool, error) {
-	output, err := g.runGitCommand(g.repoPath, "worktree", "list", "--porcelain")
+	// Bounded (#1917): this is Cleanup's error-path probe, so it must not be the
+	// step that hangs the kill the bounded `worktree remove` above just rescued.
+	output, err := g.runGitLocalCommand(g.repoPath, "worktree", "list", "--porcelain")
 	if err != nil {
 		return false, err
 	}
@@ -402,9 +430,10 @@ func normalizeWorktreePath(p string) string {
 	return p
 }
 
-// Prune removes all working tree administrative files and directories
+// Prune removes all working tree administrative files and directories.
+// Bounded by localGitTimeout (#1917): both callers are on Cleanup's teardown path.
 func (g *GitWorktree) Prune() error {
-	if _, err := g.runGitCommand(g.repoPath, "worktree", "prune"); err != nil {
+	if _, err := g.runGitLocalCommand(g.repoPath, "worktree", "prune"); err != nil {
 		return fmt.Errorf("failed to prune worktrees: %w", err)
 	}
 	return nil

--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -325,6 +325,38 @@ func (r *cleanupRun) git(args ...string) (string, error) {
 	return out, err
 }
 
+// destructive runs a git command that DESTROYS something, and refuses once the run
+// is unknown (#1917 round 8).
+//
+// Every destructive act in the run must be gated, not just the file deletion. When
+// `git worktree remove -f` times out AFTER deregistering the checkout but BEFORE
+// deleting its files, removeDir correctly preserved the directory — and cleanup
+// then went on to `git branch -D`, which SUCCEEDED precisely because the checkout
+// was now unregistered, deleting the retained workspace's only ref and making its
+// unique commits unreachable. Saving the files and destroying the only pointer to
+// them is worse than either alone: the workspace survives and nothing can find it.
+//
+// So the rule is the run's, not each step's: once anything here is unknown, nothing
+// else may destroy.
+func (r *cleanupRun) destructive(what string, args ...string) (string, error) {
+	if r.unknown || r.g.cleanupHasStalled() {
+		err := fmt.Errorf("%w: refusing to %s: a cleanup command timed out against this workspace, so it is being retained — destroying its metadata would leave the files with nothing pointing at them", errRefusedDestructive, what)
+		r.errs = append(r.errs, err)
+		r.unknown = true
+		return "", err
+	}
+	return r.git(args...)
+}
+
+// errRefusedDestructive marks an act this run DECLINED because the workspace's
+// state is unknown — as opposed to one that RAN and failed.
+//
+// Callers must tell them apart. destructive() has already recorded a refusal, so
+// re-reporting it duplicates; but a command that ran and TIMED OUT sets r.unknown
+// itself, and suppressing that on an "is the run unknown?" test would swallow the
+// very deadline the caller needs to see. That mistake is easy and was made here.
+var errRefusedDestructive = errors.New("refused: the workspace's state is unknown")
+
 // removeDir is the choke point for the one destructive act Cleanup performs
 // directly. It REFUSES while the run is unknown: whatever stalled git (a hung
 // mount, a D-state process holding the tree) stalls os.RemoveAll on the very same
@@ -352,8 +384,14 @@ func (r *cleanupRun) removeDir(path string) {
 
 // prune runs `git worktree prune` through the run, so its deadline counts.
 func (r *cleanupRun) prune() {
-	if _, err := r.git("worktree", "prune"); err != nil {
-		r.errs = append(r.errs, fmt.Errorf("failed to prune worktrees: %w", err))
+	// Destructive metadata: prune drops git's record of worktrees it believes are
+	// gone. Gated like every other destructive step.
+	if _, err := r.destructive("prune worktree metadata", "worktree", "prune"); err != nil {
+		// Same rule as branch -D: a refusal recorded itself, a real failure is the
+		// caller's to see.
+		if !errors.Is(err, errRefusedDestructive) {
+			r.errs = append(r.errs, fmt.Errorf("failed to prune worktrees: %w", err))
+		}
 	}
 }
 
@@ -473,9 +511,16 @@ func (g *GitWorktree) Cleanup() (CleanupState, error) {
 	// reused a pre-existing branch via setupFromExistingBranch(), the branch
 	// may contain unrelated user work and must be preserved.
 	if g.branchCreatedByUs {
-		if _, err := r.git("branch", "-D", g.branchName); err != nil {
-			// Only log if it's not a "branch not found" error
-			if !strings.Contains(err.Error(), "not found") {
+		// THE branch delete. Gated (#1917 round 8): a timed-out `worktree remove`
+		// deregisters before it stalls, which is exactly what makes this succeed —
+		// so an ungated branch -D destroys the ref of the workspace the same run just
+		// decided to keep, and its unique commits become unreachable.
+		if _, err := r.destructive("delete branch "+g.branchName, "branch", "-D", g.branchName); err != nil {
+			// A REFUSAL already recorded itself. Anything else RAN — including a
+			// deadline, which the caller must still see — and "branch not found" is
+			// success (#478). Testing r.unknown here instead would swallow the branch
+			// delete's own timeout, since that timeout is what set it.
+			if !errors.Is(err, errRefusedDestructive) && !strings.Contains(err.Error(), "not found") {
 				r.errs = append(r.errs, fmt.Errorf("failed to remove branch %s: %w", g.branchName, err))
 			}
 		}

--- a/session/git/worktree_test.go
+++ b/session/git/worktree_test.go
@@ -243,7 +243,8 @@ func TestSetupFromExistingBranch_SetsBaseCommitSHA(t *testing.T) {
 	assert.Equal(t, headSHA, gw.GetBaseCommitSHA(), "baseCommitSHA should equal the HEAD commit")
 
 	// Clean up
-	require.NoError(t, gw.Cleanup())
+	_, cleanupErrX := gw.Cleanup()
+	require.NoError(t, cleanupErrX)
 }
 
 // TestSetupFromExistingBranch_RecreatesAfterExternalDeletion is a regression
@@ -303,7 +304,8 @@ func TestSetupFromExistingBranch_RecreatesAfterExternalDeletion(t *testing.T) {
 	_, err = os.Stat(worktreePath)
 	require.NoError(t, err, "worktree directory should be recreated")
 
-	require.NoError(t, gw.Cleanup())
+	_, cleanupErrX := gw.Cleanup()
+	require.NoError(t, cleanupErrX)
 }
 
 // TestCleanup_PreservesPreExistingBranch verifies that when Setup() reuses a
@@ -342,7 +344,8 @@ func TestCleanup_PreservesPreExistingBranch(t *testing.T) {
 		"BranchCreatedByUs should be false when Setup reused an existing branch")
 
 	// Cleanup should remove the worktree but NOT delete the branch.
-	require.NoError(t, gw.Cleanup())
+	_, cleanupErrX := gw.Cleanup()
+	require.NoError(t, cleanupErrX)
 
 	// Verify the branch still exists in the repo.
 	verifyCmd := exec.Command("git", "-C", repoRoot, "show-ref", "--verify", "refs/heads/test/preexisting")
@@ -380,7 +383,8 @@ func TestCleanup_DeletesBranchWeCreated(t *testing.T) {
 	assert.True(t, gw.BranchCreatedByUs(),
 		"BranchCreatedByUs should be true when Setup created a new branch")
 
-	require.NoError(t, gw.Cleanup())
+	_, cleanupErrX := gw.Cleanup()
+	require.NoError(t, cleanupErrX)
 
 	// Branch should be gone.
 	verifyCmd := exec.Command("git", "-C", repoRoot, "show-ref", "--verify", "refs/heads/test/brand-new")
@@ -434,7 +438,8 @@ func TestCleanup_LegacyExternalWorktreeIsPreserved(t *testing.T) {
 	require.True(t, gw.IsExternalWorktree(), "restored legacy worktree must report external")
 
 	// Cleanup must be a no-op for an external worktree.
-	require.NoError(t, gw.Cleanup())
+	_, cleanupErrX := gw.Cleanup()
+	require.NoError(t, cleanupErrX)
 
 	// The worktree directory must still exist.
 	_, statErr := os.Stat(externalWtPath)
@@ -488,7 +493,7 @@ func TestCleanup_PrunesBeforeBranchDelete(t *testing.T) {
 
 	// Cleanup may return errors from the failed `worktree remove`, but it
 	// must still delete the branch — that's the user-visible regression.
-	_ = gw.Cleanup()
+	_, _ = gw.Cleanup()
 
 	// The branch should be gone — this is what regresses without the prune
 	// before `git branch -D`.
@@ -541,7 +546,7 @@ func TestCleanup_RemovesOrphanedDirectory(t *testing.T) {
 	require.NoError(t, os.Remove(filepath.Join(worktreePath, ".git")))
 
 	// Cleanup may report errors, but it must remove the on-disk directory.
-	_ = gw.Cleanup()
+	_, _ = gw.Cleanup()
 
 	_, err = os.Stat(worktreePath)
 	assert.True(t, os.IsNotExist(err),
@@ -597,7 +602,8 @@ func TestCleanup_RemovesDirWhenGitDeregistered(t *testing.T) {
 	require.NoError(t, err)
 
 	// Full recovery is expected: no error, directory gone, branch gone.
-	require.NoError(t, gw.Cleanup())
+	_, cleanupErrX := gw.Cleanup()
+	require.NoError(t, cleanupErrX)
 
 	_, err = os.Stat(worktreePath)
 	assert.True(t, os.IsNotExist(err),
@@ -644,7 +650,7 @@ func TestCleanup_SurfacesErrorWhenGitStillOwnsWorktree(t *testing.T) {
 	out, err = lockCmd.CombinedOutput()
 	require.NoError(t, err, string(out))
 
-	err = gw.Cleanup()
+	_, err = gw.Cleanup()
 	require.Error(t, err,
 		"Cleanup() must surface the failure when git still owns the worktree and the cause is unknown")
 	assert.Contains(t, err.Error(), "locked")
@@ -686,7 +692,7 @@ func TestCleanup_EmptyRepoPath(t *testing.T) {
 	require.NoError(t, err)
 	// Simulate a corrupted state by zeroing out repoPath
 	gw.repoPath = ""
-	err = gw.Cleanup()
+	_, err = gw.Cleanup()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "repo path is empty")
 }
@@ -696,7 +702,7 @@ func TestCleanup_EmptyWorktreePath(t *testing.T) {
 	require.NoError(t, err)
 	// Simulate a corrupted state by zeroing out worktreePath
 	gw.worktreePath = ""
-	err = gw.Cleanup()
+	_, err = gw.Cleanup()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "worktree path is empty")
 }

--- a/session/instance.go
+++ b/session/instance.go
@@ -472,7 +472,11 @@ func (i *Instance) CloseTab(idx int) error {
 	if tab.tmux == nil {
 		return nil
 	}
-	if err := tab.tmux.Close(); err != nil {
+	// Pane state deliberately ignored: closing ONE tab touches no worktree, so
+	// nothing destructive follows an unknown here. (A Close that fails after the
+	// tab was already dropped from i.Tabs above leaks the tmux session — true of
+	// every Close failure, not just a timeout, and unchanged by #1917.)
+	if _, err := tab.tmux.Close(); err != nil {
 		return fmt.Errorf("failed to close tab %q: %w", tab.Name, err)
 	}
 	return nil

--- a/session/instance_accessors.go
+++ b/session/instance_accessors.go
@@ -157,8 +157,14 @@ func (i *Instance) SetTitle(title string) error {
 
 // TmuxAlive returns true if the underlying session is alive.
 // For remote backends this delegates to IsAlive.
+//
+// It collapses IsAlive's tri-state to a bool, treating "could not ask" as NOT
+// alive. That is safe for its callers — the TUI's attach/pane guards, which only
+// refuse to attach — but it must never be used as evidence of liveness: take
+// IsAlive directly for that (#1917 round 8).
 func (i *Instance) TmuxAlive() bool {
-	return i.backend.IsAlive(i)
+	alive, err := i.backend.IsAlive(i)
+	return err == nil && alive
 }
 
 // ResolvedAgent returns the canonical agent (one of tmux.SupportedPrograms)

--- a/session/provenance_legacy_test.go
+++ b/session/provenance_legacy_test.go
@@ -75,7 +75,11 @@ func TestLegacyNilProvenance_CleanupPreservesReusedUserBranch(t *testing.T) {
 	require.NotNil(t, restored.gitWorktree)
 
 	// The kill/archive teardown step, verbatim (teardownKill.handleWorktree).
-	require.NoError(t, restored.gitWorktree.Cleanup())
+	// Cleanup reports a CleanupState alongside its error in this branch (#1917):
+	// the state is irrelevant to #1953's provenance question — nothing here stalls,
+	// so it is trivially settled — but the error still is.
+	_, cleanupErr := restored.gitWorktree.Cleanup()
+	require.NoError(t, cleanupErr)
 
 	assert.True(t, legacyBranchExists(t, repoRoot, "user-feature"),
 		"#1953: kill/archive force-deleted the user's pre-existing branch %q "+

--- a/session/ptychannel_tmux_test.go
+++ b/session/ptychannel_tmux_test.go
@@ -118,7 +118,11 @@ func TestClientlessCaptureCloseWakesBlockedRead(t *testing.T) {
 	if err := ts.Start(t.TempDir()); err != nil {
 		t.Fatalf("start tmux session: %v", err)
 	}
-	t.Cleanup(func() { _ = ts.Close() })
+	// Pane state deliberately ignored: this is #1944's FIFO-wake regression test
+	// tearing down its own fixture session; nothing destructive follows. The second
+	// return is new in this PR (tmux.PaneState) — the production captureReader from
+	// #1944 is untouched, only this call site acknowledges the added value.
+	t.Cleanup(func() { _, _ = ts.Close() })
 
 	ch := newTmuxClientlessChannel(ts)
 	rc, err := ch.StartCapture()

--- a/session/ptychannel_tmux_test.go
+++ b/session/ptychannel_tmux_test.go
@@ -35,7 +35,7 @@ func TestTmuxSnapshotRepaintCursorRealTmux(t *testing.T) {
 	if err := ts.Start(t.TempDir()); err != nil {
 		t.Fatalf("start tmux session: %v", err)
 	}
-	t.Cleanup(func() { _ = ts.Close() })
+	t.Cleanup(func() { _, _ = ts.Close() })
 
 	// Narrow the pane so a 25-char line wraps across two physical rows.
 	const paneW, paneH = 20, 8

--- a/session/storage.go
+++ b/session/storage.go
@@ -350,11 +350,29 @@ func (s *Storage) DeleteInstance(title string) error {
 	return nil
 }
 
+// InstanceDeleteLockTimeout bounds how long DeleteInstanceByStableID waits for
+// the per-repo instances flock. A var so tests can shorten it; production never
+// reassigns.
+//
+// The delete is the LAST step of a session kill, and the daemon runs it holding
+// that session's kill guard, so an unbounded wait here does not just stall one
+// write — it strands a session whose kill-intent tombstone is already on disk,
+// leaving it undeletable for the daemon's whole lifetime (#1917). The budget is
+// generous: this lock is held only across a read-modify-write of one small JSON
+// file, so exceeding it means a peer is genuinely wedged, not merely slow.
+var InstanceDeleteLockTimeout = 10 * time.Second
+
 // DeleteInstanceByStableID removes an instance from storage only when the
 // record still matches the stable session identity captured by the caller. A
 // false nil result means a same-titled record exists but belongs to a different
 // instance, so the caller must treat the delete as stale and leave it alone.
 // Empty IDs are legacy-compatible and fall back to title matching.
+//
+// It takes the instances flock with a DEADLINE (config.WithFileLockTimeout), not
+// the blocking WithFileLock every other Storage writer uses: a contended lock
+// surfaces as a retryable config.ErrLockTimeout instead of parking the caller
+// forever. See InstanceDeleteLockTimeout for why this writer in particular
+// cannot afford an unbounded wait.
 func (s *Storage) DeleteInstanceByStableID(title, id string) (bool, error) {
 	path, pathErr := config.RepoInstancesPath(s.repoID)
 	if pathErr != nil {
@@ -362,7 +380,7 @@ func (s *Storage) DeleteInstanceByStableID(title, id string) (bool, error) {
 	}
 	deleted := false
 	sameTitleDifferentID := false
-	if err := config.WithFileLock(path, func() error {
+	if err := config.WithFileLockTimeout(path, InstanceDeleteLockTimeout, func() error {
 		raw, err := s.state.GetInstances(s.repoID)
 		if err != nil {
 			return err

--- a/session/storage.go
+++ b/session/storage.go
@@ -252,7 +252,17 @@ func (s *Storage) SaveInstances(instances []*Instance) error {
 		// per-repo checkpoint save — triggered whenever ANY started instance in
 		// the same repo is saved — would silently orphan the archived worktree.
 		// (Lost is unaffected: it loads started=true, so it already survives.)
-		if !inst.Started() && status != Archived {
+		//
+		// A TOMBSTONED instance is the same shape and is kept for the same reason
+		// (#1917). A kill clears started BEFORE teardown, so a teardown that could
+		// not complete safely — tmux never confirmed the pane dead, or a worktree
+		// removal was cut off — leaves exactly this: started=false, not Archived,
+		// workspace still on disk, and the record deliberately RETAINED as its only
+		// handle. Without this clause the next checkpoint triggered by any other
+		// started session in the repo would silently drop it, undoing the retention
+		// in a layer that never heard of it, and orphaning the very workspace the
+		// retention exists to protect. Retention is a claim on this writer too.
+		if !inst.Started() && status != Archived && !inst.UserKilled() {
 			continue
 		}
 		root := inst.GetRepoPath()

--- a/session/storage_lock_test.go
+++ b/session/storage_lock_test.go
@@ -1,0 +1,83 @@
+package session
+
+import (
+	"errors"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+// DeleteInstanceByStableID is the LAST step of a session kill, and the #1917
+// field evidence points straight at it: the daemon's restart log ("tombstoned
+// record survived its teardown") proves the kill-intent tombstone reached disk
+// and the record delete did not. The delete took a blocking flock, so any other
+// af process holding it parked the kill forever — while the kill held the guard
+// that makes every retry fail and the session undeletable.
+//
+// PRE-FIX BEHAVIOR THIS REPRODUCES: with config.WithFileLock (no deadline) this
+// test hangs until the go test timeout instead of failing its deadline.
+func TestDeleteInstanceByStableID_ContendedLock_TimesOutInsteadOfHanging(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	const repoID = "deadbeef"
+	path, err := config.RepoInstancesPath(repoID)
+	if err != nil {
+		t.Fatalf("RepoInstancesPath: %v", err)
+	}
+	if err := config.SaveRepoInstances(repoID, []byte(`[{"title":"doomed"}]`)); err != nil {
+		t.Fatalf("seed instances: %v", err)
+	}
+
+	prev := InstanceDeleteLockTimeout
+	InstanceDeleteLockTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { InstanceDeleteLockTimeout = prev })
+
+	// Hold the same flock from an independent file description, exactly as a
+	// second af process would (flock contends per open-file-description).
+	f, err := os.OpenFile(path+".lock", os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		t.Fatalf("open lock file: %v", err)
+	}
+	defer f.Close()
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		t.Fatalf("flock: %v", err)
+	}
+
+	storage, err := NewStorage(config.LoadState(), repoID)
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, derr := storage.DeleteInstanceByStableID("doomed", "")
+		done <- derr
+	}()
+
+	select {
+	case derr := <-done:
+		if !errors.Is(derr, config.ErrLockTimeout) {
+			t.Fatalf("delete must fail with a retryable ErrLockTimeout, got: %v", derr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("HUNG: DeleteInstanceByStableID never returned against a held instances lock — " +
+			"this is the #1917 wedge: the kill holds killsInFlight across this call, so the " +
+			"session becomes undeletable until the daemon restarts")
+	}
+
+	// Releasing the contention must make the very same delete succeed: the bound
+	// has to leave a RETRYABLE state, not a poisoned one.
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_UN); err != nil {
+		t.Fatalf("unlock: %v", err)
+	}
+	deleted, err := storage.DeleteInstanceByStableID("doomed", "")
+	if err != nil {
+		t.Fatalf("delete after the lock cleared must succeed, got: %v", err)
+	}
+	if !deleted {
+		t.Fatal("delete after the lock cleared reported nothing deleted")
+	}
+}

--- a/session/storage_retain_test.go
+++ b/session/storage_retain_test.go
@@ -1,0 +1,69 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+// TestSaveInstances_KeepsTombstonedRowAlongsideStartedSibling is #1917 round-5
+// finding (1): the retain is undone by a writer in another layer.
+//
+// A kill clears started BEFORE teardown, so a teardown that could not complete
+// safely leaves the record started=false, not Archived, workspace still on disk,
+// and deliberately RETAINED as its only handle. SaveInstances — the daemon's
+// shutdown checkpoint — rewrites the whole repo list from the started instances,
+// and fires whenever ANY other started session in the repo is saved. It used to
+// drop the retained row, orphaning the exact workspace the retention exists to
+// protect.
+//
+// The started sibling is load-bearing: without it the repo has no rows to save and
+// the checkpoint is a no-op, so the bug never fires.
+//
+// PRE-FIX BEHAVIOR THIS REPRODUCES: the tombstoned row is absent after the save.
+func TestSaveInstances_KeepsTombstonedRowAlongsideStartedSibling(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoPath := t.TempDir()
+
+	// A live session in the repo: its save is what triggers the wholesale rewrite.
+	alive := &Instance{Title: "alive", Path: repoPath, started: true}
+	alive.SetStatusForTest(Running)
+
+	// The retained row: kill cleared started, the teardown could not finish, and the
+	// record is the only pointer left at its workspace.
+	doomed := &Instance{Title: "doomed", Path: repoPath, started: false}
+	doomed.SetStatusForTest(Running)
+	doomed.MarkUserKilled()
+
+	storage, err := NewStorage(config.LoadState(), "")
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+	if err := storage.SaveInstances([]*Instance{alive, doomed}); err != nil {
+		t.Fatalf("SaveInstances: %v", err)
+	}
+
+	repoID := config.RepoIDFromRoot(repoPath)
+	scoped, err := NewStorage(config.LoadState(), repoID)
+	if err != nil {
+		t.Fatalf("NewStorage(scoped): %v", err)
+	}
+	rows, err := scoped.LoadInstanceData()
+	if err != nil {
+		t.Fatalf("LoadInstanceData: %v", err)
+	}
+	var kept bool
+	for _, r := range rows {
+		if r.Title == "doomed" {
+			kept = true
+			if !r.UserKilled {
+				t.Fatal("the retained row lost its tombstone: the next daemon would treat it as Lost and RESTORE it")
+			}
+		}
+	}
+	if !kept {
+		t.Fatal("the daemon's checkpoint silently dropped a RETAINED tombstoned row: its workspace " +
+			"is still on disk and this record was its only handle, so the retention that KillSession " +
+			"and finishUserKill deliberately performed is undone by a writer in another layer (#1917 round 5)")
+	}
+}

--- a/session/tab_spawn.go
+++ b/session/tab_spawn.go
@@ -96,7 +96,9 @@ func (i *Instance) AddShellTab() (*Tab, error) {
 		// Tear down the just-spawned session so it does not outlive the worktree
 		// Kill is removing or archive is moving. Close is best-effort/idempotent
 		// (#967): a kill-session on an already-gone session is not an error.
-		if cerr := shellTmux.Close(); cerr != nil {
+		// Pane state deliberately ignored: this closes a tmux session we just
+		// spawned and are abandoning; no worktree action follows.
+		if _, cerr := shellTmux.Close(); cerr != nil {
 			log.WarningLog.Printf("add shell tab to %q: closing orphaned tmux after kill/archive race: %v", title, cerr)
 		}
 		return nil, fmt.Errorf("session was killed during tab creation")
@@ -170,7 +172,8 @@ func (i *Instance) AddProcessTab(command, requestedName string) (*Tab, error) {
 	i.mu.Unlock()
 	if stale {
 		// Best-effort/idempotent teardown of the orphaned session (#967).
-		if cerr := procTmux.Close(); cerr != nil {
+		// Pane state deliberately ignored: same abandoned-spawn cleanup as above.
+		if _, cerr := procTmux.Close(); cerr != nil {
 			log.WarningLog.Printf("add process tab to %q: closing orphaned tmux after kill/archive race: %v", title, cerr)
 		}
 		return nil, fmt.Errorf("session was killed during tab creation")

--- a/session/teardown.go
+++ b/session/teardown.go
@@ -1,7 +1,6 @@
 package session
 
 import (
-	"context"
 	"errors"
 	"fmt"
 
@@ -99,6 +98,16 @@ const (
 // that is still writing to it destroys the user's work on a guess. Callers must
 // treat this as "retry later", never as "the tmux part failed, carry on".
 var ErrPaneMayBeLive = errors.New("tmux did not confirm the session is dead; its pane may still be running")
+
+// ErrWorkspaceLeftBehind reports that a session was abandoned while its worktree
+// was still (partly) on disk, because the cleanup that should have removed it was
+// cut off by its own deadline.
+//
+// It exists for the paths that DISCARD an instance rather than tear one down — a
+// failed create, whose instance was never registered or persisted. Those paths have
+// no record to keep, so the leftovers have no handle at all: the caller must at
+// least refuse to hand the title back out over them (#1917).
+var ErrWorkspaceLeftBehind = errors.New("the session's workspace was left on disk: its cleanup was cut off by a deadline")
 
 // ErrWorkspaceStateUnknown reports that a worktree action was cut off by its own
 // deadline, so the workspace may be half-removed and is still (partly) on disk.
@@ -236,22 +245,22 @@ func (teardownKill) handleWorktree(gw *git.GitWorktree, title string) (teardownS
 	if gw == nil {
 		return stateKnown, nil
 	}
-	err := gw.Cleanup()
-	if err == nil {
-		return stateKnown, nil
-	}
-	// Same rule as closeTab, one layer down (#1917). A git command that ANSWERED
-	// with a failure leaves Cleanup's #802/#726 decision tree in charge and stays
-	// best-effort, so a stuck-but-diagnosed worktree never blocks dropping the
+	cleanupState, err := gw.Cleanup()
+	// Same rule as closeTab, one layer down (#1917), and read off Cleanup's own
+	// reported STATE rather than re-derived from its error here. A git command that
+	// ANSWERED with a failure leaves Cleanup's #802/#726 decision tree in charge and
+	// stays best-effort, so a stuck-but-diagnosed worktree never blocks dropping the
 	// record. A TIMEOUT is different in kind: git was SIGKILLed mid-delete, so the
 	// worktree directory and its registration may both still be there. Reporting it
 	// keeps the record — and with it the user's handle on the session — so the
 	// cleanup can be retried, instead of orphaning a registered worktree whose
 	// session row we just deleted.
-	if errors.Is(err, context.DeadlineExceeded) {
+	if cleanupState == git.CleanupStateUnknown {
 		return stateUnknown, fmt.Errorf("kill %q: git worktree cleanup: %w", title, err)
 	}
-	log.WarningLog.Printf("kill %q: git worktree cleanup failed: %v", title, err)
+	if err != nil {
+		log.WarningLog.Printf("kill %q: git worktree cleanup failed: %v", title, err)
+	}
 	return stateKnown, nil
 }
 

--- a/session/teardown.go
+++ b/session/teardown.go
@@ -122,6 +122,31 @@ var ErrWorkspaceLeftBehind = errors.New("the session's workspace was left on dis
 // worktree with nothing left pointing at it.
 var ErrWorkspaceStateUnknown = errors.New("the worktree action was cut off by its deadline; the workspace may be partially removed")
 
+// TeardownStateUnknown reports whether err means "we do not know whether this
+// session's workspace still exists" — as opposed to any other teardown failure.
+//
+// This distinction is the whole taxonomy, and getting it wrong inverts the design
+// (#1917 round 5). A caller that blocks the record delete on ANY teardown error
+// turns safe-by-default into STUCK-by-default: a remote session whose sandbox was
+// successfully reaped but whose in-sandbox /kill call failed reports an error whose
+// subject is a dead HTTP endpoint, not the workspace — the workspace is provably
+// gone. Refusing to delete that record makes the finisher retry a dead endpoint
+// forever, and the tombstone never clears.
+//
+// So only these two block, and they exist for exactly one reason each: the pane's
+// liveness was never established, or a worktree removal was cut off mid-flight.
+// Both mean the workspace may still be on disk with this record as its only handle.
+// Everything else — an endpoint that did not answer, a tmux that answered with a
+// failure, a sandbox reap that reported a problem — is a teardown that TOLD us
+// something, and the record may go.
+//
+// It lives here, beside the sentinels, because the teardown choke points are their
+// only producers: teardownTabs raises them, ghostCleanup forwards them, and no
+// other code constructs them. One producer, one predicate, one place to change.
+func TeardownStateUnknown(err error) bool {
+	return errors.Is(err, ErrPaneMayBeLive) || errors.Is(err, ErrWorkspaceStateUnknown)
+}
+
 // closeTabForDestructiveTeardown is the shared close-and-classify for the two
 // modes that go on to touch the workspace (kill and archive).
 //

--- a/session/teardown.go
+++ b/session/teardown.go
@@ -80,12 +80,17 @@ type closedTab struct {
 type teardownState int
 
 const (
+	// stateUnknown (the ZERO VALUE): a bound tripped, so what the step did — or
+	// whether the thing it acted on is still live — is genuinely unknown. Nothing
+	// destructive may follow.
+	//
+	// Zero deliberately (#1917): a mode that returns an unset state, or a future
+	// mode whose author forgets the field, refuses to destroy rather than
+	// permitting it. Safe is the lazy outcome.
+	stateUnknown teardownState = iota
 	// stateKnown: the step's effect on the system was established. The mode's own
 	// best-effort contract governs from here.
-	stateKnown teardownState = iota
-	// stateUnknown: a bound tripped, so what the step did — or whether the thing it
-	// acted on is still live — is genuinely unknown. Nothing destructive may follow.
-	stateUnknown
+	stateKnown
 )
 
 // ErrPaneMayBeLive reports that tmux never confirmed a session dead — the server
@@ -127,7 +132,7 @@ var ErrWorkspaceStateUnknown = errors.New("the worktree action was cut off by it
 // Two copies of a safety rule is one copy of a safety rule.
 func closeTabForDestructiveTeardown(ts *tmux.TmuxSession, verb, title, tabName string) (teardownState, error) {
 	state, err := ts.CloseAndWaitForPaneExit()
-	if state == tmux.PaneStateUnknown {
+	if state != tmux.PaneStateKnown {
 		return stateUnknown, fmt.Errorf("%s %q: tab %q: %w", verb, title, tabName, err)
 	}
 	// tmux ANSWERED. Whatever it said, the session's fate is established, so #478's
@@ -175,8 +180,10 @@ func (i *Instance) teardownTabs(mode teardownMode) error {
 			errs = append(errs, err)
 		}
 		// Gate on the STATE, never on the error: a mode that logs-and-returns-nil
-		// still cannot hide an unknown from this check (#1917).
-		if state == stateUnknown {
+		// still cannot hide an unknown from this check. Written as "not proven
+		// known" rather than "== unknown" so an unset/zero state — the state a
+		// future mode forgets to set — lands on the safe side (#1917).
+		if state != stateKnown {
 			paneMayBeLive = true
 		}
 	}
@@ -193,7 +200,7 @@ func (i *Instance) teardownTabs(mode teardownMode) error {
 	if err != nil {
 		errs = append(errs, err)
 	}
-	if wtState == stateUnknown {
+	if wtState != stateKnown {
 		// The worktree action was cut off mid-flight, so the workspace is still
 		// (partly) on disk. finalize would clear the tmux refs and the gitWorktree
 		// pointer — the exact state a retry needs — and a later retry would then
@@ -255,7 +262,7 @@ func (teardownKill) handleWorktree(gw *git.GitWorktree, title string) (teardownS
 	// keeps the record — and with it the user's handle on the session — so the
 	// cleanup can be retried, instead of orphaning a registered worktree whose
 	// session row we just deleted.
-	if cleanupState == git.CleanupStateUnknown {
+	if cleanupState != git.CleanupSettled {
 		return stateUnknown, fmt.Errorf("kill %q: git worktree cleanup: %w", title, err)
 	}
 	if err != nil {

--- a/session/teardown.go
+++ b/session/teardown.go
@@ -31,19 +31,25 @@ import (
 // dispatch (rather than a type-switch in the core) keeps the core closed to new
 // modes: an added mode implements these methods and the core is untouched.
 type teardownMode interface {
-	// closeTab tears down one tab's tmux session, OUTSIDE i.mu. It returns an
-	// error for the core to join into teardownTabs' result (release-PTY surfaces
-	// its per-tab errors), or nil after best-effort logging (kill/archive only
-	// log a tmux that ANSWERED with a failure, so the record can still be
-	// dropped). An error wrapping tmux.ErrTmuxTimeout is special: the core reads
-	// it as "this pane may still be alive" and skips the worktree action entirely
-	// (#1917) — so a mode must return, never swallow, a timeout.
-	closeTab(ts *tmux.TmuxSession, title, tabName string) error
+	// closeTab tears down one tab's tmux session, OUTSIDE i.mu. It reports whether
+	// the tab's state was ESTABLISHED (see teardownState) alongside an error for
+	// the core to join into teardownTabs' result.
+	//
+	// The state is a separate return, not a flavor of the error, precisely so a
+	// mode CANNOT reduce an unknown to a log line and a nil (#1917): that is how
+	// the archive path kept moving worktrees out from under possibly-live panes
+	// after the kill path had been fixed. A mode still chooses what to do with the
+	// error — kill and archive log a tmux that ANSWERED, so the record can still be
+	// dropped (#478) — but it does not get to choose whether the core learns the
+	// state is unknown.
+	closeTab(ts *tmux.TmuxSession, title, tabName string) (teardownState, error)
 	// handleWorktree performs the mode's worktree action once every pane is
 	// CONFIRMED exited: delete (kill), move (archive — returns the move error for
 	// the caller to roll back on), or nothing (release-PTY). gw may be nil. Not
-	// called at all when a closeTab reported a possibly-live pane.
-	handleWorktree(gw *git.GitWorktree, title string) error
+	// called at all when a closeTab reported a possibly-live pane. Reports its own
+	// state: a cut-off removal leaves the workspace half-there, and finalize must
+	// not run on that.
+	handleWorktree(gw *git.GitWorktree, title string) (teardownState, error)
 	// clearsStarted reports whether started is set false before teardown. Kill
 	// and release-PTY clear it (so the #990 tab-spawn guard fires); archive keeps
 	// it true and fences with OpArchiving instead, so a failed move self-heals
@@ -64,6 +70,25 @@ type closedTab struct {
 	ts  *tmux.TmuxSession
 }
 
+// teardownState reports whether a teardown step ESTABLISHED what it did.
+//
+// It is the session-layer half of the same idea as tmux.PaneState, and it exists
+// for the same reason: bounding a destructive path only helps if the "I don't
+// know" answer reaches the code that decides whether to destroy. As an error
+// value it did not — every intermediate layer reduced it to log-and-continue
+// (#1917 review). As a required return, a layer that wants to drop it must write
+// the drop down.
+type teardownState int
+
+const (
+	// stateKnown: the step's effect on the system was established. The mode's own
+	// best-effort contract governs from here.
+	stateKnown teardownState = iota
+	// stateUnknown: a bound tripped, so what the step did — or whether the thing it
+	// acted on is still live — is genuinely unknown. Nothing destructive may follow.
+	stateUnknown
+)
+
 // ErrPaneMayBeLive reports that tmux never confirmed a session dead — the server
 // did not answer within its deadline — so the pane may still be RUNNING.
 //
@@ -74,6 +99,35 @@ type closedTab struct {
 // that is still writing to it destroys the user's work on a guess. Callers must
 // treat this as "retry later", never as "the tmux part failed, carry on".
 var ErrPaneMayBeLive = errors.New("tmux did not confirm the session is dead; its pane may still be running")
+
+// ErrWorkspaceStateUnknown reports that a worktree action was cut off by its own
+// deadline, so the workspace may be half-removed and is still (partly) on disk.
+//
+// The caller must keep the session's record: it is the only handle the user — or
+// the daemon's own retry — has on the leftovers. Dropping it orphans a registered
+// worktree with nothing left pointing at it.
+var ErrWorkspaceStateUnknown = errors.New("the worktree action was cut off by its deadline; the workspace may be partially removed")
+
+// closeTabForDestructiveTeardown is the shared close-and-classify for the two
+// modes that go on to touch the workspace (kill and archive).
+//
+// It is one function, not two, deliberately. When this logic was open-coded per
+// mode, kill got the timeout gate and archive did not — so archive, which is the
+// DEFAULT reap action and therefore runs constantly, stepped straight from a
+// wedged tmux server into MoveWorktree on a possibly-live pane (#1917 review).
+// Two copies of a safety rule is one copy of a safety rule.
+func closeTabForDestructiveTeardown(ts *tmux.TmuxSession, verb, title, tabName string) (teardownState, error) {
+	state, err := ts.CloseAndWaitForPaneExit()
+	if state == tmux.PaneStateUnknown {
+		return stateUnknown, fmt.Errorf("%s %q: tab %q: %w", verb, title, tabName, err)
+	}
+	// tmux ANSWERED. Whatever it said, the session's fate is established, so #478's
+	// best-effort contract holds: log and let the caller drop the record.
+	if err != nil {
+		log.WarningLog.Printf("%s %q: tmux cleanup for tab %q failed: %v", verb, title, tabName, err)
+	}
+	return stateKnown, nil
+}
 
 // teardownTabs runs the one teardown skeleton for the given mode. It snapshots
 // each tab's tmux under i.mu, tears them down OUTSIDE the lock (closing under
@@ -107,12 +161,13 @@ func (i *Instance) teardownTabs(mode teardownMode) error {
 	var errs []error
 	paneMayBeLive := false
 	for _, c := range closed {
-		err := mode.closeTab(c.ts, title, c.tab.Name)
-		if err == nil {
-			continue
+		state, err := mode.closeTab(c.ts, title, c.tab.Name)
+		if err != nil {
+			errs = append(errs, err)
 		}
-		errs = append(errs, err)
-		if errors.Is(err, tmux.ErrTmuxTimeout) {
+		// Gate on the STATE, never on the error: a mode that logs-and-returns-nil
+		// still cannot hide an unknown from this check (#1917).
+		if state == stateUnknown {
 			paneMayBeLive = true
 		}
 	}
@@ -124,8 +179,19 @@ func (i *Instance) teardownTabs(mode teardownMode) error {
 		errs = append(errs, fmt.Errorf("%w: leaving %q's workspace untouched", ErrPaneMayBeLive, title))
 		return errors.Join(errs...)
 	}
-	if err := mode.handleWorktree(gw, title); err != nil {
+
+	wtState, err := mode.handleWorktree(gw, title)
+	if err != nil {
 		errs = append(errs, err)
+	}
+	if wtState == stateUnknown {
+		// The worktree action was cut off mid-flight, so the workspace is still
+		// (partly) on disk. finalize would clear the tmux refs and the gitWorktree
+		// pointer — the exact state a retry needs — and a later retry would then
+		// find no workspace, "succeed", and drop the record, orphaning the leftovers
+		// forever. Skip it and report, same rule as the pane gate above.
+		errs = append(errs, fmt.Errorf("%w: leaving %q's session state intact so the cleanup can be retried", ErrWorkspaceStateUnknown, title))
+		return errors.Join(errs...)
 	}
 
 	i.mu.Lock()
@@ -158,34 +224,21 @@ func clearClosedTmuxRefs(closed []closedTab) {
 // keeps the record and retries rather than destroying a workspace on a guess.
 type teardownKill struct{}
 
-func (teardownKill) closeTab(ts *tmux.TmuxSession, title, tabName string) error {
-	// Wait for the pane to exit before the worktree delete in handleWorktree: a
-	// process still flushing state mid-shutdown races git's recursive delete and
-	// leaks a half-deleted directory ("Directory not empty", #802). Best-effort.
-	err := ts.CloseAndWaitForPaneExit()
-	if err == nil {
-		return nil
-	}
-	// A TIMEOUT is not an ordinary tmux failure and must not be swallowed like one
-	// (#1917). Every other failure here means tmux ANSWERED and the session is
-	// gone or unkillable — teardown's goal either way, so #478's best-effort
-	// contract holds and the kill proceeds. A timeout means the server never
-	// answered, so the pane may still be alive; the core refuses to touch the
-	// worktree on that, and the caller retries.
-	if errors.Is(err, tmux.ErrTmuxTimeout) {
-		return fmt.Errorf("kill %q: tab %q: %w", title, tabName, err)
-	}
-	log.WarningLog.Printf("kill %q: tmux cleanup for tab %q failed: %v", title, tabName, err)
-	return nil
+// closeTab waits for the pane to exit before the worktree delete in
+// handleWorktree: a process still flushing state mid-shutdown races git's
+// recursive delete and leaves a half-deleted directory ("Directory not empty",
+// #802). Best-effort for anything tmux ANSWERED with; an unknown stops the core.
+func (teardownKill) closeTab(ts *tmux.TmuxSession, title, tabName string) (teardownState, error) {
+	return closeTabForDestructiveTeardown(ts, "kill", title, tabName)
 }
 
-func (teardownKill) handleWorktree(gw *git.GitWorktree, title string) error {
+func (teardownKill) handleWorktree(gw *git.GitWorktree, title string) (teardownState, error) {
 	if gw == nil {
-		return nil
+		return stateKnown, nil
 	}
 	err := gw.Cleanup()
 	if err == nil {
-		return nil
+		return stateKnown, nil
 	}
 	// Same rule as closeTab, one layer down (#1917). A git command that ANSWERED
 	// with a failure leaves Cleanup's #802/#726 decision tree in charge and stays
@@ -196,10 +249,10 @@ func (teardownKill) handleWorktree(gw *git.GitWorktree, title string) error {
 	// cleanup can be retried, instead of orphaning a registered worktree whose
 	// session row we just deleted.
 	if errors.Is(err, context.DeadlineExceeded) {
-		return fmt.Errorf("kill %q: git worktree cleanup: %w", title, err)
+		return stateUnknown, fmt.Errorf("kill %q: git worktree cleanup: %w", title, err)
 	}
 	log.WarningLog.Printf("kill %q: git worktree cleanup failed: %v", title, err)
-	return nil
+	return stateKnown, nil
 }
 
 func (teardownKill) clearsStarted() bool { return true }
@@ -220,14 +273,20 @@ func (teardownKill) finalize(i *Instance, closed []closedTab, gw *git.GitWorktre
 // errors are collected and returned (not merely logged).
 type teardownReleasePTY struct{}
 
-func (teardownReleasePTY) closeTab(ts *tmux.TmuxSession, _, tabName string) error {
+// closeTab is always stateKnown: CloseAttachOnly runs no tmux command (it only
+// releases what this object opened, and post-#1592-PR7 that is nothing), so there
+// is no deadline to trip and nothing to be unknown about. This mode touches no
+// worktree either way.
+func (teardownReleasePTY) closeTab(ts *tmux.TmuxSession, _, tabName string) (teardownState, error) {
 	if err := ts.CloseAttachOnly(); err != nil {
-		return fmt.Errorf("tab %q: %w", tabName, err)
+		return stateKnown, fmt.Errorf("tab %q: %w", tabName, err)
 	}
-	return nil
+	return stateKnown, nil
 }
 
-func (teardownReleasePTY) handleWorktree(_ *git.GitWorktree, _ string) error { return nil }
+func (teardownReleasePTY) handleWorktree(_ *git.GitWorktree, _ string) (teardownState, error) {
+	return stateKnown, nil
+}
 
 func (teardownReleasePTY) clearsStarted() bool { return true }
 
@@ -249,20 +308,29 @@ func (teardownReleasePTY) finalize(_ *Instance, closed []closedTab, _ *git.GitWo
 // loop.
 type teardownArchive struct{ dest string }
 
-func (teardownArchive) closeTab(ts *tmux.TmuxSession, title, tabName string) error {
-	// Wait for the pane to exit before handleWorktree relocates the worktree: a
-	// process still flushing state races the move otherwise (#802). Best-effort.
-	if err := ts.CloseAndWaitForPaneExit(); err != nil {
-		log.WarningLog.Printf("archive %q: tmux teardown for tab %q failed: %v", title, tabName, err)
-	}
-	return nil
+// closeTab waits for the pane to exit before handleWorktree relocates the
+// worktree: a process still flushing state races the move otherwise (#802).
+//
+// It shares closeTabForDestructiveTeardown with kill rather than open-coding the
+// same handling, because it needs the SAME guarantee: this path used to log every
+// close error — timeouts included — and return nil, so a wedged tmux server led
+// straight into moving a live agent's workspace out from under it. Archive is the
+// default reap action, so that ran far more often than the kill path did (#1917
+// review).
+func (teardownArchive) closeTab(ts *tmux.TmuxSession, title, tabName string) (teardownState, error) {
+	return closeTabForDestructiveTeardown(ts, "archive", title, tabName)
 }
 
-func (m teardownArchive) handleWorktree(gw *git.GitWorktree, title string) error {
+func (m teardownArchive) handleWorktree(gw *git.GitWorktree, title string) (teardownState, error) {
 	if gw == nil {
-		return fmt.Errorf("cannot archive %q: instance has no worktree to relocate", title)
+		return stateKnown, fmt.Errorf("cannot archive %q: instance has no worktree to relocate", title)
 	}
-	return gw.MoveWorktree(m.dest)
+	// stateKnown either way: MoveWorktree runs on the UNBOUNDED local-git runner,
+	// so it cannot report an unknown — it either moves or answers with an error the
+	// daemon rolls the session back to Lost on, and that rollback (which needs
+	// finalize to have run) is the pre-#1917 contract. If the move is ever bounded,
+	// a tripped deadline must return stateUnknown here.
+	return stateKnown, gw.MoveWorktree(m.dest)
 }
 
 func (teardownArchive) clearsStarted() bool { return false }

--- a/session/teardown.go
+++ b/session/teardown.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -33,11 +34,15 @@ type teardownMode interface {
 	// closeTab tears down one tab's tmux session, OUTSIDE i.mu. It returns an
 	// error for the core to join into teardownTabs' result (release-PTY surfaces
 	// its per-tab errors), or nil after best-effort logging (kill/archive only
-	// log a stuck tmux so the record can still be dropped).
+	// log a tmux that ANSWERED with a failure, so the record can still be
+	// dropped). An error wrapping tmux.ErrTmuxTimeout is special: the core reads
+	// it as "this pane may still be alive" and skips the worktree action entirely
+	// (#1917) — so a mode must return, never swallow, a timeout.
 	closeTab(ts *tmux.TmuxSession, title, tabName string) error
-	// handleWorktree performs the mode's worktree action once every pane has
-	// exited: delete (kill), move (archive — returns the move error for the
-	// caller to roll back on), or nothing (release-PTY). gw may be nil.
+	// handleWorktree performs the mode's worktree action once every pane is
+	// CONFIRMED exited: delete (kill), move (archive — returns the move error for
+	// the caller to roll back on), or nothing (release-PTY). gw may be nil. Not
+	// called at all when a closeTab reported a possibly-live pane.
 	handleWorktree(gw *git.GitWorktree, title string) error
 	// clearsStarted reports whether started is set false before teardown. Kill
 	// and release-PTY clear it (so the #990 tab-spawn guard fires); archive keeps
@@ -59,12 +64,31 @@ type closedTab struct {
 	ts  *tmux.TmuxSession
 }
 
+// ErrPaneMayBeLive reports that tmux never confirmed a session dead — the server
+// did not answer within its deadline — so the pane may still be RUNNING.
+//
+// It is the difference between "tmux says the session is gone" and "tmux did not
+// say anything". The first is teardown's goal and is best-effort by design
+// (#478/#967); the second is an unknown, and the worktree step is not safe to run
+// on an unknown: deleting (kill) or moving (archive) the workspace of an agent
+// that is still writing to it destroys the user's work on a guess. Callers must
+// treat this as "retry later", never as "the tmux part failed, carry on".
+var ErrPaneMayBeLive = errors.New("tmux did not confirm the session is dead; its pane may still be running")
+
 // teardownTabs runs the one teardown skeleton for the given mode. It snapshots
 // each tab's tmux under i.mu, tears them down OUTSIDE the lock (closing under
 // i.mu would stall every reader while a pane drains), performs the mode's
 // worktree action while no pane is cwd'd in the worktree, then re-locks and lets
 // the mode finalize the tab/worktree state. Errors from closeTab/handleWorktree
 // are joined and returned.
+//
+// The worktree step is GATED on every pane being confirmed dead (#1917). Bounding
+// the tmux commands means they can now return "I don't know" instead of blocking
+// forever, and an unknown must stop the destructive step rather than be logged
+// and stepped over — otherwise the bound converts a hang (recoverable) into a
+// worktree deleted out from under a live agent (not recoverable). On that path
+// the mode's finalize is skipped too: it clears the tmux refs and the worktree
+// pointer, which are exactly what a retry needs to find intact.
 func (i *Instance) teardownTabs(mode teardownMode) error {
 	i.mu.Lock()
 	closed := make([]closedTab, 0, len(i.Tabs))
@@ -81,10 +105,24 @@ func (i *Instance) teardownTabs(mode teardownMode) error {
 	i.mu.Unlock()
 
 	var errs []error
+	paneMayBeLive := false
 	for _, c := range closed {
-		if err := mode.closeTab(c.ts, title, c.tab.Name); err != nil {
-			errs = append(errs, err)
+		err := mode.closeTab(c.ts, title, c.tab.Name)
+		if err == nil {
+			continue
 		}
+		errs = append(errs, err)
+		if errors.Is(err, tmux.ErrTmuxTimeout) {
+			paneMayBeLive = true
+		}
+	}
+	if paneMayBeLive {
+		// Do NOT touch the worktree and do NOT finalize: a pane we could not
+		// confirm dead may still be running in it. Leaving the refs intact keeps
+		// the session exactly retryable — the caller holds the record so the whole
+		// teardown runs again once tmux answers.
+		errs = append(errs, fmt.Errorf("%w: leaving %q's workspace untouched", ErrPaneMayBeLive, title))
+		return errors.Join(errs...)
 	}
 	if err := mode.handleWorktree(gw, title); err != nil {
 		errs = append(errs, err)
@@ -113,24 +151,54 @@ func clearClosedTmuxRefs(closed []closedTab) {
 // the worktree pointer. started is cleared. Best-effort — a stuck tmux or a
 // failed worktree cleanup only logs, so the caller can still drop the record
 // (#478).
+//
+// "Best-effort" covers failures tmux and git ANSWERED with. It does NOT cover a
+// tripped deadline (#1917): a timeout leaves the pane's liveness or the
+// worktree's removal genuinely unknown, and this mode reports those so the caller
+// keeps the record and retries rather than destroying a workspace on a guess.
 type teardownKill struct{}
 
 func (teardownKill) closeTab(ts *tmux.TmuxSession, title, tabName string) error {
 	// Wait for the pane to exit before the worktree delete in handleWorktree: a
 	// process still flushing state mid-shutdown races git's recursive delete and
 	// leaks a half-deleted directory ("Directory not empty", #802). Best-effort.
-	if err := ts.CloseAndWaitForPaneExit(); err != nil {
-		log.WarningLog.Printf("kill %q: tmux cleanup for tab %q failed: %v", title, tabName, err)
+	err := ts.CloseAndWaitForPaneExit()
+	if err == nil {
+		return nil
 	}
+	// A TIMEOUT is not an ordinary tmux failure and must not be swallowed like one
+	// (#1917). Every other failure here means tmux ANSWERED and the session is
+	// gone or unkillable — teardown's goal either way, so #478's best-effort
+	// contract holds and the kill proceeds. A timeout means the server never
+	// answered, so the pane may still be alive; the core refuses to touch the
+	// worktree on that, and the caller retries.
+	if errors.Is(err, tmux.ErrTmuxTimeout) {
+		return fmt.Errorf("kill %q: tab %q: %w", title, tabName, err)
+	}
+	log.WarningLog.Printf("kill %q: tmux cleanup for tab %q failed: %v", title, tabName, err)
 	return nil
 }
 
 func (teardownKill) handleWorktree(gw *git.GitWorktree, title string) error {
-	if gw != nil {
-		if err := gw.Cleanup(); err != nil {
-			log.WarningLog.Printf("kill %q: git worktree cleanup failed: %v", title, err)
-		}
+	if gw == nil {
+		return nil
 	}
+	err := gw.Cleanup()
+	if err == nil {
+		return nil
+	}
+	// Same rule as closeTab, one layer down (#1917). A git command that ANSWERED
+	// with a failure leaves Cleanup's #802/#726 decision tree in charge and stays
+	// best-effort, so a stuck-but-diagnosed worktree never blocks dropping the
+	// record. A TIMEOUT is different in kind: git was SIGKILLed mid-delete, so the
+	// worktree directory and its registration may both still be there. Reporting it
+	// keeps the record — and with it the user's handle on the session — so the
+	// cleanup can be retried, instead of orphaning a registered worktree whose
+	// session row we just deleted.
+	if errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Errorf("kill %q: git worktree cleanup: %w", title, err)
+	}
+	log.WarningLog.Printf("kill %q: git worktree cleanup failed: %v", title, err)
 	return nil
 }
 

--- a/session/teardown_gate_test.go
+++ b/session/teardown_gate_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
@@ -22,23 +23,48 @@ import (
 // gateStubMode records what the teardown core invoked. closeTab returns a
 // caller-supplied error so each test can drive one classification.
 type gateStubMode struct {
+	closeState       teardownState
 	closeErr         error
+	worktreeState    teardownState
 	worktreeCalled   bool
 	finalizeCalled   bool
 	clearStartedFlag bool
 }
 
-func (m *gateStubMode) closeTab(_ *tmux.TmuxSession, _, _ string) error { return m.closeErr }
+func (m *gateStubMode) closeTab(_ *tmux.TmuxSession, _, _ string) (teardownState, error) {
+	return m.closeState, m.closeErr
+}
 
-func (m *gateStubMode) handleWorktree(_ *git.GitWorktree, _ string) error {
+func (m *gateStubMode) handleWorktree(_ *git.GitWorktree, _ string) (teardownState, error) {
 	m.worktreeCalled = true
-	return nil
+	return m.worktreeState, nil
 }
 
 func (m *gateStubMode) clearsStarted() bool { return m.clearStartedFlag }
 
 func (m *gateStubMode) finalize(_ *Instance, _ []closedTab, _ *git.GitWorktree) {
 	m.finalizeCalled = true
+}
+
+// wedgedTmuxSession returns a TmuxSession whose server never answers kill-session,
+// so the bound trips and the state comes back unknown. panePID/list-panes answer
+// immediately, so exactly ONE tmuxCommandTimeout elapses per teardown.
+//
+// A mock that merely returned an error would prove nothing: the unknown state is
+// derived from ctx.Err(), so the deadline has to actually elapse. tmuxCommandTimeout
+// is unexported to this package and cannot be shortened from here, which is what
+// these tests pay 10s for.
+func wedgedTmuxSession(name string) *tmux.TmuxSession {
+	wedged := cmd_test.MockCmdExec{
+		RunFunc: func(*exec.Cmd) error {
+			time.Sleep(11 * time.Second)
+			return fmt.Errorf("wedged tmux server never answered")
+		},
+		OutputFunc: func(*exec.Cmd) ([]byte, error) {
+			return nil, fmt.Errorf("wedged tmux server never answered")
+		},
+	}
+	return tmux.NewTmuxSessionWithDeps(name, "claude", nil, wedged)
 }
 
 func instanceWithTmuxTab(t *testing.T, ts *tmux.TmuxSession) *Instance {
@@ -58,7 +84,8 @@ func instanceWithTmuxTab(t *testing.T, ts *tmux.TmuxSession) *Instance {
 // deleting the worktree of an agent that may still have been running in it.
 func TestTeardownTabs_PaneMayBeLive_SkipsTheWorktreeStep(t *testing.T) {
 	mode := &gateStubMode{
-		closeErr: fmt.Errorf("tab %q: %w: kill-session after 10s", "agent", tmux.ErrTmuxTimeout),
+		closeState: stateUnknown,
+		closeErr:   fmt.Errorf("tab %q: %w: kill-session after 10s", "agent", tmux.ErrTmuxTimeout),
 	}
 	inst := instanceWithTmuxTab(t, &tmux.TmuxSession{})
 
@@ -91,7 +118,7 @@ func TestTeardownTabs_PaneMayBeLive_SkipsTheWorktreeStep(t *testing.T) {
 // goal either way — and #478's best-effort contract must still hold, or a stuck
 // session becomes undeletable again.
 func TestTeardownTabs_ConfirmedTmuxFailure_StillProceeds(t *testing.T) {
-	mode := &gateStubMode{closeErr: nil} // teardownKill swallows answered failures
+	mode := &gateStubMode{closeState: stateKnown, closeErr: nil} // an ANSWERED tmux failure
 	inst := instanceWithTmuxTab(t, &tmux.TmuxSession{})
 
 	if err := inst.teardownTabs(mode); err != nil {
@@ -122,25 +149,91 @@ func TestTeardownKill_ClassifiesTmuxTimeoutAsUnsafe(t *testing.T) {
 	if testing.Short() {
 		t.Skip("costs one real 10s tmux deadline")
 	}
-	wedged := cmd_test.MockCmdExec{
-		// kill-session: never answers, so the bound trips and ctx.Err() is set.
-		RunFunc: func(*exec.Cmd) error {
-			time.Sleep(11 * time.Second)
-			return fmt.Errorf("wedged tmux server never answered")
-		},
-		// panePID / list-panes: answer immediately so only ONE deadline elapses.
-		OutputFunc: func(*exec.Cmd) ([]byte, error) {
-			return nil, fmt.Errorf("wedged tmux server never answered")
-		},
-	}
-	ts := tmux.NewTmuxSessionWithDeps("wedged-1917", "claude", nil, wedged)
+	ts := wedgedTmuxSession("wedged-kill-1917")
 
-	err := teardownKill{}.closeTab(ts, "guarded", "agent")
-	if err == nil {
-		t.Fatal("teardownKill swallowed a tmux TIMEOUT: the core then deletes the worktree of a " +
-			"session tmux never confirmed dead (#1917). A timeout is not an ordinary best-effort failure.")
+	state, err := teardownKill{}.closeTab(ts, "guarded", "agent")
+	if state != stateUnknown {
+		t.Fatal("teardownKill reported a KNOWN state for a tmux TIMEOUT: the core then deletes the " +
+			"worktree of a session tmux never confirmed dead (#1917). A timeout is not an ordinary " +
+			"best-effort failure.")
 	}
-	if !errors.Is(err, tmux.ErrTmuxTimeout) {
-		t.Fatalf("the returned error must stay identifiable as a tmux timeout so the core can gate on it, got: %v", err)
+	if err == nil || !errors.Is(err, tmux.ErrTmuxTimeout) {
+		t.Fatalf("the error must stay identifiable as a tmux timeout for the caller's message, got: %v", err)
+	}
+}
+
+// TestTeardownTabs_ArchivePaneMayBeLive_SkipsTheMove is finding (1) of the second
+// review: the archive path never got the kill path's gate.
+//
+// It matters MORE than the kill path, not less: archive is the default reap
+// action, so it runs constantly. handleWorktree is where MoveWorktree lives, and
+// it also rejects a nil worktree — so proving it never ran is exactly proving the
+// move never happened.
+//
+// PRE-FIX BEHAVIOR THIS REPRODUCES: teardownArchive.closeTab logged every
+// CloseAndWaitForPaneExit error and returned nil, so the core moved the worktree
+// of a session tmux had never confirmed dead.
+func TestTeardownTabs_ArchivePaneMayBeLive_SkipsTheMove(t *testing.T) {
+	if testing.Short() {
+		t.Skip("costs one real 10s tmux deadline")
+	}
+	inst := instanceWithTmuxTab(t, wedgedTmuxSession("wedged-archive-1917"))
+	inst.gitWorktree = nil // handleWorktree would REJECT this; the gate must run first
+
+	err := inst.teardownTabs(teardownArchive{dest: t.TempDir()})
+
+	if err == nil {
+		t.Fatal("archive reported success though tmux never confirmed the pane was dead")
+	}
+	if !errors.Is(err, ErrPaneMayBeLive) {
+		t.Fatalf("archive must report a possibly-live pane so the daemon rolls back and retries, got: %v", err)
+	}
+	// If handleWorktree had run it would have returned "cannot archive … no worktree
+	// to relocate". Its absence proves MoveWorktree was never reached.
+	if strings.Contains(err.Error(), "cannot archive") {
+		t.Fatal("handleWorktree ran despite tmux never confirming the pane was dead: on a wedged " +
+			"tmux server this MOVES the workspace out from under a live agent (#1917 review)")
+	}
+	if inst.Tabs[0].tmux == nil {
+		t.Fatal("the tab's tmux ref was cleared, so a retried archive has nothing to tear down")
+	}
+}
+
+// TestTeardownTabs_WorktreeStateUnknown_SkipsFinalize is finding (3): a git
+// cleanup cut off by its deadline leaves the workspace half-removed, so finalize
+// must not run.
+//
+// finalize clears the tmux refs and the gitWorktree pointer. If it runs, a later
+// retry finds no workspace, concludes there is nothing to do, "succeeds", and
+// deletes the record — orphaning the partially-removed worktree forever, with
+// nothing left pointing at it.
+//
+// PRE-FIX BEHAVIOR THIS REPRODUCES: the core ran finalize unconditionally after
+// handleWorktree, so the retain-the-tombstone fix bought nothing.
+func TestTeardownTabs_WorktreeStateUnknown_SkipsFinalize(t *testing.T) {
+	mode := &gateStubMode{closeState: stateKnown, worktreeState: stateUnknown}
+	inst := instanceWithTmuxTab(t, &tmux.TmuxSession{})
+	gw := &git.GitWorktree{}
+	inst.gitWorktree = gw
+
+	err := inst.teardownTabs(mode)
+
+	if !mode.worktreeCalled {
+		t.Fatal("the worktree action must run when the panes are confirmed dead")
+	}
+	if err == nil || !errors.Is(err, ErrWorkspaceStateUnknown) {
+		t.Fatalf("a cut-off worktree action must be reported so the caller keeps the record, got: %v", err)
+	}
+	if mode.finalizeCalled {
+		t.Fatal("finalize ran after a worktree action that was cut off mid-flight: it clears the " +
+			"refs a retry needs, so the retry sees no workspace, 'succeeds', and drops the record — " +
+			"orphaning the half-removed worktree forever (#1917 review)")
+	}
+	// The retry must still find the workspace it has to finish removing.
+	if inst.gitWorktree != gw {
+		t.Fatal("the worktree pointer was cleared; the retry has lost the workspace")
+	}
+	if inst.Tabs[0].tmux == nil {
+		t.Fatal("the tab's tmux ref was cleared; the retry has lost the session")
 	}
 }

--- a/session/teardown_gate_test.go
+++ b/session/teardown_gate_test.go
@@ -84,8 +84,9 @@ func instanceWithTmuxTab(t *testing.T, ts *tmux.TmuxSession) *Instance {
 // deleting the worktree of an agent that may still have been running in it.
 func TestTeardownTabs_PaneMayBeLive_SkipsTheWorktreeStep(t *testing.T) {
 	mode := &gateStubMode{
-		closeState: stateUnknown,
-		closeErr:   fmt.Errorf("tab %q: %w: kill-session after 10s", "agent", tmux.ErrTmuxTimeout),
+		closeState:    stateUnknown,
+		worktreeState: stateKnown, // irrelevant here: the pane gate must fire first
+		closeErr:      fmt.Errorf("tab %q: %w: kill-session after 10s", "agent", tmux.ErrTmuxTimeout),
 	}
 	inst := instanceWithTmuxTab(t, &tmux.TmuxSession{})
 
@@ -118,7 +119,10 @@ func TestTeardownTabs_PaneMayBeLive_SkipsTheWorktreeStep(t *testing.T) {
 // goal either way — and #478's best-effort contract must still hold, or a stuck
 // session becomes undeletable again.
 func TestTeardownTabs_ConfirmedTmuxFailure_StillProceeds(t *testing.T) {
-	mode := &gateStubMode{closeState: stateKnown, closeErr: nil} // an ANSWERED tmux failure
+	// worktreeState must be set EXPLICITLY: its zero value is stateUnknown now, so a
+	// mode that forgets it refuses to destroy. That default is the point (#1917) —
+	// this stub forgetting it is what a real mode forgetting it would look like.
+	mode := &gateStubMode{closeState: stateKnown, worktreeState: stateKnown, closeErr: nil}
 	inst := instanceWithTmuxTab(t, &tmux.TmuxSession{})
 
 	if err := inst.teardownTabs(mode); err != nil {

--- a/session/teardown_gate_test.go
+++ b/session/teardown_gate_test.go
@@ -1,0 +1,146 @@
+package session
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	"github.com/sachiniyer/agent-factory/session/git"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// The #1917 follow-up locks: bounding the teardown's tmux commands means they can
+// now answer "I don't know" instead of blocking forever — and an unknown must STOP
+// the worktree step, not be logged and stepped over.
+//
+// Getting this wrong is worse than the bug the bound fixes: a kill that hangs is
+// recoverable, a kill that deletes a live agent's worktree is not.
+
+// gateStubMode records what the teardown core invoked. closeTab returns a
+// caller-supplied error so each test can drive one classification.
+type gateStubMode struct {
+	closeErr         error
+	worktreeCalled   bool
+	finalizeCalled   bool
+	clearStartedFlag bool
+}
+
+func (m *gateStubMode) closeTab(_ *tmux.TmuxSession, _, _ string) error { return m.closeErr }
+
+func (m *gateStubMode) handleWorktree(_ *git.GitWorktree, _ string) error {
+	m.worktreeCalled = true
+	return nil
+}
+
+func (m *gateStubMode) clearsStarted() bool { return m.clearStartedFlag }
+
+func (m *gateStubMode) finalize(_ *Instance, _ []closedTab, _ *git.GitWorktree) {
+	m.finalizeCalled = true
+}
+
+func instanceWithTmuxTab(t *testing.T, ts *tmux.TmuxSession) *Instance {
+	t.Helper()
+	return &Instance{
+		Title: "guarded",
+		Tabs:  []*Tab{{ID: "tab-1", Name: agentTabName, Kind: TabKindAgent, tmux: ts}},
+	}
+}
+
+// TestTeardownTabs_PaneMayBeLive_SkipsTheWorktreeStep is the gate itself: a tmux
+// TIMEOUT means the pane's liveness is UNKNOWN, so the worktree action — delete
+// for kill, move for archive — must not run at all.
+//
+// PRE-FIX BEHAVIOR THIS REPRODUCES: the core called handleWorktree
+// unconditionally after closeTab, so a wedged tmux server led straight to
+// deleting the worktree of an agent that may still have been running in it.
+func TestTeardownTabs_PaneMayBeLive_SkipsTheWorktreeStep(t *testing.T) {
+	mode := &gateStubMode{
+		closeErr: fmt.Errorf("tab %q: %w: kill-session after 10s", "agent", tmux.ErrTmuxTimeout),
+	}
+	inst := instanceWithTmuxTab(t, &tmux.TmuxSession{})
+
+	err := inst.teardownTabs(mode)
+
+	if mode.worktreeCalled {
+		t.Fatal("the worktree action ran after tmux FAILED TO CONFIRM the pane was dead: " +
+			"on a wedged tmux server this deletes (kill) or moves (archive) the workspace of " +
+			"an agent that may still be running in it — data loss on a guess (#1917)")
+	}
+	if err == nil {
+		t.Fatal("teardown reported success despite never confirming the pane was dead")
+	}
+	if !errors.Is(err, ErrPaneMayBeLive) {
+		t.Fatalf("teardown error must be identifiable as a possibly-live pane so callers keep the record and retry, got: %v", err)
+	}
+	// finalize clears the tmux refs and the worktree pointer — exactly what a retry
+	// needs to find intact.
+	if mode.finalizeCalled {
+		t.Fatal("finalize ran on the unsafe path; it clears the tmux refs a retry depends on")
+	}
+	if inst.Tabs[0].tmux == nil {
+		t.Fatal("the tab's tmux ref was cleared, so a retry has nothing left to kill")
+	}
+}
+
+// TestTeardownTabs_ConfirmedTmuxFailure_StillProceeds guards the other side, so
+// the fix above cannot quietly become "any tmux hiccup blocks the kill". A tmux
+// that ANSWERED with a failure means the session is gone or unkillable — teardown's
+// goal either way — and #478's best-effort contract must still hold, or a stuck
+// session becomes undeletable again.
+func TestTeardownTabs_ConfirmedTmuxFailure_StillProceeds(t *testing.T) {
+	mode := &gateStubMode{closeErr: nil} // teardownKill swallows answered failures
+	inst := instanceWithTmuxTab(t, &tmux.TmuxSession{})
+
+	if err := inst.teardownTabs(mode); err != nil {
+		t.Fatalf("an answered tmux failure must stay best-effort (#478), got: %v", err)
+	}
+	if !mode.worktreeCalled {
+		t.Fatal("the worktree action was skipped for a CONFIRMED-dead pane; the kill would never complete")
+	}
+	if !mode.finalizeCalled {
+		t.Fatal("finalize must run on the normal path")
+	}
+}
+
+// TestTeardownKill_ClassifiesTmuxTimeoutAsUnsafe drives the REAL teardownKill
+// against a REAL TmuxSession whose tmux never answers, proving the production
+// mode surfaces the timeout rather than swallowing it into a log line. Without
+// this the gate above would sit behind a mode that never reports.
+//
+// It costs one real tmuxCommandTimeout (10s): the deadline is what produces
+// ErrTmuxTimeout, and tmuxCommandTimeout is unexported to this package so it
+// cannot be shortened from here. A mock that merely returns an error would prove
+// nothing — the classification keys off ctx.Err(), so the deadline has to elapse.
+//
+// PRE-FIX BEHAVIOR THIS REPRODUCES: teardownKill.closeTab logged every
+// CloseAndWaitForPaneExit error and returned nil, so the timeout never reached
+// the core and the worktree step ran anyway.
+func TestTeardownKill_ClassifiesTmuxTimeoutAsUnsafe(t *testing.T) {
+	if testing.Short() {
+		t.Skip("costs one real 10s tmux deadline")
+	}
+	wedged := cmd_test.MockCmdExec{
+		// kill-session: never answers, so the bound trips and ctx.Err() is set.
+		RunFunc: func(*exec.Cmd) error {
+			time.Sleep(11 * time.Second)
+			return fmt.Errorf("wedged tmux server never answered")
+		},
+		// panePID / list-panes: answer immediately so only ONE deadline elapses.
+		OutputFunc: func(*exec.Cmd) ([]byte, error) {
+			return nil, fmt.Errorf("wedged tmux server never answered")
+		},
+	}
+	ts := tmux.NewTmuxSessionWithDeps("wedged-1917", "claude", nil, wedged)
+
+	err := teardownKill{}.closeTab(ts, "guarded", "agent")
+	if err == nil {
+		t.Fatal("teardownKill swallowed a tmux TIMEOUT: the core then deletes the worktree of a " +
+			"session tmux never confirmed dead (#1917). A timeout is not an ordinary best-effort failure.")
+	}
+	if !errors.Is(err, tmux.ErrTmuxTimeout) {
+		t.Fatalf("the returned error must stay identifiable as a tmux timeout so the core can gate on it, got: %v", err)
+	}
+}

--- a/session/tmux/bounded.go
+++ b/session/tmux/bounded.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 	"syscall"
 	"time"
+
+	"github.com/sachiniyer/agent-factory/cmd"
 )
 
 // Bounded tmux control commands (#1787).
@@ -31,6 +33,14 @@ import (
 // captureMu hold finite, so no lock restructuring is needed. CapturePaneContentContext
 // already established the exec.CommandContext pattern here; this generalizes it
 // for the commands that had no context to thread.
+//
+// #1917 extended the same treatment to the TEARDOWN commands (kill-session,
+// has-session, display-message #{pane_pid}, list-panes), which had stayed on bare
+// exec.Command. daemon.KillSession runs the whole teardown with no deadline of its
+// own while holding a per-session kills-in-flight guard, so a single unbounded tmux
+// call there does not merely stall one kill: it makes that session permanently
+// undeletable for the daemon's entire lifetime. Every tmux command in this package
+// is now bounded; new ones must be too.
 //
 // A var (not a const) only so tests can shorten it; production never reassigns.
 var tmuxCommandTimeout = 10 * time.Second
@@ -87,20 +97,33 @@ func reapTmuxGroup(cmd *exec.Cmd) {
 	}
 }
 
+// runTmuxBoundedWith runs a tmux command under ctx against an explicit executor,
+// discarding output. The receiver-less teardown helpers (sessionExists,
+// SessionProcessTrees) are handed a cmd.Executor rather than a TmuxSession, so
+// they cannot use the methods below; this is the same body they share.
+func runTmuxBoundedWith(ctx context.Context, cmdExec cmd.Executor, args ...string) error {
+	c := boundedTmuxCommand(ctx, args...)
+	err := cmdExec.Run(c)
+	reapTmuxGroup(c)
+	return normalizeWaitDelay(err)
+}
+
+// outputTmuxBoundedWith is outputTmuxBounded against an explicit executor.
+func outputTmuxBoundedWith(ctx context.Context, cmdExec cmd.Executor, args ...string) ([]byte, error) {
+	c := boundedTmuxCommand(ctx, args...)
+	out, err := cmdExec.Output(c)
+	reapTmuxGroup(c)
+	return out, normalizeWaitDelay(err)
+}
+
 // runTmuxBounded runs a tmux command under tmuxCommandTimeout, discarding output.
 func (t *TmuxSession) runTmuxBounded(ctx context.Context, args ...string) error {
-	cmd := boundedTmuxCommand(ctx, args...)
-	err := t.cmdExec.Run(cmd)
-	reapTmuxGroup(cmd)
-	return normalizeWaitDelay(err)
+	return runTmuxBoundedWith(ctx, t.cmdExec, args...)
 }
 
 // outputTmuxBounded runs a tmux command under tmuxCommandTimeout and returns stdout.
 func (t *TmuxSession) outputTmuxBounded(ctx context.Context, args ...string) ([]byte, error) {
-	cmd := boundedTmuxCommand(ctx, args...)
-	out, err := t.cmdExec.Output(cmd)
-	reapTmuxGroup(cmd)
-	return out, normalizeWaitDelay(err)
+	return outputTmuxBoundedWith(ctx, t.cmdExec, args...)
 }
 
 // normalizeWaitDelay converts an exec.ErrWaitDelay into success: tmux itself

--- a/session/tmux/cleanup.go
+++ b/session/tmux/cleanup.go
@@ -44,19 +44,39 @@ func (t *TmuxSession) DoesSessionExist() bool {
 // or any other tmux error — still reports false, preserving the pre-#1917
 // conflation callers already relied on.
 func sessionExists(cmdExec cmd.Executor, name string) bool {
+	exists, known := probeSession(cmdExec, name)
+	if !known {
+		log.WarningLog.Printf("tmux has-session for %s timed out after %s; the server is wedged, so "+
+			"reporting the session as still present rather than risk a false teardown", name, tmuxCommandTimeout)
+		return true
+	}
+	return exists
+}
+
+// probeSession is sessionExists WITHOUT the lossy collapse: it reports whether
+// the session exists AND whether tmux actually answered.
+//
+// The two-value form exists because the collapse above, while safe for the
+// probe's many read-only callers, silently destroyed information for the one
+// caller that tears sessions down: Close asked "does it still exist?", got back
+// a `true` synthesized from a TIMEOUT, and reported an ordinary kill failure —
+// so its caller deleted the workspace with the session's fate unknown (#1917).
+// A caller that acts on the answer takes this form and handles !known; a caller
+// that only reads takes the bool and gets the conservative lie.
+func probeSession(cmdExec cmd.Executor, name string) (exists bool, known bool) {
 	ctx, cancel := tmuxTimeoutContext()
 	defer cancel()
 	// Using "-t name" does a prefix match, which is wrong. `-t=` does an exact match.
 	err := runTmuxBoundedWith(ctx, cmdExec, "has-session", fmt.Sprintf("-t=%s", name))
 	if err == nil {
-		return true
+		return true, true
 	}
 	if ctx.Err() != nil {
-		log.WarningLog.Printf("tmux has-session for %s timed out after %s; the server is wedged, so "+
-			"reporting the session as still present rather than risk a false teardown", name, tmuxCommandTimeout)
-		return true
+		return false, false
 	}
-	return false
+	// tmux answered: the usual `has-session` exit 1 for "no such session", or any
+	// other error, which this probe has always conflated with absence.
+	return false, true
 }
 
 // exactTarget builds an exact-match `-t` target spec for the named session.

--- a/session/tmux/cleanup.go
+++ b/session/tmux/cleanup.go
@@ -53,6 +53,20 @@ func sessionExists(cmdExec cmd.Executor, name string) bool {
 	return exists
 }
 
+// ProbeSession reports whether this session exists AND whether tmux actually
+// ANSWERED — the tri-state a bool cannot express (#1917 round 8).
+//
+// DoesSessionExist has to pick yes or no, so a timed-out probe becomes "yes": the
+// conservative lie, safe for the read-only callers that only ever act on "no". But
+// it launders UNKNOWN into AFFIRMATIVE at the bottom of the stack, and every caller
+// above is then downstream of a lie it cannot detect — which is how a wedged tmux
+// server came to be reported as a live agent, and how a liveness counter built on
+// affirmative evidence got fooled anyway. Callers that treat "alive" as EVIDENCE
+// must take this form; callers that merely need a bool keep the lie, knowingly.
+func (t *TmuxSession) ProbeSession() (exists bool, known bool) {
+	return probeSession(t.cmdExec, t.sanitizedName)
+}
+
 // probeSession is sessionExists WITHOUT the lossy collapse: it reports whether
 // the session exists AND whether tmux actually answered.
 //

--- a/session/tmux/cleanup.go
+++ b/session/tmux/cleanup.go
@@ -21,10 +21,42 @@ func (t *TmuxSession) DoesSessionExist() bool {
 // sessionExists reports whether a tmux session with the exact name `name`
 // currently exists. Shared by DoesSessionExist and the receiver-less
 // CleanupSessions path so both probe identically.
+//
+// Bounded by tmuxCommandTimeout (#1917): has-session against a wedged server
+// parks forever, and this probe is the fallback on nearly every tmux error path
+// in the package — including Close's, on the daemon's undeletable-session
+// teardown.
+//
+// A tripped deadline reports TRUE (exists). The bool cannot express "unknown",
+// so the answer has to be the one that is safe to be wrong about, and every
+// caller that acts destructively acts on FALSE: Close reaps the session's
+// process trees, and io.go/clientless.go raise ErrSessionGone, which the daemon
+// reads as a confirmed death. A false "gone" against a server that is merely
+// wedged would SIGKILL a live agent's process tree and tear down a session that
+// is still running — the exact mistake tmuxTimeoutContext exists to prevent. A
+// false "exists" only costs a best-effort skip, so it is the conservative lie.
+//
+// Callers that must not paper over the difference do not use this probe at all:
+// they check ctx.Err() on their own bounded command and skip it entirely (see
+// tmuxTimeoutContext, and Close's kill-session timeout branch).
+//
+// A non-timeout failure — the usual `has-session` exit 1 for "no such session",
+// or any other tmux error — still reports false, preserving the pre-#1917
+// conflation callers already relied on.
 func sessionExists(cmdExec cmd.Executor, name string) bool {
+	ctx, cancel := tmuxTimeoutContext()
+	defer cancel()
 	// Using "-t name" does a prefix match, which is wrong. `-t=` does an exact match.
-	existsCmd := exec.Command("tmux", "has-session", fmt.Sprintf("-t=%s", name))
-	return cmdExec.Run(existsCmd) == nil
+	err := runTmuxBoundedWith(ctx, cmdExec, "has-session", fmt.Sprintf("-t=%s", name))
+	if err == nil {
+		return true
+	}
+	if ctx.Err() != nil {
+		log.WarningLog.Printf("tmux has-session for %s timed out after %s; the server is wedged, so "+
+			"reporting the session as still present rather than risk a false teardown", name, tmuxCommandTimeout)
+		return true
+	}
+	return false
 }
 
 // exactTarget builds an exact-match `-t` target spec for the named session.

--- a/session/tmux/close.go
+++ b/session/tmux/close.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 	"syscall"
@@ -27,15 +26,29 @@ func (t *TmuxSession) Close() error {
 	// (#1104).
 	leaked := SessionProcessTrees(t.cmdExec, t.sanitizedName)
 
-	cmd := exec.Command("tmux", "kill-session", "-t", exactTarget(t.sanitizedName))
-	if err := t.cmdExec.Run(cmd); err != nil {
-		// Idempotent teardown (#967): a kill-session that fails because the
-		// session is already gone has achieved Close's goal — a dead session
-		// is the desired end state. Only a session that survives the kill is a
-		// genuine failure. Probe has-session rather than matching tmux's bare
-		// "exit status 1", which it reuses for unrelated errors. Mirrors the
-		// `_`-ignored cleanup kill in Start (above).
-		if t.DoesSessionExist() {
+	// Bounded by tmuxCommandTimeout (#1917): an unbounded kill-session against a
+	// wedged server blocks daemon.KillSession forever behind its kills-in-flight
+	// guard, leaving the session undeletable until the daemon restarts.
+	ctx, cancel := tmuxTimeoutContext()
+	defer cancel()
+	if err := t.runTmuxBounded(ctx, "kill-session", "-t", exactTarget(t.sanitizedName)); err != nil {
+		switch {
+		case ctx.Err() != nil:
+			// The deadline tripped, so the session's real state is UNKNOWN. Do
+			// NOT probe has-session: it would spawn another tmux command against
+			// the same wedged server and hang identically, defeating the bound we
+			// just came here for (see tmuxTimeoutContext). Report the timeout and
+			// take the conservative branch — a session we cannot confirm dead may
+			// well be alive, and its processes are then not leaks.
+			errs = append(errs, fmt.Errorf("%w: kill-session after %s", ErrTmuxTimeout, tmuxCommandTimeout))
+			leaked = nil
+		case t.DoesSessionExist():
+			// Idempotent teardown (#967): a kill-session that fails because the
+			// session is already gone has achieved Close's goal — a dead session
+			// is the desired end state. Only a session that survives the kill is a
+			// genuine failure. Probe has-session rather than matching tmux's bare
+			// "exit status 1", which it reuses for unrelated errors. Mirrors the
+			// `_`-ignored cleanup kill in Start (above).
 			errs = append(errs, fmt.Errorf("error killing tmux session: %w", err))
 			// The session survived — its processes are not leaks. Do not reap.
 			leaked = nil
@@ -92,6 +105,14 @@ const paneExitWait = 3 * time.Second
 // any directory removal that follows and leaves a half-deleted worktree
 // behind ("Directory not empty", #802). Callers that delete the session's
 // worktree right after teardown must use this instead of Close.
+//
+// paneExitWait bounds ONLY the waitForPIDExit poll below, NOT the whole call —
+// a distinction #1917 was misread on. The tmux commands are what a wedged server
+// stalls, and each carries its own tmuxCommandTimeout: display-message (panePID),
+// then Close's list-panes, kill-session, and at most one has-session probe. So the
+// real worst case is ~4×tmuxCommandTimeout + paneExitWait, all of it finite —
+// which is the property daemon.KillSession needs, since it holds a per-session
+// kills-in-flight guard across this call with no deadline of its own.
 func (t *TmuxSession) CloseAndWaitForPaneExit() error {
 	pid, pidErr := t.panePID()
 	closeErr := t.Close()
@@ -113,9 +134,17 @@ func (t *TmuxSession) panePID() (int, error) {
 	// exactTarget forces an exact session match, mirroring DoesSessionExist.
 	// (The bare `=name` form returns an empty pane_pid for display-message —
 	// the trailing `:` in exactTarget is what makes the pid resolve. See #1006.)
-	cmd := exec.Command("tmux", "display-message", "-p", "-t", exactTarget(t.sanitizedName), "#{pane_pid}")
-	output, err := t.cmdExec.Output(cmd)
+	//
+	// Bounded by tmuxCommandTimeout (#1917): this is the FIRST tmux command on
+	// the kill teardown, so an unbounded stall here wedges the kill before
+	// kill-session is even attempted.
+	ctx, cancel := tmuxTimeoutContext()
+	defer cancel()
+	output, err := t.outputTmuxBounded(ctx, "display-message", "-p", "-t", exactTarget(t.sanitizedName), "#{pane_pid}")
 	if err != nil {
+		if ctx.Err() != nil {
+			return 0, fmt.Errorf("%w: display-message pane_pid after %s", ErrTmuxTimeout, tmuxCommandTimeout)
+		}
 		return 0, fmt.Errorf("failed to query pane pid: %w", err)
 	}
 	pid, err := strconv.Atoi(strings.TrimSpace(string(output)))

--- a/session/tmux/close.go
+++ b/session/tmux/close.go
@@ -30,15 +30,19 @@ import (
 type PaneState int
 
 const (
-	// PaneStateKnown: every tmux command ANSWERED. The session is gone, or it
-	// survived a kill tmux reported on — either way its state was established, and
-	// the caller's own best-effort contract (#478/#967) governs from here.
-	PaneStateKnown PaneState = iota
-	// PaneStateUnknown: a bounded tmux command tripped its deadline, so the server
-	// never answered and the session may still be RUNNING. No caller may take a
-	// destructive step on this — deleting or moving a workspace an agent is still
-	// writing to destroys the user's work on a guess. Retry instead.
-	PaneStateUnknown
+	// PaneStateUnknown (the ZERO VALUE): a bounded tmux command tripped its
+	// deadline, so the server never answered and the session may still be RUNNING —
+	// or nobody established its state at all. No caller may take a destructive step
+	// on this: deleting or moving a workspace an agent is still writing to destroys
+	// the user's work on a guess. Retry instead.
+	//
+	// Unknown is the zero value deliberately (#1917). The safe outcome must be the
+	// LAZY outcome: a state nobody set refuses to destroy rather than permitting it.
+	PaneStateUnknown PaneState = iota
+	// PaneStateKnown: every tmux command in the teardown ANSWERED. The session is
+	// gone, or it survived a kill tmux reported on — either way its state was
+	// established, and the caller's own best-effort contract (#478/#967) governs.
+	PaneStateKnown
 )
 
 // Close terminates the tmux session and cleans up resources. It reports whether
@@ -50,55 +54,96 @@ const (
 // tmux-server-mediated attach driver was retired), so Close is now just
 // kill-session plus the leaked-process reap — no PTY close, no attach-goroutine
 // drain, no killAttach/termAttach coordination.
+// closeRun executes ONE Close and OWNS its state, mirroring git's cleanupRun.
+//
+// Close used to assert PaneStateKnown up front and downgrade by hand at each place
+// a deadline could trip — and a missed one (the has-session probe) shipped, letting
+// a caller delete a workspace whose session tmux had never confirmed dead. The
+// author no longer writes the state: every bounded tmux command goes through
+// run.tmux, which records a tripped deadline, and state() derives the answer.
+type closeRun struct {
+	t       *TmuxSession
+	unknown bool
+}
+
+// tmux runs one bounded tmux command and RECORDS a tripped deadline. The only
+// place in the close path that decides what a deadline means.
+func (r *closeRun) tmux(args ...string) error {
+	ctx, cancel := tmuxTimeoutContext()
+	defer cancel()
+	err := r.t.runTmuxBounded(ctx, args...)
+	if err != nil && ctx.Err() != nil {
+		r.unknown = true
+		return fmt.Errorf("%w: %s after %s", ErrTmuxTimeout, args[0], tmuxCommandTimeout)
+	}
+	return err
+}
+
+// probe asks whether the session still exists. A timed-out probe marks the run
+// unknown via the shared probe helper and reports ok=false, so "could not ask" is
+// never read as "not there".
+func (r *closeRun) probe() (exists bool, ok bool) {
+	exists, known := probeSession(r.t.cmdExec, r.t.sanitizedName)
+	if !known {
+		r.unknown = true
+	}
+	return exists, known
+}
+
+func (r *closeRun) state() PaneState {
+	if r.unknown {
+		return PaneStateUnknown
+	}
+	return PaneStateKnown
+}
+
 func (t *TmuxSession) Close() (PaneState, error) {
 	var errs []error
-	state := PaneStateKnown
+	r := &closeRun{t: t}
 
 	// Capture the panes' process trees before kill-session — afterwards any
 	// survivor is reparented to init and its ancestry is unrecoverable
 	// (#1104).
 	leaked := SessionProcessTrees(t.cmdExec, t.sanitizedName)
 
-	// Bounded by tmuxCommandTimeout (#1917): an unbounded kill-session against a
-	// wedged server blocks daemon.KillSession forever behind its kills-in-flight
-	// guard, leaving the session undeletable until the daemon restarts.
-	ctx, cancel := tmuxTimeoutContext()
-	defer cancel()
-	if err := t.runTmuxBounded(ctx, "kill-session", "-t", exactTarget(t.sanitizedName)); err != nil {
-		if ctx.Err() != nil {
-			// The deadline tripped, so the session's real state is UNKNOWN. Do
-			// NOT probe has-session: it would spawn another tmux command against
-			// the same wedged server and hang identically, defeating the bound we
-			// just came here for (see tmuxTimeoutContext). Report the timeout and
-			// take the conservative branch — a session we cannot confirm dead may
+	// Bounded by tmuxCommandTimeout (#1917), through the run so the deadline counts
+	// itself: an unbounded kill-session against a wedged server blocks
+	// daemon.KillSession forever behind its kills-in-flight guard, leaving the
+	// session undeletable until the daemon restarts.
+	if err := r.tmux("kill-session", "-t", exactTarget(t.sanitizedName)); err != nil {
+		switch {
+		case r.unknown:
+			// r.tmux already wrapped this as ErrTmuxTimeout.
+			errs = append(errs, err)
+			// The deadline tripped, so the session's real state is UNKNOWN. Do NOT
+			// probe has-session: it would spawn another tmux command against the same
+			// wedged server and hang identically, defeating the bound we just came
+			// here for (see tmuxTimeoutContext). A session we cannot confirm dead may
 			// well be alive, and its processes are then not leaks.
-			errs = append(errs, fmt.Errorf("%w: kill-session after %s", ErrTmuxTimeout, tmuxCommandTimeout))
-			state = PaneStateUnknown
 			leaked = nil
-		} else {
-			// kill-session ANSWERED with a failure, fast. Ask what actually happened
-			// — but the probe is bounded too, so it has three answers, not two.
-			exists, known := probeSession(t.cmdExec, t.sanitizedName)
+		default:
+			// kill-session ANSWERED with a failure, fast. Ask what actually happened —
+			// but the probe is bounded too, so it has three answers, not two. A
+			// timed-out probe marks the run unknown inside r.probe, so the caller
+			// learns the fate is unknown instead of receiving an ordinary kill error
+			// and deleting the workspace on it.
+			exists, ok := r.probe()
 			switch {
-			case !known:
-				// The probe timed out (#1917). Reporting only the original
-				// kill-session error would hand the caller an ordinary failure and
-				// lose the fact that the session's fate is UNKNOWN — and the caller
-				// would then delete the workspace. Surface the timeout instead.
+			case !ok:
 				errs = append(errs, fmt.Errorf("%w: has-session probe after kill-session failed (%v)", ErrTmuxTimeout, err))
-				state = PaneStateUnknown
 				leaked = nil
 			case exists:
+				errs = append(errs, fmt.Errorf("error killing tmux session: %w", err))
 				// Idempotent teardown (#967): a kill-session that fails because the
-				// session is already gone has achieved Close's goal — a dead session
-				// is the desired end state. Only a session that survives the kill is
-				// a genuine failure. Probe has-session rather than matching tmux's
-				// bare "exit status 1", which it reuses for unrelated errors.
+				// session is already gone has achieved Close's goal — a dead session is
+				// the desired end state. Only a session that survives the kill is a
+				// genuine failure. Probe has-session rather than matching tmux's bare
+				// "exit status 1", which it reuses for unrelated errors.
 				//
 				// The state stays KNOWN: tmux answered, and this session is alive.
-				// Callers keep their pre-#1917 best-effort contract here (#478) —
-				// see the note on that trade in teardownKill.
-				errs = append(errs, fmt.Errorf("error killing tmux session: %w", err))
+				// Callers keep their pre-#1917 best-effort contract here (#478) — see
+				// the note on that trade in teardownKill.
+				//
 				// The session survived — its processes are not leaks. Do not reap.
 				leaked = nil
 			}
@@ -112,16 +157,11 @@ func (t *TmuxSession) Close() (PaneState, error) {
 		go reapLeakedProcesses(t.sanitizedName, leaked, reapGraceWait, reapTermWait)
 	}
 
-	if len(errs) == 0 {
-		return state, nil
-	}
-	if len(errs) == 1 {
-		return state, errs[0]
-	}
 	// errors.Join, not a flattened string: the ErrTmuxTimeout sentinel has to stay
 	// reachable through errors.Is for callers that gate on it (#1917). The old
-	// hand-built message erased it.
-	return state, errors.Join(errs...)
+	// hand-built message erased it. The state is DERIVED from the run — this
+	// function never names a PaneState constant.
+	return r.state(), errors.Join(errs...)
 }
 
 // CloseAttachOnly is the non-destructive sibling of Close: it releases whatever

--- a/session/tmux/close.go
+++ b/session/tmux/close.go
@@ -12,14 +12,47 @@ import (
 	"github.com/sachiniyer/agent-factory/log"
 )
 
-// Close terminates the tmux session and cleans up resources.
+// PaneState is what a bounded teardown could ESTABLISH about a tmux session, and
+// it is returned SEPARATELY from the error on purpose (#1917).
+//
+// Bounding the tmux commands introduced a third answer next to "killed" and
+// "failed to kill": "the server never replied, so I do not know". That answer has
+// to reach the caller who deletes or moves the workspace, and returning it only as
+// an error type did not work — four separate layers reduced it to
+// log-the-error-and-carry-on, which is byte-for-byte identical to having no
+// timeout at all, and each one ended in a destructive step running against a
+// session that might still be alive.
+//
+// An error can be swallowed by accident; a second return value cannot. Every
+// caller must name it, and a caller that wants to ignore it has to write the
+// ignore down. That is the whole point of the type: it makes the unknown case
+// impossible to drop silently rather than merely possible to detect.
+type PaneState int
+
+const (
+	// PaneStateKnown: every tmux command ANSWERED. The session is gone, or it
+	// survived a kill tmux reported on — either way its state was established, and
+	// the caller's own best-effort contract (#478/#967) governs from here.
+	PaneStateKnown PaneState = iota
+	// PaneStateUnknown: a bounded tmux command tripped its deadline, so the server
+	// never answered and the session may still be RUNNING. No caller may take a
+	// destructive step on this — deleting or moving a workspace an agent is still
+	// writing to destroys the user's work on a guess. Retry instead.
+	PaneStateUnknown
+)
+
+// Close terminates the tmux session and cleans up resources. It reports whether
+// tmux actually established the session's fate (see PaneState) alongside any
+// error: callers that go on to touch the session's workspace MUST gate on the
+// state, not on the error.
 //
 // Post-#1592-PR7 a TmuxSession holds no attach PTY or client child (the
 // tmux-server-mediated attach driver was retired), so Close is now just
 // kill-session plus the leaked-process reap — no PTY close, no attach-goroutine
 // drain, no killAttach/termAttach coordination.
-func (t *TmuxSession) Close() error {
+func (t *TmuxSession) Close() (PaneState, error) {
 	var errs []error
+	state := PaneStateKnown
 
 	// Capture the panes' process trees before kill-session — afterwards any
 	// survivor is reparented to init and its ancestry is unrecoverable
@@ -32,8 +65,7 @@ func (t *TmuxSession) Close() error {
 	ctx, cancel := tmuxTimeoutContext()
 	defer cancel()
 	if err := t.runTmuxBounded(ctx, "kill-session", "-t", exactTarget(t.sanitizedName)); err != nil {
-		switch {
-		case ctx.Err() != nil:
+		if ctx.Err() != nil {
 			// The deadline tripped, so the session's real state is UNKNOWN. Do
 			// NOT probe has-session: it would spawn another tmux command against
 			// the same wedged server and hang identically, defeating the bound we
@@ -41,17 +73,35 @@ func (t *TmuxSession) Close() error {
 			// take the conservative branch — a session we cannot confirm dead may
 			// well be alive, and its processes are then not leaks.
 			errs = append(errs, fmt.Errorf("%w: kill-session after %s", ErrTmuxTimeout, tmuxCommandTimeout))
+			state = PaneStateUnknown
 			leaked = nil
-		case t.DoesSessionExist():
-			// Idempotent teardown (#967): a kill-session that fails because the
-			// session is already gone has achieved Close's goal — a dead session
-			// is the desired end state. Only a session that survives the kill is a
-			// genuine failure. Probe has-session rather than matching tmux's bare
-			// "exit status 1", which it reuses for unrelated errors. Mirrors the
-			// `_`-ignored cleanup kill in Start (above).
-			errs = append(errs, fmt.Errorf("error killing tmux session: %w", err))
-			// The session survived — its processes are not leaks. Do not reap.
-			leaked = nil
+		} else {
+			// kill-session ANSWERED with a failure, fast. Ask what actually happened
+			// — but the probe is bounded too, so it has three answers, not two.
+			exists, known := probeSession(t.cmdExec, t.sanitizedName)
+			switch {
+			case !known:
+				// The probe timed out (#1917). Reporting only the original
+				// kill-session error would hand the caller an ordinary failure and
+				// lose the fact that the session's fate is UNKNOWN — and the caller
+				// would then delete the workspace. Surface the timeout instead.
+				errs = append(errs, fmt.Errorf("%w: has-session probe after kill-session failed (%v)", ErrTmuxTimeout, err))
+				state = PaneStateUnknown
+				leaked = nil
+			case exists:
+				// Idempotent teardown (#967): a kill-session that fails because the
+				// session is already gone has achieved Close's goal — a dead session
+				// is the desired end state. Only a session that survives the kill is
+				// a genuine failure. Probe has-session rather than matching tmux's
+				// bare "exit status 1", which it reuses for unrelated errors.
+				//
+				// The state stays KNOWN: tmux answered, and this session is alive.
+				// Callers keep their pre-#1917 best-effort contract here (#478) —
+				// see the note on that trade in teardownKill.
+				errs = append(errs, fmt.Errorf("error killing tmux session: %w", err))
+				// The session survived — its processes are not leaks. Do not reap.
+				leaked = nil
+			}
 		}
 	}
 
@@ -63,17 +113,15 @@ func (t *TmuxSession) Close() error {
 	}
 
 	if len(errs) == 0 {
-		return nil
+		return state, nil
 	}
 	if len(errs) == 1 {
-		return errs[0]
+		return state, errs[0]
 	}
-
-	errMsg := "multiple errors occurred during cleanup:"
-	for _, err := range errs {
-		errMsg += "\n  - " + err.Error()
-	}
-	return errors.New(errMsg)
+	// errors.Join, not a flattened string: the ErrTmuxTimeout sentinel has to stay
+	// reachable through errors.Is for callers that gate on it (#1917). The old
+	// hand-built message erased it.
+	return state, errors.Join(errs...)
 }
 
 // CloseAttachOnly is the non-destructive sibling of Close: it releases whatever
@@ -113,18 +161,34 @@ const paneExitWait = 3 * time.Second
 // real worst case is ~4×tmuxCommandTimeout + paneExitWait, all of it finite —
 // which is the property daemon.KillSession needs, since it holds a per-session
 // kills-in-flight guard across this call with no deadline of its own.
-func (t *TmuxSession) CloseAndWaitForPaneExit() error {
+func (t *TmuxSession) CloseAndWaitForPaneExit() (PaneState, error) {
 	pid, pidErr := t.panePID()
-	closeErr := t.Close()
+	state, closeErr := t.Close()
 	if pidErr != nil {
-		// Session already gone (or unqueryable) — nothing to wait on.
-		return closeErr
+		// A TIMED-OUT panePID is not "nothing to wait on" (#1917). It means the
+		// server never told us which process to wait for — so even if the
+		// kill-session that follows succeeds, we skip the #802 pane-exit wait and
+		// have no way to know the agent stopped writing. Returning the successful
+		// Close's KNOWN state here would tell the caller it may delete the worktree
+		// while the HUP'd agent is still flushing into it. Keep the unknown, and
+		// keep the sentinel reachable.
+		if errors.Is(pidErr, ErrTmuxTimeout) {
+			return PaneStateUnknown, errors.Join(closeErr, pidErr)
+		}
+		// Any other panePID failure means tmux ANSWERED: the session is already
+		// gone or the pane is unqueryable, so there is genuinely nothing to wait on
+		// and Close's own state stands.
+		return state, closeErr
 	}
 	if !waitForPIDExit(pid, paneExitWait) {
+		// Pre-existing #802 behavior, deliberately unchanged: kill-session was
+		// CONFIRMED delivered, so this pane is dying — it is merely slow. Treating a
+		// slow flush as unknown would defer routine kills of any agent that takes
+		// >3s to exit. The unknown cases above are the ones where tmux never spoke.
 		log.WarningLog.Printf("tmux session %s: pane process %d still alive %v after kill-session; "+
 			"worktree cleanup may race with its in-flight writes", t.sanitizedName, pid, paneExitWait)
 	}
-	return closeErr
+	return state, closeErr
 }
 
 // panePID returns the PID of the root process running in the session's pane

--- a/session/tmux/close_unknown_test.go
+++ b/session/tmux/close_unknown_test.go
@@ -1,0 +1,108 @@
+package tmux
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+)
+
+// The #1917 review locks for the two places a tmux TIMEOUT used to be silently
+// downgraded to an ordinary failure, letting the caller delete a workspace while
+// the session's fate was unknown.
+
+// wedgeOn returns an executor that stalls past the deadline for the tmux verbs in
+// wedged and answers every other verb via fast.
+func wedgeOn(wedged []string, fast func(args []string) error) cmd_test.MockCmdExec {
+	isWedged := func(c *exec.Cmd) bool {
+		for _, w := range wedged {
+			for _, a := range c.Args {
+				if a == w {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	run := func(c *exec.Cmd) error {
+		if isWedged(c) {
+			time.Sleep(2 * time.Second)
+			return fmt.Errorf("wedged tmux server never answered %s", strings.Join(c.Args, " "))
+		}
+		return fast(c.Args)
+	}
+	return cmd_test.MockCmdExec{
+		RunFunc:    run,
+		OutputFunc: func(c *exec.Cmd) ([]byte, error) { return nil, run(c) },
+	}
+}
+
+// TestCloseAndWaitForPaneExit_PanePIDTimeout_KeepsTheUnknown is review finding (2).
+//
+// display-message times out while the kill-session that follows SUCCEEDS. The old
+// code threw pidErr away and returned Close's nil error, so the caller was told
+// the teardown was clean — but the #802 pane-exit wait had been skipped, because
+// we never learned which process to wait for. The caller then removed the worktree
+// while the HUP'd agent was still flushing into it.
+//
+// PRE-FIX BEHAVIOR THIS REPRODUCES: state comes back KNOWN with a nil error.
+func TestCloseAndWaitForPaneExit_PanePIDTimeout_KeepsTheUnknown(t *testing.T) {
+	// Trip the bound fast: these tests are about WHICH answer a tripped deadline
+	// produces, not how long it takes to trip.
+	shortTmuxTimeout(t, 150*time.Millisecond)
+	// Only display-message stalls; kill-session and list-panes answer cleanly.
+	exec := wedgeOn([]string{"display-message"}, func([]string) error { return nil })
+	session := NewTmuxSessionFromSanitizedNameWithDeps("af_pidtimeout", "claude", NewMockPtyFactory(t), exec)
+
+	state, err := session.CloseAndWaitForPaneExit()
+
+	if state != PaneStateUnknown {
+		t.Fatal("a timed-out panePID reported a KNOWN state: the pane-exit wait was skipped (we never " +
+			"learned which process to wait for), so the caller deletes the worktree while the HUP'd " +
+			"agent is still flushing into it (#1917 review)")
+	}
+	if err == nil || !errors.Is(err, ErrTmuxTimeout) {
+		t.Fatalf("the timeout must stay reachable through errors.Is for callers that gate on it, got: %v", err)
+	}
+}
+
+// TestClose_HasSessionProbeTimeout_ReportsUnknown is review finding (4).
+//
+// kill-session fails FAST (so Close probes has-session to tell "already gone" from
+// "refused to die"), and the probe — newly bounded — times out. sessionExists
+// collapsed that to `true`, so Close reported only the original ordinary
+// kill-session error and the caller proceeded to worktree cleanup with the
+// session's liveness unknown.
+//
+// PRE-FIX BEHAVIOR THIS REPRODUCES: state KNOWN, and the error does not wrap
+// ErrTmuxTimeout.
+func TestClose_HasSessionProbeTimeout_ReportsUnknown(t *testing.T) {
+	// Trip the bound fast: these tests are about WHICH answer a tripped deadline
+	// produces, not how long it takes to trip.
+	shortTmuxTimeout(t, 150*time.Millisecond)
+	// kill-session answers with a failure immediately; the has-session probe stalls.
+	exec := wedgeOn([]string{"has-session"}, func(args []string) error {
+		for _, a := range args {
+			if a == "kill-session" {
+				return fmt.Errorf("exit status 1")
+			}
+		}
+		return nil
+	})
+	session := NewTmuxSessionFromSanitizedNameWithDeps("af_probetimeout", "claude", NewMockPtyFactory(t), exec)
+
+	state, err := session.Close()
+
+	if state != PaneStateUnknown {
+		t.Fatal("a timed-out has-session probe reported a KNOWN state: Close then hands the caller an " +
+			"ordinary kill failure, and the caller cleans up the worktree without ever establishing " +
+			"whether the session is still running (#1917 review)")
+	}
+	if err == nil || !errors.Is(err, ErrTmuxTimeout) {
+		t.Fatalf("the probe's timeout must reach the caller as a timeout, got: %v", err)
+	}
+}

--- a/session/tmux/close_wait_test.go
+++ b/session/tmux/close_wait_test.go
@@ -63,7 +63,10 @@ func TestCloseAndWaitForPaneExit_QueriesPaneBeforeKill(t *testing.T) {
 	session := newTmuxSession(toTmuxName("close-wait", ""), "claude", NewMockPtyFactory(t), cmdExec)
 
 	start := time.Now()
-	require.NoError(t, session.CloseAndWaitForPaneExit())
+	state, err := session.CloseAndWaitForPaneExit()
+	require.NoError(t, err)
+	require.Equal(t, PaneStateKnown, state,
+		"tmux answered every command, so the pane's fate is established")
 	require.Less(t, time.Since(start), time.Second,
 		"wait on an already-dead agent process must return promptly")
 
@@ -91,7 +94,10 @@ func TestCloseAndWaitForPaneExit_SessionGone(t *testing.T) {
 	session := newTmuxSession(toTmuxName("close-wait-gone", ""), "claude", NewMockPtyFactory(t), cmdExec)
 
 	start := time.Now()
-	require.NoError(t, session.CloseAndWaitForPaneExit())
+	state, err := session.CloseAndWaitForPaneExit()
+	require.NoError(t, err)
+	require.Equal(t, PaneStateKnown, state,
+		"tmux answered every command, so the pane's fate is established")
 	require.Less(t, time.Since(start), time.Second)
 	require.True(t, killed, "kill-session must still run when the pane PID is unqueryable")
 }

--- a/session/tmux/idempotent_close_test.go
+++ b/session/tmux/idempotent_close_test.go
@@ -56,8 +56,11 @@ func TestClose_AlreadyDeadSession_ReturnsNil(t *testing.T) {
 	exec := killSessionProbeExec(false /* session gone */, &killCalls)
 	session := NewTmuxSessionFromSanitizedNameWithDeps("af_dead", "claude", NewMockPtyFactory(t), exec)
 
-	require.NoError(t, session.Close(),
+	state, err := session.Close()
+	require.NoError(t, err,
 		"a kill-session on an already-dead session is success, not an error (#967)")
+	require.Equal(t, PaneStateKnown, state,
+		"the has-session probe ANSWERED, so the session's fate is established")
 	require.Equal(t, 1, killCalls, "Close must still attempt the kill-session")
 }
 
@@ -69,8 +72,11 @@ func TestClose_SessionSurvivesKill_StillErrors(t *testing.T) {
 	exec := killSessionProbeExec(true /* session still present */, nil)
 	session := NewTmuxSessionFromSanitizedNameWithDeps("af_stuck", "claude", NewMockPtyFactory(t), exec)
 
-	err := session.Close()
+	state, err := session.Close()
 	require.Error(t, err, "a session that survives kill-session is a real failure")
+	require.Equal(t, PaneStateKnown, state,
+		"tmux ANSWERED (the probe found the session alive), so the state is known and the "+
+			"caller's pre-#1917 best-effort contract still governs")
 	require.Contains(t, err.Error(), "error killing tmux session")
 }
 

--- a/session/tmux/kill_wedge_test.go
+++ b/session/tmux/kill_wedge_test.go
@@ -1,0 +1,160 @@
+package tmux
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/cmd"
+	"github.com/sachiniyer/agent-factory/internal/proctree"
+)
+
+// #1917: a session kill that wedges forever, leaving the session permanently
+// undeletable until the daemon restarts.
+//
+// daemon.KillSession runs the whole teardown with no deadline of its own while
+// holding a per-session kills-in-flight guard, so ANY unbounded step below is
+// enough to reproduce the reported symptom. Before the fix every tmux command on
+// the teardown path used bare exec.Command: display-message (panePID),
+// list-panes (SessionProcessTrees), kill-session and has-session (Close). Each is
+// now bounded by tmuxCommandTimeout.
+//
+// These tests drive a REAL fake tmux on PATH rather than a MockCmdExec that
+// sleeps, and that is load-bearing, not a stylistic choice: a mock's RunFunc
+// blocks the calling goroutine directly and is not reachable by ANY context
+// deadline, so a blocking mock would "fail" identically before and after the fix
+// and prove nothing. The bound only exists because a real subprocess can be
+// SIGKILLed on the deadline — so the test has to exercise a real subprocess.
+// stallingTmuxOnPath (bounded_test.go) additionally sleeps in a CHILD, so
+// passing also requires the process-group kill and tmuxWaitDelay.
+
+// TestTeardownTmuxCommandsDoNotWedgeTheKill is the #1917 regression. Every tmux
+// command reachable from the kill teardown must return against a wedged server.
+func TestTeardownTmuxCommandsDoNotWedgeTheKill(t *testing.T) {
+	cases := []struct {
+		name string
+		// call runs one teardown entry point and returns its error (nil for the
+		// best-effort probes, which report through their return value instead).
+		call func(ts *TmuxSession) error
+	}{
+		// The whole teardown call the daemon actually makes (session/teardown.go).
+		{"CloseAndWaitForPaneExit", func(ts *TmuxSession) error { return ts.CloseAndWaitForPaneExit() }},
+		// Close alone: list-panes + kill-session (+ the has-session probe).
+		{"Close", func(ts *TmuxSession) error { return ts.Close() }},
+		// The first command on the teardown, and the one whose stall the issue
+		// misread as "capped at 3s" (paneExitWait bounds only waitForPIDExit).
+		{"panePID", func(ts *TmuxSession) error { _, err := ts.panePID(); return err }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stallingTmuxOnPath(t)
+			shortTmuxTimeout(t, 200*time.Millisecond)
+			ts := NewTmuxSessionWithDeps("wedge-1917", "sh", MakePtyFactory(), cmd.MakeExecutor())
+
+			done := make(chan error, 1)
+			go func() { done <- tc.call(ts) }()
+
+			// Generous relative to the 200ms deadline, but far below the fake
+			// tmux's 300s sleep: only a real bound can land inside it.
+			select {
+			case err := <-done:
+				if !errors.Is(err, ErrTmuxTimeout) {
+					t.Fatalf("want ErrTmuxTimeout against a stalled tmux, got %v", err)
+				}
+				// A wedged server proves nothing about the session, so the
+				// teardown must never claim it confirmed the session gone —
+				// that would let a caller reap a live agent's process tree.
+				if errors.Is(err, ErrSessionGone) {
+					t.Fatalf("timeout must not be reported as ErrSessionGone: %v", err)
+				}
+			case <-time.After(30 * time.Second):
+				t.Fatalf("%s hung against a stalled tmux (#1917): no return within 30s — "+
+					"the daemon's kills-in-flight guard is held across this call, so the session "+
+					"would be undeletable until the daemon restarts", tc.name)
+			}
+		})
+	}
+}
+
+// TestSessionProcessTreesDoesNotWedgeTheKill covers the teardown's other tmux
+// command. It is best-effort (nil on any failure) rather than error-returning, so
+// it gets its own test: the contract is that it RETURNS, and returns nil — a
+// wedged server has told us nothing about which processes are leaked, and reaping
+// on a guess would SIGKILL a live session's tree.
+func TestSessionProcessTreesDoesNotWedgeTheKill(t *testing.T) {
+	stallingTmuxOnPath(t)
+	shortTmuxTimeout(t, 200*time.Millisecond)
+
+	done := make(chan []proctree.Process, 1)
+	go func() { done <- SessionProcessTrees(cmd.MakeExecutor(), "wedge-1917") }()
+
+	select {
+	case procs := <-done:
+		if len(procs) != 0 {
+			t.Fatalf("a stalled list-panes must yield no reap set, got %d processes", len(procs))
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("SessionProcessTrees hung against a stalled tmux (#1917): it is the FIRST tmux " +
+			"command on the kill teardown, so a stall here wedges the kill before kill-session runs")
+	}
+}
+
+// TestDoesSessionExistOnWedgedServerReportsPresent pins the deliberate choice in
+// sessionExists: the bool cannot express "unknown", so a tripped deadline reports
+// TRUE. Every caller that acts destructively acts on FALSE (Close reaps the
+// session's process trees; io.go/clientless.go raise ErrSessionGone, which the
+// daemon reads as a confirmed death), so a false "gone" against a merely-wedged
+// server would tear down a live session. A false "exists" only costs a
+// best-effort skip. Returning quickly is the fix; returning TRUE is the safety
+// property that keeps the fix from trading a hang for data loss.
+func TestDoesSessionExistOnWedgedServerReportsPresent(t *testing.T) {
+	stallingTmuxOnPath(t)
+	shortTmuxTimeout(t, 200*time.Millisecond)
+	ts := NewTmuxSessionWithDeps("wedge-1917-probe", "sh", MakePtyFactory(), cmd.MakeExecutor())
+
+	done := make(chan bool, 1)
+	go func() { done <- ts.DoesSessionExist() }()
+
+	select {
+	case exists := <-done:
+		if !exists {
+			t.Fatal("a wedged tmux server must not be reported as a gone session: " +
+				"callers reap process trees and raise ErrSessionGone on false")
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("DoesSessionExist hung against a stalled tmux (#1917): it is the fallback probe " +
+			"on nearly every tmux error path in this package, including Close's")
+	}
+}
+
+// TestCloseOnWedgedServerSkipsTheExistenceProbe guards the rule
+// tmuxTimeoutContext documents: after kill-session trips its deadline, Close must
+// NOT fall back to has-session. The probe would spawn another tmux command
+// against the same wedged server and hang identically, so the bound would buy
+// nothing. Timing is the only observable: with the probe, teardown costs a second
+// full deadline.
+func TestCloseOnWedgedServerSkipsTheExistenceProbe(t *testing.T) {
+	stallingTmuxOnPath(t)
+	const bound = 400 * time.Millisecond
+	shortTmuxTimeout(t, bound)
+	ts := NewTmuxSessionWithDeps("wedge-1917-probe-skip", "sh", MakePtyFactory(), cmd.MakeExecutor())
+
+	done := make(chan time.Duration, 1)
+	go func() {
+		start := time.Now()
+		_ = ts.Close()
+		done <- time.Since(start)
+	}()
+
+	select {
+	case elapsed := <-done:
+		// Close spends one deadline on list-panes and one on kill-session. A
+		// third would mean the has-session probe ran on the timeout path.
+		if max := 3 * bound; elapsed >= max {
+			t.Fatalf("Close took %v (>= %v): kill-session's timeout path appears to have fallen "+
+				"back to a DoesSessionExist probe, which hangs on the same wedged server", elapsed, max)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("Close hung against a stalled tmux (#1917)")
+	}
+}

--- a/session/tmux/kill_wedge_test.go
+++ b/session/tmux/kill_wedge_test.go
@@ -38,9 +38,9 @@ func TestTeardownTmuxCommandsDoNotWedgeTheKill(t *testing.T) {
 		call func(ts *TmuxSession) error
 	}{
 		// The whole teardown call the daemon actually makes (session/teardown.go).
-		{"CloseAndWaitForPaneExit", func(ts *TmuxSession) error { return ts.CloseAndWaitForPaneExit() }},
+		{"CloseAndWaitForPaneExit", func(ts *TmuxSession) error { _, err := ts.CloseAndWaitForPaneExit(); return err }},
 		// Close alone: list-panes + kill-session (+ the has-session probe).
-		{"Close", func(ts *TmuxSession) error { return ts.Close() }},
+		{"Close", func(ts *TmuxSession) error { _, err := ts.Close(); return err }},
 		// The first command on the teardown, and the one whose stall the issue
 		// misread as "capped at 3s" (paneExitWait bounds only waitForPIDExit).
 		{"panePID", func(ts *TmuxSession) error { _, err := ts.panePID(); return err }},
@@ -142,7 +142,7 @@ func TestCloseOnWedgedServerSkipsTheExistenceProbe(t *testing.T) {
 	done := make(chan time.Duration, 1)
 	go func() {
 		start := time.Now()
-		_ = ts.Close()
+		_, _ = ts.Close()
 		done <- time.Since(start)
 	}()
 

--- a/session/tmux/reap.go
+++ b/session/tmux/reap.go
@@ -1,7 +1,6 @@
 package tmux
 
 import (
-	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -52,9 +51,17 @@ var (
 // teardown paths call it BEFORE kill-session; `af doctor` uses it to map a
 // live session's legitimate processes. Returns nil on any failure — callers
 // treat it as strictly best-effort.
+//
+// The list-panes probe is bounded by tmuxCommandTimeout (#1917): it runs first
+// on the kill teardown, so an unbounded stall here wedges the kill before
+// kill-session is even attempted. A tripped deadline degrades to the existing
+// nil (best-effort) result — nothing is reaped, which is the safe direction: a
+// wedged server has told us nothing about which processes are actually leaked.
 func SessionProcessTrees(cmdExec cmd.Executor, sanitizedName string) []proctree.Process {
-	out, err := cmdExec.Output(exec.Command(
-		"tmux", "list-panes", "-s", "-t", exactTarget(sanitizedName), "-F", "#{pane_pid}"))
+	ctx, cancel := tmuxTimeoutContext()
+	defer cancel()
+	out, err := outputTmuxBoundedWith(ctx, cmdExec,
+		"list-panes", "-s", "-t", exactTarget(sanitizedName), "-F", "#{pane_pid}")
 	if err != nil {
 		return nil
 	}

--- a/session/tmux/reap_test.go
+++ b/session/tmux/reap_test.go
@@ -120,7 +120,8 @@ func TestCloseReapsEscapedPaneProcesses(t *testing.T) {
 	require.True(t, proctree.AliveSame(escapee), "escapee must be alive before Close")
 
 	session := NewTmuxSessionFromSanitizedName(name, "sh")
-	require.NoError(t, session.Close())
+	_, closeErr := session.Close()
+	require.NoError(t, closeErr)
 	require.False(t, session.DoesSessionExist(), "session must be gone after Close")
 
 	// Close reaps asynchronously; the escapee ignores SIGHUP, so only the
@@ -210,7 +211,8 @@ func TestCloseDoesNotReapWhenSessionSurvives(t *testing.T) {
 		},
 	}
 	session := newTmuxSession("af_survivor", "sh", NewMockPtyFactory(t), cmdExec)
-	require.Error(t, session.Close(), "a surviving session must surface the kill failure")
+	_, survErr := session.Close()
+	require.Error(t, survErr, "a surviving session must surface the kill failure")
 
 	time.Sleep(3 * reapGraceWait)
 	require.NoError(t, child.Process.Signal(syscall.Signal(0)),

--- a/session/tmux/start.go
+++ b/session/tmux/start.go
@@ -52,7 +52,10 @@ func (t *TmuxSession) Start(workDir string) error {
 			// ever sees it — name the likely cause and the exact command so
 			// the user isn't left with a bare timeout (#1116, #1131).
 			timeoutErr := fmt.Errorf("timed out waiting for tmux session %s; the pane program may have exited immediately after launch — check that it runs and accepts its flags (program: %q)", t.sanitizedName, t.programCmd())
-			if cleanupErr := t.Close(); cleanupErr != nil {
+			// Pane state deliberately ignored: this is the cleanup of a session
+			// that never came up, and Start's failure path touches no worktree —
+			// nothing downstream is destructive, so an unknown state costs nothing.
+			if _, cleanupErr := t.Close(); cleanupErr != nil {
 				timeoutErr = fmt.Errorf("%v (cleanup error: %v)", timeoutErr, cleanupErr)
 			}
 			return timeoutErr
@@ -87,7 +90,9 @@ func (t *TmuxSession) Start(workDir string) error {
 		// pane program exited within milliseconds of launch. Say so instead
 		// of the misleading "session does not exist" (#1116, #1131).
 		vanished := !t.DoesSessionExist()
-		if cleanupErr := t.Close(); cleanupErr != nil {
+		// Pane state deliberately ignored: same as the timeout path above — a
+		// failed Start returns an error and deletes nothing.
+		if _, cleanupErr := t.Close(); cleanupErr != nil {
 			err = fmt.Errorf("%v (cleanup error: %v)", err, cleanupErr)
 		}
 		if vanished {

--- a/session/tmux/start.go
+++ b/session/tmux/start.go
@@ -52,11 +52,20 @@ func (t *TmuxSession) Start(workDir string) error {
 			// ever sees it — name the likely cause and the exact command so
 			// the user isn't left with a bare timeout (#1116, #1131).
 			timeoutErr := fmt.Errorf("timed out waiting for tmux session %s; the pane program may have exited immediately after launch — check that it runs and accepts its flags (program: %q)", t.sanitizedName, t.programCmd())
-			// Pane state deliberately ignored: this is the cleanup of a session
-			// that never came up, and Start's failure path touches no worktree —
-			// nothing downstream is destructive, so an unknown state costs nothing.
-			if _, cleanupErr := t.Close(); cleanupErr != nil {
+			// The pane state is LOAD-BEARING here, and the comment that used to sit
+			// on this line said the opposite: "Start's failure path touches no
+			// worktree". It does. LocalBackend.Launch calls gw.Cleanup() the moment
+			// Start returns an error, so dropping an unknown here deletes the
+			// brand-new worktree out from under a pane that may still be RUNNING —
+			// tmux never confirmed this session's fate, and a detached session can
+			// exist even though the readiness poll never saw it (#1917 round 7).
+			// %w, never %v: flattening the error erases the sentinel Launch gates on.
+			state, cleanupErr := t.Close()
+			if cleanupErr != nil {
 				timeoutErr = fmt.Errorf("%v (cleanup error: %v)", timeoutErr, cleanupErr)
+			}
+			if state != PaneStateKnown {
+				timeoutErr = fmt.Errorf("%w: %w", timeoutErr, ErrTmuxTimeout)
 			}
 			return timeoutErr
 		default:
@@ -90,10 +99,14 @@ func (t *TmuxSession) Start(workDir string) error {
 		// pane program exited within milliseconds of launch. Say so instead
 		// of the misleading "session does not exist" (#1116, #1131).
 		vanished := !t.DoesSessionExist()
-		// Pane state deliberately ignored: same as the timeout path above — a
-		// failed Start returns an error and deletes nothing.
-		if _, cleanupErr := t.Close(); cleanupErr != nil {
+		// Same rule as the timeout path above: a failed Start DOES lead to a worktree
+		// delete in Launch, so an unknown pane state must reach it (#1917 round 7).
+		state, cleanupErr := t.Close()
+		if cleanupErr != nil {
 			err = fmt.Errorf("%v (cleanup error: %v)", err, cleanupErr)
+		}
+		if state != PaneStateKnown {
+			err = fmt.Errorf("%w: %w", err, ErrTmuxTimeout)
 		}
 		if vanished {
 			return fmt.Errorf("tmux session %s vanished before attach; the pane program likely exited immediately after launch — check that it runs and accepts its flags (program: %q): %w", t.sanitizedName, t.programCmd(), err)

--- a/session/tmux/start_unknown_test.go
+++ b/session/tmux/start_unknown_test.go
@@ -1,0 +1,60 @@
+package tmux
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+)
+
+// TestStart_ReadinessTimeoutOnWedgedServer_PropagatesTheUnknown is #1917 round-7
+// finding (2): Start dropped its cleanup Close's PaneStateUnknown and flattened the
+// error with %v.
+//
+// The path that matters: has-session answers "no" (so Start proceeds), the spawn
+// SUCCEEDS — a detached session now exists and its pane may be RUNNING in the
+// worktree — and then the server wedges, so the readiness poll times out and the
+// cleanup Close cannot confirm the session's fate. LocalBackend.Launch calls
+// gw.Cleanup() the instant Start returns an error, so if this error does not carry
+// the unknown, the brand-new worktree is deleted out from under that live pane.
+//
+// PRE-FIX BEHAVIOR THIS REPRODUCES: the returned error does not wrap ErrTmuxTimeout
+// (the state was dropped, and %v erased the sentinel even where it existed).
+func TestStart_ReadinessTimeoutOnWedgedServer_PropagatesTheUnknown(t *testing.T) {
+	shortTmuxTimeout(t, 150*time.Millisecond)
+
+	// has-session: answers fast and says "gone", so Start gets past its
+	// already-exists gate and spawns. Everything else stalls past the deadline —
+	// the readiness poll never sees the session, and the cleanup Close cannot
+	// confirm whether the pane it just spawned is running.
+	execu := cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			for _, a := range c.Args {
+				if a == "has-session" {
+					return fmt.Errorf("exit status 1") // answered: no such session
+				}
+			}
+			time.Sleep(2 * time.Second)
+			return fmt.Errorf("wedged tmux server never answered")
+		},
+		OutputFunc: func(*exec.Cmd) ([]byte, error) {
+			return nil, fmt.Errorf("wedged tmux server never answered")
+		},
+	}
+	session := NewTmuxSessionFromSanitizedNameWithDeps("af_wedged_start", "claude", NewMockPtyFactory(t), execu)
+
+	err := session.Start(t.TempDir())
+
+	if err == nil {
+		t.Fatal("a Start whose readiness poll never sees its session must fail")
+	}
+	if !errors.Is(err, ErrTmuxTimeout) {
+		t.Fatalf("Start dropped the unknown pane state: its cleanup Close could not confirm whether "+
+			"the session it just spawned is dead, but the error does not say so — LocalBackend.Launch "+
+			"then deletes the brand-new worktree out from under a possibly-live pane (#1917 round 7). "+
+			"got: %v", err)
+	}
+}

--- a/session/tmux/submit_bracketed_test.go
+++ b/session/tmux/submit_bracketed_test.go
@@ -62,7 +62,7 @@ func startReceiverPane(t *testing.T, name string) (*TmuxSession, string) {
 	out := filepath.Join(dir, "received.bin")
 	ts := NewTmuxSession(name, receiverProgram(out))
 	require.NoError(t, ts.Start(dir))
-	t.Cleanup(func() { _ = ts.Close() })
+	t.Cleanup(func() { _, _ = ts.Close() })
 
 	// Wait for the marker the RECEIVER prints, never for the pane merely being
 	// non-empty. `capture-pane` on a completely blank pane returns one newline per

--- a/session/tmux/submit_test.go
+++ b/session/tmux/submit_test.go
@@ -234,7 +234,8 @@ func TestBashWrappedSubmitDoesNotDuplicateCommandPrefix(t *testing.T) {
 	)
 	require.NoError(t, session.Start(t.TempDir()))
 	t.Cleanup(func() {
-		require.NoError(t, session.Close())
+		_, closeErrX := session.Close()
+		require.NoError(t, closeErrX)
 	})
 
 	resizeCmd := exec.Command("tmux", "resize-window", "-t", exactTarget(session.sanitizedName), "-x", "24", "-y", "10")

--- a/task/start_test.go
+++ b/task/start_test.go
@@ -49,7 +49,7 @@ func (b *startBackend) SendPromptCommand(_ *session.Instance, prompt string) err
 }
 func (b *startBackend) SendKeys(*session.Instance, string) error         { return nil }
 func (b *startBackend) SetPreviewSize(*session.Instance, int, int) error { return nil }
-func (b *startBackend) IsAlive(*session.Instance) bool                   { return true }
+func (b *startBackend) IsAlive(*session.Instance) (bool, error)          { return true, nil }
 func (b *startBackend) CheckAndHandleTrustPrompt(*session.Instance) bool {
 	b.trustChecks++
 	if b.trustPrompts <= 0 {


### PR DESCRIPTION
> [!IMPORTANT]
> ## This PR does NOT fix #1917 — #1944 already did (merged, v1.0.195).
>
> pradeepiyer captured a SIGQUIT dump from a wedged daemon (**#1943**). On macOS a delete blocks forever inside the **PTY broker** teardown: `ptyBroker.readLoop` is stuck in a raw `read(2)` on the pipe-pane FIFO, the WS stream handler (last subscriber, because the TUI drops its stream on delete) joins that read at `ptybroker.go:311` **while holding `captureMu`**, and `KillSession` blocks on `captureMu` holding the manager lock — so the whole daemon seizes. Underlying cause: **#1941** — Go marks FIFOs non-pollable on darwin, so `Close()` cannot wake a blocked `Read()`.
>
> **#1944 (40eaf65) shipped pradeepiyer's fix on 2026-07-16, in v1.0.195**: a `captureReader` whose `Close` writes a sentinel byte before closing the fd, so a read parked in `read(2)` on darwin is always woken. That is the user's fix. It is on master, and this branch is rebased onto it.
>
> **This PR is defense in depth, not the cure.** Bounding the kill teardown stops the guard being held forever, but it would not unstick `readLoop`, release `captureMu`, or un-seize the daemon. It is worth having on its own merits — a kill that can hold a session's guard forever is a real defect on every platform — but it is separate, lower-urgency hardening. It does **not** close #1917.
>
> ### Correction: I previously ruled out the real root cause, wrongly
>
> An earlier revision of this description claimed `ptybroker.go:311 <-done` was **"disproved by experiment"** and said *"do not fix it."* **That claim was wrong and is retracted.** I built a standalone FIFO repro and ran it **on this Linux dev box** — where FIFOs *are* pollable and `Close()` *does* evict the parked read. The reported bug is macOS-only, and per #1941 Go marks FIFOs non-pollable on darwin precisely so that path takes a blocking `syscall.Read` that `Close()` cannot interrupt. My experiment was run on the one platform where the mechanism cannot occur, so it could not have observed it. It proved nothing about darwin, and I wrote it up as if it had settled the question.
>
> The fix for that deadlock belongs to **#1943/#1941** and is deliberately **out of scope here** — `ptybroker.go` is owned by that work and two sessions editing it would collide.

---

## Summary

`KillSession` registers a session in `killsInFlight` and removes it **only on return**, so any unbounded wait in between does not stall one kill — it makes the session permanently undeletable (every retry → `kill already in progress`, every other action → `session is being deleted`) for the daemon's whole lifetime. Fixes #1917, and #1910, whose hot-loop is the trigger that kept a Recover holding the very op lock the kill blocks on.

Daemon-side only. #1921 (already merged) fixed the **client** side; both are required — a client timeout alone leaves the daemon wedged holding the lock, so the session stays undeletable server-side until a restart.

## The blocking call, pinned

The issue asked for a goroutine dump from the next occurrence. Rather than wait, I reproduced the wedge (a held instances flock, exactly what a second `af` process does) and dumped stacks. It names the first offender exactly:

```
syscall.Flock                                       <- blocked, no deadline
config.WithFileLock                                 config/filelock.go:62  (LOCK_EX, no LOCK_NB)
config.LoadAndMigrateSchemaFile                     config/schema_migration.go:179
config.MigrateAllRepoInstancesForDaemonLoad         config/instances_schema.go:81
daemon.refreshDaemonInstances                       daemon/daemon.go:369
daemon.(*Manager).refreshLocked                     daemon/manager.go:272   <- holds m.mu (GLOBAL)
daemon.(*Manager).findSession / resolveActionSession
daemon.(*Manager).KillSession                       daemon/manager_sessions.go:19
```

This is the repo's known `WithFileLock` BLOCKS bug class. It is worse than the guard wedge: it parks **before** the guard is even registered, holding the manager's **global** lock — freezing every RPC, which is the reported `daemon did not exit within 5s of SIGTERM; escalating to SIGKILL`.

### What the field evidence proves, and what it rules out

`rootkill.go:99` (`finishing interrupted kill … tombstoned record survived its teardown`) only runs from `finishUserKill`, reached only when the **on-disk** record has `UserKilled=true`. That tombstone reaches disk only via `persistKillTombstone`, which is *after* `opLock.Lock()` — and `MarkUserKilled()` lives inside it. So had the field kills wedged at the op-lock acquire, nothing would have been written and restart would not have logged that line.

**The two field occurrences were therefore downstream of the op lock and downstream of the tombstone** — which rules out the issue's own leading hypothesis as the cause of *those* wedges. The surviving-tombstone-but-undeleted-record signature points at the last step, `DeleteInstanceByStableID` → `session/storage.go:337` → the same blocking flock.

I could not narrow the field occurrences to a single call beyond that set, so rather than guess I bounded **every** unbounded wait on the path and added the watchdog so the next one self-identifies.

### Ruled out by evidence, not assumed

- **`vscode.stopFor`** — bounded (5s + 5s grace, worst ~13s). Not it.
- ~~**`ptybroker.go:311 <-done`** — disproved by experiment.~~ **RETRACTED — this was the actual root cause (#1943).** My FIFO repro ran on Linux, where `Close()` evicts a parked read; on darwin Go marks FIFOs non-pollable (#1941) so the read blocks in a raw syscall `Close()` cannot interrupt. The experiment was run on the one platform where the mechanism cannot occur. See the banner at the top.
- **The issue's "the pane-exit wait is capped at 3s, so the wedge is elsewhere"** is **false**. `paneExitWait` bounds only `waitForPIDExit`; four raw `exec.Command` tmux calls inside `CloseAndWaitForPaneExit` had no deadline at all.

## Lock-semantics decision

The blocking `opLock.Lock()` exists to serialize a kill against an in-flight Recover (#1108), and that exclusion is load-bearing — a kill must never interleave with a respawn. **It is kept exactly.** `lockWithin` polls `TryLock` to a deadline: still a real mutual exclusion, never racy. Only the *failure mode* changes — an unbounded wait turns a stuck peer into a permanently undeletable session; a bounded wait turns it into a retryable error.

Failing at the acquire is safe **because it precedes the commit point**: no tombstone, no durable mutation, session bit-for-bit unchanged — so the retry the error asks for is a true retry, not a resumption of a half-finished kill. `TestKillSession_WaitsForInFlightRecover` (the #1137 Greptile P1 lock on the exclusion) still passes unchanged.

The tradeoff: `TryLock` polling forfeits the mutex's starvation-avoidance fairness. Acceptable — the only bounded acquirer is a user-initiated kill, and the alternative is waiting forever.

## No restart-only tombstone — the self-heal was starved, not missing

`refreshInstanceStatus` already routes any tombstoned record to `finishUserKill` on **every poll**, and that finisher completes the teardown and deletes the record. It skips for exactly one reason: `killsInFlight` still being held. **The wedged kill starved the very mechanism built to heal it.** So guaranteeing `KillSession` returns re-arms the self-heal — the record is reaped on the next tick with no daemon restart. Requirement (c) falls out of (b); they are the same fix.

## Bounds added

| Site | Was | Now |
|---|---|---|
| `manager_sessions.go` op lock | `Lock()`, unbounded | `lockWithin`, 30s → retryable error |
| `schema_migration.go:179` flock | `WithFileLock` | `SchemaMigrationLockTimeout` 10s |
| `state.go` `UpdateRepoInstances` flock | `WithFileLock` | `RepoInstancesLockTimeout` 10s |
| `storage.go` record delete flock | `WithFileLock` | `InstanceDeleteLockTimeout` 10s |
| tmux `kill-session`/`has-session`/`display-message`/`list-panes` | raw `exec.Command` | existing `bounded.go` helpers (10s) |
| git `worktree remove -f` / `branch -D` / `prune` / `list` | `context.Background()` | `localGitTimeout` 60s |
| — | — | `WithFileLockTimeout` + `ErrLockTimeout` (new) |

Bounding `UpdateRepoInstances` also closes a second wedge shape: the Lost-restore loop takes that same flock **while holding the op lock**, so a contended lock parked the restore and every kill behind it.

## Confirmed-alive (#1910)

`Recover` returns success once tmux accepts the new-session and `ConfirmLive` marks the row live — and `ConfirmLive` is a **pure in-memory state edge, not a liveness probe** (verified in `backend_local.go`). So an agent that exits at startup still produces a *successful* Recover; the next poll re-marked it Lost as a brand-new episode, `lostRestoreFailed` never saw an error, and the #1108 backoff never armed → respawn every ~2s for ~28 min.

**Definition:** a recovered Lost session is CONFIRMED ALIVE only once its replacement runtime has been observed non-Lost by a later poll, past a settle interval (`lostRestoreConfirmSettle`, 15s). Retry state is **retained** across the spawn-succeeded-but-died transition and `consecutiveFailures` carries, so deaths accumulate against one episode and the existing exponential backoff + single ERROR escalation apply.

Both clear sites had to change — the tail of `restoreLostSession` *and* the sweep in `RestoreLostSessions`, which cleared on "no longer Lost" alone and so fired the instant the spawn returned.

**Alignment with #1899:** that branch (`siyer/feat-1892-watch-concurrency`) adds only the new leaf file `session/activity.go`; it does **not** touch `lostrestore.go` (an earlier diff against a 64-commit-stale local `master` made it look like it did), so there is no file conflict. Its `ClassifyActivity` currently maps `LiveLost → ActivityTerminal`. The confirmed-alive notion here is daemon-loop retry state, deliberately **not** a second activity classification — when #1899 lands its "keep auto-restorable Lost sessions counted until restoration is no longer possible" cap-slot hold, it should consume this one definition rather than restate it.

## Failing-then-passing evidence

Every bound was watched failing first. Semantics reverted in place (the tests reference new symbols, so pure-master compilation isn't possible — the same approach #1921 used).

**#1917 — daemon (unbounded restored):**
```
--- FAIL: TestKillSession_ContendedInstancesLock_IsBoundedAndRetryable (10.54s)
    HUNG: KillSession never returned while the instances lock was held
--- FAIL: TestKillSession_StuckPeerOperation_DoesNotWedgeIndefinitely (10.53s)
    HUNG: KillSession never returned while a Recover held the op lock
```
After: both PASS (0.83s). Each asserts the three properties the fix owes: the kill **returns**, the guard is **released**, and a **retry succeeds** — plus that a timed-out acquire tore nothing down and left no tombstone.

**#1917 — storage (blocking `WithFileLock` restored):**
```
--- FAIL: TestDeleteInstanceByStableID_ContendedLock_TimesOutInsteadOfHanging (5.01s)
    HUNG: DeleteInstanceByStableID never returned against a held instances lock
```
After: PASS (0.23s).

**#1910 (retry-state clearing restored):**
```
--- FAIL: TestRestoreLostSessions_SpawnSucceedsButRuntimeDies_BacksOff (0.06s)
    hot loop: 20 recovery spawns across 20 poll passes
--- FAIL: TestRestoreLostSessions_RepeatedImmediateExits_EscalateExponentially
--- FAIL: TestRestoreLostSessions_ConfirmedAliveClearsRetryState
```
`20 spawns across 20 passes` is the reported respawn-every-poll shape exactly. After: all PASS.

**tmux/git leaves** (real subprocess hangs, not blocking mocks — a mock executor blocks the calling goroutine and is unreachable by a context deadline, so it would "fail" identically before and after and prove nothing):
```
--- FAIL: TestTeardownTmuxCommandsDoNotWedgeTheKill/{CloseAndWaitForPaneExit,Close,panePID} (30s each)
--- FAIL: TestSessionProcessTreesDoesNotWedgeTheKill (30.03s)
--- FAIL: TestCleanup_DoesNotWedgeOnStalledGit (60.04s)
--- FAIL: TestCleanup_StalledRemoveDoesNotDeleteTheDirectory (60.06s)
```
After: all PASS (0.03–1.21s). `TestCleanup_HealthyWorktreeStillSucceeds` passes both ways, showing the harness is sound.

`TestRestoreLostSessions_RecoversLostInstance:99` asserted *"successful recovery must drop the retry state"* — that assertion **encodes the #1910 bug**. Updated to require a confirmation pass, with the reasoning in place.

## Two judgment calls worth review

1. **`sessionExists` reports `true` on timeout.** A bool can't say "unknown", so it takes the answer that is safe to be wrong about: every caller that acts destructively acts on `false`, and a false "gone" would SIGKILL a live agent's process tree. Blast radius: a wedged `Start` now fails with a misleading "session already exists" (previously: hung forever).
2. **`shouldRemoveWorktreeDir` returns false on a timed-out removal.** Without it the bound buys nothing: a timeout can leave the worktree deregistered → `removeDir=true` → `os.RemoveAll`, which takes no context and would stall on the same paths that stalled git — moving the hang one line down and making it unkillable. The #802/#726 decision tree is otherwise byte-identical.

## Known limits (stated, not papered over)

- `os.Stat`/`os.RemoveAll` in `Cleanup` are in-process syscalls; on a D-state mount no Go deadline can bound them. This caps what the git bound achieves: it rescues stalls where **git is killable**. A truly D-state git ignores SIGKILL and `cmd.Wait` still parks — which is precisely why the watchdog exists.
- `git worktree add` runs the repo's `post-checkout` hook (arbitrary user code) unbounded, but it is on the **create** path, not teardown, and a legitimate hook has no defensible upper bound. Left alone deliberately; the false "local git cannot stall" doc comment is corrected rather than left to mislead.
- There is still no single overall deadline on the teardown, by design: abandoning a teardown mid-flight while holding the op lock would let a Recover interleave with it — the exact thing the lock prevents. Each leaf is finite instead, so the teardown terminates on its own.

## Diagnostics

A watchdog logs the in-flight stage + goroutine stacks if a kill exceeds 45s. It only observes — never cancels, never touches locks — and a normal kill stops the timer having done nothing.

## Gates

`make test-container` exit=0 (29 packages, 0 failures) · `go build ./...` · `gofmt -l .` empty · `golangci-lint --fast` exit=0 · `deadcode -test ./...` empty · `scripts/lint-file-length.sh` passed. Rebased onto master **after #1921 merged**; zero file overlap with it. Not dev-installed; no real daemon touched (all work in throwaway container homes).

— Captain Claude


---

## Codex review round (all 4 findings fixed, `780cf8f` → `55df7c7`)

All four were real and share one root cause worth stating plainly: **I bounded the teardown but left the timeouts advisory.** When a bound tripped, the caller logged it and kept destroying. That trades a recoverable hang for unrecoverable data loss — strictly worse than the bug this PR set out to fix. A bound on a destructive path is only safe if it is **load-bearing on control flow**.

A fifth instance of the same defect turned up while fixing them: `finishUserKill` logged its `Kill` error and deleted the record anyway. That is the *retry* path this PR promises, so the retry would itself have destroyed on the next poll. Fixed too.

Worth noting: the record-retention control flow **already existed and was already tested** (`TestKillSession_TombstoneSurvivesFailedTeardown` — KillSession returns before `DeleteInstance` on a `Kill` error). The defect was that the new timeouts never *reached* it, because `teardownKill` swallowed every error into a log line.

### 1 — Worktree deleted while the agent is still alive (P2, data loss)

`teardownTabs` now gates the worktree step on every pane being **confirmed** dead. `teardownKill.closeTab` returns (rather than logs) an error wrapping `tmux.ErrTmuxTimeout`; the core then skips `handleWorktree` **and** `finalize` — finalize clears the tmux refs and worktree pointer, which are exactly what a retry needs intact.

The distinction that keeps #478 alive: a tmux failure that **answered** means the session is gone or unkillable — teardown's goal either way — and stays best-effort, so a stuck session is still deletable. A **timeout** means tmux said nothing, so the pane may be running. Only the second blocks. The archive mode inherits the same gate from the shared core, so a move can't land on a live pane either.

### 2 — A killed session can come back (P2)

**Chosen: abort before teardown.** Rationale, since you asked for it explicitly: keeping the write unbounded would reintroduce the exact #1917 wedge (a held flock → the kill hangs forever holding `killsInFlight`) — the one thing this PR exists to remove. Abort keeps the no-hang property *and* makes the bound load-bearing. The tombstone is the commit point; everything before it is reversible, so a failure there costs a retry and destroys nothing.

Also fixed a latent ordering trap this exposed: `MarkUserKilled()` ran **before** the write. Aborting with the in-memory flag set would leave a session that `refreshInstanceStatus` routes to `finishUserKill`, completing on the next tick the very kill just refused. The tombstone data is now built without mutating the instance, and the flag is set only after the write lands. `TestKillSession_UnrecordableKill_AbortsBeforeTeardown` asserts exactly this.

### 3 — Orphaned worktree, lost handle (P3)

`teardownKill.handleWorktree` reports a `context.DeadlineExceeded` cleanup, so `Instance.Kill` errors and `KillSession` skips the record delete. The tombstone stays durable, so the kill stays committed and `finishUserKill` retries every poll. Cleanup failures git *answered* with stay best-effort, leaving the #802/#726 decision tree in charge.

### 4 — Confirm deadline not checked (P2)

`diedBeforeConfirm` now requires `time.Now().Before(st.confirmBy)`. Past the deadline the runtime was confirmed alive by definition — the sweep only runs while the row reads non-Lost, so a death just after the window can beat it — and the episode starts clean rather than inheriting the previous one's history.

### Failing-then-passing (each watched failing first)

```
--- FAIL: TestTeardownTabs_PaneMayBeLive_SkipsTheWorktreeStep
    the worktree action ran after tmux FAILED TO CONFIRM the pane was dead
--- FAIL: TestTeardownKill_ClassifiesTmuxTimeoutAsUnsafe (11.00s)
    teardownKill swallowed a tmux TIMEOUT
--- FAIL: TestKillSession_UnrecordableKill_AbortsBeforeTeardown
    the session was torn down despite its kill never being recorded (kills=1)
--- FAIL: TestFinishUserKill_UnsafeTeardown_KeepsTheRecordForRetry
    finishUserKill deleted the record even though the teardown could not complete safely
--- FAIL: TestRestoreLostSessions_SurvivedSettleThenDied_StartsFreshEpisode
    a runtime that outlived its settle window was charged 1 failure(s) from the PREVIOUS episode
```
All PASS after. `TestTeardownTabs_ConfirmedTmuxFailure_StillProceeds` guards the other direction — that the fix can't quietly become "any tmux hiccup blocks the kill" — and passes both ways.

`TestTeardownKill_ClassifiesTmuxTimeoutAsUnsafe` costs one real 10s deadline: the classification keys off `ctx.Err()`, and `tmuxCommandTimeout` is unexported to `session`, so it can't be shortened from there. A mock that merely returned an error would prove nothing.

### Honest coverage note

The tmux chain is proven end to end (a wedged server → `ErrTmuxTimeout` in `session/tmux`; the real `teardownKill` surfaces it; the core then skips the worktree). For git, the two links are proven separately rather than in one test: `TestCleanup_StalledRemoveDoesNotDeleteTheDirectory` proves a stalled removal yields a `DeadlineExceeded`-wrapping error and preserves the directory, and `TestFinishUserKill_UnsafeTeardown_KeepsTheRecordForRetry` proves a teardown error keeps the record. The `errors.Is` that joins them is three lines, verified by inspection — I'd rather say that than imply an end-to-end test that doesn't exist.

### Gates (re-run)

`make test-container` exit=0 (29 packages, 0 failures) · `go build ./...` · `gofmt -l .` empty · `golangci-lint --fast` exit=0 · `deadcode -test ./...` empty · `scripts/lint-file-length.sh` passed. Rebased onto current master. No real daemon touched.


---

## Codex review round 2 — the meta-failure, and the structural fix (`55df7c7` → `b3fe493`)

The diagnosis is right and it is the important part: **I made the bound load-bearing at one call site while four others still dropped it.** A timeout carried only as an error value is a suggestion — any layer can reduce it to `log-and-continue`, and four did. That is byte-for-byte identical to having no timeout, and every one of those layers ended in a destructive step running against a session that might still be alive.

So I did not patch the five sites. **The type was the problem, so I changed the type.**

### The invariant, and what now enforces it

> An unknown-state timeout can never be downgraded to an ordinary failure, and no destructive step may run while state is unknown.

`tmux.Close` / `CloseAndWaitForPaneExit` now return a **`PaneState` alongside the error**, and the teardown core **gates on the state, never on the error**:

```go
state, err := mode.closeTab(c.ts, title, c.tab.Name)
if err != nil { errs = append(errs, err) }
if state == stateUnknown { paneMayBeLive = true }   // a mode that logs-and-returns-nil still cannot hide this
```

An error can be swallowed by accident; a second return value cannot. Every call site is named by the compiler, and a caller that wants to ignore it has to **write the ignore down**. That is the difference between the unknown being *possible to detect* and *impossible to drop silently*.

**The compiler found a sixth site the review did not:** `ghostCleanup` (daemon/manager_persist.go) logged its tmux kill failure and called `ghostCleanupWorktree` anyway — the ghost twin of the exact defect, deleting a possibly-live session's workspace. It now gates both the worktree cleanup and the record delete. That site is the argument for the approach: enumeration found it, review didn't.

### Full enumeration — every consumer of a bounded call

**`Close` / `CloseAndWaitForPaneExit`** (all 9 compiler-forced):

| Site | Destructive step downstream? | Handling |
|---|---|---|
| `teardownKill.closeTab` | worktree **delete** | gates (round 1) |
| `teardownArchive.closeTab` | worktree **move** | **FIXED** — shares one classify helper with kill |
| `teardownReleasePTY.closeTab` | none | `CloseAttachOnly` runs no tmux command → always known |
| `ghostCleanup` (via `ghostKillTmuxByName`) | ghost worktree **delete** + record delete | **FIXED** — found by this audit |
| `Instance.CloseTab` | none (one tab) | ignore, written down |
| `tab_spawn.go` ×2 | none (abandoned spawn) | ignore, written down |
| `tmux/start.go` ×2 | none (failed start returns an error) | ignore, written down |

**`sessionExists` (bool, collapses unknown→`true`)** — the collapse is safe for every read-only consumer (`io.go`, `clientless.go`, `start.go`, `backend_local.go`, `instance.go`, `manager_create.go`): each acts destructively only on `false`, and a false "gone" would SIGKILL a live agent's tree. The one consumer that *acts* — `Close` — now takes the new two-value `probeSession` and handles `!known`.

**`SessionProcessTrees`** — a timeout returns `nil`, so nothing is reaped. Conservative at every caller (`close.go`, `start.go`, `doctor/`).

**git `runGitLocalCommand`** — `Cleanup`'s timeout gates finalize + the record delete. **`MoveWorktree` is still on the unbounded runner**, so it *hangs* rather than destroying under uncertainty — not a violation of this invariant, and out of scope here; flagged in code where a future bound must return `stateUnknown`.

**`config` flock timeouts** — schema migration fails before the guard (clean); the tombstone write aborts before teardown; the record delete keeps the record + tombstone for the finisher.

### Deliberately NOT changed

`Close` reporting `PaneStateKnown` when tmux **answers** that the session *survived* the kill. That is a confirmed-alive session, and the worktree step still proceeds — pre-existing #478/#967 behavior, arguably its own latent bug. Changing it would make a genuinely unkillable session undeletable, which is a product decision beyond this fix. Called out in `Close` rather than silently altered.

Likewise `waitForPIDExit` timing out stays a log: kill-session was **confirmed** delivered, so the pane is dying, merely slow. Treating a slow flush as unknown would defer routine kills of any agent taking >3s to exit. The unknown cases are the ones where tmux never spoke.

### Failing-then-passing (each watched failing first)

```
--- FAIL: TestTeardownTabs_ArchivePaneMayBeLive_SkipsTheMove (11.00s)
    handleWorktree ran despite tmux never confirming the pane was dead
--- FAIL: TestCloseAndWaitForPaneExit_PanePIDTimeout_KeepsTheUnknown (2.01s)
    a timed-out panePID reported a KNOWN state: the pane-exit wait was skipped
--- FAIL: TestTeardownTabs_WorktreeStateUnknown_SkipsFinalize
    finalize ran after a worktree action that was cut off mid-flight
--- FAIL: TestClose_HasSessionProbeTimeout_ReportsUnknown (2.01s)
    a timed-out has-session probe reported a KNOWN state
--- FAIL: TestRefreshInstanceStatus_TombstonedAfterTeardown_StillFinishesTheKill
    the poll never finished the tombstoned kill … until the daemon restarts
```
All PASS after. `TestTeardownTabs_ConfirmedTmuxFailure_StillProceeds` and `TestClose_SessionSurvivesKill_StillErrors` guard the other direction — that this cannot quietly become "any tmux hiccup blocks the kill" — and pass both ways.

### On finding 5, the one that reached furthest

`refreshInstanceStatus` returned at `!Started()` **before** looking for the tombstone. This survived round 1 only because the tombstone is written *before* teardown, so the DISK record still says `started=true` and a **daemon restart** reloads it and finishes the kill — i.e. it degraded to exactly the "only a restart can reap it" behavior this PR exists to remove, while the error told the user it would be retried automatically. A promise the code did not keep. The tombstone check now outranks the started fence.

### Gates (re-run)

`make test-container` exit=0 (29 packages, 0 failures) · `go build ./...` · `gofmt -l .` empty · `golangci-lint --fast` exit=0 · `deadcode -test ./...` empty · `scripts/lint-file-length.sh` passed (667 files). Rebased onto current master. No real daemon touched; all work in throwaway container homes.


---

## Codex review round 3 — the exhaustive audit (`b3fe493` → `6e55ec6`)

> "If a reviewer keeps finding new instances, the audit was not exhaustive."

Correct, and the reason is specific. In round 2 I made `tmux.Close` return a `PaneState`, and the **compiler** enumerated its call sites for me — that surface is exhaustive because it had to be. I never gave the **worktree/record** surface the same treatment. I fixed it where I happened to be standing. That is why round 3 found more.

So `GitWorktree.Cleanup` now returns a **`CleanupState`** next to its error, same trick. The compiler named every caller, and **that found two sites this review did not**:

- **`daemon/rootagent.go:296`** — the dead-root reap logged `inst.Kill()`'s error and deleted the record anyway. Fourth instance of the class.
- **`session/backend_local.go:301`** — the create-failure cleanup folded a cut-off removal into a prose message; the create then released the title over the leftovers (this is finding 3's actual root).

### Audit table — every destructive step, with verdicts

**A. `gw.Cleanup()` — all 4 callers (compiler-enumerated):**

| Site | Destructive step downstream | Verdict |
|---|---|---|
| `teardownKill.handleWorktree` | finalize + record delete | **gated** on `CleanupState` (round 2) |
| `ghostCleanupWorktree` → `ghostCleanup` | ghost record delete | **FIXED** (finding 2) — returns state; `KillSession` keeps the record |
| `backend_local.go:301` (create-failure) | title release | **FIXED** — surfaces `ErrWorkspaceLeftBehind` (finding 3's root) |
| *(`Cleanup` itself)* | `os.RemoveAll` | `shouldRemoveWorktreeDir` refuses on a tripped deadline (round 1) |

**B. Worktree removal / move:**

| Site | Verdict |
|---|---|
| `Cleanup` `worktree remove -f` / `branch -D` / `prune` | bounded; timeout ⇒ `CleanupStateUnknown` |
| `MoveWorktree` (archive) | **unbounded** ⇒ *hangs*, never destroys-under-unknown. Not a violation of this invariant; gated upstream by the pane state. Code note marks where a future bound must return `stateUnknown`. |
| `RebuildFromExistingBranch` / `RebuildFreshFromRecordedBase` (`worktree remove -f`, `_`-ignored) | **create/recover** path, rebuilding a worktree that is already gone. Nothing to orphan. |
| `CleanupWorktreesForRepo`, `commands/reset.go`, `doctor` | `af reset` / diagnostics sweeps, not session teardown. Out of this invariant's scope. |
| `ptychannel_tmux.go` `RemoveAll` | its own FIFO temp dir. Not a workspace. |

**C. Record deletion — all 4 sites:**

| Site | Verdict |
|---|---|
| `KillSession` (`manager_sessions.go:161`) | **gated** — skipped on any unsafe teardown (rounds 1–2) |
| `finishUserKill` (`rootkill.go:143`) | **gated** — keeps the record on an unsafe `Kill` (round 2) |
| `reapDeadRoot` (`rootagent.go:303`) | **FIXED** — was log-and-delete; now keeps the record, retries next tick |
| `Storage.DeleteInstance` (title-only) | thin wrapper over the gated `DeleteInstanceByStableID`; no daemon caller |
| `delete(m.instances, …)` (in-memory) | follows a successful disk delete, or rolls back a failed append. Destroys nothing on disk. |

**D. The tombstone write** — the commit point itself; see finding 1 below.

### Finding 1 — a commit point another writer could roll back

The write and the in-memory mark straddled a `repoStartLock` release. A status poll could take the lock in that gap, read `userKilled` still false, and write the tombstone straight back out.

Fixed by marking **inside the same hold**. I verified the premise rather than assuming it: every single-record writer (`persistInstanceErr`, `conversation_capture.go`, `limit.go`, `manager_tabs.go` ×3, `manager_create.go`) evaluates `instance.ToInstanceData()` **under** `repoStartLock` — `limit.go` already documents the same "while STILL HOLDING the repo start lock" pattern. `manager.go:266` and `manager_create.go:419` are reads, not writes. So a poll now lands either before the write (we overwrite it) or after the mark (it reads `true`).

**Note on this test, because it deserves the caveat:** my first version **passed against the neutered code** — the real gap is nanoseconds, so the racing poll essentially never won. Rather than claim a proof I did not have, I widened the pre-existing gap with a sleep *in the neuter only*. The sleep does not create the bug; it makes an existing window observable. The shipped code has no sleep.

### Failing-then-passing

```
--- FAIL: TestPersistKillTombstone_ConcurrentPollWrite_TombstoneSurvives (0.94s)
    a concurrent poll write erased the kill tombstone … A commit point another writer can roll back is not a commit point.
--- FAIL: TestGhostCleanup_WorktreeTimeout_RetainsTheRecord
    ghostCleanup reported success though the worktree removal was cut off mid-delete
--- FAIL: TestCreateSession_UnsafeCleanup_KeepsTheRecordAndTheTitle
    a create whose cleanup could not complete safely released its title and kept NO record
```
All PASS after.

### Still deliberately unchanged (unchanged from round 2, restated)

`Close` reports `PaneStateKnown` when tmux **answers** that the session survived the kill — a confirmed-alive session, where the worktree step still proceeds. Pre-existing #478/#967; changing it would make a genuinely unkillable session undeletable, which is a product call. Flagged in code, not silently altered.

### Gates

`make test-container` exit=0 (29 packages, 0 failures) · `go build ./...` · `gofmt -l .` empty · `golangci-lint --fast` exit=0 · `deadcode -test ./...` empty · `scripts/lint-file-length.sh` passed (668 files). Rebased onto current master. No real daemon touched.



---

## Round 4 — the design step, and the destructive-surface table (`6e55ec6` → `2b829f6`)

Four rounds, one shape. The invariant was a **habit**: every call site had to remember not to swallow a deadline and not to proceed. Habits lose. This round makes it structural.

### What changed

**1. Invert the default — `Unknown` is the ZERO VALUE** of `PaneState`, `CleanupState`, and `teardownState`, and every gate is written as **prove-settled** (`!= Known`) rather than `== unknown`. A state nobody set refuses to destroy.

Your option 3 needed one correction to bite: a zero-value flip alone would *not* have caught round 4, because the bug was an explicit `state := CleanupSettled` followed by a hand-downgrade at **one of five** bounded commands. So:

**2. The runner owns the state.** `cleanupRun` (git) and `closeRun` (tmux) run every bounded command through one method that records a tripped deadline, and **derive** the state. Verified mechanically:

```
$ sed -n '/func .*Cleanup/,/^}/p' | grep -c 'CleanupSettled\|CleanupStateUnknown'   → 0
$ sed -n '/func .*Close() (PaneState/,/^}/p' | grep -c 'PaneState...'                → 0
```

Neither function names a state constant. A command added to either participates automatically — there is nothing left to forget. Both round-4 findings die at the root rather than individually.

**3. Choke points for the destructive acts**: `cleanupRun.removeDir` (worktree directory) and `Manager.deleteSessionRecord` (the record). Verified: **zero** `DeleteInstanceByStableID` callers in `daemon/` outside the choke point.

### The destructive-surface table

| # | Site | What it destroys | How unknown state is prevented from reaching it |
|---|---|---|---|
| 1 | `cleanupRun.removeDir` | worktree **directory** (`os.RemoveAll`) | **Choke point.** Refuses while `r.unknown`. The only `os.RemoveAll` in `Cleanup`. |
| 2 | `Cleanup` → `worktree remove -f` | worktree + registration | via `r.git` ⇒ deadline marks the run unknown |
| 3 | `Cleanup` → `branch -D` | **branch** | via `r.git` — **round-4 finding 2** |
| 4 | `Cleanup` → `prune` ×2 | worktree metadata | via `r.git` — **round-4 finding 2** |
| 5 | `cleanupRun.shouldRemoveWorktreeDir` → `registered()` | *gates* #1 | via `r.git`; an unanswered probe returns `ok=false` ⇒ never takes the string fallback — **round-4 finding 1** |
| 6 | `teardownTabs` → `handleWorktree` | worktree delete (kill) / **move** (archive) | core gates on `state != stateKnown` from every `closeTab` |
| 7 | `teardownTabs` → `finalize` | tmux refs + worktree pointer (the retry's handle) | gated on `wtState != stateKnown` |
| 8 | `Manager.deleteSessionRecord` | **session record** | **Choke point.** Refuses on a non-nil `teardownErr`. |
| 9 | `KillSession` record delete | record | routes through #8 |
| 10 | `finishUserKill` record delete | record | routes through #8 |
| 11 | `reapDeadRoot` record delete | record | routes through #8 — *was still log-and-delete after two audits I called exhaustive* |
| 12 | `ghostCleanup` → `ghostCleanupWorktree` | ghost worktree + record | gates on `PaneState` and on `CleanupState` |
| 13 | `CreateSession` failure → title release | releases a title over live leftovers | keeps a record when `Kill` reports unsafe |
| 14 | `Close` → `reapLeakedProcesses` | agent **process trees** | `leaked = nil` on every unknown branch |

**Not gated, deliberately, with reasons:**

| Site | Why |
|---|---|
| `MoveWorktree` git commands | **unbounded** ⇒ *hangs*, never destroys-under-unknown. Not a violation of this invariant. Gated upstream by the pane state; code note marks where a future bound must return `stateUnknown`. |
| `Close` when tmux **answers** "session survived" | Confirmed-alive, not unknown. Worktree step proceeds — pre-existing #478/#967. Changing it makes an unkillable session undeletable: a product call, flagged not altered. |
| `waitForPIDExit` timeout | kill-session was **confirmed** delivered; the pane is dying, merely slow. Treating slow as unknown would defer routine kills. |
| `g.isWorktreeRegistered` (old probe) | Only reached from `DiagnoseMissingWorktree` — read-only diagnostics, nothing destructive downstream. |
| `RebuildFrom*` `worktree remove -f` (`_`-ignored) | **create/recover** path, rebuilding a worktree already gone. Nothing to orphan. |
| `CleanupWorktreesForRepo`, `commands/reset.go`, `doctor` | `af reset` / diagnostics sweeps, not session teardown. |
| `os.RemoveAll` **after** entry | No Go deadline interrupts a stalled in-kernel syscall. The choke point stops us *entering* under unknown; a mount that stalls after entry still parks. **Real residual limit.** |

### The inversion caught a real one immediately

Four tests went red on the first full run. Three were a genuine regression I introduced (my `closeRun` refactor appended the raw kill error unconditionally, breaking #967 idempotency — an already-dead session started erroring). **The fourth was the design working**: a test stub forgot to set `worktreeState`, it defaulted to `stateUnknown`, and the core refused to destroy. That is precisely the failure mode we wanted — forgetting is now safe rather than destructive.

### Failing-then-passing

```
--- FAIL: TestCleanup_TimedOutRegistrationProbe_DoesNotDeleteTheDirectory (0.31s)
    a timed-out registration probe reported a SETTLED cleanup … the string fallback lets an
    UNBOUNDED os.RemoveAll run against the very path that just stalled git
--- FAIL: TestCleanup_TimedOutBranchDelete_ReportsUnknown (0.30s)
    a timed-out `git branch -D` reported a SETTLED cleanup … EVERY bounded command in the run
    must mark unknown, not just the worktree remove.
```
Both PASS after. `TestCleanup_HealthyRun_IsSettled` guards the other direction — that inverting the default has not made every cleanup refuse — and passes both ways.

### Gates

`make test-container` exit=0 (29 packages, 0 failures) · `go build ./...` · `gofmt -l .` empty · `golangci-lint --fast` exit=0 · `deadcode -test ./...` empty · `scripts/lint-file-length.sh` passed (668 files). Rebased onto current master. `ptybroker.go` untouched — #1943/#1941 own it.



---

## Rebased onto #1944 (`2b829f6` → `a058c00`)

#1944 merged while this branch was in review and added `TestClientlessCaptureCloseWakesBlockedRead`, which calls `ts.Close()` — a signature this PR changed to `(PaneState, error)`. CI's two failures were one root: the package stopped compiling, and `deadcode` cannot analyze a package that will not build.

**Only the test's call site changed.** #1944's `captureReader` is the real fix for the user's bug; its production code is untouched here. Verified: this branch's diff against master touches **neither** `session/ptychannel_tmux.go` nor `session/ptybroker.go`. That layer belongs to #1943/#1944.

`TestClientlessCaptureCloseWakesBlockedRead` **passes on this branch** (0.33s) — checked explicitly rather than inferred from a green suite.

Worth noting: this is the compiler-forced enumeration doing exactly its job. A call site added by an unrelated PR was caught at **build time** and made to acknowledge the pane state, instead of silently taking a default that permits destruction. Under the old zero-value-means-safe-to-destroy scheme, a newly added caller would have compiled fine and been wrong.

**Process correction:** I gated round 4 *before* rebasing and pushed the rebased result, so the tree CI tested was not the tree I verified. That is what let this reach CI. Gates below were re-run on the rebased tree.

### Gates (on the rebased tree, `a058c00` atop v1.0.195)

`make test-container` exit=0 (29 packages, 0 failures) · `go build ./...` · `gofmt -l .` empty · `golangci-lint --fast` exit=0 · `deadcode -test ./...` empty · `scripts/lint-file-length.sh` passed (670 files).


---

## Round 5 — retention is a claim on other layers (`a058c00` → `5cb7034`)

The lesson lands and it is genuinely different from rounds 2–4. The choke point makes the **destructive act** safe. It does nothing to make the **retained state durable** — and retention turns out to be a claim on three layers I never touched, none of which had heard of it.

### The retention table — for a record we retain: who can delete it, who picks it up, what makes them aware

| Retained row | Who can delete it | Who must pick it up | What makes them aware it exists | Status |
|---|---|---|---|---|
| **Tombstoned live instance** (KillSession / finishUserKill refused) | `deleteSessionRecord` — gated on unknown state | `refreshInstanceStatus` → `finishUserKill`, every poll | It is in `m.instances`; the tombstone check now outranks the `!Started()` fence (round 2) | ✅ |
| ″ | **`Storage.SaveInstances` checkpoint** — drops non-started, non-Archived rows | — | **Nothing did.** Now: `UserKilled` joins `Archived` in the keep clause | ✅ **FIXED (1)** |
| **`keepFailedCreate` row** (my own round-3 retain) | same checkpoint | nobody | **Nothing did — this retention was decoration too.** Now tombstoned, so the checkpoint keeps it *and* the finisher reaps it | ✅ **FIXED** (not reported; found by applying this question to my own path) |
| **Tombstoned GHOST** (`instance == nil`) | `deleteSessionRecord` | **nobody — `finishUserKill` only visits `m.instances`, which a ghost never enters** | Nothing can. The message no longer claims otherwise | ⚠️ **BY DESIGN (3)** — user retries |

### (1) The checkpoint erased what the kill retained

`SaveInstances` already carried this exact exception for `Archived`, with a comment describing the bug class verbatim (#1028): *"Dropping it on a wholesale per-repo checkpoint save — triggered whenever ANY started instance in the same repo is saved — would silently orphan the archived worktree."* A kill clears `started` **before** teardown, so every row an unsafe teardown retained had precisely that shape and was silently dropped. I recreated a bug whose fix was three lines above mine.

### (2) Safe-by-default had become stuck-by-default

This one inverted the PR's own goal, and the diagnosis is exactly right: **"the endpoint didn't answer" is not "we don't know if it's destroyed."** `remoteAgentServer.Kill` returns `killErr` even when `s.teardown()` **succeeded** — sandbox reaped, workspace provably gone — and my blanket `teardownErr != nil` gate read that as unknown and refused forever.

The taxonomy now lives in one predicate, `session.TeardownStateUnknown`, beside the two sentinels whose **only** producers are the teardown choke points (`teardownTabs` raises them, `ghostCleanup` forwards them, nothing else constructs them). One producer, one predicate, one place to change.

This also **exposed a too-loose test of mine**: `TestFinishUserKill_UnsafeTeardown_KeepsTheRecordForRetry` used a *generic* error to mean "unsafe". Under the corrected taxonomy a generic failure does not block, so it went red — correctly. The double now returns an unknown-state error, which is what "unsafe" actually means. The pre-existing `TestKillSession_TombstoneSurvivesFailedTeardown` (#1108's contract) passes unchanged.

### (3) A promise the code could not keep

Fixed by deleting the promise, not by faking it. Making a ghost reachable means giving the finisher a second iteration source (a disk sweep) — a real change to the poll's shape, and out of scope here. The record and tombstone still survive, which keeps the workspace addressable and stops the poll classifying it Lost; the retry is the user's, and the message says so. Worth its own issue if ghosts with persistent `FromInstanceData` errors turn out to be more than theoretical.

### Failing-then-passing

```
--- FAIL: TestSaveInstances_KeepsTombstonedRowAlongsideStartedSibling
    the daemon's checkpoint silently dropped a RETAINED tombstoned row … the retention that
    KillSession and finishUserKill deliberately performed is undone by a writer in another layer
--- FAIL: TestDeleteSessionRecord_EndpointDeadButWorkspaceGone_ClearsTheTombstone (0.54s)
    a teardown error that is NOT about workspace state must not block the delete … safe-by-default
    became stuck-by-default
```
Both PASS after. `TestDeleteSessionRecord_UnknownState_StillBlocks` guards the other direction — narrowing the taxonomy must not let a genuinely-unknown teardown through — and passes both ways. The checkpoint test's *started sibling* is load-bearing: without it the repo has no rows to save, the checkpoint is a no-op, and the bug never fires.

### Gates (rebased FIRST, then gated — last round's lesson)

`make test-container` exit=0 (29 packages, 0 failures) · `go build ./...` · `gofmt -l .` empty · `golangci-lint --fast` exit=0 · `deadcode -test ./...` empty · `scripts/lint-file-length.sh` passed (671 files). 0 behind master.


---

## Round 6 — the invariant lived in the wrong lifetime (`5cb7034` → `8edfe6f`)

Both findings are one root, and naming it is worth more than the diff: **"unknown" is a fact about the workspace and about the runtime — but I stored it on a struct that dies on retry, and inferred it from a clock that never looked.**

### The lifetime table — where each piece of knowledge must live

| Knowledge | Lifetime it needs | Where it was | Where it is now |
|---|---|---|---|
| "this filesystem stalls" | the **workspace**, across every retry | `cleanupRun.unknown` — died with the attempt | `GitWorktree.cleanupStalled`, latched; the unsafe path skips `finalize` precisely so the worktree pointer survives, so this is exactly the retry path's lifetime |
| "this run's outcome" | the **attempt** | `cleanupRun.unknown` — correct here | unchanged; `state()` stays per-run so a healed FS can still settle and drop the record |
| "this runtime survived" | a **poll observation**, whenever it happens | `confirmBy` — a fixed 15s clock | `Manager.aliveObservations`, incremented only where a probe gets an answer |

### (1) Refusing once is not refusing

The shape is nastier than "a missed site": attempt 1 correctly refuses the unbounded `RemoveAll`; `finishUserKill` then retries with a **fresh run whose `unknown` is false**; `worktree list` answers "not registered" — *because the timed-out remove had already deregistered it* — so the delete runs against the same stalled mount and wedges the guard. My safety was per-attempt against a fault that is per-workspace.

**Choice, since you asked for one: the deletion stays avoided, and the knowledge is latched on the workspace.** Justification — `os.RemoveAll` takes no context, so *entering* it is a one-way door; bounding it with a goroutine+deadline instead would park a goroutine in the kernel per attempt, and at `finishUserKill`'s poll cadence that leaks one per second. Avoiding entry beats bounding entry. The latch is sticky for the daemon's life and re-probed on restart, which is the one moment there is genuinely new information (the mount may be back). The cost is named: if the FS heals but git still reports the path unregistered, the record is retained until restart — recoverable and visible, versus a wedged guard.

`removeDir` also marks the run unknown when it refuses, so a refusal can never be reported as a settled cleanup and drop the record.

### (2) Time is not observation

> "Elapsed time without a successful liveness observation is not proof that the runtime survived."

That sentence is the fix. The fixed 15s window was wrong at both ends, and both cases collapse into one property once confirmation is an observation:

- `daemon_poll_interval` > the window: a process that exits **immediately** is only seen Lost *after* the window — history cleared, fresh episode, backoff never arms. Which is #1910, reintroduced by #1910's own fix.
- Remote at defaults: `remoteLostGracePeriod` (60s) deliberately keeps an unanswerable session non-Lost for 4× the window. Same outcome.

Confirmation is now `Manager.aliveObservations`, incremented **only** where `as.Snapshot()` succeeds — the daemon's single positive proof of life — and compared against the count captured at respawn. It scales with the real poll interval and the real grace because it waits for the thing itself. **`lostRestoreConfirmSettle` is deleted**; there is no duration left to guess.

This also forced two of my own tests to be rewritten: they advanced `confirmBy` into the past, i.e. they *asserted that elapsed time confirms a runtime*. They now drive an explicit observation, and no test in this area touches a clock.

### Failing-then-passing

```
--- FAIL: TestCleanup_RetryAfterStall_StillRefusesTheUnboundedDelete (0.31s)
    the RETRY ran the unbounded os.RemoveAll against a filesystem already known to stall:
    the knowledge died with attempt 1's run … Refusing once is not refusing.
--- FAIL: TestRestoreLostSessions_NeverObservedAlive_BacksOffRegardlessOfElapsedTime
    consecutiveFailures = 0 after repeated unobserved deaths; each one must count against
    the SAME episode so the backoff escalates
```
Both PASS after. The second covers **both** reported configurations with one property — long poll interval and the 60s remote grace are the same case once the test is "no answer, no confirmation, however much time passes". `TestRestoreLostSessions_ObservationConfirms_NotElapsedTime` guards the positive half so the fix cannot become "nothing ever confirms".

### Gates (rebased first, then gated)

`make test-container` exit=0 (29 packages, 0 failures) · `go build ./...` · `gofmt -l .` empty · `golangci-lint --fast` exit=0 · `deadcode -test ./...` empty · `scripts/lint-file-length.sh` passed (674 files). 0 behind master.


---

## Round 7 — the evidence trace (`8edfe6f` → `452a28d`)

> "Every round of this PR has been one shape: **evidence exists, and something between it and the decision drops it.**"

That is exactly right, and round 7 is the sharpest instance because the thing that dropped it was *my own fix for round 6*. I replaced "time is not observation" with a counter — and the counter was defeated by **"no error is not alive"**. Absence of an error masqueraded as evidence.

### The trace: for each decision, what evidence it requires and every hop that evidence survives

**Decision A — delete the worktree?** Requires: *tmux confirmed this pane is not running.*

| hop | can it turn "I don't know" into "fine"? |
|---|---|
| `kill-session` / `has-session` / `display-message` | **Was yes** — raw `exec.Command`, no deadline → hung (rounds 1–2). Now bounded; `closeRun` records the deadline. |
| `Close` → `PaneState` | **Was yes** — hand-assigned at 2 of 3 sites (round 2 f4). Now derived by `closeRun`; `Close` names no constant. |
| `CloseAndWaitForPaneExit` | **Was yes** — discarded a timed-out `panePID` (round 2 f2). Now keeps the unknown. |
| `teardownKill` / `teardownArchive`.closeTab | **Was yes** — logged and returned nil (round 2 f1). Now one shared classifier; the core gates on **state**, not the error. |
| `Start` → `Launch` | **Was yes** — dropped the state behind a **false comment**, and `%v` erased the sentinel (round 7 f2). Now `%w`; Launch retains the workspace. |
| `shouldRemoveWorktreeDir` → `registered()` | **Was yes** — a timed-out probe fell through to the string gate (round 4 f1). Now `ok=false` refuses. |
| `cleanupRun.unknown` across a **retry** | **Was yes** — died with the run (round 6 f1). Now latched on the `GitWorktree`. |

**Decision B — clear the restore history?** Requires: *affirmative proof this runtime is alive.*

| hop | can it turn "I don't know" into "alive"? |
|---|---|
| elapsed time | **Was yes** — a fixed 15s window (round 6 f2). **Deleted.** |
| `Snapshot() err == nil` | **Was yes** — `localAgentServer.Snapshot` returns nil *unconditionally*; it wraps `HasUpdated`, which suppresses capture/session-gone failures (round 7 f1). **Removed as a signal.** |
| `updated` / `hasPrompt` / `probeAlive` | **No.** Each can say **yes**: output only a live pane emits; a matched prompt proves the capture succeeded (every failure path returns `""`); `probeAlive` is "the agent answered and is running". Decided in **one** place. |

**Decision C — retain the record?** Requires: *the retention actually survives every other writer.*

| hop | can it drop the retained row? |
|---|---|
| `SaveInstances` checkpoint | **Was yes** — omits non-started, non-Archived (round 5 f1). Now `UserKilled` joins `Archived`. |
| `deleteSessionRecord` | **Was inverted** — blocked on *any* error, so a reaped sandbox could never clear (round 5 f2). Now only `TeardownStateUnknown`. |
| `CreateSession` failure branch | **Was yes** — used `killErr != nil`, so a remote whose sandbox teardown SUCCEEDED tombstoned a row and blocked its title over a workspace already gone (round 7 f3). Now the same classifier. |
| the finisher's iteration source | **Still yes for ghosts** — `m.instances` only; a ghost never enters it. Not fixed; the message no longer promises it. |

**The rule that falls out:** any hop that can produce "no error" without having asked a question is not an evidence source. `Snapshot` is the archetype — it cannot fail, so it cannot inform.

### Two ignores whose written-down reasons were false

Round 2 I said an ignore is fine if you *write the ignore down*. Both of round 7's worktree findings were ignores **with** a written reason — and the reason was wrong about a layer I never checked:

- `start.go`: *"Start's failure path touches no worktree"* — `Launch` calls `gw.Cleanup()` the instant Start errors.
- `backend_local.go`: *"the tmux session never came up, so there is no live pane"* — against a wedged server a detached session may exist with its pane running.

Writing the ignore down is not enough if the justification is unverified. Both now carry a check, not a claim.

### A finding beyond the report

Building the test for f2 surfaced that under a wedged server `Start` returns early at its `DoesSessionExist` gate — the deliberate conservative lie reports "exists" — and **never reaches the cleanup `Close` at all**. That path is safe (the worktree is brand-new and nothing ever spawned into it), but it is why the regression test drives has-session→*answered-no* + spawn-succeeds + readiness-timeout: the reported path is only reachable once a pane may genuinely be live.

### Failing-then-passing

```
--- FAIL: TestRefreshInstanceStatus_SnapshotNilErrorOnDeadSession_IsNotAnObservation
    a Snapshot that returned NIL for a session this very tick marked Lost was counted as a
    liveness observation … rebuilding #1910's hot loop
--- FAIL: TestStart_ReadinessTimeoutOnWedgedServer_PropagatesTheUnknown (4.01s)
    Start dropped the unknown pane state … got: … (cleanup error: tmux command timed out: kill-session after 150ms)
```
Both PASS after. The second's neutered output is itself the `%v` lesson: the words *"tmux command timed out"* are right there in the message, and `errors.Is` still cannot see them — a flattened error is not a signal. `TestRefreshInstanceStatus_LiveSessionIsObserved` guards the positive half, so requiring affirmative evidence cannot become "nothing ever confirms".

### Gates

`make test-container` exit=0 (29 packages, 0 failures) · `go build ./...` · `gofmt -l .` empty · `golangci-lint --fast` exit=0 · `deadcode -test ./...` empty · `scripts/lint-file-length.sh` passed (675 files). Rebased first, then gated. 0 behind master.


---

## Round 8 — the root: bool where we needed a tri-state (`452a28d` → `412c740`)

> "You keep fixing the callers. The callers are not the problem: **the type is**."

That is the root, and it explains every round of this PR. A bool cannot say "I don't know", so every timeout-capable primitive was **forced** to pick — and always picked the convenient answer. `sessionExists` turned a timed-out `tmux has-session` into `true`; `IsAlive` passed it up as a plain bool; `localAgentServer.Alive` hardcoded `nil`. UNKNOWN was laundered into AFFIRMATIVE at the bottom of the stack, and everything above — including this PR's own affirmative-evidence counter, built one round earlier to fix exactly this disease — was downstream of a lie it could not detect.

### The fix is one signature

```go
-  IsAlive(instance *Instance) bool
+  IsAlive(instance *Instance) (bool, error)   // "could not ask" is now sayable
```

The plumbing above it was **already correct** and had been all along:

```go
alive, err := as.Alive()
if err != nil { return probeUnknown }   // ← this branch was unreachable for local
if alive     { return probeAlive   }
return probeDead
```

`probeLiveness` had a perfectly good three-valued answer, with `probeAlive` documented as *"the agent answered and is running"* — and `probeUnknown` as *"NOT evidence of death"*. The whole tri-state existed. It was simply unreachable, because the primitive underneath could not express it. Now the counter, the teardown gate and Ready-marking all **inherit** the truth instead of re-deriving it.

`TmuxSession.ProbeSession` exposes the tri-state `probeSession` already computed internally. `DoesSessionExist` keeps its conservative lie for the ~15 read-only callers that only ever act on "no" — now documented as **unusable as evidence**, with `IsAlive` the one to take when the answer is evidence.

### The P1 was the worst outcome in this PR's history

A `git worktree remove -f` that times out AFTER deregistering the checkout leaves `branch -D` free to **succeed** — precisely *because* the checkout is now unregistered, so git raises no "branch is checked out" objection. `removeDir` had correctly retained the files; the very same run then deleted their only ref. **We save the workspace and destroy the pointer to it**, which is worse than either alone: the files survive and nothing can find them.

Every destructive act in a run now goes through one gate (`destructive()`), not just the file deletion — the same "one place, not three" shape as the rest of this PR.

### Two smaller ones, both the same disease

- `reapDeadRoot` returned `(false, nil)` on failure — *"no, but fine"* is absence-of-error wearing a different hat. The caller skipped `rootEnsureFailed`, so a persistent timeout re-ran the whole bounded teardown **every tick**, occupying the single poll loop.
- The watchdog fired at **45s** against a worst-case *legitimate* teardown of **~727s** (387s of tmux across `maxTabs` + 300s of git + graces). It cried wolf on healthy work. Now 15m, with the arithmetic written into the constant so it cannot drift silently.

### Failing-then-passing

```
--- FAIL: TestCleanup_StalledRemove_DoesNotDeleteTheRetainedWorkspacesBranch (0.30s)
    cleanup deleted the BRANCH of a workspace it had just decided to RETAIN … unique commits
    become unreachable … Unknown must gate EVERY destructive act in the run.
--- FAIL: TestRefreshInstanceStatus_WedgedProbe_IsNotAnObservation (0.04s)
    a liveness probe that TIMED OUT was counted as affirmative evidence … The fix is the
    primitive's type, not this caller: the next caller would have been round 9's finding.
```
Both PASS after. The second's neuter is the argument in miniature: to reproduce the bug the double must `return true, nil` — *exactly what a bool primitive was forced to say*.

### Two mistakes of mine this round, since they are part of the record

1. **My own de-dup swallowed a real deadline.** Suppressing the branch-delete error on `r.unknown` was wrong: `r.unknown` was set *by that very command's timeout*, so the deadline never reached the joined error. A round-4 test caught it. Fixed by distinguishing **refused** (already recorded) from **ran-and-failed** (the caller must see it) — the same evidence-must-arrive rule, one level down.
2. **A careless `git checkout` in a restore path** reverted a test file to HEAD, silently destroying the new test and a signature fix. The `vet` gate caught it. Rebuilt.

### Gates

`make test-container` exit=0 (29 packages, 0 failures) · `go build ./...` · `gofmt -l .` empty · `golangci-lint --fast` exit=0 · `deadcode -test ./...` empty · `scripts/lint-file-length.sh` passed (675 files). Rebased first, then gated. 0 behind master.


---

### Follow-up filed: #1962 — the root, beyond this PR's scope

Round 8's root — *a bool cannot say "I don't know"* — is only patched here, on the liveness path (`Backend.IsAlive` → `(bool, error)`, `TmuxSession.ProbeSession`). The primitive is still a bool, and **16 production call sites still inherit the lie**, including two already known to misread it (`start.go:16` fails a wedged start with a misleading "session already exists"; `start.go:46`'s readiness poll exits as if the session came up). `HasUpdated`/`Snapshot` still cannot report that a capture failed.

Tracked in **#1962** with the full call-site table and acceptance criteria. Deliberately **not** landed here — it is a cross-cutting refactor of the tmux package, and this PR is already large enough to review.


---

## Self-review round (`c8464a7` → `d36327c`) — the bot has not reviewed this PR

**Proof, not assumption.** The GitHub review bot is down, and on this PR "no findings" means nobody looked:

| | |
|---|---|
| current head | `d36327c`, committed **2026-07-17T09:10:49Z** |
| the **only** review ever posted | **2026-07-16T16:28:40Z**, on commit **`780cf8f`** |

That review is ~17h old and sits on the **round-1 head — eleven heads ago**. Its four inline comments are round 2's findings. **Everything from round 3 onward, including the tri-state root fix, has never been seen by GitHub.** Staying in draft.

So I read my own diff. It found a P1 in my own work.

### P1 — an orphan I nearly shipped, caused by this PR's own fix

`cleanupRun.registered()` returned `ok=false` for **any** git error, so `shouldRemoveWorktreeDir` refused whenever the registration was unreadable. That **conflates "could not ask" with "asked and got an error"** — the exact disease this PR has been fixing, in my own code.

The #726 shape: `worktree remove -f` fails fast with `"validation failed"` (a corrupted `.git` pointer) **and** `worktree list` also fails fast. Both ANSWERED; nothing stalled. Result:

- nothing deleted (the probe "could not be read" ⇒ refuse), **but**
- no deadline tripped ⇒ `state()` reports **CleanupSettled** ⇒ the caller **drops the record**.

Workspace left on disk with nothing pointing at it — **the orphaning this PR exists to prevent, introduced by round 4's fix for it.** Master handled this correctly and said so in a comment I read and didn't heed: *"Also the path taken when `worktree list` itself failed (listErr != nil): without a readable registration we fall back to the conservative #726 string gate."*

Now: a **timed-out** probe keeps round 4's refusal (the run is already unknown, so the record is retained and a retry can finish); an **answered** error falls back to the string gate, as before.

### P2 — a race my own comment denied

`persistKillTombstone` read `instance.ToInstanceData()` **outside** the repo lock, while the comment I wrote in round 6 claimed *"every other writer … serializes `instance.ToInstanceData()` under it."* True of the others — and not of this function. Round 6 closed the **mark** side of the race and left the **read** side open, so a poll persisting in that window would be clobbered by a stale snapshot. The snapshot is taken under the lock now: the comment had to be made **true**, not deleted.

### P3 — a doc that lied about its own return shape

`deleteSessionRecord`'s comment promised *"Returns deleted=false with a nil error when the delete was correctly skipped"*. It returns an **error** on refusal — and callers depend on that (`reapDeadRoot`'s backoff arms from it). Corrected.

### Failing-then-passing

```
--- FAIL: TestCleanup_CorruptRepoWithUnreadableRegistration_StillDeletesTheDirectory (0.01s)
    a corrupted worktree whose registration could not be READ (an answered error, not a stall)
    was left on disk while the run reported its outcome as settled — so the caller deletes the
    record and orphans it. 'Could not ask' and 'asked and got an error' are different: only the
    first is unknown (#726 regression).
```
PASS after. Round 4's `TestCleanup_TimedOutRegistrationProbe_DoesNotDeleteTheDirectory` still passes, so the timeout refusal is intact — the two cases are now genuinely distinguished rather than traded off.

### A second collision, caught by rebasing first

**#1965** (`929199c`, v1.0.197 — #1953's branch-provenance fix) landed mid-review and added `TestLegacyNilProvenance_CleanupPreservesReusedUserBranch`, which calls `Cleanup()` — a signature this PR changed. Only the test's call site changed; #1953's fix is untouched and **both of its regression tests pass on this branch** (checked explicitly, not inferred from a green suite).

### Gates

`make test-container` exit=0 (29 packages, 0 failures) · `go build ./...` · `gofmt -l .` empty · `golangci-lint --fast` exit=0 · `deadcode -test ./...` empty · `scripts/lint-file-length.sh` passed (678 files). Rebased onto v1.0.197 **first**, then gated. 0 behind master.
