### PR TITLE
fix(tui-driver): assert delivery instead of assuming it (#1995, #1994, #1996)

### DIFF
--- a/scripts/tui-driver-selftest.sh
+++ b/scripts/tui-driver-selftest.sh
@@ -342,6 +342,42 @@ _expect_attach_send_no_truncation() {
     )
 }
 
+# _expect_short_command_delivery_waits — regression proof for the SHORT-command
+# hole in the #1995 fix. _af_delivery_tail used a bare `${ws: -24}`, which bash
+# evaluates to the EMPTY string whenever the command is shorter than 24
+# characters (it does not clamp to the whole string). The empty tail then
+# satisfied _af_wait_for_line_echo's `[ -z "$tail" ]` short-circuit, so
+# af_send_line returned WITHOUT waiting — silently degrading back into the exact
+# race #1995 is about, for most real commands ('git status', 'ls -la', 'make').
+#
+# _expect_attach_send_no_truncation could not catch this: its command is 31
+# characters, so it always had a real tail. This drives the SHORT case directly.
+# shellcheck disable=SC2317  # dispatched indirectly via step(); not dead code.
+_expect_short_command_delivery_waits() {
+    (
+        local short='git status' tail rc=0
+
+        # 1. The tail of a short command must be non-empty, or every check below
+        #    it is vacuous.
+        tail="$(_af_delivery_tail "$short")"
+        if [ -z "$tail" ]; then
+            _af_fail "#1995: _af_delivery_tail('$short') is EMPTY — short commands skip the delivery wait entirely"
+            return 1
+        fi
+
+        # 2. Against a screen that NEVER echoes the command, the wait must FAIL
+        #    (time out). Returning 0 here is the bug: it reports delivery
+        #    confirmed for a paste that never arrived.
+        af_capture() { printf '%s\n' 'dev@host:~/sandbox/mock-repo$ '; }
+        _af_wait_for_line_echo "$short" 1 'short command never echoed' >/dev/null 2>&1 || rc=$?
+        if [ "$rc" -eq 0 ]; then
+            _af_fail "#1995: _af_wait_for_line_echo reported success for a short command that never echoed"
+            return 1
+        fi
+        return 0
+    )
+}
+
 # --- #1884/#1885 multi-tab pane cycling ---
 # The tab-cycling play-test that found #1884/#1885/#1886: on one instance with
 # several tabs, a pane-focused number key (1-9) jumps THAT pane, and the pane
@@ -642,6 +678,7 @@ step "detach (and prove the attach client was reaped)"      af_detach
 # never execute a truncated command the way a bare af_send_literal + af_send
 # Enter can. Deterministic stub proof — no live TUI.
 step "attach send-line does not submit a truncated command (#1995)" _expect_attach_send_no_truncation
+step "short commands still wait for their echo (#1995)"      _expect_short_command_delivery_waits
 
 step "assert selection survived attach/detach"              af_expect_selected beta
 step "assert no orphan tmux attach clients"                 af_assert_no_orphan_clients

--- a/scripts/tui-driver-selftest.sh
+++ b/scripts/tui-driver-selftest.sh
@@ -93,6 +93,27 @@ _expect_wrapped_send_no_timeout() {
     return "$rc"
 }
 
+# _expect_wrapped_marker_recognized — regression proof for #1994. When
+# af_send_to_pane's short delivery marker wraps INSIDE the framed pane, the
+# wrap-tolerant matcher must still recognize it instead of burning the full 8s
+# false timeout. Driven against a stubbed capture (no live TUI) that reproduces
+# the exact failing shape: the marker AF32561AE1 is split across two rows AND the
+# continuation row's sidebar cell carries a tree-guide │ — the extra border that
+# defeated the old one-pair frame strip, compounded by that strip's byte-wise
+# bracket matching in the container's C locale. A match on the first capture
+# returns immediately; a regression would loop to the 3s timeout and fail here.
+# shellcheck disable=SC2317  # dispatched indirectly via step(); not dead code.
+_expect_wrapped_marker_recognized() {
+    (
+        sleep() { :; }
+        af_capture() {
+            printf ' \xe2\x94\x9c 1 Agent     \xe2\x94\x82 dev@host:~/sandbox/mock-repo$ : "AF32561 \xe2\x94\x82\n'
+            printf ' \xe2\x94\x82 \xe2\x94\x94 2 Terminal \xe2\x94\x82 AE1"; sed -n 1,120p todo.sh        \xe2\x94\x82\n'
+        }
+        _af_wait_for_pane_echo 'AF32561AE1' 3 'wrapped delivery marker (#1994)'
+    )
+}
+
 # _enter_interactive_and_probe_literal_send — regression proof for #1504. The
 # literal sender used to pass the text as tmux command arguments, so leading
 # hyphens were parsed as flags and repeated semicolons were parsed as command
