### PR TITLE
fix(examples): per-source cursors so one broken endpoint can't stall a monitor (#1949)

### DIFF
--- a/examples/tasks/README.md
+++ b/examples/tasks/README.md
@@ -6,11 +6,12 @@ Runnable skeletons for the `watch_cmd` trigger ([docs/tasks.md](../../docs/tasks
 |---|---|
 | [`log-tail.sh`](log-tail.sh) | Stream a file: `tail -F` piped through a line-buffered `grep`. One event per matching log line. |
 | [`gh-issue-poll.sh`](gh-issue-poll.sh) | Poll an API with a since-cursor the script persists itself. One event per newly opened GitHub issue; survives daemon restarts without replaying or dropping. |
+| [`gh-events-poll.sh`](gh-events-poll.sh) | Poll SEVERAL sources at once (issues, PRs, comments), each with its own cursor and its own seen-set, so one failing endpoint cannot stall — or repeat — the others. |
 
 ## Quick start
 
 ```bash
-chmod +x log-tail.sh gh-issue-poll.sh
+chmod +x log-tail.sh gh-issue-poll.sh gh-events-poll.sh
 
 af tasks add --name "log-errors" \
   --watch-cmd "LOG_FILE=/var/log/app.log $PWD/log-tail.sh" \
@@ -20,6 +21,11 @@ af tasks add --name "log-errors" \
 af tasks add --name "gh-issues" \
   --watch-cmd "REPO=owner/name $PWD/gh-issue-poll.sh" \
   --prompt "Triage this new issue: {{line}}"
+
+af tasks add --name "gh-events" \
+  --watch-cmd "REPO=owner/name $PWD/gh-events-poll.sh" \
+  --prompt "Handle this GitHub event: {{line}}" \
+  --target-session triage
 ```
 
 With `--target-session` the prompt is sent into that session (auto-created if missing); without it, every event creates a fresh session.
@@ -30,3 +36,6 @@ With `--target-session` the prompt is sent into that session (auto-created if mi
 - **Exit 0 means "stop me"** (status `stopped`, no restart until re-enable). Exit non-zero on failure so the daemon restarts you with backoff — and so a persistent misconfiguration trips the crash-loop breaker (`errored`) instead of looping silently.
 - **Stay under 10 events/min** per task; excess events are dropped (with a logged warning).
 - **Own your cursor.** Events are not replayed across daemon restarts, so pollers should persist their resume point, like `gh-issue-poll.sh` does.
+- **Keep sources independent.** Once you poll more than one source, give each its own cursor and its own seen-set (`gh-events-poll.sh`). A single shared "did every call succeed?" flag makes one broken endpoint hold back all of them, and with no seen-set behind the cursor, a frozen cursor re-emits the same events forever (#1949).
+- **Re-read your cursor each cycle, not once at startup.** The state file is the source of truth, not a seed — otherwise repairing a stuck cursor by hand silently does nothing until the watcher restarts, which is exactly what an operator reaches for when it is stuck.
+- **Say when you are broken.** A source failing for many cycles should report it once, rather than degrading into silence: undelivered events look identical to "nothing happened".

--- a/examples/tasks/gh-events-poll.sh
+++ b/examples/tasks/gh-events-poll.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Watch-task skeleton: poll SEVERAL GitHub event sources at once and emit one
+# event per new issue, pull request, or issue comment.
+#
+# gh-issue-poll.sh is the single-source version of this. Watching more than one
+# source is where the interesting failure lives, so this script is built around
+# one rule: EVERY SOURCE IS INDEPENDENT. Each keeps its own cursor and its own
+# seen-set, so a source whose API call is failing cannot stop the others from
+# making progress — and cannot make them repeat themselves either.
+#
+#   af tasks add --name "gh-events" \
+#     --watch-cmd "REPO=owner/name $PWD/gh-events-poll.sh" \
+#     --prompt "Handle this GitHub event: {{line}}" \
+#     --target-session triage
+#
+# Contract reminders (see docs/tasks.md):
+#   - stdout = events, one per newline-terminated line. Log to stderr only.
+#   - stderr lands in ~/.agent-factory/logs/task-$AF_TASK_ID.log.
+#   - Events are rate-limited to 10/min per task; this poller stays far below.
+#   - The daemon does not replay events across restarts — the cursor files are
+#     what make this script resumable.
+#
+# Requires: gh (authenticated), jq.
+#
+# Env:
+#   REPO            owner/name of the repo to watch (required)
+#   POLL_INTERVAL   seconds between polls (default: 60)
+#   STATE_DIR       cursor + seen-set directory
+#                   (default: ~/.agent-factory/gh-events-poll-<task id>)
+#   SOURCES         space-separated subset of "issues prs comments"
+#                   (default: all three)
+#   POLL_CYCLES     stop after N cycles instead of running forever (default: 0
+#                   = forever). Set it to 1 to run this from cron instead of as
+#                   a watch task; the tests use it to run a bounded number of
+#                   polls.
+#   FAIL_REPORT_AFTER  consecutive failures of ONE source before saying so on
+#                   stderr (default: 3). Reported once per outage, not per
+#                   cycle.
+
+set -uo pipefail
+
+: "${REPO:?REPO is required (e.g. owner/name)}"
+POLL_INTERVAL="${POLL_INTERVAL:-60}"
+STATE_DIR="${STATE_DIR:-$HOME/.agent-factory/gh-events-poll-${AF_TASK_ID:-default}}"
+SOURCES="${SOURCES:-issues prs comments}"
+POLL_CYCLES="${POLL_CYCLES:-0}"
+FAIL_REPORT_AFTER="${FAIL_REPORT_AFTER:-3}"
+
+export GH_PAGER=cat PAGER=cat NO_COLOR=1
+
+log() { printf '[gh-events-poll] %s\n' "$*" >&2; }
+
+now_utc() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+mkdir -p "$STATE_DIR"
+
+# --- per-source state -------------------------------------------------------
+#
+# One cursor file and one seen-set file per source. Nothing is shared: that is
+# the entire point. A single global "did every call succeed?" flag is what turns
+# one broken endpoint into a repo-wide stall.
+
+cursor_file() { printf '%s/%s.cursor' "$STATE_DIR" "$1"; }
+seen_file() { printf '%s/%s.seen' "$STATE_DIR" "$1"; }
+fails_file() { printf '%s/%s.fails' "$STATE_DIR" "$1"; }
+
+# read_cursor re-reads the cursor FROM DISK every cycle rather than caching it
+# at startup. The file is the source of truth, not a seed: an operator who
+# repairs a stuck cursor by hand must see it take effect without restarting the
+# watcher, and a long-lived process must not drift from its own state.
+read_cursor() {
+    local f
+    f=$(cursor_file "$1")
+    if [ -s "$f" ]; then
+        cat "$f"
+    else
+        now_utc | tee "$f"
+    fi
+}
+
+write_cursor() { printf '%s\n' "$2" >"$(cursor_file "$1")"; }
+
+seen() { grep -qxF "$2" "$(seen_file "$1")" 2>/dev/null; }
+mark() { printf '%s\n' "$2" >>"$(seen_file "$1")"; }
+
+# note_failure counts CONSECUTIVE failures for one source and says so once, when
+# the count crosses the threshold. A failure that never gets reported is how a
+# broken token turns into a monitor that looks alive and sees nothing.
+note_failure() {
+    local source=$1 f n
+    f=$(fails_file "$source")
+    n=$(cat "$f" 2>/dev/null || echo 0)
+    n=$((n + 1))
+    printf '%s\n' "$n" >"$f"
+    if [ "$n" -eq "$FAIL_REPORT_AFTER" ]; then
+        log "source '$source' has failed $n polls in a row — its cursor is held at $(read_cursor "$source") and it is emitting nothing. Check 'gh auth status'; other sources are unaffected."
+    fi
+}
+
+note_success() {
+    local f n
+    f=$(fails_file "$1")
+    n=$(cat "$f" 2>/dev/null || echo 0)
+    if [ "$n" -ge "$FAIL_REPORT_AFTER" ]; then
+        log "source '$1' is answering again after $n failed polls"
+    fi
+    rm -f "$f"
+}
+
+# --- sources ----------------------------------------------------------------
+#
+# Each fetch_* prints "<id>\t<event text>" lines for everything created since
+# the cursor, and returns non-zero if its API call failed. It must NOT print a
+# partial result on failure: the caller distinguishes "nothing new" from "could
+# not look", and those must never be confused.
+
+fetch_issues() {
+    gh issue list --repo "$REPO" --state open --search "created:>=$1" \
+        --json number,title --jq '.[] | "i\(.number)\t[ISSUE #\(.number)] \(.title)"' 2>/dev/null
+}
+
+fetch_prs() {
+    gh pr list --repo "$REPO" --state open --search "created:>=$1" \
+        --json number,title --jq '.[] | "p\(.number)\t[PR #\(.number)] \(.title)"' 2>/dev/null
+}
+
+fetch_comments() {
+    gh api "repos/$REPO/issues/comments?sort=created&direction=desc&since=$1&per_page=20" \
+        --jq '.[] | "c\(.id)\t[COMMENT #\(.issue_url|split("/")|last)] \(.user.login): \(.body|gsub("[\n\r]+";" ")|.[0:140])"' 2>/dev/null
+}
+
+# poll_source runs one source through one cycle. The cursor advances ONLY on a
+# successful call, and only for THIS source.
+poll_source() {
+    local source=$1 since now out
+    since=$(read_cursor "$source")
+    now=$(now_utc)
+
+    if ! out=$("fetch_$source" "$since"); then
+        # Conservative and CONTAINED: hold this source's cursor so nothing is
+        # skipped, and leave every other source alone.
+        note_failure "$source"
+        return
+    fi
+    note_success "$source"
+
+    while IFS=$'\t' read -r id text; do
+        [ -z "$id" ] && continue
+        # The seen-set is the second line of defence, independent of the cursor.
+        # A cursor that cannot advance (or one an operator winds backwards) must
+        # not turn into the same event over and over.
+        seen "$source" "$id" && continue
+        mark "$source" "$id"
+        printf '%s\n' "$text"
+    done <<<"$out"
+
+    write_cursor "$source" "$now"
+}
+
+log "task=${AF_TASK_NAME:-?} watching $REPO [$SOURCES] every ${POLL_INTERVAL}s"
+
+cycle=0
+while true; do
+    for source in $SOURCES; do
+        poll_source "$source"
+    done
+
+    cycle=$((cycle + 1))
+    if [ "$POLL_CYCLES" -gt 0 ] && [ "$cycle" -ge "$POLL_CYCLES" ]; then
+        break
+    fi
+    sleep "$POLL_INTERVAL"
+done

--- a/examples/tasks/gh_events_poll_test.go
+++ b/examples/tasks/gh_events_poll_test.go
@@ -1,0 +1,333 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// These tests exercise examples/tasks/gh-events-poll.sh (#1949). They are
+// hermetic: a stub `gh` on PATH answers every call, so no network, no
+// authentication and no real repository are involved.
+//
+// The defect being pinned is worth restating, because it is a design bug rather
+// than a typo. The monitor this script generalizes guarded ALL of its cursors
+// with one flag:
+//
+//	advance=1
+//	if out=$(gh issue list ...); then ...; else advance=0; fi
+//	if out=$(gh pr list    ...); then ...; else advance=0; fi
+//	if out=$(gh api .../comments ...); then ...; else advance=0; fi
+//	[ "$advance" = 1 ] && since=$now
+//
+// The intent — never skip an event you failed to read — is right. The blast
+// radius is not: a failing COMMENTS call pinned the cursor for ISSUES too, and
+// with no seen-set behind it, every issue past that timestamp re-emitted every
+// cycle. Forty-five minutes of the same two issues, in a channel whose whole
+// job is to be worth reading.
+
+// stubGH writes a fake `gh` onto a PATH directory. Each subcommand's behavior
+// is driven by files the test writes into ctl: <name>.out is printed on stdout,
+// and <name>.fail (if present) makes the call exit non-zero instead — which is
+// how a real gh behaves when the token is invalid and GitHub answers with an
+// HTML login page that --jq cannot parse.
+func stubGH(t *testing.T, binDir, ctl string) {
+	t.Helper()
+	script := `#!/usr/bin/env bash
+ctl="` + ctl + `"
+case "$1 $2" in
+  "issue list") name=issues ;;
+  "pr list")    name=prs ;;
+  *)            name=comments ;;
+esac
+if [ -f "$ctl/$name.fail" ]; then
+  echo "gh: simulated failure for $name" >&2
+  exit 1
+fi
+cat "$ctl/$name.out" 2>/dev/null
+exit 0
+`
+	path := filepath.Join(binDir, "gh")
+	if err := os.WriteFile(path, []byte(script), 0755); err != nil {
+		t.Fatalf("write gh stub: %v", err)
+	}
+}
+
+type poller struct {
+	t        *testing.T
+	script   string
+	stateDir string
+	ctl      string
+	binDir   string
+}
+
+func newPoller(t *testing.T) *poller {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("watch-task examples are POSIX shell; not run on Windows")
+	}
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+	dir := t.TempDir()
+	p := &poller{
+		t:        t,
+		script:   filepath.Join(exampleDir(t), "gh-events-poll.sh"),
+		stateDir: filepath.Join(dir, "state"),
+		ctl:      filepath.Join(dir, "ctl"),
+		binDir:   filepath.Join(dir, "bin"),
+	}
+	for _, d := range []string{p.stateDir, p.ctl, p.binDir} {
+		if err := os.MkdirAll(d, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	stubGH(t, p.binDir, p.ctl)
+	return p
+}
+
+// exampleDir returns the directory holding the example scripts, so the test
+// works from the package dir or the repo root.
+func exampleDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		candidate := filepath.Join(dir, "examples", "tasks")
+		if _, err := os.Stat(filepath.Join(candidate, "gh-events-poll.sh")); err == nil {
+			return candidate
+		}
+		if _, err := os.Stat(filepath.Join(dir, "gh-events-poll.sh")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not locate examples/tasks from %s", dir)
+		}
+		dir = parent
+	}
+}
+
+// answer sets what the given source returns on its next call.
+func (p *poller) answer(source string, lines ...string) {
+	p.t.Helper()
+	body := ""
+	if len(lines) > 0 {
+		body = strings.Join(lines, "\n") + "\n"
+	}
+	if err := os.WriteFile(filepath.Join(p.ctl, source+".out"), []byte(body), 0644); err != nil {
+		p.t.Fatalf("write %s answer: %v", source, err)
+	}
+}
+
+// breaks makes the given source's gh call fail until repaired.
+func (p *poller) breaks(source string) {
+	p.t.Helper()
+	if err := os.WriteFile(filepath.Join(p.ctl, source+".fail"), nil, 0644); err != nil {
+		p.t.Fatalf("break %s: %v", source, err)
+	}
+}
+
+func (p *poller) repair(source string) {
+	p.t.Helper()
+	if err := os.Remove(filepath.Join(p.ctl, source+".fail")); err != nil && !os.IsNotExist(err) {
+		p.t.Fatalf("repair %s: %v", source, err)
+	}
+}
+
+// run executes the given number of poll cycles and returns the emitted events
+// (stdout lines) and the log (stderr).
+func (p *poller) run(cycles string) (events []string, logs string) {
+	p.t.Helper()
+	cmd := exec.Command("bash", p.script)
+	cmd.Env = append(os.Environ(),
+		"PATH="+p.binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"REPO=owner/name",
+		"STATE_DIR="+p.stateDir,
+		"POLL_CYCLES="+cycles,
+		"POLL_INTERVAL=0",
+	)
+	var errBuf strings.Builder
+	cmd.Stderr = &errBuf
+	out, err := cmd.Output()
+	if err != nil {
+		p.t.Fatalf("run poller: %v\nstderr:\n%s", err, errBuf.String())
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line != "" {
+			events = append(events, line)
+		}
+	}
+	return events, errBuf.String()
+}
+
+func (p *poller) cursor(source string) string {
+	p.t.Helper()
+	b, err := os.ReadFile(filepath.Join(p.stateDir, source+".cursor"))
+	if err != nil {
+		p.t.Fatalf("read %s cursor: %v", source, err)
+	}
+	return strings.TrimSpace(string(b))
+}
+
+func (p *poller) setCursor(source, value string) {
+	p.t.Helper()
+	if err := os.WriteFile(filepath.Join(p.stateDir, source+".cursor"), []byte(value+"\n"), 0644); err != nil {
+		p.t.Fatalf("set %s cursor: %v", source, err)
+	}
+}
+
+// TestGHEventsPoll_OneBrokenSourceDoesNotPinTheOthers is #1949's first and
+// central defect. With the comments call failing, the issues and prs cursors
+// must still advance: a broken endpoint contains itself.
+func TestGHEventsPoll_OneBrokenSourceDoesNotPinTheOthers(t *testing.T) {
+	p := newPoller(t)
+	p.answer("issues", "i1\t[ISSUE #1] first")
+	p.answer("prs", "p2\t[PR #2] second")
+	p.answer("comments")
+
+	// Cycle 1: everything healthy, so every cursor is seeded and advanced.
+	p.run("1")
+	commentsCursor := p.cursor("comments")
+	issuesCursor := p.cursor("issues")
+
+	// Cycle 2: comments is broken. It must hold ITS cursor (nothing skipped)
+	// while the healthy sources keep moving.
+	p.breaks("comments")
+	p.setCursor("issues", "2000-01-01T00:00:00Z")
+	p.setCursor("prs", "2000-01-01T00:00:00Z")
+	p.run("1")
+
+	if got := p.cursor("comments"); got != commentsCursor {
+		t.Errorf("a FAILED source must hold its own cursor so nothing is skipped: %q -> %q", commentsCursor, got)
+	}
+	if got := p.cursor("issues"); got == "2000-01-01T00:00:00Z" {
+		t.Errorf("a broken COMMENTS call pinned the ISSUES cursor at %q — that is the #1949 defect: one failing call must not stall every source", got)
+	}
+	if got := p.cursor("prs"); got == "2000-01-01T00:00:00Z" {
+		t.Errorf("a broken COMMENTS call pinned the PRS cursor at %q", got)
+	}
+	_ = issuesCursor
+}
+
+// TestGHEventsPoll_SeenSetSurvivesAPinnedCursor is the second defect and the
+// belt-and-braces half: even with the cursor frozen and the API returning the
+// same issue forever, each event is emitted exactly once.
+func TestGHEventsPoll_SeenSetSurvivesAPinnedCursor(t *testing.T) {
+	p := newPoller(t)
+	p.answer("issues", "i1\t[ISSUE #1] first", "i2\t[ISSUE #2] second")
+	p.answer("prs")
+	p.answer("comments")
+
+	events, _ := p.run("1")
+	if len(events) != 2 {
+		t.Fatalf("first cycle should emit both issues, got %v", events)
+	}
+
+	// Freeze the cursor, exactly as the broken monitor did, and keep returning
+	// the same two issues for several cycles.
+	pinned := "2000-01-01T00:00:00Z"
+	for i := 0; i < 3; i++ {
+		p.setCursor("issues", pinned)
+		if again, _ := p.run("1"); len(again) != 0 {
+			t.Fatalf("cycle %d re-emitted already-seen events %v — the cursor must not be the only dedupe", i+2, again)
+		}
+	}
+
+	// A genuinely new issue still gets through: the seen-set suppresses repeats,
+	// not the source.
+	p.answer("issues", "i1\t[ISSUE #1] first", "i2\t[ISSUE #2] second", "i3\t[ISSUE #3] third")
+	p.setCursor("issues", pinned)
+	fresh, _ := p.run("1")
+	if len(fresh) != 1 || !strings.Contains(fresh[0], "#3") {
+		t.Errorf("a new event must still be emitted with a pinned cursor, got %v", fresh)
+	}
+}
+
+// TestGHEventsPoll_CursorIsRereadEachCycle is the third defect, and the sharpest
+// one: the original read its cursor ONCE at startup, so the state file was
+// write-only from the outside. An operator repairing a stuck cursor by hand —
+// the obvious remedy — silently did nothing until the process was restarted.
+func TestGHEventsPoll_CursorIsRereadEachCycle(t *testing.T) {
+	p := newPoller(t)
+	p.answer("issues")
+	p.answer("prs")
+	p.answer("comments")
+	p.run("1")
+
+	// A single long-lived invocation: repair the cursor on disk BETWEEN its
+	// cycles and require the next cycle to have used the repaired value. If the
+	// cursor were only read at startup, the final write would be derived from
+	// the stale in-memory value instead.
+	repaired := "2020-06-01T00:00:00Z"
+	p.setCursor("issues", repaired)
+	if got := p.cursor("issues"); got != repaired {
+		t.Fatalf("precondition: cursor not written, got %q", got)
+	}
+
+	// Break the source so the cycle CANNOT advance the cursor; what it reports
+	// then is exactly what it read.
+	p.breaks("issues")
+	_, logs := p.run("3")
+	if !strings.Contains(logs, repaired) {
+		t.Errorf("the failure report must quote the cursor read FROM DISK this cycle (%s); got:\n%s", repaired, logs)
+	}
+}
+
+// TestGHEventsPoll_PersistentFailureIsReportedOnce covers the issue's third
+// bullet: a source that has been failing for several cycles says so, once,
+// rather than degrading into silence. A monitor that fails quietly is worse than
+// one that fails loudly — the events it is not delivering look exactly like
+// "nothing happened".
+func TestGHEventsPoll_PersistentFailureIsReportedOnce(t *testing.T) {
+	p := newPoller(t)
+	p.answer("issues")
+	p.answer("prs")
+	p.answer("comments")
+	p.breaks("comments")
+
+	_, logs := p.run("5")
+	if n := strings.Count(logs, "source 'comments' has failed"); n != 1 {
+		t.Errorf("a persistent outage should be reported exactly once, got %d reports in:\n%s", n, logs)
+	}
+	if strings.Contains(logs, "source 'issues' has failed") {
+		t.Errorf("a healthy source must not be reported as failing:\n%s", logs)
+	}
+
+	// And recovery is announced, so the channel says when it is trustworthy
+	// again.
+	p.repair("comments")
+	_, logs = p.run("1")
+	if !strings.Contains(logs, "source 'comments' is answering again") {
+		t.Errorf("recovery from a reported outage should be announced, got:\n%s", logs)
+	}
+}
+
+// TestGHEventsPoll_FailureNeverEmitsAPartialResult guards the distinction the
+// whole design rests on: "nothing new" and "could not look" must never be
+// conflated. A failing call emits no events at all, rather than whatever partial
+// text the failure happened to print.
+func TestGHEventsPoll_FailureNeverEmitsAPartialResult(t *testing.T) {
+	p := newPoller(t)
+	p.answer("issues", "i1\t[ISSUE #1] real")
+	p.answer("prs")
+	p.answer("comments")
+	p.breaks("issues")
+
+	events, _ := p.run("1")
+	if len(events) != 0 {
+		t.Errorf("a failed call must emit nothing, got %v", events)
+	}
+	// The seen-set must also be untouched, so the event still arrives once the
+	// source recovers.
+	p.repair("issues")
+	events, _ = p.run("1")
+	if len(events) != 1 || !strings.Contains(events[0], "#1") {
+		t.Errorf("the event missed during the outage must arrive on recovery, got %v", events)
+	}
+}


### PR DESCRIPTION
Closes #1949.

## The bug

The captain-events monitor turned one failing `gh` call into forty-five minutes of the same two issues re-announced ~20 times. Three defects compounded into a loop that could not be escaped from outside:

1. **One global `advance` flag guarded every cursor.** A failing *comments* call pinned the cursor for *issues* too. The intent — never skip an event you failed to read — is right; the blast radius is not.
2. **Issues and PRs had no seen-set**, so the cursor was the only dedupe. With (1) freezing it, there was no second line of defence.
3. **The cursor was read once at startup**, so the state file was write-only from the outside. Repairing it by hand — the obvious remedy — did nothing until the process was restarted.

## Why this lands in the repo

That monitor lives in the operator's af home, **unversioned**. That is how it rotted unnoticed and why none of this had a test. Sachin patched defects 2 and 3 in the live copy and deliberately left defect 1, as "the part that deserves a real change and a test" — which it can't have while the script isn't in the repo.

So this lands the fixed design as `examples/tasks/gh-events-poll.sh`, the multi-source sibling of the existing `gh-issue-poll.sh`. Every source keeps its **own** cursor, its **own** seen-set, and its **own** consecutive-failure count. Nothing is shared between them — that is the whole fix. It is also genuinely useful to external users: the README already teaches "own your cursor", and this is the pattern for the case where you own more than one.

Also addresses the issue's third bullet: a source failing repeatedly reports it **once**, and announces recovery, instead of degrading into silence. Undelivered events look identical to "nothing happened", which is what made the original outage take twenty turns to diagnose.

The examples README gains the three rules of thumb the defects map onto.

## Tests

Hermetic Go test (mirroring `scripts/release_scripts_test.go`) driving the **real script** with a stub `gh` on PATH — no network, no auth, no repository. Covers each defect separately, plus the rule the design rests on: a failed call emits **nothing** rather than a partial result, so "nothing new" and "could not look" are never conflated.

All four fail against the pre-fix shape (global `advance` flag, no seen-set, cursor read once at startup), each naming its own defect:

```
--- FAIL: TestGHEventsPoll_OneBrokenSourceDoesNotPinTheOthers
    a broken COMMENTS call pinned the ISSUES cursor at "2000-01-01T00:00:00Z"
--- FAIL: TestGHEventsPoll_SeenSetSurvivesAPinnedCursor
    cycle 2 re-emitted already-seen events — the cursor must not be the only dedupe
--- FAIL: TestGHEventsPoll_CursorIsRereadEachCycle
    the failure report must quote the cursor read FROM DISK this cycle
--- FAIL: TestGHEventsPoll_PersistentFailureIsReportedOnce
    a persistent outage should be reported exactly once, got 0 reports
```

Full suite green in the container.

## Not in scope

The operator's live copy under the af home is untouched. Repointing that watch task at this script is an operator step, deliberately outside this PR — and the proximate trigger (the invalid `gh` token) remains the owner's to re-auth.