### PR TITLE
fix(daemon): stop the archived-name-reuse recovery branch self-deadlocking m.mu (#2106)

### DIFF
--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -426,6 +426,10 @@ func (m *Manager) archiveExclusiveTabLock(key string, instance *session.Instance
 // refreshInstanceStatus's persist, and returns any write error. persistInstance
 // wraps it for the best-effort callers; the archive commit uses this variant to
 // make the persist durable (#1538).
+//
+// LOCK CONTRACT (#2106): it goes through startLockForRepo, which takes m.mu, so
+// it must NEVER be called with m.mu held — see startLockForRepo. Under m.mu, call
+// persistInstanceData directly instead.
 func (m *Manager) persistInstanceErr(repoID string, instance *session.Instance) error {
 	repoStartLock := m.startLockForRepo(repoID)
 	repoStartLock.Lock()
@@ -436,6 +440,9 @@ func (m *Manager) persistInstanceErr(repoID string, instance *session.Instance) 
 // persistInstance is the best-effort form of persistInstanceErr: a failed write
 // only logs. Used everywhere the persist is a checkpoint that the next poll/tick
 // will re-attempt, never where the write's durability gates correctness.
+//
+// LOCK CONTRACT (#2106): inherits persistInstanceErr's — never call it with m.mu
+// held. Under m.mu, call persistInstanceData directly.
 func (m *Manager) persistInstance(repoID string, instance *session.Instance) {
 	if err := m.persistInstanceErr(repoID, instance); err != nil {
 		log.WarningLog.Printf("failed to persist instance %q: %v", instance.Title, err)

--- a/daemon/deadlock_2106_test.go
+++ b/daemon/deadlock_2106_test.go
@@ -1,0 +1,144 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/session"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReserveCreate_ReusesArchivedName_DoubleFailureNoSelfDeadlock is the #2106
+// regression.
+//
+// reserveCreate holds m.mu across its whole body and calls
+// renameArchivedForReuseLocked under it. That function's double-failure recovery
+// branch — the durable title rewrite fails AND the worktree rollback that should
+// undo it also fails — used to call m.persistInstance, which reaches
+// persistInstanceErr -> startLockForRepo -> m.mu.Lock(). Go's sync.Mutex is not
+// reentrant, so the goroutine blocked on the manager lock it was already holding:
+// the create never returned and every other daemon operation waiting on m.mu
+// stalled behind it. A total daemon hang needing a process restart.
+//
+// Both failures are forced deterministically through the reuseArchivedRenamePersist
+// seam, which fires in exactly the window between the two worktree moves:
+//
+//  1. the real first move has already relocated the archived worktree
+//     origDest -> newDest, vacating origDest;
+//  2. the seam re-occupies origDest and returns an error, so the durable rewrite
+//     "fails";
+//  3. the rollback move newDest -> origDest then fails on relocateWorktreeTo's
+//     "destination already exists" guard (a plain stat, not a permission trick,
+//     so it behaves identically for root and in a container).
+//
+// That lands the create on the recovery branch on the real production path
+// (reserveCreate -> renameArchivedForReuseLocked), which is the point: calling the
+// locking helper under m.mu in isolation would only re-prove that Go mutexes are
+// not reentrant, not that this code path reaches it.
+//
+// The exercised call runs in a goroutine behind a select/timeout so a pre-fix run
+// FAILS with a clear message instead of hanging the suite until the test binary
+// panics.
+func TestReserveCreate_ReusesArchivedName_DoubleFailureNoSelfDeadlock(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	archived, _ := seedArchivedSession(t, manager, repoID, repoPath, "foo", "foo")
+
+	// Where the archived worktree lives before the rename; the rollback move
+	// targets exactly this path.
+	origDest, err := archivedWorktreePath(repoID, "foo")
+	require.NoError(t, err)
+	newDest, err := archivedWorktreePath(repoID, "foo (archived)")
+	require.NoError(t, err)
+	require.True(t, exists(origDest), "the seeded archived worktree must start at the pre-rename path")
+
+	errForcedPersist := fmt.Errorf("forced durable-rename failure (#2106 repro)")
+	seamFired := false
+	blockerPlanted := false
+	prev := reuseArchivedRenamePersist
+	reuseArchivedRenamePersist = func(rid, oldTitle string, newData session.InstanceData) error {
+		seamFired = true
+		// The first move has vacated origDest by now; re-occupying it is what makes
+		// the rollback's dest-already-exists guard trip.
+		if mkErr := os.MkdirAll(origDest, 0o755); mkErr == nil {
+			blockerPlanted = true
+		}
+		return errForcedPersist
+	}
+	t.Cleanup(func() { reuseArchivedRenamePersist = prev })
+
+	type outcome struct {
+		err     error
+		release func()
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		_, _, release, _, rerr := manager.reserveCreate(CreateSessionRequest{
+			RepoPath: repoPath,
+			Title:    "foo",
+			Program:  "claude",
+		})
+		done <- outcome{err: rerr, release: release}
+	}()
+
+	var got outcome
+	select {
+	case got = <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("deadlock (#2106): reserveCreate never returned — the archived-name-reuse " +
+			"double-failure recovery branch persists while holding m.mu, and persistInstance " +
+			"re-acquires m.mu via startLockForRepo (sync.Mutex is not reentrant), hanging the daemon")
+	}
+	if got.release != nil {
+		got.release()
+	}
+
+	// The harness must actually have produced the double failure; a repro that
+	// silently stopped reaching the branch would pass for the wrong reason.
+	require.True(t, seamFired, "the durable-rename seam never fired; the repro did not reach the rename path")
+	require.True(t, blockerPlanted, "could not re-occupy the pre-rename archive path; the rollback would not have failed")
+	require.True(t, exists(newDest), "the archived worktree must still be at the post-rename path — the rollback was forced to fail")
+
+	// The create aborts, surfacing BOTH failures so the operator can recover the
+	// archive by hand.
+	require.Error(t, got.err, "the create must abort when the rename can neither be persisted nor rolled back")
+	assert.ErrorIs(t, got.err, errForcedPersist, "the persist failure must be wrapped, not swallowed")
+	assert.Contains(t, got.err.Error(), "may need manual recovery",
+		"the error must tell the operator the archive was left needing recovery")
+
+	// The archived row stays re-keyed under its new title: the bytes live at
+	// newDest, so the manager map must agree with the filesystem.
+	assert.Equal(t, "foo (archived)", archived.Title)
+	manager.mu.Lock()
+	_, oldKeyed := manager.instances[daemonInstanceKey(repoID, "foo")]
+	_, newKeyed := manager.instances[daemonInstanceKey(repoID, "foo (archived)")]
+	manager.mu.Unlock()
+	assert.False(t, oldKeyed, "the archived row must not remain keyed under the un-freed name")
+	assert.True(t, newKeyed, "the archived row must stay addressable under the name its worktree now uses")
+
+	// m.mu must be usable afterwards. reserveCreate takes and releases it, so a
+	// second create completing at all is the direct proof the manager lock was not
+	// left wedged by the recovery branch.
+	second := make(chan error, 1)
+	go func() {
+		_, _, release, _, rerr := manager.reserveCreate(CreateSessionRequest{
+			RepoPath:  repoPath,
+			TitleBase: "after-recovery",
+			Program:   "claude",
+		})
+		if release != nil {
+			release()
+		}
+		second <- rerr
+	}()
+	select {
+	case rerr := <-second:
+		assert.NoError(t, rerr, "a create after the recovery branch must still succeed")
+	case <-time.After(30 * time.Second):
+		t.Fatal("deadlock (#2106): the manager lock was left held by the double-failure recovery branch — " +
+			"a subsequent create can never acquire m.mu")
+	}
+}

--- a/daemon/manager.go
+++ b/daemon/manager.go
@@ -337,6 +337,20 @@ func (m *Manager) refreshLocked() error {
 	return nil
 }
 
+// startLockForRepo returns the per-repo lock serializing session/tab creation
+// against other mutations of that repo, lazily creating it.
+//
+// LOCK CONTRACT (#2106): it takes m.mu, so it must NEVER be called with m.mu
+// already held — sync.Mutex is not reentrant and the goroutine would deadlock on
+// the manager lock, stalling every other operation behind it. That rules out
+// calling it, m.persistInstance, or m.persistInstanceErr from any `...Locked`
+// helper or other code running under m.mu; persist from there with the lock-free
+// persistInstanceData instead, which takes only the instances.json file lock.
+//
+// Acquiring the returned lock while holding m.mu is likewise forbidden: the
+// established order is repoStartLock BEFORE m.mu (CreateSession holds the start
+// lock across its body and takes m.mu under it), so the reverse closes an ABBA
+// cycle — the #2006 lock-inversion class.
 func (m *Manager) startLockForRepo(repoID string) *sync.Mutex {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -264,6 +264,14 @@ func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, 
 	return repo, title, release, renamedArchived, nil
 }
 
+// reuseArchivedRenamePersist is the durable title rewrite the archived-name-reuse
+// rename runs. A package var so tests can force that write to fail in isolation —
+// exercising the rollback, and the double-failure recovery branch behind it
+// (#2106) — without disturbing any other persist. Mirrors archivePersist's and
+// killTombstonePersist's precedent. Production points it at the real writer and
+// never reassigns it.
+var reuseArchivedRenamePersist = renameInstanceDataTitle
+
 // renameArchivedForReuseLocked frees `title` for a new session when the ONLY thing
 // holding it is an archived session, by renaming that archived session to a
 // disambiguated "<title> (archived[ N])" (feat: reuse archived name). It returns
@@ -310,12 +318,39 @@ func (m *Manager) renameArchivedForReuseLocked(repoID, repoPath, title, program 
 	// #1538): otherwise the on-disk record would point at the pre-rename path that no
 	// longer exists, stranding the archive after a daemon restart.
 	renamed := archived.ToInstanceData()
-	if perr := renameInstanceDataTitle(repoID, oldTitle, renamed); perr != nil {
+	if perr := reuseArchivedRenamePersist(repoID, oldTitle, renamed); perr != nil {
 		if rbErr := archived.RenameArchived(oldTitle, origDest); rbErr != nil {
 			// Could not move the worktree home: leave it re-keyed under the new title
 			// (the bytes live at newDest) and surface both failures so the operator can
 			// recover it. The new session create aborts.
-			m.persistInstance(repoID, archived)
+			//
+			// persistInstanceData DIRECTLY, never m.persistInstance (#2106): we are on
+			// reserveCreate's stack, which holds m.mu across this whole call, and
+			// m.persistInstance -> persistInstanceErr -> startLockForRepo takes m.mu
+			// again. sync.Mutex is not reentrant, so that self-deadlocked the goroutine
+			// on the manager lock and hung every other daemon operation behind it.
+			//
+			// Do NOT "fix" this by grabbing the repo start lock without m.mu either.
+			// CreateSession holds repoStartLock across its body and takes m.mu under it
+			// (the appendInstanceData critical section), so repoStartLock->m.mu is the
+			// established order; adding m.mu->repoStartLock here would close an ABBA
+			// cycle — the #2006 lock-inversion class, traded for the self-deadlock.
+			// Nothing is lost by skipping it: the per-repo start lock serializes
+			// spawn-then-persist sequences, while what actually serializes writers to
+			// instances.json is the file lock inside config.UpdateRepoInstances, which
+			// persistInstanceData takes on its own. CreateTab/CloseTab/SetPRInfo already
+			// persist through this same lock-free primitive.
+			//
+			// Best-effort by design: this is a recovery breadcrumb on an already-failing
+			// path, so a write failure is logged rather than returned — the operator
+			// error below is the real report. It commonly WILL fail with "not found in
+			// storage", because the durable rewrite that just failed is what would have
+			// moved the on-disk row to the new title; that is pre-existing behavior this
+			// fix deliberately does not change, and the returned error covers it.
+			if wErr := persistInstanceData(repoID, archived.ToInstanceData()); wErr != nil {
+				log.WarningLog.Printf("archived session %q was renamed to %q but could not be persisted or rolled back; recording its new identity also failed: %v",
+					oldTitle, archived.Title, wErr)
+			}
 			return nil, fmt.Errorf("failed to durably rename archived session %q and could not roll it back (%v); it may need manual recovery: %w", oldTitle, rbErr, perr)
 		}
 		delete(m.instances, newKey)

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -338,8 +338,15 @@ func (m *Manager) renameArchivedForReuseLocked(repoID, repoPath, title, program 
 			// Nothing is lost by skipping it: the per-repo start lock serializes
 			// spawn-then-persist sequences, while what actually serializes writers to
 			// instances.json is the file lock inside config.UpdateRepoInstances, which
-			// persistInstanceData takes on its own. CreateTab/CloseTab/SetPRInfo already
-			// persist through this same lock-free primitive.
+			// persistInstanceData takes on its own.
+			//
+			// This is the one site that calls persistInstanceData bare while holding
+			// m.mu; the other callers reach it with m.mu NOT held (CreateTab and
+			// SetPRInfo under the repo start lock, CloseTab under only its per-session
+			// op lock), so do not read them as precedent for the call shape here. What
+			// makes it safe is a property of the primitive rather than of any wrapper:
+			// persistInstanceData never re-enters m.mu, which is exactly where the old
+			// persistInstance -> persistInstanceErr -> startLockForRepo path went wrong.
 			//
 			// Best-effort by design: this is a recovery breadcrumb on an already-failing
 			// path, so a write failure is logged rather than returned — the operator


### PR DESCRIPTION
Fixes #2106.

The daemon self-deadlocks — hangs forever, needing a process restart — on the
"reuse an archived session name" path, in the recovery branch that runs when
freeing the name fails in both directions.

## The deadlock chain

`reserveCreate` holds the manager lock across its entire body and calls
`renameArchivedForReuseLocked` under it:

```
daemon/manager_create.go:158   reserveCreate: m.mu.Lock(); defer m.mu.Unlock()
daemon/manager_create.go:219   -> m.renameArchivedForReuseLocked(...)     [m.mu HELD]
daemon/manager_create.go:326   -> m.persistInstance(repoID, archived)     [m.mu STILL HELD]
daemon/archive.go:440          -> m.persistInstanceErr(...)
daemon/archive.go:430          -> m.startLockForRepo(repoID)
daemon/manager.go:340          -> m.mu.Lock()                            <-- blocks forever
```

Go's `sync.Mutex` is not reentrant, so the goroutine blocks on the mutex it is
already holding. Because `m.mu` is *the* manager lock, everything else waiting
on it stalls behind the wedged create: a total daemon hang.

Reaching it needs a double failure inside `renameArchivedForReuseLocked` — the
durable title rewrite `renameInstanceDataTitle` fails **and** the worktree
rollback `archived.RenameArchived` also fails — which is why it survived
review since #1719. It is not unreachable, though: both are ordinary I/O
against `instances.json` and the archive dir.

## The fix

Persist directly through the lock-free `persistInstanceData` instead of
`m.persistInstance`, and log (not swallow) a write failure.

### Why lock-free is correct, and why keeping the start lock would have been an ABBA

The obvious alternative — keep the per-repo start lock but acquire it without
re-taking `m.mu` (a `startLockForRepoLocked` helper) — trades a self-deadlock
for a lock inversion. **I verified the existing ordering rather than assuming
it**, and it holds:

`CreateSession` (`daemon/manager_create.go`) acquires them in the order
**repoStartLock → m.mu**:

- line 44: `m.reserveCreate(req)` — takes and *releases* `m.mu` internally
- line 60: `repoStartLock.Lock()`, held via `defer` across the rest of the function
- line 125: `m.mu.Lock()` inside the `appendInstanceData` critical section —
  acquired **while `repoStartLock` is held**

So `repoStartLock → m.mu` is established in production today. Introducing
`m.mu → repoStartLock` at the recovery branch would close the cycle:

| goroutine | holds | blocks on |
|---|---|---|
| A: `CreateSession` (repo R) | `repoStartLock(R)` (line 60) | `m.mu` (line 125) |
| B: `reserveCreate` (repo R), recovery branch | `m.mu` (line 158) | `repoStartLock(R)` |

That is exactly the #2006 class this repo was already bitten by, where the
canonical rule is target-before-op and an op-first path ABBA'd the daemon.
So the issue's own recommendation is the right one.

Nothing is lost by skipping the start lock. What actually serializes writers to
`instances.json` is the **file lock** — `persistInstanceData` →
`config.UpdateRepoInstances` → `config.WithFileLockTimeout` (`config/state.go:375`),
which it takes on its own. The per-repo start lock serializes *spawn-then-persist
sequences*, not the file. Confirmed by reading, not assumed.

This also makes the site match the convention the rest of the codebase already
follows: every other path that persists while holding `m.mu` uses a lock-free
primitive — `keepFailedCreate` (`manager_create.go:716-719`) and the
`CreateSession` critical section (line 125-128) both call `appendInstanceData`
under `m.mu`; `CreateTab`/`CloseTab`/`SetPRInfo` call `persistInstanceData`.

One honest note on scope: the best-effort write will commonly fail with
"not found in storage", because the durable rewrite that just failed is what
would have moved the on-disk row to the new title. That is pre-existing
behavior of the author's original intent (`m.persistInstance` would have hit
the same lookup), it is now logged rather than hung on, and the returned
operator error covers the recovery. Changing it is out of scope for a deadlock
fix.

## Fail-first evidence

Written and watched fail before the fix. Verbatim, pre-fix:

```
$ make test-container GOTESTARGS="-count=1 -run TestReserveCreate_ReusesArchivedName_DoubleFailureNoSelfDeadlock -v ./daemon/..."
scripts/testbox.sh test -count=1 -run TestReserveCreate_ReusesArchivedName_DoubleFailureNoSelfDeadlock -v ./daemon/...
=== RUN   TestReserveCreate_ReusesArchivedName_DoubleFailureNoSelfDeadlock
    deadlock_2106_test.go:91: deadlock (#2106): reserveCreate never returned — the archived-name-reuse double-failure recovery branch persists while holding m.mu, and persistInstance re-acquires m.mu via startLockForRepo (sync.Mutex is not reentrant), hanging the daemon
--- FAIL: TestReserveCreate_ReusesArchivedName_DoubleFailureNoSelfDeadlock (30.06s)
FAIL
FAIL	github.com/sachiniyer/agent-factory/daemon	30.069s
```

Post-fix, same command: `--- PASS ... (0.05s)`.

The 30s wall is the test's own `select` timeout (mirroring
`session/tmux/kill_wedge_test.go` and `daemon/deadlock_2006_test.go`), so a
pre-fix run fails loudly instead of hanging the suite until the test binary
panics.

### How the repro is honest

The `daemon/deadlock_probe_test.go` the issue mentions **does not exist in this
repo** — that was Detail's own scratch work, so this is a fresh test. It drives
the real production path (`reserveCreate → renameArchivedForReuseLocked`), not
the locking helper in isolation: calling `startLockForRepo` under `m.mu`
directly would only re-prove that Go mutexes are non-reentrant, which is a
language fact, not evidence about this code.

Both failures are forced deterministically through **one** new production seam,
`reuseArchivedRenamePersist` (a package var over `renameInstanceDataTitle`,
mirroring the existing `archivePersist` and `killTombstonePersist` precedents).
It fires in exactly the window between the two worktree moves:

1. the real first move has already relocated the worktree `origDest → newDest`,
   vacating `origDest`;
2. the seam re-occupies `origDest` and returns an error — the durable rewrite "fails";
3. the rollback move `newDest → origDest` then fails on `relocateWorktreeTo`'s
   `destination already exists` guard (`session/git/worktree_archive.go:139`).

No filesystem-permission tricks: that guard is a plain `stat`, so it behaves
identically as root and in a container. The test also asserts the harness
actually produced the double failure (`seamFired`, `blockerPlanted`,
worktree still at `newDest`), so it cannot pass for the wrong reason by
silently ceasing to reach the branch. Finally it runs a second `reserveCreate`
and requires it to complete — direct proof `m.mu` was not left wedged.

## Adjacent audit

`manager_create.go:318` was unlikely to be the only instance of this class, so
I audited **every** call to `m.persistInstance` / `m.persistInstanceErr` /
`m.startLockForRepo` — 27 sites — asking for each whether `m.mu` can be held by
the same goroutine at that point.

Method: a call-graph reachability pass over the non-test `daemon/` sources that
tracks `m.mu` lock depth per function (including `defer`-held regions), then
expands transitively through same-goroutine calls only (`go`-launched calls are
a *different* goroutine and cannot self-deadlock). Every result below was then
confirmed by reading the callers — **not** by trusting the `Locked` suffix, and
that mattered (see `resumeFromLimitLocked`).

| Site | Enclosing function | Reached with `m.mu` held? | Verdict |
|---|---|---|---|
| `manager_create.go:318` | `renameArchivedForReuseLocked` | **YES** — via `reserveCreate` (`manager_create.go:219`), which holds `m.mu` at line 158 | **THE BUG — fixed** |
| `manager_create.go:59` | `CreateSession` | No — `reserveCreate` released `m.mu` at line 44 | checked, safe |
| `limit.go:411` | `resumeFromLimitLocked` | No | checked, safe |
| `limit.go:431` | `resumeFromLimitLocked` | No | checked, safe |
| `limit.go:132` | `persistPollChange` | No — callers `settleRemoteProbeFailure` / `observeTaskRunWhilePaused` / `refreshInstanceStatus` are all `m.mu`-free | checked, safe |
| `lostrestore.go:326` | `restoreLostSession` | No — caller `RestoreLostSessions` (`lostrestore.go:156`) is `m.mu`-free | checked, safe |
| `lostrestore.go:342` | `restoreLostSession` | No | checked, safe |
| `lostrestore.go:370` | `restoreLostSession` | No | checked, safe |
| `restore.go:94` | `restoreLostOrDeadSession` | No — caller `RestoreSession` (`restore.go:26`) is `m.mu`-free | checked, safe |
| `restore.go:102` | `restoreLostOrDeadSession` | No | checked, safe |
| `restore.go:112` | `restoreLostOrDeadSession` | No | checked, safe |
| `archive.go:166` | `ArchiveSession` | No — entry point / `DeleteProject` caller is `m.mu`-free | checked, safe |
| `archive.go:187` | `ArchiveSession` (`archivePersist`) | No | checked, safe |
| `archive.go:193` | `ArchiveSession` | No | checked, safe |
| `archive.go:219` | `undoCommittedArchive` | No — caller `ArchiveSession:189` is `m.mu`-free | checked, safe |
| `archive.go:241` | `archiveRemoteSession` | No — caller `ArchiveSession:104` is `m.mu`-free | checked, safe |
| `archive.go:248` | `archiveRemoteSession` (`archivePersist`) | No | checked, safe |
| `archive.go:255` | `archiveRemoteSession` | No | checked, safe |
| `archive.go:275` | `restoreRemoteSession` | No — caller `RestoreArchived:350` is `m.mu`-free | checked, safe |
| `archive.go:289` | `restoreRemoteSession` | No | checked, safe |
| `archive.go:386` | `RestoreArchived` | No | checked, safe |
| `archive.go:391` | `RestoreArchived` | No | checked, safe |
| `archive.go:430` | `persistInstanceErr` | No — sole `m.mu`-held reacher was `manager_create.go:318` | checked, safe |
| `manager_tabs.go:104` | `CreateTab` | No — RPC entry point | checked, safe |
| `manager_tabs.go:293` | `SetPRInfo` | No — RPC entry point | checked, safe |
| `manager_tabs_arrange.go:111` | `tabMutationTarget` | No — callers `CloseTab` / `RenameTab` / `ReorderTab` are `m.mu`-free | checked, safe |
| `conversation_capture.go:43` | `captureAgentConversation` | No — reached only via `go captureAgentConversationAsync`, a *different* goroutine | checked, safe |
| `rootkill.go:76` | `persistKillTombstone` | No — caller `KillSession` (`manager_sessions.go:111`) is `m.mu`-free | checked, safe |

**Result: `manager_create.go:318` was the only occurrence.** No other latent
hang of this class was found.

Two things worth flagging from the audit:

- **The `Locked` suffix is not a reliable signal here.** `resumeFromLimitLocked`
  ends in `Locked` but the locks it documents are the per-target and per-session
  op locks, *not* `m.mu` — its body takes `m.mu` itself at `limit.go:312-315`,
  which proves the caller does not hold it. Its two `persistInstance` calls are
  therefore fine. Trusting the name would have produced two false positives.
- **After the fix, the reachability pass reports `persistInstance`,
  `persistInstanceErr`, `startLockForRepo` and `opLockFor` as all unreachable
  under `m.mu` on the same goroutine.** The only persist primitives still
  reachable under `m.mu` are the lock-free ones — `persistInstanceData`,
  `appendInstanceData`, `renameInstanceDataTitle` — which is the intended
  convention.

## Structural guard

Rather than only fixing the site, the contract is now written down where the
next person will hit it — a doc comment on each of the three helpers stating
plainly that they must never be called with `m.mu` held, naming
`persistInstanceData` as the thing to use instead, and recording the
`repoStartLock → m.mu` ordering so the ABBA "cleanup" is pre-empted:

- `startLockForRepo` (`daemon/manager.go`) — the full contract, both directions
- `persistInstanceErr` (`daemon/archive.go`) — inherits it, points at the above
- `persistInstance` (`daemon/archive.go`) — inherits it

Plus an in-line comment at the fixed call site explaining why it must not be
"cleaned up" back to `m.persistInstance`, and why the start lock must not be
reintroduced.

This is deliberately cheap and durable rather than a structural refactor. A
mechanically enforced version (splitting the manager lock, or a lock-order
checker) is a much larger change than a hang fix should carry.

## Gates

- `gofmt -l .` — clean
- `go build ./...` — clean
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean
- `scripts/lint-file-length.sh` — passed (808 files, 0 grandfathered)
- `make test-container` — full suite green

Signed, Captain Claude
