### PR TITLE
fix(cli): detect --prompt with Changed(), so `send-prompt --prompt ""` reaches validation

### DIFF
--- a/api/sessions_sendprompt.go
+++ b/api/sessions_sendprompt.go
@@ -29,15 +29,28 @@ var (
 	sendPromptIncludeRootFlag bool
 )
 
+// promptFlagGiven reports whether --prompt was passed, empty value included.
+// `--prompt ""` is the flag being GIVEN with an empty value — a script whose
+// variable came back unset writes exactly that — not the flag being omitted, so
+// this asks cobra's Changed bit rather than testing the value (#2139). Testing
+// `sendPromptPromptFlag != ""` instead made an empty flag look like no flag: the
+// arity check went looking for a positional <prompt> the user never meant to
+// type and died on a misleading "takes exactly 2 positional argument(s)", while
+// the positional spelling of the same thing (`send-prompt <title> ""`) sailed
+// through. Same reasoning as --target-session in tasks.go.
+func promptFlagGiven(cmd *cobra.Command) bool {
+	return cmd.Flags().Changed("prompt")
+}
+
 // sendPromptArgCount is how many positionals send-prompt expects in the current
 // mode. The prompt comes from --prompt or the last positional, and --all drops
 // the <title>, so the arity is a 2x2 rather than a constant.
