### PR TITLE
fix: two 'cleanup misses what a later step created' resource leaks (#2007, #2008)

### DIFF
--- a/daemon/ghost_tab_tmux_test.go
+++ b/daemon/ghost_tab_tmux_test.go
@@ -1,0 +1,91 @@
+package daemon
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// createRealTmuxSession starts a detached session named `name` on the test's
+// private tmux server. Its pane runs a plain sleeper, whose default SIGHUP
+// disposition is to terminate — so `tmux kill-session` reaps it cleanly and a
+// killed session leaves no survivor, exactly the outcome ghostCleanup must
+// achieve for EVERY tab.
+func createRealTmuxSession(t *testing.T, name string) {
+	t.Helper()
+	out, err := exec.Command("tmux", "new-session", "-d", "-s", name, "sleep 300").CombinedOutput()
+	require.NoError(t, err, "tmux new-session %q: %s", name, out)
+}
+
+// liveTmuxSessions returns the set of session names on the test's private tmux
+// server. A server with no sessions left (tmux exits non-zero with "no server
+// running") is reported as the empty set, not an error.
+func liveTmuxSessions(t *testing.T) map[string]bool {
+	t.Helper()
+	out, err := exec.Command("tmux", "list-sessions", "-F", "#{session_name}").CombinedOutput()
+	live := map[string]bool{}
+	if err != nil {
+		return live // no server / no sessions → nothing alive
+	}
+	for _, name := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if name = strings.TrimSpace(name); name != "" {
+			live[name] = true
+		}
+	}
+	return live
+}
+
+// TestGhostCleanup_KillsEveryTabTmux is the #2007 regression. Killing a ghost
+// session — one with no live Instance in memory, only its persisted record —
+// must reap the tmux sessions of its shell and process tabs, not just the legacy
+// agent-tab name. Before the fix, ghostCleanup killed only data.TmuxName, so a
+// multi-tab ghost's `<agent>__shell` and `<agent>__btop` tmux sessions leaked
+// onto the server with no cleanup path short of `af reset`.
+//
+// It queries the test's PRIVATE tmux server (testguard.IsolateTmux), so nothing
+// it creates can touch or leak onto a real one.
+func TestGhostCleanup_KillsEveryTabTmux(t *testing.T) {
+	testguard.IsolateTmux(t) // a private tmux server, killed when the test ends
+
+	const (
+		agentName = "af_ghost2007_agent"
+		shellName = "af_ghost2007_agent__shell"
+		btopName  = "af_ghost2007_agent__btop"
+	)
+	all := []string{agentName, shellName, btopName}
+	for _, name := range all {
+		createRealTmuxSession(t, name)
+	}
+	// Precondition: all three sessions are live before the ghost is cleaned up.
+	before := liveTmuxSessions(t)
+	for _, name := range all {
+		require.Truef(t, before[name], "precondition: %q should be live before ghostCleanup", name)
+	}
+
+	// A ghost record in the post-#953 shape: the agent tab is in the legacy
+	// TmuxName field AND all three tabs are in the persisted Tabs list. The
+	// Worktree is left empty so ghostCleanupWorktree is a no-op and only the tmux
+	// teardown under test runs.
+	data := &session.InstanceData{
+		Title:    "ghost2007",
+		Program:  "claude",
+		TmuxName: agentName,
+		Tabs: []session.TabData{
+			{Name: "agent", Kind: session.TabKindAgent, TmuxName: agentName},
+			{Name: "shell", Kind: session.TabKindShell, TmuxName: shellName},
+			{Name: "btop", Kind: session.TabKindProcess, TmuxName: btopName},
+		},
+	}
+
+	require.NoError(t, ghostCleanup(data, "ghost2007"))
+
+	after := liveTmuxSessions(t)
+	require.Falsef(t, after[shellName], "#2007: shell tab tmux session %q leaked after ghost kill", shellName)
+	require.Falsef(t, after[btopName], "#2007: process tab tmux session %q leaked after ghost kill", btopName)
+	require.Falsef(t, after[agentName], "agent tab tmux session %q should also be gone", agentName)
+}

