### PR TITLE
fix(shell): route every pasteable command through one shellsuggest seam (#1978)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -75,6 +75,18 @@ jobs:
           go-version: "1.25"
           cache: true
 
+      # internal/shellsuggest builds the shell commands we PRINT for a user to
+      # paste, and claims correctness in sh, bash AND zsh — so its tests execute
+      # under each. zsh is the one that matters most: it has been macOS's default
+      # login shell since Catalina, so it is what most readers actually paste
+      # into, and it is the ONLY one of the three where a leading '=' expands
+      # (#1978). The ubuntu runner ships sh and bash but not zsh; without this the
+      # suite would cover two of the three shells it claims, and a zsh-only defect
+      # would reach users with CI green — the same gap test-macos exists to close,
+      # one layer down. The macOS runner already ships zsh, so this is Linux-only.
+      - name: Install zsh
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends zsh
+
       - name: Run tests
         run: go test -v -race -count=1 ./...
 

--- a/api/apicmd.go
+++ b/api/apicmd.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sachiniyer/agent-factory/apiproto"
 	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/internal/shellsuggest"
 
 	"github.com/spf13/cobra"
 )
@@ -131,23 +132,8 @@ func routeName(rt daemon.HTTPRoute) string {
 // no-argument RPC accepts as-is and every other RPC accepts as a starting point
 // to fill in.
 func curlExample(socketPath string, rt daemon.HTTPRoute) string {
-	base := fmt.Sprintf("curl --unix-socket %s http://localhost%s", shellQuoteArg(socketPath), rt.Path)
 	if rt.Method == "GET" {
-		return base
+		return shellsuggest.Command("curl", "--unix-socket", socketPath, "http://localhost"+rt.Path)
 	}
-	return base + " -d '{}'"
-}
-
-func shellQuoteArg(arg string) string {
-	if arg == "" {
-		return "''"
-	}
-	for _, r := range arg {
-		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') ||
-			strings.ContainsRune("@%_+=:,./-", r) {
-			continue
-		}
-		return "'" + strings.ReplaceAll(arg, "'", `'\''`) + "'"
-	}
-	return arg
+	return shellsuggest.Command("curl", "--unix-socket", socketPath, "http://localhost"+rt.Path, "-d", "{}")
 }

--- a/api/sessions.go
+++ b/api/sessions.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/git"
 
+	"github.com/sachiniyer/agent-factory/internal/shellsuggest"
 	"github.com/spf13/cobra"
 )
 
