### PR TITLE
fix(daemon): gate the WS stream routes on manager-ready so warm-up cannot orphan an instance (#2109)

### DIFF
--- a/daemon/stream_warmup_test.go
+++ b/daemon/stream_warmup_test.go
@@ -1,0 +1,223 @@
+package daemon
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// The warm-up contract for the WebSocket stream plane (#2109), the same contract
+// the web-tab proxy was brought under in #1878.
+//
+// RunDaemon binds the HTTP listener long BEFORE the restore finishes (#829,
+// deliberately: the restore shells out per remote-hook session and can take
+// minutes). Both stream routes are HTTP rather than net/rpc, so — exactly like the
+// proxy did — they slipped the requireManagerReady gate that every state-reading
+// RPC goes through. A stream request landing in that window runs
+// agentServerForStream → resolveStreamSession → refreshLocked, which builds
+// instances off disk and puts them in m.instances. RestoreInstances then rebuilds
+// that map from scratch, so the instance already handed to the client is no longer
+// the tracked one: an orphan the client keeps streaming against. requireManagerReady's
+// own doc comment names this failure mode — "construct throwaway instances from
+// disk that the restore then orphans".
+
+// seedWarmingStreamDaemon sets up the state RunDaemon is in between the listener
+// bind and the end of the restore: a session sitting ON DISK, and a manager over
+// that same home holding no instances and not ready.
+//
+// The row has to be one a restore would really MATERIALIZE, and getting there
+// takes some care. seedDiskInstance's minimal InstanceData carries no worktree, so
+// FromInstanceData rejects it outright; a row for a LIVE local session carries one
+// but FromInstanceData then calls instance.Start, which reconnects to a REAL tmux
+// session that a mock-tmux fixture never created — so it is skipped too. Against
+// either seed the side-effect assertion below passes on UNFIXED code and the whole
+// test is vacuous.
+//
+// An ARCHIVED row is the shape that loads without a live tmux: FromInstanceData
+// rebuilds its worktree and returns INERT before Start (#1028). It is a real
+// restorable session — the restore materializes it, findSession registers it — so
+// it reproduces the orphaning faithfully, and restorableRowGuard proves it does
+// rather than leaving that to be assumed.
+func seedWarmingStreamDaemon(t *testing.T) (mux *http.ServeMux, warming *Manager, repoID, title string) {
+	t.Helper()
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	title = "streamer"
+
+	ready, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	inst := startedLocalTabInstance(t, ready, repo.ID, repoPath, title, "af_"+title+"_agent")
+	if err := inst.Transition(session.ObserveLiveness(session.LiveArchived)); err != nil {
+		t.Fatalf("archive transition: %v", err)
+	}
+	ready.persistInstance(repo.ID, inst)
+	restorableRowGuard(t)
+
+	warming = warmingManager(t)
+	return newHTTPMux(&controlServer{manager: warming}), warming, repo.ID, title
+}
+
+// restorableRowGuard proves the seeded home holds a session a restore actually
+// loads. Without it, "the warm-up request loaded no instances" could mean the gate
+// works OR that there was never anything loadable there — and the second reading
+// is a green test that checks nothing.
+func restorableRowGuard(t *testing.T) {
+	t.Helper()
+	probe, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager (restorable-row probe): %v", err)
+	}
+	probe.mu.Lock()
+	loaded := len(probe.instances)
+	probe.mu.Unlock()
+	if loaded == 0 {
+		t.Fatal("the seeded home holds no RESTORABLE session: a warm-up request would find nothing to load, " +
+			"so the side-effect assertion would pass even on ungated code")
+	}
+}
+
+// streamGet issues a GET against a stream route with a plain recorder. A recorder
+// is not a Hijacker, which is exactly the point for the /stream case: if the gate
+// works, the refusal is written as an ordinary HTTP response and the upgrade is
+// never attempted.
+func streamGet(t *testing.T, mux *http.ServeMux, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	// coder/websocket only attempts an upgrade for a request that ASKS for one, so
+	// the /stream case has to ask — otherwise the handler would fall out somewhere
+	// unrelated to the gate and the test would prove nothing about it.
+	if !contains(path, "stream-info") {
+		req.Header.Set("Connection", "Upgrade")
+		req.Header.Set("Upgrade", "websocket")
+		req.Header.Set("Sec-WebSocket-Version", "13")
+		req.Header.Set("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+	}
+	mux.ServeHTTP(rec, req)
+	return rec
+}
+
+// assertNoRestoreDriven is the side-effect assertion, and it is the one that
+// matters: the point is not that the request is refused, it is that it does not do
+// the RESTORE'S JOB on its way to being refused.
+func assertNoRestoreDriven(t *testing.T, m *Manager, status int) {
+	t.Helper()
+	m.mu.Lock()
+	loaded := len(m.instances)
+	m.mu.Unlock()
+	if loaded != 0 {
+		t.Fatalf("a warm-up stream request loaded %d instance(s) off disk (status %d): it drove its own restore, "+
+			"and RestoreInstances will orphan what it just handed the client — exactly the case "+
+			"requireManagerReady documents as \"throwaway instances from disk that the restore then orphans\"",
+			loaded, status)
+	}
+	if m.Ready() {
+		t.Fatal("a stream request must never be what marks the manager ready")
+	}
+}
+
+// TestStreamInfoHandler_WarmUpDoesNotDriveItsOwnRestore is the #2109 regression
+// test for GET /v1/sessions/{id}/stream-info.
+func TestStreamInfoHandler_WarmUpDoesNotDriveItsOwnRestore(t *testing.T) {
+	mux, warming, repoID, title := seedWarmingStreamDaemon(t)
+
+	rec := streamGet(t, mux, fmt.Sprintf("/v1/sessions/%s/stream-info?repo_id=%s", title, repoID))
+
+	assertNoRestoreDriven(t, warming, rec.Code)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503 during warm-up (body: %s)", rec.Code, rec.Body.String())
+	}
+	if !contains(rec.Body.String(), daemonStartingErrText) {
+		t.Fatalf("body = %s, want the warm-up error text so a client knows to retry", rec.Body.String())
+	}
+}
+
+// TestStreamHandler_WarmUpRefusedBeforeUpgrade is the #2109 regression test for GET
+// /v1/sessions/{id}/stream, and it pins WHERE the refusal happens as well as that
+// it happens. The gate has to fire BEFORE websocket.Accept: after the upgrade the
+// only way to say no is a WS close frame, which a client handles on a completely
+// different path from an HTTP status — it reads as a stream that dropped, not as
+// "retry in a moment". A recorder cannot be hijacked, so an attempted upgrade would
+// show up here as a failure that is not the gate's 503.
+func TestStreamHandler_WarmUpRefusedBeforeUpgrade(t *testing.T) {
+	mux, warming, repoID, title := seedWarmingStreamDaemon(t)
+
+	rec := streamGet(t, mux, fmt.Sprintf("/v1/sessions/%s/stream?repo_id=%s", title, repoID))
+
+	assertNoRestoreDriven(t, warming, rec.Code)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503 during warm-up (body: %s)", rec.Code, rec.Body.String())
+	}
+	if rec.Code == http.StatusSwitchingProtocols || rec.Header().Get("Sec-WebSocket-Accept") != "" {
+		t.Fatal("the warm-up refusal upgraded the connection first; it must be a plain HTTP 503")
+	}
+	if ct := rec.Header().Get("Content-Type"); !contains(ct, "application/json") {
+		t.Fatalf("Content-Type = %q, want the JSON failure envelope every other stream error uses", ct)
+	}
+	if !contains(rec.Body.String(), daemonStartingErrText) {
+		t.Fatalf("body = %s, want the warm-up error text so a client knows to retry", rec.Body.String())
+	}
+}
+
+// TestStreamInfoHandler_ServesOnceReady is the other half of the gate: it must be a
+// WARM-UP gate, not a new refusal. A ready manager — every daemon's within seconds
+// of boot — answers exactly as before.
+func TestStreamInfoHandler_ServesOnceReady(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if !manager.Ready() {
+		t.Fatal("NewManager restores synchronously; its manager must be ready")
+	}
+	const title = "streamer"
+	startedLocalTabInstance(t, manager, repo.ID, repoPath, title, "af_"+title+"_agent")
+	mux := newHTTPMux(&controlServer{manager: manager})
+
+	rec := streamGet(t, mux, fmt.Sprintf("/v1/sessions/%s/stream-info?repo_id=%s", title, repo.ID))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 once the manager is ready (body: %s)", rec.Code, rec.Body.String())
+	}
+	if got := rec.Body.String(); !contains(got, "/stream") {
+		t.Fatalf("stream-info body = %s, want the session's stream URL", got)
+	}
+}
+
+// TestStreamHandler_ReadyManagerReachesResolution proves the gate is scoped to
+// warm-up on the /stream route too: with a ready manager the request runs on into
+// session resolution, and an unknown session is refused as the 404 it has always
+// been — never the warm-up 503.
+func TestStreamHandler_ReadyManagerReachesResolution(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	mux := newHTTPMux(&controlServer{manager: manager})
+
+	rec := streamGet(t, mux, "/v1/sessions/no-such-session/stream")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 for an unknown session on a ready manager (body: %s)",
+			rec.Code, rec.Body.String())
+	}
+	if contains(rec.Body.String(), daemonStartingErrText) {
+		t.Fatalf("a ready manager answered with the warm-up error: %s", rec.Body.String())
+	}
+}

