### PR TITLE
fix(tui): delete-project must state what it actually does to each session (#1973)

### DIFF
--- a/app/delete_project_test.go
+++ b/app/delete_project_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	xansi "github.com/charmbracelet/x/ansi"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -37,14 +38,18 @@ func deleteProjectSession(title string, external bool) session.InstanceData {
 }
 
 // dialogText reduces a rendered overlay to the prose the user reads: it strips
-// the box-drawing frame and collapses the wrap, so an assertion can match a
-// whole phrase that the overlay happened to break across two lines (the border
-// glyphs otherwise land mid-sentence and every multi-word match silently fails).
+// ANSI and the box-drawing frame, then collapses the wrap, so an assertion can
+// match a whole phrase the overlay happened to break across two lines.
+//
+// ANSI must go first. lipgloss's colour profile is process-global, so depending
+// on which tests ran before, the border arrives either as "│" glyphs or as
+// colour-escaped spaces — strip only the glyphs and the assertions pass alone
+// but fail in a full run.
 func dialogText(rendered string) string {
 	frame := strings.NewReplacer(
 		"│", " ", "─", " ", "╭", " ", "╮", " ", "╰", " ", "╯", " ",
 	)
-	return strings.Join(strings.Fields(frame.Replace(rendered)), " ")
+	return strings.Join(strings.Fields(frame.Replace(xansi.Strip(rendered))), " ")
 }
 
 // armDeleteProjectDialog drives the REAL prod gate up to the confirmation: it
@@ -55,13 +60,21 @@ func dialogText(rendered string) string {
 // Returns the home and the dialog text as the user sees it, unwrapped.
 func armDeleteProjectDialog(t *testing.T, data []session.InstanceData) (*home, string) {
 	t.Helper()
+	// Roomy window: the assertions are about the copy, not the viewport.
+	return armDeleteProjectDialogAt(t, data, 120, 45)
+}
+
+// armDeleteProjectDialogAt is armDeleteProjectDialog at a specific terminal
+// size, so a test can assert on what the overlay ACTUALLY RENDERS at that size.
+// The message string was always correct — the rendering is what lied — so a test
+// that inspects the input copy reproduces nothing.
+func armDeleteProjectDialogAt(t *testing.T, data []session.InstanceData, w, hgt int) (*home, string) {
+	t.Helper()
 	h := newTestHome(t)
 	t.Cleanup(SetAllReposSnapshotFetcherForTest(func() ([]session.InstanceData, error) {
 		return data, nil
 	}))
-	// Roomy window so the dialog body is never windowed away by the overlay's
-	// height fit — the assertions are about the copy, not the viewport.
-	resizeHome(h, 120, 45)
+	resizeHome(h, w, hgt)
 
 	// The section's rows come from the same discovery prod uses on launch, poll,
 	// and project switch. This is what makes the test cover the derivation.
@@ -95,10 +108,10 @@ func TestDeleteProjectConfirmStatesRealSplit(t *testing.T) {
 			deleteProjectSession("beta", false),
 		})
 
-		assert.Contains(t, dialog, "2 sessions are archived and restorable",
+		assert.Contains(t, dialog, "2 sessions archived — restorable",
 			"a project of ordinary sessions is fully restorable and must say so")
 		assert.Contains(t, dialog, "af sessions restore")
-		assert.NotContains(t, dialog, "torn down and cannot be restored",
+		assert.NotContains(t, dialog, "not restorable",
 			"nothing is killed here — the dialog must not invent a scary split")
 		assert.NotContains(t, dialog, "in-place")
 	})
@@ -108,14 +121,14 @@ func TestDeleteProjectConfirmStatesRealSplit(t *testing.T) {
 			deleteProjectSession("root", true),
 		})
 
-		assert.Contains(t, dialog, "1 in-place session is torn down and cannot be restored",
+		assert.Contains(t, dialog, "1 in-place session torn down — not restorable",
 			"an in-place session is killed; the user must be told before consenting")
 		// The honest half of the split: the kill does not destroy their work.
 		// GitWorktree.Cleanup() no-ops for an external worktree, so the branch and
 		// uncommitted changes survive — only the session and its agent are gone.
 		assert.Contains(t, dialog, "stay exactly where they are")
 		assert.Contains(t, dialog, "the session and its agent are gone")
-		assert.NotContains(t, dialog, "archived and restorable",
+		assert.NotContains(t, dialog, "archived — restorable",
 			"nothing here is restorable — claiming otherwise is exactly bug #1973")
 		assert.NotContains(t, dialog, "af sessions restore",
 			"restore cannot bring a killed in-place session back; do not offer it")
@@ -130,14 +143,81 @@ func TestDeleteProjectConfirmStatesRealSplit(t *testing.T) {
 
 		// The case that matters: the user must see BOTH numbers, each with its
 		// real consequence, not one blended count.
-		assert.Contains(t, dialog, "2 sessions are archived and restorable",
+		assert.Contains(t, dialog, "2 sessions archived — restorable",
 			"the archived count must exclude the in-place session")
-		assert.Contains(t, dialog, "The other 1 in-place session is torn down and cannot be restored",
+		assert.Contains(t, dialog, "1 in-place session torn down — not restorable",
 			"the killed count must be stated with its consequence")
 		assert.Contains(t, dialog, "Your real git repository is untouched.")
-		assert.NotContains(t, dialog, "3 sessions are archived",
+		assert.NotContains(t, dialog, "3 sessions archived",
 			"the total must never be reported as if it were all archived")
 	})
+}
+
+// TestDeleteProjectConfirmRendersConsequencesWhenCompact is the #1973 P1: the
+// honest split is worth nothing if the terminal renders it below the fold. The
+// overlay clips from the BOTTOM (windowOverlayBody keeps lines[:limit-1]), so a
+// dialog that led with the reassuring "N archived (restorable)" pushed the
+// non-restorable count off-screen — the user reads the safe half, presses y, and
+// loses sessions that were never restorable. That is the very bug this fix
+// exists to prevent, reintroduced by the layout.
+//
+// Both sizes are real: 40x10 is the floor this app DECLARES it supports
+// (ui/layout/grid.go HardMinWidth/HardMinHeight — below it ui/fallback.go takes
+// over), and 59x14 is where the review gate reproduced the clip. These assert on
+// the RENDERED overlay, not the message string handed to it.
+//
+// The dialog is armed at a roomy size and the terminal is THEN shrunk, because
+// that is the only way a user reaches this: below MinimalWidth/MinimalHeight
+// (60x15) the layout drops the Projects section entirely, so `D` cannot be
+// pressed at 40x10 in the first place. An open dialog, however, re-fits on every
+// relayout (relayout -> layoutModalOverlays -> SetMaxSize), so shrinking the
+// terminal — or a tmux pane resize — re-renders it at the smaller size with the
+// consequences clipped. The dialog outlives the size it was opened at.
+func TestDeleteProjectConfirmRendersConsequencesWhenCompact(t *testing.T) {
+	mixed := []session.InstanceData{
+		deleteProjectSession("alpha", false),
+		deleteProjectSession("beta", false),
+		deleteProjectSession("root", true),
+	}
+
+	for _, tc := range []struct {
+		name string
+		w, h int
+	}{
+		{name: "declared floor 40x10", w: 40, h: 10},
+		{name: "gate reproduction 59x14", w: 59, h: 14},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h, _ := armDeleteProjectDialog(t, mixed)
+			// Shrink with the dialog open — the overlay re-fits to the new size.
+			resizeHome(h, tc.w, tc.h)
+			require.NotNil(t, h.confirmationOverlay, "the dialog must survive the resize")
+			dialog := dialogText(h.confirmationOverlay.Render())
+
+			// The destructive fact must survive the clip.
+			assert.Contains(t, dialog, "1 in-place session torn down — not restorable",
+				"the non-restorable count must render at %dx%d — clipping it is the bug", tc.w, tc.h)
+			// And the user must still be able to see what key commits them.
+			assert.Regexp(t, `(?i)confirm`, dialog,
+				"the confirm prompt must render at %dx%d", tc.w, tc.h)
+			// Reading exactly one consequence line must mean reading the dangerous
+			// one: the reassuring half is what gives ground, never the reverse.
+			if strings.Contains(dialog, "archived — restorable") {
+				assert.Less(t, strings.Index(dialog, "not restorable"), strings.Index(dialog, "archived — restorable"),
+					"the non-restorable count must lead the restorable one")
+			}
+			// Nothing may be swallowed in silence: if the elaboration was clipped,
+			// the dialog says so rather than looking complete.
+			if !strings.Contains(dialog, "Your real git repository is untouched") {
+				assert.Contains(t, dialog, "resize to read",
+					"clipped detail must be announced, not silently dropped")
+			}
+			// The dialog must genuinely be confirmable at a supported size.
+			require.NotNil(t, h.confirmationOverlay)
+			assert.NotContains(t, dialog, "Too small to confirm safely",
+				"%dx%d is a supported size — delete must work here, not refuse", tc.w, tc.h)
+		})
+	}
 }
 
 // TestDeleteProjectResultReportsBothCounts closes the loop: after the user

--- a/app/delete_project_test.go
+++ b/app/delete_project_test.go
@@ -1,0 +1,240 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/ui/layout"
+)
+
+// deleteProjectTestRoot is the repo root the delete-project tests build their
+// snapshot around. RepoIDFromRoot is a pure hash of the path and the delete verb
+// never touches the filesystem, so no real git repo is needed here.
+const deleteProjectTestRoot = "/tmp/af-delete-project-test/acme"
+
+// deleteProjectSession builds a live snapshot record for the test repo.
+// external mirrors Worktree.ExternalWorktree — the in-place/`--here` flag that
+// ToInstanceData copies straight from gitWorktree.IsExternalWorktree(), i.e. the
+// exact predicate daemon.deleteProject branches kill-vs-archive on (#1973).
+func deleteProjectSession(title string, external bool) session.InstanceData {
+	return session.InstanceData{
+		Title: title,
+		Worktree: session.GitWorktreeData{
+			RepoPath:         deleteProjectTestRoot,
+			WorktreePath:     deleteProjectTestRoot,
+			SessionName:      title,
+			BranchName:       "af/" + title,
+			ExternalWorktree: external,
+		},
+	}
+}
+
+// dialogText reduces a rendered overlay to the prose the user reads: it strips
+// the box-drawing frame and collapses the wrap, so an assertion can match a
+// whole phrase that the overlay happened to break across two lines (the border
+// glyphs otherwise land mid-sentence and every multi-word match silently fails).
+func dialogText(rendered string) string {
+	frame := strings.NewReplacer(
+		"│", " ", "─", " ", "╭", " ", "╮", " ", "╰", " ", "╯", " ",
+	)
+	return strings.Join(strings.Fields(frame.Replace(rendered)), " ")
+}
+
+// armDeleteProjectDialog drives the REAL prod gate up to the confirmation: it
+// feeds the snapshot through buildProjectListFrom (the derivation that populates
+// InPlaceCount), pushes the rows into the Projects section, focuses it, and
+// presses the actual delete-project key on the cursor's row — rather than
+// hand-building a ui.SidebarProject or calling the message builder directly.
+// Returns the home and the dialog text as the user sees it, unwrapped.
+func armDeleteProjectDialog(t *testing.T, data []session.InstanceData) (*home, string) {
+	t.Helper()
+	h := newTestHome(t)
+	t.Cleanup(SetAllReposSnapshotFetcherForTest(func() ([]session.InstanceData, error) {
+		return data, nil
+	}))
+	// Roomy window so the dialog body is never windowed away by the overlay's
+	// height fit — the assertions are about the copy, not the viewport.
+	resizeHome(h, 120, 45)
+
+	// The section's rows come from the same discovery prod uses on launch, poll,
+	// and project switch. This is what makes the test cover the derivation.
+	h.refreshSidebarProjects()
+	require.Len(t, h.projects.Projects(), 1, "the snapshot must yield exactly the test project")
+
+	h.focusRegion(layout.RegionProjects)
+	require.Equal(t, layout.RegionProjects, h.ring.Active())
+
+	// 'D' on the focused Projects section — the binding handleProjectsFocus routes
+	// to handleDeleteProject in prod.
+	model, _, consumed := h.handleProjectsFocus(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("D")})
+	require.True(t, consumed, "the delete-project key must be consumed by the focused Projects section")
+	h = model.(*home)
+	require.Equal(t, stateConfirm, h.state, "delete project must open a confirmation")
+	require.NotNil(t, h.confirmationOverlay)
+
+	return h, dialogText(h.confirmationOverlay.Render())
+}
+
+// TestDeleteProjectConfirmStatesRealSplit is the #1973 guarantee on the surface
+// that matters most: the confirmation is the entire basis on which the user
+// consents to a destructive action, so it must state what actually happens to
+// each class of session BEFORE they answer. In-place/external-worktree sessions
+// are torn down by daemon.deleteProject, never archived — promising them back via
+// restore is the bug.
+func TestDeleteProjectConfirmStatesRealSplit(t *testing.T) {
+	t.Run("only normal sessions are archived and restorable", func(t *testing.T) {
+		_, dialog := armDeleteProjectDialog(t, []session.InstanceData{
+			deleteProjectSession("alpha", false),
+			deleteProjectSession("beta", false),
+		})
+
+		assert.Contains(t, dialog, "2 sessions are archived and restorable",
+			"a project of ordinary sessions is fully restorable and must say so")
+		assert.Contains(t, dialog, "af sessions restore")
+		assert.NotContains(t, dialog, "torn down and cannot be restored",
+			"nothing is killed here — the dialog must not invent a scary split")
+		assert.NotContains(t, dialog, "in-place")
+	})
+
+	t.Run("only in-place sessions are torn down and not restorable", func(t *testing.T) {
+		_, dialog := armDeleteProjectDialog(t, []session.InstanceData{
+			deleteProjectSession("root", true),
+		})
+
+		assert.Contains(t, dialog, "1 in-place session is torn down and cannot be restored",
+			"an in-place session is killed; the user must be told before consenting")
+		// The honest half of the split: the kill does not destroy their work.
+		// GitWorktree.Cleanup() no-ops for an external worktree, so the branch and
+		// uncommitted changes survive — only the session and its agent are gone.
+		assert.Contains(t, dialog, "stay exactly where they are")
+		assert.Contains(t, dialog, "the session and its agent are gone")
+		assert.NotContains(t, dialog, "archived and restorable",
+			"nothing here is restorable — claiming otherwise is exactly bug #1973")
+		assert.NotContains(t, dialog, "af sessions restore",
+			"restore cannot bring a killed in-place session back; do not offer it")
+	})
+
+	t.Run("mixed project names both outcomes", func(t *testing.T) {
+		_, dialog := armDeleteProjectDialog(t, []session.InstanceData{
+			deleteProjectSession("alpha", false),
+			deleteProjectSession("beta", false),
+			deleteProjectSession("root", true),
+		})
+
+		// The case that matters: the user must see BOTH numbers, each with its
+		// real consequence, not one blended count.
+		assert.Contains(t, dialog, "2 sessions are archived and restorable",
+			"the archived count must exclude the in-place session")
+		assert.Contains(t, dialog, "The other 1 in-place session is torn down and cannot be restored",
+			"the killed count must be stated with its consequence")
+		assert.Contains(t, dialog, "Your real git repository is untouched.")
+		assert.NotContains(t, dialog, "3 sessions are archived",
+			"the total must never be reported as if it were all archived")
+	})
+}
+
+// TestDeleteProjectResultReportsBothCounts closes the loop: after the user
+// consents, the completion must report the SAME split the confirmation promised,
+// using the daemon's own counts. The TUI used to discard resp.KilledCount, so it
+// could only ever say "archived N (restorable)" — false whenever anything was
+// torn down (#1973). Drives the full prod chain: confirm → deleteProjectCmd →
+// projectDeletedMsg → handleProjectDeleted → the transient notice.
+func TestDeleteProjectResultReportsBothCounts(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		data        []session.InstanceData
+		archived    int
+		killed      int
+		wantContain []string
+		wantAbsent  []string
+		// killedLeads asserts the torn-down half comes FIRST. The notice is a
+		// single line that the error box clips to the pane width, so the tail is
+		// what gets dropped — the half the user must not lose has to lead.
+		killedLeads bool
+	}{
+		{
+			name:        "only normal sessions",
+			data:        []session.InstanceData{deleteProjectSession("alpha", false), deleteProjectSession("beta", false)},
+			archived:    2,
+			killed:      0,
+			wantContain: []string{"archived 2 sessions (restorable)"},
+			wantAbsent:  []string{"tore down"},
+		},
+		{
+			name:        "only in-place sessions",
+			data:        []session.InstanceData{deleteProjectSession("root", true)},
+			archived:    0,
+			killed:      1,
+			wantContain: []string{"tore down 1 in-place session (not restorable, worktree and branch untouched)"},
+			wantAbsent:  []string{"restorable)", "archived"},
+		},
+		{
+			name:     "mixed project",
+			data:     []session.InstanceData{deleteProjectSession("alpha", false), deleteProjectSession("beta", false), deleteProjectSession("root", true)},
+			archived: 2,
+			killed:   1,
+			wantContain: []string{
+				"archived 2 sessions (restorable)",
+				"tore down 1 in-place session (not restorable, worktree and branch untouched)",
+			},
+			wantAbsent:  []string{"archived 3"},
+			killedLeads: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h, _ := armDeleteProjectDialog(t, tc.data)
+
+			// Stub the daemon at the same seam prod dials through, returning the
+			// split the daemon would compute for this project.
+			var gotRepoID string
+			prev := deleteProjectThroughDaemon
+			deleteProjectThroughDaemon = func(repoRoot, repoID string) (daemon.DeleteProjectResponse, error) {
+				gotRepoID = repoID
+				return daemon.DeleteProjectResponse{
+					OK:            true,
+					ArchivedCount: tc.archived,
+					KilledCount:   tc.killed,
+				}, nil
+			}
+			t.Cleanup(func() { deleteProjectThroughDaemon = prev })
+
+			// 'y' confirms; the overlay forwards the start message into the loop.
+			model, cmd := h.handleStateConfirm(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+			h = model.(*home)
+			require.Equal(t, stateDefault, h.state, "confirm must close the dialog")
+			require.NotNil(t, cmd, "confirm must forward the start-delete message")
+			startMsg, ok := cmd().(startDeleteProjectMsg)
+			require.True(t, ok, "confirm must emit startDeleteProjectMsg")
+
+			// The async command → the completion message the handler consumes.
+			done, ok := h.deleteProjectCmd(startMsg)().(projectDeletedMsg)
+			require.True(t, ok, "deleteProjectCmd must emit projectDeletedMsg")
+			require.NotEmpty(t, gotRepoID, "the delete must reach the daemon seam")
+			assert.Equal(t, tc.archived, done.archived)
+			assert.Equal(t, tc.killed, done.killed,
+				"the killed count must survive the daemon→message hop; dropping it is bug #1973")
+
+			model, _ = h.handleProjectDeleted(done)
+			h = model.(*home)
+
+			notice := h.errBox.FullError()
+			for _, want := range tc.wantContain {
+				assert.Contains(t, notice, want, "the result must report what actually happened")
+			}
+			for _, absent := range tc.wantAbsent {
+				assert.NotContains(t, notice, absent, "the result must not overstate what is restorable")
+			}
+			if tc.killedLeads {
+				assert.Less(t, strings.Index(notice, "tore down"), strings.Index(notice, "archived"),
+					"the torn-down half must lead: the notice is width-clipped, so a trailing 'not restorable' is the part that disappears")
+			}
+		})
+	}
+}

