### PR TITLE
fix(daemon): manual restore must not reset the lost-restore backoff (#1976)

### DIFF
--- a/daemon/lostrestore.go
+++ b/daemon/lostrestore.go
@@ -369,18 +369,39 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 	// is exactly the kind of statement the rule above keeps out of that window.
 	m.persistInstance(repoID, inst)
 	log.InfoLog.Printf("restored lost session %q (repo %s): agent re-spawned in its workspace", inst.Title, repoID)
-	// The spawn succeeded — but that is NOT recovery (#1910). Recover returns once
-	// tmux accepted the new session, which an agent that exits on startup also
-	// satisfies. So arm the confirmation window instead of clearing the retry
-	// state here: RestoreLostSessions clears it once the runtime has stayed
-	// non-Lost past confirmBy, and this function counts it as a failure if the row
-	// goes Lost first. consecutiveFailures is deliberately CARRIED (not reset) —
-	// resetting on an unconfirmed spawn is precisely the bug: it is what let a
-	// session that never stays up look like a first-time loss on every poll.
+	// The spawn succeeded — but that is NOT recovery (#1910). Arm the confirmation
+	// window rather than clearing the retry state; see armRestoreConfirmation.
+	m.armRestoreConfirmation(key, repoID, inst)
+}
+
+// armRestoreConfirmation marks a session whose recovery spawn just RETURNED SUCCESS
+// as awaiting the liveness observation that will confirm it — the shared mechanism
+// both the automatic loop (restoreLostSession) and the manual RPC
+// (restoreLostOrDeadSession) use so they cannot drift. It exists because they DID
+// drift: the auto path was fixed to arm this window (#1910), while the manual path
+// kept clearing the state on spawn-success alone (#1976).
+//
+// A spawn returning proves only that tmux accepted the new session, which an agent
+// that exits on startup also satisfies. So the retry state is RETAINED, not cleared,
+// and consecutiveFailures is deliberately CARRIED: RestoreLostSessions clears it
+// once a poll has OBSERVED the runtime alive (aliveObservations moving past
+// observedAtSpawn), and restoreLostSession charges an immediate re-loss against this
+// same episode so the #1108 backoff escalates. Clearing here on spawn success is
+// precisely the bug on both paths — it is what let a session that never stays up
+// look like a first-time loss on every poll.
+//
+// The entry is created if absent: the manual path may run with no prior automatic
+// attempts on record. Takes m.mu itself; the caller must not already hold it.
+func (m *Manager) armRestoreConfirmation(key, repoID string, inst *session.Instance) {
 	m.mu.Lock()
+	defer m.mu.Unlock()
+	st := m.lostRestoreStates[key]
+	if st == nil {
+		st = &lostRestoreState{}
+		m.lostRestoreStates[key] = st
+	}
 	st.awaitingConfirm = true
 	st.observedAtSpawn = m.aliveObservations[remoteLossKey(repoID, inst)]
-	m.mu.Unlock()
 }
 
 // observedAliveSinceSpawnLocked reports whether a poll has gotten an ANSWER out of

--- a/daemon/lostrestore_test.go
+++ b/daemon/lostrestore_test.go
@@ -134,11 +134,35 @@ func TestRestoreSession_RecoversLostInstanceOnDemand(t *testing.T) {
 	if got := inst.GetStatus(); got != session.Running {
 		t.Fatalf("status = %v, want Running after manual restore", got)
 	}
+	// A successful spawn is NOT confirmation (#1910/#1976): the retry state must be
+	// RETAINED, awaiting a liveness observation, with the prior failure history
+	// carried — not cleared the instant tmux accepts the session. Clearing here is
+	// what let a manual restore of a flapping session reset the backoff and re-open
+	// the hot-loop the automatic path prevents.
+	manager.mu.Lock()
+	st := manager.lostRestoreStates[key]
+	manager.mu.Unlock()
+	if st == nil {
+		t.Fatal("manual restore dropped the retry state on spawn success: an agent that dies " +
+			"before confirmation then re-enters as a fresh episode with a zeroed backoff (#1976)")
+	}
+	if !st.awaitingConfirm {
+		t.Fatal("a successful manual restore must arm the confirmation window")
+	}
+	if st.consecutiveFailures != 3 {
+		t.Fatalf("consecutiveFailures = %d, want 3 carried: manual restore must not reset the "+
+			"backoff history (#1976)", st.consecutiveFailures)
+	}
+
+	// A poll then ANSWERS: the runtime is confirmed alive, and only now is the
+	// episode forgotten.
+	observeAlive(manager, repoID, inst)
+	manager.RestoreLostSessions()
 	manager.mu.Lock()
 	_, hasState := manager.lostRestoreStates[key]
 	manager.mu.Unlock()
 	if hasState {
-		t.Fatal("manual restore must drop Lost retry state")
+		t.Fatal("a confirmed-alive manual restore must drop the retry state")
 	}
 }
 

