### PR TITLE
fix(proctree): darwin working-directory backend so the #2025 reap works on macOS (#2050)

### DIFF
--- a/internal/proctree/proctree_darwin.go
+++ b/internal/proctree/proctree_darwin.go
@@ -32,6 +32,9 @@ import (
 //   - proc_info(PROC_PIDTASKINFO) — cumulative CPU. kinfo_proc's p_uticks /
 //     p_sticks are legacy fields the modern XNU kernel does not populate, so
 //     reading them would report a confident 0% for a process pegging a core.
+//   - proc_info(PROC_PIDVNODEPATHINFO) — the working directory, this platform's
+//     answer to /proc/<pid>/cwd. kinfo_proc carries no cwd at all, so there is no
+//     cheaper source. Its buffer is decoded in vnodepathinfo.go (#2050).
 //
 // Nothing here reports a read failure as an empty result: an unreadable
 // process table returns an error, and an unreadable CPU counter returns
@@ -225,6 +228,9 @@ const (
 	procInfoCallPIDInfo = 2
 	// procPIDTaskInfo is PROC_PIDTASKINFO, the flavor returning procTaskInfo.
 	procPIDTaskInfo = 4
+	// procPIDVnodePathInfo is PROC_PIDVNODEPATHINFO, the flavor returning
+	// struct proc_vnodepathinfo — the process's cwd and root directory.
+	procPIDVnodePathInfo = 9
 )
 
 // readCPUTime returns pid's cumulative user+system CPU time.
@@ -258,18 +264,53 @@ func readCPUTime(pid int) (time.Duration, error) {
 	return time.Duration(ti.TotalUser + ti.TotalSystem), nil
 }
 
-// readWorkingDir has no darwin backend yet, and returns the honest unknown
-// rather than a guess.
+// readWorkingDir reads pid's cwd from proc_info(PROC_PIDVNODEPATHINFO), the
+// darwin equivalent of reading Linux's /proc/<pid>/cwd symlink (#2050).
 //
-// darwin's cwd source is proc_pidinfo(PROC_PIDVNODEPATHINFO), whose struct is
-// large and cannot be verified from a Linux dev box — and a mis-declared offset
-// would return a WRONG path, i.e. a fabricated POSITIVE, which is strictly worse
-// than "unknown" for the caller that resolves a home in this frame. So until it
-// can be written and proven on a real Mac, this reports (", false): WorkingDir's
-// explicit unknown channel, which skew.go already treats as "cannot resolve"
-// (#1044) and skips. A daemon whose home is spelled RELATIVELY is therefore not
-// evaluated for skew on darwin — a report-only, safe degradation, not a
-// fabricated fact.
-func readWorkingDir(int) (string, bool) {
-	return "", false
+// This goes through the proc_info syscall rather than libproc's proc_pidinfo()
+// for the same reason readCPUTime does: the wrapper needs cgo, and darwin builds
+// here run cgo-free. The flavor is the only difference between the two calls —
+// PROC_PIDVNODEPATHINFO instead of PROC_PIDTASKINFO — so this reuses a syscall
+// shape the package already relies on rather than introducing a cgo dependency
+// on the one path that must keep cross-compiling.
+//
+// The kernel refuses this for processes we do not own (and for others it does
+// not explain — SIP and code-signing restrictions among them). Per this
+// package's rule, that refusal is NOT modelled in advance: we ask, and classify
+// what comes back. Every failure — a refusal, a short write, a path that does
+// not validate — becomes the honest unknown, which the callers treat as "cannot
+// resolve" and skip (#1044). Deliberately no error channel: WorkingDir's
+// contract is two-valued, and every caller here already handles false.
+//
+// The decode is NOT done in this file. It lives in vnodepathinfo.go, untagged,
+// so Linux CI exercises the offset arithmetic that this file can only feed —
+// see that file for why the offsets are validated rather than trusted, and for
+// what a wrong one would cost on the destructive reap path.
+func readWorkingDir(pid int) (string, bool) {
+	var buf [vnodePathInfoSize]byte
+	n, _, errno := syscall.Syscall6(
+		uintptr(unix.SYS_PROC_INFO),
+		uintptr(procInfoCallPIDInfo),
+		uintptr(pid),
+		uintptr(procPIDVnodePathInfo),
+		0,
+		uintptr(unsafe.Pointer(&buf[0])),
+		uintptr(len(buf)),
+	)
+	if errno != 0 {
+		// Includes the forward-compatible case: proc_info returns ENOMEM when the
+		// buffer is smaller than the flavor's struct, so if a future macOS grows
+		// proc_vnodepathinfo this reports unknown and the reap goes back to
+		// no-opping — the same safe degradation it had before #2050, never a
+		// half-decoded path.
+		return "", false
+	}
+	if n != uintptr(len(buf)) {
+		// A short write means the kernel's struct is not the one vnodepathinfo.go
+		// describes, so the bytes at the cwd offset are not the cwd. Same reasoning
+		// as readCPUTime's length check, with a sharper consequence: this value is
+		// what reapWorktreeWriters signals on.
+		return "", false
+	}
+	return cwdFromVnodePathInfo(buf[:n])
 }

--- a/internal/proctree/proctree_darwin_test.go
+++ b/internal/proctree/proctree_darwin_test.go
@@ -1,0 +1,100 @@
+//go:build darwin
+
+package proctree
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests are the RUNTIME half of #2050's verification, and they exist
+// because the other half cannot be done anywhere but here.
+//
+// vnodepathinfo_test.go proves the decode and the struct offsets on every
+// platform, but no amount of Linux CI can prove the syscall itself: that
+// PROC_PIDVNODEPATHINFO is flavor 9, that the kernel writes 2352 bytes, that
+// pvi_cdir really is the current directory and not the root directory. Those are
+// facts about a running XNU kernel. So they are written down as tests that
+// execute the moment anyone runs this suite on a Mac, rather than as a paragraph
+// asking a reviewer to check by hand.
+//
+// If the backend were wrong, this is what would catch it: a bad flavor or size
+// fails the syscall (every assertion below goes false), and reading pvi_rdir
+// instead of pvi_cdir returns "/" — which TestReadWorkingDir_FollowsChdir
+// rejects specifically.
+
+// resolved matches what the kernel reports: vn_getpath returns the real path, so
+// /tmp comes back as /private/tmp. Comparing raw strings would fail on macOS for
+// that reason alone.
+func resolved(t *testing.T, path string) string {
+	t.Helper()
+	r, err := filepath.EvalSymlinks(path)
+	require.NoError(t, err)
+	return r
+}
+
+// TestReadWorkingDir_MatchesOwnCwd is the load-bearing one: the kernel's answer
+// for this process must equal the working directory this process knows it has.
+func TestReadWorkingDir_MatchesOwnCwd(t *testing.T) {
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+
+	got, ok := readWorkingDir(os.Getpid())
+	require.True(t, ok, "readWorkingDir must resolve our OWN pid — if this is false the "+
+		"syscall failed outright (wrong flavor, wrong buffer size, or an unexpected refusal)")
+	assert.Equal(t, resolved(t, wd), resolved(t, got))
+}
+
+// TestReadWorkingDir_FollowsChdir proves we read pvi_cdir and not pvi_rdir. A
+// mis-declared offset that landed on the root directory would return "/" here and
+// still have passed a laxer version of the test above on a process started at /.
+func TestReadWorkingDir_FollowsChdir(t *testing.T) {
+	orig, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, os.Chdir(orig)) })
+
+	dir := t.TempDir()
+	require.NoError(t, os.Chdir(dir))
+
+	got, ok := readWorkingDir(os.Getpid())
+	require.True(t, ok)
+	assert.Equal(t, resolved(t, dir), resolved(t, got))
+	assert.NotEqual(t, "/", got, "returning the root directory means pvi_rdir is being read instead of pvi_cdir")
+}
+
+// TestReadWorkingDir_UnknownForDeadPid pins the honest-unknown contract on the
+// failure side: a pid that names nothing must report false, never a stale or
+// fabricated path. reapWorktreeWriters signals what this returns.
+func TestReadWorkingDir_UnknownForDeadPid(t *testing.T) {
+	// A pid we can be confident is not live: allocate one, then reap it.
+	cmd := exec.Command("/usr/bin/true")
+	require.NoError(t, cmd.Run())
+	dead := cmd.Process.Pid
+
+	got, ok := readWorkingDir(dead)
+	assert.False(t, ok, "a reaped pid has no working directory to report")
+	assert.Empty(t, got)
+}
+
+// TestReadWorkingDir_ForeignProcessIsUnknownNotWrong checks the refusal path.
+// pid 1 (launchd) is root-owned, so an unprivileged run must be REFUSED rather
+// than answered. Whatever comes back, it must never be a path we then treat as a
+// match — the fabricated-negative/positive rule this package exists for.
+func TestReadWorkingDir_ForeignProcessIsUnknownNotWrong(t *testing.T) {
+	got, ok := readWorkingDir(1)
+	if os.Geteuid() == 0 {
+		t.Skip("running as root, so pid 1 is not a foreign process and nothing is refused")
+	}
+	if ok {
+		// Not a failure per se — Apple may disclose it — but it must at least be a
+		// real absolute path rather than decoded garbage.
+		assert.True(t, filepath.IsAbs(got), "any disclosed cwd must be absolute, got %q", got)
+	} else {
+		assert.Empty(t, got)
+	}
+}