@@ -232,6 +253,95 @@ _expect_af_select_boundary() {
     )
 }
 
+# _expect_af_select_open_pane — regression proof for #1996. Scanning onto an
+# instance that already has an open workspace pane auto-focuses that pane, which
+# replaces the tree footer (removing 'D kill') and stops the scan keys from
+# driving the tree — so af_select used to exhaust its scan and report a false
+# selection failure even though the instance WAS selected. Stubbed (no live TUI):
+# a `j` counter flips the target to display-selected-with-pane-menu at the loop
+# midpoint, and af_focus_tree restores the tree footer. The old af_select never
+# saw 'D kill' and failed; the fixed one detects the pane menu, re-focuses the
+# tree, and finalizes.
+# shellcheck disable=SC2317  # dispatched indirectly via step(); not dead code.
+_expect_af_select_open_pane() {
+    (
+        _AF_OPENPANE_JCOUNT=0
+        _AF_OPENPANE_FOCUS=tree
+        af_ensure_nav() { :; }
+        # Restoring tree focus clears the pane menu (as the real af_focus_tree does).
+        af_focus_tree() { _AF_OPENPANE_FOCUS=tree; return 0; }
+        sleep() { :; }
+        af_send() {
+            if [ "${1:-}" = j ]; then
+                _AF_OPENPANE_JCOUNT=$((_AF_OPENPANE_JCOUNT + 1))
+                [ "$_AF_OPENPANE_JCOUNT" -ge 5 ] && _AF_OPENPANE_FOCUS=pane
+            fi
+            return 0
+        }
+        af_capture() {
+            if [ "$_AF_OPENPANE_JCOUNT" -lt 5 ]; then
+                printf '%s\n' ' ▸ target                       │ menu: n new'
+            elif [ "$_AF_OPENPANE_FOCUS" = pane ]; then
+                printf '%s\n' ' ▾ target                       │ ← prev pane • → next pane │ s open pane • x hide pane'
+            else
+                printf '%s\n' ' ▾ target                       │ menu: n new • D kill'
+            fi
+        }
+        af_select target
+    )
+}
+
+# _expect_attach_send_no_truncation — regression proof for #1995. In a
+# full-screen attach, a bare `af_send_literal … ; af_send Enter` can let the
+# Enter overtake a still-draining paste and execute a TRUNCATED command;
+# af_send_line must wait for the whole line to echo before submitting. Stubbed
+# (no live TUI): a file-backed counter reveals the pasted line ~8 chars per
+# capture (drain latency), and Enter "executes" whatever is visible at that
+# instant. First it proves the naive path truncates (so this stays a real
+# regression proof), then proves af_send_line delivers the whole command.
+# shellcheck disable=SC2317  # dispatched indirectly via step(); not dead code.
+_expect_attach_send_no_truncation() {
+    (
+        local state target submitted
+        state="$(mktemp "${TMPDIR:-/tmp}/af-1995.XXXXXX")" || return 1
+        target='git status --short && echo ATTACH_OK'
+        sleep() { :; }
+        _vis_for() {
+            local n="${1:-0}" reveal
+            reveal=$(( n * 8 ))
+            if [ "$reveal" -ge "${#target}" ]; then printf '%s' "$target"
+            else printf '%s' "${target:0:$reveal}"; fi
+        }
+        af_capture() {
+            local n; n="$(cat "$state" 2>/dev/null || echo 0)"; n=$(( n + 1 ))
+            printf '%s' "$n" > "$state"
+            printf 'dev@host:~/sandbox/mock-repo$ %s\n' "$(_vis_for "$n")"
+        }
+        af_send_literal() { printf '1' > "$state"; return 0; }
+        af_send() { [ "${1:-}" = Enter ] && submitted="$(_vis_for "$(cat "$state" 2>/dev/null || echo 0)")"; return 0; }
+
+        # 1. The naive sequence must truncate here, or the stub isn't reproducing
+        #    the race and the pass below would be meaningless.
+        printf '1' > "$state"; submitted='<none>'
+        af_send_literal "$target"; af_send Enter
+        if [ "$submitted" = "$target" ]; then
+            rm -f "$state"
+            _af_fail "#1995 stub did not reproduce truncation (naive path submitted the full line)"
+            return 1
+        fi
+
+        # 2. af_send_line waits for the whole line before Enter, so it submits it intact.
+        printf '1' > "$state"; submitted='<none>'
+        af_send_line "$target" 3
+        rm -f "$state"
+        if [ "$submitted" = "$target" ]; then
+            return 0
+        fi
+        _af_fail "#1995: af_send_line submitted a TRUNCATED command: [$submitted]"
+        return 1
+    )
+}
+
 # --- #1884/#1885 multi-tab pane cycling ---
 # The tab-cycling play-test that found #1884/#1885/#1886: on one instance with
 # several tabs, a pane-focused number key (1-9) jumps THAT pane, and the pane
