### PR TITLE
fix(web): guard createSessionTab's post-await pane rebind (#2000)

### DIFF
--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7563,6 +7563,12 @@ function tabToKeepOnClose(ids, closedIndex, activeIndex) {
   const keepIndex = closedIndex === activeIndex ? activeIndex - 1 : activeIndex;
   return ids[keepIndex] ?? "";
 }
+function rebindTargetAfterAwait(pinnedGen, pinnedSelId, currentGen, currentSelId, targetIdx) {
+  if (currentGen !== pinnedGen || currentSelId !== pinnedSelId || targetIdx < 0) {
+    return -1;
+  }
+  return targetIdx;
+}
 
 // src/layout.ts
 var TAB_DND_MIME = "application/x-af-tab";
@@ -11215,6 +11221,20 @@ function openTab(index) {
   splitView.setFocusedTab(index);
   focusTerminal();
 }
+function guardedTabRebind(selId, run, resolve, attach) {
+  const gen = splitView.layoutGeneration();
+  void run().then((sessions) => {
+    const targetIdx = resolve(sessions);
+    store.set({ sessions, selectedId: pickSelection(sessions, store.get().selectedId) });
+    const idx = rebindTargetAfterAwait(gen, selId, splitView.layoutGeneration(), store.get().selectedId, targetIdx);
+    if (idx >= 0) {
+      splitView.setFocusedTab(idx);
+      if (attach) {
+        focusTerminal();
+      }
+    }
+  }).catch((e) => surfaceTabError(e));
+}
 function createSessionTab(kind = "shell") {
   const sel = selectedSessionData();
   const tok = token;
@@ -11224,13 +11244,24 @@ function createSessionTab(kind = "shell") {
   clearTabError();
   const selId = sel.id ?? "";
   const create = kind === "vscode" ? createVSCodeTab : createTab;
-  void create(selId, sel.title, tok).then(() => fetchSnapshot(tok)).then((sessions) => {
-    const grown = sessions.find((s) => s.id === selId);
-    const newIdx = grown ? sessionTabs(grown).length - 1 : store.get().activeTab;
-    store.set({ sessions, selectedId: pickSelection(sessions, store.get().selectedId) });
-    splitView.setFocusedTab(newIdx);
-    focusTerminal();
-  }).catch((e) => surfaceTabError(e));
+  let createdName = "";
+  guardedTabRebind(
+    selId,
+    () => create(selId, sel.title, tok).then((name) => {
+      createdName = name;
+      return fetchSnapshot(tok);
+    }),
+    // Focus the created tab BY its resolved name, never `length - 1`: the last slot is
+    // an ordinal, and a concurrent create from another client landing inside this
+    // round trip would make it THEIR tab. Resolving the name to its current ordinal in
+    // the post-await roster is the create-side twin of closeSessionTab's keepId, and a
+    // -1 (name gone, or session vanished) bails rather than guessing (#2000).
+    (sessions) => {
+      const grown = sessions.find((s) => s.id === selId);
+      return grown ? sessionTabs(grown).findIndex((t) => t.name === createdName) : -1;
+    },
+    true
+  );
 }
 function closeSessionTab(index) {
   const sel = selectedSessionData();
@@ -11246,15 +11277,18 @@ function closeSessionTab(index) {
   clearTabError();
   const selId = sel.id ?? "";
   const keepId = tabToKeepOnClose(tabs.map(tabIdentity), index, store.get().activeTab);
-  const gen = splitView.layoutGeneration();
-  void closeTab(selId, sel.title, target.name, tabRealId(target), tok).then(() => fetchSnapshot(tok)).then((sessions) => {
-    const shrunk = sessions.find((s) => s.id === selId);
-    const next = shrunk ? sessionTabs(shrunk).map(tabIdentity).indexOf(keepId) : -1;
-    store.set({ sessions, selectedId: pickSelection(sessions, store.get().selectedId) });
-    if (next >= 0 && splitView.layoutGeneration() === gen && store.get().selectedId === selId) {
-      splitView.setFocusedTab(next);
-    }
-  }).catch((e) => surfaceTabError(e));
+  guardedTabRebind(
+    selId,
+    () => closeTab(selId, sel.title, target.name, tabRealId(target), tok).then(() => fetchSnapshot(tok)),
+    // Resolve the kept tab's CURRENT ordinal in the post-close roster; -1 (a concurrent
+    // close took it too) leaves the pane where syncSplit's identity remap already
+    // settled it rather than guessing again.
+    (sessions) => {
+      const shrunk = sessions.find((s) => s.id === selId);
+      return shrunk ? sessionTabs(shrunk).map(tabIdentity).indexOf(keepId) : -1;
+    },
+    false
+  );
 }
 function renameSessionTab(id, name, editedSessionId) {
   const sel = selectedSessionData();

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "42526cc823ca";
+const VERSION = "954e3de2d70c";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -48,7 +48,14 @@ import { InstallAffordance } from "./install.js";
 import { decideKey, type KeyboardFocus, type View } from "./nav.js";
 import { defaultFilter, filterSessions, loadFilter, persistFilter, withKind } from "./filter.js";
 import { loadProjectChoice, persistProjectChoice, pickerProjects, reconcileProject, scopeToProject } from "./project.js";
-import { applyEvent, clampActiveTab, pickSelection, tabToKeepOnClose, upsertSession } from "./sessions.js";
+import {
+  applyEvent,
+  clampActiveTab,
+  pickSelection,
+  rebindTargetAfterAwait,
+  tabToKeepOnClose,
+  upsertSession,
+} from "./sessions.js";
 import { SplitView } from "./split.js";
 import { isArchived, type RowKind } from "./status.js";
 import { isRenameableTab } from "./tablabel.js";
@@ -677,14 +684,58 @@ function openTab(index: number): void {
   focusTerminal();
 }
 
+/** Runs a tab mutation whose post-await step re-points the FOCUSED pane, applying the
+ *  two guards every such rebind needs so a new async gesture can't forget them
+ *  (#2000). Both create and close await a round trip and then point the focused pane
+ *  at a tab resolved against the roster they mutated — but splitView.trees is
+ *  per-session and setFocusedTab carries no session of its own, so re-pointing from an
+ *  intent formed BEFORE the await would yank the pane once the user has since selected
+ *  another session or focused another pane (the #1815 hazard closeSessionTab first
+ *  named, which createSessionTab shipped without).
+ *
+ *  `run` issues the RPC and resolves to the refreshed roster; `resolve` names the tab
+ *  the pane should end on in that post-await roster BY IDENTITY, returning -1 when it's
+ *  gone (never an ordinal snapshotted before the await, which names a tab only relative
+ *  to one roster). The roster is committed unconditionally so the grown/shrunk tab list
+ *  always lands; only the pane rebind is gated, by sessions.rebindTargetAfterAwait —
+ *  the one place the guard lives, so both call sites (and the next) stay in step.
+ *  `attach` attaches the focused terminal after (a create/open, mirroring the TUI's
+ *  `t`), or leaves the keyboard where it is (a close). Errors (e.g. a remote session,
+ *  or the tab cap) surface on the pane header's status line. */
+function guardedTabRebind(
+  selId: string,
+  run: () => Promise<SessionData[]>,
+  resolve: (sessions: SessionData[]) => number,
+  attach: boolean,
+): void {
+  // Pinned BEFORE the RPC is issued, exactly where closeSessionTab captured `gen`.
+  const gen = splitView.layoutGeneration();
+  void run()
+    .then((sessions) => {
+      const targetIdx = resolve(sessions);
+      // Commit the roster first (rerender → syncSplit re-validates the tree against the
+      // new tabCount), then re-point the focused pane only if the pinned intent still
+      // holds. selectedId is read AFTER the set so it reflects any session switch the
+      // user made during the await (pickSelection keeps their newer choice).
+      store.set({ sessions, selectedId: pickSelection(sessions, store.get().selectedId) });
+      const idx = rebindTargetAfterAwait(gen, selId, splitView.layoutGeneration(), store.get().selectedId, targetIdx);
+      if (idx >= 0) {
+        splitView.setFocusedTab(idx);
+        if (attach) {
+          focusTerminal();
+        }
+      }
+    })
+    .catch((e) => surfaceTabError(e));
+}
+
 /** Creates a $SHELL tab on the selected session (the `t` key / + button), then
  *  resyncs to pull the grown tab list, selects the new tab, and attaches it —
  *  mirroring the TUI's `t`, which opens the fresh tab as a pane. The resync is
  *  kept for THIS window's own mutation because it must select+attach the new tab
  *  synchronously, which needs the tab in hand rather than an event later; a tab
  *  changed by any OTHER actor now arrives on its own, since CreateTab/CloseTab
- *  publish session.updated with the refreshed roster (#1812). Errors (e.g. a
- *  remote session, or the tab cap) surface on the pane header's status line. */
+ *  publish session.updated with the refreshed roster (#1812). */
 function createSessionTab(kind: NewTabKind = "shell"): void {
   const sel = selectedSessionData();
   const tok = token;
@@ -696,19 +747,27 @@ function createSessionTab(kind: NewTabKind = "shell"): void {
   clearTabError();
   const selId = sel.id ?? "";
   const create = kind === "vscode" ? createVSCodeTab : createTab;
-  void create(selId, sel.title, tok)
-    .then(() => fetchSnapshot(tok))
-    .then((sessions) => {
+  // createTab returns the daemon's resolved, collision-suffixed name; hold it so the
+  // rebind lands on the tab THIS create made.
+  let createdName = "";
+  guardedTabRebind(
+    selId,
+    () =>
+      create(selId, sel.title, tok).then((name) => {
+        createdName = name;
+        return fetchSnapshot(tok);
+      }),
+    // Focus the created tab BY its resolved name, never `length - 1`: the last slot is
+    // an ordinal, and a concurrent create from another client landing inside this
+    // round trip would make it THEIR tab. Resolving the name to its current ordinal in
+    // the post-await roster is the create-side twin of closeSessionTab's keepId, and a
+    // -1 (name gone, or session vanished) bails rather than guessing (#2000).
+    (sessions) => {
       const grown = sessions.find((s) => s.id === selId);
-      const newIdx = grown ? sessionTabs(grown).length - 1 : store.get().activeTab;
-      // Commit the grown tab list first (rerender → syncSplit sees the new tabCount),
-      // then point the focused pane at the fresh tab and attach it — mirroring the
-      // TUI's `t`, which opens the new tab as the active pane.
-      store.set({ sessions, selectedId: pickSelection(sessions, store.get().selectedId) });
-      splitView.setFocusedTab(newIdx);
-      focusTerminal();
-    })
-    .catch((e) => surfaceTabError(e));
+      return grown ? sessionTabs(grown).findIndex((t) => t.name === createdName) : -1;
+    },
+    true,
+  );
 }
 
 /** Closes the tab at `index` of the selected session (the `w` key / × button),
@@ -747,34 +806,28 @@ function closeSessionTab(index: number): void {
   // the layout tree, applied to the store's index. See sessions.tabToKeepOnClose, which
   // holds the decision as a pure function so both directions above are unit-tested.
   const keepId = tabToKeepOnClose(tabs.map(tabIdentity), index, store.get().activeTab);
-  // Pin what the rebind assumes: this session, and no explicit layout/focus mutation
-  // since. A slow close leaves a wide window in which the user can select another tab
-  // or focus another pane, and re-pointing from an intent formed before that would
-  // yank it back (the same stale-async hazard the #1777 scroll-fill token guards).
-  const gen = splitView.layoutGeneration();
   // tabRealId, NOT tabIdentity: this crosses the wire, so it must be an id the DAEMON
   // can resolve — never the synthesized kind:name tabIdentity falls back to for a
   // pre-#1738 record (see renameSessionTab). The keepId above is the opposite case,
   // local bookkeeping, which is why the two helpers appear within a few lines of each
   // other here and are not interchangeable.
-  void closeTab(selId, sel.title, target.name, tabRealId(target), tok)
-    .then(() => fetchSnapshot(tok))
-    .then((sessions) => {
-      // Resolve the kept tab's CURRENT ordinal in the post-close roster.
+  //
+  // The post-await rebind — and its layoutGeneration + selectedId guard, once
+  // spelled out here and the source of the #1815 finding — now lives in
+  // guardedTabRebind, which createSessionTab shares so neither can forget it (#2000).
+  // A close only re-points the focused pane; it does not attach (attach = false).
+  guardedTabRebind(
+    selId,
+    () => closeTab(selId, sel.title, target.name, tabRealId(target), tok).then(() => fetchSnapshot(tok)),
+    // Resolve the kept tab's CURRENT ordinal in the post-close roster; -1 (a concurrent
+    // close took it too) leaves the pane where syncSplit's identity remap already
+    // settled it rather than guessing again.
+    (sessions) => {
       const shrunk = sessions.find((s) => s.id === selId);
-      const next = shrunk ? sessionTabs(shrunk).map(tabIdentity).indexOf(keepId) : -1;
-      // Commit the shrunk tab list first (rerender → syncSplit re-validates the tree,
-      // clamping any pane past the new end), then re-point the focused pane — but only
-      // if the rebind still describes anything real: the user must not have moved focus
-      // or switched away while the close was in flight, and the kept tab must still
-      // exist (a concurrent close can take it too, in which case syncSplit's remap has
-      // already settled the pane somewhere sane and guessing again would only misroute).
-      store.set({ sessions, selectedId: pickSelection(sessions, store.get().selectedId) });
-      if (next >= 0 && splitView.layoutGeneration() === gen && store.get().selectedId === selId) {
-        splitView.setFocusedTab(next);
-      }
-    })
-    .catch((e) => surfaceTabError(e));
+      return shrunk ? sessionTabs(shrunk).map(tabIdentity).indexOf(keepId) : -1;
+    },
+    false,
+  );
 }
 
 /**

--- a/web/src/sessions.test.ts
+++ b/web/src/sessions.test.ts
@@ -12,6 +12,7 @@ import {
   applyEvent,
   clampActiveTab,
   pickSelection,
+  rebindTargetAfterAwait,
   removeSession,
   sessionKey,
   tabToKeepOnClose,
@@ -230,4 +231,44 @@ test("an out-of-range active index yields no tab to follow", () => {
   // Identities are never empty (ui.tabIdentity synthesizes a kind:name fallback), so
   // "" can't accidentally match a real tab when the caller resolves it.
   assert.equal(["id-agent", "id-a"].indexOf(""), -1);
+});
+
+// --- rebindTargetAfterAwait: the shared guard on a post-await pane rebind ----
+//
+// Both createSessionTab and closeSessionTab await a round trip and then re-point the
+// focused pane. splitView.trees is per-session and setFocusedTab carries no session of
+// its own, so a target resolved before the await must NOT be applied if the user
+// formed a newer intent DURING it — switching sessions (selectedId moves) or focusing
+// another pane / changing the layout (layoutGeneration bumps). closeSessionTab pinned
+// exactly this since #1815; createSessionTab shipped with neither guard (#2000). These
+// pin the shared decision both now route through, so a third async rebind can't forget
+// it.
+
+test("rebind proceeds to the resolved tab when neither generation nor selection moved", () => {
+  assert.equal(rebindTargetAfterAwait(5, "sess-a", 5, "sess-a", 3), 3);
+});
+
+test("rebind BAILS when the user switched sessions during the await (#2000)", () => {
+  // The + round trip spawns a tmux window / code-server, so the await is real. If the
+  // user selects another session meanwhile, an ordinal resolved against the OLD
+  // session's roster must not be applied to the NEW session's per-session tree — the
+  // #1815 finding, in the one place (create) its guard was never applied.
+  assert.equal(rebindTargetAfterAwait(5, "sess-a", 5, "sess-b", 3), -1);
+});
+
+test("rebind BAILS when the layout generation moved — the user focused another pane (#1815)", () => {
+  // A slow round trip leaves a wide window in which the user can focus another pane or
+  // split the layout; re-pointing from an intent formed before that yanks it back.
+  assert.equal(rebindTargetAfterAwait(5, "sess-a", 6, "sess-a", 3), -1);
+});
+
+test("rebind BAILS when the resolved target no longer exists (idx < 0)", () => {
+  // The created/kept tab was closed by another client during the await, or the session
+  // vanished: -1 is the honest "leave the pane where syncSplit already settled it",
+  // never a guess. Mirrors closeSessionTab's `next >= 0` and tabToKeepOnClose's -1.
+  assert.equal(rebindTargetAfterAwait(5, "sess-a", 5, "sess-a", -1), -1);
+});
+
+test("a null current selection (session killed mid-flight) bails against any pinned id", () => {
+  assert.equal(rebindTargetAfterAwait(5, "sess-a", 5, null, 3), -1);
 });

--- a/web/src/sessions.ts
+++ b/web/src/sessions.ts
@@ -176,7 +176,8 @@ export function rebindTargetAfterAwait(
   currentSelId: string | null,
   targetIdx: number,
 ): number {
-  // FAIL-FIRST STUB (#2000): models the shipped createSessionTab, which re-points the
-  // pane unconditionally with neither guard. The guarded body lands in the next commit.
+  if (currentGen !== pinnedGen || currentSelId !== pinnedSelId || targetIdx < 0) {
+    return -1;
+  }
   return targetIdx;
 }

--- a/web/src/sessions.ts
+++ b/web/src/sessions.ts
@@ -148,3 +148,35 @@ export function tabToKeepOnClose(ids: string[], closedIndex: number, activeIndex
   const keepIndex = closedIndex === activeIndex ? activeIndex - 1 : activeIndex;
   return ids[keepIndex] ?? "";
 }
+
+/** The tab ordinal a post-await pane rebind should land on, or -1 to leave the pane
+ *  where it is. The store-side twin of the layout guard, and the shared decision
+ *  createSessionTab and closeSessionTab both route through (#2000).
+ *
+ *  Both verbs await a round trip and then re-point the FOCUSED pane. splitView.trees
+ *  is per-session and setFocusedTab carries no session of its own, so a `targetIdx`
+ *  resolved against the roster the verb mutated must not be applied once the user has
+ *  formed a NEWER intent during the await:
+ *
+ *   - selection guard: the user selected another session (`currentSelId` moved off the
+ *     pinned `pinnedSelId`), so the ordinal names a tab in a session that is no longer
+ *     on screen — applying it re-points and attaches the wrong session's pane. This is
+ *     the #1815 finding, in the one place (create) its guard was never applied.
+ *   - generation guard: the user focused another pane or changed the layout, bumping
+ *     `layoutGeneration`; re-pointing from an intent formed before that yanks it back.
+ *
+ *  `targetIdx < 0` is the honest "the tab is gone" — the created/kept tab was closed
+ *  out-of-band during the await, or its session vanished — and -1 flows straight
+ *  through as "leave the pane where syncSplit's identity remap already settled it",
+ *  never a guess. Mirrors closeSessionTab's `next >= 0` and tabToKeepOnClose's -1. */
+export function rebindTargetAfterAwait(
+  pinnedGen: number,
+  pinnedSelId: string,
+  currentGen: number,
+  currentSelId: string | null,
+  targetIdx: number,
+): number {
+  // FAIL-FIRST STUB (#2000): models the shipped createSessionTab, which re-points the
+  // pane unconditionally with neither guard. The guarded body lands in the next commit.
+  return targetIdx;
+}


### PR DESCRIPTION
Closes #2000.

## The bug

`web/src/index.ts` `createSessionTab` awaited the `+`/`t` create round trip and then
called `splitView.setFocusedTab(...)` + `focusTerminal()` with **neither** guard its
sibling `closeSessionTab` has carried since the #1815 finding — no `layoutGeneration`
guard, no `selectedId` guard — and computed its target as `sessionTabs(grown).length - 1`,
throwing away the resolved name `createTab` returns.

`splitView.trees` is per-session and `setFocusedTab` has no session of its own, so:

1. **Switch session while `+` is in flight** → an ordinal resolved against the OLD
   session's roster is applied to the NEW session's tree: the wrong session's pane is
   re-pointed and attached. The round trip spawns a tmux window / code-server, so the
   window is real. This is the #1815 finding in the one place its guard was never applied.
2. **`length - 1` is an ordinal** → a concurrent create from another client lands inside
   the round trip and it's *their* tab that gets focused and attached.

## The fix

Sachin's issue comment was explicit: *don't hand-copy `closeSessionTab`'s guard* — two
sites each remembering to pin generation+selection across an await is the
habit-not-invariant pattern that produced this gap. So both verbs now route through a
single wrapper:

- **`guardedTabRebind(selId, run, resolve, attach)`** (index.ts) — pins
  `layoutGeneration()` before the RPC, awaits, commits the roster unconditionally, and
  re-points the focused pane **only** if the pinned intent still holds. `createSessionTab`
  and `closeSessionTab` both call it, so a third async rebind can't forget the guard.
- **`rebindTargetAfterAwait(...)`** (sessions.ts) — the pure guard decision, extracted to
  the same DOM-free module as `tabToKeepOnClose` and unit-tested the same way (the
  `closeSessionTab` comment already says such decisions live there "as a pure function so
  both directions are unit-tested"). This is the only place the guard logic lives.
- `createSessionTab` now focuses the tab **this** create made, resolving `createTab`'s
  returned name to its current ordinal in the post-await roster (the create-side twin of
  close's `keepId`), never `length - 1`. A `-1` (name gone / session vanished) bails
  rather than guessing — strictly safer than the old `store.get().activeTab` fallback,
  which would attach a pane in a vanished/other session.

Behavior for `closeSessionTab` is unchanged: the wrapper preserves the exact ordering
(resolve target → `store.set` → guard-read of `selectedId`).

**Scope note:** the fix is in `web/src/index.ts` per the issue, plus one pure export in
`web/src/sessions.ts` (its testable home — index.ts has top-level `document`/`mount()`
side effects and can't be imported by the node test runner) and its test in
`web/src/sessions.test.ts`. `web/dist` regenerated via `make web-build` (never hand-edited).

## Fail-first evidence

Commit `7c4dadc` lands `rebindTargetAfterAwait` as an **unguarded stub** that faithfully
models the shipped `createSessionTab` (rebinds unconditionally), with the guard tests.
Run at that commit — 3 fail, reproducing the symptom (bail expected, yank observed):

```
not ok 23 - rebind BAILS when the user switched sessions during the await (#2000)
  expected: -1   actual: 3
not ok 24 - rebind BAILS when the layout generation moved — the user focused another pane (#1815)
  expected: -1   actual: 3
not ok 26 - a null current selection (session killed mid-flight) bails against any pinned id
  expected: -1   actual: 3
```

Commit `6a66610` adds the guard body → all 26 sessions tests (322 web tests total) pass.

A full Playwright selftest was impractical here — reproducing a *slow* create with a
mid-await session switch needs intercepting/delaying the CreateTab REST call — so per the
issue this is a unit test around the guarded rebind logic (the sanctioned fallback).

## Adjacent-site audit

Sachin asked to check for other awaiting rebinds in the file. Every post-await
`setFocusedTab` / pane re-point in `index.ts`:

| function | awaits? | re-points a pane post-await? | status |
|---|---|---|---|
| `createSessionTab` | yes | yes (`setFocusedTab` + attach) | **was unguarded — fixed** |
| `closeSessionTab` | yes | yes (`setFocusedTab`) | guarded since #1815 — now shares the wrapper |
| `renameSessionTab` | yes | **no** (only `store.set`) | correctly needs no guard |
| `reorderSessionTab` | yes | **no** (documented: panes follow identities via `remapByIdentity`) | correctly needs no guard |
| `switchTab` / `openTab` | no (synchronous) | — | n/a |

Considered and **excluded**: the session-create modal `onSubmit` (`createSession(...).then`)
sets `selectedId: created.id, activeTab: 0` after its await, but that's a *different
gesture* — it deliberately switches selection to the just-created session (the whole
point of "create session"), touches no per-session `splitView.setFocusedTab`, and carries
its own `activeTab: 0` reset. It is not the #1815/#2000 "re-point a pane by a pre-await
ordinal" class. The `onResync` path (`fetchSnapshot().then(applySessions)`) is projection
reconciliation, already identity-based via `settledTab`/`clampActiveTab`, not a gesture
rebind.

So exactly two functions did a post-await pane rebind; both now go through
`guardedTabRebind`.

## Gate note

Per the issue, the codex review tier is exhausted (~until Jul 22), so this lands on its
own fail-first tests + diff-read and **stays in draft** until a real gate is back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
