### PR TITLE
fix(session): resolve teardown's tmux-ref clear against the live roster (#1987)

### DIFF
--- a/session/teardown.go
+++ b/session/teardown.go
@@ -61,12 +61,24 @@ type teardownMode interface {
 	finalize(i *Instance, closed []closedTab, gw *git.GitWorktree)
 }
 
-// closedTab pairs a tab with the exact tmux session teardownTabs closed for it,
-// so finalize can identity-guard the ref clear: only a ref that is STILL the
-// session we closed is nil'd, never a fresh one a concurrent Start swapped in.
+// closedTab records the tmux session teardownTabs closed for a tab, keyed by
+// that tab's STABLE ID (#1738) rather than by the *Tab pointer it was captured
+// from, plus the name the close is reported under.
+//
+// The pointer is not a stable handle. Since #1904 a rename writes through
+// replaceTabFieldLocked, which COPIES the Tab and stores a new pointer in
+// i.Tabs — so a rename landing inside teardown's unlock window would leave a
+// captured pointer aimed at a stale copy. The ref clear would then nil the dead
+// object while the live tab kept a ref to a session that had already been
+// killed: no error, no panic, just a tab holding a corpse forever (#1987).
+//
+// The id survives the copy. The tmux session is kept beside it because the clear
+// still has to be identity-guarded — only a ref that is STILL the session we
+// closed may be nil'd, never a fresh one a concurrent Start swapped in.
 type closedTab struct {
-	tab *Tab
-	ts  *tmux.TmuxSession
+	id   string
+	name string
+	ts   *tmux.TmuxSession
 }
 
 // teardownState reports whether a teardown step ESTABLISHED what it did.
