### PR TITLE
test(lifecycle): clean-install and install->upgrade coverage in a throwaway environment

### DIFF
--- a/.github/workflows/lifecycle.yml
+++ b/.github/workflows/lifecycle.yml
@@ -31,6 +31,7 @@ on:
       - ".github/workflows/lifecycle.yml"
       - "scripts/lifecycle.sh"
       - "scripts/lifecycle-lib.sh"
+      - "scripts/lifecycle-selftest.sh"
       - "scripts/container/lifecycle-entry.sh"
       - "scripts/container/Dockerfile.test"
       - "scripts/testbox.sh"
@@ -52,6 +53,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # The harness's own safety logic. Pure shell logic — no container, no network —
+  # so unlike the legs below it is cheap enough to never skip, and it is what
+  # keeps the gate itself from silently becoming a rubber stamp.
+  selftest:
+    name: Lifecycle harness selftest
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - run: make lifecycle-selftest
+
   # The leg that covers assertion #4. A GitHub runner is itself a clean,
   # ephemeral machine with a real systemd user manager — which the test
   # container does not have (PID 1 is docker-init, `af daemon install` fails

--- a/.github/workflows/lifecycle.yml
+++ b/.github/workflows/lifecycle.yml
@@ -1,0 +1,157 @@
+name: Lifecycle (clean install + upgrade)
+
+# The clean-environment install/upgrade gate. Every other workflow builds THIS
+# TREE and tests it in isolation; this one installs a REAL previous release into
+# a throwaway machine, puts sessions on it, upgrades it the way a user does, and
+# asserts the machine is coherent afterwards.
+#
+# That version boundary is where the bugs users actually hit live — #1921 (a new
+# client against an old daemon), #796 (the daemon demoted from its unit to an
+# ad-hoc child) — and no single-version test can construct it.
+#
+# WHY NIGHTLY, NOT PER-PR:
+#   * it downloads real published release tarballs, so it needs network and is
+#     not hermetic — a GitHub outage or a rate limit would redden unrelated PRs;
+#   * it installs across a RELEASE boundary, so what it tests is "the last two
+#     releases + this tree", which changes when releases cut, not when a PR
+#     lands. A per-PR run would mostly re-test the same boundary all day.
+# Run it on demand from the Actions tab (workflow_dispatch) before anything that
+# touches upgrade, daemon lifecycle, or autostart.
+#
+# NOTE: this file is deliberately separate from pr.yml/build.yml so the macOS
+# matrix leg can be added here without touching the workflows other jobs share.
+
+on:
+  # Self-test: run on a PR ONLY when the gate's own definition changes, so the
+  # PR that touches it proves it still works. Unrelated PRs never pay the cost
+  # and can never be reddened by a GitHub-releases outage.
+  pull_request:
+    branches: [master]
+    paths:
+      - ".github/workflows/lifecycle.yml"
+      - "scripts/lifecycle.sh"
+      - "scripts/lifecycle-lib.sh"
+      - "scripts/container/lifecycle-entry.sh"
+      - "scripts/container/Dockerfile.test"
+      - "scripts/testbox.sh"
+  schedule:
+    # 07:00 UTC daily — after the nightly release cadence has settled.
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+    inputs:
+      inject:
+        description: "Fault injection to prove the gate still detects a bad machine (e.g. skip-daemon-restart)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lifecycle-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # The leg that covers assertion #4. A GitHub runner is itself a clean,
+  # ephemeral machine with a real systemd user manager — which the test
+  # container does not have (PID 1 is docker-init, `af daemon install` fails
+  # outright there). So supervision is only really tested here.
+  native:
+    name: Lifecycle (${{ matrix.os }}, native)
+    strategy:
+      fail-fast: false
+      matrix:
+        # macOS leg: add `macos-latest` here once the macos-latest runner job
+        # lands (the ci-macos-runner work). Two helpers in
+        # scripts/lifecycle-lib.sh are Linux-only and must grow a Darwin branch
+        # first — lc_daemon_version reads /proc/<pid>/exe, and lc_unit_main_pid
+        # asks systemctl. On macOS the same scenario must cover the launchd
+        # path, which is where the real user's bugs live.
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.25"
+
+      - name: Install harness dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends tmux jq curl
+
+      - name: Enable the systemd user manager
+        # `af daemon install` registers a user-level unit (systemctl --user), so
+        # the user manager has to be running and reachable. On a GitHub runner
+        # the user has no login session, so enable lingering and point
+        # XDG_RUNTIME_DIR at the resulting runtime dir.
+        #
+        # If this ever stops working the gate does NOT silently pass: the
+        # harness prints "SKIP assertion #4" and the verify step below fails the
+        # job, because a green run that quietly stopped testing supervision is
+        # exactly the lie this whole workflow exists to prevent.
+        run: |
+          sudo loginctl enable-linger "$USER"
+          echo "XDG_RUNTIME_DIR=/run/user/$(id -u)" >> "$GITHUB_ENV"
+          for i in $(seq 1 30); do
+            [ -d "/run/user/$(id -u)" ] && break
+            sleep 1
+          done
+          systemctl --user show-environment >/dev/null 2>&1 \
+            && echo "systemd user manager: reachable" \
+            || echo "::warning::systemd --user is not reachable; the supervision assertion will SKIP and this job will fail"
+
+      - name: Build af from this tree
+        run: |
+          go build -o "$RUNNER_TEMP/bin/af" .
+          "$RUNNER_TEMP/bin/af" version
+
+      - name: Run the lifecycle gate
+        env:
+          # The runner is ephemeral and has no real AF home, so it IS the
+          # throwaway machine this harness requires.
+          AF_LIFECYCLE_DISPOSABLE: "1"
+          AF_LIFECYCLE_AF_BIN: ${{ runner.temp }}/bin/af
+          AF_LIFECYCLE_WORKSPACE: ${{ runner.temp }}/af-lifecycle
+          AF_LIFECYCLE_INJECT: ${{ github.event.inputs.inject }}
+          # Raises the release-API rate limit; the API is public either way.
+          GITHUB_TOKEN: ${{ github.token }}
+        run: bash scripts/lifecycle.sh all 2>&1 | tee "$RUNNER_TEMP/lifecycle.log"
+
+      - name: Verify the supervision assertion actually ran
+        # The container leg legitimately skips assertion #4. This leg is the ONLY
+        # place it runs, so a SKIP here means the job proved nothing about the
+        # thing it exists for.
+        if: ${{ always() && github.event.inputs.inject == '' }}
+        run: |
+          if grep -q 'SKIP.*assertion #4' "$RUNNER_TEMP/lifecycle.log"; then
+            echo "::error::assertion #4 (unit stays the supervisor) was SKIPPED on the native leg — this job exists to cover it. Check the systemd user manager setup."
+            exit 1
+          fi
+          echo "assertion #4 ran on this leg."
+
+      - name: Upload the run log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lifecycle-${{ matrix.os }}-log
+          path: ${{ runner.temp }}/lifecycle.log
+          if-no-files-found: ignore
+
+  # The same gate a maintainer runs on a shared dev box (`make
+  # lifecycle-container`). It covers everything except supervision, and exists
+  # here so the container path itself cannot rot unnoticed.
+  container:
+    name: Lifecycle (container)
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v6
+      - name: Run the containerized lifecycle gate
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          AF_LIFECYCLE_INJECT: ${{ github.event.inputs.inject }}
+        run: make lifecycle-container

--- a/.github/workflows/lifecycle.yml
+++ b/.github/workflows/lifecycle.yml
@@ -119,7 +119,13 @@ jobs:
           AF_LIFECYCLE_INJECT: ${{ github.event.inputs.inject }}
           # Raises the release-API rate limit; the API is public either way.
           GITHUB_TOKEN: ${{ github.token }}
-        run: bash scripts/lifecycle.sh all 2>&1 | tee "$RUNNER_TEMP/lifecycle.log"
+        # `set -o pipefail` is load-bearing: without it the exit status of
+        # `lifecycle.sh | tee` is TEE's, so a run with failing assertions
+        # reported success. That is not hypothetical — it happened on the first
+        # run of this workflow, which passed while reporting two FAILs.
+        run: |
+          set -o pipefail
+          bash scripts/lifecycle.sh all 2>&1 | tee "$RUNNER_TEMP/lifecycle.log"
 
       - name: Verify the supervision assertion actually ran
         # The container leg legitimately skips assertion #4. This leg is the ONLY

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@
 	agent-server-roundtrip-container remote-agent-server-roundtrip-container \
 	backend-docker-roundtrip backend-ssh-roundtrip \
 	playtest-container playtest-container-detached tui-driver tui-driver-selftest \
+	lifecycle-container \
 	testbox-image lint-file-length docs web-build web-test web-selftest-container
 
 # Structural-health lint (#1145): fail if any Go file exceeds its line limit
@@ -112,6 +113,24 @@ tui-driver:
 
 tui-driver-selftest:
 	scripts/testbox.sh selftest
+
+# Clean-environment install + upgrade gate. Every other target here tests THIS
+# TREE in isolation; this one installs a REAL previous release into a throwaway
+# machine, puts sessions on it, upgrades it the way a user does, and asserts the
+# machine is coherent afterwards (daemon restarted onto the new binary, no
+# version skew, one daemon, sessions survived, doctor clean).
+#
+# That version boundary is where the bugs users actually hit this week live —
+# #1921 (new client vs old daemon), #796 (daemon demoted from its unit) — and no
+# single-version test can construct it.
+#
+# Needs network: it downloads published release tarballs. Wired nightly rather
+# than per-PR for that reason (.github/workflows/lifecycle.yml). The container
+# has no systemd, so the supervision assertion is SKIPped here and covered by
+# the CI runner leg. Narrow the run with LIFECYCLE_SCENARIO=scenario-a.
+# See docs/lifecycle-testing.md.
+lifecycle-container:
+	scripts/testbox.sh lifecycle $(LIFECYCLE_SCENARIO)
 
 # (Re)build the toolchain image only.
 testbox-image:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 	agent-server-roundtrip-container remote-agent-server-roundtrip-container \
 	backend-docker-roundtrip backend-ssh-roundtrip \
 	playtest-container playtest-container-detached tui-driver tui-driver-selftest \
-	lifecycle-container \
+	lifecycle-container lifecycle-selftest \
 	testbox-image lint-file-length docs web-build web-test web-selftest-container
 
 # Structural-health lint (#1145): fail if any Go file exceeds its line limit
@@ -131,6 +131,14 @@ tui-driver-selftest:
 # See docs/lifecycle-testing.md.
 lifecycle-container:
 	scripts/testbox.sh lifecycle $(LIFECYCLE_SCENARIO)
+
+# Tests for the lifecycle harness's OWN safety logic: that a fault injection
+# which cannot execute FAILS rather than passing, that the disposable guard
+# refuses an unrecognized runtime, and that concurrent runs cannot share an
+# image tag. Pure logic — no containers, no daemons, no network, no AF home —
+# so it runs on the host in about a second and gates every PR.
+lifecycle-selftest:
+	bash scripts/lifecycle-selftest.sh
 
 # (Re)build the toolchain image only.
 testbox-image:

--- a/docs/container-testing.md
+++ b/docs/container-testing.md
@@ -93,10 +93,33 @@ assertions. `make tui-driver-selftest` is the acceptance gate; `make
 tui-driver` drops you into a live driven session. See
 [tui-manual-testing.md](tui-manual-testing.md).
 
+## `make lifecycle-container` — clean install + upgrade
+
+```bash
+make lifecycle-container
+make lifecycle-container LIFECYCLE_SCENARIO=scenario-a   # narrow it
+```
+
+The one target here that does **not** just test this tree: it installs a REAL
+previous release into a throwaway machine, puts sessions on it, upgrades it the
+way a user does (`af upgrade` and the launch-time auto-update), and asserts the
+machine is coherent afterwards — daemon restarted onto the new binary, no
+client/daemon version skew, exactly one daemon, sessions survived, `af doctor`
+clean. That version boundary is where #1921 and #796 shipped, and no
+single-version test can construct it.
+
+Two things make it unlike the other targets: it needs **network** (it downloads
+published release tarballs), so it is wired **nightly** rather than per-PR; and
+it **cannot** cover the autostart-supervision assertion here, because there is no
+systemd in the container — that assertion is SKIPped loudly and covered by the
+CI runner leg. See [lifecycle-testing.md](lifecycle-testing.md).
+
 ## Known limitations
 
 - **No systemd inside** — autostart-unit flows (`af daemon install`) still
-  need CI or careful host testing.
+  need CI or careful host testing. It fails outright in the container
+  ("systemctl: executable file not found"), which is why the lifecycle gate
+  SKIPs its supervision assertion here and runs it on the CI runner instead.
 - **Network-dependent flows** (`gh`, pushing branches) need an explicitly
   injected token; the sandbox has none by default, which keeps external
   access opt-in and visible.

--- a/docs/lifecycle-testing.md
+++ b/docs/lifecycle-testing.md
@@ -201,6 +201,39 @@ The general rule this settles on: **prefer fail-closed**. Enumerating bad states
 fails open — anything you did not think of passes. Asking "is this provably the
 good state?" turns every surprise into a loud failure instead of a quiet green.
 
+## The harness's own tests (`make lifecycle-selftest`)
+
+The gate proves things about af; this proves things about the gate — and it is
+the cheaper half: pure logic, no containers, no daemons, no network, so it runs
+on the host in a second and gates every PR.
+
+It covers the three ways this harness can become a rubber stamp, none of which
+is visible in a passing run:
+
+* **a fault injection that cannot execute.** An unregistered name
+  (`skip-restart` vs `skip-daemon-restart`) matches no branch, so nothing is
+  injected and every assertion passes — a green check for an experiment that
+  never happened. Names are now validated against a registry *before* anything
+  runs (hard exit 2), and execution is **recorded**: an injection requested but
+  never reached (e.g. asked for scenario B while only scenario A runs) FAILS the
+  run. Never a skip — a skip is how this class hides.
+* **the disposable guard saying yes to a real machine.** Detection is positive
+  only and the default is NO: docker (`/.dockerenv`), podman
+  (`/run/.containerenv` — testbox supports both engines, so a podman box could
+  not run this gate at all before), or `CI=true`. An unrecognized runtime is
+  never "probably fine".
+* **concurrent runs sharing an image tag.** That is #1171 (the fixed
+  `af-playtest` name), fixed in #1166 with per-run-unique names; the tag now
+  carries the same per-run token the container does and is removed on exit.
+
+Each case was **watched failing** against the pre-fix code. That discipline paid
+for itself immediately: the first version of the podman test re-implemented the
+detection and grepped the source for `/run/.containerenv` — and **passed against
+code with podman detection deleted**, because that string also appears in the
+guard's error message. The markers are now injectable variables so the test
+drives the real function. A test written to confirm a fix is not a test until
+you have seen it fail.
+
 ## What this does NOT cover yet
 
 * **macOS / launchd.** `lc_unit_active` and `lc_unit_main_pid` already have

--- a/docs/lifecycle-testing.md
+++ b/docs/lifecycle-testing.md
@@ -123,20 +123,58 @@ apparently "running"). Assertions 1 and 2 fail and the gate exits non-zero.
 Re-run this whenever you change the harness. An assertion that cannot be watched
 failing is not evidence.
 
