### PR TITLE
fix(tmux): bound Start's pty-start-failure cleanup kill-session (#2028)

### DIFF
--- a/session/tmux/start.go
+++ b/session/tmux/start.go
@@ -41,8 +41,16 @@ func (t *TmuxSession) Start(workDir string) error {
 		// attempt against a possibly-live session, never a false liveness claim.
 		if t.ExistsOrUnknown() {
 			leaked := SessionProcessTrees(t.cmdExec, t.sanitizedName)
-			cleanupCmd := exec.Command("tmux", "kill-session", "-t", exactTarget(t.sanitizedName))
-			if cleanupErr := t.cmdExec.Run(cleanupCmd); cleanupErr != nil {
+			// Bound the cleanup kill-session (#2028): on bare exec.Command it could
+			// hang forever on a wedged tmux server, and Start is on the daemon's
+			// create/launch path, so an unbounded stall here wedges that handler. Route
+			// it through the same bounded runner as the rest of the package's tmux
+			// commands (#1917) — a tripped deadline degrades to a best-effort cleanup
+			// failure, the same as any other kill-session error below.
+			ctx, cancel := tmuxTimeoutContext()
+			cleanupErr := t.runTmuxBounded(ctx, "kill-session", "-t", exactTarget(t.sanitizedName))
+			cancel()
+			if cleanupErr != nil {
 				err = fmt.Errorf("%v (cleanup error: %v)", err, cleanupErr)
 			} else if len(leaked) > 0 {
 				go reapLeakedProcesses(t.sanitizedName, leaked, reapGraceWait, reapTermWait)
@@ -97,17 +105,22 @@ func (t *TmuxSession) Start(workDir string) error {
 	}
 	ptmx.Close()
 
-	// Set history limit to enable scrollback (default is 2000, we'll use 10000 for more history)
-	historyCmd := exec.Command("tmux", "set-option", "-t", exactTarget(t.sanitizedName), "history-limit", "10000")
-	if err := t.cmdExec.Run(historyCmd); err != nil {
+	// Set history limit to enable scrollback (default is 2000, we'll use 10000 for
+	// more history). Bounded like every other tmux command in this package (#1917/
+	// #2028): these run on the daemon's create path, so a wedged server must not
+	// hang them; both are best-effort and only log on failure.
+	ctx, cancel := tmuxTimeoutContext()
+	if err := t.runTmuxBounded(ctx, "set-option", "-t", exactTarget(t.sanitizedName), "history-limit", "10000"); err != nil {
 		log.InfoLog.Printf("Warning: failed to set history-limit for session %s: %v", t.sanitizedName, err)
 	}
+	cancel()
 
 	// Enable mouse scrolling for the session
-	mouseCmd := exec.Command("tmux", "set-option", "-t", exactTarget(t.sanitizedName), "mouse", "on")
-	if err := t.cmdExec.Run(mouseCmd); err != nil {
+	ctx, cancel = tmuxTimeoutContext()
+	if err := t.runTmuxBounded(ctx, "set-option", "-t", exactTarget(t.sanitizedName), "mouse", "on"); err != nil {
 		log.InfoLog.Printf("Warning: failed to enable mouse scrolling for session %s: %v", t.sanitizedName, err)
 	}
+	cancel()
 
 	// Attach to the session we just created. Pass empty workDir so a missing
 	// session here surfaces as an error rather than recursively re-spawning.

--- a/session/tmux/start_cleanup_bound_test.go
+++ b/session/tmux/start_cleanup_bound_test.go
@@ -1,0 +1,119 @@
+package tmux
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/cmd"
+)
+
+// #2028: the cleanup kill-session on Start's pty-start-failure path used a bare,
+// unbounded t.cmdExec.Run, so a wedged tmux server would hang it forever. Start
+// runs on the daemon's create/launch path, so that stall wedges the whole handler
+// — the same class as #1917's teardown wedge and #1967's unbounded exec.
+//
+// Like the other wedge tests in this package (kill_wedge_test.go / start_wedge_
+// test.go) this drives a REAL fake tmux on PATH that sleeps in a CHILD, not a
+// blocking MockCmdExec: a blocking mock is unreachable by any context deadline and
+// would fail identically before and after the fix, proving nothing. Only a real
+// subprocess can be SIGKILLed on the deadline, and only the process-group kill +
+// tmuxWaitDelay collect the pipe-holding child.
+
+// failingPtyFactory is a PtyFactory whose Start always fails, driving Start
+// straight into its pty-start-failure cleanup branch (the #2028 site) without a
+// real PTY.
+type failingPtyFactory struct{}
+
+func (failingPtyFactory) Start(*exec.Cmd) (*os.File, error) {
+	return nil, fmt.Errorf("simulated pty start failure")
+}
+func (failingPtyFactory) Close() {}
+
+// wedgeKillSessionAfterCreateOnPath installs a fake `tmux` on PATH that:
+//   - answers the FIRST has-session "no such session" (exit 1), so Start's up-front
+//     existence gate passes and the create proceeds to ptyFactory.Start;
+//   - answers every LATER has-session "exists" (exit 0), so the post-failure
+//     ExistsOrUnknown reports the session present and the cleanup kill-session runs;
+//   - answers list-panes (SessionProcessTrees) cleanly with no panes;
+//   - WEDGES kill-session by sleeping in a child, standing in for a wedged server —
+//     the command whose unbounded Run this test pins.
+func wedgeKillSessionAfterCreateOnPath(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	state := filepath.Join(dir, "has_session_calls")
+	pidFile := filepath.Join(dir, "wedge.pid")
+	script := "#!/bin/sh\n" +
+		"case \"$1\" in\n" +
+		"has-session)\n" +
+		"  n=$(cat " + state + " 2>/dev/null || echo 0)\n" +
+		"  n=$((n + 1))\n" +
+		"  echo \"$n\" > " + state + "\n" +
+		"  if [ \"$n\" -eq 1 ]; then exit 1; fi\n" +
+		"  exit 0\n" +
+		"  ;;\n" +
+		"list-panes)\n" +
+		"  exit 0\n" +
+		"  ;;\n" +
+		"kill-session)\n" +
+		"  sleep 300 &\n" +
+		"  echo $! > " + pidFile + "\n" +
+		"  wait\n" +
+		"  ;;\n" +
+		"*)\n" +
+		"  exit 0\n" +
+		"  ;;\n" +
+		"esac\n"
+	if err := os.WriteFile(filepath.Join(dir, "tmux"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	// Backstop: if a regression leaves the cleanup blocked (the test then times
+	// out), kill the wedged child so nothing is orphaned past the test.
+	t.Cleanup(func() {
+		data, err := os.ReadFile(pidFile)
+		if err != nil {
+			return
+		}
+		if pid, err := strconv.Atoi(strings.TrimSpace(string(data))); err == nil && pid > 0 {
+			_ = exec.Command("kill", "-9", strconv.Itoa(pid)).Run()
+		}
+	})
+}
+
+// TestStartPtyFailureCleanupKillSessionIsBounded is the #2028 regression: when
+// ptyFactory.Start fails and the server is wedged, Start's cleanup kill-session
+// must return on its own deadline rather than hang. Before the fix the cleanup ran
+// on a bare, unbounded exec.Command and Start never returned.
+func TestStartPtyFailureCleanupKillSessionIsBounded(t *testing.T) {
+	wedgeKillSessionAfterCreateOnPath(t)
+	shortTmuxTimeout(t, 200*time.Millisecond)
+	// Pin the `-e` support probe so sessionEnvFlags never runs an unbounded
+	// `tmux -V` against the wedging fake (envmarker.go) — not what this exercises.
+	forceNewSessionEnvMarkers(t, false)
+	ts := NewTmuxSessionWithDeps("wedge-2028-cleanup", "sh", failingPtyFactory{}, cmd.MakeExecutor())
+
+	done := make(chan error, 1)
+	go func() { done <- ts.Start(t.TempDir()) }()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Start must fail when ptyFactory.Start fails")
+		}
+		// The pty-start failure must survive; the bounded cleanup only appends its
+		// own (timeout) cause to it — it does not replace or swallow the real error.
+		if !strings.Contains(err.Error(), "error starting tmux session") {
+			t.Fatalf("want the pty-start failure surfaced, got %v", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("Start hung on the pty-start-failure cleanup kill-session against a wedged tmux " +
+			"server (#2028): the cleanup kill-session was an unbounded t.cmdExec.Run, and Start runs " +
+			"on the daemon's create/launch path, so the whole handler wedges")
+	}
+}


### PR DESCRIPTION
Closes #2028.

## Problem

`session/tmux/start.go`'s cleanup `kill-session` on the pty-start-failure path
ran on a bare, unbounded `t.cmdExec.Run`, so a wedged tmux server could hang it
forever. `Start` runs on the daemon's create/launch path, so that stall wedges
the whole handler — the same class as #1917 (teardown wedge) and #1967
(unbounded exec). The rest of the package's tmux commands were bounded in #1917;
this one and its two siblings had stayed on bare `exec.Command`.

## Fix

Route the cleanup `kill-session` through the package's existing bounded runner
(`runTmuxBounded` → `tmuxCommandTimeout` deadline + `Setpgid` process-group kill
+ `tmuxWaitDelay`). A tripped deadline degrades to a best-effort cleanup failure,
exactly like any other `kill-session` error on that path.

**Audit (same function):** the two sibling `set-option` commands on the success
path (`history-limit`, `mouse`) were the only other loose tmux commands in
`Start`; both are now bounded too, closing `Start` under the package invariant
("every tmux command in this package is bounded"). `new-session` stays via the
PTY factory — it is the interactive pane, not a control command, and is
intentionally unbounded.

**Deliberately out of scope:** `cleanup.go`'s `CleanupSessions` (the `af reset`
CLI sweep: `tmux ls` + `kill-session`) is a separate, user-invoked short-lived
path, not the daemon session lifecycle; bounding it is a follow-up, noted so it
isn't lost.

## Test (fail-first)

`TestStartPtyFailureCleanupKillSessionIsBounded` drives a **real** fake tmux on
PATH that answers has-session/list-panes and wedges `kill-session` in a child
process (a blocking `MockCmdExec` is unreachable by any context deadline and
would pass/fail identically before and after the fix — the standard rationale
from `kill_wedge_test.go`).

- **Observed failing at `d4bae18`** (unfixed `start.go`): 30s hang → FAIL.
- With the bound: passes in 0.2s.

Full `./session/tmux/...` package green. `gofmt`/`go build`/`golangci-lint
--fast`/`deadcode -test ./...` all clean.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)