--- a/daemon/manager_persist.go
+++ b/daemon/manager_persist.go
@@ -320,6 +320,32 @@ var ghostCleanupWorktree = func(data *session.InstanceData, title string) (git.C
 	return state, cleanupErr
 }
 
+// ghostTmuxNames returns the deduped, ordered set of tmux session names a ghost
+// record owns: the legacy agent-tab name (data.TmuxName) first, then each tab's
+// name in persisted order. Empty names are skipped. A post-#953 record repeats
+// the agent tab in BOTH data.TmuxName and data.Tabs, so the dedupe collapses that
+// to a single kill; a pre-#953 record has no Tabs and yields just data.TmuxName,
+// keeping the legacy path byte-identical.
+func ghostTmuxNames(data *session.InstanceData) []string {
+	names := make([]string, 0, len(data.Tabs)+1)
+	seen := make(map[string]struct{}, len(data.Tabs)+1)
+	add := func(name string) {
+		if name == "" {
+			return
+		}
+		if _, ok := seen[name]; ok {
+			return
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	add(data.TmuxName)
+	for _, tab := range data.Tabs {
+		add(tab.TmuxName)
+	}
+	return names
+}
+
 // ghostCleanup runs best-effort teardown of a ghost session's external
 // resources. Tmux teardown is independent of worktree state (#516/#549): a
 // ghost record can have an empty worktree path while a tmux session with the
@@ -333,10 +359,23 @@ var ghostCleanupWorktree = func(data *session.InstanceData, title string) (git.C
 // workspace of a session that might still be running. Found by auditing every
 // caller of the bounded teardown rather than by the review itself.
 func ghostCleanup(data *session.InstanceData, title string) error {
-	if data.TmuxName != "" {
-		state, killErr := ghostKillTmuxByName(data.TmuxName)
+	// Kill EVERY tmux session this ghost owns, not just the agent tab. The live
+	// teardown path (Instance.teardownTabs) closes every tab's tmux; the ghost
+	// path has no live Instance, so it must reconstruct the same set from the
+	// persisted record. Before #2007 it killed only the legacy data.TmuxName (the
+	// agent tab), so a multi-tab ghost's shell (`<agent>__shell`) and process
+	// (`<agent>__btop`) tmux sessions leaked with no cleanup short of `af reset` —
+	// the tab list persisted by #953 was never consulted here.
+	//
+	// The per-tab kills gate the worktree delete the same way the agent tab always
+	// has (#1917): a tmux we could not confirm dead (state != Known) may still have
+	// a pane writing into the workspace, so we stop before touching it and keep the
+	// record intact for a retry. Tmux still goes FIRST for the #802 reason (a live
+	// agent racing git's recursive delete leaks a half-deleted directory).
+	for _, name := range ghostTmuxNames(data) {
+		state, killErr := ghostKillTmuxByName(name)
 		if killErr != nil {
-			log.WarningLog.Printf("ghost session %q: tmux cleanup failed: %v", title, killErr)
+			log.WarningLog.Printf("ghost session %q: tmux cleanup failed for %q: %v", title, name, killErr)
 		}
 		if state != tmux.PaneStateKnown {
 			return fmt.Errorf("ghost session %q: %w: leaving its workspace and record intact: %v",

--- a/session/backend_docker.go
+++ b/session/backend_docker.go
@@ -99,6 +99,21 @@ func SetDockerSelfBinaryForTest(path string) func() {
 	return func() { dockerSelfBinary = prev }
 }
 
+// dockerExec runs `docker <args...>` and returns its combined output. It is a
+// package-level seam (mirroring dockerSelfBinary / lookPath) so tests can drive
+// the runtime against a fake docker CLI — including the create-then-fail path
+// (#2008) — without a real daemon on the box. Production wraps exec.CommandContext.
+var dockerExec = func(ctx context.Context, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, "docker", args...).CombinedOutput()
+}
+
+// SetDockerExecForTest overrides the docker CLI runner and returns a restore func.
+func SetDockerExecForTest(f func(ctx context.Context, args ...string) ([]byte, error)) func() {
+	prev := dockerExec
+	dockerExec = f
+	return func() { dockerExec = prev }
+}
+
 // dockerBanner mirrors daemon.AgentServerInfo field-for-field (the JSON the
 // `af agent-server` prints on startup). It is duplicated here rather than
 // imported because daemon imports session (a cycle); the shared contract is the
@@ -236,6 +251,18 @@ func (p *dockerProvisioner) runContainer() error {
 
 	out, err := p.docker(dockerProvisionStepTimeout, args...)
 	if err != nil {
+		// `docker run -d` can CREATE the container and print its id to stdout, then
+		// still exit non-zero when a later start step fails — a run_arg naming a
+		// nonexistent device/volume/network, `--gpus all` on a GPU-less host. The
+		// container is then left behind in `created` state. Capture the id off the
+		// combined output even on this error path and store it so the
+		// provision-failure reap in Provision (guarded on p.containerID != "") removes
+		// it instead of leaking it (#2008). This is the exec started-vs-succeeded
+		// rule: gate cleanup on the container having been CREATED, not on `docker run`
+		// exiting zero.
+		if id := parseCreatedContainerID(out); id != "" {
+			p.containerID = id
+		}
 		return fmt.Errorf("backend=docker: `docker run` failed for image %q: %s: %w", p.image, strings.TrimSpace(string(out)), err)
 	}
 	id := strings.TrimSpace(string(out))
@@ -403,7 +430,7 @@ func (p *dockerProvisioner) reap() error {
 func (p *dockerProvisioner) docker(timeout time.Duration, args ...string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	return exec.CommandContext(ctx, "docker", args...).CombinedOutput()
+	return dockerExec(ctx, args...)
 }
 
 // execSh runs a `sh -c <script>` inside the container.
@@ -416,6 +443,37 @@ func (p *dockerProvisioner) shortID() string {
 		return p.containerID[:12]
 	}
 	return p.containerID
+}
+
+// parseCreatedContainerID extracts the container id `docker run -d` prints to
+// stdout the moment it CREATES the container — even when a later start step fails
+// and docker exits non-zero (a run_arg naming a nonexistent device/volume/network,
+// `--gpus all` on a GPU-less host). docker writes the 64-char id to stdout and the
+// start error to stderr, and CombinedOutput interleaves them — so a bare TrimSpace
+// of the whole blob can't be trusted on the error path, but a line that is nothing
+// but hex digits is unambiguously the id (docker's error lines carry words, spaces
+// and colons). Returns "" when no such line is present — docker failed before
+// creating anything — leaving containerID empty so nothing is reaped.
+func parseCreatedContainerID(out []byte) string {
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if len(line) >= 12 && isHexString(line) {
+			return line
+		}
+	}
+	return ""
+}
+
+// isHexString reports whether every rune of s is a hex digit. A full docker
+// container id is 64 lowercase hex chars; uppercase is accepted too so the match
+// never turns on docker's casing.
+func isHexString(s string) bool {
+	for _, r := range s {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') && (r < 'A' || r > 'F') {
+			return false
+		}
+	}
+	return true
 }
 
 // parseDockerPort extracts the host port from `docker port` output. The output is

--- a/session/backend_docker_test.go
+++ b/session/backend_docker_test.go
@@ -1,0 +1,115 @@
+package session
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createThenFailRunOutput is the combined output `docker run -d` produces when it
+// CREATES the container (prints its 64-char id to stdout) but the subsequent start
+// step fails and docker exits non-zero — e.g. a run_arg names a device that does
+// not exist. CombinedOutput interleaves the stdout id and the stderr error.
+const dockerCreatedID = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+
+func createThenFailRunOutput() []byte {
+	return []byte(dockerCreatedID +
+		"\ndocker: Error response from daemon: error gathering device information while adding custom device \"/dev/nope\": no such file or directory.\n")
+}
+
+// sawDockerRm reports whether the recorded docker invocations include a
+// `rm -f <id>` — the reap call that removes a container so it does not leak.
+func sawDockerRm(calls [][]string, id string) bool {
+	for _, c := range calls {
+		if len(c) == 3 && c[0] == "rm" && c[1] == "-f" && c[2] == id {
+			return true
+		}
+	}
+	return false
+}
+
+// TestDockerProvision_CreateThenFail_ReapsContainer is the #2008 regression:
+// `docker run -d` creates the container but fails to start it, so its id is on
+// stdout while the command exits non-zero. Provisioning must capture that id and
+// reap the container (`docker rm -f <id>`) instead of leaving it orphaned in
+// `created` state.
+//
+// It drives the runtime against a FAKE docker CLI (SetDockerExecForTest), so no
+// real docker daemon on the box is touched.
+func TestDockerProvision_CreateThenFail_ReapsContainer(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoRoot := initTempGitRepo(t)
+	writeInRepoConfig(t, repoRoot, map[string]any{"backend": "docker", "docker": map[string]any{"image": "img:latest"}})
+
+	// Cheap hermetic preconditions so Provision reaches runContainer: docker "found"
+	// on PATH and a stub `af` binary to copy in. Neither is executed under the fake.
+	defer SetLookPathForTest(func(string) (string, error) { return "/usr/bin/docker", nil })()
+	defer SetDockerSelfBinaryForTest(filepath.Join(t.TempDir(), "af"))()
+
+	var calls [][]string
+	defer SetDockerExecForTest(func(_ context.Context, args ...string) ([]byte, error) {
+		calls = append(calls, append([]string(nil), args...))
+		switch args[0] {
+		case "run":
+			// Container CREATED (id on stdout) but the start step fails → non-zero exit.
+			return createThenFailRunOutput(), fmt.Errorf("exit status 125")
+		case "rm":
+			return []byte(dockerCreatedID + "\n"), nil
+		default:
+			return nil, fmt.Errorf("unexpected docker call in this test: %v", args)
+		}
+	})()
+
+	_, err := dockerRuntime{}.Provision(ProvisionSpec{RepoRoot: repoRoot, Title: "leaky", CloneURL: "file:///x"})
+	require.Error(t, err, "a `docker run` that creates-then-fails must surface an error")
+
+	require.Truef(t, sawDockerRm(calls, dockerCreatedID),
+		"#2008: created-then-failed container %s was not reaped (`docker rm -f` never issued); docker calls=%v",
+		dockerCreatedID, calls)
+}
+
+// TestRunContainer_CapturesCreatedIDOnError pins the fix at its source: even when
+// `docker run` returns an error, runContainer must extract the created container's
+// id from the (combined) output and store it, so the provision-failure reap —
+// guarded on p.containerID != "" — can remove it. Before the fix p.containerID
+// stayed empty on the error path.
+func TestRunContainer_CapturesCreatedIDOnError(t *testing.T) {
+	defer SetDockerExecForTest(func(_ context.Context, args ...string) ([]byte, error) {
+		return createThenFailRunOutput(), fmt.Errorf("exit status 125")
+	})()
+
+	p := &dockerProvisioner{image: "img:latest", spec: ProvisionSpec{Title: "leaky"}}
+	err := p.runContainer()
+
+	require.Error(t, err)
+	assert.Equal(t, dockerCreatedID, p.containerID,
+		"created-then-failed container id must be captured so the failed provision can reap it")
+}
+
+// TestParseCreatedContainerID covers the extraction: a create-then-fail blob
+// yields the id regardless of line order, a clean success line yields it, and
+// output with no container id (docker failed before creating anything) yields ""
+// so nothing bogus is reaped.
+func TestParseCreatedContainerID(t *testing.T) {
+	cases := []struct {
+		name string
+		out  string
+		want string
+	}{
+		{"created then fail (id then error)", dockerCreatedID + "\ndocker: Error response from daemon: bad --device\n", dockerCreatedID},
+		{"created then fail (error then id)", "docker: Error response from daemon: bad --device\n" + dockerCreatedID + "\n", dockerCreatedID},
+		{"clean success", dockerCreatedID + "\n", dockerCreatedID},
+		{"no id — failed before create", "docker: Error response from daemon: invalid reference format\n", ""},
+		{"empty", "", ""},
+		{"image digest line is not a bare id", "sha256:" + dockerCreatedID + "\ndocker: pull error\n", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, parseCreatedContainerID([]byte(tc.out)))
+		})
+	}
+}


### PR DESCRIPTION
Two independent resource leaks of the same class — teardown reaps only what an
*earlier* step created and misses what a *later* step added. One atomic commit
each; disjoint packages.

## #2007 — ghost-session kill leaks per-tab tmux (`daemon/manager_persist.go`)

`ghostCleanup` (the no-live-Instance teardown path) killed only the legacy
agent-tab tmux name (`data.TmuxName`) and ignored the per-tab `TmuxName` fields
persisted in `data.Tabs` since #953. A ghost session with a shell tab
(`<agent>__shell`) and/or a process tab (`<agent>__btop`) therefore leaked those
tmux sessions with no cleanup path short of `af reset`.

**Fix:** mirror the live teardown path (`Instance.teardownTabs` closes every
tab's tmux) — enumerate the deduped set of tmux names the ghost record owns
(agent tab + every per-tab name) via `ghostTmuxNames` and kill each. The #1917
safety gate is preserved (a tmux that can't be confirmed dead still blocks the
worktree delete and retains the record), and tmux teardown still precedes the
worktree delete (#802). The dedupe keeps a post-#953 record — which lists the
agent tab in *both* `TmuxName` and `Tabs` — to a single kill, so the legacy path
is byte-identical.

**Test:** `TestGhostCleanup_KillsEveryTabTmux` creates the agent, shell and
process tmux sessions on a **private** tmux server (`testguard.IsolateTmux`),
runs `ghostCleanup`, and asserts none survive. Verified **fail-first** in the
container harness (shell/process sessions leak without the fix). All existing
`Ghost*` tests still pass.

Fixes #2007

## #2008 — docker backend leaks containers (`session/backend_docker.go`)

`docker run -d` can **create** a container (printing its id to stdout) yet still
exit non-zero when a later start step fails — a `run_args` entry naming a
nonexistent device/volume/network, `--gpus all` on a GPU-less host. `runContainer`
returned on that error without ever extracting the id, so `p.containerID` stayed
empty and the provision-failure reap (guarded on `p.containerID != ""`) skipped
it — the container leaked in `created` state.

**Fix:** capture the id off the combined output on the error path too
(`parseCreatedContainerID` scans for the bare hex id line), so the existing
`docker rm -f <id>` reap removes it. The exec started-vs-succeeded rule: gate
cleanup on the container having been **created**, not on the command exiting zero.

**Test:** adds a `dockerExec` package seam so the create-then-fail path is
unit-tested against a **fake** docker CLI — no real docker on the box is touched.
`TestDockerProvision_CreateThenFail_ReapsContainer` asserts `docker rm -f <id>`
is issued; verified **fail-first** (no `rm` without the fix). Plus a focused
`runContainer` capture test and a `parseCreatedContainerID` table test.

Fixes #2008

## Gate
- `go build ./...`, `gofmt -l`, `golangci-lint run --timeout=3m --fast`,
  `deadcode -test ./...`, and file-length lint all clean.
- #2007 daemon test run **in the container** (`make test-container`); #2008
  session tests on host (fake exec, no real docker).
- Left as **draft** pending a fresh review before merge.

— Captain Claude