### PR TITLE
fix(ui): surface the watch-task run-now refusal in list mode (#2137)

### DIFF
--- a/ui/task_pane.go
+++ b/ui/task_pane.go
@@ -13,11 +13,17 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	xansi "github.com/charmbracelet/x/ansi"
 )
 
 // programDefaultLabel is the selector option that resolves to an empty Program
 // string (the daemon then falls back to the user's configured default_program).
 const programDefaultLabel = "(use config default)"
+
+// watchRunNowRefusal explains why "run now" is unavailable on a watch task.
+// Both surfaces that accept r (the list and the editor) report it, so it lives
+// in one place rather than drifting between them.
+const watchRunNowRefusal = "watch tasks run on their watch command's output, not on manual trigger"
 
 // taskPlaceholderStyle renders form placeholders faint so an example (the
 // cron "e.g. 0 9 * * 1-5") can never be mistaken for a typed value.
@@ -76,7 +82,14 @@ type TaskPane struct {
 	editProgramIdx     int
 	editError          string // last validation error shown to the user
 	editErrorField     int    // focus stop the error is rendered under (-1 = none)
-	focusIndex         int
+	// listNotice is the list-mode counterpart of editError: edit mode hangs a
+	// validation message under the offending field, but list mode has no
+	// fields, so a refused action (r on a watch task) reported nothing and the
+	// key looked dead (#2137). The notice renders just above the hint row and
+	// clears on the next keypress, so it reads as feedback for one action
+	// rather than a stale error.
+	listNotice string
+	focusIndex int
 	// formScroll is the edit form's line offset when the pane is shorter than
 	// the rendered form (#1098): renderEditMode windows the form so the
 	// focused field stays in view instead of clipping off the top.
@@ -196,6 +209,7 @@ func (s *TaskPane) initForm(tsk *task.Task, defaultPath string) {
 	s.focusIndex = taskFocusName
 	s.editError = ""
 	s.editErrorField = -1
+	s.listNotice = ""
 	s.formScroll = 0
 }
 
@@ -315,6 +329,8 @@ func (s *TaskPane) ScrollUp() {
 	if s.editing || s.creating {
 		return
 	}
+	// Moving the selection retires a notice about the row being left behind.
+	s.listNotice = ""
 	if s.selectedIdx > 0 {
 		s.selectedIdx--
 	}
@@ -325,6 +341,7 @@ func (s *TaskPane) ScrollDown() {
 	if s.editing || s.creating {
 		return
 	}
+	s.listNotice = ""
 	if s.selectedIdx < len(s.tasks)-1 {
 		s.selectedIdx++
 	}
@@ -335,6 +352,11 @@ func (s *TaskPane) HandleKeyPress(msg tea.KeyMsg) bool {
 	if !s.hasFocus {
 		return false
 	}
+	// The notice is feedback for the key that produced it; every later key is a
+	// new action, so drop it up front and let this key's handler set its own.
+	// Clearing here (rather than in handleNormalMode) also means a notice set
+	// inside the editor can't follow the user back out to the list.
+	s.listNotice = ""
 	if s.editing || s.creating {
 		return s.handleEditMode(msg)
 	}
@@ -425,11 +447,14 @@ func (s *TaskPane) runSelectedTask() {
 	}
 	// Watch tasks fire from their watch command's stdout; a manual trigger has
 	// no event line to render the prompt, so the daemon refuses them (RunTask).
-	// Don't queue a doomed run — surface the reason inline (shown in edit mode)
-	// and keep the "run now" affordance out of the hints for watch tasks (#1758).
+	// Don't queue a doomed run — surface the reason on whichever surface the
+	// key came from (edit mode hangs it under the trigger selector, list mode
+	// renders it above the hint row, #2137) and keep the "run now" affordance
+	// out of the hints for watch tasks (#1758).
 	if s.tasks[s.selectedIdx].IsWatch() {
-		s.editError = "watch tasks run on their watch command's output, not on manual trigger"
+		s.editError = watchRunNowRefusal
 		s.editErrorField = taskFocusTrigger
+		s.listNotice = watchRunNowRefusal
 		return
 	}
 	s.pendingTrigger = true
@@ -590,6 +615,33 @@ func (s *TaskPane) renderListMode() string {
 	}
 
 	b.WriteString("\n")
+
+	// A refused action reports directly above the hint row, styled like the
+	// editor's inline field error so the two surfaces read the same. It is
+	// word-wrapped rather than ellipsized: the consequential half of this
+	// message is its tail, and a clipped tail reads as no explanation at all
+	// (#1973). pinnedFooter keeps the notice on screen with the hint when a
+	// long task list would otherwise scroll it off.
+	pinnedFooter := 1
+	if s.listNotice != "" {
+		noticeStyle := lipgloss.NewStyle().Foreground(t.Error).Bold(true)
+		noticeWidth := s.width - 4
+		if noticeWidth < 1 {
+			noticeWidth = 1
+		}
+		for i, line := range strings.Split(xansi.Wrap(s.listNotice, noticeWidth, ""), "\n") {
+			// The "! " marker leads the first line; continuations align under
+			// the text rather than under the marker.
+			indent := "    "
+			if i == 0 {
+				indent = "  ! "
+			}
+			b.WriteString(noticeStyle.Render(fitLine(indent+line, s.width)))
+			b.WriteString("\n")
+			pinnedFooter++
+		}
+	}
+
 	if s.hasFocus {
 		hint := "↑/↓ select • n new • enter edit • r run now • x toggle • D delete • esc back"
 		short := "r run now • ↑/↓ • n new • enter • esc"
@@ -607,7 +659,7 @@ func (s *TaskPane) renderListMode() string {
 		b.WriteString(hintStyle.Render(fitLine("enter to focus and edit tasks", s.width)))
 	}
 
-	return fitBlockToSize(b.String(), s.width, s.height, 1)
+	return fitBlockToSize(b.String(), s.width, s.height, pinnedFooter)
 }
 
 // promptSnippet collapses a prompt to a single line truncated to maxWidth,

--- a/ui/task_pane_notice_test.go
+++ b/ui/task_pane_notice_test.go
@@ -1,0 +1,147 @@
+package ui
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/sachiniyer/agent-factory/task"
+	"github.com/stretchr/testify/assert"
+)
+
+// watchTaskPane builds a focused list-mode pane holding a single watch task.
+func watchTaskPane(t *testing.T, width, height int) *TaskPane {
+	t.Helper()
+	tp := NewTaskPane()
+	tp.SetSize(width, height)
+	tp.SetFocus(true)
+	tp.SetTasks([]task.Task{{
+		ID:       "watchy",
+		Name:     "watchy",
+		Prompt:   "do it",
+		WatchCmd: "tail -f log",
+		Program:  "claude",
+		Enabled:  true,
+	}})
+	return tp
+}
+
+func pressRune(tp *TaskPane, r string) bool {
+	return tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(r)})
+}
+
+// TestTaskPaneWatchRunNowNoticeVisibleInListMode pins #2137: pressing r on a
+// watch task in LIST mode refused the run but rendered nothing, so the key
+// looked dead. The refusal must be visible on the surface the user is on.
+func TestTaskPaneWatchRunNowNoticeVisibleInListMode(t *testing.T) {
+	tp := watchTaskPane(t, 80, 20)
+
+	assert.True(t, pressRune(tp, "r"))
+	assert.False(t, tp.HasPendingTrigger(), "a watch task must not queue a doomed run")
+
+	out := tp.String()
+	assert.Contains(t, out, "not on manual trigger",
+		"r on a watch task in list mode must explain why manual run is unavailable")
+}
+
+// TestTaskPaneWatchRunNowNoticeUnclippedAt80Cols keeps the consequential half
+// of the notice on screen at the reference width: a transient message whose
+// tail is ellipsized away reads as no explanation at all (#1973).
+func TestTaskPaneWatchRunNowNoticeUnclippedAt80Cols(t *testing.T) {
+	tp := watchTaskPane(t, 80, 20)
+	pressRune(tp, "r")
+
+	out := tp.String()
+	assert.Contains(t, out, "watch tasks run on their watch command's output")
+	assert.Contains(t, out, "not on manual trigger")
+	assert.NotContains(t, out, "…", "the notice must fit at 80 cols, not be ellipsized")
+	for _, line := range strings.Split(out, "\n") {
+		assert.LessOrEqual(t, lipgloss.Width(line), 80, "no rendered line may exceed the pane width")
+	}
+}
+
+// TestTaskPaneWatchRunNowNoticeWrapsWhenNarrow: below the notice's width the
+// message wraps instead of losing its tail, so the refusal still reads.
+func TestTaskPaneWatchRunNowNoticeWrapsWhenNarrow(t *testing.T) {
+	tp := watchTaskPane(t, 46, 20)
+	pressRune(tp, "r")
+
+	out := tp.String()
+	assert.Contains(t, out, "not on manual trigger",
+		"a narrow pane must wrap the notice, not truncate its tail")
+	for _, line := range strings.Split(out, "\n") {
+		assert.LessOrEqual(t, lipgloss.Width(line), 46, "no rendered line may exceed the pane width")
+	}
+}
+
+// TestTaskPaneWatchRunNowNoticeIsTransient: the notice is feedback for one
+// keypress, so the next action clears it rather than leaving a stale error
+// hanging under an unrelated selection.
+func TestTaskPaneWatchRunNowNoticeIsTransient(t *testing.T) {
+	tp := watchTaskPane(t, 80, 20)
+	pressRune(tp, "r")
+	assert.Contains(t, tp.String(), "not on manual trigger")
+
+	pressRune(tp, "j")
+	assert.NotContains(t, tp.String(), "not on manual trigger",
+		"the notice must clear on the next keypress")
+
+	// Mouse-wheel scrolling moves the selection without a keypress, so it
+	// retires the notice too.
+	pressRune(tp, "r")
+	assert.Contains(t, tp.String(), "not on manual trigger")
+	tp.ScrollDown()
+	assert.NotContains(t, tp.String(), "not on manual trigger",
+		"the notice must clear when the selection scrolls")
+}
+
+// TestTaskPaneWatchRunNowNoticeSurvivesAClampedList: a task list taller than
+// the pane windows its rows, and the notice must be pinned with the hint
+// instead of scrolling off with them.
+func TestTaskPaneWatchRunNowNoticeSurvivesAClampedList(t *testing.T) {
+	tp := NewTaskPane()
+	tp.SetSize(80, 10)
+	tp.SetFocus(true)
+	tasks := make([]task.Task, 0, 12)
+	for i := 0; i < 12; i++ {
+		tasks = append(tasks, task.Task{
+			ID:       "t" + strconv.Itoa(i),
+			Name:     "task-" + strconv.Itoa(i),
+			WatchCmd: "tail -f log",
+			Enabled:  true,
+		})
+	}
+	tp.SetTasks(tasks)
+
+	pressRune(tp, "r")
+	out := tp.String()
+	assert.Contains(t, out, "not on manual trigger",
+		"the notice must stay on screen when the list is clamped to the pane height")
+	assert.Len(t, strings.Split(out, "\n"), 10, "the pane must still fit its height")
+}
+
+// TestTaskPaneRunNowStillTriggersNonWatchTask guards the regression side: a
+// cron task's r still queues the trigger and shows no refusal.
+func TestTaskPaneRunNowStillTriggersNonWatchTask(t *testing.T) {
+	tp := NewTaskPane()
+	tp.SetSize(80, 20)
+	tp.SetFocus(true)
+	tp.SetTasks([]task.Task{{
+		ID:       "cronny",
+		Name:     "cronny",
+		Prompt:   "do it",
+		CronExpr: "0 9 * * 1-5",
+		Program:  "claude",
+		Enabled:  true,
+	}})
+
+	assert.True(t, pressRune(tp, "r"))
+	assert.True(t, tp.HasPendingTrigger(), "a cron task's r must still queue a trigger")
+	tsk := tp.ConsumePendingTrigger()
+	if assert.NotNil(t, tsk) {
+		assert.Equal(t, "cronny", tsk.ID)
+	}
+	assert.NotContains(t, tp.String(), "not on manual trigger")
+}


### PR DESCRIPTION
Fixes #2137

## The bug

`runSelectedTask` correctly refuses a manual trigger of a **watch** task —
watch tasks fire from their watch command's stdout, so a manual run has no
event line and the daemon's `RunTask` rejects it — and sets

```go
s.editError = "watch tasks run on their watch command's output, not on manual trigger"
s.editErrorField = taskFocusTrigger
```

But `editError` is only ever drawn by `renderEditMode`, hung under the field
it belongs to. In **list** mode `String()` calls `renderListMode`, which has no
fields and never rendered it. So pressing `r` on a watch task in the task list
set a message nobody saw: the key looked dead.

## The fix

List mode now renders a transient notice directly above the hint row, styled
like the editor's inline field error so both surfaces read the same:

```
Tasks

▸ [✓]  watchy  watch: tail -f log [watching]  new session
      do it
      claude • last: never

  ! watch tasks run on their watch command's output, not on manual trigger
↑/↓ select • n new • enter edit • x toggle • D delete • esc back
```

Details:

- **Word-wrapped, not ellipsized.** The consequential half of this message is
  its tail, and a clipped tail reads as no explanation at all (#1973). At 46
  cols it wraps, with continuations aligned under the text rather than the `!`:

  ```
    ! watch tasks run on their watch command's
      output, not on manual trigger
  ```

- **Pinned with the hint.** `fitBlockToSize`'s `pinnedFooter` grows with the
  notice, so a task list taller than the pane windows its rows (`↓ more`)
  without scrolling the notice off.

- **Transient.** Any later keypress — or a selection scroll from the mouse
  wheel — clears it, so it's feedback for one action, not a stale error. A
  notice set by `r` inside the editor can't follow the user back out to the
  list either.

- The message is now one `watchRunNowRefusal` const, shared by the two surfaces
  that accept `r`, instead of drifting between them.

Out of scope, unchanged: the daemon's `RunTask` refusal, watch-task semantics,
and #1758's suppression of the `r run now` hint for watch tasks (the hidden
hint is the complement here, not the substitute — the keypress must still
answer).

## Fail-first output

Five new tests in `ui/task_pane_notice_test.go`. On master, the four notice
tests fail and the non-watch regression test passes:

```
--- FAIL: TestTaskPaneWatchRunNowNoticeVisibleInListMode (0.00s)
    task_pane_notice_test.go:44:
        Error:  "Tasks\n\n▸ [✓]  watchy  watch: tail -f log [watching]  new session\n      do it\n      claude • last: never\n\n↑/↓ select • n new • enter edit • x toggle • D delete • esc back" does not contain "not on manual trigger"
        Messages: r on a watch task in list mode must explain why manual run is unavailable
--- FAIL: TestTaskPaneWatchRunNowNoticeUnclippedAt80Cols (0.00s)
    task_pane_notice_test.go:56: ... does not contain "watch tasks run on their watch command's output"
    task_pane_notice_test.go:57: ... does not contain "not on manual trigger"
--- FAIL: TestTaskPaneWatchRunNowNoticeWrapsWhenNarrow (0.00s)
    task_pane_notice_test.go:71:
        Error:  "Tasks\n\n▸ [✓]  watchy  watch: tail -f log [watching] …\n      do it\n      claude • last: never\n\n↑/↓ • n new • enter • esc" does not contain "not on manual trigger"
        Messages: a narrow pane must wrap the notice, not truncate its tail
--- FAIL: TestTaskPaneWatchRunNowNoticeIsTransient (0.00s)
    task_pane_notice_test.go:84: ... does not contain "not on manual trigger"
FAIL
FAIL	github.com/sachiniyer/agent-factory/ui	0.016s
```

(The clamped-list test and the scroll leg of the transient test were added
after the fix; the four above are the reproduction.)

Coverage now: `r` in list mode renders the message; it is unclipped at 80 cols
and no rendered line exceeds the pane width; it wraps at 46 cols; it clears on
the next keypress and on scroll; it survives a height-clamped list; and a cron
task's `r` still queues its trigger with no refusal shown.

## Gates

`gofmt -l .` clean · `go build ./...` · `scripts/lint-file-length.sh` passed
(the new tests went in a new file — `task_pane_test.go` is at 1466/1500) ·
`golangci-lint run --timeout=3m --fast` clean · `go test ./ui/... ./app/...
./task/...` all green.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
