### PR TITLE
fix(tmux): make the wedged-server liveness lie visible — migrate DoesSessionExist evidence sites to ProbeSession (#1962)

### DIFF
--- a/daemon/deliver_prompt_test.go
+++ b/daemon/deliver_prompt_test.go
@@ -1039,7 +1039,7 @@ func TestDeliverPrompt_TmuxOrphanReturnsImmediatelyWithError(t *testing.T) {
 	})
 
 	// The orphan must exist in tmux but carry no daemon/disk record.
-	if !tmux.NewTmuxSessionForRepo(orphanTitle, repo.Root, program).DoesSessionExist() {
+	if !tmux.NewTmuxSessionForRepo(orphanTitle, repo.Root, program).ExistsOrUnknown() {
 		t.Fatal("orphan tmux session should exist after creation")
 	}
 	if exists, _, _, err := manager.targetSessionState(repo.ID, orphanTitle); err != nil {

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -504,7 +504,18 @@ func (m *Manager) validateTitleAvailableLocked(repoID, repoPath, title, program 
 		}
 		return nil
 	}
-	if tmuxSession := tmux.NewTmuxSessionForRepo(title, repoPath, program); tmuxSession.DoesSessionExist() {
+	tmuxSession := tmux.NewTmuxSessionForRepo(title, repoPath, program)
+	// Existence gates the create here, so read the tri-state, not the lossy bool
+	// (#1962): only a CONFIRMED existing session (known && exists) blocks. A
+	// wedged/timed-out has-session is NOT proof of a name collision — reporting
+	// "exists" through ExistsOrUnknown would refuse a legitimate create against a
+	// merely-wedged server. An unanswered probe (!known) falls through and lets the
+	// create proceed. That never silently clobbers a real orphan: the create's own
+	// `tmux new-session -s <name>` fails on a duplicate name, and Start's existence
+	// check (now ProbeSession too) surfaces it as "already exists" once the server
+	// answers, or as ErrTmuxTimeout while it stays wedged — either way non-
+	// destructive. Blocking here on a guess is the only unsafe option.
+	if exists, known := tmuxSession.ProbeSession(); known && exists {
 		// A tmux session exists with no daemon reservation, in-memory instance,
 		// or disk record — an orphan left by a crash or an external process.
 		// No creator will ever finish it, so this stays a plain error (not

--- a/daemon/status_test.go
+++ b/daemon/status_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 // errSessionAbsent makes the mock executor's has-session probe report "no such
-// session", driving DoesSessionExist to false for the #999 nil-monitor test.
+// session", driving ExistsOrUnknown to false for the #999 nil-monitor test.
 var errSessionAbsent = errors.New("no such session")
 
 // deadTmuxBackend is a FakeBackend whose IsAlive reports false, modelling a
@@ -176,7 +176,7 @@ func (b nilMonitorBackend) HasUpdated(*session.Instance) (bool, bool, string) {
 	return b.ts.HasUpdated()
 }
 func (b nilMonitorBackend) IsAlive(*session.Instance) (bool, error) {
-	return b.ts.DoesSessionExist(), nil
+	return b.ts.ExistsOrUnknown(), nil
 }
 
 // TestRefreshStatuses_DeadNilMonitorDoesNotPanic is the #999 regression at the

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -575,14 +575,24 @@ func (b *LocalBackend) setupTabs(i *Instance) {
 		if err := tab.tmux.Restore(worktreePath); err != nil {
 			log.WarningLog.Printf("restore tab %q for %q failed: %v", tab.Name, i.Title, err)
 		}
-		// Only count a shell tab as live when its tmux session actually exists
-		// server-side after Restore. Restore (and its re-spawn) can fail — e.g.
-		// the worktree was removed so `tmux new-session -c $workdir` errors —
-		// leaving a dead shell tab. Gating on presence alone (the old behavior)
-		// suppressed the fresh-shell fallback below and stranded the user with a
-		// dead terminal (#991).
-		if tab.Kind == TabKindShell && tab.tmux.DoesSessionExist() {
-			hasLiveShell = true
+		// Only count a shell tab as live when a has-session probe ANSWERED that its
+		// tmux session exists server-side after Restore. Restore (and its re-spawn)
+		// can fail — e.g. the worktree was removed so `tmux new-session -c $workdir`
+		// errors — leaving a dead shell tab. Gating on presence alone suppressed the
+		// fresh-shell fallback below and stranded the user with a dead terminal
+		// (#991).
+		//
+		// Existence is EVIDENCE here, so probe the tri-state instead of the lossy
+		// bool (#1962): only known && exists counts as live. A wedged/timed-out
+		// has-session reports "exists" through ExistsOrUnknown, which would suppress
+		// the fallback and re-strand the user with a dead/wedged terminal — the exact
+		// #991 regression. Treating !known as "not confirmed live" means a merely-
+		// wedged server may cost a redundant fresh-shell spawn; a spare shell tab is
+		// strictly better than a dead one, so this is the deliberate tradeoff.
+		if tab.Kind == TabKindShell {
+			if exists, known := tab.tmux.ProbeSession(); known && exists {
+				hasLiveShell = true
+			}
 		}
 	}
 	// No persisted shell tab means a fresh instance (or one whose user closed
@@ -724,9 +734,9 @@ func (b *LocalBackend) IsAlive(i *Instance) (bool, error) {
 		// No binding at all: an answer, not a guess.
 		return false, nil
 	}
-	// ProbeSession, not DoesSessionExist (#1917 round 8): this result is EVIDENCE —
+	// ProbeSession, not ExistsOrUnknown (#1917 round 8): this result is EVIDENCE —
 	// the daemon's poll turns it into probeAlive, which clears a session's restore
-	// history and marks it Ready. DoesSessionExist reports a timed-out probe as
+	// history and marks it Ready. ExistsOrUnknown reports a timed-out probe as
 	// "exists", so taking it here would report a wedged server as a live agent.
 	exists, known := ts.ProbeSession()
 	if !known {

--- a/session/instance.go
+++ b/session/instance.go
@@ -420,12 +420,20 @@ func (i *Instance) PreviewTabFullHistory(idx int) (string, error) {
 	return ts.CapturePaneContentWithOptions("-", "-")
 }
 
-// TabAlive reports whether the tab at idx has a live tmux session.
+// TabAlive reports whether the tab at idx has a live tmux session, as a LOSSY
+// bool: true means "alive OR could-not-determine (wedged/timeout)", false means
+// "no binding, or definitively gone". It is deliberately kept lossy because its
+// only consumers (ui/tab_pane.go) act solely on !TabAlive — they swap to the
+// "Terminal session not available" fallback. A wedged server reads as alive here,
+// which keeps the read-only TUI rendering the pane instead of falsely declaring a
+// merely-unreachable terminal dead: the safe direction for a view (#1962). A
+// caller that needs existence as EVIDENCE must use TmuxSession.ProbeSession
+// directly and handle !known.
 func (i *Instance) TabAlive(idx int) bool {
 	i.mu.RLock()
 	ts := i.tabTmuxAtLocked(idx)
 	i.mu.RUnlock()
-	return ts != nil && ts.DoesSessionExist()
+	return ts != nil && ts.ExistsOrUnknown()
 }
 
 // TabCount returns the number of tabs the instance currently holds.

--- a/session/tab_lifecycle_test.go
+++ b/session/tab_lifecycle_test.go
@@ -85,7 +85,7 @@ func TestFreshStart_OnlyAgentTab(t *testing.T) {
 
 	shellTs := tmux.NewTmuxSessionFromSanitizedNameWithDeps(
 		agentName+shellTmuxSuffix, defaultShell(), pty, cmdExec)
-	assert.False(t, shellTs.DoesSessionExist(),
+	assert.False(t, shellTs.ExistsOrUnknown(),
 		"no __shell tmux session may be spawned on a fresh start (#1100)")
 
 	// The terminal tab is still available on demand.
@@ -230,7 +230,7 @@ func TestDropClosedTab_RemovesWithoutKilling(t *testing.T) {
 	tab, err := inst.AddShellTab()
 	require.NoError(t, err)
 	require.Equal(t, 2, inst.TabCount())
-	require.True(t, tab.tmux.DoesSessionExist())
+	require.True(t, tab.tmux.ExistsOrUnknown())
 
 	require.Error(t, inst.DropClosedTab(0), "the agent tab must be undroppable")
 	require.Equal(t, 2, inst.TabCount(), "a rejected drop must not mutate the list")
@@ -238,7 +238,7 @@ func TestDropClosedTab_RemovesWithoutKilling(t *testing.T) {
 
 	require.NoError(t, inst.DropClosedTab(1))
 	require.Equal(t, 1, inst.TabCount(), "drop must remove the tab from the list")
-	require.True(t, tab.tmux.DoesSessionExist(),
+	require.True(t, tab.tmux.ExistsOrUnknown(),
 		"DropClosedTab must NOT kill the tmux session (the daemon owns the kill)")
 }
 

--- a/session/tmux/bounded.go
+++ b/session/tmux/bounded.go
@@ -140,7 +140,7 @@ func normalizeWaitDelay(err error) error {
 
 // tmuxTimeoutContext returns the deadline every bounded tmux command runs under.
 //
-// Callers MUST check ctx.Err() before falling back to a DoesSessionExist probe
+// Callers MUST check ctx.Err() before falling back to an ExistsOrUnknown probe
 // on the error path: the probe spawns ANOTHER tmux command against the same
 // wedged server, so it would hang exactly like the command that just timed out
 // and defeat the bound we came here for. On a tripped deadline the session's

--- a/session/tmux/bounded_test.go
+++ b/session/tmux/bounded_test.go
@@ -15,7 +15,7 @@ import (
 
 // stallingTmuxOnPath puts a `tmux` earlier on PATH that never exits, standing in
 // for a wedged tmux server: EVERY tmux invocation — including the
-// DoesSessionExist probe the error paths would otherwise fall back to — hangs.
+// ExistsOrUnknown probe the error paths would otherwise fall back to — hangs.
 // The script sleeps in a CHILD process, so it also covers the case that makes a
 // naive deadline useless: killing only the direct tmux process leaves the child
 // holding the inherited capture pipe, and Output()/Run() block on pipe EOF until

--- a/session/tmux/cleanup.go
+++ b/session/tmux/cleanup.go
@@ -14,12 +14,28 @@ import (
 	"github.com/sachiniyer/agent-factory/log"
 )
 
-func (t *TmuxSession) DoesSessionExist() bool {
+// ExistsOrUnknown reports session existence as a deliberately LOSSY bool: it
+// returns true for "the session exists OR tmux could not be reached (a wedged /
+// timed-out has-session)", and false ONLY for "definitively absent" — tmux
+// answered and said no such session. A wedged has-session is laundered into true
+// here (via sessionExists), the conservative lie a bool is forced to tell.
+//
+// The name states the lie so it is visible at every call site. Contract:
+//
+//   - A caller MAY act on !ExistsOrUnknown() ("definitively gone"): classify a
+//     failed command as ErrSessionGone, or skip the idempotent teardown of an
+//     already-absent session. A wedged server reads as "exists", so these callers
+//     never falsely tear down or abandon a session that is merely slow — the safe
+//     direction, and the reason this form is kept.
+//   - A caller MUST NOT read a bare true as proof of life: "true" folds in "I
+//     could not tell". Any site that treats existence as EVIDENCE or as a POSITIVE
+//     gate must call ProbeSession() and handle !known explicitly (#1917/#1962).
+func (t *TmuxSession) ExistsOrUnknown() bool {
 	return sessionExists(t.cmdExec, t.sanitizedName)
 }
 
 // sessionExists reports whether a tmux session with the exact name `name`
-// currently exists. Shared by DoesSessionExist and the receiver-less
+// currently exists. Shared by ExistsOrUnknown and the receiver-less
 // CleanupSessions path so both probe identically.
 //
 // Bounded by tmuxCommandTimeout (#1917): has-session against a wedged server
@@ -56,7 +72,7 @@ func sessionExists(cmdExec cmd.Executor, name string) bool {
 // ProbeSession reports whether this session exists AND whether tmux actually
 // ANSWERED — the tri-state a bool cannot express (#1917 round 8).
 //
-// DoesSessionExist has to pick yes or no, so a timed-out probe becomes "yes": the
+// ExistsOrUnknown has to pick yes or no, so a timed-out probe becomes "yes": the
 // conservative lie, safe for the read-only callers that only ever act on "no". But
 // it launders UNKNOWN into AFFIRMATIVE at the bottom of the stack, and every caller
 // above is then downstream of a lie it cannot detect — which is how a wedged tmux

--- a/session/tmux/clientless.go
+++ b/session/tmux/clientless.go
@@ -29,7 +29,7 @@ import "fmt"
 // captureMu, so an unbounded stall would strand that mutex and deadlock every
 // LATER capture start/stop for the session — the deadline is what keeps the
 // lock hold finite. On a tripped deadline it returns ErrTmuxTimeout without
-// probing DoesSessionExist — see tmuxTimeoutContext.
+// probing ExistsOrUnknown — see tmuxTimeoutContext.
 func (t *TmuxSession) EnablePipePane(shellCommand string) error {
 	ctx, cancel := tmuxTimeoutContext()
 	defer cancel()
@@ -37,7 +37,7 @@ func (t *TmuxSession) EnablePipePane(shellCommand string) error {
 		if ctx.Err() != nil {
 			return fmt.Errorf("%w: pipe-pane after %s", ErrTmuxTimeout, tmuxCommandTimeout)
 		}
-		if !t.DoesSessionExist() {
+		if !t.ExistsOrUnknown() {
 			return fmt.Errorf("%w: pipe-pane", ErrSessionGone)
 		}
 		return fmt.Errorf("error enabling pipe-pane: %w", err)
@@ -55,6 +55,11 @@ func (t *TmuxSession) EnablePipePane(shellCommand string) error {
 // the server is wedged, so whether the pipe is actually closed is UNKNOWN, and
 // silently claiming success would let the broker believe it had torn down a pipe
 // that may still be writing.
+//
+// The !ExistsOrUnknown no-op success below is gated on the DEFINITIVELY-absent
+// branch only, and safely (#1962): the timeout is already handled above, so this
+// runs only when pipe-pane answered with a fast error, and a wedged→"exists"
+// keeps that a real error rather than a false no-op — never the other way.
 func (t *TmuxSession) DisablePipePane() error {
 	ctx, cancel := tmuxTimeoutContext()
 	defer cancel()
@@ -62,7 +67,7 @@ func (t *TmuxSession) DisablePipePane() error {
 		if ctx.Err() != nil {
 			return fmt.Errorf("%w: pipe-pane after %s", ErrTmuxTimeout, tmuxCommandTimeout)
 		}
-		if !t.DoesSessionExist() {
+		if !t.ExistsOrUnknown() {
 			return nil
 		}
 		return fmt.Errorf("error disabling pipe-pane: %w", err)
@@ -96,7 +101,7 @@ func (t *TmuxSession) SendRawKeys(b []byte) error {
 		if ctx.Err() != nil {
 			return fmt.Errorf("%w: send-keys after %s", ErrTmuxTimeout, tmuxCommandTimeout)
 		}
-		if !t.DoesSessionExist() {
+		if !t.ExistsOrUnknown() {
 			return fmt.Errorf("%w: send-keys", ErrSessionGone)
 		}
 		return fmt.Errorf("error sending raw keys: %w", err)
@@ -120,7 +125,7 @@ func (t *TmuxSession) ResizeWindow(cols, rows int) error {
 		if ctx.Err() != nil {
 			return fmt.Errorf("%w: resize-window after %s", ErrTmuxTimeout, tmuxCommandTimeout)
 		}
-		if !t.DoesSessionExist() {
+		if !t.ExistsOrUnknown() {
 			return fmt.Errorf("%w: resize-window", ErrSessionGone)
 		}
 		// resize-window fails on tmux servers older than 2.9; surface the error so

--- a/session/tmux/close.go
+++ b/session/tmux/close.go
@@ -235,7 +235,7 @@ func (t *TmuxSession) CloseAndWaitForPaneExit() (PaneState, error) {
 // (the agent program). Must be called before kill-session — afterwards there
 // is nothing left to query.
 func (t *TmuxSession) panePID() (int, error) {
-	// exactTarget forces an exact session match, mirroring DoesSessionExist.
+	// exactTarget forces an exact session match, mirroring ExistsOrUnknown.
 	// (The bare `=name` form returns an empty pane_pid for display-message —
 	// the trailing `:` in exactTarget is what makes the pid resolve. See #1006.)
 	//

--- a/session/tmux/io.go
+++ b/session/tmux/io.go
@@ -16,7 +16,7 @@ type statusMonitor struct {
 	// Store hashes to save memory.
 	prevOutputHash []byte
 	// dead is set once a capture-pane failure has been confirmed by
-	// DoesSessionExist() reporting the tmux session is gone. While true,
+	// ExistsOrUnknown() reporting the tmux session is gone. While true,
 	// HasUpdated short-circuits and emits no further logs so a stale
 	// instance can't flood agent-factory.log (#489). A successful Start or
 	// Restore replaces the monitor with a fresh one, which naturally clears
@@ -45,7 +45,7 @@ func (m *statusMonitor) hash(s string) []byte {
 func (t *TmuxSession) TapEnter() error {
 	cmd := exec.Command("tmux", "send-keys", "-t", exactTarget(t.sanitizedName), "Enter")
 	if err := t.cmdExec.Run(cmd); err != nil {
-		if !t.DoesSessionExist() {
+		if !t.ExistsOrUnknown() {
 			return fmt.Errorf("%w: send-keys Enter", ErrSessionGone)
 		}
 		return fmt.Errorf("error sending enter keystroke: %w", err)
@@ -60,7 +60,7 @@ func (t *TmuxSession) TapEnter() error {
 func (t *TmuxSession) TapDAndEnter() error {
 	cmd := exec.Command("tmux", "send-keys", "-t", exactTarget(t.sanitizedName), "D", "Enter")
 	if err := t.cmdExec.Run(cmd); err != nil {
-		if !t.DoesSessionExist() {
+		if !t.ExistsOrUnknown() {
 			return fmt.Errorf("%w: send-keys D Enter", ErrSessionGone)
 		}
 		return fmt.Errorf("error sending D+enter keystroke: %w", err)
@@ -106,7 +106,7 @@ func (t *TmuxSession) HasUpdated() (updated bool, hasPrompt bool, content string
 		// monitor as dead so the daemon's per-second poll doesn't spam
 		// the log (#489). Transient capture-pane failures while the
 		// session is still alive are rare and still surface every tick.
-		// CapturePaneContent has already probed DoesSessionExist on the
+		// CapturePaneContent has already probed ExistsOrUnknown on the
 		// error path, so use the wrapped sentinel rather than re-probing.
 		if errors.Is(err, ErrSessionGone) {
 			log.ErrorLog.Printf("tmux session %s is gone; status monitor going silent (capture-pane error: %v)", t.sanitizedName, err)
@@ -149,10 +149,13 @@ func (t *TmuxSession) HasUpdated() (updated bool, hasPrompt bool, content string
 	return changed, hasPrompt, content
 }
 
-// CapturePaneContent captures the content of the tmux pane. When the
-// capture fails and DoesSessionExist confirms the session is gone, the
+// CapturePaneContent captures the content of the tmux pane. When the capture
+// fails and !ExistsOrUnknown reports the session is definitively gone, the
 // returned error wraps ErrSessionGone so non-daemon callers can degrade
-// gracefully instead of logging at ERROR (#496).
+// gracefully instead of logging at ERROR (#496). Classifying on the lossy bool
+// is the SAFE direction here (#1962): a wedged→"exists" keeps the failure a
+// generic error, so a merely-slow server is never misread as ErrSessionGone —
+// the same asymmetry every send-keys/capture site in this package relies on.
 func (t *TmuxSession) CapturePaneContent() (string, error) {
 	return t.CapturePaneContentContext(context.Background())
 }
@@ -163,7 +166,7 @@ func (t *TmuxSession) CapturePaneContent() (string, error) {
 // to completion. The readiness poll (task.WaitForReady) uses it so an abandoned
 // create tears down its in-flight capture — no lingering tmux subprocess or
 // goroutine after the caller gives up. On cancellation it returns ctx.Err()
-// directly, skipping the DoesSessionExist probe (which would spawn another tmux
+// directly, skipping the ExistsOrUnknown probe (which would spawn another tmux
 // subprocess) since the failure cause is the cancel, not a dead session.
 func (t *TmuxSession) CapturePaneContentContext(ctx context.Context) (string, error) {
 	// Add -e flag to preserve escape sequences (ANSI color codes). `=` forces
@@ -176,7 +179,7 @@ func (t *TmuxSession) CapturePaneContentContext(ctx context.Context) (string, er
 		if ctx.Err() != nil {
 			return "", ctx.Err()
 		}
-		if !t.DoesSessionExist() {
+		if !t.ExistsOrUnknown() {
 			return "", fmt.Errorf("%w: capture-pane: %v", ErrSessionGone, err)
 		}
 		return "", fmt.Errorf("error capturing pane content: %v", err)
@@ -199,7 +202,7 @@ func (t *TmuxSession) CapturePaneContentContext(ctx context.Context) (string, er
 // Bounded by tmuxCommandTimeout (#1787): this runs on the WS subscribe path
 // BEFORE the 101 upgrade, so an unbounded stall here means the client never
 // receives a socket at all. On a tripped deadline it returns ErrTmuxTimeout
-// without probing DoesSessionExist — see tmuxTimeoutContext.
+// without probing ExistsOrUnknown — see tmuxTimeoutContext.
 func (t *TmuxSession) CaptureVisiblePaneGrid() (string, error) {
 	ctx, cancel := tmuxTimeoutContext()
 	defer cancel()
@@ -208,7 +211,7 @@ func (t *TmuxSession) CaptureVisiblePaneGrid() (string, error) {
 		if ctx.Err() != nil {
 			return "", fmt.Errorf("%w: capture-pane grid after %s", ErrTmuxTimeout, tmuxCommandTimeout)
 		}
-		if !t.DoesSessionExist() {
+		if !t.ExistsOrUnknown() {
 			return "", fmt.Errorf("%w: capture-pane: %v", ErrSessionGone, err)
 		}
 		return "", fmt.Errorf("error capturing pane grid: %v", err)
@@ -252,7 +255,7 @@ func (t *TmuxSession) CapturePaneContentWithOptions(start, end string) (string, 
 	cmd := exec.Command("tmux", "capture-pane", "-p", "-e", "-J", "-S", start, "-E", end, "-t", exactTarget(t.sanitizedName))
 	output, err := t.cmdExec.Output(cmd)
 	if err != nil {
-		if !t.DoesSessionExist() {
+		if !t.ExistsOrUnknown() {
 			return "", fmt.Errorf("%w: capture-pane: %v", ErrSessionGone, err)
 		}
 		return "", fmt.Errorf("failed to capture tmux pane content with options: %v", err)

--- a/session/tmux/io_test.go
+++ b/session/tmux/io_test.go
@@ -18,7 +18,7 @@ import (
 // pin the ErrSessionGone mapping the daemon poll / AutoYes callers depend on.
 
 // recordTapCommands captures every tmux invocation the given tap func issues,
-// with has-session (DoesSessionExist) reporting `alive`.
+// with has-session (ExistsOrUnknown) reporting `alive`.
 func recordTapCommands(t *testing.T, alive bool, tap func(s *TmuxSession) error) ([]string, error) {
 	t.Helper()
 	var cmds []string
@@ -26,7 +26,7 @@ func recordTapCommands(t *testing.T, alive bool, tap func(s *TmuxSession) error)
 		RunFunc: func(c *exec.Cmd) error {
 			joined := strings.Join(c.Args, " ")
 			cmds = append(cmds, joined)
-			// The tap's send-keys fails, then DoesSessionExist's has-session probe
+			// The tap's send-keys fails, then ExistsOrUnknown's has-session probe
 			// reports whether the session is gone.
 			if strings.Contains(joined, "has-session") {
 				if alive {

--- a/session/tmux/kill_wedge_test.go
+++ b/session/tmux/kill_wedge_test.go
@@ -99,7 +99,7 @@ func TestSessionProcessTreesDoesNotWedgeTheKill(t *testing.T) {
 	}
 }
 
-// TestDoesSessionExistOnWedgedServerReportsPresent pins the deliberate choice in
+// TestExistsOrUnknownOnWedgedServerReportsPresent pins the deliberate choice in
 // sessionExists: the bool cannot express "unknown", so a tripped deadline reports
 // TRUE. Every caller that acts destructively acts on FALSE (Close reaps the
 // session's process trees; io.go/clientless.go raise ErrSessionGone, which the
@@ -107,13 +107,13 @@ func TestSessionProcessTreesDoesNotWedgeTheKill(t *testing.T) {
 // server would tear down a live session. A false "exists" only costs a
 // best-effort skip. Returning quickly is the fix; returning TRUE is the safety
 // property that keeps the fix from trading a hang for data loss.
-func TestDoesSessionExistOnWedgedServerReportsPresent(t *testing.T) {
+func TestExistsOrUnknownOnWedgedServerReportsPresent(t *testing.T) {
 	stallingTmuxOnPath(t)
 	shortTmuxTimeout(t, 200*time.Millisecond)
 	ts := NewTmuxSessionWithDeps("wedge-1917-probe", "sh", MakePtyFactory(), cmd.MakeExecutor())
 
 	done := make(chan bool, 1)
-	go func() { done <- ts.DoesSessionExist() }()
+	go func() { done <- ts.ExistsOrUnknown() }()
 
 	select {
 	case exists := <-done:
@@ -122,7 +122,7 @@ func TestDoesSessionExistOnWedgedServerReportsPresent(t *testing.T) {
 				"callers reap process trees and raise ErrSessionGone on false")
 		}
 	case <-time.After(30 * time.Second):
-		t.Fatal("DoesSessionExist hung against a stalled tmux (#1917): it is the fallback probe " +
+		t.Fatal("ExistsOrUnknown hung against a stalled tmux (#1917): it is the fallback probe " +
 			"on nearly every tmux error path in this package, including Close's")
 	}
 }
@@ -152,7 +152,7 @@ func TestCloseOnWedgedServerSkipsTheExistenceProbe(t *testing.T) {
 		// third would mean the has-session probe ran on the timeout path.
 		if max := 3 * bound; elapsed >= max {
 			t.Fatalf("Close took %v (>= %v): kill-session's timeout path appears to have fallen "+
-				"back to a DoesSessionExist probe, which hangs on the same wedged server", elapsed, max)
+				"back to an ExistsOrUnknown probe, which hangs on the same wedged server", elapsed, max)
 		}
 	case <-time.After(30 * time.Second):
 		t.Fatal("Close hung against a stalled tmux (#1917)")

--- a/session/tmux/reap_test.go
+++ b/session/tmux/reap_test.go
@@ -120,7 +120,7 @@ func TestCloseReapsEscapedPaneProcesses(t *testing.T) {
 	session := NewTmuxSessionFromSanitizedName(name, "sh")
 	_, closeErr := session.Close()
 	require.NoError(t, closeErr)
-	require.False(t, session.DoesSessionExist(), "session must be gone after Close")
+	require.False(t, session.ExistsOrUnknown(), "session must be gone after Close")
 
 	// Close reaps asynchronously; the escapee ignores SIGHUP, so only the
 	// reaper's SIGTERM/SIGKILL can end it.

--- a/session/tmux/session.go
+++ b/session/tmux/session.go
@@ -99,7 +99,7 @@ func repoHash(repoPath string) string {
 // toTmuxName builds the tmux session name from a user-supplied title.
 //
 // Characters that tmux does not preserve verbatim in session names must be
-// replaced here so DoesSessionExist() and kill paths match the name tmux
+// replaced here so ExistsOrUnknown() and kill paths match the name tmux
 // actually created (#574). Verified against tmux 3.4:
 //   - '.' and ':' are silently rewritten to '_'; using them as-is causes
 //     Start() to poll for a name tmux never created and time out, orphaning

--- a/session/tmux/start.go
+++ b/session/tmux/start.go
@@ -12,8 +12,16 @@ import (
 // Start creates and starts a new tmux session, then attaches to it. Program is the command to run in
 // the session (ex. claude). workdir is the git worktree directory.
 func (t *TmuxSession) Start(workDir string) error {
-	// Check if the session already exists
-	if t.DoesSessionExist() {
+	// Check if the session already exists. This is a POSITIVE existence gate, so
+	// it must not read the lossy bool: a wedged/timed-out has-session is NOT proof
+	// the name is taken, and ExistsOrUnknown would launder it into "already
+	// exists" — the exact misread #1962 fixes. Surface the timeout instead so the
+	// caller learns the server never answered rather than that the name collided.
+	exists, known := t.ProbeSession()
+	if !known {
+		return fmt.Errorf("%w: has-session probe for session %q did not answer", ErrTmuxTimeout, t.sanitizedName)
+	}
+	if exists {
 		return fmt.Errorf("tmux session already exists: %s", t.sanitizedName)
 	}
 
@@ -27,8 +35,11 @@ func (t *TmuxSession) Start(workDir string) error {
 
 	ptmx, err := t.ptyFactory.Start(cmd)
 	if err != nil {
-		// Cleanup any partially created session if any exists.
-		if t.DoesSessionExist() {
+		// Cleanup any partially created session if any exists. ExistsOrUnknown is
+		// safe here: the only action gated on true is a bounded best-effort
+		// kill-session, so a wedged→"exists" merely triggers a harmless cleanup
+		// attempt against a possibly-live session, never a false liveness claim.
+		if t.ExistsOrUnknown() {
 			leaked := SessionProcessTrees(t.cmdExec, t.sanitizedName)
 			cleanupCmd := exec.Command("tmux", "kill-session", "-t", exactTarget(t.sanitizedName))
 			if cleanupErr := t.cmdExec.Run(cleanupCmd); cleanupErr != nil {
@@ -40,10 +51,18 @@ func (t *TmuxSession) Start(workDir string) error {
 		return fmt.Errorf("error starting tmux session: %w", err)
 	}
 
-	// Poll for session existence with exponential backoff
+	// Poll for session existence with exponential backoff. Break only on a probe
+	// that ANSWERED "exists" (known && exists): reading the lossy bool here let a
+	// mid-poll wedge exit the loop as if the session had come up, so Start reported
+	// success for a session tmux never confirmed (#1962). A !known probe means keep
+	// waiting until the 2s deadline, then take the timeout path below — which
+	// threads pane-state / ErrTmuxTimeout correctly.
 	timeout := time.After(2 * time.Second)
 	sleepDuration := 5 * time.Millisecond
-	for !t.DoesSessionExist() {
+	for {
+		if exists, known := t.ProbeSession(); known && exists {
+			break
+		}
 		select {
 		case <-timeout:
 			ptmx.Close()
@@ -98,7 +117,13 @@ func (t *TmuxSession) Start(workDir string) error {
 		// above saw the session, so if it is gone again by attach time the
 		// pane program exited within milliseconds of launch. Say so instead
 		// of the misleading "session does not exist" (#1116, #1131).
-		vanished := !t.DoesSessionExist()
+		//
+		// !ExistsOrUnknown is the definitively-absent branch: a wedged→"exists"
+		// only means we fall through to the generic "error restoring" message
+		// instead of the more specific "vanished" one — never a false "vanished"
+		// claim against a merely-slow server. This only picks the error wording;
+		// no destructive action is gated on it (#1962).
+		vanished := !t.ExistsOrUnknown()
 		// Same rule as the timeout path above: a failed Start DOES lead to a worktree
 		// delete in Launch, so an unknown pane state must reach it (#1917 round 7).
 		state, cleanupErr := t.Close()
@@ -269,7 +294,13 @@ func claudeTrustPromptPresent(content string) bool {
 // without such a flag, or programs that already include one, are left
 // untouched.
 func (t *TmuxSession) Restore(workDir string) error {
-	if !t.DoesSessionExist() {
+	// !ExistsOrUnknown is the definitively-absent branch (#1962): only a session
+	// tmux CONFIRMED gone triggers the re-spawn. A wedged→"exists" falls through
+	// to the pure rebind below, which is the safe direction — re-spawning against
+	// a server that is merely wedged around a still-live session would create a
+	// duplicate. The #386 respawn design has always fired only on definitive
+	// absence, and this preserves it.
+	if !t.ExistsOrUnknown() {
 		if workDir == "" {
 			return fmt.Errorf("tmux session %q does not exist", t.sanitizedName)
 		}

--- a/session/tmux/start_wedge_test.go
+++ b/session/tmux/start_wedge_test.go
@@ -1,0 +1,126 @@
+package tmux
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/cmd"
+)
+
+// #1962 regressions for the two known DoesSessionExist misreads in Start. Both
+// reuse the wedged-server harness from bounded_test.go (stallingTmuxOnPath /
+// shortTmuxTimeout): a fake `tmux` on PATH that sleeps in a child, so a real
+// deadline can SIGKILL it — the only faithful reproduction of a wedged server
+// (a blocking mock is unreachable by any context deadline; see kill_wedge_test.go).
+
+// TestStartOnWedgedServerReportsTimeoutNotAlreadyExists covers start.go's up-front
+// existence check. It is a POSITIVE existence gate, so a wedged/timed-out
+// has-session must NOT be laundered into "tmux session already exists": that
+// misreads UNKNOWN as a confirmed name collision (#1962). With stallingTmuxOnPath
+// every tmux command wedges, so the line-16 probe is the one under test — Start
+// must surface the timeout and return fast.
+func TestStartOnWedgedServerReportsTimeoutNotAlreadyExists(t *testing.T) {
+	stallingTmuxOnPath(t)
+	shortTmuxTimeout(t, 200*time.Millisecond)
+	ts := NewTmuxSessionWithDeps("wedge-1962-start", "sh", NewMockPtyFactory(t), cmd.MakeExecutor())
+
+	done := make(chan error, 1)
+	go func() { done <- ts.Start(t.TempDir()) }()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Start against a wedged tmux server must fail, got nil")
+		}
+		// The wedged server never answered has-session, so the name is NOT known
+		// to be taken. Claiming "already exists" is the exact misread #1962 fixes.
+		if strings.Contains(err.Error(), "already exists") {
+			t.Fatalf("wedged has-session laundered into a false name collision (#1962): %v", err)
+		}
+		if !errors.Is(err, ErrTmuxTimeout) {
+			t.Fatalf("want ErrTmuxTimeout from Start's existence check against a wedged server, got %v", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("Start hung against a stalled tmux (#1962): the line-16 existence check must be bounded")
+	}
+}
+
+// TestStartReadinessPollDoesNotExitOnWedgedServer covers start.go's readiness
+// poll. Reading the lossy bool let a mid-poll wedge exit the loop as if the
+// session had come up, so Start reported SUCCESS for a session tmux never
+// confirmed (#1962). The poll must instead keep waiting on a !known probe until
+// its 2s deadline, then take the existing timeout path (ErrTmuxTimeout).
+//
+// stallingTmuxOnPath alone can't reproduce this — it wedges the line-16 check
+// too, so Start never reaches the poll. wedgeHasSessionAfterFirstOnPath answers
+// the first has-session ("not found", so line 16 passes and the create proceeds)
+// and wedges every command after it, standing in for a server that goes wedged
+// DURING the poll.
+func TestStartReadinessPollDoesNotExitOnWedgedServer(t *testing.T) {
+	wedgeHasSessionAfterFirstOnPath(t)
+	shortTmuxTimeout(t, 200*time.Millisecond)
+	// Pin the `-e` support probe so Start's sessionEnvFlags never runs an
+	// unbounded `tmux -V` against the wedging fake (envmarker.go:78) — that probe
+	// is not what this test exercises, and it has no deadline of its own.
+	forceNewSessionEnvMarkers(t, false)
+	ts := NewTmuxSessionWithDeps("wedge-1962-poll", "sh", NewMockPtyFactory(t), cmd.MakeExecutor())
+
+	done := make(chan error, 1)
+	go func() { done <- ts.Start(t.TempDir()) }()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Start reported success against a server that wedged during the readiness " +
+				"poll — the poll exited on the lie that the session came up (#1962)")
+		}
+		// The poll could not confirm the session, so the failure must be the
+		// timeout path (which threads pane-state / ErrTmuxTimeout), never a false
+		// success and never a confirmed-gone classification.
+		if !errors.Is(err, ErrTmuxTimeout) {
+			t.Fatalf("want ErrTmuxTimeout when the readiness poll cannot confirm the session, got %v", err)
+		}
+		if errors.Is(err, ErrSessionGone) {
+			t.Fatalf("a wedged server proves nothing about the session; must not report ErrSessionGone: %v", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("Start hung against a stalled tmux (#1962)")
+	}
+}
+
+// wedgeHasSessionAfterFirstOnPath installs a fake `tmux` on PATH that answers the
+// FIRST has-session with "no such session" (exit 1) — so Start's existence check
+// passes and the create proceeds — then WEDGES every subsequent tmux command
+// (has-session, list-panes, kill-session, display-message) by sleeping in a child.
+// set-option answers fast so the non-wedged control path can still complete. It
+// reproduces a server that goes wedged DURING the readiness poll, which
+// stallingTmuxOnPath cannot (that fake wedges the line-16 check too).
+func wedgeHasSessionAfterFirstOnPath(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	state := filepath.Join(dir, "has_session_calls")
+	script := "#!/bin/sh\n" +
+		"case \"$1\" in\n" +
+		"has-session)\n" +
+		"  n=$(cat " + state + " 2>/dev/null || echo 0)\n" +
+		"  n=$((n + 1))\n" +
+		"  echo \"$n\" > " + state + "\n" +
+		"  if [ \"$n\" -eq 1 ]; then exit 1; fi\n" +
+		"  sleep 300 & wait\n" +
+		"  ;;\n" +
+		"set-option|new-session)\n" +
+		"  exit 0\n" +
+		"  ;;\n" +
+		"*)\n" +
+		"  sleep 300 & wait\n" +
+		"  ;;\n" +
+		"esac\n"
+	if err := os.WriteFile(filepath.Join(dir, "tmux"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}

--- a/session/tmux/tmux_test.go
+++ b/session/tmux/tmux_test.go
@@ -105,7 +105,7 @@ func TestSanitizeName(t *testing.T) {
 // TestSanitizeNameTmuxRestrictedChars guards toTmuxName against the #574
 // failure mode: tmux silently rewrites or escapes certain characters in
 // session names, so a title containing them must be transformed before we
-// hand it to tmux. Otherwise DoesSessionExist() polls for a name tmux never
+// hand it to tmux. Otherwise ExistsOrUnknown() polls for a name tmux never
 // created and Start() times out, orphaning the session.
 func TestSanitizeNameTmuxRestrictedChars(t *testing.T) {
 	cases := []struct {
@@ -443,7 +443,7 @@ func TestHasUpdatedRespawnResetsDead(t *testing.T) {
 }
 
 // TestHasUpdatedTransientErrorKeepsLogging covers the other branch of #489:
-// if capture-pane fails but DoesSessionExist still reports the session is
+// if capture-pane fails but ExistsOrUnknown still reports the session is
 // alive (a rare transient error), the monitor must NOT latch dead and the
 // error must still be visible in the log every tick — the spam fix should
 // not silently swallow real problems.

--- a/ui/terminal_test.go
+++ b/ui/terminal_test.go
@@ -421,7 +421,7 @@ func TestTabPaneShellScrollModeSessionGoneExternally(t *testing.T) {
 			switch {
 			case strings.Contains(s, "has-session"):
 				// A session killed externally fails has-session, which is what
-				// DoesSessionExist()/TabAlive keys off of (#977).
+				// ExistsOrUnknown()/TabAlive keys off of (#977).
 				if gone.Load() {
 					return fmt.Errorf("session gone")
 				}


### PR DESCRIPTION
## PR 1 of #1962 — the existence-probe migration

A `bool` cannot say "I don't know". `sessionExists` (session/tmux/cleanup.go) converts a *timed-out* `tmux has-session` — a wedged server — into **TRUE**, and `DoesSessionExist() bool` handed that lie up the stack. That is the correct/conservative lie for callers that only ever act on "definitively absent" (a false "gone" would SIGKILL a live agent's process tree). It is a *dangerous* lie for any caller that reads existence as **evidence** or as a **positive gate**, because "wedged" gets laundered into "present".

The tri-state already exists and is documented: `TmuxSession.ProbeSession() (exists, known bool)`. #1923 fixed the liveness-evidence path (`IsAlive → ProbeSession`). **This PR finishes the migration for the remaining `DoesSessionExist()` sites**, and makes the lie visible at every call site by renaming the lossy bool.

Scope is exactly the existence-probe migration + rename. The `HasUpdated`/`Snapshot` error path is explicitly **out of scope** (PR 2 follow-up) — untouched here.

### The design (signed off in #1962)

1. **Rename** `DoesSessionExist() → ExistsOrUnknown()`, with a doc comment stating the contract plainly: returns `true` for "exists **or** could-not-determine (wedged/timeout)", `false` **only** for "definitively absent". A caller may act on `!ExistsOrUnknown()`; a caller must never read a bare `true` as proof of life. The private `sessionExists` collapse (used by `CleanupSessions`) is kept.
2. **Every evidence / positive-gate site migrates to `ProbeSession()`** and handles `!known` explicitly.
3. **Every definitively-absent site keeps the renamed bool** with a verified, one-line reason — the `ExistsOrUnknown` name itself now surfaces the lie at the call site.

### The two known misreads (fixed, with fail-first regression tests)

- **`start.go:16`** — Start's up-front existence check. A wedged server used to yield the misleading **"tmux session already exists"**. Now: `!known` → an `ErrTmuxTimeout` "probe did not answer" error; `known && exists` → "already exists"; `known && !exists` → proceed.
- **`start.go:46`** — the readiness poll (`for !t.DoesSessionExist()`) used to **exit on the lie** (a mid-poll wedge read as "the session came up", so Start reported success for a session tmux never confirmed). Now the loop breaks only on `known && exists`; a `!known` probe keeps waiting until the existing 2s deadline, then takes the existing timeout path (which threads pane-state / `ErrTmuxTimeout` correctly — preserved).

### Site-by-site audit

Every `DoesSessionExist()` call site (verified complete: `grep -rn DoesSessionExist` now returns nothing).

| # | Site | Reads existence as… | Disposition |
|---|------|--------------------|-------------|
| 1 | `session/tmux/start.go:16` (Start, already-exists check) | **positive gate** | **Migrated → ProbeSession.** `!known` → `ErrTmuxTimeout`, not a false "already exists". *(known misread)* |
| 2 | `session/tmux/start.go:46` (Start, readiness poll) | **evidence** | **Migrated → ProbeSession.** Break only on `known && exists`; `!known` waits out the 2s deadline → timeout path. *(known misread)* |
| 3 | `session/backend_local.go:584` (`setupTabs` `hasLiveShell`) | **evidence** | **Migrated → ProbeSession.** Only `known && exists` counts as live, so a wedged shell no longer suppresses the #991 fresh-shell fallback. Tradeoff (documented): a merely-wedged server may cost a redundant fresh shell — a spare tab beats a dead one. |
| 4 | `daemon/manager_create.go:507` (title-collision) | **positive gate** | **Migrated → ProbeSession.** `!known` is not proof of a collision; only `known && exists` blocks the create. A real orphan is still caught non-destructively downstream (`tmux new-session` fails on a duplicate name; Start's own check surfaces it). |
| 5 | `session/instance.go:428` (`TabAlive`) | consumers act only on `!TabAlive` | **Kept `ExistsOrUnknown` + documented bool contract.** Audited callers: only `ui/tab_pane.go:490,676`, both `!TabAlive` → "Terminal session not available" fallback. A wedged server reads as alive, keeping the read-only TUI rendering the pane rather than falsely declaring a merely-unreachable terminal dead — the safe direction for a view. |
| 6 | `session/tmux/start.go:31` (cleanup partial session) | true-branch → bounded best-effort kill | **Kept.** The only action gated on `true` is a bounded best-effort `kill-session`; a wedged→"exists" triggers a harmless cleanup attempt, never a false liveness claim or destructive teardown. |
| 7 | `session/tmux/start.go:101` (vanished-before-attach) | definitively-absent (error wording only) | **Kept.** `!ExistsOrUnknown` only chooses between the "vanished" and generic "error restoring" messages; no destructive action, and a wedged→"exists" never yields a false "vanished". |
| 8 | `session/tmux/start.go:272` (`Restore` respawn-if-missing) | definitively-absent | **Kept.** Only a session tmux confirmed gone triggers a re-spawn; a wedged→"exists" falls through to a pure rebind — the #386 design has always respawned only on definitive absence, and re-spawning against a merely-wedged live session would create a duplicate. |
| 9–13 | `session/tmux/io.go` ×5 (`TapEnter`, `TapDAndEnter`, `CapturePaneContentContext`, `CaptureVisiblePaneGrid`, `CapturePaneContentWithOptions`) | definitively-absent → `ErrSessionGone` classification | **Kept.** Each classifies a *failed* command: `!ExistsOrUnknown` → `ErrSessionGone`, else generic error. A wedged→"exists" keeps a generic error, so a merely-slow server is never misread as gone — the safe direction. |
| 14–17 | `session/tmux/clientless.go` ×4 (`EnablePipePane`, `DisablePipePane`, `SendRawKeys`, `ResizeWindow`) | definitively-absent → `ErrSessionGone` (`DisablePipePane` → nil no-op) | **Kept.** Same classification pattern; the timeout is already handled above each site, so `!ExistsOrUnknown` runs only on a fast error. `DisablePipePane` returns nil only on definitively-absent (its documented no-op success). |
| — | `session/tmux/cleanup.go` `sessionExists` in `CleanupSessions` | idempotent-teardown TOCTOU | **Kept (private helper, unchanged).** A session that vanished between `tmux ls` and the kill is the *goal* of cleanup; only a survivor is a real failure, so a wedged→"exists" correctly reports the (possible) survivor. |

Migrated to `ProbeSession`: **4** (all evidence/positive-gate). Kept `ExistsOrUnknown` (definitively-absent, verified safe): **12** + the private `sessionExists`.

Not touched (already correct as of #1923): `LocalBackend.IsAlive` — comment reference updated only.

### Fail-first proof (mandatory)

New tests: `session/tmux/start_wedge_test.go`, reusing the wedged-server harness (`stallingTmuxOnPath` / `shortTmuxTimeout` from `bounded_test.go` — a fake `tmux` on PATH that sleeps in a child so a real deadline can SIGKILL it). The readiness-poll test adds `wedgeHasSessionAfterFirstOnPath` because `stallingTmuxOnPath` alone wedges the line-16 check too, so Start would never reach the poll.

**Against the broken code** (fix neutralized in place — line 16 reverted to `if t.ExistsOrUnknown()`, the poll to `for !t.ExistsOrUnknown()`), both tests go RED with the exact misread:

```
=== RUN   TestStartOnWedgedServerReportsTimeoutNotAlreadyExists
    start_wedge_test.go:42: wedged has-session laundered into a false name collision (#1962): tmux session already exists: af_wedge-1962-start
--- FAIL: TestStartOnWedgedServerReportsTimeoutNotAlreadyExists (0.20s)
=== RUN   TestStartReadinessPollDoesNotExitOnWedgedServer
    start_wedge_test.go:78: Start reported success against a server that wedged during the readiness poll — the poll exited on the lie that the session came up (#1962)
--- FAIL: TestStartReadinessPollDoesNotExitOnWedgedServer (0.41s)
FAIL
```

**With the fix**, both pass:

```
--- PASS: TestStartOnWedgedServerReportsTimeoutNotAlreadyExists (0.20s)
--- PASS: TestStartReadinessPollDoesNotExitOnWedgedServer (2.61s)
```

### Gates

- `go build ./...` — clean
- `gofmt -l .` — empty
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — empty (the rename left no dead code; `ExistsOrUnknown` is still used by the 12 kept sites)
- `scripts/lint-file-length.sh` — passed
- `go test $(go list ./... | grep -v '/daemon')` — pass (31 packages)
- `daemon/` via `make test-container GOTESTARGS="./daemon/..."` — `ok ... daemon 155.722s` (exit 0)

Closes nothing (this is structural debt with a known blast radius; #1962 stays open for PR 2). Link: #1962.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
