### PR TITLE
feat(web): choose a session's backend on create (#1933)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -586,7 +586,7 @@ func init() {
 	sessionsCreateCmd.Flags().StringVar(&createProgramFlag, "program", "", "Program to run (one of: "+tmux.SupportedProgramsString()+"; defaults to config default)")
 	sessionsCreateCmd.Flags().BoolVar(&createHereFlag, "here", false, "Run in the repo's existing working tree at its current branch (no new worktree/branch; kill preserves both)")
 	sessionsCreateCmd.Flags().BoolVar(&createInPlaceFlag, "in-place", false, "Alias for --here")
-	sessionsCreateCmd.Flags().StringVar(&createBackendFlag, "backend", "", "Runtime to run the session on (one of: "+config.BackendLocal+", "+config.BackendDocker+", "+config.BackendSSH+", "+config.BackendHook+"; defaults to the repo's backend config, or local). docker runs the session in a container (set docker.image in the repo config); ssh runs it on a remote host (set ssh.host in the repo config)")
+	sessionsCreateCmd.Flags().StringVar(&createBackendFlag, "backend", "", "Runtime to run the session on (one of: "+config.SupportedBackendsString()+"; defaults to the repo's backend config, or local). docker runs the session in a container (set docker.image in the repo config); ssh runs it on a remote host (set ssh.host in the repo config)")
 	sessionsCreateCmd.MarkFlagRequired("name")
 
 	sessionsSendPromptCmd.Flags().BoolVar(&sendPromptCreateFlag, "create", false, "Auto-create the session if it doesn't exist")

--- a/config/backend.go
+++ b/config/backend.go
@@ -1,5 +1,7 @@
 package config
 
+import "strings"
+
 // Backend selection (#1592 Phase 4 PR3). A repo declares which runtime its
 // sessions run on via the in-repo `backend` key, alongside the docker/ssh
 // sections that parameterize the two sandboxed runtimes. The canonical values
@@ -18,6 +20,27 @@ const (
 	BackendSSH    = "ssh"
 	BackendHook   = "hook"
 )
+
+// SupportedBackends is the canonical, ordered list of the backend values a user
+// may select — the backend analogue of tmux.SupportedPrograms, and the SINGLE
+// SOURCE OF TRUTH every surface renders from: the `--backend` flag help, the
+// ListBackends RPC (and through it the web's create form), and ParseBackend's
+// validation. Order is presentation order: local (the default) first, then the
+// sandboxed runtimes, then the BYO-provisioner escape hatch.
+//
+// Adding a backend means adding it here and registering its runtime; a drift
+// guard test in the session package proves this list and the runtime registry
+// hold the same set, so a backend can never be constructible-but-unofferable (or
+// offered-but-unconstructible). Every client reads the list off the daemon at
+// run time rather than hard-coding it, so a new backend reaches the web without
+// a web change (#1933).
+var SupportedBackends = []string{BackendLocal, BackendDocker, BackendSSH, BackendHook}
+
+// SupportedBackendsString returns the canonical user-facing backend enum list,
+// comma-separated — the string CLI help and error messages interpolate.
+func SupportedBackendsString() string {
+	return strings.Join(SupportedBackends, ", ")
+}
 
 // DockerConfig parameterizes the docker runtime (#1592 Phase 4 PR3 config
 // surface; the runtime that consumes it lands in PR4). A session with

--- a/config/inrepo.go
+++ b/config/inrepo.go
@@ -165,6 +165,23 @@ func InRepoTomlConfigPath(repoRoot string) string {
 	return filepath.Join(repoRoot, InRepoConfigDirName, TomlConfigFileName)
 }
 
+// InRepoConfigFileName returns the repo-relative NAME of the in-repo config file
+// a repo actually carries — ".agent-factory/config.toml" or
+// ".agent-factory/config.json" — for user-facing messages that must point the user
+// at the file a bad value came from (#1933). Since either name is valid
+// indefinitely (#1030), a message that guessed one would send half of users to a
+// file that does not exist.
+//
+// Falls back to the config.json spelling when the repo carries neither file (or
+// carries both, which LoadInRepoConfig rejects with its own message): there is no
+// file to name then, and config.json is the spelling the rest of the messages use.
+func InRepoConfigFileName(repoRoot string) string {
+	if path, err := locateInRepoConfigFile(repoRoot); err == nil && path != "" {
+		return filepath.Join(InRepoConfigDirName, filepath.Base(path))
+	}
+	return filepath.Join(InRepoConfigDirName, ConfigFileName)
+}
+
 // locateInRepoConfigFile picks the in-repo config file for a repo root:
 // config.toml or config.json, whichever exists ("" when neither does). A repo
 // carrying BOTH is a hard error rather than a precedence rule: this file

