### PR TITLE
fix(reset): unknown branch provenance must never authorize deletion (#1953)

### DIFF
--- a/commands/reset.go
+++ b/commands/reset.go
@@ -498,7 +498,17 @@ func planFactoryReset() (*resetPlan, error) {
 			// Prune ONLY branches AF created for its sessions — never a branch
 			// the session merely reused (--here), and never a branch with no
 			// record (the user's own master/main/feature branches).
-			if branchCreatedByAF(r.Worktree) && r.Worktree.BranchName != "" {
+			//
+			// The !ExternalWorktree guard mirrors the worktree pass above and is
+			// independent of the flag, deliberately (#1953). An external session
+			// IS the user's live tree, so AF never created its branch no matter
+			// what the record claims — and a legacy external record can claim
+			// wrongly: ToInstanceData always writes the flag, so any legacy nil
+			// record that a post-2026-04-17 daemon loaded and saved had the old
+			// nil→true default LAUNDERED into an explicit true on disk. Fixing
+			// the default cannot un-write those records; this structural guard is
+			// what actually protects them.
+			if !r.Worktree.ExternalWorktree && branchCreatedByAF(r.Worktree) && r.Worktree.BranchName != "" {
 				plan.branches[root] = append(plan.branches[root], r.Worktree.BranchName)
 			}
 		}
@@ -542,13 +552,23 @@ func planFactoryReset() (*resetPlan, error) {
 	return plan, nil
 }
 
-// branchCreatedByAF reports whether AF created this session's branch itself.
-// A nil BranchCreatedByUs means the record predates the flag; those were always
-// AF-created branches, so nil is treated as true (rollforward). An explicit
-// false means the session reused a pre-existing branch, which must NOT be
-// pruned.
+// branchCreatedByAF reports whether AF created this session's branch itself —
+// the sole authorization for `git branch -D` in the reset (see
+// git.DeleteLocalBranch). It requires POSITIVE EVIDENCE: only an explicit true
+// authorizes deletion.
+//
+// A nil BranchCreatedByUs means the record predates the flag (2026-04-17) and we
+// CANNOT determine who created the branch, so we do not prune it — the same rule
+// the corrupt-record path fifteen lines up already applies to records it cannot
+// read, now applied consistently to a field it cannot read (#1953). The old
+// nil→true reading assumed legacy records were always AF-created; they were not
+// (a pre-flag Setup on an existing branch, or an attach-to-existing-worktree
+// session, both persisted no flag over a branch the user owned).
+//
+// An explicit false means the session reused a pre-existing branch, which must
+// NOT be pruned.
 func branchCreatedByAF(w session.GitWorktreeData) bool {
-	return w.BranchCreatedByUs == nil || *w.BranchCreatedByUs
+	return w.BranchCreatedByUs != nil && *w.BranchCreatedByUs
 }
 
 // executeFactoryReset performs the destructive wipe described by plan. It is

--- a/commands/reset_test.go
+++ b/commands/reset_test.go
@@ -651,6 +651,98 @@ func TestFactoryReset_PauseFailureWarnsAndWipes(t *testing.T) {
 	}
 }
 
+// TestFactoryReset_LegacyNilProvenance_PreservesUserBranches is the #1953
+// headline regression: a PRE-EXISTING USER BRANCH SURVIVES RESET.
+//
+// It drives the real reset path (planFactoryReset → executeFactoryReset →
+// git.DeleteLocalBranch) against a real throwaway AGENT_FACTORY_HOME and a real
+// git repo with real branches — not branchCreatedByAF in isolation, which skips
+// the ExternalWorktree/BranchName gates that decide whether the branch ever
+// reaches the deletion plan.
+//
+// Both legacy shapes that predate branch_created_by_us (2026-04-17) are covered:
+//
+//   - external_worktree=true + nil — the issue's shape: a `--here`/attach
+//     session IS the user's live tree, so AF never owned its branch.
+//   - external_worktree=false + nil — the shape the issue does NOT mention: a
+//     normal AF linked worktree built by setupFromExistingBranch on a branch the
+//     user already had. No external flag protects this one anywhere.
+//
+// Neither branch may be touched. The AF-created branches of
+// TestFactoryReset_WipesEverythingKeepsRepoAndConfig (explicit true) are still
+// pruned, which is what keeps this fix from over-correcting into a no-op.
+func TestFactoryReset_LegacyNilProvenance_PreservesUserBranches(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	t.Chdir(t.TempDir())
+	stubResetDaemonHandling(t, home, false, nil)
+
+	repo := t.TempDir()
+	runGit(t, repo, "init", "-q")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("hi"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "add", "-A")
+	runGit(t, repo, "commit", "-q", "-m", "init")
+	runGit(t, repo, "branch", "-M", "master")
+	runGit(t, repo, "branch", "legacy-here")   // user branch an attach/--here session reused
+	runGit(t, repo, "branch", "legacy-reused") // user branch a linked worktree reused
+
+	legacyReusedWT := filepath.Join(home, "worktrees", "legacy-reused")
+	runGit(t, repo, "worktree", "add", "-q", legacyReusedWT, "legacy-reused")
+
+	repoID := config.RepoIDFromRoot(repo)
+	recs := []session.InstanceData{
+		{ // #1953: attach-to-existing-worktree record, Mar 3 – Apr 17 2026.
+			Title:    "legacy-here",
+			Path:     repo,
+			Liveness: session.LiveReady,
+			Worktree: session.GitWorktreeData{
+				RepoPath: repo, WorktreePath: repo, ExternalWorktree: true,
+				BranchName: "legacy-here", BranchCreatedByUs: nil,
+			},
+		},
+		{ // The unmentioned sibling: setupFromExistingBranch record, pre Apr 17 2026.
+			Title:    "legacy-reused",
+			Path:     repo,
+			Liveness: session.LiveReady,
+			Worktree: session.GitWorktreeData{
+				RepoPath: repo, WorktreePath: legacyReusedWT, ExternalWorktree: false,
+				BranchName: "legacy-reused", BranchCreatedByUs: nil,
+			},
+		},
+	}
+	raw, err := json.Marshal(recs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := config.SaveRepoInstances(repoID, raw); err != nil {
+		t.Fatal(err)
+	}
+
+	plan, err := planFactoryReset()
+	if err != nil {
+		t.Fatalf("planFactoryReset: %v", err)
+	}
+	if plan.branchCount() != 0 {
+		t.Errorf("branchCount = %d, want 0: unknown provenance must never plan a branch deletion (planned: %v)",
+			plan.branchCount(), plan.branches)
+	}
+	if _, err := executeFactoryReset(plan); err != nil {
+		t.Fatalf("executeFactoryReset: %v", err)
+	}
+
+	for _, branch := range []string{"legacy-here", "legacy-reused", "master"} {
+		if !branchExists(repo, branch) {
+			t.Errorf("#1953: reset deleted the user-owned branch %q", branch)
+		}
+	}
+	// The external session's "worktree" IS the user's repo — it must survive.
+	if _, err := os.Stat(filepath.Join(repo, "README.md")); err != nil {
+		t.Errorf("reset removed the external session's live repo tree: %v", err)
+	}
+}
+
 func TestResetConfirmed(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/daemon/ghost_provenance_test.go
+++ b/daemon/ghost_provenance_test.go
@@ -1,0 +1,69 @@
+package daemon
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/session"
+
+	"github.com/stretchr/testify/require"
+)
+
+func ghostGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	c := exec.Command("git", args...)
+	c.Dir = dir
+	c.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@example.com",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@example.com",
+		"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
+	)
+	out, err := c.CombinedOutput()
+	require.NoError(t, err, "git %v: %s", args, string(out))
+}
+
+func ghostBranchExists(repo, branch string) bool {
+	return exec.Command("git", "-C", repo, "show-ref", "--verify", "--quiet", "refs/heads/"+branch).Run() == nil
+}
+
+// TestGhostCleanupWorktree_LegacyNilProvenance_PreservesUserBranch covers the
+// third copy of the nil→provenance default (#1953), in daemon-side ghost
+// teardown. Every other daemon test STUBS ghostCleanupWorktree, so its real body
+// — and its own duplicated default — had no lock at all; that is how it rotted
+// out of step with the reset call site.
+//
+// The ExternalWorktree bail at the top of ghostCleanupWorktree already covers the
+// shape the issue describes. It does NOT cover this one: a normal, non-external
+// AF linked worktree that Setup built on a branch the user already had
+// (setupFromExistingBranch, 2025-07-23), whose pre-2026-04-17 record persisted no
+// flag. Unknown provenance must not reach `git branch -D`.
+//
+// This calls the real function against a real repo. It spawns no daemon.
+func TestGhostCleanupWorktree_LegacyNilProvenance_PreservesUserBranch(t *testing.T) {
+	repo := t.TempDir()
+	ghostGit(t, repo, "init", "-q")
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "README.md"), []byte("hi"), 0644))
+	ghostGit(t, repo, "add", "-A")
+	ghostGit(t, repo, "commit", "-q", "-m", "init")
+	ghostGit(t, repo, "branch", "-M", "master")
+	ghostGit(t, repo, "branch", "user-feature")
+
+	wt := filepath.Join(t.TempDir(), "wt")
+	ghostGit(t, repo, "worktree", "add", "-q", wt, "user-feature")
+	require.True(t, ghostBranchExists(repo, "user-feature"))
+
+	ghostCleanupWorktree(&session.InstanceData{
+		Title: "legacy-ghost",
+		Path:  repo,
+		Worktree: session.GitWorktreeData{
+			RepoPath: repo, WorktreePath: wt, SessionName: "legacy-ghost",
+			BranchName: "user-feature", ExternalWorktree: false, BranchCreatedByUs: nil,
+		},
+	}, "legacy-ghost")
+
+	require.True(t, ghostBranchExists(repo, "user-feature"),
+		"#1953: ghost cleanup force-deleted the user's pre-existing branch from a legacy record with no provenance")
+	require.True(t, ghostBranchExists(repo, "master"), "master must survive")
+}

