### PR TITLE
fix(reset): verify locked-worktree cleanup instead of trusting prune's exit code (#2110)

### DIFF
--- a/commands/reset.go
+++ b/commands/reset.go
@@ -14,6 +14,7 @@ import (
 	cmdutil "github.com/sachiniyer/agent-factory/cmd"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/internal/pathutil"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/git"
@@ -321,9 +322,9 @@ func runReset(cmd *cobra.Command, _ []string) (err error) {
 	//    failure, so the user sees exactly where the reset got to.
 	printResetSummary(out, summary)
 	if resetErr != nil {
-		fmt.Fprintln(out, "\nSome items could not be removed; the reset is PARTIAL. Their session records "+
-			"were KEPT, so a re-run revisits exactly that work — but clear the cause below first, "+
-			"or the re-run repeats the same failure. Details:")
+		fmt.Fprintln(out, "\nSome items could not be removed, so this reset is only partial. Their session "+
+			"records were kept, so a re-run revisits exactly that work — but clear the cause below first, "+
+			"or the re-run just repeats the same failure. Details:")
 		fmt.Fprintln(out, resetErr)
 		return resetErr
 	}
@@ -811,33 +812,22 @@ func pruneWorktreeResidue(root string, keep []string) []error {
 	return errs
 }
 
-// holdsAnyPath reports whether dir IS, or contains, any of paths. Both sides are
-// symlink-resolved best-effort so a record written through /tmp still matches a
-// scan that walked /private/tmp (macOS).
+// holdsAnyPath reports whether dir IS, or contains, any of paths.
+//
+// Both sides go through pathutil.ResolveForCompare so a record stored with one
+// spelling matches a scan that walked another — and, critically, so a blocked
+// worktree whose DIRECTORY is already gone still matches: a plain EvalSymlinks
+// cannot resolve a missing leaf, which on a symlinked root (macOS /var ->
+// /private/var) silently turns "keep this" into "delete this" (#2110).
 func holdsAnyPath(dir string, paths []string) bool {
-	dir = resolvePath(dir)
+	dir = pathutil.ResolveForCompare(dir)
 	for _, p := range paths {
-		p = resolvePath(p)
-		if p == dir {
-			return true
-		}
-		rel, err := filepath.Rel(dir, p)
-		if err != nil {
-			continue
-		}
-		if rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		p = pathutil.ResolveForCompare(p)
+		if p == dir || pathutil.IsStrictlyInside(p, dir) {
 			return true
 		}
 	}
 	return false
-}
-
-func resolvePath(p string) string {
-	p = filepath.Clean(p)
-	if resolved, err := filepath.EvalSymlinks(p); err == nil {
-		return resolved
-	}
-	return p
 }
 
 // retainBlockedInstances rewrites repoID's record set down to ONLY the sessions
@@ -897,14 +887,14 @@ func printResetSummary(out io.Writer, s *resetSummary) {
 	fmt.Fprintf(out, "  worktrees: %d\n", s.worktrees)
 	fmt.Fprintf(out, "  branches:  %d\n", s.branches)
 	if s.corrupt > 0 {
-		fmt.Fprintf(out, "  NEEDS ATTENTION: %d repo(s) had unreadable records and were LEFT INTACT "+
-			"— their records, branches, and archived worktrees were all KEPT (nothing dangling). "+
-			"Fix or remove those instances.json files and re-run to finish.\n", s.corrupt)
+		fmt.Fprintf(out, "  Needs attention: %d repo(s) had unreadable records and were left untouched "+
+			"— their records, branches, and archived worktrees were all kept, so nothing is dangling. "+
+			"Fix or remove those instances.json files, then re-run `af reset` to finish.\n", s.corrupt)
 	}
 	if s.blocked > 0 {
-		fmt.Fprintf(out, "  NEEDS ATTENTION: %d worktree(s) are still registered with git (usually a locked "+
-			"worktree) and were LEFT IN PLACE with their branch and session record. "+
-			"Run the unlock shown with each one below, then re-run `af reset` to finish.\n", s.blocked)
+		fmt.Fprintf(out, "  Needs attention: %d worktree(s) are still registered with git — usually because "+
+			"they are locked. Each was left in place, along with its branch and its session record. "+
+			"Run the recovery command shown with each one below, then re-run `af reset` to finish.\n", s.blocked)
 	}
 	fmt.Fprintln(out, "Preserved: your git repositories and daemon config (config.toml).")
 	fmt.Fprintln(out, "The supervised daemon will restart with empty session/task state and the same config.")

--- a/commands/reset.go
+++ b/commands/reset.go
@@ -32,6 +32,10 @@ const wipeConfirmWord = "WIPE"
 // WIPE confirmation for non-interactive/scripted use.
 var resetForceFlag bool
 
+// worktreesResidueDir is the AF home subdirectory holding AF-managed session
+// worktrees. Named because the wipe has to special-case it (see resetWipePaths).
+const worktreesResidueDir = "worktrees"
+
 // resetWipePaths are the state trees/files under the AF home directory that a
 // factory reset removes wholesale (in addition to instances/, handled by
 // DeleteAllInstances, and tasks.json, handled by task.DeleteAllTasks).
@@ -54,8 +58,13 @@ var resetForceFlag bool
 // NOTE: "archived" is deliberately NOT here — archived worktrees are removed
 // per-repo (removeArchivedDirs) so a preserved (corrupt/unreadable) record is
 // never left pointing at a deleted archive.
+//
+// NOTE: "worktrees" is a wholesale removal only because the per-worktree pass is
+// expected to have emptied it. When that pass DELIBERATELY left a worktree in
+// place (#2110), this blind delete would destroy the very directory git still
+// owns — so the wipe below skips it and prunes the tree entry-by-entry instead.
 var resetWipePaths = []string{
-	"worktrees",             // AF-managed worktree parent dir (residue after cleanup)
+	worktreesResidueDir,     // AF-managed worktree parent dir (residue after cleanup)
 	"events",                // daemon event queue
 	"logs",                  // per-task run logs
 	"locks",                 // per-task run locks
@@ -95,10 +104,12 @@ type resetPlan struct {
 }
 
 // worktreeTarget is one AF-created worktree directory to remove, with the repo
-// root git needs to operate on it.
+// root git needs to operate on it and the repoID whose record set describes it
+// (the record is retained when the removal is blocked — see #2110).
 type worktreeTarget struct {
-	root string
-	path string
+	repoID string
+	root   string
+	path   string
 }
 
 func (p *resetPlan) branchCount() int {
@@ -117,6 +128,7 @@ type resetSummary struct {
 	worktrees int
 	branches  int // branches actually deleted (<= plan.branchCount())
 	corrupt   int // repos left intact because their records were unreadable
+	blocked   int // worktrees git would not release (locked) — records retained (#2110)
 }
 
 var resetCmd = &cobra.Command{
@@ -309,8 +321,9 @@ func runReset(cmd *cobra.Command, _ []string) (err error) {
 	//    failure, so the user sees exactly where the reset got to.
 	printResetSummary(out, summary)
 	if resetErr != nil {
-		fmt.Fprintln(out, "\nSome items could not be removed; the reset is PARTIAL. "+
-			"Every step is idempotent — re-run `af reset` to finish. Details:")
+		fmt.Fprintln(out, "\nSome items could not be removed; the reset is PARTIAL. Their session records "+
+			"were KEPT, so a re-run revisits exactly that work — but clear the cause below first, "+
+			"or the re-run repeats the same failure. Details:")
 		fmt.Fprintln(out, resetErr)
 		return resetErr
 	}
@@ -489,7 +502,7 @@ func planFactoryReset() (*resetPlan, error) {
 			if r.Worktree.WorktreePath != "" && !r.Worktree.ExternalWorktree && root != "" {
 				plan.worktrees++
 				plan.worktreeTargets = append(plan.worktreeTargets,
-					worktreeTarget{root: root, path: r.Worktree.WorktreePath})
+					worktreeTarget{repoID: repoID, root: root, path: r.Worktree.WorktreePath})
 			}
 			if root == "" {
 				continue
@@ -602,9 +615,19 @@ func executeFactoryReset(plan *resetPlan) (*resetSummary, error) {
 	// the user's own manually-created linked worktrees. Deletes NO branch here;
 	// branch deletion is funneled through the BranchCreatedByUs-guarded pass
 	// below. Resilient: a per-worktree failure is collected, not fatal.
+	//
+	// A worktree git would NOT release (locked, #2110) is recorded per repo: its
+	// session record is retained below so the recovery the error prints
+	// (`git worktree unlock <path> && af reset`) has something to revisit. Deleting
+	// the record here is what made the old "re-run to finish" guidance a lie — the
+	// re-run planned nothing and the branch stayed blocked forever.
+	blockedWorktrees := make(map[string][]string) // repoID -> worktree paths still registered
 	for _, wt := range plan.worktreeTargets {
 		if _, err := git.RemoveWorktreeDir(wt.root, wt.path); err != nil {
 			errs = append(errs, fmt.Errorf("remove worktree %s: %w", wt.path, err))
+			if errors.Is(err, git.ErrWorktreeStillRegistered) {
+				blockedWorktrees[wt.repoID] = append(blockedWorktrees[wt.repoID], wt.path)
+			}
 		}
 	}
 
@@ -633,12 +656,27 @@ func executeFactoryReset(plan *resetPlan) (*resetSummary, error) {
 	// repos we could parse and LEAVE the corrupt ones (and their branches)
 	// intact — erasing a record whose branch we deliberately did not prune would
 	// orphan that branch.
-	if len(plan.corruptRepoIDs) == 0 {
+	//
+	// A repo with a BLOCKED worktree (#2110) is preserved the same way, but at
+	// record granularity: only the records whose worktree is still registered
+	// survive, so the retained state is exactly the part of the reset that did not
+	// happen — and no record is left pointing at a worktree this run deleted.
+	preserveRepoIDs := append([]string(nil), plan.corruptRepoIDs...)
+	for rid := range blockedWorktrees {
+		preserveRepoIDs = append(preserveRepoIDs, rid)
+	}
+	if len(preserveRepoIDs) == 0 {
 		if err := plan.storage.DeleteAllInstances(); err != nil {
 			errs = append(errs, fmt.Errorf("reset session storage: %w", err))
 		}
 	} else {
 		for _, rid := range plan.processedRepoIDs {
+			if paths, blocked := blockedWorktrees[rid]; blocked {
+				if err := retainBlockedInstances(rid, paths); err != nil {
+					errs = append(errs, fmt.Errorf("retain blocked session records for repo %s: %w", rid, err))
+				}
+				continue
+			}
 			if err := config.DeleteRepoInstances(rid); err != nil {
 				errs = append(errs, fmt.Errorf("delete instances for repo %s: %w", rid, err))
 			}
@@ -646,10 +684,17 @@ func executeFactoryReset(plan *resetPlan) (*resetSummary, error) {
 	}
 
 	// Remove archived-session worktree dirs PER REPO, skipping any preserved
-	// (corrupt/unreadable) repo — its records still point at those archives, so
-	// deleting them would leave a dangling reference. A whole-tree wipe would do
-	// exactly that; keep preserved records and their archives consistent.
-	errs = append(errs, removeArchivedDirs(plan.configDir, plan.corruptRepoIDs)...)
+	// (corrupt/unreadable, or #2110-blocked) repo — its records still point at
+	// those archives, so deleting them would leave a dangling reference. A
+	// whole-tree wipe would do exactly that; keep preserved records and their
+	// archives consistent.
+	//
+	// This is repo-granular where the record retention above is record-granular,
+	// deliberately: a blocked worktree may itself BE an archived one, and this
+	// pass must not delete the directory RemoveWorktreeDir just refused to touch.
+	// The cost is that one repo's already-deleted archives linger until the
+	// recovery re-run — over-preserving, never dangling.
+	errs = append(errs, removeArchivedDirs(plan.configDir, preserveRepoIDs)...)
 
 	// Delete the task store (removes <AF_HOME>/tasks.json).
 	if err := task.DeleteAllTasks(); err != nil {
@@ -658,13 +703,29 @@ func executeFactoryReset(plan *resetPlan) (*resetSummary, error) {
 
 	// Remove the remaining AF state trees/files, leaving config (config.toml,
 	// config.json, repos/) and daemon identity untouched.
+	var blockedPaths []string
+	for _, paths := range blockedWorktrees {
+		blockedPaths = append(blockedPaths, paths...)
+	}
 	for _, name := range resetWipePaths {
 		p := filepath.Join(plan.configDir, name)
+		// The worktrees/ tree is wiped wholesale ONLY because the per-worktree pass
+		// above is expected to have emptied it. A worktree that pass deliberately
+		// left in place (#2110) is still git's — deleting it here would undo the
+		// ownership check three steps later and destroy the tree the user locked.
+		if name == worktreesResidueDir && len(blockedPaths) > 0 {
+			errs = append(errs, pruneWorktreeResidue(p, blockedPaths)...)
+			continue
+		}
 		if err := os.RemoveAll(p); err != nil {
 			errs = append(errs, fmt.Errorf("remove %s: %w", p, err))
 		}
 	}
 
+	blockedCount := 0
+	for _, paths := range blockedWorktrees {
+		blockedCount += len(paths)
+	}
 	summary := &resetSummary{
 		sessions:  plan.sessions,
 		archived:  plan.archived,
@@ -672,6 +733,7 @@ func executeFactoryReset(plan *resetPlan) (*resetSummary, error) {
 		worktrees: plan.worktrees,
 		branches:  branchesDeleted,
 		corrupt:   len(plan.corruptRepoIDs),
+		blocked:   blockedCount,
 	}
 	if len(errs) > 0 {
 		return summary, errors.Join(errs...)
@@ -720,6 +782,97 @@ func removeArchivedDirs(configDir string, preserve []string) []error {
 	return errs
 }
 
+// pruneWorktreeResidue empties the AF worktrees/ tree entry-by-entry, keeping
+// any top-level entry that holds a worktree the reset deliberately left in place
+// (#2110). It is the guarded form of the wholesale `os.RemoveAll(worktrees/)`.
+//
+// Keeping is TOP-LEVEL: an entry that merely contains a blocked worktree is kept
+// whole, siblings included. Over-preserving is the safe direction — the residue
+// is one directory that the recovery re-run removes once the worktree is gone,
+// whereas under-preserving destroys a checkout git still owns.
+func pruneWorktreeResidue(root string, keep []string) []error {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return []error{fmt.Errorf("read %s: %w", root, err)}
+	}
+	var errs []error
+	for _, e := range entries {
+		p := filepath.Join(root, e.Name())
+		if holdsAnyPath(p, keep) {
+			continue
+		}
+		if err := os.RemoveAll(p); err != nil {
+			errs = append(errs, fmt.Errorf("remove %s: %w", p, err))
+		}
+	}
+	return errs
+}
+
+// holdsAnyPath reports whether dir IS, or contains, any of paths. Both sides are
+// symlink-resolved best-effort so a record written through /tmp still matches a
+// scan that walked /private/tmp (macOS).
+func holdsAnyPath(dir string, paths []string) bool {
+	dir = resolvePath(dir)
+	for _, p := range paths {
+		p = resolvePath(p)
+		if p == dir {
+			return true
+		}
+		rel, err := filepath.Rel(dir, p)
+		if err != nil {
+			continue
+		}
+		if rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}
+
+func resolvePath(p string) string {
+	p = filepath.Clean(p)
+	if resolved, err := filepath.EvalSymlinks(p); err == nil {
+		return resolved
+	}
+	return p
+}
+
+// retainBlockedInstances rewrites repoID's record set down to ONLY the sessions
+// whose worktree git refused to release (#2110), dropping every record the reset
+// actually completed.
+//
+// This is what makes the printed recovery honest. `af reset` deletes records
+// even on partial failure, so the old "re-run `af reset` to finish" planned
+// nothing on the second run and the blocked branch was stuck forever. Keeping
+// the blocked session's record — and only that one — means the re-run after
+// `git worktree unlock` plans exactly the leftover work, and the TUI never shows
+// a record whose worktree this run already deleted.
+func retainBlockedInstances(repoID string, blockedPaths []string) error {
+	keep := make(map[string]struct{}, len(blockedPaths))
+	for _, p := range blockedPaths {
+		keep[filepath.Clean(p)] = struct{}{}
+	}
+	return config.UpdateRepoInstances(repoID, func(raw json.RawMessage) (json.RawMessage, error) {
+		var recs []session.InstanceData
+		if err := json.Unmarshal(raw, &recs); err != nil {
+			return nil, fmt.Errorf("read instances: %w", err)
+		}
+		kept := make([]session.InstanceData, 0, len(blockedPaths))
+		for _, r := range recs {
+			if r.Worktree.WorktreePath == "" {
+				continue
+			}
+			if _, blocked := keep[filepath.Clean(r.Worktree.WorktreePath)]; blocked {
+				kept = append(kept, r)
+			}
+		}
+		return json.Marshal(kept)
+	})
+}
+
 func printResetPlan(out io.Writer, plan *resetPlan) {
 	fmt.Fprintln(out, "af reset — factory reset (IRREVERSIBLE)")
 	fmt.Fprintln(out)
@@ -747,6 +900,11 @@ func printResetSummary(out io.Writer, s *resetSummary) {
 		fmt.Fprintf(out, "  NEEDS ATTENTION: %d repo(s) had unreadable records and were LEFT INTACT "+
 			"— their records, branches, and archived worktrees were all KEPT (nothing dangling). "+
 			"Fix or remove those instances.json files and re-run to finish.\n", s.corrupt)
+	}
+	if s.blocked > 0 {
+		fmt.Fprintf(out, "  NEEDS ATTENTION: %d worktree(s) are still registered with git (usually a locked "+
+			"worktree) and were LEFT IN PLACE with their branch and session record. "+
+			"Run the unlock shown with each one below, then re-run `af reset` to finish.\n", s.blocked)
 	}
 	fmt.Fprintln(out, "Preserved: your git repositories and daemon config (config.toml).")
 	fmt.Fprintln(out, "The supervised daemon will restart with empty session/task state and the same config.")

--- a/commands/reset_locked_worktree_test.go
+++ b/commands/reset_locked_worktree_test.go
@@ -1,0 +1,134 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
+	git "github.com/sachiniyer/agent-factory/session/git"
+)
+
+// TestFactoryReset_LockedWorktreeIsRecoverable is the #2110 end-to-end lock.
+//
+// `git worktree prune` exits 0 while refusing to prune a locked worktree's
+// metadata, so the reset used to believe the registration was gone, fail the
+// branch delete, and print "re-run `af reset` to finish" — after having deleted
+// every session record, which left the re-run with nothing to plan and the
+// branch blocked forever.
+//
+// The fix must make the printed recovery TRUE: report the failure, keep the
+// blocked session's record (and only that one), and let
+// `git worktree unlock` + a re-run finish the job.
+func TestFactoryReset_LockedWorktreeIsRecoverable(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	t.Chdir(t.TempDir())
+
+	repo, liveWT, reusedWT := seedMockRepo(t, home)
+	seedAFState(t, home, repo, liveWT, reusedWT)
+	repoID := config.RepoIDFromRoot(repo)
+
+	// The user (or a tool) locked the live session's worktree.
+	runGit(t, repo, "worktree", "lock", liveWT, "--reason", "still in use")
+
+	plan, err := planFactoryReset()
+	if err != nil {
+		t.Fatalf("planFactoryReset: %v", err)
+	}
+
+	summary, err := executeFactoryReset(plan)
+	if err == nil {
+		t.Fatal("executeFactoryReset: want an error for the locked worktree, got nil")
+	}
+
+	// --- The failure is surfaced, classified, and actionable ---
+	if !errors.Is(err, git.ErrWorktreeStillRegistered) {
+		t.Errorf("error = %v, want it to wrap ErrWorktreeStillRegistered", err)
+	}
+	if !strings.Contains(err.Error(), "worktree unlock") || !strings.Contains(err.Error(), liveWT) {
+		t.Errorf("error must name the unlock recovery for %s, got: %v", liveWT, err)
+	}
+	if summary.blocked != 1 {
+		t.Errorf("summary.blocked = %d, want 1", summary.blocked)
+	}
+
+	// --- Ownership safety: git still owns that path, so AF left it alone ---
+	if _, statErr := os.Stat(liveWT); statErr != nil {
+		t.Errorf("locked worktree directory must survive, stat: %v", statErr)
+	}
+	if !branchExists(repo, "af-session-1") {
+		t.Error("the blocked session's branch must survive so the recovery has something to finish")
+	}
+
+	// --- Everything NOT blocked was still reset (resilience is preserved) ---
+	if _, statErr := os.Stat(reusedWT); !os.IsNotExist(statErr) {
+		t.Errorf("unblocked worktree %s should still have been removed, stat: %v", reusedWT, statErr)
+	}
+	if branchExists(repo, "af-session-2") {
+		t.Error("unblocked AF branch af-session-2 should still have been deleted")
+	}
+	if !branchExists(repo, "reused-linked") {
+		t.Error("a reused user branch must never be deleted")
+	}
+
+	// --- ONLY the blocked session's record is retained ---
+	raw, err := config.LoadRepoInstances(repoID)
+	if err != nil {
+		t.Fatalf("LoadRepoInstances: %v", err)
+	}
+	var kept []session.InstanceData
+	if err := json.Unmarshal(raw, &kept); err != nil {
+		t.Fatalf("unmarshal retained records: %v", err)
+	}
+	if len(kept) != 1 {
+		t.Fatalf("retained %d records, want exactly 1 (the blocked session): %+v", len(kept), kept)
+	}
+	if kept[0].Worktree.WorktreePath != liveWT {
+		t.Errorf("retained record worktree = %s, want the blocked %s", kept[0].Worktree.WorktreePath, liveWT)
+	}
+
+	// The summary must tell the user what to do about it.
+	var out bytes.Buffer
+	printResetSummary(&out, summary)
+	if !strings.Contains(out.String(), "NEEDS ATTENTION") || !strings.Contains(out.String(), "unlock") {
+		t.Errorf("summary must flag the blocked worktree and point at the unlock recovery, got:\n%s", out.String())
+	}
+
+	// --- RECOVERY: follow the printed advice; the re-run must finish the job ---
+	runGit(t, repo, "worktree", "unlock", liveWT)
+
+	plan2, err := planFactoryReset()
+	if err != nil {
+		t.Fatalf("planFactoryReset (re-run): %v", err)
+	}
+	if plan2.sessions != 1 || plan2.worktrees != 1 || plan2.branchCount() != 1 {
+		t.Fatalf("re-run planned sessions=%d worktrees=%d branches=%d, want exactly the leftover 1/1/1",
+			plan2.sessions, plan2.worktrees, plan2.branchCount())
+	}
+
+	summary2, err := executeFactoryReset(plan2)
+	if err != nil {
+		t.Fatalf("executeFactoryReset (re-run) after unlock: %v", err)
+	}
+	if summary2.blocked != 0 {
+		t.Errorf("re-run summary.blocked = %d, want 0", summary2.blocked)
+	}
+	if _, statErr := os.Stat(liveWT); !os.IsNotExist(statErr) {
+		t.Errorf("worktree should be gone after unlock + re-run, stat: %v", statErr)
+	}
+	if branchExists(repo, "af-session-1") {
+		t.Error("branch should be deleted after unlock + re-run")
+	}
+	if _, statErr := os.Stat(filepath.Join(home, "instances")); !os.IsNotExist(statErr) {
+		t.Errorf("instances/ should be gone after the recovery re-run, stat: %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(home, "archived")); !os.IsNotExist(statErr) {
+		t.Errorf("archived/ should be gone after the recovery re-run, stat: %v", statErr)
+	}
+}

--- a/commands/reset_locked_worktree_test.go
+++ b/commands/reset_locked_worktree_test.go
@@ -96,7 +96,7 @@ func TestFactoryReset_LockedWorktreeIsRecoverable(t *testing.T) {
 	// The summary must tell the user what to do about it.
 	var out bytes.Buffer
 	printResetSummary(&out, summary)
-	if !strings.Contains(out.String(), "NEEDS ATTENTION") || !strings.Contains(out.String(), "unlock") {
+	if !strings.Contains(out.String(), "Needs attention") || !strings.Contains(out.String(), "recovery command") {
 		t.Errorf("summary must flag the blocked worktree and point at the unlock recovery, got:\n%s", out.String())
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -390,7 +390,7 @@ func TestDefaultConfig(t *testing.T) {
 
 	t.Run("bash alias with flags lands in override unquoted", func(t *testing.T) {
 		// An alias value is already shell syntax: it must reach the
-		// override verbatim, NOT wrapped in quotes by shellQuotePath as a
+		// override verbatim, NOT wrapped in quotes by ShellQuotePath as a
 		// single "path" (#688).
 		bashPath := requireBash(t)
 		homeDir := t.TempDir()

--- a/config/config_types.go
+++ b/config/config_types.go
@@ -462,7 +462,7 @@ func DefaultConfig() *Config {
 		// space/apostrophe quoting treatment (#569).
 		command := claudePath
 		if _, statErr := os.Stat(claudePath); statErr == nil {
-			command = shellQuotePath(claudePath)
+			command = ShellQuotePath(claudePath)
 		}
 		cfg.ProgramOverrides = map[string]string{
 			tmux.ProgramClaude: command + " --dangerously-skip-permissions",

--- a/config/inrepo.go
+++ b/config/inrepo.go
@@ -423,28 +423,6 @@ func LoadInRepoConfig(repoRoot string) (*InRepoConfig, []byte, error) {
 	return &cfg, data, nil
 }
 
-// resolveSymlinksForCompare resolves symlinks in a path that may not exist
-// yet, for path-identity comparisons: the deepest existing ancestor is
-// resolved with filepath.EvalSymlinks and the non-existent remainder is
-// re-joined. Falls back to the cleaned input when nothing resolves, so a
-// comparison built on it is never weaker than comparing Clean-ed paths.
-func resolveSymlinksForCompare(path string) string {
-	path = filepath.Clean(path)
-	suffix := ""
-	for {
-		resolved, err := filepath.EvalSymlinks(path)
-		if err == nil {
-			return filepath.Join(resolved, suffix)
-		}
-		parent := filepath.Dir(path)
-		if parent == path {
-			return filepath.Join(path, suffix)
-		}
-		suffix = filepath.Join(filepath.Base(path), suffix)
-		path = parent
-	}
-}
-
 // beforeInRepoConfigWrite is a test hook for exercising filesystem races at
 // the last point before the save opens its destination for writing.
 var beforeInRepoConfigWrite func() error
@@ -585,14 +563,14 @@ func SaveInRepoPostWorktreeCommands(repoRoot string, commands []string) error {
 	// AGENT_FACTORY_HOME (or a symlinked .agent-factory dir) makes distinct
 	// strings name the same file, and these guards exist precisely for the
 	// aliased cases.
-	resolvedPath := resolveSymlinksForCompare(path)
+	resolvedPath := pathutil.ResolveForCompare(path)
 	// A repo rooted at the user's home directory makes the in-repo path
 	// collide with the global config file; writing hooks there would clobber
 	// the user's global settings.
 	if configDir, dirErr := GetConfigDir(); dirErr == nil {
 		for _, globalName := range []string{ConfigFileName, TomlConfigFileName} {
 			globalPath := filepath.Join(configDir, globalName)
-			if resolvedPath == resolveSymlinksForCompare(globalPath) {
+			if resolvedPath == pathutil.ResolveForCompare(globalPath) {
 				return fmt.Errorf("in-repo config path %s collides with the global config file %s; not saving — run this from a repo whose root is not the config home", prettyHomePath(path), prettyHomePath(globalPath))
 			}
 		}
@@ -601,7 +579,7 @@ func SaveInRepoPostWorktreeCommands(repoRoot string, commands []string) error {
 	// dir symlinked outside the repo must not receive the save. The read
 	// guard alone can't cover this — it only fires when the config file
 	// already exists at the resolved location.
-	if !pathutil.IsStrictlyInside(resolvedPath, resolveSymlinksForCompare(repoRoot)) {
+	if !pathutil.IsStrictlyInside(resolvedPath, pathutil.ResolveForCompare(repoRoot)) {
 		return fmt.Errorf("in-repo config %s resolves outside the repository (to %s); refusing to save it", prettyHomePath(path), prettyHomePath(resolvedPath))
 	}
 	data, _, err := readInRepoConfigFile(repoRoot)

--- a/config/paths.go
+++ b/config/paths.go
@@ -29,12 +29,16 @@ func prettyHomePath(absPath string) string {
 	return absPath
 }
 
-// shellQuotePath wraps a non-empty filesystem path in single quotes, escaping
+// ShellQuotePath wraps a non-empty filesystem path in single quotes, escaping
 // any embedded apostrophes with the standard POSIX single-quote escape idiom.
 // Used by DefaultConfig when persisting auto-detected claude paths into
 // ProgramOverrides — the value is passed to `sh -c` by tmux, so shell
 // metacharacters in paths must never be left for the shell to interpret.
-func shellQuotePath(path string) string {
+//
+// Exported for the other half of that rule: any path AF prints inside a command
+// it expects the user to PASTE must be quoted the same way (#1978), or a path
+// with a space silently becomes two arguments.
+func ShellQuotePath(path string) string {
 	if path == "" {
 		return path
 	}

--- a/config/paths_test.go
+++ b/config/paths_test.go
@@ -28,7 +28,7 @@ func TestShellQuotePathQuotesEveryNonEmptyPath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, shellQuotePath(tt.path))
+			assert.Equal(t, tt.want, ShellQuotePath(tt.path))
 		})
 	}
 }

--- a/internal/pathutil/resolve.go
+++ b/internal/pathutil/resolve.go
@@ -1,0 +1,34 @@
+package pathutil
+
+import "path/filepath"
+
+// ResolveForCompare resolves symlinks in a path that may not exist, for
+// path-identity comparisons: the deepest existing ancestor is resolved with
+// filepath.EvalSymlinks and the non-existent remainder is re-joined. Falls back
+// to the cleaned input when nothing resolves, so a comparison built on it is
+// never weaker than comparing Clean-ed paths.
+//
+// The missing-leaf case is the whole point, and getting it wrong is a
+// PLATFORM-SPECIFIC bug that only shows up where the temp/working root is itself
+// a symlink — macOS `/var` -> `/private/var` being the common one (#2110).
+// A plain EvalSymlinks fails outright on a path whose last component was just
+// deleted, so both sides of a comparison silently stay un-canonicalized and two
+// spellings of the same path compare unequal. When that comparison is a probe
+// ("is this still registered?"), the failure to resolve becomes a confident
+// WRONG ANSWER rather than an error — so canonicalize both sides through here.
+func ResolveForCompare(path string) string {
+	path = filepath.Clean(path)
+	suffix := ""
+	for {
+		resolved, err := filepath.EvalSymlinks(path)
+		if err == nil {
+			return filepath.Join(resolved, suffix)
+		}
+		parent := filepath.Dir(path)
+		if parent == path {
+			return filepath.Join(path, suffix)
+		}
+		suffix = filepath.Join(filepath.Base(path), suffix)
+		path = parent
+	}
+}

--- a/internal/pathutil/resolve_test.go
+++ b/internal/pathutil/resolve_test.go
@@ -1,0 +1,67 @@
+package pathutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestResolveForCompare_MissingLeafBehindSymlink pins the property the whole
+// helper exists for: two spellings of the same path must compare EQUAL even
+// when the final component does not exist. A plain filepath.EvalSymlinks
+// returns an error there and leaves callers comparing un-canonicalized strings,
+// which is how a path-identity probe silently returns the wrong answer on any
+// platform whose working root is a symlink (macOS /var -> /private/var, #2110).
+func TestResolveForCompare_MissingLeafBehindSymlink(t *testing.T) {
+	base := t.TempDir()
+	realRoot := filepath.Join(base, "real")
+	if err := os.MkdirAll(realRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linkRoot := filepath.Join(base, "link")
+	if err := os.Symlink(realRoot, linkRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	// The leaf deliberately does NOT exist — this is the post-deletion state
+	// every worktree registration probe runs in.
+	viaLink := filepath.Join(linkRoot, "gone")
+	viaReal := filepath.Join(realRoot, "gone")
+
+	if _, err := filepath.EvalSymlinks(viaLink); err == nil {
+		t.Fatal("sanity: EvalSymlinks should fail on a missing leaf")
+	}
+
+	// The contract is path IDENTITY, so assert that — not a literal string. The
+	// expectation cannot be spelled as a constant: under a symlinked TMPDIR the
+	// test's own `realRoot` still carries the symlinked prefix, so comparing
+	// against it would fail for the very reason this helper exists.
+	if ResolveForCompare(viaLink) != ResolveForCompare(viaReal) {
+		t.Errorf("both spellings of the same path must compare equal: %q vs %q",
+			ResolveForCompare(viaLink), ResolveForCompare(viaReal))
+	}
+
+	// And it must genuinely resolve rather than pass the input through: the
+	// symlinked ancestor is replaced, the missing leaf is preserved.
+	got := ResolveForCompare(viaLink)
+	resolvedRoot, err := filepath.EvalSymlinks(linkRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(resolvedRoot, "gone"); got != want {
+		t.Errorf("ResolveForCompare(%q) = %q, want %q", viaLink, got, want)
+	}
+	if filepath.Base(got) != "gone" {
+		t.Errorf("the missing leaf must be preserved, got %q", got)
+	}
+}
+
+// TestResolveForCompare_FallsBackToCleaned keeps the documented floor: a path
+// with nothing resolvable is still cleaned, so callers are never worse off than
+// comparing filepath.Clean output.
+func TestResolveForCompare_FallsBackToCleaned(t *testing.T) {
+	in := filepath.Join(string(filepath.Separator), "definitely", "not", "here", "..", "here", "x")
+	if got, want := ResolveForCompare(in), filepath.Clean(in); got != want {
+		t.Errorf("ResolveForCompare(%q) = %q, want cleaned %q", in, got, want)
+	}
+}

--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/internal/proctree"
 	"github.com/sachiniyer/agent-factory/log"
 )
@@ -405,16 +406,24 @@ func (r *cleanupRun) registered() (yes bool, ok bool) {
 	if err != nil {
 		return false, false
 	}
-	target := normalizeWorktreePath(r.g.worktreePath)
-	for _, line := range strings.Split(output, "\n") {
+	return worktreeListed(output, r.g.worktreePath), true
+}
+
+// worktreeListed reports whether `git worktree list --porcelain` output names
+// worktreePath. The single scanner behind every registration probe in this
+// package — the probes differ only in how they BOUND the git call, never in how
+// they read its answer.
+func worktreeListed(porcelain, worktreePath string) bool {
+	target := normalizeWorktreePath(worktreePath)
+	for _, line := range strings.Split(porcelain, "\n") {
 		if !strings.HasPrefix(line, "worktree ") {
 			continue
 		}
 		if normalizeWorktreePath(strings.TrimPrefix(line, "worktree ")) == target {
-			return true, true
+			return true
 		}
 	}
-	return false, true
+	return false
 }
 
 // state derives the run's outcome. Settled ONLY if nothing tripped a deadline.
@@ -558,27 +567,44 @@ func (g *GitWorktree) Cleanup() (CleanupState, error) {
 // read as "not ours" (#1917 round 4).
 func (r *cleanupRun) shouldRemoveWorktreeDir(removeErr error) bool {
 	registered, ok := r.registered()
-	if !ok {
-		// The probe could not be read — but WHY matters, and conflating the two
-		// reasons was itself a bug (found reviewing this PR's own diff).
-		if r.unknown {
-			// It TIMED OUT. Never act on a verdict we could not obtain, and never
-			// re-enter the unbounded delete on a filesystem that just stalled. The run
-			// is already unknown, so the record is retained and a retry can finish.
-			return false
-		}
-		// It ANSWERED with an error (a corrupted repo, not a stall). Nothing is
-		// unknown here, so refusing would report a SETTLED cleanup while leaving the
-		// directory on disk — the caller would then drop the record and orphan it,
-		// which is the outcome this whole PR exists to prevent. Fall back to the
-		// conservative #726 string gate, exactly as before this PR (#719/#726).
-		return strings.Contains(removeErr.Error(), "validation failed")
+	if !ok && r.unknown {
+		// The probe TIMED OUT. Never act on a verdict we could not obtain, and never
+		// re-enter the unbounded delete on a filesystem that just stalled. The run
+		// is already unknown, so the record is retained and a retry can finish.
+		//
+		// This branch is the RUN's, not the rule's — which is why it lives here and
+		// the rule itself is the shared function below. Conflating a stall with an
+		// error was itself a bug (found reviewing #1917's own diff).
+		return false
 	}
-	if !registered {
+	return mayDeleteWorktreeDir(registered, ok, removeErr)
+}
+
+// mayDeleteWorktreeDir is the #802/#726 ownership rule: after a failed
+// `git worktree remove -f`, may we delete the directory ourselves?
+//
+// It is shared by Cleanup (via shouldRemoveWorktreeDir) and by the factory
+// reset (RemoveWorktreeDir), which had no ownership check at all before #2110 —
+// it deleted unconditionally, which is how a locked worktree lost its directory
+// while keeping the registration that blocks its branch delete.
+//
+//   - Probe answered "not registered": git has let go of the worktree but the
+//     directory survived (#802). Ours to remove.
+//   - Probe answered "still registered": git owns the path. Only the
+//     conservative #726 corrupted-`.git`-pointer gate may delete — a locked
+//     worktree, submodules, or a permissions failure all land here and are
+//     surfaced instead of deleted.
+//   - Probe ANSWERED WITH AN ERROR (a corrupted repo, not a stall): nothing is
+//     unknown, so refusing would report a settled cleanup while leaving the
+//     directory on disk and the caller would drop the record and orphan it.
+//     Fall back to the same conservative string gate (#719/#726).
+//
+// A probe that could not be asked at all is the CALLER's to handle: never let
+// "could not ask" resolve to "not ours" or to "delete it".
+func mayDeleteWorktreeDir(registered, probeAnswered bool, removeErr error) bool {
+	if probeAnswered && !registered {
 		return true
 	}
-	// Still registered: only the conservative #726 corrupted-pointer gate may
-	// delete.
 	return strings.Contains(removeErr.Error(), "validation failed")
 }
 
@@ -594,16 +620,7 @@ func (g *GitWorktree) isWorktreeRegistered() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	target := normalizeWorktreePath(g.worktreePath)
-	for _, line := range strings.Split(output, "\n") {
-		if !strings.HasPrefix(line, "worktree ") {
-			continue
-		}
-		if normalizeWorktreePath(strings.TrimPrefix(line, "worktree ")) == target {
-			return true, nil
-		}
-	}
-	return false, nil
+	return worktreeListed(output, g.worktreePath), nil
 }
 
 // normalizeWorktreePath cleans the path and resolves symlinks (best-effort)
@@ -732,6 +749,12 @@ func pathAtOrUnder(root, p string) bool {
 	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
+// ErrWorktreeStillRegistered marks a worktree removal that did NOT complete:
+// git still lists the path as a linked worktree of the repo, so its branch
+// cannot be deleted. Callers classify on this to preserve the session record
+// (see commands/reset.go) instead of erasing it and orphaning the branch.
+var ErrWorktreeStillRegistered = errors.New("worktree is still registered with git")
+
 // RemoveWorktreeDir removes a SINGLE worktree directory that AF created for a
 // session in the repo at repoRoot, and prunes the registry. It deletes NO
 // branch. It reports whether a directory was actually removed.
@@ -747,6 +770,13 @@ func pathAtOrUnder(root, p string) bool {
 // A missing directory is not an error (idempotent: a second reset is a clean
 // no-op); the registry is still pruned so a stale entry cannot later block a
 // `git branch -D`.
+//
+// It VERIFIES the outcome rather than inferring it from exit codes (#2110).
+// `git worktree prune` REFUSES to prune a locked worktree's metadata and still
+// exits 0 — "prune ran" is not "the registration is gone" — so this re-probes
+// `git worktree list` afterwards and returns ErrWorktreeStillRegistered when the
+// registration survived. Reporting that success left the branch permanently
+// undeletable behind a "re-run to finish" message that could never finish.
 func RemoveWorktreeDir(repoRoot, worktreePath string) (bool, error) {
 	if repoRoot == "" || worktreePath == "" {
 		return false, nil
@@ -757,29 +787,61 @@ func RemoveWorktreeDir(repoRoot, worktreePath string) (bool, error) {
 		return false, nil
 	}
 
-	// If the directory is already gone, just prune any stale registry entry so a
-	// later branch delete isn't blocked, and report nothing removed.
-	if _, err := os.Stat(worktreePath); os.IsNotExist(err) {
-		_ = exec.Command("git", "-C", repoRoot, "worktree", "prune").Run()
-		return false, nil
-	}
-
-	// Reap any process still writing inside the tree before removing it (#2025) —
-	// the same race GitWorktree.Cleanup guards: a survivor re-creating files
-	// defeats both the git remove and the os.RemoveAll fallback. worktreePath here
-	// is always an AF-created session worktree (reset passes AF's own record paths
-	// and the main tree is refused above), so the cwd-scoped reap only ever hits
-	// this session's processes.
-	reapWorktreeWriters(worktreePath)
-
-	// Remove the worktree FIRST (git refuses to delete a branch checked out in a
-	// worktree). Fall back to a manual directory removal if git can't (e.g. the
-	// worktree was relocated to the archive and is no longer registered).
-	if err := exec.Command("git", "-C", repoRoot, "worktree", "remove", "-f", worktreePath).Run(); err != nil {
-		log.ErrorLog.Printf("failed to remove worktree %s: %v", worktreePath, err)
+	// A repo that is GONE registers nothing: there is no worktree list to consult,
+	// and no stale registration that could block a branch delete (there is no repo
+	// left to hold the branch either). Remove AF's orphaned directory and report
+	// it, rather than failing the verification below on a probe that cannot run —
+	// the same skip-and-proceed rule CleanupWorktreesForRepo applies to deleted
+	// repo roots. `af reset` legitimately iterates over records whose repo the user
+	// has since deleted, moved, or unmounted.
+	if _, err := os.Stat(repoRoot); os.IsNotExist(err) {
+		if _, err := os.Stat(worktreePath); os.IsNotExist(err) {
+			return false, nil
+		}
 		if rmErr := os.RemoveAll(worktreePath); rmErr != nil {
 			return false, fmt.Errorf("remove worktree dir %s: %w", worktreePath, rmErr)
 		}
+		return true, nil
+	}
+
+	removed := false
+	// A missing directory is not proof the registration is gone — git keeps the
+	// admin entry for a locked worktree whose directory was deleted out from under
+	// it. Skip the removal, but still run the prune-and-VERIFY below.
+	if _, err := os.Stat(worktreePath); err == nil {
+		// Reap any process still writing inside the tree before removing it (#2025) —
+		// the same race GitWorktree.Cleanup guards: a survivor re-creating files
+		// defeats both the git remove and the os.RemoveAll fallback. worktreePath here
+		// is always an AF-created session worktree (reset passes AF's own record paths
+		// and the main tree is refused above), so the cwd-scoped reap only ever hits
+		// this session's processes.
+		reapWorktreeWriters(worktreePath)
+
+		// Remove the worktree FIRST (git refuses to delete a branch checked out in a
+		// worktree). Fall back to a manual directory removal if git can't (e.g. the
+		// worktree was relocated to the archive and is no longer registered).
+		if err := exec.Command("git", "-C", repoRoot, "worktree", "remove", "-f", worktreePath).Run(); err != nil {
+			log.ErrorLog.Printf("failed to remove worktree %s: %v", worktreePath, err)
+
+			// Ownership check, restored from Cleanup (#2110). The reset's fallback
+			// used to delete unconditionally, which is how a LOCKED worktree — a
+			// path git still owns — lost its directory while keeping the
+			// registration. Same rule, one shared function: only a deregistered
+			// worktree (or the #726 corrupted-pointer case) is ours to delete.
+			registered, probeErr := worktreeRegisteredIn(repoRoot, worktreePath)
+			if !mayDeleteWorktreeDir(registered, probeErr == nil, err) {
+				if probeErr != nil {
+					// Do not name a lock we never confirmed: the probe is what failed.
+					return false, fmt.Errorf("%w: could not determine whether git still owns worktree %s, so it was left in place: %w (git worktree remove: %v)",
+						ErrWorktreeStillRegistered, worktreePath, probeErr, err)
+				}
+				return false, worktreeStillRegisteredError(repoRoot, worktreePath, err)
+			}
+			if rmErr := os.RemoveAll(worktreePath); rmErr != nil {
+				return false, fmt.Errorf("remove worktree dir %s: %w", worktreePath, rmErr)
+			}
+		}
+		removed = true
 	}
 
 	// Prune stale metadata so a subsequent `git branch -D` for this session's
@@ -787,7 +849,57 @@ func RemoveWorktreeDir(repoRoot, worktreePath string) (bool, error) {
 	if err := exec.Command("git", "-C", repoRoot, "worktree", "prune").Run(); err != nil {
 		log.ErrorLog.Printf("failed to prune worktrees for %s: %v", repoRoot, err)
 	}
-	return true, nil
+
+	// VERIFY. prune's exit 0 means "I ran", not "the metadata is gone": it
+	// silently declines to prune a locked worktree. Ask git what it actually
+	// still tracks — the registration, not the exit code, is what blocks the
+	// branch delete the caller is about to attempt.
+	//
+	// A probe that ERRORS is not evidence of success either; report it rather
+	// than let the caller drop the record on an answer we never got.
+	registered, probeErr := worktreeRegisteredIn(repoRoot, worktreePath)
+	if probeErr != nil {
+		return removed, fmt.Errorf("%w: could not verify that worktree %s was deregistered: %w",
+			ErrWorktreeStillRegistered, worktreePath, probeErr)
+	}
+	if registered {
+		return removed, worktreeStillRegisteredError(repoRoot, worktreePath, nil)
+	}
+	return removed, nil
+}
+
+// worktreeRegisteredIn reports whether git still lists worktreePath as a linked
+// worktree of the repo at repoRoot. The free-function counterpart of
+// GitWorktree.isWorktreeRegistered, for callers (the factory reset) that hold
+// only two paths; both read the answer through worktreeListed.
+func worktreeRegisteredIn(repoRoot, worktreePath string) (bool, error) {
+	out, err := exec.Command("git", "-C", repoRoot, "worktree", "list", "--porcelain").Output()
+	if err != nil {
+		return false, err
+	}
+	return worktreeListed(string(out), worktreePath), nil
+}
+
+// worktreeStillRegisteredError builds the ACTIONABLE failure for a worktree git
+// would not let go of. The old message ("re-run `af reset` to finish") was a
+// lie in two ways: a re-run repeated the identical failure, and the session
+// record had already been deleted so a re-run planned nothing at all. Name the
+// command that actually unblocks it, and keep the record so the re-run has
+// something to revisit (see commands/reset.go).
+//
+// AF deliberately does not force past the lock itself (`remove -f -f`): a lock
+// is a human saying "in use", and overriding it is the caller's call to make.
+func worktreeStillRegisteredError(repoRoot, worktreePath string, cause error) error {
+	// The recovery is meant to be PASTED, so quote the paths (#1978): an AF
+	// worktree path with a space would otherwise become two arguments.
+	msg := fmt.Sprintf("%s is still a registered git worktree, so its branch cannot be deleted"+
+		" — a locked worktree is the usual cause (`git worktree prune` refuses to prune one and still exits 0)."+
+		" Recover with: git -C %s worktree unlock %s && af reset",
+		worktreePath, config.ShellQuotePath(repoRoot), config.ShellQuotePath(worktreePath))
+	if cause != nil {
+		return fmt.Errorf("%w: %s (git worktree remove: %w)", ErrWorktreeStillRegistered, msg, cause)
+	}
+	return fmt.Errorf("%w: %s", ErrWorktreeStillRegistered, msg)
 }
 
 // CleanupWorktreesForRepo removes all worktrees and their associated branches

--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/internal/proctree"
 	"github.com/sachiniyer/agent-factory/log"
 )
@@ -409,23 +408,6 @@ func (r *cleanupRun) registered() (yes bool, ok bool) {
 	return worktreeListed(output, r.g.worktreePath), true
 }
 
-// worktreeListed reports whether `git worktree list --porcelain` output names
-// worktreePath. The single scanner behind every registration probe in this
-// package — the probes differ only in how they BOUND the git call, never in how
-// they read its answer.
-func worktreeListed(porcelain, worktreePath string) bool {
-	target := normalizeWorktreePath(worktreePath)
-	for _, line := range strings.Split(porcelain, "\n") {
-		if !strings.HasPrefix(line, "worktree ") {
-			continue
-		}
-		if normalizeWorktreePath(strings.TrimPrefix(line, "worktree ")) == target {
-			return true
-		}
-	}
-	return false
-}
-
 // state derives the run's outcome. Settled ONLY if nothing tripped a deadline.
 func (r *cleanupRun) state() CleanupState {
 	if r.unknown {
@@ -580,34 +562,6 @@ func (r *cleanupRun) shouldRemoveWorktreeDir(removeErr error) bool {
 	return mayDeleteWorktreeDir(registered, ok, removeErr)
 }
 
-// mayDeleteWorktreeDir is the #802/#726 ownership rule: after a failed
-// `git worktree remove -f`, may we delete the directory ourselves?
-//
-// It is shared by Cleanup (via shouldRemoveWorktreeDir) and by the factory
-// reset (RemoveWorktreeDir), which had no ownership check at all before #2110 —
-// it deleted unconditionally, which is how a locked worktree lost its directory
-// while keeping the registration that blocks its branch delete.
-//
-//   - Probe answered "not registered": git has let go of the worktree but the
-//     directory survived (#802). Ours to remove.
-//   - Probe answered "still registered": git owns the path. Only the
-//     conservative #726 corrupted-`.git`-pointer gate may delete — a locked
-//     worktree, submodules, or a permissions failure all land here and are
-//     surfaced instead of deleted.
-//   - Probe ANSWERED WITH AN ERROR (a corrupted repo, not a stall): nothing is
-//     unknown, so refusing would report a settled cleanup while leaving the
-//     directory on disk and the caller would drop the record and orphan it.
-//     Fall back to the same conservative string gate (#719/#726).
-//
-// A probe that could not be asked at all is the CALLER's to handle: never let
-// "could not ask" resolve to "not ours" or to "delete it".
-func mayDeleteWorktreeDir(registered, probeAnswered bool, removeErr error) bool {
-	if probeAnswered && !registered {
-		return true
-	}
-	return strings.Contains(removeErr.Error(), "validation failed")
-}
-
 // isWorktreeRegistered reports whether git still lists g.worktreePath as a
 // registered worktree of the repo. Used after a failed `git worktree remove`
 // to distinguish "git released the worktree but the directory survived"
@@ -621,17 +575,6 @@ func (g *GitWorktree) isWorktreeRegistered() (bool, error) {
 		return false, err
 	}
 	return worktreeListed(output, g.worktreePath), nil
-}
-
-// normalizeWorktreePath cleans the path and resolves symlinks (best-effort)
-// so `worktree list` output compares equal to a stored path even when one
-// side went through a symlinked parent (e.g. /tmp -> /private/tmp on macOS).
-func normalizeWorktreePath(p string) string {
-	p = filepath.Clean(p)
-	if resolved, err := filepath.EvalSymlinks(p); err == nil {
-		return resolved
-	}
-	return p
 }
 
 var (
@@ -747,159 +690,6 @@ func pathAtOrUnder(root, p string) bool {
 		return false
 	}
 	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
-}
-
-// ErrWorktreeStillRegistered marks a worktree removal that did NOT complete:
-// git still lists the path as a linked worktree of the repo, so its branch
-// cannot be deleted. Callers classify on this to preserve the session record
-// (see commands/reset.go) instead of erasing it and orphaning the branch.
-var ErrWorktreeStillRegistered = errors.New("worktree is still registered with git")
-
-// RemoveWorktreeDir removes a SINGLE worktree directory that AF created for a
-// session in the repo at repoRoot, and prunes the registry. It deletes NO
-// branch. It reports whether a directory was actually removed.
-//
-// This is the factory reset's only worktree-removal path (`af reset`, #1736):
-// reset must remove ONLY the worktrees AF created — identified by the paths in
-// AF's own session records — and NEVER the user's manually-created linked
-// worktrees, so there is deliberately no per-repo bulk pass. It also refuses to
-// touch the main worktree: a worktreePath that resolves to repoRoot (an
-// external `--here` session's tree) is a no-op. Branch deletion is handled
-// separately, gated on BranchCreatedByUs, so this never removes a branch either.
-//
-// A missing directory is not an error (idempotent: a second reset is a clean
-// no-op); the registry is still pruned so a stale entry cannot later block a
-// `git branch -D`.
-//
-// It VERIFIES the outcome rather than inferring it from exit codes (#2110).
-// `git worktree prune` REFUSES to prune a locked worktree's metadata and still
-// exits 0 — "prune ran" is not "the registration is gone" — so this re-probes
-// `git worktree list` afterwards and returns ErrWorktreeStillRegistered when the
-// registration survived. Reporting that success left the branch permanently
-// undeletable behind a "re-run to finish" message that could never finish.
-func RemoveWorktreeDir(repoRoot, worktreePath string) (bool, error) {
-	if repoRoot == "" || worktreePath == "" {
-		return false, nil
-	}
-	// Never remove the main repo/working tree (e.g. an external --here session
-	// whose worktree path IS the user's repo).
-	if filepath.Clean(repoRoot) == filepath.Clean(worktreePath) {
-		return false, nil
-	}
-
-	// A repo that is GONE registers nothing: there is no worktree list to consult,
-	// and no stale registration that could block a branch delete (there is no repo
-	// left to hold the branch either). Remove AF's orphaned directory and report
-	// it, rather than failing the verification below on a probe that cannot run —
-	// the same skip-and-proceed rule CleanupWorktreesForRepo applies to deleted
-	// repo roots. `af reset` legitimately iterates over records whose repo the user
-	// has since deleted, moved, or unmounted.
-	if _, err := os.Stat(repoRoot); os.IsNotExist(err) {
-		if _, err := os.Stat(worktreePath); os.IsNotExist(err) {
-			return false, nil
-		}
-		if rmErr := os.RemoveAll(worktreePath); rmErr != nil {
-			return false, fmt.Errorf("remove worktree dir %s: %w", worktreePath, rmErr)
-		}
-		return true, nil
-	}
-
-	removed := false
-	// A missing directory is not proof the registration is gone — git keeps the
-	// admin entry for a locked worktree whose directory was deleted out from under
-	// it. Skip the removal, but still run the prune-and-VERIFY below.
-	if _, err := os.Stat(worktreePath); err == nil {
-		// Reap any process still writing inside the tree before removing it (#2025) —
-		// the same race GitWorktree.Cleanup guards: a survivor re-creating files
-		// defeats both the git remove and the os.RemoveAll fallback. worktreePath here
-		// is always an AF-created session worktree (reset passes AF's own record paths
-		// and the main tree is refused above), so the cwd-scoped reap only ever hits
-		// this session's processes.
-		reapWorktreeWriters(worktreePath)
-
-		// Remove the worktree FIRST (git refuses to delete a branch checked out in a
-		// worktree). Fall back to a manual directory removal if git can't (e.g. the
-		// worktree was relocated to the archive and is no longer registered).
-		if err := exec.Command("git", "-C", repoRoot, "worktree", "remove", "-f", worktreePath).Run(); err != nil {
-			log.ErrorLog.Printf("failed to remove worktree %s: %v", worktreePath, err)
-
-			// Ownership check, restored from Cleanup (#2110). The reset's fallback
-			// used to delete unconditionally, which is how a LOCKED worktree — a
-			// path git still owns — lost its directory while keeping the
-			// registration. Same rule, one shared function: only a deregistered
-			// worktree (or the #726 corrupted-pointer case) is ours to delete.
-			registered, probeErr := worktreeRegisteredIn(repoRoot, worktreePath)
-			if !mayDeleteWorktreeDir(registered, probeErr == nil, err) {
-				if probeErr != nil {
-					// Do not name a lock we never confirmed: the probe is what failed.
-					return false, fmt.Errorf("%w: could not determine whether git still owns worktree %s, so it was left in place: %w (git worktree remove: %v)",
-						ErrWorktreeStillRegistered, worktreePath, probeErr, err)
-				}
-				return false, worktreeStillRegisteredError(repoRoot, worktreePath, err)
-			}
-			if rmErr := os.RemoveAll(worktreePath); rmErr != nil {
-				return false, fmt.Errorf("remove worktree dir %s: %w", worktreePath, rmErr)
-			}
-		}
-		removed = true
-	}
-
-	// Prune stale metadata so a subsequent `git branch -D` for this session's
-	// branch isn't blocked by a lingering worktree registration.
-	if err := exec.Command("git", "-C", repoRoot, "worktree", "prune").Run(); err != nil {
-		log.ErrorLog.Printf("failed to prune worktrees for %s: %v", repoRoot, err)
-	}
-
-	// VERIFY. prune's exit 0 means "I ran", not "the metadata is gone": it
-	// silently declines to prune a locked worktree. Ask git what it actually
-	// still tracks — the registration, not the exit code, is what blocks the
-	// branch delete the caller is about to attempt.
-	//
-	// A probe that ERRORS is not evidence of success either; report it rather
-	// than let the caller drop the record on an answer we never got.
-	registered, probeErr := worktreeRegisteredIn(repoRoot, worktreePath)
-	if probeErr != nil {
-		return removed, fmt.Errorf("%w: could not verify that worktree %s was deregistered: %w",
-			ErrWorktreeStillRegistered, worktreePath, probeErr)
-	}
-	if registered {
-		return removed, worktreeStillRegisteredError(repoRoot, worktreePath, nil)
-	}
-	return removed, nil
-}
-
-// worktreeRegisteredIn reports whether git still lists worktreePath as a linked
-// worktree of the repo at repoRoot. The free-function counterpart of
-// GitWorktree.isWorktreeRegistered, for callers (the factory reset) that hold
-// only two paths; both read the answer through worktreeListed.
-func worktreeRegisteredIn(repoRoot, worktreePath string) (bool, error) {
-	out, err := exec.Command("git", "-C", repoRoot, "worktree", "list", "--porcelain").Output()
-	if err != nil {
-		return false, err
-	}
-	return worktreeListed(string(out), worktreePath), nil
-}
-
-// worktreeStillRegisteredError builds the ACTIONABLE failure for a worktree git
-// would not let go of. The old message ("re-run `af reset` to finish") was a
-// lie in two ways: a re-run repeated the identical failure, and the session
-// record had already been deleted so a re-run planned nothing at all. Name the
-// command that actually unblocks it, and keep the record so the re-run has
-// something to revisit (see commands/reset.go).
-//
-// AF deliberately does not force past the lock itself (`remove -f -f`): a lock
-// is a human saying "in use", and overriding it is the caller's call to make.
-func worktreeStillRegisteredError(repoRoot, worktreePath string, cause error) error {
-	// The recovery is meant to be PASTED, so quote the paths (#1978): an AF
-	// worktree path with a space would otherwise become two arguments.
-	msg := fmt.Sprintf("%s is still a registered git worktree, so its branch cannot be deleted"+
-		" — a locked worktree is the usual cause (`git worktree prune` refuses to prune one and still exits 0)."+
-		" Recover with: git -C %s worktree unlock %s && af reset",
-		worktreePath, config.ShellQuotePath(repoRoot), config.ShellQuotePath(worktreePath))
-	if cause != nil {
-		return fmt.Errorf("%w: %s (git worktree remove: %w)", ErrWorktreeStillRegistered, msg, cause)
-	}
-	return fmt.Errorf("%w: %s", ErrWorktreeStillRegistered, msg)
 }
 
 // CleanupWorktreesForRepo removes all worktrees and their associated branches

--- a/session/git/worktree_remove.go
+++ b/session/git/worktree_remove.go
@@ -1,0 +1,265 @@
+package git
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/pathutil"
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+// This file owns worktree REMOVAL and the registration identity it depends on:
+// the factory reset's removal path (#1736, #2110), the shared ownership rule
+// that decides when a directory is AF's to delete, and the path/porcelain
+// primitives both this file and Cleanup() compare registrations with.
+//
+// Split out of worktree_ops.go for the file-length limit (#1145). Same package,
+// same behavior — Cleanup() still calls straight into the helpers below.
+
+// ErrWorktreeStillRegistered marks a worktree removal that did NOT complete:
+// git still lists the path as a linked worktree of the repo, so its branch
+// cannot be deleted. Callers classify on this to preserve the session record
+// (see commands/reset.go) instead of erasing it and orphaning the branch.
+var ErrWorktreeStillRegistered = errors.New("worktree is still registered with git")
+
+// RemoveWorktreeDir removes a SINGLE worktree directory that AF created for a
+// session in the repo at repoRoot, and prunes the registry. It deletes NO
+// branch. It reports whether a directory was actually removed.
+//
+// This is the factory reset's only worktree-removal path (`af reset`, #1736):
+// reset must remove ONLY the worktrees AF created — identified by the paths in
+// AF's own session records — and NEVER the user's manually-created linked
+// worktrees, so there is deliberately no per-repo bulk pass. It also refuses to
+// touch the main worktree: a worktreePath that resolves to repoRoot (an
+// external `--here` session's tree) is a no-op. Branch deletion is handled
+// separately, gated on BranchCreatedByUs, so this never removes a branch either.
+//
+// A missing directory is not an error (idempotent: a second reset is a clean
+// no-op); the registry is still pruned so a stale entry cannot later block a
+// `git branch -D`.
+//
+// It VERIFIES the outcome rather than inferring it from exit codes (#2110).
+// `git worktree prune` REFUSES to prune a locked worktree's metadata and still
+// exits 0 — "prune ran" is not "the registration is gone" — so this re-probes
+// `git worktree list` afterwards and returns ErrWorktreeStillRegistered when the
+// registration survived. Reporting that success left the branch permanently
+// undeletable behind a "re-run to finish" message that could never finish.
+func RemoveWorktreeDir(repoRoot, worktreePath string) (bool, error) {
+	if repoRoot == "" || worktreePath == "" {
+		return false, nil
+	}
+	// Never remove the main repo/working tree (e.g. an external --here session
+	// whose worktree path IS the user's repo).
+	if filepath.Clean(repoRoot) == filepath.Clean(worktreePath) {
+		return false, nil
+	}
+
+	// A repo that registers nothing has no worktree list to consult and no stale
+	// registration that could block a branch delete — there is no repo left to hold
+	// the branch either. Remove AF's orphaned directory and report it, rather than
+	// failing the verification below on a probe that cannot run. This is the same
+	// skip-and-proceed rule CleanupWorktreesForRepo applies to deleted repo roots,
+	// and `af reset` legitimately iterates over records whose repo the user has
+	// since deleted, moved, unmounted, or stripped of its .git.
+	if repoRegistersNothing(repoRoot) {
+		if _, err := os.Stat(worktreePath); os.IsNotExist(err) {
+			return false, nil
+		}
+		if rmErr := os.RemoveAll(worktreePath); rmErr != nil {
+			return false, fmt.Errorf("remove worktree dir %s: %w", worktreePath, rmErr)
+		}
+		return true, nil
+	}
+
+	removed := false
+	// A missing directory is not proof the registration is gone — git keeps the
+	// admin entry for a locked worktree whose directory was deleted out from under
+	// it. Skip the removal, but still run the prune-and-VERIFY below.
+	if _, err := os.Stat(worktreePath); err == nil {
+		// Reap any process still writing inside the tree before removing it (#2025) —
+		// the same race GitWorktree.Cleanup guards: a survivor re-creating files
+		// defeats both the git remove and the os.RemoveAll fallback. worktreePath here
+		// is always an AF-created session worktree (reset passes AF's own record paths
+		// and the main tree is refused above), so the cwd-scoped reap only ever hits
+		// this session's processes.
+		reapWorktreeWriters(worktreePath)
+
+		// Remove the worktree FIRST (git refuses to delete a branch checked out in a
+		// worktree). Fall back to a manual directory removal if git can't (e.g. the
+		// worktree was relocated to the archive and is no longer registered).
+		if err := exec.Command("git", "-C", repoRoot, "worktree", "remove", "-f", worktreePath).Run(); err != nil {
+			log.ErrorLog.Printf("failed to remove worktree %s: %v", worktreePath, err)
+
+			// Ownership check, restored from Cleanup (#2110). The reset's fallback
+			// used to delete unconditionally, which is how a LOCKED worktree — a
+			// path git still owns — lost its directory while keeping the
+			// registration. Same rule, one shared function: only a deregistered
+			// worktree (or the #726 corrupted-pointer case) is ours to delete.
+			registered, probeErr := worktreeRegisteredIn(repoRoot, worktreePath)
+			if !mayDeleteWorktreeDir(registered, probeErr == nil, err) {
+				if probeErr != nil {
+					// Do not name a lock we never confirmed: the probe is what failed.
+					return false, fmt.Errorf("%w: could not determine whether git still owns worktree %s, so it was left in place: %w (git worktree remove: %v)",
+						ErrWorktreeStillRegistered, worktreePath, probeErr, err)
+				}
+				return false, worktreeStillRegisteredError(repoRoot, worktreePath, err)
+			}
+			if rmErr := os.RemoveAll(worktreePath); rmErr != nil {
+				return false, fmt.Errorf("remove worktree dir %s: %w", worktreePath, rmErr)
+			}
+		}
+		removed = true
+	}
+
+	// Prune stale metadata so a subsequent `git branch -D` for this session's
+	// branch isn't blocked by a lingering worktree registration.
+	if err := exec.Command("git", "-C", repoRoot, "worktree", "prune").Run(); err != nil {
+		log.ErrorLog.Printf("failed to prune worktrees for %s: %v", repoRoot, err)
+	}
+
+	// VERIFY. prune's exit 0 means "I ran", not "the metadata is gone": it
+	// silently declines to prune a locked worktree. Ask git what it actually
+	// still tracks — the registration, not the exit code, is what blocks the
+	// branch delete the caller is about to attempt.
+	//
+	// A probe that ERRORS is not evidence of success either; report it rather
+	// than let the caller drop the record on an answer we never got.
+	registered, probeErr := worktreeRegisteredIn(repoRoot, worktreePath)
+	if probeErr != nil {
+		return removed, fmt.Errorf("%w: could not verify that worktree %s was deregistered: %w",
+			ErrWorktreeStillRegistered, worktreePath, probeErr)
+	}
+	if registered {
+		return removed, worktreeStillRegisteredError(repoRoot, worktreePath, nil)
+	}
+	return removed, nil
+}
+
+// repoRegistersNothing reports whether repoRoot definitively cannot hold a
+// worktree registration: the directory is gone, or it is no longer a git repo
+// because its .git is gone.
+//
+// Both are DIRECT filesystem observations, deliberately — not inferences from a
+// failed git command. "git errored, so there must be no repo" is the reasoning
+// this whole change exists to remove, and it would turn a transient failure
+// (permissions, an unmounted parent) into a deletion. An error that is not
+// "does not exist" therefore leaves the conservative path below to handle it.
+//
+// The alternative — letting a de-git'd repo fall through to the probe — reads
+// worse than it sounds: the probe fails, the worktree is reported as possibly
+// still registered, and reset retains the session record. But no re-run could
+// ever clear it, so the user is left with a permanent record and advice to
+// unlock a worktree that no longer has a repo to be registered with. That is the
+// same unactionable dead end #2110 is about, so this case is settled here.
+func repoRegistersNothing(repoRoot string) bool {
+	if _, err := os.Stat(repoRoot); os.IsNotExist(err) {
+		return true
+	}
+	// .git is a directory in a main worktree and a file in a linked one; Stat
+	// accepts either.
+	if _, err := os.Stat(filepath.Join(repoRoot, ".git")); os.IsNotExist(err) {
+		return true
+	}
+	return false
+}
+
+// worktreeRegisteredIn reports whether git still lists worktreePath as a linked
+// worktree of the repo at repoRoot. The free-function counterpart of
+// GitWorktree.isWorktreeRegistered, for callers (the factory reset) that hold
+// only two paths; both read the answer through worktreeListed.
+func worktreeRegisteredIn(repoRoot, worktreePath string) (bool, error) {
+	out, err := exec.Command("git", "-C", repoRoot, "worktree", "list", "--porcelain").Output()
+	if err != nil {
+		return false, err
+	}
+	return worktreeListed(string(out), worktreePath), nil
+}
+
+// worktreeStillRegisteredError builds the ACTIONABLE failure for a worktree git
+// would not let go of. The old message ("re-run `af reset` to finish") was a
+// lie in two ways: a re-run repeated the identical failure, and the session
+// record had already been deleted so a re-run planned nothing at all. Name the
+// command that actually unblocks it, and keep the record so the re-run has
+// something to revisit (see commands/reset.go).
+//
+// AF deliberately does not force past the lock itself (`remove -f -f`): a lock
+// is a human saying "in use", and overriding it is the caller's call to make.
+func worktreeStillRegisteredError(repoRoot, worktreePath string, cause error) error {
+	// The recovery is meant to be PASTED, so quote the paths (#1978): an AF
+	// worktree path with a space would otherwise become two arguments.
+	msg := fmt.Sprintf("%s is still a registered git worktree, so its branch cannot be deleted"+
+		" — a locked worktree is the usual cause (`git worktree prune` refuses to prune one and still exits 0)."+
+		" Recover with: git -C %s worktree unlock %s && af reset",
+		worktreePath, config.ShellQuotePath(repoRoot), config.ShellQuotePath(worktreePath))
+	if cause != nil {
+		return fmt.Errorf("%w: %s (git worktree remove: %w)", ErrWorktreeStillRegistered, msg, cause)
+	}
+	return fmt.Errorf("%w: %s", ErrWorktreeStillRegistered, msg)
+}
+
+// mayDeleteWorktreeDir is the #802/#726 ownership rule: after a failed
+// `git worktree remove -f`, may we delete the directory ourselves?
+//
+// It is shared by Cleanup (via shouldRemoveWorktreeDir) and by the factory
+// reset (RemoveWorktreeDir), which had no ownership check at all before #2110 —
+// it deleted unconditionally, which is how a locked worktree lost its directory
+// while keeping the registration that blocks its branch delete.
+//
+//   - Probe answered "not registered": git has let go of the worktree but the
+//     directory survived (#802). Ours to remove.
+//   - Probe answered "still registered": git owns the path. Only the
+//     conservative #726 corrupted-`.git`-pointer gate may delete — a locked
+//     worktree, submodules, or a permissions failure all land here and are
+//     surfaced instead of deleted.
+//   - Probe ANSWERED WITH AN ERROR (a corrupted repo, not a stall): nothing is
+//     unknown, so refusing would report a settled cleanup while leaving the
+//     directory on disk and the caller would drop the record and orphan it.
+//     Fall back to the same conservative string gate (#719/#726).
+//
+// A probe that could not be asked at all is the CALLER's to handle: never let
+// "could not ask" resolve to "not ours" or to "delete it".
+func mayDeleteWorktreeDir(registered, probeAnswered bool, removeErr error) bool {
+	if probeAnswered && !registered {
+		return true
+	}
+	return strings.Contains(removeErr.Error(), "validation failed")
+}
+
+// worktreeListed reports whether `git worktree list --porcelain` output names
+// worktreePath. The single scanner behind every registration probe in this
+// package — the probes differ only in how they BOUND the git call, never in how
+// they read its answer.
+func worktreeListed(porcelain, worktreePath string) bool {
+	target := normalizeWorktreePath(worktreePath)
+	for _, line := range strings.Split(porcelain, "\n") {
+		if !strings.HasPrefix(line, "worktree ") {
+			continue
+		}
+		if normalizeWorktreePath(strings.TrimPrefix(line, "worktree ")) == target {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizeWorktreePath cleans the path and resolves symlinks so `worktree list`
+// output compares equal to a stored path even when one side went through a
+// symlinked parent (e.g. /var -> /private/var on macOS). git reports the
+// CANONICAL path; AF stores whatever spelling the session was created with, so
+// both sides must be canonicalized the same way or the comparison is meaningless.
+//
+// It resolves through the deepest EXISTING ancestor, which is the difference
+// that matters (#2110). The old plain EvalSymlinks gave up on a path whose last
+// component had just been deleted — precisely the state every post-removal probe
+// runs in — so on a symlinked root neither side got canonicalized and a
+// still-registered worktree compared as absent. A probe that could not resolve
+// the path answered "not registered" with full confidence, which is the same
+// fabricated negative this file's verification exists to prevent, one layer down.
+func normalizeWorktreePath(p string) string {
+	return pathutil.ResolveForCompare(p)
+}

--- a/session/git/worktree_reset_locked_test.go
+++ b/session/git/worktree_reset_locked_test.go
@@ -165,6 +165,64 @@ func TestRemoveWorktreeDir_MissingDirWithLockedMetadata(t *testing.T) {
 	require.ErrorIs(t, err, ErrWorktreeStillRegistered)
 }
 
+// TestRemoveWorktreeDir_SymlinkedRootWithMissingDir is the darwin-only bug this
+// fix originally shipped with, pinned so it cannot come back on any platform.
+//
+// macOS puts temp/working roots behind a symlink (/var -> /private/var), and git
+// reports the CANONICAL path in `worktree list --porcelain` while AF holds the
+// spelling the session was created with. The registration probe compared the two
+// raw strings. That works while the checkout exists — EvalSymlinks canonicalizes
+// both sides — but every post-removal probe runs with the leaf DELETED, where
+// plain EvalSymlinks fails on both sides and neither gets canonicalized. The
+// probe then reported a still-locked worktree as "not registered": a fabricated
+// negative, the exact failure mode the verification above exists to catch.
+//
+// The symlinked root is built INSIDE the test rather than taken from TMPDIR, so
+// this reproduces on Linux CI too instead of only on the macOS runner (#2110).
+func TestRemoveWorktreeDir_SymlinkedRootWithMissingDir(t *testing.T) {
+	base := t.TempDir()
+	realRoot := filepath.Join(base, "real")
+	require.NoError(t, os.MkdirAll(realRoot, 0o755))
+	linkRoot := filepath.Join(base, "link")
+	require.NoError(t, os.Symlink(realRoot, linkRoot))
+
+	// Everything below is addressed through the SYMLINK, exactly as an AF record
+	// created under macOS /var would be; git canonicalizes to realRoot internally.
+	repoRoot := filepath.Join(linkRoot, "repo")
+	require.NoError(t, os.MkdirAll(repoRoot, 0o755))
+	git := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", repoRoot}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+		)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %s: %s", strings.Join(args, " "), string(out))
+	}
+	git("init", "-q", "-b", "master", ".")
+	git("commit", "-q", "--allow-empty", "-m", "initial")
+
+	worktreePath := filepath.Join(linkRoot, "wt-symlinked")
+	git("worktree", "add", "-q", "-b", "symlinked", worktreePath)
+	git("worktree", "lock", worktreePath, "--reason", "still in use")
+
+	// Sanity: git really does report a DIFFERENT spelling than the one AF holds.
+	listed, err := exec.Command("git", "-C", repoRoot, "worktree", "list", "--porcelain").Output()
+	require.NoError(t, err)
+	require.NotContains(t, string(listed), linkRoot,
+		"sanity: git should report the canonical (non-symlinked) path")
+
+	// The half-cleaned state: directory gone, locked metadata retained. Neither
+	// side of the comparison can be resolved by a plain EvalSymlinks now.
+	require.NoError(t, os.RemoveAll(worktreePath))
+
+	_, err = RemoveWorktreeDir(repoRoot, worktreePath)
+	require.Error(t, err,
+		"a still-registered worktree must be detected even when the record's path is spelled through a symlink")
+	require.ErrorIs(t, err, ErrWorktreeStillRegistered)
+}
+
 // TestRemoveWorktreeDir_DeletedRepoStillRemovesOrphanDir guards the other side
 // of the #2110 verification: a repo the user has deleted registers nothing, so
 // the probe that cannot run must NOT be read as "still registered" and leak AF's
@@ -177,6 +235,28 @@ func TestRemoveWorktreeDir_DeletedRepoStillRemovesOrphanDir(t *testing.T) {
 
 	removed, err := RemoveWorktreeDir(repoRoot, worktreePath)
 	require.NoError(t, err, "a deleted repo is not a failed cleanup")
+	assert.True(t, removed)
+
+	_, statErr := os.Stat(worktreePath)
+	assert.True(t, os.IsNotExist(statErr), "the orphaned worktree directory should be removed")
+}
+
+// TestRemoveWorktreeDir_DeGittedRepoStillRemovesOrphanDir pins the de-git'd repo
+// edge: the directory survives but its .git is gone, so it registers nothing.
+//
+// The conservative reading ("the probe failed, so maybe it is still registered")
+// would retain the record and tell the user to unlock a worktree that has no repo
+// to be registered with — advice no re-run could ever satisfy. Since "not a git
+// repo" is directly observable rather than inferred from a git error, reset
+// settles it instead of leaving an unclearable record behind (#2110).
+func TestRemoveWorktreeDir_DeGittedRepoStillRemovesOrphanDir(t *testing.T) {
+	repoRoot, worktreePath, _ := resetRepoWithWorktree(t, "degitted")
+
+	// The user blew away .git but kept the working tree.
+	require.NoError(t, os.RemoveAll(filepath.Join(repoRoot, ".git")))
+
+	removed, err := RemoveWorktreeDir(repoRoot, worktreePath)
+	require.NoError(t, err, "a repo that registers nothing is not a failed cleanup")
 	assert.True(t, removed)
 
 	_, statErr := os.Stat(worktreePath)

--- a/session/git/worktree_reset_locked_test.go
+++ b/session/git/worktree_reset_locked_test.go
@@ -1,0 +1,199 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resetRepoWithWorktree builds a THROWAWAY repo in t.TempDir() with one linked
+// worktree on its own branch, and returns (repoRoot, worktreePath, branch).
+//
+// It deliberately uses the git CLI directly rather than NewGitWorktree: these
+// tests exercise the factory reset's free-function removal path, which takes
+// only a repo root and a worktree path, and must not depend on an AF home.
+func resetRepoWithWorktree(t *testing.T, branch string) (string, string, string) {
+	t.Helper()
+
+	base := t.TempDir()
+	repoRoot := filepath.Join(base, "repo")
+	require.NoError(t, os.MkdirAll(repoRoot, 0o755))
+
+	git := func(dir string, args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+		)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %s: %s", strings.Join(args, " "), string(out))
+		return string(out)
+	}
+
+	git(repoRoot, "init", "-q", "-b", "master", ".")
+	git(repoRoot, "commit", "-q", "--allow-empty", "-m", "initial")
+
+	worktreePath := filepath.Join(base, "wt-"+branch)
+	git(repoRoot, "worktree", "add", "-q", "-b", branch, worktreePath)
+
+	return repoRoot, worktreePath, branch
+}
+
+// worktreeMetadataDir is the .git/worktrees/<id> admin directory git keeps for a
+// linked worktree. Its survival is what blocks `git branch -D`.
+func worktreeMetadataDir(repoRoot, worktreePath string) string {
+	return filepath.Join(repoRoot, ".git", "worktrees", filepath.Base(worktreePath))
+}
+
+// TestRemoveWorktreeDir_LockedWorktreeIsReportedAsIncomplete is the #2110
+// regression lock.
+//
+// `git worktree prune` REFUSES to prune a locked worktree's metadata and still
+// exits 0 — "I ran" is not "the metadata is gone". Trusting that exit code made
+// reset report success while `.git/worktrees/<id>` survived, which then blocked
+// `git branch -D` and left the branch stuck with no recovery path.
+func TestRemoveWorktreeDir_LockedWorktreeIsReportedAsIncomplete(t *testing.T) {
+	repoRoot, worktreePath, branch := resetRepoWithWorktree(t, "locked")
+
+	lock := exec.Command("git", "-C", repoRoot, "worktree", "lock", worktreePath, "--reason", "still in use")
+	out, err := lock.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	_, err = RemoveWorktreeDir(repoRoot, worktreePath)
+
+	// 1. The failure must be SURFACED, not swallowed behind prune's exit 0.
+	require.Error(t, err,
+		"RemoveWorktreeDir must report failure when the worktree metadata survives (#2110)")
+	require.ErrorIs(t, err, ErrWorktreeStillRegistered,
+		"the failure must be classifiable so reset can preserve the record")
+
+	// 2. The error must be ACTIONABLE: it must name the real recovery.
+	assert.Contains(t, err.Error(), "worktree unlock",
+		"the error must tell the user the actual recovery command")
+	assert.Contains(t, err.Error(), worktreePath,
+		"the error must name the worktree it could not remove")
+
+	// 3. The metadata git refused to prune is still there — that is the fact the
+	//    old code inferred away.
+	_, statErr := os.Stat(worktreeMetadataDir(repoRoot, worktreePath))
+	assert.NoError(t, statErr, "sanity: git keeps a locked worktree's metadata")
+
+	// 4. Ownership safety (#2110 History note): the directory is STILL a
+	//    registered git worktree, so it is not ours to os.RemoveAll — the same
+	//    rule Cleanup() applies via shouldRemoveWorktreeDir.
+	_, statErr = os.Stat(worktreePath)
+	assert.NoError(t, statErr,
+		"RemoveWorktreeDir must not delete a directory git still registers as a worktree")
+
+	// 5. The consequence the user actually hit: the branch cannot be deleted.
+	_, err = DeleteLocalBranch(repoRoot, branch)
+	assert.Error(t, err, "sanity: the surviving registration blocks branch deletion")
+}
+
+// TestRemoveWorktreeDir_UnlockRecoversTheWorktree proves the guidance in the
+// error is REAL: `git worktree unlock` + a re-run finishes the job. Recovery is
+// only possible because the failing run left the worktree directory intact.
+func TestRemoveWorktreeDir_UnlockRecoversTheWorktree(t *testing.T) {
+	repoRoot, worktreePath, branch := resetRepoWithWorktree(t, "recoverable")
+
+	lock := exec.Command("git", "-C", repoRoot, "worktree", "lock", worktreePath, "--reason", "still in use")
+	out, err := lock.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	_, err = RemoveWorktreeDir(repoRoot, worktreePath)
+	require.Error(t, err)
+
+	// Follow the error's own advice.
+	unlock := exec.Command("git", "-C", repoRoot, "worktree", "unlock", worktreePath)
+	out, err = unlock.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	removed, err := RemoveWorktreeDir(repoRoot, worktreePath)
+	require.NoError(t, err, "the documented recovery must actually finish the removal")
+	assert.True(t, removed)
+
+	_, statErr := os.Stat(worktreePath)
+	assert.True(t, os.IsNotExist(statErr), "worktree directory should be gone after unlock + retry")
+	_, statErr = os.Stat(worktreeMetadataDir(repoRoot, worktreePath))
+	assert.True(t, os.IsNotExist(statErr), "worktree metadata should be pruned after unlock + retry")
+
+	deleted, err := DeleteLocalBranch(repoRoot, branch)
+	require.NoError(t, err, "branch deletion must no longer be blocked")
+	assert.True(t, deleted)
+}
+
+// TestRemoveWorktreeDir_UnlockedWorktreeStillRemovesCleanly is the happy-path
+// regression guard: the verification added for #2110 must not turn a normal
+// removal into a failure.
+func TestRemoveWorktreeDir_UnlockedWorktreeStillRemovesCleanly(t *testing.T) {
+	repoRoot, worktreePath, branch := resetRepoWithWorktree(t, "normal")
+
+	removed, err := RemoveWorktreeDir(repoRoot, worktreePath)
+	require.NoError(t, err)
+	assert.True(t, removed, "an existing worktree directory was removed")
+
+	_, statErr := os.Stat(worktreePath)
+	assert.True(t, os.IsNotExist(statErr), "worktree directory should be gone")
+	_, statErr = os.Stat(worktreeMetadataDir(repoRoot, worktreePath))
+	assert.True(t, os.IsNotExist(statErr), "worktree metadata should be pruned")
+
+	deleted, err := DeleteLocalBranch(repoRoot, branch)
+	require.NoError(t, err)
+	assert.True(t, deleted, "branch deletion must succeed after a clean worktree removal")
+}
+
+// TestRemoveWorktreeDir_MissingDirWithLockedMetadata covers the half-cleaned
+// state an older AF version could leave behind (directory deleted, locked
+// metadata retained). The verification must catch it there too — the missing
+// directory is not evidence that the registration is gone.
+func TestRemoveWorktreeDir_MissingDirWithLockedMetadata(t *testing.T) {
+	repoRoot, worktreePath, _ := resetRepoWithWorktree(t, "halfcleaned")
+
+	lock := exec.Command("git", "-C", repoRoot, "worktree", "lock", worktreePath, "--reason", "still in use")
+	out, err := lock.CombinedOutput()
+	require.NoError(t, err, string(out))
+	require.NoError(t, os.RemoveAll(worktreePath))
+
+	_, err = RemoveWorktreeDir(repoRoot, worktreePath)
+	require.Error(t, err, "a missing directory must not be read as a completed cleanup")
+	require.ErrorIs(t, err, ErrWorktreeStillRegistered)
+}
+
+// TestRemoveWorktreeDir_DeletedRepoStillRemovesOrphanDir guards the other side
+// of the #2110 verification: a repo the user has deleted registers nothing, so
+// the probe that cannot run must NOT be read as "still registered" and leak AF's
+// orphaned worktree directory. `af reset` iterates records whose repo may be
+// gone, moved, or unmounted.
+func TestRemoveWorktreeDir_DeletedRepoStillRemovesOrphanDir(t *testing.T) {
+	repoRoot, worktreePath, _ := resetRepoWithWorktree(t, "orphan")
+
+	require.NoError(t, os.RemoveAll(repoRoot))
+
+	removed, err := RemoveWorktreeDir(repoRoot, worktreePath)
+	require.NoError(t, err, "a deleted repo is not a failed cleanup")
+	assert.True(t, removed)
+
+	_, statErr := os.Stat(worktreePath)
+	assert.True(t, os.IsNotExist(statErr), "the orphaned worktree directory should be removed")
+}
+
+// TestRemoveWorktreeDir_MissingDirAndMetadataIsCleanNoOp keeps the idempotence
+// contract: a second `af reset` over an already-removed worktree is silent
+// success, not a new error.
+func TestRemoveWorktreeDir_MissingDirAndMetadataIsCleanNoOp(t *testing.T) {
+	repoRoot, worktreePath, _ := resetRepoWithWorktree(t, "gone")
+
+	removed, err := RemoveWorktreeDir(repoRoot, worktreePath)
+	require.NoError(t, err)
+	require.True(t, removed)
+
+	removed, err = RemoveWorktreeDir(repoRoot, worktreePath)
+	require.NoError(t, err, "a second removal must be a clean no-op")
+	assert.False(t, removed)
+}


### PR DESCRIPTION
Fixes #2110

## The bug

`git worktree prune` **refuses to prune a locked worktree's metadata and still exits 0.** `RemoveWorktreeDir` read that exit code as "the registration is gone":

```go
if err := exec.Command("git", "-C", repoRoot, "worktree", "prune").Run(); err != nil { // <-- exit 0 even when it prunes nothing
	log.ErrorLog.Printf(...)
}
return true, nil   // <-- reports success
```

Observed directly in a throwaway repo (locked worktree, directory deleted, prune run):

```
$ git worktree remove -f ../wt
fatal: cannot remove a locked working tree, lock reason: still in use
use 'remove -f -f' to override or unlock first          → exit 128
$ rm -rf ../wt && git worktree prune                    → exit 0
$ ls .git/worktrees/                                    → wt        # still there
$ git branch -D feature
error: cannot delete branch 'feature' used by worktree at '.../wt'  → exit 1
```

So reset reported `PARTIAL` with *"Every step is idempotent — re-run `af reset` to finish"* — which could never finish, because reset deletes every session record on the first run. The re-run planned nothing and the branch stayed blocked indefinitely.

This is the repo's fabricated-positive pattern: **exit 0 means "prune ran", not "the metadata is gone."**

## The fix

**1. Verify instead of inferring.** After prune, re-probe `git worktree list --porcelain` for *that* path and return `ErrWorktreeStillRegistered` if the registration survived. A probe that *errors* is reported too — an answer we never got is not evidence of success. The probe is path-scoped, so an unrelated locked worktree elsewhere in the repo never trips it.

**2. Actionable error.** It names the real recovery, shell-quoted so it pastes (#1978):

```
worktree is still registered with git: /path/wt is still a registered git worktree, so its
branch cannot be deleted — a locked worktree is the usual cause (`git worktree prune`
refuses to prune one and still exits 0). Recover with:
git -C '/path/repo' worktree unlock '/path/wt' && af reset
```

AF deliberately does **not** force past the lock itself (`remove -f -f`). A lock is a human saying "in use"; overriding it is the user's call.

**3. Made the re-run actually possible** — issue item (c). I took the *defer-deletion* branch rather than the *manual-instructions* branch, at **record granularity**:

reset now retains the blocked session's record — **and only that one** — so a re-run after `git worktree unlock` plans exactly the leftover work. This mirrors the corrupt-repo preservation that already exists (`corruptRepoIDs` → records kept, branches not pruned), for the same stated reason: *erasing a record whose branch we deliberately did not prune would orphan that branch*.

Why record- and not repo-granular (which is what the corrupt path does): a blocked repo's *other* worktrees were successfully removed, so keeping the whole `instances.json` would leave records pointing at directories this run deleted. Filtering down to the blocked records leaves exactly the part of the reset that did not happen — nothing dangling in either direction. The top-level `PARTIAL` message was rewritten to match, and no longer claims a bare re-run finishes the job:

> Some items could not be removed, so this reset is only partial. Their session records were kept, so a re-run revisits exactly that work — but clear the cause below first, or the re-run just repeats the same failure.

(Sentence-cased in the follow-up round below, per the #1826 copy conventions.)

**4. Ownership safety restored** — issue item (d). The History note is correct: `RemoveWorktreeDir` deleted unconditionally on any `worktree remove -f` failure, dropping the verification `Cleanup()` has had since 0e947fd. For a locked worktree that is exactly backwards — the path is *still registered*, i.e. git still owns it, and AF deleted the user's checkout anyway.

Rather than reimplement the check, I extracted the existing rule out of `shouldRemoveWorktreeDir` into a shared `mayDeleteWorktreeDir(registered, probeAnswered, removeErr)` that both paths now call. `Cleanup`'s timeout branch (`r.unknown` → refuse) stays with the run, where it belongs — it's the run's rule, not the ownership rule. Same for the porcelain scan: the three copies are now one `worktreeListed` helper.

Consequence: a locked worktree's **directory now survives**, which is also what makes the printed recovery work end to end (unlock → the checkout is still there → `remove -f` succeeds → prune → branch deleted).

## One thing the issue didn't mention

The ownership check would have been undone three steps later. `resetWipePaths` ends with a blind `os.RemoveAll(<AF_HOME>/worktrees)` — safe only under the assumption that the per-worktree pass already emptied it. Once that pass can *deliberately* leave a worktree in place, the blind delete destroys the very directory git still owns. That wipe now prunes the tree entry-by-entry, keeping any entry holding a blocked worktree (and `removeArchivedDirs` likewise preserves a blocked repo's archives, since a blocked worktree may itself be an archived one).

Caught by the test, not by reading — the first run of the end-to-end test failed on `locked worktree directory must survive`.

## Fail-first

Tests were written first, then run against the **pre-fix tree** (9f9a522 in a scratch clone) with only the sentinel error type and the `blocked` summary field added so they compile — no behavior change:

```
=== RUN   TestRemoveWorktreeDir_LockedWorktreeIsReportedAsIncomplete
    worktree_reset_locked_test.go:71:
        	Error:      	An error is expected but got nil.
        	Messages:   	RemoveWorktreeDir must report failure when the worktree metadata survives (#2110)
--- FAIL: TestRemoveWorktreeDir_LockedWorktreeIsReportedAsIncomplete (0.03s)
=== RUN   TestRemoveWorktreeDir_UnlockRecoversTheWorktree
    worktree_reset_locked_test.go:110:
        	Error:      	An error is expected but got nil.
--- FAIL: TestRemoveWorktreeDir_UnlockRecoversTheWorktree (0.03s)
=== RUN   TestRemoveWorktreeDir_UnlockedWorktreeStillRemovesCleanly
--- PASS: TestRemoveWorktreeDir_UnlockedWorktreeStillRemovesCleanly (0.03s)
=== RUN   TestRemoveWorktreeDir_MissingDirWithLockedMetadata
    worktree_reset_locked_test.go:164:
        	Error:      	An error is expected but got nil.
        	Messages:   	a missing directory must not be read as a completed cleanup
--- FAIL: TestRemoveWorktreeDir_MissingDirWithLockedMetadata (0.02s)
=== RUN   TestRemoveWorktreeDir_DeletedRepoStillRemovesOrphanDir
--- PASS: TestRemoveWorktreeDir_DeletedRepoStillRemovesOrphanDir (0.03s)
=== RUN   TestRemoveWorktreeDir_MissingDirAndMetadataIsCleanNoOp
--- PASS: TestRemoveWorktreeDir_MissingDirAndMetadataIsCleanNoOp (0.03s)
FAIL
FAIL	github.com/sachiniyer/agent-factory/session/git	0.187s
```

The three PASSes are the no-regression locks — they pass before *and* after, which is what proves the new verification didn't turn normal removals (or a deleted repo root) into failures.

The end-to-end test is the more useful artifact, because it shows all three symptoms at once on the pre-fix tree:

```
=== RUN   TestFactoryReset_LockedWorktreeIsRecoverable
    reset_locked_worktree_test.go:52: error = delete branch af-session-1 in /tmp/.../003: git branch -D
        af-session-1 ...: exit status 1: error: cannot delete branch 'af-session-1' used by worktree
        at '/tmp/.../001/worktrees/live', want it to wrap ErrWorktreeStillRegistered
    reset_locked_worktree_test.go:58: summary.blocked = 0, want 1
    reset_locked_worktree_test.go:63: locked worktree directory must survive, stat:
        stat /tmp/.../001/worktrees/live: no such file or directory
    reset_locked_worktree_test.go:90: retained 0 records, want exactly 1 (the blocked session): []
--- FAIL: TestFactoryReset_LockedWorktreeIsRecoverable (0.13s)
```

Read in order, that is the whole issue:

- **line 52** — the only error reset surfaces is the *downstream* `git branch -D` failure. `RemoveWorktreeDir` reported success; the user is told about the symptom, never the cause, and nothing tells them about the lock.
- **line 63** — the locked worktree's directory is **gone**. Master deleted a checkout git still owned (item (d), confirmed rather than assumed).
- **line 90** — `retained 0 records: []`. Every record is deleted, so "re-run `af reset` to finish" plans nothing. The guidance was unfollowable, exactly as reported.

## Tests

`session/git/worktree_reset_locked_test.go` — throwaway repo in `t.TempDir()`, real `git worktree lock`:
- locked worktree → error, classified, actionable, directory + branch preserved, `.git/worktrees/<id>` still present
- unlock → retry removes cleanly and the branch deletes (recovery is real)
- **unlocked worktree still removes + prunes + allows `branch -D`** (no happy-path regression)
- directory already gone but metadata locked → still detected
- second removal is a clean no-op (idempotence preserved)
- deleted repo root → orphan directory still removed, not misread as "still registered"

`commands/reset_locked_worktree_test.go` — full plan → execute → recover cycle: error classified, only the blocked record retained, unblocked worktrees/branches still reset, reused user branch untouched, then unlock + re-run leaves the home fully clean.

## Verification

- `make test-container` — full suite green
- `golangci-lint run --timeout=3m --fast`, `gofmt -l .`, `deadcode -test ./...`, `scripts/lint-file-length.sh` — all clean
- `go build ./...`

No `af` command was run against the real AF home while developing this — the whole thing is reproduced from throwaway `t.TempDir()` repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up round (CI red + review nits)

### macOS-only failure — a real bug in the fix, not a flaky runner

`TestRemoveWorktreeDir_MissingDirWithLockedMetadata` failed on the macOS runner and passed on Linux. Reproduced on Linux first (symlinked `TMPDIR`), then confirmed the mechanism instead of patching the hypothesis:

```
raw path AF compares:  .../scratchpad/symtmp/probe/wt
git worktree list:     .../scratchpad/realtmp/probe/wt      # git reports the CANONICAL path
```

`normalizeWorktreePath` reconciled the two spellings with a plain `EvalSymlinks` — which **fails on a path whose last component was just deleted**, i.e. the state every post-removal probe runs in. On a symlinked root (macOS `/var` -> `/private/var`) *neither side* got canonicalized, so a still-registered locked worktree compared as absent and the new verification silently passed.

That is the same failure mode as the bug this PR fixes, one layer down: a probe that could not resolve the path answered "not registered" with full confidence.

**The correct mechanism was already in-tree.** `config/inrepo.go`'s `resolveSymlinksForCompare` resolves the deepest *existing* ancestor and re-joins the missing remainder — exactly the missing-leaf case. Moved to `internal/pathutil.ResolveForCompare` and shared by `config`, `session/git`, and the `commands` copy, rather than adding a fourth variant; `holdsAnyPath`'s hand-rolled containment collapsed into the existing `pathutil.IsStrictlyInside`.

The regression guard builds its symlinked root **inside the test**, so it reproduces on Linux CI rather than only on the macOS runner. Verified it fails without the fix:

```
=== RUN   TestRemoveWorktreeDir_SymlinkedRootWithMissingDir
    worktree_reset_locked_test.go:221:
        	Error:      	An error is expected but got nil.
        	Messages:   	a still-registered worktree must be detected even when the record's
        	            	path is spelled through a symlink
--- FAIL: TestRemoveWorktreeDir_SymlinkedRootWithMissingDir (0.02s)
```

### File-length lint (#1145)

Split rather than allowlisted: `worktree_ops.go` 1024 → **807**, with the removal path and registration-identity primitives now in `session/git/worktree_remove.go` (265). Verified a **pure move** rather than asserted — identical top-level symbol set apart from the one addition below, and **zero insertions** into `worktree_ops.go` (deletions only, so nothing that stayed was altered).

### Copy conventions (#1826)

Reset summary strings reworded to sentence case with the emphasis written into the sentence. Fixed the pre-existing corrupt-repo line too, since it was in-line. Left the structural `WILL REMOVE:` / `IRREVERSIBLE` plan headers alone as out of scope.

### De-git'd repo edge

I fixed this rather than pinning current behavior, because pinning it would pin a bug. A repo whose directory survives but whose `.git` is gone registers nothing — yet the probe error marked it **blocked**, so reset retained the session record *permanently* and the summary advised unlocking a worktree with no repo to be registered with. No re-run could ever clear it: the same unactionable dead end this PR is about.

`repoRegistersNothing` settles it from a **direct filesystem observation** (`.git` missing), never inferred from a git error — so a transient permissions failure or unmounted parent still takes the conservative path. This also aligns with `CleanupWorktreesForRepo`'s existing skip-non-git handling. Pinned by `TestRemoveWorktreeDir_DeGittedRepoStillRemovesOrphanDir`.

Related inaccuracy this surfaced: the summary said "unlock command" when the probe-error path offers none — now "recovery command", with the specific command carried per-error.

### Verification

- `make test-container` green on the pushed tree (32 packages, 0 failures)
- affected packages green **both** with a normal `TMPDIR` and under the symlinked-`TMPDIR` macOS simulation
- `gofmt -l .`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh` — all clean

**One pre-existing failure, deliberately not touched:** under the symlinked-`TMPDIR` simulation `TestFactoryReset_PreservesUserWorktreesWithNoAFRecords` fails — but it fails identically on the pre-fix tree at 9f9a522, so it is not a regression from this work. It asserts `strings.Contains(porcelainOutput, rawPath)`, a harness assumption that breaks whenever the temp root is a symlink; it passes on the real macOS runner, which is why CI reported only the one failure. A one-line fix (compare canonicalized paths), but it belongs in its own PR.
