### PR TITLE
fix(watcher): refund the rate slot when a delivery attempt reached nothing

### DIFF
--- a/daemon/delivery.go
+++ b/daemon/delivery.go
@@ -51,6 +51,34 @@ const StatusDeferredAttached = "deferred: target attached"
 // durable re-queue/retry without tripping the delivery-failure alarm (#1238).
 var errTargetBusy = errors.New("target session is attached; delivery deferred until detach")
 
+// errNotAttempted marks a delivery failure that provably sent NOTHING: the
+// attempt died on a pre-flight check, before any session was created and before
+// any keystroke reached a pane. The watch paths refund the rate slot such an
+// attempt reserved (#2102) — the rule is "refund iff nothing was delivered", so
+// a deferral (errTargetBusy), a cap refusal (errAtConcurrencyLimit), and a
+// pre-flight error are the same case, and only the deferrals used to refund.
+//
+// Deliberately NOT applied to a failed create or a failed send. Both cross the
+// control socket, and delivery itself is keystrokes-then-submit, so their error
+// can surface AFTER the session was created or the prompt was already pasted;
+// the caller cannot distinguish "never sent" from "sent, then the reply was
+// lost". Refunding an ambiguous failure would let a delivered event escape the
+// per-minute budget — the exact pressure this limiter exists to bound — so
+// ambiguity stays charged. Under-refunding costs a little throughput;
+// over-refunding breaks the guarantee.
+var errNotAttempted = errors.New("delivery not attempted")
+
+// notAttempted tags err as a pre-flight failure. The wrapper is transparent:
+// Error() is the wrapped message verbatim, so every log line reads exactly as
+// before and only errors.Is(err, errNotAttempted) flips.
+func notAttempted(err error) error { return &notAttemptedError{err: err} }
+
+type notAttemptedError struct{ err error }
+
+func (e *notAttemptedError) Error() string        { return e.err.Error() }
+func (e *notAttemptedError) Unwrap() error        { return e.err }
+func (e *notAttemptedError) Is(target error) bool { return target == errNotAttempted }
+
 // deferWhileAttached reports whether an automated delivery must be held because a
 // TUI is attached full-screen to the target (#1586). Every SendPrompt delivery
 // path routes through this: the fast "exists" path AND both wait-then-send paths

