### PR TITLE
fix(git): return nil + warn when cross-device relocate copy succeeds but source cleanup fails (#2011)

### DIFF
--- a/session/git/worktree_archive.go
+++ b/session/git/worktree_archive.go
@@ -187,7 +187,26 @@ func (g *GitWorktree) relocateWorktreeTo(dest string) error {
 			)
 		}
 		if sourceCleanupErr != nil {
-			return fmt.Errorf("worktree copied and registered at %s, but failed to remove original %s; remove the original manually: %w", dest, src, sourceCleanupErr)
+			// Copy AND git registration both succeeded: the worktree is valid,
+			// registered, and usable at dest. Removing the leftover source dir is
+			// the only step that failed — a disk-reclamation nuisance, not a move
+			// failure. Returning an error here is actively harmful (#2011): it
+			// drives the daemon's archive-rollback / restore-retry logic even
+			// though a valid worktree already exists at dest, and the retry picks a
+			// fresh collision-suffixed dest, copies + registers a SECOND worktree,
+			// orphaning the first and corrupting `git worktree list` and branch
+			// exclusivity. The old "remove the original manually" advice is worse
+			// than useless: instance state may still point at src, so following it
+			// breaks recovery. Warn (so the leftover disk stays visible and
+			// reclaimable) and return nil.
+			log.WarningLog.Printf(
+				"worktree copied and registered at %s, but failed to remove the leftover source directory %s; "+
+					"the worktree is valid and usable at %s — the leftover is only reclaimable disk, "+
+					"remove it by hand with `%s`: %v",
+				dest, src, dest,
+				shellsuggest.Command("rm", "-rf", src),
+				sourceCleanupErr,
+			)
 		}
 		return nil
 	}

