### PR TITLE
docs: point four stale doc-comment test references at the real tests (#2018)

### DIFF
--- a/app/layout_cutover_test.go
+++ b/app/layout_cutover_test.go
@@ -157,14 +157,12 @@ func TestLayoutCutover_AutomationsFocusConsumesHiddenPaneVerbs(t *testing.T) {
 		"hidden s must not focus the existing workspace pane")
 }
 
-// TestLayoutCutover_EnterOpensTasksOverlay: Enter on the focused in-rail
-// section opens the task manager as a centered modal (#1096 play-test fix 1),
-// preselecting the section cursor's task; Esc closes it and saving runs.
-// TestLayoutCutover_EnterOpensTaskInEditMode is the #1249 guard: acting on a
-// task once (Enter on the section cursor's task) drops straight into that
-// task's editable config form — no second keypress to leave the list. Esc
-// steps back out of the form to the list (overlay still open), and a second
-// Esc closes the overlay.
+// TestLayoutCutover_EnterOpensTaskInEditMode covers the whole Enter gesture on
+// the focused in-rail section: it opens the task manager as a centered modal
+// (#1096 play-test fix 1) preselecting the section cursor's task, and — the
+// #1249 guard — acting on a task once drops straight into that task's editable
+// config form, with no second keypress to leave the list. Esc steps back out of
+// the form to the list (overlay still open), and a second Esc closes it.
 func TestLayoutCutover_EnterOpensTaskInEditMode(t *testing.T) {
 	h := newTestHome(t)
 	resizeHome(h, 100, 30)

--- a/app/pr_info_test.go
+++ b/app/pr_info_test.go
@@ -221,13 +221,17 @@ func TestPrInfoUpdatedMsg_Error_PreservesCacheAndDebounces(t *testing.T) {
 		"MarkPRInfoFetched should have bumped the fetch timestamp to prevent retry thrash")
 }
 
-// TestSelectionChanged_TriggersFetchForStaleSelectedInstance — verifies the
-// lazy-on-select wiring: landing on an instance whose PR info is stale (or
-// never fetched) schedules a fetch.
+// TestSelectionChanged_DoesNotRefetchFreshInstance pins the debounce half of the
+// lazy-on-select wiring: landing on an instance whose PR info is already fresh
+// must not schedule another `gh pr view`.
 //