--- a/internal/proctree/vnodepathinfo.go
+++ b/internal/proctree/vnodepathinfo.go
@@ -1,0 +1,115 @@
+package proctree
+
+import "bytes"
+
+// This file decodes darwin's PROC_PIDVNODEPATHINFO buffer — the kernel's answer
+// to Linux's /proc/<pid>/cwd — and like procargs2.go it carries NO build tag,
+// deliberately.
+//
+// The risk here is not that the decode is intricate; it is that it is
+// UNFALSIFIABLE at a glance. The buffer is a 2352-byte C struct and the cwd
+// lives at a fixed offset inside it, so a mis-declared offset does not fail —
+// it returns a DIFFERENT STRING. That string is handed to reapWorktreeWriters
+// (session/git/worktree_ops.go), which signals every process whose cwd is under
+// the worktree. A fabricated path there is not a wrong report, it is a wrong
+// kill: exactly the fabricated-positive this package exists to refuse (#1939),
+// on the one call path where it is destructive.
+//
+// So the offsets are pinned here as named constants with their full derivation,
+// the decode validates rather than trusts what it finds, and the whole thing is
+// platform-independent so Linux CI exercises it on every run — the darwin
+// syscall that feeds it stays in proctree_darwin.go. See #2050.
+
+// Layout of struct proc_vnodepathinfo, transcribed from Apple's headers:
+//
+//	xnu bsd/sys/proc_info.h:
+//	  struct vinfo_stat {
+//	          uint32_t vst_dev;  uint16_t vst_mode; uint16_t vst_nlink;
+//	          uint64_t vst_ino;  uid_t vst_uid;     gid_t vst_gid;
+//	          int64_t  vst_atime, vst_atimensec, vst_mtime, vst_mtimensec,
+//	                   vst_ctime, vst_ctimensec, vst_birthtime, vst_birthtimensec;
+//	          off_t    vst_size; int64_t vst_blocks;
+//	          int32_t  vst_blksize; uint32_t vst_flags, vst_gen, vst_rdev;
+//	          int64_t  vst_qspare[2];
+//	  };
+//	  struct vnode_info      { struct vinfo_stat vi_stat; int vi_type; int vi_pad; fsid_t vi_fsid; };
+//	  struct vnode_info_path { struct vnode_info vip_vi; char vip_path[MAXPATHLEN]; };
+//	  struct proc_vnodepathinfo { struct vnode_info_path pvi_cdir, pvi_rdir; };
+//
+// with the typedef chain resolved from Apple's own headers rather than assumed:
+// uid_t/gid_t are __uint32_t, off_t is __int64_t, fsid_t is
+// `struct fsid { int32_t val[2]; }` (bsd/sys/_types/_fsid_t.h), and MAXPATHLEN
+// is PATH_MAX (bsd/sys/param.h) which is 1024 (bsd/sys/syslimits.h).
+//
+// Every field is a fixed-width scalar or a char array — there is no long,
+// pointer or long double — so natural alignment makes the layout identical on
+// every LP64 target, i.e. the same on arm64 and amd64 macs. The numbers below
+// were confirmed by compiling those exact declarations and printing
+// sizeof/offsetof, not by hand arithmetic:
+//
+//	sizeof(vinfo_stat)                 = 136
+//	sizeof(vnode_info)                 = 152
+//	offsetof(vnode_info_path, vip_path)= 152
+//	sizeof(vnode_info_path)            = 1176
+//	sizeof(proc_vnodepathinfo)         = 2352
+//
+// pvi_cdir is the FIRST member, so the current directory's path begins at
+// offset 152 and runs for MAXPATHLEN bytes. vnodepathinfo_test.go re-derives all
+// of this from an independent field table so a typo in a constant fails a test
+// rather than fabricating a path.
+const (
+	// vnodePathInfoMaxPathLen is MAXPATHLEN: the width of vip_path.
+	vnodePathInfoMaxPathLen = 1024
+	// vnodePathInfoSize is sizeof(struct proc_vnodepathinfo). The kernel writes
+	// exactly this many bytes; readWorkingDir rejects any other count.
+	vnodePathInfoSize = 2352
+	// vnodePathInfoCwdPathOffset is offsetof(pvi_cdir.vip_path) — where the
+	// working directory's NUL-terminated path starts.
+	vnodePathInfoCwdPathOffset = 152
+)
+
+// cwdFromVnodePathInfo extracts the working directory from a
+// PROC_PIDVNODEPATHINFO buffer, reporting false rather than guessing.
+//
+// It VALIDATES instead of trusting the offset, because the caller is
+// destructive. Three independent things must hold, and each one is a way a wrong
+// layout gets caught rather than believed:
+//
+//   - the buffer is exactly sizeof(struct proc_vnodepathinfo). A kernel whose
+//     struct is not the one described above writes a different count, and a
+//     short buffer would otherwise be read past its meaningful end.
+//   - the path is NUL-terminated within MAXPATHLEN. The kernel guarantees this
+//     itself — proc_pidvnodepathinfo() in bsd/kern/proc_info.c ends with
+//     `pvi_cdir.vip_path[MAXPATHLEN - 1] = 0` — so its absence means we are not
+//     looking at vip_path.
+//   - the path is absolute and free of control bytes. vn_getpath() always
+//     returns a rooted path, while the bytes preceding vip_path are timestamps,
+//     sizes and a fsid — small integers and zeros that essentially never spell a
+//     plausible '/'-led string.
+//
+// A path this rejects degrades to the honest unknown, which every caller already
+// handles as "cannot resolve" and skips. That asymmetry is the point: a false
+// negative costs an unreaped writer (the status quo on darwin), a false positive
+// costs the wrong process.
+func cwdFromVnodePathInfo(buf []byte) (string, bool) {
+	if len(buf) != vnodePathInfoSize {
+		return "", false
+	}
+	raw := buf[vnodePathInfoCwdPathOffset : vnodePathInfoCwdPathOffset+vnodePathInfoMaxPathLen]
+	end := bytes.IndexByte(raw, 0)
+	if end <= 0 {
+		// -1: no terminator, so this is not vip_path. 0: an empty path, which is
+		// what a process with no cwd (a kernel task) reports — unknown, not "/".
+		return "", false
+	}
+	path := raw[:end]
+	if path[0] != '/' {
+		return "", false
+	}
+	for _, c := range path {
+		if c < 0x20 || c == 0x7f {
+			return "", false
+		}
+	}
+	return string(path), true
+}

