### PR TITLE
feat(tui): initial-prompt field in the create-session form (#1936)

### DIFF
--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -27,6 +27,7 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.state = stateDefault
 		m.namingInstance = nil
+		m.pendingPrompt = ""
 		// Menu.SetState rebuilds the options slice; call it synchronously
 		// on the event-loop goroutine rather than from a tea.Cmd closure
 		// that runs off-loop and races with home.View -> Menu.String.
@@ -90,6 +91,13 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// began — re-raising it here would be a second BeginCreate from OpCreating,
 		// an illegal edge the chokepoint rejects (#1350). Set it exactly once.
 		instance.Program = m.pendingProgram
+		// Read the pending prompt here, on the event loop, and clear it with the
+		// rest of the naming state: the cmd below runs off-loop, so reading
+		// m.pendingPrompt from inside the closure would race the next create's
+		// reset. TrimSpace so a field holding only whitespace is "no prompt"
+		// rather than a stray newline delivered to the agent.
+		prompt := strings.TrimSpace(m.pendingPrompt)
+		m.pendingPrompt = ""
 		m.namingInstance = nil
 		m.state = stateDefault
 		m.menu.SetState(ui.StateDefault)
@@ -101,9 +109,15 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		start := startSessionThroughDaemon
 		startCmd := func() tea.Msg {
 			req := sessionStartRequest{
-				Title:       instance.Title,
-				RepoPath:    instance.Path,
-				Program:     instance.Program,
+				Title:    instance.Title,
+				RepoPath: instance.Path,
+				Program:  instance.Program,
+				// The initial prompt typed into the naming form's shift+tab
+				// field (#1936). session_control.go forwards it to the daemon,
+				// which delivers it once the agent is ready — the same path
+				// `af sessions create --prompt` takes. Empty means "no prompt",
+				// exactly as before this field existed.
+				Prompt:      prompt,
 				AutoYes:     m.autoYes,
 				ForceRemote: instance.Capabilities().Workspace == session.WorkspaceRemote,
 			}
@@ -131,6 +145,13 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.selectionOverlay.SetSelectedIndex(selectedIdx)
 		m.layoutSelectionOverlay()
 		m.state = stateSelectProgram
+		return m, nil
+	case tea.KeyShiftTab:
+		// Open the initial-prompt field, seeded with whatever is already
+		// pending so reopening it is an edit, not a retype (#1936).
+		m.promptOverlay = overlay.NewPromptOverlay("Initial prompt", m.pendingPrompt)
+		m.layoutPromptOverlay()
+		m.state = statePromptInput
 		return m, nil
 	case tea.KeyRunes:
 		newTitle := instance.Title + string(msg.Runes)
@@ -163,6 +184,7 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			log.ErrorLog.Printf("failed to clean up instance on cancel: %v", err)
 		}
 		m.namingInstance = nil
+		m.pendingPrompt = ""
 		m.state = stateDefault
 		cmd := m.selectionChanged()
 
@@ -180,6 +202,10 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 // If remote is true, the instance is forced to use the remote hook backend.
 func (m *home) startNewInstance(remote bool) (tea.Model, tea.Cmd) {
 	m.pendingProgram = m.program
+	// Every create starts with an empty prompt field. The cancel paths clear it
+	// too, but this is the authoritative reset: it also covers a create that
+	// ended by any route other than Enter/Esc/ctrl+c.
+	m.pendingPrompt = ""
 	if m.pendingProgram == "" && m.appConfig != nil {
 		m.pendingProgram = m.appConfig.DefaultProgram
 	}
@@ -214,6 +240,7 @@ func (m *home) startNewInstance(remote bool) (tea.Model, tea.Cmd) {
 	m.sidebar.SelectInstance(instance)
 	m.namingInstance = instance
 	m.state = stateNew
+	m.menu.SetNamingHasPrompt(false)
 	m.menu.SetState(ui.StateNewInstance)
 	return m, nil
 }

--- a/app/handle_input_test.go
+++ b/app/handle_input_test.go
@@ -86,10 +86,11 @@ func TestHandleMenuHighlightingDoesNotInterceptNamingText(t *testing.T) {
 }
 
 // TestHandleMenuHighlightingNewInstanceActions is the regression guard for
-// issue #691/#1413: pressing Enter, Tab, or Esc while naming a new instance must drive the
-// menu highlight animation. The bug (commit f294e5b) folded stateNew into the
-// early-return filter, which made the Enter→KeySubmitName / Tab→KeyChangeProgram
-// remapping — and thus the highlight render path — unreachable.
+// issue #691/#1413: pressing Enter, Tab, Shift-Tab, or Esc while naming a new
+// instance must drive the menu highlight animation. The bug (commit f294e5b)
+// folded stateNew into the early-return filter, which made the
+// Enter→KeySubmitName / Tab→KeyChangeProgram remapping — and thus the highlight
+// render path — unreachable.
 func TestHandleMenuHighlightingNewInstanceActions(t *testing.T) {
 	// Force a real color profile so lipgloss emits the underline escape that
 	// signals a highlighted menu option; the Ascii profile used by default in
@@ -109,6 +110,9 @@ func TestHandleMenuHighlightingNewInstanceActions(t *testing.T) {
 	}{
 		{"enter", tea.KeyMsg{Type: tea.KeyEnter}},
 		{"tab", tea.KeyMsg{Type: tea.KeyTab}},
+		// shift+tab opens the initial-prompt field (#1936) — the naming form's
+		// third action key, and so subject to the same #691 filter.
+		{"shift+tab", tea.KeyMsg{Type: tea.KeyShiftTab}},
 		{"esc", tea.KeyMsg{Type: tea.KeyEsc}},
 	}
 

--- a/app/handle_overlay.go
+++ b/app/handle_overlay.go
@@ -3,6 +3,7 @@ package app
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/keys"
@@ -28,6 +29,31 @@ func (m *home) handleStateSelectProgram(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.menu.SetState(ui.StateNewInstance)
 		return m, nil
 	}
+	return m, nil
+}
+
+// handleStateInitialPrompt handles key events while the naming form's
+// initial-prompt field is open (#1936). Closing keeps the text — the field is
+// part of the create form, so Tab/Esc back out of it rather than discarding it
+// — and returns to naming, mirroring handleStateSelectProgram. ctrl+c is the
+// exception: it means "cancel this create", so it is replayed into the naming
+// handler, which owns the kill-and-clean-up path (#717).
+func (m *home) handleStateInitialPrompt(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	shouldClose := m.promptOverlay.HandleKeyPress(msg)
+	if !shouldClose {
+		return m, nil
+	}
+	canceled := m.promptOverlay.IsCanceled()
+	if !canceled {
+		m.pendingPrompt = m.promptOverlay.Value()
+	}
+	m.promptOverlay = nil
+	m.state = stateNew
+	if canceled {
+		return m.handleStateNew(tea.KeyMsg{Type: tea.KeyCtrlC})
+	}
+	m.menu.SetNamingHasPrompt(strings.TrimSpace(m.pendingPrompt) != "")
+	m.menu.SetState(ui.StateNewInstance)
 	return m, nil
 }
 

--- a/app/home_model.go
+++ b/app/home_model.go
@@ -41,6 +41,10 @@ const (
 	stateSwitchProject
 	// stateSelectProgram is the state when the user is selecting a program during naming.
 	stateSelectProgram
+	// statePromptInput is the state when the initial-prompt field of the naming
+	// form is open (#1936). Like stateSelectProgram it is a sub-state of
+	// stateNew: closing it returns to naming rather than to stateDefault.
+	statePromptInput
 	// stateHooks is the state when the post-worktree hooks editor overlay is
 	// open (#1024 PR 4: hooks lost their persistent sidebar slot and are
 	// hosted as a modal overlay instead).
@@ -367,6 +371,15 @@ type home struct {
 	projectPickerOverlay *overlay.ProjectPickerOverlay
 	// pendingProgram tracks the program selected during new instance naming
 	pendingProgram string
+	// promptOverlay handles initial-prompt entry during new-instance naming
+	// (#1936).
+	promptOverlay *overlay.PromptOverlay
+	// pendingPrompt tracks the initial prompt typed during new instance naming.
+	// It is the value handleStateNew puts on sessionStartRequest.Prompt, which
+	// the daemon delivers to the agent once it is ready — the same field
+	// `af sessions create --prompt` fills. Reset by startNewInstance so a
+	// cancelled create can never leak its prompt into the next one.
+	pendingPrompt string
 
 	// attached is set while the user is inside an attached tmux session.
 	// While true, periodic background work that hits the shared tmux server

--- a/app/home_update.go
+++ b/app/home_update.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -420,6 +421,13 @@ func (m *home) handleMenuHighlighting(msg tea.KeyMsg) (cmd tea.Cmd, returnEarly 
 			name = keys.KeySubmitName
 		case "tab":
 			name = keys.KeyChangeProgram
+		case "shift+tab":
+			// The initial-prompt hint (#1936) swaps its verb once a prompt is
+			// attached, so highlight whichever variant the bar is showing.
+			name = keys.KeySetPrompt
+			if strings.TrimSpace(m.pendingPrompt) != "" {
+				name = keys.KeyEditPrompt
+			}
 		case "esc":
 			name = keys.KeyCancelName
 		default:
@@ -495,6 +503,8 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 		return m.handleStateSwitchProject(msg)
 	case stateSelectProgram:
 		return m.handleStateSelectProgram(msg)
+	case statePromptInput:
+		return m.handleStateInitialPrompt(msg)
 	case stateHooks:
 		return m.handleStateHooks(msg)
 	case stateTasks:

--- a/app/home_view.go
+++ b/app/home_view.go
@@ -200,6 +200,12 @@ func (m *home) View() string {
 		fg := m.selectionOverlay.Render()
 		m.selectionOverlay.RegisterZones(m.zones, overlayOrigin(fg, mainView))
 		return overlay.PlaceOverlay(0, 0, fg, mainView, true)
+	} else if m.state == statePromptInput {
+		if m.promptOverlay == nil {
+			log.ErrorLog.Printf("prompt overlay is nil")
+			return mainView
+		}
+		return overlay.PlaceOverlay(0, 0, m.promptOverlay.Render(), mainView, true)
 	} else if m.state == stateHooks {
 		return overlay.PlaceOverlay(0, 0, m.renderHooksOverlay(), mainView, true)
 	} else if m.state == stateTasks {

--- a/app/initial_prompt_test.go
+++ b/app/initial_prompt_test.go
@@ -1,0 +1,372 @@
+package app
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/ui"
+)
+
+// #1936: the TUI's create flow could not send an initial prompt. The field
+// existed on sessionStartRequest and was plumbed to the daemon
+// (session_control.go), but the naming form — the only place in app/ that
+// builds that request — never populated it, so it was dead from the TUI while
+// `af sessions create --prompt` and the web modal both had it.
+//
+// These tests drive the REAL key path (handleKeyPress, not the sub-handlers)
+// so they cover the state dispatch and the menu-highlight hop a key must
+// survive during naming — a key that opens the field in handleStateNew but is
+// swallowed on the way there is exactly the bug shape this flow invites. The
+// highlight RENDER for the new hint is pinned separately, in
+// TestNamingKeysHighlightMenu (handle_input_test.go).
+
+// pressFormKey feeds msg through handleKeyPress the way the Bubble Tea event loop
+// does, including the re-emit hop: during naming, handleMenuHighlighting
+// intercepts the form's action keys, fires the highlight, and re-emits the key
+// as a message. Replaying that hop here is what makes the tests cover the
+// highlight path rather than route around it. Returns every non-key message the
+// press produced.
+func pressFormKey(t *testing.T, h *home, msg tea.KeyMsg) []tea.Msg {
+	t.Helper()
+	_, cmd := h.handleKeyPress(msg)
+	if cmd == nil {
+		return nil
+	}
+	var out []tea.Msg
+	for _, produced := range drainCmd(t, cmd, time.Second) {
+		km, ok := produced.(tea.KeyMsg)
+		if !ok {
+			out = append(out, produced)
+			continue
+		}
+		if _, replayCmd := h.handleKeyPress(km); replayCmd != nil {
+			out = append(out, drainCmd(t, replayCmd, time.Second)...)
+		}
+	}
+	return out
+}
+
+func typeRunes(t *testing.T, h *home, s string) {
+	t.Helper()
+	for _, r := range s {
+		if r == ' ' {
+			// Bubble Tea overrides the type for a space but still carries the
+			// rune (key.go: "If it's a space, override the type with KeySpace
+			// (but still include the rune)"). Both halves matter: the naming
+			// form's title branch switches on the TYPE, the prompt field's
+			// textarea reads the RUNE.
+			pressFormKey(t, h, tea.KeyMsg{Type: tea.KeySpace, Runes: []rune{' '}})
+			continue
+		}
+		pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+}
+
+// startNaming puts h in the naming state with a titled instance, the shape
+// startNewInstance leaves behind, without needing a real repo on disk.
+func startNaming(t *testing.T, h *home, title string) *session.Instance {
+	t.Helper()
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title:   title,
+		Path:    t.TempDir(),
+		Program: "claude",
+	})
+	require.NoError(t, err)
+	h.store.AddInstance(inst)
+	h.namingInstance = inst
+	h.pendingProgram = "claude"
+	h.state = stateNew
+	h.menu.SetState(ui.StateNewInstance)
+	return inst
+}
+
+// recordStartRequest captures the sessionStartRequest the naming form submits.
+func recordStartRequest(t *testing.T) *sessionStartRequest {
+	t.Helper()
+	var got sessionStartRequest
+	t.Cleanup(SetSessionStarterForTest(func(inst *session.Instance, req sessionStartRequest) (*session.Instance, error) {
+		got = req
+		return inst, nil
+	}))
+	return &got
+}
+
+// TestNamingFormPromptReachesSessionStartRequest is the #1936 regression guard:
+// a prompt typed into the naming form's initial-prompt field must arrive on the
+// request the TUI hands the daemon. Before the fix this asserted "" — the field
+// had no way to be populated at all.
+func TestNamingFormPromptReachesSessionStartRequest(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(120, 1)
+	got := recordStartRequest(t)
+	startNaming(t, h, "fix-flaky-test")
+
+	// Open the initial-prompt field, type a prompt, close it, submit the form.
+	pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyShiftTab})
+	require.Equal(t, statePromptInput, h.state,
+		"shift+tab during naming must open the initial-prompt field")
+	require.NotNil(t, h.promptOverlay)
+
+	const prompt = "fix the flaky test in session/tmux"
+	typeRunes(t, h, prompt)
+	pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyTab})
+	require.Equal(t, stateNew, h.state, "tab must close the field back to naming")
+
+	pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.Equal(t, prompt, got.Prompt,
+		"the typed prompt must ride the sessionStartRequest to the daemon")
+	// Guard the rest of the request too: a change that populated Prompt by
+	// rebuilding the struct must not drop a sibling field on the way.
+	assert.Equal(t, "fix-flaky-test", got.Title)
+	assert.Equal(t, "claude", got.Program)
+}
+
+// TestNamingFormWithoutPromptSendsEmpty pins the unchanged default: a user who
+// never opens the field submits exactly what they submitted before #1936. This
+// is the half that keeps "populate Prompt" from becoming "always send
+// something".
+func TestNamingFormWithoutPromptSendsEmpty(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(120, 1)
+	got := recordStartRequest(t)
+	startNaming(t, h, "no-prompt")
+
+	pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.Empty(t, got.Prompt, "an untouched prompt field must send no prompt")
+	assert.Equal(t, "no-prompt", got.Title)
+}
+
+// TestInitialPromptFieldKeepsEnterForNewlines pins the property that made the
+// field textarea-backed instead of a hand-rolled string: Enter is a newline,
+// not a submit. A hand-rolled buffer would read a pasted newline as submit and
+// silently drop the rest of a multi-line prompt.
+func TestInitialPromptFieldKeepsEnterForNewlines(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(120, 1)
+	got := recordStartRequest(t)
+	startNaming(t, h, "multiline")
+
+	pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyShiftTab})
+	typeRunes(t, h, "first line")
+	pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyEnter})
+	require.Equal(t, statePromptInput, h.state,
+		"enter inside the prompt field must insert a newline, not close the field")
+	typeRunes(t, h, "second line")
+	pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyTab})
+	pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.Equal(t, "first line\nsecond line", got.Prompt,
+		"both lines of a multi-line prompt must survive to the request")
+}
+
+// TestInitialPromptFieldSurvivesAMultiLinePaste is the other half of the
+// textarea rationale, and the one a future refactor is most likely to break.
+// Bubble Tea delivers a bracketed paste as ONE KeyRunes message whose runes are
+// "not to be interpreted further" (key_sequences.go detectBracketedPaste) — so
+// the tabs and newlines inside a pasted prompt must land as text. A handler
+// that switched on the key STRING, or grew a KeyRunes case of its own, would
+// close the field on the pasted tab and spray the remainder into the title.
+func TestInitialPromptFieldSurvivesAMultiLinePaste(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(120, 1)
+	got := recordStartRequest(t)
+	inst := startNaming(t, h, "pasted")
+
+	const pasted = "refactor this:\n\tif err != nil {\n\t\treturn err\n\t}"
+	pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyShiftTab})
+	pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyRunes, Paste: true, Runes: []rune(pasted)})
+
+	require.Equal(t, statePromptInput, h.state,
+		"a pasted tab must not close the field")
+	require.Equal(t, "pasted", inst.Title,
+		"no part of the paste may leak into the title")
+
+	pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyTab})
+	pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyEnter})
+
+	// Line structure survives; the tabs arrive as four spaces each. That is
+	// bubbles' textarea sanitizing its input (runeutil.NewSanitizer defaults to
+	// ReplaceTabs("    ") and the sanitizer is unexported in v0.20, so it is not
+	// configurable), and it is exactly what the task form's prompt field already
+	// does. Indentation is preserved, no text is dropped, and nothing reaches
+	// the title — the properties that matter for a pasted prompt.
+	assert.Equal(t, "refactor this:\n    if err != nil {\n        return err\n    }", got.Prompt,
+		"every line of the paste must reach the request, tabs widened to spaces")
+	assert.Equal(t, strings.Count(pasted, "\n"), strings.Count(got.Prompt, "\n"),
+		"line structure must survive the paste")
+}
+
+// TestInitialPromptFieldReopensWithItsText pins that the field is an editable
+// value rather than a write-once box: reopening shows what is already attached.
+func TestInitialPromptFieldReopensWithItsText(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(120, 1)
+	got := recordStartRequest(t)
+	startNaming(t, h, "reopen")
+
+	pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyShiftTab})
+	typeRunes(t, h, "review the diff")
+	pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyEsc})
+	require.Equal(t, stateNew, h.state, "esc must back out of the field, not out of naming")
+	require.NotNil(t, h.namingInstance, "esc in the prompt field must not cancel the create")
+
+	pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyShiftTab})
+	require.NotNil(t, h.promptOverlay)
+	require.Equal(t, "review the diff", h.promptOverlay.Value(),
+		"reopening the field must show the prompt already typed")
+
+	typeRunes(t, h, " carefully")
+	pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyTab})
+	pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.Equal(t, "review the diff carefully", got.Prompt)
+}
+
+// TestInitialPromptDoesNotLeakIntoNextCreate is the leak guard: pendingPrompt
+// is home-scoped state that outlives one create, so a cancelled or submitted
+// create must not hand its prompt to the next session the user makes.
+func TestInitialPromptDoesNotLeakIntoNextCreate(t *testing.T) {
+	cases := []struct {
+		name string
+		end  tea.KeyMsg
+	}{
+		{"submitted", tea.KeyMsg{Type: tea.KeyEnter}},
+		{"cancelled with esc", tea.KeyMsg{Type: tea.KeyEsc}},
+		{"cancelled with ctrl+c", tea.KeyMsg{Type: tea.KeyCtrlC}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHome(t)
+			h.errBox.SetSize(120, 1)
+			got := recordStartRequest(t)
+
+			startNaming(t, h, "first")
+			pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyShiftTab})
+			typeRunes(t, h, "prompt for the first session")
+			pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyTab})
+			pressFormKey(t, h, tc.end)
+			require.Empty(t, h.pendingPrompt,
+				"leaving the naming form must clear the pending prompt")
+
+			// The next create submits without ever opening the field.
+			*got = sessionStartRequest{}
+			startNaming(t, h, "second")
+			pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyEnter})
+
+			assert.Empty(t, got.Prompt,
+				"the previous create's prompt must not ride the next session's request")
+			assert.Equal(t, "second", got.Title)
+		})
+	}
+}
+
+// TestStartNewInstanceResetsThePromptField covers the authoritative half of the
+// leak guard: whatever route the previous create exited by, beginning a new one
+// starts from an empty prompt field. The per-exit clears above are defence in
+// depth on top of this.
+func TestStartNewInstanceResetsThePromptField(t *testing.T) {
+	repoDir := setupRealRepo(t)
+	t.Chdir(repoDir)
+
+	h := newTestHome(t)
+	h.errBox.SetSize(120, 1)
+	h.pendingPrompt = "a prompt stranded by some earlier create"
+
+	model, cmd := h.startNewInstance(false)
+	require.Same(t, h, model)
+	require.Nil(t, cmd)
+	require.Equal(t, stateNew, h.state)
+
+	assert.Empty(t, h.pendingPrompt,
+		"beginning a create must start with an empty initial-prompt field")
+}
+
+// TestInitialPromptCtrlCCancelsTheCreate pins that ctrl+c keeps meaning "cancel
+// this create" inside the field, rather than being a dead key behind a modal.
+func TestInitialPromptCtrlCCancelsTheCreate(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(120, 1)
+	startNaming(t, h, "abandoned")
+
+	pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyShiftTab})
+	typeRunes(t, h, "never mind")
+	pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyCtrlC})
+
+	assert.Equal(t, stateDefault, h.state, "ctrl+c must leave the naming form entirely")
+	assert.Nil(t, h.namingInstance, "ctrl+c must cancel the pending create")
+	assert.Nil(t, h.promptOverlay)
+}
+
+// TestWhitespaceOnlyPromptSendsNoPrompt mirrors the #973 title rule: a field
+// holding only whitespace is empty, not a prompt. Without this a stray space or
+// newline would be delivered to the agent as its first instruction.
+func TestWhitespaceOnlyPromptSendsNoPrompt(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(120, 1)
+	got := recordStartRequest(t)
+	startNaming(t, h, "blank-prompt")
+
+	pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyShiftTab})
+	typeRunes(t, h, "  ")
+	pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyEnter})
+	pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyTab})
+	pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.Empty(t, got.Prompt, "a whitespace-only field must send no prompt")
+}
+
+// TestNamingMenuAdvertisesThePromptField covers discoverability: the field is
+// behind a modal, so the status bar is the only thing that can tell a user it
+// exists — and the only confirmation that a prompt is attached before they
+// press Enter.
+func TestNamingMenuAdvertisesThePromptField(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(200, 1)
+	h.menu.SetSize(200, 3)
+	startNaming(t, h, "hints")
+
+	require.Contains(t, h.menu.String(), "initial prompt",
+		"the naming form must advertise its initial-prompt field")
+	require.NotContains(t, h.menu.String(), "initial prompt ✓",
+		"precondition: no prompt attached yet")
+
+	pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyShiftTab})
+	typeRunes(t, h, "do the thing")
+	pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyTab})
+
+	assert.Contains(t, h.menu.String(), "initial prompt ✓",
+		"the hint must confirm a prompt is attached once the field holds text")
+}
+
+// TestPromptOverlayRendersInsideTheTerminal guards the #1998 overlay class: an
+// overlay whose content is wider or taller than the terminal spills raw text
+// over the frame. The field takes free-form prose, so it is a natural candidate.
+func TestPromptOverlayRendersInsideTheTerminal(t *testing.T) {
+	for _, size := range []struct{ w, h int }{{120, 40}, {80, 24}, {60, 15}} {
+		h := newTestHome(t)
+		h.errBox.SetSize(size.w, 1)
+		startNaming(t, h, "sized")
+		h.termWidth, h.termHeight = size.w, size.h
+
+		pressFormKey(t, h, tea.KeyMsg{Type: tea.KeyShiftTab})
+		h.layoutPromptOverlay()
+		typeRunes(t, h, strings.Repeat("a very long prompt that keeps going ", 8))
+
+		rendered := h.promptOverlay.Render()
+		for i, line := range strings.Split(rendered, "\n") {
+			require.LessOrEqual(t, lipgloss.Width(line), size.w,
+				"overlay line %d overflows a %dx%d terminal", i, size.w, size.h)
+		}
+		require.LessOrEqual(t, strings.Count(rendered, "\n")+1, size.h,
+			"overlay is taller than a %dx%d terminal", size.w, size.h)
+	}
+}

