### PR TITLE
fix(doctor): prove temp-home disuse with a lock, three-value the ping, reconcile the summary (#1989, #2040, #1979)

### DIFF
--- a/daemon/health.go
+++ b/daemon/health.go
@@ -156,6 +156,32 @@ func classifyDialFailure(path string, err error) ProbeAnswer {
 	return AnswerNo()
 }
 
+// ClassifyPingFailure turns a FAILED control-socket ping into a three-valued
+// answer about daemon liveness, so `af doctor` never reads a dial TIMEOUT as a
+// definite "the daemon is dead". It is the ping-path twin of classifyDialFailure
+// on the HTTP path (#2014/#2039): the control socket has an accept backlog too,
+// and under heavy TUI/CLI RPC load a dial can time out at daemonDialTimeout
+// while a perfectly live daemon is merely busy.
+//
+//   - A nil error is Yes: a daemon answered.
+//   - A timeout (os.IsTimeout / os.ErrDeadlineExceeded) is Undetermined: a
+//     live-but-backlogged daemon times out the same way, so a made-up "dead"
+//     would send the user to `af daemon restart` over a working daemon — the
+//     exact timeout-is-not-a-negative fabrication #1920 set out to kill (#2040).
+//   - Anything else — a refusal (ECONNREFUSED), a reset, an RPC-level error — is
+//     a completed answer that nothing is responding: a definite No.
+func ClassifyPingFailure(err error) ProbeAnswer {
+	if err == nil {
+		return AnswerYes()
+	}
+	if os.IsTimeout(err) || errors.Is(err, os.ErrDeadlineExceeded) {
+		return Undetermined(fmt.Errorf(
+			"the control socket did not answer within %s, so daemon liveness is unknown "+
+				"(a live daemon may be busy with a saturated accept backlog): %w", daemonDialTimeout, err))
+	}
+	return AnswerNo()
+}
+
 // DaemonSocketNames returns the file names of the Unix sockets a daemon binds
 // inside an agent-factory home. Exported so `af doctor` can look for sockets
 // left behind in a home it was pointed at, rather than only the active one,
@@ -190,8 +216,9 @@ func ProcessArgv(pid int) []string {
 	return daemonArgs(pid)
 }
 
-// PIDLooksAlive reports whether pid still appears to name a live process,
-// using the same zombie-aware liveness probe as daemon shutdown paths.
-func PIDLooksAlive(pid int) bool {
-	return pidLooksAlive(pid)
-}
+// PIDLooksAlive is GONE with its last caller. It was exported so `af doctor`
+// could decide whether a temp home's daemon.pid named a live daemon — the
+// heuristic PID validation #960 rejected, and the inference #1989 replaced with
+// the per-home flock (ProbeHomeLock). Nothing outside this package needs to
+// guess at daemon liveness any more: ask the lock. The internal pidLooksAlive
+// remains for the shutdown paths that own a PID legitimately.

--- a/daemon/health_test.go
+++ b/daemon/health_test.go
@@ -96,6 +96,41 @@ func TestProbeHTTPSocket_DialRefusedIsNo(t *testing.T) {
 	requireAnswer(t, "no", listening, "a refused dial is a completed answer that nothing is listening")
 }
 
+// The control-socket ping's timeout must be Undetermined, not a definite No —
+// the same fix as probeHTTPSocket, one path over (#2040). A momentarily
+// backlogged control socket times out exactly like a dead one, so collapsing
+// the timeout into a Fail would send a user to `af daemon restart` over a live
+// daemon. The error injected here is the exact shape net.DialTimeout returns on
+// a deadline expiry.
+func TestClassifyPingFailure_TimeoutIsUndetermined(t *testing.T) {
+	timeoutErr := &net.OpError{Op: "dial", Net: "unix", Err: os.ErrDeadlineExceeded}
+	require.True(t, os.IsTimeout(timeoutErr) || errors.Is(timeoutErr, os.ErrDeadlineExceeded),
+		"the injected error must be exactly what the production classification keys on")
+
+	answer := ClassifyPingFailure(timeoutErr)
+	requireAnswer(t, "unknown", answer,
+		"a dial timeout is not evidence the daemon is dead (#2040)")
+	require.Error(t, answer.Cause(), "an undetermined answer must carry its cause")
+}
+
+// A refusal (ECONNREFUSED) is a completed answer — nobody is home — and must
+// stay a definite No that drives the Fail. The fix must not blur it into
+// "unknown".
+func TestClassifyPingFailure_RefusalIsNo(t *testing.T) {
+	refusedErr := &net.OpError{Op: "dial", Net: "unix",
+		Err: &os.SyscallError{Syscall: "connect", Err: syscall.ECONNREFUSED}}
+	require.False(t, os.IsTimeout(refusedErr) || errors.Is(refusedErr, os.ErrDeadlineExceeded),
+		"a refusal must not look like a timeout to the classification")
+
+	requireAnswer(t, "no", ClassifyPingFailure(refusedErr),
+		"a refused ping is a completed answer that nothing is responding")
+}
+
+// A nil error is Yes: a daemon answered.
+func TestClassifyPingFailure_NilIsYes(t *testing.T) {
+	requireAnswer(t, "yes", ClassifyPingFailure(nil), "a nil ping error means a daemon answered")
+}
+
 // A real listener that actually accepts answers Yes — the happy path, run
 // through the REAL dial (no stub) so the seam's production wiring is covered.
 func TestProbeHTTPSocket_LiveListenerIsYes(t *testing.T) {

--- a/daemon/singleton_lock.go
+++ b/daemon/singleton_lock.go
@@ -16,13 +16,20 @@ import (
 // PID file, which readers can only heuristically validate (#960 split-brain).
 const daemonLockFileName = "daemon.lock"
 
-// daemonLockPath returns <home>/daemon.lock.
+// daemonLockPathIn returns <dir>/daemon.lock for an arbitrary home directory.
+// It is what lets `af doctor` ask the lock question of a home it is inspecting
+// rather than only the current one (#1989).
+func daemonLockPathIn(dir string) string {
+	return filepath.Join(dir, daemonLockFileName)
+}
+
+// daemonLockPath returns <home>/daemon.lock for the current home.
 func daemonLockPath() (string, error) {
 	dir, err := config.GetConfigDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(dir, daemonLockFileName), nil
+	return daemonLockPathIn(dir), nil
 }
 
 // homeLock is a held exclusive advisory lock on the per-home daemon lock file.
@@ -101,4 +108,105 @@ func (l *homeLock) release() {
 	_ = syscall.Flock(int(l.f.Fd()), syscall.LOCK_UN)
 	_ = l.f.Close()
 	l.f = nil
+}
+
+// The read side of the daemon lock, for `af doctor` (#1989).
+//
+// The lock the daemon holds for its whole lifetime is the SOUND answer to "is a
+// daemon running for this home?" — the kernel releases it on death including
+// SIGKILL, so a takeable lock is proof, not inference, that no live daemon owns
+// the home. That is what a temp-home delete must rest on: doctor's old
+// process-scan predicate ("I saw no process referencing this home") was an
+// inferred negative that four consecutive P1 reviews each found a fresh way to
+// falsify, and every one authorised an rm -rf. The lock cannot be falsified that
+// way — but it CAN lie in two directions we must design against, below.
+
+var (
+	// errLockHeld reports that a live daemon holds the home's lock (EWOULDBLOCK).
+	errLockHeld = errors.New("a live daemon holds this home's lock")
+	// errLockUnprovable reports that we could not establish whether a daemon
+	// holds the lock: no lock file at all, a filesystem whose flock cannot be
+	// trusted, or an I/O error. It must never be read as "unused".
+	errLockUnprovable = errors.New("cannot prove whether a daemon owns this home")
+)
+
+// lockFSReliable reports whether flock on a file under dir can be trusted: true
+// on local filesystems, false on network ones (NFS, SMB, 9p, FUSE) where a
+// successful flock may silently no-op and hand back a fabricated "I took it".
+// A package var so a test can force either verdict without a real NFS mount.
+var lockFSReliable = flockReliableFilesystem
+
+// acquireHomeLockAt tries to take dir's daemon lock WITHOUT creating the lock
+// file, and returns the held lock on success. The no-create rule is
+// load-bearing: creating the file would let us take a lock nobody ever held,
+// manufacturing the very "unused" proof we are testing for (#1989).
+//
+//   - (*homeLock, nil): the lock file existed on a filesystem whose flock we
+//     trust, and we took it — proof that no live daemon owns the home. The
+//     caller MUST release() it.
+//   - (nil, errLockHeld): a live daemon holds it (EWOULDBLOCK). The home is in
+//     use.
+//   - (nil, errLockUnprovable): unprovable — no lock file (absence of a lock is
+//     not proof of non-use), a filesystem whose flock we cannot vouch for, or an
+//     I/O error.
+func acquireHomeLockAt(dir string) (*homeLock, error) {
+	path := daemonLockPathIn(dir)
+	// No O_CREATE: a missing file means no daemon ever wrote a lock here, which
+	// is UNKNOWN, not "free". Any other open error (permission, I/O) is equally
+	// a failure to look, never evidence of freedom.
+	f, err := os.OpenFile(path, os.O_RDWR, 0600)
+	if err != nil {
+		return nil, errLockUnprovable
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = f.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) {
+			return nil, errLockHeld
+		}
+		// A flock error that is not EWOULDBLOCK is not evidence of freedom.
+		return nil, errLockUnprovable
+	}
+	// We took the lock — but a successful flock on a filesystem that does not
+	// really lock (NFS and friends) is a FABRICATED positive: it reports
+	// provably-unused when a daemon on this same host holds its own copy that
+	// also silently did not lock. Trust the acquisition only where flock is
+	// reliable; anywhere else the answer is unknown, never a delete-authorising
+	// "no".
+	if ok, ferr := lockFSReliable(dir); ferr != nil || !ok {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+		return nil, errLockUnprovable
+	}
+	return &homeLock{f: f}, nil
+}
+
+// ProbeHomeLock answers "is a daemon running for this home?" through the
+// per-home daemon.lock — the kernel-guaranteed fact the PID file and a process
+// scan can only heuristically approximate (#960). It never creates the lock
+// file, and it never blocks.
+//
+//   - AnswerYes    → a live daemon holds the lock. The home is IN USE.
+//   - AnswerNo     → the lock existed on a trusted filesystem and we took it: no
+//     live daemon owns the home. This is the ONLY answer that may authorise
+//     removing an abandoned temp home (#1989) — a positive proof, not an
+//     inferred negative.
+//   - Undetermined → we could not tell: no lock file at all, a filesystem whose
+//     flock cannot be trusted, or an I/O error. Leave the home alone and report
+//     it.
+//
+// A flock proves only that no live DAEMON owns the home, not that nothing uses
+// it: a home with live tmux sessions but a dead daemon holds no lock. Callers
+// must keep that second signal (doctor's liveTmuxHomes) — it asks tmux, a
+// different and sound surface — before acting on an AnswerNo.
+func ProbeHomeLock(dir string) ProbeAnswer {
+	lock, err := acquireHomeLockAt(dir)
+	switch {
+	case err == nil:
+		lock.release()
+		return AnswerNo()
+	case errors.Is(err, errLockHeld):
+		return AnswerYes()
+	default:
+		return Undetermined(fmt.Errorf("cannot verify whether a daemon owns %s: %w", dir, err))
+	}
 }

--- a/daemon/singleton_lock_fs_darwin.go
+++ b/daemon/singleton_lock_fs_darwin.go
@@ -1,0 +1,18 @@
+//go:build darwin
+
+package daemon
+
+import "golang.org/x/sys/unix"
+
+// flockReliableFilesystem trusts flock only on locally-mounted filesystems.
+// Darwin's statfs reports MNT_LOCAL directly, so there is no magic-number
+// allowlist to maintain — the kernel already answers "is this local?", which is
+// exactly the question that separates a trustworthy flock from a network mount
+// where it can silently no-op (#1989).
+func flockReliableFilesystem(dir string) (bool, error) {
+	var st unix.Statfs_t
+	if err := unix.Statfs(dir, &st); err != nil {
+		return false, err
+	}
+	return st.Flags&unix.MNT_LOCAL != 0, nil
+}

--- a/daemon/singleton_lock_fs_linux.go
+++ b/daemon/singleton_lock_fs_linux.go
@@ -1,0 +1,39 @@
+//go:build linux
+
+package daemon
+
+import "golang.org/x/sys/unix"
+
+// trustedFlockMagics are the super-block magics of local filesystems whose
+// flock is reliable. This is an ALLOWLIST, not a denylist: an unrecognised
+// filesystem is treated as untrusted, because flock can silently no-op on
+// network filesystems (NFS, SMB, 9p, FUSE) and hand back a fabricated "I took
+// the lock". The cost of omitting a local filesystem here is only
+// under-cleaning a stale temp home — cosmetic; the cost of trusting a network
+// one is deleting a home a daemon on another host is using (#1989). Add local
+// filesystems as needed.
+var trustedFlockMagics = map[uint32]bool{
+	unix.TMPFS_MAGIC:           true, // the usual /tmp
+	unix.RAMFS_MAGIC:           true,
+	unix.EXT4_SUPER_MAGIC:      true, // shares 0xef53 with ext2/ext3
+	unix.XFS_SUPER_MAGIC:       true,
+	unix.BTRFS_SUPER_MAGIC:     true,
+	unix.F2FS_SUPER_MAGIC:      true,
+	unix.OVERLAYFS_SUPER_MAGIC: true, // container roots (docker/podman)
+	unix.REISERFS_SUPER_MAGIC:  true,
+	unix.NILFS_SUPER_MAGIC:     true,
+	unix.BCACHEFS_SUPER_MAGIC:  true,
+	0x2fc12fc1:                 true, // ZFS (not exported by x/sys/unix)
+	0x3153464a:                 true, // JFS
+}
+
+// flockReliableFilesystem reports whether the filesystem backing dir is a local
+// one whose flock we trust. It reads the super-block magic via statfs and
+// consults the allowlist above; anything unrecognised is untrusted.
+func flockReliableFilesystem(dir string) (bool, error) {
+	var st unix.Statfs_t
+	if err := unix.Statfs(dir, &st); err != nil {
+		return false, err
+	}
+	return trustedFlockMagics[uint32(st.Type)], nil
+}

--- a/daemon/singleton_lock_fs_other.go
+++ b/daemon/singleton_lock_fs_other.go
@@ -1,0 +1,9 @@
+//go:build !linux && !darwin
+
+package daemon
+
+// flockReliableFilesystem cannot identify the filesystem on this platform, so it
+// treats every path as untrusted: the temp-home delete stays disabled here
+// rather than risk a fabricated "unused" on a filesystem whose flock we cannot
+// vouch for (#1989). Under-cleaning is cosmetic; over-cleaning eats work.
+func flockReliableFilesystem(string) (bool, error) { return false, nil }

--- a/daemon/singleton_lock_probe_test.go
+++ b/daemon/singleton_lock_probe_test.go
@@ -1,0 +1,94 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// forceReliableFS makes lockFSReliable return a fixed verdict for one test, so
+// the three-valued lock logic can be exercised without a real NFS mount (the
+// untrusted case) or a dependence on the box's temp filesystem (the trusted
+// case). The real statfs plumbing is covered separately by
+// TestFlockReliableFilesystem_LocalTempDirIsTrusted.
+func forceReliableFS(t *testing.T, ok bool) {
+	t.Helper()
+	prev := lockFSReliable
+	t.Cleanup(func() { lockFSReliable = prev })
+	lockFSReliable = func(string) (bool, error) { return ok, nil }
+}
+
+// A missing lock file is UNKNOWN, never "unused". Absence of a lock is not proof
+// of non-use — a home may predate the lock or have been made by a build that
+// never wrote one — and taking a lock nobody ever held would prove nothing
+// (#1989). The probe must also NOT create the file: that would manufacture the
+// very proof it is testing for.
+func TestProbeHomeLock_NoLockFileIsUndeterminedAndDoesNotCreateIt(t *testing.T) {
+	forceReliableFS(t, true)
+	dir := t.TempDir()
+
+	requireAnswer(t, "unknown", ProbeHomeLock(dir),
+		"no daemon.lock file means we cannot prove the home is unused — absence is not proof of non-use")
+
+	_, err := os.Stat(filepath.Join(dir, daemonLockFileName))
+	require.True(t, os.IsNotExist(err),
+		"the probe must NOT create the lock file: taking a lock nobody ever held would manufacture the proof")
+}
+
+// A lock a live daemon holds reads as Yes — the home is in use. Simulated with a
+// second open-file-description held in this process: flock contends across
+// descriptions exactly as it does across processes, so this is the same
+// EWOULDBLOCK a real daemon produces.
+func TestProbeHomeLock_HeldIsYes(t *testing.T) {
+	forceReliableFS(t, true)
+	dir := t.TempDir()
+	path := filepath.Join(dir, daemonLockFileName)
+
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = f.Close() })
+	require.NoError(t, syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB))
+
+	requireAnswer(t, "yes", ProbeHomeLock(dir),
+		"a held daemon.lock means a live daemon owns the home")
+}
+
+// An existing lock we CAN take, on a filesystem whose flock we trust, is the
+// kernel-guaranteed proof that no live daemon owns the home — the only answer
+// that may authorise a delete.
+func TestProbeHomeLock_TakeableOnTrustedFSIsNo(t *testing.T) {
+	forceReliableFS(t, true)
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, daemonLockFileName), nil, 0600))
+
+	requireAnswer(t, "no", ProbeHomeLock(dir),
+		"an existing lock we can take on a trusted filesystem proves no live daemon owns the home")
+}
+
+// The fabricated-positive guard: on a filesystem whose flock cannot be trusted
+// (NFS and friends silently no-op), a successful acquisition proves nothing. It
+// must land in UNKNOWN, never in a delete-authorising No — otherwise the lock
+// lies in the one direction that eats someone's work (#1989).
+func TestProbeHomeLock_UntrustedFilesystemIsUndetermined(t *testing.T) {
+	forceReliableFS(t, false)
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, daemonLockFileName), nil, 0600))
+
+	requireAnswer(t, "unknown", ProbeHomeLock(dir),
+		"on a filesystem whose flock is unreliable, a successful acquisition is a fabricated positive; the "+
+			"answer must be unknown, never a delete-authorising 'no'")
+}
+
+// The real statfs path on THIS box's temp filesystem. tmpfs, overlayfs, and the
+// ext/xfs/btrfs family are on the allowlist; a red here means the allowlist is
+// missing the filesystem the test suite runs on, and stale-temp-home cleanup
+// would silently never fire in this environment.
+func TestFlockReliableFilesystem_LocalTempDirIsTrusted(t *testing.T) {
+	ok, err := flockReliableFilesystem(t.TempDir())
+	require.NoError(t, err)
+	require.True(t, ok,
+		"the local temp filesystem must be on the trusted-flock allowlist, or stale-temp-home cleanup silently never runs here")
+}

