### PR TITLE
fix(daemon): closing a tab ends that tab's PTY stream (#2136)

### DIFF
--- a/agentproto/message.go
+++ b/agentproto/message.go
@@ -43,15 +43,41 @@ func NewResizeMessage(rows, cols uint16) ResizeMessage {
 	return ResizeMessage{Type: MsgResize, Rows: rows, Cols: cols}
 }
 
+// ExitReason says WHY a MsgExit ended the stream. It is an additive
+// discriminator (#1029: additive envelope, no renames): a client that ignores it
+// reads every exit exactly as it did before the field existed, which is the
+// correct end-of-stream handling in all cases — the stream it was reading is over
+// and reconnecting to it is pointless. A client that reads it can say something
+// truer than "the agent exited".
+type ExitReason string
+
+const (
+	// ExitReasonTabClosed marks the exit of a stream whose TAB was closed (#2136),
+	// as opposed to the session-wide end (an empty reason). The distinction is
+	// per-stream either way — both mean "this PTY is gone" — so it changes only what
+	// a client can RENDER and whether it may keep other tabs of the same session
+	// open, never whether it stops reading this one.
+	ExitReasonTabClosed ExitReason = "tab_closed"
+)
+
 // ExitMessage reports the agent/PTY end code.
 type ExitMessage struct {
 	Type MessageType `json:"type"`
 	Code int         `json:"code"`
+	// Reason is why the stream ended; omitempty so the session-end exit every
+	// existing client already handles goes on the wire byte-identically.
+	Reason ExitReason `json:"reason,omitempty"`
 }
 
 // NewExitMessage builds an exit notice.
 func NewExitMessage(code int) ExitMessage {
 	return ExitMessage{Type: MsgExit, Code: code}
+}
+
+// NewTabClosedMessage builds the exit notice for a stream whose tab was closed
+// (#2136). Code 0: a closed tab is an orderly teardown, not a crashed process.
+func NewTabClosedMessage() ExitMessage {
+	return ExitMessage{Type: MsgExit, Code: 0, Reason: ExitReasonTabClosed}
 }
 
 // DetachMessage is a client's clean-close signal.

