### PR TITLE
fix(ui): a modal's rectangle is opaque, so no pane bleeds through it (#2149)

### DIFF
--- a/ui/automations.go
+++ b/ui/automations.go
@@ -47,23 +47,6 @@ var automationDetailStyle = lipgloss.NewStyle().
 var automationsHintStyle = lipgloss.NewStyle().
 	Foreground(activeTheme.ForegroundDim)
 
-// fitLine truncates plain text to w cells, marking a cut with a trailing "…"
-// (dropped when even the ellipsis cannot fit) — the same treatment the tree
-// rows apply, replacing the bare hard cut ClampToRect would make.
-func fitLine(s string, w int) string {
-	if w <= 0 {
-		return ""
-	}
-	if runewidth.StringWidth(s) <= w {
-		return s
-	}
-	tail := "…"
-	if w < runewidth.StringWidth(tail) {
-		tail = ""
-	}
-	return runewidth.Truncate(s, w, tail)
-}
-
 // AutomationsPane is the bottom section of the left rail (#1087 revised RFC
 // §2.1's bottom strip): one row per task — the enabled glyph and the task
 // title in the instances-list title color — pinned under the instances tree

--- a/ui/fit.go
+++ b/ui/fit.go
@@ -7,14 +7,29 @@ import (
 	xansi "github.com/charmbracelet/x/ansi"
 )
 
