### PR TITLE
test(app): make project-switch task path explicit

### DIFF
--- a/app/switch_project_test.go
+++ b/app/switch_project_test.go
@@ -483,14 +483,14 @@ func TestTaskCreateAfterFailedResolveUsesGlobalProgram(t *testing.T) {
 
 	h.switchProject(repoB)
 
-	// Drive the inline create form the way a user would: the program field is
-	// left on its default option, which is exactly the case that falls back to
-	// m.program in handleTaskCreate.
+	// Enter the form with the switched-to repo explicitly: this test is about the
+	// program fallback, not the list's `n` shortcut or its process-CWD fallback.
+	// The testbox intentionally copies the source without .git, so relying on its
+	// CWD would make form validation reject the unrelated project-path field.
 	tp := h.automations.TaskPane()
 	_, _ = h.showTasksOverlay()
 	require.Equal(t, stateTasks, h.state)
-	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
-	require.True(t, tp.IsCreating(), "'n' must open the inline create form")
+	tp.EnterCreateMode(projectBRoot)
 	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("nightly")})
 	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> trigger selector (cron)
 	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> schedule picker (valid default)


### PR DESCRIPTION
## What changed

The project-switch task-persistence regression test now enters the task form through `TaskPane.EnterCreateMode(projectBRoot)`, the existing path-bearing API, instead of detouring through the list's `n` shortcut and inheriting its process-CWD fallback.

## Why this is simpler

The test's contract is the program fallback after an incoming project's config fails to resolve. Its old setup accidentally added a second contract: the process CWD had to be a Git repository so the unrelated project-path field would validate. GitHub checkouts satisfy that by accident; the sanctioned testbox intentionally copies the source without `.git`, so the form was rejected before the task reached disk.

Supplying the already-created target repository directly removes that hidden environment dependency and keeps the regression test at the abstraction boundary it actually needs.

## Behavior

Production code is unchanged. The test still drives the same task form, leaves the program selector on its default option, submits through the same app handler, and asserts the same persisted value. Only the fixture's project path is now explicit.

## Validation

- `make test-container GOTESTARGS="./app -run TestTaskCreateAfterFailedResolveUsesGlobalProgram -count=10"`
- `make test-container`
- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (empty)
- `go build ./...`
- `deadcode -test ./...` (empty)
- `scripts/lint-file-length.sh`

Relates to #1241 and the structural-health lens in #1195.

— Captain Claude
