### PR TITLE
feat(ci): auto-close stale external-contributor PRs

### DIFF
--- a/.github/scripts/stale-external-pr.js
+++ b/.github/scripts/stale-external-pr.js
@@ -1,0 +1,480 @@
+"use strict";
+
+// Auto-close stale EXTERNAL-contributor pull requests.
+//
+// Policy (see CLAUDE.md "External PR 12h no-response → close"): when a
+// maintainer requests changes on a fork PR and the contributor then goes quiet
+// for more than STALE_HOURS, close the PR with a warm, non-punitive note
+// inviting them to reopen. We move too fast to keep PRs parked — but the clock
+// only ever runs while the ball is in the contributor's court.
+//
+// Hard safety rails, in evaluation order (see decide()):
+//   * only fork PRs are ever eligible — same-repo (internal) branches such as
+//     our own `sachiniyer/*` session branches share the base repo's full name
+//     and are NEVER touched;
+//   * maintainer-authored PRs are skipped (their fork, our merge);
+//   * the latest decisional maintainer review must be CHANGES_REQUESTED and the
+//     contributor must not have pushed / commented / reviewed since it — if the
+//     last move was the contributor's, the maintainer owes the response and we
+//     keep it open;
+//   * a pending maintainer APPROVAL is never closed — that's ours to merge;
+//   * a change request younger than STALE_HOURS gets a grace window.
+//
+// The decision function `decide()` is PURE (no I/O) so the risky logic is unit
+// tested in stale-external-pr.test.js. `run()` is the thin GitHub-API glue that
+// gathers each PR's timeline, calls decide(), and (unless dry-run) comments,
+// labels, and closes.
+
+const STALE_HOURS = 12;
+const STALE_LABEL = "auto-closed-stale";
+const LABEL_COLOR = "d4c5f9";
+const LABEL_DESCRIPTION =
+  "Closed automatically after an external contributor went quiet on a change request";
+
+// author_association values that mark a maintainer rather than an external
+// contributor. GitHub reports these on reviews, comments, and the PR itself.
+const MAINTAINER_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+
+// Belt-and-suspenders login allowlist so a mis-reported association can never
+// let us close our own automation's PRs. Mirrors auto-gate.js ALLOWED_AUTHORS.
+const MAINTAINER_LOGINS = new Set([
+  "sachiniyer",
+  "app-detail-app",
+  "app-detail-app[bot]",
+]);
+
+// Warm, non-punitive close note. The first paragraph is the verbatim message
+// Sachin asked for; the footer keeps it auditable.
+const CLOSE_COMMENT = [
+  "Thanks for the contribution! We move fast here and don't keep PRs open long — closing this for now, but please re-open and push your adjustment whenever you're ready and we'll pick it right back up.",
+  "",
+  "<sub>Closed automatically by the stale-external-PR policy · reopen anytime and we'll resume · — Captain Claude 🤖</sub>",
+].join("\n");
+
+/**
+ * @typedef {Object} Review
+ * @property {string} author            login of the reviewer ("" if unknown)
+ * @property {string} authorAssociation OWNER/MEMBER/COLLABORATOR/CONTRIBUTOR/NONE/…
+ * @property {string} state             APPROVED/CHANGES_REQUESTED/COMMENTED/DISMISSED/PENDING
+ * @property {?string} submittedAt      ISO timestamp
+ *
+ * @typedef {Object} Commit
+ * @property {string} author            login of the commit author ("" if unknown)
+ * @property {?string} committedAt       ISO timestamp
+ *
+ * @typedef {Object} Comment
+ * @property {string} author            login of the commenter ("" if unknown)
+ * @property {string} authorAssociation author_association of the commenter
+ * @property {?string} createdAt         ISO timestamp
+ *
+ * @typedef {Object} PullState
+ * @property {number} number
+ * @property {string} state             'open' | 'closed'
+ * @property {string} author            PR author login (the contributor)
+ * @property {string} authorAssociation PR author's association
+ * @property {string} headRepoFullName  head repo "owner/name" ("" if the fork was deleted)
+ * @property {string} baseRepoFullName  base repo "owner/name"
+ * @property {string} headRef           head branch name
+ * @property {string[]} labels
+ * @property {Review[]} reviews
+ * @property {Commit[]} commits
+ * @property {Comment[]} comments
+ */
+
+/**
+ * Pure staleness decision for a single PR.
+ *
+ * @param {PullState} pr   normalized PR timeline
+ * @param {Date|number} now evaluation time
+ * @returns {{shouldClose: boolean, reason: string}}
+ */
+function decide(pr, now) {
+  const nowMs = toMs(now);
+
+  if (pr.state !== "open") {
+    return skip("PR is not open");
+  }
+
+  // Fork-only. Same-repo PRs (our own sachiniyer/* session branches and any
+  // other internal branch) share the base repo's full name and are never
+  // eligible. A deleted fork head reports no repo but still isn't an internal
+  // branch, so it counts as external.
+  if (!isExternalHead(pr.headRepoFullName, pr.baseRepoFullName)) {
+    return skip(
+      `internal-branch PR (head ${pr.headRef || "?"} lives in the base repo)`,
+    );
+  }
+
+  // Never auto-close a maintainer's own PR, even from a fork.
+  if (isMaintainer(pr.author, pr.authorAssociation)) {
+    return skip(`authored by maintainer ${pr.author || "(unknown)"}`);
+  }
+
+  // Latest *decisional* (APPROVED / CHANGES_REQUESTED) maintainer review.
+  const decisional = (pr.reviews || [])
+    .filter((r) => isMaintainer(r.author, r.authorAssociation))
+    .filter((r) => r.state === "APPROVED" || r.state === "CHANGES_REQUESTED")
+    .filter((r) => !Number.isNaN(toMs(r.submittedAt)))
+    .sort((a, b) => toMs(a.submittedAt) - toMs(b.submittedAt));
+
+  const latest = decisional[decisional.length - 1];
+  if (!latest) {
+    return skip("no maintainer changes-requested review");
+  }
+  if (latest.state === "APPROVED") {
+    // A passing approval is ours to merge, never stale (rule 5).
+    return skip("latest maintainer review is APPROVED (pending merge)");
+  }
+
+  const reviewMs = toMs(latest.submittedAt);
+
+  // Ball-in-court: any contributor push / comment / review strictly after the
+  // change request means the maintainer owes the next move — keep it open.
+  const respondedMs = latestContributorResponse(pr, reviewMs);
+  if (respondedMs !== null) {
+    return skip(
+      `contributor responded ${hoursBetween(reviewMs, respondedMs)}h after the change request (ball in maintainer's court)`,
+    );
+  }
+
+  const ageHours = hoursBetween(reviewMs, nowMs);
+  if (ageHours < STALE_HOURS) {
+    return skip(`change request only ${ageHours}h old (< ${STALE_HOURS}h grace)`);
+  }
+
+  return {
+    shouldClose: true,
+    reason: `external fork PR: maintainer requested changes ${ageHours}h ago with no contributor response since`,
+  };
+}
+
+/**
+ * True when the PR head is a fork (or a deleted fork), false for internal
+ * same-repo branches. Deleted heads report no full name and can never equal the
+ * base, so they are treated as external.
+ */
+function isExternalHead(headRepoFullName, baseRepoFullName) {
+  if (!headRepoFullName) return true;
+  return headRepoFullName !== baseRepoFullName;
+}
+
+function isMaintainer(login, association) {
+  if (login && MAINTAINER_LOGINS.has(login)) return true;
+  return association ? MAINTAINER_ASSOCIATIONS.has(association) : false;
+}
+
+/**
+ * Latest timestamp (ms) of contributor activity strictly after the review, or
+ * null. Any commit newer than the review counts: a branch that advanced after a
+ * change request is being worked, and biasing toward "keep open" is the safe
+ * direction for a tool that closes things. Comments and reviews count only when
+ * authored by the contributor — a maintainer's or third party's chatter does
+ * not move the ball back to us.
+ */
+function latestContributorResponse(pr, reviewMs) {
+  let latest = null;
+  const consider = (ms) => {
+    if (Number.isNaN(ms) || ms <= reviewMs) return;
+    if (latest === null || ms > latest) latest = ms;
+  };
+
+  for (const c of pr.commits || []) {
+    consider(toMs(c.committedAt));
+  }
+  for (const c of pr.comments || []) {
+    if (c.author && c.author === pr.author) consider(toMs(c.createdAt));
+  }
+  for (const r of pr.reviews || []) {
+    if (r.author && r.author === pr.author) consider(toMs(r.submittedAt));
+  }
+  return latest;
+}
+
+function skip(reason) {
+  return { shouldClose: false, reason };
+}
+
+function toMs(value) {
+  if (value === null || value === undefined) return NaN;
+  const ms = value instanceof Date ? value.getTime() : Date.parse(value);
+  return Number.isNaN(ms) ? NaN : ms;
+}
+
+// Whole-tenths of an hour, for readable log/reason lines.
+function hoursBetween(fromMs, toMsValue) {
+  return Math.round(((toMsValue - fromMs) / 36e5) * 10) / 10;
+}
+
+/**
+ * Cheap pre-screen so we don't spend three paginated API calls per obviously
+ * ineligible PR (closed / internal / maintainer-authored). decide() re-checks
+ * all of this authoritatively with the full timeline; this only decides whether
+ * fetching that timeline is worth it.
+ */
+function preScreen(pull, baseRepoFullName) {
+  if (pull.state !== "open") {
+    return { eligible: false, reason: "PR is not open" };
+  }
+  const headRepoFullName =
+    pull.head && pull.head.repo ? pull.head.repo.full_name : "";
+  if (!isExternalHead(headRepoFullName, baseRepoFullName)) {
+    const ref = pull.head ? pull.head.ref : "?";
+    return {
+      eligible: false,
+      reason: `internal-branch PR (head ${ref} lives in the base repo)`,
+    };
+  }
+  const author = pull.user ? pull.user.login : "";
+  if (isMaintainer(author, pull.author_association)) {
+    return {
+      eligible: false,
+      reason: `authored by maintainer ${author || "(unknown)"}`,
+    };
+  }
+  return { eligible: true, reason: "" };
+}
+
+function normalizePull(pull, baseRepoFullName, timeline) {
+  return {
+    number: pull.number,
+    state: pull.state,
+    author: pull.user ? pull.user.login : "",
+    authorAssociation: pull.author_association,
+    headRepoFullName:
+      pull.head && pull.head.repo ? pull.head.repo.full_name : "",
+    baseRepoFullName,
+    headRef: pull.head ? pull.head.ref : "",
+    labels: (pull.labels || []).map((l) => (typeof l === "string" ? l : l.name)),
+    reviews: (timeline.reviews || []).map((r) => ({
+      author: r.user ? r.user.login : "",
+      authorAssociation: r.author_association,
+      state: r.state,
+      submittedAt: r.submitted_at,
+    })),
+    commits: (timeline.commits || []).map((c) => ({
+      author: c.author ? c.author.login : "",
+      committedAt: commitDate(c),
+    })),
+    comments: (timeline.comments || []).map((c) => ({
+      author: c.user ? c.user.login : "",
+      authorAssociation: c.author_association,
+      createdAt: c.created_at,
+    })),
+  };
+}
+
+function commitDate(c) {
+  if (!c.commit) return null;
+  if (c.commit.committer && c.commit.committer.date) return c.commit.committer.date;
+  if (c.commit.author && c.commit.author.date) return c.commit.author.date;
+  return null;
+}
+
+/**
+ * Sweep all open PRs and close the stale external ones.
+ *
+ * @param {Object} args
+ * @param {Object} args.github  authenticated Octokit (actions/github-script)
+ * @param {Object} args.context github-script context
+ * @param {Object} args.core    github-script core
+ * @param {boolean} args.dryRun when true, only log what would be closed
+ * @returns {Promise<{evaluated:number, skipped:number, closed:number, wouldClose:number}>}
+ */
+async function run({ github, context, core, dryRun }) {
+  const { owner, repo } = context.repo;
+  const baseRepoFullName = `${owner}/${repo}`;
+  const now = new Date();
+
+  core.info(
+    `stale-external-pr: sweeping ${baseRepoFullName} at ${now.toISOString()}`,
+  );
+  core.info(
+    `stale-external-pr: mode = ${dryRun ? "DRY-RUN (nothing will be closed)" : "LIVE (stale PRs will be closed)"}`,
+  );
+  core.info(`stale-external-pr: threshold = ${STALE_HOURS}h; label = ${STALE_LABEL}`);
+
+  const pulls = await github.paginate(github.rest.pulls.list, {
+    owner,
+    repo,
+    state: "open",
+    per_page: 100,
+  });
+  core.info(`stale-external-pr: ${pulls.length} open PR(s) to evaluate`);
+
+  const summary = { evaluated: 0, skipped: 0, closed: 0, wouldClose: 0 };
+  let labelEnsured = false;
+
+  for (const pull of pulls) {
+    summary.evaluated++;
+    const tag = `#${pull.number} (${pull.user ? pull.user.login : "unknown"} · ${pull.head ? pull.head.ref : "?"}) ${pull.title || ""}`.trim();
+
+    const pre = preScreen(pull, baseRepoFullName);
+    if (!pre.eligible) {
+      core.info(`stale-external-pr: SKIP ${tag} — ${pre.reason}`);
+      summary.skipped++;
+      continue;
+    }
+
+    let timeline;
+    try {
+      const [reviews, commits, issueComments, reviewComments] = await Promise.all([
+        github.paginate(github.rest.pulls.listReviews, {
+          owner,
+          repo,
+          pull_number: pull.number,
+          per_page: 100,
+        }),
+        github.paginate(github.rest.pulls.listCommits, {
+          owner,
+          repo,
+          pull_number: pull.number,
+          per_page: 100,
+        }),
+        github.paginate(github.rest.issues.listComments, {
+          owner,
+          repo,
+          issue_number: pull.number,
+          per_page: 100,
+        }),
+        // Inline review-thread replies: a contributor can answer feedback here
+        // without pushing or leaving a conversation comment. Missing it would be
+        // a false-close, so it feeds the same contributor-response signal.
+        github.paginate(github.rest.pulls.listReviewComments, {
+          owner,
+          repo,
+          pull_number: pull.number,
+          per_page: 100,
+        }),
+      ]);
+      timeline = { reviews, commits, comments: issueComments.concat(reviewComments) };
+    } catch (error) {
+      // A fetch failure must never turn into a close. Log and skip this PR.
+      core.warning(
+        `stale-external-pr: SKIP ${tag} — could not load timeline: ${errText(error)}`,
+      );
+      summary.skipped++;
+      continue;
+    }
+
+    const state = normalizePull(pull, baseRepoFullName, timeline);
+    const decision = decide(state, now);
+    if (!decision.shouldClose) {
+      core.info(`stale-external-pr: SKIP ${tag} — ${decision.reason}`);
+      summary.skipped++;
+      continue;
+    }
+
+    if (dryRun) {
+      core.notice(`stale-external-pr: [dry-run] WOULD close ${tag} — ${decision.reason}`);
+      summary.wouldClose++;
+      continue;
+    }
+
+    core.notice(`stale-external-pr: closing ${tag} — ${decision.reason}`);
+    try {
+      if (!labelEnsured) {
+        await ensureLabel({ github, owner, repo, core });
+        labelEnsured = true;
+      }
+      await github.rest.issues.createComment({
+        owner,
+        repo,
+        issue_number: pull.number,
+        body: CLOSE_COMMENT,
+      });
+      await github.rest.issues.addLabels({
+        owner,
+        repo,
+        issue_number: pull.number,
+        labels: [STALE_LABEL],
+      });
+      await github.rest.pulls.update({
+        owner,
+        repo,
+        pull_number: pull.number,
+        state: "closed",
+      });
+      summary.closed++;
+    } catch (error) {
+      core.warning(
+        `stale-external-pr: FAILED to close ${tag}: ${errText(error)}`,
+      );
+    }
+  }
+
+  const tail = dryRun
+    ? `${summary.wouldClose} would be closed`
+    : `${summary.closed} closed`;
+  core.info(
+    `stale-external-pr: done — ${summary.evaluated} evaluated · ${summary.skipped} skipped · ${tail}`,
+  );
+
+  if (core.setOutput) {
+    core.setOutput("evaluated", String(summary.evaluated));
+    core.setOutput("skipped", String(summary.skipped));
+    core.setOutput("closed", String(summary.closed));
+    core.setOutput("would_close", String(summary.wouldClose));
+  }
+
+  await writeSummary({ core, baseRepoFullName, now, dryRun, summary });
+  return summary;
+}
+
+async function ensureLabel({ github, owner, repo, core }) {
+  try {
+    await github.rest.issues.getLabel({ owner, repo, name: STALE_LABEL });
+  } catch (error) {
+    if (error && error.status === 404) {
+      await github.rest.issues.createLabel({
+        owner,
+        repo,
+        name: STALE_LABEL,
+        color: LABEL_COLOR,
+        description: LABEL_DESCRIPTION,
+      });
+      core.info(`stale-external-pr: created label ${STALE_LABEL}`);
+    } else {
+      core.warning(
+        `stale-external-pr: could not verify label ${STALE_LABEL}: ${errText(error)}`,
+      );
+    }
+  }
+}
+
+async function writeSummary({ core, baseRepoFullName, now, dryRun, summary }) {
+  if (!core.summary || typeof core.summary.addHeading !== "function") return;
+  const verb = dryRun ? "Would close" : "Closed";
+  const count = dryRun ? summary.wouldClose : summary.closed;
+  try {
+    core.summary
+      .addHeading("Stale external PR sweep", 3)
+      .addRaw(
+        `Repo \`${baseRepoFullName}\` · ${now.toISOString()} · mode: ${dryRun ? "dry-run" : "live"}`,
+      )
+      .addBreak()
+      .addRaw(
+        `Evaluated ${summary.evaluated} · skipped ${summary.skipped} · ${verb.toLowerCase()} ${count}`,
+      );
+    await core.summary.write();
+  } catch (error) {
+    core.warning(`stale-external-pr: could not write job summary: ${errText(error)}`);
+  }
+}
+
+function errText(error) {
+  if (!error) return "unknown error";
+  return error.message ? error.message : String(error);
+}
+
+module.exports = {
+  run,
+  __test: {
+    decide,
+    preScreen,
+    isExternalHead,
+    isMaintainer,
+    STALE_HOURS,
+    STALE_LABEL,
+    CLOSE_COMMENT,
+  },
+};

