### PR TITLE
fix(daemon): a stale poll can no longer undo a usage-limit resume (#2135)

### DIFF
--- a/daemon/limit.go
+++ b/daemon/limit.go
@@ -72,10 +72,25 @@ func createdTaskStatus(data session.InstanceData) string {
 // static frame through every quiet gap in a turn). So before settling Ready, ask
 // the agent: a pane that says it is working IS working, and stays Running. See
 // task.IsWorkingContent for why a debounce cannot stand in for this.
-func (m *Manager) resolveIdleLiveness(instance *session.Instance, content string) {
+//
+// epoch is the instance's state epoch captured BEFORE the pane capture `content`
+// came from, and every write below is scoped to it (#2135). This whole function
+// is a conclusion about a session as it was when its pane was read, and between
+// that read and here an authoritative transition can land — above all a resume
+// (the manual `c` retry or the auto-resume scheduler) clearing the usage-limit
+// block, re-delivering the prompt and persisting LiveRunning. Applying the
+// detector's hit on top of that re-parked a session that was in fact working, and
+// the persist gate then wrote the reverted state to disk. So the applies here
+// carry the epoch: the state moved ⇒ this decision is about a state the session
+// has already left, and it is dropped rather than clobbering the newer one. The
+// next tick re-decides from content captured after the transition, which is why
+// nothing is lost — see session/state_epoch.go.
+func (m *Manager) resolveIdleLiveness(instance *session.Instance, content string, epoch uint64) {
 	agent := instance.ResolvedAgent()
 	if hit, resetAt, _ := m.limitDetector.Check(content, agent, time.Now()); hit {
-		instance.SetLimitReached(resetAt)
+		// Returns false when the decision was superseded; nothing to do about it
+		// here — the next tick observes the session as it is now.
+		_ = instance.SetLimitReachedAtEpoch(resetAt, epoch)
 		return
 	}
 	if task.IsWorkingContent(content, agent) {
@@ -83,14 +98,14 @@ func (m *Manager) resolveIdleLiveness(instance *session.Instance, content string
 		// stays dark. Settling Ready here is the green flash (#1766 says green ==
 		// waiting for you), and it is not merely cosmetic — a Ready amp is what
 		// `af sessions watch` unblocks on and what tells a user their turn is done.
-		_ = instance.Transition(session.ObserveLiveness(session.LiveRunning))
+		_ = instance.Transition(session.ObserveLiveness(session.LiveRunning).AtEpoch(epoch))
 		return
 	}
 	// Plain idle: settle to Ready. On the two-axis model (#1195) SetLiveness
 	// writes only the liveness axis and never clobbers an in-flight op, so it
 	// needs no "if not deleting" guard — this is exactly what the poll's Ready
 	// fallback does inline in refreshInstanceStatus.
-	_ = instance.Transition(session.ObserveLiveness(session.LiveReady))
+	_ = instance.Transition(session.ObserveLiveness(session.LiveReady).AtEpoch(epoch))
 }
 
 // testHookPollBeforePublish runs immediately before persistPollChange announces
@@ -99,6 +114,13 @@ func (m *Manager) resolveIdleLiveness(instance *session.Instance, content string
 // property that keeps an older whole-session payload from landing after a newer
 // tab roster. No-op in production.
 var testHookPollBeforePublish = func() {}
+
+// testHookPollBeforePersistLock runs in persistPollChange after it has read the
+// payload it intends to write and BEFORE it takes the repo start lock — the exact
+// window a concurrent transition (a usage-limit resume) can land in and be
+// overwritten by this poll's older payload. Tests substitute it to land that
+// transition deterministically, with no goroutines or sleeps. No-op in production.
+var testHookPollBeforePersistLock = func() {}
 
 // persistPollChange writes an instance's state to disk when the poll changed
 // something durable this tick (the #960 targeted writer): its LIVENESS
@@ -119,19 +141,43 @@ var testHookPollBeforePublish = func() {}
 // A concurrent client op (create/kill/archive) means that op's executor owns the
 // durable state, so the poll never persists over it. Split from
 // refreshInstanceStatus so control.go stays under its length ceiling (#1145).
+//
+// WHAT IS WRITTEN IS WHAT IS TRUE AT WRITE TIME (#2135). The change test above is
+// a decision about a payload read at one instant, and the write happens at
+// another — after a repo start lock that a session create can hold for seconds.
+// An authoritative transition landing in between (a usage-limit resume clearing
+// the block and persisting LiveRunning, above all) would otherwise be overwritten
+// by the intermediate this poll decided from, and the reset-time arm is what
+// carried it there: it fires INDEPENDENTLY of the liveness, so a poll whose
+// liveness compare read "unchanged" (LimitReached → LimitReached) still flushed —
+// planting a limit-blocked row on disk for a session that was working.
+//
+// So the payload is re-read under the lock whenever the state epoch shows it
+// moved: the poll's gate decides WHETHER to write, never WHAT. Deliberately not
+// the reverse (take the lock, then read once): the lock is uncontended only when
+// nothing is being created, and taking it on every tick of every session would
+// park the whole poll behind an unrelated create. The epoch keeps the hot path
+// lock-free and costs a second read only in the rare superseded case.
 func (m *Manager) persistPollChange(repoID string, instance *session.Instance, before session.Liveness, beforeReset time.Time) {
 	if instance.GetInFlightOp() != session.OpNone {
 		return
 	}
-	afterReset, _ := instance.LimitResetAt()
-	livenessChanged := instance.GetLiveness() != before
-	resetChanged := !afterReset.Equal(beforeReset)
+	data, epoch := instance.ToInstanceDataWithEpoch()
+	livenessChanged := data.Liveness != before
+	resetChanged := !data.LimitResetAt.Equal(beforeReset)
 	if !livenessChanged && !resetChanged {
 		return
 	}
 	repoStartLock := m.startLockForRepo(repoID)
+	testHookPollBeforePersistLock()
 	repoStartLock.Lock()
-	data := instance.ToInstanceData()
+	if current, now := instance.ToInstanceDataWithEpoch(); now != epoch {
+		// Superseded while we waited for the lock. Persist and publish what is true
+		// NOW — the transition that beat us owns this state, and both the disk row
+		// and the session.updated payload must show it, not the intermediate this
+		// tick decided from.
+		data = current
+	}
 	err := persistInstanceData(repoID, data)
 	// Push the change onto the events plane (#1592 PR5): this is the single choke
 	// point every liveness/limit transition already flows through, so one publish

--- a/daemon/limit_resume_poll_race_test.go
+++ b/daemon/limit_resume_poll_race_test.go
@@ -1,0 +1,218 @@
+package daemon
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// limitRacePollBackend is a FakeBackend that reproduces the #2135 interleaving
+// exactly: its pane capture returns a fixed usage-limit banner every idle tick,
+// and it runs a one-shot hook AFTER the content has been captured but BEFORE the
+// poll acts on it. The hook is where the racing resume lands, so the poll's
+// decision is provably made from PRE-resume content.
+//
+// Driving the race from inside the capture (rather than from a second goroutine)
+// makes it deterministic: the poll goroutine is the one that runs the resume, so
+// there is no sleep, no barrier, and no flake.
+type limitRacePollBackend struct {
+	*session.FakeBackend
+	mu           sync.Mutex
+	content      string
+	afterCapture func()
+	sentPrompts  []string
+}
+
+func (b *limitRacePollBackend) HasUpdated(*session.Instance) (bool, bool, string) {
+	b.mu.Lock()
+	content := b.content
+	hook := b.afterCapture
+	b.afterCapture = nil // one-shot: later ticks are ordinary polls
+	b.mu.Unlock()
+	if hook != nil {
+		hook()
+	}
+	return false, false, content
+}
+
+func (b *limitRacePollBackend) SendPromptCommand(_ *session.Instance, prompt string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.sentPrompts = append(b.sentPrompts, prompt)
+	return nil
+}
+
+func (b *limitRacePollBackend) prompts() []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return append([]string(nil), b.sentPrompts...)
+}
+
+func (b *limitRacePollBackend) setHook(fn func()) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.afterCapture = fn
+}
+
+// TestResumeFromLimit_ConcurrentPollCannotRevertResume is the #2135 regression: a
+// poll tick that captured its pane content BEFORE a resume must not re-park the
+// session at the usage-limit wall using that stale content.
+//
+// The interleaving: the poll snapshots a pane still showing the limit banner, the
+// resume then clears the limit, re-delivers the prompt and persists LiveRunning,
+// and only then does the poll run the detector over its stale capture. Before the
+// fix that detector hit and called SetLimitReached, reverting the session to
+// LiveLimitReached in memory; persistPollChange then flushed it to DISK too,
+// because the reset time had changed even though the liveness compare read
+// unchanged (LimitReached → LimitReached). The user was shown a limit-blocked
+// session that was in fact working, and a daemon restart reloaded the wrong state.
+func TestResumeFromLimit_ConcurrentPollCannotRevertResume(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &limitRacePollBackend{FakeBackend: session.NewFakeBackend(), content: claudeLimitBanner}
+	inst := registerStarted(t, manager, repoID, repoPath, "limited", backend, true, session.Running)
+	inst.Prompt = "finish the migration"
+
+	// Park it at the wall with a reset time that differs from the one the banner
+	// parses to, so the poll's re-detection changes the reset time — the exact
+	// shape that made persistPollChange flush the reverted state to disk.
+	inst.SetLimitReached(time.Date(2030, 1, 1, 12, 0, 0, 0, time.UTC))
+	manager.persistInstance(repoID, inst)
+
+	// The resume lands between the poll's capture and the poll's decision.
+	backend.setHook(func() {
+		if err := manager.resumeFromLimit(ResumeFromLimitRequest{Title: "limited", RepoID: repoID}); err != nil {
+			t.Errorf("resumeFromLimit: %v", err)
+		}
+	})
+
+	manager.RefreshStatuses()
+
+	if got := backend.prompts(); len(got) != 1 || got[0] != "finish the migration" {
+		t.Fatalf("delivered prompts = %v, want exactly the stored prompt (the resume must have landed)", got)
+	}
+	if inst.LimitReached() {
+		t.Errorf("in-memory liveness = %v, want LiveRunning: a poll deciding from PRE-resume content must not re-park the session (#2135)", inst.GetLiveness())
+	}
+	if got := inst.GetLiveness(); got != session.LiveRunning {
+		t.Errorf("in-memory liveness = %v, want LiveRunning (#2135)", got)
+	}
+	if got, ok := inst.LimitResetAt(); ok || !got.IsZero() {
+		t.Errorf("in-memory reset time = (%v, %v), want (zero, false) after a successful resume (#2135)", got, ok)
+	}
+	if got := persistedLiveness(t, repoID, "limited"); got != session.LiveRunning {
+		t.Errorf("persisted liveness = %v, want LiveRunning: the stale poll must not reach disk (#2135)", got)
+	}
+	if got := persistedLimitReset(t, repoID, "limited"); !got.IsZero() {
+		t.Errorf("persisted reset time = %v, want zero (#2135)", got)
+	}
+}
+
+// TestRefreshStatuses_GenuineLimitHitAfterResumeStillParks is the
+// over-suppression control for #2135: the fix drops only a decision made from
+// content captured before a transition, never limit detection in general. A LATER
+// tick — fresh capture, no racing resume — that still sees the banner must park
+// the session again, in memory and on disk.
+//
+// This is what rules out a "suppress limit detection for N seconds after a
+// resume" fix: an agent that immediately walks back into the wall would go
+// undetected for the whole window.
+func TestRefreshStatuses_GenuineLimitHitAfterResumeStillParks(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &limitRacePollBackend{FakeBackend: session.NewFakeBackend(), content: claudeLimitBanner}
+	inst := registerStarted(t, manager, repoID, repoPath, "limited", backend, true, session.Running)
+	inst.Prompt = "finish the migration"
+	inst.SetLimitReached(time.Date(2030, 1, 1, 12, 0, 0, 0, time.UTC))
+	manager.persistInstance(repoID, inst)
+
+	backend.setHook(func() {
+		if err := manager.resumeFromLimit(ResumeFromLimitRequest{Title: "limited", RepoID: repoID}); err != nil {
+			t.Errorf("resumeFromLimit: %v", err)
+		}
+	})
+	manager.RefreshStatuses()
+	if inst.LimitReached() {
+		t.Fatalf("precondition: the resumed session must not be limit-blocked, got %v", inst.GetLiveness())
+	}
+
+	// Next tick: no resume in flight, the pane still shows the banner. This is a
+	// genuine observation and must park the session.
+	manager.RefreshStatuses()
+
+	if !inst.LimitReached() {
+		t.Fatalf("in-memory liveness = %v, want LiveLimitReached: a fresh limit observation must still park the session", inst.GetLiveness())
+	}
+	if _, ok := inst.LimitResetAt(); !ok {
+		t.Error("a parseable reset time must be stored for the badge")
+	}
+	if got := persistedLiveness(t, repoID, "limited"); got != session.LiveLimitReached {
+		t.Errorf("persisted liveness = %v, want LiveLimitReached", got)
+	}
+}
+
+// TestPersistPollChange_ResumeDuringWriteWindowIsNotOverwritten is the second
+// half of #2135, and it survives the first: even when the poll's limit detection
+// is GENUINE — fresh content, nothing stale about it — the write itself happens
+// later, after a repo start lock a session create can hold for seconds. A resume
+// landing in that window cleared the limit and persisted LiveRunning; the poll
+// then flushed the payload it had decided from and put the limit-blocked row back
+// on disk, where a daemon restart would reload it.
+//
+// The poll must persist what is TRUE at write time, not the intermediate it
+// decided from.
+func TestPersistPollChange_ResumeDuringWriteWindowIsNotOverwritten(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &limitRacePollBackend{FakeBackend: session.NewFakeBackend(), content: claudeLimitBanner}
+	inst := registerStarted(t, manager, repoID, repoPath, "limited", backend, true, session.Running)
+	inst.Prompt = "finish the migration"
+
+	// The poll's own decision, made from content that is genuinely current: park
+	// the session at the wall. This is what it is about to write.
+	before := inst.GetLiveness()
+	beforeReset, _ := inst.LimitResetAt()
+	inst.SetLimitReached(time.Date(2026, 7, 20, 18, 0, 0, 0, time.UTC))
+
+	// The resume lands in the write window: after the poll read its payload, before
+	// it takes the repo start lock.
+	prev := testHookPollBeforePersistLock
+	t.Cleanup(func() { testHookPollBeforePersistLock = prev })
+	once := false
+	testHookPollBeforePersistLock = func() {
+		if once {
+			return
+		}
+		once = true
+		if err := manager.resumeFromLimit(ResumeFromLimitRequest{Title: "limited", RepoID: repoID}); err != nil {
+			t.Errorf("resumeFromLimit: %v", err)
+		}
+	}
+
+	manager.persistPollChange(repoID, inst, before, beforeReset)
+
+	if got := persistedLiveness(t, repoID, "limited"); got != session.LiveRunning {
+		t.Errorf("persisted liveness = %v, want LiveRunning: the poll must not overwrite a resume that landed while it waited for the write lock (#2135)", got)
+	}
+	if got := persistedLimitReset(t, repoID, "limited"); !got.IsZero() {
+		t.Errorf("persisted reset time = %v, want zero (#2135)", got)
+	}
+}
+
+// TestRefreshStatuses_OrdinaryPollUnaffectedByEpochGuard is the plain-path
+// control: an idle session with no limit banner and nothing racing it still
+// settles Ready and still persists that transition. The #2135 guard must be
+// invisible to the ordinary poll.
+func TestRefreshStatuses_OrdinaryPollUnaffectedByEpochGuard(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &limitRacePollBackend{FakeBackend: session.NewFakeBackend(), content: "$ "}
+	inst := registerStarted(t, manager, repoID, repoPath, "idle", backend, true, session.Running)
+
+	manager.RefreshStatuses()
+
+	if got := inst.GetLiveness(); got != session.LiveReady {
+		t.Fatalf("in-memory liveness = %v, want LiveReady", got)
+	}
+	if got := persistedLiveness(t, repoID, "idle"); got != session.LiveReady {
+		t.Fatalf("persisted liveness = %v, want LiveReady", got)
+	}
+}

--- a/daemon/manager_status.go
+++ b/daemon/manager_status.go
@@ -218,6 +218,7 @@ func (m *Manager) isPollPaused(repoID, title string) bool {
 func (m *Manager) observeTaskRunWhilePaused(repoID, key string, instance *session.Instance) {
 	before := instance.GetLiveness()
 	beforeReset, _ := instance.LimitResetAt()
+	epoch := instance.StateEpoch() // see refreshInstanceStatus (#2135)
 	obs, err := instance.AgentServer().Snapshot()
 	// Whatever happened, no loss episode survives an attach (see above).
 	m.clearRemoteLoss(key)
@@ -229,7 +230,7 @@ func (m *Manager) observeTaskRunWhilePaused(repoID, key string, instance *sessio
 	// Idle output. The normal poll would probe liveness here to tell a healthy idle
 	// session from a vanished one; this path deliberately does not, because it must
 	// never conclude death. The attach already answers that question.
-	m.resolveIdleLiveness(instance, obs.Content)
+	m.resolveIdleLiveness(instance, obs.Content, epoch)
 	m.persistPollChange(repoID, instance, before, beforeReset)
 }
 
@@ -376,6 +377,11 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 	as := instance.AgentServer()
 	before := instance.GetLiveness()
 	beforeReset, _ := instance.LimitResetAt()
+	// Captured BEFORE the observation below, so the idle resolve can tell whether
+	// the conclusion it draws from that capture is still about the state it
+	// observed — or whether a resume/kill/archive has moved the session on since
+	// (#2135). See resolveIdleLiveness and session/state_epoch.go.
+	epoch := instance.StateEpoch()
 	// Snapshot dismisses a pending trust prompt then reads the pane in one probe
 	// (the exact order the poll used to run CheckAndHandleTrustPrompt then
 	// HasUpdated). Content is the capture handed back so the idle branch runs the
@@ -487,7 +493,7 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 			// Idle output: settle to Ready, or LimitReached when the pane shows a
 			// usage-limit banner for a claude/codex session (#1146). content is
 			// HasUpdated's capture (no re-capture); see resolveIdleLiveness.
-			m.resolveIdleLiveness(instance, content)
+			m.resolveIdleLiveness(instance, content, epoch)
 		}
 	}
 	if observedAlive {

--- a/session/instance.go
+++ b/session/instance.go
@@ -147,6 +147,13 @@ type Instance struct {
 	// carried in the daemon snapshot so the badge survives a restart; PR3's
 	// auto-resume scheduler reads it. Mutex-protected.
 	limitResetAt time.Time
+	// stateEpoch is the generation counter for the lifecycle state above — the two
+	// axes plus limitResetAt — bumped by every writer that actually changes one of
+	// them (#2135). It is how an observer that decided from a captured pane learns
+	// its decision has been superseded by a newer transition before it applies it;
+	// see state_epoch.go. Mutex-protected, in-memory only: it describes a window
+	// between an observation and its apply, and no such window survives a restart.
+	stateEpoch uint64
 	// Program is the program to run in the instance.
 	Program string
 	// Height is the height of the instance.

--- a/session/instance_backend.go
+++ b/session/instance_backend.go
@@ -70,9 +70,11 @@ func (i *Instance) ArchiveTeardown(dest string) error {
 func (i *Instance) SetArchived() {
 	i.mu.Lock()
 	defer i.mu.Unlock()
+	lv, op, resetAt := i.lifecycleStateLocked()
 	i.started = false
 	i.liveness = LiveArchived
 	i.inFlightOp = OpNone
+	i.noteStateChangeLocked(lv, op, resetAt)
 }
 
 // RestoreArchivedWorktree moves this instance's archived worktree back to dest

--- a/session/instance_data.go
+++ b/session/instance_data.go
@@ -12,7 +12,23 @@ import (
 func (i *Instance) ToInstanceData() InstanceData {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
+	return i.toInstanceDataLocked()
+}
 
+// ToInstanceDataWithEpoch returns the serializable form together with the state
+// epoch it was read at, both under ONE hold of i.mu (#2135). A writer that
+// persists what it read uses it so the epoch it re-checks before the write
+// provably belongs to the payload it is about to write — reading the two
+// separately would leave a window in which the state moves between them, which is
+// the very thing the epoch exists to detect.
+func (i *Instance) ToInstanceDataWithEpoch() (InstanceData, uint64) {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.toInstanceDataLocked(), i.stateEpoch
+}
+
+// toInstanceDataLocked is the shared body. Caller holds i.mu (read or write).
+func (i *Instance) toInstanceDataLocked() InstanceData {
 	data := InstanceData{
 		ID:     i.ID,
 		TaskID: i.TaskID,

--- a/session/liveness.go
+++ b/session/liveness.go
@@ -166,6 +166,7 @@ func (i *Instance) statusLocked() Status {
 // untouched (they overlay it); settled values set liveness and clear the op —
 // matching the old single-field clobber exactly.
 func (i *Instance) setStatusLocked(s Status) {
+	lv, op, resetAt := i.lifecycleStateLocked()
 	switch s {
 	case Loading:
 		i.inFlightOp = OpCreating
@@ -175,6 +176,7 @@ func (i *Instance) setStatusLocked(s Status) {
 		i.inFlightOp = OpNone
 		i.liveness = LivenessForStatus(s)
 	}
+	i.noteStateChangeLocked(lv, op, resetAt)
 }
 
 // SetStatusForTest sets the status under the instance mutex by decomposing the
@@ -332,7 +334,9 @@ func (i *Instance) HasInFlightOp() bool {
 func (i *Instance) SetInFlightOpForTest(op InFlightOp) {
 	i.mu.Lock()
 	defer i.mu.Unlock()
+	lv, prevOp, resetAt := i.lifecycleStateLocked()
 	i.inFlightOp = op
+	i.noteStateChangeLocked(lv, prevOp, resetAt)
 }
 
 // MarkLive is retired (#1195 Phase 2e): marking a completed create/recover live
@@ -375,12 +379,42 @@ func (i *Instance) TabSpawnBlocked() error {
 func (i *Instance) SetLimitReached(resetAt time.Time) {
 	i.mu.Lock()
 	defer i.mu.Unlock()
-	if s := i.statusLocked(); s == Loading || s == Deleting {
-		return
+	i.setLimitReachedLocked(resetAt)
+}
+
+// SetLimitReachedAtEpoch is SetLimitReached for a decision derived from an
+// OBSERVATION — the daemon poll's usage-limit detection over captured pane
+// content (#2135). It applies the block only while the instance's state epoch is
+// still the one the observation was captured at; if a newer authoritative
+// transition has landed since (a resume's ClearLimitReached above all, but equally
+// a kill or an archive) the decision is known-stale and is dropped. Reports
+// whether it applied.
+//
+// The check and the write are one critical section under i.mu, which is the whole
+// point: an epoch read followed by a separate SetLimitReached would leave the same
+// window it closes.
+func (i *Instance) SetLimitReachedAtEpoch(resetAt time.Time, epoch uint64) bool {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.stateEpoch != epoch {
+		return false
 	}
+	return i.setLimitReachedLocked(resetAt)
+}
+
+// setLimitReachedLocked is the shared body: mark the instance limit-blocked and
+// record its reset time, skipping a row mid create/kill teardown so it never
+// clobbers an in-flight op. Reports whether it applied. Caller holds i.mu.
+func (i *Instance) setLimitReachedLocked(resetAt time.Time) bool {
+	if s := i.statusLocked(); s == Loading || s == Deleting {
+		return false
+	}
+	lv, op, prevReset := i.lifecycleStateLocked()
 	i.inFlightOp = OpNone
 	i.liveness = LiveLimitReached
 	i.limitResetAt = resetAt
+	i.noteStateChangeLocked(lv, op, prevReset)
+	return true
 }
 
 // SetLimitResetAt records only the display-only reset time (#1146), leaving both
@@ -394,7 +428,9 @@ func (i *Instance) SetLimitReached(resetAt time.Time) {
 func (i *Instance) SetLimitResetAt(resetAt time.Time) {
 	i.mu.Lock()
 	defer i.mu.Unlock()
+	lv, op, prevReset := i.lifecycleStateLocked()
 	i.limitResetAt = resetAt
+	i.noteStateChangeLocked(lv, op, prevReset)
 }
 
 // ClearLimitReached moves a limit-blocked instance back to LiveRunning so the
@@ -407,8 +443,13 @@ func (i *Instance) ClearLimitReached() {
 	if i.liveness != LiveLimitReached {
 		return
 	}
+	lv, op, prevReset := i.lifecycleStateLocked()
 	i.liveness = LiveRunning
 	i.limitResetAt = time.Time{}
+	// The epoch bump here is what a racing poll checks: it is the resume's
+	// completion point, so any limit re-detection made from content captured before
+	// it is stale by definition and must not land (#2135).
+	i.noteStateChangeLocked(lv, op, prevReset)
 }
 
 // LimitReached reports whether the instance is blocked on a usage limit (#1146).

--- a/session/state_epoch.go
+++ b/session/state_epoch.go
@@ -1,0 +1,65 @@
+package session
+
+import "time"
+
+// The state epoch (#2135).
+//
+// The daemon poll DECIDES FROM A SNAPSHOT: it captures pane content, and a moment
+// later runs the usage-limit detector and the working check over that capture and
+// writes the state they resolve to. Between those two moments an authoritative
+// transition can land — a manual `c` retry or the auto-resume scheduler clearing a
+// usage-limit block, a kill, an archive — and a decision made from content that
+// PREDATES it then overwrites newer truth. #2135 is exactly that: a resume cleared
+// the limit, re-delivered the prompt and persisted LiveRunning, and the in-flight
+// poll re-parked the session at the wall from a capture taken before the resume —
+// in memory AND, via the reset-time arm of the persist gate, on disk. The user was
+// shown a limit-blocked session that was in fact working.
+//
+// stateEpoch makes "has the authoritative state moved since I looked?" answerable
+// in ONE comparison. It is bumped under i.mu by every mutation of the lifecycle
+// state the daemon reasons about — the liveness axis, the in-flight op axis, and
+// the usage-limit reset time — so an observer captures it alongside the content it
+// decides from and hands it back when it applies the decision. The apply is then a
+// compare-and-set under that same mutex: same epoch → the decision is still about
+// the state it was made about, and is applied; different epoch → something newer
+// landed, the decision is known-stale, and it is DROPPED.
+//
+// It is bumped only on a REAL change (the tracked triple actually differs), so a
+// re-observation of the state a session is already in — the poll's common case —
+// never invalidates another observer's in-flight decision.
+//
+// Dropping is safe and self-healing precisely because the guard is
+// per-observation rather than a time window: the poll re-observes on its next tick
+// and re-decides from content that postdates the transition. A session that
+// genuinely walks straight back into a usage-limit wall after a resume is
+// therefore still parked on the very next tick — which a "suppress limit detection
+// for N seconds after a resume" guard could not promise. Under-applying by one
+// tick is recoverable; clobbering a newer transition is not.
+
+// StateEpoch returns the instance's lifecycle-state generation counter (#2135).
+// Capture it BEFORE the observation a decision will be made from, and hand it back
+// to the epoch-scoped applier (TransitionEvent.AtEpoch / SetLimitReachedAtEpoch)
+// so a decision that a newer transition has superseded is dropped instead of
+// applied. See the file comment for why this is a counter and not a lock.
+func (i *Instance) StateEpoch() uint64 {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.stateEpoch
+}
+
+// lifecycleStateLocked captures the state the epoch tracks: both axes plus the
+// usage-limit reset time. Caller holds i.mu.
+func (i *Instance) lifecycleStateLocked() (Liveness, InFlightOp, time.Time) {
+	return i.liveness, i.inFlightOp, i.limitResetAt
+}
+
+// noteStateChangeLocked bumps the epoch when the tracked state differs from the
+// snapshot lifecycleStateLocked took before the mutation. Caller holds i.mu.
+// Every writer of the two axes or the reset time pairs with it, so "the epoch
+// moved" means exactly "the authoritative state changed".
+func (i *Instance) noteStateChangeLocked(lv Liveness, op InFlightOp, resetAt time.Time) {
+	if i.liveness == lv && i.inFlightOp == op && i.limitResetAt.Equal(resetAt) {
+		return
+	}
+	i.stateEpoch++
+}

--- a/session/state_epoch_test.go
+++ b/session/state_epoch_test.go
@@ -1,0 +1,132 @@
+package session
+
+import (
+	"testing"
+	"time"
+)
+
+// newEpochTestInstance builds a bare instance for the epoch unit tests. It needs
+// no backend or worktree: every property under test is pure lifecycle state.
+func newEpochTestInstance(t *testing.T) *Instance {
+	t.Helper()
+	inst, err := NewInstance(InstanceOptions{Title: "epoch", Path: t.TempDir(), Program: "claude"})
+	if err != nil {
+		t.Fatalf("NewInstance: %v", err)
+	}
+	return inst
+}
+
+// TestStateEpoch_AdvancesOnlyOnRealChange pins the counter's contract (#2135):
+// it moves when the lifecycle state actually changes and stays put otherwise. A
+// counter that ticked on every write would make the poll's ordinary
+// re-observation of an unchanged session invalidate another observer's in-flight
+// decision, turning a correctness guard into a source of dropped updates.
+func TestStateEpoch_AdvancesOnlyOnRealChange(t *testing.T) {
+	inst := newEpochTestInstance(t)
+	_ = inst.Transition(ObserveLiveness(LiveReady))
+
+	start := inst.StateEpoch()
+	if err := inst.Transition(ObserveLiveness(LiveReady)); err != nil {
+		t.Fatalf("Transition: %v", err)
+	}
+	if got := inst.StateEpoch(); got != start {
+		t.Fatalf("epoch = %d after re-observing the same liveness, want %d (unchanged)", got, start)
+	}
+
+	if err := inst.Transition(ObserveLiveness(LiveRunning)); err != nil {
+		t.Fatalf("Transition: %v", err)
+	}
+	if got := inst.StateEpoch(); got == start {
+		t.Fatalf("epoch = %d after a real liveness change, want it advanced", got)
+	}
+
+	// The usage-limit reset time is tracked too: a later-parsed reset time on an
+	// already-limit-blocked session is a real change (#1204's persist case).
+	inst.SetLimitReached(time.Time{})
+	parked := inst.StateEpoch()
+	inst.SetLimitReached(time.Date(2026, 7, 20, 18, 0, 0, 0, time.UTC))
+	if got := inst.StateEpoch(); got == parked {
+		t.Fatalf("epoch = %d after the reset time changed, want it advanced", got)
+	}
+}
+
+// TestSetLimitReachedAtEpoch_DropsSupersededDecision is the session-level half of
+// the #2135 fix: a limit decision made from an observation is applied only while
+// the state it was made about is still current. A resume clearing the block moves
+// the epoch, so the stale decision behind it is dropped rather than re-parking a
+// session that is working again.
+func TestSetLimitReachedAtEpoch_DropsSupersededDecision(t *testing.T) {
+	inst := newEpochTestInstance(t)
+	resetAt := time.Date(2026, 7, 20, 18, 0, 0, 0, time.UTC)
+	inst.SetLimitReached(resetAt)
+
+	// An observer captures the epoch, then a resume lands.
+	observed := inst.StateEpoch()
+	inst.ClearLimitReached()
+
+	if applied := inst.SetLimitReachedAtEpoch(resetAt, observed); applied {
+		t.Fatal("a decision from a superseded epoch must not apply (#2135)")
+	}
+	if inst.LimitReached() {
+		t.Fatalf("liveness = %v, want LiveRunning: the resume must stand", inst.GetLiveness())
+	}
+	if got, ok := inst.LimitResetAt(); ok || !got.IsZero() {
+		t.Fatalf("reset time = (%v, %v), want (zero, false)", got, ok)
+	}
+
+	// A decision made about the CURRENT state still applies — the guard is
+	// per-observation, not a window in which detection is suppressed.
+	if applied := inst.SetLimitReachedAtEpoch(resetAt, inst.StateEpoch()); !applied {
+		t.Fatal("a decision at the current epoch must apply")
+	}
+	if !inst.LimitReached() {
+		t.Fatalf("liveness = %v, want LiveLimitReached", inst.GetLiveness())
+	}
+}
+
+// TestTransitionAtEpoch_DropsSupersededObservation: the same guard on the
+// liveness chokepoint. An unscoped event is unaffected — AtEpoch is opt-in, for
+// writers whose conclusion was drawn from an earlier observation.
+func TestTransitionAtEpoch_DropsSupersededObservation(t *testing.T) {
+	inst := newEpochTestInstance(t)
+	_ = inst.Transition(ObserveLiveness(LiveRunning))
+
+	observed := inst.StateEpoch()
+	inst.SetLimitReached(time.Time{}) // something newer lands
+
+	if err := inst.Transition(ObserveLiveness(LiveReady).AtEpoch(observed)); err != nil {
+		t.Fatalf("a superseded event must be dropped silently, got error %v", err)
+	}
+	if got := inst.GetLiveness(); got != LiveLimitReached {
+		t.Fatalf("liveness = %v, want LiveLimitReached (the stale Ready must not land)", got)
+	}
+
+	if err := inst.Transition(ObserveLiveness(LiveReady)); err != nil {
+		t.Fatalf("Transition: %v", err)
+	}
+	if got := inst.GetLiveness(); got != LiveReady {
+		t.Fatalf("liveness = %v, want LiveReady (an unscoped event still applies)", got)
+	}
+}
+
+// TestToInstanceDataWithEpoch_ReadsBothUnderOneLock: the payload and the epoch a
+// writer re-checks before persisting must describe the same instant, or the
+// re-check proves nothing about what is being written (#2135).
+func TestToInstanceDataWithEpoch_ReadsBothUnderOneLock(t *testing.T) {
+	inst := newEpochTestInstance(t)
+	resetAt := time.Date(2026, 7, 20, 18, 0, 0, 0, time.UTC)
+	inst.SetLimitReached(resetAt)
+
+	data, epoch := inst.ToInstanceDataWithEpoch()
+	if epoch != inst.StateEpoch() {
+		t.Fatalf("epoch = %d, want the instance's current %d", epoch, inst.StateEpoch())
+	}
+	if data.Liveness != LiveLimitReached || !data.LimitResetAt.Equal(resetAt) {
+		t.Fatalf("data = (%v, %v), want (LiveLimitReached, %v)", data.Liveness, data.LimitResetAt, resetAt)
+	}
+
+	inst.ClearLimitReached()
+	if epoch == inst.StateEpoch() {
+		t.Fatal("the epoch read earlier must not track later mutations")
+	}
+}

--- a/session/transition.go
+++ b/session/transition.go
@@ -88,10 +88,26 @@ func (k transitionKind) String() string {
 
 // TransitionEvent is a lifecycle event handed to Instance.Transition. Construct
 // one with the exported constructors below; lv is meaningful only for
-// ObserveLiveness.
+// ObserveLiveness. epoch/epochScoped are set only by AtEpoch.
 type TransitionEvent struct {
-	kind transitionKind
-	lv   Liveness
+	kind        transitionKind
+	lv          Liveness
+	epoch       uint64
+	epochScoped bool
+}
+
+// AtEpoch scopes an event to the state epoch its decision was made at (#2135):
+// Transition applies it only while the instance is still at that epoch, and
+// silently DROPS it once a newer authoritative transition has moved the state on.
+// Use it wherever the event is a conclusion drawn from an observation taken
+// earlier — the daemon poll settling liveness from pane content it captured a
+// moment ago — so a decision about a state the session has already left cannot
+// overwrite the one it moved to. Events constructed without it are unscoped and
+// apply unconditionally, exactly as before. See session/state_epoch.go.
+func (ev TransitionEvent) AtEpoch(epoch uint64) TransitionEvent {
+	ev.epoch = epoch
+	ev.epochScoped = true
+	return ev
 }
 
 // BeginCreate overlays OpCreating for an optimistic create (was SetStatus(Loading)).
@@ -395,6 +411,13 @@ func (i *Instance) Transition(ev TransitionEvent) error {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 
+	if ev.epochScoped && i.stateEpoch != ev.epoch {
+		// The decision behind this event was drawn from an observation that a newer
+		// authoritative transition has since superseded. Drop it — silently and
+		// without an error, since being out-competed by newer truth is not a
+		// mis-ordered edge (#2135). The observer re-decides on its next tick.
+		return nil
+	}
 	from := stateAxes{i.liveness, i.inFlightOp}
 	spec, ok := transitionTable[ev.kind]
 	if !ok {
@@ -430,6 +453,9 @@ func (i *Instance) Transition(ev TransitionEvent) error {
 	}
 	i.liveness = to.liveness
 	i.inFlightOp = to.op
+	// Every real change to the lifecycle state advances the epoch, so an observer
+	// holding an older one learns its in-flight decision is stale (#2135).
+	i.noteStateChangeLocked(from.liveness, from.op, i.limitResetAt)
 	switch spec.started {
 	case startedSet:
 		i.started = true


### PR DESCRIPTION
Fixes #2135.

## The race

The daemon poll **decides from a snapshot**: `refreshInstanceStatus` captures pane
content, and a moment later `resolveIdleLiveness` runs the usage-limit detector over
that capture and writes the result. A resume landing in between — the `c` retry or the
auto-resume scheduler — cleared the limit, re-delivered the prompt and persisted
`LiveRunning`; the poll then called `SetLimitReached` from content that predated all of
it and re-parked the session.

It reached **disk** too. `persistPollChange`'s reset-time arm fires *independently* of
the liveness compare (correctly — #1204's later-parsed reset time depends on it), so the
"unchanged" liveness (`LimitReached → LimitReached`) did not stop the flush, and the
changed reset time carried the reverted row through. The user saw a limit-blocked
session that was in fact working, and a daemon restart reloaded the wrong state.

## The fix

A **state epoch** on the instance (`session/state_epoch.go`): a generation counter
bumped under `i.mu` by every real change to the lifecycle state — both axes plus the
usage-limit reset time. An observer captures it *before* the observation it decides
from and hands it back when it applies:

- `instance.SetLimitReachedAtEpoch(resetAt, epoch)`
- `instance.Transition(session.ObserveLiveness(lv).AtEpoch(epoch))` — opt-in scoping on
  the existing #1195 chokepoint; unscoped events behave exactly as before.

Same epoch → the decision is still about the state it was made about, and applies.
Different epoch → something newer landed, and the decision is **dropped**. The check and
the write are one critical section under `i.mu`, so there is no window left where an
epoch read and a separate setter could be split.

It is **per-observation, not a time window**, which is what keeps it from
over-suppressing: a session that walks straight back into the wall after a resume is
parked again on the very *next* tick, from content captured after the resume. A
"suppress detection for N seconds after a resume" guard could not promise that.
Under-applying by one tick is recoverable; clobbering a newer transition is not.

`persistPollChange` gets the other half: it re-reads the payload under the repo start
lock when the epoch shows the state moved while it waited, so **the poll's gate decides
whether to write, never what**. Deliberately not "take the lock, then read once" — the
repo start lock is held across session creates, and taking it on every tick of every
session would park the whole poll behind an unrelated create.

No lock-order change: the epoch is instance-local state under `i.mu`, and
`resumeFromLimitLocked`'s target-before-op order (#2006) is untouched.

## Fail-first

Three of the four new daemon tests fail on `master`. The race test reproduces the issue
verbatim — memory **and** disk reverted:

```
=== RUN   TestResumeFromLimit_ConcurrentPollCannotRevertResume
    limit_resume_poll_race_test.go:96: in-memory liveness = 6, want LiveRunning: a poll deciding from PRE-resume content must not re-park the session (#2135)
    limit_resume_poll_race_test.go:99: in-memory liveness = 6, want LiveRunning (#2135)
    limit_resume_poll_race_test.go:102: in-memory reset time = (2026-07-20 18:00:00 +0000 UTC, true), want (zero, false) after a successful resume (#2135)
    limit_resume_poll_race_test.go:105: persisted liveness = 6, want LiveRunning: the stale poll must not reach disk (#2135)
    limit_resume_poll_race_test.go:108: persisted reset time = 2026-07-20 18:00:00 +0000 UTC, want zero (#2135)
--- FAIL: TestResumeFromLimit_ConcurrentPollCannotRevertResume (0.03s)
=== RUN   TestRefreshStatuses_GenuineLimitHitAfterResumeStillParks
    limit_resume_poll_race_test.go:136: precondition: the resumed session must not be limit-blocked, got 6
--- FAIL: TestRefreshStatuses_GenuineLimitHitAfterResumeStillParks (0.03s)
=== RUN   TestRefreshStatuses_OrdinaryPollUnaffectedByEpochGuard
--- PASS: TestRefreshStatuses_OrdinaryPollUnaffectedByEpochGuard (0.02s)
FAIL	github.com/sachiniyer/agent-factory/daemon	0.104s
```

(`liveness = 6` is `LiveLimitReached`.) The persist-window test fails on master the same
way:

```
=== RUN   TestPersistPollChange_ResumeDuringWriteWindowIsNotOverwritten
    limit_resume_poll_race_test.go:194: persisted liveness = 6, want LiveRunning: the poll must not overwrite a resume that landed while it waited for the write lock (#2135)
    limit_resume_poll_race_test.go:197: persisted reset time = 2026-07-20 18:00:00 +0000 UTC, want zero (#2135)
--- FAIL: TestPersistPollChange_ResumeDuringWriteWindowIsNotOverwritten (0.03s)
```

Both interleavings are driven deterministically from inside the code path (a backend
capture hook and a new `testHookPollBeforePersistLock`) — no goroutines, no sleeps, no
flake.

**Each half was ablated separately** to confirm it is load-bearing: reverting
`SetLimitReachedAtEpoch` → `SetLimitReached` fails the race test; dropping the
`persistPollChange` re-read fails the write-window test.

## Tests

- `daemon/limit_resume_poll_race_test.go` — the race, the persist window, the genuine
  fresh limit hit (over-suppression control), the ordinary idle poll (plain-path control).
- `session/state_epoch_test.go` — the epoch advances only on a real change, a superseded
  decision is dropped and a current one applies, `ToInstanceDataWithEpoch` reads payload
  and epoch under one lock.

## Gate

`gofmt -l .` clean · `golangci-lint run --timeout=3m --fast` clean · `go build ./...` ·
`deadcode -test ./...` clean · `scripts/lint-file-length.sh` passed · full
`make test-container` green (all packages) · `-race` run of the daemon + session limit
and status tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
