### PR TITLE
fix(bugreport): redact non-loopback web-tab URLs in bug bundles (#1954)

### DIFF
--- a/bugreport/bugreport_test.go
+++ b/bugreport/bugreport_test.go
@@ -193,6 +193,34 @@ func TestRedactInstanceDataKeepsStructuralDropsFreeText(t *testing.T) {
 	}
 }
 
+// TestRedactInstanceDataRedactsNonLoopbackWebTabURL pins the #1954 fix: a web
+// tab's URL is user-supplied (any http/https target passes NormalizeWebTabURL)
+// and can name internal infrastructure or a private repo, exactly the class of
+// data PRInfo.URL is redacted for. A NON-loopback URL must be redacted; a
+// loopback URL (the proxied dev-server case) is kept for triage, mirroring the
+// same loopback/non-loopback split the daemon proxy draws.
+func TestRedactInstanceDataRedactsNonLoopbackWebTabURL(t *testing.T) {
+	const externalURL = "https://github.com/company/private-repo/pull/42"
+	const loopbackURL = "http://localhost:3000/dashboard"
+	d := session.InstanceData{
+		ID:      "abc123",
+		Program: "claude",
+		Tabs: []session.TabData{
+			{Name: "external", Kind: session.TabKindWeb, URL: externalURL},
+			{Name: "devserver", Kind: session.TabKindWeb, URL: loopbackURL},
+		},
+	}
+
+	redactInstanceData(&d)
+
+	if d.Tabs[0].URL != redactedMarker {
+		t.Errorf("non-loopback web tab URL not redacted: %q (leaks internal/private identifiers, same class as PRInfo.URL)", d.Tabs[0].URL)
+	}
+	if d.Tabs[1].URL != loopbackURL {
+		t.Errorf("loopback web tab URL must survive for triage: got %q, want %q", d.Tabs[1].URL, loopbackURL)
+	}
+}
+
 func TestRedactInstancesJSONDropsTitleSecretEverywhere(t *testing.T) {
 	const plantedSecret = "customer roadmap acquisition codename"
 

--- a/bugreport/redact.go
+++ b/bugreport/redact.go
@@ -511,6 +511,16 @@ func redactInstanceData(d *session.InstanceData) {
 		if d.Tabs[i].TmuxName != "" {
 			d.Tabs[i].TmuxName = redactedMarker
 		}
+		// A web tab's URL is user-supplied (any http/https target passes
+		// NormalizeWebTabURL) and can name internal infrastructure or a private
+		// repo — the same class of sensitive URL PRInfo.URL is redacted for
+		// below (#1954). Redact non-loopback targets; keep loopback ones (the
+		// proxied dev-server case), which are safe and useful for triage,
+		// mirroring the loopback/non-loopback split the daemon proxy already
+		// draws (session.IsLoopbackWebTarget).
+		if d.Tabs[i].URL != "" && !session.IsLoopbackWebTarget(d.Tabs[i].URL) {
+			d.Tabs[i].URL = redactedMarker
+		}
 		if d.Tabs[i].Conversation != nil {
 			d.Tabs[i].Conversation.ID = ""
 		}


### PR DESCRIPTION
Closes #1954.

## Problem

`TabData.URL` is user-supplied — any `http`/`https` target passes `NormalizeWebTabURL` (e.g. `af sessions tab-create --kind web --url https://github.com/company/private-repo/pull/42`) and is stored in `instances.json`. `redactInstanceData` left it untouched while redacting `PRInfo.URL` — **the same class of user-supplied URL in the same struct family**. A bug bundle could therefore ship a user's external/internal web-tab URLs, leaking internal-infrastructure hostnames or private-repo identifiers. Nobody decided web-tab URLs were safe; the field just skipped the redactor — same shape as the #1915 leak, one field over.

## Fix

In `redactInstanceData`, redact **non-loopback** tab URLs via the existing `session.IsLoopbackWebTarget`, and keep **loopback** ones (the proxied dev-server case) — safe and useful for triage. This mirrors the loopback/non-loopback split the daemon proxy already draws.

## Adjacent-site audit (fix all or justify)

- **Fallback path** (`redactUnknownJSON`): already blanks every `url` key wholesale when `instances.json` can't decode typed — conservative, no change.
- **`noteSession`/scrubLog**: no addition needed — the daemon proxies **only loopback** targets, so a non-loopback web-tab URL is never written to the daemon log tail (the only proxy log line, `webtab_proxy.go:625`, logs a loopback target).
- **Daemon-status snapshot**: scheduler/watcher health only; carries no tab data.

## Test

Added `TestRedactInstanceDataRedactsNonLoopbackWebTabURL`, **observed failing at d4bae18** (the non-loopback URL survived redaction). Now: non-loopback redacted, loopback preserved. Full `bugreport` suite green; `gofmt`, `go build ./...`, `golangci-lint --fast`, `deadcode -test ./...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)