### PR TITLE
fix(preview): remove fixed capture-path latency

### DIFF
--- a/api/sessions.go
+++ b/api/sessions.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"errors"
 	"fmt"
 
 	"os/exec"
@@ -36,7 +35,17 @@ var (
 	closeTabViaDaemon       = daemon.CloseTab
 	renameTabViaDaemon      = daemon.RenameTab
 	reorderTabViaDaemon     = daemon.ReorderTab
-	preflightLocalSession   = preflight.LocalSessionPrereqs
+	previewSessionViaDaemon = func(req daemon.PreviewRequest) (string, bool, bool, error) {
+		if !apiclient.IsRemoteTarget() {
+			return daemon.PreviewSession(req)
+		}
+		client, err := apiclient.NewTargeted()
+		if err != nil {
+			return "", false, false, err
+		}
+		return client.Preview(req)
+	}
+	preflightLocalSession = preflight.LocalSessionPrereqs
 	// snapshotViaDaemon is the non-spawning read path for list/get/whoami
 	// (#1029 PR 2). It reflects the daemon's authoritative in-memory state when
 	// a daemon is already running, and returns daemon.ErrDaemonUnavailable
@@ -343,41 +352,13 @@ var (
 	previewFullFlag    bool
 )
 
-// resolvePreviewTab picks the tab slot `af sessions preview` should capture on
-// the LOCAL path, from the --tab-id/--tab-name/--tab flags.
-//
-// The precedence and the refuse-never-fall-back rule are session's
-// (ResolveTabIndex) — the same definition the daemon resolves against — so the
-// two paths cannot drift into disagreeing about what --tab-name means (#1948).
-// Only the wording is the CLI's, and it names the FLAG that was wrong, which the
-// daemon's session-oriented message cannot.
-func resolvePreviewTab(tabs []*session.Tab) (int, error) {
-	idx, err := session.ResolveTabIndex(tabs, previewTabIDFlag, previewTabNameFlag, previewTabFlag)
-	switch {
-	case errors.Is(err, session.ErrTabIDNotFound), errors.Is(err, session.ErrTabIndexOutOfRange):
-		return 0, previewTabMissErr()
-	case errors.Is(err, session.ErrTabNameNotFound):
-		ids := make([]string, 0, len(tabs))
-		for _, t := range tabs {
-			ids = append(ids, session.TabIdentifiers(t))
-		}
-		return 0, fmt.Errorf("--tab-name %q matches no tab in this session; its tabs are: %s",
-			previewTabNameFlag, strings.Join(ids, ", "))
-	case err != nil:
-		return 0, err
-	}
-	return idx, nil
-}
-
 // previewTabMissErr is the message for a tab-level miss — an --tab-id that no
 // longer resolves, or a --tab that is not a slot.
 //
-// One function serves BOTH paths on purpose. The local path learns the miss from
-// session.ResolveTabIndex and the remote path from the daemon's TabGone, but a
-// user should not be able to tell which machine resolved their flag, and the two
-// drifting apart is what this whole cluster is about. It names the FLAG the user
-// passed, which neither the daemon's session-oriented error nor a bare "gone"
-// can do.
+// Both local and remote previews are daemon-resolved and report the miss through
+// TabGone, so a user cannot tell which machine resolved the selector. It names
+// the FLAG the user passed, which neither the daemon's session-oriented error nor
+// a bare "gone" can do.
 //
 // A --tab-name miss is deliberately NOT here: it is answered with the session's
 // roster, which only the side holding the tab list can produce.
@@ -423,66 +404,31 @@ whatever tab had shifted into it.
 			return jsonError(err)
 		}
 
-		// A remote target must be previewed BY the remote daemon. The local path
-		// below reads this machine's instances.json and restores the session to
-		// capture it — against --daemon-url that would preview (and start) a
-		// same-titled LOCAL session, or report not-found even though the remote
-		// holds the session. The daemon resolves {title, repoID} on its own side,
-		// where the sessions actually live.
-		if apiclient.IsRemoteTarget() {
-			client, cerr := apiclient.NewTargeted()
-			if cerr != nil {
-				return jsonError(cerr)
-			}
-			// The tab selectors go over the wire as-is: the DAEMON resolves them,
-			// against the roster it actually holds, through the same
-			// session.ResolveTabIndex the local path below uses. Resolving a name
-			// client-side would need an extra round trip and would race — the
-			// roster it read could differ from the one the capture runs against.
-			content, gone, tabGone, perr := client.Preview(daemon.PreviewRequest{
-				Title:   args[0],
-				RepoID:  repoID,
-				Tab:     previewTabFlag,
-				TabName: previewTabNameFlag,
-				TabID:   previewTabIDFlag,
-				Full:    previewFullFlag,
-			})
-			if perr != nil {
-				return jsonError(perr)
-			}
-			// A tab-level miss is NOT a dead session. Reporting one as the other
-			// told the user their running session had ended because they mistyped a
-			// --tab-id, and the same message for both is what let that pass. The
-			// daemon distinguishes them (TabGone), so this does not have to guess
-			// from "we sent a selector" — which would be wrong in exactly the case
-			// where the session really did die mid-capture.
-			if tabGone {
-				return jsonError(previewTabMissErr())
-			}
-			if gone {
-				return jsonError(fmt.Errorf("session %q is no longer running", args[0]))
-			}
-			return jsonOut(map[string]string{
-				"title":   args[0],
-				"content": content,
-			})
-		}
-
-		instance, _, err := findLiveInstanceByTitleInScope(repoID, args[0])
+		// Capture through the daemon on both local and remote targets. Rebuilding a
+		// local Instance here used to restore the session in this short-lived CLI
+		// process, which also ran the configured shell-command probe before the one
+		// capture-pane the command actually needed. The daemon already owns the
+		// canonical live Instance and is the sole capture path, so selectors travel
+		// there unresolved and are applied atomically against its current tab roster.
+		content, gone, tabGone, err := previewSessionViaDaemon(daemon.PreviewRequest{
+			Title:   args[0],
+			RepoID:  repoID,
+			Tab:     previewTabFlag,
+			TabName: previewTabNameFlag,
+			TabID:   previewTabIDFlag,
+			Full:    previewFullFlag,
+		})
 		if err != nil {
 			return jsonError(err)
 		}