--- a/doctor/checks.go
+++ b/doctor/checks.go
@@ -25,8 +25,13 @@ func selfPID() int { return os.Getpid() }
 func tempDirDefault() string { return os.TempDir() }
 
 var (
-	daemonProcessArgv   = daemon.ProcessArgv
-	daemonPIDLooksAlive = daemon.PIDLooksAlive
+	daemonProcessArgv = daemon.ProcessArgv
+	// tempHomeLockProbe answers "is a daemon running for this home?" through the
+	// home's daemon.lock — the kernel-guaranteed fact that authorises removing an
+	// abandoned temp home (#1989). A package var so tests can stage each of the
+	// three outcomes (held / takeable / unprovable) deterministically, without a
+	// real daemon or a real NFS mount.
+	tempHomeLockProbe = daemon.ProbeHomeLock
 	// The per-process facts that decide whether a daemon is OURS (#1044).
 	// Injectable for the same reason as the two above: the states that matter —
 	// another user's process, an environ we may not read — cannot be staged by
@@ -121,8 +126,32 @@ func checkDaemonHealth(ctx *scanContext, report *Report, h daemon.HealthStatus) 
 	case !h.SocketExists:
 		report.Pass(sectionDaemon, "daemon", "not running; starts on demand")
 	default:
-		report.Fail(sectionDaemon, "daemon", fmt.Sprintf("socket %s exists but the daemon is not responding (%v)", h.SocketPath, h.PingErr),
-			"run `af daemon restart`; if it still fails, remove the stale socket after verifying no daemon is running")
+		// The socket exists but the ping failed — classify WHY. A dial timeout
+		// is not proof the daemon is dead: a live daemon with a saturated
+		// control-socket accept backlog times out identically, so reading that
+		// as a Fail would send the user to `af daemon restart` over a working
+		// daemon and drive a spurious nonzero exit (#2040). Only a completed
+		// negative (a refusal) is the definite Fail; a timeout is advisory.
+		notResponding := func() {
+			report.Fail(sectionDaemon, "daemon", fmt.Sprintf("socket %s exists but the daemon is not responding (%v)", h.SocketPath, h.PingErr),
+				"run `af daemon restart`; if it still fails, remove the stale socket after verifying no daemon is running")
+		}
+		daemon.ClassifyPingFailure(h.PingErr).Match(
+			// Yes and NotFound are unreachable: ClassifyPingFailure returns them
+			// only for a nil error, and this arm runs only when the ping FAILED.
+			// They route to the definite Fail rather than to a fabricated pass, so
+			// a future fifth outcome cannot quietly turn a broken daemon healthy.
+			notResponding,
+			notResponding, // No: a refusal — nobody is behind the socket.
+			notResponding,
+			func(cause error) {
+				report.Warn(sectionDaemon, "daemon",
+					fmt.Sprintf("control socket %s did not answer within the dial timeout, so daemon liveness is "+
+						"unknown — it may be alive but busy (%v)", h.SocketPath, h.PingErr),
+					"if the daemon seems wedged run `af daemon restart`; a momentary timeout under heavy RPC load is "+
+						"harmless and needs no action", false)
+			},
+		)
 	}
 	// "A unit file exists" is not "this home has autostart". There is one unit
 	// per user and it bakes its AGENT_FACTORY_HOME at install time, so under a
