### PR TITLE
fix(tui): N (new remote) explains itself instead of eating the keypress (#2020)

### DIFF
--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -223,7 +223,21 @@ func (m *home) startNewInstance(remote bool) (tea.Model, tea.Cmd) {
 			return m, m.handleError(err)
 		}
 		if !configured {
-			return m, nil
+			// The menu advertises `N new remote` next to `n new`, so an
+			// unconfigured repo must SAY that rather than eat the keypress
+			// (#2020). RemoteHooksConfiguredForPath reports the unconfigured
+			// repo as (false, nil) — a normal empty state, not an error — which
+			// is why only a MALFORMED remote_hooks config used to surface
+			// anything, and the common case (no remote_hooks at all) did
+			// nothing at all. Every other gated action in the TUI explains
+			// itself; this was the one that did not.
+			//
+			// The cause and the fix lead the sentence: the transient notice
+			// clips to the terminal width and the tail is what disappears
+			// (#1973), so the guide URL — recoverable under `E details` — goes
+			// last.
+			return m, m.handleError(fmt.Errorf(
+				"remote sessions need a remote_hooks backend configured for this repo — press n for a local session, or configure remote_hooks and try again. Guide: https://sachiniyer.github.io/agent-factory/remote-hooks/"))
 		}
 	}
 	instance, err := session.NewInstance(session.InstanceOptions{

--- a/app/handle_input_test.go
+++ b/app/handle_input_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -171,7 +172,14 @@ func TestStartNewInstanceSelectsNamingInstanceAfterSortedInsert(t *testing.T) {
 		"the #1350 BeginCreate chokepoint still fires exactly once when naming starts")
 }
 
-func TestStartNewRemoteWithoutHooksNoops(t *testing.T) {
+// TestStartNewRemoteWithoutHooksExplains is the #2020 regression guard. The menu
+// advertises `N new remote` as a peer of `n new`, but for a repo with no
+// remote_hooks — nearly every repo — N used to be a silent no-op: byte-identical
+// screen, no overlay, no error, no hint that remote sessions need setup. This
+// asserts the visible outcome, naming remote_hooks so the user knows what to
+// configure. It inverts the earlier TestStartNewRemoteWithoutHooksNoops, which
+// pinned the swallow as intended behavior.
+func TestStartNewRemoteWithoutHooksExplains(t *testing.T) {
 	repoDir := setupRealRepo(t)
 	t.Chdir(repoDir)
 
@@ -181,11 +189,37 @@ func TestStartNewRemoteWithoutHooksNoops(t *testing.T) {
 	model, cmd := h.startNewInstance(true)
 
 	require.Same(t, h, model)
-	require.Nil(t, cmd)
+	require.NotNil(t, cmd, "pressing an advertised key must produce a visible outcome, never a swallowed keypress")
+	// No session is created and no naming overlay opens — the refusal itself is
+	// unchanged; only its silence is.
 	assert.Equal(t, stateDefault, h.state)
 	assert.Nil(t, h.namingInstance)
 	assert.Equal(t, 0, h.store.NumInstances())
-	assert.Empty(t, h.errBox.FullError())
+
+	full := h.errBox.FullError()
+	assert.Contains(t, full, "remote_hooks", "the message must name the config the user has to add")
+	assert.Contains(t, full, "n for a local session", "the message must offer the action that does work here")
+}
+
+// TestStartNewRemoteWithoutHooksLeadsWithTheCause pins the ordering the #1973
+// clipping class forces: the transient notice is truncated to the terminal
+// width and the TAIL is what vanishes, so the cause has to arrive before the
+// guide URL rather than after it.
+func TestStartNewRemoteWithoutHooksLeadsWithTheCause(t *testing.T) {
+	repoDir := setupRealRepo(t)
+	t.Chdir(repoDir)
+
+	h := newTestHome(t)
+	h.errBox.SetSize(120, 1)
+
+	h.startNewInstance(true)
+
+	full := h.errBox.FullError()
+	cause := strings.Index(full, "remote_hooks")
+	url := strings.Index(full, "https://")
+	require.NotEqual(t, -1, cause)
+	require.NotEqual(t, -1, url)
+	assert.Less(t, cause, url, "the cause must survive width-clipping; the URL is the part that may be cut")
 }
 
 func TestStartNewRemoteInvalidHooksStillErrors(t *testing.T) {


### PR DESCRIPTION
Closes #2020.

## The bug

The empty-state menu advertises `N new remote` as a peer of `n new`, but for a repo with no `remote_hooks` — nearly every repo — `N` did absolutely nothing. Byte-identical screen, no overlay, no error, no hint that remote sessions need setup.

`RemoteHooksConfiguredForPath` reports an unconfigured repo as `(false, nil)` — a normal empty state rather than an error — so only a **malformed** `remote_hooks` config took the error branch. The common case fell straight into `return m, nil`.

Every other gated action in the TUI explains itself (new-tab on a remote instance, closing the agent tab). This was the one that did not — the #988 advertise-but-unavailable class.

## The shape chosen

Sachin offered two: **disable-with-reason** or **act-or-explain**, preferring the former *if the menu can express disabled items*. It can't — the menu can only show or hide a hint (`splitPaneAvailable`, #1419), and hiding `N` outright would cost the discoverability the hint exists for. So: act-or-explain. `N` stays pressable and now names `remote_hooks` as the thing to configure, offers `n` as the action that does work here, and links the guide.

Message ordering is deliberate. The transient notice clips to the terminal width and the **tail** is what disappears (#1973), so the cause leads and the URL — recoverable under `E details` — goes last. A test pins that ordering so a later edit cannot quietly bury the cause.

## Play-tested against the real TUI at 80x24

Pressing `N` in a repo with no `remote_hooks`:

```
               n new • N new remote │ / search │ ? help • q quit
remote sessions need a remote_hooks backend configured for this repo…  E details
```

The consequential half survives the clip. `E details` shows the whole thing, and the guide URL returns 200. Confirmed `n` still opens the naming overlay.

## Adjacent-site audit

The sibling silent returns in `handle_input.go` / `handle_actions.go` are all `selected == nil` and `IsCreating()` guards, where the screen already shows why and there is nothing for the user to configure. The `remote_hooks` gate was the only one refusing an **advertised** action for a reason the user could have acted on.

## Tests

`TestStartNewRemoteWithoutHooksNoops` pinned the swallow as intended behavior; it is inverted into `TestStartNewRemoteWithoutHooksExplains`. Both new tests fail on the pre-fix handler (`require.NotNil(cmd)` fails; the cause string is absent).

Full suite green in the container, rebased onto #2075 which touched the same create-session path.