### PR TITLE
fix(daemon): skip session-title suffixes whose branch a worktree already holds (#2091)

### DIFF
--- a/daemon/create_branch_hold_test.go
+++ b/daemon/create_branch_hold_test.go
@@ -1,0 +1,94 @@
+package daemon
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// holdBranchInArchivedWorktree reproduces what archiving leaves behind (#2013):
+// a worktree on `branch`, MOVED into the AF home's archive layout and still
+// registered with git, so the branch stays checked out under a path no session
+// record points at. It returns the archived worktree path.
+func holdBranchInArchivedWorktree(t *testing.T, repoPath, branch, archiveName string) string {
+	t.Helper()
+	live := filepath.Join(t.TempDir(), "live")
+	out, err := exec.Command("git", "-C", repoPath, "worktree", "add", "-b", branch, live).CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	archived := filepath.Join(t.TempDir(), archiveName+" (archived)")
+	out, err = exec.Command("git", "-C", repoPath, "worktree", "move", live, archived).CombinedOutput()
+	require.NoError(t, err, string(out))
+	return archived
+}
+
+// TestNextAvailableTitle_SkipsBranchHeldByArchivedWorktree is the #2091
+// regression lock at the production call site: the derived-title walk that every
+// session-creating scheduled task goes through (taskrun passes TitleBase, which
+// routes here).
+//
+// The rot: a recurring task creates "sweep", archives it, and the archived
+// worktree keeps branch <prefix>sweep checked out. Nothing in the title walk
+// consulted git, so the next run happily handed back a title whose branch a
+// registered worktree already held — and `git worktree add` then failed hard,
+// every run, forever.
+//
+// The seeded worktrees deliberately have NO session records: that is the field
+// shape (#2091 shows archived worktrees whose rows had been renamed out from
+// under them), and it is the case only git can answer.
+func TestNextAvailableTitle_SkipsBranchHeldByArchivedWorktree(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+
+	holdBranchInArchivedWorktree(t, repoPath, manager.branchForTitle("sweep"), "sweep")
+	holdBranchInArchivedWorktree(t, repoPath, manager.branchForTitle("sweep-2"), "sweep-2")
+
+	manager.mu.Lock()
+	title, err := manager.nextAvailableTitleLocked(repoID, repoPath, "sweep", "claude", false, nil)
+	manager.mu.Unlock()
+	require.NoError(t, err)
+
+	assert.Equal(t, "sweep-3", title,
+		"the walk must skip every suffix an archived worktree still holds")
+
+	// Not merely unheld on paper — the worktree the create exists to build
+	// actually gets built under the resolved name.
+	dest := filepath.Join(t.TempDir(), "run")
+	out, addErr := exec.Command("git", "-C", repoPath, "worktree", "add", "-b",
+		manager.branchForTitle(title), dest).CombinedOutput()
+	require.NoError(t, addErr, "resolved title %q must be usable: %s", title, string(out))
+}
+
+// TestNextAvailableTitle_UncontestedNameKeepsBareForm is the no-regression side:
+// consulting git must not push an uncontested name off its bare form.
+func TestNextAvailableTitle_UncontestedNameKeepsBareForm(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+
+	manager.mu.Lock()
+	title, err := manager.nextAvailableTitleLocked(repoID, repoPath, "sweep", "claude", false, nil)
+	manager.mu.Unlock()
+
+	require.NoError(t, err)
+	assert.Equal(t, "sweep", title)
+}
+
+// TestNextAvailableTitle_ExistingBranchIsNotAHold keeps the new check as narrow
+// as the failure it fixes. AF reuses an existing branch when one matches the
+// derived name (setupFromExistingBranch), so a branch that merely EXISTS must
+// not cost the session its bare title — only a branch some worktree has
+// checked out is unusable.
+func TestNextAvailableTitle_ExistingBranchIsNotAHold(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+
+	out, err := exec.Command("git", "-C", repoPath, "branch", manager.branchForTitle("sweep")).CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	manager.mu.Lock()
+	title, err := manager.nextAvailableTitleLocked(repoID, repoPath, "sweep", "claude", false, nil)
+	manager.mu.Unlock()
+
+	require.NoError(t, err)
+	assert.Equal(t, "sweep", title)
+}

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -216,6 +216,14 @@ func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, 
 		// archived session out of the way so the new session can take the name
 		// (feat: reuse archived name). A LIVE collision is left untouched, so
 		// validateTitleAvailableLocked below still rejects it exactly as before.
+		//
+		// This path deliberately does NOT get #2091's worktree-branch check. The
+		// walk above can route around a held branch by taking the next suffix; an
+		// explicitly requested title has nowhere to go, and the rename that frees
+		// the title does not free the BRANCH the archived worktree still holds —
+		// so gating here would only move a guaranteed failure earlier, not fix it.
+		// Making reuse-archived-name actually work means releasing the branch too;
+		// tracked in #2127.
 		renamedArchived, err = m.renameArchivedForReuseLocked(repo.ID, repo.Root, title, req.Program, &diskData)
 		if err != nil {
 			return nil, "", nil, nil, err
@@ -416,6 +424,11 @@ func (m *Manager) findArchivedOnlyCollisionLocked(repoID, title string) (*sessio
 // archived session being renamed out of the way: "<base> (archived)", then
 // "<base> (archived 2)", "(archived 3)", … skipping any that collide with an
 // existing live or archived session (feat: reuse archived name). Runs under m.mu.
+//
+// No worktree-branch check here (#2091): this walk renames an EXISTING archived
+// session, which keeps the branch it already has checked out. The new title is a
+// label, not a branch to be created, so "is this branch checked out somewhere" is
+// not a question about it.
 func (m *Manager) uniqueArchivedTitleLocked(repoID, repoPath, base, program string, remote bool, diskData []session.InstanceData) (string, error) {
 	for i := 1; i <= 10000; i++ {
 		candidate := fmt.Sprintf("%s (archived)", base)
@@ -434,10 +447,27 @@ func (m *Manager) uniqueArchivedTitleLocked(repoID, repoPath, base, program stri
 }
 
 func (m *Manager) nextAvailableTitleLocked(repoID, repoPath, baseTitle, program string, remote bool, diskData []session.InstanceData) (string, error) {
+	// Session records are not the only thing that can make a candidate unusable
+	// (#2091). A branch already CHECKED OUT by some worktree cannot be checked
+	// out again, and archiving relocates a worktree rather than removing it
+	// (#2013), so an archived session keeps its branch — under a path no record
+	// points at once its row has been renamed. The rot that produced: a daily
+	// task walked to a suffix its own archived predecessor still held, `git
+	// worktree add` refused it, and the task died that way every run, forever.
+	// So ask the one component that knows which branches are checked out
+	// somewhere, ONCE per walk, and skip those rungs instead of discovering the
+	// collision at add time.
+	heldBranches := m.worktreeHeldBranchesLocked(repoPath, remote)
 	for i := 1; i <= 10000; i++ {
 		candidate := baseTitle
 		if i > 1 {
 			candidate = fmt.Sprintf("%s-%d", baseTitle, i)
+		}
+		branch := m.branchForTitle(candidate)
+		if holder, held := heldBranches[branch]; held {
+			log.InfoLog.Printf("title %q derives branch %q, which the worktree at %s still has checked out; trying the next suffix",
+				candidate, branch, holder)
+			continue
 		}
 		err := m.validateTitleAvailableLocked(repoID, repoPath, candidate, program, remote, false, diskData)
 		if err == nil {
@@ -678,6 +708,34 @@ func (m *Manager) findTitleConflictLocked(repoID, title string, diskData []sessi
 // TUI's naming pre-check stay in lockstep (#936).
 func (m *Manager) titlesCollide(a, b string) bool {
 	return git.TitlesCollide(a, b, m.cfg.BranchPrefix)
+}
+
+// worktreeHeldBranchesLocked answers "which branches are already checked out by
+// a worktree of this repo" for the title walk (#2091), mapping each to the
+// worktree holding it. Runs under m.mu.
+//
+// Two deliberate non-answers:
+//
+//   - Hook sessions (remote) never take a local worktree — backend_local is the
+//     only caller of NewGitWorktree — so no local branch can block their name,
+//     and probing the repo for them would be answering a question nobody asked.
+//   - A probe that could not RUN returns nil, not an empty map with a shrug.
+//     Nil means "no holds known", which leaves the pre-#2091 behavior exactly as
+//     it was: the create proceeds, and if the name really is held, `git worktree
+//     add` refuses it loudly and changes nothing. That is the right failure for
+//     an unanswerable question. The destructive reading would be to treat an
+//     unreadable repo as "everything is held" and walk a recurring task's name
+//     to an ever-growing suffix on the strength of a probe that never answered.
+func (m *Manager) worktreeHeldBranchesLocked(repoPath string, remote bool) map[string]string {
+	if remote {
+		return nil
+	}
+	held, err := git.BranchesHeldByWorktrees(repoPath)
+	if err != nil {
+		log.WarningLog.Printf("could not list worktree branch holds for %s; resolving the session title without them (a name an archived worktree holds will fail at worktree add instead of being skipped): %v", repoPath, err)
+		return nil
+	}
+	return held
 }
 
 // branchForTitle derives the git branch name for a session title using the same

--- a/session/git/branch_holds.go
+++ b/session/git/branch_holds.go
@@ -1,0 +1,102 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// worktreeListTimeout bounds the branch-hold probe. The probe runs on the
+// session-CREATE path while the daemon holds its manager lock, so an
+// unbounded read against a stalled filesystem would not merely slow a create
+// down — it would wedge every RPC behind that lock (the #896/#1917 lesson,
+// applied before it can bite here).
+//
+// A var (not a const) only so tests can shorten it; production never reassigns.
+var worktreeListTimeout = 10 * time.Second
+
+// BranchesHeldByWorktrees returns every local branch that a registered worktree
+// of the repo at repoRoot currently has CHECKED OUT, mapped to the path of the
+// worktree holding it. Branches with no worktree — and worktrees on a detached
+// HEAD — are absent.
+//
+// This is the authority the session-name resolver was missing (#2091). A
+// branch's mere existence says nothing about whether AF can use it: AF
+// deliberately reuses an existing branch when one matches the derived name
+// (setupFromExistingBranch), so `git branch` cannot distinguish "reusable" from
+// "unusable". A branch already checked out SOMEWHERE is the unusable case, and
+// git refuses `worktree add` on it with "already used by worktree at …". Only
+// `git worktree list` knows which those are.
+//
+// The archived worktrees under the AF home are why this must be a git query and
+// not a scan of archived/: archiving RELOCATES a worktree and repairs its
+// registration (#2013) rather than removing it, so an archived session keeps its
+// branch checked out and stays registered under a path the resolver has no
+// reason to know. git knows. Ask git.
+//
+// An unreadable repo returns an error and a nil map, never an empty one: "I
+// could not ask" and "nothing is held" are different answers, and a caller that
+// cannot tell them apart would treat a failed probe as a confident all-clear.
+func BranchesHeldByWorktrees(repoRoot string) (map[string]string, error) {
+	if strings.TrimSpace(repoRoot) == "" {
+		return nil, fmt.Errorf("cannot list worktrees: repo path is empty")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), worktreeListTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "-C", repoRoot, "worktree", "list", "--porcelain")
+	// Bound the post-exit wait so a child that inherited the capture pipe cannot
+	// hold Output() open past the deadline (#856).
+	cmd.WaitDelay = gitWaitDelay
+
+	output, err := cmd.Output()
+	if errors.Is(err, exec.ErrWaitDelay) {
+		// git itself exited successfully (a non-zero exit surfaces as an
+		// ExitError); only a pipe-holder outlived it, so the output is complete.
+		err = nil
+	}
+	if err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return nil, fmt.Errorf("git worktree list in %s timed out after %s: %w", repoRoot, worktreeListTimeout, ctx.Err())
+		}
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return nil, fmt.Errorf("git worktree list in %s failed: %s (%w)", repoRoot, strings.TrimSpace(string(exitErr.Stderr)), err)
+		}
+		return nil, fmt.Errorf("git worktree list in %s failed: %w", repoRoot, err)
+	}
+	return parseWorktreeBranchHolds(string(output)), nil
+}
+
+// parseWorktreeBranchHolds reads `git worktree list --porcelain` output into
+// branch -> holding worktree path. Each record is a `worktree <path>` line
+// followed by attribute lines and terminated by a blank line; a record carries a
+// `branch refs/heads/<name>` line only when that worktree has a branch checked
+// out (detached and bare worktrees do not).
+//
+// Paths are taken verbatim to the end of the line, which is what git emits —
+// every archived worktree path contains spaces, so any whitespace-splitting
+// parse would truncate exactly the paths this exists to report.
+func parseWorktreeBranchHolds(porcelain string) map[string]string {
+	holds := make(map[string]string)
+	worktreePath := ""
+	for _, line := range strings.Split(porcelain, "\n") {
+		line = strings.TrimSuffix(line, "\r")
+		switch {
+		case line == "":
+			// Record separator: nothing after it belongs to the previous path.
+			worktreePath = ""
+		case strings.HasPrefix(line, "worktree "):
+			worktreePath = strings.TrimPrefix(line, "worktree ")
+		case strings.HasPrefix(line, "branch "):
+			branch := strings.TrimPrefix(strings.TrimPrefix(line, "branch "), "refs/heads/")
+			if branch != "" && worktreePath != "" {
+				holds[branch] = worktreePath
+			}
+		}
+	}
+	return holds
+}

--- a/session/git/branch_holds_test.go
+++ b/session/git/branch_holds_test.go
@@ -1,0 +1,200 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// archivedHoldRepo builds the exact shape #2091 rots on: a repo whose branches
+// `foo` and `foo-2` are checked out by worktrees that have been MOVED out of
+// their original location — what teardownArchive does when a session is archived
+// (#2013 relocates the worktree and repairs its registration rather than
+// removing it, so the archived session keeps its branch checked out).
+//
+// It returns the repo root and the archive directory holding the relocated
+// worktrees.
+func archivedHoldRepo(t *testing.T, heldBranches ...string) (repoRoot, archiveDir string) {
+	t.Helper()
+	sandboxHome(t)
+	repoRoot = createGitRepo(t)
+	runGitInPlaceTest(t, repoRoot, "commit", "--allow-empty", "-m", "init")
+
+	archiveDir = filepath.Join(filepath.Dir(repoRoot), "archived")
+	require.NoError(t, os.MkdirAll(archiveDir, 0755))
+
+	for _, branch := range heldBranches {
+		live := filepath.Join(filepath.Dir(repoRoot), "live-"+branch)
+		runGitInPlaceTest(t, repoRoot, "worktree", "add", "-b", branch, live)
+		// The archive move: relocate the directory, then repair the two-way
+		// registration. The name mirrors the real archive layout, spaces and all.
+		dest := filepath.Join(archiveDir, branch+" (archived)")
+		runGitInPlaceTest(t, repoRoot, "worktree", "move", live, dest)
+	}
+	return repoRoot, archiveDir
+}
+
+// firstFreeSuffix walks the `<base>`, `<base>-2`, `<base>-3`, … ladder the
+// session-title resolver walks, skipping every candidate whose branch a
+// registered worktree already holds. It models the daemon's
+// nextAvailableTitleLocked walk over the authoritative answer this file provides.
+func firstFreeSuffix(t *testing.T, repoRoot, base string) string {
+	t.Helper()
+	held, err := BranchesHeldByWorktrees(repoRoot)
+	require.NoError(t, err)
+	for i := 1; i <= 10; i++ {
+		candidate := base
+		if i > 1 {
+			candidate = base + "-" + strconv.Itoa(i)
+		}
+		if _, taken := held[candidate]; !taken {
+			return candidate
+		}
+	}
+	t.Fatalf("no free suffix for %q within 10 candidates", base)
+	return ""
+}
+
+// TestBranchesHeldByWorktrees_ReportsArchivedHolds is the #2091 root-cause
+// observation: `git branch` alone cannot answer "is this name usable" — every
+// held branch is also just a branch — but `git worktree list --porcelain` names
+// the worktree holding each one, including worktrees that have been moved into
+// the archive.
+func TestBranchesHeldByWorktrees_ReportsArchivedHolds(t *testing.T) {
+	repoRoot, archiveDir := archivedHoldRepo(t, "foo", "foo-2")
+
+	held, err := BranchesHeldByWorktrees(repoRoot)
+	require.NoError(t, err)
+
+	require.Contains(t, held, "foo")
+	require.Contains(t, held, "foo-2")
+	assert.Equal(t, filepath.Join(archiveDir, "foo (archived)"), held["foo"])
+	assert.Equal(t, filepath.Join(archiveDir, "foo-2 (archived)"), held["foo-2"])
+	// The next rung of the ladder is free, and nothing invented a hold for it.
+	assert.NotContains(t, held, "foo-3")
+}
+
+// TestBranchesHeldByWorktrees_WalkSkipsArchivedSuffixes is the regression lock
+// for #2091. A recurring task derives `<name>[-N]` afresh on every run; once its
+// archived predecessors hold `foo` and `foo-2`, the walk must land on `foo-3`
+// and that name must actually be usable. Before the fix the resolver consulted
+// only session records, handed back a name an archived worktree still held, and
+// `git worktree add` failed hard — the same failure asserted below for the held
+// rungs.
+func TestBranchesHeldByWorktrees_WalkSkipsArchivedSuffixes(t *testing.T) {
+	repoRoot, archiveDir := archivedHoldRepo(t, "foo", "foo-2")
+
+	// A held rung is genuinely unusable — this is the failure the daily task hit
+	// every run, and the reason the walk cannot stop at a name `git branch`
+	// alone would call taken-but-reusable.
+	//
+	// The assertion is on the SUBSTANCE, not on git's wording: git says "already
+	// used by worktree at <path>" on some versions and "'<branch>' is already
+	// checked out at <path>" on others. What every version does is refuse, and
+	// name the worktree holding the branch — which is the fact the resolver
+	// depends on.
+	for _, held := range []string{"foo", "foo-2"} {
+		out, err := runGitAllowFail(t, repoRoot, "worktree", "add",
+			filepath.Join(t.TempDir(), "collide-"+held), held)
+		require.Error(t, err, "expected %q to be unusable while an archived worktree holds it", held)
+		assert.Contains(t, out, filepath.Join(archiveDir, held+" (archived)"),
+			"expected the refusal to name the archived worktree holding %q, got: %s", held, out)
+	}
+
+	assert.Equal(t, "foo-3", firstFreeSuffix(t, repoRoot, "foo"))
+
+	// The resolved name is not merely unheld on paper: the worktree it exists to
+	// create actually gets created.
+	dest := filepath.Join(t.TempDir(), "run")
+	runGitInPlaceTest(t, repoRoot, "worktree", "add", "-b", "foo-3", dest)
+	assert.DirExists(t, dest)
+}
+
+// TestBranchesHeldByWorktrees_NoCollisionKeepsBareName guards the other
+// direction: adding the worktree-hold check must not push an uncontested name
+// off its bare form. A repo with no session worktrees holds only its own
+// checked-out branch.
+func TestBranchesHeldByWorktrees_NoCollisionKeepsBareName(t *testing.T) {
+	repoRoot, _ := archivedHoldRepo(t)
+
+	held, err := BranchesHeldByWorktrees(repoRoot)
+	require.NoError(t, err)
+	assert.NotContains(t, held, "foo")
+
+	assert.Equal(t, "foo", firstFreeSuffix(t, repoRoot, "foo"))
+}
+
+// TestBranchesHeldByWorktrees_UnheldExistingBranchStaysFree keeps the check
+// narrow. AF deliberately REUSES an existing branch when one matches the derived
+// name (setupFromExistingBranch), so a branch that merely exists must not read as
+// taken — only a branch some worktree has CHECKED OUT is unusable.
+func TestBranchesHeldByWorktrees_UnheldExistingBranchStaysFree(t *testing.T) {
+	repoRoot, _ := archivedHoldRepo(t)
+	runGitInPlaceTest(t, repoRoot, "branch", "foo")
+
+	held, err := BranchesHeldByWorktrees(repoRoot)
+	require.NoError(t, err)
+	assert.NotContains(t, held, "foo", "an existing but unchecked-out branch is reusable, not held")
+	assert.Equal(t, "foo", firstFreeSuffix(t, repoRoot, "foo"))
+}
+
+// TestBranchesHeldByWorktrees_NonRepoErrors pins the answer AF must not
+// fabricate: a repo it cannot ask returns an error, never an empty "nothing is
+// held" map that would read as a confident all-clear.
+func TestBranchesHeldByWorktrees_NonRepoErrors(t *testing.T) {
+	held, err := BranchesHeldByWorktrees(t.TempDir())
+	require.Error(t, err)
+	assert.Nil(t, held)
+
+	held, err = BranchesHeldByWorktrees("")
+	require.Error(t, err)
+	assert.Nil(t, held)
+}
+
+func TestParseWorktreeBranchHolds(t *testing.T) {
+	// A detached worktree contributes no hold, a bare main worktree has neither
+	// HEAD nor branch, and a path with spaces (every archived worktree has one)
+	// survives intact.
+	porcelain := strings.Join([]string{
+		"worktree /repos/main",
+		"HEAD 1111111111111111111111111111111111111111",
+		"branch refs/heads/master",
+		"",
+		"worktree /home/u/.agent-factory/archived/abc/Simplify Abstractions-2 (archived)",
+		"HEAD 2222222222222222222222222222222222222222",
+		"branch refs/heads/siyer/simplify-abstractions-2",
+		"",
+		"worktree /repos/detached",
+		"HEAD 3333333333333333333333333333333333333333",
+		"detached",
+		"",
+	}, "\n")
+
+	held := parseWorktreeBranchHolds(porcelain)
+
+	assert.Equal(t, map[string]string{
+		"master": "/repos/main",
+		"siyer/simplify-abstractions-2": "/home/u/.agent-factory/archived/abc/" +
+			"Simplify Abstractions-2 (archived)",
+	}, held)
+}
+
+// runGitAllowFail runs git and returns its combined output plus the error,
+// instead of failing the test — for the assertions that a git command MUST fail.
+func runGitAllowFail(t *testing.T, dir string, args ...string) (string, error) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}


### PR DESCRIPTION
Fixes #2091.

## The rot

A scheduled task that creates a session dies permanently once its derived branch
name is held by an archived worktree. The daily **Simplify Abstractions** and
**TUI Playtest** tasks failed every single run:

```
failed to create worktree from branch siyer/simplify-abstractions-2:
fatal: 'siyer/simplify-abstractions-2' is already used by worktree at
'/home/siyer/.agent-factory/archived/0f8fc14cb4d0/Simplify Abstractions-2 (archived)'
```

The title walk — `nextAvailableTitleLocked`, where every `TitleBase` create lands,
which is the path `taskrun` uses — validated each `<name>[-N]` candidate against
session records, reserved titles, and tmux. **Nothing asked git.**

Archiving RELOCATES a worktree and repairs its registration rather than removing
it (#2013), so an archived session keeps its branch checked out — under a path no
session record points at, once its row has been renamed out of the way. The walk
happily handed back a name an archived worktree still held, `git worktree add`
refused it, and the task's own archived predecessors filled its namespace one
suffix at a time. There is no state it recovers from on its own.

## The fix — ask the authority

`git worktree list --porcelain` names the worktree holding each checked-out
branch, archived ones included. The walk now consults it **once**, up front, and
steps past every rung whose branch is held instead of discovering the checkout
collision at `add` time.

New in `session/git`: `BranchesHeldByWorktrees(repoRoot)` → `branch → holding
worktree path`. A git query, not a scan of `archived/` — archived worktrees are
still git-registered, and git is the only component that knows about a worktree
AF has lost the record for.

Two properties worth naming, both locked by tests:

- **A branch that merely EXISTS stays free.** AF reuses a matching branch on
  purpose (`setupFromExistingBranch`), so `git branch` cannot tell "reusable"
  from "unusable" — every held branch is also just a branch. Only a branch some
  worktree has CHECKED OUT is unusable, and that is exactly what this reads.
- **A probe that cannot run returns `nil`, not an empty map.** "Could not ask"
  and "nothing is held" are different answers. `nil` restores the exact pre-fix
  behavior (the create proceeds; a genuinely held name fails loudly at `worktree
  add` and changes nothing), which is the right failure for an unanswerable
  question. Treating an unreadable repo as "everything is held" would walk a
  recurring task's name to an ever-growing suffix on the strength of a probe that
  never answered — the fabricated-negative shape this repo keeps paying for.

The probe is bounded (10s + `WaitDelay`): it runs under the manager lock on the
create path, so an unbounded read against a stalled filesystem would wedge every
RPC behind that lock, not merely slow one create down.

## Fail-first

At the production call site, in-container, **before** the fix:

```
--- FAIL: TestNextAvailableTitle_SkipsBranchHeldByArchivedWorktree (0.04s)
    create_branch_hold_test.go:56:
        	Error:      	Not equal:
        	            	expected: "sweep-3"
        	            	actual  : "sweep"
        	Messages:   	the walk must skip every suffix an archived worktree still holds
    create_branch_hold_test.go:64:
        	Error:      	Received unexpected error: exit status 255
        	Messages:   	resolved title "sweep" must be usable: Preparing worktree (new branch 'dev/sweep')
        	            	fatal: a branch named 'dev/sweep' already exists
```

That is #2091 reproduced end-to-end: the walk grants `sweep`, whose branch an
archived worktree holds, and the worktree the create exists to build cannot be
built. After the fix it resolves `sweep-3` and the `worktree add` succeeds.

The seeded worktrees deliberately carry **no session records** — that is the
field shape (#2091 shows archived worktrees whose rows had been renamed out from
under them), and it is the case only git can answer.

## Tests

`daemon/create_branch_hold_test.go` (walk at the production call site) and
`session/git/branch_holds_test.go` (the query itself):

- suffixes held by relocated/archived worktrees resolve to the next FREE rung,
  and that rung actually `git worktree add`s
- an uncontested name keeps its bare form (no regression)
- an existing-but-unchecked-out branch is **not** a hold (the reuse path stays
  intact)
- an unreadable repo errors with a nil map rather than a confident all-clear
- porcelain parsing: detached worktrees contribute nothing, and paths with spaces
  survive — every archived worktree path has one, so a whitespace-splitting parse
  would truncate exactly the paths this exists to report

One test assertion was rewritten after the container run: git says `already used
by worktree at <path>` on some versions and `'<branch>' is already checked out at
<path>` on others. The assertion now pins the substance both versions share — git
refuses, and names the worktree holding the branch.

## Adjacent callers — audited, excluded with reasons in-code

- **`uniqueArchivedTitleLocked`** renames an EXISTING archived session, which
  keeps the branch it already has. The new title is a label, not a branch to be
  created; "is this branch checked out somewhere" is not a question about it.
- **The explicit-title path** has the same collision and no fix of this shape.
  A walk can route around a held branch; a title the caller named by hand cannot,
  and the archived rename that frees the *title* does not free the *branch*.
  Gating it would only move a guaranteed failure earlier.

  Probing that path turned up a real, separate defect: **reuse-archived-name
  renames the archived session out of the way and then fails at `worktree add`
  anyway** — and the existing test misses it only because `seedArchivedSession`
  seeds `af/<slug>` while `branchForTitle` yields `dev/<title>`, so the fixture
  never collides the way production does. Filed as **#2127** with the probe
  output and three options; fixing it means releasing the branch on archive,
  which changes what happens to a user's branches and is not a call to make
  inside a resolver PR.

## On the issue's option 2

Option 2 (a recurring task reusing a stable target session, or a date-suffixed
run-unique name) is **not** implemented here. Fix 1 resolves the rot on its own:
the walk now always terminates on a usable name, so a task can create-and-archive
indefinitely. Worth revisiting as a task-ergonomics change — a task accumulating
one archived session per day is working as designed but not obviously *desirable*
— but that is a product decision, not part of this bug.

## Verification

- `go build ./...`, `gofmt -l .` (clean), `golangci-lint run --fast` (0),
  `deadcode -test ./...` (empty), `scripts/lint-file-length.sh` (pass)
- `go test ./session/git/...` on host: ok
- Container (`make test-container`): full suite green, including the `daemon`
  package (157s) that owns the changed walk. No host `go test ./daemon/...`.

Co-Authored-By: Captain Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
