### PR TITLE
docs(examples): Codex plugin POC (exploration for #2172)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@
 # Build artifacts
 agent-factory
 af
+
+# ...but "agent-factory" is also a legitimate directory name (an af skill is
+# named after the tool), and the bare pattern above matches at any depth.
+!examples/codex-plugin/plugin/skills/agent-factory/
 cs
 *.exe
 *.dll

--- a/examples/codex-plugin/.agents/plugins/marketplace.json
+++ b/examples/codex-plugin/.agents/plugins/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "name": "agent-factory-example",
+  "interface": {
+    "displayName": "Agent Factory (example)"
+  },
+  "plugins": [
+    {
+      "name": "agent-factory",
+      "source": {
+        "source": "local",
+        "path": "./plugin"
+      },
+      "policy": {
+        "installation": "AVAILABLE"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/examples/codex-plugin/README.md
+++ b/examples/codex-plugin/README.md
@@ -1,0 +1,53 @@
+# Codex plugin (exploration example)
+
+**This is an exploration artifact, not a product surface.** Nothing here is wired
+into the build, the release, or any `af` command. It exists to prove the shape of
+a Codex plugin that hands the `af` CLI to a Codex session, so a maintainer can
+decide whether to ship one. See the exploration issue for the write-up.
+
+## What it is
+
+A minimal Codex plugin — a manifest, one skill, and one lifecycle hook — plus a
+local marketplace that serves it.
+
+```
+examples/codex-plugin/
+├── .agents/plugins/marketplace.json   the marketplace that offers the plugin
+└── plugin/
+    ├── .codex-plugin/plugin.json      the plugin manifest
+    ├── skills/agent-factory/SKILL.md  teaches Codex to drive the af CLI
+    └── hooks/
+        ├── hooks.json                 SessionStart hook declaration
+        └── af-preflight.sh            reports whether af is on PATH
+```
+
+## Try it
+
+The plugin installs into `$CODEX_HOME`, so point that at a throwaway directory
+unless you actually want it in your own Codex config:
+
+```bash
+export CODEX_HOME=$(mktemp -d)
+codex plugin marketplace add ./examples/codex-plugin
+codex plugin add agent-factory@agent-factory-example
+```
+
+Verified against `codex-cli 0.144.6`: the plugin installs to
+`$CODEX_HOME/plugins/cache/agent-factory-example/agent-factory/0.1.0/` with the
+manifest, skill, and hooks all present.
+
+## What it does not do
+
+- **It does not install the `af` binary.** A Codex plugin has no declarative way
+  to ship or depend on a native binary; the only executable seam is hooks. The
+  hook here therefore *detects* `af` and prints install instructions rather than
+  downloading a release asset — a plugin hook runs as the user before the user
+  has any reason to trust it, so fetch-and-execute is the wrong shape.
+- **It exposes no MCP tools.** `af` has no MCP server today. The manifest could
+  gain `"mcpServers": "./.mcp.json"` later without changing how users install
+  the plugin.
+- **The skill duplicates `afUsageReference`.** The canonical af usage text lives
+  in `session/systemprompt.go` and is delivered to agents af itself launches.
+  This SKILL.md is a hand-written variant addressed to a Codex session that is
+  *not* running inside af. Shipping for real means generating it from the
+  canonical text so the two cannot drift.

--- a/examples/codex-plugin/plugin/.codex-plugin/plugin.json
+++ b/examples/codex-plugin/plugin/.codex-plugin/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "agent-factory",
+  "version": "0.1.0",
+  "description": "Drive Agent Factory (af) from Codex: run coding agents in isolated git worktrees, and schedule them.",
+  "author": {
+    "name": "Agent Factory"
+  },
+  "homepage": "https://github.com/sachiniyer/agent-factory",
+  "repository": "https://github.com/sachiniyer/agent-factory",
+  "license": "AGPL-3.0",
+  "keywords": ["agents", "worktrees", "tmux", "automation"],
+  "skills": "./skills/",
+  "hooks": "./hooks/hooks.json",
+  "interface": {
+    "displayName": "Agent Factory",
+    "shortDescription": "Run and schedule coding agents in isolated git worktrees",
+    "longDescription": "Agent Factory (af) runs each AI coding agent in its own git worktree and tmux session. This plugin teaches Codex to drive the af CLI — create and prompt sessions, preview their output, and schedule recurring tasks — and checks at session start whether af is installed.",
+    "developerName": "Agent Factory",
+    "category": "Productivity",
+    "websiteURL": "https://github.com/sachiniyer/agent-factory",
+    "defaultPrompt": [
+      "Use Agent Factory to start a session that fixes the failing test in this repo.",
+      "Use Agent Factory to list my running sessions and preview the one that looks stuck."
+    ]
+  }
+}

--- a/examples/codex-plugin/plugin/hooks/af-preflight.sh
+++ b/examples/codex-plugin/plugin/hooks/af-preflight.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Report whether the af CLI is on PATH. Read-only on purpose.
+#
+# This hook deliberately does NOT download or install anything. A plugin hook
+# runs as the user, before the user has any reason to trust it, so fetching and
+# executing a release binary from here is the wrong shape — see the exploration
+# issue this example belongs to. Installing af stays an explicit user action.
+set -euo pipefail
+
+if command -v af >/dev/null 2>&1; then
+	# `af version` can print a second "an upgrade is available" line; the hook
+	# only wants the version itself.
+	version=$(af version 2>/dev/null | head -n 1)
+	echo "${version:-af (version unknown)} is available."
+else
+	echo "af is not installed. Install it with:"
+	echo "  curl -fsSL https://raw.githubusercontent.com/sachiniyer/agent-factory/master/install.sh | bash"
+fi

--- a/examples/codex-plugin/plugin/hooks/hooks.json
+++ b/examples/codex-plugin/plugin/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${PLUGIN_ROOT}/hooks/af-preflight.sh\"",
+            "statusMessage": "Checking for the af CLI"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/examples/codex-plugin/plugin/skills/agent-factory/SKILL.md
+++ b/examples/codex-plugin/plugin/skills/agent-factory/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: agent-factory
+description: Run and manage Agent Factory (af) coding-agent sessions, tabs, and scheduled tasks from the shell
+---
+
+Agent Factory (`af`) is a terminal multiplexer that runs each AI coding agent in
+an isolated git worktree. Use it to hand work to a background agent instead of
+doing it in this conversation, and to schedule recurring agent runs.
+
+## Before you use it
+
+`af` is a separate CLI and is not bundled with this plugin. Check it is
+installed:
+
+```
+af version
+```
+
+If that fails, tell the user to install it and stop — do not attempt to download
+or install a binary yourself:
+
+```
+curl -fsSL https://raw.githubusercontent.com/sachiniyer/agent-factory/master/install.sh | bash
+```
+
+Session and task commands need the af daemon, which starts on demand; `af daemon
+status` reports it.
+
+## Commands
+
+Commands print JSON on stdout. Run `af <command> --help` for full flag lists.
+
+Every session and task command is PROJECT-SCOPED: it acts on the current
+directory's project unless `--repo <path>` names another one. Session titles are
+unique within a project, not across projects. Task ids are globally unique but
+still project-scoped.
+
+Sessions (one agent per isolated worktree):
+
+```
+af sessions list                                     List sessions
+af sessions get <title>                              Fetch one session
+af sessions create --name <title> [--prompt <p>] [--program claude|codex|aider|gemini|amp|opencode]
+af sessions send-prompt <title> <prompt> [--create]  Send a prompt
+af sessions preview <title>                          Snapshot a session's terminal output
+af sessions watch <title>                            Block until the session goes idle
+af sessions archive <title>                          Archive it (restartable; nothing is deleted)
+af sessions restore <title>                          Restore an archived session
+af sessions kill <title>                             Kill it and clean up its worktree
+```
+
+Tabs (extra processes in a session's worktree; max 9 per session):
+
+```
+af sessions tabs <title>
+af sessions tab-create <title> --command <cmd> [--name <tab>]
+af sessions tab-delete <title> --name <tab>
+```
+
+Tasks (deliver a prompt on a cron schedule, or whenever a watch script prints a
+stdout line):
+
+```
+af tasks list [--all]
+af tasks add --name <n> --prompt <p> --cron "0 9 * * *" [--target-session <title>]
+af tasks add --name <n> --watch-cmd <cmd> [--prompt "... {{line}} ..."]
+af tasks trigger <id>
+af tasks remove <id>
+```
+
+## Writing a prompt for a session
+
+The prompt is the entire contract: the receiving agent inherits no context from
+this conversation. State everything it needs, including the expected output
+shape — e.g. "Open a PR titled X, link it back, do not merge" or "Write a report
+to <file> and stop; no code changes".
+
+## Destructive commands
+
+`af sessions kill` deletes the session's worktree and branch — prefer `af
+sessions archive`, which is restorable. Never run `af reset`: it kills every
+session and deletes all linked worktrees and their branches across every repo.
+Confirm with the user before either.


### PR DESCRIPTION
**Example / exploration — not wired into the build.** Draft on purpose: this is
evidence for the decision in #2172, not a change to merge on CI-green alone.

The minimal Codex plugin that proves af can be distributed as one: a manifest,
one skill teaching Codex to drive the `af` CLI, a local marketplace that serves
it, and a `SessionStart` hook.

```
examples/codex-plugin/
├── README.md
├── .agents/plugins/marketplace.json
└── plugin/
    ├── .codex-plugin/plugin.json
    ├── skills/agent-factory/SKILL.md
    └── hooks/{hooks.json,af-preflight.sh}
```

Verified against `codex-cli 0.144.6` with a throwaway `CODEX_HOME`:

```
$ codex plugin marketplace add ./examples/codex-plugin
{"marketplaceName":"agent-factory-example","alreadyAdded":false}
$ codex plugin add agent-factory@agent-factory-example
{"pluginId":"agent-factory@agent-factory-example","version":"0.1.0",
 "installedPath":"$CODEX_HOME/plugins/cache/agent-factory-example/agent-factory/0.1.0",
 "authPolicy":"ON_INSTALL"}
```

Manifest, skill, and both hook files land in the cache. The preflight hook was
run with and without `af` on `PATH` and is shellcheck-clean. `go build ./...`,
`gofmt -l .`, and `scripts/lint-file-length.sh` are clean; no Go code changed.

Two things worth a reviewer's eye:

- **The hook only detects `af`; it does not install it.** A Codex plugin has no
  declarative way to ship a native binary, and hooks run as the user before the
  user has trusted them — while neither `install.sh` nor `af upgrade` verifies a
  checksum today (`install.sh:116-123`, `commands/upgrade.go:75-91`).
  Fetch-and-execute would be the wrong shape to demonstrate. Reasoning in #2172.
- **`.gitignore` needed a narrow negation.** The `agent-factory` build-artifact
  pattern has no slash, so it matches at any depth, and it was silently
  swallowing `skills/agent-factory/` — the skill directory is named after the
  tool by convention (`session/agentskill.go:19`). Caught only because the
  staged file list came up one short.

The SKILL.md here is hand-written. Shipping for real means generating it from
`afUsageReference` (`session/systemprompt.go:16`) so the two cannot drift — see
the open questions in #2172.

Closes nothing; #2172 tracks the decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
