### PR TITLE
fix(ci): install zsh in every lane that runs the suite, not just pr.yml

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -49,6 +49,13 @@ jobs:
           fi
         fi
 
+    # The preflight runs the full suite, and internal/shellsuggest FAILS rather
+    # than skips when a shell it claims (sh/bash/zsh) is absent (#1978/#1988).
+    # Without zsh the preflight cannot pass, so a release would be unable to cut.
+    - name: Install zsh
+      if: steps.check.outputs.should_release == 'true'
+      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends zsh
+
     - name: Release preflight
       if: steps.check.outputs.should_release == 'true'
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,14 @@ jobs:
         go-version: '1.25'
         cache: true
 
+    # internal/shellsuggest claims correctness in sh, bash AND zsh, and its tests
+    # FAIL rather than skip when a claimed shell is missing (#1978/#1988). Every
+    # lane that runs `go test` therefore needs zsh, not just pr.yml — this job
+    # runs the suite on the release matrix, and auto-release/stable-release run it
+    # too. The runner is ubuntu regardless of the GOOS/GOARCH it builds for.
+    - name: Install zsh
+      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends zsh
+
     - name: Run tests
       run: go test -v ./...
 

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -46,6 +46,12 @@ jobs:
         NEW_VERSION: ${{ inputs.version }}
       run: git tag | .github/scripts/validate-stable-version.sh "$NEW_VERSION"
 
+    # The preflight runs the full suite, and internal/shellsuggest FAILS rather
+    # than skips when a shell it claims (sh/bash/zsh) is absent (#1978/#1988).
+    # Without zsh the preflight cannot pass, so a release would be unable to cut.
+    - name: Install zsh
+      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends zsh
+
     - name: Release preflight
       run: |
         unformatted=$(gofmt -l .)


### PR DESCRIPTION
**Master is red and releases are blocked.** This fixes both.

## What happened

#1988 added zsh to `pr.yml` because `internal/shellsuggest` claims correctness in sh, bash **and** zsh, and its tests **fail rather than skip** when a claimed shell is missing — deliberately, so the suite can never quietly certify a shell it never ran. That design is right and stays.

But **four workflows run `go test`**, not one:

| workflow | runs suite | had zsh |
|---|---|---|
| `pr.yml` | yes | yes (#1988) |
| `build.yml` | yes — post-merge matrix | no → **master went red** |
| `auto-release.yml` | yes — release preflight | no → **release could not cut** |
| `stable-release.yml` | yes — release preflight | no → **release could not cut** |

`Build Binary and Test (linux, arm64)` failed the moment #1988 landed:

```
shellsuggest_test.go:105: zsh is not installed, so this run does NOT cover a shell the package claims
```

The runner is ubuntu regardless of the GOOS/GOARCH it builds for, so the same one-line install works in every lane.

## My error, for the record

I reviewed #1988's zsh addition against `pr.yml`'s Test job, confirmed the macOS runner already ships zsh — and never asked *which other lanes run the suite*. The test caught a lane I didn't know existed. **The test was right; the merge was premature.**

Worth noting what it means that this was caught at all: a `t.Skip` would have kept master green while silently covering two of the three shells the package claims — on the shell that is macOS's default and the only one of the three where a leading `=` expands. The hard failure cost a few minutes of red master and bought a guarantee that CI can never lie about shell coverage again. That's the trade I want every time.

## Follow-up

Four lanes each remembering to install a dependency is the same "invariant maintained by habit" pattern we've been designing away all week. Filing a follow-up to give the Go lanes one shared setup step, so a new lane cannot silently under-provision.

— Captain Claude
