### PR TITLE
feat(web): usable mobile layout — collapsing session drawer + touch targets

### DIFF
--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -307,6 +307,7 @@ body {
 }
 .af-app {
   height: 100vh;
+  height: 100dvh;
   display: flex;
   flex-direction: column;
 }
@@ -314,10 +315,30 @@ body {
   display: flex;
   align-items: center;
   gap: var(--af-sp-4);
-  padding: var(--af-sp-3) var(--af-sp-5);
+  padding: max(var(--af-sp-3), env(safe-area-inset-top)) max(var(--af-sp-5), env(safe-area-inset-right)) var(--af-sp-3) max(var(--af-sp-5), env(safe-area-inset-left));
   background: var(--af-bg-surface);
   border-bottom: 1px solid var(--af-border);
   flex-wrap: wrap;
+}
+.af-nav-toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.75rem;
+  min-height: 2.75rem;
+  padding: 0.3rem 0.55rem;
+  background: transparent;
+  color: var(--af-text);
+  border: 1px solid var(--af-border);
+  border-radius: var(--af-r-md);
+  font: inherit;
+  font-size: var(--af-fs-lg);
+  line-height: 1;
+  cursor: pointer;
+}
+.af-nav-toggle:hover {
+  background: var(--af-bg-inset);
+  border-color: var(--af-border-strong);
 }
 .af-brand {
   font-weight: 600;
@@ -538,6 +559,10 @@ body {
   flex: 1;
   display: flex;
   min-height: 0;
+  position: relative;
+}
+.af-nav-scrim {
+  display: none;
 }
 .af-rail {
   width: 18rem;
@@ -1591,16 +1616,73 @@ body {
   padding: 0.3rem 0.55rem;
   font-size: var(--af-fs-xs);
 }
-@media (max-width: 640px) {
-  .af-body {
-    flex-direction: column;
+@media (max-width: 768px) {
+  .af-app.af-view-sessions .af-nav-toggle {
+    display: inline-flex;
   }
   .af-rail {
-    width: 100%;
-    flex: 0 0 auto;
-    max-height: 45vh;
-    border-right: none;
-    border-bottom: 1px solid var(--af-border);
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    z-index: 30;
+    width: min(85vw, 20rem);
+    flex: none;
+    transform: translateX(-100%);
+    visibility: hidden;
+    transition: transform 0.22s ease, visibility 0s linear 0.22s;
+  }
+  .af-app.af-nav-open .af-rail {
+    transform: translateX(0);
+    visibility: visible;
+    box-shadow: var(--af-shadow-overlay);
+    transition: transform 0.22s ease, visibility 0s linear 0s;
+  }
+  .af-nav-scrim {
+    display: block;
+    position: absolute;
+    inset: 0;
+    z-index: 29;
+    background: var(--af-backdrop);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.22s ease;
+  }
+  .af-app.af-nav-open .af-nav-scrim {
+    opacity: 1;
+    pointer-events: auto;
+  }
+  .af-brand {
+    display: none;
+  }
+  .af-tab {
+    min-height: 2.5rem;
+  }
+  .af-term-action {
+    min-height: 2.5rem;
+    padding: 0.4rem 0.7rem;
+  }
+  .af-tab-close,
+  .af-tab-new {
+    min-width: 2rem;
+    min-height: 2rem;
+  }
+  .af-rail-new,
+  .af-rail-filter,
+  .af-project-switch,
+  .af-viewtab,
+  .af-theme-opt {
+    min-height: 2.25rem;
+  }
+  .af-row {
+    padding-top: var(--af-sp-3);
+    padding-bottom: var(--af-sp-3);
+  }
+  .af-modal-backdrop {
+    padding: var(--af-sp-3);
+  }
+  .af-modal-card {
+    max-height: 92vh;
   }
 }
 .af-config {

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -9836,9 +9836,15 @@ var AppShell = class {
         this.closeProjectMenu();
       }
     });
+    this.navToggle = h2("button", { type: "button", class: "af-nav-toggle" }, "\u2630");
+    this.navToggle.setAttribute("aria-label", "Toggle sessions");
+    this.navToggle.setAttribute("aria-controls", "af-rail");
+    this.navToggle.setAttribute("aria-expanded", "false");
+    this.navToggle.addEventListener("click", () => this.toggleNav());
     const header = h2(
       "header",
       { class: "af-appbar" },
+      this.navToggle,
       h2("span", { class: "af-brand" }, "Agent Factory"),
       viewNav,
       this.projectSwitchWrap,
@@ -9883,9 +9889,13 @@ var AppShell = class {
     this.railList = h2("ul", { class: "af-rail-list" });
     this.railList.setAttribute("role", "listbox");
     this.railList.setAttribute("aria-label", "Sessions");
-    const rail = h2("nav", { class: "af-rail" }, railHead, this.railList);
+    this.railList.addEventListener("click", () => this.setNav(false));
+    const rail = h2("nav", { class: "af-rail", id: "af-rail" }, railHead, this.railList);
     this.main = h2("section", { class: "af-main" });
-    this.sessionsBody = h2("div", { class: "af-body" }, rail, this.main);
+    this.navScrim = h2("div", { class: "af-nav-scrim" });
+    this.navScrim.setAttribute("aria-hidden", "true");
+    this.navScrim.addEventListener("click", () => this.setNav(false));
+    this.sessionsBody = h2("div", { class: "af-body" }, rail, this.main, this.navScrim);
     this.tasksPane = new TasksPane({
       add: () => this.actions.addTask(),
       toggle: (task) => this.actions.toggleTask(task),
@@ -9993,6 +10003,16 @@ var AppShell = class {
   // selection-changed guard alone wouldn't fire) — otherwise the pane is blank on
   // load until a select-then-deselect. (#1592 Phase 5 PR9)
   mainRendered = false;
+  // The narrow-viewport session rail (web mobile pass): below ~768px the rail is an
+  // off-canvas drawer that the .af-nav-toggle hamburger slides over the terminal, so a
+  // phone gives the terminal the full width. This is the ONLY piece of the responsive
+  // work that needs JS — everything else is @media CSS. `navOpen` is pure UI ephemera
+  // (never store state): the drawer is closed on load, opens on the toggle, and
+  // auto-closes when a session is selected (reveal the terminal) or the view changes.
+  // On desktop the CSS ignores the class, so setNav is an inert no-op there.
+  navToggle;
+  navScrim;
+  navOpen = false;
   /** Points the browser tab at what is on screen, so a pinned/backgrounded tab and the
    *  history entry name the session and project rather than a static "Agent Factory".
    *  Assigns only on a real change (a rename, a selection, or a project switch). */
@@ -10002,6 +10022,21 @@ var AppShell = class {
       this.lastDocTitle = title;
       document.title = title;
     }
+  }
+  /** Opens or closes the narrow-viewport session drawer (web mobile pass). A class on
+   *  the app root that the @media CSS turns into a slide-in rail + scrim; on desktop the
+   *  CSS ignores it, so this is a no-op there. Cheap-guarded so a redundant call from
+   *  update() doesn't thrash the class or the aria state. */
+  setNav(open) {
+    if (this.navOpen === open) {
+      return;
+    }
+    this.navOpen = open;
+    this.el.classList.toggle("af-nav-open", open);
+    this.navToggle.setAttribute("aria-expanded", open ? "true" : "false");
+  }
+  toggleNav() {
+    this.setNav(!this.navOpen);
   }
   /** Applies the latest state, touching only what changed. */
   update(state) {
@@ -10031,6 +10066,8 @@ var AppShell = class {
         tab.classList.toggle("af-viewtab-active", v === state.view);
         tab.setAttribute("aria-selected", v === state.view ? "true" : "false");
       }
+      this.el.classList.toggle("af-view-sessions", state.view === "sessions");
+      this.setNav(false);
     }
     if (this.lastThemeChoice !== state.themeChoice) {
       this.lastThemeChoice = state.themeChoice;
@@ -10049,6 +10086,9 @@ var AppShell = class {
     const sessionsChanged = this.lastSessions !== state.sessions;
     const selectionChanged = this.lastSelectedId !== state.selectedId;
     const projectChanged = this.lastSelectedProject !== state.selectedProject;
+    if (selectionChanged && state.selectedId) {
+      this.setNav(false);
+    }
     if (this.lastProjectSessions !== state.sessions || this.lastProjectTasks !== state.tasks || projectChanged) {
       this.lastProjectSessions = state.sessions;
       this.lastProjectTasks = state.tasks;

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -2,7 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <!-- viewport-fit=cover lets the themed appbar/background paint edge-to-edge under a
+         phone's notch/home-indicator; the safe-area env() insets in styles.css keep the
+         actual controls out of those cutouts. Without width=device-width a mobile browser
+         renders at ~980px desktop width and the @media breakpoints never engage. -->
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>Agent Factory</title>
     <!-- Same-origin bundle only: the daemon serves this shell with a strict
          `Content-Security-Policy: default-src 'self'` (#1592 Phase 5 PR2), so the

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "2051252742e6";
+const VERSION = "6dbb6e7b5724";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -36,7 +36,7 @@
 // playwright.config.ts): AF_WEB_BASE_URL and the two seeded session titles
 // AF_WEB_SESSION_A / AF_WEB_SESSION_B. No token is needed.
 
-import { expect, type Locator, type Page, test } from "@playwright/test";
+import { expect, type Browser, type BrowserContext, type Locator, type Page, test } from "@playwright/test";
 
 const SESSION_A = process.env.AF_WEB_SESSION_A ?? "probe-a";
 const SESSION_B = process.env.AF_WEB_SESSION_B ?? "probe-b";
@@ -4774,4 +4774,119 @@ test("#1929/#1971: a rename, a reorder and a close from the web carry the tab's 
   await page.unroute("**/v1/CloseTab");
   expect(closeBody.tab_id, "a close must carry the CLOSED tab's stable id").toBe(doomedId);
   expect(closeBody.tab_name, "…alongside the name fallback").toBe(doomed);
+});
+
+// ---- Mobile / narrow-viewport pass ------------------------------------------
+//
+// Sachin's ask: the web UI must be USABLE on a phone — below ~768px the session rail
+// auto-collapses to an off-canvas drawer so the terminal gets the full width, a
+// hamburger slides it back over as an overlay, and picking a session folds it shut. And
+// the classic mobile bug — one overflowing element scrolling the whole page sideways —
+// must never happen at a phone or small-tablet width.
+//
+// These drive a REAL headless Chromium at fixed viewport sizes, each in its OWN context
+// so the emulated viewport + fresh localStorage never leak into the shared desktop
+// `page` the rest of the file uses. They are the responsive-layout gate: the CSS is
+// @media-driven, so only a real sized viewport proves the breakpoint actually engages.
+
+/** Opens the app in a fresh context at the given viewport and waits for the tokenless
+ *  shell + a populated rail. Rail rows exist in the DOM even while the mobile drawer is
+ *  collapsed (visibility:hidden), so this readiness signal is viewport-agnostic — it
+ *  works at a phone width and a desktop width alike. */
+async function openAt(browser: Browser, width: number, height: number): Promise<{ ctx: BrowserContext; p: Page }> {
+  const ctx = await browser.newContext({ viewport: { width, height } });
+  const p = await ctx.newPage();
+  await p.goto("/");
+  await expect(p.locator(".af-app")).toBeVisible();
+  await expect(p.locator(".af-rail-list .af-row", { hasText: SESSION_A })).toHaveCount(1);
+  return { ctx, p };
+}
+
+/** The page's horizontal overflow past the viewport, in px — the number that must stay
+ *  ≤ 0 (a hair of sub-pixel tolerance) or the page scrolls sideways. */
+async function horizontalOverflow(p: Page): Promise<number> {
+  return p.evaluate(() => {
+    const de = document.documentElement;
+    return Math.max(de.scrollWidth, document.body.scrollWidth) - window.innerWidth;
+  });
+}
+
+test("mobile (375px): the rail auto-collapses to a drawer; the hamburger reveals it as an overlay and picking a session folds it shut", async ({
+  browser,
+}) => {
+  const { ctx, p } = await openAt(browser, 375, 667);
+  const app = p.locator(".af-app");
+  const rail = p.locator(".af-rail");
+  const toggle = p.locator(".af-nav-toggle");
+
+  // Collapsed by default: the hamburger is offered, the rail is off-canvas (not
+  // visible), and the terminal/main pane owns the full width.
+  await expect(toggle).toBeVisible();
+  await expect(rail).not.toBeVisible();
+  await expect(app).not.toHaveClass(/af-nav-open/);
+  const widths = () =>
+    p.evaluate(() => ({
+      app: document.querySelector(".af-app")!.getBoundingClientRect().width,
+      main: document.querySelector(".af-main")!.getBoundingClientRect().width,
+    }));
+  let w = await widths();
+  expect(w.main, "the main pane fills the width while the rail is collapsed").toBeGreaterThan(w.app - 2);
+
+  // The hamburger slides the drawer in. It overlays the terminal (the main pane keeps
+  // its full width underneath) rather than reflowing it, and it sits within the viewport
+  // without covering the whole screen.
+  await toggle.click();
+  await expect(app).toHaveClass(/af-nav-open/);
+  await expect(rail).toBeVisible();
+  // Poll the settled position: the drawer slides in over ~0.22s, so a boundingBox read
+  // the instant it turns visible catches it mid-transform. Poll until its left edge
+  // reaches the viewport.
+  await expect
+    .poll(async () => (await rail.boundingBox())?.x ?? -9999, {
+      message: "the open drawer slides fully into the viewport",
+    })
+    .toBeGreaterThanOrEqual(-1);
+  const railBox = await rail.boundingBox();
+  expect(railBox!.width, "the drawer does not swallow the whole screen").toBeLessThan(375);
+  w = await widths();
+  expect(w.main, "opening the drawer overlays — it does not shrink the terminal").toBeGreaterThan(w.app - 2);
+
+  // Picking a session closes the drawer and reveals that session's terminal.
+  await p.locator(".af-rail-list .af-row", { hasText: SESSION_A }).click();
+  await expect(app).not.toHaveClass(/af-nav-open/);
+  await expect(rail).not.toBeVisible();
+  await expect(p.locator(".af-main.af-main-term")).toBeVisible();
+
+  await ctx.close();
+});
+
+for (const width of [375, 768]) {
+  test(`mobile (${width}px): the page never scrolls sideways, drawer closed or open`, async ({ browser }) => {
+    const { ctx, p } = await openAt(browser, width, 812);
+
+    expect(await horizontalOverflow(p), "the page must not scroll sideways with the drawer closed").toBeLessThanOrEqual(
+      1,
+    );
+
+    // Open the drawer and re-check: an off-canvas layer that widened the page would show
+    // up here.
+    await p.locator(".af-nav-toggle").click();
+    await expect(p.locator(".af-app")).toHaveClass(/af-nav-open/);
+    expect(await horizontalOverflow(p), "…nor with the drawer slid open").toBeLessThanOrEqual(1);
+
+    await ctx.close();
+  });
+}
+
+test("desktop (1280px): the mobile drawer never engages — the rail stays in view and the hamburger is hidden", async ({
+  browser,
+}) => {
+  // The desktop guard: the responsive rules are scoped to a @media (max-width: 768px)
+  // block, so above it the layout must be exactly as it was — rail in the flow, no
+  // hamburger. This is the "don't regress desktop" assertion.
+  const { ctx, p } = await openAt(browser, 1280, 800);
+  await expect(p.locator(".af-rail")).toBeVisible();
+  await expect(p.locator(".af-nav-toggle")).toBeHidden();
+  await expect(p.locator(".af-app")).not.toHaveClass(/af-nav-open/);
+  await ctx.close();
 });

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -2,7 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <!-- viewport-fit=cover lets the themed appbar/background paint edge-to-edge under a
+         phone's notch/home-indicator; the safe-area env() insets in styles.css keep the
+         actual controls out of those cutouts. Without width=device-width a mobile browser
+         renders at ~980px desktop width and the @media breakpoints never engage. -->
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>Agent Factory</title>
     <!-- Same-origin bundle only: the daemon serves this shell with a strict
          `Content-Security-Policy: default-src 'self'` (#1592 Phase 5 PR2), so the

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -361,7 +361,12 @@ body {
 
 /* Authed app shell: appbar over a rail + main body. */
 .af-app {
+  /* 100vh is the fallback; 100dvh (dynamic viewport height) is the real value on a
+   * phone, where the address bar shrinks the visible area — with plain vh the terminal
+   * would be cut off under the browser chrome. dvh == vh on desktop, so this is inert
+   * there. */
   height: 100vh;
+  height: 100dvh;
   display: flex;
   flex-direction: column;
 }
@@ -370,13 +375,44 @@ body {
   display: flex;
   align-items: center;
   gap: var(--af-sp-4);
-  padding: var(--af-sp-3) var(--af-sp-5);
+  /* The base padding is the desktop value; the max(…, env(safe-area-inset-*)) only
+   * grows it on a device with a display cutout (notch/rounded corner) once the viewport
+   * meta opts into viewport-fit=cover. env() resolves to 0 on every non-notched display,
+   * so the desktop bar is byte-for-byte unchanged. */
+  padding: max(var(--af-sp-3), env(safe-area-inset-top)) max(var(--af-sp-5), env(safe-area-inset-right))
+    var(--af-sp-3) max(var(--af-sp-5), env(safe-area-inset-left));
   background: var(--af-bg-surface);
   border-bottom: 1px solid var(--af-border);
   /* Keep the bar to one row on a comfortable width, but never let it force the page
    * wider than the viewport: on a narrow window it wraps to a second line instead of
    * overflowing (the overflow-x guard on body would otherwise clip it). */
   flex-wrap: wrap;
+}
+
+/* The narrow-viewport rail toggle (web mobile pass): a hamburger that slides the
+ * session drawer over the terminal. Hidden on desktop (the rail is always in view) and
+ * shown only in the sessions view on a phone — see the @media block. Sized to a ~44px
+ * tap target so it clears the touch-target floor. */
+.af-nav-toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.75rem;
+  min-height: 2.75rem;
+  padding: 0.3rem 0.55rem;
+  background: transparent;
+  color: var(--af-text);
+  border: 1px solid var(--af-border);
+  border-radius: var(--af-r-md);
+  font: inherit;
+  font-size: var(--af-fs-lg);
+  line-height: 1;
+  cursor: pointer;
+}
+
+.af-nav-toggle:hover {
+  background: var(--af-bg-inset);
+  border-color: var(--af-border-strong);
 }
 
 .af-brand {
@@ -648,11 +684,21 @@ body {
   font-weight: 600;
 }
 
-/* Body: fixed-width rail + flexible main content. */
+/* Body: fixed-width rail + flexible main content. `position: relative` is the
+ * positioning context the narrow-viewport rail drawer + its scrim absolutely position
+ * against (web mobile pass); it is inert for the desktop flex row. */
 .af-body {
   flex: 1;
   display: flex;
   min-height: 0;
+  position: relative;
+}
+
+/* The rail drawer's tap-to-dismiss scrim (web mobile pass). Absent on desktop; the
+ * @media block turns it into a dimming layer over the terminal while the mobile rail is
+ * open, and a tap on it closes the drawer (ui.ts). */
+.af-nav-scrim {
+  display: none;
 }
 
 .af-rail {
@@ -2065,18 +2111,120 @@ body {
   font-size: var(--af-fs-xs);
 }
 
-/* Narrow viewport: stack the rail above the main pane (design §7.2 item 7 —
- * usable-but-not-optimized on a phone). */
-@media (max-width: 640px) {
-  .af-body {
-    flex-direction: column;
+/* ---- Narrow viewport: the session rail becomes an off-canvas drawer -------
+ * Sachin's mobile pass: below ~768px (a phone, and a small tablet in portrait) the
+ * rail slides off-canvas so the terminal gets the full width, and the .af-nav-toggle
+ * hamburger slides it back over the terminal as an overlay. Everything here is CSS on a
+ * single root class (.af-nav-open, set by ui.ts) — no JS layout math — and none of it
+ * exists above the breakpoint, so the desktop rail + main row is untouched.
+ *
+ * The drawer overlays rather than reflows: it is absolutely positioned inside .af-body,
+ * so the main pane keeps the full body width whether the drawer is open or shut, and the
+ * terminal's own ResizeObserver never sees a width change when it toggles. */
+@media (max-width: 768px) {
+  /* The hamburger is meaningful only where there is a rail to reveal — the sessions
+   * view. In tasks/config the body (and its drawer) is display:none, so the toggle
+   * would be a dead control; hide it there. */
+  .af-app.af-view-sessions .af-nav-toggle {
+    display: inline-flex;
   }
+
+  /* The parked drawer sits at translateX(-100%) — off the left edge — which the root
+   * `body { overflow-x: hidden }` guard already clips, so no `overflow: hidden` is needed
+   * here (and adding one would clip the rail-head filter menu / tab-new menu that open
+   * inside the body). */
+
+  /* The rail: a left-edge drawer, parked off-canvas and slid in on .af-nav-open. It is
+   * out of flow (position: absolute), so .af-main below takes the whole body width. */
   .af-rail {
-    width: 100%;
-    flex: 0 0 auto;
-    max-height: 45vh;
-    border-right: none;
-    border-bottom: 1px solid var(--af-border);
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    z-index: 30;
+    width: min(85vw, 20rem);
+    flex: none;
+    transform: translateX(-100%);
+    /* The parked drawer is visibility:hidden so it takes no touches and drops out of the
+     * tab/a11y order; the 0.22s visibility delay lets it finish sliding OUT before it
+     * disappears (open flips it visible immediately, at 0s). */
+    visibility: hidden;
+    transition:
+      transform 0.22s ease,
+      visibility 0s linear 0.22s;
+  }
+
+  .af-app.af-nav-open .af-rail {
+    transform: translateX(0);
+    visibility: visible;
+    box-shadow: var(--af-shadow-overlay);
+    transition:
+      transform 0.22s ease,
+      visibility 0s linear 0s;
+  }
+
+  /* The scrim over the terminal while the drawer is open — dim + tap-to-close. */
+  .af-nav-scrim {
+    display: block;
+    position: absolute;
+    inset: 0;
+    z-index: 29;
+    background: var(--af-backdrop);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.22s ease;
+  }
+
+  .af-app.af-nav-open .af-nav-scrim {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  /* The brand wordmark is decorative — drop it on a phone so the functional appbar
+   * controls (hamburger, view nav, project switch) have room before they wrap. */
+  .af-brand {
+    display: none;
+  }
+
+  /* Touch targets: lift the primary controls to a ~40-44px tap area so nothing on the
+   * terminal path depends on a precise tap or a hover that touch never delivers. */
+  .af-tab {
+    min-height: 2.5rem;
+  }
+
+  .af-term-action {
+    min-height: 2.5rem;
+    padding: 0.4rem 0.7rem;
+  }
+
+  .af-tab-close,
+  .af-tab-new {
+    min-width: 2rem;
+    min-height: 2rem;
+  }
+
+  .af-rail-new,
+  .af-rail-filter,
+  .af-project-switch,
+  .af-viewtab,
+  .af-theme-opt {
+    min-height: 2.25rem;
+  }
+
+  .af-row {
+    padding-top: var(--af-sp-3);
+    padding-bottom: var(--af-sp-3);
+  }
+
+  /* Overlays go near-full-width so a modal (create session, confirms) is never clipped
+   * off the edge — the card is already width:100% max-width:30rem, this just trims the
+   * backdrop gutter that would otherwise pinch it on a 375px screen. */
+  .af-modal-backdrop {
+    padding: var(--af-sp-3);
+  }
+
+  .af-modal-card {
+    max-height: 92vh;
   }
 }
 

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -590,6 +590,17 @@ export class AppShell {
   // load until a select-then-deselect. (#1592 Phase 5 PR9)
   private mainRendered = false;
 
+  // The narrow-viewport session rail (web mobile pass): below ~768px the rail is an
+  // off-canvas drawer that the .af-nav-toggle hamburger slides over the terminal, so a
+  // phone gives the terminal the full width. This is the ONLY piece of the responsive
+  // work that needs JS — everything else is @media CSS. `navOpen` is pure UI ephemera
+  // (never store state): the drawer is closed on load, opens on the toggle, and
+  // auto-closes when a session is selected (reveal the terminal) or the view changes.
+  // On desktop the CSS ignores the class, so setNav is an inert no-op there.
+  private readonly navToggle: HTMLButtonElement;
+  private readonly navScrim: HTMLElement;
+  private navOpen = false;
+
   constructor(
     private readonly actions: Actions,
     private readonly termHost: HTMLElement,
@@ -673,9 +684,20 @@ export class AppShell {
       }
     });
 
+    // The narrow-viewport rail toggle (web mobile pass): a hamburger that slides the
+    // session drawer over the terminal. CSS keeps it display:none on desktop and shows
+    // it only in the sessions view on a phone (the tasks/config views have no rail), so
+    // it never competes with the appbar controls on a comfortable width.
+    this.navToggle = h("button", { type: "button", class: "af-nav-toggle" }, "☰");
+    this.navToggle.setAttribute("aria-label", "Toggle sessions");
+    this.navToggle.setAttribute("aria-controls", "af-rail");
+    this.navToggle.setAttribute("aria-expanded", "false");
+    this.navToggle.addEventListener("click", () => this.toggleNav());
+
     const header = h(
       "header",
       { class: "af-appbar" },
+      this.navToggle,
       h("span", { class: "af-brand" }, "Agent Factory"),
       viewNav,
       this.projectSwitchWrap,
@@ -733,10 +755,20 @@ export class AppShell {
     this.railList = h("ul", { class: "af-rail-list" });
     this.railList.setAttribute("role", "listbox");
     this.railList.setAttribute("aria-label", "Sessions");
-    const rail = h("nav", { class: "af-rail" }, railHead, this.railList);
+    // Tapping a row on a phone should reveal the terminal, so any click that reaches a
+    // rail row closes the drawer (the row's own handler still attaches). Delegated on
+    // the list — not the rail head — so filtering/creating stays possible with the
+    // drawer open. Idempotent and inert on desktop (setNav no-ops there).
+    this.railList.addEventListener("click", () => this.setNav(false));
+    const rail = h("nav", { class: "af-rail", id: "af-rail" }, railHead, this.railList);
 
     this.main = h("section", { class: "af-main" });
-    this.sessionsBody = h("div", { class: "af-body" }, rail, this.main);
+    // The drawer scrim: a tap-to-dismiss layer over the terminal while the mobile rail
+    // is open. CSS keeps it display:none except in the narrow-viewport drawer state.
+    this.navScrim = h("div", { class: "af-nav-scrim" });
+    this.navScrim.setAttribute("aria-hidden", "true");
+    this.navScrim.addEventListener("click", () => this.setNav(false));
+    this.sessionsBody = h("div", { class: "af-body" }, rail, this.main, this.navScrim);
 
     // The tasks view is a peer of the sessions body inside one viewport; update()
     // shows exactly one and hides the other by `state.view`. It owns its own subtree
@@ -770,6 +802,23 @@ export class AppShell {
       this.lastDocTitle = title;
       document.title = title;
     }
+  }
+
+  /** Opens or closes the narrow-viewport session drawer (web mobile pass). A class on
+   *  the app root that the @media CSS turns into a slide-in rail + scrim; on desktop the
+   *  CSS ignores it, so this is a no-op there. Cheap-guarded so a redundant call from
+   *  update() doesn't thrash the class or the aria state. */
+  private setNav(open: boolean): void {
+    if (this.navOpen === open) {
+      return;
+    }
+    this.navOpen = open;
+    this.el.classList.toggle("af-nav-open", open);
+    this.navToggle.setAttribute("aria-expanded", open ? "true" : "false");
+  }
+
+  private toggleNav(): void {
+    this.setNav(!this.navOpen);
   }
 
   /** Applies the latest state, touching only what changed. */
@@ -812,6 +861,11 @@ export class AppShell {
         tab.classList.toggle("af-viewtab-active", v === state.view);
         tab.setAttribute("aria-selected", v === state.view ? "true" : "false");
       }
+      // The mobile rail drawer belongs to the sessions view (tasks/config have no
+      // rail): gate the hamburger's visibility on a root class, and fold the drawer
+      // shut on any view switch so it never lingers open over another surface.
+      this.el.classList.toggle("af-view-sessions", state.view === "sessions");
+      this.setNav(false);
     }
 
     // Highlight the active theme option (redesign PR1) when the choice changes.
@@ -841,6 +895,14 @@ export class AppShell {
     const sessionsChanged = this.lastSessions !== state.sessions;
     const selectionChanged = this.lastSelectedId !== state.selectedId;
     const projectChanged = this.lastSelectedProject !== state.selectedProject;
+
+    // Selecting a session on a phone should reveal its terminal, so fold the drawer
+    // shut whenever the selection lands on a real session — the keyboard/programmatic
+    // path (j/k then Enter) that never touches the rail's delegated click. Guarded on a
+    // non-null id so a deselection doesn't yank a browsing user out of the rail.
+    if (selectionChanged && state.selectedId) {
+      this.setNav(false);
+    }
 
     // The project switcher label + menu reflect the derived project list and the
     // current scope; rebuild when the sessions, the tasks (a task-only project), or


### PR DESCRIPTION
## What

Makes the web UI **usable on a phone / narrow viewport**. Sachin's scope: *"the sessions should auto collapse and stuff … it should be usable"* — responsive CSS + a collapsing rail, not a bespoke mobile app.

Below **~768px** the session rail becomes an **off-canvas drawer** so the terminal gets the full width. A `☰` hamburger slides it back over the terminal as an overlay; tapping the scrim, the toggle, or a session row folds it shut. Selecting a session — by tap **or** keyboard — auto-closes the drawer to reveal that session's terminal.

## Before / after (key widths)

The number that matters is the **terminal (main pane) width** and whether the rail can get out of the way.

```
iPhone-width viewport (375px)
                          rail        main / terminal        rail reachable?
  before (≤640 rule)   full-width   375px wide, but only    always on top,
                       stacked on   ~55vh tall (rail eats    no way to hide —
                       top, 45vh    the other 45vh)          eats half the screen
  after                off-canvas   375px wide, full height  ☰ → slides over as
                       (hidden)                              an overlay; tap to close

Small-tablet viewport (768px)
                          rail        main / terminal
  before               288px fixed  480px  (rail always pinned beside it)
  after                off-canvas   768px  (full width; rail on demand via ☰)

Desktop (> 768px) — UNCHANGED
  rail 288px (18rem) pinned beside the main pane, exactly as today.
```

```
after, 375px:                       after, 375px, drawer open:
┌───────────────────────────┐       ┌───────────────────────────┐
│ ☰  [Sess|Tasks|Cfg] ▣▼ ●  │       │ ☰  [Sess|Tasks|Cfg] ▣▼ ●  │
├───────────────────────────┤       ├──────────────┬────────────┤
│                           │       │  Sessions    │▒▒▒▒▒▒▒▒▒▒▒▒│
│      terminal (full)      │       │  ● probe-a   │▒ scrim ▒▒▒▒│
│                           │       │  ● probe-b   │▒ (tap to  ▒│
│                           │       │              │▒  close)  ▒│
└───────────────────────────┘       └──────────────┴────────────┘
        drawer closed                 drawer overlays, terminal
                                       keeps its full width beneath
```

## Also in the pass

- **`viewport-fit=cover`** in the shell + `max(…, env(safe-area-inset-*))` appbar padding — a notched phone keeps its controls clear of the cutout (env() is `0` on any non-notched display, so desktop is byte-identical).
- **`100dvh`** on the app shell so the terminal clears the mobile URL bar (dvh == vh on desktop).
- **~40–44px tap targets** on the primary controls (rail toggle, tabs, session actions) and **near-full-width modals** so a create/confirm form is never clipped off a 375px edge.
- Drops the old `max-width:640px` *"stack the rail above main at 45vh"* block, which permanently ate half a phone screen with no way to hide the rail.

## Not regressing desktop

Every rule is scoped to the `@media (max-width: 768px)` block, or to an `env()` / `dvh` value that resolves to the existing desktop value. The **only** JS is the drawer open/close class on the app root (`ui.ts`) — the layout itself is pure CSS. A dedicated selftest asserts the desktop layout at 1280px is untouched (rail in view, no hamburger).

## Testing

Web selftest harness (`make web-selftest-container`) — **94/94 green**, including 4 new specs that drive real 375/768px Chromium viewports:

- `mobile (375px)`: rail collapsed by default, terminal fills the width, hamburger reveals the drawer as an overlay (main keeps full width beneath), picking a session folds it shut → terminal shown.
- `mobile (375px / 768px)`: the page never scrolls sideways, drawer closed **or** open.
- `desktop (1280px)`: the mobile drawer never engages — rail in view, hamburger hidden.

Also: `npm run typecheck` clean, 315 unit tests pass, `make web-build` clean (committed `dist/` rebuilt), `go build ./...` OK, `gofmt` clean.

> **Draft** — held for a fresh review before merge, per the agreed gate. The web selftest is not part of CI (container-only), so the green run above is the layout gate.

— Captain Claude
