### PR TITLE
feat(cli): let `af sessions preview` address a tab, and share one resolver (#1948)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -595,6 +595,16 @@ func init() {
 	sessionsCreateCmd.Flags().StringVar(&createBackendFlag, "backend", "", "Runtime to run the session on (one of: "+config.SupportedBackendsString()+"; defaults to the repo's backend config, or local). docker runs the session in a container (set docker.image in the repo config); ssh runs it on a remote host (set ssh.host in the repo config)")
 	sessionsCreateCmd.MarkFlagRequired("name")
 
+	// Tab addressing for `sessions preview` (#1948). The daemon's PreviewRequest
+	// always carried Tab/TabID/Full and the CLI sent none of them, so `af sessions
+	// preview` could only ever capture tab 0's visible screen — it could CREATE a
+	// tab it had no way to read. --tab-name is the handle a person actually has;
+	// --tab-id is for scripts that must not follow a reused name.
+	sessionsPreviewCmd.Flags().IntVar(&previewTabFlag, "tab", 0, "Tab slot to capture, 0-based as the tab bar reads left to right (slot 0 is the agent tab)")
+	sessionsPreviewCmd.Flags().StringVar(&previewTabNameFlag, "tab-name", "", "Name of the tab to capture, as reported by \"af sessions get\" (not the TUI's \"Agent\"/\"Terminal\" label); wins over --tab")
+	sessionsPreviewCmd.Flags().StringVar(&previewTabIDFlag, "tab-id", "", "Stable id of the tab to capture (#1738); wins over --tab-name and --tab")
+	sessionsPreviewCmd.Flags().BoolVar(&previewFullFlag, "full", false, "Capture the entire scrollback instead of the visible screen")
+
 	// --prompt is an ALIAS for the positional <prompt>, mirroring `sessions
 	// create --prompt` so the two sibling verbs take the same concept the same
 	// way. The positional stays supported: this is additive, not a migration.

--- a/api/sessions.go
+++ b/api/sessions.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 
 	"os/exec"
@@ -335,6 +336,42 @@ pointing at one).`,
 	},
 }
 
+var (
+	previewTabFlag     int
+	previewTabNameFlag string
+	previewTabIDFlag   string
+	previewFullFlag    bool
+)
+
+// resolvePreviewTab picks the tab slot `af sessions preview` should capture on
+// the LOCAL path, from the --tab-id/--tab-name/--tab flags.
+//
+// The precedence and the refuse-never-fall-back rule are session's
+// (ResolveTabIndex) — the same definition the daemon resolves against — so the
+// two paths cannot drift into disagreeing about what --tab-name means (#1948).
+// Only the wording is the CLI's, and it names the FLAG that was wrong, which the
+// daemon's session-oriented message cannot.
+func resolvePreviewTab(tabs []*session.Tab) (int, error) {
+	idx, err := session.ResolveTabIndex(tabs, previewTabIDFlag, previewTabNameFlag, previewTabFlag)
+	switch {
+	case errors.Is(err, session.ErrTabIDNotFound):
+		return 0, fmt.Errorf("--tab-id %q matches no tab in this session; it may have been closed", previewTabIDFlag)
+	case errors.Is(err, session.ErrTabNameNotFound):
+		ids := make([]string, 0, len(tabs))
+		for _, t := range tabs {
+			ids = append(ids, session.TabIdentifiers(t))
+		}
+		return 0, fmt.Errorf("--tab-name %q matches no tab in this session; its tabs are: %s",
+			previewTabNameFlag, strings.Join(ids, ", "))
+	case errors.Is(err, session.ErrTabIndexOutOfRange):
+		return 0, fmt.Errorf("--tab %d is not a slot in this session, which has %d tab(s)",
+			previewTabFlag, len(tabs))
+	case err != nil:
+		return 0, err
+	}
+	return idx, nil
+}
+
 var sessionsPreviewCmd = &cobra.Command{
 	Use:   "preview <title>",
 	Short: "Preview a session's terminal content",
@@ -344,7 +381,18 @@ name can exist in several repos. The title resolves inside the repo given by
 
 With no repo context, a title held by exactly one session still resolves; one
 held by sessions in several projects is ambiguous and reports an error naming
-those projects instead of guessing between them.`,
+those projects instead of guessing between them.
+
+By default this captures the session's AGENT tab (slot 0), visible screen only.
+Address another tab with --tab-name (the tab name "af sessions tab-create"
+printed, as reported by "af sessions get" — not the TUI's "Agent"/"Terminal"
+label), --tab-id (the stable id, for scripts that must not follow a reused
+name), or --tab (the 0-based slot). They resolve in that precedence — id, then
+name, then slot — the same order every tab verb uses. An id or name that does
+not resolve is an error, never a silent fall back to a slot: that would capture
+whatever tab had shifted into it.
+
+--full returns the entire scrollback instead of the visible screen.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Initialize(false)
@@ -369,7 +417,19 @@ those projects instead of guessing between them.`,
 			if cerr != nil {
 				return jsonError(cerr)
 			}
-			content, gone, perr := client.Preview(daemon.PreviewRequest{Title: args[0], RepoID: repoID})
+			// The tab selectors go over the wire as-is: the DAEMON resolves them,
+			// against the roster it actually holds, through the same
+			// session.ResolveTabIndex the local path below uses. Resolving a name
+			// client-side would need an extra round trip and would race — the
+			// roster it read could differ from the one the capture runs against.
+			content, gone, perr := client.Preview(daemon.PreviewRequest{
+				Title:   args[0],
+				RepoID:  repoID,
+				Tab:     previewTabFlag,
+				TabName: previewTabNameFlag,
+				TabID:   previewTabIDFlag,
+				Full:    previewFullFlag,
+			})
 			if perr != nil {
 				return jsonError(perr)
 			}
@@ -387,7 +447,14 @@ those projects instead of guessing between them.`,
 			return jsonError(err)
 		}
 
-		content, err := instance.AgentServer().Preview(0, false)
+		// Same precedence as the daemon path, from the same definition
+		// (session.ResolveTabIndex) rather than a second copy of the rule.
+		tab, terr := resolvePreviewTab(instance.GetTabs())
+		if terr != nil {
+			return jsonError(terr)
+		}
+
+		content, err := instance.AgentServer().Preview(tab, previewFullFlag)
 		if err != nil {
 			return jsonError(fmt.Errorf("failed to get preview: %w", err))
 		}