--- a/daemon/manual_restore_backoff_test.go
+++ b/daemon/manual_restore_backoff_test.go
@@ -1,0 +1,121 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// The #1976 regression lock: the MANUAL restore path (RestoreSession — the
+// `af sessions restore` RPC and the TUI's restore action) must NOT reset the
+// #1108 exponential backoff on Recover()-success alone.
+//
+// That was the exact pre-#1910 anti-pattern the automatic loop was fixed to avoid
+// (#1923): a spawn returning proves only that tmux accepted the new session, which
+// an agent that exits on startup also satisfies. The auto path now arms a
+// confirmation window instead of clearing the state; the manual path still ran an
+// unconditional delete(lostRestoreStates[key]) after Recover, so a user (or an
+// autoyes flow) restoring a flapping session re-opened the very hot-loop the auto
+// path prevents. This pins the manual path to the same confirm-alive gate.
+
+// TestRestoreSession_ImmediateReLossAfterManualRestore_EscalatesNotResets drives
+// the field shape end to end: Recover returns nil (the tmux spawn genuinely works)
+// but the agent exits before the next poll, so the row is Lost again. The
+// accumulated failure history must survive the manual restore, and the immediate
+// re-loss must escalate against the same episode rather than respawning at poll
+// cadence into an agent that will not stay up.
+func TestRestoreSession_ImmediateReLossAfterManualRestore_EscalatesNotResets(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &diesOnSpawnBackend{FakeBackend: session.NewFakeBackend()}
+	registerStarted(t, manager, repoID, repoPath, "flapper", backend, true, session.Lost)
+
+	// The automatic loop has already tried and failed three times: a real backoff
+	// episode is in progress when the user reaches for manual restore.
+	key := daemonInstanceKey(repoID, "flapper")
+	manager.mu.Lock()
+	manager.lostRestoreStates[key] = &lostRestoreState{consecutiveFailures: 3}
+	manager.mu.Unlock()
+
+	// The user restores by hand. The spawn succeeds (Recover returns nil) but the
+	// agent immediately exits, so the row is Lost again by the time the poll looks.
+	if _, err := manager.RestoreSession(RestoreSessionRequest{Title: "flapper", RepoID: repoID}); err != nil {
+		t.Fatalf("RestoreSession: %v", err)
+	}
+	if got := backend.recoverCount(); got != 1 {
+		t.Fatalf("manual restore must spawn exactly once, got %d", got)
+	}
+
+	// One automatic poll. It finds the row Lost again inside the confirmation
+	// window, so it must charge the death against the SAME episode — never respawn.
+	manager.RestoreLostSessions()
+
+	if got := backend.recoverCount(); got != 1 {
+		t.Fatalf("the poll RESPAWNED after a manual restore whose runtime died before "+
+			"confirmation (%d total spawns): the manual path cleared the backoff state, so the "+
+			"immediate re-loss looked like a fresh episode and hot-looped at poll cadence (#1976)", got)
+	}
+	manager.mu.Lock()
+	st := manager.lostRestoreStates[key]
+	failures := -1
+	if st != nil {
+		failures = st.consecutiveFailures
+	}
+	manager.mu.Unlock()
+	if st == nil {
+		t.Fatal("retry state was dropped by the manual restore; the immediate re-loss had no " +
+			"episode to escalate against, so the #1108 backoff never arms (#1976)")
+	}
+	if failures != 4 {
+		t.Fatalf("consecutiveFailures = %d, want 4: the manual restore must CARRY the 3 prior "+
+			"failures and the immediate re-loss must add one, so the backoff escalates instead of "+
+			"restarting from zero (#1976)", failures)
+	}
+}
+
+// TestRestoreSession_LongLivedThenDied_ResetsBackoff is the necessary other half:
+// a manual restore whose runtime is CONFIRMED alive and only dies much later must
+// start a fresh episode, not inherit the old escalation. Only the immediate flap is
+// throttled — a genuinely recovered session that runs for a while earns a prompt
+// re-restore.
+func TestRestoreSession_LongLivedThenDied_ResetsBackoff(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &recoverFakeBackend{FakeBackend: session.NewFakeBackend()}
+	inst := registerStarted(t, manager, repoID, repoPath, "long-lived", backend, true, session.Lost)
+	zeroRestoreBackoff(t)
+
+	key := daemonInstanceKey(repoID, "long-lived")
+	manager.mu.Lock()
+	manager.lostRestoreStates[key] = &lostRestoreState{consecutiveFailures: 3}
+	manager.mu.Unlock()
+
+	if _, err := manager.RestoreSession(RestoreSessionRequest{Title: "long-lived", RepoID: repoID}); err != nil {
+		t.Fatalf("RestoreSession: %v", err)
+	}
+
+	// A poll ANSWERS: the runtime is confirmed alive, so the episode is forgotten.
+	observeAlive(manager, repoID, inst)
+	manager.RestoreLostSessions()
+	manager.mu.Lock()
+	_, tracked := manager.lostRestoreStates[key]
+	manager.mu.Unlock()
+	if tracked {
+		t.Fatal("a confirmed-alive manual restore must clear the retry state so a later, genuine " +
+			"loss does not inherit the old backoff (#1976)")
+	}
+
+	// It dies much later. The next poll marks it Lost and recovers it as attempt #1,
+	// not attempt #4 — the prior escalation must not carry into an unrelated loss.
+	inst.SetStatusForTest(session.Lost)
+	manager.RestoreLostSessions()
+	manager.mu.Lock()
+	st := manager.lostRestoreStates[key]
+	failures := -1
+	if st != nil {
+		failures = st.consecutiveFailures
+	}
+	manager.mu.Unlock()
+	if failures > 0 {
+		t.Fatalf("a runtime confirmed alive after a manual restore was charged %d failure(s) from "+
+			"the PREVIOUS episode when it later died: a genuine re-loss must start a fresh backoff", failures)
+	}
+}

