### PR TITLE
refactor(session): split Tab name (the handle) from label (presentation-only) (#1986)

### DIFF
--- a/api/sessions_tabs.go
+++ b/api/sessions_tabs.go
@@ -134,7 +134,10 @@ var sessionsTabDeleteCmd = &cobra.Command{
 The tab is removed from the daemon's session state and its tmux window is
 killed. The removal is persistent: the daemon will not respawn the tab, and it
 does not return on a daemon/af restart. The name to pass is the tab name
-tab-create printed (also visible in the TUI tab bar).
+tab-create printed, as reported by "af sessions get" — not the label the TUI
+tab bar shows, which is a fixed "Agent"/"Terminal" for agent and shell tabs. A
+miss lists the tabs that exist, with those labels, so a wrong name is a next
+step rather than a dead end.
 
 The agent tab can't be deleted — use "af sessions kill" to tear down the whole
 session. Deleting a tab or session that doesn't exist is an error, not a

--- a/daemon/close_tab_test.go
+++ b/daemon/close_tab_test.go
@@ -592,17 +592,23 @@ func TestRPCClients_CloseTab_RoundTrip(t *testing.T) {
 	// set_prinfo_test.go.
 }
 
-// TestCloseTab_AcceptsTheLabelTheTUIDisplays is #1984, reported by hand:
+// TestCloseTab_RefusesTheDisplayedLabelButNamesTheTab is the #1986 flip of the
+// original #1984 report:
 //
 //	$ af sessions tab-delete alpha --name Terminal
-//	session "alpha" has no tab named "Terminal"      # the tab bar SAYS "Terminal"
+//	session "alpha" has no tab named "Terminal"; its tabs are: … "shell" (shown as "Terminal")
 //	$ af sessions tab-delete alpha --name shell
 //	# works
 //
-// The TUI renders a LABEL and CloseTab demanded the canonical NAME, so a user
-// read "Terminal" off the screen, typed it, and was told a tab they could see
-// did not exist. The label is now accepted as an alias.
-func TestCloseTab_AcceptsTheLabelTheTUIDisplays(t *testing.T) {
+// #1937 first closed the #1984 gap by ACCEPTING "Terminal" as an alias for
+// "shell". #1986 reverses that: the display label is presentation-only and must
+// never resolve, because two strings addressing one tab is the ambiguity
+// #1929/#1904 removed from the tab surface. The #1984 symptom (a user typing a
+// label they read off the bar) is kept from returning not by accepting the
+// label but by NAMING the real handle in the miss error — so the user learns to
+// type "shell". This is the daemon-level lock on that contract at the shared
+// resolver every destructive tab verb goes through.
+func TestCloseTab_RefusesTheDisplayedLabelButNamesTheTab(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 	repoPath := setupControlRepo(t)
 	repo, err := config.RepoFromPath(repoPath)
@@ -626,12 +632,27 @@ func TestCloseTab_AcceptsTheLabelTheTUIDisplays(t *testing.T) {
 			shell.Name, session.TabLabel(shell), "shell", "Terminal")
 	}
 
-	name, err := manager.CloseTab(CloseTabRequest{Title: title, RepoID: repo.ID, TabName: "Terminal"})
-	if err != nil {
-		t.Fatalf("CloseTab by the displayed label %q failed: %v\n"+
-			"This is the #1984 report: the tab bar shows \"Terminal\" and the user typed it.", "Terminal", err)
+	// The displayed label must NOT resolve — the tab stays untouched.
+	_, err = manager.CloseTab(CloseTabRequest{Title: title, RepoID: repo.ID, TabName: "Terminal"})
+	if err == nil {
+		t.Fatalf("CloseTab by the displayed label %q succeeded; the label is presentation-only "+
+			"and must never resolve (#1986).", "Terminal")
 	}
-	// The daemon reports the CANONICAL name back, not the alias the user typed.
+	// …but the error must lead the user to the real handle, not assert an absence
+	// they can see is false. It names "shell" AND the label they typed.
+	if !strings.Contains(err.Error(), `"shell" (shown as "Terminal")`) {
+		t.Fatalf("CloseTab miss error = %q; it must name the real handle so a user who read "+
+			"\"Terminal\" learns to type \"shell\" (#1984 discoverability).", err.Error())
+	}
+	if inst.TabCount() != 2 {
+		t.Fatalf("expected 2 tabs (agent+shell) still present after a refused close, got %d", inst.TabCount())
+	}
+
+	// And the canonical name still closes it.
+	name, err := manager.CloseTab(CloseTabRequest{Title: title, RepoID: repo.ID, TabName: "shell"})
+	if err != nil {
+		t.Fatalf("CloseTab by the canonical name %q failed: %v", "shell", err)
+	}
 	if name != "shell" {
 		t.Fatalf("closed tab name = %q, want the canonical %q", name, "shell")
 	}
@@ -640,8 +661,8 @@ func TestCloseTab_AcceptsTheLabelTheTUIDisplays(t *testing.T) {
 	}
 }
 
-// TestCloseTab_StillAcceptsTheCanonicalName pins that the label alias is
-// ADDITIVE: every script already passing "shell" must keep working.
+// TestCloseTab_StillAcceptsTheCanonicalName pins that the canonical name keeps
+// working: every script already passing "shell" must be unaffected by #1986.
 func TestCloseTab_StillAcceptsTheCanonicalName(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 	repoPath := setupControlRepo(t)

--- a/daemon/manager_tabs_arrange.go
+++ b/daemon/manager_tabs_arrange.go
@@ -154,26 +154,22 @@ func resolveTabTarget(tabs []*session.Tab, title, tabID, tabName string, tabInde
 		return 0, "", fmt.Errorf("session %q has no tab with id %q; it may have been closed — reload the session's tabs and retry", title, tabID)
 	}
 	if tabName != "" {
-		// Match the canonical Name first, then the label the UI DISPLAYS
-		// (session.TabMatches, #1984). The TUI shows "Terminal" for a tab named
-		// "shell", so a user reading the bar and typing what they saw was told
-		// the tab did not exist while it sat on screen. Accepting the label is
-		// additive: every script passing "shell" keeps working, nothing is
-		// renamed, no display changes — and because this is the shared resolver
-		// (#1971), close, rename, and reorder all gain it at once.
+		// Match the canonical Name only (session.TabMatches, #1986). The display
+		// label is presentation and is never an identifier: the TUI shows
+		// "Terminal" for a tab named "shell", but the label does not resolve here —
+		// accepting it would make two strings address one tab, the ambiguity #1929/
+		// #1904 removed from the tab surface. A user who typed the label is not left
+		// stranded: the miss error below names the real handle. Because this is the
+		// shared resolver (#1971), close, rename, and reorder all key on Name alike.
 		for i, tab := range tabs {
 			if session.TabMatches(tab, tabName) {
-				// Return the CANONICAL name, not the input: the label is an input
-				// spelling only. Otherwise a caller passing "Terminal" gets
-				// {"name":"Terminal"} back — a string that is not any tab's
-				// identity, and a lie to any script that captures it.
 				return i, tab.Name, nil
 			}
 		}
-		// Name the tabs that DO exist, with their labels where the two differ.
-		// The old error asserted an absence and left the user to guess the
-		// mapping; listing the valid options turns a dead end into a fix, and
-		// still fires correctly for a real typo.
+		// Name the tabs that DO exist, with their labels where the two differ, so a
+		// user who read "Terminal" learns to type "shell". The old error asserted an
+		// absence and left the user to guess the mapping; listing the valid options
+		// turns a dead end into a fix, and still fires correctly for a real typo.
 		ids := make([]string, 0, len(tabs))
 		for _, tab := range tabs {
 			ids = append(ids, session.TabIdentifiers(tab))

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1283,7 +1283,10 @@ Delete the named tab from an existing session — the counterpart of tab-create.
 The tab is removed from the daemon's session state and its tmux window is
 killed. The removal is persistent: the daemon will not respawn the tab, and it
 does not return on a daemon/af restart. The name to pass is the tab name
-tab-create printed (also visible in the TUI tab bar).
+tab-create printed, as reported by "af sessions get" — not the label the TUI
+tab bar shows, which is a fixed "Agent"/"Terminal" for agent and shell tabs. A
+miss lists the tabs that exist, with those labels, so a wrong name is a next
+step rather than a dead end.
 
 The agent tab can't be deleted — use "af sessions kill" to tear down the whole
 session. Deleting a tab or session that doesn't exist is an error, not a

--- a/docs/surface-parity.md
+++ b/docs/surface-parity.md
@@ -135,25 +135,30 @@ asserted a tab was absent while the user could see it on screen — and left the
 to discover the mapping. One concept, two representations: the same disease as
 #1972 and #1970.
 
-The rule now lives beside the `Tab` type, not in the TUI, because **a label a
-user can read is an identifier they will type**:
+The rule lives beside the `Tab` type, not in the TUI, so "what a user reads"
+sits next to "what a user types" — and the two are deliberately allowed to
+differ ([#1986](https://github.com/sachiniyer/agent-factory/issues/1986)):
 
-- `session.TabLabel` — the one definition of what a user SEES. `ui/tree` delegates
-  to it, so display cannot drift from what is accepted.
-- `session.TabMatches` — accepts the canonical name **or** the label. Additive:
-  `--name shell` keeps working for every script, nothing is renamed, no display
-  changes.
+- `session.TabLabel` — the one definition of what a user SEES. Presentation
+  only: agent and shell tabs render fixed labels (`Agent`/`Terminal`) that are
+  not their names (`agent`/`shell`). `ui/tree` delegates to it, so display has a
+  single source.
+- `session.TabMatches` — resolves on the canonical **name alone**. The label is
+  never an identifier: accepting it would make two strings address one tab, the
+  ambiguity #1929/#1904 removed from the tab surface.
 - `session.TabIdentifiers` — renders a tab as both spellings, so *"no tab named
-  X"* lists the valid options instead of asserting an absence. That is worth more
-  than the alias: it still fires for a real typo, but turns a dead end into a fix.
+  X"* lists the valid options with their labels. This is the whole mechanism
+  now: the label never resolves, but a user who read `Terminal` off the bar is
+  told the real name `shell` rather than left at a dead end.
 
-The label is an **input** spelling only — the resolver canonicalises before
-returning, or `tab-delete --name Terminal` would answer `{"name":"Terminal"}`, a
-string that is not any tab's identity.
+[#1937](https://github.com/sachiniyer/agent-factory/issues/1937) first closed
+the gap by accepting the label as an alias; #1986 reversed that so the label
+carries no identity, keeping the #1984 symptom from returning through
+discoverability rather than a second handle.
 
-`TestDisplayedTabIdentifiersAreAccepted` enforces the invariant for every
-`TabKind`, including kinds with no UI yet, so a new kind cannot ship a label its
-own CLI rejects.
+`TestLabelIsNeverAnAcceptedIdentifier` enforces the invariant for every
+`TabKind`, including kinds with no UI yet: the name resolves, the label does
+not, and where the two differ the label is still named in the error.
 
 ## The CLI-vs-CLI axis: argument shape
 

--- a/parity/identifier_test.go
+++ b/parity/identifier_test.go
@@ -1,12 +1,13 @@
 package parity
 
-// Identifier parity: is the string we SHOW the string we ACCEPT?
+// Identifier parity: the string we SHOW is presentation-only and never resolves;
+// the string we ACCEPT is discoverable from what we show.
 //
 // A fourth dimension, and the one that is invisible until someone types it. The
 // others ask whether a surface has a verb, its options, or the right values.
-// This asks something narrower and nastier: when a surface DISPLAYS an
-// identifier, does every surface that TAKES that identifier accept the string
-// the user just read?
+// This asks something narrower and nastier: when a surface DISPLAYS a label and
+// a user types it, does the tool lead them to the real handle rather than assert
+// a tab they can see does not exist?
 //
 // It was found by hand, like the others (#1984):
 //
@@ -21,12 +22,23 @@ package parity
 // disease as #1972 (create --name vs a positional <title>) and #1970 (the web's
 // copy of the agent enum).
 //
-// The invariant is one line: anything a user can read off a surface must be
-// accepted by the surfaces that take it. This test enforces it for every tab
-// kind, including kinds nobody has shipped a UI for yet, so a new TabKind cannot
-// introduce a label its own CLI rejects.
+// #1937 first closed the gap by ACCEPTING the label as an alias. #1986 undid that
+// choice deliberately: the label is presentation-only and must never be an
+// identifier, because two strings addressing one tab is the ambiguity #1929/#1904
+// spent a PR removing from the tab surface. So the invariant flips. It is no
+// longer "the label must be accepted"; it is two clauses that together keep the
+// #1984 symptom from returning WITHOUT the ambiguity:
+//
+//  1. Name is the SOLE handle — the label never resolves (session.TabMatches).
+//  2. The label stays DISCOVERABLE — when it differs from the name, a "no tab
+//     named …" error names the real handle (session.TabIdentifiers), so a user
+//     who read "Terminal" learns to type "shell" rather than hitting a dead end.
+//
+// Enforced for every tab kind, including kinds nobody has shipped a UI for yet,
+// so a new TabKind cannot introduce a label that strands the user who reads it.
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/sachiniyer/agent-factory/session"
@@ -46,31 +58,43 @@ var tabKindsUnderAudit = []struct {
 	{session.TabKindVSCode, "editor"},
 }
 
-// TestDisplayedTabIdentifiersAreAccepted is the invariant: every label a surface
-// shows must be accepted by the surfaces that take a tab name.
-func TestDisplayedTabIdentifiersAreAccepted(t *testing.T) {
+// TestLabelIsNeverAnAcceptedIdentifier is the #1986 invariant: the name is the
+// sole handle, the label never resolves, and where the two differ the label is
+// still discoverable through the miss error.
+func TestLabelIsNeverAnAcceptedIdentifier(t *testing.T) {
 	for _, c := range tabKindsUnderAudit {
 		tab := &session.Tab{Name: c.name, Kind: c.kind}
 		label := session.TabLabel(tab)
 
 		if label == "" {
-			t.Errorf("kind %v renders an EMPTY label — a user can read nothing to type", c.kind)
+			t.Errorf("kind %v renders an EMPTY label — a user can read nothing off the screen", c.kind)
 			continue
 		}
-		if !session.TabMatches(tab, label) {
-			t.Errorf("kind %v is DISPLAYED as %q but %q is not accepted as its identifier.\n\n"+
-				"A user reads the label off the screen and types it; if only %q works, the "+
-				"error tells them a tab they can see does not exist (#1984). Accept the label "+
-				"as an alias in session.TabMatches — additively, never by renaming the tab or "+
-				"changing what the UI shows.", c.kind, label, label, c.name)
-		}
-		// The canonical name must keep working: the alias is additive, and every
-		// script passing "shell" today must be unaffected.
+		// 1. The canonical name is the sole handle and must always resolve.
 		if !session.TabMatches(tab, c.name) {
-			t.Errorf("kind %v no longer accepts its canonical name %q — the label alias must "+
-				"ADD a spelling, never replace one. Scripts depend on this.", c.kind, c.name)
+			t.Errorf("kind %v does not accept its canonical name %q — Name is the one handle a "+
+				"user types, and every tab verb resolves against it.", c.kind, c.name)
 		}
-		// Not blind: a matcher that accepts everything would satisfy the above.
+		// The label is presentation-only and must NOT be an identifier. This only
+		// bites where the label diverges from the name (agent/shell); for kinds
+		// whose label IS the name (process/web/vscode) it resolves because it is
+		// the name, not because the label is accepted, so skip those.
+		if label != c.name {
+			if session.TabMatches(tab, label) {
+				t.Errorf("kind %v is DISPLAYED as %q but that label is ACCEPTED as an identifier.\n\n"+
+					"The label is presentation-only (#1986): accepting it makes two strings address "+
+					"one tab, the ambiguity #1929/#1904 removed. Resolve on Name alone in "+
+					"session.TabMatches; let the miss error name the real handle instead.", c.kind, label)
+			}
+			// 2. …but the label must not be a dead end: the error the miss produces
+			//    must name it, so the user who read it can find the name to type.
+			if ids := session.TabIdentifiers(tab); !strings.Contains(ids, label) {
+				t.Errorf("kind %v is shown as %q, which does not resolve, yet TabIdentifiers(%q) = %s "+
+					"does not surface %q — a user who read the label off the bar is stranded with no "+
+					"path to the real name (#1984).", c.kind, label, c.name, ids, label)
+			}
+		}
+		// Not blind: a matcher that accepts everything would satisfy clause 1.
 		if session.TabMatches(tab, "definitely-not-a-tab-name") {
 			t.Errorf("kind %v matches an arbitrary token — TabMatches is accepting anything, "+
 				"so the assertions above prove nothing.", c.kind)
@@ -78,14 +102,15 @@ func TestDisplayedTabIdentifiersAreAccepted(t *testing.T) {
 	}
 }
 
-// TestTabIdentifiersNameTheAlternatives pins the other half of #1984, which is
-// worth more than the alias: the error a real typo produces must name the tabs
-// that exist rather than assert an absence.
+// TestTabIdentifiersNameTheAlternatives pins the discoverability half of #1984,
+// which is now the whole mechanism (there is no alias): the error a real typo —
+// or a label a user typed — produces must name the tabs that exist rather than
+// assert an absence.
 func TestTabIdentifiersNameTheAlternatives(t *testing.T) {
 	shell := &session.Tab{Name: "shell", Kind: session.TabKindShell}
 	got := session.TabIdentifiers(shell)
 	// Both spellings, because the whole point is that the user knows only one.
-	if !contains([]string{got}, `"shell" (shown as "Terminal")`) {
+	if got != `"shell" (shown as "Terminal")` {
 		t.Errorf("TabIdentifiers(shell) = %s; it must give BOTH the name and the label when "+
 			"they differ, since a user who saw \"Terminal\" cannot guess \"shell\" from an "+
 			"error that only says \"shell\".", got)
@@ -101,7 +126,7 @@ func TestTabIdentifiersNameTheAlternatives(t *testing.T) {
 
 // TestTabKindCoverageIsComplete keeps the audit's denominator honest: a TabKind
 // added without an entry above would never be checked, and the suite would go
-// green while a new label went unaccepted — under-coverage, which is worse than
+// green while a new label went unchecked — under-coverage, which is worse than
 // no check.
 func TestTabKindCoverageIsComplete(t *testing.T) {
 	// TabKind is an iota enum with no reflective listing, so probe upward until
@@ -119,6 +144,6 @@ func TestTabKindCoverageIsComplete(t *testing.T) {
 	if label := session.TabLabel(next); label != "Tab" {
 		t.Errorf("TabKind %v renders as %q, not the generic %q fallback — it looks like a real "+
 			"kind that tabKindsUnderAudit (parity/identifier_test.go) does not list, so its "+
-			"label is never checked against what the CLI accepts.", highest+1, label, "Tab")
+			"label is never audited against the #1986 identity split.", highest+1, label, "Tab")
 	}
 }

--- a/session/tab.go
+++ b/session/tab.go
@@ -28,20 +28,26 @@ var newTabID = func() string {
 	return fmt.Sprintf("%x", b[:])
 }
 
-// agentTabName is the display label of the default Agent tab.
+// agentTabName is the canonical name of the default Agent tab — the handle a
+// user types (`--name agent`), not the label the UI shows (which is "Agent";
+// see TabLabel).
 const agentTabName = "agent"
 
-// shellTabName is the display label of the first Shell tab — the on-demand
-// per-instance terminal session ('t' / `af sessions tab-create`).
+// shellTabName is the canonical name of the first Shell tab — the on-demand
+// per-instance terminal session ('t' / `af sessions tab-create`). The handle a
+// user types (`--name shell`), not the label the UI shows (which is "Terminal";
+// see TabLabel).
 const shellTabName = "shell"
 
-// webTabName is the default display label of a web/iframe tab ('web', then
-// 'web-2', … on collision). Created via `af sessions tab-create --kind web`.
+// webTabName is the default canonical name of a web/iframe tab ('web', then
+// 'web-2', … on collision). Created via `af sessions tab-create --kind web`. For
+// web tabs the label equals the name (see TabLabel).
 const webTabName = "web"
 
-// vscodeTabName is the default display label of a VS Code tab ('vscode', then
+// vscodeTabName is the default canonical name of a VS Code tab ('vscode', then
 // 'vscode-2', … on collision). Created via `af sessions tab-create --kind vscode`
-// or the web UI's + New tab flow.
+// or the web UI's + New tab flow. For vscode tabs the label equals the name (see
+// TabLabel).
 const vscodeTabName = "vscode"
 
 // tmuxTabSeparator joins an instance's agent tmux session name to a tab's name
@@ -144,7 +150,17 @@ type Tab struct {
 	// (reused on close+recreate). Empty only for a legacy persisted tab written
 	// before #1738, which restoreLocalTabs backfills with a fresh id on load.
 	ID string
-	// Name is the display label (e.g. "agent").
+	// Name is the tab's canonical handle: the stable, human-typable string a user
+	// addresses it by (`agent`, `shell`, `btop`, or a name set at create/rename),
+	// unique within the instance. It is what every tab verb resolves against
+	// (`--name`, via TabMatches), alongside the stable ID above.
+	//
+	// It is NOT the display label. What the UI renders is TabLabel, a
+	// presentation-only string that is never resolved against — the two
+	// deliberately differ for agent/shell tabs (named `agent`/`shell`, shown as
+	// "Agent"/"Terminal"). This field's doc once claimed to be "the display
+	// label"; that confusion was #1986, and the split into Name (the one handle)
+	// and TabLabel (the one display string) is its resolution.
 	Name string
 	// Kind selects the tab's process behavior.
 	Kind TabKind
@@ -251,18 +267,22 @@ func tabKindForData(k TabKind) TabKind {
 	}
 }
 
-// TabLabel returns the string a user SEES for a tab.
+// TabLabel returns the presentation-only string a user SEES for a tab — its
+// display label. It is NEVER an identifier: no surface resolves a tab by it
+// (TabMatches keys on Name alone), which is exactly what frees it to be a
+// prettier, non-unique string than the canonical Name. Agent and shell tabs
+// render fixed labels ("Agent", "Terminal") that are deliberately not their
+// names (`agent`/`shell`); every other kind shows its Name.
 //
-// It lives beside the Tab type rather than in the TUI because a label a user can
-// read off the screen is, in practice, an identifier they will type — and until
-// #1984 the two disagreed: the TUI showed "Terminal" while the only accepted
-// name was "shell", so `af sessions tab-delete alpha --name Terminal` reported
-// that the tab did not exist while it sat visible in the tab bar. Keeping the
-// rule here lets every surface that ACCEPTS a tab name honour what the TUI
-// SHOWS, from one definition.
-//
-// Note Tab.Name's doc calls itself "the display label"; it is not, and that
-// confusion is the bug. Name is the canonical identifier; this is the label.
+// This is the #1986 split: Name is the one handle a user types, the label is the
+// one string a user reads, and they are allowed to differ because the label
+// carries no identity. It lives beside the Tab type — not in the TUI — so the
+// definition of "what a user reads" sits next to Name, the definition of "what a
+// user types": whenever the two differ, TabIdentifiers surfaces the label in a
+// "no tab named …" error, so a user who read "Terminal" off the bar is told the
+// real name `shell` rather than left to guess it. That discoverability is what
+// replaces the label-as-alias #1937 shipped (#1984): the label never resolves,
+// but it is never a dead end either.
 func TabLabel(t *Tab) string {
 	if t == nil {
 		return ""
@@ -290,22 +310,27 @@ func TabLabel(t *Tab) string {
 	}
 }
 
-// TabMatches reports whether token identifies this tab, by its canonical Name or
-// by the label the UI displays for it.
-//
-// The label is accepted as an ALIAS: `--name shell` keeps working for every
-// script that already uses it, and `--name Terminal` now works for the person
-// who read it off the screen. Nothing is renamed and no display changes.
+// TabMatches reports whether token identifies this tab. It keys on the canonical
+// Name ONLY: the display label (TabLabel) is presentation and is never an
+// identifier (#1986). A person who typed a label they read off the screen is not
+// matched here — accepting it would make two strings address one tab, the
+// ambiguity #1929/#1904 removed from the tab surface. The label is not a dead
+// end either: TabIdentifiers names it in the resulting "no tab named …" error,
+// so the user learns the real name to type (the discoverability half of #1984).
 func TabMatches(t *Tab, token string) bool {
 	if t == nil || token == "" {
 		return false
 	}
-	return t.Name == token || TabLabel(t) == token
+	return t.Name == token
 }
 
-// TabIdentifiers renders a tab as the strings a user may type for it: its name,
-// plus its label when that differs. Used to make "no tab named X" list the valid
-// options instead of asserting an absence the user can see is false.
+// TabIdentifiers renders a tab as the strings that help a user address it in an
+// error: its canonical Name, plus the label the UI shows when that differs.
+// Because the label is presentation-only and never accepted (TabMatches keys on
+// Name), naming it here is what lets a user who read "Terminal" off the bar find
+// the `shell` they must type — the discoverability the #1986 split relies on in
+// place of the label alias. Used to make "no tab named X" list the valid options
+// instead of asserting an absence the user can see is false.
 func TabIdentifiers(t *Tab) string {
 	if t == nil {
 		return ""

--- a/ui/tree/labels.go
+++ b/ui/tree/labels.go
@@ -135,12 +135,12 @@ func labelForTab(tab *session.Tab) string {
 }
 
 // textForTab delegates to session.TabLabel, the single definition of what a user
-// SEES for a tab's text (#1984). It moved beside the Tab type because the
-// surfaces that ACCEPT a tab name must honour the same rule — the text a user
-// reads is an identifier they will type — and a second copy here would let the
-// two drift apart, the bug that made `--name Terminal` report a visible tab as
-// nonexistent. session.TabMatches accepts this same string as a name alias, and
-// session.TabLabel returns exactly what this switch used to (Agent/Terminal/name).
+// SEES for a tab's text. It lives beside the Tab type because the label is
+// presentation-only and deliberately differs from the name for agent/shell tabs
+// (#1986); keeping "what a user reads" next to "what a user types" is what lets a
+// "no tab named …" error surface the real name when the two differ, rather than
+// asserting a visible tab is absent (#1984). The label is never resolved against
+// (session.TabMatches keys on Name alone), so it is free to be the pretty string.
 func textForTab(tab *session.Tab) string {
 	return session.TabLabel(tab)
 }


### PR DESCRIPTION
Closes #1986 (the anchor of the tab-identity cluster). Type-level split only; the siblings (#1984 help, #1957/#1991/#1948/#1987 keying migrations) land as focused follow-ups **on top of this**.

## The confusion

`session.Tab.Name` did two jobs. Its doc comment claimed to be *"the display label"*; it is not — it's the canonical identifier the daemon resolves against. Meanwhile the label leaked into being a *second* identifier: #1937 taught `TabMatches` to accept the displayed label, so `--name Terminal` and `--name shell` both addressed one tab. Two strings, one tab — the ambiguity #1929/#1904 had just spent a PR removing from the tab surface.

## The split

One handle + a label that is never an identifier:

| | role after this PR |
|---|---|
| `Tab.ID` | stable identity (#1738) — internal keying (unchanged here) |
| `Tab.Name` | the **one** human-typable handle; what every tab verb resolves against |
| `TabLabel` | **presentation-only**; never resolved against, free to be pretty (`Agent`/`Terminal`) |

`TabMatches` now keys on `Name` alone.

## ⚠️ Load-bearing decision — please gate on this

**This removes the `--name Terminal` label alias #1937 shipped.** After this PR, `af sessions tab-delete alpha --name Terminal` is *refused*. That is deliberate — it's the "label is NEVER an identifier" half of the issue — but it changes public CLI behavior, so I'm flagging it explicitly.

The #1984 symptom (a user types a label they read off the bar) is kept from returning through **discoverability, not a second handle**. The miss error already names the real handle:

```
$ af sessions tab-delete alpha --name Terminal
session "alpha" has no tab named "Terminal"; its tabs are: "agent" (shown as "Agent"), "shell" (shown as "Terminal")
```

So a user who read `Terminal` learns to type `shell` — a next step, not a dead end.

This is the reading of your cluster directive ("a separate Label that is NEVER used as an identifier" · "#1984 → the CLI accepts the real names + the TUI shows labels"). The anchor issue's older lean was toward option 1 (rename the tabs to `Terminal`/`Agent`, a breaking change to persisted state + CLI needing a deprecation window); I did **not** take that — it's heavier and breaks more. If you'd rather keep the alias (option 3, status quo) or go for option 1, this is the fork to redirect at, and the alias-removal + parity inversion is the isolated ~15 lines to flip.

## What changed

- `session/tab.go` — honest docs on `Name`/`TabLabel`; `TabMatches` → name-only; `TabIdentifiers`/const docs corrected.
- `daemon/manager_tabs_arrange.go` — `resolveTabTarget` comment corrected (name-only; the miss error carries discoverability). It's the shared resolver, so close/rename/reorder all key on `Name` alike.
- `parity/identifier_test.go` — the identifier invariant **inverted**: from "the displayed label must be accepted" to "the name is the sole handle, the label never resolves, and where they differ the label is still named in the error".
- `daemon/close_tab_test.go` — the old `AcceptsTheLabel` test flipped to `RefusesTheDisplayedLabelButNamesTheTab` (daemon-level lock on the new contract).
- `api/sessions_tabs.go` + regenerated `docs/reference/cli.md` — `tab-delete --help` drops the now-false "also visible in the TUI tab bar" and points at `af sessions get`.
- `docs/surface-parity.md` — the identifier-axis section rewritten to the #1986 design.

## Fail-first

Observed failing at `d4bae18` (current master): a probe asserting the new contract failed because `TabMatches(shell, "Terminal") == true` on master. The daemon lock `TestCloseTab_RefusesTheDisplayedLabelButNamesTheTab` fails on master (the label resolved and closed the tab) and passes here.

## Verification

- `go build ./...`, `gofmt -l .` (clean), `golangci-lint --fast` (0), `deadcode -test ./...` (empty), `scripts/lint-file-length.sh` (pass).
- Host: `./parity/`, `./ui/tree/`, targeted `./session/` tab tests — green.
- Container (`make test-container GOTESTARGS="./daemon/ -run TestCloseTab"`): all 20 CloseTab tests pass, including the flipped one and the existing discoverability test.

No visible TUI change in this PR (display is untouched — labels still render `Agent`/`Terminal`); the behavior change is CLI-only.

Co-Authored-By: Captain Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)