### PR TITLE
fix(tui): reset the default program when a project's config fails to resolve (#2138)

### DIFF
--- a/app/switch_project.go
+++ b/app/switch_project.go
@@ -409,9 +409,28 @@ func (m *home) switchProject(repo *config.RepoContext) (tea.Model, tea.Cmd) {
 
 	// Re-resolve the new project's default program for future sessions. AutoYes,
 	// BranchPrefix, etc. are global-only, so they do not change on switch.
+	//
+	// m.program is PROJECT-scoped state, so every path out of this block must
+	// land on a value derived from the INCOMING project: its own default_program
+	// when it sets one, the global default otherwise. What none of them may do is
+	// leave the OUTGOING project's program in place — task creation falls back to
+	// m.program without re-resolving config and PERSISTS it into tasks.json, so a
+	// carried-over value silently runs this project's tasks under the previous
+	// project's agent (#2138). Session creation is separately covered:
+	// preflightSessionCreate re-resolves and blocks.
 	if resolved, err := config.ResolveConfig(repo.Root); err == nil {
+		// A project that sets no default_program already arrives here as the
+		// global default: ResolveConfig seeds DefaultProgram from the global
+		// config and only overwrites it with a non-empty in-repo value, and a
+		// global config that loaded successfully always carries a valid — hence
+		// non-empty — default_program (validateConfig runs it through
+		// ValidateProgramEnum, which rejects ""). The empty case is therefore
+		// unreachable today; the else keeps the rule above true by construction
+		// rather than by that chain of reasoning holding forever.
 		if resolved.DefaultProgram != "" {
 			m.program = resolved.DefaultProgram
+		} else if m.appConfig != nil {
+			m.program = m.appConfig.DefaultProgram
 		}
 		m.store.SetHookCount(len(resolved.PostWorktreeCommands))
 		m.hooksPane.SetCommands(resolved.PostWorktreeCommands)
@@ -424,13 +443,11 @@ func (m *home) switchProject(repo *config.RepoContext) (tea.Model, tea.Cmd) {
 		// this only matters on an in-place switch.
 		m.store.SetHookCount(0)
 		m.hooksPane.SetCommands(nil)
-		// Reset the program for the same reason, and to the same target the
-		// success branch would land on for a project with no override: the global
-		// default (#2138). Leaving it alone kept the OUTGOING project's program,
-		// and task creation falls back to m.program without re-resolving config —
-		// so the stale value was PERSISTED into tasks.json and the new project's
-		// tasks ran under the previous project's agent. Session creation is
-		// already covered: preflightSessionCreate re-resolves and blocks.
+		// Same reasoning for the program (#2138): a config we cannot parse tells
+		// us nothing about this project's preference, so fall back to the global
+		// default — the value a project that expresses no preference gets. This
+		// branch is where the leak actually shipped, because it was the one path
+		// that left m.program untouched.
 		if m.appConfig != nil {
 			m.program = m.appConfig.DefaultProgram
 		}

--- a/app/switch_project.go
+++ b/app/switch_project.go
@@ -424,6 +424,16 @@ func (m *home) switchProject(repo *config.RepoContext) (tea.Model, tea.Cmd) {
 		// this only matters on an in-place switch.
 		m.store.SetHookCount(0)
 		m.hooksPane.SetCommands(nil)
+		// Reset the program for the same reason, and to the same target the
+		// success branch would land on for a project with no override: the global
+		// default (#2138). Leaving it alone kept the OUTGOING project's program,
+		// and task creation falls back to m.program without re-resolving config —
+		// so the stale value was PERSISTED into tasks.json and the new project's
+		// tasks ran under the previous project's agent. Session creation is
+		// already covered: preflightSessionCreate re-resolves and blocks.
+		if m.appConfig != nil {
+			m.program = m.appConfig.DefaultProgram
+		}
 	}
 
 	// Re-prime the projection from the snapshot fetched above (scoped to the new

--- a/app/switch_project_test.go
+++ b/app/switch_project_test.go
@@ -347,6 +347,126 @@ func TestSwitchProjectClearsHooksWhenConfigResolveFails(t *testing.T) {
 	assert.Empty(t, h.hooksPane.GetCommands(), "stale hooks from the previous project must be cleared, not carried over")
 }
 
+// writeInRepoConfig writes <root>/.agent-factory/config.toml with body.
+func writeInRepoConfig(t *testing.T, root, body string) {
+	t.Helper()
+	dir := filepath.Join(root, config.InRepoConfigDirName)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.toml"), []byte(body), 0o644))
+}
+
+// TestSwitchProjectResetsProgramWhenConfigResolveFails is the #2138 guarantee,
+// the m.program half of the #1686 hooks reset above: when ResolveConfig fails
+// for the incoming project (here, a corrupt IN-REPO config), the switch must
+// reset m.program to the global default rather than leave the OUTGOING
+// project's program in place. Session creation is protected by
+// preflightSessionCreate, which re-resolves and blocks; task creation is not —
+// it falls back to m.program and PERSISTS it into tasks.json, so a stale value
+// silently runs the new project's tasks under the previous project's agent.
+func TestSwitchProjectResetsProgramWhenConfigResolveFails(t *testing.T) {
+	h := newTestHome(t)
+	h.snapshotFetcher = func(string) (daemon.SnapshotResponse, error) {
+		return daemon.SnapshotResponse{}, nil
+	}
+
+	globalDefault := h.appConfig.DefaultProgram
+	require.NotEmpty(t, globalDefault, "precondition: the global config carries a default program")
+
+	// The outgoing project (A) set a non-global program, and its hooks are in
+	// the pane — both are project-scoped state that must not survive the switch.
+	h.program = "codex"
+	require.NotEqual(t, globalDefault, h.program, "precondition: the outgoing program differs from the global default")
+	h.hooksPane.SetCommands([]string{"echo 'project-a-hook'"})
+	h.store.SetHookCount(1)
+
+	// The incoming project (B) is a real git repo whose in-repo config cannot be
+	// parsed. Only B's config is corrupt: the global config stays valid, which is
+	// what makes "reset to the global default" a well-defined target.
+	projectBRoot := initTestGitRepo(t)
+	writeInRepoConfig(t, projectBRoot, "invalid toml {{{\n[broken")
+	repoB := &config.RepoContext{Root: projectBRoot, ID: config.RepoIDFromRoot(projectBRoot)}
+
+	_, err := config.ResolveConfig(projectBRoot)
+	require.Error(t, err, "precondition: ResolveConfig must fail with the corrupt in-repo config")
+	global, err := config.LoadConfig()
+	require.NoError(t, err, "precondition: the global config must still load")
+	require.Equal(t, globalDefault, global.DefaultProgram)
+
+	h.switchProject(repoB)
+
+	assert.Equal(t, projectBRoot, h.repoRoot, "repoRoot must be re-scoped to the new project")
+	assert.Equal(t, globalDefault, h.program,
+		"the outgoing project's program must be reset to the global default, not carried over (#2138)")
+	assert.Empty(t, h.hooksPane.GetCommands(), "hooks must still be cleared on a failed resolve (#1686)")
+	assert.Equal(t, 0, h.store.GetHookCount(), "the hook count must still be cleared on a failed resolve (#1686)")
+}
+
+// TestSwitchProjectAppliesProjectProgramWhenConfigResolves guards the success
+// branch the #2138 reset sits beside: a project whose in-repo config sets
+// default_program still wins over both the outgoing program and the global
+// default.
+func TestSwitchProjectAppliesProjectProgramWhenConfigResolves(t *testing.T) {
+	h := newTestHome(t)
+	h.snapshotFetcher = func(string) (daemon.SnapshotResponse, error) {
+		return daemon.SnapshotResponse{}, nil
+	}
+	h.program = "codex"
+
+	projectBRoot := initTestGitRepo(t)
+	writeInRepoConfig(t, projectBRoot, "default_program = \"aider\"\n")
+	repoB := &config.RepoContext{Root: projectBRoot, ID: config.RepoIDFromRoot(projectBRoot)}
+
+	h.switchProject(repoB)
+
+	assert.Equal(t, "aider", h.program, "the incoming project's default_program must win on a successful resolve")
+}
+
+// TestTaskCreateAfterFailedResolveUsesGlobalProgram is the user-visible half of
+// #2138: the leaked program was not just a field, it was PERSISTED. Creating a
+// task in a project whose config failed to resolve must record the global
+// default program, not the previous project's.
+func TestTaskCreateAfterFailedResolveUsesGlobalProgram(t *testing.T) {
+	h := newTestHome(t)
+	h.snapshotFetcher = func(string) (daemon.SnapshotResponse, error) {
+		return daemon.SnapshotResponse{}, nil
+	}
+	globalDefault := h.appConfig.DefaultProgram
+	h.program = "codex"
+
+	projectBRoot := initTestGitRepo(t)
+	writeInRepoConfig(t, projectBRoot, "invalid toml {{{\n[broken")
+	repoB := &config.RepoContext{Root: projectBRoot, ID: config.RepoIDFromRoot(projectBRoot)}
+	_, err := config.ResolveConfig(projectBRoot)
+	require.Error(t, err, "precondition: ResolveConfig must fail with the corrupt in-repo config")
+
+	h.switchProject(repoB)
+
+	// Drive the inline create form the way a user would: the program field is
+	// left on its default option, which is exactly the case that falls back to
+	// m.program in handleTaskCreate.
+	tp := h.automations.TaskPane()
+	_, _ = h.showTasksOverlay()
+	require.Equal(t, stateTasks, h.state)
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
+	require.True(t, tp.IsCreating(), "'n' must open the inline create form")
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("nightly")})
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> trigger selector (cron)
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> schedule picker (valid default)
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> prompt
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("do the thing")})
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> target session
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> path
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> program (default option)
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> save button
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyEnter})
+
+	saved, err := task.LoadTasks()
+	require.NoError(t, err)
+	require.Len(t, saved, 1, "the create must have reached disk")
+	assert.Equal(t, globalDefault, saved[0].Program,
+		"a task created after a failed resolve must carry the global default program, not the previous project's (#2138)")
+}
+
 // TestBuildProjectListUnionsSourcesWithCounts: the picker list unions the
 // cross-repo session snapshot (with counts), the root_agents opt-ins, and the
 // active project, deduped by repo root.

