### PR TITLE
fix(app): warn before killing committed-but-unmerged work (#2022)

### DIFF
--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os/exec"
 	"runtime"
-	"strings"
 
 	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/log"
@@ -183,17 +182,60 @@ func (m *home) handleKill() (tea.Model, tea.Cmd) {
 		return nil
 	}
 
-	// Check for uncommitted changes in the worktree (skip for backends without a
-	// local worktree, e.g. remote hook sessions).
-	warning := ""
+	// Assess what killing this session would destroy. Two independent losses,
+	// each with its own copy: a dirty worktree (uncommitted changes, #815) and
+	// local-only commits (committed-but-unmerged-and-unpushed work, #2022). The
+	// second is unrecoverable — kill force-deletes the branch with `git branch
+	// -D` — so it escalates the confirmation to the critical-content guarantee
+	// (#1973) AND a distinct confirm key, exactly as the reserved-root kill
+	// (#1238) does. A session can be both dirty and carry unmerged commits, so
+	// the warnings accumulate rather than replace one another. Both checks skip
+	// for backends without a local worktree (e.g. remote hook sessions).
+	var warnings []string
+	severeLine := ""
 	if selected.Capabilities().Workspace == session.WorkspaceLocalWorktree {
 		if wt := selected.GetWorktreePath(); wt != "" {
-			warning = killConfirmationWarning(wt)
+			if w := killConfirmationWarning(wt); w != "" {
+				warnings = append(warnings, w)
+			}
+		}
+		// GetGitWorktree is gated on the session being started, which is the case
+		// for the #2022 target: a live session whose agent has committed work.
+		if gw, err := selected.GetGitWorktree(); err == nil && gw != nil {
+			prState := ""
+			if pr := selected.GetPRInfo(); pr != nil {
+				prState = pr.State
+			}
+			if line, severe := unmergedCommitWarning(gw.GetWorktreePath(), gw.GetBaseCommitSHA(), prState); line != "" {
+				if severe {
+					severeLine = line
+				} else {
+					// Fail-closed (unverifiable): warn, but do not force the extra
+					// keystroke — we have not established that work is being lost.
+					warnings = append(warnings, line)
+				}
+			}
 		}
 	}
 
 	reserved := session.IsReservedTitle(selectedTitle)
-	message := killConfirmMessage(selectedTitle, warning, reserved)
+
+	if severeLine != "" {
+		// The severe consequence and any dirty-worktree warning are the critical
+		// content the user is consenting to; they must render in full or the
+		// overlay refuses the confirm (#1973). Only the recovery hint — genuine
+		// elaboration — goes in the clippable detail.
+		critical := killConfirmMessage(selectedTitle, joinWarnings(append([]string{severeLine}, warnings...)), reserved)
+		archiveKey := keys.GlobalKeyBindings[keys.KeyArchive].Help().Key
+		detail := fmt.Sprintf("Archive (%s) keeps the branch to restore later — kill removes it for good.", archiveKey)
+		cmd := m.confirmActionWithDetail(critical, detail, killAction)
+		if m.confirmationOverlay != nil {
+			m.confirmationOverlay.SetConfirmKey(unmergedKillConfirmKey)
+		}
+		return m, cmd
+	}
+
+	message := killConfirmMessage(selectedTitle, joinWarnings(warnings), reserved)
 	cmd := m.confirmAction(message, killAction)
 	if reserved && m.confirmationOverlay != nil {
 		// Break the muscle-memory D+y reflex on the daemon-managed singleton
@@ -203,38 +245,6 @@ func (m *home) handleKill() (tea.Model, tea.Cmd) {
 		m.confirmationOverlay.SetConfirmKey(rootKillConfirmKey)
 	}
 	return m, cmd
-}
-
-// rootKillConfirmKey is the confirm key the kill dialog demands for the reserved
-// root agent (#1238). Deliberately NOT the ordinary 'y' so an inattentive D+y —
-// the exact gesture that silently decapitated root's event pipeline on
-// 2026-07-05 — cannot dispatch the kill; the key is surfaced in the rendered
-// prompt ("Press k to confirm").
-const rootKillConfirmKey = "k"
-
-// killConfirmMessage builds the kill-confirmation copy for a session. The
-// reserved root agent (#1238) gets distinct, consequence-bearing copy instead of
-// the generic "[!] Kill session 'root'?" that killing any throwaway worktree
-// shows: killing root stops every scheduled/watch-task delivery to it (the
-// inbound event pipeline) until it self-heals or the daemon is restarted. This
-// mirrors the reserved-title guard the create path already applies
-// (app/handle_input.go). #1237 made root self-heal ~2 min after a kill, so the
-// copy names that recovery rather than the pre-#1237 "until the daemon restarts".
-func killConfirmMessage(title, warning string, reserved bool) string {
-	var message string
-	if reserved {
-		message = fmt.Sprintf(
-			"[!] '%s' is the daemon-managed root agent, not a scratch session.\n"+
-				"Killing it stops scheduled and watch-task delivery to '%s' until it\n"+
-				"self-heals (~2 min) or you restart the daemon.\n\n"+
-				"Kill the root agent anyway?", title, title)
-	} else {
-		message = fmt.Sprintf("[!] Kill session '%s'?", title)
-	}
-	if warning != "" {
-		message += "\n\n" + warning
-	}
-	return message
 }
 
 // killInstanceCmd returns a tea.Cmd that performs the actual session teardown
@@ -550,25 +560,6 @@ func (m *home) handleInstanceRestored(msg instanceRestoredMsg) (tea.Model, tea.C
 		break
 	}
 	return m, m.selectionChanged()
-}
-
-// killConfirmationWarning returns the data-loss warning line for the kill
-// confirmation dialog, or "" if the worktree at wt is verifiably clean. Kill
-// tears the worktree down with `git worktree remove -f`, which bypasses git's
-// own refusal to delete a dirty worktree, so this check is the only warning
-// the user gets. If `git status` itself fails we cannot prove the worktree is
-// clean — fail closed and warn that changes may be lost rather than silently
-// skipping the warning (#815).
-func killConfirmationWarning(wt string) string {
-	out, err := exec.Command("git", "-C", wt, "status", "--porcelain").Output()
-	if err != nil {
-		log.WarningLog.Printf("could not verify worktree status for %s before kill: %v", wt, err)
-		return fmt.Sprintf("WARNING: Could not verify worktree status (%v); it may contain uncommitted changes that will be lost!", err)
-	}
-	if len(strings.TrimSpace(string(out))) > 0 {
-		return "WARNING: This worktree has uncommitted changes that will be lost!"
-	}
-	return ""
 }
 
 // handleEnter is the Enter verb (#1089 PR 2, RFC §2.3): enter INTERACTIVE

