### PR TITLE
fix(docker): a timed-out container reap is workspace-state-unknown, not a known teardown (#2049)

### DIFF
--- a/session/backend_docker.go
+++ b/session/backend_docker.go
@@ -78,10 +78,14 @@ const (
 const (
 	dockerProvisionStepTimeout = 5 * time.Minute
 	dockerShortStepTimeout     = 30 * time.Second
-	dockerReapTimeout          = 30 * time.Second
 	dockerBannerPollTimeout    = 45 * time.Second
 	dockerBannerPollInterval   = 400 * time.Millisecond
 )
+
+// dockerReapTimeout bounds the `docker rm -f` container reap. A var (not a const)
+// only so tests can shorten it to exercise the deadline path; production never
+// reassigns it. Mirrors networkGitTimeout / tmuxCommandTimeout.
+var dockerReapTimeout = 30 * time.Second
 
 // dockerWaitDelay bounds how long cmd.Wait blocks after the docker CLI (or the
 // origin-lookup git in originRemoteURL) exits or is killed on its deadline,
@@ -440,13 +444,33 @@ func (p *dockerProvisioner) reap() error {
 		if p.containerID == "" {
 			return
 		}
-		out, err := p.docker(dockerReapTimeout, "rm", "-f", p.containerID)
-		if err != nil {
-			reapErr = fmt.Errorf("backend=docker: `docker rm -f %s` failed: %s: %w", p.shortID(), strings.TrimSpace(string(out)), err)
-			log.WarningLog.Printf("%v", reapErr)
+		// Own the context here (rather than via p.docker) so a tripped deadline is
+		// distinguishable from a reap that docker ANSWERED with an error — the two
+		// mean opposite things for the record (#2049).
+		ctx, cancel := context.WithTimeout(context.Background(), dockerReapTimeout)
+		defer cancel()
+		out, err := dockerExec(ctx, "rm", "-f", p.containerID)
+		if err == nil {
+			log.InfoLog.Printf("docker runtime: reaped container %s for session %q", p.shortID(), p.spec.Title)
 			return
 		}
-		log.InfoLog.Printf("docker runtime: reaped container %s for session %q", p.shortID(), p.spec.Title)
+		reapErr = fmt.Errorf("backend=docker: `docker rm -f %s` failed: %s: %w", p.shortID(), strings.TrimSpace(string(out)), err)
+		// A tripped deadline is NOT a report that the container is gone: docker was
+		// SIGKILLed mid-reap, so the container may STILL be running. Wrap the
+		// unknown-state sentinel so KillSession/deleteSessionRecord RETAIN the row —
+		// the only handle on the possibly-leaked container — instead of classifying
+		// the timeout as a known teardown and deleting it, orphaning the container
+		// (#2049, the fabricated-negative / teardown-taxonomy family: a two-valued
+		// error can't say "I don't know if it's gone", so a timeout reads as "gone").
+		// A docker that ANSWERED with an error (e.g. "No such container" — already
+		// gone) stays a plain, known-state error and the row may go, per the
+		// documented deleteSessionRecord contract. The #914 guard applies: only when
+		// err != nil AND the ctx deadline tripped, so a bare exec.ErrWaitDelay that
+		// dockerExec already normalized to success (err == nil) never lands here.
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			reapErr = fmt.Errorf("%w: %w", ErrWorkspaceStateUnknown, reapErr)
+		}
+		log.WarningLog.Printf("%v", reapErr)
 	})
 	return reapErr
 }

--- a/session/backend_docker.go
+++ b/session/backend_docker.go
@@ -218,7 +218,17 @@ type dockerProvisioner struct {
 	program string
 
 	containerID string
-	reapOnce    sync.Once
+
+	// reap memoizes across the repeated Kill retries and the Kill-vs-provision-
+	// failure race, but only for a reap that COMPLETED: reaped latches on success
+	// or on a failure docker ANSWERED with (already-gone, etc.), storing the outcome
+	// in reapErr. A TIMEOUT deliberately does NOT latch — the reap did not complete
+	// and the container may still be running, so the daemon's kill-retry must be able
+	// to re-run `docker rm -f` (#2049 / #2063 review). A plain sync.Once cannot
+	// express "done, but re-runnable", so this is a mutex + explicit latch.
+	reapMu  sync.Mutex
+	reaped  bool
+	reapErr error
 }
 
 // provision runs the full container lifecycle and returns the wiring a docker
