### PR TITLE
fix(tmux): deliver prompts as a bracketed paste for every agent — a plain paste is executed as vim commands (#1956)

### DIFF
--- a/session/tmux/submit.go
+++ b/session/tmux/submit.go
@@ -41,26 +41,40 @@ func pasteBufferName(processToken, sanitizedName string, seq uint64) string {
 // SendKeysCommand sends text to the tmux pane using tmux commands instead of
 // writing to the PTY. This is more reliable for headless/scheduled runs where
 // the PTY connection may not persist. Text is loaded into a tmux paste buffer,
-// pasted into the pane, followed by a pause to let terminal control sequences
-// drain, then Enter to submit.
+// pasted into the pane as a BRACKETED paste, followed by a pause to let terminal
+// control sequences drain, then Enter to submit.
 //
-// Most panes receive a plain paste. Codex is the exception: its composer runs
-// paste-burst detection, so it needs explicit bracketed-paste boundaries before
-// the following Enter is unambiguously a submit (#1254/#1256). Submit handling
-// is keyed off the agent actually running in the pane (DetectAgentFromCommand),
-// mirroring HasUpdated's per-agent prompt heuristics, so a program_overrides
-// redirect can't misclassify the pane.
+// Every pane gets the bracketed paste — there is no per-agent exception list.
+// See sendKeysPasteBuffer for why that is both necessary and safe (#1956).
 func (t *TmuxSession) SendKeysCommand(text string) error {
-	return t.sendKeysPasteBuffer(text, DetectAgentFromCommand(t.programCmd()) == ProgramCodex)
+	return t.sendKeysPasteBuffer(text)
 }
 
-// sendKeysPasteBuffer delivers text to the pane through a tmux paste buffer
-// (`load-buffer` + `paste-buffer`) and then sends Enter to submit. This avoids
-// the literal `send-keys -l` text path whose per-character delivery can leave a
-// duplicated wrapped prefix in bash/readline panes (#1292). Text is streamed via
-// stdin rather than an argv argument so arbitrarily large prompts are not
-// bounded by ARG_MAX.
-func (t *TmuxSession) sendKeysPasteBuffer(text string, bracketed bool) error {
+// sendKeysPasteBuffer delivers text to the pane through a BRACKETED tmux paste
+// buffer (`load-buffer` + `paste-buffer -p`) and then sends Enter to submit.
+// Text is streamed via stdin rather than an argv argument so arbitrarily large
+// prompts are not bounded by ARG_MAX.
+//
+// The paste MUST be bracketed (`-p`), for every pane. A plain paste is delivered
+// to the application as ordinary KEYSTROKES, indistinguishable from typing, so an
+// agent whose composer is modal executes the prompt as EDITOR COMMANDS instead of
+// inserting it as text (#1956). With claude's `editorMode: "vim"` the composer
+// rests in NORMAL mode, where a prompt beginning "status check…" loses its leading
+// `s` to the substitute command, and one beginning "deploy…" runs `d` as the delete
+// operator — the prompt mangles the box rather than filling it. Bracketing tells the
+// application the bytes are pasted data, not commands. It also stops every `\n` in a
+// multi-line prompt from acting as its own Enter, which submitted long prompts in
+// fragments.
+//
+// Unconditional is safe: tmux only emits the bracketed-paste markers when the
+// application has itself requested the mode (DECSET 2004), so `-p` is a literal
+// no-op for panes that never enabled it. Panes that DO enable it (bash/readline,
+// and the agent composers) are precisely the ones that must not be typed at.
+// Codex reached this path first for a different reason — its paste-burst detection
+// needs an explicit end-of-paste marker before the trailing Enter counts as a
+// submit (#1254/#1256) — and keeps working unchanged; it was never special, it was
+// just the only agent whose breakage was loud enough to notice.
+func (t *TmuxSession) sendKeysPasteBuffer(text string) error {
 	// A per-call unique buffer name: two concurrent deliveries to the same
 	// session must not share a buffer, or one call's load-buffer could overwrite
 	// the other's content between its load and paste and corrupt the submit. The
@@ -75,20 +89,11 @@ func (t *TmuxSession) sendKeysPasteBuffer(text string, bracketed bool) error {
 		return fmt.Errorf("error loading paste buffer: %w", err)
 	}
 
-	// `-d` deletes the buffer after pasting, `=` forces an exact session match
-	// so input never reaches a prefix-matched sibling session (#1006).
-	//
-	// Codex additionally needs `-p`: tmux inserts bracketed-paste markers (when
-	// the app requested the mode), giving codex an end-of-paste marker so the
-	// following Enter submits instead of being swallowed by paste-burst
-	// detection (#1254/#1256). Other panes intentionally use a plain paste to
-	// preserve their pre-existing raw-input newline behavior while still
-	// avoiding the wrapped-prefix redraw issue (#1292).
-	args := []string{"paste-buffer", "-d"}
-	if bracketed {
-		args = append(args, "-p")
-	}
-	args = append(args, "-b", buf, "-t", exactTarget(t.sanitizedName))
+	// `-d` deletes the buffer after pasting, `-p` brackets it (see the doc
+	// comment: prompts are pasted DATA, never keystrokes), and `=` forces an
+	// exact session match so input never reaches a prefix-matched sibling
+	// session (#1006).
+	args := []string{"paste-buffer", "-d", "-p", "-b", buf, "-t", exactTarget(t.sanitizedName)}
 	pasteCmd := exec.Command("tmux", args...)
 	if err := t.cmdExec.Run(pasteCmd); err != nil {
 		// `-d` only deletes the buffer once the paste succeeds; a failed paste
@@ -104,6 +109,14 @@ func (t *TmuxSession) sendKeysPasteBuffer(text string, bracketed bool) error {
 
 	// Wait for terminal control sequences (e.g. OSC color responses) and the
 	// paste to drain before sending Enter, otherwise they can corrupt the input.
+	//
+	// Bracketing (above) may make this unnecessary for apps that requested the
+	// mode: the `\x1b[201~` end-of-paste marker tells them the paste is complete,
+	// which is the whole reason codex needed `-p` rather than a longer sleep
+	// (#1254/#1256). It cannot go away unconditionally, though — `-p` is a no-op
+	// for apps that never enabled the mode, and those get no marker and still
+	// need the drain. Removing it is a separate change with its own evidence;
+	// left alone here deliberately (#1956 follow-up).
 	time.Sleep(500 * time.Millisecond)
 
 	// Send Enter separately to submit.

--- a/session/tmux/submit_bracketed_test.go
+++ b/session/tmux/submit_bracketed_test.go
@@ -1,0 +1,148 @@
+package tmux
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+)
+
+// receiverProgram builds a pane program that stands in for an agent composer at
+// the only level that matters here: it requests bracketed-paste mode (DECSET
+// 2004) exactly as claude/codex do, and records the RAW bytes the pane actually
+// delivers to it. `stty raw -echo` keeps the tty from line-buffering or echoing,
+// so the capture is byte-for-byte what the application's stdin saw.
+//
+// Only sh/stty/cat are used — all present in the toolchain image — so this test
+// never skips in CI for want of an agent binary.
+func receiverProgram(outPath string) string {
+	return fmt.Sprintf(`sh -c 'stty raw -echo; printf "\033[?2004h"; cat > %s'`, outPath)
+}
+
+// startReceiverPane brings up a real tmux session running the receiver and
+// returns it plus the path its captured bytes land in.
+func startReceiverPane(t *testing.T, name string) (*TmuxSession, string) {
+	t.Helper()
+	testguard.IsolateTmux(t)
+
+	dir := t.TempDir()
+	out := filepath.Join(dir, "received.bin")
+	ts := NewTmuxSession(name, receiverProgram(out))
+	require.NoError(t, ts.Start(dir))
+	t.Cleanup(func() { _ = ts.Close() })
+
+	// Let the pane program reach its read loop and emit ?2004h before pasting;
+	// a paste that lands before the app requests the mode would legitimately
+	// arrive unbracketed and make this test lie.
+	waitFor(t, func() bool {
+		content, err := ts.CapturePaneContent()
+		return err == nil && content != ""
+	}, "receiver pane did not start")
+	time.Sleep(300 * time.Millisecond)
+	return ts, out
+}
+
+func waitFor(t *testing.T, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatal(msg)
+}
+
+// readReceived polls until the receiver has flushed the delivery, then returns
+// the raw bytes it got.
+func readReceived(t *testing.T, path string, want string) string {
+	t.Helper()
+	var got string
+	waitFor(t, func() bool {
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return false
+		}
+		got = string(b)
+		return strings.Contains(got, want)
+	}, fmt.Sprintf("receiver never saw %q; got %q", want, got))
+	return got
+}
+
+// TestSendKeysCommandDeliversPromptAsPasteNotKeystrokes is the #1956 regression
+// gate, and it asserts on what the AGENT RECEIVED rather than on the argv we
+// built. That distinction is the whole point: the pre-fix code sent its paste
+// successfully every time, so every test that asserted the send passed while the
+// bug was live and corrupting real dispatches.
+//
+// A plain (unbracketed) tmux paste reaches the application as ordinary
+// KEYSTROKES, indistinguishable from typing. An agent whose composer is modal —
+// claude with `editorMode: "vim"`, which rests in NORMAL mode — then EXECUTES the
+// prompt as editor commands instead of inserting it: "sentinel-alpha" loses its
+// leading `s` to the substitute command and arrives as "entinel-alpha", and a
+// prompt starting "deploy…" runs `d` as the delete operator. Verified against
+// real vim: plain paste → "entinel-alpha", bracketed paste → "sentinel-alpha".
+//
+// The invariant that prevents all of it is that the pane receives the prompt
+// wrapped in bracketed-paste markers — i.e. tagged as DATA, not commands. That is
+// what this asserts, for every agent, with no exception list.
+func TestSendKeysCommandDeliversPromptAsPasteNotKeystrokes(t *testing.T) {
+	// The leading rune of each prompt is a destructive vim NORMAL-mode command:
+	// s substitutes, d deletes, x deletes a char, : opens the command line, u
+	// undoes. These are the prompts that mangle a live agent's composer today.
+	for _, prompt := range []string{
+		"sentinel-alpha",
+		"deploy the fix",
+		"x marks the spot",
+		":wq is not a prompt",
+		"undraft it and merge once Build is green",
+	} {
+		t.Run(prompt, func(t *testing.T) {
+			ts, out := startReceiverPane(t, "af_submit_1956")
+			require.NoError(t, ts.SendKeysCommand(prompt))
+
+			got := readReceived(t, out, prompt)
+
+			require.Contains(t, got, "\x1b[200~"+prompt+"\x1b[201~",
+				"prompt must reach the pane BRACKETED (as pasted data). Received %q — "+
+					"unbracketed means the agent gets it as keystrokes, and a modal "+
+					"composer executes the leading character as a command (#1956)", got)
+		})
+	}
+}
+
+// TestSendKeysCommandBracketsForEveryAgent pins the no-exception-list rule from
+// #1956: bracketing is not a codex special case (#1254/#1256), it is how every
+// prompt is delivered. A per-agent conditional here is what let claude regress
+// silently for months while codex was fine, so an agent added later must not be
+// able to opt out by omission.
+func TestSendKeysCommandBracketsForEveryAgent(t *testing.T) {
+	for _, program := range []string{
+		"claude", "codex", "aider", "gemini", "amp",
+		"bash",                 // program_overrides / __shell panes
+		"/home/foo/bin/claude", // legacy free-form persisted Program (#677)
+	} {
+		t.Run(program, func(t *testing.T) {
+			cmds := recordTmuxCommands(t, program, "sentinel-alpha")
+
+			var pasted bool
+			for _, c := range cmds {
+				if len(c.args) > 1 && c.args[1] == "paste-buffer" {
+					pasted = true
+					require.True(t, hasArg(c.args, "-p"),
+						"%s: paste-buffer must carry -p; a plain paste is delivered as "+
+							"keystrokes and a modal composer executes them (#1956). argv: %v",
+						program, c.args)
+				}
+			}
+			require.True(t, pasted, "%s: expected a paste-buffer delivery, got %v", program, joinedArgs(cmds))
+		})
+	}
+}

--- a/session/tmux/submit_bracketed_test.go
+++ b/session/tmux/submit_bracketed_test.go
@@ -13,16 +13,30 @@ import (
 	"github.com/sachiniyer/agent-factory/internal/testguard"
 )
 
+// receiverReadyMarker is printed by the receiver AFTER it has put the tty in raw
+// mode and emitted DECSET 2004. Seeing it on the pane is proof from the receiver
+// itself that both happened — and, because tmux renders the pane in order, proof
+// that tmux PROCESSED the DECSET before the marker. That is exactly the
+// precondition a bracketed paste depends on, so it is the only sound thing to
+// wait for.
+const receiverReadyMarker = "AF-RECEIVER-READY"
+
 // receiverProgram builds a pane program that stands in for an agent composer at
 // the only level that matters here: it requests bracketed-paste mode (DECSET
-// 2004) exactly as claude/codex do, and records the RAW bytes the pane actually
-// delivers to it. `stty raw -echo` keeps the tty from line-buffering or echoing,
-// so the capture is byte-for-byte what the application's stdin saw.
+// 2004) exactly as claude/codex/aider/gemini/amp/opencode do, and records the RAW
+// bytes the pane actually delivers to it. `stty raw -echo` keeps the tty from
+// line-buffering or echoing, so the capture is byte-for-byte what the
+// application's stdin saw.
+//
+// The order is load-bearing: raw mode, then the DECSET, then the marker. A test
+// that pastes before the DECSET lands would get an unbracketed paste for a
+// legitimate reason and blame the code under test.
 //
 // Only sh/stty/cat are used — all present in the toolchain image — so this test
 // never skips in CI for want of an agent binary.
 func receiverProgram(outPath string) string {
-	return fmt.Sprintf(`sh -c 'stty raw -echo; printf "\033[?2004h"; cat > %s'`, outPath)
+	return fmt.Sprintf(`sh -c 'stty raw -echo; printf "\033[?2004h%s\r\n"; cat > %s'`,
+		receiverReadyMarker, outPath)
 }
 
 // startReceiverPane brings up a real tmux session running the receiver and
@@ -37,14 +51,28 @@ func startReceiverPane(t *testing.T, name string) (*TmuxSession, string) {
 	require.NoError(t, ts.Start(dir))
 	t.Cleanup(func() { _ = ts.Close() })
 
-	// Let the pane program reach its read loop and emit ?2004h before pasting;
-	// a paste that lands before the app requests the mode would legitimately
-	// arrive unbracketed and make this test lie.
+	// Wait for the marker the RECEIVER prints, never for the pane merely being
+	// non-empty. `capture-pane` on a completely blank pane returns one newline per
+	// row — 24 bytes of "\n" for a 24-row pane — so a `content != ""` check is true
+	// the instant tmux has a pane at all, before the receiver has run a single
+	// line. That check plus a fixed sleep is a race that passes locally and flakes
+	// in CI, and a flake HERE reads as "the paste logic is broken" and sends the
+	// next person hunting the wrong thing.
+	//
+	// It is also the very mistake this file exists to catch, one level up: the bug
+	// under test is af sending input before establishing that the receiver would
+	// take it as text. Waiting on a signal only a live receiver can emit is the
+	// structural fix; "the buffer is not empty" is an artifact of tmux, not a fact
+	// about the receiver.
+	//
+	// The marker proves raw mode is set and the DECSET is processed. `cat` may not
+	// have been exec'd yet at that instant, which is harmless: the tty input queue
+	// holds the pasted bytes until it starts reading. Nothing is lost, and the
+	// bracketing decision — the thing under test — is already settled.
 	waitFor(t, func() bool {
 		content, err := ts.CapturePaneContent()
-		return err == nil && content != ""
-	}, "receiver pane did not start")
-	time.Sleep(300 * time.Millisecond)
+		return err == nil && strings.Contains(content, receiverReadyMarker)
+	}, "receiver never printed "+receiverReadyMarker+": the pane program did not start")
 	return ts, out
 }
 

--- a/session/tmux/submit_bracketed_test.go
+++ b/session/tmux/submit_bracketed_test.go
@@ -3,6 +3,7 @@ package tmux
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -32,11 +33,23 @@ const receiverReadyMarker = "AF-RECEIVER-READY"
 // that pastes before the DECSET lands would get an unbracketed paste for a
 // legitimate reason and blame the code under test.
 //
-// Only sh/stty/cat are used — all present in the toolchain image — so this test
-// never skips in CI for want of an agent binary.
+// outPath is shell-quoted (shellQuoteArg, the package's existing POSIX quoter):
+// t.TempDir() inherits TMPDIR, so the path can hold a space or a metacharacter
+// even though Go sanitizes the subtest name out of it. Unquoted, `cat > /tmp/af
+// space dir/received.bin` redirects to `/tmp/af` — the fixture breaks, and it
+// breaks as "the submit test failed", sending the reader after the paste logic
+// instead of the harness (#1978 class).
+//
+// tmux runs the command string through a shell itself, so there is deliberately
+// no `sh -c '…'` wrapper here: that second level of quoting is what would make a
+// correctly-quoted path unquotable (its single quotes would close the wrapper's).
+// One shell, one level of quoting, one correct answer.
+//
+// Only stty/printf/cat are used — all present in the toolchain image — so this
+// test never skips in CI for want of an agent binary.
 func receiverProgram(outPath string) string {
-	return fmt.Sprintf(`sh -c 'stty raw -echo; printf "\033[?2004h%s\r\n"; cat > %s'`,
-		receiverReadyMarker, outPath)
+	return fmt.Sprintf(`stty raw -echo; printf "\033[?2004h%s\r\n"; cat > %s`,
+		receiverReadyMarker, shellQuoteArg(outPath))
 }
 
 // startReceiverPane brings up a real tmux session running the receiver and
@@ -102,6 +115,40 @@ func readReceived(t *testing.T, path string, want string) string {
 		return strings.Contains(got, want)
 	}, fmt.Sprintf("receiver never saw %q; got %q", want, got))
 	return got
+}
+
+// TestReceiverProgramQuotesOutputPath keeps the fixture honest about its own
+// input. t.TempDir() inherits TMPDIR, so the receiver's output path can contain a
+// space or a shell metacharacter on a perfectly ordinary machine. Unquoted, the
+// redirect splits and the fixture dies — reported as "the submit test failed",
+// which sends the reader hunting the paste logic instead of the harness.
+//
+// That failure mode is this PR's own headline finding in miniature: a test whose
+// breakage teaches people to distrust the test rather than the code. The submit
+// path's test must not be the least reliable thing on the submit path (#1978 class).
+func TestReceiverProgramQuotesOutputPath(t *testing.T) {
+	for _, path := range []string{
+		"/tmp/af space dir/received.bin",
+		"/tmp/semi;colon/received.bin",
+		"/tmp/it's/received.bin",
+		"/tmp/dollar$VAR/received.bin",
+	} {
+		t.Run(path, func(t *testing.T) {
+			prog := receiverProgram(path)
+			// The redirect target must survive as ONE shell word. Round-trip it
+			// through a real shell rather than asserting on the string: `sh -c`
+			// echoing the quoted arg answers the only question that matters —
+			// what the shell resolves it to.
+			out, err := exec.Command("sh", "-c", "printf %s "+shellQuoteArg(path)).Output()
+			require.NoError(t, err)
+			require.Equal(t, path, string(out),
+				"shell must resolve the quoted path back to exactly one intact word")
+			require.Contains(t, prog, shellQuoteArg(path),
+				"receiver program must embed the QUOTED path, never the raw one")
+			require.NotContains(t, prog, "cat > "+path,
+				"receiver program must not splice the raw path into the redirect")
+		})
+	}
 }
 
 // TestSendKeysCommandDeliversPromptAsPasteNotKeystrokes is the #1956 regression