--- a/api/sessions.go
+++ b/api/sessions.go
@@ -354,8 +354,8 @@ var (
 func resolvePreviewTab(tabs []*session.Tab) (int, error) {
 	idx, err := session.ResolveTabIndex(tabs, previewTabIDFlag, previewTabNameFlag, previewTabFlag)
 	switch {
-	case errors.Is(err, session.ErrTabIDNotFound):
-		return 0, fmt.Errorf("--tab-id %q matches no tab in this session; it may have been closed", previewTabIDFlag)
+	case errors.Is(err, session.ErrTabIDNotFound), errors.Is(err, session.ErrTabIndexOutOfRange):
+		return 0, previewTabMissErr()
 	case errors.Is(err, session.ErrTabNameNotFound):
 		ids := make([]string, 0, len(tabs))
 		for _, t := range tabs {
@@ -363,13 +363,30 @@ func resolvePreviewTab(tabs []*session.Tab) (int, error) {
 		}
 		return 0, fmt.Errorf("--tab-name %q matches no tab in this session; its tabs are: %s",
 			previewTabNameFlag, strings.Join(ids, ", "))
-	case errors.Is(err, session.ErrTabIndexOutOfRange):
-		return 0, fmt.Errorf("--tab %d is not a slot in this session, which has %d tab(s)",
-			previewTabFlag, len(tabs))
 	case err != nil:
 		return 0, err
 	}
 	return idx, nil
+}
+
+// previewTabMissErr is the message for a tab-level miss — an --tab-id that no
+// longer resolves, or a --tab that is not a slot.
+//
+// One function serves BOTH paths on purpose. The local path learns the miss from
+// session.ResolveTabIndex and the remote path from the daemon's TabGone, but a
+// user should not be able to tell which machine resolved their flag, and the two
+// drifting apart is what this whole cluster is about. It names the FLAG the user
+// passed, which neither the daemon's session-oriented error nor a bare "gone"
+// can do.
+//
+// A --tab-name miss is deliberately NOT here: it is answered with the session's
+// roster, which only the side holding the tab list can produce.
+func previewTabMissErr() error {
+	if previewTabIDFlag != "" {
+		return fmt.Errorf("--tab-id %q matches no tab in this session; it may have been closed",
+			previewTabIDFlag)
+	}
+	return fmt.Errorf("--tab %d is not a slot in this session", previewTabFlag)
 }
 
 var sessionsPreviewCmd = &cobra.Command{
@@ -422,7 +439,7 @@ whatever tab had shifted into it.
 			// session.ResolveTabIndex the local path below uses. Resolving a name
 			// client-side would need an extra round trip and would race — the
 			// roster it read could differ from the one the capture runs against.
-			content, gone, perr := client.Preview(daemon.PreviewRequest{
+			content, gone, tabGone, perr := client.Preview(daemon.PreviewRequest{
 				Title:   args[0],
 				RepoID:  repoID,
 				Tab:     previewTabFlag,
@@ -432,6 +449,15 @@ whatever tab had shifted into it.
 			})
 			if perr != nil {
 				return jsonError(perr)
+			}
+			// A tab-level miss is NOT a dead session. Reporting one as the other
+			// told the user their running session had ended because they mistyped a
+			// --tab-id, and the same message for both is what let that pass. The
+			// daemon distinguishes them (TabGone), so this does not have to guess
+			// from "we sent a selector" — which would be wrong in exactly the case
+			// where the session really did die mid-capture.
+			if tabGone {
+				return jsonError(previewTabMissErr())
 			}
 			if gone {
 				return jsonError(fmt.Errorf("session %q is no longer running", args[0]))

--- a/apiclient/skew_test.go
+++ b/apiclient/skew_test.go
@@ -91,7 +91,7 @@ func TestPreview_VersionSkew_SurfacesActionableError(t *testing.T) {
 		return apiproto.Failure(daemonMsg)
 	})
 
-	_, _, err := c.Preview(daemon.PreviewRequest{Title: "alpha", TabID: "t-abc"})
+	_, _, _, err := c.Preview(daemon.PreviewRequest{Title: "alpha", TabID: "t-abc"})
 	if err == nil {
 		t.Fatal("want an error from a skewed daemon")
 	}
@@ -123,7 +123,7 @@ func TestEnvelopeError_NonSkew_StaysVerbatim(t *testing.T) {
 	c := routeServer(t, "Preview", func([]byte) apiproto.Envelope {
 		return apiproto.Failure(`session "ghost" not found`)
 	})
-	_, _, err := c.Preview(daemon.PreviewRequest{Title: "ghost"})
+	_, _, _, err := c.Preview(daemon.PreviewRequest{Title: "ghost"})
 	if err == nil || err.Error() != `session "ghost" not found` {
 		t.Fatalf("want the verbatim daemon message, got %v", err)
 	}
@@ -153,7 +153,7 @@ func TestCall_SendsClientVersionHeader(t *testing.T) {
 	go func() { _ = srv.Serve(ln) }()
 	t.Cleanup(func() { _ = srv.Close() })
 
-	if _, _, err := NewWithSocket(sockPath).Preview(daemon.PreviewRequest{Title: "alpha"}); err != nil {
+	if _, _, _, err := NewWithSocket(sockPath).Preview(daemon.PreviewRequest{Title: "alpha"}); err != nil {
 		t.Fatalf("Preview: %v", err)
 	}
 	select {

--- a/apiclient/stream.go
+++ b/apiclient/stream.go
@@ -108,14 +108,20 @@ func (c *Client) DialStream(ctx context.Context, title, repoID, tabID string, ta
 const streamSeqHeader = "X-Af-Stream-Seq"
 
 // Preview captures a session tab's content through the daemon — the sole capturer
-// after PR6. It returns the captured content, or gone=true when the session's tmux
-// vanished mid-capture (the caller maps that to its session-gone fallback). Used
-// for surfaces the TUI can't stream live: remote/hook sessions, scroll-mode
+// after PR6. It returns the captured content, or gone=true when the capture found
+// nothing to read (the caller maps that to its session-gone fallback). Used for
+// surfaces the TUI can't stream live: remote/hook sessions, scroll-mode
 // scrollback (full=true), and the transient preview target.
-func (c *Client) Preview(req daemon.PreviewRequest) (content string, gone bool, err error) {
+//
+// tabGone NARROWS gone: the session is alive, only the addressed TAB is missing
+// (an id that no longer resolves, or an ordinal that is not a slot). It is always
+// accompanied by gone, so a caller that ignores it keeps the old behavior.
+// Callers that let a user ADDRESS a tab need it to avoid reporting a healthy
+// session as dead — a distinction the daemon can make and a client cannot (#1948).
+func (c *Client) Preview(req daemon.PreviewRequest) (content string, gone, tabGone bool, err error) {
 	var resp daemon.PreviewResponse
 	if err := c.call("Preview", req, &resp); err != nil {
-		return "", false, err
+		return "", false, false, err
 	}
-	return resp.Content, resp.Gone, nil
+	return resp.Content, resp.Gone, resp.TabGone, nil
 }

--- a/apiclient/stream_test.go
+++ b/apiclient/stream_test.go
@@ -51,7 +51,7 @@ func TestPreview_CarriesTabAndReturnsContent(t *testing.T) {
 		return apiproto.Success(daemon.PreviewResponse{Content: "PANE-" + strconv.Itoa(req.Tab)})
 	})
 
-	content, gone, err := c.Preview(daemon.PreviewRequest{Title: "alpha", RepoID: "r", Tab: 2, Full: true})
+	content, gone, _, err := c.Preview(daemon.PreviewRequest{Title: "alpha", RepoID: "r", Tab: 2, Full: true})
 	if err != nil {
 		t.Fatalf("Preview: %v", err)
 	}
@@ -72,7 +72,7 @@ func TestPreview_GoneSurfacesFlag(t *testing.T) {
 	c, _ := previewServer(t, func(daemon.PreviewRequest) apiproto.Envelope {
 		return apiproto.Success(daemon.PreviewResponse{Gone: true})
 	})
-	content, gone, err := c.Preview(daemon.PreviewRequest{Title: "alpha"})
+	content, gone, _, err := c.Preview(daemon.PreviewRequest{Title: "alpha"})
 	if err != nil {
 		t.Fatalf("Preview: %v", err)
 	}

--- a/app/session_control.go
+++ b/app/session_control.go
@@ -342,7 +342,9 @@ func snapshotThroughDaemon(repoID string) (daemon.SnapshotResponse, error) {
 func previewThroughDaemon(req daemon.PreviewRequest) (content string, gone bool, err error) {
 	err = withDaemonHTTP(func(c *apiclient.Client) error {
 		var e error
-		content, gone, e = c.Preview(req)
+		// tabGone is deliberately dropped here: the TUI renders its session-gone
+		// fallback for either cause, and it addresses tabs it can see (#1948).
+		content, gone, _, e = c.Preview(req)
 		return e
 	})
 	return content, gone, err

--- a/daemon/manager_tabs_arrange.go
+++ b/daemon/manager_tabs_arrange.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -145,29 +146,19 @@ func (m *Manager) tabMutationTarget(reqID, reqTitle, reqRepoID string, labels ta
 // it already holds, and a second lookup against the live list could return an
 // index that no longer addresses the same element of tabs.
 func resolveTabTarget(tabs []*session.Tab, title, tabID, tabName string, tabIndex int) (int, string, error) {
-	if tabID != "" {
-		for i, tab := range tabs {
-			if tab.ID == tabID {
-				return i, tab.Name, nil
-			}
-		}
+	// The PRECEDENCE and the refuse-never-fall-back rule live in
+	// session.ResolveTabIndex (#1948), because the daemon is no longer the only
+	// resolver — `af sessions preview` addresses a tab on the local path without an
+	// RPC. This function owns only the MESSAGES, which are the daemon's to write:
+	// they name the session and list the tabs that exist.
+	idx, err := session.ResolveTabIndex(tabs, tabID, tabName, tabIndex)
+	switch {
+	case errors.Is(err, session.ErrTabIDNotFound):
 		return 0, "", fmt.Errorf("session %q has no tab with id %q; it may have been closed — reload the session's tabs and retry", title, tabID)
-	}
-	if tabName != "" {
-		// Match the canonical Name only (session.TabMatches, #1986). The display
-		// label is presentation and is never an identifier: the TUI shows
-		// "Terminal" for a tab named "shell", but the label does not resolve here —
-		// accepting it would make two strings address one tab, the ambiguity #1929/
-		// #1904 removed from the tab surface. A user who typed the label is not left
-		// stranded: the miss error below names the real handle. Because this is the
-		// shared resolver (#1971), close, rename, and reorder all key on Name alike.
-		for i, tab := range tabs {
-			if session.TabMatches(tab, tabName) {
-				return i, tab.Name, nil
-			}
-		}
+	case errors.Is(err, session.ErrTabNameNotFound):
 		// Name the tabs that DO exist, with their labels where the two differ, so a
-		// user who read "Terminal" learns to type "shell". The old error asserted an
+		// user who read "Terminal" learns to type "shell" — the label is
+		// presentation-only and never resolves (#1986). The old error asserted an
 		// absence and left the user to guess the mapping; listing the valid options
 		// turns a dead end into a fix, and still fires correctly for a real typo.
 		ids := make([]string, 0, len(tabs))
@@ -176,11 +167,12 @@ func resolveTabTarget(tabs []*session.Tab, title, tabID, tabName string, tabInde
 		}
 		return 0, "", fmt.Errorf("session %q has no tab named %q; its tabs are: %s",
 			title, tabName, strings.Join(ids, ", "))
-	}
-	if tabIndex < 0 || tabIndex >= len(tabs) {
+	case errors.Is(err, session.ErrTabIndexOutOfRange):
 		return 0, "", fmt.Errorf("session %q has no tab at index %d", title, tabIndex)
+	case err != nil:
+		return 0, "", err
 	}
-	return tabIndex, tabs[tabIndex].Name, nil
+	return idx, tabs[idx].Name, nil
 }
 
 // Rollback on persist failure: rename and reorder DO roll back, CloseTab

--- a/daemon/preview.go
+++ b/daemon/preview.go
@@ -68,6 +68,19 @@ type PreviewRequest struct {
 type PreviewResponse struct {
 	Content string `json:"content"`
 	Gone    bool   `json:"gone,omitempty"`
+	// TabGone NARROWS Gone: the session is alive and well, but the TAB the request
+	// addressed is not there — an id that no longer resolves, or an ordinal that is
+	// not a slot. Gone is always set alongside it, so a client that only knows
+	// about Gone (the TUI's session-gone fallback) behaves exactly as before.
+	//
+	// It exists because the two causes are indistinguishable to a CLIENT and the
+	// daemon knows them apart. `af sessions preview --tab-id x` used to report a
+	// tab-level miss as "session %q is no longer running": a plain lie about a
+	// running session, and one the CLI could only have avoided by GUESSING from
+	// the fact that it had sent a selector — which is wrong precisely when the
+	// session really did die mid-capture. Carrying the fact is the alternative to
+	// inferring it.
+	TabGone bool `json:"tab_gone,omitempty"`
 }
 
 // Preview captures one tab's content through the session's agent-server — the same
@@ -98,31 +111,33 @@ func (s *controlServer) Preview(req PreviewRequest, resp *PreviewResponse) error
 	// degrades on — the addressed tab is genuinely no longer there.
 	//
 	// The ordinal is used ONLY when neither an id nor a name was supplied — a
-	// legacy client, for which positional addressing is all there ever was — and
-	// that path is left byte-for-byte as it was, so such a client is unaffected.
-	tab := req.Tab
-	if req.TabID != "" || req.TabName != "" {
-		idx, rerr := session.ResolveTabIndex(instance.GetTabs(), req.TabID, req.TabName, req.Tab)
-		switch {
-		case errors.Is(rerr, session.ErrTabIDNotFound):
-			// Gone, not an error: the specific tab this client was looking at is no
-			// longer there, which is the fallback the TUI already degrades on.
-			resp.Gone = true
-			return nil
-		case errors.Is(rerr, session.ErrTabNameNotFound):
-			// A name that matches nothing is far more likely a typo than a
-			// disappearance, so answer with the roster rather than an empty capture.
-			tabs := instance.GetTabs()
-			ids := make([]string, 0, len(tabs))
-			for _, t := range tabs {
-				ids = append(ids, session.TabIdentifiers(t))
-			}
-			return fmt.Errorf("session %q has no tab named %q; its tabs are: %s",
-				req.Title, req.TabName, strings.Join(ids, ", "))
-		case rerr != nil:
-			return rerr
+	// legacy client, for which positional addressing is all there ever was. It goes
+	// through this same call so it is BOUNDS-CHECKED like every other selector: an
+	// in-range ordinal resolves to itself and behaves byte-for-byte as it always
+	// did, while an out-of-range one used to reach as.Preview and come back as a
+	// silent empty capture with no error at all. A capture verb that answers "" to
+	// a bad slot is the dishonesty this cluster exists to remove, so it is now a
+	// tab-level Gone like any other missing tab.
+	tabs := instance.GetTabs()
+	tab, rerr := session.ResolveTabIndex(tabs, req.TabID, req.TabName, req.Tab)
+	switch {
+	case errors.Is(rerr, session.ErrTabIDNotFound), errors.Is(rerr, session.ErrTabIndexOutOfRange):
+		// Gone, not an error: the tab this client addressed is no longer there,
+		// which is the fallback the TUI already degrades on. TabGone says the
+		// SESSION is fine, so a client need not guess which vanished.
+		resp.Gone, resp.TabGone = true, true
+		return nil
+	case errors.Is(rerr, session.ErrTabNameNotFound):
+		// A name that matches nothing is far more likely a typo than a
+		// disappearance, so answer with the roster rather than an empty capture.
+		ids := make([]string, 0, len(tabs))
+		for _, t := range tabs {
+			ids = append(ids, session.TabIdentifiers(t))
 		}
-		tab = idx
+		return fmt.Errorf("session %q has no tab named %q; its tabs are: %s",
+			req.Title, req.TabName, strings.Join(ids, ", "))
+	case rerr != nil:
+		return rerr
 	}
 	content, err := as.Preview(tab, req.Full)
 	if err != nil {

--- a/daemon/preview.go
+++ b/daemon/preview.go
@@ -2,7 +2,10 @@ package daemon
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 
+	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
@@ -42,7 +45,20 @@ type PreviewRequest struct {
 	// resolveTabTarget (#1929): once a client addresses a tab by its stable id, no
 	// daemon path may fall back to a positional one.
 	TabID string `json:"tab_id,omitempty"`
-	Full  bool   `json:"full"`
+	// TabName addresses the tab by its canonical name — the handle a user types
+	// (#1986), the one `af sessions tab-create` printed. It is what a person has
+	// on hand: `af sessions preview alpha --tab-name shell` (#1948). Resolved
+	// against the roster the DAEMON holds, so the CLI never has to fetch the tab
+	// list and race it.
+	//
+	// Ranks BELOW TabID and ABOVE Tab, the precedence every tab verb shares (see
+	// session.ResolveTabIndex). A name that matches nothing is an ERROR listing the
+	// tabs that exist — unlike an unresolvable TabID, which answers Gone: an id
+	// that stops resolving means the exact tab the client was looking at went
+	// away, while a name that matches nothing is far more likely a typo, and a
+	// typo deserves the roster rather than a silent empty capture.
+	TabName string `json:"tab_name,omitempty"`
+	Full    bool   `json:"full"`
 }
 
 // PreviewResponse carries the captured content, or Gone=true when the session's
@@ -69,21 +85,42 @@ func (s *controlServer) Preview(req PreviewRequest, resp *PreviewResponse) error
 	if err != nil {
 		return err
 	}
-	// Address the capture by the stable tab id (#1738) when the client gives one:
-	// resolve it to the tab's CURRENT ordinal so a capture follows the tab across a
-	// reorder/close. A non-empty id that no longer resolves is REFUSED as gone —
-	// NOT fallen back to req.Tab (#1779). The fallback previewed whatever tab had
-	// shifted into the stale ordinal, which is precisely the misroute the stable id
-	// exists to prevent. Gone (rather than an error) is the honest answer and the
-	// shape the TUI already degrades on: the addressed tab is genuinely no longer
-	// there. The ordinal is used ONLY when no id was supplied at all — a legacy
-	// client, for which positional addressing is all there ever was.
+	// Address the capture by the stable tab id (#1738), or by name (#1948), when
+	// the client gives one: resolve it to the tab's CURRENT ordinal so a capture
+	// follows the tab across a reorder/close. The precedence — id, then name, then
+	// ordinal — is session.ResolveTabIndex's, shared with every other tab verb
+	// rather than restated here.
+	//
+	// A non-empty id that no longer resolves is REFUSED as gone, NOT fallen back to
+	// req.Tab (#1779): the fallback previewed whatever tab had shifted into the
+	// stale ordinal, precisely the misroute the stable id exists to prevent. Gone
+	// (rather than an error) is the honest answer and the shape the TUI already
+	// degrades on — the addressed tab is genuinely no longer there.
+	//
+	// The ordinal is used ONLY when neither an id nor a name was supplied — a
+	// legacy client, for which positional addressing is all there ever was — and
+	// that path is left byte-for-byte as it was, so such a client is unaffected.
 	tab := req.Tab
-	if req.TabID != "" {
-		idx, ok := instance.TabIndexByID(req.TabID)
-		if !ok {
+	if req.TabID != "" || req.TabName != "" {
+		idx, rerr := session.ResolveTabIndex(instance.GetTabs(), req.TabID, req.TabName, req.Tab)
+		switch {
+		case errors.Is(rerr, session.ErrTabIDNotFound):
+			// Gone, not an error: the specific tab this client was looking at is no
+			// longer there, which is the fallback the TUI already degrades on.
 			resp.Gone = true
 			return nil
+		case errors.Is(rerr, session.ErrTabNameNotFound):
+			// A name that matches nothing is far more likely a typo than a
+			// disappearance, so answer with the roster rather than an empty capture.
+			tabs := instance.GetTabs()
+			ids := make([]string, 0, len(tabs))
+			for _, t := range tabs {
+				ids = append(ids, session.TabIdentifiers(t))
+			}
+			return fmt.Errorf("session %q has no tab named %q; its tabs are: %s",
+				req.Title, req.TabName, strings.Join(ids, ", "))
+		case rerr != nil:
+			return rerr
 		}
 		tab = idx
 	}

--- a/daemon/preview_tab_miss_test.go
+++ b/daemon/preview_tab_miss_test.go
@@ -1,0 +1,137 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+)
+
+// Tab-level misses on the Preview RPC (#1948 review).
+//
+// `af sessions preview` gained --tab/--tab-id, and on the REMOTE path both
+// answered dishonestly:
+//
+//   - an unresolvable --tab-id came back as a bare Gone, which the CLI printed as
+//     "session %q is no longer running" — a lie about a perfectly healthy session
+//   - an out-of-range --tab skipped resolution entirely and produced a SILENT
+//     EMPTY capture with no error at all
+//
+// Both are the shape this cluster exists to remove: the daemon knew the answer
+// and the client could not see it. Gone now carries TabGone, which says the
+// SESSION is fine and only the addressed tab is missing — so the CLI reports the
+// flag that was wrong instead of guessing from "I sent a selector", a guess that
+// is wrong in exactly the case where the session really did die mid-capture.
+
+// previewTestSession stands up a started local session with one extra process
+// tab, so the roster is [agent, a] — ordinals 0 and 1 are real, 2+ are not.
+func previewTestSession(t *testing.T) (*controlServer, string, string) {
+	t.Helper()
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	const title = "worker"
+	inst := startedLocalTabInstance(t, manager, repo.ID, repoPath, title, "af_"+title+"_agent")
+	if _, err := inst.AddProcessTab("a", ""); err != nil {
+		t.Fatalf("AddProcessTab: %v", err)
+	}
+	if got := inst.TabCount(); got != 2 {
+		t.Fatalf("premise: want a 2-tab roster, got %d", got)
+	}
+	return &controlServer{manager: manager}, title, repo.ID
+}
+
+// TestPreview_OutOfRangeOrdinalIsATabMiss is the silent-empty bug. Before this,
+// a bare out-of-range --tab bypassed resolution (the guard was `TabID != "" ||
+// TabName != ""`), reached the capture with a bad index, and returned "" with
+// Gone=false and no error — so `af sessions preview x --tab 99` printed an empty
+// capture and exited 0, which reads as "that tab is empty" rather than "there is
+// no such tab".
+func TestPreview_OutOfRangeOrdinalIsATabMiss(t *testing.T) {
+	cs, title, repoID := previewTestSession(t)
+
+	for _, ordinal := range []int{2, 99, -1} {
+		var resp PreviewResponse
+		if err := cs.Preview(PreviewRequest{Title: title, RepoID: repoID, Tab: ordinal}, &resp); err != nil {
+			t.Fatalf("--tab %d must be a structured miss, not a transport error: %v", ordinal, err)
+		}
+		if !resp.Gone {
+			t.Errorf("--tab %d on a 2-tab session returned Gone=false with content %q — a capture "+
+				"verb answering \"\" to a slot that does not exist is indistinguishable from an "+
+				"empty tab", ordinal, resp.Content)
+		}
+		if !resp.TabGone {
+			t.Errorf("--tab %d reported Gone without TabGone, so the CLI cannot tell it from a dead "+
+				"session and prints \"session is no longer running\" about a healthy one", ordinal)
+		}
+		if resp.Content != "" {
+			t.Errorf("--tab %d captured %q; a miss must capture nothing", ordinal, resp.Content)
+		}
+	}
+}
+
+// TestPreview_UnresolvableTabIDIsATabMiss pins the other half: the id case
+// already answered Gone (#1779), but said nothing about WHICH thing was gone.
+func TestPreview_UnresolvableTabIDIsATabMiss(t *testing.T) {
+	cs, title, repoID := previewTestSession(t)
+
+	var resp PreviewResponse
+	if err := cs.Preview(PreviewRequest{Title: title, RepoID: repoID, TabID: "never-minted"}, &resp); err != nil {
+		t.Fatalf("an unknown tab id must be a structured miss: %v", err)
+	}
+	if !resp.Gone {
+		t.Fatal("an unknown tab id must report gone rather than capture tab 0")
+	}
+	if !resp.TabGone {
+		t.Error("an unknown tab id reported Gone without TabGone — the session is alive and the CLI " +
+			"would tell the user it had ended because they mistyped --tab-id")
+	}
+}
+
+// TestPreview_InRangeOrdinalIsUnchanged is the no-regression guard on the path
+// that was already correct. Routing the bare ordinal through ResolveTabIndex must
+// bounds-check it WITHOUT altering a legacy positional capture: same content,
+// and emphatically not a miss.
+func TestPreview_InRangeOrdinalIsUnchanged(t *testing.T) {
+	cs, title, repoID := previewTestSession(t)
+
+	for _, ordinal := range []int{0, 1} {
+		var resp PreviewResponse
+		if err := cs.Preview(PreviewRequest{Title: title, RepoID: repoID, Tab: ordinal}, &resp); err != nil {
+			t.Fatalf("in-range --tab %d must still capture: %v", ordinal, err)
+		}
+		if resp.Gone || resp.TabGone {
+			t.Errorf("in-range --tab %d reported gone=%v tabGone=%v; the pre-existing positional "+
+				"path must be untouched", ordinal, resp.Gone, resp.TabGone)
+		}
+	}
+}
+
+// TestPreview_TabGoneNarrowsRatherThanReplacesGone pins the compatibility rule
+// the TUI depends on: TabGone never appears without Gone. The TUI reads only
+// Gone and degrades to its session-gone fallback; if a tab miss set TabGone
+// alone, the TUI would render a stale pane instead.
+func TestPreview_TabGoneNarrowsRatherThanReplacesGone(t *testing.T) {
+	cs, title, repoID := previewTestSession(t)
+
+	for _, req := range []PreviewRequest{
+		{Title: title, RepoID: repoID, Tab: 99},
+		{Title: title, RepoID: repoID, TabID: "never-minted"},
+	} {
+		var resp PreviewResponse
+		if err := cs.Preview(req, &resp); err != nil {
+			t.Fatalf("Preview(%+v): %v", req, err)
+		}
+		if resp.TabGone && !resp.Gone {
+			t.Errorf("Preview(%+v) set TabGone without Gone; a client that only knows Gone (the TUI) "+
+				"would keep rendering a tab that is not there", req)
+		}
+	}
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1145,9 +1145,29 @@ With no repo context, a title held by exactly one session still resolves; one
 held by sessions in several projects is ambiguous and reports an error naming
 those projects instead of guessing between them.
 
+By default this captures the session's AGENT tab (slot 0), visible screen only.
+Address another tab with --tab-name (the tab name "af sessions tab-create"
+printed, as reported by "af sessions get" — not the TUI's "Agent"/"Terminal"
+label), --tab-id (the stable id, for scripts that must not follow a reused
+name), or --tab (the 0-based slot). They resolve in that precedence — id, then
+name, then slot — the same order every tab verb uses. An id or name that does
+not resolve is an error, never a silent fall back to a slot: that would capture
+whatever tab had shifted into it.
+
+--full returns the entire scrollback instead of the visible screen.
+
 ```
-af sessions preview <title>
+af sessions preview <title> [flags]
 ```
+
+**Flags**
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--full` |  | Capture the entire scrollback instead of the visible screen |
+| `--tab` | `int` | Tab slot to capture, 0-based as the tab bar reads left to right (slot 0 is the agent tab) (default `0`) |
+| `--tab-id` | `string` | Stable id of the tab to capture (#1738); wins over --tab-name and --tab |
+| `--tab-name` | `string` | Name of the tab to capture, as reported by "af sessions get" (not the TUI's "Agent"/"Terminal" label); wins over --tab |
 
 **Global flags**
 

--- a/parity/honesty_test.go
+++ b/parity/honesty_test.go
@@ -156,45 +156,61 @@ func TestDerivationSeesTUIBackendGap(t *testing.T) {
 	}
 }
 
-// TestDerivationSeesPreviewTabGap pins #1948: `af sessions preview` reaches the
-// Preview RPC but can only ever see tab 0. This one also proves the derivation
-// covers an INTERNAL route — Preview is absent from the public catalog, so a
-// route-catalog-only check cannot see it.
-func TestDerivationSeesPreviewTabGap(t *testing.T) {
+// TestDerivationTracksPreviewTabUse is the successor to the #1948 fixture. That
+// gap ("`af sessions preview` reaches the Preview RPC but can only ever see tab
+// 0") is now CLOSED, and the old test said what to do when that happened: retire
+// the fixture. Retiring it outright would delete the meta-check with it, so it is
+// repointed rather than removed — and the post-fix state is a strictly better
+// fixture, because one request type now exercises BOTH failure directions at
+// once:
+//
+//   - under-reporting: the CLI sets tab/tab_id/tab_name/full, so a walk that
+//     missed real usage would report them unreached and manufacture a false gap.
+//   - over-reporting: the TUI sets every field EXCEPT tab_name (it holds the live
+//     tab and addresses it by the stronger TabID), so a walk that credited
+//     construction it never saw would report nothing unreached and hide a real
+//     one.
+//
+// It also still proves the derivation covers an INTERNAL route — Preview is
+// absent from the public catalog, so a route-catalog-only check cannot see it.
+func TestDerivationTracksPreviewTabUse(t *testing.T) {
 	use := deriveGoRequestUse(t, "cli")
 	typeUse := deriveTypeFieldUse(t, "cli")
 
 	u, ok := use["PreviewRequest"]
 	if !ok {
 		t.Fatal("AST found no CLI PreviewRequest construction — the walk is blind " +
-			"(expected api/sessions.go:674)")
+			"(expected api/sessions.go, sessionsPreviewCmd)")
 	}
 	unreached := unreachedFields(auditedRequests["PreviewRequest"], u, typeUse)
-	for _, f := range []string{"tab", "tab_id", "full"} {
-		if !contains(unreached, f) {
-			t.Errorf("derivation says the CLI reaches PreviewRequest.%s, but api/sessions.go:674 "+
-				"sends only {Title, RepoID}. Either #1948 was fixed (retire the fixture) or "+
-				"the AST walk is over-crediting.", f)
+	// Not blind: the CLI provably sets all four selectors since #1948.
+	for _, f := range []string{"title", "tab", "tab_id", "tab_name", "full"} {
+		if contains(unreached, f) {
+			t.Errorf("derivation says the CLI never sets PreviewRequest.%s, but sessionsPreviewCmd "+
+				"plainly does (#1948) — the AST walk is under-reporting, which manufactures false "+
+				"gaps.", f)
 		}
 	}
-	if contains(unreached, "title") {
-		t.Error("derivation says the CLI never sets PreviewRequest.title — it plainly does; " +
-			"the AST walk is under-reporting.")
-	}
 
-	// The TUI is the control: it drives the SAME RPC with every field, so a
-	// derivation that reported the gap for both surfaces would be broken in a way
-	// the CLI-only assertions above could not distinguish.
+	// The TUI is the control, and it is no longer a trivial one: it sets every
+	// field but tab_name, so this pins the derivation's ability to spot a genuine
+	// non-use rather than just agreeing that everything is covered.
 	tuiUse := deriveGoRequestUse(t, "tui")
 	tui, ok := tuiUse["PreviewRequest"]
 	if !ok {
 		t.Fatal("AST found no TUI PreviewRequest construction (expected app/live_stream.go:35)")
 	}
 	tuiUnreached := unreachedFields(auditedRequests["PreviewRequest"], tui, deriveTypeFieldUse(t, "tui"))
-	if len(tuiUnreached) != 0 {
-		t.Errorf("the TUI sets every PreviewRequest field (app/live_stream.go:35), but derivation "+
-			"reports %v unreached — it is over-reporting, which would manufacture false gaps.",
-			tuiUnreached)
+	if !contains(tuiUnreached, "tab_name") {
+		t.Error("derivation says the TUI reaches PreviewRequest.tab_name, but app/live_stream.go " +
+			"addresses the tab by TabID and never sends a name — the AST walk is over-crediting, " +
+			"which HIDES real gaps.")
+	}
+	for _, f := range []string{"title", "tab", "tab_id", "full"} {
+		if contains(tuiUnreached, f) {
+			t.Errorf("derivation says the TUI never sets PreviewRequest.%s, but app/live_stream.go:35 "+
+				"does — the AST walk is under-reporting.", f)
+		}
 	}
 }
 

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -357,12 +357,11 @@
         "pointer": "web/src/terminal.ts:205-223 streams any tab via tab_id"
       },
       "cli": {
-        "status": "no",
-        "pointer": "api/sessions.go:674 sends only {Title, RepoID}; no --tab flag"
+        "status": "yes",
+        "pointer": "api/sessions.go sessionsPreviewCmd --tab/--tab-name/--tab-id"
       },
-      "verdict": "real-gap",
-      "issue": "#1948",
-      "notes": "The substrate supports it and one surface does not expose it: PreviewRequest carries Tab (ordinal) and TabID (stable id, #1738), the TUI drives both, and `af sessions preview <title>` can only ever see tab 0. Absurd in practice because the CLI can CREATE a tab (`af sessions tab-create --name x --command …`) and then has no way to read it — create without read. Found by dogfooding, not by the verb-level check, which is why field_coverage now exists."
+      "verdict": "parity",
+      "notes": "Closed by #1948. PreviewRequest always carried Tab and TabID and the CLI sent neither, so `af sessions preview` could only ever see tab 0 — it could CREATE a tab and then had no way to read it. The CLI now sends all three selectors and gained --tab-name, the handle a person actually has; the id/name/ordinal precedence is session.ResolveTabIndex, shared with every other tab verb rather than restated per surface."
     },
     {
       "id": "session.preview-full",
@@ -376,12 +375,11 @@
         "pointer": "web/src/terminal.ts (xterm holds its own scrollback)"
       },
       "cli": {
-        "status": "no",
-        "pointer": "api/sessions.go:674 never sets Full"
+        "status": "yes",
+        "pointer": "api/sessions.go sessionsPreviewCmd --full"
       },
-      "verdict": "real-gap",
-      "issue": "#1948",
-      "notes": "PreviewRequest.Full selects PreviewFullHistory over the visible capture (daemon/preview.go:80 -> session/agentserver_local.go:122-130). `af sessions preview` can only ever show the visible screen, never scrollback — the same unexposed-field shape as session.preview-tab, on the same request, so it is tracked by the same issue."
+      "verdict": "parity",
+      "notes": "Closed by #1948. --full selects PreviewFullHistory over the visible capture, so the CLI can read scrollback instead of only the visible screen."
     },
     {
       "id": "session.tab.create.options",
@@ -1464,7 +1462,11 @@
       "af sessions kill --force": "session.kill",
       "af sessions kill --help": "meta.discovery",
       "af sessions list --help": "meta.discovery",
+      "af sessions preview --full": "session.preview-full",
       "af sessions preview --help": "meta.discovery",
+      "af sessions preview --tab": "session.preview-tab",
+      "af sessions preview --tab-id": "session.preview-tab",
+      "af sessions preview --tab-name": "session.preview-tab",
       "af sessions restore --help": "meta.discovery",
       "af sessions send-prompt --all": "session.send-prompt.broadcast",
       "af sessions send-prompt --all-repos": "session.send-prompt.broadcast",
@@ -1563,15 +1565,9 @@
     ],
     "requests": {
       "PreviewRequest": {
-        "cli": {
-          "tab": {
-            "gap": "session.preview-tab"
-          },
-          "tab_id": {
-            "gap": "session.preview-tab"
-          },
-          "full": {
-            "gap": "session.preview-full"
+        "tui": {
+          "tab_name": {
+            "ok": "The TUI holds the live tab object and addresses it by TabID, which is the stronger handle: a name is freed by a close and handed to the next tab that asks for it, a stable id never is. TabName exists for the CLI, where a person types the handle they actually have on hand (#1948)."
           }
         }
       },

--- a/session/tab.go
+++ b/session/tab.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -322,6 +323,64 @@ func TabMatches(t *Tab, token string) bool {
 		return false
 	}
 	return t.Name == token
+}
+
+// Sentinel misses from ResolveTabIndex. They are values rather than formatted
+// strings because the CALLER owns the message: the daemon names the session and
+// lists the tabs that exist, the CLI says which flag was wrong. Only the RULE is
+// shared.
+var (
+	// ErrTabIDNotFound: a stable id was supplied and is not in the roster.
+	ErrTabIDNotFound = errors.New("no tab with that id")
+	// ErrTabNameNotFound: a name was supplied and matches no tab.
+	ErrTabNameNotFound = errors.New("no tab with that name")
+	// ErrTabIndexOutOfRange: no id or name was supplied and the ordinal is not a slot.
+	ErrTabIndexOutOfRange = errors.New("tab index out of range")
+)
+
+// ResolveTabIndex resolves which tab of tabs a caller addresses, in the
+// repo-wide precedence every tab verb shares: the stable tabID first, then
+// tabName, then the ordinal tabIndex.
+//
+// The id comes first because it is the only handle that is not REUSABLE (#1929).
+// A name is freed by a close and handed to the next tab that asks for it; an
+// ordinal shifts on every close and reorder. So a client that resolved a tab and
+// then sends its name is asking for "whatever is called that NOW", which after a
+// concurrent close+create or rename is a different tab — and a name-keyed
+// resolve does not fail, it succeeds on the wrong tab.
+//
+// A non-empty id or name that does not resolve is REFUSED, never fallen back to
+// the ordinal. That is the #1779/#1929 rule: falling back would address whatever
+// tab has since taken the slot — the precise misroute the stable id exists to
+// prevent, wearing a backward-compatible face. The ordinal is used ONLY when
+// neither an id nor a name was supplied.
+//
+// This lives beside the Tab type rather than in the daemon because the daemon is
+// no longer the only resolver: `af sessions preview` reads a tab on the LOCAL
+// path without going through a daemon RPC at all (#1948), and a second copy of
+// the precedence is how the two would drift into disagreeing about what
+// `--tab-name` means.
+func ResolveTabIndex(tabs []*Tab, tabID, tabName string, tabIndex int) (int, error) {
+	if tabID != "" {
+		for i, tab := range tabs {
+			if tab.ID == tabID {
+				return i, nil
+			}
+		}
+		return 0, ErrTabIDNotFound
+	}
+	if tabName != "" {
+		for i, tab := range tabs {
+			if TabMatches(tab, tabName) {
+				return i, nil
+			}
+		}
+		return 0, ErrTabNameNotFound
+	}
+	if tabIndex < 0 || tabIndex >= len(tabs) {
+		return 0, ErrTabIndexOutOfRange
+	}
+	return tabIndex, nil
 }
 
 // TabIdentifiers renders a tab as the strings that help a user address it in an

--- a/session/tab_resolve_test.go
+++ b/session/tab_resolve_test.go
@@ -1,0 +1,109 @@
+package session
+
+import (
+	"errors"
+	"testing"
+)
+
+// resolverRoster is a three-tab session whose selectors deliberately disagree,
+// so a resolution that silently used the wrong one is visible rather than
+// coincidentally right: the tab named "shell" is NOT at the ordinal a caller
+// would guess, and its label ("Terminal") is not its name.
+func resolverRoster() []*Tab {
+	return []*Tab{
+		{ID: "id-agent", Name: "agent", Kind: TabKindAgent},
+		{ID: "id-btop", Name: "btop", Kind: TabKindProcess},
+		{ID: "id-shell", Name: "shell", Kind: TabKindShell},
+	}
+}
+
+// TestResolveTabIndex_Precedence pins the order every tab verb shares: id, then
+// name, then ordinal. Each case supplies selectors that point at DIFFERENT tabs,
+// so the winner identifies which rule actually ran.
+func TestResolveTabIndex_Precedence(t *testing.T) {
+	tabs := resolverRoster()
+
+	for _, c := range []struct {
+		name    string
+		tabID   string
+		tabName string
+		ordinal int
+		want    int
+		why     string
+	}{
+		{"id beats name and ordinal", "id-shell", "btop", 0, 2,
+			"the stable id is the only non-reusable handle, so it wins outright"},
+		{"name beats ordinal", "", "btop", 0, 1,
+			"a name outranks a slot: the slot shifts on every close and reorder"},
+		{"ordinal only when nothing else is given", "", "", 1, 1,
+			"positional addressing is the legacy fallback, not a co-equal selector"},
+		{"ordinal zero is a real answer", "", "", 0, 0,
+			"slot 0 is the agent tab, not an 'unset' sentinel"},
+	} {
+		got, err := ResolveTabIndex(tabs, c.tabID, c.tabName, c.ordinal)
+		if err != nil {
+			t.Errorf("%s: unexpected error %v", c.name, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("%s: resolved slot %d, want %d — %s", c.name, got, c.want, c.why)
+		}
+	}
+}
+
+// TestResolveTabIndex_RefusesRatherThanFallsBack is the #1779/#1929 rule and the
+// reason this function exists as one definition rather than one per caller.
+//
+// A supplied id or name that does not resolve must be an ERROR. Falling back to
+// the ordinal would address whatever tab has since shifted into that slot — the
+// exact misroute the stable id exists to prevent, wearing a backward-compatible
+// face. It is the quiet kind of wrong: the caller asked for a specific tab, got a
+// different one, and nothing failed.
+func TestResolveTabIndex_RefusesRatherThanFallsBack(t *testing.T) {
+	tabs := resolverRoster()
+
+	// An id that no longer resolves, with a perfectly valid ordinal alongside it.
+	if _, err := ResolveTabIndex(tabs, "id-closed", "", 1); !errors.Is(err, ErrTabIDNotFound) {
+		t.Errorf("unresolvable id returned %v, want ErrTabIDNotFound — it must never fall back "+
+			"to ordinal 1, which is a different, still-live tab", err)
+	}
+	// Same for a name, and note the ordinal here is valid too.
+	if _, err := ResolveTabIndex(tabs, "", "gone", 1); !errors.Is(err, ErrTabNameNotFound) {
+		t.Errorf("unresolvable name returned %v, want ErrTabNameNotFound — no silent fall back "+
+			"to the ordinal", err)
+	}
+	// A bad ordinal, when it IS the selector, is its own miss.
+	for _, bad := range []int{-1, 3, 99} {
+		if _, err := ResolveTabIndex(tabs, "", "", bad); !errors.Is(err, ErrTabIndexOutOfRange) {
+			t.Errorf("ordinal %d returned %v, want ErrTabIndexOutOfRange", bad, err)
+		}
+	}
+	// An empty roster resolves nothing, rather than panicking on tabs[0].
+	if _, err := ResolveTabIndex(nil, "", "", 0); !errors.Is(err, ErrTabIndexOutOfRange) {
+		t.Errorf("empty roster returned %v, want ErrTabIndexOutOfRange", err)
+	}
+}
+
+// TestResolveTabIndex_DoesNotAcceptTheDisplayLabel ties the shared resolver to
+// the #1986 split: the label is presentation-only and must never address a tab,
+// on THIS path as much as on the daemon's. A resolver that accepted it would
+// reintroduce two strings for one tab through the back door — and this is the
+// path `af sessions preview --tab-name` now runs on, which did not exist when
+// #1986 landed.
+func TestResolveTabIndex_DoesNotAcceptTheDisplayLabel(t *testing.T) {
+	tabs := resolverRoster()
+	shell := tabs[2]
+
+	label := TabLabel(shell) // "Terminal"
+	if label == shell.Name {
+		t.Skip("TabLabel now equals Name; there is no second string to reject")
+	}
+	if _, err := ResolveTabIndex(tabs, "", label, 0); !errors.Is(err, ErrTabNameNotFound) {
+		t.Errorf("the display label %q resolved a tab; it is presentation-only and must never be "+
+			"an identifier (#1986). Only the name %q addresses it.", label, shell.Name)
+	}
+	// …and the real name still works, so the rejection above is not blanket failure.
+	if got, err := ResolveTabIndex(tabs, "", shell.Name, 0); err != nil || got != 2 {
+		t.Errorf("ResolveTabIndex by name %q = (%d, %v), want (2, nil)", shell.Name, got, err)
+	}
+}


### PR DESCRIPTION
Closes #1948. Third of the tab-identity cluster; branched off current master (`7c5c49e`).

## The gap

```console
$ af sessions tab-create root --name decisions --command '…'   # works
$ af sessions preview root --tab 1                             # unknown flag
```

The CLI could **create** a tab and then had no way to **read** it. `PreviewRequest` has carried `Tab`, `TabID` and `Full` all along and the TUI drives all three; the CLI sent two of five fields, so `af sessions preview` could only ever capture tab 0's visible screen.

Adds `--tab` (slot), `--tab-name` (the handle a person actually has), `--tab-id` (the stable id, for scripts that must not follow a reused name), and `--full`.

## The issue understated the work — and it matters

> "The plumbing is complete; only the flags are missing."

True of the **remote** path, false of the **local** one: `af sessions preview` calls `instance.AgentServer().Preview(0, false)` directly, bypassing the daemon's tab resolution entirely. So the precedence rule was needed in two places — and a second copy is precisely how the two drift into disagreeing about what `--tab-name` means.

So the rule moved to **`session.ResolveTabIndex`**, beside the `Tab` type: id → name → ordinal, with a supplied id/name that doesn't resolve **refused** rather than falling back (#1779/#1929).

- `daemon.resolveTabTarget` now **delegates** to it and keeps only its *messages*, which are the daemon's to write. Every existing error string is unchanged, so the close/rename/reorder assertions still hold.
- The CLI local path and the Preview RPC resolve from that same definition.

`PreviewRequest` gains `TabName` so the **daemon** resolves the name against the roster it actually holds — resolving client-side would need an extra round trip and would race the roster it read against the one the capture runs on.

Divergence kept deliberate: an unresolvable **name** is an error listing the tabs (a typo deserves the roster), while an unresolvable **id** still answers `Gone` (that tab genuinely went away). The existing TUI contract and the pure-ordinal path are untouched.

## Fail-first — using the repo's own machinery

No hand-written assertion needed. Removing the two declared gaps from `parity/inventory.json` made the field-coverage check rediscover all three unaided at `7c5c49e`, exactly as #1948 predicted:

```
PreviewRequest (cli, [api/sessions.go:372:42]) never sets "full", and the inventory does not say why.
PreviewRequest (cli, [api/sessions.go:372:42]) never sets "tab",  and the inventory does not say why.
PreviewRequest (cli, [api/sessions.go:372:42]) never sets "tab_id", and the inventory does not say why.
```

Plus `session/tab_resolve_test.go` for the shared rule: precedence (each case points the selectors at *different* tabs, so the winner identifies which rule ran), the refuse-never-fall-back guarantee, and that the display label still never resolves (#1986) on this new path.

## One judgement call worth flagging

`TestDerivationSeesPreviewTabGap` used this gap as its fixture, and its own comment said *"either #1948 was fixed (retire the fixture) or the AST walk is over-crediting."* I **repointed** it instead of retiring it — retiring would delete the meta-check that the derivation works at all. The post-fix state is a strictly better fixture: the CLI now sets every field and the TUI sets all but `tab_name`, so one request type exercises **both** under-reporting *and* over-reporting, where before it only covered the first.

`session.preview-tab` and `session.preview-full` flip from `real-gap` to `parity`.

## Verification

- `go build ./...`, `gofmt -l .` (clean), `golangci-lint --fast` (0), `deadcode -test ./...` (empty), `scripts/lint-file-length.sh` (pass), `gen-docs.sh` regenerated.
- **Container** (`make test-container GOTESTARGS="./session/ ./daemon/ ./parity/ ./api/"`): session 32.8s, **daemon 157.3s**, parity 0.9s, api 1.6s — all ok. The daemon suite is the one that matters here: it exercises `resolveTabTarget` through close/rename/reorder, which now delegate.

Co-Authored-By: Captain Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review round 2 — remote/local honesty (commit 2)

Review caught that the flags this PR adds answered **dishonestly over `--daemon-url`**, while the local path was already right — so remote and local disagreed on the surface this PR itself opened.

| case | before (remote) | before (local) | now (both) |
|---|---|---|---|
| unresolvable `--tab-id` | `session "x" is no longer running` — a **lie**, session is fine | `--tab-id "…" matches no tab…` | `--tab-id "…" matches no tab in this session; it may have been closed` |
| out-of-range `--tab` | **silent empty capture, exit 0** | `--tab N is not a slot…` | `--tab N is not a slot in this session` |
| unresolvable `--tab-name` | error + roster | error + roster | unchanged |

**The fix carries the fact rather than inferring it.** `PreviewResponse` gains `TabGone`, which *narrows* `Gone`: the session is alive, the addressed tab is not there.

I deliberately did **not** take the suggested client-side shape ("a preview that supplied a tab selector ⇒ treat Gone as tab-level"). That inference is wrong in exactly the case where the session *really did* die mid-capture, and guessing from a signal that cannot distinguish the two causes is the failure mode this repo keeps relearning. The daemon knows which; it now says which.

The bare ordinal routes through `session.ResolveTabIndex` like every other selector, so it is bounds-checked. **In-range ordinals are byte-for-byte unchanged** (`TestPreview_InRangeOrdinalIsUnchanged`) — only the out-of-range case moves, from silent-empty to a tab miss.

`TabGone` never appears without `Gone`, so the TUI (which reads only `Gone`) is unaffected — pinned by `TestPreview_TabGoneNarrowsRatherThanReplacesGone`. One CLI helper serves both paths, so a user cannot tell which machine resolved their flag.

**Mutation-tested, not assumed:** restoring the old guard fails `OutOfRangeOrdinalIsATabMiss`; setting `Gone` without `TabGone` fails both miss tests; the in-range guard stays green under the first.

⚠️ **Heads-up:** this touches `app/session_control.go` by **one line** (`content, gone, _, e = c.Preview(req)` plus a comment) because `apiclient.Preview` gained a return. That file is in open PR #2071's footprint — trivial to reconcile, but worth knowing about for merge order.

Container re-run: session 32.9s · **daemon 158.6s** · parity · api · apiclient · **app 94.6s** — all ok.