--- a/app/switch_project_test.go
+++ b/app/switch_project_test.go
@@ -421,6 +421,48 @@ func TestSwitchProjectAppliesProjectProgramWhenConfigResolves(t *testing.T) {
 	assert.Equal(t, "aider", h.program, "the incoming project's default_program must win on a successful resolve")
 }
 
+// TestSwitchProjectUsesGlobalDefaultWhenProjectSetsNoProgram locks the third
+// case beside the two above: a project whose config resolves FINE but sets no
+// default_program of its own must still land on the GLOBAL default, never the
+// outgoing project's program.
+//
+// This holds through ResolveConfig rather than through switchProject's `!= ""`
+// guard: ResolveConfig seeds res.DefaultProgram from the global config and only
+// overwrites it with a non-empty in-repo value, and a successfully loaded global
+// config always carries a valid (hence non-empty) default_program —
+// validateConfig runs it through ValidateProgramEnum, which rejects "". So
+// "project sets no default_program" already arrives as the global default. The
+// test pins that end-to-end behavior so it cannot regress silently into the same
+// leak shape as #2138 one branch over.
+func TestSwitchProjectUsesGlobalDefaultWhenProjectSetsNoProgram(t *testing.T) {
+	h := newTestHome(t)
+	h.snapshotFetcher = func(string) (daemon.SnapshotResponse, error) {
+		return daemon.SnapshotResponse{}, nil
+	}
+	globalDefault := h.appConfig.DefaultProgram
+	require.NotEmpty(t, globalDefault)
+
+	// (1) A valid in-repo config that configures OTHER keys but no program.
+	withConfig := initTestGitRepo(t)
+	writeInRepoConfig(t, withConfig, "post_worktree_commands = [\"echo hi\"]\n")
+	resolved, err := config.ResolveConfig(withConfig)
+	require.NoError(t, err, "precondition: this project's config must resolve cleanly")
+	require.Equal(t, globalDefault, resolved.DefaultProgram,
+		"precondition: a project with no default_program resolves to the global default")
+
+	h.program = "codex"
+	h.switchProject(&config.RepoContext{Root: withConfig, ID: config.RepoIDFromRoot(withConfig)})
+	assert.Equal(t, globalDefault, h.program,
+		"a project that sets no default_program must use the global default, not the outgoing project's program")
+
+	// (2) A project with no in-repo config at all — the common case.
+	noConfig := initTestGitRepo(t)
+	h.program = "codex"
+	h.switchProject(&config.RepoContext{Root: noConfig, ID: config.RepoIDFromRoot(noConfig)})
+	assert.Equal(t, globalDefault, h.program,
+		"a project with no in-repo config must use the global default, not the outgoing project's program")
+}
+
 // TestTaskCreateAfterFailedResolveUsesGlobalProgram is the user-visible half of
 // #2138: the leaked program was not just a field, it was PERSISTED. Creating a
 // task in a project whose config failed to resolve must record the global