@@ -459,7 +460,7 @@ results.`,
 			return jsonError(err)
 		}
 		if !exists {
-			return jsonError(fmt.Errorf("session %q not found. Use --create to auto-create the session, or run: af sessions create --name %q --prompt <prompt>", title, title))
+			return jsonError(fmt.Errorf("session %q not found. Use --create to auto-create the session, or run: %s --prompt <prompt>", title, shellsuggest.Command("af", "sessions", "create", "--name", title)))
 		}
 
 		if err := sendPromptViaDaemon(daemon.SendPromptRequest{Title: title, RepoID: repoID, Prompt: prompt}); err != nil {

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sachiniyer/agent-factory/ui"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/sachiniyer/agent-factory/internal/shellsuggest"
 )
 
 // handleDefaultKeyPress handles key events in stateDefault (main interaction state).
@@ -685,10 +686,10 @@ func interactiveGuard(inst *session.Instance) error {
 		// record. Entering or attaching is impossible right now; say what
 		// happened — same explicit-feedback contract as the Deleting path
 		// (#935). Checked before TmuxAlive so the specific message wins.
-		return fmt.Errorf("session '%s' was lost — restore it first (af sessions restore %s)", inst.Title, inst.Title)
+		return fmt.Errorf("session '%s' was lost — restore it first (%s)", inst.Title, shellsuggest.Command("af", "sessions", "restore", inst.Title))
 	}
 	if inst.GetLiveness() == session.LiveDead {
-		return fmt.Errorf("session '%s' is no longer running — restore it first (af sessions restore %s)", inst.Title, inst.Title)
+		return fmt.Errorf("session '%s' is no longer running — restore it first (%s)", inst.Title, shellsuggest.Command("af", "sessions", "restore", inst.Title))
 	}
 	if inst.GetLiveness() == session.LiveArchived {
 		// Archived (#1028): the user tore the session down and its worktree was
@@ -696,7 +697,7 @@ func interactiveGuard(inst *session.Instance) error {
 		// Point at the off-ramp (restore) rather than a bare "not running" —
 		// same explicit-feedback contract as Lost/Deleting. Checked before
 		// TmuxAlive so the specific message wins.
-		return fmt.Errorf("session '%s' is archived — restore it first (af sessions restore %s)", inst.Title, inst.Title)
+		return fmt.Errorf("session '%s' is archived — restore it first (%s)", inst.Title, shellsuggest.Command("af", "sessions", "restore", inst.Title))
 	}
 	if !inst.TmuxAlive() {
 		return fmt.Errorf("session '%s' is no longer running", inst.Title)

--- a/app/handle_panes.go
+++ b/app/handle_panes.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sachiniyer/agent-factory/ui/tree"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/sachiniyer/agent-factory/internal/shellsuggest"
 )
 
 // This file hosts the N-pane verbs (#1088, RFC §2.3, replacing the PR-5 A/B
@@ -567,10 +568,10 @@ func (m *home) handleEnterPane(p *store.OpenPane) (tea.Model, tea.Cmd) {
 		return m, m.handleError(fmt.Errorf("session '%s' is being restored", instance.Title))
 	}
 	if instance.GetLiveness() == session.LiveLost {
-		return m, m.handleError(fmt.Errorf("session '%s' was lost — restore it first (af sessions restore %s)", instance.Title, instance.Title))
+		return m, m.handleError(fmt.Errorf("session '%s' was lost — restore it first (%s)", instance.Title, shellsuggest.Command("af", "sessions", "restore", instance.Title)))
 	}
 	if instance.GetLiveness() == session.LiveDead {
-		return m, m.handleError(fmt.Errorf("session '%s' is no longer running — restore it first (af sessions restore %s)", instance.Title, instance.Title))
+		return m, m.handleError(fmt.Errorf("session '%s' is no longer running — restore it first (%s)", instance.Title, shellsuggest.Command("af", "sessions", "restore", instance.Title)))
 	}
 	if !instance.TmuxAlive() {
 		return m, m.handleError(fmt.Errorf("session '%s' is no longer running", instance.Title))

--- a/daemon/deliver_prompt_test.go
+++ b/daemon/deliver_prompt_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/shellsuggest"
 	"github.com/sachiniyer/agent-factory/internal/testguard"
 	"github.com/sachiniyer/agent-factory/session"
 	sessiongit "github.com/sachiniyer/agent-factory/session/git"
@@ -389,20 +390,26 @@ func TestDeliverPrompt_RefusesArchivedTargetBeforeTmuxSend(t *testing.T) {
 
 // TestPromptTargetLivenessError_ArchivedQuotesRestoreCommand pins that the
 // suggested `af sessions restore <title>` command is shell-safe (#1529): a
-// title with a space or shell metacharacter must be single-quoted so a
-// copy-pasted command restores the intended session and cannot smuggle a second
-// shell command. A plain title stays unquoted so the common case reads cleanly.
+// title with a space or shell metacharacter must be quoted so a copy-pasted
+// command restores the intended session and cannot smuggle a second shell
+// command. A plain title stays unquoted so the common case reads cleanly.
+//
+// It asserts this site routes through the shellsuggest seam rather than pinning
+// a literal quoting idiom (#1978): the idiom is the seam's business, and
+// shellsuggest's own tests prove it by EXECUTING the result in a real shell —
+// which is the property that matters and which a string comparison here could
+// never establish. What stays local is the check that carries the value: the
+// raw, unquoted form must not appear.
 func TestPromptTargetLivenessError_ArchivedQuotesRestoreCommand(t *testing.T) {
 	cases := []struct {
 		name     string
 		title    string
-		wantCmd  string
 		unwanted string // a raw, unquoted form that must NOT appear
 	}{
-		{"plain title unquoted", "captain", "af sessions restore captain", ""},
-		{"space quoted", "my session", "af sessions restore 'my session'", "restore my session)"},
-		{"semicolon quoted", "a;rm -rf ~", "af sessions restore 'a;rm -rf ~'", "restore a;rm -rf ~"},
-		{"embedded quote escaped", "it's", `af sessions restore 'it'"'"'s'`, ""},
+		{"plain title unquoted", "captain", ""},
+		{"space quoted", "my session", "restore my session)"},
+		{"semicolon quoted", "a;rm -rf ~", "restore a;rm -rf ~"},
+		{"embedded quote escaped", "it's", ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -410,13 +417,20 @@ func TestPromptTargetLivenessError_ArchivedQuotesRestoreCommand(t *testing.T) {
 			if err == nil {
 				t.Fatalf("expected an Archived liveness error for %q", tc.title)
 			}
-			if !strings.Contains(err.Error(), tc.wantCmd) {
-				t.Fatalf("expected restore command %q in error, got: %v", tc.wantCmd, err)
+			wantCmd := shellsuggest.Command("af", "sessions", "restore", tc.title)
+			if !strings.Contains(err.Error(), wantCmd) {
+				t.Fatalf("expected restore command %q in error, got: %v", wantCmd, err)
 			}
 			if tc.unwanted != "" && strings.Contains(err.Error(), tc.unwanted) {
 				t.Fatalf("error must not contain the unquoted command %q (shell-injection risk), got: %v", tc.unwanted, err)
 			}
 		})
+	}
+
+	// The readable common case is a real requirement, not an accident of the
+	// seam: a suggestion exists to be read, so pin it literally here.
+	if got := shellsuggest.Command("af", "sessions", "restore", "captain"); got != "af sessions restore captain" {
+		t.Errorf("plain title must stay unquoted for readability, got %q", got)
 	}
 }
 

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sachiniyer/agent-factory/agentproto"
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/shellsuggest"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/git"
@@ -450,7 +451,7 @@ func (m *Manager) validateTitleAvailableLocked(repoID, repoPath, title, program 
 		// No creator will ever finish it, so this stays a plain error (not
 		// errConcurrentCreate): DeliverPrompt must fail fast with cleanup
 		// guidance rather than wait out waitForTargetSession's timeout (#916).
-		return fmt.Errorf("conflicting tmux session %q is already running; no agent-factory session owns it. Clean it up with: tmux kill-session -t %s", title, tmuxSession.SanitizedName())
+		return fmt.Errorf("conflicting tmux session %q is already running; no agent-factory session owns it. Clean it up with: %s", title, shellsuggest.Command("tmux", "kill-session", "-t", tmuxSession.SanitizedName()))
 	}
 	return nil
 }

--- a/daemon/manager_sessions.go
+++ b/daemon/manager_sessions.go
@@ -2,9 +2,9 @@ package daemon
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/shellsuggest"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 )
@@ -199,26 +199,9 @@ func promptTargetLivenessError(title string, liveness session.Liveness) error {
 		// restore command embeds the title, so shell-quote it — a title with
 		// spaces or shell metacharacters must not turn a copy-pasted
 		// `af sessions restore ...` into the wrong target or a second command.
-		return fmt.Errorf("target session %q is Archived; prompt not delivered; restore it first (af sessions restore %s)", title, shellQuoteArg(title))
+		return fmt.Errorf("target session %q is Archived; prompt not delivered; restore it first (%s)", title, shellsuggest.Command("af", "sessions", "restore", title))
 	}
 	return nil
-}
-
-// shellQuoteArg makes s safe to paste as a single shell argument: already-safe
-// strings pass through unquoted (so the common `restore captain` stays clean),
-// and anything with whitespace/metacharacters is single-quoted with embedded
-// quotes escaped. Mirrors the sibling copies in session/tmux/resume.go and
-// api/apicmd.go (a shared util is a separate consolidation, #1529).
-func shellQuoteArg(s string) string {
-	if s != "" && strings.IndexFunc(s, func(r rune) bool {
-		return !((r >= 'a' && r <= 'z') ||
-			(r >= 'A' && r <= 'Z') ||
-			(r >= '0' && r <= '9') ||
-			strings.ContainsRune("_@%+=:,./-", r))
-	}) == -1 {
-		return s
-	}
-	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
 }
 
 // agentServerForStream resolves the /v1/sessions/{id}/stream target to its cached

--- a/doctor/checks.go
+++ b/doctor/checks.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/internal/proctree"
+	"github.com/sachiniyer/agent-factory/internal/shellsuggest"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
@@ -331,7 +332,10 @@ func checkLeakedTmuxSessions(ctx *scanContext, report *Report) {
 		report.Findings = append(report.Findings, Finding{
 			Check: "leaked-tmux-session",
 			Detail: fmt.Sprintf("tmux session %s has no backing record in %s (%s); "+
-				"kill it with: tmux kill-session -t '=%s:'", name, ctx.opts.ConfigDir, origin, name),
+				"kill it with: %s", name, ctx.opts.ConfigDir, origin,
+				// "=name:" is tmux's exact-match target syntax — one argument, so
+				// it is one piece the seam quotes as a whole.
+				shellsuggest.Command("tmux", "kill-session", "-t", "="+name+":")),
 		})
 	}
 }

--- a/doctor/remote.go
+++ b/doctor/remote.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/shellsuggest"
 )
 
 // defaultRemoteConfig resolves the remote-hook backend for the repository
@@ -177,8 +178,8 @@ func hookExecIssue(field, cmd, configHint string) string {
 				"executable — check the path %s", field, cmd, configHint)
 		}
 		if info.Mode().Perm()&0o111 == 0 {
-			return fmt.Sprintf("remote_hooks.%s script %s is not executable — run: chmod +x %s",
-				field, cmd, cmd)
+			return fmt.Sprintf("remote_hooks.%s script %s is not executable — run: %s",
+				field, cmd, shellsuggest.Command("chmod", "+x", cmd))
 		}
 		return ""
 	}

--- a/doctor/setup.go
+++ b/doctor/setup.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/shellsuggest"
 	aflog "github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/preflight"
 	"github.com/sachiniyer/agent-factory/session/tmux"
@@ -107,7 +108,7 @@ func checkConfig(_ *scanContext, report *Report) *config.Config {
 	if _, statErr := os.Stat(path); statErr != nil {
 		report.Findings = append(report.Findings, Finding{
 			Check:  "config",
-			Detail: fmt.Sprintf("config loaded in memory but %s is not materialized on disk — run `af config set default_program %s` or fix AF home permissions: %v", path, cfg.DefaultProgram, statErr),
+			Detail: fmt.Sprintf("config loaded in memory but %s is not materialized on disk — run `%s` or fix AF home permissions: %v", path, shellsuggest.Command("af", "config", "set", "default_program", cfg.DefaultProgram), statErr),
 		})
 		return cfg
 	}

--- a/internal/shellsuggest/shellsuggest.go
+++ b/internal/shellsuggest/shellsuggest.go
@@ -1,0 +1,93 @@
+// Package shellsuggest builds the shell commands af PRINTS for a human to paste
+// and run by hand ("kill it with: …", "restore it first (…)", "run: chmod +x …").
+//
+// It exists because those commands are built from values a user chose — session
+// titles, filesystem paths, config values — and titles are not shell-safe by
+// construction: toTmuxName (session/tmux/session.go) rewrites only the characters
+// TMUX needs, and its own comment notes that other punctuation is "preserved
+// verbatim". So a session titled  deploy `id` ; echo hi  reaches these commands
+// intact. Interpolated raw, the printed command either fails or — worse — reads
+// like one thing and does another. It is printed exactly when someone is already
+// cleaning up a mess, which is when it most has to be right (#1978).
+//
+// # Why a seam rather than "remember to quote"
+//
+// Quoting correctly at each of ten call sites is a habit, and habits lose to the
+// next contributor: the class was already understood and fixed at ONE site
+// (daemon/manager_sessions.go, whose comment states the hazard exactly) while
+// nine others kept printing raw values — one of them the very same
+// `af sessions restore` suggestion. #1915's redaction guard was bypassed by
+// adjacent sites twice for the same reason.
+//
+// So the suggestion API takes the command's PIECES, never a preformatted string.
+// There is no parameter to smuggle an unquoted `fmt.Sprintf` through, and every
+// piece is quoted on the way out. Doing it right is the only thing the seam lets
+// you do, and it keeps the phrasing of what we tell users to run consistent.
+//
+// # Scope
+//
+// This is for commands we PRINT. Strings af itself feeds to a shell (ssh scripts,
+// tmux program strings) are a different job with different helpers; consolidating
+// those is #1529.
+package shellsuggest
+
+import "strings"
+
+// shellSafeChars are the punctuation runes a POSIX shell treats literally in an
+// unquoted word, so a value made only of these (plus alphanumerics) needs no
+// quoting and stays readable.
+const shellSafeChars = "_@%+=:,./-"
+
+// Arg renders s as exactly ONE shell argument.
+//
+// Values that need no quoting pass through, so the common suggestion stays clean
+// and readable (`af sessions restore captain`, not `af sessions restore 'captain'`)
+// — readability matters for a string whose whole purpose is to be read and pasted.
+// Anything else is single-quoted, with embedded single quotes escaped by the
+// standard POSIX idiom ('\”), which makes every other metacharacter — space, ",
+// $, backtick, ;, newline — literal.
+//
+// Prefer Command: a bare Arg still leaves a caller assembling a command by hand.
+// Arg is exported for the rare site that must interleave quoted values with
+// literal shell syntax it controls.
+func Arg(s string) string {
+	if s == "" {
+		return "''"
+	}
+	if !strings.ContainsFunc(s, needsQuoting) {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+func needsQuoting(r rune) bool {
+	switch {
+	case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		return false
+	case strings.ContainsRune(shellSafeChars, r):
+		return false
+	default:
+		return true
+	}
+}
+
+// Command renders a command that is safe to paste, from its pieces: the program
+// name and each argument, quoted individually.
+//
+// It deliberately takes pieces rather than a format string — that is the whole
+// point of the seam. Pass the raw values; do NOT pre-format them:
+//
+//	shellsuggest.Command("tmux", "kill-session", "-t", sessionName)  // yes
+//	shellsuggest.Command("tmux kill-session -t " + sessionName)      // defeats it
+//
+// The second compiles (it is a valid one-piece command) but quotes the whole
+// string as a single argument, which is visibly wrong in the output — the failure
+// is loud rather than silent.
+func Command(name string, args ...string) string {
+	parts := make([]string, 0, len(args)+1)
+	parts = append(parts, Arg(name))
+	for _, a := range args {
+		parts = append(parts, Arg(a))
+	}
+	return strings.Join(parts, " ")
+}

--- a/internal/shellsuggest/shellsuggest.go
+++ b/internal/shellsuggest/shellsuggest.go
@@ -83,11 +83,24 @@ func needsQuoting(r rune) bool {
 // The second compiles (it is a valid one-piece command) but quotes the whole
 // string as a single argument, which is visibly wrong in the output — the failure
 // is loud rather than silent.
+//
+// Built with a strings.Builder rather than the obvious
+// make([]string, 0, len(args)+1) + strings.Join. That form tripped CodeQL's
+// go/allocation-size-overflow (high) on `len(args)+1` inside make(). The alert
+// was a FALSE POSITIVE — every call site passes a fixed literal arg list, so
+// len(args) is a small compile-time constant, and reaching an overflow would
+// need a []string of ~2^63 elements (~10^20 bytes of headers alone), which
+// cannot be constructed. But the arithmetic bought nothing on a path that runs
+// only while formatting an error message for a human, and code with no
+// allocation-size expression at all beats code that argues with a scanner. Do
+// not "optimise" this back into make()+Join: it re-raises a required-check
+// failure to save an allocation nobody will ever measure (#1978).
 func Command(name string, args ...string) string {
-	parts := make([]string, 0, len(args)+1)
-	parts = append(parts, Arg(name))
+	var b strings.Builder
+	b.WriteString(Arg(name))
 	for _, a := range args {
-		parts = append(parts, Arg(a))
+		b.WriteByte(' ')
+		b.WriteString(Arg(a))
 	}
-	return strings.Join(parts, " ")
+	return b.String()
 }

--- a/internal/shellsuggest/shellsuggest.go
+++ b/internal/shellsuggest/shellsuggest.go
@@ -33,19 +33,28 @@ package shellsuggest
 
 import "strings"
 
-// shellSafeChars are the punctuation runes a POSIX shell treats literally in an
-// unquoted word, so a value made only of these (plus alphanumerics) needs no
-// quoting and stays readable.
+// shellSafeChars are the punctuation runes sh, bash and zsh all treat literally
+// in the MIDDLE of an unquoted word, so a value made only of these (plus
+// alphanumerics) needs no quoting and stays readable.
+//
+// Position matters: see startsExpandable — some of these are inert mid-word and
+// expand at the START of one.
 const shellSafeChars = "_@%+=:,./-"
 
-// Arg renders s as exactly ONE shell argument.
+// Arg renders s as exactly ONE shell argument, correct in **sh, bash and zsh**.
+//
+// Naming the shells is deliberate: "shell-safe" with no named target is a vibe,
+// not a claim, and the next contributor inherits whichever shells the last one
+// happened to think about. zsh is not optional here — it has been macOS's default
+// login shell since Catalina, so it is the shell most readers of these
+// suggestions are pasting into.
 //
 // Values that need no quoting pass through, so the common suggestion stays clean
 // and readable (`af sessions restore captain`, not `af sessions restore 'captain'`)
 // — readability matters for a string whose whole purpose is to be read and pasted.
 // Anything else is single-quoted, with embedded single quotes escaped by the
 // standard POSIX idiom ('\”), which makes every other metacharacter — space, ",
-// $, backtick, ;, newline — literal.
+// $, backtick, ;, newline — literal in all three shells.
 //
 // Prefer Command: a bare Arg still leaves a caller assembling a command by hand.
 // Arg is exported for the rare site that must interleave quoted values with
@@ -54,10 +63,39 @@ func Arg(s string) string {
 	if s == "" {
 		return "''"
 	}
-	if !strings.ContainsFunc(s, needsQuoting) {
+	if !startsExpandable(s) && !strings.ContainsFunc(s, needsQuoting) {
 		return s
 	}
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// startsExpandable reports whether s begins with a character that is inert in the
+// middle of a word but EXPANDS at the start of one, so the passthrough must judge
+// the first character more strictly than the rest.
+//
+//	'='  zsh equals-expansion: an unquoted word starting with '=' expands to the
+//	     path of that command (the EQUALS option, on by default). `=foo:` becomes
+//	     "foo: not found" and the command does not run. sh/bash leave it alone —
+//	     so a bash-only test passes against this bug, which is why the test for it
+//	     executes under zsh (#1978 review).
+//
+// This is not hypothetical for us: exactTarget() (session/tmux/cleanup.go) builds
+// "=<name>:" precisely BECAUSE the '=' makes tmux match that session EXACTLY
+// rather than prefix-matching a sibling (#1006). So the arguments most likely to
+// start with '=' are exactly the ones where hitting the wrong target is the
+// disaster the '=' was added to avoid.
+//
+// '~' (tilde expansion, sh/bash/zsh) needs no case here: it is absent from
+// shellSafeChars, so the general rule already quotes it. '%' is a job spec only
+// as an argument to a job-control builtin (kill/fg/bg), which we never suggest,
+// and both shells leave it literal otherwise — verified, not assumed.
+//
+// A leading '-' is deliberately NOT handled: quoting does not stop a program
+// parsing '-rf' as a flag (the shell passes the same bytes either way), that is a
+// job for a "--" separator at the call site, and quoting every "-t"/"--init" we
+// pass would make the common suggestion unreadable for no gain.
+func startsExpandable(s string) bool {
+	return s[0] == '='
 }
 
 func needsQuoting(r rune) bool {

--- a/internal/shellsuggest/shellsuggest_test.go
+++ b/internal/shellsuggest/shellsuggest_test.go
@@ -1,0 +1,141 @@
+package shellsuggest
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// hostileTitle is the session title from the #1978 report: a space, a single
+// quote, a backtick, a `;`, and a `$`. Every one of these survives toTmuxName
+// (which only rewrites what tmux needs), so it reaches a printed command intact.
+//
+// Every payload here is INERT on purpose. These strings are handed to a real
+// shell, so if the quoting is broken they RUN — a destructive payload would make
+// this test's failure mode worse than the bug it guards. `id` and `echo` are
+// harmless and their output is observable, which is exactly what proves the
+// quoting held.
+const hostileTitle = "deploy `id` ; echo hi $HOME 'x'"
+
+// TestArgSurvivesARealShell is the property that matters: whatever a shell parses
+// back out must be the literal input, byte for byte. A test that asserted the
+// produced STRING would happily bless a command that is wrong in a shell — that
+// is the whole bug, the string looked fine.
+func TestArgSurvivesARealShell(t *testing.T) {
+	cases := map[string]string{
+		"hostile title": hostileTitle,
+		"space":         "two words",
+		"single quote":  "sachin's",
+		"double quote":  `say "hi"`,
+		"dollar":        "$HOME and ${x}",
+		"backtick":      "`whoami`",
+		"semicolon":     "x; echo pwned",
+		"newline":       "line1\nline2",
+		"pipe":          "a | b",
+		"ampersand":     "a && b",
+		"glob":          "*",
+		"tilde":         "~",
+		"leading dash":  "-rf",
+		"empty":         "",
+		"plain":         "captain",
+		"path":          "/home/u/.agent-factory/hooks/delete.sh",
+	}
+	for name, raw := range cases {
+		t.Run(name, func(t *testing.T) {
+			// printf %s writes its argument with no interpretation, so whatever
+			// comes back is exactly what the shell decided the argument was.
+			out, err := exec.Command("sh", "-c", "printf %s "+Arg(raw)).CombinedOutput()
+			if err != nil {
+				t.Fatalf("Arg(%q) = %s produced a command the shell rejects: %v\noutput: %s", raw, Arg(raw), err, out)
+			}
+			if string(out) != raw {
+				t.Errorf("Arg(%q) did not survive the shell: got %q", raw, string(out))
+			}
+		})
+	}
+}
+
+// TestArgLeavesReadableValuesAlone locks the readability half of the contract: a
+// suggestion exists to be read, so the common case must not be noisy with quotes.
+func TestArgLeavesReadableValuesAlone(t *testing.T) {
+	for _, s := range []string{"captain", "fix-auth-bug", "/usr/bin/tmux", "v1.2.3", "a_b", "80%"} {
+		if got := Arg(s); got != s {
+			t.Errorf("Arg(%q) = %q; a shell-safe value must pass through unquoted", s, got)
+		}
+	}
+}
+
+// TestCommandExecutesExactlyTheTargetAndNothingElse is the #1978 headline: a
+// suggested command built for a hostile title must, when actually pasted and run,
+// hit exactly that target and run nothing else.
+//
+// It asserts the EXECUTED EFFECT. The stand-in for "the target" is a file named
+// after the title; the stand-in for "nothing else" is a bystander file plus a
+// canary the injected `echo`/`id` would trip.
+func TestCommandExecutesExactlyTheTargetAndNothingElse(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, hostileTitle)
+	bystander := filepath.Join(dir, "someone-elses-session")
+	for _, f := range []string{target, bystander} {
+		if err := os.WriteFile(f, []byte("live"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// A stand-in for `tmux kill-session -t <title>`: it "kills" exactly the one
+	// target it is handed, and echoes what it was given so we can prove the
+	// argument arrived as ONE intact piece.
+	killer := filepath.Join(dir, "kill.sh")
+	script := "#!/usr/bin/env bash\n" +
+		"[[ $1 == -t ]] || { echo \"bad flag: $1\" >&2; exit 2; }\n" +
+		"printf '%s' \"$2\" > " + Arg(filepath.Join(dir, "received")) + "\n" +
+		"[[ $# -eq 2 ]] || { echo \"wrong arg count: $#\" >&2; exit 3; }\n" +
+		"rm -f -- \"$2\"\n"
+	if err := os.WriteFile(killer, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmdLine := Command(killer, "-t", target)
+
+	out, err := exec.Command("sh", "-c", cmdLine).CombinedOutput()
+	if err != nil {
+		t.Fatalf("the command we told the user to paste does not run: %s\nerr: %v\noutput: %s", cmdLine, err, out)
+	}
+
+	// The argument arrived intact and as a single word — not split, not expanded.
+	received, err := os.ReadFile(filepath.Join(dir, "received"))
+	if err != nil {
+		t.Fatalf("kill.sh never ran: %v", err)
+	}
+	if string(received) != target {
+		t.Errorf("the pasted command targeted the wrong thing:\n  wanted %q\n  got    %q", target, string(received))
+	}
+
+	// It hit exactly the target...
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Errorf("the pasted command did not affect the session it names")
+	}
+	// ...and nothing else.
+	if _, err := os.Stat(bystander); err != nil {
+		t.Errorf("the pasted command affected a session it does not name: %v", err)
+	}
+	// The injected `; echo hi` / `id` never executed as shell syntax.
+	if s := string(out); strings.Contains(s, "hi") || strings.Contains(s, "uid=") {
+		t.Errorf("injected shell ran: output %q", s)
+	}
+}
+
+// TestCommandQuotesEveryPiece guards the seam's shape: the program name is a
+// piece too, so a hostile PATH gets quoted like any argument.
+func TestCommandQuotesEveryPiece(t *testing.T) {
+	got := Command("/opt/my tools/af", "sessions", "restore", hostileTitle)
+	if !strings.HasPrefix(got, `'/opt/my tools/af' sessions restore `) {
+		t.Errorf("Command did not quote the program name: %s", got)
+	}
+	// The readable pieces stay readable.
+	if !strings.Contains(got, " sessions restore ") {
+		t.Errorf("Command over-quoted safe pieces: %s", got)
+	}
+}

--- a/internal/shellsuggest/shellsuggest_test.go
+++ b/internal/shellsuggest/shellsuggest_test.go
@@ -57,6 +57,82 @@ func TestArgSurvivesARealShell(t *testing.T) {
 	}
 }
 
+// shellsUnderTest are the shells Arg claims to be correct for. zsh is the one
+// that matters most here and the one a bash-only test cannot speak for: it is
+// macOS's default login shell, so it is what most readers paste into.
+var shellsUnderTest = []string{"sh", "bash", "zsh"}
+
+// TestArgSurvivesEveryClaimedShell runs the round-trip under EACH shell the
+// package claims, not just /bin/sh. The leading-'=' bug (#1978 review) is
+// zsh-only: sh and bash leave "=foo" alone, so a bash-only test passes against
+// the broken code — the same guard-test failure this PR's own body is about.
+//
+// A shell that is missing is reported, never silently skipped: a test that
+// quietly covers two of three shells is how "shell-safe" decays into a vibe.
+func TestArgSurvivesEveryClaimedShell(t *testing.T) {
+	// exactTargetShaped mirrors session/tmux/cleanup.go's exactTarget(): the '='
+	// prefix is load-bearing (it makes tmux match EXACTLY this session instead of
+	// prefix-matching a sibling, #1006), so these are the arguments where hitting
+	// the wrong target is the disaster the '=' exists to prevent.
+	const exactTargetShaped = "=af_a1b2c3_captain:"
+
+	cases := []string{
+		exactTargetShaped,
+		"=af_a1b2c3_deploy `id` ; echo hi:", // exact target AND hostile
+		"~foo",                              // tilde expansion: zsh errors, bash may expand
+		"~",
+		"%foo",  // job spec only for job builtins; must stay literal
+		"a=b",   // '=' mid-word is inert — must NOT get quoted
+		"-rf",   // a program's flag problem, not the shell's
+		"$HOME", //
+		"`id`",  //
+		"a b",   //
+		"it's",  //
+		"captain",
+	}
+
+	var ran int
+	for _, sh := range shellsUnderTest {
+		path, err := exec.LookPath(sh)
+		if err != nil {
+			t.Errorf("%s is not installed, so this run does NOT cover a shell the package claims "+
+				"(add it to scripts/container/Dockerfile.test); saying so rather than skipping quietly", sh)
+			continue
+		}
+		ran++
+		for _, raw := range cases {
+			t.Run(sh+"/"+raw, func(t *testing.T) {
+				out, err := exec.Command(path, "-c", "printf %s "+Arg(raw)).CombinedOutput()
+				if err != nil {
+					t.Fatalf("%s rejected the command we tell users to paste: Arg(%q) = %s\nerr: %v\nout: %s",
+						sh, raw, Arg(raw), err, out)
+				}
+				if string(out) != raw {
+					t.Errorf("%s did not receive the literal value: Arg(%q) = %s arrived as %q",
+						sh, raw, Arg(raw), string(out))
+				}
+			})
+		}
+	}
+	if ran == 0 {
+		t.Fatal("no shell under test was available; this test proved nothing")
+	}
+}
+
+// TestArgQuotesLeadingEquals pins the quoting decision itself, so the property
+// holds even where zsh is unavailable to execute it (the assertion above needs a
+// real zsh; this one does not).
+func TestArgQuotesLeadingEquals(t *testing.T) {
+	if got := Arg("=af_a1b2c3_captain:"); got != `'=af_a1b2c3_captain:'` {
+		t.Errorf("a leading '=' must be quoted (zsh equals-expansion), got %s", got)
+	}
+	// '=' mid-word is inert in every claimed shell — quoting it would cost
+	// readability for nothing.
+	if got := Arg("a=b"); got != "a=b" {
+		t.Errorf("'=' mid-word must not trigger quoting, got %s", got)
+	}
+}
+
 // TestArgLeavesReadableValuesAlone locks the readability half of the contract: a
 // suggestion exists to be read, so the common case must not be noisy with quotes.
 func TestArgLeavesReadableValuesAlone(t *testing.T) {

--- a/internal/shellsuggest/shellsuggest_test.go
+++ b/internal/shellsuggest/shellsuggest_test.go
@@ -95,8 +95,15 @@ func TestArgSurvivesEveryClaimedShell(t *testing.T) {
 	for _, sh := range shellsUnderTest {
 		path, err := exec.LookPath(sh)
 		if err != nil {
-			t.Errorf("%s is not installed, so this run does NOT cover a shell the package claims "+
-				"(add it to scripts/container/Dockerfile.test); saying so rather than skipping quietly", sh)
+			// Fail rather than skip. A skip here would mean the suite silently
+			// covers two of the three shells the package claims, and the one most
+			// likely to go missing (zsh, absent from the ubuntu runner and from a
+			// minimal container) is the one whose bug bash cannot see. Install it:
+			// scripts/container/Dockerfile.test for the local container,
+			// .github/workflows/pr.yml ("Install zsh") for CI. The macOS runner
+			// ships zsh already.
+			t.Errorf("%s is not installed, so this run does NOT cover a shell the package claims; "+
+				"saying so rather than skipping quietly", sh)
 			continue
 		}
 		ran++

--- a/preflight/preflight.go
+++ b/preflight/preflight.go
@@ -9,6 +9,7 @@ import (
 	"unicode"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/shellsuggest"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
@@ -79,7 +80,7 @@ func CheckCommand(command string) (*ProgramCheck, error) {
 			return check, fmt.Errorf("executable %q is a directory", exe)
 		}
 		if info.Mode().Perm()&0o111 == 0 {
-			return check, fmt.Errorf("executable %q is not executable; run: chmod +x %s", exe, path)
+			return check, fmt.Errorf("executable %q is not executable; run: %s", exe, shellsuggest.Command("chmod", "+x", path))
 		}
 		check.Path = path
 		return check, nil

--- a/scripts/container/Dockerfile.test
+++ b/scripts/container/Dockerfile.test
@@ -10,7 +10,7 @@ FROM golang:1.25-bookworm
 # tmux + git are what the suite drives; procps provides pgrep for the
 # daemon's SIGTERM fallback path.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends tmux git procps \
+    && apt-get install -y --no-install-recommends tmux git procps zsh \
     && rm -rf /var/lib/apt/lists/*
 
 # Give the container a stable git identity so no test or mock-repo commit

--- a/session/git/worktree_archive.go
+++ b/session/git/worktree_archive.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/shellsuggest"
 	"github.com/sachiniyer/agent-factory/log"
 )
 
@@ -175,11 +176,14 @@ func (g *GitWorktree) relocateWorktreeTo(dest string) error {
 		if sErr := worktreeRepairSubmodules(g, dest); sErr != nil {
 			log.WarningLog.Printf(
 				"submodule gitdir repair failed after moving worktree to %s; "+
-					"run `git -C %q submodule absorbgitdirs` "+
-					"(or `git -C %q submodule update --init --recursive`) "+
+					"run `%s` "+
+					"(or `%s`) "+
 					"to fix submodule status; continuing because the worktree move "+
 					"and registration repair already succeeded: %v",
-				dest, dest, dest, sErr,
+				dest,
+				shellsuggest.Command("git", "-C", dest, "submodule", "absorbgitdirs"),
+				shellsuggest.Command("git", "-C", dest, "submodule", "update", "--init", "--recursive"),
+				sErr,
 			)
 		}
 		if sourceCleanupErr != nil {

--- a/session/git/worktree_archive_test.go
+++ b/session/git/worktree_archive_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/shellsuggest"
 	"github.com/sachiniyer/agent-factory/internal/testguard"
 	aflog "github.com/sachiniyer/agent-factory/log"
 )
@@ -252,8 +253,12 @@ func TestRestoreWorktreeTo_SubmoduleRepairFailureIsBestEffort(t *testing.T) {
 	assert.False(t, pathExists(archiveDest), "the archive directory must be gone after restore")
 	assertLiveWorktreeAt(t, gw, restoreDest)
 	assert.Contains(t, warnings.String(), "submodule gitdir repair failed after moving worktree")
-	assert.Contains(t, warnings.String(), "git -C \""+restoreDest+"\" submodule absorbgitdirs")
-	assert.Contains(t, warnings.String(), "git -C \""+restoreDest+"\" submodule update --init --recursive")
+	// The advice is a command a human pastes, so it goes through the shellsuggest
+	// seam (#1978). It used to be built with %q — Go quoting, which renders a
+	// double-quoted string a shell still expands `$` and backticks inside, so it
+	// LOOKED quoted and was not.
+	assert.Contains(t, warnings.String(), shellsuggest.Command("git", "-C", restoreDest, "submodule", "absorbgitdirs"))
+	assert.Contains(t, warnings.String(), shellsuggest.Command("git", "-C", restoreDest, "submodule", "update", "--init", "--recursive"))
 }
 
 // TestRestoreWorktreePath_SiblingCollisionAndSanitize: in the default sibling

--- a/session/tmux/cleanup.go
+++ b/session/tmux/cleanup.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sachiniyer/agent-factory/cmd"
 	"github.com/sachiniyer/agent-factory/internal/proctree"
+	"github.com/sachiniyer/agent-factory/internal/shellsuggest"
 	"github.com/sachiniyer/agent-factory/log"
 )
 
@@ -87,7 +88,8 @@ func CleanupSessions(cmdExec cmd.Executor) error {
 		home, ok := sessionHomeMarker(cmdExec, match)
 		switch {
 		case !ok:
-			log.InfoLog.Printf("leaving tmux session %s: no AF_HOME ownership marker (pre-marker build or tmux <3.2); kill manually with: tmux kill-session -t '=%s'", match, match)
+			log.InfoLog.Printf("leaving tmux session %s: no AF_HOME ownership marker (pre-marker build or tmux <3.2); kill manually with: %s", match,
+				shellsuggest.Command("tmux", "kill-session", "-t", "="+match))
 		case filepath.Clean(home) != filepath.Clean(ownHome):
 			log.InfoLog.Printf("leaving tmux session %s: owned by another agent-factory home (%s)", match, home)
 		default:


### PR DESCRIPTION
Fixes #1978. Follow-up from the #1966 review, which fixed **one** site and asked whether it was the only one. It was not.

We print shell commands for humans to paste — "kill it with: …", "restore it first (…)", "run: chmod +x …" — built by interpolating values a user chose. Unquoted, they fail, or read like one thing and do another. They are printed *precisely* when someone is already cleaning up a mess, which is when they most have to be right.

## Why this is one class, not ten bugs

**The hazard was already understood, fixed at exactly one site, and locked with a test — while nine siblings printed raw.**

`daemon/manager_sessions.go:202` quoted with `shellQuoteArg`, its comment naming the hazard exactly:

> `// spaces or shell metacharacters must not turn a copy-pasted`
> `` // `af sessions restore ...` into the wrong target or a second command. ``

