### PR TITLE
feat(web): editable tasks — seed the add form as an edit modal (#1935)

### DIFF
--- a/parity/honesty_test.go
+++ b/parity/honesty_test.go
@@ -198,10 +198,18 @@ func TestDerivationSeesPreviewTabGap(t *testing.T) {
 	}
 }
 
-// TestDerivationSeesNestedProjectPathGap pins the wrapper case behind #1935.
-// UpdateTask is {id, update}: a top-level-only check calls it covered the moment
-// the web sends `update`, hiding every option inside task.TaskUpdate. This is the
-// exact shape that hid project_path.
+// TestDerivationSeesNestedProjectPathGap pins the wrapper case that motivated
+// #1935. UpdateTask is {id, update}: a top-level-only check calls it covered the
+// moment the web sends `update`, hiding every option inside task.TaskUpdate —
+// exactly how project_path stayed invisible.
+//
+// #1935 LANDED (like #1968 for the sibling fixture above): the web now edits tasks,
+// and its edit call site sends project_path as an inline literal. So this fixture
+// asserts the reverse of what it did before — project_path is IN the TS interface
+// AND reachable BY VALUE (the derivation real coverage uses) — while still proving
+// the recursion and the CLI-side assignment walk see what they must. The CLI has no
+// --project-path flag, so the assignment walk must still report TaskUpdate.ProjectPath
+// unreached: the surviving CLI half of task.edit.project-path.
 func TestDerivationSeesNestedProjectPathGap(t *testing.T) {
 	paths := jsonFieldPaths(auditedRequests["UpdateTaskRequest"])
 	var nested []string
@@ -217,15 +225,16 @@ func TestDerivationSeesNestedProjectPathGap(t *testing.T) {
 	}
 	if !contains(nested, "update.project_path") {
 		t.Fatal("update.project_path is not in the derived field paths — the recursion is blind " +
-			"to the very field that motivated it (task/task.go:428)")
+			"to the very field that motivated it (task/task.go:566)")
 	}
 
-	// The web's contract for the payload is its TS interface; project_path is
-	// absent from it (web/src/types.ts:174-182) while the other options are not.
+	// #1935 landed: project_path is now in the web's TS TaskUpdate (web/src/types.ts),
+	// alongside the options that were always there. If it disappears the fix was
+	// reverted — flip task.edit.project-path's web cell back to `no`.
 	ts := webTSInterfaceFields(t, "TaskUpdate")
