### PR TITLE
feat(tui): friendly schedule picker + shared schedule model (phase 1 of #2057)

### DIFF
--- a/app/handle_overlay_test.go
+++ b/app/handle_overlay_test.go
@@ -267,8 +267,9 @@ func TestHandleStateTasks_PendingCreateFlushesDirtyTaskState(t *testing.T) {
 
 	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("new-task")})
 	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> trigger selector (cron stays selected)
-	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> cron value
-	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("* * * * *")})
+	// The schedule picker occupies the cron value stop and defaults to a valid
+	// daily schedule (#2057), so this create needs no cron input.
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> schedule picker
 	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> prompt
 	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("do other thing")})
 	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> target session
@@ -519,8 +520,8 @@ func TestHandleStateTasks_FailedCreateDoesNotDuplicateOnReopen(t *testing.T) {
 	require.True(t, tp.IsCreating(), "'n' must open the inline create form")
 	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("dup-task")})
 	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> trigger selector
-	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> cron value
-	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("* * * * *")})
+	// Schedule picker defaults to a valid daily schedule; no cron input needed.
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> schedule picker
 	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> prompt
 	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("dup prompt")})
 	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> target session
@@ -586,8 +587,11 @@ func TestHandleTaskCreate_RoutesThroughDaemonRPC(t *testing.T) {
 	require.True(t, tp.IsCreating(), "'n' must open the inline create form")
 	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("new-task")})
 	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> trigger selector (cron stays selected)
-	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> cron value
-	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("* * * * *")})
+	// The cron trigger's value stop is now the schedule picker (#2057); a user
+	// who accepts its default composes a daily-at-9:00-AM task ("0 9 * * *"),
+	// so no cron text is typed here. (The picker's own key handling and explicit
+	// schedule choices are covered by the ui package tests.)
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> schedule picker
 	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> prompt
 	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("do a thing")})
 	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> target session
@@ -597,11 +601,13 @@ func TestHandleTaskCreate_RoutesThroughDaemonRPC(t *testing.T) {
 	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyEnter})
 
 	// (a) The create was dispatched through the daemon seam exactly once, with
-	// the task the user composed.
+	// the task the user composed. The schedule picker's default (daily at
+	// 9:00 AM) replaces the old raw-cron every-minute default, which was a poor
+	// default that hammered every minute (#2057).
 	require.Equal(t, 1, calls, "create must route through the daemon RPC, not a direct disk write")
 	require.NotNil(t, got)
 	assert.Equal(t, "new-task", got.Name)
-	assert.Equal(t, "* * * * *", got.CronExpr)
+	assert.Equal(t, "0 9 * * *", got.CronExpr)
 
 	// (b) The TUI wrote nothing to disk: with the daemon stubbed out, the only
 	// writer, tasks.json holds no task.

--- a/schedule/schedule.go
+++ b/schedule/schedule.go
@@ -1,0 +1,312 @@
+// Package schedule is the canonical, UI-agnostic model behind the friendly
+// task-schedule picker (#2057). It maps a small set of preset schedule shapes
+// (every N minutes/hours, hourly, daily, weekly, monthly) to and from the
+// 5-field cron expressions the task store persists, plus a plain-English
+// Describe() for the picker preview. The TUI form and the phase-2 web modal
+// both drive this model, so the two surfaces cannot disagree about what a
+// picker state means — the shared test vectors in testdata/vectors.json (loaded
+// by both the Go and the future web tests) pin that contract.
+//
+// Cron generation is the only exhaustive direction: ParseCron is best-effort
+// and recognizes just the shapes Cron emits (so an existing task re-opens as
+// its matching preset), falling back to Type=Custom for anything else. The
+// daemon's own cron validation and scheduling (task.ValidateCronExpr /
+// task.ParseCron) are unchanged — this package only shapes the INPUT, and its
+// generated expressions round-trip through that validator (asserted in the
+// tests).
+package schedule
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Type is the preset schedule shape a Schedule takes.
+type Type string
+
+const (
+	// EveryNMinutes fires every Interval minutes ("*/N * * * *").
+	EveryNMinutes Type = "everyNMinutes"
+	// EveryNHours fires every Interval hours on the hour ("0 */N * * *").
+	EveryNHours Type = "everyNHours"
+	// Hourly fires once an hour at Minute past the hour ("M * * * *").
+	Hourly Type = "hourly"
+	// Daily fires once a day at Hour:Minute ("M H * * *").
+	Daily Type = "daily"
+	// Weekly fires at Hour:Minute on each selected weekday ("M H * * <days>").
+	Weekly Type = "weekly"
+	// Monthly fires at Hour:Minute on DayOfMonth ("M H DOM * *").
+	Monthly Type = "monthly"
+	// Custom carries a raw cron expression verbatim (the advanced escape hatch).
+	Custom Type = "custom"
+)
+
+// Schedule is a preset schedule plus its contextual fields. Only the fields
+// relevant to Type are meaningful; the rest stay zero. Hour is 24-hour (0-23) —
+// the 12-hour AM/PM presentation lives in Describe and the UI, not in the
+// model. Weekdays holds time.Weekday values (Sunday=0 … Saturday=6).
+type Schedule struct {
+	Type       Type           `json:"type"`
+	Interval   int            `json:"interval,omitempty"`
+	Hour       int            `json:"hour,omitempty"`
+	Minute     int            `json:"minute,omitempty"`
+	Weekdays   []time.Weekday `json:"weekdays,omitempty"`
+	DayOfMonth int            `json:"dayOfMonth,omitempty"`
+	Raw        string         `json:"raw,omitempty"`
+}
+
+// Cron renders the schedule as a 5-field cron expression (minute hour
+// day-of-month month day-of-week). Custom returns Raw verbatim. The generated
+// expressions are exactly the shapes ParseCron recognizes, so
+// ParseCron(s.Cron()) round-trips every preset back to s.
+func (s Schedule) Cron() string {
+	switch s.Type {
+	case EveryNMinutes:
+		return fmt.Sprintf("*/%d * * * *", s.Interval)
+	case EveryNHours:
+		return fmt.Sprintf("0 */%d * * *", s.Interval)
+	case Hourly:
+		return fmt.Sprintf("%d * * * *", s.Minute)
+	case Daily:
+		return fmt.Sprintf("%d %d * * *", s.Minute, s.Hour)
+	case Weekly:
+		return fmt.Sprintf("%d %d * * %s", s.Minute, s.Hour, weekdayField(s.Weekdays))
+	case Monthly:
+		return fmt.Sprintf("%d %d %d * *", s.Minute, s.Hour, s.DayOfMonth)
+	default: // Custom and any unknown type
+		return s.Raw
+	}
+}
+
+// Describe renders the schedule as the plain-English preview line, e.g.
+// "Every 15 minutes", "Every day at 3:41 PM", "Every week on Mon, Wed at
+// 9:00 AM". Custom echoes its raw cron ("Custom: 41 3 * * *"). Times use a
+// 12-hour clock with AM/PM.
+func (s Schedule) Describe() string {
+	switch s.Type {
+	case EveryNMinutes:
+		if s.Interval == 1 {
+			return "Every minute"
+		}
+		return fmt.Sprintf("Every %d minutes", s.Interval)
+	case EveryNHours:
+		if s.Interval == 1 {
+			return "Every hour"
+		}
+		return fmt.Sprintf("Every %d hours", s.Interval)
+	case Hourly:
+		return fmt.Sprintf("Every hour at :%02d", s.Minute)
+	case Daily:
+		return fmt.Sprintf("Every day at %s", clockTime(s.Hour, s.Minute))
+	case Weekly:
+		return fmt.Sprintf("Every week on %s at %s", weekdayNames(s.Weekdays), clockTime(s.Hour, s.Minute))
+	case Monthly:
+		return fmt.Sprintf("Every month on the %s at %s", ordinal(s.DayOfMonth), clockTime(s.Hour, s.Minute))
+	default: // Custom and any unknown type
+		return "Custom: " + s.Raw
+	}
+}
+
+// ParseCron best-effort maps a 5-field cron expression back to a structured
+// Schedule. It recognizes exactly the shapes Cron emits — so a task saved by
+// the picker re-opens as its matching preset — plus a Sunday day-of-week alias
+// (7). Anything else (ranges, multi-value minute/hour fields, month
+// restrictions, step forms we don't emit, or a malformed expression) returns
+// {Type: Custom, Raw: expr} with ok=false, signalling the UI to fall back to
+// the raw-cron editor. It deliberately does NOT parse arbitrary cron.
+func ParseCron(expr string) (Schedule, bool) {
+	fields := strings.Fields(strings.TrimSpace(expr))
+	if len(fields) != 5 {
+		return custom(expr), false
+	}
+	minute, hour, dom, month, dow := fields[0], fields[1], fields[2], fields[3], fields[4]
+
+	// No preset restricts the month field.
+	if month != "*" {
+		return custom(expr), false
+	}
+
+	// every N minutes: */N * * * *
+	if n, ok := stepOfStar(minute); ok && hour == "*" && dom == "*" && dow == "*" {
+		return Schedule{Type: EveryNMinutes, Interval: n}, true
+	}
+	// every N hours: 0 */N * * *
+	if n, ok := stepOfStar(hour); ok && minute == "0" && dom == "*" && dow == "*" {
+		return Schedule{Type: EveryNHours, Interval: n}, true
+	}
+	// hourly: M * * * *
+	if m, ok := singleInt(minute, 0, 59); ok && hour == "*" && dom == "*" && dow == "*" {
+		return Schedule{Type: Hourly, Minute: m}, true
+	}
+
+	// The remaining presets all pin a single minute and hour.
+	m, okM := singleInt(minute, 0, 59)
+	h, okH := singleInt(hour, 0, 23)
+	if okM && okH {
+		switch {
+		case dom == "*" && dow == "*":
+			// daily: M H * * *
+			return Schedule{Type: Daily, Hour: h, Minute: m}, true
+		case dom == "*":
+			// weekly: M H * * <days>
+			if days, ok := weekdayList(dow); ok {
+				return Schedule{Type: Weekly, Hour: h, Minute: m, Weekdays: days}, true
+			}
+		case dow == "*":
+			// monthly: M H DOM * *
+			if d, ok := singleInt(dom, 1, 31); ok {
+				return Schedule{Type: Monthly, Hour: h, Minute: m, DayOfMonth: d}, true
+			}
+		}
+	}
+	return custom(expr), false
+}
+
+func custom(expr string) Schedule {
+	return Schedule{Type: Custom, Raw: expr}
+}
+
+// weekdayField renders the day-of-week cron field: a sorted, de-duplicated,
+// comma-separated list of weekday numbers (0-6). Empty weekdays render as "*"
+// (every day) so the expression stays valid even mid-edit; the UI requires at
+// least one day before it will save a weekly task.
+func weekdayField(days []time.Weekday) string {
+	nums := normalizeWeekdays(days)
+	if len(nums) == 0 {
+		return "*"
+	}
+	parts := make([]string, len(nums))
+	for i, n := range nums {
+		parts[i] = strconv.Itoa(n)
+	}
+	return strings.Join(parts, ",")
+}
+
+// weekdayNames renders weekdays as sorted three-letter abbreviations joined by
+// ", ", e.g. [Monday, Wednesday] → "Mon, Wed". Ordered Sunday-first to match
+// the cron day-of-week numbering.
+func weekdayNames(days []time.Weekday) string {
+	nums := normalizeWeekdays(days)
+	parts := make([]string, len(nums))
+	for i, n := range nums {
+		parts[i] = time.Weekday(n).String()[:3]
+	}
+	return strings.Join(parts, ", ")
+}
+
+// normalizeWeekdays maps each weekday into 0-6 (7 is the Sunday alias),
+// de-duplicates, and sorts ascending so both the cron field and the
+// description present days in a stable Sunday-first order.
+func normalizeWeekdays(days []time.Weekday) []int {
+	seen := make(map[int]bool, len(days))
+	nums := make([]int, 0, len(days))
+	for _, d := range days {
+		n := int(d) % 7
+		if n < 0 {
+			n += 7
+		}
+		if !seen[n] {
+			seen[n] = true
+			nums = append(nums, n)
+		}
+	}
+	sort.Ints(nums)
+	return nums
+}
+
+// clockTime formats a 24-hour hour/minute as a 12-hour clock time with AM/PM,
+// e.g. (0,0)→"12:00 AM", (12,0)→"12:00 PM", (15,41)→"3:41 PM".
+func clockTime(hour, minute int) string {
+	suffix := "AM"
+	h := hour
+	switch {
+	case h == 0:
+		h = 12
+	case h == 12:
+		suffix = "PM"
+	case h > 12:
+		h -= 12
+		suffix = "PM"
+	}
+	return fmt.Sprintf("%d:%02d %s", h, minute, suffix)
+}
+
+// ordinal renders n as an English ordinal: 1→"1st", 2→"2nd", 3→"3rd",
+// 11→"11th", 21→"21st", 31→"31st".
+func ordinal(n int) string {
+	suffix := "th"
+	if n%100 < 11 || n%100 > 13 {
+		switch n % 10 {
+		case 1:
+			suffix = "st"
+		case 2:
+			suffix = "nd"
+		case 3:
+			suffix = "rd"
+		}
+	}
+	return strconv.Itoa(n) + suffix
+}
+
+// stepOfStar parses a "*/N" field and returns N (N>=1). Any other shape (a bare
+// "*", a single int, a range step, or a list) returns ok=false.
+func stepOfStar(field string) (int, bool) {
+	rest, ok := strings.CutPrefix(field, "*/")
+	if !ok {
+		return 0, false
+	}
+	n, err := strconv.Atoi(rest)
+	if err != nil || n < 1 {
+		return 0, false
+	}
+	return n, true
+}
+
+// singleInt parses a field that is a single integer within [min,max]. A field
+// containing any cron metacharacter (* / , -) fails, so only a bare number
+// matches.
+func singleInt(field string, min, max int) (int, bool) {
+	n, err := strconv.Atoi(field)
+	if err != nil || n < min || n > max {
+		return 0, false
+	}
+	return n, true
+}
+
+// weekdayList parses a day-of-week field that is a comma-separated list of
+// single weekday numbers (0-6, or 7 as a Sunday alias) into sorted,
+// de-duplicated time.Weekday values — the shape Cron emits for a weekly
+// schedule. A wildcard, range, or step form returns ok=false so the caller
+// falls back to Custom.
+func weekdayList(field string) ([]time.Weekday, bool) {
+	if field == "*" {
+		return nil, false
+	}
+	seen := make(map[int]bool)
+	var nums []int
+	for _, part := range strings.Split(field, ",") {
+		n, err := strconv.Atoi(part)
+		if err != nil || n < 0 || n > 7 {
+			return nil, false
+		}
+		if n == 7 {
+			n = 0 // Sunday alias
+		}
+		if !seen[n] {
+			seen[n] = true
+			nums = append(nums, n)
+		}
+	}
+	if len(nums) == 0 {
+		return nil, false
+	}
+	sort.Ints(nums)
+	days := make([]time.Weekday, len(nums))
+	for i, n := range nums {
+		days[i] = time.Weekday(n)
+	}
+	return days, true
+}

