### PR TITLE
fix(session): reap descendant writers before removing a session worktree (#2025)

### DIFF
--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -660,6 +660,14 @@ var (
 // It never errors and never loops: a writer that ignores SIGKILL (a D-state,
 // uninterruptible I/O, a mount) is left for the removal to fail loudly on, not
 // spun on forever.
+//
+// PLATFORM GAP (darwin): proctree.WorkingDir has no macOS backend yet — it
+// returns the honest unknown rather than fabricate a path from an unverifiable
+// libproc struct (proctree_darwin.go) — so on darwin every process reads as
+// "cwd unknown", this finds no writers, and the reap no-ops. The #2025 orphan
+// therefore still races on macOS until the darwin working-directory backend
+// lands (tracked in #2050). No-op is the safe degradation: it can never signal
+// the wrong process, only fail to signal the right one.
 func reapWorktreeWriters(worktreePath string) {
 	// The path exists (callers reap only after an os.Stat succeeds), so resolving
 	// symlinks here matches /proc/<pid>/cwd, which the kernel already resolves.

--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -8,7 +8,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
+	"github.com/sachiniyer/agent-factory/internal/proctree"
 	"github.com/sachiniyer/agent-factory/log"
 )
 
@@ -456,6 +458,14 @@ func (g *GitWorktree) Cleanup() (CleanupState, error) {
 
 	// Check if worktree path exists before attempting removal
 	if _, err := os.Stat(g.worktreePath); err == nil {
+		// Reap any process still writing inside the tree BEFORE removing it
+		// (#2025). Both the git remove below and the os.RemoveAll fallback delete
+		// recursively and fail "directory not empty" only when a live writer keeps
+		// re-creating files under the path faster than they can be unlinked; a
+		// session whose agent backgrounded a survivor (installer, dev server) leaks
+		// the worktree otherwise. Best-effort and bounded — see reapWorktreeWriters.
+		reapWorktreeWriters(g.worktreePath)
+
 		// Remove the worktree using git command. Bounded by localGitTimeout
 		// (#1917): this recursive delete is the one local git command that
 		// genuinely stalls forever (hung mount, D-state process in the tree), and
@@ -607,6 +617,114 @@ func normalizeWorktreePath(p string) string {
 	return p
 }
 
+var (
+	// worktreeReapGrace is how long a writer discovered inside the worktree gets
+	// to exit on its own before it is SIGTERMed. Zero: by the time a worktree is
+	// being deleted the pane teardown has already SIGHUP'd the pane's process
+	// group and waited for the pane to exit (#802), so a process still writing
+	// here has already had its grace and there is no reason to wait again — go
+	// straight to the escalation. var, not const, so a test can tune the pacing.
+	worktreeReapGrace = 0 * time.Second
+	// worktreeReapTermWait is how long a SIGTERMed writer gets before SIGKILL.
+	// WaitForExits returns as soon as everything is gone, so a well-behaved writer
+	// costs a poll interval, not the whole wait.
+	worktreeReapTermWait = 2 * time.Second
+)
+
+// reapWorktreeWriters kills every live process still working inside worktreePath
+// BEFORE the tree is deleted (#2025): any process whose current working directory
+// is at or under the tree, plus that process's whole descendant subtree.
+//
+// The leak this closes: `git worktree remove -f` and the os.RemoveAll fallback
+// both delete recursively and do NOT fail on a merely-non-empty directory — they
+// fail "directory not empty" only when files are being CREATED into the tree
+// faster than they can be unlinked, i.e. a live process is still writing to it.
+// A session whose agent backgrounded a long-lived writer (an installer, a dev
+// server, a package manager) can leave that writer alive after the kill tore down
+// the agent/tmux — the tmux reaper (#1104) escalates asynchronously and does not
+// block this removal — and it then races, and beats, the delete, orphaning the
+// worktree (the worktree_ops.go / teardown.go "directory not empty" pair).
+// Killing the writers first removes the racer so the delete can finish.
+//
+// WHICH processes are killed is deliberately narrow (the #1104 "only our own
+// descendants" discipline, and the "which children are garbage" hazard): an AF
+// worktree directory is a session-private path, so a process cwd'd inside it is
+// unambiguously this session's and no unrelated process is ever signalled. The
+// kill itself routes through the existing #1104 reaper (proctree.KillEscalating):
+// every signal is identity-verified against (pid, start-time) so a recycled PID
+// is never hit, and the SIGTERM→SIGKILL escalation is shared, not re-implemented.
+//
+// Best-effort, like every reaper on this path: an unreadable process table (no
+// /proc, an unsupported platform) degrades to a no-op — nothing is reaped, and
+// the existing WARNING plus doctor's stale-worktree path own whatever survives.
+// It never errors and never loops: a writer that ignores SIGKILL (a D-state,
+// uninterruptible I/O, a mount) is left for the removal to fail loudly on, not
+// spun on forever.
+func reapWorktreeWriters(worktreePath string) {
+	// The path exists (callers reap only after an os.Stat succeeds), so resolving
+	// symlinks here matches /proc/<pid>/cwd, which the kernel already resolves.
+	root := normalizeWorktreePath(worktreePath)
+	snap, err := proctree.Snapshot()
+	if err != nil {
+		// Could not READ the process table — never the same fact as "no writers"
+		// (proctree's whole design). Skip the reap and let the removal proceed; a
+		// writer that really is alive surfaces as the existing "directory not empty"
+		// WARNING for doctor to reconcile, never a silently-swept process table.
+		return
+	}
+	seen := make(map[int]bool)
+	var procs []proctree.Process
+	add := func(p proctree.Process) {
+		if !seen[p.PID] {
+			seen[p.PID] = true
+			procs = append(procs, p)
+		}
+	}
+	for pid := range snap {
+		cwd, ok := proctree.WorkingDir(pid)
+		if !ok {
+			// Foreign process (its cwd link is not readable) or already gone: it
+			// cannot be proven to be one of ours, and an unreadable cwd is never
+			// treated as a match — the honest-unknown rule this package enforces.
+			continue
+		}
+		if !pathAtOrUnder(root, filepath.Clean(cwd)) {
+			continue
+		}
+		// Take the whole subtree of the matching process: a child of a
+		// worktree-cwd'd writer is this session's too even if it chdir'd elsewhere,
+		// and it may be the actual file-creator holding the directory non-empty.
+		for _, p := range proctree.TreeOf(snap, pid) {
+			add(p)
+		}
+	}
+	if len(procs) == 0 {
+		return
+	}
+	proctree.KillEscalating(procs, worktreeReapGrace, worktreeReapTermWait, func(format string, args ...any) {
+		// worktreePath is a runtime value that may legally contain `%`, so it MUST
+		// be a `%s` ARGUMENT, never spliced into the format string (the #1211 rule
+		// the tmux reaper follows). `format` is KillEscalating's own constant literal.
+		log.WarningLog.Printf("worktree %s: "+format, append([]any{worktreePath}, args...)...)
+	})
+}
+
+// pathAtOrUnder reports whether cleaned path p is root itself or a path nested
+// inside it. root must already be cleaned and symlink-resolved (normalizeWorktreePath)
+// and p cleaned; the kernel resolves /proc/<pid>/cwd, so the caller cleans the cwd
+// but need not re-resolve it. A sibling ("/a/b-other") or a parent is rejected —
+// only the tree itself and its descendants match.
+func pathAtOrUnder(root, p string) bool {
+	if p == root {
+		return true
+	}
+	rel, err := filepath.Rel(root, p)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
 // RemoveWorktreeDir removes a SINGLE worktree directory that AF created for a
 // session in the repo at repoRoot, and prunes the registry. It deletes NO
 // branch. It reports whether a directory was actually removed.
@@ -638,6 +756,14 @@ func RemoveWorktreeDir(repoRoot, worktreePath string) (bool, error) {
 		_ = exec.Command("git", "-C", repoRoot, "worktree", "prune").Run()
 		return false, nil
 	}
+
+	// Reap any process still writing inside the tree before removing it (#2025) —
+	// the same race GitWorktree.Cleanup guards: a survivor re-creating files
+	// defeats both the git remove and the os.RemoveAll fallback. worktreePath here
+	// is always an AF-created session worktree (reset passes AF's own record paths
+	// and the main tree is refused above), so the cwd-scoped reap only ever hits
+	// this session's processes.
+	reapWorktreeWriters(worktreePath)
 
 	// Remove the worktree FIRST (git refuses to delete a branch checked out in a
 	// worktree). Fall back to a manual directory removal if git can't (e.g. the

--- a/session/git/worktree_reap_test.go
+++ b/session/git/worktree_reap_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"syscall"
 	"testing"
@@ -34,6 +35,18 @@ import (
 // file so it never fills the disk; exec.CommandContext SIGKILLs it at a deadline;
 // t.Cleanup SIGKILLs its whole process group and reaps it.
 func TestCleanup_ReapsSurvivingWriterBeforeRemoval(t *testing.T) {
+	// The reap finds writers by working directory, and proctree has no darwin cwd
+	// backend yet: readWorkingDir on macOS returns the honest unknown ("", false)
+	// rather than risk a fabricated path from an unverifiable libproc struct — which
+	// for a DESTRUCTIVE reap would mean signalling the wrong process. So on darwin
+	// reapWorktreeWriters safely no-ops, and the #2025 orphan persists on macOS
+	// until the darwin working-directory backend lands. This is a real, pre-existing
+	// platform gap in a shared package, not a defect in this fix — tracked in #2050.
+	if runtime.GOOS == "darwin" {
+		t.Skip("proctree has no darwin working-directory backend, so the cwd-based " +
+			"writer reap no-ops on macOS — #2025 stays open there until #2050 adds it")
+	}
+
 	sandboxHome(t)
 	repoRoot := createGitRepo(t)
 	runGit(t, repoRoot, "commit", "--allow-empty", "-m", "initial")

--- a/session/git/worktree_reap_test.go
+++ b/session/git/worktree_reap_test.go
@@ -1,0 +1,177 @@
+package git
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCleanup_ReapsSurvivingWriterBeforeRemoval is the #2025 fail-first
+// regression: a session whose agent left a live process writing into the
+// worktree orphans the tree, because teardown removes the worktree WITHOUT first
+// ensuring the session's descendant processes are dead.
+//
+// The observable orphan (`git worktree remove -f` then the os.RemoveAll fallback
+// both failing "directory not empty") is a genuine filesystem race — `git
+// worktree remove -f` drains most of the tree before failing, so the fallback
+// os.RemoveAll then usually wins against the near-empty remainder. What is NOT a
+// race, and is the actual defect, is that a process still cwd'd in the worktree
+// SURVIVES the kill: on current code nothing reaps it, so it is still alive after
+// Cleanup returns and can (and on the maintainer's box did) win the removal race
+// on a later attempt. This test asserts that deterministic invariant — teardown
+// must have reaped the survivor — and then that the tree is fully removed.
+//
+// Every guard is a HARD cap so the writer can never wedge CI: the shell loop
+// self-terminates after a finite iteration count; it truncates a single recurring
+// file so it never fills the disk; exec.CommandContext SIGKILLs it at a deadline;
+// t.Cleanup SIGKILLs its whole process group and reaps it.
+func TestCleanup_ReapsSurvivingWriterBeforeRemoval(t *testing.T) {
+	sandboxHome(t)
+	repoRoot := createGitRepo(t)
+	runGit(t, repoRoot, "commit", "--allow-empty", "-m", "initial")
+
+	worktreePath := filepath.Join(t.TempDir(), "wt")
+	runGit(t, repoRoot, "worktree", "add", "-b", "af-reap-2025", worktreePath)
+	require.DirExists(t, worktreePath)
+
+	// A node_modules-style untracked tree gives the removal real work to do, so a
+	// surviving writer has a window to race it — the shape the bug needs.
+	seedLargeUntrackedTree(t, filepath.Join(worktreePath, "packages", "node_modules"))
+
+	// A real, detached (own process group) survivor whose cwd is the worktree,
+	// standing in for an installer/dev-server that outlived the session kill. It
+	// keeps writing into the worktree AND beats a heartbeat to an absolute path
+	// OUTSIDE it. The heartbeat is what makes the test sound: it means the writer
+	// can only ever exit by being SIGNALLED, never by "its files vanished" — so a
+	// closed exit channel unambiguously means teardown reaped it, not that Cleanup
+	// deleted the tree out from under a shell that then self-terminated.
+	heartbeat := filepath.Join(t.TempDir(), "heartbeat")
+	exited := startWorktreeWriter(t, worktreePath, heartbeat)
+
+	// Prove the writer is actually alive and running before Cleanup starts, so a
+	// pass can only mean the reap killed a LIVE writer — not that we raced an idle
+	// one that had already exited.
+	requireEventually(t, 5*time.Second, func() bool {
+		_, err := os.Stat(heartbeat)
+		return err == nil
+	}, "the survivor never started running")
+
+	// Long enough that real git never trips it, short enough to keep the test fast.
+	shortenLocalTimeout(t, 30*time.Second)
+
+	gw := &GitWorktree{
+		repoPath:          repoRoot,
+		worktreePath:      worktreePath,
+		branchName:        "af-reap-2025",
+		branchCreatedByUs: true,
+	}
+
+	state, err := gw.Cleanup()
+
+	// THE fail-first assertion: teardown must have reaped the survivor. On current
+	// code nothing kills a process merely cwd'd in the worktree, so it is still
+	// looping here and this wait times out. The bound is generous versus the reap's
+	// SIGTERM→SIGKILL escalation yet finite, so a red test fails fast, never hangs.
+	select {
+	case <-exited:
+		// Reaped — the writer process exited during teardown.
+	case <-time.After(5 * time.Second):
+		t.Fatal("teardown did not reap the surviving writer (#2025): a process still " +
+			"cwd'd in the worktree outlived the kill and can race the worktree removal")
+	}
+
+	// With the writer gone, the removal is no longer racing anything, so it must
+	// have fully succeeded and left no orphan.
+	require.NoError(t, err, "with the writer reaped, Cleanup must remove the tree cleanly")
+	require.Equal(t, CleanupSettled, state, "a reaped-then-removed teardown establishes its outcome")
+	assert.NoDirExists(t, worktreePath,
+		"the worktree must be fully removed once the surviving writer has been reaped (#2025)")
+}
+
+// seedLargeUntrackedTree fills dir with enough small files that a recursive
+// delete has measurable work to do — the window a racing writer needs.
+func seedLargeUntrackedTree(t *testing.T, dir string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	for i := 0; i < 16; i++ {
+		sub := filepath.Join(dir, "d"+strconv.Itoa(i))
+		require.NoError(t, os.MkdirAll(sub, 0o755))
+		for j := 0; j < 256; j++ {
+			require.NoError(t, os.WriteFile(filepath.Join(sub, "f"+strconv.Itoa(j)), []byte("x"), 0o644))
+		}
+	}
+}
+
+// startWorktreeWriter launches a background process whose working directory is
+// worktreeDir. Each iteration it (1) writes a heartbeat to the absolute path
+// heartbeat, OUTSIDE the worktree, which always succeeds, and (2) writes into the
+// worktree, which may fail once Cleanup deletes it. Both use `echo` — a REGULAR
+// built-in, so a redirection error only sets $? and the shell keeps looping; it
+// never self-terminates when the worktree vanishes. It returns a channel closed
+// when the process exits, so the caller can assert whether teardown reaped it.
+// Aggressively self-bounding — see the guards in the test doc.
+func startWorktreeWriter(t *testing.T, worktreeDir, heartbeat string) <-chan struct{} {
+	t.Helper()
+	// Bounded iteration count so it self-terminates even if every other guard
+	// failed. No external command per iteration (echo is a built-in), so it loops
+	// fast enough to keep the worktree genuinely busy for the removal race, while
+	// the absolute heartbeat guarantees it never dies just because its cwd/target
+	// disappeared.
+	loop := `i=0
+while [ "$i" -lt 2000000000 ]; do
+  echo x > "` + heartbeat + `" 2>/dev/null || true
+  echo x > .af-writer-keepalive 2>/dev/null || true
+  i=$((i + 1))
+done`
+
+	// The context deadline is the outermost hard cap: even if every other guard
+	// failed, the writer is SIGKILLed here. Comfortably longer than the reap
+	// escalation and the removal, short enough to never hang CI.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	cmd := exec.CommandContext(ctx, "sh", "-c", loop)
+	cmd.Dir = worktreeDir
+	// Own process group so the whole writer tree can be reaped as a group and so it
+	// mimics a detached survivor that escaped the pane's foreground group.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	// On context cancel, kill the GROUP, not just the shell.
+	cmd.Cancel = func() error { return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL) }
+	cmd.WaitDelay = 2 * time.Second
+
+	require.NoError(t, cmd.Start())
+	exited := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(exited)
+	}()
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		}
+		<-exited
+	})
+	return exited
+}
+
+// requireEventually polls cond until it is true or timeout elapses, failing with
+// msg otherwise. Bounded, so it can never hang the test.
+func requireEventually(t *testing.T, timeout time.Duration, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal(msg)
+}


### PR DESCRIPTION
Fixes #2025.

## The leak

Killing a session tore down the agent/tmux, but a **descendant process that outlived the pane kill** — an installer, dev server, or package manager the agent had backgrounded — kept writing into the worktree and raced the removal:

```
ERROR   worktree_ops.go:464: failed to remove worktree …: Directory not empty
WARNING teardown.go:294:     kill "…": git worktree cleanup failed: … unlinkat …/packages: directory not empty
```

Both `git worktree remove -f` and the `os.RemoveAll` fallback delete recursively and do **not** fail on a merely-non-empty directory — they fail `directory not empty` only when files are being *created* faster than they can be unlinked, i.e. a live writer is still in the tree. So teardown removed the worktree **without first ensuring the session's descendant processes were dead**, the writer won the race, and the worktree was orphaned for `doctor`/prune to mop up.

## The fix

The tmux reaper (#1104) already knows how to kill a session's full descendant tree, but on the kill path it fires **asynchronously in a goroutine** with a grace + SIGTERM→SIGKILL escalation — so the *synchronous* worktree removal runs first and loses.

`reapWorktreeWriters` reaps **synchronously, before** the removal:

- Enumerate every process whose **working directory is at or under the worktree**. An AF worktree is a session-private path, so cwd membership unambiguously proves the process is *this session's* — satisfying the #1104 "only our own descendants" discipline and the "which children are garbage" hazard; no unrelated process is ever signalled.
- Take each match's **full descendant subtree** (`proctree.TreeOf`) — a child that `chdir`'d elsewhere may be the actual file-creator.
- **Route the kill through the existing #1104 reaper** (`proctree.KillEscalating`): every signal is identity-verified against `(pid, start-time)` so a recycled PID is never hit, and the SIGTERM→SIGKILL escalation is shared, not re-implemented.
- Then remove — no writer left to race.

**Best-effort and bounded**, like every reaper on this path: an unreadable process table (no `/proc`, unsupported platform) degrades to a no-op; a writer that ignores SIGKILL (D-state, hung mount) is left for the existing WARNING + `doctor` to own. It never errors and never loops. It also cannot reintroduce the #1917 wedge: it runs only after the enclosing `os.Stat(worktree)` succeeded, and its process-table reads hit procfs (a `readlink` of `/proc/pid/cwd` returns the symlink target without traversing into a stalled mount).

## Adjacent-call-site audit

- **`GitWorktree.Cleanup`** — the issue's exact path (teardown → Cleanup). **Fixed.**
- **`RemoveWorktreeDir`** — the active `af reset` per-AF-session removal (`commands/reset.go`), same `git remove` → `os.RemoveAll` race. **Fixed** (reuses the same helper; reset only ever passes AF-created session-worktree paths and refuses the main tree, so the reap stays session-scoped).
- **`CleanupWorktreesForRepo`** — **intentionally not touched.** It has no production caller — `reset` deliberately avoids its bulk pass because it can operate on user-created linked worktrees — so reaping arbitrary user processes there would exceed this issue's surviving-SESSION-writer scope and change reset's blast radius.

## Fail-first evidence

`TestCleanup_ReapsSurvivingWriterBeforeRemoval` spawns a **real, detached** survivor whose cwd is the worktree (an installer stand-in), proves it's alive, runs `Cleanup`, and asserts teardown **reaped** it — then that the tree is fully removed. The observable orphan is a genuine filesystem race (git pre-drains the tree so the fallback usually wins), but the *root cause* is deterministic: on current code nothing reaps a process merely cwd'd in the worktree. The writer beats a heartbeat to an absolute path **outside** the worktree, so its exit can only ever mean "a signal reaped it", never "its files vanished". Every guard is a hard cap (bounded loop, context deadline, process-group cleanup) so it can never wedge CI.

- **Failing 2/2** against pristine `origin/master` (c05dd29): `teardown did not reap the surviving writer (#2025)`.
- **Passing 5/5** with the fix (~0.23s each).
- Full `make test-container` suite **green** (all packages, incl. `daemon`, `session`, `session/tmux`).

## Scope

Confined to `session/git/worktree_ops.go` (+ new test). Deliberately does **not** touch `daemon/manager_sessions.go` or `session/tmux/*` (sibling PRs). Related but distinct from #2007 (surviving *tmux*) and #1967 (pipe-holding children).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Platform coverage

The reap finds writers by working directory, and `proctree.WorkingDir` has **no darwin backend yet** — `readWorkingDir` on macOS returns the honest unknown rather than fabricate a path from an unverifiable libproc struct (which, for a *destructive* reap, would risk signalling the wrong process). So on darwin `reapWorktreeWriters` **safely no-ops** (it can only ever fail to signal the right process, never signal a wrong one), and #2025 still races on macOS until the darwin cwd backend lands — a pre-existing shared-package gap, **tracked in #2050**, not a defect in this Linux fix.

`TestCleanup_ReapsSurvivingWriterBeforeRemoval` therefore `t.Skip`s on darwin with a reason that names the gap and #2050 — an honest skip of a known platform limitation, not a fabricated green. The no-op is also documented at the `reapWorktreeWriters` call site so the boundary is visible at the mechanism.