### PR TITLE
fix(daemon): overwrite Loading ghost in renameInstanceDataTitle (#1951)

### DIFF
--- a/daemon/create_reuse_archived_test.go
+++ b/daemon/create_reuse_archived_test.go
@@ -1,11 +1,13 @@
 package daemon
 
 import (
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
 
+	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/session"
 	sessiongit "github.com/sachiniyer/agent-factory/session/git"
 
@@ -103,6 +105,86 @@ func TestReserveCreate_ReusesArchivedName(t *testing.T) {
 	assert.Equal(t, "uncommitted-foo", string(dirty))
 	assert.Equal(t, branch, archived.GetBranch(), "restore preserves the original branch")
 	assert.Equal(t, id, archived.ID, "restore preserves the original stable id")
+}
+
+// seedLoadingGhost plants a legacy Loading-status ghost record (#551) alongside
+// whatever is already on disk for repoID. It reads the current rows, appends the
+// ghost with a literal Status==Loading and an empty id/worktree, and writes the
+// combined array RAW — deliberately NOT through appendInstanceData, because
+// ForStorage() would recompose the Loading status into Ready and the row would
+// stop being a ghost. This mirrors exactly what an older TUI binary left on disk.
+func seedLoadingGhost(t *testing.T, repoID, title, repoPath string) {
+	t.Helper()
+	data, err := loadRepoInstanceData(repoID)
+	require.NoError(t, err)
+	data = append(data, session.InstanceData{Title: title, Path: repoPath, Status: session.Loading})
+	raw, err := json.Marshal(data)
+	require.NoError(t, err)
+	require.NoError(t, config.LoadState().SaveInstances(repoID, raw))
+}
+
+// countRecordsWithTitle counts the persisted rows carrying exactly `title` in
+// repoID's instances.json. recordFor returns only the first match, so it cannot
+// see a duplicate; this is what the #1951 corruption assertion needs.
+func countRecordsWithTitle(t *testing.T, repoID, title string) int {
+	t.Helper()
+	data, err := loadRepoInstanceData(repoID)
+	require.NoError(t, err)
+	n := 0
+	for i := range data {
+		if data[i].Title == title {
+			n++
+		}
+	}
+	return n
+}
+
+// TestReserveCreate_ReusesArchivedName_OverwritesLoadingGhost is the #1951
+// regression test. A legacy TUI binary (#551) could persist a Loading-status
+// ghost record to disk; the rest of the codebase treats such ghosts as
+// overwritable, never as real title reservations — appendInstanceData overwrites
+// a same-titled Loading ghost, and findTitleConflictLocked skips Loading rows
+// when deciding a title is free. renameInstanceDataTitle (the reuse-archived-name
+// rewrite from #1719) copied the stable-id collision guard but NOT that ghost
+// handling, so when its rename lands on a title a Loading ghost holds it wrote a
+// SECOND record beside the ghost instead of replacing it — two rows sharing one
+// title, i.e. instances.json corruption and ambiguous lookups.
+//
+// Repro on the real production path (reserveCreate -> renameArchivedForReuseLocked
+// -> renameInstanceDataTitle): archive "foo", plant a Loading ghost on the exact
+// slot the rename will choose ("foo (archived)" — the availability check skips the
+// ghost, so uniqueArchivedTitleLocked picks it rather than "(archived 2)"), then
+// create a new "foo". Exactly ONE record must carry "foo (archived)" afterward,
+// and it must be the real archived session (stable id + branch preserved), proving
+// the ghost was overwritten rather than the archived record dropped.
+func TestReserveCreate_ReusesArchivedName_OverwritesLoadingGhost(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	archived, id := seedArchivedSession(t, manager, repoID, repoPath, "foo", "foo")
+	branch := archived.GetBranch()
+
+	// A legacy Loading ghost squatting on the exact title the rename will pick.
+	seedLoadingGhost(t, repoID, "foo (archived)", repoPath)
+
+	_, title, release, renamed, err := manager.reserveCreate(CreateSessionRequest{RepoPath: repoPath, Title: "foo", Program: "claude"})
+	require.NoError(t, err)
+	defer release()
+
+	assert.Equal(t, "foo", title)
+	require.NotNil(t, renamed, "the collision must have renamed the archived session")
+	assert.Equal(t, "foo (archived)", renamed.Title, "the rename must land on the ghost-held slot, not skip past it")
+
+	// The corruption assertion: the ghost must be REPLACED, leaving exactly one
+	// record under the reused title — not two. (Pre-fix: two.)
+	assert.Equal(t, 1, countRecordsWithTitle(t, repoID, "foo (archived)"),
+		"exactly one record must carry the reused title; a surviving Loading ghost beside the renamed record is the #1951 corruption")
+
+	// The surviving record must be the real archived session, not the ghost —
+	// stable id and branch preserved, status Archived.
+	rec := recordFor(t, repoID, "foo (archived)")
+	require.NotNil(t, rec, "the archived record must be persisted under the reused name")
+	assert.Equal(t, id, rec.ID, "the surviving record must be the archived session (its stable id), not the empty-id ghost")
+	assert.Equal(t, branch, rec.Branch, "the git branch must be preserved across the rename")
+	assert.Equal(t, session.Archived, rec.Status)
 }
 
 // TestReserveCreate_ReusesArchivedName_SuffixCollision: with BOTH archived "foo"

--- a/daemon/manager_persist.go
+++ b/daemon/manager_persist.go
@@ -123,6 +123,25 @@ func renameInstanceDataTitle(repoID, oldTitle string, newData session.InstanceDa
 		if err := json.Unmarshal(raw, &existing); err != nil {
 			return nil, fmt.Errorf("failed to parse existing instances: %w", err)
 		}
+		// A Loading ghost left by an older TUI binary (#551) does NOT reserve a
+		// title: appendInstanceData overwrites a same-titled Loading ghost rather
+		// than treating it as a conflict, and findTitleConflictLocked skips Loading
+		// rows when deciding a title is free — which is exactly why
+		// uniqueArchivedTitleLocked could hand us a newData.Title a ghost still
+		// holds. Drop any such ghost before the collision check so the rename
+		// REPLACES the ghost instead of writing a second same-titled record beside
+		// it (#1951). Without this the ghost's empty ID also makes
+		// stableIDMatchesForDaemon report a match, so the collision guard below
+		// never fires and the duplicate persists silently — two rows sharing one
+		// title, i.e. instances.json corruption.
+		kept := existing[:0]
+		for i := range existing {
+			if existing[i].Title == newData.Title && existing[i].Status == session.Loading {
+				continue
+			}
+			kept = append(kept, existing[i])
+		}
+		existing = kept
 		for i := range existing {
 			if existing[i].Title == newData.Title && !stableIDMatchesForDaemon(existing[i].ID, newData.ID) {
 				return nil, fmt.Errorf("cannot rename archived session to %q: another session already holds that title", newData.Title)


### PR DESCRIPTION
Fixes #1951 — **data corruption**: session creation could persist two `instances.json` records under the same title.

## The bug
`renameInstanceDataTitle` (the "reuse archived name" rewrite from #1719) decides whether the target title `newData.Title` is free **without** special-casing `Status==session.Loading` ghost records — unlike its sister `appendInstanceData`.

A legacy TUI binary (#551) can persist a `Loading` ghost to disk. The rest of the codebase treats such ghosts as *overwritable*, never as real title reservations:
- `appendInstanceData` overwrites a same-titled `Loading` ghost instead of erroring.
- `findTitleConflictLocked` (→ `validateTitleAvailableLocked` → `uniqueArchivedTitleLocked`) **skips** `Loading` rows when deciding a title is free.

So when an archived session's title is reused, `uniqueArchivedTitleLocked` happily picks a `newTitle` (e.g. `"foo (archived)"`) that a `Loading` ghost still holds, and `renameInstanceDataTitle` writes a **second** record beside the ghost instead of replacing it → two rows sharing one title → ambiguous lookups / corruption.

The ghost's empty `ID` compounds it: `stableIDMatchesForDaemon` treats an empty id on either side as a match, so the existing collision guard (`!stableIDMatchesForDaemon(...)`) never even fires.

## The fix
Drop any `Status==Loading` row holding `newData.Title` before the collision check, mirroring `appendInstanceData`'s established ghost handling. The #1719 free-title reuse behavior is unchanged; a real (non-`Loading`) same-titled record still blocks the rename.

Scope: the instances-persistence layer only (`daemon/manager_persist.go`). No changes to `daemon/health.go` or the status/poll code.

## Fail-first evidence
New test `TestReserveCreate_ReusesArchivedName_OverwritesLoadingGhost` drives the **real production path** — `reserveCreate → renameArchivedForReuseLocked → renameInstanceDataTitle` — not a helper that bypasses the buggy gate. It archives `"foo"`, plants a raw `Loading` ghost on the exact slot the rename picks (`"foo (archived)"`), creates a new `"foo"`, and asserts **exactly one** record carries the reused title.

Observed **failing at `ad20df3`** (pre-fix) — the assertion caught two records:
```
create_reuse_archived_test.go:178:
    expected: 1
    actual  : 2
    Messages: exactly one record must carry the reused title; a surviving
              Loading ghost beside the renamed record is the #1951 corruption
--- FAIL: TestReserveCreate_ReusesArchivedName_OverwritesLoadingGhost
```
Green after the fix; the sister tests (`TestReserveCreate_ReusesArchivedName`, `_SuffixCollision`, `TestManagerCreateSessionIgnoresLoadingGhost`) and the full `daemon` package all pass in-container.

The ghost is seeded raw (not via `appendInstanceData`), because `ForStorage()` recomposes `Loading → Ready` — running it through the append helper would produce a `Ready` row, not a ghost. This matches how `control_test.go` seeds its #551 ghost.

## Adjacent call-site audit
Every instances.json write path in the persistence layer, checked for the same "collision check blind to Loading ghosts" anti-pattern:

- **`appendInstanceData`** (create path) — already overwrites same-titled `Loading` ghosts. Correct; the pattern this fix mirrors.
- **`renameInstanceDataTitle`** (reuse-archived rename) — the bug. **Fixed here.**
- **`persistInstanceData`** (in-place mutation for CloseTab/CreateTab/RenameTab/ReorderTab/SetPRInfo/status polls) — matches an existing row by `(title, stable id)` and **never appends**, so it cannot materialize a second same-titled record. A pre-existing ghost is orthogonal and reaped by the next wholesale checkpoint. Correctly excluded.
- **`SaveInstances`** (wholesale) — serializes the manager's in-memory view, populated by `refreshDaemonInstances`, which skips ghosts; it never re-materializes a disk ghost into a duplicate. Excluded.

No out-of-scope stragglers → no follow-up issue needed.

## Gates
- `gofmt -l .` clean · `go build ./...` OK · `golangci-lint run --fast` clean · `deadcode -test ./...` clean
- `make test-container GOTESTARGS="./daemon/..."` → `ok ... 160.255s`

🤖 Generated with [Claude Code](https://claude.com/claude-code)