+## Where assertion #4 (supervision) actually runs
+
+This is the assertion the gate most needs — an upgrade demoting the daemon off
+its unit (#796) is **invisible to every other check here**, because the demoted
+daemon keeps running and keeps answering. So it gets its own rules.
+
+It runs on the **CI native leg**, against a real systemd user manager, and it
+passes there today:
+
+```
+PASS  assertion 4: the unit is still active (= active)
+PASS  assertion 4: af still sees the autostart unit (= true)
+PASS  assertion 4: the running daemon IS the unit's child (MainPID=7712) — not demoted
+```
+
+That last line is the one that catches the demotion: it compares *the daemon
+that is running* against *the daemon systemd owns*. A demoted daemon still
+answers pings; it just is not the unit's child any more.
+
+It **cannot** run in the test container, and that is not a policy choice:
+
+| approach | verdict |
+|---|---|
+| `systemd --user` standalone in the container | **impossible** — it refuses without PID 1 systemd: *"Trying to run as user instance, but the system has not been booted with systemd."* |
+| full systemd as PID 1 in the container | works, but needs `--privileged` + host cgroups — which dissolves the very fence the container exists to provide on a shared box. Rejected as a default. |
+| assert it at the af layer instead | does not help: with no service manager, `af daemon install` fails outright, so there is no unit to be the supervisor of. The layer was never the problem. |
+| the CI runner | **works** — it is itself a clean, ephemeral machine with a real systemd. This is where it runs. |
+
+Two guards keep that honest:
+
+* a **SKIP is not a pass**: any skipped check exits the run non-zero unless
+  `AF_LIFECYCLE_ALLOW_PARTIAL=1` is set. `make lifecycle-container` sets it (a
+  dev-box container genuinely cannot host a service manager) and prints a
+  PARTIAL COVERAGE banner naming what went untested;
+* the CI native leg **fails the job** if assertion #4 ever silently starts
+  skipping — a green run that quietly stopped testing supervision is the exact
+  lie this gate exists to prevent.
+
 ## What this does NOT cover yet
 
-* **macOS / launchd.** `lc_daemon_version` reads `/proc/<pid>/exe`, which macOS
-  does not have, and `lc_unit_main_pid` asks `systemctl`. Both need a Darwin
-  branch before the `macos-latest` matrix leg is switched on in
-  `.github/workflows/lifecycle.yml`. On macOS the same scenario must cover the
-  launchd path, which is where the real user's bugs live.
-* **Assertion #4 on container runs.** The test container has no systemd (PID 1
-  is `docker-init`), so `af daemon install` fails there outright. The assertion
-  is **SKIPped loudly** and only really runs on the CI runner, which has a real
-  systemd user manager. The workflow fails the native leg if that assertion ever
-  silently starts skipping.
-* **`af reset` racing a supervised relaunch** (#1916) — the scenario upgrades,
-  it does not reset.
+* **macOS / launchd.** `lc_unit_active` and `lc_unit_main_pid` already have
+  Darwin branches, so assertion #4 asserts the *same property* against launchd
+  (`state = running` and `pid = N` in the `gui/<uid>` domain af restarts) rather
+  than a re-invented one. The blocker for the `macos-latest` leg is **assertion
+  2**: `lc_daemon_version` reads `/proc/<pid>/exe`, which macOS has no
+  equivalent of — `ps` would report the path, whose bytes are the NEW binary
+  after an upgrade, i.e. exactly the inference this assertion refuses to make.
+  The macOS leg therefore wants **#1920**'s daemon-reported version. Given
+  #1931 turned on macOS CI and immediately found three real darwin defects
+  (#1939, #1940, #1941), this leg is worth landing soon.
+* **#1916's reset-vs-relaunch race** — this scenario upgrades, it does not
+  reset.
 * **Downgrades and channel switches** (`--allow-downgrade`, preview → stable).
 * **Package-manager installs** (Homebrew, `install.sh`); the gate installs the
   release tarball the way `af upgrade` does.

--- a/docs/lifecycle-testing.md
+++ b/docs/lifecycle-testing.md
@@ -116,12 +116,30 @@ the machine so the assertions can be watched failing:
 AF_LIFECYCLE_INJECT=skip-daemon-restart make lifecycle-container LIFECYCLE_SCENARIO=scenario-b
 ```
 
-`skip-daemon-restart` swaps the binary to N and never restarts the daemon —
-reconstructing the #1921 machine exactly (new client, old daemon, everything
-apparently "running"). Assertions 1 and 2 fail and the gate exits non-zero.
+| injection | reconstructs | must fail |
+|---|---|---|
+| `skip-daemon-restart` | the #1921 machine: binary swapped to N, daemon never restarted — new client, old daemon, everything apparently "running" | assertions 1 and 2 |
+| `unhealthy-session` | a session left in a non-healthy state across the upgrade (`Archived(6)/LiveArchived(5)`) | assertion 5 |
 
-Re-run this whenever you change the harness. An assertion that cannot be watched
-failing is not evidence.
+Re-run these whenever you change the harness. **An assertion that cannot be
+watched failing is not evidence** — and this gate has caught itself twice on
+exactly that:
+
+* the Lost check tested `status/liveness == 4` (`Dead`/`LiveDead`), both
+  **write-never** since #1108 — deaths record `Lost`, and persisted `Dead` is
+  rewritten to `Lost` on load. It could not match anything on any machine, and
+  reported "0 sessions Lost: PASS" forever. It is now **fail-closed**: it asks
+  "is every session in a state I recognise as healthy?", so an unknown or
+  drifted enum value fails LOUDLY instead of quietly matching nothing;
+* an unscoped `sessions list` counted the wrong project's sessions and passed
+  locally by accident (see the `--repo` note above).
+
+Why `unhealthy-session` archives rather than killing a pane: **it can't be Lost
+on demand.** Killing a session's tmux does not strand it — the daemon restores it
+within ~4s (measured: Running→Ready, and it heals even with the worktree
+deleted, #1108's restore loop). So an injection built on that would quietly
+inject nothing, which is the same vacuity in a different hat. Archive is durable
+and lands on a real non-healthy state.
 
 ## Where assertion #4 (supervision) actually runs
 

--- a/docs/lifecycle-testing.md
+++ b/docs/lifecycle-testing.md
@@ -1,0 +1,142 @@
+# Lifecycle testing — clean install and install → upgrade
+
+Every other gate in this repo tests **code in isolation**. `make test-container`,
+the `*-roundtrip-container` harnesses, `make tui-driver-selftest` — each builds
+the current tree and exercises it. None of them ever installs a release,
+upgrades it, and checks what the machine looks like afterwards.
+
+That is where the bugs users actually hit live. They are not logic bugs; they
+are **lifecycle** bugs, and they need two versions and a real machine to exist
+at all:
+
+| | what escaped |
+|---|---|
+| [#1921](https://github.com/sachiniyer/agent-factory/issues/1921) | a **new client** against an **old daemon** hard-failed (`unknown field "tab_id"`). The daemon is upgraded independently of its clients, so this is only reachable across a version boundary. |
+| [#1916](https://github.com/sachiniyer/agent-factory/issues/1916) | `af reset` SIGKILLed a wedged daemon; the service manager relaunched it mid-wipe. Found by a **user**. |
+| [#796](https://github.com/sachiniyer/agent-factory/issues/796) | the daemon **demoted** from supervised (a systemd unit) to an ad-hoc child: a daemon still runs and still answers, while the unit sits inactive/dead. |
+
+A dev box is the *opposite* of the environment those need: it has an installed
+unit, a live daemon, and months of state. "Works here" says nothing about a new
+machine, which has **no config, no unit, no home, no daemon**.
+
+`scripts/lifecycle.sh` builds that machine from nothing, then upgrades it.
+
+## Running it
+
+```bash
+# The whole gate, container-fenced. The only way to run it on a dev box.
+make lifecycle-container
+
+# Narrow it while iterating.
+make lifecycle-container LIFECYCLE_SCENARIO=scenario-a
+make lifecycle-container LIFECYCLE_SCENARIO=scenario-b
+```
+
+It needs **network**: it downloads real published release tarballs. That is the
+point — the whole gate is about the boundary between two real releases — but it
+also means this is the one testbox target that is not hermetic, which is why it
+is wired **nightly** rather than per-PR (`.github/workflows/lifecycle.yml`). It
+also runs on a PR that touches the gate's own files, so a change to the harness
+proves itself.
+
+## The scenarios
+
+### A — clean first run
+
+The machine a new user has: no `config.toml`, no AF home, no autostart unit, no
+daemon. Nothing in af may assume any of them exist. It asserts the preconditions
+first (so a "clean run" that wasn't clean cannot pass quietly), then: `af
+version` works, `af doctor` reports **zero FAIL** a new user cannot act on
+(missing agents are WARNs with a fix line — correct), the **TUI renders its
+first frame** on a virgin home without panicking, and the daemon comes up
+**exactly once**.
+
+### B — install → upgrade
+
+Install a **real previous release**, put sessions on it, upgrade the way a user
+actually does, assert the machine is coherent. Both upgrade paths are covered,
+because they are different code paths into the same restart:
+
+* `af upgrade`
+* the **launch-time auto-update** (`commands/root.go` → `autoUpdateOnLaunch`),
+  which is gated on stdout being a TTY and so can only be driven through a real
+  terminal — a tmux pane, never a plain exec.
+
+| # | assertion |
+|---|---|
+| 1 | the daemon is **restarted onto the new binary** — not left running the old one |
+| 2 | **client version == daemon version**, queried rather than inferred |
+| 3 | exactly **one** daemon afterwards; no orphan survives |
+| 4 | if a unit was installed, it is **still the supervisor** — not demoted to an ad-hoc child, and the unit is not left inactive/dead |
+| 5 | pre-existing **sessions survive** (count before == after; none Lost) |
+| 6 | `af doctor` reports **zero FAILs** afterwards |
+
+The release pair is resolved from the API at run time (the two newest
+non-prereleases), not pinned: nothing here asserts a specific version, so the
+gate keeps testing the current boundary as releases cut.
+
+## How assertion 2 queries the daemon
+
+There is no "what version are you?" RPC on the daemon today — that is
+[#1920](https://github.com/sachiniyer/agent-factory/pull/1920). So the daemon's
+version is read from the image it is **actually executing**: copy
+`/proc/<pid>/exe` and ask it. This is a real query, not an inference from the
+binary on disk, and that distinction is the whole bug — after an upgrade the
+on-disk binary is N while a daemon that was never restarted is still executing
+the N-1 image. `/proc/<pid>/exe` still resolves to those bytes even though the
+path now reads `(deleted)`.
+
+`lc_doctor_fail_count` **feature-detects** `af doctor --json`: it parses the text
+summary today, and switches to the structured summary the moment #1920 lands. No
+follow-up edit needed here.
+
+## Isolation
+
+The harness is destructive by design — it installs binaries, registers autostart
+units, upgrades af over itself, and stops daemons. It refuses to run unless
+**both** are true:
+
+1. `AF_LIFECYCLE_DISPOSABLE=1` is set explicitly, and
+2. the environment *positively* looks disposable — `/.dockerenv` (container) or
+   `CI=true`.
+
+A shared dev box has neither, so it refuses there **even with the opt-in set**.
+The workspace is validated too: it can never be, or sit inside, the real AF
+home. Every daemon it signals is proven to serve its own throwaway home by
+reading `/proc/<pid>/environ` — so it cannot touch a real daemon, or another
+user's.
+
+## Proving the gate still bites
+
+Most of the bugs above are fixed, so a green run proves little on its own — the
+value is the ones it catches **next**. `AF_LIFECYCLE_INJECT` deliberately breaks
+the machine so the assertions can be watched failing:
+
+```bash
+AF_LIFECYCLE_INJECT=skip-daemon-restart make lifecycle-container LIFECYCLE_SCENARIO=scenario-b
+```
+
+`skip-daemon-restart` swaps the binary to N and never restarts the daemon —
+reconstructing the #1921 machine exactly (new client, old daemon, everything
+apparently "running"). Assertions 1 and 2 fail and the gate exits non-zero.
+
+Re-run this whenever you change the harness. An assertion that cannot be watched
+failing is not evidence.
+
+## What this does NOT cover yet
+
+* **macOS / launchd.** `lc_daemon_version` reads `/proc/<pid>/exe`, which macOS
+  does not have, and `lc_unit_main_pid` asks `systemctl`. Both need a Darwin
+  branch before the `macos-latest` matrix leg is switched on in
+  `.github/workflows/lifecycle.yml`. On macOS the same scenario must cover the
+  launchd path, which is where the real user's bugs live.
+* **Assertion #4 on container runs.** The test container has no systemd (PID 1
+  is `docker-init`), so `af daemon install` fails there outright. The assertion
+  is **SKIPped loudly** and only really runs on the CI runner, which has a real
+  systemd user manager. The workflow fails the native leg if that assertion ever
+  silently starts skipping.
+* **`af reset` racing a supervised relaunch** (#1916) — the scenario upgrades,
+  it does not reset.
+* **Downgrades and channel switches** (`--allow-downgrade`, preview → stable).
+* **Package-manager installs** (Homebrew, `install.sh`); the gate installs the
+  release tarball the way `af upgrade` does.

--- a/docs/lifecycle-testing.md
+++ b/docs/lifecycle-testing.md
@@ -179,6 +179,28 @@ Two guards keep that honest:
   skipping — a green run that quietly stopped testing supervision is the exact
   lie this gate exists to prevent.
 
+## The audit: "what would make this pass without testing anything?"
+
+Asked of every assertion in the script. It is the only question that matters for
+a gate like this, and it found five real holes — four of which would have shipped
+green:
+
+| assertion | what would make it pass vacuously | what stops it now |
+|---|---|---|
+| TUI renders **on a virgin home** | the doctor probe ran first and **created the home + log**, so "virgin" was already false when measured. An observation that creates the state it observes is not an observation. | each probe gets its **own pristine home** and calls `lc_assert_virgin` immediately before touching it — which holds regardless of which command materializes what, on either side of the upgrade |
+| **no panic** on the first frame | an **empty capture**: `grep` finds no panic in a dead pane and passes | require the screen to contain the TUI marker *before* concluding anything about what is not on it (it reports how many lines it searched) |
+| **first session created** | `af sessions create` answering **0 while its JSON body carries a refusal** — observed on this harness | assert the outcome: the daemon must *list* the session |
+| **no version skew** (the #1921 check) | `lc_assert_eq "" ""` — if `/proc/<pid>/exe` were unreadable *and* the client version came back empty, the most important assertion here would compare nothing to nothing and report "no skew" | both operands must be non-empty or it fails |
+| **no session Lost** | testing `status == 4` (`Dead`) — **write-never** since #1108, so it matched nothing on any machine | fail-**closed**: "is every session in a state I recognise as healthy?", so unknown/drifted values fail loudly |
+| **unit installed** | `af daemon install` returning 0 without registering anything | confirm `daemon status --json .autostart_unit` is true |
+| **fault injections** | the injection **silently no-ops** (a CLI change, an RPC error) and the run reports on a scenario that never existed | each injection asserts its **outcome** (not its exit code) and aborts the scenario if it did not apply |
+| **sessions survive** | counting **0 before and 0 after** (`0 == 0`) | scenario B aborts unless exactly 2 sessions exist first |
+| session counts | an unscoped `sessions list` counting **the wrong project** | every query passes `--repo` |
+
+The general rule this settles on: **prefer fail-closed**. Enumerating bad states
+fails open — anything you did not think of passes. Asking "is this provably the
+good state?" turns every surprise into a loud failure instead of a quiet green.
+
 ## What this does NOT cover yet
 
 * **macOS / launchd.** `lc_unit_active` and `lc_unit_main_pid` already have

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,6 +130,7 @@ nav:
           - HTTP API reference: reference/api.md
       - Maintainers:
           - Container testing: container-testing.md
+          - Lifecycle testing: lifecycle-testing.md
           - Web client selftest: web-selftest.md
           - File-length lint: file-length-lint.md
           - Release process: release-process.md

--- a/scripts/container/Dockerfile.test
+++ b/scripts/container/Dockerfile.test
@@ -8,9 +8,12 @@
 FROM golang:1.25-bookworm
 
 # tmux + git are what the suite drives; procps provides pgrep for the
-# daemon's SIGTERM fallback path.
+# daemon's SIGTERM fallback path; zsh is exercised by the shell-suggest lanes
+# (#1990). curl + jq are the lifecycle gate's (scripts/lifecycle.sh): it
+# downloads real release tarballs and reads `af daemon status --json` /
+# `af doctor --json` rather than scraping text.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends tmux git procps zsh \
+    && apt-get install -y --no-install-recommends tmux git procps zsh curl jq \
     && rm -rf /var/lib/apt/lists/*
 
 # Give the container a stable git identity so no test or mock-repo commit

--- a/scripts/container/lifecycle-entry.sh
+++ b/scripts/container/lifecycle-entry.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Runs INSIDE the testbox container (see scripts/testbox.sh lifecycle):
+# build af from the mounted source, then hand over to scripts/lifecycle.sh,
+# which builds its own throwaway machines under a scratch workspace and drives
+# the clean-install / install->upgrade scenarios against them.
+#
+# Everything here — the tmux server, every daemon, every AF home, every binary
+# this installs — dies with the container. Teardown is container exit.
+#
+# NOTE ON COVERAGE: this container has no systemd (PID 1 is docker-init), so
+# `af daemon install` cannot work here and the supervision assertion (#4) is
+# SKIPped. That assertion only really runs on the CI runner, which has a real
+# systemd user manager. The skip is printed loudly in the summary — see
+# docs/lifecycle-testing.md.
+set -euo pipefail
+
+export AF_LIFECYCLE_WORKSPACE="${AF_LIFECYCLE_WORKSPACE:-$HOME/af-lifecycle}"
+# The harness is destructive by design and refuses to run without this; the
+# container is exactly the throwaway environment it wants.
+export AF_LIFECYCLE_DISPOSABLE=1
+
+mkdir -p "$HOME/bin"
+
+echo ">>> building af from /src ..."
+# Same two ownership guards as playtest-entry.sh (#1167): /src is a read-only
+# bind mount owned by the host user, so git would refuse the "dubious
+# ownership" repo and the toolchain would fail reading .git for a VCS stamp.
+# Keep the entry scripts consistent on this.
+(cd / && git config --global --add safe.directory /src) 2>/dev/null || true
+(cd /src && go build -buildvcs=false -o "$HOME/bin/af" .)
+
+# Scenario A installs "the af a new user gets today" — this tree's build.
+# Scenario B ignores it and installs REAL published releases instead.
+export AF_LIFECYCLE_AF_BIN="$HOME/bin/af"
+
+echo ">>> af built: $("$AF_LIFECYCLE_AF_BIN" version 2>/dev/null | head -1)"
+
+exec bash /src/scripts/lifecycle.sh "$@"

--- a/scripts/lifecycle-lib.sh
+++ b/scripts/lifecycle-lib.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+# lifecycle-lib.sh — guards, assertions, and daemon introspection for the
+# clean-environment install/upgrade gate (scripts/lifecycle.sh).
+#
+# Split from lifecycle.sh so the scenarios read as scenarios: everything here
+# is plumbing that answers ONE question — "what is actually true of this
+# machine right now" — without any opinion about what should be true.
+#
+# Sourced, never executed.
+
+# ----------------------------------------------------------------------------
+# Result accounting. Assertions never abort the run: a lifecycle scenario that
+# stops at the first failure hides the other five, and the whole point of this
+# gate is to report the full state of an upgraded machine in one pass.
+# ----------------------------------------------------------------------------
+LC_PASS=0
+LC_FAIL=0
+LC_SKIP=0
+LC_FAILED_NAMES=()
+
+lc_say() { printf '[lifecycle] %s\n' "$*" >&2; }
+lc_section() { printf '\n[lifecycle] ===== %s =====\n' "$*" >&2; }
+
+lc_pass() {
+    LC_PASS=$((LC_PASS + 1))
+    printf '[lifecycle]   PASS  %s\n' "$*" >&2
+}
+
+lc_fail() {
+    LC_FAIL=$((LC_FAIL + 1))
+    LC_FAILED_NAMES+=("$1")
+    printf '[lifecycle]   FAIL  %s\n' "$*" >&2
+}
+
+# lc_skip — a check that could not run here. Loud on purpose: a silently
+# skipped assertion reads exactly like a passing one in a green log, and the
+# supervision check (#4) is skipped on every container run. Anything that
+# skips must say so in the summary too.
+lc_skip() {
+    LC_SKIP=$((LC_SKIP + 1))
+    printf '[lifecycle]   SKIP  %s\n' "$*" >&2
+}
+
+lc_assert_eq() {
+    local want="$1" got="$2" what="$3"
+    if [ "$want" = "$got" ]; then
+        lc_pass "$what (= $got)"
+    else
+        lc_fail "$what: want '$want', got '$got'"
+    fi
+}
+
+lc_assert_ne() {
+    local unwant="$1" got="$2" what="$3"
+    if [ "$unwant" != "$got" ]; then
+        lc_pass "$what (changed to $got)"
+    else
+        lc_fail "$what: expected a change, but it is still '$got'"
+    fi
+}
+
+lc_summary() {
+    printf '\n[lifecycle] ===== summary =====\n' >&2
+    printf '[lifecycle] %d PASS, %d FAIL, %d SKIP\n' "$LC_PASS" "$LC_FAIL" "$LC_SKIP" >&2
+    if [ "$LC_SKIP" -gt 0 ]; then
+        printf '[lifecycle] NOTE: %d check(s) were SKIPPED — this run did not cover them.\n' "$LC_SKIP" >&2
+    fi
+    if [ "$LC_FAIL" -gt 0 ]; then
+        printf '[lifecycle] failed checks:\n' >&2
+        local n
+        for n in "${LC_FAILED_NAMES[@]}"; do printf '[lifecycle]   - %s\n' "$n" >&2; done
+        return 1
+    fi
+    return 0
+}
+
+# ----------------------------------------------------------------------------
+# The isolation guard.
+#
+# This harness is destructive BY DESIGN: it installs binaries, registers an
+# autostart unit with the user's service manager, upgrades af over itself, and
+# stops daemons. Every one of those is a catastrophe against a real machine —
+# so the guard's default answer is NO, and it takes both an explicit opt-in and
+# a disposable-looking environment to get a yes.
+#
+# Detection is positive, never "not obviously a dev box": a container has
+# /.dockerenv, a CI runner sets CI=true. A shared dev box has neither, so it
+# refuses even if someone exports the opt-in by accident.
+# ----------------------------------------------------------------------------
+lc_guard_disposable() {
+    if [ "${AF_LIFECYCLE_DISPOSABLE:-}" != "1" ]; then
+        lc_say "REFUSING: this harness installs binaries, registers autostart units,"
+        lc_say "upgrades af over itself and stops daemons. It only ever runs in a"
+        lc_say "throwaway environment. Set AF_LIFECYCLE_DISPOSABLE=1 to confirm."
+        lc_say "On a dev box use: make lifecycle-container"
+        return 1
+    fi
+
+    local disposable=no reason=""
+    if [ -f /.dockerenv ]; then
+        disposable=yes
+        reason="container (/.dockerenv)"
+    elif [ "${CI:-}" = "true" ]; then
+        disposable=yes
+        reason="CI runner (CI=true)"
+    fi
+    if [ "$disposable" != yes ]; then
+        lc_say "REFUSING: no disposable environment detected (no /.dockerenv, CI!=true)."
+        lc_say "This looks like a real machine. Use: make lifecycle-container"
+        return 1
+    fi
+
+    # A disposable environment is necessary but not sufficient: inside a
+    # container someone can still bind-mount a real home in and point the
+    # workspace at it. Every AF home this harness uses is built under
+    # $LC_WORKSPACE, so validating the workspace covers all of them.
+    if [ -z "${LC_WORKSPACE:-}" ]; then
+        lc_say "REFUSING: LC_WORKSPACE is unset."
+        return 1
+    fi
+    case "$LC_WORKSPACE" in
+    "$HOME/.agent-factory" | "$HOME/.agent-factory"/* | "$HOME" | /)
+        lc_say "REFUSING: workspace '$LC_WORKSPACE' is (or is inside) the real AF home."
+        return 1
+        ;;
+    esac
+    if [ -n "${AGENT_FACTORY_HOME:-}" ] && [ "$AGENT_FACTORY_HOME" = "$HOME/.agent-factory" ]; then
+        lc_say "REFUSING: AGENT_FACTORY_HOME is the real default home."
+        return 1
+    fi
+
+    lc_say "isolation: $reason; workspace=$LC_WORKSPACE"
+    return 0
+}
+
+# ----------------------------------------------------------------------------
+# Daemon introspection.
+#
+# Everything below reads the machine directly rather than asking af, because
+# these are the assertions that must still hold when af is the thing that is
+# broken. Where af DOES have an answer (daemon status --json), we use it — but
+# never as the only witness for "is there exactly one daemon".
+# ----------------------------------------------------------------------------
+
+# lc_daemon_pids <home> — pids of af daemons serving exactly this AF home.
+#
+# Three filters, each closing a false positive we actually hit while building
+# this harness:
+#   * argv[1] == "--daemon" exactly, and argv[0]'s basename is an af binary —
+#     `pgrep -f "af --daemon"` matches the harness's own shell command line,
+#     because that string appears in it.
+#   * environ AGENT_FACTORY_HOME == our home — a global scan otherwise adopts
+#     daemons from other homes (and, on a shared box, other users' daemons).
+#     /proc/<pid>/environ is owner-only, so another user's daemon is invisible
+#     here rather than miscounted — the same rule af's own scan learned in
+#     #1920.
+lc_daemon_pids() {
+    local home="$1" d pid argv0 argv1 dhome
+    for d in /proc/[0-9]*; do
+        [ -r "$d/cmdline" ] || continue
+        argv1=$(tr '\0' '\n' <"$d/cmdline" 2>/dev/null | sed -n '2p')
+        [ "$argv1" = "--daemon" ] || continue
+        argv0=$(tr '\0' '\n' <"$d/cmdline" 2>/dev/null | sed -n '1p')
+        case "$(basename "${argv0:-}")" in
+        af | agent-factory) ;;
+        *) continue ;;
+        esac
+        dhome=$(tr '\0' '\n' <"$d/environ" 2>/dev/null | sed -n 's/^AGENT_FACTORY_HOME=//p' | head -1)
+        [ "$dhome" = "$home" ] || continue
+        pid=${d#/proc/}
+        printf '%s\n' "$pid"
+    done
+}
+
+lc_daemon_count() { lc_daemon_pids "$1" | wc -l | tr -d ' '; }
+
+# lc_daemon_version <pid> — the version of the image the daemon is ACTUALLY
+# running, by copying /proc/<pid>/exe and asking it.
+#
+# This is a real query, not an inference from the binary on disk — which is the
+# whole point: after an upgrade the on-disk binary is N while a daemon that was
+# never restarted is still executing the N-1 image, and /proc/<pid>/exe still
+# resolves to those bytes even though the path now reads "(deleted)".
+#
+# Linux-only (needs /proc). macOS has no equivalent, which is one reason the
+# macOS leg is not wired yet — see the header of scripts/lifecycle.sh.
+#
+# SWAP POINT (#1920): once `af doctor --json` ships a `daemon version` check,
+# this can become a plain query of the daemon's own reported version. Until
+# then this is the only way to learn a running daemon's version.
+lc_daemon_version() {
+    local pid="$1" tmp out
+    tmp="$(mktemp "${TMPDIR:-/tmp}/lc-daemon-image.XXXXXX")" || return 1
+    if ! cp "/proc/$pid/exe" "$tmp" 2>/dev/null; then
+        rm -f "$tmp"
+        return 1
+    fi
+    chmod +x "$tmp" 2>/dev/null || true
+    out=$("$tmp" version 2>/dev/null | sed -n 's/^agent-factory version //p' | head -1)
+    rm -f "$tmp"
+    [ -n "$out" ] || return 1
+    printf '%s\n' "$out"
+}
+
+# lc_client_version <bin> — the version the installed binary reports.
+lc_client_version() {
+    "$1" version 2>/dev/null | sed -n 's/^agent-factory version //p' | head -1
+}
+
+# lc_status_field <bin> <jq-path> — a field from `af daemon status --json`,
+# which is wrapped in the shared {data,error} envelope.
+lc_status_field() {
+    local bin="$1" path="$2"
+    "$bin" daemon status --json 2>/dev/null | jq -r "$path" 2>/dev/null
+}
+
+# lc_doctor_fail_count <bin> — how many checks doctor reports as FAIL.
+#
+# Feature-detects `--json` so this auto-upgrades the moment #1920 lands: today
+# it parses the "Summary: 9 PASS, 7 WARN, 0 FAIL" line, and the instant doctor
+# grows a --json flag it reads the structured summary instead. No follow-up
+# edit needed here.
+lc_doctor_fail_count() {
+    local bin="$1" out n
+    if "$bin" doctor --help 2>&1 | grep -q -- '--json'; then
+        out=$("$bin" doctor --json 2>/dev/null)
+        # #1920's envelope: {data:{summary:{fail:N}}}. Fall through to the text
+        # parser if the shape is not what we expect rather than silently
+        # reporting 0 FAILs — a wrong 0 here would make the whole gate a no-op.
+        n=$(printf '%s' "$out" | jq -r '.data.summary.fail // empty' 2>/dev/null)
+        if [ -n "$n" ]; then
+            printf '%s\n' "$n"
+            return 0
+        fi
+    fi
+    out=$("$bin" doctor 2>&1)
+    n=$(printf '%s' "$out" | sed -n 's/.*Summary:.*[, ]\([0-9]\{1,\}\) FAIL.*/\1/p' | head -1)
+    [ -n "$n" ] || return 1
+    printf '%s\n' "$n"
+}
+
+# lc_doctor_dump <bin> — doctor's FAIL lines, for the log when a check trips.
+lc_doctor_dump() {
+    "$1" doctor 2>&1 | grep -E '^\s*(FAIL|Summary)' || true
+}
+
+# ----------------------------------------------------------------------------
+# Service manager (assertion #4).
+# ----------------------------------------------------------------------------
+LC_UNIT_NAME="agent-factory-daemon.service"
+
+# lc_supervisor_available — can this environment actually supervise a daemon?
+#
+# The test container cannot: it has no systemd (PID 1 is docker-init), so
+# `af daemon install` fails outright with "systemctl: executable file not
+# found". That is why the supervision assertion is SKIPPED on container runs
+# and only really runs on the CI runner, which has a real systemd user manager.
+lc_supervisor_available() {
+    case "$(uname -s)" in
+    Linux)
+        command -v systemctl >/dev/null 2>&1 || return 1
+        systemctl --user show-environment >/dev/null 2>&1 || return 1
+        return 0
+        ;;
+    Darwin)
+        command -v launchctl >/dev/null 2>&1 || return 1
+        return 0
+        ;;
+    *) return 1 ;;
+    esac
+}
+
+# lc_unit_active — is the autostart unit currently supervising anything?
+lc_unit_active() {
+    systemctl --user is-active "$LC_UNIT_NAME" 2>/dev/null
+}
+
+# lc_unit_main_pid — the pid systemd believes it supervises, or 0.
+#
+# This is the assertion that catches the demotion: when respawnDaemonAfterUpgrade
+# falls back to an ad-hoc child, a daemon is still running and still answers
+# pings — but it is nobody's child, and the unit's MainPID no longer matches it
+# (typically 0, with the unit inactive/dead). Comparing "the daemon that is
+# running" against "the daemon systemd owns" is the only way to tell a
+# supervised daemon from an orphan that happens to work.
+lc_unit_main_pid() {
+    systemctl --user show -p MainPID --value "$LC_UNIT_NAME" 2>/dev/null | tr -d ' '
+}

--- a/scripts/lifecycle-lib.sh
+++ b/scripts/lifecycle-lib.sh
@@ -59,19 +59,44 @@ lc_assert_ne() {
     fi
 }
 
+# lc_summary — the run's verdict.
+#
+# A SKIP is NOT a pass. A run that skipped the supervision assertion and then
+# reported green would manufacture exactly the confidence this gate exists to
+# destroy: the one regression we know shipped (an upgrade demoting the daemon
+# off its unit, #796) is invisible to every OTHER assertion, because the
+# demoted daemon keeps running and keeps answering. So an incomplete run exits
+# NON-ZERO unless the operator explicitly acknowledges partial coverage with
+# AF_LIFECYCLE_ALLOW_PARTIAL=1 (which `make lifecycle-container` sets, because a
+# dev box's container genuinely cannot host a service manager — the CI leg is
+# the authority for those checks and fails if they ever stop running).
 lc_summary() {
     printf '\n[lifecycle] ===== summary =====\n' >&2
     printf '[lifecycle] %d PASS, %d FAIL, %d SKIP\n' "$LC_PASS" "$LC_FAIL" "$LC_SKIP" >&2
-    if [ "$LC_SKIP" -gt 0 ]; then
-        printf '[lifecycle] NOTE: %d check(s) were SKIPPED — this run did not cover them.\n' "$LC_SKIP" >&2
-    fi
+
+    local rc=0
     if [ "$LC_FAIL" -gt 0 ]; then
         printf '[lifecycle] failed checks:\n' >&2
         local n
         for n in "${LC_FAILED_NAMES[@]}"; do printf '[lifecycle]   - %s\n' "$n" >&2; done
-        return 1
+        rc=1
     fi
-    return 0
+
+    if [ "$LC_SKIP" -gt 0 ]; then
+        printf '[lifecycle]\n' >&2
+        printf '[lifecycle] *** PARTIAL COVERAGE: %d check(s) did NOT run. ***\n' "$LC_SKIP" >&2
+        printf '[lifecycle] This run proves nothing about them. Supervision-across-upgrade\n' >&2
+        printf '[lifecycle] (#796) is invisible to every other assertion here: a demoted\n' >&2
+        printf '[lifecycle] daemon still runs and still answers.\n' >&2
+        if [ "${AF_LIFECYCLE_ALLOW_PARTIAL:-}" = "1" ]; then
+            printf '[lifecycle] AF_LIFECYCLE_ALLOW_PARTIAL=1 — not failing the run, but this is\n' >&2
+            printf '[lifecycle] NOT full coverage. The CI leg (real systemd) is the authority.\n' >&2
+        else
+            printf '[lifecycle] Failing the run: a skipped check must never read as a pass.\n' >&2
+            rc=1
+        fi
+    fi
+    return "$rc"
 }
 
 # ----------------------------------------------------------------------------
@@ -248,6 +273,11 @@ lc_doctor_dump() {
 # Service manager (assertion #4).
 # ----------------------------------------------------------------------------
 LC_UNIT_NAME="agent-factory-daemon.service"
+# launchd's equivalent (daemon/autostart.go: autostartLaunchdLabel). af restarts
+# it as gui/<uid>/<label>, so that is the domain to interrogate — a launchd
+# agent loaded OUTSIDE that domain is one of the ways supervision silently
+# stops being real (#1920 checks the same thing).
+LC_LAUNCHD_LABEL="com.agent-factory.daemon"
 
 # lc_supervisor_available — can this environment actually supervise a daemon?
 #
@@ -271,8 +301,30 @@ lc_supervisor_available() {
 }
 
 # lc_unit_active — is the autostart unit currently supervising anything?
+# Prints "active" when it is, anything else when it is not, on BOTH platforms —
+# so assertion #4 asserts one property, not one per OS.
 lc_unit_active() {
-    systemctl --user is-active "$LC_UNIT_NAME" 2>/dev/null
+    case "$(uname -s)" in
+    Linux)
+        systemctl --user is-active "$LC_UNIT_NAME" 2>/dev/null
+        ;;
+    Darwin)
+        # `launchctl print` succeeding is NOT "running" — it prints happily for a
+        # loaded-but-stopped agent. The state field is the answer (the same trap
+        # #1920 hit: split Loaded from Active).
+        local out
+        out="$(launchctl print "gui/$(id -u)/$LC_LAUNCHD_LABEL" 2>/dev/null)" || {
+            printf 'inactive\n'
+            return 0
+        }
+        if printf '%s' "$out" | grep -qE '^[[:space:]]*state = running'; then
+            printf 'active\n'
+        else
+            printf 'inactive\n'
+        fi
+        ;;
+    *) printf 'unsupported\n' ;;
+    esac
 }
 
 # lc_unit_main_pid — the pid systemd believes it supervises, or 0.
@@ -284,5 +336,16 @@ lc_unit_active() {
 # running" against "the daemon systemd owns" is the only way to tell a
 # supervised daemon from an orphan that happens to work.
 lc_unit_main_pid() {
-    systemctl --user show -p MainPID --value "$LC_UNIT_NAME" 2>/dev/null | tr -d ' '
+    case "$(uname -s)" in
+    Linux)
+        systemctl --user show -p MainPID --value "$LC_UNIT_NAME" 2>/dev/null | tr -d ' '
+        ;;
+    Darwin)
+        # launchctl print emits "pid = 1234" for a running job; absent when the
+        # job is loaded but not running — which is precisely the demoted case.
+        launchctl print "gui/$(id -u)/$LC_LAUNCHD_LABEL" 2>/dev/null |
+            sed -n 's/^[[:space:]]*pid = \([0-9][0-9]*\).*/\1/p' | head -1
+        ;;
+    *) printf '' ;;
+    esac
 }

--- a/scripts/lifecycle-lib.sh
+++ b/scripts/lifecycle-lib.sh
@@ -112,6 +112,40 @@ lc_summary() {
 # /.dockerenv, a CI runner sets CI=true. A shared dev box has neither, so it
 # refuses even if someone exports the opt-in by accident.
 # ----------------------------------------------------------------------------
+# The container markers, as variables so the selftest can point them at temp
+# files and exercise THIS function rather than a re-implementation of it. A test
+# that greps the source for "/run/.containerenv" is not a test: that string also
+# appears in the error message below, so it passes against code with the
+# detection removed — observed, which is why these are parameters now.
+: "${LC_MARKER_DOCKER:=/.dockerenv}"
+: "${LC_MARKER_PODMAN:=/run/.containerenv}"
+
+# lc_detect_disposable — prints why this environment is disposable and returns 0,
+# or returns 1. Positive detection only, and THE DEFAULT ANSWER IS NO: an
+# unrecognized runtime is not "probably a container", it is a machine we cannot
+# vouch for — and this harness installs binaries, registers units and stops
+# daemons. Markers a real dev box does not have:
+#   /.dockerenv          docker
+#   /run/.containerenv   podman (docker has no such file and podman has no
+#                        /.dockerenv; testbox.sh supports BOTH engines, so a
+#                        podman box could not run this gate at all before)
+#   CI=true              an ephemeral CI runner
+lc_detect_disposable() {
+    if [ -f "$LC_MARKER_DOCKER" ]; then
+        printf 'docker container (%s)\n' "$LC_MARKER_DOCKER"
+        return 0
+    fi
+    if [ -f "$LC_MARKER_PODMAN" ]; then
+        printf 'podman container (%s)\n' "$LC_MARKER_PODMAN"
+        return 0
+    fi
+    if [ "${CI:-}" = "true" ]; then
+        printf 'CI runner (CI=true)\n'
+        return 0
+    fi
+    return 1
+}
+
 lc_guard_disposable() {
     if [ "${AF_LIFECYCLE_DISPOSABLE:-}" != "1" ]; then
         lc_say "REFUSING: this harness installs binaries, registers autostart units,"
@@ -121,16 +155,14 @@ lc_guard_disposable() {
         return 1
     fi
 
-    local disposable=no reason=""
-    if [ -f /.dockerenv ]; then
-        disposable=yes
-        reason="container (/.dockerenv)"
-    elif [ "${CI:-}" = "true" ]; then
-        disposable=yes
-        reason="CI runner (CI=true)"
-    fi
-    if [ "$disposable" != yes ]; then
-        lc_say "REFUSING: no disposable environment detected (no /.dockerenv, CI!=true)."
+    local reason=""
+    if reason="$(lc_detect_disposable)"; then
+        :
+    else
+        lc_say "REFUSING: no disposable environment detected."
+        lc_say "  looked for: /.dockerenv (docker), /run/.containerenv (podman), CI=true"
+        lc_say "An UNRECOGNIZED runtime is treated as NOT disposable — this harness"
+        lc_say "never decides 'probably fine' about whether it may wreck a machine."
         lc_say "This looks like a real machine. Use: make lifecycle-container"
         return 1
     fi
@@ -166,6 +198,57 @@ lc_guard_disposable() {
 # broken. Where af DOES have an answer (daemon status --json), we use it — but
 # never as the only witness for "is there exactly one daemon".
 # ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Fault-injection bookkeeping.
+#
+# A fault injection that never runs is the most dangerous outcome this harness
+# has: every assertion then passes, and the run reports that we survived a fault
+# we never injected — a green check for an experiment that did not happen. Two
+# ways that happens, both silent before this:
+#   * a typo'd / retired name matches no branch (`AF_LIFECYCLE_INJECT=skip-restart`
+#     vs `skip-daemon-restart`), so nothing is injected and everything passes;
+#   * a valid injection is requested for a scenario that this run does not
+#     execute (`AF_LIFECYCLE_INJECT=skip-daemon-restart ... scenario-a`), so its
+#     branch is never reached.
+#
+# So: names are validated against a registry up front, and execution is RECORDED.
+# If an injection was asked for and never applied, the run FAILS — loudly, as a
+# harness defect. Never a skip; a skip is how this class hides.
+# ----------------------------------------------------------------------------
+LC_KNOWN_INJECTIONS="skip-daemon-restart unhealthy-session"
+LC_INJECT_APPLIED=0
+
+# lc_validate_injection <name> — accept only a registered injection.
+lc_validate_injection() {
+    local want="$1" k
+    [ -z "$want" ] && return 0
+    for k in $LC_KNOWN_INJECTIONS; do
+        [ "$k" = "$want" ] && return 0
+    done
+    lc_say "UNKNOWN fault injection '$want'."
+    lc_say "  known: $LC_KNOWN_INJECTIONS"
+    lc_say "Refusing to run: an unrecognized injection injects NOTHING, and every"
+    lc_say "assertion would then pass — reporting that we survived a fault that was"
+    lc_say "never applied."
+    return 1
+}
+
+# lc_note_injection_applied — called by an injection once it has PROVED its
+# effect landed (outcome, not exit code).
+lc_note_injection_applied() { LC_INJECT_APPLIED=1; }
+
+# lc_assert_injection_ran <name> — the end-of-run reckoning.
+lc_assert_injection_ran() {
+    local want="$1"
+    [ -z "$want" ] && return 0
+    if [ "$LC_INJECT_APPLIED" = "1" ]; then
+        lc_pass "fault injection '$want' was actually applied during this run"
+        return 0
+    fi
+    lc_fail "fault injection '$want' was requested but NEVER EXECUTED — this run proves nothing about it (wrong scenario selected?)"
+    return 1
+}
 
 # lc_assert_virgin <home> <what> — prove this home is untouched, RIGHT BEFORE the
 # probe that depends on it.

--- a/scripts/lifecycle-lib.sh
+++ b/scripts/lifecycle-lib.sh
@@ -167,6 +167,39 @@ lc_guard_disposable() {
 # never as the only witness for "is there exactly one daemon".
 # ----------------------------------------------------------------------------
 
+# lc_assert_virgin <home> <what> — prove this home is untouched, RIGHT BEFORE the
+# probe that depends on it.
+#
+# Exists because an observation that CREATES the state it observes is not an
+# observation. `af doctor` and `af daemon status` both materialize the home
+# directory and agent-factory.log (measured; `af version` touches nothing) — so a
+# scenario that probes doctor and then claims to boot the TUI "on a virgin home"
+# is measuring a home its own earlier probe built. Asserting virginity once at
+# the top of a scenario only ever covers the FIRST probe.
+#
+# Each probe therefore gets its own pristine home and calls this immediately
+# before touching it, which holds regardless of which command materializes what —
+# including on the far side of an upgrade, where the answer may differ.
+lc_assert_virgin() {
+    local home="$1" what="$2" dirty=""
+    [ -e "$home" ] && dirty="home directory exists"
+    [ -e "$home/config.toml" ] && dirty="${dirty:+$dirty; }config.toml exists"
+    [ -e "$home/state.json" ] && dirty="${dirty:+$dirty; }state.json exists"
+    if [ -n "$dirty" ]; then
+        lc_fail "$what: home '$home' is NOT virgin ($dirty) — this probe's premise is already broken"
+        find "$home" -maxdepth 1 -mindepth 1 2>/dev/null | sed 's/^/[lifecycle]   | /' >&2
+        return 1
+    fi
+    local n
+    n="$(lc_daemon_count "$home")"
+    if [ "$n" != "0" ]; then
+        lc_fail "$what: $n daemon(s) already serve '$home'"
+        return 1
+    fi
+    lc_pass "$what: home is virgin (no dir, no config, no state, no daemon)"
+    return 0
+}
+
 # lc_daemon_pids <home> — pids of af daemons serving exactly this AF home.
 #
 # Three filters, each closing a false positive we actually hit while building

--- a/scripts/lifecycle-lib.sh
+++ b/scripts/lifecycle-lib.sh
@@ -297,6 +297,18 @@ lc_assert_virgin() {
 #     #1920.
 lc_daemon_pids() {
     local home="$1" d pid argv0 argv1 dhome
+    # REFUSE an empty home. This function feeds lc_teardown_home, which SIGKILLs
+    # what it returns — so the matching rule is a safety boundary, not a filter.
+    # With home="", the test below becomes [ "$dhome" = "" ], which matches every
+    # daemon whose environ carries NO AGENT_FACTORY_HOME — that is precisely how
+    # a real daemon on the default home runs. One empty variable and this would
+    # hand the maintainer's daemon to kill -9. The disposable guard makes that
+    # unreachable today, but a kill path must not depend on a guard three layers
+    # up being correct.
+    if [ -z "$home" ]; then
+        lc_say "REFUSING to scan for daemons with an empty home (would match the real default-home daemon)"
+        return 1
+    fi
     for d in /proc/[0-9]*; do
         [ -r "$d/cmdline" ] || continue
         argv1=$(tr '\0' '\n' <"$d/cmdline" 2>/dev/null | sed -n '2p')

--- a/scripts/lifecycle-selftest.sh
+++ b/scripts/lifecycle-selftest.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# lifecycle-selftest.sh — tests for the lifecycle harness's OWN safety logic.
+#
+# The gate in scripts/lifecycle.sh proves things about af. This proves things
+# about the gate, and it is the cheaper half: every case here is pure logic —
+# no containers, no daemons, no network, no AF home — so it runs on the host in
+# about a second and can gate every PR.
+#
+# It exists because the harness's failure mode is not "red when it should be
+# green", it is "GREEN WHEN IT PROVED NOTHING": a fault injection that never
+# executes, a disposable-environment guard that says yes to a real machine, two
+# concurrent runs sharing an image tag. Each of those turns a gate into a
+# rubber stamp, and none of them is visible in a passing run.
+#
+# Every case here was watched failing against the pre-fix code before the fix
+# landed. See docs/lifecycle-testing.md.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PASS=0
+FAIL=0
+
+ok() {
+    PASS=$((PASS + 1))
+    printf '  PASS  %s\n' "$*"
+}
+no() {
+    FAIL=$((FAIL + 1))
+    printf '  FAIL  %s\n' "$*"
+}
+
+# Source the library in a subshell-safe way: it only defines functions and
+# counters, and touches nothing outside the process.
+LC_WORKSPACE="/tmp/lc-selftest-never-created"
+# shellcheck source=scripts/lifecycle-lib.sh
+. "$HERE/lifecycle-lib.sh"
+
+printf '\n=== fault injections that cannot execute must FAIL the harness ===\n'
+
+# An unregistered name matches no branch, so nothing is injected and every
+# assertion passes — a green check for an experiment that never happened.
+if lc_validate_injection "skip-restart" 2>/dev/null; then
+    no "an unknown injection name was accepted (it would inject nothing and pass)"
+else
+    ok "unknown injection name is rejected before anything runs"
+fi
+if lc_validate_injection "skip-daemon-restart" 2>/dev/null; then
+    ok "a registered injection name is accepted"
+else
+    no "a registered injection name was rejected"
+fi
+if lc_validate_injection "" 2>/dev/null; then
+    ok "no injection requested is fine (the normal green path)"
+else
+    no "an empty injection was treated as an error"
+fi
+
+# The other half: a VALID injection that never reaches its branch — e.g.
+# requested for scenario-b while only scenario-a runs.
+LC_INJECT_APPLIED=0
+LC_FAIL=0
+if lc_assert_injection_ran "skip-daemon-restart" 2>/dev/null; then
+    no "a requested-but-never-applied injection was reported as ran"
+else
+    ok "a requested injection that never executed FAILS the harness"
+fi
+LC_INJECT_APPLIED=0
+LC_FAIL=0
+lc_note_injection_applied
+if lc_assert_injection_ran "skip-daemon-restart" 2>/dev/null; then
+    ok "an injection that DID apply is accepted"
+else
+    no "an applied injection was reported as never run"
+fi
+LC_INJECT_APPLIED=0
+LC_FAIL=0
+if lc_assert_injection_ran "" 2>/dev/null; then
+    ok "no injection requested => nothing to have run"
+else
+    no "the no-injection case was treated as a missing injection"
+fi
+
+printf '\n=== the disposable guard defaults to NO ===\n'
+
+# These drive the REAL lc_detect_disposable by pointing its markers at temp
+# paths. An earlier version of this test re-implemented the detection and
+# grepped the source for "/run/.containerenv" — and PASSED against code with
+# podman detection deleted, because that string also lives in the guard's error
+# message. Watched failing is the only reason we know this one works.
+probe="$(mktemp -d)"
+trap 'rm -rf "$probe"' EXIT
+: >"$probe/dockerenv"
+: >"$probe/containerenv"
+
+detect() { # $1=docker-marker-path $2=podman-marker-path $3=CI
+    # shellcheck disable=SC2030,SC2031  # the subshell IS the isolation: these
+    # overrides must not leak into the next case.
+    (
+        LC_MARKER_DOCKER="$1" LC_MARKER_PODMAN="$2" CI="$3"
+        export LC_MARKER_DOCKER LC_MARKER_PODMAN CI
+        if lc_detect_disposable >/dev/null 2>&1; then echo yes; else echo no; fi
+    )
+}
+
+none="$probe/absent"
+if [ "$(detect "$none" "$none" '')" = no ]; then
+    ok "an unrecognized runtime (no marker at all) is NOT disposable — refuses"
+else
+    no "an unrecognized runtime was treated as disposable"
+fi
+if [ "$(detect "$probe/dockerenv" "$none" '')" = yes ]; then
+    ok "docker (/.dockerenv) is recognized"
+else
+    no "docker was not recognized"
+fi
+if [ "$(detect "$none" "$probe/containerenv" '')" = yes ]; then
+    ok "podman (/run/.containerenv) is recognized"
+else
+    no "podman was not recognized"
+fi
+if [ "$(detect "$none" "$none" true)" = yes ]; then
+    ok "CI=true is recognized"
+else
+    no "CI was not recognized"
+fi
+# The real marker paths must be the real ones, not left pointing at a test
+# fixture. Read from a clean process so the subshells above cannot colour it.
+# shellcheck disable=SC2031
+real_markers="$(bash -c ". '$HERE/lifecycle-lib.sh'; printf '%s %s' \"\$LC_MARKER_DOCKER\" \"\$LC_MARKER_PODMAN\"")"
+if [ "$real_markers" = "/.dockerenv /run/.containerenv" ]; then
+    ok "the production marker paths are the real ones"
+else
+    no "production marker paths are wrong ($real_markers)"
+fi
+# And the guard must require the explicit opt-in before any of that matters.
+if printf '%s' "$(declare -f lc_guard_disposable)" | grep -q 'AF_LIFECYCLE_DISPOSABLE'; then
+    ok "lc_guard_disposable requires the explicit AF_LIFECYCLE_DISPOSABLE opt-in"
+else
+    no "lc_guard_disposable does not require the opt-in"
+fi
+
+printf '\n=== concurrent invocations must not share an image tag ===\n'
+
+# Two invocations of the tag-minting logic must differ. _uniq lives in
+# testbox.sh, which runs a `case` at source time, so pull the two lines out
+# rather than sourcing the whole script.
+tag_of() { # emulate testbox.sh's per-run tag
+    bash -c '
+        _uniq() {
+            local r=""
+            [ -r /dev/urandom ] && r="$(od -An -N3 -tx1 /dev/urandom 2>/dev/null | tr -d " ")"
+            printf "%s" "$$${r:+-$r}"
+        }
+        printf "agent-factory-lifecycle:%s\n" "$(_uniq)"
+    '
+}
+t1="$(tag_of)"
+t2="$(tag_of)"
+if [ -n "$t1" ] && [ -n "$t2" ] && [ "$t1" != "$t2" ]; then
+    ok "two invocations mint different image tags ($t1 != $t2)"
+else
+    no "two invocations share an image tag ($t1 == $t2) — concurrent runs would clobber (#1171)"
+fi
+
+# The real script must not hardcode a fixed default tag: that is the #1171 bug.
+# shellcheck disable=SC2016  # matching literal shell source, expansion is wrong here
+if grep -q 'LIFECYCLE_IMAGE="\${AF_LIFECYCLE_IMAGE:-}"' "$HERE/testbox.sh"; then
+    ok "testbox.sh mints the lifecycle tag per run (no fixed default)"
+else
+    no "testbox.sh has a FIXED default lifecycle image tag — concurrent runs clobber (#1171)"
+fi
+# shellcheck disable=SC2016  # matching literal shell source
+if grep -q 'agent-factory-lifecycle:\$lc_token' "$HERE/testbox.sh"; then
+    ok "the per-run tag carries the unique token"
+else
+    no "the lifecycle tag does not carry a per-run token"
+fi
+
+printf '\n=== summary: %d PASS, %d FAIL ===\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/scripts/lifecycle-selftest.sh
+++ b/scripts/lifecycle-selftest.sh
@@ -80,6 +80,31 @@ else
     no "the no-injection case was treated as a missing injection"
 fi
 
+printf '\n=== the kill path refuses an empty home ===\n'
+
+# lc_daemon_pids feeds lc_teardown_home, which SIGKILLs what it returns. With an
+# empty home its match becomes [ "$dhome" = "" ], which matches every daemon
+# whose environ carries NO AGENT_FACTORY_HOME — exactly how a real default-home
+# daemon runs. This is the difference between a scoped teardown and shooting the
+# maintainer's daemon.
+if lc_daemon_pids "" >/dev/null 2>&1; then
+    no "lc_daemon_pids accepted an empty home (would match the real default-home daemon)"
+else
+    ok "lc_daemon_pids refuses an empty home"
+fi
+# ...and it must print nothing, since the caller pipes its output into kill.
+if [ -z "$(lc_daemon_pids "" 2>/dev/null)" ]; then
+    ok "lc_daemon_pids emits no pids for an empty home"
+else
+    no "lc_daemon_pids emitted pids for an empty home — those would be killed"
+fi
+# A home nothing serves must simply be empty, not an error.
+if [ -z "$(lc_daemon_pids "/tmp/lc-selftest-no-such-home" 2>/dev/null)" ]; then
+    ok "a home with no daemons yields no pids"
+else
+    no "a home with no daemons yielded pids"
+fi
+
 printf '\n=== the disposable guard defaults to NO ===\n'
 
 # These drive the REAL lc_detect_disposable by pointing its markers at temp

--- a/scripts/lifecycle.sh
+++ b/scripts/lifecycle.sh
@@ -404,8 +404,19 @@ scenario_b() {
     fi
 
     # --- put state on the old daemon ----------------------------------------
-    (cd "$repo" && "$bin" sessions create --name pre1 >/dev/null 2>&1)
-    (cd "$repo" && "$bin" sessions create --name pre2 >/dev/null 2>&1)
+    # Errors are surfaced, not swallowed: if the sessions never get created the
+    # rest of this scenario is vacuous ("0 sessions survived the upgrade" is a
+    # PASS that tested nothing), so this has to be loud and fatal.
+    local n
+    for n in pre1 pre2; do
+        local out rc=0
+        out="$(cd "$repo" && "$bin" sessions create --name "$n" 2>&1)" || rc=$?
+        if [ "$rc" != 0 ]; then
+            lc_say "session create '$n' failed (rc=$rc):"
+            printf '%s\n' "$out" | head -5 | sed 's/^/[lifecycle]   | /' >&2
+        fi
+    done
+
     local before_sessions before_pid before_daemon_ver
     before_sessions="$(lc_session_count "$bin")"
     before_pid="$(lc_daemon_pids "$home" | head -1)"
@@ -415,7 +426,19 @@ scenario_b() {
     fi
     before_daemon_ver="$(lc_daemon_version "$before_pid")"
     lc_say "before upgrade: daemon pid=$before_pid version=$before_daemon_ver sessions=$before_sessions"
-    lc_assert_eq "2" "$before_sessions" "two sessions exist before the upgrade"
+
+    # Hard gate. Scenario B's whole premise is "there is state to preserve"; if
+    # we could not put any on the machine, ABORT rather than run assertion 5
+    # against zero sessions and report a vacuous pass. This is the difference
+    # between a gate and a green light.
+    if [ "$before_sessions" != "2" ]; then
+        lc_fail "scenario-b/$mode: expected 2 sessions before the upgrade, got '$before_sessions' — aborting (assertion 5 would be vacuous)"
+        lc_say "session list was:"
+        "$bin" sessions list 2>&1 | head -10 | sed 's/^/[lifecycle]   | /' >&2
+        lc_teardown_home "$home" "$supervised"
+        return 1
+    fi
+    lc_pass "two sessions exist before the upgrade (= $before_sessions)"
 
     local before_unit_pid=""
     if [ "$supervised" = yes ]; then
@@ -565,9 +588,26 @@ lc_do_upgrade() {
 }
 
 # lc_session_count <bin> — sessions the daemon knows about.
+#
+# Prints "unreadable" rather than 0 when the list cannot be parsed. A silent 0
+# fallback here would be indistinguishable from a real empty machine, which
+# would turn assertion 5 into "0 sessions survived: PASS" — the exact vacuous
+# green this gate exists to prevent.
 lc_session_count() {
-    "$1" sessions list 2>/dev/null | jq -r '[.[]?] | length' 2>/dev/null ||
-        printf '0\n'
+    local out n
+    out="$("$1" sessions list 2>/dev/null)" || {
+        printf 'unreadable\n'
+        return 0
+    }
+    n="$(printf '%s' "$out" | jq -r '[.[]?] | length' 2>/dev/null)" || {
+        printf 'unreadable\n'
+        return 0
+    }
+    [ -n "$n" ] || {
+        printf 'unreadable\n'
+        return 0
+    }
+    printf '%s\n' "$n"
 }
 
 # lc_lost_session_count <bin> — sessions whose worktree/tmux vanished. An

--- a/scripts/lifecycle.sh
+++ b/scripts/lifecycle.sh
@@ -884,6 +884,12 @@ lc_session_states() {
 # anyway; a CI runner that runs several scenarios in one job does not.
 lc_teardown_home() {
     local home="$1" supervised="${2:-no}" pid
+    # Belt to lc_daemon_pids' braces: this function sends SIGKILL, so it states
+    # its own precondition rather than inheriting one.
+    if [ -z "$home" ]; then
+        lc_fail "lc_teardown_home called with an empty home — refusing to signal anything"
+        return 1
+    fi
     if [ "$supervised" = yes ] && lc_supervisor_available; then
         systemctl --user stop "$LC_UNIT_NAME" >/dev/null 2>&1 || true
         systemctl --user disable "$LC_UNIT_NAME" >/dev/null 2>&1 || true

--- a/scripts/lifecycle.sh
+++ b/scripts/lifecycle.sh
@@ -407,14 +407,17 @@ scenario_b() {
     # Errors are surfaced, not swallowed: if the sessions never get created the
     # rest of this scenario is vacuous ("0 sessions survived the upgrade" is a
     # PASS that tested nothing), so this has to be loud and fatal.
-    local n
+    # Capture create output unconditionally. `af sessions create` can report a
+    # refusal in its JSON body ({"error": "... is not installed or not on
+    # PATH"}) — so an exit status alone is not evidence that a session exists,
+    # and a diagnostic that only fires on a non-zero exit prints nothing at all
+    # in exactly the case you need it.
+    local n rc create_log=""
     for n in pre1 pre2; do
-        local out rc=0
+        local out
+        rc=0
         out="$(cd "$repo" && "$bin" sessions create --name "$n" 2>&1)" || rc=$?
-        if [ "$rc" != 0 ]; then
-            lc_say "session create '$n' failed (rc=$rc):"
-            printf '%s\n' "$out" | head -5 | sed 's/^/[lifecycle]   | /' >&2
-        fi
+        create_log+="[$n rc=$rc] $(printf '%s' "$out" | head -3)"$'\n'
     done
 
     local before_sessions before_pid before_daemon_ver
@@ -433,8 +436,12 @@ scenario_b() {
     # between a gate and a green light.
     if [ "$before_sessions" != "2" ]; then
         lc_fail "scenario-b/$mode: expected 2 sessions before the upgrade, got '$before_sessions' — aborting (assertion 5 would be vacuous)"
+        lc_say "what 'sessions create' actually said:"
+        printf '%s' "$create_log" | sed 's/^/[lifecycle]   | /' >&2
         lc_say "session list was:"
-        "$bin" sessions list 2>&1 | head -10 | sed 's/^/[lifecycle]   | /' >&2
+        "$bin" sessions list 2>&1 | head -5 | sed 's/^/[lifecycle]   | /' >&2
+        lc_say "configured program_overrides:"
+        "$bin" config get program_overrides.claude 2>&1 | head -3 | sed 's/^/[lifecycle]   | /' >&2
         lc_teardown_home "$home" "$supervised"
         return 1
     fi

--- a/scripts/lifecycle.sh
+++ b/scripts/lifecycle.sh
@@ -40,12 +40,26 @@
 #
 # WHAT THIS DOES NOT COVER YET
 #
-#   * macOS/launchd. lc_daemon_version reads /proc/<pid>/exe, which macOS does
-#     not have, and the supervision assertion would need launchctl. A macOS
-#     matrix leg lands once the macos-latest CI job does; the scenarios are
-#     written to be OS-agnostic apart from those two helpers.
+#   * macOS/launchd. Assertion #4 is already written for it (lc_unit_active /
+#     lc_unit_main_pid have Darwin branches, so the mac leg asserts the SAME
+#     property against launchd). The blocker for turning on the macos-latest leg
+#     is assertion 2: lc_daemon_version reads /proc/<pid>/exe, which macOS has no
+#     equivalent of — `ps` reports the path, whose bytes are the NEW binary after
+#     an upgrade, i.e. exactly the inference that assertion refuses to make. That
+#     leg wants #1920's daemon-reported version.
 #   * Assertion #4 (supervision) on container runs: no systemd inside, so it is
-#     SKIPped loudly there and only really runs on the CI runner.
+#     SKIPped there and only really runs on the CI runner. A SKIP is not a pass —
+#     the run exits non-zero unless AF_LIFECYCLE_ALLOW_PARTIAL=1 acknowledges it.
+#
+# A NOTE ON ASSERTIONS THAT CANNOT FAIL
+#
+# This gate's whole thesis is that a green run which proves nothing is worse than
+# no run. That standard applies to the gate itself, and it has already caught
+# itself twice: an unscoped `sessions list` counted the wrong project's sessions
+# and passed locally by accident, and the Lost check tested a write-never enum
+# value so it could never match. Both are fixed. Every assertion here must be
+# demonstrable via AF_LIFECYCLE_INJECT — if you add one, add the injection that
+# makes it fail, and watch it fail.
 #
 # Usage:
 #   AF_LIFECYCLE_DISPOSABLE=1 scripts/lifecycle.sh [scenario-a|scenario-b|all]
@@ -76,6 +90,10 @@ LC_DL="https://github.com/$LC_REPO_SLUG/releases/download"
 #   skip-daemon-restart  swap the binary to N but never restart the daemon —
 #                        exactly the #1921 skew condition (new client, old
 #                        daemon). Assertions 1 and 2 must FAIL.
+#   unhealthy-session    leave a session in a non-healthy state (archive it →
+#                        Archived(6)/LiveArchived(5)). Assertion 5 must FAIL.
+#                        NOT "kill its tmux": the daemon restores a killed pane
+#                        within ~4s (#1108), so that injects nothing.
 LC_INJECT="${AF_LIFECYCLE_INJECT:-}"
 
 # ----------------------------------------------------------------------------
@@ -472,6 +490,32 @@ scenario_b() {
         return 1
     }
 
+    # Fault injection: leave a session in a state that is NOT healthy, to prove
+    # assertion 5 can actually FIRE. The check it replaced tested status/liveness
+    # == 4 (Dead/LiveDead) — both write-never since #1108 — so it matched nothing
+    # on any machine and passed forever. An assertion nobody has watched fail is
+    # not evidence, so this is the fire-drill for it.
+    #
+    # Archive rather than "kill the tmux and call it Lost": a killed pane does
+    # NOT produce Lost, because the daemon RESTORES it within ~4s (measured:
+    # Running→Ready, and it heals even with the worktree deleted — #1108's
+    # restore loop). Lost is therefore not artificially reachable against a live
+    # daemon, and an injection that quietly fails to inject would be the very
+    # vacuity this gate exists to prevent. Archive is durable, and it lands on
+    # Archived(6)/LiveArchived(5) — a real non-healthy state the predicate must
+    # catch, which also confirms the enum ordinals end-to-end.
+    if [ "$LC_INJECT" = "unhealthy-session" ]; then
+        lc_say "INJECT: archiving 'pre1' so it is no longer in a healthy state"
+        "$bin" sessions archive pre1 --repo "$repo" >/dev/null 2>&1 ||
+            "$bin" sessions archive pre1 >/dev/null 2>&1
+        local j
+        for ((j = 0; j < 40; j++)); do
+            [ "$(lc_unhealthy_session_count "$bin" "$repo")" != "0" ] && break
+            sleep 0.5
+        done
+        lc_say "INJECT: session states now: $(lc_session_states "$bin" "$repo")"
+    fi
+
     # --- assertions ----------------------------------------------------------
     local after_pid after_daemon_ver client_ver after_sessions
     after_pid="$(lc_daemon_pids "$home" | head -1)"
@@ -523,9 +567,12 @@ scenario_b() {
     # 5. pre-existing sessions survive.
     after_sessions="$(lc_wait_session_count "$bin" "$repo" "$before_sessions" 30)"
     lc_assert_eq "$before_sessions" "$after_sessions" "assertion 5: sessions survive the upgrade"
-    local lost
-    lost="$(lc_lost_session_count "$bin" "$repo")"
-    lc_assert_eq "0" "$lost" "assertion 5: no session went Lost across the upgrade"
+    local unhealthy
+    unhealthy="$(lc_unhealthy_session_count "$bin" "$repo")"
+    lc_assert_eq "0" "$unhealthy" "assertion 5: every session is still healthy (none Lost/Dead) across the upgrade"
+    if [ "$unhealthy" != "0" ]; then
+        lc_say "session states: $(lc_session_states "$bin" "$repo")"
+    fi
 
     # 6. doctor is the oracle: zero FAILs on the upgraded machine.
     local fails
@@ -588,16 +635,42 @@ lc_do_upgrade() {
             tmux kill-session -t lc-b 2>/dev/null
             return 1
         fi
-        # The re-exec'd TUI must actually come back up.
+        # The re-exec'd TUI must actually come back up. A wait that merely
+        # stops waiting is not an assertion: if the re-exec left the user with
+        # no TUI, giving up quietly here would let every downstream check run
+        # against a machine we never verified and report green.
+        ok=1
         for ((i = 0; i < 120; i++)); do
-            lc_capture lc-b | grep -q 'Agent Factory' && break
+            if lc_capture lc-b | grep -q 'Agent Factory'; then
+                ok=0
+                break
+            fi
             sleep 0.5
         done
-        # Give the restart-daemon step room to finish before we measure it.
+        if [ "$ok" != 0 ]; then
+            lc_say "the re-exec'd TUI never rendered after the launch-time update; screen was:"
+            lc_capture lc-b | sed 's/^/[lifecycle]   | /' >&2
+            tmux kill-session -t lc-b 2>/dev/null
+            return 1
+        fi
+
+        # The daemon must come back. Timing out here means the launch path left
+        # the machine with NO daemon — the loudest possible outcome, not a
+        # reason to proceed and measure nothing.
+        ok=1
         for ((i = 0; i < 60; i++)); do
-            [ "$(lc_status_field "$bin" '.data.running')" = "true" ] && break
+            if [ "$(lc_status_field "$bin" '.data.running')" = "true" ]; then
+                ok=0
+                break
+            fi
             sleep 0.5
         done
+        if [ "$ok" != 0 ]; then
+            lc_say "no daemon is running 30s after the launch-time update finished"
+            "$bin" daemon status 2>&1 | head -5 | sed 's/^/[lifecycle]   | /' >&2
+            tmux kill-session -t lc-b 2>/dev/null
+            return 1
+        fi
         tmux kill-session -t lc-b 2>/dev/null
         ;;
     *)
@@ -654,16 +727,44 @@ lc_wait_session_count() {
     printf '%s\n' "$n"
 }
 
-# lc_lost_session_count <bin> <repo> — sessions whose worktree/tmux vanished. An
-# upgrade that strands sessions is a data-loss bug, not a cosmetic one.
-lc_lost_session_count() {
+# The enum ordinals af serializes, from session/instance.go and
+# session/liveness.go. Status: Running=0 Ready=1 Loading=2 Deleting=3 Dead=4
+# Lost=5 Archived=6. Liveness: Unset=0 LiveRunning=1 LiveReady=2 LiveLost=3
+# LiveDead=4 LiveArchived=5 LiveLimitReached=6.
+#
+# These are safe to hardcode: Status serializes as an int, and the enum's own
+# contract is "appending, never renumbering, is what keeps old records
+# readable" (session/instance.go). They are NOT safe to guess — the first cut of
+# this helper tested 4 on both axes, which is Dead/LiveDead, and #1108 made BOTH
+# of those write-never (observed deaths record Lost; FromInstanceData rewrites
+# persisted Dead to Lost on load). So the check could not match anything, ever:
+# a vacuous assertion reporting "0 sessions Lost: PASS" on any machine at all,
+# including one where every session had been destroyed.
+LC_STATUS_HEALTHY='0,1'   # Running, Ready
+LC_LIVENESS_HEALTHY='1,2' # LiveRunning, LiveReady
+
+# lc_unhealthy_session_count <bin> <repo> — sessions NOT in a healthy state.
+#
+# Deliberately fail-CLOSED: it counts anything that is not provably healthy,
+# rather than enumerating the bad values. Enumerating bad values fails OPEN — if
+# the enum ever shifts, or a state we never thought of appears, a
+# "select(status == 5)" check silently matches nothing and passes. Asking "is
+# every session in a state I recognise as healthy?" turns that same drift into a
+# LOUD failure instead of a quiet green. Lost(5) is the state this is really
+# hunting (an upgrade that strands sessions is data loss, not cosmetics), but it
+# is caught as "not healthy", not as "== 5".
+lc_unhealthy_session_count() {
     local bin="$1" repo="$2" out n
     out="$("$bin" sessions list --repo "$repo" 2>/dev/null)" || {
         printf 'unreadable\n'
         return 0
     }
-    n="$(printf '%s' "$out" |
-        jq -r '[.[]? | select((.status|tostring) == "4" or (.liveness|tostring) == "4")] | length' 2>/dev/null)" || {
+    # `. as $r` is load-bearing: inside `$st | index(.status)` the dot rebinds to
+    # $st, so the row has to be captured before the pipe or jq errors out.
+    n="$(printf '%s' "$out" | jq -r --argjson st "[$LC_STATUS_HEALTHY]" \
+        --argjson lv "[$LC_LIVENESS_HEALTHY]" \
+        '[.[]? | . as $r | select(($st | index($r.status)) == null or ($lv | index($r.liveness)) == null)] | length' \
+        2>/dev/null)" || {
         printf 'unreadable\n'
         return 0
     }
@@ -672,6 +773,14 @@ lc_lost_session_count() {
         return 0
     }
     printf '%s\n' "$n"
+}
+
+# lc_session_states <bin> <repo> — "title:status/liveness" per session, for the
+# log when the check above trips. A bare count cannot tell you WHICH state.
+lc_session_states() {
+    "$1" sessions list --repo "$2" 2>/dev/null |
+        jq -r '.[]? | "\(.title):status=\(.status)/liveness=\(.liveness)"' 2>/dev/null |
+        tr '\n' ' '
 }
 
 # lc_teardown_home <home> [supervised] — stop what this scenario started so the

--- a/scripts/lifecycle.sh
+++ b/scripts/lifecycle.sh
@@ -420,8 +420,14 @@ scenario_b() {
         create_log+="[$n rc=$rc] $(printf '%s' "$out" | head -3)"$'\n'
     done
 
+    # Wait for the sessions to actually EXIST rather than reading the list the
+    # instant create returns. `sessions create` answers with the record, which
+    # is not the same fact as "the daemon has persisted it and will list it" —
+    # so a read here is a race, and it is the kind that passes on a fast box and
+    # fails on a loaded CI runner. Same rule the TUI driver follows (#1161):
+    # wait on the condition, never on a sleep.
     local before_sessions before_pid before_daemon_ver
-    before_sessions="$(lc_session_count "$bin")"
+    before_sessions="$(lc_wait_session_count "$bin" 2 30)"
     before_pid="$(lc_daemon_pids "$home" | head -1)"
     if [ -z "$before_pid" ]; then
         lc_fail "scenario-b/$mode: no daemon came up on the old release; nothing to upgrade"
@@ -440,8 +446,15 @@ scenario_b() {
         printf '%s' "$create_log" | sed 's/^/[lifecycle]   | /' >&2
         lc_say "session list was:"
         "$bin" sessions list 2>&1 | head -5 | sed 's/^/[lifecycle]   | /' >&2
-        lc_say "configured program_overrides:"
-        "$bin" config get program_overrides.claude 2>&1 | head -3 | sed 's/^/[lifecycle]   | /' >&2
+        lc_say "config.toml [program_overrides] (config get does not know this key on older releases):"
+        grep -A2 'program_overrides' "$home/config.toml" 2>/dev/null |
+            head -3 | sed 's/^/[lifecycle]   | /' >&2
+        # The daemon's own log is the only witness that can explain a session
+        # that was created and then vanished from the list.
+        lc_say "daemon log (tail):"
+        tail -25 "$home/agent-factory.log" 2>/dev/null | sed 's/^/[lifecycle]   | /' >&2
+        lc_say "tmux sessions the daemon owns:"
+        tmux ls 2>&1 | head -5 | sed 's/^/[lifecycle]   | /' >&2
         lc_teardown_home "$home" "$supervised"
         return 1
     fi
@@ -614,6 +627,19 @@ lc_session_count() {
         printf 'unreadable\n'
         return 0
     }
+    printf '%s\n' "$n"
+}
+
+# lc_wait_session_count <bin> <want> <timeout-s> — poll until the daemon lists
+# <want> sessions, then print the count (or the last count seen on timeout, so
+# the caller reports what was actually there rather than a fabricated number).
+lc_wait_session_count() {
+    local bin="$1" want="$2" timeout="${3:-30}" i n=""
+    for ((i = 0; i < timeout * 2; i++)); do
+        n="$(lc_session_count "$bin")"
+        [ "$n" = "$want" ] && break
+        sleep 0.5
+    done
     printf '%s\n' "$n"
 }
 

--- a/scripts/lifecycle.sh
+++ b/scripts/lifecycle.sh
@@ -1,0 +1,639 @@
+#!/usr/bin/env bash
+# lifecycle.sh — the clean-environment install + upgrade gate.
+#
+# WHY THIS EXISTS
+#
+# Every other gate in this repo tests CODE IN ISOLATION. `make test-container`,
+# the *-roundtrip harnesses, the TUI driver self-test — all of them build the
+# current tree and exercise it. None of them ever installs a release, upgrades
+# it, and checks what the machine looks like afterwards. So the failures that
+# reached users were all the ones that live BETWEEN versions:
+#
+#   #1921  a NEW client against an OLD daemon hard-failed ("unknown field
+#          tab_id"). The daemon is upgraded independently of its clients, so
+#          this is only reachable across a version boundary — no single-version
+#          test can construct it.
+#   #1916  `af reset` SIGKILLed a wedged daemon and the service manager
+#          relaunched it mid-wipe. Observed by a user, not by us.
+#   #796   the daemon demoted from supervised (a systemd unit) to an ad-hoc
+#          child after a restart: a daemon still runs and still answers, while
+#          the unit sits inactive/dead. Happened on the maintainer's box.
+#
+# A dev box is the opposite of the environment those bugs need: it has an
+# already-installed unit, a live daemon, months of state. "Works here" says
+# nothing about a new machine, which has NO config, NO unit, NO home, NO daemon.
+# This harness builds that machine from nothing and then upgrades it.
+#
+# SCENARIOS
+#
+#   A) clean first run   — nothing pre-exists; af must come up anyway.
+#   B) install -> upgrade — install a REAL previous release, put state on it,
+#                           upgrade the way a user actually does, then assert
+#                           the machine is coherent afterwards.
+#
+# ISOLATION
+#
+# This harness is destructive by design (it installs binaries, registers
+# autostart units, upgrades af over itself, stops daemons). It refuses to run
+# outside a container or CI runner — see lc_guard_disposable. On a dev box the
+# only entry point is `make lifecycle-container`.
+#
+# WHAT THIS DOES NOT COVER YET
+#
+#   * macOS/launchd. lc_daemon_version reads /proc/<pid>/exe, which macOS does
+#     not have, and the supervision assertion would need launchctl. A macOS
+#     matrix leg lands once the macos-latest CI job does; the scenarios are
+#     written to be OS-agnostic apart from those two helpers.
+#   * Assertion #4 (supervision) on container runs: no systemd inside, so it is
+#     SKIPped loudly there and only really runs on the CI runner.
+#
+# Usage:
+#   AF_LIFECYCLE_DISPOSABLE=1 scripts/lifecycle.sh [scenario-a|scenario-b|all]
+#
+# Environment:
+#   AF_LIFECYCLE_AF_BIN      af built from this tree (scenario A's "new user
+#                            installs today's af"). Required for scenario A.
+#   AF_LIFECYCLE_WORKSPACE   throwaway scratch root (default: $HOME/af-lifecycle)
+#   AF_LIFECYCLE_INJECT      fault injection for proving the harness detects a
+#                            known-bad machine. See INJECTIONS below.
+#   GITHUB_TOKEN             optional; only to raise the release-API rate limit.
+
+set -uo pipefail
+
+LC_HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LC_WORKSPACE="${AF_LIFECYCLE_WORKSPACE:-$HOME/af-lifecycle}"
+# shellcheck source=scripts/lifecycle-lib.sh
+. "$LC_HERE/lifecycle-lib.sh"
+
+LC_REPO_SLUG="sachiniyer/agent-factory"
+LC_API="https://api.github.com/repos/$LC_REPO_SLUG/releases?per_page=100"
+LC_DL="https://github.com/$LC_REPO_SLUG/releases/download"
+
+# INJECTIONS — deliberately break the machine to prove an assertion fires.
+# The gate's value is the bugs it catches NEXT, so it has to be shown catching
+# one now. See the PR body / docs/lifecycle-testing.md.
+#
+#   skip-daemon-restart  swap the binary to N but never restart the daemon —
+#                        exactly the #1921 skew condition (new client, old
+#                        daemon). Assertions 1 and 2 must FAIL.
+LC_INJECT="${AF_LIFECYCLE_INJECT:-}"
+
+# ----------------------------------------------------------------------------
+# Fixtures
+# ----------------------------------------------------------------------------
+
+# lc_mock_repo <dir> — a small real git repo to run sessions against. Built
+# here rather than reused from the playtest sandbox so this harness is
+# self-contained: it runs identically in the container and on a CI runner,
+# which has no sandbox scaffolding.
+lc_mock_repo() {
+    local dir="$1"
+    [ -d "$dir/.git" ] && return 0
+    mkdir -p "$dir" || return 1
+    (
+        cd "$dir" || exit 1
+        git init -q -b master
+        printf '# mock\nA throwaway project for the lifecycle gate.\n' >README.md
+        git add -A
+        git -c user.name="AF Lifecycle" -c user.email="lifecycle@localhost" \
+            commit -qm "initial"
+    )
+}
+
+# lc_cheap_agent <bin> — stand in for "the user has an agent installed": run
+# `bash` instead of a real agent, so a session is a real session (worktree,
+# tmux pane, daemon record) without shipping claude into the image. The
+# play-test sandbox does the same thing (#1116/#1131: af keys flag injection
+# and readiness off the program the override actually runs, so bare `bash` gets
+# no claude flags appended).
+#
+# Set through `af config set` rather than by writing a config file, for two
+# reasons learned the hard way:
+#   * af materializes config.toml on its FIRST run, and config.toml then wins
+#     over a hand-written config.json — so a file dropped in afterwards is
+#     silently ignored and every session create fails "claude not on PATH".
+#   * `af config set` is the supported surface and exists on both sides of the
+#     upgrade boundary (verified against v1.0.192), so scenario B can use the
+#     same helper on the old release.
+#
+# The daemon reads config at startup, so callers must set this BEFORE a daemon
+# starts, or restart it afterwards — af says so itself when you run it.
+lc_cheap_agent() {
+    local bin="$1"
+    "$bin" config set program_overrides.claude bash >/dev/null 2>&1
+}
+
+# lc_goos_goarch — the release asset suffix for this machine.
+lc_goos_goarch() {
+    local os arch
+    case "$(uname -s)" in
+    Linux) os=linux ;;
+    Darwin) os=darwin ;;
+    *)
+        lc_say "unsupported OS: $(uname -s)"
+        return 1
+        ;;
+    esac
+    case "$(uname -m)" in
+    x86_64 | amd64) arch=amd64 ;;
+    aarch64 | arm64) arch=arm64 ;;
+    *)
+        lc_say "unsupported arch: $(uname -m)"
+        return 1
+        ;;
+    esac
+    printf '%s-%s\n' "$os" "$arch"
+}
+
+# lc_two_newest_stable — "N-1<TAB>N": the two newest non-prerelease releases.
+#
+# Resolved from the API rather than pinned so the gate keeps testing the real
+# current boundary as releases cut. Nothing here asserts a specific version —
+# the assertions are about daemon/client coherence, which is version-agnostic.
+lc_two_newest_stable() {
+    local auth=() json tags
+    [ -n "${GITHUB_TOKEN:-}" ] && auth=(-H "Authorization: Bearer $GITHUB_TOKEN")
+    json=$(curl -sSL --max-time 60 "${auth[@]}" "$LC_API" 2>/dev/null) || return 1
+    tags=$(printf '%s' "$json" |
+        jq -r '[.[] | select(.draft==false and .prerelease==false) | .tag_name] | .[0:2] | @tsv' 2>/dev/null)
+    [ -n "$tags" ] || return 1
+    # Two distinct releases are required: with fewer, "upgrade from N-1 to N"
+    # has nothing to upgrade across.
+    [ "$(printf '%s' "$tags" | awk -F'\t' '{print NF}')" = "2" ] || return 1
+    # @tsv gives newest-first; the caller wants N-1 first.
+    printf '%s\t%s\n' "$(printf '%s' "$tags" | cut -f2)" "$(printf '%s' "$tags" | cut -f1)"
+}
+
+# lc_install_release <tag> <dest-bin> — install a REAL release binary, the way
+# a user gets one: download the published tarball and put the binary on PATH.
+lc_install_release() {
+    local tag="$1" dest="$2" sfx tgz tmp
+    sfx="$(lc_goos_goarch)" || return 1
+    tmp="$(mktemp -d "${TMPDIR:-/tmp}/lc-rel.XXXXXX")" || return 1
+    tgz="$tmp/af.tar.gz"
+    if ! curl -sSL --max-time 180 -o "$tgz" \
+        "$LC_DL/$tag/agent-factory-$sfx.tar.gz"; then
+        lc_say "failed to download release $tag ($sfx)"
+        rm -rf "$tmp"
+        return 1
+    fi
+    if ! tar -xzf "$tgz" -C "$tmp" 2>/dev/null; then
+        lc_say "failed to extract release $tag"
+        rm -rf "$tmp"
+        return 1
+    fi
+    mkdir -p "$(dirname "$dest")"
+    # Write through a temp name + mv so dest is never a half-written binary.
+    mv "$tmp/agent-factory" "$dest.new" || {
+        rm -rf "$tmp"
+        return 1
+    }
+    chmod +x "$dest.new"
+    mv "$dest.new" "$dest"
+    rm -rf "$tmp"
+}
+
+# lc_boot_tui <bin> <home> <repo> <tmux-session> [marker-timeout]
+#
+# Boot the real TUI in a private tmux session and wait for its first frame.
+# Waits on a screen marker rather than sleeping, the same rule the TUI driver
+# follows (#1161) — a fixed sleep here would flake on a loaded CI box.
+lc_boot_tui() {
+    local bin="$1" home="$2" repo="$3" sess="$4" timeout="${5:-60}"
+    local i deadline
+    tmux kill-session -t "$sess" 2>/dev/null
+    tmux new-session -d -s "$sess" -x 100 -y 30 || return 1
+    tmux send-keys -t "$sess" \
+        "export AGENT_FACTORY_HOME=$home; cd $repo && $bin" Enter
+    deadline=$((timeout * 2))
+    for ((i = 0; i < deadline; i++)); do
+        if tmux capture-pane -p -t "$sess" 2>/dev/null | grep -q 'Agent Factory'; then
+            return 0
+        fi
+        sleep 0.5
+    done
+    lc_say "TUI did not render a first frame within ${timeout}s; screen was:"
+    tmux capture-pane -p -t "$sess" 2>/dev/null | sed 's/^/[lifecycle]   | /' >&2
+    return 1
+}
+
+lc_capture() { tmux capture-pane -p -t "$1" 2>/dev/null; }
+
+# ----------------------------------------------------------------------------
+# Scenario A — clean first run.
+#
+# The machine a new user has: no config.toml, no AF home, no autostart unit, no
+# daemon. Nothing in af may assume any of them already exist.
+# ----------------------------------------------------------------------------
+scenario_a() {
+    lc_section "scenario A — clean first run"
+
+    local bin="${AF_LIFECYCLE_AF_BIN:-}"
+    if [ -z "$bin" ] || [ ! -x "$bin" ]; then
+        lc_fail "scenario-a: AF_LIFECYCLE_AF_BIN is not an executable af binary ('$bin')"
+        return 1
+    fi
+
+    # Separate statements on purpose: `local a=1 b=$a` expands every argument
+    # BEFORE assigning any of them, so $a would still be unbound in b.
+    local ws="$LC_WORKSPACE/a"
+    local home="$ws/home"
+    local repo="$ws/repo"
+    rm -rf "$ws"
+    mkdir -p "$ws"
+    lc_mock_repo "$repo" || {
+        lc_fail "scenario-a: could not build the mock repo"
+        return 1
+    }
+
+    # Preconditions: prove the environment really is clean before we claim af
+    # coped with a clean one.
+    if [ ! -e "$home" ]; then
+        lc_pass "precondition: no AF home at $home"
+    else
+        lc_fail "precondition: AF home already exists at $home"
+    fi
+    if [ ! -e "$home/config.toml" ]; then
+        lc_pass "precondition: no config.toml"
+    else
+        lc_fail "precondition: config.toml already exists"
+    fi
+    lc_assert_eq "0" "$(lc_daemon_count "$home")" "precondition: no daemon for this home"
+    if lc_supervisor_available && [ "$(lc_unit_active)" = "active" ]; then
+        lc_fail "precondition: an autostart unit is already active"
+    else
+        lc_pass "precondition: no active autostart unit"
+    fi
+
+    export AGENT_FACTORY_HOME="$home"
+    # A fresh home has no throttle record, so the launch path would try to
+    # self-update and re-exec mid-scenario. Scenario A is about the clean boot,
+    # not the update; scenario B owns that path explicitly.
+    export AGENT_FACTORY_AUTO_UPDATE=false
+
+    # 1. af runs at all.
+    if "$bin" version >/dev/null 2>&1; then
+        lc_pass "af version exits 0 in a virgin environment"
+    else
+        lc_fail "af version failed in a virgin environment"
+    fi
+
+    # 2. doctor is the new user's first stop: it must run, and must not report a
+    #    FAIL that a brand-new user cannot act on. (Missing agents are WARNs
+    #    with a fix line, which is correct — they are not FAILs.)
+    local fails
+    fails="$(lc_doctor_fail_count "$bin")"
+    if [ -z "$fails" ]; then
+        lc_fail "scenario-a: could not read a FAIL count out of af doctor"
+    else
+        lc_assert_eq "0" "$fails" "af doctor reports no FAIL on a brand-new machine"
+        [ "$fails" = "0" ] || lc_doctor_dump "$bin" | sed 's/^/[lifecycle]   | /' >&2
+    fi
+
+    # 3. The TUI itself comes up on a virgin home — no config, no state.json,
+    #    every first-run overlay unseen. This is a new user's literal first act.
+    if lc_boot_tui "$bin" "$home" "$repo" lc-a; then
+        lc_pass "the TUI renders its first frame on a virgin home"
+        local screen
+        screen="$(lc_capture lc-a)"
+        if printf '%s' "$screen" | grep -qiE 'panic:|fatal error|runtime error'; then
+            lc_fail "the TUI first frame contains a panic/fatal error"
+            printf '%s' "$screen" | sed 's/^/[lifecycle]   | /' >&2
+        else
+            lc_pass "no panic on the virgin first frame"
+        fi
+    else
+        lc_fail "the TUI did not boot on a virgin home"
+    fi
+
+    # 4. The daemon comes up exactly ONCE. Launching the TUI is what starts it
+    #    on a clean machine (measured: 0 daemons before the first launch, 1
+    #    after), so this is the moment to count — a second daemon racing up here
+    #    is the orphan/duplicate class.
+    local i
+    for ((i = 0; i < 40; i++)); do
+        [ "$(lc_daemon_count "$home")" -ge 1 ] && break
+        sleep 0.5
+    done
+    lc_assert_eq "1" "$(lc_daemon_count "$home")" "the daemon came up exactly once on first launch"
+    lc_assert_eq "true" "$(lc_status_field "$bin" '.data.running')" "daemon reports running"
+    lc_assert_eq "true" "$(lc_status_field "$bin" '.data.pid_verified')" "daemon pid is verified"
+    tmux kill-session -t lc-a 2>/dev/null
+
+    # 5. Stand in for "the user installs an agent", then use the machine. The
+    #    daemon is already up and read its config at startup, so it needs the
+    #    restart af itself prescribes — and that restart must not leave two.
+    lc_cheap_agent "$bin"
+    "$bin" daemon restart >/dev/null 2>&1
+    lc_assert_eq "1" "$(lc_daemon_count "$home")" "still exactly one daemon after a config-change restart"
+
+    if (cd "$repo" && "$bin" sessions create --name clean1 >/dev/null 2>&1); then
+        lc_pass "first session created on a clean machine"
+    else
+        lc_fail "could not create the first session on a clean machine"
+        (cd "$repo" && "$bin" sessions create --name clean1 2>&1 | head -3 |
+            sed 's/^/[lifecycle]   | /' >&2)
+    fi
+
+    # A second client must adopt the running daemon, never race up a rival.
+    (cd "$repo" && "$bin" sessions create --name clean2 >/dev/null 2>&1)
+    lc_assert_eq "1" "$(lc_daemon_count "$home")" "still exactly one daemon after a second client"
+
+    lc_teardown_home "$home"
+}
+
+# ----------------------------------------------------------------------------
+# Scenario B — install a real N-1 release, then upgrade to N.
+#
+# $1: upgrade mode — "upgrade-cmd" (af upgrade) or "launch" (the launch-time
+#     auto-update path, which is a different code path into the same restart).
+# ----------------------------------------------------------------------------
+scenario_b() {
+    local mode="$1"
+    lc_section "scenario B — install -> upgrade (mode: $mode)"
+
+    # Separate statements: see the note in scenario_a.
+    local ws="$LC_WORKSPACE/b-$mode"
+    local home="$ws/home"
+    local repo="$ws/repo"
+    local bin="$ws/bin/af"
+    rm -rf "$ws"
+    mkdir -p "$ws/bin"
+    lc_mock_repo "$repo" || {
+        lc_fail "scenario-b/$mode: could not build the mock repo"
+        return 1
+    }
+
+    local tags old_tag new_tag
+    tags="$(lc_two_newest_stable)" || {
+        lc_fail "scenario-b/$mode: could not resolve the two newest stable releases (network? rate limit?)"
+        return 1
+    }
+    old_tag="$(printf '%s' "$tags" | cut -f1)"
+    new_tag="$(printf '%s' "$tags" | cut -f2)"
+    lc_say "upgrading across the real release boundary: $old_tag -> $new_tag"
+
+    # --- install the REAL previous release -----------------------------------
+    lc_install_release "$old_tag" "$bin" || {
+        lc_fail "scenario-b/$mode: could not install $old_tag"
+        return 1
+    }
+    export AGENT_FACTORY_HOME="$home"
+    export AGENT_FACTORY_AUTO_UPDATE=false
+
+    local old_ver
+    old_ver="$(lc_client_version "$bin")"
+    lc_assert_eq "${old_tag#v}" "$old_ver" "installed the real previous release"
+
+    # Configure the cheap agent BEFORE any daemon exists, so the daemon reads it
+    # at startup and no restart is needed to apply it.
+    lc_cheap_agent "$bin" || lc_fail "scenario-b/$mode: could not set program_overrides on $old_tag"
+
+    # --- supervise it, when the environment can ------------------------------
+    local supervised=no
+    if lc_supervisor_available; then
+        if "$bin" daemon install >/dev/null 2>&1; then
+            supervised=yes
+            lc_pass "autostart unit installed (this machine can supervise)"
+        else
+            lc_fail "af daemon install failed on a machine with a service manager"
+        fi
+    else
+        # Loud, not silent: a container run does NOT cover assertion #4.
+        lc_skip "assertion #4 (unit stays the supervisor): no user service manager here (container has no systemd)"
+    fi
+
+    # --- put state on the old daemon ----------------------------------------
+    (cd "$repo" && "$bin" sessions create --name pre1 >/dev/null 2>&1)
+    (cd "$repo" && "$bin" sessions create --name pre2 >/dev/null 2>&1)
+    local before_sessions before_pid before_daemon_ver
+    before_sessions="$(lc_session_count "$bin")"
+    before_pid="$(lc_daemon_pids "$home" | head -1)"
+    if [ -z "$before_pid" ]; then
+        lc_fail "scenario-b/$mode: no daemon came up on the old release; nothing to upgrade"
+        return 1
+    fi
+    before_daemon_ver="$(lc_daemon_version "$before_pid")"
+    lc_say "before upgrade: daemon pid=$before_pid version=$before_daemon_ver sessions=$before_sessions"
+    lc_assert_eq "2" "$before_sessions" "two sessions exist before the upgrade"
+
+    local before_unit_pid=""
+    if [ "$supervised" = yes ]; then
+        before_unit_pid="$(lc_unit_main_pid)"
+        lc_assert_eq "active" "$(lc_unit_active)" "the unit supervises the daemon before the upgrade"
+    fi
+
+    # --- the upgrade ---------------------------------------------------------
+    lc_do_upgrade "$mode" "$bin" "$home" "$repo" "$new_tag" || {
+        lc_fail "scenario-b/$mode: the upgrade step itself failed"
+        return 1
+    }
+
+    # --- assertions ----------------------------------------------------------
+    local after_pid after_daemon_ver client_ver after_sessions
+    after_pid="$(lc_daemon_pids "$home" | head -1)"
+    client_ver="$(lc_client_version "$bin")"
+
+    # (0) the client really did move to N — otherwise every assertion below is
+    #     vacuously true and the gate would pass while testing nothing.
+    lc_assert_eq "${new_tag#v}" "$client_ver" "the client binary is now the new release"
+
+    if [ -z "$after_pid" ]; then
+        lc_fail "assertion 1/2/3: NO daemon is running after the upgrade"
+    else
+        after_daemon_ver="$(lc_daemon_version "$after_pid")"
+        lc_say "after upgrade: daemon pid=$after_pid version=$after_daemon_ver client=$client_ver"
+
+        # 1. the daemon is RESTARTED onto the NEW binary — not left on the old.
+        lc_assert_ne "$before_pid" "$after_pid" "assertion 1: the daemon was restarted (pid)"
+        lc_assert_eq "false" "$(lc_status_field "$bin" '.data.binary_stale')" \
+            "assertion 1: the daemon is not running a since-replaced binary"
+
+        # 2. client version == daemon version. Queried, not inferred: the
+        #    daemon's version comes from the image it is ACTUALLY executing
+        #    (/proc/<pid>/exe), so a daemon left on the old bytes cannot hide
+        #    behind a new binary on disk. This is the #1921 skew condition.
+        lc_assert_eq "$client_ver" "$after_daemon_ver" \
+            "assertion 2: no version skew (client == daemon)"
+
+        # 3. exactly ONE daemon; no orphan/second survived the restart.
+        lc_assert_eq "1" "$(lc_daemon_count "$home")" "assertion 3: exactly one daemon afterwards"
+    fi
+
+    # 4. if a unit was installed, it is STILL the supervisor.
+    if [ "$supervised" = yes ]; then
+        lc_assert_eq "active" "$(lc_unit_active)" "assertion 4: the unit is still active"
+        lc_assert_eq "true" "$(lc_status_field "$bin" '.data.autostart_unit')" \
+            "assertion 4: af still sees the autostart unit"
+        local unit_pid
+        unit_pid="$(lc_unit_main_pid)"
+        # The demotion this catches: a daemon still runs and still answers, but
+        # it is an ad-hoc child systemd does not own — the unit's MainPID stops
+        # matching the daemon that is actually serving (#796).
+        if [ -n "$after_pid" ] && [ "$unit_pid" = "$after_pid" ]; then
+            lc_pass "assertion 4: the running daemon IS the unit's child (MainPID=$unit_pid) — not demoted"
+        else
+            lc_fail "assertion 4: daemon DEMOTED to an ad-hoc child (unit MainPID=$unit_pid, running daemon=$after_pid, was $before_unit_pid)"
+        fi
+    fi
+
+    # 5. pre-existing sessions survive.
+    after_sessions="$(lc_session_count "$bin")"
+    lc_assert_eq "$before_sessions" "$after_sessions" "assertion 5: sessions survive the upgrade"
+    local lost
+    lost="$(lc_lost_session_count "$bin")"
+    lc_assert_eq "0" "$lost" "assertion 5: no session went Lost across the upgrade"
+
+    # 6. doctor is the oracle: zero FAILs on the upgraded machine.
+    local fails
+    fails="$(lc_doctor_fail_count "$bin")"
+    if [ -z "$fails" ]; then
+        lc_fail "assertion 6: could not read a FAIL count out of af doctor"
+    else
+        lc_assert_eq "0" "$fails" "assertion 6: af doctor reports zero FAILs after the upgrade"
+        [ "$fails" = "0" ] || lc_doctor_dump "$bin" | sed 's/^/[lifecycle]   | /' >&2
+    fi
+
+    lc_teardown_home "$home" "$supervised"
+}
+
+# lc_do_upgrade <mode> <bin> <home> <repo> <new-tag> — perform the upgrade the
+# way the named path does it.
+lc_do_upgrade() {
+    local mode="$1" bin="$2" home="$3" repo="$4" new_tag="$5"
+
+    # Fault injection: swap the binary to N and never restart the daemon. This
+    # is what a broken upgrade looks like from the outside — and it is exactly
+    # the machine #1921 shipped: new client, old daemon, everything "running".
+    if [ "$LC_INJECT" = "skip-daemon-restart" ]; then
+        lc_say "INJECT: swapping the binary to $new_tag WITHOUT restarting the daemon"
+        lc_install_release "$new_tag" "$bin" || return 1
+        return 0
+    fi
+
+    case "$mode" in
+    upgrade-cmd)
+        lc_say "running: af upgrade"
+        local out
+        out="$("$bin" upgrade 2>&1)"
+        printf '%s\n' "$out" | sed 's/^/[lifecycle]   | /' >&2
+        printf '%s' "$out" | grep -q 'Upgraded successfully' || return 1
+        ;;
+    launch)
+        # The launch-time auto-update path (commands/root.go -> autoUpdateOnLaunch)
+        # is gated on stdout being a TTY: it deliberately never fires for a
+        # script or a pipe. So it can only be exercised through a real terminal
+        # — a tmux pane — not a plain exec.
+        lc_say "booting the TUI with auto-update enabled (launch-time path)"
+        AGENT_FACTORY_AUTO_UPDATE=true \
+            tmux new-session -d -s lc-b -x 100 -y 30 || return 1
+        tmux send-keys -t lc-b \
+            "export AGENT_FACTORY_HOME=$home AGENT_FACTORY_AUTO_UPDATE=true; cd $repo && $bin" Enter
+        # Wait for the NEW version to be on disk: the launch path downloads,
+        # installs, restarts the daemon, then re-execs into the new TUI.
+        local i ok=1
+        for ((i = 0; i < 240; i++)); do
+            if [ "$(lc_client_version "$bin")" = "${new_tag#v}" ]; then
+                ok=0
+                break
+            fi
+            sleep 0.5
+        done
+        if [ "$ok" != 0 ]; then
+            lc_say "launch-time auto-update never installed $new_tag; screen was:"
+            lc_capture lc-b | sed 's/^/[lifecycle]   | /' >&2
+            tmux kill-session -t lc-b 2>/dev/null
+            return 1
+        fi
+        # The re-exec'd TUI must actually come back up.
+        for ((i = 0; i < 120; i++)); do
+            lc_capture lc-b | grep -q 'Agent Factory' && break
+            sleep 0.5
+        done
+        # Give the restart-daemon step room to finish before we measure it.
+        for ((i = 0; i < 60; i++)); do
+            [ "$(lc_status_field "$bin" '.data.running')" = "true" ] && break
+            sleep 0.5
+        done
+        tmux kill-session -t lc-b 2>/dev/null
+        ;;
+    *)
+        lc_say "unknown upgrade mode '$mode'"
+        return 1
+        ;;
+    esac
+}
+
+# lc_session_count <bin> — sessions the daemon knows about.
+lc_session_count() {
+    "$1" sessions list 2>/dev/null | jq -r '[.[]?] | length' 2>/dev/null ||
+        printf '0\n'
+}
+
+# lc_lost_session_count <bin> — sessions whose worktree/tmux vanished. An
+# upgrade that strands sessions is a data-loss bug, not a cosmetic one.
+lc_lost_session_count() {
+    "$1" sessions list 2>/dev/null |
+        jq -r '[.[]? | select((.status|tostring) == "4" or (.liveness|tostring) == "4")] | length' 2>/dev/null ||
+        printf '0\n'
+}
+
+# lc_teardown_home <home> [supervised] — stop what this scenario started so the
+# next scenario's daemon count starts from zero. The container reaps everything
+# anyway; a CI runner that runs several scenarios in one job does not.
+lc_teardown_home() {
+    local home="$1" supervised="${2:-no}" pid
+    if [ "$supervised" = yes ] && lc_supervisor_available; then
+        systemctl --user stop "$LC_UNIT_NAME" >/dev/null 2>&1 || true
+        systemctl --user disable "$LC_UNIT_NAME" >/dev/null 2>&1 || true
+        rm -f "$HOME/.config/systemd/user/$LC_UNIT_NAME" 2>/dev/null || true
+        systemctl --user daemon-reload >/dev/null 2>&1 || true
+    fi
+    # Only ever signal daemons proven to serve THIS throwaway home.
+    for pid in $(lc_daemon_pids "$home"); do
+        kill -TERM "$pid" 2>/dev/null || true
+    done
+    sleep 1
+    for pid in $(lc_daemon_pids "$home"); do
+        kill -KILL "$pid" 2>/dev/null || true
+    done
+}
+
+# ----------------------------------------------------------------------------
+main() {
+    local what="${1:-all}"
+
+    lc_guard_disposable || exit 2
+    mkdir -p "$LC_WORKSPACE"
+
+    for t in curl tar jq git tmux; do
+        command -v "$t" >/dev/null 2>&1 || {
+            lc_say "missing required tool: $t"
+            exit 2
+        }
+    done
+
+    lc_say "af lifecycle gate — $(uname -s)/$(uname -m)"
+    [ -n "$LC_INJECT" ] && lc_say "FAULT INJECTION ACTIVE: $LC_INJECT (assertions are EXPECTED to fail)"
+
+    case "$what" in
+    scenario-a) scenario_a ;;
+    scenario-b)
+        scenario_b upgrade-cmd
+        scenario_b launch
+        ;;
+    all)
+        scenario_a
+        scenario_b upgrade-cmd
+        scenario_b launch
+        ;;
+    *)
+        lc_say "unknown scenario '$what' (want: scenario-a | scenario-b | all)"
+        exit 2
+        ;;
+    esac
+
+    lc_summary
+}
+
+main "$@"

--- a/scripts/lifecycle.sh
+++ b/scripts/lifecycle.sh
@@ -80,7 +80,7 @@ LC_WORKSPACE="${AF_LIFECYCLE_WORKSPACE:-$HOME/af-lifecycle}"
 . "$LC_HERE/lifecycle-lib.sh"
 
 LC_REPO_SLUG="sachiniyer/agent-factory"
-LC_API="https://api.github.com/repos/$LC_REPO_SLUG/releases?per_page=100"
+LC_API_BASE="https://api.github.com/repos/$LC_REPO_SLUG/releases"
 LC_DL="https://github.com/$LC_REPO_SLUG/releases/download"
 
 # INJECTIONS — deliberately break the machine to prove an assertion fires.
@@ -169,17 +169,37 @@ lc_goos_goarch() {
 # current boundary as releases cut. Nothing here asserts a specific version —
 # the assertions are about daemon/client coherence, which is version-agnostic.
 lc_two_newest_stable() {
-    local auth=() json tags
+    local auth=() page=1 json n stable=() tag
     [ -n "${GITHUB_TOKEN:-}" ] && auth=(-H "Authorization: Bearer $GITHUB_TOKEN")
-    json=$(curl -sSL --max-time 60 "${auth[@]}" "$LC_API" 2>/dev/null) || return 1
-    tags=$(printf '%s' "$json" |
-        jq -r '[.[] | select(.draft==false and .prerelease==false) | .tag_name] | .[0:2] | @tsv' 2>/dev/null)
-    [ -n "$tags" ] || return 1
-    # Two distinct releases are required: with fewer, "upgrade from N-1 to N"
-    # has nothing to upgrade across.
-    [ "$(printf '%s' "$tags" | awk -F'\t' '{print NF}')" = "2" ] || return 1
-    # @tsv gives newest-first; the caller wants N-1 first.
-    printf '%s\t%s\n' "$(printf '%s' "$tags" | cut -f2)" "$(printf '%s' "$tags" | cut -f1)"
+
+    # PAGINATE. A single ?per_page=100 fetch makes "100 is enough" a silent
+    # assumption: this repo interleaves -preview-N prereleases with stables, so a
+    # busy preview cycle can push the second-newest stable off page one. Walk
+    # pages until two stables are found, and FAIL if the set cannot be
+    # enumerated — never guess from page one and call it an upgrade matrix.
+    while [ "$page" -le "${LC_RELEASE_MAX_PAGES:-10}" ]; do
+        json=$(curl -sSL --max-time 60 "${auth[@]}" \
+            "$LC_API_BASE?per_page=100&page=$page" 2>/dev/null) || return 1
+        # A non-array (rate-limit object, error envelope) must not read as "no
+        # more releases" — that would end the walk and look like exhaustion.
+        [ "$(printf '%s' "$json" | jq -r 'type' 2>/dev/null)" = "array" ] || return 1
+        n=$(printf '%s' "$json" | jq -r 'length' 2>/dev/null)
+        [ -n "$n" ] || return 1
+        while IFS= read -r tag; do
+            [ -n "$tag" ] && stable+=("$tag")
+        done < <(printf '%s' "$json" |
+            jq -r '.[] | select(.draft==false and .prerelease==false) | .tag_name' 2>/dev/null)
+        [ "${#stable[@]}" -ge 2 ] && break
+        # A short page is the last page.
+        [ "$n" -lt 100 ] && break
+        page=$((page + 1))
+    done
+
+    # Two distinct releases are required: with fewer, "upgrade from N-1 to N" has
+    # nothing to upgrade across.
+    [ "${#stable[@]}" -ge 2 ] || return 1
+    # The API lists newest-first; the caller wants "N-1<TAB>N".
+    printf '%s\t%s\n' "${stable[1]}" "${stable[0]}"
 }
 
 # lc_install_release <tag> <dest-bin> — install a REAL release binary, the way
@@ -564,6 +584,7 @@ scenario_b() {
             lc_teardown_home "$home" "$supervised"
             return 1
         fi
+        lc_note_injection_applied
         lc_say "INJECT: applied — session states now: $(lc_session_states "$bin" "$repo")"
     fi
 
@@ -671,6 +692,7 @@ lc_do_upgrade() {
             lc_fail "INJECT skip-daemon-restart: binary is '$got', expected '${new_tag#v}' — the injection did not apply"
             return 1
         fi
+        lc_note_injection_applied
         lc_say "INJECT: applied — client is now $got, daemon deliberately left on the old image"
         return 0
     fi
@@ -893,6 +915,9 @@ main() {
     done
 
     lc_say "af lifecycle gate — $(uname -s)/$(uname -m)"
+    # Validate BEFORE running anything: an unrecognized injection injects
+    # nothing, and a green run would then claim we survived a fault never applied.
+    lc_validate_injection "$LC_INJECT" || exit 2
     [ -n "$LC_INJECT" ] && lc_say "FAULT INJECTION ACTIVE: $LC_INJECT (assertions are EXPECTED to fail)"
 
     case "$what" in
@@ -911,6 +936,9 @@ main() {
         exit 2
         ;;
     esac
+
+    # An injection asked for but never reached is a harness defect, not a pass.
+    lc_assert_injection_ran "$LC_INJECT"
 
     lc_summary
 }

--- a/scripts/lifecycle.sh
+++ b/scripts/lifecycle.sh
@@ -265,40 +265,53 @@ scenario_a() {
     }
 
     # Preconditions: prove the environment really is clean before we claim af
-    # coped with a clean one.
-    if [ ! -e "$home" ]; then
-        lc_pass "precondition: no AF home at $home"
-    else
-        lc_fail "precondition: AF home already exists at $home"
-    fi
-    if [ ! -e "$home/config.toml" ]; then
-        lc_pass "precondition: no config.toml"
-    else
-        lc_fail "precondition: config.toml already exists"
-    fi
-    lc_assert_eq "0" "$(lc_daemon_count "$home")" "precondition: no daemon for this home"
+    # coped with a clean one. Machine-level facts here; each probe re-asserts its
+    # OWN home is virgin immediately before touching it (lc_assert_virgin).
     if lc_supervisor_available && [ "$(lc_unit_active)" = "active" ]; then
         lc_fail "precondition: an autostart unit is already active"
     else
         lc_pass "precondition: no active autostart unit"
     fi
 
-    export AGENT_FACTORY_HOME="$home"
     # A fresh home has no throttle record, so the launch path would try to
     # self-update and re-exec mid-scenario. Scenario A is about the clean boot,
     # not the update; scenario B owns that path explicitly.
     export AGENT_FACTORY_AUTO_UPDATE=false
 
-    # 1. af runs at all.
+    # ---- probe 1: doctor, on a machine NOTHING has touched --------------------
+    #
+    # Its own home, because AN OBSERVATION THAT CREATES THE STATE IT OBSERVES IS
+    # NOT AN OBSERVATION. `af doctor` materializes the home directory and
+    # agent-factory.log (measured: `af version` touches nothing, doctor and
+    # `daemon status` both create home/ + the log). Running doctor and then the
+    # TUI against ONE home means the TUI's "virgin home" claim is measuring a
+    # home doctor already built — and the preconditions asserted at the top of
+    # the scenario only ever covered the first probe.
+    #
+    # Two pristine homes, each with its precondition checked IMMEDIATELY before
+    # the probe that depends on it, is the only version of this that cannot rot:
+    # it holds no matter which command materializes what, on either side of the
+    # upgrade boundary.
+    local dhome="$ws/home-doctor"
+    export AGENT_FACTORY_HOME="$dhome"
+    lc_assert_virgin "$dhome" "doctor probe"
+
+    # af version must not even create the home (it is the one command that can
+    # be run before anything exists).
     if "$bin" version >/dev/null 2>&1; then
         lc_pass "af version exits 0 in a virgin environment"
     else
         lc_fail "af version failed in a virgin environment"
     fi
+    if [ ! -e "$dhome" ]; then
+        lc_pass "af version did not materialize the home (nothing to observe yet)"
+    else
+        lc_fail "af version created $dhome — the doctor probe below is no longer virgin"
+    fi
 
-    # 2. doctor is the new user's first stop: it must run, and must not report a
-    #    FAIL that a brand-new user cannot act on. (Missing agents are WARNs
-    #    with a fix line, which is correct — they are not FAILs.)
+    # doctor is the new user's first stop: it must run, and must not report a
+    # FAIL that a brand-new user cannot act on. (Missing agents are WARNs with a
+    # fix line, which is correct — they are not FAILs.)
     local fails
     fails="$(lc_doctor_fail_count "$bin")"
     if [ -z "$fails" ]; then
@@ -307,18 +320,28 @@ scenario_a() {
         lc_assert_eq "0" "$fails" "af doctor reports no FAIL on a brand-new machine"
         [ "$fails" = "0" ] || lc_doctor_dump "$bin" | sed 's/^/[lifecycle]   | /' >&2
     fi
+    lc_teardown_home "$dhome"
 
-    # 3. The TUI itself comes up on a virgin home — no config, no state.json,
-    #    every first-run overlay unseen. This is a new user's literal first act.
+    # ---- probe 2: the TUI, on a SECOND machine nothing has touched ------------
+    #
+    # A new user's literal first act. Pristine again — doctor's home above is
+    # not reused, so "virgin" here is a fact rather than a hope.
+    export AGENT_FACTORY_HOME="$home"
+    lc_assert_virgin "$home" "TUI probe"
     if lc_boot_tui "$bin" "$home" "$repo" lc-a; then
         lc_pass "the TUI renders its first frame on a virgin home"
         local screen
         screen="$(lc_capture lc-a)"
-        if printf '%s' "$screen" | grep -qiE 'panic:|fatal error|runtime error'; then
+        # AUDIT: "grep found no panic" passes on an EMPTY screen — a dead pane
+        # would sail through the no-panic check. Prove there is a screen to
+        # search before concluding anything about what is not on it.
+        if ! printf '%s' "$screen" | grep -q 'Agent Factory'; then
+            lc_fail "no-panic check has nothing to read: the captured screen is empty/not the TUI"
+        elif printf '%s' "$screen" | grep -qiE 'panic:|fatal error|runtime error'; then
             lc_fail "the TUI first frame contains a panic/fatal error"
             printf '%s' "$screen" | sed 's/^/[lifecycle]   | /' >&2
         else
-            lc_pass "no panic on the virgin first frame"
+            lc_pass "no panic on the virgin first frame (searched $(printf '%s' "$screen" | wc -l) captured lines)"
         fi
     else
         lc_fail "the TUI did not boot on a virgin home"
@@ -345,12 +368,19 @@ scenario_a() {
     "$bin" daemon restart >/dev/null 2>&1
     lc_assert_eq "1" "$(lc_daemon_count "$home")" "still exactly one daemon after a config-change restart"
 
-    if (cd "$repo" && "$bin" sessions create --name clean1 >/dev/null 2>&1); then
-        lc_pass "first session created on a clean machine"
+    # AUDIT: an exit status is NOT evidence a session exists. `af sessions create`
+    # can answer 0 while its JSON body carries a refusal ("claude is not
+    # installed…") — observed on this very harness. So assert the OUTCOME: the
+    # daemon lists it.
+    local c_out c_rc=0
+    c_out="$(cd "$repo" && "$bin" sessions create --name clean1 2>&1)" || c_rc=$?
+    local n_after
+    n_after="$(lc_wait_session_count "$bin" "$repo" 1 30)"
+    if [ "$n_after" = "1" ]; then
+        lc_pass "first session created on a clean machine (daemon lists it)"
     else
-        lc_fail "could not create the first session on a clean machine"
-        (cd "$repo" && "$bin" sessions create --name clean1 2>&1 | head -3 |
-            sed 's/^/[lifecycle]   | /' >&2)
+        lc_fail "first session not created on a clean machine (create rc=$c_rc, daemon lists '$n_after')"
+        printf '%s\n' "$c_out" | head -3 | sed 's/^/[lifecycle]   | /' >&2
     fi
 
     # A second client must adopt the running daemon, never race up a rival.
@@ -410,11 +440,16 @@ scenario_b() {
     # --- supervise it, when the environment can ------------------------------
     local supervised=no
     if lc_supervisor_available; then
-        if "$bin" daemon install >/dev/null 2>&1; then
+        # AUDIT: trusting `daemon install`'s exit code would let a no-op install
+        # set supervised=yes, and assertion 4 would then "pass" against a unit
+        # that was never registered. The unit file has to actually exist.
+        if "$bin" daemon install >/dev/null 2>&1 &&
+            [ "$(lc_status_field "$bin" '.data.autostart_unit')" = "true" ]; then
             supervised=yes
             lc_pass "autostart unit installed (this machine can supervise)"
         else
-            lc_fail "af daemon install failed on a machine with a service manager"
+            lc_fail "af daemon install did not register a unit on a machine with a service manager"
+            "$bin" daemon install 2>&1 | head -3 | sed 's/^/[lifecycle]   | /' >&2
         fi
     else
         # Loud, not silent: a container run does NOT cover assertion #4.
@@ -506,14 +541,30 @@ scenario_b() {
     # catch, which also confirms the enum ordinals end-to-end.
     if [ "$LC_INJECT" = "unhealthy-session" ]; then
         lc_say "INJECT: archiving 'pre1' so it is no longer in a healthy state"
-        "$bin" sessions archive pre1 --repo "$repo" >/dev/null 2>&1 ||
-            "$bin" sessions archive pre1 >/dev/null 2>&1
-        local j
+        local arc_out arc_rc=0
+        arc_out="$("$bin" sessions archive pre1 --repo "$repo" 2>&1)" || arc_rc=$?
+        local j applied=1
         for ((j = 0; j < 40; j++)); do
-            [ "$(lc_unhealthy_session_count "$bin" "$repo")" != "0" ] && break
+            [ "$(lc_unhealthy_session_count "$bin" "$repo")" != "0" ] && {
+                applied=0
+                break
+            }
             sleep 0.5
         done
-        lc_say "INJECT: session states now: $(lc_session_states "$bin" "$repo")"
+        # A fault injection whose SETUP silently no-ops is the worst case of all:
+        # every assertion downstream then reports on a scenario that never
+        # existed, and the run looks like proof. errexit is off here (assertions
+        # must accumulate), so the archive's status is checked explicitly rather
+        # than assumed — and the OUTCOME is confirmed, not just the exit code: a
+        # CLI that returns 0 without archiving would still be caught.
+        if [ "$applied" != 0 ]; then
+            lc_fail "INJECT unhealthy-session: the injection DID NOT APPLY (archive rc=$arc_rc) — refusing to report on a scenario that was never set up"
+            printf '%s\n' "$arc_out" | head -3 | sed 's/^/[lifecycle]   | /' >&2
+            lc_say "session states: $(lc_session_states "$bin" "$repo")"
+            lc_teardown_home "$home" "$supervised"
+            return 1
+        fi
+        lc_say "INJECT: applied — session states now: $(lc_session_states "$bin" "$repo")"
     fi
 
     # --- assertions ----------------------------------------------------------
@@ -540,8 +591,18 @@ scenario_b() {
         #    daemon's version comes from the image it is ACTUALLY executing
         #    (/proc/<pid>/exe), so a daemon left on the old bytes cannot hide
         #    behind a new binary on disk. This is the #1921 skew condition.
-        lc_assert_eq "$client_ver" "$after_daemon_ver" \
-            "assertion 2: no version skew (client == daemon)"
+        #
+        #    AUDIT: `lc_assert_eq "" ""` PASSES. If lc_daemon_version could not
+        #    read /proc/<pid>/exe (a permission change, a macOS runner, a dead
+        #    pid) and lc_client_version also came back empty, the single most
+        #    important assertion in this gate would report "no skew" having
+        #    compared nothing against nothing. Both operands must exist first.
+        if [ -z "$after_daemon_ver" ] || [ -z "$client_ver" ]; then
+            lc_fail "assertion 2: cannot compare versions (daemon='$after_daemon_ver', client='$client_ver') — refusing to report 'no skew' from unreadable values"
+        else
+            lc_assert_eq "$client_ver" "$after_daemon_ver" \
+                "assertion 2: no version skew (client == daemon)"
+        fi
 
         # 3. exactly ONE daemon; no orphan/second survived the restart.
         lc_assert_eq "1" "$(lc_daemon_count "$home")" "assertion 3: exactly one daemon afterwards"
@@ -597,7 +658,20 @@ lc_do_upgrade() {
     # the machine #1921 shipped: new client, old daemon, everything "running".
     if [ "$LC_INJECT" = "skip-daemon-restart" ]; then
         lc_say "INJECT: swapping the binary to $new_tag WITHOUT restarting the daemon"
-        lc_install_release "$new_tag" "$bin" || return 1
+        lc_install_release "$new_tag" "$bin" || {
+            lc_fail "INJECT skip-daemon-restart: could not install $new_tag — the injection did not apply"
+            return 1
+        }
+        # Confirm the OUTCOME, not just that the download returned 0: if the
+        # binary on disk is not actually N, there is no skew to detect and every
+        # assertion below would report on a machine that was never broken.
+        local got
+        got="$(lc_client_version "$bin")"
+        if [ "$got" != "${new_tag#v}" ]; then
+            lc_fail "INJECT skip-daemon-restart: binary is '$got', expected '${new_tag#v}' — the injection did not apply"
+            return 1
+        fi
+        lc_say "INJECT: applied — client is now $got, daemon deliberately left on the old image"
         return 0
     fi
 

--- a/scripts/lifecycle.sh
+++ b/scripts/lifecycle.sh
@@ -427,7 +427,7 @@ scenario_b() {
     # fails on a loaded CI runner. Same rule the TUI driver follows (#1161):
     # wait on the condition, never on a sleep.
     local before_sessions before_pid before_daemon_ver
-    before_sessions="$(lc_wait_session_count "$bin" 2 30)"
+    before_sessions="$(lc_wait_session_count "$bin" "$repo" 2 30)"
     before_pid="$(lc_daemon_pids "$home" | head -1)"
     if [ -z "$before_pid" ]; then
         lc_fail "scenario-b/$mode: no daemon came up on the old release; nothing to upgrade"
@@ -445,7 +445,7 @@ scenario_b() {
         lc_say "what 'sessions create' actually said:"
         printf '%s' "$create_log" | sed 's/^/[lifecycle]   | /' >&2
         lc_say "session list was:"
-        "$bin" sessions list 2>&1 | head -5 | sed 's/^/[lifecycle]   | /' >&2
+        "$bin" sessions list --repo "$repo" 2>&1 | head -5 | sed 's/^/[lifecycle]   | /' >&2
         lc_say "config.toml [program_overrides] (config get does not know this key on older releases):"
         grep -A2 'program_overrides' "$home/config.toml" 2>/dev/null |
             head -3 | sed 's/^/[lifecycle]   | /' >&2
@@ -521,10 +521,10 @@ scenario_b() {
     fi
 
     # 5. pre-existing sessions survive.
-    after_sessions="$(lc_session_count "$bin")"
+    after_sessions="$(lc_wait_session_count "$bin" "$repo" "$before_sessions" 30)"
     lc_assert_eq "$before_sessions" "$after_sessions" "assertion 5: sessions survive the upgrade"
     local lost
-    lost="$(lc_lost_session_count "$bin")"
+    lost="$(lc_lost_session_count "$bin" "$repo")"
     lc_assert_eq "0" "$lost" "assertion 5: no session went Lost across the upgrade"
 
     # 6. doctor is the oracle: zero FAILs on the upgraded machine.
@@ -607,15 +607,26 @@ lc_do_upgrade() {
     esac
 }
 
-# lc_session_count <bin> — sessions the daemon knows about.
+# lc_session_count <bin> <repo> — sessions the daemon knows about FOR THIS REPO.
+#
+# `--repo` is not decoration. `af sessions list` resolves its project from the
+# CURRENT DIRECTORY when the flag is absent, and this script runs from the af
+# checkout — so an unscoped list asks "what sessions exist in agent-factory?",
+# gets the correct answer [], and reports zero sessions on a machine that has
+# two. That read cost a whole debugging cycle: it passed locally, where /src is
+# an af WORKTREE whose .git file points outside the container, so git fails,
+# no project resolves, and af falls back to listing everything — the right
+# number for the wrong reason. On a clean CI checkout the resolution works and
+# the bug appears. The flag exists on both sides of the upgrade boundary
+# (verified against v1.0.193), so scope it explicitly and depend on nothing.
 #
 # Prints "unreadable" rather than 0 when the list cannot be parsed. A silent 0
-# fallback here would be indistinguishable from a real empty machine, which
-# would turn assertion 5 into "0 sessions survived: PASS" — the exact vacuous
-# green this gate exists to prevent.
+# fallback would be indistinguishable from a real empty machine, turning
+# assertion 5 into "0 sessions survived: PASS" — the vacuous green this gate
+# exists to prevent.
 lc_session_count() {
-    local out n
-    out="$("$1" sessions list 2>/dev/null)" || {
+    local bin="$1" repo="$2" out n
+    out="$("$bin" sessions list --repo "$repo" 2>/dev/null)" || {
         printf 'unreadable\n'
         return 0
     }
@@ -634,21 +645,33 @@ lc_session_count() {
 # <want> sessions, then print the count (or the last count seen on timeout, so
 # the caller reports what was actually there rather than a fabricated number).
 lc_wait_session_count() {
-    local bin="$1" want="$2" timeout="${3:-30}" i n=""
+    local bin="$1" repo="$2" want="$3" timeout="${4:-30}" i n=""
     for ((i = 0; i < timeout * 2; i++)); do
-        n="$(lc_session_count "$bin")"
+        n="$(lc_session_count "$bin" "$repo")"
         [ "$n" = "$want" ] && break
         sleep 0.5
     done
     printf '%s\n' "$n"
 }
 
-# lc_lost_session_count <bin> — sessions whose worktree/tmux vanished. An
+# lc_lost_session_count <bin> <repo> — sessions whose worktree/tmux vanished. An
 # upgrade that strands sessions is a data-loss bug, not a cosmetic one.
 lc_lost_session_count() {
-    "$1" sessions list 2>/dev/null |
-        jq -r '[.[]? | select((.status|tostring) == "4" or (.liveness|tostring) == "4")] | length' 2>/dev/null ||
-        printf '0\n'
+    local bin="$1" repo="$2" out n
+    out="$("$bin" sessions list --repo "$repo" 2>/dev/null)" || {
+        printf 'unreadable\n'
+        return 0
+    }
+    n="$(printf '%s' "$out" |
+        jq -r '[.[]? | select((.status|tostring) == "4" or (.liveness|tostring) == "4")] | length' 2>/dev/null)" || {
+        printf 'unreadable\n'
+        return 0
+    }
+    [ -n "$n" ] || {
+        printf 'unreadable\n'
+        return 0
+    }
+    printf '%s\n' "$n"
 }
 
 # lc_teardown_home <home> [supervised] — stop what this scenario started so the

--- a/scripts/testbox.sh
+++ b/scripts/testbox.sh
@@ -24,15 +24,23 @@ IMAGE="${AF_TESTBOX_IMAGE:-agent-factory-testbox}"
 # see scripts/container/Dockerfile.web-selftest. Kept distinct so it never bloats
 # the plain testbox image every other gate shares.
 WEB_IMAGE="${AF_WEB_TESTBOX_IMAGE:-agent-factory-web-selftest}"
-# The lifecycle gate gets its OWN tag, even though it builds from the same
-# Dockerfile as the testbox. The tag is a GLOBAL name on the docker daemon, and
-# this box runs many worktrees: a sibling running `make test-container` from a
-# checkout that predates a Dockerfile change rebuilds `agent-factory-testbox`
-# from THEIR Dockerfile and moves the shared tag back, so whichever build ran
-# last wins. That is not theoretical — it silently reverted the image under this
-# gate mid-run ("missing required tool: jq"). A dedicated tag means a concurrent
-# sibling cannot decide what this gate runs against. Same reasoning as WEB_IMAGE.
-LIFECYCLE_IMAGE="${AF_LIFECYCLE_IMAGE:-agent-factory-lifecycle}"
+# The lifecycle gate's image tag is UNIQUE PER RUN.
+#
+# An image tag is a global name on the docker daemon, and this box runs many
+# worktrees at once. A fixed tag has two failure modes, and we have now eaten
+# both:
+#   * a SIBLING gate rebuilds the shared `agent-factory-testbox` tag from THEIR
+#     checkout's Dockerfile, so whichever build ran last wins — that silently
+#     reverted the image under this gate mid-run ("missing required tool: jq");
+#   * two CONCURRENT lifecycle runs from different worktrees clobber each
+#     other's tag. That is exactly #1171 (the fixed `af-playtest` name), fixed in
+#     #1166 with per-run-unique names. Re-introducing it in the sibling harness
+#     would be repeating a bug we already paid for.
+#
+# So the tag carries the same per-run token the container name does, and is
+# removed on exit. Layer cache is keyed on Dockerfile content, not the tag, so a
+# unique tag costs nothing on a warm cache. Pin AF_LIFECYCLE_IMAGE to reuse one.
+LIFECYCLE_IMAGE="${AF_LIFECYCLE_IMAGE:-}"
 
 # _uniq — a per-invocation token (pid + a little randomness) for container
 # names, so two runs never share a name.
@@ -222,13 +230,24 @@ lifecycle)
     # one testbox target that is not hermetic. It is wired nightly rather than
     # per-PR for that reason — see .github/workflows/lifecycle.yml.
     #
-    # Runs in an EPHEMERAL uniquely-named container (#1171) so concurrent runs
-    # cannot clobber each other and nothing survives the gate.
-    # Built from the same Dockerfile as the testbox, but under this gate's own
-    # tag so a concurrent sibling build cannot swap the image mid-run.
+    # Runs in an EPHEMERAL uniquely-named container AND under a uniquely-named
+    # image tag (#1171/#1166) so concurrent runs cannot clobber each other and
+    # nothing survives the gate. Built from the same Dockerfile as the testbox.
+    lc_token="$(_uniq)"
+    lc_teardown=no
+    if [ -z "$LIFECYCLE_IMAGE" ]; then
+        LIFECYCLE_IMAGE="agent-factory-lifecycle:$lc_token"
+        lc_teardown=yes
+    fi
+    LIFECYCLE_NAME="af-lifecycle-$lc_token"
+    # Remove the per-run tag however we exit; the underlying layers stay cached
+    # for the next run. A pinned AF_LIFECYCLE_IMAGE is the caller's to manage.
+    if [ "$lc_teardown" = yes ]; then
+        # shellcheck disable=SC2064  # expand the tag now, not at trap time
+        trap "\"$ENGINE\" rmi -f \"$LIFECYCLE_IMAGE\" >/dev/null 2>&1 || true" EXIT INT TERM
+    fi
     "$ENGINE" build -q -t "$LIFECYCLE_IMAGE" - <"$REPO_ROOT/scripts/container/Dockerfile.test" >/dev/null
     fix_cache_perms "$LIFECYCLE_IMAGE"
-    LIFECYCLE_NAME="af-lifecycle-$(_uniq)"
     rc=0
     "$ENGINE" run --rm \
         "${RUN_FLAGS[@]}" \

--- a/scripts/testbox.sh
+++ b/scripts/testbox.sh
@@ -9,6 +9,7 @@
 #   scripts/testbox.sh playtest -d             detached; drive via `docker exec`
 #   scripts/testbox.sh selftest                run the TUI driver self-test (#1161)
 #   scripts/testbox.sh drive                   boot af via the driver + attach
+#   scripts/testbox.sh lifecycle [scenario]    clean-install / install->upgrade gate
 #   scripts/testbox.sh build                   (re)build the image only
 #
 # The container gets: its own tmux server, a throwaway AF home, pids/memory
@@ -198,6 +199,31 @@ drive)
     echo "testbox: tear down with: $ENGINE rm -f $PLAYTEST_NAME" >&2
     exec "$ENGINE" exec -it "$PLAYTEST_NAME" tmux attach -t drive
     ;;
+lifecycle)
+    # Clean-environment install + upgrade gate. Unlike every other target here,
+    # this one does not just run this tree's code: it installs REAL published
+    # releases into throwaway machines and upgrades across the version boundary
+    # — the seam #1921/#796 shipped through, which no single-version test can
+    # reach.
+    #
+    # Network is required (it downloads real release tarballs), so this is the
+    # one testbox target that is not hermetic. It is wired nightly rather than
+    # per-PR for that reason — see .github/workflows/lifecycle.yml.
+    #
+    # Runs in an EPHEMERAL uniquely-named container (#1171) so concurrent runs
+    # cannot clobber each other and nothing survives the gate.
+    build_image
+    fix_cache_perms
+    LIFECYCLE_NAME="af-lifecycle-$(_uniq)"
+    rc=0
+    "$ENGINE" run --rm \
+        "${RUN_FLAGS[@]}" \
+        --name "$LIFECYCLE_NAME" \
+        -e "GITHUB_TOKEN=${GITHUB_TOKEN:-}" \
+        -e "AF_LIFECYCLE_INJECT=${AF_LIFECYCLE_INJECT:-}" \
+        "$IMAGE" bash /src/scripts/container/lifecycle-entry.sh "$@" || rc=$?
+    exit "$rc"
+    ;;
 web-selftest)
     # Playwright web-driver-selftest (#1592 Phase 5 PR6): build the dedicated
     # Go+Node+Chromium image, then run the whole harness in ONE ephemeral
@@ -218,7 +244,7 @@ web-selftest)
         "$WEB_IMAGE" bash /src/scripts/container/web-selftest-entry.sh
     ;;
 *)
-    echo "testbox: unknown command '$cmd' (want: test | playtest | selftest | drive | web-selftest | build)" >&2
+    echo "testbox: unknown command '$cmd' (want: test | playtest | selftest | drive | lifecycle | web-selftest | build)" >&2
     exit 1
     ;;
 esac

--- a/scripts/testbox.sh
+++ b/scripts/testbox.sh
@@ -221,6 +221,7 @@ lifecycle)
         --name "$LIFECYCLE_NAME" \
         -e "GITHUB_TOKEN=${GITHUB_TOKEN:-}" \
         -e "AF_LIFECYCLE_INJECT=${AF_LIFECYCLE_INJECT:-}" \
+        -e "AF_LIFECYCLE_ALLOW_PARTIAL=${AF_LIFECYCLE_ALLOW_PARTIAL:-1}" \
         "$IMAGE" bash /src/scripts/container/lifecycle-entry.sh "$@" || rc=$?
     exit "$rc"
     ;;

--- a/scripts/testbox.sh
+++ b/scripts/testbox.sh
@@ -24,6 +24,15 @@ IMAGE="${AF_TESTBOX_IMAGE:-agent-factory-testbox}"
 # see scripts/container/Dockerfile.web-selftest. Kept distinct so it never bloats
 # the plain testbox image every other gate shares.
 WEB_IMAGE="${AF_WEB_TESTBOX_IMAGE:-agent-factory-web-selftest}"
+# The lifecycle gate gets its OWN tag, even though it builds from the same
+# Dockerfile as the testbox. The tag is a GLOBAL name on the docker daemon, and
+# this box runs many worktrees: a sibling running `make test-container` from a
+# checkout that predates a Dockerfile change rebuilds `agent-factory-testbox`
+# from THEIR Dockerfile and moves the shared tag back, so whichever build ran
+# last wins. That is not theoretical — it silently reverted the image under this
+# gate mid-run ("missing required tool: jq"). A dedicated tag means a concurrent
+# sibling cannot decide what this gate runs against. Same reasoning as WEB_IMAGE.
+LIFECYCLE_IMAGE="${AF_LIFECYCLE_IMAGE:-agent-factory-lifecycle}"
 
 # _uniq — a per-invocation token (pid + a little randomness) for container
 # names, so two runs never share a name.
@@ -91,11 +100,14 @@ fi
 # Cache volumes created by older harness versions (or manual root runs)
 # can be root-owned, which the non-root test user can't write to. A
 # one-shot root chown makes the harness self-healing.
+# $1: image to run the chown in (defaults to the shared testbox image). The
+# lifecycle gate passes its own so it never depends on the shared tag existing
+# or being current.
 fix_cache_perms() {
     "$ENGINE" run --rm --user 0 \
         -v af-testbox-gomod:/cache/gomod \
         -v af-testbox-gobuild:/cache/gobuild \
-        "$IMAGE" chown -R dev:dev /cache >/dev/null
+        "${1:-$IMAGE}" chown -R dev:dev /cache >/dev/null
 }
 
 # start_playtest_detached — run the play-test sandbox container detached, so a
@@ -212,8 +224,10 @@ lifecycle)
     #
     # Runs in an EPHEMERAL uniquely-named container (#1171) so concurrent runs
     # cannot clobber each other and nothing survives the gate.
-    build_image
-    fix_cache_perms
+    # Built from the same Dockerfile as the testbox, but under this gate's own
+    # tag so a concurrent sibling build cannot swap the image mid-run.
+    "$ENGINE" build -q -t "$LIFECYCLE_IMAGE" - <"$REPO_ROOT/scripts/container/Dockerfile.test" >/dev/null
+    fix_cache_perms "$LIFECYCLE_IMAGE"
     LIFECYCLE_NAME="af-lifecycle-$(_uniq)"
     rc=0
     "$ENGINE" run --rm \
@@ -222,7 +236,7 @@ lifecycle)
         -e "GITHUB_TOKEN=${GITHUB_TOKEN:-}" \
         -e "AF_LIFECYCLE_INJECT=${AF_LIFECYCLE_INJECT:-}" \
         -e "AF_LIFECYCLE_ALLOW_PARTIAL=${AF_LIFECYCLE_ALLOW_PARTIAL:-1}" \
-        "$IMAGE" bash /src/scripts/container/lifecycle-entry.sh "$@" || rc=$?
+        "$LIFECYCLE_IMAGE" bash /src/scripts/container/lifecycle-entry.sh "$@" || rc=$?
     exit "$rc"
     ;;
 web-selftest)


### PR DESCRIPTION
## The gap

Every gate we have tests **code in isolation**. `make test-container`, the
`*-roundtrip-container` harnesses, `make tui-driver-selftest` — each builds this
tree and exercises it. **Nothing has ever installed a release, upgraded it, and
checked that the daemon came back correctly.**

So none of them could have caught what actually reached users this week. None of
it is a logic bug; all of it is **lifecycle**:

| | what escaped |
|---|---|
| **#1921** | a **new client** against an **old daemon** hard-failed (`unknown field "tab_id"`). The daemon is upgraded independently of its clients — only reachable across a version boundary. |
| **#1916** | `af reset` SIGKILLed a wedged daemon; launchd relaunched it 2s later, mid-wipe. Observed by a **user**. |
| **#796** | the daemon **demoted** from supervised to an ad-hoc child — unit inactive/dead while a daemon still runs. Happened on the maintainer box. |

And our dev box is the *opposite* of a clean environment (231 sessions, orphan
processes, 15 days of state, an installed unit), so "works here" says nothing
about a new machine, which has **no config, no unit, no home, no daemon**.

## The scenarios

`scripts/lifecycle.sh`, in a container with a throwaway `AGENT_FACTORY_HOME`,
private tmux, and a mock repo it builds itself.

**A — clean first run.** Asserts the preconditions *first* (so a "clean run" that
wasn't clean can't pass quietly), then: `af version` works · `af doctor` reports
**zero FAIL** a new user cannot act on (missing agents are WARNs with fix lines —
correct) · the **TUI renders a virgin first frame** with no panic · the daemon
comes up **exactly once**.

**B — install → upgrade.** Installs a **real N-1 release**, puts 2 sessions on it,
then upgrades via **both** real paths — `af upgrade`, and the launch-time
auto-update (which is TTY-gated, so it can only be driven through a tmux pane,
never a plain exec). Assertions 1–6 as specified.

The release pair is resolved from the API at run time rather than pinned —
mid-development **v1.0.194 cut and the gate simply retargeted `1.0.193 → 1.0.194`
on its own**. Nothing asserts a specific version.

## The known-bad demonstration

It passed on the first run against master. Per the brief I treated that as
suspicious rather than done — #1921/#1916/#1919 are fixed, so a green run proves
little. `AF_LIFECYCLE_INJECT=skip-daemon-restart` swaps the binary to N and never
restarts the daemon, reconstructing the #1921 machine exactly:

```
[lifecycle] INJECT: swapping the binary to v1.0.194 WITHOUT restarting the daemon
[lifecycle]   PASS  the client binary is now the new release (= 1.0.194)
[lifecycle] after upgrade: daemon pid=164 version=1.0.193 client=1.0.194
[lifecycle]   FAIL  assertion 1: the daemon was restarted (pid): expected a change, but it is still '164'
[lifecycle]   FAIL  assertion 1: the daemon is not running a since-replaced binary: want 'false', got 'true'
[lifecycle]   FAIL  assertion 2: no version skew (client == daemon): want '1.0.194', got '1.0.193'

[lifecycle] 14 PASS, 6 FAIL, 2 SKIP     (exit 2)
```

### ⚠️ It also caught something real: `af doctor` does **not** currently detect this

Look at the same known-bad run:

```
[lifecycle]   PASS  assertion 6: af doctor reports zero FAILs after the upgrade (= 0)
```

On a **genuinely skewed machine** — daemon on 1.0.193, client on 1.0.194 —
today's `af doctor` reports **zero FAILs**. That independently confirms #1920's
premise ("doctor should have probably caught this bug. It couldn't."), from the
outside.

This matters for the brief's instruction to *"use doctor as the oracle rather
than hand-rolling assertions"*: doctor is **not yet** a sufficient oracle — it
becomes one when **#1920** merges. So assertion 6 uses doctor **and** assertions
1–3 are hand-rolled, and those are what catch the skew today.

**Coordination with #1920** (open, draft, unmerged): `lc_doctor_fail_count`
**feature-detects** `af doctor --help` for `--json` and reads
`.data.summary.fail` the moment it exists, falling back to the text summary
today — and falls back rather than reporting a wrong `0`, which would silently
make the gate a no-op. **No follow-up edit needed here when #1920 lands.**

## How assertion 2 queries the daemon (not infers)

There is no daemon-version RPC on master (`PingResponse` is `{OK bool}`; the
`Version` field is #1920). So the daemon's version is read from **the image it is
actually executing** — copy `/proc/<pid>/exe` and ask it. After an upgrade the
on-disk binary is N while an unrestarted daemon still executes the N-1 image, and
`/proc/<pid>/exe` resolves to those bytes even though the path reads `(deleted)`.
Measured directly:

| | version |
|---|---|
| daemon's running image (`/proc/909/exe`) | **1.0.192** |
| client binary on disk | **1.0.193** |

## Assertion #4 (supervision) — it RUNS, and it is the reason for the CI leg

This is the assertion the gate most needs: an upgrade demoting the daemon off its
unit (#796 — what happened on the real box) is **invisible to every other check
here**, because the demoted daemon keeps running and keeps answering. It runs on
the **CI native leg**, against a real systemd user manager, and passes today:

```
PASS  assertion 4: the unit is still active (= active)
PASS  assertion 4: af still sees the autostart unit (= true)
PASS  assertion 4: the running daemon IS the unit's child (MainPID=7712) — not demoted
```

That last line is the catch: it compares *the daemon that is running* against
*the daemon systemd owns*. Native leg: **44 PASS, 0 FAIL, 0 SKIP**.

It cannot run inside the test container, and I tested each option rather than
assuming:

| approach | verdict |
|---|---|
| `systemd --user` standalone in the container | **impossible** — refuses without PID 1 systemd: *"Trying to run as user instance, but the system has not been booted with systemd."* |
| full systemd as PID 1 in the container | **works** (`--privileged --cgroupns=host`, verified) — but dissolves the very fence the container exists to provide on a shared box. Rejected as a default. |
| assert it at the af layer instead | **does not help**: with no service manager `af daemon install` fails outright, so there is no unit to be the supervisor *of*. The layer was never the problem — the missing service manager was. |
| the CI runner | **works, and is what shipped** — a runner is itself a clean ephemeral machine with real systemd. |

Two guards keep that honest, so the SKIP cannot sit quietly in a green gate:

* **a SKIP is not a pass** — any skipped check exits the run **non-zero** unless
  `AF_LIFECYCLE_ALLOW_PARTIAL=1`. `make lifecycle-container` sets it (a dev-box
  container genuinely cannot host a service manager) and prints a **PARTIAL
  COVERAGE** banner naming exactly what went untested;
* the CI native leg **fails the job** if assertion #4 ever silently starts
  skipping.

**macOS/launchd**: `lc_unit_active`/`lc_unit_main_pid` already have Darwin
branches, so the mac leg asserts the *same property* against launchd
(`state = running` + `pid = N` in the `gui/<uid>` domain af restarts, not
"`launchctl print` succeeded") rather than re-inventing it later. The blocker for
turning on `macos-latest` is **assertion 2**, not #4 — see below.

## Isolation

Destructive by design, so the guard's default answer is **no**. It requires
`AF_LIFECYCLE_DISPOSABLE=1` **and** a positively disposable environment
(`/.dockerenv` or `CI=true`) — a dev box refuses **even with the opt-in set**
(verified on this box). The workspace can never be, or sit inside, the real AF
home. Every daemon it signals is proven to serve its own throwaway home by
reading `/proc/<pid>/environ`, so it cannot touch a real or another user's
daemon. No real daemon, real AF home, or host `go test` was involved at any point.

## The setup bug (`sessions=0`) — root cause

The first CI run reported `expected 2 sessions, got 0`. The sessions were **always
being created correctly** — the daemon log showed the worktrees created, and tmux
showed `af_5469e117_pre1`/`pre2` alive. The **count** was wrong.

`af sessions list` resolves its project from the **current directory** when
`--repo` is absent, and the script runs from the af checkout. So the unscoped list
asked *"what sessions exist in agent-factory?"*, correctly answered `[]`, and
reported zero sessions on a machine that had two.

Worth recording, because it fooled me twice: **locally it passed for the wrong
reason.** On the dev box `/src` is an af *worktree* whose `.git` is a file pointing
outside the container — git fails there, no project resolves, and af falls back to
listing every session. The right number by accident. A clean CI checkout resolves
properly and exposed it. Local green was the bug hiding.

Fix: scope every session query with `--repo` (present on both sides of the
boundary — verified against v1.0.193), and **wait** for the count rather than
racing the create. Now: `sessions=2` before, `2` after, `0` Lost.

Two related holes closed along the way, both the same family — *a gate reporting
success while testing nothing*:

* `lifecycle.sh | tee` returned **tee's** exit status, so the first native run
  reported **pass while printing two FAILs**. `set -o pipefail`.
* scenario B now **aborts** if it cannot put 2 sessions on the machine instead of
  running assertion 5 against zero and reporting "sessions survive (= 0)".
  `lc_session_count` reports `unreadable` rather than a silent `0`.

## Where it runs

* `make lifecycle-container` — the dev-box path, container-fenced.
* **Nightly** CI + `workflow_dispatch`. Not per-PR: it downloads real release
  tarballs, so it isn't hermetic and a GitHub outage would redden unrelated PRs;
  and it tests "the last two releases", which changes when releases cut, not when
  a PR lands.
* It **does** run per-PR when the gate's own files change — which is why this PR
  is running it, and how the systemd leg gets validated.
* A **new workflow file**, deliberately not `pr.yml`/`build.yml`, so the
  `ci-macos-runner` session and this one cannot collide.

## What it does NOT yet cover

* **macOS/launchd** — assertion #4 is already written for it (Darwin branches
  above). The blocker for switching on `macos-latest` is **assertion 2**:
  `lc_daemon_version` reads `/proc/<pid>/exe`, which macOS has no equivalent of —
  `ps` reports the path, whose bytes are the NEW binary after an upgrade, i.e.
  precisely the inference this assertion refuses to make. The macOS leg wants
  **#1920**'s daemon-reported version. Given #1931 turned on macOS CI and it
  immediately found three real darwin defects (#1939, #1940, #1941), this leg is
  worth landing soon.
* **Assertion #4 in the container** — SKIPped (no systemd inside), which now
  **exits non-zero** unless partial coverage is explicitly acknowledged. Covered
  on the CI leg; see above.
* **#1916's reset-vs-relaunch race** — this scenario upgrades, it does not reset.
* Downgrades/channel switches (`--allow-downgrade`), and package-manager installs
  (Homebrew, `install.sh`).

## Gates

`make lifecycle-container` (**34 PASS, 0 FAIL, 2 SKIP**, exit 0) ·
`make test-container` (**29 packages, 0 failures**) · `go build ./...` ·
`gofmt -l .` · `golangci-lint run --fast` · `deadcode -test ./...` ·
`scripts/lint-file-length.sh` · `shellcheck -x` clean on all new scripts.

`jq` + `curl` are added to `Dockerfile.test` (one cached rebuild) so the harness
reads `--json` envelopes instead of scraping text.

Held as **draft**. No dev-install performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
