### PR TITLE
fix(session): wake the pipe-pane FIFO read on capture teardown so session delete cannot wedge the daemon

### DIFF
--- a/session/ptychannel_tmux.go
+++ b/session/ptychannel_tmux.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 
 	"github.com/sachiniyer/agent-factory/session/tmux"
@@ -21,9 +22,51 @@ type tmuxClientlessChannel struct {
 	ts *tmux.TmuxSession
 
 	mu   sync.Mutex
-	dir  string   // temp dir holding the FIFO, removed on StopCapture
-	fifo string   // FIFO path pipe-pane writes to
-	rc   *os.File // read end of the FIFO
+	dir  string         // temp dir holding the FIFO, removed on StopCapture
+	fifo string         // FIFO path pipe-pane writes to
+	rc   *captureReader // read end of the FIFO
+}
+
+// captureReader wraps the FIFO's read end so Close wakes a Read parked in
+// read(2). The FIFO cannot enter Go's netpoller on darwin (kqueue does not
+// work with fifos — see os/file_unix.go), so the fd is a plain blocking
+// descriptor and close(2) does NOT interrupt an in-flight read: with pipe-pane
+// already gone no byte would ever arrive, and the teardown join in
+// ptyBroker.stopCapture hung forever, wedging session delete and with it the
+// whole daemon (#1943). Close latches stopped, then writes one sentinel byte
+// into the FIFO — the O_RDWR read end keeps a reader registered, so the
+// nonblocking writer open cannot fail with ENXIO — forcing any parked read to
+// return. Read reports io.EOF once stopped, so the sentinel never reaches the
+// broker ring.
+type captureReader struct {
+	f       *os.File
+	fifo    string
+	stopped atomic.Bool
+	once    sync.Once
+	err     error
+}
+
+func (r *captureReader) Read(p []byte) (int, error) {
+	if r.stopped.Load() {
+		return 0, io.EOF
+	}
+	n, err := r.f.Read(p)
+	if r.stopped.Load() {
+		return 0, io.EOF
+	}
+	return n, err
+}
+
+func (r *captureReader) Close() error {
+	r.once.Do(func() {
+		r.stopped.Store(true)
+		if w, err := os.OpenFile(r.fifo, os.O_WRONLY|syscall.O_NONBLOCK, 0); err == nil {
+			_, _ = w.Write([]byte{0})
+			_ = w.Close()
+		}
+		r.err = r.f.Close()
+	})
+	return r.err
 }
 
 var _ clientlessChannel = (*tmuxClientlessChannel)(nil)
@@ -53,16 +96,17 @@ func (c *tmuxClientlessChannel) StartCapture() (io.ReadCloser, error) {
 		_ = os.RemoveAll(dir)
 		return nil, fmt.Errorf("mkfifo pty stream: %w", err)
 	}
-	rc, err := os.OpenFile(fifo, os.O_RDWR, 0600)
+	f, err := os.OpenFile(fifo, os.O_RDWR, 0600)
 	if err != nil {
 		_ = os.RemoveAll(dir)
 		return nil, fmt.Errorf("open pty stream fifo: %w", err)
 	}
 	if err := c.ts.EnablePipePane(pipePaneCommand(fifo)); err != nil {
-		_ = rc.Close()
+		_ = f.Close()
 		_ = os.RemoveAll(dir)
 		return nil, err
 	}
+	rc := &captureReader{f: f, fifo: fifo}
 	c.dir, c.fifo, c.rc = dir, fifo, rc
 	return rc, nil
 }

--- a/session/ptychannel_tmux_test.go
+++ b/session/ptychannel_tmux_test.go
@@ -97,3 +97,59 @@ func TestTmuxSnapshotRepaintCursorRealTmux(t *testing.T) {
 		t.Fatalf("emulator cursor row %d = %q, want the marker %q (cursor landed on the wrong line)", snap.CursorRow, row, marker)
 	}
 }