@@ -433,45 +443,71 @@ func (p *dockerProvisioner) publishedPort() (string, error) {
 	return port, nil
 }
 
-// reap removes the container, idempotently. It runs on the session's Kill (after
-// the in-container workspace is torn down over REST), on a provisioning failure,
-// and on a bad-endpoint NewInstance failure — so a container is never leaked. The
-// sync.Once makes the repeated Kill retries and the Kill-vs-provision-failure
-// races collapse to one `docker rm -f`.
+// reap removes the container. It runs on the session's Kill (after the in-container
+// workspace is torn down over REST), on a provisioning failure, and on a
+// bad-endpoint NewInstance failure — so a container is never leaked.
+//
+// It is memoized but only for a reap that COMPLETED: a success, or a failure docker
+// ANSWERED with, latches (reaped=true, outcome in reapErr) so the repeated Kill
+// retries and the Kill-vs-provision-failure race collapse to that one result.
+//
+// A TIMEOUT deliberately does NOT latch. The `docker rm -f` was SIGKILLed mid-reap,
+// so it did not complete and the container may STILL be running; the daemon's
+// kill-retry (finishUserKill, on every poll for the retained record) must therefore
+// be able to actually re-run `docker rm -f` rather than see a stale nil. This is the
+// #2063-review defect the naive sync.Once had: it latched on the timeout too, so the
+// second reap() skipped the closure and returned nil (reapErr was a per-call local),
+// the row was deleted, and the container was orphaned exactly one poll later —
+// retention that lasted a single tick. Not latching a timeout makes retention
+// durable AND the reap genuinely retry-able.
+//
+// While a reap keeps timing out it keeps returning the ErrWorkspaceStateUnknown
+// sentinel (row retained); once docker answers — a later `docker rm -f` succeeds or
+// reports (e.g. "No such container", already gone) — it latches and the row may go.
+// It never silently returns nil while the container may still be leaked.
 func (p *dockerProvisioner) reap() error {
-	var reapErr error
-	p.reapOnce.Do(func() {
-		if p.containerID == "" {
-			return
-		}
-		// Own the context here (rather than via p.docker) so a tripped deadline is
-		// distinguishable from a reap that docker ANSWERED with an error — the two
-		// mean opposite things for the record (#2049).
-		ctx, cancel := context.WithTimeout(context.Background(), dockerReapTimeout)
-		defer cancel()
-		out, err := dockerExec(ctx, "rm", "-f", p.containerID)
-		if err == nil {
-			log.InfoLog.Printf("docker runtime: reaped container %s for session %q", p.shortID(), p.spec.Title)
-			return
-		}
-		reapErr = fmt.Errorf("backend=docker: `docker rm -f %s` failed: %s: %w", p.shortID(), strings.TrimSpace(string(out)), err)
-		// A tripped deadline is NOT a report that the container is gone: docker was
-		// SIGKILLed mid-reap, so the container may STILL be running. Wrap the
-		// unknown-state sentinel so KillSession/deleteSessionRecord RETAIN the row —
-		// the only handle on the possibly-leaked container — instead of classifying
-		// the timeout as a known teardown and deleting it, orphaning the container
-		// (#2049, the fabricated-negative / teardown-taxonomy family: a two-valued
-		// error can't say "I don't know if it's gone", so a timeout reads as "gone").
-		// A docker that ANSWERED with an error (e.g. "No such container" — already
-		// gone) stays a plain, known-state error and the row may go, per the
-		// documented deleteSessionRecord contract. The #914 guard applies: only when
-		// err != nil AND the ctx deadline tripped, so a bare exec.ErrWaitDelay that
-		// dockerExec already normalized to success (err == nil) never lands here.
-		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			reapErr = fmt.Errorf("%w: %w", ErrWorkspaceStateUnknown, reapErr)
-		}
+	// Held across the docker call so concurrent reaps serialize (no double
+	// `docker rm -f`) and the latch is read/written race-free — the same
+	// mutual-exclusion the sync.Once gave, minus its permanent latch.
+	p.reapMu.Lock()
+	defer p.reapMu.Unlock()
+	if p.reaped {
+		return p.reapErr
+	}
+	if p.containerID == "" {
+		p.reaped = true
+		return nil
+	}
+	// Own the context here (rather than via p.docker) so a tripped deadline is
+	// distinguishable from a reap that docker ANSWERED with an error — the two mean
+	// opposite things for the record (#2049).
+	ctx, cancel := context.WithTimeout(context.Background(), dockerReapTimeout)
+	defer cancel()
+	out, err := dockerExec(ctx, "rm", "-f", p.containerID)
+	if err == nil {
+		p.reaped = true
+		p.reapErr = nil
+		log.InfoLog.Printf("docker runtime: reaped container %s for session %q", p.shortID(), p.spec.Title)
+		return nil
+	}
+	reapErr := fmt.Errorf("backend=docker: `docker rm -f %s` failed: %s: %w", p.shortID(), strings.TrimSpace(string(out)), err)
+	// The #914 guard: classify a TIMEOUT only when err != nil AND the ctx deadline
+	// tripped, so a bare exec.ErrWaitDelay that dockerExec already normalized to
+	// success (err == nil) never reaches here.
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		// Unknown-state, and NOT latched: RETAIN the row now and re-run on the next
+		// reap. (#2049 classification + #2063-review retry.)
+		reapErr = fmt.Errorf("%w: %w", ErrWorkspaceStateUnknown, reapErr)
 		log.WarningLog.Printf("%v", reapErr)
-	})
+		return reapErr
+	}
+	// docker ANSWERED with an error: the reap completed and TOLD us something, so it
+	// latches as a KNOWN-state error and the row may be deleted, per the documented
+	// deleteSessionRecord contract. Latching also stops retries from re-running a
+	// command that will keep answering the same way.
+	p.reaped = true
+	p.reapErr = reapErr
+	log.WarningLog.Printf("%v", reapErr)
 	return reapErr
 }
 

