### PR TITLE
fix(session): deliver the recovery repaint before any respawned-pane bytes (#1975)

### DIFF
--- a/session/ptybroker.go
+++ b/session/ptybroker.go
@@ -362,6 +362,14 @@ func (b *ptyBroker) maybeStopCapture() {
 //     With no subscribers left, the lazy lifecycle is simply re-armed for the next
 //     Subscribe.
 //
+// Recovery is ATOMIC as each attached subscriber sees it (#1975): the barrier armed
+// below holds every subscriber's content stream from the moment recovery starts until
+// the repaint is installed, so the repaint is the FIRST thing a subscriber renders
+// after the respawn. Without it, steps 1-3 each leak a frame the repaint then wipes —
+// the dead pane's still-buffered bytes before the discard, and (the reported case) the
+// re-spawned pane's live bytes during step 3's snapshot, which runs without b.mu while
+// the freshly-started readLoop is already feeding and waking subscribers.
+//
 // The subscriber count is re-read AFTER the stop (still under captureMu) so a
 // subscriber that left during the blocking teardown is not resurrected onto a capture
 // nobody wants. A no-op when the broker is already closed.
@@ -374,6 +382,11 @@ func (b *ptyBroker) resetCapture() {
 		b.mu.Unlock()
 		return
 	}
+	// Arm the barrier FIRST — before the teardown, the discard, and the restart — so no
+	// subscriber can emit a frame at any point inside the recovery. Armed subscribers
+	// are captured by identity, not re-read from b.subs at release time, so one that
+	// detaches mid-recovery is still released rather than left parked (#1975).
+	armed := b.armRecoveryRepaintLocked()
 	var stop func()
 	if b.capturing {
 		stop = b.stopCapture
@@ -381,6 +394,14 @@ func (b *ptyBroker) resetCapture() {
 		b.stopCapture = nil
 	}
 	b.mu.Unlock()
+
+	// The barrier MUST be lifted on EVERY path out — a failed restart, a Snapshot
+	// error, nobody left attached — or an armed subscriber parks in NextEvent forever
+	// waiting for a repaint that never comes. rp is read when the deferred call runs,
+	// so this single exit point both installs whatever repaint the recovery managed to
+	// build and lifts the barrier, atomically under b.mu.
+	var rp []byte
+	defer func() { b.releaseRecoveryRepaint(armed, rp) }()
 
 	if stop != nil {
 		stop()
@@ -416,37 +437,73 @@ func (b *ptyBroker) resetCapture() {
 
 	// A subscriber stayed attached across the respawn. Restart the capture against the
 	// re-spawned pane and re-seed every current subscriber so it repaints the recovered
-	// screen and resumes live output without a new Subscribe.
+	// screen and resumes live output without a new Subscribe. The restarted capture's
+	// readLoop begins feeding and waking subscribers IMMEDIATELY — the barrier is what
+	// keeps those bytes behind the repaint built below (#1975).
 	if err := b.ensureCaptureStartedLocked(); err != nil {
 		log.WarningLog.Printf("pty broker: restart capture after recovery: %v", err)
 		return
 	}
-	b.reseedSubscribersLocked()
+	rp = b.recoveryRepaint()
 }
 
-// reseedSubscribersLocked gives every currently-registered subscriber a fresh initial
-// repaint of the recovered pane's screen and wakes it, so a client that stayed
-// attached across a tmux respawn repaints the current screen and resumes live output
-// on its own (#1682). It mirrors subscribe()'s initial-repaint injection but fans the
-// one snapshot to ALL subscribers. Best-effort: a Snapshot error (or an empty screen)
-// degrades to just waking the subscribers — the restarted capture's next live byte
-// still reaches them — rather than failing the recovery. Caller holds captureMu; the
-// snapshot exec runs without b.mu held, matching subscribe().
-func (b *ptyBroker) reseedSubscribersLocked() {
-	var rp []byte
-	if snap, err := b.ch.Snapshot(); err != nil {
-		log.WarningLog.Printf("pty broker: snapshot for recovery re-seed: %v", err)
-	} else if len(snap.Screen) > 0 {
-		rp = buildRepaint(snap)
+// armRecoveryRepaintLocked holds every currently-registered subscriber's content
+// stream (PTYCursor/PTYData) until the recovery repaint is installed, and returns the
+// subscribers it armed. Caller holds b.mu.
+//
+// The returned slice — NOT a later re-read of b.subs — is what releaseRecoveryRepaint
+// walks: a subscriber that detaches mid-recovery is gone from the map but may still be
+// parked in NextEvent, and it must be released too.
+func (b *ptyBroker) armRecoveryRepaintLocked() []*ptySub {
+	armed := make([]*ptySub, 0, len(b.subs))
+	for _, s := range b.subs {
+		s.repaintArmed = true
+		armed = append(armed, s)
 	}
+	return armed
+}
+
+// recoveryRepaint captures the recovered pane's screen and builds the repaint bytes
+// the re-seed installs, so a client that stayed attached across a tmux respawn
+// repaints the current screen and resumes live output on its own (#1682). It mirrors
+// subscribe()'s initial-repaint injection but builds ONE snapshot for all subscribers.
+// The Snapshot exec runs without b.mu held (matching subscribe) — which is precisely
+// the window the barrier exists to cover. Best-effort: a Snapshot error or an empty
+// screen yields nil, and the release degrades to just lifting the barrier and waking
+// the subscribers — the restarted capture's next live byte still reaches them — rather
+// than failing the recovery. Caller holds captureMu.
+func (b *ptyBroker) recoveryRepaint() []byte {
+	snap, err := b.ch.Snapshot()
+	if err != nil {
+		log.WarningLog.Printf("pty broker: snapshot for recovery re-seed: %v", err)
+		return nil
+	}
+	if len(snap.Screen) == 0 {
+		return nil
+	}
+	return buildRepaint(snap)
+}
+
+// releaseRecoveryRepaint installs rp on every armed subscriber and lifts the barrier —
+// both under ONE b.mu hold, so a subscriber can never observe the lifted barrier
+// without also seeing the repaint that was owed to it. Waking is what makes a parked
+// subscriber re-read that state.
+func (b *ptyBroker) releaseRecoveryRepaint(armed []*ptySub, rp []byte) {
 	b.mu.Lock()
-	if len(rp) > 0 {
-		for _, s := range b.subs {
+	for _, s := range armed {
+		if len(rp) > 0 {
 			s.pendingRepaint = rp
 		}
+		s.repaintArmed = false
 	}
 	b.wakeAllLocked()
 	b.mu.Unlock()
+	// wakeAllLocked only rings subscribers still in b.subs. An armed subscriber that
+	// detached mid-recovery is not in the map but can still be parked on the barrier,
+	// so ring its doorbell directly; wake() is a coalescing no-op when already signaled.
+	for _, s := range armed {
+		s.wake()
+	}
 }
 
 // readLoop copies the clientless capture reader into the ring until it errors or
@@ -588,8 +645,13 @@ type ptySub struct {
 	// pendingRepaint is a one-shot initial screen repaint delivered before any
 	// other event to a fresh subscriber (set by subscribe). Read/written under br.mu.
 	pendingRepaint []byte
-	notify         chan struct{}
-	closeOnce      sync.Once
+	// repaintArmed marks this subscriber as held at a recovery boundary: a repaint of
+	// the recovered screen is being captured for it, so NextEvent must emit NOTHING
+	// until it lands (#1975). Set/cleared under br.mu by resetCapture's arm/release
+	// pair, which is the only thing that may set it.
+	repaintArmed bool
+	notify       chan struct{}
+	closeOnce    sync.Once
 }
 
 // wake signals this subscriber's doorbell (coalescing, cap-1). Safe to call
@@ -624,6 +686,20 @@ func (s *ptySub) NextEvent(ctx context.Context) (PTYEvent, error) {
 			s.br.mu.Unlock()
 			return PTYEvent{Kind: PTYRepaint, Data: data}, nil
 		}
+		// A recovery is in flight and this subscriber's repaint of the recovered screen
+		// is still being captured: emit NOTHING until it lands (#1975). Everything this
+		// subscriber could send right now paints the WRONG screen — the dead pane's
+		// buffered tail, the cursor jump the discard is about to make, or the re-spawned
+		// pane's first bytes rendered onto the pre-death frame — and the repaint wipes it
+		// a moment later, which is the flicker. Held, not dropped: nothing is consumed
+		// here, so after the release the repaint goes first and the same cursor/data
+		// events follow it in order.
+		if s.repaintArmed {
+			if err := s.awaitWake(ctx); err != nil {
+				return PTYEvent{}, err
+			}
+			continue
+		}
 		if s.br.hasSize && s.resizeSeen != s.br.resizeGen {
 			s.resizeSeen = s.br.resizeGen
 			ev := PTYEvent{Kind: PTYResize, Rows: s.br.rows, Cols: s.br.cols}
@@ -655,13 +731,22 @@ func (s *ptySub) NextEvent(ctx context.Context) (PTYEvent, error) {
 			s.br.mu.Unlock()
 			return PTYEvent{Kind: PTYData, Data: data}, nil
 		}
-		s.br.mu.Unlock()
-
-		select {
-		case <-ctx.Done():
-			return PTYEvent{}, ctx.Err()
-		case <-s.notify:
+		if err := s.awaitWake(ctx); err != nil {
+			return PTYEvent{}, err
 		}
+	}
+}
+
+// awaitWake RELEASES br.mu (which the caller must hold) and blocks until this
+// subscriber's doorbell rings or ctx ends. NextEvent re-takes the lock and re-reads all
+// state on the next iteration, so the doorbell only has to say "something changed".
+func (s *ptySub) awaitWake(ctx context.Context) error {
+	s.br.mu.Unlock()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-s.notify:
+		return nil
 	}
 }
 

--- a/session/ptybroker_recovery_test.go
+++ b/session/ptybroker_recovery_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -283,6 +284,94 @@ func TestPTYBrokerRecoveryDoesNotReplayStaleBytes(t *testing.T) {
 	// ring or strand A's cursor above head.
 	ch.emit(t, []byte("post-recovery-output"))
 	mustData(t, a, "post-recovery-output")
+}
+
+// TestPTYBrokerRecoveryRepaintPrecedesLiveBytes is #1975: a subscriber that stayed
+// attached across a tmux respawn must see the recovery repaint BEFORE any byte from
+// the re-spawned pane — never a stale/partial frame that the repaint then wipes.
+//
+// The window is `reseedSubscribersLocked`'s Snapshot, which runs WITHOUT b.mu (a real
+// `capture-pane` exec takes milliseconds) AFTER resetCapture has already restarted the
+// capture. The fresh readLoop feeds and wakes subscribers during that window, and
+// pendingRepaint is not set yet, so NextEvent hands back PTYCursor/PTYData first: the
+// client renders live bytes onto its pre-death screen, then the repaint clears and
+// redraws it — the visible flicker. Order delivered was PTYData -> PTYRepaint; the
+// order owed is PTYRepaint -> PTYCursor -> PTYData.
+//
+// Fail-before/pass-after: the snapshotHook drives exactly that interleaving — it emits
+// pane output while the recovery snapshot is still being taken and waits (bounded) for
+// the subscriber to consume it. On the pre-fix ordering the subscriber's cursor moves
+// inside the hook and the first recorded event is PTYData, so the PTYRepaint assert
+// below fails. With the barrier the subscriber stays parked for the whole recovery, the
+// repaint lands first, and the live bytes follow it undropped.
+func TestPTYBrokerRecoveryRepaintPrecedesLiveBytes(t *testing.T) {
+	const live = "LIVE-BYTES-FROM-RESPAWNED-PANE"
+	ch := &fakeClientlessChannel{snapshot: []byte("SCREEN-BEFORE-DEATH")}
+	br := newPTYBroker(ch)
+
+	a, err := br.subscribe(0)
+	if err != nil {
+		t.Fatalf("subscribe A: %v", err)
+	}
+	mustRepaintContains(t, a, "SCREEN-BEFORE-DEATH")
+
+	// A stays attached and parked in NextEvent across the respawn — the common case
+	// (a web/TUI client whose socket never dropped). Record its event stream in order.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	events := make(chan PTYEvent, 8)
+	go func() {
+		for {
+			ev, err := a.NextEvent(ctx)
+			if err != nil {
+				return
+			}
+			events <- ev
+		}
+	}()
+
+	// tmux dies and the daemon re-spawns it. The recovered pane shows a new screen —
+	// and starts producing output while the recovery snapshot is still being captured.
+	ch.mu.Lock()
+	ch.snapshot = []byte("SCREEN-AFTER-RECOVERY")
+	ch.snapshotHook = func() {
+		ch.emit(t, []byte(live))
+		waitRingHead(t, br, Seq(len(live)))
+		// Give the woken subscriber room to deliver those bytes. On the pre-fix
+		// ordering it does so at once (its cursor moves); with the barrier it stays
+		// parked and this simply burns its deadline.
+		deadline := time.Now().Add(300 * time.Millisecond)
+		for time.Now().Before(deadline) && a.Seq() == 0 {
+			time.Sleep(time.Millisecond)
+		}
+	}
+	ch.mu.Unlock()
+
+	br.resetCapture()
+
+	// The repaint is the FIRST thing A sees after recovery. Anything before it is a
+	// frame rendered against the wrong screen that the repaint immediately wipes.
+	select {
+	case ev := <-events:
+		if ev.Kind != PTYRepaint || !strings.Contains(string(ev.Data), "SCREEN-AFTER-RECOVERY") {
+			t.Fatalf("first post-recovery event = Kind=%d Data=%q, want the PTYRepaint of "+
+				"the recovered screen: pane output delivered before the recovery repaint "+
+				"renders a stale frame the repaint then wipes (the flicker)", ev.Kind, ev.Data)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no post-recovery event: A was never re-seeded")
+	}
+
+	// Holding the stream is not dropping it: the bytes the pane produced during the
+	// snapshot window still arrive, after the repaint.
+	select {
+	case ev := <-events:
+		if ev.Kind != PTYData || string(ev.Data) != live {
+			t.Fatalf("event after the repaint = Kind=%d Data=%q, want PTYData %q", ev.Kind, ev.Data, live)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("pane output produced during the recovery snapshot was never delivered")
+	}
 }
 
 // clientCursor models what a REAL client does with the events it receives — the same

--- a/session/ptybroker_test.go
+++ b/session/ptybroker_test.go
@@ -47,6 +47,11 @@ type fakeClientlessChannel struct {
 	// stopDone, when non-nil, is signaled AFTER StopCapture has closed the writer,
 	// so a test can order an assertion strictly after the teardown's effect.
 	stopDone chan struct{}
+	// snapshotHook, when non-nil, runs at the START of each Snapshot with f.mu NOT
+	// held. The real Snapshot is a `tmux capture-pane` exec taking milliseconds, and
+	// the pane keeps producing the whole time; the hook is how a test drives output
+	// into that window (the #1975 recovery-flicker race).
+	snapshotHook func()
 }
 
 func (f *fakeClientlessChannel) StartCapture() (io.ReadCloser, error) {
@@ -96,6 +101,12 @@ func (f *fakeClientlessChannel) Resize(rows, cols uint16) error {
 }
 
 func (f *fakeClientlessChannel) Snapshot() (PaneSnapshot, error) {
+	f.mu.Lock()
+	hook := f.snapshotHook
+	f.mu.Unlock()
+	if hook != nil {
+		hook() // runs WITHOUT f.mu so it can emit() into the live capture pipe
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.snapshots++


### PR DESCRIPTION
Closes #1975.

## The bug

A client that stayed attached across a tmux respawn renders a stale frame that the recovery repaint then wipes — the visible flicker.

`resetCapture` restarts the capture **before** `reseedSubscribersLocked` takes its snapshot, and that `Snapshot()` is a real `capture-pane` exec running **without `b.mu`**. The freshly-started `readLoop` feeds and wakes subscribers for the whole duration of that exec while `pendingRepaint` is still unset, so `NextEvent` hands back `PTYCursor`/`PTYData` first.

Delivered order was `PTYData -> PTYRepaint`. The order owed is `PTYRepaint -> PTYCursor -> PTYData`.

## The fix: a barrier, not a reordering

The issue's suggested fix — advance each subscriber's cursor to `head` when installing the repaint — does not actually close the race. The cursor is only advanced under the *post*-snapshot lock, so a subscriber woken *during* the snapshot still emits ahead of the repaint; it changes what happens afterward, not what happens in the window. It would also silently drop the `#1845` `PTYCursor` announcement, which the client needs to keep its `?since` in sync.

So instead `resetCapture` arms every attached subscriber **up front** — before the teardown, the discard, and the restart — and `NextEvent` emits nothing while armed. `releaseRecoveryRepaint` installs the repaint and lifts the barrier under **one** `b.mu` hold, so a subscriber can never observe the lifted barrier without also seeing the repaint it was owed.

Making recovery atomic *as a subscriber sees it* also closes the two smaller leaks on the same path, which the narrow fix would have left open:

- the dead pane's still-buffered tail, deliverable between `resetCapture` entry and the `#1840` discard;
- the cursor jump the discard is about to make.

**Held, not dropped.** Nothing is consumed under the barrier, so after the release the repaint goes first and the same cursor/data events follow it in order — both halves asserted by the test. The `#1845` `PTYCursor` re-seed still fires, now *after* the repaint, which is exactly the order the issue names as correct.

Armed subscribers are captured **by identity**, not re-read from `b.subs` at release time: one that detaches mid-recovery is gone from the map but may still be parked in `NextEvent`, and it must be released too. The release is `defer`red so a failed restart, a `Snapshot` error, or a no-subscribers-left early return can never strand a subscriber waiting for a repaint that never comes.

## Fail-first

`TestPTYBrokerRecoveryRepaintPrecedesLiveBytes` drives the exact interleaving via a new `snapshotHook` on the fake channel: it emits pane output while the recovery snapshot is being taken, then waits (bounded) for the subscriber to consume it.

Verified against the **unfixed** `ptybroker.go`, 8/8 runs under `-race`, each failing in 0.00s:

```
first post-recovery event = Kind=0 Data="LIVE-BYTES-FROM-RESPAWNED-PANE",
want the PTYRepaint of the recovered screen
```

`Kind=0` is `PTYData` — the stale frame, arriving first. With the fix the repaint leads and the live bytes follow it undropped.

## Adjacent audit

- **`subscribe()`** runs the same `Snapshot`-without-`b.mu` pattern and is registered in `b.subs` before it, so `feed()` can wake it — but the `*ptySub` is not returned to the caller until after `pendingRepaint` is installed, so no pre-repaint delivery is observable. Not vulnerable; gated by construction. Its `cursor = head` (read *before* the snapshot, `#1872`) is preserved.
- **`resize()`** deliberately injects no repaint, so it is not on this path. The barrier does hold a pending resize echo behind the repaint; that converges either way (`buildRepaint` is width-agnostic by design, and the pane's SIGWINCH redraw streams right after), and it keeps the barrier a single simple rule.
- **`localAgentServer.resetBrokerCaptures`** is the only production caller; it fans out to `resetCapture` per tab-broker, so every tab is covered. The remote path shares `ptyBroker` via `remoteClientlessChannel`, so it is covered too.
- **`daemon/ws_pty.go`** (`writePTYStream`) passes the *connection-lifetime* ctx to `NextEvent` with no per-event deadline — a held subscriber is indistinguishable from an idle pane, so the barrier cannot cause a disconnect. The write timeout applies only after an event arrives.
- Lock order is unchanged: `captureMu` then `mu`, never the reverse. `close()` already takes `captureMu`, so it cannot flip `closed` mid-recovery and strand an armed subscriber.

## Verification

- `gofmt -l .`, `go build ./...`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh` — all clean.
- `make test-container` — full suite green, including `daemon` (159s), which hosts the WS pump consuming these events.
- `go test -race ./session/...` green; broker tests stressed at `-count=12` under `-race` with no flakes.
- One `task` failure (`TestWaitForReadyNonAgentBecomesReadyOnAnyOutput`) appeared in a full-parallel host run and did not reproduce at `-p=2` or in the container. It is a 2s wall-clock watchdog with no broker coupling — dev-box contention, not this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)