--- a/daemon/backends.go
+++ b/daemon/backends.go
@@ -1,0 +1,103 @@
+package daemon
+
+import (
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// The backend catalog RPC (#1933). The daemon has always ACCEPTED a backend on
+// create (CreateSessionRequest.Backend, the `--backend` flag), but a client had
+// no way to ask which backends exist or whether a given repo is configured for
+// one. The CLI papered over that by hard-coding the enum in its flag help; the
+// web offered no choice at all, so a remote session could only be started from
+// the TUI/CLI.
+//
+// ListBackends closes that gap by making the daemon the one place a client asks.
+// It answers from config.SupportedBackends and the repo's own config, so a
+// backend added server-side is offered by every client that renders this response
+// — no client-side enum to update, and none to drift.
+
+// ListBackendsRequest asks which runtimes a create against RepoPath may select.
+// RepoPath is the repo ROOT (or any path inside it — it is resolved the same way
+// CreateSession resolves it), and is required: availability and the default are
+// both properties of a specific repo's config, so there is no repo-less answer.
+type ListBackendsRequest struct {
+	RepoPath string `json:"repo_path"`
+}
+
+// BackendOption is one selectable runtime and whether this repo is configured for
+// it.
+//
+// Available reflects the repo CONFIG preconditions only (session.BackendConfigError):
+// docker.image, ssh.host, remote_hooks. It is a "may the user pick this without a
+// guaranteed config error" signal, NOT a promise that provisioning will succeed —
+// environment preconditions (the `docker` CLI on PATH, an `origin` remote to clone
+// from) are not knowable from config and still surface at create time. Available
+// false is therefore reliable (it WILL fail as configured); available true means
+// "not ruled out".
+type BackendOption struct {
+	// Name is the wire value: what a client sends back as CreateSessionRequest.Backend.
+	Name string `json:"name"`
+	// Available is false when this repo's config cannot satisfy the backend.
+	Available bool `json:"available"`
+	// Reason is the actionable, user-facing explanation when Available is false —
+	// the SAME text the CLI prints at create time, because both come from
+	// session.BackendConfigError. Empty when Available is true.
+	Reason string `json:"reason,omitempty"`
+}
+
+// ListBackendsResponse is the catalog for one repo.
+type ListBackendsResponse struct {
+	// Backends is every supported backend in canonical presentation order
+	// (config.SupportedBackends), available or not. Unavailable ones are included
+	// deliberately: a client that hid them would leave the user guessing why the
+	// backend they read about is missing, when the useful answer is the Reason.
+	Backends []BackendOption `json:"backends"`
+	// Default is the backend a create with NO explicit backend resolves to for this
+	// repo — the repo's `backend` config key, else local. Clients render it as the
+	// label of their "repo default" choice and must send NO backend to get it, not
+	// this value echoed back: sending it explicitly would freeze today's default
+	// into the request and silently ignore a later repo-config change.
+	Default string `json:"default"`
+}
+
+// ListBackends reports the selectable runtimes for a repo, and which backend an
+// unspecified create resolves to. It is read-only: it provisions nothing, starts
+// nothing, and touches no session state.
+func (s *controlServer) ListBackends(req ListBackendsRequest, resp *ListBackendsResponse) error {
+	repo, err := config.RepoFromPath(req.RepoPath)
+	if err != nil {
+		return err
+	}
+
+	// Resolution mirrors create's precedence exactly (session.resolveBackendKind):
+	// a config that fails to resolve is not fatal there — the create falls back to
+	// local — so it must not be fatal here either, or the web would refuse to offer
+	// a choice for a repo the CLI can still create in. A nil cfg reads as "every
+	// optional section absent", which is the honest answer for both a repo with no
+	// in-repo config and one whose config could not be read.
+	var cfg *config.ResolvedConfig
+	if resolved, rerr := config.ResolveConfig(repo.Root); rerr == nil {
+		cfg = resolved
+	}
+
+	// The default comes from the factory's own decision function rather than a
+	// reimplementation of the precedence here, so this answer cannot disagree with
+	// what a real create actually does.
+	def := string(session.BackendLocal)
+	if kind, kerr := session.BackendKindFor(session.InstanceOptions{}, repo.Root); kerr == nil {
+		def = string(kind)
+	}
+	resp.Default = def
+
+	resp.Backends = make([]BackendOption, 0, len(config.SupportedBackends))
+	for _, name := range config.SupportedBackends {
+		opt := BackendOption{Name: name, Available: true}
+		if cerr := session.BackendConfigError(session.BackendKind(name), cfg); cerr != nil {
+			opt.Available = false
+			opt.Reason = cerr.Error()
+		}
+		resp.Backends = append(resp.Backends, opt)
+	}
+	return nil
+}

--- a/daemon/backends.go
+++ b/daemon/backends.go
@@ -1,103 +1,178 @@
 package daemon
 
 import (
+	"fmt"
+
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/session"
 )
 
 // The backend catalog RPC (#1933). The daemon has always ACCEPTED a backend on
 // create (CreateSessionRequest.Backend, the `--backend` flag), but a client had
-// no way to ask which backends exist or whether a given repo is configured for
-// one. The CLI papered over that by hard-coding the enum in its flag help; the
-// web offered no choice at all, so a remote session could only be started from
-// the TUI/CLI.
+// no way to ask which backends exist or whether a given repo can actually use one.
+// The CLI papered over that by hard-coding the enum in its flag help; the web
+// offered no choice at all, so a remote session could only be started from the
+// TUI/CLI.
 //
 // ListBackends closes that gap by making the daemon the one place a client asks.
-// It answers from config.SupportedBackends and the repo's own config, so a
-// backend added server-side is offered by every client that renders this response
-// — no client-side enum to update, and none to drift.
+// It answers from config.SupportedBackends and the repo's own config + environment,
+// so a backend added server-side is offered by every client that renders this
+// response — no client-side enum to update, and none to drift.
+//
+// The contract that matters most here: a picker built from this response is a
+// PROMISE. Every entry rendered as usable tells the user "choose this and it will
+// work". So this RPC never guesses. Where it cannot verify a precondition it says
+// so, by name, rather than returning a plausible default — an unverified "sure,
+// looks fine" is how a picker becomes the bug it was meant to fix.
+
+// BackendAvailability is the three-outcome answer to "can this repo use this
+// backend?". The third value is the point: "I could not check" is a DIFFERENT
+// answer from "yes" and from "no", and collapsing it into either is how a probe
+// that cannot answer ends up answering anyway. Callers must render all three.
+type BackendAvailability string
+
+const (
+	// BackendAvailable means every precondition that can be checked without side
+	// effects was checked and passed.
+	BackendAvailable BackendAvailability = "available"
+	// BackendUnavailable means a precondition was checked and FAILED: creating on
+	// this backend would fail as the repo is configured right now. Reason says what
+	// to fix.
+	BackendUnavailable BackendAvailability = "unavailable"
+	// BackendUnknown means the preconditions could not be evaluated at all (e.g. the
+	// repo's config could not be read), so neither yes nor no is honest. Reason says
+	// what stopped the check. A client must not present this as usable.
+	BackendUnknown BackendAvailability = "unknown"
+)
 
 // ListBackendsRequest asks which runtimes a create against RepoPath may select.
-// RepoPath is the repo ROOT (or any path inside it — it is resolved the same way
+// RepoPath is the repo ROOT (or any path inside it — resolved the same way
 // CreateSession resolves it), and is required: availability and the default are
-// both properties of a specific repo's config, so there is no repo-less answer.
+// both properties of a specific repo, so there is no repo-less answer.
 type ListBackendsRequest struct {
 	RepoPath string `json:"repo_path"`
 }
 
-// BackendOption is one selectable runtime and whether this repo is configured for
-// it.
-//
-// Available reflects the repo CONFIG preconditions only (session.BackendConfigError):
-// docker.image, ssh.host, remote_hooks. It is a "may the user pick this without a
-// guaranteed config error" signal, NOT a promise that provisioning will succeed —
-// environment preconditions (the `docker` CLI on PATH, an `origin` remote to clone
-// from) are not knowable from config and still surface at create time. Available
-// false is therefore reliable (it WILL fail as configured); available true means
-// "not ruled out".
+// BackendOption is one selectable runtime and whether this repo can use it.
 type BackendOption struct {
 	// Name is the wire value: what a client sends back as CreateSessionRequest.Backend.
 	Name string `json:"name"`
-	// Available is false when this repo's config cannot satisfy the backend.
-	Available bool `json:"available"`
-	// Reason is the actionable, user-facing explanation when Available is false —
-	// the SAME text the CLI prints at create time, because both come from
-	// session.BackendConfigError. Empty when Available is true.
+	// Status is the checked answer; see BackendAvailability.
+	Status BackendAvailability `json:"status"`
+	// Reason is the actionable, user-facing explanation whenever Status is not
+	// available — the SAME text the CLI prints at create time, because both come
+	// from the session package's precondition checks. It names what to fix ("set
+	// docker.image in …"), never merely "unavailable". Empty when available.
 	Reason string `json:"reason,omitempty"`
 }
 
 // ListBackendsResponse is the catalog for one repo.
 type ListBackendsResponse struct {
 	// Backends is every supported backend in canonical presentation order
-	// (config.SupportedBackends), available or not. Unavailable ones are included
-	// deliberately: a client that hid them would leave the user guessing why the
-	// backend they read about is missing, when the useful answer is the Reason.
+	// (config.SupportedBackends). Unusable ones are included deliberately: a client
+	// that hid them would leave the user guessing why the backend they read about is
+	// missing, when the useful answer is the Reason.
 	Backends []BackendOption `json:"backends"`
 	// Default is the backend a create with NO explicit backend resolves to for this
-	// repo — the repo's `backend` config key, else local. Clients render it as the
-	// label of their "repo default" choice and must send NO backend to get it, not
-	// this value echoed back: sending it explicitly would freeze today's default
-	// into the request and silently ignore a later repo-config change.
+	// repo. Clients render it as the label of their "repo default" choice and must
+	// send NO backend to get it, not this value echoed back: sending it explicitly
+	// would freeze today's default into the request and ignore a later config change.
+	//
+	// EMPTY when the repo's `backend` key names something unrecognized — there is no
+	// default to report then, because such a create does not fall back to local, it
+	// FAILS (session.resolveBackendKind: "misconfiguration should fail the create,
+	// not silently run local"). DefaultStatus/DefaultReason carry the misconfiguration.
 	Default string `json:"default"`
+	// DefaultStatus is the checked answer for the repo-default choice itself, so a
+	// client can block a default it knows will fail instead of discovering it at
+	// create time.
+	DefaultStatus BackendAvailability `json:"default_status"`
+	// DefaultReason explains a DefaultStatus that is not available, naming the
+	// offending value and the file it is in.
+	DefaultReason string `json:"default_reason,omitempty"`
 }
 
 // ListBackends reports the selectable runtimes for a repo, and which backend an
 // unspecified create resolves to. It is read-only: it provisions nothing, starts
-// nothing, and touches no session state.
+// nothing, dials nothing, and touches no session state.
 func (s *controlServer) ListBackends(req ListBackendsRequest, resp *ListBackendsResponse) error {
 	repo, err := config.RepoFromPath(req.RepoPath)
 	if err != nil {
 		return err
 	}
 
-	// Resolution mirrors create's precedence exactly (session.resolveBackendKind):
-	// a config that fails to resolve is not fatal there — the create falls back to
-	// local — so it must not be fatal here either, or the web would refuse to offer
-	// a choice for a repo the CLI can still create in. A nil cfg reads as "every
-	// optional section absent", which is the honest answer for both a repo with no
-	// in-repo config and one whose config could not be read.
-	var cfg *config.ResolvedConfig
-	if resolved, rerr := config.ResolveConfig(repo.Root); rerr == nil {
-		cfg = resolved
-	}
-
-	// The default comes from the factory's own decision function rather than a
-	// reimplementation of the precedence here, so this answer cannot disagree with
-	// what a real create actually does.
-	def := string(session.BackendLocal)
-	if kind, kerr := session.BackendKindFor(session.InstanceOptions{}, repo.Root); kerr == nil {
-		def = string(kind)
-	}
-	resp.Default = def
-
+	cfg, cfgErr := config.ResolveConfig(repo.Root)
 	resp.Backends = make([]BackendOption, 0, len(config.SupportedBackends))
 	for _, name := range config.SupportedBackends {
-		opt := BackendOption{Name: name, Available: true}
-		if cerr := session.BackendConfigError(session.BackendKind(name), cfg); cerr != nil {
-			opt.Available = false
-			opt.Reason = cerr.Error()
-		}
-		resp.Backends = append(resp.Backends, opt)
+		resp.Backends = append(resp.Backends, backendOptionFor(session.BackendKind(name), cfg, cfgErr, repo.Root))
 	}
+	resp.Default, resp.DefaultStatus, resp.DefaultReason = defaultFor(resp.Backends, cfg, cfgErr, repo.Root)
 	return nil
+}
+
+// backendOptionFor answers for ONE backend, honestly.
+//
+// The unreadable-config case is why Status is a tri-state. Reporting "docker
+// requires docker.image" for a repo whose config we could not parse would be a
+// fabricated finding: docker.image might be set perfectly well in a file with a
+// stray comma elsewhere. The user needs to hear about the comma.
+func backendOptionFor(kind session.BackendKind, cfg *config.ResolvedConfig, cfgErr error, repoRoot string) BackendOption {
+	opt := BackendOption{Name: string(kind)}
+
+	if cfgErr != nil {
+		// local is the one backend that reads nothing from the repo config, so an
+		// unreadable config genuinely does not affect it — and a create with no
+		// explicit backend still runs local (resolveBackendKind falls back on a
+		// config-resolve failure). Saying "unknown" for it would be its own lie.
+		if kind == session.BackendLocal {
+			opt.Status = BackendAvailable
+			return opt
+		}
+		opt.Status = BackendUnknown
+		opt.Reason = fmt.Sprintf("cannot tell whether this repo can use backend=%s: its %s could not be read (%v). Fix that file, then reopen this form.", kind, config.InRepoConfigFileName(repoRoot), cfgErr)
+		return opt
+	}
+
+	if reason := session.BackendUnusableReason(kind, cfg, repoRoot); reason != nil {
+		opt.Status = BackendUnavailable
+		opt.Reason = reason.Error()
+		return opt
+	}
+	opt.Status = BackendAvailable
+	return opt
+}
+
+// defaultFor reports the backend an unspecified create resolves to, and whether
+// THAT is usable.
+//
+// It asks the factory's own decision function rather than reimplementing the
+// precedence, so this answer cannot disagree with what a real create does — and
+// crucially it propagates the function's ERROR instead of swallowing it. An
+// invalid `backend` value makes a create fail; a catalog that answered "local"
+// there would tell a user with a broken config that everything is normal, and
+// their sessions would land on a backend they never chose.
+func defaultFor(backends []BackendOption, cfg *config.ResolvedConfig, cfgErr error, repoRoot string) (string, BackendAvailability, string) {
+	kind, kerr := session.BackendKindFor(session.InstanceOptions{}, repoRoot)
+	if kerr != nil {
+		// Reached only when the config LOADED and named a backend we do not
+		// recognize (BackendKindFor falls back to local on a resolve failure). Name
+		// the value and the file — "unknown backend" alone leaves the user hunting.
+		raw := ""
+		if cfgErr == nil && cfg != nil {
+			raw = cfg.Backend
+		}
+		return "", BackendUnavailable, fmt.Sprintf("this repo's %s sets backend = %q, which is not a known backend (valid: %s). A session created here fails rather than falling back to local — fix that key, or pick a backend above.", config.InRepoConfigFileName(repoRoot), raw, config.SupportedBackendsString())
+	}
+
+	// The default's usability IS the resolved backend's usability; reuse the answer
+	// already computed for it rather than re-deriving one that could disagree.
+	for _, opt := range backends {
+		if opt.Name == string(kind) {
+			return string(kind), opt.Status, opt.Reason
+		}
+	}
+	// A registered backend missing from the catalog would be an enum/registry drift
+	// the session package's guard test exists to prevent; say so rather than
+	// claiming it is fine.
+	return string(kind), BackendUnknown, fmt.Sprintf("this repo defaults to backend=%s, which is not in the supported list (%s)", kind, config.SupportedBackendsString())
 }

--- a/daemon/backends_test.go
+++ b/daemon/backends_test.go
@@ -1,0 +1,180 @@
+package daemon
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// ListBackends is a pure read: it resolves a repo's config and answers from the
+// backend enum, never touching the manager or provisioning anything. A zero
+// controlServer is therefore the whole fixture — no daemon, no tmux, no sessions.
+func listBackends(t *testing.T, repoPath string) ListBackendsResponse {
+	t.Helper()
+	var resp ListBackendsResponse
+	require.NoError(t, (&controlServer{}).ListBackends(ListBackendsRequest{RepoPath: repoPath}, &resp))
+	return resp
+}
+
+// writeRepoBackendConfig writes an in-repo .agent-factory/config.json carrying the
+// given keys — the file a user edits to opt a repo into docker/ssh/hook.
+func writeRepoBackendConfig(t *testing.T, repoRoot string, cfg map[string]any) {
+	t.Helper()
+	dir := filepath.Join(repoRoot, config.InRepoConfigDirName)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	blob, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.json"), blob, 0o644))
+}
+
+func optionByName(t *testing.T, resp ListBackendsResponse, name string) BackendOption {
+	t.Helper()
+	for _, opt := range resp.Backends {
+		if opt.Name == name {
+			return opt
+		}
+	}
+	t.Fatalf("backend %q missing from the catalog %+v", name, resp.Backends)
+	return BackendOption{}
+}
+
+// TestListBackends_OffersEverySupportedBackend is the core of #1933: the daemon —
+// not a hand-typed list in a client — decides what a create may select. A repo
+// with no in-repo config gets the whole enum in canonical order, with local usable
+// and the config-gated runtimes reported unavailable rather than hidden.
+func TestListBackends_OffersEverySupportedBackend(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repo := setupControlRepo(t)
+
+	resp := listBackends(t, repo)
+
+	names := make([]string, 0, len(resp.Backends))
+	for _, opt := range resp.Backends {
+		names = append(names, opt.Name)
+	}
+	assert.Equal(t, config.SupportedBackends, names, "the catalog is the canonical enum, in canonical order")
+
+	assert.True(t, optionByName(t, resp, config.BackendLocal).Available, "local needs no repo config")
+	assert.Empty(t, optionByName(t, resp, config.BackendLocal).Reason)
+
+	// Unavailable, but present and explained — a client that hid these would leave
+	// the user wondering where docker went; the useful answer is the reason.
+	for _, name := range []string{config.BackendDocker, config.BackendSSH, config.BackendHook} {
+		opt := optionByName(t, resp, name)
+		assert.Falsef(t, opt.Available, "%s is unconfigured in this repo and must not be offered as usable", name)
+		assert.NotEmptyf(t, opt.Reason, "%s must carry an actionable reason, not just a disabled flag", name)
+	}
+	assert.Contains(t, optionByName(t, resp, config.BackendDocker).Reason, "docker.image")
+	assert.Contains(t, optionByName(t, resp, config.BackendSSH).Reason, "ssh.host")
+}
+
+// TestListBackends_ReflectsRepoConfig proves the availability answer tracks the
+// repo's actual config: set docker.image and ssh.host, and both become selectable
+// with no reason to show.
+func TestListBackends_ReflectsRepoConfig(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repo := setupControlRepo(t)
+	writeRepoBackendConfig(t, repo, map[string]any{
+		"docker": map[string]any{"image": "my-runtime:latest"},
+		"ssh":    map[string]any{"host": "build-box:2222"},
+	})
+
+	resp := listBackends(t, repo)
+
+	for _, name := range []string{config.BackendLocal, config.BackendDocker, config.BackendSSH} {
+		opt := optionByName(t, resp, name)
+		assert.Truef(t, opt.Available, "%s is configured in this repo and must be selectable", name)
+		assert.Emptyf(t, opt.Reason, "%s is available, so there is nothing to explain", name)
+	}
+	// hook was not configured, so it stays unavailable — availability is per
+	// backend, not a single "repo is configured" flag.
+	assert.False(t, optionByName(t, resp, config.BackendHook).Available)
+}
+
+// TestListBackends_DefaultMatchesTheCreatePath pins the contract the web relies on
+// to avoid overriding a repo default: Default reports what a create with NO
+// explicit backend resolves to. The web renders it as a label and sends nothing.
+func TestListBackends_DefaultMatchesTheCreatePath(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	t.Run("no repo config defaults to local", func(t *testing.T) {
+		repo := setupControlRepo(t)
+		assert.Equal(t, config.BackendLocal, listBackends(t, repo).Default)
+	})
+
+	t.Run("repo backend config is the default", func(t *testing.T) {
+		repo := setupControlRepo(t)
+		writeRepoBackendConfig(t, repo, map[string]any{
+			"backend": "docker",
+			"docker":  map[string]any{"image": "my-runtime:latest"},
+		})
+
+		resp := listBackends(t, repo)
+		assert.Equal(t, config.BackendDocker, resp.Default, "a repo that declares backend=docker defaults to docker")
+
+		// The same decision function the real create path uses must agree — this is
+		// the whole point of reporting a default rather than assuming local.
+		kind, err := session.BackendKindFor(session.InstanceOptions{}, repo)
+		require.NoError(t, err)
+		assert.Equal(t, string(kind), resp.Default, "the reported default must be the backend a real create would pick")
+	})
+
+	t.Run("a default whose config is broken is still reported, with its reason", func(t *testing.T) {
+		// backend=docker declared but docker.image missing. The default is honestly
+		// "docker" (that IS what a create resolves to) AND docker is unavailable, so
+		// a client can warn instead of silently offering a default that cannot run.
+		repo := setupControlRepo(t)
+		writeRepoBackendConfig(t, repo, map[string]any{"backend": "docker"})
+
+		resp := listBackends(t, repo)
+		assert.Equal(t, config.BackendDocker, resp.Default)
+		assert.False(t, optionByName(t, resp, config.BackendDocker).Available)
+		assert.Contains(t, optionByName(t, resp, config.BackendDocker).Reason, "docker.image")
+	})
+}
+
+// TestListBackends_NewBackendReachesClientsWithNoClientChange is THE anti-drift
+// test for #1933 (the daemon half; web/src/backends.test.ts is the other half).
+//
+// It registers a backend the way a real one is added — a runtime in the registry
+// plus an entry in the canonical enum — and asserts it flows out of the RPC with
+// no edit to this handler and, crucially, none to any client. If someone later
+// reintroduces a hard-coded list inside ListBackends, this fails.
+func TestListBackends_NewBackendReachesClientsWithNoClientChange(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repo := setupControlRepo(t)
+
+	require.NotContains(t, config.SupportedBackends, "fargate", "precondition: the fake backend must not already exist")
+
+	restoreRuntime := session.SetRuntimeForTest(session.BackendKind("fargate"), func() session.Runtime { return nil })
+	t.Cleanup(restoreRuntime)
+
+	prev := config.SupportedBackends
+	config.SupportedBackends = append(append([]string{}, prev...), "fargate")
+	t.Cleanup(func() { config.SupportedBackends = prev })
+
+	resp := listBackends(t, repo)
+
+	opt := optionByName(t, resp, "fargate")
+	assert.True(t, opt.Available, "a backend with no repo-config requirement is selectable as soon as it is registered")
+	assert.Empty(t, opt.Reason)
+	assert.Equal(t, "fargate", resp.Backends[len(resp.Backends)-1].Name, "it lands in enum order, not appended by a special case")
+}
+
+// TestListBackends_RequiresARepo: availability and the default are both properties
+// of a specific repo, so a path that is not a repo is an error rather than a
+// silently local-only catalog.
+func TestListBackends_RequiresARepo(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	var resp ListBackendsResponse
+	err := (&controlServer{}).ListBackends(ListBackendsRequest{RepoPath: t.TempDir()}, &resp)
+	assert.Error(t, err, "a non-repo path cannot answer which backends its sessions may use")
+}

--- a/daemon/backends_test.go
+++ b/daemon/backends_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -21,6 +22,21 @@ func listBackends(t *testing.T, repoPath string) ListBackendsResponse {
 	var resp ListBackendsResponse
 	require.NoError(t, (&controlServer{}).ListBackends(ListBackendsRequest{RepoPath: repoPath}, &resp))
 	return resp
+}
+
+// addOrigin gives a repo an `origin` remote. docker/ssh clone the workspace from
+// origin, so a repo without one genuinely cannot use them — tests that expect those
+// backends to be usable must look like a real repo.
+func addOrigin(t *testing.T, repoRoot string) {
+	t.Helper()
+	require.NoError(t, exec.Command("git", "-C", repoRoot, "remote", "add", "origin", "https://example.invalid/repo.git").Run())
+}
+
+// stubLookPath makes every executable resolve, so a test's expectations do not
+// depend on whether the CI image happens to ship a `docker` binary.
+func stubLookPath(t *testing.T) {
+	t.Helper()
+	t.Cleanup(session.SetLookPathForTest(func(file string) (string, error) { return "/usr/bin/" + file, nil }))
 }
 
 // writeRepoBackendConfig writes an in-repo .agent-factory/config.json carrying the
@@ -61,15 +77,15 @@ func TestListBackends_OffersEverySupportedBackend(t *testing.T) {
 	}
 	assert.Equal(t, config.SupportedBackends, names, "the catalog is the canonical enum, in canonical order")
 
-	assert.True(t, optionByName(t, resp, config.BackendLocal).Available, "local needs no repo config")
+	assert.Equal(t, BackendAvailable, optionByName(t, resp, config.BackendLocal).Status, "local needs no repo config")
 	assert.Empty(t, optionByName(t, resp, config.BackendLocal).Reason)
 
 	// Unavailable, but present and explained — a client that hid these would leave
 	// the user wondering where docker went; the useful answer is the reason.
 	for _, name := range []string{config.BackendDocker, config.BackendSSH, config.BackendHook} {
 		opt := optionByName(t, resp, name)
-		assert.Falsef(t, opt.Available, "%s is unconfigured in this repo and must not be offered as usable", name)
-		assert.NotEmptyf(t, opt.Reason, "%s must carry an actionable reason, not just a disabled flag", name)
+		assert.Equalf(t, BackendUnavailable, opt.Status, "%s is unconfigured in this repo and must not be offered as usable", name)
+		assert.NotEmptyf(t, opt.Reason, "%s must carry an actionable reason, not just a status", name)
 	}
 	assert.Contains(t, optionByName(t, resp, config.BackendDocker).Reason, "docker.image")
 	assert.Contains(t, optionByName(t, resp, config.BackendSSH).Reason, "ssh.host")
@@ -80,7 +96,9 @@ func TestListBackends_OffersEverySupportedBackend(t *testing.T) {
 // with no reason to show.
 func TestListBackends_ReflectsRepoConfig(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	stubLookPath(t)
 	repo := setupControlRepo(t)
+	addOrigin(t, repo)
 	writeRepoBackendConfig(t, repo, map[string]any{
 		"docker": map[string]any{"image": "my-runtime:latest"},
 		"ssh":    map[string]any{"host": "build-box:2222"},
@@ -90,12 +108,12 @@ func TestListBackends_ReflectsRepoConfig(t *testing.T) {
 
 	for _, name := range []string{config.BackendLocal, config.BackendDocker, config.BackendSSH} {
 		opt := optionByName(t, resp, name)
-		assert.Truef(t, opt.Available, "%s is configured in this repo and must be selectable", name)
+		assert.Equalf(t, BackendAvailable, opt.Status, "%s is configured in this repo and must be selectable", name)
 		assert.Emptyf(t, opt.Reason, "%s is available, so there is nothing to explain", name)
 	}
 	// hook was not configured, so it stays unavailable — availability is per
 	// backend, not a single "repo is configured" flag.
-	assert.False(t, optionByName(t, resp, config.BackendHook).Available)
+	assert.Equal(t, BackendUnavailable, optionByName(t, resp, config.BackendHook).Status)
 }
 
 // TestListBackends_DefaultMatchesTheCreatePath pins the contract the web relies on
@@ -110,7 +128,9 @@ func TestListBackends_DefaultMatchesTheCreatePath(t *testing.T) {
 	})
 
 	t.Run("repo backend config is the default", func(t *testing.T) {
+		stubLookPath(t)
 		repo := setupControlRepo(t)
+		addOrigin(t, repo)
 		writeRepoBackendConfig(t, repo, map[string]any{
 			"backend": "docker",
 			"docker":  map[string]any{"image": "my-runtime:latest"},
@@ -135,9 +155,128 @@ func TestListBackends_DefaultMatchesTheCreatePath(t *testing.T) {
 
 		resp := listBackends(t, repo)
 		assert.Equal(t, config.BackendDocker, resp.Default)
-		assert.False(t, optionByName(t, resp, config.BackendDocker).Available)
+		assert.Equal(t, BackendUnavailable, optionByName(t, resp, config.BackendDocker).Status)
 		assert.Contains(t, optionByName(t, resp, config.BackendDocker).Reason, "docker.image")
+		// The DEFAULT itself must carry the problem, not just the docker row: a client
+		// renders the default as its own choice and would otherwise show it as fine.
+		assert.Equal(t, BackendUnavailable, resp.DefaultStatus)
+		assert.Contains(t, resp.DefaultReason, "docker.image")
 	})
+}
+
+// TestListBackends_InvalidConfiguredDefaultIsSurfaced is the regression for the
+// review's finding 1, and the sharpest form of "a probe that cannot answer,
+// answering anyway".
+//
+// A repo whose `backend` key names something unrecognized has NO default: such a
+// create fails outright (session.resolveBackendKind: "misconfiguration should fail
+// the create, not silently run local"). Reporting "local" there told a user with a
+// broken config that everything was normal — and implied their sessions would land
+// on local, a backend they never chose.
+func TestListBackends_InvalidConfiguredDefaultIsSurfaced(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repo := setupControlRepo(t)
+	writeRepoBackendConfig(t, repo, map[string]any{"backend": "bogus"})
+
+	resp := listBackends(t, repo)
+
+	assert.NotEqual(t, config.BackendLocal, resp.Default, "reporting local here is a lie: this create fails, it does not fall back to local")
+	assert.Empty(t, resp.Default, "there is no default to name when the configured one is not a backend")
+	assert.Equal(t, BackendUnavailable, resp.DefaultStatus)
+	assert.Contains(t, resp.DefaultReason, `"bogus"`, "name the offending value — 'unknown backend' alone leaves the user hunting")
+	assert.Contains(t, resp.DefaultReason, config.InRepoConfigDirName, "name the file the bad value is in")
+	assert.Contains(t, resp.DefaultReason, config.SupportedBackendsString(), "and say what the valid values are")
+
+	// The real create must agree that this is broken — otherwise the catalog is
+	// pessimistic rather than honest.
+	_, err := session.BackendKindFor(session.InstanceOptions{}, repo)
+	assert.Error(t, err, "precondition: a create with no explicit backend genuinely fails for this repo")
+}
+
+// TestListBackends_HookNeedsRunnableCommands is the regression for finding 2:
+// availability must mean "I checked", not "it is configured". A hook whose command
+// does not exist is the worst case in this class — the section IS present, so a
+// config-only check calls it available, the user picks it, and the failure lands
+// later, mid-provision, looking like something else.
+func TestListBackends_HookNeedsRunnableCommands(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repo := setupControlRepo(t)
+	writeRepoBackendConfig(t, repo, map[string]any{
+		"remote_hooks": map[string]any{
+			"launch_cmd": "af-definitely-not-installed-launch",
+			"delete_cmd": "af-definitely-not-installed-delete",
+		},
+	})
+
+	resp := listBackends(t, repo)
+	opt := optionByName(t, resp, config.BackendHook)
+
+	assert.Equal(t, BackendUnavailable, opt.Status, "remote_hooks is fully configured, but the command does not exist — offering it would be a promise we cannot keep")
+	assert.Contains(t, opt.Reason, "af-definitely-not-installed-launch", "name the command that is missing")
+	assert.Contains(t, opt.Reason, "PATH", "and say why it could not be used, so the user can act")
+}
+
+// TestListBackends_HookAvailableWhenCommandsResolve is the other half: a hook whose
+// commands DO resolve is offered. Without this, "always unavailable" would pass the
+// test above.
+func TestListBackends_HookAvailableWhenCommandsResolve(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	stubLookPath(t)
+	repo := setupControlRepo(t)
+	writeRepoBackendConfig(t, repo, map[string]any{
+		"remote_hooks": map[string]any{"launch_cmd": "af-launch", "delete_cmd": "af-delete"},
+	})
+
+	opt := optionByName(t, listBackends(t, repo), config.BackendHook)
+	assert.Equal(t, BackendAvailable, opt.Status)
+	assert.Empty(t, opt.Reason)
+}
+
+// TestListBackends_EmptyHookCommandIsNotAvailable: remote_hooks present but
+// launch_cmd empty. RemoteHooks.Validate is what create runs, so reusing it here is
+// what stops "configured" from ever again meaning merely "the section exists".
+func TestListBackends_EmptyHookCommandIsNotAvailable(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	stubLookPath(t)
+	repo := setupControlRepo(t)
+	writeRepoBackendConfig(t, repo, map[string]any{
+		"remote_hooks": map[string]any{"launch_cmd": "", "delete_cmd": "af-delete"},
+	})
+
+	opt := optionByName(t, listBackends(t, repo), config.BackendHook)
+	assert.Equal(t, BackendUnavailable, opt.Status)
+	assert.Contains(t, opt.Reason, "launch_cmd")
+}
+
+// TestListBackends_UnreadableConfigIsUnknownNotUnavailable pins the third outcome.
+//
+// A config that will not parse means we cannot tell whether docker.image is set —
+// docker.image might be perfectly fine, in a file with a stray comma elsewhere.
+// Answering "requires docker.image" there would be a fabricated finding pointing at
+// the wrong line; answering "available" would be a promise nobody checked. The only
+// honest answer is "I could not check, and here is what stopped me".
+func TestListBackends_UnreadableConfigIsUnknownNotUnavailable(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repo := setupControlRepo(t)
+	dir := filepath.Join(repo, config.InRepoConfigDirName)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.json"), []byte("{ this is not json"), 0o644))
+
+	resp := listBackends(t, repo)
+
+	for _, name := range []string{config.BackendDocker, config.BackendSSH, config.BackendHook} {
+		opt := optionByName(t, resp, name)
+		assert.Equalf(t, BackendUnknown, opt.Status, "%s cannot be evaluated against a config that will not parse", name)
+		assert.NotContainsf(t, opt.Reason, "requires", "%s must not invent a missing-key finding it never checked for", name)
+		assert.NotEmptyf(t, opt.Reason, "%s must say what stopped the check", name)
+	}
+
+	// local reads no repo config, and a create with no explicit backend still runs
+	// local through this failure — so calling it unknown would be its own lie, and
+	// the user can still create a session while they fix the file.
+	assert.Equal(t, BackendAvailable, optionByName(t, resp, config.BackendLocal).Status)
+	assert.Equal(t, config.BackendLocal, resp.Default)
+	assert.Equal(t, BackendAvailable, resp.DefaultStatus)
 }
 
 // TestListBackends_NewBackendReachesClientsWithNoClientChange is THE anti-drift
@@ -163,7 +302,7 @@ func TestListBackends_NewBackendReachesClientsWithNoClientChange(t *testing.T) {
 	resp := listBackends(t, repo)
 
 	opt := optionByName(t, resp, "fargate")
-	assert.True(t, opt.Available, "a backend with no repo-config requirement is selectable as soon as it is registered")
+	assert.Equal(t, BackendAvailable, opt.Status, "a backend with no repo-config requirement is selectable as soon as it is registered")
 	assert.Empty(t, opt.Reason)
 	assert.Equal(t, "fargate", resp.Backends[len(resp.Backends)-1].Name, "it lands in enum order, not appended by a special case")
 }

--- a/daemon/httproutes.go
+++ b/daemon/httproutes.go
@@ -60,6 +60,13 @@ var httpRoutes = []HTTPRoute{
 	},
 	{
 		Method:        http.MethodPost,
+		Path:          "/v1/ListBackends",
+		Description:   "List the runtimes a session in this repo can be created on, whether the repo's config supports each, and the backend an unspecified create defaults to.",
+		RequestFields: jsonFields(reflect.TypeOf(ListBackendsRequest{})),
+		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.ListBackends) },
+	},
+	{
+		Method:        http.MethodPost,
 		Path:          "/v1/Snapshot",
 		Description:   "List sessions from the daemon's authoritative in-memory state (empty repo_id = all repos).",
 		RequestFields: jsonFields(reflect.TypeOf(SnapshotRequest{})),

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -14,6 +14,7 @@ Request fields are the JSON keys of each route's request body; a `—` means the
 |--------|------|----------------|-------------|
 | `GET` | `/v1/health` | — | Liveness probe (alias for the Ping RPC); answers even while the daemon is restoring sessions. |
 | `POST` | `/v1/CreateSession` | `title`, `title_base`, `repo_path`, `program`, `prompt`, `auto_yes`, `in_place`, `force_remote`, `backend` | Create a new session (git worktree + agent) in a repo. |
+| `POST` | `/v1/ListBackends` | `repo_path` | List the runtimes a session in this repo can be created on, whether the repo's config supports each, and the backend an unspecified create defaults to. |
 | `POST` | `/v1/Snapshot` | `repo_id` | List sessions from the daemon's authoritative in-memory state (empty repo_id = all repos). |
 | `POST` | `/v1/KillSession` | `title`, `repo_id`, `id` | Tear down a session: kill its tmux/agent and remove its worktree and record. |
 | `POST` | `/v1/ArchiveSession` | `title`, `repo_id`, `id` | Archive a session: tear down tmux and relocate its worktree to the archive dir, keeping the record. |

--- a/session/backend_catalog_test.go
+++ b/session/backend_catalog_test.go
@@ -1,0 +1,138 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+// TestSupportedBackendsMatchesRuntimeRegistry is the drift guard behind #1933's
+// "render the choices from what the daemon actually supports" contract. Two lists
+// describe backends: config.SupportedBackends (what clients may OFFER) and
+// runtimeRegistry (what the daemon can actually CONSTRUCT). Nothing in the type
+// system ties them together, so this test does.
+//
+// Both directions are failures, and each is a real bug a contributor would
+// otherwise ship silently:
+//   - registered but not supported → a working backend the CLI's `--backend` help
+//     omits and no client ever offers. That is precisely bug #1933, one backend
+//     down.
+//   - supported but not registered → every client offers a choice that fails at
+//     create time with "unknown backend".
+//
+// Adding a backend means touching both lists; this test is what tells you the
+// second one exists.
+func TestSupportedBackendsMatchesRuntimeRegistry(t *testing.T) {
+	registered := make(map[string]bool, len(runtimeRegistry))
+	for kind := range runtimeRegistry {
+		registered[string(kind)] = true
+	}
+
+	supported := make(map[string]bool, len(config.SupportedBackends))
+	for _, name := range config.SupportedBackends {
+		supported[name] = true
+		assert.Truef(t, registered[name], "backend %q is in config.SupportedBackends but has no runtime registered: every client will offer it and every create will fail with \"unknown backend\" — register a runtime in runtimeRegistry or drop it from the enum", name)
+	}
+
+	for kind := range runtimeRegistry {
+		assert.Truef(t, supported[string(kind)], "runtime %q is registered but missing from config.SupportedBackends: it works, but the --backend help omits it and no client (web included) will ever offer it — add it to the enum (#1933)", kind)
+	}
+
+	assert.Len(t, config.SupportedBackends, len(runtimeRegistry), "the backend enum and the runtime registry must describe the same set")
+}
+
+// TestSupportedBackendsAreParseable pins the third list that used to hand-repeat
+// the enum: ParseBackendKind. Every offered backend must parse, or a client would
+// faithfully render a choice the create path then rejects.
+func TestSupportedBackendsAreParseable(t *testing.T) {
+	for _, name := range config.SupportedBackends {
+		kind, err := ParseBackendKind(name)
+		require.NoErrorf(t, err, "backend %q is offered to users but ParseBackendKind rejects it", name)
+		assert.Equal(t, BackendKind(name), kind)
+	}
+
+	// The empty value is the "no explicit choice" signal every client sends to get
+	// the repo default — it must stay parseable and must NOT be a backend name.
+	kind, err := ParseBackendKind("")
+	require.NoError(t, err)
+	assert.Equal(t, BackendLocal, kind)
+}
+
+// TestBackendConfigError_ReportsRepoConfigRequirements covers the choose-time
+// answer #1933 needs: which backends a repo's config can actually satisfy, and an
+// actionable reason naming the missing key for those it cannot.
+func TestBackendConfigError_ReportsRepoConfigRequirements(t *testing.T) {
+	t.Run("nil config leaves only local usable", func(t *testing.T) {
+		assert.NoError(t, BackendConfigError(BackendLocal, nil), "local needs nothing from the repo config")
+
+		for _, tc := range []struct {
+			kind BackendKind
+			key  string
+		}{
+			{BackendDocker, "docker.image"},
+			{BackendSSH, "ssh.host"},
+			{BackendHook, "remote_hooks"},
+		} {
+			err := BackendConfigError(tc.kind, nil)
+			require.Errorf(t, err, "%s must report its unmet config requirement", tc.kind)
+			assert.Containsf(t, err.Error(), tc.key, "the %s reason must name the missing key so the message is actionable", tc.kind)
+		}
+	})
+
+	t.Run("configured backends report no error", func(t *testing.T) {
+		cfg := &config.ResolvedConfig{
+			Docker:      &config.DockerConfig{Image: "my-runtime:latest"},
+			SSH:         &config.SSHConfig{Host: "build-box"},
+			RemoteHooks: &config.RemoteHooks{},
+		}
+		assert.NoError(t, BackendConfigError(BackendDocker, cfg))
+		assert.NoError(t, BackendConfigError(BackendSSH, cfg))
+		assert.NoError(t, BackendConfigError(BackendHook, cfg))
+	})
+
+	t.Run("present but blank counts as unset", func(t *testing.T) {
+		// A `docker = {}` / `ssh = { host = "  " }` section is the shape a user lands
+		// on mid-setup. It must read as unset, not as configured-with-empty, or the
+		// web would offer the backend and the create would fail anyway.
+		cfg := &config.ResolvedConfig{
+			Docker: &config.DockerConfig{Image: "   "},
+			SSH:    &config.SSHConfig{Host: ""},
+		}
+		assert.Error(t, BackendConfigError(BackendDocker, cfg))
+		assert.Error(t, BackendConfigError(BackendSSH, cfg))
+	})
+}
+
+// TestBackendConfigError_IsTheMessageProvisionPrints is the anti-drift link for
+// the REASON text. #1933 asks the web to state a missing-config requirement at
+// choose time instead of letting the user discover it as a create failure — which
+// is only an improvement if both surfaces say the same thing.
+//
+// Asserting equality (not "contains") is deliberate: it fails the moment someone
+// reworded one path, which is exactly when the two would start disagreeing.
+func TestBackendConfigError_IsTheMessageProvisionPrints(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	t.Run("docker", func(t *testing.T) {
+		repo := initTempGitRepo(t)
+		writeInRepoConfig(t, repo, map[string]any{"backend": "docker", "docker": map[string]any{}})
+
+		_, err := dockerRuntime{}.Provision(ProvisionSpec{RepoRoot: repo, Title: "s", CloneURL: "file:///x"})
+		require.Error(t, err)
+		assert.Equal(t, BackendConfigError(BackendDocker, nil).Error(), err.Error(),
+			"the docker create-time error and the choose-time reason must be one string from one place")
+	})
+
+	t.Run("ssh", func(t *testing.T) {
+		repo := initTempGitRepo(t)
+		writeInRepoConfig(t, repo, map[string]any{"backend": "ssh", "ssh": map[string]any{}})
+
+		_, err := sshRuntime{}.Provision(ProvisionSpec{RepoRoot: repo, Title: "s", CloneURL: "file:///x"})
+		require.Error(t, err)
+		assert.Equal(t, BackendConfigError(BackendSSH, nil).Error(), err.Error(),
+			"the ssh create-time error and the choose-time reason must be one string from one place")
+	})
+}

--- a/session/backend_docker.go
+++ b/session/backend_docker.go
@@ -130,11 +130,14 @@ func (dockerRuntime) Provision(spec ProvisionSpec) (ProvisionResult, error) {
 	// fails the test rather than panicking the daemon here).
 	image := strings.TrimSpace(cfg.Docker.Image)
 	runArgs := cfg.Docker.RunArgs
+	// Both wordings are shared with BackendUnusableReason (#1933) so the reason the
+	// web gives at choose time is the reason printed here at create time. The check
+	// ORDER is unchanged: origin before the CLI probe.
 	if spec.CloneURL == "" {
-		return ProvisionResult{}, fmt.Errorf("backend=docker: repo %q has no `origin` remote to clone the workspace from; add one (GitHub is the durable workspace store) or push the repo first", spec.RepoRoot)
+		return ProvisionResult{}, missingOriginError(BackendDocker, spec.RepoRoot)
 	}
-	if _, err := exec.LookPath("docker"); err != nil {
-		return ProvisionResult{}, fmt.Errorf("backend=docker: the `docker` CLI is not on PATH; install Docker or select a different backend: %w", err)
+	if _, err := lookPath("docker"); err != nil {
+		return ProvisionResult{}, dockerCLIMissingError(err)
 	}
 
 	afBin, err := dockerSelfBinary()

--- a/session/backend_docker.go
+++ b/session/backend_docker.go
@@ -118,15 +118,18 @@ func (dockerRuntime) Provision(spec ProvisionSpec) (ProvisionResult, error) {
 	if err != nil {
 		return ProvisionResult{}, fmt.Errorf("backend=docker: cannot resolve repo config for %q: %w", spec.RepoRoot, err)
 	}
-	image := ""
-	var runArgs []string
-	if cfg.Docker != nil {
-		image = strings.TrimSpace(cfg.Docker.Image)
-		runArgs = cfg.Docker.RunArgs
+	// The config precondition is shared with the ListBackends RPC (#1933), so the
+	// web states this requirement at choose time in the same words the CLI prints
+	// here at create time.
+	if err := BackendConfigError(BackendDocker, cfg); err != nil {
+		return ProvisionResult{}, err
 	}
-	if image == "" {
-		return ProvisionResult{}, fmt.Errorf("backend=docker requires docker.image to be set in this repo's .agent-factory/config.json (the container image that carries git + tmux + the agent CLIs; the `af` binary is copied in automatically)")
-	}
+	// Safe to dereference: BackendConfigError returns non-nil for a missing Docker
+	// section, so reaching here means it is set (locked by
+	// TestBackendConfigError_ReportsRepoConfigRequirements — weakening that check
+	// fails the test rather than panicking the daemon here).
+	image := strings.TrimSpace(cfg.Docker.Image)
+	runArgs := cfg.Docker.RunArgs
 	if spec.CloneURL == "" {
 		return ProvisionResult{}, fmt.Errorf("backend=docker: repo %q has no `origin` remote to clone the workspace from; add one (GitHub is the durable workspace store) or push the repo first", spec.RepoRoot)
 	}

--- a/session/backend_preconditions.go
+++ b/session/backend_preconditions.go
@@ -2,38 +2,65 @@ package session
 
 import (
 	"fmt"
+	"os/exec"
 	"strings"
 
 	"github.com/sachiniyer/agent-factory/config"
 )
 
-// Backend config preconditions (#1933). docker, ssh, and hook each need a key in
-// the repo's own .agent-factory config before a session can run on them:
-// docker.image, ssh.host, and remote_hooks respectively. Those requirements were
-// previously stated only inside each runtime's Provision, which meant they could
-// only be discovered by trying to create a session and reading the failure.
+// Backend preconditions (#1933). docker, ssh, and hook each need things to be true
+// before a session can run on them. Those requirements used to be stated only
+// inside each runtime's Provision, so the only way to discover one was to create a
+// session and read the failure.
 //
-// BackendConfigError states the same requirement from the repo config ALONE, with
-// no provisioning and no side effects, so a client can ask "could this repo use
-// docker?" before offering the choice. The runtimes call it as their first
-// config-dependent check, so the message a user reads at choose time in the web is
-// the identical message the CLI prints at create time — one string, one place,
-// no drift.
+// This file states them from the repo config and the daemon's own environment,
+// with NO side effects and no provisioning, so a client can ask "could this repo
+// use docker?" before offering the choice — and the runtimes call the same
+// functions, so the message a user reads at choose time in the web is the message
+// the CLI prints at create time.
 //
-// Scope is deliberately repo CONFIG only. Preconditions that depend on the
-// environment or the session (the `docker` CLI being on PATH, the repo having an
-// `origin` remote to clone from) stay in Provision: they are not answerable from
-// config, and a client that pre-checked them would be asserting things it cannot
-// know. So a backend reported available here can still fail to provision — this
-// narrows the failure surface to the environment, it does not eliminate it.
+// The rule these functions exist to enforce: a picker is a promise. Every backend
+// offered as usable says "choose this and it will work". So availability is a
+// CHECKED fact, never an assumed one — if a precondition cannot be verified, the
+// answer is "unknown, and here is why", never a cheerful default. What can be
+// checked here without side effects:
+//
+//	local  — nothing; it is always usable.
+//	docker — docker.image set, the `docker` CLI on PATH, an `origin` to clone from.
+//	ssh    — ssh.host set, an `origin` to clone from. (The transport is the Go ssh
+//	         client, so there is no ssh CLI to look for; host reachability is a
+//	         network fact this must not dial for.)
+//	hook   — remote_hooks set AND valid AND its commands actually runnable.
+//
+// What is deliberately NOT checked, because it cannot be without doing the work:
+// whether the image pulls, whether the ssh host is up and authorized, whether
+// launch_cmd exits 0. Those still surface at create time. So "available" means
+// "every precondition I can check without side effects passed" — a real promise,
+// just not omniscience.
 
-// BackendConfigError reports why kind cannot be used in the repo whose resolved
-// config is cfg, or nil when the repo config satisfies the backend's
-// requirements. A nil cfg is treated as an empty config (every optional section
-// absent), which is the correct reading for a repo with no in-repo config file.
+// lookPath resolves an executable the way exec.Command will when the runtime later
+// runs it — same process, same PATH, so the answer here is the answer at create
+// time. A package var so tests can drive the not-on-PATH branches hermetically
+// (a test must not depend on whether the CI image ships a `docker` binary).
+var lookPath = exec.LookPath
+
+// SetLookPathForTest replaces the executable resolver with f and returns a restore
+// function. Mirrors the SetRuntimeForTest / SetBackendFactoryForTest seam pattern.
+func SetLookPathForTest(f func(string) (string, error)) func() {
+	prev := lookPath
+	lookPath = f
+	return func() { lookPath = prev }
+}
+
+// BackendConfigError reports why kind's repo CONFIG is insufficient, or nil when
+// the config satisfies it. This is the config-key half only — the runtimes call it
+// as their first config-dependent check, and BackendUnusableReason calls it first
+// too, so all three surfaces name the missing key in the same words.
 //
-// The returned error is user-facing and actionable: it names the missing key and
-// the file it belongs in.
+// A nil cfg is treated as an empty config (every optional section absent), which is
+// the correct reading for a repo with no in-repo config file. It is NOT the reading
+// for a config that failed to LOAD — the caller must not conflate "no config" with
+// "unreadable config"; see ListBackends, which reports the latter as unknown.
 func BackendConfigError(kind BackendKind, cfg *config.ResolvedConfig) error {
 	switch kind {
 	case BackendDocker:
@@ -51,6 +78,72 @@ func BackendConfigError(kind BackendKind, cfg *config.ResolvedConfig) error {
 	}
 	// BackendLocal needs nothing from the repo config, and an unregistered kind is
 	// not this function's error to raise — ParseBackendKind rejects those. A new
-	// backend with no config requirement correctly reports available by default.
+	// backend with no config requirement correctly reports no config error.
 	return nil
+}
+
+// BackendUnusableReason reports why kind cannot be used for a session in the repo
+// at repoRoot, or nil when every checkable precondition passes. cfg must be the
+// repo's RESOLVED config (a caller that could not resolve it has an unknown
+// answer, not a nil-cfg one).
+//
+// This is the choose-time question a picker must ask before offering a backend.
+// It checks config keys, then the environment facts the runtime will need — a
+// backend that is configured but whose command is missing is exactly the
+// "offered, then fails later somewhere less obvious" trap this is here to close.
+func BackendUnusableReason(kind BackendKind, cfg *config.ResolvedConfig, repoRoot string) error {
+	if err := BackendConfigError(kind, cfg); err != nil {
+		return err
+	}
+
+	switch kind {
+	case BackendDocker:
+		if _, err := lookPath("docker"); err != nil {
+			return dockerCLIMissingError(err)
+		}
+		if originRemoteURL(repoRoot) == "" {
+			return missingOriginError(BackendDocker, repoRoot)
+		}
+	case BackendSSH:
+		if originRemoteURL(repoRoot) == "" {
+			return missingOriginError(BackendSSH, repoRoot)
+		}
+	case BackendHook:
+		// Validate() is what create runs (via loadRemoteHooksForPath): it catches an
+		// empty launch_cmd/delete_cmd and a config still carrying the removed
+		// pre-PR7 keys. Reusing it means "configured" can never again mean merely
+		// "the section exists".
+		if err := cfg.RemoteHooks.Validate(); err != nil {
+			return fmt.Errorf("backend=hook: %w", err)
+		}
+		// The hook commands are exec'd directly as the program (not through a
+		// shell), so resolving them is exactly what create will do. A hook whose
+		// command is missing is the worst offender in this class: it is CONFIGURED,
+		// so a config-only check calls it available, and the failure lands later,
+		// mid-provision, as somebody else's error.
+		for _, hook := range []struct{ key, cmd string }{
+			{"launch_cmd", cfg.RemoteHooks.LaunchCmd},
+			{"delete_cmd", cfg.RemoteHooks.DeleteCmd},
+		} {
+			if _, err := lookPath(hook.cmd); err != nil {
+				return fmt.Errorf("backend=hook: remote_hooks.%s %q was not found on PATH (agent-factory runs it directly to provision the session); install it, or set an absolute path in this repo's %s", hook.key, hook.cmd, config.InRepoConfigFileName(repoRoot))
+			}
+		}
+	}
+	return nil
+}
+
+// dockerCLIMissingError is the one wording for "the docker CLI is absent", shared
+// by the docker runtime (which hits it at create time) and BackendUnusableReason
+// (which hits it at choose time).
+func dockerCLIMissingError(err error) error {
+	return fmt.Errorf("backend=docker: the `docker` CLI is not on PATH; install Docker or select a different backend: %w", err)
+}
+
+// missingOriginError is the one wording for "this repo has nothing to clone from",
+// shared by the docker and ssh runtimes and by BackendUnusableReason. Both
+// sandboxed runtimes clone the workspace from origin (epic decision 4: GitHub is
+// the durable store), so neither can run in a repo that has no origin.
+func missingOriginError(kind BackendKind, repoRoot string) error {
+	return fmt.Errorf("backend=%s: repo %q has no `origin` remote to clone the workspace from; add one (GitHub is the durable workspace store) or push the repo first", kind, repoRoot)
 }

--- a/session/backend_preconditions.go
+++ b/session/backend_preconditions.go
@@ -1,0 +1,56 @@
+package session
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+// Backend config preconditions (#1933). docker, ssh, and hook each need a key in
+// the repo's own .agent-factory config before a session can run on them:
+// docker.image, ssh.host, and remote_hooks respectively. Those requirements were
+// previously stated only inside each runtime's Provision, which meant they could
+// only be discovered by trying to create a session and reading the failure.
+//
+// BackendConfigError states the same requirement from the repo config ALONE, with
+// no provisioning and no side effects, so a client can ask "could this repo use
+// docker?" before offering the choice. The runtimes call it as their first
+// config-dependent check, so the message a user reads at choose time in the web is
+// the identical message the CLI prints at create time — one string, one place,
+// no drift.
+//
+// Scope is deliberately repo CONFIG only. Preconditions that depend on the
+// environment or the session (the `docker` CLI being on PATH, the repo having an
+// `origin` remote to clone from) stay in Provision: they are not answerable from
+// config, and a client that pre-checked them would be asserting things it cannot
+// know. So a backend reported available here can still fail to provision — this
+// narrows the failure surface to the environment, it does not eliminate it.
+
+// BackendConfigError reports why kind cannot be used in the repo whose resolved
+// config is cfg, or nil when the repo config satisfies the backend's
+// requirements. A nil cfg is treated as an empty config (every optional section
+// absent), which is the correct reading for a repo with no in-repo config file.
+//
+// The returned error is user-facing and actionable: it names the missing key and
+// the file it belongs in.
+func BackendConfigError(kind BackendKind, cfg *config.ResolvedConfig) error {
+	switch kind {
+	case BackendDocker:
+		if cfg == nil || cfg.Docker == nil || strings.TrimSpace(cfg.Docker.Image) == "" {
+			return fmt.Errorf("backend=docker requires docker.image to be set in this repo's .agent-factory/config.json (the container image that carries git + tmux + the agent CLIs; the `af` binary is copied in automatically)")
+		}
+	case BackendSSH:
+		if cfg == nil || cfg.SSH == nil || strings.TrimSpace(cfg.SSH.Host) == "" {
+			return fmt.Errorf("backend=ssh requires ssh.host to be set in this repo's .agent-factory/config.json (the remote host the session's workspace + agent run on)")
+		}
+	case BackendHook:
+		if cfg == nil || cfg.RemoteHooks == nil {
+			return fmt.Errorf("backend=hook requires remote_hooks to be configured in this repo's .agent-factory/config.json (the launch/delete commands that provision the session on your own infrastructure)")
+		}
+	}
+	// BackendLocal needs nothing from the repo config, and an unregistered kind is
+	// not this function's error to raise — ParseBackendKind rejects those. A new
+	// backend with no config requirement correctly reports available by default.
+	return nil
+}

--- a/session/backend_ssh.go
+++ b/session/backend_ssh.go
@@ -140,7 +140,9 @@ func (sshRuntime) Provision(spec ProvisionSpec) (ProvisionResult, error) {
 	// is set here (locked by TestBackendConfigError_ReportsRepoConfigRequirements).
 	sshCfg := *cfg.SSH
 	if spec.CloneURL == "" {
-		return ProvisionResult{}, fmt.Errorf("backend=ssh: repo %q has no `origin` remote to clone the workspace from; add one (GitHub is the durable workspace store) or push the repo first", spec.RepoRoot)
+		// Shared with BackendUnusableReason (#1933) — one wording, choose time and
+		// create time.
+		return ProvisionResult{}, missingOriginError(BackendSSH, spec.RepoRoot)
 	}
 
 	afBin, err := sshSelfBinary()

--- a/session/backend_ssh.go
+++ b/session/backend_ssh.go
@@ -132,13 +132,13 @@ func (sshRuntime) Provision(spec ProvisionSpec) (ProvisionResult, error) {
 	if err != nil {
 		return ProvisionResult{}, fmt.Errorf("backend=ssh: cannot resolve repo config for %q: %w", spec.RepoRoot, err)
 	}
-	var sshCfg config.SSHConfig
-	if cfg.SSH != nil {
-		sshCfg = *cfg.SSH
+	// Shared with the ListBackends RPC (#1933) — see BackendConfigError.
+	if err := BackendConfigError(BackendSSH, cfg); err != nil {
+		return ProvisionResult{}, err
 	}
-	if strings.TrimSpace(sshCfg.Host) == "" {
-		return ProvisionResult{}, fmt.Errorf("backend=ssh requires ssh.host to be set in this repo's .agent-factory/config.json (the remote host the session's workspace + agent run on)")
-	}
+	// Safe to dereference: BackendConfigError rejects a missing SSH section, so it
+	// is set here (locked by TestBackendConfigError_ReportsRepoConfigRequirements).
+	sshCfg := *cfg.SSH
 	if spec.CloneURL == "" {
 		return ProvisionResult{}, fmt.Errorf("backend=ssh: repo %q has no `origin` remote to clone the workspace from; add one (GitHub is the durable workspace store) or push the repo first", spec.RepoRoot)
 	}

--- a/session/runtime.go
+++ b/session/runtime.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/sachiniyer/agent-factory/config"
 )
@@ -33,15 +34,16 @@ const (
 // mirroring RemoteHooks.Validate, this validation runs when a runtime is
 // resolved at create time, not at config load.
 func ParseBackendKind(s string) (BackendKind, error) {
-	switch s {
-	case "":
+	if s == "" {
 		return BackendLocal, nil
-	case config.BackendLocal, config.BackendDocker, config.BackendSSH, config.BackendHook:
-		return BackendKind(s), nil
-	default:
-		return "", fmt.Errorf("unknown backend %q (valid: %s, %s, %s, %s)",
-			s, config.BackendLocal, config.BackendDocker, config.BackendSSH, config.BackendHook)
 	}
+	// Validated against config.SupportedBackends, not a hand-written case list, so
+	// a newly registered backend becomes parseable by appearing in the one
+	// canonical enum (#1933).
+	if slices.Contains(config.SupportedBackends, s) {
+		return BackendKind(s), nil
+	}
+	return "", fmt.Errorf("unknown backend %q (valid: %s)", s, config.SupportedBackendsString())
 }
 
 // ProvisionSpec is the input a Runtime needs to establish a session's execution

--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -1370,6 +1370,15 @@ body {
   font-size: var(--af-fs-sm);
   line-height: 1.4;
 }
+.af-modal-hint {
+  margin: 0;
+  color: var(--af-text-2);
+  font-size: var(--af-fs-sm);
+  line-height: 1.4;
+}
+.af-modal-hint:empty {
+  display: none;
+}
 .af-modal-foot {
   display: flex;
   justify-content: flex-end;

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -6402,37 +6402,31 @@ var EventStream = class {
 var REPO_DEFAULT = "";
 function backendChoices(catalog) {
   if (catalog === null) {
-    return [{ value: REPO_DEFAULT, label: "Repo default", available: true, reason: "" }];
+    return [{ value: REPO_DEFAULT, label: "Repo default", status: "available", reason: "" }];
   }
-  const reason = defaultReason(catalog);
   const choices = [
     {
       value: REPO_DEFAULT,
+      // "Repo default" with no parenthetical when the daemon reports no default:
+      // that is the misconfigured case, where naming a backend would be inventing
+      // one. The reason says what is wrong with the key.
       label: catalog.default === "" ? "Repo default" : `Repo default (${catalog.default})`,
-      // A repo whose declared default is unconfigured is genuinely unusable: that
-      // create resolves to the broken backend and fails. Reporting it as such
-      // surfaces the config bug at choose time instead of at create time — which is
-      // the whole point of #1933 — and is why this is computed, not hardcoded true.
-      available: reason === "",
-      reason
+      // Taken from the daemon, not inferred here. A repo whose declared default is
+      // broken resolves to that broken backend and FAILS — it does not quietly run
+      // local — so the default is not automatically a safe harbour.
+      status: catalog.default_status,
+      reason: catalog.default_status === "available" ? "" : catalog.default_reason ?? ""
     }
   ];
   for (const opt of catalog.backends) {
     choices.push({
       value: opt.name,
       label: opt.name,
-      available: opt.available,
-      reason: opt.available ? "" : opt.reason ?? ""
+      status: opt.status,
+      reason: opt.status === "available" ? "" : opt.reason ?? ""
     });
   }
   return choices;
-}
-function defaultReason(catalog) {
-  const resolved = catalog.backends.find((b) => b.name === catalog.default);
-  if (resolved === void 0 || resolved.available) {
-    return "";
-  }
-  return resolved.reason ?? "";
 }
 function backendNotice(choices, selected) {
   const choice = choices.find((c) => c.value === selected);
@@ -6440,7 +6434,7 @@ function backendNotice(choices, selected) {
 }
 function backendSelectable(choices, selected) {
   const choice = choices.find((c) => c.value === selected);
-  return choice === void 0 || choice.available;
+  return choice === void 0 || choice.status === "available";
 }
 
 // src/modals.ts
@@ -6548,9 +6542,16 @@ function newSessionModal(projects, defaultProject2, callbacks) {
   const backendHint = h("p", { class: "af-modal-hint" });
   backendHint.setAttribute("role", "status");
   let choices = backendChoices(null);
-  const syncSelection = () => {
+  let busy = false;
+  const syncSubmitState = () => {
     backendHint.textContent = backendNotice(choices, backendSelect.value);
-    confirmBtn.disabled = projects.length === 0 || !backendSelectable(choices, backendSelect.value);
+    confirmBtn.disabled = busy || projects.length === 0 || !backendSelectable(choices, backendSelect.value);
+  };
+  const chromeSetBusy = handle.setBusy.bind(handle);
+  handle.setBusy = (b) => {
+    busy = b;
+    chromeSetBusy(b);
+    syncSubmitState();
   };
   const renderChoices = () => {
     const previous = backendSelect.value;
@@ -6559,9 +6560,9 @@ function newSessionModal(projects, defaultProject2, callbacks) {
       backendSelect.append(h("option", { value: choice.value }, choice.label));
     }
     backendSelect.value = choices.some((c) => c.value === previous) ? previous : REPO_DEFAULT;
-    syncSelection();
+    syncSubmitState();
   };
-  backendSelect.addEventListener("change", syncSelection);
+  backendSelect.addEventListener("change", syncSubmitState);
   let loadSeq = 0;
   const loadBackendsFor = (repoPath) => {
     const seq = ++loadSeq;

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -6223,18 +6223,22 @@ async function probeAuthRequired() {
   }
   return env?.data?.auth_required !== false;
 }
+async function listBackends(repoPath, token2) {
+  return af("ListBackends", { repo_path: repoPath }, token2);
+}
 async function createSession(input, token2) {
-  const resp = await af(
-    "CreateSession",
-    {
-      title_base: input.title,
-      repo_path: input.repoPath,
-      program: input.program,
-      prompt: input.prompt,
-      auto_yes: input.autoYes
-    },
-    token2
-  );
+  const body = {
+    title_base: input.title,
+    repo_path: input.repoPath,
+    program: input.program,
+    prompt: input.prompt,
+    auto_yes: input.autoYes
+  };
+  const backend = (input.backend ?? "").trim();
+  if (backend !== "") {
+    body.backend = backend;
+  }
+  const resp = await af("CreateSession", body, token2);
   return resp.instance;
 }
 async function sendPrompt(id, title, prompt, token2) {
@@ -6394,6 +6398,51 @@ var EventStream = class {
   }
 };
 
+// src/backends.ts
+var REPO_DEFAULT = "";
+function backendChoices(catalog) {
+  if (catalog === null) {
+    return [{ value: REPO_DEFAULT, label: "Repo default", available: true, reason: "" }];
+  }
+  const reason = defaultReason(catalog);
+  const choices = [
+    {
+      value: REPO_DEFAULT,
+      label: catalog.default === "" ? "Repo default" : `Repo default (${catalog.default})`,
+      // A repo whose declared default is unconfigured is genuinely unusable: that
+      // create resolves to the broken backend and fails. Reporting it as such
+      // surfaces the config bug at choose time instead of at create time — which is
+      // the whole point of #1933 — and is why this is computed, not hardcoded true.
+      available: reason === "",
+      reason
+    }
+  ];
+  for (const opt of catalog.backends) {
+    choices.push({
+      value: opt.name,
+      label: opt.name,
+      available: opt.available,
+      reason: opt.available ? "" : opt.reason ?? ""
+    });
+  }
+  return choices;
+}
+function defaultReason(catalog) {
+  const resolved = catalog.backends.find((b) => b.name === catalog.default);
+  if (resolved === void 0 || resolved.available) {
+    return "";
+  }
+  return resolved.reason ?? "";
+}
+function backendNotice(choices, selected) {
+  const choice = choices.find((c) => c.value === selected);
+  return choice === void 0 ? "" : choice.reason;
+}
+function backendSelectable(choices, selected) {
+  const choice = choices.find((c) => c.value === selected);
+  return choice === void 0 || choice.available;
+}
+
 // src/modals.ts
 function h(tag, props = {}, ...children) {
   const el2 = document.createElement(tag);
@@ -6494,6 +6543,48 @@ function newSessionModal(projects, defaultProject2, callbacks) {
   for (const prog of ["claude", "codex", "aider", "gemini", "amp"]) {
     programSelect.append(h("option", { value: prog }, prog));
   }
+  const backendSelect = h("select", { class: "af-input" });
+  backendSelect.setAttribute("aria-label", "Backend");
+  const backendHint = h("p", { class: "af-modal-hint" });
+  backendHint.setAttribute("role", "status");
+  let choices = backendChoices(null);
+  const syncSelection = () => {
+    backendHint.textContent = backendNotice(choices, backendSelect.value);
+    confirmBtn.disabled = projects.length === 0 || !backendSelectable(choices, backendSelect.value);
+  };
+  const renderChoices = () => {
+    const previous = backendSelect.value;
+    backendSelect.replaceChildren();
+    for (const choice of choices) {
+      backendSelect.append(h("option", { value: choice.value }, choice.label));
+    }
+    backendSelect.value = choices.some((c) => c.value === previous) ? previous : REPO_DEFAULT;
+    syncSelection();
+  };
+  backendSelect.addEventListener("change", syncSelection);
+  let loadSeq = 0;
+  const loadBackendsFor = (repoPath) => {
+    const seq = ++loadSeq;
+    if (repoPath === "") {
+      choices = backendChoices(null);
+      renderChoices();
+      return;
+    }
+    void callbacks.loadBackends(repoPath).then((catalog) => {
+      if (seq !== loadSeq) {
+        return;
+      }
+      choices = backendChoices(catalog);
+      renderChoices();
+    }).catch(() => {
+      if (seq !== loadSeq) {
+        return;
+      }
+      choices = backendChoices(null);
+      renderChoices();
+    });
+  };
+  projectSelect.addEventListener("change", () => loadBackendsFor(projectSelect.value));
   const promptArea = h("textarea", { class: "af-input af-textarea", placeholder: "Initial prompt (optional)", rows: 3 });
   promptArea.setAttribute("aria-label", "Initial prompt");
   const autoYes = h("input", { type: "checkbox", id: "af-autoyes" });
@@ -6502,9 +6593,13 @@ function newSessionModal(projects, defaultProject2, callbacks) {
     field("Title", titleInput),
     field("Project", projectSelect),
     field("Program", programSelect),
+    field("Backend", backendSelect),
+    backendHint,
     field("Prompt", promptArea),
     autoYesRow
   );
+  renderChoices();
+  loadBackendsFor(projectSelect.value);
   const card = handle.el.firstElementChild;
   asForm(card, () => {
     const title = titleInput.value.trim();
@@ -6518,7 +6613,10 @@ function newSessionModal(projects, defaultProject2, callbacks) {
       repoPath: projectSelect.value,
       program: programSelect.value,
       prompt: promptArea.value,
-      autoYes: autoYes.checked
+      autoYes: autoYes.checked,
+      // REPO_DEFAULT ("") when the user did not choose — createSession then omits
+      // `backend` entirely and the repo's config decides (#1933).
+      backend: backendSelect.value
     });
   });
   queueMicrotask(() => titleInput.focus());
@@ -10180,6 +10278,11 @@ function newSession() {
   const projects = pickerProjects(store.get().sessions, store.get().tasks);
   openModal(
     newSessionModal(projects, store.get().selectedProject, {
+      // The backend catalog is per-repo and read at choose time (#1933), so the
+      // modal asks for the picked project's on open and on every project change.
+      // Tokenless ("") is a valid credential (#1696), so a null token — not a
+      // falsy one — is the "not authorized yet" case.
+      loadBackends: (repoPath) => token === null ? Promise.reject(new Error("not authorized")) : listBackends(repoPath, token),
       onSubmit: (values) => {
         const tok = token;
         if (tok === null || !modal) {

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "b28f65b6e24d";
+const VERSION = "7d948af54780";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "7d948af54780";
+const VERSION = "756821b9dfd5";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -1878,6 +1878,33 @@ test.describe("create → kill (one session, two flows)", () => {
     const modal = page.locator(".af-modal-card");
     await expect(modal).toBeVisible();
 
+    // #1933 end-to-end: the backend picker is populated by the DAEMON (ListBackends
+    // against the picked project), not by a list in the web. This is the only test
+    // that proves the whole chain — enum → RPC → rendered options — through a real
+    // daemon; the unit tests either side of it both stub their counterpart.
+    const backendSelect = modal.locator('select[aria-label="Backend"]');
+    await expect(backendSelect).toBeVisible();
+    // Populated asynchronously, so wait for the daemon's answer rather than the
+    // "repo default"-only placeholder the field is built with.
+    await expect(backendSelect.locator("option")).not.toHaveCount(1, { timeout: 30_000 });
+    await expect(backendSelect.locator("option")).toHaveText(
+      [/^Repo default \(local\)$/, "local", "docker", "ssh", "hook"],
+      { timeout: 30_000 },
+    );
+    // The mock repo configures no docker.image. Picking docker must state the missing
+    // key AND block Create — the choose-time message standing in for the create-time
+    // failure this issue is about. The reason is the daemon's own text, so this also
+    // proves the CLI and the web say the same thing.
+    await backendSelect.selectOption("docker");
+    await expect(modal.locator(".af-modal-hint")).toHaveText(/docker\.image/);
+    await expect(modal.locator("button.af-primary")).toBeDisabled();
+
+    // Back to the repo default: the notice clears, Create is live again, and the
+    // submit below sends NO backend — so this create stays local.
+    await backendSelect.selectOption("");
+    await expect(modal.locator(".af-modal-hint")).toHaveText("");
+    await expect(modal.locator("button.af-primary")).toBeEnabled();
+
     // Title is required; the project picker defaults to the scoped project (redesign
     // PR2 — the first mock repo A/B live in), so the created session lands there and is
     // visible in the scoped rail. Program is left at "Repo default" (claude → the fake

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -1984,6 +1984,58 @@ test("archive: the archive confirm retires the session out of the default rail",
   await expect(row(page, SESSION_B)).toHaveCount(0);
 });
 
+test("#1933: a backend availability refresh must not re-enable Create mid-submit", async () => {
+  // The race: a ListBackends is in flight when the user submits, and its response
+  // lands DURING the create. Re-rendering the choices must not decide, on its own,
+  // whether Create is clickable — the busy state is a separate reason it is
+  // disabled, and clobbering it re-arms the button under an in-flight create (a
+  // double-create is one Enter away).
+  //
+  // Both sides are held with route interception so the ordering is deterministic
+  // rather than a timing hope. The create is aborted, never forwarded, so this test
+  // makes no session.
+  let releaseCatalog: () => void = () => {};
+  const catalogHeld = new Promise<void>((resolve) => {
+    releaseCatalog = resolve;
+  });
+  await page.route("**/v1/ListBackends", async (route) => {
+    await catalogHeld;
+    await route.continue();
+  });
+  await page.route("**/v1/CreateSession", async (route) => {
+    // Held open so the modal stays busy across the assertion, then aborted so the
+    // request never reaches the daemon.
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+    await route.abort();
+  });
+
+  await page.locator("button.af-rail-new").click();
+  const modal = page.locator(".af-modal-card");
+  await expect(modal).toBeVisible();
+  await modal.locator('input[aria-label="Session title"]').fill("probe-busy-race");
+
+  const createBtn = modal.locator("button.af-primary");
+  await expect(createBtn).toBeEnabled();
+  await createBtn.click();
+  await expect(createBtn).toBeDisabled();
+
+  // Let the catalog land mid-create, then look AFTER the re-render has run — the
+  // assertion has to outlast the event, or it would pass on the pre-render state.
+  const catalogResponse = page.waitForResponse("**/v1/ListBackends");
+  releaseCatalog();
+  await catalogResponse;
+  await page.waitForTimeout(300);
+  await expect(createBtn, "an availability refresh must not re-enable Create while a create is in flight").toBeDisabled();
+
+  // And once the create actually fails, the button comes back — the busy gate must
+  // not strand the form either.
+  await expect(createBtn).toBeEnabled({ timeout: 15_000 });
+  await page.keyboard.press("Escape");
+  await expect(modal).toBeHidden();
+  await page.unroute("**/v1/ListBackends");
+  await page.unroute("**/v1/CreateSession");
+});
+
 // --- the status filter (feat: hide archived by default) --------------------
 //
 // These run right after the archive flow, which leaves the first project holding both

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -11,9 +11,12 @@ import {
   ApiError,
   archiveSession,
   closeTab,
+  createSession,
+  type CreateSessionInput,
   createTab,
   errorText,
   killSession,
+  listBackends,
   removeTask,
   sendPrompt,
   triggerTask,
@@ -48,6 +51,52 @@ function stubFetch(): Captured {
 
 afterEach(() => {
   delete (globalThis as { fetch?: unknown }).fetch;
+});
+
+// The backend-on-create contract (#1933). The daemon already accepted `backend`;
+// these pin that the web now sends it — and, just as load-bearing, that it stays
+// ABSENT when the user made no choice.
+
+/** A create form submission with no backend chosen (the default state). */
+function createInput(over: Partial<CreateSessionInput> = {}): CreateSessionInput {
+  return { title: "feature", repoPath: "/repos/af", program: "", prompt: "", autoYes: false, ...over };
+}
+
+for (const backend of ["local", "docker", "ssh", "hook"]) {
+  test(`createSession sends backend=${backend} when the user picks it`, async () => {
+    const cap = stubFetch();
+    await createSession(createInput({ backend }), "tok");
+    assert.equal(cap.url, "/v1/CreateSession");
+    assert.equal(cap.body.backend, backend, "an explicit choice must reach the daemon verbatim, as `af sessions create --backend` does");
+    assert.equal(cap.body.repo_path, "/repos/af");
+  });
+}
+
+test("createSession omits backend entirely when the user chose the repo default", async () => {
+  // This is the subtle half. Sending "local" here would look equivalent and is
+  // not: an explicit backend WINS over the repo's `backend` config key, so a repo
+  // configured for docker would silently create local sessions from the web while
+  // the CLI honoured docker. Absent is the only encoding of "let the repo decide".
+  const cap = stubFetch();
+  await createSession(createInput({ backend: "" }), "tok");
+
+  assert.equal("backend" in cap.body, false, "no choice must send NO backend key, not an explicit local");
+});
+
+test("createSession omits backend when the field is absent altogether", async () => {
+  const cap = stubFetch();
+  await createSession(createInput(), "tok");
+
+  assert.equal("backend" in cap.body, false, "an undefined backend is the same 'let the repo decide' as an empty one");
+});
+
+test("listBackends asks the daemon for the picked repo's catalog", async () => {
+  const cap = stubFetch();
+  await listBackends("/repos/af", "tok");
+
+  assert.equal(cap.url, "/v1/ListBackends");
+  assert.equal(cap.auth, "Bearer tok");
+  assert.equal(cap.body.repo_path, "/repos/af", "availability and the default are per-repo facts");
 });
 
 test("killSession posts the stable id as the primary key alongside the title", async () => {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -11,6 +11,7 @@
 // request. The WS `?access_token=` fallback (browsers cannot set WS headers) is
 // used by the /v1/events subscriber (events.ts) and, in PR4, the PTY stream.
 
+import type { BackendCatalog } from "./backends.js";
 import type { SessionData, SnapshotResponse, TaskData, TasksResponse, TaskUpdate } from "./types.js";
 
 const TOKEN_KEY = "af.token";
@@ -244,22 +245,41 @@ export interface CreateSessionInput {
   prompt: string;
   /** Whether to run the session in auto-yes mode. */
   autoYes: boolean;
+  /** The runtime to create the session on (#1933) — a name from ListBackends,
+   *  mirroring `af sessions create --backend`. Empty means the user did not
+   *  choose, and createSession then sends NO backend so the repo's own config
+   *  decides. */
+  backend?: string;
+}
+
+/** Lists the runtimes a session in this repo can be created on, whether the repo's
+ *  config supports each, and the backend an unspecified create defaults to
+ *  (#1933). The daemon owns the enum; the web renders whatever it returns and
+ *  hard-codes no backend names of its own. */
+export async function listBackends(repoPath: string, token: string): Promise<BackendCatalog> {
+  return af<BackendCatalog>("ListBackends", { repo_path: repoPath }, token);
 }
 
 /** Creates a session and returns the daemon's authoritative projection of it (the
  *  resolved title + stable id). The created row also arrives via /v1/events. */
 export async function createSession(input: CreateSessionInput, token: string): Promise<SessionData> {
-  const resp = await af<{ instance: SessionData }>(
-    "CreateSession",
-    {
-      title_base: input.title,
-      repo_path: input.repoPath,
-      program: input.program,
-      prompt: input.prompt,
-      auto_yes: input.autoYes,
-    },
-    token,
-  );
+  const body: Record<string, unknown> = {
+    title_base: input.title,
+    repo_path: input.repoPath,
+    program: input.program,
+    prompt: input.prompt,
+    auto_yes: input.autoYes,
+  };
+  // `backend` is sent ONLY when the user picked one. Sending "local" for an
+  // unspecified choice would look equivalent and is not: an explicit backend wins
+  // over the repo's `backend` config key, so it would silently override the repo
+  // default that `af sessions create` (with no --backend) honours. Absent is the
+  // only way to mean "let the repo decide" (#1933).
+  const backend = (input.backend ?? "").trim();
+  if (backend !== "") {
+    body.backend = backend;
+  }
+  const resp = await af<{ instance: SessionData }>("CreateSession", body, token);
   return resp.instance;
 }
 

--- a/web/src/backends.test.ts
+++ b/web/src/backends.test.ts
@@ -13,11 +13,12 @@ import { REPO_DEFAULT, type BackendCatalog, backendChoices, backendNotice, backe
 function catalog(over: Partial<BackendCatalog> = {}): BackendCatalog {
   return {
     default: "local",
+    default_status: "available",
     backends: [
-      { name: "local", available: true },
-      { name: "docker", available: false, reason: "backend=docker requires docker.image to be set in this repo's .agent-factory/config.json" },
-      { name: "ssh", available: false, reason: "backend=ssh requires ssh.host to be set in this repo's .agent-factory/config.json" },
-      { name: "hook", available: false, reason: "backend=hook requires remote_hooks to be configured" },
+      { name: "local", status: "available" },
+      { name: "docker", status: "unavailable", reason: "backend=docker requires docker.image to be set in this repo's .agent-factory/config.json" },
+      { name: "ssh", status: "unavailable", reason: "backend=ssh requires ssh.host to be set in this repo's .agent-factory/config.json" },
+      { name: "hook", status: "unavailable", reason: "backend=hook requires remote_hooks to be configured" },
     ],
     ...over,
   };
@@ -42,8 +43,8 @@ test("the picker offers every backend the daemon lists, in the daemon's order", 
 test("a backend the web has never heard of is offered without a web change", () => {
   const withNewBackend = catalog({
     backends: [
-      { name: "local", available: true },
-      { name: "fargate", available: true },
+      { name: "local", status: "available" },
+      { name: "fargate", status: "available" },
     ],
   });
 
@@ -52,7 +53,7 @@ test("a backend the web has never heard of is offered without a web change", () 
   const fargate = choices.find((c) => c.value === "fargate");
   assert.ok(fargate, "a newly supported backend must appear with no change to the web");
   assert.equal(fargate.label, "fargate", "its label comes from the daemon's name, not a local map that would render it blank");
-  assert.equal(fargate.available, true);
+  assert.equal(fargate.status, "available");
   assert.equal(fargate.reason, "");
 });
 
@@ -61,7 +62,7 @@ test("an unconfigured backend is offered, explained, and blocked from submitting
 
   const docker = choices.find((c) => c.value === "docker");
   assert.ok(docker);
-  assert.equal(docker.available, false, "creating with it would fail, so the form must not submit it");
+  assert.equal(docker.status, "unavailable", "creating with it would fail, so the form must not submit it");
   assert.match(docker.reason, /docker\.image/, "the reason names the missing key, so it is actionable");
 
   // Selectable on purpose: a disabled <option> would hide the reason, leaving the
@@ -72,18 +73,18 @@ test("an unconfigured backend is offered, explained, and blocked from submitting
 
 test("a configured backend is selectable with nothing to explain", () => {
   const choices = backendChoices(
-    catalog({ backends: [{ name: "docker", available: true }] }),
+    catalog({ backends: [{ name: "docker", status: "available" }] }),
   );
 
   const docker = choices.find((c) => c.value === "docker");
   assert.ok(docker);
-  assert.equal(docker.available, true);
+  assert.equal(docker.status, "available");
   assert.equal(docker.reason, "");
   assert.equal(backendSelectable(choices, "docker"), true);
 });
 
 test("the repo default is labelled with the backend it resolves to", () => {
-  const choices = backendChoices(catalog({ default: "docker", backends: [{ name: "docker", available: true }] }));
+  const choices = backendChoices(catalog({ default: "docker", backends: [{ name: "docker", status: "available" }] }));
 
   assert.equal(choices[0].value, REPO_DEFAULT, "the default choice always sends nothing");
   assert.equal(choices[0].label, "Repo default (docker)", "a repo that defaults to docker says so, so the user need not pick docker to get it");
@@ -93,7 +94,13 @@ test("a repo whose declared default is unconfigured is explained, not silently b
   // backend = "docker" with no docker.image. Leaving the choice alone still resolves
   // to docker and still fails, so the default is not a safe harbour here — naming the
   // problem while the user is looking at the form is the whole point of #1933.
-  const choices = backendChoices(catalog({ default: "docker" }));
+  const choices = backendChoices(
+    catalog({
+      default: "docker",
+      default_status: "unavailable",
+      default_reason: "backend=docker requires docker.image to be set in this repo's .agent-factory/config.json",
+    }),
+  );
 
   assert.match(choices[0].reason, /docker\.image/, "the broken config is surfaced at choose time");
   assert.equal(
@@ -101,6 +108,44 @@ test("a repo whose declared default is unconfigured is explained, not silently b
     false,
     "this create resolves to the broken docker and WOULD fail, so blocking it beats letting it fail",
   );
+});
+
+// The tri-state's whole reason to exist: "I could not check" is a THIRD answer.
+// Rendering unknown as usable would be a promise nobody verified — the picker
+// telling the user "go ahead" about a backend it knows nothing about.
+test("an unknown backend is never offered as usable, and says why", () => {
+  const choices = backendChoices(
+    catalog({
+      backends: [
+        { name: "local", status: "available" },
+        { name: "docker", status: "unknown", reason: "cannot tell whether this repo can use backend=docker: its .agent-factory/config.toml could not be read (unexpected comma)" },
+      ],
+    }),
+  );
+
+  assert.equal(backendSelectable(choices, "docker"), false, "unknown must not be presented as a working choice");
+  assert.match(backendNotice(choices, "docker"), /could not be read/, "and the user is told what stopped the check, not a made-up requirement");
+
+  // Blocking unknown can never strand the user: local reads no repo config, so it
+  // stays available through exactly the failure that makes the others unknown.
+  assert.equal(backendSelectable(choices, "local"), true, "a session is still creatable while the config is broken");
+});
+
+test("a repo whose configured default is not a known backend reports NO default", () => {
+  // The misconfiguration case: `backend = "bogus"`. There is no default to name —
+  // that create fails rather than falling back to local — so the label must not
+  // invent one, and the reason must carry the misconfiguration.
+  const choices = backendChoices(
+    catalog({
+      default: "",
+      default_status: "unavailable",
+      default_reason: 'this repo\'s .agent-factory/config.json sets backend = "bogus", which is not a known backend (valid: local, docker, ssh, hook)',
+    }),
+  );
+
+  assert.equal(choices[0].label, "Repo default", "no parenthetical: there is no resolved default to claim");
+  assert.match(choices[0].reason, /"bogus"/, "the offending value is named");
+  assert.equal(backendSelectable(choices, REPO_DEFAULT), false, "and the doomed default cannot be submitted");
 });
 
 test("an unrecognized selection is allowed through rather than vetoed locally", () => {

--- a/web/src/backends.test.ts
+++ b/web/src/backends.test.ts
@@ -1,0 +1,130 @@
+// Tests for the create form's backend choice (#1933). The daemon has always
+// accepted `backend` on create; the web never sent it, so remote sessions could
+// only be started from the TUI/CLI. These pin the two properties that make the web
+// half correct: it renders whatever the daemon lists (and nothing it knows itself),
+// and "no choice" stays genuinely absent so the repo default still applies.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { REPO_DEFAULT, type BackendCatalog, backendChoices, backendNotice, backendSelectable } from "./backends.js";
+
+/** A catalog in the daemon's own shape: canonical order, availability per backend. */
+function catalog(over: Partial<BackendCatalog> = {}): BackendCatalog {
+  return {
+    default: "local",
+    backends: [
+      { name: "local", available: true },
+      { name: "docker", available: false, reason: "backend=docker requires docker.image to be set in this repo's .agent-factory/config.json" },
+      { name: "ssh", available: false, reason: "backend=ssh requires ssh.host to be set in this repo's .agent-factory/config.json" },
+      { name: "hook", available: false, reason: "backend=hook requires remote_hooks to be configured" },
+    ],
+    ...over,
+  };
+}
+
+test("the picker offers every backend the daemon lists, in the daemon's order", () => {
+  const choices = backendChoices(catalog());
+
+  assert.deepEqual(
+    choices.map((c) => c.value),
+    [REPO_DEFAULT, "local", "docker", "ssh", "hook"],
+    "repo default leads, then the daemon's list verbatim",
+  );
+});
+
+// THE anti-drift test, and the point of the design (#1933). A backend added
+// server-side must reach the web with no web change — no enum to extend, no label
+// map to teach, no `if (name === …)`. This simulates exactly that: a daemon that
+// lists a backend this file has never heard of.
+//
+// If someone "helpfully" adds a local name→label map or an allow-list, this fails.
+test("a backend the web has never heard of is offered without a web change", () => {
+  const withNewBackend = catalog({
+    backends: [
+      { name: "local", available: true },
+      { name: "fargate", available: true },
+    ],
+  });
+
+  const choices = backendChoices(withNewBackend);
+
+  const fargate = choices.find((c) => c.value === "fargate");
+  assert.ok(fargate, "a newly supported backend must appear with no change to the web");
+  assert.equal(fargate.label, "fargate", "its label comes from the daemon's name, not a local map that would render it blank");
+  assert.equal(fargate.available, true);
+  assert.equal(fargate.reason, "");
+});
+
+test("an unconfigured backend is offered, explained, and blocked from submitting", () => {
+  const choices = backendChoices(catalog());
+
+  const docker = choices.find((c) => c.value === "docker");
+  assert.ok(docker);
+  assert.equal(docker.available, false, "creating with it would fail, so the form must not submit it");
+  assert.match(docker.reason, /docker\.image/, "the reason names the missing key, so it is actionable");
+
+  // Selectable on purpose: a disabled <option> would hide the reason, leaving the
+  // user with a greyed-out "docker" and no idea that one config key unlocks it.
+  assert.equal(backendSelectable(choices, "docker"), false, "the submit is what gets blocked, not the choice");
+  assert.match(backendNotice(choices, "docker"), /docker\.image/, "and picking it explains exactly why");
+});
+
+test("a configured backend is selectable with nothing to explain", () => {
+  const choices = backendChoices(
+    catalog({ backends: [{ name: "docker", available: true }] }),
+  );
+
+  const docker = choices.find((c) => c.value === "docker");
+  assert.ok(docker);
+  assert.equal(docker.available, true);
+  assert.equal(docker.reason, "");
+  assert.equal(backendSelectable(choices, "docker"), true);
+});
+
+test("the repo default is labelled with the backend it resolves to", () => {
+  const choices = backendChoices(catalog({ default: "docker", backends: [{ name: "docker", available: true }] }));
+
+  assert.equal(choices[0].value, REPO_DEFAULT, "the default choice always sends nothing");
+  assert.equal(choices[0].label, "Repo default (docker)", "a repo that defaults to docker says so, so the user need not pick docker to get it");
+});
+
+test("a repo whose declared default is unconfigured is explained, not silently broken", () => {
+  // backend = "docker" with no docker.image. Leaving the choice alone still resolves
+  // to docker and still fails, so the default is not a safe harbour here — naming the
+  // problem while the user is looking at the form is the whole point of #1933.
+  const choices = backendChoices(catalog({ default: "docker" }));
+
+  assert.match(choices[0].reason, /docker\.image/, "the broken config is surfaced at choose time");
+  assert.equal(
+    backendSelectable(choices, REPO_DEFAULT),
+    false,
+    "this create resolves to the broken docker and WOULD fail, so blocking it beats letting it fail",
+  );
+});
+
+test("an unrecognized selection is allowed through rather than vetoed locally", () => {
+  // The daemon is the authority on what it accepts. A client that blocked a value it
+  // merely does not recognize would be the hardcoded-enum bug (#1933) again.
+  const choices = backendChoices(catalog());
+  assert.equal(backendSelectable(choices, "fargate"), true);
+});
+
+test("the notice tracks the selected choice", () => {
+  const choices = backendChoices(catalog());
+
+  assert.equal(backendNotice(choices, REPO_DEFAULT), "", "a healthy default has nothing to say");
+  assert.match(backendNotice(choices, "docker"), /docker\.image/, "selecting an unconfigured backend explains itself");
+  assert.equal(backendNotice(choices, "local"), "", "a usable backend shows no notice");
+  assert.equal(backendNotice(choices, "nonexistent"), "", "an unknown selection invents no message");
+});
+
+test("an unavailable catalog degrades to the repo default alone", () => {
+  // The ListBackends call failing must cost the user the CHOICE, not the session:
+  // "repo default" still creates exactly as the web did before this field existed.
+  const choices = backendChoices(null);
+
+  assert.deepEqual(choices.map((c) => c.value), [REPO_DEFAULT]);
+  assert.equal(choices[0].label, "Repo default");
+  assert.equal(backendSelectable(choices, REPO_DEFAULT), true, "a create must still be possible when the catalog is unknown");
+});

--- a/web/src/backends.ts
+++ b/web/src/backends.ts
@@ -11,22 +11,36 @@
 // change to this file — the property web/src/backends.test.ts pins. A label map
 // would look harmless and would silently render a new backend as blank.
 
+/** The daemon's three-outcome availability answer (daemon.BackendAvailability).
+ *
+ *  "unknown" is load-bearing: it means the daemon could NOT check (e.g. the repo's
+ *  config would not parse), which is a different answer from yes and from no. It
+ *  must never be folded into either — an unknown rendered as available is a
+ *  promise nobody verified, and rendered as unavailable it invents a finding. */
+export type BackendAvailability = "available" | "unavailable" | "unknown";
+
 /** One backend as the daemon reports it (daemon.BackendOption). */
 export interface BackendOption {
   /** The wire value sent back as CreateSession's `backend`. */
   name: string;
-  /** False when this repo's config cannot satisfy the backend. */
-  available: boolean;
-  /** Actionable reason when `available` is false — the same text the CLI prints
-   *  at create time. Absent when available. */
+  /** The checked answer for this repo. */
+  status: BackendAvailability;
+  /** Actionable reason whenever `status` is not "available" — the same text the
+   *  CLI prints at create time. Absent when available. */
   reason?: string;
 }
 
 /** The daemon's per-repo backend catalog (daemon.ListBackendsResponse). */
 export interface BackendCatalog {
   backends: BackendOption[];
-  /** The backend a create with no explicit backend resolves to for this repo. */
+  /** The backend a create with no explicit backend resolves to for this repo.
+   *  EMPTY when the repo's `backend` key names something unrecognized: such a
+   *  create fails rather than falling back to local, so there is no default. */
   default: string;
+  /** The checked answer for the repo-default choice itself. */
+  default_status: BackendAvailability;
+  /** Why the default is not usable, naming the offending value and its file. */
+  default_reason?: string;
 }
 
 /** The sentinel value of the "repo default" choice. It is the EMPTY STRING on
@@ -44,13 +58,16 @@ export interface BackendChoice {
    *  NOT looked up in a local name→label map, which is what would silently render
    *  a newly added backend as blank. */
   label: string;
-  /** False when this repo's config cannot satisfy the choice, so creating with it
-   *  would fail. Such a choice stays SELECTABLE: disabling it would hide `reason`,
-   *  which is the actionable half — a greyed-out "docker" tells a user they cannot
-   *  have it, never that one config key would give it to them. Selecting it shows
-   *  the reason and blocks the submit instead. */
-  available: boolean;
-  /** The actionable reason this choice is unusable; "" when it is fine. */
+  /** The daemon's checked answer. Only "available" may be offered as usable: both
+   *  "unavailable" (checked, will fail) and "unknown" (could not be checked) are
+   *  unverified promises, and the picker must not make one.
+   *
+   *  Such a choice stays SELECTABLE: disabling it would hide `reason`, which is the
+   *  actionable half — a greyed-out "docker" tells a user they cannot have it, never
+   *  that one config key would give it to them. Selecting it shows the reason and
+   *  blocks the submit instead. */
+  status: BackendAvailability;
+  /** The actionable reason this choice is not usable; "" when it is fine. */
   reason: string;
 }
 
@@ -67,20 +84,21 @@ export interface BackendChoice {
  */
 export function backendChoices(catalog: BackendCatalog | null): BackendChoice[] {
   if (catalog === null) {
-    return [{ value: REPO_DEFAULT, label: "Repo default", available: true, reason: "" }];
+    return [{ value: REPO_DEFAULT, label: "Repo default", status: "available", reason: "" }];
   }
 
-  const reason = defaultReason(catalog);
   const choices: BackendChoice[] = [
     {
       value: REPO_DEFAULT,
+      // "Repo default" with no parenthetical when the daemon reports no default:
+      // that is the misconfigured case, where naming a backend would be inventing
+      // one. The reason says what is wrong with the key.
       label: catalog.default === "" ? "Repo default" : `Repo default (${catalog.default})`,
-      // A repo whose declared default is unconfigured is genuinely unusable: that
-      // create resolves to the broken backend and fails. Reporting it as such
-      // surfaces the config bug at choose time instead of at create time — which is
-      // the whole point of #1933 — and is why this is computed, not hardcoded true.
-      available: reason === "",
-      reason,
+      // Taken from the daemon, not inferred here. A repo whose declared default is
+      // broken resolves to that broken backend and FAILS — it does not quietly run
+      // local — so the default is not automatically a safe harbour.
+      status: catalog.default_status,
+      reason: catalog.default_status === "available" ? "" : (catalog.default_reason ?? ""),
     },
   ];
 
@@ -88,26 +106,11 @@ export function backendChoices(catalog: BackendCatalog | null): BackendChoice[] 
     choices.push({
       value: opt.name,
       label: opt.name,
-      available: opt.available,
-      reason: opt.available ? "" : (opt.reason ?? ""),
+      status: opt.status,
+      reason: opt.status === "available" ? "" : (opt.reason ?? ""),
     });
   }
   return choices;
-}
-
-/**
- * The reason the "repo default" choice is unusable, when the repo's declared
- * default is itself unconfigured (e.g. `backend = "docker"` with no docker.image).
- *
- * Returns "" when the default is fine, or when it names a backend the daemon did
- * not list — nothing is known about that, so claiming a problem would be a guess.
- */
-function defaultReason(catalog: BackendCatalog): string {
-  const resolved = catalog.backends.find((b) => b.name === catalog.default);
-  if (resolved === undefined || resolved.available) {
-    return "";
-  }
-  return resolved.reason ?? "";
 }
 
 /**
@@ -122,15 +125,20 @@ export function backendNotice(choices: BackendChoice[], selected: string): strin
 }
 
 /**
- * Whether a create with this selection can proceed. False only for a selection the
- * daemon reported unusable — the create would fail, so the form blocks it and
- * `backendNotice` says why.
+ * Whether a create with this selection can proceed. Only an "available" choice may
+ * — a picker is a promise, and both "unavailable" (checked, would fail) and
+ * "unknown" (could not be checked) are promises nobody verified. `backendNotice`
+ * says why, so the block is never a dead end.
  *
- * An unknown selection is allowed through: the daemon is the authority on what it
- * accepts, and a client that vetoed a value it merely does not recognize would be
- * the same hardcoded-enum bug (#1933) wearing a different hat.
+ * Blocking "unknown" cannot lock a user out: the only thing that makes a backend
+ * unknown is an unreadable repo config, and local stays available through that (it
+ * reads no repo config), so a session can still be created while they fix the file.
+ *
+ * A choice the picker does not list at all is allowed through: the daemon is the
+ * authority on what it accepts, and a client that vetoed a value it merely does not
+ * recognize would be the hardcoded-enum bug (#1933) wearing a different hat.
  */
 export function backendSelectable(choices: BackendChoice[], selected: string): boolean {
   const choice = choices.find((c) => c.value === selected);
-  return choice === undefined || choice.available;
+  return choice === undefined || choice.status === "available";
 }

--- a/web/src/backends.ts
+++ b/web/src/backends.ts
@@ -1,0 +1,136 @@
+// The create form's backend choice (#1933).
+//
+// The daemon has always accepted a backend on create (the CLI's `--backend`), but
+// the web never offered one, so a remote session could only be started from the
+// TUI/CLI. This module is the web half of closing that: it turns the daemon's
+// ListBackends answer into the option list the new-session modal renders.
+//
+// The one rule this file exists to hold: THE WEB KNOWS NO BACKEND NAMES. There is
+// no local enum, no name→label map, no `if (name === "docker")`. Every option is
+// built from the response, so a backend added server-side is offered here with no
+// change to this file — the property web/src/backends.test.ts pins. A label map
+// would look harmless and would silently render a new backend as blank.
+
+/** One backend as the daemon reports it (daemon.BackendOption). */
+export interface BackendOption {
+  /** The wire value sent back as CreateSession's `backend`. */
+  name: string;
+  /** False when this repo's config cannot satisfy the backend. */
+  available: boolean;
+  /** Actionable reason when `available` is false — the same text the CLI prints
+   *  at create time. Absent when available. */
+  reason?: string;
+}
+
+/** The daemon's per-repo backend catalog (daemon.ListBackendsResponse). */
+export interface BackendCatalog {
+  backends: BackendOption[];
+  /** The backend a create with no explicit backend resolves to for this repo. */
+  default: string;
+}
+
+/** The sentinel value of the "repo default" choice. It is the EMPTY STRING on
+ *  purpose: it is what createSession omits on, so picking the default sends no
+ *  backend and the repo's own config decides — the same defaulting the CLI gets
+ *  by leaving `--backend` off. Any non-empty sentinel here would eventually be
+ *  sent as a literal backend name. */
+export const REPO_DEFAULT = "";
+
+/** A backend choice, ready to render as an <option>. */
+export interface BackendChoice {
+  /** The <option> value: REPO_DEFAULT, or a backend name to send verbatim. */
+  value: string;
+  /** The visible label. It is the daemon's backend name verbatim — deliberately
+   *  NOT looked up in a local name→label map, which is what would silently render
+   *  a newly added backend as blank. */
+  label: string;
+  /** False when this repo's config cannot satisfy the choice, so creating with it
+   *  would fail. Such a choice stays SELECTABLE: disabling it would hide `reason`,
+   *  which is the actionable half — a greyed-out "docker" tells a user they cannot
+   *  have it, never that one config key would give it to them. Selecting it shows
+   *  the reason and blocks the submit instead. */
+  available: boolean;
+  /** The actionable reason this choice is unusable; "" when it is fine. */
+  reason: string;
+}
+
+/**
+ * Builds the backend picker's choices from the daemon's catalog.
+ *
+ * The first choice is always "repo default", labelled with the backend it
+ * actually resolves to, so the user can see that a repo defaults to docker
+ * without having to pick docker. The rest are the daemon's backends in the order
+ * it sent them (its canonical enum order).
+ *
+ * Unavailable backends are kept rather than dropped: a user who read the docs and
+ * looks for docker deserves the reason it is unusable, not a mystery absence.
+ */
+export function backendChoices(catalog: BackendCatalog | null): BackendChoice[] {
+  if (catalog === null) {
+    return [{ value: REPO_DEFAULT, label: "Repo default", available: true, reason: "" }];
+  }
+
+  const reason = defaultReason(catalog);
+  const choices: BackendChoice[] = [
+    {
+      value: REPO_DEFAULT,
+      label: catalog.default === "" ? "Repo default" : `Repo default (${catalog.default})`,
+      // A repo whose declared default is unconfigured is genuinely unusable: that
+      // create resolves to the broken backend and fails. Reporting it as such
+      // surfaces the config bug at choose time instead of at create time — which is
+      // the whole point of #1933 — and is why this is computed, not hardcoded true.
+      available: reason === "",
+      reason,
+    },
+  ];
+
+  for (const opt of catalog.backends) {
+    choices.push({
+      value: opt.name,
+      label: opt.name,
+      available: opt.available,
+      reason: opt.available ? "" : (opt.reason ?? ""),
+    });
+  }
+  return choices;
+}
+
+/**
+ * The reason the "repo default" choice is unusable, when the repo's declared
+ * default is itself unconfigured (e.g. `backend = "docker"` with no docker.image).
+ *
+ * Returns "" when the default is fine, or when it names a backend the daemon did
+ * not list — nothing is known about that, so claiming a problem would be a guess.
+ */
+function defaultReason(catalog: BackendCatalog): string {
+  const resolved = catalog.backends.find((b) => b.name === catalog.default);
+  if (resolved === undefined || resolved.available) {
+    return "";
+  }
+  return resolved.reason ?? "";
+}
+
+/**
+ * The message to show for the currently-selected backend, or "" when the
+ * selection is fine. This is the choose-time answer #1933 asks for: the user reads
+ * "backend=docker requires docker.image…" while picking, instead of submitting and
+ * decoding a create failure.
+ */
+export function backendNotice(choices: BackendChoice[], selected: string): string {
+  const choice = choices.find((c) => c.value === selected);
+  return choice === undefined ? "" : choice.reason;
+}
+
+/**
+ * Whether a create with this selection can proceed. False only for a selection the
+ * daemon reported unusable — the create would fail, so the form blocks it and
+ * `backendNotice` says why.
+ *
+ * An unknown selection is allowed through: the daemon is the authority on what it
+ * accepts, and a client that vetoed a value it merely does not recognize would be
+ * the same hardcoded-enum bug (#1933) wearing a different hat.
+ */
+export function backendSelectable(choices: BackendChoice[], selected: string): boolean {
+  const choice = choices.find((c) => c.value === selected);
+  return choice === undefined || choice.available;
+}

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -25,6 +25,7 @@ import {
   errorText,
   fetchSnapshot,
   killSession,
+  listBackends,
   listTasks,
   loadToken,
   probeAuthRequired,
@@ -501,6 +502,11 @@ function newSession(): void {
   const projects = pickerProjects(store.get().sessions, store.get().tasks);
   openModal(
     newSessionModal(projects, store.get().selectedProject, {
+      // The backend catalog is per-repo and read at choose time (#1933), so the
+      // modal asks for the picked project's on open and on every project change.
+      // Tokenless ("") is a valid credential (#1696), so a null token — not a
+      // falsy one — is the "not authorized yet" case.
+      loadBackends: (repoPath: string) => (token === null ? Promise.reject(new Error("not authorized")) : listBackends(repoPath, token)),
       onSubmit: (values: CreateSessionInput) => {
         const tok = token;
         // `=== null` not `!tok`: "" is the authorized-tokenless credential (#1696).

--- a/web/src/modals.ts
+++ b/web/src/modals.ts
@@ -197,18 +197,31 @@ export function newSessionModal(
   backendHint.setAttribute("role", "status");
 
   let choices: BackendChoice[] = backendChoices(null);
+  // Mirrors the chrome's busy flag. An async availability refresh can land at ANY
+  // time — including mid-submit — and it must never be the thing that decides
+  // whether Create is clickable.
+  let busy = false;
 
-  // Reflect the current selection: show its reason (if any) and gate Create on it.
-  // An unconfigured backend stays SELECTABLE — a disabled <option> would hide the
-  // reason, which is the actionable half, and browsers do not reliably surface a
-  // tooltip on one anyway. Picking it explains itself and blocks the submit, so the
-  // user learns the missing key at choose time instead of from a create failure.
-  const syncSelection = (): void => {
+  // The SINGLE writer of confirmBtn.disabled, so no update can clobber another's
+  // reason for disabling it. Every input that gates Create is OR-ed here rather
+  // than assigned from its own call site:
+  //   busy      — a submit is in flight; re-enabling would allow a double-create.
+  //   projects  — nothing to create in (set once, before any catalog lands).
+  //   backend   — the selection is unusable or unverified.
+  // A bare `confirmBtn.disabled = …` anywhere else silently drops the other two.
+  const syncSubmitState = (): void => {
     backendHint.textContent = backendNotice(choices, backendSelect.value);
-    // `projects.length` is re-checked, not assumed: this runs after the no-projects
-    // branch above has already disabled Create, and a bare assignment here would
-    // silently re-enable it for a repo-less client.
-    confirmBtn.disabled = projects.length === 0 || !backendSelectable(choices, backendSelect.value);
+    confirmBtn.disabled = busy || projects.length === 0 || !backendSelectable(choices, backendSelect.value);
+  };
+
+  // Route the chrome's setBusy through the same writer. index.ts drives busy around
+  // the create call; without this, a catalog response arriving mid-create would
+  // re-enable the button underneath it.
+  const chromeSetBusy = handle.setBusy.bind(handle);
+  handle.setBusy = (b: boolean): void => {
+    busy = b;
+    chromeSetBusy(b);
+    syncSubmitState();
   };
 
   const renderChoices = (): void => {
@@ -220,10 +233,10 @@ export function newSessionModal(
     // Re-selecting the prior value keeps a user's pick across a project switch when
     // it is still offered; otherwise fall back to the repo default, which always is.
     backendSelect.value = choices.some((c) => c.value === previous) ? previous : REPO_DEFAULT;
-    syncSelection();
+    syncSubmitState();
   };
 
-  backendSelect.addEventListener("change", syncSelection);
+  backendSelect.addEventListener("change", syncSubmitState);
 
   // A per-load token: a slow catalog for the project the user just left must not
   // overwrite the choices for the one they just picked.

--- a/web/src/modals.ts
+++ b/web/src/modals.ts
@@ -17,6 +17,7 @@
 // policy holds.
 
 import type { CreateSessionInput } from "./api.js";
+import { type BackendCatalog, type BackendChoice, REPO_DEFAULT, backendChoices, backendNotice, backendSelectable } from "./backends.js";
 
 /** A live modal: its root element plus in-place patch controls index.ts drives
  *  around the async submit. close() removes it from the DOM. */
@@ -130,13 +131,25 @@ export function asForm(card: HTMLElement, onSubmit: () => void): void {
   });
 }
 
-/** The new-session modal: title, project picker, program, initial prompt, auto-yes.
- *  Projects are the distinct repo roots derived from the current sessions (like the
- *  TUI's zero-config picker). onSubmit fires with the collected form values. */
+/** The new-session modal: title, project picker, program, backend, initial prompt,
+ *  auto-yes. Projects are the distinct repo roots derived from the current sessions
+ *  (like the TUI's zero-config picker). onSubmit fires with the collected form
+ *  values.
+ *
+ *  loadBackends fetches the picked project's backend catalog (#1933). It is passed
+ *  in rather than imported so this module stays free of the API/token layer, and is
+ *  re-run whenever the project changes: availability and the default are per-repo
+ *  facts, so the choices must follow the project picker. If it rejects, the backend
+ *  field degrades to "repo default" alone — the exact behavior before this field
+ *  existed, so a catalog failure can never block a create. */
 export function newSessionModal(
   projects: string[],
   defaultProject: string | null,
-  callbacks: { onSubmit: (values: CreateSessionInput) => void; onCancel: () => void },
+  callbacks: {
+    onSubmit: (values: CreateSessionInput) => void;
+    onCancel: () => void;
+    loadBackends: (repoPath: string) => Promise<BackendCatalog>;
+  },
 ): ModalHandle {
   const { handle, body, confirmBtn } = modalChrome({
     title: "New session",
@@ -174,6 +187,76 @@ export function newSessionModal(
     programSelect.append(h("option", { value: prog }, prog));
   }
 
+  // The backend field (#1933). Its options come from the daemon, never from a list
+  // here, so a backend added server-side shows up with no change to the web.
+  const backendSelect = h("select", { class: "af-input" });
+  backendSelect.setAttribute("aria-label", "Backend");
+  const backendHint = h("p", { class: "af-modal-hint" });
+  // Announce the notice when it changes: the reason a choice is unusable must
+  // reach a screen reader, not only sighted users scanning under the select.
+  backendHint.setAttribute("role", "status");
+
+  let choices: BackendChoice[] = backendChoices(null);
+
+  // Reflect the current selection: show its reason (if any) and gate Create on it.
+  // An unconfigured backend stays SELECTABLE — a disabled <option> would hide the
+  // reason, which is the actionable half, and browsers do not reliably surface a
+  // tooltip on one anyway. Picking it explains itself and blocks the submit, so the
+  // user learns the missing key at choose time instead of from a create failure.
+  const syncSelection = (): void => {
+    backendHint.textContent = backendNotice(choices, backendSelect.value);
+    // `projects.length` is re-checked, not assumed: this runs after the no-projects
+    // branch above has already disabled Create, and a bare assignment here would
+    // silently re-enable it for a repo-less client.
+    confirmBtn.disabled = projects.length === 0 || !backendSelectable(choices, backendSelect.value);
+  };
+
+  const renderChoices = (): void => {
+    const previous = backendSelect.value;
+    backendSelect.replaceChildren();
+    for (const choice of choices) {
+      backendSelect.append(h("option", { value: choice.value }, choice.label));
+    }
+    // Re-selecting the prior value keeps a user's pick across a project switch when
+    // it is still offered; otherwise fall back to the repo default, which always is.
+    backendSelect.value = choices.some((c) => c.value === previous) ? previous : REPO_DEFAULT;
+    syncSelection();
+  };
+
+  backendSelect.addEventListener("change", syncSelection);
+
+  // A per-load token: a slow catalog for the project the user just left must not
+  // overwrite the choices for the one they just picked.
+  let loadSeq = 0;
+  const loadBackendsFor = (repoPath: string): void => {
+    const seq = ++loadSeq;
+    if (repoPath === "") {
+      choices = backendChoices(null);
+      renderChoices();
+      return;
+    }
+    void callbacks
+      .loadBackends(repoPath)
+      .then((catalog) => {
+        if (seq !== loadSeq) {
+          return;
+        }
+        choices = backendChoices(catalog);
+        renderChoices();
+      })
+      .catch(() => {
+        if (seq !== loadSeq) {
+          return;
+        }
+        // Degrade to "repo default" only. The create path is unchanged by an
+        // unknown catalog, so this costs the user the choice, not the session.
+        choices = backendChoices(null);
+        renderChoices();
+      });
+  };
+
+  projectSelect.addEventListener("change", () => loadBackendsFor(projectSelect.value));
+
   const promptArea = h("textarea", { class: "af-input af-textarea", placeholder: "Initial prompt (optional)", rows: 3 });
   promptArea.setAttribute("aria-label", "Initial prompt");
 
@@ -184,9 +267,14 @@ export function newSessionModal(
     field("Title", titleInput),
     field("Project", projectSelect),
     field("Program", programSelect),
+    field("Backend", backendSelect),
+    backendHint,
     field("Prompt", promptArea),
     autoYesRow,
   );
+
+  renderChoices();
+  loadBackendsFor(projectSelect.value);
 
   const card = handle.el.firstElementChild as HTMLElement;
   asForm(card, () => {
@@ -202,6 +290,9 @@ export function newSessionModal(
       program: programSelect.value,
       prompt: promptArea.value,
       autoYes: autoYes.checked,
+      // REPO_DEFAULT ("") when the user did not choose — createSession then omits
+      // `backend` entirely and the repo's config decides (#1933).
+      backend: backendSelect.value,
     });
   });
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1748,6 +1748,22 @@ body {
   line-height: 1.4;
 }
 
+/* A field-level advisory (#1933: why a backend is not selectable, or why a repo's
+ * default backend cannot run). Muted, not --af-danger: nothing has failed and the
+ * user has done nothing wrong — it states a repo-config fact at choose time. The
+ * meaning is carried by the words, so it stays legible in both themes with no
+ * color-only signal. */
+.af-modal-hint {
+  margin: 0;
+  color: var(--af-text-2);
+  font-size: var(--af-fs-sm);
+  line-height: 1.4;
+}
+
+.af-modal-hint:empty {
+  display: none;
+}
+
 .af-modal-foot {
   display: flex;
   justify-content: flex-end;


### PR DESCRIPTION
Fixes #1933 — "remote instances does not work on the web — I can only create a remote instance from the TUI."

**DRAFT, staying draft.** The codex bot is down: its only review here (08:28:08Z) predates the current head (09:42:48Z) by 74 minutes, so it reviewed a *different commit* and says nothing about this code. Nothing below rests on GitHub being quiet — every claim is a test I watched fail and pass.

## What was wrong

Not a missing capability. The daemon has always accepted `backend` on create (`CreateSessionRequest.Backend`, the `--backend` flag). The web only ever *read* `backend_type` to draw a `[remote]` badge; nothing in `web/src` ever *sent* it. This adds the control.

## Rendered from the daemon, not a list in the web

Three hand-maintained copies of the four backends already existed (CLI flag help, `ParseBackendKind`, `runtimeRegistry`). A fourth in the web would drift the moment a backend was added.

`config.SupportedBackends` is now the single enum; `POST /v1/ListBackends` serves it per repo; the web renders whatever comes back — no names, no label map. A drift guard ties the enum to the runtime registry **both ways** ("registered but not offered" *is* this bug, one backend down).

## Availability is a checked fact (review gate)

Three findings, two of them the same disease — a probe that cannot answer, answering anyway:

1. **Invalid configured default reported as `local`.** A repo whose `backend` names something unrecognized has *no* default: that create FAILS (`resolveBackendKind`: "misconfiguration should fail the create, not silently run local"). We swallowed the error and said local — telling a user with a broken config that all was normal. Now: no default, names the value, names the file (`config.toml` or `config.json`, whichever the repo actually carries), lists valid values.
2. **hook marked available without checking it could run.** Present ≠ runnable. Now runs `RemoteHooks.Validate` (the same call create makes) and resolves `launch_cmd`/`delete_cmd` on PATH — which is exactly what create does with them (exec'd directly, no shell).
3. **Availability refresh clobbered busy.** `syncSubmitState` is now the single writer of Create's disabled flag, OR-ing every reason; `setBusy` routes through it.

Availability is now three outcomes — **available / unavailable+reason / unknown+reason** — never collapsing unknown. That third state caught a **fourth instance I had shipped**: an unreadable config was answered "requires docker.image", a fabricated finding pointing at the wrong line when `docker.image` may be set fine in a file with a stray comma elsewhere. `local` stays available through it, so unknown never strands the user. Both unavailable and unknown block the submit.

**Checked** (side-effect-free, shared with the runtimes so choose-time and create-time are one string): `docker.image` + `docker` on PATH + an origin to clone from; `ssh.host` + origin; `remote_hooks` valid + runnable.
**Not checked, and documented as such:** whether the image pulls, the host is up, `launch_cmd` exits 0. Those still surface at create.

## Defaulting preserved

"Repo default" sends **no** `backend` key, never an explicit `local` — an explicit backend *wins* over the repo config, so sending local would override a repo default the CLI honours.

## Tests — each watched failing against the bug it guards

| Guard | Broken with | Result |
|---|---|---|
| omits backend when unchosen | unconditional send | 2 fail |
| new backend appears, no web change | a local name→label map | 1 fail |
| enum ↔ registry drift | dropping `ssh` from the enum | fails, names the fix |
| invalid default surfaced | swallow → report local | "reporting local here is a lie" |
| hook needs runnable commands | configured == available | "a promise we cannot keep" |
| unreadable config → unknown | treat as "no config" | "must not invent a missing-key finding" |
| busy preserved | renderChoices writes the button | selftest re-enables Create mid-create |

Gates: `make test-container` (29 pkgs), `web-test` (248), `web-selftest-container` (69), dist rebuilt, build/gofmt/lint/deadcode/file-length. All daemon work in-container.

## Open risk — the end-to-end remote path is NOT fully proven

I built a mock-remote fixture (hook-backed repo, real `af agent-server`) to prove a remote session is creatable **from the browser**, and could not get it green. What I observed:

- The browser create with `backend=hook` **did** drive a real remote provision: `hook runtime: session "probe-remote-…" provisioned via launch_cmd, agent-server at http://127.0.0.1:40083`.
- The session then never became ready: `failed to start instance: timed out waiting for program to start (1m0s)`, empty pane snippet, reaped after 60s.

I could **not** determine whether that is my fixture's program resolution or a real gap for the *no-explicit-program* remote create — which is the web's default path. Rather than ship a red test or hand-wave it, I removed the fixture. **This is the highest-value follow-up**: if it is real, a web remote create at "Repo default" program fails for every user, and #1933 is only half fixed. The existing green `TestRemoteHookRoundTripMockRemote` covers the remote start path *with* an explicit program, which is why I do not think it is a broad regression — but I have not proven that.

## Deliberately not fixed

The **program** picker still hardcodes `["claude","codex","aider","gemini","amp"]` against `tmux.SupportedPrograms` — identical drift, already live, now with a serving pattern to copy. Flagged to #1937.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
