### PR TITLE
ci(web): run the web tests, bundle-reproducibility check and selftest in CI (#2069)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -113,6 +113,80 @@ jobs:
       - name: Run tests
         run: go test -v -race -count=1 ./...
 
+  # The web client's deterministic gates (#2069). Until this landed, NOTHING in
+  # GitHub Actions ran them: the schedule/frame/icons parity tests, the typecheck,
+  # and the committed-bundle reproducibility check were enforced only by a human
+  # typing `make web-test` locally. A web regression merged green.
+  #
+  # Runs on EVERY PR rather than behind a `web/**` path filter, for two reasons:
+  #
+  #   * The parity tests guard a CROSS-LANGUAGE contract. schedule.test.ts loads
+  #     schedule/testdata/vectors.json — a Go-owned file — precisely so the TUI and
+  #     web cannot drift (#2057). A `web/**` filter would skip the check on exactly
+  #     the Go-side change most likely to break it.
+  #   * pr.yml has no workflow-level path filter (Lint/Build must run on every PR),
+  #     and job-level filtering means either an external action or a hand-rolled
+  #     `git diff` step whose skip semantics then have to be reasoned about against
+  #     the merge_group event. The job costs well under a minute; the filter would
+  #     cost more than it saves.
+  #
+  # It uses the `make` targets rather than open-coding npm, so what CI runs is what
+  # a developer runs. A CI-only copy of these steps is how the two quietly diverge.
+  web:
+    name: Web
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      # Pinned major, matching the toolchain the lockfile was resolved against.
+      # `cache: npm` caches ~/.npm (the download cache), not node_modules — `npm ci`
+      # still runs and still installs from the lockfile, which is what keeps the
+      # bundle reproducible.
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      # `make web-test` runs `npm ci` (via the web/node_modules file target) then
+      # typecheck + the node:test suite: the frame codec golden vectors, the
+      # schedule parity vectors shared with Go, the icon set, and the unit tests.
+      - name: Typecheck and test the web client
+        run: make web-test
+
+      # Bundle reproducibility. web/dist is COMMITTED because the Go binary embeds
+      # it (web/embed.go) and the Go side must stay Node-free — so a PR that edits
+      # web/src and forgets `make web-build` ships a binary serving the OLD bundle,
+      # and nothing before this caught it. The selftest serves the committed dist,
+      # so it would have been testing the stale one too.
+      - name: Rebuild the committed bundle
+        run: make web-build
+
+      # `git status --porcelain`, not `git diff --exit-code`: diff sees modified
+      # tracked files but is BLIND to a new untracked one, so a build that started
+      # emitting an extra asset (an icon, a chunk) would pass a diff-only check while
+      # the committed dist was genuinely incomplete. Porcelain catches modified,
+      # untracked and deleted alike.
+      - name: Check the committed bundle matches web/src
+        run: |
+          dirty="$(git status --porcelain -- web/dist)"
+          if [ -n "$dirty" ]; then
+            echo "::error::web/dist is stale — it does not match a fresh build of web/src."
+            echo "$dirty"
+            echo
+            echo "The Go binary embeds the COMMITTED web/dist (web/embed.go), so this PR would"
+            echo "ship a bundle that does not match its source. Fix it with:"
+            echo
+            echo "    make web-build && git add web/dist"
+            echo
+            echo "Rebuild — never hand-edit or hand-merge dist/af-web.js; it is generated."
+            git diff -- web/dist | head -50
+            exit 1
+          fi
+          echo "web/dist matches a fresh build."
+
   # We cross-compile and ship darwin/arm64 and darwin/amd64 binaries from
   # stable-release.yml, but every job in this repo ran on ubuntu — so no test had
   # ever executed on the OS we ship to. macOS-only defects reached users instead
@@ -177,7 +251,7 @@ jobs:
     # blocks anyway, since it demands conclusion === "success", but the native path
     # would not.) So: run ALWAYS, and fail loudly on any unsuccessful need. Now a
     # red macOS job turns the REQUIRED check red instead of quietly skipping it.
-    needs: [lint, test, test-macos]
+    needs: [lint, test, test-macos, web]
     if: always()
     steps:
       - name: Gate on the jobs this check stands in for
@@ -186,7 +260,7 @@ jobs:
           echo "::error::A required job failed — failing Build so the required check goes RED rather than skipping."
           # needs['test-macos'], not needs.test-macos: a hyphen in a property path is
           # parsed as subtraction, so the dotted form silently yields an empty string.
-          echo "lint=${{ needs.lint.result }} test=${{ needs.test.result }} test-macos=${{ needs['test-macos'].result }}"
+          echo "lint=${{ needs.lint.result }} test=${{ needs.test.result }} test-macos=${{ needs['test-macos'].result }} web=${{ needs.web.result }}"
           exit 1
 
       - uses: actions/checkout@v6

--- a/.github/workflows/web-selftest.yml
+++ b/.github/workflows/web-selftest.yml
@@ -1,0 +1,99 @@
+name: Web selftest
+
+# The Playwright web-driver selftest (#1592 Phase 5 PR6, docs/web-selftest.md):
+# a real af daemon on a throwaway home, two seeded sessions behind a fake agent,
+# and the embedded SPA driven in a headless Chromium. It is the acceptance proof
+# for the web client and, until #2069, it ran only when someone typed `make
+# web-selftest-container` by hand.
+#
+# It lives in its OWN workflow rather than as a job in pr.yml for two reasons:
+#
+#   * pr.yml has no `paths:` filter because its Lint/Build jobs must run on every
+#     PR. This one is expensive — it builds a Go+Node+Chromium image, then boots a
+#     daemon and a browser — so it is worth filtering, and a workflow-level
+#     `paths:` is the only native way to do that.
+#   * It is deliberately NOT wired into pr.yml's Build job, so it does not gate
+#     merges. See "Why this does not gate" below.
+#
+# The fast, deterministic web checks (parity tests + bundle reproducibility) DO
+# gate — they are the `Web` job in pr.yml.
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      # The SPA itself, and the committed bundle the harness actually serves.
+      - 'web/**'
+      # The harness drives a REAL daemon, so the daemon's HTTP/WS surface and the
+      # embedding are as capable of breaking it as web/ is. #1932 (a header that
+      # went stale) and #1894 (a detach that dropped scroll) were both found here.
+      - 'daemon/**'
+      - 'agentproto/**'
+      - 'apiproto/**'
+      # The harness itself.
+      - 'scripts/testbox.sh'
+      - 'scripts/container/Dockerfile.web-selftest'
+      - 'scripts/container/web-selftest-entry.sh'
+      - '.github/workflows/web-selftest.yml'
+
+concurrency:
+  group: web-selftest-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+# Read-only: checks out source and runs the harness in a container. It never
+# comments on or modifies the PR.
+permissions:
+  contents: read
+
+jobs:
+  selftest:
+    name: Web selftest
+    runs-on: ubuntu-latest
+    # The image build (Go + Node + Chromium + system deps) dominates a cold run.
+    # GitHub gives no persistent docker layer cache between runs, so budget for
+    # the cold path every time — but not for a hung browser burning six hours.
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v6
+
+      # `make web-selftest-container` is the ONLY sanctioned entry point
+      # (docs/web-selftest.md), and CI uses it verbatim rather than reimplementing
+      # the steps — a CI-only copy of the harness is how the thing CI runs stops
+      # being the thing developers run. The ubuntu runner ships Docker, which is
+      # all the target needs; pr.yml's macOS job cannot host it for exactly this
+      # reason.
+      #
+      # Everything (daemon, tmux, browser) lives on 127.0.0.1 inside an ephemeral
+      # container with no published ports, so this is as isolated on a runner as
+      # it is on a dev box.
+      - name: Run the web-driver selftest
+        run: make web-selftest-container
+
+      # No artifact-upload step, deliberately. The harness copies /src into /work
+      # inside the container (the bind mount is read-only) and Playwright writes
+      # its traces there, so they die with the container — there is nothing on the
+      # host to upload. A step pointing at web/test-results/ would upload an empty
+      # artifact on every failure and read as though traces were captured.
+      #
+      # What you get instead is Playwright's reporter output in the job log, which
+      # names the failing assertion. For a trace, reproduce locally:
+      #   make web-selftest-container
+
+# ── Why this does not gate ────────────────────────────────────────────────────
+#
+# This repo's ruleset (14851503) requires only "Lint" and "Build", so a new job
+# gates nothing unless pr.yml's Build job lists it in `needs` — the mechanism
+# documented on the auto-gate helper test. That was a deliberate choice NOT to
+# use here:
+#
+#   * Cost: a cold Go+Node+Chromium image build plus a daemon+browser boot on
+#     every web PR, against ~40s for the deterministic checks that do gate.
+#   * Flake surface: it drives a real browser against a real daemon over a real
+#     PTY. Those have been contention-sensitive (see the dev-box selftest flakes),
+#     and a flaky REQUIRED check blocks every merge in the repo, not just web PRs.
+#
+# So it runs as a signal: red here means read it before merging. To promote it to
+# a gate, add `web-selftest` to pr.yml's Build `needs` — but note that a job in
+# ANOTHER workflow cannot be a `needs` dependency, so promoting it means moving it
+# into pr.yml (accepting the cost on every PR) or adding "Web selftest" to the
+# ruleset's required checks, which needs repo-admin access.

--- a/docs/web-selftest.md
+++ b/docs/web-selftest.md
@@ -32,6 +32,25 @@ Everything — the daemon, its tmux server, the sessions, the browser — lives 
 ports**, no access to the host tmux server, and no touch of the real
 `~/.agent-factory`, exactly like the other container harnesses.
 
+## In CI
+
+Since #2069 a PR touching `web/`, `daemon/`, `agentproto/`, `apiproto/` or the
+harness itself also runs this on a GitHub runner
+(`.github/workflows/web-selftest.yml`), using the same `make` target — CI does
+not keep its own copy of the steps.
+
+It is a **signal, not a gate**: it is not in `pr.yml`'s `Build` `needs`, so a red
+run does not block the merge button. Read it before merging anyway. The reasoning
+(cost on every web PR, and the flake surface of a real browser driving a real
+daemon) and the promotion path are written out in that workflow.
+
+The deterministic web checks — typecheck, the unit/parity suites, and
+`web/dist` reproducibility — **do** gate, as pr.yml's `Web` job.
+
+Failures give you Playwright's assertion output in the job log but no trace: the
+harness works inside the container's own copy of the tree, so its
+`web/test-results/` never reaches the host. Reproduce locally for a trace.
+
 ## What it asserts
 
 Against the live SPA served over the daemon's plain-HTTP listener:


### PR DESCRIPTION
Closes #2069.

## The gap

The web has real correctness tests and NO GitHub workflow ran any of
them. `schedule.test.ts` (the TUI↔web cron parity vectors), `frame.test.ts`
(the PTY codec golden vectors), `icons.test.ts`, the typecheck, the
committed-bundle reproducibility check, and the Playwright selftest were
all enforced only by a human typing `make web-test` locally.

So a web regression merged green, and two things could rot silently:

- **Anti-drift became advisory.** #2057's whole design is that the web and
  Go share `schedule/testdata/vectors.json` so they cannot diverge. If a
  PR broke that parity, CI stayed green — the #2068 reviewer had to run
  the suite by hand to close the gate.
- **A stale bundle shipped.** `web/dist` is committed because the binary
  embeds it and the Go side stays Node-free. A PR that edits `web/src`
  and forgets `make web-build` ships a binary serving the OLD bundle —
  and the selftest, which serves the committed dist, would have been
  testing the stale one too.

## Two jobs, deliberately split by cost

**`Web` (pr.yml, GATES).** Typecheck + the node:test suites + `make
web-build` + a working-tree check on `web/dist`. Under a minute, fully
deterministic.

It is wired into `Build`'s `needs`, which is how a job gets teeth in this
repo: the ruleset requires only "Lint" and "Build", so a standalone job
would gate nothing until someone edited it — the same reasoning already
written on the auto-gate helper test.

**`Web selftest` (its own workflow, SIGNAL ONLY).** The Playwright
harness via the existing `make web-selftest-container`.

Not gated, on purpose: it builds a Go+Node+Chromium image and boots a
daemon and a browser on every web PR, and it drives real processes over a
real PTY — a flaky REQUIRED check blocks every merge in the repo, not
just web PRs. The tradeoff and the promotion path are written into the
workflow rather than left implicit.

## Three judgment calls worth flagging

**The `Web` job is NOT `web/**`-path-filtered**, which the issue's wording
suggests. The parity tests guard a CROSS-LANGUAGE contract: `schedule.test.ts`
loads a Go-owned `vectors.json` precisely so the two cannot drift, so a
`web/**` filter would skip the check on exactly the Go-side change most
likely to break it. The job is cheap enough that the filter would cost more
than it saves. The expensive selftest IS path-filtered.

**`git status --porcelain`, not `git diff --exit-code`** for the bundle
check. `diff` sees modified tracked files but is blind to a new UNTRACKED
one, so a build that started emitting an extra asset would pass while the
committed dist was genuinely incomplete.

**CI calls the `make` targets** rather than open-coding npm, so what CI
runs is what a developer runs. A CI-only copy is how the two diverge.

## No artifact upload

Deliberately omitted rather than forgotten. The harness copies the tree
into the container (the bind mount is read-only) and Playwright writes
traces there, so they die with the container — nothing on the host to
upload. A step pointing at `web/test-results/` would upload an empty
artifact on every failure and read as though traces were captured.

## Verification

Each step was run locally as CI will run it:

- `make web-test` — 375 pass.
- `make web-build` + the porcelain check on a clean tree — passes.
- **Fail-first:** committing an edit to `web/src/status.ts` WITHOUT
  rebuilding makes the check fire, naming `web/dist/af-web.js` and
  `web/dist/sw.js`. Reverted after.
- `make web-build` verified byte-identical across consecutive rebuilds, so
  the reproducibility check cannot false-fire.
- Both workflow files parse, and `Build.needs` resolves to
  `[lint, test, test-macos, web]`.
- `make web-selftest-container` run end-to-end on this branch: **97 Playwright
  tests pass in 48s**, exit 0 (~7 min wall including the cold image build). So the
  job I am adding is green today rather than a red signal shipped on faith.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
