### PR TITLE
fix(task): scope the TUI task pane by repo identity, not raw path

### DIFF
--- a/api/scope.go
+++ b/api/scope.go
@@ -129,85 +129,35 @@ func (s projectScope) matchesTask(t *task.Task, ids *projectIDCache) bool {
 	return ids.idFor(t.ProjectPath) == s.Repo.ID
 }
 
-// resolvedProject is a project path resolved to its owning repository. root is
-// "" when nothing could be resolved, which is what makes an invented identity
-// distinguishable from a real one.
-type resolvedProject struct {
-	id   string
-	root string
-}
-
 // projectIDCache memoizes path→repo resolution for one command invocation.
-// config.RepoFromPath shells out to git, and a scoped list resolves every
+// config.ResolveProjectPath shells out to git, and a scoped list resolves every
 // task's project, so without this a list of N tasks costs N git invocations —
 // most of them for the same handful of paths.
+//
+// The resolution rule itself lives in config.ResolveProjectPath, shared with the
+// TUI task pane's repo filter (#2098). Retaining the id at bind time
+// (task.Task.RepoID) is the durable fix and takes precedence; resolution is the
+// fallback for rows written before that field, and for paths that never
+// resolved.
 type projectIDCache struct {
-	resolved map[string]resolvedProject
+	resolved map[string]config.ResolvedProject
 }
 
 func newProjectIDCache() *projectIDCache {
-	return &projectIDCache{resolved: map[string]resolvedProject{}}
+	return &projectIDCache{resolved: map[string]config.ResolvedProject{}}
 }
 
 func (c *projectIDCache) idFor(projectPath string) string {
-	return c.resolve(projectPath).id
+	return c.resolve(projectPath).ID
 }
 
