### PR TITLE
fix(daemon): a config agent gets a session's trust-prompt budget, not an eighth of it

### DIFF
--- a/daemon/configagent.go
+++ b/daemon/configagent.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
@@ -145,13 +144,22 @@ func (t tmuxReadinessTarget) PreviewContent(ctx context.Context) (string, error)
 // an external worktree already takes.
 func (t tmuxReadinessTarget) HooksDone() <-chan struct{} { return nil }
 
-// configAgentTrustPromptAttempts bounds the trust-prompt dismissal loop,
-// mirroring task.StartAndSendPrompt's own cap.
-const configAgentTrustPromptAttempts = 5
+// configAgentTrustTarget is tmuxReadinessTarget plus the trust-prompt check, so
+// the config agent runs task.DismissTrustPrompt — the same loop, on the same
+// budget, as every regular session.
+//
+// The budget used to live here as a second pair of constants (5 attempts ×
+// 500ms) under a comment claiming they mirrored task/start.go's, which they
+// never did: the canonical budget is 20 × 1s, so a config agent whose trust
+// dialogs took longer than 2.5s failed with "trust prompt did not dismiss" —
+// and the caller reaps the session and shows the error, so the user is left
+// unable to configure af — where a regular session would have succeeded
+// (#2097). The numbers are not copied here any more; the loop is shared.
+type configAgentTrustTarget struct{ tmuxReadinessTarget }
 
-// configAgentTrustRetryDelay is the pause between trust-prompt dismissal
-// attempts, mirroring task.StartAndSendPrompt.
-const configAgentTrustRetryDelay = 500 * time.Millisecond
+func (t configAgentTrustTarget) CheckAndHandleTrustPrompt() bool {
+	return t.ts.CheckAndHandleTrustPrompt()
+}
 
 // SpawnConfigAgent starts a config agent in a bare tmux session rooted at AF
 // home, waits for it to be ready, dismisses any trust prompt, delivers the