--- a/.github/scripts/stale-external-pr.test.js
+++ b/.github/scripts/stale-external-pr.test.js
@@ -1,0 +1,261 @@
+"use strict";
+
+// Unit tests for the pure staleness decision. Run with the runner's built-in
+// node:test (no package.json, no install) — wired into CI in pr.yml alongside
+// the auto-gate helper tests:
+//   node --test .github/scripts/stale-external-pr.test.js
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const { __test } = require("./stale-external-pr.js");
+const { decide, preScreen, isExternalHead } = __test;
+
+const NOW = new Date("2026-07-17T12:00:00Z");
+const BASE = "sachiniyer/agent-factory";
+const hoursAgo = (h) => new Date(NOW.getTime() - h * 3600 * 1000).toISOString();
+
+function forkPR(overrides = {}) {
+  return {
+    number: 1,
+    state: "open",
+    author: "ext-user",
+    authorAssociation: "CONTRIBUTOR",
+    headRepoFullName: "ext-user/agent-factory",
+    baseRepoFullName: BASE,
+    headRef: "patch-1",
+    labels: [],
+    reviews: [],
+    commits: [],
+    comments: [],
+    ...overrides,
+  };
+}
+
+function maintReview(state, at, author = "sachiniyer") {
+  return { author, authorAssociation: "OWNER", state, submittedAt: at };
+}
+
+// ---- The five required cases -------------------------------------------------
+
+test("fork PR, changes requested 13h ago, no response → CLOSE", () => {
+  const pr = forkPR({ reviews: [maintReview("CHANGES_REQUESTED", hoursAgo(13))] });
+  const d = decide(pr, NOW);
+  assert.equal(d.shouldClose, true, d.reason);
+});
+
+test("fork PR, contributor pushed a commit 1h ago → KEEP", () => {
+  const pr = forkPR({
+    reviews: [maintReview("CHANGES_REQUESTED", hoursAgo(13))],
+    commits: [{ author: "ext-user", committedAt: hoursAgo(1) }],
+  });
+  const d = decide(pr, NOW);
+  assert.equal(d.shouldClose, false);
+  assert.match(d.reason, /ball in maintainer/);
+});
+
+test("internal-branch PR (same repo) → NEVER close", () => {
+  const pr = forkPR({
+    headRepoFullName: BASE,
+    headRef: "sachiniyer/some-session",
+    author: "sachiniyer",
+    authorAssociation: "OWNER",
+    reviews: [maintReview("CHANGES_REQUESTED", hoursAgo(48))],
+  });
+  const d = decide(pr, NOW);
+  assert.equal(d.shouldClose, false);
+  assert.match(d.reason, /internal-branch/);
+});
+
+test("maintainer owes the response (contributor commented after CR) → KEEP", () => {
+  const pr = forkPR({
+    reviews: [maintReview("CHANGES_REQUESTED", hoursAgo(20))],
+    comments: [
+      { author: "ext-user", authorAssociation: "CONTRIBUTOR", createdAt: hoursAgo(2) },
+    ],
+  });
+  const d = decide(pr, NOW);
+  assert.equal(d.shouldClose, false);
+  assert.match(d.reason, /ball in maintainer/);
+});
+
+test("pending maintainer approval → NEVER close", () => {
+  const pr = forkPR({
+    reviews: [
+      maintReview("CHANGES_REQUESTED", hoursAgo(30)),
+      maintReview("APPROVED", hoursAgo(20)),
+    ],
+  });
+  const d = decide(pr, NOW);
+  assert.equal(d.shouldClose, false);
+  assert.match(d.reason, /APPROVED/);
+});
+
+// ---- Threshold / grace -------------------------------------------------------
+
+test("change request younger than 12h → grace, KEEP", () => {
+  const pr = forkPR({ reviews: [maintReview("CHANGES_REQUESTED", hoursAgo(6))] });
+  const d = decide(pr, NOW);
+  assert.equal(d.shouldClose, false);
+  assert.match(d.reason, /grace/);
+});
+
+test("change request exactly 12h old → CLOSE (boundary is inclusive)", () => {
+  const pr = forkPR({ reviews: [maintReview("CHANGES_REQUESTED", hoursAgo(12))] });
+  assert.equal(decide(pr, NOW).shouldClose, true);
+});
+
+// ---- Review ordering / decisional state --------------------------------------
+
+test("changes requested AFTER an earlier approval → CLOSE when stale", () => {
+  const pr = forkPR({
+    reviews: [
+      maintReview("APPROVED", hoursAgo(30)),
+      maintReview("CHANGES_REQUESTED", hoursAgo(20)),
+    ],
+  });
+  assert.equal(decide(pr, NOW).shouldClose, true);
+});
+
+test("no changes-requested review at all → KEEP", () => {
+  const pr = forkPR({ reviews: [maintReview("COMMENTED", hoursAgo(40))] });
+  const d = decide(pr, NOW);
+  assert.equal(d.shouldClose, false);
+  assert.match(d.reason, /no maintainer changes-requested/);
+});
+
+test("changes requested by a NON-maintainer is ignored → KEEP", () => {
+  const pr = forkPR({
+    reviews: [
+      { author: "rando", authorAssociation: "NONE", state: "CHANGES_REQUESTED", submittedAt: hoursAgo(40) },
+    ],
+  });
+  const d = decide(pr, NOW);
+  assert.equal(d.shouldClose, false);
+  assert.match(d.reason, /no maintainer changes-requested/);
+});
+
+test("MEMBER and COLLABORATOR reviews also count as maintainer change requests", () => {
+  for (const assoc of ["MEMBER", "COLLABORATOR"]) {
+    const pr = forkPR({
+      reviews: [
+        { author: "other-maint", authorAssociation: assoc, state: "CHANGES_REQUESTED", submittedAt: hoursAgo(20) },
+      ],
+    });
+    assert.equal(decide(pr, NOW).shouldClose, true, `assoc=${assoc}`);
+  }
+});
+
+// ---- Ball-in-court nuances ---------------------------------------------------
+
+test("contributor's follow-up COMMENTED review after CR → KEEP", () => {
+  const pr = forkPR({
+    reviews: [
+      maintReview("CHANGES_REQUESTED", hoursAgo(20)),
+      { author: "ext-user", authorAssociation: "CONTRIBUTOR", state: "COMMENTED", submittedAt: hoursAgo(3) },
+    ],
+  });
+  assert.equal(decide(pr, NOW).shouldClose, false);
+});
+
+test("contributor comment BEFORE the change request does not reset the clock → CLOSE", () => {
+  const pr = forkPR({
+    reviews: [maintReview("CHANGES_REQUESTED", hoursAgo(20))],
+    comments: [
+      { author: "ext-user", authorAssociation: "CONTRIBUTOR", createdAt: hoursAgo(30) },
+    ],
+  });
+  assert.equal(decide(pr, NOW).shouldClose, true);
+});
+
+test("a third party's comment after the CR does not keep it open → CLOSE", () => {
+  const pr = forkPR({
+    reviews: [maintReview("CHANGES_REQUESTED", hoursAgo(20))],
+    comments: [
+      { author: "passerby", authorAssociation: "NONE", createdAt: hoursAgo(1) },
+    ],
+  });
+  assert.equal(decide(pr, NOW).shouldClose, true);
+});
+
+test("any commit after the CR keeps it open, even if attributed to no one → KEEP", () => {
+  const pr = forkPR({
+    reviews: [maintReview("CHANGES_REQUESTED", hoursAgo(20))],
+    commits: [{ author: "", committedAt: hoursAgo(2) }],
+  });
+  assert.equal(decide(pr, NOW).shouldClose, false);
+});
+
+// ---- Author / fork identity --------------------------------------------------
+
+test("maintainer-authored fork PR is NEVER closed", () => {
+  const pr = forkPR({
+    author: "sachiniyer",
+    authorAssociation: "OWNER",
+    headRepoFullName: "sachiniyer/agent-factory-fork",
+    reviews: [maintReview("CHANGES_REQUESTED", hoursAgo(40), "someone-else")],
+  });
+  const d = decide(pr, NOW);
+  assert.equal(d.shouldClose, false);
+  assert.match(d.reason, /maintainer/);
+});
+
+test("bot-authored PR (allowlisted login) is NEVER closed", () => {
+  const pr = forkPR({
+    author: "app-detail-app[bot]",
+    authorAssociation: "NONE",
+    reviews: [maintReview("CHANGES_REQUESTED", hoursAgo(40))],
+  });
+  assert.equal(decide(pr, NOW).shouldClose, false);
+});
+
+test("deleted fork head (no head repo) still counts as external → CLOSE when stale", () => {
+  const pr = forkPR({
+    headRepoFullName: "",
+    reviews: [maintReview("CHANGES_REQUESTED", hoursAgo(20))],
+  });
+  assert.equal(decide(pr, NOW).shouldClose, true);
+});
+
+// ---- State gate --------------------------------------------------------------
+
+test("already-closed PR → SKIP", () => {
+  const pr = forkPR({
+    state: "closed",
+    reviews: [maintReview("CHANGES_REQUESTED", hoursAgo(40))],
+  });
+  const d = decide(pr, NOW);
+  assert.equal(d.shouldClose, false);
+  assert.match(d.reason, /not open/);
+});
+
+// ---- Helpers -----------------------------------------------------------------
+
+test("isExternalHead: same repo is internal; fork and deleted-head are external", () => {
+  assert.equal(isExternalHead(BASE, BASE), false);
+  assert.equal(isExternalHead("ext/agent-factory", BASE), true);
+  assert.equal(isExternalHead("", BASE), true);
+  assert.equal(isExternalHead(null, BASE), true);
+  assert.equal(isExternalHead(undefined, BASE), true);
+});
+
+test("preScreen mirrors decide's cheap gates (fork / maintainer / open)", () => {
+  const internal = preScreen(
+    { state: "open", head: { repo: { full_name: BASE }, ref: "sachiniyer/x" }, user: { login: "sachiniyer" }, author_association: "OWNER" },
+    BASE,
+  );
+  assert.equal(internal.eligible, false);
+  assert.match(internal.reason, /internal-branch/);
+
+  const eligible = preScreen(
+    { state: "open", head: { repo: { full_name: "ext/agent-factory" }, ref: "patch-1" }, user: { login: "ext-user" }, author_association: "CONTRIBUTOR" },
+    BASE,
+  );
+  assert.equal(eligible.eligible, true);
+
+  const closed = preScreen(
+    { state: "closed", head: { repo: { full_name: "ext/agent-factory" }, ref: "patch-1" }, user: { login: "ext-user" }, author_association: "CONTRIBUTOR" },
+    BASE,
+  );
+  assert.equal(closed.eligible, false);
+  assert.match(closed.reason, /not open/);
+});

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -63,6 +63,12 @@ jobs:
       - name: Test auto-gate helper
         run: node --test .github/scripts/auto-gate.test.js
 