--- a/daemon/ws_events.go
+++ b/daemon/ws_events.go
@@ -95,6 +95,13 @@ func (m *Manager) publishEvent(t agentproto.EventType, payload any) {
 
 // eventsHandler upgrades GET /v1/events to a WebSocket and streams state-change
 // events to the client until it disconnects.
+//
+// Deliberately NOT gated on requireManagerReady, unlike the stream routes (#2109)
+// and the web-tab proxy (#1878): it resolves no session and reads no instance
+// state — it only subscribes to the hub — so it cannot build an instance off disk
+// for the restore to orphan, which is the whole hazard that gate exists for. A
+// client that connects mid-warm-up simply starts receiving events as the restore
+// publishes them, which is what a client watching a daemon come up wants.
 func (cs *controlServer) eventsHandler(w http.ResponseWriter, r *http.Request) {
 	if cs.manager == nil || cs.manager.events == nil {
 		writeHTTPError(w, r, http.StatusServiceUnavailable, fmt.Errorf("daemon has no events hub"))

--- a/daemon/ws_pty.go
+++ b/daemon/ws_pty.go
@@ -75,6 +75,26 @@ func (cs *controlServer) streamHandler(w http.ResponseWriter, r *http.Request) {
 		writeHTTPError(w, r, http.StatusServiceUnavailable, fmt.Errorf("daemon has no session manager"))
 		return
 	}
+	// Refuse during warm-up, BEFORE anything reads session state (#2109) — the same
+	// gate every state-dependent RPC goes through, and the one webTabProxyHandler
+	// was brought under in #1878 for this identical reason: an HTTP route is not
+	// net/rpc, so it slips the gating by default.
+	//
+	// The listener binds long before the restore finishes (#829), and a stale client
+	// reconnects the instant the port answers. Resolution runs refreshLocked, which
+	// builds instances off disk; RestoreInstances then rebuilds that map wholesale,
+	// so the instance already handed to this client stops being the tracked one —
+	// requireManagerReady's own comment names it, "throwaway instances from disk
+	// that the restore then orphans".
+	//
+	// It has to fire BEFORE websocket.Accept. Past the upgrade the only refusal
+	// available is a close frame, which a client reads as a stream that DROPPED and
+	// handles on an entirely different path; a plain 503 is a retry it already
+	// understands, and matches every other pre-upgrade error on this route.
+	if err := cs.requireManagerReady(); err != nil {
+		writeHTTPError(w, r, http.StatusServiceUnavailable, err)
+		return
+	}
 	id := r.PathValue("id")
 	repoID := r.URL.Query().Get("repo_id")
 	since, err := parseSince(r.URL.Query().Get("since"))
@@ -398,6 +418,15 @@ type streamInfoResponse struct {
 func (cs *controlServer) streamInfoHandler(w http.ResponseWriter, r *http.Request) {
 	if cs.manager == nil {
 		writeHTTPError(w, r, http.StatusServiceUnavailable, fmt.Errorf("daemon has no session manager"))
+		return
+	}
+	// Same warm-up gate as streamHandler (#2109), and needed for the same reason:
+	// this route resolves the session through the very code path that builds
+	// instances off disk, so an ungated call during the restore window orphans what
+	// it just resolved. Answering the stream's ADDRESS is not a lesser read — it is
+	// the call a client makes immediately before dialing the stream itself.
+	if err := cs.requireManagerReady(); err != nil {
+		writeHTTPError(w, r, http.StatusServiceUnavailable, err)
 		return
 	}
 	id := r.PathValue("id")


### PR DESCRIPTION
Fixes #2109.

`streamHandler` and `streamInfoHandler` checked `cs.manager == nil` but never
called `requireManagerReady()`. Both are HTTP routes rather than net/rpc, so —
exactly like `webTabProxyHandler` before #1878 — they slipped the gate every
state-dependent RPC goes through.

RunDaemon binds the listener long before the restore finishes (#829), so a client
reconnecting in that window resolves through `agentServerForStream` →
`resolveStreamSession` → `refreshLocked`, which builds an instance off disk and
registers it. `RestoreInstances` then rebuilds the map wholesale, so the instance
already handed to the client is no longer tracked — the orphan
`requireManagerReady`'s own comment names: *"throwaway instances from disk that
the restore then orphans"*.

This is the correct mechanism already in-tree. It mirrors `webTabProxyHandler`'s
fix (8eb6153) rather than inventing anything.

## Watched to fail first

```
=== RUN   TestStreamInfoHandler_WarmUpDoesNotDriveItsOwnRestore
    stream_warmup_test.go:141: a warm-up stream request loaded 1 instance(s) off disk
    (status 200): it drove its own restore, and RestoreInstances will orphan what it
    just handed the client — exactly the case requireManagerReady documents as
    "throwaway instances from disk that the restore then orphans"
--- FAIL: TestStreamInfoHandler_WarmUpDoesNotDriveItsOwnRestore (0.03s)
=== RUN   TestStreamHandler_WarmUpRefusedBeforeUpgrade
    stream_warmup_test.go:162: a warm-up stream request loaded 1 instance(s) off disk
    (status 500): [same]
--- FAIL: TestStreamHandler_WarmUpRefusedBeforeUpgrade (0.02s)
=== RUN   TestStreamInfoHandler_ServesOnceReady
--- PASS: TestStreamInfoHandler_ServesOnceReady (0.02s)
=== RUN   TestStreamHandler_ReadyManagerReachesResolution
--- PASS: TestStreamHandler_ReadyManagerReachesResolution (0.00s)
```

Note the statuses on the unfixed code: `stream-info` **served a 200** during
warm-up, and `/stream` ran all the way to the upgrade attempt. Both after loading
an instance the restore would orphan. All four pass after the fix, stable across
`-count=2`.

### Getting a real repro took three fixtures, and the first two are worth recording

The first seed used `seedDiskInstance`. The tests "failed" — but only on the
status assertion. The **side-effect** check passed *vacuously*: that minimal
`InstanceData` carries no worktree, `FromInstanceData` rejects it, and there was
never anything on disk to load. A persisted *live* instance fails differently:
`FromInstanceData` calls `instance.Start`, which reconnects to a **real** tmux
session that a mock-tmux fixture never created, so the row is skipped too.

An **archived** row is the shape that loads without live tmux — `FromInstanceData`
rebuilds its worktree and returns inert before `Start` (#1028) — so it reproduces
the orphaning faithfully.

`restorableRowGuard` pins that distinction: a probe manager over the seeded home
must load ≥1 instance, or the test fails loudly. Without it, *"the warm-up request
loaded no instances"* reads identically whether the gate works or whether there
was nothing loadable there — a green test that checks nothing. It is the assertion
that would have caught my own first two attempts.

## The fix

`requireManagerReady()` immediately after the `cs.manager == nil` check in both
handlers, returning a plain HTTP 503 with the warm-up error text (there is no
generic `errDaemonStarting` → status mapping; `rpcHandler` maps handler errors to
500, so the status is set explicitly, matching the 503 already adjacent in these
same handlers).

On `/stream` the gate fires **before** `websocket.Accept`. Past the upgrade the
only refusal available is a close frame, which a client reads as a stream that
*dropped* and handles on an entirely different path; a 503 is a retry it already
understands. The test asserts this positively — no `Sec-WebSocket-Accept`, JSON
envelope, 503 — not just that the request failed somehow.

## Adjacent audit

There are exactly four non-catalog HTTP handlers:

| handler | gated | why |
|---|---|---|
| `webTabProxyHandler` | yes | #1878 / 8eb6153 |
| `streamHandler` | **now** | this PR |
| `streamInfoHandler` | **now** | this PR |
| `eventsHandler` | no — deliberate | resolves no session, reads no instance state |

`eventsHandler` only subscribes to the hub, so it cannot build an instance for the
restore to orphan — the whole hazard the gate exists for. A client connecting
mid-warm-up simply starts receiving events as the restore publishes them, which is
what a client watching a daemon come up wants. I documented that exclusion in
place so the next audit doesn't have to re-derive it.

Everything in `servedHTTPRoutes` goes through `rpcHandler` to RPC methods that are
individually gated, with the deliberate exclusions already commented.

`agentServerForStream` / `resolveStreamSession` / `RestoreInstances` are untouched.

## Verification

- `gofmt -l .` — clean
- `golangci-lint run --timeout=3m --fast` — clean
- `go build ./...` — OK
- `scripts/lint-file-length.sh` — 821 files, 0 grandfathered
- `make test-container` — **full suite green, every package** (daemon 158s, app 96s, integration 42s)

Captain Claude