--- a/internal/proctree/vnodepathinfo_test.go
+++ b/internal/proctree/vnodepathinfo_test.go
@@ -1,0 +1,210 @@
+package proctree
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// cField is one C struct member, as size and alignment in bytes.
+type cField struct {
+	name        string
+	size, align int
+}
+
+// cLayout applies the C struct layout rules — pad each member up to its own
+// alignment, then round the total up to the struct's alignment (the max of its
+// members') — and returns each member's offset plus the total size.
+//
+// This exists so the constants in vnodepathinfo.go are checked against a
+// DERIVATION rather than against themselves. The field table below is
+// transcribed from xnu bsd/sys/proc_info.h independently of the production
+// file's numbers, so a typo in either one shows up as a failure here instead of
+// as a working build that reads the wrong 1024 bytes.
+func cLayout(fields []cField) (map[string]int, int) {
+	offsets := make(map[string]int, len(fields))
+	off, structAlign := 0, 1
+	for _, f := range fields {
+		if f.align > structAlign {
+			structAlign = f.align
+		}
+		if pad := off % f.align; pad != 0 {
+			off += f.align - pad
+		}
+		offsets[f.name] = off
+		off += f.size
+	}
+	if pad := off % structAlign; pad != 0 {
+		off += structAlign - pad
+	}
+	return offsets, off
+}
+
+// TestVnodePathInfoLayoutMatchesSDKHeaders re-derives sizeof(struct
+// proc_vnodepathinfo) and offsetof(pvi_cdir.vip_path) from the SDK field list
+// and pins the constants the darwin backend indexes with.
+//
+// The typedef chain is resolved from Apple's headers, not assumed: uid_t/gid_t
+// are __uint32_t, off_t is __int64_t, fsid_t is `struct fsid { int32_t val[2]; }`
+// (bsd/sys/_types/_fsid_t.h), MAXPATHLEN is PATH_MAX = 1024 (bsd/sys/param.h,
+// bsd/sys/syslimits.h). Every member is a fixed-width scalar or a char array, so
+// the layout is identical on every LP64 target — arm64 and amd64 macs alike —
+// which is why deriving it here on Linux is sound.
+func TestVnodePathInfoLayoutMatchesSDKHeaders(t *testing.T) {
+	// struct vinfo_stat
+	_, vinfoStatSize := cLayout([]cField{
+		{"vst_dev", 4, 4}, {"vst_mode", 2, 2}, {"vst_nlink", 2, 2}, {"vst_ino", 8, 8},
+		{"vst_uid", 4, 4}, {"vst_gid", 4, 4},
+		{"vst_atime", 8, 8}, {"vst_atimensec", 8, 8},
+		{"vst_mtime", 8, 8}, {"vst_mtimensec", 8, 8},
+		{"vst_ctime", 8, 8}, {"vst_ctimensec", 8, 8},
+		{"vst_birthtime", 8, 8}, {"vst_birthtimensec", 8, 8},
+		{"vst_size", 8, 8}, {"vst_blocks", 8, 8},
+		{"vst_blksize", 4, 4}, {"vst_flags", 4, 4}, {"vst_gen", 4, 4}, {"vst_rdev", 4, 4},
+		{"vst_qspare", 16, 8},
+	})
+	require.Equal(t, 136, vinfoStatSize, "sizeof(struct vinfo_stat)")
+
+	// struct vnode_info
+	_, vnodeInfoSize := cLayout([]cField{
+		{"vi_stat", vinfoStatSize, 8},
+		{"vi_type", 4, 4}, {"vi_pad", 4, 4},
+		{"vi_fsid", 8, 4}, // struct fsid { int32_t val[2]; }
+	})
+	require.Equal(t, 152, vnodeInfoSize, "sizeof(struct vnode_info)")
+
+	// struct vnode_info_path
+	vipOffsets, vnodeInfoPathSize := cLayout([]cField{
+		{"vip_vi", vnodeInfoSize, 8},
+		{"vip_path", vnodePathInfoMaxPathLen, 1},
+	})
+	require.Equal(t, 1176, vnodeInfoPathSize, "sizeof(struct vnode_info_path)")
+
+	// struct proc_vnodepathinfo { pvi_cdir, pvi_rdir }
+	pviOffsets, pviSize := cLayout([]cField{
+		{"pvi_cdir", vnodeInfoPathSize, 8},
+		{"pvi_rdir", vnodeInfoPathSize, 8},
+	})
+
+	// The two numbers the darwin backend actually indexes with.
+	assert.Equal(t, pviSize, vnodePathInfoSize,
+		"vnodePathInfoSize must equal sizeof(struct proc_vnodepathinfo)")
+	assert.Equal(t, pviOffsets["pvi_cdir"]+vipOffsets["vip_path"], vnodePathInfoCwdPathOffset,
+		"vnodePathInfoCwdPathOffset must equal offsetof(pvi_cdir.vip_path)")
+
+	// Belt: the path window must lie inside the buffer.
+	assert.LessOrEqual(t, vnodePathInfoCwdPathOffset+vnodePathInfoMaxPathLen, vnodePathInfoSize)
+}
+
+// vnodePathInfoBuf builds a PROC_PIDVNODEPATHINFO buffer whose cwd path is
+// cwd, with the leading vnode_info bytes filled with plausible stat data rather
+// than zeros — zeros would make an off-by-N offset look like an empty path and
+// pass for the wrong reason.
+func vnodePathInfoBuf(cwd string) []byte {
+	buf := make([]byte, vnodePathInfoSize)
+	for i := range buf[:vnodePathInfoCwdPathOffset] {
+		buf[i] = byte(i%251 + 1) // non-zero, non-'/'-leading filler
+	}
+	copy(buf[vnodePathInfoCwdPathOffset:], cwd)
+	return buf
+}
+
+func TestCwdFromVnodePathInfo(t *testing.T) {
+	t.Run("reads the current directory at pvi_cdir.vip_path", func(t *testing.T) {
+		got, ok := cwdFromVnodePathInfo(vnodePathInfoBuf("/Users/x/af/worktrees/s1"))
+		require.True(t, ok)
+		assert.Equal(t, "/Users/x/af/worktrees/s1", got)
+	})
+
+	t.Run("reads a path of the maximum length", func(t *testing.T) {
+		long := "/" + strings.Repeat("d", vnodePathInfoMaxPathLen-2)
+		got, ok := cwdFromVnodePathInfo(vnodePathInfoBuf(long))
+		require.True(t, ok)
+		assert.Equal(t, long, got)
+	})
+
+	t.Run("rejects a buffer that is not exactly the struct size", func(t *testing.T) {
+		full := vnodePathInfoBuf("/tmp/wt")
+		for _, n := range []int{0, vnodePathInfoSize - 1, vnodePathInfoSize + 1} {
+			b := make([]byte, n)
+			copy(b, full)
+			_, ok := cwdFromVnodePathInfo(b)
+			assert.False(t, ok, "a %d-byte buffer is not a proc_vnodepathinfo", n)
+		}
+	})
+
+	t.Run("rejects an unterminated path", func(t *testing.T) {
+		buf := vnodePathInfoBuf("/tmp/wt")
+		for i := vnodePathInfoCwdPathOffset; i < vnodePathInfoCwdPathOffset+vnodePathInfoMaxPathLen; i++ {
+			buf[i] = 'x'
+		}
+		buf[vnodePathInfoCwdPathOffset] = '/'
+		_, ok := cwdFromVnodePathInfo(buf)
+		assert.False(t, ok, "the kernel always NUL-terminates vip_path; its absence means this is not vip_path")
+	})
+
+	t.Run("reports a process with no cwd as unknown, never as root", func(t *testing.T) {
+		got, ok := cwdFromVnodePathInfo(vnodePathInfoBuf(""))
+		assert.False(t, ok)
+		assert.Empty(t, got)
+	})
+
+	t.Run("rejects a relative path", func(t *testing.T) {
+		_, ok := cwdFromVnodePathInfo(vnodePathInfoBuf("Users/x/af"))
+		assert.False(t, ok, "vn_getpath always returns a rooted path")
+	})
+
+	t.Run("rejects a path carrying control bytes", func(t *testing.T) {
+		_, ok := cwdFromVnodePathInfo(vnodePathInfoBuf("/tmp/\x01\x02wt"))
+		assert.False(t, ok)
+	})
+
+	// The one that matters for #2050: a wrong offset must yield the honest
+	// unknown, never a plausible-looking path. reapWorktreeWriters SIGNALS what
+	// this returns, so a fabricated positive is a wrong kill.
+	t.Run("a mis-declared offset degrades to unknown rather than fabricating a path", func(t *testing.T) {
+		real := "/Users/x/af/worktrees/s1"
+		for _, skew := range []int{-152, -16, -8, -4, -1, 1, 4, 8, 16, 152} {
+			buf := make([]byte, vnodePathInfoSize)
+			for i := range buf {
+				buf[i] = byte(i%251 + 1)
+			}
+			at := vnodePathInfoCwdPathOffset + skew
+			copy(buf[at:], real)
+			buf[at+len(real)] = 0
+
+			got, ok := cwdFromVnodePathInfo(buf)
+			if ok {
+				assert.NotEqual(t, real, got,
+					"offset skew %d must not resolve to the real path", skew)
+				assert.True(t, strings.HasPrefix(got, "/"),
+					"anything accepted must at least be absolute (skew %d)", skew)
+			}
+		}
+	})
+
+	t.Run("ignores pvi_rdir", func(t *testing.T) {
+		// The root directory follows the cwd in the struct. Reading it by mistake
+		// would report "/" for every process, which under a worktree root would
+		// match nothing — but under "/" would match everything.
+		buf := vnodePathInfoBuf("/Users/x/af/worktrees/s1")
+		rdir := vnodePathInfoSize/2 + vnodePathInfoCwdPathOffset
+		copy(buf[rdir:], "/")
+		buf[rdir+1] = 0
+
+		got, ok := cwdFromVnodePathInfo(buf)
+		require.True(t, ok)
+		assert.Equal(t, "/Users/x/af/worktrees/s1", got)
+	})
+
+	t.Run("does not read past the NUL into adjacent struct bytes", func(t *testing.T) {
+		buf := vnodePathInfoBuf("/tmp/wt")
+		copy(buf[vnodePathInfoCwdPathOffset+len("/tmp/wt")+1:], bytes.Repeat([]byte("junk"), 8))
+		got, ok := cwdFromVnodePathInfo(buf)
+		require.True(t, ok)
+		assert.Equal(t, "/tmp/wt", got)
+	})
+}