@@ -237,7 +245,7 @@ func (m *Manager) SpawnConfigAgent(ctx context.Context, req SpawnConfigAgentRequ
 	if err := task.WaitForReadyOn(ctx, tmuxReadinessTarget{ts: ts, agent: agent}); err != nil {
 		return fail(fmt.Errorf("config agent: %w", err))
 	}
-	if err := dismissConfigAgentTrustPrompt(ctx, ts, agent); err != nil {
+	if err := dismissConfigAgentTrustPrompt(ctx, configAgentTrustTarget{tmuxReadinessTarget{ts: ts, agent: agent}}); err != nil {
 		return fail(fmt.Errorf("config agent: %w", err))
 	}
 	// The briefing rides in over a tmux paste buffer (stdin-streamed), so its
@@ -261,26 +269,13 @@ func (m *Manager) SpawnConfigAgent(ctx context.Context, req SpawnConfigAgentRequ
 // asking a non-agent command about one would tap Enter into an arbitrary
 // program. The decision is keyed off the RESOLVED agent for the same reason it
 // is there.
-func dismissConfigAgentTrustPrompt(ctx context.Context, ts *tmux.TmuxSession, agent string) error {
-	switch agent {
+func dismissConfigAgentTrustPrompt(ctx context.Context, target task.TrustPromptTarget) error {
+	switch target.ResolvedAgent() {
 	case tmux.ProgramClaude, tmux.ProgramCodex, tmux.ProgramAider, tmux.ProgramGemini, tmux.ProgramAmp:
 	default:
 		return nil // not a known agent: it has no trust dialog to dismiss
 	}
-	for attempts := 0; ts.CheckAndHandleTrustPrompt(); attempts++ {
-		if attempts+1 >= configAgentTrustPromptAttempts {
-			return fmt.Errorf("trust prompt did not dismiss after %d attempts", configAgentTrustPromptAttempts)
-		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(configAgentTrustRetryDelay):
-		}
-		if err := task.WaitForReadyOn(ctx, tmuxReadinessTarget{ts: ts, agent: agent}); err != nil {
-			return err
-		}
-	}
-	return nil
+	return task.DismissTrustPrompt(ctx, target)
 }
 
 // ReapConfigAgent tears down a config-agent session by name. It is the caller's

--- a/daemon/configagent_trust_test.go
+++ b/daemon/configagent_trust_test.go
@@ -1,0 +1,97 @@
+package daemon
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/session/tmux"
+	"github.com/sachiniyer/agent-factory/task"
+)
+
+// fakeTrustTarget is a config-agent-shaped task.TrustPromptTarget with no tmux
+// behind it. dismissConfigAgentTrustPrompt takes the target interface rather
+// than a *tmux.TmuxSession precisely so the budget below is assertable without
+// a real pane, a real agent, or a real daemon.
+type fakeTrustTarget struct {
+	agent string
+	// prompts is how many trust dialogs this pane will show before it settles.
+	prompts int
+	checks  int
+}
+
+func (f *fakeTrustTarget) ResolvedAgent() string { return f.agent }
+
+// PreviewContent renders claude's ready glyph, so the readiness re-wait between
+// dismissals returns on its first poll instead of dominating the test.
+func (f *fakeTrustTarget) PreviewContent(context.Context) (string, error) { return "❯", nil }
+
+func (f *fakeTrustTarget) HooksDone() <-chan struct{} { return nil }
+
+func (f *fakeTrustTarget) CheckAndHandleTrustPrompt() bool {
+	f.checks++
+	if f.prompts <= 0 {
+		return false
+	}
+	f.prompts--
+	return true
+}
+
+// TestDismissConfigAgentTrustPrompt_GetsTheSameBudgetAsASession is the #2097
+// regression test: a config agent must clear exactly as many trust dialogs as a
+// regular session, because it now runs the SAME loop on the SAME budget.
+//
+// Before the fix the daemon carried its own 5 × 500ms constants under a comment
+// claiming they mirrored task/start.go's 20 × 1s, so this case — a pane that
+// settles after more dialogs than 5 but far fewer than the canonical budget —
+// failed the spawn with "trust prompt did not dismiss", the caller reaped the
+// session, and the user was left unable to configure af.
+func TestDismissConfigAgentTrustPrompt_GetsTheSameBudgetAsASession(t *testing.T) {
+	defer task.SetTrustPromptTimingForTest(time.Nanosecond)()
+
+	// Eight dialogs: more than the retired 5-attempt config-agent cap and fewer
+	// than the canonical budget — squarely inside the window where a session
+	// succeeded and a config agent did not.
+	target := &fakeTrustTarget{agent: tmux.ProgramClaude, prompts: 8}
+	if err := dismissConfigAgentTrustPrompt(context.Background(), target); err != nil {
+		t.Fatalf("a config agent must clear as many trust dialogs as a session does, got: %v", err)
+	}
+	// Eight dismissals plus the clean check that ends the loop.
+	if target.checks != 9 {
+		t.Fatalf("expected 9 trust checks, got %d", target.checks)
+	}
+}
+
+// TestDismissConfigAgentTrustPrompt_BoundedByTheCanonicalBudget keeps the loop
+// bounded: raising the budget must not turn a permanently-stuck dialog into an
+// unbounded spin. The bound is asserted against task.MaxTrustPromptAttempts
+// rather than a literal so this test cannot become the next copy that drifts.
+func TestDismissConfigAgentTrustPrompt_BoundedByTheCanonicalBudget(t *testing.T) {
+	defer task.SetTrustPromptTimingForTest(time.Nanosecond)()
+
+	target := &fakeTrustTarget{agent: tmux.ProgramClaude, prompts: task.MaxTrustPromptAttempts + 5}
+	err := dismissConfigAgentTrustPrompt(context.Background(), target)
+	if err == nil {
+		t.Fatal("a trust prompt that never clears must still fail the spawn")
+	}
+	if !strings.Contains(err.Error(), "trust prompt did not dismiss") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if target.checks != task.MaxTrustPromptAttempts {
+		t.Fatalf("expected %d trust checks, got %d", task.MaxTrustPromptAttempts, target.checks)
+	}
+}
+
+// TestDismissConfigAgentTrustPrompt_SkipsNonAgents holds the per-agent gate that
+// predates this fix: only known agents have a trust dialog, and asking anything
+// else about one taps Enter into an arbitrary program.
+func TestDismissConfigAgentTrustPrompt_SkipsNonAgents(t *testing.T) {
+	target := &fakeTrustTarget{agent: "", prompts: 1}
+	if err := dismissConfigAgentTrustPrompt(context.Background(), target); err != nil {
+		t.Fatalf("a non-agent program has no trust dialog to dismiss, got: %v", err)
+	}
+	if target.checks != 0 {
+		t.Fatalf("Enter must never be tapped into a non-agent program, got %d checks", target.checks)
+	}
+}

--- a/task/start.go
+++ b/task/start.go
@@ -8,9 +8,86 @@ import (
 	"github.com/sachiniyer/agent-factory/session"
 )
 
-const maxTrustPromptAttempts = 20
+// MaxTrustPromptAttempts and trustPromptRetryDelay are THE trust-prompt
+// dismissal budget: ~20s, enough for a sequence of dialogs (folder trust, then
+// MCP trust) plus the readiness re-wait each one costs.
+//
+// The budget is exported and the loop below is shared because copying the pair
+// is how it broke: the daemon's config agent carried its own 5 × 500ms
+// constants under a comment claiming they mirrored these, giving a config-agent
+// spawn an eighth of a session's budget and failing it with "trust prompt did
+// not dismiss" where a session would have succeeded (#2097). A second copy of
+// the numbers cannot drift if there is no second copy — every caller goes
+// through DismissTrustPrompt.
+const MaxTrustPromptAttempts = 20
 
 var trustPromptRetryDelay = time.Second
+
+// SetTrustPromptTimingForTest compresses the trust-prompt dismissal loop's
+// timing — both the backoff between attempts and the readiness poll each retry
+// drives — so a test outside this package can exercise the full attempt budget
+// without sleeping through ~20s of it. Returns a restore func, matching the
+// session.SetBackendFactoryForTest seam. Test-only.
+func SetTrustPromptTimingForTest(retryDelay time.Duration) func() {
+	oldDelay, oldPoll := trustPromptRetryDelay, waitForReadyPollInterval
+	poll := retryDelay
+	if poll <= 0 {
+		// time.NewTicker panics on a non-positive duration, so the poll floor is
+		// the smallest tick rather than the caller's zero.
+		poll = time.Nanosecond
+	}
+	trustPromptRetryDelay, waitForReadyPollInterval = retryDelay, poll
+	return func() {
+		trustPromptRetryDelay, waitForReadyPollInterval = oldDelay, oldPoll
+	}
+}
+
+// TrustPromptTarget is a ReadinessTarget that can also dismiss its own first-run
+// trust dialog — the narrow contract DismissTrustPrompt drives, implemented both
+// by a full session.Instance and by the daemon's bare tmux config agent.
+type TrustPromptTarget interface {
+	ReadinessTarget
+	// CheckAndHandleTrustPrompt dismisses a visible trust dialog and reports
+	// whether one was there — i.e. whether another may follow it.
+	CheckAndHandleTrustPrompt() bool
+}
+
+// DismissTrustPrompt clears an agent's first-run trust dialogs, bounded by the
+// canonical budget above.
+//
+// Dialogs arrive one at a time (folder trust, then MCP trust), so each dismissal
+// is followed by a fresh readiness wait before the next check; the loop ends
+// when the pane shows no dialog. A nil ctx is treated as context.Background().
+func DismissTrustPrompt(ctx context.Context, target TrustPromptTarget) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	for attempts := 0; target.CheckAndHandleTrustPrompt(); attempts++ {
+		if attempts+1 >= MaxTrustPromptAttempts {
+			return fmt.Errorf("trust prompt did not dismiss after %d attempts", MaxTrustPromptAttempts)
+		}
+		// Honor cancellation while backing off between trust-prompt retries so an
+		// abandoned create doesn't sit here sleeping and re-waiting.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(trustPromptRetryDelay):
+		}
+		if err := WaitForReadyOn(ctx, target); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// instanceTrustTarget adapts a full session.Instance to TrustPromptTarget,
+// reusing the readiness adapter so the trust loop polls the same way
+// WaitForReady does.
+type instanceTrustTarget struct{ instanceReadinessTarget }
+
+func (t instanceTrustTarget) CheckAndHandleTrustPrompt() bool {
+	return t.inst.CheckAndHandleTrustPrompt()
+}
 
 // StartAndSendPrompt is the canonical way to start an instance, wait for
 // readiness, handle trust prompts, and optionally send a prompt.
@@ -45,20 +122,8 @@ func StartAndSendPrompt(ctx context.Context, instance *session.Instance, prompt 
 		return err
 	}
 
-	for attempts := 0; instance.CheckAndHandleTrustPrompt(); attempts++ {
-		if attempts+1 >= maxTrustPromptAttempts {
-			return fmt.Errorf("trust prompt did not dismiss after %d attempts", maxTrustPromptAttempts)
-		}
-		// Honor cancellation while backing off between trust-prompt retries so an
-		// abandoned create doesn't sit here sleeping and re-waiting.
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(trustPromptRetryDelay):
-		}
-		if err := WaitForReady(ctx, instance); err != nil {
-			return err
-		}
+	if err := DismissTrustPrompt(ctx, instanceTrustTarget{instanceReadinessTarget{inst: instance}}); err != nil {
+		return err
 	}
 
 	if prompt != "" {

--- a/task/start_test.go
+++ b/task/start_test.go
@@ -97,7 +97,7 @@ func TestStartAndSendPrompt_BoundsPersistentTrustPrompt(t *testing.T) {
 		waitForReadyPollInterval = oldPoll
 	})
 
-	backend := &startBackend{trustPrompts: maxTrustPromptAttempts + 5}
+	backend := &startBackend{trustPrompts: MaxTrustPromptAttempts + 5}
 	err := StartAndSendPrompt(context.Background(), newStartTestInstance(t, backend), "do work")
 	if err == nil {
 		t.Fatalf("expected persistent trust prompt error")
@@ -105,8 +105,8 @@ func TestStartAndSendPrompt_BoundsPersistentTrustPrompt(t *testing.T) {
 	if !strings.Contains(err.Error(), "trust prompt did not dismiss") {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if backend.trustChecks != maxTrustPromptAttempts {
-		t.Fatalf("expected %d trust checks, got %d", maxTrustPromptAttempts, backend.trustChecks)
+	if backend.trustChecks != MaxTrustPromptAttempts {
+		t.Fatalf("expected %d trust checks, got %d", MaxTrustPromptAttempts, backend.trustChecks)
 	}
 	if backend.sentPrompt != "" {
 		t.Fatalf("prompt should not be sent after trust prompt failure, got %q", backend.sentPrompt)


### PR DESCRIPTION
Fixes #2097

## The bug

`dismissConfigAgentTrustPrompt` (`daemon/configagent.go`) carried its own trust-prompt dismissal constants — **5 attempts × 500ms (~2.5s)** — under comments claiming they mirrored `task.StartAndSendPrompt`'s. They never did: the canonical budget is **20 attempts × 1s (~20s)**.

So a config agent whose first-run dialogs took longer than ~2.5s failed with `trust prompt did not dismiss` where a regular session would have succeeded. A sequence of dialogs is exactly the case that blows the smaller budget — folder trust followed by MCP trust, each costing a dismissal plus a readiness re-wait.

There is no manual fallback on that path: `SpawnConfigAgent`'s `fail` closure reaps the session and `configagent.Spawn` returns `failed to start the config agent: …`, so takeover never happens and the user is left unable to configure `af`.

## The fix

Copying the numbers into a second place is what broke, so this doesn't copy the *corrected* numbers there too. The bounded loop moves to `task.DismissTrustPrompt`, driven by a new `task.TrustPromptTarget` — a `ReadinessTarget` that can also dismiss its own dialog, i.e. the same seam `ReadinessTarget` already established for the config agent's readiness wait (and for the same stated reason: one implementation, not two that drift).

- `task/start.go`: `MaxTrustPromptAttempts` + `trustPromptRetryDelay` are now the single budget; `DismissTrustPrompt` is the single loop. `StartAndSendPrompt` calls it via an `instanceTrustTarget` adapter — behavior unchanged (`WaitForReady` is `WaitForReadyOn(instanceReadinessTarget{…})`).
- `daemon/configagent.go`: both constants and the duplicated loop are **deleted**. `dismissConfigAgentTrustPrompt` keeps its per-agent gate (a non-agent command must never get Enter tapped into it) and delegates the rest.

The budget now exists once, so the "mirrors" comment cannot lie again.

## Test

`daemon/configagent_trust_test.go` — watched fail first:

```
--- FAIL: TestDismissConfigAgentTrustPrompt_GetsTheSameBudgetAsASession
    a config agent must clear as many trust dialogs as a session does,
    got: trust prompt did not dismiss after 5 attempts
```

(reproduced by pinning the shared budget back to 5 — the exact #2097 error, and it confirms the assertion is budget-sensitive rather than vacuous).

- **`_GetsTheSameBudgetAsASession`** — a pane settling after 8 dialogs (more than the retired 5-attempt cap, fewer than the canonical budget: the window where master failed and a session succeeded) now succeeds.
- **`_BoundedByTheCanonicalBudget`** — a dialog that never clears still fails, asserted against `task.MaxTrustPromptAttempts` rather than a literal, so the test cannot become the next copy that drifts.
- **`_SkipsNonAgents`** — the per-agent gate still holds.

All three run without a real pane, agent, or daemon, since the daemon helper now takes the target interface. `task.SetTrustPromptTimingForTest` compresses the loop's timing so the full budget is exercised in milliseconds.

## Gates

- `gofmt -l .` clean · `golangci-lint run --timeout=3m --fast` clean · `deadcode -test ./...` clean · `scripts/lint-file-length.sh` passed
- `go build ./...` OK
- `make test-container GOTESTARGS="-count=1 ./daemon/..."` — ok (159s)
- Host-safe remainder (`go list ./... | grep -v /daemon`) — all green

Out of scope, deliberately: the trust-prompt *mechanism* is untouched. The other `CheckAndHandleTrustPrompt` call sites (`agentserver_local.go`, `manager_status.go`) are single-shot poll dismissals, not budgeted loops, and are left alone.

Captain Claude