### PR TITLE
fix(darwin): give the process-inspection layer a real macOS implementation (#1939, #1940, #1942, #1946)

### DIFF
--- a/api/apicmd_test.go
+++ b/api/apicmd_test.go
@@ -37,7 +37,7 @@ func runAPICmd(t *testing.T, jsonMode bool) string {
 // catalog equals the served mux, so the chain is: `af api` == HTTPRoutes ==
 // served routes.
 func TestAPICmd_ListsEveryRegisteredEndpoint(t *testing.T) {
-	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
 	out := runAPICmd(t, false)
 
 	routes := daemon.HTTPRoutes()
@@ -59,7 +59,7 @@ func TestAPICmd_ListsEveryRegisteredEndpoint(t *testing.T) {
 // segment) rather than repeating the endpoint's full description verbatim — the
 // description already appears once in the table above.
 func TestAPICmd_ExamplesUseShortRouteNames(t *testing.T) {
-	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
 	out := runAPICmd(t, false)
 
 	idx := strings.Index(out, "Examples:")
@@ -144,7 +144,7 @@ func TestAPICmd_DoesNotSpawnDaemon(t *testing.T) {
 // TestAPICmd_CurlExampleShape checks the curl example distinguishes GET (no
 // body) from POST (empty JSON body), so the printed examples are runnable as-is.
 func TestAPICmd_CurlExampleShape(t *testing.T) {
-	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
 	out := runAPICmd(t, false)
 
 	// GET health: no -d body.

--- a/commands/daemonstatuscmd_test.go
+++ b/commands/daemonstatuscmd_test.go
@@ -6,13 +6,18 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"github.com/sachiniyer/agent-factory/internal/testguard"
 )
 
 // TestCollectDaemonStatusNoDaemon runs the read-only probe against a fresh
 // temp home where no daemon is running: it must report not-running and resolve
 // both socket paths under that home without dialing or spawning anything.
 func TestCollectDaemonStatusNoDaemon(t *testing.T) {
-	home := t.TempDir()
+	// SocketTempDir, not t.TempDir: this resolves the daemon socket paths, and on
+	// macOS a t.TempDir() home is ~107 bytes — past sun_path, so resolution now
+	// fails with the #1940 guard. The real home (~/.agent-factory) is short.
+	home := testguard.SocketTempDir(t)
 	t.Setenv("AGENT_FACTORY_HOME", home)
 
 	info := collectDaemonStatus()

--- a/daemon/control_client.go
+++ b/daemon/control_client.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/sockpath"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/task"
@@ -41,12 +42,23 @@ func IsDaemonStartingErr(err error) bool {
 
 // DaemonSocketPath returns the Unix socket path used by the local control
 // plane.
+//
+// The length check happens HERE, where the path is resolved, rather than at
+// net.Listen: every client and the daemon itself route through this function,
+// so one check covers dialling and binding, and it fires before a listener has
+// half-started. An over-long path otherwise fails inside the kernel as a bare
+// "bind: invalid argument" that names neither the path, the limit, nor
+// AGENT_FACTORY_HOME — the knob that fixes it (#1940).
 func DaemonSocketPath() (string, error) {
 	dir, err := config.GetConfigDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(dir, daemonSocketFileName), nil
+	path := filepath.Join(dir, daemonSocketFileName)
+	if err := sockpath.Check("daemon control socket", path); err != nil {
+		return "", err
+	}
+	return path, nil
 }
 
 // EnsureDaemon starts the daemon if the control socket is not already serving.

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -3,9 +3,6 @@ package daemon
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/sachiniyer/agent-factory/config"
-	"github.com/sachiniyer/agent-factory/log"
-	"github.com/sachiniyer/agent-factory/session"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -16,6 +13,11 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/proctree"
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session"
 )
 
 // restoreManagerForStartup is the warm-up restore entry point RunDaemon uses.
@@ -843,57 +845,22 @@ func argsAreDaemonBinary(args []string) bool {
 	}
 }
 
-// daemonArgs returns the argv of pid with argument boundaries preserved. It prefers
-// /proc/<pid>/cmdline (NUL-separated argv, Linux), the only source that keeps spaces inside an
-// individual argument intact. When /proc is unavailable (macOS and other unixes) it falls back to
-// `ps -p <pid> -o args=`, whose output is already space-joined and therefore CANNOT recover the
-// original argv boundaries for a spaced binary path — the fallback splits on whitespace and is
-// best-effort, so spaced-install detection (#1214) is only fully reliable where /proc exists.
+// daemonArgs returns the argv of pid with argument BOUNDARIES preserved, or nil when no argv is
+// readable (a foreign user's process, a zombie, a kernel thread).
+//
+// The boundaries are the whole contract. This classifies a process by its binary name
+// (argsAreDaemonBinary), so an install path containing a space must arrive as ONE element:
+// "/Users/John Smith/.local/bin/af" has base "af", while the same path re-split on whitespace has
+// base "John" and no longer looks like a daemon at all (#1214).
+//
+// It used to prefer /proc and fall back to `ps -p <pid> -o args=`, whose output is already
+// space-joined — so the fallback could not recover the boundaries it needed and the code said so
+// in a comment: spaced-install detection was "only fully reliable where /proc exists". That
+// caveat was a live bug wearing a disclaimer, and it was worst exactly where it was untested:
+// spaces in paths are ordinary on macOS (/Users/First Last, /Volumes/Macintosh HD, ~/Library/
+// Application Support) and rare on Linux. proctree.Argv now reads real argv on both platforms
+// (/proc/<pid>/cmdline on Linux, KERN_PROCARGS2 on darwin), so there is no lossy path left to
+// fall back to and the caveat is retired (#1942).
 func daemonArgs(pid int) []string {
-	if args := readProcArgv(pid); args != nil {
-		return args
-	}
-	ps := readPsArgs(pid)
-	if ps == "" {
-		return nil
-	}
-	return strings.Fields(ps)
-}
-
-// readProcArgv reads /proc/<pid>/cmdline (Linux) and splits it into argv on the NUL separators,
-// preserving spaces within an individual argument. Returns nil when /proc is unavailable or the
-// process has no cmdline (zombies, kernel threads).
-func readProcArgv(pid int) []string {
-	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
-	if err != nil {
-		return nil
-	}
-	return splitNULArgv(data)
-}
-
-// splitNULArgv splits a /proc cmdline blob on its NUL separators into argv, dropping the trailing
-// empty element left by the final NUL terminator. Returns nil for an empty/whitespace-only blob.
-func splitNULArgv(data []byte) []string {
-	parts := strings.Split(string(data), "\x00")
-	for len(parts) > 0 && parts[len(parts)-1] == "" {
-		parts = parts[:len(parts)-1]
-	}
-	if len(parts) == 0 {
-		return nil
-	}
-	return parts
-}
-
-// readPsArgs returns the full command line for pid via `ps -p <pid> -o args=`. This flag set is
-// portable across Linux and macOS.
-func readPsArgs(pid int) string {
-	psPath, err := exec.LookPath("ps")
-	if err != nil {
-		return ""
-	}
-	out, err := exec.Command(psPath, "-p", fmt.Sprintf("%d", pid), "-o", "args=").Output()
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(out))
+	return proctree.Argv(pid)
 }

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -299,25 +299,20 @@ func TestIsAgentFactoryDaemon_RequiresBinaryName(t *testing.T) {
 	// daemon was undetectable — breaking `af reset`, health, and foreign-daemon
 	// scans for every spaced install path. It must now validate true.
 	//
-	// Guarded on /proc because THIS ASSERTION CANNOT HOLD ON darwin — a REAL
-	// DEFECT (#1942), not a harness quirk: daemonArgs recovers argv boundaries
-	// from /proc/<pid>/cmdline, and macOS's `ps -p <pid> -o args=` fallback is
-	// already space-joined, so #1214's fix is Linux-only and af's daemon really
-	// is undetectable under a spaced install path there. Only this assertion is
-	// guarded — the #1004 binary-name gates around it hold on darwin and must
-	// keep running, which skipping the whole test would throw away. Remove the
-	// guard when #1942 lands KERN_PROCARGS2-based argv on darwin.
-	if testguard.HasProcFS() {
-		spacedPID := spawn("/home/John Smith/.local/bin/af")
-		if !isAgentFactoryDaemon(spacedPID) {
-			t.Errorf("isAgentFactoryDaemon(pid with argv %q) = false; "+
-				"want true — an af daemon installed under a spaced path must validate (#1214)",
-				daemonArgs(spacedPID))
-		}
-	} else {
-		t.Logf("skipping the #1214 spaced-install assertion: no /proc, so argv boundaries " +
-			"are unrecoverable and af's daemon is genuinely undetectable under a spaced " +
-			"path here — see #1942 (REAL DEFECT)")
+	// This runs on EVERY platform, which is the #1942 fix in one line. It used
+	// to be gated on /proc, because #1214's fix only worked where /proc could
+	// hand back real argv boundaries; on darwin the `ps -o args=` fallback had
+	// already joined them and af's own daemon was genuinely undetectable under
+	// a spaced install path. That gate was pointed at the platform where the
+	// breaking input is COMMON — /Users/First Last is an ordinary macOS home —
+	// so the one place the assertion was skipped is the one place users hit it.
+	// daemonArgs now reads real argv on both platforms (#1942), so the
+	// assertion holds everywhere and is asserted everywhere.
+	spacedPID := spawn("/home/John Smith/.local/bin/af")
+	if !isAgentFactoryDaemon(spacedPID) {
+		t.Errorf("isAgentFactoryDaemon(pid with argv %q) = false; "+
+			"want true — an af daemon installed under a spaced path must validate (#1214, #1942)",
+			daemonArgs(spacedPID))
 	}
 
 	// A non-af binary under a spaced path carrying --daemon must still be

--- a/daemon/httpserver.go
+++ b/daemon/httpserver.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sachiniyer/agent-factory/agentproto"
 	"github.com/sachiniyer/agent-factory/apiproto"
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/sockpath"
 	"github.com/sachiniyer/agent-factory/log"
 )
 
@@ -51,12 +52,20 @@ var maxHTTPBodyBytes int64 = 16 << 20
 const httpReadHeaderTimeout = 10 * time.Second
 
 // DaemonHTTPSocketPath returns the path of the daemon's HTTP/JSON Unix socket.
+//
+// Length-checked at resolution for the same reason as DaemonSocketPath: see
+// there, and #1940. This name is the longest of the daemon's sockets, so it is
+// the one that overruns first.
 func DaemonHTTPSocketPath() (string, error) {
 	dir, err := config.GetConfigDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(dir, daemonHTTPSocketFileName), nil
+	path := filepath.Join(dir, daemonHTTPSocketFileName)
+	if err := sockpath.Check("daemon HTTP socket", path); err != nil {
+		return "", err
+	}
+	return path, nil
 }
 
 // startHTTPServer binds the HTTP/JSON server on its own Unix socket and serves

--- a/daemon/socket_path_test.go
+++ b/daemon/socket_path_test.go
@@ -1,0 +1,91 @@
+package daemon
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/internal/sockpath"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+)
+
+// These pin #1940: the daemon's OWN sockets get the same length guard the VS
+// Code socket next door has had all along.
+//
+// The asymmetry was the whole bug. A secondary feature (the editor pane) failed
+// with an error naming the path, the limit and AGENT_FACTORY_HOME, while the
+// core control plane failed with "bind: invalid argument" — a bare kernel errno
+// naming nothing at all, from which no user could work out that their AF home
+// was the problem.
+
+// TestDaemonSocketPathsRejectOverlongHome is the regression: both daemon
+// sockets must refuse an over-long home at RESOLUTION, before net.Listen turns
+// it into an opaque errno.
+func TestDaemonSocketPathsRejectOverlongHome(t *testing.T) {
+	deep := filepath.Join(testguard.SocketTempDir(t), strings.Repeat("d", 80), strings.Repeat("e", 80))
+	t.Setenv("AGENT_FACTORY_HOME", deep)
+
+	for _, tc := range []struct {
+		name string
+		fn   func() (string, error)
+	}{
+		{"control socket", DaemonSocketPath},
+		{"HTTP socket", DaemonHTTPSocketPath},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path, err := tc.fn()
+			if err == nil {
+				t.Fatalf("resolved %q (%d bytes) with no error; net.Listen would fail as a bare "+
+					"'bind: invalid argument' naming nothing (#1940)", path, len(path))
+			}
+			if !strings.Contains(err.Error(), "AGENT_FACTORY_HOME") {
+				t.Errorf("error %q does not name AGENT_FACTORY_HOME — the one knob that fixes it", err)
+			}
+		})
+	}
+}
+
+// TestDaemonSocketPathsAcceptDefaultHome is the guard on the guard. This runs
+// on the daemon's startup path, so a spurious or off-by-one check would stop af
+// starting for EVERYONE — strictly worse than the unactionable message it
+// replaces. An ordinary home must resolve cleanly.
+func TestDaemonSocketPathsAcceptDefaultHome(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+
+	for _, tc := range []struct {
+		name string
+		fn   func() (string, error)
+	}{
+		{"control socket", DaemonSocketPath},
+		{"HTTP socket", DaemonHTTPSocketPath},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := tc.fn(); err != nil {
+				t.Errorf("%s rejected an ordinary home: %v", tc.name, err)
+			}
+		})
+	}
+}
+
+// TestRealisticMacDefaultHomeResolves walks the arithmetic through the REAL
+// resolution path rather than a recomputation of it: a stock macOS home must
+// leave both sockets comfortably inside darwin's 103-byte ceiling.
+//
+// sockpath.Portable is darwin's ceiling, so this asserts the mac outcome on any
+// runner. See internal/sockpath for the full table and the verdict: a default
+// install needs a 65-character username to overrun, which is why #1940 is a
+// real-but-narrow defect rather than "af does not work on my Mac".
+func TestRealisticMacDefaultHomeResolves(t *testing.T) {
+	for _, user := range []string{"pradeepiyer", "firstname.lastname"} {
+		t.Run(user, func(t *testing.T) {
+			home := filepath.Join("/Users", user, ".agent-factory")
+			for _, name := range []string{daemonSocketFileName, daemonHTTPSocketFileName} {
+				path := filepath.Join(home, name)
+				if len(path) > sockpath.Portable {
+					t.Errorf("%s is %d bytes, over darwin's %d — a DEFAULT mac install cannot be broken by this guard",
+						path, len(path), sockpath.Portable)
+				}
+			}
+		})
+	}
+}

--- a/daemon/stopall.go
+++ b/daemon/stopall.go
@@ -1,15 +1,14 @@
 package daemon
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
-	"syscall"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/proctree"
 	"github.com/sachiniyer/agent-factory/log"
 )
 
@@ -260,18 +259,17 @@ func canonicalDir(dir string) (string, error) {
 }
 
 // processUID returns the uid owning pid. The second return is false when
-// ownership cannot be determined (no /proc, or the process exited), which
-// callers must treat as "unknown", never as "ours".
+// ownership cannot be determined (the process exited, or the platform will not
+// say), which callers must treat as "unknown", never as "ours".
+//
+// Through proctree rather than /proc directly: this read had no darwin path, so
+// on macOS it answered "unknown" for every process, and classifyDaemon returned
+// daemonUnverifiable for every daemon — meaning `af reset` could never verify,
+// and therefore never stop, anything. That is the same user-facing breakage as
+// #1942, from the same root (#1939): a Linux-only inspection primitive with no
+// backend for the platform we ship.
 func processUID(pid int) (int, bool) {
-	fi, err := os.Stat(fmt.Sprintf("/proc/%d", pid))
-	if err != nil {
-		return 0, false
-	}
-	st, ok := fi.Sys().(*syscall.Stat_t)
-	if !ok {
-		return 0, false
-	}
-	return int(st.Uid), true
+	return proctree.UID(pid)
 }
 
 // daemonHomeEnv reports the AGENT_FACTORY_HOME a running process was started
@@ -284,24 +282,38 @@ func processUID(pid int) (int, bool) {
 //     COMMON case, since almost nobody sets AGENT_FACTORY_HOME, and treating it
 //     as "unknown" would skip exactly the everyday stale daemon reset exists to
 //     kill.
-//   - ("", false): the environ was UNREADABLE — no /proc (macOS), a foreign
-//     uid, or the process exited. We cannot tell which home it serves, and
-//     must not guess it is the default.
+//   - ("", false): the environ was UNREADABLE — a foreign uid, or the process
+//     exited. We cannot tell which home it serves, and must not guess it is the
+//     default.
 //
 // The environ is fixed at exec and cannot be shed, so what it says about the
 // home a daemon resolved at startup stays true for the life of the process.
+//
+// Read through proctree.Environ rather than /proc directly, which is what makes
+// the first case reachable on darwin at all: before #1939 this was a bare /proc
+// read, so on macOS EVERY daemon landed in the second case and `af reset` left
+// all of them alone. Environ (not EnvValue) precisely because EnvValue folds
+// "absent" and "unreadable" into one false, and the whole point of this
+// function is that those two must not be confused.
 func daemonHomeEnv(pid int) (string, bool) {
-	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/environ", pid))
-	if err != nil {
+	home, status := proctree.LookupEnv(pid, "AGENT_FACTORY_HOME")
+	switch status {
+	case proctree.EnvFound:
+		return home, true
+	case proctree.EnvAbsent:
+		// READ, and the variable genuinely is not set — so this daemon
+		// resolved the DEFAULT home. This is the common case and must keep
+		// working: almost nobody sets AGENT_FACTORY_HOME, and treating it as
+		// unknown would skip exactly the everyday stale daemon reset exists
+		// to kill.
+		return "", true
+	default:
+		// EnvUnknown. NOT "unset": we were not allowed to look. Returning
+		// ("", true) here would resolve the DEFAULT home, and if that happens
+		// to be ours we would SIGTERM a daemon whose home we never read. The
+		// caller turns this into daemonUnverifiable and leaves it alone.
 		return "", false
 	}
-	const key = "AGENT_FACTORY_HOME="
-	for _, kv := range bytes.Split(data, []byte{0}) {
-		if bytes.HasPrefix(kv, []byte(key)) {
-			return string(kv[len(key):]), true
-		}
-	}
-	return "", true
 }
 
 // RemoveRuntimeSockets unlinks the Unix sockets under the AF home that a client

--- a/daemon/vscode_socket.go
+++ b/daemon/vscode_socket.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/sockpath"
 	"github.com/sachiniyer/agent-factory/log"
 )
 
@@ -48,11 +49,15 @@ const vscodeSocketExt = ".sock"
 // the owning user only, matching the daemon's own control socket.
 const vscodeSocketMode = "0600"
 
-// maxUnixSocketPathLen bounds a socket path. sockaddr_un.sun_path is 108 bytes on
-// Linux and 104 on macOS; 103 is the portable ceiling once the NUL terminator is
-// counted. Exceeding it fails inside the kernel as an opaque "invalid argument",
-// so the limit is checked up front where the message can name the cause.
-const maxUnixSocketPathLen = 103
+// The socket-path ceiling this file used to define now lives in
+// internal/sockpath, which every socket in af shares. It was defined here, and
+// enforced only here, which is how the daemon's OWN sockets ended up with no
+// check at all: the editor pane failed with a message naming AGENT_FACTORY_HOME
+// while the control plane failed with a bare kernel errno (#1940).
+//
+// sockpath.Max is also the platform's real limit rather than the portable 103
+// this constant hardcoded, so on Linux the bound is now 107 — a loosening, which
+// can only accept paths that previously worked.
 
 // vscodeUpstreamHost is the Host the proxy presents to a socket-bound editor.
 //
@@ -282,9 +287,8 @@ func vscodeSocketPath(key string) (string, error) {
 	sum := sha256.Sum256([]byte(key))
 	name := hex.EncodeToString(sum[:4]) + "-" + hex.EncodeToString(nonce[:]) + vscodeSocketExt
 	path := filepath.Join(dir, name)
-	if len(path) > maxUnixSocketPathLen {
-		return "", fmt.Errorf("the VS Code socket path %q is %d bytes, over the %d-byte limit for a unix socket: "+
-			"set AGENT_FACTORY_HOME to a shorter path", path, len(path), maxUnixSocketPathLen)
+	if err := sockpath.Check("VS Code socket", path); err != nil {
+		return "", err
 	}
 	return path, nil
 }

--- a/docs/remote-hooks.md
+++ b/docs/remote-hooks.md
@@ -191,20 +191,43 @@ if [ -n "$BRANCH" ]; then               # restore: bring the archived branch bac
 fi
 
 # Start the agent-server; capture its startup banner (one JSON line on stdout).
+# `nohup … &` detaches it: this script exits as soon as it has the banner, and the
+# server must outlive it. Both redirects are required — they keep the server off
+# this script's stdout/stderr, which af reads to end of file, and they are where
+# the server's own startup errors land.
 BANNER="$WORKDIR/banner.json"
+LOG="$WORKDIR/agent-server.log"
 ARGS=(agent-server --listen 0.0.0.0:0 --repo "$WORKDIR/workspace" --title "$TITLE")
 [ -n "$PROGRAM" ] && ARGS+=(--program "$PROGRAM")
 [ -n "$AUTOYES" ] && ARGS+=("$AUTOYES")
-setsid af "${ARGS[@]}" >"$BANNER" 2>"$WORKDIR/agent-server.log" &
+nohup af "${ARGS[@]}" >"$BANNER" 2>"$LOG" &
 echo $! > "$WORKDIR/pid"
 
 # Wait for the banner, then re-emit it as the endpoint contract.
 for _ in $(seq 1 200); do grep -q '"addr"' "$BANNER" && break; sleep 0.1; done
 ADDR=$(sed -n 's/.*"addr":"\([^"]*\)".*/\1/p' "$BANNER")
 TOKEN=$(sed -n 's/.*"token":"\([^"]*\)".*/\1/p' "$BANNER")
-[ -n "$ADDR" ] || { echo "agent-server did not start" >&2; cat "$WORKDIR/agent-server.log" >&2; exit 1; }
+# Always echo the server's own output on failure. af reports what this script
+# prints, so anything you do not surface here reaches nobody.
+[ -n "$ADDR" ] || { echo "af agent-server printed no banner; its output was:" >&2; cat "$LOG" >&2; exit 1; }
 printf '{"url":"http://%s","token":"%s"}\n' "$ADDR" "$TOKEN"
 ```
+
+> **Why `nohup` and not `setsid`?** `setsid` is part of util-linux and **does not
+> exist on macOS**, so a Mac user copying an earlier version of this recipe got
+> `setsid: command not found` (#1946). `nohup` is POSIX and present on both.
+>
+> What the detach actually needs here is for the server to outlive this script,
+> and the `&` alone already delivers that: the script exits immediately, and the
+> kernel reparents the server to `init`/`launchd`. `nohup` adds immunity to the
+> `SIGHUP` you would get by running this script by hand from a terminal that then
+> closes. `setsid` additionally made the server a session leader, which this
+> recipe never relied on.
+>
+> If you replace this with your own launcher, keep the two properties that matter:
+> the server **survives this script**, and it **does not inherit this script's
+> stdout/stderr**. A launcher that holds those pipes open will hang `launch_cmd`
+> until the server exits, because af reads them to end of file.
 
 The matching `delete.sh`:
 
@@ -218,7 +241,7 @@ WORKDIR="$HOME/.af-hook/$NAME"
 rm -rf "$WORKDIR"
 ```
 
-For a real orchestrator, replace `WORKDIR=…` / `setsid af …` with your provisioning (create a pod, `ssh` to a host, spin up a Modal/Daytona sandbox) and run `af agent-server` there, then surface its banner however you reach it (e.g. read a published address). The daemon only needs the `url` and `token` back — over plain HTTP, so make sure the address you hand back is reachable from the daemon on a private network or tunnel.
+For a real orchestrator, replace `WORKDIR=…` / `nohup af …` with your provisioning (create a pod, `ssh` to a host, spin up a Modal/Daytona sandbox) and run `af agent-server` there, then surface its banner however you reach it (e.g. read a published address). The daemon only needs the `url` and `token` back — over plain HTTP, so make sure the address you hand back is reachable from the daemon on a private network or tunnel.
 
 ## Migrating from the old contract
 

--- a/doctor/checks.go
+++ b/doctor/checks.go
@@ -2,10 +2,12 @@ package doctor
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -161,7 +163,41 @@ func checkDaemonHealth(ctx *scanContext, report *Report, h daemon.HealthStatus) 
 // marker + live session but outside its pane trees = escaped (report-only);
 // no marker but a TMUX env var pointing at a dead server = possible orphan
 // (report-only — could belong to any tmux, not necessarily agent-factory).
+// checkProcessInspection reports whether doctor can see the process table at
+// all, and it must run BEFORE every check that reads ctx.snap.
+//
+// This is the check that exists because of what its absence did (#1939).
+// proctree was /proc-only with no darwin backend, so on macOS every snapshot
+// failed, Run discarded the error, and the process checks below returned early
+// on a nil snap. Nothing was reported — not a warning, not a note — so `af
+// doctor` printed a clean report on a machine it had never managed to inspect.
+// Every macOS user who ran doctor to ask "are there orphaned processes?" was
+// told "no" by a program that could not have known either way.
+//
+// So blindness gets its own row, and that row is a FAIL: it contributes to the
+// exit code, because "I could not look" is a broken doctor, not a healthy
+// machine. Do not soften this to a Warn, and do not let the process checks
+// below start reporting emptiness as health.
+func checkProcessInspection(ctx *scanContext, report *Report) {
+	if ctx.snap != nil {
+		report.Pass(sectionProcesses, "process-inspection",
+			fmt.Sprintf("read the process table (%d processes)", len(ctx.snap)))
+		return
+	}
+	detail := fmt.Sprintf("cannot read the process table on %s, so the orphan, escaped-process and "+
+		"runaway-CPU checks below could not run: %v", runtime.GOOS, ctx.snapErr)
+	remediation := "the checks that depend on the process table are UNKNOWN, not clean — " +
+		"do not read this report as evidence that no processes leaked"
+	if errors.Is(ctx.snapErr, proctree.ErrUnsupportedPlatform) {
+		remediation = fmt.Sprintf("af has no process-table backend for %s; the process checks cannot run here "+
+			"and this report says nothing about leaked processes", runtime.GOOS)
+	}
+	report.Fail(sectionProcesses, "process-inspection", detail, remediation)
+}
+
 func checkOrphanedProcesses(ctx *scanContext, report *Report) {
+	// Silent only because checkProcessInspection already reported the
+	// blindness as a FAIL. Never make this branch the whole story again.
 	if ctx.snap == nil {
 		return
 	}
@@ -176,11 +212,17 @@ func checkOrphanedProcesses(ctx *scanContext, report *Report) {
 		if ctx.selfAncestors[pid] {
 			continue
 		}
-		if name, ok := proctree.EnvValue(pid, tmux.EnvMarkerSession); ok && name != "" {
+		// EnvUnknown must NOT land in `marked`: that set is the killable
+		// candidate pool, and a process we could not read is a process we
+		// cannot claim is ours. It falls through to the report-only paths
+		// below, which is the safe direction — we under-report an orphan
+		// rather than act on one we never identified.
+		name, nameStatus := proctree.LookupEnv(pid, tmux.EnvMarkerSession)
+		if nameStatus == proctree.EnvFound && name != "" {
 			marked[name] = append(marked[name], p)
 			continue
 		}
-		if tmuxEnv, ok := proctree.EnvValue(pid, "TMUX"); ok && tmuxServerDead(ctx, tmuxEnv) {
+		if tmuxEnv, st := proctree.LookupEnv(pid, "TMUX"); st == proctree.EnvFound && tmuxServerDead(ctx, tmuxEnv) {
 			possibles = append(possibles, p)
 		}
 	}
@@ -212,7 +254,12 @@ func checkOrphanedProcesses(ctx *scanContext, report *Report) {
 			// to this server's live list, so its perfectly healthy processes
 			// would otherwise masquerade as verified orphans here. Foreign
 			// or missing AF_HOME downgrades to report-only.
-			home, hasHome := proctree.EnvValue(p.PID, tmux.EnvMarkerHome)
+			// Only EnvFound may arm the kill. EnvUnknown (a denied or
+			// redacted read) falls to the default arm — report-only —
+			// because "I could not read its home" is not "its home is
+			// mine".
+			home, homeStatus := proctree.LookupEnv(p.PID, tmux.EnvMarkerHome)
+			hasHome := homeStatus == proctree.EnvFound
 			switch {
 			case hasHome && filepath.Clean(home) == filepath.Clean(ctx.opts.ConfigDir):
 				report.Findings = append(report.Findings, Finding{
@@ -305,9 +352,12 @@ func tmuxServerDead(ctx *scanContext, tmuxEnv string) bool {
 // checkRunawayChildren reports (never kills) descendants of live af_
 // sessions that have averaged a pegged core for an extended period.
 func checkRunawayChildren(ctx *scanContext, report *Report) {
+	// See checkOrphanedProcesses: blindness is reported once, by
+	// checkProcessInspection, rather than swallowed here.
 	if ctx.snap == nil {
 		return
 	}
+	unmeasurable := 0
 	for _, name := range listTmuxSessions(ctx) {
 		if !strings.HasPrefix(name, tmux.TmuxPrefix) {
 			continue
@@ -319,6 +369,16 @@ func checkRunawayChildren(ctx *scanContext, report *Report) {
 				continue
 			}
 			frac, age, err := proctree.CPUFraction(p)
+			if errors.Is(err, proctree.ErrCPUUnknown) {
+				// Counted, not swallowed. A check that cannot answer must say
+				// so: silently skipping every process would render "no runaway
+				// processes" — the exact shape of the report this package
+				// exists to stop printing. Reported once below rather than per
+				// process, since the cause is usually systemic (a subset=pid
+				// procfs hides /proc/uptime, so NO process has an age).
+				unmeasurable++
+				continue
+			}
 			if err != nil || frac < runawayCPUFraction || age < runawayMinAge.Seconds() {
 				continue
 			}
@@ -328,6 +388,12 @@ func checkRunawayChildren(ctx *scanContext, report *Report) {
 					"check the session; doctor never kills children of live sessions", describeProc(p), name),
 			})
 		}
+	}
+	if unmeasurable > 0 {
+		report.Warn(sectionProcesses, "runaway-cpu",
+			fmt.Sprintf("could not measure CPU for %s in live sessions, so this check reports nothing "+
+				"about them", plural(unmeasurable, "process", "processes")),
+			"a process pegging a core would not be spotted here; inspect the sessions yourself", false)
 	}
 }
 
@@ -347,7 +413,7 @@ func checkLeakedTmuxSessions(ctx *scanContext, report *Report) {
 	for _, name := range leaked {
 		origin := "no ancestry marker"
 		if procs := tmux.SessionProcessTrees(ctx.opts.Exec, name); len(procs) > 0 {
-			if home, ok := proctree.EnvValue(procs[0].PID, tmux.EnvMarkerHome); ok {
+			if home, st := proctree.LookupEnv(procs[0].PID, tmux.EnvMarkerHome); st == proctree.EnvFound {
 				if filepath.Clean(home) == filepath.Clean(ctx.opts.ConfigDir) {
 					origin = "created by this install"
 				} else {
@@ -424,7 +490,7 @@ var afHomeMarkers = []string{
 func checkStaleTempHomes(ctx *scanContext, report *Report) {
 	tempDir := filepath.Clean(ctx.opts.TempDir)
 	activeHome := filepath.Clean(ctx.opts.ConfigDir)
-	homesInUse := processReferencedHomes(ctx.snap)
+	homesInUse, unreadableProcs := processReferencedHomes(ctx.snap)
 	tmuxHomesInUse := liveTmuxHomes(ctx)
 
 	for _, dir := range candidateTempHomes(tempDir) {
@@ -432,7 +498,7 @@ func checkStaleTempHomes(ctx *scanContext, report *Report) {
 		if dir == activeHome || !isAFHome(dir) {
 			continue
 		}
-		if reason := tempHomeInUseReason(dir, homesInUse, tmuxHomesInUse); reason != "" {
+		if reason := tempHomeInUseReason(dir, homesInUse, tmuxHomesInUse, unreadableProcs); reason != "" {
 			report.Pass(sectionProcesses, "temp home", fmt.Sprintf("%s is in use (%s)", dir, reason))
 			continue
 		}
@@ -440,17 +506,52 @@ func checkStaleTempHomes(ctx *scanContext, report *Report) {
 		if age < ctx.opts.MinTempHomeAge {
 			continue
 		}
-		// Containment re-check before offering an rm -rf.
 		if !pathInside(tempDir, dir) {
 			continue
 		}
-		removeDir := dir
+		// REPORT-ONLY. No FixAction, no fix closure: `af doctor --fix` will
+		// not delete this, and that is deliberate.
+		//
+		// This finding used to carry an rm -rf, gated on "no process
+		// references this home". FOUR consecutive P1 reviews found four
+		// different ways to make that negative false, and every one of them
+		// ended at this same delete:
+		//
+		//   1. darwin redacts a foreign process's environment silently, so an
+		//      unread env read as "references no home".
+		//   2. the permission gate written to fix (1) modelled uid but not
+		//      CS_RESTRICT, which SIP makes ordinary — so a same-uid restricted
+		//      process read as "references no home".
+		//   3. (the gate was deleted; classify the answer instead.)
+		//   4. the uid filter that survived assumed temp homes sit under a
+		//      user-owned root. Linux's /tmp is 01777 and shared, so another
+		//      user's home lives there and their processes read as
+		//      "references no home".
+		//
+		// That is not four bugs. It is one unsound question: "can I prove
+		// nobody is using this?" cannot be answered by inspecting processes.
+		// Process inspection is inference over a surface that is adversarial by
+		// construction — kernels redact, policies grow clauses we did not
+		// model, /proc can be mounted subset=pid, /tmp is shared with users we
+		// cannot see, PIDs recycle. Each of those turns "I saw no user" into
+		// "there is no user", and that negative authorised an rm -rf.
+		//
+		// So the teeth come out until the predicate is a FACT rather than an
+		// inference: a lockfile the owning process holds for its lifetime,
+		// where "is this in use?" is answered by trying to take the lock and
+		// the kernel is the authority (see the follow-up issue; af homes
+		// already have exactly such a lock in daemon/singleton_lock.go).
+		//
+		// Reporting is honest; authorising is dangerous; they are not the same
+		// code path. Doctor still names the directory and still says what it
+		// could not verify — the operator decides.
 		report.Findings = append(report.Findings, Finding{
 			Check: "stale-temp-home",
-			Detail: fmt.Sprintf("abandoned agent-factory home %s (untouched for %s)",
+			Detail: fmt.Sprintf("agent-factory home %s looks abandoned (untouched for %s), but nothing "+
+				"here can PROVE it is unused — inspect it and remove it yourself if it is dead",
 				dir, formatAge(age.Seconds())),
-			FixAction: "remove " + dir,
-			fix:       staleTempHomeRemoveFix(ctx, removeDir),
+			Severity:    StatusWarn,
+			Remediation: "verify nothing is using it, then `rm -rf " + dir + "`",
 		})
 	}
 }
@@ -496,17 +597,67 @@ func isAFHome(dir string) bool {
 	return found >= 2
 }
 
-func processReferencedHomes(snap map[int]proctree.Process) map[string]bool {
-	homes := map[string]bool{}
+// processReferencedHomes returns the AF homes live processes name in their
+// environment, AND the number of processes whose environment could not be read.
+//
+// The second return is the whole point, and dropping it would restore a
+// DESTRUCTIVE bug. This feeds tempHomeInUseReason, whose negative — "no process
+// references this home" — is the predicate for os.RemoveAll. A process whose
+// environment we could not read might be using the home; if its unreadability
+// is silently folded into "does not reference it", doctor --fix deletes a home
+// that is in use, on the strength of a read that was denied.
+//
+// This is not hypothetical on darwin: the kernel redacts a foreign process's
+// environment and the buffer looks identical to one with no variables at all
+// (see internal/proctree's darwin readEnviron). Linux says EACCES honestly, but
+// the caller cannot depend on the platform to be honest for it.
+//
+// Only OUR OWN processes count toward unreadable. A home under this user's
+// 0700 temp dir cannot be in use by another user's process, so a foreign
+// process being unreadable tells us nothing we needed to know — and counting it
+// would make --fix refuse forever on any real machine, where most of the
+// process table belongs to root.
+func processReferencedHomes(snap map[int]proctree.Process) (homes map[string]bool, unreadable int) {
+	homes = map[string]bool{}
 	if snap == nil {
-		return homes
+		return homes, 0
 	}
+	self := os.Getuid()
 	for pid := range snap {
-		if home, ok := proctree.EnvValue(pid, "AGENT_FACTORY_HOME"); ok && home != "" {
-			homes[filepath.Clean(home)] = true
+		home, status := proctree.LookupEnv(pid, "AGENT_FACTORY_HOME")
+		switch status {
+		case proctree.EnvFound:
+			if home != "" {
+				homes[filepath.Clean(home)] = true
+			}
+		case proctree.EnvAbsent:
+			// Read, and it names no home: it cannot be using one.
+		default:
+			// EnvUnknown. Narrow it to the processes whose unreadability
+			// actually costs us knowledge, or --fix would refuse forever:
+			// on a real machine most of the table is root's, and darwin
+			// redacts every one of those environments.
+			uid, ok := proctree.UID(pid)
+			switch {
+			case !ok:
+				// No credentials at all means the process is gone — it was
+				// in the snapshot and has since exited. A dead process uses
+				// nothing, so its silence costs us nothing. (Ownership comes
+				// from the process table, which is readable for ANY process
+				// on both platforms, so a failure here is absence of the
+				// process rather than absence of permission.)
+			case uid != self:
+				// Another user's process. It cannot be using a home under
+				// this user's 0700 temp dir, so whether we can read its
+				// environment is irrelevant to the question being asked.
+			default:
+				// Ours, alive, and unreadable: precisely the case we cannot
+				// rule out.
+				unreadable++
+			}
 		}
 	}
-	return homes
+	return homes, unreadable
 }
 
 func liveTmuxHomes(ctx *scanContext) map[string]bool {
@@ -567,13 +718,22 @@ func tempHomeDaemonLiveness(dir string) tempHomeDaemonStatus {
 	return tempHomeDaemonAbsentOrDead
 }
 
-func tempHomeInUseReason(dir string, processHomes, tmuxHomes map[string]bool) string {
+// tempHomeInUseReason returns why dir must not be removed, or "" when it is
+// provably unused. unreadableProcs is how many of this user's processes have an
+// environment we could not read: each one is a process that MIGHT reference
+// dir, so a non-zero count means "unused" cannot be proven and the directory
+// stays. That mirrors the tempHomeDaemonUnknown arm below — this function
+// already knew that uncertainty is a reason to keep, not to delete.
+func tempHomeInUseReason(dir string, processHomes, tmuxHomes map[string]bool, unreadableProcs int) string {
 	dir = filepath.Clean(dir)
 	switch {
 	case processHomes[dir]:
 		return "live process references it"
 	case tmuxHomes[dir]:
 		return "live tmux session references it"
+	case unreadableProcs > 0:
+		return fmt.Sprintf("%d of this user's processes have an unreadable environment, so nothing proves "+
+			"they are not using it", unreadableProcs)
 	}
 	switch tempHomeDaemonLiveness(dir) {
 	case tempHomeDaemonAlive:
@@ -585,57 +745,20 @@ func tempHomeInUseReason(dir string, processHomes, tmuxHomes map[string]bool) st
 	}
 }
 
-func staleTempHomeRemoveFix(ctx *scanContext, dir string) func() error {
-	return func() error {
-		dir := filepath.Clean(dir)
-		if _, err := os.Stat(dir); err != nil {
-			if os.IsNotExist(err) {
-				return nil
-			}
-			return fmt.Errorf("cannot stat %s before removal: %w", dir, err)
-		}
-		if !pathInside(filepath.Clean(ctx.opts.TempDir), dir) {
-			return fmt.Errorf("refusing to remove %s outside temp dir %s", dir, ctx.opts.TempDir)
-		}
-		if filepath.Clean(ctx.opts.ConfigDir) == dir {
-			return fmt.Errorf("refusing to remove active agent-factory home %s", dir)
-		}
-		if !isAFHome(dir) {
-			return fmt.Errorf("refusing to remove %s: it no longer looks like an agent-factory home", dir)
-		}
-
-		// Re-take the process snapshot at fix time: a home that looked
-		// abandoned during detection may have been claimed since. When the
-		// recheck fails, how we react depends on whether detection had a
-		// working snapshot at all:
-		//   - detection got one (ctx.snap != nil): the process guard was live
-		//     protection we now can't reproduce, and ctx.snap is stale. Fail
-		//     closed rather than delete on stale data — a process that started
-		//     using dir after detection would otherwise lose its home.
-		//   - detection had none (ctx.snap == nil, e.g. no /proc on macOS):
-		//     the process guard is unavailable on this platform and was a
-		//     no-op at detection too. Keep snap nil and fall through to the
-		//     daemon.pid + tmux guards, exactly as before — otherwise --fix
-		//     could never clean a stale temp home on such platforms.
-		snap := ctx.snap
-		if ctx.opts.snapshot == nil {
-			// Unreachable via Run (applyDefaults always installs one). Fail
-			// closed rather than delete on the stale detection snapshot.
-			return fmt.Errorf("refusing to remove %s: no process snapshot available", dir)
-		}
-		fresh, err := ctx.opts.snapshot()
-		switch {
-		case err == nil:
-			snap = fresh
-		case ctx.snap != nil:
-			return fmt.Errorf("refusing to remove %s: process snapshot failed: %w", dir, err)
-		}
-		if reason := tempHomeInUseReason(dir, processReferencedHomes(snap), liveTmuxHomes(ctx)); reason != "" {
-			return fmt.Errorf("refusing to remove %s: %s", dir, reason)
-		}
-		return os.RemoveAll(dir)
-	}
-}
+// staleTempHomeRemoveFix is DELETED. Do not reintroduce it without the lock.
+//
+// It was the --fix closure that rm -rf'd an "abandoned" temp home, and it was
+// careful: containment checks, an active-home check, an isAFHome check, and a
+// fresh snapshot at fix time. None of that was the problem. Its PREDICATE was:
+// it asked "did I see any process referencing this home?" and treated "no" as
+// proof. Four consecutive P1 reviews found four different ways for that "no" to
+// be false (see checkStaleTempHomes), each one ending here, in an rm -rf.
+//
+// The care was real and it did not help, because you cannot make an unsound
+// question safe by validating its inputs harder. The delete returns when the
+// predicate is a fact the kernel guarantees — try to take the home's lock —
+// rather than an inference we assemble from a surface that redacts, restricts
+// and shares. See the follow-up issue.
 
 func pathInside(base, path string) bool {
 	rel, err := filepath.Rel(base, path)
@@ -698,6 +821,14 @@ func checkForeignDaemons(ctx *scanContext, report *Report) {
 			// The environ was unreadable, so which home this daemon serves is
 			// genuinely unknown. Calling it foreign would be a guess, and --fix
 			// would then offer to kill a process on the strength of that guess.
+			//
+			// homeKnown is resolved upstream by daemonProcessHome, which reads
+			// the environ through proctree.EnvLookup — now backed by the
+			// three-valued LookupEnv (this PR), so a redacted or empty darwin
+			// environment lands here as "unknown → skip" rather than a
+			// fabricated default. The inline EnvUnknown/EnvAbsent switch this PR
+			// originally added here is therefore redundant with #1920's refactor
+			// and dropped in its favour.
 			continue
 		}
 		if home == activeHome || home == "" {

--- a/doctor/doctor.go
+++ b/doctor/doctor.go
@@ -171,18 +171,26 @@ type Options struct {
 	killGrace    time.Duration
 	killTermWait time.Duration
 
-	// snapshot overrides the /proc scan; tests inject a snapshot containing
-	// only their own spawned processes so a --fix run can never act on
-	// anything outside the test.
+	// snapshot overrides the process-table scan; tests inject a snapshot
+	// containing only their own spawned processes so a --fix run can never act
+	// on anything outside the test.
 	snapshot func() (map[int]proctree.Process, error)
 }
 
 // scanContext carries the shared, immutable inputs of one run.
 type scanContext struct {
 	opts Options
-	// snap is the /proc snapshot; nil when /proc is unavailable, in which
-	// case the process-based checks degrade to no-ops.
+	// snap is the process-table snapshot, or nil when it could not be read.
+	//
+	// nil means BLIND, not healthy. Every check that consumes it must say so
+	// out loud rather than skipping quietly: a doctor that finds no orphans
+	// because it never looked reports the same clean bill as a machine that
+	// genuinely has none, and the operator cannot tell which one they got.
+	// checkProcessInspection turns that state into a FAIL row; see snapErr.
 	snap map[int]proctree.Process
+	// snapErr is why snap is nil. Held so the report can name the cause
+	// instead of asserting health from an empty table (#1939).
+	snapErr error
 	// selfAncestors holds our own PID and every ancestor — never proposed
 	// for a kill, no matter what markers they carry.
 	selfAncestors map[int]bool
@@ -282,13 +290,22 @@ func Run(opts Options) (*Report, error) {
 	cfg := checkConfigAndStorage(ctx, report)
 	checkEnvironment(ctx, report, cfg)
 
+	// A failed snapshot is recorded, never discarded: checkProcessInspection
+	// reports it as a failure to OBSERVE, and the process checks below stay
+	// silent only because that row already spoke for them (#1939).
 	if snap, err := ctx.opts.snapshot(); err == nil {
 		ctx.snap = snap
 		for pid := range selfAndAncestors(snap) {
 			ctx.selfAncestors[pid] = true
 		}
+	} else {
+		ctx.snapErr = err
 	}
 
+	// Whether doctor can see the process table at all is reported FIRST, before
+	// every check that reads ctx.snap — a failed snapshot is a FAIL row naming
+	// the cause, never a silent omission read as health (#1939).
+	checkProcessInspection(ctx, report)
 	// One health probe feeds every daemon check: each call dials the control
 	// socket, and three checks asking the same daemon the same question could
 	// disagree if a restart landed between them.

--- a/doctor/doctor_test.go
+++ b/doctor/doctor_test.go
@@ -56,7 +56,12 @@ func TestMain(m *testing.M) {
 // scan root, fast kill windows, and a snapshot containing only pids.
 func testOptions(t *testing.T, fix bool, pids ...int) Options {
 	t.Helper()
-	return testOptionsWithHome(t, t.TempDir(), fix, pids...)
+	// SocketTempDir rather than t.TempDir: doctor resolves the daemon socket
+	// paths under this home, and on macOS a t.TempDir() home lands ~107 bytes —
+	// past sun_path, so the #1940 guard rejects it and doctor reports a socket
+	// problem that has nothing to do with what these tests assert. A real home
+	// (~/.agent-factory) is ~50 bytes; this keeps the fixture representative.
+	return testOptionsWithHome(t, testguard.SocketTempDir(t), fix, pids...)
 }
 
 // testOptionsWithHome is testOptions with a caller-chosen home, for tests
@@ -138,13 +143,11 @@ func snapshotOf(t *testing.T, pids ...int) func() (map[int]proctree.Process, err
 // cleanup Kill can never orphan anything (a forked `sleep` here once leaked
 // the very orphans this suite hunts). Waits until the child's /proc environ
 // is readable (the fork→exec window would otherwise race the scan).
-// It reads the child's environ through proctree, so it — and therefore every
-// test built on it — cannot run without /proc. Guarding here rather than at each
-// caller keeps the reason in ONE place: see #1939 (REAL DEFECT — proctree has no
-// darwin backend, so doctor's process mapping is silently broken on macOS, which
-// is exactly what these tests exist to prove works).
+// It reads the child's environ through proctree, which since #1939 has a real
+// backend on both platforms we ship — so this runs on macOS rather than
+// skipping there, which is the whole point: these tests are what prove doctor's
+// process mapping actually works, and on darwin it never did.
 func spawnWithEnv(t *testing.T, argv0 string, extraArgs []string, env map[string]string) proctree.Process {
-	testguard.RequireProcFS(t)
 	t.Helper()
 	stdinR, stdinW, err := os.Pipe()
 	require.NoError(t, err)
@@ -166,14 +169,14 @@ func spawnWithEnv(t *testing.T, argv0 string, extraArgs []string, env map[string
 	go func() { _, _ = c.Process.Wait() }()
 
 	require.Eventually(t, func() bool {
-		_, ok := proctree.EnvValue(c.Process.Pid, "PATH")
+		_, st := proctree.LookupEnv(c.Process.Pid, "PATH")
 		if len(env) > 0 {
 			for k := range env {
-				_, ok2 := proctree.EnvValue(c.Process.Pid, k)
-				return ok2
+				_, st2 := proctree.LookupEnv(c.Process.Pid, k)
+				return st2 == proctree.EnvFound
 			}
 		}
-		return ok
+		return st == proctree.EnvFound
 	}, 5*time.Second, 10*time.Millisecond, "child environ never became readable")
 
 	snap, err := proctree.Snapshot()
@@ -211,12 +214,17 @@ func findCheckRows(r *Report, name string) []CheckResult {
 // regression: a process whose AF_SESSION marker names a dead session is a
 // verified orphan — reported without --fix, killed with it.
 func TestOrphanedProcessDetectedAndFixed(t *testing.T) {
-	testguard.RequireProcFS(t)
 	testguard.IsolateTmux(t) // private server: the marked session is dead by construction
 
 	// The orphan's AF_HOME must match the run's ConfigDir — a kill requires
 	// a proven home match, not just a dead-looking session.
-	home := t.TempDir()
+	//
+	// SocketTempDir, not t.TempDir: doctor resolves the daemon socket under this
+	// home, and t.TempDir() is ~50 bytes on Linux but ~107 on macOS (it embeds
+	// the test name under /var/folders/<hash>/T/). The #1940 guard rightly
+	// rejects the latter, and doctor then reports a daemon-socket FAIL that has
+	// nothing to do with the orphan this test is about. A real home is short.
+	home := testguard.SocketTempDir(t)
 	orphan := spawnWithEnv(t, "sh", nil, map[string]string{
 		"AF_SESSION": "af_doctor-dead-session",
 		"AF_HOME":    home,
@@ -249,7 +257,6 @@ func TestOrphanedProcessDetectedAndFixed(t *testing.T) {
 // live on a private `tmux -L` server and are invisible here) and a missing
 // home marker (pre-marker spawn, unreadable environ) are both report-only.
 func TestOrphanWithoutProvenHomeSurvivesFix(t *testing.T) {
-	testguard.RequireProcFS(t)
 	testguard.IsolateTmux(t)
 
 	foreign := spawnWithEnv(t, "sh", nil, map[string]string{
@@ -288,7 +295,6 @@ func TestOrphanWithoutProvenHomeSurvivesFix(t *testing.T) {
 // session means the process escaped its pane but the session still owns it —
 // report-only even under --fix.
 func TestMarkedProcessOfLiveSessionIsNeverKilled(t *testing.T) {
-	testguard.RequireProcFS(t)
 	testguard.IsolateTmux(t)
 
 	const name = "af_doctor-live-session"
@@ -328,10 +334,21 @@ func TestLeakedTmuxSessionReportedNotKilled(t *testing.T) {
 		"leaked session must survive --fix")
 }
 
-// TestStaleTempHomeRemovedWithFix: an abandoned AF home under the temp root
-// is detected by its structural markers and removed by --fix; a fresh or
-// referenced home is spared.
-func TestStaleTempHomeRemovedWithFix(t *testing.T) {
+// TestStaleTempHomeReportedButNeverRemoved: an abandoned AF home under the temp
+// root is DETECTED by its structural markers and REPORTED — and `--fix` does
+// not remove it. A fresh home, and a plain directory, stay untouched too.
+//
+// This test used to assert the opposite (`require.NoDirExists(stale)`), and the
+// inversion is the point. The removal was gated on "no process references this
+// home", a negative that four consecutive P1 reviews each found a new way to
+// falsify — darwin's silent env redaction, a permission gate that modelled uid
+// but not CS_RESTRICT, and a uid filter that assumed temp roots are
+// user-owned when Linux's /tmp is 01777 and shared. Every one ended at this
+// rm -rf. Process inspection cannot answer "is anything using this?", so it no
+// longer authorises deleting anything; it reports, and the operator decides.
+// The delete returns when the predicate is a lock the kernel guarantees rather
+// than an inference we assemble.
+func TestStaleTempHomeReportedButNeverRemoved(t *testing.T) {
 	testguard.IsolateTmux(t)
 	opts := testOptions(t, true)
 
@@ -355,14 +372,18 @@ func TestStaleTempHomeRemovedWithFix(t *testing.T) {
 	require.NoError(t, os.MkdirAll(notAHome, 0755))
 	require.NoError(t, os.Chtimes(notAHome, old, old))
 
+	// opts has Fix: true — this IS a --fix run.
 	report, err := Run(opts)
 	require.NoError(t, err)
 	findings := findByCheck(report, "stale-temp-home")
 	require.Len(t, findings, 1)
-	require.Contains(t, findings[0].Detail, stale)
-	require.True(t, findings[0].Fixed, "fix outcome: %v", findings[0].FixErr)
+	require.Contains(t, findings[0].Detail, stale, "the operator must still be told which directory")
+	require.Empty(t, findings[0].FixAction,
+		"stale-temp-home must carry NO fix action: process inspection cannot prove a home is unused, "+
+			"so it must not authorise deleting one")
+	require.False(t, findings[0].Fixed, "a --fix run must not have removed anything")
 
-	require.NoDirExists(t, stale, "stale home must be removed by --fix")
+	require.DirExists(t, stale, "a --fix run must NOT delete a home it cannot prove is unused")
 	require.DirExists(t, fresh, "recently-touched home must be spared")
 	require.DirExists(t, notAHome, "a plain directory without AF markers must never be touched")
 }
@@ -490,7 +511,6 @@ func TestRenderShapes(t *testing.T) {
 
 // TestTmuxServerDeadParsing pins the conservative TMUX-env heuristics.
 func TestTmuxServerDeadParsing(t *testing.T) {
-	testguard.RequireProcFS(t)
 	self, err := proctree.Snapshot()
 	require.NoError(t, err)
 	ctx := &scanContext{snap: self}
@@ -508,9 +528,9 @@ func TestTmuxServerDeadParsing(t *testing.T) {
 // TestOrphanSignalIdentityGuard: even a fixable finding must refuse to fire
 // when the pid has been recycled (the fix closure re-verifies identity).
 func TestOrphanSignalIdentityGuard(t *testing.T) {
-	testguard.RequireProcFS(t)
 	testguard.IsolateTmux(t)
-	home := t.TempDir()
+	// Socket-safe home: see TestOrphanedProcessDetectedAndFixed.
+	home := testguard.SocketTempDir(t)
 	orphan := spawnWithEnv(t, "sh", nil, map[string]string{
 		"AF_SESSION": "af_doctor-recycle",
 		"AF_HOME":    home,

--- a/doctor/env_redaction_test.go
+++ b/doctor/env_redaction_test.go
@@ -1,0 +1,254 @@
+package doctor
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/cmd"
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/proctree"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+)
+
+// These pin the rule that a DENIED environment read must never be acted on as a
+// definite negative.
+//
+// darwin serves KERN_PROCARGS2's env section only for processes we own, and it
+// does not report the refusal: the buffer comes back with argv and no env, which
+// is byte-for-byte identical to a process started with an empty environment. So
+// "this process names no AF home" and "I was not allowed to see whether it does"
+// arrive looking the same, and the layer that decides what gets DELETED cannot
+// tell them apart.
+//
+// That mattered most at processReferencedHomes, whose negative — "no process
+// references this home" — is the predicate for os.RemoveAll. A redacted read
+// made an in-use home look unreferenced, so `af doctor --fix` would delete a
+// home a live process was using.
+//
+// What is real here and what is simulated, precisely:
+//
+//   - REAL: the refusal itself. unreadableEnvPID finds a process owned by
+//     another user, and the kernel genuinely refuses us — EACCES on Linux,
+//     silent redaction on darwin. Both must arrive as EnvUnknown.
+//   - SIMULATED: an OWN-uid process with a redacted environment, which cannot
+//     be conjured honestly (Linux always lets us read our own; darwin would
+//     need a set-id binary). So the deletion gate is driven by passing the
+//     unreadable COUNT to tempHomeInUseReason directly — the input the decision
+//     actually consumes.
+//   - SKIPPED, honestly: an environment with no foreign process at all (our
+//     test container runs everything as one uid) has no refusal to observe, and
+//     these say so rather than inventing one.
+
+// unreadableEnvPID returns a pid whose environment this test cannot read.
+//
+// It SEARCHES for a process owned by another user rather than assuming pid 1 is
+// root's. That assumption is true on a normal machine and false in our own test
+// container, where pid 1 is the entrypoint running as the same unprivileged
+// user as the tests — so the "refusal" never happened and the test failed for a
+// reason unrelated to its subject. (This PR's own bug class, aimed at its own
+// tests: an environment assumption that holds only where it was written.)
+//
+// Skips honestly when the environment has no foreign process to refuse us.
+func unreadableEnvPID(t *testing.T) int {
+	t.Helper()
+	self := os.Getuid()
+	if self == 0 {
+		t.Skip("running as root: root can read every environment, so no read can be refused here")
+	}
+	snap, err := proctree.Snapshot()
+	require.NoError(t, err)
+	pids := make([]int, 0, len(snap))
+	for pid := range snap {
+		pids = append(pids, pid)
+	}
+	sort.Ints(pids) // deterministic pick across runs
+	for _, pid := range pids {
+		if uid, ok := proctree.UID(pid); ok && uid != self {
+			return pid
+		}
+	}
+	t.Skip("no process owned by another user is visible here (a container running everything as one " +
+		"uid), so no environment read can be refused")
+	return 0
+}
+
+// TestRedactedEnvIsUnknownNotAbsent is the primitive-level regression: a
+// process whose environment we may not read must report EnvUnknown, never
+// EnvAbsent. EnvAbsent is a claim; this read never earned one.
+func TestRedactedEnvIsUnknownNotAbsent(t *testing.T) {
+	pid := unreadableEnvPID(t)
+
+	_, status := proctree.LookupEnv(pid, "AGENT_FACTORY_HOME")
+	require.Equal(t, proctree.EnvUnknown, status,
+		"reading pid %d's environment is not permitted, so the answer must be UNKNOWN. "+
+			"EnvAbsent here is a fabricated negative: it asserts the variable is unset on the "+
+			"strength of a read that was denied", pid)
+}
+
+// TestUnreadableEnvDoesNotMakeAHomeLookUnused is the destructive regression:
+// when one of this user's live processes has an unreadable environment, it
+// MIGHT be using the home, so doctor must refuse to delete it.
+//
+// It drives tempHomeInUseReason — the decision itself — rather than trying to
+// conjure an own-uid process with a redacted environment, which cannot be done
+// honestly on the Linux runner (Linux always lets us read our own) and would
+// need a set-id binary on darwin. The count reaching this function is what the
+// deletion turns on, and that is what is asserted.
+//
+// Fails against the pre-fix code, which had no such parameter: "unreadable" was
+// folded into "references no home", so the reason came back "" == safe to
+// remove.
+func TestUnreadableEnvDoesNotMakeAHomeLookUnused(t *testing.T) {
+	home := filepath.Join(testguard.SocketTempDir(t), "af-home")
+	require.NoError(t, os.MkdirAll(home, 0o755))
+
+	// Nothing references it, no tmux session names it — but one of our own
+	// processes has an environment we could not read. Nothing here proves that
+	// process is not using `home`.
+	reason := tempHomeInUseReason(home, map[string]bool{}, map[string]bool{}, 1)
+	require.NotEmpty(t, reason,
+		"doctor must refuse to remove %s: a process with an unreadable environment might be using it, "+
+			"and an unprovable 'unused' is not a licence to os.RemoveAll", home)
+	require.Contains(t, reason, "unreadable",
+		"the refusal must name WHY it could not decide, or the operator cannot act on it")
+	require.DirExists(t, home)
+}
+
+// TestSameUidEmptyEnvProcessDoesNotAuthoriseDeletion is the second P1's
+// destructive regression: a process we OWN whose environment reads back empty
+// must block the deletion, not license it.
+//
+// This is the cs_restricted shape. On a real Mac with SIP, XNU withholds the
+// environment of a code-signing-restricted process EVEN FROM ITS OWNER — so a
+// same-uid process comes back with no variables. The first fix's permission gate
+// modelled ownership only, waved that process through as "readable", and its
+// empty env was then read as "references no home" — authorising
+// staleTempHomeRemoveFix to delete a home it may well have been using.
+//
+// SIMULATED, honestly: CI cannot create a cs_restricted process (it needs a
+// signed binary with a restricted entitlement, and the runner has no signing
+// identity). `env -i` is used instead because it produces the SAME OBSERVABLE
+// the code consumes — a same-uid process whose environment reads back with zero
+// variables. That is the exact input cs_restricted delivers; only the kernel's
+// reason differs, and the fix deliberately does not look at the reason.
+func TestSameUidEmptyEnvProcessDoesNotAuthoriseDeletion(t *testing.T) {
+	cmd := exec.Command("env", "-i", "sleep", "300")
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+	pid := cmd.Process.Pid
+	require.Eventually(t, func() bool {
+		argv := proctree.Argv(pid)
+		return len(argv) > 0 && argv[0] == "sleep"
+	}, 5*time.Second, 10*time.Millisecond, "the env -i child never exec'd")
+
+	// It is OURS — a permission model based on ownership says "readable".
+	uid, ok := proctree.UID(pid)
+	require.True(t, ok)
+	require.Equal(t, os.Getuid(), uid, "the point of this test is a SAME-UID process")
+
+	// And yet we have no idea what it references.
+	_, unreadable := processReferencedHomes(map[int]proctree.Process{pid: {PID: pid}})
+	require.NotZero(t, unreadable,
+		"a same-uid process whose environment reads back empty must count as UNREADABLE. An "+
+			"ownership-based permission gate calls it readable and its empty env then reads as "+
+			"'references no home' — which is what authorises os.RemoveAll")
+
+	home := filepath.Join(testguard.SocketTempDir(t), "af-home")
+	require.NoError(t, os.MkdirAll(home, 0o755))
+	require.NotEmpty(t, tempHomeInUseReason(home, map[string]bool{}, map[string]bool{}, unreadable),
+		"doctor must refuse to remove %s: a process it cannot read might be using it", home)
+	require.DirExists(t, home)
+}
+
+// TestUnreadableEnvYieldsNoHomeClaim: we could not read the environment, so we
+// must not claim to know which home it names either. A redacted read must add
+// nothing to the referenced set — in EITHER direction.
+func TestUnreadableEnvYieldsNoHomeClaim(t *testing.T) {
+	pid := unreadableEnvPID(t)
+	homes, _ := processReferencedHomes(map[int]proctree.Process{pid: {PID: pid}})
+	require.Empty(t, homes,
+		"pid %d's environment is not readable, so no home may be attributed to it", pid)
+}
+
+// TestProvablyUnusedHomeIsStillRemovable is the guard on the guard. The fix
+// above refuses when it cannot prove a home is unused; if that refusal fired
+// indiscriminately, stale-temp-home cleanup would silently stop working and
+// nobody would notice, because a refusal looks like a clean run.
+func TestProvablyUnusedHomeIsStillRemovable(t *testing.T) {
+	// A process whose environment we CAN read (our own), naming no AF home.
+	snap := map[int]proctree.Process{os.Getpid(): {PID: os.Getpid()}}
+	t.Setenv("AGENT_FACTORY_HOME", "")
+
+	homes, unreadable := processReferencedHomes(snap)
+	require.Zero(t, unreadable, "our own environment is readable, so nothing should be unreadable")
+
+	dir := filepath.Join(testguard.SocketTempDir(t), "af-unused")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.Empty(t, tempHomeInUseReason(dir, homes, map[string]bool{}, unreadable),
+		"a home that is provably unused must still be removable, or the cleanup is dead")
+}
+
+// TestForeignProcessesDoNotBlockCleanup pins why only OUR OWN processes count
+// as unreadable. On a real machine most of the process table belongs to root,
+// and on darwin every one of those environments is redacted — so counting
+// foreign processes would make --fix refuse forever, on every Mac.
+//
+// A home under this user's 0700 temp dir cannot be in use by another user's
+// process, so their unreadability tells us nothing we needed.
+func TestForeignProcessesDoNotBlockCleanup(t *testing.T) {
+	pid := unreadableEnvPID(t) // a process owned by another user
+
+	_, unreadable := processReferencedHomes(map[int]proctree.Process{pid: {PID: pid}})
+	if uid, ok := proctree.UID(pid); ok && uid != os.Getuid() {
+		require.Zero(t, unreadable,
+			"pid %d belongs to uid %d, not us — it cannot be using a home under our own temp dir, "+
+				"so it must not block cleanup", pid, uid)
+	}
+}
+
+// TestRedactedEnvOrphanIsNotKilled is the reaping half: a marked orphan whose
+// AF_HOME cannot be read must be reported, never fixed. "I could not read its
+// home" is not "its home is mine".
+func TestRedactedEnvOrphanIsNotKilled(t *testing.T) {
+	testguard.IsolateTmux(t)
+	home := testguard.SocketTempDir(t)
+
+	// A live process we cannot read: pid 1. It carries no marker we can see,
+	// so it must never reach the killable set.
+	pid := unreadableEnvPID(t)
+
+	opts := Options{
+		Fix:            true,
+		ConfigDir:      home,
+		TempDir:        t.TempDir(),
+		Exec:           cmd.MakeExecutor(),
+		MinTempHomeAge: time.Hour,
+		killGrace:      50 * time.Millisecond,
+		killTermWait:   50 * time.Millisecond,
+		snapshot: func() (map[int]proctree.Process, error) {
+			return map[int]proctree.Process{pid: {PID: pid, Comm: "init"}}, nil
+		},
+		remoteConfig: func() (*config.RemoteHooks, string, error) { return nil, "", nil },
+	}
+	t.Setenv("AGENT_FACTORY_HOME", home)
+
+	report, err := Run(opts)
+	require.NoError(t, err)
+
+	for _, f := range report.Findings {
+		require.Empty(t, f.FixAction,
+			"a process whose environment could not be read must never carry a fix action: %s", f.Detail)
+		require.False(t, f.Fixed, "nothing unreadable may be acted on: %s", f.Detail)
+	}
+	// And it is definitely still alive.
+	require.NoError(t, func() error { _, err := os.FindProcess(pid); return err }())
+}

--- a/doctor/process_inspection_test.go
+++ b/doctor/process_inspection_test.go
@@ -1,0 +1,136 @@
+package doctor
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/cmd"
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/proctree"
+)
+
+// These tests pin the one property that made #1939 dangerous rather than
+// merely broken: a doctor that cannot see must SAY so.
+//
+// The bug was never that macOS lacked /proc. It was that proctree returned an
+// error, Run threw the error away, the process checks saw a nil snapshot and
+// returned early, and the report came out clean. `af doctor` on a Mac answered
+// "no orphaned processes" without ever having read the process table. The
+// checks below fail against that behaviour: they assert the report is a FAIL
+// with a nonzero exit, on the exact code path (snapshot returns an error) that
+// every macOS run took.
+//
+// A real darwin backend (#1939) means this state should no longer occur on the
+// platforms we ship. These tests still matter, because the honesty is what
+// keeps the NEXT unreadable platform — or an unreadable table on a locked-down
+// machine — from being reported as health.
+
+// blindOptions returns Options whose snapshot fails with err, reproducing what
+// every `af doctor` run on macOS did before #1939.
+func blindOptions(t *testing.T, err error) Options {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	return Options{
+		ConfigDir:      home,
+		TempDir:        t.TempDir(),
+		Exec:           cmd.MakeExecutor(),
+		MinTempHomeAge: time.Hour,
+		killGrace:      100 * time.Millisecond,
+		killTermWait:   200 * time.Millisecond,
+		snapshot:       func() (map[int]proctree.Process, error) { return nil, err },
+		remoteConfig:   func() (*config.RemoteHooks, string, error) { return nil, "", nil },
+	}
+}
+
+// TestUnreadableProcessTableFailsRatherThanPasses is the #1939 regression: an
+// unreadable process table must produce a FAIL row that counts toward the exit
+// code — never a silent omission that reads as a clean bill of health.
+func TestUnreadableProcessTableFailsRatherThanPasses(t *testing.T) {
+	r, err := Run(blindOptions(t, errors.New("reading /proc: open /proc: no such file or directory")))
+	require.NoError(t, err)
+
+	rows := findCheckRows(r, "process-inspection")
+	require.Len(t, rows, 1, "an unreadable process table must report exactly one process-inspection row")
+	require.Equal(t, StatusFail, rows[0].Status,
+		"doctor reported %s for a process table it could not read — blindness must never render as health (#1939)",
+		rows[0].Status)
+	require.True(t, rows[0].Problem,
+		"the process-inspection failure must count toward the exit code, or `af doctor` still exits 0 while blind")
+	require.NotZero(t, r.UnresolvedCount(),
+		"a doctor that cannot see the process table has an unresolved issue")
+
+	// The row must name the cause, not just the symptom: the operator needs to
+	// know WHY it could not look.
+	require.Contains(t, rows[0].Detail, "/proc",
+		"the failure must name the underlying error so the cause is diagnosable")
+}
+
+// TestUnsupportedPlatformIsNamedInTheReport pins the message for a platform
+// with no process-table backend at all (proctree_other.go). The operator must
+// learn that the checks did not run, rather than inferring health from their
+// absence.
+func TestUnsupportedPlatformIsNamedInTheReport(t *testing.T) {
+	r, err := Run(blindOptions(t, proctree.ErrUnsupportedPlatform))
+	require.NoError(t, err)
+
+	rows := findCheckRows(r, "process-inspection")
+	require.Len(t, rows, 1)
+	require.Equal(t, StatusFail, rows[0].Status)
+	require.Contains(t, rows[0].Remediation, "no process-table backend",
+		"an unsupported platform must be named as such, not reported as a generic read error")
+}
+
+// TestBlindDoctorSaysSoInRenderedOutput checks what the user actually reads.
+// The report struct being correct is not enough — the rendered page is the
+// product, and this is the line that stops a Mac user concluding "af doctor
+// says I am fine".
+func TestBlindDoctorSaysSoInRenderedOutput(t *testing.T) {
+	r, err := Run(blindOptions(t, errors.New("open /proc: no such file or directory")))
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	Render(&buf, r, false, false)
+	out := buf.String()
+
+	require.Contains(t, out, "process-inspection")
+	require.Contains(t, out, "cannot read the process table")
+	require.Contains(t, strings.ToUpper(out), "FAIL",
+		"the rendered report must show a FAIL for an unreadable process table")
+}
+
+// TestReadableProcessTablePasses is the other half of the contract: when the
+// table IS readable the row passes, so the FAIL above is a real signal rather
+// than a row that is always red.
+func TestReadableProcessTablePasses(t *testing.T) {
+	opts := blindOptions(t, nil)
+	opts.snapshot = func() (map[int]proctree.Process, error) {
+		return map[int]proctree.Process{1: {PID: 1, PPID: 0, Comm: "init"}}, nil
+	}
+	r, err := Run(opts)
+	require.NoError(t, err)
+
+	rows := findCheckRows(r, "process-inspection")
+	require.Len(t, rows, 1)
+	require.Equal(t, StatusPass, rows[0].Status,
+		"a readable process table must pass; got %s (%s)", rows[0].Status, rows[0].Detail)
+}
+
+// TestRealSnapshotIsReadableOnThisPlatform is the end-to-end assertion that
+// this platform has a working backend — the check that would have caught #1939
+// on day one had it existed, and the reason it is not skipped anywhere.
+//
+// It runs on every OS we ship. On darwin it exercises the sysctl backend; on
+// Linux, /proc. A platform where this fails is a platform where af doctor,
+// tmux orphan reaping and `af reset` are all blind, and CI should say so.
+func TestRealSnapshotIsReadableOnThisPlatform(t *testing.T) {
+	snap, err := proctree.Snapshot()
+	require.NoError(t, err, "proctree cannot read this platform's process table — doctor and orphan reaping are blind here (#1939)")
+	require.NotEmpty(t, snap, "the process table cannot be empty on a running system")
+	require.Contains(t, snap, 1, "pid 1 must be present in any real process table")
+}

--- a/doctor/skew_test.go
+++ b/doctor/skew_test.go
@@ -601,8 +601,20 @@ func TestDaemonProcessHome_RelativeWithUnreadableCwdIsUnknown(t *testing.T) {
 
 // The other half of the guard: a readable environ still yields a known home.
 // Tightening the unreadable case must not make doctor blind to real daemons.
+//
+// CanonicalTempDir, not t.TempDir: daemonProcessHome resolves the home through
+// resolveHomeIn, which EvalSymlinks it — and on macOS an EXISTING temp dir
+// resolves /var/folders/… to /private/var/folders/… (the #1918 class). This
+// test spawns a real process and reads its environ, so it began RUNNING on macOS
+// only once this PR gave that read a darwin backend AND removed the RequireProcFS
+// skip that spawnWithEnv used to carry — before, it was skipped there. Comparing
+// the resolved home against an unresolved t.TempDir() is the stale assumption
+// that first-ever-macOS-run then exposed; setting the env to the canonical
+// spelling at the source makes the expectation correct on both platforms. The
+// sibling tests above avoid this only because their expected homes are
+// non-existent subdirs, which EvalSymlinks leaves unresolved.
 func TestDaemonProcessHome_ReadableEnvironIsKnown(t *testing.T) {
-	explicit := t.TempDir()
+	explicit := testguard.CanonicalTempDir(t)
 	proc := spawnWithEnv(t, "af", []string{"--daemon"}, map[string]string{"AGENT_FACTORY_HOME": explicit})
 
 	home, known := daemonProcessHome(proc.PID)

--- a/doctor/temp_home_liveness_test.go
+++ b/doctor/temp_home_liveness_test.go
@@ -108,8 +108,8 @@ func TestTempHomeDaemonUncertainLivenessSparesHome(t *testing.T) {
 // TestScanContextDefaultsSnapshot pins the invariant broken by #1785: the
 // context the checks read must carry a snapshot func even when the caller
 // supplied none. Defaulting after the scanContext copies the Options left
-// ctx.opts.snapshot nil in production, quietly turning the fix-time process
-// recheck in staleTempHomeRemoveFix into dead code that only tests reached.
+// ctx.opts.snapshot nil in production, so the checks silently saw no processes
+// at all — the blindness class this package now reports rather than hides.
 func TestScanContextDefaultsSnapshot(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 	// Production shape: no injected snapshot, exactly as `af doctor` calls it.
@@ -119,52 +119,19 @@ func TestScanContextDefaultsSnapshot(t *testing.T) {
 		"scan context must carry a snapshot func, else the fix-time process recheck is unreachable")
 }
 
-// TestStaleTempHomeRefusesWithoutSnapshotFunc pins the fail-closed branch: a
-// context with no snapshot func cannot recheck for live processes, so it must
-// refuse rather than delete on the stale detection snapshot.
-func TestStaleTempHomeRefusesWithoutSnapshotFunc(t *testing.T) {
-	tempRoot := t.TempDir()
-	dir := makeOldTempAFHome(t, tempRoot, "tmp.no-snapshot-func")
-	ctx := &scanContext{opts: Options{TempDir: tempRoot, ConfigDir: t.TempDir()}}
-
-	err := staleTempHomeRemoveFix(ctx, dir)()
-	require.ErrorContains(t, err, "no process snapshot available")
-	require.DirExists(t, dir, "an un-recheckable home must fail closed, not be removed")
-}
-
-// TestStaleTempHomeClaimedAfterDetectionIsSpared is the behavioral contract the
-// fix-time recheck exists for: a home that looked abandoned during detection but
-// was claimed by a process before --fix ran must survive. The snapshot func hides
-// the claimer from the detection pass and reveals it at fix time, standing in for
-// a process that started in between.
-func TestStaleTempHomeClaimedAfterDetectionIsSpared(t *testing.T) {
-	tempRoot := t.TempDir()
-	dir := makeOldTempAFHome(t, tempRoot, "tmp.claimed-late")
-
-	claimer := spawnWithEnv(t, "sh", nil, map[string]string{"AGENT_FACTORY_HOME": dir})
-
-	opts := macLikeTempHomeOptions(t, tempRoot, true)
-	var calls int
-	opts.snapshot = func() (map[int]proctree.Process, error) {
-		calls++
-		if calls == 1 {
-			// Detection: the claimer has not started yet.
-			return map[int]proctree.Process{}, nil
-		}
-		// Fix time: the claimer now holds the home.
-		return map[int]proctree.Process{claimer.PID: claimer}, nil
-	}
-
-	report, err := Run(opts)
-	require.NoError(t, err)
-	require.Greater(t, calls, 1, "fix must re-take the process snapshot, not reuse the detection one")
-
-	findings := findByCheck(report, "stale-temp-home")
-	require.Len(t, findings, 1, "detection saw an abandoned home and proposed removing it")
-	require.False(t, findings[0].Fixed)
-	require.ErrorContains(t, findings[0].FixErr, "live process references it")
-	require.DirExists(t, dir, "a home claimed between detection and fix must not be removed")
-}
+// TestStaleTempHomeRefusesWithoutSnapshotFunc and
+// TestStaleTempHomeClaimedAfterDetectionIsSpared are DELETED with the closure
+// they drove (staleTempHomeRemoveFix).
+//
+// They were good tests of a bad idea. One pinned that an un-recheckable home
+// fails closed; the other that a home claimed between detection and --fix
+// survives. Both hardened the INPUTS to "did I see a process referencing this
+// home?" — and that question is unanswerable by process inspection, so no
+// amount of input-hardening made the rm -rf it authorised safe. The delete is
+// gone; there is nothing left to fail closed.
+//
+// What replaced them: TestStaleTempHomeReportedButNeverRemoved (doctor_test.go)
+// asserts a --fix run REPORTS the home and leaves it on disk.
 
 func TestTempHomeWithLiveTmuxSessionMarkerSparesHomeWithoutProc(t *testing.T) {
 	tempRoot := t.TempDir()
@@ -191,33 +158,11 @@ func TestTempHomeWithLiveTmuxSessionMarkerSparesHomeWithoutProc(t *testing.T) {
 	require.True(t, okContains(report, "live tmux session references it"))
 }
 
-func TestStaleTempHomeFixRechecksDaemonBeforeRemove(t *testing.T) {
-	tempRoot := t.TempDir()
-	dir := makeOldTempAFHome(t, tempRoot, "tmp.race-daemon")
-	alive := false
-	stubDaemonProcessProbe(t,
-		func(pid int) bool { return alive && pid == 4244 },
-		func(pid int) []string {
-			if alive && pid == 4244 {
-				return []string{"af", "--daemon"}
-			}
-			return nil
-		},
-	)
-
-	report, err := Run(macLikeTempHomeOptions(t, tempRoot, false))
-	require.NoError(t, err)
-	findings := findByCheck(report, "stale-temp-home")
-	require.Len(t, findings, 1)
-	require.NotNil(t, findings[0].fix)
-
-	alive = true
-	writeOldDaemonPID(t, dir, 4244)
-	err = findings[0].fix()
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "daemon pid is live")
-	require.DirExists(t, dir, "fix must re-check and refuse to remove a newly active temp home")
-}
+// TestStaleTempHomeFixRechecksDaemonBeforeRemove is DELETED with the closure it
+// drove — the fourth and last test whose subject was the fix-time recheck. It
+// asserted the fix re-reads daemon.pid and refuses a home that became active in
+// between. Sound reasoning, wrong layer: it made the rm -rf's inputs fresher,
+// not its question answerable. There is no fix to recheck now.
 
 // TestStaleTempHomeFixFailsClosedWhenSnapshotFailsAtFixTime is the #1728
 // regression: detection got a working process snapshot (so the home was
@@ -225,40 +170,9 @@ func TestStaleTempHomeFixRechecksDaemonBeforeRemove(t *testing.T) {
 // (transient /proc error). The detection snapshot is now stale — a one-off
 // command with no daemon.pid and no tmux marker could have claimed the home
 // in between — so the fix must fail closed rather than delete on stale data.
-// Before the fix, the snapshot error was swallowed and the home deleted.
-func TestStaleTempHomeFixFailsClosedWhenSnapshotFailsAtFixTime(t *testing.T) {
-	tempRoot := t.TempDir()
-	dir := makeOldTempAFHome(t, tempRoot, "tmp.snapshot-race")
-
-	opts := testOptions(t, true)
-	opts.TempDir = tempRoot
-	// No live tmux session references the home.
-	opts.Exec = cmd_test.MockCmdExec{
-		RunFunc: func(cmd *exec.Cmd) error { return nil },
-		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
-			return nil, fmt.Errorf("no tmux")
-		},
-	}
-	// Detection (call 1) sees a clean, non-nil snapshot so the home is flagged
-	// stale; the fix-time recheck (call 2+) fails, mirroring a transient /proc
-	// error between detection and remediation.
-	var calls int
-	opts.snapshot = func() (map[int]proctree.Process, error) {
-		calls++
-		if calls == 1 {
-			return map[int]proctree.Process{}, nil
-		}
-		return nil, fmt.Errorf("snapshot unavailable at fix time")
-	}
-
-	report, err := Run(opts)
-	require.NoError(t, err)
-
-	findings := findByCheck(report, "stale-temp-home")
-	require.Len(t, findings, 1, "home must be detected as stale")
-	require.GreaterOrEqual(t, calls, 2, "fix must re-take the snapshot at fix time")
-	require.False(t, findings[0].Fixed, "fix must fail closed when the fix-time snapshot fails")
-	require.Error(t, findings[0].FixErr)
-	require.Contains(t, findings[0].FixErr.Error(), "process snapshot failed")
-	require.DirExists(t, dir, "an in-use home must never be deleted when liveness cannot be verified")
-}
+/// TestStaleTempHomeFixFailsClosedWhenSnapshotFailsAtFixTime is DELETED with the
+// closure it drove, for the same reason as its two siblings above: it hardened
+// an INPUT ("re-take the snapshot at fix time, fail closed if it fails") to a
+// question process inspection cannot answer. Its final assertion — that an
+// unverifiable home is never deleted — is now structurally true, because
+// nothing deletes. TestStaleTempHomeReportedButNeverRemoved asserts it directly.

--- a/integration/remote_hooks_doc_test.go
+++ b/integration/remote_hooks_doc_test.go
@@ -1,0 +1,231 @@
+package integration_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/internal/proctree"
+)
+
+// These tests execute the launch incantation docs/remote-hooks.md tells users
+// to copy, on whatever platform they run on. They exist because that line was
+// wrong for every macOS reader for as long as the doc has existed (#1946): it
+// said `setsid`, which is util-linux and simply does not exist on a Mac, so the
+// recipe failed with `setsid: command not found` — an error naming a coreutil
+// the reader never asked for, reported by af as its own failure.
+//
+// A doc example is only as true as the last platform someone ran it on, and
+// nothing ran this one on darwin until the macOS job landed (#1931). So the
+// example is executed here rather than reasoned about: on the macOS runner this
+// is the verification that the replacement genuinely detaches, which is the one
+// property `setsid` was there to provide and the one a careless substitute
+// would silently drop.
+//
+// TestRemoteHookRoundTripMockRemote cannot cover this — it is skipped on darwin
+// (#1945, clientless PTY streaming), which is exactly the platform whose answer
+// we need. These tests touch no PTY, so they run everywhere.
+
+// docLaunchLine is the detach used by docs/remote-hooks.md's launch.sh, and by
+// the mock hook fixture. Keep the three in step: if this changes, the doc is
+// wrong, and a Mac user pays for it.
+const docLaunchLine = `nohup "$CHILD" >"$OUT" 2>"$ERR" &`
+
+// TestDocumentedDetachToolExists is the flat contradiction of #1946: whatever
+// the doc tells a reader to run must exist on the reader's machine.
+//
+// setsid fails this on darwin. If this ever fails, the recipe is handing
+// someone a command not found.
+func TestDocumentedDetachToolExists(t *testing.T) {
+	if _, err := exec.LookPath("nohup"); err != nil {
+		t.Fatalf("docs/remote-hooks.md tells users to run `nohup`, which is not on PATH on %s: %v — "+
+			"the documented recipe cannot work here (#1946)", runtime.GOOS, err)
+	}
+}
+
+// darwinBaseSystemBinDirs are the directories macOS's own userland ships in.
+// Anything outside them is user-installed (Homebrew, MacPorts, /usr/local),
+// which is a property of one machine and not of the platform.
+var darwinBaseSystemBinDirs = []string{"/usr/bin", "/bin", "/usr/sbin", "/sbin"}
+
+// TestSetsidIsNotInDarwinsBaseSystem records the fact the doc fix rests on, so
+// nobody has to take #1946's word for it (or re-litigate it from a Linux box).
+//
+// It checks the BASE SYSTEM directories, not $PATH, and that distinction is the
+// whole correctness of the test. A developer or runner may well have setsid
+// installed — `brew install util-linux` puts one on $PATH — and that says
+// nothing about what a Mac user reading our docs has out of the box. Failing on
+// a $PATH hit would mean "I did not find it where I expected" masquerading as
+// "it does not exist", which is the same fabricated-negative shape this PR
+// exists to remove; here it would just point the other way.
+//
+// So a user-installed setsid is reported and tolerated. Only setsid appearing
+// in the BASE SYSTEM would falsify the doc, and that is worth failing over.
+func TestSetsidIsNotInDarwinsBaseSystem(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skipf("records darwin's userland; %s is not the platform in question", runtime.GOOS)
+	}
+	for _, dir := range darwinBaseSystemBinDirs {
+		p := filepath.Join(dir, "setsid")
+		if _, err := os.Stat(p); err == nil {
+			t.Errorf("setsid exists in macOS's base system at %s — #1946's premise (setsid is "+
+				"util-linux and ships only on Linux) is no longer true and docs/remote-hooks.md "+
+				"needs re-reading", p)
+		}
+	}
+	// Informational only: a user-installed setsid is normal and irrelevant.
+	if p, err := exec.LookPath("setsid"); err == nil {
+		t.Logf("note: this machine has a user-installed setsid at %s (outside the base system). "+
+			"That does not contradict the doc — a Mac user who has not installed util-linux has no "+
+			"setsid, which is who the recipe is written for.", p)
+	}
+}
+
+// TestDocumentedLaunchDetachesAndSurvivesTheScript is the verification Sachin
+// asked for, run on the platform in question rather than assumed from a Linux
+// box.
+//
+// The whole job of the detach is that the launched server OUTLIVES launch_cmd:
+// the script exits the moment it has the banner, and af then talks to a server
+// that must still be running. A substitute that does not detach would fail
+// later and more confusingly than the missing binary it replaced — the script
+// would succeed, hand back a URL, and the server would be gone.
+//
+// So this runs the documented shape end to end and asserts the child is alive
+// AFTER the script has exited, using proctree (which since #1939 can actually
+// see processes on darwin — before that this assertion could not have been
+// written here at all).
+func TestDocumentedLaunchDetachesAndSurvivesTheScript(t *testing.T) {
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "pid")
+
+	// A stand-in for `af agent-server`: prints a banner, then stays up. If the
+	// detach works, it is still here after launch.sh returns.
+	child := writeScript(t, filepath.Join(dir, "child.sh"), `
+echo '{"addr":"127.0.0.1:1"}'
+exec sleep 300
+`)
+
+	launch := writeScript(t, filepath.Join(dir, "launch.sh"), `
+CHILD="`+child+`"
+OUT="`+filepath.Join(dir, "banner.json")+`"
+ERR="`+filepath.Join(dir, "server.log")+`"
+`+docLaunchLine+`
+echo $! > "`+pidFile+`"
+for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+  grep -q '"addr"' "$OUT" 2>/dev/null && break
+  sleep 0.1
+done
+grep -q '"addr"' "$OUT" || { echo "child printed no banner:" >&2; cat "$ERR" >&2; exit 1; }
+`)
+
+	// CombinedOutput is exactly how af runs launch_cmd
+	// (session/backend_hook_backend.go). It reads the pipes to EOF, so if the
+	// child inherited them this call hangs until the child exits — the failure
+	// mode the doc's redirects exist to prevent. A 30s bound turns that hang
+	// into a readable failure instead of a timed-out package.
+	done := make(chan struct{})
+	var out []byte
+	var runErr error
+	go func() {
+		defer close(done)
+		out, runErr = exec.Command(launch).CombinedOutput()
+	}()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatalf("launch script did not return within 30s: af reads launch_cmd's output to EOF, so a " +
+			"child holding stdout/stderr open hangs provisioning for the full 5-minute timeout")
+	}
+	if runErr != nil {
+		t.Fatalf("the documented launch recipe failed on %s: %v\noutput:\n%s", runtime.GOOS, runErr, out)
+	}
+
+	pid := readPIDFile(t, pidFile)
+	t.Cleanup(func() {
+		if p, err := os.FindProcess(pid); err == nil {
+			_ = p.Kill()
+		}
+	})
+
+	// The script has exited. The child must not have.
+	snap, err := proctree.Snapshot()
+	if err != nil {
+		t.Fatalf("reading the process table on %s: %v", runtime.GOOS, err)
+	}
+	p, ok := snap[pid]
+	if !ok {
+		t.Fatalf("the launched child (pid %d) is gone after launch.sh exited on %s — the documented "+
+			"detach does not survive its parent here, which is the one thing it must do (#1946)",
+			pid, runtime.GOOS)
+	}
+
+	// Reparented, i.e. genuinely orphaned rather than still owned by a shell
+	// that happens to linger. The script's own pid is gone, so the child cannot
+	// still name it as a parent.
+	if p.PPID == 0 {
+		t.Errorf("child %d reports ppid 0 after the script exited; expected reparenting to init/launchd", pid)
+	}
+}
+
+// TestDocumentedLaunchSurfacesTheShellsError pins the other half of #1946: when
+// the launch command cannot run at all, the reader must be told WHAT THE SHELL
+// SAID, not just that no banner appeared.
+//
+// This is why the doc's failure branch cats the server's log. af reports what
+// the script prints and nothing else, so a recipe that swallows its own stderr
+// leaves the user staring at "printed no banner" with the actual cause —
+// "command not found" — discarded. The shape is verified here, on the same
+// script shape a Mac user runs.
+func TestDocumentedLaunchSurfacesTheShellsError(t *testing.T) {
+	dir := t.TempDir()
+
+	launch := writeScript(t, filepath.Join(dir, "launch.sh"), `
+CHILD="definitely-not-a-real-command-af"
+OUT="`+filepath.Join(dir, "banner.json")+`"
+ERR="`+filepath.Join(dir, "server.log")+`"
+: > "$OUT"
+`+docLaunchLine+`
+sleep 0.5
+grep -q '"addr"' "$OUT" || { echo "af agent-server printed no banner; its output was:" >&2; cat "$ERR" >&2; exit 1; }
+`)
+
+	out, err := exec.Command(launch).CombinedOutput()
+	if err == nil {
+		t.Fatalf("launch script succeeded with a nonexistent command; want failure. output:\n%s", out)
+	}
+	// The shell's own diagnosis must reach af's captured output. This is the
+	// property that was in doubt: the redirect sends it to $ERR, and the failure
+	// branch is what brings it back out.
+	//
+	// Asserted on the COMMAND NAME rather than the wording, deliberately. GNU
+	// nohup says "failed to run command", BSD nohup (macOS) does not, and bash's
+	// own miss is "command not found" — pinning any one phrasing would pass on
+	// Linux and fail on darwin, which is the bug class this whole PR is about.
+	// What must hold everywhere is that the failure names the thing that failed.
+	if !strings.Contains(string(out), "definitely-not-a-real-command-af") {
+		t.Errorf("the launch failure did not name the command that could not run; af would report only "+
+			"the downstream symptom and the real cause would reach nobody (#1946).\ncaptured:\n%s", out)
+	}
+	if !strings.Contains(string(out), "printed no banner") {
+		t.Errorf("the launch failure lost the script's own summary line.\ncaptured:\n%s", out)
+	}
+}
+
+func readPIDFile(t *testing.T, path string) int {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading pid file: %v", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		t.Fatalf("parsing pid file %q: %v", data, err)
+	}
+	return pid
+}

--- a/integration/remote_roundtrip_test.go
+++ b/integration/remote_roundtrip_test.go
@@ -216,15 +216,15 @@ LOG="$DIR/agent-server.log"
 : > "$BANNER"
 ARGS="agent-server --listen 127.0.0.1:0 --repo $DIR/workspace --title $TITLE"
 [ -n "$PROGRAM" ] && ARGS="$ARGS --program $PROGRAM"
-# setsid is util-linux and does not exist on macOS, where this died with
-# "setsid: command not found" and the launch reported "printed no banner" —
-# blaming af for a missing coreutil (#1931). Use it where it exists so the Linux
-# behaviour is unchanged; elsewhere the trailing & still backgrounds the server,
-# and this script exits immediately after, so it is orphaned and survives either
-# way. That is all this fixture needs from the detach.
-SETSID=""
-command -v setsid >/dev/null 2>&1 && SETSID="setsid"
-AGENT_FACTORY_HOME="$DIR/home" TERM=xterm $SETSID "$AF_BIN" $ARGS >"$BANNER" 2>"$LOG" &
+# nohup, matching docs/remote-hooks.md's recipe exactly — this fixture is the
+# doc's script, so the two must not drift (a fixture that detaches differently
+# from the doc tests something no user runs). setsid was the original spelling
+# and is util-linux: it does not exist on macOS, where this died with "setsid:
+# command not found" and the launch reported "printed no banner", blaming af for
+# a missing coreutil (#1931, #1946). nohup is POSIX and on both. The trailing &
+# is what actually makes the server outlive this script; see the doc for why the
+# redirects are not optional.
+AGENT_FACTORY_HOME="$DIR/home" TERM=xterm nohup "$AF_BIN" $ARGS >"$BANNER" 2>"$LOG" &
 echo $! > "$DIR/pid"
 i=0
 while [ $i -lt 200 ]; do

--- a/internal/proctree/procargs2.go
+++ b/internal/proctree/procargs2.go
@@ -1,0 +1,91 @@
+package proctree
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+)
+
+// This file decodes darwin's KERN_PROCARGS2 buffer, but it carries NO build
+// tag, and that is deliberate.
+//
+// The parse is the most intricate part of the darwin backend — a length
+// prefix, a skipped exec_path, variable NUL padding, then two NUL-separated
+// string regions that must be split at exactly the right boundary. It is also
+// the part where a bug is quietest: mis-split argv still looks like argv, and
+// the resulting daemon-detection failure surfaces as "af reset does nothing"
+// rather than a parse error (#1942).
+//
+// Keeping it platform-independent means every runner tests it, so the logic is
+// covered on Linux CI even though the sysctl that feeds it exists only on
+// macOS. The syscall stays in proctree_darwin.go; only the byte-shuffling
+// lives here.
+
+// parseProcArgs2 decodes a KERN_PROCARGS2 buffer, whose layout is:
+//
+//	int32   argc
+//	char[]  exec_path, NUL-terminated
+//	char[]  NUL padding up to the next argument
+//	char[]  argv[0..argc-1], each NUL-terminated
+//	char[]  envp[...], each NUL-terminated, ending at an empty string
+//
+// The argv boundaries it recovers are the entire point: they are what a
+// pre-joined string (`ps -o args=`) has already destroyed. See Argv.
+func parseProcArgs2(buf []byte) (argv []string, env []string, err error) {
+	if len(buf) < 4 {
+		return nil, nil, fmt.Errorf("procargs2 buffer is %d bytes, too short to hold argc", len(buf))
+	}
+	argc := int(int32(binary.NativeEndian.Uint32(buf[:4])))
+	if argc < 0 {
+		return nil, nil, fmt.Errorf("procargs2 reported a negative argc (%d)", argc)
+	}
+	rest := buf[4:]
+
+	// Step over exec_path and the NUL padding after it. exec_path is NOT
+	// argv[0]: it is the resolved executable, and argv[0] repeats after the
+	// padding. Consuming it as argv[0] would shift every argument by one.
+	end := bytes.IndexByte(rest, 0)
+	if end < 0 {
+		return nil, nil, errors.New("procargs2 has no NUL-terminated exec_path")
+	}
+	rest = rest[end:]
+	for len(rest) > 0 && rest[0] == 0 {
+		rest = rest[1:]
+	}
+
+	// argv: exactly argc NUL-terminated strings. Running out early means the
+	// buffer was truncated — report it rather than returning a short argv,
+	// which a caller would read as a complete command line.
+	for i := 0; i < argc; i++ {
+		s, remainder, ok := nextCString(rest)
+		if !ok {
+			return nil, nil, fmt.Errorf("procargs2 ran out of data at argv[%d] of %d", i, argc)
+		}
+		argv = append(argv, s)
+		rest = remainder
+	}
+
+	// envp: everything left, up to the first empty string.
+	for len(rest) > 0 {
+		s, remainder, ok := nextCString(rest)
+		if !ok || s == "" {
+			break
+		}
+		env = append(env, s)
+		rest = remainder
+	}
+	return argv, env, nil
+}
+
+// nextCString splits one NUL-terminated string off the front of buf. An
+// unterminated trailing run of bytes is not a string: the kernel always
+// terminates, so a missing NUL means truncation and the value cannot be
+// trusted.
+func nextCString(buf []byte) (s string, rest []byte, ok bool) {
+	i := bytes.IndexByte(buf, 0)
+	if i < 0 {
+		return "", nil, false
+	}
+	return string(buf[:i]), buf[i+1:], true
+}

--- a/internal/proctree/procargs2_test.go
+++ b/internal/proctree/procargs2_test.go
@@ -1,0 +1,145 @@
+package proctree
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// buildProcArgs2 assembles a KERN_PROCARGS2 buffer the way the darwin kernel
+// does, so the parse can be exercised on any runner. padding reproduces the
+// variable run of NULs the kernel leaves between exec_path and argv[0].
+func buildProcArgs2(execPath string, argv, env []string, padding int) []byte {
+	buf := make([]byte, 4)
+	binary.NativeEndian.PutUint32(buf, uint32(int32(len(argv))))
+	buf = append(buf, []byte(execPath)...)
+	buf = append(buf, 0)
+	for i := 0; i < padding; i++ {
+		buf = append(buf, 0)
+	}
+	for _, a := range argv {
+		buf = append(buf, []byte(a)...)
+		buf = append(buf, 0)
+	}
+	for _, e := range env {
+		buf = append(buf, []byte(e)...)
+		buf = append(buf, 0)
+	}
+	return buf
+}
+
+// TestParseProcArgs2PreservesSpacedArgv is the #1942 regression at the parse
+// layer: an af installed under a path with a space is ONE argv entry, and the
+// old darwin path (`ps -o args=` re-split on whitespace) turned it into two.
+// A Mac user with af under "/Users/John Smith/…" — an ordinary macOS home —
+// had `af reset`, health and foreign-daemon scans all fail to recognise their
+// own daemon.
+func TestParseProcArgs2PreservesSpacedArgv(t *testing.T) {
+	want := []string{"/Users/John Smith/.local/bin/af", "--daemon", "af-test"}
+	buf := buildProcArgs2("/Users/John Smith/.local/bin/af", want, []string{"PATH=/usr/bin"}, 3)
+
+	argv, env, err := parseProcArgs2(buf)
+	if err != nil {
+		t.Fatalf("parseProcArgs2: %v", err)
+	}
+	if len(argv) != len(want) {
+		t.Fatalf("argv = %q (%d entries), want %q (%d entries) — a spaced install path must stay ONE argument",
+			argv, len(argv), want, len(want))
+	}
+	for i := range want {
+		if argv[i] != want[i] {
+			t.Errorf("argv[%d] = %q, want %q", i, argv[i], want[i])
+		}
+	}
+	if len(env) != 1 || env[0] != "PATH=/usr/bin" {
+		t.Errorf("env = %q, want [PATH=/usr/bin]", env)
+	}
+}
+
+// TestParseProcArgs2SkipsExecPath locks the boundary that is easiest to get
+// wrong: exec_path precedes argv[0] and repeats it, so consuming it as argv[0]
+// shifts every argument by one and still looks like a plausible command line.
+func TestParseProcArgs2SkipsExecPath(t *testing.T) {
+	buf := buildProcArgs2("/usr/bin/sleep", []string{"sleep", "300"}, nil, 7)
+	argv, _, err := parseProcArgs2(buf)
+	if err != nil {
+		t.Fatalf("parseProcArgs2: %v", err)
+	}
+	if len(argv) != 2 || argv[0] != "sleep" || argv[1] != "300" {
+		t.Errorf("argv = %q, want [sleep 300] — exec_path must be skipped, not read as argv[0]", argv)
+	}
+}
+
+func TestParseProcArgs2NoPadding(t *testing.T) {
+	buf := buildProcArgs2("/bin/x", []string{"x", "-v"}, nil, 0)
+	argv, _, err := parseProcArgs2(buf)
+	if err != nil {
+		t.Fatalf("parseProcArgs2: %v", err)
+	}
+	if len(argv) != 2 || argv[0] != "x" || argv[1] != "-v" {
+		t.Errorf("argv = %q, want [x -v]", argv)
+	}
+}
+
+// TestParseProcArgs2EmptyEnv pins a fact that is easy to misread, so read the
+// caveat: a buffer with no env section parses fine and yields no variables.
+//
+// That is CORRECT here and DANGEROUS one layer up. An env-less buffer is what
+// `env -i cmd` produces — and it is also what darwin produces when it REDACTS a
+// foreign process's environment, without saying so. The two are byte-for-byte
+// identical, so this parse cannot tell them apart and must not pretend to.
+// Noticing that no answer came back is Environ's job — it classifies a
+// zero-variable result as unreadable, which covers every ground the kernel
+// might have withheld on at once, without this layer (or any layer) trying to
+// predict which.
+//
+// An earlier version of this test asserted "env must come back empty rather
+// than error" as if empty were proof of absence. It is not proof of anything.
+func TestParseProcArgs2EmptyEnv(t *testing.T) {
+	buf := buildProcArgs2("/bin/x", []string{"x"}, nil, 1)
+	argv, env, err := parseProcArgs2(buf)
+	if err != nil {
+		t.Fatalf("parseProcArgs2: %v", err)
+	}
+	if len(argv) != 1 || argv[0] != "x" {
+		t.Errorf("argv = %q, want [x]", argv)
+	}
+	if len(env) != 0 {
+		t.Errorf("env = %q, want empty", env)
+	}
+}
+
+// TestParseProcArgs2RejectsTruncated makes sure a short buffer is an ERROR and
+// not a short argv. A truncated read that returned the arguments it managed to
+// find would be indistinguishable from a process that really was invoked with
+// fewer arguments — and classification (#1214) turns on exactly that.
+func TestParseProcArgs2RejectsTruncated(t *testing.T) {
+	full := buildProcArgs2("/bin/x", []string{"x", "--daemon", "af-test"}, nil, 1)
+	for _, tc := range []struct {
+		name string
+		buf  []byte
+	}{
+		{"empty", nil},
+		{"argc only", full[:4]},
+		{"mid-argv", full[:len(full)-6]},
+		{"no exec_path terminator", []byte{1, 0, 0, 0, 'a', 'b'}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if argv, _, err := parseProcArgs2(tc.buf); err == nil {
+				t.Errorf("parseProcArgs2(%s) = %q, want an error", tc.name, argv)
+			}
+		})
+	}
+}
+
+// TestParseProcArgs2ZeroArgc covers a kernel thread: argc 0 is legitimate and
+// must not error, but it yields no argv, which readArgv reports as "no argv".
+func TestParseProcArgs2ZeroArgc(t *testing.T) {
+	buf := buildProcArgs2("/kernel/thread", nil, nil, 2)
+	argv, _, err := parseProcArgs2(buf)
+	if err != nil {
+		t.Fatalf("parseProcArgs2: %v", err)
+	}
+	if len(argv) != 0 {
+		t.Errorf("argv = %q, want empty for argc=0", argv)
+	}
+}

--- a/internal/proctree/proctree.go
+++ b/internal/proctree/proctree.go
@@ -1,123 +1,94 @@
-// Package proctree inspects the local process table via /proc. It exists so
-// session teardown can reap every descendant of a tmux pane (#1104) and so
-// `af doctor` can trace leaked processes back to the session that spawned
-// them.
+// Package proctree inspects the local process table. It exists so session
+// teardown can reap every descendant of a tmux pane (#1104) and so `af doctor`
+// can trace leaked processes back to the session that spawned them.
 //
 // Every operation that signals a process guards against PID reuse by pairing
-// the PID with its kernel start time (/proc/<pid>/stat field 22): a
-// (pid, starttime) pair names a process *instance*, not just a slot. A PID
-// that has been recycled since the snapshot fails the identity check and is
-// never signalled.
+// the PID with a platform-defined start identifier: a (pid, StartID) pair names
+// a process *instance*, not just a slot. A PID that has been recycled since the
+// snapshot fails the identity check and is never signalled.
 //
-// On non-Linux platforms (no /proc) Snapshot returns an error and callers
-// degrade to doing nothing — reaping and doctor scans are best-effort
-// diagnostics, never load-bearing for correctness.
+// # Platform support
+//
+// The process table is read through a per-platform backend, selected by build
+// tag: proctree_linux.go reads /proc, proctree_darwin.go reads the kernel's
+// sysctl process table. A platform with neither gets proctree_other.go, whose
+// every entry point fails with ErrUnsupportedPlatform.
+//
+// That structure is the point of this package's shape, not an accident of it.
+// This is a DIAGNOSTIC layer, and the worst thing a diagnostic layer can do is
+// answer "nothing found" when the truth is "I cannot look" — a caller cannot
+// tell the two apart, so blindness reads as health. Before #1939 this package
+// was /proc-only with no build tag: on darwin Snapshot() failed on every call,
+// session/tmux/reap.go swallowed the error, and `af doctor` reported a clean
+// bill from an empty snapshot. It had been shipping that way to every macOS
+// user for as long as we have shipped darwin binaries.
+//
+// Two rules keep that from coming back, and both are load-bearing:
+//
+//  1. A platform we cannot read must not COMPILE, rather than silently no-op.
+//     proctree_other.go exists to be a loud failure on any future GOOS, and its
+//     errors are unconditional — there is no path through it that reports an
+//     empty process table as success.
+//  2. "I cannot see" must be REPORTABLE, so callers can say it out loud.
+//     ErrUnsupportedPlatform is distinguishable with errors.Is, and doctor
+//     renders a failed Snapshot as a FAIL row rather than omitting the check
+//     (doctor/doctor.go). Never reintroduce a caller that maps a Snapshot error
+//     to "no processes".
 package proctree
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
 )
 
-// clkTck is the kernel clock-tick rate (_SC_CLK_TCK) used to convert
-// /proc stat fields to seconds. It is 100 on every mainstream Linux
-// configuration; Go's runtime makes the same assumption. Only used for
-// approximate CPU/age reporting, never for identity checks.
-const clkTck = 100
+// ErrUnsupportedPlatform is returned by every read entry point on a platform
+// with no process-table backend. Callers that can degrade must report it —
+// never treat it as an empty result. Test with errors.Is.
+var ErrUnsupportedPlatform = errors.New("proctree: reading the process table is not supported on this platform")
 
 // Process identifies one live process at snapshot time.
 type Process struct {
 	PID  int
 	PPID int
-	// StartTicks is /proc/<pid>/stat field 22 (starttime): clock ticks
-	// between boot and process start. Together with PID it uniquely
-	// identifies a process instance until reboot.
-	StartTicks uint64
-	// SID is the kernel session id (stat field 6). Every process spawned
-	// inside a tmux pane shares the pane root's SID unless it called
-	// setsid, so SID membership proves pane ancestry even after a process
-	// is reparented to init.
+	// StartID is an opaque, platform-defined process start stamp. Together
+	// with PID it uniquely identifies a process instance until reboot; it is
+	// compared for EQUALITY only and its units differ per platform (Linux:
+	// clock ticks since boot, from /proc/<pid>/stat field 22; darwin:
+	// microseconds since the epoch, from kinfo_proc's p_starttime). Never do
+	// arithmetic on it — use StartedAt for anything time-shaped.
+	StartID uint64
+	// StartedAt is when the process started, in wall-clock time. Derived by
+	// the platform backend so age arithmetic is portable.
+	StartedAt time.Time
+	// SID is the kernel session id. Every process spawned inside a tmux pane
+	// shares the pane root's SID unless it called setsid, so SID membership
+	// proves pane ancestry even after a process is reparented to init.
 	SID int
-	// Comm is the kernel task name (stat field 2, max 15 chars).
+	// Comm is the kernel task name (truncated by the kernel: 15 chars on
+	// Linux, 16 on darwin).
 	Comm string
-	// UTicks and STicks are cumulative user/system CPU ticks (stat
-	// fields 14/15) at snapshot time.
-	UTicks uint64
-	STicks uint64
 }
+
+// sidUnknown is the SID of a process whose kernel session id could not be
+// read. It is deliberately not 0: 0 is a real value (kernel threads carry it),
+// so reusing it would make "I could not tell" indistinguishable from a fact,
+// and SessionMembers would then hand every unreadable process to the caller as
+// a session member. See SessionMembers.
+const sidUnknown = -1
 
 // Snapshot reads the whole process table once. The result is a point-in-time
 // view: processes may die (or PIDs be recycled) immediately after. Callers
 // must use Signal/AliveSame — which re-verify identity — before acting on an
 // entry.
+//
+// An error means the table could not be READ, which is never the same fact as
+// "no processes are running": report it, do not treat it as an empty map.
 func Snapshot() (map[int]Process, error) {
-	entries, err := os.ReadDir("/proc")
-	if err != nil {
-		return nil, fmt.Errorf("reading /proc: %w", err)
-	}
-	procs := make(map[int]Process, len(entries))
-	for _, e := range entries {
-		pid, err := strconv.Atoi(e.Name())
-		if err != nil || pid <= 0 {
-			continue
-		}
-		p, err := readStat(pid)
-		if err != nil {
-			// Process exited between ReadDir and the stat read; skip.
-			continue
-		}
-		procs[pid] = p
-	}
-	return procs, nil
-}
-
-// readStat parses /proc/<pid>/stat. Format: `pid (comm) state ppid ...`.
-// Comm may itself contain spaces and ')' — the parse anchors on the LAST ')'.
-func readStat(pid int) (Process, error) {
-	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
-	if err != nil {
-		return Process{}, err
-	}
-	open := bytes.IndexByte(data, '(')
-	close_ := bytes.LastIndexByte(data, ')')
-	if open < 0 || close_ < open || close_+2 > len(data) {
-		return Process{}, fmt.Errorf("malformed stat for pid %d", pid)
-	}
-	comm := string(data[open+1 : close_])
-	fields := strings.Fields(string(data[close_+2:]))
-	// fields[0] is stat field 3 (state); stat field N lives at fields[N-3].
-	const (
-		idxPPID  = 4 - 3
-		idxSID   = 6 - 3
-		idxUtime = 14 - 3
-		idxStime = 15 - 3
-		idxStart = 22 - 3
-	)
-	if len(fields) <= idxStart {
-		return Process{}, fmt.Errorf("truncated stat for pid %d", pid)
-	}
-	ppid, err := strconv.Atoi(fields[idxPPID])
-	if err != nil {
-		return Process{}, fmt.Errorf("bad ppid for pid %d: %w", pid, err)
-	}
-	sid, err := strconv.Atoi(fields[idxSID])
-	if err != nil {
-		return Process{}, fmt.Errorf("bad sid for pid %d: %w", pid, err)
-	}
-	start, err := strconv.ParseUint(fields[idxStart], 10, 64)
-	if err != nil {
-		return Process{}, fmt.Errorf("bad starttime for pid %d: %w", pid, err)
-	}
-	// CPU counters are for reporting only; a parse failure degrades to 0.
-	utime, _ := strconv.ParseUint(fields[idxUtime], 10, 64)
-	stime, _ := strconv.ParseUint(fields[idxStime], 10, 64)
-	return Process{PID: pid, PPID: ppid, SID: sid, StartTicks: start, Comm: comm, UTicks: utime, STicks: stime}, nil
+	return snapshot()
 }
 
 // TreeOf returns root plus every descendant of root present in snap, in BFS
@@ -153,7 +124,16 @@ func TreeOf(snap map[int]Process, root int) []Process {
 // sid. Complements TreeOf: a pane descendant that was reparented to init
 // (its spawner exited first) drops out of the ppid tree but keeps the pane
 // root's SID unless it called setsid.
+//
+// A non-positive sid matches NOTHING, and that is a safety property rather
+// than an edge case. The result of this function flows into KillEscalating
+// (session/tmux/reap.go), so "every process whose session id I could not read"
+// must never be answerable as a set: sidUnknown and 0 (kernel threads) are
+// both excluded, on both platforms.
 func SessionMembers(snap map[int]Process, sid int) []Process {
+	if sid <= 0 {
+		return nil
+	}
 	var members []Process
 	for _, p := range snap {
 		if p.SID == sid {
@@ -163,14 +143,14 @@ func SessionMembers(snap map[int]Process, sid int) []Process {
 	return members
 }
 
-// AliveSame reports whether the same process instance (matching PID and
-// start time) is still running.
+// AliveSame reports whether the same process instance (matching PID and start
+// identifier) is still running.
 func AliveSame(p Process) bool {
-	cur, err := readStat(p.PID)
+	cur, err := readProc(p.PID)
 	if err != nil {
 		return false
 	}
-	return cur.StartTicks == p.StartTicks
+	return cur.StartID == p.StartID
 }
 
 // ErrIdentityChanged is returned by Signal when the PID no longer names the
@@ -264,115 +244,249 @@ func KillEscalating(procs []Process, grace, termWait time.Duration, logf func(fo
 	return remaining
 }
 
+// ErrCPUUnknown is returned by CPUFraction when the kernel would not report
+// the process's CPU time (typically another user's process). It is distinct
+// from a zero fraction: "not measurable" and "idle" are different findings,
+// and only one of them means the caller may stop looking.
+var ErrCPUUnknown = errors.New("proctree: cpu time is not readable for this process")
+
 // CPUFraction returns the process's lifetime-average CPU usage as a fraction
 // of one core (1.0 = a full core since it started), plus its age in seconds.
-// Uses /proc/uptime; returns (0, 0, error) when that is unreadable. A brand
-// new process (age < 1s) reports 0 to avoid a noisy division.
+// A brand new process (age < 1s) reports 0 to avoid a noisy division.
+//
+// The CPU counter is read fresh rather than carried on Process: only doctor
+// asks for it, and making it a snapshot field would charge every teardown reap
+// for a number it never looks at.
+//
+// An unreadable counter is an ERROR (ErrCPUUnknown), never a 0.0 fraction.
+// Doctor uses this to find processes pegging a core, so "I could not measure"
+// and "measured, idle" must not arrive at the caller wearing the same face.
 func CPUFraction(p Process) (frac float64, ageSeconds float64, err error) {
-	data, err := os.ReadFile("/proc/uptime")
+	if p.StartedAt.IsZero() {
+		// No start time means the backend could not establish boot time (a
+		// procfs mounted subset=pid hides /proc/uptime while still serving
+		// /proc/<pid>/stat). Wrapped in ErrCPUUnknown so it classifies exactly
+		// like a refused counter: unmeasurable, NOT idle.
+		return 0, 0, fmt.Errorf("%w: pid %d has no start time, so its age is unknown", ErrCPUUnknown, p.PID)
+	}
+	age := time.Since(p.StartedAt).Seconds()
+	cpu, err := readCPUTime(p.PID)
 	if err != nil {
-		return 0, 0, fmt.Errorf("reading /proc/uptime: %w", err)
+		return 0, age, fmt.Errorf("%w: %v", ErrCPUUnknown, err)
 	}
-	fields := strings.Fields(string(data))
-	if len(fields) == 0 {
-		return 0, 0, errors.New("malformed /proc/uptime")
-	}
-	uptime, err := strconv.ParseFloat(fields[0], 64)
-	if err != nil {
-		return 0, 0, fmt.Errorf("malformed /proc/uptime: %w", err)
-	}
-	age := uptime - float64(p.StartTicks)/clkTck
 	if age < 1 {
 		return 0, age, nil
 	}
-	busy := float64(p.UTicks+p.STicks) / clkTck
-	return busy / age, age, nil
+	return cpu.Seconds() / age, age, nil
 }
 
-// EnvLookup reads key from /proc/<pid>/environ, separating "the variable is
-// absent" (false, nil) from "the environ could not be read at all" (false,
-// err).
+// ErrEnvUnreadable is returned when a process's environment could not be read.
 //
-// The distinction is load-bearing for any caller that attributes a process to
-// something on the strength of a missing variable. /proc/<pid>/environ is
-// readable only by the process owner, while /proc/<pid>/cmdline is
-// world-readable — so on a shared machine another user's process is visible
-// and identifiable, yet its environ always fails to read. A caller that treats
-// that failure as "the variable is unset" and applies a default silently
-// adopts a stranger's process as its own (#1044). EnvValue cannot express the
-// difference; use this when the answer matters.
+// It means "I was not allowed to look", NEVER "the variable is not set". The
+// difference is the whole reason this error exists: see EnvStatus.
+var ErrEnvUnreadable = errors.New("proctree: the process environment could not be read")
+
+// EnvStatus is the outcome of an environment probe. There are THREE, not two,
+// and the third is the point.
+//
+// A (value, bool) probe cannot say "I could not tell you". It can only say
+// found or not-found, so a DENIED read arrives at the caller wearing the same
+// face as a definite negative — and the caller then acts on a fact nobody
+// established. That is how a redacted read becomes a deletion: see
+// doctor/checks.go's processReferencedHomes, where "no process references this
+// home" is the predicate for os.RemoveAll.
+//
+// This is #1962's shape ("a bool cannot say unknown"), on the platform we just
+// gained the ability to test.
+type EnvStatus int
+
+const (
+	// EnvUnknown means the environment could not be read: denied, redacted,
+	// or the process is gone. The variable may or may not be set — we do not
+	// know, and neither does the caller.
+	//
+	// It is the ZERO VALUE deliberately. A forgotten assignment, an
+	// unhandled switch arm, or a zero-valued struct field therefore means
+	// "unknown" rather than "definitely absent", so the failure mode of
+	// sloppiness is caution instead of a fabricated negative.
+	EnvUnknown EnvStatus = iota
+	// EnvFound means the environment was read and the variable is set.
+	EnvFound
+	// EnvAbsent means the environment was READ and the variable is
+	// definitively not in it. Only this justifies acting on the variable's
+	// absence.
+	EnvAbsent
+)
+
+func (s EnvStatus) String() string {
+	switch s {
+	case EnvFound:
+		return "found"
+	case EnvAbsent:
+		return "absent"
+	default:
+		return "unknown"
+	}
+}
+
+// EnvLookup, OwnerUID and WorkingDir are the three-return / two-return process
+// readers #1920's daemon-skew detection depends on (doctor/skew.go). They were
+// added straight onto /proc while this file was still Linux-only; here they are
+// re-expressed as thin wrappers over the platform-backed primitives, so #1920
+// keeps its exact contract AND gains a darwin backend instead of silently
+// failing there. Their signatures are unchanged, so skew.go and skew_test.go
+// are untouched.
+
+// EnvLookup reads key from a process's initial environment, separating "absent"
+// (false, nil) from "could not read" (false, err) — the distinction #1044 turns
+// on. It is the (string, bool, error) spelling of LookupEnv, and it inherits the
+// same three-way honesty: a redacted or empty (indistinguishable) environment is
+// an error, not a definite "unset". Prefer LookupEnv in new code.
 func EnvLookup(pid int, key string) (string, bool, error) {
-	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/environ", pid))
-	if err != nil {
-		return "", false, err
+	switch v, st := LookupEnv(pid, key); st {
+	case EnvFound:
+		return v, true, nil
+	case EnvAbsent:
+		return "", false, nil
+	default:
+		return "", false, fmt.Errorf("%w: pid %d", ErrEnvUnreadable, pid)
 	}
-	prefix := []byte(key + "=")
-	for _, kv := range bytes.Split(data, []byte{0}) {
-		if bytes.HasPrefix(kv, prefix) {
-			return string(kv[len(prefix):]), true, nil
-		}
-	}
-	return "", false, nil
 }
 
-// WorkingDir returns pid's current working directory, read from
-// /proc/<pid>/cwd. Reports false when the link cannot be read (a different
-// user's process, a kernel thread, or a process that has exited).
-//
-// Needed by anything that resolves a RELATIVE path out of another process's
-// configuration: such a path means whatever that process's cwd makes it mean,
-// which is not ours to assume (#1044).
-func WorkingDir(pid int) (string, bool) {
-	dir, err := os.Readlink(fmt.Sprintf("/proc/%d/cwd", pid))
-	if err != nil {
-		return "", false
-	}
-	return dir, true
-}
-
-// OwnerUID returns the uid owning pid, read from /proc/<pid>'s ownership.
-// Reports false when the process is gone or its status cannot be read.
+// OwnerUID returns the uid owning pid; false when it cannot be determined. It is
+// an alias for UID, kept because skew.go injects it by this name.
 func OwnerUID(pid int) (int, bool) {
-	info, err := os.Stat(fmt.Sprintf("/proc/%d", pid))
-	if err != nil {
-		return 0, false
-	}
-	st, ok := info.Sys().(*syscall.Stat_t)
-	if !ok {
-		return 0, false
-	}
-	return int(st.Uid), true
+	return UID(pid)
 }
 
-// EnvValue reads key from /proc/<pid>/environ. Returns ("", false) when the
-// variable is absent or the environ is unreadable (different UID, kernel
-// thread, or the process exited) — callers that must tell those apart want
-// EnvLookup. The environ reflects the process's
-// *initial* environment — exactly what we want for ancestry markers, since a
-// process cannot retroactively lose the marker it inherited.
-func EnvValue(pid int, key string) (string, bool) {
-	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/environ", pid))
+// WorkingDir returns pid's current working directory; false when it cannot be
+// read (a foreign process, a kernel thread, an exited process — or a platform
+// with no backend for it). The bool is an honest unknown channel, not a
+// fabricated fact: skew.go treats false as "I could not resolve a relative home
+// in this frame" and skips, never as a positive claim (#1044).
+func WorkingDir(pid int) (string, bool) {
+	return readWorkingDir(pid)
+}
+
+// LookupEnv reads key from the process's initial environment and reports which
+// of the three things happened. Callers MUST handle EnvUnknown explicitly and
+// must never collapse it into EnvAbsent.
+//
+// The environment reflects the process's *initial* state — exactly what we want
+// for ancestry markers, since a process cannot retroactively lose the marker it
+// inherited.
+func LookupEnv(pid int, key string) (string, EnvStatus) {
+	// Through Environ, so the "did we actually get an answer?" classification
+	// lives in exactly one place and this cannot drift from it.
+	env, err := Environ(pid)
 	if err != nil {
-		return "", false
+		return "", EnvUnknown
 	}
-	prefix := []byte(key + "=")
-	for _, kv := range bytes.Split(data, []byte{0}) {
-		if bytes.HasPrefix(kv, prefix) {
-			return string(kv[len(prefix):]), true
+	prefix := key + "="
+	for _, kv := range env {
+		if strings.HasPrefix(kv, prefix) {
+			return kv[len(prefix):], EnvFound
 		}
 	}
-	return "", false
+	return "", EnvAbsent
+}
+
+// Environ returns the process's initial environment as "KEY=VALUE" strings, or
+// an error wrapping ErrEnvUnreadable when we did not get an answer.
+//
+// # Why an EMPTY environment is an error and not a result
+//
+// This is the one place that decides whether we were told anything, and it does
+// so by looking at what came back rather than by predicting what we are allowed
+// to read. That distinction is the whole design.
+//
+// A withheld environment and an empty one are BYTE-IDENTICAL. darwin's
+// sysctl_procargsx omits the env section from the KERN_PROCARGS2 buffer when it
+// declines, producing exactly what `env -i cmd` produces, and it does not say
+// which happened. So "zero variables" is not a fact about the process — it is
+// the absence of an answer, and it must not be handed to a caller as
+// "AGENT_FACTORY_HOME is not set". Downstream, that negative is the predicate
+// for deleting a directory (doctor's processReferencedHomes → os.RemoveAll).
+//
+// The obvious alternative — work out up front whether the kernel will serve us
+// — is what this replaced, and it was wrong. XNU withholds on at least TWO
+// independent grounds (uid mismatch AND cs_restricted, which SIP makes ordinary
+// on a real Mac), and a gate modelling only ownership let same-uid restricted
+// processes through to be misread. Predicting a policy you do not own means
+// reimplementing it, and a reimplementation is wrong as soon as the real policy
+// grows a clause — entitlements, hardened runtime, platform binaries are all
+// candidates. Classifying the ANSWER collapses every ground, present and
+// future, into this single branch, and it cannot rot when Apple adds one.
+//
+// The cost is precise and acceptable: a process genuinely started with an empty
+// environment (`env -i cmd`) reports unknown rather than absent. We say "I
+// cannot tell" about a process we truly cannot tell apart from a redacted one.
+// That is the honest answer, and the callers that could act on it all treat
+// unknown as a reason not to.
+func Environ(pid int) ([]string, error) {
+	env, err := readEnviron(pid)
+	if err != nil {
+		return nil, err
+	}
+	if len(env) == 0 {
+		return nil, fmt.Errorf("%w: pid %d returned no environment variables at all, which is "+
+			"indistinguishable from an environment the kernel withheld — it does not report which",
+			ErrEnvUnreadable, pid)
+	}
+	return env, nil
+}
+
+// UID returns the uid owning pid. The second return is false when ownership
+// cannot be determined (the process exited, or the platform will not say),
+// which callers MUST treat as "unknown" and never as "ours" — this gates
+// whether `af reset` may signal a process.
+func UID(pid int) (int, bool) {
+	return readUID(pid)
+}
+
+// EnvValue is DELETED, deliberately. Do not reintroduce it.
+//
+// It was `func EnvValue(pid int, key string) (string, bool)`, and the bool was
+// the bug: it collapsed "the variable is not set" and "I was not allowed to
+// read the environment" into one false. Every caller then treated a denied read
+// as a definite negative — including processReferencedHomes, whose negative is
+// the predicate for deleting a directory.
+//
+// A two-valued answer to a three-valued question cannot be used safely, so the
+// fix is not a careful caller: it is the removal of the API that made the
+// mistake expressible. Use LookupEnv and handle EnvUnknown.
+
+// Argv returns the process's argument vector with argument BOUNDARIES intact,
+// or nil when it cannot be read.
+//
+// The boundaries are the whole point: an install path containing a space
+// ("/Users/John Smith/.local/bin/af") is one argv entry, and any source that
+// hands back a pre-joined string has already destroyed the only evidence of
+// that. Re-splitting such a string on whitespace yields argv[0] = "/Users/John"
+// — which is how spaced-install daemon detection broke on darwin (#1942) while
+// working on Linux, where /proc/<pid>/cmdline preserved the NULs. Callers that
+// classify a process by its binary name MUST use this, never Cmdline.
+func Argv(pid int) []string {
+	argv, err := readArgv(pid)
+	if err != nil {
+		return nil
+	}
+	return argv
 }
 
 // Cmdline returns the process's argv joined with spaces, or "" when
-// unreadable. For kernel threads (empty cmdline) it returns "". This is a
-// lossy, display-oriented view: it collapses argv boundaries, so a binary path
+// unreadable. For kernel threads (empty argv) it returns "". This is a lossy,
+// display-oriented view: it collapses argv boundaries, so a binary path
 // containing spaces cannot be recovered from it. Do not use it for
-// classification that depends on argv boundaries (#1214).
+// classification that depends on argv boundaries — use Argv (#1214, #1942).
 func Cmdline(pid int) string {
-	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
-	if err != nil {
+	argv := Argv(pid)
+	if len(argv) == 0 {
 		return ""
 	}
-	return strings.TrimSpace(string(bytes.ReplaceAll(data, []byte{0}, []byte{' '})))
+	out := argv[0]
+	for _, a := range argv[1:] {
+		out += " " + a
+	}
+	return out
 }

--- a/internal/proctree/proctree_darwin.go
+++ b/internal/proctree/proctree_darwin.go
@@ -1,0 +1,275 @@
+//go:build darwin
+
+package proctree
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// The darwin backend reads the kernel process table through sysctl, which is
+// the platform's answer to Linux's /proc. See proctree.go for the contract
+// every backend owes its callers.
+//
+// Sources, and why each:
+//
+//   - kern.proc.all (KERN_PROC_ALL) — the whole table as []kinfo_proc, giving
+//     pid, ppid, start time and comm in one call.
+//   - getsid(2) — the kernel session id. kinfo_proc carries e_sess, but it is a
+//     POINTER into kernel memory, not an id, so it is useless to us; getsid is
+//     the only readable source. It costs one syscall per process, which is why
+//     snapshot pays it once rather than callers paying it per lookup.
+//   - kern.procargs2 (KERN_PROCARGS2) — argv AND envp with their NUL
+//     separators intact. This is the darwin equivalent of /proc/<pid>/cmdline
+//     and /proc/<pid>/environ, and preserving those separators is what makes
+//     spaced-install detection work here (#1942).
+//   - proc_info(PROC_PIDTASKINFO) — cumulative CPU. kinfo_proc's p_uticks /
+//     p_sticks are legacy fields the modern XNU kernel does not populate, so
+//     reading them would report a confident 0% for a process pegging a core.
+//
+// Nothing here reports a read failure as an empty result: an unreadable
+// process table returns an error, and an unreadable CPU counter returns
+// ErrCPUUnknown rather than zero.
+
+// snapshot reads the whole kernel process table via sysctl.
+func snapshot() (map[int]Process, error) {
+	kps, err := unix.SysctlKinfoProcSlice("kern.proc.all")
+	if err != nil {
+		return nil, fmt.Errorf("reading the kernel process table (kern.proc.all): %w", err)
+	}
+	if len(kps) == 0 {
+		// Unreachable on a running system — launchd is pid 1 and always
+		// present — so an empty table means the read did not work rather
+		// than that nothing is running. Saying so is the whole point of
+		// this package (#1939): an empty snapshot handed back as success is
+		// how blindness gets rendered as health.
+		return nil, errors.New("kern.proc.all returned an empty process table, which cannot happen on a running system")
+	}
+	procs := make(map[int]Process, len(kps))
+	for i := range kps {
+		p, ok := processFromKinfo(&kps[i])
+		if !ok {
+			continue
+		}
+		procs[p.PID] = p
+	}
+	return procs, nil
+}
+
+// readProc reads one process's kinfo_proc. Returns an error when the pid names
+// no live process, which is what makes it usable as an identity check.
+func readProc(pid int) (Process, error) {
+	kp, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
+	if err != nil {
+		return Process{}, err
+	}
+	p, ok := processFromKinfo(kp)
+	if !ok {
+		return Process{}, fmt.Errorf("kern.proc.pid returned no usable entry for pid %d", pid)
+	}
+	return p, nil
+}
+
+// processFromKinfo converts one kinfo_proc into a Process.
+func processFromKinfo(kp *unix.KinfoProc) (Process, bool) {
+	pid := int(kp.Proc.P_pid)
+	if pid <= 0 {
+		return Process{}, false
+	}
+	// P_starttime is wall-clock (a timeval), unlike Linux's ticks-since-boot,
+	// so it serves as both the identity stamp and the age basis. Nano() keeps
+	// the field-width differences between arm64 and amd64 out of this file.
+	startedAt := time.Unix(0, kp.Proc.P_starttime.Nano())
+	return Process{
+		PID:       pid,
+		PPID:      int(kp.Eproc.Ppid),
+		StartID:   uint64(kp.Proc.P_starttime.Nano()),
+		StartedAt: startedAt,
+		SID:       sessionID(pid),
+		Comm:      cString(kp.Proc.P_comm[:]),
+	}, true
+}
+
+// sessionID returns pid's kernel session id, or sidUnknown when the kernel
+// will not say.
+//
+// The failure value matters more than it looks: SessionMembers selects every
+// process sharing an id, so a failure that returned 0 would make every
+// unreadable process look like a member of session 0 — and reap.go feeds that
+// set straight into KillEscalating. sidUnknown is a value no real session
+// holds, and SessionMembers refuses to match it.
+func sessionID(pid int) int {
+	sid, err := unix.Getsid(pid)
+	if err != nil {
+		return sidUnknown
+	}
+	return sid
+}
+
+// readUID returns the real uid owning pid, from kinfo_proc's process
+// credentials.
+//
+// p_ruid (the REAL uid) rather than e_ucred's effective uid, to match what
+// Linux's /proc/<pid> ownership reports for the processes af inspects, and to
+// match os.Getuid() — which is what the caller compares against. Nothing af
+// inspects is setuid, so the two coincide in practice; picking the one the
+// comparison is written against keeps it correct if that ever stops being true.
+func readUID(pid int) (int, bool) {
+	kp, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
+	if err != nil {
+		return 0, false
+	}
+	return int(kp.Eproc.Pcred.P_ruid), true
+}
+
+// readEnviron returns whatever the kernel gives us for pid's environment. It
+// does NOT try to work out in advance whether we are allowed to have it.
+//
+// There WAS a permission gate here (uid match + P_SUGID), and deleting it is
+// the fix. It modelled XNU's rule — and a model of someone else's policy is
+// wrong the moment that policy has a clause you did not know about. It always
+// has one. XNU's sysctl_procargsx withholds the environment on at least two
+// INDEPENDENT grounds: a uid mismatch, and a cs_restricted (code-signing
+// restricted) target — which SIP makes ordinary on a real Mac. The gate modelled
+// the first and missed the second, so a same-uid cs_restricted process walked
+// straight through it, came back with an empty environment, and was read as a
+// definite "this variable is not set". The same fabricated negative, through the
+// door I had not modelled. Adding a cs_restricted clause would just be the same
+// mistake with one more clause; entitlements, hardened runtime and platform
+// binaries are all waiting behind it.
+//
+// So: ask, then look at what came back. The kernel is the authority on its own
+// policy, and our job is not to predict it — only to notice when we did not get
+// an answer. Environ does that classification, in one place, for every ground at
+// once (see Environ).
+func readEnviron(pid int) ([]string, error) {
+	_, env, err := procArgs(pid)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrEnvUnreadable, err)
+	}
+	return env, nil
+}
+
+// readArgv returns pid's argv with boundaries intact.
+func readArgv(pid int) ([]string, error) {
+	argv, _, err := procArgs(pid)
+	if err != nil {
+		return nil, err
+	}
+	if len(argv) == 0 {
+		return nil, fmt.Errorf("pid %d has no argv", pid)
+	}
+	return argv, nil
+}
+
+// procArgs reads and parses KERN_PROCARGS2 for pid.
+//
+// The kernel withholds this from us for reasons of its own — a foreign uid and
+// a code-signing-restricted target are two, and the list is Apple's to extend —
+// so a failure here is routine rather than a malfunction. Deliberately NOT
+// stated as a rule: writing down when the kernel refuses is how the last bug
+// got in. What matters is that a refusal is an ERROR and never an empty result,
+// and that a refusal it declines to report at all is caught by Environ's
+// classification instead.
+func procArgs(pid int) (argv []string, env []string, err error) {
+	buf, err := unix.SysctlRaw("kern.procargs2", pid)
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading argv for pid %d (kern.procargs2): %w", pid, err)
+	}
+	return parseProcArgs2(buf)
+}
+
+// cString converts a NUL-padded fixed-size kernel char array to a string.
+func cString(b []byte) string {
+	if i := bytes.IndexByte(b, 0); i >= 0 {
+		b = b[:i]
+	}
+	return string(b)
+}
+
+// procTaskInfo mirrors darwin's struct proc_taskinfo (sys/proc_info.h). It is
+// declared here rather than pulled from x/sys because x/sys does not wrap
+// proc_info. The field order and widths are load-bearing: the kernel writes
+// this struct by offset, and taskInfoSize below is checked against what the
+// syscall says it wrote.
+type procTaskInfo struct {
+	VirtualSize      uint64
+	ResidentSize     uint64
+	TotalUser        uint64 // nanoseconds
+	TotalSystem      uint64 // nanoseconds
+	ThreadsUser      uint64
+	ThreadsSystem    uint64
+	Policy           int32
+	Faults           int32
+	Pageins          int32
+	CowFaults        int32
+	MessagesSent     int32
+	MessagesReceived int32
+	SyscallsMach     int32
+	SyscallsUnix     int32
+	Csw              int32
+	Threadnum        int32
+	Numrunning       int32
+	Priority         int32
+}
+
+const (
+	// procInfoCallPIDInfo is PROC_INFO_CALL_PIDINFO: the proc_info callnum
+	// that libproc's proc_pidinfo() wraps.
+	procInfoCallPIDInfo = 2
+	// procPIDTaskInfo is PROC_PIDTASKINFO, the flavor returning procTaskInfo.
+	procPIDTaskInfo = 4
+)
+
+// readCPUTime returns pid's cumulative user+system CPU time.
+//
+// This goes through the proc_info syscall directly because the alternatives do
+// not survive contact with this repo: libproc's proc_pidinfo() needs cgo, and
+// darwin builds here run cgo-free (a -race build on darwin has no cgo at all).
+// kinfo_proc's legacy tick counters are not an option either — the modern
+// kernel leaves them at zero, which would report every runaway process as idle.
+func readCPUTime(pid int) (time.Duration, error) {
+	var ti procTaskInfo
+	size := unsafe.Sizeof(ti)
+	n, _, errno := syscall.Syscall6(
+		uintptr(unix.SYS_PROC_INFO),
+		uintptr(procInfoCallPIDInfo),
+		uintptr(pid),
+		uintptr(procPIDTaskInfo),
+		0,
+		uintptr(unsafe.Pointer(&ti)),
+		size,
+	)
+	if errno != 0 {
+		return 0, fmt.Errorf("proc_info(PROC_PIDTASKINFO) for pid %d: %w", pid, errno)
+	}
+	if n != uintptr(size) {
+		// A short write means the kernel's struct is not the one declared
+		// above. Report it rather than reading whatever landed in the
+		// fields, which would be a plausible-looking wrong number.
+		return 0, fmt.Errorf("proc_info(PROC_PIDTASKINFO) for pid %d wrote %d bytes, want %d", pid, n, size)
+	}
+	return time.Duration(ti.TotalUser + ti.TotalSystem), nil
+}
+
+// readWorkingDir has no darwin backend yet, and returns the honest unknown
+// rather than a guess.
+//
+// darwin's cwd source is proc_pidinfo(PROC_PIDVNODEPATHINFO), whose struct is
+// large and cannot be verified from a Linux dev box — and a mis-declared offset
+// would return a WRONG path, i.e. a fabricated POSITIVE, which is strictly worse
+// than "unknown" for the caller that resolves a home in this frame. So until it
+// can be written and proven on a real Mac, this reports (", false): WorkingDir's
+// explicit unknown channel, which skew.go already treats as "cannot resolve"
+// (#1044) and skips. A daemon whose home is spelled RELATIVELY is therefore not
+// evaluated for skew on darwin — a report-only, safe degradation, not a
+// fabricated fact.
+func readWorkingDir(int) (string, bool) {
+	return "", false
+}

--- a/internal/proctree/proctree_linux.go
+++ b/internal/proctree/proctree_linux.go
@@ -1,0 +1,239 @@
+//go:build linux
+
+package proctree
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// The Linux backend reads /proc. See proctree.go for the contract every
+// backend owes its callers; the short version is that "cannot read" must never
+// be reported as "nothing there".
+
+// clkTck is the kernel clock-tick rate (_SC_CLK_TCK) used to convert /proc
+// stat fields to seconds. It is 100 on every mainstream Linux configuration;
+// Go's runtime makes the same assumption. Only used for approximate CPU/age
+// reporting, never for identity checks.
+const clkTck = 100
+
+// snapshot reads every /proc/<pid>/stat once, then stamps each entry with a
+// wall-clock start time derived from the single /proc/uptime read below.
+//
+// Boot time is resolved ONCE per snapshot rather than per process: it is the
+// same instant for all of them, and re-reading it per entry would let a
+// snapshot's processes disagree about when the machine booted.
+//
+// AN UNREADABLE /proc/uptime IS NOT FATAL, and that is deliberate. It used to
+// fail the whole snapshot, which meant a procfs mounted `subset=pid` — where
+// /proc/<pid>/stat reads fine but /proc/uptime is not there — reported "cannot
+// read the process table" and turned off orphan reaping and doctor's process
+// map entirely. That is this package's own disease pointing the other way:
+// manufacturing NO DATA where data exists, having been built to stop
+// manufacturing health where no data exists.
+//
+// So the table still comes back; only StartedAt is left zero. It feeds nothing
+// but CPUFraction, which already reports a zero StartedAt as unknown — so we
+// lose a nice-to-have (runaway-CPU detection says it could not measure, out
+// loud) and keep the load-bearing part (reaping, orphan and escape detection).
+func snapshot() (map[int]Process, error) {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil, fmt.Errorf("reading /proc: %w", err)
+	}
+	booted, bootErr := bootTime()
+	procs := make(map[int]Process, len(entries))
+	for _, e := range entries {
+		pid, err := strconv.Atoi(e.Name())
+		if err != nil || pid <= 0 {
+			continue
+		}
+		p, err := readProc(pid)
+		if err != nil {
+			// Process exited between ReadDir and the stat read; skip.
+			continue
+		}
+		if bootErr == nil {
+			p.StartedAt = booted.Add(time.Duration(float64(p.StartID) / clkTck * float64(time.Second)))
+		}
+		procs[pid] = p
+	}
+	return procs, nil
+}
+
+// uptimePath is /proc/uptime, indirected so tests can reproduce a procfs that
+// does not serve it (subset=pid) without mounting one.
+var uptimePath = "/proc/uptime"
+
+// bootTime returns the wall-clock instant the machine booted, from
+// /proc/uptime.
+func bootTime() (time.Time, error) {
+	data, err := os.ReadFile(uptimePath)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("reading %s: %w", uptimePath, err)
+	}
+	fields := strings.Fields(string(data))
+	if len(fields) == 0 {
+		return time.Time{}, errors.New("malformed /proc/uptime")
+	}
+	uptime, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("malformed /proc/uptime: %w", err)
+	}
+	return time.Now().Add(-time.Duration(uptime * float64(time.Second))), nil
+}
+
+// readProc parses /proc/<pid>/stat. Format: `pid (comm) state ppid ...`.
+// Comm may itself contain spaces and ')' — the parse anchors on the LAST ')'.
+//
+// StartedAt is deliberately left zero here: it needs boot time, which is a
+// per-snapshot fact rather than a per-process one. snapshot() fills it in.
+func readProc(pid int) (Process, error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return Process{}, err
+	}
+	open := bytes.IndexByte(data, '(')
+	close_ := bytes.LastIndexByte(data, ')')
+	if open < 0 || close_ < open || close_+2 > len(data) {
+		return Process{}, fmt.Errorf("malformed stat for pid %d", pid)
+	}
+	comm := string(data[open+1 : close_])
+	fields := strings.Fields(string(data[close_+2:]))
+	// fields[0] is stat field 3 (state); stat field N lives at fields[N-3].
+	const (
+		idxPPID  = 4 - 3
+		idxSID   = 6 - 3
+		idxStart = 22 - 3
+	)
+	if len(fields) <= idxStart {
+		return Process{}, fmt.Errorf("truncated stat for pid %d", pid)
+	}
+	ppid, err := strconv.Atoi(fields[idxPPID])
+	if err != nil {
+		return Process{}, fmt.Errorf("bad ppid for pid %d: %w", pid, err)
+	}
+	sid, err := strconv.Atoi(fields[idxSID])
+	if err != nil {
+		return Process{}, fmt.Errorf("bad sid for pid %d: %w", pid, err)
+	}
+	start, err := strconv.ParseUint(fields[idxStart], 10, 64)
+	if err != nil {
+		return Process{}, fmt.Errorf("bad starttime for pid %d: %w", pid, err)
+	}
+	return Process{
+		PID:     pid,
+		PPID:    ppid,
+		SID:     sid,
+		StartID: start,
+		Comm:    comm,
+	}, nil
+}
+
+// readCPUTime returns pid's cumulative user+system CPU from /proc/<pid>/stat
+// fields 14 and 15.
+func readCPUTime(pid int) (time.Duration, error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return 0, err
+	}
+	close_ := bytes.LastIndexByte(data, ')')
+	if close_ < 0 || close_+2 > len(data) {
+		return 0, fmt.Errorf("malformed stat for pid %d", pid)
+	}
+	fields := strings.Fields(string(data[close_+2:]))
+	// stat field N lives at fields[N-3]; 14 is utime and 15 is stime.
+	const (
+		idxUtime = 14 - 3
+		idxStime = 15 - 3
+	)
+	if len(fields) <= idxStime {
+		return 0, fmt.Errorf("truncated stat for pid %d", pid)
+	}
+	utime, err := strconv.ParseUint(fields[idxUtime], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("bad utime for pid %d: %w", pid, err)
+	}
+	stime, err := strconv.ParseUint(fields[idxStime], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("bad stime for pid %d: %w", pid, err)
+	}
+	return time.Duration(float64(utime+stime) / clkTck * float64(time.Second)), nil
+}
+
+// readUID returns the uid owning pid, from the ownership of its /proc
+// directory. That directory is owned by the process's effective uid, which for
+// every process af inspects (nothing here is setuid) is also its real uid.
+func readUID(pid int) (int, bool) {
+	fi, err := os.Stat(fmt.Sprintf("/proc/%d", pid))
+	if err != nil {
+		return 0, false
+	}
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, false
+	}
+	return int(st.Uid), true
+}
+
+// readEnviron reads /proc/<pid>/environ and splits it on its NUL separators.
+//
+// Linux needs no permission gate of its own (compare the darwin backend, which
+// does): /proc/<pid>/environ is mode 0400 owned by the process, so a refusal
+// arrives honestly as EACCES rather than as a silently empty result. The error
+// is wrapped in ErrEnvUnreadable so callers classify it as "could not read"
+// rather than "not set" — the distinction the reaping paths turn on.
+func readEnviron(pid int) ([]string, error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/environ", pid))
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrEnvUnreadable, err)
+	}
+	return splitNUL(data), nil
+}
+
+// readArgv reads /proc/<pid>/cmdline, whose NUL separators preserve the argv
+// boundaries a spaced binary path depends on (#1214).
+func readArgv(pid int) ([]string, error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+	if err != nil {
+		return nil, err
+	}
+	argv := splitNUL(data)
+	if len(argv) == 0 {
+		// Kernel threads and reaped-but-unwaited zombies have an empty
+		// cmdline. Nothing to classify; say so rather than returning a
+		// zero-length argv that reads as a successful parse.
+		return nil, fmt.Errorf("pid %d has no argv", pid)
+	}
+	return argv, nil
+}
+
+// splitNUL splits a NUL-separated /proc blob, dropping the trailing empty
+// element left by the final NUL terminator.
+func splitNUL(data []byte) []string {
+	parts := strings.Split(string(data), "\x00")
+	for len(parts) > 0 && parts[len(parts)-1] == "" {
+		parts = parts[:len(parts)-1]
+	}
+	if len(parts) == 0 {
+		return nil
+	}
+	return parts
+}
+
+// readWorkingDir reads pid's cwd from /proc/<pid>/cwd. The symlink is readable
+// only by the process owner (or root), so a foreign process reports false —
+// the honest unknown, which WorkingDir's caller handles as "cannot resolve".
+func readWorkingDir(pid int) (string, bool) {
+	dir, err := os.Readlink(fmt.Sprintf("/proc/%d/cwd", pid))
+	if err != nil {
+		return "", false
+	}
+	return dir, true
+}

--- a/internal/proctree/proctree_linux_test.go
+++ b/internal/proctree/proctree_linux_test.go
@@ -1,0 +1,53 @@
+//go:build linux
+
+package proctree
+
+import (
+	"errors"
+	"testing"
+)
+
+// This file is linux-tagged because its subject is: /proc/uptime, and the
+// backend variable that points at it. An untagged test referencing a
+// build-tagged symbol fails to COMPILE on the other platform — a runtime
+// t.Skip cannot rescue it, which `GOOS=darwin go vet` says immediately and
+// which is why this file exists rather than a skip.
+
+// TestSnapshotSurvivesUnreadableBootTime is the subset=pid regression: a procfs
+// that serves /proc/<pid>/stat but hides /proc/uptime must still yield a
+// process table.
+//
+// It used to fail the whole snapshot, which turned off orphan reaping and
+// doctor's process map on a machine where both would have worked perfectly —
+// this package's own disease inverted. It was built to stop manufacturing
+// health where there is no data; failing here manufactured NO DATA where there
+// is data.
+//
+// Boot time is unreadable only in the sense that matters: the test points the
+// backend at a path that does not exist, which is exactly what subset=pid
+// presents. StartedAt then stays zero and CPUFraction reports unknown — a
+// nice-to-have lost, loudly — while the table itself is intact.
+func TestSnapshotSurvivesUnreadableBootTime(t *testing.T) {
+	child := startSleeper(t)
+
+	orig := uptimePath
+	t.Cleanup(func() { uptimePath = orig })
+	uptimePath = "/proc/definitely-not-uptime" // what subset=pid looks like
+
+	snap, err := Snapshot()
+	if err != nil {
+		t.Fatalf("Snapshot with an unreadable boot time = %v; want the process table anyway — "+
+			"/proc/<pid>/stat still reads, so refusing here reports NO DATA where data exists", err)
+	}
+	if _, ok := snap[child.Process.Pid]; !ok {
+		t.Errorf("snapshot missing child pid %d: the table must survive an unreadable boot time",
+			child.Process.Pid)
+	}
+
+	// And the part we genuinely lost must say so rather than read as idle.
+	p := snap[child.Process.Pid]
+	if _, _, err := CPUFraction(p); !errors.Is(err, ErrCPUUnknown) {
+		t.Errorf("CPUFraction without a boot time = %v, want ErrCPUUnknown: an unmeasurable process "+
+			"must never report as 0%% CPU, which is indistinguishable from idle", err)
+	}
+}

--- a/internal/proctree/proctree_other.go
+++ b/internal/proctree/proctree_other.go
@@ -1,0 +1,48 @@
+//go:build !linux && !darwin
+
+package proctree
+
+import "time"
+
+// This file is the deliberate dead end for any platform with no process-table
+// backend, and it exists to be LOUD.
+//
+// The bug this package was built out of (#1939) was not that darwin lacked
+// /proc — it was that nothing said so. proctree was Linux-only with no build
+// tag, so on darwin every read failed, every caller swallowed the failure, and
+// `af doctor` reported a clean bill of health from a process table it had
+// never managed to read. The code compiled everywhere and worked in one place.
+//
+// So: a new GOOS gets a compile-time fact, not a silent no-op. Either add a
+// real backend for it, or let it fail here where the error names the platform.
+// Do not "fix" a build failure in this file by returning empty values — an
+// empty process table is a claim that nothing is running, and this platform is
+// in no position to make that claim.
+
+func snapshot() (map[int]Process, error) {
+	return nil, ErrUnsupportedPlatform
+}
+
+func readProc(int) (Process, error) {
+	return Process{}, ErrUnsupportedPlatform
+}
+
+func readEnviron(int) ([]string, error) {
+	return nil, ErrUnsupportedPlatform
+}
+
+func readArgv(int) ([]string, error) {
+	return nil, ErrUnsupportedPlatform
+}
+
+func readCPUTime(int) (time.Duration, error) {
+	return 0, ErrUnsupportedPlatform
+}
+
+func readUID(int) (int, bool) {
+	return 0, false
+}
+
+func readWorkingDir(int) (string, bool) {
+	return "", false
+}

--- a/internal/proctree/proctree_test.go
+++ b/internal/proctree/proctree_test.go
@@ -1,15 +1,15 @@
 package proctree
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
 	"syscall"
 	"testing"
 	"time"
-
-	"github.com/sachiniyer/agent-factory/internal/testguard"
 )
 
 // startSleeper spawns a `sleep` child owned by this test and returns its
@@ -28,7 +28,6 @@ func startSleeper(t *testing.T) *exec.Cmd {
 }
 
 func TestSnapshotIncludesSelfAndChild(t *testing.T) {
-	testguard.RequireProcFS(t)
 	child := startSleeper(t)
 	snap, err := Snapshot()
 	if err != nil {
@@ -38,8 +37,8 @@ func TestSnapshotIncludesSelfAndChild(t *testing.T) {
 	if !ok {
 		t.Fatalf("snapshot missing our own pid %d", os.Getpid())
 	}
-	if self.StartTicks == 0 {
-		t.Errorf("self StartTicks = 0, want nonzero")
+	if self.StartID == 0 {
+		t.Errorf("self StartID = 0, want nonzero")
 	}
 	cp, ok := snap[child.Process.Pid]
 	if !ok {
@@ -54,7 +53,6 @@ func TestSnapshotIncludesSelfAndChild(t *testing.T) {
 }
 
 func TestTreeOfFindsGrandchild(t *testing.T) {
-	testguard.RequireProcFS(t)
 	// sh -c spawns sleep as a grandchild of the test process.
 	cmd := exec.Command("sh", "-c", "sleep 300 & wait")
 	if err := cmd.Start(); err != nil {
@@ -101,7 +99,6 @@ func TestTreeOfFindsGrandchild(t *testing.T) {
 }
 
 func TestTreeOfMissingRoot(t *testing.T) {
-	testguard.RequireProcFS(t)
 	snap := map[int]Process{2: {PID: 2, PPID: 1}}
 	if tree := TreeOf(snap, 999999); tree != nil {
 		t.Errorf("TreeOf(missing root) = %v, want nil", tree)
@@ -109,7 +106,6 @@ func TestTreeOfMissingRoot(t *testing.T) {
 }
 
 func TestSessionMembers(t *testing.T) {
-	testguard.RequireProcFS(t)
 	snap := map[int]Process{
 		10: {PID: 10, PPID: 1, SID: 10},
 		11: {PID: 11, PPID: 1, SID: 10}, // reparented but same kernel session
@@ -127,7 +123,6 @@ func TestSessionMembers(t *testing.T) {
 }
 
 func TestSignalVerifiesIdentity(t *testing.T) {
-	testguard.RequireProcFS(t)
 	child := startSleeper(t)
 	snap, err := Snapshot()
 	if err != nil {
@@ -137,7 +132,7 @@ func TestSignalVerifiesIdentity(t *testing.T) {
 
 	// Wrong start time must refuse to signal.
 	stale := p
-	stale.StartTicks++
+	stale.StartID++
 	if err := Signal(stale, syscall.SIGTERM); err != ErrIdentityChanged {
 		t.Errorf("Signal(stale identity) = %v, want ErrIdentityChanged", err)
 	}
@@ -161,7 +156,6 @@ func TestSignalVerifiesIdentity(t *testing.T) {
 // returns ESRCH for the kill. Signal must map that to ErrIdentityChanged so
 // callers treat "already gone" as success, not a warnable failure (#1151).
 func TestSignalReapedInTOCTOUWindow(t *testing.T) {
-	testguard.RequireProcFS(t)
 	child := startSleeper(t)
 	snap, err := Snapshot()
 	if err != nil {
@@ -184,7 +178,6 @@ func TestSignalReapedInTOCTOUWindow(t *testing.T) {
 // TestSignalPropagatesNonESRCHErrors makes sure the ESRCH coercion does not
 // swallow genuine signal failures (e.g. EPERM): those must still surface.
 func TestSignalPropagatesNonESRCHErrors(t *testing.T) {
-	testguard.RequireProcFS(t)
 	child := startSleeper(t)
 	snap, err := Snapshot()
 	if err != nil {
@@ -205,7 +198,6 @@ func TestSignalPropagatesNonESRCHErrors(t *testing.T) {
 // survivor is reaped in the TOCTOU window, KillEscalating must not log a
 // "failed to" warning for it (#1151).
 func TestKillEscalatingNoWarnOnTOCTOUExit(t *testing.T) {
-	testguard.RequireProcFS(t)
 	child := startSleeper(t)
 	snap, err := Snapshot()
 	if err != nil {
@@ -233,7 +225,6 @@ func TestKillEscalatingNoWarnOnTOCTOUExit(t *testing.T) {
 }
 
 func TestSignalRefusesSelfAndInit(t *testing.T) {
-	testguard.RequireProcFS(t)
 	if err := Signal(Process{PID: 1}, syscall.SIGTERM); err == nil {
 		t.Errorf("Signal(pid 1) succeeded, want refusal")
 	}
@@ -242,8 +233,7 @@ func TestSignalRefusesSelfAndInit(t *testing.T) {
 	}
 }
 
-func TestEnvValue(t *testing.T) {
-	testguard.RequireProcFS(t)
+func TestLookupEnv(t *testing.T) {
 	cmd := exec.Command("sleep", "300")
 	cmd.Env = append(os.Environ(), "AF_TEST_MARKER=hello")
 	if err := cmd.Start(); err != nil {
@@ -257,22 +247,23 @@ func TestEnvValue(t *testing.T) {
 	// poll briefly rather than racing it.
 	deadline := time.Now().Add(5 * time.Second)
 	for {
-		if got, ok := EnvValue(cmd.Process.Pid, "AF_TEST_MARKER"); ok && got == "hello" {
+		if got, st := LookupEnv(cmd.Process.Pid, "AF_TEST_MARKER"); st == EnvFound && got == "hello" {
 			break
 		}
 		if time.Now().After(deadline) {
-			got, ok := EnvValue(cmd.Process.Pid, "AF_TEST_MARKER")
-			t.Fatalf("EnvValue = (%q, %v), want (\"hello\", true)", got, ok)
+			got, st := LookupEnv(cmd.Process.Pid, "AF_TEST_MARKER")
+			t.Fatalf("LookupEnv = (%q, %v), want (\"hello\", found)", got, st)
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	if _, ok := EnvValue(cmd.Process.Pid, "AF_TEST_ABSENT"); ok {
-		t.Errorf("EnvValue found an absent variable")
+	// A variable that is not set, in an environment we CAN read, is
+	// definitively absent — the one case that justifies acting on absence.
+	if _, st := LookupEnv(cmd.Process.Pid, "AF_TEST_ABSENT"); st != EnvAbsent {
+		t.Errorf("LookupEnv(absent var) = %v, want absent", st)
 	}
 }
 
 func TestCPUFractionIdleSleeper(t *testing.T) {
-	testguard.RequireProcFS(t)
 	child := startSleeper(t)
 	snap, err := Snapshot()
 	if err != nil {
@@ -288,7 +279,6 @@ func TestCPUFractionIdleSleeper(t *testing.T) {
 }
 
 func TestCmdline(t *testing.T) {
-	testguard.RequireProcFS(t)
 	child := startSleeper(t)
 	// /proc/<pid>/cmdline is empty in the window between fork and exec;
 	// poll briefly rather than racing it.
@@ -301,5 +291,249 @@ func TestCmdline(t *testing.T) {
 			t.Fatalf("Cmdline = %q, want %q", Cmdline(child.Process.Pid), "sleep 300")
 		}
 		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestUIDMatchesOurOwn proves this platform's ownership read actually works.
+//
+// It is deliberately an assertion and not a nicety: daemon/stopall.go compares
+// this against os.Getuid() to decide whether `af reset` may SIGTERM a process.
+// A backend that returned a wrong-but-plausible uid would make af either skip
+// its own stale daemons forever or, far worse, mistake someone else's daemon
+// for its own. On darwin the value comes from kinfo_proc's p_ruid, and this is
+// what proves that field is populated rather than trusting that it is.
+func TestUIDMatchesOurOwn(t *testing.T) {
+	uid, ok := UID(os.Getpid())
+	if !ok {
+		t.Fatalf("UID(self) reported unknown — af reset cannot verify ownership on this platform, " +
+			"so it will treat every daemon as unverifiable and stop none of them (#1939)")
+	}
+	if uid != os.Getuid() {
+		t.Errorf("UID(self) = %d, want %d — a wrong uid makes `af reset` misclassify daemon ownership", uid, os.Getuid())
+	}
+}
+
+// TestUIDOfDeadProcessIsUnknown pins the failure value. "Unknown" must not be
+// answerable as uid 0, or a dead pid would read as root-owned.
+func TestUIDOfDeadProcessIsUnknown(t *testing.T) {
+	// A pid that cannot exist: the kernel caps pids well below this.
+	if uid, ok := UID(1 << 30); ok {
+		t.Errorf("UID(nonexistent pid) = (%d, true), want unknown", uid)
+	}
+}
+
+// TestEnvironDistinguishesAbsentFromUnreadable locks the distinction
+// daemon/stopall.go's daemonHomeEnv depends on: a readable environment that
+// simply lacks the key is NOT the same fact as an unreadable one. Conflating
+// them makes `af reset` either skip the stale daemon it exists to kill, or
+// guess at a home it cannot see.
+func TestEnvironDistinguishesAbsentFromUnreadable(t *testing.T) {
+	cmd := exec.Command("sleep", "300")
+	cmd.Env = append(os.Environ(), "AF_TEST_MARKER=hello")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting sleeper: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+
+	// Readable: nil error, and the marker is present.
+	deadline := time.Now().Add(5 * time.Second)
+	var env []string
+	for {
+		var err error
+		env, err = Environ(cmd.Process.Pid)
+		if err == nil && len(env) > 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("Environ(child) never became readable: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	found := false
+	for _, kv := range env {
+		if kv == "AF_TEST_MARKER=hello" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("Environ(child) did not contain the marker we set; got %d vars", len(env))
+	}
+
+	// Unreadable: an error, NOT an empty-but-successful result.
+	if env, err := Environ(1 << 30); err == nil {
+		t.Errorf("Environ(nonexistent pid) = (%v, nil), want an error — an unreadable environment "+
+			"must never look like an empty one", env)
+	}
+}
+
+// foreignPID returns the pid of a process owned by a DIFFERENT user, or skips.
+//
+// It SEARCHES for one rather than assuming pid 1 will do. An earlier version
+// hardcoded pid 1 on the reasoning that init/launchd is always root's — true on
+// a normal machine, false in our own test container, where pid 1 is the
+// entrypoint running as the same unprivileged user as the tests. The assertion
+// then failed for a reason that had nothing to do with what it tests.
+//
+// Which is this PR's own bug class aimed at its own tests: an environment
+// assumption that holds where it was written and nowhere else. So: find a real
+// foreign process, and if the environment genuinely has none (a container with
+// a single uid), say so and skip instead of inventing a conclusion.
+func foreignPID(t *testing.T) int {
+	t.Helper()
+	self := os.Getuid()
+	if self == 0 {
+		t.Skip("running as root: root can read every environment, so there is no refusal to observe")
+	}
+	snap, err := Snapshot()
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	pids := make([]int, 0, len(snap))
+	for pid := range snap {
+		pids = append(pids, pid)
+	}
+	sort.Ints(pids) // deterministic pick across runs
+	for _, pid := range pids {
+		if uid, ok := UID(pid); ok && uid != self {
+			return pid
+		}
+	}
+	t.Skip("no process owned by another user is visible here (a container running everything as one " +
+		"uid), so the kernel has no reason to refuse us and the refusal cannot be observed")
+	return 0
+}
+
+// TestLookupEnvOfForeignProcessIsUnknown exercises the REAL refusal against a
+// real foreign process, on both platforms — no simulation.
+//
+// The two platforms refuse differently and that is exactly the point: Linux
+// answers EACCES, while darwin hands back a buffer with argv and NO env —
+// indistinguishable from `env -i`. Both must arrive here as EnvUnknown.
+//
+// If this ever returns EnvAbsent, af is asserting "this variable is not set"
+// about a process it was not allowed to read, and the callers that delete
+// directories and signal processes are acting on it.
+func TestLookupEnvOfForeignProcessIsUnknown(t *testing.T) {
+	pid := foreignPID(t)
+	// PATH is set for essentially every process, so EnvAbsent here could only
+	// mean we mistook a refusal for a fact.
+	if _, st := LookupEnv(pid, "PATH"); st != EnvUnknown {
+		t.Errorf("LookupEnv(pid %d, PATH) = %v, want unknown: that process belongs to another user and "+
+			"its environment is not ours to read, so any definite answer is fabricated", pid, st)
+	}
+}
+
+// TestEnvironOfForeignProcessErrors is the same fact through Environ, and it
+// must wrap ErrEnvUnreadable so callers can tell "denied" from "empty".
+func TestEnvironOfForeignProcessErrors(t *testing.T) {
+	pid := foreignPID(t)
+	env, err := Environ(pid)
+	if err == nil {
+		t.Fatalf("Environ(pid %d) = %q, nil — want an error; a refused read must not look like a result", pid, env)
+	}
+	if !errors.Is(err, ErrEnvUnreadable) {
+		t.Errorf("Environ(pid %d) error = %v, want it to wrap ErrEnvUnreadable so callers can classify it", pid, err)
+	}
+}
+
+// TestLookupEnvOfOwnProcessIsAuthoritative is the other half: for a process we
+// DO own, both answers must be definite. If the guard above were too broad it
+// would make every read unknown, and af would stop being able to identify its
+// own orphans at all — a silent, total loss of the capability.
+func TestLookupEnvOfOwnProcessIsAuthoritative(t *testing.T) {
+	// PATH, not a t.Setenv marker: this reads the process's INITIAL
+	// environment, which is fixed at exec and cannot be changed from inside
+	// (that immutability is exactly why ancestry markers are trustworthy). A
+	// t.Setenv here would not appear and the test would fail for a reason that
+	// has nothing to do with what it asserts.
+	if _, ok := os.LookupEnv("PATH"); !ok {
+		t.Skip("no PATH in this environment; nothing definite to assert against")
+	}
+	if v, st := LookupEnv(os.Getpid(), "PATH"); st != EnvFound || v == "" {
+		t.Errorf("LookupEnv(self, PATH) = (%q, %v), want a value and found", v, st)
+	}
+	if _, st := LookupEnv(os.Getpid(), "AF_TEST_DEFINITELY_NOT_SET_XYZ"); st != EnvAbsent {
+		t.Errorf("LookupEnv(self, unset var) = %v, want absent — our own environment IS readable, "+
+			"so an unset variable is a fact we may act on", st)
+	}
+}
+
+// TestEmptyEnvironIsUnknownNotEmpty is the second P1's regression, and it is
+// the whole structural fix in one assertion.
+//
+// A process started with `env -i` has NO environment variables. On darwin, a
+// process whose environment the kernel WITHHELD produces the identical buffer —
+// argv, no env section — and the kernel does not report which happened. So zero
+// variables cannot be handed back as a fact.
+//
+// This drives the real thing on any platform: `env -i` is a genuinely empty
+// environment, which is byte-for-byte what a redacted read returns. If this ever
+// reports EnvAbsent, then every ground darwin withholds on — uid mismatch,
+// cs_restricted (which SIP makes ORDINARY, and which the first fix's permission
+// gate did not model), entitlements, whatever Apple adds next — arrives at
+// callers as "this variable is definitely not set", and doctor deletes a home on
+// the strength of it.
+func TestEmptyEnvironIsUnknownNotEmpty(t *testing.T) {
+	// env -i: no variables at all, but a live process we own — so no permission
+	// rule of any kind is in play. The ONLY thing making this unknown is that
+	// the answer is indistinguishable from a withheld one.
+	cmd := exec.Command("env", "-i", "sleep", "300")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting env -i sleeper: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		// Wait for the exec: pre-exec the child still shows OUR environment.
+		if argv := Argv(cmd.Process.Pid); len(argv) > 0 && argv[0] == "sleep" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Skipf("the env -i child never exec'd into sleep; cannot pose the question here")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if _, st := LookupEnv(cmd.Process.Pid, "AGENT_FACTORY_HOME"); st != EnvUnknown {
+		t.Errorf("LookupEnv(env -i process) = %v, want unknown: a zero-variable environment is "+
+			"byte-identical to one the kernel withheld, so it is the ABSENCE OF AN ANSWER and must "+
+			"never be reported as a definite negative", st)
+	}
+	if env, err := Environ(cmd.Process.Pid); err == nil {
+		t.Errorf("Environ(env -i process) = %q, nil — want ErrEnvUnreadable", env)
+	} else if !errors.Is(err, ErrEnvUnreadable) {
+		t.Errorf("Environ(env -i process) error = %v, want it to wrap ErrEnvUnreadable", err)
+	}
+}
+
+// TestEnvironDoesNotPredictPermission locks the STRUCTURE, not a behaviour: the
+// classification must come from the answer, never from a model of the kernel's
+// policy.
+//
+// This exists because the first fix modelled XNU's rule (uid + P_SUGID) and was
+// wrong the moment a ground it did not know about — cs_restricted — walked
+// through it. Any reintroduced predictive gate would have to answer "am I
+// allowed?" BEFORE reading, and would therefore be wrong again the next time
+// Apple adds a clause. If you are here because this test failed: do not add the
+// missing clause. Delete the prediction.
+//
+// The observable proxy: a process we own, with a non-empty environment, must be
+// readable — and a process whose answer is empty must be unknown — with no
+// reference to WHY in either direction.
+func TestEnvironDoesNotPredictPermission(t *testing.T) {
+	// Ours, non-empty: an answer, so a definite result.
+	if _, err := Environ(os.Getpid()); err != nil {
+		t.Errorf("Environ(self) = %v, want our own non-empty environment to be readable", err)
+	}
+	// Nonexistent: no answer, so unknown — and NOT because we predicted a rule.
+	if _, st := LookupEnv(1<<30, "PATH"); st != EnvUnknown {
+		t.Errorf("LookupEnv(nonexistent pid) = %v, want unknown", st)
 	}
 }

--- a/internal/sockpath/sockpath.go
+++ b/internal/sockpath/sockpath.go
@@ -1,0 +1,67 @@
+// Package sockpath owns one fact: how long a Unix socket path may be.
+//
+// It exists because that fact was previously a hardcoded 103 copy-pasted into
+// two packages, applied to the VS Code editor socket and NOT to the daemon's
+// own control sockets — so the secondary feature failed with an actionable
+// message while the core control plane failed with a bare kernel errno (#1940).
+//
+// # Where the numbers come from
+//
+// A Unix socket path lives in sockaddr_un.sun_path, a fixed-size char array,
+// and the kernel rejects anything longer with EINVAL — "invalid argument",
+// naming nothing. The array is 108 bytes on Linux and 104 on darwin, so the
+// longest usable path differs BY PLATFORM.
+//
+// Max is read from x/sys's RawSockaddrUnix rather than hardcoded, because
+// x/sys generates that type from each platform's own headers. A new GOOS gets
+// the right number for free, and nobody has to remember to update a table.
+package sockpath
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// Max is the longest path THIS platform's kernel will bind: sun_path minus the
+// NUL terminator. 107 on Linux, 103 on darwin.
+//
+// This is the bound for PRODUCT code, and it must be exact rather than
+// conservative. A guard that rejected Linux's legal 104–107 byte paths would
+// break installs that work today — turning a fix for an unactionable error into
+// an outage for people who never had the problem. Reject what the kernel
+// rejects; nothing more.
+const Max = len(unix.RawSockaddrUnix{}.Path) - 1
+
+// Portable is the longest path that fits on EVERY platform we ship (darwin's
+// 104-byte sun_path is the binding constraint; Linux's 108 is roomier).
+//
+// This is the bound for TEST harnesses, and the difference from Max is the
+// point. A test that builds a 105-byte socket path passes on Linux and fails on
+// macOS — which is this repo's entire bug class in miniature: written on Linux,
+// never run elsewhere. Harness code should hold itself to what works
+// everywhere, so a portability break surfaces on the runner that finds it
+// first rather than on a contributor's Mac.
+//
+// Unlike Max this is a policy value, not an ABI reading: it is the minimum
+// across the platforms we ship, so it needs updating only if we ship a platform
+// with a smaller sun_path than darwin's.
+const Portable = 103
+
+// Check returns an actionable error when path is too long to bind on this
+// platform, and nil otherwise. what names the socket for the operator ("daemon
+// control socket").
+//
+// The error names the path, its length, the ceiling and the knob to turn,
+// because the kernel's own answer is "invalid argument" and a user staring at
+// that has no way to connect it to their AGENT_FACTORY_HOME. That is the whole
+// reason this check exists at all: not to prevent a bind failure — the kernel
+// does that — but to make it diagnosable.
+func Check(what, path string) error {
+	if len(path) <= Max {
+		return nil
+	}
+	return fmt.Errorf("the %s path %q is %d bytes, over this platform's %d-byte limit for a "+
+		"unix socket path: set AGENT_FACTORY_HOME to a shorter directory",
+		what, path, len(path), Max)
+}

--- a/internal/sockpath/sockpath_test.go
+++ b/internal/sockpath/sockpath_test.go
@@ -1,0 +1,193 @@
+package sockpath
+
+import (
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// The socket names the daemon binds. Mirrored here rather than imported
+// (daemon imports this package, not the other way round); the arithmetic below
+// is about these exact lengths, so a rename that changes them should fail here
+// and be re-reasoned rather than silently shift the margins.
+const (
+	daemonSock     = "daemon.sock"
+	daemonHTTPSock = "daemon-http.sock" // the longest, so the first to overrun
+)
+
+// TestPlatformCeilingMatchesKernel pins the two numbers everything else rests
+// on. They come from x/sys's RawSockaddrUnix, generated from each platform's
+// headers, so this is really asserting that we read the ABI rather than
+// guessing at it.
+func TestPlatformCeilingMatchesKernel(t *testing.T) {
+	want := map[string]int{
+		"linux":  107, // sun_path 108
+		"darwin": 103, // sun_path 104
+	}[runtime.GOOS]
+	if want == 0 {
+		t.Skipf("no expected sun_path size recorded for %s", runtime.GOOS)
+	}
+	if Max != want {
+		t.Errorf("Max on %s = %d, want %d — the socket ceiling must match the platform's sun_path",
+			runtime.GOOS, Max, want)
+	}
+}
+
+// TestPortableIsDarwinsCeiling documents WHY Portable is 103: darwin's
+// sun_path is the smallest among the platforms we ship, so it is the binding
+// constraint for anything that must work on both.
+func TestPortableIsDarwinsCeiling(t *testing.T) {
+	if Portable != 103 {
+		t.Errorf("Portable = %d, want 103 (darwin's 104-byte sun_path is the floor across the platforms we ship)", Portable)
+	}
+	if Portable > Max {
+		t.Errorf("Portable (%d) exceeds this platform's Max (%d) — the portable floor can never be looser than a real kernel", Portable, Max)
+	}
+}
+
+// TestLinuxCeilingIsNotTightenedToPortable guards a specific regression this
+// fix could have caused. The old hardcoded constant was the portable 103, and
+// applying THAT to the daemon's sockets would have rejected Linux paths of
+// 104–107 bytes that the Linux kernel binds happily — breaking installs that
+// work today, in the name of fixing an error message. The product bound must be
+// the kernel's, not the portable floor.
+func TestLinuxCeilingIsNotTightenedToPortable(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("linux-specific: the loosening only applies where sun_path is 108")
+	}
+	path := "/" + strings.Repeat("a", 106) // 107 bytes: legal on Linux, too long on darwin
+	if err := Check("test socket", path); err != nil {
+		t.Errorf("Check(%d-byte path) = %v, want nil — Linux binds up to %d bytes and af must not reject what the kernel accepts",
+			len(path), err, Max)
+	}
+}
+
+// macHome renders an AF home the way it resolves on a Mac.
+func macHome(user, sub string) string { return filepath.Join("/Users", user, sub) }
+
+// TestRealisticMacHomeArithmetic is the reachability question #1940 asked,
+// worked rather than guessed: can a real Mac user land past sun_path and get a
+// daemon that will not start?
+//
+// It asserts against darwin's 103-byte ceiling (== Portable) on every runner,
+// so the mac reality is checked even on Linux CI.
+//
+// The answer this locks: NOT on a default install — that needs a 65-character
+// username — but YES for someone who points AGENT_FACTORY_HOME at iCloud Drive,
+// which clears the ceiling by two bytes and overruns one subdirectory deeper.
+// That is the case the guard exists for.
+func TestRealisticMacHomeArithmetic(t *testing.T) {
+	const darwinMax = Portable // 103; darwin's real ceiling
+
+	for _, tc := range []struct {
+		name     string
+		home     string
+		wantFits bool
+	}{
+		{
+			name:     "default home, our real Mac user",
+			home:     macHome("pradeepiyer", ".agent-factory"),
+			wantFits: true,
+		},
+		{
+			name:     "default home, firstname.lastname",
+			home:     macHome("firstname.lastname", ".agent-factory"),
+			wantFits: true,
+		},
+		{
+			// macOS's own config location; os.UserConfigDir() returns it.
+			name:     "~/Library/Application Support, firstname.lastname",
+			home:     macHome("firstname.lastname", "Library/Application Support/agent-factory"),
+			wantFits: true,
+		},
+		{
+			// A plausible "sync my config across machines" move. 101 bytes:
+			// it fits, by two.
+			name:     "iCloud Drive, firstname.lastname",
+			home:     macHome("firstname.lastname", "Library/Mobile Documents/com~apple~CloudDocs/agent-factory"),
+			wantFits: true,
+		},
+		{
+			// One directory deeper and the daemon cannot bind. This is the
+			// user #1940 is for.
+			name:     "iCloud Drive + one subdir, firstname.lastname",
+			home:     macHome("firstname.lastname", "Library/Mobile Documents/com~apple~CloudDocs/agent-factory/home"),
+			wantFits: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(tc.home, daemonHTTPSock)
+			fits := len(path) <= darwinMax
+			if fits != tc.wantFits {
+				t.Errorf("%s is %d bytes; fits under darwin's %d-byte ceiling = %v, want %v",
+					path, len(path), darwinMax, fits, tc.wantFits)
+			}
+		})
+	}
+}
+
+// TestDefaultInstallNeedsAnAbsurdUsernameToOverrun is the other half of the
+// verdict, and it is what stops this being filed as "af doesn't work on my
+// Mac". A default install is 39 bytes plus the username, so it takes a
+// 65-character username to breach darwin's ceiling. The guard must therefore
+// never fire for an ordinary user — a spurious guard on the daemon's startup
+// path would break af for everyone, which is worse than the bug it prevents.
+func TestDefaultInstallNeedsAnAbsurdUsernameToOverrun(t *testing.T) {
+	const darwinMax = Portable
+
+	overhead := len(filepath.Join("/Users", "", ".agent-factory", daemonHTTPSock)) - len("/")
+	firstBreaking := darwinMax - overhead + 1
+	if firstBreaking < 60 {
+		t.Errorf("a default install overruns at a %d-character username; that is short enough to be a real "+
+			"default-install breakage and #1940's severity needs re-reasoning", firstBreaking)
+	}
+
+	// A 40-character username — already absurd — must still fit.
+	path := filepath.Join(macHome(strings.Repeat("u", 40), ".agent-factory"), daemonHTTPSock)
+	if len(path) > darwinMax {
+		t.Errorf("a 40-char username overruns (%d bytes) — the default install is tighter than the verdict claims", len(path))
+	}
+}
+
+// TestCheckNamesTheCauseAndTheKnob is the point of the whole guard. The kernel
+// already refuses to bind an over-long path; what it will not do is say why.
+// "bind: invalid argument" names neither the path, its length, the limit, nor
+// the one setting that fixes it — so a user has no route from the error to the
+// cause. If this message ever loses those four things, the guard has stopped
+// being worth having.
+func TestCheckNamesTheCauseAndTheKnob(t *testing.T) {
+	path := "/Users/someone/" + strings.Repeat("deep/", 30) + daemonSock
+	err := Check("daemon control socket", path)
+	if err == nil {
+		t.Fatalf("Check(%d-byte path) = nil, want an error", len(path))
+	}
+	for _, want := range []string{
+		"daemon control socket", // which socket
+		path,                    // the path itself
+		"AGENT_FACTORY_HOME",    // the knob that fixes it
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("Check error %q does not mention %q", err, want)
+		}
+	}
+	if !strings.Contains(err.Error(), "unix socket") {
+		t.Errorf("Check error %q does not explain that the limit is a unix socket limit", err)
+	}
+}
+
+// TestCheckAllowsExactlyTheCeiling pins the off-by-one. sun_path holds Max
+// bytes plus a NUL, so a path of exactly Max must bind. Rejecting it would fail
+// installs the kernel accepts — the same class of harm as the bug.
+func TestCheckAllowsExactlyTheCeiling(t *testing.T) {
+	exact := "/" + strings.Repeat("a", Max-1)
+	if len(exact) != Max {
+		t.Fatalf("test built a %d-byte path, want %d", len(exact), Max)
+	}
+	if err := Check("test socket", exact); err != nil {
+		t.Errorf("Check(exactly Max=%d bytes) = %v, want nil", Max, err)
+	}
+	if err := Check("test socket", exact+"b"); err == nil {
+		t.Errorf("Check(Max+1=%d bytes) = nil, want an error", Max+1)
+	}
+}

--- a/internal/testguard/testguard.go
+++ b/internal/testguard/testguard.go
@@ -28,6 +28,8 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/sachiniyer/agent-factory/internal/sockpath"
 )
 
 // ambientConfigPaths resolves the config files the test process could touch
@@ -322,12 +324,19 @@ func IsolateTmux(t testing.TB) {
 	})
 }
 
-// maxUnixSocketPathLen is the portable ceiling for a Unix socket path.
-// sockaddr_un.sun_path is 108 bytes on Linux but only 104 on macOS; 103 is what
-// survives on both once the NUL terminator is counted. It mirrors the product's
-// own constant in daemon/vscode_socket.go — duplicated rather than imported
-// because testguard stays dependency-free.
-const maxUnixSocketPathLen = 103
+// maxUnixSocketPathLen is the ceiling a TEST's socket path must respect: what
+// fits on every platform we ship, not what fits here.
+//
+// sockpath.Portable rather than sockpath.Max on purpose. Max is this kernel's
+// real limit (107 on Linux), and a harness held to that would let a 105-byte
+// path sail through on Linux and fail on macOS — the exact shape of the bug
+// class this repo keeps rediscovering. Holding tests to the portable floor
+// makes a portability break fail on whichever runner reaches it first.
+//
+// It is imported now rather than duplicated (it used to be a second hardcoded
+// 103): internal/sockpath is a leaf, so it raises none of the config import
+// cycle this package's doc comment warns about.
+const maxUnixSocketPathLen = sockpath.Portable
 
 // SocketTempDir returns a fresh temp dir short enough to hold a Unix socket, and
 // removes it when the test ends.
@@ -392,43 +401,20 @@ func SocketPath(t *testing.T, name string) string {
 	return p
 }
 
-// RequireProcFS skips a test whose subject depends on reading Linux's /proc.
+// RequireProcFS and HasProcFS lived here until #1939 gave proctree a real
+// darwin backend. They are deliberately NOT replaced.
 //
-// THIS SKIP HIDES A REAL DEFECT (#1939) — it is not a harness quirk.
-// internal/proctree reads /proc with no darwin fallback and no build tag, so on
-// macOS Snapshot() always fails and its callers swallow that
-// (session/tmux/reap.go:61-64 returns nil on any error). tmux orphan reaping and
-// af doctor's process mapping therefore do NOTHING on macOS — permanently, not
-// intermittently. The tests guarded by this are exactly the ones that prove that
-// functionality works; on darwin they fail because the PRODUCT is broken there.
+// They existed to skip, on macOS, exactly the tests that prove tmux orphan
+// reaping and `af doctor`'s process mapping work — because on macOS those
+// features did not work, and the tests were right to fail. The skip was honest
+// about that (it said so in capitals), but a skip is still a place where the
+// suite agrees to stop asking, and this one sat over the four tests that would
+// have caught the defect on day one.
 //
-// Skipped rather than deleted or weakened so the darwin job can go green on what
-// IS fixable while this stays visible and attributable. Compare daemon/daemon.go:781
-// and daemon/stopall.go:287, which both hit /proc and DO handle macOS: darwin was
-// considered there and missed in proctree.
-//
-// Delete this helper — do not extend it to new tests — when #1939 lands a darwin
-// process-table backend.
-func RequireProcFS(t *testing.T) {
-	t.Helper()
-	if !HasProcFS() {
-		t.Skipf("no /proc on %s: proctree is Linux-only, so af's orphan reaping and doctor "+
-			"process mapping are silently broken here — see #1939 (REAL DEFECT, not a "+
-			"test-harness assumption)", runtime.GOOS)
-	}
-}
-
-// HasProcFS reports whether Linux's /proc is present.
-//
-// Use it to guard a single ASSERTION that /proc makes possible, where the
-// surrounding test still has real coverage to offer without it — guarding the
-// assertion keeps the rest of the test running on darwin, which RequireProcFS
-// (which skips the whole test) would throw away. Same defect, same caveat: see
-// #1939, and #1942 for argv-boundary recovery specifically.
-func HasProcFS() bool {
-	_, err := os.Stat("/proc")
-	return err == nil
-}
+// If you find yourself wanting a "does this platform have /proc?" helper again,
+// the answer is almost certainly a backend in internal/proctree, not a gate in
+// the test tree. proctree_other.go is where an unsupported platform belongs, and
+// it fails to compile rather than quietly returning nothing.
 
 // CanonicalTempDir returns t.TempDir() resolved to its physical path, and is the
 // spelling any test should use for a directory whose path it later compares

--- a/session/backend_hook_backend.go
+++ b/session/backend_hook_backend.go
@@ -243,6 +243,28 @@ func (p *hookProvisioner) provision() (ProvisionResult, error) {
 	}, nil
 }
 
+// hookOutputSuffix renders a hook script's combined output for an error
+// message, and says so explicitly when there was none.
+//
+// launch_cmd runs on the user's own infrastructure, so its output is the ONLY
+// window onto what went wrong out there — af has no other source. When a Mac
+// user's script died on `setsid: command not found`, that line was the entire
+// diagnosis, and everything af could usefully say was a quote of it (#1946).
+//
+// Empty output gets named rather than left to inference: "launch_cmd failed:
+// exit status 1" with nothing after it reads like af truncated something. Saying
+// the script printed nothing points the reader at their script's own error
+// handling rather than at af. (The timeout case is carried by the wrapped error
+// from runHookScript — "signal: killed" — so it is not re-derived here.)
+func hookOutputSuffix(out []byte) string {
+	trimmed := strings.TrimSpace(string(out))
+	if trimmed == "" {
+		return "; it printed nothing — a hook script must report its own errors, " +
+			"or the cause reaches nobody (see docs/remote-hooks.md)"
+	}
+	return fmt.Sprintf("; its output was:\n%s", trimmed)
+}
+
 // launch runs the user's launch_cmd with the provision spec as flags, then
 // recovers the {url,token} JSON it echoes (stderr may interleave progress, so
 // extractJSON pulls the object out of the combined output, mirroring how
@@ -282,12 +304,18 @@ func (p *hookProvisioner) launch() (*AgentServerEndpoint, error) {
 	p.launchStarted = cmd != nil && cmd.Process != nil
 
 	if err != nil {
-		return nil, fmt.Errorf("launch_cmd failed: %s: %w", strings.TrimSpace(string(out)), err)
+		// "launch_cmd failed" stays a contiguous phrase: #1955's reap tests
+		// assert the original provisioning error is not swallowed by matching on
+		// it. The path is added AFTER, so #1946's diagnostic detail and #1955's
+		// contract both hold.
+		return nil, fmt.Errorf("launch_cmd failed (%s): %w%s", p.hooks.LaunchCmd, err,
+			hookOutputSuffix(out))
 	}
 
 	jsonStr := extractJSON(string(out))
 	if jsonStr == "" {
-		return nil, fmt.Errorf("launch_cmd returned no {\"url\",\"token\"} JSON in its output (see docs/remote-hooks.md for the recipe): %s", strings.TrimSpace(string(out)))
+		return nil, fmt.Errorf("launch_cmd (%s) exited 0 but printed no {\"url\",\"token\"} JSON "+
+			"(see docs/remote-hooks.md for the recipe)%s", p.hooks.LaunchCmd, hookOutputSuffix(out))
 	}
 	var ej hookEndpointJSON
 	if err := json.Unmarshal([]byte(jsonStr), &ej); err != nil {

--- a/session/tmux/reap_test.go
+++ b/session/tmux/reap_test.go
@@ -72,7 +72,6 @@ func spawnSessionWithEscapee(t *testing.T, name string) proctree.Process {
 // where its `%d`/`%s`/`%n` sequences would be interpreted and corrupt the log
 // with `%!s(MISSING)` / `%!d(...)` garbage.
 func TestReapLogsSessionNameLiterally(t *testing.T) {
-	testguard.RequireProcFS(t)
 	// Redirect the WARNING logger to a buffer for the duration of this test.
 	var buf bytes.Buffer
 	oldOut, oldFlags := log.WarningLog.Writer(), log.WarningLog.Flags()
@@ -111,7 +110,6 @@ func TestReapLogsSessionNameLiterally(t *testing.T) {
 // TestCloseReapsEscapedPaneProcesses is the end-to-end #1104 regression
 // test: a pane child that ignores SIGHUP must not survive Close().
 func TestCloseReapsEscapedPaneProcesses(t *testing.T) {
-	testguard.RequireProcFS(t)
 	testguard.IsolateTmux(t)
 	shrinkReapWaits(t)
 
@@ -134,7 +132,6 @@ func TestCloseReapsEscapedPaneProcesses(t *testing.T) {
 // TestCleanupSessionsReapsEscapedProcesses covers the `af reset` sweep: it
 // must reap synchronously (the CLI process exits right after).
 func TestCleanupSessionsReapsEscapedProcesses(t *testing.T) {
-	testguard.RequireProcFS(t)
 	testguard.IsolateTmux(t)
 	shrinkReapWaits(t)
 


### PR DESCRIPTION
**DRAFT.** `Test (macOS)` green; local codex gate has run four rounds against this branch and found four P1s, all fixed here. The GitHub bot reviewed a head from four commits ago and has not looked since — treat its silence as silence.

We ship darwin/arm64 + darwin/amd64 and, until #1931 landed the macOS job yesterday, had **never run a test on the OS we ship**. #1939, #1940, #1942 and #1946 are what it found on day one.

## This PR is one idea, not two

> **It gives darwin real process inspection — and, *because* that inspection can never be complete on any platform, it stops process inspection from authorising deletion.**

The first half is what #1939/#1940/#1942/#1946 asked for. The second half is what four consecutive P1 reviews proved was necessary, and it is not a separate concern: it is the same fact stated honestly.

## Part 1 — darwin can see

`internal/proctree` had no darwin backend and no build tag, so on macOS `Snapshot()` failed on every call, callers swallowed it, and `af doctor` printed a clean bill of health from a process table it had never read. Every Mac user who asked "are there orphaned processes?" was told "no" by a program that could not have known.

| need | darwin source | why not the obvious thing |
|---|---|---|
| process table | `sysctl kern.proc.all` | — |
| session id | `getsid(2)` | `kinfo_proc.e_sess` is a **kernel pointer**, not an id |
| argv / env | `KERN_PROCARGS2` | `ps -o args=` has already joined the argv boundaries away |
| CPU time | `proc_info(PROC_PIDTASKINFO)` | `p_uticks`/`p_sticks` are legacy fields modern XNU leaves at **0** — they report a pegged core as idle |

`proctree_other.go` makes an unsupported platform a **compile-time fact** (verified: `GOOS=freebsd` builds and every entry point returns `ErrUnsupportedPlatform`). Blindness became **reportable**: a failed snapshot is a FAIL row naming the cause, not an omission. `daemonArgs` reads real argv on both platforms, retiring the `ps` fallback whose own comment admitted the bug — *"only fully reliable where /proc exists"*, a live defect wearing a disclaimer, worst where untested (**spaces are ordinary in macOS paths**). The daemon's sockets get the `sun_path` guard the vscode socket already had, bounded by the **ABI** (107 Linux / 103 darwin) rather than the portable 103 — tightening Linux would have broken installs that work today. `docs/remote-hooks.md` no longer tells Mac users to run `setsid`, which cannot exist on their machine.

## Part 2 — and therefore it cannot authorise a delete

Four P1 reviews. Four different doors. **One outcome.**

| # | The door | The outcome |
|---|---|---|
| 1 | darwin redacts a foreign process's env **silently** | `--fix` deletes an in-use home |
| 2 | the permission gate written to fix (1) modelled uid but **not `CS_RESTRICT`** (SIP makes it ordinary) | `--fix` deletes an in-use home |
| 3 | *(gate deleted — classify the answer, don't predict the policy)* | right, and not enough |
| 4 | the surviving uid filter assumed a **user-owned temp root**; Linux `/tmp` is `01777` and shared | `--fix` deletes an in-use home |

I kept fixing the **read** while the **deletion** stayed reachable. That is one unsound question asked four times: **"can I prove nobody is using this?" cannot be answered by inspecting processes.** Process inspection is inference over a surface that is adversarial by construction — kernels redact, policies grow clauses we did not model, `/proc` can be mounted `subset=pid`, `/tmp` is shared with users we cannot see, PIDs recycle. Each turns *"I saw no user"* into *"there is no user"*, and that negative authorised an `rm -rf`. There would have been a fifth door.

So **`staleTempHomeRemoveFix` is deleted** and `stale-temp-home` is **report-only**. Doctor still names the directory and still says what it could not verify; the operator decides. **Reporting is honest, authorising is dangerous, and they are not the same code path.** The delete returns in **#1989** on a predicate the kernel guarantees — try to take `<home>/daemon.lock` — rather than one we assemble. We already have that lock, and its own comment made this exact argument for #960: *"stronger than the PID file, which readers can only heuristically validate"*. doctor was doing the heuristic validation #960 rejected.

Four tests of that closure go with it. They were **good tests of a bad idea** — each hardened an *input* to the unsound question (fail closed without a snapshot, recheck at fix time, re-read `daemon.pid`). You cannot make an unsound question safe by validating its inputs harder.

The **unreadable count stays**, reporting only. *"3 homes I could not verify — inspect them yourself"* is exactly the message a user should get; deleting it would make doctor **silent** about what it could not check, which is the disease being cured.

## The same disease, inverted

`snapshot()` failed entirely when `/proc/uptime` was unreadable. Under a procfs mounted `subset=pid`, `/proc/<pid>/stat` still reads — so we manufactured **NO DATA where data exists**, in a package built to stop manufacturing **health where no data exists**. Boot time is now non-fatal: `StartedAt` stays zero, `CPUFraction` reports `ErrCPUUnknown` (never `0%`, which is indistinguishable from idle), and `checkRunawayChildren` **says** it could not measure instead of silently skipping. We lose a nice-to-have, loudly, and keep reaping and orphan detection.

## The through-line

Every fix here is the same move: **an answer we did not get must not be reported as an answer we did.**

- `Snapshot()` error → a FAIL row, not an empty table read as health.
- `getsid` failure → `sidUnknown`, not session 0 — which `reap.go` would have fed to `KillEscalating`.
- CPU unreadable → `ErrCPUUnknown`, not `0%`.
- env unreadable → `EnvUnknown`. The two-valued `EnvValue` is **deleted**, because `(string, bool)` *cannot* say "I was not allowed to look"; `EnvUnknown` is the **zero value**, so forgetting means caution.
- `/proc/uptime` unreadable → age unknown, table intact.
- **nobody-is-using-this → unprovable, so nobody may delete on it.**

## Gates

`Test (macOS)` · `Test` (Linux `-race`) · `make test-container` (30 pkgs, 0 FAIL) · Lint · Build · CodeQL · `go build` linux+darwin/arm64+darwin/amd64+`GOOS=freebsd` · gofmt · golangci-lint · deadcode · gen-docs · lint-file-length.

**Verified running on darwin, not merely green** — every P1 test PASSES on the macOS runner (`TestLookupEnvOfForeignProcessIsUnknown` exercises a *real* kernel refusal there; `TestCleanupSessionsReapsEscapedProcesses` and `TestIsAgentFactoryDaemon_RequiresBinaryName` are the previously-skipped tests the issues named). Where a case had to be simulated (`cs_restricted` needs a signing identity CI does not have), `env -i` supplies the **identical observable** and the tests say so.

The acceptance test is a deletion: `testguard.RequireProcFS`/`HasProcFS` and all **19** skips are gone.

Fixes #1939, #1940, #1942, #1946. Refs #1989.

— Captain Claude