--- a/schedule/schedule.go
+++ b/schedule/schedule.go
@@ -129,12 +129,12 @@ func ParseCron(expr string) (Schedule, bool) {
 		return custom(expr), false
 	}
 
-	// every N minutes: */N * * * *
-	if n, ok := stepOfStar(minute); ok && hour == "*" && dom == "*" && dow == "*" {
+	// every N minutes: */N * * * * (N in 1-59; see stepOfStar)
+	if n, ok := stepOfStar(minute, 59); ok && hour == "*" && dom == "*" && dow == "*" {
 		return Schedule{Type: EveryNMinutes, Interval: n}, true
 	}
-	// every N hours: 0 */N * * *
-	if n, ok := stepOfStar(hour); ok && minute == "0" && dom == "*" && dow == "*" {
+	// every N hours: 0 */N * * * (N in 1-23)
+	if n, ok := stepOfStar(hour, 23); ok && minute == "0" && dom == "*" && dow == "*" {
 		return Schedule{Type: EveryNHours, Interval: n}, true
 	}
 	// hourly: M * * * *
@@ -251,15 +251,20 @@ func ordinal(n int) string {
 	return strconv.Itoa(n) + suffix
 }
 
-// stepOfStar parses a "*/N" field and returns N (N>=1). Any other shape (a bare
-// "*", a single int, a range step, or a list) returns ok=false.
-func stepOfStar(field string) (int, bool) {
+// stepOfStar parses a "*/N" field and returns N when it is a friendly interval,
+// 1 <= N <= max. A step at or beyond the field size (e.g. "*/60" for minutes or
+// "*/24" for hours) is rejected so ParseCron falls back to Custom and preserves
+// the raw expression, rather than the picker clamping it (to */59 / */23) and
+// silently rewriting the cron on an otherwise-untouched re-save (#2057). Any
+// other shape (a bare "*", a single int, a range step, or a list) also returns
+// ok=false.
+func stepOfStar(field string, max int) (int, bool) {
 	rest, ok := strings.CutPrefix(field, "*/")
 	if !ok {
 		return 0, false
 	}
 	n, err := strconv.Atoi(rest)
-	if err != nil || n < 1 {
+	if err != nil || n < 1 || n > max {
 		return 0, false
 	}
 	return n, true

--- a/schedule/schedule_test.go
+++ b/schedule/schedule_test.go
@@ -1,0 +1,197 @@
+package schedule
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/task"
+)
+
+// parseExpect overrides the default ParseCron expectation for a vector. Any
+// field left nil falls back to the vector's own cron/schedule (see the schema
+// note in testdata/vectors.json).
+type parseExpect struct {
+	Cron     *string   `json:"cron"`
+	OK       *bool     `json:"ok"`
+	Schedule *Schedule `json:"schedule"`
+}
+
+// vector is one shared test triple loaded from testdata/vectors.json. Pointer
+// fields distinguish "absent" from a zero value so the loader knows which
+// assertions apply.
+type vector struct {
+	Name     string       `json:"name"`
+	Schedule *Schedule    `json:"schedule"`
+	Cron     *string      `json:"cron"`
+	Human    *string      `json:"human"`
+	Parse    *parseExpect `json:"parse"`
+}
+
+type vectorFile struct {
+	Vectors []vector `json:"vectors"`
+}
+
+func loadVectors(t *testing.T) []vector {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", "vectors.json"))
+	if err != nil {
+		t.Fatalf("read vectors: %v", err)
+	}
+	var vf vectorFile
+	if err := json.Unmarshal(data, &vf); err != nil {
+		t.Fatalf("parse vectors: %v", err)
+	}
+	if len(vf.Vectors) == 0 {
+		t.Fatal("no vectors loaded")
+	}
+	return vf.Vectors
+}
+
+// TestVectors drives the shared vector file: it is the contract the phase-2 web
+// implementation must also satisfy. Every entry checks Cron(), Describe(),
+// and/or ParseCron() per the rules documented in the JSON header.
+func TestVectors(t *testing.T) {
+	for _, v := range loadVectors(t) {
+		t.Run(v.Name, func(t *testing.T) {
+			if v.Schedule != nil && v.Cron != nil {
+				if got := v.Schedule.Cron(); got != *v.Cron {
+					t.Errorf("Cron() = %q, want %q", got, *v.Cron)
+				}
+			}
+			if v.Schedule != nil && v.Human != nil {
+				if got := v.Schedule.Describe(); got != *v.Human {
+					t.Errorf("Describe() = %q, want %q", got, *v.Human)
+				}
+			}
+
+			// ParseCron: input and expectations default to the vector, with the
+			// optional parse block overriding.
+			input, hasInput := "", false
+			switch {
+			case v.Parse != nil && v.Parse.Cron != nil:
+				input, hasInput = *v.Parse.Cron, true
+			case v.Cron != nil:
+				input, hasInput = *v.Cron, true
+			}
+			if !hasInput {
+				return
+			}
+			expectOK := true
+			if v.Parse != nil && v.Parse.OK != nil {
+				expectOK = *v.Parse.OK
+			}
+			var expected Schedule
+			haveExpected := false
+			switch {
+			case v.Parse != nil && v.Parse.Schedule != nil:
+				expected, haveExpected = *v.Parse.Schedule, true
+			case v.Schedule != nil:
+				expected, haveExpected = *v.Schedule, true
+			}
+
+			got, ok := ParseCron(input)
+			if ok != expectOK {
+				t.Errorf("ParseCron(%q) ok = %v, want %v", input, ok, expectOK)
+			}
+			if haveExpected && !reflect.DeepEqual(got, expected) {
+				t.Errorf("ParseCron(%q) = %+v, want %+v", input, got, expected)
+			}
+		})
+	}
+}
+
+// TestGeneratedCronValidatesThroughDaemon is the round-trip guard the issue
+// calls for: every preset cron the picker can generate must pass the daemon's
+// existing validator (task.ValidateCronExpr) and be schedulable by its parser
+// (task.ParseCron). This is what lets the picker replace the raw-cron field
+// without touching how cron is validated or persisted.
+func TestGeneratedCronValidatesThroughDaemon(t *testing.T) {
+	for _, v := range loadVectors(t) {
+		if v.Schedule == nil || v.Schedule.Type == Custom {
+			continue // custom carries arbitrary user text; only presets are guaranteed valid
+		}
+		expr := v.Schedule.Cron()
+		t.Run(v.Name+"/"+expr, func(t *testing.T) {
+			if err := task.ValidateCronExpr(expr); err != nil {
+				t.Errorf("ValidateCronExpr(%q) = %v, want nil", expr, err)
+			}
+			if _, err := task.ParseCron(expr); err != nil {
+				t.Errorf("task.ParseCron(%q) = %v, want nil", expr, err)
+			}
+		})
+	}
+}
+
+// TestParseCronRoundTrip asserts the structural round-trip for every preset:
+// ParseCron(s.Cron()) reproduces s with ok=true. This is the property that lets
+// an existing task re-open as its matching preset in the picker.
+func TestParseCronRoundTrip(t *testing.T) {
+	presets := []Schedule{
+		{Type: EveryNMinutes, Interval: 1},
+		{Type: EveryNMinutes, Interval: 45},
+		{Type: EveryNHours, Interval: 1},
+		{Type: EveryNHours, Interval: 8},
+		{Type: Hourly, Minute: 0},
+		{Type: Hourly, Minute: 17},
+		{Type: Daily, Hour: 0, Minute: 0},
+		{Type: Daily, Hour: 23, Minute: 59},
+		{Type: Weekly, Hour: 9, Minute: 30, Weekdays: []time.Weekday{time.Monday}},
+		{Type: Weekly, Hour: 7, Minute: 0, Weekdays: []time.Weekday{time.Sunday, time.Saturday}},
+		{Type: Monthly, Hour: 12, Minute: 0, DayOfMonth: 1},
+		{Type: Monthly, Hour: 6, Minute: 15, DayOfMonth: 28},
+	}
+	for _, s := range presets {
+		expr := s.Cron()
+		got, ok := ParseCron(expr)
+		if !ok {
+			t.Errorf("ParseCron(%q) ok=false, want a recognized preset", expr)
+		}
+		if !reflect.DeepEqual(got, s) {
+			t.Errorf("ParseCron(%q) = %+v, want %+v", expr, got, s)
+		}
+	}
+}
+
+// TestParseCronUnrecognizedFallsBackToCustom pins the best-effort contract: an
+// expression that is not one of the emitted shapes returns {Custom, Raw} with
+// ok=false so the UI knows to drop into the raw-cron editor.
+func TestParseCronUnrecognizedFallsBackToCustom(t *testing.T) {
+	for _, expr := range []string{
+		"0 9 * * 1-5",    // weekday range (we emit comma lists)
+		"*/7 9-17 * * *", // hour range
+		"15 */3 * * *",   // minute + hour-step combination we never emit
+		"0 0 1,15 * *",   // day-of-month list
+		"0 0 * JAN *",    // named month
+		"@daily",         // descriptor
+		"0 0",            // too few fields
+	} {
+		got, ok := ParseCron(expr)
+		if ok {
+			t.Errorf("ParseCron(%q) ok=true, want false", expr)
+		}
+		if got.Type != Custom || got.Raw != expr {
+			t.Errorf("ParseCron(%q) = %+v, want {Custom, Raw:%q}", expr, got, expr)
+		}
+	}
+}
+
+// TestWeekdayOrderIsSundayFirstAndDeduped verifies the day-of-week field and
+// description are normalized (deduped, Sunday-first) regardless of input order.
+func TestWeekdayOrderIsSundayFirstAndDeduped(t *testing.T) {
+	s := Schedule{
+		Type:     Weekly,
+		Hour:     9,
+		Minute:   0,
+		Weekdays: []time.Weekday{time.Wednesday, time.Sunday, time.Monday, time.Wednesday},
+	}
+	if got, want := s.Cron(), "0 9 * * 0,1,3"; got != want {
+		t.Errorf("Cron() = %q, want %q", got, want)
+	}
+	if got, want := s.Describe(), "Every week on Sun, Mon, Wed at 9:00 AM"; got != want {
+		t.Errorf("Describe() = %q, want %q", got, want)
+	}
+}

--- a/schedule/schedule_test.go
+++ b/schedule/schedule_test.go
@@ -133,8 +133,10 @@ func TestParseCronRoundTrip(t *testing.T) {
 	presets := []Schedule{
 		{Type: EveryNMinutes, Interval: 1},
 		{Type: EveryNMinutes, Interval: 45},
+		{Type: EveryNMinutes, Interval: 59}, // upper bound still a preset
 		{Type: EveryNHours, Interval: 1},
 		{Type: EveryNHours, Interval: 8},
+		{Type: EveryNHours, Interval: 23}, // upper bound still a preset
 		{Type: Hourly, Minute: 0},
 		{Type: Hourly, Minute: 17},
 		{Type: Daily, Hour: 0, Minute: 0},
@@ -168,6 +170,8 @@ func TestParseCronUnrecognizedFallsBackToCustom(t *testing.T) {
 		"0 0 * JAN *",    // named month
 		"@daily",         // descriptor
 		"0 0",            // too few fields
+		"*/60 * * * *",   // minute step at/over field size — clamps if parsed, so Custom
+		"0 */24 * * *",   // hour step at/over field size — Custom, not clamped to */23
 	} {
 		got, ok := ParseCron(expr)
 		if ok {

--- a/schedule/testdata/vectors.json
+++ b/schedule/testdata/vectors.json
@@ -1,0 +1,70 @@
+{
+  "_readme": [
+    "Shared schedule test vectors for #2057 (task-scheduling UX). BOTH the Go",
+    "tests (schedule/schedule_test.go) and the phase-2 web tests load this file",
+    "so the two Schedule implementations cannot drift (the #1970 shared-source-",
+    "of-truth pattern). Do not tighten it to Go-only shapes.",
+    "",
+    "Each entry in `vectors` is checked as follows:",
+    "  - schedule + cron   -> assert Schedule.Cron() == cron",
+    "  - schedule + human  -> assert Schedule.Describe() == human",
+    "  - ParseCron:  input    = parse.cron   if present, else cron (skipped if neither)",
+    "                expectOk = parse.ok     if present, else true",
+    "                expected = parse.schedule if present, else schedule",
+    "                assert ParseCron(input) == (expected, expectOk)",
+    "Weekdays use time.Weekday numbering (Sunday=0 .. Saturday=6)."
+  ],
+  "vectors": [
+    { "name": "every-1-minute",  "schedule": { "type": "everyNMinutes", "interval": 1 },  "cron": "*/1 * * * *",  "human": "Every minute" },
+    { "name": "every-5-minutes", "schedule": { "type": "everyNMinutes", "interval": 5 },  "cron": "*/5 * * * *",  "human": "Every 5 minutes" },
+    { "name": "every-15-minutes","schedule": { "type": "everyNMinutes", "interval": 15 }, "cron": "*/15 * * * *", "human": "Every 15 minutes" },
+    { "name": "every-30-minutes","schedule": { "type": "everyNMinutes", "interval": 30 }, "cron": "*/30 * * * *", "human": "Every 30 minutes" },
+
+    { "name": "every-1-hour",   "schedule": { "type": "everyNHours", "interval": 1 },  "cron": "0 */1 * * *",  "human": "Every hour" },
+    { "name": "every-2-hours",  "schedule": { "type": "everyNHours", "interval": 2 },  "cron": "0 */2 * * *",  "human": "Every 2 hours" },
+    { "name": "every-6-hours",  "schedule": { "type": "everyNHours", "interval": 6 },  "cron": "0 */6 * * *",  "human": "Every 6 hours" },
+    { "name": "every-12-hours", "schedule": { "type": "everyNHours", "interval": 12 }, "cron": "0 */12 * * *", "human": "Every 12 hours" },
+
+    { "name": "hourly-at-0",  "schedule": { "type": "hourly", "minute": 0 },  "cron": "0 * * * *",  "human": "Every hour at :00" },
+    { "name": "hourly-at-5",  "schedule": { "type": "hourly", "minute": 5 },  "cron": "5 * * * *",  "human": "Every hour at :05" },
+    { "name": "hourly-at-30", "schedule": { "type": "hourly", "minute": 30 }, "cron": "30 * * * *", "human": "Every hour at :30" },
+    { "name": "hourly-at-59", "schedule": { "type": "hourly", "minute": 59 }, "cron": "59 * * * *", "human": "Every hour at :59" },
+
+    { "name": "daily-midnight",  "schedule": { "type": "daily", "hour": 0,  "minute": 0 },  "cron": "0 0 * * *",   "human": "Every day at 12:00 AM" },
+    { "name": "daily-morning",   "schedule": { "type": "daily", "hour": 9,  "minute": 5 },  "cron": "5 9 * * *",   "human": "Every day at 9:05 AM" },
+    { "name": "daily-noon",      "schedule": { "type": "daily", "hour": 12, "minute": 0 },  "cron": "0 12 * * *",  "human": "Every day at 12:00 PM" },
+    { "name": "daily-1pm",       "schedule": { "type": "daily", "hour": 13, "minute": 0 },  "cron": "0 13 * * *",  "human": "Every day at 1:00 PM" },
+    { "name": "daily-afternoon", "schedule": { "type": "daily", "hour": 15, "minute": 41 }, "cron": "41 15 * * *", "human": "Every day at 3:41 PM" },
+    { "name": "daily-late",      "schedule": { "type": "daily", "hour": 23, "minute": 59 }, "cron": "59 23 * * *", "human": "Every day at 11:59 PM" },
+
+    { "name": "weekly-mon-wed",  "schedule": { "type": "weekly", "hour": 9,  "minute": 0,  "weekdays": [1, 3] },          "cron": "0 9 * * 1,3",         "human": "Every week on Mon, Wed at 9:00 AM" },
+    { "name": "weekly-sunday",   "schedule": { "type": "weekly", "hour": 0,  "minute": 0,  "weekdays": [0] },             "cron": "0 0 * * 0",           "human": "Every week on Sun at 12:00 AM" },
+    { "name": "weekly-saturday", "schedule": { "type": "weekly", "hour": 10, "minute": 15, "weekdays": [6] },             "cron": "15 10 * * 6",         "human": "Every week on Sat at 10:15 AM" },
+    { "name": "weekly-weekdays", "schedule": { "type": "weekly", "hour": 8,  "minute": 30, "weekdays": [1, 2, 3, 4, 5] }, "cron": "30 8 * * 1,2,3,4,5",  "human": "Every week on Mon, Tue, Wed, Thu, Fri at 8:30 AM" },
+    { "name": "weekly-weekend",  "schedule": { "type": "weekly", "hour": 18, "minute": 0,  "weekdays": [0, 6] },          "cron": "0 18 * * 0,6",        "human": "Every week on Sun, Sat at 6:00 PM" },
+
+    { "name": "monthly-1st",  "schedule": { "type": "monthly", "hour": 0,  "minute": 0,  "dayOfMonth": 1 },  "cron": "0 0 1 * *",    "human": "Every month on the 1st at 12:00 AM" },
+    { "name": "monthly-2nd",  "schedule": { "type": "monthly", "hour": 6,  "minute": 0,  "dayOfMonth": 2 },  "cron": "0 6 2 * *",    "human": "Every month on the 2nd at 6:00 AM" },
+    { "name": "monthly-3rd",  "schedule": { "type": "monthly", "hour": 6,  "minute": 0,  "dayOfMonth": 3 },  "cron": "0 6 3 * *",    "human": "Every month on the 3rd at 6:00 AM" },
+    { "name": "monthly-11th", "schedule": { "type": "monthly", "hour": 6,  "minute": 0,  "dayOfMonth": 11 }, "cron": "0 6 11 * *",   "human": "Every month on the 11th at 6:00 AM" },
+    { "name": "monthly-12th", "schedule": { "type": "monthly", "hour": 6,  "minute": 0,  "dayOfMonth": 12 }, "cron": "0 6 12 * *",   "human": "Every month on the 12th at 6:00 AM" },
+    { "name": "monthly-13th", "schedule": { "type": "monthly", "hour": 6,  "minute": 0,  "dayOfMonth": 13 }, "cron": "0 6 13 * *",   "human": "Every month on the 13th at 6:00 AM" },
+    { "name": "monthly-15th", "schedule": { "type": "monthly", "hour": 14, "minute": 30, "dayOfMonth": 15 }, "cron": "30 14 15 * *", "human": "Every month on the 15th at 2:30 PM" },
+    { "name": "monthly-21st", "schedule": { "type": "monthly", "hour": 6,  "minute": 0,  "dayOfMonth": 21 }, "cron": "0 6 21 * *",   "human": "Every month on the 21st at 6:00 AM" },
+    { "name": "monthly-22nd", "schedule": { "type": "monthly", "hour": 6,  "minute": 0,  "dayOfMonth": 22 }, "cron": "0 6 22 * *",   "human": "Every month on the 22nd at 6:00 AM" },
+    { "name": "monthly-23rd", "schedule": { "type": "monthly", "hour": 6,  "minute": 0,  "dayOfMonth": 23 }, "cron": "0 6 23 * *",   "human": "Every month on the 23rd at 6:00 AM" },
+    { "name": "monthly-31st", "schedule": { "type": "monthly", "hour": 23, "minute": 0,  "dayOfMonth": 31 }, "cron": "0 23 31 * *",  "human": "Every month on the 31st at 11:00 PM" },
+
+    { "name": "custom-echoes-raw",       "schedule": { "type": "custom", "raw": "0 9 * * 1-5" }, "cron": "0 9 * * 1-5", "human": "Custom: 0 9 * * 1-5", "parse": { "ok": false } },
+    { "name": "custom-step-range",       "schedule": { "type": "custom", "raw": "*/7 9-17 * * *" }, "cron": "*/7 9-17 * * *", "human": "Custom: */7 9-17 * * *", "parse": { "ok": false } },
+    { "name": "custom-raw-is-recognized","schedule": { "type": "custom", "raw": "41 3 * * *" }, "cron": "41 3 * * *", "human": "Custom: 41 3 * * *", "parse": { "ok": true, "schedule": { "type": "daily", "hour": 3, "minute": 41 } } },
+
+    { "name": "parse-sunday-alias-7",    "cron": "0 0 * * 7",     "parse": { "ok": true,  "schedule": { "type": "weekly", "hour": 0, "minute": 0, "weekdays": [0] } } },
+    { "name": "parse-empty",             "cron": "",              "parse": { "ok": false, "schedule": { "type": "custom", "raw": "" } } },
+    { "name": "parse-garbage",           "cron": "not a cron",    "parse": { "ok": false, "schedule": { "type": "custom", "raw": "not a cron" } } },
+    { "name": "parse-six-fields",        "cron": "0 0 * * * *",   "parse": { "ok": false, "schedule": { "type": "custom", "raw": "0 0 * * * *" } } },
+    { "name": "parse-month-restricted",  "cron": "0 9 1 6 *",     "parse": { "ok": false, "schedule": { "type": "custom", "raw": "0 9 1 6 *" } } },
+    { "name": "parse-minute-list",       "cron": "0,30 * * * *",  "parse": { "ok": false, "schedule": { "type": "custom", "raw": "0,30 * * * *" } } },
+    { "name": "parse-dom-and-dow",       "cron": "0 9 1 * 1",     "parse": { "ok": false, "schedule": { "type": "custom", "raw": "0 9 1 * 1" } } }
+  ]
+}

--- a/schedule/testdata/vectors.json
+++ b/schedule/testdata/vectors.json
@@ -19,8 +19,10 @@
     { "name": "every-5-minutes", "schedule": { "type": "everyNMinutes", "interval": 5 },  "cron": "*/5 * * * *",  "human": "Every 5 minutes" },
     { "name": "every-15-minutes","schedule": { "type": "everyNMinutes", "interval": 15 }, "cron": "*/15 * * * *", "human": "Every 15 minutes" },
     { "name": "every-30-minutes","schedule": { "type": "everyNMinutes", "interval": 30 }, "cron": "*/30 * * * *", "human": "Every 30 minutes" },
+    { "name": "every-59-minutes","schedule": { "type": "everyNMinutes", "interval": 59 }, "cron": "*/59 * * * *", "human": "Every 59 minutes" },
 
     { "name": "every-1-hour",   "schedule": { "type": "everyNHours", "interval": 1 },  "cron": "0 */1 * * *",  "human": "Every hour" },
+    { "name": "every-23-hours", "schedule": { "type": "everyNHours", "interval": 23 }, "cron": "0 */23 * * *", "human": "Every 23 hours" },
     { "name": "every-2-hours",  "schedule": { "type": "everyNHours", "interval": 2 },  "cron": "0 */2 * * *",  "human": "Every 2 hours" },
     { "name": "every-6-hours",  "schedule": { "type": "everyNHours", "interval": 6 },  "cron": "0 */6 * * *",  "human": "Every 6 hours" },
     { "name": "every-12-hours", "schedule": { "type": "everyNHours", "interval": 12 }, "cron": "0 */12 * * *", "human": "Every 12 hours" },
@@ -60,6 +62,8 @@
     { "name": "custom-raw-is-recognized","schedule": { "type": "custom", "raw": "41 3 * * *" }, "cron": "41 3 * * *", "human": "Custom: 41 3 * * *", "parse": { "ok": true, "schedule": { "type": "daily", "hour": 3, "minute": 41 } } },
 
     { "name": "parse-sunday-alias-7",    "cron": "0 0 * * 7",     "parse": { "ok": true,  "schedule": { "type": "weekly", "hour": 0, "minute": 0, "weekdays": [0] } } },
+    { "name": "parse-minute-step-overflow", "cron": "*/60 * * * *", "parse": { "ok": false, "schedule": { "type": "custom", "raw": "*/60 * * * *" } } },
+    { "name": "parse-hour-step-overflow",   "cron": "0 */24 * * *", "parse": { "ok": false, "schedule": { "type": "custom", "raw": "0 */24 * * *" } } },
     { "name": "parse-empty",             "cron": "",              "parse": { "ok": false, "schedule": { "type": "custom", "raw": "" } } },
     { "name": "parse-garbage",           "cron": "not a cron",    "parse": { "ok": false, "schedule": { "type": "custom", "raw": "not a cron" } } },
     { "name": "parse-six-fields",        "cron": "0 0 * * * *",   "parse": { "ok": false, "schedule": { "type": "custom", "raw": "0 0 * * * *" } } },

--- a/ui/schedule_picker.go
+++ b/ui/schedule_picker.go
@@ -1,0 +1,608 @@
+package ui
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/sachiniyer/agent-factory/schedule"
+	"github.com/sachiniyer/agent-factory/task"
+)
+
+// schedulePicker is the friendly, cron-free editor for a time-triggered task's
+// schedule (#2057). It occupies the cron trigger's value focus stop in the task
+// form: a schedule-type selector plus only the inputs that type needs, a live
+// plain-English preview, and the generated cron shown read-only so users trust
+// what gets saved. The underlying model and cron generation live in the
+// canonical, UI-agnostic schedule package; this type is only the terminal
+// input surface over it (the phase-2 web modal is the other surface).
+//
+// Navigation is self-contained so the outer form's tab model is untouched: the
+// picker owns a single form stop and handles internal movement itself —
+// up/down moves between the visible cells, left/right adjusts the focused cell
+// (cycle the type, ±1 a number, flip AM/PM, walk the weekday row), space
+// toggles (AM/PM, a weekday), and digits type into the numeric cells. Custom
+// hands its raw-cron cell straight to a text input, restoring today's behavior.
+type schedulePicker struct {
+	typ           int    // index into scheduleTypes
+	interval      string // shared by every-N-minutes / every-N-hours
+	hourStr       string // 12-hour hour (1-12) for daily/weekly/monthly
+	minuteStr     string // minute (0-59); also minute-of-hour for hourly
+	domStr        string // day-of-month (1-31) for monthly
+	meridiemPM    bool   // false=AM, true=PM
+	weekdays      [7]bool
+	weekdayCursor int
+	raw           textinput.Model // custom cron escape hatch
+	cursor        int             // index into cells() — the focused cell
+	focused       bool
+	width         int
+}
+
+// scheduleType pairs a schedule.Type with its selector label, in selector
+// order. Custom sits last as the advanced escape hatch.
+type scheduleTypeOption struct {
+	kind  schedule.Type
+	label string
+}
+
+var scheduleTypes = []scheduleTypeOption{
+	{schedule.EveryNMinutes, "Every N minutes"},
+	{schedule.EveryNHours, "Every N hours"},
+	{schedule.Hourly, "Hourly"},
+	{schedule.Daily, "Daily"},
+	{schedule.Weekly, "Weekly"},
+	{schedule.Monthly, "Monthly"},
+	{schedule.Custom, "Custom (cron)"},
+}
+
+// Weekday toggles render Monday-first ("M T W T F S S", #2057) but map to the
+// Sunday-first time.Weekday numbering the schedule package normalizes on.
+var (
+	weekdayDisplayOrder = [7]int{1, 2, 3, 4, 5, 6, 0} // display index → time.Weekday
+	weekdayLetters      = [7]string{"M", "T", "W", "T", "F", "S", "S"}
+)
+
+// scheduleCell identifies one editable element within the picker. Which cells
+// are present depends on the selected type (see cells).
+type scheduleCell int
+
+const (
+	cellType scheduleCell = iota
+	cellInterval
+	cellHour
+	cellMinute
+	cellMeridiem
+	cellWeekdays
+	cellDayOfMonth
+	cellRaw
+)
+
+func newSchedulePicker() *schedulePicker {
+	raw := textinput.New()
+	raw.Placeholder = "e.g. 0 9 * * 1-5"
+	raw.PlaceholderStyle = taskPlaceholderStyle
+	raw.CharLimit = 64
+	raw.Blur()
+
+	p := &schedulePicker{raw: raw}
+	p.reset()
+	return p
+}
+
+// reset seeds a sensible default for a brand-new task: daily at 9:00 AM. Every
+// other type's fields also get valid defaults so switching types after this
+// never lands on an empty/invalid input.
+func (p *schedulePicker) reset() {
+	p.setType(schedule.Daily)
+	p.interval = "15"
+	p.hourStr = "9"
+	p.minuteStr = "00"
+	p.domStr = "1"
+	p.meridiemPM = false
+	p.weekdays = [7]bool{true} // Monday
+	p.weekdayCursor = 0
+	p.raw.SetValue("")
+	p.cursor = 0
+}
+
+// seed populates the picker from a Schedule parsed out of an existing task's
+// cron. It starts from reset defaults so unrelated types keep valid values,
+// then overlays the seeded type's fields. A custom schedule drops into the raw
+// editor with the original expression.
+func (p *schedulePicker) seed(sc schedule.Schedule) {
+	p.reset()
+	p.setType(sc.Type)
+	switch sc.Type {
+	case schedule.EveryNMinutes, schedule.EveryNHours:
+		if sc.Interval > 0 {
+			p.interval = strconv.Itoa(sc.Interval)
+		}
+	case schedule.Hourly:
+		p.minuteStr = fmt.Sprintf("%02d", sc.Minute)
+	case schedule.Daily:
+		p.setClockFields(sc.Hour, sc.Minute)
+	case schedule.Weekly:
+		p.setClockFields(sc.Hour, sc.Minute)
+		p.setWeekdays(sc.Weekdays)
+	case schedule.Monthly:
+		p.setClockFields(sc.Hour, sc.Minute)
+		if sc.DayOfMonth > 0 {
+			p.domStr = strconv.Itoa(sc.DayOfMonth)
+		}
+	case schedule.Custom:
+		p.raw.SetValue(sc.Raw)
+		p.raw.CursorEnd()
+	}
+	p.cursor = 0
+	p.syncRawFocus()
+}
+
+func (p *schedulePicker) setClockFields(hour24, minute int) {
+	h12, pm := to12Hour(hour24)
+	p.hourStr = strconv.Itoa(h12)
+	p.minuteStr = fmt.Sprintf("%02d", minute)
+	p.meridiemPM = pm
+}
+
+// setWeekdays lights up the toggle row for the given weekdays, mapping the
+// Sunday-first time.Weekday numbering onto the Monday-first display order.
+func (p *schedulePicker) setWeekdays(days []time.Weekday) {
+	p.weekdays = [7]bool{}
+	for _, d := range days {
+		n := int(d) % 7
+		if n < 0 {
+			n += 7
+		}
+		for i, wd := range weekdayDisplayOrder {
+			if wd == n {
+				p.weekdays[i] = true
+			}
+		}
+	}
+}
+
+// setType points the selector at t (falling back to Custom for an unknown
+// type) and keeps the cursor within the new cell set.
+func (p *schedulePicker) setType(t schedule.Type) {
+	p.typ = len(scheduleTypes) - 1 // Custom
+	for i, opt := range scheduleTypes {
+		if opt.kind == t {
+			p.typ = i
+			break
+		}
+	}
+	p.clampCursor()
+	p.syncRawFocus()
+}
+
+func (p *schedulePicker) kind() schedule.Type { return scheduleTypes[p.typ].kind }
+
+// cells returns the focusable cells for the current type, in visual order.
+func (p *schedulePicker) cells() []scheduleCell {
+	switch p.kind() {
+	case schedule.EveryNMinutes, schedule.EveryNHours:
+		return []scheduleCell{cellType, cellInterval}
+	case schedule.Hourly:
+		return []scheduleCell{cellType, cellMinute}
+	case schedule.Daily:
+		return []scheduleCell{cellType, cellHour, cellMinute, cellMeridiem}
+	case schedule.Weekly:
+		return []scheduleCell{cellType, cellHour, cellMinute, cellMeridiem, cellWeekdays}
+	case schedule.Monthly:
+		return []scheduleCell{cellType, cellHour, cellMinute, cellMeridiem, cellDayOfMonth}
+	default: // Custom
+		return []scheduleCell{cellType, cellRaw}
+	}
+}
+
+func (p *schedulePicker) clampCursor() {
+	if n := len(p.cells()); p.cursor >= n {
+		p.cursor = n - 1
+	}
+	if p.cursor < 0 {
+		p.cursor = 0
+	}
+}
+
+func (p *schedulePicker) activeCell() scheduleCell { return p.cells()[p.cursor] }
+
+// setFocused toggles whether the picker is the active form stop; it only
+// affects rendering (the active-cell highlight) and the raw input's cursor.
+func (p *schedulePicker) setFocused(focused bool) {
+	p.focused = focused
+	p.syncRawFocus()
+}
+
+func (p *schedulePicker) setWidth(width int) {
+	p.width = width
+	rawWidth := width - 8
+	if rawWidth < 1 {
+		rawWidth = 1
+	}
+	p.raw.Width = rawWidth
+}
+
+// syncRawFocus keeps the raw text input's cursor visible only while it is the
+// focused cell of a focused picker.
+func (p *schedulePicker) syncRawFocus() {
+	if p.focused && p.activeCell() == cellRaw {
+		p.raw.Focus()
+	} else {
+		p.raw.Blur()
+	}
+}
+
+// handleKey processes one key while the picker owns focus. Tab/enter/esc are
+// intercepted by the outer form before reaching here, so those still move
+// between form stops and submit as usual.
+func (p *schedulePicker) handleKey(msg tea.KeyMsg) {
+	switch msg.Type {
+	case tea.KeyUp:
+		p.moveCursor(-1)
+		return
+	case tea.KeyDown:
+		p.moveCursor(1)
+		return
+	}
+
+	// The raw cron cell is a plain text field: give it every remaining key
+	// (including left/right for the text cursor) except the up/down handled
+	// above.
+	if p.activeCell() == cellRaw {
+		p.raw, _ = p.raw.Update(msg)
+		return
+	}
+
+	switch {
+	case msg.Type == tea.KeyLeft:
+		p.adjust(-1)
+	case msg.Type == tea.KeyRight:
+		p.adjust(1)
+	case msg.Type == tea.KeySpace || msg.String() == " ":
+		p.toggle()
+	case msg.Type == tea.KeyBackspace:
+		p.editNumeric(msg)
+	case msg.Type == tea.KeyRunes:
+		p.editNumeric(msg)
+	}
+}
+
+func (p *schedulePicker) moveCursor(dir int) {
+	n := len(p.cells())
+	p.cursor = (p.cursor + dir + n) % n
+	p.syncRawFocus()
+}
+
+// adjust applies left/right to the focused cell: cycle the type, step a number,
+// flip AM/PM, or walk the weekday-row cursor.
+func (p *schedulePicker) adjust(dir int) {
+	switch p.activeCell() {
+	case cellType:
+		prev := p.toSchedule()
+		n := len(scheduleTypes)
+		p.typ = (p.typ + dir + n) % n
+		p.clampCursor()
+		// Switching into Custom prefills the raw field with the cron the
+		// previous preset generated, so the escape hatch starts from a working
+		// expression rather than blank.
+		if p.kind() == schedule.Custom && strings.TrimSpace(p.raw.Value()) == "" {
+			p.raw.SetValue(prev.Cron())
+			p.raw.CursorEnd()
+		}
+		p.syncRawFocus()
+	case cellInterval:
+		p.interval = stepNumber(p.interval, dir, 1, p.intervalMax())
+	case cellHour:
+		p.hourStr = stepNumber(p.hourStr, dir, 1, 12)
+	case cellMinute:
+		p.minuteStr = stepNumber(p.minuteStr, dir, 0, 59)
+	case cellDayOfMonth:
+		p.domStr = stepNumber(p.domStr, dir, 1, 31)
+	case cellMeridiem:
+		p.meridiemPM = !p.meridiemPM
+	case cellWeekdays:
+		p.weekdayCursor = clampInt(p.weekdayCursor+dir, 0, 6)
+	}
+}
+
+// toggle applies space to the focused cell: flip AM/PM, or toggle the weekday
+// under the row cursor.
+func (p *schedulePicker) toggle() {
+	switch p.activeCell() {
+	case cellMeridiem:
+		p.meridiemPM = !p.meridiemPM
+	case cellWeekdays:
+		p.weekdays[p.weekdayCursor] = !p.weekdays[p.weekdayCursor]
+	}
+}
+
+// editNumeric appends a typed digit to (or backspaces) the focused numeric
+// cell. Non-digit runes are ignored; values are clamped to a valid range only
+// when the schedule is materialized, so a mid-edit "7" on the way to "17" is
+// never fought.
+func (p *schedulePicker) editNumeric(msg tea.KeyMsg) {
+	field, maxLen := p.numericField()
+	if field == nil {
+		return
+	}
+	cur := *field
+	if msg.Type == tea.KeyBackspace {
+		if r := []rune(cur); len(r) > 0 {
+			cur = string(r[:len(r)-1])
+		}
+		*field = cur
+		return
+	}
+	for _, r := range msg.Runes {
+		if unicode.IsDigit(r) && len([]rune(cur)) < maxLen {
+			cur += string(r)
+		}
+	}
+	*field = cur
+}
+
+// numericField returns a pointer to the string backing the focused numeric
+// cell and its max digit length, or (nil, 0) if the focused cell is not a
+// numeric input.
+func (p *schedulePicker) numericField() (*string, int) {
+	switch p.activeCell() {
+	case cellInterval:
+		return &p.interval, 3
+	case cellHour:
+		return &p.hourStr, 2
+	case cellMinute:
+		return &p.minuteStr, 2
+	case cellDayOfMonth:
+		return &p.domStr, 2
+	default:
+		return nil, 0
+	}
+}
+
+func (p *schedulePicker) intervalMax() int {
+	if p.kind() == schedule.EveryNHours {
+		return 23
+	}
+	return 59
+}
+
+// toSchedule materializes the current picker state into a canonical Schedule,
+// clamping numeric fields into valid ranges so the generated cron is always
+// well-formed (custom raw text excepted — it is validated separately).
+func (p *schedulePicker) toSchedule() schedule.Schedule {
+	switch p.kind() {
+	case schedule.EveryNMinutes:
+		return schedule.Schedule{Type: schedule.EveryNMinutes, Interval: atoiClamp(p.interval, 1, 59, 15)}
+	case schedule.EveryNHours:
+		return schedule.Schedule{Type: schedule.EveryNHours, Interval: atoiClamp(p.interval, 1, 23, 1)}
+	case schedule.Hourly:
+		return schedule.Schedule{Type: schedule.Hourly, Minute: atoiClamp(p.minuteStr, 0, 59, 0)}
+	case schedule.Daily:
+		return schedule.Schedule{Type: schedule.Daily, Hour: p.hour24(), Minute: atoiClamp(p.minuteStr, 0, 59, 0)}
+	case schedule.Weekly:
+		return schedule.Schedule{Type: schedule.Weekly, Hour: p.hour24(), Minute: atoiClamp(p.minuteStr, 0, 59, 0), Weekdays: p.selectedWeekdays()}
+	case schedule.Monthly:
+		return schedule.Schedule{Type: schedule.Monthly, Hour: p.hour24(), Minute: atoiClamp(p.minuteStr, 0, 59, 0), DayOfMonth: atoiClamp(p.domStr, 1, 31, 1)}
+	default: // Custom
+		return schedule.Schedule{Type: schedule.Custom, Raw: strings.TrimSpace(p.raw.Value())}
+	}
+}
+
+// Cron and Describe are the values the form saves and previews; both are always
+// live off the current picker state.
+func (p *schedulePicker) Cron() string     { return p.toSchedule().Cron() }
+func (p *schedulePicker) Describe() string { return p.toSchedule().Describe() }
+
+// validate returns a user-facing error message for an unsavable schedule, or ""
+// when the schedule is valid. It enforces the picker-specific constraints
+// (a weekly needs at least one day; custom needs a non-empty, valid cron) then
+// confirms the generated expression passes the daemon's own validator — the
+// same gate the form applied to the old raw-cron field.
+func (p *schedulePicker) validate() string {
+	switch p.kind() {
+	case schedule.Custom:
+		raw := strings.TrimSpace(p.raw.Value())
+		if raw == "" {
+			return "cron expression is required"
+		}
+		if err := task.ValidateCronExpr(raw); err != nil {
+			return fmt.Sprintf("invalid cron: %v", err)
+		}
+	case schedule.Weekly:
+		if len(p.selectedWeekdays()) == 0 {
+			return "select at least one day of the week"
+		}
+	}
+	if err := task.ValidateCronExpr(p.Cron()); err != nil {
+		return fmt.Sprintf("invalid cron: %v", err)
+	}
+	return ""
+}
+
+func (p *schedulePicker) hour24() int {
+	h := atoiClamp(p.hourStr, 1, 12, 12)
+	switch {
+	case p.meridiemPM && h == 12:
+		return 12
+	case p.meridiemPM:
+		return h + 12
+	case h == 12: // 12 AM = midnight
+		return 0
+	default:
+		return h
+	}
+}
+
+func (p *schedulePicker) selectedWeekdays() []time.Weekday {
+	var days []time.Weekday
+	for i, on := range p.weekdays {
+		if on {
+			days = append(days, time.Weekday(weekdayDisplayOrder[i]))
+		}
+	}
+	return days
+}
+
+// render draws the picker block: the type selector, only the inputs the current
+// type needs, the plain-English preview, and the generated cron shown
+// read-only. Each line is clipped to the pane width; the returned block carries
+// no trailing newline (the form adds it). Sub-lines are indented so the block
+// reads as one unit under the "Schedule:" label even on a narrow terminal.
+func (p *schedulePicker) render() string {
+	t := CurrentTheme()
+	labelStyle := lipgloss.NewStyle().Bold(true)
+	dimStyle := lipgloss.NewStyle().Foreground(t.ForegroundDim)
+	previewStyle := lipgloss.NewStyle().Foreground(t.Foreground)
+	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(t.Warning)
+	dimSelectedStyle := lipgloss.NewStyle().Foreground(t.ForegroundDim)
+
+	lines := []string{labelStyle.Render("Schedule:") + " " + p.renderTypeSelector(selectedStyle, dimSelectedStyle)}
+	lines = append(lines, p.renderContextLines()...)
+	// Preview (plain-English) and the generated cron share one read-only line to
+	// keep the picker compact enough to fit an 80x24 pane; the preview leads so
+	// it survives on a narrow terminal even if the trailing cron clips.
+	lines = append(lines, indentSub+previewStyle.Render(p.Describe())+dimStyle.Render("  ·  "+p.Cron()))
+	if p.focused {
+		lines = append(lines, indentSub+dimStyle.Render(p.hint()))
+	}
+
+	for i := range lines {
+		lines[i] = fitLine(lines[i], p.width)
+	}
+	return strings.Join(lines, "\n")
+}
+
+const indentSub = "  "
+
+func (p *schedulePicker) renderTypeSelector(selected, dim lipgloss.Style) string {
+	label := scheduleTypes[p.typ].label
+	if p.focused && p.activeCell() == cellType {
+		return selected.Render("◂ " + label + " ▸")
+	}
+	return dim.Render(label)
+}
+
+// renderContextLines renders the inputs specific to the selected type.
+func (p *schedulePicker) renderContextLines() []string {
+	t := CurrentTheme()
+	plain := lipgloss.NewStyle().Foreground(t.ForegroundMuted)
+	switch p.kind() {
+	case schedule.EveryNMinutes:
+		return []string{indentSub + plain.Render("Every") + p.chip(cellInterval, p.interval) + plain.Render("minutes")}
+	case schedule.EveryNHours:
+		return []string{indentSub + plain.Render("Every") + p.chip(cellInterval, p.interval) + plain.Render("hours")}
+	case schedule.Hourly:
+		return []string{indentSub + plain.Render("At minute") + p.chip(cellMinute, p.minuteStr)}
+	case schedule.Daily:
+		return []string{indentSub + p.renderTimeLine(plain)}
+	case schedule.Weekly:
+		return []string{
+			indentSub + p.renderTimeLine(plain),
+			indentSub + plain.Render("Days") + p.renderWeekdayRow(),
+		}
+	case schedule.Monthly:
+		return []string{
+			indentSub + p.renderTimeLine(plain),
+			indentSub + plain.Render("Day") + p.chip(cellDayOfMonth, p.domStr),
+		}
+	default: // Custom
+		return []string{indentSub + plain.Render("Cron ") + p.raw.View()}
+	}
+}
+
+func (p *schedulePicker) renderTimeLine(plain lipgloss.Style) string {
+	meridiem := "AM"
+	if p.meridiemPM {
+		meridiem = "PM"
+	}
+	return plain.Render("At") + p.chip(cellHour, p.hourStr) + plain.Render(":") +
+		p.chip(cellMinute, p.minuteStr) + p.chip(cellMeridiem, meridiem)
+}
+
+func (p *schedulePicker) renderWeekdayRow() string {
+	t := CurrentTheme()
+	active := p.focused && p.activeCell() == cellWeekdays
+	var b strings.Builder
+	for i, letter := range weekdayLetters {
+		style := lipgloss.NewStyle().Foreground(t.ForegroundMuted)
+		if p.weekdays[i] {
+			style = lipgloss.NewStyle().Foreground(t.Warning).Bold(true)
+		}
+		if active && i == p.weekdayCursor {
+			style = style.Reverse(true)
+		}
+		b.WriteString(style.Render(" " + letter + " "))
+	}
+	return b.String()
+}
+
+// chip renders one value cell, highlighting it when it is the focused cell of a
+// focused picker (matching the form's focused-button treatment).
+func (p *schedulePicker) chip(cell scheduleCell, text string) string {
+	t := CurrentTheme()
+	if strings.TrimSpace(text) == "" {
+		text = " "
+	}
+	style := lipgloss.NewStyle().Foreground(t.Foreground)
+	if p.focused && p.activeCell() == cell {
+		style = lipgloss.NewStyle().Bold(true).Background(t.Accent).Foreground(t.Background)
+	}
+	return style.Render(" " + text + " ")
+}
+
+// hint is the picker's one-line internal-navigation help, tailored to the
+// focused cell. The form's own footer still shows tab/enter/esc.
+func (p *schedulePicker) hint() string {
+	switch p.activeCell() {
+	case cellRaw:
+		return "type cron • ↑/↓ fields • tab next"
+	case cellWeekdays:
+		return "←/→ day • space toggle • ↑/↓ fields"
+	case cellType, cellMeridiem:
+		return "←/→ change • ↑/↓ fields • tab next"
+	default:
+		return "type or ←/→ • ↑/↓ fields • tab next"
+	}
+}
+
+// stepNumber parses cur (falling back to min when unset/invalid), moves it by
+// dir, and wraps within [min,max] so the arrow keys cycle rather than dead-end.
+func stepNumber(cur string, dir, min, max int) string {
+	v, err := strconv.Atoi(strings.TrimSpace(cur))
+	if err != nil {
+		v = min
+	}
+	span := max - min + 1
+	v = min + ((v-min+dir)%span+span)%span
+	return strconv.Itoa(v)
+}
+
+// atoiClamp parses s and clamps it into [min,max], returning def when s is
+// unset or non-numeric.
+func atoiClamp(s string, min, max, def int) int {
+	v, err := strconv.Atoi(strings.TrimSpace(s))
+	if err != nil {
+		return def
+	}
+	return clampInt(v, min, max)
+}
+
+// to12Hour converts a 24-hour hour into a 12-hour hour and an isPM flag.
+func to12Hour(hour24 int) (int, bool) {
+	switch {
+	case hour24 == 0:
+		return 12, false
+	case hour24 == 12:
+		return 12, true
+	case hour24 > 12:
+		return hour24 - 12, true
+	default:
+		return hour24, false
+	}
+}

--- a/ui/schedule_picker_test.go
+++ b/ui/schedule_picker_test.go
@@ -1,0 +1,291 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/sachiniyer/agent-factory/schedule"
+	"github.com/sachiniyer/agent-factory/task"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func keyType(kt tea.KeyType) tea.KeyMsg { return tea.KeyMsg{Type: kt} }
+func keyRunes(s string) tea.KeyMsg      { return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)} }
+
+// TestSchedulePickerDefaultIsDailyNineAM pins the friendly default a brand-new
+// task opens on: daily at 9:00 AM, a valid cron with no typing required.
+func TestSchedulePickerDefaultIsDailyNineAM(t *testing.T) {
+	p := newSchedulePicker()
+	assert.Equal(t, "0 9 * * *", p.Cron())
+	assert.Equal(t, "Every day at 9:00 AM", p.Describe())
+	assert.Equal(t, "", p.validate(), "the default schedule must be savable")
+}
+
+// TestSchedulePickerSeedsMatchingPreset verifies an existing task's cron
+// re-opens on its matching preset, and an unrecognized expression falls back to
+// Custom with the raw cron preserved (#2057).
+func TestSchedulePickerSeedsMatchingPreset(t *testing.T) {
+	cases := []struct {
+		cron     string
+		wantKind schedule.Type
+		wantDesc string
+	}{
+		{"*/15 * * * *", schedule.EveryNMinutes, "Every 15 minutes"},
+		{"0 */2 * * *", schedule.EveryNHours, "Every 2 hours"},
+		{"5 * * * *", schedule.Hourly, "Every hour at :05"},
+		{"41 15 * * *", schedule.Daily, "Every day at 3:41 PM"},
+		{"0 9 * * 1,3", schedule.Weekly, "Every week on Mon, Wed at 9:00 AM"},
+		{"30 14 15 * *", schedule.Monthly, "Every month on the 15th at 2:30 PM"},
+		{"0 9 * * 1-5", schedule.Custom, "Custom: 0 9 * * 1-5"},
+	}
+	for _, c := range cases {
+		t.Run(c.cron, func(t *testing.T) {
+			p := newSchedulePicker()
+			sc, _ := schedule.ParseCron(c.cron)
+			p.seed(sc)
+			assert.Equal(t, c.wantKind, p.kind())
+			assert.Equal(t, c.wantDesc, p.Describe())
+			// The generated cron must round-trip the seeded expression exactly,
+			// so re-saving an untouched task never rewrites its schedule.
+			assert.Equal(t, c.cron, p.Cron(), "seeded cron must round-trip losslessly")
+		})
+	}
+}
+
+// TestSchedulePickerSeedLightsWeekdayToggles checks a weekly seed turns on the
+// exact day toggles (Monday-first display order).
+func TestSchedulePickerSeedLightsWeekdayToggles(t *testing.T) {
+	p := newSchedulePicker()
+	sc, ok := schedule.ParseCron("0 9 * * 1,3")
+	require.True(t, ok)
+	p.seed(sc)
+	// Display order is M T W T F S S -> Monday=index 0, Wednesday=index 2.
+	assert.True(t, p.weekdays[0], "Monday toggle on")
+	assert.True(t, p.weekdays[2], "Wednesday toggle on")
+	assert.False(t, p.weekdays[1], "Tuesday toggle off")
+	assert.False(t, p.weekdays[6], "Sunday toggle off")
+}
+
+// TestSchedulePickerRenderShowsSelectorInputsPreviewCron is the core visible
+// contract: the block renders the type selector, the contextual inputs, the
+// plain-English preview, and the generated cron read-only.
+func TestSchedulePickerRenderShowsSelectorInputsPreviewCron(t *testing.T) {
+	p := newSchedulePicker()
+	p.setWidth(80)
+	p.setFocused(true)
+	out := p.render()
+	assert.Contains(t, out, "Schedule:", "type-selector label")
+	assert.Contains(t, out, "Daily", "the selected type")
+	assert.Contains(t, out, "AM", "the contextual time input")
+	assert.Contains(t, out, "Every day at 9:00 AM", "the plain-English preview")
+	assert.Contains(t, out, "0 9 * * *", "the generated cron shown read-only")
+}
+
+// TestSchedulePickerRenderWeeklyShowsDayRow verifies the weekly type reveals the
+// day-of-week toggle row and its own preview.
+func TestSchedulePickerRenderWeeklyShowsDayRow(t *testing.T) {
+	p := newSchedulePicker()
+	sc, _ := schedule.ParseCron("0 9 * * 1,3")
+	p.seed(sc)
+	p.setWidth(80)
+	p.setFocused(true)
+	out := p.render()
+	assert.Contains(t, out, "Weekly")
+	assert.Contains(t, out, "Days", "weekly reveals the day-of-week row")
+	assert.Contains(t, out, "Every week on Mon, Wed at 9:00 AM")
+}
+
+// TestSchedulePickerRenderNarrowDoesNotPanic guards the small-terminal path:
+// the block still renders (with the preview leading) at a cramped width.
+func TestSchedulePickerRenderNarrowDoesNotPanic(t *testing.T) {
+	p := newSchedulePicker()
+	sc, _ := schedule.ParseCron("30 8 * * 1,2,3,4,5")
+	p.seed(sc)
+	for _, w := range []int{10, 20, 40} {
+		p.setWidth(w)
+		p.setFocused(true)
+		assert.NotPanics(t, func() {
+			out := p.render()
+			assert.Contains(t, out, "Schedule:")
+		})
+	}
+}
+
+// TestSchedulePickerTypeSwitchChangesCron drives the type selector with the
+// arrow keys and confirms the generated cron follows the chosen shape.
+func TestSchedulePickerTypeSwitchChangesCron(t *testing.T) {
+	p := newSchedulePicker() // Daily, cursor on the type cell
+	p.setFocused(true)
+	p.handleKey(keyType(tea.KeyRight)) // Daily -> Weekly
+	assert.Equal(t, schedule.Weekly, p.kind())
+	assert.Equal(t, "0 9 * * 1", p.Cron(), "weekly keeps the 9:00 AM time on the default Monday")
+
+	p.handleKey(keyType(tea.KeyRight)) // Weekly -> Monthly
+	assert.Equal(t, schedule.Monthly, p.kind())
+	assert.Equal(t, "0 9 1 * *", p.Cron())
+}
+
+// TestSchedulePickerNumericAndMeridiemEntry drives the daily contextual inputs:
+// move to the hour/minute cells, type values, and flip AM->PM.
+func TestSchedulePickerNumericAndMeridiemEntry(t *testing.T) {
+	p := newSchedulePicker() // Daily
+	p.setFocused(true)
+
+	p.handleKey(keyType(tea.KeyDown))      // type -> hour
+	p.handleKey(keyType(tea.KeyBackspace)) // clear "9"
+	p.handleKey(keyRunes("3"))
+	p.handleKey(keyType(tea.KeyDown))      // hour -> minute
+	p.handleKey(keyType(tea.KeyBackspace)) // clear "00" -> "0"
+	p.handleKey(keyType(tea.KeyBackspace)) // -> ""
+	p.handleKey(keyRunes("45"))
+	p.handleKey(keyType(tea.KeyDown))  // minute -> meridiem
+	p.handleKey(keyType(tea.KeySpace)) // AM -> PM
+
+	assert.Equal(t, "45 15 * * *", p.Cron())
+	assert.Equal(t, "Every day at 3:45 PM", p.Describe())
+}
+
+// TestSchedulePickerWeekdayCursorAndToggle walks the weekday row and toggles a
+// second day on with space.
+func TestSchedulePickerWeekdayCursorAndToggle(t *testing.T) {
+	p := newSchedulePicker()
+	p.setFocused(true)
+	p.handleKey(keyType(tea.KeyRight)) // Daily -> Weekly (Monday on by default)
+
+	// Move to the weekday row: type -> hour -> minute -> meridiem -> weekdays.
+	for i := 0; i < 4; i++ {
+		p.handleKey(keyType(tea.KeyDown))
+	}
+	assert.Equal(t, cellWeekdays, p.activeCell())
+	p.handleKey(keyType(tea.KeyRight)) // Mon -> Tue
+	p.handleKey(keyType(tea.KeyRight)) // Tue -> Wed
+	p.handleKey(keyType(tea.KeySpace)) // toggle Wed on
+
+	assert.Equal(t, "0 9 * * 1,3", p.Cron())
+	assert.Equal(t, "Every week on Mon, Wed at 9:00 AM", p.Describe())
+}
+
+// TestSchedulePickerWeeklyRequiresDay confirms a weekly schedule with every day
+// toggled off is rejected with a friendly message rather than an invalid cron.
+func TestSchedulePickerWeeklyRequiresDay(t *testing.T) {
+	p := newSchedulePicker()
+	p.setFocused(true)
+	p.handleKey(keyType(tea.KeyRight)) // -> Weekly, Monday on
+
+	for i := 0; i < 4; i++ {
+		p.handleKey(keyType(tea.KeyDown)) // -> weekday row, cursor on Monday
+	}
+	p.handleKey(keyType(tea.KeySpace)) // toggle Monday off -> no days
+
+	assert.Equal(t, "select at least one day of the week", p.validate())
+}
+
+// TestSchedulePickerCustomAcceptsAndValidatesRaw checks the escape hatch: the
+// Custom cell edits like the old raw-cron field and runs the same validator.
+func TestSchedulePickerCustomAcceptsAndValidatesRaw(t *testing.T) {
+	p := newSchedulePicker()
+	p.setType(schedule.Custom)
+	p.raw.SetValue("")
+	assert.Equal(t, "cron expression is required", p.validate())
+
+	p.raw.SetValue("bogus cron")
+	assert.Contains(t, p.validate(), "invalid cron")
+
+	p.raw.SetValue("0 9 * * 1-5")
+	assert.Equal(t, "", p.validate())
+	assert.Equal(t, "0 9 * * 1-5", p.Cron())
+}
+
+// TestSchedulePickerSwitchToCustomPrefillsCron verifies switching into Custom
+// seeds the raw field with the immediately-previous preset's cron, so the
+// escape hatch starts from a working expression.
+func TestSchedulePickerSwitchToCustomPrefillsCron(t *testing.T) {
+	p := newSchedulePicker() // Daily
+	p.setFocused(true)
+	// Daily(3) -> Weekly -> Monthly -> Custom(6): three rights. Monthly is the
+	// last preset before Custom, so its cron is what prefills.
+	for i := 0; i < 3; i++ {
+		p.handleKey(keyType(tea.KeyRight))
+	}
+	require.Equal(t, schedule.Custom, p.kind())
+	assert.Equal(t, "0 9 1 * *", strings.TrimSpace(p.raw.Value()),
+		"custom prefills with the immediately-previous preset's cron")
+}
+
+// TestTaskPaneCreateSavesGeneratedCron drives a full create with the default
+// schedule and confirms the pending create carries the generated cron.
+func TestTaskPaneCreateSavesGeneratedCron(t *testing.T) {
+	tp := NewTaskPane()
+	tp.EnterCreateMode(newGitRepo(t))
+	fillCreateForm(t, tp, "nightly")
+
+	tabTo(tp, taskFocusSave)
+	tp.HandleKeyPress(keyType(tea.KeyEnter))
+
+	require.True(t, tp.HasPendingCreate(), "a valid schedule must submit")
+	_, _, cron, watch, _, _, _ := tp.ConsumePendingCreate()
+	assert.Equal(t, "0 9 * * *", cron, "the default daily schedule's cron is saved")
+	assert.Equal(t, "", watch)
+}
+
+// TestTaskPaneEditSeedsPresetAndPreservesCron opens an existing weekly task,
+// asserts the form seeds the matching preview, and confirms re-saving without
+// changes round-trips the cron unchanged.
+func TestTaskPaneEditSeedsPresetAndPreservesCron(t *testing.T) {
+	tp := NewTaskPane()
+	tp.SetSize(80, 24)
+	tp.SetTasks([]task.Task{{
+		ID:          "wk",
+		Name:        "weekly-standup",
+		Prompt:      "stand up",
+		CronExpr:    "0 9 * * 1,3",
+		ProjectPath: newGitRepo(t),
+		Enabled:     true,
+	}})
+	tp.SetFocus(true)
+	tp.HandleKeyPress(keyType(tea.KeyEnter)) // enter edit mode
+	require.True(t, tp.IsEditing())
+
+	assert.Contains(t, tp.String(), "Every week on Mon, Wed at 9:00 AM",
+		"an existing cron seeds the matching preset preview")
+
+	tabTo(tp, taskFocusCount-1) // walk to Save
+	tp.HandleKeyPress(keyType(tea.KeyEnter))
+
+	require.False(t, tp.IsEditing(), "save exits edit mode")
+	assert.Equal(t, "0 9 * * 1,3", tp.GetTasks()[0].CronExpr,
+		"re-saving an untouched schedule must not rewrite its cron")
+}
+
+// TestTaskPaneEditChangeScheduleTypeUpdatesCron seeds an every-15-minutes task,
+// switches the type to daily through the picker, and confirms the saved cron
+// follows the new schedule.
+func TestTaskPaneEditChangeScheduleTypeUpdatesCron(t *testing.T) {
+	tp := NewTaskPane()
+	tp.SetSize(80, 24)
+	tp.SetTasks([]task.Task{{
+		ID:          "iv",
+		Name:        "poller",
+		Prompt:      "poll",
+		CronExpr:    "*/15 * * * *",
+		ProjectPath: newGitRepo(t),
+		Enabled:     true,
+	}})
+	tp.SetFocus(true)
+	tp.HandleKeyPress(keyType(tea.KeyEnter)) // edit mode, focus on Name
+	require.True(t, tp.IsEditing())
+
+	tabTo(tp, taskFocusTriggerValue) // into the schedule picker (on the type cell)
+	// EveryNMinutes(0) -> Daily(3): three rights.
+	for i := 0; i < 3; i++ {
+		tp.HandleKeyPress(keyType(tea.KeyRight))
+	}
+	tabTo(tp, taskFocusCount-1-taskFocusTriggerValue) // walk to Save
+	tp.HandleKeyPress(keyType(tea.KeyEnter))
+
+	require.False(t, tp.IsEditing())
+	assert.Equal(t, "0 9 * * *", tp.GetTasks()[0].CronExpr,
+		"switching the schedule type rewrites the stored cron")
+}

--- a/ui/task_pane.go
+++ b/ui/task_pane.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/sachiniyer/agent-factory/schedule"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 	"github.com/sachiniyer/agent-factory/task"
 
@@ -60,10 +61,13 @@ type TaskPane struct {
 	// selector back and forth never loses typed input; save resolves to
 	// exactly one via triggerValues.
 	editTriggerIsWatch bool
-	editCron           textinput.Model
-	editWatch          textinput.Model
-	editTarget         textinput.Model
-	editPath           textinput.Model
+	// schedule is the friendly cron-free picker that replaces the raw-cron
+	// input for a time trigger (#2057). It owns the generated cron; editWatch
+	// stays the plain command input for a watch trigger.
+	schedule   *schedulePicker
+	editWatch  textinput.Model
+	editTarget textinput.Model
+	editPath   textinput.Model
 	// Program selector state. editProgramOptions is the list of choices shown
 	// inline (index 0 is always the "use config default" entry, followed by
 	// tmux.SupportedPrograms). Per-task Program is restricted to the agent
@@ -140,14 +144,10 @@ func (s *TaskPane) initForm(tsk *task.Task, defaultPath string) {
 	prompt.CharLimit = 0
 	prompt.MaxHeight = 0
 
-	// The cron placeholder is an EXAMPLE, not a prefilled value: the "e.g."
-	// prefix plus the faint placeholder style keep it visually distinct from
-	// typed input, so an untouched field reads as empty (play-test on #1096).
-	cron := textinput.New()
-	cron.Placeholder = "e.g. 0 9 * * 1-5"
-	cron.PlaceholderStyle = taskPlaceholderStyle
-	cron.CharLimit = 64
-	cron.Blur()
+	// The time trigger is edited through the friendly schedule picker (#2057)
+	// rather than a raw-cron field; the picker generates the cron the store
+	// still persists. It is seeded below from the task's existing cron.
+	picker := newSchedulePicker()
 
 	watch := textinput.New()
 	watch.Placeholder = "long-running cmd; 1 stdout line = 1 event"
@@ -169,12 +169,18 @@ func (s *TaskPane) initForm(tsk *task.Task, defaultPath string) {
 	if tsk != nil {
 		name.SetValue(tsk.Name)
 		prompt.SetValue(tsk.Prompt)
-		cron.SetValue(tsk.CronExpr)
 		watch.SetValue(tsk.WatchCmd)
 		target.SetValue(tsk.TargetSession)
 		path.SetValue(tsk.ProjectPath)
 		s.editTriggerIsWatch = tsk.IsWatch()
 		s.setProgramFromValue(tsk.Program)
+		// Re-open an existing time trigger on its matching preset when the cron
+		// maps cleanly; otherwise ParseCron falls back to Custom with the raw
+		// expression shown, so nothing is lost (#2057).
+		if !s.editTriggerIsWatch && strings.TrimSpace(tsk.CronExpr) != "" {
+			sc, _ := schedule.ParseCron(tsk.CronExpr)
+			picker.seed(sc)
+		}
 	} else {
 		path.SetValue(defaultPath)
 		s.editTriggerIsWatch = false
@@ -183,7 +189,7 @@ func (s *TaskPane) initForm(tsk *task.Task, defaultPath string) {
 
 	s.editName = name
 	s.editPrompt = prompt
-	s.editCron = cron
+	s.schedule = picker
 	s.editWatch = watch
 	s.editTarget = target
 	s.editPath = path
@@ -253,7 +259,7 @@ func (s *TaskPane) triggerValues() (cron, watch string) {
 	if s.editTriggerIsWatch {
 		return "", strings.TrimSpace(s.editWatch.Value())
 	}
-	return strings.TrimSpace(s.editCron.Value()), ""
+	return s.schedule.Cron(), ""
 }
 
 // HasPendingCreate returns true if a new task was submitted and needs saving.

--- a/ui/task_pane_edit.go
+++ b/ui/task_pane_edit.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/session/git"
-	"github.com/sachiniyer/agent-factory/task"
 )
 
 // validateForm enforces the shared create/edit form contract, mirroring
@@ -30,12 +29,11 @@ func (s *TaskPane) validateForm() (string, int) {
 			return "watch command is required", taskFocusTriggerValue
 		}
 	} else {
-		cron := strings.TrimSpace(s.editCron.Value())
-		if cron == "" {
-			return "cron expression is required", taskFocusTriggerValue
-		}
-		if err := task.ValidateCronExpr(cron); err != nil {
-			return fmt.Sprintf("invalid cron: %v", err), taskFocusTriggerValue
+		// The schedule picker owns the generated cron and its own validation
+		// (a weekly needs a day, custom needs a valid expression); it round-
+		// trips the same task.ValidateCronExpr gate the raw field used (#2057).
+		if msg := s.schedule.validate(); msg != "" {
+			return msg, taskFocusTriggerValue
 		}
 		if strings.TrimSpace(s.editPrompt.Value()) == "" {
 			return "prompt must be non-empty", taskFocusPrompt
@@ -148,7 +146,7 @@ func (s *TaskPane) handleEditMode(msg tea.KeyMsg) bool {
 			if s.editTriggerIsWatch {
 				s.editWatch, _ = s.editWatch.Update(msg)
 			} else {
-				s.editCron, _ = s.editCron.Update(msg)
+				s.schedule.handleKey(msg)
 			}
 		case taskFocusPrompt:
 			s.editPrompt, _ = s.editPrompt.Update(msg)
@@ -197,10 +195,12 @@ func (s *TaskPane) handleProgramKey(msg tea.KeyMsg) {
 func (s *TaskPane) updateEditFocus() {
 	s.editName.Blur()
 	s.editPrompt.Blur()
-	s.editCron.Blur()
 	s.editWatch.Blur()
 	s.editTarget.Blur()
 	s.editPath.Blur()
+	// The schedule picker is active only while it is the focused trigger value
+	// on a cron task; blur it otherwise so its raw-cron cursor stays hidden.
+	s.schedule.setFocused(s.focusIndex == taskFocusTriggerValue && !s.editTriggerIsWatch)
 
 	switch s.focusIndex {
 	case taskFocusName:
@@ -208,8 +208,6 @@ func (s *TaskPane) updateEditFocus() {
 	case taskFocusTriggerValue:
 		if s.editTriggerIsWatch {
 			s.editWatch.Focus()
-		} else {
-			s.editCron.Focus()
 		}
 	case taskFocusPrompt:
 		s.editPrompt.Focus()
@@ -250,7 +248,7 @@ func (s *TaskPane) renderEditMode() string {
 	if s.height > 0 {
 		s.editPrompt.SetHeight(s.height / 4)
 	}
-	s.editCron.Width = inputWidth
+	s.schedule.setWidth(s.width)
 	s.editWatch.Width = inputWidth
 	s.editTarget.Width = inputWidth
 	s.editPath.Width = inputWidth
@@ -325,8 +323,9 @@ func (s *TaskPane) renderEditMode() string {
 		b.WriteString(label("Watch:"))
 		b.WriteString(s.editWatch.View())
 	} else {
-		b.WriteString(label("Cron:"))
-		b.WriteString(s.editCron.View())
+		// The picker renders its own multi-line block (type selector,
+		// contextual inputs, preview, read-only cron) in place of the raw field.
+		b.WriteString(s.schedule.render())
 	}
 	b.WriteString("\n")
 	b.WriteString(fieldErr(taskFocusTriggerValue))

--- a/ui/task_pane_test.go
+++ b/ui/task_pane_test.go
@@ -9,6 +9,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/sachiniyer/agent-factory/keys"
+	"github.com/sachiniyer/agent-factory/schedule"
 	"github.com/sachiniyer/agent-factory/task"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -344,16 +345,15 @@ func tabTo(tp *TaskPane, presses int) {
 	}
 }
 
-// fillCreateForm types a name, cron expression, and prompt into the create
-// form (the trigger selector defaults to cron) so submitting via the Save
-// button doesn't trip validation. Leaves focus back on index 0 (Name) so
-// callers can walk to whichever field they want to drive next.
+// fillCreateForm types a name and prompt into the create form (the trigger
+// selector defaults to cron) so submitting via the Save button doesn't trip
+// validation. The schedule picker seeds a valid default (daily at 9:00 AM), so
+// the cron trigger needs no input to be savable (#2057). Leaves focus back on
+// index 0 (Name) so callers can walk to whichever field they want to drive next.
 func fillCreateForm(t *testing.T, tp *TaskPane, name string) {
 	t.Helper()
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(name)})
-	tabTo(tp, 2) // name -> trigger selector (cron stays selected) -> cron value
-	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("* * * * *")})
-	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> prompt
+	tabTo(tp, taskFocusPrompt) // name -> trigger selector -> schedule picker -> prompt
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("do something")})
 	// Walk back to name (index 0) so callers can navigate forward consistently.
 	for i := 0; i < taskFocusPrompt; i++ {
@@ -888,21 +888,27 @@ func TestTaskPaneCreateModeInactiveTriggerNotSaved(t *testing.T) {
 	assert.Equal(t, "tail -F log", watchCmd)
 }
 
-// TestTaskPaneCreateModeRejectsEmptyCron covers the cron half of the trigger
-// contract: submitting a cron-type task with no expression must surface an
-// inline error under the trigger field instead of creating an unfireable task.
-func TestTaskPaneCreateModeRejectsEmptyCron(t *testing.T) {
+// TestTaskPaneCreateModeRejectsEmptyCustomCron covers the surviving empty-cron
+// path: a preset schedule always generates a valid cron, but the Custom escape
+// hatch can be emptied. Submitting Custom with a blank expression must surface
+// the inline error under the trigger field instead of creating an unfireable
+// task (#2057).
+func TestTaskPaneCreateModeRejectsEmptyCustomCron(t *testing.T) {
 	tp := NewTaskPane()
 	tp.EnterCreateMode("/tmp/repo")
 
-	// Name and prompt only — no cron expression.
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("untriggered")})
 	tabTo(tp, taskFocusPrompt)
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("do something")})
+
+	// Drop the schedule into Custom and clear the raw expression.
+	tp.schedule.setType(schedule.Custom)
+	tp.schedule.raw.SetValue("")
+
 	tabTo(tp, taskFocusSave-taskFocusPrompt)
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
 
-	assert.False(t, tp.HasPendingCreate(), "no trigger must not produce a pending create")
+	assert.False(t, tp.HasPendingCreate(), "empty custom cron must not produce a pending create")
 	assert.True(t, tp.IsCreating(), "form must stay open so user can fix the error")
 	assert.Equal(t, "cron expression is required", tp.editError)
 	assert.Equal(t, taskFocusTriggerValue, tp.editErrorField)
@@ -1278,21 +1284,22 @@ func TestTaskPaneSetTasksClearsPendingCreateButKeepsPendingTrigger(t *testing.T)
 // TestTaskPaneCreateModeEnterMovesFocusToInvalidField: submitting an invalid
 // form from any field surfaces the inline error AND moves focus to the
 // offending field, so the error is in view even when the clamped form has it
-// scrolled off-screen (#1098).
+// scrolled off-screen (#1098). The schedule picker seeds a valid default cron,
+// so the first offending field for a name-only form is now the empty prompt.
 func TestTaskPaneCreateModeEnterMovesFocusToInvalidField(t *testing.T) {
 	repo := newGitRepo(t)
 	tp := NewTaskPane()
 	tp.SetSize(80, 24)
 	tp.EnterCreateMode(repo)
-	// Name typed, cron left empty.
+	// Name typed, prompt left empty (the schedule defaults to a valid cron).
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("half-filled")})
 
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
 	assert.True(t, tp.creating, "invalid form must not submit")
 	assert.False(t, tp.pendingCreate)
-	assert.Equal(t, "cron expression is required", tp.editError)
-	assert.Equal(t, taskFocusTriggerValue, tp.editErrorField)
-	assert.Equal(t, taskFocusTriggerValue, tp.focusIndex,
+	assert.Equal(t, "prompt must be non-empty", tp.editError)
+	assert.Equal(t, taskFocusPrompt, tp.editErrorField)
+	assert.Equal(t, taskFocusPrompt, tp.focusIndex,
 		"focus must land on the offending field")
 }
 

--- a/ui/task_pane_test.go
+++ b/ui/task_pane_test.go
@@ -871,10 +871,10 @@ func TestTaskPaneConsumeDeletedClearsState(t *testing.T) {
 func TestTaskPaneCreateModeInactiveTriggerNotSaved(t *testing.T) {
 	tp := NewTaskPane()
 	tp.EnterCreateMode(newGitRepo(t))
-	fillCreateForm(t, tp, "both") // name, cron, prompt — cron type selected
+	fillCreateForm(t, tp, "both") // name + prompt; schedule picker holds its default
 
-	// Flip the trigger type to watch and fill the watch command. The cron
-	// buffer still holds "* * * * *".
+	// Flip the trigger type to watch and fill the watch command. The schedule
+	// picker still holds its default cron, but the watch selection must win.
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> trigger selector
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRight})
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> watch value


### PR DESCRIPTION
Phase 1 of #2057 — replace the raw-cron field in the task create/edit form with a **preset schedule picker** that generates cron underneath. Interaction model is the one Sachin chose: **preset schedule types + contextual inputs** (not a visual builder, not natural-language). Cron stays the stored/wire format — **no change to the daemon scheduler, cron validation, or persistence**; existing tasks keep working and `Custom (cron)` remains the advanced escape hatch. Web is **phase 2** and is untouched here.

## Part A — canonical `schedule` package

The single source of truth both surfaces drive (UI-agnostic, no `task`/`ui` deps in production code):

- `Schedule{Type, Interval, Hour, Minute, Weekdays []time.Weekday, DayOfMonth, Raw}` where `Type ∈ {everyNMinutes, everyNHours, hourly, daily, weekly, monthly, custom}`. `Hour` is 24-hour; the 12h AM/PM presentation lives in `Describe`/the UI.
- `(Schedule).Cron()` — generates the exact shapes: `*/n * * * *`, `0 */n * * *`, `min * * * *`, `m h * * *`, `m h * * <days>`, `m h dom * *`, and Custom → `Raw` verbatim.
- `ParseCron(expr) (Schedule, bool)` — **best-effort**: recognizes only the shapes we emit (plus the Sunday-alias `7`), returning that structured preset with `ok=true`; anything else → `{Custom, Raw}` with `ok=false` so the UI knows it's a fallback. It deliberately does not parse arbitrary cron.
- `(Schedule).Describe()` — plain-English preview: `Every 15 minutes`, `Every hour at :05`, `Every day at 3:41 PM`, `Every week on Mon, Wed at 9:00 AM`, `Every month on the 1st at 12:00 AM`, `Custom: 41 3 * * *`.

## Part B — shared test vectors (prevents TUI/web drift)

`schedule/testdata/vectors.json` is an array of `{schedule, cron, human, parse}` entries covering every type + edge cases (midnight/noon, single vs multiple weekdays, every-1-minute, ordinals 1st/2nd/3rd/11th/21st, unrecognized fallbacks). The Go tests load it and assert `Cron()`, `Describe()`, and `ParseCron()` round-trips; the file is designed so the **phase-2 web tests load the exact same file** — the #1970 shared-source-of-truth pattern. The Go tests additionally round-trip every generated preset cron through the repo's existing `task.ValidateCronExpr` / `task.ParseCron`, so the picker can't emit anything the daemon would reject.

## Part C — the TUI task form

`ui/schedule_picker.go` renders a schedule-type selector, only the inputs each type needs (interval · 12h hour:minute AM/PM · M T W T F S S weekday toggles · day-of-month · raw cron for Custom), a **live `Describe()` preview**, and the **generated cron read-only**. The picker owns a single form focus stop and navigates itself — `↑/↓` between cells, `←/→` adjust (cycle type / ±number / flip AM·PM / walk the weekday row), space toggles, digits type — so the outer form's tab model, the `#782` exactly-one-trigger contract, and the `#1098` height-clamping are all untouched. Editing seeds the form via `ParseCron(task.cron)` (matching preset if clean, else Custom with the raw shown); submit stores `Schedule.Cron()`. It's compact enough to fit an 80x24 pane and degrades preview-first on narrow terminals.

## Tests

- `schedule/`: table + shared-vector tests for `Cron`, `Describe`, `ParseCron` round-trips, unrecognized→Custom fallback, and validation through the daemon's validator.
- `ui/`: picker unit tests (default, seeding→preset, weekday toggles, numeric/meridiem entry, type-switch, weekly-requires-a-day, Custom validation, narrow-width no-panic) plus form-integration tests (default schedule saves its cron, an existing cron seeds the matching preset, changing type rewrites the stored cron). Updated the three existing task-form tests whose premises changed (a cron task now always has a valid default schedule; the form is a few lines taller).
- `gofmt` / `go build ./...` / `golangci-lint --fast` / `deadcode -test ./...` / file-length lint all clean; `go test ./schedule/... ./ui/... ./task/...` green.

## Gate

This is a **visible TUI change**, so it needs a play-test on the real rendered form (80x24 + narrower) before merge — that's yours to run. Draft until then.

## Phase 2 (follow-up)

The web modal mirrors this proven model in TS and loads the **same** `schedule/testdata/vectors.json`, keeping the two implementations honest.

— Captain Claude