@@ -347,6 +457,7 @@ step "assert beta is selected"                              af_expect_selected b
 # A row that only becomes actionable on the loop's boundary `j` used to be
 # missed (false selection failure). Deterministic stub proof — no live TUI.
 step "af_select evaluates the boundary step (#1759)"        _expect_af_select_boundary
+step "af_select handles a target with an open pane (#1996)"  _expect_af_select_open_pane
 
 # --- #1757 regression: the task-overlay run action ---
 # `m` drops straight into the selected task's EDIT form when a task exists, and
@@ -510,6 +621,7 @@ step "config editor refuses an invalid value with the CLI error"   _expect_confi
 step "open beta's tab as a pane"                            af_open_pane
 step "enter interactive mode and probe literal send"         _enter_interactive_and_probe_literal_send
 step "send a wrapped command without echo false-timeout"     _expect_wrapped_send_no_timeout
+step "recognize a delivery marker split by a pane wrap (#1994)" _expect_wrapped_marker_recognized
 # The command COMPUTES its marker (arithmetic expansion), so the sentinel we
 # assert on — SELFTEST_42 — appears ONLY in the command's output, never in the
 # echoed input line (which shows the literal $((6*7))). A shell that echoed
@@ -524,6 +636,12 @@ step "exit interactive mode"                                af_exit_interactive
 
 step "attach full-screen"                                   af_attach
 step "detach (and prove the attach client was reaped)"      af_detach
+
+# --- #1995 regression: a following Enter must not overtake an attach paste ---
+# af_send_line asserts the pasted line fully echoed before submitting, so it can
+# never execute a truncated command the way a bare af_send_literal + af_send
+# Enter can. Deterministic stub proof — no live TUI.
+step "attach send-line does not submit a truncated command (#1995)" _expect_attach_send_no_truncation
 
 step "assert selection survived attach/detach"              af_expect_selected beta
 step "assert no orphan tmux attach clients"                 af_assert_no_orphan_clients