and `daemon/deliver_prompt_test.go:390` — `TestPromptTargetLivenessError_ArchivedQuotesRestoreCommand` — pinned it, citing #1529. Meanwhile `app/handle_actions.go:688` printed **the same suggestion**, unquoted. The correct fix sat in-tree, next to the bug, unused. (#1915's redaction guard was bypassed by adjacent sites twice for the same reason.)

That test is worth dwelling on, because it is the part of this worth remembering. It is correct. It has always passed. And by existing — green, well-named, citing the issue — **it made the whole class look handled** while nine siblings printed raw. It is the sibling of #1956's `TestNonCodexSubmitUsesPlainPasteBuffer`, which *asserted the bug* and passed for months. Both teach the same thing, from opposite directions:

> **A green test tells you about the line it covers and nothing about the class — and we keep reading it as the second.**

A passing test is evidence about its own call site. It is not evidence that the hazard it names has been dealt with anywhere else, and the better the test is written, the more it looks like it is. That is why this PR enumerates the surface in a table instead of pointing at a test, and why the fix is a seam instead of a tenth careful call site.

**Titles are not shell-safe by construction.** `toTmuxName` (`session/tmux/session.go:111`) rewrites only what *tmux* needs, and its own comment concedes the rest is "preserved verbatim". So a session titled ``deploy `id` ; echo hi`` reaches every one of these commands intact.

