### PR TITLE
fix(session): stop the daemon poll recursing on a torn-down remote runtime (#2005)

### DIFF
--- a/daemon/status_torn_remote_test.go
+++ b/daemon/status_torn_remote_test.go
@@ -1,0 +1,96 @@
+package daemon
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// delegatingRemoteBackend reproduces the load-bearing shape of the REAL sandbox
+// backends (docker/ssh/hook) that the existing remoteWorkspaceBackend does not:
+// its HasUpdated delegates STRAIGHT BACK to inst.AgentServer().Snapshot(), exactly
+// as remoteAgentBackend does. That delegation is the #2005 hazard — paired with a
+// torn-down runtime (remoteClient nil) whose AgentServer() used to fall back to a
+// localAgentServer, it made the poll recurse localAgentServer→backend→AgentServer→…
+// until the daemon overflowed its stack. A depth cap stands in for the kernel stack
+// limit so the pre-fix recursion is a bounded, assertable spike instead of a crash.
+type delegatingRemoteBackend struct {
+	*session.FakeBackend
+	mu       sync.Mutex
+	depth    int
+	maxDepth int
+}
+
+func (b *delegatingRemoteBackend) Type() string { return "docker" }
+
+func (b *delegatingRemoteBackend) Capabilities() session.Capabilities {
+	return session.Capabilities{
+		Workspace:        session.WorkspaceRemote,
+		Archive:          true,
+		Recover:          true,
+		InteractiveInput: true,
+	}
+}
+
+func (b *delegatingRemoteBackend) HasUpdated(inst *session.Instance) (bool, bool, string) {
+	b.mu.Lock()
+	b.depth++
+	over := b.depth > b.maxDepth
+	b.mu.Unlock()
+	if over {
+		return false, false, ""
+	}
+	obs, _ := inst.AgentServer().Snapshot()
+	return obs.Updated, obs.HasPrompt, obs.Content
+}
+
+func (b *delegatingRemoteBackend) reentries() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.depth
+}
+
+// TestRefreshInstanceStatus_TornDownRemoteRuntime_DoesNotRecurse is the daemon-side
+// #2005 regression. A remote sandbox session that went Lost is left, after a FAILED
+// lost-recovery, with started=true + Lost + a WorkspaceRemote backend still bound
+// but its remoteClient torn down (nil). A poll tick over that instance must run to
+// completion — probe, settle, return — and leave the session in a definite Lost
+// state, NOT recurse into a localAgentServer that delegates back through the remote
+// backend forever and overflows the daemon's stack.
+func TestRefreshInstanceStatus_TornDownRemoteRuntime_DoesNotRecurse(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+
+	// No RemoteAgentServer endpoint => remoteClient stays nil, the torn-down shape.
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title:   "torn-remote",
+		Path:    repoPath,
+		Program: "claude",
+	})
+	if err != nil {
+		t.Fatalf("NewInstance: %v", err)
+	}
+	backend := &delegatingRemoteBackend{FakeBackend: session.NewFakeBackend(), maxDepth: 64}
+	inst.SetBackend(backend)
+	inst.SetStartedForTest(true)          // a running session that went Lost keeps started=true
+	inst.SetStatusForTest(session.Lost)   // Lost + started is what the poll and restore loop touch
+	seedDiskInstance(t, repoID, "torn-remote", repoPath)
+	manager.mu.Lock()
+	manager.instances[daemonInstanceKey(repoID, "torn-remote")] = inst
+	manager.mu.Unlock()
+
+	// One poll tick. Pre-fix this recursed until the stack overflowed (the depth cap
+	// turns that into a bounded spike); post-fix AgentServer() returns the dead
+	// server, whose Snapshot errors without ever touching the backend.
+	manager.refreshInstanceStatus(repoID, inst)
+
+	if got := backend.reentries(); got > 1 {
+		t.Fatalf("poll recursed through the remote backend %d times (#2005); it must not re-enter it at all", got)
+	}
+	if got := inst.GetLiveness(); got != session.LiveLost {
+		t.Fatalf("poll left the session at %v; a torn-down remote session must resolve to a definite Lost", got)
+	}
+	if !inst.Started() {
+		t.Fatalf("poll cleared started; the session must stay started so the #1128 restore loop keeps retrying")
+	}
+}

