### PR TITLE
fix(tmux): bound every capture/poll tmux command so a wedged server can't hang the daemon (#2099, #2105)

### DIFF
--- a/session/tmux/bounded.go
+++ b/session/tmux/bounded.go
@@ -3,6 +3,7 @@ package tmux
 import (
 	"context"
 	"errors"
+	"io"
 	"os"
 	"os/exec"
 	"syscall"
@@ -39,8 +40,32 @@ import (
 // exec.Command. daemon.KillSession runs the whole teardown with no deadline of its
 // own while holding a per-session kills-in-flight guard, so a single unbounded tmux
 // call there does not merely stall one kill: it makes that session permanently
-// undeletable for the daemon's entire lifetime. Every tmux command in this package
-// is now bounded; new ones must be too.
+// undeletable for the daemon's entire lifetime.
+//
+// #2099/#2105 closed the last gaps, which were regressions against the invariant
+// this comment used to assert outright ("every tmux command in this package is now
+// bounded") while three capture paths were in fact still unbounded — the claim was
+// load-bearing enough that later code trusted it instead of checking:
+//
+//   - The CAPTURE/POLL paths: CapturePaneContent (the daemon's per-second status
+//     poll, via HasUpdated), CapturePaneContentWithOptions, and the submit path's
+//     capturePaneForDelivery. The daemon polls instances SEQUENTIALLY, so one
+//     wedged session froze the status of every instance behind it.
+//   - CapturePaneContentContext had a ctx but ran on plain exec.CommandContext,
+//     which sets no WaitDelay and kills only the direct process — so a child
+//     holding the inherited stdout pipe kept Output() blocked on pipe EOF and
+//     silently defeated the deadline. A ctx alone is NOT a bound; it has to go
+//     through boundedTmuxCommand.
+//   - The remaining send-keys/buffer/sweep commands (TapEnter, TapDAndEnter,
+//     sendEnter, load-buffer, paste-buffer, delete-buffer, show-environment,
+//     tmux -V, tmux ls, CleanupSessions' kill-session).
+//
+// The invariant is real again, and stated as an obligation rather than a fact:
+// every tmux command in this package MUST be bounded, and session/tmux's wedge
+// tests (bounded_test.go, kill_wedge_test.go, capture_wedge_test.go) are what
+// hold new ones to it. The one deliberate exception is start.go's `new-session`,
+// which is not a control command: it is handed to the PtyFactory as the session's
+// own long-lived process, and its lifetime is managed by the ptmx, not a deadline.
 //
 // A var (not a const) only so tests can shorten it; production never reassigns.
 var tmuxCommandTimeout = 10 * time.Second
@@ -126,6 +151,30 @@ func (t *TmuxSession) outputTmuxBounded(ctx context.Context, args ...string) ([]
 	return outputTmuxBoundedWith(ctx, t.cmdExec, args...)
 }
 
+// runTmuxBoundedStdin runs a tmux command under ctx with stdin wired to r. It
+// exists because the helpers above deliberately take no stdin, and `load-buffer`
+// is this package's only tmux command that STREAMS a payload in (#2099).
+//
+// It does NOT normalize exec.ErrWaitDelay to success, and that divergence from
+// runTmuxBounded is the whole reason it is a separate helper. exec copies a
+// non-*os.File stdin to the child through an OS pipe on a background goroutine,
+// and WaitDelay force-closes that pipe when it elapses — which is exactly what
+// keeps a killed tmux from stranding the copier, but it also means an unknown
+// PREFIX of the payload may be all that landed. For the output-discarding control
+// commands, normalizing is right: tmux exited cleanly and only a pipe-holding
+// child lingered, so the work is done (#676/#914). For load-buffer it would claim
+// a prompt was loaded when it was truncated, and the paste that follows would
+// submit the mangled remainder while still reporting success — the silent
+// prompt-corruption class of #1982, which is strictly worse than the hang this
+// bound removes. So the error propagates and the submit fails loudly.
+func runTmuxBoundedStdin(ctx context.Context, cmdExec cmd.Executor, r io.Reader, args ...string) error {
+	c := boundedTmuxCommand(ctx, args...)
+	c.Stdin = r
+	err := cmdExec.Run(c)
+	reapTmuxGroup(c)
+	return err
+}
+
 // normalizeWaitDelay converts an exec.ErrWaitDelay into success: tmux itself
 // exited cleanly (a non-zero exit surfaces as an ExitError, not ErrWaitDelay)
 // and only an inherited child held the capture pipe open past tmuxWaitDelay —
@@ -149,4 +198,25 @@ func normalizeWaitDelay(err error) error {
 // cancellation, where it skips the probe and returns ctx.Err() directly).
 func tmuxTimeoutContext() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), tmuxCommandTimeout)
+}
+
+// tmuxTimeoutContextWithin is tmuxTimeoutContext for a caller that already has a
+// SHORTER deadline of its own: the bound becomes the smaller of budget and
+// tmuxCommandTimeout.
+//
+// It exists for poll loops (#2099). A loop whose whole budget is
+// pasteDeliveryMaxWait (2s) cannot bound the tmux command inside it at the flat
+// tmuxCommandTimeout (10s): one stalled command would then overshoot the loop's
+// entire budget 5x, and the loop's own deadline check — the code that decides to
+// give up — stays unreachable for the whole 10s. Bounding each command by what is
+// LEFT of the loop's budget is what makes that check actually run on time.
+//
+// A non-positive budget yields an already-expired context rather than an
+// unbounded one: the caller is past its deadline, so the correct outcome is for
+// the command to fail immediately and let the loop exit.
+func tmuxTimeoutContextWithin(budget time.Duration) (context.Context, context.CancelFunc) {
+	if budget > tmuxCommandTimeout {
+		budget = tmuxCommandTimeout
+	}
+	return context.WithTimeout(context.Background(), budget)
 }

