### PR TITLE
fix(exec): bound docker + gh CommandContext reads with WaitDelay (#1967)

### DIFF
--- a/commands/bugreport_github.go
+++ b/commands/bugreport_github.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"os/exec"
@@ -134,9 +135,16 @@ func openViaGh(repoSlug, title, body string) (opened bool, reason string) {
 	defer cancel()
 
 	c := exec.CommandContext(ctx, "gh", ghIssueCreateWebArgs(repoSlug, title, body)...)
+	c.WaitDelay = ghDraftWaitDelay
 	var errBuf bytes.Buffer
 	c.Stderr = &errBuf
-	if err := c.Run(); err != nil {
+	// A bare exec.ErrWaitDelay means gh exited 0 and only a child it backgrounded
+	// (the browser --web launches) held the captured stderr pipe open past
+	// ghDraftWaitDelay — the draft WAS opened. Treating that as failure would send
+	// the caller down the fallback path and report a false "could not open a
+	// draft" on a working operation, the exact backwards-handling #1966/#1967 warn
+	// about; success keys on the exit status, which ErrWaitDelay does not touch.
+	if err := c.Run(); err != nil && !errors.Is(err, exec.ErrWaitDelay) {
 		detail := firstLine(strings.TrimSpace(errBuf.String()))
 		if detail == "" {
 			detail = err.Error()
@@ -149,6 +157,14 @@ func openViaGh(repoSlug, title, body string) (opened bool, reason string) {
 // ghDraftTimeout bounds openViaGh so a wedged gh can never hang `af bug-report`;
 // gh --web normally returns in well under a second.
 const ghDraftTimeout = 20 * time.Second
+
+// ghDraftWaitDelay bounds how long c.Run() blocks after gh exits before the
+// captured stderr pipe is force-closed. Without it the ghDraftTimeout above is
+// decorative: exec.CommandContext kills only gh, and the browser it backgrounds
+// (--web) can inherit the stderr pipe and hold it open, so Run() blocks on pipe
+// EOF for the life of the browser past the deadline. Mirrors gitWaitDelay
+// (#856/#1967).
+const ghDraftWaitDelay = 2 * time.Second
 
 // firstLine returns s up to (not including) the first newline, so a multi-line
 // gh error collapses to a single readable reason.

--- a/commands/bugreport_github_waitdelay_test.go
+++ b/commands/bugreport_github_waitdelay_test.go
@@ -1,0 +1,92 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// #1967: exec.CommandContext kills only the DIRECT child, not its descendants.
+// openViaGh runs `gh issue create --web`, which deliberately backgrounds the
+// browser it launches; that browser can inherit the captured stderr pipe and
+// hold it open, so without cmd.WaitDelay c.Run() blocks on pipe EOF for the life
+// of the browser — past ghDraftTimeout, which then only decorates the hang. This
+// test drives the REAL openViaGh through a fake `gh` on PATH that writes to
+// stderr and backgrounds a straggler inheriting that pipe, and asserts the call
+// returns within ghDraftStragglerGuard.
+//
+// Observed failing before the ghDraftWaitDelay fix: without it c.Run() returns
+// only when the straggler dies (ghDraftStragglerSleep), tripping the guard. The
+// fix must also treat the resulting exec.ErrWaitDelay as success (gh exited 0 —
+// the draft WAS opened), which the opened/reason assertions verify; getting that
+// backwards would report a false "could not open a draft" and force the fallback.
+const (
+	// ghDraftStragglerSleep must exceed ghDraftStragglerGuard so a missing
+	// WaitDelay is a guard failure, not a slow pass; cleanup kills it early.
+	ghDraftStragglerSleep = 30
+	// ghDraftStragglerGuard sits between the 2s ghDraftWaitDelay and the straggler
+	// sleep, with ample slack over 2s so a loaded box never flakes the fixed path.
+	ghDraftStragglerGuard = 8 * time.Second
+)
+
+func TestOpenViaGh_WaitDelayBoundsStraggler(t *testing.T) {
+	installGhDraftStragglerFake(t)
+
+	var (
+		opened bool
+		reason string
+	)
+	if !returnsWithinDraft(ghDraftStragglerGuard, func() { opened, reason = openViaGh("owner/repo", "title", "body") }) {
+		t.Fatalf("openViaGh did not return within %s — c.Run() is blocked on a backgrounded browser holding the stderr pipe past the deadline; ghDraftWaitDelay is missing (#1967)", ghDraftStragglerGuard)
+	}
+	if !opened || reason != "" {
+		t.Fatalf("openViaGh = (opened=%v, reason=%q), want (true, \"\") — a bare exec.ErrWaitDelay must be treated as success (gh exited 0; the draft was opened)", opened, reason)
+	}
+}
+
+// installGhDraftStragglerFake writes an executable `gh` onto PATH that writes to
+// stderr (the pipe openViaGh captures), backgrounds a sleep inheriting that pipe
+// (the surviving descendant of #1967), records its pid, and exits 0. The
+// straggler is killed on cleanup so nothing is orphaned and a call left blocked
+// by a regression is unblocked immediately.
+func installGhDraftStragglerFake(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "straggler.pid")
+	script := "#!/bin/sh\n" +
+		"printf 'gh chatter\\n' 1>&2\n" +
+		"sleep " + strconv.Itoa(ghDraftStragglerSleep) + " &\n" +
+		"echo $! > '" + pidFile + "'\n" +
+		"exit 0\n"
+	if err := os.WriteFile(filepath.Join(dir, "gh"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Cleanup(func() {
+		data, err := os.ReadFile(pidFile)
+		if err != nil {
+			return
+		}
+		if pid, err := strconv.Atoi(strings.TrimSpace(string(data))); err == nil && pid > 0 {
+			_ = syscall.Kill(pid, syscall.SIGKILL)
+		}
+	})
+}
+
+// returnsWithinDraft runs fn in a goroutine and reports whether it returned
+// within d. A false result is the signature of a missing WaitDelay: the call is
+// blocked on a straggler holding the capture pipe past the deadline (#1967).
+func returnsWithinDraft(d time.Duration, fn func()) bool {
+	done := make(chan struct{})
+	go func() { defer close(done); fn() }()
+	select {
+	case <-done:
+		return true
+	case <-time.After(d):
+		return false
+	}
+}

--- a/session/backend_docker.go
+++ b/session/backend_docker.go
@@ -3,6 +3,7 @@ package session
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -82,6 +83,18 @@ const (
 	dockerBannerPollInterval   = 400 * time.Millisecond
 )
 
+// dockerWaitDelay bounds how long cmd.Wait blocks after the docker CLI (or the
+// origin-lookup git in originRemoteURL) exits or is killed on its deadline,
+// before the inherited stdout/stderr pipes are force-closed. exec.CommandContext
+// kills only the direct child; any descendant that inherited the capture pipe
+// keeps its read end open, and CombinedOutput()/Output() block on pipe EOF until
+// that descendant dies — which would silently defeat the timeouts above, so a
+// wedged docker daemon could hang the container reap forever (the guarantee
+// dockerReapTimeout reads as, but wasn't). Mirrors gitWaitDelay (#856/#896);
+// none of these children legitimately background a long-lived process, so
+// reaping the straggler is safe (#1967).
+const dockerWaitDelay = 2 * time.Second
+
 // dockerSelfBinary resolves the `af` binary to docker cp into the sandbox. In
 // production it is the running daemon's own executable — the same binary provides
 // `af agent-server`, so the sandbox is always version-matched to the daemon
@@ -104,7 +117,19 @@ func SetDockerSelfBinaryForTest(path string) func() {
 // the runtime against a fake docker CLI — including the create-then-fail path
 // (#2008) — without a real daemon on the box. Production wraps exec.CommandContext.
 var dockerExec = func(ctx context.Context, args ...string) ([]byte, error) {
-	return exec.CommandContext(ctx, "docker", args...).CombinedOutput()
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	cmd.WaitDelay = dockerWaitDelay
+	out, err := cmd.CombinedOutput()
+	if errors.Is(err, exec.ErrWaitDelay) {
+		// docker itself exited cleanly — a non-zero exit surfaces as an
+		// *exec.ExitError, not ErrWaitDelay — and only a descendant held the
+		// capture pipe open past dockerWaitDelay and was just force-closed. The
+		// output is already complete, so this is not a command failure: treating
+		// it as one would fail a healthy `docker rm -f` and report a leaked
+		// container that was in fact reaped (#1966/#1967, #676/#914 precedent).
+		err = nil
+	}
+	return out, err
 }
 
 // SetDockerExecForTest overrides the docker CLI runner and returns a restore func.
@@ -501,8 +526,14 @@ func parseDockerPort(out string) string {
 func originRemoteURL(repoRoot string) string {
 	ctx, cancel := context.WithTimeout(context.Background(), dockerShortStepTimeout)
 	defer cancel()
-	out, err := exec.CommandContext(ctx, "git", "-C", repoRoot, "remote", "get-url", "origin").Output()
-	if err != nil {
+	cmd := exec.CommandContext(ctx, "git", "-C", repoRoot, "remote", "get-url", "origin")
+	cmd.WaitDelay = dockerWaitDelay
+	out, err := cmd.Output()
+	// ErrWaitDelay means git exited cleanly and only a straggler held the pipe
+	// past dockerWaitDelay; the URL is already in out, so it is not a failure.
+	// Without this guard the WaitDelay bound would turn a healthy lookup into a
+	// spurious "" and mask a real origin (#1967).
+	if err != nil && !errors.Is(err, exec.ErrWaitDelay) {
 		return ""
 	}
 	return strings.TrimSpace(string(out))

--- a/session/backend_docker_waitdelay_test.go
+++ b/session/backend_docker_waitdelay_test.go
@@ -1,0 +1,123 @@
+package session
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// #1967: exec.CommandContext kills only the DIRECT child, not its descendants. A
+// descendant that inherits the CombinedOutput()/Output() capture pipe holds it
+// open, so without cmd.WaitDelay the call blocks on pipe EOF long past the
+// context deadline — the deadline is decorative and a wedged docker daemon could
+// hang the container reap (dockerReapTimeout) forever. These tests drive the REAL
+// production paths (dockerExec, originRemoteURL) through a fake CLI on PATH that
+// backgrounds a straggler holding the pipe, and assert the call returns within
+// dockerStragglerGuard rather than waiting the straggler out.
+//
+// Observed failing before the dockerWaitDelay fix: without it the call returns
+// only when the straggler dies (dockerStragglerSleep), tripping the guard. The
+// fix must also treat the resulting exec.ErrWaitDelay as success — docker/git
+// exited 0 — which the output/URL assertions verify (getting that backwards
+// would fail a healthy `docker rm -f` and report a leaked container, #1966).
+const (
+	// dockerStragglerSleep must exceed dockerStragglerGuard so a missing WaitDelay
+	// is a guard failure, not a slow pass; cleanup kills it well before it ends.
+	dockerStragglerSleep = 30
+	// dockerStragglerGuard sits between the 2s dockerWaitDelay and the straggler
+	// sleep, with ample slack over 2s so a loaded box never flakes the fixed path.
+	dockerStragglerGuard = 8 * time.Second
+)
+
+func TestDockerExec_WaitDelayBoundsStraggler(t *testing.T) {
+	installExecStragglerFake(t, "docker", "container-reaped", false)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	defer cancel()
+
+	var (
+		out []byte
+		err error
+	)
+	// Real production path: dockerExec is the single seam every docker invocation
+	// (including the `docker rm -f` reap) flows through. The 400ms ctx proves the
+	// deadline does not bound the call — only dockerWaitDelay does.
+	if !returnsWithinExec(dockerStragglerGuard, func() { out, err = dockerExec(ctx, "rm", "-f", "some-container") }) {
+		t.Fatalf("dockerExec did not return within %s — the ctx deadline does not bound CombinedOutput() while a straggler holds the capture pipe; dockerWaitDelay is missing (#1967)", dockerStragglerGuard)
+	}
+	if err != nil {
+		t.Fatalf("dockerExec returned error (a bare exec.ErrWaitDelay must normalize to success — docker exited 0): %v", err)
+	}
+	if !strings.Contains(string(out), "container-reaped") {
+		t.Fatalf("dockerExec output %q missing the captured line — the straggler-held pipe must not lose already-written output", out)
+	}
+}
+
+func TestOriginRemoteURL_WaitDelayBoundsStraggler(t *testing.T) {
+	const url = "https://origin.example/repo.git"
+	installExecStragglerFake(t, "git", url, false)
+
+	var got string
+	if !returnsWithinExec(dockerStragglerGuard, func() { got = originRemoteURL(t.TempDir()) }) {
+		t.Fatalf("originRemoteURL did not return within %s — Output() is blocked on a straggler holding the capture pipe past the deadline; dockerWaitDelay is missing (#1967)", dockerStragglerGuard)
+	}
+	if got != url {
+		t.Fatalf("originRemoteURL = %q, want %q — a bare exec.ErrWaitDelay must be treated as success (git exited 0) rather than dropped to \"\"", got, url)
+	}
+}
+
+// installExecStragglerFake writes an executable named `name` onto PATH that
+// prints line (to stdout, or stderr when toStderr), backgrounds a sleep
+// inheriting the capture pipe (the surviving descendant of #1967), records its
+// pid, and exits 0. The straggler is killed on cleanup so nothing is orphaned and
+// a call left blocked by a regression is unblocked immediately.
+func installExecStragglerFake(t *testing.T, name, line string, toStderr bool) {
+	t.Helper()
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "straggler.pid")
+	redir := ""
+	if toStderr {
+		redir = " 1>&2"
+	}
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' " + shSingleQuoteExec(line) + redir + "\n" +
+		"sleep " + strconv.Itoa(dockerStragglerSleep) + " &\n" +
+		"echo $! > " + shSingleQuoteExec(pidFile) + "\n" +
+		"exit 0\n"
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake %s: %v", name, err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Cleanup(func() {
+		data, err := os.ReadFile(pidFile)
+		if err != nil {
+			return
+		}
+		if pid, err := strconv.Atoi(strings.TrimSpace(string(data))); err == nil && pid > 0 {
+			_ = syscall.Kill(pid, syscall.SIGKILL)
+		}
+	})
+}
+
+func shSingleQuoteExec(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// returnsWithinExec runs fn in a goroutine and reports whether it returned within
+// d. A false result is the signature of a missing WaitDelay: the call is blocked
+// on a straggler holding the capture pipe past the context deadline (#1967).
+func returnsWithinExec(d time.Duration, fn func()) bool {
+	done := make(chan struct{})
+	go func() { defer close(done); fn() }()
+	select {
+	case <-done:
+		return true
+	case <-time.After(d):
+		return false
+	}
+}

--- a/session/git/github.go
+++ b/session/git/github.go
@@ -18,6 +18,15 @@ import (
 // sufficient.
 const ghNetworkTimeout = 30 * time.Second
 
+// ghWaitDelay bounds how long cmd.Wait blocks after gh exits before its inherited
+// stdout pipe is force-closed. exec.CommandContext kills only the direct child, so
+// any descendant that inherited the capture pipe holds its read end open and
+// Output() blocks on pipe EOF past the deadline above — the deadline kills gh and
+// then we wait on EOF anyway. Mirrors gitWaitDelay (#856); gh never legitimately
+// backgrounds a long-lived process here, so force-closing a straggler is safe
+// (#1967).
+const ghWaitDelay = 2 * time.Second
+
 // PRInfo holds information about a GitHub pull request associated with a branch.
 type PRInfo struct {
 	Number int    `json:"number"`
@@ -59,8 +68,13 @@ func FetchPRInfo(repoPath, branchName string) (*PRInfo, error) {
 	cmd := exec.CommandContext(ctx, "gh", "pr", "list", "--head", branchName, "--state", "all",
 		"--json", "number,title,url,state", "--limit", "10")
 	cmd.Dir = repoPath
+	cmd.WaitDelay = ghWaitDelay
 	out, err := cmd.Output()
-	if err != nil {
+	// A bare exec.ErrWaitDelay means gh exited cleanly (a non-zero exit is an
+	// *exec.ExitError, not ErrWaitDelay) and only a straggler held the capture
+	// pipe past ghWaitDelay; the JSON is already in out, so parse it rather than
+	// reporting a failure that would clear cached PR info on a healthy fetch.
+	if err != nil && !errors.Is(err, exec.ErrWaitDelay) {
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return nil, fmt.Errorf("gh pr list timed out after %s (GitHub unreachable or stalled): %w", ghNetworkTimeout, ctx.Err())
 		}

--- a/session/git/github_waitdelay_test.go
+++ b/session/git/github_waitdelay_test.go
@@ -1,0 +1,99 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// #1967: exec.CommandContext kills only the DIRECT child, not its descendants. A
+// descendant that inherits the Output() capture pipe holds it open, so without
+// cmd.WaitDelay FetchPRInfo blocks on pipe EOF long past its context deadline —
+// the deadline kills gh and then we wait on the straggler anyway. This test
+// drives the REAL FetchPRInfo through a fake `gh` on PATH that prints its JSON
+// and then backgrounds a `sleep` inheriting the capture pipe, and asserts the
+// call returns within ghStragglerGuard rather than waiting out the straggler.
+//
+// Observed failing before the ghWaitDelay fix: without it the call returns only
+// when the straggler dies (ghStragglerSleep), tripping the guard. The fix must
+// also treat the resulting exec.ErrWaitDelay as success (gh exited 0), which the
+// PR assertion on the parsed PR verifies.
+const (
+	// ghStragglerSleep must exceed ghStragglerGuard so a missing WaitDelay is a
+	// guard failure rather than a slow pass; cleanup kills it well before it ends.
+	ghStragglerSleep = 30
+	// ghStragglerGuard sits between the 2s ghWaitDelay and ghStragglerSleep, with
+	// ample slack over 2s so a loaded box never flakes the fixed path.
+	ghStragglerGuard = 8 * time.Second
+)
+
+func TestFetchPRInfo_WaitDelayBoundsStraggler(t *testing.T) {
+	installGhStragglerFake(t, `[{"number":7,"title":"t","url":"https://example/7","state":"OPEN"}]`)
+
+	var (
+		pr  *PRInfo
+		err error
+	)
+	if !returnsWithin(ghStragglerGuard, func() { pr, err = FetchPRInfo(t.TempDir(), "some-branch") }) {
+		t.Fatalf("FetchPRInfo did not return within %s — the ctx deadline does not bound Output() while a straggler holds the capture pipe; ghWaitDelay is missing (#1967)", ghStragglerGuard)
+	}
+	if err != nil {
+		t.Fatalf("FetchPRInfo returned error (a bare exec.ErrWaitDelay must be treated as success — gh exited 0): %v", err)
+	}
+	if pr == nil || pr.Number != 7 {
+		t.Fatalf("FetchPRInfo = %+v, want PR #7 parsed from the captured output", pr)
+	}
+}
+
+// installGhStragglerFake writes an executable `gh` onto PATH that prints line to
+// stdout, backgrounds a sleep inheriting the capture pipe (the surviving
+// descendant of #1967), records its pid, and exits 0. The straggler is killed on
+// cleanup so nothing is orphaned and a call left blocked by a regression is
+// unblocked immediately.
+func installGhStragglerFake(t *testing.T, line string) {
+	t.Helper()
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "straggler.pid")
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' " + shSingleQuote(line) + "\n" +
+		"sleep " + strconv.Itoa(ghStragglerSleep) + " &\n" +
+		"echo $! > " + shSingleQuote(pidFile) + "\n" +
+		"exit 0\n"
+	if err := os.WriteFile(filepath.Join(dir, "gh"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Cleanup(func() { killStragglerFromPidFile(pidFile) })
+}
+
+func shSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+func killStragglerFromPidFile(pidFile string) {
+	data, err := os.ReadFile(pidFile)
+	if err != nil {
+		return
+	}
+	if pid, err := strconv.Atoi(strings.TrimSpace(string(data))); err == nil && pid > 0 {
+		_ = syscall.Kill(pid, syscall.SIGKILL)
+	}
+}
+
+// returnsWithin runs fn in a goroutine and reports whether it returned within d.
+// A false result is the signature of a missing WaitDelay: the call is blocked on
+// a straggler holding the capture pipe past the context deadline (#1967).
+func returnsWithin(d time.Duration, fn func()) bool {
+	done := make(chan struct{})
+	go func() { defer close(done); fn() }()
+	select {
+	case <-done:
+		return true
+	case <-time.After(d):
+		return false
+	}
+}


### PR DESCRIPTION
Fixes #1967.

## The defect

`exec.CommandContext` kills only the **direct** child. A descendant that inherits the `CombinedOutput()`/`Output()` capture pipe keeps its read end open, so the call blocks on pipe EOF **past the context deadline** — the deadline kills the process and then we wait on the straggler anyway. Measured in the issue: `echo hi; sleep 3600` under a **400ms** deadline never returned without `WaitDelay`; with it, it returned at deadline+delay.

This repo already names the class five times (`gitWaitDelay` #856, `tmuxWaitDelay` #856/#896, `hookWaitDelay`, `probeWaitDelay`, `doctor/remote.go`). This PR routes the remaining unbounded **docker + gh** reader sites through the same mechanism — it does **not** invent a new one.

## The fix, and the trap

Set `cmd.WaitDelay = 2 * time.Second` (matching the existing consts) on each site, **and** treat a bare `exec.ErrWaitDelay` as **success**: the child exited 0 (a non-zero exit is an `*exec.ExitError`, not `ErrWaitDelay`) and only a straggler held the pipe. Getting this backwards turns a working op into a spurious failure — it would fail a healthy `docker rm -f` and report a leaked container that was in fact reaped (#1966). Same idiom as `worktree_git.go` / `tmux.normalizeWaitDelay` / `claude_probe.go`.

All four sites are in the "child cannot legitimately background a long-lived process" bucket (per the issue's own refinement: `git`/`tmux`/`gh`/`docker rm -f`), so force-closing a straggler is safe here. The **file-form** fix is for sites that *can* background a product (the hook backend — see audit below); those are untouched.

### Sites fixed

| Site | Command | Capture | Fix |
|---|---|---|---|
| `session/backend_docker.go` `dockerExec` | every `docker …` incl. the `docker rm -f` reap | `CombinedOutput` | `dockerWaitDelay` + normalize |
| `session/backend_docker.go` `originRemoteURL` | `git remote get-url origin` | `Output` | `dockerWaitDelay` + normalize |
| `session/git/github.go` `FetchPRInfo` | `gh pr list` | `Output` | `ghWaitDelay` + normalize |
| `commands/bugreport_github.go` `openViaGh` | `gh issue create --web` | `Run` (stderr pipe) | `ghDraftWaitDelay` + normalize |

`docker` is the one that matters most: `dockerReapTimeout` *read* as a guarantee that a kill can't hang on a wedged daemon, and it wasn't one — the reap flows through `dockerExec`, now bounded.

## Fail-first evidence

Each fixed site has a regression test that drives the **real production function** (not a bypass seam) through a fake CLI on `PATH` which prints its output and then backgrounds a `sleep` inheriting the capture pipe — the exact surviving-descendant shape of #1967 — and asserts the call returns within an 8s guard (the 2s `WaitDelay` window + slack). The straggler is killed on cleanup, and its sleep (30s) far exceeds the guard, so a missing `WaitDelay` is a deterministic guard failure, never a slow pass. The tests can never wedge CI.

Observed **failing at `ad20df3`** (source fixes stashed, tests present):

```
--- FAIL: TestFetchPRInfo_WaitDelayBoundsStraggler (8.01s)
    FetchPRInfo did not return within 8s — the ctx deadline does not bound Output() … ghWaitDelay is missing (#1967)
--- FAIL: TestOpenViaGh_WaitDelayBoundsStraggler (8.00s)
    openViaGh did not return within 8s — c.Run() is blocked on a backgrounded browser holding the stderr pipe … (#1967)
--- FAIL: TestDockerExec_WaitDelayBoundsStraggler (8.01s)      [container]
--- FAIL: TestOriginRemoteURL_WaitDelayBoundsStraggler (8.01s) [container]
```

**Green with the fix** — all four return at **2.00s** (process-exit + `WaitDelay`), and the output/PR/URL/opened assertions confirm `ErrWaitDelay` normalizes to success rather than a false failure.

Empirically re-derived the arming semantics first (the repo's "measure, don't reason" lesson): with a grandchild holding the pipe, `WaitDelay` arms on **process-exit**, so the bound holds even when the ctx deadline (e.g. `ghNetworkTimeout` 30s) is far longer than the straggler.

## Adjacent-call-site audit

Every **production** `exec.CommandContext` site, verdicted:

| Site | WaitDelay status |
|---|---|
| `session/backend_docker.go` `dockerExec` (docker) | **fixed** — `dockerWaitDelay` |
| `session/backend_docker.go` `originRemoteURL` (git) | **fixed** — `dockerWaitDelay` |
| `session/git/github.go` `FetchPRInfo` (gh) | **fixed** — `ghWaitDelay` |
| `commands/bugreport_github.go` `openViaGh` (gh) | **fixed** — `ghDraftWaitDelay` |
| `config/claude_probe.go` (shell probe) | already-had — `probeWaitDelay` |
| `daemon/autostart_inspect.go` (af probe) | already-had — `autostartProbeWaitDelay` |
| `doctor/skew.go` (version probe) | already-had — `binaryProbeWaitDelay` |
| `doctor/remote.go` (coder whoami) | already-had — `500ms` |
| `session/git/hooks.go` (post-worktree hook) | already-had — `hookWaitDelay` |
| `session/git/worktree_git.go` (git) | already-had — `gitWaitDelay` |
| `session/backend_hook_backend.go` `runHookScript` (launch/delete hooks) | **justified exclusion** — uses the **file form** (`Stdout/Stderr = *os.File`), the deliberately different #1966 fix: these hooks *can* background a long-lived tunnel, and `WaitDelay` would reap the product. Must **not** get `WaitDelay`. |
| `session/tmux/bounded.go` (tmux control cmds) | already-had — `tmuxWaitDelay` |
| `session/tmux/io.go` `CapturePaneContentContext` / `CapturePaneContentWithOptions` (capture-pane) | **out of scope** — these build raw `exec.CommandContext`/`exec.Command` and go through `cmd.Exec.Output` (a bare passthrough), so capture-pane is **not** bounded by `WaitDelay`. `session/tmux/*` is owned by a concurrent PR per the work split; flagging here so it isn't lost. |

Bare `exec.Command` (no ctx) output-readers are a different class (no `CommandContext` deadline to defeat) and are not in #1967's scope.

## Verification

- `gofmt -l .` clean · `go build ./...` ok · `golangci-lint run --timeout=3m --fast` clean · `deadcode -test ./...` clean
- `make test-container GOTESTARGS="-count=1 ./session/ ./session/git/ ./commands/"` — all green (no regression from the `dockerExec` normalize)

Did not touch `session/tmux/*` (concurrent PR).

— Captain Claude
