### PR TITLE
ci: make PR-required checks run on merge_group (merge-queue ready)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,9 +3,26 @@ name: PR Validation
 on:
   pull_request:
     branches: [master]
+  # A merge queue creates a temporary gh-readonly-queue/… ref and dispatches the
+  # merge_group event. The required "Lint" and "Build" checks below MUST run on
+  # that event and report against the merge_group ref, or the queue never gets a
+  # result and every merge stalls forever. The jobs are the SAME ones the PR runs
+  # (none is gated on github.event_name), so they report the identical "Lint" and
+  # "Build" check contexts on the merged-result ref. Do NOT filter merge_group by
+  # branch — the queue only ever targets master, and a base-branch filter here is
+  # an easy way to silently stop the checks from running.
+  merge_group:
 
 concurrency:
-  group: pr-${{ github.event.pull_request.number }}
+  # pull_request keys the group on the PR number so a new push cancels the stale
+  # run (pr-123). merge_group carries no pull_request payload, so that expression
+  # is empty: without a fallback EVERY merge_group run would share the group "pr-"
+  # and cancel-in-progress would cancel the previous queue entry, stalling the
+  # merge queue. Fall back to github.ref, which is the unique gh-readonly-queue/…
+  # ref per merge_group entry (and refs/pull/N/merge for PRs, so PR runs never
+  # collide with queue runs either). Mirrors how auto-gate.yml keys off a fallback
+  # chain when the pull_request payload is null.
+  group: pr-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 # Read-only: workflow only checks out source and runs lint/test/build; it never comments on or modifies the PR.


### PR DESCRIPTION
## Why

Sachin approved enabling a GitHub **merge queue**. This PR is the **workflow side only** — the `merge_queue` ruleset rule is enabled separately via API *after* this lands, so the ordering is safe.

A merge queue dispatches the **`merge_group`** event against a temporary `refs/heads/gh-readonly-queue/master/…` ref. The required status checks **must** run on that event, or the queue never gets a result and **every merge stalls forever**. So this has to be correct before the rule is turned on.

## What changed (only `.github/workflows/pr.yml`)

1. **Added the `merge_group:` trigger** alongside the existing `pull_request` trigger.
2. **Fixed the concurrency group** so merge_group runs don't cancel each other.

```yaml
on:
  pull_request:
    branches: [master]
  merge_group:

concurrency:
  group: pr-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

## Verification

**Which check contexts report on `merge_group`** — the required ruleset checks are named exactly **"Lint"** and **"Build"**, and both come from `pr.yml`:

| Job id | `name:` → check context | Runs on merge_group? |
|---|---|---|
| `lint` | **Lint** *(required)* | ✅ |
| `test` | Test | ✅ |
| `test-macos` | Test (macOS) | ✅ |
| `build` | **Build** *(required)* | ✅ |

- **Confirmed the required contexts originate here.** `lint.yml` (push-only) has a *lowercase* `lint` job → context "lint"; `build.yml`, `auto-release.yml`, `stable-release.yml` also have "Build"-ish jobs but all run on `push`/tag/`workflow_dispatch` — **none run on `pull_request` or `merge_group`**, so on the queue only `pr.yml` produces "Lint"/"Build". `build.yml`'s push-to-master matrix and the release workflows are **untouched**.
- **No job is `github.event_name`-gated.** Verified by parsing the YAML: all four jobs have no event-based `if:`, so they run identically on `pull_request` and `merge_group` and report the **same** "Lint" and "Build" contexts on the merged-result ref. `build`'s `if: always()` + `needs: [lint, test, test-macos]` gate is unchanged, so a red Test/macOS still turns the required **Build** check red on merge_group too.
- **zsh lane covered (#1990).** The `test` job's `Install zsh` step is unconditional, so it runs on merge_group — the shellsuggest suite won't hard-fail in the queue.
- **Concurrency.** `github.event.pull_request.number` is empty under merge_group; without the fallback every queue run would share group `pr-` and `cancel-in-progress: true` would cancel the previous queue entry, stalling the queue. Falling back to `github.ref` gives each queue entry its unique `gh-readonly-queue/…` ref (and PRs keep `pr-123` via `refs/pull/N/merge`), mirroring how `auto-gate.yml` handles a null `pull_request` payload.
- **Validity:** `python3 yaml.safe_load` parses clean; **`actionlint` reports clean**.

## Net effect on a `merge_group` event
Runs **Lint + Test + Test (macOS) + Build**, reporting the required **"Lint"** and **"Build"** contexts against the merge-queue ref. ✅

## Not in scope
Enabling the `merge_queue` ruleset rule (Captain Claude does that via API after merge). Staying in **draft** for a fresh Claude review per Sachin — infra-critical, trigger correctness scrutinized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)