### PR TITLE
fix(daemon): resolve ABBA deadlock between DeliverPrompt and resumeFromLimit (#2006)

### DIFF
--- a/daemon/deadlock_2006_test.go
+++ b/daemon/deadlock_2006_test.go
@@ -1,0 +1,126 @@
+package daemon
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// TestDeliverPromptResumeFromLimit_NoInvertedLockDeadlock is the #2006 regression.
+//
+// DeliverPrompt takes the per-target lock and then the per-session op lock (the op
+// lock is acquired inside SendPrompt), i.e. target-before-op. resumeFromLimit used
+// to take those same two locks in the OPPOSITE order: the op lock first (TryLock),
+// then the target lock (inside resumeFromLimitLocked). A manual send-prompt that
+// overlapped a resume of the SAME session therefore formed an ABBA deadlock — and
+// the auto-resume scheduler drives resumeFromLimitLocked automatically whenever
+// limit_auto_resume is on, so any such daemon could wedge indefinitely.
+//
+// The interleaving is forced deterministically through two no-op production seams:
+// a resumeFromLimit goroutine is pinned holding its FIRST lock, a DeliverPrompt
+// goroutine is then let take the target lock, and only then is the resume released
+// to go for its SECOND lock. Under the inverted order the two goroutines block on
+// each other's second lock forever, the guard timeout fires, and the test FAILS
+// (rather than hanging CI). Under the canonical target-before-op order both paths
+// acquire in the same order, so both goroutines complete — the asserted outcome.
+func TestDeliverPromptResumeFromLimit_NoInvertedLockDeadlock(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+
+	// alive=true → a live stall: resumeFromLimit re-delivers the stored prompt with
+	// no respawn, so the whole path runs against the fake backend. The session must
+	// be LimitReached or resumeFromLimit bails out before it acquires any lock.
+	backend := &limitResumeBackend{FakeBackend: session.NewFakeBackend(), alive: true}
+	inst := registerStarted(t, manager, repoID, repoPath, "shared", backend, true, session.Running)
+	inst.Prompt = "resume the work"
+	inst.SetLimitReached(time.Now())
+
+	resumeGotFirstLock := make(chan struct{}, 1)
+	deliverGotTargetLock := make(chan struct{}, 1)
+	releaseResume := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseResume) }) }
+
+	// The resume goroutine signals once it holds its first lock, then parks here so
+	// the test can arrange the crossing before it reaches for the second.
+	testHookResumeAfterFirstLock = func() {
+		select {
+		case resumeGotFirstLock <- struct{}{}:
+		default:
+		}
+		<-releaseResume
+	}
+	// The delivery goroutine signals once it holds the target lock. Non-blocking so
+	// it never stalls the real path, and buffered so a late fire after the test has
+	// stopped listening is harmless.
+	testHookDeliverAfterTargetLock = func() {
+		select {
+		case deliverGotTargetLock <- struct{}{}:
+		default:
+		}
+	}
+	t.Cleanup(func() {
+		release() // never strand a parked resume goroutine on a failure path
+		testHookResumeAfterFirstLock = func() {}
+		testHookDeliverAfterTargetLock = func() {}
+	})
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	var resumeErr, deliverErr error
+
+	// Goroutine A: resumeFromLimit — grabs its first lock and parks in the seam.
+	go func() {
+		defer wg.Done()
+		resumeErr = manager.resumeFromLimit(ResumeFromLimitRequest{Title: "shared", RepoID: repoID})
+	}()
+
+	// Do not start the delivery until the resume goroutine is provably holding its
+	// first lock, so the two paths are guaranteed to contend on the second.
+	select {
+	case <-resumeGotFirstLock:
+	case <-time.After(5 * time.Second):
+		release()
+		t.Fatal("resumeFromLimit never reached its first lock; test harness is broken, not the code under test")
+	}
+
+	// Goroutine B: DeliverPrompt — a manual send-prompt to the SAME session.
+	go func() {
+		defer wg.Done()
+		_, deliverErr = manager.DeliverPrompt(DeliverPromptRequest{
+			Title:    "shared",
+			RepoPath: repoPath,
+			Prompt:   "manual send",
+		})
+	}()
+
+	// Under the inverted order the delivery takes the free target lock immediately
+	// and heads for the op lock the resume holds; this fires. Under the fixed order
+	// it blocks on the target lock the resume holds and never fires, so this wait
+	// falls through after the deadline — that is expected and fine.
+	select {
+	case <-deliverGotTargetLock:
+	case <-time.After(3 * time.Second):
+	}
+
+	// Release the resume goroutine to reach for its SECOND lock. This is the moment
+	// the ABBA closes under the inverted order.
+	release()
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+
+	select {
+	case <-done:
+		if resumeErr != nil {
+			t.Fatalf("resumeFromLimit returned %v, want nil", resumeErr)
+		}
+		if deliverErr != nil {
+			t.Fatalf("DeliverPrompt returned %v, want nil", deliverErr)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("deadlock (#2006): DeliverPrompt and resumeFromLimit did not both complete — " +
+			"the two paths acquire the per-target and per-session op locks in inverted order")
+	}
+}

