### PR TITLE
fix(session): a renamed tab frees its old name for reuse (#1957)

### DIFF
--- a/apiclient/control.go
+++ b/apiclient/control.go
@@ -76,13 +76,16 @@ func (c *Client) ResumeFromLimit(req daemon.ResumeFromLimitRequest) error {
 }
 
 // CreateTab asks the daemon to spawn, persist, and report a new process/shell
-// tab on an existing session, returning the resolved (collision-suffixed) name.
-func (c *Client) CreateTab(req daemon.CreateTabRequest) (string, error) {
+// tab on an existing session, returning the resolved (collision-suffixed) name
+// and the tmux session it was spawned under. Callers need BOTH: the two names
+// are independent namespaces that diverge after a rename (#1957), so the tmux
+// session cannot be re-derived from the tab name. See CreateTabResponse.TmuxName.
+func (c *Client) CreateTab(req daemon.CreateTabRequest) (string, string, error) {
 	var resp daemon.CreateTabResponse
 	if err := c.call("CreateTab", req, &resp); err != nil {
-		return "", err
+		return "", "", err
 	}
-	return resp.Name, nil
+	return resp.Name, resp.TmuxName, nil
 }
 
 // CloseTab asks the daemon to close a non-agent tab and returns the resolved

--- a/apiclient/control_test.go
+++ b/apiclient/control_test.go
@@ -74,13 +74,20 @@ func TestControlRoundTrips(t *testing.T) {
 		}
 	})
 
