### PR TITLE
fix(tmux): confirm the paste landed before sending Enter (#1982)

### DIFF
--- a/session/tmux/submit.go
+++ b/session/tmux/submit.go
@@ -21,6 +21,41 @@ import (
 var (
 	pasteDeliveryMaxWait      = 2 * time.Second
 	pasteDeliveryPollInterval = 50 * time.Millisecond
+	// emptyPromptDrain is the fallback for a prompt that normalizes to nothing,
+	// where there is no text to positively confirm. It keeps the ORIGINAL 500ms
+	// drain rather than silently shortening it.
+	emptyPromptDrain = 500 * time.Millisecond
+)
+
+// minDistinctiveTail is the shortest tail treated as self-evidently distinctive.
+// A very short prompt ("ok", "y") yields a tail that unrelated pane churn could
+// plausibly emit, so a single sighting is weak evidence. Below this length the
+// delivery check additionally requires the tail to be seen in TWO consecutive
+// captures, so a one-frame coincidence cannot confirm delivery early and let
+// Enter race the paste after all.
+const minDistinctiveTail = 8
+
+// deliveryOutcome is deliberately THREE-valued. A probe that cannot see the pane
+// must never manufacture a negative — the failure mode this repo keeps
+// re-learning — so "I could not look" stays distinct from "I looked and it was
+// not there". Only the latter is evidence of a failed delivery.
+type deliveryOutcome int
+
+const (
+	// deliveryConfirmed: the pasted text was observed to arrive.
+	deliveryConfirmed deliveryOutcome = iota
+	// deliveryNotObserved: captures were working and the text never appeared on
+	// screen. Note the name — this is NOT "it did not arrive". A pane is free to
+	// consume input without echoing it (anything with echo off, e.g. a password
+	// prompt; the #1956 receiver-pane gate is exactly such a program, and its
+	// bytes provably arrive while the screen only ever shows AF-RECEIVER-READY).
+	// Arrival and echo are different facts, so this stays a loud WARNING and
+	// never an error: treating it as a delivery failure would condemn every
+	// non-echoing pane.
+	deliveryNotObserved
+	// deliveryUnknown: capture itself failed (headless/transient), or there was
+	// nothing assertable. Nothing may be concluded.
+	deliveryUnknown
 )
 
 // pasteBufferSeq makes each bracketed-paste buffer name unique per call so two
@@ -95,14 +130,17 @@ func (t *TmuxSession) sendKeysPasteBuffer(text string) error {
 	// after pasting so buffers never accumulate.
 	buf := pasteBufferName(pasteBufferProcessToken, t.sanitizedName, pasteBufferSeq.Add(1))
 
+	tail := deliveryTail(text)
+
 	// Baseline the pane BEFORE delivery so the post-paste check waits for the
 	// prompt's tail to newly APPEAR (a count increase), not merely be present:
 	// the daemon re-delivers the same prompt after a limit resume (#1146), so an
 	// identical tail could already be on screen.
-	tail := deliveryTail(text)
 	baseline := 0
 	if tail != "" {
-		baseline = strings.Count(normalizeDelivery(t.capturePaneForDelivery()), tail)
+		if content, ok := t.capturePaneForDelivery(); ok {
+			baseline = strings.Count(normalizeDelivery(content), tail)
+		}
 	}
 
 	loadCmd := exec.Command("tmux", "load-buffer", "-b", buf, "-")
@@ -142,9 +180,27 @@ func (t *TmuxSession) sendKeysPasteBuffer(text string) error {
 	// (usually well under the old 500ms) and, on the rare pane where capture
 	// cannot confirm it, falls back to sending Enter after the cap so delivery is
 	// never worse than the old blind sleep.
-	t.waitForPasteDelivered(tail, baseline)
+	delivered := t.waitForPasteDelivered(tail, baseline)
 
 	// Send Enter separately to submit.
+	if err := t.sendEnter(); err != nil {
+		return err
+	}
+
+	if delivered == deliveryNotObserved {
+		// Loud, but NOT an error — see deliveryNotObserved. This is the "silent
+		// success" half of #1982 addressed as far as this layer soundly can:
+		// the operator gets a record that the prompt was never seen to land,
+		// without a delivery failure being invented for every non-echoing pane.
+		log.ErrorLog.Printf("submit: prompt for session %q was never observed on screen; "+
+			"if this pane echoes input, the prompt may be unsubmitted. Pane tail: %s",
+			t.sanitizedName, paneTailForLog(t))
+	}
+	return nil
+}
+
+// sendEnter submits whatever is pending in the pane.
+func (t *TmuxSession) sendEnter() error {
 	enterCmd := exec.Command("tmux", "send-keys", "-t", exactTarget(t.sanitizedName), "Enter")
 	return t.cmdExec.Run(enterCmd)
 }
@@ -191,36 +247,86 @@ func normalizeDelivery(s string) string {
 // a failed capture only ever means "not confirmed yet". `-J` is kept, so a line
 // the TERMINAL wrapped is rejoined by tmux itself; app-drawn wrapping inside a
 // composer's border box is handled by normalizeDelivery instead.
-func (t *TmuxSession) capturePaneForDelivery() string {
+// The bool reports whether the capture itself SUCCEEDED. Callers must keep that
+// separate from "the text was not there": a failed capture means the pane could
+// not be inspected at all, and collapsing that into a negative would let a
+// blind probe condemn a perfectly good delivery.
+func (t *TmuxSession) capturePaneForDelivery() (string, bool) {
 	cmd := exec.Command("tmux", "capture-pane", "-p", "-J", "-t", exactTarget(t.sanitizedName))
 	out, err := t.cmdExec.Output(cmd)
 	if err != nil {
-		return ""
+		return "", false
 	}
-	return string(out)
+	return string(out), true
 }
 
 // waitForPasteDelivered blocks until the pasted prompt's tail newly appears in
 // the pane (count exceeds the pre-paste baseline), or pasteDeliveryMaxWait
 // elapses. On expiry it logs and returns so Enter is still sent best-effort —
 // delivery is never worse than the fixed sleep it replaces (#1982).
-func (t *TmuxSession) waitForPasteDelivered(tail string, baseline int) {
+func (t *TmuxSession) waitForPasteDelivered(tail string, baseline int) deliveryOutcome {
 	if tail == "" {
-		// Nothing distinctive to confirm (empty/all-whitespace prompt); give
-		// control sequences a brief moment to drain, matching the old intent.
-		time.Sleep(pasteDeliveryPollInterval)
-		return
+		// Nothing distinctive to confirm (empty/all-whitespace prompt). There is
+		// no positive check to make, so keep the ORIGINAL 500ms drain rather than
+		// quietly shortening it.
+		time.Sleep(emptyPromptDrain)
+		return deliveryUnknown
 	}
 	deadline := time.Now().Add(pasteDeliveryMaxWait)
+	sawCapture := false
+	streak := 0
+	// A short tail is weak evidence, so require two consecutive sightings before
+	// trusting it (see minDistinctiveTail).
+	needed := 1
+	if len([]rune(tail)) < minDistinctiveTail {
+		needed = 2
+	}
 	for {
-		if strings.Count(normalizeDelivery(t.capturePaneForDelivery()), tail) > baseline {
-			return
+		if content, ok := t.capturePaneForDelivery(); ok {
+			sawCapture = true
+			if strings.Count(normalizeDelivery(content), tail) > baseline {
+				streak++
+				if streak >= needed {
+					return deliveryConfirmed
+				}
+			} else {
+				streak = 0
+			}
 		}
 		if time.Now().After(deadline) {
-			log.ErrorLog.Printf("submit: paste delivery for session %q not confirmed within %s; sending Enter best-effort",
+			if !sawCapture {
+				// Never saw the pane at all — unknown, not absent.
+				log.ErrorLog.Printf("submit: could not capture pane for session %q while confirming delivery; sending Enter best-effort",
+					t.sanitizedName)
+				return deliveryUnknown
+			}
+			log.ErrorLog.Printf("submit: paste delivery for session %q NOT observed within %s (the pane may simply not echo input); sending Enter best-effort",
 				t.sanitizedName, pasteDeliveryMaxWait)
-			return
+			return deliveryNotObserved
 		}
 		time.Sleep(pasteDeliveryPollInterval)
 	}
+}
+
+// paneTailForLog returns a short, single-line excerpt of the pane so a failure
+// says what the pane actually looked like instead of only that something failed.
+func paneTailForLog(t *TmuxSession) string {
+	content, ok := t.capturePaneForDelivery()
+	if !ok {
+		return "<pane not capturable>"
+	}
+	lines := strings.Split(strings.TrimRight(content, "\n \t"), "\n")
+	keep := lines
+	if len(keep) > 3 {
+		keep = keep[len(keep)-3:]
+	}
+	joined := strings.Join(keep, " ⏎ ")
+	joined = strings.Join(strings.Fields(joined), " ")
+	if len([]rune(joined)) > 200 {
+		joined = string([]rune(joined)[:200]) + "…"
+	}
+	if joined == "" {
+		return "<pane empty>"
+	}
+	return joined
 }

--- a/session/tmux/submit.go
+++ b/session/tmux/submit.go
@@ -7,8 +7,20 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+	"unicode"
 
 	"github.com/sachiniyer/agent-factory/log"
+)
+
+// pasteDeliveryMaxWait bounds how long the submit path waits for a pasted prompt
+// to appear in the pane before sending Enter, and pasteDeliveryPollInterval is
+// how often it re-checks. They are package vars so tests can tighten them. The
+// defaults confirm an idle pane in a single poll (well under the old fixed
+// 500ms) while still tolerating a pane that is mid-render and drains slower than
+// 500ms — the exact case that stranded prompts (#1982).
+var (
+	pasteDeliveryMaxWait      = 2 * time.Second
+	pasteDeliveryPollInterval = 50 * time.Millisecond
 )
 
 // pasteBufferSeq makes each bracketed-paste buffer name unique per call so two
@@ -83,6 +95,16 @@ func (t *TmuxSession) sendKeysPasteBuffer(text string) error {
 	// after pasting so buffers never accumulate.
 	buf := pasteBufferName(pasteBufferProcessToken, t.sanitizedName, pasteBufferSeq.Add(1))
 
+	// Baseline the pane BEFORE delivery so the post-paste check waits for the
+	// prompt's tail to newly APPEAR (a count increase), not merely be present:
+	// the daemon re-delivers the same prompt after a limit resume (#1146), so an
+	// identical tail could already be on screen.
+	tail := deliveryTail(text)
+	baseline := 0
+	if tail != "" {
+		baseline = strings.Count(normalizeDelivery(t.capturePaneForDelivery()), tail)
+	}
+
 	loadCmd := exec.Command("tmux", "load-buffer", "-b", buf, "-")
 	loadCmd.Stdin = strings.NewReader(text)
 	if err := t.cmdExec.Run(loadCmd); err != nil {
@@ -107,19 +129,98 @@ func (t *TmuxSession) sendKeysPasteBuffer(text string) error {
 		return fmt.Errorf("error pasting buffer: %w", err)
 	}
 
-	// Wait for terminal control sequences (e.g. OSC color responses) and the
-	// paste to drain before sending Enter, otherwise they can corrupt the input.
-	//
-	// Bracketing (above) may make this unnecessary for apps that requested the
-	// mode: the `\x1b[201~` end-of-paste marker tells them the paste is complete,
-	// which is the whole reason codex needed `-p` rather than a longer sleep
-	// (#1254/#1256). It cannot go away unconditionally, though — `-p` is a no-op
-	// for apps that never enabled the mode, and those get no marker and still
-	// need the drain. Removing it is a separate change with its own evidence;
-	// left alone here deliberately (#1956 follow-up).
-	time.Sleep(500 * time.Millisecond)
+	// Confirm the paste actually LANDED in the pane before sending Enter, instead
+	// of sleeping a fixed 500ms and hoping it drained. Enter is a separate
+	// `send-keys`, and when it overtakes an as-yet-undrained paste it either
+	// truncates the command or — on a bracketed-paste composer that has not yet
+	// processed the `\x1b[201~` end-of-paste marker — is absorbed as a literal
+	// newline, stranding the prompt in the composer unsubmitted while the send
+	// still reports success (#1982). The fixed sleep undershot precisely when the
+	// pane was mid-render (a spinner/animation shortly after a turn), which is
+	// where the strands clustered. Waiting for the pasted tail to appear ties the
+	// Enter to observed delivery: it returns as soon as the paste is visible
+	// (usually well under the old 500ms) and, on the rare pane where capture
+	// cannot confirm it, falls back to sending Enter after the cap so delivery is
+	// never worse than the old blind sleep.
+	t.waitForPasteDelivered(tail, baseline)
 
 	// Send Enter separately to submit.
 	enterCmd := exec.Command("tmux", "send-keys", "-t", exactTarget(t.sanitizedName), "Enter")
 	return t.cmdExec.Run(enterCmd)
+}
+
+// deliveryTail returns a distinctive whitespace/box-free suffix of text used to
+// confirm the WHOLE paste landed before submitting: a racing Enter drops the
+// TAIL, so the tail is exactly what must be visible. Whitespace and box-drawing
+// glyphs are removed so an agent composer that wraps the prompt inside its
+// border box (claude/aider render one) still reads back as one contiguous run.
+// A short tail keeps it within a single composer line so a wrap can't split it.
+func deliveryTail(text string) string {
+	n := []rune(normalizeDelivery(text))
+	const tailRunes = 32
+	if len(n) > tailRunes {
+		n = n[len(n)-tailRunes:]
+	}
+	return string(n)
+}
+
+// normalizeDelivery strips whitespace and box-drawing / block-element glyphs so
+// a prompt wrapped inside a composer box reads back as one contiguous run,
+// independent of the pane's width or the agent's framing.
+func normalizeDelivery(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if unicode.IsSpace(r) || (r >= 0x2500 && r <= 0x259F) {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// capturePaneForDelivery returns the pane's visible content, or "" if capture
+// fails (a transient/headless miss just means "not confirmed yet" — the caller
+// keeps polling and ultimately falls back to a best-effort Enter).
+//
+// It deliberately does NOT reuse CapturePaneContent, which is shaped for prompt
+// detection rather than text matching: that helper passes `-e` to PRESERVE ANSI
+// escapes, and a colourized composer would then interleave escape bytes through
+// the very text being matched. It also probes ExistsOrUnknown() on failure,
+// spawning a second tmux subprocess — wasted work inside the submit path, where
+// a failed capture only ever means "not confirmed yet". `-J` is kept, so a line
+// the TERMINAL wrapped is rejoined by tmux itself; app-drawn wrapping inside a
+// composer's border box is handled by normalizeDelivery instead.
+func (t *TmuxSession) capturePaneForDelivery() string {
+	cmd := exec.Command("tmux", "capture-pane", "-p", "-J", "-t", exactTarget(t.sanitizedName))
+	out, err := t.cmdExec.Output(cmd)
+	if err != nil {
+		return ""
+	}
+	return string(out)
+}
+
+// waitForPasteDelivered blocks until the pasted prompt's tail newly appears in
+// the pane (count exceeds the pre-paste baseline), or pasteDeliveryMaxWait
+// elapses. On expiry it logs and returns so Enter is still sent best-effort —
+// delivery is never worse than the fixed sleep it replaces (#1982).
+func (t *TmuxSession) waitForPasteDelivered(tail string, baseline int) {
+	if tail == "" {
+		// Nothing distinctive to confirm (empty/all-whitespace prompt); give
+		// control sequences a brief moment to drain, matching the old intent.
+		time.Sleep(pasteDeliveryPollInterval)
+		return
+	}
+	deadline := time.Now().Add(pasteDeliveryMaxWait)
+	for {
+		if strings.Count(normalizeDelivery(t.capturePaneForDelivery()), tail) > baseline {
+			return
+		}
+		if time.Now().After(deadline) {
+			log.ErrorLog.Printf("submit: paste delivery for session %q not confirmed within %s; sending Enter best-effort",
+				t.sanitizedName, pasteDeliveryMaxWait)
+			return
+		}
+		time.Sleep(pasteDeliveryPollInterval)
+	}
 }

--- a/session/tmux/submit_test.go
+++ b/session/tmux/submit_test.go
@@ -25,18 +25,35 @@ type recordedCmd struct {
 
 func recordTmuxCommands(t *testing.T, program string, text string) []recordedCmd {
 	t.Helper()
+	var mu sync.Mutex
 	var cmds []recordedCmd
+	var loaded string
 	cmdExec := cmd_test.MockCmdExec{
 		RunFunc: func(c *exec.Cmd) error {
 			rec := recordedCmd{args: c.Args}
 			if c.Stdin != nil {
 				b, _ := io.ReadAll(c.Stdin)
 				rec.stdin = string(b)
+				if strings.Contains(strings.Join(c.Args, " "), "load-buffer") {
+					mu.Lock()
+					loaded = rec.stdin
+					mu.Unlock()
+				}
 			}
+			mu.Lock()
 			cmds = append(cmds, rec)
+			mu.Unlock()
 			return nil
 		},
-		OutputFunc: func(c *exec.Cmd) ([]byte, error) { return []byte("content"), nil },
+		// capture-pane reads the pane back: echo the loaded paste so the positive
+		// delivery check (#1982) confirms on the first poll instead of waiting out
+		// pasteDeliveryMaxWait. capture-pane goes through Output, so it never lands
+		// in cmds — the load/paste/Enter shape assertions are unaffected.
+		OutputFunc: func(c *exec.Cmd) ([]byte, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			return []byte(loaded), nil
+		},
 	}
 
 	session := newTmuxSession("af_proj", program, NewMockPtyFactory(t), cmdExec)
@@ -174,6 +191,11 @@ func TestEveryAgentSubmitUsesBracketedPasteBuffer(t *testing.T) {
 // buffer, and every paste must read back the buffer its own load wrote.
 func TestCodexSubmitConcurrentDeliveriesUseDistinctBuffers(t *testing.T) {
 	const workers = 24
+
+	// This test asserts buffer distinctness, not delivery timing; its mock does
+	// not echo the paste, so shorten the delivery wait to keep the run fast (each
+	// worker just falls back to a best-effort Enter after the cap).
+	defer withPasteDeliveryTiming(20*time.Millisecond, time.Millisecond)()
 
 	var mu sync.Mutex
 	var loadBufs []string
@@ -327,4 +349,78 @@ func captureRawPane(session *TmuxSession) (string, error) {
 		return "", err
 	}
 	return string(out), nil
+}
+
+// withPasteDeliveryTiming overrides the delivery-poll knobs for a test and
+// returns a restore func for defer.
+func withPasteDeliveryTiming(maxWait, poll time.Duration) func() {
+	savedMax, savedPoll := pasteDeliveryMaxWait, pasteDeliveryPollInterval
+	pasteDeliveryMaxWait, pasteDeliveryPollInterval = maxWait, poll
+	return func() { pasteDeliveryMaxWait, pasteDeliveryPollInterval = savedMax, savedPoll }
+}
+
+// TestSubmitWaitsForPasteBeforeEnter is the #1982 regression: the submit path
+// must not send Enter until the pasted prompt has actually landed in the pane.
+// The old code slept a fixed 500ms and sent Enter blind, so an Enter that
+// overtook an as-yet-undrained bracketed paste was absorbed as a newline and the
+// prompt stranded in the composer, unsubmitted, while the send reported success.
+//
+// The mock models drain latency: capture-pane returns the pane WITHOUT the
+// pasted text for the first few polls, then WITH it. The test asserts (a) the
+// path actually polled capture-pane, and (b) `send-keys Enter` was issued only
+// AFTER a capture confirmed the text was present. Under the old blind-sleep code
+// there are zero capture-pane calls, so both assertions fail — it reproduces the
+// defect at the mechanism level (Enter sent without confirming delivery).
+func TestSubmitWaitsForPasteBeforeEnter(t *testing.T) {
+	defer withPasteDeliveryTiming(2*time.Second, time.Millisecond)()
+
+	const prompt = "deploy the staging build and report back DELIVERY_TAIL_OK"
+
+	var mu sync.Mutex
+	var loaded string
+	var captureCalls int
+	confirmedText := false         // a capture has returned the pasted text
+	enterSawConfirmedText := false // Enter was sent after such a capture
+	const revealAfter = 3          // captures before the text becomes visible
+
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			joined := strings.Join(c.Args, " ")
+			if strings.Contains(joined, "load-buffer") && c.Stdin != nil {
+				b, _ := io.ReadAll(c.Stdin)
+				mu.Lock()
+				loaded = string(b)
+				mu.Unlock()
+			}
+			if strings.Contains(joined, "send-keys") && strings.Contains(joined, "Enter") {
+				mu.Lock()
+				enterSawConfirmedText = confirmedText
+				mu.Unlock()
+			}
+			return nil
+		},
+		OutputFunc: func(c *exec.Cmd) ([]byte, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			captureCalls++
+			// Withhold the pasted text for the first few polls (drain latency),
+			// then reveal it — inside a composer border box, to prove the tail is
+			// recognized through the framing.
+			if captureCalls <= revealAfter || loaded == "" {
+				return []byte("╭─ composer ─╮\n│ >          │\n╰────────────╯"), nil
+			}
+			confirmedText = true
+			return []byte("╭─ composer ────────────╮\n│ > " + loaded + " │\n╰───────────────────────╯"), nil
+		},
+	}
+
+	session := newTmuxSession("af_proj", "claude", NewMockPtyFactory(t), cmdExec)
+	require.NoError(t, session.SendKeysCommand(prompt))
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Greater(t, captureCalls, revealAfter,
+		"submit must poll capture-pane until the paste lands, not send Enter blind (#1982); got %d captures", captureCalls)
+	require.True(t, enterSawConfirmedText,
+		"Enter must be sent only AFTER a capture confirmed the pasted text is present (#1982)")
 }

--- a/session/tmux/submit_test.go
+++ b/session/tmux/submit_test.go
@@ -342,6 +342,63 @@ func TestPasteBufferNameProcessTokenPreventsCrossProcessCollision(t *testing.T) 
 	require.NotEmpty(t, pasteBufferProcessToken, "the process token must be resolved at startup")
 }
 
+// TestSubmitDoesNotManufactureAFailureWhenThePaneDoesNotEcho pins the reason
+// this package does NOT verify submission after Enter, so the idea is not
+// re-implemented from first principles later.
+//
+// The tempting post-submit check is "after Enter, the prompt should no longer be
+// the pane's trailing content". It is unsound, and three integration gates prove
+// it: a pane whose agent ECHOES the prompt back leaves exactly that shape on a
+// perfectly good delivery —
+//
+//	❯ hello-integration
+//	hello-integration        <- prompt text, trailing, AFTER a successful submit
+//
+// so the check condemns healthy sends of `af sessions send-prompt`. Telling that
+// apart from a real strand needs per-agent composer geometry, which this layer
+// cannot know.
+//
+// The same trap one step earlier: this pane never renders what it receives (the
+// #1956 receiver gate writes its bytes to a FILE while the screen only shows
+// AF-RECEIVER-READY). "Not echoed" is not "not delivered" — arrival and echo are
+// different facts, and any echo-off pane, a password prompt being the everyday
+// case, looks identical. So an unobserved paste is logged loudly and never
+// turned into an error.
+func TestSubmitDoesNotManufactureAFailureWhenThePaneDoesNotEcho(t *testing.T) {
+	defer withPasteDeliveryTiming(50*time.Millisecond, time.Millisecond)()
+
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error { return nil },
+		// A pane that never renders what it receives.
+		OutputFunc: func(c *exec.Cmd) ([]byte, error) { return []byte("AF-RECEIVER-READY"), nil },
+	}
+	session := newTmuxSession("af_proj", "claude", NewMockPtyFactory(t), cmdExec)
+
+	require.NoError(t, session.SendKeysCommand("a prompt to a pane that does not echo"),
+		"a non-echoing pane must NOT be reported as a failed delivery — the bytes still arrive")
+}
+
+// TestSubmitDoesNotManufactureAFailureWhenThePaneIsUnreadable is the polarity
+// guard for the capture itself. Every check here is a probe that can fail to
+// SEE, and a probe that cannot see must never manufacture a negative — the
+// failure mode this repo keeps re-learning. With capture-pane failing outright,
+// delivery is unverifiable, so the submit path must keep its best-effort
+// behaviour and report SUCCESS rather than invent a delivery failure.
+func TestSubmitDoesNotManufactureAFailureWhenThePaneIsUnreadable(t *testing.T) {
+	defer withPasteDeliveryTiming(50*time.Millisecond, time.Millisecond)()
+
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error { return nil },
+		OutputFunc: func(c *exec.Cmd) ([]byte, error) {
+			return nil, fmt.Errorf("no server running on /tmp/tmux-1000/default")
+		},
+	}
+	session := newTmuxSession("af_proj", "claude", NewMockPtyFactory(t), cmdExec)
+
+	require.NoError(t, session.SendKeysCommand("a prompt to an unreadable pane"),
+		"an unreadable pane is NOT evidence of a failed delivery; it must stay best-effort")
+}
+
 func captureRawPane(session *TmuxSession) (string, error) {
 	cmd := exec.Command("tmux", "capture-pane", "-p", "-t", exactTarget(session.sanitizedName))
 	out, err := session.cmdExec.Output(cmd)


### PR DESCRIPTION
Closes #1982.

## The bug

A prompt delivered via `af sessions send-prompt` could land in the composer **in full** and never be submitted. The session then sat idle holding someone's instruction, and every layer reported success. Sachin's follow-up made it worse than "an instruction sits unread": the stranded draft is not inert — the next prompt **appends to it** and the two submit as one concatenated message, so the agent acts on an instruction that is neither prompt, and the evidence disappears because the composer clears.

## Root cause

Delivery is `load-buffer` → `paste-buffer -p` → a **separate** `send-keys Enter`, with a fixed 500ms sleep between them "to let the paste drain".

When that Enter overtakes an as-yet-undrained paste, the still-open bracketed paste absorbs it as a **literal newline** instead of it acting as a submit. That explains the exact symptom: all the text is there, and nothing submits it. The fixed sleep undershot precisely when the pane was mid-render (a spinner shortly after a turn) — which is where the strands clustered. #1981's 18/18 result is consistent rather than contradictory: those were **idle** panes, which drain well inside 500ms.

## The fix

Replace the blind sleep with a **positive delivery check**: baseline the pane, and after the paste poll `capture-pane` until the prompt's tail newly appears — then send Enter.

The sleep is **replaced, not removed**. Per #1995 that drain wait is load-bearing, and the one path lacking it executes truncated commands; turning it into nothing was never an option. Bounded by `pasteDeliveryMaxWait` (2s); on expiry it logs and still sends Enter, so delivery is never *worse* than the old sleep. In the common case it confirms in one 50ms poll — i.e. **faster** than before.

Two details worth review:
- Matching normalizes away whitespace and box glyphs, so a prompt wrapped inside a composer's border box still reads back as one contiguous run.
- It waits for a count **increase**, not mere presence, because the daemon re-delivers the same prompt after a limit resume (#1146) and an identical tail could already be on screen.

## Deliberately not done

**Verifying after Enter that the composer is empty.** Sachin argued for this in the issue thread, and it is the right instinct — but as an implementation it is agent-specific screen-shape guessing with a high false-positive cost (a custom shell pane has no composer at all), and a false "did not land" would break working sends. This check *prevents* the strand rather than reporting it afterwards. Happy to revisit if you'd rather have the loud-report version too.

## Fail-first

`TestSubmitWaitsForPasteBeforeEnter` models drain latency: `capture-pane` withholds the pasted text for the first few polls, then reveals it inside a composer border box. It asserts the path actually polled, and that Enter was issued **only after** a capture confirmed the text.

**Observed failing at `d4bae18`** — `"0" is not greater than "3" … got 0 captures`, i.e. the old path sends Enter blind. Passes with this change.

## Verification

- `go build ./...`, `gofmt -l .`, `golangci-lint run --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh` — all clean
- Full `session/tmux` package green, **including the real-tmux** `TestBashWrappedSubmitDoesNotDuplicateCommandPrefix` (proves the check works against a real tmux+bash pane, not just mocks)
- `make test-container` full suite green

## Adjacent sites audited

`TapEnter` and the `D Enter` send are single keystrokes with no paste to drain; the raw PTY path is user-driven interactive input. `sendKeysPasteBuffer` is the only automated paste-then-submit path, so this is the whole bug class in the Go tree. `daemon/configagent.go` reaches it via `SendKeysCommand` and inherits the fix.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)