-func sendPromptArgCount() int {
+func sendPromptArgCount(cmd *cobra.Command) int {
 	want := 2 // <title> <prompt>
 	if sendPromptAllFlag {
 		want-- // broadcast has no target title
 	}
-	if sendPromptPromptFlag != "" {
+	if promptFlagGiven(cmd) {
 		want-- // the prompt came from the flag
 	}
 	return want
@@ -46,13 +59,13 @@ func sendPromptArgCount() int {
 // sendPromptUsage names the exact invocation the current flags imply, so an
 // arity error tells the user what to type instead of just counting (#658/#734:
 // a public CLI owes actionable errors).
-func sendPromptUsage() string {
+func sendPromptUsage(cmd *cobra.Command) string {
 	switch {
-	case sendPromptAllFlag && sendPromptPromptFlag != "":
+	case sendPromptAllFlag && promptFlagGiven(cmd):
 		return "af sessions send-prompt --all --prompt <prompt> (no positional arguments)"
 	case sendPromptAllFlag:
 		return "af sessions send-prompt --all <prompt>"
-	case sendPromptPromptFlag != "":
+	case promptFlagGiven(cmd):
 		return "af sessions send-prompt <title> --prompt <prompt>"
 	default:
 		return "af sessions send-prompt <title> <prompt>"
@@ -62,8 +75,8 @@ func sendPromptUsage() string {
 // resolveSendPrompt returns the prompt for this invocation and the positionals
 // with it removed, so callers read the title from a consistent place regardless
 // of which spelling the user chose.
-func resolveSendPrompt(args []string) (prompt string, rest []string) {
-	if sendPromptPromptFlag != "" {
+func resolveSendPrompt(cmd *cobra.Command, args []string) (prompt string, rest []string) {
+	if promptFlagGiven(cmd) {
 		return sendPromptPromptFlag, args
 	}
 	if len(args) == 0 {
@@ -101,9 +114,9 @@ results.`,
 		if err := validateSendPromptFlags(); err != nil {
 			return jsonError(err)
 		}
-		if want := sendPromptArgCount(); len(args) != want {
+		if want := sendPromptArgCount(cmd); len(args) != want {
 			return jsonError(fmt.Errorf("%s takes exactly %d positional argument(s); got %d",
-				sendPromptUsage(), want, len(args)))
+				sendPromptUsage(cmd), want, len(args)))
 		}
 		return nil
 	},
@@ -119,12 +132,12 @@ results.`,
 		}
 		// Re-check arity here too: unit tests drive RunE directly (bypassing
 		// Args), so indexing rest[0] below must not depend on Args having run.
-		if len(args) != sendPromptArgCount() {
+		if len(args) != sendPromptArgCount(cmd) {
 			return jsonError(fmt.Errorf("%s takes exactly %d positional argument(s); got %d",
-				sendPromptUsage(), sendPromptArgCount(), len(args)))
+				sendPromptUsage(cmd), sendPromptArgCount(cmd), len(args)))
 		}
 
-		prompt, rest := resolveSendPrompt(args)
+		prompt, rest := resolveSendPrompt(cmd, args)
 		if sendPromptAllFlag {
 			return runBroadcast(prompt)
 		}

--- a/api/sessions_sendprompt_test.go
+++ b/api/sessions_sendprompt_test.go
@@ -1,0 +1,253 @@
+package api
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// sendPromptFlagNames are every flag send-prompt owns, so a reset can clear both
+// the bound variable and cobra's Changed bit. Changed is load-bearing here —
+// `--prompt ""` is detected by it — and it is sticky across ParseFlags calls, so
+// a test that skipped it would inherit the previous invocation's "flag given".
+var sendPromptFlagNames = []string{"prompt", "create", "program", "all", "all-repos", "include-root"}
+
+// resetSendPromptState restores the pre-test flag values on cleanup and starts
+// the test from defaults, so package-level flag state never leaks between tests.
+func resetSendPromptState(t *testing.T) {
+	t.Helper()
+	prevPrompt := sendPromptPromptFlag
+	prevProgram := sendPromptProgramFlag
+	prevCreate := sendPromptCreateFlag
+	prevAll := sendPromptAllFlag
+	prevAllRepos := sendPromptAllReposFlag
+	prevRoot := sendPromptIncludeRootFlag
+	prevRepo := repoFlag
+	t.Cleanup(func() {
+		clearSendPromptFlags()
+		sendPromptPromptFlag = prevPrompt
+		sendPromptProgramFlag = prevProgram
+		sendPromptCreateFlag = prevCreate
+		sendPromptAllFlag = prevAll
+		sendPromptAllReposFlag = prevAllRepos
+		sendPromptIncludeRootFlag = prevRoot
+		repoFlag = prevRepo
+	})
+	clearSendPromptFlags()
+}
+
+// clearSendPromptFlags resets the bound variables and cobra's Changed bits to
+// the state a fresh process would start in.
+func clearSendPromptFlags() {
+	sendPromptPromptFlag = ""
+	sendPromptProgramFlag = ""
+	sendPromptCreateFlag = false
+	sendPromptAllFlag = false
+	sendPromptAllReposFlag = false
+	sendPromptIncludeRootFlag = false
+	for _, name := range sendPromptFlagNames {
+		if f := sessionsSendPromptCmd.Flags().Lookup(name); f != nil {
+			f.Changed = false
+		}
+	}
+}
+
+// parseSendPrompt runs argv through the real command's flag parser — the only
+// way to reproduce what cobra does with `--prompt ""` — and returns the leftover
+// positionals plus the error the Args validator gives them.
+func parseSendPrompt(t *testing.T, argv ...string) (rest []string, argsErr error) {
+	t.Helper()
+	clearSendPromptFlags()
+	if err := sessionsSendPromptCmd.ParseFlags(argv); err != nil {
+		t.Fatalf("ParseFlags(%q): %v", argv, err)
+	}
+	rest = sessionsSendPromptCmd.Flags().Args()
+	return rest, sessionsSendPromptCmd.Args(sessionsSendPromptCmd, rest)
+}
+
+// TestSendPromptEmptyPromptFlagIsNotAnArityError is the regression test for
+// #2139. `--prompt ""` is the flag being GIVEN with an empty value (a script
+// with an unset variable writes exactly that), not the flag being omitted.
+// Deciding on the value instead of on cobra's Changed bit made the command
+// expect a positional <prompt> the user never intended to type, so the
+// invocation died on a misleading "takes exactly 2 positional argument(s); got
+// 1" instead of reaching normal prompt handling — where the positional spelling
+// `send-prompt <title> ""` already lands.
+func TestSendPromptEmptyPromptFlagIsNotAnArityError(t *testing.T) {
+	resetSendPromptState(t)
+	silenceCLIOutput(t)
+
+	rest, err := parseSendPrompt(t, "mytitle", "--prompt", "")
+	if err != nil {
+		t.Fatalf("`send-prompt mytitle --prompt \"\"` was rejected before it could be validated: %v", err)
+	}
+	if len(rest) != 1 || rest[0] != "mytitle" {
+		t.Fatalf("positionals after parsing = %q, want [mytitle] (the title)", rest)
+	}
+
+	// The positional spelling of the same thing has always been accepted here.
+	// TestSendPromptDeliveryHonorsPromptFlag proves the two spellings then land
+	// on the same daemon request; this only pins that neither is turned away at
+	// the door.
+	if _, posErr := parseSendPrompt(t, "mytitle", ""); posErr != nil {
+		t.Fatalf("positional `send-prompt mytitle \"\"` errored: %v", posErr)
+	}
+}
+
+// TestSendPromptArity covers the 2x2 the arity check has to get right: --all
+// drops the <title>, an explicitly-given --prompt drops the <prompt>, and an
+// empty --prompt counts as given.
+func TestSendPromptArity(t *testing.T) {
+	resetSendPromptState(t)
+	silenceCLIOutput(t)
+
+	cases := []struct {
+		name    string
+		argv    []string
+		wantErr bool
+	}{
+		{"positional title and prompt", []string{"mytitle", "hi"}, false},
+		{"positional empty prompt", []string{"mytitle", ""}, false},
+		{"flag prompt", []string{"mytitle", "--prompt", "hi"}, false},
+		{"flag empty prompt", []string{"mytitle", "--prompt", ""}, false},
+		{"flag prompt rejects a stray positional", []string{"mytitle", "extra", "--prompt", "hi"}, true},
+		{"flag empty prompt rejects a stray positional", []string{"mytitle", "extra", "--prompt", ""}, true},
+		{"missing prompt", []string{"mytitle"}, true},
+		{"broadcast positional prompt", []string{"--all", "hi"}, false},
+		{"broadcast flag prompt", []string{"--all", "--prompt", "hi"}, false},
+		{"broadcast flag empty prompt takes no positionals", []string{"--all", "--prompt", ""}, false},
+		{"broadcast flag empty prompt rejects a positional", []string{"--all", "mytitle", "--prompt", ""}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseSendPrompt(t, tc.argv...)
+			if tc.wantErr && err == nil {
+				t.Fatalf("`send-prompt %s` was accepted, want an arity error", strings.Join(tc.argv, " "))
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("`send-prompt %s` was rejected: %v", strings.Join(tc.argv, " "), err)
+			}
+			// The error names the invocation the user should type, so it has to
+			// reflect the spelling they actually used (#658/#734).
+			if tc.wantErr && err != nil && strings.Contains(err.Error(), "--prompt") != usesPromptFlag(tc.argv) {
+				t.Fatalf("arity error for `send-prompt %s` names the wrong invocation: %v", strings.Join(tc.argv, " "), err)
+			}
+		})
+	}
+}
+
+// usesPromptFlag reports whether argv passes --prompt, so the arity test can
+// check the error names the invocation the user actually typed.
+func usesPromptFlag(argv []string) bool {
+	for _, a := range argv {
+		if a == "--prompt" {
+			return true
+		}
+	}
+	return false
+}
+
+// TestSendPromptDeliveryHonorsPromptFlag drives the real RunE end to end: every
+// spelling of the prompt must reach the daemon with the value the user meant,
+// and the two empty spellings must produce identical requests.
+func TestSendPromptDeliveryHonorsPromptFlag(t *testing.T) {
+	tmp := testguard.SocketTempDir(t)
+	t.Setenv("AGENT_FACTORY_HOME", tmp)
+	resetSendPromptState(t)
+	silenceCLIOutput(t)
+
+	repoRoot := filepath.Join(tmp, "repo")
+	if err := os.MkdirAll(repoRoot, 0755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	if out, err := exec.Command("git", "-C", repoRoot, "init").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v (%s)", err, out)
+	}
+	repo, err := config.RepoFromPath(repoRoot)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	raw, err := json.Marshal([]session.InstanceData{{Title: "mytitle", Path: repoRoot}})
+	if err != nil {
+		t.Fatalf("marshal instances: %v", err)
+	}
+	if err := config.SaveRepoInstances(repo.ID, raw); err != nil {
+		t.Fatalf("save instances: %v", err)
+	}
+
+	var gotReq daemon.SendPromptRequest
+	prevSend := sendPromptViaDaemon
+	sendPromptViaDaemon = func(req daemon.SendPromptRequest) error {
+		gotReq = req
+		return nil
+	}
+	t.Cleanup(func() { sendPromptViaDaemon = prevSend })
+
+	send := func(t *testing.T, argv ...string) daemon.SendPromptRequest {
+		t.Helper()
+		gotReq = daemon.SendPromptRequest{}
+		clearSendPromptFlags()
+		repoFlag = repoRoot
+		if err := sessionsSendPromptCmd.ParseFlags(argv); err != nil {
+			t.Fatalf("ParseFlags(%q): %v", argv, err)
+		}
+		rest := sessionsSendPromptCmd.Flags().Args()
+		if err := sessionsSendPromptCmd.Args(sessionsSendPromptCmd, rest); err != nil {
+			t.Fatalf("`send-prompt %s` failed arity validation: %v", strings.Join(argv, " "), err)
+		}
+		if err := sessionsSendPromptCmd.RunE(sessionsSendPromptCmd, rest); err != nil {
+			t.Fatalf("`send-prompt %s` returned error: %v", strings.Join(argv, " "), err)
+		}
+		return gotReq
+	}
+
+	t.Run("flag prompt is delivered", func(t *testing.T) {
+		req := send(t, "mytitle", "--prompt", "hi")
+		if req.Title != "mytitle" || req.Prompt != "hi" {
+			t.Fatalf("delivered (title %q, prompt %q), want (mytitle, hi)", req.Title, req.Prompt)
+		}
+	})
+
+	t.Run("positional prompt is delivered", func(t *testing.T) {
+		req := send(t, "mytitle", "hi")
+		if req.Title != "mytitle" || req.Prompt != "hi" {
+			t.Fatalf("delivered (title %q, prompt %q), want (mytitle, hi)", req.Title, req.Prompt)
+		}
+	})
+
+	t.Run("empty flag and empty positional are identical", func(t *testing.T) {
+		flagReq := send(t, "mytitle", "--prompt", "")
+		posReq := send(t, "mytitle", "")
+		if flagReq != posReq {
+			t.Fatalf("--prompt \"\" delivered %+v but positional \"\" delivered %+v; the two spellings must be identical", flagReq, posReq)
+		}
+		if flagReq.Title != "mytitle" || flagReq.Prompt != "" {
+			t.Fatalf("delivered (title %q, prompt %q), want (mytitle, \"\")", flagReq.Title, flagReq.Prompt)
+		}
+	})
+}
+
+// silenceCLIOutput points stdout/stderr at /dev/null for the test: the command
+// prints its JSON result and jsonError prints the failure, neither of which
+// belongs in test output.
+func silenceCLIOutput(t *testing.T) {
+	t.Helper()
+	devnull, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("open devnull: %v", err)
+	}
+	origStdout, origStderr := os.Stdout, os.Stderr
+	os.Stdout, os.Stderr = devnull, devnull
+	t.Cleanup(func() {
+		os.Stdout, os.Stderr = origStdout, origStderr
+		devnull.Close()
+	})
+}


### PR DESCRIPTION
Fixes #2139

## The bug

`sessions send-prompt` decided whether `--prompt` was provided by testing the
flag's *value*:

```go
if sendPromptPromptFlag != "" { ... }   // in sendPromptArgCount, sendPromptUsage, resolveSendPrompt
```

Cobra sets the value to `""` when you type `--prompt ""` — which is what a
script writes when its variable came back unset — so the flag being **given
with an empty value** was indistinguishable from the flag being **omitted**.
The arity check then went looking for a positional `<prompt>` the user never
meant to type:

```
$ af sessions send-prompt mytitle --prompt ""
af sessions send-prompt <title> <prompt> takes exactly 2 positional argument(s); got 1
```

The positional spelling of the same thing (`send-prompt mytitle ""`) passed
arity and continued to normal handling, so the two spellings disagreed.

## The fix

Ask cobra's `Changed("prompt")` instead of testing the value — the mechanism
already in the tree: `--target-session` distinguishes "flag not given" from
"given as empty" exactly this way (`api/tasks.go:494-501`, with the comment the
issue quotes). All three decision sites (`sendPromptArgCount`,
`sendPromptUsage`, `resolveSendPrompt`) now route through one
`promptFlagGiven(cmd)` helper. `--prompt ""` lands precisely where `""` as a
positional lands.

`sendPromptUsage` is included because it is the same predicate: without it the
arity error for `send-prompt a b --prompt ""` would tell the user to type the
positional form they didn't use.

## Second bug this closes

The old check also mis-counted the broadcast arity in the *permissive*
direction. `send-prompt --all mytitle --prompt ""` computed `want = 1`, was
**accepted**, and then broadcast the literal string `"mytitle"` as the prompt
to every session in scope. It is now the arity error it always should have
been — see the `broadcast flag empty prompt rejects a positional` case below.

## Fail-first output (on master, before the fix)

```
--- FAIL: TestSendPromptEmptyPromptFlagIsNotAnArityError (0.00s)
    sessions_sendprompt_test.go:90: `send-prompt mytitle --prompt ""` was rejected before it could be validated: af sessions send-prompt <title> <prompt> takes exactly 2 positional argument(s); got 1
--- FAIL: TestSendPromptArity (0.00s)
    --- FAIL: TestSendPromptArity/flag_empty_prompt (0.00s)
        sessions_sendprompt_test.go:138: `send-prompt mytitle --prompt ` was rejected: af sessions send-prompt <title> <prompt> takes exactly 2 positional argument(s); got 1
    --- FAIL: TestSendPromptArity/flag_empty_prompt_rejects_a_stray_positional (0.00s)
        sessions_sendprompt_test.go:135: `send-prompt mytitle extra --prompt ` was accepted, want an arity error
    --- FAIL: TestSendPromptArity/broadcast_flag_empty_prompt_takes_no_positionals (0.00s)
        sessions_sendprompt_test.go:138: `send-prompt --all --prompt ` was rejected: af sessions send-prompt --all <prompt> takes exactly 1 positional argument(s); got 0
    --- FAIL: TestSendPromptArity/broadcast_flag_empty_prompt_rejects_a_positional (0.00s)
        sessions_sendprompt_test.go:135: `send-prompt --all mytitle --prompt ` was accepted, want an arity error
--- FAIL: TestSendPromptDeliveryHonorsPromptFlag (0.02s)
    --- FAIL: TestSendPromptDeliveryHonorsPromptFlag/empty_flag_and_empty_positional_are_identical (0.00s)
        sessions_sendprompt_test.go:229: `send-prompt mytitle --prompt ` failed arity validation: af sessions send-prompt <title> <prompt> takes exactly 2 positional argument(s); got 1
FAIL
FAIL	github.com/sachiniyer/agent-factory/api	0.023s
```

All green after the fix.

## Tests

New `api/sessions_sendprompt_test.go`. The tests drive the **real** command
through `ParseFlags` → `Args` → `RunE`, because `--prompt ""` only exists as a
distinct state after cobra has parsed it — setting the bound variable by hand
would not reproduce the bug.

- `TestSendPromptEmptyPromptFlagIsNotAnArityError` — `--prompt ""` is not
  turned away at the door, same as the positional `""`.
- `TestSendPromptArity` — the full 2x2 (`--all` drops `<title>`, a given
  `--prompt` drops `<prompt>`), plus an assertion that each arity error names
  the invocation the user actually typed.
- `TestSendPromptDeliveryHonorsPromptFlag` — end-to-end through `RunE` with a
  stubbed daemon: `--prompt hi` and positional `hi` both deliver `"hi"`; the
  two empty spellings produce **identical** `SendPromptRequest`s. Omitting
  `--prompt` still takes the prompt from the positional.

The helpers reset cobra's `Changed` bits between invocations — it is sticky and
now load-bearing, so a test that skipped it would inherit the previous case's
state.

## Verification

- `gofmt -l .` — clean
- `golangci-lint run --timeout=3m --fast` — clean
- `go build ./...` — clean
- `scripts/lint-file-length.sh` — passed (834 files)
- `deadcode -test ./...` — clean
- `go test ./api/... ./parity/... -count=1` — passed

Scope is deliberately narrow: flag-was-provided detection only. No new
empty-prompt rejection is added — the issue's alternative — so `--prompt ""`
behaves exactly like the positional `""` that has always been accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)