### PR TITLE
fix(daemon): drop the +1 allocation-size arithmetic CodeQL flags on ghost tab names (#2036)

### DIFF
--- a/daemon/ghost_tmux_names_test.go
+++ b/daemon/ghost_tmux_names_test.go
@@ -1,0 +1,97 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// TestGhostTmuxNames_OrderDedupeAndEmptySkip pins the contract ghostCleanup
+// depends on: the legacy agent-tab name first, then each tab in persisted order,
+// deduped, with empty names dropped.
+//
+// This is a REGRESSION GUARD, not a fail-first repro. #2036 changed only the two
+// make() capacity hints (dropping a `+1` that CodeQL flagged as a possible
+// allocation-size overflow), which is behaviour-neutral by construction — there
+// is no input for which the old and new code return different names, so no test
+// can fail on the old code. What this pins is that the restructure did not
+// disturb the observable contract, and that a future re-tune of the pre-size
+// cannot either.
+//
+// TestGhostCleanup_KillsEveryTabTmux covers the same function end-to-end against
+// a real tmux server, but it asserts the OUTCOME (every tab's session is dead),
+// which is order- and dedupe-blind. This asserts the list itself, needs no tmux
+// server, and names the property the doc comment claims.
+func TestGhostTmuxNames_OrderDedupeAndEmptySkip(t *testing.T) {
+	tests := []struct {
+		name string
+		data *session.InstanceData
+		want []string
+	}{
+		{
+			// Pre-#953: no Tabs at all. This is the case the dropped `+1` used to
+			// pre-size for, so it is the one where the new cap (0) must still grow
+			// to hold the legacy name.
+			name: "pre-#953 record yields just the legacy name",
+			data: &session.InstanceData{TmuxName: "af_solo"},
+			want: []string{"af_solo"},
+		},
+		{
+			// Post-#953: the agent tab is repeated in BOTH TmuxName and Tabs[0].
+			// The dedupe must collapse it to a single kill, or ghostCleanup would
+			// kill an already-dead session and read the second failure as "not
+			// confirmed dead" — which strands the workspace (#1917).
+			name: "post-#953 record collapses the repeated agent tab",
+			data: &session.InstanceData{
+				TmuxName: "af_multi",
+				Tabs: []session.TabData{
+					{Name: "agent", Kind: session.TabKindAgent, TmuxName: "af_multi"},
+					{Name: "shell", Kind: session.TabKindShell, TmuxName: "af_multi__shell"},
+					{Name: "btop", Kind: session.TabKindProcess, TmuxName: "af_multi__btop"},
+				},
+			},
+			want: []string{"af_multi", "af_multi__shell", "af_multi__btop"},
+		},
+		{
+			// A tab that never got a tmux session (e.g. a web tab) carries an empty
+			// name; killing "" would target the caller's own server-wide default.
+			name: "empty tab names are skipped",
+			data: &session.InstanceData{
+				TmuxName: "af_web",
+				Tabs: []session.TabData{
+					{Name: "agent", Kind: session.TabKindAgent, TmuxName: "af_web"},
+					{Name: "docs", Kind: session.TabKindWeb, TmuxName: ""},
+					{Name: "shell", Kind: session.TabKindShell, TmuxName: "af_web__shell"},
+				},
+			},
+			want: []string{"af_web", "af_web__shell"},
+		},
+		{
+			// An empty legacy name must not become a leading "" entry either.
+			name: "empty legacy name is skipped, tabs still ordered",
+			data: &session.InstanceData{
+				TmuxName: "",
+				Tabs: []session.TabData{
+					{Name: "shell", Kind: session.TabKindShell, TmuxName: "af_orphan__shell"},
+					{Name: "btop", Kind: session.TabKindProcess, TmuxName: "af_orphan__btop"},
+				},
+			},
+			want: []string{"af_orphan__shell", "af_orphan__btop"},
+		},
+		{
+			name: "a record with nothing to kill yields no names",
+			data: &session.InstanceData{},
+			want: []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Equal (not ElementsMatch) is deliberate: persisted order is part of
+			// the contract, and the legacy name leads.
+			assert.Equal(t, tc.want, ghostTmuxNames(tc.data))
+		})
+	}
+}

