### PR TITLE
fix(tui-driver): never submit an unconfirmed paste; boot past a scrolled rail (#2147, #2148)

### DIFF
--- a/docs/tui-manual-testing.md
+++ b/docs/tui-manual-testing.md
@@ -166,7 +166,7 @@ compose across `docker exec` invocations.
 | Function | Keys | Completion marker |
 |----------|------|-------------------|
 | `af_reset_sandbox` | — | wipes instances/branches for a deterministic rerun (sandbox-scoped, fails closed) |
-| `af_boot` | launch `af` | `Agent Factory` + `Instances (` frame |
+| `af_boot` | launch `af` | `Agent Factory` frame + the instance rail painted — `Instances (` **or** the scrolled `▲ N more` the rail shows in its place (#2148) |
 | `af_new_instance <name>` | `n`,text,`Enter` | the row shows `<name> … ●` (ready) |
 | `af_select <name>` | `k`×,`j`× | `<name>`'s row shows `▾` |
 | `af_open_pane` | `s` | pane-focus menu (`x hide pane`) |
@@ -175,6 +175,7 @@ compose across `docker exec` invocations.
 | `af_exit_interactive` | `Ctrl-]` | interactive menu gone |
 | `af_send_to_pane <text>` | marker+text,`Enter` | short delivery marker echoes in the pane (then wait for output yourself) |
 | `af_attach` | `o` | TUI chrome gone (full-screen) |
+| `af_send_line <text> [t]` | text,`Enter` | the WHOLE line echoed on the attached screen. **Fails closed** (#2147): it clears and re-pastes up to `AF_DRIVER_SEND_LINE_ATTEMPTS` times, and if the line still never lands complete it returns non-zero having sent **no** `Enter` — a submitted partial leaves an unbalanced quote and drops the shell into `>` |
 | `af_detach [raw_seq]` | `Ctrl-W` (once) | TUI chrome back **and** the attach client is reaped (guards #1157) |
 | `af_new_tab` | `t` | tab-child count rises |
 | `af_close_tab` | `w` | tab-child count falls |

--- a/scripts/tui-driver-selftest.sh
+++ b/scripts/tui-driver-selftest.sh
@@ -348,12 +348,21 @@ _expect_attach_send_no_truncation() {
             printf '%s' "$n" > "$state"
             printf 'dev@host:~/sandbox/mock-repo$ %s\n' "$(_vis_for "$n")"
         }
-        af_send_literal() { printf '1' > "$state"; return 0; }
-        af_send() { [ "${1:-}" = Enter ] && submitted="$(_vis_for "$(cat "$state" 2>/dev/null || echo 0)")"; return 0; }
+        af_send_literal() { printf '0' > "$state"; return 0; }
+        # ctrl-u wipes the input line, exactly as readline does — af_send_line
+        # clears before each paste (#2147), and a stub that ignored the clear
+        # would leave the previous attempt's text on screen and confirm it.
+        af_send() {
+            case "${1:-}" in
+                Enter) submitted="$(_vis_for "$(cat "$state" 2>/dev/null || echo 0)")" ;;
+                C-u)   printf '0' > "$state" ;;
+            esac
+            return 0
+        }
 
         # 1. The naive sequence must truncate here, or the stub isn't reproducing
         #    the race and the pass below would be meaningless.
-        printf '1' > "$state"; submitted='<none>'
+        printf '0' > "$state"; submitted='<none>'
         af_send_literal "$target"; af_send Enter
         if [ "$submitted" = "$target" ]; then
             rm -f "$state"
@@ -362,7 +371,7 @@ _expect_attach_send_no_truncation() {
         fi
 
         # 2. af_send_line waits for the whole line before Enter, so it submits it intact.
-        printf '1' > "$state"; submitted='<none>'
+        printf '0' > "$state"; submitted='<none>'
         af_send_line "$target" 3
         rm -f "$state"
         if [ "$submitted" = "$target" ]; then
@@ -374,35 +383,133 @@ _expect_attach_send_no_truncation() {
 }
 
 # _expect_short_command_delivery_waits — regression proof for the SHORT-command
-# hole in the #1995 fix. _af_delivery_tail used a bare `${ws: -24}`, which bash
-# evaluates to the EMPTY string whenever the command is shorter than 24
-# characters (it does not clamp to the whole string). The empty tail then
-# satisfied _af_wait_for_line_echo's `[ -z "$tail" ]` short-circuit, so
-# af_send_line returned WITHOUT waiting — silently degrading back into the exact
-# race #1995 is about, for most real commands ('git status', 'ls -la', 'make').
+# hole in the #1995 fix, now expressed against the whole-line matcher (#2147).
 #
-# _expect_attach_send_no_truncation could not catch this: its command is 31
-# characters, so it always had a real tail. This drives the SHORT case directly.
+# The original hole was in _af_delivery_tail: a bare `${ws: -24}` evaluates to
+# the EMPTY string whenever the command is shorter than 24 characters (bash does
+# not clamp to the whole string), and an empty tail satisfied the matcher's
+# `[ -z "$tail" ]` short-circuit — so af_send_line returned WITHOUT waiting for
+# most real commands ('git status', 'ls -la', 'make'). Matching the WHOLE text
+# removes the tail, and with it the short-command special case: there is no
+# length below which the matcher stops looking at anything. This pins the
+# BEHAVIOUR that hole broke, so it stays locked however the matcher is written.
+#
+# Both polarities, because either alone is satisfiable by a broken matcher: one
+# that always fails passes the negative, one that always succeeds passes the
+# positive.
 # shellcheck disable=SC2317  # dispatched indirectly via step(); not dead code.
 _expect_short_command_delivery_waits() {
     (
-        local short='git status' tail rc=0
+        local short='git status' rc=0
 
-        # 1. The tail of a short command must be non-empty, or every check below
-        #    it is vacuous.
-        tail="$(_af_delivery_tail "$short")"
-        if [ -z "$tail" ]; then
-            _af_fail "#1995: _af_delivery_tail('$short') is EMPTY — short commands skip the delivery wait entirely"
+        # 1. NEGATIVE — a screen that never echoes the command must never
+        #    confirm. Reporting success here is the bug: delivery "confirmed"
+        #    for a paste that never arrived.
+        af_capture() { printf '%s\n' 'dev@host:~/sandbox/mock-repo$ '; }
+        _af_wait_for_line_echo "$short" 1 >/dev/null 2>&1 || rc=$?
+        if [ "$rc" -eq 0 ]; then
+            _af_fail "#1995: _af_wait_for_line_echo reported success for a short command that never echoed"
             return 1
         fi
 
-        # 2. Against a screen that NEVER echoes the command, the wait must FAIL
-        #    (time out). Returning 0 here is the bug: it reports delivery
-        #    confirmed for a paste that never arrived.
-        af_capture() { printf '%s\n' 'dev@host:~/sandbox/mock-repo$ '; }
-        _af_wait_for_line_echo "$short" 1 'short command never echoed' >/dev/null 2>&1 || rc=$?
+        # 2. POSITIVE — once the short command IS echoed it must confirm, or the
+        #    negative above would also pass on a matcher that never matches.
+        af_capture() { printf '%s\n' 'dev@host:~/sandbox/mock-repo$ git status'; }
+        if ! _af_wait_for_line_echo "$short" 1 >/dev/null 2>&1; then
+            _af_fail "#1995: _af_wait_for_line_echo failed to confirm a short command that IS fully echoed"
+            return 1
+        fi
+        return 0
+    )
+}
+
+# _expect_partial_middle_not_confirmed — the assumption #2147 broke. The old
+# matcher checked a 24-character TAIL of the line, on the theory that the only
+# way a paste can be incomplete is a racing Enter chopping its END. The
+# full-screen attach path falsifies that: whole INTERIOR chunks go missing while
+# the tail lands (reproduced live — a 128-char line arrived as chunks 1, 2 and 4,
+# with chunk 3 dropped), and a tail-only check happily confirms that mangled
+# line, so af_send_line submits a command the user never wrote.
+#
+# The stub is that live shape: the screen holds the line's first half and its
+# last quarter, with a 32-byte middle chunk missing. The tail is fully present,
+# so a tail matcher returns 0 here; the whole-line matcher must not.
+# shellcheck disable=SC2317  # dispatched indirectly via step(); not dead code.
+_expect_partial_middle_not_confirmed() {
+    (
+        local target mangled tail_ws mangled_ws rc=0
+        target='sed -i "/first item/a ./todo.sh done 1" test.sh && echo tests-edited-2147'
+        # Drop 20 characters out of the MIDDLE, keep the rest — including the
+        # whole tail window — verbatim.
+        mangled="${target:0:20}${target:40}"
+        af_capture() { printf 'dev@host:~/sandbox/mock-repo$ %s\n' "$mangled"; }
+
+        # Premise: the old 24-character tail check would still PASS on this
+        # screen. Without that, the case proves nothing about tail matching —
+        # it would just be another "incomplete line" the old code also caught.
+        tail_ws="$(printf '%s' "$target" | tr -d '[:space:]')"; tail_ws="${tail_ws: -24}"
+        mangled_ws="$(printf '%s' "$mangled" | tr -d '[:space:]')"
+        if ! printf '%s' "$mangled_ws" | grep -Fq -- "$tail_ws"; then
+            _af_fail "#2147 stub is not reproducing the shape: the mangled screen lost the TAIL too, so a tail matcher would have caught it"
+            return 1
+        fi
+
+        _af_wait_for_line_echo "$target" 1 >/dev/null 2>&1 || rc=$?
         if [ "$rc" -eq 0 ]; then
-            _af_fail "#1995: _af_wait_for_line_echo reported success for a short command that never echoed"
+            _af_fail "#2147: delivery was CONFIRMED for a line with a dropped middle chunk — af_send_line would submit a mangled command"
+            return 1
+        fi
+        return 0
+    )
+}
+
+# _expect_send_line_refuses_partial — the #2147 headline: af_send_line must not
+# press Enter on a line it could not confirm.
+#
+# The old helper logged "submitting best-effort" and submitted anyway. That is
+# strictly worse than failing: the live repro pasted a ~120-character QUOTED
+# command, only its first 32 bytes landed, and submitting that prefix left bash
+# in its `>` continuation prompt — after which every later scripted command
+# became a continuation line and the whole scenario was driving a corrupted
+# shell while reporting success.
+#
+# The stub makes the live drop permanent: the screen only ever shows the first 32
+# bytes, on every attempt. Three things are asserted, and the first is the one
+# that matters — no Enter is EVER sent. A helper that returns non-zero but has
+# already submitted has still wrecked the session.
+# shellcheck disable=SC2317  # dispatched indirectly via step(); not dead code.
+_expect_send_line_refuses_partial() {
+    (
+        local target enters=0 cleared=0 rc=0
+        target='sed -i '"'"'/\.\/todo.sh | grep -q "first item"/a ./todo.sh done 1'"'"' test.sh && echo tests-edited'
+        # The real clock and the real poll sleep are used deliberately. _af_now is
+        # called as `$(_af_now)`, i.e. in a SUBSHELL, so a counter-in-a-variable
+        # clock stub can never advance and the wait loop spins forever; and
+        # stubbing sleep against a real clock busy-forks for the whole timeout.
+        # A 1s budget over 2 attempts keeps this at ~2s.
+        af_capture() { printf 'dev@host:~/sandbox/mock-repo$ %s\n' "${target:0:32}"; }
+        af_send_literal() { return 0; }
+        af_send() {
+            case "${1:-}" in
+                Enter) enters=$(( enters + 1 )) ;;
+                C-u)   cleared=$(( cleared + 1 )) ;;
+            esac
+            return 0
+        }
+
+        AF_DRIVER_SEND_LINE_ATTEMPTS=2
+        af_send_line "$target" 1 >/dev/null 2>&1 || rc=$?
+
+        if [ "$enters" -ne 0 ]; then
+            _af_fail "#2147: af_send_line SUBMITTED an unconfirmed partial line (${enters} Enter(s)) — that is what corrupts the attached shell"
+            return 1
+        fi
+        if [ "$rc" -eq 0 ]; then
+            _af_fail "#2147: af_send_line reported SUCCESS for a line that only ever landed as a 32-byte prefix"
+            return 1
+        fi
+        if [ "$cleared" -eq 0 ]; then
+            _af_fail "#2147: af_send_line gave up without clearing the partial line, leaving an unbalanced fragment on the prompt"
             return 1
         fi
         return 0
@@ -483,6 +590,155 @@ _expect_cycle_w_closes_viewed() {
     af_refute_screen 'AF_CYCLE_T2' 'the viewed shell tab was closed, so its marker is gone' || return 1
 }
 
+# _expect_live_attach_send_line — the LIVE half of #2147, and the reason the
+# stub above is not enough on its own. The #1995 case is a deterministic stub
+# proof, and it stayed green while the real 80x24 attach path mis-drove every
+# day: only a driver talking to a real attach can show that a ~120-character
+# quoted command actually arrives whole and RUNS.
+#
+# Shaped to reproduce the drop rather than dodge it. The paste goes in
+# immediately after af_attach, which is where the loss concentrates (the first
+# paste after an attach truncated on 3 of 3 live attempts with no added settle,
+# versus intermittently later), so af_send_line's clear-and-re-paste recovery is
+# exercised on nearly every run rather than only when unlucky.
+#
+# The asserted marker is COMPUTED by the command (arithmetic expansion), so
+# AF_2147_9182 can appear ONLY in the command's OUTPUT — the echoed input line
+# shows the literal $((9000+182)). A shell that echoed the line but never ran it
+# therefore fails here. Single quotes are REQUIRED so the arithmetic reaches the
+# attached shell unexpanded.
+#
+# The refute is the corruption check proper: an unbalanced quote from a
+# submitted prefix leaves bash in its `>` continuation prompt, which is the
+# state that swallowed every subsequent command in the #2147 report.
+# shellcheck disable=SC2317  # dispatched indirectly via step(); not dead code.
+# shellcheck disable=SC2016
+_expect_live_attach_send_line() {
+    local saved_cols="$AF_DRIVER_COLS" saved_rows="$AF_DRIVER_ROWS" rc=0
+    # shellcheck disable=SC2016
+    local cmd='printf "%s\n" "af-2147-alpha-bravo-charlie-delta-echo" | grep -q "charlie" && echo AF_2147_$((9000+182))'
+
+    af_resize 80 24 || return 1
+    if af_select beta && af_attach; then
+        af_send_line "$cmd" || rc=$?
+        if [ "$rc" -eq 0 ]; then
+            af_wait_for 'AF_2147_9182([^0-9]|$)' 15 'the WHOLE quoted line ran in the attached shell' || rc=$?
+            af_refute_screen '^>' 'attached shell is NOT stuck in a quote-continuation prompt (#2147)' || rc=$?
+        fi
+        # shellcheck disable=SC2119  # af_detach's optional arg is for encoded keys
+        af_detach || rc=1
+    else
+        rc=1
+    fi
+
+    af_resize "$saved_cols" "$saved_rows" || return 1
+    return "$rc"
+}
+
+# _expect_scrolled_rail_reads_as_booted — regression proof for #2148, driven off
+# stubbed captures (no live TUI) so all three polarities are deterministic.
+#
+# 1. POSITIVE: the exact first frame from the report — three sessions at 80x24
+#    with a lower one restored, so the rail has scrolled `Instances (N)` out of
+#    the window and drew `▲ 2 more` in its place. af_boot waited 35s for the
+#    header, never saw it, and reported a boot failure for a TUI that had booted
+#    fine with every session alive.
+# 2. NEGATIVE (not booted): a bare shell prompt must still time out. Without
+#    this, "fix" the marker by matching anything and the boot gate becomes
+#    decorative — it would report success for an af that never started.
+# 3. NEGATIVE (pane text): a workspace pane printing "▲ 3 more" must NOT satisfy
+#    the gate. The indicator is anchored to the sidebar's left edge, so only
+#    leading whitespace may precede it; pane text always carries the sidebar
+#    columns and a pane border ahead of it.
+# shellcheck disable=SC2317  # dispatched indirectly via step(); not dead code.
+_expect_scrolled_rail_reads_as_booted() {
+    (
+        # Real clock/sleep on purpose — see _expect_send_line_refuses_partial:
+        # `$(_af_now)` is a subshell, so a variable-counter clock stub never
+        # advances and the negative probes would spin forever. The positive
+        # matches on its first capture; the two negatives cost 1s each.
+        af_capture() {
+            cat <<'SCREEN'
+                      ╭────────────────────────────────────────╮
+ Agent Factory        │ PREVIEW gamma · ◆ Agent                │
+ ▲ 2 more             │dev@host:~/sandbox/mock-repo-gamma$     │
+                      │                                        │
+  ▸  beta          ●  │                                        │
+     ⎇-dev/beta       │                                        │
+                      │                                        │
+  ▾  gamma         ●  │                                        │
+     ⎇-dev/gamma      │                                        │
+                      │                                        │
+    └ 1 ◆ Agent *     │                                        │
+                      ╰────────────────────────────────────────╯
+     n new • D kill │ t new tab • w close tab │ ? help • q quit
+SCREEN
+        }
+        # Premise: the frame really is missing the header, or this is just
+        # re-testing the case that always worked.
+        if af_capture | grep -qE -- 'Instances \('; then
+            _af_fail "#2148 stub is not reproducing the shape: the scrolled frame still shows the Instances header"
+            return 1
+        fi
+        if ! af_wait_for "$_AF_RAIL_MARKER" 3 'scrolled rail reads as booted (#2148)' >/dev/null 2>&1; then
+            _af_fail "#2148: a scrolled rail (▲ N more, header off-window) was not accepted as booted"
+            return 1
+        fi
+
+        local rc=0
+        af_capture() { printf '%s\n' 'dev@host:~/sandbox/mock-repo$ '; }
+        af_wait_for "$_AF_RAIL_MARKER" 1 'not booted' >/dev/null 2>&1 || rc=$?
+        if [ "$rc" -eq 0 ]; then
+            _af_fail "#2148: the boot marker matched a bare shell prompt — the gate no longer proves af booted"
+            return 1
+        fi
+
+        rc=0
+        af_capture() {
+            printf '%s\n' '  ▾  alpha        ●  │ $ cat rail.txt                     │'
+            printf '%s\n' '     ⎇-dev/alpha     │ ▲ 3 more                           │'
+        }
+        af_wait_for "$_AF_RAIL_MARKER" 1 'pane text' >/dev/null 2>&1 || rc=$?
+        if [ "$rc" -eq 0 ]; then
+            _af_fail "#2148: pane output containing '▲ 3 more' satisfied the boot gate — the indicator is not anchored to the sidebar"
+            return 1
+        fi
+        return 0
+    )
+}
+
+# _expect_scrolled_rail_relaunch — the LIVE half of #2148. Three sessions at
+# 80x24 with the lowest selected is exactly the reported state: the rail scrolls,
+# the header is gone, and the boot gate has to read the frame as booted anyway.
+# af_relaunch shares af_boot's gate, so this drives the real thing end to end.
+#
+# The premise is asserted AFTER the relaunch rather than assumed: if the rail
+# happened NOT to scroll, the relaunch would pass on unfixed code too and this
+# step would be quietly vacuous.
+# shellcheck disable=SC2317  # dispatched indirectly via step(); not dead code.
+_expect_scrolled_rail_relaunch() {
+    local saved_cols="$AF_DRIVER_COLS" saved_rows="$AF_DRIVER_ROWS" rc=0
+
+    af_resize 80 24 || return 1
+    if af_select cycle; then
+        af_relaunch || rc=$?
+        if [ "$rc" -eq 0 ]; then
+            if ! af_capture | grep -qE -- '^[[:space:]]*▲ [0-9]+ more'; then
+                _af_log "#2148 premise not met: the 80x24 rail did NOT scroll, so this step proves nothing"
+                rc=1
+            elif af_capture | grep -qE -- 'Instances \('; then
+                _af_log "#2148 premise not met: the header is still visible, so the old gate would have passed too"
+                rc=1
+            fi
+        fi
+    else
+        rc=1
+    fi
+
+    af_resize "$saved_cols" "$saved_rows" || return 1
+    return "$rc"
+}
+
 printf '=== tui-driver self-test (#1161) ===\n'
 printf 'session=%s size=%sx%s home=%s\n' \
     "$AF_DRIVER_SESSION" "$AF_DRIVER_COLS" "$AF_DRIVER_ROWS" "$AGENT_FACTORY_HOME"
@@ -495,6 +751,11 @@ step "reset sandbox to a clean state"                       af_reset_sandbox
 # af_resize works (#1174 item 2 / #1201).
 step "boot af at ${AF_DRIVER_COLS}x${AF_DRIVER_ROWS}"        af_boot
 step "af_resize fails loudly on an impossible resize"       _expect_resize_rejected
+# --- #2148 regression: the boot gate must survive a scrolled rail ---
+# The `Instances (N)` header is the rail's first windowed ROW, not chrome, so a
+# scrolled rail hides it behind `▲ N more` and a header-only gate false-times-out
+# on a TUI that booted fine. Deterministic stub proof — both polarities.
+step "a scrolled rail still reads as booted (#2148)"        _expect_scrolled_rail_reads_as_booted
 step "create instance 'alpha'"                              af_new_instance alpha
 
 # --- #1174 item 1 / #1199 regression: the SINGLE-instance false positive ---
@@ -712,6 +973,15 @@ step "detach (and prove the attach client was reaped)"      af_detach
 step "attach send-line does not submit a truncated command (#1995)" _expect_attach_send_no_truncation
 step "short commands still wait for their echo (#1995)"      _expect_short_command_delivery_waits
 
+# --- #2147 regression: an unconfirmed paste must never become shell input ---
+# The attach path really does drop bytes, so "submit best-effort" turns a
+# ~120-char quoted command into a 32-byte prefix, bash into its `>` continuation
+# prompt, and every later scripted command into a continuation line. Two stub
+# proofs (no live TUI) then the live 80x24 attach the daily play-test found it in.
+step "a dropped middle chunk must not confirm delivery (#2147)" _expect_partial_middle_not_confirmed
+step "af_send_line REFUSES to submit a partial line (#2147)"   _expect_send_line_refuses_partial
+step "live attach: a long quoted line lands whole and RUNS (#2147)" _expect_live_attach_send_line
+
 step "assert selection survived attach/detach"              af_expect_selected beta
 step "assert no orphan tmux attach clients"                 af_assert_no_orphan_clients
 step "pane text must not inflate the tab count (#1561 review)" _expect_pane_text_not_counted_as_tabs
@@ -752,6 +1022,11 @@ step "cycle: add a shell-2 tab (t)"                         af_new_tab
 step "cycle: open the active tab as a pane"                 af_open_pane
 step "cycle: pane number-jumps land and STAY (#1885)"       _expect_cycle_jumps_land
 step "cycle: w closes the VIEWED tab, not the tree's (#1884)" _expect_cycle_w_closes_viewed
+
+# --- #2148 live: relaunch at 80x24 with three sessions and the lowest selected.
+# Runs last because it needs a third instance ('cycle') to make the rail scroll,
+# and because it relaunches the TUI.
+step "relaunch boots with the rail scrolled past the header (#2148)" _expect_scrolled_rail_relaunch
 
 printf '\n=== SELF-TEST PASSED — %d/%d steps green ===\n' "$PASS" "$PASS"
 printf 'the #1156 mis-drive is now a deterministic scenario.\n'

--- a/scripts/tui-driver.sh
+++ b/scripts/tui-driver.sh
@@ -41,6 +41,7 @@
 : "${AF_DRIVER_POLL:=0.25}"                       # capture-pane poll interval
 : "${AF_DRIVER_DETACH_KEY:=C-w}"                 # tmux key that detaches attach
 : "${AF_DRIVER_STATE_DIR:=${TMPDIR:-/tmp}/af-driver}"  # cross-call scratch
+: "${AF_DRIVER_SEND_LINE_ATTEMPTS:=4}"           # af_send_line paste retries
 : "${AGENT_FACTORY_AUTO_UPDATE:=false}"          # disable startup auto-update: a
                                                  # branch binary built behind the
                                                  # latest release would try to
@@ -236,54 +237,74 @@ _af_wait_for_pane_echo() {
     done
 }
 
-# _af_delivery_tail <text> — a distinctive whitespace-free suffix of <text>. A
-# racing Enter after a paste truncates the TAIL, so the tail is exactly what must
-# be on screen before it is safe to submit. Whitespace is removed so a wrap at
-# the terminal edge can't hide it; the last 24 non-space characters are enough to
-# be distinctive while short enough to stay within one line.
-_af_delivery_tail() {
-    local ws; ws="$(printf '%s' "$1" | tr -d '[:space:]')"
-    # Bash evaluates ${ws: -N} to the EMPTY STRING when N exceeds the string's
-    # length — it does NOT clamp to the whole string (zsh does, which is exactly
-    # what makes this easy to get wrong). An empty tail then satisfies the
-    # `[ -z "$tail" ]` short-circuit in _af_wait_for_line_echo, which "confirms"
-    # delivery on the first iteration WITHOUT waiting — silently degrading
-    # af_send_line back into the naive send-then-Enter race (#1995) for every
-    # command under 24 characters, i.e. most real commands. Fall back to the
-    # whole stripped string when it is shorter than the window.
-    if [ "${#ws}" -le 24 ]; then
-        printf '%s' "$ws"
-    else
-        printf '%s' "${ws: -24}"
-    fi
+# _af_line_echo_count <text> — how many times the WHOLE of <text> is currently
+# echoed on an UNFRAMED (full-screen attach) screen.
+#
+# Both sides are stripped of ALL whitespace before comparing, which buys three
+# things at once and is why this is not a plain `grep -F` on the raw capture:
+#   * a line that WRAPPED at the terminal edge still matches (the wrap is just a
+#     newline between two halves of the same string);
+#   * a space that fell exactly ON the wrap column is not fatal — capture-pane
+#     right-trims every row, so that space is simply absent from the capture
+#     (observed live: a 128-char line echoes as 127 captured characters, missing
+#     the space between `echo` and its argument);
+#   * the compare is byte-wise on the stripped strings, so it is independent of
+#     the sandbox's C/POSIX locale (cf. _af_tab_count).
+#
+# Matching the WHOLE text — not a suffix of it — is the #2147 correction. The
+# old check matched a 24-character TAIL, on the theory that a racing Enter can
+# only truncate the END of a paste. That theory does not hold on the full-screen
+# attach path: whole interior chunks of a paste can go missing while the tail
+# lands (reproduced live — a 128-char line echoed as chunks 1, 2 and 4 with
+# chunk 3 dropped), and a tail-only check CONFIRMS that mangled line. A probe
+# that cannot see the middle of the line must not get to vouch for it.
+_af_line_echo_count() {
+    local text_ws screen_ws count
+    text_ws="$(printf '%s' "$1" | tr -d '[:space:]')"
+    if [ -z "$text_ws" ]; then printf '0'; return 0; fi
+    screen_ws="$(af_capture | tr -d '[:space:]')"
+    count="$(printf '%s' "$screen_ws" | grep -oF -- "$text_ws" | wc -l)" || count=0
+    count="${count//[^0-9]/}"
+    printf '%s' "${count:-0}"
+    return 0
 }
 
-# _af_wait_for_line_echo <text> [timeout_s] [label] — wait until <text> has FULLY
-# echoed on an UNFRAMED (full-screen attach) screen. It matches a whitespace-free
-# tail of <text> against the whitespace-stripped screen, so a line that wrapped
-# at the terminal edge is still recognized. This is the full-screen counterpart
-# to _af_wait_for_pane_echo: there is no pane box to reconstruct, so stripping ALL
-# whitespace is both sufficient and locale-independent (pure ASCII compare).
+# _af_wait_for_line_echo <text> [timeout_s] [baseline] — wait until the
+# screen shows MORE than <baseline> (default 0) complete echoes of <text>. This
+# is the full-screen counterpart to _af_wait_for_pane_echo: there is no pane box
+# to reconstruct, so the whitespace-stripped compare above is sufficient.
+#
+# The baseline is what keeps the confirmation honest across repeats. A command
+# the driver already ran once is still on screen in the scrollback, so a bare
+# "is it there?" check would confirm the NEXT paste of the same text before a
+# single byte of it had landed. Callers pass the count they measured immediately
+# before pasting, so what is confirmed is that THIS paste added an occurrence.
+#
+# Deliberately silent: af_send_line retries around it and owns the diagnostics,
+# so a recovered attempt does not print a TIMEOUT banner into a passing run.
 # Returns 0 on match, 1 on timeout.
 _af_wait_for_line_echo() {
-    local text="$1" timeout="${2:-8}" label="${3:-line echo}" screen tail screen_ws
-    tail="$(_af_delivery_tail "$text")"
+    local text="$1" timeout="${2:-8}" baseline="${3:-0}"
     local deadline; deadline=$(( $(_af_now) + timeout ))
     while :; do
-        screen="$(af_capture)"
-        screen_ws="$(printf '%s' "$screen" | tr -d '[:space:]')"
-        if [ -z "$tail" ] || printf '%s' "$screen_ws" | grep -Fq -- "$tail"; then
+        if [ "$(_af_line_echo_count "$text")" -gt "$baseline" ]; then
             return 0
         fi
         if [ "$(_af_now)" -ge "$deadline" ]; then
-            _af_log "TIMEOUT ${timeout}s waiting for: $label"
-            _af_log "----- last screen -----"
-            printf '%s\n' "$screen" >&2
-            _af_log "-----------------------"
             return 1
         fi
         sleep "$AF_DRIVER_POLL"
     done
+}
+
+# _af_clear_input_line — wipe whatever is sitting on the attached shell's input
+# line (ctrl-u, readline's unix-line-discard). Used by af_send_line both BETWEEN
+# retries — so a re-paste appends to an empty line instead of concatenating onto
+# a partial one — and on give-up, so a failed delivery leaves the shell at a
+# clean prompt rather than holding an unbalanced fragment.
+_af_clear_input_line() {
+    af_send C-u
+    sleep "$AF_DRIVER_POLL"
 }
 
 # af_ensure_nav — force a known focus state. Ctrl-] exits interactive mode (a
@@ -451,6 +472,36 @@ af_reset_sandbox() {
     sleep 0.5
 }
 
+# _AF_RAIL_MARKER — proof that the instance rail has painted, i.e. that af is
+# past its first frame and not merely showing chrome. Used as the second boot
+# gate by af_boot and af_relaunch.
+#
+# It accepts EITHER the section header OR the rail's scrolled-up indicator,
+# because the header is not chrome: it is the rail's first windowed ROW
+# (ui/sidebar_render.go String()), so it scrolls out of the window like any
+# other row. At 80x24 with three sessions and the middle or lower one selected,
+# the rail scrolls and renders `▲ 2 more` where the header used to be — the TUI
+# has booted perfectly, every session is alive, and a header-only gate waits the
+# full timeout and reports a boot failure that never happened (#2148).
+#
+# The two alternatives are exhaustive rather than a widened net: the rail draws
+# the ▲ indicator exactly when it has hidden rows above (hiddenAbove > 0), and
+# when it has not, row 0 — the header — is on screen. One of them is always
+# present the instant the rail paints, whichever session the restored selection
+# lands on. Neither is present before af paints, so this still fails a boot that
+# did not happen: a shell prompt, a build error, or a hung launch matches
+# nothing here. (`Agent Factory`, the sidebar's title chip, is NOT sufficient on
+# its own — it is static chrome that paints with the frame, so it would go on
+# matching an af that rendered its shell and no rail at all.)
+#
+# The indicator is anchored to the sidebar's left edge — only leading whitespace
+# may precede it — the same anchor _af_tab_count uses, so a workspace pane that
+# happens to print "▲ 3 more" cannot satisfy the boot gate: pane text is always
+# preceded on its row by the sidebar columns and the pane's own border. `▲` is
+# matched as a literal byte sequence rather than inside a bracket expression,
+# which the sandbox's C/POSIX locale would match byte-wise (#1994).
+: "${_AF_RAIL_MARKER:=Instances \(|^[[:space:]]*▲ [0-9]+ more}"
+
 # af_boot — launch af at a fixed size in a fresh driver session and wait for
 # the first frame. Pre-seeds help_screens_seen so the one-time overlays
 # (instance-created, attach, interactive) never appear — the single biggest
@@ -485,7 +536,8 @@ af_boot() {
     af_send_literal "cd $AF_DRIVER_REPO && $bin"
     af_send Enter
     af_wait_for 'Agent Factory' "$AF_DRIVER_TIMEOUT" 'af first frame' || return 1
-    af_wait_for 'Instances \(' "$AF_DRIVER_TIMEOUT" 'instances header' || return 1
+    af_wait_for "$_AF_RAIL_MARKER" "$AF_DRIVER_TIMEOUT" \
+        'instance rail painted (header or scrolled ▲ indicator)' || return 1
     af_focus_tree
 }
 
@@ -670,22 +722,60 @@ af_send_to_pane() {
 }
 
 # af_send_line <text> [timeout_s] — paste <text> into a FULL-SCREEN attach and
-# submit it, but only AFTER confirming the whole paste has landed in the input
+# submit it, but ONLY after confirming the whole paste has landed in the input
 # line. In a full-screen attach, af_send_literal streams the bytes through the
 # raw attach proxy into the nested session; a following bare `af_send Enter` can
 # overtake the still-draining paste and execute a TRUNCATED command (#1995) — the
 # harness analog of submit.go's load-bearing drain wait, which the attach path
-# lacks. The driver can SEE the attached screen, so it asserts delivery (waits
-# for the text to echo) instead of guessing, then sends Enter. Use this rather
-# than a bare `af_send_literal … ; af_send Enter` whenever the submitted command
-# matters. Precondition: a full-screen attach is active (af_attach).
+# lacks. The driver can SEE the attached screen, so it asserts delivery instead
+# of guessing. Use this rather than a bare `af_send_literal … ; af_send Enter`
+# whenever the submitted command matters. Precondition: a full-screen attach is
+# active (af_attach). Returns non-zero if the line could not be delivered.
+#
+# It FAILS CLOSED (#2147). The old version confirmed best-effort: on an
+# unconfirmed paste it logged a note and pressed Enter anyway. That is strictly
+# worse than not delivering at all, because the attach path really does drop
+# bytes — the first paste after an attach frequently lands only a prefix (a
+# multiple of 32 bytes, the attach input pump's read size; reproduced on 5 of 9
+# consecutive live 80x24 attempts). Submitting a prefix of a QUOTED command
+# leaves bash in its `>` continuation prompt, and every later scripted command
+# becomes a continuation line — one unconfirmed paste silently corrupts the whole
+# rest of the scenario. A testing helper must never turn an unconfirmed partial
+# paste into shell input; the caller needs an error, not a wrecked session.
+#
+# Recovery before refusal: the drop is transient rather than terminal — the input
+# path stays alive, and a re-paste lands in full (5 of 5 live retries). So each
+# attempt clears the input line first (so the re-paste cannot concatenate onto
+# the partial one) and re-pastes, and only after AF_DRIVER_SEND_LINE_ATTEMPTS
+# failures does it clear the line one last time and fail loudly, having pressed
+# no Enter at all. The [timeout_s] budget is per attempt.
 af_send_line() {
-    local text="$1"
-    [ -n "$text" ] || { af_send Enter; return 0; }
-    af_send_literal "$text" || return 1
-    _af_wait_for_line_echo "$text" "${2:-8}" "attached input echoed '$text'" \
-        || _af_log "note: attached input for '$text' not confirmed; submitting best-effort"
-    af_send Enter
+    local text="$1" timeout="${2:-8}" attempt baseline
+    # Nothing to confirm in an empty/whitespace-only line: submitting it is
+    # harmless and there is no echo to match against.
+    if [ -z "$(printf '%s' "$text" | tr -d '[:space:]')" ]; then
+        af_send Enter
+        return 0
+    fi
+    for attempt in $(seq 1 "$AF_DRIVER_SEND_LINE_ATTEMPTS"); do
+        _af_clear_input_line
+        # Measured AFTER the clear and BEFORE the paste, so what gets confirmed
+        # is this paste's own echo and not an identical command still sitting in
+        # the scrollback from an earlier af_send_line.
+        baseline="$(_af_line_echo_count "$text")"
+        af_send_literal "$text" || return 1
+        if _af_wait_for_line_echo "$text" "$timeout" "$baseline"; then
+            af_send Enter
+            return 0
+        fi
+        _af_log "af_send_line: attempt ${attempt}/${AF_DRIVER_SEND_LINE_ATTEMPTS} landed only PART of the line; clearing and re-pasting"
+    done
+    _af_log "----- last screen -----"
+    af_capture >&2
+    _af_log "-----------------------"
+    _af_clear_input_line
+    _af_fail "af_send_line: only part of the line ever echoed after ${AF_DRIVER_SEND_LINE_ATTEMPTS} attempts; NOT submitting it — a partial line would corrupt the attached shell (#2147). Line: $text"
+    return 1
 }
 
 # af_attach — attach the selected instance full-screen (`o`). Precondition: an
@@ -961,7 +1051,8 @@ af_relaunch() {
     af_send_literal "cd $AF_DRIVER_REPO && $bin"
     af_send Enter
     af_wait_for 'Agent Factory' "$AF_DRIVER_TIMEOUT" 'af first frame (relaunch)' || return 1
-    af_wait_for 'Instances \(' "$AF_DRIVER_TIMEOUT" 'instances header (relaunch)' || return 1
+    af_wait_for "$_AF_RAIL_MARKER" "$AF_DRIVER_TIMEOUT" \
+        'instance rail painted (relaunch)' || return 1
     af_focus_tree
 }
 


### PR DESCRIPTION
Two tui-driver robustness bugs from the daily play-test. Same file, so one PR —
separate ones would collide on merge. Rebased on #2151 first; the ║-border
marker fix is **not** what #2147 was, and the partial paste still reproduced.

Driver scripts + docs only. **No af product code.**

## #2147 — `af_send_line` submitted an unconfirmed partial paste

### Diagnosed, not guessed

The full-screen attach path really does drop bytes. Measured in the sandbox at
80x24, pasting the reporter's 128-character line and counting what echoes:

```
delay-after-attach=0     run=1 landed= 32/128   run=2 landed= 32/128   run=3 landed= 32/128
delay-after-attach=0.25  run=1 landed= 32/128   run=2 landed=127/128   run=3 landed=full
delay-after-attach=1.0   run=1 landed= 64/128   run=2 landed= 32/128   run=3 landed=127/128
```

Every truncation is at an exact multiple of **32 bytes** — the read size of the
attach stdin pump (`apiclient/attach.go`, `buf := make([]byte, 32)`). Controls
that rule out the driver: the same line pasted into a **plain tmux pane** lands
whole, and a 128-character run of digits pasted into the attach also lands
whole, so it is neither `tmux paste-buffer` nor payload length. Filed separately
as an af product bug — it is a real user-facing paste-loss, not a harness issue.

Two further facts shaped the fix: the input path is **not** dead after a
truncation (5/5 re-pastes landed the line in full), and chunks can go missing
from the **middle** — a chunked paste arrived as chunks 1, 2 and 4.

### What was wrong

1. **It submitted anyway.** On an unconfirmed paste it logged
   `submitting best-effort` and pressed Enter. A 32-byte prefix of a quoted
   command leaves bash in its `>` continuation prompt, and every later scripted
   command becomes a continuation line — the driver corrupts the session and
   reports success.
2. **The confirmation could not see the failure.** It matched a 24-character
   **tail**, on the theory that only the END of a paste can be lost. A dropped
   interior chunk leaves the tail intact, so the check *confirmed* mangled
   lines — a probe that cannot see the middle of the line vouching for it.

### Fix

- Confirm the **whole** line, whitespace-stripped on both sides, so a terminal
  wrap — and the space `capture-pane` trims at the wrap column (a 128-char line
  captures as 127) — are tolerated without weakening the check. A baseline count
  taken *before* the paste stops an identical command in the scrollback from
  confirming the next one.
- **Fail closed.** Each attempt clears the input line (ctrl-u, so a re-paste
  cannot concatenate onto a partial) and re-pastes; after
  `AF_DRIVER_SEND_LINE_ATTEMPTS` (4) failures it clears the line and returns
  non-zero having pressed **no** Enter. The caller gets an error instead of a
  wrecked shell.

`af_send_to_pane` is deliberately untouched: it drives the *pane* through the
TUI's own key handling, not the attach proxy, and does not exhibit this loss.

## #2148 — `af_boot` timed out when a scrolled rail hid the Instances header

`Instances (N)` is not chrome — it is the rail's first windowed row
(`ui/sidebar_render.go`), so it scrolls out like any other. Confirmed live: at
80x24 with three sessions and the middle or lower one selected, `Instances (`
is absent and `▲ 2 more` is drawn in its place, on the live frame and on the
first frame after a relaunch.

The gate now accepts the header **or** the scrolled-up indicator. That is
exhaustive rather than a widened net: the rail draws ▲ exactly when it has
hidden rows above, and when it does not, row 0 — the header — is on screen.
It is **not** weakened into always-passing — the self-test asserts both
negatives: a bare shell prompt must still time out, and pane output containing
`▲ 3 more` must not satisfy it (the indicator is anchored to the sidebar's left
edge, the same anchor `_af_tab_count` uses).

## Self-test: fail-first, then green

Five new cases. Fail-first was run by pointing the **new** cases at the
**pre-fix** driver (`git show origin/master:scripts/tui-driver.sh`):

| Case | pre-fix | post-fix |
|---|---|---|
| a dropped middle chunk must not confirm delivery (#2147) | ✗ `delivery was CONFIRMED for a line with a dropped middle chunk` | ✓ |
| af_send_line REFUSES to submit a partial line (#2147) | ✗ `af_send_line SUBMITTED an unconfirmed partial line (1 Enter(s))` | ✓ |
| live attach: a long quoted line lands whole and RUNS (#2147) | ✗ `TIMEOUT 15s` + `REFUTE FAILED: … quote-continuation prompt` | ✓ |
| a scrolled rail still reads as booted (#2148) | ✗ `a scrolled rail (▲ N more, header off-window) was not accepted as booted` | ✓ |
| relaunch boots with the rail scrolled past the header (#2148) | ✗ `TIMEOUT 25s waiting for: instances header (relaunch)` | ✓ |

The pre-fix live #2147 run reproduces the report exactly — 32 bytes landed,
"best-effort" submit, bash in `>`:

```
[tui-driver] TIMEOUT 8s waiting for: attached input echoed 'printf "%s\n" "af-2147-alpha-…'
dev@…:~/sandbox/mock-repo-beta$ printf "%s\n" "af-2147-alpha-bra
[tui-driver] note: attached input … not confirmed; submitting best-effort
[tui-driver] TIMEOUT 15s waiting for: the WHOLE quoted line ran in the attached shell
dev@…:~/sandbox/mock-repo-beta$ printf "%s\n" "af-2147-alpha-bra
>
[tui-driver] REFUTE FAILED: screen unexpectedly matched: attached shell is NOT stuck in a quote-continuation prompt (#2147)
```

Post-fix, same case — the drop still happens, the driver recovers:

```
[tui-driver] af_send_line: attempt 1/4 landed only PART of the line; clearing and re-pasting
[tui-driver] refute OK: attached shell is NOT stuck in a quote-continuation prompt (#2147)
AF_2147_9182
```

The #2148 stub case was additionally proven to lock the *semantics*, not just
the variable's existence: with the post-fix driver but `_AF_RAIL_MARKER` forced
back to the old header-only literal, it fails.

Full suite, fresh ephemeral container (`make tui-driver-selftest`):

```
=== SELF-TEST PASSED — 61/61 steps green ===
```

56 before, +5 new, every pre-existing case still green. Run twice (pinned
sandbox and a fresh ephemeral container), both 61/61. The live #2147 case was
additionally stressed 5× — 5/5 pass, with the recovery path firing on 4 of 5,
so it exercises the retry rather than passing by luck.

`shellcheck` clean on both changed scripts; `gofmt -l` clean; `go build ./...`
OK; file-length lint OK. No Go files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
