### PR TITLE
fix(session): stop editing users' global agent config as a session side effect (#1977)

### DIFF
--- a/commands/configcmd.go
+++ b/commands/configcmd.go
@@ -86,6 +86,7 @@ func configEntries(cfg *config.Config) []configEntry {
 		{"theme", cfg.Theme},
 		{"root_agents", cfg.RootAgents},
 		{"limit_auto_resume", cfg.LimitAutoResume},
+		{"global_agent_skills", cfg.GlobalAgentSkills},
 		{"limit_retry_interval", cfg.LimitRetryInterval},
 		{"limit_patterns", cfg.LimitPatterns},
 		{"keys", cfg.KeymapOverrides()},
@@ -223,6 +224,7 @@ Settable keys:
   limit_auto_resume          true | false
   limit_retry_interval       Go duration (e.g. 30m), or "" to never retry
   limit_patterns.<agent>     usage-limit banner regex for an agent
+  global_agent_skills        true | false
 
 Structural keys (root_agents, [theme], the [keys] rebind table) and the
 cors_allowed_origins list are not settable here — edit config.toml directly.

--- a/config/config_types.go
+++ b/config/config_types.go
@@ -202,6 +202,29 @@ type Config struct {
 	// retry from PR2) and the scheduler does zero work. Deliberately GLOBAL-ONLY
 	// (it configures daemon behavior), like auto_yes / daemon_poll_interval.
 	LimitAutoResume bool `json:"limit_auto_resume" toml:"limit_auto_resume"`
+	// GlobalAgentSkills opts af into writing its "agent-factory" skill file
+	// into the USER'S GLOBAL per-agent config directories — codex's
+	// $CODEX_HOME/skills, gemini's ~/.gemini/skills, amp's
+	// ~/.config/amp/skills — so those agents discover af's CLI guidance
+	// (#1977). DEFAULT FALSE: creating a session is not consent to edit the
+	// user's global tool configuration, and a file written there outlives the
+	// session, survives uninstalling af, and still loads when the user runs
+	// that agent by hand somewhere af has nothing to do with.
+	//
+	// It governs ONLY the three agents with no per-launch pointer. claude
+	// (--plugin-dir), aider (--read) and opencode (OPENCODE_CONFIG) get the
+	// same guidance from af-OWNED files under af's own config dir, are
+	// unaffected by this key, and stay on unconditionally — nothing of af's
+	// escapes into the user's config on those paths.
+	//
+	// With it false, af additionally removes the marker-stamped file a PRIOR af
+	// version wrote, so the edit does not outlive the decision not to make it.
+	// A file at that path without af's marker is the user's and is never
+	// touched either way.
+	//
+	// Global-only, like auto_yes and root_agents: what af writes into your home
+	// directory must not be settable by cloning a repo.
+	GlobalAgentSkills bool `json:"global_agent_skills" toml:"global_agent_skills"`
 	// LimitRetryInterval is the fixed fallback cadence the auto-resume scheduler
 	// uses ONLY when a usage-limit banner carried no parseable reset time (#1146
 	// PR3): a Go duration string ("30m", "1h"). Empty or a non-positive duration
@@ -409,6 +432,7 @@ func DefaultConfig() *Config {
 		ListenAddr:           defaultListenAddr,
 		DaemonPollInterval:   defaultDaemonPollInterval,
 		LimitAutoResume:      false,
+		GlobalAgentSkills:    false,
 		LimitRetryInterval:   defaultLimitRetryInterval,
 		LogMaxSizeMB:         log.DefaultMaxSizeMB,
 		LogMaxBackups:        log.DefaultMaxBackups,

--- a/config/configset.go
+++ b/config/configset.go
@@ -101,6 +101,7 @@ var settableKeySpecs = map[string]settableKeySpec{
 	// where the binary is actually run, and already lives there.
 	"vscode_server_binary": {kind: cfgString},
 	"limit_auto_resume":    {kind: cfgBool},
+	"global_agent_skills":  {kind: cfgBool},
 	"limit_retry_interval": {kind: cfgString, validate: func(_, v string) error {
 		return validateLimitRetryIntervalValue(v)
 	}},

--- a/config/inrepo.go
+++ b/config/inrepo.go
@@ -114,7 +114,11 @@ var inRepoGlobalOnlyKeys = map[string]bool{
 	"cors_allowed_origins": true,
 	"daemon_poll_interval": true,
 	"detach_keys":          true,
-	"listen_addr":          true,
+	// What af writes into your HOME directory is a user/host decision; a
+	// cloned repo must never be able to opt you into af editing your global
+	// codex/gemini/amp config (#1977).
+	"global_agent_skills": true,
+	"listen_addr":         true,
 	// The [keys] keymap is a user/host preference: a cloned repo must never
 	// be able to rebind someone's terminal (#1026).
 	"keys":                 true,

--- a/config/manifest.go
+++ b/config/manifest.go
@@ -255,6 +255,14 @@ var configManifest = []ManifestEntry{
 		Settable: true,
 	},
 	{
+		Key:      "global_agent_skills",
+		Type:     "bool",
+		Default:  "false",
+		Purpose:  "Let af add its af-usage skill to your own codex/gemini/amp config folders · off means those agents are not told about af.",
+		Tier:     TierAdvanced,
+		Settable: true,
+	},
+	{
 		Key:      "limit_retry_interval",
 		Type:     "string",
 		Default:  "30m",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,7 +9,7 @@ Precedence is **app defaults → global config → in-repo config**: an in-repo 
 
 Config is [TOML](https://toml.io) — chosen so it is easy to hand-edit. If you are upgrading from a version that used `config.json`, see [Migrating from JSON](#migrating-from-json) below; the change is automatic.
 
-You can also read and write the global config from the CLI: `af config get <key>` / `af config list` print the effective values, and `af config set <key> <value>` writes a single settable scalar key **in place**, preserving all comments and ordering (it never regenerates the file) and validating the value first. Settable keys are the scalar tunables — `default_program`, `program_overrides.<agent>`, `auto_yes`, `auto_update`, `listen_addr`, `require_token`, `require_loopback_token`, `daemon_poll_interval`, `log_max_size_mb`, `log_max_backups`, `branch_prefix`, `worktree_root`, `detach_keys`, `update_channel`, `vscode_server_binary`, `limit_auto_resume`, `limit_retry_interval`, `limit_patterns.<agent>`; the structural tables (`root_agents`, `[theme]`, `[keys]`) and the `cors_allowed_origins` list are hand-edited only. See [`af config`](reference/cli.md#af-config) in the CLI reference. Changes apply on the next `af`/daemon start, the same as a hand-edit.
+You can also read and write the global config from the CLI: `af config get <key>` / `af config list` print the effective values, and `af config set <key> <value>` writes a single settable scalar key **in place**, preserving all comments and ordering (it never regenerates the file) and validating the value first. Settable keys are the scalar tunables — `default_program`, `program_overrides.<agent>`, `auto_yes`, `auto_update`, `listen_addr`, `require_token`, `require_loopback_token`, `daemon_poll_interval`, `log_max_size_mb`, `log_max_backups`, `branch_prefix`, `worktree_root`, `detach_keys`, `update_channel`, `vscode_server_binary`, `limit_auto_resume`, `limit_retry_interval`, `limit_patterns.<agent>`, `global_agent_skills`; the structural tables (`root_agents`, `[theme]`, `[keys]`) and the `cors_allowed_origins` list are hand-edited only. See [`af config`](reference/cli.md#af-config) in the CLI reference. Changes apply on the next `af`/daemon start, the same as a hand-edit.
 
 ## Global config
 
@@ -27,6 +27,7 @@ log_max_size_mb = 50
 log_max_backups = 2
 update_channel = "stable"
 limit_auto_resume = false
+global_agent_skills = false
 limit_retry_interval = "30m"
 
 [program_overrides]
@@ -75,6 +76,7 @@ pane_border_preview = "#DC8CC3"
 | `root_agents` | Opt-in table of repositories that get an always-ensured `root` agent (default: none). See [Root agents](#root-agents-always-ensured). |
 | `limit_auto_resume` | Opt in to the daemon auto-resuming a session parked at a usage-limit wall once its limit window elapses (default: `false`). See [Usage-limit auto-resume](#usage-limit-auto-resume). |
 | `limit_retry_interval` | Fallback retry cadence (Go duration, e.g. `30m`) used only when `limit_auto_resume` is on **and** the limit banner carried no parseable reset time (default: `30m`). Empty or `0` disables the fallback. |
+| `global_agent_skills` | Opt in to af writing its `agent-factory` skill file into your **global** codex/gemini/amp config directories so those agents discover af's CLI guidance (default: `false`). See [Agent guidance and your global agent config](#agent-guidance-and-your-global-agent-config). |
 | `limit_patterns` | Optional map from agent enum to a regex that overrides the built-in usage-limit **detection** banner for that agent (the built-in reset-time parser is kept). Default: none. See [Custom usage-limit detection](#custom-usage-limit-detection-limit_patterns). |
 | `theme` | Optional TUI color table. Defaults to a Zenburn-derived palette and validates each value as `#RRGGBB`; invalid values fall back to the corresponding default with a warning. See [Theme colors](#theme-colors-theme). |
 | `keys` | Optional keymap overrides for the TUI. See [Key bindings](#key-bindings-keys). |
@@ -208,6 +210,26 @@ scroll_up = "shift+up"
 scroll_down = "shift+down"
 ```
 
+### Agent guidance and your global agent config
+
+af teaches each agent how to drive `af` itself — `af sessions whoami`, `af sessions archive --self`, and the rest. How that guidance reaches the agent depends on what the agent supports.
+
+For **claude**, **aider** and **opencode**, af owns the file and points the agent at it for that launch only (`--plugin-dir`, `--read`, and `OPENCODE_CONFIG` respectively). Everything lives under af's own config directory, so it disappears when you uninstall af and is invisible to an agent af did not launch.
+
+**codex**, **gemini** and **amp** auto-discover skills from a directory in your home and offer no per-launch pointer to an extra one. The only way to reach them is to write a file into *your* config — `$CODEX_HOME/skills/agent-factory/`, `~/.gemini/skills/agent-factory/`, `~/.config/amp/skills/agent-factory/` — which outlives the session, survives uninstalling af, and applies when you run those agents by hand somewhere af has nothing to do with. Creating a session is not consent to that, so **af does not do it by default**:
+
+```toml
+global_agent_skills = true
+```
+
+With it on, af writes (and keeps up to date) a single `agent-factory/SKILL.md` under each of those agents' skills directories. With it off — the default — those three agents simply do not get af's guidance; everything else about the session is unchanged.
+
+af only ever manages the file it wrote. Each one carries an af marker, and:
+
+- a file at that path **without** the marker is yours and is never overwritten or removed;
+- turning the key off (or leaving it off after an af version that wrote one) removes af's **own** marked file, so af's edit does not outlive the decision;
+- the `agent-factory/` directory is removed only if it is empty, so anything you put beside af's file keeps the directory alive.
+
 ### Choosing the agent
 
 Override the agent for new sessions with `-p`:
@@ -241,7 +263,7 @@ delete_cmd = "./infra/delete.sh"
 | `default_program`, `program_overrides` | Valid globally **and** in-repo (in-repo wins). |
 | `post_worktree_commands`, `remote_hooks` | **In-repo only.** The legacy `~/.agent-factory/repos/<repoID>/config.json` location keeps working for one more release (a deprecation warning in the log points at the new file) and is shadowed whenever the in-repo file sets the same key — including by an explicit empty value like `post_worktree_commands = []`. |
 | `backend`, `docker`, `ssh` | **In-repo only.** Select the runtime a repo's sessions run on. |
-| `auto_yes`, `auto_update`, `require_token`, `require_loopback_token`, `listen_addr`, `cors_allowed_origins`, `daemon_poll_interval`, `branch_prefix`, `worktree_root`, `detach_keys`, `log_max_size_mb`, `log_max_backups`, `update_channel`, `keys`, `theme`, `root_agents`, `limit_auto_resume`, `limit_retry_interval`, `vscode_server_binary` | Global only. Setting them in-repo is rejected with an error naming the key. The daemon network-surface keys (`require_token`, `listen_addr`, `cors_allowed_origins`) are global-only so a cloned repo can never open a port, widen CORS, or disable auth. `vscode_server_binary` is global-only for the same reason: it names a binary the daemon executes. See [remote-http-auth.md](remote-http-auth.md). |
+| `auto_yes`, `auto_update`, `require_token`, `require_loopback_token`, `listen_addr`, `cors_allowed_origins`, `daemon_poll_interval`, `branch_prefix`, `worktree_root`, `detach_keys`, `log_max_size_mb`, `log_max_backups`, `update_channel`, `keys`, `theme`, `root_agents`, `limit_auto_resume`, `limit_retry_interval`, `vscode_server_binary`, `global_agent_skills` | Global only. Setting them in-repo is rejected with an error naming the key. The daemon network-surface keys (`require_token`, `listen_addr`, `cors_allowed_origins`) are global-only so a cloned repo can never open a port, widen CORS, or disable auth. `vscode_server_binary` is global-only for the same reason: it names a binary the daemon executes. See [remote-http-auth.md](remote-http-auth.md). |
 
 `post_worktree_commands` are shell commands run after each new worktree is created (e.g. `npm install`, `make build`) — they can also be edited from the TUI via the `e` (worktree hooks) key. `remote_hooks` configures a remote-machine backend; see [remote-hooks.md](remote-hooks.md) for the script protocol.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -535,6 +535,7 @@ Settable keys:
   limit_auto_resume          true | false
   limit_retry_interval       Go duration (e.g. 30m), or "" to never retry
   limit_patterns.<agent>     usage-limit banner regex for an agent
+  global_agent_skills        true | false
 
 Structural keys (root_agents, [theme], the [keys] rebind table) and the
 cors_allowed_origins list are not settable here — edit config.toml directly.

--- a/session/agentskill.go
+++ b/session/agentskill.go
@@ -65,6 +65,36 @@ func writeAfMarkedFile(path, content string) (bool, error) {
 	return true, nil
 }
 
+// globalSkillConsent is what af knows about the user's answer to "may af manage
+// your global agent config?". It has THREE values on purpose (#1933's rule): a
+// config af could not read is UNKNOWN, not "no" — collapsing it to "no" would
+// let an unreadable config authorize deleting a file, which is the
+// fabricated-negative shape this repo keeps getting bitten by.
+type globalSkillConsent int
+
+const (
+	globalSkillUnknown globalSkillConsent = iota // config unreadable: write nothing, delete nothing
+	globalSkillDeclined
+	globalSkillGranted
+)
+
+// globalAgentSkillsConsent reads the global_agent_skills opt-in.
+//
+// The key is global-only and defaults FALSE, so on a default install af writes
+// nothing into any agent's global config. Enabling it is the user stating that
+// af may manage that directory.
+func globalAgentSkillsConsent() globalSkillConsent {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		log.WarningLog.Printf("af skill: could not read the af config (%v); leaving the global agent skills directories exactly as they are", err)
+		return globalSkillUnknown
+	}
+	if cfg.GlobalAgentSkills {
+		return globalSkillGranted
+	}
+	return globalSkillDeclined
+}
+
 // ensureAfSkillDir writes the af-managed "agent-factory" skill into the given
 // per-agent skills base directory and returns the skill directory path. The agent
 // auto-discovers skills there with NO command-line flag, so this injects
@@ -75,9 +105,43 @@ func writeAfMarkedFile(path, content string) (bool, error) {
 // agent loses the af guidance for this launch; callers log and carry on. The write
 // is non-destructive (writeAfMarkedFile): a user's own un-marked SKILL.md at our
 // path is left untouched and logged.
+//
+// Every base passed here is the USER'S GLOBAL per-agent config directory
+// (codex's $CODEX_HOME/skills, gemini's ~/.gemini/skills, amp's
+// ~/.config/amp/skills), which is why the consent gate lives at this one choke
+// point rather than in each caller (#1977). A file written there reaches outside
+// af and outlives it: it survives archiving the session, survives uninstalling
+// af, and is still loaded when the user runs that agent by hand in an unrelated
+// directory tomorrow. Creating a session is not consent to edit the user's
+// global tool configuration, so af does none of it unless global_agent_skills
+// is on. An empty returned path means "not injected"; every caller discards the
+// path and only checks the error, so this reads as a clean skip.
+//
+// The af-owned seams are unaffected and stay unconditional: claude
+// (--plugin-dir), aider (--read) and opencode (OPENCODE_CONFIG) all point at
+// files under af's OWN config dir, so they vanish with af and are invisible to
+// an agent af did not launch. That is the pattern this gate exists to converge
+// on; these three agents expose no equivalent per-launch pointer (codex's
+// CODEX_HOME and gemini's GEMINI_CLI_HOME relocate the agent's whole home,
+// auth and history included, and amp's --settings-file would have af own
+// settings the user also sets), so consent is the honest seam until one does.
 func ensureAfSkillDir(base string) (string, error) {
 	skillDir := filepath.Join(base, afSkillDirName)
 	path := filepath.Join(skillDir, "SKILL.md")
+
+	switch globalAgentSkillsConsent() {
+	case globalSkillGranted:
+	case globalSkillDeclined:
+		// Also clean up what an EARLIER af version wrote here before this key
+		// existed, so af's edits to the user's global config do not outlive the
+		// decision not to make them (#1977's first objection).
+		removeAfSkillDir(skillDir, path)
+		log.WarningLog.Printf("af skill: not writing %s — af does not manage global agent config directories unless global_agent_skills = true is set in the af config (af guidance not injected for this agent)", path)
+		return "", nil
+	default: // globalSkillUnknown
+		return "", nil
+	}
+
 	wrote, err := writeAfMarkedFile(path, afSkillDoc)
 	if err != nil {
 		return "", err
@@ -86,6 +150,42 @@ func ensureAfSkillDir(base string) (string, error) {
 		log.WarningLog.Printf("af skill: %s exists but is not af-managed; leaving it untouched (af guidance not injected)", path)
 	}
 	return skillDir, nil
+}
+
+// removeAfSkillDir deletes the skill af ITSELF wrote into a global agent config
+// directory, and nothing else.
+//
+// Every step is gated on a POSITIVE observed fact, never an inference:
+//
+//   - The file is removed only when it is present AND carries afSkillMarker. A
+//     file at our path without the marker is the user's (or another tool's) and
+//     is left alone, exactly as writeAfMarkedFile refuses to overwrite it.
+//   - A read that FAILS for any reason other than not-exist (permissions, I/O)
+//     leaves the file alone. "I could not look" is not "there is nothing of
+//     value here" — that conflation is the #1969/#2011 class.
+//   - The enclosing agent-factory/ directory is removed with os.Remove, not
+//     RemoveAll, so the kernel refuses (ENOTEMPTY) if anything else is in there.
+//     A user who dropped their own file beside ours keeps it, and we never have
+//     to predict what else the directory holds.
+func removeAfSkillDir(skillDir, path string) {
+	existing, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.WarningLog.Printf("af skill: could not read %s to check whether af wrote it (%v); leaving it in place", path, err)
+		}
+		return
+	}
+	if !bytes.Contains(existing, []byte(afSkillMarker)) {
+		return
+	}
+	if err := os.Remove(path); err != nil {
+		log.WarningLog.Printf("af skill: could not remove the af-managed %s (%v); it stays until removed by hand", path, err)
+		return
+	}
+	// Best-effort, and deliberately not RemoveAll: this succeeds only if the
+	// directory is now empty.
+	_ = os.Remove(skillDir)
+	log.WarningLog.Printf("af skill: removed the af-managed %s — af no longer writes into global agent config directories (set global_agent_skills = true to restore it)", path)
 }
 
 // codexSkillsBaseDir returns codex's skills-discovery base: $CODEX_HOME/skills, or

--- a/session/agentskill_consent_test.go
+++ b/session/agentskill_consent_test.go
@@ -1,0 +1,267 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+// #1977: af must not edit the user's GLOBAL per-agent config directories
+// (codex's $CODEX_HOME/skills, gemini's ~/.gemini/skills, amp's
+// ~/.config/amp/skills) as a side effect of creating a session. Those files
+// reach outside af and outlive it — they survive archiving the session and
+// uninstalling af, and still load when the user runs that agent by hand.
+//
+// The gate lives at ensureAfSkillDir, the one choke point all three share.
+
+// agentHome points HOME at a temp dir so every global agent skills base
+// resolves inside the test, and returns it. The af home is sandboxed
+// package-wide by TestMain, and each test that needs a specific af CONFIG
+// overrides AGENT_FACTORY_HOME itself via grantGlobalAgentSkills /
+// declineGlobalAgentSkills.
+func agentHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	return home
+}
+
+// writeAfConfig gives this test its own af home holding a config with
+// global_agent_skills set as given.
+func writeAfConfig(t *testing.T, enabled bool) {
+	t.Helper()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	cfg := config.DefaultConfig()
+	cfg.GlobalAgentSkills = enabled
+	if err := config.SaveConfig(cfg); err != nil {
+		t.Fatalf("save af config: %v", err)
+	}
+}
+
+// grantGlobalAgentSkills opts this test's af home into af managing the global
+// agent skills directories — the consent the feature now requires (#1977).
+// Tests that assert on WHERE and HOW the skill file is written need it; without
+// it the default config declines and nothing is written at all.
+func grantGlobalAgentSkills(t *testing.T) {
+	t.Helper()
+	writeAfConfig(t, true)
+}
+
+// ampSkillPath is where af would write amp's copy under home.
+func ampSkillPath(home string) string {
+	return filepath.Join(home, ".config", "amp", "skills", "agent-factory", "SKILL.md")
+}
+
+// seedAfOwnedSkill writes a marker-stamped SKILL.md exactly as a PRIOR af
+// version would have left it, and returns its path.
+func seedAfOwnedSkill(t *testing.T, home string) string {
+	t.Helper()
+	path := ampSkillPath(home)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("seed mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(afSkillDoc), 0644); err != nil {
+		t.Fatalf("seed af-owned skill: %v", err)
+	}
+	return path
+}
+
+// TestGlobalAgentSkills_DefaultWritesNothingIntoTheUsersConfig is the #1977
+// regression. On a default install — no config key set, which is every install
+// — creating a session for codex, gemini or amp wrote a SKILL.md into the
+// user's own agent config directory. Nothing may land there now.
+func TestGlobalAgentSkills_DefaultWritesNothingIntoTheUsersConfig(t *testing.T) {
+	cases := []struct {
+		agent string
+		run   func() (string, error)
+		path  func(home string) string
+	}{
+		{"amp", ensureAmpSkillDir, ampSkillPath},
+		{"codex", ensureCodexSkillDir, func(h string) string {
+			return filepath.Join(h, ".codex", "skills", "agent-factory", "SKILL.md")
+		}},
+		{"gemini", ensureGeminiSkillDir, func(h string) string {
+			return filepath.Join(h, ".gemini", "skills", "agent-factory", "SKILL.md")
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.agent, func(t *testing.T) {
+			home := agentHome(t)
+			writeAfConfig(t, false) // the default; written explicitly so the intent is visible
+
+			dir, err := tc.run()
+			if err != nil {
+				t.Fatalf("a declined write must not be an error: %v", err)
+			}
+			if dir != "" {
+				t.Errorf("expected no skill dir reported when af may not write one, got %q", dir)
+			}
+			if _, err := os.Stat(tc.path(home)); !os.IsNotExist(err) {
+				t.Errorf("af wrote into the user's global %s config at %s (stat err: %v)", tc.agent, tc.path(home), err)
+			}
+		})
+	}
+}
+
+// TestGlobalAgentSkills_DefaultConfigDeclines pins the DEFAULT itself, not just
+// the behavior under an explicitly-false config: a brand-new af home with no
+// config file at all must still decline. A default that flipped to true would
+// reintroduce the whole issue while every test above still passed.
+func TestGlobalAgentSkills_DefaultConfigDeclines(t *testing.T) {
+	if config.DefaultConfig().GlobalAgentSkills {
+		t.Fatal("global_agent_skills must default to false: creating a session is not consent to edit the user's global agent config")
+	}
+
+	home := agentHome(t)
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir()) // empty af home, no config written
+
+	if _, err := ensureAmpSkillDir(); err != nil {
+		t.Fatalf("ensureAmpSkillDir: %v", err)
+	}
+	if _, err := os.Stat(ampSkillPath(home)); !os.IsNotExist(err) {
+		t.Errorf("a fresh af home with no config must not write into the user's amp config")
+	}
+}
+
+// TestGlobalAgentSkills_GrantedStillWrites is the other half: the capability is
+// not removed, only gated. A user who asks for it gets exactly what af wrote
+// before.
+func TestGlobalAgentSkills_GrantedStillWrites(t *testing.T) {
+	home := agentHome(t)
+	grantGlobalAgentSkills(t)
+
+	dir, err := ensureAmpSkillDir()
+	if err != nil {
+		t.Fatalf("ensureAmpSkillDir: %v", err)
+	}
+	if want := filepath.Dir(ampSkillPath(home)); dir != want {
+		t.Errorf("skill dir = %q, want %q", dir, want)
+	}
+	content, err := os.ReadFile(ampSkillPath(home))
+	if err != nil {
+		t.Fatalf("expected SKILL.md written under consent: %v", err)
+	}
+	if !strings.Contains(string(content), afSkillMarker) {
+		t.Errorf("expected the af-managed marker, got %q", content)
+	}
+}
+
+// TestGlobalAgentSkills_DeclinedRemovesAfsOwnFile covers the issue's first
+// objection — "it outlives af". A user upgrading past this change still has the
+// file a PRIOR af version wrote; af removes its own, so the edit does not
+// survive the decision not to make it.
+func TestGlobalAgentSkills_DeclinedRemovesAfsOwnFile(t *testing.T) {
+	home := agentHome(t)
+	path := seedAfOwnedSkill(t, home)
+	writeAfConfig(t, false)
+
+	if _, err := ensureAmpSkillDir(); err != nil {
+		t.Fatalf("ensureAmpSkillDir: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("af's own file must not outlive af's decision not to write it (stat err: %v)", err)
+	}
+	// The af-namespaced directory goes too, once empty.
+	if _, err := os.Stat(filepath.Dir(path)); !os.IsNotExist(err) {
+		t.Errorf("the emptied agent-factory/ dir should be removed as well (stat err: %v)", err)
+	}
+}
+
+// TestGlobalAgentSkills_DeclinedNeverTouchesTheUsersOwnFile is the destruction
+// guard. Removal is gated on af's MARKER, a positive observed fact — a file at
+// af's path without it belongs to the user (or another tool) and must survive,
+// exactly as writeAfMarkedFile refuses to overwrite it.
+func TestGlobalAgentSkills_DeclinedNeverTouchesTheUsersOwnFile(t *testing.T) {
+	home := agentHome(t)
+	path := ampSkillPath(home)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("seed mkdir: %v", err)
+	}
+	const userSkill = "---\nname: agent-factory\ndescription: my own skill\n---\nhand-written, keep me\n"
+	if err := os.WriteFile(path, []byte(userSkill), 0644); err != nil {
+		t.Fatalf("seed user skill: %v", err)
+	}
+	writeAfConfig(t, false)
+
+	if _, err := ensureAmpSkillDir(); err != nil {
+		t.Fatalf("ensureAmpSkillDir: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("the user's own file must survive: %v", err)
+	}
+	if string(got) != userSkill {
+		t.Errorf("the user's un-marked skill was modified: %q", got)
+	}
+}
+
+// TestGlobalAgentSkills_DeclinedKeepsSiblingFiles proves the directory removal
+// cannot take anything with it: os.Remove (not RemoveAll) means the kernel
+// itself refuses a non-empty directory, so we never have to predict what else
+// the user put in there.
+func TestGlobalAgentSkills_DeclinedKeepsSiblingFiles(t *testing.T) {
+	home := agentHome(t)
+	path := seedAfOwnedSkill(t, home)
+	sibling := filepath.Join(filepath.Dir(path), "notes.md")
+	if err := os.WriteFile(sibling, []byte("the user's notes\n"), 0644); err != nil {
+		t.Fatalf("seed sibling: %v", err)
+	}
+	writeAfConfig(t, false)
+
+	if _, err := ensureAmpSkillDir(); err != nil {
+		t.Fatalf("ensureAmpSkillDir: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("af's own SKILL.md should still be removed")
+	}
+	if _, err := os.ReadFile(sibling); err != nil {
+		t.Errorf("a file the user placed beside af's must survive: %v", err)
+	}
+}
+
+// TestGlobalAgentSkills_UnreadableConfigTouchesNothing is the three-value rule
+// (#1933). A config af could not read is UNKNOWN, not "declined": af neither
+// writes the skill nor deletes the existing one. Collapsing unknown into "no"
+// would let an unparseable config authorize a deletion — the fabricated-negative
+// shape behind #1969 and #2011.
+func TestGlobalAgentSkills_UnreadableConfigTouchesNothing(t *testing.T) {
+	home := agentHome(t)
+	path := seedAfOwnedSkill(t, home)
+
+	afHome := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", afHome)
+	if err := os.WriteFile(filepath.Join(afHome, "config.toml"), []byte("this is = not [valid toml\n"), 0644); err != nil {
+		t.Fatalf("seed broken config: %v", err)
+	}
+
+	if _, err := ensureAmpSkillDir(); err != nil {
+		t.Fatalf("an unreadable config must not be fatal to the launch: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("af must not delete anything on the strength of a config it could not read: %v", err)
+	}
+}
+
+// TestGlobalAgentSkills_AfOwnedSeamsAreUnaffected is the adjacent-site audit as
+// a test. The gate is specifically about the USER'S directories; claude
+// (--plugin-dir), aider (--read) and opencode (OPENCODE_CONFIG) all point at
+// af-OWNED files under af's own config dir, so they keep injecting af guidance
+// unconditionally and nothing of af's escapes into the user's config on those
+// paths.
+func TestGlobalAgentSkills_AfOwnedSeamsAreUnaffected(t *testing.T) {
+	agentHome(t)
+	writeAfConfig(t, false)
+
+	if got := injectSystemPrompt("claude"); !strings.Contains(got, "--plugin-dir") {
+		t.Errorf("claude's af-owned plugin seam must be unaffected by the global-config gate, got %q", got)
+	}
+	if got := injectSystemPrompt("aider"); !strings.Contains(got, "--read") {
+		t.Errorf("aider's af-owned --read seam must be unaffected by the global-config gate, got %q", got)
+	}
+	if got := injectSystemPrompt("opencode"); !strings.Contains(got, "OPENCODE_CONFIG=") {
+		t.Errorf("opencode's af-owned config seam must be unaffected by the global-config gate, got %q", got)
+	}
+}

--- a/session/systemprompt_test.go
+++ b/session/systemprompt_test.go
@@ -65,6 +65,10 @@ func TestInjectSystemPrompt_ClaudeWithResolvedFlags(t *testing.T) {
 // -c developer_instructions= blob (#1043 retired): the launch command comes back
 // UNCHANGED and the af skill is written where codex auto-discovers it.
 func TestInjectSystemPrompt_Codex(t *testing.T) {
+	// These agents write into the USER'S global config dir, which af only does
+	// under the global_agent_skills opt-in (#1977). Grant it: this test is about
+	// WHERE and HOW the file is written, not whether af may write it.
+	grantGlobalAgentSkills(t)
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("CODEX_HOME", "") // force the ~/.codex fallback under the temp HOME
@@ -132,6 +136,10 @@ func TestInjectSystemPrompt_Aider(t *testing.T) {
 // Gemini gets a FILE seam (its user skills folder, 0.42.0+): launch command
 // UNCHANGED, af skill written where gemini auto-discovers and enables it.
 func TestInjectSystemPrompt_Gemini(t *testing.T) {
+	// These agents write into the USER'S global config dir, which af only does
+	// under the global_agent_skills opt-in (#1977). Grant it: this test is about
+	// WHERE and HOW the file is written, not whether af may write it.
+	grantGlobalAgentSkills(t)
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("GEMINI_CLI_HOME", "") // force the ~/.gemini fallback under the temp HOME
@@ -156,6 +164,10 @@ func TestInjectSystemPrompt_Gemini(t *testing.T) {
 }
 
 func TestInjectSystemPrompt_Amp(t *testing.T) {
+	// These agents write into the USER'S global config dir, which af only does
+	// under the global_agent_skills opt-in (#1977). Grant it: this test is about
+	// WHERE and HOW the file is written, not whether af may write it.
+	grantGlobalAgentSkills(t)
 	// Amp's seam is a file, not a flag: point HOME at a temp dir so the write
 	// lands there instead of the real ~/.config/amp (amp discovers skills under
 	// $HOME/.config, ignoring XDG_CONFIG_HOME).
@@ -457,6 +469,10 @@ func TestAfUsageReference_CoversFullSurface(t *testing.T) {
 }
 
 func TestEnsureAmpSkillDir(t *testing.T) {
+	// These agents write into the USER'S global config dir, which af only does
+	// under the global_agent_skills opt-in (#1977). Grant it: this test is about
+	// WHERE and HOW the file is written, not whether af may write it.
+	grantGlobalAgentSkills(t)
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
@@ -496,6 +512,10 @@ func TestEnsureAmpSkillDir(t *testing.T) {
 // marker belongs to the user (or another tool) and must survive untouched
 // (#1585 review, finding 1). A file WITH the marker is af-owned and regenerates.
 func TestEnsureAmpSkillDir_NonDestructive(t *testing.T) {
+	// These agents write into the USER'S global config dir, which af only does
+	// under the global_agent_skills opt-in (#1977). Grant it: this test is about
+	// WHERE and HOW the file is written, not whether af may write it.
+	grantGlobalAgentSkills(t)
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
@@ -542,6 +562,10 @@ func TestEnsureAmpSkillDir_NonDestructive(t *testing.T) {
 // (verified against the amp CLI), so honoring XDG here would write the skill
 // where amp never looks for a user who has XDG_CONFIG_HOME set.
 func TestEnsureAmpSkillDir_IgnoresXDG(t *testing.T) {
+	// These agents write into the USER'S global config dir, which af only does
+	// under the global_agent_skills opt-in (#1977). Grant it: this test is about
+	// WHERE and HOW the file is written, not whether af may write it.
+	grantGlobalAgentSkills(t)
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir()) // a DIFFERENT dir; must be ignored
@@ -557,6 +581,10 @@ func TestEnsureAmpSkillDir_IgnoresXDG(t *testing.T) {
 }
 
 func TestEnsureAmpSkillDir_Idempotent(t *testing.T) {
+	// These agents write into the USER'S global config dir, which af only does
+	// under the global_agent_skills opt-in (#1977). Grant it: this test is about
+	// WHERE and HOW the file is written, not whether af may write it.
+	grantGlobalAgentSkills(t)
 	t.Setenv("HOME", t.TempDir())
 
 	dir1, err := ensureAmpSkillDir()
@@ -574,6 +602,10 @@ func TestEnsureAmpSkillDir_Idempotent(t *testing.T) {
 
 // Codex skills base resolves under $CODEX_HOME when set, else $HOME/.codex.
 func TestEnsureCodexSkillDir(t *testing.T) {
+	// These agents write into the USER'S global config dir, which af only does
+	// under the global_agent_skills opt-in (#1977). Grant it: this test is about
+	// WHERE and HOW the file is written, not whether af may write it.
+	grantGlobalAgentSkills(t)
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("CODEX_HOME", "")
@@ -598,6 +630,10 @@ func TestEnsureCodexSkillDir(t *testing.T) {
 }
 
 func TestEnsureCodexSkillDir_HonorsCodexHome(t *testing.T) {
+	// These agents write into the USER'S global config dir, which af only does
+	// under the global_agent_skills opt-in (#1977). Grant it: this test is about
+	// WHERE and HOW the file is written, not whether af may write it.
+	grantGlobalAgentSkills(t)
 	codexHome := t.TempDir()
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("CODEX_HOME", codexHome)
@@ -615,6 +651,10 @@ func TestEnsureCodexSkillDir_HonorsCodexHome(t *testing.T) {
 // Gemini skills base resolves under $GEMINI_CLI_HOME/.gemini when set, else
 // $HOME/.gemini.
 func TestEnsureGeminiSkillDir(t *testing.T) {
+	// These agents write into the USER'S global config dir, which af only does
+	// under the global_agent_skills opt-in (#1977). Grant it: this test is about
+	// WHERE and HOW the file is written, not whether af may write it.
+	grantGlobalAgentSkills(t)
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("GEMINI_CLI_HOME", "")
@@ -639,6 +679,10 @@ func TestEnsureGeminiSkillDir(t *testing.T) {
 }
 
 func TestEnsureGeminiSkillDir_HonorsGeminiCliHome(t *testing.T) {
+	// These agents write into the USER'S global config dir, which af only does
+	// under the global_agent_skills opt-in (#1977). Grant it: this test is about
+	// WHERE and HOW the file is written, not whether af may write it.
+	grantGlobalAgentSkills(t)
 	geminiHome := t.TempDir()
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("GEMINI_CLI_HOME", geminiHome)
@@ -657,6 +701,9 @@ func TestEnsureGeminiSkillDir_HonorsGeminiCliHome(t *testing.T) {
 // non-clobber guarantee, exercised through the codex skills path (the same guard
 // protects gemini, amp, and the aider context file).
 func TestWriteAfMarkedFile_NonDestructive(t *testing.T) {
+	// Exercises the af-owned-vs-user-owned write rules inside a global agent
+	// config dir, so it needs the global_agent_skills opt-in (#1977).
+	grantGlobalAgentSkills(t)
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("CODEX_HOME", "")


### PR DESCRIPTION
Closes #1977.

## The bug

af wrote a `SKILL.md` into the user's **own** codex, gemini and amp config directories (`$CODEX_HOME/skills`, `~/.gemini/skills`, `~/.config/amp/skills`) as a side effect of creating a session. Those files reach outside af and outlive it: they survive archiving the session, survive uninstalling af, and still load when the user runs that agent by hand in a directory af has nothing to do with.

As Sachin put it on #1959: *we do not get to modify a user's global tool configuration as a side effect of them creating a session.*

## Why consent rather than a pointer

The issue asks whether a per-launch pointer exists for each agent. I checked **against the real binaries**, not their `--help` (the #1963 trap):

| agent | candidate seam | verdict |
|---|---|---|
| codex 0.144.5 | `CODEX_HOME` | relocates the agent's **entire** home — auth, history, config.toml. Not a drop-in. |
| gemini 0.51.0 | `GEMINI_CLI_HOME` | same whole-home relocation. `gemini skills link` registers into the same global config. |
| amp | `--settings-file` | af would own settings the user also sets. |

opencode's fix (#1959) worked only because `OPENCODE_CONFIG` **merges**. None of these do. So consent is the honest seam until one of them grows an additive pointer.

## The fix

New global-only `global_agent_skills` key, **default false**. The gate sits at `ensureAfSkillDir` — the single choke point all three agents share — so any future agent taking the same seam inherits the consent requirement rather than re-deciding it.

**Consent is three-valued, not two** (#1933's rule). A config af could not read is `UNKNOWN`: af writes nothing *and deletes nothing*. Collapsing that into "declined" would let an unparseable config authorize a deletion — the fabricated-negative shape behind #1969 and #2011.

With consent declined, af also removes the marker-stamped file a **prior** af version wrote, so the edit does not outlive the decision not to make it (the issue's first objection). Every step of that removal is gated on a positive observed fact:

- the file must exist **and** carry af's marker — an unmarked file at that path is the user's and is never touched;
- a read that fails for any reason but not-exist leaves it alone;
- the enclosing dir goes via `os.Remove`, **not** `RemoveAll`, so the kernel refuses (ENOTEMPTY) if anything else is in there. A file the user put beside af's keeps the directory alive.

## Adjacent-site audit

claude (`--plugin-dir`), aider (`--read`) and opencode (`OPENCODE_CONFIG`) all point at af-**owned** files under af's own config dir, so nothing of af's escapes into the user's config on those paths. They are deliberately unaffected by the key, with a test pinning that.

## Surfaces touched

`config_types.go` (+ `DefaultConfig`), `inrepo.go` (global-only — a cloned repo must not opt your machine into af editing your home), `configset.go` (settable via `af config set`), `manifest.go`, `configcmd.go` help, `docs/configuration.md` (new section + key table + global-only table), regenerated `docs/reference/cli.md`.

Verified end-to-end with the real binary: `af config get/set global_agent_skills` round-trips, and an in-repo `global_agent_skills = true` is rejected with `"global_agent_skills" is a global setting and cannot be set per-repo; move it to <global config>`.

## Tests

New tests fail on the pre-fix (always-granted) path: all three agents write into the user's config, af's own stale file is not removed, and a sibling-file case is untouched. The existing skill tests keep their coverage of **where** and **how** the file is written and now run under granted consent.

Full suite green in the container.

## One call worth gating on

Default-false means codex/gemini/amp sessions lose af's CLI guidance unless the user opts in, and af removes the file it previously wrote. That is what the issue asks for (option (b), "drop the guidance for that agent", is listed as honest) — but it is a user-visible behavior change for existing users of those three agents, so flagging it explicitly rather than burying it.