## The fix: one seam — `internal/shellsuggest`

I took option 1. The enforcing property is that it takes the command's **pieces, never a formatted string**:

```go
shellsuggest.Command("tmux", "kill-session", "-t", sessionName)
```

There is no parameter to smuggle an unquoted `fmt.Sprintf` through, every piece is quoted on the way out, and the phrasing of what we tell users to run now lives in one place.

**What the seam accepts is the point — not what it rejects.** It accepts the command while the boundary between *shell syntax* and *data* still exists: `name` and each `arg` arrive as separate values, so the seam knows which bytes are a program, which are flags, and which are a user's title. The old sites accepted a `string` — and by the time you hold a formatted string, that boundary has already been erased. No amount of care downstream can re-derive which bytes were data, which is why every one of those sites had to remember to quote *before* flattening, and why nine of them didn't. The seam isn't stricter; it's earlier. It takes the input at the moment the distinction is still recoverable, and that is what makes the bypass inexpressible rather than merely discouraged.

`Arg` passes shell-safe values through unquoted, so the common case stays readable — a suggestion exists to be read:

```
af sessions restore captain                                   ← clean
af sessions restore 'deploy `id` ; echo hi $HOME '\''x'\'''   ← hostile, neutralised
tmux kill-session -t =af_abc_captain:
chmod +x '/home/u/my hooks/delete.sh'
curl --unix-socket /run/af.sock http://localhost/v1/sessions -d '{}'
```