--- a/app/kill_confirm.go
+++ b/app/kill_confirm.go
@@ -1,0 +1,216 @@
+package app
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+// This file holds the kill-confirmation copy and the data-loss detection behind
+// it. handleKill (handle_actions.go) assembles these into the confirmation the
+// user consents to. The governing rule (#2022): show the bare, safe-looking
+// prompt ONLY with positive evidence there is no unmerged work to lose; unknown
+// or unverifiable warns. Forgetting must be safe.
+
+// rootKillConfirmKey is the confirm key the kill dialog demands for the reserved
+// root agent (#1238). Deliberately NOT the ordinary 'y' so an inattentive D+y —
+// the exact gesture that silently decapitated root's event pipeline on
+// 2026-07-05 — cannot dispatch the kill; the key is surfaced in the rendered
+// prompt ("Press k to confirm").
+const rootKillConfirmKey = "k"
+
+// unmergedKillConfirmKey is the confirm key the kill dialog demands when the
+// session carries committed-but-unmerged-and-unpushed work (#2022). Like the
+// reserved-root guard (#1238) it is deliberately NOT the ordinary 'y': killing
+// force-deletes the branch with `git branch -D`, orphaning those commits for
+// good, and the muscle-memory D+y must not dispatch that permanent loss. The
+// user has to read the warning and press the named key surfaced in the prompt
+// ("Press k to confirm"). It shares the root key's value on purpose — both mean
+// "this kill is irreversible; press the named key".
+const unmergedKillConfirmKey = "k"
+
+// killConfirmMessage builds the kill-confirmation copy for a session. The
+// reserved root agent (#1238) gets distinct, consequence-bearing copy instead of
+// the generic "[!] Kill session 'root'?" that killing any throwaway worktree
+// shows: killing root stops every scheduled/watch-task delivery to it (the
+// inbound event pipeline) until it self-heals or the daemon is restarted. This
+// mirrors the reserved-title guard the create path already applies
+// (app/handle_input.go). #1237 made root self-heal ~2 min after a kill, so the
+// copy names that recovery rather than the pre-#1237 "until the daemon restarts".
+func killConfirmMessage(title, warning string, reserved bool) string {
+	var message string
+	if reserved {
+		message = fmt.Sprintf(
+			"[!] '%s' is the daemon-managed root agent, not a scratch session.\n"+
+				"Killing it stops scheduled and watch-task delivery to '%s' until it\n"+
+				"self-heals (~2 min) or you restart the daemon.\n\n"+
+				"Kill the root agent anyway?", title, title)
+	} else {
+		message = fmt.Sprintf("[!] Kill session '%s'?", title)
+	}
+	if warning != "" {
+		message += "\n\n" + warning
+	}
+	return message
+}
+
+// killConfirmationWarning returns the data-loss warning line for the kill
+// confirmation dialog, or "" if the worktree at wt is verifiably clean. Kill
+// tears the worktree down with `git worktree remove -f`, which bypasses git's
+// own refusal to delete a dirty worktree, so this check is the only warning
+// the user gets. If `git status` itself fails we cannot prove the worktree is
+// clean — fail closed and warn that changes may be lost rather than silently
+// skipping the warning (#815).
+func killConfirmationWarning(wt string) string {
+	out, err := exec.Command("git", "-C", wt, "status", "--porcelain").Output()
+	if err != nil {
+		log.WarningLog.Printf("could not verify worktree status for %s before kill: %v", wt, err)
+		return fmt.Sprintf("WARNING: Could not verify worktree status (%v); it may contain uncommitted changes that will be lost!", err)
+	}
+	if len(strings.TrimSpace(string(out))) > 0 {
+		return "WARNING: This worktree has uncommitted changes that will be lost!"
+	}
+	return ""
+}
+
+// unmergedCommitWarning reports whether killing a session would permanently
+// destroy committed work, and how loud the warning must be. Kill runs
+// `git branch -D` (session/git/worktree_ops.go), which force-deletes the local
+// branch regardless of merge state — so any commit on the branch that is not
+// merged into its base AND not pushed to a remote is orphaned, recoverable only
+// from the reflog until gc. That is the #2022 data-loss case; the bare
+// "[!] Kill session 'x'?" prompt hid it entirely.
+//
+// It returns:
+//   - (severe line, true) when the branch carries commits that exist ONLY
+//     locally — unmerged and unpushed. This is unrecoverable, so the caller
+//     escalates the confirmation to the distinct confirm key.
+//   - (fail-closed line, false) when we cannot prove the branch is free of such
+//     commits (base undeterminable, or a git command failed). Unknown is not
+//     clean: we warn, mirroring the #815 fail-closed discipline for a dirty
+//     worktree — but we do NOT escalate the key, because we have not established
+//     that work is actually being lost.
+//   - ("", false) when we have POSITIVE evidence there is nothing to lose: no
+//     commits beyond base, or every such commit is already pushed to a remote or
+//     carried by a merged PR (branch -D deletes only the LOCAL branch, so
+//     pushed/merged commits survive the kill).
+//
+// The check is deliberately offline (no `git fetch`): a kill confirmation must
+// stay as fast as the existing status check and is no place to touch the
+// network. The cost is that a commit pushed since the last fetch, whose remote-
+// tracking ref is stale, reads as local-only and over-warns. Over-warning is the
+// conservative side — the loud path still kills on one keystroke — so we accept
+// it rather than risk staying silent on genuine loss.
+func unmergedCommitWarning(worktreePath, recordedBaseSHA, prState string) (string, bool) {
+	if strings.TrimSpace(worktreePath) == "" {
+		return unmergedFailClosedLine(fmt.Errorf("no worktree path")), false
+	}
+	base, baseLabel, ok := resolveKillBase(worktreePath, recordedBaseSHA)
+	if !ok {
+		return unmergedFailClosedLine(fmt.Errorf("base branch/commit could not be determined")), false
+	}
+	// Commits reachable from the branch tip (HEAD is the branch, checked out in
+	// the worktree) but not from base: the session's own commits.
+	uniqueOut, err := exec.Command("git", "-C", worktreePath, "log", "--oneline", base+"..HEAD").Output()
+	if err != nil {
+		return unmergedFailClosedLine(err), false
+	}
+	if countGitLines(uniqueOut) == 0 {
+		return "", false // nothing beyond base — kill loses no committed work
+	}
+	// A merged PR means the work landed in the base's history (even a squash,
+	// whose original commits branch -D would orphan, preserves the diff), so it
+	// survives the kill.
+	if strings.EqualFold(strings.TrimSpace(prState), "MERGED") {
+		return "", false
+	}
+	// Of the session's commits, those NOT reachable from any remote-tracking ref
+	// are the ones that exist only here. branch -D orphans exactly these.
+	localOut, err := exec.Command("git", "-C", worktreePath, "log", "--oneline", base+"..HEAD", "--not", "--remotes").Output()
+	if err != nil {
+		return unmergedFailClosedLine(err), false
+	}
+	localOnly := countGitLines(localOut)
+	if localOnly == 0 {
+		return "", false // every commit is pushed somewhere — recoverable
+	}
+	return unmergedSevereLine(localOnly, baseLabel), true
+}
+
+// resolveKillBase resolves the commit the branch is measured against for the
+// unmerged-work check, offline. It mirrors the base resolution the worktree code
+// already uses (session/git/worktree_ops.go): the recorded base commit first,
+// then origin's default branch. It deliberately does NOT fall back to HEAD —
+// HEAD is the branch tip itself, which would make every branch look zero commits
+// ahead and fabricate a "nothing to lose" negative. When neither resolves, ok is
+// false and the caller fails closed. baseLabel names the base branch when known
+// (for the copy), else "".
+func resolveKillBase(worktreePath, recordedBaseSHA string) (base, baseLabel string, ok bool) {
+	commitExists := func(rev string) bool {
+		_, err := exec.Command("git", "-C", worktreePath, "rev-parse", "--verify", "--quiet", rev+"^{commit}").Output()
+		return err == nil
+	}
+	if b := strings.TrimSpace(recordedBaseSHA); b != "" && commitExists(b) {
+		return b, "", true
+	}
+	// origin/HEAD (symbolic ref to origin's default branch), then the usual names.
+	if out, err := exec.Command("git", "-C", worktreePath, "symbolic-ref", "--short", "-q", "refs/remotes/origin/HEAD").Output(); err == nil {
+		if ref := strings.TrimSpace(string(out)); ref != "" && commitExists(ref) {
+			return ref, strings.TrimPrefix(ref, "origin/"), true
+		}
+	}
+	for _, name := range []string{"main", "master"} {
+		if commitExists("origin/" + name) {
+			return "origin/" + name, name, true
+		}
+	}
+	return "", "", false
+}
+
+// unmergedSevereLine is the #2022 data-loss headline: it names the exact count
+// of commits that would be permanently deleted and that the loss is final. It is
+// the critical (never-clipped, #1973) line of the confirmation.
+func unmergedSevereLine(n int, baseLabel string) string {
+	commitWord, pronoun := "commits", "them"
+	where := "that aren't merged or pushed anywhere"
+	if n == 1 {
+		commitWord, pronoun = "commit", "it"
+		where = "that isn't merged or pushed anywhere"
+	}
+	if baseLabel != "" {
+		where = fmt.Sprintf("not on %s and not pushed anywhere", baseLabel)
+	}
+	return fmt.Sprintf("This branch has %d %s %s. Killing permanently deletes %s · this cannot be undone.", n, commitWord, where, pronoun)
+}
+
+// unmergedFailClosedLine mirrors the #815 could-not-verify warning for the
+// committed-work check: when we cannot prove the branch is free of local-only
+// commits, we say so rather than showing the bare, safe-looking prompt.
+func unmergedFailClosedLine(err error) string {
+	return fmt.Sprintf("Could not verify whether this branch has unmerged commits (%v); any that exist only here would be permanently deleted.", err)
+}
+
+// countGitLines counts non-empty lines in git command output.
+func countGitLines(out []byte) int {
+	n := 0
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.TrimSpace(line) != "" {
+			n++
+		}
+	}
+	return n
+}
+
+// joinWarnings joins non-empty warning lines with blank-line spacing for the
+// confirmation body, or returns "" when there are none.
+func joinWarnings(lines []string) string {
+	var kept []string
+	for _, l := range lines {
+		if strings.TrimSpace(l) != "" {
+			kept = append(kept, l)
+		}
+	}
+	return strings.Join(kept, "\n\n")
+}

