### PR TITLE
fix(ui): render non-agent tab preview body when the capture is taller than the pane (#1958)

### DIFF
--- a/ui/preview_narrow_test.go
+++ b/ui/preview_narrow_test.go
@@ -1,0 +1,111 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	xansi "github.com/charmbracelet/x/ansi"
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/ui/layout"
+)
+
+// previewBodyLines returns the pane body rows of a rendered TabbedWindow: the
+// lines between the frame's top border + header row and its bottom border, with
+// the vertical frame characters and ANSI stripped. It is the "what the user sees
+// in the preview body" projection the #1958 assertions check.
+func previewBodyLines(rendered string) []string {
+	all := strings.Split(rendered, "\n")
+	if len(all) < 4 {
+		return nil
+	}
+	// Row 0 is the top border, row 1 is the header, the last row is the bottom
+	// border. Everything in between is the body.
+	body := all[2 : len(all)-1]
+	out := make([]string, 0, len(body))
+	for _, line := range body {
+		stripped := xansi.Strip(line)
+		// Drop the frame border columns (│ … │) and surrounding whitespace so the
+		// test sees only the pane content.
+		stripped = strings.Trim(stripped, "│ ")
+		out = append(out, stripped)
+	}
+	return out
+}
+
+func previewBodyHasContent(rendered string) bool {
+	for _, line := range previewBodyLines(rendered) {
+		if strings.TrimSpace(line) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// TestPreviewBodyNonEmptyWhenCaptureTallerThanPane is the #1958 regression: a
+// non-agent tab's transient preview renders the daemon capture of that tab's
+// tmux session. capture-pane returns the session's FULL screen height — the
+// visible content (a shell prompt at the top) followed by blank padding rows it
+// does NOT strip. When that captured session is TALLER than the preview pane —
+// the common case, since a non-streamed tab's window keeps whatever taller size
+// a prior stream pinned it to — the keep-newest truncation in TabPane.String()
+// kept the trailing blank rows and dropped the real content off the top, so the
+// body rendered EMPTY while the header stayed correct.
+//
+// The reporter measured this against terminal WIDTH (blank at 80x24 / 90x24,
+// content at 100x30), but the driver is HEIGHT: only the 100x30 case gave the
+// pane enough inner rows to keep the top content. The pane's inner height at a
+// 24-row terminal is below the 25-row capture; at 30 rows it clears it. The body
+// must show the content (top-aligned, possibly truncated) at every size, never
+// go blank.
+func TestPreviewBodyNonEmptyWhenCaptureTallerThanPane(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	// A shell-tab capture: the prompt on the first row, then blank padding rows
+	// out to the (taller-than-the-pane) session height — exactly what
+	// `tmux capture-pane -p` returns for an idle shell whose window is 25 rows.
+	const marker = "PROMPT_TOP_MARKER$"
+	capture := marker + strings.Repeat("\n", 24)
+
+	cases := []struct {
+		name string
+		w, h int
+	}{
+		// The two sizes the reporter saw blank on current code (terminal height 24
+		// → pane inner height ~21, below the 25-row capture).
+		{"80x24", 80, 24},
+		{"90x24", 90, 24},
+		// The control: a 30-row terminal gives the pane enough rows to keep the top.
+		{"100x30", 100, 30},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			inst := startedWindowInstance(t, "alpha")
+			w := newTestTabbedWindow()
+			setWindowInstance(w, inst)
+			w.SetRect(layout.Rect{W: tc.w, H: tc.h})
+			// Enter the transient preview binding for the shell tab (index 1) so the
+			// header renders "PREVIEW …" exactly as the reported repro does.
+			w.SetPreview(inst, 1, "alpha · shell")
+			// Publish the shell capture as the pane's content, as the daemon-backed
+			// capture would on a refresh.
+			w.tab.content = tabContentState{fallback: false, text: capture}
+
+			rendered := w.View()
+
+			require := func(cond bool, msg string) {
+				t.Helper()
+				if !cond {
+					t.Errorf("%s\n--- rendered %dx%d ---\n%s", msg, tc.w, tc.h, rendered)
+				}
+			}
+			// The header must always be correct — the bug never touched it.
+			require(strings.Contains(rendered, "PREVIEW"), "preview header must render")
+			require(previewBodyHasContent(rendered),
+				"preview body must not be empty when the capture is taller than the pane")
+			require(strings.Contains(xansi.Strip(rendered), marker),
+				"the captured content (the prompt) must be visible in the body")
+		})
+	}
+}

--- a/ui/tab_pane.go
+++ b/ui/tab_pane.go
@@ -591,11 +591,23 @@ func (p *TabPane) String() string {
 	}
 
 	lines := strings.Split(p.content.text, "\n")