-// We only assert the returned cmd is non-nil for a *stale* started instance;
-// asserting the cmd produces a prInfoUpdatedMsg would require a real `gh`
-// invocation, which is covered by the e2e layer.
+// It asserts on the instance's cached info and fetch timestamp rather than on the
+// returned cmd, because selectionChanged also dispatches an off-loop pane refresh
+// (#579) — the cmd is non-nil either way, so checking it would prove nothing.
+//
+// The other half (a stale instance DOES schedule a fetch, exactly once) is
+// covered against fetchPRInfoCmd directly by
+// TestFetchPRInfoCmd_MarksFetchAtKickoff_DebouncesConcurrentCalls below.
 func TestSelectionChanged_DoesNotRefetchFreshInstance(t *testing.T) {
 	h := newTestHome(t)
 	inst := newStartedInstance(t, "fresh")

--- a/config/manifest_value.go
+++ b/config/manifest_value.go
@@ -77,8 +77,19 @@ func CurrentValue(cfg *Config, key string) (string, bool) {
 // two. The TUI calls ManifestWithValues in-process; the daemon returns the same
 // slice from GetConfig and the web UI renders that. Neither surface holds a key
 // list, a type switch, or a copy of the defaults, so adding a key to
-// config_types.go reaches both without either UI being touched — which is what
-// TestBothEditorSurfacesRenderEveryManifestKey pins.
+// config_types.go reaches both without either UI being touched.
+//
+// No single test pins that end to end; one per link in the chain does:
+//   - TestManifestCoversEveryConfigKey (config) — every toml-tagged Config field
+//     has a manifest entry.
+//   - TestCurrentValueCoversEveryManifestKey (config) — every entry's Key
+//     resolves through the reflection walk both surfaces read values with, so an
+//     entry with a typo'd Key cannot render as "unknown" in both UIs.
+//   - TestConfigPaneRendersEveryManifestKey (ui) — the TUI editor renders every
+//     manifest key.
+//   - "the control for a key is decided by the manifest, so an unknown key still
+//     renders" (web/src/config.test.ts) — the web control is chosen from the
+//     entry's own description, so a key the bundle predates still renders.
 type ConfigEntry struct {
 	Key      string `json:"key"`
 	Type     string `json:"type"`

--- a/daemon/close_tab_test.go
+++ b/daemon/close_tab_test.go
@@ -539,12 +539,14 @@ func TestControlServer_CloseTab_GatedAndValidated(t *testing.T) {
 	}
 }
 
-// TestRPCClients_CloseTabAndSetPRInfo_RoundTrip drives the package-level client
-// funcs (daemon.CloseTab / daemon.SetPRInfo) through an in-process control
-// server bound on a temp-HOME socket — exercising the full client → RPC →
-// Manager → persist wire path. It is hermetic: the launch seam is stubbed so a
-// ping race can never fork the real daemon, and the socket lives under the test
-// temp HOME.
+// TestRPCClients_CloseTab_RoundTrip drives the package-level client func
+// (daemon.CloseTab) through an in-process control server bound on a temp-HOME
+// socket — exercising the full client → RPC → Manager → persist wire path. It is
+// hermetic: the launch seam is stubbed so a ping race can never fork the real
+// daemon, and the socket lives under the test temp HOME.
+//
+// SetPRInfo used to ride along here; see the note at the end of the body for
+// where its coverage moved.
 func TestRPCClients_CloseTab_RoundTrip(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
 

--- a/ui/preview_scroll_fallback_test.go
+++ b/ui/preview_scroll_fallback_test.go
@@ -23,7 +23,9 @@ import (
 // fallback entry point while in scroll mode and assert the fallback message
 // renders, scroll mode is exited, and the viewport content is cleared.
 //
-// Mirrors TestTerminalScroll* / the TerminalPane setFallbackState invariant.
+// Mirrors the TabPane twin of this invariant in terminal_test.go:
+// TestTabPaneShellFallbackResetsScrollMode and the TestTabPaneShellScrollMode*
+// cases.
 
 const staleScrollMarker = "STALE-SCROLL-VIEWPORT-CONTENT"
 


### PR DESCRIPTION
Closes #2018.

`ConfigEntry`'s doc comment credited the render-every-key property to
`TestBothEditorSurfacesRenderEveryManifestKey`, which does not exist. The
property is genuinely covered — this was a stale reference, not a coverage
gap — so the comment now names the tests that actually pin it, one per link
in the chain:

  - TestManifestCoversEveryConfigKey (config) — every toml-tagged Config
    field has a manifest entry.
  - TestCurrentValueCoversEveryManifestKey (config) — every entry's Key
    resolves through the reflection walk both surfaces read values with.
  - TestConfigPaneRendersEveryManifestKey (ui) — the TUI renders every key.
  - "the control for a key is decided by the manifest, so an unknown key
    still renders" (web/src/config.test.ts) — the web side.

## Adjacent sites

Audited every `Test*` identifier named in a Go comment against the set of
test functions actually defined in the tree. Most misses are deliberate
tombstones ("… removed — …", "used to be …"), which are correct as written
and left alone. Three were the same defect as #2018 — a doc comment whose
named test does not exist — and all three are the same shape: a header
glued to a function it no longer describes.

  - `app/pr_info_test.go` — the header named
    `TestSelectionChanged_TriggersFetchForStaleSelectedInstance` and
    described the STALE path, sitting above
    `TestSelectionChanged_DoesNotRefetchFreshInstance`, which tests the
    FRESH path. It was describing the opposite of the test it headed, and
    its last paragraph explained an assertion the function does not make.
    Rewritten for the real function, noting where the stale half is
    actually covered (against fetchPRInfoCmd directly).

  - `app/layout_cutover_test.go` — the header opened with
    `TestLayoutCutover_EnterOpensTasksOverlay` and then introduced a second
    test by name. The two were merged; the surviving function covers both
    behaviours. Collapsed to one header.

  - `daemon/close_tab_test.go` — named
    `TestRPCClients_CloseTabAndSetPRInfo_RoundTrip` and claimed to drive
    `daemon.SetPRInfo`, which moved onto the HTTP apiclient in #1592 Phase 2
    PR3. The body already carries an accurate note about where that coverage
    went; only the header was stale.

  - `ui/preview_scroll_fallback_test.go` — "Mirrors TestTerminalScroll*",
    a family that no longer exists under that name. Pointed at the real
    TabPane twin (`TestTabPaneShellFallbackResetsScrollMode` and the
    `TestTabPaneShellScrollMode*` cases).

Comments only — no test or production behaviour changes. Re-ran the audit
after the edits: the only remaining unresolved reference is
`teatest.TestModel`, a third-party type.

A lint for this class was considered and skipped: the tombstone comments
are legitimate and would need a phrasing convention to whitelist, which is
more machinery than a P3 nit warrants. Worth revisiting if it recurs.

Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>


🤖 Generated with [Claude Code](https://claude.com/claude-code)