**The seam absorbed 2 of the 5 duplicate quoting helpers**: after migrating, `deadcode` flagged `api/apicmd.go` and `daemon/manager_sessions.go`'s `shellQuoteArg` as unreachable and they are deleted. The 3 that remain (`session/systemprompt.go`, `session/tmux/resume.go`, `config/paths.go`) are all **executed**-context — strings af feeds to a shell itself, a different job. That is #1529 and stays open.

## The surface, enumerated once

Every site that prints a shell command. If a site is not here, the table is wrong.

| site | prints | via seam? |
|---|---|---|
| `app/handle_actions.go:689,692,700` | `af sessions restore <title>` | ✅ |
| `app/handle_panes.go:571,574` | `af sessions restore <title>` | ✅ |
| `daemon/manager_create.go:454` | `tmux kill-session -t <tmux-name>` | ✅ |
| `daemon/manager_sessions.go:202` | `af sessions restore <title>` | ✅ (was `shellQuoteArg`) |
| `doctor/checks.go:338` | `tmux kill-session -t =<name>:` | ✅ |
| `doctor/remote.go:182` | `chmod +x <remote_hooks.*>` | ✅ |
| `doctor/setup.go:111` | `af config set default_program <p>` | ✅ |
| `preflight/preflight.go:83` | `chmod +x <program path>` | ✅ |
| `session/tmux/cleanup.go:92` | `tmux kill-session -t =<name>` | ✅ |
| `api/sessions.go:463` | `af sessions create --name <title>` | ✅ (was `%q` — Go quoting) |
| `api/apicmd.go:136,138` | `curl --unix-socket <sock> …` | ✅ (was `shellQuoteArg`) |
| `session/git/worktree_archive.go:184,185` | `git -C <dest> submodule …` | ✅ (was `%q` — Go quoting) |
| `session/liveness.go:292,352` | `af sessions restore` — **no argument** | n/a — nothing interpolated |
| `daemon/manager_tabs.go:165` | `af sessions restore` — **no argument** | n/a — nothing interpolated |