--- a/session/tmux/submit_test.go
+++ b/session/tmux/submit_test.go
@@ -115,33 +115,40 @@ func TestCodexSubmitUsesBracketedPaste(t *testing.T) {
 	}
 }
 
-// TestNonCodexSubmitUsesPlainPasteBuffer guards against regressing the agents
-// that do not need bracketed-paste submit semantics
-// (claude/aider/gemini/amp and unknown/override panes): they use tmux's plain
-// paste-buffer path plus Enter.
-// This keeps codex's #1256 bracketed-paste behavior scoped to codex while
-// avoiding the literal `send-keys -l` wrapped-redraw issue seen in bash-backed
-// sessions (#1292).
-func TestNonCodexSubmitUsesPlainPasteBuffer(t *testing.T) {
+// TestEveryAgentSubmitUsesBracketedPasteBuffer guards the delivery shape shared
+// by every pane: load-buffer (payload on stdin) → bracketed paste-buffer → a
+// separate Enter to submit.
+//
+// This test used to be TestNonCodexSubmitUsesPlainPasteBuffer and asserted the
+// OPPOSITE — that claude/aider/gemini/amp/overrides must NOT get `-p`. It passed
+// continuously while #1956 corrupted real dispatches, because a plain paste is
+// delivered to the pane as KEYSTROKES: a claude composer in vim NORMAL mode
+// (`editorMode: "vim"`) executed each prompt's leading character as an editor
+// command instead of inserting it. The assertion was inverted, not merely
+// incomplete, so it is replaced rather than relaxed. See
+// submit_bracketed_test.go for the gate that asserts what the pane RECEIVES —
+// the property this argv-level test cannot see (#1956).
+func TestEveryAgentSubmitUsesBracketedPasteBuffer(t *testing.T) {
 	for _, program := range []string{"claude", "aider", "gemini", "amp", "some-custom-shell"} {
 		t.Run(program, func(t *testing.T) {
 			const prompt = "hello"
 			cmds := recordTmuxCommands(t, program, prompt)
 			joined := joinedArgs(cmds)
 
-			require.Len(t, cmds, 3, "plain paste path is load-buffer, paste-buffer, send-keys Enter; got %v", joined)
+			require.Len(t, cmds, 3, "paste path is load-buffer, paste-buffer, send-keys Enter; got %v", joined)
 			require.Contains(t, joined[0], "load-buffer", "first command must load the paste buffer; got %v", joined)
 			require.Equal(t, prompt, cmds[0].stdin, "paste text must be streamed on stdin")
 			require.Contains(t, joined[1], "paste-buffer", "second command must paste the buffer; got %v", joined)
 			require.Contains(t, joined[1], "-d", "paste must delete the buffer afterward (-d)")
-			require.False(t, hasArg(cmds[1].args, "-p"),
-				"non-codex panes must use plain paste, not bracketed paste; got %v", joined)
+			require.True(t, hasArg(cmds[1].args, "-p"),
+				"every pane must receive a BRACKETED paste: a plain paste arrives as keystrokes "+
+					"and a modal composer executes it as commands (#1956); got %v", joined)
 			require.Contains(t, joined[2], "send-keys", "last command must send Enter; got %v", joined)
 			require.Contains(t, joined[2], "Enter", "last command must submit with Enter; got %v", joined)
 
 			for _, j := range joined {
 				require.NotContains(t, j, "send-keys -t =af_proj: -l",
-					"non-codex must not use the literal send-keys path that redraws wrapped bash input (#1292); got %v", joined)
+					"no pane may use the literal send-keys path that redraws wrapped bash input (#1292); got %v", joined)
 			}
 
 			loadBuf, pasteBuf := bufferOf(cmds[0].args), bufferOf(cmds[1].args)
@@ -151,7 +158,7 @@ func TestNonCodexSubmitUsesPlainPasteBuffer(t *testing.T) {
 			for _, c := range cmds {
 				if tgt := targetOf(c.args); tgt != "" {
 					require.Equal(t, "=af_proj:", tgt,
-						"plain paste submit commands must target by exact match (#1006); got %q in %v", tgt, joined)
+						"submit commands must target by exact match (#1006); got %q in %v", tgt, joined)
 				}
 			}
 		})


### PR DESCRIPTION
Fixes #1956.

**Retitled from the symptom to the root cause:** *af delivers prompts as keystrokes, so a vim-mode agent executes them as commands.*

> ## The most instructive thing in this change
>
> **`TestNonCodexSubmitUsesPlainPasteBuffer` asserted the bug — and passed continuously while every prompt to every claude session was being corrupted.**
>
> It required that non-codex panes must **not** get `-p`. That is the defect, written down as an invariant and guarded by CI. It could never have caught this, because it asserted **what af sent**, and the send always succeeded. The bug lived entirely in **what the pane received**.
>
> The assertion was *inverted, not incomplete*, so it is **replaced, not relaxed** — and the new gate asserts received bytes on a real tmux server. If you read one thing here, read this: a test can be the reason a bug survives.


## Root cause

`submit.go:54` passed `-p` (bracketed paste) **only for codex**. Every other agent got a plain paste — and tmux delivers a plain paste to the application as ordinary **keystrokes**, indistinguishable from typing. An agent whose composer is modal therefore **executes the prompt as editor commands**.

Sachin's `~/.claude/settings.json` sets `"editorMode": "vim"` (verified), so his claude composers rest in NORMAL mode.

Codex was never special. #1254/#1256 gave it `-p` for an unrelated reason (paste-burst detection needs an end-of-paste marker before the trailing Enter counts as a submit). It was simply the only agent whose breakage was loud enough to notice. **The per-agent conditional is deleted, not extended.**

## Independent verification (real vim, not a mock)

| paste | vim buffer received |
|---|---|
| plain `sentinel-alpha` | `entinel-alpha` — `s` ran as **substitute** |
| `-p` `sentinel-alpha` | `sentinel-alpha` |
| plain `deploy the fix` | `\|\|y the fix` — `d` ran as the **delete operator**, `o` opened lines |
| `-p` `deploy the fix` | `deploy the fix` |

Reproduces the reported live-pane A/B character for character.

## Why unconditional is safe (measured, not assumed)

| app requested `?2004h` | paste | bytes the app received |
|---|---|---|
| no | plain | `sentinel-alpha` |
| no | **`-p`** | `sentinel-alpha` — **genuine no-op** |
| yes | plain | `sentinel-alpha` — **no markers: arrives as keystrokes** |
| yes | **`-p`** | `\x1b[200~sentinel-alpha\x1b[201~` |

Verified across `extended-keys` off/on/always and kitty flags 0/1/15.

## Per-agent table (requested for #1959 coordination)

Captured with `tmux pipe-pane` on each agent's real startup negotiation; **no prompt was sent to any agent**.

| agent | requests bracketed paste? | `-p` effect |
|---|---|---|
| claude | **yes** | fixes the vim-mode corruption |
| codex | **yes** | unchanged (already `-p` since #1256) |
| aider | **yes** | markers now emitted |
| gemini | **yes** | markers now emitted |
| amp | **yes** | markers now emitted |
| **opencode** (#1959) | **yes** | markers now emitted |

**Exception list: EMPTY.** Note the honest caveat: because all six request the mode, `-p` is *not* a no-op for any of them — the "no-op" argument covers only future/override panes. bash was checked directly (`enable-bracketed-paste on`): a multi-line payload runs the same commands with the same output either way, `-p` merely inserts one clean block instead of streaming keystrokes through readline — which aligns with #1292 rather than fighting it.

**⚠️ opencode row is verification-by-negotiation, not by submit.** Per the coordination note, #1959 merges first; I'll rebase and ask that session to re-run its submit replay against the bracketed path. Requesting the mode does not prove correct handling of it — see the readline finding below.

## `-p` is not automatically safe just because an app requests the mode

bash's readline **requests** bracketed paste but **mishandles the markers in vi NORMAL mode**:

```
plain -> entinel-alpha     (broken)
-p    -> entinel-alphA     (still broken, differently)
```

readline binds bracketed-paste only in its insert keymap. Real vim handles `-p` correctly. This is why the per-agent table matters and why I did not use bash's vi mode as the test fixture — it would have produced a test that **fails against the correct fix**.

## The test that guarded the bug

`TestNonCodexSubmitUsesPlainPasteBuffer` asserted non-codex panes **must not** get `-p`. It passed continuously while this corrupted real dispatches. The assertion was inverted, not incomplete, so it is **replaced**, not relaxed.

New `submit_bracketed_test.go` asserts **what the pane RECEIVED**, on a real tmux server, through the real `SendKeysCommand` — the property the argv-level tests structurally cannot see. Watched failing first:

```
Received "sentinel-alpha\r" — unbracketed means the agent gets it as keystrokes
```

Fixture uses only `sh`/`stty`/`cat` (in the toolchain image), so it never skips for want of an agent binary. Prompts cover leading `s`/`d`/`x`/`:`/`u`.

## Scope: what this does NOT fix

**The "prompt sits unsubmitted" symptom is NOT closed by this PR. That is deliberate. It lives in #1982.**

The hypothesis that it shared this root cause did not survive testing. Against a **real claude pane** (vim mode, `-- INSERT --` showing), box forced into INSERT so the leading-char bug could not confound it, detector validated in **both** directions first:

| prompt length | plain | `-p` |
|---|---|---|
| 12 chars | 3/3 SUBMIT | 3/3 SUBMIT |
| 400 chars | 3/3 SUBMIT | 3/3 SUBMIT |
| 4000 chars | 3/3 SUBMIT | 3/3 SUBMIT |

**18/18 in both conditions.** Claude does not exhibit codex's paste-burst Enter-swallow on an idle pane, and `-p` changes nothing there. (My first run reported 18/18 with a **broken** detector that matched `esc to interrupt` in scrollback; the numbers above are from the re-run after a no-Enter control proved the detector could report `STUCK`. A detector that only ever returns one answer is not evidence.)

**The stranding is real, and worse than "delayed".** It reproduces from a **busy-state** delivery — under `-p` as well as plain — and on top of the 18/18 result it was shown that a stranded draft **concatenates with the next prompt and submits as one message**: draft `STRANDED-DRAFT` + delivery `NEW-PROMPT` → the receiver got `STRANDED-DRAFTNEW-PROMPT`. So a stranded instruction does not merely wait; **it corrupts the next one**. Bracketing does not close that, which is exactly why it is **#1982** and not this PR.

## The 500ms sleep (`submit.go:105`) — reported, not changed

Left in place and documented. Bracketing may make it unnecessary **for apps that requested the mode** (they get the `\x1b[201~` end-of-paste marker — codex's whole reason for `-p`), but it **cannot** be removed unconditionally: `-p` is a no-op for apps that never enabled the mode, and those still get no marker and still need the drain. Follow-up, with its own evidence.

## Local codex gate — P2 fixed (readiness race)

**Finding:** the integration test's readiness check used `content != ""`, but `capture-pane` returns a newline per row even for a blank pane, so it was true before the receiver existed.

**Verified before fixing** — a pane running `sleep 300` (nothing printed) returns 24 bytes of `\n`:

| pane state | old check (`content != ""`) | new check (sees marker) |
|---|---|---|
| BLANK, no receiver | **true** ← the race | false |
| live receiver | true | true |

The old check returned **true in both states** — it carried zero information; `time.Sleep(300ms)` was doing all the work.

**Fix:** the receiver now prints `AF-RECEIVER-READY` *after* setting raw mode and emitting DECSET 2004; the test polls for that marker and the sleep is gone. Because tmux renders in order, seeing the marker proves tmux **processed the DECSET** — the exact precondition a bracketed paste depends on.

The gate's framing is right and worth recording: **the bug under test is af sending input without establishing the receiver would take it as text; the test called the receiver ready without establishing the receiver was ready.** Same class, one level up.

Re-verified the test still **fails against the pre-fix code** afterwards (`Received "sentinel-alpha\r"`), so the readiness fix did not make it vacuous. Ran `-count=5` clean.

## Gates

`gofmt -l .` clean · `go build ./...` clean · `deadcode -test ./...` clean · `scripts/lint-file-length.sh` pass (661 files) · **`make test-container` exit 0**.

Isolation: every probe ran on a private tmux socket or a throwaway container; no real daemon ops; the real AF home was never touched; the agent probes observed startup only and sent no prompts.

**Review status:** the GitHub codex bot is down — quiet ≠ clean. Held in **draft**; not claiming any bot review.

— Captain Claude