### PR TITLE
fix(tmux): require both dialog markers before injecting 'D'+Enter (#1952)

### DIFF
--- a/session/tmux/doc_trust_prompt_test.go
+++ b/session/tmux/doc_trust_prompt_test.go
@@ -105,6 +105,39 @@ func TestCheckAndHandleTrustPrompt_BareDialogMarkerInjectsNothing(t *testing.T) 
 	require.Empty(t, sentKeystrokes(cmds), "got %v", cmds)
 }
 
+// The marker is NOT a sufficient second anchor on its own, because aider prints
+// "(D)on't ask again" on EVERY confirmation it asks (see the test above). So the
+// only thing separating the doc-trust dialog from every other aider prompt is the
+// full prose question. A predicate that requires the marker plus a mere PREFIX of
+// the prose is satisfied by: an unrelated confirmation that is up right now, plus
+// the shorter string sitting anywhere on screen — in ordinary output, or in a
+// source file the agent has open.
+//
+// That combination answers 'D' ("don't ask again") to a question we never read.
+// This repo is self-hosted, so the shorter string is literally on screen whenever
+// an agent has this file or task/runner.go open — which is how a real aider
+// session hits it.
+func TestCheckAndHandleTrustPrompt_DocPrefixPlusUnrelatedConfirmInjectsNothing(t *testing.T) {
+	// The agent has this very file open (the short string is source text here),
+	// and aider independently asks an ordinary confirmation.
+	content := `	return strings.Contains(content, "Open documentation url") &&
+		strings.Contains(content, "(D)on't ask again")
+
+Add src/main.go to the chat?
+(Y)es/(N)o/(D)on't ask again [Yes]:`
+
+	for _, program := range []string{ProgramAider, ProgramGemini} {
+		t.Run(program, func(t *testing.T) {
+			handled, cmds := runTrustPromptCheck(t, program, content)
+			require.Empty(t, sentKeystrokes(cmds),
+				"the doc-trust prose PREFIX plus a marker that every aider confirmation "+
+					"renders is not evidence the doc dialog is up — tapping 'D' here answers an "+
+					"unrelated question; got %v", cmds)
+			require.False(t, handled)
+		})
+	}
+}
+
 // The Claude branch is a separate gate and must keep its own behavior: the doc
 // phrase never routes a claude pane into the 'D'+Enter path.
 func TestCheckAndHandleTrustPrompt_ClaudeBranchUnaffectedByDocPhrase(t *testing.T) {

--- a/session/tmux/doc_trust_prompt_test.go
+++ b/session/tmux/doc_trust_prompt_test.go
@@ -1,0 +1,115 @@
+package tmux
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	cmd_test "github.com/sachiniyer/agent-factory/cmd/cmd_test"
+)
+
+// The non-Claude branch of CheckAndHandleTrustPrompt dismisses the aider/gemini
+// documentation-link trust dialog by injecting 'D'+Enter into a LIVE agent pane.
+// It runs on the daemon's continuous 1-second poll against a visible-only
+// capture, so `content` is whatever the agent has on screen right now — its own
+// output, a log line, a file it cat'd, a diff of the issue describing this bug.
+//
+// These tests drive the real CheckAndHandleTrustPrompt, NOT the predicate: the
+// injection is gated in production on DetectAgentFromCommand(t.programCmd()) !=
+// ProgramClaude, and a test that called the predicate directly would hop over
+// that gate and prove nothing about the path that actually types into the pane
+// (#1952).
+
+// Real aider doc-trust dialog: the prose line co-occurs with the dialog-only
+// "(D)on't ask again" affordance.
+const aiderDocTrustDialog = `Add https://aider.chat/docs/faq.html to the chat?
+Open documentation url for more info
+(Y)es/(N)o/(D)on't ask again [Yes]:`
+
+// The SAME prose line as ordinary agent output — no dialog, nothing to dismiss.
+// This is the #1952 repro: an agent that merely mentions the phrase must not be
+// typed into.
+const aiderDocPhraseInOutput = `I read through the aider docs to answer your question.
+The CLI prints "Open documentation url for more info" when it wants to open a
+link. Here is the summary you asked for, with no prompt waiting.`
+
+// runTrustPromptCheck drives CheckAndHandleTrustPrompt for a pane running
+// `program` and showing `content`, returning its verdict plus every tmux
+// command it issued.
+func runTrustPromptCheck(t *testing.T, program, content string) (handled bool, cmds []string) {
+	t.Helper()
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			cmds = append(cmds, strings.Join(c.Args, " "))
+			return nil
+		},
+		OutputFunc: func(c *exec.Cmd) ([]byte, error) { return []byte(content), nil },
+	}
+	session := newTmuxSession(toTmuxName("trust", ""), program, NewMockPtyFactory(t), cmdExec)
+	return session.CheckAndHandleTrustPrompt(), cmds
+}
+
+// sentKeystrokes returns the send-keys commands issued, i.e. the input actually
+// injected into the user's agent.
+func sentKeystrokes(cmds []string) []string {
+	var keys []string
+	for _, c := range cmds {
+		if strings.Contains(c, "send-keys") {
+			keys = append(keys, c)
+		}
+	}
+	return keys
+}
+
+// The bug: ordinary agent output that happens to contain the documentation
+// phrase must NOT get keystrokes injected into it.
+func TestCheckAndHandleTrustPrompt_DocPhraseInOutputInjectsNothing(t *testing.T) {
+	for _, program := range []string{ProgramAider, ProgramGemini} {
+		t.Run(program, func(t *testing.T) {
+			handled, cmds := runTrustPromptCheck(t, program, aiderDocPhraseInOutput)
+			// Assert the INJECTION first: that is the harm #1952 reports. The
+			// bool is secondary (and is discarded by the daemon poll anyway).
+			require.Empty(t, sentKeystrokes(cmds),
+				"#1952: no keystroke may be injected into a running agent on the strength of a "+
+					"prose phrase alone — a false positive types into the user's session and can modify files; got %v", cmds)
+			require.False(t, handled,
+				"the bare documentation phrase in ordinary output is not a trust dialog")
+		})
+	}
+}
+
+// The other direction: the real dialog must still be dismissed, or the fix is
+// half-tested and startup hangs at the prompt.
+func TestCheckAndHandleTrustPrompt_RealDocDialogIsDismissed(t *testing.T) {
+	for _, program := range []string{ProgramAider, ProgramGemini} {
+		t.Run(program, func(t *testing.T) {
+			handled, cmds := runTrustPromptCheck(t, program, aiderDocTrustDialog)
+			require.True(t, handled, "the real doc-trust dialog must be reported handled")
+			require.Contains(t, sentKeystrokes(cmds), "tmux send-keys -t =af_trust: D Enter",
+				"the real doc-trust dialog is dismissed with 'D'+Enter; got %v", cmds)
+		})
+	}
+}
+
+// The dialog marker alone is not the doc-trust dialog: aider renders
+// "(D)on't ask again" on every confirmation prompt it asks. Dismissing an
+// arbitrary confirmation with 'D' ("don't ask again") is exactly the unbidden
+// action this gate exists to prevent.
+func TestCheckAndHandleTrustPrompt_BareDialogMarkerInjectsNothing(t *testing.T) {
+	content := `Add src/main.go to the chat?
+(Y)es/(N)o/(D)on't ask again [Yes]:`
+	handled, cmds := runTrustPromptCheck(t, ProgramAider, content)
+	require.False(t, handled, "a confirmation prompt that is not the doc-trust dialog must not be auto-dismissed")
+	require.Empty(t, sentKeystrokes(cmds), "got %v", cmds)
+}
+
+// The Claude branch is a separate gate and must keep its own behavior: the doc
+// phrase never routes a claude pane into the 'D'+Enter path.
+func TestCheckAndHandleTrustPrompt_ClaudeBranchUnaffectedByDocPhrase(t *testing.T) {
+	handled, cmds := runTrustPromptCheck(t, ProgramClaude, aiderDocTrustDialog)
+	require.False(t, handled, "the doc-trust dialog is not a Claude launch gate")
+	require.Empty(t, sentKeystrokes(cmds),
+		"a claude pane must never take the 'D'+Enter path; got %v", cmds)
+}

