### PR TITLE
fix(tui-driver): reconstruct markers split by the interactive ║ border (#2145)

### DIFF
--- a/scripts/tui-driver-selftest.sh
+++ b/scripts/tui-driver-selftest.sh
@@ -114,6 +114,37 @@ _expect_wrapped_marker_recognized() {
     )
 }
 
+# _expect_interactive_wrapped_marker_recognized — regression proof for #2145,
+# the INTERACTIVE-mode variant of the case above. af_send_to_pane by definition
+# types into the pane that owns the keyboard, and that pane is framed with the
+# DOUBLE border ║ (ui/tabbed_window.go interactiveWindowStyle), not the rounded
+# │. A │-only reconstruction therefore saw no pane column at all on the one
+# screen it was always run against: every successful command paid the full 8s
+# false timeout (reproduced on four consecutive commands at 80x24).
+#
+# The stub is the shape captured live from that repro — marker AF553325DF split
+# across two rows by the pane's right ║ border, the continuation row resuming
+# flush against the left ║ — plus a sidebar tree-guide │ on the continuation
+# row, so the row carries BOTH glyphs and pins that $(NF - 1) still lands on the
+# pane cell in a mixed row rather than on a sidebar cell.
+#
+# This case and the #1994 one above are a PAIR, and neither alone is the lock:
+# splitting on only │ fails this one, splitting on only ║ fails that one. Both
+# green means the reconstruction is border-glyph agnostic, which is the actual
+# invariant — the driver does not know, and must not need to know, which frame
+# state the pane it is matching happens to be in.
+# shellcheck disable=SC2317  # dispatched indirectly via step(); not dead code.
+_expect_interactive_wrapped_marker_recognized() {
+    (
+        sleep() { :; }
+        af_capture() {
+            printf '  \xe2\x96\xbe  alpha        \xe2\x97\x8f  \xe2\x95\x91dev@host:~/sandbox/mock-repo-alpha$ : "AF553325D\xe2\x95\x91\n'
+            printf ' \xe2\x94\x82   \xe2\x94\x94 2 Terminal    \xe2\x95\x91F"; echo HELLO_2145                       \xe2\x95\x91\n'
+        }
+        _af_wait_for_pane_echo 'AF553325DF' 3 'interactive-mode wrapped delivery marker (#2145)'
+    )
+}
+
 # _enter_interactive_and_probe_literal_send — regression proof for #1504. The
 # literal sender used to pass the text as tmux command arguments, so leading
 # hyphens were parsed as flags and repeated semicolons were parsed as command
@@ -658,6 +689,7 @@ step "open beta's tab as a pane"                            af_open_pane
 step "enter interactive mode and probe literal send"         _enter_interactive_and_probe_literal_send
 step "send a wrapped command without echo false-timeout"     _expect_wrapped_send_no_timeout
 step "recognize a delivery marker split by a pane wrap (#1994)" _expect_wrapped_marker_recognized
+step "recognize a marker split by the interactive ║ border (#2145)" _expect_interactive_wrapped_marker_recognized
 # The command COMPUTES its marker (arithmetic expansion), so the sentinel we
 # assert on — SELFTEST_42 — appears ONLY in the command's output, never in the
 # echoed input line (which shows the literal $((6*7))). A shell that echoed

--- a/scripts/tui-driver.sh
+++ b/scripts/tui-driver.sh
@@ -133,22 +133,41 @@ af_wait_gone() {
     done
 }
 
-# _af_pane_column — for each captured row, the workspace pane's OWN text: the
-# cell between its box's two vertical borders (the second-to-last │-delimited
-# field). Rows with fewer than two borders — sidebar-only rows, the box's ─
-# top/bottom, an unframed full-screen capture — contribute nothing. Joined across
-# rows (via _af_join_lines_*), this reconstructs a line that wrapped INSIDE the
-# pane.
+# _AF_PANE_BORDER_FS — the field separator that splits a captured row on ANY
+# pane vertical border. A pane's frame glyph depends on its STATE, not on the
+# driver's mode-agnostic view of it: ordinary/selected/preview panes render the
+# rounded border │ (U+2502), while the pane that owns the keyboard in
+# interactive mode renders a DOUBLE border ║ (U+2551) — ui/tabbed_window.go's
+# interactiveWindowStyle, the #1089 "keystrokes go INTO this terminal" signal
+# that must read without color. Splitting on only one of them makes every
+# wrap-tolerant matcher below work in one mode and false-time-out in the other
+# (#2145), so every border is one separator set here and no caller
+# special-cases a mode.
 #