--- a/session/backend_docker_reap_unknown_test.go
+++ b/session/backend_docker_reap_unknown_test.go
@@ -1,0 +1,111 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// #2049: a wedged / timed-out `docker rm -f` reap actually LEAKED a container, but
+// the reap returned a PLAIN error. KillSession/deleteSessionRecord classify a
+// teardown by session.TeardownStateUnknown — retain on ErrWorkspaceStateUnknown /
+// ErrPaneMayBeLive, otherwise treat it as a KNOWN teardown and delete the row. So
+// a timeout was classified "known" → the row was deleted → the leaked container
+// was orphaned with no record pointing at it.
+//
+// This is the fabricated-negative / teardown-taxonomy family: a two-valued error
+// cannot say "I don't know whether the container is gone", so a timeout reads as
+// "gone". The fix maps a tripped deadline to ErrWorkspaceStateUnknown so the row
+// is RETAINED (and the leaked container surfaced) rather than silently deleted.
+
+// withShortDockerReapTimeout shortens the reap deadline so the timeout path is
+// exercised in milliseconds, restoring it after the test.
+func withShortDockerReapTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	prev := dockerReapTimeout
+	dockerReapTimeout = d
+	t.Cleanup(func() { dockerReapTimeout = prev })
+}
+
+// TestDockerReapTimeoutIsWorkspaceStateUnknown is the #2049 regression: a reap
+// whose `docker rm -f` is killed on its deadline (the container's state is
+// therefore unknown — it may still be running) must wrap ErrWorkspaceStateUnknown,
+// so TeardownStateUnknown returns true and the daemon RETAINS the row.
+//
+// The injected dockerExec faithfully models a deadline kill: it blocks until the
+// caller's context is cancelled and returns ctx.Err() (context.DeadlineExceeded),
+// exactly as exec.CommandContext's kill surfaces to reap via ctx.Err(). Before the
+// fix reap returned a plain error and TeardownStateUnknown was false.
+func TestDockerReapTimeoutIsWorkspaceStateUnknown(t *testing.T) {
+	withShortDockerReapTimeout(t, 150*time.Millisecond)
+	restore := SetDockerExecForTest(func(ctx context.Context, _ ...string) ([]byte, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+	defer restore()
+
+	p := &dockerProvisioner{spec: ProvisionSpec{Title: "wedged"}, containerID: "deadbeefcafe0000"}
+
+	done := make(chan error, 1)
+	go func() { done <- p.reap() }()
+
+	var err error
+	select {
+	case err = <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("reap did not return within 10s — dockerReapTimeout/dockerWaitDelay is not bounding the reap")
+	}
+
+	if err == nil {
+		t.Fatal("a timed-out `docker rm -f` must return an error, got nil")
+	}
+	if !errors.Is(err, ErrWorkspaceStateUnknown) {
+		t.Fatalf("a wedged/timed-out reap must wrap ErrWorkspaceStateUnknown so the row is retained (#2049); got a plain error: %v", err)
+	}
+	if !TeardownStateUnknown(err) {
+		t.Fatalf("TeardownStateUnknown must be true for a timed-out reap so KillSession/deleteSessionRecord RETAIN the row instead of orphaning the leaked container; got false for: %v", err)
+	}
+}
+
+// TestDockerReapReportedErrorStaysKnown locks the polarity in the other
+// direction: a reap that docker ANSWERED with an error (the container is already
+// gone, or docker reported a real problem) is a teardown that TOLD us something —
+// it must stay a KNOWN-state error so the row may be deleted, per the documented
+// deleteSessionRecord contract. Mapping every reap failure to unknown would make
+// the "No such container" (already-gone) case wedge the record forever.
+func TestDockerReapReportedErrorStaysKnown(t *testing.T) {
+	withShortDockerReapTimeout(t, 5*time.Second) // never reached; the fake answers instantly
+	restore := SetDockerExecForTest(func(_ context.Context, _ ...string) ([]byte, error) {
+		return []byte("Error: No such container: deadbeef"), fmt.Errorf("exit status 1")
+	})
+	defer restore()
+
+	p := &dockerProvisioner{spec: ProvisionSpec{Title: "answered"}, containerID: "deadbeefcafe0000"}
+	err := p.reap()
+	if err == nil {
+		t.Fatal("a failed `docker rm -f` must return an error")
+	}
+	if errors.Is(err, ErrWorkspaceStateUnknown) {
+		t.Fatalf("a reap docker ANSWERED with an error must NOT be classified unknown — that would wedge the already-gone case forever: %v", err)
+	}
+	if TeardownStateUnknown(err) {
+		t.Fatalf("TeardownStateUnknown must be false for an answered reap failure so the row may be deleted: %v", err)
+	}
+}
+
+// TestDockerReapSuccessReturnsNil guards the healthy path: a clean reap returns
+// nil, so the WaitDelay/timeout plumbing never turns a successful `docker rm -f`
+// into a phantom leak report.
+func TestDockerReapSuccessReturnsNil(t *testing.T) {
+	restore := SetDockerExecForTest(func(_ context.Context, _ ...string) ([]byte, error) {
+		return []byte("deadbeefcafe0000\n"), nil
+	})
+	defer restore()
+
+	p := &dockerProvisioner{spec: ProvisionSpec{Title: "clean"}, containerID: "deadbeefcafe0000"}
+	if err := p.reap(); err != nil {
+		t.Fatalf("a successful reap must return nil, got %v", err)
+	}
+}

--- a/session/backend_docker_reap_unknown_test.go
+++ b/session/backend_docker_reap_unknown_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -107,5 +108,108 @@ func TestDockerReapSuccessReturnsNil(t *testing.T) {
 	p := &dockerProvisioner{spec: ProvisionSpec{Title: "clean"}, containerID: "deadbeefcafe0000"}
 	if err := p.reap(); err != nil {
 		t.Fatalf("a successful reap must return nil, got %v", err)
+	}
+}
+
+// reapWithin runs p.reap() (which blocks up to dockerReapTimeout) in a goroutine and
+// returns its error, failing the test if it does not return within guard.
+func reapWithin(t *testing.T, p *dockerProvisioner, guard time.Duration) error {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() { done <- p.reap() }()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(guard):
+		t.Fatalf("reap did not return within %s", guard)
+		return nil
+	}
+}
+
+// TestDockerReapTimeoutIsReRunnable is the #2063-review guard: a timed-out reap must
+// NOT latch. The daemon's finishUserKill re-invokes instance.Kill() → reap() on
+// every poll for a retained (tombstoned) record; if reap latched on the first
+// timeout, the second call would return nil — the container never re-reaped — so the
+// row would be deleted and the container orphaned exactly one poll later, defeating
+// the fix. A second reap() while docker is still wedged must (i) actually re-attempt
+// `docker rm -f` and (ii) keep returning the unknown sentinel, never nil.
+func TestDockerReapTimeoutIsReRunnable(t *testing.T) {
+	withShortDockerReapTimeout(t, 150*time.Millisecond)
+	var calls int32
+	restore := SetDockerExecForTest(func(ctx context.Context, _ ...string) ([]byte, error) {
+		atomic.AddInt32(&calls, 1)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+	defer restore()
+
+	p := &dockerProvisioner{spec: ProvisionSpec{Title: "wedged"}, containerID: "deadbeefcafe0000"}
+
+	first := reapWithin(t, p, 10*time.Second)
+	if !errors.Is(first, ErrWorkspaceStateUnknown) {
+		t.Fatalf("first timed-out reap must wrap ErrWorkspaceStateUnknown, got %v", first)
+	}
+
+	second := reapWithin(t, p, 10*time.Second)
+	if second == nil {
+		t.Fatal("second reap after a timeout returned nil — the latch skipped the retry, so the row " +
+			"would be deleted and the container orphaned one poll later (#2063 review)")
+	}
+	if !errors.Is(second, ErrWorkspaceStateUnknown) {
+		t.Fatalf("a second reap while docker is still wedged must keep returning ErrWorkspaceStateUnknown, got %v", second)
+	}
+	if !TeardownStateUnknown(second) {
+		t.Fatalf("the retained row depends on TeardownStateUnknown staying true across retries, got false for: %v", second)
+	}
+	if n := atomic.LoadInt32(&calls); n < 2 {
+		t.Fatalf("a timed-out reap must actually re-attempt `docker rm -f` on the next call; dockerExec ran %d times, want >= 2", n)
+	}
+}
+
+// TestDockerReapTimeoutThenSuccessClears completes the retry contract: once docker
+// recovers, a reap after a prior timeout actually reaps the container and returns
+// nil, so the row is finally deleted rather than retained forever — and a further
+// reap stays latched at nil.
+//
+// The call-count assertion is what makes this discriminating rather than
+// decorative: a latching reap ALSO returns nil on the second call (that is the
+// #2063-review bug), so "returned nil" alone passes on the broken code. Only proving
+// `docker rm -f` actually RAN again distinguishes a real re-attempt from a stale
+// latched nil.
+func TestDockerReapTimeoutThenSuccessClears(t *testing.T) {
+	withShortDockerReapTimeout(t, 150*time.Millisecond)
+	var wedged atomic.Bool
+	var calls int32
+	wedged.Store(true)
+	restore := SetDockerExecForTest(func(ctx context.Context, _ ...string) ([]byte, error) {
+		atomic.AddInt32(&calls, 1)
+		if wedged.Load() {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+		return []byte("deadbeefcafe0000\n"), nil
+	})
+	defer restore()
+
+	p := &dockerProvisioner{spec: ProvisionSpec{Title: "recovers"}, containerID: "deadbeefcafe0000"}
+
+	if err := reapWithin(t, p, 10*time.Second); !errors.Is(err, ErrWorkspaceStateUnknown) {
+		t.Fatalf("first (wedged) reap must be unknown, got %v", err)
+	}
+	wedged.Store(false) // docker recovers
+	if err := reapWithin(t, p, 10*time.Second); err != nil {
+		t.Fatalf("after docker recovers, the retry must reap and return nil so the row is deleted, got %v", err)
+	}
+	if n := atomic.LoadInt32(&calls); n < 2 {
+		t.Fatalf("the post-recovery reap must actually re-run `docker rm -f`, not return a latched nil; "+
+			"dockerExec ran %d times, want >= 2 (a latched nil would leave the container leaked)", n)
+	}
+	// Now that a reap COMPLETED, it latches: no further docker command, still nil.
+	after := atomic.LoadInt32(&calls)
+	if err := reapWithin(t, p, 10*time.Second); err != nil {
+		t.Fatalf("a completed reap must latch nil, got %v", err)
+	}
+	if n := atomic.LoadInt32(&calls); n != after {
+		t.Fatalf("a completed reap must not re-run `docker rm -f` (the Kill-retry collapse the latch exists for); ran %d more times", n-after)
 	}
 }


### PR DESCRIPTION
Closes #2049.

## Problem

`KillSession` / `deleteSessionRecord` decide whether to delete a session's row by
`session.TeardownStateUnknown(teardownErr)` — **retain** on
`ErrWorkspaceStateUnknown` / `ErrPaneMayBeLive`, otherwise treat the teardown as
**known** and delete. But `dockerProvisioner.reap` (`session/backend_docker.go`)
returned a **plain** error when `docker rm -f` was killed on its deadline. So a
wedged/timed-out reap that actually **leaked** a container was classified "known"
→ the row was deleted → the container was orphaned with no record pointing at it.

This is the fabricated-negative / teardown-taxonomy family (see #1917 / #2017): a
two-valued error can't say *"I don't know whether the container is gone"*, so a
timeout reads as *"gone"*. Pre-existing — **not** introduced by #2046, which only
removed a false "left intact" message; the delete end-state was the same before it.

## Fix

`reap` now owns its `context` (rather than hiding it inside `p.docker`) so a
tripped deadline is distinguishable from a reap docker *answered* with an error:

- **deadline kill** (`ctx.Err() == DeadlineExceeded`, and `err != nil` — the #914
  guard, so a normalized `exec.ErrWaitDelay` success never lands here) → wrap
  `ErrWorkspaceStateUnknown` → `TeardownStateUnknown` is true → the daemon
  **retains** the row (its only handle on the possibly-leaked container).
- **docker answered with an error** (e.g. `No such container` — already gone, or a
  real reported problem) → stays a plain **known**-state error and the row may go,
  per the documented `deleteSessionRecord` contract. Mapping *every* reap failure
  to unknown would wedge the already-gone case forever.

The sentinel reaches the daemon unchanged: `remoteAgentServer.Kill` joins the
REST-kill and reap errors via `errors.Join`, which preserves `errors.Is`, so
`TeardownStateUnknown` sees it — **no daemon-side change needed**.

`dockerReapTimeout` becomes a `var` so tests can shorten it (mirrors
`networkGitTimeout` / `tmuxCommandTimeout`); production never reassigns it.

## Tests (fail-first)

- `TestDockerReapTimeoutIsWorkspaceStateUnknown` — injects a `dockerExec` that
  returns `ctx.Err()` on a deadline kill. **Observed failing** with the
  sentinel-wrap removed (plain `context deadline exceeded`,
  `TeardownStateUnknown=false`); passes with the wrap.
- `TestDockerReapReportedErrorStaysKnown` — a docker-*answered* failure must
  **not** be classified unknown (polarity lock).
- `TestDockerReapSuccessReturnsNil` — a clean reap returns nil.

Full `./session/` package green. `gofmt`/`go build`/`golangci-lint --fast`/`deadcode
-test ./...` all clean.

## Adjacent sites (audited, deferred)

The ssh (`runSession`) and hook (`runHookScript`) reaps share this bug class, but
collapse the deadline inside **shared runners used by provisioning paths**, so
mapping their timeouts to `ErrWorkspaceStateUnknown` correctly needs its own
change + tests (touching multi-caller runners) rather than being bundled into this
docker-scoped fix. Flagged here so it isn't lost.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)