--- a/daemon/delivery.go
+++ b/daemon/delivery.go
@@ -27,6 +27,14 @@ var (
 	targetDeliverPoll = 100 * time.Millisecond
 )
 
+// testHookDeliverAfterTargetLock fires in DeliverPrompt immediately after the
+// per-target lock is acquired, before the op lock is taken (inside SendPrompt).
+// No-op in production; the #2006 ABBA regression test substitutes a signal so it
+// can prove DeliverPrompt holds the target lock before releasing the resume
+// goroutine — the ordering that used to deadlock. Mirrors the existing
+// testHookPollBeforePublish seam.
+var testHookDeliverAfterTargetLock = func() {}
+
 // StatusDeferredAttached is the delivery status returned when an automated task
 // delivery (DeferWhileAttached) targets a session a TUI is attached full-screen
 // to (#1586). It extends the "started"/"sent" status vocabulary. It is
@@ -78,6 +86,7 @@ func (m *Manager) DeliverPrompt(req DeliverPromptRequest) (string, error) {
 
 	unlock := m.lockTarget(repo.ID, req.Title)
 	defer unlock()
+	testHookDeliverAfterTargetLock()
 
 	exists, deleting, liveness, err := m.targetSessionState(repo.ID, req.Title)
 	if err != nil {

--- a/daemon/limit.go
+++ b/daemon/limit.go
@@ -214,10 +214,19 @@ func (s *controlServer) ResumeFromLimit(req ResumeFromLimitRequest, resp *Resume
 // respawn arm re-applies the block for that reason — Respawn ends in ConfirmLive,
 // which would otherwise report a session as resumed before its prompt existed.
 //
-// Runs under the per-(repo, title) target lock (like DeliverPrompt) and re-
-// verifies the limit state under it, so it never races a self-recovery, a kill,
-// or a concurrent resume. Rejects a tombstoned / reserved-root session, mirroring
-// the lostrestore guards.
+// Takes the per-(repo, title) target lock and then the per-session op lock — the
+// same target-before-op order DeliverPrompt uses (#2006) — and re-verifies the
+// limit state under them, so it never races a self-recovery, a kill, a concurrent
+// resume, or an overlapping send-prompt. Rejects a tombstoned / reserved-root
+// session, mirroring the lostrestore guards.
+//
+// testHookResumeAfterFirstLock fires in resumeFromLimit immediately after the
+// FIRST of its two locks is acquired, before the second. No-op in production; the
+// #2006 ABBA regression test substitutes a barrier so it can pin one resume
+// goroutine holding its first lock and force the cross-lock interleaving that the
+// inverted order deadlocked on.
+var testHookResumeAfterFirstLock = func() {}
+
 func (m *Manager) resumeFromLimit(req ResumeFromLimitRequest) error {
 	instance, repoID, _, err := m.findSession(req.Title, req.RepoID)
 	if err != nil {
@@ -238,6 +247,17 @@ func (m *Manager) resumeFromLimit(req ResumeFromLimitRequest) error {
 	}
 	m.mu.Unlock()
 
+	// Canonical lock order is target-before-op (#2006). DeliverPrompt holds the
+	// per-target lock across the op lock it acquires inside SendPrompt, so every
+	// path that needs both must take the target lock FIRST. Taking the op lock
+	// first here — as this path used to — inverted that order, so a manual resume
+	// overlapping a send-prompt (or the auto-resume scheduler) to the same session
+	// deadlocked: each held one lock and blocked on the other. The op lock is still
+	// only TryLock'd, so a resume never blocks behind a kill teardown that holds it.
+	unlock := m.lockTarget(repoID, instance.Title)
+	defer unlock()
+	testHookResumeAfterFirstLock()
+
 	opLock := m.opLockFor(key)
 	if !opLock.TryLock() {
 		return nil
@@ -255,14 +275,14 @@ func (m *Manager) resumeFromLimit(req ResumeFromLimitRequest) error {
 	return m.resumeFromLimitLocked(repoID, key, instance, req.Title)
 }
 
-// resumeFromLimitLocked performs the shared limit-resume action. The caller
-// must hold the per-session op lock for key, so a manual retry cannot interleave
-// with kill teardown and auto-resume can reuse the body after its own op-lock
-// guard.
+// resumeFromLimitLocked performs the shared limit-resume action. The caller must
+// hold BOTH the per-target lock and the per-session op lock for key, acquired in
+// that canonical target-before-op order (#2006) — the target lock serializes this
+// resume's send against a concurrent DeliverPrompt to the same pane, and the op
+// lock keeps a manual retry from interleaving with kill teardown. Both entry
+// points (resumeFromLimit and the auto-resume scheduler) take the two locks before
+// calling in, so this body never touches the lock helpers itself.
 func (m *Manager) resumeFromLimitLocked(repoID, key string, instance *session.Instance, requestedTitle string) error {
-	unlock := m.lockTarget(repoID, instance.Title)
-	defer unlock()
-
 	// Re-verify under the lock: a self-recovery or the poll may have cleared the
 	// limit between the check above and the lock.
 	if !instance.LimitReached() {

--- a/daemon/limitresume.go
+++ b/daemon/limitresume.go
@@ -114,11 +114,11 @@ func (m *Manager) ResumeLimitedSessions() {
 // resumeLimitedSession auto-resumes one session when it is eligible and its
 // limit window has elapsed. Eligibility mirrors restoreLostSession: started,
 // LiveLimitReached, not tombstoned, not the reserved root (the manual retry and
-// the poll own those), and no kill in flight. The op lock is only TryLock'd so
-// the poll goroutine never stalls behind a kill teardown; everything is
-// re-verified under it because the checks above are point-in-time. The resume
-// itself is the shared resumeFromLimit action (PR2), which takes its own target
-// lock and re-verifies the limit state once more before acting.
+// the poll own those), and no kill in flight. It takes the per-target lock and
+// then the per-session op lock in that canonical order (#2006) before invoking the
+// shared resumeFromLimitLocked body; the op lock is only TryLock'd so the poll
+// goroutine never stalls behind a kill teardown, and everything is re-verified
+// under the locks because the checks above are point-in-time.
 func (m *Manager) resumeLimitedSession(key, repoID string, inst *session.Instance, retryInterval time.Duration) {
 	if inst == nil || !inst.Started() || inst.GetLiveness() != session.LiveLimitReached {
 		return
@@ -164,6 +164,14 @@ func (m *Manager) resumeLimitedSession(key, repoID string, inst *session.Instanc
 	if skip {
 		return
 	}
+
+	// Canonical lock order is target-before-op (#2006); see resumeFromLimit. This
+	// runs on the poll goroutine, so it can briefly block here on a DeliverPrompt
+	// in flight to the same session — bounded and correct, exactly where taking the
+	// op lock first used to deadlock the whole daemon. The op lock is still only
+	// TryLock'd, so the poll never stalls behind a kill teardown that holds it.
+	unlockTarget := m.lockTarget(repoID, inst.Title)
+	defer unlockTarget()
 
 	opLock := m.opLockFor(key)
 	if !opLock.TryLock() {


### PR DESCRIPTION
Fixes #2006.

## The bug (ABBA, proven)

Two per-session locks, both keyed by `daemonInstanceKey(repoID, title)` (same key → same mutex for a given session):

- **T** = per-target delivery lock — `m.targetLocks[key]`, via `lockTarget` (`delivery.go`).
- **O** = per-session op lock — `m.instanceOpLocks[key]`, via `opLockFor` (`manager.go`).

The two paths acquired them in **opposite** order:

| Path | Order | Sites |
|------|-------|-------|
| `DeliverPrompt` (send path) | **T → O** | `lockTarget` (`delivery.go:79`) → `SendPrompt` does `opLock.Lock()` (`manager_sessions.go:231`) |
| `resumeFromLimit` / auto-resume `resumeLimitedSession` | **O → T** | `opLock.TryLock()` (`limit.go:242`) → `resumeFromLimitLocked` does `lockTarget` (`limit.go:263`) |

Interleaving on the same session:

1. resume: `TryLock(O)` succeeds — holds O, T free.
2. DeliverPrompt: `lockTarget` succeeds — holds T, hasn't touched O.
3. DeliverPrompt → `SendPrompt` → `opLock.Lock()` — **blocks on O**.
4. resume → `resumeFromLimitLocked` → `lockTarget` — **blocks on T**.

Circular wait → the whole daemon wedges. The auto-resume scheduler runs on the poll goroutine, so with `limit_auto_resume` on it drives step 1 automatically the instant it overlaps a manual `send-prompt` — the P1 trigger. The `TryLock` on O does **not** save it: it only avoids blocking *at step 1*; once O is held, the subsequent blocking `lockTarget` closes the cycle.

## The fix

Establish **one canonical order — target-before-op (T → O)** — and make both resume entry points obey it.

`DeliverPrompt`'s T → O order is structurally load-bearing and can't reasonably invert: T must wrap the whole create-or-send decision (#865), and O is taken *deep inside* `SendPrompt`/`CreateSession`, which are also standalone entry points — flipping DeliverPrompt to O → T would need `SendPrompt` split into locked/unlocked halves (Go mutexes aren't reentrant). So the lone inverter (resume) flips:

- `resumeFromLimit` and `resumeLimitedSession` now take `lockTarget` (T) **before** `opLock.TryLock()` (O).
- The `lockTarget` acquisition moved **out** of `resumeFromLimitLocked` and **into** both callers; the shared body now documents the caller holds both locks in canonical order.

O stays `TryLock`, so a resume still never blocks behind a kill teardown that holds O. Both locks genuinely must be held around the send (T serializes against a concurrent DeliverPrompt to the same pane; O against kill/restore teardown), so narrowing to non-overlap isn't available — the canonical order *is* the fix. No new deadlock with kill teardown: kill grabs O but never T, so it can neither be blocked by a T-holder nor block a resume (whose O is TryLock'd).

## The test (watched failing first)

`daemon/deadlock_2006_test.go` drives the **real** `DeliverPrompt` and **real** `resumeFromLimit` concurrently on the same session. Two no-op production seams (mirroring the existing `testHookPollBeforePublish`) force the exact interleaving deterministically: pin a resume goroutine holding its first lock, let a DeliverPrompt take the target lock, then release the resume to reach for its second lock. Guarded by a 10s timeout so a regression is a **test FAILURE, not a hung CI run**; asserts the observable outcome (both goroutines complete). Run under `-race`.

- Against **unfixed** code: `--- FAIL … deadlock (#2006) … did not both complete` at 10.04s (the guard).
- With the **fix**: `ok` at ~4s.

## Gates (daemon work — container-only; host tmux/daemon/AF-home untouched)

- New test in container under `-race` — **ok** (fail-first proven first).
- `ResumeFromLimit|ResumeLimited|LimitResume|DeliverPrompt|Resume` in container under `-race` — **ok**.
- Full `./daemon/...` in container under `-race` — **ok 176.8s** (covers the kill/restore/archive/tabs paths sharing the op lock; race detector clean).
- `go build ./...` — clean · `gofmt -l .` — empty · `golangci-lint … --fast` — exit 0 · `deadcode -test ./...` — empty · `scripts/lint-file-length.sh` — passed.

Both review gates are down (codex out of credits), so this stays **DRAFT** — @sachiniyer re-gates via a fresh review and merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude
