### PR TITLE
fix(daemon): free taskRunProbeDue entries — cleanup keyed to match the writer (#2015)

### DIFF
--- a/daemon/manager.go
+++ b/daemon/manager.go
@@ -144,11 +144,17 @@ type Manager struct {
 	pausedMu    sync.Mutex
 	pausedPolls map[string]time.Time
 	// taskRunProbeDue schedules the backstop observation for a PAUSED session whose
-	// task run is still in flight (#1892), keyed like pausedPolls and guarded by the
-	// same pausedMu. An attach suppresses the liveness probe, and the cap's slot is
-	// released by observing the agent go idle — so without a bounded backstop a user
-	// watching their own task run silently stalls the task. Entries exist only while
-	// such a session is attached; ResumeStatusPoll drops them with the pause.
+	// task run is still in flight (#1892). Guarded by pausedMu (the same lock as
+	// pausedPolls) but keyed by remoteLossKey — the stable instance ID — NOT by
+	// pausedPolls' daemonInstanceKey: taskRunBackstopDue is its only writer and keys
+	// it that way, so a same-title successor never inherits a predecessor's stale due
+	// time. An attach suppresses the liveness probe, and the cap's slot is released
+	// by observing the agent go idle — so without a bounded backstop a user watching
+	// their own task run silently stalls the task. Entries live only while the
+	// session is paused: ResumeStatusPoll drops one on a clean detach (matching the
+	// writer's key), and sweepTaskRunProbeDue reclaims any whose lease lapsed or
+	// whose session was torn down, so the map tracks pausedPolls and never grows
+	// unbounded over the daemon's lifetime (#2015).
 	taskRunProbeDue map[string]time.Time
 
 	// events is the WS events-plane fan-out (#1592 Phase 2 PR5): every session/

--- a/daemon/manager_status.go
+++ b/daemon/manager_status.go
@@ -65,12 +65,36 @@ func (m *Manager) PauseStatusPoll(repoID, title string) {
 
 // ResumeStatusPoll clears a pause immediately on a clean detach so the poll
 // resumes on the next tick rather than waiting out the lease (#1160).
+//
+// It also frees the session's backstop-timer entry (#2015). That entry is keyed
+// by remoteLossKey (the stable instance ID), NOT the daemonInstanceKey pausedPolls
+// uses — taskRunBackstopDue is its only writer and keys it that way — so the
+// delete must resolve the instance to match the writer; deleting under the pause
+// key was a silent no-op that leaked one entry per probed-while-paused session.
+// sweepTaskRunProbeDue reclaims any entry this cannot (a crashed TUI that never
+// resumes, a session torn down mid-pause), so a lookup miss here is harmless.
 func (m *Manager) ResumeStatusPoll(repoID, title string) {
 	key := daemonInstanceKey(repoID, title)
+	probeKey := m.taskRunProbeKey(repoID, title)
 	m.pausedMu.Lock()
 	delete(m.pausedPolls, key)
-	delete(m.taskRunProbeDue, key)
+	if probeKey != "" {
+		delete(m.taskRunProbeDue, probeKey)
+	}
 	m.pausedMu.Unlock()
+}
+
+// taskRunProbeKey resolves the taskRunProbeDue key (remoteLossKey — the stable
+// instance ID) for a tracked session, or "" when the session is no longer tracked
+// (already torn down; the sweep drops any orphaned entry). Reads m.instances under
+// m.mu and is never called with pausedMu held, so the two locks stay unnested.
+func (m *Manager) taskRunProbeKey(repoID, title string) string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if inst := m.instances[daemonInstanceKey(repoID, title)]; inst != nil {
+		return remoteLossKey(repoID, inst)
+	}
+	return ""
 }
 
 // taskRunBackstopDue reports whether a PAUSED session with an in-flight task run
@@ -93,6 +117,58 @@ func (m *Manager) taskRunBackstopDue(key string) bool {
 	}
 	m.taskRunProbeDue[key] = now.Add(taskRunPollBackstop)
 	return true
+}
+
+// sweepTaskRunProbeDue drops backstop-timer entries whose session is no longer
+// PAUSED (#2015): a clean detach already reclaims its own via ResumeStatusPoll,
+// but a crashed TUI that never resumes (its lease lapses) and a session killed or
+// archived mid-pause both strand an entry with nothing left to delete it. The
+// entry is armed and read ONLY in refreshInstanceStatus's paused branch, so once
+// the pause is gone it is dead weight; without this GC the map grows one entry per
+// distinct task session ever probed-while-paused and never shrinks over the
+// daemon's lifetime. Called once per poll from RefreshStatuses, beside the sibling
+// sweepRemoteLossStates.
+//
+// That sibling keys garbage on "session gone", but a session stays live across a
+// detach, so this keys garbage on "not currently paused" instead. taskRunProbeDue
+// is keyed by remoteLossKey (the stable instance ID) while pausedPolls is keyed by
+// daemonInstanceKey, so the live set is bridged by walking m.instances. m.mu and
+// pausedMu are taken SEPARATELY, never nested — the poll deliberately keeps them
+// apart so a slow probe under one can't block RPCs behind the other (see
+// pausedPolls' field doc).
+func (m *Manager) sweepTaskRunProbeDue() {
+	m.pausedMu.Lock()
+	empty := len(m.taskRunProbeDue) == 0
+	m.pausedMu.Unlock()
+	if empty {
+		return // nothing armed: skip the instance walk in the common case
+	}
+
+	type keyPair struct{ daemonKey, probeKey string }
+	m.mu.Lock()
+	pairs := make([]keyPair, 0, len(m.instances))
+	for key, inst := range m.instances {
+		repoID, _ := splitDaemonInstanceKey(key)
+		pairs = append(pairs, keyPair{daemonKey: key, probeKey: remoteLossKey(repoID, inst)})
+	}
+	m.mu.Unlock()
+
+	now := nowFunc()
+	m.pausedMu.Lock()
+	defer m.pausedMu.Unlock()
+	live := make(map[string]struct{}, len(m.pausedPolls))
+	for _, p := range pairs {
+		// An expired lease is treated as unpaused even before isPollPaused lazily
+		// deletes it, so the entry is reclaimed the same tick the lease lapses.
+		if expiry, ok := m.pausedPolls[p.daemonKey]; ok && now.Before(expiry) {
+			live[p.probeKey] = struct{}{}
+		}
+	}
+	for key := range m.taskRunProbeDue {
+		if _, ok := live[key]; !ok {
+			delete(m.taskRunProbeDue, key)
+		}
+	}
 }
 
 // isPollPaused reports whether an instance's poll is currently paused (#1160).
@@ -171,8 +247,10 @@ func (m *Manager) RefreshStatuses() {
 	m.mu.Unlock()
 
 	// Drop debounce state for sessions that are gone or replaced, colocated with
-	// the pass that creates it (#1794).
+	// the pass that creates it (#1794), and backstop timers for sessions no longer
+	// paused (#2015) — both maps the poll itself populates.
 	m.sweepRemoteLossStates()
+	m.sweepTaskRunProbeDue()
 
 	for _, e := range entries {
 		m.refreshInstanceStatus(e.repoID, e.instance)

--- a/daemon/status_probedue_leak_test.go
+++ b/daemon/status_probedue_leak_test.go
@@ -1,0 +1,124 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// registerTaskRun seeds a started, task-run-active instance — the only shape
+// that arms taskRunProbeDue. taskRunActive is derived from TaskID (#1892), so a
+// non-empty TaskID is what distinguishes this from registerStarted's user
+// session. The instance still carries a stable ID (remoteLossKey's basis), which
+// is exactly the key the backstop timer is stored under.
+func registerTaskRun(t *testing.T, m *Manager, repoID, repoPath, title string) *session.Instance {
+	t.Helper()
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title: title, Path: repoPath, Program: "claude", TaskID: "task-" + title,
+	})
+	if err != nil {
+		t.Fatalf("NewInstance: %v", err)
+	}
+	inst.SetBackend(session.NewFakeBackend())
+	inst.SetStartedForTest(true)
+	inst.SetStatusForTest(session.Running)
+	seedDiskInstance(t, repoID, title, repoPath)
+	m.mu.Lock()
+	m.instances[daemonInstanceKey(repoID, title)] = inst
+	m.mu.Unlock()
+	return inst
+}
+
+// probeDueLen reads taskRunProbeDue's size under its guarding lock, so the
+// assertions never race the poll goroutine's writes.
+func probeDueLen(m *Manager) int {
+	m.pausedMu.Lock()
+	defer m.pausedMu.Unlock()
+	return len(m.taskRunProbeDue)
+}
+
+// TestResumeStatusPoll_FreesTaskRunProbeDueEntry is the #2015 fail-first: a clean
+// detach must FREE the backstop-timer entry an attach armed. The map is written
+// by taskRunBackstopDue under remoteLossKey (the stable instance ID), but the
+// buggy ResumeStatusPoll deletes under daemonInstanceKey(repoID,title) — keys
+// that never coincide for an ID-bearing session — so the delete is a no-op and
+// the entry leaks. The map must return to its pre-attach baseline of 0.
+func TestResumeStatusPoll_FreesTaskRunProbeDueEntry(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst := registerTaskRun(t, manager, repoID, repoPath, "attached-run")
+
+	if inst.ID == "" {
+		t.Fatal("precondition: a task-run instance must carry a stable ID (remoteLossKey's basis)")
+	}
+	if !inst.TaskRunActive() {
+		t.Fatal("precondition: instance must be task-run-active to arm the backstop")
+	}
+	if n := probeDueLen(manager); n != 0 {
+		t.Fatalf("baseline taskRunProbeDue size = %d, want 0", n)
+	}
+
+	// Attach: pause the poll, then one refresh ARMS the backstop timer (the first
+	// paused tick only arms; see taskRunBackstopDue).
+	manager.PauseStatusPoll(repoID, "attached-run")
+	manager.RefreshStatuses()
+	if n := probeDueLen(manager); n != 1 {
+		t.Fatalf("after arming, taskRunProbeDue size = %d, want 1 (a paused task run must arm its backstop)", n)
+	}
+
+	// Detach: a clean ResumeStatusPoll must reclaim the armed entry.
+	manager.ResumeStatusPoll(repoID, "attached-run")
+	if n := probeDueLen(manager); n != 0 {
+		t.Fatalf("after clean detach, taskRunProbeDue size = %d, want 0 — the entry leaked (#2015: cleanup keyed by the wrong function)", n)
+	}
+}
+
+// TestRefreshStatuses_SweepsLapsedTaskRunProbeDue guards the crashed-TUI path: a
+// TUI that never sends Resume leaves the pause to lapse on its lease. There is no
+// Resume to reclaim the armed backstop entry, so the poll's own GC must — once
+// the lease has expired the entry is dead weight and the map must shrink back to
+// 0 on the next pass.
+func TestRefreshStatuses_SweepsLapsedTaskRunProbeDue(t *testing.T) {
+	advance := withFrozenClock(t)
+	manager, repoID, repoPath := newStatusTestManager(t)
+	registerTaskRun(t, manager, repoID, repoPath, "crashed-attach")
+
+	manager.PauseStatusPoll(repoID, "crashed-attach")
+	manager.RefreshStatuses() // arms
+	if n := probeDueLen(manager); n != 1 {
+		t.Fatalf("after arming, taskRunProbeDue size = %d, want 1", n)
+	}
+
+	// The lease lapses with no Resume; the next poll must reclaim the orphan.
+	advance(statusPollLease + time.Second)
+	manager.RefreshStatuses()
+	if n := probeDueLen(manager); n != 0 {
+		t.Fatalf("after lease lapse, taskRunProbeDue size = %d, want 0 — a crashed attach must not leak its backstop entry (#2015)", n)
+	}
+}
+
+// TestRefreshStatuses_SweepsTornDownTaskRunProbeDue guards the teardown path: a
+// session killed or archived while attached leaves m.instances without ever
+// sending Resume. Its backstop entry (keyed by the now-dead instance ID) can
+// never be reached again, so the poll's GC must reclaim it.
+func TestRefreshStatuses_SweepsTornDownTaskRunProbeDue(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	registerTaskRun(t, manager, repoID, repoPath, "torn-down")
+
+	manager.PauseStatusPoll(repoID, "torn-down")
+	manager.RefreshStatuses() // arms
+	if n := probeDueLen(manager); n != 1 {
+		t.Fatalf("after arming, taskRunProbeDue size = %d, want 1", n)
+	}
+
+	// The session is killed/archived out from under the pause: its record leaves
+	// m.instances and Resume never fires.
+	manager.mu.Lock()
+	delete(manager.instances, daemonInstanceKey(repoID, "torn-down"))
+	manager.mu.Unlock()
+
+	manager.RefreshStatuses()
+	if n := probeDueLen(manager); n != 0 {
+		t.Fatalf("after teardown, taskRunProbeDue size = %d, want 0 — a killed/archived session must not leak its backstop entry (#2015)", n)
+	}
+}


### PR DESCRIPTION
Fixes #2015.

## The bug

`taskRunProbeDue` (the #1892 backstop-timer map) leaks: it grows one entry per
distinct task session ever probed-while-paused and never shrinks — unbounded over
the daemon's lifetime, cleared only by a daemon restart.

Its only writer, `taskRunBackstopDue`, keys entries by `remoteLossKey` (= the
stable `instance.ID` for every modern ID-bearing session). But `ResumeStatusPoll`
deleted `m.taskRunProbeDue[daemonInstanceKey(repoID, title)]`. The two keys never
coincide for an ID-bearing session, so the delete was a **silent no-op**. There
was also no lease-lapse GC (`isPollPaused` only clears `pausedPolls`) and no
removal on instance teardown.

## The fix

- **`ResumeStatusPoll`** now resolves the instance and deletes under
  `remoteLossKey`, matching the writer — a clean detach actually frees the entry.
- **`sweepTaskRunProbeDue`** (new), called each poll beside the sibling
  `sweepRemoteLossStates`, reclaims what the resume path can't: a crashed TUI
  whose pause lease lapsed, and a session killed/archived mid-pause. It keys
  garbage on *"not currently paused"* — a detached session stays live, so the
  sibling's *"session gone"* predicate would miss it — and bridges pausedPolls'
  `daemonInstanceKey` to taskRunProbeDue's `remoteLossKey` by walking
  `m.instances`. `m.mu` and `pausedMu` are always taken **separately, never
  nested**.
- **Field doc** at `manager.go` corrected (it wrongly claimed "keyed like
  pausedPolls … ResumeStatusPoll drops them with the pause").

No functional behavior changes: slot release, event delivery, and completion
observation already used `remoteLossKey` consistently on both sides. This only
stops the leak and the secondary effect the issue names (a stale, now-past `due`
forcing a contending capture-pane probe on re-attach instead of honoring the
#1160 quiet window).

## Adjacent-audit

Grepped both key functions. After the fix, **every** `taskRunProbeDue` write
(`taskRunBackstopDue`, keyed `remoteLossKey`) has a matching-key delete —
`ResumeStatusPoll` (`remoteLossKey`) and `sweepTaskRunProbeDue` (live set built
from `remoteLossKey`). No `daemonInstanceKey` delete remains on this map.
`pausedPolls` is keyed by `daemonInstanceKey` consistently across
Pause/Resume/isPollPaused — no analogous mismatch there.

## Fail-first evidence

Three tests assert the map returns to its pre-attach baseline (0) after a
pause→resume, a pause→lease-lapse, and a pause→teardown. All three **fail on
`9e7bcaa`** (base of this branch) with `size = 1, want 0` (entry orphaned), and
pass with the fix:

```
--- FAIL: TestResumeStatusPoll_FreesTaskRunProbeDueEntry
    after clean detach, taskRunProbeDue size = 1, want 0 — the entry leaked
--- FAIL: TestRefreshStatuses_SweepsLapsedTaskRunProbeDue
    after lease lapse, taskRunProbeDue size = 1, want 0
--- FAIL: TestRefreshStatuses_SweepsTornDownTaskRunProbeDue
    after teardown, taskRunProbeDue size = 1, want 0
```

## Verification

- `make test-container GOTESTARGS="./daemon/"` → `ok … 159.305s` (full daemon
  package green)
- `go build ./...`, `gofmt -l .`, `golangci-lint run --timeout=3m --fast`,
  `deadcode -test ./...`, `scripts/lint-file-length.sh` — all clean

File scope: `daemon/manager_status.go`, `daemon/manager.go`, and a new
`daemon/status_probedue_leak_test.go`. Did not touch `manager_sessions.go`,
`manager_persist.go`, or `health.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)