-
-		// Same precedence as the daemon path, from the same definition
-		// (session.ResolveTabIndex) rather than a second copy of the rule.
-		tab, terr := resolvePreviewTab(instance.GetTabs())
-		if terr != nil {
-			return jsonError(terr)
+		// A tab-level miss is NOT a dead session. Reporting one as the other
+		// tells the user their running session ended because they mistyped a
+		// selector. The daemon carries the distinction so this path never guesses.
+		if tabGone {
+			return jsonError(previewTabMissErr())
 		}
-
-		content, err := instance.AgentServer().Preview(tab, previewFullFlag)
-		if err != nil {
-			return jsonError(fmt.Errorf("failed to get preview: %w", err))
+		if gone {
+			return jsonError(fmt.Errorf("session %q is no longer running", args[0]))
 		}
 		return jsonOut(map[string]string{
 			"title":   args[0],

--- a/api/sessions_preview_test.go
+++ b/api/sessions_preview_test.go
@@ -1,0 +1,53 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/daemon"
+)
+
+// TestSessionsPreviewUsesDaemonCapturePath is the #2177 regression guard for
+// the fixed ~660ms CLI delay. The local command must hand the unresolved target
+// to the daemon instead of rebuilding/restoring an Instance in this short-lived
+// process (which ran the user's shell startup probe before capture-pane).
+func TestSessionsPreviewUsesDaemonCapturePath(t *testing.T) {
+	repoID := setupRepoForCmd(t)
+
+	prevTab, prevName, prevID, prevFull := previewTabFlag, previewTabNameFlag, previewTabIDFlag, previewFullFlag
+	previewTabFlag = 2
+	previewTabNameFlag = "logs"
+	previewTabIDFlag = "tab-stable-id"
+	previewFullFlag = true
+	t.Cleanup(func() {
+		previewTabFlag, previewTabNameFlag, previewTabIDFlag, previewFullFlag = prevTab, prevName, prevID, prevFull
+	})
+
+	var got daemon.PreviewRequest
+	prevPreview := previewSessionViaDaemon
+	previewSessionViaDaemon = func(req daemon.PreviewRequest) (string, bool, bool, error) {
+		got = req
+		return "captured by daemon", false, false, nil
+	}
+	t.Cleanup(func() { previewSessionViaDaemon = prevPreview })
+
+	// There is deliberately no persisted "worker" session in this test home. A
+	// client-side find/restore therefore fails before reaching the seam, while the
+	// daemon-owned path succeeds and proves the CLI did not reconstruct one.
+	out, err := runCmdCaptureStdout(t, sessionsPreviewCmd, []string{"worker"})
+	if err != nil {
+		t.Fatalf("sessions preview: %v", err)
+	}
+	if got.Title != "worker" || got.RepoID != repoID || got.Tab != 2 ||
+		got.TabName != "logs" || got.TabID != "tab-stable-id" || !got.Full {
+		t.Fatalf("Preview request = %+v, want title/repo and every selector forwarded unchanged", got)
+	}
+
+	var payload map[string]string
+	if err := json.Unmarshal(out, &payload); err != nil {
+		t.Fatalf("preview output is not JSON (%q): %v", out, err)
+	}
+	if payload["title"] != "worker" || payload["content"] != "captured by daemon" {
+		t.Fatalf("preview output = %v, want daemon capture payload", payload)
+	}
+}

--- a/app/home_update.go
+++ b/app/home_update.go
@@ -308,6 +308,9 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// currently in flight.
 		endDetachWatchdog()
 		return m, nil
+	case panePreviewStaleExpiredMsg:
+		m.expireStalePanePreview(msg)
+		return m, nil
 	case instanceStartedMsg:
 		// The user may have navigated elsewhere while the instance was
 		// starting. Don't yank their selection or pop a modal onto them.

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -205,7 +205,7 @@ func TestPane_HeaderAnnotatesSelectionDivergence(t *testing.T) {
 		"canceling preview restores the #1289 selected row vs shown content invariant")
 }
 
-func TestPanePreviewInvalidatesStaleContentSynchronously(t *testing.T) {
+func TestPanePreviewPaintsLastCaptureWhileRefreshing(t *testing.T) {
 	h := paneTestHome(t)
 	alpha := h.store.GetInstanceByTitle("alpha")
 	beta := h.store.GetInstanceByTitle("beta")
@@ -224,11 +224,33 @@ func TestPanePreviewInvalidatesStaleContentSynchronously(t *testing.T) {
 
 	view := h.View()
 	assert.Contains(t, view, "PREVIEW beta · ◆ Agent (original alpha · ◆ Agent)")
-	assert.Contains(t, view, "Loading preview…")
-	assert.NotContains(t, view, "ALPHA_PREVIEW_CONTENT",
-		"retargeting preview must clear the original content before async beta capture returns")
+	assert.Contains(t, view, "ALPHA_PREVIEW_CONTENT",
+		"retargeting must paint the last capture instead of blanking while beta loads")
+	assert.NotContains(t, view, "Loading preview…")
 	assert.Same(t, alpha, paneA.Instance(), "preview must not mutate the committed pane binding")
 	assert.Same(t, beta, h.panePreviewTxn.target.instance)
+
+	require.IsType(t, panesRefreshedMsg{}, refreshPaneBindingCmd(w, beta, 0, h.panePreviewTxn.seq)())
+	view = h.View()
+	assert.Contains(t, view, "BETA_PREVIEW_CONTENT",
+		"the daemon capture must replace stale content in place when it lands")
+	assert.NotContains(t, view, "ALPHA_PREVIEW_CONTENT")
+}
+
+func TestPanePreviewRetargetHonorsCaptureThrottle(t *testing.T) {
+	h := paneTestHome(t)
+	beta := h.store.GetInstanceByTitle("beta")
+
+	pressKey(t, h, "s")
+	paneA := h.store.OpenPanes()[0]
+	recent := time.Now()
+	h.lastPaneCapture[paneA.ID()] = recent
+
+	h.updatePanePreview(beta, 0, false, false)
+	assert.Equal(t, recent, h.lastPaneCapture[paneA.ID()],
+		"arrowing to a new preview must not bypass the per-pane capture cadence")
+	assert.Nil(t, h.panesRefresh(false),
+		"a selection inside the 100ms window must reuse the next scheduled refresh")
 }
 
 func TestPanePreviewSplitHintRequiresActivePreview(t *testing.T) {
@@ -255,6 +277,7 @@ func TestPanePreviewFastScrollLatestWins(t *testing.T) {
 	alpha := h.store.GetInstanceByTitle("alpha")
 	beta := h.store.GetInstanceByTitle("beta")
 	gamma := h.store.GetInstanceByTitle("gamma")
+	setPreviewText(alpha, "ALPHA_PREVIEW_CONTENT")
 	setPreviewText(beta, "BETA_PREVIEW_CONTENT")
 	setPreviewText(gamma, "GAMMA_PREVIEW_CONTENT")
 
@@ -262,6 +285,7 @@ func TestPanePreviewFastScrollLatestWins(t *testing.T) {
 	paneA := h.store.OpenPanes()[0]
 	w := h.paneWindows[paneA.ID()]
 	require.NotNil(t, w)
+	require.IsType(t, panesRefreshedMsg{}, refreshPaneBindingCmd(w, alpha, 0, w.ContentSeq())())
 
 	h.sidebar.SetSelectedInstance(1)
 	_ = h.selectionChanged()
@@ -277,7 +301,8 @@ func TestPanePreviewFastScrollLatestWins(t *testing.T) {
 	require.IsType(t, panesRefreshedMsg{}, refreshPaneBindingCmd(w, beta, 0, betaSeq)())
 	view := h.View()
 	assert.Contains(t, view, "PREVIEW gamma · ◆ Agent (original alpha · ◆ Agent)")
-	assert.Contains(t, view, "Loading preview…")
+	assert.Contains(t, view, "ALPHA_PREVIEW_CONTENT",
+		"a late capture for beta must leave the last painted frame in place")
 	assert.NotContains(t, view, "BETA_PREVIEW_CONTENT",
 		"late beta capture must not overwrite the newer gamma preview target")
 

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -237,6 +237,70 @@ func TestPanePreviewPaintsLastCaptureWhileRefreshing(t *testing.T) {
 	assert.NotContains(t, view, "ALPHA_PREVIEW_CONTENT")
 }
 
+func TestPanePreviewSlowCaptureFallsBackAfterGrace(t *testing.T) {
+	h := paneTestHome(t)
+	alpha := h.store.GetInstanceByTitle("alpha")
+	beta := h.store.GetInstanceByTitle("beta")
+	setPreviewText(alpha, "ALPHA_PREVIEW_CONTENT")
+
+	pressKey(t, h, "s")
+	paneA := h.store.OpenPanes()[0]
+	w := h.paneWindows[paneA.ID()]
+	require.NotNil(t, w)
+	require.IsType(t, panesRefreshedMsg{}, refreshPaneBindingCmd(w, alpha, 0, w.ContentSeq())())
+
+	started := time.Now()
+	graceCmd := h.updatePanePreview(beta, 0, false, false)
+	require.NotNil(t, graceCmd, "a new preview target must arm the stale-frame grace period")
+	assert.Contains(t, h.View(), "ALPHA_PREVIEW_CONTENT",
+		"the completed frame stays visible during the fast-path grace period")
+	assert.Nil(t, h.updatePanePreview(beta, 0, false, false),
+		"refresh ticks for the same target must not keep restarting the grace period")
+
+	msg := graceCmd()
+	assert.GreaterOrEqual(t, time.Since(started), panePreviewStaleGrace)
+	require.IsType(t, panePreviewStaleExpiredMsg{}, msg)
+	_, followup := h.Update(msg)
+	assert.Nil(t, followup)
+
+	view := h.View()
+	assert.Contains(t, view, "PREVIEW beta · ◆ Agent (original alpha · ◆ Agent)")
+	assert.Contains(t, view, "Loading preview…",
+		"a capture that does not arrive must stop showing another session's pane")
+	assert.NotContains(t, view, "ALPHA_PREVIEW_CONTENT")
+}
+
+func TestPanePreviewCompletedCaptureWinsGraceExpiry(t *testing.T) {
+	h := paneTestHome(t)
+	alpha := h.store.GetInstanceByTitle("alpha")
+	beta := h.store.GetInstanceByTitle("beta")
+	setPreviewText(alpha, "ALPHA_PREVIEW_CONTENT")
+	setPreviewText(beta, "BETA_PREVIEW_CONTENT")
+
+	pressKey(t, h, "s")
+	paneA := h.store.OpenPanes()[0]
+	w := h.paneWindows[paneA.ID()]
+	require.NotNil(t, w)
+	require.IsType(t, panesRefreshedMsg{}, refreshPaneBindingCmd(w, alpha, 0, w.ContentSeq())())
+
+	require.NotNil(t, h.updatePanePreview(beta, 0, false, false))
+	txn := *h.panePreviewTxn
+	expiry := panePreviewStaleExpiredMsg{
+		ownerPaneID:    txn.ownerPaneID,
+		target:         txn.target,
+		seq:            txn.seq,
+		renderRevision: w.RenderRevision(),
+	}
+	require.IsType(t, panesRefreshedMsg{}, refreshPaneBindingCmd(w, beta, 0, txn.seq)())
+
+	_, followup := h.Update(expiry)
+	assert.Nil(t, followup)
+	view := h.View()
+	assert.Contains(t, view, "BETA_PREVIEW_CONTENT",
+		"the grace timer must not overwrite a capture that already landed")
+	assert.NotContains(t, view, "Loading preview…")
+}
+
 func TestPanePreviewRetargetHonorsCaptureThrottle(t *testing.T) {
 	h := paneTestHome(t)
 	beta := h.store.GetInstanceByTitle("beta")
@@ -291,12 +355,21 @@ func TestPanePreviewFastScrollLatestWins(t *testing.T) {
 	_ = h.selectionChanged()
 	require.NotNil(t, h.panePreviewTxn)
 	betaSeq := h.panePreviewTxn.seq
+	betaExpiry := panePreviewStaleExpiredMsg{
+		ownerPaneID:    h.panePreviewTxn.ownerPaneID,
+		target:         h.panePreviewTxn.target,
+		seq:            betaSeq,
+		renderRevision: w.RenderRevision(),
+	}
 
 	h.sidebar.SetSelectedInstance(2)
 	_ = h.selectionChanged()
 	require.NotNil(t, h.panePreviewTxn)
 	gammaSeq := h.panePreviewTxn.seq
 	require.NotEqual(t, betaSeq, gammaSeq)
+	_, _ = h.Update(betaExpiry)
+	assert.NotContains(t, h.View(), "Loading preview…",
+		"the grace timer for an older target must not blank the newest preview")
 
 	require.IsType(t, panesRefreshedMsg{}, refreshPaneBindingCmd(w, beta, 0, betaSeq)())
 	view := h.View()

--- a/app/pane_preview.go
+++ b/app/pane_preview.go
@@ -29,6 +29,19 @@ type panePreviewSuppression struct {
 	target   paneBinding
 }
 
+// Two capture cadences give a retarget suppressed by the per-pane throttle one
+// full tick to dispatch and the measured 4–6ms local capture time to land. A
+// slower or wedged capture then degrades from the stale frame to an honest
+// loading state instead of leaving the previous session mislabeled forever.
+const panePreviewStaleGrace = 2 * paneCaptureMinInterval
+
+type panePreviewStaleExpiredMsg struct {
+	ownerPaneID    int
+	target         paneBinding
+	seq            uint64
+	renderRevision uint64
+}
+
 func samePaneBinding(a, b paneBinding) bool {
 	return a.instance == b.instance && a.tab == b.tab
 }
@@ -110,6 +123,7 @@ func (m *home) updatePanePreview(selected *session.Instance, targetTab int, tabS
 		m.enforceInteractiveInvariant()
 	}
 
+	previousSeq := w.ContentSeq()
 	seq := w.SetPreview(target.instance, target.tab, paneBindingLabel(original))
 	m.panePreviewTxn = &panePreviewTxn{
 		ownerPaneID: owner.ID(),
@@ -123,8 +137,40 @@ func (m *home) updatePanePreview(selected *session.Instance, targetTab int, tabS
 	// timestamp also defeated panesRefresh's 100ms rapid-navigation throttle and
 	// dispatched one RPC per arrow key. The render generation above still drops a
 	// late capture for an older target, so stale-first painting cannot overwrite a
-	// newer selection.
-	return nil
+	// newer selection. If no completed state lands within the grace window, the
+	// timer replaces this stale frame with an honest loading state. Repeated
+	// refresh ticks for the same target do not restart the timer.
+	if seq == previousSeq {
+		return nil
+	}
+	renderRevision := w.RenderRevision()
+	return tea.Tick(panePreviewStaleGrace, func(time.Time) tea.Msg {
+		return panePreviewStaleExpiredMsg{
+			ownerPaneID:    owner.ID(),
+			target:         target,
+			seq:            seq,
+			renderRevision: renderRevision,
+		}
+	})
+}
+
+func (m *home) expireStalePanePreview(msg panePreviewStaleExpiredMsg) {
+	txn := m.panePreviewTxn
+	if txn == nil || txn.ownerPaneID != msg.ownerPaneID || txn.seq != msg.seq ||
+		!samePaneBinding(txn.target, msg.target) {
+		return
+	}
+	w := m.paneWindows[msg.ownerPaneID]
+	if w == nil {
+		return
+	}
+	w.InvalidateContentIfUnchanged(
+		msg.target.instance,
+		msg.target.tab,
+		msg.seq,
+		msg.renderRevision,
+		"Loading preview…",
+	)
 }
 
 // effectivePaneBinding resolves what a pane is ACTUALLY SHOWING — the single

--- a/app/pane_preview.go
+++ b/app/pane_preview.go
@@ -105,11 +105,6 @@ func (m *home) updatePanePreview(selected *session.Instance, targetTab int, tabS
 		m.cancelPanePreview(false)
 		return nil
 	}
-	changed := m.panePreviewTxn == nil ||
-		m.panePreviewTxn.ownerPaneID != owner.ID() ||
-		!samePaneBinding(m.panePreviewTxn.original, original) ||
-		!samePaneBinding(m.panePreviewTxn.target, target)
-
 	if m.liveTerms[owner.ID()] != nil {
 		m.closeLiveTermPaneFor(owner.ID())
 		m.enforceInteractiveInvariant()
@@ -122,10 +117,13 @@ func (m *home) updatePanePreview(selected *session.Instance, targetTab int, tabS
 		target:      target,
 		seq:         seq,
 	}
-	if changed {
-		w.InvalidateContent(target.instance, target.tab, "Loading preview…")
-		m.lastPaneCapture[owner.ID()] = time.Time{}
-	}
+	// Keep the last completed capture on screen while the existing off-loop
+	// refresh pipeline fetches this target. Clearing it to "Loading preview…"
+	// made every selection visibly wait on the daemon RPC; resetting the capture
+	// timestamp also defeated panesRefresh's 100ms rapid-navigation throttle and
+	// dispatched one RPC per arrow key. The render generation above still drops a
+	// late capture for an older target, so stale-first painting cannot overwrite a
+	// newer selection.
 	return nil
 }
 

--- a/app/tui_state.go
+++ b/app/tui_state.go
@@ -287,7 +287,8 @@ func (m *home) persistTUIViewStateAfter(msg tea.Msg) {
 
 func shouldPersistTUIViewStateAfter(msg tea.Msg) bool {
 	switch msg.(type) {
-	case previewTickMsg, panesRefreshedMsg, repaintAfterDetachMsg, keyupMsg, hideErrMsg:
+	case previewTickMsg, panesRefreshedMsg, panePreviewStaleExpiredMsg,
+		repaintAfterDetachMsg, keyupMsg, hideErrMsg:
 		return false
 	default:
 		return true

--- a/daemon/control_client.go
+++ b/daemon/control_client.go
@@ -277,6 +277,18 @@ func SnapshotNoSpawn(req SnapshotRequest) ([]session.InstanceData, error) {
 	return resp.Instances, nil
 }
 
+// PreviewSession captures one session tab through the daemon's sole Preview
+// handler. Unlike SnapshotNoSpawn, previewing a live terminal is an active read:
+// it ensures the daemon is running and waits through daemon warm-up, just like
+// the other session control calls.
+func PreviewSession(req PreviewRequest) (content string, gone, tabGone bool, err error) {
+	var resp PreviewResponse
+	if err := callDaemon("Preview", req, &resp); err != nil {
+		return "", false, false, err
+	}
+	return resp.Content, resp.Gone, resp.TabGone, nil
+}
+
 // KillSession asks the daemon to kill a session and remove it from storage.
 func KillSession(req KillSessionRequest) error {
 	var resp KillSessionResponse

--- a/daemon/manager_sessions.go
+++ b/daemon/manager_sessions.go
@@ -335,20 +335,26 @@ func (m *Manager) agentServerForStream(idOrTitle, repoID string) (session.AgentS
 // returns the instance, its resolved repoID, and its title — the last so the
 // killsInFlight gate keys off the real title even when the caller addressed the
 // session by id. The id scan only sees in-memory (live) instances, which is all a
-// stream can attach to; an unmatched id falls through to findSession, which also
-// restores an on-disk session the title path may need.
+// stream can attach to. Both the stable-id and repo-scoped title paths consult
+// the daemon's already-restored map directly: Preview is a repaint hot path, so
+// re-scanning every persisted session before each capture makes its latency grow
+// with the whole session history. A miss still falls through to findSession,
+// preserving the disk restore and unscoped-title ambiguity checks for callers
+// that genuinely address an untracked session.
 func (m *Manager) resolveStreamSession(idOrTitle, repoID string) (*session.Instance, string, string, error) {
 	m.mu.Lock()
-	if err := m.refreshLocked(); err != nil {
-		m.mu.Unlock()
-		return nil, "", "", err
-	}
 	for key, instance := range m.instances {
-		if instance.ID != "" && instance.ID == idOrTitle {
+		if instance != nil && instance.ID != "" && instance.ID == idOrTitle {
 			rid, _ := splitDaemonInstanceKey(key)
 			title := instance.Title
 			m.mu.Unlock()
 			return instance, rid, title, nil
+		}
+	}
+	if repoID != "" {
+		if instance := m.instances[daemonInstanceKey(repoID, idOrTitle)]; instance != nil {
+			m.mu.Unlock()
+			return instance, repoID, instance.Title, nil
 		}
 	}
 	m.mu.Unlock()

--- a/daemon/stream_id_resolution_test.go
+++ b/daemon/stream_id_resolution_test.go
@@ -1,10 +1,13 @@
 package daemon
 
 import (
+	"errors"
+	"sync/atomic"
 	"testing"
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/internal/testguard"
+	"github.com/sachiniyer/agent-factory/session"
 )
 
 // The /v1/sessions/{id}/stream route resolves its {id} segment by the session's
@@ -96,10 +99,10 @@ func TestResolveStreamSessionIDBeatsCrossRepoTitleCollision(t *testing.T) {
 	}
 }
 
-// TestResolveStreamSessionTitleFallback pins the unchanged TUI path: a value that
-// matches no instance id falls back to title resolution, returning the passed
-// string as the title (what the killsInFlight gate and error messages use).
-func TestResolveStreamSessionTitleFallback(t *testing.T) {
+// TestResolveStreamSessionTrackedTitleSkipsDiskRefresh pins the TUI hot path: a
+// repo-scoped title already restored in the daemon resolves from m.instances
+// without walking persisted session history before every preview capture.
+func TestResolveStreamSessionTrackedTitleSkipsDiskRefresh(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
 	repoPath := setupControlRepo(t)
 	repo, err := config.RepoFromPath(repoPath)
@@ -117,6 +120,18 @@ func TestResolveStreamSessionTitleFallback(t *testing.T) {
 	manager.instances[daemonInstanceKey(repo.ID, "byname")] = inst
 	manager.mu.Unlock()
 
+	// Replace the on-disk roster with an unrelated row after the canonical target
+	// is tracked. Any refresh would both invoke this materializer and evict the
+	// target from the map; the preview resolver must do neither.
+	seedDiskInstance(t, repo.ID, "disk-only", repoPath)
+	var diskBuilds atomic.Int32
+	prev := fromInstanceDataForRefresh
+	fromInstanceDataForRefresh = func(session.InstanceData) (*session.Instance, error) {
+		diskBuilds.Add(1)
+		return nil, errors.New("unexpected preview-path disk materialization")
+	}
+	t.Cleanup(func() { fromInstanceDataForRefresh = prev })
+
 	// Address by TITLE (no id match) — the TUI's call shape.
 	got, rid, title, err := manager.resolveStreamSession("byname", repo.ID)
 	if err != nil {
@@ -130,5 +145,8 @@ func TestResolveStreamSessionTitleFallback(t *testing.T) {
 	}
 	if title != "byname" {
 		t.Fatalf("resolved title = %q, want %q", title, "byname")
+	}
+	if got := diskBuilds.Load(); got != 0 {
+		t.Fatalf("tracked preview resolution materialized %d on-disk session(s), want 0", got)
 	}
 }

--- a/ui/tab_pane.go
+++ b/ui/tab_pane.go
@@ -62,8 +62,13 @@ type TabPane struct {
 	width  int
 	height int
 
-	content     tabContentState
-	isScrolling bool
+	content tabContentState
+	// renderRevision advances whenever this pane publishes a completed render
+	// state: captured content, a fallback, or a filled scroll viewport. Preview
+	// retargeting snapshots it so a grace-period expiry can replace stale content
+	// without racing and overwriting a capture that landed at the deadline.
+	renderRevision uint64
+	isScrolling    bool
 	// scrollFillPending is set when ScrollUp/ScrollDown enter scroll mode and
 	// cleared once the off-loop capture has populated the viewport. Scroll entry
 	// no longer captures on the bubbletea event loop (#1637); this flag is the
@@ -213,6 +218,14 @@ func (p *TabPane) dropStaleView(instance *session.Instance, activeTab int) {
 	}
 }
 
+// publishContent replaces the normal/fallback render state and records that a
+// completed state for the current binding is ready to paint. Caller must hold
+// p.mu.
+func (p *TabPane) publishContent(content tabContentState) {
+	p.content = content
+	p.renderRevision++
+}
+
 // setFallbackState sets the pane to display a centered fallback message. Caller
 // must hold p.mu.
 //
@@ -222,13 +235,21 @@ func (p *TabPane) dropStaleView(instance *session.Instance, activeTab int) {
 // session-gone) would render the prior view's stale viewport instead of the
 // fallback message (#669/#672/#940).
 func (p *TabPane) setFallbackState(message string) {
-	p.content = tabContentState{
+	p.publishContent(tabContentState{
 		fallback: true,
 		text:     lipgloss.JoinVertical(lipgloss.Center, FallBackText, "", message),
-	}
+	})
 	p.isScrolling = false
 	p.resetScrollFill()
 	p.viewport.SetContent("")
+}
+
+// RenderRevision returns the completed-render generation. It is safe to read
+// from the Bubble Tea event loop while an off-loop capture is publishing.
+func (p *TabPane) RenderRevision() uint64 {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.renderRevision
 }
 
 type contentGuard func() bool
@@ -249,6 +270,26 @@ func (p *TabPane) InvalidateContent(instance *session.Instance, activeTab int, m
 	defer p.mu.Unlock()
 	p.dropStaleView(instance, activeTab)
 	p.setFallbackState(message)
+}
+
+// InvalidateContentIfRevision publishes a fallback only if no capture or other
+// completed state has landed since expected was sampled. The check and write
+// share p.mu so a capture completing at the grace-period boundary wins instead
+// of being overwritten by a late loading fallback.
+func (p *TabPane) InvalidateContentIfRevision(
+	instance *session.Instance,
+	activeTab int,
+	expected uint64,
+	message string,
+) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.renderRevision != expected {
+		return false
+	}
+	p.dropStaleView(instance, activeTab)
+	p.setFallbackState(message)
+	return true
 }
 
 // UpdateContent captures the selected tab's content. Safe to call from a
@@ -361,6 +402,7 @@ func (p *TabPane) updateAgent(instance *session.Instance, guard contentGuard) er
 		// preserved (#1637).
 		p.viewport.GotoBottom()
 		p.resetScrollFill()
+		p.renderRevision++
 		return nil
 	}
 
@@ -390,7 +432,7 @@ func (p *TabPane) updateAgent(instance *session.Instance, guard contentGuard) er
 	if len(content) == 0 && !instance.Started() {
 		p.setFallbackState("Please enter a name for the instance.")
 	} else {
-		p.content = tabContentState{fallback: false, text: content}
+		p.publishContent(tabContentState{fallback: false, text: content})
 	}
 	return nil
 }
@@ -530,6 +572,7 @@ func (p *TabPane) updateShell(instance *session.Instance, activeTab int, guard c
 		p.viewport.SetContent(lipgloss.JoinVertical(lipgloss.Left, content, scrollFooter()))
 		p.viewport.GotoBottom()
 		p.resetScrollFill()
+		p.renderRevision++
 		return nil
 	}
 
@@ -556,7 +599,7 @@ func (p *TabPane) updateShell(instance *session.Instance, activeTab int, guard c
 		}
 		return fmt.Errorf("tab pane: failed to capture terminal content: %w", err)
 	}
-	p.content = tabContentState{fallback: false, text: content}
+	p.publishContent(tabContentState{fallback: false, text: content})
 	return nil
 }
 

--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -473,6 +473,26 @@ func (w *TabbedWindow) InvalidateContent(instance *session.Instance, tab int, me
 	w.tab.InvalidateContent(instance, tab, message)
 }
 
+// RenderRevision returns the generation of the last completed pane render.
+func (w *TabbedWindow) RenderRevision() uint64 {
+	return w.tab.RenderRevision()
+}
+
+// InvalidateContentIfUnchanged replaces stale content only while both the
+// preview binding and completed render are unchanged from the caller's sample.
+func (w *TabbedWindow) InvalidateContentIfUnchanged(
+	instance *session.Instance,
+	tab int,
+	seq uint64,
+	renderRevision uint64,
+	message string,
+) bool {
+	if w.ContentSeq() != seq {
+		return false
+	}
+	return w.tab.InvalidateContentIfRevision(instance, tab, renderRevision, message)
+}
+
 // ResetToNormalMode resets the pane's tab view to normal (non-scroll) mode.
 func (w *TabbedWindow) ResetToNormalMode(instance *session.Instance) error {
 	return w.tab.ResetToNormalMode(instance, w.activeTab())


### PR DESCRIPTION
## Summary

- route local `af sessions preview` through the daemon-owned Preview handler instead of reconstructing and restoring a session in the CLI process
- resolve already-tracked preview/stream targets directly from the daemon's in-memory map, retaining the existing disk/ambiguity fallback only for genuine misses
- keep the last completed pane capture visible during a 200 ms fast-path grace window, then show an honest loading state if the current-target capture does not arrive; stop sidebar navigation from bypassing the existing 100 ms per-pane capture throttle
- add focused regressions for the CLI route, no-refresh resolver path, stale-first paint, bounded slow/hung fallback, deadline-race safety, latest-wins capture guard, and rapid-selection throttle

Fixes #2177.

## Profile and root cause

The `daemon_poll_interval = 1000` hypothesis was false. That interval schedules daemon status snapshots; the TUI preview path independently calls the daemon Preview RPC from an off-event-loop capture command.

### Production breakdown before the fix

| Measurement | Time |
|---|---:|
| `af sessions preview "Simplify Abstractions-9"` | 0.65–0.67 s |
| `af sessions list` | 0.03 s |
| configured zsh startup/Claude-command probe alone | 0.65–0.67 s |
| same CLI preview with `SHELL=/bin/sh` | 0.06 s |
| daemon HTTP Preview RPC | 206–244 ms |
| daemon Snapshot RPC | 9–12 ms |
| direct exact-target `tmux capture-pane` | <10 ms |

Strace showed why the CLI number was so fixed: rebuilding the local Instance ran the configured `source ~/.zshrc …; which claude` probe before capture. On this host that shell startup spawned 339 helper processes; the final capture itself was cheap. Routing the command to the daemon removes that entire client-side restore/probe.

The TUI had a separate roster-dependent delay. A repo-scoped title went through:

`Preview → agentServerForStream → resolveStreamSession → refreshLocked`

Because the title did not match a stable ID, it then fell through to `findSession`, which called `refreshLocked` again. Each refresh scanned and decoded every persisted session before capturing. At profiling time the box held 332 persisted rows (320 archived, 12 currently live), producing the 206–244 ms RPC even though the exact tmux capture was under 10 ms.

### Session-count scaling and selection cadence

A controlled container run isolated the scaling dimension:

| Persisted rows | Live rows | Preview before |
|---:|---:|---:|
| 1 | 1 | 3.3–4.3 ms |
| 3 | 3 | 3.4–4.1 ms |
| 19 | 1 | 7.9–9.3 ms |
| 19 | 3 | 7.3–8.6 ms |

Latency scaled with total persisted history, not live-session count: changing 1 → 3 live sessions at a fixed 19 rows was noise.

The real 80×24 TUI trace also answered repaint versus selection: the 100 ms preview tick dispatched one capture per repaint (8–15 ms each in the 19-row baseline), while each changed sidebar target zeroed `lastPaneCapture` and forced another capture inside that interval. Rapid arrowing therefore compounded work per selection as well as paying the steady repaint cadence. The sequence guard prevented stale results from painting, but did not prevent the redundant RPCs.

### After

| Persisted rows | Live rows | Daemon Preview | Local CLI preview |
|---:|---:|---:|---:|
| 3 | 3 | 2.6–3.5 ms | 11–14 ms |
| 19 | 1 | 2.6–2.8 ms | 10–11 ms |
| 19 | 3 | 2.5–2.9 ms | — |

The endpoint is now at the ~2 ms capture floor and stays flat as stored history grows. Under the real TUI driver at 19 rows, refreshes were typically 4–6 ms. Selection immediately keeps the last rendered frame, refreshes it in place, and shares the next allowed capture cadence instead of forcing a per-arrow RPC; the existing render-generation guard still drops late results for older targets.

### Slow and wedged captures

Before the follow-up, a non-`ErrSessionGone` capture error was only logged and left `TabPane.content` untouched. A capture that never returned emitted no `panesRefreshedMsg` at all. Because the current target's render generation remained valid, session A's last frame could therefore remain under session B's preview header indefinitely; the existing generation guard only protected against late results for *older* targets.

A genuine retarget now snapshots the pane's completed-render revision and arms a one-shot 200 ms grace timer—two 100 ms capture cadences, enough for a throttled selection to dispatch on the next tick and for the measured 4–6 ms local capture to land. If the same owner, target, and render sequence are still current and no completed target state has published, the timer conditionally replaces the stale frame with `Loading preview…`. The revision check and fallback write share the `TabPane` mutex, so a capture that lands at the deadline wins atomically; an older target's timer is rejected by the existing sequence/target checks. Any eventual successful capture still refreshes the loading state in place.

## Validation

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (no output)
- `go build ./...`
- `make test-container`
- `deadcode -test ./...` (no output)
- `scripts/lint-file-length.sh`
- `make tui-driver-selftest` (61/61 steps)
- focused `go test -race` coverage for slow expiry, deadline publication, and older-target rejection
- real containerized TUI at 80×24 and 60×15, including a deliberately stopped private sandbox daemon: stale content degraded to `Loading preview…`, then refreshed in place after the daemon resumed

— Captain Claude