-# It splits on the LITERAL │ (U+2502) string, which is locale-safe. The old
-# _af_strip_screen_frame used bracket expressions ([│…]); in the sandbox's C
-# locale GNU grep/sed match those byte-by-byte, so they matched only the first
-# byte of the 3-byte glyph and mangled the strip (the same trap _af_tab_count
-# documents). It also removed only the FIRST and LAST border, so the sidebar's
-# own tree-guide │ became the "first border" and its cell text leaked between the
-# marker's halves — the two ways #1994's split marker went unrecognized.
+# The two glyphs are joined with an ERE ALTERNATION, never a bracket expression
+# ([│║]): the sandbox runs a C/POSIX locale where a bracket expression matches
+# byte-by-byte, so it would match single bytes of these 3-byte glyphs and
+# shred the row (the trap #1994 and _af_tab_count both document). Alternation
+# matches each glyph's literal byte sequence regardless of locale.
+: "${_AF_PANE_BORDER_FS:=│|║}"
+
+# _af_pane_column — for each captured row, the workspace pane's OWN text: the
+# cell between its box's two vertical borders (the second-to-last
+# border-delimited field). Rows with fewer than two borders — sidebar-only
+# rows, the box's ─/═ top/bottom, an unframed full-screen capture — contribute
+# nothing. Joined across rows (via _af_join_lines_*), this reconstructs a line
+# that wrapped INSIDE the pane.
+#
+# Taking $(NF - 1) — rather than stripping the first and last border — is what
+# makes the extra borders on a row harmless: the sidebar's own tree-guide │,
+# and the mixed row where a │-bordered sidebar/pane sits left of a ║-bordered
+# interactive pane. The old _af_strip_screen_frame removed only the FIRST and
+# LAST border, so a sidebar tree-guide │ became the "first border" and its cell
+# text leaked between the marker's halves — one of the two ways #1994's split
+# marker went unrecognized (its bracket-expression matching, see
+# _AF_PANE_BORDER_FS, was the other).
 _af_pane_column() {
-    awk -F'│' '
+    awk -F"$_AF_PANE_BORDER_FS" '
         NF >= 3 {
             cell = $(NF - 1)
             gsub(/\r/, "", cell)
@@ -175,6 +194,11 @@ _af_squash_ws() {
 # pane is framed by the TUI, so reconstruct the pane's own column and normalize
 # both "wrap inside a word" (tight join) and "wrap at whitespace" (spaced join)
 # before falling back to a whitespace-squashed comparison.
+#
+# The reconstruction is border-glyph agnostic (_AF_PANE_BORDER_FS): the caller
+# is usually af_send_to_pane, which by definition runs against the INTERACTIVE
+# pane and its ║ frame, so a │-only split matched nothing there and every
+# successful command paid the full 8s timeout (#2145).
 _af_wait_for_pane_echo() {
     local text="$1" timeout="${2:-8}" label="${3:-pane echo}" screen
     local tight spaced spaced_ws text_ws
@@ -757,7 +781,8 @@ af_close_tab() {
 # whitespace before its connector. A workspace pane, by contrast, is a
 # rounded-border box to the RIGHT of the sidebar, so tree-like text INSIDE a
 # pane (e.g. a shell printing `├ 1 foo`) is always preceded on its line by the
-# sidebar columns and the pane's own `│` border — never only whitespace — so it
+# sidebar columns and the pane's own border (`│`, or `║` when that pane is the
+# interactive one — _AF_PANE_BORDER_FS) — never only whitespace — so it
 # is NOT counted. Without the `^[[:space:]]*` anchor such pane output would
 # re-introduce af_close_tab false timeouts from the opposite direction (#1561
 # review). The `[0-9]+` index additionally keeps this off instance rows, which


### PR DESCRIPTION
Fixes #2145.

## The bug

`af_send_to_pane`'s wrap-tolerant marker reconstruction (`_af_pane_column`)
split each captured row on the rounded pane border `│` only.

But `af_send_to_pane` **by definition** types into the pane that owns the
keyboard, and that pane is framed with the **double** border `║` —
`ui/tabbed_window.go`'s `interactiveWindowStyle`, the #1089 signal that
"keystrokes go INTO this terminal" and that still reads without color. So a
marker wrapped at the interactive pane edge is split by `║`, the `│`-only
reconstruction found no pane column at all on the one screen it was ever run
against, and every *successful* command paid the full 8s false timeout.

This is the interactive-mode variant of the #1994 class: same reconstruction,
uncovered glyph.

## Repro (container sandbox, 80x24, master 2c0fce0)

Booted the TUI at 80x24 in the play-test container, created three bash-backed
sessions, entered a session pane, and sent four ordinary commands. All four ran
correctly; all four burned 8s:

```
### elapsed 8s for: echo HELLO_2145_A
### elapsed 8s for: echo HELLO_2145_B
### elapsed 8s for: echo HELLO_2145_C
### elapsed 8s for: echo HELLO_2145_D
```

with `[tui-driver] note: delivery marker ... not seen echoed` on each, over a
screen showing the marker split exactly as the issue reports:

```
                      ║dev@96b46a5c5d24:~/sandbox/mock-repo-alpha$ : "AF553325D║
  ▾  alpha         ●  ║F"; echo HELLO_2145_A                                   ║
     ⎇-dev/alpha      ║HELLO_2145_A                                            ║
```

Same sandbox, same 80x24 interactive pane, after the fix — markers still wrap
at the `║` border, confirmation is immediate:

```
### elapsed 1s for: echo POSTFIX_A
### elapsed 0s for: echo POSTFIX_B
### elapsed 0s for: echo POSTFIX_C
### elapsed 1s for: echo POSTFIX_D
```

## The fix

One separator set, `_AF_PANE_BORDER_FS`, covering every pane vertical border,
so the driver never needs to know — and no caller special-cases — which frame
state the pane it is matching happens to be in.

The two glyphs are joined with an ERE **alternation**, never a bracket
expression `[│║]`: the sandbox runs a C/POSIX locale where a bracket expression
matches byte-by-byte and would shred these 3-byte glyphs — the same trap #1994
and `_af_tab_count` document. Verified under gawk, mawk, and busybox awk.

The existing `$(NF - 1)` field choice needed no change: it already makes extra
borders on a row harmless, including the mixed row where a `│`-bordered sidebar
sits left of a `║`-bordered interactive pane.

No product code touched — the command always delivered correctly; only the
driver's echo detection was wrong.

## Test

New self-test case `_expect_interactive_wrapped_marker_recognized`, stubbed
against the shape captured live from the repro above (marker split by the pane's
right `║`, continuation row resuming flush against the left `║`, plus a sidebar
tree-guide `│` so the row carries **both** glyphs).

**Fail-first**, the new case run against master's `│`-only reconstruction:

```
MASTER-BEHAVIOUR: FAILED (timed out after 3s) <-- fail-first confirmed
```

The two marker cases are a **pair**, and neither alone is the lock — I checked
the inverse too, so a "fix" that merely swapped `│` for `║` cannot pass:

```
║-only: #1994 case FAILED -> the pair is the lock
```

**Post-fix**, full run — the previous 55 stay green:

```
>>> recognize a delivery marker split by a pane wrap (#1994)
    ✓ recognize a delivery marker split by a pane wrap (#1994)

>>> recognize a marker split by the interactive ║ border (#2145)
    ✓ recognize a marker split by the interactive ║ border (#2145)

=== SELF-TEST PASSED — 56/56 steps green ===
```

`shellcheck` clean on both changed scripts; `scripts/lint-file-length.sh`
passes. No Go changed.

## Audited, not changed

`_af_pane_header_row` anchors on the rounded `╭` and has the same one-glyph
blind spot, but its only caller (`af_hide_pane`) acts on a nav-mode keypress,
where no pane carries the interactive frame. Left alone rather than changed
speculatively; noted here so the next reader does not have to re-derive it.

— Captain Claude