--- a/app/render.go
+++ b/app/render.go
@@ -86,6 +86,7 @@ func (m *home) renderFittedPaneOverlay(r layout.Rect, setSize func(int, int), re
 func (m *home) layoutModalOverlays() {
 	m.layoutTextOverlay()
 	m.layoutSelectionOverlay()
+	m.layoutPromptOverlay()
 	m.layoutConfirmationOverlay()
 	m.layoutSearchOverlay()
 	m.layoutProjectPickerOverlay()
@@ -98,6 +99,17 @@ func (m *home) layoutSelectionOverlay() {
 	}
 	m.selectionOverlay.SetWidth(int(float32(m.termWidth) * 0.6))
 	m.selectionOverlay.SetMaxSize(m.termWidth, m.termHeight)
+}
+
+// layoutPromptOverlay sizes the initial-prompt field (#1936). It asks for the
+// same 60% of the terminal the program picker does, so the two fields of the
+// naming form open to the same box.
+func (m *home) layoutPromptOverlay() {
+	if m.promptOverlay == nil {
+		return
+	}
+	m.promptOverlay.SetWidth(int(float32(m.termWidth) * 0.6))
+	m.promptOverlay.SetMaxSize(m.termWidth, m.termHeight)
 }
 
 func (m *home) layoutConfirmationOverlay() {

--- a/docs/tui-manual-testing.md
+++ b/docs/tui-manual-testing.md
@@ -100,6 +100,12 @@ it.
 | `Ctrl-P` | switch project | | `Ctrl-U`/`Ctrl-D` | scroll tab |
 | `Ctrl-W` | detach (full-screen) |
 
+While naming a new instance the form owns the keyboard and its keys are fixed:
+`Tab` opens the program picker, `Shift-Tab` opens the initial-prompt field
+(#1936), `Enter` submits, `Esc`/`Ctrl-C` cancel the create. Inside the prompt
+field `Enter` is a newline — `Tab`/`Esc` close it keeping the text, `Ctrl-C`
+cancels the whole create.
+
 `Enter`, `Tab`, `Shift-Tab`, `Esc`, `Ctrl-]`, and `1`–`9` are **reserved** and
 cannot be rebound (`[keys]` config). `Ctrl-W` is the configurable detach key
 (`detach_keys`); the driver reads it from `AF_DRIVER_DETACH_KEY`.
@@ -270,6 +276,37 @@ make tui-driver-selftest
 The self-test is the baseline gate for *any* PR that touches startup, the
 sidebar/tree, panes, interactive mode, or attach/detach. If it isn't green,
 stop.
+
+### Create-form changes (the #1936 class)
+
+The naming form is a multi-field form behind a single row, so gate every field
+plus the paths that leave it:
+
+```bash
+af_boot
+af_ensure_nav; af_focus_tree
+af_send n; af_wait_for 'submit name'
+af_wait_for 'initial prompt'                  # the field is advertised
+af_send Tab; af_wait_for 'Select Program'     # sibling field still opens
+af_send Escape; af_wait_for 'submit name'
+af_send BTab; af_wait_for 'enter newline'     # shift+tab opens the field
+af_send_literal 'first line'; af_send Enter   # enter is a NEWLINE here…
+af_wait_for 'enter newline'                   # …so the field is still open
+af_send Tab; af_wait_for 'initial prompt ✓'   # closes, hint confirms it stuck
+af_send BTab; af_wait_for 'first line'        # reopening shows the text
+af_send Escape                                # esc keeps the text (field, not dialog)
+af_wait_for 'initial prompt ✓'
+```
+
+`enter newline` is the overlay's own hint row, used as the marker rather than
+its `Initial prompt` title: the status-bar hint underneath says `initial
+prompt` too, so the title alone cannot tell "field open" from "field
+advertised".
+
+Then finish the create by hand and confirm the agent receives the prompt as its
+first input — that round trip is the whole point of the feature and no marker
+can stand in for it. Re-run `n` afterwards and confirm the hint is back to
+`initial prompt` with no `✓`: a prompt must never leak into the next session.
 
 ### Tree / selection / focus changes (the #1156, #1084 class)
 

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -120,6 +120,22 @@ const (
 	// iota-based, so inserting a name mid-block silently renumbers every
 	// KeyName after it. New names go here.
 	KeyConfigAgent
+
+	// KeySetPrompt and KeyEditPrompt are the two faces of the same display-only
+	// hint: the initial-prompt field of the naming form (#1936). The naming
+	// menu shows KeySetPrompt while the pending prompt is empty and
+	// KeyEditPrompt once it holds text, so the status bar is the confirmation
+	// that a prompt is attached — the overlay is modal, so there is nowhere
+	// else for that feedback to live. Same pattern as the archive/restore
+	// verb swap in Menu.addInstanceOptions.
+	//
+	// shift+tab rather than a mnemonic like ctrl+p: ctrl+p is a REBINDABLE
+	// global (switch_project), so hardcoding it here would silently drift the
+	// day a user rebinds that action. shift+tab is a reserved structural key
+	// config can never claim, it is a no-op in the naming flow today, and it
+	// pairs with the tab that opens the program field.
+	KeySetPrompt
+	KeyEditPrompt
 )
 
 // spec is one action's canonical binding definition: its default keys, help
@@ -205,6 +221,8 @@ var specs = []spec{
 	// -- Special keybindings --
 	{name: KeySubmitName, keys: []string{"enter"}, helpLabel: "enter", desc: "submit name"},
 	{name: KeyChangeProgram, keys: []string{"tab"}, desc: "change program"},
+	{name: KeySetPrompt, keys: []string{"shift+tab"}, desc: "initial prompt"},
+	{name: KeyEditPrompt, keys: []string{"shift+tab"}, desc: "initial prompt ✓"},
 	{name: KeyCancelName, keys: []string{"esc"}, desc: "cancel"},
 }
 

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -75,8 +75,8 @@
       "id": "session.create.opt.prompt",
       "title": "Send an initial prompt with the new session",
       "tui": {
-        "status": "no",
-        "pointer": "app/handle_input.go:103-109 builds sessionStartRequest without Prompt"
+        "status": "yes",
+        "pointer": "shift+tab during naming -> app/handle_overlay.go handleStateInitialPrompt -> app/handle_input.go sessionStartRequest.Prompt"
       },
       "web": {
         "status": "yes",
@@ -86,9 +86,9 @@
         "status": "yes",
         "pointer": "api/api.go:585 --prompt"
       },
-      "verdict": "real-gap",
+      "verdict": "parity",
       "issue": "#1936",
-      "notes": "Inverted gap: the TUI is the surface that lacks this. sessionStartRequest.Prompt exists and is plumbed to the daemon (app/session_control.go:106) but its only construction site never populates it, so the field is dead from the TUI."
+      "notes": "Closed by #1936: the naming form grew an initial-prompt field on shift+tab (a textarea overlay, so multi-line prompts and pastes survive), populating the sessionStartRequest.Prompt that was already plumbed to the daemon. Was an inverted gap — the TUI was the short surface, with the field dead at its only construction site."
     },
     {
       "id": "session.create.opt.autoyes",
@@ -1333,6 +1333,8 @@
       "fixed:delete project": "project.delete",
       "fixed:focus": "tui.navigation",
       "fixed:focus prev": "tui.navigation",
+      "fixed:initial prompt": "session.create.opt.prompt",
+      "fixed:initial prompt ✓": "session.create.opt.prompt",
       "fixed:interact": "session.send-prompt",
       "fixed:jump": "tui.panes",
       "fixed:manage": "task.list",

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -70,6 +70,11 @@ type Menu struct {
 	// clickable key zones while the gesture is in flight.
 	statusText string
 
+	// namingHasPrompt is true while the session being named carries a non-empty
+	// initial prompt (#1936), which swaps the naming form's prompt hint to its
+	// "✓" variant. Only meaningful in StateNewInstance.
+	namingHasPrompt bool
+
 	// keyDown is the key which is pressed. The default is -1.
 	keyDown keys.KeyName
 
@@ -82,7 +87,14 @@ type Menu struct {
 }
 
 var defaultMenuOptions = []keys.KeyName{keys.KeyNew, keys.KeyNewRemote, keys.KeySearch, keys.KeyHelp, keys.KeyQuit}
-var newInstanceMenuOptions = []keys.KeyName{keys.KeySubmitName, keys.KeyChangeProgram, keys.KeyCancelName}
+
+// newInstanceMenuOptions are the naming-form hints. The third slot is the
+// initial-prompt field (#1936) and swaps its verb once a prompt is typed —
+// newInstanceOptions picks the variant, mirroring the archive/restore swap in
+// addInstanceOptions.
+var newInstanceMenuOptions = []keys.KeyName{
+	keys.KeySubmitName, keys.KeyChangeProgram, keys.KeySetPrompt, keys.KeyCancelName,
+}
 
 // automationsMenuOptions are the status-bar hints while the in-rail
 // automations section has focus: Enter opens the task manager overlay (which
@@ -249,11 +261,39 @@ func (m *Menu) updateOptions() {
 			}
 		}
 	case StateNewInstance:
-		m.options = newInstanceMenuOptions
+		m.options = m.newInstanceOptions()
 		m.groups = []menuGroup{
 			{start: 0, end: len(newInstanceMenuOptions), isAction: true},
 		}
 	}
+}
+
+// newInstanceOptions returns the naming-form hints with the initial-prompt slot
+// reading "initial prompt ✓" once the pending prompt holds text. The overlay
+// that edits it is modal, so the status bar is the only surface that can tell
+// the user a prompt is attached before they press Enter (#1936).
+func (m *Menu) newInstanceOptions() []keys.KeyName {
+	if !m.namingHasPrompt {
+		return newInstanceMenuOptions
+	}
+	opts := make([]keys.KeyName, len(newInstanceMenuOptions))
+	copy(opts, newInstanceMenuOptions)
+	for i, name := range opts {
+		if name == keys.KeySetPrompt {
+			opts[i] = keys.KeyEditPrompt
+		}
+	}
+	return opts
+}
+
+// SetNamingHasPrompt records whether the session being named carries a
+// non-empty initial prompt, and rebuilds the hints if that changed.
+func (m *Menu) SetNamingHasPrompt(has bool) {
+	if m.namingHasPrompt == has {
+		return
+	}
+	m.namingHasPrompt = has
+	m.updateOptions()
 }
 
 func (m *Menu) addInstanceOptions() {
@@ -412,8 +452,17 @@ func centerStart(box, content int) int {
 // help/quit are the global escape hatches, and `D kill` is the selected-
 // instance affordance the containerized TUI driver uses to distinguish a real
 // row cursor from the sticky single-instance display selection (#1174/#1422
-// redo). Naming-flow options are also absent because that row is short.
+// redo).
+//
+// The naming row used to be absent from this list because it was short. #1936
+// added its initial-prompt hint, taking it from ~62 to ~78 cells — wide enough
+// to overflow an 80-column bar once the bar has any padding, at which point the
+// clamp would cut `esc cancel` off the right edge. So the prompt hint leads the
+// list: it advertises an OPTIONAL field, and losing it costs a user far less
+// than losing the way out of the form. Submit/change-program/cancel stay absent
+// — those are the form's three load-bearing verbs.
 var hintDropOrder = [][]keys.KeyName{
+	{keys.KeySetPrompt, keys.KeyEditPrompt},
 	{keys.KeyShiftUp, keys.KeyShiftDown},
 	{keys.KeyAttach},
 	{keys.KeySearch},

--- a/ui/menu_test.go
+++ b/ui/menu_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/lipgloss"
+
 	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/ui/layout"
@@ -160,6 +162,79 @@ func TestMenuNewInstanceShowsSubmitProgramAndCancel(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Fatalf("new-instance footer missing %q:\n%s", want, out)
 		}
+	}
+}
+
+// TestMenuNewInstanceDropsPromptHintBeforeTheWayOut is the narrow-terminal
+// guard for #1936. Adding a fourth hint took the naming row from ~62 to ~78
+// cells, so it now overflows bars it used to fit — and the clamp cuts the RIGHT
+// edge, i.e. `esc cancel`, the only advertised way out of the form (the #1083
+// class). The prompt hint must be shed first instead: it advertises an optional
+// field, while submit/change-program/cancel are the form's load-bearing verbs.
+func TestMenuNewInstanceDropsPromptHintBeforeTheWayOut(t *testing.T) {
+	// 52..78 is the band this change created: wide enough for the three
+	// load-bearing verbs (51 cells) but not for the fourth hint. Below 52 even
+	// the shed row overflows and the status bar's clamp takes over — that is
+	// pre-existing behavior the drop list has never been able to fix.
+	for _, width := range []int{78, 70, 60, 55} {
+		m := NewMenu()
+		m.SetState(StateNewInstance)
+		m.SetNamingHasPrompt(true)
+		m.SetSize(width, 1)
+		out := m.String()
+
+		for _, want := range []string{"enter submit name", "tab change program", "esc cancel"} {
+			if !strings.Contains(out, want) {
+				t.Fatalf("width %d dropped the load-bearing hint %q:\n%s", width, want, out)
+			}
+		}
+		if strings.Contains(out, "initial prompt") {
+			t.Fatalf("width %d kept the optional prompt hint in an overflowing row:\n%s", width, out)
+		}
+		for i, line := range strings.Split(out, "\n") {
+			if got := lipgloss.Width(line); got > width {
+				t.Fatalf("width %d: hint row line %d is %d cells wide:\n%s", width, i, got, out)
+			}
+		}
+	}
+
+	// At the standard 80-column terminal everything still fits — the drop is a
+	// degradation, not the default.
+	m := NewMenu()
+	m.SetState(StateNewInstance)
+	m.SetSize(80, 1)
+	if out := m.String(); !strings.Contains(out, "initial prompt") {
+		t.Fatalf("an 80-column bar must still advertise the prompt field:\n%s", out)
+	}
+}
+
+// TestMenuNewInstancePromptHintSwapsAndDoesNotAlias covers the #1936 hint: the
+// naming footer advertises the initial-prompt field, and marks it once the
+// field holds text. The aliasing half is the part worth pinning — the swap
+// builds a copy, because writing the "✓" variant into the shared
+// newInstanceMenuOptions slice would leak it into every later naming form,
+// including ones with no prompt at all.
+func TestMenuNewInstancePromptHintSwapsAndDoesNotAlias(t *testing.T) {
+	m := NewMenu()
+	m.SetState(StateNewInstance)
+	m.SetSize(120, 1)
+
+	if out := m.String(); !strings.Contains(out, "initial prompt") {
+		t.Fatalf("new-instance footer missing the initial-prompt hint:\n%s", out)
+	}
+
+	m.SetNamingHasPrompt(true)
+	if out := m.String(); !strings.Contains(out, "initial prompt ✓") {
+		t.Fatalf("footer must mark an attached prompt:\n%s", out)
+	}
+
+	// A fresh menu must be back to the unmarked hint: if the swap had mutated
+	// the package-level slice in place, this would still read "✓".
+	fresh := NewMenu()
+	fresh.SetState(StateNewInstance)
+	fresh.SetSize(120, 1)
+	if out := fresh.String(); strings.Contains(out, "initial prompt ✓") {
+		t.Fatalf("the prompt-hint swap leaked into the shared options slice:\n%s", out)
 	}
 }
 

--- a/ui/overlay/promptOverlay.go
+++ b/ui/overlay/promptOverlay.go
@@ -1,0 +1,165 @@
+package overlay
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textarea"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/sachiniyer/agent-factory/ui"
+)
+
+// promptOverlayChrome is the number of content rows Render spends on anything
+// that is not the textarea: the title, the blank under it, the blank above the
+// hint, and the hint. The textarea gets whatever is left.
+const promptOverlayChrome = 4
+
+// promptOverlayDefaultHeight is the textarea height used when the overlay has
+// no height budget yet (SetMaxSize not called, e.g. before the first
+// WindowSizeMsg). Big enough for a paragraph without dominating the screen.
+const promptOverlayDefaultHeight = 6
+
+// PromptOverlay is the free-text entry overlay used for a new session's
+// initial prompt (#1936). It is textarea-backed rather than hand-rolled like
+// SearchOverlay's query string because a prompt is multi-line prose: the CLI's
+// --prompt and the web's promptArea both take newlines, so the TUI field that
+// closes that gap has to as well. A single-string buffer would have to spend
+// Enter on submit and could never hold a hand-typed second line.
+//
+// So Enter inserts a newline here and does NOT submit, matching the task form's
+// prompt field (ui/task_pane_edit.go), the other multi-line prompt input in the
+// TUI. Tab and Esc both close the overlay KEEPING the text: this is a field of
+// the create form, not a dialog, so backing out of it must not destroy what was
+// typed. Cancelling the whole create stays on ctrl+c, exactly as in the naming
+// flow the overlay returns to.
+//
+// Switching on msg.Type (not msg.String()) is load-bearing for paste: Bubble
+// Tea delivers a bracketed paste as one KeyRunes message whose contents are
+// "not to be interpreted further", so a pasted tab or newline reaches the
+// textarea as text instead of tripping the Tab/Enter cases above.
+type PromptOverlay struct {
+	textarea  textarea.Model
+	title     string
+	canceled  bool
+	width     int
+	maxWidth  int
+	maxHeight int
+}
+
+// NewPromptOverlay creates a prompt overlay seeded with value, so reopening it
+// shows what is already attached to the pending session rather than a blank
+// box.
+func NewPromptOverlay(title, value string) *PromptOverlay {
+	ta := textarea.New()
+	ta.ShowLineNumbers = false
+	ta.Prompt = ""
+	ta.Placeholder = "Sent to the agent as soon as it is ready…"
+	// No cap: the daemon delivers this verbatim to the agent, and an initial
+	// prompt is legitimately a paragraph or a pasted spec.
+	ta.CharLimit = 0
+	ta.MaxHeight = 0
+	// The cursor-line highlight spans the full textarea width, which reads as a
+	// selection bar inside a bordered box. Drop it (the task form does the same).
+	ta.FocusedStyle.CursorLine = lipgloss.NewStyle()
+	ta.SetValue(value)
+	// Land the cursor after the seeded text so reopening resumes typing rather
+	// than inserting at the top.
+	ta.CursorEnd()
+	ta.Focus()
+
+	return &PromptOverlay{
+		textarea: ta,
+		title:    title,
+		width:    60,
+	}
+}
+
+// HandleKeyPress processes a key press. Returns true if the overlay should
+// close.
+func (p *PromptOverlay) HandleKeyPress(msg tea.KeyMsg) bool {
+	switch msg.Type {
+	case tea.KeyCtrlC:
+		p.canceled = true
+		return true
+	case tea.KeyTab, tea.KeyEsc:
+		return true
+	}
+	// Everything else — including Enter — is text. The blink cmd is dropped
+	// deliberately: this repo has no animated indicators (#1766).
+	p.textarea, _ = p.textarea.Update(msg)
+	return false
+}
+
+// IsCanceled reports whether the overlay closed on ctrl+c, which cancels the
+// whole session create rather than just this field.
+func (p *PromptOverlay) IsCanceled() bool {
+	return p.canceled
+}
+
+// Value returns the text typed so far.
+func (p *PromptOverlay) Value() string {
+	return p.textarea.Value()
+}
+
+// SetWidth sets the preferred overlay width.
+func (p *PromptOverlay) SetWidth(width int) {
+	p.width = width
+}
+
+// SetMaxSize sets the maximum outer size the rendered overlay may occupy.
+func (p *PromptOverlay) SetMaxSize(width, height int) {
+	p.maxWidth = width
+	p.maxHeight = height
+}
+
+// Render renders the prompt overlay.
+func (p *PromptOverlay) Render() string {
+	t := ui.CurrentTheme()
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(t.Accent)
+	hintStyle := lipgloss.NewStyle().Foreground(t.ForegroundDim)
+	// Themed styles are resolved per render, like every sibling overlay, so a
+	// theme change lands without rebuilding the overlay.
+	placeholder := lipgloss.NewStyle().Foreground(t.ForegroundDim)
+	p.textarea.FocusedStyle.Placeholder = placeholder
+	p.textarea.BlurredStyle.Placeholder = placeholder
+
+	style := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(t.Accent).
+		Padding(1, 2)
+	fit := fitOverlayContent(p.width, 0, p.maxWidth, p.maxHeight, style)
+	if fit.W <= 0 {
+		fit.W = p.width
+	}
+	if fit.W <= 0 {
+		fit.W = 1
+	}
+	textRect := overlayTextRect(fit, style)
+
+	rows := promptOverlayDefaultHeight
+	if textRect.H > 0 {
+		rows = textRect.H - promptOverlayChrome
+		if rows < 1 {
+			rows = 1
+		}
+	}
+	p.textarea.SetWidth(textRect.W)
+	p.textarea.SetHeight(rows)
+
+	lines := []string{truncateOverlayLine(titleStyle.Render(p.title), textRect.W), ""}
+	lines = append(lines, strings.Split(p.textarea.View(), "\n")...)
+	lines = append(lines, "")
+
+	hint := "enter newline • tab done • ctrl+c cancel"
+	if lipgloss.Width(hint) > textRect.W {
+		hint = "tab done • ctrl+c cancel"
+	}
+	lines = append(lines, truncateOverlayLine(hintStyle.Render(hint), textRect.W))
+
+	style = style.Width(fit.W)
+	if fit.H > 0 && len(lines) >= textRect.H {
+		style = style.Height(fit.H)
+	}
+	return style.Render(strings.Join(lines, "\n"))
+}


### PR DESCRIPTION
Closes #1936.

`sessionStartRequest.Prompt` was plumbed end-to-end to the daemon
(`app/session_control.go` → `daemon.CreateSessionRequest.Prompt` →
`task.StartAndSendPrompt`) but its only construction site in `app/` never set
it, so the field was dead from the TUI. The web modal and
`af sessions create --prompt` both had it; the primary surface did not.

This adds the field to the naming form and populates it. No protocol change.

## The interaction

`shift+tab` during naming opens an **Initial prompt** overlay, alongside the
`tab` program picker. The three existing verbs are untouched, so the
type-name-Enter-go path is byte-for-byte what it was.

| Key | In the naming form | In the prompt field |
|-----|--------------------|---------------------|
| `enter` | submit | **newline** |
| `tab` | program picker | close, keep the text |
| `shift+tab` | prompt field | — |
| `esc` | cancel create | close, keep the text |
| `ctrl+c` | cancel create | cancel create |

The status bar advertises the field, and swaps to `initial prompt ✓` once it
holds text — the overlay is modal, so the bar is the only place that
confirmation can live.

### Taste calls, since #1936 asked for them

**`shift+tab`, not a mnemonic like `ctrl+p`.** `ctrl+p` is a *rebindable*
global (`switch_project`); hardcoding it in the form would silently drift the
day a user rebinds that action. `shift+tab` is a reserved structural key config
can never claim, it was a no-op in the naming flow, and it pairs with the `tab`
that opens the sibling field.

**A textarea, not a hand-rolled string buffer.** A prompt is multi-line prose —
`--prompt` and the web's promptArea both take newlines, so the field closing
that gap has to as well. A single-string buffer would have to spend `Enter` on
submit and could never hold a hand-typed second line. Enter-as-newline matches
the task form's prompt field, the TUI's other multi-line prompt input.

**Tab/Esc keep the text.** This is a *field of a form*, not a dialog, so backing
out of it must not destroy what was typed. Cancelling the whole create stays on
`ctrl+c` (and on `esc` at the naming level), exactly as before.

## Adjacent fix: the naming hint row no longer overflows

`hintDropOrder` carried the comment *"Naming-flow options are also absent
because that row is short."* A fourth hint invalidates that premise — the row
goes from ~62 to ~78 cells, so it overflows bars it used to fit, and the clamp
cuts the **right** edge: `esc cancel`, the only advertised way out of the form.
That is precisely the #1083 failure the drop list exists to prevent.

The prompt hint now leads `hintDropOrder`, so a narrow bar sheds the optional
field's hint and keeps the three load-bearing verbs. At 80 columns all four fit;
between 52 and 78 the row degrades to exactly what it rendered before this PR.

## Tests

`app/initial_prompt_test.go` drives the **real** key path (`handleKeyPress`, not
the sub-handlers) so the state dispatch and the naming-form menu-highlight hop
are covered, not routed around:

- the typed prompt reaches `sessionStartRequest.Prompt`
- an untouched field still sends nothing
- `Enter` is a newline; a multi-line prompt arrives whole
- a bracketed **paste** containing tabs and newlines lands as text — it does not
  trip the Tab/Esc close and does not spray into the title
- reopening the field shows the text already typed
- whitespace-only is "no prompt" (the #973 title rule)
- the prompt never leaks into the next create — submitted, esc-cancelled,
  ctrl+c-cancelled, and via `startNewInstance`'s authoritative reset
- the overlay renders inside 120×40, 80×24 and 60×15

Plus `ui/menu_test.go` for the hint swap (including that it does not mutate the
shared options slice) and the narrow-width drop, `keys`/`parity` updates, and
`shift+tab` added to the existing #691 highlight table.

**Each test was mutation-verified** — I broke the production behavior it claims
to pin and confirmed it goes red: dropping `Prompt` from the request, removing
the in-flow resets, removing `startNewInstance`'s reset, dropping `TrimSpace`,
disabling the highlight case, aliasing the options slice, and removing the
drop-order entry. All seven turned the relevant test red.

## Known behavior, called out rather than hidden

- **Pasted tabs become four spaces.** bubbles' textarea sanitizes its input
  (`runeutil.NewSanitizer` defaults to `ReplaceTabs("    ")`, and the sanitizer
  is unexported in v0.20, so it is not configurable). Indentation and line
  structure survive; nothing is dropped. The task form's prompt field has
  behaved this way all along. Pinned by the paste test so it is a recorded
  decision, not a surprise.
- **Only the TUI trims a whitespace-only prompt.** `--prompt "   "` still
  reaches the daemon verbatim. Deliberate: the trim here follows #973's title
  rule, which is about a *UI field that looks empty behaving empty*. A CLI flag
  is an explicit machine interface, and moving the trim into the daemon to cover
  both would change the web's behavior too — a wider call than this issue.
- **The status bar keeps showing the form's hints while the overlay is open**,
  so it reads `enter submit name` while Enter inserts a newline. This is
  pre-existing and shared with the program picker (which shows the same bar
  while Enter selects a program); the overlay's own hint row is the
  authoritative one. Fixing it means giving modal sub-states their own menu
  state, which would touch the program flow too — out of scope here, and I did
  not want to silently expand this PR into it.

## Verification

- `make test-container` green (full suite, incl. `daemon`)
- `make tui-driver-selftest` green
- `gofmt -l .`, `go build ./...`, `golangci-lint --fast`, `deadcode -test ./...`,
  `scripts/lint-file-length.sh` all clean

**Play-test still required — this is a visible TUI change and I have not driven
the rendered UI by hand.** `docs/tui-manual-testing.md` gains a "Create-form
changes (the #1936 class)" recipe with the exact driver calls, including the
part no marker can stand in for: finish the create and confirm the agent
receives the prompt as its first input.

Captain Claude