+
+// TestClientlessCaptureCloseWakesBlockedRead is the #1943 gate: tearing down the
+// clientless capture must wake a read loop that is parked inside a blocking
+// read(2) on the pipe-pane FIFO. The FIFO is opened O_RDWR and darwin's kqueue
+// cannot poll fifos, so the fd never enters the netpoller and closing it does
+// not interrupt an in-flight read — before the fix, the teardown join below
+// hangs forever, which is exactly how a session delete wedged the daemon
+// (KillSession → ptyBroker.close blocks on captureMu behind the stuck join).
+func TestClientlessCaptureCloseWakesBlockedRead(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skipf("tmux not available: %v", err)
+	}
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skipf("bash not available: %v", err)
+	}
+
+	ts := tmux.NewTmuxSession("fifo-wake-1943", "bash --noprofile --norc -i")
+	if err := ts.Start(t.TempDir()); err != nil {
+		t.Fatalf("start tmux session: %v", err)
+	}
+	t.Cleanup(func() { _ = ts.Close() })
+
+	ch := newTmuxClientlessChannel(ts)
+	rc, err := ch.StartCapture()
+	if err != nil {
+		t.Fatalf("start capture: %v", err)
+	}
+
+	readerDone := make(chan struct{})
+	go func() {
+		defer close(readerDone)
+		buf := make([]byte, 32*1024)
+		for {
+			if _, err := rc.Read(buf); err != nil {
+				return
+			}
+		}
+	}()
+
+	// Let the reader drain the shell's startup output and park inside a
+	// blocking Read with the pane idle — the state a session sits in when the
+	// user deletes it.
+	time.Sleep(300 * time.Millisecond)
+
+	// Mirror ptyBroker's stopCapture teardown: stop the capture, close the
+	// reader, then join the read loop. The join must complete promptly.
+	if err := ch.StopCapture(); err != nil {
+		t.Fatalf("stop capture: %v", err)
+	}
+	_ = rc.Close()
+	select {
+	case <-readerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("read loop still blocked after StopCapture+Close; capture teardown cannot join a parked FIFO read (#1943)")
+	}
+}


### PR DESCRIPTION
Fixes #1943.

## Problem

Deleting a session on macOS could wedge the daemon permanently. Root cause (from a goroutine dump taken while wedged — full chain in #1943): the clientless capture FIFO is opened `O_RDWR` and Go refuses to netpoll fifos on darwin (kqueue does not support them), so the fd is a plain blocking descriptor. `close(2)` does not interrupt a read parked in `read(2)`, and with pipe-pane's `dd` already gone no byte ever arrives — so `ptyBroker.stopCapture`'s `<-done` join blocked forever holding `captureMu`, `KillSession` blocked behind it holding the kill-in-flight guard and manager locks, and every other RPC piled up until a daemon restart. The same join runs in the #1682 `resetCapture` recovery path, so session recovery was exposed to the identical hang.

Intermittent by nature: it needs the pane to be **idle** at teardown (read loop parked inside `read(2)`). If output was flowing, the next read on the closed fd returned `EBADF` and the loop exited — which is why deletes usually worked. Linux is unaffected (fifos are epoll-pollable there, `Close()` wakes the reader).

## Fix

Wrap the FIFO read end in a `captureReader` whose `Close` latches a `stopped` flag and writes one sentinel byte into the FIFO before closing the fd. The `O_RDWR` read end keeps a reader registered, so the nonblocking writer open cannot fail with `ENXIO`, and a write of one byte to the drained FIFO always succeeds — a parked read is therefore always woken. `Read` reports `io.EOF` once stopped, so the sentinel never reaches the broker ring.

## Test

`TestClientlessCaptureCloseWakesBlockedRead` (real tmux, real FIFO, no mocks) parks a read loop on an idle pane and runs the exact `stopCapture` teardown ordering. Written first and watched fail on darwin with the production symptom (join still blocked after `StopCapture`+`Close`); passes in 0.4s with the fix. On Linux it passes either way — it guards the darwin/BSD invariant.

## Validation

- `go build ./...`, `gofmt -l` clean, `deadcode -test ./...` clean
- `go test ./session/...` — new test green; `TestCleanupSessionsReapsEscapedProcesses` fails on a darwin host with or without this change (needs `/proc`; container/CI covers it)
- golangci-lint: no findings in touched files (host has v2 installed, so the run isn't byte-identical to CI's pinned config; CI gates)

## Follow-ups deliberately not in this PR (tracked in #1943)

- `KillSession` holds the manager lock across the whole teardown — one stuck teardown silences the entire daemon; a narrower lock scope would contain the blast radius.
- No `/debug/pprof` on the loopback listener; this bug was only diagnosable via `SIGQUIT`.

— Captain Claude