The last three print a bare literal with nothing interpolated, so they are safe as-is; they are listed because they are printed-command sites and the table must be complete. (They also never name *which* session to restore, unlike every other site — a UX nit, not a bug, and not touched here.)

**The two `%q` sites deserve emphasis**: `%q` emits a *Go* double-quoted literal. Pasted into a shell, `"…"` still expands `$var` and backticks. It looked quoted and was not — the most dangerous state to be in.

## Tests — watched failing first

`internal/shellsuggest/shellsuggest_test.go`, asserting the **executed effect**:

- `TestCommandExecutesExactlyTheTargetAndNothingElse` — a session titled ``deploy `id` ; echo hi $HOME 'x'`` (space, quote, backtick, `;`, `$`), whose suggested command is **run through a real shell** and must hit exactly that target, leave a bystander untouched, arrive as one intact argument, and run nothing else.
- `TestArgSurvivesEveryClaimedShell` — every payload round-tripped under **each of sh, bash and zsh**, including a real `exactTarget()`-shaped `=af_a1b2c3_captain:`.

### A missing shell is a hard failure, not a skip

This is deliberate and load-bearing, so it should not be softened later.

`t.Skip("zsh not installed")` would have gone **green**. The suite would have reported success while covering **none** of the shell the bug is actually about — on macOS's default shell, which is also the maintainer's. That is this PR's own thesis turned on itself: a green test certifying a shell it never ran, exactly as `TestPromptTargetLivenessError_ArchivedQuotesRestoreCommand` certified a class it only covered one site of.

