### PR TITLE
fix(upgrade): make the post-upgrade daemon restart actually land (#1947, #1950)

### DIFF
--- a/commands/autoupdate_launch_test.go
+++ b/commands/autoupdate_launch_test.go
@@ -77,7 +77,7 @@ func seedNewerRelease(t *testing.T, current, latest string) string {
 	downloadBinaryFn = func(string, time.Duration) ([]byte, error) { return []byte("new-binary"), nil }
 	osExecutableFn = func() (string, error) { return tempBin, nil }
 	requestDaemonShutdownFn = func() (daemon.ShutdownResult, error) { return daemon.ShutdownNoDaemon, nil }
-	respawnDaemonFn = func(string) error { return nil }
+	respawnDaemonFn = func(string) (respawnResult, error) { return respawnResult{}, nil }
 	return tempBin
 }
 

--- a/commands/autoupdate_test.go
+++ b/commands/autoupdate_test.go
@@ -355,10 +355,10 @@ func TestAutoUpdateCallsShutdownAfterBinarySwap(t *testing.T) {
 	prevRespawn := respawnDaemonFn
 	respawnCalls := 0
 	var respawnPath string
-	respawnDaemonFn = func(path string) error {
+	respawnDaemonFn = func(path string) (respawnResult, error) {
 		respawnCalls++
 		respawnPath = path
-		return nil
+		return respawnResult{}, nil
 	}
 	t.Cleanup(func() { respawnDaemonFn = prevRespawn })
 
@@ -432,9 +432,9 @@ func TestAutoUpdateSucceedsWhenShutdownErrors(t *testing.T) {
 	})
 	prevRespawn := respawnDaemonFn
 	respawnCalls := 0
-	respawnDaemonFn = func(string) error {
+	respawnDaemonFn = func(string) (respawnResult, error) {
 		respawnCalls++
-		return nil
+		return respawnResult{}, nil
 	}
 	t.Cleanup(func() { respawnDaemonFn = prevRespawn })
 
@@ -987,7 +987,7 @@ func TestAutoUpdateDownloadsByTag(t *testing.T) {
 	requestDaemonShutdownFn = func() (daemon.ShutdownResult, error) {
 		return daemon.ShutdownNoDaemon, nil
 	}
-	respawnDaemonFn = func(string) error { return nil }
+	respawnDaemonFn = func(string) (respawnResult, error) { return respawnResult{}, nil }
 
 	if _, err := runAutoUpdate(); err != nil {
 		t.Fatalf("autoUpdate: %v", err)

--- a/commands/daemoncmd.go
+++ b/commands/daemoncmd.go
@@ -313,6 +313,29 @@ type respawnResult struct {
 	StaleUnitExec string
 }
 
+// restartPhase names the step of the shutdown-then-respawn sequence that
+// failed. The two failures are OPPOSITE states and must never share a message:
+//
+//   - restartPhaseShutdown: the old daemon would not stop, so it is STILL
+//     RUNNING THE OLD BINARY. That is #1947's own symptom — the upgrade did not
+//     reach the daemon.
+//   - restartPhaseRespawn: the old daemon stopped but no new one came up, so
+//     NOTHING IS RUNNING. Task schedules, watch scripts and autoyes are all
+//     stopped until something starts a daemon.
+//
+// "Still on the old code" and "no daemon at all" need opposite remedies, and
+// telling them apart by reading the wrapped error's text is exactly the
+// guessing this PR exists to delete. The phase is carried, not inferred.
+type restartPhase int
+
+const (
+	// restartPhaseNone: nothing failed. The zero value, valid only alongside a
+	// nil error.
+	restartPhaseNone restartPhase = iota
+	restartPhaseShutdown
+	restartPhaseRespawn
+)
+
 // restartOutcome is the whole story of a shutdown-then-respawn: how the old
 // daemon was stopped, and how (or whether) a new one came back.
 type restartOutcome struct {
@@ -320,6 +343,9 @@ type restartOutcome struct {
 	// Respawned is false when no daemon was running, so nothing was respawned.
 	Respawned bool
 	Respawn   respawnResult
+	// FailedPhase is restartPhaseNone unless the accompanying error is
+	// non-nil, and names which half of the sequence broke.
+	FailedPhase restartPhase
 }
 
 // restartDaemonFromPath keeps the (result, error) shape the auto-update path
@@ -334,6 +360,7 @@ func restartDaemonFromPathDetailed(execPath string) (restartOutcome, error) {
 	result, shutdownErr := requestDaemonShutdownFn()
 	outcome := restartOutcome{Shutdown: result}
 	if shutdownErr != nil {
+		outcome.FailedPhase = restartPhaseShutdown
 		return outcome, fmt.Errorf("failed to stop running daemon: %w", shutdownErr)
 	}
 	if result == daemon.ShutdownNoDaemon {
@@ -342,6 +369,7 @@ func restartDaemonFromPathDetailed(execPath string) (restartOutcome, error) {
 	respawn, err := respawnDaemonFn(execPath)
 	outcome.Respawn = respawn
 	if err != nil {
+		outcome.FailedPhase = restartPhaseRespawn
 		return outcome, fmt.Errorf("failed to restart daemon: %w", err)
 	}
 	outcome.Respawned = true

--- a/commands/daemoncmd.go
+++ b/commands/daemoncmd.go
@@ -298,6 +298,14 @@ type respawnResult struct {
 	// login. Nil when no unit was restarted because none serves this home,
 	// which is not a degradation.
 	UnitErr error
+	// UnitGateErr is set when we could not TELL whether the installed unit
+	// serves this home, so we conservatively did not restart it and spawned an
+	// ad-hoc daemon instead. That is the safe call, but it is a real
+	// degradation the user has to hear about: if the unit was in fact theirs,
+	// their supervised daemon just became an unsupervised one. Distinct from
+	// the quiet, correct "no unit serves this home" case, which is not an
+	// error and must stay silent.
+	UnitGateErr error
 	// StaleUnitExec is the binary the restarted unit launches, set only when
 	// that is NOT the binary the upgrade just wrote. The unit bakes its
 	// program path at install time, so a second install on the box brings the
@@ -350,27 +358,33 @@ func restartDaemonFromPathDetailed(execPath string) (restartOutcome, error) {
 // and returns — leaving the sandbox it was actually upgrading with no daemon
 // at all. Anything short of proof that the unit serves this home means we do
 // not touch it and spawn an ad-hoc daemon for the home in front of us.
-func unitRestartTarget() (useUnit bool, unitExec string) {
+// gateErr is returned (not just logged) when the decision could not be made:
+// skipping the unit is the safe call, but it silently costs a supervised
+// daemon its supervision, and this whole path exists because degradations that
+// only reach the log are degradations nobody fixes.
+func unitRestartTarget() (useUnit bool, unitExec string, gateErr error) {
 	configDir, err := configDirFn()
 	if err != nil {
-		log.WarningLog.Printf("post-upgrade respawn: cannot resolve the config dir to check whether the autostart unit serves this home; not restarting it: %v", err)
-		return false, ""
+		return false, "", fmt.Errorf("cannot resolve the config dir to check whether the autostart unit serves this home: %w", err)
 	}
 	serves, installed, err := autostartUnitServesHomeFn(configDir)
 	if err != nil {
-		log.WarningLog.Printf("post-upgrade respawn: cannot tell whether the autostart unit serves %s; not restarting it: %v", configDir, err)
-		return false, ""
+		return false, "", fmt.Errorf("cannot tell whether the autostart unit serves %s: %w", configDir, err)
 	}
 	if !installed || !serves {
-		return false, ""
+		// The ordinary answer for an ad-hoc install, and for any upgrade run
+		// against a home the installed unit does not serve. Not an error.
+		return false, "", nil
 	}
-	// Best-effort: an unreadable program path costs the staleness warning, not
-	// the restart.
+	// Best-effort, and log-only on purpose: the unit restart below is the
+	// authority on whether the daemon came back, and it is about to run either
+	// way. An unreadable program path costs only the staleness check — no
+	// behavior changes — so it does not warrant a line the user must act on.
 	unitExec, _, err = autostartUnitExecPathFn()
 	if err != nil {
-		log.WarningLog.Printf("post-upgrade respawn: cannot read the autostart unit's program path: %v", err)
+		log.WarningLog.Printf("post-upgrade respawn: cannot read the autostart unit's program path, so cannot check it launches the upgraded binary: %v", err)
 	}
-	return true, unitExec
+	return true, unitExec, nil
 }
 
 // staleUnitExec reports the unit's program path when it is NOT the binary the
@@ -433,7 +447,11 @@ func respawnDaemonAfterUpgrade(execPath string) (respawnResult, error) {
 		log.WarningLog.Printf("post-upgrade respawn: %v; respawning anyway, but the new daemon may see the old one as alive and exit — run af again if schedules stay dark", err)
 	}
 	var unitErr error
-	if useUnit, unitExec := unitRestartTarget(); useUnit {
+	useUnit, unitExec, gateErr := unitRestartTarget()
+	if gateErr != nil {
+		log.WarningLog.Printf("post-upgrade respawn: not restarting the autostart unit: %v", gateErr)
+	}
+	if useUnit {
 		err := restartAutostartUnitFn()
 		if err == nil {
 			log.InfoLog.Printf("restarted the daemon autostart unit from the new binary")
@@ -445,12 +463,12 @@ func respawnDaemonAfterUpgrade(execPath string) (respawnResult, error) {
 	if err := ensureDaemonFromPathFn(execPath); err != nil {
 		log.ErrorLog.Printf("failed to respawn daemon after upgrade: %v", err)
 		if unitErr != nil {
-			return respawnResult{UnitErr: unitErr},
+			return respawnResult{UnitErr: unitErr, UnitGateErr: gateErr},
 				fmt.Errorf("unit restart failed: %w; ad-hoc fallback failed: %v", unitErr, err)
 		}
-		return respawnResult{}, err
+		return respawnResult{UnitGateErr: gateErr}, err
 	}
-	return respawnResult{UnitErr: unitErr}, nil
+	return respawnResult{UnitErr: unitErr, UnitGateErr: gateErr}, nil
 }
 
 // ensureDaemonForTasks starts the daemon when any enabled task exists, so

--- a/commands/daemoncmd.go
+++ b/commands/daemoncmd.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/sachiniyer/agent-factory/apiproto"
+	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/task"
@@ -274,37 +275,143 @@ var respawnDaemonFn = respawnDaemonAfterUpgrade
 
 // Indirection points so respawnDaemonAfterUpgrade tests can observe which
 // branch ran without touching the real systemctl/launchctl or spawning a
-// daemon process.
+// daemon process. autostartUnitServesHomeFn (reset.go) is shared.
 var (
 	autostartInstalledFn        = daemon.AutostartInstalled
 	restartAutostartUnitFn      = daemon.RestartAutostartUnit
 	ensureDaemonFromPathFn      = daemon.EnsureDaemonFromPath
 	waitForShutdownCompletionFn = daemon.WaitForShutdownCompletion
+	autostartUnitExecPathFn     = daemon.AutostartUnitExecPath
+	configDirFn                 = config.GetConfigDir
 )
 
+// respawnResult reports the ways a respawn can succeed and still leave the
+// user worse off than they think, so callers can say so instead of assuming
+// the restart landed the way they asked. Both were log-only warnings printed
+// underneath an unqualified "Restarted the running daemon from the new binary"
+// (#1947). The zero value is the good outcome: the daemon came back, on the
+// binary we just wrote, however it was started.
+type respawnResult struct {
+	// UnitErr is set when a unit restart was attempted and failed, so the
+	// daemon was demoted to the ad-hoc fallback: running and on the new
+	// binary, but unsupervised — it dies with the session and skips the next
+	// login. Nil when no unit was restarted because none serves this home,
+	// which is not a degradation.
+	UnitErr error
+	// StaleUnitExec is the binary the restarted unit launches, set only when
+	// that is NOT the binary the upgrade just wrote. The unit bakes its
+	// program path at install time, so a second install on the box brings the
+	// OLD image straight back up — the restart lands, and changes nothing.
+	StaleUnitExec string
+}
+
+// restartOutcome is the whole story of a shutdown-then-respawn: how the old
+// daemon was stopped, and how (or whether) a new one came back.
+type restartOutcome struct {
+	Shutdown daemon.ShutdownResult
+	// Respawned is false when no daemon was running, so nothing was respawned.
+	Respawned bool
+	Respawn   respawnResult
+}
+
+// restartDaemonFromPath keeps the (result, error) shape the auto-update path
+// and `af daemon restart` are written against. Callers that must report on the
+// restart's fidelity — `af upgrade` — use restartDaemonFromPathDetailed.
 func restartDaemonFromPath(execPath string) (daemon.ShutdownResult, error) {
+	outcome, err := restartDaemonFromPathDetailed(execPath)
+	return outcome.Shutdown, err
+}
+
+func restartDaemonFromPathDetailed(execPath string) (restartOutcome, error) {
 	result, shutdownErr := requestDaemonShutdownFn()
+	outcome := restartOutcome{Shutdown: result}
 	if shutdownErr != nil {
-		return result, fmt.Errorf("failed to stop running daemon: %w", shutdownErr)
+		return outcome, fmt.Errorf("failed to stop running daemon: %w", shutdownErr)
 	}
 	if result == daemon.ShutdownNoDaemon {
-		return result, nil
+		return outcome, nil
 	}
-	if err := respawnDaemonFn(execPath); err != nil {
-		return result, fmt.Errorf("failed to restart daemon: %w", err)
+	respawn, err := respawnDaemonFn(execPath)
+	outcome.Respawn = respawn
+	if err != nil {
+		return outcome, fmt.Errorf("failed to restart daemon: %w", err)
 	}
-	return result, nil
+	outcome.Respawned = true
+	return outcome, nil
+}
+
+// unitRestartTarget decides whether the post-upgrade respawn may restart the
+// installed autostart unit, and reports the binary that unit would launch.
+//
+// "A unit file exists" and "that unit is the daemon I just stopped" are
+// different questions (#1916/#1919, and #1950 for this path). The unit bakes
+// its AGENT_FACTORY_HOME at install time, so `AGENT_FACTORY_HOME=/tmp/sandbox
+// af upgrade` gating on existence alone restarts the developer's REAL daemon
+// and returns — leaving the sandbox it was actually upgrading with no daemon
+// at all. Anything short of proof that the unit serves this home means we do
+// not touch it and spawn an ad-hoc daemon for the home in front of us.
+func unitRestartTarget() (useUnit bool, unitExec string) {
+	configDir, err := configDirFn()
+	if err != nil {
+		log.WarningLog.Printf("post-upgrade respawn: cannot resolve the config dir to check whether the autostart unit serves this home; not restarting it: %v", err)
+		return false, ""
+	}
+	serves, installed, err := autostartUnitServesHomeFn(configDir)
+	if err != nil {
+		log.WarningLog.Printf("post-upgrade respawn: cannot tell whether the autostart unit serves %s; not restarting it: %v", configDir, err)
+		return false, ""
+	}
+	if !installed || !serves {
+		return false, ""
+	}
+	// Best-effort: an unreadable program path costs the staleness warning, not
+	// the restart.
+	unitExec, _, err = autostartUnitExecPathFn()
+	if err != nil {
+		log.WarningLog.Printf("post-upgrade respawn: cannot read the autostart unit's program path: %v", err)
+	}
+	return true, unitExec
+}
+
+// staleUnitExec reports the unit's program path when it is NOT the binary the
+// upgrade just wrote, and "" when they agree (or when it cannot be told).
+// Both sides are resolved through symlinks first: the unit is routinely
+// installed with a symlinked path (~/.local/bin/af) while the upgrade resolves
+// to the real file, and those are the same binary.
+func staleUnitExec(unitExec, upgradedPath string) string {
+	if unitExec == "" {
+		return ""
+	}
+	if canonicalExec(unitExec) == canonicalExec(upgradedPath) {
+		return ""
+	}
+	return unitExec
+}
+
+// canonicalExec resolves p through symlinks, falling back to the input when it
+// cannot be resolved (the unit may name a binary that no longer exists — which
+// is itself worth reporting as a mismatch rather than swallowing).
+func canonicalExec(p string) string {
+	if resolved, err := filepath.EvalSymlinks(p); err == nil {
+		return resolved
+	}
+	return p
 }
 
 // respawnDaemonAfterUpgrade restores the daemon that the upgrade/auto-update
 // path just stopped. The Shutdown RPC is a clean exit, and the autostart unit
 // uses Restart=on-failure (deliberately — Restart=always would make the
 // daemon unstoppable via RPC), so the service manager will not bring the
-// daemon back on its own. When the unit is installed, restart it through
-// systemctl/launchctl so the daemon stays supervised instead of being demoted
-// to an ad-hoc child that dies with the session and skips the next reboot
-// (#796). Without a unit, or when the service manager call fails, spawn an
-// ad-hoc daemon.
+// daemon back on its own. When the unit is installed AND SERVES THIS HOME,
+// restart it through systemctl/launchctl so the daemon stays supervised
+// instead of being demoted to an ad-hoc child that dies with the session and
+// skips the next reboot (#796). Without such a unit, or when the service
+// manager call fails, spawn an ad-hoc daemon.
+//
+// The returned respawnResult says which of those actually happened. Callers
+// must report a degraded respawn rather than printing plain success over it:
+// silently demoting to an ad-hoc daemon under a "Restarted the running daemon"
+// line is half of #1947.
 //
 // Both branches respawn unconditionally: callers only reach this function
 // after stopping a running daemon, and that daemon may have been serving
@@ -312,7 +419,7 @@ func restartDaemonFromPath(execPath string) (daemon.ShutdownResult, error) {
 // left autoyes-only users without a daemon until the next af run (#813). The
 // task gate belongs only on the cold-start path (ensureDaemonForTasks), where
 // nothing was running and "no enabled tasks" means there is nothing to start.
-func respawnDaemonAfterUpgrade(execPath string) error {
+func respawnDaemonAfterUpgrade(execPath string) (respawnResult, error) {
 	// The Shutdown RPC acks before the daemon tears down, so the old daemon's
 	// control socket can still answer pings here. Respawning into that window
 	// makes EnsureDaemon — or the unit-restarted daemon's own startup ping
@@ -326,11 +433,11 @@ func respawnDaemonAfterUpgrade(execPath string) error {
 		log.WarningLog.Printf("post-upgrade respawn: %v; respawning anyway, but the new daemon may see the old one as alive and exit — run af again if schedules stay dark", err)
 	}
 	var unitErr error
-	if autostartInstalledFn() {
+	if useUnit, unitExec := unitRestartTarget(); useUnit {
 		err := restartAutostartUnitFn()
 		if err == nil {
 			log.InfoLog.Printf("restarted the daemon autostart unit from the new binary")
-			return nil
+			return respawnResult{StaleUnitExec: staleUnitExec(unitExec, execPath)}, nil
 		}
 		unitErr = err
 		log.WarningLog.Printf("failed to restart the daemon autostart unit; falling back to an ad-hoc daemon: %v", err)
@@ -338,11 +445,12 @@ func respawnDaemonAfterUpgrade(execPath string) error {
 	if err := ensureDaemonFromPathFn(execPath); err != nil {
 		log.ErrorLog.Printf("failed to respawn daemon after upgrade: %v", err)
 		if unitErr != nil {
-			return fmt.Errorf("unit restart failed: %w; ad-hoc fallback failed: %v", unitErr, err)
+			return respawnResult{UnitErr: unitErr},
+				fmt.Errorf("unit restart failed: %w; ad-hoc fallback failed: %v", unitErr, err)
 		}
-		return err
+		return respawnResult{}, err
 	}
-	return nil
+	return respawnResult{UnitErr: unitErr}, nil
 }
 
 // ensureDaemonForTasks starts the daemon when any enabled task exists, so

--- a/commands/daemoncmd_test.go
+++ b/commands/daemoncmd_test.go
@@ -14,27 +14,45 @@ const testUpgradeDaemonPath = "/tmp/af-upgraded"
 // touches the real systemctl/launchctl or spawns a daemon process — a real
 // supervised daemon may be running on the machine executing these tests.
 
-// stubRespawnCollaborators replaces the autostart-detection, unit-restart,
-// ad-hoc-spawn, and shutdown-wait hooks used by respawnDaemonAfterUpgrade,
-// restoring them on cleanup. The shutdown wait is stubbed to an immediate nil
-// so no test here pings the host's control socket — a real supervised daemon
-// answering it would stall the wait for its full grace. It returns counters
-// for the restart and ad-hoc paths.
+// stubRespawnCollaborators replaces the autostart-detection, home-gate,
+// unit-restart, ad-hoc-spawn, and shutdown-wait hooks used by
+// respawnDaemonAfterUpgrade, restoring them on cleanup. The shutdown wait is
+// stubbed to an immediate nil so no test here pings the host's control socket —
+// a real supervised daemon answering it would stall the wait for its full
+// grace. The home gate and unit-path reader are stubbed for the same reason:
+// unstubbed they read the REAL host's autostart unit and config dir. It
+// returns counters for the restart and ad-hoc paths.
+//
+// The stubbed unit serves THIS home and launches the very binary the upgrade
+// wrote, so tests using this helper keep asserting what they always asserted:
+// the unit-vs-ad-hoc branch. The cross-home gate (#1950) and the stale-binary
+// check (#1947) are exercised by their own tests, which override these.
 func stubRespawnCollaborators(t *testing.T, installed bool, restartErr error) (restartCalls, ensureCalls *int) {
 	t.Helper()
 	prevInstalled := autostartInstalledFn
 	prevRestart := restartAutostartUnitFn
 	prevEnsure := ensureDaemonFromPathFn
 	prevWait := waitForShutdownCompletionFn
+	prevServes := autostartUnitServesHomeFn
+	prevUnitExec := autostartUnitExecPathFn
+	prevConfigDir := configDirFn
 	t.Cleanup(func() {
 		autostartInstalledFn = prevInstalled
 		restartAutostartUnitFn = prevRestart
 		ensureDaemonFromPathFn = prevEnsure
 		waitForShutdownCompletionFn = prevWait
+		autostartUnitServesHomeFn = prevServes
+		autostartUnitExecPathFn = prevUnitExec
+		configDirFn = prevConfigDir
 	})
 	restartCalls = new(int)
 	ensureCalls = new(int)
 	autostartInstalledFn = func() bool { return installed }
+	autostartUnitServesHomeFn = func(string) (serves bool, isInstalled bool, err error) {
+		return installed, installed, nil
+	}
+	autostartUnitExecPathFn = func() (string, bool, error) { return testUpgradeDaemonPath, installed, nil }
+	configDirFn = func() (string, error) { return "/tmp/af-test-home", nil }
 	restartAutostartUnitFn = func() error {
 		*restartCalls++
 		return restartErr
@@ -54,7 +72,7 @@ func stubRespawnCollaborators(t *testing.T, installed bool, restartErr error) (r
 func TestRespawnAfterUpgradeRestartsInstalledUnit(t *testing.T) {
 	restartCalls, ensureCalls := stubRespawnCollaborators(t, true, nil)
 
-	if err := respawnDaemonAfterUpgrade(testUpgradeDaemonPath); err != nil {
+	if _, err := respawnDaemonAfterUpgrade(testUpgradeDaemonPath); err != nil {
 		t.Fatalf("respawnDaemonAfterUpgrade: %v", err)
 	}
 
@@ -71,7 +89,7 @@ func TestRespawnAfterUpgradeRestartsInstalledUnit(t *testing.T) {
 func TestRespawnAfterUpgradeWithoutUnitSpawnsAdHoc(t *testing.T) {
 	restartCalls, ensureCalls := stubRespawnCollaborators(t, false, nil)
 
-	if err := respawnDaemonAfterUpgrade(testUpgradeDaemonPath); err != nil {
+	if _, err := respawnDaemonAfterUpgrade(testUpgradeDaemonPath); err != nil {
 		t.Fatalf("respawnDaemonAfterUpgrade: %v", err)
 	}
 
@@ -89,7 +107,7 @@ func TestRespawnAfterUpgradeWithoutUnitSpawnsAdHoc(t *testing.T) {
 func TestRespawnAfterUpgradeFallsBackWhenRestartFails(t *testing.T) {
 	restartCalls, ensureCalls := stubRespawnCollaborators(t, true, errors.New("systemctl exited 1"))
 
-	if err := respawnDaemonAfterUpgrade(testUpgradeDaemonPath); err != nil {
+	if _, err := respawnDaemonAfterUpgrade(testUpgradeDaemonPath); err != nil {
 		t.Fatalf("respawnDaemonAfterUpgrade: %v", err)
 	}
 
@@ -112,7 +130,7 @@ func TestRespawnAfterUpgradeSpawnsWithZeroEnabledTasks(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 	_, ensureCalls := stubRespawnCollaborators(t, false, nil)
 
-	if err := respawnDaemonAfterUpgrade(testUpgradeDaemonPath); err != nil {
+	if _, err := respawnDaemonAfterUpgrade(testUpgradeDaemonPath); err != nil {
 		t.Fatalf("respawnDaemonAfterUpgrade: %v", err)
 	}
 
@@ -129,7 +147,7 @@ func TestRespawnAfterUpgradeSpawnsAdHocFromProvidedPath(t *testing.T) {
 		return nil
 	}
 
-	if err := respawnDaemonAfterUpgrade("/opt/af/new"); err != nil {
+	if _, err := respawnDaemonAfterUpgrade("/opt/af/new"); err != nil {
 		t.Fatalf("respawnDaemonAfterUpgrade: %v", err)
 	}
 
@@ -173,7 +191,7 @@ func TestRespawnAfterUpgradeWaitsForShutdownFirst(t *testing.T) {
 				return prevEnsure(path)
 			}
 
-			if err := respawnDaemonAfterUpgrade(testUpgradeDaemonPath); err != nil {
+			if _, err := respawnDaemonAfterUpgrade(testUpgradeDaemonPath); err != nil {
 				t.Fatalf("respawnDaemonAfterUpgrade: %v", err)
 			}
 
@@ -194,9 +212,9 @@ func TestRestartDaemonFromPathNoDaemonIsNoOp(t *testing.T) {
 	requestDaemonShutdownFn = func() (daemon.ShutdownResult, error) {
 		return daemon.ShutdownNoDaemon, nil
 	}
-	respawnDaemonFn = func(string) error {
+	respawnDaemonFn = func(string) (respawnResult, error) {
 		t.Fatalf("respawn must not run when no daemon is present")
-		return nil
+		return respawnResult{}, nil
 	}
 
 	result, err := restartDaemonFromPath(testUpgradeDaemonPath)
@@ -219,9 +237,9 @@ func TestRestartDaemonFromPathRespawnsStoppedDaemon(t *testing.T) {
 		return daemon.ShutdownViaRPC, nil
 	}
 	var gotPath string
-	respawnDaemonFn = func(path string) error {
+	respawnDaemonFn = func(path string) (respawnResult, error) {
 		gotPath = path
-		return nil
+		return respawnResult{}, nil
 	}
 
 	result, err := restartDaemonFromPath("/opt/af/current")

--- a/commands/upgrade.go
+++ b/commands/upgrade.go
@@ -97,9 +97,23 @@ func downloadBinary(url string, timeout time.Duration) ([]byte, error) {
 // --allow-downgrade skips that guard.
 var upgradeAllowDowngrade bool
 
+// upgradeNoRestart opts out of the post-upgrade daemon restart. The restart is
+// not new — `af upgrade` has restarted the running daemon since #498/#1386 —
+// so this is the opt-out for behavior that already exists, not a new default
+// (#1947). Default stays restart: a fix that never reaches the daemon is not
+// shipped.
+var upgradeNoRestart bool
+
+// daemonHealthFn is indirected so tests can describe the daemon's liveness
+// without a real control socket or PID file. Read-only: daemon.Health never
+// spawns or signals anything.
+var daemonHealthFn = daemon.Health
+
 func init() {
 	upgradeCmd.Flags().BoolVar(&upgradeAllowDowngrade, "allow-downgrade", false,
 		"Install the channel's latest release even if it is older than the current binary (e.g. switching from preview back to stable)")
+	upgradeCmd.Flags().BoolVar(&upgradeNoRestart, "no-restart", false,
+		"Leave the running daemon alone (af upgrade restarts it by default so the new binary takes effect)")
 }
 
 var upgradeCmd = &cobra.Command{
@@ -116,7 +130,13 @@ keeps working either way.
 A manual upgrade never downgrades: if the channel's latest release is older
 than the running binary — which happens when you switch from the preview
 channel back to stable — the upgrade is a no-op with an explanation. Pass
---allow-downgrade to install the older release anyway.`,
+--allow-downgrade to install the older release anyway.
+
+af upgrade restarts the running daemon after the swap, and always has: the
+daemon keeps executing the old code until something restarts it, so a fix that
+does not reach it is not really installed. Live sessions survive — they run in
+tmux and the new daemon re-adopts them. Pass --no-restart to leave the daemon
+on the old binary until you restart it yourself with 'af daemon restart'.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// RequestShutdown's SIGTERM fallback (#504) writes through
 		// log.InfoLog / log.WarningLog. Initialize logging up-front so those
@@ -155,7 +175,7 @@ channel back to stable — the upgrade is a no-op with an explanation. Pass
 		}
 
 		fmt.Printf("Downloading %s for %s/%s...\n", latestTag, goos, goarch)
-		return runUpgrade(downloadURL)
+		return runUpgrade(cmd.OutOrStdout(), cmd.ErrOrStderr(), downloadURL, upgradeNoRestart)
 	},
 }
 
@@ -203,10 +223,12 @@ func shouldUpgrade(latestTag, current, channel string, allowDowngrade bool) (pro
 }
 
 // runUpgrade downloads the release tarball at downloadURL, atomically swaps
-// the current executable with the embedded binary, and asks any running
-// daemon to exit so users actually pick up the new image. Extracted from
-// upgradeCmd.RunE so tests can drive it without going through Cobra.
-func runUpgrade(downloadURL string) error {
+// the current executable with the embedded binary, and (unless noRestart)
+// restarts any running daemon so users actually pick up the new image.
+// Extracted from upgradeCmd.RunE so tests can drive it without going through
+// Cobra. out carries the result; errOut carries anything that means the user
+// is not running the version they just installed.
+func runUpgrade(out, errOut io.Writer, downloadURL string, noRestart bool) error {
 	binary, err := downloadBinaryFn(downloadURL, downloadTimeout)
 	if err != nil {
 		return err
@@ -227,24 +249,71 @@ func runUpgrade(downloadURL string) error {
 		return fmt.Errorf("failed to write new binary: %w", err)
 	}
 
+	if noRestart {
+		fmt.Fprintln(out, "Upgraded successfully! Left the running daemon alone (--no-restart); it keeps executing the old binary until you run `af daemon restart`.")
+		return nil
+	}
+
 	// The running daemon process still references the old binary's inode on
 	// Linux, so users would keep running the stale image until they killed it
 	// manually. Restart any running daemon now from the freshly written binary
 	// (#498/#1386). Pre-#501 daemons don't speak the Shutdown RPC, so
 	// RequestShutdown falls back to PID-file-based SIGTERM (#504).
-	result, restartErr := restartDaemonFromPath(resolvedPath)
-	switch {
-	case restartErr != nil:
-		fmt.Printf("Upgraded successfully! Failed to restart the running daemon: %v\n", restartErr)
-		fmt.Println("Stop the daemon manually (e.g. `af reset`) or kill the `--daemon` process to pick up the new binary.")
-	case result == daemon.ShutdownViaRPC:
-		fmt.Println("Upgraded successfully! Restarted the running daemon from the new binary.")
-	case result == daemon.ShutdownViaSIGTERM:
-		fmt.Println("Upgraded successfully! Stopped the running daemon (pre-fix; used SIGTERM) and restarted it from the new binary.")
-	default:
-		fmt.Println("Upgraded successfully!")
-	}
+	outcome, restartErr := restartDaemonFromPathDetailed(resolvedPath)
+	reportUpgradeRestart(out, errOut, outcome, restartErr, resolvedPath)
 	return nil
+}
+
+// reportUpgradeRestart tells the user what the restart actually did.
+//
+// The rule (#1947): never claim the daemon is on the new binary unless it is.
+// A restart that runs, fails to land, and reports success is worse than no
+// restart at all — the user stops looking. Every path that leaves a daemon on
+// the old image says so on errOut, with the command that fixes it; the quiet
+// success line is reserved for "the daemon is now running what you installed"
+// and for "there was no daemon to restart", which is not a problem.
+func reportUpgradeRestart(out, errOut io.Writer, outcome restartOutcome, restartErr error, upgradedPath string) {
+	if restartErr != nil {
+		// ShutdownFailed/ShutdownError land here: a daemon was proven to be
+		// listening but we could not stop it (#553/#978).
+		fmt.Fprintln(out, "Upgraded successfully!")
+		fmt.Fprintf(errOut, "The daemon was not restarted: %v\n", restartErr)
+		fmt.Fprintln(errOut, "It is still running the old binary. Restart it with `af daemon restart`, or stop the `--daemon` process yourself.")
+		return
+	}
+
+	if !outcome.Respawned {
+		// RequestShutdown reports ShutdownNoDaemon for a missing or
+		// unreachable socket, so "no daemon was running" and "a daemon is
+		// running that we cannot see" arrive identically. Ask the health probe
+		// which one this is before printing an all-clear.
+		if h := daemonHealthFn(); h.PIDVerified {
+			fmt.Fprintln(out, "Upgraded successfully!")
+			fmt.Fprintf(errOut, "The daemon was not restarted: no daemon answered the control socket, but pid %d is a running af daemon.\n", h.PIDFilePID)
+			fmt.Fprintln(errOut, "It is still running the old binary. Restart it with `af daemon restart`.")
+			return
+		}
+		fmt.Fprintln(out, "Upgraded successfully!")
+		return
+	}
+
+	switch outcome.Shutdown {
+	case daemon.ShutdownViaSIGTERM:
+		fmt.Fprintln(out, "Upgraded successfully! Stopped the running daemon (pre-fix; used SIGTERM) and restarted it from the new binary.")
+	default:
+		fmt.Fprintln(out, "Upgraded successfully! Restarted the running daemon from the new binary.")
+	}
+
+	// The restart landed, but on what? Both of these mean the daemon came back
+	// wrong, and neither fails the respawn, so they only ever reached the log.
+	if stale := outcome.Respawn.StaleUnitExec; stale != "" {
+		fmt.Fprintf(errOut, "The daemon autostart unit launches %s, which is not the binary this upgrade wrote (%s).\n", stale, upgradedPath)
+		fmt.Fprintln(errOut, "The restarted daemon is running that other install's older binary. Re-point the unit at this one with `af daemon install`.")
+	}
+	if outcome.Respawn.UnitErr != nil {
+		fmt.Fprintf(errOut, "The daemon autostart unit could not be restarted: %v\n", outcome.Respawn.UnitErr)
+		fmt.Fprintln(errOut, "The daemon was restarted as an ad-hoc process instead: it is on the new binary, but unsupervised and will not return at next login. Re-register it with `af daemon install`.")
+	}
 }
 
 // extractBinaryFromTarGz reads a tar.gz stream and returns the contents of the

--- a/commands/upgrade.go
+++ b/commands/upgrade.go
@@ -264,6 +264,45 @@ func runUpgrade(out, errOut io.Writer, downloadURL string, noRestart bool) error
 	return nil
 }
 
+// stopDaemonHint names a command that actually stops a daemon we could not
+// stop over the control socket.
+//
+// It is deliberately NOT `af daemon restart`. Every state this hint fires in
+// is one where the control socket did not answer, and `af daemon restart` goes
+// straight back through it: daemon.RequestShutdown stats the socket and
+// returns (ShutdownNoDaemon, nil) on fs.ErrNotExist or ECONNREFUSED — the
+// SIGTERM fallback fires only for a method-not-found reply on a socket that
+// DID answer — so restartDaemonFromPath returns early and `af daemon restart`
+// prints "no running daemon to restart" and stops nothing. Recommending the
+// thing that just failed is how a user ends up on the old daemon believing
+// they are patched, which is the whole bug.
+//
+// The pid is a fact we already hold, so the hint is built from that instead.
+// `kill` sends SIGTERM, which the daemon handles (daemon.go's signal.Notify),
+// and it names ONE pid: the repo's own pkill -f -- '--daemon' fallback would
+// also kill daemons serving other AF homes.
+func stopDaemonHint(h daemon.HealthStatus) string {
+	if h.PIDVerified && h.PIDFilePID > 0 {
+		return fmt.Sprintf("Stop it with `kill %d`, then run af — the next run starts a fresh daemon from the new binary.", h.PIDFilePID)
+	}
+	// No verified pid to name: point at the command that finds it rather than
+	// guessing one.
+	return "Find its pid with `af daemon status` and stop it, then run af — the next run starts a fresh daemon from the new binary."
+}
+
+// startDaemonHint names what brings a daemon back when none is running.
+//
+// Also NOT `af daemon restart`: with no daemon up there is no socket, so it
+// reports "no running daemon to restart" and starts nothing — it restarts, it
+// does not start. Running af does start one (the TUI cold start calls
+// daemon.EnsureDaemon, as does ensureDaemonForTasks), and `af daemon install`
+// both starts one and re-registers it for this home (systemctl --user enable
+// --now / a RunAtLoad launchd agent), which is the only option here that ends
+// with the daemon supervised.
+func startDaemonHint() string {
+	return "Running af starts one from the new binary; `af daemon install` starts it and keeps it supervised across logins."
+}
+
 // reportUpgradeRestart tells the user what the restart actually did.
 //
 // The rule (#1947): never claim the daemon is on the new binary unless it is.
@@ -273,12 +312,21 @@ func runUpgrade(out, errOut io.Writer, downloadURL string, noRestart bool) error
 // success line is reserved for "the daemon is now running what you installed"
 // and for "there was no daemon to restart", which is not a problem.
 func reportUpgradeRestart(out, errOut io.Writer, outcome restartOutcome, restartErr error, upgradedPath string) {
-	if restartErr != nil {
-		// ShutdownFailed/ShutdownError land here: a daemon was proven to be
-		// listening but we could not stop it (#553/#978).
+	switch outcome.FailedPhase {
+	case restartPhaseShutdown:
+		// The old daemon would not stop, so it is still serving the old
+		// binary: #1947's exact symptom, reached by a different road.
 		fmt.Fprintln(out, "Upgraded successfully!")
-		fmt.Fprintf(errOut, "The daemon was not restarted: %v\n", restartErr)
-		fmt.Fprintln(errOut, "It is still running the old binary. Restart it with `af daemon restart`, or stop the `--daemon` process yourself.")
+		fmt.Fprintf(errOut, "The running daemon could not be stopped: %v\n", restartErr)
+		fmt.Fprintln(errOut, "It is still running the old binary, so this upgrade has not reached it yet.")
+		fmt.Fprintln(errOut, stopDaemonHint(daemonHealthFn()))
+		return
+	case restartPhaseRespawn:
+		// The opposite state: the old daemon is gone and nothing replaced it.
+		fmt.Fprintln(out, "Upgraded successfully!")
+		fmt.Fprintf(errOut, "The old daemon was stopped, but a new one could not be started: %v\n", restartErr)
+		fmt.Fprintln(errOut, "No daemon is running at all right now, so task schedules, watch scripts, and autoyes are stopped.")
+		fmt.Fprintln(errOut, startDaemonHint())
 		return
 	}
 
@@ -289,8 +337,9 @@ func reportUpgradeRestart(out, errOut io.Writer, outcome restartOutcome, restart
 		// which one this is before printing an all-clear.
 		if h := daemonHealthFn(); h.PIDVerified {
 			fmt.Fprintln(out, "Upgraded successfully!")
-			fmt.Fprintf(errOut, "The daemon was not restarted: no daemon answered the control socket, but pid %d is a running af daemon.\n", h.PIDFilePID)
-			fmt.Fprintln(errOut, "It is still running the old binary. Restart it with `af daemon restart`.")
+			fmt.Fprintf(errOut, "No daemon answered the control socket, but pid %d is a running af daemon, so it was not restarted.\n", h.PIDFilePID)
+			fmt.Fprintln(errOut, "It is still running the old binary.")
+			fmt.Fprintln(errOut, stopDaemonHint(h))
 			return
 		}
 		fmt.Fprintln(out, "Upgraded successfully!")
@@ -325,7 +374,14 @@ func reportUpgradeRestart(out, errOut io.Writer, outcome restartOutcome, restart
 	}
 	if outcome.Respawn.UnitGateErr != nil {
 		fmt.Fprintf(errOut, "The daemon autostart unit was left alone: %v\n", outcome.Respawn.UnitGateErr)
-		fmt.Fprintln(errOut, "Restarting a unit we cannot prove serves this AF home could stop an unrelated daemon, so the daemon was restarted as an unsupervised ad-hoc process instead. If the unit is this home's, restart it yourself with `af daemon restart`.")
+		fmt.Fprintln(errOut, "Restarting a unit we cannot prove serves this AF home could stop an unrelated daemon, so the daemon was restarted as an unsupervised ad-hoc process: it will not return at next login.")
+		// NOT `af daemon restart`: that re-enters this same respawn, hits this
+		// same gate, and falls back to an ad-hoc daemon again — it would look
+		// like it worked while leaving supervision just as broken. Only a
+		// reinstall re-registers the unit for THIS home (InstallAutostart
+		// bakes the current AGENT_FACTORY_HOME and starts it), so it is the
+		// only repair that ends with the daemon supervised.
+		fmt.Fprintln(errOut, "Re-register this home's unit with `af daemon install` to restore supervision.")
 	}
 }
 

--- a/commands/upgrade.go
+++ b/commands/upgrade.go
@@ -297,6 +297,18 @@ func reportUpgradeRestart(out, errOut io.Writer, outcome restartOutcome, restart
 		return
 	}
 
+	// The restart landed — but on WHAT? A unit that relaunches another
+	// install's binary brought the daemon back on the OLD image, so the
+	// success line must not go on to claim the new one. stderr is routinely
+	// redirected away; a stdout line that needs stderr to not be a lie is the
+	// same defect in a new place.
+	if stale := outcome.Respawn.StaleUnitExec; stale != "" {
+		fmt.Fprintln(out, "Upgraded successfully!")
+		fmt.Fprintf(errOut, "The daemon was restarted, but the autostart unit launches %s — not the binary this upgrade wrote (%s).\n", stale, upgradedPath)
+		fmt.Fprintln(errOut, "So the daemon is back on that other install's older binary. Re-point the unit at this one with `af daemon install`.")
+		return
+	}
+
 	switch outcome.Shutdown {
 	case daemon.ShutdownViaSIGTERM:
 		fmt.Fprintln(out, "Upgraded successfully! Stopped the running daemon (pre-fix; used SIGTERM) and restarted it from the new binary.")
@@ -304,15 +316,16 @@ func reportUpgradeRestart(out, errOut io.Writer, outcome restartOutcome, restart
 		fmt.Fprintln(out, "Upgraded successfully! Restarted the running daemon from the new binary.")
 	}
 
-	// The restart landed, but on what? Both of these mean the daemon came back
-	// wrong, and neither fails the respawn, so they only ever reached the log.
-	if stale := outcome.Respawn.StaleUnitExec; stale != "" {
-		fmt.Fprintf(errOut, "The daemon autostart unit launches %s, which is not the binary this upgrade wrote (%s).\n", stale, upgradedPath)
-		fmt.Fprintln(errOut, "The restarted daemon is running that other install's older binary. Re-point the unit at this one with `af daemon install`.")
-	}
+	// The daemon IS on the new binary in both cases below — it is the
+	// supervision that was lost, so the success line above stands and these
+	// qualify it.
 	if outcome.Respawn.UnitErr != nil {
 		fmt.Fprintf(errOut, "The daemon autostart unit could not be restarted: %v\n", outcome.Respawn.UnitErr)
 		fmt.Fprintln(errOut, "The daemon was restarted as an ad-hoc process instead: it is on the new binary, but unsupervised and will not return at next login. Re-register it with `af daemon install`.")
+	}
+	if outcome.Respawn.UnitGateErr != nil {
+		fmt.Fprintf(errOut, "The daemon autostart unit was left alone: %v\n", outcome.Respawn.UnitGateErr)
+		fmt.Fprintln(errOut, "Restarting a unit we cannot prove serves this AF home could stop an unrelated daemon, so the daemon was restarted as an unsupervised ad-hoc process instead. If the unit is this home's, restart it yourself with `af daemon restart`.")
 	}
 }
 

--- a/commands/upgrade_restart_test.go
+++ b/commands/upgrade_restart_test.go
@@ -283,6 +283,63 @@ func TestUpgrade_StaleUnitBinaryIsLoud(t *testing.T) {
 	if !strings.Contains(errOut.String(), "af daemon install") {
 		t.Fatalf("stderr must name the fix.\ngot=%q", errOut.String())
 	}
+	// stdout must not claim the thing stderr is busy denying. stderr is
+	// routinely redirected away, and a success line that is only true when
+	// read together with a warning is the same silent-failure defect wearing a
+	// different hat.
+	if strings.Contains(out.String(), "from the new binary") {
+		t.Fatalf("stdout claims the daemon came back on the new binary when it came back on %s.\ngot=%q", otherInstall, out.String())
+	}
+}
+
+// TestUpgrade_UnprovableUnitGateIsLoud: when we cannot TELL whether the unit
+// serves this home we refuse to restart it — the right call, but it costs a
+// supervised daemon its supervision, so it cannot be a log-only warning. The
+// quiet "no unit serves this home" case is a different thing entirely and is
+// locked below.
+func TestUpgrade_UnprovableUnitGateIsLoud(t *testing.T) {
+	_, url := upgradeHarness(t)
+	stubShutdown(t, daemon.ShutdownViaRPC, nil)
+	stubDaemonHealth(t, daemon.HealthStatus{})
+	stubRespawnCollaborators(t, true, nil)
+	autostartUnitServesHomeFn = func(string) (bool, bool, error) {
+		return false, true, errors.New("permission denied")
+	}
+
+	var out, errOut bytes.Buffer
+	if err := runUpgrade(&out, &errOut, url, false); err != nil {
+		t.Fatalf("runUpgrade: %v", err)
+	}
+
+	if errOut.Len() == 0 {
+		t.Fatalf("an unprovable unit gate demotes a supervised daemon to ad-hoc; that must reach the user.\nstdout=%q", out.String())
+	}
+	if !strings.Contains(errOut.String(), "permission denied") {
+		t.Fatalf("stderr must say why the unit was left alone.\ngot=%q", errOut.String())
+	}
+}
+
+// TestUpgrade_NoUnitForThisHomeIsQuiet locks the ordinary ad-hoc install: no
+// unit serves this home, so there is nothing to restart and nothing to say.
+// Without this, the gate warning above fires on every upgrade on every machine
+// that never ran `af daemon install`.
+func TestUpgrade_NoUnitForThisHomeIsQuiet(t *testing.T) {
+	_, url := upgradeHarness(t)
+	stubShutdown(t, daemon.ShutdownViaRPC, nil)
+	stubDaemonHealth(t, daemon.HealthStatus{})
+	stubRespawnCollaborators(t, false, nil)
+
+	var out, errOut bytes.Buffer
+	if err := runUpgrade(&out, &errOut, url, false); err != nil {
+		t.Fatalf("runUpgrade: %v", err)
+	}
+
+	if errOut.Len() != 0 {
+		t.Fatalf("no unit serving this home is the normal case and must stay quiet.\ngot stderr=%q", errOut.String())
+	}
+	if !strings.Contains(out.String(), "Restarted the running daemon from the new binary") {
+		t.Fatalf("stdout should report the clean ad-hoc restart.\ngot=%q", out.String())
+	}
 }
 
 // TestUpgrade_UnitLaunchingTheUpgradedBinaryIsQuiet locks the staleness check

--- a/commands/upgrade_restart_test.go
+++ b/commands/upgrade_restart_test.go
@@ -317,6 +317,16 @@ func TestUpgrade_UnprovableUnitGateIsLoud(t *testing.T) {
 	if !strings.Contains(errOut.String(), "permission denied") {
 		t.Fatalf("stderr must say why the unit was left alone.\ngot=%q", errOut.String())
 	}
+	// `af daemon restart` re-enters this same respawn, hits this same gate,
+	// and falls back to an ad-hoc daemon AGAIN — it looks like it worked and
+	// leaves supervision just as broken. Only a reinstall re-registers the
+	// unit for this home.
+	if strings.Contains(errOut.String(), "af daemon restart") {
+		t.Fatalf("`af daemon restart` re-hits this gate and silently demotes to ad-hoc again; it does not restore supervision.\ngot=%q", errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "af daemon install") {
+		t.Fatalf("the repair must be the one that restores supervision.\ngot=%q", errOut.String())
+	}
 }
 
 // TestUpgrade_NoUnitForThisHomeIsQuiet locks the ordinary ad-hoc install: no
@@ -385,7 +395,7 @@ func TestUpgrade_NoDaemonButDaemonRunningIsNotUnqualifiedSuccess(t *testing.T) {
 	if errOut.Len() == 0 {
 		t.Fatalf("a running-but-unreachable daemon must be reported, not papered over with success.\nstdout=%q", out.String())
 	}
-	for _, want := range []string{"4242", "old binary", "af daemon restart"} {
+	for _, want := range []string{"4242", "old binary", "kill 4242"} {
 		if !strings.Contains(errOut.String(), want) {
 			t.Fatalf("stderr missing %q.\ngot=%q", want, errOut.String())
 		}
@@ -417,20 +427,154 @@ func TestUpgrade_NoDaemonIsQuietWhenTrulyNoDaemon(t *testing.T) {
 // could not stop (ShutdownFailed/#553, ShutdownError/#978) always arrives with
 // an error. That error used to print to STDOUT prefixed with "Upgraded
 // successfully!" — the user is left on the old daemon either way, so it belongs
-// on stderr with the recovery command.
+// on stderr with a recovery command that works.
 func TestUpgrade_UnreachableDaemonIsLoud(t *testing.T) {
 	_, url := upgradeHarness(t)
 	stubShutdown(t, daemon.ShutdownError, errors.New("dial timeout"))
-	stubDaemonHealth(t, daemon.HealthStatus{})
+	stubDaemonHealth(t, daemon.HealthStatus{PIDFilePID: 7777, PIDVerified: true})
 
 	var out, errOut bytes.Buffer
 	if err := runUpgrade(&out, &errOut, url, false); err != nil {
 		t.Fatalf("runUpgrade must not fail the install when the daemon cannot be stopped: %v", err)
 	}
 
-	for _, want := range []string{"dial timeout", "old binary", "af daemon restart"} {
+	for _, want := range []string{"dial timeout", "still running the old binary", "kill 7777"} {
 		if !strings.Contains(errOut.String(), want) {
 			t.Fatalf("stderr missing %q.\ngot=%q", want, errOut.String())
 		}
+	}
+}
+
+// TestUpgrade_ShutdownAndRespawnFailuresAreOppositeStates is the P1 repro.
+//
+// restartDaemonFromPathDetailed wraps two OPPOSITE failures into a non-nil
+// error: a failed SHUTDOWN means the old daemon is still alive on the old code
+// (#1947's own symptom), and a failed RESPAWN means there is no daemon at all
+// (schedules, watches and autoyes all stopped). Reporting both with one message
+// guarantees it is wrong for one of them — and for the respawn case the old
+// message was actively false: it claimed something was "still running the old
+// binary" when nothing was running, and offered a remedy for a daemon that did
+// not exist. Same disease as the bug being cured: a restart path that cannot
+// tell which state it is in.
+func TestUpgrade_ShutdownAndRespawnFailuresAreOppositeStates(t *testing.T) {
+	t.Run("shutdown failed: the OLD daemon is still alive on the old binary", func(t *testing.T) {
+		_, url := upgradeHarness(t)
+		stubShutdown(t, daemon.ShutdownFailed, errors.New("no PID candidate found"))
+		stubDaemonHealth(t, daemon.HealthStatus{PIDFilePID: 4242, PIDVerified: true})
+
+		var out, errOut bytes.Buffer
+		if err := runUpgrade(&out, &errOut, url, false); err != nil {
+			t.Fatalf("runUpgrade: %v", err)
+		}
+
+		got := errOut.String()
+		if !strings.Contains(got, "could not be stopped") || !strings.Contains(got, "still running the old binary") {
+			t.Fatalf("a failed shutdown must say the old daemon is still on the old binary.\ngot=%q", got)
+		}
+		if !strings.Contains(got, "kill 4242") {
+			t.Fatalf("the remedy must actually stop the daemon we named.\ngot=%q", got)
+		}
+		if strings.Contains(got, "No daemon is running") {
+			t.Fatalf("a daemon IS running here; the message must not claim otherwise.\ngot=%q", got)
+		}
+	})
+
+	t.Run("respawn failed: NOTHING is running", func(t *testing.T) {
+		_, url := upgradeHarness(t)
+		stubShutdown(t, daemon.ShutdownViaRPC, nil)
+		stubDaemonHealth(t, daemon.HealthStatus{})
+		// Drive the real respawn: no unit, and the ad-hoc spawn fails.
+		stubRespawnCollaborators(t, false, nil)
+		ensureDaemonFromPathFn = func(string) error { return errors.New("fork/exec: permission denied") }
+
+		var out, errOut bytes.Buffer
+		if err := runUpgrade(&out, &errOut, url, false); err != nil {
+			t.Fatalf("runUpgrade: %v", err)
+		}
+
+		got := errOut.String()
+		if !strings.Contains(got, "permission denied") {
+			t.Fatalf("stderr must carry why the respawn failed.\ngot=%q", got)
+		}
+		if !strings.Contains(got, "No daemon is running") {
+			t.Fatalf("a failed respawn leaves NOTHING running; the message must say so.\ngot=%q", got)
+		}
+		// The precise lie the old shared message told.
+		if strings.Contains(got, "still running the old binary") {
+			t.Fatalf("nothing is running here — claiming a daemon is on the old binary is false.\ngot=%q", got)
+		}
+		// The state is "no daemon", so a *re*start is not the remedy: with no
+		// socket, `af daemon restart` prints "no running daemon to restart".
+		if strings.Contains(got, "af daemon restart") {
+			t.Fatalf("`af daemon restart` starts nothing when no daemon is running.\ngot=%q", got)
+		}
+		if !strings.Contains(got, "Running af starts one") {
+			t.Fatalf("the message must name what actually starts a daemon.\ngot=%q", got)
+		}
+	})
+}
+
+// TestUpgrade_HintsNeverRouteThroughTheDeadSocket is the P2 repro, as a rule
+// rather than a case: `af daemon restart` reaches the daemon through the
+// control socket, and daemon.RequestShutdown returns (ShutdownNoDaemon, nil)
+// for a missing or refused one — so in every state below, where the socket did
+// not answer, that command no-ops and stops nothing. A hint routed through the
+// thing that just failed is not a remedy.
+func TestUpgrade_HintsNeverRouteThroughTheDeadSocket(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		result daemon.ShutdownResult
+		err    error
+		health daemon.HealthStatus
+	}{
+		{
+			name:   "socket silent but a daemon is verifiably alive",
+			result: daemon.ShutdownNoDaemon,
+			health: daemon.HealthStatus{PIDFilePID: 4242, PIDVerified: true},
+		},
+		{
+			name:   "socket present but unreachable",
+			result: daemon.ShutdownError,
+			err:    errors.New("dial timeout"),
+			health: daemon.HealthStatus{PIDFilePID: 4242, PIDVerified: true},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, url := upgradeHarness(t)
+			stubShutdown(t, tc.result, tc.err)
+			stubDaemonHealth(t, tc.health)
+
+			var out, errOut bytes.Buffer
+			if err := runUpgrade(&out, &errOut, url, false); err != nil {
+				t.Fatalf("runUpgrade: %v", err)
+			}
+
+			if strings.Contains(errOut.String(), "af daemon restart") {
+				t.Fatalf("`af daemon restart` goes back through the socket that just failed, so it does nothing here.\ngot=%q", errOut.String())
+			}
+			if !strings.Contains(errOut.String(), "kill 4242") {
+				t.Fatalf("the remedy must be built from the pid we already hold.\ngot=%q", errOut.String())
+			}
+		})
+	}
+}
+
+// TestUpgrade_NoVerifiedPidPointsAtTheCommandThatFindsOne: with no pid to name,
+// the hint must not invent one — it points at the command that reports it.
+func TestUpgrade_NoVerifiedPidPointsAtTheCommandThatFindsOne(t *testing.T) {
+	_, url := upgradeHarness(t)
+	stubShutdown(t, daemon.ShutdownFailed, errors.New("no PID candidate found"))
+	stubDaemonHealth(t, daemon.HealthStatus{})
+
+	var out, errOut bytes.Buffer
+	if err := runUpgrade(&out, &errOut, url, false); err != nil {
+		t.Fatalf("runUpgrade: %v", err)
+	}
+
+	if !strings.Contains(errOut.String(), "af daemon status") {
+		t.Fatalf("with no verified pid the hint must name the command that finds one.\ngot=%q", errOut.String())
+	}
+	if strings.Contains(errOut.String(), "kill 0") {
+		t.Fatalf("hint invented a pid.\ngot=%q", errOut.String())
 	}
 }

--- a/commands/upgrade_restart_test.go
+++ b/commands/upgrade_restart_test.go
@@ -1,0 +1,379 @@
+package commands
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/daemon"
+)
+
+// Tests for the post-upgrade daemon restart actually LANDING, and for never
+// reporting success when it did not (#1947), plus the cross-home unit gate
+// (#1950).
+//
+// `af upgrade` has restarted the daemon since #498/#1386 — that is not what
+// was broken. What was broken is that the restart could run, fail to land, and
+// still print "Upgraded successfully!": the unit could serve a different home,
+// relaunch a different binary, or fail and silently demote to an ad-hoc
+// daemon, and every one of those printed success.
+//
+// Everything the restart path touches is stubbed. These run on a machine with
+// a REAL supervised daemon: an unstubbed health probe reads its pid file and
+// pings its control socket, and an unstubbed home gate reads its autostart
+// unit.
+
+// stubDaemonHealth pins the liveness probe runUpgrade consults before printing
+// an all-clear, so no test here reads the host's real pid file or pings its
+// control socket.
+func stubDaemonHealth(t *testing.T, h daemon.HealthStatus) {
+	t.Helper()
+	prev := daemonHealthFn
+	t.Cleanup(func() { daemonHealthFn = prev })
+	daemonHealthFn = func() daemon.HealthStatus { return h }
+}
+
+// upgradeHarness stands up a release server and a throwaway "installed"
+// binary, and returns the path runUpgrade will overwrite. The binary is real
+// on disk because runUpgrade resolves it through EvalSymlinks.
+func upgradeHarness(t *testing.T) (binPath string, url string) {
+	t.Helper()
+	binPath = tempBinPath(t)
+	if err := os.WriteFile(binPath, []byte("old-binary"), 0755); err != nil {
+		t.Fatalf("seed binary: %v", err)
+	}
+	archive := makeTarGz(t, map[string][]byte{"agent-factory": []byte("new-binary")})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write(archive)
+	}))
+	t.Cleanup(srv.Close)
+
+	prevExe := osExecutableFn
+	t.Cleanup(func() { osExecutableFn = prevExe })
+	osExecutableFn = func() (string, error) { return binPath, nil }
+	return binPath, srv.URL
+}
+
+// stubShutdown pins what RequestShutdown reports and counts the calls.
+func stubShutdown(t *testing.T, result daemon.ShutdownResult, err error) *int {
+	t.Helper()
+	prev := requestDaemonShutdownFn
+	t.Cleanup(func() { requestDaemonShutdownFn = prev })
+	calls := new(int)
+	requestDaemonShutdownFn = func() (daemon.ShutdownResult, error) {
+		*calls++
+		return result, err
+	}
+	return calls
+}
+
+// TestRespawnAfterUpgrade_LeavesOtherHomesUnitAlone is the #1950 repro, from
+// that issue's ready-made failing test (its home gate is stubbed here so it
+// cannot read the host's real unit).
+//
+// `AGENT_FACTORY_HOME=/tmp/sandbox af upgrade` stops the sandbox's daemon,
+// then restarts whatever autostart unit EXISTS — the developer's real one,
+// serving a different home — and returns on success, skipping the ad-hoc
+// fallback. The sandbox it was actually upgrading is left with no daemon at
+// all, and someone else's daemon gets a bounce it never asked for.
+func TestRespawnAfterUpgrade_LeavesOtherHomesUnitAlone(t *testing.T) {
+	restartCalls, ensureCalls := stubRespawnCollaborators(t, true, nil)
+	// The unit file exists, and the unit restart would succeed — but it serves
+	// a DIFFERENT home than the one being upgraded.
+	autostartUnitServesHomeFn = func(string) (serves bool, installed bool, err error) {
+		return false, true, nil
+	}
+
+	if _, err := respawnDaemonAfterUpgrade(testUpgradeDaemonPath); err != nil {
+		t.Fatalf("respawnDaemonAfterUpgrade: %v", err)
+	}
+
+	if *restartCalls != 0 {
+		t.Fatalf("unit restarts = %d, want 0 (a unit serving another home must never be restarted)", *restartCalls)
+	}
+	if *ensureCalls != 1 {
+		t.Fatalf("ad-hoc spawns = %d, want 1 (the current home must still get a daemon)", *ensureCalls)
+	}
+}
+
+// TestRespawnAfterUpgrade_RestartsUnitServingThisHome locks the other side of
+// the gate: the home check must not cost the #796 supervised restart when the
+// unit is ours. Without this, "never restart the unit" would pass #1950.
+func TestRespawnAfterUpgrade_RestartsUnitServingThisHome(t *testing.T) {
+	restartCalls, ensureCalls := stubRespawnCollaborators(t, true, nil)
+	autostartUnitServesHomeFn = func(string) (serves bool, installed bool, err error) {
+		return true, true, nil
+	}
+
+	if _, err := respawnDaemonAfterUpgrade(testUpgradeDaemonPath); err != nil {
+		t.Fatalf("respawnDaemonAfterUpgrade: %v", err)
+	}
+
+	if *restartCalls != 1 {
+		t.Fatalf("unit restarts = %d, want 1 (a unit serving THIS home stays supervised)", *restartCalls)
+	}
+	if *ensureCalls != 0 {
+		t.Fatalf("ad-hoc spawns = %d, want 0 (a good unit restart must not be demoted)", *ensureCalls)
+	}
+}
+
+// TestRespawnAfterUpgrade_UnprovableHomeLeavesUnitAlone: the gate is proof, not
+// permission. When the unit's home cannot be determined, restarting it is a
+// coin flip on someone else's daemon — spawn ad-hoc for the home in front of us
+// instead.
+func TestRespawnAfterUpgrade_UnprovableHomeLeavesUnitAlone(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		serves func(string) (bool, bool, error)
+		config func() (string, error)
+	}{
+		{
+			name:   "unit unreadable",
+			serves: func(string) (bool, bool, error) { return false, true, errors.New("permission denied") },
+			config: func() (string, error) { return "/tmp/af-test-home", nil },
+		},
+		{
+			name:   "config dir unresolvable",
+			serves: func(string) (bool, bool, error) { return true, true, nil },
+			config: func() (string, error) { return "", errors.New("no home dir") },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			restartCalls, ensureCalls := stubRespawnCollaborators(t, true, nil)
+			autostartUnitServesHomeFn = tc.serves
+			configDirFn = tc.config
+
+			if _, err := respawnDaemonAfterUpgrade(testUpgradeDaemonPath); err != nil {
+				t.Fatalf("respawnDaemonAfterUpgrade: %v", err)
+			}
+
+			if *restartCalls != 0 {
+				t.Fatalf("unit restarts = %d, want 0 (an unproven unit must not be touched)", *restartCalls)
+			}
+			if *ensureCalls != 1 {
+				t.Fatalf("ad-hoc spawns = %d, want 1 (this home still needs a daemon)", *ensureCalls)
+			}
+		})
+	}
+}
+
+// TestUpgrade_NoRestartSkipsRestart pins the --no-restart opt-out: it must not
+// stop the daemon at all. The binary swap still happens.
+func TestUpgrade_NoRestartSkipsRestart(t *testing.T) {
+	binPath, url := upgradeHarness(t)
+	shutdownCalls := stubShutdown(t, daemon.ShutdownViaRPC, nil)
+	stubDaemonHealth(t, daemon.HealthStatus{})
+
+	var out, errOut bytes.Buffer
+	if err := runUpgrade(&out, &errOut, url, true); err != nil {
+		t.Fatalf("runUpgrade --no-restart: %v", err)
+	}
+
+	if *shutdownCalls != 0 {
+		t.Fatalf("shutdown calls = %d, want 0 (--no-restart must leave the daemon alone)", *shutdownCalls)
+	}
+	got, err := os.ReadFile(binPath)
+	if err != nil {
+		t.Fatalf("read upgraded binary: %v", err)
+	}
+	if string(got) != "new-binary" {
+		t.Fatalf("binary contents = %q, want new-binary (--no-restart must still install)", got)
+	}
+	// The user opted out, so this is not a warning — but it must not read as
+	// "you are running the new version" either.
+	if !strings.Contains(out.String(), "--no-restart") {
+		t.Fatalf("stdout must say the daemon was deliberately left on the old binary.\ngot=%q", out.String())
+	}
+}
+
+// TestUpgrade_DefaultRestarts locks the default the whole issue turns on: the
+// restart is not opt-in. If this ever flips, a shipped fix stops reaching the
+// daemon and #1947 is back.
+func TestUpgrade_DefaultRestarts(t *testing.T) {
+	_, url := upgradeHarness(t)
+	shutdownCalls := stubShutdown(t, daemon.ShutdownViaRPC, nil)
+	stubDaemonHealth(t, daemon.HealthStatus{})
+	stubRespawnCollaborators(t, false, nil)
+
+	var out, errOut bytes.Buffer
+	if err := runUpgrade(&out, &errOut, url, false); err != nil {
+		t.Fatalf("runUpgrade: %v", err)
+	}
+
+	if *shutdownCalls != 1 {
+		t.Fatalf("shutdown calls = %d, want 1 (af upgrade restarts the daemon by default)", *shutdownCalls)
+	}
+	if !strings.Contains(out.String(), "Restarted the running daemon") {
+		t.Fatalf("stdout should report the restart.\ngot=%q", out.String())
+	}
+}
+
+// TestUpgrade_NoRestartFlagRegistered pins the flag onto the command with the
+// default the restart behavior depends on. runUpgrade's noRestart parameter is
+// covered by the two tests above; this covers the wiring that reaches it.
+func TestUpgrade_NoRestartFlagRegistered(t *testing.T) {
+	f := upgradeCmd.Flags().Lookup("no-restart")
+	if f == nil {
+		t.Fatal("af upgrade has no --no-restart flag")
+	}
+	if f.DefValue != "false" {
+		t.Fatalf("--no-restart default = %q, want false (restarting is the default)", f.DefValue)
+	}
+	if !strings.Contains(f.Usage, "restarts it by default") {
+		t.Fatalf("--no-restart help must say the restart already happens by default.\ngot=%q", f.Usage)
+	}
+}
+
+// TestUpgrade_FailedUnitRestartIsLoud is a repro for the silent demotion. When
+// the unit restart fails, the respawn falls back to an ad-hoc daemon and only
+// WARNs to the log — which the user never sees — while stdout says "Restarted
+// the running daemon from the new binary". The daemon is now unsupervised and
+// will not come back at next login, and nothing told the user.
+func TestUpgrade_FailedUnitRestartIsLoud(t *testing.T) {
+	binPath, url := upgradeHarness(t)
+	stubShutdown(t, daemon.ShutdownViaRPC, nil)
+	stubDaemonHealth(t, daemon.HealthStatus{})
+	// A unit that serves this home and launches this very binary, so the ONLY
+	// thing wrong is the failing restart.
+	stubRespawnCollaborators(t, true, errors.New("systemctl exited 1"))
+	autostartUnitExecPathFn = func() (string, bool, error) { return binPath, true, nil }
+
+	var out, errOut bytes.Buffer
+	if err := runUpgrade(&out, &errOut, url, false); err != nil {
+		t.Fatalf("runUpgrade: %v", err)
+	}
+
+	if errOut.Len() == 0 {
+		t.Fatalf("a failed unit restart must reach the user, not just the log; stderr was empty.\nstdout=%q", out.String())
+	}
+	for _, want := range []string{"systemctl exited 1", "af daemon install"} {
+		if !strings.Contains(errOut.String(), want) {
+			t.Fatalf("stderr missing %q.\ngot=%q", want, errOut.String())
+		}
+	}
+}
+
+// TestUpgrade_StaleUnitBinaryIsLoud is the repro for the most likely macOS
+// cause: the unit bakes its program path at install time, so with two installs
+// on one box (Homebrew /opt/homebrew/bin/af vs ~/.local/bin/af) `af upgrade`
+// overwrites the one it is running, the unit restart faithfully brings the
+// OTHER, older binary back up, and we print "Upgraded successfully! Restarted
+// the running daemon from the new binary." Every word of that is wrong.
+func TestUpgrade_StaleUnitBinaryIsLoud(t *testing.T) {
+	const otherInstall = "/opt/homebrew/bin/af"
+	_, url := upgradeHarness(t)
+	stubShutdown(t, daemon.ShutdownViaRPC, nil)
+	stubDaemonHealth(t, daemon.HealthStatus{})
+	stubRespawnCollaborators(t, true, nil)
+	autostartUnitExecPathFn = func() (string, bool, error) { return otherInstall, true, nil }
+
+	var out, errOut bytes.Buffer
+	if err := runUpgrade(&out, &errOut, url, false); err != nil {
+		t.Fatalf("runUpgrade: %v", err)
+	}
+
+	if !strings.Contains(errOut.String(), otherInstall) {
+		t.Fatalf("a unit that relaunches a DIFFERENT binary must be reported; stderr did not name %s.\nstdout=%q\nstderr=%q",
+			otherInstall, out.String(), errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "af daemon install") {
+		t.Fatalf("stderr must name the fix.\ngot=%q", errOut.String())
+	}
+}
+
+// TestUpgrade_UnitLaunchingTheUpgradedBinaryIsQuiet locks the staleness check
+// against false alarms: the normal single-install case must stay quiet, or the
+// warning becomes noise users learn to ignore.
+func TestUpgrade_UnitLaunchingTheUpgradedBinaryIsQuiet(t *testing.T) {
+	binPath, url := upgradeHarness(t)
+	stubShutdown(t, daemon.ShutdownViaRPC, nil)
+	stubDaemonHealth(t, daemon.HealthStatus{})
+	stubRespawnCollaborators(t, true, nil)
+	autostartUnitExecPathFn = func() (string, bool, error) { return binPath, true, nil }
+
+	var out, errOut bytes.Buffer
+	if err := runUpgrade(&out, &errOut, url, false); err != nil {
+		t.Fatalf("runUpgrade: %v", err)
+	}
+
+	if errOut.Len() != 0 {
+		t.Fatalf("a unit launching the upgraded binary must not warn.\ngot stderr=%q", errOut.String())
+	}
+	if !strings.Contains(out.String(), "Restarted the running daemon from the new binary") {
+		t.Fatalf("stdout should report the clean restart.\ngot=%q", out.String())
+	}
+}
+
+// TestUpgrade_NoDaemonButDaemonRunningIsNotUnqualifiedSuccess is the repro for
+// the false "no daemon". RequestShutdown reports ShutdownNoDaemon for a
+// missing OR unreachable socket, so "nothing was running" and "a daemon is
+// running that we cannot reach" arrive identically — and the default branch
+// printed a bare "Upgraded successfully!" over both. The daemon kept serving
+// the old binary with nothing said.
+func TestUpgrade_NoDaemonButDaemonRunningIsNotUnqualifiedSuccess(t *testing.T) {
+	_, url := upgradeHarness(t)
+	stubShutdown(t, daemon.ShutdownNoDaemon, nil)
+	// The socket said "nobody home"; the process table disagrees.
+	stubDaemonHealth(t, daemon.HealthStatus{PIDFilePID: 4242, PIDVerified: true})
+
+	var out, errOut bytes.Buffer
+	if err := runUpgrade(&out, &errOut, url, false); err != nil {
+		t.Fatalf("runUpgrade: %v", err)
+	}
+
+	if errOut.Len() == 0 {
+		t.Fatalf("a running-but-unreachable daemon must be reported, not papered over with success.\nstdout=%q", out.String())
+	}
+	for _, want := range []string{"4242", "old binary", "af daemon restart"} {
+		if !strings.Contains(errOut.String(), want) {
+			t.Fatalf("stderr missing %q.\ngot=%q", want, errOut.String())
+		}
+	}
+}
+
+// TestUpgrade_NoDaemonIsQuietWhenTrulyNoDaemon locks the common case — fresh
+// installs, CI, and any `af upgrade` with nothing running — against the check
+// above turning into a false alarm on every run.
+func TestUpgrade_NoDaemonIsQuietWhenTrulyNoDaemon(t *testing.T) {
+	_, url := upgradeHarness(t)
+	stubShutdown(t, daemon.ShutdownNoDaemon, nil)
+	stubDaemonHealth(t, daemon.HealthStatus{})
+
+	var out, errOut bytes.Buffer
+	if err := runUpgrade(&out, &errOut, url, false); err != nil {
+		t.Fatalf("runUpgrade: %v", err)
+	}
+
+	if errOut.Len() != 0 {
+		t.Fatalf("no daemon running is not a problem and must stay quiet.\ngot stderr=%q", errOut.String())
+	}
+	if strings.TrimSpace(out.String()) != "Upgraded successfully!" {
+		t.Fatalf("stdout = %q, want a plain success line", out.String())
+	}
+}
+
+// TestUpgrade_UnreachableDaemonIsLoud: a daemon proven to be listening that we
+// could not stop (ShutdownFailed/#553, ShutdownError/#978) always arrives with
+// an error. That error used to print to STDOUT prefixed with "Upgraded
+// successfully!" — the user is left on the old daemon either way, so it belongs
+// on stderr with the recovery command.
+func TestUpgrade_UnreachableDaemonIsLoud(t *testing.T) {
+	_, url := upgradeHarness(t)
+	stubShutdown(t, daemon.ShutdownError, errors.New("dial timeout"))
+	stubDaemonHealth(t, daemon.HealthStatus{})
+
+	var out, errOut bytes.Buffer
+	if err := runUpgrade(&out, &errOut, url, false); err != nil {
+		t.Fatalf("runUpgrade must not fail the install when the daemon cannot be stopped: %v", err)
+	}
+
+	for _, want := range []string{"dial timeout", "old binary", "af daemon restart"} {
+		if !strings.Contains(errOut.String(), want) {
+			t.Fatalf("stderr missing %q.\ngot=%q", want, errOut.String())
+		}
+	}
+}

--- a/commands/upgrade_test.go
+++ b/commands/upgrade_test.go
@@ -219,10 +219,10 @@ func TestUpgradeCallsShutdownAfterBinarySwap(t *testing.T) {
 	prevRespawn := respawnDaemonFn
 	respawnCalls := 0
 	var respawnPath string
-	respawnDaemonFn = func(path string) error {
+	respawnDaemonFn = func(path string) (respawnResult, error) {
 		respawnCalls++
 		respawnPath = path
-		return nil
+		return respawnResult{}, nil
 	}
 	t.Cleanup(func() { respawnDaemonFn = prevRespawn })
 	osExecutableFn = func() (string, error) { return tempBin, nil }
@@ -232,7 +232,8 @@ func TestUpgradeCallsShutdownAfterBinarySwap(t *testing.T) {
 		return daemon.ShutdownViaRPC, nil
 	}
 
-	if err := runUpgrade(srv.URL); err != nil {
+	stubDaemonHealth(t, daemon.HealthStatus{})
+	if err := runUpgrade(io.Discard, io.Discard, srv.URL, false); err != nil {
 		t.Fatalf("runUpgrade: %v", err)
 	}
 	if shutdownCalls != 1 {
@@ -277,9 +278,9 @@ func TestUpgradeSucceedsWhenNoDaemon(t *testing.T) {
 	})
 	prevRespawn := respawnDaemonFn
 	respawnCalls := 0
-	respawnDaemonFn = func(string) error {
+	respawnDaemonFn = func(string) (respawnResult, error) {
 		respawnCalls++
-		return nil
+		return respawnResult{}, nil
 	}
 	t.Cleanup(func() { respawnDaemonFn = prevRespawn })
 	osExecutableFn = func() (string, error) { return tempBin, nil }
@@ -289,7 +290,8 @@ func TestUpgradeSucceedsWhenNoDaemon(t *testing.T) {
 		return daemon.ShutdownNoDaemon, nil
 	}
 
-	if err := runUpgrade(srv.URL); err != nil {
+	stubDaemonHealth(t, daemon.HealthStatus{})
+	if err := runUpgrade(io.Discard, io.Discard, srv.URL, false); err != nil {
 		t.Fatalf("runUpgrade with absent daemon failed: %v", err)
 	}
 	if respawnCalls != 0 {
@@ -327,9 +329,9 @@ func TestUpgradeSucceedsWhenShutdownErrors(t *testing.T) {
 	})
 	prevRespawn := respawnDaemonFn
 	respawnCalls := 0
-	respawnDaemonFn = func(string) error {
+	respawnDaemonFn = func(string) (respawnResult, error) {
 		respawnCalls++
-		return nil
+		return respawnResult{}, nil
 	}
 	t.Cleanup(func() { respawnDaemonFn = prevRespawn })
 	osExecutableFn = func() (string, error) { return tempBin, nil }
@@ -337,7 +339,8 @@ func TestUpgradeSucceedsWhenShutdownErrors(t *testing.T) {
 		return daemon.ShutdownNoDaemon, errors.New("simulated rpc failure")
 	}
 
-	if err := runUpgrade(srv.URL); err != nil {
+	stubDaemonHealth(t, daemon.HealthStatus{})
+	if err := runUpgrade(io.Discard, io.Discard, srv.URL, false); err != nil {
 		t.Fatalf("runUpgrade should not fail when Shutdown errors, got: %v", err)
 	}
 	got, err := os.ReadFile(tempBin)
@@ -374,10 +377,10 @@ func TestUpgradeReportsSIGTERMFallback(t *testing.T) {
 	prevRespawn := respawnDaemonFn
 	respawnCalls := 0
 	var respawnPath string
-	respawnDaemonFn = func(path string) error {
+	respawnDaemonFn = func(path string) (respawnResult, error) {
 		respawnCalls++
 		respawnPath = path
-		return nil
+		return respawnResult{}, nil
 	}
 	t.Cleanup(func() { respawnDaemonFn = prevRespawn })
 	osExecutableFn = func() (string, error) { return tempBin, nil }
@@ -385,25 +388,13 @@ func TestUpgradeReportsSIGTERMFallback(t *testing.T) {
 		return daemon.ShutdownViaSIGTERM, nil
 	}
 
-	// Capture stdout so we can assert on the user-visible message.
-	origStdout := os.Stdout
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("pipe: %v", err)
-	}
-	os.Stdout = w
-	defer func() { os.Stdout = origStdout }()
-
-	if err := runUpgrade(srv.URL); err != nil {
+	stubDaemonHealth(t, daemon.HealthStatus{})
+	var out, errOut bytes.Buffer
+	if err := runUpgrade(&out, &errOut, srv.URL, false); err != nil {
 		t.Fatalf("runUpgrade: %v", err)
 	}
-	w.Close()
-	captured, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatalf("read captured stdout: %v", err)
-	}
 
-	got := string(captured)
+	got := out.String()
 	want := "Upgraded successfully! Stopped the running daemon (pre-fix; used SIGTERM)"
 	if !strings.Contains(got, want) {
 		t.Fatalf("runUpgrade stdout missing SIGTERM-fallback message.\n got=%q\nwant substring=%q", got, want)

--- a/daemon/autostart.go
+++ b/daemon/autostart.go
@@ -24,6 +24,33 @@ const (
 	autostartLaunchdLabel = "com.agent-factory.daemon"
 )
 
+// Every launchctl call af makes names the gui/<uid> domain explicitly, and
+// they must all name the SAME one (#1947).
+//
+// The legacy verbs (`launchctl load`/`unload`) take no domain: they bootstrap
+// into the domain of the CALLING session, so an install run over ssh lands the
+// agent in user/<uid> while an install run from a Terminal window lands it in
+// gui/<uid>. RestartAutostartUnit has always kicked gui/<uid> explicitly, so a
+// legacy-loaded agent could sit in a domain our own restart never targets —
+// `launchctl kickstart` then fails to find the job, the upgrade path logs a
+// warning nobody reads, and the stale daemon keeps serving the old binary.
+// That silent no-op is the macOS half of #1947 (#1920 found the same case).
+//
+// The modern verbs take the domain as an argument, so install, pause, resume,
+// restart, and uninstall all target gui/<uid> no matter how af was invoked.
+// Bootstrapping into gui/<uid> requires a GUI login session; without one
+// `bootstrap` fails loudly at install time, which is strictly better than the
+// legacy path's success followed by a restart that silently never lands.
+func launchdGUIDomain() string {
+	return fmt.Sprintf("gui/%d", os.Getuid())
+}
+
+// launchdServiceTarget is the service-target form (`gui/<uid>/<label>`) that
+// bootout and kickstart address the loaded job by.
+func launchdServiceTarget() string {
+	return launchdGUIDomain() + "/" + autostartLaunchdLabel
+}
+
 // quoteExecStartPath quotes a path for use in an ExecStart= line.
 // systemd parses ExecStart= with shell-like quoting, so surrounding the path
 // in double quotes allows spaces. Internal backslashes and double quotes are
@@ -212,8 +239,9 @@ func InstallAutostart() (string, error) {
 		}
 		logPath := filepath.Join(configDir, "daemon-launchd.log")
 		content := launchdAutostartPlist(execPath, os.Getenv("PATH"), os.Getenv("SHELL"), os.Getenv("AGENT_FACTORY_HOME"), logPath)
-		// Unload a previous agent first so launchctl load picks up the new file.
-		_, _ = autostartUnitCommand("launchctl", "unload", plistPath)
+		// Boot out a previous agent first so bootstrap picks up the new file.
+		// Best-effort: it fails when no agent is loaded, which is the norm.
+		_, _ = autostartUnitCommand("launchctl", "bootout", launchdServiceTarget())
 		if err := config.AtomicWriteFile(plistPath, []byte(content), 0644); err != nil {
 			return "", fmt.Errorf("failed to write plist file: %w", err)
 		}
@@ -222,9 +250,9 @@ func InstallAutostart() (string, error) {
 		if _, err := autostartStopDaemon(); err != nil {
 			log.WarningLog.Printf("failed to stop the running daemon before loading the autostart agent; loading anyway: %v", err)
 		}
-		if out, err := autostartUnitCommand("launchctl", "load", plistPath); err != nil {
+		if out, err := autostartUnitCommand("launchctl", "bootstrap", launchdGUIDomain(), plistPath); err != nil {
 			removeAutostartUnitFile(plistPath)
-			return "", fmt.Errorf("failed to load launch agent: %w\n%s", err, strings.TrimSpace(string(out)))
+			return "", fmt.Errorf("failed to bootstrap launch agent into %s: %w\n%s", launchdGUIDomain(), err, strings.TrimSpace(string(out)))
 		}
 		return plistPath, nil
 
@@ -417,6 +445,128 @@ func launchdPlistEnvValue(content, name string) (string, bool) {
 	return html.UnescapeString(rest[:end]), true
 }
 
+// AutostartUnitExecPath returns the binary path the INSTALLED autostart unit
+// launches. installed is false when no unit file is present.
+//
+// The unit bakes its program path at install time (InstallAutostart captures
+// os.Executable), exactly as it bakes AGENT_FACTORY_HOME — and for the upgrade
+// path that is a trap. `af upgrade` overwrites the binary it is CURRENTLY
+// running; restarting the unit then relaunches whatever path the unit was
+// installed with. With two installs on one box (Homebrew /opt/homebrew/bin/af
+// and ~/.local/bin/af), a restart faithfully brings the OLD image back up while
+// the upgrade reports success — the stale daemon of #1947. Callers compare this
+// against the binary they just wrote and say so when they disagree.
+func AutostartUnitExecPath() (execPath string, installed bool, err error) {
+	path, err := autostartUnitFilePath()
+	if err != nil {
+		return "", false, err
+	}
+	if path == "" {
+		return "", false, nil // autostart unsupported on this platform
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("failed to read the autostart unit %s: %w", path, err)
+	}
+
+	var (
+		baked string
+		found bool
+	)
+	switch autostartGOOS {
+	case "linux":
+		baked, found = systemdUnitExecStart(string(data))
+	case "darwin":
+		baked, found = launchdPlistProgramPath(string(data))
+	default:
+		return "", false, nil
+	}
+	if !found || baked == "" {
+		return "", true, fmt.Errorf("the autostart unit %s does not name a program to launch", path)
+	}
+	return baked, true, nil
+}
+
+// systemdUnitExecStart extracts the program path from the unit's ExecStart=
+// line. The exact inverse of quoteExecStartPath, and must stay in lockstep with
+// it — TestAutostartUnitExecPathRoundTrip pins the pair together.
+func systemdUnitExecStart(content string) (string, bool) {
+	for _, line := range strings.Split(content, "\n") {
+		rest, ok := strings.CutPrefix(strings.TrimSpace(line), "ExecStart=")
+		if !ok {
+			continue
+		}
+		// The renderer always double-quotes the path, so scan to the matching
+		// UNESCAPED quote: cutting at the first space would truncate a path
+		// containing one, and cutting at the first quote would truncate a path
+		// containing an escaped quote.
+		if !strings.HasPrefix(rest, `"`) {
+			// Defensive: a hand-edited unit may leave the path bare. Only then
+			// is a space a field separator.
+			field, _, _ := strings.Cut(rest, " ")
+			return field, field != ""
+		}
+		for i := 1; i < len(rest); i++ {
+			if rest[i] == '\\' {
+				i++
+				continue
+			}
+			if rest[i] == '"' {
+				return unquoteExecStartPath(rest[1:i]), true
+			}
+		}
+		return "", false
+	}
+	return "", false
+}
+
+// unquoteExecStartPath reverses quoteExecStartPath's escaping of an already
+// unwrapped (quotes stripped) value: C-style \\ and \", plus systemd's doubled
+// $$ and %% specifiers. One pass, so a literal backslash followed by a quote
+// survives — two ReplaceAll passes would not.
+func unquoteExecStartPath(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+1 < len(s) {
+			i++
+			b.WriteByte(s[i])
+			continue
+		}
+		if (s[i] == '$' || s[i] == '%') && i+1 < len(s) && s[i+1] == s[i] {
+			i++
+			b.WriteByte(s[i])
+			continue
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
+
+// launchdPlistProgramPath extracts the program from the plist's
+// ProgramArguments array: the first <string> after the key. The inverse of
+// launchdAutostartPlist's html.EscapeString, kept in lockstep by the same
+// round-trip test.
+func launchdPlistProgramPath(content string) (string, bool) {
+	idx := strings.Index(content, "<key>ProgramArguments</key>")
+	if idx < 0 {
+		return "", false
+	}
+	rest := content[idx:]
+	start := strings.Index(rest, "<string>")
+	if start < 0 {
+		return "", false
+	}
+	rest = rest[start+len("<string>"):]
+	end := strings.Index(rest, "</string>")
+	if end < 0 {
+		return "", false
+	}
+	return html.UnescapeString(rest[:end]), true
+}
+
 // RestartAutostartUnit restarts the daemon through the OS service manager —
 // `systemctl --user restart` on Linux, `launchctl kickstart -k` on macOS — so
 // the daemon stays supervised. Used by the upgrade/auto-update respawn path
@@ -432,7 +582,10 @@ func RestartAutostartUnit() error {
 		}
 		return nil
 	case "darwin":
-		target := fmt.Sprintf("gui/%d/%s", os.Getuid(), autostartLaunchdLabel)
+		// The domain here is the one InstallAutostart bootstraps into: they
+		// are the same helper precisely so they cannot drift apart again
+		// (#1947).
+		target := launchdServiceTarget()
 		if out, err := autostartUnitCommand("launchctl", "kickstart", "-k", target); err != nil {
 			return fmt.Errorf("launchctl kickstart -k %s failed: %w\n%s", target, err, strings.TrimSpace(string(out)))
 		}
@@ -458,13 +611,14 @@ func PauseAutostartUnit() error {
 		}
 		return nil
 	case "darwin":
-		dir, err := autostartLaunchAgentsDir()
-		if err != nil {
-			return fmt.Errorf("failed to resolve LaunchAgents directory: %w", err)
-		}
-		plistPath := filepath.Join(dir, autostartLaunchdLabel+".plist")
-		if out, err := autostartUnitCommand("launchctl", "unload", plistPath); err != nil {
-			return fmt.Errorf("launchctl unload %s failed: %w\n%s", plistPath, err, strings.TrimSpace(string(out)))
+		// Addressed by service target, not plist path, so the pause lands in
+		// the same gui/<uid> domain the install bootstrapped into (#1947).
+		// A bootout of a job that is not loaded fails — but a job that is not
+		// loaded is already paused for our purposes, and the caller (`af
+		// reset`) only warns, so the failure is cosmetic where it is possible
+		// at all.
+		if out, err := autostartUnitCommand("launchctl", "bootout", launchdServiceTarget()); err != nil {
+			return fmt.Errorf("launchctl bootout %s failed: %w\n%s", launchdServiceTarget(), err, strings.TrimSpace(string(out)))
 		}
 		return nil
 	default:
@@ -488,8 +642,10 @@ func ResumeAutostartUnit() error {
 			return fmt.Errorf("failed to resolve LaunchAgents directory: %w", err)
 		}
 		plistPath := filepath.Join(dir, autostartLaunchdLabel+".plist")
-		if out, err := autostartUnitCommand("launchctl", "load", plistPath); err != nil {
-			return fmt.Errorf("launchctl load %s failed: %w\n%s", plistPath, err, strings.TrimSpace(string(out)))
+		// bootstrap (not the legacy load) so the resumed agent lands back in
+		// the same gui/<uid> domain the install used and the restart kicks.
+		if out, err := autostartUnitCommand("launchctl", "bootstrap", launchdGUIDomain(), plistPath); err != nil {
+			return fmt.Errorf("launchctl bootstrap %s %s failed: %w\n%s", launchdGUIDomain(), plistPath, err, strings.TrimSpace(string(out)))
 		}
 		return nil
 	default:
@@ -536,7 +692,9 @@ func UninstallAutostart() (string, error) {
 		if _, err := os.Stat(plistPath); os.IsNotExist(err) {
 			return "", nil
 		}
-		_, _ = autostartUnitCommand("launchctl", "unload", plistPath)
+		// Same gui/<uid> domain as the install's bootstrap (#1947). Best-effort:
+		// removing the plist is what makes the uninstall stick across logins.
+		_, _ = autostartUnitCommand("launchctl", "bootout", launchdServiceTarget())
 		if err := os.Remove(plistPath); err != nil && !os.IsNotExist(err) {
 			return "", fmt.Errorf("failed to remove plist file: %w", err)
 		}

--- a/daemon/autostart.go
+++ b/daemon/autostart.go
@@ -184,7 +184,7 @@ func launchdAutostartPlist(execPath, pathEnv, shellEnv, agentFactoryHome, logPat
 //     daemon is left at worst enabled-but-inactive until the next login — far
 //     better than a present-but-not-enabled unit. (Previously a stop failure
 //     returned early, leaving the file on disk but never enabled.)
-//   - On a hard failure of the reload/enable/load step the just-written unit
+//   - On a hard failure of the reload/enable/bootstrap step the just-written unit
 //     file is removed, so AutostartInstalled — which reports on file existence —
 //     can never misreport a not-enabled unit as installed and mislead the
 //     upgrade respawn path into RestartAutostartUnit on a unit that was never
@@ -246,9 +246,9 @@ func InstallAutostart() (string, error) {
 			return "", fmt.Errorf("failed to write plist file: %w", err)
 		}
 		// Hand any ad-hoc daemon over to the supervised one, but never let a
-		// stop failure block loading — see the function comment (#974).
+		// stop failure block the bootstrap — see the function comment (#974).
 		if _, err := autostartStopDaemon(); err != nil {
-			log.WarningLog.Printf("failed to stop the running daemon before loading the autostart agent; loading anyway: %v", err)
+			log.WarningLog.Printf("failed to stop the running daemon before bootstrapping the autostart agent; bootstrapping anyway: %v", err)
 		}
 		if out, err := autostartUnitCommand("launchctl", "bootstrap", launchdGUIDomain(), plistPath); err != nil {
 			removeAutostartUnitFile(plistPath)
@@ -596,7 +596,7 @@ func RestartAutostartUnit() error {
 }
 
 // PauseAutostartUnit stops the daemon autostart unit — `systemctl --user stop`
-// on Linux, `launchctl unload` on macOS — WITHOUT uninstalling it, so the
+// on Linux, `launchctl bootout gui/<uid>/<label>` on macOS — WITHOUT uninstalling it, so the
 // service manager cannot (re)launch the daemon until ResumeAutostartUnit.
 // Stopping the unit also stops the supervised daemon itself. `af reset` wraps
 // its wipe in this pair: the unit relaunches a daemon that exits uncleanly,
@@ -627,8 +627,8 @@ func PauseAutostartUnit() error {
 }
 
 // ResumeAutostartUnit re-arms the unit PauseAutostartUnit stopped — `systemctl
-// --user start` on Linux, `launchctl load` on macOS — which also starts the
-// daemon again (the launchd agent is RunAtLoad).
+// --user start` on Linux, `launchctl bootstrap gui/<uid>` on macOS — which also
+// starts the daemon again (the launchd agent is RunAtLoad).
 func ResumeAutostartUnit() error {
 	switch autostartGOOS {
 	case "linux":

--- a/daemon/autostart_home_test.go
+++ b/daemon/autostart_home_test.go
@@ -50,6 +50,69 @@ func TestAutostartUnitHomeRoundTrip(t *testing.T) {
 	}
 }
 
+// TestAutostartUnitExecPathRoundTrip pins the program-path renderers and their
+// parsers together, for the same reason the home round trip exists: the
+// upgrade path decides whether the restarted unit will relaunch the binary it
+// just wrote by READING BACK the ExecStart/ProgramArguments that
+// InstallAutostart baked in (#1947). A renderer change the parser does not
+// follow reports a mismatch that is not there — and a warning that cries wolf
+// on every ordinary upgrade is one users stop reading.
+//
+// The awkward values are the point: quoteExecStartPath escapes backslashes and
+// quotes, and doubles systemd's '$' and '%' specifiers, none of which appear in
+// the happy path (#1214 is the spaced-path precedent).
+func TestAutostartUnitExecPathRoundTrip(t *testing.T) {
+	paths := []string{
+		"/usr/local/bin/af",
+		"/opt/homebrew/bin/af",
+		"/home/John Smith/bin/af",
+		`/tmp/pct%bin/af`,
+		`/tmp/dollar$bin/af`,
+		`/tmp/quote"bin/af`,
+		`/tmp/back\slash/af`,
+		`/tmp/back\"both/af`,
+	}
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			unit := systemdAutostartUnit(path, "/usr/bin:/bin", "/bin/zsh", "/home/u/.agent-factory")
+			got, found := systemdUnitExecStart(unit)
+			if !found {
+				t.Fatalf("systemd unit for %q exposes no ExecStart:\n%s", path, unit)
+			}
+			if got != path {
+				t.Errorf("systemd round trip = %q, want %q\nunit:\n%s", got, path, unit)
+			}
+
+			plist := launchdAutostartPlist(path, "/usr/bin:/bin", "/bin/zsh", "", "/tmp/af.log")
+			got, found = launchdPlistProgramPath(plist)
+			if !found {
+				t.Fatalf("launchd plist for %q exposes no ProgramArguments:\n%s", path, plist)
+			}
+			if got != path {
+				t.Errorf("launchd round trip = %q, want %q", got, path)
+			}
+		})
+	}
+}
+
+// TestAutostartUnitExecPath_StopsAtTheProgram: the parser must return the
+// program alone, never the --daemon argument that follows it. A value of
+// `/usr/local/bin/af --daemon` compares unequal to every real binary path, so
+// the staleness check would warn on every single upgrade.
+func TestAutostartUnitExecPath_StopsAtTheProgram(t *testing.T) {
+	unit := systemdAutostartUnit("/usr/local/bin/af", "/usr/bin", "/bin/zsh", "")
+	got, found := systemdUnitExecStart(unit)
+	if !found || got != "/usr/local/bin/af" {
+		t.Errorf("ExecStart round trip = %q found=%v, want /usr/local/bin/af", got, found)
+	}
+
+	plist := launchdAutostartPlist("/usr/local/bin/af", "/usr/bin", "/bin/zsh", "", "/tmp/af.log")
+	got, found = launchdPlistProgramPath(plist)
+	if !found || got != "/usr/local/bin/af" {
+		t.Errorf("ProgramArguments round trip = %q found=%v, want /usr/local/bin/af", got, found)
+	}
+}
+
 // TestAutostartUnitHome_AbsentMeansDefault: a unit installed WITHOUT
 // AGENT_FACTORY_HOME serves the DEFAULT home. Reporting that as "no home found"
 // and treating it as unknown would make the gate skip the ordinary supervised

--- a/daemon/autostart_pause_test.go
+++ b/daemon/autostart_pause_test.go
@@ -44,10 +44,13 @@ func TestPauseAndResumeAutostartUnitDarwin(t *testing.T) {
 		t.Fatalf("ResumeAutostartUnit: %v", err)
 	}
 
+	// Pause boots the job OUT of the same gui/<uid> domain the install
+	// bootstrapped it into, and resume bootstraps it back there — so a paused
+	// unit is one RestartAutostartUnit's kickstart can still find (#1947).
 	plist := filepath.Join(dir, autostartLaunchdLabel+".plist")
 	want := [][]string{
-		{"launchctl", "unload", plist},
-		{"launchctl", "load", plist},
+		{"launchctl", "bootout", launchdServiceTarget()},
+		{"launchctl", "bootstrap", launchdGUIDomain(), plist},
 	}
 	if !reflect.DeepEqual(*calls, want) {
 		t.Errorf("unit commands = %v, want %v", *calls, want)

--- a/daemon/autostart_restart_test.go
+++ b/daemon/autostart_restart_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -120,7 +121,8 @@ func TestInstallAutostartEnablesUnitWhenStopDaemonFailsLinux(t *testing.T) {
 }
 
 // TestInstallAutostartLoadsAgentWhenStopDaemonFailsDarwin is the macOS variant:
-// a stop failure must not block the launchctl load that makes autostart real.
+// a stop failure must not block the launchctl bootstrap that makes autostart
+// real.
 func TestInstallAutostartLoadsAgentWhenStopDaemonFailsDarwin(t *testing.T) {
 	dir := withAutostartTestEnv(t, "darwin")
 	calls := stubAutostartUnitCommand(t, nil)
@@ -139,8 +141,8 @@ func TestInstallAutostartLoadsAgentWhenStopDaemonFailsDarwin(t *testing.T) {
 	if !AutostartInstalled() {
 		t.Fatalf("AutostartInstalled() = false after a successful install")
 	}
-	if !calledWith(*calls, "launchctl", "load", plistPath) {
-		t.Fatalf("load did not run after the stop failure; calls = %v", *calls)
+	if !calledWith(*calls, "launchctl", "bootstrap", launchdGUIDomain(), plistPath) {
+		t.Fatalf("bootstrap did not run after the stop failure; calls = %v", *calls)
 	}
 }
 
@@ -169,19 +171,19 @@ func TestInstallAutostartRemovesUnitWhenEnableFailsLinux(t *testing.T) {
 }
 
 // TestInstallAutostartRemovesPlistWhenLoadFailsDarwin is the macOS cleanup
-// variant: a hard launchctl load failure must not leave an orphaned plist.
+// variant: a hard launchctl bootstrap failure must not leave an orphaned plist.
 func TestInstallAutostartRemovesPlistWhenLoadFailsDarwin(t *testing.T) {
 	dir := withAutostartTestEnv(t, "darwin")
 	stubAutostartStopDaemon(t, true, nil)
 	stubAutostartUnitCommandFunc(t, func(name string, args ...string) ([]byte, error) {
-		if len(args) > 0 && args[0] == "load" {
-			return []byte("load failed"), errors.New("exit status 1")
+		if len(args) > 0 && args[0] == "bootstrap" {
+			return []byte("bootstrap failed"), errors.New("exit status 1")
 		}
 		return nil, nil
 	})
 
 	if _, err := InstallAutostart(); err == nil {
-		t.Fatalf("InstallAutostart succeeded despite a failing load")
+		t.Fatalf("InstallAutostart succeeded despite a failing bootstrap")
 	}
 	if _, statErr := os.Stat(filepath.Join(dir, autostartLaunchdLabel+".plist")); !os.IsNotExist(statErr) {
 		t.Fatalf("plist should be cleaned up after load failure; stat err = %v", statErr)
@@ -250,6 +252,64 @@ func TestRestartAutostartUnitDarwin(t *testing.T) {
 	want := []string{"launchctl", "kickstart", "-k", wantTarget}
 	if len(*calls) != 1 || strings.Join((*calls)[0], " ") != strings.Join(want, " ") {
 		t.Fatalf("unit commands = %v, want [%v]", *calls, want)
+	}
+}
+
+// TestAutostartLaunchdCallsShareOneDomain is the #1947 mechanism-3 repro:
+// every launchctl verb af issues must name the SAME launchd domain.
+//
+// InstallAutostart used the legacy `launchctl load`, which takes no domain and
+// bootstraps into the CALLING session's — user/<uid> over ssh, gui/<uid> from a
+// Terminal window — while RestartAutostartUnit has always kicked gui/<uid>
+// explicitly. When they disagree, the kickstart cannot find the job: the
+// post-upgrade restart silently no-ops, the stale daemon keeps serving the old
+// binary, and `af upgrade` prints success anyway. That is the macOS half of the
+// stale-daemon report, and #1920 independently found the same case.
+//
+// Asserting exact argv (rather than "contains gui/") is the point: a legacy
+// verb passes any domain-substring check by simply having no domain at all.
+func TestAutostartLaunchdCallsShareOneDomain(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	dir := withAutostartTestEnv(t, "darwin")
+	stubAutostartStopDaemon(t, true, nil)
+	calls := stubAutostartUnitCommand(t, nil)
+	plist := filepath.Join(dir, autostartLaunchdLabel+".plist")
+
+	if _, err := InstallAutostart(); err != nil {
+		t.Fatalf("InstallAutostart: %v", err)
+	}
+	if err := RestartAutostartUnit(); err != nil {
+		t.Fatalf("RestartAutostartUnit: %v", err)
+	}
+	if err := PauseAutostartUnit(); err != nil {
+		t.Fatalf("PauseAutostartUnit: %v", err)
+	}
+	if err := ResumeAutostartUnit(); err != nil {
+		t.Fatalf("ResumeAutostartUnit: %v", err)
+	}
+	if _, err := UninstallAutostart(); err != nil {
+		t.Fatalf("UninstallAutostart: %v", err)
+	}
+
+	// Computed here rather than via the production helpers, so a change to
+	// those cannot silently redefine what this test is checking.
+	domain := fmt.Sprintf("gui/%d", os.Getuid())
+	target := domain + "/" + autostartLaunchdLabel
+	want := [][]string{
+		{"launchctl", "bootout", target},          // install: displace any previous agent
+		{"launchctl", "bootstrap", domain, plist}, // install
+		{"launchctl", "kickstart", "-k", target},  // restart
+		{"launchctl", "bootout", target},          // pause
+		{"launchctl", "bootstrap", domain, plist}, // resume
+		{"launchctl", "bootout", target},          // uninstall
+	}
+	if !reflect.DeepEqual(*calls, want) {
+		t.Fatalf("launchctl calls must all target %s.\n got=%v\nwant=%v", domain, *calls, want)
+	}
+	for _, c := range *calls {
+		if len(c) > 1 && (c[1] == "load" || c[1] == "unload") {
+			t.Fatalf("launchctl %s takes no domain and lands in the caller's session domain, which kickstart gui/<uid> may never see: %v", c[1], c)
+		}
 	}
 }
 
@@ -359,7 +419,7 @@ func TestUninstallAutostartDarwin(t *testing.T) {
 	if _, statErr := os.Stat(plistPath); !os.IsNotExist(statErr) {
 		t.Fatalf("plist should be gone after uninstall; stat err = %v", statErr)
 	}
-	if !calledWith(*calls, "launchctl", "unload", plistPath) {
-		t.Fatalf("uninstall did not unload the agent; calls = %v", *calls)
+	if !calledWith(*calls, "launchctl", "bootout", launchdServiceTarget()) {
+		t.Fatalf("uninstall did not boot the agent out; calls = %v", *calls)
 	}
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1673,6 +1673,12 @@ than the running binary — which happens when you switch from the preview
 channel back to stable — the upgrade is a no-op with an explanation. Pass
 --allow-downgrade to install the older release anyway.
 
+af upgrade restarts the running daemon after the swap, and always has: the
+daemon keeps executing the old code until something restarts it, so a fix that
+does not reach it is not really installed. Live sessions survive — they run in
+tmux and the new daemon re-adopts them. Pass --no-restart to leave the daemon
+on the old binary until you restart it yourself with 'af daemon restart'.
+
 ```
 af upgrade [flags]
 ```
@@ -1682,6 +1688,7 @@ af upgrade [flags]
 | Flag | Type | Description |
 |------|------|-------------|
 | `--allow-downgrade` |  | Install the channel's latest release even if it is older than the current binary (e.g. switching from preview back to stable) |
+| `--no-restart` |  | Leave the running daemon alone (af upgrade restarts it by default so the new binary takes effect) |
 
 **Global flags**
 


### PR DESCRIPTION
## The premise of #1947 is wrong, and this PR fixes what is actually broken

**`af upgrade` already restarts the daemon, and has since #498/#1386.** `runUpgrade` calls `restartDaemonFromPath(resolvedPath)` unconditionally right after the binary swap (`commands/upgrade.go:235`), and the on-launch auto-update does the same (`commands/autoupdate.go:177`). Both `v1.0.192` and `v1.0.195` contain the call, so it was live on the affected machine the whole time, and `TestUpgradeCallsShutdownAfterBinarySwap` already locked it. I verified this against the code before implementing, and recorded it in [a correction comment](https://github.com/sachiniyer/agent-factory/issues/1947#issuecomment-5000801197).

So "restart the daemon by default" was already true. **The bug is that the restart runs, fails to land, and reports success.** A stale v1.0.192 daemon under a v1.0.195 client means the restart happened and didn't stick. That is what this PR fixes.

## The three mechanisms, and what closes each

**1 — The autostart unit relaunches a *different* binary.** `InstallAutostart` bakes `os.Executable()` into the unit at install time; `af upgrade` overwrites the *currently running* resolved path. With two installs on one box (Homebrew `/opt/homebrew/bin/af` vs `~/.local/bin/af`), the restart faithfully brings the **old** binary back up. The most likely cause on a Mac.

→ Closed by **deliverable 3**. New `daemon.AutostartUnitExecPath` reads the unit's baked program path; when it isn't the binary the upgrade just wrote, `af upgrade` says so on stderr and names `af daemon install` as the fix. Detection, not silent repair: re-pointing someone's unit is not a thing an upgrade should do behind their back.

**2 — Silent success on a false "no daemon".** `RequestShutdown` returns `(ShutdownNoDaemon, nil)` for a missing *or unreachable* socket, so "nothing was running" and "a daemon is running that we cannot reach" arrived identically, and the `default:` branch printed a bare `Upgraded successfully!` over both.

→ Closed by **deliverable 3**. The no-daemon path now consults the existing read-only `daemon.Health()` probe: `PIDVerified` means a real af daemon is alive despite the silent socket, and that goes to stderr with its pid. When there genuinely is no daemon it stays quiet — that is the common case (fresh installs, CI) and must not become a false alarm.

**3 — The darwin launchd domain mismatch.** `InstallAutostart` used legacy `launchctl load` (`autostart.go:225`); `RestartAutostartUnit` uses modern `kickstart -k gui/<uid>/<label>` (`autostart.go:436`). Legacy `load` takes no domain and bootstraps into the *calling session's* — `user/<uid>` over ssh, `gui/<uid>` from a Terminal window — so the kickstart can target a job that isn't there. #1920 independently found this same case.

→ Closed by **deliverable 2** (below).

**Common thread: every one of these reported success.** A restart that silently didn't happen is the whole bug.

## Deliverable 1 — home-gate the unit restart (folds in #1950)

`respawnDaemonAfterUpgrade` restarted whatever unit *existed*, without checking it serves **this** AF home, and returned on success — skipping the ad-hoc fallback. So `AGENT_FACTORY_HOME=/tmp/sandbox af upgrade` stopped the sandbox's daemon, bounced the developer's real one, and left the sandbox with no daemon at all.

Now gated on the existing `daemon.AutostartUnitServesHome(configDir)` from #1919, behind a new `autostartUnitServesHomeFn` indirection (shared with `reset.go`). The gate is **proof, not permission**: an unreadable unit or an unresolvable config dir also falls through to the ad-hoc spawn, because restarting a unit we can't prove is ours is a coin flip on someone else's daemon.

**The sweep** (#1950 asked for the class, not the instance — "an invariant enforced at one call site is not an invariant"). Every `AutostartInstalled`/`autostartInstalledFn` gate in prod code:

| Call site | Verdict |
|---|---|
| `commands/daemoncmd.go` respawn | **Fixed here.** Was the ungated one. |
| `commands/reset.go:340/344` | Already correct (#1919): existence is a cheap pre-check, `AutostartUnitServesHome` is the real gate. |
| `daemon/health.go:49` | **Excluded, justified.** It *reports* ("autostart: installed") rather than operating on the unit. "Is a unit installed on this machine" is the question it prints the answer to. What status should report about a foreign-home unit is a separate product question. |

`af daemon restart` shares this respawn path and picks up the same fix for free — it was the adjacent instance of the identical defect.

## Deliverable 2 — the darwin domain decision: modern verbs, one domain

**Decision: move install/pause/resume/uninstall onto the modern `bootstrap`/`bootout`, all explicitly targeting `gui/<uid>` — i.e. make everything agree with `kickstart`, rather than dragging the restart back to legacy.** Reasons:

1. **Only the modern verbs can agree.** The legacy verbs take *no* domain argument — they land wherever the caller happens to be. There is no version of `load` that reliably agrees with anything; the mismatch is structural, not a typo. The direction of agreement is forced.
2. **The domain becomes impossible to drift again.** `launchdGUIDomain()`/`launchdServiceTarget()` are single helpers every call site shares.
3. **Failure moves to the loud end.** Bootstrapping into `gui/<uid>` needs a GUI login session; without one, `bootstrap` fails *at install time*, and #974's cleanup already removes the unit file on a failed install. That is strictly better than legacy's succeed-now, silently-no-op-at-restart-forever — which is the entire bug being fixed.
4. Apple deprecated `load`/`unload`.

Every `launchctl` call site audited:

| Site | Was | Now |
|---|---|---|
| `InstallAutostart` pre-clean | `unload <plist>` | `bootout gui/<uid>/<label>` |
| `InstallAutostart` load | `load <plist>` | `bootstrap gui/<uid> <plist>` |
| `RestartAutostartUnit` | `kickstart -k gui/<uid>/<label>` | unchanged (now via the shared helper) |
| `PauseAutostartUnit` | `unload <plist>` | `bootout gui/<uid>/<label>` |
| `ResumeAutostartUnit` | `load <plist>` | `bootstrap gui/<uid> <plist>` |
| `UninstallAutostart` | `unload <plist>` | `bootout gui/<uid>/<label>` |
| `daemon/legacy_units.go:115` | `unload <plist>` | **Excluded, justified** ↓ |

**The `legacy_units.go` exclusion.** That sweep removes *pre-#782 per-task* agents (`com.agent-factory.task-*.plist`) that old af versions bootstrapped via legacy `load`, into whatever domain that version's install ran in. They are not part of the install/restart domain-agreement invariant — af never restarts them, it deletes them, and **removing the plist is what actually makes the removal stick** across reboots. Targeting `bootout gui/<uid>` would name a domain those units may never have been in, turning a currently-succeeding unload into a failure on a path that has been quiet since #782. The unload is already best-effort and logged.

**One behavior change worth naming:** `bootout` on a job that is not loaded fails, where `unload` often didn't. This only affects `PauseAutostartUnit`, whose only caller (`af reset`) treats a pause failure as a warning. And it is cosmetic where it is possible at all: bootout failing implies the job isn't loaded, which means there is no daemon to relaunch mid-wipe — the exact race the pause exists to prevent can't occur.

## Deliverable 3 — never report success when the restart didn't land

`runUpgrade` now distinguishes **"no daemon was running"** (fine, quiet, plain `Upgraded successfully!`) from **"a daemon is running but we couldn't reach/stop it"** (loud, on stderr, with the recovery command). The two degraded-but-successful respawns — demoted to an ad-hoc daemon after a failed unit restart, and a unit that relaunched the wrong binary — were **log-only warnings printed underneath "Restarted the running daemon from the new binary"**; they now reach the user. `ShutdownFailed`/`ShutdownError` (#553/#978) already carried an error but printed it to *stdout* prefixed with "Upgraded successfully!"; that moves to stderr.

`runUpgrade` takes explicit `out`/`errOut` writers, which also let the SIGTERM test drop its `os.Stdout`-swapping pipe.

## Deliverable 4 — `--no-restart`

The opt-out for behavior that already exists. Default stays restart — a fix that never reaches the daemon isn't shipped. `--help` and the long help say exactly that rather than implying the restart is new. Docs regenerated via `scripts/gen-docs.sh`.

## Deliberately unchanged

- **The on-launch auto-update restart stays.** `commands/autoupdate.go` is untouched. It has shipped for many releases without a reported incident, and removing it on a premise I disproved would be a regression for no reason. (It *does* pick up the home gate through the shared respawn path — that is #1950's own scope, which names the auto-update path in its title, and it makes the restart correct rather than removing it.)
- **No proactive skew warning.** Deferred to a follow-up on #1920, which owns `PingResponse.Version`/`daemon.SetVersion`. Adding a second version source to race it is exactly the wrong move. #1921's reactive `apiclient/skew.go` is already on master and untouched.
- **`af daemon restart` still prints "daemon restarted" on a demotion to ad-hoc.** Same silent-demotion class, one command over; out of scope here and its `--quiet` contract is parsed by the install scripts. Noting it rather than smuggling it in.

## Gates

| Gate | Result |
|---|---|
| `make test-container` | ✅ green, all 33 packages (incl. `daemon` 128s, `app` 79s, `integration` 46s) |
| `go build ./...` | ✅ |
| `gofmt -l .` | ✅ no output |
| `golangci-lint run --timeout=3m --fast` | ✅ no output |
| `deadcode -test ./...` | ✅ no output |
| `scripts/lint-file-length.sh` | ✅ 663 files, 0 grandfathered |
| `scripts/gen-docs.sh` | ✅ `docs/reference/cli.md` regenerated (upgrade help + `--no-restart`) |

Nothing in this PR ran against the real daemon: every test drives the existing injection points (`requestDaemonShutdownFn`, `respawnDaemonFn`, `autostartUnitServesHomeFn`, `ensureDaemonFromPathFn`, `waitForShutdownCompletionFn`, `daemonHealthFn`, `autostartGOOS`, `autostartUnitCommand`, …) as fakes. The daemon suite ran only inside `make test-container`.

## Tests: repros vs locks

**Repros** — each was watched failing against the broken code, by reverting that specific fix and confirming the test reproduces the *reported symptom*:

| Test | Reverted | Observed failure |
|---|---|---|
| `TestRespawnAfterUpgrade_LeavesOtherHomesUnitAlone` | home gate → existence check | `unit restarts = 1, want 0` — the other home's unit bounced, ad-hoc skipped (#1950's symptom) |
| `TestRespawnAfterUpgrade_UnprovableHomeLeavesUnitAlone` | same | `unit restarts = 1, want 0` on both unreadable-unit and unresolvable-configdir |
| `TestUpgrade_FailedUnitRestartIsLoud` | drop the `UnitErr` report | stderr empty; silent demotion under a success line |
| `TestUpgrade_StaleUnitBinaryIsLoud` | drop the `StaleUnitExec` report | stderr never names the other install |
| `TestUpgrade_NoDaemonButDaemonRunningIsNotUnqualifiedSuccess` | drop the health probe | `stdout="Upgraded successfully!\n"`, stderr empty — the exact reported symptom |
| `TestUpgrade_UnreachableDaemonIsLoud` | restore the stdout printf | `stderr missing "dial timeout"; got=""` |
| `TestUpgrade_NoRestartSkipsRestart` | drop the `noRestart` branch | `shutdown calls = 1, want 0` |
| `TestAutostartLaunchdCallsShareOneDomain` | install → legacy `load`/`unload` | `got=[launchctl load <plist>] [launchctl kickstart -k gui/1000/…]` vs `want=[bootstrap gui/1000 <plist>] [kickstart -k gui/1000/…]` — the mismatch, printed |

All of these go through the prod entry point: the `TestUpgrade_*` cases drive **`runUpgrade`** with only leaf collaborators stubbed, so the real `restartDaemonFromPathDetailed` → `respawnDaemonAfterUpgrade` → gate chain runs. `TestAutostartLaunchdCallsShareOneDomain` calls the real `InstallAutostart`/`RestartAutostartUnit`/`Pause`/`Resume`/`Uninstall` and asserts **exact argv** — deliberately, because a legacy verb passes any "contains `gui/`" check by having no domain at all.

**Locks** — these do not reproduce a bug; they pin behavior a plausible wrong fix would break:

- `TestRespawnAfterUpgrade_RestartsUnitServingThisHome` — "never restart the unit" would pass #1950. This costs that shortcut the #796 supervised restart.
- `TestUpgrade_DefaultRestarts` — the default this whole issue turns on.
- `TestUpgrade_NoRestartFlagRegistered` — the flag + default + the help text saying the restart is pre-existing. (Covers the one-line `RunE` wiring that reaches `runUpgrade`'s parameter, which the two tests above cover directly.)
- `TestUpgrade_UnitLaunchingTheUpgradedBinaryIsQuiet` / `TestUpgrade_NoDaemonIsQuietWhenTrulyNoDaemon` — the two new warnings must not fire on the ordinary path. A warning that cries wolf on every upgrade is one users stop reading.
- `TestAutostartUnitExecPathRoundTrip` / `TestAutostartUnitExecPath_StopsAtTheProgram` — pins the new parser to the renderer, mirroring `TestAutostartUnitHomeRoundTrip`. The escaping (`\`, `"`, `$$`, `%%`) and stopping before `--daemon` are exactly where a silent mismatch would come from.

Closes #1947. Closes #1950.

— Captain Claude
