### PR TITLE
fix(daemon): treat an already-archived target as success in DeleteProject (#2108)

### DIFF
--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -14,6 +14,16 @@ import (
 	sessiongit "github.com/sachiniyer/agent-factory/session/git"
 )
 
+// ErrAlreadyArchived is returned by ArchiveSession when its target is already in
+// the archived state. It is a SENTINEL — not just prose — because "already
+// archived" is the one archive rejection that means the caller's goal is already
+// met: a bulk caller that just wants the session archived (DeleteProject, #2108)
+// must be able to tell it apart from a genuine failure (busy, op in flight,
+// teardown error) with errors.Is, and count it as success instead of reporting a
+// misleading partial failure. Only in-process callers can match it; over the
+// control RPC it degrades to its (unchanged) message.
+var ErrAlreadyArchived = errors.New("already archived")
+
 // ArchiveSession archives a session (#1028): it tears down the session's tmux
 // (agent + shell/process tabs; web tabs have none and are preserved with their
 // URLs, #1809) while PRESERVING the record, relocates the
@@ -63,7 +73,12 @@ func (m *Manager) ArchiveSession(req ArchiveSessionRequest) (string, session.Ins
 		return "", session.InstanceData{}, fmt.Errorf("cannot archive an in-place/external worktree session %q — archive relocates the worktree, which isn't supported for in-place sessions", req.Title)
 	}
 	if instance.GetLiveness() == session.LiveArchived {
-		return "", session.InstanceData{}, fmt.Errorf("session %q is already archived", req.Title)
+		// Sentinel-wrapped, and returned WITH the resolved identity: a caller that
+		// only wants the session archived (DeleteProject, #2108) can treat this as
+		// idempotent success and still report the right {id, title}, while a caller
+		// archiving one named session — the CLI/TUI verbs — keeps the same message
+		// and the same failure it has always shown.
+		return "", resolved, fmt.Errorf("session %q is %w", req.Title, ErrAlreadyArchived)
 	}
 	if instance.GetInFlightOp() != session.OpNone {
 		return "", session.InstanceData{}, fmt.Errorf("session %q is busy (%v); try again in a moment", req.Title, instance.GetStatus())

--- a/daemon/archive_test.go
+++ b/daemon/archive_test.go
@@ -172,9 +172,17 @@ func TestArchiveSession_RejectsAlreadyArchived(t *testing.T) {
 	inst, _ := registerArchivable(t, manager, repoID, repoPath, "worker")
 	inst.SetStatusForTest(session.Archived)
 
-	_, _, err := manager.ArchiveSession(ArchiveSessionRequest{Title: "worker", RepoID: repoID})
+	_, archived, err := manager.ArchiveSession(ArchiveSessionRequest{Title: "worker", RepoID: repoID})
 	require.Error(t, err)
+	// The message single-session callers (CLI/TUI, and every caller across the
+	// control RPC, where the sentinel cannot survive) show is unchanged...
 	assert.Contains(t, err.Error(), "already archived")
+	// ...and it is matchable as ErrAlreadyArchived, which is what lets an in-process
+	// bulk caller treat it as idempotent success (#2108). The resolved identity
+	// comes back with it so that caller can report the row it skipped.
+	assert.ErrorIs(t, err, ErrAlreadyArchived)
+	assert.Equal(t, "worker", archived.Title)
+	assert.Equal(t, inst.ID, archived.ID)
 }
 
 // TestArchiveSession_RejectsWhenOperationInFlight: an archive is refused while

--- a/daemon/deleteproject.go
+++ b/daemon/deleteproject.go
@@ -135,6 +135,20 @@ func (m *Manager) DeleteProject(req DeleteProjectRequest) (DeleteProjectResult, 
 			continue
 		}
 		_, archived, err := m.ArchiveSession(ArchiveSessionRequest{Title: t.title, RepoID: repoID})
+		// A target that is ALREADY archived is idempotent SUCCESS, not a failure
+		// (#2108). The snapshot above is a point-in-time read taken under m.mu and
+		// then acted on with the lock released, so a concurrent ArchiveSession can
+		// land in that window and leave a target in exactly the state this delete
+		// wants it in. Counting that as a failure returned a partial-failure error,
+		// omitted the session from Archived (an undercount), and pushed the TUI down
+		// the error path — all for a session that IS archived. ArchiveSession returns
+		// the resolved identity alongside the sentinel, so the row is reported with
+		// its real {id, title}. Every OTHER error stays a failure: a busy session, an
+		// op in flight, or a teardown that broke is genuinely not archived, and the
+		// caller must be told to retry.
+		if errors.Is(err, ErrAlreadyArchived) {
+			err = nil
+		}
 		if err != nil {
 			errs = append(errs, fmt.Errorf("session %q: %w", t.title, err))
 			continue

--- a/daemon/deleteproject_test.go
+++ b/daemon/deleteproject_test.go
@@ -210,3 +210,79 @@ func TestDeleteProject_TildePathMatches(t *testing.T) {
 	assert.Len(t, result.Archived, 1, "a ~/-prefixed path must resolve to the real project, not silently miss")
 	assert.Empty(t, liveProjectRoots(manager.Snapshot(repoID)))
 }
+
+// TestDeleteProject_ConcurrentlyArchivedTargetIsSuccess is the #2108 regression:
+// DeleteProject snapshots the repo's live sessions under m.mu, releases the lock,
+// then archives them one by one. A concurrent ArchiveSession that lands in that
+// window leaves a snapshot target ALREADY in the desired archived state, so
+// ArchiveSession's early liveness guard rejects it. That is idempotent SUCCESS,
+// not a failure: the session is archived, which is all the delete wanted. Before
+// the fix DeleteProject returned a partial-failure error and omitted the session
+// from result.Archived, so the TUI took the error path (no refresh) and reported
+// an undercount.
+func TestDeleteProject_ConcurrentlyArchivedTargetIsSuccess(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	registerArchivable(t, manager, repoID, repoPath, "alpha")
+	beta, betaSrc := registerArchivable(t, manager, repoID, repoPath, "beta")
+	require.NoError(t, manager.SaveInstances())
+
+	// Stand in for the race deterministically. Targets are archived in sorted
+	// order, so flipping "beta" to Archived during "alpha"'s archive commit puts it
+	// in exactly the state a concurrent ArchiveSession would have left it in by the
+	// time the loop reaches it — no real data race needed to hit the guard.
+	orig := archivePersist
+	t.Cleanup(func() { archivePersist = orig })
+	archivePersist = func(m *Manager, rid string, inst *session.Instance) error {
+		if inst.Title == "alpha" {
+			beta.SetStatusForTest(session.Archived)
+		}
+		return orig(m, rid, inst)
+	}
+
+	result, err := manager.DeleteProject(DeleteProjectRequest{RepoID: repoID, RepoPath: repoPath})
+	require.NoError(t, err, "a target already in the desired archived state is success, not a partial failure")
+
+	var titles []string
+	for _, d := range result.Archived {
+		titles = append(titles, d.Title)
+		assert.NotEmpty(t, d.ID, "every reported session carries its stable id, so the event names the right row")
+	}
+	assert.ElementsMatch(t, []string{"alpha", "beta"}, titles,
+		"the already-archived session counts toward Archived — omitting it undercounts what the delete achieved")
+	assert.Empty(t, result.Killed)
+
+	// beta really is archived (the pre-flip stood in for a completed concurrent
+	// archive, so its worktree is still where that archive would have left it) and
+	// the project is gone from the active list — the contract the caller is told.
+	assert.Equal(t, session.Archived, beta.GetStatus())
+	assert.True(t, exists(betaSrc), "the seam only flipped liveness; this delete must not re-move an archived worktree")
+	assert.Empty(t, liveProjectRoots(manager.Snapshot(repoID)), "no live session ⇒ the project drops out of the active list")
+}
+
+// TestDeleteProject_GenuineArchiveFailureStillReportsPartialFailure is the
+// other half of #2108: treating "already archived" as success must NOT become a
+// blanket swallow of ArchiveSession errors. A session that genuinely could not be
+// archived — here one held by another destructive op — is still a real failure,
+// still reported, and still excluded from result.Archived, so the caller knows to
+// retry.
+func TestDeleteProject_GenuineArchiveFailureStillReportsPartialFailure(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	registerArchivable(t, manager, repoID, repoPath, "alpha")
+	beta, betaSrc := registerArchivable(t, manager, repoID, repoPath, "beta")
+	require.NoError(t, manager.SaveInstances())
+
+	// beta is genuinely busy: another destructive op holds it, so its archive fails
+	// for real and it stays LIVE.
+	manager.mu.Lock()
+	manager.killsInFlight[daemonInstanceKey(repoID, "beta")] = struct{}{}
+	manager.mu.Unlock()
+
+	result, err := manager.DeleteProject(DeleteProjectRequest{RepoID: repoID, RepoPath: repoPath})
+	require.Error(t, err, "a genuine archive failure must still surface as a partial failure")
+	assert.Contains(t, err.Error(), "could not be removed")
+	assert.Len(t, result.Archived, 1, "only the session that actually archived is reported")
+	assert.Equal(t, "alpha", result.Archived[0].Title)
+
+	assert.NotEqual(t, session.Archived, beta.GetStatus(), "the busy session is untouched")
+	assert.True(t, exists(betaSrc), "the busy session's worktree is untouched")
+}


### PR DESCRIPTION
Fixes #2108

## The bug

`DeleteProject` snapshots a repo's live sessions under `m.mu`, releases the lock,
then archives them one at a time. If a concurrent `ArchiveSession` completes in
that window, the target is already archived by the time the loop reaches it, so
`ArchiveSession`'s early liveness guard returns an error — and `DeleteProject`
counted **any** error as a per-session failure. Result: a partial-failure error,
the session omitted from `result.Archived` (an undercount), and the TUI down the
error path with no refresh — all for a session that **is** in the desired state.

"Already in the desired state" is idempotent success. This mirrors what the web
UI already does on the client side (`session.archived` events set `needsResync`,
so duplicate archive events are safe); the server side now agrees.

## The fix

- **`daemon/archive.go`** — new `ErrAlreadyArchived` sentinel, returned wrapped
  from the liveness guard. It also returns the **resolved `{id, title}`**
  alongside the error, so a caller treating it as success can still report the
  row accurately instead of guessing.
- **`daemon/deleteproject.go`** — `errors.Is(err, ErrAlreadyArchived)` counts the
  session as archived.

**Not a blanket swallow** — that's the whole point. A busy session, an op in
flight, or a teardown that broke is genuinely *not* archived and still produces
the partial-failure error the caller needs in order to retry.

## Caller audit

Every `ArchiveSession` caller, checked for behavior change:

| Caller | Effect |
|---|---|
| `daemon/deleteproject.go` | The fix. Already-archived → success. |
| `daemon/control_server.go:414` | Returns on `err` **before** reading the `InstanceData`, so the newly-populated identity on the error path is never observed. Error propagates unchanged. |
| `api/sessions.go` (`af sessions archive`) | Reaches `ArchiveSession` over the control RPC, where a sentinel cannot survive; only the message is surfaced. |
| `app/session_control.go` (TUI archive verb) | Same — via `apiclient`, message only. |

The sentinel wraps into the **byte-identical** message (`session %q is already
archived`), so single-session callers that legitimately want to know "it was
already archived" are unchanged. Grep confirms no product code anywhere
(including web/TS) string-matches that message — only a test, which now asserts
both the message *and* `errors.Is`.

Deliberately **out of scope**, called out rather than silently skipped: the
`external` branch of the same loop calls `KillSession`, where a concurrent kill
removes the row entirely and yields a "not found" error. Whether that is
"already in the desired state" or "never existed" is a genuinely different
question needing its own sentinel — and #2108 is specifically about the archive
guard. The snapshot/lock pattern itself is also untouched, per the issue.

## Fail-first

Both new tests were written and run against master before the fix. The
already-archived test failed with exactly the symptom the issue describes:

```
--- FAIL: TestDeleteProject_ConcurrentlyArchivedTargetIsSuccess (0.05s)
    deleteproject_test.go:243:
        	Error Trace:	/work/daemon/deleteproject_test.go:243
        	Error:      	Received unexpected error:
        	            	delete project f626a8792df9: archived 1, tore down 0, but 1 session(s) could not be removed (retry to finish): session "beta": session "beta" is already archived
        	Test:       	TestDeleteProject_ConcurrentlyArchivedTargetIsSuccess
        	Messages:   	a target already in the desired archived state is success, not a partial failure
FAIL
FAIL	github.com/sachiniyer/agent-factory/daemon	0.116s
```

The genuine-failure test passed on master and still passes — that's intended: it
is the lock proving the fix does **not** over-swallow, so it must be green on
both sides.

## Tests

- `TestDeleteProject_ConcurrentlyArchivedTargetIsSuccess` — an already-archived
  target is in `result.Archived` with its real id, the count is right, and no
  partial-failure error is returned. The race is reproduced **deterministically**
  via the existing `archivePersist` seam: targets archive in sorted order, so
  `beta` is flipped to Archived during `alpha`'s commit, putting it in exactly
  the state a completed concurrent archive would have. No real data race needed.
- `TestDeleteProject_GenuineArchiveFailureStillReportsPartialFailure` — a target
  held by another destructive op still yields the partial-failure error, is
  excluded from `result.Archived`, and is left untouched.
- `TestArchiveSession_RejectsAlreadyArchived` — extended to lock both the
  unchanged message and `errors.Is(err, ErrAlreadyArchived)` + the resolved
  identity.
- Happy path (`TestDeleteProject_ArchivesAllSessionsRestorableRepoUntouched`)
  unchanged and green.

## Gates

`gofmt -l .` clean · `golangci-lint run --timeout=3m --fast` clean ·
`go build ./...` · `scripts/lint-file-length.sh` passed ·
`deadcode -test ./...` clean · **full `make test-container` green** (all
packages, `daemon` 158.5s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