So the test refuses to certify what it did not check, and names both remediations (`Dockerfile.test` for the container lane, `pr.yml` for CI) so the next person on a fresh box fixes the **environment**, not the case.

It immediately earned it. On `ubuntu-latest` the Test job went red with:

```
shellsuggest_test.go: zsh is not installed, so this run does NOT cover a shell the package claims
```

That is the test working: the ubuntu runner has sh and bash but no zsh, so the run genuinely did not cover a third of what the package promises — and the bug it guards (`=` expanding) is **invisible to sh and bash**, so a zsh-less suite would have gone green straight over it. The fix is the environment: `Install zsh` in `pr.yml`, and `zsh` in `scripts/container/Dockerfile.test`. Both claimed lanes now cover all three shells.

**Verified rather than assumed, per lane:**

| lane | zsh | evidence |
|---|---|---|
| `Test (macOS)` | ships it | **12 zsh subtests ran and passed** on the runner, incl. `=af_a1b2c3_captain:` — checked in the job log, not inferred from a green tick |
| `Test` (ubuntu) | absent → installed | red with the message above; `Install zsh` step added |
| `make test-container` | absent → added | `zsh` added to `Dockerfile.test`; suite green locally |
- `TestArgQuotesLeadingEquals` — pins the decision itself, so the property still holds somewhere zsh is unavailable to execute.
- `TestArgSurvivesARealShell` — 16 payloads round-tripped via `printf %s`, byte-for-byte.
- `TestArgLeavesReadableValuesAlone` — the common case stays unquoted.

**The zsh fail-first is the sharpest evidence in this PR.** With the leading-`=` handling reverted, under a real zsh:

```
--- FAIL: TestArgSurvivesEveryClaimedShell/zsh/=af_a1b2c3_captain:
    zsh rejected the command we tell users to paste: Arg("=af_a1b2c3_captain:") = =af_a1b2c3_captain:
    out: zsh:1: af_a1b2c3_captain: not found
```

…while the `sh/` and `bash/` subtests **passed against that same broken code**. A bash-only test would have blessed it — which is this PR's own thesis, arriving as a bug in this PR.

**Fail-first, with `Arg` as the identity function** (i.e. what the ten sites did): the hostile title came back as

```
deployuid=1000(dev)gid=1000(dev)groups=1000(dev)hi /home/dev x
```

The backtick **executed `id`**. `; echo hi` ran. `$HOME` expanded. `*` globbed the cwd. That is the bug, live — and the printed string looked fine the whole time, which is exactly why these assert effects.

