### PR TITLE
fix(ci): compare exact durations in the stale-external-pr grace check (#2027)

### DIFF
--- a/.github/scripts/stale-external-pr.js
+++ b/.github/scripts/stale-external-pr.js
@@ -137,8 +137,14 @@ function decide(pr, now) {
     );
   }
 
+  // The DECISION compares exact milliseconds; hoursBetween is for the log line
+  // only. Comparing the rounded hours closed up to ~3 minutes early: a change
+  // request aged [11.95h, 12h) rounds to 12.0, which is not < 12, so the grace
+  // window ended before it was actually over (#2027). Never a wrong-target close,
+  // but the threshold we publish should be the threshold we enforce.
+  const ageMs = nowMs - reviewMs;
   const ageHours = hoursBetween(reviewMs, nowMs);
-  if (ageHours < STALE_HOURS) {
+  if (ageMs < STALE_HOURS * 36e5) {
     return skip(`change request only ${ageHours}h old (< ${STALE_HOURS}h grace)`);
   }
 
@@ -200,9 +206,15 @@ function toMs(value) {
   return Number.isNaN(ms) ? NaN : ms;
 }
 
-// Whole-tenths of an hour, for readable log/reason lines.
+// Whole-tenths of an hour, for readable log/reason lines. It never decides
+// anything — the grace check in decide() compares exact milliseconds (#2027).
+//
+// Truncates rather than rounds so the number can never OVER-report an age.
+// Rounding made the grace message argue with itself: at 11h57m it read "only 12h
+// old (< 12h grace)", quoting an age that is not less than the threshold it was
+// granting grace against. Truncation keeps this a lower bound on the real age.
 function hoursBetween(fromMs, toMsValue) {
-  return Math.round(((toMsValue - fromMs) / 36e5) * 10) / 10;
+  return Math.floor(((toMsValue - fromMs) / 36e5) * 10) / 10;
 }
 
 /**

--- a/.github/scripts/stale-external-pr.test.js
+++ b/.github/scripts/stale-external-pr.test.js
@@ -104,6 +104,36 @@ test("change request exactly 12h old → CLOSE (boundary is inclusive)", () => {
   assert.equal(decide(pr, NOW).shouldClose, true);
 });
 
+// #2027: the grace check used to compare hoursBetween (rounded to tenths)
+// against STALE_HOURS. 11h57m is 11.95h, which rounds to 12.0 — not < 12 — so
+// the PR closed ~3 minutes before its grace window was actually up. The
+// comparison is now exact milliseconds.
+test("change request 11h57m old → KEEP (rounding must not end grace early)", () => {
+  const pr = forkPR({ reviews: [maintReview("CHANGES_REQUESTED", hoursAgo(11 + 57 / 60))] });
+  const d = decide(pr, NOW);
+  assert.equal(d.shouldClose, false, "grace ends at 12h exactly, not at the first age that rounds to 12h");
+  assert.match(d.reason, /grace/);
+});
+
+// The reported age is a log detail, but it must not contradict the decision it
+// accompanies: a message granting grace cannot quote an age >= the threshold.
+test("the grace message never reports an age at or past the threshold", () => {
+  for (const ageHours of [11 + 57 / 60, 11.99, 11.999]) {
+    const pr = forkPR({ reviews: [maintReview("CHANGES_REQUESTED", hoursAgo(ageHours))] });
+    const d = decide(pr, NOW);
+    assert.equal(d.shouldClose, false, `${ageHours}h is inside the grace window`);
+    const reported = Number(d.reason.match(/only ([\d.]+)h old/)[1]);
+    assert.ok(reported < 12, `grace message reported ${reported}h, which reads as already stale`);
+  }
+});
+
+// The exact comparison must not drift the other way either: a hair PAST 12h is
+// stale, even though it truncates to "12h" in the message.
+test("change request 12h01m old → CLOSE", () => {
+  const pr = forkPR({ reviews: [maintReview("CHANGES_REQUESTED", hoursAgo(12 + 1 / 60))] });
+  assert.equal(decide(pr, NOW).shouldClose, true);
+});
+
 // ---- Review ordering / decisional state --------------------------------------
 
 test("changes requested AFTER an earlier approval → CLOSE when stale", () => {


### PR DESCRIPTION
Closes #2027.

The 12h grace window for an external PR with an unanswered change request
was enforced against `hoursBetween(...)`, which rounds to tenths of an
hour:

    const ageHours = hoursBetween(reviewMs, nowMs);
    if (ageHours < STALE_HOURS) { ... }

A change request aged [11.95h, 12h) rounds to 12.0, which is not < 12, so
the PR was closed up to ~3 minutes before its grace window was actually
up. Immaterial in effect — it can never pick a wrong target, only clip the
tail of a window — but the threshold we publish should be the threshold we
enforce.

The decision now compares exact milliseconds. `hoursBetween` stays, for
the log and reason lines only.

It also now truncates rather than rounds, because rounding made the grace
message argue with itself: at 11h57m it read "only 12h old (< 12h grace)",
quoting an age that is not less than the threshold it was granting grace
against. Truncation makes the reported number a lower bound on the real
age, so a message granting grace can never quote an age at or past the
threshold. The three call sites are all descriptive, and none can see a
negative duration (contributor responses are filtered to strictly after
the review; `nowMs` is always later).

## Verification

Watched the new tests fail on the old code and pass on the new (the JS
tests run in pr.yml's Lint job, so they gate):

  - 11h57m → KEEP — fails on old code, which closes it. This is the
    reported bug.
  - the grace message never reports an age >= the threshold — fails on old
    code at 11h57m / 11.99h / 11.999h.
  - 12h01m → CLOSE — passes both ways. Not a repro; it pins that the exact
    comparison did not drift the window the other way.

The existing boundary test (exactly 12h → CLOSE, inclusive) still passes,
so the fix moved the tail of the window without moving the boundary
itself. Full file: 24 tests, all green.

Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>


🤖 Generated with [Claude Code](https://claude.com/claude-code)