--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -661,13 +661,12 @@ var (
 // uninterruptible I/O, a mount) is left for the removal to fail loudly on, not
 // spun on forever.
 //
-// PLATFORM GAP (darwin): proctree.WorkingDir has no macOS backend yet — it
-// returns the honest unknown rather than fabricate a path from an unverifiable
-// libproc struct (proctree_darwin.go) — so on darwin every process reads as
-// "cwd unknown", this finds no writers, and the reap no-ops. The #2025 orphan
-// therefore still races on macOS until the darwin working-directory backend
-// lands (tracked in #2050). No-op is the safe degradation: it can never signal
-// the wrong process, only fail to signal the right one.
+// Linux and darwin both back proctree.WorkingDir (/proc/<pid>/cwd and
+// proc_info(PROC_PIDVNODEPATHINFO) respectively), so the reap is live on both
+// as of #2050. Elsewhere, and for any process whose cwd the kernel will not
+// disclose, WorkingDir reports the honest unknown and that process is simply not
+// matched — the safe degradation, since it can only fail to signal the right
+// process, never signal the wrong one.
 func reapWorktreeWriters(worktreePath string) {
 	// The path exists (callers reap only after an os.Stat succeeds), so resolving
 	// symlinks here matches /proc/<pid>/cwd, which the kernel already resolves.

--- a/session/git/worktree_reap_test.go
+++ b/session/git/worktree_reap_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"syscall"
 	"testing"
@@ -35,18 +34,13 @@ import (
 // file so it never fills the disk; exec.CommandContext SIGKILLs it at a deadline;
 // t.Cleanup SIGKILLs its whole process group and reaps it.
 func TestCleanup_ReapsSurvivingWriterBeforeRemoval(t *testing.T) {
-	// The reap finds writers by working directory, and proctree has no darwin cwd
-	// backend yet: readWorkingDir on macOS returns the honest unknown ("", false)
-	// rather than risk a fabricated path from an unverifiable libproc struct — which
-	// for a DESTRUCTIVE reap would mean signalling the wrong process. So on darwin
-	// reapWorktreeWriters safely no-ops, and the #2025 orphan persists on macOS
-	// until the darwin working-directory backend lands. This is a real, pre-existing
-	// platform gap in a shared package, not a defect in this fix — tracked in #2050.
-	if runtime.GOOS == "darwin" {
-		t.Skip("proctree has no darwin working-directory backend, so the cwd-based " +
-			"writer reap no-ops on macOS — #2025 stays open there until #2050 adds it")
-	}
-
+	// Runs on darwin as of #2050: proctree grew a working-directory backend
+	// (proc_info(PROC_PIDVNODEPATHINFO)), so the cwd-based writer reap is live on
+	// macOS rather than no-opping. This test is the only thing that exercises that
+	// backend against a REAL process — the decode has unit coverage on every
+	// platform, but "the kernel actually returns this pid's cwd" can only be
+	// observed on a Mac. If it fails here, suspect the syscall path in
+	// proctree_darwin.go before suspecting the reap.
 	sandboxHome(t)
 	repoRoot := createGitRepo(t)
 	runGit(t, repoRoot, "commit", "--allow-empty", "-m", "initial")


### PR DESCRIPTION
Closes #2050.

`internal/proctree` had no darwin backend for a process's working directory —
`readWorkingDir` returned `("", false)` by design, because a mis-declared libproc
struct offset would fabricate a WRONG path, and the caller that consumes it
(`reapWorktreeWriters`, #2025) **signals** what it returns. A fabricated positive
there is not a wrong report, it's a wrong kill. So the reap no-opped on macOS and
`TestCleanup_ReapsSurvivingWriterBeforeRemoval` was skipped there.

This adds the backend via `proc_info(PROC_PIDVNODEPATHINFO)` and un-skips that test
on darwin.

## ⚠️ Runtime verification needs a Mac — NOT verified here

**This was written and gated on Linux. The darwin syscall path has never been
executed.** CI's darwin lane cross-compiles but does not run these tests. What is
actually proven here:

- ✅ compiles and `go vet`s clean for `darwin/arm64` **and** `darwin/amd64`
  (including vet's `unsafeptr` analyzer, which is what checks the
  `uintptr(unsafe.Pointer(…))` syscall pattern)
- ✅ the struct offsets are correct-by-construction against Apple's headers (below)
- ✅ the decode is unit-tested on every platform, including its rejection behaviour
- ❌ **unproven: that the kernel actually answers this call as expected**

Before this is treated as working on macOS, someone with a Mac should run
`go test ./internal/proctree/ ./session/git/ -run 'WorkingDir|ReapsSurvivingWriter'`.
I wrote that verification as **tests rather than a checklist** — `proctree_darwin_test.go`
is darwin-tagged and self-executes the moment the suite runs on a Mac. It asserts
`readWorkingDir(os.Getpid())` equals `os.Getwd()`, that it follows a `chdir` (which
is what would catch reading `pvi_rdir` instead of `pvi_cdir` — that failure mode
returns `/` for every process), and that a reaped pid reports unknown.

## Deviation from the issue: no cgo

The issue proposed cgo (`proc_pidinfo`). I used the raw `proc_info` syscall instead,
because **the package already does exactly this** — `readCPUTime` calls
`syscall.Syscall6(unix.SYS_PROC_INFO, …)` and documents why: libproc's wrapper needs
cgo and darwin builds here run cgo-free. `PROC_PIDVNODEPATHINFO` is the same syscall
with a different flavor, so this reuses a proven shape rather than adding a cgo
dependency to a package that must keep cross-compiling. Flag if you'd rather have
the cgo version.

## How the offsets were verified

Not from memory. The chain, all from Apple's published sources:

| Fact | Source |
|---|---|
| `struct vinfo_stat` / `vnode_info` / `vnode_info_path` / `proc_vnodepathinfo` | xnu `bsd/sys/proc_info.h` |
| `PROC_PIDVNODEPATHINFO = 9` | same header |
| `MAXPATHLEN = PATH_MAX` | xnu `bsd/sys/param.h` |
| `PATH_MAX = 1024` | xnu `bsd/sys/syslimits.h` |
| `fsid_t = struct fsid { int32_t val[2]; }` | xnu `bsd/sys/_types/_fsid_t.h` |
| kernel NUL-terminates `vip_path` | `bsd/kern/proc_info.c`: `pvi_cdir.vip_path[MAXPATHLEN-1] = 0` |

Cross-check that the header I read is the right one: it also defines
`PROC_PIDTASKINFO = 4`, which matches the constant already in-tree and demonstrably
working in `readCPUTime`.

I then **compiled those exact declarations** and printed `sizeof`/`offsetof` rather
than trusting hand arithmetic: `sizeof(proc_vnodepathinfo) = 2352`,
`offsetof(pvi_cdir.vip_path) = 152`. Every member is a fixed-width scalar or a char
array — no `long`, pointer, or `long double`, the only types whose alignment differs
between LP64 ABIs — so the layout is identical on arm64 and amd64 macs, which is
what makes deriving it on Linux sound.

`TestVnodePathInfoLayoutMatchesSDKHeaders` re-derives all of it from an independent
field table, so a typo in a constant fails a test instead of shifting the read
window. I mutation-checked it: `152→156`, `2352→2360`, `1024→4096` each fail.

## Why a wrong offset can't fabricate a path anyway

Belt as well as braces, because the consumer is destructive. The decode validates
instead of trusting: the buffer must be exactly 2352 bytes, the path must be
NUL-terminated within `MAXPATHLEN`, and it must be absolute and free of control
bytes. The 152 bytes preceding `vip_path` are timestamps, sizes and a fsid — small
integers and zeros that essentially never spell a plausible `/`-led string.
`TestCwdFromVnodePathInfo` walks the offset ±152 bytes and asserts no skew ever
resolves to the real path.

Every failure — refusal, short write, failed validation — becomes the honest unknown.
That asymmetry is deliberate: a false negative costs an unreaped writer (the status
quo on darwin), a false positive costs the wrong process. This also covers the
forward-compatible case: if a future macOS grows the struct, `proc_info` returns
ENOMEM and the reap simply goes back to no-opping.

## Fail-first, honestly

`internal/proctree` tests fail to compile without the implementation, and the layout
test fails under constant mutation. But I want to be straight about the limit: **the
behavioural fail-first — reap no-ops on macOS before, reaps after — cannot be
demonstrated on Linux.** The Linux-runnable tests lock the decode and the offsets,
not the kernel's answer.

## Structure

Follows the `procargs2.go` precedent already in the package: the byte-shuffling goes
in an **untagged** file (`vnodepathinfo.go`) so Linux CI exercises it on every run,
and only the syscall stays in `proctree_darwin.go`.

## Adjacent audit

- `session/git/worktree_ops.go` — retired the now-false `PLATFORM GAP (darwin)` note.
- `session/git/worktree_reap_test.go` — skip removed, `runtime` import dropped.
- `doctor/skew.go` (the other `WorkingDir` caller) — needed no change; it already
  handles false generically, and now gains working relative-home resolution on macOS
  for free.
- `doctor/checks.go:199`, `daemon/stopall.go:265` mention "no darwin backend" but are
  **historical narratives about past bugs** (#1939), not current-gap claims — left as
  written.

## Gates

`gofmt` · `go build` (linux + darwin arm64/amd64) · `golangci-lint --fast` (also
under `GOOS=darwin`, so the darwin-tagged files are actually linted) · `deadcode
-test` · `make test-container`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