@@ -187,7 +199,10 @@ func (i *Instance) teardownTabs(mode teardownMode) error {
 	closed := make([]closedTab, 0, len(i.Tabs))
 	for _, tab := range i.Tabs {
 		if tab.tmux != nil {
-			closed = append(closed, closedTab{tab: tab, ts: tab.tmux})
+			// Capture the name here, under the lock, rather than reading it off the
+			// *Tab later: the kills below run unlocked, and a concurrent rename is
+			// exactly what this struct no longer wants to be holding a pointer into.
+			closed = append(closed, closedTab{id: tab.ID, name: tab.Name, ts: tab.tmux})
 		}
 	}
 	gw := i.gitWorktree
@@ -200,7 +215,7 @@ func (i *Instance) teardownTabs(mode teardownMode) error {
 	var errs []error
 	paneMayBeLive := false
 	for _, c := range closed {
-		state, err := mode.closeTab(c.ts, title, c.tab.Name)
+		state, err := mode.closeTab(c.ts, title, c.name)
 		if err != nil {
 			errs = append(errs, err)
 		}
@@ -242,13 +257,32 @@ func (i *Instance) teardownTabs(mode teardownMode) error {
 	return errors.Join(errs...)
 }
 
-// clearClosedTmuxRefs nils each closed tab's tmux ref under a held i.mu,
-// identity-guarded so a concurrent Start that swapped in a fresh session is
-// never clobbered. Shared by the kill and release-PTY finalizers.
-func clearClosedTmuxRefs(closed []closedTab) {
+// clearClosedTmuxRefs nils each closed tab's tmux ref under a held i.mu. Shared
+// by the kill and release-PTY finalizers.
+//
+// The fix for #1987 is the RESOLUTION, not the key: this looks the tab up in the
+// live roster instead of dereferencing a pointer captured before the unlock
+// window, so a copy-on-write rename that replaced i.Tabs[idx] mid-teardown is
+// still found rather than silently missed.
+//
+// Of the two conditions, only the session check is provably load-bearing —
+// deleting it lets a concurrent Start's fresh session be clobbered, which a test
+// catches. Matching on the id as well is defense in depth and, mainly,
+// documentation: it says the thing being cleared is the tab we closed, rather
+// than leaving that to incidental pointer equality. (It is not independently
+// testable here: closed holds ts alive for the duration, so no other session can
+// occupy that address and an id-blind match behaves identically. Said plainly so
+// nobody later mistakes the id for the guard.)
+//
+// A tab whose id no longer resolves has been dropped from the roster entirely;
+// there is nothing left to clear, which is the correct no-op.
+func clearClosedTmuxRefs(i *Instance, closed []closedTab) {
 	for _, c := range closed {
-		if c.tab.tmux == c.ts {
-			c.tab.tmux = nil
+		for _, tab := range i.Tabs {
+			if tab.ID == c.id && tab.tmux == c.ts {
+				tab.tmux = nil
+				break
+			}
 		}
 	}
 }
@@ -299,7 +333,7 @@ func (teardownKill) handleWorktree(gw *git.GitWorktree, title string) (teardownS
 func (teardownKill) clearsStarted() bool { return true }
 
 func (teardownKill) finalize(i *Instance, closed []closedTab, gw *git.GitWorktree) {
-	clearClosedTmuxRefs(closed)
+	clearClosedTmuxRefs(i, closed)
 	if i.gitWorktree == gw {
 		i.gitWorktree = nil
 	}
@@ -331,8 +365,8 @@ func (teardownReleasePTY) handleWorktree(_ *git.GitWorktree, _ string) (teardown
 
 func (teardownReleasePTY) clearsStarted() bool { return true }
 
-func (teardownReleasePTY) finalize(_ *Instance, closed []closedTab, _ *git.GitWorktree) {
-	clearClosedTmuxRefs(closed)
+func (teardownReleasePTY) finalize(i *Instance, closed []closedTab, _ *git.GitWorktree) {
+	clearClosedTmuxRefs(i, closed)
 }
 
 // teardownArchive tears down every tab's tmux session and RELOCATES the worktree

--- a/session/teardown_identity_test.go
+++ b/session/teardown_identity_test.go
@@ -1,0 +1,108 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// TestClearClosedTmuxRefs_SurvivesACopyOnWriteReplace is #1987.
+//
+// teardownTabs snapshots the tabs it is about to close under i.mu, releases the
+// lock to do the kills (they shell out to tmux and must not block readers), then
+// re-locks to clear each closed tab's tmux ref. The ref clear was guarded by
+// POINTER IDENTITY on the *Tab it captured.
+//
+// That guard is load-bearing for a real reason — it must not clobber a fresh
+// session a concurrent Start swapped in — but it silently assumes the *Tab in
+// i.Tabs is still the same OBJECT. Since #1904 it may not be: RenameTab and
+// ReconcileTabsFromData write through replaceTabFieldLocked, which copies the
+// Tab and stores a NEW pointer at i.Tabs[idx]. A rename landing inside
+// teardown's unlock window therefore leaves the captured pointer pointing at a
+// stale copy, and the clear nils the dead object while the LIVE tab keeps a ref
+// to a session that has already been killed.
+//
+// This is exactly the failure the issue warns is quiet: no compile error, no
+// panic, just a tab holding a dead session forever. It is not reachable in
+// production today because the daemon's per-session op-lock serializes rename
+// against kill/archive — but that lock lives in a different package, which
+// session can neither see nor enforce, so the type must not depend on it.
+//
+// The fix is to key the ref clear on the tab's STABLE ID (#1738) instead of on
+// pointer identity, keeping the tmux-session check as the concurrent-Start
+// guard it always was.
+func TestClearClosedTmuxRefs_SurvivesACopyOnWriteReplace(t *testing.T) {
+	closing := &tmux.TmuxSession{}
+	original := &Tab{ID: "tab-stable-id", Name: "shell", Kind: TabKindShell, tmux: closing}
+
+	inst := &Instance{Title: "alpha", Tabs: []*Tab{original}}
+
+	// What teardownTabs captures under the lock, before it releases it to kill.
+	closed := []closedTab{{id: original.ID, name: original.Name, ts: closing}}
+
+	// The unlock window: a rename arrives and writes through the copy-on-write
+	// helper, so i.Tabs[0] is a DIFFERENT object carrying the same identity and
+	// the same live tmux session.
+	inst.replaceTabFieldLocked(0, func(c *Tab) { c.Name = "renamed" })
+	live := inst.Tabs[0]
+	if live == original {
+		t.Fatal("premise broken: replaceTabFieldLocked did not replace the pointer, so this " +
+			"test cannot reproduce #1987")
+	}
+	if live.tmux != closing {
+		t.Fatal("premise broken: the copy did not carry the tmux session forward")
+	}
+
+	clearClosedTmuxRefs(inst, closed)
+
+	// The live tab is the one whose session was killed, so it is the one that must
+	// be cleared. Before #1987 this is the assertion that fails: the clear found
+	// only the stale copy.
+	if live.tmux != nil {
+		t.Errorf("the LIVE tab still references the tmux session teardown already killed.\n\n"+
+			"teardown captured *Tab %p and cleared that, but a copy-on-write rename had "+
+			"replaced i.Tabs[0] with %p. Key the clear on the stable tab ID, not on pointer "+
+			"identity (#1987).", original, live)
+	}
+}
+
+// TestClearClosedTmuxRefs_LeavesAFreshSessionAlone pins the guard the #1987 fix
+// must NOT lose. The whole reason the clear was identity-guarded is that a
+// concurrent Start can swap a brand-new tmux session onto the tab while teardown
+// is killing the old one; nil-ing that would strand a live session with no
+// reference to it. Keying on the stable id makes the tab easier to FIND, which
+// would make clobbering easier too if the session check were dropped with it.
+func TestClearClosedTmuxRefs_LeavesAFreshSessionAlone(t *testing.T) {
+	closing, restarted := &tmux.TmuxSession{}, &tmux.TmuxSession{}
+	tab := &Tab{ID: "tab-stable-id", Name: "shell", Kind: TabKindShell, tmux: closing}
+	inst := &Instance{Title: "alpha", Tabs: []*Tab{tab}}
+
+	closed := []closedTab{{id: tab.ID, name: tab.Name, ts: closing}}
+
+	// A concurrent Start wins the race and installs a fresh session on the SAME
+	// tab (same id, same pointer) before finalize re-locks.
+	tab.tmux = restarted
+
+	clearClosedTmuxRefs(inst, closed)
+
+	if tab.tmux != restarted {
+		t.Errorf("cleared a tmux session teardown did not close: the tab now holds %v, want the "+
+			"fresh session a concurrent Start installed. The id makes the tab findable; the "+
+			"session check is what keeps the clear from clobbering.", tab.tmux)
+	}
+}
+
+// TestClearClosedTmuxRefs_ClearsAClosedTabThatWasNotReplaced is the ordinary
+// path — no rename, no restart — so the fix cannot pass the two cases above by
+// simply never clearing anything.
+func TestClearClosedTmuxRefs_ClearsAClosedTabThatWasNotReplaced(t *testing.T) {
+	closing := &tmux.TmuxSession{}
+	tab := &Tab{ID: "tab-stable-id", Name: "shell", Kind: TabKindShell, tmux: closing}
+	inst := &Instance{Title: "alpha", Tabs: []*Tab{tab}}
+
+	clearClosedTmuxRefs(inst, []closedTab{{id: tab.ID, name: tab.Name, ts: closing}})
+
+	if tab.tmux != nil {
+		t.Error("a closed tab that was never replaced must have its tmux ref cleared")
+	}
+}


### PR DESCRIPTION
Closes #1987. First of the stable-id cluster; branched off current master (`acce4ba`).

## The defect

`teardownTabs` snapshots the tabs it is about to close under `i.mu`, releases the lock to run the kills (they shell out to tmux and must not block readers), then re-locks to clear each closed tab's tmux ref. The clear was guarded by **pointer identity on the `*Tab` it captured**:

```go
if c.tab.tmux == c.ts { c.tab.tmux = nil }
```

That assumes the `*Tab` in `i.Tabs` is still the same **object**. Since #1904 it may not be: `RenameTab` and `ReconcileTabsFromData` write through `replaceTabFieldLocked`, which *copies* the Tab and stores a **new pointer** at `i.Tabs[idx]`. A rename landing inside teardown's unlock window leaves the captured pointer aimed at a stale copy — so the clear nils the dead object while the **live tab keeps a ref to a session that has already been killed**. No error, no panic, a tab holding a corpse forever.

**Not reachable in production today**: the daemon's per-session op-lock serializes rename against kill/archive. But that lock lives in a *different package*, which `session` can neither see nor enforce — which is the design smell half of #1987, today's safety resting on a lock one level up.

## The fix

`closedTab` now carries the tab's stable `ID` (#1738) plus the name the close is reported under, both captured under the lock, instead of a `*Tab` pointer. `clearClosedTmuxRefs` takes the instance and resolves against the **live roster**.

**Deliberately NOT done:** applying `replaceTabFieldLocked` to `tmux`/`Conversation`. Reaching for that *instead of* this change is the trap #1987 warns about — against the old pointer-identity guard it reproduces the same staleness rather than fixing it. To be precise about the direction: this change does not forbid COW-ing those fields, it is the **prerequisite** for it. With the clear resolving against the live roster the pointer-identity assumption is gone entirely, which is what makes the pattern survive a future COW — so `Conversation` becomes cheaply COW-able as a follow-up, exactly as the issue lays out.

## Honest note on what the tests actually prove

The issue prescribes "key by ID", but the load-bearing change is the **resolution against the live roster**, not the key. I mutation-tested both conditions:

| Mutation | Result |
|---|---|
| delete the tmux-session check (match id only) | ❌ `LeavesAFreshSessionAlone` fails — a concurrent `Start`'s fresh session gets clobbered |
| delete the id check (match ts only) | ✅ everything still passes |

So the `id` is **not** independently testable here: `closed` holds `ts` alive for the duration, so no other session can occupy that address and an id-blind match behaves identically. It stays as defense in depth and as documentation that we clear *the tab we closed* rather than relying on incidental pointer equality — and the code comment says exactly this, so nobody later mistakes the id for the guard.

I'd rather state that than let the PR imply a stronger claim than the tests support.

## Fail-first

Observed at `acce4ba`, via a probe written against master's signature (the final tests use the new struct shape, so they can't compile on master):

```
probe1987_test.go:28: LIVE tab (0xc0000bfd60) still references the killed tmux session;
                      teardown cleared the stale copy (0xc0000bfcc0) instead — #1987
```

Three tests ship: the COW-replace case, the no-clobber guard, and the ordinary path (so the fix can't pass the first two by never clearing anything).

## Verification

- `go build ./...`, `gofmt -l .` (clean), `golangci-lint --fast` (0), `deadcode -test ./...` (empty), `scripts/lint-file-length.sh` (pass).
- **Container** (`make test-container GOTESTARGS="./session/ ./daemon/"`): `session` 32.8s ok, `daemon` 157.0s ok — the full daemon suite drives the kill/archive teardown paths this changes. No host `go test ./daemon/...`.

## Remaining in the cluster

#1991, #1948, #1957 are **not** in this PR — see the handoff note in my summary. They're in different layers (`app/`+`ui/` view state, `api/` CLI flags, `session/tab_names.go`+`daemon/` messaging), so this stayed focused on the one destructive-path change.

Co-Authored-By: Captain Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