@@ -490,18 +519,45 @@ var afHomeMarkers = []string{
 func checkStaleTempHomes(ctx *scanContext, report *Report) {
 	tempDir := filepath.Clean(ctx.opts.TempDir)
 	activeHome := filepath.Clean(ctx.opts.ConfigDir)
-	homesInUse, unreadableProcs := processReferencedHomes(ctx.snap)
-	tmuxHomesInUse := liveTmuxHomes(ctx)
+	processHomes := processReferencedHomes(ctx.snap)
+	tmuxHomes := liveTmuxHomes(ctx)
 
 	for _, dir := range candidateTempHomes(tempDir) {
 		dir = filepath.Clean(dir)
 		if dir == activeHome || !isAFHome(dir) {
 			continue
 		}
-		if reason := tempHomeInUseReason(dir, homesInUse, tmuxHomesInUse, unreadableProcs); reason != "" {
-			report.Pass(sectionProcesses, "temp home", fmt.Sprintf("%s is in use (%s)", dir, reason))
+		// POSITIVE proofs of use come first. Each can only ADD a reason to keep
+		// the home; none authorises a delete, so an unread or unavailable surface
+		// here costs at worst an unreported keep — never a wrong removal.
+		if processHomes[dir] {
+			report.Pass(sectionProcesses, "temp home", fmt.Sprintf("%s is in use (a live process references it)", dir))
 			continue
 		}
+		if tmuxHomes[dir] {
+			report.Pass(sectionProcesses, "temp home", fmt.Sprintf("%s is in use (a live tmux session references it)", dir))
+			continue
+		}
+		// The AUTHORITATIVE signal: does a live daemon hold the home's lock? This
+		// replaces the old "did I see a process referencing this home?" — a
+		// negative four consecutive P1 reviews each found a fresh way to falsify,
+		// every one ending at an rm -rf. The lock cannot be falsified that way:
+		// the kernel releases it on the daemon's death, so a takeable lock is
+		// PROOF (not inference) that no live daemon owns the home (#1989).
+		lock := tempHomeLockProbe(dir)
+		var daemonHoldsLock, provablyFree bool
+		var lockCause error
+		lock.Match(
+			func() { daemonHoldsLock = true }, // Yes: a live daemon owns it
+			func() { provablyFree = true },    // No: we took the lock; no daemon owns it
+			func() {},                         // NotFound: ProbeHomeLock never returns this; treat as unknown
+			func(cause error) { lockCause = cause },
+		)
+		if daemonHoldsLock {
+			report.Pass(sectionProcesses, "temp home", fmt.Sprintf("%s is in use (an af daemon holds its lock)", dir))
+			continue
+		}
+
 		age := timeSince(newestMtime(dir))
 		if age < ctx.opts.MinTempHomeAge {
 			continue
@@ -509,51 +565,46 @@ func checkStaleTempHomes(ctx *scanContext, report *Report) {
 		if !pathInside(tempDir, dir) {
 			continue
 		}
-		// REPORT-ONLY. No FixAction, no fix closure: `af doctor --fix` will
-		// not delete this, and that is deliberate.
-		//
-		// This finding used to carry an rm -rf, gated on "no process
-		// references this home". FOUR consecutive P1 reviews found four
-		// different ways to make that negative false, and every one of them
-		// ended at this same delete:
-		//
-		//   1. darwin redacts a foreign process's environment silently, so an
-		//      unread env read as "references no home".
-		//   2. the permission gate written to fix (1) modelled uid but not
-		//      CS_RESTRICT, which SIP makes ordinary — so a same-uid restricted
-		//      process read as "references no home".
-		//   3. (the gate was deleted; classify the answer instead.)
-		//   4. the uid filter that survived assumed temp homes sit under a
-		//      user-owned root. Linux's /tmp is 01777 and shared, so another
-		//      user's home lives there and their processes read as
-		//      "references no home".
-		//
-		// That is not four bugs. It is one unsound question: "can I prove
-		// nobody is using this?" cannot be answered by inspecting processes.
-		// Process inspection is inference over a surface that is adversarial by
-		// construction — kernels redact, policies grow clauses we did not
-		// model, /proc can be mounted subset=pid, /tmp is shared with users we
-		// cannot see, PIDs recycle. Each of those turns "I saw no user" into
-		// "there is no user", and that negative authorised an rm -rf.
-		//
-		// So the teeth come out until the predicate is a FACT rather than an
-		// inference: a lockfile the owning process holds for its lifetime,
-		// where "is this in use?" is answered by trying to take the lock and
-		// the kernel is the authority (see the follow-up issue; af homes
-		// already have exactly such a lock in daemon/singleton_lock.go).
-		//
-		// Reporting is honest; authorising is dangerous; they are not the same
-		// code path. Doctor still names the directory and still says what it
-		// could not verify — the operator decides.
+
+		if provablyFree {
+			// The teeth, restored on a FACT. The lock is takeable (no live daemon)
+			// and no live tmux session names it, so the home is provably unused.
+			// The fix re-verifies every precondition at fix time (TOCTOU): a
+			// daemon may have started, or a tmux session appeared, since detection.
+			report.Findings = append(report.Findings, Finding{
+				Check: "stale-temp-home",
+				Detail: fmt.Sprintf("agent-factory home %s is abandoned (untouched for %s) and no live daemon "+
+					"holds its lock, so it is safe to remove", dir, formatAge(age.Seconds())),
+				FixAction:   "remove " + dir,
+				fix:         staleTempHomeRemoveFix(ctx, dir, tempDir, activeHome),
+				Severity:    StatusWarn,
+				Remediation: "run `af doctor --fix` to remove it, or `rm -rf " + dir + "`",
+			})
+			continue
+		}
+
+		// UNKNOWN: no lock file at all (absence of a lock is not proof of
+		// non-use), a filesystem whose flock cannot be trusted (NFS), or an I/O
+		// error. Report it — reporting is safe — but never authorise the delete
+		// on a proof we do not have. The operator decides.
 		report.Findings = append(report.Findings, Finding{
 			Check: "stale-temp-home",
-			Detail: fmt.Sprintf("agent-factory home %s looks abandoned (untouched for %s), but nothing "+
-				"here can PROVE it is unused — inspect it and remove it yourself if it is dead",
-				dir, formatAge(age.Seconds())),
+			Detail: fmt.Sprintf("agent-factory home %s looks abandoned (untouched for %s), but nothing here can "+
+				"PROVE it is unused (%s) — inspect it and remove it yourself if it is dead",
+				dir, formatAge(age.Seconds()), lockUnknownReason(lockCause)),
 			Severity:    StatusWarn,
 			Remediation: "verify nothing is using it, then `rm -rf " + dir + "`",
 		})
 	}
+}
+
+// lockUnknownReason renders the cause of an undetermined lock probe for the
+// report, defaulting to a plain phrase when the probe carried none.
+func lockUnknownReason(cause error) string {
+	if cause == nil {
+		return "no lock to take proves nothing"
+	}
+	return cause.Error()
 }
 
 // timeSince is time.Since, indirected so tests can pin the clock if needed.
@@ -598,66 +649,25 @@ func isAFHome(dir string) bool {
 }
 
 // processReferencedHomes returns the AF homes live processes name in their
-// environment, AND the number of processes whose environment could not be read.
+// AGENT_FACTORY_HOME environment. It is a POSITIVE signal only: finding a
+// process that names a home proves the home is in use, which spares it. The
+// converse — "no process names it" — is NOT proof of non-use and is deliberately
+// not derived here: that inference was the unsound predicate behind the
+// temp-home rm -rf, and the delete now rests on the daemon lock instead (#1989,
+// staleTempHomeRemoveFix). So an unreadable environment simply contributes no
+// home, which can only under-spare — never authorise a removal.
 //
-// The second return is the whole point, and dropping it would restore a
-// DESTRUCTIVE bug. This feeds tempHomeInUseReason, whose negative — "no process
-// references this home" — is the predicate for os.RemoveAll. A process whose
-// environment we could not read might be using the home; if its unreadability
-// is silently folded into "does not reference it", doctor --fix deletes a home
-// that is in use, on the strength of a read that was denied.
-//
-// This is not hypothetical on darwin: the kernel redacts a foreign process's
-// environment and the buffer looks identical to one with no variables at all
-// (see internal/proctree's darwin readEnviron). Linux says EACCES honestly, but
-// the caller cannot depend on the platform to be honest for it.
-//
-// Only OUR OWN processes count toward unreadable. A home under this user's
-// 0700 temp dir cannot be in use by another user's process, so a foreign
-// process being unreadable tells us nothing we needed to know — and counting it
-// would make --fix refuse forever on any real machine, where most of the
-// process table belongs to root.
-func processReferencedHomes(snap map[int]proctree.Process) (homes map[string]bool, unreadable int) {
-	homes = map[string]bool{}
-	if snap == nil {
-		return homes, 0
-	}
-	self := os.Getuid()
+// Only EnvFound attributes a home. A redacted or denied read (EnvUnknown) must
+// add nothing to the set in either direction — "I could not read its home" is
+// not "its home is X", and it is not "it names no home" either.
+func processReferencedHomes(snap map[int]proctree.Process) map[string]bool {
+	homes := map[string]bool{}
 	for pid := range snap {
-		home, status := proctree.LookupEnv(pid, "AGENT_FACTORY_HOME")
-		switch status {
-		case proctree.EnvFound:
-			if home != "" {
-				homes[filepath.Clean(home)] = true
-			}
-		case proctree.EnvAbsent:
-			// Read, and it names no home: it cannot be using one.
-		default:
-			// EnvUnknown. Narrow it to the processes whose unreadability
-			// actually costs us knowledge, or --fix would refuse forever:
-			// on a real machine most of the table is root's, and darwin
-			// redacts every one of those environments.
-			uid, ok := proctree.UID(pid)
-			switch {
-			case !ok:
-				// No credentials at all means the process is gone — it was
-				// in the snapshot and has since exited. A dead process uses
-				// nothing, so its silence costs us nothing. (Ownership comes
-				// from the process table, which is readable for ANY process
-				// on both platforms, so a failure here is absence of the
-				// process rather than absence of permission.)
-			case uid != self:
-				// Another user's process. It cannot be using a home under
-				// this user's 0700 temp dir, so whether we can read its
-				// environment is irrelevant to the question being asked.
-			default:
-				// Ours, alive, and unreadable: precisely the case we cannot
-				// rule out.
-				unreadable++
-			}
+		if home, status := proctree.LookupEnv(pid, "AGENT_FACTORY_HOME"); status == proctree.EnvFound && home != "" {
+			homes[filepath.Clean(home)] = true
 		}
 	}
-	return homes, unreadable
+	return homes
 }
 
 func liveTmuxHomes(ctx *scanContext) map[string]bool {
@@ -682,83 +692,57 @@ func tmuxSessionHomeMarker(ctx *scanContext, name string) (string, bool) {
 	return strings.CutPrefix(strings.TrimSpace(string(out)), tmux.EnvMarkerHome+"=")
 }
 
-type tempHomeDaemonStatus int
-
-const (
-	tempHomeDaemonAbsentOrDead tempHomeDaemonStatus = iota
-	tempHomeDaemonAlive
-	tempHomeDaemonUnknown
-)
-
-// tempHomeDaemonLiveness reports whether the home's daemon.pid names a live
-// agent-factory daemon. A live PID with unreadable argv is unknown, not dead:
-// doctor must not delete a home when daemon liveness cannot be verified.
-func tempHomeDaemonLiveness(dir string) tempHomeDaemonStatus {
-	data, err := os.ReadFile(filepath.Join(dir, "daemon.pid"))
-	if err != nil {
-		if os.IsNotExist(err) {
-			return tempHomeDaemonAbsentOrDead
+// staleTempHomeRemoveFix rm -rf's an abandoned temp home — the teeth #1969 took
+// out, restored on a predicate the kernel guarantees rather than an inference we
+// assemble (#1989).
+//
+// The old closure was careful — containment, active-home and isAFHome checks, a
+// fresh snapshot at fix time — and none of that was the problem. Its PREDICATE
+// was: "did I see any process referencing this home? no → delete." Four
+// consecutive P1 reviews each found a fresh way for that "no" to be false, every
+// one ending here in an rm -rf. You cannot make an unsound question safe by
+// validating its inputs harder.
+//
+// So the gate is now a FACT: re-probe the home's daemon lock, and delete only on
+// AnswerNo — the lock existed on a trusted filesystem and we took it, proving no
+// live daemon owns the home. Everything is re-checked at fix time because the
+// findings are applied after detection, leaving a window in which a daemon could
+// start (its lock would then be held → refuse) or a tmux session could claim the
+// home (refuse). Undetermined (no lock file, untrusted filesystem) never reaches
+// here: only a provably-free home carries this closure.
+func staleTempHomeRemoveFix(ctx *scanContext, dir, tempDir, activeHome string) func() error {
+	return func() error {
+		dir = filepath.Clean(dir)
+		// Re-assert containment and identity at fix time — cheap, and the home
+		// may have changed under us since detection.
+		if dir == activeHome {
+			return fmt.Errorf("refusing to remove the active home %s", dir)
 		}
-		return tempHomeDaemonUnknown
-	}
-	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
-	if err != nil || pid <= 0 {
-		return tempHomeDaemonUnknown
-	}
-	if !daemonPIDLooksAlive(pid) {
-		return tempHomeDaemonAbsentOrDead
-	}
-	args := daemonProcessArgv(pid)
-	if len(args) == 0 {
-		return tempHomeDaemonUnknown
-	}
-	if daemon.LooksLikeDaemonArgv(args) {
-		return tempHomeDaemonAlive
-	}
-	return tempHomeDaemonAbsentOrDead
-}
-
-// tempHomeInUseReason returns why dir must not be removed, or "" when it is
-// provably unused. unreadableProcs is how many of this user's processes have an
-// environment we could not read: each one is a process that MIGHT reference
-// dir, so a non-zero count means "unused" cannot be proven and the directory
-// stays. That mirrors the tempHomeDaemonUnknown arm below — this function
-// already knew that uncertainty is a reason to keep, not to delete.
-func tempHomeInUseReason(dir string, processHomes, tmuxHomes map[string]bool, unreadableProcs int) string {
-	dir = filepath.Clean(dir)
-	switch {
-	case processHomes[dir]:
-		return "live process references it"
-	case tmuxHomes[dir]:
-		return "live tmux session references it"
-	case unreadableProcs > 0:
-		return fmt.Sprintf("%d of this user's processes have an unreadable environment, so nothing proves "+
-			"they are not using it", unreadableProcs)
-	}
-	switch tempHomeDaemonLiveness(dir) {
-	case tempHomeDaemonAlive:
-		return "daemon pid is live"
-	case tempHomeDaemonUnknown:
-		return "daemon.pid liveness is uncertain"
-	default:
-		return ""
+		if !pathInside(tempDir, dir) {
+			return fmt.Errorf("refusing to remove %s: it is not inside the temp dir %s", dir, tempDir)
+		}
+		if !isAFHome(dir) {
+			return fmt.Errorf("refusing to remove %s: it no longer looks like an agent-factory home", dir)
+		}
+		// A live tmux session naming the home is the second, sound signal the
+		// lock cannot see (a home with live tmux sessions but a dead daemon holds
+		// no lock). Re-check it fresh.
+		if liveTmuxHomes(ctx)[dir] {
+			return fmt.Errorf("refusing to remove %s: a live tmux session now references it", dir)
+		}
+		// The authoritative gate: delete ONLY on a proven "no live daemon owns
+		// this" (AnswerNo). A daemon that appeared since detection now holds the
+		// lock (Yes → refuse); an unprovable answer (Undetermined → refuse) is not
+		// a licence to os.RemoveAll.
+		answer := tempHomeLockProbe(dir)
+		proven := false
+		answer.Match(func() {}, func() { proven = true }, func() {}, func(error) {})
+		if !proven {
+			return fmt.Errorf("refusing to remove %s: cannot prove no daemon owns it (lock answer: %s)", dir, answer.String())
+		}
+		return os.RemoveAll(dir)
 	}
 }
-
-// staleTempHomeRemoveFix is DELETED. Do not reintroduce it without the lock.
-//
-// It was the --fix closure that rm -rf'd an "abandoned" temp home, and it was
-// careful: containment checks, an active-home check, an isAFHome check, and a
-// fresh snapshot at fix time. None of that was the problem. Its PREDICATE was:
-// it asked "did I see any process referencing this home?" and treated "no" as
-// proof. Four consecutive P1 reviews found four different ways for that "no" to
-// be false (see checkStaleTempHomes), each one ending here, in an rm -rf.
-//
-// The care was real and it did not help, because you cannot make an unsound
-// question safe by validating its inputs harder. The delete returns when the
-// predicate is a fact the kernel guarantees — try to take the home's lock —
-// rather than an inference we assemble from a surface that redacts, restricts
-// and shares. See the follow-up issue.
 
 func pathInside(base, path string) bool {
 	rel, err := filepath.Rel(base, path)

--- a/doctor/doctor.go
+++ b/doctor/doctor.go
@@ -19,6 +19,16 @@
 // identity. Anything ambiguous — a process that merely looks orphaned, a
 // session that might belong to another agent-factory home — is reported,
 // never touched.
+//
+// The same asymmetry governs removing an abandoned temp home, and it is worth
+// stating explicitly because getting it wrong deletes someone's work. `--fix`
+// removes one only on a POSITIVE proof: the home's daemon.lock exists on a
+// filesystem whose flock we trust and doctor could TAKE it, which the kernel
+// guarantees means no live daemon owns the home (#1989) — plus no live tmux
+// session names it. Every other outcome, including "no lock file at all" and
+// "this filesystem's flock cannot be trusted", is UNKNOWN: reported, never
+// removed. Doctor never infers "unused" from having failed to find a user;
+// under-cleaning is cosmetic, over-cleaning is not.
 package doctor
 
 import (
@@ -92,8 +102,12 @@ type Report struct {
 	Findings []Finding
 }
 
-// UnresolvedCount returns how many findings remain un-remediated (either
-// report-only, fix not requested, or fix failed).
+// UnresolvedCount returns how many underlying issues remain un-remediated
+// (either report-only, fix not requested, or fix failed). It is the number the
+// summary leads with and the exit code keys on, so it counts TRUE underlying
+// issues — a collapsed "… and N more" summary finding stands for N issues, not
+// one — and therefore equals the sum of the per-check counts a reader sees, not
+// the smaller number of collapsed rows (#1979).
 func (r *Report) UnresolvedCount() int {
 	n := 0
 	for _, c := range r.Checks {
@@ -101,12 +115,7 @@ func (r *Report) UnresolvedCount() int {
 			n++
 		}
 	}
-	for _, f := range r.Findings {
-		if !f.Fixed {
-			n++
-		}
-	}
-	return n
+	return n + countUnresolvedFindings(r.Findings)
 }
 
 // Options configures a doctor run. Zero values resolve to production

--- a/doctor/doctor_test.go
+++ b/doctor/doctor_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -334,20 +335,18 @@ func TestLeakedTmuxSessionReportedNotKilled(t *testing.T) {
 		"leaked session must survive --fix")
 }
 
-// TestStaleTempHomeReportedButNeverRemoved: an abandoned AF home under the temp
-// root is DETECTED by its structural markers and REPORTED — and `--fix` does
-// not remove it. A fresh home, and a plain directory, stay untouched too.
+// TestStaleTempHomeReportedButNeverRemoved: an abandoned AF home with NO
+// daemon.lock file is DETECTED by its structural markers and REPORTED — and
+// `--fix` does not remove it. A fresh home, and a plain directory, stay
+// untouched too.
 //
-// This test used to assert the opposite (`require.NoDirExists(stale)`), and the
-// inversion is the point. The removal was gated on "no process references this
-// home", a negative that four consecutive P1 reviews each found a new way to
-// falsify — darwin's silent env redaction, a permission gate that modelled uid
-// but not CS_RESTRICT, and a uid filter that assumed temp roots are
-// user-owned when Linux's /tmp is 01777 and shared. Every one ended at this
-// rm -rf. Process inspection cannot answer "is anything using this?", so it no
-// longer authorises deleting anything; it reports, and the operator decides.
-// The delete returns when the predicate is a lock the kernel guarantees rather
-// than an inference we assemble.
+// This is the "no lock file → never deleted" acceptance of #1989. The delete now
+// rests on a kernel fact — a takeable daemon.lock proves no live daemon owns the
+// home — but ABSENCE of a lock is not proof of non-use: a home may predate the
+// lock, or have been made by a build that never wrote one, and taking a lock
+// nobody ever held would prove nothing. So a home with no lock lands in UNKNOWN:
+// reported (the operator decides), never removed. (The takeable-lock delete that
+// DOES fire is exercised by TestTakeableLockTempHomeRemovedOnFix.)
 func TestStaleTempHomeReportedButNeverRemoved(t *testing.T) {
 	testguard.IsolateTmux(t)
 	opts := testOptions(t, true)
@@ -379,8 +378,8 @@ func TestStaleTempHomeReportedButNeverRemoved(t *testing.T) {
 	require.Len(t, findings, 1)
 	require.Contains(t, findings[0].Detail, stale, "the operator must still be told which directory")
 	require.Empty(t, findings[0].FixAction,
-		"stale-temp-home must carry NO fix action: process inspection cannot prove a home is unused, "+
-			"so it must not authorise deleting one")
+		"stale-temp-home with no lock file must carry NO fix action: absence of a lock is not proof of "+
+			"non-use, so it must not authorise deleting one")
 	require.False(t, findings[0].Fixed, "a --fix run must not have removed anything")
 
 	require.DirExists(t, stale, "a --fix run must NOT delete a home it cannot prove is unused")
@@ -702,4 +701,138 @@ func TestRemoteCoderWhoamiWarnsWithoutFailingDoctor(t *testing.T) {
 	require.Contains(t, checks[0].Detail, "not logged in")
 	require.Equal(t, "run `coder login`", checks[0].Remediation)
 	require.Zero(t, report.UnresolvedCount(), "coder auth warnings must not fail doctor")
+}
+
+// TestDaemonPingTimeoutIsAdvisoryNotFail is the #2040 fail-first: when the
+// control socket EXISTS but the ping DIAL times out — a live daemon momentarily
+// backlogged under heavy RPC load looks exactly like this — doctor must not read
+// it as a definite Fail. A Fail would drive a nonzero exit and tell the user to
+// `af daemon restart` a working daemon. The timeout is advisory: a WARN whose
+// Problem is false, so it never touches the exit code.
+//
+// Observed failing at 307f159: checkDaemonHealth's default arm collapsed any
+// non-nil PingErr into report.Fail, so the daemon row came back FAIL with
+// Problem true and the StatusWarn / !Problem assertions failed.
+func TestDaemonPingTimeoutIsAdvisoryNotFail(t *testing.T) {
+	testguard.IsolateTmux(t)
+	opts := testOptions(t, false)
+	home := opts.ConfigDir
+
+	// The socket file must be present so checkDaemonHealth reaches the ping arm
+	// rather than the "not running; starts on demand" pass.
+	sockPath := filepath.Join(home, "daemon.sock")
+	require.NoError(t, os.WriteFile(sockPath, nil, 0600))
+
+	// The exact error shape net.DialTimeout returns on a deadline expiry.
+	timeoutErr := &net.OpError{Op: "dial", Net: "unix", Err: os.ErrDeadlineExceeded}
+	require.True(t, os.IsTimeout(timeoutErr) || errors.Is(timeoutErr, os.ErrDeadlineExceeded))
+	opts.daemonHealth = func() daemon.HealthStatus {
+		return daemon.HealthStatus{
+			SocketPath:    sockPath,
+			SocketExists:  true,
+			PingErr:       timeoutErr,
+			HTTPListening: daemon.Undetermined(errNoDaemon),
+		}
+	}
+
+	report, err := Run(opts)
+	require.NoError(t, err)
+
+	rows := findCheckRows(report, "daemon")
+	require.Len(t, rows, 1)
+	require.Equal(t, StatusWarn, rows[0].Status,
+		"a dial timeout is not proof the daemon is dead — a busy daemon times out identically (#2040)")
+	require.False(t, rows[0].Problem, "a timeout is advisory; it must not drive the exit code (#2040)")
+}
+
+// TestDaemonPingRefusalStaysFail: a refusal (ECONNREFUSED) is a completed answer
+// — nobody is home — and must stay the definite Fail. The #2040 fix must demote
+// only timeouts, not blur a real refusal into an advisory warning.
+func TestDaemonPingRefusalStaysFail(t *testing.T) {
+	testguard.IsolateTmux(t)
+	opts := testOptions(t, false)
+	home := opts.ConfigDir
+	sockPath := filepath.Join(home, "daemon.sock")
+	require.NoError(t, os.WriteFile(sockPath, nil, 0600))
+
+	refusedErr := &net.OpError{Op: "dial", Net: "unix",
+		Err: &os.SyscallError{Syscall: "connect", Err: syscall.ECONNREFUSED}}
+	opts.daemonHealth = func() daemon.HealthStatus {
+		return daemon.HealthStatus{
+			SocketPath:    sockPath,
+			SocketExists:  true,
+			PingErr:       refusedErr,
+			HTTPListening: daemon.Undetermined(errNoDaemon),
+		}
+	}
+
+	report, err := Run(opts)
+	require.NoError(t, err)
+
+	rows := findCheckRows(report, "daemon")
+	require.Len(t, rows, 1)
+	require.Equal(t, StatusFail, rows[0].Status, "a refused ping is a definite negative")
+	require.True(t, rows[0].Problem, "a refusal is actionable and must drive the exit code")
+}
+
+// TestSummaryLeadsWithActionableCountMatchingUnresolved is the #1979 fail-first:
+// the summary must LEAD with the actionable count (which the exit code keys on),
+// and that count must be the TRUE number of underlying issues so it matches the
+// per-check counts a reader sees — not the smaller number of collapsed rows.
+//
+// Observed failing at 307f159: UnresolvedCount counted the two collapsed finding
+// STRUCTS (1 shown + 1 "… and 46 more") as 2, and the summary trailed with
+// "0 PASS, 1 WARN, 0 FAIL; 2 underlying issues require action" — so both the
+// "47 issues require action" assertion and the leads-before-FAIL ordering failed
+// while the per-check row already said "47 processes".
+func TestSummaryLeadsWithActionableCountMatchingUnresolved(t *testing.T) {
+	r := &Report{
+		Findings: []Finding{
+			{Check: "possible-orphan", Detail: "pid 1 (x) belongs to a dead tmux server"},
+			{Check: "possible-orphan", Detail: "… and 46 more processes of dead tmux servers"},
+		},
+	}
+	// 1 shown + 46 folded into the summary row = 47 underlying issues, the same
+	// number the collapsed per-check row shows.
+	require.Equal(t, 47, r.UnresolvedCount(),
+		"the count that drives the exit code must reflect the true underlying issues, not the number of collapsed rows (#1979)")
+
+	var buf bytes.Buffer
+	Render(&buf, r, false, false)
+	out := buf.String()
+
+	require.Contains(t, out, "47 issues require action")
+	require.Contains(t, out, "47 processes belong to dead tmux servers",
+		"the per-check row and the summary total must be the same arithmetic (#1979)")
+
+	idxCount := strings.Index(out, "issues require action")
+	idxFail := strings.Index(out, "FAIL")
+	require.GreaterOrEqual(t, idxCount, 0)
+	require.GreaterOrEqual(t, idxFail, 0)
+	require.Less(t, idxCount, idxFail,
+		"the summary must lead with the actionable count, not the FAIL tally, so a reader who stops at "+
+			"'0 FAIL' cannot conclude healthy while doctor exits nonzero (#1979)")
+}
+
+// TestSummarizedMoreCountIsAnchoredNotOpportunistic: a finding whose detail
+// embeds a process cmdline containing the words "and 5 more" must count as ONE
+// issue, not five. The roll-up count is read back out of rendered English, so
+// the match is anchored to the "… and N more" prefix the roll-up is written
+// with. Unanchored, a user's command line silently inflates the total that now
+// drives the exit code (#1979).
+func TestSummarizedMoreCountIsAnchoredNotOpportunistic(t *testing.T) {
+	embedded := &Report{
+		Findings: []Finding{
+			{Check: "possible-orphan", Detail: "pid 42 (sh): /bin/sh -c 'sync and 5 more files' belongs to a dead tmux server"},
+		},
+	}
+	require.Equal(t, 1, embedded.UnresolvedCount(),
+		"a cmdline that happens to contain 'and 5 more' is one finding, not five")
+
+	// The genuine roll-up still expands to what it folded.
+	rollup := &Report{
+		Findings: []Finding{{Check: "possible-orphan", Detail: "… and 46 more processes of dead tmux servers"}},
+	}
+	require.Equal(t, 46, rollup.UnresolvedCount(),
+		"the real roll-up must still stand for every process it folded")
 }

--- a/doctor/env_redaction_test.go
+++ b/doctor/env_redaction_test.go
@@ -2,8 +2,6 @@ package doctor
 
 import (
 	"os"
-	"os/exec"
-	"path/filepath"
 	"sort"
 	"testing"
 	"time"
@@ -23,27 +21,18 @@ import (
 // does not report the refusal: the buffer comes back with argv and no env, which
 // is byte-for-byte identical to a process started with an empty environment. So
 // "this process names no AF home" and "I was not allowed to see whether it does"
-// arrive looking the same, and the layer that decides what gets DELETED cannot
-// tell them apart.
+// arrive looking the same.
 //
-// That mattered most at processReferencedHomes, whose negative — "no process
-// references this home" — is the predicate for os.RemoveAll. A redacted read
-// made an in-use home look unreferenced, so `af doctor --fix` would delete a
-// home a live process was using.
-//
-// What is real here and what is simulated, precisely:
-//
-//   - REAL: the refusal itself. unreadableEnvPID finds a process owned by
-//     another user, and the kernel genuinely refuses us — EACCES on Linux,
-//     silent redaction on darwin. Both must arrive as EnvUnknown.
-//   - SIMULATED: an OWN-uid process with a redacted environment, which cannot
-//     be conjured honestly (Linux always lets us read our own; darwin would
-//     need a set-id binary). So the deletion gate is driven by passing the
-//     unreadable COUNT to tempHomeInUseReason directly — the input the decision
-//     actually consumes.
-//   - SKIPPED, honestly: an environment with no foreign process at all (our
-//     test container runs everything as one uid) has no refusal to observe, and
-//     these say so rather than inventing one.
+// This once mattered most at the temp-home DELETE gate, whose predicate was "no
+// process references this home" — a redacted read made an in-use home look
+// unreferenced, so `af doctor --fix` would delete a home a live process was
+// using. That gate is gone: the delete now rests on the daemon lock, a
+// kernel-guaranteed fact, and process inspection is only a POSITIVE spare-signal
+// (finding a process that names a home keeps it; not finding one authorises
+// nothing — #1989). So the destructive tests those redactions drove are gone
+// too; what remains here is the primitive-level rule that a denied read never
+// fabricates an attribution, in EITHER direction — still load-bearing for the
+// orphan-reaping path and for the positive spare-signal.
 
 // unreadableEnvPID returns a pid whose environment this test cannot read.
 //
@@ -51,8 +40,7 @@ import (
 // root's. That assumption is true on a normal machine and false in our own test
 // container, where pid 1 is the entrypoint running as the same unprivileged
 // user as the tests — so the "refusal" never happened and the test failed for a
-// reason unrelated to its subject. (This PR's own bug class, aimed at its own
-// tests: an environment assumption that holds only where it was written.)
+// reason unrelated to its subject.
 //
 // Skips honestly when the environment has no foreign process to refuse us.
 func unreadableEnvPID(t *testing.T) int {
@@ -91,128 +79,15 @@ func TestRedactedEnvIsUnknownNotAbsent(t *testing.T) {
 			"strength of a read that was denied", pid)
 }
 
-// TestUnreadableEnvDoesNotMakeAHomeLookUnused is the destructive regression:
-// when one of this user's live processes has an unreadable environment, it
-// MIGHT be using the home, so doctor must refuse to delete it.
-//
-// It drives tempHomeInUseReason — the decision itself — rather than trying to
-// conjure an own-uid process with a redacted environment, which cannot be done
-// honestly on the Linux runner (Linux always lets us read our own) and would
-// need a set-id binary on darwin. The count reaching this function is what the
-// deletion turns on, and that is what is asserted.
-//
-// Fails against the pre-fix code, which had no such parameter: "unreadable" was
-// folded into "references no home", so the reason came back "" == safe to
-// remove.
-func TestUnreadableEnvDoesNotMakeAHomeLookUnused(t *testing.T) {
-	home := filepath.Join(testguard.SocketTempDir(t), "af-home")
-	require.NoError(t, os.MkdirAll(home, 0o755))
-
-	// Nothing references it, no tmux session names it — but one of our own
-	// processes has an environment we could not read. Nothing here proves that
-	// process is not using `home`.
-	reason := tempHomeInUseReason(home, map[string]bool{}, map[string]bool{}, 1)
-	require.NotEmpty(t, reason,
-		"doctor must refuse to remove %s: a process with an unreadable environment might be using it, "+
-			"and an unprovable 'unused' is not a licence to os.RemoveAll", home)
-	require.Contains(t, reason, "unreadable",
-		"the refusal must name WHY it could not decide, or the operator cannot act on it")
-	require.DirExists(t, home)
-}
-
-// TestSameUidEmptyEnvProcessDoesNotAuthoriseDeletion is the second P1's
-// destructive regression: a process we OWN whose environment reads back empty
-// must block the deletion, not license it.
-//
-// This is the cs_restricted shape. On a real Mac with SIP, XNU withholds the
-// environment of a code-signing-restricted process EVEN FROM ITS OWNER — so a
-// same-uid process comes back with no variables. The first fix's permission gate
-// modelled ownership only, waved that process through as "readable", and its
-// empty env was then read as "references no home" — authorising
-// staleTempHomeRemoveFix to delete a home it may well have been using.
-//
-// SIMULATED, honestly: CI cannot create a cs_restricted process (it needs a
-// signed binary with a restricted entitlement, and the runner has no signing
-// identity). `env -i` is used instead because it produces the SAME OBSERVABLE
-// the code consumes — a same-uid process whose environment reads back with zero
-// variables. That is the exact input cs_restricted delivers; only the kernel's
-// reason differs, and the fix deliberately does not look at the reason.
-func TestSameUidEmptyEnvProcessDoesNotAuthoriseDeletion(t *testing.T) {
-	cmd := exec.Command("env", "-i", "sleep", "300")
-	require.NoError(t, cmd.Start())
-	t.Cleanup(func() {
-		_ = cmd.Process.Kill()
-		_, _ = cmd.Process.Wait()
-	})
-	pid := cmd.Process.Pid
-	require.Eventually(t, func() bool {
-		argv := proctree.Argv(pid)
-		return len(argv) > 0 && argv[0] == "sleep"
-	}, 5*time.Second, 10*time.Millisecond, "the env -i child never exec'd")
-
-	// It is OURS — a permission model based on ownership says "readable".
-	uid, ok := proctree.UID(pid)
-	require.True(t, ok)
-	require.Equal(t, os.Getuid(), uid, "the point of this test is a SAME-UID process")
-
-	// And yet we have no idea what it references.
-	_, unreadable := processReferencedHomes(map[int]proctree.Process{pid: {PID: pid}})
-	require.NotZero(t, unreadable,
-		"a same-uid process whose environment reads back empty must count as UNREADABLE. An "+
-			"ownership-based permission gate calls it readable and its empty env then reads as "+
-			"'references no home' — which is what authorises os.RemoveAll")
-
-	home := filepath.Join(testguard.SocketTempDir(t), "af-home")
-	require.NoError(t, os.MkdirAll(home, 0o755))
-	require.NotEmpty(t, tempHomeInUseReason(home, map[string]bool{}, map[string]bool{}, unreadable),
-		"doctor must refuse to remove %s: a process it cannot read might be using it", home)
-	require.DirExists(t, home)
-}
-
 // TestUnreadableEnvYieldsNoHomeClaim: we could not read the environment, so we
-// must not claim to know which home it names either. A redacted read must add
-// nothing to the referenced set — in EITHER direction.
+// must not attribute a home to it. A redacted read must add nothing to the
+// referenced set — which keeps the positive spare-signal honest: it can only
+// spare a home it can genuinely see a process using, never one it guessed at.
 func TestUnreadableEnvYieldsNoHomeClaim(t *testing.T) {
 	pid := unreadableEnvPID(t)
-	homes, _ := processReferencedHomes(map[int]proctree.Process{pid: {PID: pid}})
+	homes := processReferencedHomes(map[int]proctree.Process{pid: {PID: pid}})
 	require.Empty(t, homes,
 		"pid %d's environment is not readable, so no home may be attributed to it", pid)
-}
-
-// TestProvablyUnusedHomeIsStillRemovable is the guard on the guard. The fix
-// above refuses when it cannot prove a home is unused; if that refusal fired
-// indiscriminately, stale-temp-home cleanup would silently stop working and
-// nobody would notice, because a refusal looks like a clean run.
-func TestProvablyUnusedHomeIsStillRemovable(t *testing.T) {
-	// A process whose environment we CAN read (our own), naming no AF home.
-	snap := map[int]proctree.Process{os.Getpid(): {PID: os.Getpid()}}
-	t.Setenv("AGENT_FACTORY_HOME", "")
-
-	homes, unreadable := processReferencedHomes(snap)
-	require.Zero(t, unreadable, "our own environment is readable, so nothing should be unreadable")
-
-	dir := filepath.Join(testguard.SocketTempDir(t), "af-unused")
-	require.NoError(t, os.MkdirAll(dir, 0o755))
-	require.Empty(t, tempHomeInUseReason(dir, homes, map[string]bool{}, unreadable),
-		"a home that is provably unused must still be removable, or the cleanup is dead")
-}
-
-// TestForeignProcessesDoNotBlockCleanup pins why only OUR OWN processes count
-// as unreadable. On a real machine most of the process table belongs to root,
-// and on darwin every one of those environments is redacted — so counting
-// foreign processes would make --fix refuse forever, on every Mac.
-//
-// A home under this user's 0700 temp dir cannot be in use by another user's
-// process, so their unreadability tells us nothing we needed.
-func TestForeignProcessesDoNotBlockCleanup(t *testing.T) {
-	pid := unreadableEnvPID(t) // a process owned by another user
-
-	_, unreadable := processReferencedHomes(map[int]proctree.Process{pid: {PID: pid}})
-	if uid, ok := proctree.UID(pid); ok && uid != os.Getuid() {
-		require.Zero(t, unreadable,
-			"pid %d belongs to uid %d, not us — it cannot be using a home under our own temp dir, "+
-				"so it must not block cleanup", pid, uid)
-	}
 }
 
 // TestRedactedEnvOrphanIsNotKilled is the reaping half: a marked orphan whose

--- a/doctor/report.go
+++ b/doctor/report.go
@@ -323,18 +323,46 @@ func collapsedCount(findings []Finding) int {
 	return total
 }
 
-func summarizedMoreCount(detail string) (int, bool) {
-	fields := strings.Fields(detail)
-	for i := 0; i+2 < len(fields); i++ {
-		if fields[i] != "and" || fields[i+2] != "more" {
+// countUnresolvedFindings counts the TRUE number of underlying issues the
+// un-remediated findings represent. It mirrors collapsedCount's expansion of a
+// "… and N more" summary into N, so the total the summary reports and the
+// per-check counts a reader sees are the same arithmetic — 1 + 15 + 62, not
+// 1 + 15 + 16 (#1979). Without this the summary's total counts collapsed ROWS
+// while the per-check details count PROCESSES, and the two never add up.
+func countUnresolvedFindings(findings []Finding) int {
+	n := 0
+	for _, f := range findings {
+		if f.Fixed {
 			continue
 		}
-		var n int
-		if _, err := fmt.Sscanf(fields[i+1], "%d", &n); err == nil {
-			return n, true
+		if c, ok := summarizedMoreCount(f.Detail); ok {
+			n += c
+			continue
 		}
+		n++
 	}
-	return 0, false
+	return n
+}
+
+// summarizedMoreCount reads N back out of a "… and N more …" roll-up detail —
+// the one finding that stands for several (see checkOrphanedProcesses' cap).
+//
+// It is ANCHORED to the "… and N more" prefix that roll-up is written with, not
+// matched anywhere in the string, because a finding's detail can embed a
+// process's cmdline (describeProc) and a command line containing the words "and
+// 5 more" would otherwise be read as a roll-up of five. That miscount now
+// reaches the exit-code-driving total (#1979), so the match has to be precise
+// rather than opportunistic.
+func summarizedMoreCount(detail string) (int, bool) {
+	fields := strings.Fields(detail)
+	if len(fields) < 4 || fields[0] != "…" || fields[1] != "and" || fields[3] != "more" {
+		return 0, false
+	}
+	var n int
+	if _, err := fmt.Sscanf(fields[2], "%d", &n); err != nil {
+		return 0, false
+	}
+	return n, true
 }
 
 func plural(n int, singular, plural string) string {
@@ -453,22 +481,29 @@ func orderedSections(rows []renderRow) []string {
 	return out
 }
 
+// summaryLine LEADS with the actionable count, then gives the status-row
+// breakdown (#1979). A reader who stops at "0 FAIL" must not conclude "healthy"
+// while `af doctor` exits nonzero: the exit code keys on the actionable count
+// (UnresolvedCount), so that count is the headline and the exit code cannot
+// contradict it. The PASS/WARN/FAIL tally is a different axis — it counts ROWS,
+// not issues, which is why it trails in parentheses and why one collapsed WARN
+// row can stand for many issues.
 func summaryLine(r *Report, rows []renderRow, fixMode bool) string {
 	counts := map[CheckStatus]int{}
 	for _, row := range rows {
 		counts[row.status]++
 	}
-	parts := []string{
+	breakdown := []string{
 		fmt.Sprintf("%d PASS", counts[StatusPass]),
 		fmt.Sprintf("%d WARN", counts[StatusWarn]),
 		fmt.Sprintf("%d FAIL", counts[StatusFail]),
 	}
 	if counts[StatusFixed] > 0 {
-		parts = append(parts, fmt.Sprintf("%d FIXED", counts[StatusFixed]))
+		breakdown = append(breakdown, fmt.Sprintf("%d FIXED", counts[StatusFixed]))
 	}
 
 	unresolved := r.UnresolvedCount()
-	summary := fmt.Sprintf("Summary: %s; %s.", strings.Join(parts, ", "), issuePhrase(unresolved))
+	summary := fmt.Sprintf("Summary: %s (%s).", issuePhrase(unresolved), strings.Join(breakdown, ", "))
 	switch {
 	case !fixMode && fixableCount(r) > 0:
 		summary = strings.TrimSuffix(summary, ".") +
@@ -485,9 +520,9 @@ func issuePhrase(n int) string {
 		return "no issues require action"
 	}
 	if n == 1 {
-		return "1 underlying issue requires action"
+		return "1 issue requires action"
 	}
-	return fmt.Sprintf("%d underlying issues require action", n)
+	return fmt.Sprintf("%d issues require action", n)
 }
 
 func fixableCount(r *Report) int {

--- a/doctor/skew_test.go
+++ b/doctor/skew_test.go
@@ -129,6 +129,16 @@ func stubProcessHomes(t *testing.T, homes map[int]string) {
 	}
 }
 
+// stubDaemonProcessArgv makes the daemon scan read a fixed argv for every pid,
+// so a test can present its own spawned shell as a daemon-shaped process without
+// depending on the real /proc argv.
+func stubDaemonProcessArgv(t *testing.T, argv func(pid int) []string) {
+	t.Helper()
+	prev := daemonProcessArgv
+	daemonProcessArgv = argv
+	t.Cleanup(func() { daemonProcessArgv = prev })
+}
+
 // stubProcessEnv gives one pid a complete fake environ, so a test can put a
 // daemon in a frame of reference (its own HOME, its own AGENT_FACTORY_HOME
 // spelling) that differs from doctor's. Other pids keep their real environ.
@@ -349,9 +359,7 @@ func TestDuplicateDaemons_AncestorDaemonIsCounted(t *testing.T) {
 	testguard.IsolateTmux(t)
 
 	home := t.TempDir()
-	stubDaemonProcessProbe(t,
-		func(int) bool { return true },
-		func(int) []string { return []string{"af", "--daemon"} })
+	stubDaemonProcessArgv(t, func(int) []string { return []string{"af", "--daemon"} })
 
 	stale := spawnWithEnv(t, "af", []string{"--daemon"}, map[string]string{"AGENT_FACTORY_HOME": home})
 	// Both the ancestor (us) and the stale extra serve this home.
@@ -375,9 +383,7 @@ func TestForeignDaemons_AncestorNeverOfferedForKill(t *testing.T) {
 	testguard.IsolateTmux(t)
 
 	home := t.TempDir()
-	stubDaemonProcessProbe(t,
-		func(int) bool { return true },
-		func(int) []string { return []string{"af", "--daemon"} })
+	stubDaemonProcessArgv(t, func(int) []string { return []string{"af", "--daemon"} })
 	// Our own process, presented as an ancestor daemon serving ANOTHER home —
 	// the shape that would otherwise reach the foreign-daemon kill path.
 	otherHome := t.TempDir()
@@ -412,9 +418,7 @@ func TestRemedies_NeverRecommendDestructiveResetForDaemonProblems(t *testing.T) 
 	home := socketTempHome(t)
 	// Stage every daemon-lifecycle problem at once: two daemons, a stale HTTP
 	// socket, a skewed daemon, and a mismatched autostart unit.
-	stubDaemonProcessProbe(t,
-		func(int) bool { return true },
-		func(int) []string { return []string{"af", "--daemon"} })
+	stubDaemonProcessArgv(t, func(int) []string { return []string{"af", "--daemon"} })
 	first := spawnWithEnv(t, "af", []string{"--daemon"}, map[string]string{"AGENT_FACTORY_HOME": home})
 	second := spawnWithEnv(t, "af", []string{"--daemon"}, map[string]string{"AGENT_FACTORY_HOME": home})
 	stubProcessHomes(t, map[int]string{first.PID: home, second.PID: home})
@@ -479,9 +483,7 @@ func TestDuplicateDaemons_ForeignUserDaemon_NotAttributedHere(t *testing.T) {
 
 	// Make every process in the (2-pid) snapshot look like an af daemon, so
 	// only ownership and the unreadable environ can tell them apart.
-	stubDaemonProcessProbe(t,
-		func(int) bool { return true },
-		func(int) []string { return []string{"af", "--daemon"} })
+	stubDaemonProcessArgv(t, func(int) []string { return []string{"af", "--daemon"} })
 
 	// $HOME is not sandboxed by the package harness (only AGENT_FACTORY_HOME
 	// is), so leaving it alone would point this test at the developer's real
@@ -635,9 +637,7 @@ func TestDuplicateDaemons_HomeSpellingsCompareEqual(t *testing.T) {
 	tildeSpelling := filepath.Join("~", filepath.Base(realHome))
 	require.Equal(t, realHome, config.ExpandTilde(tildeSpelling), "test premise: the two spell one dir")
 
-	stubDaemonProcessProbe(t,
-		func(int) bool { return true },
-		func(int) []string { return []string{"af", "--daemon"} })
+	stubDaemonProcessArgv(t, func(int) []string { return []string{"af", "--daemon"} })
 
 	first := spawnWithEnv(t, "af", []string{"--daemon"}, nil)
 	second := spawnWithEnv(t, "af", []string{"--daemon"}, nil)

--- a/doctor/temp_home_liveness_test.go
+++ b/doctor/temp_home_liveness_test.go
@@ -5,14 +5,15 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/internal/proctree"
 )
 
@@ -34,24 +35,15 @@ func makeOldTempAFHome(t *testing.T, tempRoot, name string) string {
 	return dir
 }
 
-func writeOldDaemonPID(t *testing.T, dir string, pid int) {
+// stubTempHomeLockProbe forces the lock-probe outcome for a test, so the
+// report/delete decisions can be driven off each of the three answers
+// (held / takeable / unprovable) without a real daemon or a real NFS mount. The
+// real probe mechanics are covered by the daemon package's ProbeHomeLock tests.
+func stubTempHomeLockProbe(t *testing.T, answer func(dir string) daemon.ProbeAnswer) {
 	t.Helper()
-	path := filepath.Join(dir, "daemon.pid")
-	require.NoError(t, os.WriteFile(path, []byte(strconv.Itoa(pid)), 0600))
-	old := time.Now().Add(-48 * time.Hour)
-	require.NoError(t, os.Chtimes(path, old, old))
-}
-
-func stubDaemonProcessProbe(t *testing.T, alive func(int) bool, argv func(int) []string) {
-	t.Helper()
-	origAlive := daemonPIDLooksAlive
-	origArgv := daemonProcessArgv
-	daemonPIDLooksAlive = alive
-	daemonProcessArgv = argv
-	t.Cleanup(func() {
-		daemonPIDLooksAlive = origAlive
-		daemonProcessArgv = origArgv
-	})
+	prev := tempHomeLockProbe
+	tempHomeLockProbe = answer
+	t.Cleanup(func() { tempHomeLockProbe = prev })
 }
 
 func macLikeTempHomeOptions(t *testing.T, tempRoot string, fix bool) Options {
@@ -70,39 +62,108 @@ func macLikeTempHomeOptions(t *testing.T, tempRoot string, fix bool) Options {
 	return opts
 }
 
-func TestTempHomeDaemonLivenessUsesDaemonProcessArgv(t *testing.T) {
-	tempRoot := t.TempDir()
-	dir := makeOldTempAFHome(t, tempRoot, "tmp.live-daemon")
-	writeOldDaemonPID(t, dir, 4242)
-	stubDaemonProcessProbe(t,
-		func(pid int) bool { return pid == 4242 },
-		func(pid int) []string {
-			require.Equal(t, 4242, pid)
-			return []string{"/usr/local/bin/af", "--daemon"}
-		},
-	)
-
-	report, err := Run(macLikeTempHomeOptions(t, tempRoot, true))
+// holdDaemonLock creates dir's daemon.lock and holds an exclusive flock on it
+// for the whole test — exactly what a running daemon does. flock contends
+// across open-file-descriptions the same in one process as across two, so this
+// is a faithful stand-in for a live daemon owning the home.
+func holdDaemonLock(t *testing.T, dir string) {
+	t.Helper()
+	path := filepath.Join(dir, "daemon.lock")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600)
 	require.NoError(t, err)
-	require.Empty(t, findByCheck(report, "stale-temp-home"))
-	require.DirExists(t, dir, "a temp home with a verified live daemon must never be removed")
-	require.True(t, okContains(report, "daemon pid is live"))
+	t.Cleanup(func() { _ = f.Close() })
+	require.NoError(t, syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB))
+	// Creating the lock file refreshed dir's mtime; age it back so the home is
+	// old enough to be a delete candidate. Otherwise the age gate would spare it
+	// for looking fresh, masking whether the LOCK is what spares it.
+	old := time.Now().Add(-48 * time.Hour)
+	require.NoError(t, os.Chtimes(path, old, old))
+	require.NoError(t, os.Chtimes(dir, old, old))
 }
 
-func TestTempHomeDaemonUncertainLivenessSparesHome(t *testing.T) {
+// TestTempHomeWithHeldDaemonLockIsSpared is the #1989 fail-first: a temp home
+// whose daemon.lock is held by a LIVE daemon must never be reported stale or
+// removed, even under --fix — and even when the process/pid surface the old
+// scan relied on shows nothing (this run has no /proc and no tmux).
+//
+// Observed failing at 307f159: the old code has no lock probe, so its process
+// scan finds no reference, reads the home as abandoned, and REPORTS it stale —
+// the assertion that nothing is reported then fails. The lock probe is what
+// turns "I saw no process" into the sound "a daemon holds the lock → in use".
+func TestTempHomeWithHeldDaemonLockIsSpared(t *testing.T) {
 	tempRoot := t.TempDir()
-	dir := makeOldTempAFHome(t, tempRoot, "tmp.unknown-daemon")
-	writeOldDaemonPID(t, dir, 4243)
-	stubDaemonProcessProbe(t,
-		func(pid int) bool { return pid == 4243 },
-		func(pid int) []string { return nil },
-	)
+	dir := makeOldTempAFHome(t, tempRoot, "tmp.live-daemon-lock")
+	holdDaemonLock(t, dir)
 
-	report, err := Run(macLikeTempHomeOptions(t, tempRoot, true))
+	report, err := Run(macLikeTempHomeOptions(t, tempRoot, true)) // Fix: true
 	require.NoError(t, err)
-	require.Empty(t, findByCheck(report, "stale-temp-home"))
-	require.DirExists(t, dir, "uncertain daemon liveness must fail closed")
-	require.True(t, okContains(report, "daemon.pid liveness is uncertain"))
+	require.Empty(t, findByCheck(report, "stale-temp-home"),
+		"a temp home whose daemon.lock is held by a live daemon must never be reported stale or removed")
+	require.DirExists(t, dir)
+	require.True(t, okContains(report, "an af daemon holds its lock"),
+		"doctor should report the held-lock home as in use")
+}
+
+// TestTakeableLockTempHomeRemovedOnFix restores the teeth on a FACT: a temp home
+// whose lock is takeable (no live daemon) and which no live tmux session names
+// is provably unused, so --fix removes it. The lock outcome is forced to the
+// proven-free answer so the test is deterministic on any filesystem; the real
+// takeable-vs-untrusted mechanics live in the daemon package tests.
+//
+// Observed failing when the checkStaleTempHomes delete-arm is reverted to
+// report-only (#1969's report-only state): the home is reported but not removed,
+// so the require.True(Fixed) / require.NoDirExists assertions fail.
+func TestTakeableLockTempHomeRemovedOnFix(t *testing.T) {
+	tempRoot := t.TempDir()
+	dir := makeOldTempAFHome(t, tempRoot, "tmp.abandoned")
+	stubTempHomeLockProbe(t, func(string) daemon.ProbeAnswer { return daemon.AnswerNo() })
+
+	report, err := Run(macLikeTempHomeOptions(t, tempRoot, true)) // Fix: true
+	require.NoError(t, err)
+	findings := findByCheck(report, "stale-temp-home")
+	require.Len(t, findings, 1)
+	require.True(t, findings[0].Fixed,
+		"a home with a takeable lock and no live tmux session must be removed on --fix")
+	require.NoDirExists(t, dir, "the provably-unused home must be gone")
+}
+
+// TestTakeableLockTempHomeReportedButNotRemovedWithoutFix: without --fix the
+// same provably-unused home is REPORTED with a fix action and left on disk.
+func TestTakeableLockTempHomeReportedButNotRemovedWithoutFix(t *testing.T) {
+	tempRoot := t.TempDir()
+	dir := makeOldTempAFHome(t, tempRoot, "tmp.abandoned")
+	stubTempHomeLockProbe(t, func(string) daemon.ProbeAnswer { return daemon.AnswerNo() })
+
+	report, err := Run(macLikeTempHomeOptions(t, tempRoot, false)) // report-only
+	require.NoError(t, err)
+	findings := findByCheck(report, "stale-temp-home")
+	require.Len(t, findings, 1)
+	require.NotEmpty(t, findings[0].FixAction, "a provably-unused home must be offered for removal")
+	require.False(t, findings[0].Fixed)
+	require.DirExists(t, dir, "a report-only run must not remove anything")
+}
+
+// TestUnprovableLockTempHomeReportedNotRemoved: when the lock answer is
+// Undetermined — no lock file, or a filesystem whose flock cannot be trusted —
+// the home is REPORTED but carries NO fix action and is never removed, even
+// under --fix. Unknown is not a licence to os.RemoveAll (#1989).
+func TestUnprovableLockTempHomeReportedNotRemoved(t *testing.T) {
+	tempRoot := t.TempDir()
+	dir := makeOldTempAFHome(t, tempRoot, "tmp.unprovable")
+	stubTempHomeLockProbe(t, func(string) daemon.ProbeAnswer {
+		return daemon.Undetermined(fmt.Errorf("simulated untrusted filesystem"))
+	})
+
+	report, err := Run(macLikeTempHomeOptions(t, tempRoot, true)) // Fix: true
+	require.NoError(t, err)
+	findings := findByCheck(report, "stale-temp-home")
+	require.Len(t, findings, 1)
+	require.Empty(t, findings[0].FixAction,
+		"an unprovable home must not authorise a delete: unknown is not proof of non-use")
+	require.False(t, findings[0].Fixed)
+	require.DirExists(t, dir, "a home we cannot prove unused must never be removed")
+	require.Contains(t, findings[0].Detail, "untrusted filesystem",
+		"the report must name WHY it could not decide, or the operator cannot act on it")
 }
 
 // TestScanContextDefaultsSnapshot pins the invariant broken by #1785: the
@@ -119,20 +180,9 @@ func TestScanContextDefaultsSnapshot(t *testing.T) {
 		"scan context must carry a snapshot func, else the fix-time process recheck is unreachable")
 }
 
-// TestStaleTempHomeRefusesWithoutSnapshotFunc and
-// TestStaleTempHomeClaimedAfterDetectionIsSpared are DELETED with the closure
-// they drove (staleTempHomeRemoveFix).
-//
-// They were good tests of a bad idea. One pinned that an un-recheckable home
-// fails closed; the other that a home claimed between detection and --fix
-// survives. Both hardened the INPUTS to "did I see a process referencing this
-// home?" — and that question is unanswerable by process inspection, so no
-// amount of input-hardening made the rm -rf it authorised safe. The delete is
-// gone; there is nothing left to fail closed.
-//
-// What replaced them: TestStaleTempHomeReportedButNeverRemoved (doctor_test.go)
-// asserts a --fix run REPORTS the home and leaves it on disk.
-
+// TestTempHomeWithLiveTmuxSessionMarkerSparesHomeWithoutProc: a live tmux
+// session naming the home spares it even with no process table and no daemon
+// lock — the second, sound signal (tmux show-environment) the lock cannot see.
 func TestTempHomeWithLiveTmuxSessionMarkerSparesHomeWithoutProc(t *testing.T) {
 	tempRoot := t.TempDir()
 	dir := makeOldTempAFHome(t, tempRoot, "tmp.live-session")
@@ -155,24 +205,33 @@ func TestTempHomeWithLiveTmuxSessionMarkerSparesHomeWithoutProc(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, findByCheck(report, "stale-temp-home"))
 	require.DirExists(t, dir, "a temp home with a live tmux session marker must never be removed")
-	require.True(t, okContains(report, "live tmux session references it"))
+	require.True(t, okContains(report, "a live tmux session references it"))
 }
 
-// TestStaleTempHomeFixRechecksDaemonBeforeRemove is DELETED with the closure it
-// drove — the fourth and last test whose subject was the fix-time recheck. It
-// asserted the fix re-reads daemon.pid and refuses a home that became active in
-// between. Sound reasoning, wrong layer: it made the rm -rf's inputs fresher,
-// not its question answerable. There is no fix to recheck now.
+// TestStaleTempHomeFixRefusesWhenDaemonAppearsAfterDetection: findings are
+// applied AFTER detection, so a daemon can start in the window between. The fix
+// re-probes the lock and must REFUSE rather than rm -rf a home that is now
+// owned. Detection sees a takeable lock; by fix time a daemon holds it.
+func TestStaleTempHomeFixRefusesWhenDaemonAppearsAfterDetection(t *testing.T) {
+	tempRoot := t.TempDir()
+	dir := makeOldTempAFHome(t, tempRoot, "tmp.claimed")
 
-// TestStaleTempHomeFixFailsClosedWhenSnapshotFailsAtFixTime is the #1728
-// regression: detection got a working process snapshot (so the home was
-// flagged stale on genuinely-empty data), but the fix-time recheck fails
-// (transient /proc error). The detection snapshot is now stale — a one-off
-// command with no daemon.pid and no tmux marker could have claimed the home
-// in between — so the fix must fail closed rather than delete on stale data.
-/// TestStaleTempHomeFixFailsClosedWhenSnapshotFailsAtFixTime is DELETED with the
-// closure it drove, for the same reason as its two siblings above: it hardened
-// an INPUT ("re-take the snapshot at fix time, fail closed if it fails") to a
-// question process inspection cannot answer. Its final assertion — that an
-// unverifiable home is never deleted — is now structurally true, because
-// nothing deletes. TestStaleTempHomeReportedButNeverRemoved asserts it directly.
+	probes := 0
+	stubTempHomeLockProbe(t, func(string) daemon.ProbeAnswer {
+		probes++
+		if probes == 1 {
+			return daemon.AnswerNo() // detection: provably free
+		}
+		return daemon.AnswerYes() // fix time: a daemon has claimed it
+	})
+
+	report, err := Run(macLikeTempHomeOptions(t, tempRoot, true)) // Fix: true
+	require.NoError(t, err)
+	findings := findByCheck(report, "stale-temp-home")
+	require.Len(t, findings, 1)
+	require.False(t, findings[0].Fixed, "a home claimed between detection and fix must not be removed")
+	require.Error(t, findings[0].FixErr, "the refusal must surface as a fix error, not a silent skip")
+	require.Contains(t, findings[0].FixErr.Error(), "cannot prove no daemon owns it")
+	require.DirExists(t, dir, "the newly-claimed home must survive the --fix run")
+	require.GreaterOrEqual(t, probes, 2, "the fix must re-probe the lock rather than trust detection")
+}


### PR DESCRIPTION
Closes #1989. Closes #2040. Closes #1979.

Three doctor-honesty defects, all instances of the same disease — a check
that answers a question it cannot answer, or reports less than it knows.

## #1989 — prove a temp home is unused with a LOCK, not a process scan

`af doctor --fix` stopped deleting stale temp homes in #1969, because the
predicate was unsound: "no process references this home" is an INFERRED
NEGATIVE, and four consecutive P1 reviews each found a different way to
falsify it (darwin env redaction, CS_RESTRICT, procfs subset=pid, a shared
01777 /tmp). Every one ended at the same `os.RemoveAll`.

The teeth come back on a FACT. `daemon.ProbeHomeLock(dir)` answers "is a
daemon running for this home?" through `<home>/daemon.lock` — the flock a
daemon holds for its whole lifetime, which the kernel releases on death
including SIGKILL. A takeable lock is POSITIVE PROOF that no live daemon
owns the home, not an inference we assembled.

Both ways the lock could lie are designed against, because they are the
whole difficulty:

- **No lock file** → UNKNOWN, never "free". A home predating the lock, or
  made by a build that never wrote one, has no lock to take, and taking a
  lock nobody held proves nothing. The probe never creates the file —
  that would manufacture the very proof under test.
- **Untrusted filesystem** → UNKNOWN. flock can silently no-op on NFS/SMB/
  9p and hand back a fabricated "I took it" — the dangerous direction,
  since it authorises the delete. Linux checks the statfs magic against an
  ALLOWLIST of local filesystems (unrecognised ⇒ untrusted); darwin reads
  MNT_LOCAL; other platforms are untrusted outright.

`liveTmuxHomes` is kept as the second, sound signal (it asks tmux, not the
process table) — a home with live tmux sessions but a dead daemon holds no
lock. `staleTempHomeRemoveFix` re-verifies containment, AF-home identity,
tmux and the lock at fix time, because findings are applied after
detection and a daemon can start in the window.

The process scan survives only as a POSITIVE spare-signal: finding a
process that names a home keeps it. The converse is no longer derived, so
`processReferencedHomes` loses the unreadable-count machinery that existed
solely to gate the old delete, and `tempHomeDaemonLiveness` /
`tempHomeInUseReason` / the now-unused `daemon.PIDLooksAlive` go with it.

Net: doctor deletes strictly less than the pre-#1969 code (it needs a
proof it never had before) while doing the job again on the common case —
and `af doctor --help`, `docs/cli.md` and `docs/reference/cli.md`, which
have promised "removes stale temp homes" throughout the report-only
period, become honest again.

## #2040 — a control-socket dial timeout is not a dead daemon

`checkDaemonHealth`'s default arm collapsed any non-nil `PingErr` into a
definite `report.Fail`, including an EAGAIN/deadline from a momentarily
saturated control-socket accept backlog: doctor told the user their LIVE
daemon was dead, told them to `af daemon restart`, and exited nonzero.

New `daemon.ClassifyPingFailure` routes the ping error through the same
three-valued `ProbeAnswer` #1920/#2039 established, mirroring
`classifyDialFailure` on the HTTP path one field over: a timeout is
Undetermined (advisory WARN, `Problem=false`, no exit-code effect); a
refusal (ECONNREFUSED) stays the definite Fail.

## #1979 — the summary contradicted itself and its own exit code

`Summary: 17 PASS, 3 WARN, 0 FAIL; 32 underlying issues require action.`
with exit 1. A reader who stopped at "0 FAIL" concluded healthy while the
command exited nonzero, and the arithmetic did not close: the per-check
rows said 1 + 15 + 62 = 78 while the total said 32.

- The summary now LEADS with the actionable count — the number the exit
  code keys on — and trails the PASS/WARN/FAIL row tally in parentheses,
  so the headline and the exit code cannot disagree.
- `UnresolvedCount` counts TRUE underlying issues: a collapsed
  "… and N more" roll-up stands for N, not one, so the total equals the
  sum of the per-check counts a reader sees. It reuses `collapsedCount`'s
  expansion, so display and total can never drift.
- `summarizedMoreCount` is now ANCHORED to the "… and N more" prefix the
  roll-up is written with. Unanchored, a process cmdline containing the
  words "and 5 more" would inflate the exit-code-driving total.

## Tests

Each issue has a fail-first test, observed failing against the pre-fix
logic before the fix was written:

- `TestTempHomeWithHeldDaemonLockIsSpared` — a home whose daemon.lock is
  held by a live daemon, with no /proc and no tmux (the surfaces the old
  scan relied on). Pre-fix it is reported stale.
- `TestTakeableLockTempHomeRemovedOnFix` — the restored delete; pre-fix
  the home is reported but never removed.
- `TestDaemonPingTimeoutIsAdvisoryNotFail` — pre-fix the row is FAIL with
  Problem=true.
- `TestSummaryLeadsWithActionableCountMatchingUnresolved` — pre-fix the
  count is 2 (rows) not 47 (issues), and "0 FAIL" precedes it.

Plus the unprovable-lock, untrusted-filesystem, no-lock-file, refusal-
stays-Fail, anchoring, and fix-time TOCTOU (a daemon claims the home
between detection and --fix ⇒ refuse) paths, and daemon-level
`ProbeHomeLock` unit tests covering all three answers, the never-create
invariant, and the real statfs allowlist on the suite's own filesystem.

Full suite green in-container (34 packages); gofmt, go build,
golangci-lint --fast, deadcode -test, and the file-length lint all clean.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
