### PR TITLE
feat(web): move session actions into the instances rail

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -343,17 +343,22 @@ header shows the session title, the terminal's connection state (`Live` /
 
 #### Per-session actions
 
-Below the terminal, three buttons act on the selected session (each behind a
-modal):
+The selected session's rail row quietly reveals two glyph actions; unselected rows
+stay free of action chrome:
 
-- **Prompt** — deliver a one-off prompt to the agent (the web analogue of
-  `af sessions send-prompt`).
-- **Archive** — move the session into the archived group (restorable).
-- **Kill** — tear the session down (behind a confirm).
+- **`▪` Archive** — move a live session into the archived group. On an archived
+  row the same slot becomes **`↶` Restore**.
+- **`⌫` Kill** — permanently tear the session down. Its resting treatment is
+  muted, while the confirmation remains explicitly destructive.
+
+Both actions keep their confirmation step. A **Retry** button appears in the pane
+header only when the selected session is blocked at a usage limit; it is the escape
+from that wall and stays hidden in every other state. Send follow-up instructions by
+typing in the attached terminal (or with `af sessions send-prompt`).
 
 **Create** a session with **`+ New`**; the new row appears in the rail and opens
-attached. All of create / kill / archive / prompt resolve the session by its stable
-id, so titles that collide across repos are never ambiguous.
+attached. Kill and archive resolve the selected session by its stable id, so titles
+that collide across repos are never ambiguous.
 
 ### Tabs
 

