### PR TITLE
fix(session): clear a stranded draft before delivery so it can't fuse with the next prompt (#2070)

### DIFF
--- a/session/tmux/submit.go
+++ b/session/tmux/submit.go
@@ -132,15 +132,44 @@ func (t *TmuxSession) sendKeysPasteBuffer(text string) error {
 
 	tail := deliveryTail(text)
 
-	// Baseline the pane BEFORE delivery so the post-paste check waits for the
-	// prompt's tail to newly APPEAR (a count increase), not merely be present:
-	// the daemon re-delivers the same prompt after a limit resume (#1146), so an
-	// identical tail could already be on screen.
+	// Clear any draft stranded in the composer BEFORE this paste (#2070/#1982
+	// half b). A prior send whose Enter never took leaves its full text sitting in
+	// the composer; without a clear, this paste appends to it and the receiver
+	// gets STRANDED-DRAFTNEW-PROMPT — one lost Enter silently corrupts the NEXT
+	// instruction. #2065 closed the pixel-inference routes as unsound (an agent
+	// echoes its prompt, an echo-off pane writes to a file — "not on screen" is
+	// not "not submitted"), so we do NOT try to detect whether a strand exists:
+	// that check cannot be made soundly from pane content. We clear
+	// unconditionally instead, which asserts nothing about the pane. The captures
+	// around the clear are for the LOG only (noteClearedDraft) — nothing is gated
+	// on them — and the post-clear pane doubles as the delivery baseline below.
+	//
+	// Clearing unconditionally is only safe because the clear keystroke is inert
+	// on a BUSY pane: see clearComposerDraft for why it is C-u and explicitly NOT
+	// Escape, which is the agents' INTERRUPT key and would abort a running turn on
+	// every scheduled delivery.
+	//
+	// Cost: this is one capture more than the single (tail-conditional) baseline
+	// capture it replaces, and both are unconditional. Each is bounded by
+	// tmuxCommandTimeout, so against a WEDGED server the delivery path can now
+	// stall one extra bound before giving up. That is the price of the
+	// discarded-draft record; if it ever matters, the `before` capture is the
+	// droppable half (it feeds only the log, never the baseline).
+	before, _ := t.capturePaneForDelivery()
+	t.clearComposerDraft()
+	after, afterOK := t.capturePaneForDelivery()
+	noteClearedDraft(t.sanitizedName, before, after)
+
+	// Baseline the pane AFTER the clear but BEFORE the paste so the post-paste
+	// check waits for the prompt's tail to newly APPEAR (a count increase), not
+	// merely be present: the daemon re-delivers the same prompt after a limit
+	// resume (#1146), so an identical tail could already be on screen. Baselining
+	// post-clear is also what lets a re-delivery whose prior attempt stranded an
+	// identical tail still confirm — the clear removed that copy, so the tail
+	// genuinely re-appears.
 	baseline := 0
-	if tail != "" {
-		if content, ok := t.capturePaneForDelivery(); ok {
-			baseline = strings.Count(normalizeDelivery(content), tail)
-		}
+	if tail != "" && afterOK {
+		baseline = strings.Count(normalizeDelivery(after), tail)
 	}
 
 	// load-buffer streams the prompt in on stdin, so it needs the stdin-carrying
@@ -231,6 +260,88 @@ func (t *TmuxSession) sendEnter() error {
 		return err
 	}
 	return nil
+}
+
+// clearComposerDraft best-effort removes any text stranded in the pane's
+// composer before a new paste, so a draft whose Enter never took (#1982) cannot
+// fuse with the next prompt into STRANDED-DRAFTNEW-PROMPT (#2070).
+//
+// It sends C-u as a KEYSTROKE — never a bracketed paste. A clear is by
+// definition a command, which is exactly what `-p` exists to prevent for the
+// PROMPT (#1956): the prompt is pasted DATA, the clear is typed control input.
+//
+// C-u ALONE, and deliberately NOT Escape. Escape looks like the natural way to
+// resolve a modal composer to a known state, and it is disqualified three times
+// over — measured against the real codex 0.144.6 binary in a container:
+//
+//   - Escape is the INTERRUPT key. Both codex and claude advertise "esc to
+//     interrupt" in the footer of a working pane, and codex ships an
+//     `interrupt_turn` action. Delivery to a busy agent is routine — cron and
+//     watch tasks fire on schedule regardless of agent state, and the #1146
+//     limit-resume re-delivery targets a session that may have resumed on its
+//     own — so an Escape here would abort in-flight work on a scheduled
+//     delivery. Killing a running turn is far worse than the fusion this fixes:
+//     fusion corrupts one prompt, that would silently destroy real work.
+//   - Escape does not even clear. Sent to a codex composer holding a stranded
+//     draft, the draft was still there afterward. It buys nothing.
+//   - Escape is destructive at a modal picker. Sent to codex's trust dialog it
+//     dismissed the dialog and tore the session down, so a delivery arriving
+//     while any picker is up would answer it by cancelling.
+//
+// Escape is also counterproductive for the modal case it was meant to serve: a
+// vim composer rests in NORMAL mode (see sendKeysPasteBuffer on claude's
+// `editorMode`), where C-u is half-page-scroll rather than kill-line. Escape
+// forces the composer INTO that mode, making the clear strictly less likely to
+// work. So it is pure downside on every axis.
+//
+// C-u carries none of that: it is not bound to interrupt in any supported agent,
+// it is the POSIX tty KILL character (so readline/bash-class panes erase the
+// pending line), and against real codex it cleared a stranded draft outright.
+// A vim-NORMAL composer is still not cleared — that residual gap is unchanged
+// from before this fix, and closing it would need the per-agent clear matrix
+// #2070 warns against.
+//
+// Best-effort: a failed clear must NOT block delivery — the paste is what
+// matters, and a session that could not be cleared is no worse off than before
+// this fix — so the error is logged and swallowed. Bounded by tmuxCommandTimeout
+// like every other tmux call on this path (#2099/#2105): it runs on the delivery
+// path the daemon drives under the per-session op lock, so an unbounded stall
+// against a wedged server would leave the session unpromptable rather than
+// merely skipping one clear.
+func (t *TmuxSession) clearComposerDraft() {
+	ctx, cancel := tmuxTimeoutContext()
+	defer cancel()
+	// send-keys discards output, so runTmuxBounded (which normalizes
+	// exec.ErrWaitDelay to success) is the right runner — the stdin-streaming
+	// caveat that makes load-buffer use its own helper does not apply here.
+	if err := t.runTmuxBounded(ctx, "send-keys", "-t", exactTarget(t.sanitizedName), "C-u"); err != nil {
+		if ctx.Err() != nil {
+			log.ErrorLog.Printf("submit: clearing composer for session %q timed out after %s (continuing to deliver)",
+				t.sanitizedName, tmuxCommandTimeout)
+			return
+		}
+		log.ErrorLog.Printf("submit: could not clear composer for session %q before delivery (continuing): %v",
+			t.sanitizedName, err)
+	}
+}
+
+// noteClearedDraft logs when the pre-delivery clear visibly changed the pane —
+// evidence the composer held pending content that would otherwise have fused
+// with this prompt (#2070). It stays SOUND because nothing is gated on it: this
+// is a record for the operator, not a decision. A normalized difference between
+// the pane captured before and after the clear is the observable EFFECT of our
+// own C-u, not an inference about composer state from ambiguous pixels — the
+// unsound move #2065 closed. A pane merely mid-render can also differ, so the
+// message hedges rather than asserting a strand. Empty/failed captures produce
+// no log (nb == "").
+func noteClearedDraft(sessionName, before, after string) {
+	nb := normalizeDelivery(before)
+	if nb == "" || nb == normalizeDelivery(after) {
+		return
+	}
+	log.ErrorLog.Printf("submit: cleared composer for session %q before delivery; the pane changed "+
+		"across the clear, so a stranded draft was likely discarded (or the pane was mid-render). "+
+		"Prior pane tail: %s", sessionName, oneLineTail(before))
 }
 
 // deliveryTail returns a distinctive whitespace/box-free suffix of text used to
@@ -374,6 +485,14 @@ func paneTailForLog(t *TmuxSession) string {
 	if !ok {
 		return "<pane not capturable>"
 	}
+	return oneLineTail(content)
+}
+
+// oneLineTail condenses pane content to a short, single-line excerpt for a log
+// line: the last few non-blank rows, whitespace collapsed, row breaks marked
+// with ⏎, and truncated. Shared by paneTailForLog and noteClearedDraft so a
+// discarded-draft record and a delivery-failure record read the same.
+func oneLineTail(content string) string {
 	lines := strings.Split(strings.TrimRight(content, "\n \t"), "\n")
 	keep := lines
 	if len(keep) > 3 {

--- a/session/tmux/submit_strand_probe_test.go
+++ b/session/tmux/submit_strand_probe_test.go
@@ -1,0 +1,99 @@
+package tmux
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+)
+
+// lineComposerProgram models a composer at the byte level using the tty's own
+// COOKED-mode line discipline: bytes accumulate in the kernel's line buffer
+// until a CR arrives, at which point the completed line is delivered to the
+// reader. That is exactly the shape of an agent composer (accumulate, submit on
+// Enter), and it is a REAL line discipline — the same mechanism a readline/bash
+// pane uses — rather than a hand-rolled imitation. C-u is the tty KILL character
+// in this mode, so the pre-paste clear (#2070) drains the pending line exactly
+// as it would on a readline-class composer.
+//
+// Each completed line is appended to outPath wrapped in [] so the test can tell
+// "two separate submissions" from "one concatenated submission".
+func lineComposerProgram(outPath string) string {
+	return fmt.Sprintf(`stty -echo; printf "AF-RECEIVER-READY\r\n"; while IFS= read -r l; do printf "[%%s]" "$l" >> %s; done`,
+		shellQuoteArg(outPath))
+}
+
+func startLineComposerPane(t *testing.T, name string) (*TmuxSession, string) {
+	t.Helper()
+	testguard.IsolateTmux(t)
+
+	dir := t.TempDir()
+	out := filepath.Join(dir, "submitted.txt")
+	ts := NewTmuxSession(name, lineComposerProgram(out))
+	require.NoError(t, ts.Start(dir))
+	t.Cleanup(func() { _, _ = ts.Close() })
+
+	waitFor(t, func() bool {
+		content, err := ts.CapturePaneContent()
+		return err == nil && strings.Contains(content, receiverReadyMarker)
+	}, "line-composer receiver never started")
+	return ts, out
+}
+
+// strandDraft pastes text into the pane WITHOUT the trailing Enter, which is
+// precisely the #1982 end state: the bytes landed in the composer and the submit
+// never took. No inference is involved — the test CREATES the strand, so the
+// regression it guards is a real fused submission, not a scraped guess about one.
+func strandDraft(t *testing.T, ts *TmuxSession, text string) {
+	t.Helper()
+	const buf = "af_strand_probe_buf"
+	load := exec.Command("tmux", "load-buffer", "-b", buf, "-")
+	load.Stdin = strings.NewReader(text)
+	require.NoError(t, ts.cmdExec.Run(load))
+	paste := exec.Command("tmux", "paste-buffer", "-d", "-p", "-b", buf, "-t", exactTarget(ts.sanitizedName))
+	require.NoError(t, ts.cmdExec.Run(paste))
+}
+
+// TestStrandedDraftDoesNotConcatenateWithNextPrompt is the #2070 / #1982-half-b
+// regression. A draft stranded in the composer must not fuse with the NEXT
+// prompt: the receiver must see the new prompt as its own submission, not as
+// STRANDED-DRAFTNEW-PROMPT. It fails on pre-#2070 code (which has no pre-paste
+// clear, so the receiver gets one fused line) and passes once the clear drains
+// the strand first.
+func TestStrandedDraftDoesNotConcatenateWithNextPrompt(t *testing.T) {
+	ts, out := startLineComposerPane(t, "af_strand_probe")
+
+	const stranded = "STRANDED-DRAFT"
+	const next = "NEW-PROMPT"
+
+	strandDraft(t, ts, stranded)
+	require.NoError(t, ts.SendKeysCommand(next))
+
+	got := readReceived(t, out, "]")
+	t.Logf("receiver saw: %q", got)
+
+	require.NotContains(t, got, stranded+next,
+		"the stranded draft fused with the next prompt — the next instruction is corrupted")
+	require.Contains(t, got, "["+next+"]",
+		"the next prompt must arrive as its own submission")
+}
+
+// TestDeliveryStillSucceedsWithNoStrandedDraft is the safety half of #2070: the
+// unconditional pre-paste clear must be a NO-OP on a clean composer. On an empty
+// pending line the clear kills nothing, so a normal delivery still arrives whole
+// and by itself — the clear must never eat or corrupt a healthy prompt.
+func TestDeliveryStillSucceedsWithNoStrandedDraft(t *testing.T) {
+	ts, out := startLineComposerPane(t, "af_nostrand_probe")
+
+	const prompt = "PLAIN-PROMPT"
+	require.NoError(t, ts.SendKeysCommand(prompt))
+
+	got := readReceived(t, out, "]")
+	require.Equal(t, "["+prompt+"]", got,
+		"a delivery to a clean composer must arrive exactly once, unaltered by the pre-paste clear")
+}

--- a/session/tmux/submit_test.go
+++ b/session/tmux/submit_test.go
@@ -98,12 +98,20 @@ func TestCodexSubmitUsesBracketedPaste(t *testing.T) {
 	cmds := recordTmuxCommands(t, "codex", prompt)
 	joined := joinedArgs(cmds)
 
-	require.Len(t, cmds, 3, "codex submit is load-buffer, paste-buffer, send-keys Enter; got %v", joined)
+	require.Len(t, cmds, 4, "codex submit is clear, load-buffer, paste-buffer, send-keys Enter; got %v", joined)
+
+	// 0. A stranded draft in the composer is cleared with keystrokes BEFORE the
+	//    paste (#2070) so a prior lost Enter cannot fuse with this prompt. It must
+	//    be a keystroke clear, never a paste (a clear is a command, #1956), and it
+	//    must precede the load so the payload lands in an empty composer.
+	require.Contains(t, joined[0], "send-keys", "first command must clear the composer; got %v", joined)
+	require.Contains(t, joined[0], "C-u", "the clear must send C-u to kill the pending line (#2070); got %v", joined)
+	require.NotContains(t, joined[0], "load-buffer", "the clear must precede the load; got %v", joined)
 
 	// 1. Text is streamed into a buffer via stdin (not an argv arg → no ARG_MAX
 	//    ceiling for large prompts) and never as `send-keys -l`.
-	require.Contains(t, joined[0], "load-buffer", "first command must load the paste buffer; got %v", joined)
-	require.Equal(t, prompt, cmds[0].stdin, "paste text must be streamed on stdin")
+	require.Contains(t, joined[1], "load-buffer", "second command must load the paste buffer; got %v", joined)
+	require.Equal(t, prompt, cmds[1].stdin, "paste text must be streamed on stdin")
 	for _, j := range joined {
 		require.NotContains(t, j, "send-keys -t =af_proj: -l",
 			"codex must not use the plain literal send-keys path that gets swallowed (#1254); got %v", joined)
@@ -112,16 +120,16 @@ func TestCodexSubmitUsesBracketedPaste(t *testing.T) {
 	// 2. The paste is bracketed (-p) so codex gets an end-of-paste marker, and
 	//    the buffer is deleted after (-d) so buffers don't accumulate. The paste
 	//    reads back the SAME buffer the load wrote (no cross-talk).
-	require.Contains(t, joined[1], "paste-buffer", "second command must paste the buffer; got %v", joined)
-	require.Contains(t, joined[1], "-p", "paste must be bracketed (-p) so codex sees the paste boundary")
-	require.Contains(t, joined[1], "-d", "paste must delete the buffer afterward (-d)")
-	loadBuf, pasteBuf := bufferOf(cmds[0].args), bufferOf(cmds[1].args)
+	require.Contains(t, joined[2], "paste-buffer", "third command must paste the buffer; got %v", joined)
+	require.Contains(t, joined[2], "-p", "paste must be bracketed (-p) so codex sees the paste boundary")
+	require.Contains(t, joined[2], "-d", "paste must delete the buffer afterward (-d)")
+	loadBuf, pasteBuf := bufferOf(cmds[1].args), bufferOf(cmds[2].args)
 	require.NotEmpty(t, loadBuf, "load-buffer must name a buffer; got %v", joined)
 	require.Equal(t, loadBuf, pasteBuf, "paste must read back the buffer the load wrote; got %v", joined)
 
 	// 3. Enter is a SEPARATE command issued last — this is what actually submits.
-	require.Contains(t, joined[2], "send-keys", "last command must send Enter; got %v", joined)
-	require.Contains(t, joined[2], "Enter", "last command must send Enter to submit; got %v", joined)
+	require.Contains(t, joined[3], "send-keys", "last command must send Enter; got %v", joined)
+	require.Contains(t, joined[3], "Enter", "last command must send Enter to submit; got %v", joined)
 
 	// Every targeted command keeps the #1006 exact-match target.
 	for _, c := range cmds {
@@ -152,23 +160,26 @@ func TestEveryAgentSubmitUsesBracketedPasteBuffer(t *testing.T) {
 			cmds := recordTmuxCommands(t, program, prompt)
 			joined := joinedArgs(cmds)
 
-			require.Len(t, cmds, 3, "paste path is load-buffer, paste-buffer, send-keys Enter; got %v", joined)
-			require.Contains(t, joined[0], "load-buffer", "first command must load the paste buffer; got %v", joined)
-			require.Equal(t, prompt, cmds[0].stdin, "paste text must be streamed on stdin")
-			require.Contains(t, joined[1], "paste-buffer", "second command must paste the buffer; got %v", joined)
-			require.Contains(t, joined[1], "-d", "paste must delete the buffer afterward (-d)")
-			require.True(t, hasArg(cmds[1].args, "-p"),
+			require.Len(t, cmds, 4, "paste path is clear, load-buffer, paste-buffer, send-keys Enter; got %v", joined)
+			require.Contains(t, joined[0], "send-keys", "first command must clear the composer; got %v", joined)
+			require.Contains(t, joined[0], "C-u",
+				"a stranded draft must be cleared with C-u before the paste so it can't fuse with this prompt (#2070); got %v", joined)
+			require.Contains(t, joined[1], "load-buffer", "second command must load the paste buffer; got %v", joined)
+			require.Equal(t, prompt, cmds[1].stdin, "paste text must be streamed on stdin")
+			require.Contains(t, joined[2], "paste-buffer", "third command must paste the buffer; got %v", joined)
+			require.Contains(t, joined[2], "-d", "paste must delete the buffer afterward (-d)")
+			require.True(t, hasArg(cmds[2].args, "-p"),
 				"every pane must receive a BRACKETED paste: a plain paste arrives as keystrokes "+
 					"and a modal composer executes it as commands (#1956); got %v", joined)
-			require.Contains(t, joined[2], "send-keys", "last command must send Enter; got %v", joined)
-			require.Contains(t, joined[2], "Enter", "last command must submit with Enter; got %v", joined)
+			require.Contains(t, joined[3], "send-keys", "last command must send Enter; got %v", joined)
+			require.Contains(t, joined[3], "Enter", "last command must submit with Enter; got %v", joined)
 
 			for _, j := range joined {
 				require.NotContains(t, j, "send-keys -t =af_proj: -l",
 					"no pane may use the literal send-keys path that redraws wrapped bash input (#1292); got %v", joined)
 			}
 
-			loadBuf, pasteBuf := bufferOf(cmds[0].args), bufferOf(cmds[1].args)
+			loadBuf, pasteBuf := bufferOf(cmds[1].args), bufferOf(cmds[2].args)
 			require.NotEmpty(t, loadBuf, "load-buffer must name a buffer; got %v", joined)
 			require.Equal(t, loadBuf, pasteBuf, "paste must read back the buffer the load wrote; got %v", joined)
 
@@ -177,6 +188,34 @@ func TestEveryAgentSubmitUsesBracketedPasteBuffer(t *testing.T) {
 					require.Equal(t, "=af_proj:", tgt,
 						"submit commands must target by exact match (#1006); got %q in %v", tgt, joined)
 				}
+			}
+		})
+	}
+}
+
+// TestClearNeverSendsEscapeTheInterruptKey pins the safety property that decides
+// WHICH keystroke the pre-delivery clear (#2070) may use.
+//
+// Escape is the agents' INTERRUPT key: codex and claude both advertise "esc to
+// interrupt" in the footer of a working pane, and codex ships an `interrupt_turn`
+// action. Deliveries routinely land on a BUSY agent — cron and watch tasks fire
+// on schedule regardless of agent state, and the #1146 limit-resume re-delivery
+// targets a session that may have resumed on its own — so an Escape on this path
+// would abort in-flight work on every scheduled delivery. That is strictly worse
+// than the fusion the clear prevents: fusion corrupts one prompt, this would
+// silently destroy real work.
+//
+// Measured against real codex 0.144.6, Escape also does not clear the composer
+// (a stranded draft survived it) and tears down a modal picker, so it is pure
+// downside. If someone later "improves" the clear by prepending Escape to handle
+// modal composers, this test is what tells them why that is a regression.
+func TestClearNeverSendsEscapeTheInterruptKey(t *testing.T) {
+	for _, program := range []string{"claude", "codex", "aider", "gemini", "amp", "opencode"} {
+		t.Run(program, func(t *testing.T) {
+			for _, j := range joinedArgs(recordTmuxCommands(t, program, "a routine scheduled prompt")) {
+				require.NotContains(t, j, "Escape",
+					"the delivery path must never send Escape: it is the agents' interrupt key, so a "+
+						"delivery to a working agent would abort its turn (#2070); got %q", j)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #2070. Fixes the concatenation half of #1982 that #2065 deliberately left open.

**Draft: not requesting review yet.**

## The bug

A draft stranded in the composer **concatenates** with the next prompt, so a lost Enter silently corrupts the *next* instruction:

```
STRANDED-DRAFT + NEW-PROMPT  →  [STRANDED-DRAFTNEW-PROMPT]
```

That is real output from the new gate against a real tty line discipline, on pre-fix code.

## Why not route 2 (the issue's recommendation)

#2070 recommends having the agent-server *"report submission as a fact over the existing WS/RPC channel"*. I built the reconnaissance for that first, and **the premise does not hold**:

- af's **agent-server is af's own process**, not the composer's owner. The composer belongs to the third-party agent binary inside the PTY. Every `AgentServer` method is af-initiated and bottoms out in `tmux capture-pane` (`session/agentserver_local.go` → `session/tmux/io.go`).
- The **remote** `af agent-server` is not different. `POST /v1/agent/send-prompt` lands on its own `localAgentServer` → `session/backend_local.go` → this same file. Same blindness, one network hop away.
- **agentproto has no agent-originated message.** Opcodes are `PTYOut`/`Input`/`Resize`/`Repaint`/`Hello`; "client" there means a TUI/web *viewer*. The agent process never speaks agentproto — it only has bytes written into its tty by `send-keys` and read out by `pipe-pane`.
- **No agent→af channel exists at all**: the skills install *prose*, the "hooks" are provisioning scripts returning `{url,token}` once at creation, there is no MCP server and no ingest endpoint.

Adding a `submitted` event would create a field **nothing can truthfully populate** — af reporting its own paste+Enter back to itself. That is the fabricated-negative class #2070 exists to escape, re-introduced at the protocol layer. The per-agent hook route is rejected too: writing a `hooks` block into the user's global claude config is exactly what #1977/#2082 landed to stop.

## The fix

Clear the composer with a keystroke immediately before the paste.

It is sound because it **asserts nothing about the pane**. We do not try to detect whether a strand exists — #2065 proved that check cannot be made soundly (an agent echoes its prompt; an echo-off pane writes to a file, so *"not on screen" is not "not submitted"*). We clear **unconditionally**, so there is no inference to be wrong about.

## The clear is `C-u`, and explicitly NOT `Escape`

An earlier revision of this PR sent `Escape`+`C-u`. **Review caught that Escape is the interrupt key, and it was right.** I measured it against the real **codex 0.144.6** binary in a container (network disabled, stub credentials, throwaway home — never against a live session). Escape is disqualified three times over:

| # | Finding | Evidence |
|---|---|---|
| 1 | **Escape is the INTERRUPT key** | codex/claude advertise `esc to interrupt` while working; the codex binary ships an `interrupt_turn` action |
| 2 | **Escape does not even clear** | strand `SECOND-DRAFT-TEXT` → send Escape → `› SECOND-DRAFT-TEXT` still in the composer |
| 3 | **Escape is destructive at a modal picker** | sent to codex's trust dialog, it dismissed the dialog and tore the session down |

Deliveries routinely land on a **busy** agent — cron and watch fire on schedule regardless of agent state, and #1146 limit-resume targets a session that may have resumed on its own. So an Escape here would abort in-flight work on every scheduled delivery. **Fusion corrupts one prompt; that would silently destroy real work.**

Escape was also *counterproductive for the very case it was added for*: a vim composer rests in NORMAL mode, where `C-u` is half-page-scroll rather than kill-line — so Escape forced the composer **into** the mode where the clear cannot work. Pure downside on every axis.

`C-u` carries none of that, and against real codex it **cleared a stranded draft outright**:

```
B: strand    → › STRANDED-DRAFT-TEXT
C: after C-u → › Implement {feature}     (placeholder returns = composer empty)
```

## What I proved, and what I did not

| Case | Status |
|---|---|
| `C-u` clears a real **codex** composer | ✅ proven (container, real binary) |
| `Escape` does **not** clear codex; destroys a modal picker | ✅ proven (container, real binary) |
| `C-u` clears a readline/cooked-mode composer | ✅ proven (Go test, real tty line discipline) |
| `Escape` = interrupt mid-turn | ✅ agents' own advertised footer + `interrupt_turn` action + reviewer's live observation |
| `C-u` on a real **claude** composer | ❌ **not verified** — claude refuses to start without reaching `api.anthropic.com`, and I declined to run an authed, networked claude to force it |
| vim-NORMAL composer cleared | ❌ **not fixed** — residual gap, unchanged from before this PR |

The vim-NORMAL gap is unchanged by this PR, and closing it would need the per-agent clear matrix #2070 warns against. Dropping Escape strictly *reduces* risk regardless of the claude cell, since Escape's harms are established and its benefit was measured to be zero.

Tradeoff accepted deliberately: the clear discards a human-typed draft. Today that draft is instead **fused and submitted**, so clearing is the safer failure. When the clear visibly changes the pane the discarded content is logged — that log is a **record, not a gate**.

## Bounded, per #2114

Rebasing surfaced a **semantic merge conflict**: master moved this file off bare `exec.Command` onto context-bounded execution (#2099/#2105), and git merged master's imports with my function body into something that did not compile. The real defect behind that compile error was an **unbounded tmux command on the hottest path in the system**. The clear now uses `tmuxTimeoutContext()` + `runTmuxBounded`, matching `sendEnter`. `send-keys` discards output, so normalizing `exec.ErrWaitDelay` is correct here; the stdin-streaming caveat that gives `load-buffer` its own helper does not apply.

## Placement

`sendKeysPasteBuffer` is the single chokepoint: CLI, TUI, task/cron, watch, limit-resume (#1146), remote, and `daemon/configagent.go` (which bypasses `session.Instance` entirely).

The delivery baseline now reads the **post-clear** pane, which additionally lets a #1146 re-delivery confirm when its prior attempt stranded an identical tail.

## Tests

- `TestStrandedDraftDoesNotConcatenateWithNextPrompt` — **fails on pre-fix code** with the fused line above. The strand is *created* by the test, so it guards a real fusion.
- `TestDeliveryStillSucceedsWithNoStrandedDraft` — the clear must be a no-op on a clean composer.
- `TestClearNeverSendsEscapeTheInterruptKey` — pins the safety property so nobody "improves" the clear by prepending Escape.
- The two argv gates now assert the clear **precedes** the load.

Rebased onto master. `gofmt` / `go build` / `golangci-lint --fast` / `deadcode -test` / file-length all clean, and the full suite is green via `make test-container` — **re-run after the rebase**, with the pushed head verified to build from a clean clone rather than only my worktree.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