--- a/agentproto/message_test.go
+++ b/agentproto/message_test.go
@@ -16,6 +16,10 @@ func TestControlMessageWireShapes(t *testing.T) {
 		{"resize", NewResizeMessage(24, 80), `{"type":"resize","rows":24,"cols":80}`},
 		{"exit", NewExitMessage(0), `{"type":"exit","code":0}`},
 		{"exit_nonzero", NewExitMessage(137), `{"type":"exit","code":137}`},
+		// #2136: the tab-close exit is the SAME frame with an additive reason, and
+		// the reasonless session-end exit above must stay byte-identical (omitempty)
+		// so no existing client sees a changed wire shape.
+		{"exit_tab_closed", NewTabClosedMessage(), `{"type":"exit","code":0,"reason":"tab_closed"}`},
 		{"detach", NewDetachMessage(), `{"type":"detach"}`},
 	}
 	for _, tc := range cases {

--- a/daemon/ws_pty.go
+++ b/daemon/ws_pty.go
@@ -321,9 +321,23 @@ func writePTYStream(ctx context.Context, sub session.PTYSubscription, conn *webs
 			// agent-server, which already emits MsgExit that the TUI attach consumes
 			// (apiclient/attach.go). Go stream consumers (TUI live panes) ignore an
 			// unrecognized control frame, so the added frame is safe for them.
+			//
+			// A tab close (#2136) is a third case that used to be NEITHER: CloseTab
+			// killed the tab's tmux without touching its broker, so NextEvent never
+			// returned and a PTY-only client sat on a dead stream until the keepalive
+			// dropped it ~15s later. It now ends the stream with ErrTabClosed, which
+			// WRAPS io.EOF — so it takes the same "tell the client" branch, and the only
+			// difference on the wire is the exit's additive reason field. An old client
+			// reads a plain exit and settles exactly as it does on a session end (which
+			// is right: this stream is over either way); a client that reads the reason
+			// can say "tab closed" and leave the session's other tabs alone.
 			if ctx.Err() == nil && errors.Is(err, io.EOF) {
+				exit := agentproto.NewExitMessage(0)
+				if errors.Is(err, session.ErrTabClosed) {
+					exit = agentproto.NewTabClosedMessage()
+				}
 				ectx, ecancel := context.WithTimeout(context.Background(), wsWriteTimeout)
-				_ = agentproto.WriteControl(ectx, conn, agentproto.NewExitMessage(0))
+				_ = agentproto.WriteControl(ectx, conn, exit)
 				ecancel()
 			}
 			return

--- a/integration/cli_daemon_test.go
+++ b/integration/cli_daemon_test.go
@@ -32,6 +32,7 @@ type instanceData struct {
 	TmuxName    string `json:"tmux_name"`
 	BackendType string `json:"backend_type"`
 	Tabs        []struct {
+		ID   string `json:"id"`
 		Name string `json:"name"`
 		Kind int    `json:"kind"`
 	} `json:"tabs"`

--- a/integration/ws_pty_test.go
+++ b/integration/ws_pty_test.go
@@ -164,6 +164,86 @@ func TestWSPTYSessionKillEmitsExit(t *testing.T) {
 	waitUntil(t, 5*time.Second, "subscriber received MsgExit on session kill", func() bool {
 		return a.sawExit()
 	})
+	// The session-end exit carries NO reason — the additive tab-close reason
+	// (#2136) must not leak onto the path every existing client already handles.
+	if r := a.exitReason(); r != "" {
+		t.Errorf("session-kill exit reason = %q, want empty", r)
+	}
+}
+
+// TestWSPTYCloseTabNotifiesSubscribers is the #2136 regression: closing a TAB
+// must end that tab's PTY stream with a protocol-level exit, promptly. Before the
+// fix CloseTab killed the tab's tmux session but left its broker open, so a
+// PTY-only subscriber (a third-party client on apiclient.DialStream, which is not
+// on the events plane) got NOTHING — it sat on a dead stream until the WS
+// keepalive dropped it up to 15s later, with no way to tell the tab had gone.
+//
+// It also pins the property the fix must not trade for that: brokers are per-tab,
+// so closing one tab must NOT tear down a SIBLING tab's live stream.
+func TestWSPTYCloseTabNotifiesSubscribers(t *testing.T) {
+	testguard.SkipDarwinPTYStream(t)
+	h := newHarness(t)
+	h.startDaemon()
+	h.createSession("wstabclose")
+
+	// Two process tabs running `cat`, so each pane echoes what its own subscriber
+	// sends and the two streams are provably distinct.
+	h.run("sessions", "--repo", h.repo, "tab-create", "wstabclose", "--command", "cat", "--name", "alpha")
+	h.run("sessions", "--repo", h.repo, "tab-create", "wstabclose", "--command", "cat", "--name", "beta")
+	closedID := h.tabID(t, "wstabclose", "alpha")
+	siblingID := h.tabID(t, "wstabclose", "beta")
+
+	// Address both by their STABLE tab id (#1738) — the id-native path a real
+	// client binds on, and the identity the broker is keyed by.
+	closed := h.dialWS(t, "/v1/sessions/wstabclose/stream?tab_id="+closedID)
+	defer closed.close()
+	sibling := h.dialWS(t, "/v1/sessions/wstabclose/stream?tab_id="+siblingID)
+	defer sibling.close()
+	closed.sendInput(t, []byte("alpha-marker\n"))
+	closed.waitOutput(t, "alpha-marker")
+	sibling.sendInput(t, []byte("beta-marker\n"))
+	sibling.waitOutput(t, "beta-marker")
+
+	h.run("sessions", "--repo", h.repo, "tab-delete", "wstabclose", "--name", "alpha")
+
+	// PROMPT: 5s is well inside the 15s keepalive this used to fall through to.
+	waitUntil(t, 5*time.Second, "closed tab's subscriber received an exit", func() bool {
+		return closed.sawExit()
+	})
+	// ...and it says WHY, so a client can render "tab closed" and leave the rest of
+	// the session alone. An older client that ignores the field reads a plain exit
+	// and settles the same way it does on a session end — which is also right here.
+	if r := closed.exitReason(); r != "tab_closed" {
+		t.Errorf("closed tab's exit reason = %q, want %q", r, "tab_closed")
+	}
+
+	// NO over-teardown: the sibling tab's stream is untouched and still live.
+	if sibling.sawExit() {
+		t.Fatal("closing one tab must not exit a SIBLING tab's stream")
+	}
+	sibling.sendInput(t, []byte("beta-still-here\n"))
+	sibling.waitOutput(t, "beta-still-here")
+}
+
+// tabID resolves a session's tab name to its stable id (#1738), the handle the
+// stream binds on (?tab_id=).
+func (h *harness) tabID(t *testing.T, title, tabName string) string {
+	t.Helper()
+	for _, s := range h.listSessions() {
+		if s.Title != title {
+			continue
+		}
+		for _, tab := range s.Tabs {
+			if tab.Name == tabName {
+				if tab.ID == "" {
+					t.Fatalf("session %q tab %q has no stable id", title, tabName)
+				}
+				return tab.ID
+			}
+		}
+	}
+	t.Fatalf("session %q has no tab named %q", title, tabName)
+	return ""
 }
 
 // wsClient is a test subscriber: a coder/websocket connection with a read pump
@@ -177,6 +257,10 @@ type wsClient struct {
 	out     []byte
 	resizes []agentproto.ResizeMessage
 	exited  bool
+	// lastExitReason is the exit's additive "reason" (#2136), read as a bare
+	// string rather than through the agentproto type so this harness asserts the
+	// WIRE contract a third-party client sees.
+	lastExitReason string
 	// cursor is the absolute replay cursor, tracked the way a real client tracks it
 	// (ui/termpane, web/src/terminal.ts): seeded from the handshake seq, ADOPTED from
 	// every HELLO frame, and advanced by each PTY_OUT byte. Deliberately NOT
@@ -245,6 +329,11 @@ func (c *wsClient) readPump() {
 				c.resizes = append(c.resizes, rm)
 			}
 		} else if typ, _ := agentproto.MessageTypeOf(msg.Text); typ == agentproto.MsgExit {
+			var em struct {
+				Reason string `json:"reason"`
+			}
+			_ = json.Unmarshal(msg.Text, &em)
+			c.lastExitReason = em.Reason
 			c.exited = true
 		}
 		c.mu.Unlock()
@@ -281,6 +370,14 @@ func (c *wsClient) sawExit() bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.exited
+}
+
+// exitReason is the "reason" carried by the MsgExit this client received, or ""
+// for the reasonless session-end exit (#2136).
+func (c *wsClient) exitReason() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.lastExitReason
 }
 
 // sinceCursor is the absolute seq this client has consumed — what it would send as

--- a/session/agentserver.go
+++ b/session/agentserver.go
@@ -3,6 +3,7 @@ package session
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 )
 