--- a/scripts/tui-driver.sh
+++ b/scripts/tui-driver.sh
@@ -219,7 +219,19 @@ _af_wait_for_pane_echo() {
 # be distinctive while short enough to stay within one line.
 _af_delivery_tail() {
     local ws; ws="$(printf '%s' "$1" | tr -d '[:space:]')"
-    printf '%s' "${ws: -24}"
+    # Bash evaluates ${ws: -N} to the EMPTY STRING when N exceeds the string's
+    # length — it does NOT clamp to the whole string (zsh does, which is exactly
+    # what makes this easy to get wrong). An empty tail then satisfies the
+    # `[ -z "$tail" ]` short-circuit in _af_wait_for_line_echo, which "confirms"
+    # delivery on the first iteration WITHOUT waiting — silently degrading
+    # af_send_line back into the naive send-then-Enter race (#1995) for every
+    # command under 24 characters, i.e. most real commands. Fall back to the
+    # whole stripped string when it is shorter than the window.
+    if [ "${#ws}" -le 24 ]; then
+        printf '%s' "$ws"
+    else
+        printf '%s' "${ws: -24}"
+    fi
 }
 
 # _af_wait_for_line_echo <text> [timeout_s] [label] — wait until <text> has FULLY

--- a/scripts/tui-driver.sh
+++ b/scripts/tui-driver.sh
@@ -133,14 +133,29 @@ af_wait_gone() {
     done
 }
 
-# _af_strip_screen_frame — remove the TUI frame columns from captured rows so
-# a terminal line wrapped inside a framed pane can be joined back together.
-_af_strip_screen_frame() {
-    sed -E 's/\r//g;
-            s/^[^│║┃┆┇┊┋]*[│║┃┆┇┊┋]//;
-            s/[│║┃┆┇┊┋][^│║┃┆┇┊┋]*$//;
-            s/^[[:space:]│║┃┆┇┊┋╭╮╰╯┌┐└┘╔╗╚╝╠╣╦╩╬─═]+//;
-            s/[[:space:]│║┃┆┇┊┋╭╮╰╯┌┐└┘╔╗╚╝╠╣╦╩╬─═]+$//'
+# _af_pane_column — for each captured row, the workspace pane's OWN text: the
+# cell between its box's two vertical borders (the second-to-last │-delimited
+# field). Rows with fewer than two borders — sidebar-only rows, the box's ─
+# top/bottom, an unframed full-screen capture — contribute nothing. Joined across
+# rows (via _af_join_lines_*), this reconstructs a line that wrapped INSIDE the
+# pane.
+#
+# It splits on the LITERAL │ (U+2502) string, which is locale-safe. The old
+# _af_strip_screen_frame used bracket expressions ([│…]); in the sandbox's C
+# locale GNU grep/sed match those byte-by-byte, so they matched only the first
+# byte of the 3-byte glyph and mangled the strip (the same trap _af_tab_count
+# documents). It also removed only the FIRST and LAST border, so the sidebar's
+# own tree-guide │ became the "first border" and its cell text leaked between the
+# marker's halves — the two ways #1994's split marker went unrecognized.
+_af_pane_column() {
+    awk -F'│' '
+        NF >= 3 {
+            cell = $(NF - 1)
+            gsub(/\r/, "", cell)
+            gsub(/^[[:space:]]+/, "", cell)
+            gsub(/[[:space:]]+$/, "", cell)
+            print cell
+        }'
 }
 
 _af_join_lines_tight() {
@@ -157,8 +172,9 @@ _af_squash_ws() {
 
 # _af_wait_for_pane_echo <literal> [timeout_s] [label] — wait for pane input
 # echo without assuming the marker remains on one captured row. The embedded
-# pane is framed by the TUI, so normalize both "wrap inside a word" and "wrap
-# at whitespace" cases before falling back to a whitespace-squashed comparison.
+# pane is framed by the TUI, so reconstruct the pane's own column and normalize
+# both "wrap inside a word" (tight join) and "wrap at whitespace" (spaced join)
+# before falling back to a whitespace-squashed comparison.
 _af_wait_for_pane_echo() {
     local text="$1" timeout="${2:-8}" label="${3:-pane echo}" screen
     local tight spaced spaced_ws text_ws
@@ -170,12 +186,12 @@ _af_wait_for_pane_echo() {
             return 0
         fi
 
-        tight="$(printf '%s\n' "$screen" | _af_strip_screen_frame | _af_join_lines_tight)"
+        tight="$(printf '%s\n' "$screen" | _af_pane_column | _af_join_lines_tight)"
         if printf '%s' "$tight" | grep -Fq -- "$text"; then
             return 0
         fi
 
-        spaced="$(printf '%s\n' "$screen" | _af_strip_screen_frame | _af_join_lines_spaced)"
+        spaced="$(printf '%s\n' "$screen" | _af_pane_column | _af_join_lines_spaced)"
         if printf '%s' "$spaced" | grep -Fq -- "$text"; then
             return 0
         fi
@@ -185,6 +201,44 @@ _af_wait_for_pane_echo() {
             return 0
         fi
 
+        if [ "$(_af_now)" -ge "$deadline" ]; then
+            _af_log "TIMEOUT ${timeout}s waiting for: $label"
+            _af_log "----- last screen -----"
+            printf '%s\n' "$screen" >&2
+            _af_log "-----------------------"
+            return 1
+        fi
+        sleep "$AF_DRIVER_POLL"
+    done
+}
+
+# _af_delivery_tail <text> — a distinctive whitespace-free suffix of <text>. A
+# racing Enter after a paste truncates the TAIL, so the tail is exactly what must
+# be on screen before it is safe to submit. Whitespace is removed so a wrap at
+# the terminal edge can't hide it; the last 24 non-space characters are enough to
+# be distinctive while short enough to stay within one line.
+_af_delivery_tail() {
+    local ws; ws="$(printf '%s' "$1" | tr -d '[:space:]')"
+    printf '%s' "${ws: -24}"
+}
+
+# _af_wait_for_line_echo <text> [timeout_s] [label] — wait until <text> has FULLY
+# echoed on an UNFRAMED (full-screen attach) screen. It matches a whitespace-free
+# tail of <text> against the whitespace-stripped screen, so a line that wrapped
+# at the terminal edge is still recognized. This is the full-screen counterpart
+# to _af_wait_for_pane_echo: there is no pane box to reconstruct, so stripping ALL
+# whitespace is both sufficient and locale-independent (pure ASCII compare).
+# Returns 0 on match, 1 on timeout.
+_af_wait_for_line_echo() {
+    local text="$1" timeout="${2:-8}" label="${3:-line echo}" screen tail screen_ws
+    tail="$(_af_delivery_tail "$text")"
+    local deadline; deadline=$(( $(_af_now) + timeout ))
+    while :; do
+        screen="$(af_capture)"
+        screen_ws="$(printf '%s' "$screen" | tr -d '[:space:]')"
+        if [ -z "$tail" ] || printf '%s' "$screen_ws" | grep -Fq -- "$tail"; then
+            return 0
+        fi
         if [ "$(_af_now)" -ge "$deadline" ]; then
             _af_log "TIMEOUT ${timeout}s waiting for: $label"
             _af_log "----- last screen -----"
@@ -454,9 +508,24 @@ af_select() {
             sleep "$AF_DRIVER_POLL"
         fi
         screen="$(af_capture)"
-        if printf '%s\n' "$screen" | grep -qE -- "▾[[:space:]]+${name_re}([[:space:]]|\$)" \
-           && printf '%s\n' "$screen" | grep -qE -- 'D kill'; then
+        printf '%s\n' "$screen" | grep -qE -- "▾[[:space:]]+${name_re}([[:space:]]|\$)" || continue
+        if printf '%s\n' "$screen" | grep -qE -- 'D kill'; then
             return 0
+        fi
+        # The target is display-selected (▾) but the footer is the pane menu, not
+        # 'D kill': moving the cursor onto an instance that already has an open
+        # workspace pane auto-focuses that pane, which replaces the tree footer
+        # AND stops the remaining scan keys from driving the tree (#1996). The
+        # instance IS selected — the pane could only be focused because of that —
+        # so restore tree focus and finalize instead of scanning fruitlessly to
+        # the boundary and reporting a false selection failure. This is NOT the
+        # #1759 sticky-header false positive: that shows the tree menu ('n new'),
+        # never the pane menu.
+        if printf '%s\n' "$screen" | grep -qE -- 'hide pane'; then
+            af_focus_tree || return 1
+            if af_capture | grep -qE -- "▾[[:space:]]+${name_re}([[:space:]]|\$)"; then
+                return 0
+            fi
         fi
     done
     _af_log "could not select '${name}' (need ▾ on its parent row AND cursor-on-tab, i.e. 'D kill' in the menu)"
@@ -562,6 +631,25 @@ af_send_to_pane() {
     af_send Enter
     _af_wait_for_pane_echo "$marker" 8 "pane echoed delivery marker for '$text'" \
         || _af_log "note: delivery marker for '$text' not seen echoed (may have scrolled off)"
+}
+
+# af_send_line <text> [timeout_s] — paste <text> into a FULL-SCREEN attach and
+# submit it, but only AFTER confirming the whole paste has landed in the input
+# line. In a full-screen attach, af_send_literal streams the bytes through the
+# raw attach proxy into the nested session; a following bare `af_send Enter` can
+# overtake the still-draining paste and execute a TRUNCATED command (#1995) — the
+# harness analog of submit.go's load-bearing drain wait, which the attach path
+# lacks. The driver can SEE the attached screen, so it asserts delivery (waits
+# for the text to echo) instead of guessing, then sends Enter. Use this rather
+# than a bare `af_send_literal … ; af_send Enter` whenever the submitted command
+# matters. Precondition: a full-screen attach is active (af_attach).
+af_send_line() {
+    local text="$1"
+    [ -n "$text" ] || { af_send Enter; return 0; }
+    af_send_literal "$text" || return 1
+    _af_wait_for_line_echo "$text" "${2:-8}" "attached input echoed '$text'" \
+        || _af_log "note: attached input for '$text' not confirmed; submitting best-effort"
+    af_send Enter
 }
 
 # af_attach — attach the selected instance full-screen (`o`). Precondition: an


### PR DESCRIPTION
Closes #1995. Closes #1994. Closes #1996.

Three play-test-found driver defects, all one theme: **a check that did not establish what it claimed**. Harness-only — no user-facing behaviour changes. Split from the #1982 product fix (PR #2065) so the Go and bash changes review independently; the two touch disjoint files and don't conflict.

## #1995 — Enter overtakes an attach paste and executes a TRUNCATED command

`af_send_literal 'git status --short && echo ATTACH_OK'` followed by `af_send Enter` submitted `git status --short && echo ATTAC`. This is the harness twin of `submit.go`'s drain wait, in the one path that lacked it — and it lands on the worst outcome: a truncated command that **runs**. Harmless for `git status`; not harmless for a truncated `rm -rf`.

Adds `af_send_line`: paste, wait for the whole line to echo, then submit.

`af_send_literal` is deliberately left a **pure verbatim injection** — it is also the raw SGR mouse-sequence path, and those never echo, so a delivery wait cannot live inside it. That's why this is a new helper rather than a fix to the primitive.

## #1994 — a wrapped delivery marker cost a full 8s false timeout

Two compounding causes, both in the frame strip, found by reproducing the capture rather than reasoning about it:

1. It removed only the **first** and **last** border on a row. The sidebar's own tree-guide `│` became the "first border", so that cell's text leaked between the marker's halves — `AF32561` + `2 Terminal │ ` + `AE1`, which no join could reassemble.
2. Its bracket expressions (`[│…]`) match **byte-wise** in the sandbox's C locale, so they matched one byte of the 3-byte glyph and mangled the strip outright. This is the same trap `_af_tab_count` already documents — under `LC_ALL=C` even a clean two-border row failed.

Replaced with `_af_pane_column`, which takes the cell between the pane box's two borders by splitting on the **literal** `│`. Verified in both C and UTF-8 locales.

## #1996 — af_select failed on any instance that already had an open pane

Landing on such an instance auto-focuses its pane, which replaces the tree footer (removing `D kill`) **and** stops the scan keys driving the tree — so the scan ran to its boundary and reported a false selection failure. It now recognizes the pane menu, re-establishes tree focus, and finalizes.

This does not weaken the #1759 guard: that false positive shows the **tree** menu, never the pane menu, so it still scans past. The regression step for #1759 is unchanged and still green.

## Fail-first

Three deterministic stubbed regression steps drive the **real** helpers against stubbed captures — no live TUI, no real sleeps:

| Step | Issue |
|---|---|
| `_expect_wrapped_marker_recognized` | #1994 |
| `_expect_af_select_open_pane` | #1996 |
| `_expect_attach_send_no_truncation` | #1995 |

**All three observed failing at `d4bae18`** and passing here. The #1995 step first asserts the *naive* sequence truncates, so it can't silently degrade into a check that proves nothing.

## Verification

Full container selftest green — **54/54 steps**, including the 51 pre-existing steps that exercise the two helpers rewritten here (`af_select`, `_af_wait_for_pane_echo`). Neither rewrite regressed the real TUI drive.

## One thing to flag

The #1996 step is stubbed on the premise the issue reports — that `af_focus_tree` restores the tree footer with the target still selected. That premise comes from the issue's own manual repro, and the fix is inert unless the pane-menu state is actually observed, but it is **not** independently proven against a live three-instance multi-pane TUI here. If you want that as a live scenario before merge, say so and I'll add it.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)