Every payload is **inert** on purpose (`; echo hi`, `id` — never `rm -rf`): they reach a real shell, so a destructive payload would make the test's failure mode worse than the bug it guards.

Two existing tests failed against this change and were re-pointed at the seam rather than at a literal idiom:

- `daemon/deliver_prompt_test.go` pinned the `'"'"'` idiom; the seam emits the equivalent `'\''`. Behaviourally identical, string-different — a string test breaking a correct change, the same weakness in miniature. It now asserts via the seam and keeps the check that carries the value: the raw form must not appear.
- `session/git/worktree_archive_test.go` pinned the **`%q`** form — the "looks quoted, isn't" bug encoded as an expectation.

## Which shells this claims to be correct for: **sh, bash and zsh**

Named deliberately. "Shell-safe" with no named target is a vibe, not a claim, and the next contributor inherits whichever shells the last one happened to think about.

- **sh / bash** — single-quoting makes every metacharacter literal; embedded `'` uses the POSIX `'\''` idiom.
- **zsh** — the one that needs saying, because it is macOS's default login shell since Catalina, so it is what most readers of these suggestions actually paste into. zsh performs **equals-expansion**: an unquoted word starting with `=` expands to the path of that command. `Arg` therefore quotes a leading `=`, verified by executing under a real zsh.

Per-character findings, measured rather than assumed:

| first char | sh | bash | zsh | handling |
|---|---|---|---|---|
| `=` | literal | literal | **expands** (`=foo:` → "foo: not found") | **quoted** (`startsExpandable`) |
| `~` | expands | expands | **errors** | already quoted — `~` is not in the safe set |
| `%` | literal | literal | literal (job spec only for `kill`/`fg`/`bg`, which we never suggest) | passthrough |
| `-` | literal | literal | literal | passthrough — see below |

A leading `-` is **deliberately not quoted**: quoting does not stop a program parsing `-rf` as a flag (the shell hands over the same bytes either way) — that needs a `--` separator at the call site — and quoting every `-t`/`--init` we pass would make the common suggestion unreadable for no gain.

### This PR regressed that, and the review caught it

Worth recording plainly, because it is the same shape as the class this PR fixes. `doctor/checks.go` and `session/tmux/cleanup.go` previously hardcoded `'=%s:'` — **already quoted**. Centralising into `Arg`'s passthrough *removed* that quoting, so a fix whose entire purpose is making pasted commands correct made a class of them **wrong in the default macOS shell**.

The `=` is load-bearing: `exactTarget()` uses it *because* it makes tmux match that session exactly instead of prefix-matching a sibling (#1006). So the arguments most likely to start with `=` are precisely the ones where hitting the wrong target is the disaster the `=` was added to avoid.

The seam is why this is a one-line fix rather than a two-site one — and why sites written next year inherit it. That is the case for a choke point, made by the choke point failing.

## CodeQL: a false positive, fixed by restructuring rather than dismissed

The first cut of `Command` used `make([]string, 0, len(args)+1)` + `strings.Join`, and CodeQL flagged it **high**: `go/allocation-size-overflow` — "involves a potentially large value and might overflow".

**It is a false positive, and I verified that rather than assuming it.** All 23 call sites pass a **fixed literal arg list** (max 6 args); there is no variadic spread anywhere in the tree, so `len(args)` is a small compile-time constant. Reaching an overflow needs `len(args) == math.MaxInt` — a `[]string` of ~2^63 elements, ~10^20 bytes of slice headers alone. It cannot be constructed. CodeQL is pattern-matching `len(x)+1` inside `make()` without reasoning about where `x` comes from.

**I still fixed it rather than dismissing it**, for four reasons:

1. CodeQL is a **required check** — it blocks the merge either way, so a dismissal costs the same and buys less.
2. Dismissing a high-severity alert on a PR whose entire subject is shell-safety is a precedent worth not setting — and the dismissal would live in GitHub's UI, where the next person will not find the reasoning.
3. The arithmetic bought nothing: this path runs only while formatting an error message for a human. It is never hot.
4. **The best version has no allocation-size expression at all.** `Command` now builds with a `strings.Builder` — no intermediate slice, no `make`, no arithmetic. That is not narrowly dodging the rule; it removes the construct, and it is simply better code than allocating a slice to `Join`. The scanner pointed at something that should not have been there, for a reason that was wrong.

The reasoning is recorded **in the code**, not only here, so the next contributor does not "optimise" it back and re-raise a required-check failure to save an allocation nobody will measure. A `nolint`-style suppression would have buried it — that is how a real finding gets missed next time.

## Honest limit: this is a strong convention, not an enforced invariant

I tried to make the unquoted form *unavailable* with a lint, and it does not work. A regex over format strings flags **~92 prose strings** ("tmux session already exists: %s") against ~10 real suggestions; no allowlist survives that. Narrowing to imperative phrasing ("run:", "with:") still flags correctly-migrated sites, because the `shellsuggest` call frequently sits on the *next* line — line-based matching cannot see it. Doing this properly needs an AST/`go vet` analyzer, which is its own piece of work, not part of this PR.

So what the seam actually buys: one obvious place to call, the phrasing centralised, the duplicate helpers shrinking rather than growing, and a new ad-hoc site now looking wrong next to twelve that aren't. That is better than a habit and less than a guarantee, and I would rather say so than claim an invariant I did not build.

(The narrow probe did earn its keep: it surfaced `session/liveness.go` and `daemon/manager_tabs.go`, which my original sweep missed. Both turned out safe — no interpolation — but the sweep *was* incomplete, and only a second, differently-shaped search found them.)

## Should titles be constrained at creation instead? No.

Asked in the review; answering here rather than filing an issue, because I think filing one would encode the wrong lesson.

**It would not have worked.** Most of the vulnerable sites interpolate the raw `inst.Title`, not the tmux name — `app/handle_actions.go:688` passes `inst.Title` straight through. A perfectly shell-safe `toTmuxName` fixes none of them.

**And it is the wrong layer.** One title flows into four domains with incompatible rules: tmux session names, shell commands, filesystem path segments, git refs. Constraining a *display* string at creation to a lowest common denominator serves none of them well, and breaks every existing session to do it.

`toTmuxName` is the codebase doing the *right* pattern — escape at the boundary, per domain — and its comment is scrupulous about scope precisely because it is a **tmux** function, not a shell function. `Slugify` is the same pattern for hook names. The bug was never that titles are free-form; it is that the shell boundary had no escaper. This PR is that escaper.

## Not a security embargo

Worth stating plainly: af does not execute these strings — a human pastes them. For nearly every site the "attacker" and the victim are the same person, so the real cost is **breakage and confusion**: a command that fails, or silently targets the wrong session. `doctor/remote.go` and `preflight/preflight.go` read values from repo-checked-in config that can arrive from a cloned repo, but this repo has an explicit precedent that in-repo config is trusted, so that is consistent rather than a new hole.

## Gates

`make test-container` (30 pkgs ok / 0 fail) · `go build ./...` · `gofmt -l .` · `golangci-lint run --timeout=3m --fast` · `deadcode -test ./...` · `scripts/lint-file-length.sh` — all six clean.

Touches `app/` (error strings only, no TUI behaviour change) — needs the `play-tested` label before it can merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
