### PR TITLE
fix(attach): a paste into a full-screen attach loses no bytes (#2157)

### DIFF
--- a/apiclient/attach_paste_test.go
+++ b/apiclient/attach_paste_test.go
@@ -1,0 +1,86 @@
+package apiclient
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+
+	"github.com/sachiniyer/agent-factory/agentproto"
+)
+
+// readInputBytes collects INPUT payloads from the server side until it has at
+// least want bytes, and returns them concatenated in arrival order. A paste
+// larger than the stdin pump's read buffer necessarily arrives as SEVERAL INPUT
+// frames; what must hold is that concatenating them reproduces the paste exactly
+// — every byte, once, in order.
+func readInputBytes(t *testing.T, conn *websocket.Conn, want int) []byte {
+	t.Helper()
+	var got []byte
+	deadline := time.Now().Add(10 * time.Second)
+	for len(got) < want {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out with %d of %d input bytes: %q", len(got), want, got)
+		}
+		msg := readServerMsg(t, conn)
+		if !msg.Binary || msg.Frame.Op != agentproto.OpInput {
+			t.Fatalf("expected INPUT frame, got %+v", msg)
+		}
+		got = append(got, msg.Frame.Data...)
+	}
+	return got
+}
+
+// TestAttachStream_PasteForwardedByteForByte pins the stdin pump's half of
+// #2157: a paste is bytes on stdin like any other input, and the pump must
+// forward ALL of them, in order, whatever the size — its 32-byte read buffer is
+// a chunk size, never a cap. The sizes straddle that buffer deliberately: one
+// byte over it, a non-multiple, the reported 128-character line, and a payload
+// two orders of magnitude larger than the buffer.
+//
+// The byte loss reported in #2157 was NOT here — it was a second reader on the
+// same terminal (see app.releaseTerminalToAttach) — which is exactly why this
+// lock belongs in the tree: the pump is the obvious suspect for a byte-loss
+// report, and the next person to read this code should find the property
+// asserted rather than have to re-derive it.
+func TestAttachStream_PasteForwardedByteForByte(t *testing.T) {
+	for _, size := range []int{33, 100, 128, 4096} {
+		t.Run(fmt.Sprintf("%dbytes", size), func(t *testing.T) {
+			payload := make([]byte, size)
+			for i := range payload {
+				payload[i] = byte('a' + i%26)
+			}
+			server, stdinW, _, done := startDriver(t)
+			if _, err := stdinW.Write(payload); err != nil {
+				t.Fatalf("write paste: %v", err)
+			}
+			got := readInputBytes(t, server, size)
+			if !bytes.Equal(got, payload) {
+				t.Fatalf("paste corrupted on the wire\n got (%d bytes): %q\nwant (%d bytes): %q",
+					len(got), got, size, payload)
+			}
+			_ = server.Close(websocket.StatusNormalClosure, "")
+			waitClosed(t, done)
+		})
+	}
+}
+
+// TestAttachStream_SingleKeystrokeForwardedImmediately guards the other side of
+// the paste fix: nothing may batch or delay interactive input while waiting for
+// a fuller buffer. Each keystroke leaves as its own INPUT frame, as it is typed.
+func TestAttachStream_SingleKeystrokeForwardedImmediately(t *testing.T) {
+	server, stdinW, _, done := startDriver(t)
+	for _, key := range []string{"a", "b", "\x1b", "[", "A"} {
+		if _, err := stdinW.Write([]byte(key)); err != nil {
+			t.Fatalf("write %q: %v", key, err)
+		}
+		msg := readServerMsg(t, server)
+		if !msg.Binary || msg.Frame.Op != agentproto.OpInput || string(msg.Frame.Data) != key {
+			t.Fatalf("expected INPUT %q as its own frame, got %+v", key, msg)
+		}
+	}
+	_ = server.Close(websocket.StatusNormalClosure, "")
+	waitClosed(t, done)
+}

--- a/app/app.go
+++ b/app/app.go
@@ -11,11 +11,20 @@ var Version string
 
 // Run is the main entrypoint into the application.
 func Run(ctx context.Context, program string, autoYes bool, repo *config.RepoContext) error {
+	h := newHome(ctx, program, autoYes, repo)
 	p := tea.NewProgram(
-		newHome(ctx, program, autoYes, repo),
+		h,
 		tea.WithAltScreen(),
 		tea.WithMouseCellMotion(), // Mouse scroll
 	)
+	// Wire the terminal-handover seams a full-screen attach needs (#2157). The
+	// attach is a raw stdin proxy, so for its duration the Program must stop
+	// reading the terminal — otherwise its input reader and the attach's pump race
+	// each other for every byte the user types or pastes. Bubble Tea's own
+	// primitives; the same pair tea.Exec uses around a child that takes over the
+	// terminal. Set here rather than in newHome because only Run has the Program.
+	h.releaseTerminal = p.ReleaseTerminal
+	h.restoreTerminal = p.RestoreTerminal
 	_, err := p.Run()
 	return err
 }

--- a/app/attach_terminal_handover_test.go
+++ b/app/attach_terminal_handover_test.go
@@ -103,9 +103,17 @@ func TestAttachOverlayCallback_ReleasesTerminalAroundTheAttach(t *testing.T) {
 }
 
 // TestAttachOverlayCallback_ReclaimsTerminalWhenAttachFails: a failed attach