--- a/daemon/manager_persist.go
+++ b/daemon/manager_persist.go
@@ -346,8 +346,22 @@ var ghostCleanupWorktree = func(data *session.InstanceData, title string) (git.C
 // to a single kill; a pre-#953 record has no Tabs and yields just data.TmuxName,
 // keeping the legacy path byte-identical.
 func ghostTmuxNames(data *session.InstanceData) []string {
-	names := make([]string, 0, len(data.Tabs)+1)
-	seen := make(map[string]struct{}, len(data.Tabs)+1)
+	// Pre-sized to len(data.Tabs), NOT len(data.Tabs)+1. The legacy name is
+	// already one of the tabs on any post-#953 record, so the +1 was slack in the
+	// common case, and the one add that can exceed this cap (a pre-#953 record,
+	// which has no Tabs at all) grows the slice itself.
+	//
+	// The arithmetic tripped CodeQL's go/allocation-size-overflow (high) on
+	// `len(...)+1` inside make(). That was a FALSE POSITIVE — data.Tabs is a
+	// persisted session's tab list (an agent tab plus a handful of shell/process/
+	// web tabs), so reaching an overflow would need ~2^63 tabs, which cannot
+	// exist. But it is the same trade as #1988: the expression bought nothing on
+	// a path that runs once per ghost record during cleanup, and code with no
+	// allocation-size arithmetic beats code that argues with a scanner. Do not
+	// add the +1 back — it re-raises two high-severity alerts on the security tab
+	// to save an allocation nobody will ever measure (#2036).
+	names := make([]string, 0, len(data.Tabs))
+	seen := make(map[string]struct{}, len(data.Tabs))
 	add := func(name string) {
 		if name == "" {
 			return


### PR DESCRIPTION
Closes #2036.

Two high-severity `go/allocation-size-overflow` alerts have been open on
the security tab since #2033, both on `ghostTmuxNames`:

    names := make([]string, 0, len(data.Tabs)+1)
    seen  := make(map[string]struct{}, len(data.Tabs)+1)

Both are FALSE POSITIVES. `data.Tabs` is a persisted session's tab list —
an agent tab plus a handful of shell/process/web tabs — so overflowing
`len+1` would need ~2^63 tabs, which cannot exist.

Fixed the way #1988 fixed the identical false positive on shellsuggest's
`make([]string, 0, len(args)+1)`: restructure so there is no allocation-size
arithmetic left to flag, rather than blanket-dismissing the rule. A
dismissal would bury a future REAL alert of the same class; this does not.

The `+1` was slack anyway. On any post-#953 record the legacy name is
already one of the tabs, so the exact cap is `len(data.Tabs)`. The one
input that can exceed it — a pre-#953 record, which has no Tabs at all —
grows the slice once, for a single string, on a path that runs once per
ghost record during cleanup.

Behaviour is unchanged by construction: same names, same order, same
dedupe, for every input.

## Verification

`ghostTmuxNames` had no direct test, so this adds
`TestGhostTmuxNames_OrderDedupeAndEmptySkip` over the contract ghostCleanup
depends on — legacy name first, persisted order, deduped, empty names
skipped.

To be explicit about what that test is and is not: it is a regression
guard, NOT a fail-first repro. The change is behaviour-neutral, so no test
can fail on the old code — the failing signal here is the CodeQL alert
itself (alerts #20 and #21, both open at the time of writing). The test
was checked for teeth by mutation instead: removing the dedupe, dropping
the legacy name, and removing the empty-name skip each turn it red.

`TestGhostCleanup_KillsEveryTabTmux` already covered this function end to
end against a real tmux server, but it asserts the outcome (every tab's
session is dead), which is order- and dedupe-blind.

## Adjacent sites

Audited every `make(..., len(x)+N)` in the tree. Three others exist —
`session/tmux/clientless.go:93`, `ui/task_pane.go:226`,
`app/home_model.go:561` — and CodeQL flags none of them; the open alert
list is exactly these two lines. Left them alone rather than churn
unflagged code: `clientless.go`'s `+4` is an exact arg-count pre-size that
would lose meaning if trimmed.

Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>


🤖 Generated with [Claude Code](https://claude.com/claude-code)
