### PR TITLE
fix(eventqueue): keep a fully-written record when only the close fails

### DIFF
--- a/daemon/eventqueue.go
+++ b/daemon/eventqueue.go
@@ -239,6 +239,28 @@ func (q *eventQueue) enqueue(line string) error {
 	rec = append(rec, '\n')
 	n, err := q.appendRecord(q.path, rec)
 	if err != nil {
+		if n >= len(rec) {
+			// The record landed IN FULL and only the close/flush failed (#2107) —
+			// a real POSIX case, since close surfaces deferred writeback errors.
+			// Truncating here would destroy a complete event: "close failed" is
+			// not "write torn". The truncate below exists solely because O_APPEND
+			// would glue the next record onto TORN bytes, and a complete record
+			// leaves none to glue onto, so the file is already record-aligned.
+			// Keep it, and account for it — the on-disk record must be counted in
+			// memory or a later torn write would truncate back to a stale size and
+			// delete it after the fact. Same philosophy as compactLocked, whose
+			// temp-file+rename leaves the original intact when its close fails.
+			q.size += int64(n)
+			q.pending++
+			log.WarningLog.Printf("watch task %s: event-queue append succeeded but close failed; kept the fully-written record: %v", q.taskID, err)
+			// Enforce the caps as the success path does: a persistently failing
+			// close must not let the backlog outgrow its bounds. The close error is
+			// the one worth returning, so a cap failure only gets logged.
+			if capErr := q.dropOldestOverCapsLocked(); capErr != nil {
+				log.WarningLog.Printf("watch task %s: failed to enforce event-queue caps after a close failure: %v", q.taskID, capErr)
+			}
+			return err
+		}
 		// A short write leaves a torn record that would corrupt the NEXT append:
 		// O_APPEND writes at the real end of file, so the next record glues onto
 		// the torn bytes into one invalid line. Truncate back to the last record

--- a/daemon/eventqueue_test.go
+++ b/daemon/eventqueue_test.go
@@ -429,6 +429,121 @@ func TestEventQueue_PartialWriteTruncateFailureRecoversAcrossRestart(t *testing.
 	}
 }
 
+// enqueueWithCloseFailure reproduces the #2107 failure mode: the record reaches
+// the real file IN FULL through the production append, and only the close
+// reports an error (a real POSIX case — close surfaces deferred writeback
+// errors). n == len(rec), so nothing on disk is torn. It returns the enqueue
+// error so the caller can assert it, and restores the production seam.
+func enqueueWithCloseFailure(q *eventQueue, line string, closeErr error) error {
+	q.appendRecord = func(path string, rec []byte) (int, error) {
+		n, err := appendRecordToFile(path, rec)
+		if err != nil {
+			return n, err
+		}
+		return n, closeErr // full write, failed close
+	}
+	defer func() { q.appendRecord = appendRecordToFile }()
+	return q.enqueue(line)
+}
+
+func eventQueueFileSize(t *testing.T, path string) int64 {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	return info.Size()
+}
+
+// TestEventQueue_FullWriteCloseFailureKeepsEvent is the #2107 regression: a
+// close error after a FULL write must not destroy the record. "Close failed" is
+// not "write torn" — truncate-to-realign exists only because O_APPEND would glue
+// the NEXT record onto torn bytes, and a complete record leaves no torn bytes to
+// glue onto. Before the fix, enqueue saw n > 0 with an error, truncated back to
+// the previous size, and the fully-written event was permanently lost.
+func TestEventQueue_FullWriteCloseFailureKeepsEvent(t *testing.T) {
+	dir := t.TempDir()
+	taskID := "ab210070"
+	q := newEventQueue(dir, taskID)
+	if err := q.enqueue("before"); err != nil {
+		t.Fatalf("enqueue before: %v", err)
+	}
+
+	closeErr := errors.New("simulated close failure")
+	err := enqueueWithCloseFailure(q, "survives-close-failure", closeErr)
+	if !errors.Is(err, closeErr) {
+		t.Fatalf("enqueue error = %v, want the close error surfaced to the caller", err)
+	}
+	// The record is on disk, so it must also be counted in memory — otherwise a
+	// later torn write would truncate back to a stale size and delete it after
+	// the fact.
+	// Errorf, not Fatalf: the drain assertion below is the one that shows the
+	// actual data loss, and it is worth reporting in the same run.
+	if got := q.pendingCount(); got != 2 {
+		t.Errorf("pending after full write + close failure = %d, want 2 (the record is on disk)", got)
+	}
+
+	// A following append must land on a record boundary, which only holds if the
+	// kept record was accounted for.
+	if err := q.enqueue("after"); err != nil {
+		t.Fatalf("enqueue after: %v", err)
+	}
+
+	// Reopen as a restarted daemon would: state comes purely from disk.
+	reopened := newEventQueue(dir, taskID)
+	got := drainAllEvents(t, reopened)
+	want := []string{"before", "survives-close-failure", "after"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("drained %v, want %v (a failed close must not drop a fully-written event)", got, want)
+	}
+}
+
+// TestEventQueue_PartialWriteTruncatesToRecordBoundary pins the OTHER branch of
+// the #2107 fix: a genuinely torn (partial) write is STILL truncated back to the
+// last record boundary. O_APPEND writes at the real end of file, so leaving the
+// torn bytes would glue the next record onto them into one invalid line.
+func TestEventQueue_PartialWriteTruncatesToRecordBoundary(t *testing.T) {
+	dir := t.TempDir()
+	taskID := "ab210071"
+	q := newEventQueue(dir, taskID)
+	if err := q.enqueue("good-1"); err != nil {
+		t.Fatalf("enqueue good-1: %v", err)
+	}
+	sizeBefore := eventQueueFileSize(t, q.path)
+
+	shortWrite := errors.New("simulated short write")
+	q.appendRecord = func(path string, rec []byte) (int, error) {
+		f, ferr := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+		if ferr != nil {
+			return 0, ferr
+		}
+		n, _ := f.Write(rec[:len(rec)/2]) // < len(rec): the trailing newline never lands
+		_ = f.Close()
+		return n, shortWrite
+	}
+	err := q.enqueue("torn")
+	q.appendRecord = appendRecordToFile
+	if !errors.Is(err, shortWrite) {
+		t.Fatalf("enqueue error = %v, want the short-write error", err)
+	}
+	if got := eventQueueFileSize(t, q.path); got != sizeBefore {
+		t.Fatalf("file size after torn write = %d, want %d (torn bytes must be truncated away)", got, sizeBefore)
+	}
+	if got := q.pendingCount(); got != 1 {
+		t.Fatalf("pending after torn write = %d, want 1 (the torn record is not an event)", got)
+	}
+
+	if err := q.enqueue("good-2"); err != nil {
+		t.Fatalf("enqueue good-2: %v", err)
+	}
+	reopened := newEventQueue(dir, taskID)
+	got := drainAllEvents(t, reopened)
+	want := []string{"good-1", "good-2"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("drained %v, want %v (the torn record must not merge into the next)", got, want)
+	}
+}
+
 // TestEventQueue_DropsOldestOverEventCap: the backlog is bounded; overflow
 // drops the OLDEST pending events (newest are the actionable ones after an
 // outage) and counts the drops.


### PR DESCRIPTION
Fixes #2107

## The bug

`appendRecordToFile` folds the close error into the write error:

```go
n, err := f.Write(rec)
if closeErr := f.Close(); err == nil {
    err = closeErr
}
return n, err
```

So a **full** write whose `f.Close()` reports a deferred writeback error (a real POSIX case) returns `(n=len(rec), err=closeErr)`. `enqueue` then read `n > 0` as "torn record" and truncated the file back to `q.size`:

```go
if n > 0 {   // conflates "some bytes written" with "the write was partial"
    if terr := q.truncate(q.path, q.size); terr != nil {
```

That deletes a **complete, record-aligned event**. Permanent loss — not every source can re-emit (real-time `tail -F -n 0`, webhooks, streams).

## Why the truncate is only for torn writes

Truncate-to-realign exists for exactly one reason: `O_APPEND` writes at the real end of file, so leaving torn bytes in place would glue the *next* record onto them into one invalid line. A fully-written record leaves **no torn bytes to glue onto** — the file is already record-aligned. "Close failed" is not "write torn."

This also restores consistency with `compactLocked`, which writes to a temp file and renames: when *its* close fails, the original queue file is left intact.

## The fix

Branch by what actually happened to the bytes:

| `appendRecord` result | Behavior |
|---|---|
| `n == len(rec)`, close error | **Record KEPT.** Counted (`size`/`pending`), caps enforced, close error still returned. |
| `0 < n < len(rec)` (torn) | Truncate/realign — unchanged, incl. the #1634 truncate-failure recovery. |
| `n == 0` (open/other error) | Unchanged — nothing on disk, nothing to undo. |

Two details on the keep branch:

- **It must be accounted for, not just left on disk.** An uncounted on-disk record leaves `q.size` stale, and the *next* torn write would truncate back to that stale size — deleting the kept record after the fact. Counting it also keeps `pending` equal to the on-disk line count.
- **Caps are still enforced** (`dropOldestOverCapsLocked`), so a persistently failing close cannot let the backlog outgrow its bounds. The close error is the one worth returning, so a cap failure is only logged.

The close error is still surfaced to the caller, per the issue. One scoped consequence, called out deliberately: `enqueueEvent` (watcher.go) treats an enqueue error as "dropped" and skips `ensureDrainer()`, so a kept record on an otherwise-idle watcher waits for the next event or a daemon reload to drain rather than waking the drainer immediately. That is at-least-once delivery instead of today's silent loss, and fixing the wake path means touching `watcher.go` — kept out to keep this PR to one bug and one file.

## Fail-first

The new test drives the real production append through the existing `q.appendRecord` seam — the record genuinely lands in full — and fails only the close.

**On master:**

```
=== RUN   TestEventQueue_FullWriteCloseFailureKeepsEvent
    eventqueue_test.go:483: pending after full write + close failure = 1, want 2 (the record is on disk)
    eventqueue_test.go:497: drained [before after], want [before survives-close-failure after] (a failed close must not drop a fully-written event)
--- FAIL: TestEventQueue_FullWriteCloseFailureKeepsEvent (0.00s)
=== RUN   TestEventQueue_PartialWriteTruncatesToRecordBoundary
--- PASS: TestEventQueue_PartialWriteTruncatesToRecordBoundary (0.00s)
FAIL
```

`survives-close-failure` is simply gone from the drain — that is the data loss. The torn-write test passes on master because it pins existing behavior.

**After the fix** (assertions are on disk state: the queue is reopened as a restarted daemon would, so the event is proven to have survived, not just to be counted in memory):

```
=== RUN   TestEventQueue_PartialWriteTruncateFailureStaysReadable
--- PASS: TestEventQueue_PartialWriteTruncateFailureStaysReadable (0.01s)
=== RUN   TestEventQueue_PartialWriteTruncateFailureRecoversAcrossRestart
--- PASS: TestEventQueue_PartialWriteTruncateFailureRecoversAcrossRestart (0.01s)
=== RUN   TestEventQueue_FullWriteCloseFailureKeepsEvent
--- PASS: TestEventQueue_FullWriteCloseFailureKeepsEvent (0.00s)
=== RUN   TestEventQueue_PartialWriteTruncatesToRecordBoundary
--- PASS: TestEventQueue_PartialWriteTruncatesToRecordBoundary (0.00s)
PASS
ok  	github.com/sachiniyer/agent-factory/daemon	0.051s
```

`TestEventQueue_PartialWriteTruncatesToRecordBoundary` is new and guards the other direction — a genuinely torn write must STILL truncate to a record boundary (no regression to torn-record recovery). The two pre-existing #1634 truncate-failure tests still pass unchanged.

## Gates

- `gofmt -l .` — clean
- `golangci-lint run --timeout=3m --fast` — clean
- `go build ./...` — clean
- `scripts/lint-file-length.sh` — passed (819 files, 0 grandfathered)
- `make test-container` — full suite green (`daemon` 158.278s ok)

🤖 Generated with [Claude Code](https://claude.com/claude-code)