### PR TITLE
fix(config): let the config agent attach inside a tmux session (#2019)

### DIFF
--- a/app/config_agent.go
+++ b/app/config_agent.go
@@ -3,7 +3,9 @@ package app
 import (
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -30,10 +32,12 @@ import (
 // A package var so tests can drive the hotkey without spawning anything, and so
 // the seam rework has exactly one call site to move.
 //
-// The signature is deliberately narrow — a mode and a repo path in, an error out
-// — so it stays valid across the rework: the caller does not care whether the
-// agent is an Instance, a pane, or a bare tmux session.
-var spawnConfigAgent = func(mode configagent.Mode, repoPath string) (string, error) {
+// The signature is deliberately narrow — a mode and a repo path in, the tmux
+// session name plus its socket path and an error out — so it stays valid across
+// the rework: the caller does not care whether the agent is an Instance, a pane,
+// or a bare tmux session. The socket path is what lets the attach pin `-S` so it
+// resolves the session independently of the TUI's TMUX_TMPDIR (#2019).
+var spawnConfigAgent = func(mode configagent.Mode, repoPath string) (string, string, error) {
 	return configagent.Spawn(configagent.Options{Mode: mode, RepoPath: repoPath})
 }
 
@@ -44,7 +48,7 @@ var reapConfigAgent = configagent.Reap
 
 // SetConfigAgentSpawnerForTest swaps the spawn seam and returns a restore func,
 // matching SetLocalSessionPreflightForTest and the other app test seams.
-func SetConfigAgentSpawnerForTest(f func(configagent.Mode, string) (string, error)) func() {
+func SetConfigAgentSpawnerForTest(f func(configagent.Mode, string) (string, string, error)) func() {
 	prev := spawnConfigAgent
 	spawnConfigAgent = f
 	return func() { spawnConfigAgent = prev }
@@ -66,6 +70,11 @@ type configAgentSpawnedMsg struct {
 	// sessionName is the bare tmux session the daemon started, empty on failure.
 	// The takeover attaches to it and the reap tears it down.
 	sessionName string
+	// socketPath is the absolute tmux server socket the session lives on, so the
+	// attach can pin it with `tmux -S <path>` and resolve the session
+	// independently of the TUI's TMUX_TMPDIR (#2019). Empty when the daemon could
+	// not resolve it; the attach then falls back to the default socket.
+	socketPath string
 	// noticeID identifies the "Starting…" notice this spawn raised, so the
 	// handler can retract ITS OWN notice and not whatever is on screen by then.
 	// The spawn runs async for up to a minute — ample time for another action to
@@ -115,8 +124,8 @@ func (m *home) handleConfigAgent() (tea.Model, tea.Cmd) {
 	noticeID := m.setTransientNotice(errors.New("Starting the config agent…"))
 	spawn := spawnConfigAgent
 	return m, func() tea.Msg {
-		name, err := spawn(configagent.ModeChange, repoPath)
-		return configAgentSpawnedMsg{err: err, sessionName: name, noticeID: noticeID}
+		name, socketPath, err := spawn(configagent.ModeChange, repoPath)
+		return configAgentSpawnedMsg{err: err, sessionName: name, socketPath: socketPath, noticeID: noticeID}
 	}
 }
 
@@ -150,7 +159,7 @@ func (m *home) handleConfigAgentSpawned(msg configAgentSpawnedMsg) (tea.Model, t
 		// terminal to a `tmux attach-session -t ""`.
 		return m, m.handleError(errors.New("the config agent started but reported no session to attach to"))
 	}
-	return m, m.enterConfigAgent(msg.sessionName)
+	return m, m.enterConfigAgent(msg.sessionName, msg.socketPath)
 }
 
 // configAgentDoneMsg reports that the user has left the config-agent takeover.
@@ -173,8 +182,8 @@ type configAgentDoneMsg struct {
 // Attaching to a tmux session is also why this can work at all without an
 // Instance: `tmux attach-session` needs only a session NAME, while the WS route
 // needs an Instance to resolve a byte source — and an Instance is a row.
-func (m *home) enterConfigAgent(sessionName string) tea.Cmd {
-	cmd := execConfigAgentAttach(sessionName)
+func (m *home) enterConfigAgent(sessionName, socketPath string) tea.Cmd {
+	cmd := execConfigAgentAttach(sessionName, socketPath)
 	return tea.ExecProcess(cmd, func(err error) tea.Msg {
 		return configAgentDoneMsg{sessionName: sessionName, err: err}
 	})
@@ -182,8 +191,59 @@ func (m *home) enterConfigAgent(sessionName string) tea.Cmd {
 
 // execConfigAgentAttach builds the attach command. A var so tests can drive the
 // takeover without a tmux server.
-var execConfigAgentAttach = func(sessionName string) *exec.Cmd {
-	return exec.Command("tmux", "attach-session", "-t", sessionName)
+//
+// Two things make this attach survive af running INSIDE a tmux session (#2019):
+//
+//   - $TMUX is scrubbed from the child's env. When af itself was launched from a
+//     tmux pane, af inherits $TMUX, and `tmux attach-session` then refuses to
+//     nest — "sessions should be nested with care, unset $TMUX to force" — and
+//     exits 1. This is the ONLY terminal handover in the TUI that shells out to
+//     `tmux attach-session` (every other attach goes through the WS raw proxy,
+//     which needs an Instance — a session-list row — that the config agent
+//     deliberately is not), so it is the only one that hits the nesting refusal.
+//     Dropping $TMUX is exactly what tmux's own error instructs.
+//
+//   - The server socket is pinned with `-S <path>`. After $TMUX is gone, tmux
+//     resolves the session through the DEFAULT socket
+//     (${TMUX_TMPDIR:-/tmp/tmux-<uid>}/default), and the daemon that spawned the
+//     session can resolve a different TMUX_TMPDIR than this TUI — so "default"
+//     could point at two different directories and the attach would not find the
+//     session. Pinning the authoritative socket the daemon reported makes
+//     resolution independent of either side's TMUX_TMPDIR. socketPath is empty
+//     only when the daemon could not resolve it, in which case the attach falls
+//     back to the default socket (Part 1 alone still fixes the reported bug).
+var execConfigAgentAttach = func(sessionName, socketPath string) *exec.Cmd {
+	args := make([]string, 0, 5)
+	if socketPath != "" {
+		args = append(args, "-S", socketPath)
+	}
+	args = append(args, "attach-session", "-t", sessionName)
+	cmd := exec.Command("tmux", args...)
+	cmd.Env = configAgentAttachEnv()
+	return cmd
+}
+
+// configAgentAttachEnv is the current environment with the TMUX marker removed,
+// so the nested `tmux attach-session` above does not refuse to run (#2019).
+//
+// Only TMUX is dropped, and deliberately: TMUX_TMPDIR is left in place because it
+// participates in default-socket resolution (and the `-S` pin depends on nothing
+// here). This mirrors daemon/vscode_server.go's vscodeChildEnv, which likewise
+// builds a child env from os.Environ() dropping selected KEY= prefixes because a
+// stale inherited handle would break the child — the same shape, one key.
+//
+// The `TMUX=` prefix match is exact: it drops `TMUX=…` without touching
+// `TMUX_TMPDIR=…`, whose key does not start with `TMUX=`.
+func configAgentAttachEnv() []string {
+	src := os.Environ()
+	out := make([]string, 0, len(src))
+	for _, kv := range src {
+		if strings.HasPrefix(kv, "TMUX=") {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
 }
 
 // handleConfigAgentDone runs when the user leaves the takeover: reap the session
@@ -216,7 +276,15 @@ func (m *home) handleConfigAgentDone(msg configAgentDoneMsg) (tea.Model, tea.Cmd
 		m.appConfig = cfg
 	}
 	if msg.err != nil {
-		return m, m.handleError(fmt.Errorf("config agent: %w", msg.err))
+		// Name what happened and what to do, not a bare exit code. A raw
+		// "config agent: exit status 1" (what tmux returns when it refuses to
+		// nest, #2019, and what any other attach failure surfaces as) tells the
+		// user neither the cause nor a way forward. Lead with the consequential
+		// half — the transient notice clips its tail at real widths, and the
+		// wrapped cause stays available under `E details`.
+		return m, m.handleError(fmt.Errorf(
+			"could not attach to the config agent — it may have exited, or tmux is unavailable · press C to retry, or run af config set to edit config directly: %w",
+			msg.err))
 	}
 	return m, nil
 }

--- a/app/config_agent_test.go
+++ b/app/config_agent_test.go
@@ -3,6 +3,8 @@ package app
 import (
 	"errors"
 	"os/exec"
+	"slices"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -31,10 +33,10 @@ func TestConfigAgentKeyDispatches(t *testing.T) {
 	var gotMode configagent.Mode
 	var gotRepo string
 	spawned := 0
-	t.Cleanup(SetConfigAgentSpawnerForTest(func(mode configagent.Mode, repoPath string) (string, error) {
+	t.Cleanup(SetConfigAgentSpawnerForTest(func(mode configagent.Mode, repoPath string) (string, string, error) {
 		spawned++
 		gotMode, gotRepo = mode, repoPath
-		return "af-config-1", nil
+		return "af-config-1", "", nil
 	}))
 
 	model, cmd := h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'C'}}, name)
@@ -73,7 +75,7 @@ func TestConfigAgentMissingBinaryIsNonFatal(t *testing.T) {
 		Command: "/nonexistent/claude",
 		Err:     errors.New("Claude Code is not installed or not on PATH (resolved command: \"/nonexistent/claude\")"),
 	}
-	t.Cleanup(SetConfigAgentSpawnerForTest(func(configagent.Mode, string) (string, error) { return "", missing }))
+	t.Cleanup(SetConfigAgentSpawnerForTest(func(configagent.Mode, string) (string, string, error) { return "", "", missing }))
 
 	_, cmd := h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'C'}}, keys.KeyConfigAgent)
 	require.NotNil(t, cmd)
@@ -101,18 +103,22 @@ func TestConfigAgentMissingBinaryIsNonFatal(t *testing.T) {
 func TestConfigAgentSpawnEntersTheTakeover(t *testing.T) {
 	h := newTestHome(t)
 
-	var attached string
+	var attached, attachedSocket string
 	prevExec := execConfigAgentAttach
-	execConfigAgentAttach = func(name string) *exec.Cmd {
-		attached = name
+	execConfigAgentAttach = func(name, socketPath string) *exec.Cmd {
+		attached, attachedSocket = name, socketPath
 		return exec.Command("true") // never actually attach in a test
 	}
 	t.Cleanup(func() { execConfigAgentAttach = prevExec })
 
-	model, cmd := h.handleConfigAgentSpawned(configAgentSpawnedMsg{sessionName: "af-config-7"})
+	model, cmd := h.handleConfigAgentSpawned(configAgentSpawnedMsg{sessionName: "af-config-7", socketPath: "/tmp/tmux-1000/default"})
 	require.NotNil(t, model)
 	require.NotNil(t, cmd, "a successful spawn must hand the terminal to the config agent")
 	assert.Equal(t, "af-config-7", attached, "the takeover must attach to the session the daemon named")
+	// The socket path the daemon reported must reach the attach, so it can pin
+	// `-S` and resolve the session independently of the TUI's TMUX_TMPDIR (#2019).
+	assert.Equal(t, "/tmp/tmux-1000/default", attachedSocket,
+		"the takeover must attach on the socket the daemon reported")
 }
 
 // TestConfigAgentSpawnWithNoSessionNameIsAnError pins the defensive case: the
@@ -171,9 +177,9 @@ func TestConfigAgentDoesNotSpawnTwice(t *testing.T) {
 	h := newTestHome(t)
 
 	spawns := 0
-	t.Cleanup(SetConfigAgentSpawnerForTest(func(configagent.Mode, string) (string, error) {
+	t.Cleanup(SetConfigAgentSpawnerForTest(func(configagent.Mode, string) (string, string, error) {
 		spawns++
-		return "af-config-1", nil
+		return "af-config-1", "", nil
 	}))
 
 	pressC := func() tea.Cmd {
@@ -215,7 +221,7 @@ func TestConfigAgentDoesNotSpawnTwice(t *testing.T) {
 // the user had not read yet. Only retract our own, and only if it is still up.
 func TestConfigAgentSpawnClearsOnlyItsOwnNotice(t *testing.T) {
 	h := newTestHome(t)
-	t.Cleanup(SetConfigAgentSpawnerForTest(func(configagent.Mode, string) (string, error) { return "af-config-1", nil }))
+	t.Cleanup(SetConfigAgentSpawnerForTest(func(configagent.Mode, string) (string, string, error) { return "af-config-1", "", nil }))
 
 	_, cmd := h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'C'}}, keys.KeyConfigAgent)
 	require.NotNil(t, cmd)
@@ -231,11 +237,80 @@ func TestConfigAgentSpawnClearsOnlyItsOwnNotice(t *testing.T) {
 
 	// The normal case still retracts our own notice.
 	h2 := newTestHome(t)
-	t.Cleanup(SetConfigAgentSpawnerForTest(func(configagent.Mode, string) (string, error) { return "af-config-1", nil }))
+	t.Cleanup(SetConfigAgentSpawnerForTest(func(configagent.Mode, string) (string, string, error) { return "af-config-1", "", nil }))
 	_, cmd2 := h2.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'C'}}, keys.KeyConfigAgent)
 	own := cmd2().(configAgentSpawnedMsg)
 	require.Contains(t, h2.errBox.FullError(), "Starting the config agent",
 		"the keypress should have raised a starting notice")
 	h2.handleConfigAgentSpawned(own)
 	assert.Empty(t, h2.errBox.FullError(), "a successful spawn should retract its own starting notice")
+}
+
+// envValue returns the value of KEY from a KEY=VALUE environment slice, and
+// whether it was present.
+func envValue(env []string, key string) (string, bool) {
+	for _, kv := range env {
+		if name, val, ok := strings.Cut(kv, "="); ok && name == key {
+			return val, true
+		}
+	}
+	return "", false
+}
+
+// TestConfigAgentAttachCommandScrubsTMUXAndPinsSocket is the deterministic guard
+// for #2019. It is NOT the primary proof — a command a test builds cannot show
+// what tmux does with it, so the behavioral reproduction lives in the tui-driver
+// selftest (af genuinely runs inside a tmux pane there) — but it locks the two
+// properties the fix depends on against silent regression, at unit speed.
+//
+//  1. $TMUX is scrubbed from the child env. af inherits $TMUX when it is launched
+//     from a tmux pane, and `tmux attach-session` then refuses to nest and exits
+//     1 — the reported failure. The child env must not carry TMUX.
+//  2. TMUX_TMPDIR is LEFT in place. It participates in default-socket resolution
+//     and is not what breaks the nesting; scrubbing it would be a gratuitous
+//     behavior change.
+//  3. The socket is pinned with `-S <path>` so resolution never depends on the
+//     TUI's own TMUX_TMPDIR, which can differ from the daemon's.
+func TestConfigAgentAttachCommandScrubsTMUXAndPinsSocket(t *testing.T) {
+	// Simulate af running inside tmux: $TMUX set, plus a TMUX_TMPDIR that must
+	// survive. t.Setenv restores both on cleanup.
+	t.Setenv("TMUX", "/tmp/tmux-1000/default,1234,0")
+	t.Setenv("TMUX_TMPDIR", "/tmp/tmux-1000")
+
+	cmd := execConfigAgentAttach("af-config-3", "/tmp/tmux-1000/default")
+
+	// The socket is pinned BEFORE the subcommand (a tmux global option), and the
+	// session is addressed by name.
+	assert.Equal(t, []string{"tmux", "-S", "/tmp/tmux-1000/default", "attach-session", "-t", "af-config-3"}, cmd.Args,
+		"the attach must pin the reported socket with -S and address the session by name")
+
+	// Env is set explicitly (nil would inherit the parent's, TMUX and all).
+	require.NotNil(t, cmd.Env, "the attach must set an explicit child env, not inherit $TMUX")
+	_, hasTMUX := envValue(cmd.Env, "TMUX")
+	assert.False(t, hasTMUX,
+		"TMUX must be scrubbed from the attach child env, or tmux refuses to nest and exits 1 (#2019)")
+	tmpdir, hasTmpdir := envValue(cmd.Env, "TMUX_TMPDIR")
+	assert.True(t, hasTmpdir, "TMUX_TMPDIR must be left in place — it is not what breaks nesting")
+	assert.Equal(t, "/tmp/tmux-1000", tmpdir, "TMUX_TMPDIR must pass through unchanged")
+
+	// A sanity check that scrubbing did not drop everything: an unrelated var
+	// survives. (Guards against a filter that is too aggressive.)
+	assert.True(t, slices.ContainsFunc(cmd.Env, func(kv string) bool {
+		return strings.HasPrefix(kv, "PATH=")
+	}), "the child env must still carry the rest of the environment")
+}
+
+// TestConfigAgentAttachWithoutSocketOmitsPin pins the fallback: when the daemon
+// could not report a socket (empty path), the attach omits `-S` and lets tmux
+// resolve the session on its default socket. Part 1 (the $TMUX scrub) alone still
+// fixes the reported nesting refusal, so an unknown socket must degrade, not
+// hand tmux an empty `-S ""`.
+func TestConfigAgentAttachWithoutSocketOmitsPin(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/tmux-1000/default,1234,0")
+
+	cmd := execConfigAgentAttach("af-config-4", "")
+	assert.Equal(t, []string{"tmux", "attach-session", "-t", "af-config-4"}, cmd.Args,
+		"an empty socket path must omit -S entirely, never pass -S \"\"")
+	_, hasTMUX := envValue(cmd.Env, "TMUX")
+	assert.False(t, hasTMUX, "TMUX must be scrubbed even on the default-socket fallback path (#2019)")
 }

--- a/configagent/agent.go
+++ b/configagent/agent.go
@@ -104,7 +104,8 @@ func Reap(sessionName string) error {
 // the real resolver.
 var resolveConfigForRepo = config.ResolveConfig
 
-// Spawn starts the config agent and returns the tmux session name to attach to.
+// Spawn starts the config agent and returns the tmux session name AND the
+// absolute socket path to attach to.
 //
 //  1. Resolve the repo's config — this picks up an in-repo default_program /
 //     program_overrides, so the agent launched is the one the user actually gets
@@ -113,6 +114,10 @@ var resolveConfigForRepo = config.ResolveConfig
 //     spawns NOTHING — never a spawn that hangs to a readiness timeout.
 //  3. Ask the daemon to run it in a bare tmux session at AF home. The daemon owns
 //     the rest: readiness, trust-prompt dismissal, briefing delivery, and reaping.
+//
+// The socket path rides back alongside the name so the caller can attach with
+// `tmux -S <socket>` (#2019); it may be empty, in which case the attach falls
+// back to the default socket.
 //
 // No Instance is created anywhere in this path, which is what keeps the config
 // agent out of instances.json and out of the session list.
@@ -125,7 +130,7 @@ var resolveConfigForRepo = config.ResolveConfig
 // permissions skipped. What actually bounds this agent is the scope fence in the
 // briefing: an instruction, not a sandbox. That is the honest posture, and it is
 // why the fence is worded as forcefully as it is.
-func Spawn(opts Options) (string, error) {
+func Spawn(opts Options) (string, string, error) {
 	// The briefing describes the GLOBAL config, because that is what `af config
 	// set`/`get` read and write — briefing the agent on a repo-resolved view
 	// would show it values it cannot write. The PROGRAM comes from the resolved
@@ -133,7 +138,7 @@ func Spawn(opts Options) (string, error) {
 	// gets in this repo.
 	globalCfg, err := config.LoadConfig()
 	if err != nil {
-		return "", fmt.Errorf("cannot read the global config to brief the config agent: %w", err)
+		return "", "", fmt.Errorf("cannot read the global config to brief the config agent: %w", err)
 	}
 	configPath, pathErr := config.GlobalConfigPath()
 	if pathErr != nil {
@@ -159,19 +164,19 @@ func Spawn(opts Options) (string, error) {
 	// Check the binary before spending a daemon round trip, a tmux session and a
 	// readiness wait on a program that cannot start.
 	if _, perr := preflight.CheckProgram(agentCfg, agent); perr != nil {
-		return "", &ProgramUnavailableError{
+		return "", "", &ProgramUnavailableError{
 			Agent:   agent,
 			Command: command,
 			Err:     preflight.ProgramError(agent, command, perr),
 		}
 	}
 
-	name, err := spawnViaDaemon(daemon.SpawnConfigAgentRequest{
+	name, socketPath, err := spawnViaDaemon(daemon.SpawnConfigAgentRequest{
 		Program: command,
 		Prompt:  BuildBriefing(opts.Mode, globalCfg, configPath),
 	})
 	if err != nil {
-		return "", fmt.Errorf("failed to start the config agent: %w", err)
+		return "", "", fmt.Errorf("failed to start the config agent: %w", err)
 	}
-	return name, nil
+	return name, socketPath, nil
 }

--- a/configagent/agent_test.go
+++ b/configagent/agent_test.go
@@ -24,7 +24,7 @@ func tempAFHome(t *testing.T) {
 
 // stubSpawn replaces the daemon round trip so a test can observe the request
 // without a daemon or a tmux server.
-func stubSpawn(t *testing.T, fn func(daemon.SpawnConfigAgentRequest) (string, error)) {
+func stubSpawn(t *testing.T, fn func(daemon.SpawnConfigAgentRequest) (string, string, error)) {
 	t.Helper()
 	prev := spawnViaDaemon
 	spawnViaDaemon = fn
@@ -68,12 +68,12 @@ func TestSpawnCreatesNoInstance(t *testing.T) {
 	})
 
 	var got daemon.SpawnConfigAgentRequest
-	stubSpawn(t, func(req daemon.SpawnConfigAgentRequest) (string, error) {
+	stubSpawn(t, func(req daemon.SpawnConfigAgentRequest) (string, string, error) {
 		got = req
-		return "af-config-1", nil
+		return "af-config-1", "", nil
 	})
 
-	name, err := Spawn(Options{Mode: ModeOnboard, RepoPath: "/tmp/some-repo"})
+	name, _, err := Spawn(Options{Mode: ModeOnboard, RepoPath: "/tmp/some-repo"})
 	if err != nil {
 		t.Fatalf("spawn: %v", err)
 	}
@@ -109,12 +109,12 @@ func TestSpawnMissingProgramReturnsTypedErrorAndCreatesNothing(t *testing.T) {
 	})
 
 	spawned := 0
-	stubSpawn(t, func(daemon.SpawnConfigAgentRequest) (string, error) {
+	stubSpawn(t, func(daemon.SpawnConfigAgentRequest) (string, string, error) {
 		spawned++
-		return "af-config-1", nil
+		return "af-config-1", "", nil
 	})
 
-	_, err := Spawn(Options{Mode: ModeOnboard, RepoPath: "/tmp/some-repo"})
+	_, _, err := Spawn(Options{Mode: ModeOnboard, RepoPath: "/tmp/some-repo"})
 	if err == nil {
 		t.Fatal("expected a missing program to be rejected")
 	}
@@ -150,12 +150,12 @@ func TestSpawnDeliversBriefingAsThePrompt(t *testing.T) {
 	})
 
 	var got daemon.SpawnConfigAgentRequest
-	stubSpawn(t, func(req daemon.SpawnConfigAgentRequest) (string, error) {
+	stubSpawn(t, func(req daemon.SpawnConfigAgentRequest) (string, string, error) {
 		got = req
-		return "af-config-1", nil
+		return "af-config-1", "", nil
 	})
 
-	if _, err := Spawn(Options{Mode: ModeChange, RepoPath: "/tmp/some-repo"}); err != nil {
+	if _, _, err := Spawn(Options{Mode: ModeChange, RepoPath: "/tmp/some-repo"}); err != nil {
 		t.Fatalf("spawn: %v", err)
 	}
 	if got.Prompt == "" {
@@ -188,12 +188,12 @@ func TestSpawnWithoutARepoFallsBackToGlobal(t *testing.T) {
 	}
 
 	var got daemon.SpawnConfigAgentRequest
-	stubSpawn(t, func(req daemon.SpawnConfigAgentRequest) (string, error) {
+	stubSpawn(t, func(req daemon.SpawnConfigAgentRequest) (string, string, error) {
 		got = req
-		return "af-config-1", nil
+		return "af-config-1", "", nil
 	})
 
-	if _, err := Spawn(Options{Mode: ModeOnboard}); err != nil {
+	if _, _, err := Spawn(Options{Mode: ModeOnboard}); err != nil {
 		t.Fatalf("spawn with no repo path must work: %v", err)
 	}
 	if got.Program != "/bin/sh" {
@@ -218,12 +218,12 @@ func TestSpawnBriefsWithGlobalConfigValues(t *testing.T) {
 	})
 
 	var got daemon.SpawnConfigAgentRequest
-	stubSpawn(t, func(req daemon.SpawnConfigAgentRequest) (string, error) {
+	stubSpawn(t, func(req daemon.SpawnConfigAgentRequest) (string, string, error) {
 		got = req
-		return "af-config-1", nil
+		return "af-config-1", "", nil
 	})
 
-	if _, err := Spawn(Options{Mode: ModeOnboard, RepoPath: "/tmp/some-repo"}); err != nil {
+	if _, _, err := Spawn(Options{Mode: ModeOnboard, RepoPath: "/tmp/some-repo"}); err != nil {
 		t.Fatalf("spawn: %v", err)
 	}
 	if got.Program != "/bin/sh" {

--- a/daemon/configagent.go
+++ b/daemon/configagent.go
@@ -155,7 +155,14 @@ const configAgentTrustRetryDelay = 500 * time.Millisecond
 
 // SpawnConfigAgent starts a config agent in a bare tmux session rooted at AF
 // home, waits for it to be ready, dismisses any trust prompt, delivers the
-// briefing, and returns the tmux session name for the caller to attach to.
+// briefing, and returns the tmux session name AND the absolute socket path for
+// the caller to attach to.
+//
+// The socket path is returned alongside the name so the TUI can attach with
+// `tmux -S <socket> attach-session` (#2019): the daemon and the TUI are
+// different processes and can resolve different TMUX_TMPDIR values, so the
+// default-socket path is not something the attaching side can assume. The socket
+// this session lives on is authoritative only here, where it was spawned.
 //
 // AF home — not the user's repo — is the working directory, and that is a
 // deliberate improvement over the in-place seam this replaces: the agent's cwd
@@ -166,36 +173,60 @@ const configAgentTrustRetryDelay = 500 * time.Millisecond
 //
 // On ANY failure the session is torn down before returning, so a half-started
 // config agent never survives as an orphan.
-func (m *Manager) SpawnConfigAgent(ctx context.Context, req SpawnConfigAgentRequest) (string, error) {
+func (m *Manager) SpawnConfigAgent(ctx context.Context, req SpawnConfigAgentRequest) (string, string, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	if req.Program == "" {
-		return "", fmt.Errorf("config agent: no program to run")
+		return "", "", fmt.Errorf("config agent: no program to run")
 	}
 	home, err := config.GetConfigDir()
 	if err != nil {
-		return "", fmt.Errorf("config agent: cannot resolve the agent-factory home: %w", err)
+		return "", "", fmt.Errorf("config agent: cannot resolve the agent-factory home: %w", err)
 	}
 
-	name := fmt.Sprintf("%s%d", configAgentSessionPrefix, configAgentSeq.Add(1))
-	ts := tmux.NewTmuxSession(name, req.Program)
+	// seq is only for uniqueness within this daemon; the tmux session NewTmuxSession
+	// actually creates is TmuxPrefix + this (af_af-config-<n>) — see SanitizedName
+	// below. Keeping the af_ prefix is what keeps the session inside the namespace
+	// every af cleanup path recognizes (`^af_`).
+	seq := fmt.Sprintf("%s%d", configAgentSessionPrefix, configAgentSeq.Add(1))
+	ts := tmux.NewTmuxSession(seq, req.Program)
 	if err := ts.Start(home); err != nil {
-		return "", fmt.Errorf("config agent: failed to start tmux session: %w", err)
+		return "", "", fmt.Errorf("config agent: failed to start tmux session: %w", err)
 	}
-	if !m.configAgents.track(name, ts) {
+	// The name the caller must attach to and reap by is the name tmux actually
+	// knows — the sanitized name, WITH the af_ prefix — not the bare seq. Returning
+	// the bare seq was a latent bug: `tmux attach-session -t af-config-<n>` does not
+	// resolve the real session af_af-config-<n>, so the attach failed with "can't
+	// find session" (masked inside tmux by the nesting refusal this PR fixes, but a
+	// hard failure everywhere once $TMUX is scrubbed). Track, reap, and return the
+	// resolvable name so every side agrees (#2019).
+	sessionName := ts.SanitizedName()
+	if !m.configAgents.track(sessionName, ts) {
 		// The daemon is shutting down; do not leak the session we just made. Pane
 		// state ignored: no worktree, so nothing destructive follows (see HooksDone).
 		_, _ = ts.Close()
-		return "", fmt.Errorf("config agent: the daemon is shutting down")
+		return "", "", fmt.Errorf("config agent: the daemon is shutting down")
 	}
 	// Any failure past this point tears the session down rather than leaving a
 	// tmux nobody owns.
-	fail := func(err error) (string, error) {
-		if rerr := m.configAgents.reap(name); rerr != nil {
+	fail := func(err error) (string, string, error) {
+		if rerr := m.configAgents.reap(sessionName); rerr != nil {
 			log.WarningLog.Printf("config agent: cleanup after a failed spawn also failed: %v", rerr)
 		}
-		return "", err
+		return "", "", err
+	}
+
+	// The absolute socket path this session lives on, queried from tmux itself so
+	// it is authoritative rather than recomputed from TMUX_TMPDIR (#2019). A
+	// failure here is NOT fatal: the attach can still resolve the session via its
+	// own default socket when both sides share a TMUX_TMPDIR, which is the common
+	// case — so degrade to an empty path and let that fall back, rather than
+	// failing a spawn that would otherwise attach fine.
+	socketPath, serr := ts.SocketPath(ctx)
+	if serr != nil {
+		log.WarningLog.Printf("config agent: could not resolve the tmux socket path for %s (%v); the attach will fall back to the default socket", sessionName, serr)
+		socketPath = ""
 	}
 
 	// The agent the pane ACTUALLY runs, detected from the command — so an
@@ -218,8 +249,8 @@ func (m *Manager) SpawnConfigAgent(ctx context.Context, req SpawnConfigAgentRequ
 			return fail(fmt.Errorf("config agent: failed to deliver the briefing: %w", err))
 		}
 	}
-	log.InfoLog.Printf("config agent: started %s in %s (agent %q)", name, home, agent)
-	return name, nil
+	log.InfoLog.Printf("config agent: started %s in %s on socket %q (agent %q)", sessionName, home, socketPath, agent)
+	return sessionName, socketPath, nil
 }
 
 // dismissConfigAgentTrustPrompt clears the agent's first-run trust dialog, the

--- a/daemon/control_client.go
+++ b/daemon/control_client.go
@@ -376,15 +376,16 @@ func TriggerTask(id string, expect task.ProjectExpectation) error {
 }
 
 // SpawnConfigAgent asks the daemon to start a config agent in a bare tmux session
-// and returns the session name to attach to. callDaemon carries the warm-up
-// retry, so pressing the hotkey while the daemon is still starting waits rather
-// than failing.
-func SpawnConfigAgent(req SpawnConfigAgentRequest) (string, error) {
+// and returns the session name AND the absolute socket path to attach to.
+// callDaemon carries the warm-up retry, so pressing the hotkey while the daemon
+// is still starting waits rather than failing. The socket path may be empty (the
+// daemon could not resolve it); the attach then falls back to the default socket.
+func SpawnConfigAgent(req SpawnConfigAgentRequest) (string, string, error) {
 	var resp SpawnConfigAgentResponse
 	if err := callDaemon("SpawnConfigAgent", req, &resp); err != nil {
-		return "", err
+		return "", "", err
 	}
-	return resp.SessionName, nil
+	return resp.SessionName, resp.SocketPath, nil
 }
 
 // ReapConfigAgent tears down a config-agent session once the caller is done with

--- a/daemon/control_server.go
+++ b/daemon/control_server.go
@@ -275,11 +275,12 @@ func (s *controlServer) SpawnConfigAgent(req SpawnConfigAgentRequest, resp *Spaw
 	if err := s.requireManagerReady(); err != nil {
 		return err
 	}
-	name, err := s.manager.SpawnConfigAgent(context.Background(), req)
+	name, socketPath, err := s.manager.SpawnConfigAgent(context.Background(), req)
 	if err != nil {
 		return err
 	}
 	resp.SessionName = name
+	resp.SocketPath = socketPath
 	return nil
 }
 

--- a/daemon/control_types.go
+++ b/daemon/control_types.go
@@ -560,9 +560,21 @@ type SpawnConfigAgentRequest struct {
 	Prompt string `json:"prompt"`
 }
 
-// SpawnConfigAgentResponse returns the tmux session name the client attaches to.
+// SpawnConfigAgentResponse returns the tmux session name AND the absolute socket
+// path the client attaches to.
+//
+// SocketPath is a PLAIN STRING, deliberately, and for the same reason the
+// request's fields are: the control socket is net/rpc gob, which elides
+// zero-value fields, so a *string would arrive as nil when empty (#1700). A
+// missing socket path is a legitimate value here — the daemon returns it empty
+// when it could not resolve the socket, and the attach then falls back to its
+// default socket — so it must transmit as "" rather than be laundered into nil.
 type SpawnConfigAgentResponse struct {
 	SessionName string `json:"session_name"`
+	// SocketPath is the absolute tmux server socket the session lives on, so the
+	// client can pin it with `tmux -S <path> attach-session` (#2019). Empty when
+	// the daemon could not resolve it; the attach falls back to the default socket.
+	SocketPath string `json:"socket_path"`
 }
 
 // ReapConfigAgentRequest tears down a config-agent session once the client is

--- a/scripts/tui-driver-selftest.sh
+++ b/scripts/tui-driver-selftest.sh
@@ -419,11 +419,90 @@ _expect_config_editor_rejects() {
     return 0
 }
 
+# _expect_config_agent_attaches_in_tmux — regression proof for #2019. This is the
+# END-TO-END gate for the config-agent takeover, and it is only meaningful HERE:
+# the driver runs af inside a real tmux pane, so pressing C hits the reporter's
+# exact condition — af has $TMUX set. On unfixed code the config agent's
+# `tmux attach-session` refuses to nest ("sessions should be nested with care,
+# unset $TMUX to force") and the takeover collapses back to the TUI as
+# "config agent: exit status 1". The fix (1) scrubs $TMUX so tmux stops refusing,
+# (2) pins the server socket with -S, and (3) attaches to the RESOLVABLE session
+# name (the daemon returned the bare seq af-config-<n>, which does not resolve the
+# real session af_af-config-<n> — a latent "can't find session" that the nesting
+# refusal masked). So the takeover LANDS: the TUI chrome is replaced by the config
+# agent's own session.
+#
+# The sandbox default_program resolves to bash (program_overrides), so the config
+# agent needs no real agent binary; the briefing arrives as a bracketed paste, so
+# bash keeps running and the takeover stays up until we detach it. The config
+# session lives on this same container tmux server, so detach-client by name
+# returns control to the TUI without guessing a nested prefix key.
+# shellcheck disable=SC2317  # dispatched indirectly via step(); not dead code.
+_expect_config_agent_attaches_in_tmux() {
+    af_ensure_nav
+    af_focus_tree || return 1
+
+    af_send C
+
+    # Resolve one of two mutually exclusive outcomes:
+    #   * the attach error surfaces — #2019 reproduced (hard fail), OR
+    #   * the TUI chrome vanishes — the takeover landed (pass).
+    # The failure strings are deterministic on unfixed code (af always runs inside
+    # tmux here), so seeing any of them is the failure. The 75s budget covers the
+    # spawn's readiness wait plus the briefing paste.
+    local deadline screen; deadline=$(( $(_af_now) + 75 ))
+    while :; do
+        screen="$(af_capture)"
+        if printf '%s\n' "$screen" | grep -qiE 'exit status 1|nested with care|can.t find session'; then
+            _af_log "#2019: config agent failed to attach (takeover collapsed to an error):"
+            printf '%s\n' "$screen" >&2
+            return 1
+        fi
+        if ! printf '%s\n' "$screen" | grep -qE 'Agent Factory'; then
+            break  # chrome gone → the takeover landed
+        fi
+        if [ "$(_af_now)" -ge "$deadline" ]; then
+            _af_log "#2019: config agent neither attached nor errored within 75s"
+            printf '%s\n' "$screen" >&2
+            return 1
+        fi
+        sleep "$AF_DRIVER_POLL"
+    done
+
+    # We are inside the config agent's tmux session now. Detach its client so
+    # control returns to the TUI (the app then reaps the session and reloads
+    # config). The session is af_af-config-<n> on this same server.
+    local cfg
+    cfg="$(tmux list-sessions -F '#{session_name}' 2>/dev/null | grep '^af_af-config-' | head -1)"
+    if [ -z "$cfg" ]; then
+        _af_log "#2019: takeover landed but no af_af-config-* session was found to detach"
+        return 1
+    fi
+    tmux detach-client -s "$cfg" 2>/dev/null || true
+
+    # Back in the TUI, and NOT via the error path.
+    af_wait_for 'Agent Factory' "$AF_DRIVER_TIMEOUT" 'returned to the TUI after the config-agent takeover' || return 1
+    af_refute_screen 'exit status 1' 'the config-agent takeover must not have errored (#2019)' || return 1
+    return 0
+}
+
 step "seed a task via the create form"                      af_add_task selftest-task
 step "close the tasks overlay after create"                 af_close_tasks
 step "reopen tasks — edit-mode overlay recognized (#1757)"  af_open_tasks
 step "assert the task editor shows the run action"          af_assert_screen "$_AF_TASKS_RUN_HINT" 'task-overlay run action'
 step "close the tasks overlay"                              af_close_tasks
+
+# --- #2019 regression: the config agent (C) must attach even though af is nested
+# inside tmux. On unfixed code the takeover collapses to "config agent: exit
+# status 1" (tmux refusing to nest); the fix scrubs $TMUX, pins the socket, and
+# attaches to the resolvable session name.
+#
+# This runs BEFORE the config-editor steps deliberately: those rewrite
+# default_program to codex (not installed in the test image), which would make the
+# config agent fail preflight rather than exercise the attach. Here the sandbox's
+# default_program still resolves to bash (config.json program_overrides), so the
+# config agent runs bash and needs no real agent binary.
+step "config agent (C) attaches while af runs inside tmux (#2019)"  _expect_config_agent_attaches_in_tmux
 
 step "open the config editor (,) and write through the real path"  _expect_config_editor_writes
 step "config editor refuses an invalid value with the CLI error"   _expect_config_editor_rejects

--- a/session/tmux/socket.go
+++ b/session/tmux/socket.go
@@ -1,0 +1,44 @@
+package tmux
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// SocketPath returns the absolute filesystem path of the tmux server socket this
+// session lives on, exactly as tmux itself resolves it (#{socket_path}).
+//
+// It exists for the config-agent attach (#2019). That takeover hands the
+// terminal to `tmux attach-session` via tea.ExecProcess, and after $TMUX is
+// scrubbed the child resolves its server through the DEFAULT socket
+// (${TMUX_TMPDIR:-/tmp/tmux-<uid>}/default). The daemon that spawned the session
+// and the TUI that attaches are different processes and can resolve DIFFERENT
+// TMUX_TMPDIR values (an autostarted daemon may lack it while the user's shell
+// sets it), so "default" would point at two different directories and the attach
+// would fail to find the session. Reporting the authoritative socket path lets
+// the attach pin it with `tmux -S <path>`, making resolution independent of
+// either process's TMUX_TMPDIR.
+//
+// It is deliberately read-only: a single display-message query, bounded like
+// panePID() (#1917). It opens no client and mutates no session state, so it does
+// not belong to — and does not disturb — the Detach/Restore/capture/send core.
+func (t *TmuxSession) SocketPath(ctx context.Context) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, tmuxCommandTimeout)
+	defer cancel()
+	// exactTarget forces an exact session match, mirroring panePID(): the bare
+	// `=name` form yields empty output for display-message, and the trailing `:`
+	// is what makes the format resolve (#1006).
+	output, err := t.outputTmuxBounded(ctx, "display-message", "-p", "-t", exactTarget(t.sanitizedName), "#{socket_path}")
+	if err != nil {
+		if ctx.Err() != nil {
+			return "", fmt.Errorf("%w: display-message socket_path after %s", ErrTmuxTimeout, tmuxCommandTimeout)
+		}
+		return "", fmt.Errorf("failed to query socket path for session %s: %w", t.sanitizedName, err)
+	}
+	path := strings.TrimSpace(string(output))
+	if path == "" {
+		return "", fmt.Errorf("tmux reported an empty socket path for session %s", t.sanitizedName)
+	}
+	return path, nil
+}

--- a/session/tmux/socket_test.go
+++ b/session/tmux/socket_test.go
@@ -1,0 +1,75 @@
+package tmux
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+)
+
+// TestSocketPath_ReturnsTrimmedTmuxReportedPath pins that SocketPath returns
+// exactly what tmux's #{socket_path} format prints, trimmed, and that it queries
+// display-message for THIS session (exact target). This is the authoritative
+// socket the config-agent attach pins with `-S` (#2019).
+func TestSocketPath_ReturnsTrimmedTmuxReportedPath(t *testing.T) {
+	var gotArgs []string
+	mock := cmd_test.MockCmdExec{
+		OutputFunc: func(c *exec.Cmd) ([]byte, error) {
+			gotArgs = c.Args
+			return []byte("/tmp/tmux-1000/default\n"), nil
+		},
+	}
+	session := NewTmuxSessionFromSanitizedNameWithDeps("af_af-config-1", "bash", NewMockPtyFactory(t), mock)
+
+	path, err := session.SocketPath(context.Background())
+	if err != nil {
+		t.Fatalf("SocketPath: %v", err)
+	}
+	if path != "/tmp/tmux-1000/default" {
+		t.Fatalf("socket path should be tmux's #{socket_path}, trimmed; got %q", path)
+	}
+
+	joined := strings.Join(gotArgs, " ")
+	for _, want := range []string{"display-message", "#{socket_path}", "af_af-config-1"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("the socket query is missing %q; got: %s", want, joined)
+		}
+	}
+}
+
+// TestSocketPath_EmptyIsAnError pins that an empty socket_path is surfaced rather
+// than returned as a usable path: attaching with `-S ""` would be worse than the
+// default-socket fallback, which an empty return triggers on the caller side.
+func TestSocketPath_EmptyIsAnError(t *testing.T) {
+	mock := cmd_test.MockCmdExec{
+		OutputFunc: func(*exec.Cmd) ([]byte, error) { return []byte("   \n"), nil },
+	}
+	session := NewTmuxSessionFromSanitizedNameWithDeps("af_af-config-1", "bash", NewMockPtyFactory(t), mock)
+
+	if _, err := session.SocketPath(context.Background()); err == nil {
+		t.Fatal("an empty socket_path must be an error, not a usable path")
+	}
+}
+
+// TestSocketPath_TimeoutStaysReachable pins that a wedged display-message surfaces
+// as ErrTmuxTimeout, so the daemon can tell "server is slow, unknown" from a real
+// answer — the same discipline every other bounded tmux query keeps (#1917).
+func TestSocketPath_TimeoutStaysReachable(t *testing.T) {
+	shortTmuxTimeout(t, 100*time.Millisecond)
+	mock := cmd_test.MockCmdExec{
+		OutputFunc: func(*exec.Cmd) ([]byte, error) {
+			time.Sleep(2 * time.Second)
+			return nil, errors.New("wedged tmux never answered")
+		},
+	}
+	session := NewTmuxSessionFromSanitizedNameWithDeps("af_af-config-1", "bash", NewMockPtyFactory(t), mock)
+
+	_, err := session.SocketPath(context.Background())
+	if err == nil || !errors.Is(err, ErrTmuxTimeout) {
+		t.Fatalf("a wedged socket_path query must surface ErrTmuxTimeout, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem (#2019)

Pressing **`C`** (config agent) while `af` is running **inside a tmux session**
fails with `config agent: exit status 1` and drops back to nav — the takeover
never lands.

## Root cause

`enterConfigAgent` hands the terminal to the config agent's tmux session with
`tea.ExecProcess` running a raw `tmux attach-session`. When `af` was itself
launched from a tmux pane it inherits `$TMUX`, and tmux refuses to nest:

```
sessions should be nested with care, unset $TMUX to force
```

exiting 1. This is the **only** terminal handover in the TUI that shells out to
`tmux attach-session` — every other attach (`o`, panes) uses the WS raw-proxy
route, which is roster-keyed (it resolves a byte source by looking the session up
in the daemon's instance map) and therefore needs an **Instance = a session-list
row**. The config agent deliberately is *not* a row, so the WS route is not an
option; the fix stays on `tmux attach-session`.

### A second, latent bug this surfaced

While proving the fix end to end I found the attach also targets the **wrong
session name**. The daemon returned the bare sequence name `af-config-<n>`, but
the tmux session it actually created carries the `af_` prefix
(`NewTmuxSession` → `af_af-config-<n>`). `tmux attach-session -t af-config-<n>`
does not resolve `af_af-config-<n>`:

```
$ tmux has-session -t af-config-1        # session is really af_af-config-1
can't find session: af-config-1
```

Inside tmux the nesting refusal fires *before* target resolution, so it masked
this — but once `$TMUX` is scrubbed the attach would just swap one `exit status
1` for another (`can't find session`). So the fix also returns/tracks/reaps the
**resolvable** name. (No behavioral change to which socket the session is spawned
on; only the reported name.)

## Fix

1. **Scrub `$TMUX`** from the attach child's env (`app/config_agent.go`
   `configAgentAttachEnv`, mirroring `daemon/vscode_server.go`'s `vscodeChildEnv`).
   `TMUX_TMPDIR` is left in place. This is exactly what tmux's own error instructs.
2. **Pin the server socket with `-S <path>`.** After `$TMUX` is gone tmux
   resolves the session through the default socket
   `${TMUX_TMPDIR:-/tmp/tmux-<uid>}/default`, and the **daemon** (which spawned the
   session) and the **TUI** (which attaches) are different processes that can
   resolve a *different* `TMUX_TMPDIR` — an autostarted daemon may lack it while
   the user's shell sets it — so "default" could point at two different
   directories and the attach would fail to find the session. The daemon now
   reports the authoritative `#{socket_path}` (new read-only
   `TmuxSession.SocketPath`, bounded like `panePID`), threaded back through the
   control RPC, and the attach pins it. **Why defensive:** in the common case both
   sides share `TMUX_TMPDIR` and `-S` is belt-and-suspenders; it also documents
   intent. Empty socket ⇒ the attach omits `-S` and falls back to the default
   socket (Part 1 alone still fixes the reported bug).
3. **Honest error.** `handleConfigAgentDone` no longer surfaces a bare
   `config agent: exit status 1`; it routes an actionable message through the
   TUI's existing `handleError` surface (leads with the consequential half; the
   wrapped cause stays under `E details`). The reap + `config.LoadConfig()` reload
   still run on every exit.

The RPC crosses the **net/rpc gob** control socket (`callDaemon`), where
zero-value fields elide to nil (#1700), so the new `SpawnConfigAgentResponse.SocketPath`
is a **plain `string`**, never `*string` — an empty socket must transmit as `""`,
not become nil.

The takeover stays **row-free** and keeps `ExecProcess`'s built-in mode-restore
(it suspends/resumes the Program around the child), so this does **not**
reintroduce the #845 raw-proxy mode-leak that the WS route has to hand-restore.
No `session/tmux` core method (Detach/Restore/capture/send) changed — only an
additive read-only `SocketPath` query, the daemon spawn-result, and the single
attach command.

## Fail-first evidence (observed at `948c5df`)

Hermetic, genuinely-nested tmux reproduction (tmux 3.4) — the driver runs `af`
inside a real tmux pane, which is the only way to trigger the nesting refusal
(`$TMUX` set in a *non-pane* env silently attaches, so env-alone does not
reproduce it):

- **Nesting refusal (unfixed `tmux attach-session`, nested):**
  `sessions should be nested with care, unset $TMUX to force` → RC=1
- **Name mismatch (unfixed returned name):**
  `tmux has-session -t af-config-1` → `can't find session: af-config-1`
  (real session `af_af-config-1`)
- **Fixed command (`$TMUX` scrubbed + `-S <socket>` + resolvable name, nested):**
  target session shows `attached=1` (the takeover landed), 0 nesting-refusal lines.

Tests:
- **End-to-end (`make tui-driver-selftest`):** a new step presses `C` while af
  runs inside the driver's tmux pane (real af, real daemon, genuine nesting) and
  asserts the takeover lands instead of flashing `config agent: exit status 1`.
  Proven to have teeth — it fails on unfixed code and passes on the fix:
  - **unfixed production (`948c5df`):** `✗ FAILED … (#2019)` with the TUI showing
    `config agent: exit status 1` — "passed 20 step(s) before the failure".
  - **fixed:** `=== SELF-TEST PASSED — 51/51 steps green ===`.
- **Guards (unit, in `make test-container`):** `execConfigAgentAttach` scrubs
  `TMUX=` from the child env, keeps `TMUX_TMPDIR`, and pins `-S <socket>` (omits it
  when the socket is empty); `TmuxSession.SocketPath` returns tmux's trimmed
  `#{socket_path}` and keeps a wedged query reachable as `ErrTmuxTimeout`. Full
  suite green (`app`, `configagent`, `session/tmux`, `daemon`).

## Gates

`go build ./...`, `gofmt -l .`, `golangci-lint run --fast`, `deadcode -test ./...`,
`scripts/lint-file-length.sh`, `make test-container`, `make tui-driver-selftest`.
No Cobra/HTTP doc surface changed (the RPC is the internal control socket), so
`scripts/gen-docs.sh` produces no diff.

Signed-off-by: Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Captain Claude <noreply@anthropic.com>