--- a/integration/web_loop_test.go
+++ b/integration/web_loop_test.go
@@ -15,8 +15,9 @@ import (
 // TestWebActionsLoop is the #1592 Phase 5 PR5 play-test in code: it drives the
 // EXACT daemon HTTP+WS endpoints the browser client speaks — CreateSession over
 // POST /v1/CreateSession, the live rail over the /v1/events WebSocket, the attach
-// terminal over /v1/sessions/{id}/stream, SendPrompt, and KillSession — against a
-// REAL daemon serving a REAL local tmux session in the container fence. It proves
+// terminal over /v1/sessions/{id}/stream and KillSession, plus the daemon's
+// SendPrompt control path — against a REAL daemon serving a REAL local tmux session
+// in the container fence. It proves
 // the v1 loop end to end (list → attach → type → create/kill) and the two
 // server-side correctness fixes this PR folds in:
 //
@@ -73,7 +74,7 @@ func TestWebActionsLoop(t *testing.T) {
 	term.waitOutput(t, "hello-from-web")
 	t.Log("STEP 4: attached the terminal by id and typed — the pane echoed it")
 
-	// --- send a prompt via SendPrompt, mirroring the send-prompt modal ---
+	// --- exercise the daemon's SendPrompt control path ---
 	if err := h.tryHTTPPost("/v1/SendPrompt", map[string]any{
 		"title":   title,
 		"repo_id": "",

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -209,14 +209,14 @@
       },
       "web": {
         "status": "yes",
-        "pointer": "web/src/api.ts:275 sendPrompt"
+        "pointer": "web/src/terminal.ts:151 onData -> sendInput"
       },
       "cli": {
         "status": "yes",
         "pointer": "api/sessions.go:346 sendPromptCmd"
       },
       "verdict": "parity",
-      "notes": "The TUI reaches this by typing into the live terminal rather than via the SendPrompt RPC; same user capability, different transport."
+      "notes": "The TUI and web reach this by typing into the live terminal rather than via the SendPrompt RPC; same user capability, different transport."
     },
     {
       "id": "session.send-prompt.broadcast",
@@ -281,7 +281,7 @@
       },
       "web": {
         "status": "yes",
-        "pointer": "web/src/api.ts:330 restoreSession -> RestoreSession; the pane header's Archive button becomes Restore on an archived row (web/src/ui.ts renderMain/patchMainHead)"
+        "pointer": "web/src/api.ts restoreSession -> RestoreSession; the selected rail row's Archive slot becomes Restore on an archived row (web/src/ui.ts selectedRowActions/patchMainHead)"
       },
       "cli": {
         "status": "yes",

--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -214,6 +214,7 @@ body {
 .af-project-switch:focus-visible,
 .af-project-item:focus-visible,
 .af-rail-filter:focus-visible,
+.af-rail-action:focus-visible,
 .af-filter-item:focus-visible,
 .af-task-action:focus-visible {
   outline: 2px solid var(--af-accent);
@@ -792,6 +793,41 @@ body {
 .af-row-main {
   min-width: 0;
   flex: 1;
+}
+.af-row-actions {
+  display: flex;
+  align-items: center;
+  align-self: center;
+  flex: 0 0 auto;
+  gap: 0.15rem;
+}
+.af-rail-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.6rem;
+  height: 1.6rem;
+  padding: 0;
+  background: transparent;
+  color: var(--af-text-2);
+  border: 1px solid var(--af-border);
+  border-radius: var(--af-r-md);
+  font: inherit;
+  font-size: var(--af-fs-sm);
+  line-height: 1;
+  cursor: pointer;
+}
+.af-rail-action:hover {
+  color: var(--af-text);
+  border-color: var(--af-border-strong);
+}
+.af-rail-kill {
+  color: var(--af-text-3);
+  border-color: transparent;
+}
+.af-rail-kill:hover {
+  color: var(--af-danger);
+  border-color: var(--af-border-strong);
 }
 .af-row-title {
   font-size: var(--af-fs-md);
@@ -1744,10 +1780,14 @@ body {
   }
   .af-rail-new,
   .af-rail-filter,
+  .af-rail-action,
   .af-project-switch,
   .af-viewtab,
   .af-theme-opt {
     min-height: 2.25rem;
+  }
+  .af-rail-action {
+    min-width: 2.25rem;
   }
   .af-row {
     padding-top: var(--af-sp-3);

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -6265,9 +6265,6 @@ async function createSession(input, token2) {
   const resp = await af("CreateSession", body, token2);
   return resp.instance;
 }
-async function sendPrompt(id, title, prompt, token2) {
-  await af("SendPrompt", { id, title, repo_id: "", prompt }, token2);
-}
 async function killSession(id, title, token2) {
   await af("KillSession", { id, title, repo_id: "" }, token2);
 }
@@ -6644,29 +6641,6 @@ function newSessionModal(projects, defaultProject2, callbacks) {
     });
   });
   queueMicrotask(() => titleInput.focus());
-  return handle;
-}
-function promptModal(sessionTitle, callbacks) {
-  const { handle, body } = modalChrome({
-    title: `Send prompt to ${sessionTitle}`,
-    confirmLabel: "Send",
-    confirmClass: "af-primary",
-    onCancel: callbacks.onCancel
-  });
-  const area = h("textarea", { class: "af-input af-textarea", placeholder: "Prompt", rows: 4 });
-  area.setAttribute("aria-label", "Prompt");
-  body.append(area);
-  const card = handle.el.firstElementChild;
-  asForm(card, () => {
-    const text = area.value.trim();
-    if (text === "") {
-      handle.setError("Enter a prompt to send.");
-      return;
-    }
-    handle.setError(null);
-    callbacks.onSubmit(text);
-  });
-  queueMicrotask(() => area.focus());
   return handle;
 }
 function confirmModal(opts) {
@@ -10610,11 +10584,11 @@ var AppShell = class {
   // Header text nodes for the selected pane, (re)created per selection.
   headTitle = null;
   headMeta = null;
-  // The archive/restore lifecycle button and the archived-ness it currently shows
-  // (#1932). The header STRUCTURE is only rebuilt on a selection change, but a session
-  // can flip archived⇄live WITHOUT one (archiving or restoring the row that is already
-  // selected — the common path), so patchMainHead swaps this button's verb in place,
-  // exactly as it patches the header text. null when nothing is selected.
+  // The selected rail row's archive/restore control and the archived-ness it currently
+  // shows (#1932, #2186). A session can flip archived⇄live WITHOUT a selection change
+  // (archiving or restoring the row that is already selected — the common path), so
+  // patchMainHead swaps this control's glyph + accessible verb in place, exactly as it
+  // patches the header text. null when the selected row is not visible in the rail.
   lifecycleBtn = null;
   lifecycleArchived = false;
   // The usage-limit Retry button and whether it is currently shown (#1934). Same
@@ -10817,6 +10791,7 @@ var AppShell = class {
   renderRail(state) {
     const scoped = scopeToProject(state.sessions, state.selectedProject);
     const visible = filterSessions(orderedSessions(scoped), state.statusFilter);
+    this.lifecycleBtn = null;
     this.railCount.textContent = String(visible.length);
     this.renderFilterMenu(state, scoped);
     const list = this.railList;
@@ -10832,9 +10807,50 @@ var AppShell = class {
       );
       return;
     }
-    const rows = visible.map((s) => sessionRow(s, s.id === state.selectedId, this.actions));
+    const rows = visible.map((s) => {
+      const selected = s.id === state.selectedId;
+      return sessionRow(s, selected, this.actions, selected ? this.selectedRowActions(s) : null);
+    });
     const notice = this.railNotice(state, scoped, visible);
     list.replaceChildren(...notice ? [notice, ...rows] : rows);
+  }
+  /** Quiet per-session controls shown only beside the selected rail row (#2186).
+   *  Archive/Restore share one slot; the click reads lifecycleArchived at gesture
+   *  time so patchMainHead can change the action without rebuilding the row. */
+  selectedRowActions(selected) {
+    const lifecycleBtn = h2("button", { type: "button", class: "af-rail-action af-rail-lifecycle" });
+    lifecycleBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      if (this.lifecycleArchived) {
+        this.actions.restore();
+      } else {
+        this.actions.archive();
+      }
+    });
+    this.lifecycleBtn = lifecycleBtn;
+    this.patchLifecycleButton(isArchived(selected));
+    const killBtn = h2("button", { type: "button", class: "af-rail-action af-rail-kill" }, "\u232B");
+    killBtn.setAttribute("aria-label", "Kill session");
+    killBtn.setAttribute("title", "Kill session");
+    killBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this.actions.kill();
+    });
+    return h2("div", { class: "af-row-actions" }, lifecycleBtn, killBtn);
+  }
+  /** Applies both the visible static glyph and the accessible reverse verb to the
+   *  selected row's lifecycle slot. Kept in one helper so render and live patching
+   *  cannot disagree about what an archived row offers. */
+  patchLifecycleButton(archived) {
+    const btn = this.lifecycleBtn;
+    if (!btn) {
+      return;
+    }
+    this.lifecycleArchived = archived;
+    const verb = archived ? "Restore session" : "Archive session";
+    btn.textContent = archived ? "\u21B6" : "\u25AA";
+    btn.setAttribute("aria-label", verb);
+    btn.setAttribute("title", verb);
   }
   /**
    * The dim one-liner above the rows explaining what ISN'T there, or null when the
@@ -11095,7 +11111,6 @@ var AppShell = class {
     if (!selected) {
       this.headTitle = null;
       this.headMeta = null;
-      this.lifecycleBtn = null;
       this.retryBtn = null;
       this.retryVisible = false;
       this.tabBar = null;
@@ -11109,25 +11124,13 @@ var AppShell = class {
     this.headTitle = h2("span", { class: "af-term-title" }, selected.title);
     this.headMeta = h2("span", { class: "af-term-meta" });
     const titleBox = h2("div", { class: "af-term-head-main" }, this.headTitle, this.headMeta);
-    const promptBtn = h2("button", { type: "button", class: "af-ghost af-term-action" }, "Prompt");
-    promptBtn.addEventListener("click", () => this.actions.sendPrompt());
-    this.lifecycleArchived = isArchived(selected);
-    const lifecycleBtn = h2(
-      "button",
-      { type: "button", class: "af-ghost af-term-action" },
-      this.lifecycleArchived ? "Restore" : "Archive"
-    );
-    lifecycleBtn.addEventListener("click", () => this.lifecycleArchived ? this.actions.restore() : this.actions.archive());
-    this.lifecycleBtn = lifecycleBtn;
     const retryBtn = h2("button", { type: "button", class: "af-ghost af-term-action" }, "Retry");
     retryBtn.title = "Resume this session from its usage-limit wall";
     retryBtn.addEventListener("click", () => this.actions.retryLimit());
     this.retryBtn = retryBtn;
     this.retryVisible = isLimitReached(selected);
     retryBtn.hidden = !this.retryVisible;
-    const killBtn = h2("button", { type: "button", class: "af-danger af-term-action" }, "Kill");
-    killBtn.addEventListener("click", () => this.actions.kill());
-    const actions2 = h2("div", { class: "af-term-actions" }, promptBtn, retryBtn, lifecycleBtn, killBtn);
+    const actions2 = h2("div", { class: "af-term-actions" }, retryBtn);
     const head = h2("div", { class: "af-term-head" }, titleBox, actions2);
     this.tabBar = h2("div", { class: "af-tabbar" });
     this.tabBar.setAttribute("role", "tablist");
@@ -11320,8 +11323,7 @@ var AppShell = class {
     this.headMeta.className = `af-term-meta af-term-${state.termStatus}`;
     const nowArchived = isArchived(selected);
     if (this.lifecycleBtn && nowArchived !== this.lifecycleArchived) {
-      this.lifecycleArchived = nowArchived;
-      this.lifecycleBtn.textContent = nowArchived ? "Restore" : "Archive";
+      this.patchLifecycleButton(nowArchived);
     }
     const nowLimited = isLimitReached(selected);
     if (this.retryBtn && nowLimited !== this.retryVisible) {
@@ -11425,7 +11427,7 @@ function beginTabRename(btn, tab, actions2, editedId, editedSessionId) {
   input.focus();
   input.select();
 }
-function sessionRow(s, selected, actions2) {
+function sessionRow(s, selected, actions2, rowActions) {
   const status = rowStatus(s);
   const title = h2("div", { class: "af-row-title" }, rowTitle(s));
   const branch = h2(
@@ -11444,6 +11446,9 @@ function sessionRow(s, selected, actions2) {
     row.append(dot);
   }
   row.append(main);
+  if (rowActions) {
+    row.append(rowActions);
+  }
   row.setAttribute("role", "option");
   row.setAttribute("aria-selected", selected ? "true" : "false");
   row.setAttribute("title", `${s.title} \u2014 ${status.label}`);
@@ -11740,29 +11745,6 @@ function newSession() {
             store.set({ sessions, selectedId: created.id, activeTab: 0, tabError: null });
           }
         }).catch((e) => {
-          m.setBusy(false);
-          m.setError(describeError(e));
-        });
-      },
-      onCancel: closeModal
-    })
-  );
-}
-function openSendPrompt() {
-  const sel = selectedSession2();
-  if (!sel) {
-    return;
-  }
-  openModal(
-    promptModal(sel.title, {
-      onSubmit: (text) => {
-        const tok = token;
-        if (tok === null || !modal) {
-          return;
-        }
-        const m = modal;
-        m.setBusy(true);
-        void sendPrompt(sel.id, sel.title, text, tok).then(closeModal).catch((e) => {
           m.setBusy(false);
           m.setError(describeError(e));
         });
@@ -12136,7 +12118,6 @@ var actions = {
   disconnect,
   open: openFromRail,
   newSession,
-  sendPrompt: openSendPrompt,
   kill: () => openConfirm("kill"),
   archive: () => openConfirm("archive"),
   restore: () => openConfirm("restore"),

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "57934ce5de98";
+const VERSION = "8623085e972b";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -20,7 +20,7 @@
 //
 // The daemon runs with the shipped default require_token=false, so NO peer needs a
 // token — the SPA's /v1/auth-info probe reports auth_required=false, the login screen
-// is skipped, and every core action (create/kill/archive/send-prompt/attach) runs on
+// is skipped, and every core action (create/kill/archive/restore/retry/attach) runs on
 // the empty-token credential. That makes this harness the end-to-end regression guard
 // that tokenless authorization works for ALL actions, not just the read path.
 //
@@ -97,6 +97,11 @@ const SESSION_ORDER = process.env.AF_WEB_SESSION_ORDER ?? "probe-order";
 /** A rail row by its session title. */
 function row(page: Page, title: string): Locator {
   return page.locator(".af-rail-list .af-row", { hasText: title });
+}
+
+/** One of the quiet lifecycle glyphs revealed on the selected rail row (#2186). */
+function railAction(page: Page, title: string, name: "Archive session" | "Restore session" | "Kill session"): Locator {
+  return row(page, title).getByRole("button", { name, exact: true });
 }
 
 /** One state's checkbox in the rail's filter menu (feat: hide archived by default). */
@@ -745,6 +750,17 @@ test("status dots (#1766): waiting shows a green dot, working shows none, error 
   await expect(p.locator(".af-dot-spin")).toHaveCount(0);
   await expect(p.locator(".af-dot-working")).toHaveCount(0);
 
+  // Retry remains the conditional pane-header escape from a usage-limit wall
+  // (#1934): selecting the synthetic limit row reveals it, while selecting an
+  // ordinary waiting row withdraws it. The rail move must not displace this path.
+  await row(p, "probe-limit").click();
+  const retry = p.locator(".af-term-head button", { hasText: "Retry" });
+  await expect(retry).toBeVisible();
+  await expect(row(p, "probe-limit").locator(".af-row-actions")).toBeVisible();
+  await expect(row(p, "probe-waiting").locator(".af-row-actions")).toHaveCount(0);
+  await row(p, "probe-waiting").click();
+  await expect(retry).toBeHidden();
+
   await ctx.close();
 });
 
