### PR TITLE
fix(session): synchronize every read of Instance.backend (#2096)

### DIFF
--- a/session/activity.go
+++ b/session/activity.go
@@ -134,11 +134,13 @@ func (i *Instance) LifecycleView() LifecycleView {
 		Status:     i.statusLocked(),
 		Started:    i.started,
 		UserKilled: i.userKilled,
-		// Capabilities() takes no lock of its own (it reads the immutable backend
-		// and returns a static struct), so calling it here cannot deadlock — and
-		// reading the backend under the instance lock is strictly more correct than
-		// the bare read it does elsewhere.
-		Recoverable:   i.Capabilities().Recover,
+		// The already-locked variant, NOT Capabilities(): the backend is mutable
+		// (a restore rebinds it in bindProvisionResult), so Capabilities() now
+		// takes i.mu.RLock itself — and calling it while this snapshot holds the
+		// same non-reentrant lock would deadlock against a queued restore writer
+		// (#2096). Resolving it here also keeps the capability in the SAME critical
+		// section as the liveness axes, so the two can never disagree.
+		Recoverable:   i.capabilitiesLocked().Recover,
 		TaskRunActive: i.taskRunActive,
 	}
 }

--- a/session/agentserver_local.go
+++ b/session/agentserver_local.go
@@ -13,7 +13,7 @@ import (
 // (HasUpdated/TapEnter/IsAlive/SendPromptCommand/Preview) now live — internal to
 // the local runtime, reached only through the uniform AgentServer interface.
 //
-// It calls the Backend methods directly (i.backend.*) rather than the Instance
+// It calls the Backend methods directly (via i.currentBackend()) rather than the Instance
 // wrappers, so the wrappers that existed only for the daemon's path (Instance
 // HasUpdated/TapEnter) could be deleted with the daemon routed here — the seam is
 // the AgentServer interface, not a second set of pass-through methods.
@@ -121,11 +121,11 @@ func backendIsRemoteWorkspace(b Backend) bool {
 var _ AgentServer = (*localAgentServer)(nil)
 
 func (s *localAgentServer) Provision(firstTimeSetup bool) error {
-	return s.inst.backend.Provision(s.inst, firstTimeSetup)
+	return s.inst.currentBackend().Provision(s.inst, firstTimeSetup)
 }
 
 func (s *localAgentServer) Launch(firstTimeSetup bool) error {
-	return s.inst.backend.Launch(s.inst, firstTimeSetup)
+	return s.inst.currentBackend().Launch(s.inst, firstTimeSetup)
 }
 
 func (s *localAgentServer) Expose() (StreamEndpoint, error) {
@@ -139,8 +139,12 @@ func (s *localAgentServer) Snapshot() (Observation, error) {
 	// exact order the daemon poll ran (CheckAndHandleTrustPrompt then HasUpdated).
 	// CheckAndHandleTrustPrompt's bool return is intentionally discarded: the poll
 	// never consumed it.
-	s.inst.backend.CheckAndHandleTrustPrompt(s.inst)
-	updated, hasPrompt, content := s.inst.backend.HasUpdated(s.inst)
+	// One backend snapshot for both calls, so the pair can never straddle a
+	// restore's rebind and dismiss a prompt on one backend while reading the pane
+	// of another (#2096).
+	b := s.inst.currentBackend()
+	b.CheckAndHandleTrustPrompt(s.inst)
+	updated, hasPrompt, content := b.HasUpdated(s.inst)
 	return Observation{Updated: updated, HasPrompt: hasPrompt, Content: content}, nil
 }
 
@@ -151,9 +155,9 @@ func (s *localAgentServer) Preview(tab int, full bool) (string, error) {
 	// updateAgent/updateShell split now that the daemon is the sole capturer.
 	if tab == 0 {
 		if full {
-			return s.inst.backend.PreviewFullHistory(s.inst)
+			return s.inst.currentBackend().PreviewFullHistory(s.inst)
 		}
-		return s.inst.backend.Preview(s.inst)
+		return s.inst.currentBackend().Preview(s.inst)
 	}
 	if full {
 		return s.inst.PreviewTabFullHistory(tab)
@@ -175,7 +179,7 @@ type ctxPreviewBackend interface {
 // the caller's wait still returns promptly; only the subprocess-kill is skipped.
 func (s *localAgentServer) PreviewContext(ctx context.Context, tab int, full bool) (string, error) {
 	if tab == 0 && !full {
-		if cb, ok := s.inst.backend.(ctxPreviewBackend); ok {
+		if cb, ok := s.inst.currentBackend().(ctxPreviewBackend); ok {
 			return cb.PreviewContext(ctx, s.inst)
 		}
 	}
@@ -191,17 +195,17 @@ func (s *localAgentServer) Alive() (bool, error) {
 	// here meant "the probe answered", which was never checked and often false.
 	// probeLiveness maps a non-nil error to probeUnknown, so this is the hop that
 	// lets an unanswerable tmux stop being counted as alive.
-	return s.inst.backend.IsAlive(s.inst)
+	return s.inst.currentBackend().IsAlive(s.inst)
 }
 
 func (s *localAgentServer) SendPrompt(prompt string) error {
 	// The reliable command path (tmux send-keys), which is what automated/scheduled
 	// deliveries need — it lands whether or not a PTY is currently attached.
-	return s.inst.backend.SendPromptCommand(s.inst, prompt)
+	return s.inst.currentBackend().SendPromptCommand(s.inst, prompt)
 }
 
 func (s *localAgentServer) TapEnter() {
-	s.inst.backend.TapEnter(s.inst)
+	s.inst.currentBackend().TapEnter(s.inst)
 }
 
 // --- data plane: WS PTY broker + clientless tmux fan-out (#1592 PR5) ---
@@ -405,5 +409,5 @@ func (s *localAgentServer) Kill() error {
 	for _, br := range brokers {
 		br.close()
 	}
-	return s.inst.backend.Kill(s.inst)
+	return s.inst.currentBackend().Kill(s.inst)
 }

--- a/session/instance_accessors.go
+++ b/session/instance_accessors.go
@@ -181,7 +181,7 @@ func (i *Instance) SetTitle(title string) error {
 // refuse to attach — but it must never be used as evidence of liveness: take
 // IsAlive directly for that (#1917 round 8).
 func (i *Instance) TmuxAlive() bool {
-	alive, err := i.backend.IsAlive(i)
+	alive, err := i.currentBackend().IsAlive(i)
 	return err == nil && alive
 }
 

--- a/session/instance_backend.go
+++ b/session/instance_backend.go
@@ -4,9 +4,31 @@ import (
 	"fmt"
 )
 
+// currentBackend snapshots the instance's backend under i.mu (#2096). The
+// backend is NOT immutable: a restore/recover of an off-box session rebinds it
+// via bindProvisionResult under i.mu.Lock, and the restore paths consult the
+// instance (Capabilities, liveness) before taking the per-instance opLock, so a
+// bare field read genuinely races that write.
+//
+// Every read goes through here — or through the *Locked variant below — and the
+// returned Backend is then used OUTSIDE the lock: the delegated calls
+// (Start/Recover/Preview/…) block on tmux, docker, and ssh I/O, and several
+// re-enter i.mu, so holding it across them would deadlock. Snapshot-then-call
+// only guarantees the pointer read is synchronized; serializing an operation
+// against a concurrent rebind is the opLock's job, not this lock's.
+//
+// Callers must not already hold i.mu — sync.RWMutex is not reentrant, and a
+// recursive RLock deadlocks the moment a writer queues between the two
+// acquisitions. Code that already holds the lock uses capabilitiesLocked.
+func (i *Instance) currentBackend() Backend {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.backend
+}
+
 // firstTimeSetup is true if this is a new instance. Otherwise, it's one loaded from storage.
 func (i *Instance) Start(firstTimeSetup bool) error {
-	return i.backend.Start(i, firstTimeSetup)
+	return i.currentBackend().Start(i, firstTimeSetup)
 }
 
 // Kill terminates the instance and cleans up all resources. It delegates to the
@@ -23,7 +45,7 @@ func (i *Instance) Kill() error {
 // the daemon's restore loop and by user-initiated restore (#1300); loads stay
 // side-effect free (#970).
 func (i *Instance) Recover() error {
-	return i.backend.Recover(i)
+	return i.currentBackend().Recover(i)
 }
 
 // Respawn re-establishes the instance's backing session in place without a
@@ -33,7 +55,7 @@ func (i *Instance) Recover() error {
 // !Lost guard rejects, but the re-spawn mechanics are identical. The caller owns
 // the precondition.
 func (i *Instance) Respawn() error {
-	return i.backend.Respawn(i)
+	return i.currentBackend().Respawn(i)
 }
 
 // ArchiveTeardown tears down every tab's tmux session for an archive AND
@@ -148,7 +170,7 @@ func (i *Instance) RestoreFromArchive() error {
 	if err := i.Transition(BeginRestore()); err != nil {
 		return err
 	}
-	if err := i.backend.Recover(i); err != nil {
+	if err := i.currentBackend().Recover(i); err != nil {
 		// Re-spawn failed: drop the fence to a plain Lost (started left true) so
 		// the #1108 restore loop owns the retry against the now-restored worktree.
 		_ = i.Transition(AbortRestoreToLost())
@@ -163,12 +185,12 @@ func (i *Instance) RestoreFromArchive() error {
 // duplicate Instance built from disk that lost a race to the canonical tracked
 // Instance (#867); see Backend.CloseAttachOnly.
 func (i *Instance) CloseAttachOnly() error {
-	return i.backend.CloseAttachOnly(i)
+	return i.currentBackend().CloseAttachOnly(i)
 }
 
 // CheckAndHandleTrustPrompt checks for and dismisses the trust prompt for supported programs.
 func (i *Instance) CheckAndHandleTrustPrompt() bool {
-	return i.backend.CheckAndHandleTrustPrompt(i)
+	return i.currentBackend().CheckAndHandleTrustPrompt(i)
 }
 
 // Capabilities returns the backing runtime's capability descriptor (#1592
@@ -177,7 +199,22 @@ func (i *Instance) CheckAndHandleTrustPrompt() bool {
 // session, so returning the zero value instead would be an incoherent
 // descriptor (local workspace but every capability off) and would regress
 // e.g. the tab-management footer.
+//
+// The backend read is synchronized (#2096): the daemon's restore loops consult
+// Capabilities().Recover BEFORE taking the instance's opLock, so it runs
+// concurrently with a restore rebinding the backend.
 func (i *Instance) Capabilities() Capabilities {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.capabilitiesLocked()
+}
+
+// capabilitiesLocked is Capabilities' already-locked half, for callers that
+// already hold i.mu (LifecycleView resolves the recover capability inside its
+// single read-locked snapshot). It must NOT take the lock itself: sync.RWMutex is
+// not reentrant, so a nested RLock deadlocks against a queued writer — which on
+// this path is exactly the restore goroutine the lock exists to exclude.
+func (i *Instance) capabilitiesLocked() Capabilities {
 	if i.backend == nil {
 		return (&LocalBackend{}).Capabilities()
 	}
@@ -186,10 +223,14 @@ func (i *Instance) Capabilities() Capabilities {
 
 // GetBackend returns the backend for the instance (mainly for testing).
 func (i *Instance) GetBackend() Backend {
-	return i.backend
+	return i.currentBackend()
 }
 
-// SetBackend sets the backend for the instance (mainly for testing).
+// SetBackend sets the backend for the instance (mainly for testing). It writes
+// under i.mu to match bindProvisionResult, so a test swapping the backend cannot
+// race a reader on a background tick.
 func (i *Instance) SetBackend(b Backend) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
 	i.backend = b
 }

--- a/session/instance_backend_race_test.go
+++ b/session/instance_backend_race_test.go
@@ -1,0 +1,77 @@
+package session
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCapabilitiesRacesRestoreBackendSwap reproduces #2096: Capabilities() read
+// i.backend bare while a concurrent restore swapped it under i.mu in
+// bindProvisionResult. The restore paths (daemon/restore.go,
+// daemon/lostrestore.go) consult Capabilities().Recover BEFORE taking the
+// per-instance opLock, so the read genuinely overlaps another goroutine's
+// re-provision of the same instance. Under -race this fails on the pre-fix code
+// with a DATA RACE on Instance.backend.
+func TestCapabilitiesRacesRestoreBackendSwap(t *testing.T) {
+	i := &Instance{Title: "s", backend: newInertSandboxBackend("docker")}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for n := 0; n < 200; n++ {
+			// Endpoint nil keeps this off the network: bindProvisionResult builds
+			// no remote client and just swaps the runtime fields, which is the
+			// write half of the race.
+			assert.NoError(t, i.bindProvisionResult(ProvisionResult{Backend: newInertSandboxBackend("docker")}))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for n := 0; n < 200; n++ {
+			_ = i.Capabilities()
+		}
+	}()
+	wg.Wait()
+}
+
+// TestLifecycleViewWithConcurrentBackendSwap pins the reentrancy constraint that
+// makes the naive fix wrong: LifecycleView() reads the recover capability while
+// already holding i.mu.RLock, so Capabilities() must not take i.mu itself on that
+// path. sync.RWMutex is not reentrant — a recursive RLock deadlocks as soon as a
+// writer (here, the restoring goroutine's bindProvisionResult) queues between the
+// two acquisitions. This test hangs, not races, if that regresses.
+func TestLifecycleViewWithConcurrentBackendSwap(t *testing.T) {
+	i := &Instance{Title: "s", backend: newInertSandboxBackend("docker")}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for n := 0; n < 200; n++ {
+			assert.NoError(t, i.bindProvisionResult(ProvisionResult{Backend: newInertSandboxBackend("docker")}))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for n := 0; n < 200; n++ {
+			_ = i.LifecycleView()
+		}
+	}()
+	wg.Wait()
+}
+
+// TestCapabilitiesBackendSnapshot is the behavioural lock: synchronizing the read
+// must not change what Capabilities() reports. A nil backend still reports local
+// full parity, and a bound backend still reports its own descriptor.
+func TestCapabilitiesBackendSnapshot(t *testing.T) {
+	var unbound Instance
+	assert.Equal(t, (&LocalBackend{}).Capabilities(), unbound.Capabilities(),
+		"a backend-less instance reports local full parity")
+
+	remote := &Instance{backend: newInertSandboxBackend("docker")}
+	assert.Equal(t, WorkspaceRemote, remote.Capabilities().Workspace,
+		"a bound backend reports its own capabilities")
+}


### PR DESCRIPTION
Fixes #2096

## The race

`Capabilities()` read `i.backend` bare; `bindProvisionResult` writes it under `i.mu.Lock()`. The daemon's restore loops (`daemon/restore.go:39`, `daemon/lostrestore.go:276`) consult `Capabilities().Recover` **before** taking the per-instance opLock, so the read genuinely overlaps a concurrent re-provision of the same instance.

The backend stopped being immutable in #1666, which introduced `bindProvisionResult`. The "immutable backend" comment in `session/activity.go` was written two days *after* the mutation already existed and has been lying ever since — removed.

## Why the recommended fix in the issue is wrong

The issue proposes putting `i.mu.RLock()` directly in `Capabilities()`. That ships a deadlock: `LifecycleView()` resolves `Recoverable` **while already holding `i.mu.RLock`**, and `sync.RWMutex` is not reentrant — a nested RLock blocks as soon as a writer queues between the two acquisitions, and on this exact path the queued writer is the restore goroutine the lock exists to exclude.

Demonstrated, not assumed. With the naive fix applied, `TestLifecycleViewWithConcurrentBackendSwap` hangs:

```
panic: test timed out after 25s
	running tests:
		TestLifecycleViewWithConcurrentBackendSwap (25s)
```

So the read splits in two: `capabilitiesLocked()` (already-locked half, used by `LifecycleView`) and the public `Capabilities()` wrapper that takes the RLock.

## Adjacent audit

Every read of `i.backend` in `session/` was checked, not just the one the detector caught:

| Site | Verdict |
|---|---|
| `instance_data.go:55` (`ToInstanceData`), `archive_sandbox.go:145` (`reprovisionRemote`), `agentserver_local.go:90` (`AgentServer`'s `backendIsRemoteWorkspace`) | Already inside an `i.mu` section — left as bare field reads |
| `instance_data.go:184/186` (`FromInstanceData`) | Construction, instance not yet shared |
| `Start`, `Recover`, `Respawn`, `RestoreFromArchive`, `CloseAttachOnly`, `CheckAndHandleTrustPrompt`, `GetBackend`, `TmuxAlive`, and all 11 `s.inst.backend.*` reads in `localAgentServer` | Unsynchronized — now routed through `currentBackend()` |
| `SetBackend` | Unsynchronized **write** — now under `i.mu.Lock()`, matching `bindProvisionResult` |

`currentBackend()` snapshots under `i.mu.RLock` and **releases before the delegated call**: those calls block on tmux/docker/ssh I/O and several re-enter `i.mu` (`remoteAgentBackend` → `i.AgentServer()`), so holding the lock across them would deadlock. `localAgentServer.Snapshot()` takes one snapshot for its `CheckAndHandleTrustPrompt` + `HasUpdated` pair so it cannot straddle a rebind and dismiss a prompt on one backend while reading the pane of another.

Reentrancy was verified for every newly-locking method: the only in-package caller that holds `i.mu` when reaching `Capabilities()` was `LifecycleView` (now on the `*Locked` variant); `RepoName` calls it before taking the lock; every `localAgentServer` method is reached through `AgentServer()`, which itself takes `i.mu` and therefore already requires callers not to hold it. All `Backend.Capabilities()` implementations are static struct literals, so none re-enters the instance.

Synchronizing the pointer read is all this does. Serializing an *operation* against a concurrent rebind remains the opLock's job — deliberately out of scope.

## Reproduction

`session/instance_backend_race_test.go` runs `Capabilities()` (and `LifecycleView()`) against a goroutine driving `bindProvisionResult`, plus a behavioural lock that a nil backend still reports local full parity and a bound backend still reports its own descriptor.

**Before** (master HEAD, `a6a54e1`) — `go test -race -run 'TestCapabilities…|TestLifecycleView…' ./session/`:

```
==================
WARNING: DATA RACE
Read at 0x00c00029c2d0 by goroutine 29:
  github.com/sachiniyer/agent-factory/session.(*Instance).Capabilities()
      /session/instance_backend.go:181 +0x44
  session.TestCapabilitiesRacesRestoreBackendSwap.func2()
      /session/instance_backend_race_test.go:34 +0x99

Previous write at 0x00c00029c2d0 by goroutine 28:
  github.com/sachiniyer/agent-factory/session.(*Instance).bindProvisionResult()
      /session/archive_sandbox.go:201 +0x15d
  session.TestCapabilitiesRacesRestoreBackendSwap.func1()
      /session/instance_backend_race_test.go:28 +0xcd
==================
--- FAIL: TestCapabilitiesRacesRestoreBackendSwap (0.00s)
    testing.go:1617: race detected during execution of test
FAIL	github.com/sachiniyer/agent-factory/session	0.082s
```

(Two `WARNING: DATA RACE` blocks — the same read is reached through `LifecycleView` too.) The stack matches the one in the issue line-for-line.

**After**:

```
=== RUN   TestCapabilitiesRacesRestoreBackendSwap
--- PASS: TestCapabilitiesRacesRestoreBackendSwap (0.00s)
=== RUN   TestLifecycleViewWithConcurrentBackendSwap
--- PASS: TestLifecycleViewWithConcurrentBackendSwap (0.00s)
=== RUN   TestCapabilitiesBackendSnapshot
--- PASS: TestCapabilitiesBackendSnapshot (0.00s)
PASS
ok  	github.com/sachiniyer/agent-factory/session	1.090s
```

## Gates

- `gofmt -l .` — clean
- `golangci-lint run --timeout=3m --fast` — clean
- `go build ./...` — clean
- `scripts/lint-file-length.sh` — clean (842 files)
- `deadcode -test ./...` — clean
- `go test -race ./session/...` — `session` 36.4s, `session/git` 13.7s, `session/tmux` 40.0s, all ok
- `go test ./app/... ./ui/... ./task/... ./api/...` — no test failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)