### PR TITLE
fix(proctree): treat a zombie as exited, not as a process still running (#2103)

### DIFF
--- a/internal/proctree/proctree.go
+++ b/internal/proctree/proctree.go
@@ -50,6 +50,23 @@ import (
 // never treat it as an empty result. Test with errors.Is.
 var ErrUnsupportedPlatform = errors.New("proctree: reading the process table is not supported on this platform")
 
+// ErrProcessExited is returned by the per-pid backend read when the PID names a
+// process that has already exited but whose parent has not yet collected its
+// exit status — a zombie on Linux, SZOMB on darwin.
+//
+// It is a POSITIVE finding, not a read failure, and that distinction is the
+// whole of #2103. Every existence-shaped check still finds a zombie: it keeps
+// its /proc entry, kill(pid, 0) succeeds, and a signal aimed at it is accepted
+// and does nothing. So a liveness check built on existence called corpses
+// "running", and the reapers waited out their entire budget — 3s per worktree
+// teardown, 6s per tmux one — for processes that had already exited, then
+// logged "survived SIGKILL" about them.
+//
+// Backends must report this rather than a generic error so the difference
+// between "it is gone" and "I could not look" stays legible; this package's
+// standing rule is that those two must never collapse into each other.
+var ErrProcessExited = errors.New("proctree: process has exited and is awaiting collection by its parent")
+
 // Process identifies one live process at snapshot time.
 type Process struct {
 	PID  int
@@ -145,6 +162,13 @@ func SessionMembers(snap map[int]Process, sid int) []Process {
 
 // AliveSame reports whether the same process instance (matching PID and start
 // identifier) is still running.
+//
+// RUNNING, not merely present in the process table: a zombie is neither, and
+// the backend reports it as ErrProcessExited (see #2103). Anything that cannot
+// be read is also reported as not-alive here — this is the one place where that
+// collapse is the safe direction, because every caller of AliveSame is deciding
+// whether to keep WAITING, and waiting forever on a process we cannot see is
+// worse than stopping early on one that is somehow still there.
 func AliveSame(p Process) bool {
 	cur, err := readProc(p.PID)
 	if err != nil {

--- a/internal/proctree/proctree_darwin.go
+++ b/internal/proctree/proctree_darwin.go
@@ -65,12 +65,24 @@ func snapshot() (map[int]Process, error) {
 	return procs, nil
 }
 
+// szomb is SZOMB from <sys/proc.h>: the p_stat of a process that has exited
+// and is waiting for its parent to collect it. x/sys/unix exposes the P_stat
+// field but not the state constants, so the value is spelled out here.
+const szomb = 5
+
 // readProc reads one process's kinfo_proc. Returns an error when the pid names
 // no live process, which is what makes it usable as an identity check.
 func readProc(pid int) (Process, error) {
 	kp, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
 	if err != nil {
 		return Process{}, err
+	}
+	// kern.proc.pid answers for zombies too, with ppid, session and start time
+	// all intact — so without this the identity check matches a process that
+	// has already exited. Same defect as the Linux state field, same fix
+	// (#2103); see ErrProcessExited.
+	if kp.Proc.P_stat == szomb {
+		return Process{}, ErrProcessExited
 	}
 	p, ok := processFromKinfo(kp)
 	if !ok {
@@ -79,10 +91,12 @@ func readProc(pid int) (Process, error) {
 	return p, nil
 }
 
-// processFromKinfo converts one kinfo_proc into a Process.
+// processFromKinfo converts one kinfo_proc into a Process. Zombies are refused
+// for the reason readProc gives: they are exited processes that every
+// existence-shaped check still finds.
 func processFromKinfo(kp *unix.KinfoProc) (Process, bool) {
 	pid := int(kp.Proc.P_pid)
-	if pid <= 0 {
+	if pid <= 0 || kp.Proc.P_stat == szomb {
 		return Process{}, false
 	}
 	// P_starttime is wall-clock (a timeval), unlike Linux's ticks-since-boot,

--- a/internal/proctree/proctree_linux.go
+++ b/internal/proctree/proctree_linux.go
@@ -56,7 +56,12 @@ func snapshot() (map[int]Process, error) {
 		}
 		p, err := readProc(pid)
 		if err != nil {
-			// Process exited between ReadDir and the stat read; skip.
+			// Exited between ReadDir and the stat read, or exited already and
+			// is waiting to be collected (ErrProcessExited). A zombie has no
+			// children of its own — the kernel reparents them when a process
+			// exits, not when it is collected — so dropping it here loses no
+			// descendant, and keeping it would only hand the reapers a corpse
+			// to kill and then wait for. Skip.
 			continue
 		}
 		if bootErr == nil {
@@ -92,6 +97,12 @@ func bootTime() (time.Time, error) {
 // readProc parses /proc/<pid>/stat. Format: `pid (comm) state ppid ...`.
 // Comm may itself contain spaces and ')' — the parse anchors on the LAST ')'.
 //
+// A zombie is reported as ErrProcessExited rather than returned as a Process
+// (#2103). The state field is the ONLY thing that distinguishes a corpse here:
+// a zombie keeps its stat entry, its ppid, its session id and — the part that
+// defeated the identity check — its unchanging start time, so PID+StartID match
+// perfectly for a process that has already exited.
+//
 // StartedAt is deliberately left zero here: it needs boot time, which is a
 // per-snapshot fact rather than a per-process one. snapshot() fills it in.
 func readProc(pid int) (Process, error) {
@@ -114,6 +125,12 @@ func readProc(pid int) (Process, error) {
 	)
 	if len(fields) <= idxStart {
 		return Process{}, fmt.Errorf("truncated stat for pid %d", pid)
+	}
+	// Z is the zombie state; X/x is EXIT_DEAD, the sliver between the two halves
+	// of teardown. Neither will ever run again or answer a signal.
+	switch fields[0] {
+	case "Z", "X", "x":
+		return Process{}, ErrProcessExited
 	}
 	ppid, err := strconv.Atoi(fields[idxPPID])
 	if err != nil {

--- a/internal/proctree/zombie_darwin_test.go
+++ b/internal/proctree/zombie_darwin_test.go
@@ -1,0 +1,20 @@
+//go:build darwin
+
+package proctree
+
+import "golang.org/x/sys/unix"
+
+// observedZombie reports whether pid is in state SZOMB, read straight from
+// kinfo_proc rather than through any proctree helper: these tests must observe
+// the zombie independently of the code under test.
+//
+// The sysctl answering AT ALL for an exited process is the darwin half of
+// #2103 — kern.proc.pid returns a full entry for a corpse, which is exactly
+// what made the identity check match one.
+func observedZombie(pid int) bool {
+	kp, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
+	if err != nil {
+		return false
+	}
+	return kp.Proc.P_stat == szomb
+}

--- a/internal/proctree/zombie_linux_test.go
+++ b/internal/proctree/zombie_linux_test.go
@@ -1,0 +1,27 @@
+//go:build linux
+
+package proctree
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+)
+
+// observedZombie reports whether pid is in state Z, read straight from
+// /proc/<pid>/stat rather than through any proctree helper: these tests must
+// observe the zombie independently of the code under test.
+//
+// Format: `pid (comm) state ...`, and comm may itself contain spaces and ')',
+// so the parse anchors on the LAST ')' — same reason readProc does.
+func observedZombie(pid int) bool {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return false
+	}
+	close_ := bytes.LastIndexByte(data, ')')
+	if close_ < 0 || close_+2 >= len(data) {
+		return false
+	}
+	return data[close_+2] == 'Z'
+}

--- a/internal/proctree/zombie_test.go
+++ b/internal/proctree/zombie_test.go
@@ -1,0 +1,157 @@
+package proctree
+
+import (
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// The subject of this file is #2103: a zombie (a process that has exited but
+// whose parent has not collected its exit status) keeps its process-table
+// entry, so every EXISTENCE check still finds it. proctree's liveness check
+// was an existence check, so the reapers waited out their full budget for
+// processes that had already exited.
+//
+// observedZombie is deliberately NOT the production check — it reads the
+// kernel's state field directly, per platform (see the _linux/_darwin siblings),
+// so these tests observe the zombie independently of the code they are testing.
+
+// startZombie spawns a child, kills it, and deliberately does NOT reap it, so
+// the kernel keeps its entry as a zombie for the rest of the test.
+//
+// The not-reaping is the whole point, and it has to be a REAL child: only a
+// direct child of this process can be our zombie, and only an uncollected one
+// stays in the table. A test that Wait()ed the child would prove nothing — the
+// entry would be gone and every check would agree it was gone.
+func startZombie(t *testing.T) Process {
+	t.Helper()
+	cmd := exec.Command("sleep", "300")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting child: %v", err)
+	}
+	pid := cmd.Process.Pid
+	// Collect it only at the very end, so the zombie does not outlive the test.
+	t.Cleanup(func() { _, _ = cmd.Process.Wait() })
+
+	snap, err := Snapshot()
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	p, ok := snap[pid]
+	if !ok {
+		t.Fatalf("child %d missing from snapshot", pid)
+	}
+
+	if err := cmd.Process.Kill(); err != nil {
+		t.Fatalf("killing child: %v", err)
+	}
+	// The kill is asynchronous: wait for the kernel to actually park the entry
+	// in the zombie state before handing it to the code under test.
+	deadline := time.Now().Add(2 * time.Second)
+	for !observedZombie(pid) {
+		if time.Now().After(deadline) {
+			t.Fatalf("child %d never became a zombie", pid)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return p
+}
+
+// TestAliveSameZombie: a zombie has exited. It will never run again and it
+// cannot be signalled into exiting — the only thing left of it is a table entry
+// its parent has not collected. The liveness check must call it dead (#2103).
+func TestAliveSameZombie(t *testing.T) {
+	p := startZombie(t)
+	if AliveSame(p) {
+		t.Errorf("AliveSame(zombie pid %d) = true, want false: an exited process is not alive", p.PID)
+	}
+}
+
+// TestWaitForExitsZombie is the user-visible half of #2103: because AliveSame
+// counted zombies as alive, WaitForExits burned its ENTIRE budget waiting for a
+// process that had already exited — 3s per worktree teardown, 6s per tmux one —
+// and then KillEscalating logged "survived SIGKILL" about a corpse.
+//
+// The assertion is on elapsed time, not just on the result: the result alone
+// cannot tell a prompt correct answer from a timed-out one.
+func TestWaitForExitsZombie(t *testing.T) {
+	p := startZombie(t)
+
+	const timeout = 2 * time.Second
+	start := time.Now()
+	remaining := WaitForExits([]Process{p}, timeout)
+	elapsed := time.Since(start)
+
+	if len(remaining) != 0 {
+		t.Errorf("WaitForExits reported %d survivor(s) for a zombie, want 0", len(remaining))
+	}
+	// A poll interval of slack; the bug spends the full timeout.
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("WaitForExits took %v for an already-exited process (timeout %v); it must return promptly", elapsed, timeout)
+	}
+}
+
+// TestSignalZombie: the kernel accepts a signal aimed at a zombie, so a caller
+// that reads "delivered" as "it will now exit" waits for an exit that already
+// happened. Signal must report the identity as gone instead — which is what
+// KillEscalating already treats as success rather than a warnable failure.
+func TestSignalZombie(t *testing.T) {
+	p := startZombie(t)
+	if err := Signal(p, syscall.SIGKILL); err != ErrIdentityChanged {
+		t.Errorf("Signal(zombie) = %v, want ErrIdentityChanged", err)
+	}
+}
+
+// TestSnapshotOmitsZombie covers how corpses got INTO the reapers' target sets
+// in the first place. The tmux reaper selects by kernel session id
+// (SessionMembers, session/tmux/reap.go) and a zombie keeps its session id — so
+// before #2103 a corpse was picked as a kill target, signalled, and then waited
+// on for the full budget.
+//
+// Dropping it from the table loses no descendant: the kernel reparents a
+// process's children when it EXITS, not when it is collected, so a zombie never
+// has any.
+func TestSnapshotOmitsZombie(t *testing.T) {
+	p := startZombie(t)
+
+	snap, err := Snapshot()
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if _, ok := snap[p.PID]; ok {
+		t.Errorf("Snapshot included zombie pid %d; reapers select kill targets from this table", p.PID)
+	}
+	if got := SessionMembers(snap, p.SID); len(got) != 0 {
+		for _, m := range got {
+			if m.PID == p.PID {
+				t.Errorf("SessionMembers selected zombie pid %d as a reap target", p.PID)
+			}
+		}
+	}
+}
+
+// TestKillEscalatingNoWarnOnZombie is the log half of #2103: a corpse must not
+// be reported as a process that "survived SIGKILL". That line sends whoever
+// reads it hunting for an unkillable process that does not exist.
+func TestKillEscalatingNoWarnOnZombie(t *testing.T) {
+	p := startZombie(t)
+
+	var lines []string
+	logf := func(format string, args ...any) {
+		lines = append(lines, format)
+	}
+	start := time.Now()
+	remaining := KillEscalating([]Process{p}, 2*time.Second, 2*time.Second, logf)
+	elapsed := time.Since(start)
+
+	if len(remaining) != 0 {
+		t.Errorf("KillEscalating reported %d survivor(s) for a zombie, want 0", len(remaining))
+	}
+	if len(lines) != 0 {
+		t.Errorf("KillEscalating logged %d line(s) about an already-exited process: %v", len(lines), lines)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("KillEscalating took %v for an already-exited process; it must return promptly", elapsed)
+	}
+}


### PR DESCRIPTION
Fixes #2103.

## The bug is real — verified before fixing

`proctree`'s liveness check was an **existence** check. A zombie — a process that
has exited but whose parent has not collected its exit status — keeps its entire
process-table entry: its `/proc/<pid>/stat`, its ppid, its session id, and its
**start time**. So `PID + StartID` matched perfectly for a process that was
already dead, and `AliveSame` called corpses alive.

`readProc` was already parsing the state field's position and simply never
consulting it — the comment on line 109 even points at it (`fields[0] is stat
field 3 (state)`).

Fail-first evidence, on the parent commit (all five tests fail):

```
TestAliveSameZombie          AliveSame(zombie pid N) = true
TestWaitForExitsZombie       took 2.009s of a 2s budget, reported 1 survivor
TestSignalZombie             Signal(zombie) = <nil>, want ErrIdentityChanged
TestSnapshotOmitsZombie      Snapshot included the zombie; SessionMembers selected it
TestKillEscalatingNoWarnOnZombie  5.025s + 3 log lines, ending "survived SIGKILL"
```

All five pass with the fix. `KillEscalating` on one zombie: **5.04s → 0.01s**.

## What this cost users

`WaitForExits` polls `AliveSame`, so it burned its **entire** budget waiting for
an exit that had already happened — 3s per worktree teardown, 6s per tmux one.
`KillEscalating` then signalled the corpse (the kernel accepts the signal and
does nothing), waited again, and logged

```
leaked process 12345 (sleep) survived SIGKILL
```

which sends whoever reads it hunting for an unkillable process that does not
exist.

**Corpses were also being *selected* as kill targets, not merely waited on** —
this part is not in the issue, and I found it tracing the callers. The tmux
reaper picks targets with `SessionMembers` (`session/tmux/reap.go:103`), and a
zombie keeps its session id, so it came straight back out of `Snapshot` in the
target set. That is what `TestSnapshotOmitsZombie` locks down.

## The fix

`readProc` reports a zombie as **`ErrProcessExited`**, a distinct sentinel rather
than a generic error. That distinction is deliberate and matches this package's
standing rule: *"it is gone"* and *"I could not look"* must never collapse into
each other. `X`/`x` (EXIT_DEAD) is treated the same — neither state will ever run
again or answer a signal.

`snapshot()` skips them, which is also why this loses nothing: the kernel
reparents a process's children when it **exits**, not when it is collected, so a
zombie never has descendants to walk to.

The race called out in the issue — the process being collected between the check
and the read — was already safe and stays safe: the read fails, and every caller
reads a failed read as gone.

## Darwin

**The same defect existed there**, so I fixed it rather than only noting it:
`kern.proc.pid` answers for zombies too, with ppid, session and start time all
intact, and nothing checked `P_stat`. A check that only holds on Linux is exactly
how this package got its last platform bug (#1931), so it is symmetric here
(`SZOMB`, spelled out because `x/sys/unix` exposes the field but not the state
constants).

**Caveat worth your attention:** the darwin half is vet-clean under
`GOOS=darwin go vet` and its test binary cross-compiles, but I cannot execute it
on this box. That part rests on inspection, not observation. The Linux half is
fully observed.

## Test design

The tests build a **real** zombie: a child that is killed and deliberately never
collected (`Wait()` is deferred to `t.Cleanup`, so the corpse does not outlive
the test). They observe the zombie state through the kernel **directly** — a
per-platform `observedZombie` helper in `zombie_linux_test.go` /
`zombie_darwin_test.go` — rather than through the code under test, so they cannot
pass by merely agreeing with the fix.

The timing assertions are on elapsed wall-clock, because the returned survivor
list alone cannot distinguish a prompt correct answer from a timed-out one.

## Verification

- `go test -race ./internal/proctree/...` — pass
- `make test-container` (full suite) — **all green, exit 0**, including `doctor`,
  `session/tmux`, `session/git` and `daemon`, the packages that read the process
  table this change filters
- `gofmt -l .`, `go build ./...`, `golangci-lint run --fast`, `deadcode -test ./...`,
  `scripts/lint-file-length.sh` — all clean
- `GOOS=darwin go vet ./internal/proctree/...` — clean

## Follow-up, not in this PR

`daemon/sigterm_fallback.go` has its own zombie detection (the empty-`cmdline`
heuristic the issue cites as precedent). It is out of this PR's file scope and
untouched, but it is now a hand-rolled duplicate of a correct in-tree mechanism.
Worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
