### PR TITLE
fix(daemon): refuse reuse-archived-name early when the derived branch is held (#2127)

### DIFF
--- a/daemon/create_reuse_archived_branch_hold_test.go
+++ b/daemon/create_reuse_archived_branch_hold_test.go
@@ -1,0 +1,199 @@
+package daemon
+
+import (
+	"fmt"
+	"os/exec"
+	"testing"
+
+	sessiongit "github.com/sachiniyer/agent-factory/session/git"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReserveCreate_HeldArchivedBranchRefusesBeforeRename is the #2127
+// regression lock.
+//
+// The rot: `af sessions create --name foo` over an archived "foo" renamed the
+// archived session to "foo (archived)" to free the TITLE, then failed anyway at
+// `git worktree add` — because archiving relocates a worktree rather than
+// removing it (#2013), so the archived session still had <prefix>foo checked
+// out, and the new session derives exactly that branch. The user was left with
+// a create that failed AND an archived session renamed out of the way for it:
+// the state reserveCreate's own admission comment promises never to produce ("a
+// refusal never leaves an archived session renamed for a create that then did
+// not happen").
+//
+// This seeds the shape archiving actually produces — branch still held — and
+// pins the honest failure: refuse up front, rename nothing, and say what is
+// blocking and how to clear it.
+func TestReserveCreate_HeldArchivedBranchRefusesBeforeRename(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	archived, id := seedArchivedSession(t, manager, repoID, repoPath, "foo", "foo")
+	branch := manager.branchForTitle("foo")
+
+	// The precondition the old fixture never established: git positively reports
+	// the archived worktree as holding the branch this create would derive.
+	held, herr := sessiongit.BranchesHeldByWorktrees(repoPath)
+	require.NoError(t, herr)
+	require.Contains(t, held, branch,
+		"the archived worktree must still hold the derived branch; without that this test proves nothing")
+
+	_, _, release, renamed, err := manager.reserveCreate(CreateSessionRequest{RepoPath: repoPath, Title: "foo", Program: "claude"})
+	if release != nil {
+		release()
+	}
+
+	require.Error(t, err, "the create must be refused: freeing the name would not free the branch it needs")
+	assert.Nil(t, renamed, "no archived rename may happen for a create that cannot succeed")
+
+	// Actionable: name the blocking branch, where it is held, and a way out.
+	msg := err.Error()
+	assert.Contains(t, msg, branch, "the error must name the branch that blocks the create")
+	assert.Contains(t, msg, "af sessions kill", "the error must offer a way to release the branch")
+	assert.Contains(t, msg, "different name", "the error must offer the non-destructive alternative")
+
+	// The invariant, asserted on every surface that could carry the rename:
+	// in-memory title, manager key, on-disk record, and the archive directory.
+	assert.Equal(t, "foo", archived.Title, "the archived session must keep its name after a refusal")
+	manager.mu.Lock()
+	_, origKeyed := manager.instances[daemonInstanceKey(repoID, "foo")]
+	_, renamedKeyed := manager.instances[daemonInstanceKey(repoID, "foo (archived)")]
+	manager.mu.Unlock()
+	assert.True(t, origKeyed, "the archived row must stay keyed under its original name")
+	assert.False(t, renamedKeyed, "no row may be keyed under the disambiguated name")
+
+	rec := recordFor(t, repoID, "foo")
+	require.NotNil(t, rec, "the archived record must survive the refusal under its original name")
+	assert.Equal(t, id, rec.ID, "the archived session must be untouched, stable id and all")
+	assert.Nil(t, recordFor(t, repoID, "foo (archived)"), "no renamed record may be persisted for a refused create")
+
+	origDir, derr := archivedWorktreePath(repoID, "foo")
+	require.NoError(t, derr)
+	newDir, derr := archivedWorktreePath(repoID, "foo (archived)")
+	require.NoError(t, derr)
+	assert.True(t, exists(origDir), "the archived worktree must stay at its original path")
+	assert.False(t, exists(newDir), "no relocation may have happened")
+
+	// And the archived session is still restorable — the refusal cost the user
+	// nothing, which is the difference between this and the pre-fix behavior.
+	_, rerr := manager.RestoreArchived(RestoreArchivedRequest{Title: "foo", RepoID: repoID})
+	require.NoError(t, rerr, "the untouched archived session must still restore under its own name")
+}
+
+// TestReserveCreate_HeldBranchWithoutArchivedCollisionIsUnguarded keeps the
+// guard as narrow as the invariant it protects. A held branch with NO archived
+// session to rename triggers no rename, so there is nothing to leave orphaned —
+// and refusing there would turn the guard into a general branch-availability
+// gate over every explicit title, refusing creates this issue is not about.
+// Such a create proceeds and fails at `git worktree add` exactly as before.
+func TestReserveCreate_HeldBranchWithoutArchivedCollisionIsUnguarded(t *testing.T) {
+	manager, _, repoPath := newStatusTestManager(t)
+
+	// A worktree holding <prefix>orphan with no session record pointing at it —
+	// #2091's field shape, and no archived row named "orphan" anywhere.
+	holdBranchInArchivedWorktree(t, repoPath, manager.branchForTitle("orphan"), "orphan")
+
+	_, title, release, renamed, err := manager.reserveCreate(CreateSessionRequest{RepoPath: repoPath, Title: "orphan", Program: "claude"})
+	require.NoError(t, err, "with no archived collision there is no rename to protect; the guard must stay out of the way")
+	defer release()
+
+	assert.Equal(t, "orphan", title)
+	assert.Nil(t, renamed, "nothing was renamed")
+}
+
+// TestReserveCreate_UnprobableBranchHoldsStillReuse is the three-valued case.
+//
+// git.BranchesHeldByWorktrees returns nil holds when it could not ask (its
+// documented contract), and "I could not ask" is not "the branch is held". A
+// guard that conflated them would refuse a legitimate reuse on the strength of
+// an answer git never gave — the fabricated-negative failure this repo keeps
+// paying for. On an unanswerable probe the create proceeds exactly as it did
+// pre-guard: if the branch really is held, `git worktree add` refuses it loudly
+// and destroys nothing.
+//
+// Forced through the branchesHeldByWorktrees seam rather than by breaking the
+// repo, which reserveCreate needs readable to reach this code at all.
+func TestReserveCreate_UnprobableBranchHoldsStillReuse(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	// Branch genuinely HELD: the guard would refuse this if it could probe, so a
+	// completed reuse here is proof the failed probe alone let it through.
+	seedArchivedSession(t, manager, repoID, repoPath, "foo", "foo")
+	held, herr := sessiongit.BranchesHeldByWorktrees(repoPath)
+	require.NoError(t, herr)
+	require.Contains(t, held, manager.branchForTitle("foo"))
+
+	probed := false
+	prev := branchesHeldByWorktrees
+	branchesHeldByWorktrees = func(string) (map[string]string, error) {
+		probed = true
+		return nil, fmt.Errorf("forced branch-hold probe failure (#2127)")
+	}
+	t.Cleanup(func() { branchesHeldByWorktrees = prev })
+
+	_, title, release, renamed, err := manager.reserveCreate(CreateSessionRequest{RepoPath: repoPath, Title: "foo", Program: "claude"})
+	if release != nil {
+		defer release()
+	}
+
+	require.True(t, probed, "the seam never fired; this test did not exercise the failed-probe path")
+	require.NoError(t, err, "an unanswerable probe must not refuse the create — nil holds is not 'held'")
+	assert.Equal(t, "foo", title)
+	require.NotNil(t, renamed, "the reuse proceeds as it did pre-guard")
+	assert.Equal(t, "foo (archived)", renamed.Title)
+}
+
+// TestReserveCreate_InPlaceCreateIgnoresBranchHold: `--here` attaches to the
+// repo's own working tree at ITS current branch (NewGitWorktreeInPlace) and
+// never derives <prefix><title>, so a hold on that branch cannot block it. The
+// guard must not refuse a create over a branch it will not use.
+func TestReserveCreate_InPlaceCreateIgnoresBranchHold(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	seedArchivedSession(t, manager, repoID, repoPath, "foo", "foo")
+
+	_, title, release, renamed, err := manager.reserveCreate(CreateSessionRequest{
+		RepoPath: repoPath, Title: "foo", Program: "claude", InPlace: true,
+	})
+	require.NoError(t, err, "an --here create derives no branch from the title, so a hold on that branch is not its problem")
+	defer release()
+
+	assert.Equal(t, "foo", title)
+	require.NotNil(t, renamed, "the archived name is still freed for an --here create")
+	assert.Equal(t, "foo (archived)", renamed.Title)
+	assert.NotNil(t, recordFor(t, repoID, "foo (archived)"))
+}
+
+// TestReserveCreate_ArchivedBranchHoldSurvivesTheRename is the fact the guard
+// exists because of, pinned directly rather than inferred: renaming an archived
+// session does NOT release its branch. If this ever stops being true — option 1
+// or 2 on #2127 — the guard becomes dead weight and this test says so by
+// failing, rather than the guard quietly refusing creates that would now work.
+func TestReserveCreate_ArchivedBranchHoldSurvivesTheRename(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	seedArchivedSessionBranchFreed(t, manager, repoID, repoPath, "foo", "foo")
+	branch := manager.branchForTitle("foo")
+
+	// Re-attach the branch so the rename runs with it held, the way archiving
+	// leaves it. (Seeded freed first only so the guard lets the rename happen —
+	// this test is about what the rename does to the hold, not about the guard.)
+	archivedPath, err := archivedWorktreePath(repoID, "foo")
+	require.NoError(t, err)
+	out, err := exec.Command("git", "-C", archivedPath, "checkout", branch).CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	manager.mu.Lock()
+	diskData, lerr := loadRepoInstanceData(repoID)
+	require.NoError(t, lerr)
+	renamed, err := manager.renameArchivedForReuseLocked(repoID, repoPath, "foo", "claude", &diskData)
+	manager.mu.Unlock()
+	require.NoError(t, err)
+	require.NotNil(t, renamed, "the rename must have run for this test to say anything")
+
+	held, herr := sessiongit.BranchesHeldByWorktrees(repoPath)
+	require.NoError(t, herr)
+	holder, stillHeld := held[branch]
+	assert.True(t, stillHeld,
+		"renaming an archived session frees its TITLE but not its BRANCH — the premise of #2127's guard")
+	assert.Contains(t, holder, "(archived)",
+		"the branch follows the relocated archived worktree to its new path")
+}

--- a/daemon/create_reuse_archived_test.go
+++ b/daemon/create_reuse_archived_test.go
@@ -15,16 +15,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// seedArchivedSession builds a real linked worktree (dir/branch derived from the
-// git-safe slug, so a title carrying spaces/parens still gets a valid branch),
+// seedArchivedSession builds a real linked worktree (dir derived from the
+// git-safe slug, so a title carrying spaces/parens still gets a valid path),
 // registers a started instance for it in the manager and on disk, then archives
 // it. The instance ends inert (LiveArchived) with its worktree relocated to the
 // title-keyed archive dir — the precondition for the reuse-archived-name tests.
 // Returns the archived instance and the stable id it was minted with.
+//
+// The branch is m.branchForTitle(title) — the SAME derivation a real create
+// applies to the same title — not a fixture-local invention (#2127). Seeding
+// "af/"+slug while branchForTitle yields "<prefix><title>" meant the fixture's
+// branch could never collide with the branch a create derives, so these tests
+// passed on a shape production never produces: they exercised freeing the TITLE
+// while silently skipping the BRANCH hold that is the whole difficulty here.
 func seedArchivedSession(t *testing.T, m *Manager, repoID, repoPath, title, slug string) (*session.Instance, string) {
 	t.Helper()
 	wtPath := filepath.Join(filepath.Dir(repoPath), "wt-"+slug)
-	branch := "af/" + slug
+	branch := m.branchForTitle(title)
 	out, err := exec.Command("git", "-C", repoPath, "worktree", "add", "-b", branch, wtPath).CombinedOutput()
 	require.NoError(t, err, string(out))
 	require.NoError(t, os.WriteFile(filepath.Join(wtPath, "dirty.txt"), []byte("uncommitted-"+slug), 0644))
@@ -36,13 +43,17 @@ func seedArchivedSession(t *testing.T, m *Manager, repoID, repoPath, title, slug
 	require.NoError(t, err)
 	inst.SetBackend(&recoverFakeBackend{FakeBackend: session.NewFakeBackend()})
 	inst.SetGitWorktreeForTest(gw)
+	// Provision sets i.Branch on a real create; SetGitWorktreeForTest does not, and
+	// InstanceData.Branch reads i.Branch — so without this every "the branch is
+	// preserved" assertion below compared "" to "" and asserted nothing.
+	inst.Branch = branch
 	inst.SetStartedForTest(true)
 	inst.SetStatusForTest(session.Ready)
 	id := inst.ID
 
 	// appendInstanceData (not seedDiskInstance) so multiple seeded sessions
 	// accumulate on disk instead of clobbering one another.
-	require.NoError(t, appendInstanceData(repoID, session.InstanceData{ID: id, Title: title, Path: repoPath, Status: session.Ready}))
+	require.NoError(t, appendInstanceData(repoID, session.InstanceData{ID: id, Title: title, Path: repoPath, Branch: branch, Status: session.Ready}))
 	m.mu.Lock()
 	m.instances[daemonInstanceKey(repoID, title)] = inst
 	m.mu.Unlock()
@@ -53,14 +64,57 @@ func seedArchivedSession(t *testing.T, m *Manager, repoID, repoPath, title, slug
 	return inst, id
 }
 
+// seedArchivedSessionBranchFreed seeds an archived session exactly as
+// seedArchivedSession does, then detaches the archived worktree's HEAD so its
+// branch is no longer checked out anywhere.
+//
+// This is the shape in which reuse-archived-name can actually COMPLETE, and it
+// is what the tests below that exercise the rename machinery — the suffix walk,
+// the Loading-ghost overwrite, the #2106 double-failure recovery — need in order
+// to reach that machinery at all: with the branch still held, #2127's guard
+// refuses before the rename runs, which is the whole point of the guard and not
+// what those tests are about.
+//
+// Detaching is a constructed shape, not what archiving produces (#2013 leaves
+// the branch checked out), and saying so is the honest framing: it is reachable
+// — a user can check something else out inside an archived worktree — and it is
+// what option 1 on #2127 would make the DEFAULT if archiving is ever changed to
+// release the branch. The worktree itself is untouched, so relocation and
+// restore behave identically.
+func seedArchivedSessionBranchFreed(t *testing.T, m *Manager, repoID, repoPath, title, slug string) (*session.Instance, string) {
+	t.Helper()
+	inst, id := seedArchivedSession(t, m, repoID, repoPath, title, slug)
+
+	archivedPath, err := archivedWorktreePath(repoID, title)
+	require.NoError(t, err)
+	out, err := exec.Command("git", "-C", archivedPath, "checkout", "--detach").CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	// Not merely detached on paper: git must no longer report the branch as held,
+	// or the tests relying on this would silently be testing the guarded shape.
+	held, err := sessiongit.BranchesHeldByWorktrees(repoPath)
+	require.NoError(t, err)
+	require.NotContains(t, held, m.branchForTitle(title),
+		"the seeded archived worktree must have released its branch")
+	return inst, id
+}
+
 // TestReserveCreate_ReusesArchivedName is the headline case (feat: reuse archived
 // name): archive "foo", then create a NEW "foo" — the create succeeds and the old
 // archived session is renamed to "foo (archived)", keyed and persisted under the
 // new name, its worktree relocated to the new title-keyed archive dir, and still
 // fully restorable (same worktree contents, branch, and stable id).
+//
+// Seeded with the branch FREED, which is now load-bearing rather than incidental
+// (#2127). The reuse can only complete when the archived session is not still
+// holding the branch the new session derives; with it held, the guard refuses
+// (TestReserveCreate_HeldArchivedBranchRefusesBeforeRename below). The old
+// fixture hid that distinction entirely by seeding an "af/"+slug branch that
+// branchForTitle never produces, so this test used to pass while asserting
+// nothing about the branch at all.
 func TestReserveCreate_ReusesArchivedName(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
-	archived, id := seedArchivedSession(t, manager, repoID, repoPath, "foo", "foo")
+	archived, id := seedArchivedSessionBranchFreed(t, manager, repoID, repoPath, "foo", "foo")
 	branch := archived.GetBranch()
 
 	_, title, release, renamed, err := manager.reserveCreate(CreateSessionRequest{RepoPath: repoPath, Title: "foo", Program: "claude"})
@@ -70,6 +124,23 @@ func TestReserveCreate_ReusesArchivedName(t *testing.T) {
 	assert.Equal(t, "foo", title, "the new session takes the freed title verbatim")
 	require.NotNil(t, renamed, "the collision must have renamed the archived session")
 	assert.Equal(t, "foo (archived)", renamed.Title)
+
+	// The gate this test was missing (#2127): a granted title is worth nothing if
+	// the create it authorizes cannot build its worktree. Freeing the NAME while
+	// the BRANCH stays checked out is exactly the failure the guard now refuses
+	// up front, and only actually running the add can tell the two apart.
+	//
+	// `worktree add <path> <branch>` with no -b is the form AF itself runs when
+	// the derived branch already exists (setupFromExistingBranch), and it is the
+	// command that reports "already used by worktree at …" on a held branch.
+	dest := filepath.Join(t.TempDir(), "new-session")
+	out, addErr := exec.Command("git", "-C", repoPath, "worktree", "add", dest,
+		manager.branchForTitle(title)).CombinedOutput()
+	require.NoError(t, addErr, "the granted title %q must be usable by the create it was granted for: %s", title, string(out))
+	// Vacate it again so the restore assertions below see the archive layout the
+	// rest of this test is about, not this probe's leftovers.
+	out, err = exec.Command("git", "-C", repoPath, "worktree", "remove", "--force", dest).CombinedOutput()
+	require.NoError(t, err, string(out))
 
 	// The archived instance now carries the disambiguated name, re-keyed in the map.
 	assert.Equal(t, "foo (archived)", archived.Title)
@@ -159,7 +230,7 @@ func countRecordsWithTitle(t *testing.T, repoID, title string) int {
 // the ghost was overwritten rather than the archived record dropped.
 func TestReserveCreate_ReusesArchivedName_OverwritesLoadingGhost(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
-	archived, id := seedArchivedSession(t, manager, repoID, repoPath, "foo", "foo")
+	archived, id := seedArchivedSessionBranchFreed(t, manager, repoID, repoPath, "foo", "foo")
 	branch := archived.GetBranch()
 
 	// A legacy Loading ghost squatting on the exact title the rename will pick.
@@ -192,8 +263,8 @@ func TestReserveCreate_ReusesArchivedName_OverwritesLoadingGhost(t *testing.T) {
 // old archived "foo" to the next free slot, "foo (archived 2)".
 func TestReserveCreate_ReusesArchivedName_SuffixCollision(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
-	seedArchivedSession(t, manager, repoID, repoPath, "foo", "foo")
-	seedArchivedSession(t, manager, repoID, repoPath, "foo (archived)", "foo-archived")
+	seedArchivedSessionBranchFreed(t, manager, repoID, repoPath, "foo", "foo")
+	seedArchivedSessionBranchFreed(t, manager, repoID, repoPath, "foo (archived)", "foo-archived")
 
 	_, title, release, renamed, err := manager.reserveCreate(CreateSessionRequest{RepoPath: repoPath, Title: "foo", Program: "claude"})
 	require.NoError(t, err)

--- a/daemon/deadlock_2106_test.go
+++ b/daemon/deadlock_2106_test.go
@@ -45,7 +45,11 @@ import (
 // panics.
 func TestReserveCreate_ReusesArchivedName_DoubleFailureNoSelfDeadlock(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
-	archived, _ := seedArchivedSession(t, manager, repoID, repoPath, "foo", "foo")
+	// Branch freed: this repro must REACH the rename to force its double failure,
+	// and #2127's guard refuses before the rename whenever the archived session
+	// still holds the branch the create derives. Guarding is not what this test
+	// pins — the lock ordering inside the recovery branch is.
+	archived, _ := seedArchivedSessionBranchFreed(t, manager, repoID, repoPath, "foo", "foo")
 
 	// Where the archived worktree lives before the rename; the rollback move
 	// targets exactly this path.

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -217,13 +217,15 @@ func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, 
 		// (feat: reuse archived name). A LIVE collision is left untouched, so
 		// validateTitleAvailableLocked below still rejects it exactly as before.
 		//
-		// This path deliberately does NOT get #2091's worktree-branch check. The
-		// walk above can route around a held branch by taking the next suffix; an
-		// explicitly requested title has nowhere to go, and the rename that frees
-		// the title does not free the BRANCH the archived worktree still holds —
-		// so gating here would only move a guaranteed failure earlier, not fix it.
-		// Making reuse-archived-name actually work means releasing the branch too;
-		// tracked in #2127.
+		// Ahead of that rename, refuse when the branch this create would derive is
+		// already checked out somewhere (#2127) — freeing the title does not free
+		// the branch, and moving that guaranteed failure EARLIER is the whole point:
+		// discovering it at `git worktree add` leaves the archived session renamed
+		// for a create that then did not happen, which is exactly the state the
+		// admission comment above promises this function never produces.
+		if err := m.refuseHeldBranchReuseLocked(repo.ID, repo.Root, title, usesHook, req.InPlace); err != nil {
+			return nil, "", nil, nil, err
+		}
 		renamedArchived, err = m.renameArchivedForReuseLocked(repo.ID, repo.Root, title, req.Program, &diskData)
 		if err != nil {
 			return nil, "", nil, nil, err
@@ -270,6 +272,63 @@ func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, 
 	}
 
 	return repo, title, release, renamedArchived, nil
+}
+
+// refuseHeldBranchReuseLocked refuses an explicit-title create BEFORE the
+// archived-name-reuse rename touches anything, when the branch the new session
+// would derive is already checked out by a registered worktree (#2127). Runs
+// under m.mu.
+//
+// renameArchivedForReuseLocked frees a TITLE. It does not free a BRANCH: per
+// #2013 archiving relocates a worktree and repairs its registration rather than
+// removing it, so the archived session keeps <prefix><title> checked out, and
+// the new session derives that same branch. `git worktree add` then refuses it
+// and the create fails — with the archived session already renamed out of the
+// way for a create that never happened, the one state reserveCreate's own
+// comment promises a refusal never leaves behind.
+//
+// So ask git first. This does not make reuse-archived-name WORK for a local
+// session — only releasing or relocating the branch can, and that changes what
+// happens to a user's branches, so it is a separate call tracked on #2127. What
+// it does is turn a state-corrupting failure into an honest one that names the
+// blocker and how to clear it.
+//
+// Three deliberate non-firings:
+//
+//   - No archived collision means renameArchivedForReuseLocked will not rename
+//     anything, so there is no invariant to protect. The create proceeds and
+//     fails at `git worktree add` exactly as before. Widening this into a
+//     general "is the branch free" gate over every explicit title would refuse
+//     creates that have nothing to do with this bug.
+//   - Hook and --here creates never derive <prefix><title> at all: a hook
+//     session takes no local worktree (backend_local is the only caller of
+//     NewGitWorktree), and --here attaches to the repo's OWN working tree at ITS
+//     current branch (NewGitWorktreeInPlace). A hold on a branch the create will
+//     not use must not block it.
+//   - A probe that could not RUN yields nil holds, and nil must never refuse.
+//     "I could not ask git" is not "the branch is held"; treating it as one
+//     would block a legitimate reuse on the strength of an answer git never
+//     gave — the fabricated-negative failure this repo keeps paying for. On a
+//     failed probe the create proceeds and, if the branch really is held, fails
+//     loudly at `git worktree add`: precisely the pre-guard behavior, which
+//     destroyed nothing. Only a branch git POSITIVELY reports as held refuses.
+func (m *Manager) refuseHeldBranchReuseLocked(repoID, repoPath, title string, remote, inPlace bool) error {
+	if remote || inPlace {
+		return nil
+	}
+	archived, _ := m.findArchivedOnlyCollisionLocked(repoID, title)
+	if archived == nil {
+		return nil
+	}
+	branch := m.branchForTitle(title)
+	// Indexing a nil map is the nil-probe path: not held, so no refusal.
+	holder, held := m.worktreeHeldBranchesLocked(repoPath, false)[branch]
+	if !held {
+		return nil
+	}
+	return fmt.Errorf("cannot create session %q: the archived session %q still has branch %q checked out at %s, and the new session would derive that same branch. Renaming the archived session aside frees its name but not its branch, so the create would fail at `git worktree add` — permanently delete the archived session to release both (%s), or create this session under a different name",
+		title, archived.Title, branch, config.ShellQuotePath(holder),
+		shellsuggest.Command("af", "sessions", "kill", archived.Title))
 }
 
 // reuseArchivedRenamePersist is the durable title rewrite the archived-name-reuse
@@ -710,6 +769,14 @@ func (m *Manager) titlesCollide(a, b string) bool {
 	return git.TitlesCollide(a, b, m.cfg.BranchPrefix)
 }
 
+// branchesHeldByWorktrees is the git query worktreeHeldBranchesLocked runs. A
+// package var so tests can force the probe to FAIL in isolation — the answer
+// that must NOT block a create (#2127) — without breaking the repo out from
+// under the rest of the create path, which needs it readable to get that far.
+// Mirrors reuseArchivedRenamePersist's precedent. Production points it at the
+// real query and never reassigns it.
+var branchesHeldByWorktrees = git.BranchesHeldByWorktrees
+
 // worktreeHeldBranchesLocked answers "which branches are already checked out by
 // a worktree of this repo" for the title walk (#2091), mapping each to the
 // worktree holding it. Runs under m.mu.
@@ -730,7 +797,7 @@ func (m *Manager) worktreeHeldBranchesLocked(repoPath string, remote bool) map[s
 	if remote {
 		return nil
 	}
-	held, err := git.BranchesHeldByWorktrees(repoPath)
+	held, err := branchesHeldByWorktrees(repoPath)
 	if err != nil {
 		log.WarningLog.Printf("could not list worktree branch holds for %s; resolving the session title without them (a name an archived worktree holds will fail at worktree add instead of being skipped): %v", repoPath, err)
 		return nil


### PR DESCRIPTION
Fixes #2127.

## The defect

`renameArchivedForReuseLocked` frees a session **title** by renaming the archived
session to `"<base> (archived)"`. It does not free the **branch**: per #2013
archiving relocates a worktree and repairs its registration rather than removing
it, so the archived session keeps `<prefix><title>` checked out — and the new
session derives exactly that branch. `git worktree add` refuses it, the create
fails, and the archived session is left renamed for a create that never happened.

That last part is the real damage. It is precisely the state `reserveCreate`'s own
admission comment promises never to produce:

> Running it here, ahead of the archived-name-reuse rename below, means a refusal
> never leaves an archived session renamed for a create that then did not happen.

## Step 1 — the fixture (fail-first)

`seedArchivedSession` seeded the archived session on branch `"af/" + slug`, while
`branchForTitle` under the test config yields `dev/<title>`. The fixture's branch
could never collide with the branch a real create derives, so the reuse tests
passed on a shape production never produces.

Pointing the fixture at `m.branchForTitle(title)` is necessary but **not
sufficient** to fail: `reserveCreate` only reserves a title, and the failure is
downstream at `git worktree add`, which no existing test ran. So the missing gate
went in too — *the granted title must actually be usable by the create it was
granted for*. Reproduced on the real production path against `master`:

```
=== RUN   TestFailFirstProbe2127
    branchForTitle(foo) = "dev/foo"
    reserveCreate returned title="foo" renamedArchived=true
    archived session is now titled "foo (archived)" (was "foo")
    worktree add for the granted title: err=exit status 128
      out=Preparing worktree (checking out 'dev/foo')
      fatal: 'dev/foo' is already checked out at '/tmp/af-1667988221/archived/29ccf68bb5a9/foo (archived)'
        Error:      Received unexpected error: exit status 128
        Messages:   the create the reservation authorized must be able to build its worktree
--- FAIL: TestFailFirstProbe2127 (0.05s)
```

That matches the issue's Observed block exactly, including the archived session
left renamed to `foo (archived)` for a create that then failed. (That probe was a
scratch reproduction and is not in the diff; the shipped regression lock is
`TestReserveCreate_HeldArchivedBranchRefusesBeforeRename`, which fails on `master`
with "An error is expected but got nil".)

A second, quieter fixture defect surfaced on the way: the fixture never set
`inst.Branch`, and `InstanceData.Branch` reads `i.Branch` — so every *"the git
branch must be preserved across the rename"* assertion was comparing `""` to `""`.
Now set, so those assertions mean something.

## Step 2 — the guard (option 3 only)

`refuseHeldBranchReuseLocked` runs in the explicit-title path **before** the
rename. If `git.BranchesHeldByWorktrees` (the #2091/#2128 helper) positively
reports the derived branch as held, the create is refused and nothing is renamed:

```
cannot create session "foo": the archived session "foo" still has branch "dev/foo"
checked out at '/tmp/af-.../archived/ba9553c429b3/foo', and the new session would
derive that same branch. Renaming the archived session aside frees its name but not
its branch, so the create would fail at `git worktree add` — permanently delete the
archived session to release both (af sessions kill foo), or create this session
under a different name
```

The suggested command goes through `shellsuggest.Command` and the path through
`config.ShellQuotePath`, so neither breaks on a title or path with a space (#1978).

**Three deliberate non-firings**, each with a test:

- **No archived collision** → no rename happens, so there is no invariant to
  protect. The create proceeds and fails at `worktree add` as before. Widening
  this into a general branch-availability gate over every explicit title would
  refuse creates this issue is not about.
- **Hook and `--here` creates** → neither derives `<prefix><title>`. A hook session
  takes no local worktree; `--here` attaches to the repo's own working tree at *its*
  current branch (`NewGitWorktreeInPlace`). A hold on a branch the create will not
  use must not block it.
- **An unanswerable probe** → `BranchesHeldByWorktrees` returns nil holds when it
  could not ask, and nil never refuses. "I could not ask git" is not "the branch is
  held"; conflating them would block a legitimate reuse on an answer git never gave.
  On a failed probe the create proceeds exactly as pre-guard and, if the branch
  really is held, fails loudly at `worktree add` — destroying nothing. Only a branch
  git **positively** reports as held refuses.

## Tests

New (`daemon/create_reuse_archived_branch_hold_test.go`):

- `..._HeldArchivedBranchRefusesBeforeRename` — the regression lock. Refuses early;
  the archived session is unrenamed on **every** surface that could carry a rename
  (in-memory title, manager key, on-disk record, archive directory) and still
  restores; the error names the branch and offers both ways out.
- `..._HeldBranchWithoutArchivedCollisionIsUnguarded` — the guard stays narrow.
- `..._UnprobableBranchHoldsStillReuse` — the nil-probe path, over a genuinely held
  branch, so a completed reuse proves the failed probe alone let it through.
- `..._InPlaceCreateIgnoresBranchHold` — `--here` is not blocked.
- `..._ArchivedBranchHoldSurvivesTheRename` — pins the guard's *premise*
  observationally: renaming an archived session does not release its branch. If
  option 1 or 2 ever makes that false, this fails and says the guard is dead weight,
  rather than the guard quietly refusing creates that would now work.

Existing tests that exercise the rename **machinery** (suffix walk, Loading-ghost
overwrite, #2106 double-failure recovery) now seed via
`seedArchivedSessionBranchFreed`, which detaches the archived worktree's HEAD so the
guard lets them reach the machinery they are actually about. That helper documents
itself honestly as a constructed shape — reachable, and what option 1 would make the
default, but not what archiving produces today.

## Scope

This is the **interim guard** only. The durable fix — option 1 (release the branch
on archive) or option 2 (rename the branch aside) — is a design call still pending
@sachiniyer on #2127, since both change what happens to a user's branches. This
guard coexists with whichever is chosen: if the branch stops being held, the guard
stops firing on its own, and `..._ArchivedBranchHoldSurvivesTheRename` fails to say
so out loud.

Reuse-archived-name therefore remains a documented no-op for local sessions whose
branch is held (which per #2013 is the normal case) — but it now fails honestly and
reversibly instead of corrupting state.

## Verification

`gofmt -l .` clean · `golangci-lint run --timeout=3m --fast` clean · `deadcode -test ./...` clean ·
`scripts/lint-file-length.sh` passed · `go build ./...` OK · full suite via
`make test-container` green (all 39 packages, daemon 158s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