-	// strings.Split produces a trailing empty element when text ends in "\n"
-	// (common for capture-pane output). Drop it so the off-by-one does not
-	// trigger truncation when content actually fits, and so the truncate branch
-	// keeps the right slice of lines (#649/#898).
-	if len(lines) > 0 && lines[len(lines)-1] == "" {
+	// Drop ALL trailing blank lines before the keep-newest truncation below. A
+	// shell/process tab is captured with `tmux capture-pane`, which returns the
+	// session's FULL screen height: the visible content (e.g. a prompt at the top)
+	// followed by blank rows padding out to the window height, which it does NOT
+	// strip. When that captured window is taller than the preview pane — the common
+	// case, since a non-streamed tab keeps whatever taller size a prior stream pinned
+	// its window to — keeping only the newest p.height lines dropped the real content
+	// off the top and left the body rendering the trailing blanks, i.e. empty
+	// (#1958). Stripping them first makes the truncation act on real content only:
+	// genuine overflow (an agent that scrolled past the pane) has content on every
+	// row and is unaffected, while a short capture padded with blanks renders
+	// top-aligned — matching what the live pane shows for the same tab. This subsumes
+	// the earlier single-trailing-"\n" strip (the empty element strings.Split leaves
+	// when text ends in "\n" — #649/#898). A row is blank when it has no printable
+	// content: lipgloss.Width is ANSI-aware (a trailing style reset is zero-width) and
+	// TrimRight handles capture's trailing-space padding.
+	for len(lines) > 0 && lipgloss.Width(strings.TrimRight(lines[len(lines)-1], " ")) == 0 {
 		lines = lines[:len(lines)-1]
 	}
 


### PR DESCRIPTION
Fixes #1958.

## Symptom

A non-agent tab's transient **preview** body renders blank at ~≤90 cols (header correct, body empty indefinitely), reversibly width-tracking. Opening the same tab as a real pane (`s`) shows content fine.

## Root cause — it's HEIGHT, not width

A previewing pane renders the daemon `capture-pane` of the target tab's tmux session. `capture-pane` returns the session's **full screen height**: the visible content (a shell prompt on the top row) followed by blank rows padding out to the window height, which it does **not** strip. `TabPane.String()` kept only the **newest** `p.height` lines (the #649 keep-newest, correct for a scrolling agent). So when the captured window is **taller than the preview pane** — the common case, since a non-streamed tab keeps whatever taller size a prior stream pinned its window to — the keep-newest slice kept the trailing **blank** rows and dropped the real content off the top → empty body, header untouched.

The reporter measured this against **width** because their sizes coupled the two axes (80x24, 90x24 both height-24; the one "content" case, 100x30, is the only tall one). The real driver is the pane's inner **height** vs the captured session height.

## Fail-first evidence

`ui/preview_narrow_test.go` renders the preview body at the reporter's exact sizes with a shell-style capture (prompt + blank padding to 25 rows).

On `9e7bcaa` (origin/master HEAD):
```
--- FAIL: .../80x24   (blank body)
--- FAIL: .../90x24   (blank body)
--- PASS: .../100x30  (control — 30 rows clears the 25-row capture)
```
— i.e. the reported table exactly. After the fix: all three pass.

**Verified in the playtest container (real daemon + tmux):** with the tab's tmux window pinned to 25 rows, the preview body was blank at 80x24 / 90x24 and filled at 100x30 (the reported table); after rebuilding `af` with the fix, the prompt **and** real terminal output render at every size, reversibly.

## Fix

`ui/tab_pane.go` — strip **all** trailing blank rows before the keep-newest truncation (was: a single trailing `\n`). Genuine overflow (content on every row) is untouched, so the #649 keep-newest still shows the newest lines; a short capture padded with blanks now renders top-aligned, matching what the live pane shows for the same tab. Blank-detection is ANSI-aware (`lipgloss.Width` treats a trailing style reset as zero-width) and tolerates trailing-space padding.

## Adjacent-site audit

- Grepped every keep-newest / capture-render site. The **only** keep-newest-of-capture is this one (`TabPane.String()` normal branch). `ui/sidebar_render.go` and `ui/layout/fit.go` keep the **first** lines (not newest) and aren't capture content.
- **Scroll-mode branch** (`viewport` + `GotoBottom`) intentionally left as-is: it's a distinct, user-initiated path whose semantics are "show newest, scroll up for history"; it always shows the `ESC to exit scroll mode` footer (never a fully-empty pane) and the content is reachable by scrolling. Touching its `GotoBottom` offset math wants its own test and is out of this bug's scope.
- Existing keep-newest regression `TestPreviewBottomTruncateShowsNewestLines` (#649) still passes.

## Testing

- `go build ./...`, `gofmt -l`, `golangci-lint run --fast`, `deadcode -test ./ui/...` — clean.
- `go test ./ui/...` and host-safe app pane/preview tests — green.

> Visible TUI change — needs the play-test gate before merge.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)