--- a/daemon/manager_persist.go
+++ b/daemon/manager_persist.go
@@ -279,7 +279,13 @@ var ghostCleanupWorktree = func(data *session.InstanceData, title string) {
 	if data.Worktree.RepoPath == "" || data.Worktree.WorktreePath == "" || data.Worktree.ExternalWorktree {
 		return
 	}
-	branchCreatedByUs := true
+	// Unknown provenance means KEEP (#1953): a nil flag predates 2026-04-17 and
+	// cannot establish that AF created the branch, and the only thing this
+	// authorizes downstream is Cleanup()'s `git branch -D`. Mirrors the default in
+	// session.FromInstanceData. (The ExternalWorktree bail above already covers
+	// external records; this covers a legacy linked worktree that Setup built on
+	// a branch the user already had.)
+	branchCreatedByUs := false
 	if data.Worktree.BranchCreatedByUs != nil {
 		branchCreatedByUs = *data.Worktree.BranchCreatedByUs
 	}

--- a/session/instance_data.go
+++ b/session/instance_data.go
@@ -156,12 +156,27 @@ func FromInstanceData(data InstanceData) (*Instance, error) {
 	default:
 		instance.backend = &LocalBackend{}
 
-		// Preserve backward compatibility: when the branch_created_by_us
-		// field is missing from persisted data (written before this field
-		// was added), default to true. Old saved sessions were created
-		// under the assumption that the session owned the branch, so
-		// keeping that behavior avoids surprising changes on restore.
-		branchCreatedByUs := true
+		// DESTRUCTION REQUIRES POSITIVE EVIDENCE (#1953). A missing
+		// branch_created_by_us (written before the field landed 2026-04-17)
+		// means we do not know who created the branch — and the only thing
+		// this flag authorizes is `git branch -D`. Unknown provenance
+		// therefore means KEEP: default to false.
+		//
+		// This inverts the original nil→true back-compat default, which
+		// assumed every legacy record was a branch AF had created. It was
+		// wrong for two legacy shapes that both persisted no flag:
+		// attach-to-existing-worktree records (external_worktree=true,
+		// 2026-03-03) and — with nothing external about them — any normal
+		// linked worktree Setup built on a branch the user already had
+		// (setupFromExistingBranch, 2025-07-23). Both are the user's
+		// branches; the old default marked them AF-created and let reset and
+		// kill/archive delete them.
+		//
+		// The cost is the opposite error: a legacy record whose branch AF
+		// really did create is now never pruned, leaking an orphaned af-*
+		// branch. That is deliberate — a leaked branch the user can see and
+		// delete beats a deletion they cannot undo.
+		branchCreatedByUs := false
 		if data.Worktree.BranchCreatedByUs != nil {
 			branchCreatedByUs = *data.Worktree.BranchCreatedByUs
 		}

--- a/session/provenance_legacy_test.go
+++ b/session/provenance_legacy_test.go
@@ -1,0 +1,125 @@
+package session
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// legacyBranchExists reports whether `branch` is a local ref in repoRoot.
+func legacyBranchExists(t *testing.T, repoRoot, branch string) bool {
+	t.Helper()
+	c := exec.Command("git", "-C", repoRoot, "show-ref", "--verify", "--quiet", "refs/heads/"+branch)
+	return c.Run() == nil
+}
+
+// TestLegacyNilProvenance_CleanupPreservesReusedUserBranch is the archive/kill
+// half of #1953, and it is a DIFFERENT legacy shape than the one the issue
+// describes.
+//
+// The issue's shape is external_worktree=true + branch_created_by_us=nil, which
+// Cleanup() is already immune to: it early-returns on externalWorktree before
+// ever reaching the branch-delete gate.
+//
+// This shape is NOT external. `setupFromExistingBranch` (2025-07-23) sets
+// branchCreatedByUs=false whenever a NORMAL, AF-created linked worktree is built
+// on a branch the user already had — no external flag involved. Records written
+// before branch_created_by_us landed (2026-04-17) persisted that provenance as
+// nothing at all, so FromInstanceData's nil→true default resurrects them as
+// "AF created this branch". Cleanup() has no externalWorktree escape hatch for
+// them, so kill/archive force-deletes a branch the user owned.
+//
+// Drives the real restore path (FromInstanceData) into the real destruction
+// path (GitWorktree.Cleanup, which teardownKill.handleWorktree calls) against a
+// real git repo and a real pre-existing branch.
+//
+// The record loads as LiveArchived so FromInstanceData returns it inert (no tmux
+// spawn) — this is the archived-then-killed path, and it is representative: the
+// provenance binding happens in the shared backend branch BEFORE the archived
+// early-return, so a live session's gitWorktree is built identically and reaches
+// the same Cleanup() via the same teardownKill.
+func TestLegacyNilProvenance_CleanupPreservesReusedUserBranch(t *testing.T) {
+	repoRoot := initInPlaceRepo(t, "user-feature")
+	// Park the repo back on the default branch so the linked worktree below can
+	// hold user-feature (a branch cannot be checked out twice).
+	gitOut(t, repoRoot, "checkout", "-q", "-")
+
+	// A NORMAL AF linked worktree built on the user's PRE-EXISTING branch. This
+	// is exactly what setupFromExistingBranch produces: not external, and the
+	// branch is not ours.
+	wt := filepath.Join(t.TempDir(), "wt")
+	gitOut(t, repoRoot, "worktree", "add", "-q", wt, "user-feature")
+	require.True(t, legacyBranchExists(t, repoRoot, "user-feature"))
+
+	// A record written before 2026-04-17: the field simply is not there.
+	data := InstanceData{
+		Title:    "legacy-reused",
+		Path:     repoRoot,
+		Liveness: LiveArchived,
+		Worktree: GitWorktreeData{
+			RepoPath:          repoRoot,
+			WorktreePath:      wt,
+			SessionName:       "legacy-reused",
+			BranchName:        "user-feature",
+			ExternalWorktree:  false,
+			BranchCreatedByUs: nil,
+		},
+	}
+
+	restored, err := FromInstanceData(data)
+	require.NoError(t, err)
+	require.NotNil(t, restored.gitWorktree)
+
+	// The kill/archive teardown step, verbatim (teardownKill.handleWorktree).
+	require.NoError(t, restored.gitWorktree.Cleanup())
+
+	assert.True(t, legacyBranchExists(t, repoRoot, "user-feature"),
+		"#1953: kill/archive force-deleted the user's pre-existing branch %q "+
+			"because a legacy record's missing branch_created_by_us defaulted to true",
+		"user-feature")
+}
+
+// TestLegacyNilProvenance_RestoreDoesNotClaimBranchOwnership pins the shared
+// default itself at the restore boundary: an absent branch_created_by_us must
+// never be read as "AF created this branch". Unknown provenance means KEEP.
+func TestLegacyNilProvenance_RestoreDoesNotClaimBranchOwnership(t *testing.T) {
+	repoRoot := initInPlaceRepo(t, "user-feature")
+
+	for _, tc := range []struct {
+		name     string
+		external bool
+		flag     *bool
+		want     bool
+	}{
+		{"legacy nil is not ours", false, nil, false},
+		{"legacy nil external is not ours", true, nil, false},
+		{"explicit true is honored", false, boolPtrForTest(true), true},
+		{"explicit false is honored", false, boolPtrForTest(false), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			wt := filepath.Join(t.TempDir(), "wt")
+			require.NoError(t, os.MkdirAll(wt, 0755))
+			restored, err := FromInstanceData(InstanceData{
+				Title:    "t",
+				Path:     repoRoot,
+				Liveness: LiveArchived,
+				Worktree: GitWorktreeData{
+					RepoPath:          repoRoot,
+					WorktreePath:      wt,
+					SessionName:       "t",
+					BranchName:        "user-feature",
+					ExternalWorktree:  tc.external,
+					BranchCreatedByUs: tc.flag,
+				},
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, restored.gitWorktree.BranchCreatedByUs())
+		})
+	}
+}
+
+func boolPtrForTest(b bool) *bool { return &b }


### PR DESCRIPTION
Fixes #1953.

`af reset` force-deletes user-owned branches. Reset's contract — *"removes AF-created resources, never touches your real repo"* — is the thing that makes it safe to recommend, and this breaks it in the worst direction: unrecoverable, invisible until gone, and reset is what we tell people to run when things are wedged, so everyone who hits it is already having a bad day.

## The governing rule

**Destruction requires positive evidence.** An absent field, an unreadable state, or an error that is not about state must never authorize deleting a user's branch. Where the code defaulted to *act*, this inverts it so that **forgetting is safe**: unknown provenance means **keep**.

This is not a new principle — it is the one reset already states, fifteen lines from the bug, for corrupt `instances.json`:

> We CANNOT determine BranchCreatedByUs for these records, so we neither prune their branches nor delete their records — conservatively leaving both intact (and reporting the repo) rather than orphaning a branch or deleting a user's branch by guessing.

The reset path already knows unknown provenance means keep. It just failed to apply it to a **field** it cannot read. This change makes the code consistent with its own stated principle.

## The two defects

**1. `commands/reset.go` — missing `!ExternalWorktree` guard.** The branch-collection pass lacked the guard that the *same commit* (`32d7f22`) correctly applied to worktree collection at the line above it. An external (`--here`) session **is** the user's live tree; AF never owned that branch.

**2. The `nil→true` default itself** (`session/instance_data.go`, `commands/reset.go` `branchCreatedByAF`, `daemon/manager_persist.go`). A missing field cost a user their branch. That is the bug, not just its symptom at the reset call site — the same rotted default is copy-pasted at three call sites, two of which the issue does not mention.

## #1953 is bigger than the issue says — kill/archive is also affected (**OBSERVED**)

The issue describes one legacy shape: `external_worktree:true` + `branch_created_by_us:nil` (attach-to-existing-worktree, 2026-03-03 → 2026-04-17). `GitWorktree.Cleanup()` happens to be immune to it — it early-returns on `externalWorktree` *before* the branch-delete gate.

There is a **second legacy shape the issue never mentions, and nothing protects it**:

`setupFromExistingBranch` (`343c7e2`, **2025-07-23**) sets `branchCreatedByUs=false` whenever a **normal, non-external** AF linked worktree is built on a branch the user already had. Records written before `branch_created_by_us` landed (`729e102`, 2026-04-17) persisted that provenance as *nothing at all*. On restore, `nil→true` resurrects them as "AF created this branch" — and `Cleanup()` has no `externalWorktree` escape hatch for them.

**Kill and archive force-delete the user's pre-existing branch.** Reproduced against a real git repo and a real branch through the real restore path into the real teardown call (`TestLegacyNilProvenance_CleanupPreservesReusedUserBranch`). Watched failing before the fix:

```
--- FAIL: TestLegacyNilProvenance_CleanupPreservesReusedUserBranch
    #1953: kill/archive force-deleted the user's pre-existing branch "user-feature"
    because a legacy record's missing branch_created_by_us defaulted to true
```

This also means the issue's recommended fix — the `!ExternalWorktree` guard alone — would have left the data loss live on both reset *and* kill/archive for this shape. Fixing the shared default is load-bearing, not cleanup.

## Audit: every reader of `BranchCreatedByUs`

| # | Reader | Authorizes destroying | Could unknown provenance reach it? (before) | After |
|---|---|---|---|---|
| 1 | `commands/reset.go:551` `branchCreatedByAF` → `git.DeleteLocalBranch` | `git branch -D` in `af reset` | **YES** — `nil→true`. The #1953 path. Both legacy shapes. | **No** — `nil→false` + `!ExternalWorktree` guard |
| 2 | `session/instance_data.go:165` `FromInstanceData` → `GitWorktree.branchCreatedByUs` → `worktree_ops.go:350` `Cleanup()` | `git branch -D` on kill/archive (`teardownKill.handleWorktree`) | **YES** — `nil→true`. External shape immune (early-return at `:274`); **non-external legacy shape NOT immune → OBSERVED data loss** | **No** — `nil→false` |
| 3 | `daemon/manager_persist.go:283` `ghostCleanupWorktree` → `gw.Cleanup()` | `git branch -D` for ghost sessions | **PARTIALLY** — the `!ExternalWorktree` bail at `:279` protects *only* the issue's shape. The non-external legacy shape reached `branch -D`. Its real body was **stubbed in every existing test**, so the duplicated default had no lock at all. | **No** — `nil→false` |
| 4 | `session/instance_data.go:79` `ToInstanceData` | nothing (write path) | n/a — **but see laundering below** | unchanged |
| 5 | `session/git/worktree.go:103` `BranchCreatedByUs()` accessor | nothing | No — only #4 and #6 call it | No |
| 6 | `session/git/worktree_diagnose.go:46` → `daemon/lostrestore.go:327` | nothing — lands in a `WORKTREE_MISSING_DETECTED` **log line** | No | No |
| 7 | `session/backend_local.go:301` → `gw.Cleanup()` (failed-create rollback) | `git branch -D` on create rollback | No — only reachable *after* `Setup()` succeeded, and `Setup()` sets the flag in-process (`setupNewWorktree`→true / `setupFromExistingBranch`→false). Positive evidence, same process. Never a persisted nil. | No |
| 8 | `session/git/worktree_ops.go:73-78` `RebuildFromExistingBranch` | nothing — saves/restores the flag across rebuild | No | No |
| 9 | `worktree_ops.go:119/152/219` `setup*` / `RebuildFreshFromRecordedBase` | nothing — **writers**; each sets the flag from what it just did | n/a — positive evidence by construction | n/a |

Non-readers checked and ruled out: `daemon/deleteproject.go` (archives, never deletes branches), `session/git/worktree_archive.go` `relocateWorktreeTo` (moves directories, refuses external, touches no branch), `daemon/limit.go:359` (comment only).

**No `nil→true` default remains anywhere.**

## The tradeoff, stated explicitly

Inverting `nil→false` has a real cost: **legacy sessions where AF genuinely did create the branch will no longer have their branches cleaned up, leaving orphaned AF branches.** That is a leak.

I accept it. A leak the user can see and delete beats a deletion they cannot undo.

The blast radius is small, and smaller than it first looks:

- `branch_created_by_us` landed **2026-04-17** (`729e102`) — **3 months and 59 releases** ago (currently v1.0.196).
- More decisively: **`ToInstanceData` always writes the field** (`BranchCreatedByUs: &branchCreatedByUs`, never omitted). Any legacy record that a post-2026-04-17 daemon has loaded and saved *already* had its `nil` **laundered into an explicit value on disk**. Surviving `nil` records are therefore only those untouched by any modern daemon for three months — i.e. very few, and each leaks at most one branch.

That same laundering cuts the other way, and it is why **defect #1 is not redundant with defect #2**: a legacy external record that was loaded and re-saved under the old default now carries an explicit `true` on disk. Fixing the default cannot un-write those records. The `!ExternalWorktree` structural guard doesn't trust the flag at all, so it protects them regardless — which makes it the load-bearing fix for external sessions, not belt-and-braces.

Known residual (out of scope, no fix possible from the record alone): a **non-external** legacy record already laundered to explicit `true` is indistinguishable from a genuine AF-created branch. Nothing in the record can recover the truth. The structural guard cannot help here because the shape is not external. This PR closes every path where the *record itself* is ambiguous.

## Tests — each watched failing first, in the real state

The Detail Bot repro in the issue calls `branchCreatedByAF` directly, which **skips the production gate that keeps the bug live** — it never exercises `planFactoryReset`'s `ExternalWorktree`/`BranchName` gates or `executeFactoryReset`'s actual `git branch -D`. A test that calls the helper directly would pass against code that still deletes branches. These go through the prod call path instead.

**What calls it in prod, and what gates it:**
- `branchCreatedByAF` is called **only** from `planFactoryReset` (`reset.go:501`), gated by `!ExternalWorktree && … && BranchName != ""`. Its output reaches destruction only via `executeFactoryReset` → `git.DeleteLocalBranch` → `git branch -D`, which is reset's *sole* branch-deletion path.
- `FromInstanceData`'s default reaches destruction via `GitWorktree.Cleanup()` (`worktree_ops.go:350`), called from `teardownKill.handleWorktree` (kill/archive), gated by the `externalWorktree` early-return at `:274` — which is exactly the gate that does **not** cover the non-external legacy shape.
- `ghostCleanupWorktree`'s default reaches the same `Cleanup()`, gated by the `ExternalWorktree` bail at `:279` — same gap.

| Test | Path driven | Watched failing as |
|---|---|---|
| `TestFactoryReset_LegacyNilProvenance_PreservesUserBranches` (headline) | Real throwaway `AGENT_FACTORY_HOME` + real mock git repo + real branches → real `planFactoryReset` → real `executeFactoryReset` → real `git branch -D` | `branchCount = 2, want 0` … `reset deleted the user-owned branch "legacy-here"` / `"legacy-reused"` |
| `TestLegacyNilProvenance_CleanupPreservesReusedUserBranch` | Real repo + real pre-existing branch → real `FromInstanceData` → real `GitWorktree.Cleanup()` | `kill/archive force-deleted the user's pre-existing branch "user-feature"` |
| `TestLegacyNilProvenance_RestoreDoesNotClaimBranchOwnership` | `FromInstanceData` provenance matrix (nil / nil+external / explicit true / explicit false) | `expected: false, actual: true` on both nil cases |
| `TestGhostCleanupWorktree_LegacyNilProvenance_PreservesUserBranch` | Real repo → real `ghostCleanupWorktree` body (not the stub) | `ghost cleanup force-deleted the user's pre-existing branch` — verified by reverting *only* that default, since the shared fix already covered it |

**Over-correction guard:** `TestFactoryReset_WipesEverythingKeepsRepoAndConfig` still passes — branches with an explicit `true` are still pruned. The fix narrows deletion to positive evidence; it does not disable it.

## Gates

All six clean: `make test-container` (full suite, 0 failures) · `go build ./...` · `gofmt -l .` · `golangci-lint run --timeout=3m --fast` · `deadcode -test ./...` · `scripts/lint-file-length.sh`

— Captain Claude