--- a/session/tmux/start.go
+++ b/session/tmux/start.go
@@ -131,9 +131,25 @@ func (t *TmuxSession) CheckAndHandleTrustPrompt() bool {
 }
 
 // DocTrustPromptPresent reports whether content shows the documentation-link
-// trust dialog shared by aider/gemini. Both substrings are required: the prose
-// line alone is not evidence a dialog is up, and the "(D)on't ask again"
-// affordance alone belongs to every aider confirmation prompt, not just this one.
+// trust dialog shared by aider/gemini:
+//
+//	Open documentation url for more info? (Y)es/(N)o/(D)on't ask again [Yes]:
+//
+// BOTH the full prose question and the "(D)on't ask again" affordance are
+// required, and NEITHER is redundant:
+//
+//   - The affordance is not a discriminator. aider renders "(D)on't ask again"
+//     on EVERY confirmation it asks ("Add src/main.go to the chat?", …). It only
+//     tells us some prompt is up — not which one. It is the weaker anchor.
+//   - The prose is the discriminator, and only at FULL length. Do not shorten it
+//     to a prefix like "Open documentation url": the prefix plus an affordance
+//     that is nearly always present means an unrelated confirmation gets answered
+//     'D' whenever that string is anywhere on screen — including in a source file
+//     the agent has open. This repo is self-hosted, so that is not hypothetical.
+//
+// The full prose is also the ORIGINAL observed string (2b23c52); the shorter form
+// was a later paraphrase introduced for readiness detection (7d78ee6), not an
+// observation of the dialog. Match what the dialog actually renders.
 //
 // ACTION HERE REQUIRES POSITIVE EVIDENCE, because the two ways to be wrong do not
 // cost the same:
