### PR TITLE
feat(web): schedule picker mirroring the shared model (phase 2 of #2057)

### DIFF
--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -1434,6 +1434,74 @@ body {
   color: var(--af-text-2);
   cursor: pointer;
 }
+.af-modal-body [hidden] {
+  display: none;
+}
+.af-schedule-row {
+  display: flex;
+  align-items: center;
+  gap: var(--af-sp-2);
+}
+.af-schedule-clock {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--af-sp-2);
+}
+.af-schedule-num {
+  width: 5rem;
+  flex: none;
+}
+.af-schedule-meridiem {
+  width: auto;
+  flex: none;
+}
+.af-schedule-sep,
+.af-schedule-unit {
+  color: var(--af-text-2);
+  font-size: var(--af-fs-sm);
+}
+.af-weekdays {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--af-sp-2);
+}
+.af-weekday {
+  width: 2.25rem;
+  height: 2.25rem;
+  padding: 0;
+  background: var(--af-bg-inset);
+  border: 1px solid var(--af-border);
+  border-radius: var(--af-r-md);
+  color: var(--af-text-2);
+  font: inherit;
+  font-size: var(--af-fs-sm);
+  cursor: pointer;
+}
+.af-weekday:hover {
+  border-color: var(--af-accent);
+}
+.af-weekday-on {
+  background: var(--af-accent);
+  border-color: var(--af-accent);
+  color: var(--af-on-accent);
+  font-weight: 600;
+}
+.af-schedule-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+.af-schedule-human {
+  margin: 0;
+  color: var(--af-text);
+  font-size: var(--af-fs-md);
+}
+.af-schedule-cron {
+  font-family: var(--af-font-mono);
+  font-size: var(--af-fs-sm);
+  color: var(--af-text-2);
+  cursor: default;
+}
 .af-modal-text {
   margin: 0;
   color: var(--af-text-2);

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -9401,6 +9401,193 @@ function registerServiceWorker() {
   });
 }
 
+// src/schedule.ts
+var SCHEDULE_TYPE_OPTIONS = [
+  { type: "everyNMinutes", label: "Every N minutes" },
+  { type: "everyNHours", label: "Every N hours" },
+  { type: "hourly", label: "Hourly" },
+  { type: "daily", label: "Daily" },
+  { type: "weekly", label: "Weekly" },
+  { type: "monthly", label: "Monthly" },
+  { type: "custom", label: "Custom (cron)" }
+];
+var WEEKDAY_ABBREV = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+function cron(s) {
+  switch (s.type) {
+    case "everyNMinutes":
+      return `*/${s.interval ?? 0} * * * *`;
+    case "everyNHours":
+      return `0 */${s.interval ?? 0} * * *`;
+    case "hourly":
+      return `${s.minute ?? 0} * * * *`;
+    case "daily":
+      return `${s.minute ?? 0} ${s.hour ?? 0} * * *`;
+    case "weekly":
+      return `${s.minute ?? 0} ${s.hour ?? 0} * * ${weekdayField(s.weekdays)}`;
+    case "monthly":
+      return `${s.minute ?? 0} ${s.hour ?? 0} ${s.dayOfMonth ?? 0} * *`;
+    default:
+      return s.raw ?? "";
+  }
+}
+function describe(s) {
+  switch (s.type) {
+    case "everyNMinutes":
+      return (s.interval ?? 0) === 1 ? "Every minute" : `Every ${s.interval ?? 0} minutes`;
+    case "everyNHours":
+      return (s.interval ?? 0) === 1 ? "Every hour" : `Every ${s.interval ?? 0} hours`;
+    case "hourly":
+      return `Every hour at :${pad2(s.minute ?? 0)}`;
+    case "daily":
+      return `Every day at ${clockTime(s.hour ?? 0, s.minute ?? 0)}`;
+    case "weekly":
+      return `Every week on ${weekdayNames(s.weekdays)} at ${clockTime(s.hour ?? 0, s.minute ?? 0)}`;
+    case "monthly":
+      return `Every month on the ${ordinal(s.dayOfMonth ?? 0)} at ${clockTime(s.hour ?? 0, s.minute ?? 0)}`;
+    default:
+      return `Custom: ${s.raw ?? ""}`;
+  }
+}
+function parseCron(expr) {
+  const f = fields(expr);
+  if (f.length !== 5) {
+    return { schedule: custom(expr), ok: false };
+  }
+  const [minute, hour, dom, month, dow] = f;
+  if (month !== "*") {
+    return { schedule: custom(expr), ok: false };
+  }
+  const everyMin = stepOfStar(minute, 59);
+  if (everyMin !== null && hour === "*" && dom === "*" && dow === "*") {
+    return { schedule: { type: "everyNMinutes", interval: everyMin }, ok: true };
+  }
+  const everyHour = stepOfStar(hour, 23);
+  if (everyHour !== null && minute === "0" && dom === "*" && dow === "*") {
+    return { schedule: { type: "everyNHours", interval: everyHour }, ok: true };
+  }
+  const hourlyMinute = singleInt(minute, 0, 59);
+  if (hourlyMinute !== null && hour === "*" && dom === "*" && dow === "*") {
+    return { schedule: { type: "hourly", minute: hourlyMinute }, ok: true };
+  }
+  const m = singleInt(minute, 0, 59);
+  const h3 = singleInt(hour, 0, 23);
+  if (m !== null && h3 !== null) {
+    if (dom === "*" && dow === "*") {
+      return { schedule: { type: "daily", hour: h3, minute: m }, ok: true };
+    }
+    if (dom === "*") {
+      const days = weekdayList(dow);
+      if (days !== null) {
+        return { schedule: { type: "weekly", hour: h3, minute: m, weekdays: days }, ok: true };
+      }
+    } else if (dow === "*") {
+      const d = singleInt(dom, 1, 31);
+      if (d !== null) {
+        return { schedule: { type: "monthly", hour: h3, minute: m, dayOfMonth: d }, ok: true };
+      }
+    }
+  }
+  return { schedule: custom(expr), ok: false };
+}
+function custom(expr) {
+  return { type: "custom", raw: expr };
+}
+function fields(expr) {
+  return expr.split(/\s+/).filter((part) => part !== "");
+}
+function weekdayField(days) {
+  const nums = normalizeWeekdays(days);
+  return nums.length === 0 ? "*" : nums.join(",");
+}
+function weekdayNames(days) {
+  return normalizeWeekdays(days).map((n) => WEEKDAY_ABBREV[n]).join(", ");
+}
+function normalizeWeekdays(days) {
+  const seen = /* @__PURE__ */ new Set();
+  for (const d of days ?? []) {
+    const n = (Math.trunc(d) % 7 + 7) % 7;
+    seen.add(n);
+  }
+  return [...seen].sort((a, b) => a - b);
+}
+function clockTime(hour, minute) {
+  let suffix = "AM";
+  let h3 = hour;
+  if (h3 === 0) {
+    h3 = 12;
+  } else if (h3 === 12) {
+    suffix = "PM";
+  } else if (h3 > 12) {
+    h3 -= 12;
+    suffix = "PM";
+  }
+  return `${h3}:${pad2(minute)} ${suffix}`;
+}
+function pad2(n) {
+  return String(n).padStart(2, "0");
+}
+function ordinal(n) {
+  let suffix = "th";
+  if (n % 100 < 11 || n % 100 > 13) {
+    switch (n % 10) {
+      case 1:
+        suffix = "st";
+        break;
+      case 2:
+        suffix = "nd";
+        break;
+      case 3:
+        suffix = "rd";
+        break;
+    }
+  }
+  return `${n}${suffix}`;
+}
+function stepOfStar(field2, max) {
+  if (!field2.startsWith("*/")) {
+    return null;
+  }
+  const n = atoi(field2.slice(2));
+  if (n === null || n < 1 || n > max) {
+    return null;
+  }
+  return n;
+}
+function singleInt(field2, min, max) {
+  const n = atoi(field2);
+  if (n === null || n < min || n > max) {
+    return null;
+  }
+  return n;
+}
+function weekdayList(field2) {
+  if (field2 === "*") {
+    return null;
+  }
+  const seen = /* @__PURE__ */ new Set();
+  for (const part of field2.split(",")) {
+    const n = atoi(part);
+    if (n === null || n < 0 || n > 7) {
+      return null;
+    }
+    seen.add(n === 7 ? 0 : n);
+  }
+  if (seen.size === 0) {
+    return null;
+  }
+  return [...seen].sort((a, b) => a - b);
+}
+function atoi(s) {
+  if (!/^[+-]?\d+$/.test(s)) {
+    return null;
+  }
+  const n = Number(s);
+  if (!Number.isSafeInteger(n)) {
+    return null;
+  }
+  return n === 0 ? 0 : n;
+}
+
 // src/tasks.ts
 function genTaskId() {
   const b = new Uint8Array(4);
@@ -9519,6 +9706,302 @@ var TasksPane = class {
     return h("li", { class: "af-task-row" }, enabledDot, main, actions2);
   }
 };
