### PR TITLE
fix(session): a snapshot reconcile racing teardown drops the tab (#2100)

### DIFF
--- a/session/instance.go
+++ b/session/instance.go
@@ -558,13 +558,18 @@ func (i *Instance) AttachShellTab(name, tmuxName string) (*Tab, error) {
 	// next snapshot's ReconcileTabsFromData adopts the daemon's authoritative id.
 	tab.ID = ""
 	i.mu.Lock()
-	// Re-check started under the write lock before appending, mirroring
+	// Re-check the teardown fence under the write lock before appending, mirroring
 	// AddShellTab: Kill is not serialized against attach and can have flipped
 	// started=false (snapshotting Tabs for teardown) in the window since our
-	// RLock. Nothing was spawned above (attach-only), so a lost race only needs to
-	// release the local attach client we opened and drop the projection; the next
-	// reconcile re-adds the tab if it still exists server-side.
-	killed := !i.started
+	// RLock, and an archive teardown+move keeps started=true and raises OpArchiving
+	// over that same window instead (#1195) — which the started-only recheck this
+	// shipped with never saw, even though the caller gates on HasInFlightOp before
+	// the daemon round-trip precisely because the op matters (#2100, the sibling of
+	// the reconcile's missing recheck). Nothing was spawned above (attach-only), so
+	// a lost race only needs to release the local attach client we opened and drop
+	// the projection; the next reconcile re-adds the tab if it still exists
+	// server-side.
+	killed := !i.started || i.tabSpawnBlockedLocked() != nil
 	title := i.Title
 	if !killed {
 		i.Tabs = append(i.Tabs, tab)
@@ -832,23 +837,13 @@ func (i *Instance) ReconcileTabsFromData(target []TabData) (bool, error) {
 		// URL rides along for a web tab (a vscode tab has none by design — its target
 		// is resolved at proxy time), or the pane would have nothing to iframe.
 		tab := &Tab{ID: id, Name: td.Name, Kind: kind, Command: td.Command, URL: td.URL, tmux: ts}
-		i.mu.Lock()
-		// Re-check under the write lock: a concurrent reconcile/AddTab may have
-		// added this tab while we reconnected outside the lock. Keyed on the id
-		// (name for an id-less roster row) to match the presence test above — a
-		// name re-check would wrongly skip a recreated tab whose new id must land.
-		exists := false
-		for _, t := range i.Tabs {
-			if (td.ID != "" && t.ID == td.ID) || (td.ID == "" && t.Name == td.Name) {
-				exists = true
-				break
-			}
-		}
-		if !exists {
-			i.Tabs = append(i.Tabs, tab)
+		// Adopt under the write lock, re-checking BOTH the already-present dedupe (a
+		// concurrent reconcile/AddTab may have added this tab while we reconnected
+		// outside the lock) and the teardown fence a Kill/archive can have raised in
+		// that same window (#2100). See appendReconciledTab.
+		if i.appendReconciledTab(td.ID, td.Name, tab) {
 			changed = true
 		}
-		i.mu.Unlock()
 	}
 
 	// Reorder LAST, once the local set matches the daemon's. A pure reorder leaves

--- a/session/snapshot_reconcile_race_test.go
+++ b/session/snapshot_reconcile_race_test.go
@@ -1,0 +1,149 @@
+package session
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The #2100 race, and why it needs its own harness.
+//
+// ReconcileTabsFromData reconnects a daemon-listed tab OUTSIDE i.mu — an
+// attach-only Restore, which shells out to tmux — and then re-acquires the lock
+// to append it. Every other tab-add path rechecks the teardown fence in that
+// second acquisition (AddShellTab/AddProcessTab in tab_spawn.go, AttachShellTab
+// in instance.go); the reconcile did not, so a Kill or an archive landing in the
+// window spliced a tab into a roster that was already being torn down.
+//
+// The window is opened by exactly one observable event: the `tmux has-session`
+// probe the attach-only Restore issues for the sibling session. Hooking that
+// probe is what makes the race deterministic rather than a timing test.
+
+// reconcileRaceExec wraps nameKeyedExec with two things a race test needs: a
+// hook that fires the FIRST time the sibling session's existence is probed (the
+// restore→append window), and a record of whether that daemon-owned session was
+// ever kill-session'd. The hook runs AFTER the probe answers, so Restore
+// completes its rebind and the reconcile goes on to the append it must skip.
+func reconcileRaceExec(agentName, shellTmuxName string, onRestore func()) (cmd_test.MockCmdExec, func() bool) {
+	base := nameKeyedExec(map[string]bool{agentName: true, shellTmuxName: true})
+	fired, killed := false, false
+	hooked := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			// Match on the sibling's name, not the agent's: the sibling name embeds the
+			// agent name ("<agent>__shell"), so this direction cannot alias.
+			s := cmd.String()
+			mine := strings.Contains(s, shellTmuxName)
+			if mine && strings.Contains(s, "kill-session") {
+				killed = true
+			}
+			err := base.RunFunc(cmd)
+			if onRestore != nil && !fired && mine && strings.Contains(s, "has-session") {
+				fired = true
+				onRestore()
+			}
+			return err
+		},
+		OutputFunc: base.OutputFunc,
+	}
+	return hooked, func() bool { return killed }
+}
+
+// TestReconcileTabsFromData_TeardownRaceDropsRestoredTab is the #2100 fix: a
+// Kill/Archive landing between the attach-only Restore and the append must leave
+// the tab OUT of the roster, so the reconcile cannot splice a tab into a session
+// teardownTabs has already snapshotted for cleanup.
+//
+// The three stale transitions are the three the fence covers, and they are not
+// interchangeable. A daemon-side Kill clears started; the TUI's own kill is an
+// OPTIMISTIC overlay that raises OpKilling and leaves started true; and archive
+// deliberately keeps started true and fences with OpArchiving instead (#1195), so
+// a started-only recheck — the one AttachShellTab shipped with — never fires for
+// the archive path at all.
+//
+// It must also NOT kill the session it declines to adopt. This loop only ever
+// ATTACHES (Restore("") errors instead of spawning, #1152) to a session the
+// daemon spawned and owns (#960); the kill it is racing is still revertible
+// (RevertKill on a failed teardown, AbortArchiveToLost on a failed move), so a
+// kill-session here would destroy a live tab over an operation that gets undone.
+func TestReconcileTabsFromData_TeardownRaceDropsRestoredTab(t *testing.T) {
+	const agentName = "af_snap_race"
+	shellName := agentName + shellTmuxSuffix
+
+	for _, tc := range []struct {
+		name  string
+		stale func(t *testing.T, i *Instance)
+	}{
+		{
+			name:  "kill clears started",
+			stale: func(_ *testing.T, i *Instance) { flipStarted(i) },
+		},
+		{
+			name: "optimistic kill raises OpKilling",
+			stale: func(t *testing.T, i *Instance) {
+				require.NoError(t, i.Transition(BeginKill()))
+			},
+		},
+		{
+			name: "archive raises OpArchiving over started=true",
+			stale: func(t *testing.T, i *Instance) {
+				require.NoError(t, i.Transition(BeginArchive()))
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var inst *Instance
+			mockExec, sessionKilled := reconcileRaceExec(agentName, shellName, func() {
+				tc.stale(t, inst)
+			})
+			inst, _ = newReconcileTestInstanceWithExec(t, agentName, mockExec)
+
+			target := []TabData{
+				{ID: "agent-id", Name: inst.GetTabs()[0].Name, Kind: TabKindAgent, TmuxName: agentName},
+				{ID: "shell-id", Name: "shell", Kind: TabKindShell, TmuxName: shellName},
+			}
+
+			changed, err := inst.ReconcileTabsFromData(target)
+			require.NoError(t, err, "a tab dropped for teardown is not a reconcile failure")
+			assert.False(t, changed, "a tab that was not adopted is not a change")
+			assert.Equal(t, 1, inst.TabCount(),
+				"a tab restored into a tearing-down session must not be appended (#2100)")
+			assert.False(t, sessionKilled(),
+				"the projection must not kill the daemon-owned session; the kill it raced can still be reverted")
+		})
+	}
+}
+
+// TestReconcileTabsFromData_NoTeardownRaceStillAdopts is the no-regression half:
+// with nothing racing, the same harness must still restore the out-of-band tab,
+// append it, and report the change — and a repeat reconcile must still dedupe it
+// rather than appending a second copy.
+func TestReconcileTabsFromData_NoTeardownRaceStillAdopts(t *testing.T) {
+	const agentName = "af_snap_norace"
+	shellName := agentName + shellTmuxSuffix
+
+	mockExec, sessionKilled := reconcileRaceExec(agentName, shellName, nil)
+	inst, _ := newReconcileTestInstanceWithExec(t, agentName, mockExec)
+
+	target := []TabData{
+		{ID: "agent-id", Name: inst.GetTabs()[0].Name, Kind: TabKindAgent, TmuxName: agentName},
+		{ID: "shell-id", Name: "shell", Kind: TabKindShell, TmuxName: shellName},
+	}
+
+	changed, err := inst.ReconcileTabsFromData(target)
+	require.NoError(t, err)
+	assert.True(t, changed, "adopting an out-of-band tab is a change")
+	require.Equal(t, 2, inst.TabCount(), "the out-of-band tab must still be adopted")
+	assert.Equal(t, shellName, inst.GetTabs()[1].tmux.SanitizedName(),
+		"the adopted tab must bind to its EXACT persisted tmux session")
+	assert.False(t, sessionKilled(), "nothing was torn down, so nothing may be killed")
+
+	changedAgain, err := inst.ReconcileTabsFromData(target)
+	require.NoError(t, err)
+	assert.False(t, changedAgain, "an unchanged snapshot must not report a change")
+	assert.Equal(t, 2, inst.TabCount(), "the already-present dedupe must still hold")
+}

--- a/session/snapshot_reconcile_test.go
+++ b/session/snapshot_reconcile_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session/git"
 	"github.com/sachiniyer/agent-factory/session/tmux"
@@ -19,13 +20,20 @@ import (
 // Restore reconnects rather than spawning.
 func newReconcileTestInstance(t *testing.T, agentName string, alive map[string]bool) (*Instance, string) {
 	t.Helper()
+	return newReconcileTestInstanceWithExec(t, agentName, nameKeyedExec(alive))
+}
+
+// newReconcileTestInstanceWithExec is newReconcileTestInstance over a caller-
+// supplied mock exec, for a test that needs to observe or hook the tmux commands
+// the reconcile issues (snapshot_reconcile_race_test.go).
+func newReconcileTestInstanceWithExec(t *testing.T, agentName string, exec cmd_test.MockCmdExec) (*Instance, string) {
+	t.Helper()
 	log.Initialize(false)
 	t.Cleanup(log.Close)
 	// Isolate config reads from the developer's real ~/.agent-factory (see
 	// tab_persist_test.go for the full #837 rationale).
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 
-	exec := nameKeyedExec(alive)
 	pty := persistPtyFactory{t: t, cmdExec: exec}
 
 	worktreePath := filepath.Join(t.TempDir(), "wt")

--- a/session/tab_kill_race_test.go
+++ b/session/tab_kill_race_test.go
@@ -266,6 +266,33 @@ func TestAttachShellTab_KillRaceDropsProjection(t *testing.T) {
 	assert.Equal(t, 1, inst.TabCount(), "the raced tab must not be appended")
 }
 
+// TestAttachShellTab_ArchiveFenceDropsProjection is the archive half of the same
+// window (#2100). handleNewTab gates on HasInFlightOp before the daemon
+// round-trip, but the archive that raises OpArchiving can land DURING it — and
+// archive deliberately keeps started=true (#1195), so the started-only recheck
+// this path shipped with never fired for it and the projection was appended into
+// a roster ArchiveTeardown had already snapshotted. Same outcome as the kill
+// race: nothing appended, nothing killed (the daemon owns the session, and a
+// failed move aborts the archive back to Lost).
+func TestAttachShellTab_ArchiveFenceDropsProjection(t *testing.T) {
+	const agentName = "af_attach_archive"
+	shellName := agentName + shellTmuxSuffix
+
+	var inst *Instance
+	mockExec, sessionKilled := reconcileRaceExec(agentName, shellName, func() {
+		require.NoError(t, inst.Transition(BeginArchive()))
+	})
+	inst, _ = newReconcileTestInstanceWithExec(t, agentName, mockExec)
+
+	tab, err := inst.AttachShellTab(shellTabName, shellName)
+	require.Error(t, err, "a tab attached during an archive teardown must be refused")
+	assert.Contains(t, err.Error(), "session was killed during tab attach")
+	assert.Nil(t, tab)
+	assert.Equal(t, 1, inst.TabCount(), "the raced projection must not be appended")
+	assert.False(t, sessionKilled(),
+		"the projection must not kill the daemon-owned session; a failed archive move aborts back to Lost")
+}
+
 // TestAddTab_NoKillRaceStillAppends verifies the fix does not regress the happy
 // path: with no concurrent kill, both AddShellTab and AddProcessTab still spawn,
 // append, and return a live tab.

--- a/session/tab_spawn.go
+++ b/session/tab_spawn.go
@@ -193,6 +193,60 @@ func (i *Instance) AddProcessTab(command, requestedName string) (*Tab, error) {
 	return tab, nil
 }
 
+// appendReconciledTab appends a tab ReconcileTabsFromData rebuilt from the
+// daemon's roster, unless the instance moved out from under the reconnect it did
+// outside i.mu. Reports whether the tab was adopted.
+//
+// It is the third site of the same recheck AddShellTab and AddProcessTab do, and
+// it lives beside them so the three cannot drift (#2100). The reconcile lacked it
+// entirely: it released i.mu to reconnect the session, and a Kill or an archive
+// landing in that window was appended straight into a roster teardownTabs had
+// already snapshotted for cleanup — a tab spliced into a session being torn down,
+// which no teardown pass will ever visit.
+//
+// matchID/name are the target ROW's keys, not the tab's: an id-less legacy row
+// mints a fresh local id, so only the row's own key can answer "did a concurrent
+// reconcile/AddTab already add this one". Keeping that dedupe is why this takes
+// the row's keys rather than reading them off tab.
+//
+// What it does NOT do on a lost race is kill the session. That is the one place
+// it deliberately parts from AddShellTab: AddShellTab SPAWNED the session it
+// abandons and therefore owns its teardown, while the reconcile only ever
+// ATTACHES — Restore("") errors instead of spawning (#1152) — to a session the
+// daemon spawned and owns (#960). It also races an operation that can be UNDONE:
+// the TUI raises OpKilling optimistically at confirmation time and RevertKill
+// puts the row back when the daemon's teardown fails, and a failed archive move
+// aborts back to Lost. Killing here would destroy a live tab over an operation
+// the user still gets back. So it releases only what this process opened and
+// drops the projection, exactly as AttachShellTab's kill-race path does.
+func (i *Instance) appendReconciledTab(matchID, name string, tab *Tab) bool {
+	i.mu.Lock()
+	// Keyed on the id (name for an id-less roster row) to match the presence test
+	// the caller ran before reconnecting — a name re-check would wrongly skip a
+	// recreated tab whose new id must land.
+	exists := false
+	for _, t := range i.Tabs {
+		if (matchID != "" && t.ID == matchID) || (matchID == "" && t.Name == name) {
+			exists = true
+			break
+		}
+	}
+	stale := !i.started || i.tabSpawnBlockedLocked() != nil
+	adopt := !stale && !exists
+	if adopt {
+		i.Tabs = append(i.Tabs, tab)
+	}
+	title := i.Title
+	i.mu.Unlock()
+
+	if stale && tab.tmux != nil {
+		if cerr := tab.tmux.CloseAttachOnly(); cerr != nil {
+			log.WarningLog.Printf("reconcile tabs for %q: releasing attach client for tab %q after kill/archive race: %v", title, name, cerr)
+		}
+	}
+	return adopt
+}
+
 // AddWebTab appends a new Web-kind tab pointing at url to the instance's Tabs and
 // returns it. Unlike shell/process tabs a web tab has NO tmux session — it is
 // pure metadata (a URL the web UI iframes and, for loopback targets, the daemon


### PR DESCRIPTION
Fixes #2100

## The race

`ReconcileTabsFromData` reconnects a daemon-listed tab **outside `i.mu`** — an
attach-only `Restore`, which shells out to tmux — and then re-acquires the lock to
append it. Every sibling tab-add path rechecks the teardown fence in that second
acquisition (`AddShellTab`/`AddProcessTab`, `tab_spawn.go`); the reconcile rechecked
only the already-present dedupe. So a Kill or an archive landing in the
restore→append window was appended straight into a roster `teardownTabs` had already
snapshotted for cleanup: a tab spliced into a session being torn down, which no
teardown pass will ever visit.

## The fix

The recheck is now `appendReconciledTab`, living **beside its two siblings** in
`tab_spawn.go` so the three cannot drift, using the identical predicate:

```go
stale := !i.started || i.tabSpawnBlockedLocked() != nil
```

The existing id/name-keyed already-present dedupe is kept verbatim — a tab another
reconcile/`AddTab` added is still skipped, and an id-less legacy row still keys on
its name.

## One deliberate departure from the issue's suggested patch

The issue recommends `ts.Close()` on the stale path. **This PR calls
`CloseAttachOnly()` instead and never kill-sessions.** Three reasons, and the third
is a live regression the suggested patch would introduce:

1. **This path cannot orphan a session, because it cannot create one.** `AddShellTab`
   *spawned* the session it abandons, so it owns the teardown. The reconcile only ever
   **attaches**: `Restore("")` passes an empty workDir precisely so a missing session
   errors instead of re-spawning (#1152), and post-#1592-PR7 a Restore onto a live
   session is a pure logical rebind that opens no client at all. The tmux session it
   binds to was spawned by the daemon, which owns it (#960).
2. **`ReconcileTabsFromData` runs only in the TUI** (`app/sync.go:657`), which is a
   read-only projection. Killing a daemon-owned session from it is exactly the
   single-writer violation `TestAttachShellTab_KillRaceDropsProjection` already pins
   ("the projection must not kill the daemon-owned session").
3. **The operation it races can be undone.** The TUI raises `OpKilling`
   *optimistically at confirmation time*, and `RevertKill` puts the row back when the
   daemon's teardown fails (`app/handle_actions.go`); a failed archive move aborts back
   to Lost. A `kill-session` here would destroy a live shell tab over an operation the
   user still gets back.

So: skip the append, release only what this process opened, and let the next poll
re-add the tab if the daemon still lists it. Same shape as `AttachShellTab`'s
kill-race path.

## Adjacent audit

`AttachShellTab` — the other attach-then-append projection — carried only the
`!i.started` half of the fence. Archive deliberately keeps `started=true` and fences
with `OpArchiving` instead (#1195), so its recheck never fired for an archive landing
during the daemon `CreateTab` round-trip (`handleNewTab` gates on `HasInFlightOp`
*before* that round-trip, so the op can only be raised inside it). Widened to the
same predicate, with its own fail-first test.

Everything else that materializes tabs is safe: `AddWebTab`/`AddVSCodeTab` never
release the lock, and `restoreLocalTabs`/`setupTabs` run on an instance not yet shared.

## Fail-first

Race injected deterministically by hooking the `tmux has-session` probe the
attach-only `Restore` issues — the one observable event that opens the window — so
these are not timing tests. On master, with only the tests applied:

```
--- FAIL: TestReconcileTabsFromData_TeardownRaceDropsRestoredTab (0.00s)
    --- FAIL: TestReconcileTabsFromData_TeardownRaceDropsRestoredTab/kill_clears_started (0.00s)
            	Error:      	Not equal:
            	            	expected: 1
            	            	actual  : 2
            	Messages:   	a tab restored into a tearing-down session must not be appended (#2100)
    --- FAIL: TestReconcileTabsFromData_TeardownRaceDropsRestoredTab/optimistic_kill_raises_OpKilling (0.00s)
            	Error:      	Not equal:
            	            	expected: 1
            	            	actual  : 2
            	Messages:   	a tab restored into a tearing-down session must not be appended (#2100)
    --- FAIL: TestReconcileTabsFromData_TeardownRaceDropsRestoredTab/archive_raises_OpArchiving_over_started=true (0.00s)
            	Error:      	Not equal:
            	            	expected: 1
            	            	actual  : 2
            	Messages:   	a tab restored into a tearing-down session must not be appended (#2100)
--- FAIL: TestAttachShellTab_ArchiveFenceDropsProjection (0.00s)
            	Error:      	An error is expected but got nil.
            	Messages:   	a tab attached during an archive teardown must be refused
FAIL	github.com/sachiniyer/agent-factory/session	0.024s
```

The three subtests are not interchangeable: a daemon Kill clears `started`, the TUI's
own kill leaves `started` true and raises `OpKilling`, and archive leaves `started`
true and raises `OpArchiving` — the last two are the ones the TUI actually reaches,
and neither is visible to a started-only check.

Each also asserts the daemon-owned session was **not** killed, which is what pins the
`CloseAttachOnly`-not-`Close` decision above.

No-regression coverage: `TestReconcileTabsFromData_NoTeardownRaceStillAdopts` (an
unraced reconcile still restores, binds to the exact persisted tmux session, and
appends) plus a repeat reconcile asserting the already-present dedupe still holds; the
pre-existing reconcile suite is unchanged and green.

## Gate

`gofmt -l .` clean · `golangci-lint run --timeout=3m --fast` clean ·
`deadcode -test ./...` clean · `scripts/lint-file-length.sh` passes
(`instance.go` 971 → 966) · `go build ./...` · `go test ./session/... ./app/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
