### PR TITLE
fix: three parsing/honesty bugs (#2004, #2009, #2010)

### DIFF
--- a/config/limit_patterns.go
+++ b/config/limit_patterns.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/sachiniyer/agent-factory/log"
@@ -20,10 +21,16 @@ const defaultLimitRetryInterval = "30m"
 // at load (sanitizeLimitRetryInterval), so a parse error here degrades safely to
 // 0 — surface-only for a no-parseable-reset-time limit.
 func (c *Config) LimitRetryIntervalDuration() time.Duration {
-	if c.LimitRetryInterval == "" {
+	// Trim before parsing so a whitespace-padded hand-edit still yields the
+	// intended cadence rather than degrading to 0 (which silently disables the
+	// fixed-interval fallback). sanitizeLimitRetryInterval already stores a
+	// trimmed value, so this is defense-in-depth for any value that reaches the
+	// consumer without passing through the loader (#2009).
+	v := strings.TrimSpace(c.LimitRetryInterval)
+	if v == "" {
 		return 0
 	}
-	d, err := time.ParseDuration(c.LimitRetryInterval)
+	d, err := time.ParseDuration(v)
 	if err != nil || d < 0 {
 		return 0
 	}
@@ -36,10 +43,16 @@ func (c *Config) LimitRetryIntervalDuration() time.Duration {
 // warns and falls back to the default so a typo can neither silently disable
 // auto-resume nor mis-time it.
 func sanitizeLimitRetryInterval(raw, prettyConfigPath string) string {
-	if raw == "" {
+	// Trim first: a stray leading/trailing space is an unambiguous hand-edit
+	// typo, and time.ParseDuration rejects " 30s ". Without this the value would
+	// fail to parse and be replaced by the default with the user's intended
+	// interval silently thrown away (#2009). The parsed value is stored trimmed
+	// so the consumer sees a canonical duration string.
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
 		return ""
 	}
-	d, err := time.ParseDuration(raw)
+	d, err := time.ParseDuration(trimmed)
 	if err != nil {
 		log.WarningLog.Printf("Config issue in %s: limit_retry_interval=%q is not a valid duration (%v); using default %q",
 			prettyConfigPath, raw, err, defaultLimitRetryInterval)
@@ -50,7 +63,7 @@ func sanitizeLimitRetryInterval(raw, prettyConfigPath string) string {
 			prettyConfigPath, raw, defaultLimitRetryInterval)
 		return defaultLimitRetryInterval
 	}
-	return raw
+	return trimmed
 }
 
 // validateLimitRetryIntervalValue applies sanitizeLimitRetryInterval's rules as
@@ -63,6 +76,12 @@ func sanitizeLimitRetryInterval(raw, prettyConfigPath string) string {
 // rejects on set): a typo the loader would quietly turn into 30m should be told
 // to the user at the moment they typed it, rather than silently mis-timing
 // auto-resume later.
+//
+// Whitespace is intentionally NOT trimmed here, unlike the loader (#2009): a
+// hand-edited config.toml with a stray space is honored leniently on load, but
+// a value passed explicitly to `af config set` is strict input — rejecting
+// " 30s " with a message naming the value is honest and actionable, not a
+// silent default, so it stays a hard error.
 func validateLimitRetryIntervalValue(value string) error {
 	if value == "" {
 		return nil

--- a/config/limit_patterns_test.go
+++ b/config/limit_patterns_test.go
@@ -1,0 +1,88 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	aflog "github.com/sachiniyer/agent-factory/log"
+)
+
+// TestSanitizeLimitRetryInterval covers the load-path handling of
+// limit_retry_interval (#2009): surrounding whitespace on an otherwise-valid
+// duration is a hand-edit typo that must be trimmed and honored — NOT thrown
+// away for the default — while a genuinely-unparseable non-empty value must
+// warn (naming the value and the key) rather than silently fall back.
+func TestSanitizeLimitRetryInterval(t *testing.T) {
+	const path = "~/.agent-factory/config.toml"
+
+	t.Run("whitespace is trimmed, not defaulted", func(t *testing.T) {
+		if got := sanitizeLimitRetryInterval(" 30s ", path); got != "30s" {
+			t.Fatalf("sanitizeLimitRetryInterval(%q) = %q, want %q", " 30s ", got, "30s")
+		}
+	})
+
+	t.Run("empty stays empty (never retry)", func(t *testing.T) {
+		if got := sanitizeLimitRetryInterval("", path); got != "" {
+			t.Fatalf("sanitizeLimitRetryInterval(%q) = %q, want empty", "", got)
+		}
+		if got := sanitizeLimitRetryInterval("   ", path); got != "" {
+			t.Fatalf("sanitizeLimitRetryInterval(%q) = %q, want empty", "   ", got)
+		}
+	})
+
+	t.Run("valid value kept verbatim", func(t *testing.T) {
+		if got := sanitizeLimitRetryInterval("45m", path); got != "45m" {
+			t.Fatalf("sanitizeLimitRetryInterval(%q) = %q, want %q", "45m", got, "45m")
+		}
+	})
+
+	t.Run("unparseable non-empty value warns rather than silently defaulting", func(t *testing.T) {
+		buf := captureLog(t, &aflog.WarningLog)
+		got := sanitizeLimitRetryInterval("soon", path)
+		if got != defaultLimitRetryInterval {
+			t.Fatalf("sanitizeLimitRetryInterval(%q) = %q, want default %q", "soon", got, defaultLimitRetryInterval)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "limit_retry_interval") {
+			t.Errorf("warning must name the key, got: %q", out)
+		}
+		if !strings.Contains(out, "soon") {
+			t.Errorf("warning must name the bad value, got: %q", out)
+		}
+	})
+
+	t.Run("negative value warns rather than silently defaulting", func(t *testing.T) {
+		buf := captureLog(t, &aflog.WarningLog)
+		got := sanitizeLimitRetryInterval("-5m", path)
+		if got != defaultLimitRetryInterval {
+			t.Fatalf("sanitizeLimitRetryInterval(%q) = %q, want default %q", "-5m", got, defaultLimitRetryInterval)
+		}
+		if !strings.Contains(buf.String(), "-5m") {
+			t.Errorf("warning must name the bad value, got: %q", buf.String())
+		}
+	})
+}
+
+// TestLimitRetryIntervalDurationTrims pins the runtime consumer's tolerance for
+// a whitespace-padded value (#2009): even if an untrimmed value reaches it, it
+// must parse to the intended duration, not degrade to 0 (which disables the
+// fixed-cadence fallback).
+func TestLimitRetryIntervalDurationTrims(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want time.Duration
+	}{
+		{" 30s ", 30 * time.Second},
+		{"30m", 30 * time.Minute},
+		{"", 0},
+		{"   ", 0},
+		{"soon", 0},
+	}
+	for _, c := range cases {
+		cfg := &Config{LimitRetryInterval: c.raw}
+		if got := cfg.LimitRetryIntervalDuration(); got != c.want {
+			t.Errorf("LimitRetryIntervalDuration(%q) = %v, want %v", c.raw, got, c.want)
+		}
+	}
+}

--- a/preflight/preflight.go
+++ b/preflight/preflight.go
@@ -1,7 +1,9 @@
 package preflight
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,6 +13,19 @@ import (
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/internal/shellsuggest"
 	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// Program-check outcome sentinels let ProgramError classify a CheckCommand
+// failure by kind instead of string-matching. A missing binary is "not
+// installed"; a present-but-unrunnable one needs chmod, not a reinstall —
+// collapsing the two sends the user to fix the wrong thing (#2010).
+var (
+	// errProgramNotFound: the executable could not be located — no such file, or
+	// absent from PATH.
+	errProgramNotFound = errors.New("not installed or not on PATH")
+	// errProgramNotExecutable: the executable exists but cannot be run (its
+	// permission bits are clear).
+	errProgramNotExecutable = errors.New("found but not executable")
 )
 
 // ProgramCheck describes the executable a configured agent command resolves to.
@@ -74,20 +89,23 @@ func CheckCommand(command string) (*ProgramCheck, error) {
 		path := config.ExpandTilde(exe)
 		info, err := os.Stat(path)
 		if err != nil {
-			return check, fmt.Errorf("executable %q does not exist", exe)
+			if os.IsNotExist(err) {
+				return check, fmt.Errorf("%w: executable %q does not exist", errProgramNotFound, exe)
+			}
+			return check, fmt.Errorf("executable %q could not be checked: %w", exe, err)
 		}
 		if info.IsDir() {
-			return check, fmt.Errorf("executable %q is a directory", exe)
+			return check, fmt.Errorf("executable %q is a directory, not a program", exe)
 		}
 		if info.Mode().Perm()&0o111 == 0 {
-			return check, fmt.Errorf("executable %q is not executable; run: %s", exe, shellsuggest.Command("chmod", "+x", path))
+			return check, fmt.Errorf("%w: executable %q is not executable; run: %s", errProgramNotExecutable, exe, shellsuggest.Command("chmod", "+x", path))
 		}
 		check.Path = path
 		return check, nil
 	}
 	path, err := exec.LookPath(exe)
 	if err != nil {
-		return check, fmt.Errorf("executable %q was not found on PATH", exe)
+		return check, fmt.Errorf("%w: executable %q was not found on PATH", errProgramNotFound, exe)
 	}
 	check.Path = path
 	return check, nil
@@ -105,15 +123,54 @@ func LocalSessionPrereqs(cfg *config.Config, agent string) error {
 	return nil
 }
 
-// ProgramError renders the actionable user-facing error for a missing agent.
+// ProgramError renders the actionable user-facing error for an agent that
+// failed its preflight check. It classifies the cause so the lead line points
+// at the real fix: a missing binary says "not installed or not on PATH" (fix:
+// install), a present-but-non-executable one says "found but not executable"
+// with a chmod hint (fix: chmod +x, NOT reinstall), and anything else reports
+// the actual error rather than a misleading not-installed message (#2010).
 func ProgramError(agent, command string, cause error) error {
 	name := agentDisplayName(agent)
-	if isSupportedAgent(agent) {
-		return fmt.Errorf("%s is not installed or not on PATH (resolved command: %q). Install %s, choose another agent, or set program_overrides.%s in ~/.agent-factory/config.toml. Details: %v",
-			name, command, name, agent, cause)
+	supported := isSupportedAgent(agent)
+
+	// subject and remediation are the supported/unsupported dimension, which is
+	// orthogonal to the failure kind below.
+	subject := name
+	remediation := fmt.Sprintf("set program_overrides.%s in ~/.agent-factory/config.toml", agent)
+	if !supported {
+		subject = fmt.Sprintf("program %q", agent)
+		remediation = "fix the command in config"
 	}
-	return fmt.Errorf("program %q is not installed or not on PATH (resolved command: %q). Install it, choose another agent, or fix the command in config. Details: %v",
-		agent, command, cause)
+
+	switch {
+	case isNotExecutable(cause):
+		return fmt.Errorf("%s was found but is not executable (resolved command: %q). Make it executable (chmod +x), choose another agent, or %s. Details: %v",
+			subject, command, remediation, cause)
+	case isNotFound(cause):
+		installWord := name
+		if !supported {
+			installWord = "it"
+		}
+		return fmt.Errorf("%s is not installed or not on PATH (resolved command: %q). Install %s, choose another agent, or %s. Details: %v",
+			subject, command, installWord, remediation, cause)
+	default:
+		return fmt.Errorf("%s could not be started (resolved command: %q). Choose another agent, or %s. Details: %v",
+			subject, command, remediation, cause)
+	}
+}
+
+// isNotExecutable reports whether cause is a present-but-unrunnable binary — a
+// permission problem that chmod, not a reinstall, fixes.
+func isNotExecutable(cause error) bool {
+	return errors.Is(cause, errProgramNotExecutable) || errors.Is(cause, fs.ErrPermission)
+}
+
+// isNotFound reports whether cause is a genuinely-absent binary, whether from a
+// resolved path that does not exist or a bare name absent from PATH.
+func isNotFound(cause error) bool {
+	return errors.Is(cause, errProgramNotFound) ||
+		errors.Is(cause, fs.ErrNotExist) ||
+		errors.Is(cause, exec.ErrNotFound)
 }
 
 func agentDisplayName(agent string) string {

--- a/preflight/preflight_test.go
+++ b/preflight/preflight_test.go
@@ -1,7 +1,6 @@
 package preflight
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -75,10 +74,64 @@ func TestCheckCommandRejectsNonExecutablePath(t *testing.T) {
 }
 
 func TestProgramErrorDisplaysAmp(t *testing.T) {
-	err := ProgramError(tmux.ProgramAmp, "amp", errors.New("missing"))
+	err := ProgramError(tmux.ProgramAmp, "amp", errProgramNotFound)
 	if !strings.Contains(err.Error(), "Amp is not installed") {
 		t.Fatalf("ProgramError() = %q, want Amp display name", err.Error())
 	}
+}
+
+// TestProgramErrorClassifiesNotExecutable is the #2010 regression lock: a
+// present-but-non-executable binary is a permission problem, and the error must
+// point the user at chmod, NOT at reinstalling. Collapsing this into "not
+// installed or not on PATH" sends them to fix the wrong thing.
+func TestProgramErrorClassifiesNotExecutable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "fake-agent")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	_, cause := CheckCommand(path)
+	if cause == nil {
+		t.Fatal("CheckCommand should reject a non-executable path")
+	}
+	msg := ProgramError(tmux.ProgramClaude, path, cause).Error()
+	if strings.Contains(msg, "not installed") {
+		t.Errorf("ProgramError() = %q, must NOT say \"not installed\" for a permission error", msg)
+	}
+	if !strings.Contains(msg, "not executable") {
+		t.Errorf("ProgramError() = %q, want a \"not executable\" message", msg)
+	}
+	if !strings.Contains(msg, "chmod") {
+		t.Errorf("ProgramError() = %q, want the chmod remediation", msg)
+	}
+}
+
+// TestProgramErrorClassifiesMissing pins the other half: a genuinely-absent
+// binary still reports "not installed or not on PATH" (via both a resolved path
+// that does not exist and a bare name absent from PATH).
+func TestProgramErrorClassifiesMissing(t *testing.T) {
+	t.Run("absolute path does not exist", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "definitely-absent")
+		_, cause := CheckCommand(path)
+		if cause == nil {
+			t.Fatal("CheckCommand should reject an absent path")
+		}
+		msg := ProgramError(tmux.ProgramClaude, path, cause).Error()
+		if !strings.Contains(msg, "not installed or not on PATH") {
+			t.Errorf("ProgramError() = %q, want the not-installed message", msg)
+		}
+	})
+
+	t.Run("bare name not on PATH", func(t *testing.T) {
+		t.Setenv("PATH", t.TempDir())
+		_, cause := CheckCommand("definitely-absent-agent")
+		if cause == nil {
+			t.Fatal("CheckCommand should reject a bare name absent from PATH")
+		}
+		msg := ProgramError(tmux.ProgramClaude, "definitely-absent-agent", cause).Error()
+		if !strings.Contains(msg, "not installed or not on PATH") {
+			t.Errorf("ProgramError() = %q, want the not-installed message", msg)
+		}
+	})
 }
 
 // TestProgramErrorDisplaysOpencode pins opencode's display name to the LOWERCASE
@@ -93,7 +146,7 @@ func TestProgramErrorDisplaysAmp(t *testing.T) {
 // `program "opencode" is not installed` fallback, which offers no fix — so this
 // doubles as the first-class-agent lock.
 func TestProgramErrorDisplaysOpencode(t *testing.T) {
-	err := ProgramError(tmux.ProgramOpencode, "opencode", errors.New("missing"))
+	err := ProgramError(tmux.ProgramOpencode, "opencode", errProgramNotFound)
 
 	if !strings.Contains(err.Error(), "opencode is not installed") {
 		t.Fatalf("ProgramError() = %q, want lowercase opencode display name", err.Error())

--- a/session/weburl.go
+++ b/session/weburl.go
@@ -63,6 +63,11 @@ func IsLoopbackWebTarget(rawURL string) bool {
 
 // isLoopbackHost reports whether host is the loopback name or a loopback IP.
 func isLoopbackHost(host string) bool {
+	// A single trailing dot is the DNS root label: "localhost." and "127.0.0.1."
+	// are the rooted-FQDN forms of the same loopback host and resolve identically,
+	// so strip one before comparing (#2004). Only one dot is stripped — a doubled
+	// dot ("localhost..") is malformed and stays non-loopback, failing closed.
+	host = strings.TrimSuffix(host, ".")
 	if host == "" {
 		return false
 	}

--- a/session/weburl_test.go
+++ b/session/weburl_test.go
@@ -58,6 +58,10 @@ func TestIsLoopbackWebTarget(t *testing.T) {
 		"http://127.0.0.1:5173",
 		"http://127.0.0.53/x",
 		"http://[::1]:8080",
+		// Rooted (trailing-dot) FQDN forms of the same loopback hosts — a
+		// browser treats "localhost." exactly as "localhost" (#2004).
+		"http://localhost.:3000",
+		"http://127.0.0.1.:5173",
 	}
 	for _, u := range loopback {
 		if !IsLoopbackWebTarget(u) {
@@ -69,10 +73,41 @@ func TestIsLoopbackWebTarget(t *testing.T) {
 		"http://192.168.1.10:3000",
 		"http://10.0.0.1/x",
 		"not a url",
+		// A rooted external name is still external — stripping the root dot
+		// must not turn a real remote host into loopback.
+		"https://example.com.",
 	}
 	for _, u := range external {
 		if IsLoopbackWebTarget(u) {
 			t.Errorf("IsLoopbackWebTarget(%q) = true, want false", u)
+		}
+	}
+}
+
+// TestIsLoopbackHostTrailingDot pins the loopback classifier directly on the
+// rooted-FQDN forms (#2004): "localhost." and "127.0.0.1." are the same host as
+// their unrooted forms and are loopback, while a doubled dot or a bare dot is
+// malformed and must fail closed as non-loopback.
+func TestIsLoopbackHostTrailingDot(t *testing.T) {
+	cases := []struct {
+		host string
+		want bool
+	}{
+		{"localhost", true},
+		{"localhost.", true},
+		{"LocalHost.", true},
+		{"127.0.0.1", true},
+		{"127.0.0.1.", true},
+		{"::1", true},
+		{"example.com", false},
+		{"example.com.", false},
+		{"", false},
+		{".", false},
+		{"localhost..", false},
+	}
+	for _, c := range cases {
+		if got := isLoopbackHost(c.host); got != c.want {
+			t.Errorf("isLoopbackHost(%q) = %v, want %v", c.host, got, c.want)
 		}
 	}
 }


### PR DESCRIPTION
Three small, independent "input handled wrong, no honest signal" fixes — one commit each, separately testable. All fail-first tests were confirmed red before the fix.

### #2004 — `localhost.` misclassified as non-loopback
`isLoopbackHost` didn't recognize the rooted-FQDN form, so a remote web tab targeting `localhost.` (or `127.0.0.1.`) was treated as external and never proxied. Strip a single trailing dot before the name/IP comparison. Only one dot is stripped, so `localhost..` fails closed and a rooted external name (`example.com.`) stays external — no SSRF widening.

### #2009 — `limit_retry_interval` whitespace → silent default
A hand-edited `config.toml` with a stray space (`limit_retry_interval = " 30s "`) was rejected by `time.ParseDuration` and silently replaced with the 30m default — the user's intended cadence vanished with no visible signal (same class as the #1899 whitespace-target bug). `TrimSpace` before parsing so an obvious typo is honored; `LimitRetryIntervalDuration` trims too as defense-in-depth. A genuinely-unparseable non-empty value still **warns** (naming the value + key) rather than defaulting silently — the honesty half. The `af config set` gate stays strict (documented): an explicit CLI value that doesn't parse is reported at type-time, which is honest input validation, not a silent default.

### #2010 — agent-start failure always said "not installed"
`ProgramError` led with "is not installed or not on PATH" for every preflight failure, including a present-but-non-executable binary whose real fix is `chmod +x` — the chmod hint was buried in trailing "Details:". This is the exec error-classification class (`reference_exec_start_vs_succeed`). `CheckCommand` now wraps failures in typed sentinels and `ProgramError` classifies the cause (matching `fs.ErrNotExist`/`exec.ErrNotFound` for missing, `fs.ErrPermission` for permission): missing → "not installed", non-executable → "found but not executable" + chmod, anything else → the actual error. No start failure is collapsed into "not installed" anymore.

## Testing
- `go build ./...`, `gofmt`, `go vet`, `golangci-lint --fast`, `deadcode` all clean on touched packages.
- `go test ./config/ ./preflight/ ./configagent/ ./doctor/` green; `session` loopback/webtab/backend-hook subset green.
- No production code string-matches on the error phrasing changed in #2010 (verified by grep) — safe cross-file.

## Gate
Draft on purpose — codex is out of credits; leaving open for a fresh Claude review before merge. Host-safe unit tests only; the real AF home was not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)