+var WEEKDAY_DISPLAY = [
+  { weekday: 1, letter: "M", name: "Monday" },
+  { weekday: 2, letter: "T", name: "Tuesday" },
+  { weekday: 3, letter: "W", name: "Wednesday" },
+  { weekday: 4, letter: "T", name: "Thursday" },
+  { weekday: 5, letter: "F", name: "Friday" },
+  { weekday: 6, letter: "S", name: "Saturday" },
+  { weekday: 0, letter: "S", name: "Sunday" }
+];
+function fieldGroup(label, control) {
+  return h("div", { class: "af-modal-field" }, h("span", { class: "af-modal-label" }, label), control);
+}
+function clampField(raw, min, max, def) {
+  const n = Number.parseInt(raw.trim(), 10);
+  if (!Number.isFinite(n)) {
+    return def;
+  }
+  return Math.min(Math.max(n, min), max);
+}
+var SchedulePicker = class {
+  /** The rows to append into the modal body, in visual order. */
+  rows;
+  typeSelect;
+  intervalInput;
+  intervalUnit;
+  hourInput;
+  minuteInput;
+  meridiemSelect;
+  domInput;
+  rawInput;
+  humanLine;
+  cronOut;
+  intervalRow;
+  timeRow;
+  timeLabel;
+  hourGroup;
+  weekdayRow;
+  domRow;
+  rawRow;
+  previewRow;
+  weekdayButtons = [];
+  weekdaysOn = /* @__PURE__ */ new Set();
+  constructor() {
+    this.typeSelect = h("select", { class: "af-input" });
+    this.typeSelect.setAttribute("aria-label", "Schedule type");
+    for (const opt of SCHEDULE_TYPE_OPTIONS) {
+      this.typeSelect.append(h("option", { value: opt.type }, opt.label));
+    }
+    this.typeSelect.addEventListener("change", () => this.onTypeChange());
+    this.intervalInput = this.numberInput("Interval", "1", "59");
+    this.intervalUnit = h("span", { class: "af-schedule-unit" }, "minutes");
+    this.intervalRow = fieldGroup(
+      "Run every",
+      h("div", { class: "af-schedule-row" }, this.intervalInput, this.intervalUnit)
+    );
+    this.hourInput = this.numberInput("Hour", "1", "12");
+    this.minuteInput = this.numberInput("Minute", "0", "59");
+    this.meridiemSelect = h("select", { class: "af-input af-schedule-meridiem" });
+    this.meridiemSelect.setAttribute("aria-label", "AM/PM");
+    this.meridiemSelect.append(h("option", { value: "AM" }, "AM"), h("option", { value: "PM" }, "PM"));
+    this.meridiemSelect.addEventListener("change", () => this.sync());
+    this.hourGroup = h(
+      "span",
+      { class: "af-schedule-clock" },
+      this.hourInput,
+      h("span", { class: "af-schedule-sep" }, ":")
+    );
+    this.timeRow = fieldGroup("Time", h("div", { class: "af-schedule-row" }, this.hourGroup, this.minuteInput, this.meridiemSelect));
+    this.timeLabel = this.timeRow.firstElementChild;
+    const weekdayGroup = h("div", { class: "af-weekdays" });
+    weekdayGroup.setAttribute("role", "group");
+    weekdayGroup.setAttribute("aria-label", "Days of the week");
+    for (const day of WEEKDAY_DISPLAY) {
+      const btn = h("button", { type: "button", class: "af-weekday" }, day.letter);
+      btn.setAttribute("aria-label", day.name);
+      btn.setAttribute("aria-pressed", "false");
+      btn.addEventListener("click", () => this.toggleWeekday(day.weekday));
+      this.weekdayButtons.push(btn);
+      weekdayGroup.append(btn);
+    }
+    this.weekdayRow = fieldGroup("Days", weekdayGroup);
+    this.domInput = this.numberInput("Day of month", "1", "31");
+    this.domRow = field("Day of month", this.domInput);
+    this.rawInput = h("input", { type: "text", class: "af-input", placeholder: "0 9 * * 1-5", autocomplete: "off" });
+    this.rawInput.setAttribute("aria-label", "Cron expression");
+    this.rawInput.addEventListener("input", () => this.sync());
+    this.rawRow = field("Cron expression", this.rawInput);
+    this.humanLine = h("p", { class: "af-schedule-human" });
+    this.humanLine.setAttribute("aria-live", "polite");
+    this.cronOut = h("input", { type: "text", class: "af-input af-schedule-cron", readOnly: true, tabIndex: -1 });
+    this.cronOut.setAttribute("aria-label", "Generated cron");
+    this.previewRow = h("div", { class: "af-schedule-preview" }, this.humanLine, this.cronOut);
+    this.rows = [
+      field("Schedule", this.typeSelect),
+      this.intervalRow,
+      this.timeRow,
+      this.weekdayRow,
+      this.domRow,
+      this.rawRow,
+      this.previewRow
+    ];
+    this.reset();
+  }
+  numberInput(label, min, max) {
+    const el2 = h("input", { type: "number", class: "af-input af-schedule-num", min, max, autocomplete: "off" });
+    el2.setAttribute("aria-label", label);
+    el2.addEventListener("input", () => this.sync());
+    return el2;
+  }
+  /** Seeds a brand-new task: daily at 9:00 AM, with every other type's fields
+   *  carrying valid defaults so switching type never lands on an empty input. The
+   *  same defaults the TUI picker resets to. */
+  reset() {
+    this.typeSelect.value = "daily";
+    this.intervalInput.value = "15";
+    this.hourInput.value = "9";
+    this.minuteInput.value = "00";
+    this.meridiemSelect.value = "AM";
+    this.domInput.value = "1";
+    this.rawInput.value = "";
+    this.weekdaysOn.clear();
+    this.weekdaysOn.add(1);
+    this.sync();
+  }
+  /**
+   * Seeds the picker from an existing task's cron: the matching preset if the
+   * expression is one of the shapes the model emits, otherwise Custom holding the
+   * original text verbatim. An empty expression (e.g. a watch task being switched to
+   * a cron trigger) keeps the new-task defaults rather than dropping into an empty
+   * Custom field.
+   */
+  seed(cronExpr) {
+    this.reset();
+    if (cronExpr.trim() === "") {
+      return;
+    }
+    const { schedule: s } = parseCron(cronExpr);
+    this.typeSelect.value = s.type;
+    switch (s.type) {
+      case "everyNMinutes":
+      case "everyNHours":
+        if (s.interval !== void 0 && s.interval > 0) {
+          this.intervalInput.value = String(s.interval);
+        }
+        break;
+      case "hourly":
+        this.minuteInput.value = pad22(s.minute ?? 0);
+        break;
+      case "daily":
+        this.setClock(s.hour ?? 0, s.minute ?? 0);
+        break;
+      case "weekly":
+        this.setClock(s.hour ?? 0, s.minute ?? 0);
+        this.weekdaysOn.clear();
+        for (const d of s.weekdays ?? []) {
+          this.weekdaysOn.add(d);
+        }
+        break;
+      case "monthly":
+        this.setClock(s.hour ?? 0, s.minute ?? 0);
+        if (s.dayOfMonth !== void 0 && s.dayOfMonth > 0) {
+          this.domInput.value = String(s.dayOfMonth);
+        }
+        break;
+      default:
+        this.rawInput.value = s.raw ?? cronExpr;
+        break;
+    }
+    this.sync();
+  }
+  /** Splits a 24-hour time into the 12-hour hour + AM/PM cells (to12Hour). */
+  setClock(hour24, minute) {
+    let h12 = hour24;
+    let pm = false;
+    if (hour24 === 0) {
+      h12 = 12;
+    } else if (hour24 === 12) {
+      pm = true;
+    } else if (hour24 > 12) {
+      h12 = hour24 - 12;
+      pm = true;
+    }
+    this.hourInput.value = String(h12);
+    this.minuteInput.value = pad22(minute);
+    this.meridiemSelect.value = pm ? "PM" : "AM";
+  }
+  toggleWeekday(weekday) {
+    if (this.weekdaysOn.has(weekday)) {
+      this.weekdaysOn.delete(weekday);
+    } else {
+      this.weekdaysOn.add(weekday);
+    }
+    this.sync();
+  }
+  get type() {
+    return this.typeSelect.value;
+  }
+  /** Switching INTO Custom prefills the raw field with the cron the previous preset
+   *  generated (when it is empty), so the escape hatch starts from a working
+   *  expression rather than blank — the TUI does the same. */
+  onTypeChange() {
+    if (this.type === "custom" && this.rawInput.value.trim() === "") {
+      this.rawInput.value = this.cronOut.value;
+    }
+    this.sync();
+  }
+  /** Materializes the current cell state into a canonical Schedule, clamping the
+   *  numeric cells so the generated cron is always well-formed (Custom's raw text
+   *  excepted — the daemon validates that). */
+  schedule() {
+    switch (this.type) {
+      case "everyNMinutes":
+        return { type: "everyNMinutes", interval: clampField(this.intervalInput.value, 1, 59, 15) };
+      case "everyNHours":
+        return { type: "everyNHours", interval: clampField(this.intervalInput.value, 1, 23, 1) };
+      case "hourly":
+        return { type: "hourly", minute: clampField(this.minuteInput.value, 0, 59, 0) };
+      case "daily":
+        return { type: "daily", hour: this.hour24(), minute: clampField(this.minuteInput.value, 0, 59, 0) };
+      case "weekly":
+        return {
+          type: "weekly",
+          hour: this.hour24(),
+          minute: clampField(this.minuteInput.value, 0, 59, 0),
+          weekdays: [...this.weekdaysOn]
+        };
+      case "monthly":
+        return {
+          type: "monthly",
+          hour: this.hour24(),
+          minute: clampField(this.minuteInput.value, 0, 59, 0),
+          dayOfMonth: clampField(this.domInput.value, 1, 31, 1)
+        };
+      default:
+        return { type: "custom", raw: this.rawInput.value.trim() };
+    }
+  }
+  hour24() {
+    const h3 = clampField(this.hourInput.value, 1, 12, 12);
+    const pm = this.meridiemSelect.value === "PM";
+    if (pm) {
+      return h3 === 12 ? 12 : h3 + 12;
+    }
+    return h3 === 12 ? 0 : h3;
+  }
+  /** The cron expression the form submits — always live off the current state. */
+  cron() {
+    return cron(this.schedule());
+  }
+  /** Re-applies the per-type row visibility and preview. The task form calls this
+   *  after showing the picker again (switching the trigger back to cron), which
+   *  unhides every row wholesale. */
+  refresh() {
+    this.sync();
+  }
+  /** A user-facing message for an unsavable schedule, or null when it is good to
+   *  save. The daemon re-validates the expression itself (it always has); these are
+   *  the picker-level constraints that would otherwise generate a nonsense cron. */
+  validate() {
+    if (this.type === "custom" && this.rawInput.value.trim() === "") {
+      return "A cron expression is required for a cron task.";
+    }
+    if (this.type === "weekly" && this.weekdaysOn.size === 0) {
+      return "Select at least one day of the week.";
+    }
+    return null;
+  }
+  /** Shows only the cells the selected type needs, and refreshes the preview + the
+   *  read-only generated cron. Runs on every edit, so what the user reads is always
+   *  what a submit would store. */
+  sync() {
+    const type = this.type;
+    const isClock = type === "daily" || type === "weekly" || type === "monthly";
+    this.intervalRow.hidden = type !== "everyNMinutes" && type !== "everyNHours";
+    this.intervalUnit.textContent = type === "everyNHours" ? "hours" : "minutes";
+    this.intervalInput.max = type === "everyNHours" ? "23" : "59";
+    this.timeRow.hidden = !isClock && type !== "hourly";
+    this.hourGroup.hidden = !isClock;
+    this.meridiemSelect.hidden = !isClock;
+    this.timeLabel.textContent = isClock ? "Time" : "Minute past the hour";
+    this.weekdayRow.hidden = type !== "weekly";
+    this.domRow.hidden = type !== "monthly";
+    this.rawRow.hidden = type !== "custom";
+    for (let i = 0; i < this.weekdayButtons.length; i++) {
+      const on = this.weekdaysOn.has(WEEKDAY_DISPLAY[i].weekday);
+      this.weekdayButtons[i].setAttribute("aria-pressed", on ? "true" : "false");
+      this.weekdayButtons[i].classList.toggle("af-weekday-on", on);
+    }
+    const s = this.schedule();
+    this.humanLine.textContent = describe(s);
+    this.cronOut.value = cron(s);
+  }
+};
+function pad22(n) {
+  return String(n).padStart(2, "0");
+}
 function taskFormModal(opts) {
   const { handle, body, confirmBtn } = modalChrome({
     title: opts.title,
@@ -9548,17 +10031,20 @@ function taskFormModal(opts) {
   triggerSelect.setAttribute("aria-label", "Trigger type");
   triggerSelect.append(h("option", { value: "cron" }, "Cron schedule"));
   triggerSelect.append(h("option", { value: "watch" }, "Watch command"));
-  const cronInput = h("input", { type: "text", class: "af-input", placeholder: "0 9 * * *", autocomplete: "off" });
-  cronInput.setAttribute("aria-label", "Cron expression");
-  const cronField = field("Cron expression", cronInput);
+  const picker = new SchedulePicker();
   const watchInput = h("input", { type: "text", class: "af-input", placeholder: "tail -F events.log", autocomplete: "off" });
   watchInput.setAttribute("aria-label", "Watch command");
   const watchField = field("Watch command", watchInput);
   watchField.hidden = true;
   const syncTriggerFields = () => {
     const isWatch = triggerSelect.value === "watch";
-    cronField.hidden = isWatch;
+    for (const row of picker.rows) {
+      row.hidden = isWatch;
+    }
     watchField.hidden = !isWatch;
+    if (!isWatch) {
+      picker.refresh();
+    }
   };
   triggerSelect.addEventListener("change", syncTriggerFields);
   const promptArea = h("textarea", { class: "af-input af-textarea", placeholder: "Prompt to deliver ({{line}} for the watch line)", rows: 3 });
@@ -9576,7 +10062,7 @@ function taskFormModal(opts) {
     nameInput.value = s.name ?? "";
     const isWatch = !!(s.watch_cmd && s.watch_cmd.trim() !== "");
     triggerSelect.value = isWatch ? "watch" : "cron";
-    cronInput.value = s.cron_expr ?? "";
+    picker.seed(s.cron_expr ?? "");
     watchInput.value = s.watch_cmd ?? "";
     syncTriggerFields();
     promptArea.value = s.prompt ?? "";
@@ -9590,7 +10076,7 @@ function taskFormModal(opts) {
     field("Name", nameInput),
     field("Project", projectSelect),
     field("Trigger", triggerSelect),
-    cronField,
+    ...picker.rows,
     watchField,
     field("Prompt", promptArea),
     field("Target session", targetInput),
@@ -9600,17 +10086,18 @@ function taskFormModal(opts) {
   asForm(card, () => {
     const trigger = triggerSelect.value === "watch" ? "watch" : "cron";
     const name = nameInput.value.trim();
-    const cron = cronInput.value.trim();
     const watchCmd = watchInput.value.trim();
     const prompt = promptArea.value.trim();
     if (name === "" || projectSelect.value === "") {
       handle.setError("A name and a project are required.");
       return;
     }
-    if (trigger === "cron" && cron === "") {
-      handle.setError("A cron expression is required for a cron task.");
+    const scheduleErr = trigger === "cron" ? picker.validate() : null;
+    if (scheduleErr !== null) {
+      handle.setError(scheduleErr);
       return;
     }
+    const cron2 = trigger === "cron" ? picker.cron() : "";
     if (trigger === "cron" && prompt === "") {
       handle.setError("A prompt is required for a cron task.");
       return;
@@ -9624,7 +10111,7 @@ function taskFormModal(opts) {
       name,
       projectPath: projectSelect.value,
       trigger,
-      cron,
+      cron: cron2,
       watchCmd,
       prompt: promptArea.value,
       targetSession: targetInput.value.trim(),

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "954e3de2d70c";
+const VERSION = "d6b86194b794";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -312,6 +312,22 @@ async function dragTabOntoPaneHitTested(
   );
 }
 
+/** Points the task modal's schedule picker (#2057) at the "every N minutes" preset.
+ *  The task form no longer has a bare cron text box: a schedule TYPE plus its
+ *  contextual inputs generate the expression, so a test that wants an
+ *  every-N-minutes cron drives the preset that produces it. */
+async function setEveryNMinutes(modal: Locator, minutes: number): Promise<void> {
+  await modal.locator('select[aria-label="Schedule type"]').selectOption("everyNMinutes");
+  await modal.locator('input[aria-label="Interval"]').fill(String(minutes));
+}
+
+/** Points the schedule picker at Custom and fills its raw cron field — the advanced
+ *  escape hatch, and the only place a literal expression is typed now. */
+async function setCustomCron(modal: Locator, expr: string): Promise<void> {
+  await modal.locator('select[aria-label="Schedule type"]').selectOption("custom");
+  await modal.locator('input[aria-label="Cron expression"]').fill(expr);
+}
+
 /** Opens the app on the loopback daemon and asserts the tokenless auto-connect
  *  (#1696): the SPA learns via /v1/auth-info that this loopback client needs no
  *  token, skips the paste-token login entirely, and renders the authed shell with
@@ -1840,7 +1856,7 @@ test("task-only project (redesign PR2, follow-on): add-task targets ITS repo, an
   const modal = page.locator(".af-modal-card");
   await expect(modal).toBeVisible();
   await modal.locator('input[aria-label="Task name"]').fill(added);
-  await modal.locator('input[aria-label="Cron expression"]').fill("*/5 * * * *");
+  await setEveryNMinutes(modal, 5);
   await modal.locator('textarea[aria-label="Prompt"]').fill("echo mock3-added");
   await modal.locator("button.af-primary").click();
 
@@ -1910,7 +1926,7 @@ test("tasks view (#1592 PR8): list the seeded task; add / trigger / remove round
   const modal = page.locator(".af-modal-card");
   await expect(modal).toBeVisible();
   await modal.locator('input[aria-label="Task name"]').fill(added);
-  await modal.locator('input[aria-label="Cron expression"]').fill("*/5 * * * *");
+  await setEveryNMinutes(modal, 5);
   await modal.locator('textarea[aria-label="Prompt"]').fill("echo scheduled-web");
   await modal.locator("button.af-primary").click();
 
@@ -1984,7 +2000,7 @@ test("tasks view edit (#1935): the Edit form is seeded from the task, and a chan
   const addModal = page.locator(".af-modal-card");
   await expect(addModal).toBeVisible();
   await addModal.locator('input[aria-label="Task name"]').fill(named);
-  await addModal.locator('input[aria-label="Cron expression"]').fill(originalCron);
+  await setEveryNMinutes(addModal, 5); // generates originalCron
   await addModal.locator('textarea[aria-label="Prompt"]').fill("echo original");
   await addModal.locator("button.af-primary").click();
 
@@ -2001,12 +2017,17 @@ test("tasks view edit (#1935): the Edit form is seeded from the task, and a chan
   await expect(editModal).toBeVisible();
   await expect(editModal.locator(".af-modal-title")).toHaveText("Edit task");
   await expect(editModal.locator('input[aria-label="Task name"]')).toHaveValue(named);
-  await expect(editModal.locator('input[aria-label="Cron expression"]')).toHaveValue(originalCron);
+  // The schedule seeds through ParseCron (#2057): the stored expression re-opens as
+  // the preset it maps to, and the read-only cron line shows what would be saved.
+  await expect(editModal.locator('select[aria-label="Schedule type"]')).toHaveValue("everyNMinutes");
+  await expect(editModal.locator('input[aria-label="Interval"]')).toHaveValue("5");
+  await expect(editModal.locator('input[aria-label="Generated cron"]')).toHaveValue(originalCron);
   await expect(editModal.locator('textarea[aria-label="Prompt"]')).toHaveValue("echo original");
 
-  // Change the cron expression and the prompt, then save.
+  // Change the cron expression and the prompt, then save. This one goes through the
+  // Custom escape hatch, so the literal expression is what gets stored.
   const newCron = "30 8 * * 1";
-  await editModal.locator('input[aria-label="Cron expression"]').fill(newCron);
+  await setCustomCron(editModal, newCron);
   await editModal.locator('textarea[aria-label="Prompt"]').fill("echo edited");
   await editModal.locator("button.af-primary", { hasText: "Save" }).click();
   await expect(editModal).toBeHidden();
@@ -2043,6 +2064,131 @@ test("tasks view edit (#1935): the Edit form is seeded from the task, and a chan
   await page.unroute("**/v1/AddTask");
   await page.unroute("**/v1/UpdateTask");
   await page.unroute("**/v1/RemoveTask");
+  await page.locator('.af-viewtab[data-view="sessions"]').click();
+  await expect(page.locator(".af-rail-list")).toBeVisible();
+});
+
+test("schedule picker (#2057): a preset generates the cron, an edit re-opens as that preset, and the change PERSISTS", async () => {
+  // Phase 2 of #2057: the raw-cron box in the task form is replaced by a schedule
+  // TYPE plus only that type's inputs, a plain-English preview, and the generated
+  // cron shown read-only. Cron is still what gets stored, so this asserts the whole
+  // chain — picker state → generated expression → what the daemon persists → what
+  // the picker shows when the task is re-opened.
+  //
+  // The cron/human strings asserted here are the same ones the shared vector file
+  // (schedule/testdata/vectors.json) pins for the Go model, so this flow also
+  // demonstrates the browser and TUI pickers agreeing on real input.
+  let addedCron: string | undefined;
+  let updateBody: { update?: Record<string, unknown> } | null = null;
+  await page.route("**/v1/AddTask", async (route) => {
+    addedCron = route.request().postDataJSON()?.task?.cron_expr;
+    await route.continue();
+  });
+  await page.route("**/v1/UpdateTask", async (route) => {
+    updateBody = route.request().postDataJSON();
+    await route.continue();
+  });
+
+  await page.locator('.af-viewtab[data-view="tasks"]').click();
+  const tasks = page.locator(".af-tasks");
+  await expect(tasks).toBeVisible();
+
+  const named = `probe-sched-${Date.now().toString(36)}`;
+  await tasks.locator(".af-tasks-add").click();
+  const addModal = page.locator(".af-modal-card");
+  await expect(addModal).toBeVisible();
+  await addModal.locator('input[aria-label="Task name"]').fill(named);
+
+  // A brand-new task opens on a friendly default (daily at 9:00 AM), NOT a blank
+  // cron box, with the preview and generated cron already filled in.
+  const typeSelect = addModal.locator('select[aria-label="Schedule type"]');
+  const generated = addModal.locator('input[aria-label="Generated cron"]');
+  const preview = addModal.locator(".af-schedule-human");
+  await expect(typeSelect).toHaveValue("daily");
+  await expect(generated).toHaveValue("0 9 * * *");
+  await expect(preview).toHaveText("Every day at 9:00 AM");
+
+  // Contextual inputs: a daily schedule shows the time, and nothing else. The
+  // weekday toggles, the day-of-month cell and the raw-cron escape hatch are all
+  // hidden until their type is picked — and the OTHER trigger's watch field stays
+  // hidden too (it shares the same `hidden` mechanism this relies on).
+  await expect(addModal.locator('input[aria-label="Hour"]')).toBeVisible();
+  await expect(addModal.locator(".af-weekdays")).toBeHidden();
+  await expect(addModal.locator('input[aria-label="Day of month"]')).toBeHidden();
+  await expect(addModal.locator('input[aria-label="Cron expression"]')).toBeHidden();
+  await expect(addModal.locator('input[aria-label="Watch command"]')).toBeHidden();
+
+  // Build "every week on Mon, Wed at 9:30 AM" through the picker.
+  await typeSelect.selectOption("weekly");
+  await expect(addModal.locator(".af-weekdays")).toBeVisible();
+  await addModal.locator('input[aria-label="Minute"]').fill("30");
+  // Monday is on by default; adding Wednesday makes the two-day list.
+  await expect(addModal.locator('button[aria-label="Monday"]')).toHaveAttribute("aria-pressed", "true");
+  await addModal.locator('button[aria-label="Wednesday"]').click();
+  await expect(addModal.locator('button[aria-label="Wednesday"]')).toHaveAttribute("aria-pressed", "true");
+
+  // The preview and the read-only cron are live, and byte-identical to what the Go
+  // model produces for this schedule.
+  await expect(preview).toHaveText("Every week on Mon, Wed at 9:30 AM");
+  await expect(generated).toHaveValue("30 9 * * 1,3");
+
+  await addModal.locator('textarea[aria-label="Prompt"]').fill("echo scheduled");
+  await addModal.locator("button.af-primary").click();
+
+  // What the daemon was asked to store is the generated expression — the wire format
+  // is unchanged, only the input UX.
+  const row = tasks.locator(".af-task-row", { hasText: named });
+  await expect(row).toBeVisible({ timeout: 30_000 });
+  await expect(addModal).toBeHidden();
+  expect(addedCron, "AddTask must carry the picker's generated cron").toBe("30 9 * * 1,3");
+  await expect(row.locator(".af-task-trigger")).toContainText("30 9 * * 1,3");
+
+  // Re-open it: the stored cron round-trips back through ParseCron into the WEEKLY
+  // preset with its cells restored — not a raw string in a text box.
+  await row.locator("button", { hasText: "Edit" }).click();
+  const editModal = page.locator(".af-modal-card");
+  await expect(editModal).toBeVisible();
+  await expect(editModal.locator('select[aria-label="Schedule type"]')).toHaveValue("weekly");
+  await expect(editModal.locator('input[aria-label="Hour"]')).toHaveValue("9");
+  await expect(editModal.locator('input[aria-label="Minute"]')).toHaveValue("30");
+  await expect(editModal.locator('select[aria-label="AM/PM"]')).toHaveValue("AM");
+  await expect(editModal.locator('button[aria-label="Monday"]')).toHaveAttribute("aria-pressed", "true");
+  await expect(editModal.locator('button[aria-label="Wednesday"]')).toHaveAttribute("aria-pressed", "true");
+  await expect(editModal.locator('button[aria-label="Tuesday"]')).toHaveAttribute("aria-pressed", "false");
+  await expect(editModal.locator('input[aria-label="Generated cron"]')).toHaveValue("30 9 * * 1,3");
+
+  // Switch it to a different preset and save.
+  await editModal.locator('select[aria-label="Schedule type"]').selectOption("everyNHours");
+  await editModal.locator('input[aria-label="Interval"]').fill("6");
+  await expect(editModal.locator(".af-schedule-human")).toHaveText("Every 6 hours");
+  await expect(editModal.locator('input[aria-label="Generated cron"]')).toHaveValue("0 */6 * * *");
+  await editModal.locator("button.af-primary", { hasText: "Save" }).click();
+  await expect(editModal).toBeHidden();
+
+  expect(updateBody?.update?.cron_expr, "the edit patch carries the newly generated cron").toBe("0 */6 * * *");
+  await expect(row.locator(".af-task-trigger")).toContainText("0 */6 * * *", { timeout: 30_000 });
+
+  // The real proof: RELOAD and re-fetch from the daemon — the generated cron was
+  // actually persisted, and the picker seeds itself from it again.
+  await page.reload();
+  await expect(page.locator(".af-app")).toBeVisible();
+  await page.locator('.af-viewtab[data-view="tasks"]').click();
+  const reloadedRow = page.locator(".af-tasks .af-task-row", { hasText: named });
+  await expect(reloadedRow).toBeVisible({ timeout: 30_000 });
+  await expect(reloadedRow.locator(".af-task-trigger")).toContainText("0 */6 * * *");
+  await reloadedRow.locator("button", { hasText: "Edit" }).click();
+  const reopened = page.locator(".af-modal-card");
+  await expect(reopened.locator('select[aria-label="Schedule type"]')).toHaveValue("everyNHours");
+  await expect(reopened.locator('input[aria-label="Interval"]')).toHaveValue("6");
+  await reopened.locator("button.af-ghost", { hasText: "Cancel" }).click();
+  await expect(reopened).toBeHidden();
+
+  // Clean up and return to the sessions view for the following flows.
+  await reloadedRow.locator("button", { hasText: "Remove" }).click();
+  await expect(page.locator(".af-tasks .af-task-row", { hasText: named })).toHaveCount(0, { timeout: 30_000 });
+
+  await page.unroute("**/v1/AddTask");
+  await page.unroute("**/v1/UpdateTask");
   await page.locator('.af-viewtab[data-view="sessions"]').click();
   await expect(page.locator(".af-rail-list")).toBeVisible();
 });

--- a/web/src/schedule.test.ts
+++ b/web/src/schedule.test.ts
@@ -1,0 +1,193 @@
+// The TypeScript half of the cross-language schedule contract (#2057 phase 2).
+//
+// It validates web/src/schedule.ts against the SAME fixture the Go test uses —
+// schedule/testdata/vectors.json, read straight across the repo root, NOT a copy —
+// so the browser picker and the TUI picker are pinned to identical cron generation,
+// identical plain-English previews, and identical parse rules, and cannot silently
+// diverge. The Go half is schedule/schedule_test.go: TestVectors — same file, same
+// assertions, same per-vector rules (documented in the fixture's own `_readme`).
+// This is the arrangement frame.test.ts already uses for the wire codec, and the
+// #1970 shared-source-of-truth pattern the issue calls for.
+//
+// If you change one implementation's behavior, this test is what fails until the
+// vectors and the other implementation agree. Go is canonical: fix the TS, or
+// change the vectors and BOTH implementations together.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { SCHEDULE_TYPE_OPTIONS, type Schedule, type ScheduleType, cron, describe, parseCron } from "./schedule.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+// web/src → repo-root/schedule/testdata/vectors.json (single source of truth,
+// shared verbatim with schedule/schedule_test.go).
+const FIXTURE_PATH = join(here, "..", "..", "schedule", "testdata", "vectors.json");
+
+/** Overrides the default parseCron expectation for a vector; any absent field falls
+ *  back to the vector's own cron/schedule (see the fixture's schema note). */
+interface ParseExpect {
+  cron?: string;
+  ok?: boolean;
+  schedule?: Schedule;
+}
+
+interface Vector {
+  name: string;
+  schedule?: Schedule;
+  cron?: string;
+  human?: string;
+  parse?: ParseExpect;
+}
+
+function loadVectors(): Vector[] {
+  // A missing/unreadable fixture must FAIL, never skip: the whole point of this
+  // test is that it breaks when the TS and Go models drift, so it may not quietly
+  // pass with nothing loaded.
+  const raw = readFileSync(FIXTURE_PATH, "utf8");
+  const parsed = JSON.parse(raw) as { vectors?: Vector[] };
+  const vectors = parsed.vectors ?? [];
+  assert.ok(vectors.length > 0, `no vectors loaded from ${FIXTURE_PATH}`);
+  return vectors;
+}
+
+/** Fills in the zero values Go's struct has but the JSON omits (`omitempty`), so a
+ *  parsed schedule and an expected one compare exactly the way Go's
+ *  reflect.DeepEqual compares them. parseCron never returns an empty-but-present
+ *  weekday list, so collapsing absent → [] loses nothing the Go test enforces. */
+function canonical(s: Schedule): Required<Schedule> {
+  return {
+    type: s.type,
+    interval: s.interval ?? 0,
+    hour: s.hour ?? 0,
+    minute: s.minute ?? 0,
+    weekdays: s.weekdays ?? [],
+    dayOfMonth: s.dayOfMonth ?? 0,
+    raw: s.raw ?? "",
+  };
+}
+
+const VECTORS = loadVectors();
+
+for (const v of VECTORS) {
+  test(`vectors: ${v.name}`, () => {
+    if (v.schedule !== undefined && v.cron !== undefined) {
+      assert.equal(cron(v.schedule), v.cron, `cron() for ${v.name}`);
+    }
+    if (v.schedule !== undefined && v.human !== undefined) {
+      assert.equal(describe(v.schedule), v.human, `describe() for ${v.name}`);
+    }
+
+    // parseCron: input and expectations default to the vector, with the optional
+    // parse block overriding — the same resolution the Go test does.
+    const input = v.parse?.cron ?? v.cron;
+    if (input === undefined) {
+      return;
+    }
+    const expectOk = v.parse?.ok ?? true;
+    const expected = v.parse?.schedule ?? v.schedule;
+
+    const got = parseCron(input);
+    assert.equal(got.ok, expectOk, `parseCron(${JSON.stringify(input)}) ok`);
+    if (expected !== undefined) {
+      assert.deepStrictEqual(
+        canonical(got.schedule),
+        canonical(expected),
+        `parseCron(${JSON.stringify(input)}) schedule`,
+      );
+    }
+  });
+}
+
+// A vector file that lost its coverage would let the parity test pass vacuously for
+// a whole schedule type. Pin that every type the picker offers is actually exercised
+// by at least one cron-generating vector.
+test("the shared vectors cover every schedule type", () => {
+  const covered = new Set<ScheduleType>();
+  for (const v of VECTORS) {
+    if (v.schedule !== undefined && v.cron !== undefined) {
+      covered.add(v.schedule.type);
+    }
+  }
+  for (const opt of SCHEDULE_TYPE_OPTIONS) {
+    assert.ok(covered.has(opt.type), `no cron vector covers the "${opt.type}" schedule type`);
+  }
+});
+
+// The structural round-trip the picker depends on: an existing task re-opens as its
+// matching preset. Mirrors Go's TestParseCronRoundTrip.
+test("parseCron(cron(s)) round-trips every preset", () => {
+  const presets: Schedule[] = [
+    { type: "everyNMinutes", interval: 1 },
+    { type: "everyNMinutes", interval: 45 },
+    { type: "everyNMinutes", interval: 59 }, // upper bound still a preset
+    { type: "everyNHours", interval: 1 },
+    { type: "everyNHours", interval: 8 },
+    { type: "everyNHours", interval: 23 }, // upper bound still a preset
+    { type: "hourly", minute: 0 },
+    { type: "hourly", minute: 17 },
+    { type: "daily", hour: 0, minute: 0 },
+    { type: "daily", hour: 23, minute: 59 },
+    { type: "weekly", hour: 9, minute: 30, weekdays: [1] },
+    { type: "weekly", hour: 7, minute: 0, weekdays: [0, 6] },
+    { type: "monthly", hour: 12, minute: 0, dayOfMonth: 1 },
+    { type: "monthly", hour: 6, minute: 15, dayOfMonth: 28 },
+  ];
+  for (const s of presets) {
+    const expr = cron(s);
+    const got = parseCron(expr);
+    assert.ok(got.ok, `parseCron(${expr}) must recognize a preset`);
+    assert.deepStrictEqual(canonical(got.schedule), canonical(s), `round-trip of ${expr}`);
+  }
+});
+
+// The best-effort contract: anything that is not one of the emitted shapes returns
+// {custom, raw} with ok=false so the UI drops into the raw-cron editor. Mirrors Go's
+// TestParseCronUnrecognizedFallsBackToCustom.
+test("an unrecognized expression falls back to custom, preserving the raw text", () => {
+  for (const expr of [
+    "0 9 * * 1-5", // weekday range (we emit comma lists)
+    "*/7 9-17 * * *", // hour range
+    "15 */3 * * *", // minute + hour-step combination we never emit
+    "0 0 1,15 * *", // day-of-month list
+    "0 0 * JAN *", // named month
+    "@daily", // descriptor
+    "0 0", // too few fields
+    "*/60 * * * *", // minute step at/over field size — clamps if parsed, so custom
+    "0 */24 * * *", // hour step at/over field size — custom, not clamped to */23
+  ]) {
+    const got = parseCron(expr);
+    assert.equal(got.ok, false, `parseCron(${expr}) ok must be false`);
+    assert.deepStrictEqual(canonical(got.schedule), canonical({ type: "custom", raw: expr }));
+  }
+});
+
+// TS's Number()/parseInt() accept shapes Go's strconv.Atoi rejects ("5x", " 5",
+// "0x10", ""). Left unguarded, those would parse into presets the Go model calls
+// custom — a drift the vectors alone don't cover, since they can't enumerate every
+// malformed field.
+test("loose numeric fields Go rejects stay custom, not a silently-accepted preset", () => {
+  for (const expr of [
+    "5x * * * *", // parseInt would take the "5"
+    "0x10 * * * *", // Number() would take 16
+    "5. * * * *", // Number() would take 5
+    "1e2 * * * *", // Number() would take 100
+    "*/5x * * * *", // the step form, same trap
+    "0 9 * * 1,2x", // a bad member of a weekday list
+  ]) {
+    const got = parseCron(expr);
+    assert.equal(got.ok, false, `parseCron(${expr}) ok must be false`);
+    assert.equal(got.schedule.type, "custom");
+    assert.equal(got.schedule.raw, expr);
+  }
+});
+
+// Normalization the cron field and the description both depend on. Mirrors Go's
+// TestWeekdayOrderIsSundayFirstAndDeduped.
+test("weekdays are deduped and ordered Sunday-first regardless of input order", () => {
+  const s: Schedule = { type: "weekly", hour: 9, minute: 0, weekdays: [3, 0, 1, 3] };
+  assert.equal(cron(s), "0 9 * * 0,1,3");
+  assert.equal(describe(s), "Every week on Sun, Mon, Wed at 9:00 AM");
+});

--- a/web/src/schedule.ts
+++ b/web/src/schedule.ts
@@ -1,0 +1,342 @@
+// The web half of the canonical schedule model behind the friendly task-schedule
+// picker (#2057, phase 2). This is a DELIBERATE MIRROR of the Go package
+// `schedule` (schedule/schedule.go) — the same preset types, the same cron
+// generation, the same best-effort ParseCron, and the same plain-English
+// describe() text, so the TUI form and this browser modal cannot disagree about
+// what a picker state means.
+//
+// Go is the canonical source: this file follows it, never the other way round.
+// What keeps the two honest is not review discipline but a test — schedule.test.ts
+// loads the SAME shared vector file the Go test loads
+// (schedule/testdata/vectors.json, read across the repo root, no copy) and asserts
+// every cron/human/parse triple matches. Diverge from Go and that test fails.
+// This is the #1970 shared-source-of-truth pattern, and the same arrangement
+// frame.ts/frame.test.ts already use for the wire codec.
+//
+// Cron stays the stored/wire format: this model only shapes the INPUT. The daemon's
+// own validation and scheduling are untouched, and Custom carries a raw expression
+// verbatim as the advanced escape hatch.
+
+/** The preset schedule shape a Schedule takes — the string values are the Go
+ *  `schedule.Type` constants verbatim (they appear in the shared vectors). */
+export type ScheduleType =
+  | "everyNMinutes"
+  | "everyNHours"
+  | "hourly"
+  | "daily"
+  | "weekly"
+  | "monthly"
+  | "custom";
+
+/** The schedule types in picker order, with their selector labels. Custom sits
+ *  last as the advanced escape hatch — the same order as the TUI's
+ *  `scheduleTypes` (ui/schedule_picker.go). */
+export const SCHEDULE_TYPE_OPTIONS: ReadonlyArray<{ type: ScheduleType; label: string }> = [
+  { type: "everyNMinutes", label: "Every N minutes" },
+  { type: "everyNHours", label: "Every N hours" },
+  { type: "hourly", label: "Hourly" },
+  { type: "daily", label: "Daily" },
+  { type: "weekly", label: "Weekly" },
+  { type: "monthly", label: "Monthly" },
+  { type: "custom", label: "Custom (cron)" },
+];
+
+/**
+ * A preset schedule plus its contextual fields — the TS shape of Go's
+ * `schedule.Schedule`. Only the fields relevant to `type` are meaningful; the
+ * rest are absent, which stands in for Go's zero values (the shared vectors omit
+ * them the same way, via `omitempty`).
+ *
+ * `hour` is 24-hour (0-23) — the 12-hour AM/PM presentation lives in describe()
+ * and the picker UI, not in the model. `weekdays` holds Go `time.Weekday`
+ * numbering: Sunday=0 … Saturday=6.
+ */
+export interface Schedule {
+  type: ScheduleType;
+  interval?: number;
+  hour?: number;
+  minute?: number;
+  weekdays?: number[];
+  dayOfMonth?: number;
+  raw?: string;
+}
+
+/** parseCron's result: the structured schedule plus whether the expression was
+ *  recognized as one of the shapes cron() emits (Go's `(Schedule, bool)`). */
+export interface ParseResult {
+  schedule: Schedule;
+  ok: boolean;
+}
+
+/** Three-letter weekday abbreviations in cron/`time.Weekday` order, matching Go's
+ *  `time.Weekday(n).String()[:3]`. */
+const WEEKDAY_ABBREV = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
+
+/**
+ * Renders the schedule as a 5-field cron expression (minute hour day-of-month
+ * month day-of-week). Custom returns `raw` verbatim. The generated expressions are
+ * exactly the shapes parseCron recognizes, so parseCron(cron(s)) round-trips every
+ * preset back to s. Mirrors Go's `(Schedule).Cron`.
+ */
+export function cron(s: Schedule): string {
+  switch (s.type) {
+    case "everyNMinutes":
+      return `*/${s.interval ?? 0} * * * *`;
+    case "everyNHours":
+      return `0 */${s.interval ?? 0} * * *`;
+    case "hourly":
+      return `${s.minute ?? 0} * * * *`;
+    case "daily":
+      return `${s.minute ?? 0} ${s.hour ?? 0} * * *`;
+    case "weekly":
+      return `${s.minute ?? 0} ${s.hour ?? 0} * * ${weekdayField(s.weekdays)}`;
+    case "monthly":
+      return `${s.minute ?? 0} ${s.hour ?? 0} ${s.dayOfMonth ?? 0} * *`;
+    default: // custom and any unknown type
+      return s.raw ?? "";
+  }
+}
+
+/**
+ * Renders the schedule as the plain-English preview line, e.g. "Every 15 minutes",
+ * "Every day at 3:41 PM", "Every week on Mon, Wed at 9:00 AM". Custom echoes its
+ * raw cron ("Custom: 41 3 * * *"). Times use a 12-hour clock with AM/PM. Mirrors
+ * Go's `(Schedule).Describe` — byte-for-byte, per the shared vectors.
+ */
+export function describe(s: Schedule): string {
+  switch (s.type) {
+    case "everyNMinutes":
+      return (s.interval ?? 0) === 1 ? "Every minute" : `Every ${s.interval ?? 0} minutes`;
+    case "everyNHours":
+      return (s.interval ?? 0) === 1 ? "Every hour" : `Every ${s.interval ?? 0} hours`;
+    case "hourly":
+      return `Every hour at :${pad2(s.minute ?? 0)}`;
+    case "daily":
+      return `Every day at ${clockTime(s.hour ?? 0, s.minute ?? 0)}`;
+    case "weekly":
+      return `Every week on ${weekdayNames(s.weekdays)} at ${clockTime(s.hour ?? 0, s.minute ?? 0)}`;
+    case "monthly":
+      return `Every month on the ${ordinal(s.dayOfMonth ?? 0)} at ${clockTime(s.hour ?? 0, s.minute ?? 0)}`;
+    default: // custom and any unknown type
+      return `Custom: ${s.raw ?? ""}`;
+  }
+}
+
+/**
+ * Best-effort maps a 5-field cron expression back to a structured Schedule. It
+ * recognizes exactly the shapes cron() emits — so a task saved by the picker
+ * re-opens as its matching preset — plus the Sunday day-of-week alias (7).
+ * Anything else (ranges, multi-value minute/hour fields, month restrictions, step
+ * forms we don't emit, or a malformed expression) returns
+ * `{type: "custom", raw: expr}` with ok=false, signalling the UI to fall back to
+ * the raw-cron editor. It deliberately does NOT parse arbitrary cron.
+ *
+ * Mirrors Go's `ParseCron`, including the out-of-range step rule (see stepOfStar):
+ * a minute step of 60 or an hour step of 24 is REJECTED rather than clamped, so an
+ * untouched re-save never silently rewrites the user's expression.
+ */
+export function parseCron(expr: string): ParseResult {
+  const f = fields(expr);
+  if (f.length !== 5) {
+    return { schedule: custom(expr), ok: false };
+  }
+  const [minute, hour, dom, month, dow] = f;
+
+  // No preset restricts the month field.
+  if (month !== "*") {
+    return { schedule: custom(expr), ok: false };
+  }
+
+  // every N minutes: */N * * * * (N in 1-59; see stepOfStar)
+  const everyMin = stepOfStar(minute, 59);
+  if (everyMin !== null && hour === "*" && dom === "*" && dow === "*") {
+    return { schedule: { type: "everyNMinutes", interval: everyMin }, ok: true };
+  }
+  // every N hours: 0 */N * * * (N in 1-23)
+  const everyHour = stepOfStar(hour, 23);
+  if (everyHour !== null && minute === "0" && dom === "*" && dow === "*") {
+    return { schedule: { type: "everyNHours", interval: everyHour }, ok: true };
+  }
+  // hourly: M * * * *
+  const hourlyMinute = singleInt(minute, 0, 59);
+  if (hourlyMinute !== null && hour === "*" && dom === "*" && dow === "*") {
+    return { schedule: { type: "hourly", minute: hourlyMinute }, ok: true };
+  }
+
+  // The remaining presets all pin a single minute and hour.
+  const m = singleInt(minute, 0, 59);
+  const h = singleInt(hour, 0, 23);
+  if (m !== null && h !== null) {
+    if (dom === "*" && dow === "*") {
+      // daily: M H * * *
+      return { schedule: { type: "daily", hour: h, minute: m }, ok: true };
+    }
+    if (dom === "*") {
+      // weekly: M H * * <days>
+      const days = weekdayList(dow);
+      if (days !== null) {
+        return { schedule: { type: "weekly", hour: h, minute: m, weekdays: days }, ok: true };
+      }
+    } else if (dow === "*") {
+      // monthly: M H DOM * *
+      const d = singleInt(dom, 1, 31);
+      if (d !== null) {
+        return { schedule: { type: "monthly", hour: h, minute: m, dayOfMonth: d }, ok: true };
+      }
+    }
+  }
+  return { schedule: custom(expr), ok: false };
+}
+
+function custom(expr: string): Schedule {
+  return { type: "custom", raw: expr };
+}
+
+/** Splits on runs of whitespace, dropping empties — Go's `strings.Fields`. */
+function fields(expr: string): string[] {
+  return expr.split(/\s+/).filter((part) => part !== "");
+}
+
+/**
+ * Renders the day-of-week cron field: a sorted, de-duplicated, comma-separated
+ * list of weekday numbers (0-6). Empty weekdays render as "*" (every day) so the
+ * expression stays valid even mid-edit; the UI requires at least one day before it
+ * will save a weekly task.
+ */
+function weekdayField(days: number[] | undefined): string {
+  const nums = normalizeWeekdays(days);
+  return nums.length === 0 ? "*" : nums.join(",");
+}
+
+/** Renders weekdays as sorted three-letter abbreviations joined by ", ", e.g.
+ *  [1, 3] → "Mon, Wed". Ordered Sunday-first to match the cron day-of-week
+ *  numbering. */
+function weekdayNames(days: number[] | undefined): string {
+  return normalizeWeekdays(days)
+    .map((n) => WEEKDAY_ABBREV[n])
+    .join(", ");
+}
+
+/** Maps each weekday into 0-6 (7 is the Sunday alias), de-duplicates, and sorts
+ *  ascending, so both the cron field and the description present days in a stable
+ *  Sunday-first order. Mirrors Go's normalizeWeekdays (which cannot receive a
+ *  fractional weekday; truncating here keeps a stray one out of the cron field). */
+function normalizeWeekdays(days: number[] | undefined): number[] {
+  const seen = new Set<number>();
+  for (const d of days ?? []) {
+    const n = ((Math.trunc(d) % 7) + 7) % 7;
+    seen.add(n);
+  }
+  return [...seen].sort((a, b) => a - b);
+}
+
+/** Formats a 24-hour hour/minute as a 12-hour clock time with AM/PM, e.g.
+ *  (0,0)→"12:00 AM", (12,0)→"12:00 PM", (15,41)→"3:41 PM". */
+function clockTime(hour: number, minute: number): string {
+  let suffix = "AM";
+  let h = hour;
+  if (h === 0) {
+    h = 12;
+  } else if (h === 12) {
+    suffix = "PM";
+  } else if (h > 12) {
+    h -= 12;
+    suffix = "PM";
+  }
+  return `${h}:${pad2(minute)} ${suffix}`;
+}
+
+function pad2(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+/** Renders n as an English ordinal: 1→"1st", 2→"2nd", 3→"3rd", 11→"11th",
+ *  21→"21st", 31→"31st". */
+function ordinal(n: number): string {
+  let suffix = "th";
+  if (n % 100 < 11 || n % 100 > 13) {
+    switch (n % 10) {
+      case 1:
+        suffix = "st";
+        break;
+      case 2:
+        suffix = "nd";
+        break;
+      case 3:
+        suffix = "rd";
+        break;
+    }
+  }
+  return `${n}${suffix}`;
+}
+
+// stepOfStar parses a "*/N" field and returns N when it is a friendly interval,
+// 1 <= N <= max, else null. A step at or beyond the field size (e.g. "*/60" for
+// minutes or "*/24" for hours) is rejected so parseCron falls back to custom and
+// preserves the raw expression, rather than the picker clamping it (to */59 /
+// */23) and silently rewriting the cron on an otherwise-untouched re-save
+// (#2057). Any other shape (a bare "*", a single int, a range step, or a list)
+// also returns null.
+function stepOfStar(field: string, max: number): number | null {
+  if (!field.startsWith("*/")) {
+    return null;
+  }
+  const n = atoi(field.slice(2));
+  if (n === null || n < 1 || n > max) {
+    return null;
+  }
+  return n;
+}
+
+/** Parses a field that is a single integer within [min,max], else null. A field
+ *  containing any cron metacharacter (* / , -) fails, so only a bare number
+ *  matches. */
+function singleInt(field: string, min: number, max: number): number | null {
+  const n = atoi(field);
+  if (n === null || n < min || n > max) {
+    return null;
+  }
+  return n;
+}
+
+/**
+ * Parses a day-of-week field that is a comma-separated list of single weekday
+ * numbers (0-6, or 7 as a Sunday alias) into sorted, de-duplicated weekday values
+ * — the shape cron() emits for a weekly schedule. A wildcard, range, or step form
+ * returns null so the caller falls back to custom.
+ */
+function weekdayList(field: string): number[] | null {
+  if (field === "*") {
+    return null;
+  }
+  const seen = new Set<number>();
+  for (const part of field.split(",")) {
+    const n = atoi(part);
+    if (n === null || n < 0 || n > 7) {
+      return null;
+    }
+    seen.add(n === 7 ? 0 : n); // Sunday alias
+  }
+  if (seen.size === 0) {
+    return null;
+  }
+  return [...seen].sort((a, b) => a - b);
+}
+
+/**
+ * Go's `strconv.Atoi` semantics, which the parse rules above depend on: an
+ * optional sign followed by ASCII digits and nothing else — no surrounding
+ * whitespace, no partial prefix ("5x"), no empty string, no float. TS's Number()
+ * and parseInt() are both looser in ways that would silently accept expressions Go
+ * rejects (and so drift from the shared vectors), hence the explicit shape check.
+ */
+function atoi(s: string): number | null {
+  if (!/^[+-]?\d+$/.test(s)) {
+    return null;
+  }
+  const n = Number(s);
+  if (!Number.isSafeInteger(n)) {
+    return null; // Go returns ErrRange for an out-of-int64 value
+  }
+  return n === 0 ? 0 : n; // normalize "-0" so equality with 0 holds
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1877,6 +1877,99 @@ body {
   cursor: pointer;
 }
 
+/* `hidden` must actually hide inside a modal. The fields' own `display:flex` above
+ * is an AUTHOR style, so it outranks the UA `[hidden] { display: none }` rule
+ * regardless of specificity — the same hazard .af-viewport documents below. Without
+ * this, a hidden row stays on screen: the schedule picker's contextual rows (#2057)
+ * would all show at once, and so would the trigger toggle's inactive field, which is
+ * how the cron AND watch inputs were both visible before this rule existed. */
+.af-modal-body [hidden] {
+  display: none;
+}
+
+/* The schedule picker (#2057): a row of cells for the selected schedule type, then
+ * the plain-English preview and the read-only cron it generates. */
+.af-schedule-row {
+  display: flex;
+  align-items: center;
+  gap: var(--af-sp-2);
+}
+
+.af-schedule-clock {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--af-sp-2);
+}
+
+.af-schedule-num {
+  width: 5rem;
+  flex: none;
+}
+
+.af-schedule-meridiem {
+  width: auto;
+  flex: none;
+}
+
+.af-schedule-sep,
+.af-schedule-unit {
+  color: var(--af-text-2);
+  font-size: var(--af-fs-sm);
+}
+
+/* The weekday toggles: "M T W T F S S", Monday-first. State reads from the filled
+ * background + aria-pressed, no animation (#1766). */
+.af-weekdays {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--af-sp-2);
+}
+
+.af-weekday {
+  width: 2.25rem;
+  height: 2.25rem;
+  padding: 0;
+  background: var(--af-bg-inset);
+  border: 1px solid var(--af-border);
+  border-radius: var(--af-r-md);
+  color: var(--af-text-2);
+  font: inherit;
+  font-size: var(--af-fs-sm);
+  cursor: pointer;
+}
+
+.af-weekday:hover {
+  border-color: var(--af-accent);
+}
+
+.af-weekday-on {
+  background: var(--af-accent);
+  border-color: var(--af-accent);
+  color: var(--af-on-accent);
+  font-weight: 600;
+}
+
+.af-schedule-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.af-schedule-human {
+  margin: 0;
+  color: var(--af-text);
+  font-size: var(--af-fs-md);
+}
+
+/* The generated cron: read-only, monospace, and visibly not an input you fill in —
+ * it is there so the user can see (and copy) exactly what gets stored. */
+.af-schedule-cron {
+  font-family: var(--af-font-mono);
+  font-size: var(--af-fs-sm);
+  color: var(--af-text-2);
+  cursor: default;
+}
+
 .af-modal-text {
   margin: 0;
   color: var(--af-text-2);

--- a/web/src/tasks.ts
+++ b/web/src/tasks.ts
@@ -13,8 +13,15 @@
 //
 // It is patched in place like the rest of the shell and CSP-safe (createElement +
 // addEventListener via the shared h() helper, no innerHTML with markup).
+//
+// The task form's cron field is the friendly schedule PICKER (#2057 phase 2, the
+// browser twin of ui/schedule_picker.go): a schedule type plus its contextual
+// inputs, generating the cron underneath. Cron is still the stored/wire format —
+// only the input UX changed — and the raw expression stays reachable as the
+// picker's Custom type.
 
 import { asForm, field, h, modalChrome, type ModalHandle, projectLabel } from "./modals.js";
+import { SCHEDULE_TYPE_OPTIONS, type Schedule, type ScheduleType, cron as scheduleCron, describe as scheduleDescribe, parseCron } from "./schedule.js";
 import type { TaskData } from "./types.js";
 
 /** The add-task form's inputs (a subset of task.Task the browser fills; the daemon
@@ -200,10 +207,371 @@ export class TasksPane {
   }
 }
 
+/** Weekday toggles render Monday-first ("M T W T F S S", #2057) but map onto the
+ *  Sunday-first weekday numbering the schedule model normalizes on — the same
+ *  display order as the TUI picker's weekdayDisplayOrder. */
+const WEEKDAY_DISPLAY: ReadonlyArray<{ weekday: number; letter: string; name: string }> = [
+  { weekday: 1, letter: "M", name: "Monday" },
+  { weekday: 2, letter: "T", name: "Tuesday" },
+  { weekday: 3, letter: "W", name: "Wednesday" },
+  { weekday: 4, letter: "T", name: "Thursday" },
+  { weekday: 5, letter: "F", name: "Friday" },
+  { weekday: 6, letter: "S", name: "Saturday" },
+  { weekday: 0, letter: "S", name: "Sunday" },
+];
+
+/** A form row that is NOT a <label>: the picker's multi-control rows (a time, a
+ *  weekday toggle group) hold several controls, and a <label> wrapping them forwards
+ *  a click on its own text to the first control inside — which would silently toggle
+ *  Monday when the user clicks the word "Days". Same class + look as modals' field(),
+ *  which stays the right helper for a single-control row. */
+function fieldGroup(label: string, control: HTMLElement): HTMLElement {
+  return h("div", { class: "af-modal-field" }, h("span", { class: "af-modal-label" }, label), control);
+}
+
+/** Parses a numeric cell, clamping into [min,max] and falling back to `def` for
+ *  anything unparseable — the browser twin of the TUI picker's atoiClamp. Clamping
+ *  happens when the schedule is MATERIALIZED, not on every keystroke, so a mid-edit
+ *  "7" on the way to "17" is never fought. */
+function clampField(raw: string, min: number, max: number, def: number): number {
+  const n = Number.parseInt(raw.trim(), 10);
+  if (!Number.isFinite(n)) {
+    return def;
+  }
+  return Math.min(Math.max(n, min), max);
+}
+
+/**
+ * The friendly schedule picker (#2057 phase 2): the browser twin of the TUI's
+ * ui/schedule_picker.go, and the cron field's replacement in the task form. A
+ * schedule-type selector plus ONLY the inputs that type needs, a live plain-English
+ * preview, and the generated cron shown read-only so users can see exactly what
+ * gets saved.
+ *
+ * All model logic — cron generation, the preview text, and seeding an existing task
+ * back into its matching preset — lives in the shared schedule module, which mirrors
+ * the canonical Go package under a vectors-driven parity test. This class is only
+ * the DOM surface over it, so the two pickers cannot drift apart in what a state
+ * means, only in how it is drawn.
+ *
+ * Cron remains the stored/wire format: cron() is what the form submits, and Custom
+ * hands back a raw expression verbatim (today's behavior, kept as the escape hatch).
+ */
+class SchedulePicker {
+  /** The rows to append into the modal body, in visual order. */
+  readonly rows: HTMLElement[];
+
+  private readonly typeSelect: HTMLSelectElement;
+  private readonly intervalInput: HTMLInputElement;
+  private readonly intervalUnit: HTMLElement;
+  private readonly hourInput: HTMLInputElement;
+  private readonly minuteInput: HTMLInputElement;
+  private readonly meridiemSelect: HTMLSelectElement;
+  private readonly domInput: HTMLInputElement;
+  private readonly rawInput: HTMLInputElement;
+  private readonly humanLine: HTMLElement;
+  private readonly cronOut: HTMLInputElement;
+
+  private readonly intervalRow: HTMLElement;
+  private readonly timeRow: HTMLElement;
+  private readonly timeLabel: HTMLElement;
+  private readonly hourGroup: HTMLElement;
+  private readonly weekdayRow: HTMLElement;
+  private readonly domRow: HTMLElement;
+  private readonly rawRow: HTMLElement;
+  private readonly previewRow: HTMLElement;
+
+  private readonly weekdayButtons: HTMLButtonElement[] = [];
+  private readonly weekdaysOn = new Set<number>();
+
+  constructor() {
+    this.typeSelect = h("select", { class: "af-input" });
+    this.typeSelect.setAttribute("aria-label", "Schedule type");
+    for (const opt of SCHEDULE_TYPE_OPTIONS) {
+      this.typeSelect.append(h("option", { value: opt.type }, opt.label));
+    }
+    this.typeSelect.addEventListener("change", () => this.onTypeChange());
+
+    this.intervalInput = this.numberInput("Interval", "1", "59");
+    this.intervalUnit = h("span", { class: "af-schedule-unit" }, "minutes");
+    this.intervalRow = fieldGroup(
+      "Run every",
+      h("div", { class: "af-schedule-row" }, this.intervalInput, this.intervalUnit),
+    );
+
+    this.hourInput = this.numberInput("Hour", "1", "12");
+    this.minuteInput = this.numberInput("Minute", "0", "59");
+    this.meridiemSelect = h("select", { class: "af-input af-schedule-meridiem" });
+    this.meridiemSelect.setAttribute("aria-label", "AM/PM");
+    this.meridiemSelect.append(h("option", { value: "AM" }, "AM"), h("option", { value: "PM" }, "PM"));
+    this.meridiemSelect.addEventListener("change", () => this.sync());
+    // Hour and AM/PM travel together: an hourly schedule keeps only the minute, so
+    // the whole group hides and the row's label switches to name what is left.
+    this.hourGroup = h(
+      "span",
+      { class: "af-schedule-clock" },
+      this.hourInput,
+      h("span", { class: "af-schedule-sep" }, ":"),
+    );
+    this.timeRow = fieldGroup("Time", h("div", { class: "af-schedule-row" }, this.hourGroup, this.minuteInput, this.meridiemSelect));
+    this.timeLabel = this.timeRow.firstElementChild as HTMLElement;
+
+    const weekdayGroup = h("div", { class: "af-weekdays" });
+    weekdayGroup.setAttribute("role", "group");
+    weekdayGroup.setAttribute("aria-label", "Days of the week");
+    for (const day of WEEKDAY_DISPLAY) {
+      // The letters repeat (T/T, S/S), so the accessible name is the full day name
+      // and aria-pressed carries the state — never the glyph alone.
+      const btn = h("button", { type: "button", class: "af-weekday" }, day.letter);
+      btn.setAttribute("aria-label", day.name);
+      btn.setAttribute("aria-pressed", "false");
+      btn.addEventListener("click", () => this.toggleWeekday(day.weekday));
+      this.weekdayButtons.push(btn);
+      weekdayGroup.append(btn);
+    }
+    this.weekdayRow = fieldGroup("Days", weekdayGroup);
+
+    this.domInput = this.numberInput("Day of month", "1", "31");
+    this.domRow = field("Day of month", this.domInput);
+
+    this.rawInput = h("input", { type: "text", class: "af-input", placeholder: "0 9 * * 1-5", autocomplete: "off" });
+    this.rawInput.setAttribute("aria-label", "Cron expression");
+    this.rawInput.addEventListener("input", () => this.sync());
+    this.rawRow = field("Cron expression", this.rawInput);
+
+    this.humanLine = h("p", { class: "af-schedule-human" });
+    this.humanLine.setAttribute("aria-live", "polite");
+    this.cronOut = h("input", { type: "text", class: "af-input af-schedule-cron", readOnly: true, tabIndex: -1 });
+    this.cronOut.setAttribute("aria-label", "Generated cron");
+    this.previewRow = h("div", { class: "af-schedule-preview" }, this.humanLine, this.cronOut);
+
+    this.rows = [
+      field("Schedule", this.typeSelect),
+      this.intervalRow,
+      this.timeRow,
+      this.weekdayRow,
+      this.domRow,
+      this.rawRow,
+      this.previewRow,
+    ];
+
+    this.reset();
+  }
+
+  private numberInput(label: string, min: string, max: string): HTMLInputElement {
+    const el = h("input", { type: "number", class: "af-input af-schedule-num", min, max, autocomplete: "off" });
+    el.setAttribute("aria-label", label);
+    el.addEventListener("input", () => this.sync());
+    return el;
+  }
+
+  /** Seeds a brand-new task: daily at 9:00 AM, with every other type's fields
+   *  carrying valid defaults so switching type never lands on an empty input. The
+   *  same defaults the TUI picker resets to. */
+  private reset(): void {
+    this.typeSelect.value = "daily";
+    this.intervalInput.value = "15";
+    this.hourInput.value = "9";
+    this.minuteInput.value = "00";
+    this.meridiemSelect.value = "AM";
+    this.domInput.value = "1";
+    this.rawInput.value = "";
+    this.weekdaysOn.clear();
+    this.weekdaysOn.add(1); // Monday
+    this.sync();
+  }
+
+  /**
+   * Seeds the picker from an existing task's cron: the matching preset if the
+   * expression is one of the shapes the model emits, otherwise Custom holding the
+   * original text verbatim. An empty expression (e.g. a watch task being switched to
+   * a cron trigger) keeps the new-task defaults rather than dropping into an empty
+   * Custom field.
+   */
+  seed(cronExpr: string): void {
+    this.reset();
+    if (cronExpr.trim() === "") {
+      return;
+    }
+    const { schedule: s } = parseCron(cronExpr);
+    this.typeSelect.value = s.type;
+    switch (s.type) {
+      case "everyNMinutes":
+      case "everyNHours":
+        if (s.interval !== undefined && s.interval > 0) {
+          this.intervalInput.value = String(s.interval);
+        }
+        break;
+      case "hourly":
+        this.minuteInput.value = pad2(s.minute ?? 0);
+        break;
+      case "daily":
+        this.setClock(s.hour ?? 0, s.minute ?? 0);
+        break;
+      case "weekly":
+        this.setClock(s.hour ?? 0, s.minute ?? 0);
+        this.weekdaysOn.clear();
+        for (const d of s.weekdays ?? []) {
+          this.weekdaysOn.add(d);
+        }
+        break;
+      case "monthly":
+        this.setClock(s.hour ?? 0, s.minute ?? 0);
+        if (s.dayOfMonth !== undefined && s.dayOfMonth > 0) {
+          this.domInput.value = String(s.dayOfMonth);
+        }
+        break;
+      default: // custom — the raw expression, unchanged
+        this.rawInput.value = s.raw ?? cronExpr;
+        break;
+    }
+    this.sync();
+  }
+
+  /** Splits a 24-hour time into the 12-hour hour + AM/PM cells (to12Hour). */
+  private setClock(hour24: number, minute: number): void {
+    let h12 = hour24;
+    let pm = false;
+    if (hour24 === 0) {
+      h12 = 12;
+    } else if (hour24 === 12) {
+      pm = true;
+    } else if (hour24 > 12) {
+      h12 = hour24 - 12;
+      pm = true;
+    }
+    this.hourInput.value = String(h12);
+    this.minuteInput.value = pad2(minute);
+    this.meridiemSelect.value = pm ? "PM" : "AM";
+  }
+
+  private toggleWeekday(weekday: number): void {
+    if (this.weekdaysOn.has(weekday)) {
+      this.weekdaysOn.delete(weekday);
+    } else {
+      this.weekdaysOn.add(weekday);
+    }
+    this.sync();
+  }
+
+  private get type(): ScheduleType {
+    return this.typeSelect.value as ScheduleType;
+  }
+
+  /** Switching INTO Custom prefills the raw field with the cron the previous preset
+   *  generated (when it is empty), so the escape hatch starts from a working
+   *  expression rather than blank — the TUI does the same. */
+  private onTypeChange(): void {
+    if (this.type === "custom" && this.rawInput.value.trim() === "") {
+      this.rawInput.value = this.cronOut.value;
+    }
+    this.sync();
+  }
+
+  /** Materializes the current cell state into a canonical Schedule, clamping the
+   *  numeric cells so the generated cron is always well-formed (Custom's raw text
+   *  excepted — the daemon validates that). */
+  schedule(): Schedule {
+    switch (this.type) {
+      case "everyNMinutes":
+        return { type: "everyNMinutes", interval: clampField(this.intervalInput.value, 1, 59, 15) };
+      case "everyNHours":
+        return { type: "everyNHours", interval: clampField(this.intervalInput.value, 1, 23, 1) };
+      case "hourly":
+        return { type: "hourly", minute: clampField(this.minuteInput.value, 0, 59, 0) };
+      case "daily":
+        return { type: "daily", hour: this.hour24(), minute: clampField(this.minuteInput.value, 0, 59, 0) };
+      case "weekly":
+        return {
+          type: "weekly",
+          hour: this.hour24(),
+          minute: clampField(this.minuteInput.value, 0, 59, 0),
+          weekdays: [...this.weekdaysOn],
+        };
+      case "monthly":
+        return {
+          type: "monthly",
+          hour: this.hour24(),
+          minute: clampField(this.minuteInput.value, 0, 59, 0),
+          dayOfMonth: clampField(this.domInput.value, 1, 31, 1),
+        };
+      default: // custom
+        return { type: "custom", raw: this.rawInput.value.trim() };
+    }
+  }
+
+  private hour24(): number {
+    const h = clampField(this.hourInput.value, 1, 12, 12);
+    const pm = this.meridiemSelect.value === "PM";
+    if (pm) {
+      return h === 12 ? 12 : h + 12;
+    }
+    return h === 12 ? 0 : h; // 12 AM = midnight
+  }
+
+  /** The cron expression the form submits — always live off the current state. */
+  cron(): string {
+    return scheduleCron(this.schedule());
+  }
+
+  /** Re-applies the per-type row visibility and preview. The task form calls this
+   *  after showing the picker again (switching the trigger back to cron), which
+   *  unhides every row wholesale. */
+  refresh(): void {
+    this.sync();
+  }
+
+  /** A user-facing message for an unsavable schedule, or null when it is good to
+   *  save. The daemon re-validates the expression itself (it always has); these are
+   *  the picker-level constraints that would otherwise generate a nonsense cron. */
+  validate(): string | null {
+    if (this.type === "custom" && this.rawInput.value.trim() === "") {
+      return "A cron expression is required for a cron task.";
+    }
+    if (this.type === "weekly" && this.weekdaysOn.size === 0) {
+      return "Select at least one day of the week.";
+    }
+    return null;
+  }
+
+  /** Shows only the cells the selected type needs, and refreshes the preview + the
+   *  read-only generated cron. Runs on every edit, so what the user reads is always
+   *  what a submit would store. */
+  private sync(): void {
+    const type = this.type;
+    const isClock = type === "daily" || type === "weekly" || type === "monthly";
+    this.intervalRow.hidden = type !== "everyNMinutes" && type !== "everyNHours";
+    this.intervalUnit.textContent = type === "everyNHours" ? "hours" : "minutes";
+    this.intervalInput.max = type === "everyNHours" ? "23" : "59";
+    this.timeRow.hidden = !isClock && type !== "hourly";
+    this.hourGroup.hidden = !isClock;
+    this.meridiemSelect.hidden = !isClock;
+    this.timeLabel.textContent = isClock ? "Time" : "Minute past the hour";
+    this.weekdayRow.hidden = type !== "weekly";
+    this.domRow.hidden = type !== "monthly";
+    this.rawRow.hidden = type !== "custom";
+
+    for (let i = 0; i < this.weekdayButtons.length; i++) {
+      const on = this.weekdaysOn.has(WEEKDAY_DISPLAY[i].weekday);
+      this.weekdayButtons[i].setAttribute("aria-pressed", on ? "true" : "false");
+      this.weekdayButtons[i].classList.toggle("af-weekday-on", on);
+    }
+
+    const s = this.schedule();
+    this.humanLine.textContent = scheduleDescribe(s);
+    this.cronOut.value = scheduleCron(s);
+  }
+}
+
+function pad2(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
 /**
  * The task form modal (mirrors the TUI's task editor + `af tasks add`/`update`):
- * name, project, a cron/watch trigger toggle with its value, a prompt, an optional
- * target session, and the agent program. Shared by the ADD and EDIT flows — the only
+ * name, project, a cron/watch trigger toggle with its value — the schedule PICKER
+ * for cron (#2057), a command for watch — a prompt, an optional target session, and
+ * the agent program. Shared by the ADD and EDIT flows — the only
  * difference is the chrome (title/confirm label) and, in edit mode, that every field
  * is SEEDED from the existing task (#1935). onSubmit fires with the collected input;
  * the caller turns it into an AddTask (buildTask) or a field-level UpdateTask patch.
@@ -256,21 +624,29 @@ function taskFormModal(opts: {
   triggerSelect.append(h("option", { value: "cron" }, "Cron schedule"));
   triggerSelect.append(h("option", { value: "watch" }, "Watch command"));
 
-  const cronInput = h("input", { type: "text", class: "af-input", placeholder: "0 9 * * *", autocomplete: "off" });
-  cronInput.setAttribute("aria-label", "Cron expression");
-  const cronField = field("Cron expression", cronInput);
+  // The friendly schedule picker replaces the raw-cron text field (#2057). It still
+  // yields a cron expression — the stored/wire format is unchanged — and keeps the
+  // raw field available under its Custom type.
+  const picker = new SchedulePicker();
 
   const watchInput = h("input", { type: "text", class: "af-input", placeholder: "tail -F events.log", autocomplete: "off" });
   watchInput.setAttribute("aria-label", "Watch command");
   const watchField = field("Watch command", watchInput);
   watchField.hidden = true;
 
-  // Show only the field for the selected trigger; the other is hidden (its value is
-  // ignored on submit, and the daemon rejects a task with both set).
+  // Show only the field(s) for the selected trigger; the other is hidden (its value
+  // is ignored on submit, and the daemon rejects a task with both set).
   const syncTriggerFields = (): void => {
     const isWatch = triggerSelect.value === "watch";
-    cronField.hidden = isWatch;
+    for (const row of picker.rows) {
+      row.hidden = isWatch;
+    }
     watchField.hidden = !isWatch;
+    if (!isWatch) {
+      // Re-assert the picker's own per-type row visibility, which the blanket
+      // unhide above just cleared.
+      picker.refresh();
+    }
   };
   triggerSelect.addEventListener("change", syncTriggerFields);
 
@@ -296,7 +672,9 @@ function taskFormModal(opts: {
     nameInput.value = s.name ?? "";
     const isWatch = !!(s.watch_cmd && s.watch_cmd.trim() !== "");
     triggerSelect.value = isWatch ? "watch" : "cron";
-    cronInput.value = s.cron_expr ?? "";
+    // The picker re-opens as the preset the stored cron maps to, or as Custom
+    // holding the original expression verbatim (#2057).
+    picker.seed(s.cron_expr ?? "");
     watchInput.value = s.watch_cmd ?? "";
     syncTriggerFields();
     promptArea.value = s.prompt ?? "";
@@ -311,7 +689,7 @@ function taskFormModal(opts: {
     field("Name", nameInput),
     field("Project", projectSelect),
     field("Trigger", triggerSelect),
-    cronField,
+    ...picker.rows,
     watchField,
     field("Prompt", promptArea),
     field("Target session", targetInput),
@@ -322,17 +700,21 @@ function taskFormModal(opts: {
   asForm(card, () => {
     const trigger = triggerSelect.value === "watch" ? "watch" : "cron";
     const name = nameInput.value.trim();
-    const cron = cronInput.value.trim();
     const watchCmd = watchInput.value.trim();
     const prompt = promptArea.value.trim();
     if (name === "" || projectSelect.value === "") {
       handle.setError("A name and a project are required.");
       return;
     }
-    if (trigger === "cron" && cron === "") {
-      handle.setError("A cron expression is required for a cron task.");
+    // The picker always yields a well-formed expression for a preset; validate()
+    // only catches the states that cannot generate one (an empty Custom cron, a
+    // weekly with no days). The daemon re-validates whatever we send, as before.
+    const scheduleErr = trigger === "cron" ? picker.validate() : null;
+    if (scheduleErr !== null) {
+      handle.setError(scheduleErr);
       return;
     }
+    const cron = trigger === "cron" ? picker.cron() : "";
     if (trigger === "cron" && prompt === "") {
       handle.setError("A prompt is required for a cron task.");
       return;


### PR DESCRIPTION
Phase 2 of #2057 — the **web** half of the friendly schedule picker. Phase 1
(PR #2060) shipped the canonical Go `schedule` package, the shared test
vectors, and the TUI form; this replaces the raw-cron input in the browser
task create/edit modal with the same picker.

**Cron stays the stored/wire format.** No change to the daemon scheduler,
cron validation, or persistence — only the input UX. Existing tasks keep
working, and `Custom (cron)` remains the escape hatch.

## The anti-drift approach (the point of phase 1)

`web/src/schedule.ts` is a deliberate mirror of `schedule/schedule.go`: the
same seven types, the same `Cron()` shapes, the same `Describe()` text, and
the same exact-shape-only `ParseCron` — including the rule that an
out-of-range step (`*/60`, `*/24`) is **rejected to Custom, not clamped**, so
an untouched re-save never silently rewrites a user's expression.

What keeps the mirror honest is not review discipline but a test.
`web/src/schedule.test.ts` loads **`schedule/testdata/vectors.json` itself** —
the same file `schedule/schedule_test.go` loads, read across the repo root,
**not a copy or a fork of the fixture** — and asserts every
`cron` / `human` / `parse` triple per the rules in the file's own `_readme`.
This is the arrangement `frame.test.ts` already uses for the wire codec, and
the #1970 shared-source-of-truth pattern.

I mutation-tested the lock rather than trusting a green run — each of these
made the vectors test fail, then was reverted:

| mutation | result |
|---|---|
| `describe()` weekday separator `", "` → `" "` | 4 failures |
| `stepOfStar()` accepts `*/60` / `*/24` (clamp instead of reject) | 3 failures |
| `cron()` emits the daily hour mod 12 | 5 failures |
| `atoi()` drops the Go-`Atoi` shape guard | 1 failure |

That last one is a TS-specific trap worth calling out: `Number()` and
`parseInt()` accept shapes Go's `strconv.Atoi` rejects (`"5x"`, `"0x10"`,
`"1e2"`, `" 5"`), which would silently parse into presets the Go model calls
Custom. `atoi()` pins the Go semantics, with a test the vectors can't cover
(they can't enumerate every malformed field).

## The picker

Type selector → only that type's inputs → a live preview → the generated cron
read-only:

- Every N minutes / Every N hours → an interval cell
- Hourly → minute past the hour
- Daily → 12h time + AM/PM
- Weekly → time + `M T W T F S S` toggles (Monday-first display, mapped onto
  the Sunday-first weekday numbering the model normalizes on)
- Monthly → time + day-of-month
- Custom (cron) → the raw field, prefilled from the previous preset's cron

Editing seeds through `ParseCron`, so a stored expression re-opens as its
matching preset with its cells restored, or as Custom holding the original
text verbatim. Defaults, clamping, and the Custom-prefill behavior match the
TUI picker's.

## One adjacent bug fixed

`.af-modal-field { display: flex }` is an author style, so it **outranks the
UA `[hidden] { display: none }` rule** — meaning `hidden` never actually hid
a modal field. The picker's contextual rows depend on that mechanism, and so
did the pre-existing trigger toggle: the cron **and** watch inputs were both
visible at once. Fixed with one `.af-modal-body [hidden]` rule (the same
hazard `.af-viewport` already documents), and the selftest now asserts the
watch field is hidden while the trigger is cron.

Multi-control rows also moved off `field()` (a `<label>`): a label wrapping
several controls forwards a click on its own text to the first control
inside, so clicking the word "Days" would have toggled Monday.

## Verification

- `make web-test` — 375 pass (48 shared vectors + the round-trip, fallback,
  numeric-strictness, and type-coverage locks)
- `make web-selftest-container` — **97 pass**, including a new #2057 flow:
  build "every week on Mon, Wed at 9:30 AM" through the picker → assert the
  preview and generated cron → assert `AddTask` carries `30 9 * * 1,3` →
  re-open and assert it seeded back as the *weekly* preset with its cells →
  switch to "every 6 hours" → assert the `UpdateTask` patch carries
  `0 */6 * * *` → **reload** and assert it persisted and re-seeds
- `make web-build` run; regenerated `web/dist` committed (bundle bytes
  unchanged since the selftest run — the `sw.js` shell hash is identical)
- `go build ./...`, `gofmt -l .`, `golangci-lint --fast`, file-length lint
  all clean (no Go files touched)

## One thing to flag

**`make web-test` is not wired into CI** — no workflow runs the web TS tests
today, so this parity lock only fires when a developer runs it locally. The
lock is real but currently manual. Adding a CI step was outside this PR's
scope; happy to do it as a follow-up if you want the drift gate enforced on
every PR.

Closes #2057.

— Captain Claude