--- a/app/kill_unmerged_test.go
+++ b/app/kill_unmerged_test.go
@@ -1,0 +1,313 @@
+package app
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/git"
+)
+
+// ----------------------------------------------------------------------------
+// Regression tests for issue #2022: killing a session force-deletes its branch
+// with `git branch -D`, permanently destroying committed-but-unmerged work,
+// while the confirmation only ever warned about a DIRTY worktree. A clean
+// worktree carrying an unmerged, unpushed commit — the normal state after an
+// agent commits — was killed behind a bare "[!] Kill session 'x'?" with no
+// data-loss warning at all.
+//
+// These drive the real confirmation path (handleKill -> the confirmation
+// overlay -> its rendered text and confirm key), not the helper on a string, so
+// they pin what the user actually sees and which key actually dispatches the
+// kill. The data-loss case must fail against the pre-#2022 code.
+// ----------------------------------------------------------------------------
+
+// killGit runs a git subcommand in dir and fails the test on error.
+func killGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	out, err := exec.Command("git", append([]string{"-C", dir}, args...)...).CombinedOutput()
+	require.NoError(t, err, "git %s failed: %s", strings.Join(args, " "), out)
+	return strings.TrimSpace(string(out))
+}
+
+// initBaseRepo creates a repo with a single base commit and returns its dir and
+// the base commit SHA (the value a real session records as BaseCommitSHA).
+func initBaseRepo(t *testing.T) (repoDir, baseSHA string) {
+	t.Helper()
+	repoDir = t.TempDir()
+	killGit(t, repoDir, "init", "-q")
+	killGit(t, repoDir, "config", "user.email", "test@example.com")
+	killGit(t, repoDir, "config", "user.name", "Test")
+	killGit(t, repoDir, "config", "commit.gpgsign", "false")
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "base.txt"), []byte("base\n"), 0o644))
+	killGit(t, repoDir, "add", "-A")
+	killGit(t, repoDir, "commit", "-q", "-m", "base commit")
+	return repoDir, killGit(t, repoDir, "rev-parse", "HEAD")
+}
+
+// addWorktree creates a linked worktree on a fresh branch, checked out at base.
+// A linked worktree shares the repo config, so user.* / commit.gpgsign carry
+// over. The returned path is what a live session's GetWorktreePath yields.
+func addWorktree(t *testing.T, repoDir, baseSHA, branch string) string {
+	t.Helper()
+	wt := filepath.Join(t.TempDir(), "wt")
+	killGit(t, repoDir, "worktree", "add", "-q", "-b", branch, wt, baseSHA)
+	return wt
+}
+
+// commitInWorktree adds one commit on the worktree's branch — the committed work
+// that a kill would orphan when it is not merged or pushed.
+func commitInWorktree(t *testing.T, wt string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(wt, "feature.txt"), []byte("work\n"), 0o644))
+	killGit(t, wt, "add", "-A")
+	killGit(t, wt, "commit", "-q", "-m", "agent: implement feature")
+}
+
+// startedWorktreeInstance builds a started, mock-backed instance (FakeBackend
+// reports WorkspaceLocalWorktree) whose GetGitWorktree resolves to a real git
+// worktree — the shape handleKill inspects for the #2022 check.
+func startedWorktreeInstance(t *testing.T, title, repoDir, worktreePath, branch, baseSHA string) *session.Instance {
+	t.Helper()
+	inst, err := session.NewInstance(session.InstanceOptions{Title: title, Path: repoDir, Program: "test"})
+	require.NoError(t, err)
+	inst.SetBackend(session.NewFakeBackend())
+	inst.SetStartedForTest(true)
+	inst.SetStatusForTest(session.Ready)
+	gw, err := git.NewGitWorktreeFromStorage(repoDir, worktreePath, title, branch, baseSHA, false, true)
+	require.NoError(t, err)
+	inst.SetGitWorktreeForTest(gw)
+	return inst
+}
+
+// flatten collapses a rendered overlay to a single whitespace-normalized line so
+// assertions survive lipgloss wrapping. It also drops the box-drawing border
+// glyphs, which otherwise land between two words split across a wrap boundary.
+func flatten(s string) string {
+	repl := strings.NewReplacer("│", " ", "─", " ", "╭", " ", "╮", " ", "╰", " ", "╯", " ")
+	return strings.Join(strings.Fields(repl.Replace(s)), " ")
+}
+
+// armKill selects the instance, presses kill, and returns the resulting home and
+// its (non-nil) confirmation overlay.
+func armKill(t *testing.T, inst *session.Instance) (*home, *home) {
+	t.Helper()
+	h := newTestHome(t)
+	h.store.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+	model, _ := h.handleKill()
+	hm := model.(*home)
+	require.Equal(t, stateConfirm, hm.state, "kill must open the confirmation dialog")
+	require.NotNil(t, hm.confirmationOverlay)
+	return h, hm
+}
+
+// TestHandleKill_UnmergedUnpushedCommit_EscalatesAndNamesLoss is the core #2022
+// guard and the data-loss case: a clean worktree whose branch carries one
+// unmerged, unpushed commit (no PR) must NOT show the bare prompt. The
+// confirmation must name the committed work with its count and the permanence,
+// and demand the distinct confirm key so a reflexive 'y' cannot orphan the work.
+func TestHandleKill_UnmergedUnpushedCommit_EscalatesAndNamesLoss(t *testing.T) {
+	repoDir, baseSHA := initBaseRepo(t)
+	wt := addWorktree(t, repoDir, baseSHA, "dev/gamma")
+	commitInWorktree(t, wt)
+	// Sanity: the worktree is clean (the pre-#2022 dirty check would say nothing).
+	require.Empty(t, killGit(t, wt, "status", "--porcelain"), "worktree must be clean")
+
+	inst := startedWorktreeInstance(t, "gamma", repoDir, wt, "dev/gamma", baseSHA)
+	_, hm := armKill(t, inst)
+
+	rendered := flatten(hm.confirmationOverlay.Render())
+	assert.Contains(t, rendered, "1 commit", "must name the committed work with a count")
+	assert.Contains(t, rendered, "permanently deletes it", "must name the permanence")
+	assert.Contains(t, rendered, "cannot be undone")
+	assert.NotContains(t, rendered, "uncommitted changes", "the loss is committed work, not a dirty worktree")
+
+	require.Equal(t, unmergedKillConfirmKey, hm.confirmationOverlay.ConfirmKey,
+		"a data-loss kill must demand the distinct confirm key, not the ordinary 'y'")
+	require.NotEqual(t, "y", hm.confirmationOverlay.ConfirmKey)
+
+	// A reflexive 'y' — the gesture that silently orphaned the commit — is ignored.
+	model, cmd := hm.handleStateConfirm(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	hm = model.(*home)
+	assert.Equal(t, stateConfirm, hm.state, "reflexive 'y' must not confirm a data-loss kill")
+	assert.NotNil(t, hm.confirmationOverlay, "dialog must stay open after a rejected key")
+	assert.Nil(t, cmd)
+	assert.NotEqual(t, session.Deleting, inst.GetStatus(), "session must not be marked Deleting")
+
+	// The named key confirms — kill stays POSSIBLE, only deliberate.
+	model, cmd = hm.handleStateConfirm(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(unmergedKillConfirmKey)})
+	hm = model.(*home)
+	assert.Equal(t, stateDefault, hm.state, "the named key must confirm")
+	assert.Nil(t, hm.confirmationOverlay, "dialog must close on confirm")
+	require.NotNil(t, cmd, "confirm must forward the start-kill message")
+	assert.Equal(t, session.Deleting, inst.GetStatus())
+	startMsg, ok := cmd().(startKillMsg)
+	require.True(t, ok, "confirm must emit startKillMsg")
+	assert.Equal(t, "gamma", startMsg.title)
+}
+
+// TestHandleKill_NoUniqueCommits_KeepsBareConfirmation guards against
+// over-warning: a clean worktree whose branch is level with base (no committed
+// work to lose) must kill behind the SAME bare confirmation and ordinary 'y' as
+// before #2022.
+func TestHandleKill_NoUniqueCommits_KeepsBareConfirmation(t *testing.T) {
+	repoDir, baseSHA := initBaseRepo(t)
+	wt := addWorktree(t, repoDir, baseSHA, "dev/empty") // no commit beyond base
+
+	inst := startedWorktreeInstance(t, "empty", repoDir, wt, "dev/empty", baseSHA)
+	_, hm := armKill(t, inst)
+
+	rendered := flatten(hm.confirmationOverlay.Render())
+	assert.Contains(t, rendered, "Kill session 'empty'?")
+	assert.NotContains(t, rendered, "commit", "a level branch must not warn about commits")
+	assert.NotContains(t, rendered, "Could not verify")
+	assert.Equal(t, "y", hm.confirmationOverlay.ConfirmKey,
+		"a session with nothing to lose must keep the ordinary 'y' confirm")
+}
+
+// TestHandleKill_PushedCommits_NotSevere: commits that also exist on a remote
+// survive `git branch -D` (it deletes only the LOCAL branch), so a pushed branch
+// must not fire the loud data-loss guard — firing it would train users to reflex
+// past a warning that isn't real.
+func TestHandleKill_PushedCommits_NotSevere(t *testing.T) {
+	repoDir, baseSHA := initBaseRepo(t)
+	wt := addWorktree(t, repoDir, baseSHA, "dev/pushed")
+	commitInWorktree(t, wt)
+	// Push the branch so a remote-tracking ref carries the commit.
+	bare := filepath.Join(t.TempDir(), "origin.git")
+	killGit(t, repoDir, "init", "-q", "--bare", bare)
+	killGit(t, repoDir, "remote", "add", "origin", bare)
+	killGit(t, wt, "push", "-q", "origin", "dev/pushed")
+
+	inst := startedWorktreeInstance(t, "pushed", repoDir, wt, "dev/pushed", baseSHA)
+	_, hm := armKill(t, inst)
+
+	rendered := flatten(hm.confirmationOverlay.Render())
+	assert.NotContains(t, rendered, "permanently deletes", "pushed commits survive the kill")
+	assert.Equal(t, "y", hm.confirmationOverlay.ConfirmKey,
+		"a pushed branch must keep the ordinary 'y' confirm")
+}
+
+// TestHandleKill_MergedPR_NotSevere: a merged PR means the work landed in base's
+// history, so even unpushed branch commits are not a real loss and must not fire
+// the loud guard.
+func TestHandleKill_MergedPR_NotSevere(t *testing.T) {
+	repoDir, baseSHA := initBaseRepo(t)
+	wt := addWorktree(t, repoDir, baseSHA, "dev/merged")
+	commitInWorktree(t, wt) // unpushed locally, but the PR is merged
+
+	inst := startedWorktreeInstance(t, "merged", repoDir, wt, "dev/merged", baseSHA)
+	inst.SetPRInfo(&git.PRInfo{Number: 7, State: "MERGED"})
+	_, hm := armKill(t, inst)
+
+	rendered := flatten(hm.confirmationOverlay.Render())
+	assert.NotContains(t, rendered, "permanently deletes", "merged work is not a loss")
+	assert.Equal(t, "y", hm.confirmationOverlay.ConfirmKey)
+}
+
+// TestHandleKill_BaseUndeterminable_FailsClosed: when we cannot determine the
+// base (no recorded base, no origin), we cannot prove the branch is free of
+// local-only commits — so we WARN rather than show the bare prompt (mirroring
+// the #815 fail-closed discipline). Unknown is not clean. We do not escalate the
+// key: we have not established that work is actually being lost.
+func TestHandleKill_BaseUndeterminable_FailsClosed(t *testing.T) {
+	repoDir, baseSHA := initBaseRepo(t)
+	wt := addWorktree(t, repoDir, baseSHA, "dev/nobody")
+	commitInWorktree(t, wt)
+
+	// Record no base and provide no origin, so base resolution has nothing to go on.
+	inst := startedWorktreeInstance(t, "nobody", repoDir, wt, "dev/nobody", "")
+	_, hm := armKill(t, inst)
+
+	rendered := flatten(hm.confirmationOverlay.Render())
+	assert.Contains(t, rendered, "Could not verify whether this branch has unmerged commits")
+	assert.Equal(t, "y", hm.confirmationOverlay.ConfirmKey,
+		"unverifiable is a warning, not a proven loss — keep the ordinary confirm")
+}
+
+// TestUnmergedCommitWarning covers the predicate directly across the matrix. The
+// rendered-path tests above prove the wiring; this pins the predicate itself.
+func TestUnmergedCommitWarning(t *testing.T) {
+	t.Run("unmerged unpushed commit is severe", func(t *testing.T) {
+		repoDir, baseSHA := initBaseRepo(t)
+		wt := addWorktree(t, repoDir, baseSHA, "dev/a")
+		commitInWorktree(t, wt)
+		line, severe := unmergedCommitWarning(wt, baseSHA, "")
+		assert.True(t, severe)
+		assert.Contains(t, line, "1 commit")
+		assert.Contains(t, line, "cannot be undone")
+	})
+
+	t.Run("no commits beyond base is safe", func(t *testing.T) {
+		repoDir, baseSHA := initBaseRepo(t)
+		wt := addWorktree(t, repoDir, baseSHA, "dev/b")
+		line, severe := unmergedCommitWarning(wt, baseSHA, "")
+		assert.False(t, severe)
+		assert.Empty(t, line)
+	})
+
+	t.Run("pushed commit is safe", func(t *testing.T) {
+		repoDir, baseSHA := initBaseRepo(t)
+		wt := addWorktree(t, repoDir, baseSHA, "dev/c")
+		commitInWorktree(t, wt)
+		bare := filepath.Join(t.TempDir(), "origin.git")
+		killGit(t, repoDir, "init", "-q", "--bare", bare)
+		killGit(t, repoDir, "remote", "add", "origin", bare)
+		killGit(t, wt, "push", "-q", "origin", "dev/c")
+		line, severe := unmergedCommitWarning(wt, baseSHA, "")
+		assert.False(t, severe)
+		assert.Empty(t, line)
+	})
+
+	t.Run("merged PR is safe despite local-only commit", func(t *testing.T) {
+		repoDir, baseSHA := initBaseRepo(t)
+		wt := addWorktree(t, repoDir, baseSHA, "dev/d")
+		commitInWorktree(t, wt)
+		line, severe := unmergedCommitWarning(wt, baseSHA, "MERGED")
+		assert.False(t, severe)
+		assert.Empty(t, line)
+	})
+
+	t.Run("multiple commits pluralize", func(t *testing.T) {
+		repoDir, baseSHA := initBaseRepo(t)
+		wt := addWorktree(t, repoDir, baseSHA, "dev/e")
+		commitInWorktree(t, wt)
+		require.NoError(t, os.WriteFile(filepath.Join(wt, "second.txt"), []byte("more\n"), 0o644))
+		killGit(t, wt, "add", "-A")
+		killGit(t, wt, "commit", "-q", "-m", "agent: more work")
+		line, severe := unmergedCommitWarning(wt, baseSHA, "")
+		assert.True(t, severe)
+		assert.Contains(t, line, "2 commits")
+		assert.Contains(t, line, "deletes them")
+	})
+
+	t.Run("undeterminable base fails closed", func(t *testing.T) {
+		repoDir, baseSHA := initBaseRepo(t)
+		wt := addWorktree(t, repoDir, baseSHA, "dev/f")
+		commitInWorktree(t, wt)
+		line, severe := unmergedCommitWarning(wt, "", "") // no recorded base, no origin
+		assert.False(t, severe, "unverifiable must not claim a proven loss")
+		assert.Contains(t, line, "Could not verify")
+	})
+
+	t.Run("empty worktree path fails closed", func(t *testing.T) {
+		line, severe := unmergedCommitWarning("", "deadbeef", "")
+		assert.False(t, severe)
+		assert.Contains(t, line, "Could not verify")
+	})
+
+	t.Run("git error fails closed", func(t *testing.T) {
+		// A non-repo directory makes the base rev-parse fail.
+		line, severe := unmergedCommitWarning(t.TempDir(), "deadbeef", "")
+		assert.False(t, severe)
+		assert.Contains(t, line, "Could not verify")
+	})
+}


