### PR TITLE
fix(tui): name the pane the narrow-width toast actually hid (#1997)

### DIFF
--- a/app/home_model.go
+++ b/app/home_model.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sachiniyer/agent-factory/ui/layout/zones"
 	"github.com/sachiniyer/agent-factory/ui/overlay"
 	"github.com/sachiniyer/agent-factory/ui/store"
+	"github.com/sachiniyer/agent-factory/ui/tree"
 )
 
 type state int
@@ -603,12 +604,29 @@ func newlyAutoHiddenPane(previousVisible, nextVisible, openPanes []*store.OpenPa
 	return nil
 }
 
+// setPaneAutoHideStatus reports the pane the terminal could not fit. It names
+// the pane that was ACTUALLY displaced — `instance · tab`, the same identity the
+// pane's own header shows — or says nothing about which pane when it cannot name
+// one. The instance title alone is not a pane identity: since #930 an instance
+// can own several panes, so "docs hidden" while a second `docs` pane is on
+// screen tells the user something they can see is false (#1997).
+//
+// The reason clause drops the word "terminal" to pay for the tab name: at 80
+// columns the old line already sat one cell under the limit, and the bar
+// truncates from the RIGHT, so a longer line silently eats the recovery hint
+// (#1973). Long instance titles still overflow — nothing can fit an unbounded
+// title — but the fragments are ordered worst-first, so what survives the
+// truncation is the half that matters: which pane went away.
 func (m *home) setPaneAutoHideStatus(p *store.OpenPane, paneCount int) {
 	if p == nil || paneCount <= 1 {
 		return
 	}
-	msg := fmt.Sprintf("%s hidden: terminal too narrow for %d panes; resize wider%s",
-		paneStatusTitle(p), paneCount, paneRecoveryStatusHint())
+	subject := "a pane is hidden"
+	if label, ok := paneStatusLabel(p); ok {
+		subject = label + " hidden"
+	}
+	msg := fmt.Sprintf("%s — too narrow for %d panes; resize wider%s",
+		subject, paneCount, paneRecoveryStatusHint())
 	m.pendingPaneAutoHideStatus = msg
 	m.paneAutoHideNoticeID = m.setTransientNotice(errors.New(msg))
 }
@@ -631,11 +649,25 @@ func (m *home) clearStaleAutoHideStatus() {
 	m.pendingPaneAutoHideStatus = ""
 }
 