-func fitStyledLine(s string, width int) string {
+// fitLine clips s to width terminal cells, marking the cut with an ellipsis.
+//
+// The measurement is ANSI-aware on purpose (#2149). A plain rune width counts
+// every byte of an escape sequence as a visible cell, so styled content gets
+// truncated many cells early — and, because the cut then lands at a byte
+// offset, usually in the MIDDLE of an escape sequence. A terminal swallows
+// everything following an unterminated CSI until a final byte arrives, so
+// inside a modal that eats the row's own padding and right border and lets the
+// pane behind print into the form. xansi.Truncate cuts on cell boundaries and
+// never splits a sequence; the trailing reset closes any style the cut left
+// open.
+func fitLine(s string, width int) string {
 	if width <= 0 {
 		return ""
 	}
 	if lipgloss.Width(s) <= width {
 		return s
 	}
-	out := xansi.Truncate(s, width, "…")
+	tail := "…"
+	if width < lipgloss.Width(tail) {
+		tail = ""
+	}
+	out := xansi.Truncate(s, width, tail)
 	if strings.Contains(out, "\x1b") {
 		out += "\x1b[0m"
 	}
@@ -24,7 +39,7 @@ func fitStyledLine(s string, width int) string {
 func fitBlockToSize(content string, width, height, pinnedFooter int) string {
 	lines := strings.Split(content, "\n")
 	for i := range lines {
-		lines[i] = fitStyledLine(lines[i], width)
+		lines[i] = fitLine(lines[i], width)
 	}
 	if height <= 0 || len(lines) <= height {
 		return strings.Join(lines, "\n")

--- a/ui/fit_test.go
+++ b/ui/fit_test.go
@@ -1,0 +1,136 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+)
+
+// #2149: fitLine is the width clamp behind every task-modal row. It used to
+// measure with a plain rune width, which counts each byte of an escape
+// sequence as a visible cell. Styled content was therefore cut many cells
+// early and — since the cut landed at a byte offset — usually in the middle of
+// an escape sequence. A terminal swallows everything after an unterminated CSI
+// until a final byte arrives, so the mangled row lost its own padding and right
+// border and the pane behind printed inside the modal.
+
+// truecolor pins the color profile so styles actually emit SGR sequences.
+// Under the default test profile every style renders as plain text and this
+// whole class of damage is invisible.
+func truecolor(t *testing.T) {
+	t.Helper()
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+}
+
+// hasTruncatedEscape reports whether s ends inside an escape sequence — a CSI
+// introduced but never closed by a final byte in 0x40-0x7E.
+func hasTruncatedEscape(s string) bool {
+	b := []byte(s)
+	for i := 0; i < len(b); i++ {
+		if b[i] != 0x1b {
+			continue
+		}
+		if i+1 >= len(b) {
+			return true
+		}
+		if b[i+1] != '[' {
+			i++
+			continue
+		}
+		j := i + 2
+		for j < len(b) && (b[j] < 0x40 || b[j] > 0x7e) {
+			j++
+		}
+		if j >= len(b) {
+			return true
+		}
+		i = j
+	}
+	return false
+}
+
+func TestFitLineMeasuresStyledContentInCells(t *testing.T) {
+	truecolor(t)
+
+	styled := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#dcdccc")).Render("At 3 : 00  AM")
+	if got, want := lipgloss.Width(styled), 13; got != want {
+		t.Fatalf("test fixture is %d cells wide, want %d", got, want)
+	}
+	if got := fitLine(styled, 20); got != styled {
+		t.Fatalf("fitLine truncated content that fits in 20 cells (%d visible): got %q", lipgloss.Width(styled), got)
+	}
+}
+
+func TestFitLineNeverSplitsAnEscapeSequence(t *testing.T) {
+	truecolor(t)
+
+	style := lipgloss.NewStyle().Foreground(lipgloss.Color("#dcdccc"))
+	var b strings.Builder
+	for i := 0; i < 10; i++ {
+		b.WriteString(style.Render("chunk "))
+	}
+	styled := b.String()
+
+	for width := 1; width <= lipgloss.Width(styled); width++ {
+		out := fitLine(styled, width)
+		if hasTruncatedEscape(out) {
+			t.Fatalf("fitLine(_, %d) cut inside an escape sequence: %q", width, out)
+		}
+		if got := lipgloss.Width(out); got > width {
+			t.Fatalf("fitLine(_, %d) returned %d cells: %q", width, got, out)
+		}
+	}
+}
+
+// TestFitLinePlainTextUnchanged pins the behavior every other caller relies on:
+// plain text still clips to the requested cell count with a trailing ellipsis,
+// dropped when even the ellipsis cannot fit, and wide runes count as 2 cells.
+func TestFitLinePlainTextUnchanged(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		in    string
+		width int
+		want  string
+	}{
+		{"fits", "nightly sweep", 20, "nightly sweep"},
+		{"exact", "nightly", 7, "nightly"},
+		{"clipped", "nightly sweep", 8, "nightly…"},
+		{"no room for the tail", "nightly", 0, ""},
+		{"wide runes", "日本語です", 4, "日…"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := fitLine(tc.in, tc.width); got != tc.want {
+				t.Fatalf("fitLine(%q, %d) = %q, want %q", tc.in, tc.width, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSchedulePickerRowsSurviveStyling is the #2149 repro at the row level: the
+// schedule editor's rows fit the pane width easily, so styling them must not
+// cost a single visible cell.
+func TestSchedulePickerRowsSurviveStyling(t *testing.T) {
+	truecolor(t)
+
+	p := newSchedulePicker()
+	p.setWidth(48) // the task modal's content width at 80x24
+	p.setFocused(true)
+	p.hourStr = "3"
+
+	rows := strings.Split(p.render(), "\n")
+	for i, row := range rows {
+		if hasTruncatedEscape(row) {
+			t.Fatalf("schedule row %d ends inside an escape sequence: %q", i, row)
+		}
+	}
+	joined := strings.Join(rows, "\n")
+	for _, want := range []string{"At", "3", "00", "AM", "Every day at 3:00 AM"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("schedule editor dropped %q from its rows:\n%q", want, joined)
+		}
+	}
+}

--- a/ui/overlay/modal_opacity_test.go
+++ b/ui/overlay/modal_opacity_test.go
@@ -1,0 +1,358 @@
+package overlay
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/mattn/go-runewidth"
+	"github.com/muesli/termenv"
+
+	"github.com/sachiniyer/agent-factory/task"
+	"github.com/sachiniyer/agent-factory/ui"
+)
+
+// #2149: a modal must be OPAQUE — every cell inside its rectangle (border,
+// field rows, and blank padding alike) is painted by the modal, so the pane
+// behind it can never show through or visually merge with the form.
+//
+// The tests below assert that property against the real render path: the real
+// ui.TaskPane edit form, framed the way app/render.go frames it, composited by
+// the real PlaceOverlay over a background pane that has content.
+//
+// Two things broke it, and both are checked here:
+//
+//   - The compositor left the tail of a short foreground row transparent, so a
+//     modal whose rows are not all padded to its full width showed background
+//     through the gap.
+//   - ui.fitLine measured styled content with an ANSI-blind width, so the
+//     schedule picker's rows were truncated far too early and, worse, mid
+//     escape sequence. A terminal swallows every byte after an unterminated
+//     CSI until a final byte arrives — eating the modal's own padding and
+//     right border, and letting the background print inside the form.
+
+// continuationCell marks the second cell of a double-width grapheme so column
+// arithmetic over the rasterized grid stays in terminal cells, not runes.
+const continuationCell = '\x00'
+
+// blankCell is what an untouched terminal cell shows.
+const blankCell = ' '
+
+// rasterizeLine converts one rendered line into the cells a terminal would
+// actually display. It implements just enough of the ANSI ground/CSI state
+// machine to be faithful about the failure this issue is about: a CSI runs
+// from "\x1b[" until a final byte in 0x40-0x7E, and everything it consumes
+// prints nothing. A sequence truncated mid-parameter therefore eats the
+// characters that follow it — which is precisely how a mangled modal row loses
+// its padding and right border and lets the pane behind bleed into the form.
+func rasterizeLine(line string) []rune {
+	var cells []rune
+	b := []byte(line)
+	for i := 0; i < len(b); {
+		if b[i] == 0x1b {
+			i++
+			if i < len(b) && b[i] == '[' {
+				i++
+				for i < len(b) && (b[i] < 0x40 || b[i] > 0x7e) {
+					i++
+				}
+				if i < len(b) {
+					i++ // the final byte, consumed by the sequence
+				}
+				continue
+			}
+			if i < len(b) {
+				i++ // two-byte escape
+			}
+			continue
+		}
+		r, size := utf8.DecodeRune(b[i:])
+		i += size
+		w := runewidth.RuneWidth(r)
+		if w <= 0 {
+			continue
+		}
+		cells = append(cells, r)
+		for k := 1; k < w; k++ {
+			cells = append(cells, continuationCell)
+		}
+	}
+	return cells
+}
+
+// rasterize renders a whole frame into a cell grid, padding every row out to
+// width so callers can index a rectangle without bounds checks. Cells the
+// frame never wrote read as blanks, exactly as they would on screen.
+func rasterize(frame string, width int) [][]rune {
+	lines := strings.Split(frame, "\n")
+	grid := make([][]rune, len(lines))
+	for i, line := range lines {
+		row := rasterizeLine(line)
+		if len(row) > width {
+			row = row[:width]
+		}
+		for len(row) < width {
+			row = append(row, blankCell)
+		}
+		grid[i] = row
+	}
+	return grid
+}
+
+// backgroundFrame is a stand-in for a session pane left showing terminal
+// output — the git-commit summary from the #2149 repro, on every row, so any
+// transparent cell anywhere in the modal rectangle shows a recognizable glyph.
+func backgroundFrame(width, height int) string {
+	const content = "1 file changed, 3 insertions(+) >> README.md "
+	row := strings.Repeat(content, width/len(content)+2)[:width]
+	lines := make([]string, height)
+	for i := range lines {
+		lines[i] = row
+	}
+	return strings.Join(lines, "\n")
+}
+
+// modalFrameStyle mirrors app/render.go's hooksOverlayStyle — the frame every
+// pane-hosted modal (tasks, hooks, config) is rendered in. Only the accent
+// border color is dropped; it has no bearing on opacity.
+func modalFrameStyle(width, height int) lipgloss.Style {
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		Padding(1, 2).
+		Width(width).
+		Height(height)
+}
+
+// taskEditModal renders the real task-edit form for a cron task, focused on the
+// schedule field (the #2149 repro: `m` on an existing cron task), inside the
+// modal frame the app draws around it.
+func taskEditModal(t *testing.T, frameW, frameH int) string {
+	t.Helper()
+	pane := ui.NewTaskPane()
+	pane.SetTasks([]task.Task{{
+		ID:          "t1",
+		Name:        "nightly",
+		Prompt:      "run the nightly sweep",
+		CronExpr:    "0 3 * * *",
+		ProjectPath: "/repo",
+		Enabled:     true,
+	}})
+	pane.SelectTask(0)
+	pane.EnterEditSelected()
+	// Tab from Name past Trigger onto the schedule picker, so the picker draws
+	// its focused cells and hint row.
+	pane.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
+	pane.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
+
+	style := modalFrameStyle(frameW, frameH)
+	pane.SetSize(frameW-style.GetHorizontalPadding(), frameH-style.GetVerticalPadding())
+	return style.Render(pane.String())
+}
+
+// taskCreateModal renders the real "New Task" form (the `n` path) in the same
+// frame, so the adjacent-surface audit covers create as well as edit.
+func taskCreateModal(t *testing.T, frameW, frameH int) string {
+	t.Helper()
+	pane := ui.NewTaskPane()
+	pane.EnterCreateMode("/repo")
+	pane.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
+	pane.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
+
+	style := modalFrameStyle(frameW, frameH)
+	pane.SetSize(frameW-style.GetHorizontalPadding(), frameH-style.GetVerticalPadding())
+	return style.Render(pane.String())
+}
+
+// truecolor pins the color profile so styles actually emit SGR sequences.
+// Under the default test profile every style renders as plain text and the
+// whole class of escape-sequence damage is invisible.
+func truecolor(t *testing.T) {
+	t.Helper()
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+}
+
+// placement mirrors PlaceOverlay's centering and clamping so a test can name
+// the rectangle the modal occupies in the composed frame.
+func placement(fg, bg string) (x, y, w, h int) {
+	fgLines := strings.Split(fg, "\n")
+	bgLines := strings.Split(bg, "\n")
+	w, h = lipgloss.Width(fg), len(fgLines)
+	bgW, bgH := lipgloss.Width(bg), len(bgLines)
+	x = clamp((bgW-w)/2, 0, bgW-w)
+	y = clamp((bgH-h)/2, 0, bgH-h)
+	return x, y, w, h
+}
+
+// TestTaskEditModalOccludesBackgroundPane is the #2149 repro. At 80x24, with
+// the task-edit form open over a pane showing commit output, every cell of the
+// modal rectangle in the composed frame must be the modal's own — never the
+// background's.
+func TestTaskEditModalOccludesBackgroundPane(t *testing.T) {
+	truecolor(t)
+
+	const termW, termH = 80, 24
+	// app/render.go: preferredOverlayWidth(52) and preferredOverlayHeight() at
+	// 80x24, less the frame's border.
+	fg := taskEditModal(t, 50, 12)
+	bg := backgroundFrame(termW, termH)
+
+	x, y, w, h := placement(fg, bg)
+	composed := rasterize(PlaceOverlay(0, 0, fg, bg, true), termW)
+	modal := rasterize(fg, w)
+
+	for row := 0; row < h; row++ {
+		for col := 0; col < w; col++ {
+			got, want := composed[y+row][x+col], modal[row][col]
+			if got != want {
+				t.Fatalf("background bled into the modal at row %d col %d: got %q, want %q\n"+
+					"composed row: %q\nmodal row:    %q",
+					row, col, string(got), string(want),
+					string(composed[y+row][x:x+w]), string(modal[row]))
+			}
+		}
+	}
+}
+
+// TestTaskEditModalPaintsItsWholeRectangle checks the other half of the
+// property: the modal itself paints every cell of its rectangle. A row that
+// rasterizes short — because a truncated escape sequence swallowed its padding
+// and right border — is a hole in the modal no compositor can fill correctly.
+func TestTaskEditModalPaintsItsWholeRectangle(t *testing.T) {
+	truecolor(t)
+
+	fg := taskEditModal(t, 50, 12)
+	lines := strings.Split(fg, "\n")
+	width := lipgloss.Width(fg)
+
+	for i, line := range lines {
+		cells := rasterizeLine(line)
+		if len(cells) != width {
+			t.Fatalf("modal row %d paints %d cells, want %d (the rest is transparent): %q",
+				i, len(cells), width, line)
+		}
+		if last := cells[len(cells)-1]; last == blankCell {
+			t.Fatalf("modal row %d lost its right border: %q", i, string(cells))
+		}
+	}
+}
+
+// TestPlaceOverlayFillsRaggedForegroundRows isolates the compositor. A modal
+// whose rows are not all padded to its full width must still occlude the
+// background across its whole rectangle — the blank tail of a short row is
+// modal, not a window onto the pane below.
+func TestPlaceOverlayFillsRaggedForegroundRows(t *testing.T) {
+	fg := strings.Join([]string{
+		"+--------------+",
+		"| short",
+		"|",
+		"| a longer row |",
+		"+--------------+",
+	}, "\n")
+	bg := backgroundFrame(40, 9)
+
+	x, y, w, h := placement(fg, bg)
+	composed := rasterize(PlaceOverlay(0, 0, fg, bg, true), 40)
+	modal := rasterize(fg, w)
+
+	for row := 0; row < h; row++ {
+		got, want := string(composed[y+row][x:x+w]), string(modal[row])
+		if got != want {
+			t.Fatalf("background bled through modal row %d: got %q, want %q", row, got, want)
+		}
+	}
+}
+
+// TestEveryModalOccludesBackgroundPane is the adjacent-surface audit #2149
+// asks for: the create-task form and every ui/overlay modal must hold the same
+// opacity property as the edit form, over the same busy pane.
+func TestEveryModalOccludesBackgroundPane(t *testing.T) {
+	truecolor(t)
+
+	const termW, termH = 80, 24
+	bg := backgroundFrame(termW, termH)
+
+	confirm := NewConfirmationOverlay("Delete session 'nightly-sweep'?")
+	confirm.SetMaxSize(termW, termH)
+	picker := NewProjectPickerOverlay([]Project{
+		{Name: "agent-factory", Root: "/repo/agent-factory"},
+		{Name: "notes", Root: "/repo/notes"},
+	}, "/repo/agent-factory")
+	picker.SetMaxSize(termW, termH)
+	selection := NewSelectionOverlay("Choose an agent", []string{"claude", "aider", "codex"})
+	selection.SetMaxSize(termW, termH)
+	prompt := NewPromptOverlay("Initial prompt", "fix the flaky test")
+	prompt.SetMaxSize(termW, termH)
+	search := NewSearchOverlay(nil)
+	search.SetMaxSize(termW, termH)
+	help := NewTextOverlay("Help\n\nj/k move\nenter attach\nq quit")
+	help.SetWidth(50)
+	help.SetHeight(12)
+
+	for _, tc := range []struct {
+		name string
+		fg   string
+	}{
+		{"task edit form", taskEditModal(t, 50, 12)},
+		{"task create form", taskCreateModal(t, 50, 12)},
+		{"confirmation", confirm.Render()},
+		{"project picker", picker.Render()},
+		{"program selection", selection.Render()},
+		{"initial prompt", prompt.Render()},
+		{"session search", search.Render()},
+		{"help", help.Render()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			x, y, w, h := placement(tc.fg, bg)
+			composed := rasterize(PlaceOverlay(0, 0, tc.fg, bg, true), termW)
+			modal := rasterize(tc.fg, w)
+			for row := 0; row < h; row++ {
+				got, want := string(composed[y+row][x:x+w]), string(modal[row])
+				if got != want {
+					t.Fatalf("background bled into modal row %d: got %q, want %q", row, got, want)
+				}
+				if strings.Contains(got, "file changed") {
+					t.Fatalf("background text printed inside modal row %d: %q", row, got)
+				}
+			}
+		})
+	}
+}
+
+// TestPlaceOverlayLeavesBackgroundOutsideTheRectangle guards the other
+// direction: making the modal opaque must not widen it. Cells outside the
+// foreground rectangle still come from the background, and a foreground that
+// is already rectangular composes exactly as before.
+func TestPlaceOverlayLeavesBackgroundOutsideTheRectangle(t *testing.T) {
+	fg := strings.Join([]string{"+---+", "|   |", "+---+"}, "\n")
+	bg := backgroundFrame(20, 5)
+
+	out := PlaceOverlay(0, 0, fg, bg, true)
+	x, y, w, h := placement(fg, bg)
+	composed := rasterize(out, 20)
+	plainBg := rasterize(bg, 20)
+
+	for row := range composed {
+		for col := 0; col < 20; col++ {
+			inModal := row >= y && row < y+h && col >= x && col < x+w
+			if inModal {
+				continue
+			}
+			if composed[row][col] != plainBg[row][col] {
+				t.Fatalf("overlay overwrote background outside its rectangle at row %d col %d: got %q, want %q",
+					row, col, string(composed[row][col]), string(plainBg[row][col]))
+			}
+		}
+	}
+	// The modal itself is unchanged by the fill: it was already rectangular.
+	modal := rasterize(fg, w)
+	for row := 0; row < h; row++ {
+		if string(composed[y+row][x:x+w]) != string(modal[row]) {
+			t.Fatalf("rectangular overlay row %d changed: got %q, want %q",
+				row, string(composed[y+row][x:x+w]), string(modal[row]))
+		}
+	}
+}

--- a/ui/overlay/overlay.go
+++ b/ui/overlay/overlay.go
@@ -166,6 +166,20 @@ func PlaceOverlay(
 	bgHeight := len(bgLines)
 	fgHeight := len(fgLines)
 
+	// An overlay is OPAQUE: every cell inside its rectangle belongs to it,
+	// including the blank tail of a row narrower than the widest one. Only the
+	// row's own width used to be written, so the compositor filled the rest of
+	// the rectangle from the layer below and the pane behind showed through
+	// mid-modal (#2149). Padding here — rather than at each caller — makes the
+	// guarantee a property of compositing, so it holds for whatever a modal
+	// happens to render. lipgloss-framed modals already pad their rows, so this
+	// is a no-op for them and only catches the ragged ones.
+	for i, line := range fgLines {
+		if w := ansi.PrintableRuneWidth(line); w < fgWidth {
+			fgLines[i] = line + strings.Repeat(" ", fgWidth-w)
+		}
+	}
+
 	// Apply a fade effect to the background by directly modifying each line
 	fadedBgLines := make([]string, len(bgLines))
 


### PR DESCRIPTION
Fixes #2149.

## What was wrong

At 80x24 with output left in a session pane, `m` on a cron task opened the Edit
Task form and background commit text printed **inside** the modal. Reproduced
exactly:

```
│    Every day at 3:00 AME.md 1 file changed, 3 inse
```

The modal's own padding and right border are simply missing on that row.

## Diagnosis — two seams, both real

**1. `ui.fitLine` measured with an ANSI-blind width.** It used
`runewidth.StringWidth`/`runewidth.Truncate`, which count every byte of an
escape sequence as a visible cell. 24 of its 25 callers pass plain text and
style afterwards, so nobody noticed — but `schedulePicker.render` clips rows
that are *already styled*. A 16-cell row measured as 46 and got cut to 7, and
because the cut lands at a **byte** offset it usually lands in the middle of an
escape sequence:

```
│  ESC[38;2;220;220;204m  ESC[38;2;220;220;204mEvery day at 3:00 AMESC[0mESC[3…            │
                                                                          ^^^^^ truncated CSI
```

A terminal swallows every byte after an unterminated CSI until a final byte in
`0x40-0x7E` arrives. The row's lipgloss padding and right border are all
`0x20`/UTF-8 bytes, so they get eaten — and the first byte that *does* stop the
sequence is a letter in the background text, which then prints inside the form.
That is the whole reported symptom.

The ANSI-aware twin already existed in the same package (`fitStyledLine`, one
caller). The two are now **one** function, so every call site gets the correct
measurement and the trap is gone rather than dodged once.

**2. `overlay.PlaceOverlay` treated a short row's tail as transparent.** It
wrote each foreground row at *its own* width and filled the rest of the
rectangle from the layer below. Any modal with a row narrower than its widest
was see-through along that row's tail. Foreground rows are now padded to the
overlay width before compositing, so opacity is a property of **compositing**
and holds for whatever a modal happens to render — not something each modal has
to remember.

## Adjacent audit (asked for in the issue)

| surface | before | now |
| --- | --- | --- |
| task **edit** form | bled | fixed |
| task **create** form | bled (same picker) | fixed |
| confirmation | opaque | pinned by test |
| project picker | opaque | pinned by test |
| program selection | opaque | pinned by test |
| initial prompt | opaque | pinned by test |
| session search | opaque | pinned by test |
| help | opaque | pinned by test |

The six that were already fine are so because lipgloss pads their rows; they now
have a regression lock. The remaining `runewidth` truncation sites (`sidebar_render.go`,
`tree/render.go`, `err.go`, `alarm.go`, `projects.go`) all measure **plain** text
and style afterwards — and `ui/err.go` explicitly `xansi.Strip`s first (#565) —
so the class is closed.

## Tests (fail-first)

`ui/overlay/modal_opacity_test.go` drives the **real** `ui.TaskPane` edit form,
framed the way `app/render.go` frames it, through the **real** `PlaceOverlay`,
over a background pane carrying the issue's commit output. It rasterizes the
composed frame through a minimal ANSI ground/CSI state machine — so a truncated
escape swallows following cells exactly as a terminal does — and asserts every
cell of the modal rectangle equals the modal's own.

On master:

```
=== RUN   TestTaskEditModalOccludesBackgroundPane
    modal_opacity_test.go:211: background bled into the modal at row 9 col 25: got "E", want " "
--- FAIL: TestTaskEditModalOccludesBackgroundPane (0.00s)
=== RUN   TestTaskEditModalPaintsItsWholeRectangle
    modal_opacity_test.go:234: modal row 9 paints 25 cells, want 52 (the rest is transparent): "│  \x1b[38;2;220;220;204m  \x1b[38;2;220;220;204mEvery day at 3:00 AM\x1b[0m\x1b[3…                         │"
--- FAIL: TestTaskEditModalPaintsItsWholeRectangle (0.00s)
=== RUN   TestPlaceOverlayFillsRaggedForegroundRows
    modal_opacity_test.go:264: background bled through modal row 1: got "| shortnsertions", want "| short         "
--- FAIL: TestPlaceOverlayFillsRaggedForegroundRows (0.00s)
=== RUN   TestEveryModalOccludesBackgroundPane
    --- FAIL: TestEveryModalOccludesBackgroundPane/task_edit_form (0.00s)
        modal_opacity_test.go:315: background bled into modal row 9: got "│    Every day at 3:00 AME.md 1 file changed, 3 inse", want "│    Every day at 3:00 AM                           "
    --- FAIL: TestEveryModalOccludesBackgroundPane/task_create_form (0.00s)
        modal_opacity_test.go:315: background bled into modal row 9: got "│    Every day at 9:00 AME.md 1 file changed, 3 inse", want "│    Every day at 9:00 AM                           "
    --- PASS: TestEveryModalOccludesBackgroundPane/confirmation (0.00s)
    --- PASS: TestEveryModalOccludesBackgroundPane/project_picker (0.00s)
    --- PASS: TestEveryModalOccludesBackgroundPane/program_selection (0.00s)
    --- PASS: TestEveryModalOccludesBackgroundPane/initial_prompt (0.00s)
    --- PASS: TestEveryModalOccludesBackgroundPane/session_search (0.00s)
    --- PASS: TestEveryModalOccludesBackgroundPane/help (0.00s)
=== RUN   TestPlaceOverlayLeavesBackgroundOutsideTheRectangle
--- PASS: TestPlaceOverlayLeavesBackgroundOutsideTheRectangle (0.00s)
```

`ui/fit_test.go`, same run on master:

```
--- FAIL: TestFitLineMeasuresStyledContentInCells (0.00s)
    fit_test.go:64: fitLine truncated content that fits in 20 cells (13 visible): got "\x1b[1;38;2;220;220;204…"
--- FAIL: TestFitLineNeverSplitsAnEscapeSequence (0.00s)
    fit_test.go:81: fitLine(_, 2) cut inside an escape sequence: "\x1b[…"
--- FAIL: TestSchedulePickerRowsSurviveStyling (0.00s)
    fit_test.go:127: schedule row 1 ends inside an escape sequence: "  \x1b[38;2;152;152;144mAt\x1b[0m\x1b[38;2;220;220;204m 3 \x1b[…"
```

Two tests pass on master by design, as the "unchanged behavior" guards:
`TestPlaceOverlayLeavesBackgroundOutsideTheRectangle` (a rectangular overlay
composes byte-identically and nothing outside its rectangle moves) and
`TestFitLinePlainTextUnchanged` (plain-text clipping, ellipsis dropping, and
wide-rune counting are all preserved).

Note both suites pin `termenv.TrueColor` — under the default test profile every
style renders as plain text and this entire class of damage is invisible.

## Gates

`gofmt -l .` clean · `golangci-lint run --timeout=3m --fast` clean ·
`go build ./...` · `scripts/lint-file-length.sh` · `deadcode -test ./...` clean ·
`go test ./ui/...` · `go test ./app/...` (126s) · `go test ./task/... ./schedule/...`

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
