### PR TITLE
fix(git): force untracked enumeration in kill/archive safety gates (#2101)

### DIFF
--- a/app/handle_actions_test.go
+++ b/app/handle_actions_test.go
@@ -123,6 +123,32 @@ func TestKillConfirmationWarning(t *testing.T) {
 		require.NotContains(t, warning, "Could not verify")
 	})
 
+	// #2101: `git status --porcelain` honours status.showUntrackedFiles, so a user
+	// (or a global/main-repo config inherited by the worktree) that sets it to `no`
+	// hid untracked files from the only safety check standing between D+y and
+	// `git worktree remove -f`. The warning must not depend on user config.
+	t.Run("untracked file with showUntrackedFiles=no still warns", func(t *testing.T) {
+		dir := gitInit(t)
+		cmd := exec.Command("git", "-C", dir, "config", "status.showUntrackedFiles", "no")
+		require.NoError(t, cmd.Run(), "git config failed")
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "untracked.txt"), []byte("data"), 0o644))
+		warning := killConfirmationWarning(dir)
+		require.Contains(t, warning, "uncommitted changes that will be lost",
+			"warning should still be shown despite showUntrackedFiles=no")
+		require.NotContains(t, warning, "Could not verify")
+	})
+
+	// The same hiding vector via the untracked file living in an untracked
+	// subdirectory — the shape `-unormal` collapses to a single `?? dir/` entry.
+	t.Run("untracked subdirectory with showUntrackedFiles=no still warns", func(t *testing.T) {
+		dir := gitInit(t)
+		cmd := exec.Command("git", "-C", dir, "config", "status.showUntrackedFiles", "no")
+		require.NoError(t, cmd.Run(), "git config failed")
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "notes", "deep"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "notes", "deep", "wip.txt"), []byte("data"), 0o644))
+		require.Contains(t, killConfirmationWarning(dir), "uncommitted changes that will be lost")
+	})
+
 	t.Run("status check failure fails closed with could-not-verify warning", func(t *testing.T) {
 		// A plain directory that is not a git repository makes `git status` fail.
 		warning := killConfirmationWarning(t.TempDir())

--- a/app/kill_confirm.go
+++ b/app/kill_confirm.go
@@ -126,8 +126,19 @@ func killConfirmMessage(title, warning string, reserved bool) string {
 // the user gets. If `git status` itself fails we cannot prove the worktree is
 // clean — fail closed and warn that changes may be lost rather than silently
 // skipping the warning (#815).
+//
+// --untracked-files=normal is load-bearing (#2101). Bare `git status --porcelain`
+// honours status.showUntrackedFiles, and a session worktree shares .git/config
+// with its main repo, so a user with that set to `no` (or inheriting it globally)
+// got the bare, safe-looking "[!] Kill session 'x'?" prompt over a worktree full
+// of untracked work — and D+y then fed it to `git worktree remove -f`. Whether
+// the user gets a data-loss warning must not depend on their status preferences.
+// `normal` rather than `all` because this is a boolean: `normal` collapses an
+// untracked directory to a single `?? dir/` entry instead of walking every file
+// under it, which matters on a path that runs synchronously on the Bubble Tea
+// Update loop (#2030).
 func killConfirmationWarning(wt string) string {
-	out, err := runKillGit(wt, "status", "--porcelain")
+	out, err := runKillGit(wt, "status", "--porcelain", "--untracked-files=normal")
 	if err != nil {
 		log.WarningLog.Printf("could not verify worktree status for %s before kill: %v", wt, err)
 		return fmt.Sprintf("WARNING: Could not verify worktree status (%v); it may contain uncommitted changes that will be lost!", err)

--- a/session/git/worktree_push.go
+++ b/session/git/worktree_push.go
@@ -54,7 +54,18 @@ func (g *GitWorktree) SnapshotAndPushBranch() (string, error) {
 	// Snapshot uncommitted work so it survives the sandbox teardown. `git status
 	// --porcelain` is empty for a clean tree, in which case there is nothing to
 	// commit and we push the committed history as-is.
-	status, err := g.runGitCommand(g.worktreePath, "status", "--porcelain")
+	//
+	// --untracked-files=normal is load-bearing (#2101): bare `git status
+	// --porcelain` honours status.showUntrackedFiles, and a worktree shares
+	// .git/config with its main repo, so a user who set that to `no` made this
+	// gate read a tree full of untracked work as clean. The `add -A` below would
+	// have staged those files perfectly well — it simply never ran, and the work
+	// died with the sandbox. The flag overrides the config, so the gate answers
+	// "is there anything to snapshot?" the same way for every user. `normal`
+	// rather than `all` because we only need that boolean: `normal` reports an
+	// untracked directory as one `?? dir/` entry instead of walking every file
+	// beneath it, which is the same answer for less work on a big tree.
+	status, err := g.runGitCommand(g.worktreePath, "status", "--porcelain", "--untracked-files=normal")
 	if err != nil {
 		return "", fmt.Errorf("failed to check worktree status before archive push: %w", err)
 	}

--- a/session/git/worktree_push_test.go
+++ b/session/git/worktree_push_test.go
@@ -99,6 +99,40 @@ func TestSnapshotAndPushBranch_SnapshotsUncommitted(t *testing.T) {
 	assert.Contains(t, files, "dirty.txt", "the uncommitted file should be in the snapshot commit")
 }
 
+// TestSnapshotAndPushBranch_SnapshotsUntrackedWhenConfigHidesThem is the #2101
+// regression, and it is data loss: the archive gate ran `git status --porcelain`,
+// which honours status.showUntrackedFiles. With it set to `no` — set here on the
+// main repo, since a worktree shares .git/config with it, exactly how the setting
+// reaches a session worktree in the wild — the gate read the tree as clean and
+// skipped the `add -A` + commit entirely. `add -A` would have staged the
+// untracked file fine; it simply never ran, so the work was dropped when the
+// sandbox was reaped. The gate must not depend on user config.
+func TestSnapshotAndPushBranch_SnapshotsUntrackedWhenConfigHidesThem(t *testing.T) {
+	sandboxHome(t)
+	gw, bare := pushTestRepo(t, "root/hidden")
+	wt := gw.GetWorktreePath()
+	runGit(t, gw.GetRepoPath(), "config", "status.showUntrackedFiles", "no")
+
+	// Precondition: the un-forced status the old gate used really does read clean.
+	require.Empty(t, strings.TrimSpace(runGitOut(t, wt, "status", "--porcelain")),
+		"precondition: status.showUntrackedFiles=no must hide the untracked file")
+
+	tipBefore := branchTip(t, wt, "HEAD")
+	require.NoError(t, os.WriteFile(filepath.Join(wt, "untracked.txt"), []byte("uncommitted work"), 0644))
+	require.NoError(t, os.MkdirAll(filepath.Join(wt, "notes"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(wt, "notes", "deep.txt"), []byte("nested work"), 0644))
+
+	_, err := gw.SnapshotAndPushBranch()
+	require.NoError(t, err)
+
+	tipAfter := branchTip(t, wt, "HEAD")
+	assert.NotEqual(t, tipBefore, tipAfter, "untracked work must produce a snapshot commit")
+	assert.Equal(t, tipAfter, branchTip(t, bare, "refs/heads/root/hidden"))
+	files := runGitOut(t, wt, "show", "--name-only", "--format=", "HEAD")
+	assert.Contains(t, files, "untracked.txt", "untracked file must survive archive despite showUntrackedFiles=no")
+	assert.Contains(t, files, "notes/deep.txt", "untracked file in an untracked dir must survive too")
+}
+
 // TestSnapshotAndPushBranch_CleanTreeJustPushes pins that a clean tree makes no
 // snapshot commit — it only pushes the existing history.
 func TestSnapshotAndPushBranch_CleanTreeJustPushes(t *testing.T) {


### PR DESCRIPTION
Fixes #2101.

## The bug (verified, data loss)

Both gates that decide whether a worktree holds work worth preserving ran bare
`git status --porcelain`, which honours `status.showUntrackedFiles`. A worktree
shares `.git/config` with its main repo, so a user who sets that to `no` —
locally, globally in `~/.gitconfig`, or in the repo the session was cut from —
made both gates read a tree full of untracked work as **clean**.

**`session/git/worktree_push.go` — `SnapshotAndPushBranch` (the data loss).**
This is the archive-side primitive for the disposable docker/ssh backends, where
the branch on origin *is* the durable workspace. The `add -A` under this gate
would have staged untracked files perfectly well — it simply never ran. No
snapshot commit was made, nothing was pushed, and the work died with the
sandbox. The whole point of snapshot-before-teardown is to not lose work.

**`app/kill_confirm.go` — `killConfirmationWarning`.** The only warning standing
between `D`+`y` and `git worktree remove -f`, which deliberately bypasses git's
own refusal to delete a dirty worktree. The user got the bare, safe-looking
`[!] Kill session 'x'?` over unsaved work — the exact shape of the #815 /
#2022 fail-closed discipline, defeated by a config value.

## Fail-first evidence

Both tests fail on the parent commit (`9c6ae31`):

```
--- FAIL: TestSnapshotAndPushBranch_SnapshotsUntrackedWhenConfigHidesThem
    worktree_push_test.go:129: Should not be: "40f3c565…"
        Messages: untracked work must produce a snapshot commit
    worktree_push_test.go:132: "" does not contain "untracked.txt"
        Messages: untracked file must survive archive despite showUntrackedFiles=no

--- FAIL: TestKillConfirmationWarning/untracked_file_with_showUntrackedFiles=no_still_warns
    handle_actions_test.go:136: "" does not contain "uncommitted changes that will be lost"
--- FAIL: TestKillConfirmationWarning/untracked_subdirectory_with_showUntrackedFiles=no_still_warns
    handle_actions_test.go:149: "" does not contain "uncommitted changes that will be lost"
```

Note the snapshot failure: not a cosmetic missing warning — **no commit was
made at all**, so the untracked file never reached origin.

## The fix

Both call sites now pass `--untracked-files=normal`, which overrides the config.

**Why `normal` and not `all`** (the issue and #2101's report suggest either):
both call sites use the output purely as a boolean — "is there anything to
snapshot / warn about?". `normal` reports an untracked directory as a single
`?? dir/` entry instead of walking every file beneath it, which is the *same
boolean* for strictly less work. That matters on the kill path, which runs
synchronously on the Bubble Tea `Update` loop and already carries a 5s deadline
apparatus for exactly this reason (#2030). `-uall` would make a large untracked
tree (an un-ignored `node_modules`) walk every file to answer a yes/no question.

**Ignored files stay excluded, deliberately.** `add -A` skips them too, so
forcing them into the gate would only desync the gate from what the snapshot can
actually commit — and would balloon snapshots with build output. The intended
snapshot is preserved; `.git` internals and ignored cruft stay out.

## Verification beyond the unit tests

Probed against real git using the **global** `~/.gitconfig` vector (the tests use
repo-local, so this covers the propagation path the report describes):

```
--- bare (what the code USED to run) ---
              <-- empty: worktree reads clean, work is lost
--- with --untracked-files=normal (the fix) ---
?? notes/
?? untracked.txt
--- does add -A stage what normal reports? ---
A  notes/deep.txt
A  untracked.txt
--- is the ignored file correctly EXCLUDED from the snapshot? ---
notes/deep.txt
untracked.txt          <-- junk.log (gitignored) correctly absent
```

This also confirms there is no gate/stage mismatch: everything `normal` reports,
`add -A` stages, so the fix cannot newly trigger a "nothing to commit" failure.

## Audit of adjacent sites

- These are the **only two `git status` call sites in production** repo-wide
  (verb census over every git invocation: 2× `status`, 4× `add` of which 3 are
  `worktree add`). Both are fixed here.
- The **local** archive path (`session/git/worktree_archive.go`) moves or copies
  the worktree with `filepath.Walk` / `os.Rename` and never consults git, so it
  preserves untracked files by construction and is unaffected.
- No `git ls-files`, `git diff`, `git stash`, or `git clean` in production code —
  no other enumeration that git config could fool.

## Gate

`gofmt -l .` clean · `go build ./...` · `golangci-lint run --timeout=3m --fast`
clean · `deadcode -test ./...` clean · `scripts/lint-file-length.sh` passed ·
full suite via `make test-container`.

Co-Authored-By: Captain Claude <noreply@anthropic.com>