-func paneStatusTitle(p *store.OpenPane) string {
+// paneStatusLabel names a pane for a user-facing message the way the pane's own
+// header names it — `instance · tab` (ui.TabbedWindow.renderHeader), reading the
+// tab through the same tree label source so the toast and the header can never
+// disagree about what a pane is called.
+//
+// It reports false rather than guessing. An instance title alone is not a pane
+// identity (#930), and tree.TabLabels answers with a placeholder "Agent" slot
+// for an instance whose tabs have not materialized — so the tab is read through
+// TabLabelAt, which distinguishes a real tab from "no tab list yet". A caller
+// that cannot name the pane must say so instead of naming the wrong one (#1997).
+func paneStatusLabel(p *store.OpenPane) (string, bool) {
 	if p == nil || p.Instance() == nil || p.Instance().Title == "" {
-		return "pane"
+		return "", false
 	}
-	return p.Instance().Title
+	label, ok := tree.TabLabelAt(p.Instance(), p.Tab())
+	if !ok {
+		return "", false
+	}
+	return fmt.Sprintf("%s · %s", p.Instance().Title, label), true
 }
 
 func paneRecoveryStatusHint() string {

--- a/app/pane_autohide_status_test.go
+++ b/app/pane_autohide_status_test.go
@@ -131,6 +131,69 @@ func TestPane_OpenFocusRefreshProducedStatusStillClears(t *testing.T) {
 		"openOrFocusPane returns a clear-timer cmd so the late notice auto-clears (#1685)")
 }
 
+// TestPane_AutoHideStatusNamesDisplacedTab is the #1997 regression, at the exact
+// size the play-test found it (80x24, where only one pane fits). Two panes are
+// open on the SAME instance — `alpha · Agent` and `alpha · Terminal` — so the
+// instance title alone names BOTH of them and cannot say which one went away.
+// Naming only the instance made the toast read "alpha hidden" while
+// `alpha · Terminal` was visibly on screen: the UI contradicting what the user
+// can see. Since #930 a pane is identified by instance AND tab, so the toast
+// must name the displaced TAB.
+//
+// The assertion is on the RENDERED status line — the clipped text the user
+// actually reads — because FullError() is the un-truncated string we passed in
+// and never shows what the 80-column bar does to it (#1973).
+func TestPane_AutoHideStatusNamesDisplacedTab(t *testing.T) {
+	h := paneTestHome(t)
+	resizeHome(h, 80, 24) // the play-test size: below MultiPaneMinWidth, one pane fits
+
+	alpha := h.store.GetInstanceByTitle("alpha")
+	require.NotNil(t, alpha)
+
+	// Open alpha · Agent (tab 0), then alpha · Terminal (tab 1). The second pane
+	// on the same instance displaces the first.
+	_, _ = h.openOrFocusPane(alpha, 0)
+	_, _ = h.openOrFocusPane(alpha, 1)
+
+	require.Equal(t, 2, h.store.NumOpenPanes(), "both of alpha's tabs are open as panes")
+	require.Equal(t, 1, len(h.visiblePanes), "only one pane fits at 80 columns")
+	require.Equal(t, 1, h.visiblePanes[0].Tab(),
+		"alpha · Terminal is the pane left visible, so alpha · Agent is the displaced one")
+
+	rendered := h.errBox.String()
+	assert.Contains(t, rendered, "alpha · Agent hidden",
+		"the toast names the tab that was actually displaced (#1997)")
+	assert.Contains(t, rendered, "resize wider",
+		"naming the tab must not push the recovery hint off the 80-column bar (#1973)")
+}
+
+// TestPane_AutoHideStatusUnnamableTabMakesNoClaim covers the other half of the
+// #1997 contract: when the pane's tab cannot be named, the toast says a pane is
+// hidden rather than naming the wrong one. An instance whose tabs have not
+// materialized yet has no real tab list to read, and tree.TabLabels answers
+// with the placeholder "Agent" slot — so naming the tab from it would present a
+// guess as a fact. The toast must decline to name instead.
+func TestPane_AutoHideStatusUnnamableTabMakesNoClaim(t *testing.T) {
+	h := paneTestHome(t)
+	resizeHome(h, 80, 24)
+
+	// An instance with no materialized tabs: nothing can say what its tab 0 is.
+	blank := instanceWithFakeBackend(t, "blank")
+	h.store.AddInstance(blank)
+	require.Empty(t, blank.GetTabs(), "the fixture instance has no materialized tabs")
+
+	alpha := h.store.GetInstanceByTitle("alpha")
+	require.NotNil(t, alpha)
+	_, _ = h.openOrFocusPane(blank, 0)
+	_, _ = h.openOrFocusPane(alpha, 0)
+
+	rendered := h.errBox.String()
+	assert.Contains(t, rendered, "a pane is hidden",
+		"an unnamable pane is reported without a name (#1997)")
+	assert.NotContains(t, rendered, "blank · Agent",
+		"the placeholder tab slot must never be presented as the displaced tab's real name")
+}
+
 // TestPane_OpenPaneWindowIsIdempotent proves the (instance, tab) →
 // at-most-one-pane invariant is enforced at the openPaneWindow chokepoint, so
 // the callers that skip the FindOpenPane pre-check (auto-open, restore) cannot

--- a/app/pane_autohide_status_test.go
+++ b/app/pane_autohide_status_test.go
@@ -143,28 +143,61 @@ func TestPane_OpenFocusRefreshProducedStatusStillClears(t *testing.T) {
 // The assertion is on the RENDERED status line — the clipped text the user
 // actually reads — because FullError() is the un-truncated string we passed in
 // and never shows what the 80-column bar does to it (#1973).
+//
+// BOTH displacement directions are driven, and that is the point rather than
+// symmetry for its own sake: with only the agent-displaced case, an
+// implementation that hard-coded "Agent" — or read the wrong pane's tab and hit
+// slot 0 by luck — passes while still being unable to name what it evicted. The
+// terminal-displaced case is what forces the label to come from the displaced
+// pane. (Verified by mutation: naming tab 0 unconditionally survives the first
+// case and fails the second.)
 func TestPane_AutoHideStatusNamesDisplacedTab(t *testing.T) {
-	h := paneTestHome(t)
-	resizeHome(h, 80, 24) // the play-test size: below MultiPaneMinWidth, one pane fits
+	for _, tc := range []struct {
+		name              string
+		openOrder         []int // tabs opened, in order; the LAST one stays visible
+		wantVisibleTab    int
+		wantHiddenNamedAs string
+	}{
+		{
+			// The issue's own repro: docs · Agent open, `t` opens docs · Terminal.
+			name:              "terminal displaces agent",
+			openOrder:         []int{0, 1},
+			wantVisibleTab:    1,
+			wantHiddenNamedAs: "alpha · Agent hidden",
+		},
+		{
+			// The reverse: the displaced pane is NOT slot 0, so a toast that
+			// cannot really name what it evicted has nothing to fall back on.
+			name:              "agent displaces terminal",
+			openOrder:         []int{1, 0},
+			wantVisibleTab:    0,
+			wantHiddenNamedAs: "alpha · Terminal hidden",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := paneTestHome(t)
+			resizeHome(h, 80, 24) // the play-test size: below MultiPaneMinWidth, one pane fits
 
-	alpha := h.store.GetInstanceByTitle("alpha")
-	require.NotNil(t, alpha)
+			alpha := h.store.GetInstanceByTitle("alpha")
+			require.NotNil(t, alpha)
 
-	// Open alpha · Agent (tab 0), then alpha · Terminal (tab 1). The second pane
-	// on the same instance displaces the first.
-	_, _ = h.openOrFocusPane(alpha, 0)
-	_, _ = h.openOrFocusPane(alpha, 1)
+			// Two panes on the SAME instance: the second displaces the first.
+			for _, tab := range tc.openOrder {
+				_, _ = h.openOrFocusPane(alpha, tab)
+			}
 
-	require.Equal(t, 2, h.store.NumOpenPanes(), "both of alpha's tabs are open as panes")
-	require.Equal(t, 1, len(h.visiblePanes), "only one pane fits at 80 columns")
-	require.Equal(t, 1, h.visiblePanes[0].Tab(),
-		"alpha · Terminal is the pane left visible, so alpha · Agent is the displaced one")
+			require.Equal(t, 2, h.store.NumOpenPanes(), "both of alpha's tabs are open as panes")
+			require.Equal(t, 1, len(h.visiblePanes), "only one pane fits at 80 columns")
+			require.Equal(t, tc.wantVisibleTab, h.visiblePanes[0].Tab(),
+				"the last-opened pane is the visible one, so the other is the displaced one")
 
-	rendered := h.errBox.String()
-	assert.Contains(t, rendered, "alpha · Agent hidden",
-		"the toast names the tab that was actually displaced (#1997)")
-	assert.Contains(t, rendered, "resize wider",
-		"naming the tab must not push the recovery hint off the 80-column bar (#1973)")
+			rendered := h.errBox.String()
+			assert.Contains(t, rendered, tc.wantHiddenNamedAs,
+				"the toast names the tab that was actually displaced (#1997)")
+			assert.Contains(t, rendered, "resize wider",
+				"naming the tab must not push the recovery hint off the 80-column bar (#1973)")
+		})
+	}
 }
 
 // TestPane_AutoHideStatusUnnamableTabMakesNoClaim covers the other half of the

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -1018,7 +1018,7 @@ func TestPane_AutoHideShowsTransientStatus(t *testing.T) {
 
 	require.Equal(t, 2, h.store.NumOpenPanes(), "the second pane still opens")
 	assert.Equal(t, []string{"beta"}, visibleTitles(h), "width pressure hides alpha and shows beta")
-	assert.Equal(t, "alpha hidden: terminal too narrow for 2 panes; resize wider or use `s` open pane",
+	assert.Equal(t, "alpha · Agent hidden — too narrow for 2 panes; resize wider or use `s` open pane",
 		h.errBox.FullError())
 }
 

--- a/app/tui_state_test.go
+++ b/app/tui_state_test.go
@@ -129,7 +129,7 @@ func TestTUIViewStateRestoredPanesAutoHideShowsStatus(t *testing.T) {
 	require.Equal(t, 1, h.lastLayout.PaneCount())
 	require.Equal(t, 2, h.store.NumOpenPanes(), "auto-hide retains both bindings")
 	assert.Empty(t, h.restoredPaneBaseline, "the sized relayout consumes the baseline")
-	assert.Contains(t, h.errBox.FullError(), "hidden: terminal too narrow for 2 panes",
+	assert.Contains(t, h.errBox.FullError(), "hidden — too narrow for 2 panes",
 		"a pane hidden on the first post-restore relayout must still surface the status (#1535)")
 }
 

--- a/ui/tree/labels.go
+++ b/ui/tree/labels.go
@@ -38,6 +38,24 @@ func TabLabels(instance *session.Instance) []string {
 	return append([]string(nil), placeholderTabLabels...)
 }
 
+// TabLabelAt returns the display label for the instance's tab at idx, reporting
+// false when the instance's real tab list cannot answer: no tabs have
+// materialized yet, or idx is out of range. Unlike TabLabels it never falls
+// back to the placeholder slot — a caller that names a pane TO THE USER must be
+// able to tell "this is the Agent tab" from "no tab list exists yet", because
+// the placeholder's "Agent" is a guess and naming the wrong pane is worse than
+// not naming one (#1997).
+func TabLabelAt(instance *session.Instance, idx int) (string, bool) {
+	if instance == nil {
+		return "", false
+	}
+	tabs := instance.GetTabs()
+	if idx < 0 || idx >= len(tabs) {
+		return "", false
+	}
+	return labelForTab(tabs[idx]), true
+}
+
 func labelForTab(tab *session.Tab) string {
 	switch tab.Kind {
 	case session.TabKindAgent:


### PR DESCRIPTION
Fixes #1997.

## The bug

At 80x24, with two panes open on one instance, the narrow-width toast named the
**instance** while the thing it was reporting was a **pane**. The user was told
something they could see was false:

```
 pane header:  docs · Terminal          ← visibly on screen
 toast:        docs hidden: terminal too narrow for 4 panes; …
```

The pane actually displaced was the older `docs · Agent`. Since #930 a pane is
identified by **instance + tab**, so `docs` names *both* of that instance's
panes and cannot say which one went away. This is the #1985 / #1904 class: the
UI asserting something it has not established. A toast that contradicts the
screen is worse than no toast — the user cannot tell which half to believe.

## 1. Can the eviction logic name the displaced pane? Yes — it already knew

This is worth stating plainly because it was the first thing to check: **nothing
needed to be taught to know.** `newlyAutoHiddenPane` returns the exact
`*store.OpenPane` it just evicted, and that value carries both `Instance()` and
`Tab()`. The identity survived all the way into `setPaneAutoHideStatus` — and
was thrown away one call later by `paneStatusTitle`, which returned
`p.Instance().Title` and dropped the tab on the floor.

So the fix is routing, not plumbing: the toast now names the displaced pane as
`instance · tab` — **the same identity its own header renders**, read from the
same `ui/tree` label source, so the toast and the header cannot disagree about
what a pane is called. That shared source is the point: the contradiction here
was literally toast-vs-header.

## 2. Where it cannot name the pane, it declines to

`tree.TabLabels` answers with a **placeholder** `["Agent"]` slot for an instance
whose tabs have not materialized. Naming a pane "docs · Agent" out of that
placeholder would be a *guess presented as a fact* — the same disease as the
bug being fixed, just quieter. So the tab is read through a new
`tree.TabLabelAt`, which has three outcomes instead of two (real label /
out of range / no tab list yet). When the pane cannot be named the toast says:

```
a pane is hidden — too narrow for 4 panes; resize wider or use `s` open pane
```

That is the "does not claim to know" branch, and it is tested.

## 3. The copy had to shrink to fit — otherwise this fix causes #1973

Naming the tab makes the line longer, and the status bar **truncates from the
right**. Measured at the real width:

| line | display width at 80 |
|---|---|
| old: `docs hidden: terminal too narrow for 4 panes; …` | 79 — fit with 1 cell to spare |
| naive: `docs · Agent hidden: terminal too narrow for 4 panes; …` | 87 — **clips the recovery hint** |
| shipped: `docs · Agent hidden — too narrow for 4 panes; …` | 79 — fits |

So the reason clause drops the word "terminal" to pay for the tab name. Without
that, this PR would have fixed #1997 by causing #1973 — naming the pane
correctly while silently eating `resize wider or use \`s\` open pane`, with only
`E details` left to hint that anything was cut.

**This does not fit for every title, and cannot.** Titles are unbounded —
`docs · Terminal` is already 82. What the fix guarantees instead is *ordering*:
fragments run worst-first, so truncation always eats the tail (the recovery
hint) and never the half that says which pane went away. Flagging this
explicitly rather than claiming a fit I can't deliver.

## 4. The structural sweep: instance-named where a pane is meant

The issue asks whether this is a class. **Honest answer: it is one drifted site,
not a class — but the drift was invisible because the pane-identity format is
hand-rolled at four sites with four different fallbacks.** Every user-facing
string in `app/` and `ui/` whose subject is a pane or tab:

| site | subject | names it | verdict |
|---|---|---|---|
| `app/home_model.go` `setPaneAutoHideStatus` | a pane | **instance only** | **under-specified → fixed here** |
| `ui/tabbed_window.go:531` `renderHeader` | a pane | `instance · tab` | correct |
| `app/pane_preview.go:412` `paneBindingLabel` | a pane | `instance · tab` | correct |
| `app/handle_panes.go:95` selection hint | a pane | `instance · tab` | correct |
| `app/handle_mouse.go:479` `dragStatusText` fallback | a tab | `docs tab 2` (ordinal) | honest, but non-canonical form — reported, not fixed |
| `app/handle_tabs.go:116,119,123`, `app/handle_actions.go:750,752` | the selected tab | deictic ("this tab") | correct — no name needed |
| `app/pane_preview.go:335-347` commit-preview failures | the **session** (lost/archived/in-flight) | instance | correct — instance *is* the subject |
| `app/handle_actions.go`, `app/handle_panes.go` lost/restore/delete | the **session** | instance | correct |

Reported but deliberately **not** fixed here:

- **The three correct sites share the placeholder edge** described in §2: they
  index `tree.TabLabels` and so present the placeholder `"Agent"` as fact for an
  instance mid-start. Lower stakes than the toast (they label what you selected;
  they don't assert a displacement), but `tree.TabLabelAt` now exists as the
  honest primitive to route them through.
- **Four sites hand-roll `fmt.Sprintf("%s · %s", …)` with four different
  fallbacks.** That duplication is *why* one could drift to instance-only
  without anyone noticing. Unifying them is the real structural follow-up; it is
  a wider diff than this fix and would collide with #1993, so it is reported
  rather than smuggled in here.
- No web-client equivalent exists — the auto-hide toast is a TUI layout concept.

Per the issue, #1993's instance-vs-session noun inconsistency is left alone; the
copy here matches the surrounding surface.

## Tests — watched fail first, in the real state

Both new tests were **watched failing against the unfixed code**, at 80x24, and
both fail with the exact user-visible symptom:

```
"alpha hidden: terminal too narrow for 2 panes; …" does not contain "alpha · Agent hidden"
```

- `TestPane_AutoHideStatusNamesDisplacedTab` — the case that matters:
  **same-instance multi-tab** at 80x24, where the instance owns two open panes
  and one displaces the other. A single-tab-per-instance test cannot catch this
  bug, since the bug only exists when one instance has two panes. It drives
  **both displacement directions**, and that is not symmetry for its own sake —
  see the mutation check below.
- `TestPane_AutoHideStatusUnnamableTabMakesNoClaim` — the unnamable branch;
  asserts the placeholder is never presented as the displaced tab's real name.

Both **assert on the rendered status line** (`errBox.String()`, clipped to 80),
not on `FullError()` — the un-truncated string we passed in. That distinction is
load-bearing: `FullError()` is exactly what let #1973 through, and it is what
the two pre-existing assertions in this file read. It also locks the width
budget: the rendered assertion fails if a future edit pushes `resize wider` off
the bar.

Prod path: `relayout` → `newlyAutoHiddenPane` → `setPaneAutoHideStatus`, driven
here through `openOrFocusPane` — the same path a real pane open takes.

**Mutation-checked, because fail-first was not sufficient here.** The first
version of the naming test drove only the issue's own direction (Terminal
displaces Agent) and it passed — but so did a deliberately broken `TabLabelAt`
that names tab 0 *unconditionally*, i.e. one that cannot name what it evicted at
all. The displaced pane in that scenario **is** tab 0, so the hard-coded answer
was accidentally right and the test proved nothing about the invariant. The
reversed case (Agent displaces Terminal) is what kills that mutant:

```
--- FAIL: TestPane_AutoHideStatusNamesDisplacedTab/agent_displaces_terminal
    "alpha · Agent hidden — …" does not contain "alpha · Terminal hidden"
```

Worth flagging for the reviewer: a test that fails on the original symptom is
not automatically a test that locks the fix.

## Play-test — containerized sandbox, mock repo, 80x24

`make playtest-container`, the issue's exact repro (create `feature`/`docs`/`qa`,
open a pane each, `t` on `docs`), driven through `scripts/tui-driver.sh`. Actual
captured output, not a reconstruction — **4 panes, matching the issue verbatim**:

**Before** (master `912e5b0` toast code) — the contradiction:

```
                      ╭──────────────────────────────────────────╮
 Agent Factory        │ docs · Terminal                          │
    ├ 1 Agent         │                                          │
    └ 2 Terminal *    │                                          │
                      ╰──────────────────────────────────────────╯
    ← prev pane • → next pane │ s open pane • x hide pane │ ? help • q quit
docs hidden: terminal too narrow for 4 panes; resize wider or use `s` open pane
```

**After** — names the pane that actually went away, hint intact:

```
                      ╭──────────────────────────────────────────╮
 Agent Factory        │ docs · Terminal                          │
    ├ 1 Agent         │                                          │
    └ 2 Terminal *    │                                          │
                      ╰──────────────────────────────────────────╯
    ← prev pane • → next pane │ s open pane • x hide pane │ ? help • q quit
docs · Agent hidden — too narrow for 4 panes; resize wider or use `s` open pane
```

The visible pane is `docs · Terminal`; the toast now names `docs · Agent`. No
contradiction, and the full line renders uncut at 80 columns.

## Gates

All six, container-only (never `go test` on the host):

- `make test-container` — **green, 27/27 packages, 0 failures**
- `go build ./...` — clean
- `gofmt -l .` — no output
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — no output
- `scripts/lint-file-length.sh` — passed (667 files, 0 grandfathered)

Copy conventions: sentence case, `…`/`—` literals, no caps-shouting.

---

**Draft on purpose — please do not auto-merge.** This touches the TUI. Play-test
evidence is above; the owner gates and merges.

— Captain Claude