-// resolve maps a recorded project path to its owning repository.
-//
-// An EXISTING path — including a subdirectory or a linked worktree — resolves
-// through git to the main repo root, which is why identity matching (rather than
-// path-string equality) sees TUI-created tasks in their own project.
-//
-// A path that no longer exists is the hard case. Hashing the stale leaf, as this
-// used to, invents an ID that equals nothing: the surviving project's ID is
-// sha256 of ITS root, never of a deleted child. That stranded the task — hidden
-// from its project's list, refused by every id-taking command, and the --repo we
-// suggested could not resolve either. So walk up to the nearest ANCESTOR that
-// still resolves: a deleted subdirectory of a surviving project resolves back to
-// that project, which is the reported case (#1893 review).
-//
-// The walk answers what git itself would say about the path if it existed, so it
-// cannot be more wrong than the path is. When nothing up the chain resolves,
-// fall back to the leaf hash — path equality, which at least keeps an orphan
-// addressable in its own recorded path — and report root "" so callers can tell
-// this identity is derived rather than real.
-//
-// Retaining the id at bind time (task.Task.RepoID) is the durable fix and takes
-// precedence; this path is the fallback for rows written before that field, and
-// for paths that never resolved.
-func (c *projectIDCache) resolve(projectPath string) resolvedProject {
+func (c *projectIDCache) resolve(projectPath string) config.ResolvedProject {
 	if got, ok := c.resolved[projectPath]; ok {
 		return got
 	}
-	got := resolveProjectPath(projectPath)
+	got := config.ResolveProjectPath(projectPath)
 	c.resolved[projectPath] = got
 	return got
-}
-
-func resolveProjectPath(projectPath string) resolvedProject {
-	if repo, err := config.RepoFromPath(projectPath); err == nil {
-		return resolvedProject{id: repo.ID, root: repo.Root}
-	}
-	cleaned := filepath.Clean(projectPath)
-	// Only walk an ABSOLUTE path. A relative one has no meaning independent of
-	// the current directory, so climbing it reaches "." and resolves to whatever
-	// repository the caller happens to be standing in — adopting a task into the
-	// current project on no evidence at all. That is the same invented identity
-	// the leaf hash produced, just harder to spot, so a relative path degrades to
-	// path equality instead. No supported writer records one (the CLI stores
-	// repo.Root, the TUI an absolute path), so this only guards hand-edited rows.
-	if filepath.IsAbs(cleaned) {
-		for dir := filepath.Dir(cleaned); ; dir = filepath.Dir(dir) {
-			if repo, err := config.RepoFromPath(dir); err == nil {
-				return resolvedProject{id: repo.ID, root: repo.Root}
-			}
-			if parent := filepath.Dir(dir); parent == dir {
-				break // reached the filesystem root
-			}
-		}
-	}
-	return resolvedProject{id: config.RepoIDFromRoot(cleaned)}
 }
 
 // sessionRepoRoot derives the root of the project a session belongs to FROM THE
@@ -245,7 +195,7 @@ func requireTaskInScope(t *task.Task, scope projectScope) error {
 	// Suggest a --repo that RESOLVES. The recorded path may be a subdirectory
 	// that no longer exists, and telling a user to pass a path we would reject
 	// is worse than not suggesting one: it reads as a fix and cannot work.
-	suggest := ids.resolve(t.ProjectPath).root
+	suggest := ids.resolve(t.ProjectPath).Root
 	if suggest == "" {
 		suggest = t.ProjectPath
 	}

--- a/config/repo.go
+++ b/config/repo.go
@@ -145,3 +145,60 @@ func repoContextFromRoot(root string) *RepoContext {
 		ID:   RepoIDFromRoot(root),
 	}
 }
+
+// ResolvedProject is a recorded project path resolved to its owning repository.
+// Root is "" when nothing could be resolved, which is what makes an invented
+// identity distinguishable from a real one.
+type ResolvedProject struct {
+	ID   string
+	Root string
+}
+
+// ResolveProjectPath maps a recorded project path to its owning repository.
+//
+// An EXISTING path — including a subdirectory or a linked worktree — resolves
+// through git to the main repo root, which is why identity matching (rather
+// than path-string equality) sees a task in its own project no matter which
+// directory it was created from.
+//
+// A path that no longer exists is the hard case. Hashing the stale leaf invents
+// an ID that equals nothing: the surviving project's ID is sha256 of ITS root,
+// never of a deleted child. That strands the record — hidden from its project
+// and unaddressable. So walk up to the nearest ANCESTOR that still resolves: a
+// deleted subdirectory of a surviving project resolves back to that project.
+//
+// The walk answers what git itself would say about the path if it existed, so
+// it cannot be more wrong than the path is. When nothing up the chain resolves,
+// fall back to the leaf hash — path equality, which at least keeps an orphan
+// addressable at its own recorded path — and report Root "" so callers can tell
+// this identity is derived rather than real.
+//
+// This is the ONE path→project-identity mechanism. It backs both the CLI's
+// project scoping (api/scope.go, #1893) and the TUI task pane's repo filter
+// (task.LoadTasksForRepo, #2098); they were separate rules until the latter's
+// raw path equality hid subdirectory-created tasks from their own pane.
+func ResolveProjectPath(projectPath string) ResolvedProject {
+	if repo, err := RepoFromPath(projectPath); err == nil {
+		return ResolvedProject{ID: repo.ID, Root: repo.Root}
+	}
+	cleaned := filepath.Clean(projectPath)
+	// Only walk an ABSOLUTE path. A relative one has no meaning independent of
+	// the current directory, so climbing it reaches "." and resolves to whatever
+	// repository the caller happens to be standing in — adopting a record into
+	// the current project on no evidence at all. That is the same invented
+	// identity the leaf hash produced, just harder to spot, so a relative path
+	// degrades to path equality instead. No supported writer records one (the
+	// CLI stores repo.Root, the TUI an absolute path), so this only guards
+	// hand-edited rows.
+	if filepath.IsAbs(cleaned) {
+		for dir := filepath.Dir(cleaned); ; dir = filepath.Dir(dir) {
+			if repo, err := RepoFromPath(dir); err == nil {
+				return ResolvedProject{ID: repo.ID, Root: repo.Root}
+			}
+			if parent := filepath.Dir(dir); parent == dir {
+				break // reached the filesystem root
+			}
+		}
+	}
+	return ResolvedProject{ID: RepoIDFromRoot(cleaned)}
+}

--- a/task/repo_scope.go
+++ b/task/repo_scope.go
@@ -1,0 +1,113 @@
+package task
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+// This file holds the repo filter behind the TUI task pane (#2098).
+//
+// A task records the project path it was BOUND to, which is not necessarily the
+// project's root: the TUI stores the absolute path the user typed or defaulted
+// to, so creating a task from `repo/some/subdir` records that subdirectory. git
+// resolves any subdirectory — and any linked worktree — back to the same
+// top-level, but string comparison of raw paths does not, so raw equality hid
+// those tasks from their own project's pane while `af tasks list` showed them
+// fine. That divergence is the bug: the CLI had already moved to repo-identity
+// matching (#1893, api/scope.go) and the pane's loader had not.
+//
+// Both sides are therefore reduced to the same canonical form — the repo ID,
+// sha256 of the main-worktree root — before comparing, exactly as the CLI does.
+
+// repoScope answers "does this task belong to repoRoot?" for one load.
+//
+// It resolves at most once per distinct project path per load, and prefers
+// answers that cost no git at all: this runs on the TUI's snapshot poll
+// (app/sync.go, every 750ms), so a filter that shelled out per task per tick
+// would burn subprocesses continuously on an otherwise idle TUI.
+type repoScope struct {
+	root string
+	id   string
+	// seen memoizes resolution within this load. The process-level cache below
+	// carries positives ACROSS loads, which is what keeps the poll cheap.
+	seen map[string]string
+}
+
+// newRepoScope canonicalizes the target side.
+//
+// repoRoot is contractually a main-worktree root (config.CurrentRepo /
+// RepoFromPath), which every caller passes, so hashing it directly yields the
+// same canonical ID the task side resolves to — no git call needed for the
+// common path. A caller that passes something else degrades to the raw path
+// equality this filter used before, never to "no tasks".
+func newRepoScope(repoRoot string) *repoScope {
+	return &repoScope{
+		root: repoRoot,
+		id:   config.RepoIDFromRoot(repoRoot),
+		seen: map[string]string{},
+	}
+}
+
+// matches reports whether t belongs to this scope.
+func (s *repoScope) matches(t Task) bool {
+	// The RETAINED id wins when present: it was resolved at bind time, while the
+	// recorded path was known to resolve, so it survives that path being deleted
+	// or moved. Re-deriving would be strictly worse information — and it is free.
+	if t.RepoID != "" {
+		return t.RepoID == s.id
+	}
+	// An unbound task belongs to no project, so no project's pane claims it.
+	// This deliberately diverges from api/scope.go, which matches an unbound task
+	// into EVERY scope so it stays deletable: reachability is the CLI's job, and
+	// duplicating one orphan into every project's pane is noise, not a fix. No
+	// supported writer creates one (see Task.ProjectPath).
+	if strings.TrimSpace(t.ProjectPath) == "" {
+		return false
+	}
+	// Exact match short-circuits the git resolution for every task created from
+	// the repo root — the majority, and the case that already worked.
+	if t.ProjectPath == s.root {
+		return true
+	}
+	return s.resolve(t.ProjectPath) == s.id
+}
+
+func (s *repoScope) resolve(projectPath string) string {
+	if got, ok := s.seen[projectPath]; ok {
+		return got
+	}
+	id := resolveProjectID(projectPath)
+	s.seen[projectPath] = id
+	return id
+}
+
+// projectIDMemo caches path→repo-ID resolutions that RESOLVED to a real
+// repository, for the life of the process.
+//
+// Only rows written before Task.RepoID existed reach resolution at all, but for
+// those the TUI's 750ms poll would otherwise re-run `git rev-parse` per task
+// forever — they are never rewritten, so they never pick the field up.
+//
+// Only positives are cached, and only real ones. A path that does not resolve
+// today may resolve tomorrow (the user creates the subdirectory, or adds the
+// worktree, after binding the task), and caching that miss would pin the task to
+// the wrong scope for the whole session; re-resolving a miss costs a git call on
+// a row that is rare by construction. A cached positive can go stale only if the
+// project is moved or deleted mid-session, which mis-scopes a displayed list
+// until restart and destroys nothing.
+var projectIDMemo sync.Map // map[string]string
+
+func resolveProjectID(projectPath string) string {
+	if cached, ok := projectIDMemo.Load(projectPath); ok {
+		return cached.(string)
+	}
+	resolved := config.ResolveProjectPath(projectPath)
+	// Root == "" means the ID was DERIVED from the path rather than read off a
+	// real repository — the negative case, which is not cached.
+	if resolved.Root != "" {
+		projectIDMemo.Store(projectPath, resolved.ID)
+	}
+	return resolved.ID
+}

--- a/task/repo_scope_test.go
+++ b/task/repo_scope_test.go
@@ -1,0 +1,176 @@
+package task
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These pin #2098: the TUI task pane loads through LoadTasksForRepo, which used
+// raw path equality (`t.ProjectPath == repoRoot`). A task created from a
+// SUBDIRECTORY of the repo records that subdirectory as its ProjectPath, so it
+// never string-matched the repo root and was invisible in its own project's
+// pane — while the same task listed fine under `af tasks list`, which had
+// already moved to repo-identity matching (#1893, api/scope.go).
+
+// mkScopeRepo creates a throwaway git repository and returns its root, resolved
+// through symlinks so it compares equal to what git reports from inside it (on
+// macOS t.TempDir() hands back a /var → /private/var symlink).
+func mkScopeRepo(t *testing.T, name string) string {
+	t.Helper()
+	repo := filepath.Join(t.TempDir(), name)
+	require.NoError(t, exec.Command("git", "init", repo).Run(), "git init %s", name)
+	real, err := filepath.EvalSymlinks(repo)
+	require.NoError(t, err)
+	return real
+}
+
+// TestLoadTasksForRepo_SubdirectoryProjectPath is the headline #2098 repro: a
+// task bound to `<repo>/some/subdir` belongs to `<repo>`, because git resolves
+// any subdirectory to the same top-level. The legacy row (no RepoID) is the
+// one that regressed — it forces the git resolution fallback.
+func TestLoadTasksForRepo_SubdirectoryProjectPath(t *testing.T) {
+	repo := mkScopeRepo(t, "project")
+	subdir := filepath.Join(repo, "some", "subdir")
+	require.NoError(t, exec.Command("mkdir", "-p", subdir).Run())
+
+	setupTestTasks(t, []Task{
+		{ID: "root0001", Name: "from-root", Prompt: "p", CronExpr: "0 * * * *", ProjectPath: repo, Program: "claude", Enabled: true, CreatedAt: time.Now()},
+		{ID: "subd0001", Name: "from-subdir", Prompt: "p", CronExpr: "0 * * * *", ProjectPath: subdir, Program: "claude", Enabled: true, CreatedAt: time.Now()},
+	})
+
+	got, err := LoadTasksForRepo(repo)
+	require.NoError(t, err)
+
+	var names []string
+	for _, tk := range got {
+		names = append(names, tk.Name)
+	}
+	assert.ElementsMatch(t, []string{"from-root", "from-subdir"}, names,
+		"a task created from a subdirectory of the repo must appear in that repo's pane (#2098)")
+}
+
+// TestLoadTasksForCurrentRepo_CreatedFromSubdirectory is the user's story end to
+// end: the TUI task form prefills its project path from os.Getwd()
+// (ui/task_pane.go EnterCreateMode), so a user standing in `repo/some/subdir`
+// creates a task bound to that subdirectory — and then the pane, which loads
+// through LoadTasksForCurrentRepo, must show it. AddTask is the real writer, so
+// this also pins that the bind-time RepoID it stamps resolves to the project.
+func TestLoadTasksForCurrentRepo_CreatedFromSubdirectory(t *testing.T) {
+	repo := mkScopeRepo(t, "project")
+	subdir := filepath.Join(repo, "some", "subdir")
+	require.NoError(t, exec.Command("mkdir", "-p", subdir).Run())
+	setupTestTasks(t, []Task{})
+
+	t.Chdir(subdir)
+	require.NoError(t, AddTask(Task{
+		ID: "subd0002", Name: "from-subdir", Prompt: "p", CronExpr: "0 * * * *",
+		ProjectPath: subdir, Program: "claude", Enabled: true, CreatedAt: time.Now(),
+	}))
+
+	got, err := LoadTasksForCurrentRepo()
+	require.NoError(t, err)
+	require.Len(t, got, 1, "a task created from a subdirectory must show in its own project's pane (#2098)")
+	assert.Equal(t, "from-subdir", got[0].Name)
+}
+
+// TestLoadTasksForRepo_OtherRepoStillExcluded is the over-listing guard: widening
+// the match to repo identity must not pull in a DIFFERENT project's tasks. A
+// sibling repo shares a parent directory with this one, so any fix that reduced
+// to lexical prefix matching on the parent would fail here.
+func TestLoadTasksForRepo_OtherRepoStillExcluded(t *testing.T) {
+	parent := t.TempDir()
+	mkSibling := func(name string) string {
+		repo := filepath.Join(parent, name)
+		require.NoError(t, exec.Command("git", "init", repo).Run(), "git init %s", name)
+		real, err := filepath.EvalSymlinks(repo)
+		require.NoError(t, err)
+		return real
+	}
+	alpha, beta := mkSibling("alpha"), mkSibling("beta")
+	betaSub := filepath.Join(beta, "nested")
+	require.NoError(t, exec.Command("mkdir", "-p", betaSub).Run())
+
+	setupTestTasks(t, []Task{
+		{ID: "alph0001", Name: "alpha-task", Prompt: "p", CronExpr: "0 * * * *", ProjectPath: alpha, Program: "claude", Enabled: true, CreatedAt: time.Now()},
+		{ID: "beta0001", Name: "beta-task", Prompt: "p", CronExpr: "0 * * * *", ProjectPath: beta, Program: "claude", Enabled: true, CreatedAt: time.Now()},
+		{ID: "beta0002", Name: "beta-subdir-task", Prompt: "p", CronExpr: "0 * * * *", ProjectPath: betaSub, Program: "claude", Enabled: true, CreatedAt: time.Now()},
+	})
+
+	got, err := LoadTasksForRepo(alpha)
+	require.NoError(t, err)
+	require.Len(t, got, 1, "only alpha's own task belongs to alpha")
+	assert.Equal(t, "alpha-task", got[0].Name)
+}
+
+// TestLoadTasksForRepo_RetainedRepoIDWins pins that the bind-time RepoID is the
+// authority when present, so a task whose recorded subdirectory has since been
+// DELETED still lists in its project rather than vanishing. This is the whole
+// reason Task.RepoID exists (#1893) and it costs no git resolution.
+func TestLoadTasksForRepo_RetainedRepoIDWins(t *testing.T) {
+	repo := mkScopeRepo(t, "project")
+	gone := filepath.Join(repo, "deleted", "subdir") // never created on disk
+
+	setupTestTasks(t, []Task{
+		{ID: "gone0001", Name: "orphan-subdir", Prompt: "p", CronExpr: "0 * * * *", ProjectPath: gone, RepoID: repoIDForPath(repo), Program: "claude", Enabled: true, CreatedAt: time.Now()},
+	})
+
+	got, err := LoadTasksForRepo(repo)
+	require.NoError(t, err)
+	require.Len(t, got, 1, "a retained RepoID keeps the task in its project even after the recorded subdirectory is gone")
+	assert.Equal(t, "orphan-subdir", got[0].Name)
+}
+
+// TestLoadTasksForRepo_LinkedWorktree covers the other shape of the same bug: a
+// task bound to a linked worktree of the repo. git resolves a linked worktree
+// back to the main repo root (config.ResolveMainRepoRoot), so it is the same
+// project — this is exactly how an af session's own worktree resolves.
+func TestLoadTasksForRepo_LinkedWorktree(t *testing.T) {
+	repo := mkScopeRepo(t, "project")
+	for _, args := range [][]string{
+		{"-C", repo, "config", "user.email", "test@example.com"},
+		{"-C", repo, "config", "user.name", "Test User"},
+		{"-C", repo, "commit", "--allow-empty", "-m", "init"},
+	} {
+		require.NoError(t, exec.Command("git", args...).Run(), "git %v", args)
+	}
+	wt := filepath.Join(t.TempDir(), "linked")
+	out, err := exec.Command("git", "-C", repo, "worktree", "add", "-b", "feature", wt).CombinedOutput()
+	require.NoError(t, err, "git worktree add: %s", out)
+	realWT, err := filepath.EvalSymlinks(wt)
+	require.NoError(t, err)
+
+	setupTestTasks(t, []Task{
+		{ID: "wtre0001", Name: "worktree-task", Prompt: "p", CronExpr: "0 * * * *", ProjectPath: realWT, Program: "claude", Enabled: true, CreatedAt: time.Now()},
+	})
+
+	got, err := LoadTasksForRepo(repo)
+	require.NoError(t, err)
+	require.Len(t, got, 1, "a linked worktree resolves to the main repo root, so its task belongs to that project")
+	assert.Equal(t, "worktree-task", got[0].Name)
+}
+
+// TestLoadTasksForRepo_NonRepoPathsFallBackToPathEquality pins the degenerate
+// case the old behavior handled and the new one must keep: paths that do not
+// resolve to any repository (a stale clone, a hand-edited row) still scope by
+// their recorded path, so they stay visible where they were recorded rather
+// than collapsing into one bucket.
+func TestLoadTasksForRepo_NonRepoPathsFallBackToPathEquality(t *testing.T) {
+	setupTestTasks(t, []Task{
+		{ID: "one00001", Name: "A", Prompt: "p", CronExpr: "0 * * * *", ProjectPath: "/repos/one", Program: "claude", Enabled: true, CreatedAt: time.Now()},
+		{ID: "two00001", Name: "B", Prompt: "p", CronExpr: "0 * * * *", ProjectPath: "/repos/two", Program: "claude", Enabled: true, CreatedAt: time.Now()},
+	})
+
+	one, err := LoadTasksForRepo("/repos/one")
+	require.NoError(t, err)
+	require.Len(t, one, 1)
+	assert.Equal(t, "A", one[0].Name)
+
+	none, err := LoadTasksForRepo("/repos/absent")
+	require.NoError(t, err)
+	assert.Empty(t, none)
+}

--- a/task/task.go
+++ b/task/task.go
@@ -455,8 +455,8 @@ func GenerateID() (string, error) {
 	return hex.EncodeToString(b), nil
 }
 
-// LoadTasksForCurrentRepo returns only tasks whose ProjectPath
-// matches the current git repository root.
+// LoadTasksForCurrentRepo returns only the tasks belonging to the git
+// repository containing cwd.
 func LoadTasksForCurrentRepo() ([]Task, error) {
 	repo, err := config.CurrentRepo()
 	if err != nil {
@@ -465,18 +465,24 @@ func LoadTasksForCurrentRepo() ([]Task, error) {
 	return LoadTasksForRepo(repo.Root)
 }
 
-// LoadTasksForRepo returns only tasks whose ProjectPath matches repoRoot (the
-// repo's main-worktree root). It is the repo-scoped loader the in-place project
-// switch (#1461) uses to repopulate the automations strip for the newly active
-// project, without re-deriving the repo from cwd.
+// LoadTasksForRepo returns only the tasks belonging to the project rooted at
+// repoRoot, which must be a main-worktree root as returned by
+// config.CurrentRepo / config.RepoFromPath. It is the repo-scoped loader the
+// TUI task pane and the in-place project switch (#1461) use to populate the
+// automations strip.
+//
+// Membership is decided by repo IDENTITY, not path strings: a task bound to a
+// SUBDIRECTORY or a linked worktree of repoRoot belongs to it, because that is
+// what git says (#2098). See repo_scope.go.
 func LoadTasksForRepo(repoRoot string) ([]Task, error) {
 	all, err := LoadTasks()
 	if err != nil {
 		return nil, err
 	}
+	scope := newRepoScope(repoRoot)
 	var filtered []Task
 	for _, t := range all {
-		if t.ProjectPath == repoRoot {
+		if scope.matches(t) {
 			filtered = append(filtered, t)
 		}
 	}


### PR DESCRIPTION
Fixes #2098

## What was wrong

A task records the project path it was **bound to**, which is not necessarily the project's root. The TUI task form prefills its project path from `os.Getwd()` (`ui/task_pane.go` `EnterCreateMode`) and stores the absolute path as typed (`app/home_tasks.go`, `ui/task_pane_edit.go`) — so a user standing in `repo/some/subdir` creates a task whose `ProjectPath` **is** that subdirectory.

`task.LoadTasksForRepo` — the loader behind every TUI task surface — filtered with raw string equality:

```go
if t.ProjectPath == repoRoot {   // repoRoot = git-resolved main-worktree root
```

git resolves any subdirectory (and any linked worktree) back to the same top-level; string comparison of raw paths does not. So the subdir-created task was **invisible in its own project's pane** and missing from the sidebar automations count — while `af tasks list` showed it fine and the daemon happily ran it on schedule. That asymmetry is the user-visible shape of the bug.

Contrast `af tasks add`, which stores `repo.Root` (`api/tasks.go:234`) — which is why only TUI-created tasks were affected.

## Why this shape of fix

The correct mechanism was **already in-tree**. #1893 moved the CLI to repo-*identity* matching (`api/scope.go`): prefer the bind-time `Task.RepoID`, else resolve the recorded path through git. `api/scope.go`'s own doc comment even calls out this exact hazard:

> the TUI stores whatever absolute path the user typed […] a subdirectory or a linked worktree both round-trip to the same project but never string-match its root.

The pane's loader was the one site left on the old rule. So rather than invent a second rule, this:

1. Hoists the resolution into `config.ResolveProjectPath` (moved verbatim out of `api/scope.go`) so there is **one** path→project-identity mechanism.
2. Points `api/scope.go` at it (net **−48 lines** there — it keeps only its per-invocation cache).
3. Applies the same rule in `task.LoadTasksForRepo` via a new `task/repo_scope.go`.

Match ordering is **deliberately identical to the CLI's** — retained `RepoID` wins, path only consulted when it is empty — so a corrupt row scopes the same way in both surfaces instead of re-introducing the divergence this removes. The one intentional divergence is documented in `repo_scope.go`: an *unbound* task (`ProjectPath == ""`) matches every scope in the CLI so it stays deletable, but the pane excludes it — reachability is the CLI's job, and duplicating one orphan into every project's pane is noise.

### Adjacent call sites audited

I swept `task/ app/ ui/ daemon/ api/ apiclient/ cmd/ config/ session/` for the same anti-pattern. `task/task.go:479` was the **only** raw-path task→repo filter. Everything else already compares identity, or is a deliberate string compare with different semantics and was left alone:

- `task/task.go:141` `ProjectExpectation.Verify` — asks "is this the same record I authorized?", not "is this my repo". Identity matching would *weaken* it (a root→subdir rebind within one repo would stop being detected).
- `daemon/watcher.go:323` `watcherSignature` — a process-identity signature (`ProjectPath` is the watch process's literal cwd, `watcher.go:293`), compared only against itself to decide restarts. Watchers are keyed by task ID, never by path.
- `daemon/taskrun.go:73,118,280` — `ProjectPath` flows into `config.RepoFromPath` downstream (`manager_create.go:152`), so a subdir already resolved correctly there.

### Performance

This runs on the TUI's 750ms snapshot poll (`app/sync.go:135`), so a filter that shelled out to git per task per tick would burn subprocesses on an otherwise idle TUI. It doesn't: `RepoID` and exact-path matches cost **no git at all**, and the resolution fallback is reachable only for rows written before `RepoID` existed — which are never rewritten, and so never pick the field up. Those memoize their *positive* results for the life of the process. Negatives are deliberately not cached: a path that doesn't resolve today may resolve tomorrow (the user creates the subdirectory after binding the task), and pinning that miss would mis-scope the task for the whole session.

## Fail-first

New tests run against pristine `origin/master` (clean worktree, only the test file copied in) — the two guards pass, the four bug tests fail:

```
=== RUN   TestLoadTasksForRepo_SubdirectoryProjectPath
--- FAIL: TestLoadTasksForRepo_SubdirectoryProjectPath (0.01s)
=== RUN   TestLoadTasksForCurrentRepo_CreatedFromSubdirectory
--- FAIL: TestLoadTasksForCurrentRepo_CreatedFromSubdirectory (0.02s)
=== RUN   TestLoadTasksForRepo_OtherRepoStillExcluded
--- PASS: TestLoadTasksForRepo_OtherRepoStillExcluded (0.01s)
=== RUN   TestLoadTasksForRepo_RetainedRepoIDWins
--- FAIL: TestLoadTasksForRepo_RetainedRepoIDWins (0.01s)
=== RUN   TestLoadTasksForRepo_LinkedWorktree
--- FAIL: TestLoadTasksForRepo_LinkedWorktree (0.03s)
=== RUN   TestLoadTasksForRepo_NonRepoPathsFallBackToPathEquality
--- PASS: TestLoadTasksForRepo_NonRepoPathsFallBackToPathEquality (0.00s)
=== RUN   TestLoadTasksForRepo                      # the pre-existing test
--- PASS: TestLoadTasksForRepo (0.00s)
FAIL
```

Headline failure:

```
--- FAIL: TestLoadTasksForRepo_SubdirectoryProjectPath (0.01s)
        Error:      elements differ
                    extra elements in list A:
                     (string) (len=11) "from-subdir"
                    listA: {"from-root", "from-subdir"}
                    listB: {"from-root"}
        Messages:   a task created from a subdirectory of the repo must appear in that repo's pane (#2098)
```

All seven pass after the fix.

The two that already passed on master are the **over-listing locks**, and they are the ones that matter for review:
- `OtherRepoStillExcluded` uses two **sibling** repos under a shared parent, plus a subdir task in the sibling — so any fix that degraded to lexical prefix matching on the parent would fail it.
- `NonRepoPathsFallBackToPathEquality` pins that paths resolving to no repository still scope by their recorded path rather than collapsing into one bucket.

`TestLoadTasksForCurrentRepo_CreatedFromSubdirectory` is the end-to-end user story: chdir into the subdir, create through the real `AddTask` writer, load through `LoadTasksForCurrentRepo` exactly as the pane does.

## Verification

- `gofmt -l .` — clean
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean
- `scripts/lint-file-length.sh` — passed (811 files, 0 grandfathered)
- `go build ./...` — clean
- `go test ./task/ ./config/ ./api/ ./app/ ./ui/` — all pass (`api/` matters here: it exercises the hoisted `config.ResolveProjectPath` through the #1893 scope contract tests)

I did **not** run a full TUI play-test. This changes only which rows the pane is handed — no render, layout, or key-handling change — and the over-listing risk is locked by the two guard tests above. Happy to run one if you'd rather have it.

— Captain Claude