@@ -12,6 +13,19 @@ import (
 // tab by its stable id, silently serving whatever tab now sits at some ordinal is
 // the misroute the id exists to prevent (#1779). Callers map it to a 404/gone.
 var ErrTabGone = errors.New("no tab with that id")
+
+// ErrTabClosed ends a PTY subscription whose TAB was closed (#2136), as opposed
+// to the session-wide teardown that ends every tab's stream at once (Kill). It is
+// the end-of-stream error CloseTab hands the closed tab's subscribers so the WS
+// writer can name the cause instead of leaving them blocked until the keepalive
+// gives up.
+//
+// It WRAPS io.EOF deliberately: every consumer of a subscription already treats
+// io.EOF as "this stream is over" (daemon/ws_pty.go, the attach clients, the
+// tests), and a tab close IS that — only with a known cause. Wrapping means the
+// distinction is opt-in for the one caller that renders it, and no existing
+// errors.Is(err, io.EOF) check has to learn about tabs.
+var ErrTabClosed = fmt.Errorf("tab closed: %w", io.EOF)
 
 // TabAddressableServer is implemented by an agent-server whose data plane can be
 // addressed by a tab's STABLE id (#1738) instead of a shifting ordinal. It is the
@@ -197,8 +211,9 @@ type Observation struct {
 type PTYSubscription interface {
 	// NextEvent blocks until the next stream event (output bytes or a resize
 	// echo), ctx cancellation, or Close. It returns io.EOF once the stream ends
-	// (the session's PTY vanished or the broker closed). A client that reconnects
-	// resumes from Seq() via Subscribe(since).
+	// (the session's PTY vanished or the broker closed), or ErrTabClosed — which
+	// wraps io.EOF — when the end came from THIS tab being closed (#2136). A client
+	// that reconnects resumes from Seq() via Subscribe(since).
 	NextEvent(ctx context.Context) (PTYEvent, error)
 	// Seq reports the cursor of the next output byte this subscriber will read, so
 	// a client that reconnects can resume the gap with Subscribe(since).

--- a/session/agentserver_local.go
+++ b/session/agentserver_local.go
@@ -298,6 +298,41 @@ func (s *localAgentServer) ensureBrokerByID(tabID string) (*ptyBroker, error) {
 	return br, nil
 }
 
+// tabStreamCloser is the optional agent-server capability of ending ONE tab's
+// PTY stream — the data-plane half of closing a tab. It is deliberately narrow
+// and unexported: CloseTab is a session-package operation, and a runtime that
+// has no in-process broker to close (the remote agent-server, whose brokers live
+// on the far side of the wire) simply does not implement it.
+type tabStreamCloser interface {
+	closeTabStream(tabID string)
+}
+
+var _ tabStreamCloser = (*localAgentServer)(nil)
+
+// closeTabStream tears down the data plane of the ONE tab named by tabID (#2136):
+// its subscribers' NextEvent returns ErrTabClosed and its clientless capture
+// stops, so a PTY-only client learns the tab is gone at once instead of blocking
+// on a stream that will never produce another byte. Every OTHER tab's broker is
+// untouched — the map is keyed by the tab's STABLE id (#1738), so this can only
+// ever reach the tab that was actually closed, even after a reorder.
+//
+// The broker is also dropped from the map: the id is never reused, so keeping a
+// closed broker under it would only retain the ring buffer. Safe to call for a
+// tab that has no broker (nobody ever streamed it), was already closed, or on an
+// agent-server already torn down by Kill — each is a no-op.
+func (s *localAgentServer) closeTabStream(tabID string) {
+	if tabID == "" {
+		return
+	}
+	s.mu.Lock()
+	br := s.brokers[tabID]
+	delete(s.brokers, tabID)
+	s.mu.Unlock()
+	if br != nil {
+		br.closeTab()
+	}
+}
+
 func (s *localAgentServer) SubscribeTab(tabID string, since Seq) (PTYSubscription, error) {
 	br, err := s.ensureBrokerByID(tabID)
 	if err != nil {

--- a/session/instance.go
+++ b/session/instance.go
@@ -488,35 +488,6 @@ func (i *Instance) TabTmuxName(idx int) string {
 	return ts.SanitizedName()
 }
 
-// CloseTab kills the tab at idx and removes it from Tabs. The agent tab (idx 0)
-// is unclosable; CloseTab errors on idx 0 or any out-of-range index. The tab is
-// removed from Tabs regardless of whether the tmux teardown succeeds (best-
-// effort, matching LocalBackend.Kill) so a broken session can't wedge the tab
-// list. Unlike Kill this does not wait for the pane to exit: the worktree is not
-// being removed, so there is no #802 delete race to guard against.
-func (i *Instance) CloseTab(idx int) error {
-	i.mu.Lock()
-	if idx <= 0 || idx >= len(i.Tabs) {
-		i.mu.Unlock()
-		return fmt.Errorf("tab cannot be closed")
-	}
-	tab := i.Tabs[idx]
-	i.Tabs = append(i.Tabs[:idx], i.Tabs[idx+1:]...)
-	i.mu.Unlock()
-
-	if tab.tmux == nil {
-		return nil
-	}
-	// Pane state deliberately ignored: closing ONE tab touches no worktree, so
-	// nothing destructive follows an unknown here. (A Close that fails after the
-	// tab was already dropped from i.Tabs above leaks the tmux session — true of
-	// every Close failure, not just a timeout, and unchanged by #1917.)
-	if _, err := tab.tmux.Close(); err != nil {
-		return fmt.Errorf("failed to close tab %q: %w", tab.Name, err)
-	}
-	return nil
-}
-
 // AttachShellTab reconnects this local instance's in-memory tab list to a shell
 // tab that already exists server-side — one the daemon's CreateTab RPC just
 // spawned out-of-band (#960 PR 2). It is the no-spawn counterpart of

--- a/session/ptybroker.go
+++ b/session/ptybroker.go
@@ -120,6 +120,12 @@ type ptyBroker struct {
 	capturing   bool
 	stopCapture func() // tears down the capture goroutine + clientless channel
 	closed      bool
+	// tabClosed records that this broker was shut down because ITS TAB was closed
+	// (#2136) rather than because the whole session was torn down. It only selects
+	// which end-of-stream error NextEvent reports (ErrTabClosed vs bare io.EOF);
+	// the teardown itself is identical. Set under mu in the same section that
+	// latches closed, so a subscriber can never observe one without the other.
+	tabClosed bool
 }
 
 func newPTYBroker(ch clientlessChannel) *ptyBroker {
@@ -608,11 +614,23 @@ func (b *ptyBroker) remove(id uint64) {
 }
 
 // close tears down the broker: every subscriber's NextEvent returns io.EOF and
-// the clientless capture is stopped. Called when the session is killed. Holds
-// captureMu (captureMu-then-mu ordering) so it cannot race a concurrent
+// the clientless capture is stopped. Called when the session is killed.
+func (b *ptyBroker) close() { b.shutdown(false) }
+
+// closeTab is close for a broker whose TAB was closed (#2136) — the same
+// teardown, but each subscriber's NextEvent reports ErrTabClosed so the WS writer
+// can tell the client its tab went away rather than leaving it to time out on the
+// keepalive. Only the closed tab's broker is shut down; a sibling tab of the same
+// session has its own broker and keeps streaming.
+func (b *ptyBroker) closeTab() { b.shutdown(true) }
+
+// shutdown is the shared teardown behind close/closeTab. Holds captureMu
+// (captureMu-then-mu ordering) so it cannot race a concurrent
 // ensureCaptureStarted into resurrecting a capture on a closed broker (#1661) —
-// a bring-up that lost the race sees b.closed and unwinds.
-func (b *ptyBroker) close() {
+// a bring-up that lost the race sees b.closed and unwinds. Idempotent: a second
+// shutdown (a tab closed while the session is being killed, or the reverse) sees
+// closed and returns without re-running the teardown or flipping the reason.
+func (b *ptyBroker) shutdown(tabClosed bool) {
 	b.captureMu.Lock()
 	defer b.captureMu.Unlock()
 
@@ -622,6 +640,7 @@ func (b *ptyBroker) close() {
 		return
 	}
 	b.closed = true
+	b.tabClosed = tabClosed
 	b.wakeAllLocked()
 	var stop func()
 	if b.capturing {
@@ -673,7 +692,14 @@ func (s *ptySub) NextEvent(ctx context.Context) (PTYEvent, error) {
 	for {
 		s.br.mu.Lock()
 		if s.br.closed {
+			tabClosed := s.br.tabClosed
 			s.br.mu.Unlock()
+			if tabClosed {
+				// ErrTabClosed wraps io.EOF, so a consumer that only asks "is the stream
+				// over" is unaffected; the daemon's WS writer asks the narrower question
+				// and turns it into an exit with a tab_closed reason (#2136).
+				return PTYEvent{}, ErrTabClosed
+			}
 			return PTYEvent{}, io.EOF
 		}
 		// The initial screen repaint is delivered before anything else, so a fresh

--- a/session/tab_close.go
+++ b/session/tab_close.go
@@ -1,0 +1,70 @@
+package session
+
+import "fmt"
+
+// Closing one tab: the destructive tab verb. Where tab_arrange.go's rename and
+// reorder never touch tmux, a close ends a real process — and, since #1592 Phase
+// 2 PR6, a real PTY STREAM. Both halves live here so neither can be updated
+// without the other in view: killing the tmux session while leaving that tab's
+// broker open is exactly the bug #2136 reported (a PTY-only subscriber blocked
+// until its 15s keepalive gave up, with nothing on the wire to say the tab went
+// away).
+
+// CloseTab kills the tab at idx, ends its PTY stream, and removes it from Tabs.
+// The agent tab (idx 0) is unclosable; CloseTab errors on idx 0 or any
+// out-of-range index. The tab is removed from Tabs regardless of whether the tmux
+// teardown succeeds (best-effort, matching LocalBackend.Kill) so a broken session
+// can't wedge the tab list. Unlike Kill this does not wait for the pane to exit:
+// the worktree is not being removed, so there is no #802 delete race to guard
+// against.
+func (i *Instance) CloseTab(idx int) error {
+	i.mu.Lock()
+	if idx <= 0 || idx >= len(i.Tabs) {
+		i.mu.Unlock()
+		return fmt.Errorf("tab cannot be closed")
+	}
+	tab := i.Tabs[idx]
+	i.Tabs = append(i.Tabs[:idx], i.Tabs[idx+1:]...)
+	i.mu.Unlock()
+
+	// End this tab's stream BEFORE its tmux dies — the same order localAgentServer
+	// .Kill uses for the session-wide case (brokers first, then the backend), and
+	// for the same reason: a subscriber should be told the stream is over rather
+	// than left reading a pane that has just been killed out from under it. Run
+	// unconditionally, including on the tmux-less paths below, so the notification
+	// never depends on how far the teardown gets.
+	i.endTabPTYStream(tab.ID)
+
+	if tab.tmux == nil {
+		return nil
+	}
+	// Pane state deliberately ignored: closing ONE tab touches no worktree, so
+	// nothing destructive follows an unknown here. (A Close that fails after the
+	// tab was already dropped from i.Tabs above leaks the tmux session — true of
+	// every Close failure, not just a timeout, and unchanged by #1917.)
+	if _, err := tab.tmux.Close(); err != nil {
+		return fmt.Errorf("failed to close tab %q: %w", tab.Name, err)
+	}
+	return nil
+}
+
+// endTabPTYStream shuts down the PTY broker serving the tab with this STABLE id
+// (#1738), so its subscribers get a prompt end-of-stream (ErrTabClosed → an exit
+// with reason "tab_closed" on the wire) instead of a silent socket that only the
+// keepalive eventually reaps (#2136). Sibling tabs keep their own brokers and
+// keep streaming.
+//
+// It reads the CACHED agent-server rather than calling AgentServer(): a session
+// nobody has streamed has no cached server and therefore no brokers, so there is
+// nothing to notify — and building one here purely to close nothing would be a
+// side effect on a teardown path. The cached field is read under i.mu, then
+// released before the call: closing a broker takes the agent-server's own lock,
+// and the ordering rule is i.mu THEN s.mu, never nested the other way.
+func (i *Instance) endTabPTYStream(tabID string) {
+	i.mu.RLock()
+	as := i.agentSrv
+	i.mu.RUnlock()
+	if c, ok := as.(tabStreamCloser); ok {
+		c.closeTabStream(tabID)
+	}
+}

--- a/session/tab_close_stream_test.go
+++ b/session/tab_close_stream_test.go
@@ -1,0 +1,141 @@
+package session
+
+import (
+	"errors"
+	"io"
+	"testing"
+	"time"
+)
+
+// #2136: closing a tab must end THAT tab's PTY stream. Before the fix CloseTab
+// only killed the tab's tmux session, leaving its broker open — so a subscriber
+// (a third-party client on apiclient.DialStream, or a pane) blocked on a stream
+// that could never produce another byte until the 15s WS keepalive dropped it,
+// with nothing on the protocol saying the tab had gone.
+//
+// The three properties pinned here are the ones the fix must not trade against
+// each other: the closed tab's subscribers end PROMPTLY and with a distinguishable
+// cause, a SIBLING tab's subscribers are untouched (the brokers are per-tab, keyed
+// by stable id — a session-wide teardown would be a regression, not a fix), and a
+// repeat/no-subscriber close is a no-op rather than a double-close panic.
+
+// newTabStreamInstance builds a started instance with an agent tab and two shell
+// tabs whose brokers are injected over in-memory channels, since a probe instance
+// has no real tmux pane for ensureBroker to bind. The tabs carry no tmux session,
+// so CloseTab's teardown is exercised without a tmux server.
+func newTabStreamInstance(t *testing.T) (*Instance, *localAgentServer, map[string]*ptyBroker) {
+	t.Helper()
+	inst, _ := newProbeInstance(t)
+	agent := &Tab{ID: newTabID(), Name: agentTabName, Kind: TabKindAgent}
+	first := &Tab{ID: newTabID(), Name: "alpha", Kind: TabKindShell}
+	second := &Tab{ID: newTabID(), Name: "beta", Kind: TabKindShell}
+	inst.mu.Lock()
+	inst.Tabs = []*Tab{agent, first, second}
+	inst.mu.Unlock()
+
+	las := inst.AgentServer().(*localAgentServer)
+	brokers := map[string]*ptyBroker{
+		agent.ID:  newPTYBroker(&fakeClientlessChannel{}),
+		first.ID:  newPTYBroker(&fakeClientlessChannel{}),
+		second.ID: newPTYBroker(&fakeClientlessChannel{}),
+	}
+	las.mu.Lock()
+	las.brokers = brokers
+	las.mu.Unlock()
+	return inst, las, brokers
+}
+
+// TestCloseTabEndsOnlyThatTabsStream is the #2136 regression: the closed tab's
+// subscriber ends with ErrTabClosed straight away, and the sibling tab's
+// subscriber keeps streaming.
+func TestCloseTabEndsOnlyThatTabsStream(t *testing.T) {
+	inst, las, brokers := newTabStreamInstance(t)
+	tabs := inst.GetTabs()
+	closedID, siblingID := tabs[1].ID, tabs[2].ID
+
+	closedSub, err := brokers[closedID].subscribe(0)
+	if err != nil {
+		t.Fatalf("subscribe closed tab: %v", err)
+	}
+	siblingSub, err := brokers[siblingID].subscribe(0)
+	if err != nil {
+		t.Fatalf("subscribe sibling tab: %v", err)
+	}
+
+	if err := inst.CloseTab(1); err != nil {
+		t.Fatalf("CloseTab: %v", err)
+	}
+
+	// The closed tab's subscriber is woken NOW (the 2s bound stands in for the
+	// keepalive it used to wait out) and can tell a tab close from a session end.
+	if _, err := nextWithin(t, closedSub, 2*time.Second); !errors.Is(err, ErrTabClosed) {
+		t.Fatalf("NextEvent on the closed tab = %v, want ErrTabClosed", err)
+	}
+	// ...while still reading as end-of-stream to every consumer that only asks
+	// io.EOF (the whole point of wrapping it).
+	if _, err := nextWithin(t, closedSub, 2*time.Second); !errors.Is(err, io.EOF) {
+		t.Fatalf("ErrTabClosed must wrap io.EOF for existing end-of-stream checks; got %v", err)
+	}
+	// The closed tab's broker is dropped, so nothing retains its ring buffer.
+	las.mu.Lock()
+	_, stillMapped := las.brokers[closedID]
+	las.mu.Unlock()
+	if stillMapped {
+		t.Error("the closed tab's broker must be dropped from the agent-server")
+	}
+
+	// The SIBLING tab is untouched: its stream is still live and still delivering.
+	brokers[siblingID].feed([]byte("still-here"))
+	for {
+		ev, err := nextWithin(t, siblingSub, 2*time.Second)
+		if err != nil {
+			t.Fatalf("sibling tab's subscriber must stay live, got %v", err)
+		}
+		if ev.Kind != PTYData { // the fresh subscriber's one-shot repaint
+			continue
+		}
+		if string(ev.Data) != "still-here" {
+			t.Fatalf("sibling event = %+v, want data %q", ev, "still-here")
+		}
+		return
+	}
+}
+
+// TestCloseTabStreamTeardownIsIdempotent pins the safety properties: closing a
+// tab nobody streams, an already-closed broker, and a repeat close must all be
+// no-ops rather than panics or double-closes.
+func TestCloseTabStreamTeardownIsIdempotent(t *testing.T) {
+	inst, las, brokers := newTabStreamInstance(t)
+	tabs := inst.GetTabs()
+	closedID := tabs[1].ID
+
+	// Already closed by a racing session teardown: closing the tab on top of it
+	// must not re-run the teardown or panic.
+	brokers[closedID].close()
+	if err := inst.CloseTab(1); err != nil {
+		t.Fatalf("CloseTab over an already-closed broker: %v", err)
+	}
+
+	// A tab nobody ever streamed has no broker at all.
+	las.mu.Lock()
+	delete(las.brokers, tabs[2].ID)
+	las.mu.Unlock()
+	if err := inst.CloseTab(1); err != nil { // beta is at index 1 now
+		t.Fatalf("CloseTab for a tab with no broker: %v", err)
+	}
+
+	// And an agent-server that never built a broker map at all (nothing streamed):
+	// no map, no id, no subscribers — still a no-op.
+	las.mu.Lock()
+	las.brokers = nil
+	las.mu.Unlock()
+	las.closeTabStream("some-id")
+	las.closeTabStream("")
+
+	// Idempotent at the broker itself: repeated teardowns of either flavour on the
+	// same broker must not double-close its capture.
+	agentBroker := brokers[tabs[0].ID]
+	agentBroker.closeTab()
+	agentBroker.closeTab()
+	agentBroker.close()
+}


### PR DESCRIPTION
Fixes #2136

## The bug

`CloseTab` killed the tab's tmux session and stopped there. Brokers are per-tab
(`localAgentServer.brokers`, keyed by the tab's stable id since #1738), and
`broker.close()` had exactly one caller: `localAgentServer.Kill`. So closing a tab
left its broker open on a pane that had just been killed — a subscriber on
`/v1/sessions/{title}/stream` received **nothing**: no bytes, no control frame,
no socket close. It blocked until the WS keepalive gave up, up to 15s later.

Official clients paper over this by watching `/v1/events` and closing the PTY
socket on `session.updated`. A PTY-only consumer — a third-party client on the
exported `apiclient.DialStream` — is not on the events plane and had no signal at
all.

## The fix

`CloseTab` now shuts down the broker for **the tab it closed**, addressed by that
tab's STABLE id (#1738/#2153), before killing its tmux — the same order
`localAgentServer.Kill` already uses for the session-wide case. Sibling tabs have
their own brokers and are untouched. The broker is also dropped from the map (the
id is never reused, so keeping it would only retain a dead ring buffer).

`Instance.CloseTab` moved out of `session/instance.go` into a new
`session/tab_close.go` alongside the stream teardown, so the two halves of
"closing a tab" can't be edited apart again. (It also keeps `instance.go` under
the 1000-line file-length limit — it was sitting exactly on it.)

## Which protocol message, and why

**Reused `MsgExit`, plus an additive `reason` field — not a new message type.**

I read both consumers first. `web/src/terminal.ts` (`onControl`'s `"exit"` arm)
marks *its own* socket exited, stops reconnecting and closes it;
`apiclient/attach.go` returns from *its own* read loop. Neither takes a
session-wide action — both treat `MsgExit` as **"this stream is over"**, which is
exactly true of a closed tab. So `MsgExit` is the right frame, and it is also the
only frame today's clients already handle correctly here: a distinct
`MsgTabClosed` would be an *unknown* frame to every shipped client, which would
fall through to the socket close and reconnect-loop against a tab that no longer
exists — strictly worse than what they do now.

What was missing is the *cause*, so that goes on additively (#1029: additive
envelope, no renames):

```json
{"type":"exit","code":0,"reason":"tab_closed"}
```

`reason` is `omitempty`, so the session-end exit stays byte-identical
(`{"type":"exit","code":0}`) — pinned by a case in the wire-shape table test, and
asserted in `TestWSPTYSessionKillEmitsExit` (kill's exit must carry an EMPTY
reason). Old clients read a plain exit and settle exactly as they do today; a
client that reads `reason` can render "tab closed" and leave the session's other
tabs alone.

Internally the cause travels as `session.ErrTabClosed`, which **wraps `io.EOF`**.
That is what keeps this a one-line change at the seam: every existing
`errors.Is(err, io.EOF)` end-of-stream check (the WS writer, the attach clients,
the tests) keeps working unchanged, and only the one caller that renders the cause
asks the narrower question.

Idempotent by construction: the teardown is once-guarded on `b.closed`, an unknown
/ empty tab id is a no-op, and a tab whose broker was already closed by a racing
session kill just returns.

## Fail-first

`make test-container` on **master** (fix stashed, tests applied):

```
=== RUN   TestWSPTYCloseTabNotifiesSubscribers
    ws_pty_test.go:210: timeout waiting for closed tab's subscriber received an exit
--- FAIL: TestWSPTYCloseTabNotifiesSubscribers (8.52s)
FAIL	github.com/sachiniyer/agent-factory/integration	8.526s
```

That is the bug verbatim: 5s of nothing on a stream whose tab was deleted a moment
earlier. With the fix:

```
=== RUN   TestWSPTYStreamTabRouting
--- PASS: TestWSPTYStreamTabRouting (3.53s)
=== RUN   TestWSPTYSessionKillEmitsExit
--- PASS: TestWSPTYSessionKillEmitsExit (1.53s)
=== RUN   TestWSPTYCloseTabNotifiesSubscribers
--- PASS: TestWSPTYCloseTabNotifiesSubscribers (1.79s)
```

## Tests

- `integration/ws_pty_test.go` — `TestWSPTYCloseTabNotifiesSubscribers`: a real
  daemon, two `cat` process tabs, both streamed by `?tab_id=` (the id-native path
  a real client binds on). Closing one gets an exit within 5s **with**
  `reason == "tab_closed"`; the sibling's subscriber has NOT exited and still
  echoes fresh input. The harness reads `reason` as a bare JSON string, not
  through the Go type, so it asserts the wire contract a third-party sees.
- `integration/ws_pty_test.go` — `TestWSPTYSessionKillEmitsExit` extended: the
  session-end exit still fires and carries no reason (no regression, no leakage of
  the new field onto the old path).
- `session/tab_close_stream_test.go` — the closed tab's subscriber ends with
  `ErrTabClosed` (and it still reads as `io.EOF`), its broker is dropped, the
  sibling's subscription keeps delivering; plus the idempotency cases (already
  closed, no broker, no broker map, empty id, double `closeTab`).
- `agentproto/message_test.go` — the additive wire shape and the unchanged one.

## Deliberately out of scope

- The issue's "codebase inconsistency" note (input/resize errors dropped in
  `readPTYClient`, so a client can't infer closure from a failed keystroke): a
  separate change to how the reader surfaces errors, and unnecessary now that the
  closure is announced. Happy to file it if you want it tracked.
- `web/src/terminal.ts` could print "[tab closed]" instead of "[agent exited
  (code 0)]" now, but the web bundle is committed and touching it drags a
  `make web-build` + rebase-conflict surface into a daemon fix. Its behavior is
  already correct (settles, stops reconnecting); only the wording is generic.

— Captain Claude