### PR DESCRIPTION
Fixes #2022.

## The bug

Killing a session force-deletes its branch with `git branch -D` (`session/git/worktree_ops.go:238`, reached from the kill teardown), which orphans **any commit that is not merged into its base and not pushed** — recoverable only from the reflog until gc. But the kill confirmation (`killConfirmationWarning`) only ran `git status --porcelain`, so it warned **solely on a dirty worktree**. A clean worktree carrying committed work — the *normal* state after an agent commits — was killed behind a bare `[!] Kill session 'x'?` with no data-loss warning at all.

The asymmetry was exactly backwards: **archive**, the fully *recoverable* action, described its consequences in full ("branch + uncommitted changes preserved. Restore later with r"); **kill**, the *irreversible* one, said nothing. This is the honesty class — the UI asserting a safety it hasn't established. The governing rule now: **show the bare, safe-looking confirmation ONLY with positive evidence there is no unmerged work to lose; unknown or unverifiable warns. Forgetting must be safe.**

## The exact predicate (and its failure modes)

The kill pre-flight now assesses the session's committed work in `unmergedCommitWarning(worktreePath, recordedBaseSHA, prState)` (`app/kill_confirm.go`). All git is run **in the worktree** (HEAD there is the branch tip) and is **offline — no `git fetch`**:

