### PR TITLE
fix(daemon): preserve tmux sessions across daemon restart

### DIFF
--- a/commands/autoupdate.go
+++ b/commands/autoupdate.go
@@ -170,20 +170,30 @@ func autoUpdateForChannel(channel string, checkTimeout, downloadBudget time.Dura
 			return fmt.Errorf("failed to write new binary: %w", err)
 		}
 
+		unitRefreshErr := refreshAutostartUnitFn()
+		if unitRefreshErr != nil {
+			// The new binary is already on disk, but stopping through a stale
+			// control-group unit is worse than leaving the old daemon running:
+			// it can take every daemon-spawned tmux pane with it (#2176).
+			log.WarningLog.Printf("auto-update: updated to %s but left the running daemon alone because its autostart unit could not be made restart-safe: %v; run af daemon install, then af daemon restart", latestVersion, unitRefreshErr)
+		}
+
 		// Same rationale as `af upgrade` (#498/#1386): restart the running daemon
 		// immediately from the freshly written binary. Quiet on the no-daemon path
 		// since this runs on every launch. Pre-#501 daemons don't speak the
 		// Shutdown RPC; RequestShutdown falls back to PID-file-based SIGTERM (#504).
-		result, restartErr := restartDaemonFromPath(resolvedPath)
-		switch {
-		case restartErr != nil:
-			log.WarningLog.Printf("auto-update: updated to %s but failed to restart daemon: %v", latestVersion, restartErr)
-		case result == daemon.ShutdownViaRPC:
-			log.InfoLog.Printf("auto-update: updated to %s and restarted running daemon", latestVersion)
-		case result == daemon.ShutdownViaSIGTERM:
-			log.InfoLog.Printf("auto-update: updated to %s and restarted pre-#501 running daemon via SIGTERM fallback", latestVersion)
-		default:
-			log.InfoLog.Printf("auto-update: updated to %s", latestVersion)
+		if unitRefreshErr == nil {
+			result, restartErr := restartDaemonFromPath(resolvedPath)
+			switch {
+			case restartErr != nil:
+				log.WarningLog.Printf("auto-update: updated to %s but failed to restart daemon: %v", latestVersion, restartErr)
+			case result == daemon.ShutdownViaRPC:
+				log.InfoLog.Printf("auto-update: updated to %s and restarted running daemon", latestVersion)
+			case result == daemon.ShutdownViaSIGTERM:
+				log.InfoLog.Printf("auto-update: updated to %s and restarted pre-#501 running daemon via SIGTERM fallback", latestVersion)
+			default:
+				log.InfoLog.Printf("auto-update: updated to %s", latestVersion)
+			}
 		}
 		// The binary on disk is now latestVersion; record it as such so the
 		// re-exec'd process sees a fresh, matching entry and skips its own

--- a/commands/autoupdate_test.go
+++ b/commands/autoupdate_test.go
@@ -46,6 +46,10 @@ func TestMain(m *testing.M) {
 	// developer's real one. Sandbox AFTER the tripwire snapshots the real
 	// environment, BEFORE logging resolves its file path.
 	restoreHome := testguard.SandboxHome()
+	// Upgrade tests replace binaries in temp dirs and must never inspect or
+	// rewrite the developer's real autostart unit. Individual migration tests
+	// override this seam explicitly.
+	refreshAutostartUnitFn = func() error { return nil }
 	// autoUpdate() calls log.ErrorLog.Printf, which panics if logging has not
 	// been initialized. Initialize once for the whole package test binary.
 	aflog.Initialize(false)
@@ -332,6 +336,7 @@ func TestAutoUpdateRecordsCheckOnDownloadFailure(t *testing.T) {
 func TestAutoUpdateCallsShutdownAfterBinarySwap(t *testing.T) {
 	withTestHome(t)
 	infoBuf, errBuf := captureLogs(t)
+	refreshCalls := stubAutostartRefresh(t, nil)
 
 	tempBin := tempBinPath(t)
 	if err := os.WriteFile(tempBin, []byte("old-binary"), 0755); err != nil {
@@ -380,6 +385,9 @@ func TestAutoUpdateCallsShutdownAfterBinarySwap(t *testing.T) {
 	if shutdownCalls != 1 {
 		t.Fatalf("expected one Shutdown call, got %d", shutdownCalls)
 	}
+	if *refreshCalls != 1 {
+		t.Fatalf("expected one installed-unit refresh before shutdown, got %d", *refreshCalls)
+	}
 	if respawnCalls != 1 {
 		t.Fatalf("expected the daemon respawn check to run once after shutdown, got %d", respawnCalls)
 	}
@@ -402,6 +410,71 @@ func TestAutoUpdateCallsShutdownAfterBinarySwap(t *testing.T) {
 	if strings.Contains(errBuf.String(), "updating from") {
 		t.Fatalf("'updating from' must not be logged at ERROR level, got:\n%s",
 			errBuf.String())
+	}
+}
+
+func TestAutoUpdateRefreshFailureSkipsDaemonRestart(t *testing.T) {
+	withTestHome(t)
+	_, errBuf := captureLogs(t)
+	previousWarningOut := aflog.WarningLog.Writer()
+	aflog.WarningLog.SetOutput(errBuf)
+	t.Cleanup(func() { aflog.WarningLog.SetOutput(previousWarningOut) })
+	refreshCalls := stubAutostartRefresh(t, errors.New("daemon-reload failed"))
+
+	tempBin := tempBinPath(t)
+	if err := os.WriteFile(tempBin, []byte("old-binary"), 0755); err != nil {
+		t.Fatalf("seed binary: %v", err)
+	}
+
+	prevGOOS := runtimeGOOS
+	prevFetch := fetchLatestReleaseTagFn
+	prevDownload := downloadBinaryFn
+	prevVersion := version
+	prevExe := osExecutableFn
+	prevShutdown := requestDaemonShutdownFn
+	prevRespawn := respawnDaemonFn
+	t.Cleanup(func() {
+		runtimeGOOS = prevGOOS
+		fetchLatestReleaseTagFn = prevFetch
+		downloadBinaryFn = prevDownload
+		version = prevVersion
+		osExecutableFn = prevExe
+		requestDaemonShutdownFn = prevShutdown
+		respawnDaemonFn = prevRespawn
+	})
+
+	runtimeGOOS = "linux"
+	version = "1.0.0"
+	fetchLatestReleaseTagFn = func(string, time.Duration) (string, error) { return "v1.0.1", nil }
+	downloadBinaryFn = func(string, time.Duration) ([]byte, error) { return []byte("new-binary"), nil }
+	osExecutableFn = func() (string, error) { return tempBin, nil }
+	shutdownCalls := 0
+	requestDaemonShutdownFn = func() (daemon.ShutdownResult, error) {
+		shutdownCalls++
+		return daemon.ShutdownViaRPC, nil
+	}
+	respawnDaemonFn = func(string) (respawnResult, error) {
+		t.Fatal("respawn must not run when systemd may still hold the destructive legacy unit")
+		return respawnResult{}, nil
+	}
+
+	installed, err := runAutoUpdate()
+	if err != nil {
+		t.Fatalf("autoUpdate: %v", err)
+	}
+	if installed != "1.0.1" {
+		t.Fatalf("installed version = %q, want 1.0.1", installed)
+	}
+	if *refreshCalls != 1 {
+		t.Fatalf("unit refresh calls = %d, want 1", *refreshCalls)
+	}
+	if shutdownCalls != 0 {
+		t.Fatalf("shutdown calls = %d, want 0 after a failed safety refresh", shutdownCalls)
+	}
+	for _, want := range []string{"left the running daemon alone", "daemon-reload failed", "af daemon install"} {
+		if !strings.Contains(errBuf.String(), want) {
+			t.Fatalf("auto-update warning missing %q:\n%s", want, errBuf.String())
+		}
 	}
 }
 

--- a/commands/daemoncmd.go
+++ b/commands/daemoncmd.go
@@ -263,6 +263,12 @@ daemon is running, this command exits successfully without starting one.`,
 		if err != nil {
 			return fmt.Errorf("failed to resolve executable path: %w", err)
 		}
+		// Existing Linux installs carry their rendered unit on disk. Make that
+		// unit restart-safe before the Shutdown RPC: refreshing it afterwards is
+		// too late, because systemd may already have cgroup-killed tmux (#2176).
+		if err := refreshAutostartUnitFn(); err != nil {
+			return fmt.Errorf("refusing to restart through an unsafe daemon autostart unit: %w", err)
+		}
 
 		result, err := restartDaemonFromPath(resolvedPath)
 		if err != nil {
@@ -308,6 +314,7 @@ var (
 	ensureDaemonFromPathFn      = daemon.EnsureDaemonFromPath
 	waitForShutdownCompletionFn = daemon.WaitForShutdownCompletion
 	autostartUnitExecPathFn     = daemon.AutostartUnitExecPath
+	refreshAutostartUnitFn      = daemon.RefreshAutostartUnit
 	configDirFn                 = config.GetConfigDir
 )
 

--- a/commands/upgrade.go
+++ b/commands/upgrade.go
@@ -249,6 +249,17 @@ func runUpgrade(out, errOut io.Writer, downloadURL string, noRestart bool) error
 		return fmt.Errorf("failed to write new binary: %w", err)
 	}
 
+	if err := refreshAutostartUnitFn(); err != nil {
+		fmt.Fprintln(out, "Upgraded successfully!")
+		fmt.Fprintf(errOut, "The daemon autostart unit could not be made restart-safe: %v\n", err)
+		if noRestart {
+			fmt.Fprintln(errOut, "The running daemon was left alone as requested, but the installed unit still needs repair. Run `af daemon install` before restarting it.")
+		} else {
+			fmt.Fprintln(errOut, "The running daemon was left alone because restarting through the stale unit could stop live tmux sessions. Run `af daemon install`, then `af daemon restart`.")
+		}
+		return nil
+	}
+
 	if noRestart {
 		fmt.Fprintln(out, "Upgraded successfully! Left the running daemon alone (--no-restart); it keeps executing the old binary until you run `af daemon restart`.")
 		return nil

--- a/commands/upgrade_restart_test.go
+++ b/commands/upgrade_restart_test.go
@@ -71,6 +71,18 @@ func stubShutdown(t *testing.T, result daemon.ShutdownResult, err error) *int {
 	return calls
 }
 
+func stubAutostartRefresh(t *testing.T, err error) *int {
+	t.Helper()
+	previous := refreshAutostartUnitFn
+	calls := new(int)
+	refreshAutostartUnitFn = func() error {
+		*calls++
+		return err
+	}
+	t.Cleanup(func() { refreshAutostartUnitFn = previous })
+	return calls
+}
+
 // TestRespawnAfterUpgrade_LeavesOtherHomesUnitAlone is the #1950 repro, from
 // that issue's ready-made failing test (its home gate is stubbed here so it
 // cannot read the host's real unit).
@@ -166,6 +178,7 @@ func TestRespawnAfterUpgrade_UnprovableHomeLeavesUnitAlone(t *testing.T) {
 func TestUpgrade_NoRestartSkipsRestart(t *testing.T) {
 	binPath, url := upgradeHarness(t)
 	shutdownCalls := stubShutdown(t, daemon.ShutdownViaRPC, nil)
+	refreshCalls := stubAutostartRefresh(t, nil)
 	stubDaemonHealth(t, daemon.HealthStatus{})
 
 	var out, errOut bytes.Buffer
@@ -175,6 +188,9 @@ func TestUpgrade_NoRestartSkipsRestart(t *testing.T) {
 
 	if *shutdownCalls != 0 {
 		t.Fatalf("shutdown calls = %d, want 0 (--no-restart must leave the daemon alone)", *shutdownCalls)
+	}
+	if *refreshCalls != 1 {
+		t.Fatalf("unit refresh calls = %d, want 1 (--no-restart still has to repair the installed unit on upgrade)", *refreshCalls)
 	}
 	got, err := os.ReadFile(binPath)
 	if err != nil {
@@ -187,6 +203,58 @@ func TestUpgrade_NoRestartSkipsRestart(t *testing.T) {
 	// "you are running the new version" either.
 	if !strings.Contains(out.String(), "--no-restart") {
 		t.Fatalf("stdout must say the daemon was deliberately left on the old binary.\ngot=%q", out.String())
+	}
+}
+
+func TestUpgradeRefreshesAutostartBeforeStoppingDaemon(t *testing.T) {
+	_, url := upgradeHarness(t)
+	stubDaemonHealth(t, daemon.HealthStatus{})
+	stubRespawnCollaborators(t, false, nil)
+
+	previousRefresh := refreshAutostartUnitFn
+	previousShutdown := requestDaemonShutdownFn
+	t.Cleanup(func() {
+		refreshAutostartUnitFn = previousRefresh
+		requestDaemonShutdownFn = previousShutdown
+	})
+	var sequence []string
+	refreshAutostartUnitFn = func() error {
+		sequence = append(sequence, "refresh")
+		return nil
+	}
+	requestDaemonShutdownFn = func() (daemon.ShutdownResult, error) {
+		sequence = append(sequence, "shutdown")
+		return daemon.ShutdownViaRPC, nil
+	}
+
+	if err := runUpgrade(&bytes.Buffer{}, &bytes.Buffer{}, url, false); err != nil {
+		t.Fatalf("runUpgrade: %v", err)
+	}
+	if len(sequence) != 2 || sequence[0] != "refresh" || sequence[1] != "shutdown" {
+		t.Fatalf("upgrade sequence = %v, want [refresh shutdown]; the legacy unit must be safe before any stop", sequence)
+	}
+}
+
+func TestUpgradeRefreshFailureLeavesDaemonRunning(t *testing.T) {
+	_, url := upgradeHarness(t)
+	refreshCalls := stubAutostartRefresh(t, errors.New("daemon-reload failed"))
+	shutdownCalls := stubShutdown(t, daemon.ShutdownViaRPC, nil)
+	stubDaemonHealth(t, daemon.HealthStatus{})
+
+	var out, errOut bytes.Buffer
+	if err := runUpgrade(&out, &errOut, url, false); err != nil {
+		t.Fatalf("the binary is already installed, so refresh failure should be reported without claiming rollback: %v", err)
+	}
+	if *refreshCalls != 1 {
+		t.Fatalf("unit refresh calls = %d, want 1", *refreshCalls)
+	}
+	if *shutdownCalls != 0 {
+		t.Fatalf("shutdown calls = %d, want 0 when systemd may still hold the destructive legacy unit", *shutdownCalls)
+	}
+	for _, want := range []string{"could not be made restart-safe", "left alone", "af daemon install"} {
+		if !strings.Contains(errOut.String(), want) {
+			t.Fatalf("refresh failure stderr missing %q:\n%s", want, errOut.String())
+		}
 	}
 }
 

--- a/daemon/autostart.go
+++ b/daemon/autostart.go
@@ -22,6 +22,11 @@ import (
 const (
 	autostartUnitName     = "agent-factory-daemon.service"
 	autostartLaunchdLabel = "com.agent-factory.daemon"
+	// autostartSystemdMarker lets the daemon distinguish its direct service
+	// process from descendants that merely inherited the unit's environment.
+	// session/tmux checks it together with SYSTEMD_EXEC_PID before asking the
+	// user manager to put a newly-created tmux server in its own scope (#2176).
+	autostartSystemdMarker = "AGENT_FACTORY_SYSTEMD_UNIT"
 )
 
 // Every launchctl call af makes names the gui/<uid> domain explicitly, and
@@ -99,6 +104,12 @@ func formatSystemdEnvLine(name, value string) string {
 // AGENT_FACTORY_HOME is captured for the same reason when the installing
 // shell has it set: without it the unit's daemon would serve the default
 // home instead of the custom one (#782).
+//
+// KillMode=process is intentional. mixed sends SIGTERM only to the main
+// process but still SIGKILLs every remaining cgroup process when that main
+// process exits, so it kills exactly the persistent tmux server #2176 needs to
+// protect. New servers leave the service cgroup through systemd-run; process
+// also protects servers an older daemon already placed there before upgrade.
 func systemdAutostartUnit(execPath, pathEnv, shellEnv, agentFactoryHome string) string {
 	envLines := formatSystemdEnvLine("PATH", pathEnv) + "\n" + formatSystemdEnvLine("SHELL", shellEnv)
 	if agentFactoryHome != "" {
@@ -108,6 +119,7 @@ func systemdAutostartUnit(execPath, pathEnv, shellEnv, agentFactoryHome string) 
 Description=Agent Factory daemon (task scheduler + autoyes)
 
 [Service]
+KillMode=process
 ExecStart=%s --daemon
 Restart=on-failure
 RestartSec=5
@@ -115,7 +127,7 @@ RestartSec=5
 
 [Install]
 WantedBy=default.target
-`, quoteExecStartPath(execPath), envLines)
+`, quoteExecStartPath(execPath), formatSystemdEnvLine(autostartSystemdMarker, autostartUnitName)+"\n"+envLines)
 }
 
 // launchdAutostartPlist renders the launchd agent that keeps the daemon
@@ -319,6 +331,110 @@ func AutostartInstalled() bool {
 	}
 	_, err = os.Stat(path)
 	return err == nil
+}
+
+// RefreshAutostartUnit makes an already-installed Linux unit safe before an
+// upgrade or explicit restart stops its daemon (#2176). Older installs carry
+// the rendered unit on disk, so changing systemdAutostartUnit alone does
+// nothing for the machines at risk. Rewrite only KillMode, preserving the
+// captured executable, environment, and #2168's planned StartLimit policy,
+// then reload the user manager before a caller is allowed to restart.
+//
+// The reload runs even when the file already contains the safe directive. A
+// prior reload may have failed after the atomic write, leaving systemd's
+// in-memory unit stale; treating the on-disk text as sufficient would make the
+// next restart destructive again.
+//
+// launchd has no systemd cgroup KillMode equivalent. Its plist is deliberately
+// left byte-identical on Darwin rather than pretending this Linux fix applies.
+func RefreshAutostartUnit() error {
+	if autostartGOOS != "linux" {
+		return nil
+	}
+
+	path, err := autostartUnitFilePath()
+	if err != nil {
+		return fmt.Errorf("failed to resolve daemon autostart unit: %w", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to read daemon autostart unit %s: %w", path, err)
+	}
+
+	content, changed, err := ensureSystemdServiceDirective(string(data), "KillMode", "process")
+	if err != nil {
+		return fmt.Errorf("cannot make daemon autostart unit restart-safe: %w", err)
+	}
+	if changed {
+		if err := config.AtomicWriteFile(path, []byte(content), 0644); err != nil {
+			return fmt.Errorf("failed to rewrite daemon autostart unit %s: %w", path, err)
+		}
+	}
+	if out, err := autostartUnitCommand("systemctl", "--user", "daemon-reload"); err != nil {
+		return fmt.Errorf("failed to reload rewritten daemon autostart unit: %w\n%s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// ensureSystemdServiceDirective returns content with exactly one key=value in
+// [Service]. Other sections and directives remain byte-for-byte and in order;
+// this is a targeted safety migration, not a re-render that could overwrite an
+// install's captured PATH, home, executable, or future StartLimit settings.
+func ensureSystemdServiceDirective(content, key, value string) (string, bool, error) {
+	lines := strings.Split(content, "\n")
+	inService := false
+	serviceFound := false
+	count := 0
+	alreadyCorrect := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+			inService = trimmed == "[Service]"
+			serviceFound = serviceFound || inService
+			continue
+		}
+		if !inService {
+			continue
+		}
+		name, got, found := strings.Cut(trimmed, "=")
+		if found && strings.TrimSpace(name) == key {
+			count++
+			alreadyCorrect = strings.TrimSpace(got) == value
+		}
+	}
+	if !serviceFound {
+		return "", false, fmt.Errorf("unit has no [Service] section")
+	}
+	if count == 1 && alreadyCorrect {
+		return content, false, nil
+	}
+
+	out := make([]string, 0, len(lines)+1)
+	inService = false
+	inserted := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+			inService = trimmed == "[Service]"
+			out = append(out, line)
+			if inService && !inserted {
+				out = append(out, key+"="+value)
+				inserted = true
+			}
+			continue
+		}
+		if inService {
+			name, _, found := strings.Cut(trimmed, "=")
+			if found && strings.TrimSpace(name) == key {
+				continue
+			}
+		}
+		out = append(out, line)
+	}
+	return strings.Join(out, "\n"), true, nil
 }
 
 // AutostartUnitServesHome reports whether the INSTALLED autostart unit's daemon

--- a/daemon/autostart_restart_test.go
+++ b/daemon/autostart_restart_test.go
@@ -228,6 +228,122 @@ func TestAutostartInstalledUnsupportedGOOS(t *testing.T) {
 	}
 }
 
+// TestRefreshAutostartUnitRewritesLegacyLinuxUnit is the upgrade half of
+// #2176: changing the renderer cannot repair the unit an existing install
+// already has on disk. The migration is deliberately surgical so #2168's
+// StartLimit and exit-status policy can land in the same template unchanged.
+func TestRefreshAutostartUnitRewritesLegacyLinuxUnit(t *testing.T) {
+	dir := withAutostartTestEnv(t, "linux")
+	calls := stubAutostartUnitCommand(t, nil)
+	unitPath := filepath.Join(dir, autostartUnitName)
+	legacy := "[Unit]\n" +
+		"Description=Agent Factory daemon\n" +
+		"StartLimitIntervalSec=60\n" +
+		"StartLimitBurst=5\n\n" +
+		"[Service]\n" +
+		"ExecStart=\"/opt/af\" --daemon\n" +
+		"Restart=on-failure\n" +
+		"RestartPreventExitStatus=78\n" +
+		"Environment=PATH=/custom/bin\n\n" +
+		"[Install]\nWantedBy=default.target\n"
+	if err := os.WriteFile(unitPath, []byte(legacy), 0644); err != nil {
+		t.Fatalf("seed legacy unit: %v", err)
+	}
+
+	if err := RefreshAutostartUnit(); err != nil {
+		t.Fatalf("RefreshAutostartUnit: %v", err)
+	}
+	got, err := os.ReadFile(unitPath)
+	if err != nil {
+		t.Fatalf("read refreshed unit: %v", err)
+	}
+	text := string(got)
+	if strings.Count(text, "KillMode=process\n") != 1 {
+		t.Fatalf("refreshed unit must contain exactly one safe KillMode:\n%s", text)
+	}
+	for _, preserved := range []string{
+		"StartLimitIntervalSec=60",
+		"StartLimitBurst=5",
+		"RestartPreventExitStatus=78",
+		"ExecStart=\"/opt/af\" --daemon",
+		"Environment=PATH=/custom/bin",
+	} {
+		if !strings.Contains(text, preserved) {
+			t.Errorf("migration dropped future/existing directive %q:\n%s", preserved, text)
+		}
+	}
+	if !calledWith(*calls, "systemctl", "--user", "daemon-reload") {
+		t.Fatalf("rewritten unit was not reloaded; calls=%v", *calls)
+	}
+}
+
+func TestRefreshAutostartUnitReplacesUnsafeAndDuplicateKillModes(t *testing.T) {
+	dir := withAutostartTestEnv(t, "linux")
+	stubAutostartUnitCommand(t, nil)
+	unitPath := filepath.Join(dir, autostartUnitName)
+	legacy := "[Unit]\nDescription=x\n\n[Service]\nKillMode=mixed\nExecStart=/opt/af --daemon\nKillMode=control-group\n"
+	if err := os.WriteFile(unitPath, []byte(legacy), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := RefreshAutostartUnit(); err != nil {
+		t.Fatalf("RefreshAutostartUnit: %v", err)
+	}
+	got, err := os.ReadFile(unitPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Count(string(got), "KillMode=") != 1 || !strings.Contains(string(got), "KillMode=process\n") {
+		t.Fatalf("unsafe/duplicate KillMode directives survived:\n%s", got)
+	}
+}
+
+func TestRefreshAutostartUnitReloadsAlreadySafeUnit(t *testing.T) {
+	dir := withAutostartTestEnv(t, "linux")
+	calls := stubAutostartUnitCommand(t, nil)
+	unitPath := filepath.Join(dir, autostartUnitName)
+	unit := "[Service]\nKillMode=process\nExecStart=/opt/af --daemon\n"
+	if err := os.WriteFile(unitPath, []byte(unit), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := RefreshAutostartUnit(); err != nil {
+		t.Fatalf("RefreshAutostartUnit: %v", err)
+	}
+	got, err := os.ReadFile(unitPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != unit {
+		t.Fatalf("already-safe unit changed:\n got=%q\nwant=%q", got, unit)
+	}
+	if !calledWith(*calls, "systemctl", "--user", "daemon-reload") {
+		t.Fatalf("already-safe unit was not reloaded after a possible prior reload failure; calls=%v", *calls)
+	}
+}
+
+func TestRefreshAutostartUnitDarwinLeavesPlistUntouched(t *testing.T) {
+	dir := withAutostartTestEnv(t, "darwin")
+	calls := stubAutostartUnitCommand(t, nil)
+	plistPath := filepath.Join(dir, autostartLaunchdLabel+".plist")
+	plist := "<plist><dict><key>Label</key><string>com.agent-factory.daemon</string></dict></plist>\n"
+	if err := os.WriteFile(plistPath, []byte(plist), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RefreshAutostartUnit(); err != nil {
+		t.Fatalf("RefreshAutostartUnit(darwin): %v", err)
+	}
+	got, err := os.ReadFile(plistPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != plist {
+		t.Fatalf("Linux cgroup migration rewrote the launchd plist:\n got=%q\nwant=%q", got, plist)
+	}
+	if len(*calls) != 0 {
+		t.Fatalf("Darwin refresh invoked a service-manager command: %v", *calls)
+	}
+}
+
 func TestRestartAutostartUnitLinux(t *testing.T) {
 	withAutostartTestEnv(t, "linux")
 	calls := stubAutostartUnitCommand(t, nil)

--- a/daemon/autostart_test.go
+++ b/daemon/autostart_test.go
@@ -15,9 +15,11 @@ func TestSystemdAutostartUnitContent(t *testing.T) {
 Description=Agent Factory daemon (task scheduler + autoyes)
 
 [Service]
+KillMode=process
 ExecStart="/home/user/.local/bin/af" --daemon
 Restart=on-failure
 RestartSec=5
+Environment=AGENT_FACTORY_SYSTEMD_UNIT=agent-factory-daemon.service
 Environment=PATH=/usr/bin:/bin
 Environment=SHELL=/bin/zsh
 
@@ -139,9 +141,11 @@ func TestSystemdAutostartUnitCapturesAgentFactoryHome(t *testing.T) {
 Description=Agent Factory daemon (task scheduler + autoyes)
 
 [Service]
+KillMode=process
 ExecStart="/home/user/.local/bin/af" --daemon
 Restart=on-failure
 RestartSec=5
+Environment=AGENT_FACTORY_SYSTEMD_UNIT=agent-factory-daemon.service
 Environment=PATH=/usr/bin:/bin
 Environment=SHELL=/bin/zsh
 Environment=AGENT_FACTORY_HOME=/srv/af-home

--- a/daemon/watcher.go
+++ b/daemon/watcher.go
@@ -108,6 +108,10 @@ func truncateRunes(s string, maxBytes int) string {
 type watcherSupervisor struct {
 	mu       sync.Mutex
 	watchers map[string]*taskWatcher // task ID → supervised watcher
+	// stopped latches during daemon teardown. The control socket deliberately
+	// stays available while Stop joins in-flight deliveries, so a concurrent
+	// ReloadTasks RPC must not repopulate the map after Stop snapshots it.
+	stopped bool
 
 	// Injection points for tests: loadTasks substitutes fixture task lists,
 	// deliver observes events without spawning sessions, setStatus observes
@@ -182,6 +186,9 @@ func (s *watcherSupervisor) Reload() error {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.stopped {
+		return fmt.Errorf("watch task supervisor is shutting down")
+	}
 
 	var stale []*taskWatcher
 	for id, w := range s.watchers {
@@ -248,6 +255,7 @@ func (s *watcherSupervisor) cleanOrphanQueues(tasks []task.Task) {
 // after the grace. Blocks until all watcher goroutines have returned.
 func (s *watcherSupervisor) Stop() {
 	s.mu.Lock()
+	s.stopped = true
 	stale := make([]*taskWatcher, 0, len(s.watchers))
 	for _, w := range s.watchers {
 		stale = append(stale, w)

--- a/daemon/watcher_test.go
+++ b/daemon/watcher_test.go
@@ -325,6 +325,40 @@ func TestWatcherStopEscalatesToGroupKill(t *testing.T) {
 	})
 }
 
+// TestWatcherStopRejectsConcurrentReload closes the KillMode=process shutdown
+// race: the control socket stays available while watcher Stop joins in-flight
+// deliveries, so a ReloadTasks RPC may already be loading tasks when teardown
+// starts. It must observe the stopped latch before spawning anything, or that
+// late process group would outlive the daemon after systemd stopped sweeping
+// the whole service cgroup (#2176).
+func TestWatcherStopRejectsConcurrentReload(t *testing.T) {
+	dir := t.TempDir()
+	loadStarted := make(chan struct{})
+	releaseLoad := make(chan struct{})
+	s, rec := newTestSupervisor(t, func() ([]task.Task, error) {
+		close(loadStarted)
+		<-releaseLoad
+		return []task.Task{watchTask("stop0001", "echo spawned; sleep 300", dir)}, nil
+	})
+
+	reloadDone := make(chan error, 1)
+	go func() { reloadDone <- s.Reload() }()
+	<-loadStarted
+	s.Stop()
+	close(releaseLoad)
+
+	if err := <-reloadDone; err == nil || !strings.Contains(err.Error(), "shutting down") {
+		t.Fatalf("Reload racing Stop returned %v, want shutting-down error", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if got := rec.eventsSnapshot(); len(got) != 0 {
+		t.Fatalf("Reload spawned a watcher after Stop: events=%v", got)
+	}
+	if ids := s.watchingTaskIDs(); len(ids) != 0 {
+		t.Fatalf("Reload registered watchers after Stop: %v", ids)
+	}
+}
+
 // TestWatcherStderrGoesToTaskLog verifies the script contract's logging leg:
 // stderr appends to the per-task log file.
 func TestWatcherStderrGoesToTaskLog(t *testing.T) {

--- a/integration/daemon_restart_cgroup_test.go
+++ b/integration/daemon_restart_cgroup_test.go
@@ -1,0 +1,212 @@
+package integration_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestDaemonRestartPreservesDaemonSpawnedTmux is the #2176 regression at the
+// lifecycle boundary. It runs only in the disposable testbox (or ephemeral CI):
+// a fake user service manager gives us deterministic cgroup semantics without
+// granting a container access to the host's real cgroups or systemd manager.
+// The daemon, CLI restart, tmux server, pane, unit install, and RPC shutdown are
+// all real.
+//
+// The fake manager models the two facts that matter:
+//   - control-group kills a tmux server inherited from the daemon service;
+//   - a server launched through systemd-run --scope is outside that cgroup.
+//
+// Comparing the server and pane PIDs before and after each restart is stronger
+// than checking only the session name: lost-restore can recreate the same name
+// after killing the original pane, which is the outage this test must catch.
+func TestDaemonRestartPreservesDaemonSpawnedTmux(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("#2176 exercises the Linux/systemd unit; Darwin is covered by the platform-specific launch wrapper tests")
+	}
+	if !disposableLifecycleEnvironment() {
+		t.Skip("destructive daemon lifecycle regression runs only in the container fence or ephemeral CI")
+	}
+
+	fakeBin := t.TempDir()
+	managerLog := filepath.Join(t.TempDir(), "fake-systemd.log")
+	writeScript(t, filepath.Join(fakeBin, "systemctl"), fakeSystemctl)
+	writeScript(t, filepath.Join(fakeBin, "systemd-run"), fakeSystemdRun)
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(t.TempDir(), "xdg"))
+	t.Setenv("AF_FAKE_MANAGER_LOG", managerLog)
+
+	h := newHarness(t)
+	t.Setenv("AF_FAKE_AF_BIN", h.bin)
+
+	h.run("daemon", "install")
+	ready := false
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		pid, ok := daemonPID(h.home)
+		if ok && pidAlive(pid) {
+			info, err := os.Stat(filepath.Join(h.home, "daemon.sock"))
+			if err == nil && info.Mode()&os.ModeSocket != 0 {
+				ready = true
+				break
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if !ready {
+		log, _ := os.ReadFile(managerLog)
+		t.Fatalf("fake-systemd daemon did not become ready:\n%s", log)
+	}
+
+	created := h.createSession("restart-survivor")
+	if created.TmuxName == "" {
+		t.Fatal("daemon-created session reported no tmux name")
+	}
+	t.Setenv("AF_FAKE_TMUX_SESSION", created.TmuxName)
+
+	serverPID, panePID := tmuxProcessIDs(t, created.TmuxName)
+	restartAndAssertTmuxPIDs(t, h, created.TmuxName, serverPID, panePID, managerLog)
+
+	// Fault-inject the old unit policy after proving the generated unit is safe.
+	// The second restart can survive only if the daemon originally created the
+	// tmux server through the transient scope, independently of KillMode.
+	unitPath := filepath.Join(os.Getenv("XDG_CONFIG_HOME"), "systemd", "user", "agent-factory-daemon.service")
+	unit, err := os.ReadFile(unitPath)
+	if err != nil {
+		t.Fatalf("read installed unit: %v", err)
+	}
+	if !strings.Contains(string(unit), "KillMode=process\n") {
+		t.Fatalf("installed unit does not protect existing daemon-owned servers with KillMode=process:\n%s", unit)
+	}
+	unsafeUnit := strings.Replace(string(unit), "KillMode=process\n", "KillMode=control-group\n", 1)
+	if err := os.WriteFile(unitPath, []byte(unsafeUnit), 0644); err != nil {
+		t.Fatalf("fault-inject control-group unit: %v", err)
+	}
+	t.Setenv("AF_FAKE_FORCE_CONTROL_GROUP", "1")
+
+	restartAndAssertTmuxPIDs(t, h, created.TmuxName, serverPID, panePID, managerLog)
+	refreshedUnit, err := os.ReadFile(unitPath)
+	if err != nil {
+		t.Fatalf("read refreshed unit: %v", err)
+	}
+	if !strings.Contains(string(refreshedUnit), "KillMode=process\n") {
+		t.Fatalf("pre-restart migration did not repair the legacy unit:\n%s", refreshedUnit)
+	}
+	log, err := os.ReadFile(managerLog)
+	if err != nil {
+		t.Fatalf("read fake manager log: %v", err)
+	}
+	if !strings.Contains(string(log), "preserved scoped tmux server") {
+		t.Fatalf("forced control-group fault was not demonstrably survived; manager log:\n%s", log)
+	}
+}
+
+func disposableLifecycleEnvironment() bool {
+	if os.Getenv("CI") == "true" {
+		return true
+	}
+	for _, marker := range []string{"/.dockerenv", "/run/.containerenv"} {
+		if _, err := os.Stat(marker); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func daemonPID(home string) (int, bool) {
+	raw, err := os.ReadFile(filepath.Join(home, "daemon.pid"))
+	if err != nil {
+		return 0, false
+	}
+	var pid int
+	if _, err := fmt.Sscanf(string(raw), "%d", &pid); err != nil || pid <= 1 {
+		return 0, false
+	}
+	return pid, true
+}
+
+func tmuxProcessIDs(t *testing.T, name string) (serverPID, panePID int) {
+	t.Helper()
+	out := runExternal(t, "", "tmux", "display-message", "-p", "-t", "="+name+":", "#{pid} #{pane_pid}")
+	if _, err := fmt.Sscanf(strings.TrimSpace(out), "%d %d", &serverPID, &panePID); err != nil {
+		t.Fatalf("parse tmux server/pane pids from %q: %v", out, err)
+	}
+	if serverPID <= 1 || panePID <= 1 {
+		t.Fatalf("unsafe tmux process ids: server=%d pane=%d", serverPID, panePID)
+	}
+	return serverPID, panePID
+}
+
+func restartAndAssertTmuxPIDs(t *testing.T, h *harness, name string, wantServerPID, wantPanePID int, managerLog string) {
+	t.Helper()
+	h.run("daemon", "restart")
+	waitUntil(t, 10*time.Second, "daemon restart to restore control-plane readiness", func() bool {
+		pid, ok := daemonPID(h.home)
+		return ok && pidAlive(pid) && tmuxSessionExists(name)
+	})
+
+	gotServerPID, gotPanePID := tmuxProcessIDs(t, name)
+	if gotServerPID != wantServerPID || gotPanePID != wantPanePID {
+		log, _ := os.ReadFile(managerLog)
+		t.Fatalf("daemon restart replaced the live tmux process tree: server pid %d -> %d, pane pid %d -> %d\nmanager log:\n%s",
+			wantServerPID, gotServerPID, wantPanePID, gotPanePID, log)
+	}
+}
+
+const fakeSystemdRun = `
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --user|--scope|--quiet|--collect|--same-dir) shift ;;
+        --) shift; break ;;
+        *) break ;;
+    esac
+done
+export AF_FAKE_OUTSIDE_DAEMON_CGROUP=1
+exec "$@"
+`
+
+const fakeSystemctl = `
+if [ "${1:-}" = "--user" ]; then
+    shift
+fi
+
+unit_path="${XDG_CONFIG_HOME}/systemd/user/agent-factory-daemon.service"
+
+start_daemon() {
+    sh -c 'AGENT_FACTORY_SYSTEMD_UNIT=agent-factory-daemon.service; SYSTEMD_EXEC_PID=$$; export AGENT_FACTORY_SYSTEMD_UNIT SYSTEMD_EXEC_PID; exec "$1" --daemon' fake-systemd "$AF_FAKE_AF_BIN" >>"$AF_FAKE_MANAGER_LOG" 2>&1 &
+    printf 'started daemon pid=%s\n' "$!" >>"$AF_FAKE_MANAGER_LOG"
+}
+
+case "${1:-}" in
+    daemon-reload)
+        exit 0
+        ;;
+    enable)
+        start_daemon
+        exit 0
+        ;;
+    restart)
+        if [ "${AF_FAKE_FORCE_CONTROL_GROUP:-}" = "1" ] || ! grep -q '^KillMode=process$' "$unit_path"; then
+            server_pid="$(tmux display-message -p -t "=${AF_FAKE_TMUX_SESSION}:" '#{pid}' 2>/dev/null || true)"
+            if [ -n "$server_pid" ] && [ "$server_pid" -gt 1 ]; then
+                if tr '\000' '\n' <"/proc/$server_pid/environ" | grep -q '^AF_FAKE_OUTSIDE_DAEMON_CGROUP=1$'; then
+                    printf 'preserved scoped tmux server pid=%s under control-group restart\n' "$server_pid" >>"$AF_FAKE_MANAGER_LOG"
+                else
+                    printf 'killed daemon-cgroup tmux server pid=%s under control-group restart\n' "$server_pid" >>"$AF_FAKE_MANAGER_LOG"
+                    kill -KILL "$server_pid"
+                fi
+            fi
+        fi
+        start_daemon
+        exit 0
+        ;;
+    *)
+        printf 'unexpected systemctl args: %s\n' "$*" >>"$AF_FAKE_MANAGER_LOG"
+        exit 1
+        ;;
+esac
+`

--- a/session/tmux/pty.go
+++ b/session/tmux/pty.go
@@ -12,19 +12,42 @@ type PtyFactory interface {
 	Close()
 }
 
+// trackedPtyFactory is the production PtyFactory extension used when the
+// caller needs the short-lived PTY command's exit status. Keep it optional so
+// existing injected factories remain source-compatible; Start's test doubles
+// generally model tmux's side effects directly and have no child to wait for.
+type trackedPtyFactory interface {
+	StartTracked(cmd *exec.Cmd) (*os.File, <-chan error, error)
+}
+
 // Pty starts a "real" pseudo-terminal (PTY) using the creack/pty package.
 type Pty struct{}
 
 func (pt Pty) Start(cmd *exec.Cmd) (*os.File, error) {
+	ptmx, _, err := pt.StartTracked(cmd)
+	return ptmx, err
+}
+
+func (pt Pty) StartTracked(cmd *exec.Cmd) (*os.File, <-chan error, error) {
 	ptmx, err := pty.Start(cmd)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	// Reap the child process when it exits to avoid zombie processes.
+	done := make(chan error, 1)
 	go func() {
-		_ = cmd.Wait()
+		done <- cmd.Wait()
+		close(done)
 	}()
-	return ptmx, nil
+	return ptmx, done, nil
+}
+
+func startPtyTracked(factory PtyFactory, cmd *exec.Cmd) (*os.File, <-chan error, error) {
+	if tracked, ok := factory.(trackedPtyFactory); ok {
+		return tracked.StartTracked(cmd)
+	}
+	ptmx, err := factory.Start(cmd)
+	return ptmx, nil, err
 }
 
 func (pt Pty) Close() {}

--- a/session/tmux/server_scope_linux.go
+++ b/session/tmux/server_scope_linux.go
@@ -1,0 +1,67 @@
+//go:build linux
+
+package tmux
+
+import (
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+const (
+	systemdDaemonUnit      = "agent-factory-daemon.service"
+	systemdDaemonMarkerEnv = "AGENT_FACTORY_SYSTEMD_UNIT"
+)
+
+var readSelfCgroup = os.ReadFile
+
+// newTmuxServerCommand wraps the only command that can create tmux's server in
+// a transient user scope when af itself is the systemd-supervised daemon
+// (#2176). setsid/double-forking changes ancestry but not cgroup membership;
+// asking the user manager for a sibling scope is what deliberately moves the
+// server out of agent-factory-daemon.service.
+//
+// Existing tmux servers are unaffected: new-session is merely a client in the
+// short-lived scope and connects to the server that already owns the socket.
+func newTmuxServerCommand(args ...string) (*exec.Cmd, bool) {
+	if !runningInSystemdDaemonUnit() {
+		return exec.Command("tmux", args...), false
+	}
+	scopeArgs := []string{"--user", "--scope", "--quiet", "--collect", "--", "tmux"}
+	scopeArgs = append(scopeArgs, args...)
+	return exec.Command("systemd-run", scopeArgs...), true
+}
+
+func runningInSystemdDaemonUnit() bool {
+	// New unit templates carry an explicit marker. SYSTEMD_EXEC_PID makes the
+	// check process-specific: tmux panes inherit the environment, but their pid
+	// differs, so a nested af does not mistake itself for the daemon.
+	if os.Getenv(systemdDaemonMarkerEnv) == systemdDaemonUnit {
+		pid, err := strconv.Atoi(os.Getenv("SYSTEMD_EXEC_PID"))
+		if err == nil && pid == os.Getpid() {
+			return true
+		}
+	}
+
+	// Units installed by an older af have no marker until reinstalled. The
+	// kernel's membership is authoritative for those upgrades and works for
+	// both unified and legacy/hybrid /proc/self/cgroup formats.
+	data, err := readSelfCgroup("/proc/self/cgroup")
+	return err == nil && cgroupContainsUnit(string(data), systemdDaemonUnit)
+}
+
+func cgroupContainsUnit(content, unit string) bool {
+	for _, line := range strings.Split(content, "\n") {
+		parts := strings.SplitN(line, ":", 3)
+		if len(parts) != 3 {
+			continue
+		}
+		for _, component := range strings.Split(parts[2], "/") {
+			if component == unit {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/session/tmux/server_scope_linux_test.go
+++ b/session/tmux/server_scope_linux_test.go
@@ -1,0 +1,147 @@
+//go:build linux
+
+package tmux
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+)
+
+func stubSelfCgroup(t *testing.T, content string, err error) {
+	t.Helper()
+	previous := readSelfCgroup
+	readSelfCgroup = func(string) ([]byte, error) {
+		return []byte(content), err
+	}
+	t.Cleanup(func() { readSelfCgroup = previous })
+}
+
+func TestNewTmuxServerCommandScopesDaemonUnitSpawn(t *testing.T) {
+	t.Setenv(systemdDaemonMarkerEnv, systemdDaemonUnit)
+	t.Setenv("SYSTEMD_EXEC_PID", strconv.Itoa(os.Getpid()))
+	stubSelfCgroup(t, "", errors.New("proc unavailable"))
+
+	cmd, scoped := newTmuxServerCommand("new-session", "-d", "-s", "af_worker")
+	if !scoped {
+		t.Fatal("daemon-owned tmux server command was not marked systemd-scoped")
+	}
+	want := "systemd-run --user --scope --quiet --collect -- tmux new-session -d -s af_worker"
+	if got := strings.Join(cmd.Args, " "); got != want {
+		t.Fatalf("daemon-owned server command = %q, want %q", got, want)
+	}
+}
+
+func TestRunningInSystemdDaemonUnitRecognizesLegacyUnitCgroup(t *testing.T) {
+	t.Setenv(systemdDaemonMarkerEnv, "")
+	t.Setenv("SYSTEMD_EXEC_PID", "")
+	stubSelfCgroup(t, "0::/user.slice/user-1001.slice/user@1001.service/app.slice/agent-factory-daemon.service\n", nil)
+
+	cmd, scoped := newTmuxServerCommand("new-session")
+	if !scoped {
+		t.Fatal("legacy daemon cgroup command was not marked systemd-scoped")
+	}
+	if got := cmd.Args[0]; got != "systemd-run" {
+		t.Fatalf("legacy unit cgroup launched %q, want systemd-run scope", got)
+	}
+}
+
+func TestNewTmuxServerCommandDoesNotTrustInheritedSystemdMarker(t *testing.T) {
+	t.Setenv(systemdDaemonMarkerEnv, systemdDaemonUnit)
+	t.Setenv("SYSTEMD_EXEC_PID", strconv.Itoa(os.Getpid()+1))
+	stubSelfCgroup(t, "0::/user.slice/user-1001.slice/session-7.scope\n", nil)
+
+	cmd, scoped := newTmuxServerCommand("new-session")
+	if scoped {
+		t.Fatal("descendant with inherited marker was marked systemd-scoped")
+	}
+	if got := strings.Join(cmd.Args, " "); got != "tmux new-session" {
+		t.Fatalf("descendant with inherited marker launched %q, want direct tmux client", got)
+	}
+}
+
+func TestCgroupContainsUnitRequiresExactPathComponent(t *testing.T) {
+	for _, content := range []string{
+		"0::/user.slice/session-7.scope\n",
+		"0::/user.slice/not-agent-factory-daemon.service\n",
+		"12:memory:/agent-factory-daemon.service-old\n",
+		"malformed\n",
+	} {
+		if cgroupContainsUnit(content, systemdDaemonUnit) {
+			t.Errorf("cgroupContainsUnit(%q) = true for no exact unit component", content)
+		}
+	}
+	if !cgroupContainsUnit("12:memory:/x/agent-factory-daemon.service/y\n", systemdDaemonUnit) {
+		t.Error("exact legacy/hybrid cgroup component was not recognized")
+	}
+}
+
+type refusingTrackedPtyFactory struct {
+	t       *testing.T
+	waitErr error
+}
+
+func (f refusingTrackedPtyFactory) Start(*exec.Cmd) (*os.File, error) {
+	f.t.Fatal("Start called instead of StartTracked")
+	return nil, nil
+}
+
+func (f refusingTrackedPtyFactory) StartTracked(*exec.Cmd) (*os.File, <-chan error, error) {
+	ptmx, err := os.CreateTemp(f.t.TempDir(), "scope-refusal-pty")
+	if err != nil {
+		return nil, nil, err
+	}
+	done := make(chan error, 1)
+	done <- f.waitErr
+	close(done)
+	return ptmx, done, nil
+}
+
+func (refusingTrackedPtyFactory) Close() {}
+
+// TestSystemdRunRefusalIsActionable covers the severe failure mode where the
+// wrapper binary exists but the user manager refuses the transient scope. Pty
+// used to discard that exit status, so Start waited two seconds and blamed tmux
+// readiness; the CreateSession RPC now carries systemd-run's role and failure.
+func TestSystemdRunRefusalIsActionable(t *testing.T) {
+	t.Setenv(systemdDaemonMarkerEnv, systemdDaemonUnit)
+	t.Setenv("SYSTEMD_EXEC_PID", strconv.Itoa(os.Getpid()))
+	stubSelfCgroup(t, "", errors.New("proc unavailable"))
+	forceNewSessionEnvMarkers(t, false)
+
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			if strings.Contains(cmd.String(), "has-session") {
+				return errors.New("session not found")
+			}
+			return nil
+		},
+		OutputFunc: func(*exec.Cmd) ([]byte, error) { return nil, nil },
+	}
+	ptyFactory := refusingTrackedPtyFactory{
+		t:       t,
+		waitErr: errors.New("Failed to start transient scope unit: Access denied"),
+	}
+	ts := newTmuxSession("af_scope-refusal", "sh", ptyFactory, cmdExec)
+
+	err := ts.Start(t.TempDir())
+	if err == nil {
+		t.Fatal("Start succeeded after systemd-run refused the transient scope")
+	}
+	for _, want := range []string{
+		"systemd-run --user --scope failed",
+		"Failed to start transient scope unit: Access denied",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("Start error %q does not contain %q", err, want)
+		}
+	}
+	if strings.Contains(err.Error(), "timed out waiting for tmux") {
+		t.Fatalf("systemd-run refusal was misreported as a tmux readiness timeout: %v", err)
+	}
+}

--- a/session/tmux/server_scope_other.go
+++ b/session/tmux/server_scope_other.go
@@ -1,0 +1,12 @@
+//go:build !linux
+
+package tmux
+
+import "os/exec"
+
+// launchd does not have systemd's shared service cgroup failure mode. Keep the
+// existing direct tmux launch on Darwin (and other non-Linux platforms) rather
+// than invoking a Linux-only service-manager command (#2176, #1931).
+func newTmuxServerCommand(args ...string) (*exec.Cmd, bool) {
+	return exec.Command("tmux", args...), false
+}

--- a/session/tmux/server_scope_other_test.go
+++ b/session/tmux/server_scope_other_test.go
@@ -1,0 +1,22 @@
+//go:build !linux
+
+package tmux
+
+import (
+	"strings"
+	"testing"
+)
+
+// This runs on the macOS CI leg added by #1931. It pins the launchd path
+// explicitly so a Linux-only systemd wrapper cannot go green by accident
+// (#2039): Darwin must keep invoking tmux directly.
+func TestNewTmuxServerCommandNonLinuxStaysDirect(t *testing.T) {
+	cmd, scoped := newTmuxServerCommand("new-session", "-d", "-s", "af_worker")
+	if scoped {
+		t.Fatal("non-Linux tmux command was marked systemd-scoped")
+	}
+	want := "tmux new-session -d -s af_worker"
+	if got := strings.Join(cmd.Args, " "); got != want {
+		t.Fatalf("non-Linux tmux command = %q, want %q", got, want)
+	}
+}

--- a/session/tmux/start.go
+++ b/session/tmux/start.go
@@ -2,7 +2,6 @@ package tmux
 
 import (
 	"fmt"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -31,10 +30,13 @@ func (t *TmuxSession) Start(workDir string) error {
 	args := []string{"new-session", "-d", "-s", t.sanitizedName, "-c", workDir}
 	args = append(args, sessionEnvFlags(t.sanitizedName)...)
 	args = append(args, t.programCmd())
-	cmd := exec.Command("tmux", args...)
+	cmd, systemdScoped := newTmuxServerCommand(args...)
 
-	ptmx, err := t.ptyFactory.Start(cmd)
+	ptmx, commandDone, err := startPtyTracked(t.ptyFactory, cmd)
 	if err != nil {
+		if systemdScoped {
+			err = fmt.Errorf("systemd-run --user --scope could not start: %w", err)
+		}
 		// Cleanup any partially created session if any exists. ExistsOrUnknown is
 		// safe here: the only action gated on true is a bounded best-effort
 		// kill-session, so a wedged→"exists" merely triggers a harmless cleanup
@@ -72,6 +74,20 @@ func (t *TmuxSession) Start(workDir string) error {
 			break
 		}
 		select {
+		case commandErr := <-commandDone:
+			// A nil exit only means the detached new-session command completed;
+			// tmux may need another poll before the session becomes visible. A
+			// non-zero systemd-run exit, however, is the actionable cause. Before
+			// #2176 that status was discarded by Pty's reaper and the operator saw
+			// only a misleading tmux readiness timeout.
+			commandDone = nil
+			if commandErr != nil {
+				_ = ptmx.Close()
+				if systemdScoped {
+					return fmt.Errorf("error starting tmux session: systemd-run --user --scope failed to create session %q: %w", t.sanitizedName, commandErr)
+				}
+				return fmt.Errorf("error starting tmux session: tmux new-session for %q failed: %w", t.sanitizedName, commandErr)
+			}
 		case <-timeout:
 			ptmx.Close()
 			// The pane program exiting instantly (bad path, rejected flag)
@@ -79,6 +95,9 @@ func (t *TmuxSession) Start(workDir string) error {
 			// ever sees it — name the likely cause and the exact command so
 			// the user isn't left with a bare timeout (#1116, #1131).
 			timeoutErr := fmt.Errorf("timed out waiting for tmux session %s; the pane program may have exited immediately after launch — check that it runs and accepts its flags (program: %q)", t.sanitizedName, t.programCmd())
+			if systemdScoped {
+				timeoutErr = fmt.Errorf("systemd-run --user --scope completed but the tmux session did not appear: %w", timeoutErr)
+			}
 			// The pane state is LOAD-BEARING here, and the comment that used to sit
 			// on this line said the opposite: "Start's failure path touches no
 			// worktree". It does. LocalBackend.Launch calls gw.Cleanup() the moment


### PR DESCRIPTION
Fixes #2176.

## What changed

- install systemd user units with `KillMode=process`, so a daemon stop never signals tmux processes already trapped in the service cgroup (`mixed` would still SIGKILL those processes after the main daemon exits)
- create a daemon-started tmux server in a sibling `systemd-run --user --scope`, removing cgroup ownership from spawn timing
- migrate existing installed units before manual restart, upgrade restart, and auto-update restart; migration preserves unrelated directives, including the `StartLimit*` / `RestartPreventExitStatus` work planned in #2168
- leave the launchd path unchanged and keep the tmux wrapper explicitly Linux-only

## Regression coverage

The new container-fenced integration test starts a real daemon with private AF/XDG/tmux state, has that daemon create a session, restarts through `af daemon restart`, and verifies both the tmux server PID and pane PID survive. It also fault-injects a legacy control-group unit to verify both on-disk migration and the independent transient-scope protection.

Before the production fix, the test failed as expected:

```text
server pid 265 -> 307, pane pid 267 -> 309
killed daemon-cgroup tmux server pid=265 under control-group restart
```

After the fix, it passes. Darwin cross-compilation covers the non-Linux implementation, and the `!linux` test executes on macOS CI.

## Validation

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`

All pass on the rebased branch.

— Captain Claude