### PR DESCRIPTION
Fixes #2138

## The bug

`switchProject` re-resolves the incoming project's config to pick up its default
program and hooks. When `config.ResolveConfig` **fails** — a corrupt in-repo
`.agent-factory/config.toml` — the error branch cleared the hook state
(`SetHookCount(0)` / `SetCommands(nil)`) but left `m.program` holding the
**outgoing** project's program.

Session creation is protected: `preflightSessionCreate` → `preflightConfig`
re-resolves and blocks. Task creation is not — `handleTaskCreate` falls back to
`program = m.program` without re-validating, so the stale program was
**persisted** into `tasks.json` and the new project's tasks ran under the
previous project's agent.

## The fix

Reset `m.program` to the global default (`m.appConfig.DefaultProgram`) in that
branch — symmetric with the hooks clear beside it, and the same value the
success branch lands on for a project that sets no `default_program` override.
The success branch is unchanged (project default when set, else current).

## Fail-first

```
=== RUN   TestSwitchProjectResetsProgramWhenConfigResolveFails
    switch_project_test.go:398:
        	Error:      	Not equal:
        	            	expected: "claude"
        	            	actual  : "codex"
        	Messages:   	the outgoing project's program must be reset to the global default, not carried over (#2138)
--- FAIL: TestSwitchProjectResetsProgramWhenConfigResolveFails (5.65s)
=== RUN   TestSwitchProjectAppliesProjectProgramWhenConfigResolves
--- PASS: TestSwitchProjectAppliesProjectProgramWhenConfigResolves (5.04s)
=== RUN   TestTaskCreateAfterFailedResolveUsesGlobalProgram
    switch_project_test.go:466:
        	Error:      	Not equal:
        	            	expected: "claude"
        	            	actual  : "codex"
        	Messages:   	a task created after a failed resolve must carry the global default program, not the previous project's (#2138)
--- FAIL: TestTaskCreateAfterFailedResolveUsesGlobalProgram (5.07s)
FAIL
```

