### PR TITLE
fix(log): benign expected conditions log at Info, not Warning (#2166)

### DIFF
--- a/session/agentskill.go
+++ b/session/agentskill.go
@@ -136,7 +136,10 @@ func ensureAfSkillDir(base string) (string, error) {
 		// existed, so af's edits to the user's global config do not outlive the
 		// decision not to make them (#1977's first objection).
 		removeAfSkillDir(skillDir, path)
-		log.WarningLog.Printf("af skill: not writing %s — af does not manage global agent config directories unless global_agent_skills = true is set in the af config (af guidance not injected for this agent)", path)
+		// INFO, not WARNING (#2166): global_agent_skills defaults false, so this
+		// fires on every codex/gemini/amp session start on a DEFAULT install. af
+		// is honoring the documented default, which is not a defect.
+		log.InfoLog.Printf("af skill: not writing %s — af does not manage global agent config directories unless global_agent_skills = true is set in the af config (af guidance not injected for this agent)", path)
 		return "", nil
 	default: // globalSkillUnknown
 		return "", nil
@@ -147,7 +150,10 @@ func ensureAfSkillDir(base string) (string, error) {
 		return "", err
 	}
 	if !wrote {
-		log.WarningLog.Printf("af skill: %s exists but is not af-managed; leaving it untouched (af guidance not injected)", path)
+		// INFO, not WARNING (#2166): the user owns a file at our path and af is
+		// deliberately not overwriting it. That is the designed outcome of the
+		// marker guard, repeated on every session start, not something to fix.
+		log.InfoLog.Printf("af skill: %s exists but is not af-managed; leaving it untouched (af guidance not injected)", path)
 	}
 	return skillDir, nil
 }
@@ -185,7 +191,9 @@ func removeAfSkillDir(skillDir, path string) {
 	// Best-effort, and deliberately not RemoveAll: this succeeds only if the
 	// directory is now empty.
 	_ = os.Remove(skillDir)
-	log.WarningLog.Printf("af skill: removed the af-managed %s — af no longer writes into global agent config directories (set global_agent_skills = true to restore it)", path)
+	// INFO, not WARNING (#2166): this reports a cleanup that SUCCEEDED, taken
+	// because the user's config says af may not manage that directory.
+	log.InfoLog.Printf("af skill: removed the af-managed %s — af no longer writes into global agent config directories (set global_agent_skills = true to restore it)", path)
 }
 
 // codexSkillsBaseDir returns codex's skills-discovery base: $CODEX_HOME/skills, or
@@ -281,7 +289,8 @@ func ensureAiderReadFile() (string, error) {
 		return "", err
 	}
 	if !wrote {
-		log.WarningLog.Printf("af skill: %s exists but is not af-managed; not injecting --read for aider", path)
+		// INFO, not WARNING (#2166): same marker-guard skip as ensureAfSkillDir.
+		log.InfoLog.Printf("af skill: %s exists but is not af-managed; not injecting --read for aider", path)
 		return "", nil
 	}
 	return path, nil

--- a/session/autoyes_notice_test.go
+++ b/session/autoyes_notice_test.go
@@ -1,0 +1,101 @@
+package session
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// captureLevels redirects the INFO and WARNING sinks into buffers for the
+// duration of the test. The daemon's log level IS the contract an operational
+// error-scraper reads, so the level a message lands on is the thing worth
+// pinning (#2166).
+func captureLevels(t *testing.T) (info, warn *bytes.Buffer) {
+	t.Helper()
+	info, warn = &bytes.Buffer{}, &bytes.Buffer{}
+	prevInfo, prevWarn := log.InfoLog.Writer(), log.WarningLog.Writer()
+	log.InfoLog.SetOutput(info)
+	log.WarningLog.SetOutput(warn)
+	t.Cleanup(func() {
+		log.InfoLog.SetOutput(prevInfo)
+		log.WarningLog.SetOutput(prevWarn)
+	})
+	return info, warn
+}
+
+// #2166: `auto_yes` on an agent af cannot wire it into is an EXPECTED
+// configuration with a documented escape hatch, not a defect — it must not read
+// as a warning to a log scraper. The guidance itself must survive the
+// reclassification, so this asserts on the flag name and the program_overrides
+// hint, not merely on the level.
+func TestResolveProgramForInstance_AutoYesUnsupportedLogsAtInfo(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	info, warn := captureLevels(t)
+
+	i := &Instance{Title: "codex-autoyes-info", Program: tmux.ProgramCodex, AutoYes: true}
+	resolveProgramForInstance(i)
+
+	got := info.String()
+	if !strings.Contains(got, "auto_yes has no effect for codex") {
+		t.Errorf("expected the auto_yes notice at INFO, got %q", got)
+	}
+	if !strings.Contains(got, "--dangerously-bypass-approvals-and-sandbox") {
+		t.Errorf("the notice must keep naming codex's own flag, got %q", got)
+	}
+	if !strings.Contains(got, "program_overrides.codex") {
+		t.Errorf("the notice must keep the program_overrides hint, got %q", got)
+	}
+	if w := warn.String(); strings.Contains(w, "auto_yes has no effect") {
+		t.Errorf("the auto_yes notice must not reach WARNING, got %q", w)
+	}
+}
+
+// Every agent in the unsupported map describes the same benign, static
+// configuration, so none of them may page a scraper.
+func TestNoteAutoYesUnsupported_AllAgentsLogAtInfo(t *testing.T) {
+	for _, agent := range []string{tmux.ProgramCodex, tmux.ProgramAmp, tmux.ProgramOpencode} {
+		t.Run(agent, func(t *testing.T) {
+			info, warn := captureLevels(t)
+			noteAutoYesUnsupported(agent, "all-agents-"+agent)
+			if !strings.Contains(info.String(), "auto_yes has no effect for "+agent) {
+				t.Errorf("expected an INFO notice for %s, got %q", agent, info.String())
+			}
+			if warn.Len() != 0 {
+				t.Errorf("expected nothing at WARNING for %s, got %q", agent, warn.String())
+			}
+		})
+	}
+}
+
+// A supported agent says nothing at all — the notice exists only for the agents
+// af genuinely cannot honor auto_yes for.
+func TestNoteAutoYesUnsupported_SupportedAgentSilent(t *testing.T) {
+	info, warn := captureLevels(t)
+	noteAutoYesUnsupported(tmux.ProgramClaude, "claude-silent")
+	if info.Len() != 0 || warn.Len() != 0 {
+		t.Errorf("expected no notice for claude, got info=%q warn=%q", info.String(), warn.String())
+	}
+}
+
+// The condition is static, but Restore re-resolves the program on every daemon
+// reconcile and every lost-restore retry. Once per session per process keeps the
+// log readable without dropping the guidance.
+func TestNoteAutoYesUnsupported_OncePerSession(t *testing.T) {
+	info, _ := captureLevels(t)
+
+	noteAutoYesUnsupported(tmux.ProgramCodex, "once-per-session")
+	first := info.String()
+	noteAutoYesUnsupported(tmux.ProgramCodex, "once-per-session")
+	if info.String() != first {
+		t.Errorf("expected the repeat call to log nothing, got %q after %q", info.String(), first)
+	}
+
+	// A different session is a different notice.
+	noteAutoYesUnsupported(tmux.ProgramCodex, "once-per-session-other")
+	if !strings.Contains(info.String(), "once-per-session-other") {
+		t.Errorf("expected a second session to get its own notice, got %q", info.String())
+	}
+}

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
@@ -49,7 +50,7 @@ func resolveProgramForInstance(i *Instance) string {
 	//
 	// opencode has NO auto-approve flag on the TUI to wire, so instead of joining
 	// codex/amp as a SILENT AutoYes no-op (#1963) it says so out loud — see
-	// warnIfAutoYesUnsupported below.
+	// noteAutoYesUnsupported below.
 	//
 	// Its whole TUI flag set is -h -v --print-logs --log-level --pure --port
 	// --hostname --mdns --mdns-domain --cors -m/--model -c/--continue -s/--session
@@ -77,7 +78,7 @@ func resolveProgramForInstance(i *Instance) string {
 		resolved = resolved + " --permission-mode bypassPermissions"
 	}
 	if i.AutoYes {
-		warnIfAutoYesUnsupported(tmux.DetectAgentFromCommand(resolved), i.Title)
+		noteAutoYesUnsupported(tmux.DetectAgentFromCommand(resolved), i.Title)
 	}
 	return resolved
 }
@@ -116,12 +117,33 @@ var autoYesUnsupported = map[string]string{
 		"If your opencode exposes one, set it via program_overrides.opencode",
 }
 
-// warnIfAutoYesUnsupported tells the user when auto_yes will not be honored for the
+// autoYesNoticed records the (agent, session) pairs this process has already told
+// the user about, so the notice is emitted once per session per process rather
+// than on every start AND every restore. Restore runs on daemon reconcile and on
+// each lost-restore retry, so without this the same static, unchanging fact is
+// re-logged on a timer.
+var autoYesNoticed sync.Map
+
+// noteAutoYesUnsupported tells the user when auto_yes will not be honored for the
 // agent they picked, instead of ignoring the setting in silence (#1963).
-func warnIfAutoYesUnsupported(agent, title string) {
-	if reason, ok := autoYesUnsupported[agent]; ok {
-		log.WarningLog.Printf("auto_yes has no effect for %s (session %q): %s", agent, title, reason)
+//
+// This is INFO, not WARNING (#2166). Severity states whether something is wrong,
+// and nothing here is: the user turned on auto_yes and picked an agent whose
+// approval knob af cannot reach, which is an expected configuration with a
+// documented escape hatch printed right in the message. An operator scraping the
+// log for WARNING/ERROR should not be paged by a normal codex session start. The
+// guidance text is unchanged — the message is still worth reading, it just is not
+// a defect report. It also keeps a plain `af` run out of log.dirty (#1749), so a
+// successful command stops ending with the "wrote logs to …" note.
+func noteAutoYesUnsupported(agent, title string) {
+	reason, ok := autoYesUnsupported[agent]
+	if !ok {
+		return
 	}
+	if _, seen := autoYesNoticed.LoadOrStore(agent+"\x00"+title, struct{}{}); seen {
+		return
+	}
+	log.InfoLog.Printf("auto_yes has no effect for %s (session %q): %s", agent, title, reason)
 }
 
 // LocalBackend implements Backend using local tmux sessions and git worktrees.

--- a/session/opencodeskill.go
+++ b/session/opencodeskill.go
@@ -82,7 +82,9 @@ func ensureOpencodeAfConfig() (string, error) {
 		return "", err
 	}
 	if !wrote {
-		log.WarningLog.Printf("af skill: %s exists but is not af-managed; not injecting OPENCODE_CONFIG for opencode", instructionsPath)
+		// INFO, not WARNING (#2166): the marker guard refusing to overwrite a
+		// user-owned file is the designed outcome, not a failure.
+		log.InfoLog.Printf("af skill: %s exists but is not af-managed; not injecting OPENCODE_CONFIG for opencode", instructionsPath)
 		return "", nil
 	}
 
@@ -92,7 +94,8 @@ func ensureOpencodeAfConfig() (string, error) {
 		return "", err
 	}
 	if !wrote {
-		log.WarningLog.Printf("af skill: %s exists but is not af-managed; not injecting OPENCODE_CONFIG for opencode", configPath)
+		// INFO, not WARNING (#2166): see above.
+		log.InfoLog.Printf("af skill: %s exists but is not af-managed; not injecting OPENCODE_CONFIG for opencode", configPath)
 		return "", nil
 	}
 	return configPath, nil

--- a/session/systemprompt.go
+++ b/session/systemprompt.go
@@ -137,7 +137,9 @@ func injectSystemPrompt(resolved string) string {
 		// opencode MERGES it with the user's own config (verified), so their
 		// settings survive, and af writes nothing into ~/.config/opencode.
 		if opencodeCarriesConfigEnv(resolved) {
-			log.WarningLog.Printf("opencode command already sets OPENCODE_CONFIG; leaving it alone (af guidance not injected for opencode)")
+			// INFO, not WARNING (#2166): the user pointed OPENCODE_CONFIG at
+			// their own file via program_overrides and af is honoring it.
+			log.InfoLog.Printf("opencode command already sets OPENCODE_CONFIG; leaving it alone (af guidance not injected for opencode)")
 			return resolved
 		}
 		path, err := ensureOpencodeAfConfig()

--- a/session/tmux/start.go
+++ b/session/tmux/start.go
@@ -111,14 +111,17 @@ func (t *TmuxSession) Start(workDir string) error {
 	// hang them; both are best-effort and only log on failure.
 	ctx, cancel := tmuxTimeoutContext()
 	if err := t.runTmuxBounded(ctx, "set-option", "-t", exactTarget(t.sanitizedName), "history-limit", "10000"); err != nil {
-		log.InfoLog.Printf("Warning: failed to set history-limit for session %s: %v", t.sanitizedName, err)
+		// Logged at INFO with no "Warning:" text (#2166): the level is the
+		// severity signal, and an embedded "Warning:" makes an INFO line trip a
+		// log scraper that greps for the word.
+		log.InfoLog.Printf("failed to set history-limit for session %s (scrollback stays at the tmux default): %v", t.sanitizedName, err)
 	}
 	cancel()
 
 	// Enable mouse scrolling for the session
 	ctx, cancel = tmuxTimeoutContext()
 	if err := t.runTmuxBounded(ctx, "set-option", "-t", exactTarget(t.sanitizedName), "mouse", "on"); err != nil {
-		log.InfoLog.Printf("Warning: failed to enable mouse scrolling for session %s: %v", t.sanitizedName, err)
+		log.InfoLog.Printf("failed to enable mouse scrolling for session %s: %v", t.sanitizedName, err)
 	}
 	cancel()
 


### PR DESCRIPTION
Fixes #2166.

## The reported line

```
WARNING backend_local.go:123: auto_yes has no effect for codex (session "..."): codex exposes
--dangerously-bypass-approvals-and-sandbox; set it via program_overrides.codex if you want
unattended approval
```

An operational error-scraper watches `agent-factory.log` and pages on
`WARNING`/`ERROR`. This line fires on every codex + `auto_yes` session start, so
a routine configuration produces a steady drip of false alarms.

The message itself is right and stays — flag name and `program_overrides.codex`
hint intact. What is wrong is its severity.

## The principle

**Log severity states whether something is WRONG.**

- Expected, user-caused, no-action-needed → `Info`.
- Anything an operator should investigate → stays `Warning`/`Error`.

Nothing is wrong when a user turns on `auto_yes` and picks codex: codex simply
uses a different approval flag, which the message names along with the escape
hatch. That is a useful note, not a defect report.

Fixed at the emit site, per the issue: no change to the log monitor, no
suppression list. A suppression list would trade a false alarm for a silent gap
and would drift from the code; the severity of a message is a property of the
message.

Secondary benefit: `log.dirty` (#1749) is set by any WARNING/ERROR write, so
each of these also made an otherwise-successful `af` command end with the
"wrote logs to …" note. Those runs are now clean.

## Changes

### Reclassified Warning → Info

| Site | Condition | Why it is benign |
| --- | --- | --- |
| `session/backend_local.go:123` | `auto_yes has no effect for <agent>` | The reported line. User config af cannot wire through; the message already names the agent's own flag and `program_overrides.<agent>`. Fires on every codex/amp/opencode + `auto_yes` start. |
| `session/agentskill.go:139` | `not writing … unless global_agent_skills = true` | `global_agent_skills` defaults **false**, so this fires on every codex/gemini/amp start on a *default* install. af is honoring the documented default. |
| `session/agentskill.go:150` | `<path> exists but is not af-managed; leaving it untouched` | The marker guard refusing to overwrite a user-owned file is the designed outcome, and the whole point of `writeAfMarkedFile`. |
| `session/agentskill.go:188` | `removed the af-managed <path>` | Reports a cleanup that **succeeded**, taken because the user's config says af may not manage that directory. |
| `session/agentskill.go:284` | aider: `not injecting --read` | Same marker-guard skip. |
| `session/opencodeskill.go:85, :95` | opencode: `not injecting OPENCODE_CONFIG` | Same marker-guard skip. |
| `session/systemprompt.go:140` | `opencode command already sets OPENCODE_CONFIG; leaving it alone` | The user pointed it at their own file via `program_overrides`; af is honoring their choice. |

### Label fix (already Info)

`session/tmux/start.go:114, :121` logged at Info but began with the literal text
`"Warning: "`. A scraper grepping for the word matches the body as readily as the
level prefix, so an Info line was still a false alarm. Text dropped; the
history-limit line now also says what the user loses (scrollback stays at the
tmux default).

### Repetition

`noteAutoYesUnsupported` (renamed from `warnIfAutoYesUnsupported`) now emits once
per `(agent, session)` per process. `resolveProgramForInstance` runs from
`Restore` as well as `Start`, and `Restore` runs on every daemon reconcile and
every lost-restore retry — so a static, unchanging fact was being re-logged on a
timer. The guidance text is unchanged.

## Audit: sites examined and left alone

Per [[audit_adjacent_callsites]], I read every `log.WarningLog` and
`log.ErrorLog` call in `session/…` (the backend) and `daemon/…` — 130 Warning
sites and 40 Error sites. Everything not in the table above stays where it is.
The ones that pattern-matched a benign shape (`unsupported` / `already` /
`skipping` / `nothing` / `leaving`) and were individually read and **kept**:

| Site | Why it stays |
| --- | --- |
| `session/agentskill.go:89` | Could not **read** the af config. An I/O failure af cannot classify; it deliberately yields `globalSkillUnknown`. Real. |
| `session/agentskill.go:174` | Could not read a file to check whether af wrote it — an unreadable file blocks a decision. Real. |
| `session/agentskill.go:182` | Could not **remove** the af-managed file; it stays until removed by hand. Real, and leaves state behind. |
| `session/systemprompt.go:110,121,126,131,145,164` | Skill/plugin setup **failed** — af guidance is missing because something broke, not because the user chose it. Real. |
| `session/backend_local.go:34,40` | Config resolution/load **failed**; the program is resolved from a fallback. Real. |
| `session/storage.go:339,495` | Corrupted `instances.json`; a session or a whole repo is being skipped. Real, and data-losing. |
| `session/git/worktree_ops.go:709,722` | `af reset` skipping a deleted / no-longer-git repo path. Tempting, but cleanup **did not happen** for a path af still has state for, and "not a git repo" can equally mean a wrong path. Also not on any repeated path. Kept. |
| `session/tmux/submit.go:213,358,362` | The strongest remaining candidates — they hedge ("the pane may simply not echo input"). Kept at Error anyway: an undelivered prompt is a real failure mode (#1982/#2070), the hedge is about the *probe*, not the condition, and downgrading it would hide the exact class this repo keeps getting bitten by. |
| `daemon/scheduler.go:94,100` | Duplicate task ID / invalid cron in `tasks.json`. User-caused, but a task **silently will not run** — the operator must fix it. |
| `daemon/watcher.go:780,704,708` | Events / stdout being **dropped** past a cap. User-caused load, real data loss. |
| `daemon/manager_persist.go:205,248`, `daemon/daemon.go:449,472` | Corrupted `instances.json`; repos and sessions skipped. Real. |
| `daemon/destructive.go:48`, `daemon/manager_create.go:102` | A teardown/cleanup **reported an error**; af proceeds, but the operator should know. Real. |
| `daemon/manager_sessions.go:74,157,178,196` | A kill could not complete, or could not take its lock. Real, and #178 explicitly says nothing will retry it. |
| `daemon/lostrestore.go:435,438`, `daemon/rootagent.go:364,367` | Repeated restore/ensure failures with backoff. Real by construction. |
| `daemon/rootkill.go:144` | Finishing an interrupted kill — implies a prior abnormal exit. Real. |
| `daemon/daemon.go:371,507` | Home vanished / repo directory missing under a live daemon. Anomalous state. Real. |
| `daemon/legacy_units.go:93–120`, `daemon/autostart.go:219–271` | Upgrade-sweep and autostart-install steps that **failed**. Real. |
| All 40 `log.ErrorLog` sites in `session/…` and `daemon/…` | Every one reports an operation that failed. None reclassified. |

The bar I applied: a message stays at Warning/Error if it reports work that did
not happen, state that is inconsistent, or a decision af could not make. It moves
to Info only if the condition is the *designed* outcome of a choice the user
made, and there is nothing for anyone to do.

## Tests

`session/autoyes_notice_test.go` (new), asserting on the **level**, which is the
contract the scraper reads:

- `TestResolveProgramForInstance_AutoYesUnsupportedLogsAtInfo` — drives the real
  `resolveProgramForInstance` path for a codex + `auto_yes` instance, asserts the
  notice lands on `InfoLog`, that WARNING stays empty, **and** that the text still
  carries `--dangerously-bypass-approvals-and-sandbox` and
  `program_overrides.codex`. The reclassification must not quietly eat the
  guidance.
- `TestNoteAutoYesUnsupported_AllAgentsLogAtInfo` — same for amp and opencode.
- `TestNoteAutoYesUnsupported_SupportedAgentSilent` — claude says nothing at all.
- `TestNoteAutoYesUnsupported_OncePerSession` — the repeat is suppressed, and a
  different session still gets its own notice.

Watched them fail first: with the level reverted to `WarningLog`, all four fail,
and the failure output reproduces the reported line verbatim —
`WARNING … backend_local.go:… auto_yes has no effect for codex (session "…"): codex exposes --dangerously-bypass-approvals-and-sandbox; …`.

## Verification

- `go build ./...`, `gofmt -l .` (clean), `golangci-lint run --timeout=3m --fast`
  (clean), `deadcode -test ./...` (clean), `scripts/lint-file-length.sh`
  (842 files, 0 grandfathered).
- `go test ./session/... -count=1` — green (`session`, `session/git`,
  `session/tmux`). `daemon/` is untouched by this PR and was not run on the host.
- One run of `./session/...` tripped the #837 config tripwire on the real
  `~/.agent-factory/config.toml`. Chased it: it does **not** reproduce (two clean
  re-runs of the same tree, plus `./session/` alone), the file is stable when
  sampled while idle, and nothing in this diff writes config. It is the live
  daemon on this shared box rewriting its own config mid-run, not an escaped
  test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