--- a/daemon/taskrun.go
+++ b/daemon/taskrun.go
@@ -53,7 +53,9 @@ var cronDeferPollInterval = 1 * time.Second
 func deliverTaskPrompt(t *task.Task, prompt string, deferWhileAttached bool) (string, error) {
 	cfg, err := config.LoadConfig()
 	if err != nil {
-		return "", fmt.Errorf("failed to load config: %w", err)
+		// Pre-flight: this returns before any create or send, so the watch paths
+		// refund the rate slot (#2102). Inert for cron, which only checks err != nil.
+		return "", notAttempted(fmt.Errorf("failed to load config: %w", err))
 	}
 
 	// Ask the SAME question the cap was validated against (#1892). Reading the raw

--- a/daemon/watcher.go
+++ b/daemon/watcher.go
@@ -808,6 +808,15 @@ func (w *taskWatcher) handleEvent(line string, tail *tailBuffer) {
 			w.releaseEventSlot()
 			log.InfoLog.Printf("watch task %s: at its max_concurrent_runs limit; queueing event until a session finishes (#1892)", w.taskID)
 		default:
+			// A genuine failure that never got as far as the target delivered
+			// nothing either, so it refunds too (#2102) — otherwise the live
+			// attempt AND every drainer retry each spend a slot, leaking the
+			// per-minute budget exactly when an outage needs it for recovery. Only
+			// pre-flight failures qualify: a failed create or send may have landed
+			// (see errNotAttempted), and a delivered event must stay charged.
+			if errors.Is(err, errNotAttempted) {
+				w.releaseEventSlot()
+			}
 			log.ErrorLog.Printf("watch task %s: failed to deliver event: %v", w.taskID, err)
 		}
 		w.enqueueEvent(line, tail)
@@ -903,16 +912,20 @@ func (w *taskWatcher) stopDraining() {
 // {{line}}, and routes through the same delivery path cron fires use, then
 // records the run status (#664 path).
 func deliverWatchEvent(taskID, line string) error {
+	// The three pre-flight checks below fail before anything is created or sent,
+	// so they are tagged notAttempted and the caller refunds their rate slot
+	// (#2102). Everything past them can fail with the delivery already in
+	// flight, and stays charged.
 	t, err := task.GetTask(taskID)
 	if err != nil {
-		return fmt.Errorf("failed to load task: %w", err)
+		return notAttempted(fmt.Errorf("failed to load task: %w", err))
 	}
 	if !t.Enabled {
-		return fmt.Errorf("task %s is disabled", taskID)
+		return notAttempted(fmt.Errorf("task %s is disabled", taskID))
 	}
 	prompt := task.RenderWatchPrompt(t.Prompt, line)
 	if strings.TrimSpace(prompt) == "" {
-		return fmt.Errorf("event rendered an empty prompt (line %q)", line)
+		return notAttempted(fmt.Errorf("event rendered an empty prompt (line %q)", line))
 	}
 	status, err := deliverTaskPrompt(t, prompt, true)
 	if err != nil {

--- a/daemon/watcher_drain.go
+++ b/daemon/watcher_drain.go
@@ -171,6 +171,14 @@ func (w *taskWatcher) drainLoop() {
 				}
 				continue
 			}
+			// Same refund rule as the live path (#2102): a replay that died on a
+			// pre-flight check reached nothing, so it must not spend the target's
+			// per-minute budget — a long outage retries many times, and charging
+			// each one throttles the drain right when the backlog needs to move.
+			// A failed create/send stays charged: it may have landed.
+			if errors.Is(err, errNotAttempted) {
+				w.releaseEventSlot()
+			}
 			log.WarningLog.Printf("watch task %s: replay delivery failed (%d event(s) pending); retrying in %s: %v", w.taskID, w.queue.pendingCount(), backoff, err)
 			if !w.sleepStopAware(backoff) {
 				w.stopDraining()

--- a/daemon/watcher_rateslot_test.go
+++ b/daemon/watcher_rateslot_test.go
@@ -1,0 +1,165 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+	"github.com/sachiniyer/agent-factory/task"
+)
+
+// Rate-slot refund discipline (#2102). tryReserveEventSlot spends one of the
+// task's 10-events/min slots before every delivery attempt; the slot must come
+// back iff the attempt delivered NOTHING. These tests pin both halves of that
+// rule — the refund, and the deliberate non-refund when a failure may have
+// landed — on the live path and the replay path.
+
+// newRateSlotWatcher builds a watcher wired to deliver, with a real queue in a
+// temp dir. stopRequested is pre-armed so ensureDrainer never spawns a drainer
+// behind the assertions; the drain-path test drives drainLoop itself.
+func newRateSlotWatcher(t *testing.T, taskID string, deliver func(string, string) error) *taskWatcher {
+	t.Helper()
+	s := newWatcherSupervisor()
+	s.eventsPerMinute = 10
+	s.deliver = deliver
+	return &taskWatcher{
+		sup:      s,
+		taskID:   taskID,
+		queue:    newEventQueue(t.TempDir(), taskID),
+		stopCh:   make(chan struct{}),
+		doneCh:   make(chan struct{}),
+		draining: false,
+	}
+}
+
+// spentSlots reports how much of the per-minute budget is currently consumed.
+func spentSlots(w *taskWatcher) int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return len(w.eventTimes)
+}
+
+// seedDisabledWatchTask writes a DISABLED watch task to the real task store, so
+// the production deliverWatchEvent hook fails its pre-flight check and provably
+// reaches neither the manager nor the target session.
+func seedDisabledWatchTask(t *testing.T, taskID string) {
+	t.Helper()
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	repo := setupTaskRepo(t)
+	seedTargetSession(t, repo, "captain")
+	if err := task.AddTask(task.Task{
+		ID:            taskID,
+		Name:          "gh-issues",
+		Prompt:        "Triage: {{line}}",
+		WatchCmd:      "watch.sh",
+		TargetSession: "captain",
+		ProjectPath:   repo,
+		Enabled:       false,
+		CreatedAt:     time.Now(),
+	}); err != nil {
+		t.Fatalf("seed task: %v", err)
+	}
+}
+
+// TestWatcherHandleEvent_RefundsRateSlotWhenNothingWasDelivered is the #2102
+// regression on the live path: a genuine error that failed pre-flight (here a
+// disabled task) delivers nothing, exactly like a deferral, so it must refund
+// the slot it reserved. Before the fix only deferrals refunded, so every failed
+// attempt burned budget the drainer's retries then had to compete for.
+func TestWatcherHandleEvent_RefundsRateSlotWhenNothingWasDelivered(t *testing.T) {
+	seedDisabledWatchTask(t, "cafe2102")
+	_, sends := stubTaskDelivery(t)
+
+	w := newRateSlotWatcher(t, "cafe2102", deliverWatchEvent)
+	close(w.stopCh) // no drainer behind the assertions
+	w.handleEvent("new issue #9", &tailBuffer{})
+
+	if len(*sends) != 0 {
+		t.Fatalf("a disabled task must not receive a delivery, got %+v", *sends)
+	}
+	if got := spentSlots(w); got != 0 {
+		t.Fatalf("rate slots spent = %d, want 0 (nothing was delivered, so the slot must be refunded)", got)
+	}
+	// The event is still queued for replay — refunding must not drop it.
+	if got := w.queue.pendingCount(); got != 1 {
+		t.Fatalf("pending = %d, want 1 (a failed delivery is queued for replay)", got)
+	}
+}
+
+// TestWatcherDrain_RefundsRateSlotWhenNothingWasDelivered is the #2102
+// regression on the replay path. The drain loop retries for as long as an
+// outage lasts, so an unrefunded slot per retry is where the leak compounds:
+// the budget the recovery needs is spent on attempts that reached nothing.
+func TestWatcherDrain_RefundsRateSlotWhenNothingWasDelivered(t *testing.T) {
+	seedDisabledWatchTask(t, "cafe2105")
+
+	attempted := make(chan struct{})
+	var once sync.Once
+	w := newRateSlotWatcher(t, "cafe2105", func(taskID, line string) error {
+		err := deliverWatchEvent(taskID, line)
+		once.Do(func() { close(attempted) })
+		return err
+	})
+	// Long backoffs: exactly one replay attempt happens before the stop below,
+	// so the assertion counts one attempt's slot, not a race with retries.
+	w.sup.drainBaseBackoff = 10 * time.Second
+	w.sup.drainMaxBackoff = 10 * time.Second
+	if err := w.queue.enqueue("new issue #9"); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	w.wg.Add(1)
+	go w.drainLoop()
+	select {
+	case <-attempted:
+	case <-time.After(10 * time.Second):
+		t.Fatal("drainer never attempted the queued event")
+	}
+	w.stopOnce.Do(func() { close(w.stopCh) })
+	w.wg.Wait()
+
+	if got := spentSlots(w); got != 0 {
+		t.Fatalf("rate slots spent after a failed replay = %d, want 0 (the retry must not double-charge)", got)
+	}
+	if got := w.queue.pendingCount(); got != 1 {
+		t.Fatalf("pending = %d, want 1 (an undelivered event stays queued)", got)
+	}
+}
+
+// TestWatcherHandleEvent_KeepsRateSlotWhenDeliveryMayHaveLanded pins the other
+// half of the rule, and is why this is not a blanket refund. A failed create or
+// send crosses the control socket and delivery is keystrokes-then-submit, so
+// the error can surface AFTER the prompt landed. Refunding that would let a
+// delivered event escape the per-minute budget the limiter exists to enforce,
+// so an ambiguous failure stays charged.
+func TestWatcherHandleEvent_KeepsRateSlotWhenDeliveryMayHaveLanded(t *testing.T) {
+	sendErr := fmt.Errorf("failed to deliver prompt to target session %q: %w", "captain", errors.New("connection reset by peer"))
+	w := newRateSlotWatcher(t, "cafe2103", func(string, string) error { return sendErr })
+	close(w.stopCh)
+
+	w.handleEvent("new issue #9", &tailBuffer{})
+
+	if got := spentSlots(w); got != 1 {
+		t.Fatalf("rate slots spent = %d, want 1 (a failure that may have landed must stay charged)", got)
+	}
+}
+
+// TestWatcherHandleEvent_SuccessfulDeliveryConsumesRateSlot guards against
+// over-refunding: a delivery that actually landed spends its slot, which is the
+// whole point of the per-minute budget.
+func TestWatcherHandleEvent_SuccessfulDeliveryConsumesRateSlot(t *testing.T) {
+	w := newRateSlotWatcher(t, "cafe2104", func(string, string) error { return nil })
+	close(w.stopCh)
+
+	w.handleEvent("new issue #9", &tailBuffer{})
+
+	if got := spentSlots(w); got != 1 {
+		t.Fatalf("rate slots spent = %d, want 1 (a delivered event must consume its slot)", got)
+	}
+	if got := w.queue.pendingCount(); got != 0 {
+		t.Fatalf("pending = %d, want 0 (a delivered event is not queued)", got)
+	}
+}


### PR DESCRIPTION
Fixes #2102

## The bug

`tryReserveEventSlot()` spends one of the task's 10-events/min slots before **every** delivery attempt. Deferrals refund it — `errTargetBusy` and `errAtConcurrencyLimit` both call `releaseEventSlot()` on the stated rationale that "a deferral delivers nothing." Genuine errors that *also* delivered nothing did not:

```go
default:
    log.ErrorLog.Printf("watch task %s: failed to deliver event: %v", w.taskID, err)
}
w.enqueueEvent(line, tail)
```

The event is then queued, the drainer retries, and each retry reserves **another** slot. During an outage that leaks budget on both the live and the replay path — throttling recovery exactly when the backlog needs to move.

## Not a blanket refund

The rule is **refund iff nothing was delivered**, so I audited each error branch reachable from `deliver` rather than refunding the whole `default:` arm. The split is not where the issue assumed:

| Branch | Delivered? | Refund |
|---|---|---|
| `failed to load task` (`task.GetTask`) | No — returns before any create/send | **Yes** |
| `task %s is disabled` | No — pre-flight gate | **Yes** |
| `event rendered an empty prompt` | No — nothing constructed to send | **Yes** |
| `failed to load config` (`deliverTaskPrompt`) | No — returns before either RPC | **Yes** |
| `failed to start task session` (`createSessionForTask`) | **Unknowable** | **No** |
| `failed to deliver prompt to target session` (`deliverPromptForTask`) | **Unknowable** | **No** |
| `errTargetBusy` / `errAtConcurrencyLimit` | No | Yes (unchanged) |
| success | Yes | No (unchanged) |

The last two error rows are the reason this isn't a one-line change, and they're where I deviate from the issue's suggested fix (it lists "failed to start session" and "target unreachable" as refundable). Both cross the daemon control socket, and prompt delivery is keystrokes-then-submit — so the error can surface **after** the session was created or after the prompt was already pasted into the pane. The caller genuinely cannot distinguish "never sent" from "sent, then the reply was lost."

Refunding those would let a **delivered** event escape the per-minute budget — the exact pressure this limiter exists to bound, and a strictly worse failure than the leak. Under-refunding costs a little throughput; over-refunding breaks the guarantee. So ambiguity stays charged, and only provable non-delivery is refunded.

## Mechanism

A new `errNotAttempted` sentinel, alongside `errTargetBusy` in `delivery.go`, marks the pre-flight failures. Both the live path (`handleEvent`) and the replay path (`drainLoop`) refund on `errors.Is(err, errNotAttempted)`.

The wrapper is transparent — `Error()` returns the wrapped message verbatim, so **no log line changes**; only `errors.Is` flips. The `deliverTaskPrompt` tag is inert for cron, which only checks `err != nil`.

## Fail-first

Both refund tests drive the **real** `deliverWatchEvent` against the real task store with a disabled task, so the marking path is exercised end to end rather than asserting on a stubbed sentinel.

**On master:**

```
=== RUN   TestWatcherHandleEvent_RefundsRateSlotWhenNothingWasDelivered
    watcher_rateslot_test.go:84: rate slots spent = 1, want 0 (nothing was delivered, so the slot must be refunded)
--- FAIL: TestWatcherHandleEvent_RefundsRateSlotWhenNothingWasDelivered (0.02s)
=== RUN   TestWatcherDrain_RefundsRateSlotWhenNothingWasDelivered
    watcher_rateslot_test.go:125: rate slots spent after a failed replay = 1, want 0 (the retry must not double-charge)
--- FAIL: TestWatcherDrain_RefundsRateSlotWhenNothingWasDelivered (0.02s)
=== RUN   TestWatcherHandleEvent_KeepsRateSlotWhenDeliveryMayHaveLanded
--- PASS: TestWatcherHandleEvent_KeepsRateSlotWhenDeliveryMayHaveLanded (0.00s)
=== RUN   TestWatcherHandleEvent_SuccessfulDeliveryConsumesRateSlot
--- PASS: TestWatcherHandleEvent_SuccessfulDeliveryConsumesRateSlot (0.00s)
FAIL
```

The two leak tests fail on master (one slot consumed by an attempt that reached nothing); the two guard tests pass on master by design — they pin behavior that must NOT change, and they are what would catch a blanket refund.

**After the fix:**

```
=== RUN   TestWatcherHandleEvent_RefundsRateSlotWhenNothingWasDelivered
--- PASS: TestWatcherHandleEvent_RefundsRateSlotWhenNothingWasDelivered (0.02s)
=== RUN   TestWatcherDrain_RefundsRateSlotWhenNothingWasDelivered
--- PASS: TestWatcherDrain_RefundsRateSlotWhenNothingWasDelivered (0.02s)
=== RUN   TestWatcherHandleEvent_KeepsRateSlotWhenDeliveryMayHaveLanded
--- PASS: TestWatcherHandleEvent_KeepsRateSlotWhenDeliveryMayHaveLanded (0.00s)
=== RUN   TestWatcherHandleEvent_SuccessfulDeliveryConsumesRateSlot
--- PASS: TestWatcherHandleEvent_SuccessfulDeliveryConsumesRateSlot (0.00s)
PASS
ok  	github.com/sachiniyer/agent-factory/daemon	0.069s
```

The refund tests also assert the event is still queued for replay, so a refund can never be mistaken for a drop.

## Gates

- `gofmt -l .` — clean
- `golangci-lint run --timeout=3m --fast` — clean
- `go build ./...` — clean
- `deadcode -test ./...` — clean
- `scripts/lint-file-length.sh` — passed (`watcher.go` 986/1000)
- `make test-container` — full suite green (`daemon` 158.165s ok)

🤖 Generated with [Claude Code](https://claude.com/claude-code)