### PR TITLE
refactor(web,daemon): serve the agent-program enum instead of copying it (#1970)

### DIFF
--- a/daemon/backends.go
+++ b/daemon/backends.go
@@ -102,12 +102,32 @@ func (s *controlServer) ListBackends(req ListBackendsRequest, resp *ListBackends
 	}
 
 	cfg, cfgErr := config.ResolveConfig(repo.Root)
-	resp.Backends = make([]BackendOption, 0, len(config.SupportedBackends))
-	for _, name := range config.SupportedBackends {
-		resp.Backends = append(resp.Backends, backendOptionFor(session.BackendKind(name), cfg, cfgErr, repo.Root))
-	}
+	resp.Backends = backendCatalog(config.SupportedBackends, cfg, cfgErr, repo.Root)
 	resp.Default, resp.DefaultStatus, resp.DefaultReason = defaultFor(resp.Backends, cfg, cfgErr, repo.Root)
 	return nil
+}
+
+// backendCatalog answers for a LIST of backends, preserving its order and adding,
+// dropping and renaming nothing.
+//
+// It takes the list as a PARAMETER rather than reading config.SupportedBackends
+// itself, which is what makes the anti-drift property — whatever the canonical
+// enum holds is offered — testable by passing a list instead of swapping the
+// global out from under the process (#2079).
+//
+// That swap is a DATA RACE, not just a smell: config.SupportedBackends is
+// read by session.ParseBackend (session/runtime.go, slices.Contains) and Go runs a
+// package's tests concurrently, so a test assigning to it races every other test
+// resolving a backend name. Its twin — the same pattern on tmux.SupportedPrograms
+// — is what `go test -race` failed on in #1970, and this one had simply not been
+// unlucky yet. Neither enum is ever written in production; both are read-only
+// after init, which is precisely why their read paths need no lock.
+func backendCatalog(names []string, cfg *config.ResolvedConfig, cfgErr error, repoRoot string) []BackendOption {
+	out := make([]BackendOption, 0, len(names))
+	for _, name := range names {
+		out = append(out, backendOptionFor(session.BackendKind(name), cfg, cfgErr, repoRoot))
+	}
+	return out
 }
 
 // backendOptionFor answers for ONE backend, honestly.

--- a/daemon/backends_test.go
+++ b/daemon/backends_test.go
@@ -76,6 +76,14 @@ func TestListBackends_OffersEverySupportedBackend(t *testing.T) {
 		names = append(names, opt.Name)
 	}
 	assert.Equal(t, config.SupportedBackends, names, "the catalog is the canonical enum, in canonical order")
+	// The RPC feeds the canonical enum straight into the catalog builder and does no
+	// filtering of its own. This is the second half of the anti-drift pair (see
+	// TestListBackends_NewBackendReachesClientsWithNoClientChange): that one proves
+	// the builder passes any list through, this one proves the list it is given is
+	// the canonical one. Together they say a new backend reaches every client.
+	cfg, cfgErr := config.ResolveConfig(repo)
+	assert.Equal(t, backendCatalog(config.SupportedBackends, cfg, cfgErr, repo), resp.Backends,
+		"ListBackends must hand the canonical enum to backendCatalog untouched")
 
 	assert.Equal(t, BackendAvailable, optionByName(t, resp, config.BackendLocal).Status, "local needs no repo config")
 	assert.Empty(t, optionByName(t, resp, config.BackendLocal).Reason)
@@ -290,21 +298,32 @@ func TestListBackends_NewBackendReachesClientsWithNoClientChange(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 	repo := setupControlRepo(t)
 
-	require.NotContains(t, config.SupportedBackends, "fargate", "precondition: the fake backend must not already exist")
+	require.NotContains(t, config.SupportedBackends, "fargate", "precondition: the fake backend must not be a real one")
 
-	restoreRuntime := session.SetRuntimeForTest(session.BackendKind("fargate"), func() session.Runtime { return nil })
-	t.Cleanup(restoreRuntime)
+	// A list carrying a backend this handler has never heard of, exactly as the
+	// canonical enum would look the moment someone adds one — PASSED IN, not
+	// assigned to config.SupportedBackends. See backendCatalog: that assignment is
+	// a data race against session.ParseBackend's read, and it is the twin of the
+	// tmux.SupportedPrograms race `go test -race` failed on (#1970/#2079).
+	//
+	// Registering a runtime is no longer needed either, which removes a second
+	// global mutation: BackendUnusableReason switches on the KNOWN kinds and
+	// consults no registry, so an unrecognized backend correctly reports no config
+	// requirement — that is the property under test.
+	cfg, cfgErr := config.ResolveConfig(repo)
+	catalog := backendCatalog([]string{config.BackendLocal, "fargate"}, cfg, cfgErr, repo)
 
-	prev := config.SupportedBackends
-	config.SupportedBackends = append(append([]string{}, prev...), "fargate")
-	t.Cleanup(func() { config.SupportedBackends = prev })
+	names := make([]string, 0, len(catalog))
+	for _, opt := range catalog {
+		names = append(names, opt.Name)
+	}
+	assert.Equal(t, []string{config.BackendLocal, "fargate"}, names,
+		"the catalog is the list it was given: same values, same order, nothing added or dropped")
 
-	resp := listBackends(t, repo)
-
-	opt := optionByName(t, resp, "fargate")
-	assert.Equal(t, BackendAvailable, opt.Status, "a backend with no repo-config requirement is selectable as soon as it is registered")
-	assert.Empty(t, opt.Reason)
-	assert.Equal(t, "fargate", resp.Backends[len(resp.Backends)-1].Name, "it lands in enum order, not appended by a special case")
+	fargate := catalog[len(catalog)-1]
+	assert.Equal(t, "fargate", fargate.Name, "a newly added backend lands in enum order, not appended by a special case")
+	assert.Equal(t, BackendAvailable, fargate.Status, "a backend with no repo-config requirement is selectable as soon as it is in the enum")
+	assert.Empty(t, fargate.Reason)
 }
 
 // TestListBackends_RequiresARepo: availability and the default are both properties