@@ -149,10 +165,17 @@ func (t *TmuxSession) CheckAndHandleTrustPrompt() bool {
 //     breaks the loop — it re-fires every tick the phrase stays on screen (#1952).
 //
 // So this is deliberately conservative BY CONSTRUCTION, and the asymmetry above is
-// the reason. If you are here to "loosen this so it catches more cases": that
-// trade buys back a keypress the user can supply themselves, and pays for it in
-// keystrokes injected into live agents. Prefer adding a NEW anchored predicate for
-// a specific dialog you can identify over widening this one.
+// the reason. When the match is ambiguous the answer is DO NOTHING. If you are here
+// to "loosen this so it catches more cases": that trade buys back a keypress the
+// user can supply themselves, and pays for it in keystrokes injected into live
+// agents. Prefer adding a NEW anchored predicate for a specific dialog you can
+// identify over widening this one.
+//
+// Before changing this predicate, answer: what does the new one ADMIT that the old
+// one did not? Not what it rejects — what it lets through. Adding a conjunct while
+// quietly weakening another term reads as tightening and is not; that is how the
+// #1952 fix itself first shipped a NEW false-positive path. The tests only exercise
+// the real dialogs, so they will not catch it for you.
 //
 // The match runs against a visible-only capture (CapturePaneContent), so content
 // is whatever is on screen right now — including the agent's own output, a log
@@ -165,7 +188,7 @@ func (t *TmuxSession) CheckAndHandleTrustPrompt() bool {
 // #1952 happened. It lives here because task already imports session/tmux; the
 // reverse edge would be an import cycle.
 func DocTrustPromptPresent(content string) bool {
-	return strings.Contains(content, "Open documentation url") &&
+	return strings.Contains(content, "Open documentation url for more info") &&
 		strings.Contains(content, "(D)on't ask again")
 }
 

--- a/session/tmux/start.go
+++ b/session/tmux/start.go
@@ -119,7 +119,7 @@ func (t *TmuxSession) CheckAndHandleTrustPrompt() bool {
 			return true
 		}
 	} else {
-		if strings.Contains(content, "Open documentation url for more info") {
+		if DocTrustPromptPresent(content) {
 			if err := t.TapDAndEnter(); err != nil {
 				log.ErrorLog.Printf("could not tap enter on trust screen: %v", err)
 				return false
@@ -128,6 +128,45 @@ func (t *TmuxSession) CheckAndHandleTrustPrompt() bool {
 		}
 	}
 	return false
+}
+
+// DocTrustPromptPresent reports whether content shows the documentation-link
+// trust dialog shared by aider/gemini. Both substrings are required: the prose
+// line alone is not evidence a dialog is up, and the "(D)on't ask again"
+// affordance alone belongs to every aider confirmation prompt, not just this one.
+//
+// ACTION HERE REQUIRES POSITIVE EVIDENCE, because the two ways to be wrong do not
+// cost the same:
+//
+//   - A MISS costs one keypress. The dialog stays up, the user presses D — or the
+//     next tick of the daemon's 1-second poll catches it, since this re-runs
+//     continuously and the real dialog does not go away on its own.
+//   - A FALSE POSITIVE types 'D'+Enter into a RUNNING agent that never asked
+//     anything (TapDAndEnter, via CheckAndHandleTrustPrompt above). That is
+//     unbidden input into someone's live session: it can answer a different
+//     question than the one we think is on screen, or land in an agent's prompt
+//     box and modify their files. The poll's caller discards the bool, so nothing
+//     breaks the loop — it re-fires every tick the phrase stays on screen (#1952).
+//
+// So this is deliberately conservative BY CONSTRUCTION, and the asymmetry above is
+// the reason. If you are here to "loosen this so it catches more cases": that
+// trade buys back a keypress the user can supply themselves, and pays for it in
+// keystrokes injected into live agents. Prefer adding a NEW anchored predicate for
+// a specific dialog you can identify over widening this one.
+//
+// The match runs against a visible-only capture (CapturePaneContent), so content
+// is whatever is on screen right now — including the agent's own output, a log
+// line, or a file it printed. Requiring a marker only the real dialog renders is
+// what keeps ordinary output from being mistaken for a question.
+//
+// This is the single copy, shared with task's readiness check (task/runner.go
+// isReadyContent) so the dismissal and the readiness signal can never drift apart
+// again — the drift between this and the Claude branch beside it is exactly how
+// #1952 happened. It lives here because task already imports session/tmux; the
+// reverse edge would be an import cycle.
+func DocTrustPromptPresent(content string) bool {
+	return strings.Contains(content, "Open documentation url") &&
+		strings.Contains(content, "(D)on't ask again")
 }
 
 // claudeTrustPromptPresent reports whether the captured pane content is showing

--- a/task/runner.go
+++ b/task/runner.go
@@ -276,9 +276,14 @@ func IsWorkingContent(content, agent string) bool {
 // isDocTrustPrompt reports whether content shows the documentation-link trust
 // dialog shared by aider/gemini (and surfaced by claude). Both substrings are
 // required to avoid false positives from unrelated documentation links.
+//
+// The predicate itself now lives in session/tmux (DocTrustPromptPresent) and is
+// shared with the dismissal path that types 'D'+Enter into the pane. The two had
+// drifted — the dismissal matched the prose line alone and injected keystrokes
+// into ordinary agent output (#1952) — so they are one copy now. See
+// DocTrustPromptPresent for why both substrings are load-bearing.
 func isDocTrustPrompt(content string) bool {
-	return strings.Contains(content, "Open documentation url") &&
-		strings.Contains(content, "(D)on't ask again")
+	return tmux.DocTrustPromptPresent(content)
 }
 
 // WaitForReady polls the instance's tmux pane until the program shows its

--- a/task/runner.go
+++ b/task/runner.go
@@ -274,14 +274,20 @@ func IsWorkingContent(content, agent string) bool {
 }
 
 // isDocTrustPrompt reports whether content shows the documentation-link trust
-// dialog shared by aider/gemini (and surfaced by claude). Both substrings are
-// required to avoid false positives from unrelated documentation links.
+// dialog shared by aider/gemini (and surfaced by claude).
 //
-// The predicate itself now lives in session/tmux (DocTrustPromptPresent) and is
-// shared with the dismissal path that types 'D'+Enter into the pane. The two had
-// drifted — the dismissal matched the prose line alone and injected keystrokes
-// into ordinary agent output (#1952) — so they are one copy now. See
-// DocTrustPromptPresent for why both substrings are load-bearing.
+// The predicate now lives in session/tmux (DocTrustPromptPresent) and is shared
+// with the dismissal path that types 'D'+Enter into the pane. The two had drifted
+// — the dismissal matched the prose alone and injected keystrokes into ordinary
+// agent output (#1952) — so they are one copy now. See DocTrustPromptPresent for
+// why both substrings are load-bearing.
+//
+// This TIGHTENED the local predicate: it required only the prefix "Open
+// documentation url", the shared one requires the dialog's full prose. That is the
+// safe direction here. Readiness gates prompt delivery (task/start.go SendPrompt),
+// so a false positive types the user's prompt into whatever is actually on screen
+// — the #729 hazard the codex branch of isReadyContent documents above. A miss
+// only costs a wait, and the real dialog carries the full prose regardless.
 func isDocTrustPrompt(content string) bool {
 	return tmux.DocTrustPromptPresent(content)
 }


### PR DESCRIPTION
EOF2
Fixes #1952.

## The bug

`session/tmux/start.go` `CheckAndHandleTrustPrompt`, non-Claude branch, matched the bare substring `"Open documentation url for more info"` and injected `'D'`+Enter into the pane. Any agent that printed that phrase — its own output, a log line, a file it `cat`'d, a diff of #1952 itself — got keystrokes typed into it.

The impact line in the issue is not overstated. It runs on the daemon's 1-second poll against a **visible-only** capture, so `content` is whatever is on screen right now. There is no loop-break: `agentserver_local.go:117` discards the bool, so it re-fires every tick the phrase stays visible.

## The fix

Require both markers, matching what the Claude branch beside it already demanded. **The asymmetry between the two sibling branches was the tell, and the stricter one was correct.**

The repo already had this predicate, correctly anchored and with a comment explaining why both substrings are required (`task/runner.go` `isDocTrustPrompt`). Rather than write a third copy — three near-identical predicates in three packages is how this bug happened — it moves to `session/tmux.DocTrustPromptPresent` and `task` calls it.

**Import direction (checked before reusing, as asked):** `task` already imports `session/tmux` (confirmed via `go list -deps ./task`). A `tmux → task` edge would be an import cycle, so the predicate lives in `tmux` and `task` calls it. It sits directly beside `claudeTrustPromptPresent` on purpose: the drift between those two is exactly how #1952 happened, and adjacency makes the next divergence visible.

**`task/runner.go` behavior is unchanged** — same expression, now shared. `./task` tests green.

One honest note: unifying shortened tmux's first term from `"Open documentation url for more info"` to `"Open documentation url"` (task's wording, kept so task is byte-identical). That marginally broadens one term, but the newly-required `"(D)on't ask again"` conjunct is what does the work — a pane must now show **both** markers. Net strictly stricter than before in any realistic case.

## The governing rule is encoded, not just satisfied

The `DocTrustPromptPresent` doc comment states the error-cost asymmetry directly, so the next person tempted to "loosen this so it catches more cases" knows what they are trading:

- A **miss** costs one keypress — the user presses D, or the next poll tick catches it (this re-runs continuously; the real dialog does not go away on its own).
- A **false positive** types into a running agent that never asked anything, and can modify files.

## What calls this in prod, and what gates it

`daemon/manager_status.go` (1s poll) → `as.Snapshot()` → `session/agentserver_local.go:117` `backend.CheckAndHandleTrustPrompt(inst)` → `session/backend_local.go:640` (narrows to claude/codex/aider/gemini/amp) → `session/tmux/start.go:104`, which gates on `DetectAgentFromCommand(t.programCmd()) != ProgramClaude` for this branch.

Second caller: `task/start.go:48` — `for attempts := 0; instance.CheckAndHandleTrustPrompt(); attempts++`. **This one uses the bool as a loop condition**, so the false positive also drove a retry loop injecting `'D'`+Enter up to `maxTrustPromptAttempts` times at session start.

The tests therefore drive the real `CheckAndHandleTrustPrompt` with `program: "aider"`/`"gemini"` — **not** the predicate directly. A test calling the predicate would hop over the `DetectAgentFromCommand` gate and prove nothing about the path that actually types into the pane. (The existing `TestClaudeTrustPromptPresent` calls its predicate directly, which is why it never caught this.)

## Watched it fail first, in the real state

Against unmodified broken code, through the prod gate — asserting the **injection**, not just the bool, since the injection is the harm:

```
--- FAIL: TestCheckAndHandleTrustPrompt_DocPhraseInOutputInjectsNothing/aider
    #1952: no keystroke may be injected into a running agent on the strength of
    a prose phrase alone; got [tmux send-keys -t =af_trust: D Enter]
--- FAIL: .../gemini   (same)
```

Both directions covered. The other three tests were **already green against broken code** — they are locks proving the fix does not over-correct, not repros:

- real dialog (both markers) → still dismissed with `'D'`+Enter ✅
- bare `"(D)on't ask again"` with no doc URL → injects nothing (aider renders that affordance on *every* confirmation prompt) ✅
- claude pane showing the doc dialog → never takes the `'D'`+Enter path ✅

## Sweep: other content-triggered keystroke injection

Every `send-keys` in the repo reaches the pane through four primitives; only three are reachable from a content match (`SendRawKeys` is interactive user typing, no predicate upstream). Findings, all verified against the code:

| Site | Match | Injects | Assessment |
|---|---|---|---|
| `tmux/start.go` non-Claude | now both markers | `D`+Enter | **fixed here** |
| `tmux/start.go` `claudeTrustPromptPresent` | anchored conjuncts | Enter | already correct |
| `tmux/io.go:127-131` `HasUpdated` → `manager_status.go:223` | per-agent option labels | Enter | chrome-anchored; see caveat below |
| `task/limit.go:56,65` → `daemon/limit.go:373` | usage-limit banners | prompt or literal `continue` | defended: `LimitAutoResume` defaults **false** |

Two things worth routing separately (**not touched here** — outside the trust-prompt matcher):

1. **`task/runner.go:166-168` — `isReadyContent`'s Claude branch matches `strings.Contains(content, "Do you trust")`.** Bare prose, no conjunct, and readiness transitively gates `SendPrompt` (`task/start.go:65`), which types **the user's full prompt text**+Enter. This is the same predicate-drift shape as #1952: the readiness check and its paired dismissal check (`claudeTrustPromptPresent`) match *non-equivalent* string sets, so output matching `"Do you trust"` satisfies readiness while the dismissal finds nothing, the `start.go:48` loop exits immediately, and the prompt lands. Notably the **codex branch 20 lines above documents this exact hazard as its reason for excluding its own trust dialog** (#729). Behind no opt-in flag. I'd rate this the strongest remaining instance of the class.

2. **The "AutoYes protects us" argument is vacuous for daemon-tracked sessions.** `manager_status.go:216` justifies its unconditional tap with "TapEnter is a no-op unless AutoYes is on", but the daemon unconditionally force-enables it (`daemon/daemon.go:420`, `daemon/manager_sessions.go:437` — both `instance.SetAutoYes(true)`, verified). So that Enter injection is effectively gated on agent detection alone. Relevant to weighing the weakest string there, gemini's `"Yes, allow once"`, and to any future loosening.

Clean (no content-match → injection path): `app/`, `ui/`, `api/`, `session/backend_remote_agent.go` (deliberate no-op), `task/runner.go` `IsWorkingContent` (feeds liveness only).

## Scope

Stayed in the trust-prompt matcher. Did **not** touch `session/agentserver_local.go`, `handleInteractiveKey`, or any key-routing path (#1956/#1961 are actively being edited elsewhere).

**Per the ask: the discarded bool at `agentserver_local.go:117` is worth a look and I did not touch it.** It is currently *documented as intentional* there, and with the matcher fixed it is no longer a live hazard — the poll re-running a correctly-anchored check is harmless. So this is a code-clarity question, not a bug. Routing it to you rather than editing.

## Gates

All six clean: `make test-container` (full suite, container-only — never `go test ./...` on the shared box), `go build ./...`, `gofmt -l .`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Signed-off-by: Captain Claude