--- a/app/home_view.go
+++ b/app/home_view.go
@@ -63,8 +63,19 @@ func (m *home) showErrorDetails() (tea.Model, tea.Cmd) {
 }
 
 func (m *home) confirmAction(message string, action tea.Cmd) tea.Cmd {
+	return m.confirmActionWithDetail(message, "", action)
+}
+
+// confirmActionWithDetail is confirmAction for a dialog whose copy splits into
+// consequences (message) and elaboration (detail). The overlay then guarantees
+// the consequences render or refuses the confirm outright, rather than clipping
+// the tail and collecting a 'y' for something it never showed (#1973).
+func (m *home) confirmActionWithDetail(message, detail string, action tea.Cmd) tea.Cmd {
 	m.state = stateConfirm
 	m.confirmationOverlay = overlay.NewConfirmationOverlay(message)
+	if detail != "" {
+		m.confirmationOverlay.SetDetail(detail)
+	}
 	m.confirmationOverlay.SetWidth(50)
 	m.layoutConfirmationOverlay()
 

--- a/app/messages.go
+++ b/app/messages.go
@@ -49,7 +49,12 @@ type projectDeletedMsg struct {
 	repoID   string
 	name     string
 	archived int
-	err      error
+	// killed is how many in-place/external-worktree sessions the daemon tore
+	// down because they cannot be archived (#1973). Reported alongside archived
+	// so the completion states the same split the confirmation promised — a
+	// torn-down session is NOT restorable, and the user must not be told it is.
+	killed int
+	err    error
 }
 
 // instanceArchivedMsg / instanceRestoredMsg report completion of an async

--- a/app/switch_project.go
+++ b/app/switch_project.go
@@ -237,50 +237,48 @@ func sessionWord(n int) string {
 }
 
 // deleteProjectConfirmMessage builds the delete-project confirmation (#1735,
-// corrected in #1973). It states the ACTUAL split before the user consents:
-// archived sessions are restorable, in-place ones are torn down and are not.
+// corrected in #1973). It returns the copy in two parts, because the overlay
+// clips from the bottom and this dialog's tail was the half that mattered:
 //
-// The split is honest in both directions, which is the whole point. Tearing
-// down an in-place session does NOT destroy the user's work — the worktree is
-// theirs, and GitWorktree.Cleanup() no-ops for an external worktree, so the
-// branch and uncommitted changes survive untouched. What does not survive is the
-// session: af deletes its record, so `af sessions restore` cannot bring it back.
-// Saying "you lose your work" would be false; saying "restorable" is the bug.
-// Both counts come from the same projection that feeds the row's own total.
-func deleteProjectConfirmMessage(name string, total, inPlace int, restoreKey string) string {
+//   - critical — the consequences the user is consenting to, one count per
+//     outcome. The overlay guarantees this renders in full or refuses the
+//     action outright, so it must stay short enough to fit the declared 40x10
+//     floor (ui/layout/grid.go HardMinWidth/HardMinHeight): a ~34-column text
+//     rect leaves four body lines. That budget is why these lines are headlines
+//     rather than prose.
+//   - detail — the elaboration, which may be clipped (and says when it is).
+//
+// The destructive count LEADS. A user who reads exactly one line must read the
+// one that cannot be undone; the reassuring half is what gives ground first.
+//
+// The split is honest in both directions. Tearing down an in-place session does
+// NOT destroy the user's work — the worktree is theirs, and GitWorktree.Cleanup()
+// no-ops for an external worktree, so the branch and uncommitted changes survive.
+// What does not survive is the session: af deletes its record, so `af sessions
+// restore` cannot bring it back. Saying "you lose your work" would be false;
+// saying "restorable" is the bug.
+func deleteProjectConfirmMessage(name string, total, inPlace int, restoreKey string) (critical, detail string) {
 	archived := total - inPlace
-	msg := fmt.Sprintf("[!] Delete project '%s'?\n\n", name)
+	title := fmt.Sprintf("[!] Delete project '%s'?", name)
+
+	killedLine := fmt.Sprintf("%d in-place %s torn down — not restorable.", inPlace, sessionWord(inPlace))
+	archivedLine := fmt.Sprintf("%d %s archived — restorable.", archived, sessionWord(archived))
+	gone := "Its worktree is yours — the branch and uncommitted changes stay exactly where they are, but the session and its agent are gone."
+	restore := fmt.Sprintf("Restore an archived session (%s, or `af sessions restore`) to bring the project back.", restoreKey)
+	repoSafe := "Your real git repository is untouched."
 
 	switch {
 	case total == 0:
-		msg += "It has no live sessions — it just leaves the projects list."
+		return title + "\nIt has no live sessions — it just leaves the projects list.", repoSafe
 	case inPlace == 0:
-		msg += fmt.Sprintf(
-			"Its %d %s %s archived and restorable — tmux torn down, worktrees moved out, branches and uncommitted work preserved. Restore any of them (%s, or `af sessions restore`) to bring the project back.",
-			archived, sessionWord(archived), isAre(archived), restoreKey,
-		)
+		return title + "\n" + archivedLine,
+			"tmux torn down, worktrees moved out — branches and uncommitted work preserved.\n\n" + restore + " " + repoSafe
 	case archived == 0:
-		msg += fmt.Sprintf(
-			"Its %d in-place %s %s torn down and cannot be restored — the worktree is yours, so its branch and uncommitted changes stay exactly where they are, but the session and its agent are gone.",
-			inPlace, sessionWord(inPlace), isAre(inPlace),
-		)
+		return title + "\n" + killedLine, gone + " " + repoSafe
 	default:
-		msg += fmt.Sprintf(
-			"%d %s %s archived and restorable — tmux torn down, worktrees moved out, branches and uncommitted work preserved. Restore any of them (%s, or `af sessions restore`) to bring the project back.\n\nThe other %d in-place %s %s torn down and cannot be restored — the worktree is yours, so its branch and uncommitted changes stay exactly where they are, but the session and its agent are gone.",
-			archived, sessionWord(archived), isAre(archived), restoreKey,
-			inPlace, sessionWord(inPlace), isAre(inPlace),
-		)
+		return title + "\n" + killedLine + "\n" + archivedLine,
+			gone + "\n\n" + restore + " " + repoSafe
 	}
-
-	return msg + "\n\nYour real git repository is untouched."
-}
-
-// isAre agrees the verb with the count so the copy reads as prose.
-func isAre(n int) string {
-	if n == 1 {
-		return "is"
-	}
-	return "are"
 }
 
 // deleteProjectResultMessage reports what delete-project ACTUALLY did, using the
@@ -317,8 +315,8 @@ func deleteProjectResultMessage(name string, archived, killed int) string {
 func (m *home) handleDeleteProject(proj ui.SidebarProject) (tea.Model, tea.Cmd) {
 	repoID := config.RepoIDFromRoot(proj.Root)
 	restoreKey := keys.GlobalKeyBindings[keys.KeyRestore].Help().Key
-	message := deleteProjectConfirmMessage(proj.Name, proj.SessionCount, proj.InPlaceCount, restoreKey)
-	return m, m.confirmAction(message, func() tea.Msg {
+	message, detail := deleteProjectConfirmMessage(proj.Name, proj.SessionCount, proj.InPlaceCount, restoreKey)
+	return m, m.confirmActionWithDetail(message, detail, func() tea.Msg {
 		return startDeleteProjectMsg{root: proj.Root, repoID: repoID, name: proj.Name}
 	})
 }

--- a/app/switch_project.go
+++ b/app/switch_project.go
@@ -54,6 +54,14 @@ func (m *home) buildProjectList() []overlay.Project {
 // it already fetched off-loop rather than issuing a second daemon RPC.
 func (m *home) buildProjectListFrom(data []session.InstanceData) []overlay.Project {
 	counts := map[string]int{}
+	// inPlace counts the subset of each repo's live sessions that delete-project
+	// tears down instead of archiving (#1973). Keyed off the SAME predicate the
+	// daemon applies in deleteProject — Instance.IsExternalWorktree(), which is
+	// exactly Worktree.ExternalWorktree on the wire (ToInstanceData sets it from
+	// gitWorktree.IsExternalWorktree(), and both read false when no worktree is
+	// attached). Deriving it here, from the snapshot that already yields the
+	// total, keeps the dialog's split as faithful as the count beside it.
+	inPlace := map[string]int{}
 	var order []string
 	seen := func(root string) {
 		if root == "" {
@@ -80,6 +88,9 @@ func (m *home) buildProjectListFrom(data []session.InstanceData) []overlay.Proje
 		}
 		seen(root)
 		counts[root]++
+		if d.Worktree.ExternalWorktree {
+			inPlace[root]++
+		}
 	}
 
 	if m.appConfig != nil {
@@ -97,6 +108,7 @@ func (m *home) buildProjectListFrom(data []session.InstanceData) []overlay.Proje
 			Name:         filepath.Base(root),
 			Root:         root,
 			SessionCount: counts[root],
+			InPlaceCount: inPlace[root],
 		})
 	}
 	sort.Slice(projects, func(i, j int) bool {
@@ -117,6 +129,7 @@ func (m *home) projectRows(projects []overlay.Project) []ui.SidebarProject {
 			Name:         p.Name,
 			Root:         p.Root,
 			SessionCount: p.SessionCount,
+			InPlaceCount: p.InPlaceCount,
 			Active:       p.Root == m.repoRoot,
 		})
 	}
@@ -215,22 +228,96 @@ func (m *home) handleAddProject(path string) (tea.Model, tea.Cmd) {
 	return m.switchProject(repo)
 }
 
-// handleDeleteProject opens the reversible delete-project confirmation for the
-// cursor's project in the Projects section (#1735). The copy makes the
-// reversibility explicit: sessions are archived (restorable), the real repo is
-// untouched, and restoring any archived session brings the project back. On
-// confirm it dispatches the async daemon archive-then-remove.
+// sessionWord pluralizes "session" for the delete-project copy.
+func sessionWord(n int) string {
+	if n == 1 {
+		return "session"
+	}
+	return "sessions"
+}
+
+// deleteProjectConfirmMessage builds the delete-project confirmation (#1735,
+// corrected in #1973). It states the ACTUAL split before the user consents:
+// archived sessions are restorable, in-place ones are torn down and are not.
+//
+// The split is honest in both directions, which is the whole point. Tearing
+// down an in-place session does NOT destroy the user's work — the worktree is
+// theirs, and GitWorktree.Cleanup() no-ops for an external worktree, so the
+// branch and uncommitted changes survive untouched. What does not survive is the
+// session: af deletes its record, so `af sessions restore` cannot bring it back.
+// Saying "you lose your work" would be false; saying "restorable" is the bug.
+// Both counts come from the same projection that feeds the row's own total.
+func deleteProjectConfirmMessage(name string, total, inPlace int, restoreKey string) string {
+	archived := total - inPlace
+	msg := fmt.Sprintf("[!] Delete project '%s'?\n\n", name)
+
+	switch {
+	case total == 0:
+		msg += "It has no live sessions — it just leaves the projects list."
+	case inPlace == 0:
+		msg += fmt.Sprintf(
+			"Its %d %s %s archived and restorable — tmux torn down, worktrees moved out, branches and uncommitted work preserved. Restore any of them (%s, or `af sessions restore`) to bring the project back.",
+			archived, sessionWord(archived), isAre(archived), restoreKey,
+		)
+	case archived == 0:
+		msg += fmt.Sprintf(
+			"Its %d in-place %s %s torn down and cannot be restored — the worktree is yours, so its branch and uncommitted changes stay exactly where they are, but the session and its agent are gone.",
+			inPlace, sessionWord(inPlace), isAre(inPlace),
+		)
+	default:
+		msg += fmt.Sprintf(
+			"%d %s %s archived and restorable — tmux torn down, worktrees moved out, branches and uncommitted work preserved. Restore any of them (%s, or `af sessions restore`) to bring the project back.\n\nThe other %d in-place %s %s torn down and cannot be restored — the worktree is yours, so its branch and uncommitted changes stay exactly where they are, but the session and its agent are gone.",
+			archived, sessionWord(archived), isAre(archived), restoreKey,
+			inPlace, sessionWord(inPlace), isAre(inPlace),
+		)
+	}
+
+	return msg + "\n\nYour real git repository is untouched."
+}
+
+// isAre agrees the verb with the count so the copy reads as prose.
+func isAre(n int) string {
+	if n == 1 {
+		return "is"
+	}
+	return "are"
+}
+
+// deleteProjectResultMessage reports what delete-project ACTUALLY did, using the
+// daemon's own counts rather than the pre-confirm estimate (#1973), so the split
+// the user consented to is the split they are told about afterward.
+//
+// The torn-down fragment leads on a mixed delete, deliberately. This lands in
+// the one-line transient notice, which the error box clips to the pane width —
+// play-testing an 80-col-ish sidebar cut a killed-last message at "tore down 1
+// in-place se…", losing exactly the half the user needs. The clipped tail must
+// be the reassuring half (what survived), never the consequential one (what did
+// not). The full string stays reachable via the notice's details view.
+func deleteProjectResultMessage(name string, archived, killed int) string {
+	switch {
+	case archived == 0 && killed == 0:
+		return fmt.Sprintf("Deleted project '%s' — no live sessions to remove", name)
+	case killed == 0:
+		return fmt.Sprintf("Deleted project '%s' — archived %d %s (restorable)", name, archived, sessionWord(archived))
+	case archived == 0:
+		return fmt.Sprintf("Deleted project '%s' — tore down %d in-place %s (not restorable, worktree and branch untouched)", name, killed, sessionWord(killed))
+	default:
+		return fmt.Sprintf(
+			"Deleted project '%s' — tore down %d in-place %s (not restorable, worktree and branch untouched) · archived %d %s (restorable)",
+			name, killed, sessionWord(killed), archived, sessionWord(archived),
+		)
+	}
+}
+
+// handleDeleteProject opens the delete-project confirmation for the cursor's
+// project in the Projects section (#1735). The copy states the real split — what
+// is archived and restorable, and what is torn down and is not (#1973) — because
+// this message is the entire basis on which the user consents to a destructive
+// action. On confirm it dispatches the async daemon archive-then-remove.
 func (m *home) handleDeleteProject(proj ui.SidebarProject) (tea.Model, tea.Cmd) {
 	repoID := config.RepoIDFromRoot(proj.Root)
-	sessionWord := "sessions"
-	if proj.SessionCount == 1 {
-		sessionWord = "session"
-	}
 	restoreKey := keys.GlobalKeyBindings[keys.KeyRestore].Help().Key
-	message := fmt.Sprintf(
-		"[!] Delete project '%s'?\n\nIts %d %s are archived (tmux torn down, worktrees moved out — branches and uncommitted work preserved) and it is removed from the projects list. Your real git repository is untouched. Restore any archived session (%s, or `af sessions restore`) to bring the project back.",
-		proj.Name, proj.SessionCount, sessionWord, restoreKey,
-	)
+	message := deleteProjectConfirmMessage(proj.Name, proj.SessionCount, proj.InPlaceCount, restoreKey)
 	return m, m.confirmAction(message, func() tea.Msg {
 		return startDeleteProjectMsg{root: proj.Root, repoID: repoID, name: proj.Name}
 	})
@@ -241,7 +328,18 @@ func (m *home) handleDeleteProject(proj ui.SidebarProject) (tea.Model, tea.Cmd) 
 func (m *home) deleteProjectCmd(msg startDeleteProjectMsg) tea.Cmd {
 	return func() tea.Msg {
 		resp, err := deleteProjectThroughDaemon(msg.root, msg.repoID)
-		return projectDeletedMsg{root: msg.root, repoID: msg.repoID, name: msg.name, archived: resp.ArchivedCount, err: err}
+		return projectDeletedMsg{
+			root:     msg.root,
+			repoID:   msg.repoID,
+			name:     msg.name,
+			archived: resp.ArchivedCount,
+			// KilledCount is the in-place sessions the daemon tore down. Carrying
+			// it is what lets the completion report the same archived-vs-torn-down
+			// split the confirmation promised (#1973); dropping it is how the TUI
+			// came to claim everything was restorable.
+			killed: resp.KilledCount,
+			err:    err,
+		}
 	}
 }
 
@@ -262,11 +360,7 @@ func (m *home) handleProjectDeleted(msg projectDeletedMsg) (tea.Model, tea.Cmd) 
 		}
 	}
 	m.refreshSidebarProjects()
-	sessionWord := "sessions"
-	if msg.archived == 1 {
-		sessionWord = "session"
-	}
-	return m, m.showTransientMessage(fmt.Sprintf("Deleted project '%s' — archived %d %s (restorable)", msg.name, msg.archived, sessionWord))
+	return m, m.showTransientMessage(deleteProjectResultMessage(msg.name, msg.archived, msg.killed))
 }
 
 func (m *home) closeProjectPicker() {

--- a/ui/overlay/confirmationOverlay.go
+++ b/ui/overlay/confirmationOverlay.go
@@ -1,12 +1,14 @@
 package overlay
 
 import (
+	"fmt"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/sachiniyer/agent-factory/ui"
+	"github.com/sachiniyer/agent-factory/ui/layout"
 )
 
 const (
@@ -20,6 +22,12 @@ type ConfirmationOverlay struct {
 	Dismissed bool
 	// Message to display in the overlay
 	message string
+	// detail is optional elaboration rendered below message. Setting it (via
+	// SetDetail) opts this overlay into the critical-content guarantee (#1973):
+	// message becomes the part the user MUST read to consent, and only detail
+	// may be clipped — announced, never swallowed. With no detail the whole
+	// message stays clippable, which is the historical behavior.
+	detail string
 	// Width of the overlay
 	width int
 	// Maximum outer dimensions available for rendering.
@@ -65,6 +73,15 @@ func (c *ConfirmationOverlay) HandleKeyPress(msg tea.KeyMsg) bool {
 		}
 		return true
 	case strings.ToLower(c.ConfirmKey):
+		// A guarded overlay too small to show its consequences must not collect a
+		// confirm (#1973). Refusing here — not merely rendering a warning — is
+		// what makes the guarantee real: the render and the key agree, so a 'y'
+		// typed blind against an unreadable dialog does nothing. The dialog stays
+		// open (esc still cancels) so the user can resize and read it.
+		rect := c.textRect()
+		if c.tooSmallToConfirm(rect.W, rect.H) {
+			return false
+		}
 		c.Dismissed = true
 		if c.OnConfirm != nil {
 			c.OnConfirm()
@@ -76,12 +93,31 @@ func (c *ConfirmationOverlay) HandleKeyPress(msg tea.KeyMsg) bool {
 	}
 }
 
-// Render renders the confirmation overlay
-func (c *ConfirmationOverlay) Render() string {
-	style := lipgloss.NewStyle().
+// frameStyle is the overlay's border+padding style, shared by every path that
+// needs to know how much room the text actually gets.
+func (c *ConfirmationOverlay) frameStyle() lipgloss.Style {
+	return lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(c.borderColor).
 		Padding(confirmationOverlayVerticalPadding, confirmationOverlayHorizontalPadding)
+}
+
+// textRect resolves the text area the message will actually be rendered into.
+// HandleKeyPress and Render MUST agree on this: if the key handler judged the
+// fit differently from the renderer, the guarantee would be fiction — a dialog
+// could refuse on screen while still accepting a 'y', or the reverse.
+func (c *ConfirmationOverlay) textRect() layout.Rect {
+	style := c.frameStyle()
+	fit := fitOverlayContent(c.width, 0, c.maxWidth, c.maxHeight, style)
+	if fit.W > 0 {
+		style = style.Width(fit.W)
+	}
+	return overlayTextRect(fit, style)
+}
+
+// Render renders the confirmation overlay
+func (c *ConfirmationOverlay) Render() string {
+	style := c.frameStyle()
 
 	fit := fitOverlayContent(c.width, 0, c.maxWidth, c.maxHeight, style)
 	if fit.W > 0 {
@@ -113,33 +149,190 @@ func (c *ConfirmationOverlay) SetConfirmKey(key string) {
 	c.ConfirmKey = key
 }
 
-func (c *ConfirmationOverlay) visibleContent(width, height int) string {
-	body := wrapOverlayLines(c.message, width)
+// SetDetail sets elaboration rendered below the message, and opts this overlay
+// into the critical-content guarantee (#1973). Split the copy so the message
+// carries the consequences the user is consenting to and the detail carries the
+// explanation: the message then either renders in full — with any clipped detail
+// announced — or the overlay refuses to confirm at all. Use it for any confirm
+// whose message would be a lie if its tail fell below the fold.
+func (c *ConfirmationOverlay) SetDetail(detail string) {
+	c.detail = detail
+}
+
+// guarded reports whether this overlay carries a critical/detail split, i.e.
+// whether its message must be readable for a confirm to be legitimate.
+func (c *ConfirmationOverlay) guarded() bool {
+	return strings.TrimSpace(c.detail) != ""
+}
+
+// detailLines wraps the elaboration. The blank spacer that separates it from
+// the message is added only when the detail fits whole (see fitDetail) — under
+// pressure a spacer is a line of nothing, and lines of nothing are the first
+// thing to surrender.
+func (c *ConfirmationOverlay) detailLines(width int) []string {
+	if !c.guarded() {
+		return nil
+	}
+	return wrapOverlayLines(c.detail, width)
+}
+
+// fitDetail places the elaboration in whatever room the message left, and
+// reports the notice the caller must show if anything was dropped.
+//
+// The notice is returned rather than rendered because when room runs out
+// entirely it goes in the blank separator's slot — the gap is a line we were
+// spending on nothing, so announcing the clip there costs zero lines. That is
+// what lets the consequences fit at the declared 40x10 floor AND still say that
+// more text exists, instead of trading one against the other.
+func fitDetail(detail []string, room, width int) (lines []string, notice string) {
+	switch {
+	case len(detail) == 0:
+		return nil, ""
+	case room >= len(detail)+1:
+		// Room for the spacer too — render it as designed.
+		return append([]string{""}, detail...), ""
+	case room >= 1:
+		return windowOverlayBody(detail, room, width), ""
+	default:
+		return nil, moreLinesNotice(countContentLines(detail))
+	}
+}
+
+// bodyBudget splits height between the body and the confirm prompt, reserving a
+// blank gap between them when there is room. Mirrors the historical math.
+func bodyBudget(height, hintLines int) (budget, gap int) {
+	gap = 1
+	budget = height - hintLines - gap
+	if budget < 1 {
+		gap = 0
+		budget = height - hintLines
+	}
+	return budget, gap
+}
+
+// tooSmallToConfirm reports whether a guarded overlay cannot render its message
+// plus the confirm prompt at the given text rect. Such an overlay must refuse
+// the action outright: a destructive confirm that cannot show its consequences
+// has no business collecting a 'y' (#1973). Unguarded overlays never refuse.
+func (c *ConfirmationOverlay) tooSmallToConfirm(width, height int) bool {
+	if !c.guarded() || height <= 0 || width <= 0 {
+		return false
+	}
+	critical := wrapOverlayLines(c.message, width)
+	budget, _ := bodyBudget(height, len(c.fittedHint(width, height)))
+	return budget < len(critical)
+}
+
+// fittedHint picks the full or compact confirm prompt for the available height.
+func (c *ConfirmationOverlay) fittedHint(width, height int) []string {
 	hint := wrapOverlayLines(c.instruction(false), width)
-	compactHint := wrapOverlayLines(c.instruction(true), width)
-	if height > 0 && (len(body)+1+len(hint) > height || len(hint) > 2) {
-		hint = compactHint
-	}
 	if height <= 0 {
-		return strings.Join(append(append([]string{}, body...), append([]string{""}, hint...)...), "\n")
+		return hint
 	}
-	if len(hint) >= height {
+	body := len(wrapOverlayLines(c.message, width)) + len(c.detailLines(width))
+	if body+1+len(hint) > height || len(hint) > 2 {
+		return wrapOverlayLines(c.instruction(true), width)
+	}
+	return hint
+}
+
+func (c *ConfirmationOverlay) visibleContent(width, height int) string {
+	critical := wrapOverlayLines(c.message, width)
+	detail := c.detailLines(width)
+
+	if height <= 0 {
+		// Unbounded: everything renders, spacer and all.
+		lines := append([]string{}, critical...)
+		if len(detail) > 0 {
+			lines = append(append(lines, ""), detail...)
+		}
+		return strings.Join(append(lines, append([]string{""}, wrapOverlayLines(c.instruction(false), width)...)...), "\n")
+	}
+
+	hint := c.fittedHint(width, height)
+
+	// A guarded overlay that cannot show what it destroys refuses instead of
+	// rendering a reassuring fragment above a hidden consequence.
+	if c.tooSmallToConfirm(width, height) {
+		return c.refusalContent(width, height)
+	}
+
+	if !c.guarded() && len(hint) >= height {
 		return strings.Join(hint[:height], "\n")
 	}
 
-	gap := 1
-	bodyLimit := height - len(hint) - gap
-	if bodyLimit < 1 {
-		gap = 0
-		bodyLimit = height - len(hint)
+	budget, gap := bodyBudget(height, len(hint))
+
+	var lines []string
+	gapLine := ""
+	if c.guarded() {
+		// The message is never windowed — tooSmallToConfirm already proved it
+		// fits. Only the elaboration gives ground, and it says what it dropped.
+		detailLines, notice := fitDetail(detail, budget-len(critical), width)
+		lines = append(lines, critical...)
+		lines = append(lines, detailLines...)
+		gapLine = notice
+	} else {
+		lines = windowOverlayBody(critical, budget, width)
 	}
-	body = windowOverlayBody(body, bodyLimit, width)
+
+	if gap > 0 && len(lines) > 0 {
+		lines = append(lines, gapLine)
+	}
+	lines = append(lines, hint...)
+	return strings.Join(lines, "\n")
+}
+
+// refusalContent is what a guarded overlay shows when the window cannot fit its
+// consequences: it names why, says how much room is missing, and offers only
+// cancel. HandleKeyPress rejects the confirm key in this state, so the action is
+// genuinely withheld rather than merely discouraged.
+func (c *ConfirmationOverlay) refusalContent(width, height int) string {
+	hint := wrapOverlayLines(lipgloss.NewStyle().Bold(true).Render("esc")+" cancel", width)
+	budget, gap := bodyBudget(height, len(hint))
+
+	critical := wrapOverlayLines(c.message, width)
+	short := len(critical) - budget
+	if short < 1 {
+		short = 1
+	}
+
+	// Pick the longest refusal that actually FITS. Windowing this text would be
+	// self-defeating: the refusal exists because content was being swallowed, so
+	// a refusal degraded into "… N more lines" would say nothing at exactly the
+	// moment saying something is the entire point.
+	body := wrapOverlayLines(refusalNotices(short)[len(refusalNotices(short))-1], width)
+	for _, candidate := range refusalNotices(short) {
+		if wrapped := wrapOverlayLines(candidate, width); len(wrapped) <= budget {
+			body = wrapped
+			break
+		}
+	}
 	lines := append([]string{}, body...)
 	if gap > 0 && len(lines) > 0 {
 		lines = append(lines, "")
 	}
 	lines = append(lines, hint...)
+	if len(lines) > height {
+		lines = lines[:height]
+	}
 	return strings.Join(lines, "\n")
+}
+
+// refusalNotices lists the refusal wording from most informative to least. A
+// window too small even for the explanation still gets a true sentence — every
+// variant leads with "Too small", so the reason survives all the way down.
+func refusalNotices(short int) []string {
+	unit := "lines"
+	if short == 1 {
+		unit = "line"
+	}
+	return []string{
+		fmt.Sprintf("Too small to confirm safely — %d more %s needed to show what this destroys. Resize, then try again.", short, unit),
+		fmt.Sprintf("Too small to confirm safely — %d more %s needed. Resize.", short, unit),
+		"Too small to confirm safely · resize",
+		"Too small · resize",
+	}
 }
 
 func (c *ConfirmationOverlay) instruction(compact bool) string {
@@ -152,6 +345,11 @@ func (c *ConfirmationOverlay) instruction(compact bool) string {
 		bold(c.CancelKey) + " or " + bold("esc") + " to cancel"
 }
 
+// windowOverlayBody keeps the leading lines and surrenders the tail, replacing
+// what it drops with a notice that SAYS how much is missing. The old bare "…"
+// was indistinguishable from "there was nothing else to say" — the reader could
+// not tell a styled ellipsis from swallowed content, which is how a hidden
+// consequence reads as an absent one (#1973).
 func windowOverlayBody(lines []string, limit, width int) []string {
 	if limit <= 0 {
 		return nil
@@ -160,9 +358,28 @@ func windowOverlayBody(lines []string, limit, width int) []string {
 		return lines
 	}
 	if limit == 1 {
-		return []string{truncateOverlayLine("…", width)}
+		return []string{truncateOverlayLine(moreLinesNotice(countContentLines(lines)), width)}
 	}
 	out := append([]string{}, lines[:limit-1]...)
-	out = append(out, truncateOverlayLine("…", width))
-	return out
+	return append(out, truncateOverlayLine(moreLinesNotice(countContentLines(lines[limit-1:])), width))
+}
+
+// countContentLines ignores blank spacers so the notice counts lines that
+// actually carry words — "1 more line" must mean one line of text, not a gap.
+func countContentLines(lines []string) int {
+	n := 0
+	for _, l := range lines {
+		if strings.TrimSpace(l) != "" {
+			n++
+		}
+	}
+	return n
+}
+
+// moreLinesNotice names what the clip is hiding and how to read it.
+func moreLinesNotice(n int) string {
+	if n == 1 {
+		return "… 1 more line · resize to read"
+	}
+	return fmt.Sprintf("… %d more lines · resize to read", n)
 }

--- a/ui/overlay/confirmationOverlay_test.go
+++ b/ui/overlay/confirmationOverlay_test.go
@@ -1,9 +1,11 @@
 package overlay
 
 import (
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	xansi "github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -155,4 +157,133 @@ func TestConfirmationOverlay_HandleKeyPress_OtherKey(t *testing.T) {
 	assert.False(t, overlay.Dismissed, "overlay should not be dismissed")
 	assert.False(t, cancelCalled, "OnCancel should not be called")
 	assert.False(t, confirmCalled, "OnConfirm should not be called")
+}
+
+// overlayProse reduces a rendered overlay to the prose inside it, so a multi-word
+// assertion matches content rather than failing on the wrap.
+//
+// It strips ANSI first, then the frame. Both are required: whether the border
+// arrives as "│" glyphs or as colour-escaped spaces depends on lipgloss's colour
+// profile, which is process-global — so a sibling test that enables colour
+// changes what this renders. Stripping only the glyphs passes alone and fails in
+// the full package run.
+func overlayProse(rendered string) string {
+	frame := strings.NewReplacer(
+		"│", " ", "─", " ", "╭", " ", "╮", " ", "╰", " ", "╯", " ",
+	)
+	return strings.Join(strings.Fields(frame.Replace(xansi.Strip(rendered))), " ")
+}
+
+// TestConfirmationOverlay_GuardedMessageIsNeverClipped: a guarded overlay (one
+// with a detail set) must render its message in full. The message carries the
+// consequences the user is consenting to; windowOverlayBody drops the TAIL, so
+// without this guarantee the last consequence silently vanishes and the user
+// confirms something the dialog never showed them (#1973).
+func TestConfirmationOverlay_GuardedMessageIsNeverClipped(t *testing.T) {
+	c := NewConfirmationOverlay("[!] Delete project 'acme'?\n1 in-place session torn down — not restorable.\n2 sessions archived — restorable.")
+	c.SetDetail("Its worktree is yours — the branch and uncommitted changes stay exactly where they are, but the session and its agent are gone. Restore an archived session to bring the project back.")
+	c.SetWidth(50)
+	c.SetMaxSize(40, 10)
+
+	rendered := overlayProse(c.Render())
+	assert.Contains(t, rendered, "1 in-place session torn down — not restorable.",
+		"the destructive consequence must survive at the declared 40x10 floor")
+	assert.Contains(t, rendered, "2 sessions archived — restorable.",
+		"and so must the other half of the split")
+	assert.Contains(t, rendered, "confirm",
+		"the confirm prompt must render alongside it")
+}
+
+// TestConfirmationOverlay_ClippedDetailIsAnnounced: when the elaboration does
+// not fit, the overlay must SAY so. A bare "…" (or nothing at all) is
+// indistinguishable from "there was nothing more to say".
+func TestConfirmationOverlay_ClippedDetailIsAnnounced(t *testing.T) {
+	c := NewConfirmationOverlay("[!] Delete project 'acme'?\n1 in-place session torn down — not restorable.")
+	c.SetDetail("Line one of elaboration that will not fit. Line two of elaboration. Line three of elaboration. Line four of elaboration that keeps going for a while.")
+	c.SetWidth(50)
+	c.SetMaxSize(40, 10)
+
+	rendered := c.Render()
+	assert.Contains(t, rendered, "resize to read",
+		"clipped detail must name itself; silence reads as completeness")
+	assert.Regexp(t, `more line`, rendered, "the notice must say how much is hidden")
+}
+
+// TestConfirmationOverlay_TooSmallRefusesConfirm: a destructive confirm that
+// cannot render its consequences has no business collecting a 'y'. The refusal
+// must be real — the key handler rejects the confirm, not just the renderer
+// showing a warning — otherwise a blind 'y' still fires the action (#1973).
+// The trigger is realistic rather than contrived: at the declared 40x10 floor a
+// long project name wraps the title onto a second line, which pushes the split
+// past the four-line body budget. That is the backstop the guarantee needs —
+// the copy is tuned to fit typical names, and refuses rather than clips when it
+// cannot.
+func TestConfirmationOverlay_TooSmallRefusesConfirm(t *testing.T) {
+	c := NewConfirmationOverlay("[!] Delete project 'a-project-with-a-very-long-name-indeed'?\n3 in-place sessions torn down — not restorable.\n7 sessions archived — restorable.")
+	c.SetDetail("Elaboration that does not matter here.")
+	c.SetWidth(50)
+	c.SetMaxSize(40, 10)
+
+	confirmed := false
+	c.OnConfirm = func() { confirmed = true }
+	cancelled := false
+	c.OnCancel = func() { cancelled = true }
+
+	rendered := overlayProse(c.Render())
+	assert.Contains(t, rendered, "Too small to confirm safely",
+		"an overlay that cannot show the consequences must say why")
+	assert.NotContains(t, rendered, "7 sessions archived",
+		"a refused dialog must not show the reassuring half either — that is the trap")
+
+	shouldClose := c.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	assert.False(t, shouldClose, "the dialog must stay open so the user can resize and read it")
+	assert.False(t, confirmed, "a 'y' typed blind against an unreadable dialog must NOT confirm")
+	assert.False(t, c.Dismissed)
+
+	// Esc must always work — the user is never trapped.
+	shouldClose = c.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEsc})
+	assert.True(t, shouldClose, "esc must still cancel a refused dialog")
+	assert.True(t, cancelled)
+}
+
+// TestConfirmationOverlay_RefusalSurvivesDegenerateSizes: the refusal must say
+// something true even when the window is far too small for its own explanation.
+// Windowing it would degrade the refusal into a bare "… N more lines" notice —
+// swallowing the reason at exactly the moment the reason is the whole point,
+// which is the same defect one level up.
+func TestConfirmationOverlay_RefusalSurvivesDegenerateSizes(t *testing.T) {
+	for _, size := range [][2]int{{30, 6}, {40, 7}, {24, 5}} {
+		c := NewConfirmationOverlay("[!] Delete project 'acme'?\n2 in-place sessions torn down — not restorable.\n5 sessions archived — restorable.")
+		c.SetDetail("Elaboration.")
+		c.SetWidth(50)
+		c.SetMaxSize(size[0], size[1])
+
+		confirmed := false
+		c.OnConfirm = func() { confirmed = true }
+
+		rendered := overlayProse(c.Render())
+		assert.Contains(t, rendered, "Too small", "at %dx%d the refusal must still name itself, got: %q", size[0], size[1], rendered)
+		assert.NotRegexp(t, `^\s*…`, rendered, "the refusal must never degrade into a bare ellipsis at %dx%d", size[0], size[1])
+
+		c.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+		assert.False(t, confirmed, "a refused dialog must not confirm at %dx%d", size[0], size[1])
+	}
+}
+
+// TestConfirmationOverlay_UnguardedKeepsConfirming: overlays with no detail (the
+// existing archive/kill confirms) keep their historical behavior — they clip
+// rather than refuse. The guarantee is opt-in via SetDetail, so this fix does
+// not silently make every confirm in the app refusable.
+func TestConfirmationOverlay_UnguardedKeepsConfirming(t *testing.T) {
+	c := NewConfirmationOverlay(strings.Repeat("a long confirmation message that will certainly not fit. ", 8))
+	c.SetWidth(50)
+	c.SetMaxSize(30, 6)
+
+	confirmed := false
+	c.OnConfirm = func() { confirmed = true }
+
+	assert.NotContains(t, c.Render(), "Too small to confirm safely",
+		"an unguarded overlay must not start refusing")
+	assert.True(t, c.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")}))
+	assert.True(t, confirmed, "unguarded confirms keep working exactly as before")
 }

--- a/ui/overlay/projectPickerOverlay.go
+++ b/ui/overlay/projectPickerOverlay.go
@@ -18,6 +18,12 @@ type Project struct {
 	Name         string
 	Root         string
 	SessionCount int
+	// InPlaceCount is how many of SessionCount's live sessions sit on an
+	// in-place/external worktree (`af sessions create --here`, the root agent).
+	// Delete-project cannot archive those — it tears them down (#1973) — so the
+	// confirmation must state the real archived-vs-torn-down split before the
+	// user consents. Derived from the same cross-repo snapshot as SessionCount.
+	InPlaceCount int
 }
 
 // ProjectPickerOverlay is the project switcher (#1461). It navigates like the

--- a/ui/projects.go
+++ b/ui/projects.go
@@ -22,6 +22,11 @@ type SidebarProject struct {
 	Name         string
 	Root         string
 	SessionCount int
+	// InPlaceCount is how many of SessionCount's live sessions sit on an
+	// in-place/external worktree, which delete-project tears down rather than
+	// archives (#1973). Carried so the delete confirmation can state the real
+	// split; the row label itself renders only the total.
+	InPlaceCount int
 	Active       bool
 }
 


### PR DESCRIPTION
Fixes #1973.

The delete-project confirmation and its completion notice promised a reversibility we do not deliver. In-place/external-worktree sessions (`af sessions create --here`, and every root agent) are **killed**, not archived — and the user consented on the basis of a message that said "archived" and offered `af sessions restore`. The message is the entire basis on which the user agreed to a destructive action.

**Gate P1 (fixed in 69edcda).** The first pass of this fix got the words right and the layout wrong: the overlay clips from the bottom, the copy led with the reassuring half, and so the non-restorable count fell below the fold on a short terminal. A fix for "the dialog does not tell the truth" whose truth is invisible is not a fix. Details in §3.

## 1. Is the pre-confirm split knowable? Yes — and this PR states it

The issue's recommended fix hedges: *"use wording like archived or torn down … unless/until the UI can accurately precompute the breakdown."* I tested that hedge rather than accepting it. **It is unnecessary — the breakdown is already in the TUI's projection.**

1. The daemon's decision is exactly one predicate — `daemon/deleteproject.go:118` records `external: inst.IsExternalWorktree()` per live session, then kills the externals and archives the rest.
2. `Instance.IsExternalWorktree()` (`session/instance_accessors.go:129`) is `gw != nil && gw.IsExternalWorktree()`.
3. `session/instance_data.go:93` already serializes it as `Worktree.ExternalWorktree` (both read `false` with no worktree, so they agree by construction).
4. `buildProjectListFrom` already iterates that exact `[]session.InstanceData`, reading `d.Worktree.RepoPath` one field away — and skips archived rows with `session.IsArchivedData(d)`, the same filter the daemon applies.

So the split costs one map in a loop that already runs. Confirmed against a live daemon in the sandbox: the TUI independently computed "1 in-place / 2 archived" for a real mixed project.

**Caveat:** the pre-confirm number is a projection and can be one poll stale — the same staleness as the `(3)` already on the project row. The split is exactly as faithful as the total beside it. That is why the **post-action** notice reports the daemon's own `ArchivedCount`/`KilledCount`: the forecast is the best available, the completion is authoritative.

## 2. Should in-place sessions be killed at all, or is *that* the bug?

**Still the owner's call — unchanged here, and the message is honest either way.** My read:

- **Archive is structurally impossible.** Archive relocates the worktree; an in-place worktree *is the user's own tree*. `daemon/archive.go` rejects it up-front.
- **Leaving it running makes delete a no-op** — the project list is derived from live sessions' `RepoPath`, so the project would stay on the list.
- **The kill does not destroy work.** Verified, not assumed: `GitWorktree.Cleanup()` (`session/git/worktree_ops.go:273-276`) returns `nil` immediately for an external worktree — no removal, no branch delete. Tree, branch, uncommitted changes all survive. What dies is the session: `KillSession` deletes the record, so `af sessions restore` cannot bring it back.

So "reversible" is mostly delivered even for in-place sessions — nothing of the user's is destroyed — but restore genuinely does not work. Both halves matter, which is why this is not softened to "N sessions removed": *not restorable* (do not promise restore) **and** *your work is untouched* (do not imply data loss).

If you rule that delete-project must never kill, the honest alternative is to **refuse** the delete while in-place sessions exist and tell the user to kill or convert them first — not to silently leave them running.

## 3. The P1: the truth must be unclippable

**Mechanism** (confirmed at `ui/overlay/confirmationOverlay.go`, `windowOverlayBody`): it keeps `lines[:limit-1]` and appends a bare `…`. Head survives, tail dies. The destructive line was in the tail.

Reordering alone is insufficient — at some size even the first line clips — so all three parts:

**(1) The destructive count leads.** A user who reads exactly one consequence line reads the one that cannot be undone.

**(2) The overlay guarantees the consequences render, or refuses the action.** `ConfirmationOverlay` gains a critical/detail split (`SetDetail`): the message is what must be read; the detail is elaboration. The message is never windowed. If it cannot fit alongside the confirm prompt, the overlay renders a refusal **and `HandleKeyPress` rejects the confirm key** — the render and the key agree, so a `y` typed blind against an unreadable dialog does nothing. Esc always cancels. `Render` and `HandleKeyPress` share one `textRect()`; if they judged fit differently the guarantee would be fiction.

**(3) Clipping announces itself:** `… N more lines · resize to read`. As you noted, the bare `…` was already there — this makes an uninformative indicator informative.

**Why the copy was re-cut.** The guarantee is only useful if the consequences actually fit the floor. At 40x10 the overlay gets a 34x6 text rect → **four body lines**. So the message became headline + elaboration. The clip notice **rides in the blank separator's slot** when room runs out — costing zero lines — which is what lets the split fit at 40x10 *and* still announce that more exists, instead of trading one against the other.

**On refusal.** You asked me to argue it. Refusal is the **backstop, not the 40x10 behavior** — because your own test spec requires the count *and* prompt to render at 40x10, and a delete that refuses at the declared floor would fail the users on small terminals rather than protect them. So the copy is tuned to fit typical names at 40x10, and refuses only when it genuinely cannot render (e.g. a long project name wrapping the title onto a second line). That is the right split: work where we claim to work, refuse where we cannot tell the truth.

### A correction to the repro path (worth knowing)

The gate's 59x14 is real, but **not reachable by opening the dialog at that size**. Below `MinimalWidth/MinimalHeight` (60x15) the layout drops the Projects section entirely, so `D` cannot be pressed at 40x10 or 59x14 — my first test failed for that reason (`focusRegion(RegionProjects)` left the ring on `tree`), which is how I found it.

The dialog is reached by **opening it at a workable size and then shrinking** — an open overlay re-fits on every relayout (`relayout → layoutModalOverlays → SetMaxSize`), so a terminal resize or tmux pane resize re-renders it clipped. **The dialog outlives the size it was opened at.** The tests and play-test drive that path.

### A bug in my own fix, found by testing it

My first refusal was itself too long to render at degenerate sizes, so `windowOverlayBody` replaced it with `… 5 more lines · resize…` — the refusal swallowed by the very mechanism it exists to defeat. It now degrades its wording (`Too small to confirm safely — N more lines needed…` → `Too small · resize`), so the reason survives all the way down. There is a test at 30x6/40x7/24x5.

## 4. Rendered output — mixed project (2 normal + 1 in-place)

Live TUI in `make playtest-container`: mock repo, real daemon, `alpha`/`beta` on their own worktrees, `root-agent` via `--here` (`external_worktree=true`). Armed at 100x40, then the terminal was shrunk with the dialog open.

**100x40:**
```
╭──────────────────────────────────────────────────╮
│  [!] Delete project 'mock-repo'?                 │
│  1 in-place session torn down — not restorable.  │
│  2 sessions archived — restorable.               │
│                                                  │
│  Its worktree is yours — the branch and          │
│  uncommitted changes stay exactly where they     │
│  are, but the session and its agent are gone.    │
│                                                  │
│  Restore an archived session (r, or `af          │
│  sessions restore`) to bring the project back.   │
│  Your real git repository is untouched.          │
│                                                  │
│  Press y to confirm, n or esc to cancel          │
╰──────────────────────────────────────────────────╯
```

**59x14 — the gate's reproduction:**
```
╭──────────────────────────────────────────────────╮
│  [!] Delete project 'mock-repo'?                 │
│  1 in-place session torn down — not restorable.  │
│  2 sessions archived — restorable.               │
│  Its worktree is yours — the branch and          │
│  uncommitted changes stay exactly where they     │
│  are, but the session and its agent are gone.    │
│                                                  │
│  … 3 more lines · resize to read                 │
│                                                  │
│  y confirm • n/esc cancel                        │
╰──────────────────────────────────────────────────╯
```

**40x10 — the declared floor:**
```
╭──────────────────────────────────────╮
│                                      │
│  [!] Delete project 'mock-repo'?     │
│  1 in-place session torn down — not  │
│  restorable.                         │
│  2 sessions archived — restorable.   │
│  … 8 more lines · resize to read     │
│  y confirm • n/esc cancel            │
│                                      │
╰──────────────────────────────────────╯
```

Pressing `y` at 40x10 completed the delete — sidebar went to `Instances (0)` / `Archived (2)`, and `af sessions list` confirmed only `alpha` and `beta` remain (liveness=archived). `root-agent` is gone. The outcome matched what the dialog promised, at the floor.

**Result notice** (unchanged from the previous round, same reasoning — the error box clips the line to the pane width, so the torn-down half leads):
```
Deleted project 'mock-repo' — tore down 1 in-place session (not restorable, worktree and…  E details
```
Full string via `E details`:
```
Deleted project 'mock-repo' — tore down 1 in-place session (not restorable, worktree and branch untouched) · archived 2 sessions (restorable)
```

## 5. What the old code rendered (fail-first)

Every test was watched failing against the previous head — the exact bytes the gate reviewed. At **40x10**:

```
[!] Delete project 'acme'? 2 sessions are archived and … y confirm • n/esc cancel
```

The kill is invisible. At **59x14** it is worse, because it reads as complete and reassuring:

```
[!] Delete project 'acme'? 2 sessions are archived and restorable — tmux torn down,
worktrees moved out, branches and uncommitted work preserved. Restore any of them
(r, or `af sessions restore`) to bring the project back. … y confirm • n/esc cancel
```

It offers restore, and the torn-down session is behind a bare `…`.

Earlier round, worst case — a project whose only session is an in-place root agent: `Its 1 session are archived … Restore any archived session … to bring the project back.` Every clause false; also ungrammatical.

## 6. Sweep: `windowOverlayBody` and the truncation class

**Callers of `windowOverlayBody`: exactly two, both inside `confirmationOverlay.go`** (the detail window and the unguarded body). It is not shared beyond this file — I am reporting that precisely rather than implying a wide blast radius.

The class is broader than the helper, so I swept the sibling overlays for load-bearing content placed last:

| Overlay | Clips? | Reachable? | Verdict |
|---|---|---|---|
| `selectionOverlay` | yes | cursor window + `… more above` / `… more below` | fine — already the good pattern |
| `projectPickerOverlay` | yes | cursor-following window; trailing "+ Add project…" is navigable | fine |
| `searchOverlay` | yes | cursor-driven result list | fine |
| `textOverlay` (help, `E details`) | yes | **scrollable** (`ScrollUp`/`ScrollDown`) | fine — also why the full result string stays retrievable |
| `confirmationOverlay` | yes | **no navigation, no scroll** | **was the bug** |

**The distinction that matters:** clipping is safe when the clipped content is *reachable* — every list follows the cursor, and the text overlay scrolls. The confirmation overlay is the only surface that is static, unscrollable prose **and** the only one that collects an irreversible decision. What it dropped was simply gone.

**Same shape as #1983** (truncated tab name eating the active-tab `*`): the layout drops whatever is last, and what is last is what mattered. Both are instances of one class — *a surface that cannot scroll must never place load-bearing content where the layout truncates, and the truncation must announce itself.* A tab label cannot scroll either, so its `*` is unreachable exactly like this dialog's killed count. I have not touched #1983 here; flagging the shared root.

Third instance, same night, found by play-testing this PR: the transient notice (`showTransientMessage` → `errBox`) is width-clipped, which is why the result message leads with the torn-down half.

## 7. Prod gate and test provenance

**The chain:** `handleProjectsFocus` (`app/handle_overlay.go:151`) fires only with the ring on `RegionProjects`; matches `keys.KeyDeleteProject` (`D`); takes `m.projects.SelectedProject()` (a `ui.SidebarProject`) → `handleDeleteProject` → `confirmActionWithDetail`. On `y`: `OnConfirm` stashes `startDeleteProjectMsg` → `handleStateConfirm` forwards → `deleteProjectCmd` dials the daemon → `handleProjectDeleted` renders the notice.

**Why `InPlaceCount` is threaded rather than computed in the dialog:** `handleDeleteProject` only sees a `ui.SidebarProject`, populated by `projectRows` ← `buildProjectListFrom` ← the daemon snapshot. A test hand-building `ui.SidebarProject{InPlaceCount: 1}` would assert the copy while skipping the derivation. So the tests drive `refreshSidebarProjects()` through the stubbed fetcher and press the real `D` on the real focused section.

**Repros vs locks** — only some of these are evidence:

| Test | vs. unfixed code | Kind |
|---|---|---|
| compact 40x10 / 59x14 (rendered) | FAILS — kill invisible behind `…` | **repro (the P1)** |
| confirm · mixed | FAILS — "Its 3 sessions are archived" | **repro** |
| confirm · in-place-only | FAILS — claims archived, offers restore | **repro** |
| result · mixed / in-place-only | FAILS — `killed` dropped; "archived 0 (restorable)" | **repro** |
| overlay guarantee / refusal / refusal-degradation | new behavior, no prior equivalent | lock |
| confirm · normal-only | FAILS on rewording only — old copy was not lying here | lock |
| result · normal-only | **PASSES** unfixed — never buggy | lock |

**One more honest note:** `TestConfirmationOverlay_GuardedMessageIsNeverClipped` initially passed alone and failed in the full suite — lipgloss's colour profile is process-global, so a sibling test enabling colour changed the border from `│` glyphs into colour-escaped spaces and my assertion helper only stripped glyphs. Both helpers now strip ANSI first. Worth knowing: **a rendered-output assertion that passes in isolation can be depending on which tests ran before it.**

## Gates

`make test-container` (full suite), `go build ./...`, `gofmt -l .`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh` — all six clean. Play-tested in the container sandbox (mock repo; never this repo, never the real AF home).

No bot has reviewed this head, and I am not treating GitHub's silence as a gate. Held **draft** deliberately — please gate and land it yourself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
