### PR TITLE
fix(daemon): delete the row on a successful remote reap whose in-sandbox /kill REST call failed (#2017)

### DIFF
--- a/daemon/kill_remote_reap_test.go
+++ b/daemon/kill_remote_reap_test.go
@@ -1,0 +1,81 @@
+package daemon
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// TestKillSession_RemoteReapSucceededDeletesRowWithoutMisleadingError is the
+// #2017 regression.
+//
+// A remote (docker/ssh/hook) session is killed after its in-sandbox agent-server
+// has already died — the common reason to kill one. remoteAgentServer.Kill then
+// joins the failed /v1/agent/kill REST call with the sandbox reap
+// (errors.Join(killErr, teardown())); the reap SUCCEEDS, so instance.Kill returns
+// a PLAIN endpoint error whose subject is a dead endpoint, not the workspace.
+// session.TeardownStateUnknown(err) is therefore false — the workspace is provably
+// gone — which is exactly the shape deleteSessionRecord was built to let through
+// and delete the row.
+//
+// The bug: KillSession early-returned on ANY non-nil instance.Kill() error before
+// reaching that choke point, so it surfaced "its workspace was left intact; the
+// kill is recorded and will be retried automatically" (FALSE — the sandbox WAS
+// reaped) and kept the row for a one-poll flicker until finishUserKill deleted it
+// anyway. The fix routes the decision through the SAME TeardownStateUnknown
+// classifier deleteSessionRecord uses, so only an UNKNOWN-state teardown retains.
+//
+// PRE-FIX BEHAVIOR THIS REPRODUCES: KillSession returns the "workspace left
+// intact" error and RETAINS the record on a fully successful reap.
+func TestKillSession_RemoteReapSucceededDeletesRowWithoutMisleadingError(t *testing.T) {
+	// The in-sandbox agent-server is dead: /v1/agent/kill answers with the error
+	// envelope the real agent-server returns for a failed op, so
+	// remoteAgentServer.Kill's killErr is a PLAIN REST error, not
+	// ErrPaneMayBeLive/ErrWorkspaceStateUnknown. runtimeTeardown is nil in this
+	// harness, so the joined error reduces to exactly killErr — the identical shape
+	// errors.Join(killErr, teardown()) collapses to when the sandbox reap SUCCEEDS
+	// (teardown() == nil). That is the input KillSession misclassified.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/v1/agent/kill" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{"message": "in-sandbox agent-server is gone"},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	manager, repoID, repoPath := newStatusTestManager(t)
+	registerStartedRemote(t, manager, repoID, repoPath, "remote-reaped", srv.URL, session.Running)
+	key := daemonInstanceKey(repoID, "remote-reaped")
+
+	killed, err := manager.KillSession(KillSessionRequest{Title: "remote-reaped", RepoID: repoID})
+	if err != nil {
+		if strings.Contains(err.Error(), "left intact") {
+			t.Fatalf("KillSession surfaced the misleading \"workspace left intact\" error on a successful remote reap — the sandbox WAS reaped, only the in-sandbox /kill REST call failed, so the message is false (#2017): %v", err)
+		}
+		t.Fatalf("KillSession returned an unexpected error on a successful remote reap: %v", err)
+	}
+	if killed.Title != "remote-reaped" {
+		t.Fatalf("killed event resolved the wrong session: got %q, want %q", killed.Title, "remote-reaped")
+	}
+
+	// The row MUST be gone with no one-poll flicker: a KNOWN-state teardown (dead
+	// endpoint, successful reap) flows through deleteSessionRecord, which logs the
+	// cause and deletes the record rather than leaving a tombstone for the next poll.
+	if rec := recordFor(t, repoID, "remote-reaped"); rec != nil {
+		t.Fatalf("killed remote session's record must be deleted after a successful reap, still present: %+v", rec)
+	}
+	manager.mu.Lock()
+	_, tracked := manager.instances[key]
+	manager.mu.Unlock()
+	if tracked {
+		t.Fatal("killed remote session must be dropped from the manager after a successful reap")
+	}
+}

--- a/daemon/lost_kill_test.go
+++ b/daemon/lost_kill_test.go
@@ -2,7 +2,7 @@ package daemon
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/sachiniyer/agent-factory/config"
@@ -10,15 +10,21 @@ import (
 	"github.com/sachiniyer/agent-factory/session"
 )
 
-// failKillBackend is a readyFakeBackend whose Kill always errors, modelling a
-// teardown that dies partway — the crash window the kill-intent tombstone
-// (#1108) exists for.
+// failKillBackend is a readyFakeBackend whose Kill reports an UNKNOWN-state
+// teardown — the pane's liveness was never confirmed (session.ErrPaneMayBeLive),
+// so the workspace may still be live and on disk. That is the ONLY teardown
+// outcome that must RETAIN the record: deleting it would orphan a possibly-live
+// workspace, so it is what exercises the #1108 kill-intent tombstone surviving a
+// failed teardown. A PLAIN error would model a teardown that told us the workspace
+// is gone, which deleteSessionRecord/TeardownStateUnknown now (correctly) let
+// through to delete the row (#2017) — so it would no longer model this case at all.
+// Mirrors the unsafeTeardownBackend rationale in kill_commit_test.go.
 type failKillBackend struct {
 	readyFakeBackend
 }
 
 func (failKillBackend) Kill(*session.Instance) error {
-	return errors.New("teardown interrupted")
+	return fmt.Errorf("teardown interrupted: %w", session.ErrPaneMayBeLive)
 }
 
 // recordFor returns the persisted InstanceData for title, or nil.

--- a/daemon/manager_sessions.go
+++ b/daemon/manager_sessions.go
@@ -133,23 +133,40 @@ func (m *Manager) KillSession(req KillSessionRequest) (session.InstanceData, err
 
 	if instance != nil {
 		stage.set("tearing down tmux + worktree")
-		// Returning here deliberately SKIPS the record delete below (#1917). Kill
-		// only errors when the teardown could not be completed safely — tmux never
-		// confirmed a pane dead, or git was cut off mid-removal — and in both cases
-		// the workspace is still there. Dropping the record would orphan it and take
-		// away the only handle the user has to retry through. The tombstone is
-		// already durable, so the kill stays committed: finishUserKill retries it on
-		// every poll until it succeeds, with no daemon restart needed.
-		if teardownErr = instance.Kill(); teardownErr != nil {
+		// Retain + retry ONLY when the teardown's outcome is UNKNOWN, gated on the
+		// SAME session.TeardownStateUnknown classifier deleteSessionRecord uses below
+		// (#2017). Returning here deliberately SKIPS the record delete: an unknown
+		// state — tmux never confirmed a pane dead (ErrPaneMayBeLive), or git was cut
+		// off mid-removal (ErrWorkspaceStateUnknown) — means the workspace may still be
+		// on disk with this record as its only handle, so dropping the record would
+		// orphan it and take away the only handle the user has to retry through. The
+		// tombstone is already durable, so the kill stays committed: finishUserKill
+		// retries it on every poll until it succeeds, with no daemon restart needed.
+		//
+		// A KNOWN-state error must NOT retain, or the message it prints is a lie. A
+		// remote (docker/ssh/hook) session's Kill joins the in-sandbox /v1/agent/kill
+		// REST result with the sandbox reap, so a session whose in-sandbox agent-server
+		// already died — the common reason to kill it — returns the failed REST call
+		// over a SUCCEEDED reap: a plain endpoint error whose subject is a dead
+		// endpoint, not the workspace. The workspace is provably gone, so we fall
+		// through to deleteSessionRecord, which logs that cause and deletes the row —
+		// instead of the old any-non-nil return reporting "its workspace was left
+		// intact … retried automatically" on a fully successful reap and flickering the
+		// row for one poll. Mirrors the create-cleanup gate in manager_create.go.
+		if teardownErr = instance.Kill(); session.TeardownStateUnknown(teardownErr) {
 			log.WarningLog.Printf("kill of session %q could not complete its teardown; the record is kept and the daemon will retry it: %v", req.Title, teardownErr)
 			return session.InstanceData{}, fmt.Errorf("kill of session %q could not finish tearing it down safely, so its workspace was left intact; the kill is recorded and will be retried automatically: %w", req.Title, teardownErr)
 		}
 	} else if data != nil {
 		stage.set("cleaning up ghost record")
-		// Same gate as the live-instance branch above: skip the record delete when
-		// the ghost's tmux never confirmed dead, so its workspace and its record
-		// both survive for finishUserKill to retry (#1917).
-		if teardownErr = ghostCleanup(data, req.Title); teardownErr != nil {
+		// Same gate as the live-instance branch above: retain + retry ONLY on an
+		// UNKNOWN-state teardown, routed through the same session.TeardownStateUnknown
+		// classifier (#1917/#2017). ghostCleanup only ever returns an ErrPaneMayBeLive/
+		// ErrWorkspaceStateUnknown wrapper or nil today, so this is behavior-preserving —
+		// but sharing the predicate keeps this branch from re-introducing the #2017
+		// defect (a known-state error misreported as "workspace left intact"): any
+		// future known-state error would fall through to deleteSessionRecord instead.
+		if teardownErr = ghostCleanup(data, req.Title); session.TeardownStateUnknown(teardownErr) {
 			// NO automatic retry is promised here, deliberately (#1917 round 5).
 			// finishUserKill is reached only from refreshInstanceStatus, which
 			// iterates m.instances — and a ghost is precisely a record that could not


### PR DESCRIPTION
Fixes #2017.

## The bug

`KillSession` (`daemon/manager_sessions.go`) early-returned on **any** non-nil `instance.Kill()` error, before reaching the `deleteSessionRecord` choke point.

For a remote (docker/ssh/hook) session whose in-sandbox agent-server has already died — the common reason to kill one — `remoteAgentServer.Kill()` returns `errors.Join(killErr, teardown())` where `killErr` is the failed `/v1/agent/kill` REST call and `teardown()` (the sandbox reap) **succeeds**. That joined error is a plain REST error, so `session.TeardownStateUnknown(err)` is `false`: the workspace is **provably gone**. `deleteSessionRecord` was built to let exactly this through and delete the row — but `KillSession` intercepted it first, returned

> its workspace was left intact; the kill is recorded and will be retried automatically

(false — the sandbox **was** reaped) and kept the row for a one-poll flicker until `finishUserKill` deleted it anyway. Errs to the safe/retain side; self-heals next poll. Net: a scary/incorrect message on a successful kill + a one-poll row flicker. P3, no data loss.

## The fix

Route the retain-or-delete decision through the **same** `session.TeardownStateUnknown` classifier `deleteSessionRecord` uses, instead of early-returning on any non-nil error:

- **UNKNOWN-state** teardown (`ErrPaneMayBeLive` / `ErrWorkspaceStateUnknown`) → retain + retry with the "workspace left intact" message (workspace may still be on disk with this record as its only handle).
- **KNOWN-state** error (dead endpoint, successful reap) → fall through to `deleteSessionRecord`, which logs the cause and deletes the row. No misleading message, no flicker.

The ghost branch is routed through the same predicate too. `ghostCleanup` only ever returns a state-unknown wrapper or `nil` today, so it is behavior-preserving — but sharing the predicate keeps that branch from re-introducing the same defect.

Scope: `daemon/manager_sessions.go`, KillSession path only. No changes to `health.go`, `manager_persist.go`, or the status/poll code.

## Adjacent call-site audit

Every daemon site that calls `.Kill()` then deletes a record **already** routes classification through `deleteSessionRecord` / `TeardownStateUnknown` — `finishUserKill` (`rootkill.go:152`), `reapDeadRoot` (`rootagent.go:304`), and both create-cleanup paths in `manager_create.go` (`:106`, `:143`, the direct precedent this fix mirrors). `KillSession` was the **sole outlier** still gating on any-non-nil. (`agentserver_headless.go` `.Kill()` calls are the in-sandbox server's own RPC handler, unrelated.)

## Fail-first evidence

New test `TestKillSession_RemoteReapSucceededDeletesRowWithoutMisleadingError` drives a **real** `remoteAgentServer` whose `/v1/agent/kill` REST call fails while the reap succeeds, and asserts the row is deleted with **no** "workspace left intact" message.

**Observed failing on the pre-fix tree** (`daemon/manager_sessions.go` is byte-identical between the fail-first base `c05dd29` and the current PR base `948c5df` — none of the 3 intervening commits touch the KillSession path):

```
=== RUN   TestKillSession_RemoteReapSucceededDeletesRowWithoutMisleadingError
    kill_remote_reap_test.go:61: KillSession surfaced the misleading "workspace left intact" error
    on a successful remote reap … : kill of session "remote-reaped" could not finish tearing it
    down safely, so its workspace was left intact; the kill is recorded and will be retried
    automatically: in-sandbox agent-server is gone
--- FAIL: TestKillSession_RemoteReapSucceededDeletesRowWithoutMisleadingError (0.03s)
```

After the fix it passes, and the full `daemon` package is green (`ok … 159.413s`, via `make test-container`).

### Existing test updated

`TestKillSession_TombstoneSurvivesFailedTeardown` passed **only because of this bug**: its `failKillBackend` modelled a failed teardown with a **plain** error and asserted the row was retained. With the fix, a plain error now (correctly) deletes the row, so that test failed post-fix (`expected KillSession to surface the teardown failure`). `failKillBackend` now returns a **state-unknown** error (`ErrPaneMayBeLive`) — the only teardown kind that must retain — so the test keeps exercising the #1108 tombstone-survival contract faithfully, matching the existing `unsafeTeardownBackend` convention.

## Checks

- `make test-container GOTESTARGS="./daemon/..."` → `ok … 159.413s`
- `gofmt -l .` clean · `go build ./...` ok · `golangci-lint run --timeout=3m --fast` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
