### PR TITLE
fix(session): guard host-wide tmux teardown in Claude sessions (#2175)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ Working style:
   stays restorable. Use `af sessions kill --force` only when you explicitly mean
   to permanently destroy the session and prune its branch. Don't let sessions
   accumulate.
+- Never run `pkill tmux`/`pkill af` or bare `tmux kill-server` on a shared host; tmux teardown must name an isolated socket with `-L` or `-S`.
 - Run `golangci-lint run --timeout=3m --fast`, `gofmt -l .`, `go build ./...`,
   and the full test suite before opening a PR — CI blocks on all four. On a
   shared dev box run the suite as `make test-container` (never bare

--- a/commands/tmuxguardcmd.go
+++ b/commands/tmuxguardcmd.go
@@ -1,0 +1,23 @@
+package commands
+
+import (
+	"github.com/sachiniyer/agent-factory/internal/tmuxguard"
+
+	"github.com/spf13/cobra"
+)
+
+// tmuxGuardHookCmd is the native half of the af-owned Claude PreToolUse hook.
+// It is hidden because it is a JSON-over-stdio integration point, not a human
+// CLI surface. The generated plugin invokes the exact af binary that wrote it.
+var tmuxGuardHookCmd = &cobra.Command{
+	Use:    "hook-guard-tmux",
+	Hidden: true,
+	Args:   cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		return tmuxguard.Run(cmd.InOrStdin(), cmd.OutOrStdout())
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(tmuxGuardHookCmd)
+}

--- a/internal/tmuxguard/guard.go
+++ b/internal/tmuxguard/guard.go
@@ -1,0 +1,386 @@
+// Package tmuxguard implements the Claude PreToolUse policy that prevents an
+// af-managed agent from tearing down the host's shared tmux server.
+package tmuxguard
+
+import (
+	"encoding/json"
+	"io"
+	"path/filepath"
+	"strings"
+	"unicode"
+)
+
+const maxHookInput = 4 << 20
+
+type hookInput struct {
+	ToolName  string `json:"tool_name"`
+	ToolInput struct {
+		Command string `json:"command"`
+	} `json:"tool_input"`
+}
+
+type hookDecision struct {
+	HookSpecificOutput struct {
+		HookEventName            string `json:"hookEventName"`
+		PermissionDecision       string `json:"permissionDecision"`
+		PermissionDecisionReason string `json:"permissionDecisionReason"`
+	} `json:"hookSpecificOutput"`
+}
+
+// Run reads one Claude PreToolUse payload and emits a structured denial when
+// its Bash command would broadly kill tmux. Malformed input fails closed: a
+// broken guard must not turn into permission to destroy the shared server.
+func Run(r io.Reader, w io.Writer) error {
+	var input hookInput
+	if err := json.NewDecoder(io.LimitReader(r, maxHookInput)).Decode(&input); err != nil {
+		return writeDenial(w, "Agent Factory could not validate this Bash command, so it was blocked to protect shared tmux sessions.")
+	}
+	if input.ToolName != "Bash" {
+		return nil
+	}
+	if reason := DenialReason(input.ToolInput.Command); reason != "" {
+		return writeDenial(w, reason)
+	}
+	return nil
+}
+
+func writeDenial(w io.Writer, reason string) error {
+	var decision hookDecision
+	decision.HookSpecificOutput.HookEventName = "PreToolUse"
+	decision.HookSpecificOutput.PermissionDecision = "deny"
+	decision.HookSpecificOutput.PermissionDecisionReason = reason
+	return json.NewEncoder(w).Encode(decision)
+}
+
+// DenialReason returns an actionable reason when command contains a direct,
+// host-wide tmux teardown. An empty result means the command is allowed.
+func DenialReason(command string) string {
+	for _, words := range shellCommandWords(command) {
+		executable, args := unwrapInvocation(removeRedirections(words))
+		switch strings.ToLower(filepath.Base(executable)) {
+		case "tmux":
+			if tmuxKillServerIsBroad(args) {
+				return "Agent Factory blocked a host-wide tmux kill-server. Target an isolated server explicitly with 'tmux -L <socket> kill-server' or 'tmux -S <path> kill-server'."
+			}
+		case "pkill":
+			if pkillTargetsTmux(args) {
+				return "Agent Factory blocked pkill targeting tmux because pkill cannot be scoped to one tmux socket. Use 'tmux -L <socket> kill-server' or 'tmux -S <path> kill-server' instead."
+			}
+		case "sh", "bash", "dash", "zsh", "ksh":
+			if nested := shellCommandArgument(args); nested != "" {
+				if reason := DenialReason(nested); reason != "" {
+					return reason
+				}
+			}
+		case "eval":
+			if reason := DenialReason(strings.Join(args, " ")); reason != "" {
+				return reason
+			}
+		}
+	}
+	return ""
+}
+
+func tmuxKillServerIsBroad(args []string) bool {
+	socketScoped := false
+	for i := 0; i < len(args); i++ {
+		switch arg := args[i]; {
+		case arg == "-L" || arg == "-S":
+			if i+1 < len(args) && args[i+1] != "" {
+				socketScoped = true
+			}
+			i++
+		case (strings.HasPrefix(arg, "-L") || strings.HasPrefix(arg, "-S")) && len(arg) > 2:
+			socketScoped = true
+		case arg == "kill-server":
+			return !socketScoped
+		}
+	}
+	return false
+}
+
+func pkillTargetsTmux(args []string) bool {
+	if len(args) == 0 {
+		return false
+	}
+	// pkill's one required positional argument is its pattern. In the normal
+	// and documented forms it is the final argument; matching "tmux" inside
+	// that regex also catches anchored spellings such as ^tmux$.
+	return strings.Contains(strings.ToLower(args[len(args)-1]), "tmux")
+}
+
+func shellCommandArgument(args []string) string {
+	for i := 0; i < len(args); i++ {
+		if args[i] == "-c" && i+1 < len(args) {
+			return args[i+1]
+		}
+		if strings.HasPrefix(args[i], "-c") && len(args[i]) > 2 {
+			return args[i][2:]
+		}
+	}
+	return ""
+}
+
+const redirectionToken = "\x00af-redirection"
+
+func removeRedirections(words []string) []string {
+	clean := make([]string, 0, len(words))
+	for i := 0; i < len(words); i++ {
+		if words[i] == redirectionToken {
+			if i+1 < len(words) {
+				i++
+			}
+			continue
+		}
+		clean = append(clean, words[i])
+	}
+	return clean
+}
+
+// unwrapInvocation returns the executable and arguments for one shell command
+// segment. It recognizes the common wrappers agents use around commands, while
+// leaving arbitrary argument text (for example "echo tmux kill-server") alone.
+func unwrapInvocation(words []string) (string, []string) {
+	for len(words) > 0 {
+		for len(words) > 0 && (isAssignment(words[0]) || isControlPrefix(words[0])) {
+			words = words[1:]
+		}
+		if len(words) == 0 {
+			return "", nil
+		}
+
+		switch strings.ToLower(filepath.Base(words[0])) {
+		case "command", "exec", "nohup":
+			words = skipFlagOnlyPrefix(words[1:])
+		case "env":
+			words = skipEnvPrefix(words[1:])
+		case "sudo":
+			words = skipSudoPrefix(words[1:])
+		case "nice":
+			words = skipNicePrefix(words[1:])
+		case "timeout":
+			words = skipTimeoutPrefix(words[1:])
+		default:
+			return words[0], words[1:]
+		}
+	}
+	return "", nil
+}
+
+func skipFlagOnlyPrefix(words []string) []string {
+	for len(words) > 0 && strings.HasPrefix(words[0], "-") {
+		if words[0] == "--" {
+			return words[1:]
+		}
+		words = words[1:]
+	}
+	return words
+}
+
+func skipEnvPrefix(words []string) []string {
+	for len(words) > 0 {
+		switch {
+		case words[0] == "--":
+			return words[1:]
+		case words[0] == "-u" || words[0] == "--unset":
+			if len(words) < 2 {
+				return nil
+			}
+			words = words[2:]
+		case strings.HasPrefix(words[0], "-") || isAssignment(words[0]):
+			words = words[1:]
+		default:
+			return words
+		}
+	}
+	return words
+}
+
+func skipSudoPrefix(words []string) []string {
+	for len(words) > 0 && strings.HasPrefix(words[0], "-") {
+		if words[0] == "--" {
+			return words[1:]
+		}
+		if sudoOptionTakesValue(words[0]) {
+			if len(words) < 2 {
+				return nil
+			}
+			words = words[2:]
+			continue
+		}
+		words = words[1:]
+	}
+	return words
+}
+
+func sudoOptionTakesValue(option string) bool {
+	switch option {
+	case "-u", "--user", "-g", "--group", "-h", "--host", "-p", "--prompt", "-C", "--close-from", "-R", "--chroot", "-T", "--command-timeout":
+		return true
+	default:
+		return false
+	}
+}
+
+func skipNicePrefix(words []string) []string {
+	if len(words) >= 2 && (words[0] == "-n" || words[0] == "--adjustment") {
+		return words[2:]
+	}
+	if len(words) > 0 && strings.HasPrefix(words[0], "-") {
+		return words[1:]
+	}
+	return words
+}
+
+func skipTimeoutPrefix(words []string) []string {
+	for len(words) > 0 && strings.HasPrefix(words[0], "-") {
+		if words[0] == "--" {
+			words = words[1:]
+			break
+		}
+		if words[0] == "-k" || words[0] == "--kill-after" || words[0] == "-s" || words[0] == "--signal" {
+			if len(words) < 2 {
+				return nil
+			}
+			words = words[2:]
+			continue
+		}
+		words = words[1:]
+	}
+	if len(words) > 0 { // duration
+		words = words[1:]
+	}
+	return words
+}
+
+func isControlPrefix(word string) bool {
+	switch word {
+	case "!", "if", "then", "elif", "else", "while", "until", "do", "time", "coproc":
+		return true
+	default:
+		return false
+	}
+}
+
+func isAssignment(word string) bool {
+	eq := strings.IndexByte(word, '=')
+	if eq <= 0 {
+		return false
+	}
+	for i, r := range word[:eq] {
+		if (i == 0 && !unicode.IsLetter(r) && r != '_') || (i > 0 && !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_') {
+			return false
+		}
+	}
+	return true
+}
+
+// shellCommandWords performs the small amount of shell lexing the policy
+// needs: quotes and backslash escapes are decoded, while list/pipeline/control
+// operators split independent command segments. It deliberately does not
+// expand variables; a dynamic socket flag is not an explicit -L/-S and is
+// therefore denied.
+func shellCommandWords(command string) [][]string {
+	var commands [][]string
+	var words []string
+	var word strings.Builder
+	inWord := false
+	quote := byte(0)
+
+	flushWord := func() {
+		if !inWord {
+			return
+		}
+		words = append(words, word.String())
+		word.Reset()
+		inWord = false
+	}
+	flushCommand := func() {
+		flushWord()
+		if len(words) != 0 {
+			commands = append(commands, words)
+			words = nil
+		}
+	}
+
+	for i := 0; i < len(command); i++ {
+		c := command[i]
+		if quote == '\'' {
+			if c == '\'' {
+				quote = 0
+			} else {
+				word.WriteByte(c)
+			}
+			continue
+		}
+		if quote == '"' {
+			switch c {
+			case '"':
+				quote = 0
+			case '\\':
+				if i+1 < len(command) {
+					i++
+					word.WriteByte(command[i])
+				}
+			default:
+				word.WriteByte(c)
+			}
+			continue
+		}
+
+		switch c {
+		case ' ', '\t', '\r':
+			flushWord()
+		case '\n', ';', '|', '&', '(', ')', '{', '}':
+			flushCommand()
+			if i+1 < len(command) && command[i+1] == c && (c == '|' || c == '&') {
+				i++
+			}
+		case '<', '>':
+			if inWord && allDigits(word.String()) {
+				word.Reset()
+				inWord = false
+			} else {
+				flushWord()
+			}
+			words = append(words, redirectionToken)
+			if i+1 < len(command) && (command[i+1] == c || command[i+1] == '&') {
+				i++
+			}
+		case '\\':
+			inWord = true
+			if i+1 < len(command) {
+				i++
+				word.WriteByte(command[i])
+			}
+		case '\'', '"':
+			inWord = true
+			quote = c
+		case '#':
+			if !inWord {
+				for i+1 < len(command) && command[i+1] != '\n' {
+					i++
+				}
+			} else {
+				word.WriteByte(c)
+			}
+		default:
+			inWord = true
+			word.WriteByte(c)
+		}
+	}
+	flushCommand()
+	return commands
+}
+
+func allDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if !unicode.IsDigit(r) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/tmuxguard/guard_test.go
+++ b/internal/tmuxguard/guard_test.go
@@ -1,0 +1,82 @@
+package tmuxguard
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestDenialReason(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		deny    bool
+	}{
+		{name: "bare kill-server", command: "tmux kill-server", deny: true},
+		{name: "absolute tmux", command: "/usr/bin/tmux kill-server", deny: true},
+		{name: "compound command", command: "echo checking && tmux kill-server 2>/dev/null", deny: true},
+		{name: "escaped executable", command: `t\mux kill-server`, deny: true},
+		{name: "environment wrapper", command: "env FOO=bar tmux kill-server", deny: true},
+		{name: "shell wrapper", command: `bash -c 'tmux kill-server'`, deny: true},
+		{name: "pkill tmux", command: "pkill tmux", deny: true},
+		{name: "anchored pkill pattern", command: `pkill -f '^tmux$'`, deny: true},
+		{name: "named socket", command: "tmux -L af-test kill-server"},
+		{name: "attached named socket", command: "tmux -Laf-test kill-server"},
+		{name: "socket path", command: "tmux -S /tmp/af-test.sock kill-server"},
+		{name: "socket option after command is too late", command: "tmux kill-server -L af-test", deny: true},
+		{name: "empty socket", command: `tmux -L '' kill-server`, deny: true},
+		{name: "other tmux command", command: "tmux list-sessions"},
+		{name: "quoted discussion", command: `printf '%s\n' 'tmux kill-server'`},
+		{name: "other pkill", command: "pkill test-worker"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DenialReason(tt.command)
+			if tt.deny && got == "" {
+				t.Fatalf("expected %q to be denied", tt.command)
+			}
+			if !tt.deny && got != "" {
+				t.Fatalf("expected %q to be allowed, got %q", tt.command, got)
+			}
+		})
+	}
+}
+
+func TestRunReturnsClaudeDenial(t *testing.T) {
+	input := `{"tool_name":"Bash","tool_input":{"command":"tmux kill-server"}}`
+	var output bytes.Buffer
+	if err := Run(strings.NewReader(input), &output); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	var decision hookDecision
+	if err := json.Unmarshal(output.Bytes(), &decision); err != nil {
+		t.Fatalf("parse decision: %v", err)
+	}
+	if decision.HookSpecificOutput.PermissionDecision != "deny" {
+		t.Fatalf("expected deny decision, got: %s", output.String())
+	}
+}
+
+func TestRunAllowsSocketedKill(t *testing.T) {
+	input := `{"tool_name":"Bash","tool_input":{"command":"tmux -S /tmp/af-test.sock kill-server"}}`
+	var output bytes.Buffer
+	if err := Run(strings.NewReader(input), &output); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if output.Len() != 0 {
+		t.Fatalf("safe command should produce no decision, got: %s", output.String())
+	}
+}
+
+func TestRunFailsClosedOnMalformedInput(t *testing.T) {
+	var output bytes.Buffer
+	if err := Run(strings.NewReader("not-json"), &output); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !strings.Contains(output.String(), `"permissionDecision":"deny"`) {
+		t.Fatalf("malformed hook input must be denied, got: %s", output.String())
+	}
+}

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -1227,6 +1227,24 @@
       },
       "verdict": "unclear",
       "notes": "#1904 added tab reorder to the CLI (tab-reorder --index) and web (ReorderTab, drag in the tab bar). No TUI affordance. Same owner call as session.tab.rename. Not filed."