-	if ts["project_path"] {
-		t.Error("web/src/types.ts TaskUpdate now has project_path. If the gap was fixed, " +
-			"update task.edit.project-path and retire this fixture.")
+	if !ts["project_path"] {
+		t.Error("web/src/types.ts TaskUpdate no longer has project_path — #1935 was reverted; " +
+			"flip task.edit's web cell back to `partial` and task.edit.project-path's to `no`.")
 	}
 	for _, f := range []string{"name", "prompt", "cron_expr", "enabled"} {
 		if !ts[f] {
@@ -234,8 +243,26 @@ func TestDerivationSeesNestedProjectPathGap(t *testing.T) {
 		}
 	}
 
+	// The interface says what is POSSIBLE; coverage keys off what the web SENDS. Prove
+	// the edit call site reaches project_path (and enabled, via the toggle) BY VALUE —
+	// the derivation the real check uses — and that no call site is unreadable (a
+	// variable body would silently blind the audit to the reach it derives here).
+	reach := webNestedValueReach(t, "TaskUpdate")
+	if len(reach.Unanalyzable) > 0 {
+		t.Errorf("web TaskUpdate has call sites the value walk cannot read: %v — the audit would "+
+			"go blind on the reach it derives from them.", reach.Unanalyzable)
+	}
+	for _, f := range []string{"project_path", "name", "prompt", "cron_expr", "enabled"} {
+		if !reach.Fields[f] {
+			t.Errorf("the web does not reach TaskUpdate.%s by value (sites: %v) — #1935's edit "+
+				"call site must send it as an inline literal, or the coverage credit is fiction.",
+				f, reach.Sites)
+		}
+	}
+
 	// The CLI reaches the payload field-by-field (`patch.Name = …`), not as a
-	// literal, so this also proves the assignment-tracking half of the walk.
+	// literal, so this also proves the assignment-tracking half of the walk. It still
+	// has no --project-path flag, so ProjectPath must stay unreached.
 	typeUse := deriveTypeFieldUse(t, "cli")
 	fields := typeUse["task.TaskUpdate"]
 	if len(fields) == 0 {

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -697,16 +697,15 @@
         "pointer": "ui/task_pane.go:362 (enter) -> ui/task_pane_edit.go form"
       },
       "web": {
-        "status": "partial",
-        "pointer": "web/src/index.ts:854-865 sends only {enabled}; no edit form exists"
+        "status": "yes",
+        "pointer": "web/src/tasks.ts editTaskModal (seeded from the task) -> web/src/index.ts openEditTask sends a field-level TaskUpdate patch via api.ts updateTask"
       },
       "cli": {
         "status": "yes",
         "pointer": "api/tasks.go:270 tasksUpdateCmd (7 fields)"
       },
-      "verdict": "real-gap",
-      "issue": "#1935",
-      "notes": "The web can create a task but never change it: the only UpdateTask call site is the enable/disable toggle. Its TS TaskUpdate type (web/src/types.ts:174-182) also omits project_path, so that field is unreachable from the web even in principle. To fix a typo'd cron the user must delete and re-add."
+      "verdict": "parity",
+      "notes": "Closed by #1935: the Edit action opens the add-task form seeded from the task and submits the changed fields to UpdateTask. project_path is now in the web TS TaskUpdate (web/src/types.ts) and sent by the edit call site, so every field the create form collects is editable."
     },
     {
       "id": "task.toggle",
@@ -1076,15 +1075,15 @@
         "pointer": "ui/task_pane_edit.go:135 edits ProjectPath; the patch is task.DiffTask over the edited task.Task (ui/task_pane_state.go:91)"
       },
       "web": {
-        "status": "no",
-        "pointer": "web/src/types.ts:174-182 TaskUpdate omits project_path"
+        "status": "yes",
+        "pointer": "web/src/tasks.ts editTaskModal project picker (seeded, editable) -> web/src/index.ts openEditTask sends update.project_path"
       },
       "cli": {
         "status": "no",
         "pointer": "api/api.go:644-650 af tasks update has no --project-path flag"
       },
       "verdict": "unclear",
-      "notes": "Found mechanically by the nested-payload derivation, not by hand: task.TaskUpdate.ProjectPath is reachable only from the TUI. Overlaps #1891 (tasks add should surface and guard the resolved project binding), so it wants triaging with that rather than a fresh issue. The web half is subsumed by #1935 (the web cannot edit a task at all)."
+      "notes": "The web half was subsumed by #1935 and is now closed: the edit form's project picker is seeded from the task and can move it to another project, so the edit call site sends update.project_path. The CLI still cannot — `af tasks update` has no --project-path flag. That remaining CLI gap overlaps #1891 (tasks add should surface and guard the resolved project binding), so it wants triaging with that rather than a fresh issue."
     },
     {
       "id": "cli.shell-completion",
@@ -1827,27 +1826,6 @@
         }
       },
       "UpdateTask": {
-        "update.project_path": {
-          "gap": "task.edit.project-path"
-        },
-        "update.cron_expr": {
-          "gap": "task.edit"
-        },
-        "update.name": {
-          "gap": "task.edit"
-        },
-        "update.program": {
-          "gap": "task.edit"
-        },
-        "update.prompt": {
-          "gap": "task.edit"
-        },
-        "update.target_session": {
-          "gap": "task.edit"
-        },
-        "update.watch_cmd": {
-          "gap": "task.edit"
-        },
         "update.max_concurrent_runs": {
           "gap": "task.max-concurrent-runs"
         },

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -9498,7 +9498,9 @@ var TasksPane = class {
       t.enabled ? "Disable" : "Enable"
     );
     toggleBtn.addEventListener("click", () => this.actions.toggle(t));
-    const actionEls = [toggleBtn];
+    const editBtn = h("button", { type: "button", class: "af-ghost af-task-action" }, "Edit");
+    editBtn.addEventListener("click", () => this.actions.edit(t));
+    const actionEls = [toggleBtn, editBtn];
     if (canTrigger(t)) {
       const triggerBtn = h("button", { type: "button", class: "af-ghost af-task-action" }, "Trigger");
       triggerBtn.addEventListener("click", () => this.actions.trigger(t));
@@ -9511,29 +9513,29 @@ var TasksPane = class {
     return h("li", { class: "af-task-row" }, enabledDot, main, actions2);
   }
 };
-function addTaskModal(projects, defaultProject2, callbacks) {
+function taskFormModal(opts) {
   const { handle, body, confirmBtn } = modalChrome({
-    title: "Add task",
-    confirmLabel: "Add",
+    title: opts.title,
+    confirmLabel: opts.confirmLabel,
     confirmClass: "af-primary",
-    onCancel: callbacks.onCancel
+    onCancel: opts.onCancel
   });
   const nameInput = h("input", { type: "text", class: "af-input", placeholder: "Task name", autocomplete: "off" });
   nameInput.setAttribute("aria-label", "Task name");
   const projectSelect = h("select", { class: "af-input" });
   projectSelect.setAttribute("aria-label", "Project");
-  if (projects.length === 0) {
+  if (opts.projects.length === 0) {
     const opt = h("option", { value: "" }, "No projects yet \u2014 create a session first");
     opt.disabled = true;
     opt.selected = true;
     projectSelect.append(opt);
     confirmBtn.disabled = true;
   } else {
-    for (const p of projects) {
+    for (const p of opts.projects) {
       projectSelect.append(h("option", { value: p }, projectLabel(p)));
     }
-    if (defaultProject2 && projects.includes(defaultProject2)) {
-      projectSelect.value = defaultProject2;
+    if (opts.defaultProject && opts.projects.includes(opts.defaultProject)) {
+      projectSelect.value = opts.defaultProject;
     }
   }
   const triggerSelect = h("select", { class: "af-input" });
@@ -9547,11 +9549,12 @@ function addTaskModal(projects, defaultProject2, callbacks) {
   watchInput.setAttribute("aria-label", "Watch command");
   const watchField = field("Watch command", watchInput);
   watchField.hidden = true;
-  triggerSelect.addEventListener("change", () => {
+  const syncTriggerFields = () => {
     const isWatch = triggerSelect.value === "watch";
     cronField.hidden = isWatch;
     watchField.hidden = !isWatch;
-  });
+  };
+  triggerSelect.addEventListener("change", syncTriggerFields);
   const promptArea = h("textarea", { class: "af-input af-textarea", placeholder: "Prompt to deliver ({{line}} for the watch line)", rows: 3 });
   promptArea.setAttribute("aria-label", "Prompt");
   const targetInput = h("input", { type: "text", class: "af-input", placeholder: "Target session (optional)", autocomplete: "off" });
@@ -9561,6 +9564,21 @@ function addTaskModal(projects, defaultProject2, callbacks) {
   programSelect.append(h("option", { value: "" }, "Repo default"));
   for (const prog of ["claude", "codex", "aider", "gemini", "amp", "opencode"]) {
     programSelect.append(h("option", { value: prog }, prog));
+  }
+  if (opts.seed) {
+    const s = opts.seed;
+    nameInput.value = s.name ?? "";
+    const isWatch = !!(s.watch_cmd && s.watch_cmd.trim() !== "");
+    triggerSelect.value = isWatch ? "watch" : "cron";
+    cronInput.value = s.cron_expr ?? "";
+    watchInput.value = s.watch_cmd ?? "";
+    syncTriggerFields();
+    promptArea.value = s.prompt ?? "";
+    targetInput.value = s.target_session ?? "";
+    if (s.program && ![...programSelect.options].some((o) => o.value === s.program)) {
+      programSelect.append(h("option", { value: s.program }, s.program));
+    }
+    programSelect.value = s.program ?? "";
   }
   body.append(
     field("Name", nameInput),
@@ -9596,7 +9614,7 @@ function addTaskModal(projects, defaultProject2, callbacks) {
       return;
     }
     handle.setError(null);
-    callbacks.onSubmit({
+    opts.onSubmit({
       name,
       projectPath: projectSelect.value,
       trigger,
@@ -9609,6 +9627,27 @@ function addTaskModal(projects, defaultProject2, callbacks) {
   });
   queueMicrotask(() => nameInput.focus());
   return handle;
+}
+function addTaskModal(projects, defaultProject2, callbacks) {
+  return taskFormModal({
+    title: "Add task",
+    confirmLabel: "Add",
+    projects,
+    defaultProject: defaultProject2,
+    onSubmit: callbacks.onSubmit,
+    onCancel: callbacks.onCancel
+  });
+}
+function editTaskModal(projects, task, callbacks) {
+  return taskFormModal({
+    title: "Edit task",
+    confirmLabel: "Save",
+    projects,
+    defaultProject: task.project_path,
+    seed: task,
+    onSubmit: callbacks.onSubmit,
+    onCancel: callbacks.onCancel
+  });
 }
 
 // src/tabreorder.ts
@@ -9914,6 +9953,7 @@ var AppShell = class {
     this.sessionsBody = h2("div", { class: "af-body" }, rail, this.main, this.navScrim);
     this.tasksPane = new TasksPane({
       add: () => this.actions.addTask(),
+      edit: (task) => this.actions.editTask(task),
       toggle: (task) => this.actions.toggleTask(task),
       trigger: (task) => this.actions.triggerTask(task),
       remove: (task) => this.actions.removeTask(task)
@@ -11355,6 +11395,41 @@ function openAddTask() {
     })
   );
 }
+function openEditTask(task) {
+  const projects = pickerProjects(store.get().sessions, store.get().tasks);
+  openModal(
+    editTaskModal(projects, task, {
+      onSubmit: (input) => {
+        const tok = token;
+        if (tok === null || !modal) {
+          return;
+        }
+        const m = modal;
+        m.setBusy(true);
+        void updateTask(
+          task.id,
+          {
+            name: input.name,
+            prompt: input.prompt,
+            cron_expr: input.trigger === "cron" ? input.cron : "",
+            watch_cmd: input.trigger === "watch" ? input.watchCmd : "",
+            target_session: input.targetSession,
+            project_path: input.projectPath,
+            program: input.program
+          },
+          tok
+        ).then(() => {
+          closeModal();
+          refreshTasks();
+        }).catch((e) => {
+          m.setBusy(false);
+          m.setError(describeError(e));
+        });
+      },
+      onCancel: closeModal
+    })
+  );
+}
 function toggleTask(task) {
   const tok = token;
   if (tok === null) {
@@ -11424,6 +11499,7 @@ var actions = {
   setStatusFilter,
   resetStatusFilter,
   addTask: openAddTask,
+  editTask: openEditTask,
   toggleTask,
   triggerTask: doTriggerTask,
   removeTask: doRemoveTask,

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "7b5aeb8a7044";
+const VERSION = "42526cc823ca";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -1954,6 +1954,99 @@ test("tasks view (#1592 PR8): list the seeded task; add / trigger / remove round
   await expect(page.locator(".af-rail-list")).toBeVisible();
 });
 
+test("tasks view edit (#1935): the Edit form is seeded from the task, and a changed cron/prompt PERSISTS", async () => {
+  // The gap this fixes: before #1935 the web could create a task but never change it —
+  // the only UpdateTask call was the enable toggle, and no edit form existed. This
+  // fails on the old bundle at the very first step (no "Edit" button in the row).
+  //
+  // Capture the AddTask (to learn the minted id) and UpdateTask (to prove the patch is
+  // a field-level UpdateTask keyed by that SAME stable id, #1678) request bodies.
+  let addedTaskId: string | undefined;
+  let updateBody: { id?: string; update?: Record<string, unknown> } | null = null;
+  await page.route("**/v1/AddTask", async (route) => {
+    addedTaskId = route.request().postDataJSON()?.task?.id;
+    await route.continue();
+  });
+  await page.route("**/v1/UpdateTask", async (route) => {
+    updateBody = route.request().postDataJSON();
+    await route.continue();
+  });
+
+  await page.locator('.af-viewtab[data-view="tasks"]').click();
+  const tasks = page.locator(".af-tasks");
+  await expect(tasks).toBeVisible();
+
+  // Seed a task of our own to edit (so this test never mutates the harness's seeded
+  // task, which other tests assert on). A cron task requires a prompt.
+  const named = `probe-edit-${Date.now().toString(36)}`;
+  const originalCron = "*/5 * * * *";
+  await tasks.locator(".af-tasks-add").click();
+  const addModal = page.locator(".af-modal-card");
+  await expect(addModal).toBeVisible();
+  await addModal.locator('input[aria-label="Task name"]').fill(named);
+  await addModal.locator('input[aria-label="Cron expression"]').fill(originalCron);
+  await addModal.locator('textarea[aria-label="Prompt"]').fill("echo original");
+  await addModal.locator("button.af-primary").click();
+
+  const editedRow = tasks.locator(".af-task-row", { hasText: named });
+  await expect(editedRow).toBeVisible({ timeout: 30_000 });
+  await expect(addModal).toBeHidden();
+  expect(addedTaskId, "AddTask must mint + send a stable task id").toBeTruthy();
+  await expect(editedRow.locator(".af-task-trigger")).toContainText(originalCron);
+
+  // Open the Edit form. It reuses the add-task modal in edit mode, SEEDED from the
+  // task's current values — proof the form is not a blank re-entry.
+  await editedRow.locator("button", { hasText: "Edit" }).click();
+  const editModal = page.locator(".af-modal-card");
+  await expect(editModal).toBeVisible();
+  await expect(editModal.locator(".af-modal-title")).toHaveText("Edit task");
+  await expect(editModal.locator('input[aria-label="Task name"]')).toHaveValue(named);
+  await expect(editModal.locator('input[aria-label="Cron expression"]')).toHaveValue(originalCron);
+  await expect(editModal.locator('textarea[aria-label="Prompt"]')).toHaveValue("echo original");
+
+  // Change the cron expression and the prompt, then save.
+  const newCron = "30 8 * * 1";
+  await editModal.locator('input[aria-label="Cron expression"]').fill(newCron);
+  await editModal.locator('textarea[aria-label="Prompt"]').fill("echo edited");
+  await editModal.locator("button.af-primary", { hasText: "Save" }).click();
+  await expect(editModal).toBeHidden();
+
+  // The UpdateTask patch is a field-level TaskUpdate keyed by the SAME id AddTask
+  // minted (never the name). It carries the changed fields plus project_path (#1935's
+  // type addition reaching the wire), and does NOT carry `enabled` — the edit form
+  // leaves the toggle's bit as-stored (the field-level merge, #1700).
+  expect(updateBody?.id, "UpdateTask must target the id AddTask minted").toBe(addedTaskId);
+  expect(updateBody?.update?.cron_expr).toBe(newCron);
+  expect(updateBody?.update?.watch_cmd, "switching to/keeping cron clears watch_cmd").toBe("");
+  expect(updateBody?.update?.prompt).toBe("echo edited");
+  expect(updateBody?.update?.project_path, "the edit reaches project_path (#1935)").toBeTruthy();
+  expect(updateBody?.update, "the edit patch omits `enabled` (the toggle owns it)").not.toHaveProperty("enabled");
+
+  // The row reflects the new trigger without a reload (the list refetched).
+  await expect(editedRow.locator(".af-task-trigger")).toContainText(newCron, { timeout: 30_000 });
+
+  // The real proof: RELOAD and re-fetch from the daemon. The new cron persisted, so
+  // the daemon actually applied the UpdateTask — not just an optimistic local echo.
+  await page.reload();
+  await expect(page.locator(".af-app")).toBeVisible();
+  await page.locator('.af-viewtab[data-view="tasks"]').click();
+  const reloadedRow = page.locator(".af-tasks .af-task-row", { hasText: named });
+  await expect(reloadedRow).toBeVisible({ timeout: 30_000 });
+  await expect(reloadedRow.locator(".af-task-trigger")).toContainText(newCron);
+  await expect(reloadedRow.locator(".af-task-trigger")).not.toContainText(originalCron);
+
+  // Clean up our task and return to the sessions view for the following flows.
+  await page.route("**/v1/RemoveTask", (route) => route.continue());
+  await reloadedRow.locator("button", { hasText: "Remove" }).click();
+  await expect(page.locator(".af-tasks .af-task-row", { hasText: named })).toHaveCount(0, { timeout: 30_000 });
+
+  await page.unroute("**/v1/AddTask");
+  await page.unroute("**/v1/UpdateTask");
+  await page.unroute("**/v1/RemoveTask");
+  await page.locator('.af-viewtab[data-view="sessions"]').click();
+  await expect(page.locator(".af-rail-list")).toBeVisible();
+});
+
 test.describe("create → kill (one session, two flows)", () => {
   // The ONE genuine ordering dependency in this file, and the only place serial
   // mode is warranted: create stashes the title it invented and kill consumes it,

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -55,7 +55,7 @@ import { isRenameableTab } from "./tablabel.js";
 import { Store } from "./store.js";
 import { registerServiceWorker } from "./serviceworker.js";
 import { bootStampTheme, persistThemeChoice, stampTheme, type ThemeChoice } from "./theme.js";
-import { addTaskModal, type AddTaskInput, buildTask } from "./tasks.js";
+import { addTaskModal, type AddTaskInput, buildTask, editTaskModal } from "./tasks.js";
 import type { TerminalStatus } from "./terminal.js";
 import {
   AppShell,
@@ -1071,6 +1071,56 @@ function openAddTask(): void {
   );
 }
 
+/** Opens the edit-task modal seeded from the task, then submits the collected fields
+ *  as a field-level UpdateTask patch (#1935) keyed by the task's stable id; the
+ *  task.updated event + a refetch reconcile. Errors surface in the modal for a retry.
+ *
+ *  `enabled` is intentionally NOT in the patch — the toggle owns that bit, and
+ *  omitting it preserves a disabled task's state across an edit (the field-level
+ *  merge leaves an unsent field as-stored, #1700). Every other field the form
+ *  collects IS sent, as an INLINE literal: the surface-parity field audit derives the
+ *  web's reach from the values passed here (not the TS type), so each editable field
+ *  must appear at this exact call site. The unused trigger is cleared to "" — safe on
+ *  the HTTP/JSON path, which (unlike the CLI's gob socket) never elides "" to nil. */
+function openEditTask(task: TaskData): void {
+  const projects = pickerProjects(store.get().sessions, store.get().tasks);
+  openModal(
+    editTaskModal(projects, task, {
+      onSubmit: (input: AddTaskInput) => {
+        const tok = token;
+        // `=== null` not `!tok`: "" is the authorized-tokenless credential (#1696).
+        if (tok === null || !modal) {
+          return;
+        }
+        const m = modal;
+        m.setBusy(true);
+        void updateTask(
+          task.id,
+          {
+            name: input.name,
+            prompt: input.prompt,
+            cron_expr: input.trigger === "cron" ? input.cron : "",
+            watch_cmd: input.trigger === "watch" ? input.watchCmd : "",
+            target_session: input.targetSession,
+            project_path: input.projectPath,
+            program: input.program,
+          },
+          tok,
+        )
+          .then(() => {
+            closeModal();
+            refreshTasks();
+          })
+          .catch((e) => {
+            m.setBusy(false);
+            m.setError(describeError(e));
+          });
+      },
+      onCancel: closeModal,
+    }),
+  );
+}
+
 /** Enables/disables a task (UpdateTask with `enabled` flipped), then refetches. A
  *  failure surfaces as the shared transient toast (task ops have no modal). Keys off
  *  the task's stable id — requireTaskID in the api layer refuses a missing one. */
@@ -1172,6 +1222,7 @@ const actions = {
   setStatusFilter,
   resetStatusFilter,
   addTask: openAddTask,
+  editTask: openEditTask,
   toggleTask,
   triggerTask: doTriggerTask,
   removeTask: doRemoveTask,

--- a/web/src/tasks.ts
+++ b/web/src/tasks.ts
@@ -37,6 +37,9 @@ export interface AddTaskInput {
 export interface TaskActions {
   /** Opens the add-task modal. */
   add(): void;
+  /** Opens the edit modal seeded from this task; submits the changed fields via
+   *  UpdateTask (the field-level patch, #1935). */
+  edit(task: TaskData): void;
   /** Flips enabled via UpdateTask. */
   toggle(task: TaskData): void;
   /** Fires the task now via TriggerTask (enabled cron tasks only). */
@@ -179,7 +182,10 @@ export class TasksPane {
     );
     toggleBtn.addEventListener("click", () => this.actions.toggle(t));
 
-    const actionEls: HTMLElement[] = [toggleBtn];
+    const editBtn = h("button", { type: "button", class: "af-ghost af-task-action" }, "Edit");
+    editBtn.addEventListener("click", () => this.actions.edit(t));
+
+    const actionEls: HTMLElement[] = [toggleBtn, editBtn];
     if (canTrigger(t)) {
       const triggerBtn = h("button", { type: "button", class: "af-ghost af-task-action" }, "Trigger");
       triggerBtn.addEventListener("click", () => this.actions.trigger(t));
@@ -195,23 +201,31 @@ export class TasksPane {
 }
 
 /**
- * The add-task modal (mirrors the TUI's task editor + `af tasks add`): name,
- * project, a cron/watch trigger toggle with its value, a prompt, an optional target
- * session, and the agent program. onSubmit fires with the collected input; the caller
- * builds the task (buildTask) and POSTs AddTask. A cron task requires a prompt (the
- * daemon rejects an empty one — there is no event line to fall back to); a watch task
- * requires its command and may omit the prompt.
+ * The task form modal (mirrors the TUI's task editor + `af tasks add`/`update`):
+ * name, project, a cron/watch trigger toggle with its value, a prompt, an optional
+ * target session, and the agent program. Shared by the ADD and EDIT flows — the only
+ * difference is the chrome (title/confirm label) and, in edit mode, that every field
+ * is SEEDED from the existing task (#1935). onSubmit fires with the collected input;
+ * the caller turns it into an AddTask (buildTask) or a field-level UpdateTask patch.
+ * A cron task requires a prompt (the daemon rejects an empty one — there is no event
+ * line to fall back to); a watch task requires its command and may omit the prompt.
  */
-export function addTaskModal(
-  projects: string[],
-  defaultProject: string | null,
-  callbacks: { onSubmit: (input: AddTaskInput) => void; onCancel: () => void },
-): ModalHandle {
+function taskFormModal(opts: {
+  title: string;
+  confirmLabel: string;
+  projects: string[];
+  /** The project the picker defaults to (add) or is seeded to (edit). */
+  defaultProject: string | null;
+  /** Present only in edit mode: the task whose current values seed the form. */
+  seed?: TaskData;
+  onSubmit: (input: AddTaskInput) => void;
+  onCancel: () => void;
+}): ModalHandle {
   const { handle, body, confirmBtn } = modalChrome({
-    title: "Add task",
-    confirmLabel: "Add",
+    title: opts.title,
+    confirmLabel: opts.confirmLabel,
     confirmClass: "af-primary",
-    onCancel: callbacks.onCancel,
+    onCancel: opts.onCancel,
   });
 
   const nameInput = h("input", { type: "text", class: "af-input", placeholder: "Task name", autocomplete: "off" });
@@ -219,20 +233,21 @@ export function addTaskModal(
 
   const projectSelect = h("select", { class: "af-input" });
   projectSelect.setAttribute("aria-label", "Project");
-  if (projects.length === 0) {
+  if (opts.projects.length === 0) {
     const opt = h("option", { value: "" }, "No projects yet — create a session first");
     opt.disabled = true;
     opt.selected = true;
     projectSelect.append(opt);
     confirmBtn.disabled = true;
   } else {
-    for (const p of projects) {
+    for (const p of opts.projects) {
       projectSelect.append(h("option", { value: p }, projectLabel(p)));
     }
     // Default the picker to the currently-scoped project (redesign PR2), so adding a
-    // task from within a project lands it in that project without extra clicks.
-    if (defaultProject && projects.includes(defaultProject)) {
-      projectSelect.value = defaultProject;
+    // task from within a project lands it in that project without extra clicks. In
+    // edit mode this is the task's own project (its seed), so it starts on it.
+    if (opts.defaultProject && opts.projects.includes(opts.defaultProject)) {
+      projectSelect.value = opts.defaultProject;
     }
   }
 
@@ -251,12 +266,13 @@ export function addTaskModal(
   watchField.hidden = true;
 
   // Show only the field for the selected trigger; the other is hidden (its value is
-  // ignored by buildTask, and the daemon rejects a task with both set).
-  triggerSelect.addEventListener("change", () => {
+  // ignored on submit, and the daemon rejects a task with both set).
+  const syncTriggerFields = (): void => {
     const isWatch = triggerSelect.value === "watch";
     cronField.hidden = isWatch;
     watchField.hidden = !isWatch;
-  });
+  };
+  triggerSelect.addEventListener("change", syncTriggerFields);
 
   const promptArea = h("textarea", { class: "af-input af-textarea", placeholder: "Prompt to deliver ({{line}} for the watch line)", rows: 3 });
   promptArea.setAttribute("aria-label", "Prompt");
@@ -269,6 +285,26 @@ export function addTaskModal(
   programSelect.append(h("option", { value: "" }, "Repo default"));
   for (const prog of ["claude", "codex", "aider", "gemini", "amp", "opencode"]) {
     programSelect.append(h("option", { value: prog }, prog));
+  }
+
+  // Seed every field from the existing task (edit mode). The trigger picker follows
+  // whichever of watch_cmd / cron_expr the task carries, and its field visibility is
+  // synced to match. A program the picker doesn't list (e.g. one set via the CLI) is
+  // appended first so an unrelated edit never silently resets it to the repo default.
+  if (opts.seed) {
+    const s = opts.seed;
+    nameInput.value = s.name ?? "";
+    const isWatch = !!(s.watch_cmd && s.watch_cmd.trim() !== "");
+    triggerSelect.value = isWatch ? "watch" : "cron";
+    cronInput.value = s.cron_expr ?? "";
+    watchInput.value = s.watch_cmd ?? "";
+    syncTriggerFields();
+    promptArea.value = s.prompt ?? "";
+    targetInput.value = s.target_session ?? "";
+    if (s.program && ![...programSelect.options].some((o) => o.value === s.program)) {
+      programSelect.append(h("option", { value: s.program }, s.program));
+    }
+    programSelect.value = s.program ?? "";
   }
 
   body.append(
@@ -306,7 +342,7 @@ export function addTaskModal(
       return;
     }
     handle.setError(null);
-    callbacks.onSubmit({
+    opts.onSubmit({
       name,
       projectPath: projectSelect.value,
       trigger,
@@ -320,4 +356,40 @@ export function addTaskModal(
 
   queueMicrotask(() => nameInput.focus());
   return handle;
+}
+
+/** The add-task modal: the shared task form with add chrome. The caller builds the
+ *  task (buildTask) and POSTs AddTask. */
+export function addTaskModal(
+  projects: string[],
+  defaultProject: string | null,
+  callbacks: { onSubmit: (input: AddTaskInput) => void; onCancel: () => void },
+): ModalHandle {
+  return taskFormModal({
+    title: "Add task",
+    confirmLabel: "Add",
+    projects,
+    defaultProject,
+    onSubmit: callbacks.onSubmit,
+    onCancel: callbacks.onCancel,
+  });
+}
+
+/** The edit-task modal (#1935): the same form seeded from `task`'s current values.
+ *  The caller submits the collected fields as a field-level UpdateTask patch. The
+ *  project picker starts on the task's own project and can move it to another. */
+export function editTaskModal(
+  projects: string[],
+  task: TaskData,
+  callbacks: { onSubmit: (input: AddTaskInput) => void; onCancel: () => void },
+): ModalHandle {
+  return taskFormModal({
+    title: "Edit task",
+    confirmLabel: "Save",
+    projects,
+    defaultProject: task.project_path,
+    seed: task,
+    onSubmit: callbacks.onSubmit,
+    onCancel: callbacks.onCancel,
+  });
 }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -177,6 +177,10 @@ export interface TaskUpdate {
   cron_expr?: string;
   watch_cmd?: string;
   target_session?: string;
+  /** The repo root the task belongs to — the project it groups under. Present so
+   *  the edit form can move a task between projects (#1935); the Go task.TaskUpdate
+   *  struct carries it, and the TUI already edits it (ui/task_pane_edit.go). */
+  project_path?: string;
   program?: string;
   enabled?: boolean;
 }

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -206,6 +206,8 @@ export interface Actions {
   resetStatusFilter(): void;
   /** Opens the add-task modal (#1592 Phase 5 PR8). */
   addTask(): void;
+  /** Opens the edit-task modal seeded from the task, submitting via UpdateTask (#1935). */
+  editTask(task: TaskData): void;
   /** Enables/disables a task via UpdateTask. */
   toggleTask(task: TaskData): void;
   /** Fires a task now via TriggerTask (enabled cron tasks). */
@@ -785,6 +787,7 @@ export class AppShell {
     // (scoped to the selected project) so a task.* event patches only that pane.
     this.tasksPane = new TasksPane({
       add: () => this.actions.addTask(),
+      edit: (task: TaskData) => this.actions.editTask(task),
       toggle: (task: TaskData) => this.actions.toggleTask(task),
       trigger: (task: TaskData) => this.actions.triggerTask(task),
       remove: (task: TaskData) => this.actions.removeTask(task),


### PR DESCRIPTION
Closes #1935.

## The gap

The web can **create** a task with every field but can never **edit** one — the only `UpdateTask` call site is the enable/disable toggle (`{ enabled }`). To fix a typo'd cron a user had to remove the task and re-add it from scratch. The TUI (`enter` → `ui/task_pane_edit.go`) and CLI (`af tasks update`, 7 flags) both have full field-level edit. The web TS `TaskUpdate` also omitted `project_path`, so that field was unreachable even in principle.

## The change (web/src only + parity guard)

- **`web/src/types.ts`** — add `project_path?` to `TaskUpdate` so it matches the Go `task.TaskUpdate` struct.
- **`web/src/tasks.ts`** — refactor `addTaskModal` into a shared `taskFormModal` + a new `editTaskModal` that **seeds every field** from the existing task (name / prompt / trigger / target / program / project). An **Edit** action joins the row's button group next to Trigger/Remove.
- **`web/src/index.ts`** — `openEditTask` submits the collected fields as a field-level `UpdateTask` patch keyed by the task's stable id. `enabled` is intentionally omitted (the toggle owns it; the field-level merge leaves an unsent field as-stored, #1700), and the unused trigger is cleared to `""` — safe on the HTTP/JSON path, which never gob-elides `""` to nil. The patch is an **inline literal** at the call site because the surface-parity field audit derives the web's reach from the values passed, not the TS type.
- **`web/src/ui.ts`** — wire `editTask` through `AppActions` → `TasksPane`.

## Parity ledger

- `task.edit`: web **partial → yes**, verdict **real-gap → parity**.
- `task.edit.project-path`: web **no → yes** (CLI still has no `--project-path`, so it stays `unclear`).
- `field_coverage.web_rpcs.UpdateTask`: the now-reached `update.*` declarations removed (kept `max_concurrent_runs` + the CLI-only `expect.*`).
- The `#1935` honesty fixture (`parity/honesty_test.go`) is **repointed** (following the `#1968` precedent in the same file) to assert the fix landed — `project_path` now reachable **by value** — while still proving the wrapper-recursion and the surviving CLI-side gap.

The gob-elision hazard (#1700) is untouched: only `project_path` was **added** to the shared shape; the web goes over HTTP/JSON and is unaffected.

## Fail-first evidence

A Playwright web selftest opens a task's Edit form, asserts it is **seeded**, changes the cron + prompt, submits, asserts the `UpdateTask` patch carries the changed fields + `project_path` (and **not** `enabled`), and asserts the change **PERSISTS across a reload/re-fetch** via the daemon.

Run against the **pre-fix** bundle it fails at exactly the missing affordance:

```
Error: locator.click: ...
  - waiting for locator('.af-tasks').locator('.af-task-row')
      .filter({ hasText: 'probe-edit-…' }).locator('button').filter({ hasText: 'Edit' })
> 1999 |   await editedRow.locator("button", { hasText: "Edit" }).click();
1 failed
```

Against the fix (`make web-selftest-container`): **95 passed (45.2s)** — including `✓ tasks view edit (#1935): the Edit form is seeded … and a changed cron/prompt PERSISTS`.

## Verification

- `make web-selftest-container` → 95 passed (fail-first proven separately, above)
- `make web-test` → typecheck + 315 unit tests green; `make web-build` regenerated the committed bundle (do not hand-edit `af-web.js`)
- `go test ./parity/...` green; `go build ./...`, `gofmt -l .`, `golangci-lint --fast`, `deadcode -test ./...` all clean

## Merge note

A sibling web PR (feat-1932-web-restore) touches `web/src` + `web/dist` in parallel. Branched off current master; if that merges first, this needs a rebase + `make web-build` to regenerate `dist` cleanly (never hand-merge `af-web.js`). Serialize the two merges.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)