Three tests:
- **`TestSwitchProjectResetsProgramWhenConfigResolveFails`** — the reset itself,
  plus the #1686 hooks clear is still intact (commands *and* count).
- **`TestTaskCreateAfterFailedResolveUsesGlobalProgram`** — the user-visible
  half: drives the real inline create form after the switch and asserts the
  task **on disk** carries the global default, not `codex`. This is what the
  issue's impact line describes, so it is locked at the persistence layer, not
  just the field.
- **`TestSwitchProjectAppliesProjectProgramWhenConfigResolves`** — no
  regression: a project whose in-repo config sets `default_program = "aider"`
  still wins over both the outgoing program and the global default.

Only the corrupt project's in-repo config is corrupted in the new tests (the
existing #1686 test corrupts the *global* config), which is what makes "the
global default" a well-defined target to reset to.

## Adjacent, not implemented

The deeper asymmetry is that the task-creation path never preflight-validates
config the way session creation does — a corrupt in-repo config blocks a new
session with a real error, but a task is created silently. Resetting
`m.program` closes the leak this issue reports; adding a symmetric preflight to
task creation is a user-facing behavior change (it turns a silent create into a
refusal), so it belongs in its own issue rather than riding along here.

## Follow-up: the success branch (review round 2)

Review flagged that the success branch's `if resolved.DefaultProgram != ""` has no `else`, so an empty resolved default would keep the outgoing program — the same leak shape one branch over.

**That case is unreachable today.** `ResolveConfig` seeds `DefaultProgram` from the global config and only overwrites it with a non-empty in-repo value; a global config that loads successfully always carries a valid, hence non-empty, `default_program` (`validateConfig` → `ValidateProgramEnum` rejects `""`). A project setting no `default_program` already arrives as the global default. `TestSwitchProjectUsesGlobalDefaultWhenProjectSetsNoProgram` **passes against master's `switchProject`** — it is a lock, not a second bug fix — and fails on both assertions with the `"codex"` leak shape when the success assignment is mutated away.

The `else` is added anyway: the reachability argument spans three files and four inference steps, none of them this file's invariant to keep. One line makes the rule true by construction — *project default if set, else global default, never the outgoing program*, on both branches — and the comment now states that rule, notes why the empty case is unreachable (so the `else` isn't deleted as dead code), and marks the error branch as where the leak actually shipped.

Gates re-run green after the follow-up: `gofmt` · `golangci-lint --fast` · `go build ./...` · `scripts/lint-file-length.sh` · full `go test ./app/...` (126s).

## Gates

`gofmt -l .` clean · `golangci-lint run --timeout=3m --fast` clean ·
`go build ./...` · `scripts/lint-file-length.sh` · `go test ./app/...` green
(116s, full package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