+    },
+    {
+      "id": "internal.hook-guard-tmux",
+      "title": "Run the Claude PreToolUse tmux safety hook",
+      "tui": {
+        "status": "n/a",
+        "pointer": "session/plugin.go:20 pluginHooks"
+      },
+      "web": {
+        "status": "n/a",
+        "pointer": "session/plugin.go:20 pluginHooks"
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "commands/tmuxguardcmd.go:11 tmuxGuardHookCmd"
+      },
+      "verdict": "deliberate",
+      "notes": "Hidden JSON-over-stdio integration command invoked only by the af-managed Claude plugin; it is not a user-facing capability and has no TUI or web analogue."
     }
   ],
   "ledger": {
@@ -1256,6 +1274,7 @@
       "af doctor": "install.doctor",
       "af gen-docs": "meta.internal",
       "af help": "meta.discovery",
+      "af hook-guard-tmux": "internal.hook-guard-tmux",
       "af keys": "meta.discovery",
       "af projects delete": "project.delete",
       "af reset": "install.reset",
@@ -1392,6 +1411,7 @@
       "af --daemon": "meta.internal",
       "af --daemon-url": "daemon.remote-access",
       "af --help": "meta.discovery",
+      "af hook-guard-tmux --help": "internal.hook-guard-tmux",
       "af --program": "session.create.opt.program",
       "af --token": "daemon.remote-access",
       "af --version": "meta.discovery",

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -82,7 +82,15 @@ refuse_live_af_sessions() {
 }
 
 list_target_sessions() {
-  tmux "${tmux_socket_args[@]}" list-sessions -F '#{session_name}' 2>/dev/null
+  # macOS still ships Bash 3.2, where expanding an empty array under `set -u`
+  # aborts before tmux is invoked. Keep the default-server probe literal until
+  # --yes-really resolves it to an explicit -S path; after that the array is
+  # necessarily populated.
+  if (( ${#tmux_socket_args[@]} == 0 )); then
+    tmux list-sessions -F '#{session_name}' 2>/dev/null
+  else
+    tmux "${tmux_socket_args[@]}" list-sessions -F '#{session_name}' 2>/dev/null
+  fi
 }
 
 # A missing server is already stopped. A reachable server is checked twice,

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,3 +1,113 @@
-tmux kill-server
-rm -rf worktree*
-rm -rf ~/.agent-factory
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/clean.sh (-L <socket-name> | -S <socket-path> | --yes-really)
+
+Remove legacy worktrees and ~/.agent-factory after safely stopping the target
+tmux server. Cleanup is refused if that server has any live af_* sessions.
+--yes-really selects the default tmux server; it does not override that guard.
+EOF
+}
+
+fail() {
+  printf 'clean.sh: %s\n' "$*" >&2
+  exit 1
+}
+
+tmux_socket_args=()
+explicit_socket=false
+yes_really=false
+
+set_socket() {
+  local flag="$1"
+  local value="$2"
+  if [[ -z "$value" ]]; then
+    fail "$flag requires a non-empty socket"
+  fi
+  if (( ${#tmux_socket_args[@]} != 0 )); then
+    fail "choose exactly one tmux socket with -L or -S"
+  fi
+  tmux_socket_args=("$flag" "$value")
+  explicit_socket=true
+}
+
+while (( $# > 0 )); do
+  case "$1" in
+    -L|-S)
+      if (( $# < 2 )); then
+        fail "$1 requires a socket"
+      fi
+      set_socket "$1" "$2"
+      shift 2
+      ;;
+    -L?*)
+      set_socket -L "${1#-L}"
+      shift
+      ;;
+    -S?*)
+      set_socket -S "${1#-S}"
+      shift
+      ;;
+    --yes-really)
+      yes_really=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument '$1' (expected -L, -S, or --yes-really)"
+      ;;
+  esac
+done
+
+if [[ "$explicit_socket" != true && "$yes_really" != true ]]; then
+  fail "refusing an implicit default socket; pass -L <name>, -S <path>, or --yes-really"
+fi
+
+refuse_live_af_sessions() {
+  local sessions="$1"
+  local session
+  while IFS= read -r session; do
+    case "$session" in
+      af_*)
+        fail "refusing cleanup: live Agent Factory session '$session' exists on the target tmux socket"
+        ;;
+    esac
+  done <<< "$sessions"
+}
+
+list_target_sessions() {
+  tmux "${tmux_socket_args[@]}" list-sessions -F '#{session_name}' 2>/dev/null
+}
+
+# A missing server is already stopped. A reachable server is checked twice,
+# immediately before teardown, so an af session observed on either side of the
+# default-socket resolution aborts before any files are removed.
+if sessions="$(list_target_sessions)"; then
+  refuse_live_af_sessions "$sessions"
+
+  if [[ "$explicit_socket" != true ]]; then
+    socket_path="$(tmux display-message -p '#{socket_path}' 2>/dev/null)"
+    if [[ -z "$socket_path" ]]; then
+      fail "tmux did not report the default server's socket path"
+    fi
+    tmux_socket_args=(-S "$socket_path")
+  fi
+
+  if sessions="$(list_target_sessions)"; then
+    refuse_live_af_sessions "$sessions"
+    if (( ${#tmux_socket_args[@]} != 2 )); then
+      fail "internal error: refusing to stop tmux without an explicit socket"
+    fi
+    tmux "${tmux_socket_args[@]}" kill-server 2>/dev/null || true
+  fi
+fi
+
+: "${HOME:?HOME must be set to clean the Agent Factory state directory}"
+rm -rf -- worktree*
+rm -rf -- "$HOME/.agent-factory"

--- a/scripts/clean_hard.sh
+++ b/scripts/clean_hard.sh
@@ -1,4 +1,7 @@
-tmux kill-server
-rm -rf worktree*
-rm -rf ~/.agent-factory
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+"$script_dir/clean.sh" "$@"
 git worktree prune

--- a/scripts/clean_scripts_test.go
+++ b/scripts/clean_scripts_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+type cleanScriptResult struct {
+	output string
+	log    string
+	err    error
+	work   string
+	home   string
+}
+
+func runCleanScript(t *testing.T, script string, args []string, sessions string) cleanScriptResult {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("cleanup scripts require bash")
+	}
+
+	tmp := t.TempDir()
+	binDir := filepath.Join(tmp, "bin")
+	workDir := filepath.Join(tmp, "work")
+	homeDir := filepath.Join(tmp, "home")
+	for _, dir := range []string{binDir, workDir, homeDir, filepath.Join(homeDir, ".agent-factory"), filepath.Join(workDir, "worktree-live")} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	tmuxLog := filepath.Join(tmp, "tmux.log")
+	fakeTmux := `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$FAKE_TMUX_LOG"
+case " $* " in
+  *" list-sessions "*) printf '%s' "${FAKE_TMUX_SESSIONS:-}" ;;
+  *" display-message "*) printf '%s\n' "${FAKE_TMUX_SOCKET:-/tmp/af-clean-test.sock}" ;;
+  *" kill-server "*) exit 0 ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(binDir, "tmux"), []byte(fakeTmux), 0755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+
+	path := filepath.Join(repoRoot(t), "scripts", script)
+	cmd := exec.Command("bash", append([]string{path}, args...)...)
+	cmd.Dir = workDir
+	cmd.Env = []string{
+		"PATH=" + binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"HOME=" + homeDir,
+		"FAKE_TMUX_LOG=" + tmuxLog,
+		"FAKE_TMUX_SESSIONS=" + sessions,
+		"FAKE_TMUX_SOCKET=/tmp/af-clean-test.sock",
+	}
+	out, err := cmd.CombinedOutput()
+	logBytes, readErr := os.ReadFile(tmuxLog)
+	if readErr != nil && !os.IsNotExist(readErr) {
+		t.Fatalf("read fake tmux log: %v", readErr)
+	}
+	return cleanScriptResult{
+		output: string(out),
+		log:    string(logBytes),
+		err:    err,
+		work:   filepath.Join(workDir, "worktree-live"),
+		home:   filepath.Join(homeDir, ".agent-factory"),
+	}
+}
+
+func TestCleanScriptsRequireExplicitSocketOrConfirmation(t *testing.T) {
+	result := runCleanScript(t, "clean.sh", nil, "")
+	if result.err == nil {
+		t.Fatal("clean.sh must refuse an implicit default tmux socket")
+	}
+	if !strings.Contains(result.output, "-L <name>, -S <path>, or --yes-really") {
+		t.Fatalf("refusal must explain the safe choices, got: %s", result.output)
+	}
+	if result.log != "" {
+		t.Fatalf("refusal must happen before tmux is invoked, got log: %s", result.log)
+	}
+}
+
+func TestCleanScriptsRefuseLiveAfSessions(t *testing.T) {
+	for _, script := range []string{"clean.sh", "clean_hard.sh"} {
+		t.Run(script, func(t *testing.T) {
+			result := runCleanScript(t, script, []string{"-L", "isolated"}, "other\naf_deadbeef_live\n")
+			if result.err == nil {
+				t.Fatalf("%s must refuse a socket containing an af session", script)
+			}
+			if !strings.Contains(result.output, "af_deadbeef_live") {
+				t.Fatalf("refusal must name the live af session, got: %s", result.output)
+			}
+			if strings.Contains(result.log, "kill-server") {
+				t.Fatalf("%s reached server teardown despite a live af session: %s", script, result.log)
+			}
+			for _, path := range []string{result.work, result.home} {
+				if _, err := os.Stat(path); err != nil {
+					t.Errorf("%s removed %s after refusing cleanup: %v", script, path, err)
+				}
+			}
+		})
+	}
+}
+
+func TestCleanScriptUsesOnlyExplicitSocketForTeardown(t *testing.T) {
+	t.Run("named socket", func(t *testing.T) {
+		result := runCleanScript(t, "clean.sh", []string{"-L", "isolated"}, "other\n")
+		if result.err != nil {
+			t.Fatalf("socket-scoped cleanup failed: %v\n%s", result.err, result.output)
+		}
+		if !strings.Contains(result.log, "-L isolated kill-server") {
+			t.Fatalf("teardown did not retain the named socket: %s", result.log)
+		}
+	})
+
+	t.Run("confirmed default resolves path", func(t *testing.T) {
+		result := runCleanScript(t, "clean.sh", []string{"--yes-really"}, "other\n")
+		if result.err != nil {
+			t.Fatalf("confirmed cleanup failed: %v\n%s", result.err, result.output)
+		}
+		if !strings.Contains(result.log, "-S /tmp/af-clean-test.sock kill-server") {
+			t.Fatalf("default teardown did not resolve to an explicit socket path: %s", result.log)
+		}
+	})
+}

--- a/scripts/clean_scripts_test.go
+++ b/scripts/clean_scripts_test.go
@@ -118,6 +118,10 @@ func TestCleanScriptUsesOnlyExplicitSocketForTeardown(t *testing.T) {
 	})
 
 	t.Run("confirmed default resolves path", func(t *testing.T) {
+		// The first probe intentionally has no socket arguments. This also pins
+		// Bash 3.2 compatibility: under `set -u`, expanding an empty array aborts
+		// before fake tmux runs, which used to make macOS mistake the live default
+		// server for a missing one.
 		result := runCleanScript(t, "clean.sh", []string{"--yes-really"}, "other\n")
 		if result.err != nil {
 			t.Fatalf("confirmed cleanup failed: %v\n%s", result.err, result.output)

--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -16,12 +16,25 @@ import (
 
 	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
 	"github.com/sachiniyer/agent-factory/internal/testguard"
+	"github.com/sachiniyer/agent-factory/internal/tmuxguard"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session/git"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
 func TestMain(m *testing.M) {
+	// The generated Claude plugin points at os.Executable so its regression
+	// test exercises the actual configured hook process. Under go test that is
+	// this package binary; mirror main's hidden-command dispatch to the same
+	// native handler before setting up the rest of the session test harness.
+	if len(os.Args) == 2 && os.Args[1] == "hook-guard-tmux" {
+		if err := tmuxguard.Run(os.Stdin, os.Stdout); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
 	// #837: fail the package loudly if any test touches the real config.json.
 	verifyRealConfig := testguard.ConfigTripwire()
 	// #1056: fail loudly if a test leaks an af_ session onto the ambient tmux

--- a/session/plugin.go
+++ b/session/plugin.go
@@ -17,6 +17,27 @@ const pluginManifest = `{
 }
 `
 
+// pluginHooks is loaded by Claude Code from an injected plugin's
+// hooks/hooks.json. Matching every Bash call is deliberate: the native handler
+// must see compound commands and wrapper forms, not just a narrow permission
+// pattern that an agent can accidentally route around (#2175).
+const pluginHooks = `{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if [ ! -x \"${CLAUDE_PLUGIN_ROOT}/hooks/guard-tmux.sh\" ]; then echo 'Agent Factory tmux safety guard is unavailable; refusing the Bash command.' >&2; exit 2; fi; \"${CLAUDE_PLUGIN_ROOT}/hooks/guard-tmux.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}
+`
+
 // pluginCommands defines the command files to write into the plugin directory.
 // ensurePluginDir writes this map to disk on every session launch and prunes any
 // .md file that isn't listed here, so adding/removing/editing a skill is as simple
@@ -39,8 +60,9 @@ var pluginCommands = map[string]string{
 		"User request (may be empty): $ARGUMENTS\n",
 }
 
-// ensurePluginDir creates the plugin directory with manifest and slash command
-// files and returns its path. The directory is located at <config-dir>/plugin/.
+// ensurePluginDir creates the plugin directory with its manifest, slash command,
+// and PreToolUse safety hook, then returns its path. The directory is located at
+// <config-dir>/plugin/.
 //
 // This is called on every claude-based session launch (see injectSystemPrompt),
 // and rewrites the manifest, writes every file in pluginCommands, and prunes any
@@ -54,6 +76,7 @@ func ensurePluginDir() (string, error) {
 
 	pluginDir := filepath.Join(configDir, "plugin")
 	commandsDir := filepath.Join(pluginDir, "commands")
+	hooksDir := filepath.Join(pluginDir, "hooks")
 	manifestDir := filepath.Join(pluginDir, ".claude-plugin")
 
 	if err := os.MkdirAll(commandsDir, 0755); err != nil {
@@ -62,10 +85,31 @@ func ensurePluginDir() (string, error) {
 	if err := os.MkdirAll(manifestDir, 0755); err != nil {
 		return "", err
 	}
+	if err := os.MkdirAll(hooksDir, 0755); err != nil {
+		return "", err
+	}
 
 	// Write plugin manifest
 	manifestPath := filepath.Join(manifestDir, "plugin.json")
 	if err := config.AtomicWriteFile(manifestPath, []byte(pluginManifest), 0644); err != nil {
+		return "", err
+	}
+
+	// The hook delegates JSON parsing and shell-command validation to this af
+	// binary, avoiding optional runtime dependencies such as jq or Python. Its
+	// wrapper converts a missing/broken helper into exit 2, which Claude treats
+	// as blocking: guard failure must fail closed rather than silently permit a
+	// host-wide teardown.
+	executable, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	hooksPath := filepath.Join(hooksDir, "hooks.json")
+	if err := config.AtomicWriteFile(hooksPath, []byte(pluginHooks), 0644); err != nil {
+		return "", err
+	}
+	guardPath := filepath.Join(hooksDir, "guard-tmux.sh")
+	if err := config.AtomicWriteFile(guardPath, []byte(pluginTmuxGuardScript(executable)), 0755); err != nil {
 		return "", err
 	}
 
@@ -96,4 +140,19 @@ func ensurePluginDir() (string, error) {
 	}
 
 	return pluginDir, nil
+}
+
+func pluginTmuxGuardScript(executable string) string {
+	return "#!/bin/sh\n" +
+		"guard_binary=" + shellQuote(executable) + "\n" +
+		"if [ ! -x \"$guard_binary\" ]; then\n" +
+		"  echo 'Agent Factory tmux safety guard binary is unavailable; refusing the Bash command.' >&2\n" +
+		"  exit 2\n" +
+		"fi\n" +
+		"\"$guard_binary\" hook-guard-tmux\n" +
+		"status=$?\n" +
+		"if [ \"$status\" -ne 0 ]; then\n" +
+		"  echo 'Agent Factory tmux safety guard failed; refusing the Bash command.' >&2\n" +
+		"  exit 2\n" +
+		"fi\n"
 }

--- a/session/plugin_test.go
+++ b/session/plugin_test.go
@@ -1,14 +1,105 @@
 package session
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
 	"github.com/sachiniyer/agent-factory/internal/testguard"
 )
+
+// TestInjectedClaudePluginGuardsBroadTmuxKills starts at injectSystemPrompt,
+// the production launch seam, then runs the handler Claude discovers through
+// that injected plugin. A unit test of the guard alone would stay green if the
+// plugin stopped installing it and would not protect a real af session (#2175).
+func TestInjectedClaudePluginGuardsBroadTmuxKills(t *testing.T) {
+	afHome := testguard.SocketTempDir(t)
+	t.Setenv("AGENT_FACTORY_HOME", afHome)
+
+	launch := injectSystemPrompt("claude")
+	if !strings.Contains(launch, "--plugin-dir") {
+		t.Fatalf("production Claude launch is missing plugin injection: %q", launch)
+	}
+
+	type hookHandler struct {
+		Type    string `json:"type"`
+		Command string `json:"command"`
+	}
+	type hookGroup struct {
+		Matcher string        `json:"matcher"`
+		Hooks   []hookHandler `json:"hooks"`
+	}
+	var cfg struct {
+		Hooks map[string][]hookGroup `json:"hooks"`
+	}
+	hooksPath := filepath.Join(afHome, "plugin", "hooks", "hooks.json")
+	raw, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("injected Claude plugin did not install its PreToolUse hook: %v", err)
+	}
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("parse generated hook config: %v", err)
+	}
+
+	var handler hookHandler
+	for _, group := range cfg.Hooks["PreToolUse"] {
+		if group.Matcher == "Bash" && len(group.Hooks) == 1 {
+			handler = group.Hooks[0]
+			break
+		}
+	}
+	if handler.Type != "command" || handler.Command == "" {
+		t.Fatalf("generated plugin has no Bash PreToolUse command handler: %s", raw)
+	}
+
+	runHook := func(shellCommand string) string {
+		t.Helper()
+		input, err := json.Marshal(map[string]any{
+			"hook_event_name": "PreToolUse",
+			"tool_name":       "Bash",
+			"tool_input": map[string]any{
+				"command": shellCommand,
+			},
+		})
+		if err != nil {
+			t.Fatalf("marshal hook input: %v", err)
+		}
+
+		cmd := exec.Command("sh", "-c", handler.Command)
+		cmd.Env = append(os.Environ(), "CLAUDE_PLUGIN_ROOT="+filepath.Join(afHome, "plugin"))
+		cmd.Stdin = bytes.NewReader(input)
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("configured PreToolUse handler failed for %q: %v\nstderr: %s", shellCommand, err, stderr.String())
+		}
+		return strings.TrimSpace(stdout.String())
+	}
+
+	blocked := runHook("tmux kill-server")
+	var decision struct {
+		HookSpecificOutput struct {
+			PermissionDecision string `json:"permissionDecision"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal([]byte(blocked), &decision); err != nil {
+		t.Fatalf("bare kill-server did not return a structured denial: %q (%v)", blocked, err)
+	}
+	if decision.HookSpecificOutput.PermissionDecision != "deny" {
+		t.Fatalf("bare kill-server must be denied, got: %s", blocked)
+	}
+
+	if allowed := runHook("tmux -L af-test-guard kill-server"); allowed != "" {
+		t.Fatalf("socket-scoped kill-server must be allowed, got: %s", allowed)
+	}
+}
 
 // TestEnsurePluginDir_ConcurrentStalePrune is a regression test for issues
 // #321 / #343: when two sessions start at the same time, both ReadDir the


### PR DESCRIPTION
Closes #2175

## Scope
This PR protects **Claude Code sessions only**. It injects a Claude `PreToolUse` hook through the af-managed plugin (`CLAUDE_PLUGIN_ROOT` / `hooks/hooks.json`). Codex, Gemini, Amp, Aider, and OpenCode sessions are not covered by this change; coverage for those agents is tracked separately in #2184.

## What changed
- Fail closed on malformed hook input or unavailable guard binaries.
- Reject bare `tmux kill-server` and `pkill tmux`, including shell wrappers, redirections, and compound commands.
- Allow explicitly socket-scoped tmux teardown.
- Harden `scripts/clean.sh` and `scripts/clean_hard.sh` with explicit socket/confirmation requirements and live `af_*` session checks.
- Document the prohibition in `CLAUDE.md` and test the real injected plugin path.

## Root cause
An agent-issued bare `tmux kill-server` can terminate every live af session on the host; documentation alone is routable around.

## Executable-path behavior
`ensurePluginDir` runs on every Claude session launch and rewrites `hooks/hooks.json` and `guard-tmux.sh`, pinning the current `os.Executable()` path. A normal `dev-install.sh` replacement at the same executable path is therefore picked up by subsequent launches. Existing in-flight sessions retain the path captured when they launched; if that path is removed or becomes non-executable, the hook intentionally fails closed and blocks Bash rather than permitting an unguarded teardown.

## Validation
- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- Bash 3.2 default-socket cleanup repro in an isolated container

— Captain Claude