--- a/daemon/restore.go
+++ b/daemon/restore.go
@@ -110,8 +110,14 @@ func (m *Manager) restoreLostOrDeadSession(req RestoreSessionRequest, repoID str
 	// automatic one; only the trigger differs (#1794).
 	m.noteRuntimeReplaced(repoID, instance)
 	m.persistInstance(repoID, instance)
-	m.mu.Lock()
-	delete(m.lostRestoreStates, key)
-	m.mu.Unlock()
+	// A manual restore is the same lifecycle event as an automatic one; only the
+	// trigger differs (#1794) — so it must arm the SAME confirm-alive gate #1923 put
+	// on the auto path, NOT clear the retry state on spawn success. The unconditional
+	// delete that used to be here reset the exponential backoff, so manually restoring
+	// a flapping session (whose agent exits on startup) re-opened the very hot-loop the
+	// auto path now prevents (#1976). consecutiveFailures is CARRIED; RestoreLostSessions
+	// clears the state once a poll observes the runtime alive, and the auto loop charges
+	// an immediate re-loss against the same episode.
+	m.armRestoreConfirmation(key, repoID, instance)
 	return instance.GetWorktreePath(), nil
 }


### PR DESCRIPTION
## Summary

Completes the #1910/#1923 confirm-alive backoff pair on the **manual** restore path.