1. **Base** — `resolveKillBase`: the recorded `BaseCommitSHA` first (verified present), else origin's default via `origin/HEAD` symbolic-ref, then `origin/main` / `origin/master`. It deliberately does **not** fall back to `HEAD` — HEAD is the branch tip itself, which would make every branch look zero commits ahead and fabricate a "nothing to lose" negative. Undeterminable ⇒ **fail closed**.
2. **Unique commits** — `git log --oneline <base>..HEAD`. Zero ⇒ **safe** (bare confirmation).
3. **Merged PR** — `prState == "MERGED"` (from the session's `PRInfo`) ⇒ **safe**: the diff landed in base's history (even a squash, whose original commits `branch -D` would orphan, preserves the work).
4. **Local-only commits** — `git log --oneline <base>..HEAD --not --remotes`: unique commits not reachable from **any** remote-tracking ref. `branch -D` orphans exactly these. Zero ⇒ **safe** (every unique commit is pushed somewhere and survives). Non-zero ⇒ **SEVERE**: `N` commits exist only locally.

The severe case is the true data loss: `N > 0`, unmerged, unpushed, no merged PR.

**Failure modes, stated:**
- **Stale remote-tracking refs** (offline, no fetch): a commit pushed since the last fetch whose `refs/remotes/...` is stale reads as local-only and **over-warns**. Over-warning is the conservative side — the loud path still kills on one keystroke — so it's accepted rather than risk silence on real loss. A kill confirmation is no place to touch the network.
- **Squash-merged branch deleted on origin**: original commits aren't ancestors of `origin/<default>`; without a `MERGED` PRInfo they'd read as local-only and over-warn. The `MERGED` check is the independent "safe" signal that covers this.
- **Undeterminable base / git error**: fail closed → warn "could not verify… any that exist only here would be permanently deleted" (mirrors the #815 discipline). We do **not** escalate the confirm key here — unknown is not a *proven* loss, so we warn but keep the ordinary `y`.
- **Scope**: the check gates on `GetGitWorktree()` (started sessions), which is the #2022 target — a live session whose agent has committed work. Not-started rows (Lost/Dead/Archived) keep today's behavior; extending honest warnings there is a worthwhile but distinct follow-up.

Kept intact: the existing dirty-worktree warning (#815) **and** the reserved-root-agent warning (#1238) — a session can be dirty **and** carry unmerged commits, so the warnings accumulate.

## Design decision: (b) require a distinct confirm key — and why

The genuine-loss case escalates to an **extra deliberate keystroke** (option **b**), not just a louder message (option a). Reasoning:

- The loss is permanent and unrecoverable; a loud warning that still accepts `y` trains users to reflex past it (the exact anti-pattern to avoid).
- The mechanism is **already in-tree, next to the bug**: #1238 established that an irreversible kill of something load-bearing (root) warrants a distinct confirm key surfaced in the prompt (`Press k to confirm`), so a muscle-memory `D`+`y` is a no-op. Permanent commit loss is at least as severe (root self-heals in ~2 min; orphaned commits do not). Reusing `SetConfirmKey` is proportionate; a typed-`WIPE` overlay would be inconsistent (the TUI has **no** typed-confirm anywhere — `WIPE` is CLI-only in `commands/reset.go`) and disproportionate.
- The consequence line goes in the overlay's **critical** message and the recovery hint in `detail`, opting into the #1973 critical-content guarantee: the consequence renders in full or the overlay refuses the confirm — it can never be clipped off-screen (the #1985 class).

**Hard constraint honored:** kill is never *refused*. A truly-abandoned session still kills — the named key just makes the loss deliberate. The clean/pushed/merged case keeps the **same bare `y` confirmation** as today; only genuine loss escalates.

## Before / after (rendered confirmation the user actually sees)

**Before** — captured against the pre-fix wiring through the real confirmation overlay (`ConfirmationOverlay.Render()`), same session (clean worktree, one unmerged unpushed commit):

```
╭──────────────────────────────────────────────────╮
│  [!] Kill session 'gamma'?                       │
│  Press y to confirm, n or esc to cancel          │
╰──────────────────────────────────────────────────╯
```

**After** — live playtest in the container sandbox (`make playtest-container`, mock repo), reproducing the issue's exact repro (`~/sandbox/mock-repo-gamma`, branch `dev/gamma`, `git status --porcelain` empty, 1 commit ahead, no remote), then pressing `D`:

```
╭──────────────────────────────────────────────────╮
│  [!] Kill session 'gamma'?                       │
│                                                  │
│  This branch has 1 commit that isn't merged or   │
│  pushed anywhere. Killing permanently deletes    │
│  it · this cannot be undone.                     │
│                                                  │
│  Archive (a) keeps the branch to restore later   │
│  — kill removes it for good.                     │
│                                                  │
│  Press k to confirm, n or esc to cancel          │
╰──────────────────────────────────────────────────╯
```

Playtest assertions: `PASS: names permanent deletion` · `PASS: names the committed work` · `PASS: demands distinct key k` · `PASS: names irreversibility`.

## Tests

`app/kill_unmerged_test.go` drives the **real** confirmation path (`handleKill` → the overlay → its rendered text + confirm key), not the helper on a string. What calls it in prod: `handleKill` (the `D` key, `keys.KeyKill`); it gates the async teardown behind the confirmation overlay's `OnConfirm`. The data-loss test was watched **failing first** against the pre-fix wiring (bare prompt, `ConfirmKey == "y"`, no "permanently deletes"), then passing.

- unmerged + unpushed + no PR ⇒ names the commit count + permanence, demands `k`, reflexive `y` is ignored, `k` confirms and emits `startKillMsg` (kill stays possible).
- no unique commits ⇒ bare confirmation, ordinary `y` (no over-warning).
- pushed commits ⇒ not severe (real bare origin + push in the harness).
- merged PR ⇒ not severe despite a local-only commit.
- undeterminable base / git error / empty worktree path ⇒ fail closed, warns, ordinary `y`.
- Plus a direct predicate matrix (`TestUnmergedCommitWarning`) and the existing #815/#1238 regression tests, unchanged and green.

`app/handle_actions.go` was over the 1000-line file-length limit after the change, so the kill-confirmation copy + detection moved to a new `app/kill_confirm.go` (split, not grandfathered).

## Gates

- `make test-container` — **32 ok packages, 0 FAIL** (4 no-test); tail `ok …/ui/tree 0.069s … ? …/web [no test files]`.
- `go build ./...` — clean, no output.
- `gofmt -l .` — **empty**.
- `golangci-lint run --timeout=3m --fast` — **exit 0**, no output.
- `deadcode -test ./...` — **exit 0**, no output.
- `scripts/lint-file-length.sh` — **passed** (752 Go files checked; 0 grandfathered).

Both review gates are down tonight, so this stays **DRAFT** — @sachiniyer re-gates via a fresh review and merges.

— Captain Claude