--- a/session/tmux/capture_wedge_test.go
+++ b/session/tmux/capture_wedge_test.go
@@ -1,0 +1,408 @@
+package tmux
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/cmd"
+)
+
+// #2099 / #2105: the CAPTURE and POLL paths kept using bare exec.Command (or
+// exec.CommandContext with context.Background()) long after #1787/#1917 bounded
+// the WS and teardown paths, so a wedged tmux server hung them forever. The two
+// reported symptoms share one root cause:
+//
+//   - #2105: the daemon's per-second status poll calls HasUpdated →
+//     CapturePaneContent → CapturePaneContentContext(context.Background()). The
+//     daemon polls instances SEQUENTIALLY, so one wedged session froze the status
+//     of every later instance — liveness, trust-prompt dismissal, AutoYes and the
+//     usage-limit detector all stop.
+//   - #2099: CapturePaneContentWithOptions and the submit path's
+//     capturePaneForDelivery ran capture-pane with no deadline at all.
+//
+// These tests drive a REAL fake tmux on PATH rather than a MockCmdExec that
+// sleeps, and that is load-bearing rather than stylistic: a mock's Func blocks
+// the CALLING GOROUTINE directly, which no context deadline can reach, so a
+// blocking mock would "fail" identically before and after the fix and would
+// prove nothing. The bound only exists because a real subprocess can be
+// SIGKILLed on the deadline. stallingTmuxOnPath (bounded_test.go) additionally
+// sleeps in a CHILD, so passing also requires boundedTmuxCommand's process-group
+// kill and tmuxWaitDelay — a plain exec.CommandContext leaves the child holding
+// the inherited stdout pipe and Output() stays blocked on pipe EOF, silently
+// defeating the deadline.
+
+// shortPasteDeliveryMaxWait tightens the submit path's own delivery budget so the
+// tests below can assert in milliseconds. Returned to its previous value on
+// cleanup.
+func shortPasteDeliveryMaxWait(t *testing.T, d time.Duration) {
+	t.Helper()
+	prev := pasteDeliveryMaxWait
+	pasteDeliveryMaxWait = d
+	t.Cleanup(func() { pasteDeliveryMaxWait = prev })
+}
+
+// TestCaptureAndPollTmuxCommandsDoNotHang is the #2099/#2105 regression. Every
+// capture/poll entry point must RETURN against a wedged server, and must report
+// the wedge as ErrTmuxTimeout — never as ErrSessionGone.
+func TestCaptureAndPollTmuxCommandsDoNotHang(t *testing.T) {
+	cases := []struct {
+		name string
+		call func(ts *TmuxSession) error
+	}{
+		// #2105: the daemon status-poll capture. The headline hang.
+		{"CapturePaneContent", func(ts *TmuxSession) error { _, err := ts.CapturePaneContent(); return err }},
+		// The context form with a caller ctx that never fires: the deadline must
+		// come from the package's own bound, not from the caller.
+		{"CapturePaneContentContext", func(ts *TmuxSession) error {
+			_, err := ts.CapturePaneContentContext(context.Background())
+			return err
+		}},
+		// #2099: the scrollback capture behind Preview/Snapshot.
+		{"CapturePaneContentWithOptions", func(ts *TmuxSession) error {
+			_, err := ts.CapturePaneContentWithOptions("-", "-")
+			return err
+		}},
+		// #2105 explicitly recommends bounding both taps: they run on the same
+		// unsupervised daemon poll as HasUpdated (AutoYes accept, trust-prompt
+		// dismissal), so a stall here freezes the poll exactly like the capture.
+		{"TapEnter", func(ts *TmuxSession) error { return ts.TapEnter() }},
+		{"TapDAndEnter", func(ts *TmuxSession) error { return ts.TapDAndEnter() }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stallingTmuxOnPath(t)
+			shortTmuxTimeout(t, 200*time.Millisecond)
+			ts := NewTmuxSessionWithDeps("wedge-2105", "sh", MakePtyFactory(), cmd.MakeExecutor())
+			ts.setMonitor(newStatusMonitor())
+
+			done := make(chan error, 1)
+			go func() { done <- tc.call(ts) }()
+
+			// Generous relative to the 200ms deadline, but far below the fake
+			// tmux's 300s sleep: only a real bound can land inside it.
+			select {
+			case err := <-done:
+				if !errors.Is(err, ErrTmuxTimeout) {
+					t.Fatalf("want ErrTmuxTimeout against a stalled tmux, got %v", err)
+				}
+				// THE safety invariant. A tripped deadline means the server is
+				// wedged and the session's real state is UNKNOWN. Callers act
+				// destructively on "gone" (the daemon marks the instance Lost and
+				// reaps its process trees), so reporting a merely-wedged server as
+				// gone would tear down a live agent.
+				if errors.Is(err, ErrSessionGone) {
+					t.Fatalf("timeout must not be reported as ErrSessionGone: %v", err)
+				}
+			case <-time.After(30 * time.Second):
+				t.Fatalf("%s hung against a stalled tmux (#2099/#2105): no return within 30s — "+
+					"the daemon polls instances sequentially, so this stalls every later instance's status", tc.name)
+			}
+		})
+	}
+}
+
+// TestHasUpdatedDoesNotHangOnWedgedServer drives the #2105 symptom through the
+// exact call the daemon makes. refreshInstanceStatus has no watchdog, so a hang
+// here is unbounded and silent.
+func TestHasUpdatedDoesNotHangOnWedgedServer(t *testing.T) {
+	stallingTmuxOnPath(t)
+	shortTmuxTimeout(t, 200*time.Millisecond)
+	ts := NewTmuxSessionWithDeps("wedge-2105-poll", "sh", MakePtyFactory(), cmd.MakeExecutor())
+	ts.setMonitor(newStatusMonitor())
+
+	done := make(chan bool, 1)
+	go func() {
+		_, _, _ = ts.HasUpdated()
+		done <- true
+	}()
+
+	select {
+	case <-done:
+		// The monitor must NOT have latched itself dead: that latch is reserved
+		// for a CONFIRMED-gone session (ErrSessionGone), and a wedged server
+		// confirms nothing. Latching on a timeout would permanently silence the
+		// status monitor for a session that is merely slow.
+		ts.monitorMu.Lock()
+		dead := ts.monitor.dead
+		ts.monitorMu.Unlock()
+		if dead {
+			t.Fatal("a wedged tmux server must not latch the status monitor dead: " +
+				"the session is UNKNOWN, not confirmed gone, and the latch is permanent until respawn")
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("HasUpdated hung against a stalled tmux (#2105): this runs on the daemon's " +
+			"unsupervised per-second poll, which polls instances sequentially")
+	}
+}
+
+// TestCapturePaneContentContextHonorsCallerCancellation guards the contract the
+// #2105 fix must NOT regress while adding its own bound. task.WaitForReady passes
+// a cancellable ctx and relies on cancellation tearing the in-flight capture down
+// (see task/amp_ready_test.go). Adding an internal deadline must therefore DERIVE
+// from the caller's ctx, not replace it — and a caller cancel must still surface
+// as ctx.Err(), distinct from the package's own ErrTmuxTimeout, so an abandoned
+// create is never misfiled as a wedged server.
+func TestCapturePaneContentContextHonorsCallerCancellation(t *testing.T) {
+	stallingTmuxOnPath(t)
+	// Deliberately LONG relative to the cancel below: if the caller's cancel were
+	// not threaded through, this test could only pass by waiting out our bound.
+	shortTmuxTimeout(t, 30*time.Second)
+	ts := NewTmuxSessionWithDeps("wedge-2105-cancel", "sh", MakePtyFactory(), cmd.MakeExecutor())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := ts.CapturePaneContentContext(ctx)
+		done <- err
+	}()
+
+	time.Sleep(100 * time.Millisecond) // let the capture get in flight
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("want context.Canceled when the CALLER cancels, got %v", err)
+		}
+		// Caller cancellation is not a wedged server. WaitForReady distinguishes
+		// them, and so must this.
+		if errors.Is(err, ErrTmuxTimeout) {
+			t.Fatalf("caller cancellation must not be reported as ErrTmuxTimeout: %v", err)
+		}
+		if errors.Is(err, ErrSessionGone) {
+			t.Fatalf("caller cancellation must not be reported as ErrSessionGone: %v", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("CapturePaneContentContext ignored the caller's cancellation — an abandoned " +
+			"create would hold the per-repo start lock across the whole capture")
+	}
+}
+
+// TestSubmitPathDoesNotHangOnWedgedServer is the #2099 submit half. Every tmux
+// command in sendKeysPasteBuffer (the delivery captures, load-buffer,
+// paste-buffer, delete-buffer, send-keys Enter) must be bounded, or a wedged
+// server hangs the prompt-delivery path — which the daemon drives while holding
+// the per-session op lock.
+func TestSubmitPathDoesNotHangOnWedgedServer(t *testing.T) {
+	stallingTmuxOnPath(t)
+	shortTmuxTimeout(t, 200*time.Millisecond)
+	shortPasteDeliveryMaxWait(t, 200*time.Millisecond)
+	ts := NewTmuxSessionWithDeps("wedge-2099-submit", "sh", MakePtyFactory(), cmd.MakeExecutor())
+
+	done := make(chan error, 1)
+	go func() { done <- ts.SendKeysCommand("a prompt long enough to be distinctive") }()
+
+	select {
+	case err := <-done:
+		// The delivery MUST fail loudly rather than silently claim success: the
+		// prompt provably did not land on a wedged server, and #1982 is exactly
+		// the bug class where a submit reports success with the prompt stranded.
+		if err == nil {
+			t.Fatal("SendKeysCommand reported success against a wedged tmux server: " +
+				"nothing was delivered, so a nil error is a silent lost prompt (#1982 class)")
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("SendKeysCommand hung against a stalled tmux (#2099): the submit path runs " +
+			"under the daemon's per-session op lock, so the session becomes unpromptable")
+	}
+}
+
+// TestPasteDeliveryLoopHonorsItsOwnBudget is subtlety (a) of the fix, and the
+// half the issue's suggested patch gets WRONG.
+//
+// capturePaneForDelivery is called from waitForPasteDelivered's poll loop, whose
+// entire budget is pasteDeliveryMaxWait. Bounding the capture at the package's
+// flat tmuxCommandTimeout would let ONE capture overshoot that budget many times
+// over, leaving the loop's `time.Now().After(deadline)` check unreachable for the
+// whole tmuxCommandTimeout — i.e. the reported bug only half fixed. The capture
+// must therefore be bounded by the loop's REMAINING budget (clamped to
+// tmuxCommandTimeout), so the loop actually honors pasteDeliveryMaxWait.
+func TestPasteDeliveryLoopHonorsItsOwnBudget(t *testing.T) {
+	stallingTmuxOnPath(t)
+	const (
+		maxWait = 300 * time.Millisecond
+		// An order of magnitude larger than maxWait: a flat tmuxCommandTimeout
+		// bound on the capture is the failure this separates out, and it is only
+		// visible when the two budgets differ.
+		tmuxBound = 3 * time.Second
+	)
+	shortTmuxTimeout(t, tmuxBound)
+	shortPasteDeliveryMaxWait(t, maxWait)
+	ts := NewTmuxSessionWithDeps("wedge-2099-budget", "sh", MakePtyFactory(), cmd.MakeExecutor())
+
+	done := make(chan time.Duration, 1)
+	go func() {
+		start := time.Now()
+		ts.waitForPasteDelivered("a-distinctive-tail", 0)
+		done <- time.Since(start)
+	}()
+
+	select {
+	case elapsed := <-done:
+		// Slack for process spawn/kill, but far below tmuxBound: a capture bounded
+		// at tmuxCommandTimeout instead of the remaining loop budget lands at
+		// ~3s and fails here.
+		if limit := 4 * maxWait; elapsed >= limit {
+			t.Fatalf("waitForPasteDelivered took %v (>= %v) against a stalled tmux: its captures are "+
+				"bounded by tmuxCommandTimeout (%v) rather than the loop's own remaining budget (%v), "+
+				"so the pasteDeliveryMaxWait deadline check stays unreachable", elapsed, limit, tmuxBound, maxWait)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("waitForPasteDelivered hung against a stalled tmux (#2099): the capture inside " +
+			"its poll loop is unbounded, so the loop's deadline check never runs")
+	}
+}
+
+// TestPaneTailForLogDoesNotHangOnWedgedServer covers capturePaneForDelivery's
+// OTHER caller. paneTailForLog runs outside the poll loop and has no deadline of
+// its own, so a per-loop budget alone would leave it unbounded — it needs the
+// package's standard bound. It runs on the delivery-not-observed logging path,
+// i.e. precisely when the pane is already misbehaving.
+func TestPaneTailForLogDoesNotHangOnWedgedServer(t *testing.T) {
+	stallingTmuxOnPath(t)
+	shortTmuxTimeout(t, 200*time.Millisecond)
+	ts := NewTmuxSessionWithDeps("wedge-2099-tail", "sh", MakePtyFactory(), cmd.MakeExecutor())
+
+	done := make(chan string, 1)
+	go func() { done <- paneTailForLog(ts) }()
+
+	select {
+	case got := <-done:
+		if got != "<pane not capturable>" {
+			t.Fatalf("a wedged server must report the pane as not capturable, got %q", got)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("paneTailForLog hung against a stalled tmux (#2099): it calls " +
+			"capturePaneForDelivery outside the poll loop, with no deadline of its own")
+	}
+}
+
+// TestCleanupSessionsDoesNotHangOnWedgedServer covers the sweep's tmux commands
+// (`tmux ls`, `show-environment`, `kill-session`). `af reset` runs this
+// synchronously in a short-lived CLI process, so an unbounded stall here is a
+// user-visible hang with no way out but ^C.
+func TestCleanupSessionsDoesNotHangOnWedgedServer(t *testing.T) {
+	stallingTmuxOnPath(t)
+	shortTmuxTimeout(t, 200*time.Millisecond)
+
+	done := make(chan error, 1)
+	go func() { done <- CleanupSessions(cmd.MakeExecutor()) }()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, ErrTmuxTimeout) {
+			t.Fatalf("want ErrTmuxTimeout against a stalled tmux, got %v", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("CleanupSessions hung against a stalled tmux: `af reset` runs it synchronously")
+	}
+}
+
+// TestSessionHomeMarkerDoesNotHangOnWedgedServer covers the ownership probe the
+// sweep runs once PER discovered session. It is best-effort (no error to return),
+// so the contract is simply that it returns — and returns "no marker", since a
+// wedged server proves nothing about ownership and the sweep's safe direction is
+// to leave a session it cannot prove it owns (#1122).
+func TestSessionHomeMarkerDoesNotHangOnWedgedServer(t *testing.T) {
+	stallingTmuxOnPath(t)
+	shortTmuxTimeout(t, 200*time.Millisecond)
+
+	type result struct {
+		home string
+		ok   bool
+	}
+	done := make(chan result, 1)
+	go func() {
+		home, ok := sessionHomeMarker(cmd.MakeExecutor(), "af_wedged")
+		done <- result{home, ok}
+	}()
+
+	select {
+	case got := <-done:
+		if got.ok {
+			t.Fatalf("a wedged server must not be read as proof of ownership, got home %q", got.home)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("sessionHomeMarker hung against a stalled tmux: CleanupSessions calls it once " +
+			"per discovered session, so one wedge stalls the whole sweep")
+	}
+}
+
+// healthyTmuxOnPath installs a fake tmux that answers immediately, standing in
+// for a healthy server. `load-buffer` copies its stdin to stdinSink so the tests
+// can prove the paste payload survives the bounded path intact.
+func healthyTmuxOnPath(t *testing.T, stdinSink string) {
+	t.Helper()
+	dir := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"load-buffer\" ]; then cat > " + stdinSink + "; exit 0; fi\n" +
+		"if [ \"$1\" = \"display-message\" ]; then echo '3 7'; exit 0; fi\n" +
+		"echo 'pane line'\n"
+	if err := os.WriteFile(filepath.Join(dir, "tmux"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// TestBoundedCapturesSucceedWhenTmuxIsHealthy guards the other direction: the new
+// deadlines must not break the normal path. A regression that always trips the
+// timeout, or that mis-reads a fast clean exit as a deadline, fails here.
+func TestBoundedCapturesSucceedWhenTmuxIsHealthy(t *testing.T) {
+	sink := filepath.Join(t.TempDir(), "stdin.txt")
+	healthyTmuxOnPath(t, sink)
+	shortTmuxTimeout(t, 10*time.Second)
+	ts := NewTmuxSessionWithDeps("healthy-2099", "sh", MakePtyFactory(), cmd.MakeExecutor())
+	ts.setMonitor(newStatusMonitor())
+
+	if got, err := ts.CapturePaneContent(); err != nil || got != "pane line\n" {
+		t.Fatalf("CapturePaneContent: got %q err %v", got, err)
+	}
+	if got, err := ts.CapturePaneContentContext(context.Background()); err != nil || got != "pane line\n" {
+		t.Fatalf("CapturePaneContentContext: got %q err %v", got, err)
+	}
+	if got, err := ts.CapturePaneContentWithOptions("-", "-"); err != nil || got != "pane line\n" {
+		t.Fatalf("CapturePaneContentWithOptions: got %q err %v", got, err)
+	}
+	if err := ts.TapEnter(); err != nil {
+		t.Fatalf("TapEnter: %v", err)
+	}
+	if err := ts.TapDAndEnter(); err != nil {
+		t.Fatalf("TapDAndEnter: %v", err)
+	}
+	if content, ok := ts.capturePaneForDelivery(); !ok || content != "pane line\n" {
+		t.Fatalf("capturePaneForDelivery: got %q ok %v", content, ok)
+	}
+}
+
+// TestLoadBufferStdinSurvivesTheBoundedPath is the load-buffer half of the fix.
+// It is the package's only tmux command that STREAMS a payload in on stdin, and
+// WaitDelay force-closes inherited pipes (#856/#896) — including the one exec
+// creates for a non-*os.File stdin. A bound that truncates the payload would
+// submit a silently mangled prompt, which is strictly worse than the hang it
+// replaces, so assert the whole prompt reaches tmux byte-for-byte.
+func TestLoadBufferStdinSurvivesTheBoundedPath(t *testing.T) {
+	sink := filepath.Join(t.TempDir(), "stdin.txt")
+	healthyTmuxOnPath(t, sink)
+	shortTmuxTimeout(t, 10*time.Second)
+	shortPasteDeliveryMaxWait(t, 100*time.Millisecond)
+	ts := NewTmuxSessionWithDeps("healthy-2099-load", "sh", MakePtyFactory(), cmd.MakeExecutor())
+
+	// Large enough that the copy is a real multi-write stream rather than a
+	// single small write that could pass by luck.
+	prompt := strings.Repeat("prompt payload that must survive intact. ", 500)
+	if err := ts.SendKeysCommand(prompt); err != nil {
+		t.Fatalf("SendKeysCommand against a healthy tmux: %v", err)
+	}
+	got, err := os.ReadFile(sink)
+	if err != nil {
+		t.Fatalf("read load-buffer stdin sink: %v", err)
+	}
+	if string(got) != prompt {
+		t.Fatalf("load-buffer stdin truncated by the bounded path: got %d bytes, want %d", len(got), len(prompt))
+	}
+}

--- a/session/tmux/cleanup.go
+++ b/session/tmux/cleanup.go
@@ -137,13 +137,25 @@ func exactTarget(name string) string {
 // test sweep that escapes onto the developer's real server must be a no-op
 // (#1122). `af doctor` lists unowned af_ sessions with a manual kill command.
 func CleanupSessions(cmdExec cmd.Executor) error {
-	// First try to list sessions
-	cmd := exec.Command("tmux", "ls")
-	output, err := cmdExec.Output(cmd)
+	// First try to list sessions. Bounded by tmuxCommandTimeout (#2099): this is
+	// the first tmux command of the sweep, and `af reset` runs the sweep
+	// synchronously in a short-lived CLI process, so an unbounded stall here is a
+	// user-visible hang with no way out but ^C.
+	listCtx, listCancel := tmuxTimeoutContext()
+	output, err := outputTmuxBoundedWith(listCtx, cmdExec, "ls")
+	listTimedOut := listCtx.Err() != nil
+	listCancel()
 
 	// If there's an error and it's because no server is running, that's fine
 	// Exit code 1 typically means no sessions exist
 	if err != nil {
+		if listTimedOut {
+			// A wedged server has told us NOTHING about what is running, so the
+			// sweep must abort rather than proceed on an empty list — an empty
+			// list here would silently read as "nothing to clean up" and report
+			// success for a reset that swept nothing.
+			return fmt.Errorf("%w: tmux ls after %s", ErrTmuxTimeout, tmuxCommandTimeout)
+		}
 		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
 			return nil // No sessions to clean up
 		}
@@ -195,12 +207,27 @@ func CleanupSessions(cmdExec cmd.Executor) error {
 		log.InfoLog.Printf("cleaning up session: %s", match)
 		// `=` forces an exact session match so a name extracted from `tmux ls`
 		// kills exactly that session and never a prefix-matching sibling (#1006).
-		if err := cmdExec.Run(exec.Command("tmux", "kill-session", "-t", exactTarget(match))); err != nil {
+		//
+		// Bounded by tmuxCommandTimeout (#2099) so one undeletable session cannot
+		// wedge the whole sweep.
+		killCtx, killCancel := tmuxTimeoutContext()
+		killErrRaw := runTmuxBoundedWith(killCtx, cmdExec, "kill-session", "-t", exactTarget(match))
+		killTimedOut := killCtx.Err() != nil
+		killCancel()
+		if killErrRaw != nil {
+			if killTimedOut {
+				// Do NOT fall back to the sessionExists probe on a tripped
+				// deadline: it spawns another tmux command against the same
+				// wedged server and would hang identically, buying nothing (see
+				// tmuxTimeoutContext). Report the wedge and stop.
+				killErr = fmt.Errorf("%w: kill-session %s after %s", ErrTmuxTimeout, match, tmuxCommandTimeout)
+				break
+			}
 			// Idempotent teardown (#967): a session can vanish between the
 			// `tmux ls` above and this kill (TOCTOU). A gone session is the
 			// goal of cleanup, so only a survivor is a real failure.
 			if sessionExists(cmdExec, match) {
-				killErr = fmt.Errorf("failed to kill tmux session %s: %v", match, err)
+				killErr = fmt.Errorf("failed to kill tmux session %s: %v", match, killErrRaw)
 				break
 			}
 		}

--- a/session/tmux/envmarker.go
+++ b/session/tmux/envmarker.go
@@ -2,7 +2,6 @@ package tmux
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -55,8 +54,17 @@ func sessionEnvFlags(sanitizedName string) []string {
 // environment (stamped via `new-session -e` at creation). Returns ("", false)
 // when the session carries no marker — created by a pre-marker build or by a
 // tmux older than 3.2, which cannot set session environment at creation.
+//
+// Bounded by tmuxCommandTimeout (#2099): CleanupSessions calls this once per
+// discovered session, so an unbounded stall on any one of them wedges the whole
+// sweep — and `af reset` runs that sweep synchronously in a short-lived CLI
+// process, where the only way out is ^C. A tripped deadline reports "no marker",
+// which is the safe direction: the sweep leaves any session it cannot PROVE this
+// home owns (#1122), and a wedged server proves nothing.
 func sessionHomeMarker(cmdExec cmd.Executor, sanitizedName string) (string, bool) {
-	out, err := cmdExec.Output(exec.Command("tmux", "show-environment", "-t", exactTarget(sanitizedName), EnvMarkerHome))
+	ctx, cancel := tmuxTimeoutContext()
+	defer cancel()
+	out, err := outputTmuxBoundedWith(ctx, cmdExec, "show-environment", "-t", exactTarget(sanitizedName), EnvMarkerHome)
 	if err != nil {
 		// show-environment exits non-zero when the variable is unset.
 		return "", false
@@ -73,9 +81,21 @@ var (
 
 // tmuxSupportsNewSessionEnv probes `tmux -V` once per process. Unparseable
 // versions ("openbsd-7.4", exotic builds) conservatively report false.
+//
+// Bounded like every other tmux command in this package (#2099), though the
+// hazard here is narrower and worth naming honestly: `tmux -V` is answered by the
+// CLIENT and never contacts the server, so a wedged SERVER — the failure mode
+// #2099/#2105 are about — cannot stall it. What can is a hanging tmux BINARY (a
+// wrapper script, a stalled network filesystem holding the executable). That is
+// defensive rather than reproduced, but the blast radius justifies the three
+// lines: this sits behind a sync.Once on the session-CREATE path, so a single
+// hang would wedge session creation for the entire process lifetime and every
+// later caller would block on the Once rather than retry.
 func tmuxSupportsNewSessionEnv() bool {
 	newSessionEnvOnce.Do(func() {
-		out, err := exec.Command("tmux", "-V").Output()
+		ctx, cancel := tmuxTimeoutContext()
+		defer cancel()
+		out, err := outputTmuxBoundedWith(ctx, cmd.MakeExecutor(), "-V")
 		if err != nil {
 			return
 		}

--- a/session/tmux/io.go
+++ b/session/tmux/io.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
-	"os/exec"
 	"strings"
 
 	"github.com/sachiniyer/agent-factory/log"
@@ -42,9 +41,19 @@ func (m *statusMonitor) hash(s string) []byte {
 // AutoYes (daemon poll) and the trust-prompt dismissal in
 // CheckAndHandleTrustPrompt. A missing session surfaces ErrSessionGone so
 // callers degrade gracefully instead of logging at ERROR (#510).
+//
+// Bounded by tmuxCommandTimeout (#2105): this runs on the daemon's unsupervised
+// per-second poll, which walks instances SEQUENTIALLY, so an unbounded stall here
+// freezes every later instance's status exactly like the capture it accompanies.
+// On a tripped deadline it returns ErrTmuxTimeout without probing ExistsOrUnknown
+// — see tmuxTimeoutContext.
 func (t *TmuxSession) TapEnter() error {
-	cmd := exec.Command("tmux", "send-keys", "-t", exactTarget(t.sanitizedName), "Enter")
-	if err := t.cmdExec.Run(cmd); err != nil {
+	ctx, cancel := tmuxTimeoutContext()
+	defer cancel()
+	if err := t.runTmuxBounded(ctx, "send-keys", "-t", exactTarget(t.sanitizedName), "Enter"); err != nil {
+		if ctx.Err() != nil {
+			return fmt.Errorf("%w: send-keys Enter after %s", ErrTmuxTimeout, tmuxCommandTimeout)
+		}
 		if !t.ExistsOrUnknown() {
 			return fmt.Errorf("%w: send-keys Enter", ErrSessionGone)
 		}
@@ -56,10 +65,15 @@ func (t *TmuxSession) TapEnter() error {
 // TapDAndEnter injects 'D' then Enter (the non-Claude trust/doc-dialog
 // dismissal) via a clientless `send-keys` command. "D" is the literal glyph and
 // "Enter" the named key — semantically identical to the old ptmx write of
-// {0x44, 0x0D}.
+// {0x44, 0x0D}. Bounded by tmuxCommandTimeout for the same reason as TapEnter
+// (#2105): it runs on the same unsupervised daemon poll.
 func (t *TmuxSession) TapDAndEnter() error {
-	cmd := exec.Command("tmux", "send-keys", "-t", exactTarget(t.sanitizedName), "D", "Enter")
-	if err := t.cmdExec.Run(cmd); err != nil {
+	ctx, cancel := tmuxTimeoutContext()
+	defer cancel()
+	if err := t.runTmuxBounded(ctx, "send-keys", "-t", exactTarget(t.sanitizedName), "D", "Enter"); err != nil {
+		if ctx.Err() != nil {
+			return fmt.Errorf("%w: send-keys D Enter after %s", ErrTmuxTimeout, tmuxCommandTimeout)
+		}
 		if !t.ExistsOrUnknown() {
 			return fmt.Errorf("%w: send-keys D Enter", ErrSessionGone)
 		}
@@ -85,9 +99,10 @@ func (t *TmuxSession) HasUpdated() (updated bool, hasPrompt bool, content string
 	// monitorMu guards the monitor pointer (swapped by Restore) and its
 	// dead/prevOutputHash fields (mutated here) against the data race #1528
 	// fixes. The lock is deliberately NOT held across CapturePaneContent: that
-	// runs an unbounded `tmux capture-pane`, and blocking Restore's setMonitor
-	// on a slow/hung tmux server would freeze detach/restore — worse than the
-	// race. So snapshot the live monitor under the lock, release it, run the
+	// runs a `tmux capture-pane` which — even bounded by tmuxCommandTimeout since
+	// #2105 — can still take that full deadline against a wedged server, and
+	// blocking Restore's setMonitor on it would freeze detach/restore for as long
+	// as the bound. So snapshot the live monitor under the lock, release it, run the
 	// tmux command lock-free, then re-acquire only to update the monitor's
 	// fields. Field writes land on the snapshotted monitor: if Restore swaps in
 	// a fresh one meanwhile, the stale monitor is discarded and updating it is a
@@ -156,28 +171,61 @@ func (t *TmuxSession) HasUpdated() (updated bool, hasPrompt bool, content string
 // is the SAFE direction here (#1962): a wedged→"exists" keeps the failure a
 // generic error, so a merely-slow server is never misread as ErrSessionGone —
 // the same asymmetry every send-keys/capture site in this package relies on.
+//
+// It passes context.Background(), so before #2105 it had no deadline whatsoever.
+// This is the daemon's per-second status-poll capture (via HasUpdated), and the
+// daemon polls instances SEQUENTIALLY with no watchdog, so a single wedged server
+// silently froze the status of every instance behind it — liveness tracking,
+// trust-prompt dismissal, AutoYes and the usage-limit detector (#1146) all stop.
+// CapturePaneContentContext now applies tmuxCommandTimeout regardless of the ctx
+// it is handed, which is what bounds this path; a tripped deadline surfaces as
+// ErrTmuxTimeout, never ErrSessionGone.
 func (t *TmuxSession) CapturePaneContent() (string, error) {
 	return t.CapturePaneContentContext(context.Background())
 }
 
-// CapturePaneContentContext is CapturePaneContent bound to ctx: the underlying
-// `tmux capture-pane` is launched with exec.CommandContext, so a cancelled or
-// deadline-exceeded ctx SIGKILLs the capture subprocess instead of letting it run
-// to completion. The readiness poll (task.WaitForReady) uses it so an abandoned
-// create tears down its in-flight capture — no lingering tmux subprocess or
-// goroutine after the caller gives up. On cancellation it returns ctx.Err()
-// directly, skipping the ExistsOrUnknown probe (which would spawn another tmux
-// subprocess) since the failure cause is the cancel, not a dead session.
+// CapturePaneContentContext is CapturePaneContent bound to ctx AND to the
+// package's own tmuxCommandTimeout, whichever fires first.
+//
+// The caller's ctx is honored as before: the readiness poll (task.WaitForReady)
+// passes a cancellable one so an abandoned create tears down its in-flight
+// capture, and cancellation returns ctx.Err() directly, skipping the
+// ExistsOrUnknown probe (which would spawn another tmux subprocess) since the
+// failure cause is the cancel, not a dead session.
+//
+// #2105 added the second, independent bound and moved the command onto
+// boundedTmuxCommand. Both halves were needed:
+//
+//   - A caller-supplied ctx is not a bound at all when the caller supplies
+//     context.Background(), which is exactly what CapturePaneContent does on the
+//     daemon's per-second status poll. Deriving our own timeout from ctx means
+//     that path is bounded no matter what the caller passes, while a caller with
+//     a SHORTER deadline still wins.
+//   - Plain exec.CommandContext sets no WaitDelay and kills only the direct
+//     process, so a child holding the inherited stdout pipe keeps Output()
+//     blocked on pipe EOF long after tmux is SIGKILLed — the deadline fires and
+//     buys nothing. boundedTmuxCommand's process-group kill plus tmuxWaitDelay is
+//     what actually makes a deadline bite.
+//
+// The two failures are reported distinctly and that distinction matters: a caller
+// cancel is a normal abandon (ctx.Err()), while a tripped internal deadline means
+// the SERVER is wedged and the session's state is UNKNOWN (ErrTmuxTimeout, never
+// ErrSessionGone — callers tear sessions down on "gone"). The parent is checked
+// first so a cancel racing the deadline is attributed to the caller.
 func (t *TmuxSession) CapturePaneContentContext(ctx context.Context) (string, error) {
 	// Add -e flag to preserve escape sequences (ANSI color codes). `=` forces
 	// an exact session match: without it tmux would prefix-match a surviving
 	// sibling session (e.g. the `__shell` tab) when the agent session has
 	// died, capturing the wrong pane and masking the dead agent (#1006).
-	cmd := exec.CommandContext(ctx, "tmux", "capture-pane", "-p", "-e", "-J", "-t", exactTarget(t.sanitizedName))
-	output, err := t.cmdExec.Output(cmd)
+	bctx, cancel := context.WithTimeout(ctx, tmuxCommandTimeout)
+	defer cancel()
+	output, err := t.outputTmuxBounded(bctx, "capture-pane", "-p", "-e", "-J", "-t", exactTarget(t.sanitizedName))
 	if err != nil {
 		if ctx.Err() != nil {
 			return "", ctx.Err()
+		}
+		if bctx.Err() != nil {
+			return "", fmt.Errorf("%w: capture-pane after %s", ErrTmuxTimeout, tmuxCommandTimeout)
 		}
 		if !t.ExistsOrUnknown() {
 			return "", fmt.Errorf("%w: capture-pane: %v", ErrSessionGone, err)
@@ -249,12 +297,20 @@ func (t *TmuxSession) CursorPosition() (row, col int, err error) {
 // CapturePaneContentWithOptions captures the pane content with additional options
 // start and end specify the starting and ending line numbers (use "-" for the start/end of history).
 // Wraps ErrSessionGone when the session has vanished, mirroring CapturePaneContent.
+//
+// Bounded by tmuxCommandTimeout (#2099): it was the last capture-pane read in the
+// package running on bare exec.Command. On a tripped deadline it returns
+// ErrTmuxTimeout without probing ExistsOrUnknown — see tmuxTimeoutContext.
 func (t *TmuxSession) CapturePaneContentWithOptions(start, end string) (string, error) {
 	// Add -e flag to preserve escape sequences (ANSI color codes). `=` forces
 	// an exact session match, mirroring CapturePaneContent (#1006).
-	cmd := exec.Command("tmux", "capture-pane", "-p", "-e", "-J", "-S", start, "-E", end, "-t", exactTarget(t.sanitizedName))
-	output, err := t.cmdExec.Output(cmd)
+	ctx, cancel := tmuxTimeoutContext()
+	defer cancel()
+	output, err := t.outputTmuxBounded(ctx, "capture-pane", "-p", "-e", "-J", "-S", start, "-E", end, "-t", exactTarget(t.sanitizedName))
 	if err != nil {
+		if ctx.Err() != nil {
+			return "", fmt.Errorf("%w: capture-pane options after %s", ErrTmuxTimeout, tmuxCommandTimeout)
+		}
 		if !t.ExistsOrUnknown() {
 			return "", fmt.Errorf("%w: capture-pane: %v", ErrSessionGone, err)
 		}

--- a/session/tmux/submit.go
+++ b/session/tmux/submit.go
@@ -1,9 +1,9 @@
 package tmux
 
 import (
+	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -143,9 +143,18 @@ func (t *TmuxSession) sendKeysPasteBuffer(text string) error {
 		}
 	}
 
-	loadCmd := exec.Command("tmux", "load-buffer", "-b", buf, "-")
-	loadCmd.Stdin = strings.NewReader(text)
-	if err := t.cmdExec.Run(loadCmd); err != nil {
+	// load-buffer streams the prompt in on stdin, so it needs the stdin-carrying
+	// bounded runner rather than the shared one — and deliberately does NOT treat
+	// exec.ErrWaitDelay as success, because a force-closed stdin pipe means the
+	// payload may be truncated. See runTmuxBoundedStdin.
+	loadCtx, loadCancel := tmuxTimeoutContext()
+	err := runTmuxBoundedStdin(loadCtx, t.cmdExec, strings.NewReader(text), "load-buffer", "-b", buf, "-")
+	loadTimedOut := loadCtx.Err() != nil
+	loadCancel()
+	if err != nil {
+		if loadTimedOut {
+			return fmt.Errorf("%w: load-buffer after %s", ErrTmuxTimeout, tmuxCommandTimeout)
+		}
 		return fmt.Errorf("error loading paste buffer: %w", err)
 	}
 
@@ -153,18 +162,27 @@ func (t *TmuxSession) sendKeysPasteBuffer(text string) error {
 	// comment: prompts are pasted DATA, never keystrokes), and `=` forces an
 	// exact session match so input never reaches a prefix-matched sibling
 	// session (#1006).
-	args := []string{"paste-buffer", "-d", "-p", "-b", buf, "-t", exactTarget(t.sanitizedName)}
-	pasteCmd := exec.Command("tmux", args...)
-	if err := t.cmdExec.Run(pasteCmd); err != nil {
+	pasteCtx, pasteCancel := tmuxTimeoutContext()
+	pasteErr := t.runTmuxBounded(pasteCtx, "paste-buffer", "-d", "-p", "-b", buf, "-t", exactTarget(t.sanitizedName))
+	pasteTimedOut := pasteCtx.Err() != nil
+	pasteCancel()
+	if pasteErr != nil {
 		// `-d` only deletes the buffer once the paste succeeds; a failed paste
 		// would otherwise strand the named buffer, and tmux buffers are
 		// server-scoped (they outlive the session), so each failed submit would
-		// leak one buffer unbounded. Best-effort delete it before returning.
-		delCmd := exec.Command("tmux", "delete-buffer", "-b", buf)
-		if derr := t.cmdExec.Run(delCmd); derr != nil {
+		// leak one buffer unbounded. Best-effort delete it before returning —
+		// bounded too, or the cleanup for a wedge-failed paste would itself wedge
+		// on the same server and undo the bound we just added.
+		delCtx, delCancel := tmuxTimeoutContext()
+		derr := t.runTmuxBounded(delCtx, "delete-buffer", "-b", buf)
+		delCancel()
+		if derr != nil {
 			log.ErrorLog.Printf("failed to delete paste buffer %q after paste error: %v", buf, derr)
 		}
-		return fmt.Errorf("error pasting buffer: %w", err)
+		if pasteTimedOut {
+			return fmt.Errorf("%w: paste-buffer after %s", ErrTmuxTimeout, tmuxCommandTimeout)
+		}
+		return fmt.Errorf("error pasting buffer: %w", pasteErr)
 	}
 
 	// Confirm the paste actually LANDED in the pane before sending Enter, instead
@@ -199,10 +217,20 @@ func (t *TmuxSession) sendKeysPasteBuffer(text string) error {
 	return nil
 }
 
-// sendEnter submits whatever is pending in the pane.
+// sendEnter submits whatever is pending in the pane. Bounded by
+// tmuxCommandTimeout (#2099): it is the last step of a submit the daemon drives
+// while holding the per-session op lock, so an unbounded stall here leaves the
+// session unpromptable rather than merely dropping one Enter.
 func (t *TmuxSession) sendEnter() error {
-	enterCmd := exec.Command("tmux", "send-keys", "-t", exactTarget(t.sanitizedName), "Enter")
-	return t.cmdExec.Run(enterCmd)
+	ctx, cancel := tmuxTimeoutContext()
+	defer cancel()
+	if err := t.runTmuxBounded(ctx, "send-keys", "-t", exactTarget(t.sanitizedName), "Enter"); err != nil {
+		if ctx.Err() != nil {
+			return fmt.Errorf("%w: send-keys Enter after %s", ErrTmuxTimeout, tmuxCommandTimeout)
+		}
+		return err
+	}
+	return nil
 }
 
 // deliveryTail returns a distinctive whitespace/box-free suffix of text used to
@@ -250,10 +278,39 @@ func normalizeDelivery(s string) string {
 // The bool reports whether the capture itself SUCCEEDED. Callers must keep that
 // separate from "the text was not there": a failed capture means the pane could
 // not be inspected at all, and collapsing that into a negative would let a
-// blind probe condemn a perfectly good delivery.
+// blind probe condemn a perfectly good delivery. A capture killed on a deadline
+// is exactly such a failure, so a wedged server yields false — never a negative.
+//
+// This form is for callers with no deadline of their own and takes the package's
+// standard tmuxCommandTimeout; waitForPasteDelivered's poll loop uses
+// capturePaneForDeliveryWithin instead. Both were unbounded before #2099.
 func (t *TmuxSession) capturePaneForDelivery() (string, bool) {
-	cmd := exec.Command("tmux", "capture-pane", "-p", "-J", "-t", exactTarget(t.sanitizedName))
-	out, err := t.cmdExec.Output(cmd)
+	ctx, cancel := tmuxTimeoutContext()
+	defer cancel()
+	return t.capturePaneForDeliveryContext(ctx)
+}
+
+// capturePaneForDeliveryWithin is capturePaneForDelivery bounded by a caller's
+// own REMAINING budget rather than the flat tmuxCommandTimeout.
+//
+// This is what makes waitForPasteDelivered actually honor pasteDeliveryMaxWait
+// (#2099). The loop's whole budget is 2s; bounding the capture inside it at
+// tmuxCommandTimeout (10s) would let ONE stalled capture overshoot that budget 5x
+// and leave the loop's own `time.Now().After(deadline)` check — the code that
+// decides to stop waiting and send Enter best-effort — unreachable for the whole
+// 10s. Fixing the hang without this would only half-fix the reported bug: the
+// call would return eventually, but the deadline it is supposed to respect still
+// would not hold.
+func (t *TmuxSession) capturePaneForDeliveryWithin(budget time.Duration) (string, bool) {
+	ctx, cancel := tmuxTimeoutContextWithin(budget)
+	defer cancel()
+	return t.capturePaneForDeliveryContext(ctx)
+}
+
+// capturePaneForDeliveryContext is the shared body: one bounded capture-pane,
+// with any failure (including a tripped deadline) reported as "could not look".
+func (t *TmuxSession) capturePaneForDeliveryContext(ctx context.Context) (string, bool) {
+	out, err := t.outputTmuxBounded(ctx, "capture-pane", "-p", "-J", "-t", exactTarget(t.sanitizedName))
 	if err != nil {
 		return "", false
 	}
@@ -282,7 +339,9 @@ func (t *TmuxSession) waitForPasteDelivered(tail string, baseline int) deliveryO
 		needed = 2
 	}
 	for {
-		if content, ok := t.capturePaneForDelivery(); ok {
+		// Bound each capture by what is LEFT of this loop's budget, so a wedged
+		// server cannot push a single capture past the deadline below (#2099).
+		if content, ok := t.capturePaneForDeliveryWithin(time.Until(deadline)); ok {
 			sawCapture = true
 			if strings.Count(normalizeDelivery(content), tail) > baseline {
 				streak++


### PR DESCRIPTION
Fixes #2099
Fixes #2105

Both issues are the same root cause, so they are fixed together: tmux commands on the **capture and poll** paths were never bounded by a deadline, so a wedged tmux server hung the caller forever.

## What was unbounded, and why it hangs

`exec.Command(...).Output()` blocks until the `tmux` subprocess completes. A wedged tmux server (stuck under load, blocked on a stalled pane, hung on its socket) parks the tmux *client* forever, and the Go caller blocks with it. #1787 and #1917 bounded the WS and teardown paths; the capture paths were left behind.

| Issue | Site | Why it matters |
|---|---|---|
| #2105 | `io.go:160` `CapturePaneContent()` → `CapturePaneContentContext(context.Background())` | Runs on the daemon's **unsupervised per-second status poll** via `HasUpdated`. The daemon polls instances **sequentially** (`manager_status.go:255-257`) with no watchdog, so one wedged session silently froze the status of every instance behind it — liveness tracking, trust-prompt dismissal, AutoYes, and the usage-limit detector (#1146) all stop. |
| #2099 | `io.go:255` `CapturePaneContentWithOptions()` | Bare `exec.Command`; behind Preview/Snapshot. |
| #2099 | `submit.go:255` `capturePaneForDelivery()` | Bare `exec.Command`, inside a poll loop whose `pasteDeliveryMaxWait` check was therefore unreachable. Runs under the daemon's per-session op lock. |

## Fail-first evidence (verbatim, pre-fix)

Tests were written first and run against unfixed code. **Every** named site reproduced as a real hang — all 12 assertions hit their 30s guard:

```
--- FAIL: TestCaptureAndPollTmuxCommandsDoNotHang (150.08s)
    --- FAIL: TestCaptureAndPollTmuxCommandsDoNotHang/CapturePaneContent (30.02s)
        capture_wedge_test.go:102: CapturePaneContent hung against a stalled tmux (#2099/#2105): no return within 30s — the daemon polls instances sequentially, so this stalls every later instance's status
    --- FAIL: TestCaptureAndPollTmuxCommandsDoNotHang/CapturePaneContentContext (30.01s)
        capture_wedge_test.go:102: CapturePaneContentContext hung against a stalled tmux (#2099/#2105): no return within 30s — the daemon polls instances sequentially, so this stalls every later instance's status
    --- FAIL: TestCaptureAndPollTmuxCommandsDoNotHang/CapturePaneContentWithOptions (30.03s)
        capture_wedge_test.go:102: CapturePaneContentWithOptions hung against a stalled tmux (#2099/#2105): no return within 30s — the daemon polls instances sequentially, so this stalls every later instance's status
    --- FAIL: TestCaptureAndPollTmuxCommandsDoNotHang/TapEnter (30.01s)
        capture_wedge_test.go:102: TapEnter hung against a stalled tmux (#2099/#2105): no return within 30s — the daemon polls instances sequentially, so this stalls every later instance's status
    --- FAIL: TestCaptureAndPollTmuxCommandsDoNotHang/TapDAndEnter (30.01s)
        capture_wedge_test.go:102: TapDAndEnter hung against a stalled tmux (#2099/#2105): no return within 30s — the daemon polls instances sequentially, so this stalls every later instance's status
--- FAIL: TestHasUpdatedDoesNotHangOnWedgedServer (30.03s)
    capture_wedge_test.go:138: HasUpdated hung against a stalled tmux (#2105): this runs on the daemon's unsupervised per-second poll, which polls instances sequentially
--- FAIL: TestCapturePaneContentContextHonorsCallerCancellation (30.13s)
    capture_wedge_test.go:181: CapturePaneContentContext ignored the caller's cancellation — an abandoned create would hold the per-repo start lock across the whole capture
--- FAIL: TestSubmitPathDoesNotHangOnWedgedServer (30.03s)
    capture_wedge_test.go:210: SendKeysCommand hung against a stalled tmux (#2099): the submit path runs under the daemon's per-session op lock, so the session becomes unpromptable
--- FAIL: TestPasteDeliveryLoopHonorsItsOwnBudget (30.02s)
    capture_wedge_test.go:256: waitForPasteDelivered hung against a stalled tmux (#2099): the capture inside its poll loop is unbounded, so the loop's deadline check never runs
--- FAIL: TestPaneTailForLogDoesNotHangOnWedgedServer (30.00s)
    capture_wedge_test.go:280: paneTailForLog hung against a stalled tmux (#2099): it calls capturePaneForDelivery outside the poll loop, with no deadline of its own
--- FAIL: TestCleanupSessionsDoesNotHangOnWedgedServer (30.00s)
    capture_wedge_test.go:302: CleanupSessions hung against a stalled tmux: `af reset` runs it synchronously
--- FAIL: TestSessionHomeMarkerDoesNotHangOnWedgedServer (30.00s)
    capture_wedge_test.go:331: sessionHomeMarker hung against a stalled tmux: CleanupSessions calls it once per discovered session, so one wedge stalls the whole sweep
FAIL
FAIL	github.com/sachiniyer/agent-factory/session/tmux	370.848s
```

Post-fix, same invocation: `ok github.com/sachiniyer/agent-factory/session/tmux 13.175s`. **370s of hangs → 13s.**

Nothing failed to reproduce. The one site I am *not* claiming a reproduced server-wedge for is `tmux -V` — see the audit table.

The tests drive a **real fake `tmux` on PATH that sleeps in a child process** (`stallingTmuxOnPath`), never a blocking `MockCmdExec`. That is load-bearing, per `kill_wedge_test.go`'s own header: a mock's func blocks the *calling goroutine*, which no context deadline can reach, so it would fail identically before and after the fix and prove nothing. Sleeping in a child additionally proves the process-group kill and `tmuxWaitDelay` work.

## Subtlety (a): the delivery capture must honor the *loop's* budget, not a flat 10s

The issue's suggested patch uses `tmuxTimeoutContext()` (10s) for `capturePaneForDelivery`. That only half-fixes the reported bug. `capturePaneForDelivery` is called from `waitForPasteDelivered`'s poll loop whose **entire** budget is `pasteDeliveryMaxWait = 2s`. A 10s bound lets **one** capture overshoot that budget 5x, and the loop's own `time.Now().After(deadline)` check — the code that decides to stop waiting and send Enter best-effort — stays unreachable for the whole 10s. The call would return eventually, but the deadline it exists to respect still would not hold.

Handled with a ctx-taking inner form plus two thin wrappers:

- `capturePaneForDeliveryContext(ctx)` — shared body.
- `capturePaneForDeliveryWithin(budget)` — new `tmuxTimeoutContextWithin` bounds each capture by `min(remaining loop budget, tmuxCommandTimeout)`. Used by the poll loop.
- `capturePaneForDelivery()` — flat `tmuxCommandTimeout`, for `paneTailForLog`, which is called **outside** the loop and has no deadline of its own.

`TestPasteDeliveryLoopHonorsItsOwnBudget` pins this specifically: it sets `pasteDeliveryMaxWait` to 300ms and `tmuxCommandTimeout` to 3s, so an implementation that bounds the capture at `tmuxCommandTimeout` lands at ~3s and fails the assertion, while the correct one lands at ~300ms.

## Subtlety (b): a deadline alone is not a bound

`CapturePaneContentContext` already used `exec.CommandContext`, but plain `exec.CommandContext` sets no `WaitDelay` and kills only the direct process. A child that inherited the stdout pipe keeps `Output()` blocked on pipe EOF even after tmux is SIGKILLed — the deadline fires and buys nothing. That is exactly why `boundedTmuxCommand` (setpgid + group SIGKILL + `tmuxWaitDelay`) exists.

It is now routed through `boundedTmuxCommand`, with its timeout **derived** from the caller's ctx (`context.WithTimeout(ctx, tmuxCommandTimeout)`) rather than replacing it. That preserves the existing contract in both directions:

- A caller with a shorter deadline still wins, and `task.WaitForReady`'s cancellation still tears the in-flight capture down (pinned by the existing `task/amp_ready_test.go` tests, still green).
- The two failure modes are distinguished and reported differently: the **parent** ctx is checked first, so a caller cancel returns `ctx.Err()`; only if the parent is fine and the derived ctx expired does it return `ErrTmuxTimeout`. Checking the parent first also attributes a cancel racing the deadline to the caller. `TestCapturePaneContentContextHonorsCallerCancellation` pins this with a deliberately long (30s) internal bound, so it can only pass if the caller's cancel is genuinely threaded through.

This is also what bounds `CapturePaneContent()`, which passes `context.Background()` — that path is now bounded regardless of what the caller supplies.

## Adjacent audit

| # | Site | Disposition |
|---|---|---|
| 1 | `io.go:160` `CapturePaneContent` | **Bounded** — inherits the derived bound from `CapturePaneContentContext`. #2105 headline. |
| 2 | `io.go:255` `CapturePaneContentWithOptions` | **Bounded** — `tmuxTimeoutContext` + `outputTmuxBounded`. #2099. |
| 3 | `submit.go:255` `capturePaneForDelivery` | **Bounded** — per-loop budget, see subtlety (a). #2099. |
| 4 | `io.go:46` `TapEnter` | **Bounded** — same unsupervised daemon poll as `HasUpdated`, so a stall freezes it identically. #2105 recommends this. |
| 5 | `io.go:61` `TapDAndEnter` | **Bounded** — same. |
| 6 | `submit.go:204` `sendEnter` | **Bounded** — last step of a submit the daemon drives under the per-session op lock; a stall leaves the session unpromptable. |
| 7 | `submit.go:157` `paste-buffer` | **Bounded**. |
| 8 | `submit.go:163` `delete-buffer` | **Bounded** — this is the *cleanup* for a failed paste, so leaving it unbounded would let the cleanup for a wedge-failed paste wedge on the same server and undo the bound. |
| 9 | `submit.go:146` `load-buffer -b <buf> -` (**has `.Stdin`**) | **Bounded, via a purpose-built helper.** See below — not half-done. |
| 10a | `envmarker.go:59` `show-environment` | **Bounded** — `CleanupSessions` calls it once per discovered session, so one wedge stalls the whole sweep. A tripped deadline reports "no marker", the safe direction: the sweep leaves any session it cannot *prove* this home owns (#1122). |
| 10b | `envmarker.go:78` `tmux -V` | **Bounded, but flagged as defensive, not reproduced.** `tmux -V` is answered by the *client* and never contacts the server, so a wedged **server** cannot stall it — only a hanging tmux **binary** (wrapper script, stalled NFS) can. It hangs under the test's fake tmux, but I am not claiming a real server-wedge repro. Bounded anyway because it sits behind a `sync.Once` on the session-create path: one hang would wedge session creation for the whole process lifetime, with every later caller blocking on the `Once` rather than retrying. Three lines for that blast radius is worth it. |
| 11a | `cleanup.go:141` `tmux ls` | **Bounded** — first command of the sweep; `af reset` runs it synchronously in a short-lived CLI process, so a stall is a user-visible hang with no way out but ^C. A timeout **aborts** the sweep rather than proceeding on an empty list, which would otherwise read as "nothing to clean up" and report success for a reset that swept nothing. |
| 11b | `cleanup.go:198` `kill-session` | **Bounded** — and on a tripped deadline it does **not** fall back to the `sessionExists` probe (see the invariant section). |
| — | `start.go:34` `new-session` | **Scoped out, deliberately.** Not a control command: it is handed to the `PtyFactory` as the session's own long-lived process, and its lifetime is managed by the ptmx, not a deadline. Documented as the one exception in `bounded.go`. |

### On #9, `load-buffer` with stdin

This is the package's only tmux command that *streams a payload in*, and the shared helpers take no stdin. It gets a new `runTmuxBoundedStdin`, which differs from `runTmuxBounded` in one deliberate way: **it does not normalize `exec.ErrWaitDelay` to success.**

`exec` copies a non-`*os.File` stdin to the child through an OS pipe on a background goroutine, and `WaitDelay` force-closes that pipe when it elapses (#856/#896) — which is what keeps a killed tmux from stranding the copier, but it also means an unknown **prefix** of the payload may be all that landed. For the output-discarding control commands, normalizing to success is right: tmux exited cleanly and only a pipe-holding child lingered (#676/#914). For `load-buffer` it would claim a prompt was loaded when it was truncated, and the paste that follows would submit the mangled remainder **while still reporting success** — the silent prompt-corruption class of #1982, which is strictly worse than the hang this bound removes. So the error propagates and the submit fails loudly.

`TestLoadBufferStdinSurvivesTheBoundedPath` guards the healthy direction: it drives a fake tmux that dumps `load-buffer`'s stdin to a file and asserts a 20KB prompt arrives byte-for-byte, so a bound that truncates the payload fails.

## `ErrTmuxTimeout` ≠ `ErrSessionGone` — invariant preserved

A tripped deadline means the tmux server is wedged and the session's real state is **UNKNOWN**. Callers act destructively on "gone" (the daemon marks the instance Lost and reaps its process trees), so misreporting a wedged server as gone would tear down a live agent. Confirmed at every site touched:

- Every timeout path checks `ctx.Err()` **before** any `ExistsOrUnknown()` / `sessionExists()` fallback and returns `ErrTmuxTimeout` instead. The probe would spawn another tmux command against the same wedged server and hang identically, buying nothing — the rule `tmuxTimeoutContext`'s doc comment states, and the way `CaptureVisiblePaneGrid` and `Close` already behave.
- `TestCaptureAndPollTmuxCommandsDoNotHang` asserts `errors.Is(err, ErrTmuxTimeout) && !errors.Is(err, ErrSessionGone)` on every entry point.
- `TestHasUpdatedDoesNotHangOnWedgedServer` additionally asserts the status monitor does **not** latch itself `dead` on a timeout. That latch is reserved for a confirmed-gone session (#489) and is permanent until respawn, so latching on a wedge would silence a merely-slow session's status forever.
- `TestSessionHomeMarkerDoesNotHangOnWedgedServer` asserts a wedged server is never read as proof of ownership.
- `CleanupSessions`' `kill-session` timeout path reports the wedge and stops rather than probing.

One consequence worth naming: `HasUpdated` on a persistently wedged server now logs a capture error per poll instead of hanging silently. Each poll costs the full bound, so that is roughly one line per 10s per instance — diagnostic signal for exactly the condition, and well short of the #489 flood the `dead` latch exists to prevent.

## Doc comment corrected

`bounded.go` asserted outright that *"Every tmux command in this package is now bounded; new ones must be too."* while three capture paths were not — a false claim that was load-bearing enough that later code trusted it instead of checking. These bugs are regressions against a stated invariant. The comment now records what #2099/#2105 closed and states the invariant as an **obligation** rather than a fact, naming the wedge tests (`bounded_test.go`, `kill_wedge_test.go`, `capture_wedge_test.go`) that hold new commands to it, plus the one deliberate exception (`start.go`'s `new-session`).

## Gates

- `gofmt -l .` — no output
- `go build ./...` — clean
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — no output
- `scripts/lint-file-length.sh` — passed (808 files, 0 grandfathered)
- `make test-container` — **full suite green**, including `task` (the `WaitForReady` ctx-contract tests that pin subtlety (b)'s preserved behavior) and `session/tmux`

— Captain Claude