--- a/session/git/worktree_archive_test.go
+++ b/session/git/worktree_archive_test.go
@@ -6,6 +6,7 @@ import (
 	stdlog "log"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 
@@ -158,9 +159,13 @@ func TestMoveWorktree_FallbackRepairsRegistration(t *testing.T) {
 }
 
 // TestMoveWorktree_CrossDeviceCopyCleanupFailureCommitsCopiedLocation covers a
-// copy-then-remove failure in the cross-device fallback. Before #1475, the
-// error returned before worktreePath was updated, so callers persisted the
-// partially deleted source while the complete copy at dest was orphaned.
+// copy-then-remove failure in the cross-device fallback. Two invariants stack
+// here: worktreePath must commit to dest where the bytes live (the #1475 fix —
+// the error used to return before worktreePath was updated, so callers persisted
+// the partially deleted source while the complete copy at dest was orphaned),
+// AND the copy+register success must NOT surface as an error (#2011 — an error
+// return drives the caller into a retry that registers a second, orphaned
+// worktree). The only correct outcome is nil + a warning naming the leftover.
 func TestMoveWorktree_CrossDeviceCopyCleanupFailureCommitsCopiedLocation(t *testing.T) {
 	prevMove := worktreeMoveFast
 	worktreeMoveFast = func(*GitWorktree, string, string) error {
@@ -173,6 +178,11 @@ func TestMoveWorktree_CrossDeviceCopyCleanupFailureCommitsCopiedLocation(t *test
 		return syscall.EXDEV
 	}
 	t.Cleanup(func() { renamePath = prevRename })
+
+	var warnings bytes.Buffer
+	origWarning := aflog.WarningLog
+	aflog.WarningLog = stdlog.New(&warnings, "WARNING: ", 0)
+	t.Cleanup(func() { aflog.WarningLog = origWarning })
 
 	gw, _, srcPath := archiveTestWorktree(t)
 	dest := filepath.Join(testguard.CanonicalTempDir(t), "archived", "repoid", "arch")
@@ -187,12 +197,115 @@ func TestMoveWorktree_CrossDeviceCopyCleanupFailureCommitsCopiedLocation(t *test
 	}
 	t.Cleanup(func() { removeAllPath = prevRemoveAll })
 
-	err := gw.MoveWorktree(dest)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, cleanupErr)
-	assert.Contains(t, err.Error(), "worktree copied and registered")
+	require.NoError(t, gw.MoveWorktree(dest),
+		"a copy+register success with only source cleanup failing must not error (#2011)")
 	assert.True(t, pathExists(srcPath), "the source cleanup failure leaves the original for manual cleanup")
-	assertLiveWorktreeAt(t, gw, dest)
+	assertLiveWorktreeAt(t, gw, dest) // worktreePath committed to dest (#1475), still valid + registered
+	assert.Contains(t, warnings.String(), "failed to remove the leftover source directory")
+	assert.Contains(t, warnings.String(), srcPath)
+}
+
+// countBranchWorktrees returns how many registered worktrees in repoRoot are
+// checked out on branch, per `git worktree list --porcelain`. Used to prove a
+// relocate leaves exactly ONE — never an orphaned second registration.
+func countBranchWorktrees(t *testing.T, repoRoot, branch string) int {
+	t.Helper()
+	out := runGitInPlaceTest(t, repoRoot, "worktree", "list", "--porcelain")
+	n := 0
+	for _, line := range strings.Split(out, "\n") {
+		if line == "branch refs/heads/"+branch {
+			n++
+		}
+	}
+	return n
+}
+
+// TestRelocate_CopySucceedsCleanupFails_NoErrorNoRetryOrphan is the #2011
+// regression. On a cross-device relocate where the byte copy AND `git worktree
+// repair` both succeed but removing the SOURCE directory fails, relocate must
+// return nil: the worktree is valid, registered, and usable at dest — a leftover
+// source dir is a disk-reclamation nuisance, not a move failure. Returning an
+// error here is what corrupts state: it drives the caller's archive-rollback /
+// restore-retry logic even though a valid worktree already exists at dest, and
+// the retry picks a fresh collision-suffixed dest, copies + registers a SECOND
+// worktree, and orphans the first — corrupting `git worktree list` and branch
+// exclusivity.
+//
+// The test drives the REAL MoveWorktree path (the same relocateWorktreeTo engine
+// RestoreWorktreeTo uses) — NOT moveDirCrossDevice directly, which would skip the
+// repair/registration gate that must have SUCCEEDED for this bug to apply — and
+// models the caller's retry-on-error loop: a correct relocate returns nil on
+// attempt 1, so the loop never advances to a second dest and no orphan is born.
+func TestRelocate_CopySucceedsCleanupFails_NoErrorNoRetryOrphan(t *testing.T) {
+	prevMove := worktreeMoveFast
+	worktreeMoveFast = func(*GitWorktree, string, string) error {
+		return errors.New("forced fast-path failure (simulating EXDEV)")
+	}
+	t.Cleanup(func() { worktreeMoveFast = prevMove })
+
+	prevRename := renamePath
+	renamePath = func(_, _ string) error { return syscall.EXDEV }
+	t.Cleanup(func() { renamePath = prevRename })
+
+	var warnings bytes.Buffer
+	origWarning := aflog.WarningLog
+	aflog.WarningLog = stdlog.New(&warnings, "WARNING: ", 0)
+	t.Cleanup(func() { aflog.WarningLog = origWarning })
+
+	gw, repoRoot, srcPath := archiveTestWorktree(t)
+
+	// Fail removal of whatever the CURRENT source directory is on every attempt: a
+	// copy+register success paired with a persistent source-cleanup failure. Keying
+	// on the live worktree path (not a fixed one) means a retry's move is caught
+	// too, so on the buggy code the modeled loop errors on BOTH attempts and
+	// physically creates the orphaned second worktree at dest2.
+	prevRemoveAll := removeAllPath
+	removeAllPath = func(path string) error {
+		if path == gw.GetWorktreePath() {
+			return errors.New("forced source cleanup failure")
+		}
+		return os.RemoveAll(path)
+	}
+	t.Cleanup(func() { removeAllPath = prevRemoveAll })
+
+	// Model the restore/retry loop: the daemon recomputes a collision-suffixed dest
+	// and retries whenever the move returns an error (RestoreArchived via
+	// RestoreWorktreePath). A correct relocate stops the loop after one attempt.
+	baseDest := filepath.Join(testguard.CanonicalTempDir(t), "archived", "repoid", "arch")
+	dest2 := baseDest + "-2"
+
+	dest := baseDest
+	attempts := 0
+	var lastErr error
+	for attempts < 2 {
+		attempts++
+		lastErr = gw.MoveWorktree(dest)
+		if lastErr == nil {
+			break
+		}
+		dest = dest2 // collision handling would pick the next free path on retry
+	}
+
+	require.NoError(t, lastErr,
+		"copy+register success with a failed source cleanup must return nil, not error (else the caller retries into a second worktree)")
+	assert.Equal(t, 1, attempts,
+		"a nil return must stop the caller after one attempt — no retry")
+	assert.False(t, pathExists(dest2),
+		"no second (orphaned) worktree directory must be created by a retry")
+
+	// The one valid worktree is registered at the first dest, branch + dirty tree intact.
+	assertLiveWorktreeAt(t, gw, baseDest)
+
+	// The un-removed source is a leftover directory for manual reclamation — NOT a
+	// registered worktree. Git tracks exactly one worktree on the branch.
+	assert.True(t, pathExists(srcPath),
+		"the source cleanup failure leaves the original directory for manual reclamation")
+	assert.Equal(t, 1, countBranchWorktrees(t, repoRoot, "arch/branch"),
+		"git must track exactly one worktree for the branch — no orphan")
+
+	// The cleanup failure is surfaced (visible, not swallowed) so the leftover disk is reclaimable.
+	assert.Contains(t, warnings.String(), "failed to remove")
+	assert.Contains(t, warnings.String(), srcPath)
 }
 
 // TestRestoreWorktreeTo_FallbackRepairsSubmoduleGitdirs archives and restores an


### PR DESCRIPTION
Fixes #2011.

## The bug

On a cross-filesystem worktree relocate, `relocateWorktreeTo`
(`session/git/worktree_archive.go`) takes a fallback path that copies the bytes
to `dest` **and** repairs/registers the worktree with git — both user-critical
steps succeed. If only the source-directory removal then failed, it returned a
non-nil error. That error return is what corrupts state:

- It triggers the daemon's archive-rollback / restore-retry logic even though a
  **valid worktree already exists at `dest`**. On retry, collision handling
  picks a fresh dest (`dest-2`), copies + registers a **second** worktree, and
  the first is left registered/orphaned — corrupting `git worktree list` and
  breaking branch exclusivity.
- The `"remove the original manually"` advice is worse than useless: instance
  state can still point at `src`, so following it breaks recovery.

## The fix

When copy **and** git-registration both succeeded and only the source cleanup
failed, emit a **WARNING** (naming the leftover dir + an `rm -rf` reclamation
command through the `shellsuggest` seam) and return **nil**. The worktree is
valid and usable at `dest`; the leftover source is a disk-reclamation nuisance,
not a move failure. The cleanup failure stays visible in the log.

The neighboring **repair-failure** branch (git registration genuinely did *not*
succeed) still returns an error — that is a real failure and out of scope for
#2011.

## Fail-first evidence

Added `TestRelocate_CopySucceedsCleanupFails_NoErrorNoRetryOrphan`, which drives
the **real** `MoveWorktree` → `relocateWorktreeTo` engine (not `moveDirCrossDevice`
directly — that would skip the repair/registration gate that must have SUCCEEDED
for this bug to apply) and models the caller's retry-on-error loop.

**Observed failing at `083c586`** (origin/master HEAD, pre-fix). The failure
output reproduces the reported orphan-on-retry directly — the loop advanced into
a **second** worktree at `…/arch-2` after the first move to `…/arch` returned an
error:

```
Received unexpected error:
  worktree copied and registered at …/archived/repoid/arch-2, but failed to
  remove original …/archived/repoid/arch; remove the original manually: copied
  worktree to …/arch-2 but failed to remove original …/arch: forced source
  cleanup failure
Messages: copy+register success with a failed source cleanup must return nil,
  not error (else the caller retries into a second worktree)
```

With the fix the loop stops after one attempt (`attempts == 1`), no `dest-2`
directory is created, exactly one worktree is registered on the branch, and the
cleanup failure surfaces as a warning. The pre-existing
`TestMoveWorktree_CrossDeviceCopyCleanupFailureCommitsCopiedLocation` was updated
from the old error contract to the new nil+warn contract while keeping its #1475
invariant (worktreePath commits to `dest`).

## Adjacent-caller audit

Grepped `session/git/` and every worktree move/relocate path for the same
"user-critical work succeeded but cleanup failed → hard error" anti-pattern:

- **`relocateWorktreeTo` line 190** — the reported bug. **Fixed.**
- **`relocateWorktreeTo` repair-failure branch (line ~172)** — returns an error
  when `git worktree repair` fails, i.e. registration did **not** succeed. This
  is a genuine failure (retry is appropriate); **left as-is**, out of scope.
- **`moveDirCrossDevice`** — returns the typed `copiedWorktreeSourceCleanupError`
  when `removeAll(src)` fails after a successful copy. This is the **signal
  channel** `relocateWorktreeTo` inspects via `errors.As` to distinguish
  "copy succeeded, cleanup failed" from "copy failed"; it does not make the
  hard-error decision. **Left as-is** — the fix relies on this signal.
- **Callers of `relocateWorktreeTo`** — `MoveWorktree` (archive teardown) and
  `RestoreWorktreeTo` (restore) both share this single engine and simply
  propagate its return, so both are fixed by the one change. No caller-side
  handling of the cleanup case remains.

## Retry path confirmed

With the nil return, `ArchiveSession` proceeds to `CommitArchive` (no
`AbortArchiveToLost`, no Lost-restore retry) and `RestoreArchived` proceeds to
`RestoreFromArchive` (no `RestoreWorktreePath` collision suffix, no second copy).
The new test models this loop and asserts a single attempt with no second
worktree.

## Verification

- `gofmt -l .` — clean
- `go build ./...` — clean
- `golangci-lint run --timeout=3m --fast` — clean (full repo)
- `go test ./session/git/...` — pass (host-safe; no daemon spawn)

🤖 Generated with [Claude Code](https://claude.com/claude-code)