--- a/daemon/status_torn_remote_test.go
+++ b/daemon/status_torn_remote_test.go
@@ -72,8 +72,8 @@ func TestRefreshInstanceStatus_TornDownRemoteRuntime_DoesNotRecurse(t *testing.T
 	}
 	backend := &delegatingRemoteBackend{FakeBackend: session.NewFakeBackend(), maxDepth: 64}
 	inst.SetBackend(backend)
-	inst.SetStartedForTest(true)          // a running session that went Lost keeps started=true
-	inst.SetStatusForTest(session.Lost)   // Lost + started is what the poll and restore loop touch
+	inst.SetStartedForTest(true)        // a running session that went Lost keeps started=true
+	inst.SetStatusForTest(session.Lost) // Lost + started is what the poll and restore loop touch
 	seedDiskInstance(t, repoID, "torn-remote", repoPath)
 	manager.mu.Lock()
 	manager.instances[daemonInstanceKey(repoID, "torn-remote")] = inst

--- a/session/agentserver_local.go
+++ b/session/agentserver_local.go
@@ -81,16 +81,41 @@ func (i *Instance) AgentServer() AgentServer {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 	if i.agentSrv == nil {
-		if i.remoteClient != nil {
+		switch {
+		case i.remoteClient != nil:
 			// teardown reaps the sandbox this session runs in (docker rm -f) after
 			// the remote Kill tears the in-sandbox workspace down — nil for the PR2
 			// out-of-process case (no sandbox to reap), set for a docker session.
 			i.agentSrv = &remoteAgentServer{rc: i.remoteClient, teardown: i.runtimeTeardown}
-		} else {
+		case backendIsRemoteWorkspace(i.backend):
+			// A remote-workspace backend (docker/ssh/hook) with NO live client:
+			// remoteClient is nil because the runtime wiring was torn down — a
+			// sandbox session loaded inert from disk, or one left Lost by a FAILED
+			// lost-recovery (reprovisionRemote succeeded, Start failed, then
+			// teardownAfterStartFailure cleared remoteClient while the session stays
+			// started+Lost so the #1128 restore loop keeps retrying). A localAgentServer
+			// must NEVER stand in here: a remote backend's data-plane methods
+			// (HasUpdated/IsAlive/Preview/…) delegate straight back to i.AgentServer(),
+			// so a localAgentServer wrapping one mutually recurses until the daemon
+			// poll overflows its stack (#2005). Report the sandbox as gone instead —
+			// the poll's remote-probe-failure path (#1794) and the restore loop's
+			// Alive gate already handle that, and the instance keeps its started+Lost
+			// state so auto-recovery is never stranded.
+			i.agentSrv = &deadRemoteAgentServer{title: i.Title}
+		default:
 			i.agentSrv = &localAgentServer{inst: i}
 		}
 	}
 	return i.agentSrv
+}
+
+// backendIsRemoteWorkspace reports whether b drives an off-box workspace
+// (docker/ssh/hook) — the backends whose data-plane methods delegate back to
+// i.AgentServer() (they embed remoteAgentBackend), and which therefore must never
+// be wrapped in a localAgentServer (#2005). A nil backend is treated as local
+// (the not-yet-initialised default, matching Instance.Capabilities).
+func backendIsRemoteWorkspace(b Backend) bool {
+	return b != nil && b.Capabilities().Workspace == WorkspaceRemote
 }
 
 var _ AgentServer = (*localAgentServer)(nil)

--- a/session/agentserver_recursion_test.go
+++ b/session/agentserver_recursion_test.go
@@ -1,0 +1,129 @@
+package session
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recursiveRemoteBackend reproduces the load-bearing shape of the real sandbox
+// backends (docker/ssh/hook) for the #2005 regression: it reports a WorkspaceRemote
+// workspace and its HasUpdated delegates STRAIGHT BACK to i.AgentServer().Snapshot(),
+// exactly like remoteAgentBackend does. A depth counter with a hard cap stands in
+// for the kernel stack limit, so the pre-fix infinite recursion is observed as a
+// bounded depth spike this test can assert on, instead of crashing the whole test
+// binary with a real (unrecoverable) stack overflow. Start fails, so it drives
+// recoverSandbox down its teardown path — the exact production trigger.
+type recursiveRemoteBackend struct {
+	*FakeBackend
+	typ      string
+	depth    int
+	maxDepth int
+}
+
+func (b *recursiveRemoteBackend) Type() string { return b.typ }
+
+func (b *recursiveRemoteBackend) Start(*Instance, bool) error { return fmt.Errorf("start failed") }
+
+func (b *recursiveRemoteBackend) Capabilities() Capabilities {
+	c := b.FakeBackend.Capabilities()
+	c.Workspace = WorkspaceRemote
+	return c
+}
+
+// HasUpdated mirrors remoteAgentBackend.HasUpdated: delegate to the agent-server.
+// With the #2005 bug AgentServer() hands back a localAgentServer whose Snapshot()
+// calls right back here — unbounded. The cap keeps the binary alive so the test can
+// ASSERT the recursion rather than die from it.
+func (b *recursiveRemoteBackend) HasUpdated(i *Instance) (bool, bool, string) {
+	b.depth++
+	if b.depth > b.maxDepth {
+		return false, false, ""
+	}
+	obs, _ := i.AgentServer().Snapshot()
+	return obs.Updated, obs.HasPrompt, obs.Content
+}
+
+// TestAgentServer_TornDownRemoteRuntime_DoesNotRecurse is the #2005 regression.
+//
+// It drives the real failed-lost-recovery path: reprovisionRemote binds a fresh
+// remote backend + client, Start fails, and teardownAfterStartFailure clears the
+// client — leaving the instance started+Lost with a WorkspaceRemote backend still
+// bound but remoteClient nil. On the next poll tick, AgentServer().Snapshot() (the
+// probe refreshInstanceStatus runs) must NOT recurse into a localAgentServer that
+// delegates back through the remote backend forever.
+func TestAgentServer_TornDownRemoteRuntime_DoesNotRecurse(t *testing.T) {
+	probe := &recursiveRemoteBackend{FakeBackend: NewFakeBackend(), typ: "docker", maxDepth: 64}
+	fake := fakeRuntime{res: ProvisionResult{
+		Backend:  probe,
+		Endpoint: &AgentServerEndpoint{URL: "http://127.0.0.1:9", Token: "tok"},
+		Teardown: func() error { return nil },
+	}}
+
+	prev := runtimeRegistry[BackendDocker]
+	runtimeRegistry[BackendDocker] = func() Runtime { return fake }
+	defer func() { runtimeRegistry[BackendDocker] = prev }()
+
+	// A running remote session that went Lost keeps started=true (that is why the
+	// poll and the restore loop still touch it). newInertSandboxBackend gives the
+	// pre-recovery inert docker backend; reprovisionRemote swaps in `probe`.
+	i := &Instance{
+		Title:    "s",
+		Path:     t.TempDir(),
+		Branch:   "root/s",
+		backend:  newInertSandboxBackend("docker"),
+		started:  true,
+		liveness: LiveLost,
+	}
+
+	require.Error(t, recoverSandbox(i), "Start must fail so recovery leaves the torn-down state")
+
+	// Post-failed-recovery invariant: the remote wiring is cleared, but the session
+	// stays started+Lost so the #1128 auto-restore loop keeps retrying it. (Setting
+	// started=false here would strand auto-recovery — that is the wrong fix.)
+	i.mu.RLock()
+	require.Nil(t, i.remoteClient, "remoteClient cleared by the failed-recovery teardown")
+	require.True(t, i.started, "started stays true so auto-recovery keeps retrying (#1128)")
+	require.Equal(t, LiveLost, i.liveness, "session stays Lost after a failed recovery")
+	require.Equal(t, WorkspaceRemote, i.backend.Capabilities().Workspace, "a remote backend is still bound")
+	i.mu.RUnlock()
+
+	// The poll tick's probe. Pre-fix: AgentServer() returns a localAgentServer whose
+	// Snapshot() delegates to backend.HasUpdated() → AgentServer().Snapshot() → …
+	// unbounded, driving probe.depth to the cap. Post-fix: AgentServer() returns a
+	// deadRemoteAgentServer whose Snapshot() errors WITHOUT ever touching the backend.
+	obs, err := i.AgentServer().Snapshot()
+
+	assert.LessOrEqual(t, probe.depth, 1,
+		"AgentServer() must not recurse through the remote backend (#2005); depth=%d means it did", probe.depth)
+	assert.Error(t, err, "a torn-down remote runtime reports its sandbox as gone, not a healthy snapshot")
+	assert.Equal(t, Observation{}, obs, "no observation when there is no live agent-server")
+
+	// The instance resolves to a DEFINITE, coherent state — a real Lost, not a
+	// spinning or corrupted one — and stays started so the restore loop can retry.
+	i.mu.RLock()
+	assert.Equal(t, LiveLost, i.liveness, "poll leaves the session in a definite Lost state")
+	assert.True(t, i.started, "poll does not clear started (auto-recovery stays eligible)")
+	i.mu.RUnlock()
+}
+
+// TestAgentServer_TornDownRemoteRuntime_KillDeletesCleanly proves a user can still
+// kill a session stuck in the torn-down remote state: instance.Kill() routes to
+// the dead server, which is a no-op success (there is nothing live to reap), so the
+// daemon's KillSession proceeds to delete the record rather than keeping it for a
+// doomed retry.
+func TestAgentServer_TornDownRemoteRuntime_KillDeletesCleanly(t *testing.T) {
+	i := &Instance{
+		Title:    "s",
+		backend:  newInertSandboxBackend("docker"),
+		started:  true,
+		liveness: LiveLost,
+	}
+	// remoteClient is nil + a remote backend => the dead server.
+	_, ok := i.AgentServer().(*deadRemoteAgentServer)
+	require.True(t, ok, "a torn-down remote instance must get the dead server, never a localAgentServer")
+
+	assert.NoError(t, i.Kill(), "killing a torn-down remote session must succeed so its record deletes")
+}

--- a/session/agentserver_remote.go
+++ b/session/agentserver_remote.go
@@ -243,6 +243,62 @@ func (s *remoteAgentServer) Archive() (string, error) {
 	return resp.Branch, nil
 }
 
+// deadRemoteAgentServer is the AgentServer for a remote-workspace instance
+// (docker/ssh/hook) whose runtime wiring has been torn down: remoteClient is nil,
+// so there is no live `af agent-server` to reach. AgentServer() returns it — never
+// a localAgentServer — for such an instance (#2005): a remote backend's data-plane
+// methods delegate back to i.AgentServer(), so a localAgentServer wrapping one
+// mutually recurses until the daemon poll overflows its stack. Two instances land
+// in this state:
+//
+//   - a sandbox session loaded inert from disk (its container is gone after a
+//     daemon restart, awaiting an explicit restore — instance_data.go), and
+//   - one left Lost by a FAILED lost-recovery (reprovisionRemote succeeded, Start
+//     failed, teardownAfterStartFailure cleared remoteClient) that stays
+//     started+Lost so the #1128 restore loop keeps retrying.
+//
+// Every method reports the sandbox as gone/unreachable — the truth — which is
+// exactly what the poll's remote-probe-failure path (#1794) and the restore loop's
+// Alive gate already expect. It carries no client and no locks: it is a pure,
+// stateless refusal, so AgentServer() can build one under i.mu just like the other
+// two impls.
+type deadRemoteAgentServer struct {
+	title string
+}
+
+var _ AgentServer = (*deadRemoteAgentServer)(nil)
+
+func (s *deadRemoteAgentServer) err() error {
+	return fmt.Errorf("session %q has no live agent-server: its sandbox is not provisioned", s.title)
+}
+
+func (s *deadRemoteAgentServer) Provision(bool) error              { return s.err() }
+func (s *deadRemoteAgentServer) Launch(bool) error                 { return s.err() }
+func (s *deadRemoteAgentServer) Expose() (StreamEndpoint, error)   { return StreamEndpoint{}, s.err() }
+func (s *deadRemoteAgentServer) Snapshot() (Observation, error)    { return Observation{}, s.err() }
+func (s *deadRemoteAgentServer) Preview(int, bool) (string, error) { return "", s.err() }
+
+// Alive returns (false, err) = UNKNOWN, never an authoritative "the agent is gone":
+// there is no sandbox to answer, so a caller must not treat this false as proof of
+// death and act destructively on it (#1794). remoteSandboxAnswersAlive reads it as
+// "did not answer alive", so the restore loop keeps re-provisioning rather than
+// declaring the row un-recoverable.
+func (s *deadRemoteAgentServer) Alive() (bool, error) { return false, s.err() }
+
+func (s *deadRemoteAgentServer) SendPrompt(string) error { return s.err() }
+func (s *deadRemoteAgentServer) TapEnter()               {}
+
+func (s *deadRemoteAgentServer) Subscribe(int, Seq) (PTYSubscription, error) { return nil, s.err() }
+func (s *deadRemoteAgentServer) Input(int, []byte) error                     { return s.err() }
+func (s *deadRemoteAgentServer) Resize(int, uint16, uint16) error            { return s.err() }
+
+// Kill is a no-op success: the sandbox was already reaped, so there is nothing
+// live to tear down, and a killed row must still delete cleanly — instance.Kill()
+// routes here, and returning an error would keep the record for a doomed retry.
+func (s *deadRemoteAgentServer) Kill() error { return nil }
+
+func (s *deadRemoteAgentServer) Archive() (string, error) { return "", s.err() }
+
 // --- remote WS clientlessChannel: the sandbox stream as a broker channel ---
 
 // remoteClientlessChannel is the remote runtime's clientlessChannel: it binds ONE


### PR DESCRIPTION
## What & why

Fixes #2005 — a **P1 daemon stack-overflow** that crashes the whole daemon.

### Mechanism (confirmed)

A remote sandbox session (docker/ssh/hook) that went **Lost** is auto-recovered by `recoverSandbox` (`session/archive_sandbox.go`):

1. `reprovisionRemote()` binds a fresh remote backend + `remoteClient` + `runtimeTeardown`.
2. `i.Start(true)` fails.
3. `teardownAfterStartFailure()` → `resetRemoteRuntime()` clears `remoteClient`, `runtimeTeardown`, and the cached `agentSrv` — but the session stays **`started=true` + `Lost`** so the #1128 restore loop keeps retrying it.

That leaves `AgentServer()` looking at a **`WorkspaceRemote` backend with `remoteClient==nil`**, so it fell through to the `localAgentServer` branch. A remote backend's data-plane methods (`HasUpdated`/`IsAlive`/`Preview`/…) delegate straight back to `i.AgentServer()`, so:

```
poll → localAgentServer.Snapshot() → backend.HasUpdated() → i.AgentServer().Snapshot() → localAgentServer.Snapshot() → …  ⇒ stack overflow
```

### Why not `started=false`

The obvious "add the missing `started=false`" is **wrong**: the auto-restore loop gates on `Started()` (`lostSessionWantsRestore`) and `lostRestoreFailed` documents *"never a permanent give-up (#1128)"*. Clearing `started` would strand auto-recovery forever — a regression.

### The fix (structural, at the chokepoint)

The real invariant: a `WorkspaceRemote` backend delegates its data-plane back to `AgentServer()`, so **`AgentServer()` must never wrap a remote backend in a `localAgentServer`.** When `remoteClient` is nil but the backend is remote, return a **`deadRemoteAgentServer`** that reports the sandbox as gone (`Snapshot`/`Alive`/… error, `Kill` no-op) instead of recursing.

- The poll's remote-probe-failure path (#1794) and the restore loop's `Alive` gate already handle a torn-down remote → the session stays a coherent **Lost**, and `started`/`Lost` are preserved so auto-recovery keeps retrying.
- Protects **all** `AgentServer()` callers, not just the poll.
- Hardens the load-from-disk path, which already relied on `started=false` to dodge the same *"recursive remote backend with no live agent-server client"* hazard (`instance_data.go`).

## Tests (fail-first verified)

- `session`: `TestAgentServer_TornDownRemoteRuntime_DoesNotRecurse` drives the **real** `recoverSandbox` failure, then the poll's probe — asserts no recursion (a depth cap stands in for the kernel stack limit so pre-fix shows depth 65 instead of crashing) and a coherent `Lost`. Plus a `Kill`-deletes-cleanly case.
- `daemon`: `TestRefreshInstanceStatus_TornDownRemoteRuntime_DoesNotRecurse` drives a full `refreshInstanceStatus` poll tick over the torn-down instance and asserts it completes without re-entering the backend and leaves the session `Lost`+`started`.

Both fail on unfixed code (recursed 65×) and pass with the fix.

## Verification

- `make test-container` (full suite) — **green** across all packages.
- `gofmt -l`, `golangci-lint --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh` — all clean.

Draft pending a fresh Claude review before merge (codex out of credits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)