### PR TITLE
feat(web): copy-on-selection Ctrl+C, explicit Ctrl+Shift+C copy, Ctrl+V paste

### DIFF
--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7569,6 +7569,7 @@ function handleClipboardKeydown(ev, deps) {
     if (deps.hasSelection()) {
       ev.preventDefault();
       deps.copy(deps.getSelection());
+      deps.clearSelection();
       return false;
     }
     ev.preventDefault();
@@ -7780,7 +7781,6 @@ function wsScheme2() {
 }
 var AttachTerminal = class {
   constructor(container, sessionId, token2, tabId, tab, cb) {
-    this.container = container;
     this.sessionId = sessionId;
     this.token = token2;
     this.tabId = tabId;
@@ -7820,6 +7820,7 @@ var AttachTerminal = class {
       (ev) => handleClipboardKeydown(ev, {
         hasSelection: () => this.term.hasSelection(),
         getSelection: () => this.term.getSelection(),
+        clearSelection: () => this.term.clearSelection(),
         copy: (text) => this.copyToClipboard(text),
         sendInput: (text) => this.sendInput(text)
       })
@@ -8104,10 +8105,12 @@ var AttachTerminal = class {
     }
   }
   /** Last-resort visible cue when BOTH clipboard paths fail, so the copy is never
-   *  silently dropped. Fixed to the viewport corner (an app-level "clipboard
-   *  unavailable" condition, not pane-specific) so it stays visible regardless of
-   *  ancestor positioning and is not clipped by the pane host's overflow:hidden;
-   *  styled inline so it needs no stylesheet plumbing and no <style> under the CSP. */
+   *  silently dropped. An app-level "clipboard unavailable" condition (not
+   *  pane-specific), so it is a viewport-fixed toast appended to document.body —
+   *  matching the app's own af-toast pattern and, by living outside the pane tree,
+   *  never clipped by a split pane's overflow:hidden or anchored to a transformed
+   *  ancestor. Styled inline so it needs no stylesheet plumbing and no <style>
+   *  element under the CSP. */
   flashCopyHint() {
     try {
       const hint = document.createElement("div");
@@ -8123,7 +8126,7 @@ var AttachTerminal = class {
       hint.style.background = "rgba(0, 0, 0, 0.82)";
       hint.style.color = "#fff";
       hint.style.pointerEvents = "none";
-      this.container.appendChild(hint);
+      document.body.appendChild(hint);
       window.setTimeout(() => hint.remove(), 2500);
     } catch {
     }

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7545,6 +7545,39 @@ function paneAddressUsesOrdinal(webTarget, realId) {
 var import_addon_fit = __toESM(require_addon_fit(), 1);
 var import_xterm = __toESM(require_xterm(), 1);
 
+// src/clipboard.ts
+var ETX = "";
+function handleClipboardKeydown(ev, deps) {
+  if (ev.type !== "keydown") {
+    return true;
+  }
+  if (ev.metaKey || ev.altKey || !ev.ctrlKey) {
+    return true;
+  }
+  const key = ev.key.toLowerCase();
+  if (key === "v") {
+    return false;
+  }
+  if (key === "c") {
+    if (ev.shiftKey) {
+      ev.preventDefault();
+      if (deps.hasSelection()) {
+        deps.copy(deps.getSelection());
+      }
+      return false;
+    }
+    if (deps.hasSelection()) {
+      ev.preventDefault();
+      deps.copy(deps.getSelection());
+      return false;
+    }
+    ev.preventDefault();
+    deps.sendInput(ETX);
+    return false;
+  }
+  return true;
+}
+
 // src/frame.ts
 var RESIZE_PAYLOAD_LEN = 4;
 var HELLO_PAYLOAD_LEN = 8;
@@ -7747,6 +7780,7 @@ function wsScheme2() {
 }
 var AttachTerminal = class {
   constructor(container, sessionId, token2, tabId, tab, cb) {
+    this.container = container;
     this.sessionId = sessionId;
     this.token = token2;
     this.tabId = tabId;
@@ -7781,7 +7815,15 @@ var AttachTerminal = class {
         }
       });
     }
-    this.term.onData((data) => this.send(encode(inputFrame(this.enc.encode(data)))));
+    this.term.onData((data) => this.sendInput(data));
+    this.term.attachCustomKeyEventHandler(
+      (ev) => handleClipboardKeydown(ev, {
+        hasSelection: () => this.term.hasSelection(),
+        getSelection: () => this.term.getSelection(),
+        copy: (text) => this.copyToClipboard(text),
+        sendInput: (text) => this.sendInput(text)
+      })
+    );
     this.ro = new ResizeObserver(() => this.scheduleFit());
     this.ro.observe(container);
     this.connect();
@@ -8006,6 +8048,84 @@ var AttachTerminal = class {
     const ws = this.ws;
     if (ws && ws.readyState === WebSocket.OPEN) {
       ws.send(bytes);
+    }
+  }
+  // --- input & clipboard -----------------------------------------------------
+  /** Sends text to the PTY as OpInput — the single input path shared by typed
+   *  keys (onData) and the Ctrl+C interrupt (clipboard.ts). UTF-8 encoded so a
+   *  multibyte char reaches the PTY as the same bytes a real terminal would send. */
+  sendInput(text) {
+    this.send(encode(inputFrame(this.enc.encode(text))));
+  }
+  /** Copies text to the system clipboard, never silently. localhost is a secure
+   *  context, so navigator.clipboard.writeText works; but if it is missing (a
+   *  non-secure origin behind a proxy) or rejects, fall back to the legacy
+   *  execCommand path, and only if THAT fails surface a visible hint — a copy that
+   *  silently fails is worse than none (the user pastes stale content unaware). */
+  copyToClipboard(text) {
+    if (text === "") {
+      return;
+    }
+    const clip = navigator.clipboard;
+    if (clip && typeof clip.writeText === "function") {
+      clip.writeText(text).catch(() => {
+        if (!this.execCommandCopy(text)) {
+          this.flashCopyHint();
+        }
+      });
+      return;
+    }
+    if (!this.execCommandCopy(text)) {
+      this.flashCopyHint();
+    }
+  }
+  /** Legacy clipboard write via a throwaway off-screen textarea. Returns whether the
+   *  copy reported success. Requires a user gesture, which the key handler provides. */
+  execCommandCopy(text) {
+    try {
+      const ta = document.createElement("textarea");
+      ta.value = text;
+      ta.setAttribute("readonly", "");
+      ta.style.position = "fixed";
+      ta.style.top = "0";
+      ta.style.left = "0";
+      ta.style.width = "1px";
+      ta.style.height = "1px";
+      ta.style.opacity = "0";
+      document.body.appendChild(ta);
+      ta.select();
+      ta.setSelectionRange(0, text.length);
+      const ok = document.execCommand("copy");
+      ta.remove();
+      this.term.focus();
+      return ok;
+    } catch {
+      return false;
+    }
+  }
+  /** Last-resort visible cue when BOTH clipboard paths fail, so the copy is never
+   *  silently dropped. Fixed to the viewport corner (an app-level "clipboard
+   *  unavailable" condition, not pane-specific) so it stays visible regardless of
+   *  ancestor positioning and is not clipped by the pane host's overflow:hidden;
+   *  styled inline so it needs no stylesheet plumbing and no <style> under the CSP. */
+  flashCopyHint() {
+    try {
+      const hint = document.createElement("div");
+      hint.textContent = "Copy failed \u2014 clipboard unavailable";
+      hint.setAttribute("role", "alert");
+      hint.style.position = "fixed";
+      hint.style.bottom = "12px";
+      hint.style.right = "12px";
+      hint.style.zIndex = "9999";
+      hint.style.padding = "4px 10px";
+      hint.style.borderRadius = "4px";
+      hint.style.font = "12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace";
+      hint.style.background = "rgba(0, 0, 0, 0.82)";
+      hint.style.color = "#fff";
+      hint.style.pointerEvents = "none";
+      this.container.appendChild(hint);
+      window.setTimeout(() => hint.remove(), 2500);
+    } catch {
     }
   }
 };

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "6aea978173ce";
+const VERSION = "28e653515fd9";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "28e653515fd9";
+const VERSION = "806e2e200d7b";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/src/clipboard.test.ts
+++ b/web/src/clipboard.test.ts
@@ -1,0 +1,193 @@
+// Pins the web terminal's clipboard/interrupt decision (the web half of Sachin's
+// "copying is not working the way I expect" report). It asserts on WHAT REACHES
+// THE WIRE and the clipboard — not on the synthetic keydown — by feeding
+// handleClipboardKeydown spies that encode input exactly as terminal.ts does
+// (encode(inputFrame(...))) and record clipboard writes. So a regression that,
+// say, sent \x03 while ALSO copying, or dropped the interrupt, fails here.
+//
+// clipboard.ts is pure and DOM-free (the browser-only copy/paste plumbing lives
+// in terminal.ts), so this needs no xterm stub — it imports the real codec.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { type ClipboardDeps, type ClipboardKeyEvent, handleClipboardKeydown } from "./clipboard.js";
+import { decode, inputFrame, Op, encode } from "./frame.js";
+
+const ETX = "\x03";
+
+/** A recording rig: captures every frame that would hit the WS (as the exact
+ *  bytes terminal.ts sends), every clipboard write, and preventDefault calls. */
+function rig(opts: { selection?: string }) {
+  const enc = new TextEncoder();
+  const wire: Uint8Array[] = [];
+  const clipboard: string[] = [];
+  let prevented = 0;
+  const selection = opts.selection ?? "";
+  const deps: ClipboardDeps = {
+    hasSelection: () => selection !== "",
+    getSelection: () => selection,
+    copy: (t) => clipboard.push(t),
+    // Byte-identical to terminal.ts's input path, so `wire` holds real OpInput frames.
+    sendInput: (t) => wire.push(encode(inputFrame(enc.encode(t)))),
+  };
+  return {
+    deps,
+    wire,
+    clipboard,
+    prevented: () => prevented,
+    markPrevented: () => {
+      prevented++;
+    },
+  };
+}
+
+/** Builds a keydown-shaped event with a preventDefault spy. */
+function keyEvent(
+  init: Partial<ClipboardKeyEvent> & { key: string },
+  onPrevent: () => void,
+): ClipboardKeyEvent {
+  return {
+    type: "keydown",
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+    altKey: false,
+    preventDefault: onPrevent,
+    ...init,
+  };
+}
+
+/** Decodes the captured wire frames to the concatenated input bytes (as a string),
+ *  proving what actually reached the OpInput channel. */
+function wireInput(frames: Uint8Array[]): string {
+  const dec = new TextDecoder();
+  let out = "";
+  for (const raw of frames) {
+    const f = decode(raw);
+    assert.equal(f.op, Op.Input, "only OpInput frames are expected on this channel");
+    out += dec.decode(f.data);
+  }
+  return out;
+}
+
+// --- Ctrl+C: copy when there's a selection, interrupt when there isn't --------
+
+test("Ctrl+C WITH a selection copies it and sends NO \\x03", () => {
+  const r = rig({ selection: "hello world" });
+  const ret = handleClipboardKeydown(keyEvent({ key: "c", ctrlKey: true }, r.markPrevented), r.deps);
+
+  assert.equal(ret, false, "must suppress xterm's own Ctrl+C so it does not also emit \\x03");
+  assert.deepEqual(r.clipboard, ["hello world"], "the selection must reach the clipboard");
+  assert.equal(wireInput(r.wire), "", "no interrupt on the wire when copying");
+  assert.equal(r.prevented(), 1, "preventDefault stops the browser's own copy");
+});
+
+test("Ctrl+C with NO selection sends \\x03 on the wire and copies nothing", () => {
+  const r = rig({ selection: "" });
+  const ret = handleClipboardKeydown(keyEvent({ key: "c", ctrlKey: true }, r.markPrevented), r.deps);
+
+  assert.equal(ret, false, "we emit the interrupt ourselves, so xterm must be suppressed");
+  assert.equal(wireInput(r.wire), ETX, "the interrupt reflex is preserved — exactly one \\x03");
+  assert.deepEqual(r.clipboard, [], "nothing to copy");
+});
+
+// --- Ctrl+Shift+C: explicit always-copy, never interrupts ---------------------
+
+test("Ctrl+Shift+C copies the selection and never sends \\x03", () => {
+  const r = rig({ selection: "abc" });
+  const ret = handleClipboardKeydown(
+    keyEvent({ key: "C", ctrlKey: true, shiftKey: true }, r.markPrevented),
+    r.deps,
+  );
+
+  assert.equal(ret, false);
+  assert.deepEqual(r.clipboard, ["abc"]);
+  assert.equal(wireInput(r.wire), "", "an explicit copy must never interrupt");
+  assert.equal(r.prevented(), 1);
+});
+
+test("Ctrl+Shift+C with NO selection is a no-op (no copy, no interrupt)", () => {
+  const r = rig({ selection: "" });
+  const ret = handleClipboardKeydown(
+    keyEvent({ key: "C", ctrlKey: true, shiftKey: true }, r.markPrevented),
+    r.deps,
+  );
+
+  assert.equal(ret, false, "still claims the key so it never falls through to \\x03");
+  assert.deepEqual(r.clipboard, []);
+  assert.equal(wireInput(r.wire), "", "explicit copy is never an interrupt, even with nothing selected");
+});
+
+// --- Paste: defer to xterm's native (browser-trusted) paste -------------------
+
+test("Ctrl+V defers to native paste: suppresses xterm's \\x16, sends nothing itself, no preventDefault", () => {
+  const r = rig({ selection: "" });
+  const ret = handleClipboardKeydown(keyEvent({ key: "v", ctrlKey: true }, r.markPrevented), r.deps);
+
+  assert.equal(ret, false, "false suppresses xterm's Ctrl+V→\\x16 keymap");
+  assert.equal(wireInput(r.wire), "", "we send no input ourselves — the native paste event does");
+  assert.deepEqual(r.clipboard, [], "paste must not touch the clipboard write path");
+  assert.equal(r.prevented(), 0, "must NOT preventDefault, or the browser's paste event never fires");
+});
+
+test("Ctrl+Shift+V also defers to native paste without preventDefault", () => {
+  const r = rig({ selection: "" });
+  const ret = handleClipboardKeydown(
+    keyEvent({ key: "V", ctrlKey: true, shiftKey: true }, r.markPrevented),
+    r.deps,
+  );
+
+  assert.equal(ret, false);
+  assert.equal(wireInput(r.wire), "");
+  assert.equal(r.prevented(), 0);
+});
+
+// --- macOS Cmd+* and Alt+* are left entirely to the browser -------------------
+
+test("Cmd+C is NOT claimed (macOS browser copies before xterm)", () => {
+  const r = rig({ selection: "sel" });
+  const ret = handleClipboardKeydown(keyEvent({ key: "c", metaKey: true }, r.markPrevented), r.deps);
+
+  assert.equal(ret, true, "leave Cmd+C to the browser");
+  assert.deepEqual(r.clipboard, [], "our handler must not double-copy on macOS");
+  assert.equal(wireInput(r.wire), "");
+  assert.equal(r.prevented(), 0);
+});
+
+test("Cmd+V is NOT claimed (native paste path untouched)", () => {
+  const r = rig({});
+  const ret = handleClipboardKeydown(keyEvent({ key: "v", metaKey: true }, r.markPrevented), r.deps);
+  assert.equal(ret, true);
+  assert.equal(r.prevented(), 0);
+});
+
+// --- The keydown-only guard: a gesture is handled once, not per key phase ------
+
+test("keyup for Ctrl+C is ignored (returns true, no side effects)", () => {
+  const r = rig({ selection: "x" });
+  const ev = keyEvent({ key: "c", ctrlKey: true }, r.markPrevented);
+  ev.type = "keyup";
+  const ret = handleClipboardKeydown(ev, r.deps);
+
+  assert.equal(ret, true, "only keydown acts; keyup/keypress must fall through to xterm");
+  assert.deepEqual(r.clipboard, [], "no duplicate copy on the keyup half of the gesture");
+  assert.equal(wireInput(r.wire), "");
+});
+
+// --- Unrelated keys are never disturbed ---------------------------------------
+
+test("a plain key and other Ctrl combos fall through untouched", () => {
+  for (const ev of [
+    keyEvent({ key: "a" }, () => {}),
+    keyEvent({ key: "a", ctrlKey: true }, () => {}),
+    keyEvent({ key: "d", ctrlKey: true }, () => {}), // Ctrl+D must still reach the PTY
+  ]) {
+    const r = rig({ selection: "sel" });
+    ev.preventDefault = r.markPrevented;
+    assert.equal(handleClipboardKeydown(ev, r.deps), true, `${ev.key} must fall through`);
+    assert.deepEqual(r.clipboard, []);
+    assert.equal(wireInput(r.wire), "");
+    assert.equal(r.prevented(), 0);
+  }
+});

--- a/web/src/clipboard.test.ts
+++ b/web/src/clipboard.test.ts
@@ -23,10 +23,17 @@ function rig(opts: { selection?: string }) {
   const wire: Uint8Array[] = [];
   const clipboard: string[] = [];
   let prevented = 0;
-  const selection = opts.selection ?? "";
+  let cleared = 0;
+  // Mutable so clearSelection() genuinely drops it — a later hasSelection() then
+  // reports false, exactly as xterm behaves after a real clear.
+  let selection = opts.selection ?? "";
   const deps: ClipboardDeps = {
     hasSelection: () => selection !== "",
     getSelection: () => selection,
+    clearSelection: () => {
+      selection = "";
+      cleared++;
+    },
     copy: (t) => clipboard.push(t),
     // Byte-identical to terminal.ts's input path, so `wire` holds real OpInput frames.
     sendInput: (t) => wire.push(encode(inputFrame(enc.encode(t)))),
@@ -36,6 +43,7 @@ function rig(opts: { selection?: string }) {
     wire,
     clipboard,
     prevented: () => prevented,
+    cleared: () => cleared,
     markPrevented: () => {
       prevented++;
     },
@@ -81,6 +89,24 @@ test("Ctrl+C WITH a selection copies it and sends NO \\x03", () => {
   assert.deepEqual(r.clipboard, ["hello world"], "the selection must reach the clipboard");
   assert.equal(wireInput(r.wire), "", "no interrupt on the wire when copying");
   assert.equal(r.prevented(), 1, "preventDefault stops the browser's own copy");
+  assert.equal(r.cleared(), 1, "the selection is cleared so the NEXT Ctrl+C can interrupt");
+});
+
+test("a SECOND Ctrl+C after a copy interrupts — the runaway-agent reflex", () => {
+  // The scenario the interrupt half exists for: copy some runaway output, then the
+  // agent keeps going and the user reaches for Ctrl+C to STOP it. Because the first
+  // Ctrl+C cleared the selection, the second one falls through to the interrupt.
+  const r = rig({ selection: "runaway output" });
+
+  const first = handleClipboardKeydown(keyEvent({ key: "c", ctrlKey: true }, r.markPrevented), r.deps);
+  assert.equal(first, false);
+  assert.deepEqual(r.clipboard, ["runaway output"], "first Ctrl+C copies");
+  assert.equal(wireInput(r.wire), "", "first Ctrl+C does NOT interrupt");
+
+  const second = handleClipboardKeydown(keyEvent({ key: "c", ctrlKey: true }, r.markPrevented), r.deps);
+  assert.equal(second, false);
+  assert.equal(wireInput(r.wire), ETX, "second Ctrl+C interrupts — exactly one \\x03");
+  assert.deepEqual(r.clipboard, ["runaway output"], "the second press does NOT re-copy");
 });
 
 test("Ctrl+C with NO selection sends \\x03 on the wire and copies nothing", () => {
@@ -105,6 +131,7 @@ test("Ctrl+Shift+C copies the selection and never sends \\x03", () => {
   assert.deepEqual(r.clipboard, ["abc"]);
   assert.equal(wireInput(r.wire), "", "an explicit copy must never interrupt");
   assert.equal(r.prevented(), 1);
+  assert.equal(r.cleared(), 0, "Ctrl+Shift+C keeps the selection — it is the 'keep selecting' gesture");
 });
 
 test("Ctrl+Shift+C with NO selection is a no-op (no copy, no interrupt)", () => {

--- a/web/src/clipboard.ts
+++ b/web/src/clipboard.ts
@@ -1,0 +1,119 @@
+// Clipboard key handling for the web attach terminal — the web half of Sachin's
+// "copying is not working the way I expect" report. His decision, verbatim:
+//
+//   "Copy on selection; Ctrl+C interrupts only when nothing is selected."
+//
+// Read as the terminal convention (NOT auto-copy-on-drag): the copy happens on
+// the Ctrl+C GESTURE when a selection is present, so drag-selecting text never
+// clobbers the clipboard on its own. Concretely:
+//
+//   - Ctrl+C with a selection → COPY the selection, do NOT send \x03.
+//   - Ctrl+C with no selection → interrupt (\x03), exactly as before — the
+//     runaway-agent reflex is preserved.
+//   - Ctrl+Shift+C → an EXPLICIT always-copy: copies the selection if any, a
+//     no-op otherwise, and NEVER interrupts.
+//   - Ctrl+V / Ctrl+Shift+V → paste, by deferring to xterm's native browser
+//     paste (see below).
+//
+// This is the DECISION half, kept pure and DOM-free so it unit-tests against
+// what reaches the wire/clipboard rather than against a synthetic keydown.
+// terminal.ts binds it to xterm via attachCustomKeyEventHandler and supplies the
+// real capabilities (xterm selection, clipboard write, OpInput send).
+
+/** The subset of a DOM KeyboardEvent this decision reads. A real KeyboardEvent
+ *  satisfies it structurally; tests construct plain objects. */
+export interface ClipboardKeyEvent {
+  /** xterm's custom handler fires for keydown/keypress/keyup alike — we act only
+   *  on "keydown" so a gesture is handled once, not three times. */
+  type: string;
+  key: string;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+  preventDefault(): void;
+}
+
+/** The side-effecting capabilities the decision drives. terminal.ts supplies real
+ *  ones; tests supply spies so an assertion can read exactly what would reach the
+ *  clipboard and the input frame. */
+export interface ClipboardDeps {
+  /** Whether the terminal currently has a text selection (xterm.hasSelection). */
+  hasSelection(): boolean;
+  /** The selected text (xterm.getSelection). Only read when hasSelection() is true. */
+  getSelection(): string;
+  /** Copy text to the system clipboard, with a graceful, never-silent fallback. */
+  copy(text: string): void;
+  /** Send text to the PTY as OpInput — the same path onData uses for typed keys. */
+  sendInput(text: string): void;
+}
+
+/** The Ctrl+C interrupt byte (End-of-Text), sent verbatim on the no-selection path. */
+const ETX = "\x03";
+
+/**
+ * Decide what a key event does for clipboard vs. interrupt. Returns whether xterm
+ * should keep its DEFAULT handling of the event:
+ *
+ *   - `true`  → not our gesture; let xterm/the browser process it as usual.
+ *   - `false` → we fully handled it; xterm skips its own processing so it does not
+ *     ALSO emit bytes for the key.
+ *
+ * Only Ctrl+* is claimed. Cmd+* (metaKey) and Alt+* are left untouched so macOS
+ * Cmd+C/Cmd+V keep working exactly as before — the browser copies/pastes before
+ * xterm ever sees the key.
+ *
+ * Paste note: for Ctrl+V (and Ctrl+Shift+V) we return `false` WITHOUT calling
+ * preventDefault. In xterm, a custom handler that returns false makes _keyDown
+ * bail before its keymap runs — so xterm's own Ctrl+V→\x16 mapping is suppressed
+ * — but it does NOT cancel the DOM event, so the browser still fires its trusted
+ * `paste` event, which xterm's native paste handler forwards to the PTY. That is
+ * a permission-free paste with no double input; navigator.clipboard.readText is
+ * deliberately NOT used (it prompts on Chrome and is blocked on Firefox).
+ */
+export function handleClipboardKeydown(ev: ClipboardKeyEvent, deps: ClipboardDeps): boolean {
+  // Act once per gesture: xterm's handler also fires for keypress/keyup, and
+  // returning false there would suppress xterm's own keyup/keypress bookkeeping.
+  if (ev.type !== "keydown") {
+    return true;
+  }
+  // Leave Cmd+* (macOS) and Alt+* to the browser/xterm untouched.
+  if (ev.metaKey || ev.altKey || !ev.ctrlKey) {
+    return true;
+  }
+
+  const key = ev.key.toLowerCase();
+
+  if (key === "v") {
+    // Defer to xterm's native (browser-trusted) paste for both Ctrl+V and
+    // Ctrl+Shift+V. Returning false suppresses xterm's Ctrl+V→\x16 keymap; NOT
+    // calling preventDefault lets the browser's `paste` event flow to xterm.
+    return false;
+  }
+
+  if (key === "c") {
+    if (ev.shiftKey) {
+      // Ctrl+Shift+C — explicit, unambiguous copy. Copies a selection if present,
+      // a no-op otherwise; never interrupts.
+      ev.preventDefault();
+      if (deps.hasSelection()) {
+        deps.copy(deps.getSelection());
+      }
+      return false;
+    }
+    // Ctrl+C — a present selection means "copy it" (the terminal convention), so
+    // copy and do NOT interrupt.
+    if (deps.hasSelection()) {
+      ev.preventDefault();
+      deps.copy(deps.getSelection());
+      return false;
+    }
+    // No selection: interrupt. Send \x03 ourselves and suppress xterm's own
+    // Ctrl+C handling so the interrupt is emitted exactly once.
+    ev.preventDefault();
+    deps.sendInput(ETX);
+    return false;
+  }
+
+  return true; // not our gesture
+}

--- a/web/src/clipboard.ts
+++ b/web/src/clipboard.ts
@@ -42,6 +42,9 @@ export interface ClipboardDeps {
   hasSelection(): boolean;
   /** The selected text (xterm.getSelection). Only read when hasSelection() is true. */
   getSelection(): string;
+  /** Clear the terminal's selection (xterm.clearSelection). Called after a Ctrl+C
+   *  copy so the NEXT Ctrl+C interrupts (see the Ctrl+C branch). */
+  clearSelection(): void;
   /** Copy text to the system clipboard, with a graceful, never-silent fallback. */
   copy(text: string): void;
   /** Send text to the PTY as OpInput — the same path onData uses for typed keys. */
@@ -94,7 +97,8 @@ export function handleClipboardKeydown(ev: ClipboardKeyEvent, deps: ClipboardDep
   if (key === "c") {
     if (ev.shiftKey) {
       // Ctrl+Shift+C — explicit, unambiguous copy. Copies a selection if present,
-      // a no-op otherwise; never interrupts.
+      // a no-op otherwise; never interrupts. The selection is deliberately LEFT
+      // intact: this is the "just copy, I want to keep selecting" gesture.
       ev.preventDefault();
       if (deps.hasSelection()) {
         deps.copy(deps.getSelection());
@@ -106,6 +110,13 @@ export function handleClipboardKeydown(ev: ClipboardKeyEvent, deps: ClipboardDep
     if (deps.hasSelection()) {
       ev.preventDefault();
       deps.copy(deps.getSelection());
+      // Clear the selection so the NEXT Ctrl+C interrupts. Without this, a user who
+      // copies runaway output and then reaches for Ctrl+C to STOP the agent keeps
+      // re-copying instead — the interrupt reflex the no-selection path exists for
+      // would be unreachable until they manually deselect. xterm only auto-clears
+      // the selection on its own onUserInput, which this path bypasses (we send via
+      // our WS and return false), so we clear it explicitly.
+      deps.clearSelection();
       return false;
     }
     // No selection: interrupt. Send \x03 ourselves and suppress xterm's own

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -39,6 +39,7 @@
 import { FitAddon } from "@xterm/addon-fit";
 import { type ITheme, Terminal } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
+import { handleClipboardKeydown } from "./clipboard.js";
 import { decode, encode, inputFrame, Op, resizeFrame } from "./frame.js";
 import { currentXtermTheme } from "./theme.js";
 
@@ -102,7 +103,7 @@ export class AttachTerminal {
   private exited = false;
 
   constructor(
-    container: HTMLElement,
+    private readonly container: HTMLElement,
     private readonly sessionId: string,
     private readonly token: string,
     private readonly tabId: string,
@@ -147,7 +148,20 @@ export class AttachTerminal {
     // Keystrokes → OpInput. xterm hands us the terminal's outgoing byte string
     // (regular chars and key escape sequences alike); UTF-8 encode it so a typed
     // multibyte char reaches the PTY as the same bytes a real terminal would send.
-    this.term.onData((data) => this.send(encode(inputFrame(this.enc.encode(data)))));
+    this.term.onData((data) => this.sendInput(data));
+
+    // Clipboard vs. interrupt (Sachin's decision — see clipboard.ts): intercept the
+    // key BEFORE xterm turns it into input. Ctrl+C copies a present selection (else
+    // interrupts), Ctrl+Shift+C is an explicit always-copy, and Ctrl+V defers to
+    // xterm's native browser paste. Returning false suppresses xterm's own handling.
+    this.term.attachCustomKeyEventHandler((ev) =>
+      handleClipboardKeydown(ev, {
+        hasSelection: () => this.term.hasSelection(),
+        getSelection: () => this.term.getSelection(),
+        copy: (text) => this.copyToClipboard(text),
+        sendInput: (text) => this.sendInput(text),
+      }),
+    );
 
     // Re-fit + re-announce size whenever the container changes (window resize,
     // rail collapse, devtools). Debounced; the server echo reconciles multi-writer.
@@ -395,6 +409,93 @@ export class AttachTerminal {
     const ws = this.ws;
     if (ws && ws.readyState === WebSocket.OPEN) {
       ws.send(bytes);
+    }
+  }
+
+  // --- input & clipboard -----------------------------------------------------
+
+  /** Sends text to the PTY as OpInput — the single input path shared by typed
+   *  keys (onData) and the Ctrl+C interrupt (clipboard.ts). UTF-8 encoded so a
+   *  multibyte char reaches the PTY as the same bytes a real terminal would send. */
+  private sendInput(text: string): void {
+    this.send(encode(inputFrame(this.enc.encode(text))));
+  }
+
+  /** Copies text to the system clipboard, never silently. localhost is a secure
+   *  context, so navigator.clipboard.writeText works; but if it is missing (a
+   *  non-secure origin behind a proxy) or rejects, fall back to the legacy
+   *  execCommand path, and only if THAT fails surface a visible hint — a copy that
+   *  silently fails is worse than none (the user pastes stale content unaware). */
+  private copyToClipboard(text: string): void {
+    if (text === "") {
+      return; // nothing selected — an explicit copy of nothing is a no-op
+    }
+    const clip = navigator.clipboard;
+    if (clip && typeof clip.writeText === "function") {
+      // The .catch fallback runs after the async rejection, i.e. outside the key
+      // gesture, so execCommand may itself fail there; the hint is the backstop.
+      clip.writeText(text).catch(() => {
+        if (!this.execCommandCopy(text)) {
+          this.flashCopyHint();
+        }
+      });
+      return;
+    }
+    if (!this.execCommandCopy(text)) {
+      this.flashCopyHint();
+    }
+  }
+
+  /** Legacy clipboard write via a throwaway off-screen textarea. Returns whether the
+   *  copy reported success. Requires a user gesture, which the key handler provides. */
+  private execCommandCopy(text: string): boolean {
+    try {
+      const ta = document.createElement("textarea");
+      ta.value = text;
+      // Off-screen but still selectable; readonly stops a mobile keyboard popping up.
+      ta.setAttribute("readonly", "");
+      ta.style.position = "fixed";
+      ta.style.top = "0";
+      ta.style.left = "0";
+      ta.style.width = "1px";
+      ta.style.height = "1px";
+      ta.style.opacity = "0";
+      document.body.appendChild(ta);
+      ta.select();
+      ta.setSelectionRange(0, text.length);
+      const ok = document.execCommand("copy");
+      ta.remove();
+      this.term.focus(); // the temp textarea stole focus; hand it back to the terminal
+      return ok;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Last-resort visible cue when BOTH clipboard paths fail, so the copy is never
+   *  silently dropped. Fixed to the viewport corner (an app-level "clipboard
+   *  unavailable" condition, not pane-specific) so it stays visible regardless of
+   *  ancestor positioning and is not clipped by the pane host's overflow:hidden;
+   *  styled inline so it needs no stylesheet plumbing and no <style> under the CSP. */
+  private flashCopyHint(): void {
+    try {
+      const hint = document.createElement("div");
+      hint.textContent = "Copy failed — clipboard unavailable";
+      hint.setAttribute("role", "alert");
+      hint.style.position = "fixed";
+      hint.style.bottom = "12px";
+      hint.style.right = "12px";
+      hint.style.zIndex = "9999";
+      hint.style.padding = "4px 10px";
+      hint.style.borderRadius = "4px";
+      hint.style.font = "12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace";
+      hint.style.background = "rgba(0, 0, 0, 0.82)";
+      hint.style.color = "#fff";
+      hint.style.pointerEvents = "none";
+      this.container.appendChild(hint);
+      window.setTimeout(() => hint.remove(), 2500);
+    } catch {
+      // If even the DOM cue fails there is nothing further to do.
     }
   }
 }

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -103,7 +103,7 @@ export class AttachTerminal {
   private exited = false;
 
   constructor(
-    private readonly container: HTMLElement,
+    container: HTMLElement,
     private readonly sessionId: string,
     private readonly token: string,
     private readonly tabId: string,
@@ -158,6 +158,7 @@ export class AttachTerminal {
       handleClipboardKeydown(ev, {
         hasSelection: () => this.term.hasSelection(),
         getSelection: () => this.term.getSelection(),
+        clearSelection: () => this.term.clearSelection(),
         copy: (text) => this.copyToClipboard(text),
         sendInput: (text) => this.sendInput(text),
       }),
@@ -473,10 +474,12 @@ export class AttachTerminal {
   }
 
   /** Last-resort visible cue when BOTH clipboard paths fail, so the copy is never
-   *  silently dropped. Fixed to the viewport corner (an app-level "clipboard
-   *  unavailable" condition, not pane-specific) so it stays visible regardless of
-   *  ancestor positioning and is not clipped by the pane host's overflow:hidden;
-   *  styled inline so it needs no stylesheet plumbing and no <style> under the CSP. */
+   *  silently dropped. An app-level "clipboard unavailable" condition (not
+   *  pane-specific), so it is a viewport-fixed toast appended to document.body —
+   *  matching the app's own af-toast pattern and, by living outside the pane tree,
+   *  never clipped by a split pane's overflow:hidden or anchored to a transformed
+   *  ancestor. Styled inline so it needs no stylesheet plumbing and no <style>
+   *  element under the CSP. */
   private flashCopyHint(): void {
     try {
       const hint = document.createElement("div");
@@ -492,7 +495,7 @@ export class AttachTerminal {
       hint.style.background = "rgba(0, 0, 0, 0.82)";
       hint.style.color = "#fff";
       hint.style.pointerEvents = "none";
-      this.container.appendChild(hint);
+      document.body.appendChild(hint);
       window.setTimeout(() => hint.remove(), 2500);
     } catch {
       // If even the DOM cue fails there is nothing further to do.


### PR DESCRIPTION
## What & why

Fixes the **web half** of Sachin's "copying is not working the way I expect" report.

Sachin's decision, verbatim — **not** redesigned here:

> "Copy on selection; Ctrl+C interrupts only when nothing is selected."

The web xterm.js terminal (`web/src/terminal.ts`) had **no clipboard path** — every key went straight through `onData`, so Ctrl+C always sent `\x03` and there was no way to copy a terminal selection. This wires the clipboard in via xterm's `attachCustomKeyEventHandler`, intercepting the key *before* it becomes input.

## Behavior

| Gesture | Result |
|---|---|
| **Ctrl+C** with a selection | Copy the selection; **do not** send `\x03` |
| **Ctrl+C** with no selection | `\x03` (interrupt) — exactly as before; the runaway-agent reflex is preserved |
| **Ctrl+Shift+C** | **Explicit always-copy**: copies a selection if any, a no-op otherwise; never interrupts |
| **Ctrl+V / Ctrl+Shift+V** | Paste (see paste note) |
| **Cmd+\*** (macOS) | Untouched — the browser handles it, so Cmd+C / Cmd+V keep working |

### Reading of "copy on selection"
Read as the **terminal convention** — Ctrl+C copies *when a selection is present* — **not** auto-copy the moment text is selected. Auto-copy-on-drag would clobber the user's clipboard mid-selection; the copy happens on the **Ctrl+C / Ctrl+Shift+C gesture**, not on selection-change. This matches the decision text and is the sensible reading.

### Paste note (xterm already handles it)
xterm.js registers native `paste` listeners on its textarea/element, so **Cmd+V and Ctrl+Shift+V already paste** via the browser's *trusted* paste event. Only plain **Ctrl+V** was broken — xterm's keymap turned it into `\x16` and canceled the event, so the native paste never fired. The fix: for `Ctrl+V`, the custom handler **returns `false` without calling `preventDefault`**. In xterm, a custom handler returning false makes `_keyDown` bail *before* its keymap runs (so no `\x16`) but does **not** cancel the DOM event — so the browser's native paste still fires and xterm forwards it to the PTY. This is a **permission-free** paste with **no double input**; `navigator.clipboard.readText` is deliberately avoided (it prompts on Chrome and is blocked on Firefox). Verified against the bundled xterm source (`_keyDown` early-return + DOM listener ignores the return value).

### Copy fallback (never silent)
`navigator.clipboard.writeText` (localhost **is** a secure context) → falls back to `document.execCommand('copy')` → and only if *both* fail, a visible transient hint. A copy that silently fails is worse than none (the user pastes stale content unaware).

### Out of scope
Image paste — Sachin picked the *copy* behavior, not image paste. Not added here.

## Tests

The decision logic is a **pure, DOM-free module** (`clipboard.ts`) so it unit-tests against **what reaches the OpInput frame and the clipboard**, not the keydown (`clipboard.test.ts`, 10 cases). The rig encodes input byte-identically to `terminal.ts` (`encode(inputFrame(...))`) and decodes the captured frames:

- Ctrl+C **with** selection → clipboard gets the selection, **no** `\x03` on the wire, `preventDefault` called.
- Ctrl+C **no** selection → exactly one `\x03` OpInput frame on the wire, nothing copied.
- Ctrl+Shift+C → copies, **no** interrupt (and a no-op with an empty selection).
- Ctrl+V / Ctrl+Shift+V → returns false, emits **no** input itself, **no** `preventDefault` (so native paste isn't blocked).
- Cmd+C / Cmd+V → not claimed (macOS untouched); keyup ignored (gesture handled once); unrelated keys (incl. Ctrl+D) fall through.

**Fail-first proven:** mutating `handleClipboardKeydown` to today's behavior (defer everything to xterm) turns all 6 behavior-changing tests **red** while the 4 non-interference tests correctly stay green.

## Gates
- `npm run typecheck` — clean
- `make web-test` — **240/240** green (230 baseline + 10 new)
- `make web-build` — clean; committed `web/dist/` rebuilt (the container serves committed dist)
- Codex review gate is out of credits → this is gated by a **Claude review + Sachin merge**. Diff self-reviewed.

## Verification note
The unit tests assert the exact wire/clipboard contract, and the paste mechanism is verified at the xterm-source level. The end-to-end real-clipboard check (canvas-drag selection + `navigator.clipboard` in headless Chromium) was **not** added: it's brittle and the dev box was under heavy contention at build time (load ~14, 6 competing containers), which would make a selftest red ambiguous. Recommend exercising copy/paste live in the browser at the review gate (localhost secure context, where the Clipboard API genuinely works) — that's the honest verification for clipboard behavior. Kept as **draft** per instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)