-// must still give the terminal back. Leaving it released would leave the TUI
-// with no input reader and a stopped renderer — a frozen app — which is a far
-// worse outcome than the attach error the user actually hit.
+// must still give the terminal back, MODES INCLUDED. Leaving it released would
+// leave the TUI with no input reader and a stopped renderer — a frozen app —
+// which is a far worse outcome than the attach error the user actually hit.
+//
+// The modes half is its own hazard, and attach errors are production-reachable
+// (a daemon that is down or restarting, an unresolved socket, a failed WS dial).
+// Releasing the terminal disables mouse reporting, and RestoreTerminal does not
+// put it back — bubbletea writes it once at startup from WithMouseCellMotion and
+// never again. So a reclaim that skips the mode re-assert hands the user a TUI
+// whose mouse is dead until the process restarts: the silent mode leak of #1832,
+// arrived at from the other side.
 func TestAttachOverlayCallback_ReclaimsTerminalWhenAttachFails(t *testing.T) {
 	h := newTestHome(t)
 	rec := newRecordingHandover(h)
@@ -123,6 +131,17 @@ func TestAttachOverlayCallback_ReclaimsTerminalWhenAttachFails(t *testing.T) {
 		"a failed attach must hand the terminal back, not strand the TUI")
 	assert.False(t, h.attached.Load())
 	assert.False(t, h.attachTransitioning)
+	assert.Equal(t, attachAltScreenEnter+remoteDetachTerminalReassert, out.String(),
+		"a released terminal must be reclaimed with its modes: every reclaim, "+
+			"clean detach or failed attach, re-asserts what RestoreTerminal does not")
+	for _, seq := range []struct{ esc, what string }{
+		{"\x1b[?1002h", "cell-motion mouse"},
+		{"\x1b[?1006h", "SGR mouse encoding"},
+	} {
+		assert.Contains(t, out.String(), seq.esc,
+			"the release disabled %s and RestoreTerminal does not put it back — "+
+				"without this write it stays dead for the rest of the session", seq.what)
+	}
 }
 
 // TestAttachOverlayCallback_NoReclaimWhenReleaseFails: if the release itself