@@ -764,6 +780,19 @@ test("click-to-attach opens the xterm terminal and shows live output", async () 
   // the attach into terminal mode (#1693/#1694).
   await expect(page.locator(".af-term-meta")).toContainText("Live");
   await expect(page.locator(".af-app.af-kb-terminal")).toBeVisible();
+
+  // The quiet actions live beside the selected instance, not permanently in the
+  // terminal header or on every rail row. Kill is a muted glyph here; af-danger is
+  // reserved for the confirmation step.
+  await expect(page.locator(".af-row-actions")).toHaveCount(1);
+  await expect(row(page, SESSION_A).locator(".af-row-actions")).toBeVisible();
+  await expect(row(page, SESSION_B).locator(".af-row-actions")).toHaveCount(0);
+  await expect(railAction(page, SESSION_A, "Archive session")).toHaveText("▪");
+  await expect(railAction(page, SESSION_A, "Kill session")).toHaveText("⌫");
+  await expect(railAction(page, SESSION_A, "Kill session")).not.toHaveClass(/af-danger/);
+  await expect(page.locator(".af-term-head button", { hasText: "Prompt" })).toHaveCount(0);
+  await expect(page.locator(".af-term-head button", { hasText: "Archive" })).toHaveCount(0);
+  await expect(page.locator(".af-term-head button", { hasText: "Kill" })).toHaveCount(0);
 });
 
 test("the #1694 keyboard model: j/k navigate, Enter attaches, Escape returns to rail", async () => {
@@ -777,8 +806,11 @@ test("the #1694 keyboard model: j/k navigate, Enter attaches, Escape returns to 
   // always navigate the rail in nav mode. (Pre-#1693 j/k silently fed the agent.)
   await page.keyboard.press("j");
   await expect(row(page, SESSION_A)).not.toHaveClass(/af-row-selected/);
+  await expect(row(page, SESSION_A).locator(".af-row-actions")).toHaveCount(0);
   const movedTo = page.locator(".af-rail-list .af-row.af-row-selected");
   await expect(movedTo).toHaveCount(1);
+  await expect(movedTo.locator(".af-row-actions")).toBeVisible();
+  await expect(page.locator(".af-row-actions")).toHaveCount(1);
   await expect(page.locator(".af-app.af-kb-rail")).toBeVisible();
 
   // k moves back up to A — j/k are symmetric rail navigation.
@@ -2451,11 +2483,11 @@ test.describe("create → kill (one session, two flows)", () => {
 
   test("kill: the kill confirm removes the session's row", async () => {
     expect(createdTitle).not.toBe("");
-    // The created session is the current selection, so the pane header shows its
-    // actions. Kill it and confirm.
+    // The created session is the current selection, so its rail row reveals the
+    // quiet actions. Kill it and confirm.
     await row(page, createdTitle).click();
     await expect(page.locator(".af-main.af-main-term")).toBeVisible();
-    await page.locator(".af-term-head button.af-danger").click();
+    await railAction(page, createdTitle, "Kill session").click();
 
     const modal = page.locator(".af-modal-card");
     await expect(modal).toBeVisible();
@@ -2472,8 +2504,8 @@ test("archive: the archive confirm retires the session out of the default rail",
   await row(page, SESSION_B).click();
   await expect(page.locator(".af-main.af-main-term")).toBeVisible();
 
-  // The Archive action is the ghost button labeled "Archive" in the pane header.
-  await page.locator(".af-term-head button", { hasText: "Archive" }).click();
+  // Archive is the quiet ▪ glyph beside the selected row, not a labelled header chip.
+  await railAction(page, SESSION_B, "Archive session").click();
   const modal = page.locator(".af-modal-card");
   await expect(modal).toBeVisible();
   await modal.locator("button.af-primary").click();
@@ -2498,15 +2530,14 @@ test("archive: the archive confirm retires the session out of the default rail",
   await expect(row(page, SESSION_B)).toHaveCount(0);
 });
 
-test("restore (#1932): the pane header's Restore action brings an archived session back to the live rail", async () => {
+test("restore (#1932): the selected rail row's Restore action brings an archived session back", async () => {
   // The return leg of archive. The preceding test left B archived; the web could
   // shelve a session but — until #1932 — offered no way back, contradicting the "you
   // can restore it later" copy the archive confirm itself prints. This drives the real
   // round-trip through the daemon AND pins the LIVE button swap: renderMain (which
   // builds the pane header) runs only on a selection change, so archiving/restoring
-  // the row that STAYS selected has to flip Archive⇄Restore in place — the exact bug
-  // the first cut of this test caught (an archived, still-selected row kept its stale
-  // Archive button, a daemon no-op).
+  // the row that STAYS selected has to flip Archive⇄Restore in place — now in the
+  // rail, but still patched by patchMainHead rather than decided only at render time.
   //
   // Hold the archived filter ON for the whole flow so B stays visible in the rail
   // across both transitions; restore the default (archived hidden) only at the end,
@@ -2517,11 +2548,11 @@ test("restore (#1932): the pane header's Restore action brings an archived sessi
   await row(page, SESSION_B).click();
   await expect(page.locator(".af-main.af-main-term")).toBeVisible();
 
-  // An archived session's lifecycle button IS Restore, not Archive — the reverse verb
-  // on the same slot, never a second button.
-  const head = page.locator(".af-term-head");
-  await expect(head.locator("button", { hasText: "Archive" })).toHaveCount(0);
-  await head.locator("button", { hasText: "Restore" }).click();
+  // An archived session's lifecycle slot IS Restore, not Archive — one selected-row
+  // slot whose accessible verb and static glyph both reverse.
+  await expect(railAction(page, SESSION_B, "Archive session")).toHaveCount(0);
+  await expect(railAction(page, SESSION_B, "Restore session")).toHaveText("↶");
+  await railAction(page, SESSION_B, "Restore session").click();
 
   // Restore is a confirm (mirroring kill/archive), so it inherits their busy/error
   // surface; the primary button POSTs RestoreSession.
@@ -2533,21 +2564,21 @@ test("restore (#1932): the pane header's Restore action brings an archived sessi
   // The daemon's session.restored event resyncs the rail: B rejoins the LIVE group,
   // no longer archived — the end-to-end proof the archived session returned to active.
   await expect(row(page, SESSION_B)).not.toHaveClass(/af-row-archived/, { timeout: 30_000 });
-  // ...and its pane header — STILL selected, never reselected — flips its verb back to
-  // Archive in place: the patchMainHead swap the selection-change-only rebuild misses.
-  await expect(head.locator("button", { hasText: "Restore" })).toHaveCount(0, { timeout: 30_000 });
-  await expect(head.locator("button", { hasText: "Archive" })).toHaveCount(1);
+  // ...and its rail row — STILL selected, never reselected — flips its verb back to
+  // Archive in place: the patchMainHead path remains load-bearing after the move.
+  await expect(railAction(page, SESSION_B, "Restore session")).toHaveCount(0, { timeout: 30_000 });
+  await expect(railAction(page, SESSION_B, "Archive session")).toHaveText("▪");
 
   // Re-archive from that same live-flipped button (NO reselect): restores the fixture
   // the downstream filter tests need (B archived) and re-proves both the archive leg
   // and the reverse (Archive→Restore) live flip in one flow.
-  await head.locator("button", { hasText: "Archive" }).click();
+  await railAction(page, SESSION_B, "Archive session").click();
   const archiveModal = page.locator(".af-modal-card");
   await expect(archiveModal).toBeVisible();
   await archiveModal.locator("button.af-primary").click();
   await expect(row(page, SESSION_B)).toHaveClass(/af-row-archived/, { timeout: 30_000 });
-  await expect(head.locator("button", { hasText: "Archive" })).toHaveCount(0);
-  await expect(head.locator("button", { hasText: "Restore" })).toHaveCount(1);
+  await expect(railAction(page, SESSION_B, "Archive session")).toHaveCount(0);
+  await expect(railAction(page, SESSION_B, "Restore session")).toHaveText("↶");
 
   // Back to the default filter (archived hidden): B drops from the rail, exactly as
   // the archive test left it.
@@ -5315,6 +5346,26 @@ test("mobile (375px): the rail auto-collapses to a drawer; the hamburger reveals
   await expect(app).not.toHaveClass(/af-nav-open/);
   await expect(rail).not.toBeVisible();
   await expect(p.locator(".af-main.af-main-term")).toBeVisible();
+
+  // Re-open the narrow drawer with a selection: both quiet glyphs fit inside the row
+  // without squeezing its title away or widening the page.
+  await toggle.click();
+  await expect(rail).toBeVisible();
+  await expect(railAction(p, SESSION_A, "Archive session")).toBeVisible();
+  await expect(railAction(p, SESSION_A, "Kill session")).toBeVisible();
+  const fit = await row(p, SESSION_A).evaluate((el) => {
+    const rowBox = el.getBoundingClientRect();
+    const mainBox = el.querySelector(".af-row-main")!.getBoundingClientRect();
+    const actionBox = el.querySelector(".af-row-actions")!.getBoundingClientRect();
+    return {
+      mainWidth: mainBox.width,
+      actionsInside: actionBox.right <= rowBox.right + 1,
+      overflow: el.scrollWidth - el.clientWidth,
+    };
+  });
+  expect(fit.mainWidth, "the selected row keeps readable room for its title").toBeGreaterThan(80);
+  expect(fit.actionsInside, "the action glyphs stay inside the selected row").toBe(true);
+  expect(fit.overflow, "the selected row does not overflow at 375px").toBeLessThanOrEqual(1);
 
   await ctx.close();
 });

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -38,7 +38,6 @@ import {
   reorderTab,
   restoreSession,
   resumeFromLimit,
-  sendPrompt,
   shouldForgetToken,
   storeToken,
   triggerTask,
@@ -46,7 +45,7 @@ import {
 } from "./api.js";
 import { createKeyedQueue } from "./config.js";
 import { EventStream, type EventStreamStatus } from "./events.js";
-import { confirmDeleteProjectModal, confirmModal, type ModalHandle, newSessionModal, promptModal } from "./modals.js";
+import { confirmDeleteProjectModal, confirmModal, type ModalHandle, newSessionModal } from "./modals.js";
 import { InstallAffordance } from "./install.js";
 import { decideKey, type KeyboardFocus, type View } from "./nav.js";
 import { defaultFilter, filterSessions, loadFilter, persistFilter, withKind } from "./filter.js";
@@ -133,7 +132,7 @@ const store = new Store<AppState>({
 // daemon requires no token for this client (loopback, or require_token=false) —
 // a fully authorized connection. Every "am I connected?" guard MUST test
 // `token === null`, never `!token`, or a tokenless client's create/kill/archive/
-// send-prompt/attach would be silently skipped because `!"" === true`.
+// restore/retry/attach would be silently skipped because `!"" === true`.
 let token: string | null = null;
 let stream: EventStream | null = null;
 
@@ -592,37 +591,9 @@ function newSession(): void {
   );
 }
 
-/** Opens the send-prompt modal for the selected session. */
-function openSendPrompt(): void {
-  const sel = selectedSession();
-  if (!sel) {
-    return;
-  }
-  openModal(
-    promptModal(sel.title, {
-      onSubmit: (text: string) => {
-        const tok = token;
-        // `=== null` not `!tok`: "" is the authorized-tokenless credential (#1696).
-        if (tok === null || !modal) {
-          return;
-        }
-        const m = modal;
-        m.setBusy(true);
-        void sendPrompt(sel.id, sel.title, text, tok)
-          .then(closeModal)
-          .catch((e) => {
-            m.setBusy(false);
-            m.setError(describeError(e));
-          });
-      },
-      onCancel: closeModal,
-    }),
-  );
-}
-
 /** Opens the kill/archive/restore confirm modal for the selected session. Restore
- *  is the reverse of archive (#1932): the archived row's Archive button becomes a
- *  Restore button, and confirming it POSTs RestoreSession. */
+ *  is the reverse of archive (#1932): the archived row's lifecycle glyph becomes
+ *  Restore, and confirming it POSTs RestoreSession. */
 function openConfirm(action: "kill" | "archive" | "restore"): void {
   const sel = selectedSession();
   if (!sel) {
@@ -1316,7 +1287,6 @@ const actions = {
   disconnect,
   open: openFromRail,
   newSession,
-  sendPrompt: openSendPrompt,
   kill: () => openConfirm("kill"),
   archive: () => openConfirm("archive"),
   restore: () => openConfirm("restore"),

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -252,6 +252,7 @@ body {
 .af-project-switch:focus-visible,
 .af-project-item:focus-visible,
 .af-rail-filter:focus-visible,
+.af-rail-action:focus-visible,
 .af-filter-item:focus-visible,
 .af-task-action:focus-visible {
   outline: 2px solid var(--af-accent);
@@ -993,6 +994,50 @@ body {
 .af-row-main {
   min-width: 0;
   flex: 1;
+}
+
+/* Per-session lifecycle controls (#2186): only the selected row creates this slot.
+ * Archive/Restore matches the rail filter's quiet outlined-glyph treatment; Kill is
+ * quieter still at rest (a bare, muted ⌫) and becomes explicit through its distinct
+ * glyph, accessible name, and the unchanged destructive confirm step. */
+.af-row-actions {
+  display: flex;
+  align-items: center;
+  align-self: center;
+  flex: 0 0 auto;
+  gap: 0.15rem;
+}
+
+.af-rail-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.6rem;
+  height: 1.6rem;
+  padding: 0;
+  background: transparent;
+  color: var(--af-text-2);
+  border: 1px solid var(--af-border);
+  border-radius: var(--af-r-md);
+  font: inherit;
+  font-size: var(--af-fs-sm);
+  line-height: 1;
+  cursor: pointer;
+}
+
+.af-rail-action:hover {
+  color: var(--af-text);
+  border-color: var(--af-border-strong);
+}
+
+.af-rail-kill {
+  color: var(--af-text-3);
+  border-color: transparent;
+}
+
+.af-rail-kill:hover {
+  color: var(--af-danger);
+  border-color: var(--af-border-strong);
 }
 
 .af-row-title {
@@ -2318,10 +2363,15 @@ body {
 
   .af-rail-new,
   .af-rail-filter,
+  .af-rail-action,
   .af-project-switch,
   .af-viewtab,
   .af-theme-opt {
     min-height: 2.25rem;
+  }
+
+  .af-rail-action {
+    min-width: 2.25rem;
   }
 
   .af-row {

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -133,8 +133,6 @@ export interface Actions {
   open(id: string): void;
   /** Opens the new-session modal (#1592 Phase 5 PR5). */
   newSession(): void;
-  /** Opens the send-prompt modal for the current selection. */
-  sendPrompt(): void;
   /** Opens the kill-confirm modal for the current selection. */
   kill(): void;
   /** Opens the archive-confirm modal for the current selection. */
@@ -560,11 +558,11 @@ export class AppShell {
   // Header text nodes for the selected pane, (re)created per selection.
   private headTitle: HTMLElement | null = null;
   private headMeta: HTMLElement | null = null;
-  // The archive/restore lifecycle button and the archived-ness it currently shows
-  // (#1932). The header STRUCTURE is only rebuilt on a selection change, but a session
-  // can flip archived⇄live WITHOUT one (archiving or restoring the row that is already
-  // selected — the common path), so patchMainHead swaps this button's verb in place,
-  // exactly as it patches the header text. null when nothing is selected.
+  // The selected rail row's archive/restore control and the archived-ness it currently
+  // shows (#1932, #2186). A session can flip archived⇄live WITHOUT a selection change
+  // (archiving or restoring the row that is already selected — the common path), so
+  // patchMainHead swaps this control's glyph + accessible verb in place, exactly as it
+  // patches the header text. null when the selected row is not visible in the rail.
   private lifecycleBtn: HTMLElement | null = null;
   private lifecycleArchived = false;
   // The usage-limit Retry button and whether it is currently shown (#1934). Same
@@ -1038,6 +1036,10 @@ export class AppShell {
   private renderRail(state: AppState): void {
     const scoped = scopeToProject(state.sessions, state.selectedProject);
     const visible = filterSessions(orderedSessions(scoped), state.statusFilter);
+    // Every rebuild replaces the row controls. Drop the old reference first so a
+    // selected row hidden by the project/status filter cannot leave patchMainHead
+    // mutating a detached button.
+    this.lifecycleBtn = null;
     // The count is what the rail SHOWS, not what the project holds — a count that
     // disagrees with the rows under it is just a bug the user has to reconcile. The
     // filter menu carries the per-state totals for what's hidden.
@@ -1058,9 +1060,55 @@ export class AppShell {
       );
       return;
     }
-    const rows = visible.map((s) => sessionRow(s, s.id === state.selectedId, this.actions));
+    const rows = visible.map((s) => {
+      const selected = s.id === state.selectedId;
+      return sessionRow(s, selected, this.actions, selected ? this.selectedRowActions(s) : null);
+    });
     const notice = this.railNotice(state, scoped, visible);
     list.replaceChildren(...(notice ? [notice, ...rows] : rows));
+  }
+
+  /** Quiet per-session controls shown only beside the selected rail row (#2186).
+   *  Archive/Restore share one slot; the click reads lifecycleArchived at gesture
+   *  time so patchMainHead can change the action without rebuilding the row. */
+  private selectedRowActions(selected: SessionData): HTMLElement {
+    const lifecycleBtn = h("button", { type: "button", class: "af-rail-action af-rail-lifecycle" });
+    lifecycleBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      if (this.lifecycleArchived) {
+        this.actions.restore();
+      } else {
+        this.actions.archive();
+      }
+    });
+    this.lifecycleBtn = lifecycleBtn;
+    this.patchLifecycleButton(isArchived(selected));
+
+    // Kill stays unmistakably destructive through its distinct ⌫ glyph and confirm,
+    // but its resting rail treatment is deliberately muted instead of af-danger.
+    const killBtn = h("button", { type: "button", class: "af-rail-action af-rail-kill" }, "⌫");
+    killBtn.setAttribute("aria-label", "Kill session");
+    killBtn.setAttribute("title", "Kill session");
+    killBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this.actions.kill();
+    });
+    return h("div", { class: "af-row-actions" }, lifecycleBtn, killBtn);
+  }
+
+  /** Applies both the visible static glyph and the accessible reverse verb to the
+   *  selected row's lifecycle slot. Kept in one helper so render and live patching
+   *  cannot disagree about what an archived row offers. */
+  private patchLifecycleButton(archived: boolean): void {
+    const btn = this.lifecycleBtn;
+    if (!btn) {
+      return;
+    }
+    this.lifecycleArchived = archived;
+    const verb = archived ? "Restore session" : "Archive session";
+    btn.textContent = archived ? "↶" : "▪";
+    btn.setAttribute("aria-label", verb);
+    btn.setAttribute("title", verb);
   }
 
   /**
@@ -1358,7 +1406,6 @@ export class AppShell {
     if (!selected) {
       this.headTitle = null;
       this.headMeta = null;
-      this.lifecycleBtn = null;
       this.retryBtn = null;
       this.retryVisible = false;
       this.tabBar = null;
@@ -1373,27 +1420,6 @@ export class AppShell {
     this.headTitle = h("span", { class: "af-term-title" }, selected.title);
     this.headMeta = h("span", { class: "af-term-meta" });
     const titleBox = h("div", { class: "af-term-head-main" }, this.headTitle, this.headMeta);
-
-    // Per-session actions (#1592 Phase 5 PR5): send a prompt, or kill/archive
-    // behind a confirm. They act on the current selection; index.ts reads it.
-    const promptBtn = h("button", { type: "button", class: "af-ghost af-term-action" }, "Prompt");
-    promptBtn.addEventListener("click", () => this.actions.sendPrompt());
-    // Archive and restore are reverse verbs on the same slot: an archived session
-    // can't be archived again (the daemon rejects it, mirroring the TUI's `a`
-    // no-op), and restore is the only way back — so an archived row shows Restore
-    // where a live row shows Archive (#1932). This makes the "you can restore it
-    // later" copy the archive confirm prints actually reachable from the web. The
-    // click handler reads this.lifecycleArchived (not a render-time capture) so
-    // patchMainHead can flip the verb in place when the row is archived/restored
-    // while it stays selected, without a header rebuild.
-    this.lifecycleArchived = isArchived(selected);
-    const lifecycleBtn = h(
-      "button",
-      { type: "button", class: "af-ghost af-term-action" },
-      this.lifecycleArchived ? "Restore" : "Archive",
-    );
-    lifecycleBtn.addEventListener("click", () => (this.lifecycleArchived ? this.actions.restore() : this.actions.archive()));
-    this.lifecycleBtn = lifecycleBtn;
 
     // Retry, for a session parked at a usage-limit wall (#1934). The web rendered
     // that state — ◆ glyph, "Limit reached" label, "[limit] resets …" title prefix
@@ -1416,9 +1442,7 @@ export class AppShell {
     this.retryVisible = isLimitReached(selected);
     retryBtn.hidden = !this.retryVisible;
 
-    const killBtn = h("button", { type: "button", class: "af-danger af-term-action" }, "Kill");
-    killBtn.addEventListener("click", () => this.actions.kill());
-    const actions = h("div", { class: "af-term-actions" }, promptBtn, retryBtn, lifecycleBtn, killBtn);
+    const actions = h("div", { class: "af-term-actions" }, retryBtn);
 
     const head = h("div", { class: "af-term-head" }, titleBox, actions);
 
@@ -1683,14 +1707,13 @@ export class AppShell {
     this.headMeta.textContent = parts.join(" · ");
     this.headMeta.className = `af-term-meta af-term-${state.termStatus}`;
 
-    // Flip the lifecycle button's verb if the selected row was archived or restored
-    // without a selection change (renderMain, which builds the button, runs only on a
-    // selection change — #1932). Archiving the currently-selected session must turn
-    // its Archive button into Restore live, and a restore must turn it back.
+    // Flip the selected rail row's lifecycle glyph + accessible verb if it was
+    // archived or restored without a selection change (#1932, #2186). The rail is
+    // often rebuilt by a fresh Snapshot too, but that is not a safe prerequisite:
+    // this patch is what keeps a same-selection state change correct in place.
     const nowArchived = isArchived(selected);
     if (this.lifecycleBtn && nowArchived !== this.lifecycleArchived) {
-      this.lifecycleArchived = nowArchived;
-      this.lifecycleBtn.textContent = nowArchived ? "Restore" : "Archive";
+      this.patchLifecycleButton(nowArchived);
     }
 
     // Show/hide Retry as the selected session enters or leaves the usage-limit wall
@@ -1973,11 +1996,11 @@ function beginTabRename(
   input.select();
 }
 
-/** One session row: a status dot, the (prefixed) title, and the branch line —
- *  the same three signals the TUI row carries (ui/tree/render.go). Clicking opens
- *  the session by its stable id (selects it and attaches its terminal, #1693); a
- *  row lacking an id (never expected from a live Snapshot) is rendered but inert. */
-function sessionRow(s: SessionData, selected: boolean, actions: Actions): HTMLElement {
+/** One session row: a status dot, the (prefixed) title, the branch line, and (only
+ *  when selected) its quiet lifecycle actions (#2186). Clicking opens the session by
+ *  its stable id (selects it and attaches its terminal, #1693); a row lacking an id
+ *  (never expected from a live Snapshot) is rendered but inert. */
+function sessionRow(s: SessionData, selected: boolean, actions: Actions, rowActions: HTMLElement | null): HTMLElement {
   const status = rowStatus(s);
 
   const title = h("div", { class: "af-row-title" }, rowTitle(s));
@@ -2001,6 +2024,9 @@ function sessionRow(s: SessionData, selected: boolean, actions: Actions): HTMLEl
     row.append(dot);
   }
   row.append(main);
+  if (rowActions) {
+    row.append(rowActions);
+  }
   row.setAttribute("role", "option");
   row.setAttribute("aria-selected", selected ? "true" : "false");
   row.setAttribute("title", `${s.title} — ${status.label}`);


### PR DESCRIPTION
## Summary

- remove the Prompt chip and move Archive/Restore plus Kill into the selected instances-rail row
- use quiet static glyph controls, with Kill muted at rest while preserving its destructive confirmation
- keep Archive⇄Restore live-patched through `patchMainHead` and leave the conditional usage-limit Retry path intact
- cover selected/unselected rows, archived Restore, limit-blocked Retry, and narrow widths in the real rendered UI
- regenerate the committed web bundle and update the affected web/parity documentation

## Verification

All commands below ran after commit `b2d8464175f7262e5eefce07c28d5514b2eacb92` was pushed, with local HEAD matching the remote branch:

- `make web-build` — generated dist matches the committed bundle
- `make web-test` — typecheck and 398 unit tests passed
- `make web-selftest-container` — 103 real-browser tests passed
- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` — no output
- `go build ./...`
- `make test-container`
- `deadcode -test ./...` — no output
- `scripts/lint-file-length.sh`

Closes #2186.

— Captain Claude