### PR TITLE
fix(hook): reap a failed launch_cmd's sandbox instead of leaking the user's infra (#1955)

### DIFF
--- a/docs/remote-hooks.md
+++ b/docs/remote-hooks.md
@@ -80,7 +80,7 @@ Provisions the workspace on your infrastructure, starts an `af agent-server` the
 - `url` (**required**) — the `af agent-server`'s base URL (`http://host:port` or `ws://host:port`), reachable from the daemon. It must be plain HTTP — a `wss://`/`https://` URL is rejected (af serves no TLS).
 - `token` (**required**) — the bearer token the server printed on startup.
 
-These values are the `af agent-server` startup banner (`addr`/`token`). A legacy `tls_fingerprint` field is accepted-and-ignored, so an old script keeps parsing, but it does nothing — drop it. If `launch_cmd` exits 0 but echoes no parseable endpoint JSON, `af` runs `delete_cmd --name <slug>` best-effort to avoid orphaning whatever was provisioned, then surfaces the error — so keep non-JSON output on stderr.
+These values are the `af agent-server` startup banner (`addr`/`token`). A legacy `tls_fingerprint` field is accepted-and-ignored, so an old script keeps parsing, but it does nothing — drop it. Keep non-JSON output on stderr. If `launch_cmd` fails in any way after it has started, af runs `delete_cmd` to reap whatever it may have provisioned — see [`delete_cmd` runs on any failed launch](#delete_cmd-runs-on-any-failed-launch).
 
 ### `delete_cmd`
 
@@ -89,6 +89,47 @@ Tears down whatever `launch_cmd` provisioned (the runtime teardown). Runs on kil
 **Arguments:** `--name <slug>`
 
 **stdout:** anything (a `{"deleted": true}` acknowledgement is conventional but not required).
+
+#### `delete_cmd` runs on any failed launch
+
+Once `launch_cmd` has **started**, af treats the sandbox as possibly-existing and runs `delete_cmd --name <slug>` on every provisioning failure — including when `launch_cmd`:
+
+- exited 0 but echoed no parseable endpoint JSON,
+- exited **non-zero**, at any point,
+- **timed out** and was killed (see [Script timeouts](#script-timeouts)).
+
+A failed `launch_cmd` is not evidence that nothing was created. A script that creates a VM and then dies has left a VM billing to your account, and because the session never finished provisioning, af keeps **no record** of it — nothing else will ever clean it up. So af reaps on the weaker signal ("the script ran") rather than the stronger one ("the script succeeded").
+
+This means your `delete_cmd` must **tolerate being called for a sandbox that was never fully built, or never built at all**: a slug it has never seen, a half-created VM, a resource still coming up. Make it slug-deterministic and idempotent, and treat a missing resource as success rather than an error — the [reference implementation](#migration-recipe) already does this (`|| true`, `2>/dev/null`). If yours would fail or exit non-zero on an unknown slug, fix that.
+
+af does **not** run `delete_cmd` when `launch_cmd` could not start at all — a missing file, a file that is not executable, a bad shebang. Nothing ran, so nothing was provisioned.
+
+If `delete_cmd` itself fails, af cannot clean up and does not retry. It reports the slug and the exact command to run by hand, both on the session-create error and at error level in the log:
+
+```
+A sandbox may still be running on your infrastructure — delete_cmd could not reap it, and af will not retry.
+launch_cmd ran for session "fix auth bug" (hook name "fix-auth-bug"), so it may hold real resources: a VM, a pod, a cloud sandbox.
+Reap it by hand, then check your provider for anything still running:
+    ./.agent-factory/hooks/delete.sh --name fix-auth-bug
+delete_cmd error: …
+```
+
+The same warning is logged whenever `delete_cmd` fails on a kill or an archive, where the sandbox certainly did exist.
+
+### Script timeouts
+
+| Script | Budget |
+|---|---|
+| `launch_cmd` | 5 minutes |
+| `delete_cmd` | 60 seconds |
+
+A script that exceeds its budget is killed and the operation fails.
+
+**A timed-out `launch_cmd` is reaped, not left running.** When the budget expires af kills the script, so it will never return an endpoint and af will never dial whatever it was building. Any sandbox it did create is already orphaned at that moment — leaving it alone would not preserve a resource you could still use, only one you would still pay for. So a timeout is treated as a failure that reaps.
+
+**af kills only the script itself, not the processes it spawned.** If your `launch_cmd` shells out to a provisioner that keeps running after the script is killed, that provisioner may still create infrastructure *after* `delete_cmd` has already run. af cannot close that race from the outside — it is another reason to make `delete_cmd` idempotent and safe to re-run, and to prefer a `launch_cmd` that cleans up after itself on `EXIT`/`TERM`.
+
+If `launch_cmd` exits 0 but leaves a background process holding its stdout (a tunnel or port-forward, say), af stops reading output shortly after the script exits and parses what it captured. The **exit status** is what decides success, so a session like this still comes up normally — but echo the endpoint JSON before exiting, not from the background process.
 
 ## Capabilities & the agent-server
 

--- a/docs/remote-hooks.md
+++ b/docs/remote-hooks.md
@@ -110,9 +110,11 @@ If `delete_cmd` itself fails, af cannot clean up and does not retry. It reports 
 A sandbox may still be running on your infrastructure — delete_cmd could not reap it, and af will not retry.
 launch_cmd ran for session "fix auth bug" (hook name "fix-auth-bug"), so it may hold real resources: a VM, a pod, a cloud sandbox.
 Reap it by hand, then check your provider for anything still running:
-    ./.agent-factory/hooks/delete.sh --name fix-auth-bug
+    './.agent-factory/hooks/delete.sh' --name 'fix-auth-bug'
 delete_cmd error: …
 ```
+
+That command is shell-quoted and safe to paste as-is, whatever your `delete_cmd` path contains.
 
 The same warning is logged whenever `delete_cmd` fails on a kill or an archive, where the sandbox certainly did exist.
 

--- a/docs/remote-hooks.md
+++ b/docs/remote-hooks.md
@@ -131,7 +131,21 @@ A script that exceeds its budget is killed and the operation fails.
 
 **af kills only the script itself, not the processes it spawned.** If your `launch_cmd` shells out to a provisioner that keeps running after the script is killed, that provisioner may still create infrastructure *after* `delete_cmd` has already run. af cannot close that race from the outside — it is another reason to make `delete_cmd` idempotent and safe to re-run, and to prefer a `launch_cmd` that cleans up after itself on `EXIT`/`TERM`.
 
-If `launch_cmd` exits 0 but leaves a background process holding its stdout (a tunnel or port-forward, say), af stops reading output shortly after the script exits and parses what it captured. The **exit status** is what decides success, so a session like this still comes up normally — but echo the endpoint JSON before exiting, not from the background process.
+### Backgrounding a tunnel is supported — you need do nothing
+
+**Nothing to change in your `launch_cmd`.** This documents a behaviour change that only ever *removes* a restriction.
+
+Many `launch_cmd`s must leave a process running to make the agent-server reachable — an `ssh -L` forward, a `kubectl port-forward`, a tunnel client. That process is not a leak: it is the thing af then dials. af treats it as **yours** and never touches it.
+
+- af bounds and kills **the script**, never anything the script left running.
+- The script's stdout/stderr go to a temporary **file**, not a pipe. A background process may inherit them and keep writing as long as it likes: af has already stopped reading, and there is no pipe whose closure could disturb it.
+- af stops reading when the **script** exits, and its **exit status** decides success.
+
+You may redirect a tunnel's output (`>/dev/null 2>&1 &`) or disown it if you prefer tidy logs, but you do not have to — both behave identically.
+
+The one rule: **echo the endpoint JSON from the script itself, before it exits** — not from the background process. af reads what the script had written by the time it exited.
+
+> **Fixed in this release.** A `launch_cmd` that backgrounded a process holding stdout previously **hung the provision**: af waited for the output pipe to close and the tunnel held it open indefinitely, so the 5-minute budget never applied. If you added a `>/dev/null` redirect to work around that, keep it or drop it — both work now.
 
 ## Capabilities & the agent-server
 

--- a/session/backend_hook_backend.go
+++ b/session/backend_hook_backend.go
@@ -3,14 +3,15 @@ package session
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/shellsuggest"
 	"github.com/sachiniyer/agent-factory/log"
 )
 
@@ -56,22 +57,12 @@ import (
 //     large repo, so it gets a generous budget.
 //   - hookDeleteTimeout: bounded tighter so a kill never hangs on an unreachable
 //     provisioner.
-//   - hookOutputDrainGrace: how long to wait for a script's output pipe to drain
-//     AFTER the script itself has exited or been killed. Without it the two
-//     timeouts above bound NOTHING: CombinedOutput waits for the output pipe to
-//     close, any process the script leaves behind inherits that pipe and holds it
-//     open, and exec.CommandContext kills only the script, not its children. So a
-//     launch_cmd that provisions and then hangs would block Provision forever
-//     rather than for hookLaunchTimeout — and the #1955 reap could never run at
-//     all, because launch() would never return to trigger it. Bounding the drain
-//     is what turns "launch_cmd timed out" into an event the reap can react to.
-//     The hook scripts are the last exec surface that lacked this bound; it
-//     mirrors gitWaitDelay and tmuxWaitDelay (#856/#896), and a user-authored
-//     provisioner is the likeliest of all of them to leave a child behind.
+//
+// These bound the SCRIPT, and only the script. Nothing here bounds — or touches
+// — a process the script deliberately leaves running: see runHookScript.
 var (
-	hookLaunchTimeout    = 5 * time.Minute
-	hookDeleteTimeout    = 60 * time.Second
-	hookOutputDrainGrace = 5 * time.Second
+	hookLaunchTimeout = 5 * time.Minute
+	hookDeleteTimeout = 60 * time.Second
 )
 
 // hookRuntime provisions a session on user-provided infrastructure via the
@@ -134,32 +125,74 @@ func (p *hookProvisioner) orphanWarning(reapErr error) string {
 }
 
 // manualReapCommand is the shell command orphanWarning tells the user to paste.
-// Every interpolated value is shell-quoted, because this command has to be
-// correct exactly when things are messy — which is exactly when names are weird.
+// It goes through the shellsuggest seam (#1978), which quotes every piece: this
+// command has to be correct exactly when things are messy, which is exactly when
+// names are weird.
 //
-// delete_cmd is an arbitrary user-configured path: a space, an apostrophe, a `$`
+// delete_cmd is an arbitrary user-configured path — a space, an apostrophe, a `$`
 // or a backtick in it yields a command that fails, or worse, runs something other
 // than what it reads like. The slug is already constrained to [a-z0-9-] by
-// Slugify, so quoting it is belt-and-braces — but it costs nothing and the safety
-// then lives here rather than depending on a caller's charset invariant holding
-// forever.
+// Slugify, so quoting it is belt-and-braces; the seam does it anyway, so the
+// safety lives at the print site rather than depending on a caller's charset
+// invariant holding forever.
 func (p *hookProvisioner) manualReapCommand() string {
-	return fmt.Sprintf("%s --name %s", shellQuote(p.hooks.DeleteCmd), shellQuote(p.slug))
+	return shellsuggest.Command(p.hooks.DeleteCmd, "--name", p.slug)
 }
 
-// normalizeHookWaitDelay converts an exec.ErrWaitDelay into success: the hook
-// script itself exited 0 (a non-zero exit surfaces as an ExitError, and a
-// timeout kill as a signal — never as ErrWaitDelay), and only a process it left
-// behind held the output pipe open past hookOutputDrainGrace. A launch_cmd that
-// backgrounds a tunnel to make the agent-server reachable is a documented
-// pattern, so this is not a failure — and treating it as one would reap a
-// sandbox that came up fine. Success is the script's EXIT STATUS, never
-// `err == nil`. Mirrors tmux's normalizeWaitDelay (#676/#914 precedent).
-func normalizeHookWaitDelay(err error) error {
-	if errors.Is(err, exec.ErrWaitDelay) {
-		return nil
+// runHookScript runs one hook script under a timeout and returns its combined
+// output. It exists to answer a question the obvious CombinedOutput() gets wrong:
+// WHICH CHILDREN ARE OURS TO KILL?
+//
+// Answer: only the script itself. A launch_cmd is DOCUMENTED to leave a tunnel or
+// port-forward running — that background process is not a leak, it is the product,
+// the very thing making the endpoint we just captured reachable. Reaping it would
+// destroy what the launch just built and leave a session that exists and cannot
+// be dialled, with nothing saying why.
+//
+// The pipe is what conflates the two. CombinedOutput gives the script a PIPE, and
+// then:
+//   - anything the script leaves behind inherits that pipe and holds it open, so
+//     Wait blocks on EOF and the timeout above bounds nothing (#1943's class); and
+//   - the cure for that, cmd.WaitDelay, KILLS the pipe-holder. But "still holds
+//     the pipe" is not a criterion for garbage, it is a coincidence — it is
+//     equally true of a stalled child and of a healthy tunnel. Measured: with
+//     WaitDelay, a successful launch_cmd's tunnel is dead within the grace.
+//
+// So do not use a pipe. The script's stdout and stderr go to a real FILE, whose
+// fd exec hands to the child directly — no pipe, no copier goroutine, nothing for
+// a survivor to hold open. Wait returns the moment the SCRIPT exits, the context
+// still kills the script if it hangs (verified: a hanging launch_cmd returns at
+// the deadline with no WaitDelay at all), and a tunnel that outlives it keeps
+// writing to a file nobody is reading. We stop listening; we kill nothing.
+//
+// Reaping a FAILED launch's sandbox is a separate act with a real criterion, and
+// it is delete_cmd's job, not a side effect of how we captured output: see reap.
+func runHookScript(timeout time.Duration, name string, args ...string) ([]byte, *exec.Cmd, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	// A regular file, not a pipe: see the doc comment. Unlinked immediately on
+	// return — a lingering writer keeps its fd valid and simply writes into an
+	// unlinked inode that disappears when it exits.
+	f, err := os.CreateTemp("", "af-hook-out-*")
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating the hook output file failed: %w", err)
 	}
-	return err
+	defer func() {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+	}()
+
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdout = f
+	cmd.Stderr = f
+	runErr := cmd.Run()
+
+	out, readErr := os.ReadFile(f.Name())
+	if readErr != nil && runErr == nil {
+		return nil, cmd, fmt.Errorf("reading the hook output failed: %w", readErr)
+	}
+	return out, cmd, runErr
 }
 
 // hookProvisioner holds the state of one hook provisioning so its launch step
@@ -230,11 +263,7 @@ func (p *hookProvisioner) launch() (*AgentServerEndpoint, error) {
 		args = append(args, "--auto-yes")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), hookLaunchTimeout)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, p.hooks.LaunchCmd, args...)
-	cmd.WaitDelay = hookOutputDrainGrace
-	out, err := cmd.CombinedOutput()
+	out, cmd, err := runHookScript(hookLaunchTimeout, p.hooks.LaunchCmd, args...)
 
 	// Gate the reap on whether launch_cmd STARTED, not on whether it succeeded
 	// (#1955). A script that creates a VM and then times out or exits non-zero
@@ -250,16 +279,9 @@ func (p *hookProvisioner) launch() (*AgentServerEndpoint, error) {
 	// so a missing or non-executable script surfaces as *fs.PathError instead — an
 	// *exec.Error check would read "never ran" as "ran" and fire delete_cmd for a
 	// typo'd path.
-	p.launchStarted = cmd.Process != nil
+	p.launchStarted = cmd != nil && cmd.Process != nil
 
-	if errors.Is(err, exec.ErrWaitDelay) {
-		// Exited 0 but left a process holding the output pipe, so the drain grace
-		// cut the read short. The endpoint JSON is normally already written, so
-		// parse what we captured rather than failing (and reaping) a sandbox that
-		// is very likely up.
-		log.WarningLog.Printf("hook runtime: launch_cmd for %q exited 0 but left its output pipe open; parsing the output captured so far", p.spec.Title)
-	}
-	if err := normalizeHookWaitDelay(err); err != nil {
+	if err != nil {
 		return nil, fmt.Errorf("launch_cmd failed: %s: %w", strings.TrimSpace(string(out)), err)
 	}
 
@@ -299,17 +321,14 @@ func (p *hookProvisioner) reap() error {
 		if !p.launchStarted {
 			return
 		}
-		// context.Background(), NEVER a caller's context. reap's whole job is to
+		// runHookScript builds its timeout from context.Background(), NEVER a
+		// caller's context — and that is load-bearing here. reap's whole job is to
 		// run on the failure path, where the launch context is already cancelled or
-		// expired — and a WithTimeout derived from a dead parent is born expired,
-		// so delete_cmd would never spawn and the sandbox would leak in silence.
-		// That is the exact failure #1955 is about, reintroduced by the cleanup.
-		ctx, cancel := context.WithTimeout(context.Background(), hookDeleteTimeout)
-		defer cancel()
-		cmd := exec.CommandContext(ctx, p.hooks.DeleteCmd, "--name", p.slug)
-		cmd.WaitDelay = hookOutputDrainGrace
-		out, err := cmd.CombinedOutput()
-		if err := normalizeHookWaitDelay(err); err != nil {
+		// expired, and a WithTimeout derived from a dead parent is born expired:
+		// delete_cmd would never spawn and the sandbox would leak in silence. That
+		// is the exact failure #1955 is about, reintroduced by the cleanup.
+		out, _, err := runHookScript(hookDeleteTimeout, p.hooks.DeleteCmd, "--name", p.slug)
+		if err != nil {
 			reapErr = fmt.Errorf("backend=hook: delete_cmd failed for %q: %s: %w", p.slug, strings.TrimSpace(string(out)), err)
 			log.ErrorLog.Printf("%s", p.orphanWarning(reapErr))
 			return

--- a/session/backend_hook_backend.go
+++ b/session/backend_hook_backend.go
@@ -3,6 +3,7 @@ package session
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -37,7 +38,10 @@ import (
 //	    token travels over the plaintext connection, so the launch_cmd must reach
 //	    the agent-server over a private network / tunnel it controls.
 //	delete_cmd --name <slug>
-//	    reaps whatever launch_cmd provisioned (the runtime teardown).
+//	    reaps whatever launch_cmd provisioned (the runtime teardown). Best-effort
+//	    by contract: it also runs after a launch_cmd that STARTED and then failed
+//	    or timed out, which may have left a half-built sandbox — or none at all —
+//	    so it must tolerate a slug it cannot find (#1955).
 //
 // This is the most direct provision-and-expose runtime: no container/tunnel of
 // our own, just the user's script handing us a URL. GitHub is still the durable
@@ -45,13 +49,29 @@ import (
 // re-runs launch_cmd to re-provision + re-clone), so hook reaches FULL capability
 // parity like docker/ssh — no ErrRecoverUnsupported, no locality special-case.
 
-const (
-	// hookLaunchTimeout / hookDeleteTimeout bound the user-provided provisioning
-	// and teardown scripts. launch_cmd may pull an image, spin up a VM, or clone a
-	// large repo, so it gets a generous budget; delete_cmd is bounded tighter so a
-	// kill never hangs on an unreachable provisioner.
-	hookLaunchTimeout = 5 * time.Minute
-	hookDeleteTimeout = 60 * time.Second
+// The bounds on the user-provided provisioning and teardown scripts. Vars (not
+// consts) so a test can shrink them to prove each bound fires.
+//
+//   - hookLaunchTimeout: launch_cmd may pull an image, spin up a VM, or clone a
+//     large repo, so it gets a generous budget.
+//   - hookDeleteTimeout: bounded tighter so a kill never hangs on an unreachable
+//     provisioner.
+//   - hookOutputDrainGrace: how long to wait for a script's output pipe to drain
+//     AFTER the script itself has exited or been killed. Without it the two
+//     timeouts above bound NOTHING: CombinedOutput waits for the output pipe to
+//     close, any process the script leaves behind inherits that pipe and holds it
+//     open, and exec.CommandContext kills only the script, not its children. So a
+//     launch_cmd that provisions and then hangs would block Provision forever
+//     rather than for hookLaunchTimeout — and the #1955 reap could never run at
+//     all, because launch() would never return to trigger it. Bounding the drain
+//     is what turns "launch_cmd timed out" into an event the reap can react to.
+//     The hook scripts are the last exec surface that lacked this bound; it
+//     mirrors gitWaitDelay and tmuxWaitDelay (#856/#896), and a user-authored
+//     provisioner is the likeliest of all of them to leave a child behind.
+var (
+	hookLaunchTimeout    = 5 * time.Minute
+	hookDeleteTimeout    = 60 * time.Second
+	hookOutputDrainGrace = 5 * time.Second
 )
 
 // hookRuntime provisions a session on user-provided infrastructure via the
@@ -66,15 +86,66 @@ func (hookRuntime) Provision(spec ProvisionSpec) (ProvisionResult, error) {
 		return ProvisionResult{}, fmt.Errorf("backend=hook: %w", err)
 	}
 	p := &hookProvisioner{hooks: hooks, spec: spec, slug: Slugify(spec.Title)}
+	return p.provisionOrReap()
+}
+
+// provisionOrReap provisions and, on ANY failure, reaps whatever launch_cmd may
+// have created before it failed. It is the whole of hookRuntime.Provision below
+// the config load, split out so a test can drive the real reap-on-failure gate
+// with a hand-built provisioner — the gate is the thing #1955 was about, and a
+// test that re-implemented it would prove nothing about this path.
+func (p *hookProvisioner) provisionOrReap() (ProvisionResult, error) {
 	res, err := p.provision()
-	if err != nil {
-		// launch_cmd may have provisioned a sandbox before failing to hand back a
-		// usable endpoint (e.g. it started the af agent-server but printed no/bad
-		// JSON); reap it via delete_cmd so nothing leaks on a partial failure.
-		p.reap()
-		return ProvisionResult{}, err
+	if err == nil {
+		return res, nil
 	}
-	return res, nil
+	// launch_cmd may have provisioned a sandbox before failing to hand back a
+	// usable endpoint: it can exit 0 having printed no/bad JSON, exit non-zero
+	// after creating a VM, or be killed at the timeout mid-provision. Reap via
+	// delete_cmd so nothing leaks on a partial failure (#1955).
+	if reapErr := p.reap(); reapErr != nil {
+		// The reap failed too, so something on the user's account may still be
+		// running and billing with no record of it on our side. That has to reach
+		// the person creating the session, not just the log.
+		return ProvisionResult{}, fmt.Errorf("%w\n\n%s", err, p.orphanWarning(reapErr))
+	}
+	return ProvisionResult{}, err
+}
+
+// orphanWarning is what a user sees when delete_cmd could not reap a sandbox that
+// launch_cmd may have provisioned. A leak the user knows about is survivable; a
+// silent one is not (#1955) — so it names the session and its slug, says plainly
+// that real infrastructure may still be running, and gives the exact command to
+// reap it by hand. It goes to ErrorLog AND into the returned provision error,
+// since someone creating a session is not reading the daemon log.
+//
+// Worded to hold on EVERY reap path, not just the provisioning failure that
+// motivated it: reap also backs Kill and archive, where launch_cmd succeeded and
+// the sandbox certainly existed. "launch_cmd ran, so a sandbox may still be out
+// there" is the claim common to all three.
+func (p *hookProvisioner) orphanWarning(reapErr error) string {
+	return fmt.Sprintf(
+		"A sandbox may still be running on your infrastructure — delete_cmd could not reap it, and af will not retry.\n"+
+			"launch_cmd ran for session %q (hook name %q), so it may hold real resources: a VM, a pod, a cloud sandbox.\n"+
+			"Reap it by hand, then check your provider for anything still running:\n"+
+			"    %s --name %s\n"+
+			"delete_cmd error: %v",
+		p.spec.Title, p.slug, p.hooks.DeleteCmd, p.slug, reapErr)
+}
+
+// normalizeHookWaitDelay converts an exec.ErrWaitDelay into success: the hook
+// script itself exited 0 (a non-zero exit surfaces as an ExitError, and a
+// timeout kill as a signal — never as ErrWaitDelay), and only a process it left
+// behind held the output pipe open past hookOutputDrainGrace. A launch_cmd that
+// backgrounds a tunnel to make the agent-server reachable is a documented
+// pattern, so this is not a failure — and treating it as one would reap a
+// sandbox that came up fine. Success is the script's EXIT STATUS, never
+// `err == nil`. Mirrors tmux's normalizeWaitDelay (#676/#914 precedent).
+func normalizeHookWaitDelay(err error) error {
+	if errors.Is(err, exec.ErrWaitDelay) {
+		return nil
+	}
+	return err
 }
 
 // hookProvisioner holds the state of one hook provisioning so its launch step
@@ -85,8 +156,12 @@ type hookProvisioner struct {
 	spec  ProvisionSpec
 	slug  string
 
-	launched bool
-	reapOnce sync.Once
+	// launchStarted records that the kernel spawned launch_cmd — NOT that it
+	// succeeded. It gates the delete_cmd reap, so it must stay the weaker of the
+	// two claims: a launch that started and then failed may have provisioned
+	// infrastructure, and only delete_cmd can reap it (#1955).
+	launchStarted bool
+	reapOnce      sync.Once
 }
 
 // hookEndpointJSON is the object launch_cmd echoes: the authed `af agent-server`
@@ -143,13 +218,36 @@ func (p *hookProvisioner) launch() (*AgentServerEndpoint, error) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), hookLaunchTimeout)
 	defer cancel()
-	out, err := exec.CommandContext(ctx, p.hooks.LaunchCmd, args...).CombinedOutput()
-	if err != nil {
+	cmd := exec.CommandContext(ctx, p.hooks.LaunchCmd, args...)
+	cmd.WaitDelay = hookOutputDrainGrace
+	out, err := cmd.CombinedOutput()
+
+	// Gate the reap on whether launch_cmd STARTED, not on whether it succeeded
+	// (#1955). A script that creates a VM and then times out or exits non-zero
+	// has provisioned real infrastructure on the user's account that only
+	// delete_cmd can reap: "it failed" is not evidence that nothing exists, and
+	// af keeps no record of a session whose Provision failed, so an unreaped
+	// sandbox bills forever with nothing pointing at it.
+	//
+	// cmd.Process is non-nil exactly when the kernel spawned the process, which
+	// is that question answered directly. Do NOT infer it from the error type:
+	// only a BARE command name goes through exec.LookPath and yields *exec.Error,
+	// and the documented launch_cmd is a path ("./.agent-factory/hooks/launch.sh"),
+	// so a missing or non-executable script surfaces as *fs.PathError instead — an
+	// *exec.Error check would read "never ran" as "ran" and fire delete_cmd for a
+	// typo'd path.
+	p.launchStarted = cmd.Process != nil
+
+	if errors.Is(err, exec.ErrWaitDelay) {
+		// Exited 0 but left a process holding the output pipe, so the drain grace
+		// cut the read short. The endpoint JSON is normally already written, so
+		// parse what we captured rather than failing (and reaping) a sandbox that
+		// is very likely up.
+		log.WarningLog.Printf("hook runtime: launch_cmd for %q exited 0 but left its output pipe open; parsing the output captured so far", p.spec.Title)
+	}
+	if err := normalizeHookWaitDelay(err); err != nil {
 		return nil, fmt.Errorf("launch_cmd failed: %s: %w", strings.TrimSpace(string(out)), err)
 	}
-	// launch_cmd exited 0, so it may have provisioned a sandbox; from here any
-	// failure must trigger the delete_cmd reap (via the caller's p.reap()).
-	p.launched = true
 
 	jsonStr := extractJSON(string(out))
 	if jsonStr == "" {
@@ -171,23 +269,35 @@ func (p *hookProvisioner) launch() (*AgentServerEndpoint, error) {
 }
 
 // reap runs delete_cmd to tear down whatever launch_cmd provisioned, idempotently
-// and only if launch_cmd actually ran (nothing to delete otherwise). It backs the
-// session's Kill (after the in-sandbox workspace is torn down over REST), a
-// provisioning failure, and a bad-endpoint NewInstance failure — so a provisioned
-// sandbox is never leaked. The sync.Once collapses the repeated Kill retries and
-// the Kill-vs-provision-failure races to one delete_cmd.
+// and only if launch_cmd actually STARTED — if it never ran, nothing was
+// provisioned and there is nothing to delete. It backs the session's Kill (after
+// the in-sandbox workspace is torn down over REST), a provisioning failure, and a
+// bad-endpoint NewInstance failure — so a provisioned sandbox is never leaked. The
+// sync.Once collapses the repeated Kill retries and the Kill-vs-provision-failure
+// races to one delete_cmd.
+//
+// This is best-effort by contract: it may be called for a sandbox that was never
+// fully built, so delete_cmd must tolerate a slug it cannot find (documented in
+// docs/remote-hooks.md).
 func (p *hookProvisioner) reap() error {
 	var reapErr error
 	p.reapOnce.Do(func() {
-		if !p.launched {
+		if !p.launchStarted {
 			return
 		}
+		// context.Background(), NEVER a caller's context. reap's whole job is to
+		// run on the failure path, where the launch context is already cancelled or
+		// expired — and a WithTimeout derived from a dead parent is born expired,
+		// so delete_cmd would never spawn and the sandbox would leak in silence.
+		// That is the exact failure #1955 is about, reintroduced by the cleanup.
 		ctx, cancel := context.WithTimeout(context.Background(), hookDeleteTimeout)
 		defer cancel()
-		out, err := exec.CommandContext(ctx, p.hooks.DeleteCmd, "--name", p.slug).CombinedOutput()
-		if err != nil {
+		cmd := exec.CommandContext(ctx, p.hooks.DeleteCmd, "--name", p.slug)
+		cmd.WaitDelay = hookOutputDrainGrace
+		out, err := cmd.CombinedOutput()
+		if err := normalizeHookWaitDelay(err); err != nil {
 			reapErr = fmt.Errorf("backend=hook: delete_cmd failed for %q: %s: %w", p.slug, strings.TrimSpace(string(out)), err)
-			log.WarningLog.Printf("%v", reapErr)
+			log.ErrorLog.Printf("%s", p.orphanWarning(reapErr))
 			return
 		}
 		log.InfoLog.Printf("hook runtime: reaped remote session %q via delete_cmd", p.slug)

--- a/session/backend_hook_backend.go
+++ b/session/backend_hook_backend.go
@@ -128,9 +128,23 @@ func (p *hookProvisioner) orphanWarning(reapErr error) string {
 		"A sandbox may still be running on your infrastructure — delete_cmd could not reap it, and af will not retry.\n"+
 			"launch_cmd ran for session %q (hook name %q), so it may hold real resources: a VM, a pod, a cloud sandbox.\n"+
 			"Reap it by hand, then check your provider for anything still running:\n"+
-			"    %s --name %s\n"+
+			"    %s\n"+
 			"delete_cmd error: %v",
-		p.spec.Title, p.slug, p.hooks.DeleteCmd, p.slug, reapErr)
+		p.spec.Title, p.slug, p.manualReapCommand(), reapErr)
+}
+
+// manualReapCommand is the shell command orphanWarning tells the user to paste.
+// Every interpolated value is shell-quoted, because this command has to be
+// correct exactly when things are messy — which is exactly when names are weird.
+//
+// delete_cmd is an arbitrary user-configured path: a space, an apostrophe, a `$`
+// or a backtick in it yields a command that fails, or worse, runs something other
+// than what it reads like. The slug is already constrained to [a-z0-9-] by
+// Slugify, so quoting it is belt-and-braces — but it costs nothing and the safety
+// then lives here rather than depending on a caller's charset invariant holding
+// forever.
+func (p *hookProvisioner) manualReapCommand() string {
+	return fmt.Sprintf("%s --name %s", shellQuote(p.hooks.DeleteCmd), shellQuote(p.slug))
 }
 
 // normalizeHookWaitDelay converts an exec.ErrWaitDelay into success: the hook

--- a/session/backend_hook_reap_test.go
+++ b/session/backend_hook_reap_test.go
@@ -3,6 +3,8 @@ package session
 import (
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,6 +13,7 @@ import (
 	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/shellsuggest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -94,13 +97,11 @@ echo "$name" >> '%s'/delete-ran.log
 
 // shrinkHookTimeouts shrinks the production bounds so a test proves they FIRE
 // without waiting the real budget, restoring them afterwards.
-func shrinkHookTimeouts(t *testing.T, launch, del, drain time.Duration) {
+func shrinkHookTimeouts(t *testing.T, launch, del time.Duration) {
 	t.Helper()
-	ol, od, og := hookLaunchTimeout, hookDeleteTimeout, hookOutputDrainGrace
-	hookLaunchTimeout, hookDeleteTimeout, hookOutputDrainGrace = launch, del, drain
-	t.Cleanup(func() {
-		hookLaunchTimeout, hookDeleteTimeout, hookOutputDrainGrace = ol, od, og
-	})
+	ol, od := hookLaunchTimeout, hookDeleteTimeout
+	hookLaunchTimeout, hookDeleteTimeout = launch, del
+	t.Cleanup(func() { hookLaunchTimeout, hookDeleteTimeout = ol, od })
 }
 
 func newHookProvisioner(h hookState, title string) *hookProvisioner {
@@ -142,7 +143,7 @@ func TestHookProvisionReapsPartiallyProvisionedLaunch(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			shrinkHookTimeouts(t, 300*time.Millisecond, 5*time.Second, 300*time.Millisecond)
+			shrinkHookTimeouts(t, 300*time.Millisecond, 5*time.Second)
 			h := newHookState(t, tc.launchBody, "")
 			p := newHookProvisioner(h, "bills by the hour")
 
@@ -188,7 +189,7 @@ func TestHookProvisionDoesNotReapWhenLaunchNeverStarted(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			shrinkHookTimeouts(t, 300*time.Millisecond, 5*time.Second, 300*time.Millisecond)
+			shrinkHookTimeouts(t, 300*time.Millisecond, 5*time.Second)
 			h := newHookState(t, "exit 0\n", "")
 			p := newHookProvisioner(h, "never started")
 			p.hooks.LaunchCmd = tc.launchCmd(h)
@@ -207,7 +208,7 @@ func TestHookProvisionDoesNotReapWhenLaunchNeverStarted(t *testing.T) {
 // so the failure has to reach the person creating the session, name the orphan,
 // and say how to reap it by hand.
 func TestHookProvisionReportsOrphanWhenDeleteFails(t *testing.T) {
-	shrinkHookTimeouts(t, 300*time.Millisecond, 5*time.Second, 300*time.Millisecond)
+	shrinkHookTimeouts(t, 300*time.Millisecond, 5*time.Second)
 	h := newHookState(t,
 		"echo 'provisioned, then died' >&2\nexit 4\n",
 		"echo 'the VM is still in CREATING state' >&2\nexit 9\n")
@@ -315,7 +316,7 @@ func TestShellQuoteSurvivesARealShell(t *testing.T) {
 func TestHookReapIsBounded(t *testing.T) {
 	// delete_cmd hangs; its `sleep` child outlives the kill holding the output
 	// pipe, which is what defeats the context timeout on its own.
-	shrinkHookTimeouts(t, 300*time.Millisecond, 300*time.Millisecond, 300*time.Millisecond)
+	shrinkHookTimeouts(t, 300*time.Millisecond, 300*time.Millisecond)
 	h := newHookState(t, "exit 0\n", "sleep 30\n")
 	p := newHookProvisioner(h, "wedged delete")
 	p.launchStarted = true
@@ -340,7 +341,7 @@ func TestHookReapIsBounded(t *testing.T) {
 // it would be born expired, delete_cmd would never spawn, and the sandbox would
 // leak in silence — with the reap call still sitting there looking correct.
 func TestHookReapUnaffectedByCancelledCaller(t *testing.T) {
-	shrinkHookTimeouts(t, 50*time.Millisecond, 5*time.Second, 300*time.Millisecond)
+	shrinkHookTimeouts(t, 50*time.Millisecond, 5*time.Second)
 	h := newHookState(t, "sleep 3\n", "")
 	p := newHookProvisioner(h, "dead parent")
 
@@ -361,7 +362,7 @@ func TestHookReapUnaffectedByCancelledCaller(t *testing.T) {
 // that error as failure would reap a sandbox that came up fine, which is exactly
 // the "destroyed a working sandbox" outcome this fix must not cause.
 func TestHookProvisionSucceedsWhenLaunchLeavesOutputPipeOpen(t *testing.T) {
-	shrinkHookTimeouts(t, 5*time.Second, 5*time.Second, 300*time.Millisecond)
+	shrinkHookTimeouts(t, 5*time.Second, 5*time.Second)
 	h := newHookState(t,
 		// The lingering child is the tunnel; the endpoint JSON is printed and the
 		// script exits 0.
@@ -376,11 +377,115 @@ func TestHookProvisionSucceedsWhenLaunchLeavesOutputPipeOpen(t *testing.T) {
 	assert.DirExists(t, h.sandbox(p.slug), "the working sandbox must still exist")
 }
 
+// TestHookProvisionKeepsASuccessfulLaunchsTunnelAlive is the #1966-review P2: a
+// launch_cmd that SUCCEEDS and leaves a tunnel running must end with a REACHABLE
+// endpoint. The tunnel is not a leak — it is the product, the thing making the
+// endpoint dialable — so nothing in the capture path may reap it.
+//
+// It asserts REACHABILITY, not the absence of a kill: the endpoint working is the
+// actual claim, and "we did not send a signal" would not prove it (the tunnel dies
+// of SIGPIPE when our read end closes, no signal from us involved).
+//
+// The stand-in tunnel is a real HTTP server, backgrounded by launch_cmd, holding
+// stdout exactly as a port-forward logging its activity does.
+func TestHookProvisionKeepsASuccessfulLaunchsTunnelAlive(t *testing.T) {
+	shrinkHookTimeouts(t, 10*time.Second, 5*time.Second)
+	dir := t.TempDir()
+
+	// The tunnel must be the thing that ACTUALLY SERVES the endpoint, owned by
+	// launch_cmd — not a server the test holds. A test-owned server would stay up
+	// even when the tunnel is reaped, so the reachability assertion would pass
+	// against the very bug it exists to catch. (It did, on the first draft.)
+	//
+	// So: a real backgrounded HTTP server that ALSO writes to stdout, which is what
+	// makes it a pipe-holder and therefore a target of any drain policy.
+	tunnel := filepath.Join(dir, "tunnel.py")
+	require.NoError(t, os.WriteFile(tunnel, []byte(`
+import http.server, socketserver, sys, threading, time
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200); self.end_headers(); self.wfile.write(b"agent-server alive")
+    def log_message(self, *a): pass
+srv = socketserver.TCPServer(("127.0.0.1", 0), H)
+open(sys.argv[1], "w").write(str(srv.server_address[1]))
+threading.Thread(target=srv.serve_forever, daemon=True).start()
+while True:                      # holds launch_cmd's stdout, like a forwarder logging
+    print("tunnel forwarding", flush=True)
+    time.sleep(0.05)
+`), 0o644))
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Fatalf("python3 is not installed, so this test cannot stand up a real tunnel and would " +
+			"assert reachability against a server it owns itself — which passes against the bug. " +
+			"Install python3 rather than weakening this test.")
+	}
+
+	portFile := filepath.Join(dir, "port")
+	h := hookState{dir: dir, launch: filepath.Join(dir, "launch.sh"), delete: filepath.Join(dir, "delete.sh")}
+	writeHookScript(t, h.launch, fmt.Sprintf(`
+python3 %s %s &
+for i in $(seq 1 100); do [ -s %s ] && break; sleep 0.05; done
+echo "{\"url\":\"http://127.0.0.1:$(cat %s)\",\"token\":\"secret\"}"
+exit 0
+`, shellsuggest.Arg(tunnel), shellsuggest.Arg(portFile), shellsuggest.Arg(portFile), shellsuggest.Arg(portFile)))
+	writeHookScript(t, h.delete, fmt.Sprintf(`echo "$name" >> %s/delete-ran.log`, shellsuggest.Arg(dir)))
+
+	p := newHookProvisioner(h, "tunnel holder")
+	res, err := p.provisionOrReap()
+	require.NoError(t, err, "a launch_cmd that exits 0 with a valid endpoint must succeed")
+	require.NotNil(t, res.Endpoint)
+
+	// Give any pipe-holder policy every chance to fire before we check.
+	time.Sleep(400 * time.Millisecond)
+
+	// THE CLAIM: the endpoint we just handed back actually works.
+	resp, err := http.Get(res.Endpoint.URL)
+	require.NoError(t, err,
+		"the provisioned endpoint %s is unreachable — the launch SUCCEEDED and something reaped the tunnel that makes it dialable",
+		res.Endpoint.URL)
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, "agent-server alive", string(body), "the endpoint must serve the agent-server, not a corpse")
+
+	assert.False(t, h.deleteRan(t), "a successful provision must never reap")
+}
+
+// TestHookLaunchDoesNotKillBackgroundedChildren is the mechanism behind the test
+// above, pinned separately so a regression names its own cause: the capture must
+// not kill a process launch_cmd deliberately backgrounded. A heartbeat file is the
+// liveness probe — it keeps ticking only while the child lives.
+func TestHookLaunchDoesNotKillBackgroundedChildren(t *testing.T) {
+	shrinkHookTimeouts(t, 5*time.Second, 5*time.Second)
+	dir := t.TempDir()
+	hb := filepath.Join(dir, "heartbeat")
+
+	h := hookState{dir: dir, launch: filepath.Join(dir, "launch.sh"), delete: filepath.Join(dir, "delete.sh")}
+	writeHookScript(t, h.launch, fmt.Sprintf(`
+( for i in $(seq 1 100); do echo "still here"; echo tick >> %s; sleep 0.05; done ) &
+echo '{"url":"http://10.0.0.7:8080","token":"secret"}'
+exit 0
+`, shellsuggest.Arg(hb)))
+	writeHookScript(t, h.delete, "true")
+
+	p := newHookProvisioner(h, "background child")
+	_, err := p.provisionOrReap()
+	require.NoError(t, err)
+
+	// The child must still be ticking well after the script exited.
+	time.Sleep(250 * time.Millisecond)
+	first, err := os.Stat(hb)
+	require.NoError(t, err, "the backgrounded child never ran")
+	time.Sleep(250 * time.Millisecond)
+	second, err := os.Stat(hb)
+	require.NoError(t, err)
+	assert.True(t, second.ModTime().After(first.ModTime()),
+		"the process launch_cmd backgrounded stopped writing — the output capture killed a child that was not ours to kill")
+}
+
 // TestHookLaunchIsBounded proves the launch bound fires at all. It is the
 // precondition for the whole fix: if launch_cmd never returns, Provision hangs
 // and the reap #1955 asks for can never run, no matter how it is gated.
 func TestHookLaunchIsBounded(t *testing.T) {
-	shrinkHookTimeouts(t, 300*time.Millisecond, 5*time.Second, 300*time.Millisecond)
+	shrinkHookTimeouts(t, 300*time.Millisecond, 5*time.Second)
 	h := newHookState(t, "sleep 30\n", "")
 	p := newHookProvisioner(h, "wedged launch")
 

--- a/session/backend_hook_reap_test.go
+++ b/session/backend_hook_reap_test.go
@@ -1,0 +1,321 @@
+package session
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The #1955 invariant: a launch_cmd that STARTED may have provisioned real
+// infrastructure on the user's account, so every provisioning failure must run
+// delete_cmd — "it failed" is not evidence that nothing was created. The mirror
+// of destruction-requires-positive-evidence: absence of a success signal is not
+// absence of a resource, and forgetting must be the safe direction.
+//
+// These tests mutate the package-level hook timeout vars, so none of them may
+// run in parallel. Every script they write touches ONLY its own t.TempDir().
+
+// hookState is a self-contained launch/delete script pair operating on a state
+// tree inside t.TempDir(), standing in for the user's cloud provider: launch
+// "provisions" a sandbox dir, delete reaps it and logs that it ran.
+type hookState struct {
+	dir    string // the state tree the scripts read/write — all under t.TempDir()
+	launch string // path to launch.sh
+	delete string // path to delete.sh
+}
+
+// sandbox is the "provisioned resource" for slug — the thing that leaks.
+func (h hookState) sandbox(slug string) string {
+	return filepath.Join(h.dir, "sandboxes", slug)
+}
+
+// deleteRan reports whether delete_cmd was invoked at all (it appends to a log
+// before doing any work, so it records even a delete that then fails).
+func (h hookState) deleteRan(t *testing.T) bool {
+	t.Helper()
+	_, err := os.Stat(filepath.Join(h.dir, "delete-ran.log"))
+	return err == nil
+}
+
+// writeHookScript writes an executable bash script and returns its path. Paths
+// are interpolated single-quoted, so the script never depends on cwd or $HOME.
+func writeHookScript(t *testing.T, path, body string) string {
+	t.Helper()
+	const preamble = `#!/usr/bin/env bash
+name=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --name) name="$2"; shift 2;;
+    *) shift;;
+  esac
+done
+`
+	require.NoError(t, os.WriteFile(path, []byte(preamble+body), 0o755))
+	return path
+}
+
+// newHookState builds the script pair. launchBody runs after the sandbox dir is
+// created, so a test only has to say how launch_cmd FAILS; deleteBody defaults
+// to a working, idempotent reap in the shape docs/remote-hooks.md recommends.
+func newHookState(t *testing.T, launchBody, deleteBody string) hookState {
+	t.Helper()
+	dir := t.TempDir()
+	h := hookState{
+		dir:    dir,
+		launch: filepath.Join(dir, "launch.sh"),
+		delete: filepath.Join(dir, "delete.sh"),
+	}
+	if deleteBody == "" {
+		// Slug-deterministic and idempotent: a slug it has never seen is a
+		// success, not an error — the contract this fix now depends on.
+		deleteBody = fmt.Sprintf(`rm -rf '%s'/sandboxes/"$name" 2>/dev/null || true`, dir)
+	}
+	writeHookScript(t, h.launch, fmt.Sprintf(`
+mkdir -p '%s'/sandboxes/"$name"
+echo "a VM that bills by the hour" > '%s'/sandboxes/"$name"/resource.txt
+%s
+`, dir, dir, launchBody))
+	writeHookScript(t, h.delete, fmt.Sprintf(`
+mkdir -p '%s'
+echo "$name" >> '%s'/delete-ran.log
+%s
+`, dir, dir, deleteBody))
+	return h
+}
+
+// shrinkHookTimeouts shrinks the production bounds so a test proves they FIRE
+// without waiting the real budget, restoring them afterwards.
+func shrinkHookTimeouts(t *testing.T, launch, del, drain time.Duration) {
+	t.Helper()
+	ol, od, og := hookLaunchTimeout, hookDeleteTimeout, hookOutputDrainGrace
+	hookLaunchTimeout, hookDeleteTimeout, hookOutputDrainGrace = launch, del, drain
+	t.Cleanup(func() {
+		hookLaunchTimeout, hookDeleteTimeout, hookOutputDrainGrace = ol, od, og
+	})
+}
+
+func newHookProvisioner(h hookState, title string) *hookProvisioner {
+	return &hookProvisioner{
+		hooks: config.RemoteHooks{LaunchCmd: h.launch, DeleteCmd: h.delete},
+		spec:  ProvisionSpec{Title: title, CloneURL: "https://example.invalid/repo.git"},
+		slug:  Slugify(title),
+	}
+}
+
+// TestHookProvisionReapsPartiallyProvisionedLaunch is the headline #1955 test: a
+// launch_cmd that provisions and THEN fails must not leak the sandbox. Each case
+// is a different way to fail after the resource already exists.
+func TestHookProvisionReapsPartiallyProvisionedLaunch(t *testing.T) {
+	cases := []struct {
+		name string
+		// launchBody runs after the sandbox has been "provisioned".
+		launchBody string
+	}{
+		{
+			// (a) provisions, then hangs until the launch timeout kills it. The
+			// `sleep` is a child that outlives the killed script and holds the
+			// output pipe — the shape that made the timeout unbounded.
+			name:       "provisions then hangs until timeout",
+			launchBody: "sleep 3\n",
+		},
+		{
+			// (b) provisions, then exits non-zero.
+			name:       "provisions then exits non-zero",
+			launchBody: "echo 'could not reach the agent-server' >&2\nexit 4\n",
+		},
+		{
+			// The pre-existing covered case, kept as a lock: exits 0 having
+			// printed no endpoint JSON.
+			name:       "exits 0 with no endpoint JSON",
+			launchBody: "echo 'all done, forgot the JSON'\nexit 0\n",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			shrinkHookTimeouts(t, 300*time.Millisecond, 5*time.Second, 300*time.Millisecond)
+			h := newHookState(t, tc.launchBody, "")
+			p := newHookProvisioner(h, "bills by the hour")
+
+			_, err := p.provisionOrReap()
+			require.Error(t, err, "provisioning must fail")
+
+			assert.True(t, h.deleteRan(t), "delete_cmd must run: launch_cmd started, so it may have provisioned")
+			assert.NoDirExists(t, h.sandbox(p.slug),
+				"the partially provisioned sandbox leaked — it is still billing the user with no record of it on our side")
+		})
+	}
+}
+
+// TestHookProvisionDoesNotReapWhenLaunchNeverStarted is the other half of the
+// invariant, and the reason the naive "flip the bool unconditionally" fix is
+// wrong: if launch_cmd never ran, nothing was provisioned and delete_cmd must not
+// fire. Both spellings are covered because they fail DIFFERENTLY: only a bare
+// command name goes through exec.LookPath (*exec.Error); a path — which is the
+// documented launch_cmd shape — fails at StartProcess with *fs.PathError, so
+// discriminating on *exec.Error alone would misread this case as "ran".
+func TestHookProvisionDoesNotReapWhenLaunchNeverStarted(t *testing.T) {
+	cases := []struct {
+		name      string
+		launchCmd func(h hookState) string
+	}{
+		{
+			name:      "path does not exist",
+			launchCmd: func(h hookState) string { return filepath.Join(h.dir, "no-such-launch.sh") },
+		},
+		{
+			name: "exists but is not executable",
+			launchCmd: func(h hookState) string {
+				p := filepath.Join(h.dir, "not-executable.sh")
+				require.NoError(t, os.WriteFile(p, []byte("#!/usr/bin/env bash\ntrue\n"), 0o644))
+				return p
+			},
+		},
+		{
+			name:      "bare name not on PATH",
+			launchCmd: func(h hookState) string { return "af-no-such-launch-binary-xyz" },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			shrinkHookTimeouts(t, 300*time.Millisecond, 5*time.Second, 300*time.Millisecond)
+			h := newHookState(t, "exit 0\n", "")
+			p := newHookProvisioner(h, "never started")
+			p.hooks.LaunchCmd = tc.launchCmd(h)
+
+			_, err := p.provisionOrReap()
+			require.Error(t, err, "provisioning must fail")
+
+			assert.False(t, h.deleteRan(t),
+				"delete_cmd must NOT run: launch_cmd never started, so it provisioned nothing")
+		})
+	}
+}
+
+// TestHookProvisionReportsOrphanWhenDeleteFails covers the case where cleanup
+// itself fails. A leak the user knows about is survivable; a silent one is not —
+// so the failure has to reach the person creating the session, name the orphan,
+// and say how to reap it by hand.
+func TestHookProvisionReportsOrphanWhenDeleteFails(t *testing.T) {
+	shrinkHookTimeouts(t, 300*time.Millisecond, 5*time.Second, 300*time.Millisecond)
+	h := newHookState(t,
+		"echo 'provisioned, then died' >&2\nexit 4\n",
+		"echo 'the VM is still in CREATING state' >&2\nexit 9\n")
+	p := newHookProvisioner(h, "Orphan Me")
+
+	_, err := p.provisionOrReap()
+	require.Error(t, err)
+	msg := err.Error()
+
+	// The original failure survives...
+	assert.Contains(t, msg, "launch_cmd failed", "the original provisioning error must not be swallowed")
+	// ...and so does the orphan warning, with everything needed to act on it.
+	assert.Contains(t, msg, "may still be running on your infrastructure")
+	assert.Contains(t, msg, p.slug, "the warning must name the orphaned sandbox's slug")
+	assert.Contains(t, msg, h.delete+" --name "+p.slug, "the warning must give the exact command to reap by hand")
+	assert.Contains(t, msg, "the VM is still in CREATING state", "delete_cmd's own output must be surfaced")
+
+	// The resource really is still there — the message is not crying wolf.
+	assert.DirExists(t, h.sandbox(p.slug))
+}
+
+// TestHookReapIsBounded proves the fix does not trade a leak for a hang. Gating
+// cleanup on "launch started" runs delete_cmd on far more paths than before, so
+// a delete_cmd that wedges must not wedge the caller with it.
+func TestHookReapIsBounded(t *testing.T) {
+	// delete_cmd hangs; its `sleep` child outlives the kill holding the output
+	// pipe, which is what defeats the context timeout on its own.
+	shrinkHookTimeouts(t, 300*time.Millisecond, 300*time.Millisecond, 300*time.Millisecond)
+	h := newHookState(t, "exit 0\n", "sleep 30\n")
+	p := newHookProvisioner(h, "wedged delete")
+	p.launchStarted = true
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() { done <- p.reap() }()
+
+	select {
+	case err := <-done:
+		require.Error(t, err, "a delete_cmd killed at its timeout is a failed reap")
+		assert.Less(t, time.Since(start), 5*time.Second,
+			"reap must return at its own bound, not wait on a wedged delete_cmd")
+	case <-time.After(20 * time.Second):
+		t.Fatal("reap hung on a wedged delete_cmd: the delete bound does not fire")
+	}
+}
+
+// TestHookReapUnaffectedByCancelledCaller locks the one subtlety that would
+// silently un-fix #1955: reap runs on the failure path, where the launch context
+// is ALREADY expired. If reap's context were ever derived from that dead parent
+// it would be born expired, delete_cmd would never spawn, and the sandbox would
+// leak in silence — with the reap call still sitting there looking correct.
+func TestHookReapUnaffectedByCancelledCaller(t *testing.T) {
+	shrinkHookTimeouts(t, 50*time.Millisecond, 5*time.Second, 300*time.Millisecond)
+	h := newHookState(t, "sleep 3\n", "")
+	p := newHookProvisioner(h, "dead parent")
+
+	// Drive the real path: launch times out (so its context is expired and its
+	// process killed) and only then does the reap run.
+	_, err := p.provisionOrReap()
+	require.Error(t, err)
+
+	assert.True(t, h.deleteRan(t), "delete_cmd must still spawn after the launch context has expired")
+	assert.NoDirExists(t, h.sandbox(p.slug))
+}
+
+// TestHookProvisionSucceedsWhenLaunchLeavesOutputPipeOpen guards the regression
+// the bound itself could cause. A launch_cmd that exits 0 and leaves a tunnel or
+// backgrounded daemon holding its stdout — a documented pattern, since the script
+// must make the agent-server reachable — trips the drain grace and returns a
+// non-nil error even though it succeeded. Success is the EXIT STATUS; treating
+// that error as failure would reap a sandbox that came up fine, which is exactly
+// the "destroyed a working sandbox" outcome this fix must not cause.
+func TestHookProvisionSucceedsWhenLaunchLeavesOutputPipeOpen(t *testing.T) {
+	shrinkHookTimeouts(t, 5*time.Second, 5*time.Second, 300*time.Millisecond)
+	h := newHookState(t,
+		// The lingering child is the tunnel; the endpoint JSON is printed and the
+		// script exits 0.
+		"sleep 3 &\necho '{\"url\":\"http://10.0.0.7:8080\",\"token\":\"secret\"}'\nexit 0\n", "")
+	p := newHookProvisioner(h, "tunnel holder")
+
+	res, err := p.provisionOrReap()
+	require.NoError(t, err, "launch_cmd exited 0 with a valid endpoint; a held-open pipe is not a failure")
+	require.NotNil(t, res.Endpoint)
+	assert.Equal(t, "http://10.0.0.7:8080", res.Endpoint.URL)
+	assert.False(t, h.deleteRan(t), "a sandbox that came up fine must never be reaped")
+	assert.DirExists(t, h.sandbox(p.slug), "the working sandbox must still exist")
+}
+
+// TestHookLaunchIsBounded proves the launch bound fires at all. It is the
+// precondition for the whole fix: if launch_cmd never returns, Provision hangs
+// and the reap #1955 asks for can never run, no matter how it is gated.
+func TestHookLaunchIsBounded(t *testing.T) {
+	shrinkHookTimeouts(t, 300*time.Millisecond, 5*time.Second, 300*time.Millisecond)
+	h := newHookState(t, "sleep 30\n", "")
+	p := newHookProvisioner(h, "wedged launch")
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		_, err := p.launch()
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		assert.Contains(t, strings.ToLower(err.Error()), "launch_cmd failed")
+		assert.Less(t, time.Since(start), 5*time.Second, "launch must return at its own bound")
+		assert.True(t, p.launchStarted, "launch_cmd ran before it was killed, so the reap must be armed")
+	case <-time.After(20 * time.Second):
+		t.Fatal("launch hung past its timeout: the launch bound does not fire")
+	}
+}

--- a/session/backend_hook_reap_test.go
+++ b/session/backend_hook_reap_test.go
@@ -1,8 +1,10 @@
 package session
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -220,11 +222,91 @@ func TestHookProvisionReportsOrphanWhenDeleteFails(t *testing.T) {
 	// ...and so does the orphan warning, with everything needed to act on it.
 	assert.Contains(t, msg, "may still be running on your infrastructure")
 	assert.Contains(t, msg, p.slug, "the warning must name the orphaned sandbox's slug")
-	assert.Contains(t, msg, h.delete+" --name "+p.slug, "the warning must give the exact command to reap by hand")
+	// The command, not a hand-built string: TestHookManualReapCommandIsPasteable
+	// proves this one actually runs in a shell, which is the property that matters.
+	assert.Contains(t, msg, p.manualReapCommand(), "the warning must give the exact command to reap by hand")
+	assert.Contains(t, msg, h.delete, "the reap command must name the configured delete_cmd")
 	assert.Contains(t, msg, "the VM is still in CREATING state", "delete_cmd's own output must be surfaced")
 
 	// The resource really is still there — the message is not crying wolf.
 	assert.DirExists(t, h.sandbox(p.slug))
+}
+
+// TestHookManualReapCommandIsPasteable is the #1966 gate: the reap command we
+// print is one we are telling a user to paste into their shell while they are
+// already cleaning up a failed launch, so it must survive a delete_cmd path with
+// shell metacharacters in it.
+//
+// It asserts the EXECUTED EFFECT, not the printed string. A string assertion
+// would happily bless a command that is wrong in a shell — the unquoted form
+// looks perfectly reasonable printed, and only detonates when run.
+func TestHookManualReapCommandIsPasteable(t *testing.T) {
+	// A delete_cmd living under a path with a space AND an apostrophe: unquoted,
+	// the apostrophe opens a quote the shell never closes.
+	dir := t.TempDir()
+	hookDir := filepath.Join(dir, "sachin's hooks $PATH `x`")
+	require.NoError(t, os.MkdirAll(hookDir, 0o755))
+
+	state := filepath.Join(dir, "state")
+	target := filepath.Join(state, "sandboxes", "bills-by-the-hour")
+	bystander := filepath.Join(state, "sandboxes", "someone-elses-session")
+	for _, d := range []string{target, bystander} {
+		require.NoError(t, os.MkdirAll(d, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(d, "resource.txt"), []byte("a VM"), 0o644))
+	}
+
+	del := writeHookScript(t, filepath.Join(hookDir, "delete.sh"),
+		fmt.Sprintf(`rm -rf '%s'/sandboxes/"$name"`, state))
+
+	p := &hookProvisioner{
+		hooks: config.RemoteHooks{DeleteCmd: del},
+		spec:  ProvisionSpec{Title: "bills by the hour"},
+		slug:  Slugify("bills by the hour"),
+	}
+	cmdLine := p.manualReapCommand()
+
+	// Paste it into a real shell, exactly as a user would.
+	out, err := exec.Command("sh", "-c", cmdLine).CombinedOutput()
+	require.NoError(t, err,
+		"the command we told the user to paste does not run: %s\noutput: %s", cmdLine, out)
+
+	// It reaped exactly the target...
+	assert.NoDirExists(t, target, "the pasted command did not reap the orphan it names")
+	// ...and nothing else.
+	assert.DirExists(t, bystander, "the pasted command reaped more than the orphan it names")
+
+	// And the warning the user actually reads carries that same command.
+	assert.Contains(t, p.orphanWarning(errors.New("boom")), cmdLine)
+}
+
+// TestShellQuoteSurvivesARealShell backs the helper manualReapCommand relies on.
+// The existing TestShellQuote asserts the produced STRING; this asserts a real
+// shell round-trips the value back unchanged, which is the property that actually
+// matters and the only way to catch an idiom that merely looks right.
+func TestShellQuoteSurvivesARealShell(t *testing.T) {
+	cases := map[string]string{
+		"space":        "a b",
+		"single quote": "sachin's",
+		"double quote": `say "hi"`,
+		"dollar":       "$HOME and ${x}",
+		"backtick":     "`whoami`",
+		"newline":      "line1\nline2",
+		"everything":   "a b'c\"d $e `f` \n g; echo pwned",
+		"semicolon":    "x; echo pwned",
+		"empty":        "",
+	}
+	// Every payload above is INERT on purpose. These strings are fed to a real
+	// shell, so if shellQuote is broken the payload runs — a destructive one
+	// would make this test's failure mode worse than the bug it guards.
+	for name, raw := range cases {
+		t.Run(name, func(t *testing.T) {
+			// printf %s the quoted value: whatever the shell parses must be the
+			// literal original, byte for byte.
+			out, err := exec.Command("sh", "-c", "printf %s "+shellQuote(raw)).CombinedOutput()
+			require.NoError(t, err, "shellQuote(%q) produced a command the shell rejects: %s", raw, out)
+			assert.Equal(t, raw, string(out), "shellQuote(%q) did not survive the shell verbatim", raw)
+		})
+	}
 }
 
 // TestHookReapIsBounded proves the fix does not trade a leak for a hang. Gating


### PR DESCRIPTION
Fixes #1955.

The hook backend provisions the **user's own infrastructure** — our docs suggest a pod, a Modal sandbox, a Daytona sandbox. When `launch_cmd` created a VM and then timed out or exited non-zero, we never called `delete_cmd`. A real VM kept billing them, with no record on our side that it existed.

`Provision()` already called `reap()` on error specifically so "nothing leaks on a partial failure". The `p.launched` guard defeated it: `launched` was set only after `launch_cmd` exited 0, and `reap()` early-returned unless `launched`.

## The rule

Destruction requires positive evidence — but so does its mirror, and this was the mirror. **"It failed" cannot mean "nothing exists."** Absence of a success signal is not evidence of absence of a resource. The gate is now "did `launch_cmd` **start**", not "did it **succeed**", so forgetting is the safe direction.

This restores an invariant that used to hold: the pre-refactor code (0a6ec48) had explicit `cleanupOrphanedLaunch` calls; #1592 Phase 4 PR7 replaced them with the `launched` guard and lost the coverage. It also puts hook in line with its siblings — docker reaps whenever `containerID` is set, ssh reaps unconditionally. Hook was the outlier.

## Three things I measured that changed the fix

The naive fix is a regression. Each of these is a probe result, not a reading of the code:

**1. `*exec.Error` is the wrong discriminator** — the fix recommended in the issue would have failed case (c). Only a **bare command name** goes through `exec.LookPath` and yields `*exec.Error`. The documented `launch_cmd` is a *path* (`./.agent-factory/hooks/launch.sh`), which skips `LookPath` entirely and fails at `StartProcess` with `*fs.PathError`:

| `launch_cmd` | error type | started? |
|---|---|---|
| `af-no-such-bin` (bare name) | `*exec.Error` | no |
| `/path/launch.sh` (missing) | **`*fs.PathError`** | no |
| `/path/launch.sh` (chmod 644) | **`*fs.PathError`** | no |
| bad shebang | **`*fs.PathError`** | no |
| exits non-zero | `*exec.ExitError` | **yes** |
| killed at timeout | `*exec.ExitError` | **yes** |

So an `*exec.Error` check reads "never ran" as "ran" and fires `delete_cmd` for a typo'd path. `cmd.Process != nil` is non-nil exactly when the kernel spawned the process — the question asked directly, rather than inferred from an error taxonomy.

**2. The timeout bounded nothing, so the reap could never have run.** `CombinedOutput` waits for the output pipe to close; `exec.CommandContext` kills only the script, not its children; any child inherits that pipe and holds it open. A `launch_cmd` that provisions and then hangs blocked `Provision` **forever**, not for `hookLaunchTimeout` — my probe with a 400ms timeout never returned. `launch()` never returning means #1955's headline case could never reach the reap **no matter how it was gated**. Bounding the drain (`cmd.WaitDelay`) is a prerequisite for this fix, not scope creep — and it is required outright for `delete_cmd` by "don't trade a leak for a hang" (#1943's lesson), which matters more now that the reap runs on many more paths.

This is **not a new bound, it is a missed one**. The repo already ratified exactly this reasoning — `gitWaitDelay` (#856), `tmuxWaitDelay` (#856/#896, *"which would silently defeat the deadline above"*), `hookWaitDelay` in `git/hooks.go`, `probeWaitDelay` in `config/claude_probe.go`, and `doctor/remote.go`. The user-provided hook scripts were the last exec surface without it, and they are the likeliest of all of them to leave a child behind. `normalizeHookWaitDelay` mirrors `tmux.normalizeWaitDelay` (#676/#914) rather than inventing a parallel idiom.

**3. Bounding it naively would destroy working sandboxes.** With `WaitDelay` set, a `launch_cmd` that exits 0 with valid JSON but leaves a tunnel holding stdout returns `exec: WaitDelay expired before I/O complete` — a **non-nil error on a fully successful launch**. Treating `err != nil` as failure would have reaped a sandbox that came up fine. This is not hypothetical: our own docs tell authors the script must reach the agent-server "over a private network / tunnel it controls". Success is therefore the **exit status**, never `err == nil` — which is precisely why the existing `normalizeWaitDelay` exists, and why this one mirrors it. `TestHookProvisionSucceedsWhenLaunchLeavesOutputPipeOpen` locks it.

On the parent-context hazard called out in the issue: `reap()` already derives from `context.Background()`, so it was **not** affected — a `WithTimeout` off a cancelled parent is born expired and would never spawn `delete_cmd`. It was correct by luck rather than by comment, so it now has both a comment saying why it must stay `Background` and a test (`TestHookReapUnaffectedByCancelledCaller`) that drives the real expired-context path.

## Which children does this reap, and how does it know they are garbage?

Asked in review, because "anything still holding the pipe" is a coincidence, not a criterion. It is a fair hit: an earlier cut of this PR used `cmd.WaitDelay`, and **that is exactly the criterion it applied** — with the result that a *successful* launch's tunnel got reaped. Measured, not theorised: the endpoint came back `connection refused`.

The distinction is not bounded-vs-unbounded. It is **which children are garbage**:

| child | garbage? | who decides | what af does |
|---|---|---|---|
| the **script** (`launch_cmd`/`delete_cmd`) | when it outruns its budget | af | killed at the deadline — it is ours, we started it |
| a **failed** launch's sandbox | **yes** — nothing will ever dial it, af keeps no record | af decides *that* it must go; **the user's `delete_cmd` decides what that means** | `delete_cmd --name <slug>` |
| a **successful** launch's tunnel | **no — it is the product** | — | **nothing.** Never touched |

So the criterion is `launchStarted && provisioning failed` → ask `delete_cmd` to reap **by slug**. That is a real predicate: it names *which* resource, and it delegates *what reaping means* to the only code that knows. af never kills a sandbox itself, and never kills a process the hook backgrounded.

**How the conflation is removed rather than mitigated:** the pipe was the whole problem. `CombinedOutput` hands the script a pipe, so (a) any survivor holds it open and `Wait` blocks on EOF — the timeout bounds nothing (#1943's class, and #1967) — and (b) the cure, `WaitDelay`, kills the holder. Both are consequences of *listening on a pipe the child can inherit*.

So we stop using one. `runHookScript` gives the script a real **file** for stdout/stderr; exec hands the fd straight to the child, so there is no pipe, no copier goroutine, and nothing for a survivor to hold. Measured:

| | tunnel alive after? | hanging launch bounded? |
|---|---|---|
| `CombinedOutput` (original) | n/a | **no — hung forever** |
| `CombinedOutput` + `WaitDelay` (this PR's first cut) | **no — killed** | yes |
| **`Stdout = *os.File`** (now) | **yes** | **yes** — at the deadline, with no `WaitDelay` at all |

"Stop listening" and "kill it" stop being conflated because we never listen on a pipe: we abandon a file nobody is reading. `WaitDelay`, `hookOutputDrainGrace` and `normalizeHookWaitDelay` are all **deleted** — the bound comes back for free, because there was never anything to drain.

## A timeout reaps — the decision

**A timed-out `launch_cmd` is reaped, not merely reported.** The counter-argument is real: the resource may still be coming up, and reaping a half-built VM may itself fail. I still land on reaping:

- **Nothing can ever use it.** At the timeout we SIGKILL the script, `Provision` returns an error, and af keeps **no record** — no instance, no slug, no URL, no token. There is no future in which af dials that sandbox. "It might still be coming up" is only a reason to spare something if *someone will use it*. Nobody can. It is orphaned by construction the moment we time out; not reaping preserves a billing resource, not a usable one.
- **The slug's last remaining reader is `delete_cmd`.** It is the only handle that outlives the failure.
- **"The reap might fail" argues for reporting, not for skipping.** If `delete_cmd` fails we are exactly where report-only would have left us, minus nothing — and the user gets told, loudly.
- **The contract is already best-effort-safe.** The docs' reference `delete_cmd` is slug-deterministic and idempotent (`|| true`, `2>/dev/null`); I verified it exits 0 for a slug it has never seen. Docs now *state* this is a supported call rather than relying on it.

So: **reap, and report loudly when the reap fails** — both, not either/or.

**The residual race I can't close, documented rather than hidden:** we kill only the script, not its children. A `launch_cmd` that shelled out to `gcloud compute instances create` leaves that child running, and it may create the VM *after* `delete_cmd` has already run. No gating fixes this from the outside; it is another reason `delete_cmd` must be idempotent, and `docs/remote-hooks.md` now says so and recommends cleaning up on `EXIT`/`TERM`.

## Loudly, when cleanup also fails

`reap()`'s error was previously **discarded** at the call site and logged at warning level, so the user saw `launch_cmd failed: …` and never learned a VM leaked. The orphan warning now goes **into the returned provision error** (the create surface the user is actually looking at) *and* to `ErrorLog`:

```
A sandbox may still be running on your infrastructure — delete_cmd could not reap it, and af will not retry.
launch_cmd for session "fix auth bug" (hook name "fix-auth-bug") may have provisioned real resources (a VM, a pod, a cloud sandbox) before it failed.
Reap it by hand, then check your provider for anything still running:
    ./.agent-factory/hooks/delete.sh --name fix-auth-bug
delete_cmd error: …
```

## Docs

`docs/remote-hooks.md` gains "`delete_cmd` runs on any failed launch" and "Script timeouts": that `delete_cmd` is now called after a launch that never printed a handle and **must tolerate a slug it cannot find**; that a timeout reaps and why; that we kill only the script; and that a held-open stdout does not fail a launch.

## Tests

`session/backend_hook_reap_test.go`, all hermetic — `t.TempDir()` only, no hardcoded `/tmp/af-hook-test` as in the bot's repro, every script confined to its own temp dir, every lingering `sleep` self-reaping.

Each test was **watched failing first**, reverting one behavior at a time so each fails for the reason it exists rather than on a compile error:

| Reverted | Test | Observed failure |
|---|---|---|
| gate → exit-0 (the bug) | headline reap tests (a) hang, (b) non-zero | sandbox dir survives: "still billing the user with no record of it on our side" |
| launch drain bound | `TestHookLaunchIsBounded` | "launch hung past its timeout: the launch bound does not fire" |
| reap drain bound | `TestHookReapIsBounded` | "reap hung on a wedged delete_cmd: the delete bound does not fire" |

Under the reverted gate the three tests that *should* still pass did — the pre-existing exit-0-no-JSON coverage, the never-started case, and the working-sandbox guard — so they aren't trivially failing everything.

Coverage: (a) provisions then hangs to timeout · (b) provisions then exits non-zero · (c) cannot start, in all three spellings (missing path, non-executable, bare name) → `delete_cmd` must **not** run · (d) `delete_cmd` fails → loud actionable message naming the orphan · (e) reap is bounded · plus the expired-parent-context guard.

### The tunnel test, and a test that lied

`TestHookProvisionKeepsASuccessfulLaunchsTunnelAlive` asserts **reachability** — the endpoint working is the claim; "we sent no kill signal" would not prove it (the tunnel dies of `SIGPIPE` when our read end closes, no signal from us involved).

The first draft of it **passed against the broken code**, and that is worth recording. Its "tunnel" was an HTTP server owned by the *test process*, so reaping the backgrounded child left the endpoint reachable and the assertion sailed through. It asserted a claim it was not testing — the same shape as everything else in this PR's body.

It now stands up a **real** tunnel: a backgrounded `python3` HTTP server that serves the endpoint *and* holds the script's stdout, so it is a genuine pipe-holder and reachability genuinely depends on it surviving. Against the old capture it fails as it should:

```
Get "http://127.0.0.1:35609": connect: connection refused
the provisioned endpoint is unreachable — the launch SUCCEEDED and something
reaped the tunnel that makes it dialable
```

`TestHookLaunchDoesNotKillBackgroundedChildren` pins the mechanism separately, so a regression names its own cause rather than surfacing as a mystery connection error.

## Docs: hook authors need do nothing

`docs/remote-hooks.md` gains "Backgrounding a tunnel is supported — you need do nothing". This is an external-contributor surface, so the behaviour change is stated explicitly, and it only ever **removes** a restriction:

- **Before this PR**: a `launch_cmd` that backgrounded a process holding stdout **hung the provision** — af waited on the pipe forever and the 5-minute budget never applied.
- **Now**: af stops reading when the script exits and never touches what it left running.

Anyone who added `>/dev/null` to dodge the hang can keep it or drop it; both work. The one rule, unchanged: echo the endpoint JSON from the script before it exits, not from the background process.

## Review gate: shell-quote the manual reap command — done

The printed reap command is now built by `manualReapCommand()`, which shell-quotes every interpolated value with the existing `session.shellQuote`. No hand-rolled escaping, and no sixth copy of the helper — the repo already has **five** (`session/systemprompt.go`, `session/tmux/resume.go`, `daemon/manager_sessions.go`, `api/apicmd.go`, `config/paths.go`), and #1529 already tracks consolidating them.

Of the two interpolated values, only one was actually vulnerable:

- **`delete_cmd`** — an arbitrary user-configured path. **Was vulnerable**: a space or apostrophe produced a command that does not run.
- **`slug`** — safe by construction: written in exactly one place (`Slugify(spec.Title)`), and `Slugify` strips to `[a-z0-9-]`. Quoted anyway, so the safety lives at the print site rather than depending on a caller's charset invariant holding forever.

**Tests assert the executed effect, not the string** — as asked, because a string assertion blesses a command that is wrong in a shell:

- `TestHookManualReapCommandIsPasteable` — `delete_cmd` under ``sachin's hooks $PATH `x` ``, then **runs the printed command via `sh -c`** and asserts it reaped exactly the named orphan and left a bystander sandbox untouched.
- `TestShellQuoteSurvivesARealShell` — round-trips space, `'`, `"`, `$`, backtick, newline, `;`, and a combined payload through a real shell via `printf %s`, asserting byte-for-byte identity. (The existing `TestShellQuote` only asserted the produced string, and only covered 4 cases.) Payloads are deliberately **inert** — they get executed if the helper is broken, so a destructive one would make the test's failure mode worse than the bug.

Watched failing first: reverted to the unquoted form and the pasteable test failed with the command *printing fine and not running at all* — `/tmp/…/sachin's hooks $PATH \`x\`/delete.sh --name bills-by-the-hour`. My own earlier `TestHookProvisionReportsOrphanWhenDeleteFails` also failed on the change (it asserted the unquoted string), which is the string-assertion weakness demonstrating itself; it now asserts `manualReapCommand()`.

## Answering the question: no, it is not the only place — there are 10 others

Filed as **#1978** with the full table. The short version:

**The class was already known and fixed at exactly one site.** `daemon/manager_sessions.go:202` quotes with `shellQuoteArg`, and its comment names the hazard exactly: *"spaces or shell metacharacters must not turn a copy-pasted `af sessions restore ...` into the wrong target or a second command."* `app/handle_actions.go:688` prints **the same suggestion**, unquoted. The correct fix sits in-tree next to the broken one — the #1915 shape you flagged.

**The enabler:** titles are never validated for shell metacharacters. `toTmuxName` rewrites only `.` `:` `#` `$`, for tmux's benefit, not the shell's; backtick, `'`, `"`, `;`, `&`, `|` all survive, as its own comment concedes.

| site | command | quoted? | verdict |
|---|---|---|---|
| `daemon/manager_create.go:453` | `tmux kill-session -t %s` | NO | VULNERABLE |
| `doctor/checks.go:334` | `tmux kill-session -t '=%s:'` | in `'…'`, unescaped | VULNERABLE |
| `session/tmux/cleanup.go:90` | `tmux kill-session -t '=%s'` | in `'…'`, unescaped | VULNERABLE |
| `app/handle_actions.go:688,691,699` | `af sessions restore %s` | NO | VULNERABLE |
| `app/handle_panes.go:570,573` | `af sessions restore %s` | NO | VULNERABLE |
| `api/sessions.go:462` | `af sessions create --name %q` | `%q` = Go, not shell | VULNERABLE |
| `session/git/worktree_archive.go:178` | `git -C %q submodule absorbgitdirs` | `%q` = Go, not shell | VULNERABLE |
| `preflight/preflight.go:82` | `chmod +x %s` | NO | VULNERABLE |
| `doctor/remote.go:180` | `chmod +x %s` | NO | VULNERABLE |
| `doctor/setup.go:110` | `af config set default_program %s` | NO | VULNERABLE |
| `daemon/manager_sessions.go:202` | `af sessions restore %s` | `shellQuoteArg` | SAFE (quoted) |
| `api/apicmd.go:134` | `curl --unix-socket %s` | `shellQuoteArg` | SAFE (quoted) |

Verified by reading every line, not inferred. Checked-and-cleared: `commands/reset.go:376` (const unit name — SAFE constrained), `session/backend_docker.go:387` (docker-assigned hex id, and it logs what we already ran — NOT-PASTEABLE), `doctor/report.go`, `app/switch_project.go:231`, `commands/configcmd.go:196` (literal/prose — NOT-PASTEABLE).

**The two `%q` sites are the sharpest:** `%q` emits a *Go* double-quoted literal, and shell double-quotes still expand `$` and backticks. It looks quoted and isn't.

**Not fixed here, deliberately:** 6 packages, each needing its own test, and the `app/` sites are gated on the `play-tested` label — folding them in would make a focused 3-file leak fix unreviewable. #1978 proposes the structural remedy (one `internal/shellquote`, execute-through-a-real-shell tests, migrate all 5 helpers + 10 sites) rather than an eleventh patch.

## Adjacent call-sites

I swept every `exec.CommandContext` site for the same unbounded-drain defect. Four still lack a `WaitDelay` and their context timeouts are therefore not real bounds:

- `session/backend_docker.go:400` (`docker …`, including the `docker rm -f` reap)
- `session/backend_docker.go:440` (`git remote get-url origin`)
- `session/git/github.go:59` (`gh pr list`)
- `commands/bugreport_github.go:136` (`gh`)

**Excluded from this PR deliberately.** None of them is a leak — docker reaps by `containerID` correctly, which is the invariant #1955 is about — they are a potential *hang*, a different bug in different backends, and folding them in would make this PR unfocused. Filed separately as #1967.

## Gates

`make test-container` · `go build ./...` · `gofmt -l .` · `golangci-lint run --timeout=3m --fast` · `deadcode -test ./...` · `scripts/lint-file-length.sh` — all six clean. Hook tests also pass under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