@@ -305,7 +324,12 @@ func TestAttachOwnsTheTerminalAlone(t *testing.T) {
 
 	forwarded := make(chan []byte, 1)
 	ch := make(chan struct{})
+	// callbackDone is what the test waits on before returning: the callback
+	// reads package-level seams (remoteDetachResetWriter) that t.Cleanup restores,
+	// so letting it outlive the test is a real data race, not a tidiness point.
+	callbackDone := make(chan struct{})
 	go func() {
+		defer close(callbackDone)
 		h.attachOverlayCallback("t1", "test-attach", "", func() (chan struct{}, error) {
 			go func() {
 				var got []byte
@@ -344,6 +368,11 @@ func TestAttachOwnsTheTerminalAlone(t *testing.T) {
 		t.Fatalf("the released TUI reader never returned")
 	}
 
-	close(ch)
+	close(ch) // detach
+	select {
+	case <-callbackDone:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("attachOverlayCallback did not return after detach")
+	}
 	endDetachWatchdog()
 }

--- a/app/attach_terminal_handover_test.go
+++ b/app/attach_terminal_handover_test.go
@@ -1,0 +1,349 @@
+package app
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The #2157 handover: a full-screen attach is a raw stdin proxy, so for its
+// duration the Bubble Tea program must stop reading the terminal. These tests
+// pin the lifecycle (release before the attach starts, reclaim after it ends,
+// on every exit path) and — with a fake tty — the property that lifecycle
+// exists for: while the attach runs, nothing else takes bytes off the terminal.
+
+// recordingTerminalHandover wires h's release/restore seams to recorders and
+// returns the shared event log. Every event that matters to the ordering — the
+// two seam calls and the attach itself — appends to it.
+type recordingTerminalHandover struct {
+	mu      sync.Mutex
+	events  []string
+	release func() error
+	restore func() error
+}
+
+func newRecordingHandover(h *home) *recordingTerminalHandover {
+	r := &recordingTerminalHandover{}
+	r.release = func() error { r.record("release"); return nil }
+	r.restore = func() error { r.record("restore"); return nil }
+	h.releaseTerminal = r.release
+	h.restoreTerminal = r.restore
+	return r
+}
+
+func (r *recordingTerminalHandover) record(event string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, event)
+}
+
+func (r *recordingTerminalHandover) log() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.events...)
+}
+
+// TestAttachOverlayCallback_ReleasesTerminalAroundTheAttach is the #2157
+// regression lock. The attach reads the REAL stdin itself; Bubble Tea's input
+// reader is blocked on that same descriptor and nothing else ever stops it, so
+// unless this callback releases the terminal FIRST the two race for every byte
+// the user types or pastes — and the bytes the TUI's reader wins never reach the
+// pane. Release must therefore happen before the attach starts, and the reclaim
+// after it ends, so the TUI gets its input reader back.
+func TestAttachOverlayCallback_ReleasesTerminalAroundTheAttach(t *testing.T) {
+	resetDetachWatchdog(t)
+	h := newTestHome(t)
+	rec := newRecordingHandover(h)
+
+	var out bytes.Buffer
+	swapRemoteDetachResetWriter(t, &out)
+
+	ch := make(chan struct{})
+	done := make(chan tea.Cmd, 1)
+	go func() {
+		done <- h.attachOverlayCallback("t1", "test-attach", "", func() (chan struct{}, error) {
+			rec.record("attach")
+			return ch, nil
+		})
+	}()
+	require.Eventually(t, func() bool { return h.attached.Load() },
+		time.Second, time.Millisecond, "attached flag must arm before <-ch blocks")
+
+	// Mid-attach: the terminal is the attach's, and has not been taken back.
+	assert.Equal(t, []string{"release", "attach"}, rec.log(),
+		"the terminal must be released BEFORE the attach starts reading stdin — "+
+			"releasing after it has already begun leaves a window in which both "+
+			"readers are live, which is the whole of #2157")
+
+	close(ch)
+	select {
+	case cmd := <-done:
+		require.NotNil(t, cmd)
+	case <-time.After(2 * time.Second):
+		t.Fatalf("attachOverlayCallback did not return after detach")
+	}
+
+	assert.Equal(t, []string{"release", "attach", "restore"}, rec.log(),
+		"the terminal must be reclaimed after the attach ends — without it the "+
+			"TUI never restarts its input reader and the session is unusable")
+	assert.Equal(t, attachAltScreenEnter+remoteDetachTerminalReassert, out.String(),
+		"exactly two writes, in this order: the alt screen the attach runs on (a "+
+			"released terminal is back on the MAIN screen, and the pane's paint "+
+			"must not be left in the user's scrollback), then the mode re-assert "+
+			"— RestoreTerminal does not re-enable mouse reporting, so the "+
+			"hand-rolled re-assert still has to run after the reclaim (#845)")
+	endDetachWatchdog()
+}
+
+// TestAttachOverlayCallback_ReclaimsTerminalWhenAttachFails: a failed attach
+// must still give the terminal back. Leaving it released would leave the TUI
+// with no input reader and a stopped renderer — a frozen app — which is a far
+// worse outcome than the attach error the user actually hit.
+func TestAttachOverlayCallback_ReclaimsTerminalWhenAttachFails(t *testing.T) {
+	h := newTestHome(t)
+	rec := newRecordingHandover(h)
+
+	var out bytes.Buffer
+	swapRemoteDetachResetWriter(t, &out)
+
+	cmd := h.attachOverlayCallback("t1", "test-attach", "", func() (chan struct{}, error) {
+		rec.record("attach")
+		return nil, assert.AnError
+	})
+
+	assert.Nil(t, cmd)
+	assert.Equal(t, []string{"release", "attach", "restore"}, rec.log(),
+		"a failed attach must hand the terminal back, not strand the TUI")
+	assert.False(t, h.attached.Load())
+	assert.False(t, h.attachTransitioning)
+}
+
+// TestAttachOverlayCallback_NoReclaimWhenReleaseFails: if the release itself
+// failed, the terminal was never handed over, so "restoring" it would re-init an
+// input reader and renderer that were never stopped. The attach still proceeds —
+// a racy paste is better than refusing to attach — but the reclaim is skipped.
+func TestAttachOverlayCallback_NoReclaimWhenReleaseFails(t *testing.T) {
+	resetDetachWatchdog(t)
+	h := newTestHome(t)
+	rec := newRecordingHandover(h)
+	h.releaseTerminal = func() error { rec.record("release-failed"); return errors.New("no tty") }
+
+	var out bytes.Buffer
+	swapRemoteDetachResetWriter(t, &out)
+
+	cmd := runAttachOverlayCallback(t, h)
+	require.NotNil(t, cmd, "a failed release must not abort the attach")
+	assert.Equal(t, []string{"release-failed"}, rec.log(),
+		"nothing to reclaim from a release that never happened")
+	assert.Equal(t, remoteDetachTerminalReassert, out.String(),
+		"only the mode re-assert is written: the alt-screen switch belongs to the "+
+			"release that did not happen")
+	endDetachWatchdog()
+}
+
+// TestAttachOverlayCallback_NoHandoverWithoutAProgram: the seams are nil when no
+// Bubble Tea program owns the terminal (every test in this package, and any
+// future headless caller). The callback must then behave exactly as before.
+func TestAttachOverlayCallback_NoHandoverWithoutAProgram(t *testing.T) {
+	resetDetachWatchdog(t)
+	h := newTestHome(t)
+	require.Nil(t, h.releaseTerminal)
+	require.Nil(t, h.restoreTerminal)
+
+	var out bytes.Buffer
+	swapRemoteDetachResetWriter(t, &out)
+
+	cmd := runAttachOverlayCallback(t, h)
+	require.NotNil(t, cmd)
+	assert.Equal(t, remoteDetachTerminalReassert, out.String(),
+		"with no program to hand the terminal to, only the mode re-assert is written")
+	endDetachWatchdog()
+}
+
+// --- the property the handover exists for -----------------------------------
+
+var errTTYReaderCancelled = errors.New("tty reader cancelled")
+
+// sharedTTY models the one thing about a terminal that makes #2157 possible:
+// readers do NOT each get a copy of what the user types. The bytes sit in one
+// queue, whichever reader is served takes them off it, and they are gone from
+// every other reader. A second live reader on the terminal is therefore not a
+// bystander — it is a thief.
+//
+// Readers are served in the order they blocked (FIFO), which makes the theft
+// deterministic instead of a coin flip: the TUI's reader has been parked on the
+// terminal since boot, so it is ahead of an attach pump that keeps going back to
+// the queue after forwarding each chunk. Cancelling a reader is what Bubble
+// Tea's ReleaseTerminal does to its cancelreader.
+type sharedTTY struct {
+	mu        sync.Mutex
+	cond      *sync.Cond
+	buf       []byte
+	queue     []int // ids of readers currently blocked, oldest first
+	cancelled map[int]bool
+}
+
+func newSharedTTY() *sharedTTY {
+	tty := &sharedTTY{cancelled: make(map[int]bool)}
+	tty.cond = sync.NewCond(&tty.mu)
+	return tty
+}
+
+// reader returns the io.Reader for reader id.
+func (tty *sharedTTY) reader(id int) io.Reader {
+	return readerFunc(func(p []byte) (int, error) { return tty.read(id, p) })
+}
+
+// typed puts bytes on the terminal, as a keystroke or a paste would.
+func (tty *sharedTTY) typed(b []byte) {
+	tty.mu.Lock()
+	defer tty.mu.Unlock()
+	tty.buf = append(tty.buf, b...)
+	tty.cond.Broadcast()
+}
+
+// cancel ends reader id's read, now and for good.
+func (tty *sharedTTY) cancel(id int) {
+	tty.mu.Lock()
+	defer tty.mu.Unlock()
+	tty.cancelled[id] = true
+	tty.cond.Broadcast()
+}
+
+// blocked reports whether reader id is parked on the terminal.
+func (tty *sharedTTY) blocked(id int) bool {
+	tty.mu.Lock()
+	defer tty.mu.Unlock()
+	for _, q := range tty.queue {
+		if q == id {
+			return true
+		}
+	}
+	return false
+}
+
+func (tty *sharedTTY) read(id int, p []byte) (int, error) {
+	tty.mu.Lock()
+	defer tty.mu.Unlock()
+	tty.queue = append(tty.queue, id)
+	defer func() {
+		for i, q := range tty.queue {
+			if q == id {
+				tty.queue = append(tty.queue[:i], tty.queue[i+1:]...)
+				break
+			}
+		}
+		tty.cond.Broadcast()
+	}()
+	for {
+		if tty.cancelled[id] {
+			return 0, errTTYReaderCancelled
+		}
+		if len(tty.buf) > 0 && tty.queue[0] == id {
+			n := copy(p, tty.buf)
+			tty.buf = tty.buf[n:]
+			return n, nil
+		}
+		tty.cond.Wait()
+	}
+}
+
+type readerFunc func([]byte) (int, error)
+
+func (f readerFunc) Read(p []byte) (int, error) { return f(p) }
+
+// TestAttachOwnsTheTerminalAlone is #2157 itself, in a unit test. A reader
+// modelling Bubble Tea's input loop is parked on the terminal, an attach starts,
+// and a 128-byte paste is typed. Every byte must reach the attach.
+//
+// Without the handover the TUI's reader is still parked and takes the paste off
+// the terminal in one 256-byte read — the pane gets a fragment or nothing, which
+// is exactly the reported symptom. With it, the release cancels that reader
+// before the attach's pump starts, so the pump is the only reader there is.
+//
+// The pump here is a stand-in for apiclient's (same 32-byte reads, same forward-
+// then-read-again loop); what is under test is the app's handover, not the pump.
+func TestAttachOwnsTheTerminalAlone(t *testing.T) {
+	resetDetachWatchdog(t)
+	const tuiReader, attachPump = 1, 2
+	paste := make([]byte, 128)
+	for i := range paste {
+		paste[i] = byte('a' + i%26)
+	}
+
+	h := newTestHome(t)
+	tty := newSharedTTY()
+	swapRemoteDetachResetWriter(t, &bytes.Buffer{})
+
+	// Bubble Tea's input loop: parked on the terminal since boot, 256-byte reads.
+	stolen := make(chan []byte, 1)
+	go func() {
+		var took []byte
+		buf := make([]byte, 256)
+		for {
+			n, err := tty.reader(tuiReader).Read(buf)
+			took = append(took, buf[:n]...)
+			if err != nil {
+				stolen <- took
+				return
+			}
+		}
+	}()
+	require.Eventually(t, func() bool { return tty.blocked(tuiReader) },
+		time.Second, time.Millisecond, "the TUI reader must be on the terminal before the attach")
+
+	// ReleaseTerminal cancels that reader; RestoreTerminal would start a new one.
+	h.releaseTerminal = func() error { tty.cancel(tuiReader); return nil }
+	h.restoreTerminal = func() error { return nil }
+
+	forwarded := make(chan []byte, 1)
+	ch := make(chan struct{})
+	go func() {
+		h.attachOverlayCallback("t1", "test-attach", "", func() (chan struct{}, error) {
+			go func() {
+				var got []byte
+				buf := make([]byte, 32) // the attach pump's read size
+				for {
+					n, err := tty.reader(attachPump).Read(buf)
+					got = append(got, buf[:n]...)
+					if err != nil || len(got) >= len(paste) {
+						forwarded <- got
+						return
+					}
+				}
+			}()
+			return ch, nil
+		})
+	}()
+	require.Eventually(t, func() bool { return tty.blocked(attachPump) },
+		time.Second, time.Millisecond, "the attach pump must be on the terminal")
+
+	tty.typed(paste)
+
+	select {
+	case got := <-forwarded:
+		assert.Equal(t, paste, got,
+			"every pasted byte must reach the attach: a second reader on the "+
+				"terminal does not copy bytes, it takes them (#2157)")
+	case <-time.After(3 * time.Second):
+		t.Fatalf("the attach never received the paste")
+	}
+	select {
+	case took := <-stolen:
+		assert.Empty(t, took,
+			"the released reader must take nothing: it was cancelled before the "+
+				"attach began, so it can no longer be served")
+	case <-time.After(time.Second):
+		t.Fatalf("the released TUI reader never returned")
+	}
+
+	close(ch)
+	endDetachWatchdog()
+}

--- a/app/home_attach.go
+++ b/app/home_attach.go
@@ -157,12 +157,25 @@ func SetAttachStreamFnForTest(fn func(context.Context, string, string, string, i
 // a real WS stream.
 func (m *home) attachOverlayCallback(title, label, traceSuffix string, attach func() (chan struct{}, error)) tea.Cmd {
 	detachTraceMark(label + "-onDismiss-entry" + traceSuffix)
+	// Snapshot the terminal-write seam ONCE, here, before the attach starts —
+	// same rule as the per-home seams captured below and as apiclient's attach
+	// driver applies to its own package-level seams. remoteDetachResetWriter is a
+	// mutable package global, and this callback runs for the whole length of an
+	// attach; re-reading it on the detach path is a live read of shared mutable
+	// state from a long-running call, which a test that swaps and restores it
+	// races (the #1970/#2079 shared-global class). Every write below goes to this
+	// local, so the writer this attach releases into is the one it reclaims into.
+	resetWriter := remoteDetachResetWriter
 	// Hand the terminal to the attach BEFORE it starts reading stdin (#2157).
-	released := m.releaseTerminalToAttach()
+	released := m.releaseTerminalToAttach(resetWriter)
 	ch, err := attach()
 	if err != nil {
+		// Only when we released: an attach that never started scribbled nothing,
+		// so there is no terminal state to take back and re-asserting modes would
+		// pointlessly wipe the current frame. When we DID release, the reclaim is
+		// mandatory — see reclaimTerminalFromAttach on the mouse.
 		if released {
-			m.reclaimTerminalFromAttach()
+			m.reclaimTerminalFromAttach(resetWriter, true)
 		}
 		m.attachTransitioning = false
 		log.ErrorLog.Printf("failed to attach (%s): %v", label+traceSuffix, err)
@@ -219,26 +232,13 @@ func (m *home) attachOverlayCallback(title, label, traceSuffix string, attach fu
 		return repaintAfterDetachMsg{}
 	}
 	// The attach driver (WS or hook) wrote its neutral restore before closing ch,
-	// so both of these land strictly after it. The Update goroutine is still
+	// so the reclaim lands strictly after it. The Update goroutine is still
 	// blocked in this callback, so no renderer write can interleave (#845).
-	//
-	// Take the terminal back first: that restarts the input reader the attach was
-	// given exclusive use of, and re-enters the alt screen with the renderer's
-	// bookkeeping and the terminal agreeing again. The hand-rolled re-assert then
-	// still runs, because RestoreTerminal does NOT re-enable mouse reporting —
-	// Bubble Tea enables it once at startup from the WithMouseCellMotion option and
-	// never again — so without it mouse scroll and click would be dead for the rest
-	// of the session after the first attach. The re-assert's other modes are
-	// re-asserted by RestoreTerminal too; writing them twice is harmless and keeps
-	// this one constant the single description of "the modes this TUI runs in".
 	//
 	// ClearScreen then invalidates the renderer's stale diff cache before the
 	// repaint flow runs; then the usual repaintAfterDetachMsg path, watchdog
 	// semantics (#683) included.
-	if released {
-		m.reclaimTerminalFromAttach()
-	}
-	_, _ = io.WriteString(remoteDetachResetWriter, remoteDetachTerminalReassert)
+	m.reclaimTerminalFromAttach(resetWriter, released)
 	return tea.Sequence(tea.ClearScreen, repaintCmd)
 }
 
@@ -274,7 +274,10 @@ func (m *home) attachOverlayCallback(title, label, traceSuffix string, attach fu
 // racy paste is a far better outcome than refusing to attach at all. The false
 // return then keeps the terminal from being "restored" from a state it was never
 // released into.
-func (m *home) releaseTerminalToAttach() bool {
+//
+// out is the terminal, captured by the caller before the attach starts, never
+// re-read from the package seam mid-attach.
+func (m *home) releaseTerminalToAttach(out io.Writer) bool {
 	if m.releaseTerminal == nil {
 		return false // no Program wired (tests): nothing owns the terminal
 	}
@@ -282,23 +285,47 @@ func (m *home) releaseTerminalToAttach() bool {
 		log.ErrorLog.Printf("failed to release the terminal to the attach: %v", err)
 		return false
 	}
-	_, _ = io.WriteString(remoteDetachResetWriter, attachAltScreenEnter)
+	_, _ = io.WriteString(out, attachAltScreenEnter)
 	return true
 }
 
-// reclaimTerminalFromAttach takes the terminal back after a released attach ends:
-// the input reader restarts, the renderer resumes, and the alt screen is
-// re-entered. Paired with a releaseTerminalToAttach that returned true.
-func (m *home) reclaimTerminalFromAttach() {
-	if m.restoreTerminal == nil {
-		return
+// reclaimTerminalFromAttach takes the terminal back for the TUI once the attach
+// is over — on a clean detach and on an attach that failed after the release.
+// released says whether the terminal was actually handed to Bubble Tea's
+// ReleaseTerminal; out is the terminal, captured by the caller.
+//
+// This is the ONLY place the mode re-assert is written, and that is deliberate.
+// Both halves of "take the terminal back" have to happen together on EVERY path:
+//
+//   - RestoreTerminal restarts the input reader the attach was given exclusive
+//     use of, resumes the renderer, and re-enters the alt screen with the
+//     renderer's bookkeeping and the terminal agreeing again;
+//   - remoteDetachTerminalReassert covers what it does not — above all MOUSE
+//     reporting, which the release disabled and which bubbletea only ever writes
+//     once, at startup, from the WithMouseCellMotion option.
+//
+// Splitting them is how a failed attach came to leave a TUI whose mouse was dead
+// until the process restarted: attach errors are ordinary (a daemon down or
+// restarting, an unresolved socket, a failed WS dial), that path returned early,
+// and it skipped a re-assert that was written further down. One function, both
+// halves, and the error path cannot drift from the detach path again.
+//
+// The re-assert is written even when the release did not happen (a headless
+// caller, or a release that errored): the attach itself is a raw byte proxy that
+// scribbled the pane program's modes onto the terminal regardless, which is the
+// #845 reason this constant exists at all. It is also written even if
+// RestoreTerminal fails, since a mouse-dead terminal helps nobody.
+func (m *home) reclaimTerminalFromAttach(out io.Writer, released bool) {
+	if released && m.restoreTerminal != nil {
+		if err := m.restoreTerminal(); err != nil {
+			// The terminal is now in whatever state the attach left it and the input
+			// reader may be down. There is no second lever to pull — surface it in the
+			// log; the mode re-assert below and the repaint the caller schedules are
+			// the best remaining recovery.
+			log.ErrorLog.Printf("failed to reclaim the terminal after attach: %v", err)
+		}
 	}
-	if err := m.restoreTerminal(); err != nil {
-		// The terminal is now in whatever state the attach left it and the input
-		// reader may be down. There is no second lever to pull — surface it in the
-		// log; the repaint the caller schedules is the best remaining recovery.
-		log.ErrorLog.Printf("failed to reclaim the terminal after attach: %v", err)
-	}
+	_, _ = io.WriteString(out, remoteDetachTerminalReassert)
 }
 
 // statusPollRenewInterval is how often an attached TUI re-sends PauseStatusPoll

--- a/app/home_attach.go
+++ b/app/home_attach.go
@@ -35,6 +35,13 @@ import (
 // pre-attach frame is on screen; the 1049h re-entry cleared it), so the
 // caller follows up with tea.ClearScreen — the native lever for "invalidate
 // the cache and repaint everything".
+//
+// Since #2157 the attach is bracketed by ReleaseTerminal/RestoreTerminal, which
+// re-asserts most of these itself from bookkeeping that is no longer stale. This
+// constant stays load-bearing anyway for the MOUSE modes: bubbletea enables them
+// once at startup from the WithMouseCellMotion option and RestoreTerminal does
+// not, so without this write mouse scroll and click would be dead for the rest of
+// the session after the first attach.
 const remoteDetachTerminalReassert = "" +
 	"\x1b[?1049h" + // re-enter the alt screen (terminal clears it)
 	"\x1b[?25l" + // bubbletea hid the cursor at startup; re-hide it
@@ -44,6 +51,23 @@ const remoteDetachTerminalReassert = "" +
 // remoteDetachResetWriter is where remoteDetachTerminalReassert is written —
 // the real terminal in production, swappable so tests can capture it.
 var remoteDetachResetWriter io.Writer = os.Stdout
+
+// attachAltScreenEnter puts the terminal back on the alt screen for the
+// duration of an attach, immediately after releaseTerminalToAttach.
+//
+// "Released" means Bubble Tea has handed the terminal back the way it found it,
+// which includes leaving the alt screen. Without this the raw attach proxy would
+// paint the pane onto the MAIN screen — straight into the user's scrollback,
+// where it stays after detach. Every full-screen attach has always run on the alt
+// screen (Bubble Tea's own, until #2157 made the release necessary), so this just
+// keeps that true: the pane gets a scratch screen, and detach hands the user back
+// the terminal they attached from.
+//
+// It is written directly rather than through the renderer because the renderer is
+// stopped and its bookkeeping must stay as ReleaseTerminal left it: the attach's
+// NeutralTerminalRestore leaves the terminal on the main screen again, which is
+// exactly the state restoreTerminal then re-enters the alt screen from.
+const attachAltScreenEnter = "\x1b[?1049h"
 
 type beginAttachMsg struct {
 	run func() tea.Cmd
@@ -115,6 +139,11 @@ func SetAttachStreamFnForTest(fn func(context.Context, string, string, string, i
 // blocked here, before the renderer can emit a frame — and precede the repaint
 // with tea.ClearScreen to invalidate the stale diff cache (#845).
 //
+// The attach is also bracketed by the terminal handover (#2157): every
+// full-screen attach reads the real stdin itself, so the Program must stop
+// reading it for the attach's duration or the two readers split the user's
+// keystrokes between them. See releaseTerminalToAttach.
+//
 // The defer on m.attached.Store(false) is load-bearing: it guarantees the
 // flag clears even if `<-ch` is woken by an abnormal close or a panic
 // further down the stack. Leaving the flag stuck at true would silently
@@ -128,8 +157,13 @@ func SetAttachStreamFnForTest(fn func(context.Context, string, string, string, i
 // a real WS stream.
 func (m *home) attachOverlayCallback(title, label, traceSuffix string, attach func() (chan struct{}, error)) tea.Cmd {
 	detachTraceMark(label + "-onDismiss-entry" + traceSuffix)
+	// Hand the terminal to the attach BEFORE it starts reading stdin (#2157).
+	released := m.releaseTerminalToAttach()
 	ch, err := attach()
 	if err != nil {
+		if released {
+			m.reclaimTerminalFromAttach()
+		}
 		m.attachTransitioning = false
 		log.ErrorLog.Printf("failed to attach (%s): %v", label+traceSuffix, err)
 		return nil
@@ -185,13 +219,86 @@ func (m *home) attachOverlayCallback(title, label, traceSuffix string, attach fu
 		return repaintAfterDetachMsg{}
 	}
 	// The attach driver (WS or hook) wrote its neutral restore before closing ch,
-	// so this lands strictly after it. The Update goroutine is still blocked in
-	// this callback, so no renderer write can interleave (#845). ClearScreen first
-	// so the renderer's stale diff cache is invalidated before the repaint flow
-	// runs; then the usual repaintAfterDetachMsg path, watchdog semantics (#683)
-	// included.
+	// so both of these land strictly after it. The Update goroutine is still
+	// blocked in this callback, so no renderer write can interleave (#845).
+	//
+	// Take the terminal back first: that restarts the input reader the attach was
+	// given exclusive use of, and re-enters the alt screen with the renderer's
+	// bookkeeping and the terminal agreeing again. The hand-rolled re-assert then
+	// still runs, because RestoreTerminal does NOT re-enable mouse reporting —
+	// Bubble Tea enables it once at startup from the WithMouseCellMotion option and
+	// never again — so without it mouse scroll and click would be dead for the rest
+	// of the session after the first attach. The re-assert's other modes are
+	// re-asserted by RestoreTerminal too; writing them twice is harmless and keeps
+	// this one constant the single description of "the modes this TUI runs in".
+	//
+	// ClearScreen then invalidates the renderer's stale diff cache before the
+	// repaint flow runs; then the usual repaintAfterDetachMsg path, watchdog
+	// semantics (#683) included.
+	if released {
+		m.reclaimTerminalFromAttach()
+	}
 	_, _ = io.WriteString(remoteDetachResetWriter, remoteDetachTerminalReassert)
 	return tea.Sequence(tea.ClearScreen, repaintCmd)
+}
+
+// releaseTerminalToAttach hands the real terminal to the full-screen attach that
+// is about to start, and reports whether it did (so the caller pairs it with
+// exactly one reclaimTerminalFromAttach).
+//
+// This is the #2157 fix. A full-screen attach is a RAW byte proxy: it reads the
+// real stdin itself (apiclient.driveAttachStream's stdin pump) and forwards every
+// byte to the pane. But Bubble Tea's input reader is blocked on that SAME file
+// descriptor for the whole attach — the Update goroutine is parked in this
+// callback, yet the read loop it started at boot is a separate goroutine and
+// nothing here ever stopped it. Two readers on one tty do not each get a copy:
+// they SPLIT the stream, and every byte the TUI's reader wins is gone from the
+// pane's input.
+//
+// A single keystroke rarely loses that race and would be invisible if it did (the
+// stolen key is just queued for a blocked Update). A PASTE loses it constantly:
+// the pump forwards its 32-byte read over the websocket while the TUI's 256-byte
+// read takes everything else the terminal has buffered. That is the reported
+// symptom exactly — a 128-character line landing as its first 32 bytes, whole
+// interior chunks missing, worst on the first paste after attaching — and it is
+// silent, so a partially-pasted quoted command reads to the user as a typo.
+//
+// ReleaseTerminal is Bubble Tea's own answer: it cancels the input reader, stops
+// the renderer, and restores the terminal — the same handover tea.Exec performs
+// around a child process that takes the terminal, and the reason the config-agent
+// attach (which goes through tea.ExecProcess) never had this bug. After it, the
+// attach's pump is the only reader of stdin, which is the invariant a raw proxy
+// needs.
+//
+// A failure to release is logged and the attach proceeds: a live attach with a
+// racy paste is a far better outcome than refusing to attach at all. The false
+// return then keeps the terminal from being "restored" from a state it was never
+// released into.
+func (m *home) releaseTerminalToAttach() bool {
+	if m.releaseTerminal == nil {
+		return false // no Program wired (tests): nothing owns the terminal
+	}
+	if err := m.releaseTerminal(); err != nil {
+		log.ErrorLog.Printf("failed to release the terminal to the attach: %v", err)
+		return false
+	}
+	_, _ = io.WriteString(remoteDetachResetWriter, attachAltScreenEnter)
+	return true
+}
+
+// reclaimTerminalFromAttach takes the terminal back after a released attach ends:
+// the input reader restarts, the renderer resumes, and the alt screen is
+// re-entered. Paired with a releaseTerminalToAttach that returned true.
+func (m *home) reclaimTerminalFromAttach() {
+	if m.restoreTerminal == nil {
+		return
+	}
+	if err := m.restoreTerminal(); err != nil {
+		// The terminal is now in whatever state the attach left it and the input
+		// reader may be down. There is no second lever to pull — surface it in the
+		// log; the repaint the caller schedules is the best remaining recovery.
+		log.ErrorLog.Printf("failed to reclaim the terminal after attach: %v", err)
+	}
 }
 
 // statusPollRenewInterval is how often an attached TUI re-sends PauseStatusPoll

--- a/app/home_model.go
+++ b/app/home_model.go
@@ -104,6 +104,14 @@ type home struct {
 	// resumeStatusPollThroughDaemon in production; tests assign fakes directly.
 	pauseStatusPoll  func(title, repoID string) error
 	resumeStatusPoll func(title, repoID string) error
+	// releaseTerminal / restoreTerminal hand the REAL terminal to a full-screen
+	// attach and take it back (#2157). They are Bubble Tea's own
+	// Program.ReleaseTerminal / RestoreTerminal, wired in Run; PER-home fields
+	// rather than package globals for the same reason as the seams above, and nil
+	// in tests, which drive attachOverlayCallback without a Program or a tty.
+	// See releaseTerminalToAttach for why a raw-proxy attach must have them.
+	releaseTerminal func() error
+	restoreTerminal func() error
 	// appConfig stores persistent application configuration
 	appConfig *config.Config
 	// appState stores persistent application state like seen help screens


### PR DESCRIPTION
Fixes #2157.

## What was actually losing the bytes

Not the stdin pump. `apiclient/attach.go`'s loop is correct — it forwards
`buf[:n]` for every read and `agentproto.WriteFrame` is a synchronous, mutex-
serialized write, so a big paste just becomes more frames. I locked that
property with a test anyway (below); it holds on master.

The thief is a **second reader on the same terminal**. A full-screen attach is a
raw stdin proxy: `driveAttachStream` reads the real `os.Stdin` itself. But the
TUI is a Bubble Tea program, and Bubble Tea's input reader is a **separate
goroutine** blocked on that same file descriptor for the whole attach — the
Update goroutine is parked inside `attachOverlayCallback`, yet nothing ever
stopped the read loop it started at boot. Two readers on one tty do not each get
a copy of what you type: they split the queue, and every byte the TUI's reader
wins is gone from the pane.

That explains every observation in the issue:

* **the 32-byte quantum** — the pump forwards its 32-byte read over the
  websocket and only then asks for more; the TUI's reader takes everything else
  the terminal has buffered in one 256-byte read (`readAnsiInputs`);
* **missing interior chunks with the tail arriving** — the thief wins some
  rounds, not all of them;
* **worst on the first paste after attaching** — that is when the TUI's reader
  has been parked longest;
* **single keystrokes look fine** — a stolen key is not lost visibly, it is just
  queued for an Update that is blocked;
* **`af sessions attach` never truncates** — no Bubble Tea program, so the pump
  is the only reader (I ran that control; see below).

## The fix

Bracket the attach with Bubble Tea's own `Program.ReleaseTerminal` /
`RestoreTerminal` (`app/home_attach.go`, wired in `app/app.go`). `ReleaseTerminal`
cancels the input reader and stops the renderer — it is exactly what `tea.Exec`
does around a child process that takes over the terminal, and it is why the
config-agent attach (`tea.ExecProcess`, `app/config_agent.go`) never had this
bug. After it, the attach's pump is the only reader of stdin, which is the
invariant a raw byte proxy needs.

Two details worth reviewing:

* A released terminal is back on the **main** screen, so the attach would paint
  the pane into the user's scrollback and leave it there. `attachAltScreenEnter`
  puts it on the alt screen for the attach's duration — where every full-screen
  attach has always run — and the attach's own `NeutralTerminalRestore` pops back
  off it, which is the state `RestoreTerminal` then re-enters from.
* `remoteDetachTerminalReassert` **stays**, and now lives *inside*
  `reclaimTerminalFromAttach`, after `RestoreTerminal`. `RestoreTerminal`
  re-asserts the alt screen, hidden cursor and bracketed paste, but *not* mouse
  reporting (Bubble Tea enables that once at startup from `WithMouseCellMotion`).
  Both halves of "take the terminal back" therefore happen together on every
  path — see the review fix below for why that matters.

Release failing is logged and the attach proceeds — a racy paste beats refusing
to attach — and the reclaim is then skipped, so the terminal is never "restored"
from a state it was not released into. A failed attach still reclaims: leaving
the terminal released would leave the TUI with no input reader, i.e. frozen.

## Evidence — the repro, before and after

Real TUI, `make playtest-container` sandbox, 80x24, driven with
`scripts/tui-driver.sh`. The attached shell **counts the bytes it received**
(`printf %s <n bytes> | wc -c`), so the assertion does not depend on what fits on
screen. One fresh attach per size.

Master (b9c63ee):

```
first paste after attach:    33 bytes -> shell received 33    OK
first paste after attach:   100 bytes -> shell received 33    LOST BYTES
first paste after attach:   128 bytes -> shell received 33    LOST BYTES
first paste after attach:   512 bytes -> shell received 0     LOST BYTES
first paste after attach:  4096 bytes -> shell received 0     LOST BYTES
```

This branch:

```
first paste after attach:    33 bytes -> shell received 33    OK
first paste after attach:   100 bytes -> shell received 100   OK
first paste after attach:   128 bytes -> shell received 128   OK
first paste after attach:   512 bytes -> shell received 512   OK
first paste after attach:  4096 bytes -> shell received 4096  OK
```

The issue's own 128-character `sed` line, measured as the issue measured it
(longest prefix echoed on the attached screen, whitespace-stripped; 108 non-space
characters):

```
                                  master        this branch
first paste after attach     4/5 TRUNCATED      0/10 TRUNCATED
  (26/108 = exactly 32 raw bytes, and 1/108)
repeated pastes in one attach  1/6 TRUNCATED     0/10 TRUNCATED
```

And the control that pins it on the second reader rather than on tmux, the
payload, or the pump — the same line into `af sessions attach`, which has no
Bubble Tea program: **6/6 full, master binary, including the first paste**.

## Evidence — fail-first unit tests

`TestAttachOwnsTheTerminalAlone` (`app/attach_terminal_handover_test.go`) is the
bug in a unit test: a fake tty where readers take bytes off one queue instead of
each getting a copy, a reader modelling Bubble Tea's input loop parked on it, and
a 128-byte paste. With the release call removed from `attachOverlayCallback`
(everything else identical):

```
=== RUN   TestAttachOverlayCallback_ReleasesTerminalAroundTheAttach
    Error:    Not equal:
              expected: []string{"release", "attach"}
              actual  : []string{"attach"}
    Messages: the terminal must be released BEFORE the attach starts reading
              stdin — releasing after it has already begun leaves a window in
              which both readers are live, which is the whole of #2157
    Error:    Not equal:
              expected: []string{"release", "attach", "restore"}
              actual  : []string{"attach"}
    Messages: the terminal must be reclaimed after the attach ends — without it
              the TUI never restarts its input reader and the session is unusable
--- FAIL: TestAttachOverlayCallback_ReleasesTerminalAroundTheAttach
--- FAIL: TestAttachOverlayCallback_ReclaimsTerminalWhenAttachFails
        Error:    expected: []string{"release", "attach", "restore"}
                  actual  : []string{"attach"}
--- FAIL: TestAttachOwnsTheTerminalAlone (3.00s)
    attach_terminal_handover_test.go:336: the attach never received the paste
FAIL
```

All green with the fix in place.

`apiclient/attach_paste_test.go` locks the pump itself: 33 / 100 / 128 / 4096
bytes arrive byte-for-byte and in order (a paste is several INPUT frames whose
concatenation must reproduce it exactly), and single keystrokes still leave
immediately as their own frames — no batching latency was introduced. To be
straight about it: **these two pass on master**, because the pump was never the
defect. They are in the tree so the next person chasing a byte-loss report finds
the property asserted instead of re-deriving it.

## Play-test gate (real TUI, 80x24)

* attach screens, detach back to the TUI, and 10 consecutive attach/detach cycles
  all render correctly;
* a command typed **one keystroke at a time** still lands and runs (no batching);
* pastes of 33 / 100 / 128 / 512 / 4096 bytes all byte-exact;
* the scrollback of the terminal `af` runs in contains none of the pane's paint
  after detach (the alt-screen bracket does its job);
* **mouse after detach**: an SGR click on another instance's row moves the
  selection — the re-assert is doing the thing `RestoreTerminal` does not;
* keyboard after detach: `?` opens the help overlay, `esc` closes it.

## Review round 2 (second commit)

**Blocker — a failed attach leaked mouse reporting.** The release disables
mouse; only the hand-rolled re-assert re-enables it; and the attach-*error*
branch returned before that write. So with the terminal released and `attach()`
failing — a daemon down or restarting, an unresolved socket, a failed WS dial,
all ordinary — the TUI came back with the keyboard fine and the **mouse dead
until the process restarted**. The #1832 silent-mode-leak class, and one master
did not have, since master never released on the error path.

Fixed by folding the re-assert into `reclaimTerminalFromAttach`: one function
does both halves, so the error path cannot drift from the detach path again.
`TestAttachOverlayCallback_ReclaimsTerminalWhenAttachFails` now asserts it, and
fails on the first commit — the buffer held only the alt-screen switch:

```
    Error:    Not equal:
              expected: "\x1b[?1049h\x1b[?1049h\x1b[?25l\x1b[?1002h\x1b[?1006h\x1b[?2004h"
              actual  : "\x1b[?1049h"
    Messages: a released terminal must be reclaimed with its modes: every
              reclaim, clean detach or failed attach, re-asserts what
              RestoreTerminal does not
    Error:    "\x1b[?1049h" does not contain "\x1b[?1002h"
    Messages: the release disabled cell-motion mouse and RestoreTerminal does
              not put it back — without this write it stays dead for the rest
              of the session
```

**Data race (CI `-race`).** `attachOverlayCallback` read the mutable package
global `remoteDetachResetWriter` on the *detach* path — a live read of shared
mutable state from a call that spans the whole attach, racing a test that swaps
and restores it (#1970/#2079). It is now snapshotted **once** at callback entry,
before the attach starts, and threaded through release/reclaim as a local — the
same rule the per-home seams beneath it already follow, and the one apiclient's
attach driver applies to its own package seams. The handover test also joins its
callback goroutine before returning so it cannot outlive `t.Cleanup`.

Re-verified after both changes: `go test -race ./app -run TestAttach -count=5`
clean, `make test-container` green plus a targeted `-race ./app/... ./apiclient/...`
inside the container, `tui-driver-selftest` 61/61, and the sandbox play-test
re-run unchanged (33/100/128/512/4096 bytes all byte-exact, mouse alive after
detach, scrollback clean).

## Not in this PR

`scripts/tui-driver.sh`'s `af_send_line` retry/confirm loop (the #2147 harness
workaround for this bug) is untouched. It is still correct — it fails closed on
an unconfirmed paste — and pruning it is a separate change once this has soaked.

— Captain Claude
