### PR TITLE
fix(kill): bound confirmation git reads + warn unmerged work for non-started sessions (#2030, #2029)

### DIFF
--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -194,19 +194,22 @@ func (m *home) handleKill() (tea.Model, tea.Cmd) {
 	var warnings []string
 	severeLine := ""
 	if selected.Capabilities().Workspace == session.WorkspaceLocalWorktree {
+		// Both loss checks run under the SAME worktree-path gate so they cover the
+		// same session states. GetWorktreePath and GetBaseCommitSHA are NOT gated on
+		// started (unlike GetGitWorktree), so a session that HAS a worktree but was
+		// never started — e.g. a restore-failed session — still gets the unmerged-work
+		// warning the old GetGitWorktree gate skipped for it (#2029). Killing force-
+		// deletes its branch either way, so the same committed work is at stake; the
+		// dirty-worktree check was already ungated, and the two must not diverge.
 		if wt := selected.GetWorktreePath(); wt != "" {
 			if w := killConfirmationWarning(wt); w != "" {
 				warnings = append(warnings, w)
 			}
-		}
-		// GetGitWorktree is gated on the session being started, which is the case
-		// for the #2022 target: a live session whose agent has committed work.
-		if gw, err := selected.GetGitWorktree(); err == nil && gw != nil {
 			prState := ""
 			if pr := selected.GetPRInfo(); pr != nil {
 				prState = pr.State
 			}
-			if line, severe := unmergedCommitWarning(gw.GetWorktreePath(), gw.GetBaseCommitSHA(), prState); line != "" {
+			if line, severe := unmergedCommitWarning(wt, selected.GetBaseCommitSHA(), prState); line != "" {
 				if severe {
 					severeLine = line
 				} else {

--- a/app/kill_confirm.go
+++ b/app/kill_confirm.go
@@ -1,12 +1,75 @@
 package app
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
+	"syscall"
+	"time"
 
 	"github.com/sachiniyer/agent-factory/log"
 )
+
+// killGitTimeout bounds the local git metadata reads the kill confirmation runs.
+// handleKill is synchronous on the Bubble Tea Update loop, so a wedged git (a
+// hung network mount, a D-state process holding the worktree) would freeze the
+// whole TUI without a deadline (#2030). The reads are local and offline (status,
+// log, rev-parse, symbolic-ref), so this only trips on a genuine stall; it is
+// generous enough that a slow-but-progressing read on a cold cache still
+// completes. Mirrors session/git's localGitTimeout reasoning (#1917).
+//
+// A var (not a const) only so tests can shorten it; production never reassigns.
+var killGitTimeout = 5 * time.Second
+
+// killGitWaitDelay bounds how long cmd.Wait blocks after git exits or is killed on
+// the deadline, before the inherited pipes are force-closed. A child that inherited
+// the capture pipe would otherwise block Output() on pipe EOF past the deadline and
+// defeat it (the #856/#1967 lesson). Mirrors gitWaitDelay.
+const killGitWaitDelay = 2 * time.Second
+
+// runKillGit runs `git -C dir args...` bounded by killGitTimeout, in its own
+// process group so the deadline tears down git and any child it spawned together,
+// with a WaitDelay so a straggler holding the capture pipe cannot outlast the
+// bound. It mirrors session/git's runGitCommandContext (#856/#896/#1967),
+// reproduced here because that runner is a private method on *GitWorktree in
+// another package and these callers operate on a bare worktree path.
+func runKillGit(dir string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), killGitTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", dir}, args...)...)
+	// Own process group so the deadline kills git AND any child together, rather
+	// than exec.CommandContext's default of SIGKILLing only the git process.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		// Negative pid targets the whole group; a group already gone (ESRCH) maps to
+		// os.ErrProcessDone, which Wait ignores rather than reporting as a failure.
+		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+			if errors.Is(err, syscall.ESRCH) {
+				return os.ErrProcessDone
+			}
+			return err
+		}
+		return nil
+	}
+	cmd.WaitDelay = killGitWaitDelay
+	out, err := cmd.Output()
+	if cmd.Process != nil {
+		// Reap any child that outlived git on every exit path so a wedged read never
+		// leaks a pipe-holding process; the group is led by the already-exited git,
+		// so this is ESRCH (ignored) in the common case.
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+	if errors.Is(err, exec.ErrWaitDelay) {
+		// git itself exited (a non-zero exit surfaces as an *exec.ExitError, not
+		// ErrWaitDelay); only a child held the pipe past killGitWaitDelay and was
+		// just reaped. The output is complete, so this is not a failure (#676/#914).
+		err = nil
+	}
+	return out, err
+}
 
 // This file holds the kill-confirmation copy and the data-loss detection behind
 // it. handleKill (handle_actions.go) assembles these into the confirmation the
@@ -64,7 +127,7 @@ func killConfirmMessage(title, warning string, reserved bool) string {
 // clean — fail closed and warn that changes may be lost rather than silently
 // skipping the warning (#815).
 func killConfirmationWarning(wt string) string {
-	out, err := exec.Command("git", "-C", wt, "status", "--porcelain").Output()
+	out, err := runKillGit(wt, "status", "--porcelain")
 	if err != nil {
 		log.WarningLog.Printf("could not verify worktree status for %s before kill: %v", wt, err)
 		return fmt.Sprintf("WARNING: Could not verify worktree status (%v); it may contain uncommitted changes that will be lost!", err)
@@ -113,7 +176,7 @@ func unmergedCommitWarning(worktreePath, recordedBaseSHA, prState string) (strin
 	}
 	// Commits reachable from the branch tip (HEAD is the branch, checked out in
 	// the worktree) but not from base: the session's own commits.
-	uniqueOut, err := exec.Command("git", "-C", worktreePath, "log", "--oneline", base+"..HEAD").Output()
+	uniqueOut, err := runKillGit(worktreePath, "log", "--oneline", base+"..HEAD")
 	if err != nil {
 		return unmergedFailClosedLine(err), false
 	}
@@ -128,7 +191,7 @@ func unmergedCommitWarning(worktreePath, recordedBaseSHA, prState string) (strin
 	}
 	// Of the session's commits, those NOT reachable from any remote-tracking ref
 	// are the ones that exist only here. branch -D orphans exactly these.
-	localOut, err := exec.Command("git", "-C", worktreePath, "log", "--oneline", base+"..HEAD", "--not", "--remotes").Output()
+	localOut, err := runKillGit(worktreePath, "log", "--oneline", base+"..HEAD", "--not", "--remotes")
 	if err != nil {
 		return unmergedFailClosedLine(err), false
 	}
@@ -149,14 +212,14 @@ func unmergedCommitWarning(worktreePath, recordedBaseSHA, prState string) (strin
 // (for the copy), else "".
 func resolveKillBase(worktreePath, recordedBaseSHA string) (base, baseLabel string, ok bool) {
 	commitExists := func(rev string) bool {
-		_, err := exec.Command("git", "-C", worktreePath, "rev-parse", "--verify", "--quiet", rev+"^{commit}").Output()
+		_, err := runKillGit(worktreePath, "rev-parse", "--verify", "--quiet", rev+"^{commit}")
 		return err == nil
 	}
 	if b := strings.TrimSpace(recordedBaseSHA); b != "" && commitExists(b) {
 		return b, "", true
 	}
 	// origin/HEAD (symbolic ref to origin's default branch), then the usual names.
-	if out, err := exec.Command("git", "-C", worktreePath, "symbolic-ref", "--short", "-q", "refs/remotes/origin/HEAD").Output(); err == nil {
+	if out, err := runKillGit(worktreePath, "symbolic-ref", "--short", "-q", "refs/remotes/origin/HEAD"); err == nil {
 		if ref := strings.TrimSpace(string(out)); ref != "" && commitExists(ref) {
 			return ref, strings.TrimPrefix(ref, "origin/"), true
 		}

--- a/app/kill_confirm_bound_test.go
+++ b/app/kill_confirm_bound_test.go
@@ -1,0 +1,103 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// #2030: the kill-confirmation's git reads run synchronously in handleKill on the
+// Bubble Tea Update loop, on bare exec.Command(...).Output() with no context, no
+// timeout, and no WaitDelay. A wedged git — a hung network mount, a D-state
+// process holding the worktree, or (as reproduced here) a child that inherited the
+// capture pipe and outlives git — would block Output() on pipe EOF and freeze the
+// whole TUI. Same class as #1967 (exec.CommandContext without WaitDelay).
+//
+// This drives a REAL fake git on PATH whose child holds the capture pipe open past
+// git's own exit (a blocking mock can't reproduce a pipe-holding descendant, which
+// is the exact failure WaitDelay exists for). Without the bound the call waits the
+// straggler out (stragglerSleep); with runKillGit's WaitDelay + process-group reap
+// it returns in ~killGitWaitDelay.
+
+const (
+	// killStragglerSleep must exceed killStragglerGuard so a missing WaitDelay is a
+	// guard failure, not a slow pass; the straggler is killed on cleanup.
+	killStragglerSleep = 30
+	// killStragglerGuard sits between the 2s killGitWaitDelay and the straggler
+	// sleep, with ample slack over 2s so a loaded box never flakes the fixed path.
+	killStragglerGuard = 8 * time.Second
+)
+
+// installStragglerGitOnPath writes a fake `git` onto PATH that backgrounds a sleep
+// inheriting the capture pipe (the surviving descendant of #1967) then exits 0, and
+// returns a worktree dir to pass to the confirmation helpers. The straggler is
+// killed on cleanup so nothing is orphaned and any call left blocked by a
+// regression is unblocked immediately.
+func installStragglerGitOnPath(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "straggler.pid")
+	script := "#!/bin/sh\n" +
+		"sleep " + strconv.Itoa(killStragglerSleep) + " &\n" +
+		"echo $! > " + shSingleQuote(pidFile) + "\n" +
+		"exit 0\n"
+	if err := os.WriteFile(filepath.Join(dir, "git"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake git: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Cleanup(func() {
+		data, err := os.ReadFile(pidFile)
+		if err != nil {
+			return
+		}
+		if pid, err := strconv.Atoi(strings.TrimSpace(string(data))); err == nil && pid > 0 {
+			_ = os.Remove(pidFile)
+			_ = syscall.Kill(pid, syscall.SIGKILL)
+		}
+	})
+	return t.TempDir() // a distinct dir as the "worktree" arg; the fake ignores it
+}
+
+func shSingleQuote(s string) string { return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'" }
+
+// TestKillConfirmationWarningIsBounded is the #2030 regression driven through the
+// real production path (killConfirmationWarning → runKillGit): it must return on
+// its own deadline rather than block on a git whose child holds the capture pipe.
+func TestKillConfirmationWarningIsBounded(t *testing.T) {
+	wt := installStragglerGitOnPath(t)
+
+	done := make(chan string, 1)
+	go func() { done <- killConfirmationWarning(wt) }()
+
+	select {
+	case <-done:
+	case <-time.After(killStragglerGuard):
+		t.Fatalf("killConfirmationWarning did not return within %s — its git exec runs on the Bubble Tea "+
+			"Update loop with no WaitDelay, so a git whose child holds the capture pipe (or a wedged git) "+
+			"freezes the whole TUI (#2030)", killStragglerGuard)
+	}
+}
+
+// TestUnmergedCommitWarningIsBounded covers the other confirmation helper, which
+// makes several git reads (rev-parse, log …) — all now through runKillGit, so a
+// wedged git on any of them cannot hang the Update loop either.
+func TestUnmergedCommitWarningIsBounded(t *testing.T) {
+	wt := installStragglerGitOnPath(t)
+
+	done := make(chan struct{}, 1)
+	go func() {
+		_, _ = unmergedCommitWarning(wt, "deadbeef", "")
+		done <- struct{}{}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(killStragglerGuard):
+		t.Fatalf("unmergedCommitWarning did not return within %s — one of its git reads on the Update "+
+			"loop is unbounded (#2030)", killStragglerGuard)
+	}
+}

--- a/app/kill_nonstarted_test.go
+++ b/app/kill_nonstarted_test.go
@@ -1,0 +1,89 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/git"
+)
+
+// #2029: the committed-unmerged-work warning (#2022) was gated behind
+// GetGitWorktree(), which errors when started=false. So a session that has a
+// worktree but was never started — e.g. one whose restore failed — got the bare,
+// safe-looking "[!] Kill session 'x'?" prompt with no data-loss warning, even
+// though killing still force-deletes its branch and orphans the same committed
+// work. The dirty-worktree check (via GetWorktreePath) was NOT so gated, so the two
+// checks covered different session states. The fix runs both under the ungated
+// GetWorktreePath / GetBaseCommitSHA accessors.
+
+// nonStartedWorktreeInstance builds an instance with a real git worktree that is
+// NOT started (the restore-failed shape #2029 is about): GetGitWorktree errors for
+// it, but GetWorktreePath / GetBaseCommitSHA still resolve. Status is set to a
+// non-creating, non-tearing-down value so handleKill opens the confirmation.
+func nonStartedWorktreeInstance(t *testing.T, title, repoDir, worktreePath, branch, baseSHA string) *session.Instance {
+	t.Helper()
+	inst, err := session.NewInstance(session.InstanceOptions{Title: title, Path: repoDir, Program: "test"})
+	require.NoError(t, err)
+	inst.SetBackend(session.NewFakeBackend())
+	inst.SetStatusForTest(session.Ready) // clears OpCreating; started stays false
+	gw, err := git.NewGitWorktreeFromStorage(repoDir, worktreePath, title, branch, baseSHA, false, true)
+	require.NoError(t, err)
+	inst.SetGitWorktreeForTest(gw)
+	return inst
+}
+
+// TestHandleKill_NonStarted_UnmergedCommit_StillWarns is the #2029 regression: a
+// non-started session whose branch carries an unmerged, unpushed commit must still
+// get the loud data-loss warning and the distinct confirm key — the same
+// protection a started session gets (#2022), because the kill destroys the same
+// work.
+func TestHandleKill_NonStarted_UnmergedCommit_StillWarns(t *testing.T) {
+	repoDir, baseSHA := initBaseRepo(t)
+	wt := addWorktree(t, repoDir, baseSHA, "dev/nonstarted")
+	commitInWorktree(t, wt)
+	require.Empty(t, killGit(t, wt, "status", "--porcelain"), "worktree must be clean (only committed work at risk)")
+
+	inst := nonStartedWorktreeInstance(t, "nonstarted", repoDir, wt, "dev/nonstarted", baseSHA)
+
+	// Preconditions that make this the #2029 case: not started, and the OLD gate
+	// (GetGitWorktree) errors — so the pre-fix code skipped the unmerged check —
+	// while the ungated accessors the fix uses still resolve.
+	require.False(t, inst.Started(), "the session must be non-started")
+	_, gwErr := inst.GetGitWorktree()
+	require.Error(t, gwErr, "GetGitWorktree is started-gated; the old code skipped the unmerged check for this session")
+	require.NotEmpty(t, inst.GetWorktreePath(), "the ungated worktree-path accessor must still resolve")
+	require.Equal(t, baseSHA, inst.GetBaseCommitSHA(), "the ungated base-SHA accessor must still resolve")
+
+	_, hm := armKill(t, inst)
+
+	rendered := flatten(hm.confirmationOverlay.Render())
+	assert.Contains(t, rendered, "1 commit",
+		"the unmerged-work warning must compute for a session that has a worktree even if never started (#2029)")
+	assert.Contains(t, rendered, "cannot be undone")
+	assert.NotContains(t, rendered, "uncommitted changes", "the loss is committed work, not a dirty worktree")
+	require.Equal(t, unmergedKillConfirmKey, hm.confirmationOverlay.ConfirmKey,
+		"a non-started session's unrecoverable committed work must still escalate the confirm key, not the ordinary 'y'")
+}
+
+// TestHandleKill_NonStarted_CleanLevelBranch_KeepsBareConfirmation guards the
+// other direction: a non-started session with nothing to lose (branch level with
+// base) must still kill behind the bare confirmation and ordinary 'y' — the
+// ungating must not manufacture a false warning.
+func TestHandleKill_NonStarted_CleanLevelBranch_KeepsBareConfirmation(t *testing.T) {
+	repoDir, baseSHA := initBaseRepo(t)
+	wt := addWorktree(t, repoDir, baseSHA, "dev/nonstarted-empty") // no commit beyond base
+
+	inst := nonStartedWorktreeInstance(t, "nonstarted-empty", repoDir, wt, "dev/nonstarted-empty", baseSHA)
+	require.False(t, inst.Started())
+
+	_, hm := armKill(t, inst)
+
+	rendered := flatten(hm.confirmationOverlay.Render())
+	assert.Contains(t, rendered, "Kill session 'nonstarted-empty'?")
+	assert.NotContains(t, rendered, "commit", "a level branch must not warn about commits")
+	assert.Equal(t, "y", hm.confirmationOverlay.ConfirmKey,
+		"a non-started session with nothing to lose must keep the ordinary 'y' confirm")
+}

--- a/session/instance_accessors.go
+++ b/session/instance_accessors.go
@@ -94,6 +94,24 @@ func (i *Instance) GetWorktreePath() string {
 	return gw.GetWorktreePath()
 }
 
+// GetBaseCommitSHA returns the recorded base commit SHA of the instance's
+// worktree, or "" when there is no worktree. Deliberately NOT gated on started
+// (unlike GetGitWorktree): the kill-confirmation's unmerged-work check must run
+// for a session that has a worktree even if it was never started — a restore-
+// failed session's branch still gets force-deleted by the kill (#2029). Mirrors
+// GetWorktreePath, which is likewise ungated so both loss checks cover the same
+// session states.
+func (i *Instance) GetBaseCommitSHA() string {
+	i.mu.RLock()
+	gw := i.gitWorktree
+	i.mu.RUnlock()
+
+	if gw == nil {
+		return ""
+	}
+	return gw.GetBaseCommitSHA()
+}
+
 // GetRepoPath returns the resolved git repo path stored in the instance's
 // worktree, or empty string when no worktree is attached (e.g. a remote-
 // backend instance). Callers using the result to derive a repo ID must


### PR DESCRIPTION
Closes #2030. Closes #2029.

Two kill-confirmation defects from the #2024 fresh review, in the same files, so
batched into one focused PR.

## #2030 — unbounded git exec on the Bubble Tea Update loop

The confirmation's git reads (`status`, `log`, `rev-parse`, `symbolic-ref`) run in
`handleKill` **synchronously on the Update loop**, on bare
`exec.Command(...).Output()` with no context, no timeout, and no `WaitDelay`. A
wedged git — a hung network mount, a D-state process holding the worktree, or a
child that inherited the capture pipe and outlives git — blocks `Output()` on pipe
EOF and freezes the whole TUI. Same class as #1967.

Fix: route all of them through a new `runKillGit` — `context` deadline
(`killGitTimeout`) + own process group (`Setpgid`) + `WaitDelay` + process-group
reap, normalizing a bare `exec.ErrWaitDelay` to success. It mirrors
`session/git`'s `runGitCommandContext` (#856/#896/#1967), reproduced in package
`app` because that runner is a private method on `*GitWorktree`. All five call
sites in `kill_confirm.go` were converted (the issue's "3-4"), so the whole
confirmation path is bounded.

## #2029 — unmerged-work warning skipped for non-started sessions

The committed-unmerged-work warning (#2022) was gated on `GetGitWorktree()`, which
**errors when `started=false`**. So a session that has a worktree but was never
started (e.g. a restore-failed one) got the bare, safe-looking
`[!] Kill session 'x'?` prompt with no data-loss warning — even though the kill
still `git branch -D`s its branch and orphans the same committed work. The
dirty-worktree check (via `GetWorktreePath`) was **not** gated, so the two loss
checks covered different session states.

Fix: add an ungated `Instance.GetBaseCommitSHA()` (mirrors the ungated
`GetWorktreePath`) and run **both** loss checks under the same `GetWorktreePath`
gate, so they cover the same session states. No change to the started case (#2022
target) — a started session resolves the same values.

## Tests (fail-first)

- `TestKillConfirmationWarningIsBounded` / `TestUnmergedCommitWarningIsBounded` —
  drive the real helpers through a fake `git` whose child holds the capture pipe (a
  blocking mock can't reproduce a pipe-holding descendant). **Observed failing**
  (8s hang) with `kill_confirm.go` at `origin/master`; pass in ~2s/4s with
  `runKillGit`.
- `TestHandleKill_NonStarted_UnmergedCommit_StillWarns` — drives `handleKill` for a
  non-started worktree instance. **Observed failing** with `handle_actions.go` at
  `origin/master` (bare prompt: confirm key `y`, no "1 commit"); passes with the
  ungated gate (escalates to `k`). `TestHandleKill_NonStarted_CleanLevelBranch_Keeps
  BareConfirmation` pins that a level branch still keeps the ordinary `y`, so the
  ungating doesn't manufacture a false warning.

Full `./app/` package green (incl. the existing #2022 suite). `gofmt`/`go build`/
`golangci-lint --fast`/`deadcode -test ./...` all clean.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)