-	t.Run("CreateTab returns resolved name", func(t *testing.T) {
+	// Both names come back, and they DIFFER: the resolved tab name and the tmux
+	// session it was spawned under are independent namespaces post-#1957, so a
+	// client that dropped the second and re-derived it from the first would bind
+	// the TUI's instant-display projection to a different tab's live session.
+	t.Run("CreateTab returns resolved name and tmux name", func(t *testing.T) {
 		c := routeServer(t, "CreateTab", func([]byte) apiproto.Envelope {
-			return apiproto.Success(daemon.CreateTabResponse{Name: "shell-2"})
+			return apiproto.Success(daemon.CreateTabResponse{Name: "shell", TmuxName: "af_x_alpha__shell-2"})
 		})
-		name, err := c.CreateTab(daemon.CreateTabRequest{Title: "alpha", Shell: true})
-		if err != nil || name != "shell-2" {
-			t.Fatalf("CreateTab = %q, %v; want shell-2", name, err)
+		name, tmuxName, err := c.CreateTab(daemon.CreateTabRequest{Title: "alpha", Shell: true})
+		if err != nil || name != "shell" {
+			t.Fatalf("CreateTab name = %q, %v; want shell", name, err)
+		}
+		if tmuxName != "af_x_alpha__shell-2" {
+			t.Fatalf("CreateTab tmux name = %q; want af_x_alpha__shell-2", tmuxName)
 		}
 	})
 

--- a/app/creation_test.go
+++ b/app/creation_test.go
@@ -59,8 +59,8 @@ func newTestHome(t *testing.T) *home {
 	// override the relevant seam. createTab/closeTab default to an error so an
 	// unstubbed mutation fails loudly rather than reaching the daemon; setPRInfo
 	// defaults to a no-op so the in-memory PR-badge path stays exercisable.
-	t.Cleanup(SetTabCreatorForTest(func(title, repoID string) (string, error) {
-		return "", fmt.Errorf("createShellTabThroughDaemon not stubbed in test")
+	t.Cleanup(SetTabCreatorForTest(func(title, repoID string) (string, string, error) {
+		return "", "", fmt.Errorf("createShellTabThroughDaemon not stubbed in test")
 	}))
 	t.Cleanup(SetTabCloserForTest(func(title, repoID, tabName string) error {
 		return fmt.Errorf("closeTabThroughDaemon not stubbed in test")

--- a/app/daemon_mutation_routing_test.go
+++ b/app/daemon_mutation_routing_test.go
@@ -19,9 +19,9 @@ func TestHandleNewTab_RoutesThroughDaemon_NoLocalSave(t *testing.T) {
 	selectInstance(h, inst)
 
 	var gotTitle, gotRepo string
-	restore := SetTabCreatorForTest(func(title, repoID string) (string, error) {
+	restore := SetTabCreatorForTest(func(title, repoID string) (string, string, error) {
 		gotTitle, gotRepo = title, repoID
-		return spawnDaemonTab(inst), nil
+		return spawnDaemonTab(inst)
 	})
 	defer restore()
 
@@ -46,8 +46,8 @@ func TestHandleCloseTab_RoutesThroughDaemon_NoLocalSave(t *testing.T) {
 	selectInstance(h, inst)
 
 	var gotTitle, gotRepo, gotTab string
-	createRestore := SetTabCreatorForTest(func(title, repoID string) (string, error) {
-		return spawnDaemonTab(inst), nil
+	createRestore := SetTabCreatorForTest(func(title, repoID string) (string, string, error) {
+		return spawnDaemonTab(inst)
 	})
 	defer createRestore()
 	closeRestore := SetTabCloserForTest(func(title, repoID, tabName string) error {

--- a/app/handle_tabs.go
+++ b/app/handle_tabs.go
@@ -37,14 +37,15 @@ func (m *home) handleNewTab() (tea.Model, tea.Cmd) {
 		return m, m.handleError(fmt.Errorf("only local sessions support new tabs — this session's workspace runs off-box (docker/ssh/remote), so there is no local worktree to spawn a tab in"))
 	}
 
-	name, err := createShellTabThroughDaemon(selected.Title, m.repoID)
+	name, tmuxName, err := createShellTabThroughDaemon(selected.Title, m.repoID)
 	if err != nil {
 		return m, m.handleError(err)
 	}
 	// The daemon spawned and persisted the tab; reflect it locally for instant
-	// display without a second spawn. The daemon write is authoritative, so the
-	// TUI never saves (#960 PR 4).
-	if _, attachErr := selected.AttachShellTab(name); attachErr != nil {
+	// display without a second spawn, binding to the exact tmux session it
+	// reported rather than one re-derived from the name (#1957). The daemon write
+	// is authoritative, so the TUI never saves (#960 PR 4).
+	if _, attachErr := selected.AttachShellTab(name, tmuxName); attachErr != nil {
 		return m, m.handleError(attachErr)
 	}
 

--- a/app/pane_tab_reconcile_test.go
+++ b/app/pane_tab_reconcile_test.go
@@ -28,8 +28,8 @@ func TestPane_CloseTabRebindsPanes(t *testing.T) {
 	selectInstance(h, inst)
 	resizeHome(h, 200, 40)
 
-	restore := SetTabCreatorForTest(func(title, repoID string) (string, error) {
-		return spawnDaemonTab(inst), nil
+	restore := SetTabCreatorForTest(func(title, repoID string) (string, string, error) {
+		return spawnDaemonTab(inst)
 	})
 	defer restore()
 	_, _ = h.handleNewTab() // agent + shell + shell-2
@@ -68,8 +68,8 @@ func TestPane_SnapshotTabRemovalRebindsPanes(t *testing.T) {
 	selectInstance(h, inst)
 	resizeHome(h, 200, 40)
 
-	restore := SetTabCreatorForTest(func(title, repoID string) (string, error) {
-		return spawnDaemonTab(inst), nil
+	restore := SetTabCreatorForTest(func(title, repoID string) (string, string, error) {
+		return spawnDaemonTab(inst)
 	})
 	defer restore()
 	_, _ = h.handleNewTab() // agent + shell + shell-2; opens the slot-2 pane
@@ -105,8 +105,8 @@ func TestPane_SnapshotTabRemovalKeepsUnaffectedPaneBinding(t *testing.T) {
 	selectInstance(h, inst)
 	resizeHome(h, 200, 40)
 
-	restore := SetTabCreatorForTest(func(title, repoID string) (string, error) {
-		return spawnDaemonTab(inst), nil
+	restore := SetTabCreatorForTest(func(title, repoID string) (string, string, error) {
+		return spawnDaemonTab(inst)
 	})
 	defer restore()
 	_, _ = h.handleNewTab() // agent + shell + shell-2; opens the slot-2 pane

--- a/app/session_control.go
+++ b/app/session_control.go
@@ -277,16 +277,20 @@ func resumeStatusPollThroughDaemon(title, repoID string) error {
 
 // createShellTabThroughDaemon routes the TUI's `t` (new shell tab) mutation to
 // the daemon so the daemon — the single writer (#960) — owns the spawn and the
-// persist, returning the resolved tab name. The TUI reflects the new tab locally
-// for instant display via Instance.AttachShellTab.
-var createShellTabThroughDaemon = func(title, repoID string) (string, error) {
-	var name string
+// persist, returning the resolved tab name AND the tmux session the daemon
+// spawned it under. The TUI reflects the new tab locally for instant display via
+// Instance.AttachShellTab, which binds to that exact session: the two names are
+// independent namespaces that diverge after a rename (#1957), so re-deriving the
+// session from the tab name would attach the projection to a DIFFERENT tab's
+// live session.
+var createShellTabThroughDaemon = func(title, repoID string) (string, string, error) {
+	var name, tmuxName string
 	err := withDaemonHTTP(func(c *apiclient.Client) error {
 		var e error
-		name, e = c.CreateTab(daemon.CreateTabRequest{Title: title, RepoID: repoID, Shell: true})
+		name, tmuxName, e = c.CreateTab(daemon.CreateTabRequest{Title: title, RepoID: repoID, Shell: true})
 		return e
 	})
-	return name, err
+	return name, tmuxName, err
 }
 
 // closeTabThroughDaemon routes the TUI's `w` (close tab) mutation to the daemon,
@@ -427,7 +431,7 @@ func SetLimitResumerForTest(f func(title, repoID string) error) func() {
 	return func() { resumeFromLimitThroughDaemon = prev }
 }
 
-func SetTabCreatorForTest(f func(title, repoID string) (string, error)) func() {
+func SetTabCreatorForTest(f func(title, repoID string) (string, string, error)) func() {
 	prev := createShellTabThroughDaemon
 	createShellTabThroughDaemon = f
 	return func() { createShellTabThroughDaemon = prev }

--- a/app/single_writer_test.go
+++ b/app/single_writer_test.go
@@ -29,8 +29,8 @@ func TestTUIHasNoInstancesWritePath(t *testing.T) {
 	require.NotNil(t, cmd, "quit must still proceed")
 
 	// new shell tab: routed through the daemon (stubbed), reflected locally only.
-	createRestore := SetTabCreatorForTest(func(title, repoID string) (string, error) {
-		return spawnDaemonTab(inst), nil
+	createRestore := SetTabCreatorForTest(func(title, repoID string) (string, string, error) {
+		return spawnDaemonTab(inst)
 	})
 	defer createRestore()
 	_, _ = h.handleNewTab()

--- a/app/tab_hotkeys_test.go
+++ b/app/tab_hotkeys_test.go
@@ -143,13 +143,17 @@ func registerDaemonSpawn(t *testing.T, inst *session.Instance, spawn func(string
 
 // spawnDaemonTab is the shared body of every stubbed daemon CreateTab: derive
 // the next shell tab name, mark that sibling session alive in the mock (the
-// daemon's server-side spawn), and return the name for the TUI to attach to.
-func spawnDaemonTab(inst *session.Instance) string {
+// daemon's server-side spawn), and return the name AND the tmux session name for
+// the TUI to attach to — both, as the real RPC does since #1957, so the stub
+// can't quietly re-establish the name-derives-the-session assumption the fix
+// removed.
+func spawnDaemonTab(inst *session.Instance) (string, string, error) {
 	name := nextShellTabName(inst.GetTabs())
+	tmuxName := inst.TabTmuxName(0) + "__" + name
 	if spawn := daemonSpawnHooks[inst]; spawn != nil {
-		spawn(inst.TabTmuxName(0) + "__" + name)
+		spawn(tmuxName)
 	}
-	return name
+	return name, tmuxName, nil
 }
 
 // startedLocalInstance is freshLocalInstance plus one on-demand shell tab
@@ -203,9 +207,9 @@ func nextShellTabName(tabs []*session.Tab) string {
 func stubTabDaemonSeams(t *testing.T, inst *session.Instance) (created, closed *int) {
 	t.Helper()
 	var c, d int
-	t.Cleanup(SetTabCreatorForTest(func(title, repoID string) (string, error) {
+	t.Cleanup(SetTabCreatorForTest(func(title, repoID string) (string, string, error) {
 		c++
-		return spawnDaemonTab(inst), nil
+		return spawnDaemonTab(inst)
 	}))
 	t.Cleanup(SetTabCloserForTest(func(title, repoID, tabName string) error {
 		d++

--- a/app/tree_nav_test.go
+++ b/app/tree_nav_test.go
@@ -151,9 +151,9 @@ func TestTreeNav_TabStopAcrossInstancePreservesParentForActions(t *testing.T) {
 		"instance actions resolve the selected tab's parent instance")
 
 	var createdFor string
-	t.Cleanup(SetTabCreatorForTest(func(title, repoID string) (string, error) {
+	t.Cleanup(SetTabCreatorForTest(func(title, repoID string) (string, string, error) {
 		createdFor = title
-		return spawnDaemonTab(beta), nil
+		return spawnDaemonTab(beta)
 	}))
 
 	_, _ = h.handleNewTab()
@@ -206,8 +206,8 @@ func TestTreeNav_TabCreateCloseFromTabRow(t *testing.T) {
 	selectInstance(h, inst)
 
 	var closedNames []string
-	t.Cleanup(SetTabCreatorForTest(func(title, repoID string) (string, error) {
-		return spawnDaemonTab(inst), nil
+	t.Cleanup(SetTabCreatorForTest(func(title, repoID string) (string, string, error) {
+		return spawnDaemonTab(inst)
 	}))
 	t.Cleanup(SetTabCloserForTest(func(title, repoID, tabName string) error {
 		closedNames = append(closedNames, tabName)

--- a/daemon/close_tab_test.go
+++ b/daemon/close_tab_test.go
@@ -129,7 +129,7 @@ func TestCloseTab_RejectsArchivedSession(t *testing.T) {
 	const title = "worker"
 	inst := startedLocalTabInstance(t, manager, repo.ID, repoPath, title, "af_"+title+"_agent")
 	const target = "http://localhost:3000"
-	if _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Kind: "web", URL: target, Name: "webpreview"}); err != nil {
+	if _, _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Kind: "web", URL: target, Name: "webpreview"}); err != nil {
 		t.Fatalf("CreateTab(web): %v", err)
 	}
 
@@ -195,7 +195,7 @@ func TestCloseTab_ArchiveWinningOpLockRaceKeepsWebTab(t *testing.T) {
 	const title = "worker"
 	inst := startedLocalTabInstance(t, manager, repo.ID, repoPath, title, "af_"+title+"_agent")
 	const target = "http://localhost:3000"
-	if _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Kind: "web", URL: target, Name: "webpreview"}); err != nil {
+	if _, _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Kind: "web", URL: target, Name: "webpreview"}); err != nil {
 		t.Fatalf("CreateTab(web): %v", err)
 	}
 
@@ -453,7 +453,7 @@ func TestCloseTab_SerializedWithInFlightKillDoesNotCloseStaleTab(t *testing.T) {
 
 	exec, isAlive := closeBlockingTabExec(map[string]bool{agentName: true}, processTmuxName, killStarted, releaseKill)
 	inst := startedLocalTabInstanceWithExec(t, manager, repoID, repoPath, title, agentName, exec)
-	if _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Command: "btop"}); err != nil {
+	if _, _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Command: "btop"}); err != nil {
 		t.Fatalf("CreateTab: %v", err)
 	}
 	if !isAlive(processTmuxName) {

--- a/daemon/control_server.go
+++ b/daemon/control_server.go
@@ -300,11 +300,12 @@ func (s *controlServer) CreateTab(req CreateTabRequest, resp *CreateTabResponse)
 	if err := validateRPCRepoID(req.RepoID); err != nil {
 		return err
 	}
-	name, err := s.manager.CreateTab(req)
+	name, tmuxName, err := s.manager.CreateTab(req)
 	if err != nil {
 		return err
 	}
 	resp.Name = name
+	resp.TmuxName = tmuxName
 	return nil
 }
 

--- a/daemon/control_types.go
+++ b/daemon/control_types.go
@@ -255,6 +255,18 @@ type CreateTabRequest struct {
 
 type CreateTabResponse struct {
 	Name string `json:"name"`
+	// TmuxName is the tmux session the tab was actually spawned under, or empty
+	// for a kind that owns no PTY (web, vscode — see session.TabKind.HasTmux).
+	//
+	// It is normally "<agent session>__<name>", but the two are independent
+	// namespaces and diverge after a rename (#1957): a tab named "fresh" spawns
+	// under "…__fresh-2" when an earlier tab that was renamed AWAY from "fresh"
+	// still holds "…__fresh". Reporting it is what lets the TUI attach its
+	// instant-display projection to the exact session (Instance.AttachShellTab)
+	// instead of re-deriving one from the name and landing on the older tab's.
+	// It also makes the reservation inspectable rather than invisible, which is
+	// the complaint #1957 opened with.
+	TmuxName string `json:"tmux_name,omitempty"`
 }
 
 // CloseTabRequest asks the daemon to close a non-agent tab of a session and

--- a/daemon/create_tab_archive_test.go
+++ b/daemon/create_tab_archive_test.go
@@ -104,7 +104,7 @@ func TestCreateTab_RejectedAfterArchive(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, exists(srcPath), "archive must have moved the worktree out of its original path")
 
-	_, err = manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Command: "btop"})
+	_, _, err = manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Command: "btop"})
 	require.Error(t, err, "CreateTab on an archived session must be rejected")
 	assert.Contains(t, err.Error(), "archived")
 	assert.False(t, isAlive(agentName+"__btop"), "no process tmux session may be spawned into the moved-away worktree")
@@ -139,7 +139,7 @@ func TestCreateTab_SerializedWithInFlightArchiveDoesNotOrphan(t *testing.T) {
 	}
 	done := make(chan result, 1)
 	go func() {
-		name, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Command: "btop"})
+		name, _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Command: "btop"})
 		done <- result{name, err}
 	}()
 
@@ -176,7 +176,7 @@ func TestArchiveSession_ModeBTearsDownExtraTabsNoOrphan(t *testing.T) {
 	// Give the session a second (process) tab BEFORE archiving, so the archive
 	// teardown has an extra live tmux session it must not orphan into the worktree
 	// it is about to move.
-	_, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Command: "btop"})
+	_, _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Command: "btop"})
 	require.NoError(t, err, "a process tab must spawn on a live session")
 	require.Equal(t, 2, inst.TabCount(), "the session now has agent + process tabs")
 	require.True(t, isAlive(agentName+"__btop"), "the process tab's tmux session is live before archive")
@@ -203,7 +203,7 @@ func TestCreateTab_ShellRejectedAfterArchive(t *testing.T) {
 	_, _, err := manager.ArchiveSession(ArchiveSessionRequest{Title: title, RepoID: repoID})
 	require.NoError(t, err)
 
-	_, err = manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Shell: true})
+	_, _, err = manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Shell: true})
 	require.Error(t, err, "shell CreateTab on an archived session must be rejected")
 	assert.Contains(t, err.Error(), "archived")
 	assert.False(t, isAlive(agentName+"__shell"), "no shell tmux session may be spawned into the moved-away worktree")

--- a/daemon/create_tab_renamed_name_test.go
+++ b/daemon/create_tab_renamed_name_test.go
@@ -1,0 +1,137 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+)
+
+// TestCreateTab_ReusesTheNameARenamedTabGaveUp is the #1957 repro at the RPC
+// layer — the CLI sequence from the issue, verbatim:
+//
+//	af sessions tab-rename beta --name fresh --new-name fresh-old
+//	af sessions tab-create beta --command … --name fresh   -> {"name":"fresh-2"}
+//
+// The roster held nothing named "fresh", and the user got "fresh-2" anyway,
+// because the renamed tab's still-live tmux session kept the old NAME reserved.
+// The reservation was real but charged to the wrong namespace: it is the SPAWN
+// that must dodge the live session ("…__fresh-2"), not the name the user typed.
+//
+// This exercises the whole daemon path — resolve, spawn, persist, respond — and
+// asserts the response reports BOTH names, since they now differ and the TUI's
+// instant-display attach binds to the second (Instance.AttachShellTab).
+func TestCreateTab_ReusesTheNameARenamedTabGaveUp(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	const title = "beta"
+	agentName := "af_" + title + "_agent"
+	startedLocalTabInstance(t, manager, repo.ID, repoPath, title, agentName)
+
+	name, tmuxName, err := manager.CreateTab(CreateTabRequest{
+		Title: title, RepoID: repo.ID, Command: "btop", Name: "fresh",
+	})
+	if err != nil {
+		t.Fatalf("CreateTab(fresh): %v", err)
+	}
+	if name != "fresh" || tmuxName != agentName+"__fresh" {
+		t.Fatalf("CreateTab(fresh) = %q/%q, want fresh/%s__fresh", name, tmuxName, agentName)
+	}
+
+	renamed, err := manager.RenameTab(RenameTabRequest{
+		Title: title, RepoID: repo.ID, TabName: "fresh", NewName: "fresh-old",
+	})
+	if err != nil {
+		t.Fatalf("RenameTab: %v", err)
+	}
+	if renamed != "fresh-old" {
+		t.Fatalf("RenameTab = %q, want fresh-old", renamed)
+	}
+
+	// Nothing on the roster is called "fresh" now, so asking for it must get it.
+	name, tmuxName, err = manager.CreateTab(CreateTabRequest{
+		Title: title, RepoID: repo.ID, Command: "btop", Name: "fresh",
+	})
+	if err != nil {
+		t.Fatalf("CreateTab(fresh, second): %v", err)
+	}
+	if name != "fresh" {
+		t.Fatalf("CreateTab returned %q for a name no tab holds; want fresh (#1957)", name)
+	}
+	if tmuxName != agentName+"__fresh-2" {
+		t.Fatalf("spawned tmux session = %q, want %s__fresh-2 — it must miss the renamed tab's live session",
+			tmuxName, agentName)
+	}
+
+	// And the persisted roster agrees, so a restart rebinds each tab to its own
+	// session rather than two tabs racing for one.
+	snap := snapshotTabs(t, manager, repo.ID, title)
+	names := arrangeTabNames(snap)
+	want := []string{"agent", "fresh-old", "fresh"}
+	if len(names) != len(want) {
+		t.Fatalf("persisted roster %v, want %v", names, want)
+	}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Fatalf("persisted roster %v, want %v", names, want)
+		}
+	}
+	seen := map[string]string{}
+	for _, td := range snap.Tabs {
+		if td.TmuxName == "" {
+			continue
+		}
+		if prev, dup := seen[td.TmuxName]; dup {
+			t.Fatalf("tabs %q and %q share the tmux session %q", prev, td.Name, td.TmuxName)
+		}
+		seen[td.TmuxName] = td.Name
+	}
+}
+
+// TestCreateTab_ReportsNoTmuxNameForATmuxlessKind: a web tab owns no PTY, so the
+// response's tmux name is empty rather than a fabricated "<agent>__<name>" that
+// names nothing. The TUI's attach path never runs for these kinds — they are
+// materialized by the roster alone (see ReconcileTabsFromData) — and an invented
+// session name would be a lie a later reader could act on.
+func TestCreateTab_ReportsNoTmuxNameForATmuxlessKind(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	const title = "webby"
+	startedLocalTabInstance(t, manager, repo.ID, repoPath, title, "af_"+title+"_agent")
+
+	name, tmuxName, err := manager.CreateTab(CreateTabRequest{
+		Title: title, RepoID: repo.ID, Kind: "web", URL: "http://localhost:5173", Name: "preview",
+	})
+	if err != nil {
+		t.Fatalf("CreateTab(web): %v", err)
+	}
+	if name != "preview" {
+		t.Fatalf("CreateTab(web) name = %q, want preview", name)
+	}
+	if tmuxName != "" {
+		t.Fatalf("CreateTab(web) tmux name = %q, want empty — a web tab owns no session", tmuxName)
+	}
+	if !tabNamed(snapshotTabs(t, manager, repo.ID, title), "preview") {
+		t.Fatal("the web tab was not persisted")
+	}
+}

--- a/daemon/create_tab_test.go
+++ b/daemon/create_tab_test.go
@@ -156,7 +156,7 @@ func TestCreateTab_RejectsEmptyCommand(t *testing.T) {
 		t.Fatalf("NewManager: %v", err)
 	}
 
-	if _, err := manager.CreateTab(CreateTabRequest{Title: "x", Command: "   "}); err == nil {
+	if _, _, err := manager.CreateTab(CreateTabRequest{Title: "x", Command: "   "}); err == nil {
 		t.Fatal("expected error for empty command, got nil")
 	}
 }
@@ -187,7 +187,7 @@ func TestCreateTab_RejectsRemoteInstance(t *testing.T) {
 	manager.instances[daemonInstanceKey(repo.ID, "rem")] = inst
 	manager.mu.Unlock()
 
-	_, err = manager.CreateTab(CreateTabRequest{Title: "rem", RepoID: repo.ID, Command: "btop"})
+	_, _, err = manager.CreateTab(CreateTabRequest{Title: "rem", RepoID: repo.ID, Command: "btop"})
 	assertTabRejection(t, err, "only local sessions support user-managed tabs")
 }
 
@@ -211,7 +211,7 @@ func TestCreateTab_SpawnsPersistsAndReturnsName(t *testing.T) {
 	agentName := "af_" + title + "_agent"
 	startedLocalTabInstance(t, manager, repo.ID, repoPath, title, agentName)
 
-	name, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Command: "btop -t"})
+	name, _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Command: "btop -t"})
 	if err != nil {
 		t.Fatalf("CreateTab: %v", err)
 	}
@@ -274,7 +274,7 @@ func TestCreateTab_ShellSpawnsPersistsAndReturnsName(t *testing.T) {
 	startedLocalTabInstance(t, manager, repo.ID, repoPath, title, agentName)
 
 	// Shell=true ignores Command and creates a $SHELL tab named "shell".
-	name, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Shell: true})
+	name, _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Shell: true})
 	if err != nil {
 		t.Fatalf("CreateTab(shell): %v", err)
 	}
@@ -337,6 +337,6 @@ func TestCreateTab_ShellRejectsRemoteInstance(t *testing.T) {
 	manager.instances[daemonInstanceKey(repo.ID, "rem")] = inst
 	manager.mu.Unlock()
 
-	_, err = manager.CreateTab(CreateTabRequest{Title: "rem", RepoID: repo.ID, Shell: true})
+	_, _, err = manager.CreateTab(CreateTabRequest{Title: "rem", RepoID: repo.ID, Shell: true})
 	assertTabRejection(t, err, "only local sessions support user-managed tabs")
 }

--- a/daemon/create_tab_vscode_test.go
+++ b/daemon/create_tab_vscode_test.go
@@ -36,7 +36,7 @@ func newVSCodeCreateFixture(t *testing.T) (m *Manager, repoID, title string) {
 func TestCreateTab_VSCodeKind(t *testing.T) {
 	manager, repoID, title := newVSCodeCreateFixture(t)
 
-	name, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Kind: "vscode"})
+	name, _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Kind: "vscode"})
 	if err != nil {
 		t.Fatalf("CreateTab(vscode): %v", err)
 	}
@@ -75,7 +75,7 @@ func TestCreateTab_VSCodeRejectsTargets(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			req := tc.req
 			req.Title, req.RepoID = title, repoID
-			_, err := manager.CreateTab(req)
+			_, _, err := manager.CreateTab(req)
 			if err == nil {
 				t.Fatalf("CreateTab(%+v) succeeded; want a rejection", tc.req)
 			}
@@ -92,7 +92,7 @@ func TestCreateTab_VSCodeRejectsTargets(t *testing.T) {
 func TestCreateTab_UnknownKindNamesTheVocabulary(t *testing.T) {
 	manager, repoID, title := newVSCodeCreateFixture(t)
 
-	_, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Kind: "emacs"})
+	_, _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Kind: "emacs"})
 	if err == nil {
 		t.Fatal("CreateTab with an unknown kind succeeded; want a rejection")
 	}
@@ -112,7 +112,7 @@ func TestCloseTab_StopsEditorOnlyWithTheLastVSCodeTab(t *testing.T) {
 	inst := manager.instances[key]
 
 	for _, n := range []string{"one", "two"} {
-		if _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Kind: "vscode", Name: n}); err != nil {
+		if _, _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Kind: "vscode", Name: n}); err != nil {
 			t.Fatalf("CreateTab(%s): %v", n, err)
 		}
 	}
@@ -146,10 +146,10 @@ func TestCloseTab_ShellTabLeavesEditorAlone(t *testing.T) {
 	manager, repoID, title := newVSCodeCreateFixture(t)
 	key := daemonInstanceKey(repoID, title)
 
-	if _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Kind: "vscode"}); err != nil {
+	if _, _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Kind: "vscode"}); err != nil {
 		t.Fatalf("CreateTab(vscode): %v", err)
 	}
-	if _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Shell: true}); err != nil {
+	if _, _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Shell: true}); err != nil {
 		t.Fatalf("CreateTab(shell): %v", err)
 	}
 	manager.vscode.servers[key] = &vscodeServer{worktree: "/nowhere", exited: make(chan struct{})}
@@ -171,7 +171,7 @@ func TestCloseTab_StopsEditorEvenWhenPersistFails(t *testing.T) {
 	manager, repoID, title := newVSCodeCreateFixture(t)
 	key := daemonInstanceKey(repoID, title)
 
-	if _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Kind: "vscode"}); err != nil {
+	if _, _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Kind: "vscode"}); err != nil {
 		t.Fatalf("CreateTab(vscode): %v", err)
 	}
 	manager.vscode.servers[key] = &vscodeServer{worktree: "/nowhere", exited: make(chan struct{})}

--- a/daemon/create_tab_web_test.go
+++ b/daemon/create_tab_web_test.go
@@ -51,7 +51,7 @@ func TestCreateTab_WebSpawnsPersistsAndReturnsName(t *testing.T) {
 	const title = "webworker"
 	startedLocalTabInstance(t, manager, repo.ID, repoPath, title, "af_"+title+"_agent")
 
-	name, err := manager.CreateTab(CreateTabRequest{
+	name, _, err := manager.CreateTab(CreateTabRequest{
 		Title: title, RepoID: repo.ID, Kind: "web", URL: "http://localhost:5173",
 	})
 	if err != nil {
@@ -93,7 +93,7 @@ func TestCreateTab_WebPortConvenience(t *testing.T) {
 	const title = "webport"
 	startedLocalTabInstance(t, manager, repo.ID, repoPath, title, "af_"+title+"_agent")
 
-	if _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Kind: "web", Port: 3000}); err != nil {
+	if _, _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Kind: "web", Port: 3000}); err != nil {
 		t.Fatalf("CreateTab(web,port): %v", err)
 	}
 	web := loadWebTab(t, repo.ID)
@@ -110,7 +110,7 @@ func TestCreateTab_WebRejectsMissingTarget(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewManager: %v", err)
 	}
-	if _, err := manager.CreateTab(CreateTabRequest{Title: "x", Kind: "web"}); err == nil {
+	if _, _, err := manager.CreateTab(CreateTabRequest{Title: "x", Kind: "web"}); err == nil {
 		t.Fatal("expected error for web tab with no target, got nil")
 	}
 }
@@ -122,7 +122,7 @@ func TestCreateTab_WebRejectsUnknownKind(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewManager: %v", err)
 	}
-	if _, err := manager.CreateTab(CreateTabRequest{Title: "x", Kind: "bogus", URL: "http://localhost:1"}); err == nil {
+	if _, _, err := manager.CreateTab(CreateTabRequest{Title: "x", Kind: "bogus", URL: "http://localhost:1"}); err == nil {
 		t.Fatal("expected error for unknown kind, got nil")
 	}
 }
@@ -152,7 +152,7 @@ func TestCreateTab_WebRejectsRemoteInstance(t *testing.T) {
 	manager.instances[daemonInstanceKey(repo.ID, "rem")] = inst
 	manager.mu.Unlock()
 
-	_, err = manager.CreateTab(CreateTabRequest{Title: "rem", RepoID: repo.ID, Kind: "web", URL: "http://localhost:3000"})
+	_, _, err = manager.CreateTab(CreateTabRequest{Title: "rem", RepoID: repo.ID, Kind: "web", URL: "http://localhost:3000"})
 	if err == nil {
 		t.Fatal("expected error for remote instance, got nil")
 	}

--- a/daemon/manager_tabs.go
+++ b/daemon/manager_tabs.go
@@ -12,7 +12,12 @@ import (
 
 // CreateTab spawns a Process-kind tab running req.Command in the target
 // session's worktree, persists the grown tab list, and returns the resolved tab
-// name (#930 PR 5). It mirrors CreateSession's discipline: the find+spawn+persist
+// name plus the tmux session it was spawned under (#930 PR 5). The two are
+// independent namespaces and diverge after a rename (#1957), so the caller is
+// told BOTH rather than left to re-derive the second from the first — see
+// CreateTabResponse.TmuxName.
+//
+// It mirrors CreateSession's discipline: the find+spawn+persist
 // runs under the per-repo start lock so a concurrent CreateSession/CreateTab on
 // the same repo can't race the tab list or derive a duplicate name. The new tab
 // is persisted immediately (ToInstanceData serializes its command + tmux name,
@@ -22,29 +27,29 @@ import (
 // commands — a remote session's only terminal tab is the terminal_cmd one), an
 // empty command, or an instance already at the soft cap (maxTabs, enforced by
 // AddProcessTab).
-func (m *Manager) CreateTab(req CreateTabRequest) (string, error) {
+func (m *Manager) CreateTab(req CreateTabRequest) (string, string, error) {
 	// An empty kind is the default (shell-or-process, per req.Shell), not a kind;
 	// every explicit kind resolves through session.ParseTabKindName, the shared
 	// vocabulary the CLI validates against, so the two can't drift.
 	kind, explicitKind := session.ParseTabKindName(req.Kind)
 	if !explicitKind && req.Kind != "" {
-		return "", fmt.Errorf("unknown tab kind %q (expected one of %s, or empty)",
+		return "", "", fmt.Errorf("unknown tab kind %q (expected one of %s, or empty)",
 			req.Kind, strings.Join(session.TabKindNameList(), ", "))
 	}
 	isWeb := explicitKind && kind == session.TabKindWeb
 	isVSCode := explicitKind && kind == session.TabKindVSCode
 	if !explicitKind && !req.Shell && strings.TrimSpace(req.Command) == "" {
-		return "", fmt.Errorf("a process tab requires a non-empty command (--command)")
+		return "", "", fmt.Errorf("a process tab requires a non-empty command (--command)")
 	}
 	// A vscode tab always edits the session's own worktree, so a target is not
 	// just unnecessary but meaningless — reject one rather than silently ignoring
 	// it and leaving the caller thinking it took effect.
 	if isVSCode {
 		if strings.TrimSpace(req.URL) != "" || req.Port != 0 {
-			return "", fmt.Errorf("--url/--port are not valid for a vscode tab (--kind vscode): it always opens the session's worktree")
+			return "", "", fmt.Errorf("--url/--port are not valid for a vscode tab (--kind vscode): it always opens the session's worktree")
 		}
 		if strings.TrimSpace(req.Command) != "" {
-			return "", fmt.Errorf("--command is not valid for a vscode tab (--kind vscode)")
+			return "", "", fmt.Errorf("--command is not valid for a vscode tab (--kind vscode)")
 		}
 	}
 	// Resolve the web target up front so an invalid URL/port fails fast, before
@@ -55,17 +60,17 @@ func (m *Manager) CreateTab(req CreateTabRequest) (string, error) {
 		target := strings.TrimSpace(req.URL)
 		if target == "" {
 			if req.Port == 0 {
-				return "", fmt.Errorf("a web tab requires a target (--url or --port)")
+				return "", "", fmt.Errorf("a web tab requires a target (--url or --port)")
 			}
 			portURL, perr := session.WebTabURLForPort(req.Port)
 			if perr != nil {
-				return "", perr
+				return "", "", perr
 			}
 			target = portURL
 		}
 		normalized, nerr := session.NormalizeWebTabURL(target)
 		if nerr != nil {
-			return "", nerr
+			return "", "", nerr
 		}
 		webURL = normalized
 	}
@@ -77,16 +82,16 @@ func (m *Manager) CreateTab(req CreateTabRequest) (string, error) {
 	// RESOLVED title, not the (possibly ambiguous) request title.
 	instance, repoID, title, _, _, err := m.resolveActionSession(req.ID, req.Title, req.RepoID)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	if instance == nil {
-		return "", fmt.Errorf("failed to restore instance %q", title)
+		return "", "", fmt.Errorf("failed to restore instance %q", title)
 	}
 	// The message names the real reason rather than the old
 	// remote_hooks.terminal_cmd knob, which #1592 Phase 4 PR7 deleted — pointing a
 	// user at a setting that no longer exists is worse than no advice (#1874).
 	if !instance.Capabilities().TabManagement {
-		return "", fmt.Errorf("cannot create a tab on session %q: only local sessions support user-managed tabs — this session's workspace runs off-box (docker/ssh/remote), so there is no local worktree to spawn a tab in", title)
+		return "", "", fmt.Errorf("cannot create a tab on session %q: only local sessions support user-managed tabs — this session's workspace runs off-box (docker/ssh/remote), so there is no local worktree to spawn a tab in", title)
 	}
 
 	// Serialize the tab spawn against an archive/kill/restore teardown+move for
@@ -94,7 +99,7 @@ func (m *Manager) CreateTab(req CreateTabRequest) (string, error) {
 	// archiveExclusiveTabLock for the op-lock ordering and orphan rationale.
 	opLock, err := m.archiveExclusiveTabLock(daemonInstanceKey(repoID, title), instance)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	defer opLock.Unlock()
 
@@ -121,7 +126,7 @@ func (m *Manager) CreateTab(req CreateTabRequest) (string, error) {
 		tab, err = instance.AddProcessTab(req.Command, req.Name)
 	}
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	// Persist through the targeted per-repo writer (persistInstanceData) — the
@@ -135,7 +140,7 @@ func (m *Manager) CreateTab(req CreateTabRequest) (string, error) {
 		if closeErr := instance.CloseTab(instance.TabCount() - 1); closeErr != nil {
 			log.WarningLog.Printf("CreateTab %q: rolling back unpersisted tab failed: %v", title, closeErr)
 		}
-		return "", fmt.Errorf("failed to persist new tab: %w", err)
+		return "", "", fmt.Errorf("failed to persist new tab: %w", err)
 	}
 
 	// Announce the grown roster (#1812). A tab created by an agent, the CLI, the
@@ -154,7 +159,26 @@ func (m *Manager) CreateTab(req CreateTabRequest) (string, error) {
 	// the same order they persisted. publishEvent is non-blocking (drop-slow), so
 	// a wedged subscriber can't stall the mutation.
 	m.publishEvent(agentproto.EventSessionUpdated, data)
-	return tab.Name, nil
+	// Report the tmux session the tab actually spawned under, read out of the very
+	// snapshot that was just persisted and keyed on the tab's STABLE ID — not on
+	// its ordinal (which any concurrent close shifts) and not by re-deriving
+	// "<agent>__<name>", which is the assumption #1957 retired. Empty for a
+	// tmux-less kind (web, vscode), which is the honest answer for them.
+	return tab.Name, tabTmuxNameByID(data.Tabs, tab.ID), nil
+}
+
+// tabTmuxNameByID returns the persisted tmux session name of the tab with this
+// stable id, or "" when it has none (a web/vscode tab) or the id is absent.
+func tabTmuxNameByID(tabs []session.TabData, id string) string {
+	if id == "" {
+		return ""
+	}
+	for _, td := range tabs {
+		if td.ID == id {
+			return td.TmuxName
+		}
+	}
+	return ""
 }
 
 // CloseTab closes a non-agent tab of the target session, kills its tmux

--- a/daemon/tab_arrange_id_test.go
+++ b/daemon/tab_arrange_id_test.go
@@ -57,7 +57,7 @@ func tabNameByID(data session.InstanceData, id string) string {
 func arrangeWebTabs(t *testing.T, m *Manager, repoID, title string, names ...string) {
 	t.Helper()
 	for _, n := range names {
-		if _, err := m.CreateTab(CreateTabRequest{
+		if _, _, err := m.CreateTab(CreateTabRequest{
 			Title: title, RepoID: repoID, Kind: "web", URL: "http://localhost:5173", Name: n,
 		}); err != nil {
 			t.Fatalf("CreateTab(%s): %v", n, err)

--- a/daemon/tab_arrange_test.go
+++ b/daemon/tab_arrange_test.go
@@ -34,7 +34,7 @@ func TestRenameTab_PublishesSessionUpdated(t *testing.T) {
 	const title = "renameevt"
 	manager, repo := tabEventSession(t, title)
 
-	if _, err := manager.CreateTab(CreateTabRequest{
+	if _, _, err := manager.CreateTab(CreateTabRequest{
 		Title: title, RepoID: repo.ID, Kind: "web", URL: "http://localhost:5173", Name: "preview",
 	}); err != nil {
 		t.Fatalf("CreateTab(web): %v", err)
@@ -68,7 +68,7 @@ func TestRenameTab_ReturnsResolvedName(t *testing.T) {
 	manager, repo := tabEventSession(t, title)
 
 	for _, n := range []string{"dup", "victim"} {
-		if _, err := manager.CreateTab(CreateTabRequest{
+		if _, _, err := manager.CreateTab(CreateTabRequest{
 			Title: title, RepoID: repo.ID, Kind: "web", URL: "http://localhost:5173", Name: n,
 		}); err != nil {
 			t.Fatalf("CreateTab(%s): %v", n, err)
@@ -102,7 +102,7 @@ func TestRenameTab_RejectsSanitizeToEmpty(t *testing.T) {
 	const title = "emptyname"
 	manager, repo := tabEventSession(t, title)
 
-	if _, err := manager.CreateTab(CreateTabRequest{
+	if _, _, err := manager.CreateTab(CreateTabRequest{
 		Title: title, RepoID: repo.ID, Kind: "web", URL: "http://localhost:5173", Name: "preview",
 	}); err != nil {
 		t.Fatalf("CreateTab(web): %v", err)
@@ -128,7 +128,7 @@ func TestRenameTab_RejectsUndisplayedKinds(t *testing.T) {
 	const title = "kindguard"
 	manager, repo := tabEventSession(t, title)
 
-	if _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Shell: true}); err != nil {
+	if _, _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Shell: true}); err != nil {
 		t.Fatalf("CreateTab(shell): %v", err)
 	}
 
@@ -155,7 +155,7 @@ func TestReorderTab_PersistsAndPublishes(t *testing.T) {
 	manager, repo := tabEventSession(t, title)
 
 	for _, n := range []string{"a", "b", "c"} {
-		if _, err := manager.CreateTab(CreateTabRequest{
+		if _, _, err := manager.CreateTab(CreateTabRequest{
 			Title: title, RepoID: repo.ID, Kind: "web", URL: "http://localhost:5173", Name: n,
 		}); err != nil {
 			t.Fatalf("CreateTab(%s): %v", n, err)
@@ -192,7 +192,7 @@ func TestReorderTab_PinsAgentSlot(t *testing.T) {
 	manager, repo := tabEventSession(t, title)
 
 	for _, n := range []string{"a", "b"} {
-		if _, err := manager.CreateTab(CreateTabRequest{
+		if _, _, err := manager.CreateTab(CreateTabRequest{
 			Title: title, RepoID: repo.ID, Kind: "web", URL: "http://localhost:5173", Name: n,
 		}); err != nil {
 			t.Fatalf("CreateTab(%s): %v", n, err)
@@ -238,7 +238,7 @@ func TestArrangeTab_RejectsArchivedSession(t *testing.T) {
 	const title = "archarrange"
 	manager, repo := tabEventSession(t, title)
 
-	if _, err := manager.CreateTab(CreateTabRequest{
+	if _, _, err := manager.CreateTab(CreateTabRequest{
 		Title: title, RepoID: repo.ID, Kind: "web", URL: "http://localhost:5173", Name: "preview",
 	}); err != nil {
 		t.Fatalf("CreateTab(web): %v", err)

--- a/daemon/tab_event_order_test.go
+++ b/daemon/tab_event_order_test.go
@@ -84,7 +84,7 @@ func TestPersistPollChange_PublishesRosterAsOfItsLock(t *testing.T) {
 		t.Fatalf("session %q missing from the manager", title)
 	}
 
-	name, err := manager.CreateTab(CreateTabRequest{
+	name, _, err := manager.CreateTab(CreateTabRequest{
 		Title: title, RepoID: repo.ID, Kind: "web", URL: "http://localhost:5173", Name: "livepreview",
 	})
 	if err != nil {

--- a/daemon/tab_event_test.go
+++ b/daemon/tab_event_test.go
@@ -73,7 +73,7 @@ func TestCreateTab_WebPublishesSessionUpdated(t *testing.T) {
 	manager, repo := tabEventSession(t, title)
 
 	_, ch := manager.events.subscribe()
-	name, err := manager.CreateTab(CreateTabRequest{
+	name, _, err := manager.CreateTab(CreateTabRequest{
 		Title: title, RepoID: repo.ID, Kind: "web", URL: "http://localhost:5173", Name: "livepreview",
 	})
 	if err != nil {
@@ -99,7 +99,7 @@ func TestCreateTab_ProcessPublishesSessionUpdated(t *testing.T) {
 	manager, repo := tabEventSession(t, title)
 
 	_, ch := manager.events.subscribe()
-	name, err := manager.CreateTab(CreateTabRequest{
+	name, _, err := manager.CreateTab(CreateTabRequest{
 		Title: title, RepoID: repo.ID, Command: "sleep 600", Name: "worker",
 	})
 	if err != nil {
@@ -122,7 +122,7 @@ func TestCloseTab_PublishesSessionUpdated(t *testing.T) {
 	const title = "closeevt"
 	manager, repo := tabEventSession(t, title)
 
-	name, err := manager.CreateTab(CreateTabRequest{
+	name, _, err := manager.CreateTab(CreateTabRequest{
 		Title: title, RepoID: repo.ID, Kind: "web", URL: "http://localhost:5173", Name: "doomed",
 	})
 	if err != nil {

--- a/daemon/vscode_server_test.go
+++ b/daemon/vscode_server_test.go
@@ -306,7 +306,7 @@ func newVSCodeFixture(t *testing.T, binary string) (m *Manager, sessionID, tabID
 	manager.vscode.cooldown = 50 * time.Millisecond
 	t.Cleanup(manager.vscode.Stop)
 
-	if _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Kind: "vscode"}); err != nil {
+	if _, _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Kind: "vscode"}); err != nil {
 		t.Fatalf("CreateTab(vscode): %v", err)
 	}
 	// The tab fixture's instance is tmux-mocked and never materializes its

--- a/daemon/webtab_proxy_test.go
+++ b/daemon/webtab_proxy_test.go
@@ -56,7 +56,7 @@ func newWebTabProxyFixtureN(t *testing.T, targets ...string) (
 	const title = "webproxy"
 	inst = startedLocalTabInstance(t, manager, repo.ID, repoPath, title, "af_"+title+"_agent")
 	for i, target := range targets {
-		if _, err := manager.CreateTab(CreateTabRequest{
+		if _, _, err := manager.CreateTab(CreateTabRequest{
 			Title: title, RepoID: repo.ID, Kind: "web", URL: target, Name: fmt.Sprintf("web%d", i),
 		}); err != nil {
 			t.Fatalf("CreateTab(web, %q): %v", target, err)
@@ -433,7 +433,7 @@ func TestWebTabProxy_RejectsNonWebTab(t *testing.T) {
 	}
 	const title = "webproxy"
 	inst := startedLocalTabInstance(t, manager, repo.ID, repoPath, title, "af_"+title+"_agent")
-	if _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Kind: "web", URL: upstream.URL}); err != nil {
+	if _, _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Kind: "web", URL: upstream.URL}); err != nil {
 		t.Fatalf("CreateTab(web): %v", err)
 	}
 	mux := newHTTPMux(&controlServer{manager: manager})

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -558,15 +558,15 @@ func (b *LocalBackend) setupTabs(i *Instance) {
 	// dead-shell replacement below applies.
 	hasShellTab := false
 	hasLiveShell := false
-	replacementShellName := ""
+	var replacementShell *Tab
 	for idx, tab := range tabs {
 		if idx == 0 {
 			continue
 		}
 		if tab.Kind == TabKindShell {
 			hasShellTab = true
-			if replacementShellName == "" {
-				replacementShellName = tab.Name
+			if replacementShell == nil {
+				replacementShell = tab
 			}
 		}
 		if tab.tmux == nil {
@@ -605,12 +605,31 @@ func (b *LocalBackend) setupTabs(i *Instance) {
 	// A persisted shell tab restored dead (#991): create a fresh shell session
 	// as a sibling of the agent session so it inherits the agent's PTY factory /
 	// executor — real in production, mock in tests — keeping the create path
-	// hermetic. The name extends the agent session's name deterministically so
-	// it is collision-free and restorable by exact name.
-	if replacementShellName == "" {
-		replacementShellName = shellTabName
+	// hermetic.
+	//
+	// Reuse the dead tab's OWN persisted tmux name rather than re-deriving one
+	// from its display name. Re-deriving is unsafe now that the two namespaces are
+	// independent (#1957, see tab_names.go): a shell tab named "shell" may hold the
+	// session "…__shell-2" because a renamed tab still owns "…__shell", and
+	// re-deriving would have this replacement collide with that live session. Its
+	// own name is also the right answer on its merits — the session it names is
+	// dead, so retaking it is free, and the tab keeps the session name already
+	// persisted against it. uniqueTabTmuxName covers the no-persisted-name case
+	// (no shell tab to inherit from, or a legacy row with an empty TmuxName).
+	replacementShellName := shellTabName
+	replacementTmuxName := ""
+	if replacementShell != nil {
+		if replacementShell.Name != "" {
+			replacementShellName = replacementShell.Name
+		}
+		if replacementShell.tmux != nil {
+			replacementTmuxName = replacementShell.tmux.SanitizedName()
+		}
 	}
-	shellTmux := agentTmux.NewSiblingSession(agentTmux.SanitizedName()+"__"+replacementShellName, defaultShell())
+	if replacementTmuxName == "" {
+		replacementTmuxName = uniqueTabTmuxName(tabs, agentTmux.SanitizedName(), replacementShellName)
+	}
+	shellTmux := agentTmux.NewSiblingSession(replacementTmuxName, defaultShell())
 	if err := shellTmux.Start(worktreePath); err != nil {
 		log.WarningLog.Printf("start shell tab for %q failed: %v", i.Title, err)
 		return

--- a/session/instance.go
+++ b/session/instance.go
@@ -523,16 +523,21 @@ func (i *Instance) CloseTab(idx int) error {
 // AddShellTab: the daemon owns the spawn (so its authoritative view holds the
 // tab and can't be clobbered), and the TUI only needs to reflect the new tab
 // locally for instant display. It binds to the EXACT tmux session the daemon
-// derived (agent session name + "__" + name) and Restores (reconnects) it,
-// mirroring restoreLocalTabs + LocalBackend.setupTabs, so the tab is immediately
-// previewable/attachable without a second spawn that would collide on the name.
+// spawned and Restores (reconnects) it, mirroring restoreLocalTabs +
+// LocalBackend.setupTabs, so the tab is immediately previewable/attachable
+// without a second, colliding spawn.
 //
-// name is the resolved tab name returned by the daemon. Local instances only —
-// callers reject backends without TabManagement first. If a tab with that name
-// is already present
-// (e.g. a refresh raced ahead) this is a no-op returning the existing tab.
-// Errors when the instance is not started or has no agent session/worktree.
-func (i *Instance) AttachShellTab(name string) (*Tab, error) {
+// name and tmuxName are BOTH the daemon's, as returned by CreateTab. tmuxName is
+// passed, not re-derived as "<agent>__<name>", because the two are independent
+// namespaces (#1957, see tab_names.go): after a rename the daemon spawns
+// "…__shell-2" for a tab named "shell", and re-deriving would bind this
+// projection to the OLDER tab's still-live session. Empty falls back to the
+// derivation — right for its only cause, a daemon predating the field.
+//
+// Local instances only — callers reject backends without TabManagement first. A
+// tab with that name already present (a refresh raced ahead) makes this a no-op
+// returning it. Errors when the instance is not started or has no session.
+func (i *Instance) AttachShellTab(name, tmuxName string) (*Tab, error) {
 	i.mu.RLock()
 	started := i.started
 	agentTmux := i.tmuxLocked()
@@ -557,8 +562,8 @@ func (i *Instance) AttachShellTab(name string) (*Tab, error) {
 		return nil, fmt.Errorf("cannot attach a tab without a worktree")
 	}
 
-	// Bind to the exact session name the daemon derived and ATTACH-ONLY to it —
-	// never spawn. Pass empty workDir so a session that is missing surfaces as an
+	// Bind to the exact session the daemon spawned and ATTACH-ONLY to it — never
+	// spawn. Pass empty workDir so a session that is missing surfaces as an
 	// error instead of re-spawning (#1152). The daemon is the single writer that
 	// owns every tmux spawn (#960); this is a pure TUI-side projection of a tab
 	// the daemon already created. If the daemon killed the instance in the window
@@ -566,7 +571,9 @@ func (i *Instance) AttachShellTab(name string) (*Tab, error) {
 	// tmux session that escapes the daemon's Kill teardown and orphans over the
 	// about-to-be-deleted worktree — the same #990 leak AddShellTab guards. Fail
 	// cleanly and let the daemon's next Snapshot reconcile the tab away.
-	tmuxName := agentTmux.SanitizedName() + "__" + name
+	if tmuxName == "" {
+		tmuxName = agentTmux.SanitizedName() + tmuxTabSeparator + name
+	}
 	shellTmux := agentTmux.NewSiblingSession(tmuxName, defaultShell())
 	if err := shellTmux.Restore(""); err != nil {
 		return nil, fmt.Errorf("failed to reconnect shell tab: %w", err)

--- a/session/tab_arrange.go
+++ b/session/tab_arrange.go
@@ -44,10 +44,15 @@ func TabKindRenameable(kind TabKind) bool {
 // Only kinds that display their name can be renamed (TabKindRenameable); the
 // agent tab is additionally pinned at index 0. Resolution and mutation are atomic
 // under the write lock so two concurrent renames cannot both resolve to the same
-// free name. Renaming does NOT touch the tab's live tmux session — restore
-// rebinds by the persisted TmuxName, not by re-deriving from the name, so the
-// tab survives a restart; uniqueTabNameExcluding keeps the now-decoupled tmux
-// token reserved against a later spawn.
+// free name.
+//
+// Renaming does NOT touch the tab's live tmux session — restore rebinds by the
+// persisted TmuxName, not by re-deriving from the name, so the tab survives a
+// restart. The name it renames AWAY from is therefore free immediately: names
+// are unique among the roster's current names and nothing else (#1957), and the
+// still-live tmux session it leaves behind is dodged at SPAWN by
+// uniqueTabTmuxName rather than by holding the user's old name hostage. See the
+// two-namespace note at the top of tab_names.go.
 func (i *Instance) RenameTab(idx int, requestedName string) (string, error) {
 	base := sanitizeTabName(requestedName)
 	if base == "" {
@@ -68,8 +73,8 @@ func (i *Instance) RenameTab(idx int, requestedName string) (string, error) {
 	//
 	//   - uniqueTabNameExcluding excludes by POINTER identity, so it has to run
 	//     while tab is still the entry in i.Tabs. Replacing first would leave the
-	//     exclusion matching nothing, and a tab could no longer reclaim its own
-	//     name or tmux token (TestRenameTab_ReclaimsItsOwnToken).
+	//     exclusion matching nothing, and a tab could no longer be renamed to the
+	//     name it already holds (TestRenameTab_ReclaimsItsOwnName).
 	//   - The write must be copy-on-write, because GetTabs hands out these very
 	//     pointers and its callers read Name off-lock (see replaceTabFieldLocked).
 	name := uniqueTabNameExcluding(i.Tabs, base, tab)

--- a/session/tab_arrange_test.go
+++ b/session/tab_arrange_test.go
@@ -12,9 +12,11 @@ import (
 )
 
 // Rename/reorder unit tests (#1813). The headline case is
-// TestRenameTab_FreesNoTmuxTokenForALaterSpawn: rename deliberately does NOT
+// TestRenameTab_SpawnDodgesTheStillLiveTmuxSession: rename deliberately does NOT
 // rename the live tmux session, so a tab's name and its tmux token decouple, and
-// the collision that opens is the one bug this feature could introduce.
+// the collision that opens is the one bug this feature could introduce. What the
+// FREED NAME must do — go straight back to the next tab that asks for it — is
+// pinned next door in tab_name_release_test.go (#1957).
 
 // tabNames returns the roster's display names, in order.
 func tabNames(i *Instance) []string {
@@ -25,19 +27,22 @@ func tabNames(i *Instance) []string {
 	return names
 }
 
-// TestRenameTab_FreesNoTmuxTokenForALaterSpawn is the regression test for the
-// collision a rename opens up. A tab's tmux session name is derived at SPAWN
+// TestRenameTab_SpawnDodgesTheStillLiveTmuxSession is the regression test for the
+// collision a rename opens up. A tab's tmux session name is fixed at SPAWN
 // ("<agent>__shell") and a rename does not touch it — restore rebinds by the
 // persisted TmuxName, so the live session must keep its original name. That
-// decouples the display name from the tmux token, and without reserving the
-// token a later `t` would re-derive the SAME tmux name and collide with the
-// renamed tab's still-live session:
+// decouples the display name from the tmux token, and a later `t` that blindly
+// re-derived "<agent>__shell" would collide with the renamed tab's still-live
+// session:
 //
-//	Name="shell"/tmux "__shell" -> rename to "editor" -> `t` sees "shell" free
-//	-> new tab derives "__shell" -> collision.
+//	Name="shell"/tmux "__shell" -> rename to "editor" -> `t` asks for "shell"
+//	-> naive derive "__shell" -> collision.
 //
-// The new tab must therefore get "shell-2"/"__shell-2".
-func TestRenameTab_FreesNoTmuxTokenForALaterSpawn(t *testing.T) {
+// The SPAWN is what takes the suffix ("__shell-2"). The NAME does not: nothing on
+// the roster is called "shell" any more, so the new tab is named "shell" (#1957 —
+// charging the user's namespace for a tmux collision is what made the -2 a
+// mystery). Both halves are asserted here so neither can regress alone.
+func TestRenameTab_SpawnDodgesTheStillLiveTmuxSession(t *testing.T) {
 	log.Initialize(false)
 	defer log.Close()
 
@@ -60,22 +65,23 @@ func TestRenameTab_FreesNoTmuxTokenForALaterSpawn(t *testing.T) {
 	assert.Equal(t, firstTmux, first.tmux.SanitizedName(),
 		"rename must leave the live tmux session's name alone — restore rebinds by it")
 
-	// The `t` key: a second shell tab. "shell" LOOKS free (no tab is named it),
-	// but the renamed tab's live session still owns the token.
+	// The `t` key: a second shell tab. "shell" IS free as a name — no tab is called
+	// it — while the renamed tab's live session still owns the tmux token.
 	second, err := inst.AddShellTab()
 	require.NoError(t, err)
 	assert.NotEqual(t, firstTmux, second.tmux.SanitizedName(),
 		"new tab derived the renamed tab's live tmux session name — collision")
-	assert.Equal(t, "shell-2", second.Name)
-	assert.Equal(t, "af_collide_agent__shell-2", second.tmux.SanitizedName())
+	assert.Equal(t, "shell", second.Name, "the freed name goes back to the next tab that asks")
+	assert.Equal(t, "af_collide_agent__shell-2", second.tmux.SanitizedName(),
+		"the spawn walks past the live session instead")
 }
 
 // TestRenameTab_TmuxTokenSurvivesSeparatorInName is the regression for the
 // Codex finding on the token parse. sanitizeTabName keeps '_', so "logs__api" is
 // a VALID tab name whose tmux session is "…__logs__api". The old parse split on
-// the LAST "__" and reserved "api", leaving "logs__api" free — so a later
-// tab-create --name logs__api derived the SAME session the renamed tab still
-// owns and collided at spawn. The token must be the whole "logs__api".
+// the LAST "__" and reserved "api", leaving the "logs__api" token unreserved — so
+// a later tab-create --name logs__api spawned the SAME session the renamed tab
+// still owns and collided. The token must be the whole "logs__api".
 func TestRenameTab_TmuxTokenSurvivesSeparatorInName(t *testing.T) {
 	log.Initialize(false)
 	defer log.Close()
@@ -94,21 +100,22 @@ func TestRenameTab_TmuxTokenSurvivesSeparatorInName(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, firstTmux, first.tmux.SanitizedName(), "rename leaves the live session alone")
 
-	// Re-request the freed name. The reserved token is the whole "logs__api", so
-	// the new tab must be suffixed rather than deriving the live session's name.
+	// Re-request the freed name. The name comes back whole, and the SESSION is what
+	// gets suffixed — which only lands clear of the live one if the reserved token
+	// is the whole "logs__api" rather than the "api" a last-"__" split would yield.
 	second, err := inst.AddProcessTab("btop", "logs__api")
 	require.NoError(t, err)
 	assert.NotEqual(t, firstTmux, second.tmux.SanitizedName(),
 		"new tab derived the renamed tab's live session name — the separator-in-name collision")
-	assert.Equal(t, "logs__api-2", second.Name)
+	assert.Equal(t, "logs__api", second.Name)
 	assert.Equal(t, "af_sep_agent__logs__api-2", second.tmux.SanitizedName())
 }
 
-// TestRenameTab_ReclaimsItsOwnToken: excluding the renamed tab covers its token
-// as well as its name, so a tab can be renamed back to what it was. Nothing else
-// can have taken the name in the meantime — it was reserved the whole time the
-// tab held it.
-func TestRenameTab_ReclaimsItsOwnToken(t *testing.T) {
+// TestRenameTab_ReclaimsItsOwnName: the rename excludes the tab being renamed
+// from the taken set, so a tab can be renamed back to what it was called. Nothing
+// else can have taken that name in the meantime — this instance's roster is the
+// whole namespace, and the tab held the name until this very rename.
+func TestRenameTab_ReclaimsItsOwnName(t *testing.T) {
 	log.Initialize(false)
 	defer log.Close()
 

--- a/session/tab_kill_race_test.go
+++ b/session/tab_kill_race_test.go
@@ -179,7 +179,7 @@ func TestAttachShellTab_KilledSessionDoesNotSpawn(t *testing.T) {
 	spawned := false
 	inst, isAlive := raceMockInstance(t, agentName, func() { spawned = true })
 
-	tab, err := inst.AttachShellTab(shellTabName)
+	tab, err := inst.AttachShellTab(shellTabName, "")
 	require.Error(t, err, "attaching to a killed session must fail, not resurrect it")
 	assert.Contains(t, err.Error(), "failed to reconnect shell tab")
 	assert.Nil(t, tab)
@@ -256,7 +256,7 @@ func TestAttachShellTab_KillRaceDropsProjection(t *testing.T) {
 		Tabs:        []*Tab{newAgentTab(agentTs)},
 	}
 
-	tab, err := inst.AttachShellTab(shellTabName)
+	tab, err := inst.AttachShellTab(shellTabName, "")
 	require.Error(t, err, "a tab attached during teardown must be refused")
 	assert.Contains(t, err.Error(), "session was killed during tab attach")
 	assert.Nil(t, tab)

--- a/session/tab_lifecycle_test.go
+++ b/session/tab_lifecycle_test.go
@@ -189,7 +189,7 @@ func TestAttachShellTab_ReconnectsExistingSessionNoSpawn(t *testing.T) {
 	// The daemon already spawned the sibling shell session.
 	inst := startedMockInstance(t, agentName, agentName+"__shell")
 
-	tab, err := inst.AttachShellTab("shell")
+	tab, err := inst.AttachShellTab("shell", "")
 	require.NoError(t, err)
 	assert.Equal(t, "shell", tab.Name)
 	assert.Equal(t, TabKindShell, tab.Kind)
@@ -200,7 +200,7 @@ func TestAttachShellTab_ReconnectsExistingSessionNoSpawn(t *testing.T) {
 
 	// A second call for the same name is a no-op returning the existing tab —
 	// guards against a refresh racing ahead of the reconnect.
-	again, err := inst.AttachShellTab("shell")
+	again, err := inst.AttachShellTab("shell", "")
 	require.NoError(t, err)
 	assert.Same(t, tab, again, "a duplicate attach must return the existing tab")
 	assert.Equal(t, 2, inst.TabCount(), "a duplicate attach must not append again")
@@ -214,7 +214,7 @@ func TestAttachShellTab_RejectedForUnstarted(t *testing.T) {
 
 	inst, err := NewInstance(InstanceOptions{Title: "unstarted", Path: t.TempDir(), Program: "claude"})
 	require.NoError(t, err)
-	_, err = inst.AttachShellTab("shell")
+	_, err = inst.AttachShellTab("shell", "")
 	require.Error(t, err)
 	require.Equal(t, 0, inst.TabCount())
 }

--- a/session/tab_name_release_test.go
+++ b/session/tab_name_release_test.go
@@ -1,0 +1,200 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/log"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #1957: a renamed tab kept its OLD name reserved, so `tab-create --name fresh`
+// answered "fresh-2" with nothing on the roster named "fresh". The reservation
+// was real — the renamed tab's tmux session still holds "…__fresh" — but it was
+// charged to the wrong namespace. These tests pin the split: a NAME is taken
+// only while a tab actually holds it, and the still-live tmux session is dodged
+// at SPAWN instead. See the note at the top of tab_names.go.
+
+// TestRenameTab_FreesTheOldNameForANewTab is the #1957 repro, verbatim from the
+// issue: rename the tab named "fresh" to "fresh-old", then ask for "fresh". The
+// answer must be "fresh" — nothing on the roster is named it — and the new tab's
+// tmux session must NOT be the one the renamed tab is still running in.
+func TestRenameTab_FreesTheOldNameForANewTab(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst := startedMockInstance(t, "af_1957_agent")
+
+	first, err := inst.AddProcessTab("btop", "fresh")
+	require.NoError(t, err)
+	require.Equal(t, "fresh", first.Name)
+	firstTmux := first.tmux.SanitizedName()
+	require.Equal(t, "af_1957_agent__fresh", firstTmux)
+
+	renamed, err := inst.RenameTab(1, "fresh-old")
+	require.NoError(t, err)
+	require.Equal(t, "fresh-old", renamed)
+	require.Equal(t, firstTmux, first.tmux.SanitizedName(),
+		"rename must leave the live tmux session alone — restore rebinds by it")
+
+	second, err := inst.AddProcessTab("btop", "fresh")
+	require.NoError(t, err)
+	assert.Equal(t, "fresh", second.Name,
+		"the name the renamed tab gave up must be handed straight back, unsuffixed")
+	assert.Equal(t, "af_1957_agent__fresh-2", second.tmux.SanitizedName(),
+		"the SPAWN takes the suffix instead, so it misses the renamed tab's live session")
+	assert.NotEqual(t, firstTmux, second.tmux.SanitizedName(),
+		"new tab derived the renamed tab's live tmux session name — collision")
+	assert.Equal(t, []string{"agent", "fresh-old", "fresh"}, tabNames(inst))
+}
+
+// TestAddTab_SuffixesANameALiveTabStillHolds is the no-over-freeing half. The
+// fix frees a name its tab gave up; it must not free one a tab is still using.
+func TestAddTab_SuffixesANameALiveTabStillHolds(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst := startedMockInstance(t, "af_1957_live")
+
+	first, err := inst.AddProcessTab("btop", "fresh")
+	require.NoError(t, err)
+	require.Equal(t, "fresh", first.Name)
+
+	// No rename this time: "fresh" is a name a live tab answers to.
+	second, err := inst.AddProcessTab("btop", "fresh")
+	require.NoError(t, err)
+	assert.Equal(t, "fresh-2", second.Name,
+		"a name a live tab still holds must still collide")
+	assert.Equal(t, "af_1957_live__fresh-2", second.tmux.SanitizedName())
+
+	// And a third stacks, rather than reusing either taken name.
+	third, err := inst.AddProcessTab("btop", "fresh")
+	require.NoError(t, err)
+	assert.Equal(t, "fresh-3", third.Name)
+	assert.Equal(t, "af_1957_live__fresh-3", third.tmux.SanitizedName())
+}
+
+// TestRenameTab_CreateRenameRoundTrips walks the full cycle the issue's user
+// would: rename away, recreate under the freed name, rename the NEW tab, and
+// recreate again. Every step must hand back the exact name asked for, and every
+// tab must end up in a tmux session of its own.
+func TestRenameTab_CreateRenameRoundTrips(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst := startedMockInstance(t, "af_1957_round")
+
+	first, err := inst.AddProcessTab("btop", "fresh")
+	require.NoError(t, err)
+	require.Equal(t, "af_1957_round__fresh", first.tmux.SanitizedName())
+
+	name, err := inst.RenameTab(1, "fresh-old")
+	require.NoError(t, err)
+	require.Equal(t, "fresh-old", name)
+
+	second, err := inst.AddProcessTab("btop", "fresh")
+	require.NoError(t, err)
+	require.Equal(t, "fresh", second.Name)
+	require.Equal(t, "af_1957_round__fresh-2", second.tmux.SanitizedName())
+
+	// Rename the NEW tab away too; "fresh" is free again for a third.
+	name, err = inst.RenameTab(2, "fresh-older")
+	require.NoError(t, err)
+	require.Equal(t, "fresh-older", name)
+
+	third, err := inst.AddProcessTab("btop", "fresh")
+	require.NoError(t, err)
+	assert.Equal(t, "fresh", third.Name)
+	assert.Equal(t, "af_1957_round__fresh-3", third.tmux.SanitizedName(),
+		"two live sessions now hold the earlier tokens, so the spawn walks past both")
+
+	assert.Equal(t, []string{"agent", "fresh-old", "fresh-older", "fresh"}, tabNames(inst))
+	assert.Len(t, distinctTmuxNames(inst), 4, "every tab must own a distinct tmux session")
+}
+
+// TestRenameTab_FreedNameIsFreeForATmuxlessTab: a web/vscode tab owns no tmux
+// session, so nothing was ever protecting it from the freed name — it was purely
+// collateral damage from the shared namespace. It must take the name too.
+func TestRenameTab_FreedNameIsFreeForATmuxlessTab(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst := startedMockInstance(t, "af_1957_web")
+
+	_, err := inst.AddProcessTab("btop", "dashboard")
+	require.NoError(t, err)
+	name, err := inst.RenameTab(1, "dashboard-old")
+	require.NoError(t, err)
+	require.Equal(t, "dashboard-old", name)
+
+	web, err := inst.AddWebTab("http://localhost:3000", "dashboard")
+	require.NoError(t, err)
+	assert.Equal(t, "dashboard", web.Name)
+
+	vscode, err := inst.AddVSCodeTab("editor")
+	require.NoError(t, err)
+	require.Equal(t, "editor", vscode.Name)
+	renamedVSCode, err := inst.RenameTab(3, "editor-old")
+	require.NoError(t, err)
+	require.Equal(t, "editor-old", renamedVSCode)
+
+	again, err := inst.AddVSCodeTab("editor")
+	require.NoError(t, err)
+	assert.Equal(t, "editor", again.Name,
+		"a tmux-less tab's freed name has nothing live behind it at all")
+}
+
+// TestCloseTab_FreesNameAndTmuxToken is the adjacent-verb check. Close kills the
+// tab's tmux session, so BOTH namespaces free up and the next tab gets the plain
+// name and the plain session — no lingering "-2" from a tab that is gone.
+func TestCloseTab_FreesNameAndTmuxToken(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst := startedMockInstance(t, "af_1957_close")
+
+	first, err := inst.AddProcessTab("btop", "fresh")
+	require.NoError(t, err)
+	require.Equal(t, "af_1957_close__fresh", first.tmux.SanitizedName())
+	require.NoError(t, inst.CloseTab(1))
+
+	second, err := inst.AddProcessTab("btop", "fresh")
+	require.NoError(t, err)
+	assert.Equal(t, "fresh", second.Name)
+	assert.Equal(t, "af_1957_close__fresh", second.tmux.SanitizedName(),
+		"the closed tab's session is dead, so its token is free to retake")
+}
+
+// TestReorderTab_TouchesNeitherNamespace is the other adjacent verb: a reorder
+// only permutes the slice, so no name and no tmux token changes hands and a
+// later create resolves exactly as it would have before.
+func TestReorderTab_TouchesNeitherNamespace(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst := startedMockInstance(t, "af_1957_reorder")
+
+	for _, n := range []string{"alpha", "beta"} {
+		_, err := inst.AddProcessTab("btop", n)
+		require.NoError(t, err)
+	}
+	require.NoError(t, inst.ReorderTab(2, 1))
+	require.Equal(t, []string{"agent", "beta", "alpha"}, tabNames(inst))
+
+	next, err := inst.AddProcessTab("btop", "alpha")
+	require.NoError(t, err)
+	assert.Equal(t, "alpha-2", next.Name, "both names are still held by live tabs")
+	assert.Equal(t, "af_1957_reorder__alpha-2", next.tmux.SanitizedName())
+}
+
+// distinctTmuxNames returns the set of tmux session names the roster's tabs hold.
+func distinctTmuxNames(i *Instance) map[string]bool {
+	names := map[string]bool{}
+	for _, t := range i.Tabs {
+		if t.tmux != nil {
+			names[t.tmux.SanitizedName()] = true
+		}
+	}
+	return names
+}

--- a/session/tab_names.go
+++ b/session/tab_names.go
@@ -7,6 +7,31 @@ import (
 	"strings"
 )
 
+// A tab has TWO names in two separate namespaces, and #1957 is what happens when
+// they are collapsed into one:
+//
+//   - its NAME — the handle a user types and every tab verb resolves against.
+//     Unique among the CURRENT names on the roster, and only those.
+//   - its TMUX SESSION NAME — "<agent sanitized>__<token>", frozen at spawn
+//     because restore rebinds by the persisted TmuxName and the TUI keys live
+//     panes by it. Unique among the LIVE tmux sessions of the roster's tabs.
+//
+// Before rename existed the two could never diverge, so one namespace sufficed.
+// #1813 made rename reachable, and the first fix kept a single namespace by
+// ALSO reserving each tab's live tmux token as a name: renaming "fresh" to
+// "fresh-old" left "fresh" un-takeable, so `tab-create --name fresh` silently
+// answered "fresh-2" with nothing on the roster named "fresh" (#1957). The
+// reservation was protective — without it the new tab re-derived the renamed
+// tab's still-live "…__fresh" session — but it charged the user's namespace for
+// a collision in tmux's.
+//
+// Splitting them pays the same debt honestly: the name is free the moment its
+// tab stops using it, and the SPAWN is what walks to "…__fresh-2" to miss the
+// live session. Nothing outside this file needs the two to agree — restore and
+// the snapshot reconcile bind by the persisted TmuxName, and CreateTab reports
+// the spawned tmux name back so the TUI's instant-display attach binds to the
+// exact session rather than re-deriving one from the name.
+
 // uniqueShellName returns a shell-tab name not already used by any tab
 // in tabs: "shell", then "shell-2", "shell-3", ...
 func uniqueShellName(tabs []*Tab) string {
@@ -21,39 +46,58 @@ func uniqueTabName(tabs []*Tab, base string) string {
 }
 
 // uniqueTabNameExcluding returns base, or base with the lowest free "-N" suffix
-// (N>=2), such that the result collides with neither an existing tab's display
-// name nor an existing tab's live tmux token (see tabTmuxToken). exclude, when
-// non-nil, is skipped entirely — it is the tab being renamed, which must be
-// allowed to keep its own name (a no-op rename) and to reclaim its own tmux
-// token, neither of which any other tab can have taken.
+// (N>=2), such that the result collides with no other tab's CURRENT name.
+// exclude, when non-nil, is skipped entirely — it is the tab being renamed,
+// which must be allowed to keep its own name (a no-op rename), and which no
+// other tab can have taken from it.
 //
-// Reserving the tmux token as well as the name upholds this invariant: no tab's
-// NAME may equal another tab's live tmux token. That is what makes the tmux name
-// derived for any name handed out here (agent session + "__" + name, see
-// tab_spawn.go) guaranteed free. Before rename existed the two were always equal
-// and reserving the name alone was sufficient; a rename decouples them (it
-// deliberately does NOT rename the live tmux session — there is no tmux
-// rename-session primitive here, and the TUI keys live panes by tmux name), so
-// without the token reservation this sequence collides:
-//
-//	shell tab: Name="shell", tmux "af_x_T__shell" -> rename to "editor"
-//	-> Name="editor", tmux still "af_x_T__shell" -> `t` finds "shell" free
-//	-> new tab derives tmux "af_x_T__shell" -> collides with the live session.
+// It reads the live roster and nothing else, so a name stops being taken the
+// instant its tab is renamed away from it or closed. Collisions in the tmux
+// namespace are not this function's business: uniqueTabTmuxName handles them
+// where they arise, at spawn.
 //
 // This is the shared collision handling for shell tabs (AddShellTab), CLI-spawned
 // process tabs (AddProcessTab), web tabs (AddWebTab), and renames (RenameTab).
 func uniqueTabNameExcluding(tabs []*Tab, base string, exclude *Tab) string {
-	agentPrefix := agentTmuxPrefix(tabs)
-	used := make(map[string]bool, 2*len(tabs))
+	used := make(map[string]bool, len(tabs))
 	for _, t := range tabs {
 		if t == exclude {
 			continue
 		}
 		used[t.Name] = true
-		if token := tabTmuxToken(agentPrefix, t); token != "" {
+	}
+	return firstFreeName(used, base)
+}
+
+// uniqueTabTmuxName returns the tmux session name to spawn a new sibling tab
+// under: the agent session's sanitized name, the "__" separator, and a token
+// starting at base that collides with no live tmux session on the roster.
+//
+// base is the new tab's already-resolved display NAME, so the two normally
+// agree and a session stays greppable by the tab it belongs to. They diverge
+// only when a rename has left an older tab's live session holding the token —
+// the #1957 sequence — and then it is the spawned session, not the user's
+// requested name, that takes the "-2".
+//
+// agentSanitized is passed in rather than read off tabs[0] because the caller
+// (tab_spawn.go) already holds the agent session it is spawning a sibling of,
+// and an instance with no agent session cannot spawn a sibling at all.
+func uniqueTabTmuxName(tabs []*Tab, agentSanitized, base string) string {
+	prefix := agentSanitized + tmuxTabSeparator
+	used := make(map[string]bool, len(tabs))
+	for _, t := range tabs {
+		if token := tabTmuxToken(prefix, t); token != "" {
 			used[token] = true
 		}
 	}
+	return prefix + firstFreeName(used, base)
+}
+
+// firstFreeName returns base, or base with the lowest "-N" suffix (N>=2) that
+// used does not contain. Shared by both namespaces so a name and a tmux token
+// suffix identically ("fresh" -> "fresh-2"), which is what keeps the suffixed
+// spelling readable wherever it shows up.
+func firstFreeName(used map[string]bool, base string) string {
 	if !used[base] {
 		return base
 	}
@@ -65,35 +109,21 @@ func uniqueTabNameExcluding(tabs []*Tab, base string, exclude *Tab) string {
 	}
 }
 
-// agentTmuxPrefix returns the tmux session-name prefix every non-agent tab's
-// session extends — the agent tab's sanitized name plus the "__" separator
-// (tab_spawn.go derives each sibling as agentSanitized + "__" + name). Empty when
-// there is no agent session yet (an unstarted instance, or an empty tab list): a
-// sibling can't exist without one, so there is nothing to reserve. Tabs[0] is the
-// agent tab by invariant.
-func agentTmuxPrefix(tabs []*Tab) string {
-	if len(tabs) == 0 || tabs[0].tmux == nil {
-		return ""
-	}
-	return tabs[0].tmux.SanitizedName() + tmuxTabSeparator
-}
-
 // tabTmuxToken returns the EXACT name token a tab's live tmux session was derived
 // from at spawn: its session name with the agent prefix stripped. Because a
-// session is always "<agent sanitized>__<name>" by construction (tab_spawn.go),
-// stripping the prefix recovers the original spawn-time name whole — even when
-// that name itself contains "__" (a sanitized name may, since sanitizeTabName
-// keeps '_'), e.g. "logs__api" derives session "…__logs__api" whose token is
-// "logs__api", NOT the "api" a split-on-last-"__" would wrongly yield and leave
-// free for a colliding tab-create. It is this spawn-time token, not the tab's
-// current name (which a rename decouples from it), that a later
-// tab-create would collide with.
+// session is always "<agent sanitized>__<token>" by construction (tab_spawn.go),
+// stripping the prefix recovers the spawn-time token whole — even when that token
+// itself contains "__" (a sanitized name may, since sanitizeTabName keeps '_'),
+// e.g. "logs__api" derives session "…__logs__api" whose token is "logs__api", NOT
+// the "api" a split-on-last-"__" would wrongly yield and leave free for a
+// colliding spawn. It is this spawn-time token, not the tab's current name (which
+// a rename decouples from it), that a later spawn would collide with.
 //
-// Empty when there is nothing to reserve: a web/vscode tab (no PTY), an unstarted
-// tab, the agent tab, or an instance with no agent session (agentPrefix == "").
-// The HasPrefix guard is belt-and-suspenders — by construction every sibling
-// carries the prefix — and declines to reserve a token it can't derive honestly
-// rather than reserving a wrong one.
+// Empty when there is no live session to reserve against: a web/vscode tab (no
+// PTY), an unstarted tab, the agent tab, or an instance with no agent session
+// (agentPrefix == ""). The HasPrefix guard is belt-and-suspenders — by
+// construction every sibling carries the prefix — and declines to reserve a token
+// it can't derive honestly rather than reserving a wrong one.
 func tabTmuxToken(agentPrefix string, t *Tab) string {
 	if t == nil || t.Kind == TabKindAgent || t.tmux == nil || agentPrefix == "" {
 		return ""

--- a/session/tab_spawn.go
+++ b/session/tab_spawn.go
@@ -48,6 +48,15 @@ func (i *Instance) AddShellTab() (*Tab, error) {
 	agentTmux := i.tmuxLocked()
 	gw := i.gitWorktree
 	displayName := uniqueShellName(i.Tabs)
+	// Resolve the tmux session name under the SAME read lock as the display name:
+	// the two are independent namespaces (see tab_names.go) and both are read off
+	// i.Tabs, so deriving the tmux name after the unlock would read the roster
+	// unsynchronized. Guarded on agentTmux because a not-started instance has no
+	// session to spawn a sibling of — the precondition check below rejects it.
+	tmuxName := ""
+	if agentTmux != nil {
+		tmuxName = uniqueTabTmuxName(i.Tabs, agentTmux.SanitizedName(), displayName)
+	}
 	nTabs := len(i.Tabs)
 	i.mu.RUnlock()
 
@@ -67,9 +76,8 @@ func (i *Instance) AddShellTab() (*Tab, error) {
 
 	// Spawn outside the lock: Start shells out to `tmux new-session` and polls
 	// for the session to appear, which must not block other readers of i.mu. The
-	// tmux name is derived from the agent session + the unique name so it
-	// is collision-free and restorable by exact name.
-	tmuxName := agentTmux.SanitizedName() + tmuxTabSeparator + displayName
+	// tmux name was resolved above against the live sibling sessions, so it is
+	// collision-free and restorable by exact name.
 	shellTmux := agentTmux.NewSiblingSession(tmuxName, defaultShell())
 	if err := shellTmux.Start(worktreePath); err != nil {
 		return nil, fmt.Errorf("failed to start shell tab: %w", err)
@@ -129,6 +137,11 @@ func (i *Instance) AddProcessTab(command, requestedName string) (*Tab, error) {
 	agentTmux := i.tmuxLocked()
 	gw := i.gitWorktree
 	displayName := uniqueTabName(i.Tabs, processTabBaseName(requestedName, command))
+	// Both namespaces resolved under the one read lock; see AddShellTab.
+	tmuxName := ""
+	if agentTmux != nil {
+		tmuxName = uniqueTabTmuxName(i.Tabs, agentTmux.SanitizedName(), displayName)
+	}
 	nTabs := len(i.Tabs)
 	i.mu.RUnlock()
 
@@ -146,11 +159,10 @@ func (i *Instance) AddProcessTab(command, requestedName string) (*Tab, error) {
 		return nil, fmt.Errorf("cannot add a tab without a worktree")
 	}
 
-	// Spawn outside the lock (see AddShellTab): the tmux name is derived from the
-	// agent session + the unique, sanitized name so it is collision-free
-	// and restorable by exact name. The sibling inherits the agent session's PTY
-	// factory / executor — real in production, mock in tests.
-	tmuxName := agentTmux.SanitizedName() + tmuxTabSeparator + displayName
+	// Spawn outside the lock (see AddShellTab): the tmux name was resolved above
+	// against the live sibling sessions, so it is collision-free and restorable by
+	// exact name. The sibling inherits the agent session's PTY factory / executor
+	// — real in production, mock in tests.
 	procTmux := agentTmux.NewSiblingSession(tmuxName, command)
 	if err := procTmux.Start(worktreePath); err != nil {
 		return nil, fmt.Errorf("failed to start process tab: %w", err)


### PR DESCRIPTION
Fixes #1957

## The bug

`af sessions tab-rename beta --name fresh --new-name fresh-old` left the roster
with nothing named `fresh` — and the very next `tab-create --name fresh` answered
`fresh-2`. The state driving that suffix (a tmux session name frozen at spawn)
was surfaced nowhere, so the tool looked confused while it was actually being
careful.

## Which fix, and why

The issue offered two acceptable outcomes: **(1)** release the reservation on
rename *if provably safe*, or **(2)** keep it and say so. This PR does (1),
because the reservation was never really about the name.

A tab has **two** names, and the pre-existing code collapsed them into one
namespace:

| | what it is | must be unique among |
|---|---|---|
| **NAME** | the handle a user types; what every tab verb resolves against | the roster's **current** names |
| **TMUX SESSION NAME** | `<agent>__<token>`, frozen at spawn (restore rebinds by the persisted `TmuxName`; the TUI keys live panes by it) | the roster's **live tmux sessions** |

Before #1813 the two could never diverge, so one namespace sufficed. Rename made
them diverge, and the first fix kept a single namespace by *also* reserving each
tab's live tmux token **as a name**. That is what made `fresh` un-takeable. The
reservation was protective — without it the new tab re-derives the renamed tab's
still-live `…__fresh` and collides at spawn — but it charged the **user's**
namespace for a collision in **tmux's**.

Splitting them pays the same debt honestly:

* the NAME is free the instant its tab is renamed away from it (or closed);
* the **SPAWN** is what walks to `…__fresh-2` to miss the live session
  (`uniqueTabTmuxName`).

Nothing has to be "provably safe" by inspection here — the collision is dodged
where it actually exists, and the safety property the old reservation bought is
the one the new spawn-side check enforces directly. Option (3) from the issue
(renaming the live tmux session) stays rejected for the reasons stated there.

## The one place that assumed the two agreed

`Instance.AttachShellTab` — the TUI's instant-display projection after the
daemon's `CreateTab` — re-derived `"<agent>__" + name`. Post-split that would
bind a new tab named `shell` to the **older** tab's live `…__shell`. So
`CreateTab` now reports the tmux session it actually spawned
(`CreateTabResponse.tmux_name`, additive) and the TUI binds to that. An empty
value falls back to the old derivation, which is exactly right for its only
cause: a daemon predating the field, whose spawn used that same derivation.
`ReconcileTabsFromData` already bound by the persisted `TmuxName` and needed no
change. The web client reads only `.name`, so it is unaffected.

Reporting the tmux name also gets the issue's option (2) for free: the
reservation is now inspectable in the response instead of invisible.

## Adjacent verbs audited

* **close** — kills the tmux session, so both namespaces free up. A recreated
  tab gets the plain name *and* the plain session, no lingering `-2`. Test added.
* **reorder** — permutes the slice only; neither namespace changes hands. Test
  added.
* **dead-shell replacement** (`LocalBackend.setupTabs`) — was the second site
  re-deriving `<agent>__<name>`. It now reuses the dead tab's **own** persisted
  tmux name (the session it names is dead, so retaking it is free), falling back
  to `uniqueTabTmuxName` when there is none.
* **#1991** deliberately untouched — it is a separate sibling over
  `instance.go` positional keys.

## Fail-first

The three "the freed name comes back" tests fail on `master` with exactly the
issue's symptom; the three "don't over-free / adjacent verb" tests pass both
before and after (they are locks, not the fix):

```
=== RUN   TestRenameTab_FreesTheOldNameForANewTab
    tab_name_release_test.go:43:
        	Error:      	Not equal:
        	            	expected: "fresh"
        	            	actual  : "fresh-2"
        	Messages:   	the name the renamed tab gave up must be handed straight back, unsuffixed
    tab_name_release_test.go:49:
        	Error:      	Not equal:
        	            	expected: []string{"agent", "fresh-old", "fresh"}
        	            	actual  : []string{"agent", "fresh-old", "fresh-2"}
--- FAIL: TestRenameTab_FreesTheOldNameForANewTab (0.00s)
=== RUN   TestAddTab_SuffixesANameALiveTabStillHolds
--- PASS: TestAddTab_SuffixesANameALiveTabStillHolds (0.00s)
=== RUN   TestRenameTab_CreateRenameRoundTrips
    tab_name_release_test.go:98:
        	Error:      	Not equal:
        	            	expected: "fresh"
        	            	actual  : "fresh-2"
--- FAIL: TestRenameTab_CreateRenameRoundTrips (0.00s)
=== RUN   TestRenameTab_FreedNameIsFreeForATmuxlessTab
    tab_name_release_test.go:133:
        	Error:      	Not equal:
        	            	expected: "dashboard"
        	            	actual  : "dashboard-2"
--- FAIL: TestRenameTab_FreedNameIsFreeForATmuxlessTab (0.00s)
=== RUN   TestCloseTab_FreesNameAndTmuxToken
--- PASS: TestCloseTab_FreesNameAndTmuxToken (0.01s)
=== RUN   TestReorderTab_TouchesNeitherNamespace
--- PASS: TestReorderTab_TouchesNeitherNamespace (0.00s)
FAIL	github.com/sachiniyer/agent-factory/session	0.046s
```

The two pre-existing tests that encoded the old behavior
(`TestRenameTab_FreesNoTmuxTokenForALaterSpawn`,
`TestRenameTab_TmuxTokenSurvivesSeparatorInName`) are **kept**, with their
load-bearing half — the new tab must not land on the renamed tab's live session —
intact and now asserted alongside the name that must come back unsuffixed. The
first is renamed to `TestRenameTab_SpawnDodgesTheStillLiveTmuxSession` to say
what it actually guards.

The daemon-level test (`TestCreateTab_ReusesTheNameARenamedTabGaveUp`) replays the
issue's CLI sequence through resolve → spawn → persist → respond and asserts no
two persisted tabs share a tmux session. It has no fail-first output because it
asserts on the new 2-name return, which doesn't compile against `master`.

## Verified against real tmux

Play-test sandbox, `af` built from this branch, the issue's repro verbatim:

```console
$ af sessions tab-create beta --command "sleep 600" --name fresh   -> {"name": "fresh"}
$ af sessions tab-rename beta --name fresh --new-name fresh-old    -> {"name": "fresh-old"}
$ af sessions tab-create beta --command "sleep 600" --name fresh   -> {"name": "fresh"}   # was "fresh-2"

$ af sessions get beta
  agent      af_f5fff34b_beta
  fresh-old  af_f5fff34b_beta__fresh
  fresh      af_f5fff34b_beta__fresh-2

$ tmux list-panes -a | grep beta
  af_f5fff34b_beta         bash
  af_f5fff34b_beta__fresh  sleep      # the renamed tab, still running
  af_f5fff34b_beta__fresh-2 sleep     # the new tab, its own session
```

And the no-over-freeing half, live: a fourth `--name fresh` while a tab still
holds that name → `{"name": "fresh-2"}`, session `…__fresh-2-2`.

## Gates

* `gofmt -l .` clean · `golangci-lint run --timeout=3m --fast` clean ·
  `deadcode -test ./...` clean · `scripts/lint-file-length.sh` passes
  (`session/instance.go` trimmed back to 1000)
* `make test-container` — full suite green
* `scripts/testbox.sh selftest` — **56/56 steps green**, including the `t`
  add-shell-tab → open-pane cycle that drives the changed `AttachShellTab`
  binding against real tmux

— Captain Claude
