### PR TITLE
feat(web): persist the token so you log in once, not every visit (#2169)

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -230,11 +230,14 @@ $ af token show
 token: kZ9abc...-...q0
 ```
 
-Paste the `token` value into the field and click **Connect**. The token is stored
-in the browser tab's `sessionStorage`, so a page reload resumes automatically; a
-rejected token shows an actionable error (`That token was rejected. Check
-af token show on the host and try again.`), and a connection that fails for any
-other reason reports the daemon's own message rather than a generic failure.
+Paste the `token` value into the field and click **Connect**. **You paste it once**:
+the token is saved in the browser's `localStorage` for that origin, so a reload, a
+new tab, and a browser restart all reconnect silently. A rejected token shows an
+actionable error (`That token was rejected. Check af token show on the host and try
+again.`) and is **forgotten**, so the next visit prompts cleanly instead of retrying
+a dead credential. A connection that fails for any other reason — the daemon is
+down, the wrong host — reports the daemon's own message and **keeps** the token: a
+daemon restart doesn't cost you a re-paste.
 
 See [Turning auth on](remote-http-auth.md#turning-auth-on-require_token-true) for
 the full setup, and the note there on why `require_loopback_token` does nothing
@@ -629,6 +632,15 @@ While a terminal is attached, all keys except `Escape` flow to the agent.
 - **The token is full access.** Under the single-owner model, one token grants full
   control of the daemon. Treat it like a password; never commit it or paste it into
   a shared log. Rotate it with `af token rotate` if you suspect exposure.
+- **The browser keeps the token in `localStorage`.** That is what makes you paste it
+  once instead of every visit, and it is a real tradeoff: anything that can run
+  same-origin JavaScript in the tab can read it. af's own bundle is fully
+  self-contained (no CDN, no third-party script, and the daemon's CSP is
+  `default-src 'self'`), so the exposure is an XSS in af itself — not a supply-chain
+  script. The token still rides the `Authorization` header rather than a cookie the
+  browser would attach automatically, so there is no CSRF surface. On a **shared
+  machine**, use **Disconnect** when you step away (it erases the stored token), or
+  use a private/incognito window, whose storage the browser discards on close.
 - **Prefer loopback + SSH over `0.0.0.0`.** Binding `listen_addr` to `127.0.0.1`
   and forwarding over SSH keeps the port off the network entirely, encrypts the
   channel, and still gives you the browser UI.

--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -249,6 +249,10 @@ body {
   font-size: var(--af-fs-md);
   line-height: 1.5;
 }
+.af-login-note {
+  margin-top: calc(-1 * var(--af-sp-3));
+  font-size: var(--af-fs-sm);
+}
 .af-subtitle code {
   font-family: var(--af-font-mono);
   color: var(--af-text);

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -6122,13 +6122,34 @@ WARNING: This link could potentially be dangerous`)) {
 // src/api.ts
 var TOKEN_KEY = "af.token";
 function loadToken() {
-  return sessionStorage.getItem(TOKEN_KEY);
+  try {
+    const raw = localStorage.getItem(TOKEN_KEY);
+    return raw === null || raw === "" ? null : raw;
+  } catch {
+    return null;
+  }
 }
 function storeToken(token2) {
-  sessionStorage.setItem(TOKEN_KEY, token2);
+  if (token2 === "") {
+    return;
+  }
+  try {
+    localStorage.setItem(TOKEN_KEY, token2);
+  } catch {
+  }
 }
 function clearToken() {
-  sessionStorage.removeItem(TOKEN_KEY);
+  try {
+    localStorage.removeItem(TOKEN_KEY);
+  } catch {
+  }
+  try {
+    sessionStorage.removeItem(TOKEN_KEY);
+  } catch {
+  }
+}
+function shouldForgetToken(e) {
+  return e instanceof ApiError && (e.status === 401 || e.status === 403);
 }
 function errorText(e, fallback = "unknown error") {
   if (e instanceof Error) {
@@ -10338,6 +10359,10 @@ function loginView(state, actions2) {
       h2("code", {}, "af token show"),
       " on the host."
     ),
+    // Say that the token is kept, and where the off switch is. Persisting a
+    // full-access credential in the browser is the user's call to make knowingly —
+    // silently writing it to disk is the thing not to do.
+    h2("p", { class: "af-subtitle af-login-note" }, "It stays saved in this browser until you disconnect."),
     form
   ];
   if (state.loginError) {
@@ -10406,6 +10431,7 @@ var AppShell = class {
     const live = h2("span", { class: "af-live" }, this.pip, this.pipLabel);
     live.setAttribute("role", "status");
     const disconnect2 = h2("button", { type: "button", class: "af-ghost" }, "Disconnect");
+    disconnect2.setAttribute("title", "Disconnect and forget the saved token");
     disconnect2.addEventListener("click", () => this.actions.disconnect());
     const themeToggle = h2("div", { class: "af-theme-toggle" });
     themeToggle.setAttribute("role", "group");
@@ -11546,14 +11572,14 @@ async function connect(candidate) {
   try {
     sessions = await probeToken(candidate);
   } catch (e) {
-    clearToken();
+    if (shouldForgetToken(e)) {
+      clearToken();
+    }
     store.set({ phase: "login", connecting: false, loginError: describeError(e) });
     return;
   }
   token = candidate;
-  if (candidate !== "") {
-    storeToken(candidate);
-  }
+  storeToken(candidate);
   let tasks = [];
   try {
     tasks = await listTasks(candidate);

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "1716c5982ac2";
+const VERSION = "57934ce5de98";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -485,6 +485,169 @@ test("an unreachable daemon reports a real transport message, not [object Object
   await ctx.close();
 });
 
+// --- token persistence (feat: log in once) ---------------------------------
+//
+// The property: after ONE successful token login, a returning visit — new tab,
+// reload, browser restart — resumes the stored credential and lands in the authed
+// shell with no prompt, until the daemon rejects it. Before this, the token lived in
+// sessionStorage, so every new tab was a fresh paste of `af token show`.
+//
+// A browser CONTEXT is the unit of persistence here: pages in one context share the
+// origin's localStorage exactly as tabs of one browser profile do, and a second
+// context is a different profile. So "a new tab in the same context" is the honest
+// proxy for a returning visit, and it is precisely what the old per-tab
+// sessionStorage failed.
+//
+// The daemon under test requires no token (require_token=false), so any bearer is
+// accepted — /v1/auth-info is intercepted to force the paste-token login into
+// existence, and the rejection cases fake the 401 the same way.
+
+/** The stored bearer token as the page sees it, or null when nothing is stored. */
+function storedToken(p: Page): Promise<string | null> {
+  return p.evaluate(() => localStorage.getItem("af.token"));
+}
+
+/** A context whose pages all believe the daemon requires a token. Context-level (not
+ *  page-level) routing so a SECOND page in the context inherits it — that second page
+ *  is the returning visit under test. */
+async function tokenRequiredContext(browser: Browser): Promise<BrowserContext> {
+  const ctx = await browser.newContext();
+  await ctx.route("**/v1/auth-info", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: authInfoBody(true) }),
+  );
+  return ctx;
+}
+
+/** Pastes a token into the login form and waits for the authed shell. */
+async function loginWithToken(p: Page, token: string): Promise<void> {
+  await p.goto("/");
+  await expect(p.locator("#af-token")).toBeVisible();
+  await p.locator("#af-token").fill(token);
+  await p.locator(".af-login-form button[type=submit]").click();
+  await expect(p.locator(".af-app")).toBeVisible();
+}
+
+test("token persistence: a NEW TAB after a login resumes the token and never prompts", async ({ browser }) => {
+  const ctx = await tokenRequiredContext(browser);
+  const first = await ctx.newPage();
+  await loginWithToken(first, "persisted-token");
+  expect(await storedToken(first)).toBe("persisted-token");
+
+  // The returning visit: a fresh tab on the same profile, no interaction at all. It
+  // must land in the authed shell — the paste field never renders. (On the old
+  // sessionStorage build this tab started empty and showed the login form.)
+  const second = await ctx.newPage();
+  await second.goto("/");
+  await expect(second.locator(".af-app")).toBeVisible();
+  await expect(second.locator("#af-token")).toHaveCount(0);
+  // And it is really authorized, not just past the gate: the events WS connected on
+  // the resumed credential.
+  await expect(second.locator(".af-live-pip.af-live-open")).toBeVisible();
+
+  // A reload of the ORIGINAL tab resumes it too (the browser-restart case, minus the
+  // restart), and the login form still never appears.
+  await first.reload();
+  await expect(first.locator(".af-app")).toBeVisible();
+  await expect(first.locator("#af-token")).toHaveCount(0);
+
+  await ctx.close();
+});
+
+test("token persistence: the login screen says the token will be saved", async ({ browser }) => {
+  // Persisting a full-access credential silently is the thing not to do: the screen
+  // that takes the token says it keeps it, and names the way back out. Kept as its
+  // own test so a copy change never masquerades as a persistence failure.
+  const ctx = await tokenRequiredContext(browser);
+  const p = await ctx.newPage();
+  await p.goto("/");
+  await expect(p.locator(".af-login-note")).toContainText("stays saved in this browser until you disconnect");
+  await ctx.close();
+});
+
+test("token persistence: Disconnect forgets the token, so the next visit prompts", async ({ browser }) => {
+  const ctx = await tokenRequiredContext(browser);
+  const p = await ctx.newPage();
+  await loginWithToken(p, "forget-me");
+
+  // The logout affordance: on a shared machine or after a rotation, this is the way
+  // back to the prompt. It must clear the STORE, not just the in-memory credential.
+  await p.locator(".af-appbar button", { hasText: "Disconnect" }).click();
+  await expect(p.locator("#af-token")).toBeVisible();
+  expect(await storedToken(p)).toBeNull();
+
+  // A new tab confirms it: nothing was left behind to resume.
+  const after = await ctx.newPage();
+  await after.goto("/");
+  await expect(after.locator("#af-token")).toBeVisible();
+  await expect(after.locator(".af-app")).toHaveCount(0);
+
+  await ctx.close();
+});
+
+test("token persistence: a REJECTED stored token clears itself and prompts once — no loop", async ({ browser }) => {
+  const ctx = await tokenRequiredContext(browser);
+  // The rotation case: the stored token is no longer valid, so the daemon 401s the
+  // login probe. Without the clear, every load would retry the dead credential.
+  await ctx.route("**/v1/Snapshot", (route) =>
+    route.fulfill({ status: 401, contentType: "application/json", body: failureBody("unauthorized") }),
+  );
+  const p = await ctx.newPage();
+  await p.goto("/");
+  await expect(p.locator("#af-token")).toBeVisible();
+  // Seed a stale token the way a previous successful login would have, then return.
+  await p.evaluate(() => localStorage.setItem("af.token", "rotated-away"));
+
+  await p.reload();
+  // Exactly one outcome: the paste form, with the rejection explained.
+  await expect(p.locator("#af-token")).toBeVisible();
+  await expect(p.locator(".af-error")).toContainText("That token was rejected");
+  await expect(p.locator(".af-app")).toHaveCount(0);
+  // Cleared, so the next load prompts straight away rather than re-probing a token
+  // that is known bad.
+  expect(await storedToken(p)).toBeNull();
+
+  // And it stays put: a further reload shows the same clean prompt, no error carried
+  // over from a retry the app should not be making.
+  await p.reload();
+  await expect(p.locator("#af-token")).toBeVisible();
+  await expect(p.locator(".af-error")).toHaveCount(0);
+
+  await ctx.close();
+});
+
+test("token persistence: an unreachable daemon KEEPS the stored token", async ({ browser }) => {
+  // The distinction that makes persistence usable: a transport failure says nothing
+  // about the credential. Clearing on it would mean every daemon restart (or asleep
+  // laptop) deleted a good token and demanded a fresh paste — the exact behavior this
+  // feature exists to remove.
+  const ctx = await tokenRequiredContext(browser);
+  const p = await ctx.newPage();
+  await p.goto("/");
+  await expect(p.locator("#af-token")).toBeVisible();
+  await p.evaluate(() => localStorage.setItem("af.token", "still-good"));
+
+  await ctx.route("**/v1/Snapshot", (route) => route.abort("connectionrefused"));
+  await p.reload();
+  await expect(p.locator(".af-error")).toContainText("Couldn't reach the daemon");
+  expect(await storedToken(p)).toBe("still-good");
+
+  // Daemon back: the very next load resumes silently, with no paste in between.
+  await ctx.unroute("**/v1/Snapshot");
+  await p.reload();
+  await expect(p.locator(".af-app")).toBeVisible();
+  await expect(p.locator("#af-token")).toHaveCount(0);
+
+  await ctx.close();
+});
+
+test("token persistence: the tokenless path stores no credential (#1696)", async () => {
+  // The shared page is the tokenless loopback client: it connects with the empty-token
+  // sentinel, which must never be written out as a stored credential — a stored ""
+  // would read back as "this client needs none" and could skip a login that IS
+  // required. Nothing on disk; the /v1/auth-info probe decides afresh on every load.
+  expect(await storedToken(page)).toBeNull();
+});
+
 test("sidebar lists the seeded sessions from the Snapshot/events plane", async () => {
   // Both seeded rows are present — proof the rail is driven by the daemon
   // projection, not a static list. The rail is SCOPED to the default project (the

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -5,11 +5,25 @@
 // this file must not fork it.
 //
 // Token handling is deliberately minimal and lives here so there is ONE place that
-// knows the credential: it is kept in sessionStorage (survives reload within the
-// tab, gone on tab-close — design §1.2, a deliberate "don't persist a full-access
-// credential to disk" posture) and attached as `Authorization: Bearer` on every
-// request. The WS `?access_token=` fallback (browsers cannot set WS headers) is
-// used by the /v1/events subscriber (events.ts) and, in PR4, the PTY stream.
+// knows the credential: it is kept in localStorage and attached as
+// `Authorization: Bearer` on every request. The WS `?access_token=` fallback
+// (browsers cannot set WS headers) is used by the /v1/events subscriber (events.ts)
+// and the PTY stream.
+//
+// localStorage, not sessionStorage: the original design §1.2 posture was "don't
+// persist a full-access credential to disk", which cost a paste of `af token show`
+// on every new tab and every browser restart — the token survived only a reload of
+// the same tab. For a self-hosted tool that is a login wall in front of your own
+// machine, so the credential now persists like the other durable choices (theme,
+// filter, project). The tradeoff is honest and bounded: a bearer in localStorage is
+// readable by same-origin JS, so an XSS in the SPA can exfiltrate it. Nothing else
+// weakens — the token still rides the Authorization header, never a cookie the
+// browser would attach automatically (no CSRF surface), and the webtab frame still
+// cannot read it (api.ts §probeWebTab, the opaque-origin sandbox).
+//
+// Forgetting it is a first-class path: Disconnect clears it, and so does a 401 from
+// a stored token (see shouldForgetToken) — a rotated token re-prompts once instead
+// of wedging the app.
 
 import type { BackendCatalog } from "./backends.js";
 import type { ProgramCatalog } from "./programs.js";
@@ -25,19 +39,63 @@ import type {
 
 const TOKEN_KEY = "af.token";
 
-/** Reads the stored bearer token for this tab, or null if none is set. */
+/** Reads the stored bearer token, or null if none is stored. Never throws: blocked
+ *  storage (private mode / a hardened profile) reads as "nothing stored", which
+ *  lands on the paste-token login rather than a broken boot. */
 export function loadToken(): string | null {
-  return sessionStorage.getItem(TOKEN_KEY);
+  try {
+    const raw = localStorage.getItem(TOKEN_KEY);
+    return raw === null || raw === "" ? null : raw;
+  } catch {
+    return null;
+  }
 }
 
-/** Persists the bearer token for this tab (sessionStorage, not localStorage). */
+/** Persists the bearer token so the next visit — new tab, reload, browser restart —
+ *  resumes it without a paste. Best-effort: a blocked store still leaves the running
+ *  app connected, it just cannot resume later. The empty-token sentinel (a client the
+ *  daemon needs no credential from, #1696) is never stored — see connect(). */
 export function storeToken(token: string): void {
-  sessionStorage.setItem(TOKEN_KEY, token);
+  if (token === "") {
+    return;
+  }
+  try {
+    localStorage.setItem(TOKEN_KEY, token);
+  } catch {
+    // no-op: persistence is best-effort
+  }
 }
 
-/** Forgets the stored token (logout / failed probe). */
+/** Forgets the stored token (Disconnect, or a stored token the daemon rejected).
+ *  Clears the legacy sessionStorage copy too, so a token written by a pre-persistence
+ *  build cannot outlive an explicit logout in the tab that stored it. */
 export function clearToken(): void {
-  sessionStorage.removeItem(TOKEN_KEY);
+  try {
+    localStorage.removeItem(TOKEN_KEY);
+  } catch {
+    // no-op
+  }
+  try {
+    sessionStorage.removeItem(TOKEN_KEY);
+  } catch {
+    // no-op
+  }
+}
+
+/**
+ * Whether a failed connect attempt means the credential itself is bad, and so the
+ * stored copy must be forgotten. ONLY an auth rejection counts: 401 (a missing or
+ * invalid bearer) and 403 (a bearer the daemon refuses).
+ *
+ * The distinction is what makes persistence usable. A transport failure (status 0 —
+ * daemon down, wrong host, laptop asleep) says nothing about the token, and clearing
+ * on it would delete a good credential every time the daemon restarted while a tab
+ * was open — re-creating the exact re-paste-every-time complaint this persistence
+ * exists to fix. Same for a 5xx. Those surface an error and keep the token, so the
+ * next load resumes silently once the daemon is back.
+ */
+export function shouldForgetToken(e: unknown): boolean {
+  return e instanceof ApiError && (e.status === 401 || e.status === 403);
 }
 
 /**

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -39,6 +39,7 @@ import {
   restoreSession,
   resumeFromLimit,
   sendPrompt,
+  shouldForgetToken,
   storeToken,
   triggerTask,
   updateTask,
@@ -222,9 +223,11 @@ function mount(): void {
 
 /** Decides the opening view (#1696): probe whether the daemon requires a token for
  *  THIS client. If not (loopback, or require_token=false), connect straight through
- *  with no credential. If it does, resume a token kept in sessionStorage across a
- *  reload, else land on the paste-token login. A probe transport failure falls back
- *  to the token login — never auto-connects on uncertainty. */
+ *  with no credential — and store nothing. If it does, resume the token kept in
+ *  localStorage (so a new tab / a browser restart logs in once, not every visit),
+ *  else land on the paste-token login. A resumed token the daemon rejects clears
+ *  itself and falls back to the paste form, once. A probe transport failure also
+ *  falls back to the token login — never auto-connects on uncertainty. */
 async function bootstrap(): Promise<void> {
   let required = true;
   try {
@@ -279,23 +282,29 @@ function rerender(): void {
 
 /** Validates the token (Snapshot probe), and on success persists it, seeds the rail
  *  from the probe's snapshot, subscribes to /v1/events, and shows the app; on
- *  failure clears it and surfaces an actionable error on the login view. */
+ *  failure surfaces an actionable error on the login view — forgetting the stored
+ *  token only when the daemon REJECTED it (shouldForgetToken). */
 async function connect(candidate: string): Promise<void> {
   store.set({ connecting: true, loginError: null });
   let sessions: SessionData[];
   try {
     sessions = await probeToken(candidate);
   } catch (e) {
-    clearToken();
+    // A rejected credential is forgotten so the next load prompts cleanly instead of
+    // retrying a dead token forever; a transport failure keeps it, because "the
+    // daemon is down" is not evidence the token is bad (see shouldForgetToken).
+    // Either way we land on the login view exactly once — no retry loop.
+    if (shouldForgetToken(e)) {
+      clearToken();
+    }
     store.set({ phase: "login", connecting: false, loginError: describeError(e) });
     return;
   }
   token = candidate;
-  // Persist only a REAL token so a reload can resume it; the empty-token sentinel
-  // (no-auth client, #1696) is never worth storing — bootstrap re-probes on reload.
-  if (candidate !== "") {
-    storeToken(candidate);
-  }
+  // Persist only a REAL token so the next visit can resume it; the empty-token
+  // sentinel (no-auth client, #1696) is never stored — bootstrap re-probes
+  // /v1/auth-info on every load, so a tokenless daemon needs nothing on disk.
+  storeToken(candidate);
   // Fetch the tasks BEFORE choosing the initial project scope (redesign PR2, Greptile
   // follow-on Fix 2): the persisted selection must reconcile against the FULL project
   // list — sessions AND tasks — so a persisted TASK-ONLY project restores AS ITSELF,
@@ -329,7 +338,10 @@ async function connect(candidate: string): Promise<void> {
   startStream(candidate);
 }
 
-/** Forgets the token, tears down the push stream + terminal, and returns to login. */
+/** Forgets the token — in memory AND in storage — tears down the push stream +
+ *  terminal, and returns to login. This is the "forget the saved token" affordance
+ *  now that the credential persists across visits: on a shared machine, or after a
+ *  rotation, Disconnect is what makes the next load prompt again. */
 function disconnect(): void {
   stopStream();
   closeModal();

--- a/web/src/project.ts
+++ b/web/src/project.ts
@@ -19,8 +19,8 @@ import type { SessionData, TaskData } from "./types.js";
 
 /** localStorage key for the persisted selected-project root (the repo path). Kept in
  *  localStorage (not sessionStorage) so the choice survives a full reload/new tab —
- *  the token lives in sessionStorage, but the project is a durable UI preference like
- *  the theme (theme.ts). */
+ *  a durable UI preference like the theme (theme.ts) and, since token persistence,
+ *  like the credential itself (api.ts). */
 const PROJECT_KEY = "af-project";
 
 /** One project's cross-project glance for the switcher menu: its repo root (the

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -294,6 +294,14 @@ body {
   line-height: 1.5;
 }
 
+/* The "it stays saved" note under the login subtitle: a quieter second line of the
+   same block, so it reads as a footnote to the paste instruction rather than a
+   second paragraph competing with it. */
+.af-login-note {
+  margin-top: calc(-1 * var(--af-sp-3));
+  font-size: var(--af-fs-sm);
+}
+
 .af-subtitle code {
   font-family: var(--af-font-mono);
   color: var(--af-text);

--- a/web/src/token.test.ts
+++ b/web/src/token.test.ts
@@ -1,0 +1,145 @@
+// Tests for bearer-token PERSISTENCE (feat: log in once). The property: a token
+// that logged in successfully survives a new tab / a browser restart, so the web UI
+// stops asking for `af token show` on every visit — and stops being trusted the
+// moment the daemon says it is bad.
+//
+// These pin the storage layer and the forget/keep decision. The end-to-end proof
+// (a second page in the same browser lands straight in the authed shell) lives in
+// the Playwright selftest, which is the only place a real localStorage and a real
+// boot sequence exist together.
+
+import { test, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+import { ApiError, clearToken, loadToken, shouldForgetToken, storeToken } from "./api.js";
+
+type StorageMap = Map<string, string>;
+
+interface Stubbed {
+  local: StorageMap;
+  session: StorageMap;
+  restore: () => void;
+}
+
+/** Installs in-memory local/sessionStorage (node has no DOM), optionally seeded, and
+ *  returns the backing maps plus a restore fn. `throwing` simulates a blocked store
+ *  (private mode / a hardened profile), which every helper must survive. */
+function stubStorage(seed: { local?: Record<string, string>; session?: Record<string, string> } = {}, throwing = false): Stubbed {
+  const local: StorageMap = new Map(Object.entries(seed.local ?? {}));
+  const session: StorageMap = new Map(Object.entries(seed.session ?? {}));
+  const priors = (["localStorage", "sessionStorage"] as const).map((name) => ({
+    name,
+    prior: Object.getOwnPropertyDescriptor(globalThis, name),
+  }));
+  const install = (name: "localStorage" | "sessionStorage", map: StorageMap): void => {
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      value: {
+        getItem: (k: string): string | null => {
+          if (throwing) {
+            throw new Error("storage blocked");
+          }
+          return map.get(k) ?? null;
+        },
+        setItem: (k: string, v: string): void => {
+          if (throwing) {
+            throw new Error("storage blocked");
+          }
+          map.set(k, v);
+        },
+        removeItem: (k: string): void => {
+          if (throwing) {
+            throw new Error("storage blocked");
+          }
+          map.delete(k);
+        },
+      },
+    });
+  };
+  install("localStorage", local);
+  install("sessionStorage", session);
+  return {
+    local,
+    session,
+    restore: () => {
+      for (const { name, prior } of priors) {
+        if (prior) {
+          Object.defineProperty(globalThis, name, prior);
+        } else {
+          delete (globalThis as Record<string, unknown>)[name];
+        }
+      }
+    },
+  };
+}
+
+let stub: Stubbed | null = null;
+
+afterEach(() => {
+  stub?.restore();
+  stub = null;
+});
+
+test("a token round-trips through localStorage, so a NEW TAB resumes it", () => {
+  stub = stubStorage();
+  storeToken("tok-abc");
+  // localStorage, not sessionStorage: sessionStorage is scoped to the one tab that
+  // wrote it, which is exactly the re-paste-every-visit behavior this replaces.
+  assert.equal(stub.local.get("af.token"), "tok-abc");
+  assert.equal(stub.session.size, 0, "the token must not be written to per-tab storage");
+  assert.equal(loadToken(), "tok-abc");
+});
+
+test("no stored token reads as null, not an empty credential", () => {
+  stub = stubStorage();
+  assert.equal(loadToken(), null);
+});
+
+test("an empty stored value reads as null — it must never pose as a valid token", () => {
+  // "" is the tokenless sentinel (#1696) inside the app; read back out of storage it
+  // would silently claim "this client needs no credential" and skip the login.
+  stub = stubStorage({ local: { "af.token": "" } });
+  assert.equal(loadToken(), null);
+});
+
+test("the tokenless sentinel is never stored", () => {
+  stub = stubStorage();
+  storeToken("");
+  assert.equal(stub.local.size, 0, "a no-credential connection must leave nothing behind");
+  assert.equal(loadToken(), null);
+});
+
+test("clearToken forgets the token, including a legacy per-tab copy", () => {
+  stub = stubStorage({ local: { "af.token": "tok-abc" }, session: { "af.token": "tok-legacy" } });
+  clearToken();
+  assert.equal(loadToken(), null);
+  assert.equal(stub.local.size, 0);
+  assert.equal(stub.session.size, 0, "a token from a pre-persistence build must not outlive a logout");
+});
+
+test("blocked storage degrades to no persistence, never a throw", () => {
+  // Private mode / a hardened profile: every helper is best-effort. A throw here
+  // would happen at BOOT (bootstrap reads the token first thing) and take the whole
+  // app down rather than showing a login form.
+  stub = stubStorage({}, true);
+  assert.doesNotThrow(() => storeToken("tok-abc"));
+  assert.doesNotThrow(() => clearToken());
+  assert.equal(loadToken(), null);
+});
+
+test("a rejected credential (401/403) is forgotten", () => {
+  assert.equal(shouldForgetToken(new ApiError(401, "unauthorized")), true);
+  assert.equal(shouldForgetToken(new ApiError(403, "forbidden")), true);
+});
+
+test("a transport failure KEEPS the token — the daemon being down says nothing about it", () => {
+  // The regression this guards: clearing on any failure means every daemon restart
+  // (or asleep laptop, or wrong host typed once) deletes a good credential and puts
+  // the paste form back — re-creating the complaint persistence exists to fix.
+  assert.equal(shouldForgetToken(new ApiError(0, "cannot reach the daemon")), false);
+  assert.equal(shouldForgetToken(new ApiError(500, "internal error")), false);
+  assert.equal(shouldForgetToken(new ApiError(502, "bad gateway")), false);
+  assert.equal(shouldForgetToken(new TypeError("network error")), false);
+  assert.equal(shouldForgetToken("boom"), false);
+  assert.equal(shouldForgetToken(undefined), false);
+});

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -422,6 +422,10 @@ function loginView(state: AppState, actions: Actions): HTMLElement {
       h("code", {}, "af token show"),
       " on the host.",
     ),
+    // Say that the token is kept, and where the off switch is. Persisting a
+    // full-access credential in the browser is the user's call to make knowingly —
+    // silently writing it to disk is the thing not to do.
+    h("p", { class: "af-subtitle af-login-note" }, "It stays saved in this browser until you disconnect."),
     form,
   ];
   if (state.loginError) {
@@ -640,7 +644,12 @@ export class AppShell {
     const live = h("span", { class: "af-live" }, this.pip, this.pipLabel);
     live.setAttribute("role", "status");
 
+    // Disconnect doubles as "forget the saved token": the credential persists across
+    // visits now, so this button is the only way back to the login prompt on a shared
+    // machine or after a rotation. The title says so — the label alone reads as a
+    // transport action, not a logout.
     const disconnect = h("button", { type: "button", class: "af-ghost" }, "Disconnect");
+    disconnect.setAttribute("title", "Disconnect and forget the saved token");
     disconnect.addEventListener("click", () => this.actions.disconnect());
 
     // The theme toggle: a compact Auto/Light/Dark segmented control. A click routes


### PR DESCRIPTION
Closes #2169.

When `require_token = true`, the web UI kept the bearer token in **`sessionStorage`**
— scoped to one browser tab. A reload of that tab resumed; a **new tab**, a closed
tab, or a **browser restart** did not. So every visit was `af token show` on the
host → copy → paste.

The credential now persists in **`localStorage`**, like every other durable choice
the client already makes (theme, status filter, selected project). You paste it
once.

## What changed

- **`web/src/api.ts`** — `loadToken`/`storeToken`/`clearToken` move to
  `localStorage`, guarded so blocked storage (private mode, a hardened profile)
  degrades to "no persistence" instead of throwing at boot. `storeToken("")` is a
  no-op — the empty-token sentinel (#1696) must never be written out, or it would
  read back as "this client needs no credential" and skip a login that IS required.
  `loadToken` maps `""` back to `null` for the same reason. `clearToken` also drops
  the legacy `sessionStorage` copy, so a token written by a pre-persistence build
  cannot outlive an explicit logout.
- **New `shouldForgetToken(e)`** — the forget/keep decision, extracted so it is
  testable and stated once: **only** a 401/403 means the credential itself is bad.
- **`web/src/index.ts`** — `connect()` no longer clears the token on *any* failure.
  A rejected token is forgotten (next load prompts cleanly, exactly once — no retry
  loop); a transport failure (status 0, 5xx) keeps it and surfaces the existing
  "Couldn't reach the daemon" error. That distinction is load-bearing: clearing on
  transport failure would delete a good token on every daemon restart and re-create
  the very complaint this fixes.
- **`web/src/ui.ts`** — the login screen says what it does with the token ("It stays
  saved in this browser until you disconnect."), and **Disconnect** — which already
  cleared the credential — now says so in its tooltip. That is the visible
  forget-the-token affordance for a shared machine or a rotated token.
- **Token-less path unchanged.** A daemon that needs no credential (loopback, or
  `require_token = false`) still auto-connects with no login and writes **nothing**;
  `/v1/auth-info` is re-probed on every load, so nothing on disk decides it.

## Security note (on the record)

A bearer token in `localStorage` is readable by same-origin JavaScript, so this
trades some XSS exposure for the UX. That is the standard tradeoff for a
self-hosted tool and it matches the "assume users are safe" stance, but it should
be written down rather than implied:

- af's bundle is fully self-contained — no CDN, no third-party script, and the
  daemon serves it under CSP `default-src 'self'` — so the exposure is an XSS in
  af's own code, not a supply-chain script.
- The token still rides the `Authorization` header, **not** a cookie the browser
  would attach automatically, so no CSRF surface is added and no existing
  same-origin/sandbox protection is touched: the webtab iframe still runs in an
  opaque origin that cannot read the parent's storage.
- Mitigations for a shared machine are documented: **Disconnect** erases the stored
  token, and a private window discards it on close.

`docs/web.md` gets both halves — the "you paste it once" behavior and this
tradeoff, in Security notes.

## Tests

**Unit (`web/src/token.test.ts`, new — 8 tests):** the storage round-trip goes
through `localStorage` and *not* `sessionStorage`; `""` is neither stored nor read
back as a credential; `clearToken` drops both copies; blocked storage never throws;
and `shouldForgetToken` forgets 401/403 while **keeping** the token on status 0,
5xx, a bare `TypeError`, and non-Error throwables.

**Browser (`web/selftest/web-driver.spec.ts`, +6 tests)** — a browser *context* is
the unit of persistence, so "a second page in the same context" is the honest proxy
for a returning visit, and it is exactly what per-tab `sessionStorage` failed:

1. after a token login, a **new tab** lands in the authed shell with no prompt and
   its events WS connects on the resumed credential (and the original tab's reload
   does too);
2. the login screen states that the token is saved (its own test, so a copy change
   can never masquerade as a persistence failure);
3. **Disconnect** clears the store — a new tab prompts again;
4. a **rejected** stored token clears itself, shows "That token was rejected"
   **once**, and the next load is a clean prompt with no carried-over error;
5. an **unreachable** daemon *keeps* the stored token, and the next load after it
   comes back resumes silently;
6. the token-less path stores no credential.

**Fail-first, verified** — the browser suite was run against **master's** bundle
with only the spec applied (sources stashed, `make web-build` from master src).
Observed there: the new-tab test, the rejected-stored-token test, and the
unreachable-daemon test all go **red** — the second and third die on the error text
that never appears, because master never reads the seeded stored token at all. The
Disconnect test and the tokenless-stores-nothing test pass on master too; they are
regression locks on behavior that already held, not proofs of the new behavior. All
of them pass with the change applied. Full runs: `make web-test` (398 pass), `make web-selftest-container`
(102 pass), plus `gofmt -l .`, `go build ./...`, `golangci-lint run --fast`, and
`scripts/lint-file-length.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
