### PR TITLE
fix(release): rebase-and-retry the stable version-bump push (#1927)

### DIFF
--- a/.github/scripts/release-bump-and-tag.sh
+++ b/.github/scripts/release-bump-and-tag.sh
@@ -42,6 +42,31 @@ git add main.go
 if ! git diff --cached --quiet; then
 	git commit -m "chore: release v${NEW_VERSION}"
 fi
+
+# Push the bump to master, tolerating a master that moved during the ~4-minute
+# build (#1927). The auto-gate squash-merges CI-green PRs continuously, so a
+# plain push races that traffic and dies non-fast-forward, throwing away four
+# good builds. On a rejection, rebase the one-line bump onto the new tip and
+# retry, bounded. A rebase drops the bump as already-applied when a prior run
+# already landed it (patch-id), so the re-run converges to a clean no-op push.
+# A genuine conflict — only a rival version bump would touch this line — fails
+# the rebase loudly here instead of force-pushing over another release.
+MAX_ATTEMPTS="${RELEASE_PUSH_MAX_ATTEMPTS:-5}"
+attempt=1
+until git push origin HEAD:master; do
+	if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+		echo "::error::Version bump push rejected after ${MAX_ATTEMPTS} attempts (master kept moving)"
+		exit 1
+	fi
+	echo "Push rejected — master advanced during the build; rebasing onto origin/master and retrying (attempt ${attempt}/${MAX_ATTEMPTS})…"
+	git fetch origin master
+	git rebase FETCH_HEAD
+	attempt=$((attempt + 1))
+done
+
+# Tag the commit that actually landed on master. A rebase above may have
+# rewritten HEAD, so the tag is created only after the push succeeds — and
+# pushed after master, never before, so a failure at worst leaves a bump commit
+# with no tag (a clean, re-runnable state) and never a tag with no release.
 git tag "v${NEW_VERSION}"
-git push origin HEAD:master
 git push origin "v${NEW_VERSION}"

--- a/.github/scripts/release-bump-and-tag.sh
+++ b/.github/scripts/release-bump-and-tag.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# release-bump-and-tag.sh — land the stable-release version bump on master and
+# tag the released commit. Called from stable-release.yml's "Tag and publish"
+# job, after all four platform builds have succeeded (#1041).
+#
+# Usage: release-bump-and-tag.sh <version>    # bare semver, no leading v
+#
+# Runs on the ubuntu-latest release runner. Kept POSIX-portable (no `sed -i`,
+# no `grep -oP`) so scripts/release_scripts_test.go can exercise it hermetically
+# on both the Linux and macOS CI runners.
+set -eu
+
+NEW_VERSION="${1:?usage: release-bump-and-tag.sh <version>}"
+
+# Extract the current value of main.go's `version` fallback string. POSIX BRE,
+# tolerant of the gofmt alignment whitespace around the `=`.
+extract_version() {
+	sed -n 's/^[[:space:]]*version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' main.go | head -n1
+}
+
+CURRENT=$(extract_version)
+echo "Current main.go version: ${CURRENT:-<none>}, releasing: $NEW_VERSION"
+
+# Rewrite the version string in place (portable: no GNU `sed -i`).
+tmp=$(mktemp)
+sed 's/^\([[:space:]]*version[[:space:]]*=[[:space:]]*"\)[^"]*\(".*\)$/\1'"$NEW_VERSION"'\2/' main.go > "$tmp"
+mv "$tmp" main.go
+
+# Fail loudly if the substitution missed (e.g. formatting drift in main.go)
+# instead of tagging a release with a stale embedded version.
+UPDATED=$(extract_version)
+if [ "$UPDATED" != "$NEW_VERSION" ]; then
+	echo "::error::Failed to update version in main.go (found '${UPDATED:-<none>}')"
+	exit 1
+fi
+
+git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+git add main.go
+# No-op when main.go already carries the version (e.g. re-running after a
+# failure that landed the bump commit but not the tag).
+if ! git diff --cached --quiet; then
+	git commit -m "chore: release v${NEW_VERSION}"
+fi
+git tag "v${NEW_VERSION}"
+git push origin HEAD:master
+git push origin "v${NEW_VERSION}"

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -126,29 +126,7 @@ jobs:
     - name: Bump version, commit, and tag
       env:
         NEW_VERSION: ${{ inputs.version }}
-      run: |
-        CURRENT=$(grep -oP 'version\s+=\s+"\K[^"]+' main.go)
-        echo "Current main.go version: $CURRENT, releasing: $NEW_VERSION"
-        sed -i "s/version     = \"${CURRENT}\"/version     = \"${NEW_VERSION}\"/" main.go
-
-        # Fail loudly if the substitution missed (e.g. formatting drift in
-        # main.go) instead of tagging a release with a stale embedded version.
-        if ! grep -q "version     = \"${NEW_VERSION}\"" main.go; then
-          echo "::error::Failed to update version in main.go"
-          exit 1
-        fi
-
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
-        git add main.go
-        # No-op when main.go already carries the version (e.g. re-running
-        # after a failure that landed the bump commit but not the tag).
-        if ! git diff --cached --quiet; then
-          git commit -m "chore: release v${NEW_VERSION}"
-        fi
-        git tag "v${NEW_VERSION}"
-        git push origin HEAD:master
-        git push origin "v${NEW_VERSION}"
+      run: .github/scripts/release-bump-and-tag.sh "$NEW_VERSION"
 
     # Immutable releases require all assets to be attached before the release
     # is published: create as draft, upload assets into the draft, then publish.

--- a/scripts/release_scripts_test.go
+++ b/scripts/release_scripts_test.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 // These tests exercise the release version-computation scripts used by the
@@ -363,6 +365,116 @@ func TestReleaseBumpIdempotentWhenBumpAlreadyLanded(t *testing.T) {
 	if tag, tip := gitOutEnv(t, origin, env, "rev-list", "-n", "1", "v1.0.1"),
 		gitOutEnv(t, origin, env, "rev-parse", "master"); tag != tip {
 		t.Fatalf("tag v1.0.1 (%s) does not point at master tip (%s)", tag, tip)
+	}
+}
+
+// runReleaseScript runs release-bump-and-tag.sh under a hard timeout so a
+// regressed unbounded retry loop is killed and reported rather than hanging the
+// whole suite. Returns combined output, whether the deadline was hit, and the
+// run error.
+func runReleaseScript(t *testing.T, dir string, env []string, version string) (out string, timedOut bool, err error) {
+	t.Helper()
+	script := filepath.Join(repoRoot(t), ".github", "scripts", "release-bump-and-tag.sh")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, script, version)
+	cmd.Dir = dir
+	cmd.Env = env
+	b, runErr := cmd.CombinedOutput()
+	return string(b), ctx.Err() == context.DeadlineExceeded, runErr
+}
+
+// TestReleaseBumpBoundsRetriesOnPersistentReject locks the retry BOUND: with a
+// remote that rejects every push to master (a racer that never lets the push
+// through) and RELEASE_PUSH_MAX_ATTEMPTS=1, the script must give up non-zero —
+// not spin forever — and must leave the remote pristine (no bump on master, no
+// tag). This fails CI if a future edit drops the MAX_ATTEMPTS guard and
+// reintroduces an unbounded loop (the run would hang and hit the timeout).
+func TestReleaseBumpBoundsRetriesOnPersistentReject(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("release-bump-and-tag.sh is POSIX sh; not run on Windows")
+	}
+	base := t.TempDir()
+	home := filepath.Join(base, "home")
+	env := isolatedGitEnv(home)
+
+	origin, work := seedReleaseRemote(t, base, env, "1.0.0")
+
+	// A pre-receive hook that declines every push stands in for a racer that
+	// keeps the master push rejecting no matter how often we rebase and retry.
+	writeExecutable(t, filepath.Join(origin, "hooks", "pre-receive"),
+		"#!/bin/sh\necho 'push rejected by test (persistent racer)' >&2\nexit 1\n")
+	masterBefore := gitOutEnv(t, origin, env, "rev-parse", "master")
+
+	out, timedOut, err := runReleaseScript(t, work,
+		isolatedGitEnv(home, "RELEASE_PUSH_MAX_ATTEMPTS=1"), "1.0.1")
+	if timedOut {
+		t.Fatalf("script did not terminate — the retry loop is unbounded?\n%s", out)
+	}
+	if err == nil {
+		t.Fatalf("expected non-zero exit when the push keeps rejecting; got success\n%s", out)
+	}
+
+	// The remote stayed pristine: master unmoved, no bump commit, no tag.
+	if tip := gitOutEnv(t, origin, env, "rev-parse", "master"); tip != masterBefore {
+		t.Fatalf("master moved (%s → %s) despite every push being rejected", masterBefore, tip)
+	}
+	if log := gitOutEnv(t, origin, env, "log", "--format=%s", "master"); strings.Contains(log, "chore: release") {
+		t.Fatalf("a bump commit reached master despite exhaustion:\n%s", log)
+	}
+	if tags := gitOutEnv(t, origin, env, "tag", "-l", "v*"); tags != "" {
+		t.Fatalf("a tag was pushed despite the push never landing: %q", tags)
+	}
+}
+
+// TestReleaseBumpFailsLoudlyOnGenuineConflict locks the fail-loud behavior when
+// the rebase genuinely conflicts — a rival commit rewrote main.go's version
+// line, so the one-line bump cannot replay. The script must abort non-zero and
+// must NOT clobber the rival's commit (no force-push) or push a tag. This fails
+// CI if someone "hardens" the loop into a silent `git push --force` over
+// another release.
+func TestReleaseBumpFailsLoudlyOnGenuineConflict(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("release-bump-and-tag.sh is POSIX sh; not run on Windows")
+	}
+	base := t.TempDir()
+	home := filepath.Join(base, "home")
+	env := isolatedGitEnv(home)
+
+	origin, work := seedReleaseRemote(t, base, env, "1.0.0")
+
+	// A rival release lands on master mid-build and rewrites the SAME version
+	// line to a different value, so our bump's rebase must conflict.
+	rival := filepath.Join(base, "rival")
+	runGitEnv(t, base, env, "clone", origin, rival)
+	writeFile(t, filepath.Join(rival, "main.go"),
+		"package main\n\nconst (\n\tversion = \"2.0.0\"\n)\n")
+	runGitEnv(t, rival, env, "add", "main.go")
+	runGitEnv(t, rival, env, "commit", "-m", "chore: release v2.0.0")
+	runGitEnv(t, rival, env, "push", "origin", "master")
+	rivalTip := gitOutEnv(t, origin, env, "rev-parse", "master")
+
+	out, timedOut, err := runReleaseScript(t, work, env, "1.0.1")
+	if timedOut {
+		t.Fatalf("script hung on a conflict instead of failing fast\n%s", out)
+	}
+	if err == nil {
+		t.Fatalf("expected non-zero exit on a genuine version-line conflict; got success\n%s", out)
+	}
+
+	// The rival was preserved — master was neither overwritten nor advanced by
+	// our bump, and no tag was pushed.
+	if tip := gitOutEnv(t, origin, env, "rev-parse", "master"); tip != rivalTip {
+		t.Fatalf("master was force-overwritten: %s (rival tip was %s)", tip, rivalTip)
+	}
+	if got := gitOutEnv(t, origin, env, "show", "master:main.go"); !strings.Contains(got, `version = "2.0.0"`) {
+		t.Fatalf("rival's version was clobbered:\n%s", got)
+	}
+	if log := gitOutEnv(t, origin, env, "log", "--format=%s", "master"); strings.Contains(log, "chore: release v1.0.1") {
+		t.Fatalf("our bump commit reached master despite the conflict:\n%s", log)
+	}
+	if tags := gitOutEnv(t, origin, env, "tag", "-l", "v*"); tags != "" {
+		t.Fatalf("a tag was pushed despite the conflict: %q", tags)
 	}
 }
 

