### PR TITLE
fix(webtab): reject only a whole ".." segment, not ".." as a substring

### DIFF
--- a/daemon/webtab_path_encoding_test.go
+++ b/daemon/webtab_path_encoding_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 )
 
@@ -259,12 +260,131 @@ func TestWebTabProxy_RejectsEncodedTraversal(t *testing.T) {
 	for _, sub := range []string{
 		"%2E%2E%2F%2E%2E%2Fetc/passwd", // fully encoded
 		"a/%2E%2E/%2E%2E/etc/passwd",   // encoded dots under a real segment
+		"%2e%2e/etc",                   // lower-case escape
+		"%2E%2e/etc",                   // mixed case within one segment
+		"a/%2e./b",                     // half-encoded, leading dot escaped
+		"a/.%2E/b",                     // half-encoded, trailing dot escaped
 	} {
 		t.Run(sub, func(t *testing.T) {
 			rec := proxyGet(t, mux, id, tabID, sub)
 			if rec.Code != http.StatusBadRequest {
 				t.Fatalf("sub=%q: status = %d, want 400 — encoded traversal must not reach upstream (body: %s)",
 					sub, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestWebTabProxy_ForwardsDotDotInsideSegment is the #2104 regression test.
+//
+// The traversal guard tested for ".." ANYWHERE in the remainder, so it also
+// refused every legitimate path that merely contains those two bytes inside a
+// longer segment: a cache-busted bundle (bundle..js), a route with a range in it
+// (v1..2), any filename an app happens to spell that way. Users hit a flat 400 on
+// a resource the dev server serves perfectly well when unproxied.
+//
+// Only a whole segment equal to ".." climbs a directory, so only that is refused
+// — these must reach upstream in their own encoding, like any other path.
+func TestWebTabProxy_ForwardsDotDotInsideSegment(t *testing.T) {
+	upstream := newEchoPathUpstream(t)
+	mux, id, tabID := newWebTabProxyFixture(t, upstream.URL)
+
+	cases := []struct{ name, sub, want string }{
+		{name: "cache-busted bundle", sub: "assets/bundle..js", want: "PATH=/assets/bundle..js"},
+		{name: "dots inside a single segment", sub: "foo..bar", want: "PATH=/foo..bar"},
+		{name: "dots in a leading segment", sub: "a..b/x", want: "PATH=/a..b/x"},
+		{name: "leading dots in a name", sub: "..hidden", want: "PATH=/..hidden"},
+		{name: "trailing dots in a name", sub: "report..", want: "PATH=/report.."},
+		{name: "three dots is not a climb", sub: "...", want: "PATH=/..."},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := proxyGet(t, mux, id, tabID, tc.sub)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("sub=%q: status = %d, want 200 — a %q inside a segment is an ordinary path, not traversal (body: %s)",
+					tc.sub, rec.Code, "..", rec.Body.String())
+			}
+			if got := rec.Body.String(); !contains(got, tc.want) {
+				t.Fatalf("sub=%q: upstream saw %q, want it to contain %q", tc.sub, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestWebTabProxy_LiteralTraversalNeverReachesUpstream pins the other half of
+// #2104: narrowing the guard to whole segments must not open the literal form.
+//
+// A literal "/../" is refused a layer EARLIER than the guard — ServeMux cleans it
+// and redirects before the handler runs — which is why these assert "never
+// forwarded" rather than a status code. The echo upstream answers "PATH=", so its
+// absence is proof the hop never happened; the redirect it answers instead must
+// still name a location inside the proxy prefix, never a climbed one.
+func TestWebTabProxy_LiteralTraversalNeverReachesUpstream(t *testing.T) {
+	upstream := newEchoPathUpstream(t)
+	mux, id, tabID := newWebTabProxyFixture(t, upstream.URL)
+
+	for _, sub := range []string{
+		"../etc/passwd",      // leading climb
+		"..",                 // bare segment
+		"a/../../etc/passwd", // climb out from under a real segment
+		"a/..",               // trailing climb
+	} {
+		t.Run(sub, func(t *testing.T) {
+			rec := proxyGet(t, mux, id, tabID, sub)
+			if rec.Code == http.StatusOK {
+				t.Fatalf("sub=%q: status = 200 — traversal must never be served (body: %s)", sub, rec.Body.String())
+			}
+			if body := rec.Body.String(); contains(body, "PATH=") {
+				t.Fatalf("sub=%q: reached upstream (body: %s) — traversal was forwarded", sub, body)
+			}
+			if loc := rec.Header().Get("Location"); loc != "" {
+				if hasDotDotSegment(loc) {
+					t.Fatalf("sub=%q: Location %q still carries a %q segment", sub, loc, "..")
+				}
+				if !strings.HasPrefix(loc, webtabPathPrefix) {
+					t.Fatalf("sub=%q: Location %q escaped the proxy prefix %q", sub, loc, webtabPathPrefix)
+				}
+			}
+		})
+	}
+}
+
+// TestHasDotDotSegment pins the predicate itself, including the contract that
+// makes it safe: it is given the DECODED path, so it needs to recognize exactly
+// one spelling of a climb.
+func TestHasDotDotSegment(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{path: "", want: false},
+		{path: "a/b/c.js", want: false},
+		// The #2104 cases: two dots inside a longer segment name a real file.
+		{path: "assets/bundle..js", want: false},
+		{path: "foo..bar", want: false},
+		{path: "a..b/x", want: false},
+		{path: "..hidden", want: false},
+		{path: "report..", want: false},
+		{path: "...", want: false},
+		{path: ".", want: false},
+		// A whole segment equal to ".." climbs, wherever it sits.
+		{path: "..", want: true},
+		{path: "../a", want: true},
+		{path: "a/..", want: true},
+		{path: "a/../b", want: true},
+		{path: "/../etc/passwd", want: true},
+		{path: "a/b/../../../etc", want: true},
+		// Callers pass the decoded path, which is what makes checking a single
+		// spelling sound: "%2e%2e" has ALREADY become ".." by the time it gets here
+		// (TestWebTabProxy_RejectsEncodedTraversal proves the proxy does that). A
+		// literal "%2e%2e" still present after decoding came from a double-encoded
+		// request and names a file, so it is correctly not a climb.
+		{path: "%2e%2e", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			if got := hasDotDotSegment(tc.path); got != tc.want {
+				t.Fatalf("hasDotDotSegment(%q) = %v, want %v", tc.path, got, tc.want)
 			}
 		})
 	}

--- a/daemon/webtab_proxy.go
+++ b/daemon/webtab_proxy.go
@@ -377,7 +377,11 @@ func (cs *controlServer) webTabProxyHandler(w http.ResponseWriter, r *http.Reque
 	// here intact. Reject the residue so a crafted request can never escape the
 	// proxied prefix. rest is the decoded view of the remainder, so testing it here
 	// covers the escaped form the proxy actually forwards.
-	if strings.Contains(rest, "..") {
+	//
+	// Only a whole SEGMENT equal to ".." climbs. Testing for ".." anywhere in the
+	// string also rejected legitimate routes that merely contain it — /assets/
+	// bundle..js and friends never reached the dev server at all (#2104).
+	if hasDotDotSegment(rest) {
 		writeHTTPError(w, r, http.StatusBadRequest, fmt.Errorf("invalid web tab path"))
 		return
 	}

--- a/daemon/webtab_url.go
+++ b/daemon/webtab_url.go
@@ -137,6 +137,29 @@ func isDoubleDotSegment(seg string) bool {
 		strings.EqualFold(seg, "%2e.") || strings.EqualFold(seg, "%2e%2e")
 }
 
+// hasDotDotSegment reports whether any SEGMENT of an already-DECODED path is
+// exactly "..", which is the only form that climbs a directory.
+//
+// Segment equality is the test, never substring containment. ".." occurring
+// INSIDE a longer segment — bundle..js, foo..bar, a range like v1..2 — is an
+// ordinary run of characters naming a real file, and the strings.Contains check
+// this replaces 400'd every one of them (#2104).
+//
+// The caller must pass the decoded view. That ordering is what keeps the guard
+// honest about the escaped path the proxy actually forwards: "%2e%2e" decodes to
+// ".." and is caught here, so the request cannot be accepted on its raw spelling
+// and then forwarded as traversal. A %2F likewise decodes to a separator, so an
+// encoded slash hiding a ".." segment splits open and is caught too — stricter
+// than the forwarded bytes strictly need, and deliberately so.
+func hasDotDotSegment(decodedPath string) bool {
+	for _, seg := range strings.Split(decodedPath, "/") {
+		if seg == ".." {
+			return true
+		}
+	}
+	return false
+}
+
 // normalizeEscapedPath resolves the "." and ".." segments of an absolute escaped
 // path, the way the browser resolves them when it follows the rewritten header.
 //


### PR DESCRIPTION
Fixes #2104

## The bug

The web-tab proxy's traversal guard was a substring test:

```go
if strings.Contains(rest, "..") {   // daemon/webtab_proxy.go:380
```

`..` inside a *longer* segment is an ordinary run of characters naming a real
file — but this refused all of them. A served app with a route like
`/assets/bundle..js` got a flat `400 invalid web tab path` and the request never
reached the dev server, even though the same URL loads fine unproxied.

## Reproduced first

Observed behavior on master, before touching anything:

| path | master | correct |
| --- | --- | --- |
| `assets/bundle..js`, `foo..bar`, `a..b/x` | **400** | 200, forwarded ← the bug |
| `..`, `../etc/passwd`, `a/../../etc/passwd` | 301 (ServeMux cleans it) | stay rejected |
| `%2e%2e/etc`, `%2E%2e/etc`, `a/%2e./b`, `a/.%2E/b` | 400 | stay 400 |

Worth recording: literal `/../` never reaches this guard at all. ServeMux cleans
and redirects it *before* the handler runs, so the guard only ever sees the
**encoded** form. That is why the new literal-traversal test asserts "never
forwarded upstream, never leaves the proxy prefix" rather than a status code —
asserting 400 there would have been asserting something untrue.

## The fix

Reject iff a whole *segment* equals `..`, via one named helper next to the
existing dot-segment predicates in `webtab_url.go`:

```go
func hasDotDotSegment(decodedPath string) bool {
	for _, seg := range strings.Split(decodedPath, "/") {
		if seg == ".." {
			return true
		}
	}
	return false
}
```

**The security invariant is unchanged, and the decode-then-check order is
load-bearing.** `rest` is the decoded view of the remainder, so:

- encoded traversal still decodes to a `..` segment and is still refused —
  `%2e%2e`, `%2E%2E`, and the half-encoded `.%2e` / `%2e.` spellings all land on
  the same check. The guard cannot accept a request on its raw spelling and then
  forward it as a climb (the accepted-vs-stripped split).
- a `%2F` also decodes to a separator, so an encoded slash hiding a `..` segment
  splits open and is caught — stricter than the forwarded bytes strictly need,
  and deliberately kept that way.

## Fail-first output

Helper present but the call site left at master's `strings.Contains`, so the
failure is purely behavioral:

```
webtab_path_encoding_test.go:304: sub="assets/bundle..js": status = 400, want 200 — a ".." inside a segment is an ordinary path, not traversal
webtab_path_encoding_test.go:304: sub="foo..bar": status = 400, want 200 — a ".." inside a segment is an ordinary path, not traversal
webtab_path_encoding_test.go:304: sub="a..b/x": status = 400, want 200 — a ".." inside a segment is an ordinary path, not traversal
webtab_path_encoding_test.go:304: sub="..hidden": status = 400, want 200 — a ".." inside a segment is an ordinary path, not traversal
webtab_path_encoding_test.go:304: sub="report..": status = 400, want 200 — a ".." inside a segment is an ordinary path, not traversal
webtab_path_encoding_test.go:304: sub="...": status = 400, want 200 — a ".." inside a segment is an ordinary path, not traversal
--- FAIL: TestWebTabProxy_ForwardsDotDotInsideSegment/cache-busted_bundle (0.00s)
--- FAIL: TestWebTabProxy_ForwardsDotDotInsideSegment/dots_inside_a_single_segment (0.00s)
--- FAIL: TestWebTabProxy_ForwardsDotDotInsideSegment/dots_in_a_leading_segment (0.00s)
--- FAIL: TestWebTabProxy_ForwardsDotDotInsideSegment/leading_dots_in_a_name (0.00s)
--- FAIL: TestWebTabProxy_ForwardsDotDotInsideSegment/trailing_dots_in_a_name (0.00s)
--- FAIL: TestWebTabProxy_ForwardsDotDotInsideSegment/three_dots_is_not_a_climb (0.00s)
```

All six pass after the fix.

## Tests

- `TestWebTabProxy_ForwardsDotDotInsideSegment` — the regression test above; each
  path must reach upstream in its own encoding.
- `TestWebTabProxy_RejectsEncodedTraversal` — extended with lower-case,
  mixed-case, and both half-encoded spellings.
- `TestWebTabProxy_LiteralTraversalNeverReachesUpstream` — a lock, not a
  fail-first test: it passes before *and* after, which is the point. Narrowing
  the guard must not open the literal form.
- `TestHasDotDotSegment` — the predicate directly, including `%2e%2e → false`
  documenting that callers pass the *decoded* path (a literal `%2e%2e` surviving
  decoding came from a double-encoded request and names a file).

## Adjacent `..` checks audited

- `daemon/webtab_url.go` `isDoubleDotSegment` — already segment-equality, and
  already handles the `%2e` spellings. Correct, untouched.
- `daemon/webserve.go:132` — `path.Clean` then `name == ".."` /
  `HasPrefix(name, "../")`. Segment-correct after Clean; `foo..bar` passes
  through fine. Not the bug.
- `daemon/control_server.go:515` → `config.ValidateRepoID` — an allowlist regex
  over repo IDs, a different domain from proxy paths. Correct by construction.

## Verification

`gofmt -l .` clean · `golangci-lint run --timeout=3m --fast` clean ·
`deadcode -test ./...` clean · `scripts/lint-file-length.sh` passed ·
`go build ./...` clean · `make test-container` full suite exit 0, 35 packages ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