+      # Same rationale as the auto-gate test above: the stale-external-pr helper
+      # decides which fork PRs to auto-close, so its pure decision logic gates
+      # here in the required Lint job. Built-in node:test, no install step.
+      - name: Test stale-external-pr helper
+        run: node --test .github/scripts/stale-external-pr.test.js
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/.github/workflows/stale-external-pr.yml
+++ b/.github/workflows/stale-external-pr.yml
@@ -1,0 +1,76 @@
+name: Stale external PRs
+
+# Auto-closes stale EXTERNAL-contributor (fork) PRs: when a maintainer has
+# requested changes and the contributor has gone quiet for 12h+, close with a
+# warm note inviting them to reopen. The decision logic (fork-only, 12h clock,
+# ball-in-court) lives in .github/scripts/stale-external-pr.js and is unit
+# tested in stale-external-pr.test.js (run in the Lint job of pr.yml).
+#
+# Safety:
+#   * Repo variable STALE_EXTERNAL_PR_ENABLED is the master kill-switch. Until
+#     it is set to 'true', every run is DRY-RUN only — scheduled runs stay
+#     auditable and harmless, so Sachin can watch the logs before arming it.
+#   * The workflow_dispatch `dry_run` input forces a preview even when enabled.
+#   * The built-in GITHUB_TOKEN is scoped to just comment + label + close.
+
+on:
+  schedule:
+    # Every 4 hours (within the 3–6h window).
+    - cron: "0 */4 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Only log what would be closed; never comment/label/close"
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: stale-external-pr
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    name: Close stale external PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out helper
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Evaluate and close
+        uses: actions/github-script@v8
+        env:
+          # Master kill-switch. Anything other than the exact string 'true'
+          # keeps the sweep in dry-run.
+          ENABLED: ${{ vars.STALE_EXTERNAL_PR_ENABLED }}
+          INPUT_DRY_RUN: ${{ github.event.inputs.dry_run }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const path = require("path");
+            const helperPath = path.join(
+              process.env.GITHUB_WORKSPACE,
+              ".github/scripts/stale-external-pr.js",
+            );
+            const { run } = require(helperPath);
+
+            const enabled = process.env.ENABLED === "true";
+            const forcedDryRun = process.env.INPUT_DRY_RUN === "true";
+            const dryRun = forcedDryRun || !enabled;
+
+            if (!enabled) {
+              core.notice(
+                "STALE_EXTERNAL_PR_ENABLED is not 'true' — running in dry-run. Set the repo variable to 'true' to arm real closes.",
+              );
+            } else if (forcedDryRun) {
+              core.notice("dry_run input is set — running in dry-run.");
+            }
+
+            await run({ github, context, core, dryRun });


### PR DESCRIPTION
## What

A scheduled GitHub Action that auto-closes **stale external (fork) PRs**. When a maintainer has requested changes and the external contributor goes quiet for **12h+**, it posts a warm, non-punitive note and closes the PR — inviting them to reopen and push their adjustment whenever they're ready. This automates the manual "external PR 12h no-response → close" policy.

## Files

- `.github/scripts/stale-external-pr.js` — pure `decide()` decision function + thin GitHub-API glue (`run()`).
- `.github/scripts/stale-external-pr.test.js` — 21 `node:test` cases for the decision logic.
- `.github/workflows/stale-external-pr.yml` — 4h cron + `workflow_dispatch` (dry-run input).
- `.github/workflows/pr.yml` — runs the new helper's tests in the required Lint job (mirrors the auto-gate helper).

## Enforced semantics (the whole point)

- **Fork-only.** Same-repo `sachiniyer/*` session branches share the base repo's full name and are **never** touched. Deleted-fork heads still count as external. Maintainer-authored PRs are skipped.
- **Ball-in-court 12h clock.** Closes only when the latest *decisional* maintainer review is `CHANGES_REQUESTED` **and** the contributor hasn't pushed a commit, left a conversation comment, replied inline, or submitted a review since it. If the last move was the contributor's, the maintainer owes the response → keep open. Age is measured against the review's `submitted_at`.
- **Never close a pending approval.** A latest `APPROVED` maintainer review is ours to merge, not stale.
- **Grace window.** A change request younger than 12h is left alone.
- **Conservative failure.** Closed PRs are skipped; a timeline re-fetch failure skips the PR (never closes on incomplete data).

## Safety

- **Master kill-switch:** repo variable `STALE_EXTERNAL_PR_ENABLED`. Until it's set to `'true'`, **every run is dry-run only** — scheduled runs stay auditable and harmless so you can watch the logs before arming it. Flip it to `true` to enable real closes; unset/anything-else keeps it in dry-run.
- **Dry-run input:** `workflow_dispatch` `dry_run` forces a preview even when enabled.
- **Minimal token:** built-in `GITHUB_TOKEN` scoped to `pull-requests: write` + `issues: write`.
- **Auditable + idempotent:** every decision is logged with its reason; closes add an `auto-closed-stale` label; already-closed PRs are skipped.

## Verification (the gate)

- ✅ `node --test .github/scripts/stale-external-pr.test.js` — 21/21 pass, covering: fork CR 13h no-response → close; contributor pushed 1h ago → keep; internal branch → never; maintainer owes response → keep; already-approved → keep; <12h grace; boundary at exactly 12h; changes-after-approval; non-maintainer CR ignored; inline reply keeps open; deleted-fork; bot/maintainer author skip.
- ✅ End-to-end dry-run against a mocked Octokit over a 5-PR mix: **dry-run mutated nothing**; live acted on **only** the one genuinely-stale external PR (comment → label → close), skipping the internal branch, the pushed-since PR, the approved PR, and the <12h PR — each with a logged reason.

Kept as **draft** for a fresh review before merge. Once merged (still disabled), scheduled runs will emit dry-run logs to watch before flipping `STALE_EXTERNAL_PR_ENABLED=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)