--- a/scripts/release_scripts_test.go
+++ b/scripts/release_scripts_test.go
@@ -172,6 +172,200 @@ func TestValidateStableVersionScript(t *testing.T) {
 	}
 }
 
+// --- release-bump-and-tag.sh: the #1927 mid-build merge race ---------------
+//
+// The stable-release "Tag and publish" job checks out github.sha, builds for
+// ~4 minutes, then bumps main.go and pushes to master. master advances during
+// that window (the auto-gate squash-merges CI-green PRs continuously), so a
+// plain `git push origin HEAD:master` races that traffic and dies
+// non-fast-forward after four good builds (#1927). These tests stand up a real
+// bare "remote" + working checkout, land a commit on master mid-window, and
+// assert the release still lands the bump on the moved tip.
+
+// isolatedGitEnv returns an environment that pins git to a throwaway HOME (no
+// user/system config — no signing, no hooks) and a deterministic identity, so
+// the release script's commits are reproducible and hermetic. Extra "KEY=val"
+// entries (e.g. GIT_*_DATE) may be appended.
+func isolatedGitEnv(home string, extra ...string) []string {
+	env := append(os.Environ(),
+		"HOME="+home,
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_AUTHOR_NAME=Release Bot",
+		"GIT_AUTHOR_EMAIL=release@example.com",
+		"GIT_COMMITTER_NAME=Release Bot",
+		"GIT_COMMITTER_EMAIL=release@example.com",
+		"GIT_TERMINAL_PROMPT=0",
+	)
+	return append(env, extra...)
+}
+
+func runGitEnv(t *testing.T, dir string, env []string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = env
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s (in %s): %v\n%s", strings.Join(args, " "), dir, err, out)
+	}
+}
+
+func gitOutEnv(t *testing.T, dir string, env []string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = env
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git %s (in %s): %v", strings.Join(args, " "), dir, err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// seedReleaseRemote creates a bare "origin" repo whose master carries a main.go
+// pinned to seedVersion, plus a detached "work" checkout of that tip standing
+// in for the stable-release job's `checkout ref: github.sha`. It returns the
+// bare remote path and the work-tree path.
+func seedReleaseRemote(t *testing.T, base string, env []string, seedVersion string) (origin, work string) {
+	t.Helper()
+	origin = filepath.Join(base, "origin.git")
+	seed := filepath.Join(base, "seed")
+	work = filepath.Join(base, "work")
+
+	runGitEnv(t, base, env, "init", "--bare", "-b", "master", origin)
+	runGitEnv(t, base, env, "init", "-b", "master", seed)
+	writeFile(t, filepath.Join(seed, "main.go"),
+		"package main\n\nconst (\n\tversion = \""+seedVersion+"\"\n)\n")
+	runGitEnv(t, seed, env, "add", "main.go")
+	runGitEnv(t, seed, env, "commit", "-m", "seed")
+	runGitEnv(t, seed, env, "remote", "add", "origin", origin)
+	runGitEnv(t, seed, env, "push", "origin", "master")
+
+	runGitEnv(t, base, env, "clone", origin, work)
+	// The job checks out an immutable github.sha, not a tracking branch.
+	runGitEnv(t, work, env, "checkout", "--detach", "HEAD")
+	return origin, work
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// TestReleaseBumpToleratesMidBuildMerge is the #1927 regression: a PR merges to
+// master while the release is building, and the version-bump push must land on
+// the moved tip instead of aborting non-fast-forward.
+func TestReleaseBumpToleratesMidBuildMerge(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("release-bump-and-tag.sh is POSIX sh; not run on Windows")
+	}
+	script := filepath.Join(repoRoot(t), ".github", "scripts", "release-bump-and-tag.sh")
+	base := t.TempDir()
+	home := filepath.Join(base, "home")
+	env := isolatedGitEnv(home)
+
+	origin, work := seedReleaseRemote(t, base, env, "1.0.0")
+
+	// A PR squash-merges to master DURING the build window — after `work` was
+	// checked out. It touches a different file, so the one-line bump rebases
+	// cleanly (as any real merge would; only a rival release touches the
+	// version line).
+	other := filepath.Join(base, "other")
+	runGitEnv(t, base, env, "clone", origin, other)
+	writeFile(t, filepath.Join(other, "CONCURRENT.md"), "landed mid-build\n")
+	runGitEnv(t, other, env, "add", "CONCURRENT.md")
+	runGitEnv(t, other, env, "commit", "-m", "feat: merged during build")
+	runGitEnv(t, other, env, "push", "origin", "master")
+
+	// Run the release bump against the now-stale checkout.
+	cmd := exec.Command(script, "1.0.1")
+	cmd.Dir = work
+	cmd.Env = env
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("release-bump-and-tag.sh failed on a mid-build merge (#1927): %v\n%s", err, out)
+	}
+
+	// The bump landed on the NEW tip: master carries both commits, main.go is
+	// bumped, and the concurrent work survived.
+	masterLog := gitOutEnv(t, origin, env, "log", "--format=%s", "master")
+	if !strings.Contains(masterLog, "feat: merged during build") {
+		t.Fatalf("concurrent commit was lost from master:\n%s", masterLog)
+	}
+	if !strings.Contains(masterLog, "chore: release v1.0.1") {
+		t.Fatalf("bump commit did not land on master:\n%s", masterLog)
+	}
+	if got := gitOutEnv(t, origin, env, "show", "master:main.go"); !strings.Contains(got, `version = "1.0.1"`) {
+		t.Fatalf("main.go on master was not bumped to 1.0.1:\n%s", got)
+	}
+	if got := gitOutEnv(t, origin, env, "show", "master:CONCURRENT.md"); !strings.Contains(got, "landed mid-build") {
+		t.Fatalf("concurrent file content missing from master: %q", got)
+	}
+
+	// The tag points at the released commit and is reachable from master, so a
+	// tag never dangles ahead of what shipped.
+	if tag, tip := gitOutEnv(t, origin, env, "rev-list", "-n", "1", "v1.0.1"),
+		gitOutEnv(t, origin, env, "rev-parse", "master"); tag != tip {
+		t.Fatalf("tag v1.0.1 (%s) does not point at master tip (%s)", tag, tip)
+	}
+}
+
+// TestReleaseBumpIdempotentWhenBumpAlreadyLanded covers re-running the job after
+// a previous run landed the bump commit on master but died before pushing the
+// tag: the re-run must converge (drop its duplicate bump, tag the landed
+// commit) rather than double-bump or abort.
+func TestReleaseBumpIdempotentWhenBumpAlreadyLanded(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("release-bump-and-tag.sh is POSIX sh; not run on Windows")
+	}
+	script := filepath.Join(repoRoot(t), ".github", "scripts", "release-bump-and-tag.sh")
+	base := t.TempDir()
+	home := filepath.Join(base, "home")
+	env := isolatedGitEnv(home)
+
+	origin, work := seedReleaseRemote(t, base, env, "1.0.0")
+
+	// A previous release run already landed the bump on master (no tag pushed).
+	// Give it a fixed EARLIER date so its commit hash differs from the re-run's
+	// bump — otherwise both bumps collide to one object and the rebase-drop
+	// path is never exercised.
+	other := filepath.Join(base, "other")
+	runGitEnv(t, base, env, "clone", origin, other)
+	writeFile(t, filepath.Join(other, "main.go"),
+		"package main\n\nconst (\n\tversion = \"1.0.1\"\n)\n")
+	prevEnv := isolatedGitEnv(home,
+		"GIT_AUTHOR_DATE=2020-01-01T00:00:00", "GIT_COMMITTER_DATE=2020-01-01T00:00:00")
+	runGitEnv(t, other, prevEnv, "add", "main.go")
+	runGitEnv(t, other, prevEnv, "commit", "-m", "chore: release v1.0.1")
+	runGitEnv(t, other, prevEnv, "push", "origin", "master")
+
+	// Re-run the job (later fixed date → distinct bump commit).
+	cmd := exec.Command(script, "1.0.1")
+	cmd.Dir = work
+	cmd.Env = isolatedGitEnv(home,
+		"GIT_AUTHOR_DATE=2020-12-31T00:00:00", "GIT_COMMITTER_DATE=2020-12-31T00:00:00")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("release-bump-and-tag.sh failed on an idempotent re-run: %v\n%s", err, out)
+	}
+
+	// Exactly one bump commit on master (no double-bump), and the tag lands on
+	// the already-published commit.
+	masterLog := gitOutEnv(t, origin, env, "log", "--format=%s", "master")
+	if n := strings.Count(masterLog, "chore: release v1.0.1"); n != 1 {
+		t.Fatalf("expected exactly one bump commit on master, got %d:\n%s", n, masterLog)
+	}
+	if got := gitOutEnv(t, origin, env, "show", "master:main.go"); !strings.Contains(got, `version = "1.0.1"`) {
+		t.Fatalf("main.go on master is not 1.0.1:\n%s", got)
+	}
+	if tag, tip := gitOutEnv(t, origin, env, "rev-list", "-n", "1", "v1.0.1"),
+		gitOutEnv(t, origin, env, "rev-parse", "master"); tag != tip {
+		t.Fatalf("tag v1.0.1 (%s) does not point at master tip (%s)", tag, tip)
+	}
+}
+
 func TestInstallScriptRestartsDaemonWithInstalledBinary(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("install.sh is POSIX sh; not run on Windows")


### PR DESCRIPTION
Fixes #1927.

## The race

The **Stable Release** `Tag and publish` job checks out `github.sha`, builds
the four platform artifacts for ~4 minutes, then bumps `main.go`, commits,
and pushes with **no rebase and no retry**:

```
git tag "v${NEW_VERSION}"
git push origin HEAD:master     # ← dies non-fast-forward if master moved
git push origin "v${NEW_VERSION}"
```

The auto-gate squash-merges CI-green PRs continuously, so any commit landing on
master inside the build window makes the push a non-fast-forward and the
release dies **after all four builds succeeded**. This killed the v1.0.193 cut
(run 29515274295): `#1924` merged mid-build and the push was rejected, throwing
away four good builds. It gets more likely as merge throughput rises.

## The fix

Extract the step into `.github/scripts/release-bump-and-tag.sh` (matching the
existing `.github/scripts/*.sh` + `scripts/release_scripts_test.go` pattern)
and wrap the push in a **bounded rebase-and-retry** loop:

- On a rejection, `git fetch origin master` + `git rebase FETCH_HEAD` replays
  the one-line bump onto the moved tip, then re-push (up to 5 attempts).
- The **tag is created only after the push lands** — a rebase rewrites `HEAD`,
  so tagging before the loop would strand the tag on an orphaned commit. It is
  still pushed *after* master, preserving the ordering the issue asked us to
  keep: a failure at worst leaves a bump-commit-with-no-tag (clean,
  re-runnable), never a tag-with-no-release.
- A rebase **drops the bump as already-applied** (patch-id) when a prior run
  already landed it, so re-running after a partial failure converges to a clean
  no-op push — the idempotent re-run the old inline guard only half-implemented
  (it guarded the *commit* but the push still died non-fast-forward on a moved
  master).
- A genuine conflict — only a rival version bump would touch this line — fails
  the rebase **loudly** rather than force-pushing over another release.

The script is kept POSIX-portable (no `sed -i`, no `grep -oP`) so the Go test
exercises it on both the Linux and macOS CI runners.

## Fail-first evidence

`scripts/release_scripts_test.go` stands up a **real bare remote + detached
checkout**, lands a commit on master mid-window, and runs the actual script
(the production path, not a helper).

- **Observed failing at `51f8ee4`** (the extracted-but-still-buggy script):
  both `TestReleaseBumpToleratesMidBuildMerge` and
  `TestReleaseBumpIdempotentWhenBumpAlreadyLanded` fail with the exact issue
  symptom:
  ```
  ! [rejected]        HEAD -> master (fetch first)
  --- FAIL: TestReleaseBumpToleratesMidBuildMerge
  --- FAIL: TestReleaseBumpIdempotentWhenBumpAlreadyLanded
  ```
- **Green at `410ac95`** (the fix): both pass. The mid-build test asserts the
  bump lands on the new tip, the concurrent commit/file survive, and the tag
  points at the master tip; the re-run test asserts exactly one bump commit on
  master (no double-bump) and the tag landing on the already-published commit.

Reviewers can reproduce: `git checkout 51f8ee4 -- .github/scripts/release-bump-and-tag.sh && go test ./scripts/ -run TestReleaseBump`.

## Adjacent call-site audit

`grep -rn "push origin" .github/` finds three push sites:

| Site | Verdict |
|------|---------|
| `stable-release.yml` master + tag push | **fixed here** — the reported race |
| `auto-release.yml:87` preview tag push | **not exposed.** Previews never touch master (`#1041`); this pushes a *tag* only, and does so *before* the build in the same step as the version compute — there is no build window between compute and push for a merge to race. |

A distinct, much-lower-severity scenario exists in `auto-release.yml` — two
overlapping preview runs (3h cron + a manual dispatch) could compute the same
`vX.Y.Z-preview-N` and the second tag push would be rejected. That is **not**
the #1927 mid-build-merge race (no master push, no build window), it is benign
(the other run publishes the tag), and I left it out of scope to keep this PR
focused. Happy to file a follow-up if preview overlap ever bites.

## Verification

- `go test ./scripts/ -race` — green (fail-first proven at `51f8ee4`)
- `gofmt -l .` — clean · `go build ./...` — ok
- `golangci-lint run --timeout=3m --fast` — clean · `deadcode -test ./...` — clean
- `sh -n` + `shellcheck` on the new script — clean · `scripts/lint-file-length.sh` — pass
- YAML validated

Scope: `.github/` release plumbing + its Go test harness only — no product
packages touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