#1923 fixed the automatic Lost-restore loop so a spawn that succeeds but dies before it can be confirmed alive counts as a *failed* attempt and backs off (#1910). The **manual** restore path — `RestoreSession` (`af sessions restore`, the TUI restore action) — was left with the exact pre-#1910 anti-pattern:

```go
// restore.go, after a successful Recover()
delete(m.lostRestoreStates, key)   // resets the exponential backoff
```

`Recover()` returning means only that tmux accepted the new session, **not** that the runtime survived a poll. So a manually restored agent that exits on startup re-entered the automatic loop as a **fresh Lost episode with a zeroed backoff** — re-opening, from the manual path, the very hot-loop #1910/#1923 prevent (a respawn every ~2s). This is the open Detail bug **#1976**, which the #1910 triage grouped with #2005 (already fixed) as "one mechanism."

## The fix

Arm the **same** confirm-alive gate on the manual path — reusing #1923's mechanism, not inventing a new one:

- Extract `armRestoreConfirmation` out of `restoreLostSession` and call it from **both** the auto loop and the manual RPC, so the two paths **cannot drift again** (the drift *is* this bug).
- On a successful manual spawn the retry state is now **retained** — `consecutiveFailures` carried, `awaitingConfirm` set against `aliveObservations` at spawn time — until a poll **observes** the runtime alive. `RestoreLostSessions` clears it then; an immediate re-loss is charged against the same episode so the #1108 backoff escalates.
- A session confirmed alive that dies **much later** still starts a fresh episode — only the immediate flap is throttled.

The `remoteSandboxAnswersAlive` heal branch in `restore.go` still clears the state: that is a **genuine liveness confirmation** (the sandbox answered), and it matches the auto path (`lostrestore.go`). Only the `Recover()`-success `delete` was the bug.

## Adjacent-site audit

Grepped every `delete(m.lostRestoreStates, key)`:

| Site | Verdict |
|---|---|
| `lostrestore.go:143/147` (auto cleanup sweep, gone-session sweep) | correct — cleared only after confirmed-alive / for gone sessions |
| `lostrestore.go` remote-answers-alive heal | correct — genuine confirmation |
| `restore.go` remote-answers-alive heal | correct — genuine confirmation (kept) |
| **`restore.go` after `Recover()` success** | **this bug (#1976) — fixed** |

## Fail-first evidence — **observed failing at `1c6b786`**

```
--- FAIL: TestRestoreSession_RecoversLostInstanceOnDemand
    manual restore dropped the retry state on spawn success ... zeroed backoff (#1976)
--- FAIL: TestRestoreSession_ImmediateReLossAfterManualRestore_EscalatesNotResets
    the poll RESPAWNED after a manual restore whose runtime died before confirmation
    (2 total spawns): the manual path cleared the backoff state ... hot-looped (#1976)
--- PASS: TestRestoreSession_LongLivedThenDied_ResetsBackoff   (don't-over-throttle guard)
```

After the fix all three pass, and the full `daemon` package suite is green in-container.

- `TestRestoreSession_ImmediateReLossAfterManualRestore_EscalatesNotResets` — new #1976 regression lock (end-to-end: manual restore → immediate re-loss → escalate, no respawn).
- `TestRestoreSession_LongLivedThenDied_ResetsBackoff` — new guard for the "only the immediate flap is throttled" requirement.
- `TestRestoreSession_RecoversLostInstanceOnDemand` — updated from the buggy "must drop state" assertion to confirm-alive semantics.

## Verification

- `make test-container GOTESTARGS="-count=1 ./daemon/"` → `ok` (159s)
- `gofmt -l .` clean · `go build ./...` ok · `golangci-lint run --timeout=3m --fast` clean · `deadcode -test ./...` clean · `scripts/lint-file-length.sh` passed

## Scope note

Fixes #1976. The related #1910 (auto path) is already fixed by #1923 (merged) and has been closed. #2005 (poll stack-overflow) is already fixed. This PR touches `daemon/restore.go` (the manual path) and `daemon/lostrestore.go` (extract the shared helper); no other behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)