### PR TITLE
fix(ui): keep the help overlay framed when scrolled at 80x24 (#1998)

### DIFF
--- a/app/help_test.go
+++ b/app/help_test.go
@@ -116,6 +116,38 @@ func TestGeneralHelpOverlayFitsAndMarksScrollAt80x24(t *testing.T) {
 	require.Contains(t, out, "↑ more", "scrolled viewport must show overflow above")
 }
 
+// TestGeneralHelpStaysCenteredWhenScrolledAt80x24 is the #1998 regression: at
+// 80x24 the general help wraps to lines one cell past the box's text width, so
+// the overlay box grew a row per such visible line, overflowed the terminal,
+// and PlaceOverlay fell back to dumping the raw frame — a ~50-column fragment at
+// column 0 with its top border clipped and the surrounding TUI blank. Drive the
+// real Ctrl-D scroll path deep into (and past) the content through home.View()
+// and assert every composited frame stays the full 80x24 window (which the
+// overflow dump violates: it is only as wide as the box and taller than the
+// terminal). The overlay's own centering geometry is locked, over a blank
+// background, by TestTextOverlayStaysFramedWhenLinesSoftWrapPastWidth.
+func TestGeneralHelpStaysCenteredWhenScrolledAt80x24(t *testing.T) {
+	const termWidth, termHeight = 80, 24
+
+	h := newTestHome(t)
+	resizeHome(h, termWidth, termHeight)
+	_, _ = h.showHelpScreen(helpTypeGeneral{}, nil)
+
+	for step := 0; step < 30; step++ {
+		out := h.View()
+		// The whole-window contract: a taller-than-terminal box makes PlaceOverlay
+		// return the raw foreground, which is only box-wide and overflows the
+		// height — failing both the per-line width and the line-count checks here.
+		requireViewSized(t, out, termWidth, termHeight)
+		// A scroll marker proves the framed, scrollable overlay is actually
+		// composited on top — not that PlaceOverlay silently dropped it.
+		require.Containsf(t, out, "more", "step %d: the scrollable help overlay must stay on screen", step)
+
+		_, _ = h.handleHelpState(tea.KeyMsg{Type: tea.KeyCtrlD})
+		require.Equalf(t, stateHelp, h.state, "step %d: Ctrl-D must scroll, not dismiss the help overlay", step)
+	}
+}
+
 func TestGeneralHelpOverlayShiftArrowsScrollAt80x24(t *testing.T) {
 	h := newTestHome(t)
 	resizeHome(h, 80, 24)

--- a/ui/overlay/textOverlay.go
+++ b/ui/overlay/textOverlay.go
@@ -5,7 +5,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/muesli/reflow/wordwrap"
+	xansi "github.com/charmbracelet/x/ansi"
 
 	"github.com/sachiniyer/agent-factory/ui"
 )
@@ -158,8 +158,16 @@ func (t *TextOverlay) visibleContent() string {
 	return strings.Join(visible, "\n")
 }
 
+// wrappedContentLines splits the content into the physical rows the box will
+// actually render. It MUST use the same wrapper lipgloss applies internally
+// (ansi.Wrap at width−padding, hard-breaking over-long words) so every logical
+// line here maps to exactly one rendered row. wordwrap.String is a *soft* wrap
+// that can leave a line one cell past the limit; lipgloss then re-wraps that
+// line into two rows, so the scroll/height math — which counts one line as one
+// row — under-counts, the box grows past the terminal, and PlaceOverlay dumps
+// the raw un-centered frame with its top border clipped (#1998).
 func (t *TextOverlay) wrappedContentLines() []string {
-	return strings.Split(wordwrap.String(t.content, t.textWidth()), "\n")
+	return strings.Split(xansi.Wrap(t.content, t.textWidth(), ""), "\n")
 }
 
 func textOverlayScrollMarker(width int, marker string) string {

--- a/ui/overlay/textOverlay_test.go
+++ b/ui/overlay/textOverlay_test.go
@@ -1,11 +1,13 @@
 package overlay
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/muesli/ansi"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // wideContent produces content whose natural render width exceeds a typical
@@ -123,6 +125,83 @@ func TestTextOverlayScrollsContent(t *testing.T) {
 	overlay.ScrollUp()
 	rendered = overlay.Render()
 	assert.Contains(t, rendered, "title", "scrolling up returns toward the top")
+}
+
+// visibleColumnOf returns the printable column at which sub first appears in an
+// ANSI-styled line, or -1 if absent. Used to check where the box frame lands
+// after PlaceOverlay composites it, independent of the styling on the line.
+func visibleColumnOf(line, sub string) int {
+	idx := strings.Index(line, sub)
+	if idx < 0 {
+		return -1
+	}
+	return ansi.PrintableRuneWidth(line[:idx])
+}
+
+// TestTextOverlayStaysFramedWhenLinesSoftWrapPastWidth is the #1998 regression
+// guard at the component level. At 80x24 the general help wraps to lines one
+// cell past the box's text width; a *soft* wrapper (wordwrap) leaves them there
+// and lipgloss then re-wraps each into two rows, so the box grew one row per
+// such visible line, overflowed the terminal, and PlaceOverlay fell back to
+// dumping the raw frame at column 0 with its top border clipped. The wrap must
+// match lipgloss's own (ansi.Wrap) so one logical line is exactly one rendered
+// row; then the box height and centering hold at every scroll offset — even
+// scrolled past content-end.
+func TestTextOverlayStaysFramedWhenLinesSoftWrapPastWidth(t *testing.T) {
+	// Interleave the real help line that soft-wraps to textWidth+1 (44→45 at the
+	// 80x24 geometry) with filler so the overlay is tall enough to scroll.
+	var b strings.Builder
+	for i := 0; i < 30; i++ {
+		if i%3 == 0 {
+			b.WriteString("c              - Retry a session blocked at a usage\n")
+		} else {
+			b.WriteString(fmt.Sprintf("line %d filler text for the help body\n", i))
+		}
+	}
+	ov := NewTextOverlay(strings.TrimRight(b.String(), "\n"))
+	// 80x24 help geometry: width = int(0.6*80) = 48, height = 24 - 2 = 22.
+	const (
+		termWidth, termHeight = 80, 24
+		boxHeight             = termHeight - 2 // outer height layoutTextOverlay sets
+	)
+	ov.SetWidth(48)
+	ov.SetHeight(boxHeight)
+
+	bgLine := strings.Repeat(" ", termWidth)
+	bgLines := make([]string, termHeight)
+	for i := range bgLines {
+		bgLines[i] = bgLine
+	}
+	bg := strings.Join(bgLines, "\n")
+
+	// Drive the scroll offset from the top well past content-end.
+	for step := 0; step <= 40; step++ {
+		fg := ov.Render()
+		require.Equal(t, boxHeight, strings.Count(fg, "\n")+1,
+			"step %d: box must stay within its %d-row height budget", step, boxHeight)
+
+		placed := PlaceOverlay(0, 0, fg, bg, true)
+		lines := strings.Split(placed, "\n")
+		require.Len(t, lines, termHeight,
+			"step %d: composited view must stay exactly terminal height", step)
+
+		// The top border must be present and horizontally centered — never
+		// flush at column 0 (the raw-fg fallback signature).
+		topRow, topCol := -1, -1
+		for i, l := range lines {
+			if c := visibleColumnOf(l, "╭"); c >= 0 {
+				topRow, topCol = i, c
+				break
+			}
+		}
+		require.GreaterOrEqual(t, topRow, 0, "step %d: top border ╭ must be visible", step)
+		expectedCol := (termWidth - ansi.PrintableRuneWidth(strings.Split(fg, "\n")[0])) / 2
+		require.Greater(t, expectedCol, 0, "sanity: centered box must have a left margin")
+		require.Equal(t, expectedCol, topCol,
+			"step %d: box must stay centered, not collapse toward column 0", step)
+
+		ov.ScrollDown()
+	}
 }
 
 func TestTextOverlayHeightWindowsWrappedContent(t *testing.T) {


### PR DESCRIPTION
Fixes #1998.

## Symptom
Rapidly scrolling the general help overlay at 80x24 (repeated `Ctrl-D`) corrupts its layout: the modal jumps from centered to column 0, the top border is clipped, and the surrounding TUI blanks — until it's scrolled back up. The tmux window stays exactly 80x24 throughout.

## Root cause
`TextOverlay.wrappedContentLines` pre-wrapped the content with `wordwrap.String`, a **soft** wrapper: it breaks on word boundaries but can leave a line one cell past the limit. At the 80x24 help geometry (box width 48 → text width 44) the row

```
c              - Retry a session blocked at a usage …
```

soft-wraps to **45** columns. The scroll/height math counts one wrapped line as one rendered row, but lipgloss — which actually renders the bordered box — **hard-wraps** that 45-col line into **two** physical rows. So:

1. The box grew one row for every such over-wide line in the visible window.
2. `lipgloss.Height(inner)` is a *minimum*, not a cap, so the box was allowed to exceed the 24-row terminal.
3. `PlaceOverlay`'s `fgHeight > bgHeight` guard then returned the **raw** foreground — a ~50-col frame at column 0, its top border scrolled off, the faded background dropped entirely.

That is exactly the reported ~50-column fragment at column 0 with the missing `╭` and blank TUI.

## Fix
Pre-wrap with the **same** wrapper lipgloss uses internally — `ansi.Wrap(content, textWidth, "")` (`charmbracelet/x/ansi`, already imported by this package) — so every logical line maps to exactly one rendered row. The scroll windowing, the `Height(inner)` decision, and the `maxScroll` clamp all then operate on accurate physical-row counts, and the box height + centering stay stable at every scroll offset (including past content-end). One-line change; the scroll offset was already clamped to `[0, maxScroll]`.

## Fail-first evidence (observed failing at `288d7bf`)
Both tests were run against the pre-fix (`wordwrap`) code and **failed**, then pass after the fix:

- `ui/overlay` · `TestTextOverlayStaysFramedWhenLinesSoftWrapPastWidth` — component level, over a blank background. Drives the scroll offset from 0 well past content-end; asserts the box stays within its height budget and the top border stays present and centered (stable left column > 0). Pre-fix: box grew to **27 rows** (budget 22) at step 0.
- `app` · `TestGeneralHelpStaysCenteredWhenScrolledAt80x24` — real production path: `showHelpScreen(helpTypeGeneral{})` → real `Ctrl-D` key handler → `home.View()`. Asserts the composited window stays exactly 80x24 via the repo's `requireViewSized` whole-window contract. Pre-fix: `View` rendered **25 lines** (and only box-wide), failing the contract.

Both exercise the real render path (real help content + real key/view path), not a helper that bypasses the wrap.

## Adjacent call-site audit
`wordwrap.String` was the **only** soft-wrap-then-window site in the tree (grep-verified). The sibling overlays — search, confirmation, selection, project-picker — route through `ui/overlay/fit.go`'s `wrapOverlayLines`, which already uses `xansi.Wrap` **plus** a per-line truncate safety net, so they cannot exhibit this class. Other `reflow`/"reflow" hits are the tmux emulator grid, unrelated. No follow-up needed.

## Scope / verification
- Files: `ui/overlay/textOverlay.go` (fix), `ui/overlay/textOverlay_test.go` + `app/help_test.go` (regression tests). No `daemon/` or `web/` changes.
- Green on host-safe suites: `gofmt -l`, `go build ./...`, `golangci-lint run --fast`, `deadcode -test ./...`, `go test ./ui/...`, `go test ./app/`.
- This is a **visible TUI** change — a real 80x24 play-test is the merge gate (owner-run), on top of these tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)