--- a/daemon/httproutes.go
+++ b/daemon/httproutes.go
@@ -67,6 +67,13 @@ var httpRoutes = []HTTPRoute{
 	},
 	{
 		Method:        http.MethodPost,
+		Path:          "/v1/ListPrograms",
+		Description:   "List the agent programs a session can be created with, and the program an unspecified create defaults to.",
+		RequestFields: jsonFields(reflect.TypeOf(ListProgramsRequest{})),
+		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.ListPrograms) },
+	},
+	{
+		Method:        http.MethodPost,
 		Path:          "/v1/Snapshot",
 		Description:   "List sessions from the daemon's authoritative in-memory state (empty repo_id = all repos).",
 		RequestFields: jsonFields(reflect.TypeOf(SnapshotRequest{})),

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -32,19 +32,14 @@ func (m *Manager) CreateSession(ctx context.Context, req CreateSessionRequest) (
 	defer cancel()
 
 	if req.Program == "" {
-		// Default from the repo-resolved config so an in-repo
-		// default_program applies to daemon-created sessions (task runs,
-		// API creates) too. Falls back to the daemon's global config when
-		// the repo path can't be resolved — reserveCreate will surface
-		// that error with more context right after.
-		req.Program = m.cfg.DefaultProgram
-		if req.RepoPath != "" {
-			if repo, err := config.RepoFromPath(req.RepoPath); err == nil {
-				if resolved, rerr := config.ResolveConfig(repo.Root); rerr == nil {
-					req.Program = resolved.DefaultProgram
-				}
-			}
-		}
+		// Default from the repo-resolved config so an in-repo default_program
+		// applies to daemon-created sessions (task runs, API creates) too.
+		//
+		// This is the ONE place the no-explicit-program default is decided, and
+		// ListPrograms (#1970) answers by calling the same function rather than
+		// restating the precedence — so the program a picker labels "repo default"
+		// cannot disagree with the one a real create picks.
+		req.Program = defaultProgramFor(m.cfg.DefaultProgram, req.RepoPath)
 	}
 	repo, title, release, renamedArchived, err := m.reserveCreate(req)
 	if err != nil {

--- a/daemon/programs.go
+++ b/daemon/programs.go
@@ -77,10 +77,7 @@ type ListProgramsResponse struct {
 // unspecified create resolves to. It is read-only: it starts nothing, dials
 // nothing, and touches no session state.
 func (s *controlServer) ListPrograms(req ListProgramsRequest, resp *ListProgramsResponse) error {
-	resp.Programs = make([]ProgramOption, 0, len(tmux.SupportedPrograms))
-	for _, name := range tmux.SupportedPrograms {
-		resp.Programs = append(resp.Programs, ProgramOption{Name: name})
-	}
+	resp.Programs = programCatalog(tmux.SupportedPrograms)
 
 	// A nil manager (test control servers, and the window before the manager is
 	// ready) means the global config is unavailable — so there is no default to
@@ -91,6 +88,28 @@ func (s *controlServer) ListPrograms(req ListProgramsRequest, resp *ListPrograms
 	}
 	resp.Default = defaultProgramFor(global, req.RepoPath)
 	return nil
+}
+
+// programCatalog turns a list of agent names into the options a client renders,
+// preserving order and adding, removing and rewriting nothing.
+//
+// It is a pure function taking the list as a PARAMETER, which is the whole point:
+// the property this RPC exists to guarantee — whatever the canonical enum holds
+// flows through untouched — is then testable by passing a list rather than by
+// swapping tmux.SupportedPrograms out from under the process.
+//
+// That swap is not merely inelegant, it is a DATA RACE. The enum is a package-level
+// global that tmux.DetectAgentFromCommand reads on a hot path (session/tmux/resume.go
+// findAgentToken), so a test assigning to it races every other test in the binary
+// that resolves an agent — which `go test -race` duly caught. Nothing in production
+// ever writes the enum; it is read-only after init, and it must stay that way for
+// the read path to be safe without a lock.
+func programCatalog(programs []string) []ProgramOption {
+	out := make([]ProgramOption, 0, len(programs))
+	for _, name := range programs {
+		out = append(out, ProgramOption{Name: name})
+	}
+	return out
 }
 
 // defaultProgramFor reports the agent program a create with no explicit program

--- a/daemon/programs.go
+++ b/daemon/programs.go
@@ -1,0 +1,122 @@
+package daemon
+
+import (
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// The agent-program catalog RPC (#1970). It is the ListBackends pattern (#1933)
+// applied one level down: not a missing FIELD, but a stale copy of an enum's
+// VALUES.
+//
+// tmux.SupportedPrograms has always been the canonical agent list. The TUI reads
+// it (app/handle_input.go) and the CLI advertises it (commands/root.go,
+// api/api.go), so both pick up a new agent for free. The web kept a hand-written
+// copy in two pickers, which meant adding a sixth agent server-side left the web
+// silently offering five — no failing test, no error, first signal a user asking
+// where their agent went. The lists happened to match; the COUPLING was the bug.
+//
+// ListPrograms removes the copy rather than re-syncing it: the daemon owns the
+// enum and every client renders what it is told. The acceptance criterion for
+// this RPC is therefore a property, not a value — a seventh agent must reach the
+// web with NO edit under web/src.
+//
+// What this RPC deliberately does NOT do is claim availability, which is where it
+// diverges from ListBackends. A backend's preconditions are properties of the
+// repo's config, which the daemon can read and check. Whether `aider` is
+// installed is a property of the machine the AGENT will run on — and for a docker
+// or ssh backend that is not the daemon's machine at all. Probing the daemon's
+// own PATH would answer a question nobody asked and, worse, answer it with a
+// NEGATIVE: an agent present in the container would be reported missing, hiding a
+// working choice behind a confident lie. A probe that cannot know must not answer
+// (#1933), so this one reports the enum and stops.
+
+// ListProgramsRequest asks which agent programs a create may select, and which
+// one an unspecified create resolves to.
+//
+// RepoPath is OPTIONAL, which is the deliberate difference from
+// ListBackendsRequest. The enum itself is global — the same six agents exist
+// everywhere — so unlike backends there IS a repo-less answer, and a caller with
+// no repo in hand (the task form before a project is picked) still deserves the
+// list. RepoPath only sharpens Default, whose in-repo override is repo-scoped.
+type ListProgramsRequest struct {
+	RepoPath string `json:"repo_path,omitempty"`
+}
+
+// ProgramOption is one selectable agent program.
+//
+// A single-field struct rather than a bare string: it is the shape that lets a
+// later field (a display label, a deprecation note) be added without breaking
+// every client's parse, which is the mistake that makes an enum expensive to
+// grow — and growing this enum cheaply is the entire point of the RPC.
+type ProgramOption struct {
+	// Name is the wire value: what a client sends back as CreateSessionRequest.Program,
+	// and — absent a label to render — what it shows the user verbatim.
+	Name string `json:"name"`
+}
+
+// ListProgramsResponse is the agent catalog.
+type ListProgramsResponse struct {
+	// Programs is every supported agent in canonical presentation order
+	// (tmux.SupportedPrograms, which is append-only so this order is stable).
+	Programs []ProgramOption `json:"programs"`
+	// Default is the program a create with NO explicit program resolves to for
+	// this repo. Clients render it as the label of their "repo default" choice and
+	// must send NO program to get it, not this value echoed back: sending it
+	// explicitly would freeze today's default into the request and ignore a later
+	// config change.
+	//
+	// EMPTY when there is no default to report — no manager (so no global config
+	// to read) or a config that resolves to no program. Clients render the
+	// "repo default" choice with no parenthetical then, rather than naming a
+	// program nobody chose.
+	Default string `json:"default"`
+}
+
+// ListPrograms reports the selectable agent programs, and which one an
+// unspecified create resolves to. It is read-only: it starts nothing, dials
+// nothing, and touches no session state.
+func (s *controlServer) ListPrograms(req ListProgramsRequest, resp *ListProgramsResponse) error {
+	resp.Programs = make([]ProgramOption, 0, len(tmux.SupportedPrograms))
+	for _, name := range tmux.SupportedPrograms {
+		resp.Programs = append(resp.Programs, ProgramOption{Name: name})
+	}
+
+	// A nil manager (test control servers, and the window before the manager is
+	// ready) means the global config is unavailable — so there is no default to
+	// report. Reporting one anyway is the failure mode this whole issue is about.
+	global := ""
+	if s.manager != nil && s.manager.cfg != nil {
+		global = s.manager.cfg.DefaultProgram
+	}
+	resp.Default = defaultProgramFor(global, req.RepoPath)
+	return nil
+}
+
+// defaultProgramFor reports the agent program a create with no explicit program
+// resolves to for repoPath, given the daemon's global default.
+//
+// This is the SHARED decision function: Manager.CreateSession calls it to pick
+// the program, and ListPrograms calls it to report the pick. That sharing is the
+// point — a catalog that restated the precedence could drift from the create it
+// describes, which is the same class of bug as the hardcoded enum this RPC
+// exists to delete, one layer down again.
+//
+// The global default is the fallback at every step where the repo cannot be
+// resolved, matching what a real create does: an unreadable in-repo config does
+// not fail the create, it falls back (reserveCreate surfaces the path problem
+// right after, with more context).
+func defaultProgramFor(globalDefault, repoPath string) string {
+	if repoPath == "" {
+		return globalDefault
+	}
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		return globalDefault
+	}
+	resolved, rerr := config.ResolveConfig(repo.Root)
+	if rerr != nil {
+		return globalDefault
+	}
+	return resolved.DefaultProgram
+}

--- a/daemon/programs_test.go
+++ b/daemon/programs_test.go
@@ -83,6 +83,13 @@ func TestListPrograms_OffersEverySupportedProgram(t *testing.T) {
 
 	assert.Equal(t, tmux.SupportedPrograms, programNames(resp),
 		"the catalog is tmux.SupportedPrograms verbatim, in its canonical (append-only) order")
+	// The RPC feeds the canonical enum straight into the catalog builder and does no
+	// filtering of its own. This is the second half of the anti-drift pair (see
+	// TestListPrograms_NewProgramReachesClientsWithNoClientChange): that one proves
+	// the builder passes any list through, this one proves the list it is given is
+	// the canonical one. Together they say a seventh agent reaches every client.
+	assert.Equal(t, programCatalog(tmux.SupportedPrograms), resp.Programs,
+		"ListPrograms must hand the canonical enum to programCatalog untouched")
 }
 
 // TestListPrograms_NewProgramReachesClientsWithNoClientChange is THE anti-drift
@@ -91,23 +98,49 @@ func TestListPrograms_OffersEverySupportedProgram(t *testing.T) {
 // It is the acceptance criterion the issue names: add a seventh agent the way a
 // real one is added — one entry in the canonical enum — and it must flow out of
 // the RPC, and therefore into every client that renders the response, with no
-// edit to this handler and none to web/src. If someone later reintroduces a
-// hardcoded list inside ListPrograms, this fails.
+// edit to this handler and none to web/src.
+//
+// It proves that by PASSING a list rather than by swapping tmux.SupportedPrograms,
+// which is what the first version of this test did. That swap is a data race: the
+// enum is a package-level global read on a hot path by tmux.DetectAgentFromCommand,
+// so writing it races every concurrently-running test that resolves an agent, and
+// `go test -race` caught exactly that. The enum is read-only after init in
+// production and must stay so; a test is not licence to make it mutable.
+//
+// Split across two claims that compose into the same guarantee, and are each
+// stronger than the end-to-end version was:
+//
+//	here                            — the catalog passes ANY list through untouched
+//	OffersEverySupportedProgram     — the RPC feeds it the canonical enum, verbatim
+//
+// If someone reintroduces a hardcoded list, a filter, or a label map inside
+// programCatalog, this fails.
 func TestListPrograms_NewProgramReachesClientsWithNoClientChange(t *testing.T) {
-	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
-	repo := setupControlRepo(t)
+	require.NotContains(t, tmux.SupportedPrograms, "cursor", "precondition: the fake agent must not be a real one")
 
-	require.NotContains(t, tmux.SupportedPrograms, "cursor", "precondition: the fake agent must not already exist")
+	// A list containing an agent this handler has never heard of, exactly as the
+	// canonical enum would look the moment someone appends a seventh agent.
+	catalog := programCatalog([]string{tmux.ProgramClaude, "cursor"})
 
-	prev := tmux.SupportedPrograms
-	tmux.SupportedPrograms = append(append([]string{}, prev...), "cursor")
-	t.Cleanup(func() { tmux.SupportedPrograms = prev })
+	names := make([]string, 0, len(catalog))
+	for _, opt := range catalog {
+		names = append(names, opt.Name)
+	}
 
-	resp := listPrograms(t, nil, repo)
+	assert.Equal(t, []string{tmux.ProgramClaude, "cursor"}, names,
+		"the catalog is the list it was given: same values, same order, nothing added or dropped")
+	assert.Equal(t, "cursor", catalog[len(catalog)-1].Name,
+		"a newly added agent lands in enum order, not appended by a special case")
+}
 
-	assert.Contains(t, programNames(resp), "cursor")
-	assert.Equal(t, "cursor", resp.Programs[len(resp.Programs)-1].Name,
-		"it lands in enum order, not appended by a special case")
+// TestProgramCatalogIsEmptySafe pins the degenerate case rather than leaving it to
+// chance: an empty enum yields an empty, non-nil slice, so the wire carries `[]`
+// and not `null`. A client that got null would have to guard for it, and the one
+// that forgot would render a broken picker instead of an empty one.
+func TestProgramCatalogIsEmptySafe(t *testing.T) {
+	got := programCatalog(nil)
+	assert.NotNil(t, got, "an empty catalog marshals as [] rather than null")
+	assert.Empty(t, got)
 }
 
 // TestListPrograms_AnswersWithoutARepo pins the deliberate difference from

--- a/daemon/programs_test.go
+++ b/daemon/programs_test.go
@@ -1,0 +1,225 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// listPrograms answers from the agent enum and a resolved config — it never
+// touches session state — so a controlServer carrying nothing but a manager (for
+// the global default) is the whole fixture.
+func listPrograms(t *testing.T, mgr *Manager, repoPath string) ListProgramsResponse {
+	t.Helper()
+	var resp ListProgramsResponse
+	require.NoError(t, (&controlServer{manager: mgr}).ListPrograms(ListProgramsRequest{RepoPath: repoPath}, &resp))
+	return resp
+}
+
+// programNames flattens the catalog to the wire values a client would render.
+func programNames(resp ListProgramsResponse) []string {
+	out := make([]string, 0, len(resp.Programs))
+	for _, opt := range resp.Programs {
+		out = append(out, opt.Name)
+	}
+	return out
+}
+
+// recordProgramThenFailTheCreate installs a backend factory that records the
+// InstanceOptions the daemon handed session.NewInstance and then FAILS, so the
+// create returns immediately.
+//
+// Failing on purpose is what keeps this fast and on-topic. The contract under test
+// is which PROGRAM a create with no explicit program resolves to — decided at the
+// top of CreateSession, before anything is provisioned — and the options are
+// recorded either way. Letting the create proceed instead drags in the readiness
+// poll, which is AGENT-SPECIFIC: the fake backend's pane ("ready\n❯") satisfies
+// claude's heuristic and not gemini's, so simply changing the default agent parks
+// the test on the full 60s start timeout for a reason that has nothing to do with
+// defaulting. (That is not hypothetical — it is what the first version of this test
+// did.)
+func recordProgramThenFailTheCreate(t *testing.T) *[]session.InstanceOptions {
+	t.Helper()
+	var seen []session.InstanceOptions
+	restore := session.SetBackendFactoryForTest(func(opts session.InstanceOptions, _ string) (session.Backend, error) {
+		seen = append(seen, opts)
+		return nil, errors.New("programs_test: create stopped after the program was resolved")
+	})
+	t.Cleanup(restore)
+	return &seen
+}
+
+// writeRepoProgramConfig writes an in-repo .agent-factory/config.json carrying a
+// default_program — the file a user edits to make one repo default to a different
+// agent than the rest.
+func writeRepoProgramConfig(t *testing.T, repoRoot, program string) {
+	t.Helper()
+	dir := filepath.Join(repoRoot, config.InRepoConfigDirName)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	blob, err := json.Marshal(map[string]any{"default_program": program})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.json"), blob, 0o644))
+}
+
+// TestListPrograms_OffersEverySupportedProgram is the core of #1970: the daemon —
+// not a hand-typed list in a client — decides which agents a create may select,
+// and it offers them in the canonical order clients render.
+func TestListPrograms_OffersEverySupportedProgram(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repo := setupControlRepo(t)
+
+	resp := listPrograms(t, nil, repo)
+
+	assert.Equal(t, tmux.SupportedPrograms, programNames(resp),
+		"the catalog is tmux.SupportedPrograms verbatim, in its canonical (append-only) order")
+}
+
+// TestListPrograms_NewProgramReachesClientsWithNoClientChange is THE anti-drift
+// test for #1970 (the daemon half; web/src/programs.test.ts is the other half).
+//
+// It is the acceptance criterion the issue names: add a seventh agent the way a
+// real one is added — one entry in the canonical enum — and it must flow out of
+// the RPC, and therefore into every client that renders the response, with no
+// edit to this handler and none to web/src. If someone later reintroduces a
+// hardcoded list inside ListPrograms, this fails.
+func TestListPrograms_NewProgramReachesClientsWithNoClientChange(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repo := setupControlRepo(t)
+
+	require.NotContains(t, tmux.SupportedPrograms, "cursor", "precondition: the fake agent must not already exist")
+
+	prev := tmux.SupportedPrograms
+	tmux.SupportedPrograms = append(append([]string{}, prev...), "cursor")
+	t.Cleanup(func() { tmux.SupportedPrograms = prev })
+
+	resp := listPrograms(t, nil, repo)
+
+	assert.Contains(t, programNames(resp), "cursor")
+	assert.Equal(t, "cursor", resp.Programs[len(resp.Programs)-1].Name,
+		"it lands in enum order, not appended by a special case")
+}
+
+// TestListPrograms_AnswersWithoutARepo pins the deliberate difference from
+// ListBackends (which errors on a repo-less request).
+//
+// A backend's availability is a property of a specific repo, so there is no
+// repo-less answer. The agent ENUM is global — the same agents exist everywhere —
+// so a caller with no repo in hand still deserves the list. Only Default is
+// repo-scoped, and it falls back to the global default exactly as a create does.
+func TestListPrograms_AnswersWithoutARepo(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	mgr := &Manager{cfg: &config.Config{DefaultProgram: tmux.ProgramCodex}}
+
+	resp := listPrograms(t, mgr, "")
+
+	assert.Equal(t, tmux.SupportedPrograms, programNames(resp), "the enum does not depend on a repo")
+	assert.Equal(t, tmux.ProgramCodex, resp.Default, "with no repo, the default is the daemon's global default")
+}
+
+// TestListPrograms_DefaultSources pins where Default actually comes from, and the
+// one case where there is none.
+//
+// The two sources are not interchangeable, and the precedence is inherited from
+// the create path rather than chosen here: a RESOLVABLE repo answers from its
+// resolved config (global config file overlaid by the in-repo one), and the
+// manager's in-memory global default is only the FALLBACK for when the repo cannot
+// be resolved. So a nil manager does not make the default unknown — the repo still
+// answers.
+//
+// The empty case is the honesty case, and the reason Default may be empty on the
+// wire: when NEITHER source has an answer, the response says so instead of naming
+// the obvious guess. A picker promising a choice nobody made is the failure this
+// whole issue is about, one layer down. Clients render "Repo default" with no
+// parenthetical (web/src/programs.ts).
+func TestListPrograms_DefaultSources(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	t.Run("a resolvable repo answers from its resolved config, with or without a manager", func(t *testing.T) {
+		repo := setupControlRepo(t)
+		writeRepoProgramConfig(t, repo, tmux.ProgramGemini)
+
+		assert.Equal(t, tmux.ProgramGemini, listPrograms(t, nil, repo).Default,
+			"the repo's own default_program is the answer — the manager is not consulted when the repo resolves")
+	})
+
+	t.Run("with neither a manager nor a repo there is no default to report", func(t *testing.T) {
+		resp := listPrograms(t, nil, "")
+
+		assert.Empty(t, resp.Default, "an unknown default is reported as unknown, not guessed")
+		assert.NotEmpty(t, resp.Programs, "the enum is still served — only the default is unknown")
+	})
+}
+
+// TestListPrograms_DefaultMatchesTheCreatePath is the contract the web relies on
+// to avoid overriding a repo default: Default reports what a create with NO
+// explicit program actually resolves to. The web renders it as a label and sends
+// nothing.
+//
+// It is deliberately driven end-to-end through Manager.CreateSession rather than
+// asserted against defaultProgramFor, which would be tautological now that both
+// call it. And it discriminates: the repo declares an agent that is NOT the global
+// default, so a catalog (or a create) that ignored the in-repo override would
+// report the global "claude" and fail here. Pinning a repo whose default happened
+// to equal the global one would pass no matter which side was wrong.
+func TestListPrograms_DefaultMatchesTheCreatePath(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	seen := recordProgramThenFailTheCreate(t)
+	repo := setupControlRepo(t)
+
+	global := config.DefaultConfig()
+	require.NotEqual(t, tmux.ProgramGemini, global.DefaultProgram,
+		"precondition: the repo override must differ from the global default, or this test cannot tell them apart")
+	writeRepoProgramConfig(t, repo, tmux.ProgramGemini)
+
+	mgr, err := NewManager(global)
+	require.NoError(t, err)
+
+	// What a real create with no explicit program picks. The create is EXPECTED to
+	// fail — see recordProgramThenFailTheCreate — because the program is chosen long
+	// before anything is provisioned, and letting the create run on would test the
+	// readiness poll rather than the defaulting.
+	_, err = mgr.CreateSession(context.Background(), CreateSessionRequest{
+		Title:    "captain-default-program",
+		RepoPath: repo,
+		Program:  "",
+	})
+	require.Error(t, err, "the recording fixture fails the create on purpose")
+	require.Len(t, *seen, 1)
+	created := (*seen)[0].Program
+
+	// What the catalog tells a client that create will pick.
+	reported := listPrograms(t, mgr, repo).Default
+
+	assert.Equal(t, tmux.ProgramGemini, created, "a create with no program honours the repo's default_program")
+	assert.Equal(t, created, reported,
+		"the program the catalog labels 'repo default' must be the one a real create picks — "+
+			"they are the same decision function (defaultProgramFor) precisely so they cannot disagree")
+}
+
+// TestDefaultProgramFor_FallsBackWhenTheRepoCannotBeResolved pins the fallback
+// half of the shared decision function.
+//
+// An unresolvable repo path does not fail the create — reserveCreate surfaces the
+// path problem right after, with more context — so the program falls back to the
+// global default. The catalog must describe that same behavior rather than
+// reporting an empty default for a create that will in fact run claude.
+func TestDefaultProgramFor_FallsBackWhenTheRepoCannotBeResolved(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	assert.Equal(t, tmux.ProgramAider, defaultProgramFor(tmux.ProgramAider, ""),
+		"no repo path at all falls back to the global default")
+	assert.Equal(t, tmux.ProgramAider, defaultProgramFor(tmux.ProgramAider, filepath.Join(t.TempDir(), "not-a-repo")),
+		"a path that is not a repo falls back to the global default")
+}

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -15,6 +15,7 @@ Request fields are the JSON keys of each route's request body; a `—` means the
 | `GET` | `/v1/health` | — | Liveness probe (alias for the Ping RPC); answers even while the daemon is restoring sessions. |
 | `POST` | `/v1/CreateSession` | `title`, `title_base`, `repo_path`, `program`, `prompt`, `auto_yes`, `in_place`, `force_remote`, `backend` | Create a new session (git worktree + agent) in a repo. |
 | `POST` | `/v1/ListBackends` | `repo_path` | List the runtimes a session in this repo can be created on, whether the repo's config supports each, and the backend an unspecified create defaults to. |
+| `POST` | `/v1/ListPrograms` | `repo_path` | List the agent programs a session can be created with, and the program an unspecified create defaults to. |
 | `POST` | `/v1/Snapshot` | `repo_id` | List sessions from the daemon's authoritative in-memory state (empty repo_id = all repos). |
 | `POST` | `/v1/KillSession` | `title`, `repo_id`, `id` | Tear down a session: kill its tmux/agent and remove its worktree and record. |
 | `POST` | `/v1/ArchiveSession` | `title`, `repo_id`, `id` | Archive a session: tear down tmux and relocate its worktree to the archive dir, keeping the record. |

--- a/parity/coverage_test.go
+++ b/parity/coverage_test.go
@@ -20,6 +20,7 @@ package parity
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"testing"
@@ -93,7 +94,21 @@ func TestAuditCoverageReport(t *testing.T) {
 	webFiles := webSourceFiles(t)
 	c.count("web.source-files", len(webFiles))
 	c.count("web.rpcs", len(deriveWebRPCs(t)))
-	c.count("web.enum-sites", len(webHardcodedProgramSites(t)))
+	// Hardcoded copies of the agent enum, which #1970 removed by serving it. This is
+	// now expected to be ZERO, so unlike the other counts it carries no floor — a
+	// floor here would demand the bug exist. The anti-vacuous guarantee moved into
+	// TestAgentEnumDetectorIsNotVacuous, which proves every run that the detector can
+	// still SEE a copy; without that, a zero here would be indistinguishable from a
+	// blind check.
+	webEnumCopies := 0
+	for _, path := range webFiles {
+		b, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		webEnumCopies += len(hardcodedAgentEnums(string(b)))
+	}
+	c.count("web.hardcoded-enum-sites", webEnumCopies)
 
 	// --- Go surfaces: request construction ---------------------------------
 	for _, surface := range []string{"cli", "tui"} {
@@ -164,7 +179,7 @@ func TestAuditCoverageReport(t *testing.T) {
 	floors := map[string]int{
 		"cli.verbs": 40, "cli.flags": 100, "daemon.public-routes": 15,
 		"tui.bindings": 40, "web.source-files": 15, "web.rpcs": 10,
-		"web.enum-sites": 2, "go.cli.request-sites": 8, "go.tui.request-sites": 8,
+		"go.cli.request-sites": 8, "go.tui.request-sites": 8,
 		"cli.noun-groups": 5, "inventory.capabilities": 50,
 	}
 	for kind, floor := range floors {

--- a/parity/enum_coverage_test.go
+++ b/parity/enum_coverage_test.go
@@ -6,23 +6,29 @@ package parity
 // surface do X?"; the field check asks "with which options?"; neither asks
 // "and does it offer the same VALUES?".
 //
-// That gap is live. web/src/modals.ts:173 hardcodes
-// ["claude","codex","aider","gemini","amp"] while session/tmux/session.go:22
-// owns the canonical list — and the TUI (app/handle_input.go:121) and CLI
-// (commands/root.go:246) both read the canonical one. Every existing check
-// passes: the web DOES send `program`, so field coverage calls it covered. Add a
-// sixth agent server-side and the web silently never offers it, with the whole
-// suite green.
+// That gap WAS live. web/src/modals.ts and web/src/tasks.ts each hardcoded a copy
+// of the agent list while session/tmux/session.go owns the canonical one, and the
+// TUI (app/handle_input.go) and CLI (commands/root.go) both read the canonical one.
+// Every other check passed: the web DOES send `program`, so field coverage called
+// it covered. Add a sixth agent server-side and the web silently never offers it,
+// with the whole suite green.
 //
-// It is the #1933 shape one level down — a surface quietly serving a stale copy
-// of something the daemon owns — so it gets the same treatment: derive both
-// sides and compare, rather than trusting a copy to stay in step.
+// #1970 closed it structurally: the daemon SERVES the enum (POST /v1/ListPrograms,
+// daemon/programs.go) and the web renders the response (web/src/programs.ts). There
+// is no copy left to drift.
 //
-// The fix for the underlying hazard is to serve the enum instead of copying it
-// (the ListBackends pattern from #1968, tracked separately). Until that lands,
-// this check makes the drift loud instead of silent.
+// So this file's job INVERTED. It used to assert "the copy is current" — a
+// mitigation that let the copy exist as long as someone remembered to sync it. It
+// now asserts the stronger thing: THERE IS NO COPY. A re-introduced hardcoded agent
+// list is the bug itself, not a list to check, and it fails here the moment it
+// appears rather than the day someone adds a seventh agent.
+//
+// Keeping a check here at all is deliberate. "Serve the enum" is a property of the
+// code that nothing in the type system enforces: a future picker can hand-type six
+// strings and work perfectly, today, exactly as these two did.
 
 import (
+	"fmt"
 	"os"
 	"regexp"
 	"sort"
@@ -32,97 +38,220 @@ import (
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
-// webProgramListRe matches the hardcoded agent list in the new-session modal:
+// quotedArrayRe matches a bracketed run of quoted strings — the shape any
+// hardcoded enum copy takes, whatever it is assigned to:
 //
-//	for (const prog of ["claude", "codex", …]) {
+//	["claude", "codex", …]
 //
-// Anchored on `const prog of [` rather than a bare array so an unrelated string
-// array cannot be mistaken for it. If the modal is rewritten (or, better, starts
-// rendering a served list), this stops matching and the test says so instead of
-// passing on an empty set.
-var webProgramListRe = regexp.MustCompile(`const\s+prog\s+of\s+\[([^\]]*)\]`)
+// Deliberately NOT anchored on the old `const prog of [` form. That anchor was the
+// weakness of the previous check: it recognized one spelling of the mistake, so a
+// copy stored in a const, a default parameter, or a Set would have slipped past
+// while the audit reported green.
+var quotedArrayRe = regexp.MustCompile(`\[((?:\s*"[^"\n]*"\s*,?)+)\s*\]`)
 
-var quotedRe = regexp.MustCompile(`"([^"]+)"`)
+var quotedRe = regexp.MustCompile(`"([^"]*)"`)
 
-// programListSite is one hardcoded copy of the agent enum in the web client.
-type programListSite struct {
-	File     string
-	Programs []string
+// stripComments blanks out TS comments so a PROSE mention of the old hardcoded
+// list — including the one at the top of web/src/programs.ts, which quotes it to
+// explain what was removed — is not mistaken for the list itself.
+//
+// It tracks string and template literals rather than blindly cutting at the first
+// `//`, because a URL inside a string ("https://…") would otherwise truncate the
+// rest of the line and hide a real copy sitting after it. Under-covering while
+// reporting green is the failure this whole file exists to prevent, so the scanner
+// errs toward scanning too much rather than too little.
+func stripComments(src string) string {
+	var out strings.Builder
+	out.Grow(len(src))
+
+	const (
+		code = iota
+		lineComment
+		blockComment
+		str
+	)
+	state := code
+	var quote byte
+	var escaped bool
+
+	for i := 0; i < len(src); i++ {
+		c := src[i]
+		switch state {
+		case code:
+			switch {
+			case c == '/' && i+1 < len(src) && src[i+1] == '/':
+				state = lineComment
+				i++
+			case c == '/' && i+1 < len(src) && src[i+1] == '*':
+				state = blockComment
+				i++
+			case c == '"' || c == '\'' || c == '`':
+				state, quote, escaped = str, c, false
+				out.WriteByte(c)
+			default:
+				out.WriteByte(c)
+			}
+		case lineComment:
+			if c == '\n' {
+				state = code
+				out.WriteByte(c)
+			}
+		case blockComment:
+			if c == '*' && i+1 < len(src) && src[i+1] == '/' {
+				state = code
+				i++
+			} else if c == '\n' {
+				// Keep newlines so reported positions stay meaningful.
+				out.WriteByte(c)
+			}
+		case str:
+			out.WriteByte(c)
+			switch {
+			case escaped:
+				escaped = false
+			case c == '\\':
+				escaped = true
+			case c == quote:
+				state = code
+			}
+		}
+	}
+	return out.String()
 }
 
-// webHardcodedProgramSites finds EVERY hardcoded agent list in the web client,
-// not just the new-session modal's.
+// hardcodedAgentEnums returns every array literal in src that lists two or more
+// canonical agent names — the signature of a copied enum.
 //
-// There are two today — web/src/modals.ts:173 (new session) and
-// web/src/tasks.ts:270 (the task form's program picker) — and checking one would
-// leave the other free to drift while the audit reported green. That is the
-// audit under-covering, which is worse than not auditing: it asserts parity over
-// a selector it never opened. Any future copy is picked up automatically.
-func webHardcodedProgramSites(t *testing.T) []programListSite {
-	t.Helper()
-	var out []programListSite
+// TWO is the threshold, not one. A single agent name in an array is ordinary and
+// legitimate (a default, a one-off fixture, an agent-specific branch); two or more
+// together is a list of agents, which is the thing the daemon now owns. Naming the
+// threshold here rather than leaving it implicit matters, because it is exactly the
+// line between "this check under-covers" and "this check false-fires".
+func hardcodedAgentEnums(src string) []string {
+	canonical := map[string]bool{}
+	for _, p := range tmux.SupportedPrograms {
+		canonical[p] = true
+	}
+
+	var found []string
+	for _, m := range quotedArrayRe.FindAllStringSubmatch(stripComments(src), -1) {
+		var hits []string
+		for _, q := range quotedRe.FindAllStringSubmatch(m[1], -1) {
+			if canonical[q[1]] {
+				hits = append(hits, q[1])
+			}
+		}
+		if len(hits) >= 2 {
+			sort.Strings(hits)
+			found = append(found, strings.Join(hits, ","))
+		}
+	}
+	return found
+}
+
+// TestWebHardcodesNoAgentEnum is the #1970 acceptance criterion as a test: adding
+// an agent server-side must reach the web with NO edit under web/src.
+//
+// It proves that by proving the only thing that could break it is absent — a local
+// list of agent names. The web's pickers build their options from ListPrograms
+// (web/src/programs.ts), so the enum has exactly one owner.
+//
+// Test files are excluded (webSourceFiles already skips *.test.ts) and that
+// exclusion is intentional, not an oversight: a test naming several agents is how
+// you verify the serving path works — web/src/programs.test.ts hands programChoices
+// a fake catalog full of agent names on purpose. Production code is where a name
+// must not appear.
+func TestWebHardcodesNoAgentEnum(t *testing.T) {
+	if len(tmux.SupportedPrograms) < 2 {
+		t.Fatalf("tmux.SupportedPrograms has %d entries — this check cannot detect a copy of a list that short", len(tmux.SupportedPrograms))
+	}
+
 	for _, path := range webSourceFiles(t) {
 		b, err := os.ReadFile(path)
 		if err != nil {
 			t.Fatalf("read %s: %v", path, err)
 		}
-		for _, m := range webProgramListRe.FindAllStringSubmatch(string(b), -1) {
-			var progs []string
-			for _, q := range quotedRe.FindAllStringSubmatch(m[1], -1) {
-				progs = append(progs, q[1])
-			}
-			if len(progs) == 0 {
-				t.Errorf("%s: matched a program-list site but parsed zero values — the parser "+
-					"is blind on it", relSite(t, path))
-				continue
-			}
-			sort.Strings(progs)
-			out = append(out, programListSite{File: relSite(t, path), Programs: progs})
+		for _, hit := range hardcodedAgentEnums(string(b)) {
+			t.Errorf("%s hardcodes a copy of the agent enum: [%s]\n\n"+
+				"The daemon owns this list (session/tmux/session.go) and serves it over "+
+				"POST /v1/ListPrograms (daemon/programs.go). A copy here works perfectly "+
+				"today and silently omits the NEXT agent someone adds, with every test "+
+				"green — that is the #1970 bug, which this copy would reintroduce.\n\n"+
+				"Build the options from the served catalog instead: programChoices() in "+
+				"web/src/programs.ts, as web/src/modals.ts and web/src/tasks.ts do.",
+				relSite(t, path), hit)
 		}
 	}
-	if len(out) < minProgramListSites {
-		t.Fatalf("found %d hardcoded program-list sites in web/src (expected >= %d).\n\n"+
-			"If the web now renders a list SERVED by the daemon, that is the fix (#1970) — "+
-			"delete this check and flip enum.agent-programs to parity in parity/inventory.json. "+
-			"If the sites were merely restructured, fix webProgramListRe: leaving it unmatched "+
-			"would make the enum drift silent again, which is the whole failure this guards.",
-			len(out), minProgramListSites)
-	}
-	return out
 }
 
-// minProgramListSites guards against a vacuous pass. Two copies exist today
-// (modals.ts, tasks.ts); if the regex stops matching them the check must fail
-// loudly rather than conclude the web hardcodes nothing.
-const minProgramListSites = 2
-
-// TestWebProgramEnumMatchesWire fails when the web's hardcoded agent list drifts
-// from the canonical one.
+// TestAgentEnumDetectorIsNotVacuous is the guard on the guard.
 //
-// This is deliberately NOT a "the web should serve this" assertion — that is
-// enum.agent-programs' verdict to carry. It is the narrower, mechanical claim
-// the copy makes implicitly and cannot keep on its own: that the copy is
-// current.
-func TestWebProgramEnumMatchesWire(t *testing.T) {
-	canonical := append([]string(nil), tmux.SupportedPrograms...)
-	sort.Strings(canonical)
-	if len(canonical) == 0 {
-		t.Fatal("tmux.SupportedPrograms is empty — the canonical source is unreadable")
-	}
+// A negative check ("no copies exist") passes just as green when it has silently
+// stopped being able to SEE a copy — a refactor, a new quoting style, a regex that
+// no longer matches. That failure mode is worse than no check, because it reports
+// coverage it does not have. So the detector is made to fire on a synthetic copy,
+// in several shapes, every run.
+func TestAgentEnumDetectorIsNotVacuous(t *testing.T) {
+	first, second := tmux.SupportedPrograms[0], tmux.SupportedPrograms[1]
 
-	for _, site := range webHardcodedProgramSites(t) {
-		if strings.Join(site.Programs, ",") == strings.Join(canonical, ",") {
-			continue
-		}
-		t.Errorf("the web's agent list has drifted from tmux.SupportedPrograms.\n"+
-			"  canonical (session/tmux/session.go:22): %v\n"+
-			"  web       (%s):                         %v\n"+
-			"  never offered by the web: %v\n"+
-			"  offered by the web but unknown to af: %v\n\n"+
-			"The web hardcodes a COPY of an enum the daemon owns, so adding an agent "+
-			"server-side silently leaves the web unable to offer it. Sync every site to "+
-			"unblock, but the real fix is to serve it (the ListBackends pattern) — see "+
-			"enum.agent-programs in parity/inventory.json (#1970).",
-			canonical, site.File, site.Programs, diff(canonical, site.Programs), diff(site.Programs, canonical))
+	for _, tc := range []struct {
+		name string
+		src  string
+	}{
+		{"the for-of loop this check originally caught", fmt.Sprintf(`for (const p of [%q, %q]) {}`, first, second)},
+		{"a const, which the old anchored regex missed", fmt.Sprintf(`const AGENTS = [%q, %q];`, first, second)},
+		{"a Set, likewise", fmt.Sprintf(`const AGENTS = new Set([%q, %q]);`, first, second)},
+		{"a default parameter", fmt.Sprintf(`function f(agents = [%q, %q]) {}`, first, second)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hardcodedAgentEnums(tc.src); len(got) == 0 {
+				t.Errorf("the detector did not fire on a hardcoded copy: %s\n\n"+
+					"TestWebHardcodesNoAgentEnum is therefore passing without being able to "+
+					"see the thing it checks for. Fix quotedArrayRe/stripComments rather than "+
+					"this test — a blind check is how the enum drift went silent the first time.",
+					tc.src)
+			}
+		})
+	}
+}
+
+// TestAgentEnumDetectorIgnoresProseAndSingletons pins the other half: the check
+// must not false-fire, or the next person deletes it.
+//
+// The comment case is load-bearing and not hypothetical — web/src/programs.ts opens
+// by quoting the exact array it replaced, to explain what was removed and why.
+func TestAgentEnumDetectorIgnoresProseAndSingletons(t *testing.T) {
+	first, second := tmux.SupportedPrograms[0], tmux.SupportedPrograms[1]
+
+	for _, tc := range []struct {
+		name string
+		src  string
+	}{
+		{"a line comment describing the removed list", fmt.Sprintf(`// the web used to hardcode [%q, %q] here`, first, second)},
+		{"a block comment doing the same", fmt.Sprintf("/* it hardcoded [%q, %q] */", first, second)},
+		{"a single agent name, which is not a list", fmt.Sprintf(`const fallback = [%q];`, first)},
+		{"an unrelated string array", `const modes = ["light", "dark"];`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hardcodedAgentEnums(tc.src); len(got) != 0 {
+				t.Errorf("the detector false-fired on %s: %v\nsource: %s", tc.name, got, tc.src)
+			}
+		})
+	}
+}
+
+// TestStripCommentsDoesNotTruncateAtAURL is the regression for the naive
+// implementation of stripComments — cutting each line at the first "//".
+//
+// A URL inside a string literal contains "//", so a naive strip would discard the
+// rest of that line, and a hardcoded enum sitting after it would become invisible.
+// The check would report green while blind, which is precisely the failure
+// TestAgentEnumDetectorIsNotVacuous exists to catch and this one localizes.
+func TestStripCommentsDoesNotTruncateAtAURL(t *testing.T) {
+	first, second := tmux.SupportedPrograms[0], tmux.SupportedPrograms[1]
+	src := fmt.Sprintf(`const docs = "https://example.invalid/agents"; const AGENTS = [%q, %q];`, first, second)
+
+	if got := hardcodedAgentEnums(src); len(got) == 0 {
+		t.Errorf("a copy after a URL string was not seen — stripComments truncated the line at the URL's //\nsource: %s", src)
 	}
 }

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -1111,16 +1111,15 @@
         "pointer": "app/handle_input.go:121-123 reads tmux.SupportedPrograms"
       },
       "web": {
-        "status": "partial",
-        "pointer": "web/src/modals.ts:173 hardcodes a COPY of the list"
+        "status": "yes",
+        "pointer": "web/src/programs.ts renders the served ListPrograms catalog (modals.ts + tasks.ts pickers)"
       },
       "cli": {
         "status": "yes",
         "pointer": "commands/root.go:246 + api/api.go:586 advertise tmux.SupportedProgramsString()"
       },
-      "verdict": "real-gap",
-      "issue": "#1970",
-      "notes": "A third drift dimension under verbs and fields: the VALUES a surface offers for a field. The TUI and CLI read tmux.SupportedPrograms (session/tmux/session.go:22); the web keeps its own copy. The lists MATCH today, so this is a live hazard rather than a live divergence — add a sixth agent server-side and the web silently never offers it while every field-level check stays green (the web does send `program`, so coverage calls it covered). Reported by the #1933 session, which found the same shape one level down. TestWebProgramEnumMatchesWire makes the drift loud in the meantime; the structural fix is to SERVE the enum, per the ListBackends reference implementation in #1968."
+      "verdict": "parity",
+      "notes": "RESOLVED by #1970. A third drift dimension under verbs and fields: the VALUES a surface offers for a field. The TUI and CLI read tmux.SupportedPrograms (session/tmux/session.go); the web kept its own copy in two pickers, so adding an agent server-side would have left the web silently offering the old set with every field-level check green. The fix is structural rather than a re-sync: the daemon SERVES the enum (POST /v1/ListPrograms, daemon/programs.go) and the web renders the response (web/src/programs.ts), so a seventh agent reaches the web with no edit under web/src — the acceptance criterion, pinned by TestListPrograms_NewProgramReachesClientsWithNoClientChange and its web twin. TestWebProgramEnumMatchesWire (the interim 'is the copy current?' guard) is replaced by TestWebHardcodesNoAgentEnum, which asserts the stronger property that NO copy exists. The reported default comes from the same decision function the create path uses (defaultProgramFor), so the picker's 'repo default' label cannot disagree with the program a real create picks."
     },
     {
       "id": "cli.argshape.session-title",
@@ -1304,6 +1303,7 @@
       "POST /v1/GetConfig": "config.read",
       "POST /v1/KillSession": "session.kill",
       "POST /v1/ListBackends": "backend.list",
+      "POST /v1/ListPrograms": "enum.agent-programs",
       "POST /v1/ListTasks": "task.list",
       "POST /v1/RemoveTask": "task.remove",
       "POST /v1/RenameTab": "session.tab.rename",
@@ -1376,6 +1376,7 @@
       "GetConfig": "config.read",
       "KillSession": "session.kill",
       "ListBackends": "backend.list",
+      "ListPrograms": "enum.agent-programs",
       "ListTasks": "task.list",
       "RemoveTask": "task.remove",
       "RenameTab": "session.tab.rename",

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -6226,6 +6226,9 @@ async function probeAuthRequired() {
 async function listBackends(repoPath, token2) {
   return af("ListBackends", { repo_path: repoPath }, token2);
 }
+async function listPrograms(repoPath, token2) {
+  return af("ListPrograms", { repo_path: repoPath }, token2);
+}
 async function createSession(input, token2) {
   const body = {
     title_base: input.title,
@@ -6396,6 +6399,27 @@ function backendSelectable(choices, selected) {
   return choice === void 0 || choice.status === "available";
 }
 
+// src/programs.ts
+var PROGRAM_REPO_DEFAULT = "";
+function programChoices(catalog, keep = "") {
+  const choices = [
+    {
+      value: PROGRAM_REPO_DEFAULT,
+      // "Repo default" with no parenthetical when the daemon reports no default —
+      // naming an agent there would be inventing one.
+      label: catalog === null || catalog.default === "" ? "Repo default" : `Repo default (${catalog.default})`
+    }
+  ];
+  for (const opt of catalog?.programs ?? []) {
+    choices.push({ value: opt.name, label: opt.name });
+  }
+  const extra = keep.trim();
+  if (extra !== "" && !choices.some((c) => c.value === extra)) {
+    choices.push({ value: extra, label: extra });
+  }
+  return choices;
+}
+
 // src/modals.ts
 function h(tag, props = {}, ...children) {
   const el2 = document.createElement(tag);
@@ -6492,10 +6516,7 @@ function newSessionModal(projects, defaultProject2, callbacks) {
   }
   const programSelect = h("select", { class: "af-input" });
   programSelect.setAttribute("aria-label", "Program");
-  programSelect.append(h("option", { value: "" }, "Repo default"));
-  for (const prog of ["claude", "codex", "aider", "gemini", "amp", "opencode"]) {
-    programSelect.append(h("option", { value: prog }, prog));
-  }
+  let programs = programChoices(null);
   const backendSelect = h("select", { class: "af-input" });
   backendSelect.setAttribute("aria-label", "Backend");
   const backendHint = h("p", { class: "af-modal-hint" });
@@ -6522,9 +6543,30 @@ function newSessionModal(projects, defaultProject2, callbacks) {
     syncSubmitState();
   };
   backendSelect.addEventListener("change", syncSubmitState);
+  const renderPrograms = () => {
+    const previous = programSelect.value;
+    programSelect.replaceChildren();
+    for (const choice of programs) {
+      programSelect.append(h("option", { value: choice.value }, choice.label));
+    }
+    programSelect.value = programs.some((c) => c.value === previous) ? previous : PROGRAM_REPO_DEFAULT;
+  };
   let loadSeq = 0;
-  const loadBackendsFor = (repoPath) => {
+  const loadCatalogsFor = (repoPath) => {
     const seq = ++loadSeq;
+    void callbacks.loadPrograms(repoPath).then((catalog) => {
+      if (seq !== loadSeq) {
+        return;
+      }
+      programs = programChoices(catalog);
+      renderPrograms();
+    }).catch(() => {
+      if (seq !== loadSeq) {
+        return;
+      }
+      programs = programChoices(null);
+      renderPrograms();
+    });
     if (repoPath === "") {
       choices = backendChoices(null);
       renderChoices();
@@ -6544,7 +6586,7 @@ function newSessionModal(projects, defaultProject2, callbacks) {
       renderChoices();
     });
   };
-  projectSelect.addEventListener("change", () => loadBackendsFor(projectSelect.value));
+  projectSelect.addEventListener("change", () => loadCatalogsFor(projectSelect.value));
   const promptArea = h("textarea", { class: "af-input af-textarea", placeholder: "Initial prompt (optional)", rows: 3 });
   promptArea.setAttribute("aria-label", "Initial prompt");
   const autoYes = h("input", { type: "checkbox", id: "af-autoyes" });
@@ -6558,8 +6600,9 @@ function newSessionModal(projects, defaultProject2, callbacks) {
     field("Prompt", promptArea),
     autoYesRow
   );
+  renderPrograms();
   renderChoices();
-  loadBackendsFor(projectSelect.value);
+  loadCatalogsFor(projectSelect.value);
   const card = handle.el.firstElementChild;
   asForm(card, () => {
     const title = titleInput.value.trim();
@@ -10059,10 +10102,35 @@ function taskFormModal(opts) {
   targetInput.setAttribute("aria-label", "Target session");
   const programSelect = h("select", { class: "af-input" });
   programSelect.setAttribute("aria-label", "Program");
-  programSelect.append(h("option", { value: "" }, "Repo default"));
-  for (const prog of ["claude", "codex", "aider", "gemini", "amp", "opencode"]) {
-    programSelect.append(h("option", { value: prog }, prog));
-  }
+  const keepProgram = opts.seed?.program ?? "";
+  let programs = programChoices(null, keepProgram);
+  const renderPrograms = () => {
+    const previous = programSelect.value;
+    programSelect.replaceChildren();
+    for (const choice of programs) {
+      programSelect.append(h("option", { value: choice.value }, choice.label));
+    }
+    programSelect.value = programs.some((c) => c.value === previous) ? previous : PROGRAM_REPO_DEFAULT;
+  };
+  renderPrograms();
+  let programSeq = 0;
+  const loadProgramsFor = (repoPath) => {
+    const seq = ++programSeq;
+    void opts.loadPrograms(repoPath).then((catalog) => {
+      if (seq !== programSeq) {
+        return;
+      }
+      programs = programChoices(catalog, keepProgram);
+      renderPrograms();
+    }).catch(() => {
+      if (seq !== programSeq) {
+        return;
+      }
+      programs = programChoices(null, keepProgram);
+      renderPrograms();
+    });
+  };
+  projectSelect.addEventListener("change", () => loadProgramsFor(projectSelect.value));
   if (opts.seed) {
     const s = opts.seed;
     nameInput.value = s.name ?? "";
@@ -10073,11 +10141,9 @@ function taskFormModal(opts) {
     syncTriggerFields();
     promptArea.value = s.prompt ?? "";
     targetInput.value = s.target_session ?? "";
-    if (s.program && ![...programSelect.options].some((o) => o.value === s.program)) {
-      programSelect.append(h("option", { value: s.program }, s.program));
-    }
     programSelect.value = s.program ?? "";
   }
+  loadProgramsFor(projectSelect.value);
   body.append(
     field("Name", nameInput),
     field("Project", projectSelect),
@@ -10133,6 +10199,7 @@ function addTaskModal(projects, defaultProject2, callbacks) {
     confirmLabel: "Add",
     projects,
     defaultProject: defaultProject2,
+    loadPrograms: callbacks.loadPrograms,
     onSubmit: callbacks.onSubmit,
     onCancel: callbacks.onCancel
   });
@@ -10144,6 +10211,7 @@ function editTaskModal(projects, task, callbacks) {
     projects,
     defaultProject: task.project_path,
     seed: task,
+    loadPrograms: callbacks.loadPrograms,
     onSubmit: callbacks.onSubmit,
     onCancel: callbacks.onCancel
   });
@@ -11396,6 +11464,7 @@ var store = new Store({
 });
 var token = null;
 var stream = null;
+var loadPrograms = (repoPath) => token === null ? Promise.reject(new Error("not authorized")) : listPrograms(repoPath, token);
 var resyncTimer = null;
 var taskResyncTimer = null;
 var tabErrorTimer = null;
@@ -11629,6 +11698,8 @@ function newSession() {
       // Tokenless ("") is a valid credential (#1696), so a null token — not a
       // falsy one — is the "not authorized yet" case.
       loadBackends: (repoPath) => token === null ? Promise.reject(new Error("not authorized")) : listBackends(repoPath, token),
+      // The agent catalog, same contract (#1970): the daemon owns the enum.
+      loadPrograms,
       onSubmit: (values) => {
         const tok = token;
         if (tok === null || !modal) {
@@ -11922,6 +11993,7 @@ function openAddTask() {
   const projects = pickerProjects(store.get().sessions, store.get().tasks);
   openModal(
     addTaskModal(projects, store.get().selectedProject, {
+      loadPrograms,
       onSubmit: (input) => {
         const tok = token;
         if (tok === null || !modal) {
@@ -11945,6 +12017,7 @@ function openEditTask(task) {
   const projects = pickerProjects(store.get().sessions, store.get().tasks);
   openModal(
     editTaskModal(projects, task, {
+      loadPrograms,
       onSubmit: (input) => {
         const tok = token;
         if (tok === null || !modal) {

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "3daea91d4e06";
+const VERSION = "1716c5982ac2";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -17,6 +17,7 @@ import {
   errorText,
   killSession,
   listBackends,
+  listPrograms,
   probeWebTab,
   removeTask,
   renameTab,
@@ -116,6 +117,27 @@ test("resumeFromLimit posts the stable id, so a duplicate title cannot misroute 
   assert.equal(cap.body.id, "id-repoB", "the daemon resolves by id first");
   assert.equal(cap.body.title, "feature", "the title still rides along for the event and the title-only fallback");
   assert.equal(cap.body.repo_id, "", "an all-repos web client scopes by id, not repo");
+});
+
+test("listPrograms asks the daemon for the agent catalog (#1970)", async () => {
+  const cap = stubFetch();
+  await listPrograms("/repos/af", "tok");
+
+  assert.equal(cap.url, "/v1/ListPrograms");
+  assert.equal(cap.auth, "Bearer tok");
+  assert.equal(cap.body.repo_path, "/repos/af", "the repo sharpens which program 'repo default' resolves to");
+});
+
+// Unlike listBackends, a repo-less request is legitimate: the agent enum is global,
+// so a form with no project picked yet still gets the list. Sending the field as ""
+// rather than omitting it keeps the wire shape uniform — the daemon treats an empty
+// repo_path as "no repo context" and answers with the global default.
+test("listPrograms works with no repo picked", async () => {
+  const cap = stubFetch();
+  await listPrograms("", "tok");
+
+  assert.equal(cap.url, "/v1/ListPrograms");
+  assert.equal(cap.body.repo_path, "");
 });
 
 test("killSession posts the stable id as the primary key alongside the title", async () => {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -12,6 +12,7 @@
 // used by the /v1/events subscriber (events.ts) and, in PR4, the PTY stream.
 
 import type { BackendCatalog } from "./backends.js";
+import type { ProgramCatalog } from "./programs.js";
 import type {
   ConfigResponse,
   ConfigSetResponse,
@@ -266,6 +267,17 @@ export interface CreateSessionInput {
  *  hard-codes no backend names of its own. */
 export async function listBackends(repoPath: string, token: string): Promise<BackendCatalog> {
   return af<BackendCatalog>("ListBackends", { repo_path: repoPath }, token);
+}
+
+/** Lists the agent programs a session may be created with, and the program an
+ *  unspecified create defaults to for this repo (#1970). The daemon owns the enum;
+ *  the web renders whatever it returns and hard-codes no agent names of its own.
+ *
+ *  `repoPath` may be empty, unlike listBackends: the agent enum is global, so a
+ *  caller with no project picked yet still gets the list — only the default needs
+ *  a repo. */
+export async function listPrograms(repoPath: string, token: string): Promise<ProgramCatalog> {
+  return af<ProgramCatalog>("ListPrograms", { repo_path: repoPath }, token);
 }
 
 /** Creates a session and returns the daemon's authoritative projection of it (the

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -27,6 +27,7 @@ import {
   killSession,
   getConfig,
   listBackends,
+  listPrograms,
   listTasks,
   setConfigValue,
   loadToken,
@@ -64,6 +65,7 @@ import { Store } from "./store.js";
 import { registerServiceWorker } from "./serviceworker.js";
 import { bootStampTheme, persistThemeChoice, stampTheme, type ThemeChoice } from "./theme.js";
 import { addTaskModal, type AddTaskInput, buildTask, editTaskModal } from "./tasks.js";
+import type { ProgramCatalog } from "./programs.js";
 import type { TerminalStatus } from "./terminal.js";
 import {
   AppShell,
@@ -133,6 +135,17 @@ const store = new Store<AppState>({
 // send-prompt/attach would be silently skipped because `!"" === true`.
 let token: string | null = null;
 let stream: EventStream | null = null;
+
+/** Fetches the agent catalog for a project (#1970), shared by the three forms that
+ *  offer a program picker: new session, add task, edit task. One helper rather than
+ *  three copies of the token dance — the hardcoded-list bug this RPC exists to
+ *  delete started as exactly that kind of duplication.
+ *
+ *  Tokenless ("") is a valid credential (#1696), so a null token — not a falsy one —
+ *  is the "not authorized yet" case. Rejecting there is safe: every caller degrades
+ *  to the repo default rather than blocking its form. */
+const loadPrograms = (repoPath: string): Promise<ProgramCatalog> =>
+  token === null ? Promise.reject(new Error("not authorized")) : listPrograms(repoPath, token);
 // Debounces the re-Snapshot that archived/restored events and reconnects trigger,
 // so a burst of events collapses into a single authoritative refetch.
 let resyncTimer: number | null = null;
@@ -528,6 +541,8 @@ function newSession(): void {
       // Tokenless ("") is a valid credential (#1696), so a null token — not a
       // falsy one — is the "not authorized yet" case.
       loadBackends: (repoPath: string) => (token === null ? Promise.reject(new Error("not authorized")) : listBackends(repoPath, token)),
+      // The agent catalog, same contract (#1970): the daemon owns the enum.
+      loadPrograms,
       onSubmit: (values: CreateSessionInput) => {
         const tok = token;
         // `=== null` not `!tok`: "" is the authorized-tokenless credential (#1696).
@@ -1102,6 +1117,7 @@ function openAddTask(): void {
   const projects = pickerProjects(store.get().sessions, store.get().tasks);
   openModal(
     addTaskModal(projects, store.get().selectedProject, {
+      loadPrograms,
       onSubmit: (input: AddTaskInput) => {
         const tok = token;
         // `=== null` not `!tok`: "" is the authorized-tokenless credential (#1696).
@@ -1140,6 +1156,7 @@ function openEditTask(task: TaskData): void {
   const projects = pickerProjects(store.get().sessions, store.get().tasks);
   openModal(
     editTaskModal(projects, task, {
+      loadPrograms,
       onSubmit: (input: AddTaskInput) => {
         const tok = token;
         // `=== null` not `!tok`: "" is the authorized-tokenless credential (#1696).

--- a/web/src/modals.ts
+++ b/web/src/modals.ts
@@ -18,6 +18,7 @@
 
 import type { CreateSessionInput } from "./api.js";
 import { type BackendCatalog, type BackendChoice, REPO_DEFAULT, backendChoices, backendNotice, backendSelectable } from "./backends.js";
+import { PROGRAM_REPO_DEFAULT, type ProgramCatalog, type ProgramChoice, programChoices } from "./programs.js";
 
 /** A live modal: its root element plus in-place patch controls index.ts drives
  *  around the async submit. close() removes it from the DOM. */
@@ -136,12 +137,13 @@ export function asForm(card: HTMLElement, onSubmit: () => void): void {
  *  (like the TUI's zero-config picker). onSubmit fires with the collected form
  *  values.
  *
- *  loadBackends fetches the picked project's backend catalog (#1933). It is passed
- *  in rather than imported so this module stays free of the API/token layer, and is
- *  re-run whenever the project changes: availability and the default are per-repo
- *  facts, so the choices must follow the project picker. If it rejects, the backend
- *  field degrades to "repo default" alone — the exact behavior before this field
- *  existed, so a catalog failure can never block a create. */
+ *  loadBackends fetches the picked project's backend catalog (#1933), and
+ *  loadPrograms the agent catalog (#1970). Both are passed in rather than imported
+ *  so this module stays free of the API/token layer, and both are re-run whenever
+ *  the project changes: each catalog's default is a per-repo fact, so the choices
+ *  must follow the project picker. If either rejects, its field degrades to "repo
+ *  default" alone — the exact behavior before these fields existed, so a catalog
+ *  failure can never block a create. */
 export function newSessionModal(
   projects: string[],
   defaultProject: string | null,
@@ -149,6 +151,7 @@ export function newSessionModal(
     onSubmit: (values: CreateSessionInput) => void;
     onCancel: () => void;
     loadBackends: (repoPath: string) => Promise<BackendCatalog>;
+    loadPrograms: (repoPath: string) => Promise<ProgramCatalog>;
   },
 ): ModalHandle {
   const { handle, body, confirmBtn } = modalChrome({
@@ -180,12 +183,12 @@ export function newSessionModal(
     }
   }
 
+  // The program field (#1970). Like the backend field below, its options come from
+  // the daemon, never from a list here, so an agent added server-side shows up with
+  // no change to the web.
   const programSelect = h("select", { class: "af-input" });
   programSelect.setAttribute("aria-label", "Program");
-  programSelect.append(h("option", { value: "" }, "Repo default"));
-  for (const prog of ["claude", "codex", "aider", "gemini", "amp", "opencode"]) {
-    programSelect.append(h("option", { value: prog }, prog));
-  }
+  let programs: ProgramChoice[] = programChoices(null);
 
   // The backend field (#1933). Its options come from the daemon, never from a list
   // here, so a backend added server-side shows up with no change to the web.
@@ -238,11 +241,47 @@ export function newSessionModal(
 
   backendSelect.addEventListener("change", syncSubmitState);
 
+  const renderPrograms = (): void => {
+    const previous = programSelect.value;
+    programSelect.replaceChildren();
+    for (const choice of programs) {
+      programSelect.append(h("option", { value: choice.value }, choice.label));
+    }
+    // Same rule as the backend picker: keep the user's pick across a project switch
+    // when it is still offered, else fall back to the repo default, which always is.
+    programSelect.value = programs.some((c) => c.value === previous) ? previous : PROGRAM_REPO_DEFAULT;
+  };
+
   // A per-load token: a slow catalog for the project the user just left must not
-  // overwrite the choices for the one they just picked.
+  // overwrite the choices for the one they just picked. Shared by both catalogs —
+  // they are fetched together and are both per-project facts, so one token orders
+  // them consistently.
   let loadSeq = 0;
-  const loadBackendsFor = (repoPath: string): void => {
+  const loadCatalogsFor = (repoPath: string): void => {
     const seq = ++loadSeq;
+
+    // The program enum is global, so this is asked even with no project picked —
+    // repoPath only sharpens which agent "repo default" resolves to.
+    void callbacks
+      .loadPrograms(repoPath)
+      .then((catalog) => {
+        if (seq !== loadSeq) {
+          return;
+        }
+        programs = programChoices(catalog);
+        renderPrograms();
+      })
+      .catch(() => {
+        if (seq !== loadSeq) {
+          return;
+        }
+        // Degrade to "repo default" only — the same contract as the backend field:
+        // an unreachable catalog costs the user the choice, never the session, since
+        // sending no program is exactly what "repo default" means on the wire.
+        programs = programChoices(null);
+        renderPrograms();
+      });
+
     if (repoPath === "") {
       choices = backendChoices(null);
       renderChoices();
@@ -268,7 +307,7 @@ export function newSessionModal(
       });
   };
 
-  projectSelect.addEventListener("change", () => loadBackendsFor(projectSelect.value));
+  projectSelect.addEventListener("change", () => loadCatalogsFor(projectSelect.value));
 
   const promptArea = h("textarea", { class: "af-input af-textarea", placeholder: "Initial prompt (optional)", rows: 3 });
   promptArea.setAttribute("aria-label", "Initial prompt");
@@ -286,8 +325,9 @@ export function newSessionModal(
     autoYesRow,
   );
 
+  renderPrograms();
   renderChoices();
-  loadBackendsFor(projectSelect.value);
+  loadCatalogsFor(projectSelect.value);
 
   const card = handle.el.firstElementChild as HTMLElement;
   asForm(card, () => {

--- a/web/src/programs.test.ts
+++ b/web/src/programs.test.ts
@@ -1,0 +1,128 @@
+// Tests for the create/task forms' agent-program choice (#1970).
+//
+// The web used to hardcode the agent list in two pickers while the daemon owned
+// the canonical one. The lists matched, so nothing was broken — the COUPLING was:
+// add an agent server-side and the web silently keeps offering the old set, with
+// every test green. These pin the two properties that make the served version
+// correct: the web renders whatever the daemon lists (and nothing it knows itself),
+// and "no choice" stays genuinely absent so the repo default still applies.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { PROGRAM_REPO_DEFAULT, type ProgramCatalog, programChoices } from "./programs.js";
+
+/** A catalog in the daemon's own shape: canonical (append-only) order, plus the
+ *  program an unspecified create resolves to. */
+function catalog(over: Partial<ProgramCatalog> = {}): ProgramCatalog {
+  return {
+    default: "claude",
+    programs: [
+      { name: "claude" },
+      { name: "codex" },
+      { name: "aider" },
+      { name: "gemini" },
+      { name: "amp" },
+      { name: "opencode" },
+    ],
+    ...over,
+  };
+}
+
+test("the picker offers every program the daemon lists, in the daemon's order", () => {
+  const choices = programChoices(catalog());
+
+  assert.deepEqual(
+    choices.map((c) => c.value),
+    [PROGRAM_REPO_DEFAULT, "claude", "codex", "aider", "gemini", "amp", "opencode"],
+    "repo default leads, then the daemon's list verbatim",
+  );
+});
+
+// THE anti-drift test, and the point of the design (#1970) — the web twin of
+// daemon/programs_test.go's TestListPrograms_NewProgramReachesClientsWithNoClientChange.
+//
+// An agent added server-side must reach the web with no web change: no enum to
+// extend, no label map to teach, no `if (name === …)`. This simulates exactly that:
+// a daemon that lists an agent this file has never heard of.
+//
+// If someone "helpfully" adds a local name→label map or an allow-list, this fails.
+test("an agent the web has never heard of is offered without a web change", () => {
+  const withNewAgent = catalog({
+    programs: [{ name: "claude" }, { name: "cursor" }],
+  });
+
+  const choices = programChoices(withNewAgent);
+
+  const cursor = choices.find((c) => c.value === "cursor");
+  assert.ok(cursor, "a newly supported agent must appear with no change to the web");
+  assert.equal(cursor.label, "cursor", "its label comes from the daemon's name, not a local map that would render it blank");
+});
+
+test("the repo default is labelled with the program it resolves to", () => {
+  const choices = programChoices(catalog({ default: "codex" }));
+
+  assert.equal(choices[0].value, PROGRAM_REPO_DEFAULT);
+  assert.equal(choices[0].label, "Repo default (codex)", "a user can see the repo defaults to codex without picking codex");
+});
+
+// The honesty case. An empty `default` means the daemon had no default to report,
+// so naming one here would invent a choice nobody made — the same failure the
+// served enum exists to prevent, one field over.
+test("a daemon that reports no default is not given one by the web", () => {
+  const choices = programChoices(catalog({ default: "" }));
+
+  assert.equal(choices[0].label, "Repo default", "no parenthetical, rather than a guessed agent name");
+});
+
+// The sentinel must stay the empty string: it is what the create/task requests
+// already send to mean "unspecified", so picking the default sends no program and
+// the repo's config decides. A non-empty sentinel would eventually be transmitted
+// as a literal program name and silently override the repo default.
+test("the repo-default choice submits as absent, not as a program name", () => {
+  assert.equal(PROGRAM_REPO_DEFAULT, "");
+  assert.equal(programChoices(catalog())[0].value, "");
+});
+
+// An unreachable catalog costs the user the choice, never the session: "repo
+// default" alone is exactly the behavior of sending no program at all.
+test("an unavailable catalog degrades to the repo default alone", () => {
+  const choices = programChoices(null);
+
+  assert.deepEqual(choices.map((c) => c.value), [PROGRAM_REPO_DEFAULT]);
+  assert.equal(choices[0].label, "Repo default");
+});
+
+// The task editor seeds its picker from the stored task. A program the catalog does
+// not list — one set via `af tasks add --program`, or one retired since — must
+// survive, or opening the editor to change a prompt silently rewrites the task's
+// agent to the repo default. That is data loss wearing the shape of a form.
+test("a seeded program the catalog does not list is preserved as a choice", () => {
+  const choices = programChoices(catalog(), "my-custom-agent");
+
+  const kept = choices.find((c) => c.value === "my-custom-agent");
+  assert.ok(kept, "an unlisted seeded program must remain selectable");
+  assert.equal(kept.label, "my-custom-agent");
+  assert.equal(choices[choices.length - 1].value, "my-custom-agent", "appended last, so it never displaces a real choice");
+});
+
+test("a seeded program the catalog already lists is not duplicated", () => {
+  const choices = programChoices(catalog(), "codex");
+
+  assert.equal(choices.filter((c) => c.value === "codex").length, 1);
+});
+
+// The seed is empty for a task that never set a program (it uses the repo default),
+// and must not become a blank option next to the real one.
+test("an empty or whitespace seed adds no choice", () => {
+  assert.deepEqual(programChoices(catalog(), "").map((c) => c.value), programChoices(catalog()).map((c) => c.value));
+  assert.deepEqual(programChoices(catalog(), "   ").map((c) => c.value), programChoices(catalog()).map((c) => c.value));
+});
+
+// Degrading and seeding compose: a catalog fetch that fails while editing a task
+// must still show that task's program, not silently reset it.
+test("a seeded program survives an unavailable catalog", () => {
+  const choices = programChoices(null, "aider");
+
+  assert.deepEqual(choices.map((c) => c.value), [PROGRAM_REPO_DEFAULT, "aider"]);
+});

--- a/web/src/programs.ts
+++ b/web/src/programs.ts
@@ -1,0 +1,96 @@
+// The create/task forms' agent-program choice (#1970).
+//
+// The web used to hardcode ["claude","codex","aider","gemini","amp","opencode"]
+// in two pickers (the new-session modal and the task form) while
+// session/tmux/session.go owned the canonical list. The TUI and CLI read the
+// canonical one, so both picked up a new agent for free; the web kept a copy,
+// which meant adding a sixth agent server-side left the web silently offering
+// five. Nothing failed — the copies happened to be current. The COUPLING was the
+// bug, and a parity test that merely caught the copy going stale was a mitigation,
+// not a fix.
+//
+// This module is the fix: it turns the daemon's ListPrograms answer into the
+// option list both forms render.
+//
+// The one rule this file exists to hold: THE WEB KNOWS NO AGENT NAMES. There is no
+// local enum, no name→label map, no `if (name === "claude")`. Every option is built
+// from the response, so an agent added server-side is offered here with no change
+// to this file — the property web/src/programs.test.ts pins. A label map would look
+// harmless and would silently render a new agent as blank.
+//
+// Note what is deliberately absent: availability. backends.ts carries a tri-state
+// status because a backend's preconditions are repo-config facts the daemon can
+// check. Whether an agent binary is installed is a fact about the machine the agent
+// will run on, which for a docker or ssh backend is not the daemon's machine — so
+// the daemon does not claim it and this module has nothing to render (see
+// daemon/programs.go). Programs are therefore a plain list, never blocked.
+
+/** One agent as the daemon reports it (daemon.ProgramOption). */
+export interface ProgramOption {
+  /** The wire value sent back as CreateSession's / AddTask's `program`. */
+  name: string;
+}
+
+/** The daemon's agent catalog (daemon.ListProgramsResponse). */
+export interface ProgramCatalog {
+  programs: ProgramOption[];
+  /** The program a create with no explicit program resolves to for this repo.
+   *  EMPTY when the daemon has no default to report, in which case the repo-default
+   *  choice is rendered with no parenthetical rather than naming a guess. */
+  default: string;
+}
+
+/** The sentinel value of the "repo default" choice. It is the EMPTY STRING on
+ *  purpose: it is what the create/task requests already send to mean "unspecified",
+ *  so picking the default sends no program and the repo's own config decides — the
+ *  same defaulting the CLI gets by leaving `--program` off. Any non-empty sentinel
+ *  here would eventually be sent as a literal program name. */
+export const PROGRAM_REPO_DEFAULT = "";
+
+/** An agent choice, ready to render as an <option>. */
+export interface ProgramChoice {
+  /** The <option> value: PROGRAM_REPO_DEFAULT, or a program name to send verbatim. */
+  value: string;
+  /** The visible label. It is the daemon's program name verbatim — deliberately NOT
+   *  looked up in a local name→label map, which is what would silently render a
+   *  newly added agent as blank. */
+  label: string;
+}
+
+/**
+ * Builds the program picker's choices from the daemon's catalog.
+ *
+ * The first choice is always "repo default", labelled with the agent it actually
+ * resolves to, so a user can see that a repo defaults to codex without having to
+ * pick codex. The rest are the daemon's programs in the order it sent them (its
+ * canonical enum order, which is append-only server-side and so stable).
+ *
+ * `keep` preserves a value the catalog does not list — a program set via the CLI,
+ * or one from an older af that has since been retired. Without it, opening the task
+ * editor to change a prompt would silently reset such a task to the repo default,
+ * which is data loss disguised as a form. It is appended last, so it never displaces
+ * a real choice, and it is trusted for the same reason backends.ts trusts an
+ * unrecognized selection: the daemon is the authority on what it accepts, and a
+ * client that vetoed a value it merely does not recognize would be the hardcoded-enum
+ * bug wearing a different hat.
+ */
+export function programChoices(catalog: ProgramCatalog | null, keep = ""): ProgramChoice[] {
+  const choices: ProgramChoice[] = [
+    {
+      value: PROGRAM_REPO_DEFAULT,
+      // "Repo default" with no parenthetical when the daemon reports no default —
+      // naming an agent there would be inventing one.
+      label: catalog === null || catalog.default === "" ? "Repo default" : `Repo default (${catalog.default})`,
+    },
+  ];
+
+  for (const opt of catalog?.programs ?? []) {
+    choices.push({ value: opt.name, label: opt.name });
+  }
+
+  const extra = keep.trim();
+  if (extra !== "" && !choices.some((c) => c.value === extra)) {
+    choices.push({ value: extra, label: extra });
+  }
+  return choices;
+}

--- a/web/src/tasks.ts
+++ b/web/src/tasks.ts
@@ -21,6 +21,7 @@
 // picker's Custom type.
 
 import { asForm, field, h, modalChrome, type ModalHandle, projectLabel } from "./modals.js";
+import { PROGRAM_REPO_DEFAULT, type ProgramCatalog, type ProgramChoice, programChoices } from "./programs.js";
 import { SCHEDULE_TYPE_OPTIONS, type Schedule, type ScheduleType, cron as scheduleCron, describe as scheduleDescribe, parseCron } from "./schedule.js";
 import type { TaskData } from "./types.js";
 
@@ -586,6 +587,10 @@ function taskFormModal(opts: {
   defaultProject: string | null;
   /** Present only in edit mode: the task whose current values seed the form. */
   seed?: TaskData;
+  /** Fetches the agent catalog for a project (#1970). Passed in rather than
+   *  imported so this module stays free of the API/token layer, and re-run on every
+   *  project change: the program a repo defaults to is a per-repo fact. */
+  loadPrograms: (repoPath: string) => Promise<ProgramCatalog>;
   onSubmit: (input: AddTaskInput) => void;
   onCancel: () => void;
 }): ModalHandle {
@@ -656,17 +661,56 @@ function taskFormModal(opts: {
   const targetInput = h("input", { type: "text", class: "af-input", placeholder: "Target session (optional)", autocomplete: "off" });
   targetInput.setAttribute("aria-label", "Target session");
 
+  // The program field (#1970). Its options come from the daemon, never from a list
+  // here, so an agent added server-side shows up with no change to the web.
   const programSelect = h("select", { class: "af-input" });
   programSelect.setAttribute("aria-label", "Program");
-  programSelect.append(h("option", { value: "" }, "Repo default"));
-  for (const prog of ["claude", "codex", "aider", "gemini", "amp", "opencode"]) {
-    programSelect.append(h("option", { value: prog }, prog));
-  }
+
+  // A program the catalog doesn't list (e.g. one set via the CLI, or one retired
+  // since the task was written) is carried through as a choice so an unrelated edit
+  // never silently resets it to the repo default — programChoices appends it last.
+  const keepProgram = opts.seed?.program ?? "";
+  let programs: ProgramChoice[] = programChoices(null, keepProgram);
+
+  const renderPrograms = (): void => {
+    const previous = programSelect.value;
+    programSelect.replaceChildren();
+    for (const choice of programs) {
+      programSelect.append(h("option", { value: choice.value }, choice.label));
+    }
+    programSelect.value = programs.some((c) => c.value === previous) ? previous : PROGRAM_REPO_DEFAULT;
+  };
+  renderPrograms();
+
+  // A per-load token: a slow catalog for the project the user just left must not
+  // overwrite the choices for the one they just picked.
+  let programSeq = 0;
+  const loadProgramsFor = (repoPath: string): void => {
+    const seq = ++programSeq;
+    void opts
+      .loadPrograms(repoPath)
+      .then((catalog) => {
+        if (seq !== programSeq) {
+          return;
+        }
+        programs = programChoices(catalog, keepProgram);
+        renderPrograms();
+      })
+      .catch(() => {
+        if (seq !== programSeq) {
+          return;
+        }
+        // Degrade to "repo default" (plus any seeded program) — an unreachable
+        // catalog costs the user the choice, never the task.
+        programs = programChoices(null, keepProgram);
+        renderPrograms();
+      });
+  };
+  projectSelect.addEventListener("change", () => loadProgramsFor(projectSelect.value));
 
   // Seed every field from the existing task (edit mode). The trigger picker follows
   // whichever of watch_cmd / cron_expr the task carries, and its field visibility is
-  // synced to match. A program the picker doesn't list (e.g. one set via the CLI) is
-  // appended first so an unrelated edit never silently resets it to the repo default.
+  // synced to match.
   if (opts.seed) {
     const s = opts.seed;
     nameInput.value = s.name ?? "";
@@ -679,11 +723,12 @@ function taskFormModal(opts: {
     syncTriggerFields();
     promptArea.value = s.prompt ?? "";
     targetInput.value = s.target_session ?? "";
-    if (s.program && ![...programSelect.options].some((o) => o.value === s.program)) {
-      programSelect.append(h("option", { value: s.program }, s.program));
-    }
     programSelect.value = s.program ?? "";
   }
+
+  // Kicked off after the seed so the catalog's re-render preserves the seeded
+  // program as the current selection rather than clobbering it with the default.
+  loadProgramsFor(projectSelect.value);
 
   body.append(
     field("Name", nameInput),
@@ -745,13 +790,18 @@ function taskFormModal(opts: {
 export function addTaskModal(
   projects: string[],
   defaultProject: string | null,
-  callbacks: { onSubmit: (input: AddTaskInput) => void; onCancel: () => void },
+  callbacks: {
+    onSubmit: (input: AddTaskInput) => void;
+    onCancel: () => void;
+    loadPrograms: (repoPath: string) => Promise<ProgramCatalog>;
+  },
 ): ModalHandle {
   return taskFormModal({
     title: "Add task",
     confirmLabel: "Add",
     projects,
     defaultProject,
+    loadPrograms: callbacks.loadPrograms,
     onSubmit: callbacks.onSubmit,
     onCancel: callbacks.onCancel,
   });
@@ -763,7 +813,11 @@ export function addTaskModal(
 export function editTaskModal(
   projects: string[],
   task: TaskData,
-  callbacks: { onSubmit: (input: AddTaskInput) => void; onCancel: () => void },
+  callbacks: {
+    onSubmit: (input: AddTaskInput) => void;
+    onCancel: () => void;
+    loadPrograms: (repoPath: string) => Promise<ProgramCatalog>;
+  },
 ): ModalHandle {
   return taskFormModal({
     title: "Edit task",
@@ -771,6 +825,7 @@ export function editTaskModal(
     projects,
     defaultProject: task.project_path,
     seed: task,
+    loadPrograms: callbacks.loadPrograms,
     onSubmit: callbacks.onSubmit,
     onCancel: callbacks.onCancel,
   });


### PR DESCRIPTION
Closes #1970. Closes #2079.

## The gap

`session/tmux/session.go` owns the canonical agent list. The TUI reads it (`app/handle_input.go`) and the CLI advertises it (`commands/root.go`, `api/api.go`), so both pick up a new agent for free. The web hardcoded a copy — in **two** pickers, `web/src/modals.ts` (new session) and `web/src/tasks.ts` (task form).

The lists matched, so nothing was broken for a user. What was broken was the coupling: add a seventh agent server-side and the web silently keeps offering six, with no failing test and no error — the first signal being someone asking where their agent went.

#1937's `TestWebProgramEnumMatchesWire` made that drift loud, but as the issue says, a check that catches a stale copy is a mitigation, not a fix. It lets the copy exist as long as someone remembers to sync it, and "someone remembering" is exactly what has failed repeatedly.

## The fix

Serve the enum, following the `ListBackends` reference implementation (#1968/#1933):

- **`POST /v1/ListPrograms`** (`daemon/programs.go`) answers from `tmux.SupportedPrograms`, plus the program an unspecified create resolves to for a repo.
- **`web/src/programs.ts`** turns that response into the option list both pickers render. It knows no agent names: no local enum, no name→label map, no `if (name === …)`.

The acceptance criterion is the property the issue names, not a value: **a seventh agent must reach the web with no edit under `web/src`.** That is pinned on both sides — `TestListPrograms_NewProgramReachesClientsWithNoClientChange` and its web twin in `programs.test.ts`.

## Two deliberate divergences from ListBackends

**No availability claim.** A backend's preconditions are repo-config facts the daemon can read. Whether `aider` is installed is a fact about the machine the *agent* will run on — for a docker or ssh backend, not the daemon's machine. Probing the daemon's own PATH would answer with a **negative**: an agent present in the container reported as missing, hiding a working choice behind a confident lie. A probe that cannot know must not answer, so this one reports the enum and stops.

**`repo_path` is optional.** Availability is a per-repo property, so `ListBackends` errors without a repo. The agent enum is global — there *is* a repo-less answer — so a form with no project picked still gets the list. Only `Default` is repo-scoped.

## One decision function, not two

`Manager.CreateSession`'s program defaulting is extracted to `defaultProgramFor`, and `ListPrograms` reports by calling **the same function**. A catalog that restated the precedence could drift from the create it describes — the same class of bug as the hardcoded enum, one layer down.

`TestListPrograms_DefaultMatchesTheCreatePath` drives this end-to-end through a real `CreateSession` (not against `defaultProgramFor`, which would be tautological), with a repo default that **differs** from the global one — so a side that ignored the in-repo override fails instead of accidentally agreeing.

## The guard inverted, not deleted

The issue says to delete `TestWebProgramEnumMatchesWire` once the enum is served. I **replaced** it instead, because "serve the enum" is a property nothing in the type system enforces: a future picker can hand-type six strings and work perfectly today, exactly as these two did.

`TestWebHardcodesNoAgentEnum` asserts the stronger property — that **no copy exists** — and is deliberately not anchored on the old `const prog of [` spelling, which would have missed a copy in a const, a `Set`, or a default parameter.

A negative check goes green just as easily when it has gone **blind**, so it ships with guards on itself:
- `TestAgentEnumDetectorIsNotVacuous` proves every run that the detector still fires on a synthetic copy, in four shapes.
- `TestStripCommentsDoesNotTruncateAtAURL` pins the comment scanner against the naive "cut at the first `//`" implementation, which a URL in a string literal would turn into a blind spot.

`parity/inventory.json` flips `enum.agent-programs` to `parity`. The `web.enum-sites: 2` coverage floor becomes `web.hardcoded-enum-sites` with **no** floor — a floor there would require the bug to exist.

## Adjacent sites audited

The parity test's own comment named two hardcoded sites; both are converted. `tasks.ts`'s "keep a program the picker doesn't list" behavior (a program set via the CLI must survive an unrelated edit) is preserved and moved into `programChoices(catalog, keep)`, with tests — dropping it would have been data loss wearing the shape of a form.

## Verification

- **Fail-first:** reverting only the two pickers to their hardcoded lists makes `TestWebHardcodesNoAgentEnum` fail, naming **both** sites.
- **Mutation-tested:** making `defaultProgramFor` ignore the repo entirely fails `DefaultMatchesTheCreatePath` and `DefaultSources` — the assertions discriminate rather than restating the default.
- Two of these tests failed on their first container run and the fixes are in: one asserted a false premise (a resolvable repo answers from its resolved config even with no manager), the other tripped the agent-specific readiness heuristic (the fake pane satisfies claude's and not gemini's, parking the test on a 60s start timeout). The second is now documented in the fixture so the next person does not rediscover it.
- `make test-container` — full suite green, 34 packages, exit 0.
- `go build ./...`, `gofmt -l .`, `golangci-lint --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh` — all clean.
- `npm test` (387 pass), `npm run typecheck`, `make web-build` with `web/dist` committed and verified byte-identical across rebuilds.

## Follow-ups folded in after CI

**Autogen docs (#1034 guard).** `docs/reference/api.md` is generated from
`daemon.HTTPRoutes()`, so a new route makes it stale. Regenerated with `make docs`
and committed; the table lists `/v1/ListPrograms` with its `repo_path` field, in the
catalog position `httpRoutes` declares it.

**A data race, and then its twin.** `go test -race` on the macOS lane failed on the
first version of the anti-drift test: it proved "a seventh agent flows through" by
appending one to `tmux.SupportedPrograms`, a global that
`tmux.DetectAgentFromCommand` reads on a hot path — and Go runs a package's tests
concurrently, so that write raced every other test resolving an agent name.

Nothing in production has ever written that enum. It is read-only after init, which
is exactly why the read path needs no lock; a test is not licence to make it mutable.

The fix extracts `programCatalog(programs []string)` — a pure function taking the
list as a **parameter** — so the property is provable by *passing* a list rather than
swapping the global. The write disappears instead of being synchronized; adding a
mutex would have meant locking a hot production read path to support one test. The
claim now splits into two, each stronger than the end-to-end version was: the builder
passes any list through untouched, and the RPC feeds it the canonical enum verbatim
(asserted against the builder, so the handler cannot filter on the way in).

Auditing the sibling site turned up **the identical pattern one file over**:
`daemon/backends_test.go` mutated `config.SupportedBackends`, which
`session.ParseBackend` reads. It had not fired yet — luck, not a difference in kind.
Filed as #2079 and then folded in here rather than left for later, since it is one
class and one fix pattern. `backendCatalog(names []string, …)` gets the same
treatment.

That also removed a *second* global mutation for free: the reworked backends test no
longer calls `session.SetRuntimeForTest`, because it never needed to —
`BackendUnusableReason` switches on the known kinds and consults no registry, so an
unrecognized backend correctly reports no config requirement, which is the property
under test. The registration looked load-bearing and was inert.

**On verification, precisely.** I could not reproduce either race locally — `-race`
over the full `./daemon` package with the racy code green'd, so it is
scheduling-dependent and the macOS runner is what surfaced it. So this is not
"reproduced and fixed". The stronger claim is available instead:

```
$ grep -rnE '(SupportedBackends|SupportedPrograms)\s*=' --include='*.go' . | grep -v '=='
session/tmux/session.go:27:var SupportedPrograms = []string{…}
config/backend.go:37:var SupportedBackends = []string{…}
```

Only the declarations. With no writer anywhere in the tree, both races are impossible
by construction rather than unlikely.

`-race -count=1 ./daemon ./session ./session/tmux ./config` green in the container.

## Note for the gate

The web bundle: this is one of two web PRs in this cluster. Whichever lands second will conflict on `web/dist/af-web.js` and needs `git rebase origin/master && make web-build`, never a hand-merge.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
