### PR TITLE
feat(web): restore an archived session from the web (#1932)

### DIFF
--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -270,7 +270,7 @@
         "pointer": "api/sessions.go:741 sessionsArchiveCmd"
       },
       "verdict": "parity",
-      "notes": "Reachable everywhere — but see session.restore: on the web this is a one-way door."
+      "notes": "Reachable everywhere. Restorable everywhere too as of #1932 — see session.restore, which closed the web's archive-only one-way door."
     },
     {
       "id": "session.restore",
@@ -280,16 +280,15 @@
         "pointer": "keys/keys.go:148 (r) -> app/session_control.go:172"
       },
       "web": {
-        "status": "no",
-        "pointer": "no RestoreSession/RestoreArchived call anywhere in web/src (grep-verified)"
+        "status": "yes",
+        "pointer": "web/src/api.ts:330 restoreSession -> RestoreSession; the pane header's Archive button becomes Restore on an archived row (web/src/ui.ts renderMain/patchMainHead)"
       },
       "cli": {
         "status": "yes",
         "pointer": "api/sessions.go:823 sessionsRestoreCmd"
       },
-      "verdict": "real-gap",
-      "issue": "#1932",
-      "notes": "Highest-impact gap found. The web can archive but not restore, so archive is a reachable dead end. Worse, the web already handles the session.restored event (web/src/sessions.ts:85) and its own copy instructs users to do the thing it cannot do: modals.ts:261 'You can restore it later.', modals.ts:292 'restore any of them to bring the project back', split.ts:868 'Restore it to open VS Code.'"
+      "verdict": "parity",
+      "notes": "Reachable everywhere as of #1932, which closed the archive-only one-way door: the web POSTs RestoreSession by title (no id field on the request, unlike archive/kill) and already handled the session.restored resync (web/src/sessions.ts:85). Since RestoreSession also recovers Lost/Dead rows, this gave the web its Lost-recovery off-ramp too."
     },
     {
       "id": "session.limit-retry",
@@ -1379,6 +1378,7 @@
       "RemoveTask": "task.remove",
       "RenameTab": "session.tab.rename",
       "ReorderTab": "session.tab.reorder",
+      "RestoreSession": "session.restore",
       "SendPrompt": "session.send-prompt",
       "SetConfigValue": "config.write",
       "Snapshot": "session.list",

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -6250,6 +6250,9 @@ async function killSession(id, title, token2) {
 async function archiveSession(id, title, token2) {
   await af("ArchiveSession", { id, title, repo_id: "" }, token2);
 }
+async function restoreSession(title, token2) {
+  await af("RestoreSession", { title, repo_id: "" }, token2);
+}
 async function deleteProject(root2, token2) {
   return af("DeleteProject", { repo_path: root2, repo_id: "" }, token2);
 }
@@ -6600,20 +6603,33 @@ function promptModal(sessionTitle, callbacks) {
   return handle;
 }
 function confirmModal(opts) {
-  const isKill = opts.action === "kill";
+  const copy = {
+    kill: {
+      title: `Kill ${opts.sessionTitle}?`,
+      confirmLabel: "Kill",
+      confirmClass: "af-danger",
+      body: "This permanently destroys the session and prunes its branch. This can't be undone."
+    },
+    archive: {
+      title: `Archive ${opts.sessionTitle}?`,
+      confirmLabel: "Archive",
+      confirmClass: "af-primary",
+      body: "This tears down the session's terminal and moves its worktree to the archive. You can restore it later."
+    },
+    restore: {
+      title: `Restore ${opts.sessionTitle}?`,
+      confirmLabel: "Restore",
+      confirmClass: "af-primary",
+      body: "This moves the session's worktree back next to its repo and re-spawns the agent, returning it to the live rail."
+    }
+  }[opts.action];
   const { handle, body } = modalChrome({
-    title: isKill ? `Kill ${opts.sessionTitle}?` : `Archive ${opts.sessionTitle}?`,
-    confirmLabel: isKill ? "Kill" : "Archive",
-    confirmClass: isKill ? "af-danger" : "af-primary",
+    title: copy.title,
+    confirmLabel: copy.confirmLabel,
+    confirmClass: copy.confirmClass,
     onCancel: opts.onCancel
   });
-  body.append(
-    h(
-      "p",
-      { class: "af-modal-text" },
-      isKill ? "This permanently destroys the session and prunes its branch. This can't be undone." : "This tears down the session's terminal and moves its worktree to the archive. You can restore it later."
-    )
-  );
+  body.append(h("p", { class: "af-modal-text" }, copy.body));
   const card = handle.el.firstElementChild;
   asForm(card, () => {
     handle.setError(null);
@@ -9961,6 +9977,13 @@ var AppShell = class {
   // Header text nodes for the selected pane, (re)created per selection.
   headTitle = null;
   headMeta = null;
+  // The archive/restore lifecycle button and the archived-ness it currently shows
+  // (#1932). The header STRUCTURE is only rebuilt on a selection change, but a session
+  // can flip archived⇄live WITHOUT one (archiving or restoring the row that is already
+  // selected — the common path), so patchMainHead swaps this button's verb in place,
+  // exactly as it patches the header text. null when nothing is selected.
+  lifecycleBtn = null;
+  lifecycleArchived = false;
   // The tab bar for the selected session, (re)created per selection and patched in
   // place when the tab list or active tab changes (#1592 Phase 5 PR7). null when
   // nothing is selected (the empty state has no tabs).
@@ -10433,6 +10456,7 @@ var AppShell = class {
     if (!selected) {
       this.headTitle = null;
       this.headMeta = null;
+      this.lifecycleBtn = null;
       this.tabBar = null;
       this.main.className = "af-main af-main-empty";
       this.main.replaceChildren(
@@ -10446,11 +10470,17 @@ var AppShell = class {
     const titleBox = h2("div", { class: "af-term-head-main" }, this.headTitle, this.headMeta);
     const promptBtn = h2("button", { type: "button", class: "af-ghost af-term-action" }, "Prompt");
     promptBtn.addEventListener("click", () => this.actions.sendPrompt());
-    const archiveBtn = h2("button", { type: "button", class: "af-ghost af-term-action" }, "Archive");
-    archiveBtn.addEventListener("click", () => this.actions.archive());
+    this.lifecycleArchived = isArchived(selected);
+    const lifecycleBtn = h2(
+      "button",
+      { type: "button", class: "af-ghost af-term-action" },
+      this.lifecycleArchived ? "Restore" : "Archive"
+    );
+    lifecycleBtn.addEventListener("click", () => this.lifecycleArchived ? this.actions.restore() : this.actions.archive());
+    this.lifecycleBtn = lifecycleBtn;
     const killBtn = h2("button", { type: "button", class: "af-danger af-term-action" }, "Kill");
     killBtn.addEventListener("click", () => this.actions.kill());
-    const actions2 = h2("div", { class: "af-term-actions" }, promptBtn, archiveBtn, killBtn);
+    const actions2 = h2("div", { class: "af-term-actions" }, promptBtn, lifecycleBtn, killBtn);
     const head = h2("div", { class: "af-term-head" }, titleBox, actions2);
     this.tabBar = h2("div", { class: "af-tabbar" });
     this.tabBar.setAttribute("role", "tablist");
@@ -10641,6 +10671,11 @@ var AppShell = class {
     }
     this.headMeta.textContent = parts.join(" \xB7 ");
     this.headMeta.className = `af-term-meta af-term-${state.termStatus}`;
+    const nowArchived = isArchived(selected);
+    if (this.lifecycleBtn && nowArchived !== this.lifecycleArchived) {
+      this.lifecycleArchived = nowArchived;
+      this.lifecycleBtn.textContent = nowArchived ? "Restore" : "Archive";
+    }
   }
 };
 var APP_NAME = "Agent Factory";
@@ -11097,7 +11132,7 @@ function openConfirm(action) {
         }
         const m = modal;
         m.setBusy(true);
-        const run = action === "kill" ? killSession(sel.id, sel.title, tok) : archiveSession(sel.id, sel.title, tok);
+        const run = action === "kill" ? killSession(sel.id, sel.title, tok) : action === "archive" ? archiveSession(sel.id, sel.title, tok) : restoreSession(sel.title, tok);
         void run.then(closeModal).catch((e) => {
           m.setBusy(false);
           m.setError(describeError(e));
@@ -11376,6 +11411,7 @@ var actions = {
   sendPrompt: openSendPrompt,
   kill: () => openConfirm("kill"),
   archive: () => openConfirm("archive"),
+  restore: () => openConfirm("restore"),
   switchTab,
   openTab,
   newTab: createSessionTab,

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "6dbb6e7b5724";
+const VERSION = "7b5aeb8a7044";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -2096,6 +2096,63 @@ test("archive: the archive confirm retires the session out of the default rail",
   await expect(row(page, SESSION_B)).toHaveCount(0);
 });
 
+test("restore (#1932): the pane header's Restore action brings an archived session back to the live rail", async () => {
+  // The return leg of archive. The preceding test left B archived; the web could
+  // shelve a session but — until #1932 — offered no way back, contradicting the "you
+  // can restore it later" copy the archive confirm itself prints. This drives the real
+  // round-trip through the daemon AND pins the LIVE button swap: renderMain (which
+  // builds the pane header) runs only on a selection change, so archiving/restoring
+  // the row that STAYS selected has to flip Archive⇄Restore in place — the exact bug
+  // the first cut of this test caught (an archived, still-selected row kept its stale
+  // Archive button, a daemon no-op).
+  //
+  // Hold the archived filter ON for the whole flow so B stays visible in the rail
+  // across both transitions; restore the default (archived hidden) only at the end,
+  // leaving B archived for the downstream filter tests.
+  await setFilter(page, "archived", true);
+  await expect(row(page, SESSION_B)).toHaveClass(/af-row-archived/, { timeout: 30_000 });
+
+  await row(page, SESSION_B).click();
+  await expect(page.locator(".af-main.af-main-term")).toBeVisible();
+
+  // An archived session's lifecycle button IS Restore, not Archive — the reverse verb
+  // on the same slot, never a second button.
+  const head = page.locator(".af-term-head");
+  await expect(head.locator("button", { hasText: "Archive" })).toHaveCount(0);
+  await head.locator("button", { hasText: "Restore" }).click();
+
+  // Restore is a confirm (mirroring kill/archive), so it inherits their busy/error
+  // surface; the primary button POSTs RestoreSession.
+  const restoreModal = page.locator(".af-modal-card");
+  await expect(restoreModal).toBeVisible();
+  await expect(restoreModal).toContainText("Restore");
+  await restoreModal.locator("button.af-primary").click();
+
+  // The daemon's session.restored event resyncs the rail: B rejoins the LIVE group,
+  // no longer archived — the end-to-end proof the archived session returned to active.
+  await expect(row(page, SESSION_B)).not.toHaveClass(/af-row-archived/, { timeout: 30_000 });
+  // ...and its pane header — STILL selected, never reselected — flips its verb back to
+  // Archive in place: the patchMainHead swap the selection-change-only rebuild misses.
+  await expect(head.locator("button", { hasText: "Restore" })).toHaveCount(0, { timeout: 30_000 });
+  await expect(head.locator("button", { hasText: "Archive" })).toHaveCount(1);
+
+  // Re-archive from that same live-flipped button (NO reselect): restores the fixture
+  // the downstream filter tests need (B archived) and re-proves both the archive leg
+  // and the reverse (Archive→Restore) live flip in one flow.
+  await head.locator("button", { hasText: "Archive" }).click();
+  const archiveModal = page.locator(".af-modal-card");
+  await expect(archiveModal).toBeVisible();
+  await archiveModal.locator("button.af-primary").click();
+  await expect(row(page, SESSION_B)).toHaveClass(/af-row-archived/, { timeout: 30_000 });
+  await expect(head.locator("button", { hasText: "Archive" })).toHaveCount(0);
+  await expect(head.locator("button", { hasText: "Restore" })).toHaveCount(1);
+
+  // Back to the default filter (archived hidden): B drops from the rail, exactly as
+  // the archive test left it.
+  await resetFilter(page);
+  await expect(row(page, SESSION_B)).toHaveCount(0);
+});
+
 test("#1933: a backend availability refresh must not re-enable Create mid-submit", async () => {
   // The race: a ListBackends is in flight when the user submits, and its response
   // lands DURING the create. Re-rendering the choices must not decide, on its own,

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -21,6 +21,7 @@ import {
   removeTask,
   renameTab,
   reorderTab,
+  restoreSession,
   sendPrompt,
   triggerTask,
   updateTask,
@@ -119,6 +120,30 @@ test("archiveSession posts the stable id alongside the title", async () => {
   assert.equal(cap.body.id, "id-repoB");
   assert.equal(cap.body.title, "feature");
   assert.equal(cap.body.repo_id, "");
+});
+
+// restoreSession is the archive round-trip's missing return leg (#1932): the web
+// could archive but never restore. Unlike kill/archive it resolves by TITLE only —
+// the daemon's RestoreSessionRequest (daemon/control_types.go) has no `id` field —
+// so these pin BOTH that it hits the RestoreSession route the CLI/TUI use AND that
+// it sends NO `id`: a web request carries no client-version header, so the daemon
+// decodes with DisallowUnknownFields and a stray `id` would be a 400.
+test("restoreSession posts to RestoreSession by title, with an empty repo_id", async () => {
+  const cap = stubFetch();
+  await restoreSession("feature", "tok");
+  assert.equal(cap.url, "/v1/RestoreSession", "must hit the same route af sessions restore / the TUI `r` use");
+  assert.equal(cap.auth, "Bearer tok");
+  assert.equal(cap.body.title, "feature");
+  assert.equal(cap.body.repo_id, "", "web is an all-repos client; repo_id stays empty, as it does for archive/kill");
+});
+
+test("restoreSession does NOT send an id (RestoreSessionRequest has no id field)", async () => {
+  const cap = stubFetch();
+  await restoreSession("feature", "tok");
+  // The daemon decodes web requests with DisallowUnknownFields; an `id` key it does
+  // not know would be rejected as a 400 "unknown field". Archive/kill send `id`
+  // only because THEIR request structs accept it — restore's does not.
+  assert.equal("id" in cap.body, false, "no id key may reach the daemon, or DisallowUnknownFields 400s the restore");
 });
 
 test("sendPrompt posts the stable id alongside the title and prompt", async () => {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -315,6 +315,22 @@ export async function archiveSession(id: string, title: string, token: string): 
   await af("ArchiveSession", { id, title, repo_id: "" }, token);
 }
 
+/** Restores an archived, Lost, or Dead session (mirrors `af sessions restore`) —
+ *  the reverse of archive: the daemon moves the worktree back next to the repo and
+ *  re-spawns the agent (#1932). RestoreSession, unlike Archive/Kill, resolves the
+ *  target by TITLE alone: its request struct (daemon/control_types.go
+ *  RestoreSessionRequest) has no `id` field, exactly as `af sessions restore
+ *  <title>` sends only {Title, RepoID}. So — unlike archiveSession — this MUST NOT
+ *  send `id`: a web request carries no X-AF-Client-Version header, so the daemon
+ *  decodes it with DisallowUnknownFields (daemon/httpserver.go) and a stray `id`
+ *  would be rejected as a 400 "unknown field". repo_id stays empty, matching the
+ *  other all-repos web callers; a duplicate title across repos surfaces the
+ *  daemon's ambiguous-title error rather than restoring the wrong one. The
+ *  session.restored event triggers a rail resync. */
+export async function restoreSession(title: string, token: string): Promise<void> {
+  await af("RestoreSession", { title, repo_id: "" }, token);
+}
+
 /** The daemon's DeleteProject response: how many sessions it archived vs tore
  *  down (in-place ones that can't be archived). */
 export interface DeleteProjectResult {

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -35,6 +35,7 @@ import {
   removeTask,
   renameTab,
   reorderTab,
+  restoreSession,
   sendPrompt,
   storeToken,
   triggerTask,
@@ -584,8 +585,10 @@ function openSendPrompt(): void {
   );
 }
 
-/** Opens the kill/archive confirm modal for the selected session. */
-function openConfirm(action: "kill" | "archive"): void {
+/** Opens the kill/archive/restore confirm modal for the selected session. Restore
+ *  is the reverse of archive (#1932): the archived row's Archive button becomes a
+ *  Restore button, and confirming it POSTs RestoreSession. */
+function openConfirm(action: "kill" | "archive" | "restore"): void {
   const sel = selectedSession();
   if (!sel) {
     return;
@@ -602,8 +605,14 @@ function openConfirm(action: "kill" | "archive"): void {
         }
         const m = modal;
         m.setBusy(true);
+        // Restore resolves the target by TITLE only — its daemon request has no id
+        // field (see restoreSession), unlike kill/archive which key by sel.id.
         const run =
-          action === "kill" ? killSession(sel.id, sel.title, tok) : archiveSession(sel.id, sel.title, tok);
+          action === "kill"
+            ? killSession(sel.id, sel.title, tok)
+            : action === "archive"
+              ? archiveSession(sel.id, sel.title, tok)
+              : restoreSession(sel.title, tok);
         void run.then(closeModal).catch((e) => {
           m.setBusy(false);
           m.setError(describeError(e));
@@ -1150,6 +1159,7 @@ const actions = {
   sendPrompt: openSendPrompt,
   kill: () => openConfirm("kill"),
   archive: () => openConfirm("archive"),
+  restore: () => openConfirm("restore"),
   switchTab,
   openTab,
   newTab: createSessionTab,

--- a/web/src/modals.ts
+++ b/web/src/modals.ts
@@ -344,27 +344,45 @@ export function promptModal(
   return handle;
 }
 
-/** A destructive-action confirm modal (kill or archive). */
+/** A session-lifecycle confirm modal (kill, archive, or restore). Kill is
+ *  destructive; archive/restore are the reversible pair (#1932). */
 export function confirmModal(
-  opts: { action: "kill" | "archive"; sessionTitle: string; onConfirm: () => void; onCancel: () => void },
+  opts: { action: "kill" | "archive" | "restore"; sessionTitle: string; onConfirm: () => void; onCancel: () => void },
 ): ModalHandle {
-  const isKill = opts.action === "kill";
+  // Restore is the reverse of archive (#1932): non-destructive, so it reads as a
+  // primary (not danger) confirm, mirroring archive's own class. The web routes it
+  // through this same confirm chrome as kill/archive so it inherits their busy +
+  // error surface; the copy makes true the "you can restore it later" promise the
+  // archive confirm already prints.
+  const copy = {
+    kill: {
+      title: `Kill ${opts.sessionTitle}?`,
+      confirmLabel: "Kill",
+      confirmClass: "af-danger",
+      body: "This permanently destroys the session and prunes its branch. This can't be undone.",
+    },
+    archive: {
+      title: `Archive ${opts.sessionTitle}?`,
+      confirmLabel: "Archive",
+      confirmClass: "af-primary",
+      body: "This tears down the session's terminal and moves its worktree to the archive. You can restore it later.",
+    },
+    restore: {
+      title: `Restore ${opts.sessionTitle}?`,
+      confirmLabel: "Restore",
+      confirmClass: "af-primary",
+      body: "This moves the session's worktree back next to its repo and re-spawns the agent, returning it to the live rail.",
+    },
+  }[opts.action];
+
   const { handle, body } = modalChrome({
-    title: isKill ? `Kill ${opts.sessionTitle}?` : `Archive ${opts.sessionTitle}?`,
-    confirmLabel: isKill ? "Kill" : "Archive",
-    confirmClass: isKill ? "af-danger" : "af-primary",
+    title: copy.title,
+    confirmLabel: copy.confirmLabel,
+    confirmClass: copy.confirmClass,
     onCancel: opts.onCancel,
   });
 
-  body.append(
-    h(
-      "p",
-      { class: "af-modal-text" },
-      isKill
-        ? "This permanently destroys the session and prunes its branch. This can't be undone."
-        : "This tears down the session's terminal and moves its worktree to the archive. You can restore it later.",
-    ),
-  );
+  body.append(h("p", { class: "af-modal-text" }, copy.body));
 
   const card = handle.el.firstElementChild as HTMLElement;
   asForm(card, () => {

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -139,6 +139,9 @@ export interface Actions {
   kill(): void;
   /** Opens the archive-confirm modal for the current selection. */
   archive(): void;
+  /** Opens the restore-confirm modal for the current selection (an archived / Lost
+   *  / Dead session): the reverse of archive (#1932). */
+  restore(): void;
   /** Switches the selected session's active tab WITHOUT attaching — the keyboard
    *  stays in rail nav mode (the 1-9 keys, mirroring the TUI). */
   switchTab(index: number): void;
@@ -546,6 +549,13 @@ export class AppShell {
   // Header text nodes for the selected pane, (re)created per selection.
   private headTitle: HTMLElement | null = null;
   private headMeta: HTMLElement | null = null;
+  // The archive/restore lifecycle button and the archived-ness it currently shows
+  // (#1932). The header STRUCTURE is only rebuilt on a selection change, but a session
+  // can flip archived⇄live WITHOUT one (archiving or restoring the row that is already
+  // selected — the common path), so patchMainHead swaps this button's verb in place,
+  // exactly as it patches the header text. null when nothing is selected.
+  private lifecycleBtn: HTMLElement | null = null;
+  private lifecycleArchived = false;
   // The tab bar for the selected session, (re)created per selection and patched in
   // place when the tab list or active tab changes (#1592 Phase 5 PR7). null when
   // nothing is selected (the empty state has no tabs).
@@ -1325,6 +1335,7 @@ export class AppShell {
     if (!selected) {
       this.headTitle = null;
       this.headMeta = null;
+      this.lifecycleBtn = null;
       this.tabBar = null;
       // Detaches the terminal host if it was mounted; index.ts disposes the terminal.
       this.main.className = "af-main af-main-empty";
@@ -1342,11 +1353,25 @@ export class AppShell {
     // behind a confirm. They act on the current selection; index.ts reads it.
     const promptBtn = h("button", { type: "button", class: "af-ghost af-term-action" }, "Prompt");
     promptBtn.addEventListener("click", () => this.actions.sendPrompt());
-    const archiveBtn = h("button", { type: "button", class: "af-ghost af-term-action" }, "Archive");
-    archiveBtn.addEventListener("click", () => this.actions.archive());
+    // Archive and restore are reverse verbs on the same slot: an archived session
+    // can't be archived again (the daemon rejects it, mirroring the TUI's `a`
+    // no-op), and restore is the only way back — so an archived row shows Restore
+    // where a live row shows Archive (#1932). This makes the "you can restore it
+    // later" copy the archive confirm prints actually reachable from the web. The
+    // click handler reads this.lifecycleArchived (not a render-time capture) so
+    // patchMainHead can flip the verb in place when the row is archived/restored
+    // while it stays selected, without a header rebuild.
+    this.lifecycleArchived = isArchived(selected);
+    const lifecycleBtn = h(
+      "button",
+      { type: "button", class: "af-ghost af-term-action" },
+      this.lifecycleArchived ? "Restore" : "Archive",
+    );
+    lifecycleBtn.addEventListener("click", () => (this.lifecycleArchived ? this.actions.restore() : this.actions.archive()));
+    this.lifecycleBtn = lifecycleBtn;
     const killBtn = h("button", { type: "button", class: "af-danger af-term-action" }, "Kill");
     killBtn.addEventListener("click", () => this.actions.kill());
-    const actions = h("div", { class: "af-term-actions" }, promptBtn, archiveBtn, killBtn);
+    const actions = h("div", { class: "af-term-actions" }, promptBtn, lifecycleBtn, killBtn);
 
     const head = h("div", { class: "af-term-head" }, titleBox, actions);
 
@@ -1610,6 +1635,16 @@ export class AppShell {
     }
     this.headMeta.textContent = parts.join(" · ");
     this.headMeta.className = `af-term-meta af-term-${state.termStatus}`;
+
+    // Flip the lifecycle button's verb if the selected row was archived or restored
+    // without a selection change (renderMain, which builds the button, runs only on a
+    // selection change — #1932). Archiving the currently-selected session must turn
+    // its Archive button into Restore live, and a restore must turn it back.
+    const nowArchived = isArchived(selected);
+    if (this.lifecycleBtn && nowArchived !== this.lifecycleArchived) {
+      this.lifecycleArchived = nowArchived;
+      this.lifecycleBtn.textContent = nowArchived ? "Restore" : "Archive";
+    }
   }
 }
 


### PR DESCRIPTION
Closes #1932.

## The gap

The web could **archive** a session (`archiveSession`, `web/src/api.ts`) but had **no way to restore one** — `web/src` had zero hits for restore anywhere. Archive is the reap action we recommend *because it's reversible*, so a web-only user shelved a session (or deleted a project, which archives its live sessions) and, from the surface they were standing in, it was gone. The web's own copy even promised the undo it couldn't deliver (`modals.ts` "You can restore it later", `split.ts` "Restore it to open VS Code").

The daemon already serves `RestoreSession` publicly (`daemon/httproutes.go`); the TUI (`r`) and CLI (`af sessions restore`) both use it. This adds the missing web button on a capability that already works.

## What changed (web/src only + regenerated bundle)

- **`api.ts`** — new `restoreSession(title, token)` POSTing `RestoreSession`, mirroring `af sessions restore` / the TUI `r`.
- **`modals.ts`** — `confirmModal` gains a non-destructive `restore` variant (primary, not danger), inheriting the same busy/error surface as kill/archive.
- **`ui.ts`** — the pane header's Archive button becomes **Restore** on an archived row (reverse verbs on one slot; archive is a daemon no-op on an already-archived session). Plus a real fix — see below.
- **`index.ts`** — wires the `restore` action through `openConfirm`.
- **`web/dist/*`** — regenerated with `make web-build` (the selftest serves committed dist, never src). `af-web.css` unchanged (reused existing classes).

## Request-shape gotcha (the key correctness point)

The issue suggested POSTing `{id, title, repo_id: ""}` like archive/kill. **That would 400.** `RestoreSessionRequest` (`daemon/control_types.go`) has **no `id` field** — it resolves by `{Title, RepoID}` only, exactly as the CLI sends. The web sends no `X-AF-Client-Version` header, so the daemon decodes web requests with `DisallowUnknownFields` (`daemon/httpserver.go`); a stray `id` is rejected as "unknown field". So `restoreSession` sends `{title, repo_id: ""}` and **omits `id`** — the faithful mirror of the TUI/CLI shape. A unit test pins exactly this (route + no-`id`).

## A real bug the selftest caught (not just a missing button)

The pane header (`renderMain`) is rebuilt **only on a selection change**; a session that flips archived⇄live *while it stays selected* is patched by `patchMainHead`, which updated header text but **not the buttons**. Since archiving the currently-open session is the common path, the Archive button stayed stale (a no-op) and never became Restore. Fixed by having `patchMainHead` swap the lifecycle verb in place (the same mechanism it already uses for header text). The selftest's first run failed on exactly this; the fix flips it green.

## Fail-first evidence (observed failing at `ad20df3`)

1. **API unit test** (`api.test.ts`) — with `restoreSession` absent: `SyntaxError: ... does not provide an export named 'restoreSession'`. With the fix: 37/37 pass. Asserts the call hits `/v1/RestoreSession` with `{title, repo_id: ""}` and sends **no** `id`.
2. **Playwright selftest** (`web/selftest/web-driver.spec.ts`) — a real archive→restore→active round-trip through the daemon UI. First run **failed** at `expect(head … "Archive").toHaveCount(0)` → `Received: 1` (the stale-button bug). With the fix: **95/95 pass** via `make web-selftest-container`. The test also pins the live Archive⇄Restore flip in place (no reselect).

## Adjacent-call-site audit

- **Lifecycle callers send `id` where the struct accepts it.** kill/archive/sendPrompt/createTab/closeTab send `id` because their request structs have an `id` field. `RestoreSession` is the one route whose struct doesn't, so `restoreSession` correctly omits it (verified against `daemon/control_types.go` + the `DisallowUnknownFields` decoder). Grep confirms no other restore call site in `web/src`.
- **Liveness-gated header affordances.** Prompt/Kill don't vary by liveness (no swap needed). The tab-management `+`/`×` are liveness-gated but already re-render via `tabBarSig` (covered by the passing archived-web-tab test). The lifecycle button was the only header element missing a liveness-driven in-place update; `patchMainHead` now handles it.
- **Out of scope (noted):** `split.ts` archived placeholders ("Restore it to open VS Code") are now *actionable* via the pane header. An in-placeholder Restore button could be a small follow-up, but the issue scoped this to the pane-header swap.

## Also unlocked

`RestoreSession` handles archived/Lost/Dead alike, so the web now also has the Lost-session recovery off-ramp it never had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
