### PR TITLE
fix(tabs): make VS Code creation discoverable

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ Three ideas carry the whole tool.
   git artifact you can diff, push, or open a PR from. Pass `--here` when you
   deliberately want the agent in your current checkout instead.
 - **Tabs — more than one thing per session.** Every session has its agent tab,
-  and a local session can open more beside it in the same worktree: a shell with
-  `t`, or — via `af sessions tab-create` — a long-running command, a web view, or
-  a VS Code editor. Sessions on the docker, ssh, and hook backends run off-box,
-  so their tab list is fixed by the runtime; adding tabs to them isn't supported
-  yet.
+  and a local session can open more beside it in the same worktree: `t` chooses a
+  terminal or VS Code editor, while `af sessions tab-create` adds a named
+  long-running command or web view. Sessions on the docker, ssh, and hook
+  backends run off-box, so their tab list is fixed by the runtime; adding tabs
+  to them isn't supported yet.
 - **Daemon — the thing that actually owns state.** A background daemon runs the
   sessions, schedules tasks, serves the web UI, and is the single source of
   truth. Opening the TUI starts one, as do autoyes mode and any enabled task;

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -118,11 +118,11 @@ func (m *home) handleDefaultKeyPress(msg tea.KeyMsg, name keys.KeyName) (tea.Mod
 	case keys.KeyShiftTab:
 		return m, m.cycleFocus(true)
 
-	// Tab lifecycle (#930 PR 4): `t` creates, `w` kills the selection's
+	// Tab lifecycle (#930 PR 4): `t` chooses and creates, `w` kills the selection's
 	// active tab. Hiding a PANE is `x` — `w` keeps its kill meaning
 	// everywhere (§2.3).
 	case keys.KeyNewTab:
-		return m.handleNewTab()
+		return m.showNewTabPicker()
 	case keys.KeyCloseTab:
 		return m.handleCloseTab()
 

--- a/app/handle_mouse.go
+++ b/app/handle_mouse.go
@@ -576,6 +576,14 @@ func (m *home) handleModalClick(id string) (tea.Model, tea.Cmd) {
 			m.selectionOverlay.SetSelectedIndex(idx)
 			return m.handleStateSelectProgram(tea.KeyMsg{Type: tea.KeyEnter})
 		}
+	case stateSelectTabKind:
+		if m.selectionOverlay == nil {
+			return m, nil
+		}
+		if idx, ok := zones.OverlaySelectIdx(id); ok {
+			m.selectionOverlay.SetSelectedIndex(idx)
+			return m.handleStateSelectTabKind(tea.KeyMsg{Type: tea.KeyEnter})
+		}
 	case stateSearch:
 		if m.searchOverlay == nil {
 			return m, nil

--- a/app/handle_tabs.go
+++ b/app/handle_tabs.go
@@ -5,6 +5,8 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/ui/overlay"
 	"github.com/sachiniyer/agent-factory/ui/tree"
 )
 
@@ -12,21 +14,89 @@ import (
 // out of handle_actions.go to keep that file under the length limit (#1145).
 // They share the pane layer's stable-id + focused-pane rules (#1884/#1885/#1886).
 
-// handleNewTab spawns a new shell tab in the selected instance and selects it
-// (#930 PR 4). Single keypress, no prompt: the tab runs $SHELL in the instance's
-// worktree. Remote instances have no local worktree and the hook protocol has no
-// run-arbitrary-command verb, so new-tab is unsupported there: a remote session's
-// only terminal tab is the one derived from remote_hooks.terminal_cmd (#930 PR 6).
+type newTabChoice struct {
+	label string
+	kind  session.TabKind
+}
+
+var newTabChoices = []newTabChoice{
+	{label: "Terminal", kind: session.TabKindShell},
+	{label: "VS Code", kind: session.TabKindVSCode},
+}
+
+// showNewTabPicker opens the TUI's existing enum-selection overlay for `t`.
+// Terminal and VS Code both need no further input, so they fit this small picker;
+// process and web tabs still need a command or URL and remain on tab-create. The
+// target title is captured now because a background snapshot can arrive while
+// the modal owns the keyboard and may replace the instance pointer.
+func (m *home) showNewTabPicker() (tea.Model, tea.Cmd) {
+	selected := m.sidebar.GetSelectedInstance()
+	if selected == nil || selected.HasInFlightOp() {
+		return m, nil
+	}
+	if !selected.Capabilities().TabManagement {
+		return m, m.handleError(fmt.Errorf("only local sessions support new tabs — this session's workspace runs off-box (docker/ssh/remote), so there is no local worktree to spawn a tab in"))
+	}
+
+	items := make([]string, len(newTabChoices))
+	for idx, choice := range newTabChoices {
+		items[idx] = choice.label
+	}
+	m.tabCreateTitle = selected.Title
+	m.selectionOverlay = overlay.NewSelectionOverlay("New tab", items)
+	m.selectionOverlay.SetWidth(40)
+	m.layoutSelectionOverlay()
+	m.state = stateSelectTabKind
+	return m, nil
+}
+
+// handleStateSelectTabKind submits or cancels the new-tab picker. It has no text
+// field, so ordinary rune keys (including a configured `q` quit key) cannot be
+// mistaken for form input or silently create a different kind.
+func (m *home) handleStateSelectTabKind(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.selectionOverlay == nil {
+		m.tabCreateTitle = ""
+		m.state = stateDefault
+		return m, nil
+	}
+	if !m.selectionOverlay.HandleKeyPress(msg) {
+		return m, nil
+	}
+
+	submitted := m.selectionOverlay.IsSubmitted()
+	idx := m.selectionOverlay.GetSelectedIndex()
+	title := m.tabCreateTitle
+	m.selectionOverlay = nil
+	m.tabCreateTitle = ""
+	m.state = stateDefault
+	if !submitted || title == "" || idx < 0 || idx >= len(newTabChoices) {
+		return m, nil
+	}
+	selected := m.store.GetInstanceByTitle(title)
+	if selected == nil {
+		return m, nil
+	}
+	return m.createNewTab(selected, newTabChoices[idx].kind)
+}
+
+// handleNewTab is the direct shell-create helper used by the Terminal picker
+// choice and focused lifecycle tests. The user-facing `t` binding opens
+// showNewTabPicker first (#2077).
+func (m *home) handleNewTab() (tea.Model, tea.Cmd) {
+	return m.createNewTab(m.sidebar.GetSelectedInstance(), session.TabKindShell)
+}
+
+// createNewTab creates one no-input tab kind through the daemon's CreateTab RPC
+// and selects it. Remote instances have no local worktree and the hook protocol
+// has no run-arbitrary-command verb, so their tab roster is runtime-fixed.
 //
 // The spawn+persist is routed through the daemon's CreateTab RPC (#960): the
 // daemon — the single writer — owns the new tab so its authoritative view holds
-// it and the TUI no longer originates a tab write at all (#959). The TUI reflects
-// the daemon-created tab locally via AttachShellTab for instant display (it
-// reconnects to the session the daemon spawned, never a second colliding spawn);
-// the snapshot reconcile (PR 3) keeps it mirrored thereafter. The daemon's soft
-// cap (max tabs) error is surfaced verbatim.
-func (m *home) handleNewTab() (tea.Model, tea.Cmd) {
-	selected := m.sidebar.GetSelectedInstance()
+// it and the TUI no longer originates a persisted tab write at all (#959). The
+// local projection is reflected immediately for both kinds; the next snapshot
+// adopts the daemon-minted stable id. The daemon's soft cap error is surfaced
+// verbatim.
+func (m *home) createNewTab(selected *session.Instance, kind session.TabKind) (tea.Model, tea.Cmd) {
 	if selected == nil {
 		return m, nil
 	}
@@ -37,22 +107,37 @@ func (m *home) handleNewTab() (tea.Model, tea.Cmd) {
 		return m, m.handleError(fmt.Errorf("only local sessions support new tabs — this session's workspace runs off-box (docker/ssh/remote), so there is no local worktree to spawn a tab in"))
 	}
 
-	name, tmuxName, err := createShellTabThroughDaemon(selected.Title, m.repoID)
+	var name, tmuxName string
+	var err error
+	switch kind {
+	case session.TabKindShell:
+		name, tmuxName, err = createShellTabThroughDaemon(selected.Title, m.repoID)
+	case session.TabKindVSCode:
+		name, tmuxName, err = createVSCodeTabThroughDaemon(selected.Title, m.repoID)
+	default:
+		return m, m.handleError(fmt.Errorf("tab kind %d is not available from the TUI", kind))
+	}
 	if err != nil {
 		return m, m.handleError(err)
 	}
-	// The daemon spawned and persisted the tab; reflect it locally for instant
-	// display without a second spawn, binding to the exact tmux session it
-	// reported rather than one re-derived from the name (#1957). The daemon write
-	// is authoritative, so the TUI never saves (#960 PR 4).
-	if _, attachErr := selected.AttachShellTab(name, tmuxName); attachErr != nil {
+	// Reflect the daemon-created tab locally for instant display. A shell binds to
+	// the exact tmux session the daemon reported (#1957); a VS Code tab is metadata
+	// only and carries no tmux session at all. Neither path spawns or persists a
+	// second tab.
+	var attachErr error
+	if kind == session.TabKindVSCode {
+		_, attachErr = selected.AttachVSCodeTab(name)
+	} else {
+		_, attachErr = selected.AttachShellTab(name, tmuxName)
+	}
+	if attachErr != nil {
 		return m, m.handleError(attachErr)
 	}
 
 	// Select the fresh tab in the tree and open it as a pane (#1088): the
-	// pre-N-pane behavior showed the new tab in the workspace immediately,
-	// and the issue's canonical flow — agent pane + terminal pane side by
-	// side for one instance — is exactly `s` then `t`.
+	// pre-N-pane behavior showed the new tab in the workspace immediately. A VS
+	// Code tab opens the existing terminal placeholder that points to the web UI;
+	// the browser renders the editor itself.
 	newIdx := len(tree.TabLabels(selected)) - 1
 	m.store.SetActiveTab(newIdx)
 	m.menu.SetActiveTab(newIdx)

--- a/app/help.go
+++ b/app/help.go
@@ -151,7 +151,7 @@ func (h helpTypeGeneral) toContent() string {
 		}},
 		{title: "Tabs:", rows: []helpRow{
 			{helpKey(keys.KeyJumpTab), "Select a tab by number (s opens it, enter attaches)"},
-			{helpKey(keys.KeyNewTab), "Open a new terminal tab"},
+			{helpKey(keys.KeyNewTab), "Choose a terminal or VS Code tab"},
 			{helpKey(keys.KeyCloseTab), "Close the current tab (the agent tab can't be closed)"},
 			{helpKey(keys.KeyShiftUp) + "/" + helpKey(keys.KeyShiftDown), "Scroll in the current tab"},
 		}},

--- a/app/home_model.go
+++ b/app/home_model.go
@@ -41,6 +41,9 @@ const (
 	stateSwitchProject
 	// stateSelectProgram is the state when the user is selecting a program during naming.
 	stateSelectProgram
+	// stateSelectTabKind is the state when the user is choosing which kind of tab
+	// the new-tab action should create.
+	stateSelectTabKind
 	// statePromptInput is the state when the initial-prompt field of the naming
 	// form is open (#1936). Like stateSelectProgram it is a sub-state of
 	// stateNew: closing it returns to naming rather than to stateDefault.
@@ -371,8 +374,13 @@ type home struct {
 	// action so that handleStateConfirm can forward it to the Bubble Tea
 	// event loop after OnConfirm runs.
 	pendingConfirmMsg tea.Msg
-	// selectionOverlay handles program selection during new-instance naming
+	// selectionOverlay handles short enum choices: program selection during
+	// new-instance naming and tab-kind selection from the new-tab action.
 	selectionOverlay *overlay.SelectionOverlay
+	// tabCreateTitle identifies the session that opened the tab-kind picker.
+	// Background snapshots may move the sidebar selection or replace an instance
+	// pointer while the modal is open, so submit re-resolves this stable title.
+	tabCreateTitle string
 	// searchOverlay handles session search
 	searchOverlay *overlay.SearchOverlay
 	// projectPickerOverlay handles switching the active project (#1461)

--- a/app/home_update.go
+++ b/app/home_update.go
@@ -506,6 +506,8 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 		return m.handleStateSwitchProject(msg)
 	case stateSelectProgram:
 		return m.handleStateSelectProgram(msg)
+	case stateSelectTabKind:
+		return m.handleStateSelectTabKind(msg)
 	case statePromptInput:
 		return m.handleStateInitialPrompt(msg)
 	case stateHooks:

--- a/app/home_view.go
+++ b/app/home_view.go
@@ -200,6 +200,14 @@ func (m *home) View() string {
 		fg := m.selectionOverlay.Render()
 		m.selectionOverlay.RegisterZones(m.zones, overlayOrigin(fg, mainView))
 		return overlay.PlaceOverlay(0, 0, fg, mainView, true)
+	} else if m.state == stateSelectTabKind {
+		if m.selectionOverlay == nil {
+			log.ErrorLog.Printf("tab-kind selection overlay is nil")
+			return mainView
+		}
+		fg := m.selectionOverlay.Render()
+		m.selectionOverlay.RegisterZones(m.zones, overlayOrigin(fg, mainView))
+		return overlay.PlaceOverlay(0, 0, fg, mainView, true)
 	} else if m.state == statePromptInput {
 		if m.promptOverlay == nil {
 			log.ErrorLog.Printf("prompt overlay is nil")

--- a/app/session_control.go
+++ b/app/session_control.go
@@ -275,22 +275,32 @@ func resumeStatusPollThroughDaemon(title, repoID string) error {
 	})
 }
 
-// createShellTabThroughDaemon routes the TUI's `t` (new shell tab) mutation to
-// the daemon so the daemon — the single writer (#960) — owns the spawn and the
-// persist, returning the resolved tab name AND the tmux session the daemon
-// spawned it under. The TUI reflects the new tab locally for instant display via
-// Instance.AttachShellTab, which binds to that exact session: the two names are
-// independent namespaces that diverge after a rename (#1957), so re-deriving the
-// session from the tab name would attach the projection to a DIFFERENT tab's
-// live session.
-var createShellTabThroughDaemon = func(title, repoID string) (string, string, error) {
+// createTabThroughDaemon is the TUI's single CreateTab RPC path. Both picker
+// choices use it, so VS Code creation sends the same Kind:"vscode" request the
+// CLI does rather than growing a TUI-only implementation. It returns the resolved
+// tab name and, for a shell/process tab, the exact tmux session the daemon spawned.
+func createTabThroughDaemon(req daemon.CreateTabRequest) (string, string, error) {
 	var name, tmuxName string
 	err := withDaemonHTTP(func(c *apiclient.Client) error {
 		var e error
-		name, tmuxName, e = c.CreateTab(daemon.CreateTabRequest{Title: title, RepoID: repoID, Shell: true})
+		name, tmuxName, e = c.CreateTab(req)
 		return e
 	})
 	return name, tmuxName, err
+}
+
+// createShellTabThroughDaemon routes the Terminal picker choice through the
+// shared RPC. The returned tab name and tmux name are independent namespaces
+// after a rename (#1957), so AttachShellTab receives both verbatim.
+var createShellTabThroughDaemon = func(title, repoID string) (string, string, error) {
+	return createTabThroughDaemon(daemon.CreateTabRequest{Title: title, RepoID: repoID, Shell: true})
+}
+
+// createVSCodeTabThroughDaemon routes the VS Code picker choice through the same
+// request shape as `af sessions tab-create <title> --kind vscode`. A VS Code tab
+// has no tmux session, so the second return value is empty by design.
+var createVSCodeTabThroughDaemon = func(title, repoID string) (string, string, error) {
+	return createTabThroughDaemon(daemon.CreateTabRequest{Title: title, RepoID: repoID, Kind: "vscode"})
 }
 
 // closeTabThroughDaemon routes the TUI's `w` (close tab) mutation to the daemon,
@@ -435,6 +445,14 @@ func SetTabCreatorForTest(f func(title, repoID string) (string, string, error)) 
 	prev := createShellTabThroughDaemon
 	createShellTabThroughDaemon = f
 	return func() { createShellTabThroughDaemon = prev }
+}
+
+// SetVSCodeTabCreatorForTest swaps the VS Code half of the TUI tab-create seam
+// without dialing a daemon.
+func SetVSCodeTabCreatorForTest(f func(title, repoID string) (string, string, error)) func() {
+	prev := createVSCodeTabThroughDaemon
+	createVSCodeTabThroughDaemon = f
+	return func() { createVSCodeTabThroughDaemon = prev }
 }
 
 func SetTabCloserForTest(f func(title, repoID, tabName string) error) func() {

--- a/app/tab_hotkeys_test.go
+++ b/app/tab_hotkeys_test.go
@@ -10,10 +10,13 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	xansi "github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
 	"github.com/sachiniyer/agent-factory/internal/testguard"
+	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 	"github.com/sachiniyer/agent-factory/ui/tree"
@@ -110,11 +113,15 @@ func setupGitRepoForTabs(t *testing.T, workdir string) {
 // since #1100: one agent tab, no shell tab until 't'.
 func freshLocalInstance(t *testing.T, title string) *session.Instance {
 	t.Helper()
+	return freshLocalInstanceNamed(t, fmt.Sprintf("af-tabs-%s-%d", title, time.Now().UnixNano()))
+}
+
+func freshLocalInstanceNamed(t *testing.T, name string) *session.Instance {
+	t.Helper()
 	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
 	workdir := t.TempDir()
 	setupGitRepoForTabs(t, workdir)
 
-	name := fmt.Sprintf("af-tabs-%s-%d", title, time.Now().UnixNano())
 	cmdExec, spawn := nameKeyedTmuxExec()
 	pty := tabHotkeysPty{t: t, cmdExec: cmdExec}
 
@@ -233,6 +240,114 @@ func TestHandleNewTabAppendsAndSelects(t *testing.T) {
 	require.Equal(t, 3, inst.TabCount(), "new-tab must append a shell tab")
 	require.Equal(t, 2, h.store.ActiveTab(),
 		"the freshly created tab must be selected")
+}
+
+// TestNewTabPickerCreatesVSCodeThroughDaemon is the #2077 TUI acceptance path:
+// the actual `t` action opens a visible kind choice, and choosing VS Code routes
+// through the daemon seam before reflecting the same TabKindVSCode the CLI's
+// --kind vscode request creates.
+func TestNewTabPickerCreatesVSCodeThroughDaemon(t *testing.T) {
+	h := newTestHome(t)
+	inst := freshLocalInstance(t, "vscode-picker")
+	selectInstance(h, inst)
+
+	called := 0
+	t.Cleanup(SetVSCodeTabCreatorForTest(func(title, repoID string) (string, string, error) {
+		called++
+		require.Equal(t, inst.Title, title)
+		require.Equal(t, h.repoID, repoID)
+		return "vscode", "", nil
+	}))
+
+	_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}}, keys.KeyNewTab)
+	require.Equal(t, stateSelectTabKind, h.state)
+	require.NotNil(t, h.selectionOverlay)
+	h.termWidth, h.termHeight = 80, 24
+	h.layoutSelectionOverlay()
+	picker := xansi.Strip(h.selectionOverlay.Render())
+	require.Contains(t, picker, "Terminal")
+	require.Contains(t, picker, "VS Code")
+
+	h.selectionOverlay.SetSelectedIndex(1)
+	_, _ = h.handleStateSelectTabKind(tea.KeyMsg{Type: tea.KeyEnter})
+
+	require.Equal(t, 1, called, "VS Code creation must cross the daemon CreateTab seam")
+	require.Equal(t, stateDefault, h.state)
+	require.Nil(t, h.selectionOverlay)
+	require.Equal(t, 2, inst.TabCount())
+	tabs := inst.GetTabs()
+	require.Equal(t, session.TabKindVSCode, tabs[1].Kind)
+	require.Empty(t, tabs[1].ID, "the projection waits for the daemon's authoritative tab id")
+	require.Equal(t, 1, h.store.ActiveTab(), "the fresh VS Code tab must be selected")
+	require.Equal(t, []string{"◆ Agent", "◱ vscode"}, tree.TabLabels(inst),
+		"the resolved daemon name is the tab's addressable label, matching CLI creation")
+}
+
+// TestNewTabPickerReResolvesSnapshotReplacement guards the modal window: a
+// snapshot may rebuild the selected session while the picker owns the keyboard.
+// Submit must mutate the live replacement, never the orphaned pointer.
+func TestNewTabPickerReResolvesSnapshotReplacement(t *testing.T) {
+	h := newTestHome(t)
+	stale := freshLocalInstance(t, "vscode-stale")
+	selectInstance(h, stale)
+	_, _ = h.showNewTabPicker()
+
+	replacement := freshLocalInstanceNamed(t, stale.Title)
+	require.True(t, h.store.ReplaceInstanceByTitle(stale.Title, replacement))
+	t.Cleanup(SetVSCodeTabCreatorForTest(func(title, repoID string) (string, string, error) {
+		require.Equal(t, replacement.Title, title)
+		return "vscode", "", nil
+	}))
+
+	h.selectionOverlay.SetSelectedIndex(1)
+	_, _ = h.handleStateSelectTabKind(tea.KeyMsg{Type: tea.KeyEnter})
+
+	require.Equal(t, 1, stale.TabCount(), "the swapped-out projection must stay untouched")
+	require.Equal(t, 2, replacement.TabCount())
+	require.Equal(t, session.TabKindVSCode, replacement.GetTabs()[1].Kind)
+}
+
+// TestNewTabPickerDefaultsToTerminal preserves the existing fast path inside the
+// new picker: Enter on its first row still creates Shell:true through the same
+// daemon seam and selects the resulting terminal.
+func TestNewTabPickerDefaultsToTerminal(t *testing.T) {
+	h := newTestHome(t)
+	inst := freshLocalInstance(t, "terminal-picker")
+	selectInstance(h, inst)
+	created, _ := stubTabDaemonSeams(t, inst)
+
+	_, _ = h.showNewTabPicker()
+	_, _ = h.handleStateSelectTabKind(tea.KeyMsg{Type: tea.KeyEnter})
+
+	require.Equal(t, 1, *created)
+	require.Equal(t, session.TabKindShell, inst.GetTabs()[1].Kind)
+	require.Equal(t, 1, h.store.ActiveTab())
+}
+
+// TestNewTabPickerFitsRequiredTerminalSizes guards both the ordinary 80x24
+// play-test viewport and narrower terminals. The picker uses no new status-row
+// hint, and its own escape hatch must remain visible instead of being clamped.
+func TestNewTabPickerFitsRequiredTerminalSizes(t *testing.T) {
+	for _, size := range []struct{ w, h int }{{80, 24}, {60, 15}, {40, 10}} {
+		h := newTestHome(t)
+		inst := freshLocalInstance(t, fmt.Sprintf("picker-%d", size.w))
+		selectInstance(h, inst)
+		h.termWidth, h.termHeight = size.w, size.h
+		_, _ = h.showNewTabPicker()
+		h.layoutSelectionOverlay()
+
+		rendered := h.selectionOverlay.Render()
+		for idx, line := range strings.Split(rendered, "\n") {
+			require.LessOrEqual(t, lipgloss.Width(line), size.w,
+				"picker line %d overflows a %dx%d terminal", idx, size.w, size.h)
+		}
+		require.LessOrEqual(t, strings.Count(rendered, "\n")+1, size.h,
+			"picker is taller than a %dx%d terminal", size.w, size.h)
+		plain := xansi.Strip(rendered)
+		require.Contains(t, plain, "Terminal")
+		require.Contains(t, plain, "VS Code")
+		require.Contains(t, plain, "esc cancel", "the way out must survive width pressure")
+	}
 }
 
 // TestHandleCloseTabSelectsNeighbor: closing a shell tab removes it and selects

--- a/docs/concepts/tui.md
+++ b/docs/concepts/tui.md
@@ -36,14 +36,18 @@ There are two ways in, split deliberately:
 A session isn't limited to its agent. Each one can hold up to nine **tabs**, all
 running in the *same* worktree:
 
-- **`t`** spawns a new tab — a shell, or any command you name (a dev server,
-  `btop`, a test watcher). It runs alongside the agent, sharing its files.
+- **`t`** opens a new-tab picker. Choose **Terminal** for a shell in the
+  worktree, or **VS Code** for a browser editor on that worktree (the TUI shows
+  its placeholder; open the web client to use the editor).
 - **`w`** closes the focused tab (the agent's own tab can't be closed — kill the
   session instead).
 - **`1`–`9`** jump straight to a tab by number.
 
 Tabs persist across restarts, and each is a real process the daemon tracks.
 (Remote sessions are more limited — see [Remote hooks](../remote-hooks.md).)
+
+For a named long-running command or a web preview with a URL/port, use
+`af sessions tab-create`; those kinds need input beyond this two-item picker.
 
 ## Working with results
 

--- a/docs/web.md
+++ b/docs/web.md
@@ -367,13 +367,14 @@ Just like the TUI, a session isn't limited to its agent — each one holds up to
 pane header and the terminal:
 
 ```
-┌──────────┬────────────┬──────────┬───┐
-│  Agent   │  Terminal  │  btop  × │ + │
-└──────────┴────────────┴──────────┴───┘
+┌──────────┬────────────┬──────────┬─────────────┐
+│  Agent   │  Terminal  │  btop  × │ + New tab ▾ │
+└──────────┴────────────┴──────────┴─────────────┘
 ```
 
 - **Tab 0 is the agent** — it's unclosable (killing the session tears it down).
-- **`t`** (or the **`+`** button) opens a new shell tab in the worktree.
+- **`t`** opens a new shell tab directly. The labelled **`+ New tab`** menu
+  offers **Terminal** and **VS Code** where the resulting pane will appear.
 - **`w`** (or a tab's **`×`**) closes the active shell tab.
 - **`1`–`9`** switch to that tab (without attaching, like j/k); **clicking** a tab
   switches *and* attaches.
@@ -381,9 +382,10 @@ pane header and the terminal:
 Tabs labelled **Agent** / **Terminal** / a process name mirror the TUI's labels. A
 failed tab op (e.g. hitting the nine-tab cap) surfaces as a brief toast rather than
 a modal. **Off-box sessions** (docker, ssh, and remote-hook) run their workspace on
-another host, so there is no daemon-side worktree to spawn a tab in — their `+` /
-`×` affordances and the `t` / `w` keys are disabled, and the tab list is fixed by
-the runtime (a single agent tab).
+another host, so there is no daemon-side worktree to spawn a tab in — the tab bar
+explains that the runtime has a fixed tab list, its `×` affordances are withdrawn,
+and the `t` / `w` keys are disabled. Archived sessions similarly say to restore
+before creating tabs instead of leaving an unexplained blank.
 
 ### Project switcher
 
@@ -427,10 +429,10 @@ dev-server preview**: an agent runs a dev server in its worktree and injects a t
 pointing at it, so you watch the app render in the browser as the agent builds it.
 
 Web tabs are created from inside a session (by an agent or by you) with the
-CLI/API — they are not in the tab bar's `+` menu, because their target comes from
-whatever the agent is running rather than from anything the UI could ask you for
-(a [VS Code tab](#vs-code-tabs), which always targets the worktree, *is* in that
-menu):
+CLI/API — they are not in the tab bar's **New tab** menu, because their target
+comes from whatever the agent is running rather than from anything the UI could
+ask you for (a [VS Code tab](#vs-code-tabs), which always targets the worktree,
+*is* in that menu):
 
 ```bash
 # a local dev server on port 5173 (Vite/Next/CRA/…)
@@ -536,8 +538,8 @@ without leaving the web UI. It renders as a pane like any other tab, and works i
 splits and drag/drop.
 
 Unlike a web tab it takes **no target**: the session's worktree is always what it
-opens. That is what makes it offerable from the tab bar's **+** menu, which lists
-**Terminal** and **VS Code**. From the CLI:
+opens. That is what makes it offerable from the tab bar's labelled **New tab**
+menu, which lists **Terminal** and **VS Code**. From the CLI:
 
 ```bash
 af sessions tab-create <title> --kind vscode [--name editor]

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -27,7 +27,7 @@ const (
 	KeyShiftTab   // ShiftTab cycles the focus ring in reverse.
 	KeySubmitName // SubmitName is a special keybinding for submitting the name of a new instance.
 
-	KeyNewTab   // NewTab spawns a new shell tab in the selected instance (#930 PR 4).
+	KeyNewTab   // NewTab opens the Terminal / VS Code picker for the selected instance (#2077).
 	KeyCloseTab // CloseTab closes the active (non-agent) tab (#930 PR 4).
 	KeyJumpTab  // JumpTab is the 1-9 number-key jump hint; dispatched manually, menu/help only.
 

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -385,8 +385,8 @@
       "id": "session.tab.create.options",
       "title": "Choose a new tab's command, name, or kind at create time",
       "tui": {
-        "status": "no",
-        "pointer": "app/session_control.go:286 sends only {Title, RepoID, Shell:true}"
+        "status": "partial",
+        "pointer": "app/handle_tabs.go showNewTabPicker chooses Terminal/VS Code; app/session_control.go sends Shell or Kind"
       },
       "web": {
         "status": "partial",
@@ -397,7 +397,7 @@
         "pointer": "api/sessions_tabs.go:112 sends Command, Name, Kind, URL, Port"
       },
       "verdict": "unclear",
-      "notes": "The TUI's `t` always spawns a bare $SHELL: it cannot name a tab or run a command. Overlaps the open tab-UX work in #1813 (tabs labelled 'Tab N', no rename), so it wants triaging with that rather than a fresh issue. Distinct from session.tab.create.web, which is a deliberate omission."
+      "notes": "#2077 added the no-input kind choice (Terminal / VS Code) to `t`. The TUI still cannot name a tab or supply a process command; those input-bearing options remain CLI/API surface. Distinct from session.tab.create.web, which is a deliberate omission."
     },
     {
       "id": "session.tab.create.shell",
@@ -476,7 +476,7 @@
       "title": "Spawn a shell/process tab in a session",
       "tui": {
         "status": "yes",
-        "pointer": "keys/keys.go:156 (t) -> app/handle_actions.go:822"
+        "pointer": "keys/keys.go KeyNewTab -> app/handle_tabs.go showNewTabPicker"
       },
       "web": {
         "status": "yes",
@@ -487,14 +487,14 @@
         "pointer": "api/sessions_tabs.go:39 tab-create"
       },
       "verdict": "parity",
-      "notes": "All three gate off-box backends: the web hides + / x for docker/ssh/remote (web/src/ui.ts:187-210) mirroring the daemon's Capabilities().TabManagement, and the TUI refuses at app/handle_actions.go:830-832."
+      "notes": "All three gate off-box backends. The web keeps a visible explanation where the create control would be, while its close controls stay withdrawn; the TUI refuses before opening the picker. Both mirror the daemon's Capabilities().TabManagement."
     },
     {
       "id": "session.tab.create.vscode",
       "title": "Spawn a VS Code tab",
       "tui": {
-        "status": "no",
-        "pointer": "no kind selector on the t binding"
+        "status": "yes",
+        "pointer": "app/handle_tabs.go showNewTabPicker -> createNewTab(TabKindVSCode)"
       },
       "web": {
         "status": "yes",
@@ -504,8 +504,8 @@
         "status": "yes",
         "pointer": "api/sessions_tabs.go:27 --kind vscode"
       },
-      "verdict": "unclear",
-      "notes": "The TUI's t always spawns $SHELL. A VS Code tab is an editor window the TUI cannot render inline, so a TUI affordance may be pointless — but the tab would still exist for web/CLI consumers. Needs an owner call."
+      "verdict": "parity",
+      "notes": "Closed by #2077. The TUI creates Kind:vscode through the same daemon CreateTab RPC as `af sessions tab-create --kind vscode`; its pane shows the existing web-UI placeholder because a terminal cannot render the editor. The web exposes the choice from a labelled New tab menu."
     },
     {
       "id": "session.tab.create.web",
@@ -1627,9 +1627,6 @@
             "gap": "session.tab.create.options"
           },
           "name": {
-            "gap": "session.tab.create.options"
-          },
-          "kind": {
             "gap": "session.tab.create.options"
           },
           "url": {

--- a/scripts/tui-driver.sh
+++ b/scripts/tui-driver.sh
@@ -826,13 +826,15 @@ af_detach() {
     done
 }
 
-# af_new_tab — spawn a new shell tab in the selected instance (`t`).
-# Precondition: an instance is selected. Syncs on the tab-child count rising.
+# af_new_tab — choose the default terminal item from the new-tab picker (`t`).
+# Precondition: an instance is selected. Syncs on the picker and tab-child count.
 af_new_tab() {
     af_ensure_nav
     af_focus_tree || return 1
     local before; before="$(_af_tab_count)"
     af_send t
+    af_wait_for 'New tab' "$AF_DRIVER_TIMEOUT" 'new-tab picker' || return 1
+    af_send Enter
     local deadline; deadline=$(( $(_af_now) + AF_DRIVER_TIMEOUT ))
     while [ "$(_af_tab_count)" -le "$before" ]; do
         if [ "$(_af_now)" -ge "$deadline" ]; then

--- a/session/tab_attach.go
+++ b/session/tab_attach.go
@@ -1,0 +1,47 @@
+package session
+
+import (
+	"fmt"
+	"strings"
+)
+
+// AttachVSCodeTab reflects a VS Code tab that the daemon's CreateTab RPC has
+// already created and persisted. It is the metadata-only counterpart of
+// AttachShellTab: no editor or tmux session is spawned here; the TUI appends a
+// projection immediately so the new tab is visible without waiting for the next
+// snapshot.
+//
+// The stable id is deliberately left empty. The daemon owns tab identity and the
+// next ReconcileTabsFromData joins this id-less projection to the authoritative
+// row by name, exactly as it does for AttachShellTab. Minting a competing local id
+// would make the reconcile read the same tab as a remove+add and close its newly
+// opened pane.
+func (i *Instance) AttachVSCodeTab(name string) (*Tab, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, fmt.Errorf("cannot attach a VS Code tab without a name")
+	}
+
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	for _, tab := range i.Tabs {
+		if tab.Name == name {
+			return tab, nil
+		}
+	}
+	if spawnErr := i.tabSpawnBlockedLocked(); spawnErr != nil {
+		return nil, spawnErr
+	}
+	if err := tabSpawnPreconditionErr(i.started, i.tmuxLocked() != nil, i.gitWorktree != nil); err != nil {
+		return nil, err
+	}
+	if len(i.Tabs) >= maxTabs {
+		return nil, fmt.Errorf("max %d tabs per session", maxTabs)
+	}
+
+	tab := newVSCodeTab()
+	tab.ID = ""
+	tab.Name = name
+	i.Tabs = append(i.Tabs, tab)
+	return tab, nil
+}

--- a/session/tab_vscode_test.go
+++ b/session/tab_vscode_test.go
@@ -51,6 +51,28 @@ func TestAddVSCodeTab_ExplicitNameAndCollisionSuffixing(t *testing.T) {
 	assert.Equal(t, "vscode", third.Name)
 }
 
+// TestAttachVSCodeTabReflectsDaemonOwnedTab verifies the TUI-side projection
+// path adds no second editor and invents no competing stable identity. A raced
+// snapshot that already reflected the daemon row is a name-keyed no-op.
+func TestAttachVSCodeTabReflectsDaemonOwnedTab(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst := startedMockInstance(t, "af_vscode_attach")
+	tab, err := inst.AttachVSCodeTab("editor")
+	require.NoError(t, err)
+	assert.Equal(t, TabKindVSCode, tab.Kind)
+	assert.Equal(t, "editor", tab.Name)
+	assert.Empty(t, tab.ID, "the next authoritative snapshot must supply the daemon-minted id")
+	assert.Nil(t, tab.tmux, "reflecting a VS Code tab must not spawn or attach a tmux session")
+	assert.Equal(t, 2, inst.TabCount())
+
+	again, err := inst.AttachVSCodeTab("editor")
+	require.NoError(t, err)
+	assert.Same(t, tab, again, "a snapshot that won the race must not duplicate the tab")
+	assert.Equal(t, 2, inst.TabCount())
+}
+
 // TestVSCodeTab_PersistRoundTrip verifies a vscode tab survives a
 // serialize/restore cycle. This is what makes "restore, then respawn the editor
 // lazily" work: the tab carries no editor state at all, so there is nothing to go

--- a/ui/overlay/selectionOverlay.go
+++ b/ui/overlay/selectionOverlay.go
@@ -138,9 +138,23 @@ func (s *SelectionOverlay) Render() string {
 	if !compact {
 		lines = append(lines, "")
 	}
-	hint := "↑/↓ navigate • enter select • esc cancel"
-	if compact || lipgloss.Width(hint) > textRect.W {
-		hint = "↑/↓ nav • enter • esc cancel"
+	// Keep the escape hatch at the right edge by choosing a whole hint that fits,
+	// never by truncating a longer one. At narrow widths navigation detail drops
+	// first, then navigation itself; `esc cancel` is the load-bearing last item.
+	hint := "esc cancel"
+	candidates := []string{
+		"↑/↓ navigate · enter select · esc cancel",
+		"↑/↓ nav · enter · esc cancel",
+		"enter · esc cancel",
+	}
+	if compact {
+		candidates = candidates[1:]
+	}
+	for _, candidate := range candidates {
+		if lipgloss.Width(candidate) <= textRect.W {
+			hint = candidate
+			break
+		}
 	}
 	lines = append(lines, truncateOverlayLine(hintStyle.Render(hint), textRect.W))
 

--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -1045,23 +1045,6 @@ body {
   display: inline-flex;
   align-items: center;
 }
-.af-tab-new-kind {
-  padding: 0.35rem 0.3rem;
-  background: transparent;
-  color: var(--af-text-2);
-  border: none;
-  font: inherit;
-  font-size: var(--af-fs-2xs);
-  line-height: 1;
-  cursor: pointer;
-}
-.af-tab-new-kind:hover {
-  color: var(--af-accent);
-}
-.af-tab-new-kind:focus-visible {
-  outline: 2px solid var(--af-accent);
-  outline-offset: 2px;
-}
 .af-tab-menu {
   position: absolute;
   top: calc(100% + 6px);
@@ -1095,19 +1078,39 @@ body {
   outline-offset: -2px;
 }
 .af-tab-new {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
   padding: 0.35rem 0.55rem;
   background: transparent;
   color: var(--af-accent);
   border: none;
   border-radius: 0;
   font: inherit;
-  font-size: var(--af-fs-md);
+  font-size: var(--af-fs-xs);
   font-weight: 600;
   line-height: 1;
+  white-space: nowrap;
   cursor: pointer;
 }
 .af-tab-new:hover {
   color: var(--af-text);
+}
+.af-tab-new-plus {
+  font-size: var(--af-fs-md);
+  line-height: 0.8;
+}
+.af-tab-new-caret {
+  color: var(--af-text-2);
+  font-size: var(--af-fs-2xs);
+}
+.af-tab-new-unavailable {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.55rem;
+  color: var(--af-text-2);
+  font-size: var(--af-fs-xs);
+  white-space: nowrap;
 }
 .af-toast {
   position: fixed;

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -10238,6 +10238,32 @@ function supportsTabManagement(s) {
 function canManageTabs(s) {
   return supportsTabManagement(s) && !isArchived(s);
 }
+function tabCreationUnavailableReason(s, tabCount = sessionTabs(s).length) {
+  const supported = supportsTabManagement(s);
+  if (isArchived(s)) {
+    if (!supported) {
+      return `Archived \xB7 ${tabRuntimeLabel(s)} sessions have a fixed tab list`;
+    }
+    return "Restore this session to create tabs";
+  }
+  if (!supported) {
+    return `${tabRuntimeLabel(s)} sessions have a fixed tab list`;
+  }
+  if (tabCount >= MAX_TABS) {
+    return "Nine-tab limit reached";
+  }
+  return null;
+}
+function tabRuntimeLabel(s) {
+  switch (s.backend_type) {
+    case "docker":
+      return "Docker";
+    case "ssh":
+      return "SSH";
+    default:
+      return "Remote";
+  }
+}
 function sessionTabs(s) {
   if (s.tabs && s.tabs.length > 0) {
     return s.tabs;
@@ -10998,34 +11024,35 @@ var AppShell = class {
     });
     return item;
   }
-  /** The `+` button and its kind menu.
+  /** The visible `+ New tab` button and its kind menu.
    *
-   *  `+` still creates a terminal tab in ONE click — it is long-established muscle
-   *  memory (and the mouse twin of the TUI's `t`), so making it open a menu would
-   *  tax every existing user to surface a second kind. The `▾` beside it opens the
-   *  picker instead: the same split VS Code itself uses for its terminal + / ▾.
+   *  The old split control created a terminal from `+` and hid VS Code behind a
+   *  separate, unlabeled `▾`. Even the project's maintainer could not find that
+   *  path (#2077), so the labelled button now makes the choice explicit where the
+   *  editor will appear. The `t` shortcut remains the direct shell fast path.
    *
    *  Built per render (the tab bar is rebuilt wholesale), so the menu's listeners
    *  are bound to THIS instance and torn down with it — see the isConnected check
    *  in onDocMouseDown, which self-cleans if a rerender detaches an open menu. */
   newTabControl() {
     const wrap = h2("div", { class: "af-tab-new-wrap" });
-    const add = h2("button", { type: "button", class: "af-tab-new", title: "New terminal tab" }, "+");
-    add.addEventListener("click", (e) => {
-      e.stopPropagation();
-      this.actions.newTab("shell");
-    });
-    const caret = h2("button", { type: "button", class: "af-tab-new-kind", title: "New tab\u2026" }, "\u25BE");
-    caret.setAttribute("aria-haspopup", "menu");
-    caret.setAttribute("aria-expanded", "false");
-    caret.setAttribute("aria-label", "Choose tab type");
+    const trigger = h2(
+      "button",
+      { type: "button", class: "af-tab-new", title: "Create a terminal or VS Code tab" },
+      h2("span", { class: "af-tab-new-plus" }, "+"),
+      h2("span", {}, "New tab"),
+      h2("span", { class: "af-tab-new-caret" }, "\u25BE")
+    );
+    trigger.setAttribute("aria-haspopup", "menu");
+    trigger.setAttribute("aria-expanded", "false");
+    trigger.setAttribute("aria-label", "New tab \xB7 Terminal or VS Code");
     const menu = h2("div", { class: "af-tab-menu" });
     menu.setAttribute("role", "menu");
     menu.setAttribute("aria-label", "Tab type");
     menu.hidden = true;
     const close = () => {
       menu.hidden = true;
-      caret.setAttribute("aria-expanded", "false");
+      trigger.setAttribute("aria-expanded", "false");
       document.removeEventListener("mousedown", onDocMouseDown);
       document.removeEventListener("keydown", onKeyDown, true);
     };
@@ -11040,11 +11067,11 @@ var AppShell = class {
       }
       e.stopPropagation();
       close();
-      caret.focus();
+      trigger.focus();
     };
     const open = () => {
       menu.hidden = false;
-      caret.setAttribute("aria-expanded", "true");
+      trigger.setAttribute("aria-expanded", "true");
       document.addEventListener("mousedown", onDocMouseDown);
       document.addEventListener("keydown", onKeyDown, true);
     };
@@ -11059,7 +11086,7 @@ var AppShell = class {
       return b;
     };
     menu.append(item("Terminal", "shell"), item("VS Code", "vscode"));
-    caret.addEventListener("click", (e) => {
+    trigger.addEventListener("click", (e) => {
       e.stopPropagation();
       if (menu.hidden) {
         open();
@@ -11067,7 +11094,7 @@ var AppShell = class {
         close();
       }
     });
-    wrap.append(add, caret, menu);
+    wrap.append(trigger, menu);
     return wrap;
   }
   toggleFilterMenu() {
@@ -11181,8 +11208,13 @@ var AppShell = class {
     const children = tabs.map(
       (tab, i) => tabButton(tab, i, i === active, shown.has(i), canManage, this.actions, () => this.liveTabIdentity(i), selected.id ?? "")
     );
-    if (canManage && tabs.length < MAX_TABS) {
+    const unavailable = tabCreationUnavailableReason(selected, tabs.length);
+    if (unavailable === null) {
       children.push(this.newTabControl());
+    } else {
+      const reason = h2("span", { class: "af-tab-new-unavailable", title: unavailable }, unavailable);
+      reason.setAttribute("aria-label", `New tab unavailable \xB7 ${unavailable}`);
+      children.push(reason);
     }
     bar.replaceChildren(...children);
     if (this.tabInsert) {
@@ -11357,8 +11389,9 @@ function tabBarSig(state) {
   const tabs = sessionTabs(selected);
   const active = Math.min(Math.max(state.activeTab, 0), tabs.length - 1);
   const canManage = canManageTabs(selected);
+  const createReason = tabCreationUnavailableReason(selected, tabs.length);
   const shown = [...new Set(state.shownTabs)].sort((a, b) => a - b);
-  return JSON.stringify([selected.id ?? "", tabs.map((t) => [t.kind, t.name]), active, shown, canManage]);
+  return JSON.stringify([selected.id ?? "", tabs.map((t) => [t.kind, t.name]), active, shown, canManage, createReason]);
 }
 function barTabs(bar) {
   return [...bar.querySelectorAll(".af-tab")];

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "8623085e972b";
+const VERSION = "b8b009016aaf";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -222,6 +222,18 @@ async function resetToAgentTab(page: Page): Promise<void> {
   await expect(tabbar.locator(".af-tab")).toHaveCount(1, { timeout: 30_000 });
 }
 
+/** Creates the menu's Terminal choice. The labelled New tab control deliberately
+ *  makes every mouse-created kind explicit; the `t` keyboard shortcut remains the
+ *  one-keystroke shell path. */
+async function createTerminalTab(page: Page): Promise<void> {
+  const tabbar = page.locator(".af-tabbar");
+  await tabbar.locator(".af-tab-new").click();
+  const menu = tabbar.locator(".af-tab-menu");
+  await expect(menu).toBeVisible();
+  await menu.locator(".af-tab-menu-item", { hasText: /^Terminal$/ }).click();
+  await expect(menu).toBeHidden();
+}
+
 /**
  * Dispatches a drop carrying a HAND-CRAFTED drag payload ({index, tabs}) onto the
  * (single) current pane — bypassing the real tab buttons so a stale / out-of-range /
@@ -955,10 +967,10 @@ test("tabs: create a shell tab, switch to it, see its distinct output, close it 
   await expect(tabbar.locator(".af-tab")).toHaveCount(1);
   await expect(tabbar.locator(".af-tab.af-tab-active .af-tab-label")).toHaveText("Agent");
 
-  // Create a $SHELL tab via the + button (mirrors the TUI `t`). The tab bar grows
+  // Create a $SHELL tab via New tab → Terminal (the mouse twin of the web `t`). The tab bar grows
   // to two tabs, the new "Terminal" tab appears AND becomes active (createSessionTab
   // attaches it), and the terminal re-points its WS stream to that tab.
-  await tabbar.locator(".af-tab-new").click();
+  await createTerminalTab(page);
   await expect(tabbar.locator(".af-tab")).toHaveCount(2, { timeout: 30_000 });
   const shellTab = tabbar.locator(".af-tab", { hasText: "Terminal" });
   await expect(shellTab).toHaveClass(/af-tab-active/);
@@ -1020,7 +1032,7 @@ test("split panes (feat): drag a tab to a pane edge splits into two live panes; 
   await expect(page.locator(".af-term-host")).toContainText(READY_MARKER);
 
   const tabbar = page.locator(".af-tabbar");
-  await tabbar.locator(".af-tab-new").click();
+  await createTerminalTab(page);
   await expect(tabbar.locator(".af-tab")).toHaveCount(2, { timeout: 30_000 });
   await expect(page.locator(".af-term-meta")).toContainText("Live");
 
@@ -1072,7 +1084,7 @@ test("split panes (feat): a FRESHLY-CREATED tab is a drag source too — drag th
   await expect(page.locator(".af-term-host")).toContainText(READY_MARKER);
 
   const tabbar = page.locator(".af-tabbar");
-  await tabbar.locator(".af-tab-new").click();
+  await createTerminalTab(page);
   await expect(tabbar.locator(".af-tab")).toHaveCount(2, { timeout: 30_000 });
   const shellTab = tabbar.locator(".af-tab", { hasText: "Terminal" });
   await expect(shellTab).toHaveClass(/af-tab-active/);
@@ -1125,7 +1137,7 @@ test("split panes (feat): a bar rebuild that replaces a drag's source ends the d
   await row(page, SESSION_A).click();
   await expect(page.locator(".af-main.af-main-term")).toBeVisible();
   const tabbar = page.locator(".af-tabbar");
-  await tabbar.locator(".af-tab-new").click();
+  await createTerminalTab(page);
   await expect(tabbar.locator(".af-tab")).toHaveCount(2, { timeout: 30_000 });
 
   // Begin a real drag on the Terminal tab and drive a dragover so a pane shows its drop
@@ -1150,7 +1162,7 @@ test("split panes (feat): a bar rebuild that replaces a drag's source ends the d
 
   // Force a bar rebuild that REPLACES the drag's source button, with NO dragend on it —
   // add another tab (a concurrent tab change would do the same).
-  await tabbar.locator(".af-tab-new").click();
+  await createTerminalTab(page);
   await expect(tabbar.locator(".af-tab")).toHaveCount(3, { timeout: 30_000 });
 
   // The drag ended cleanly: no stuck flag, and the overlay is no longer shown (its
@@ -1189,7 +1201,7 @@ test("split panes (feat): a mid-drag tab-set change cancels the drop — no misb
   await row(page, SESSION_A).click();
   await expect(page.locator(".af-main.af-main-term")).toBeVisible();
   const tabbar = page.locator(".af-tabbar");
-  await tabbar.locator(".af-tab-new").click();
+  await createTerminalTab(page);
   await expect(tabbar.locator(".af-tab")).toHaveCount(2, { timeout: 30_000 });
   await expect(page.locator(".af-term-host .af-pane")).toHaveCount(1);
 
@@ -1225,7 +1237,7 @@ test("split panes (#1901): dragging the ACTIVE tab splits and opens a DIFFERENT 
 
   const tabbar = page.locator(".af-tabbar");
   await resetToAgentTab(page);
-  await tabbar.locator(".af-tab-new").click();
+  await createTerminalTab(page);
   await expect(tabbar.locator(".af-tab")).toHaveCount(2, { timeout: 30_000 });
   await expect(page.locator(".af-term-meta")).toContainText("Live");
   // Creating a tab switches to it: the pane now shows Terminal, and Terminal is the tab
@@ -1478,8 +1490,10 @@ test("web tab (#1809 follow-up): an ARCHIVED session's preserved web tab is iner
   // The × is withdrawn: clicking it would strip the very URL the archive preserved,
   // and the daemon would refuse anyway — so the affordance must not be offered.
   await expect(shelvedTab.locator(".af-tab-close")).toHaveCount(0);
-  // ...and so is the + (an archived session can't gain tabs either).
+  // Creation does not vanish: the bar names the restore step instead of looking
+  // indistinguishable from a product with no tab-create feature (#2077).
   await expect(tabbar.locator(".af-tab-new")).toHaveCount(0);
+  await expect(tabbar.locator(".af-tab-new-unavailable")).toHaveText("Restore this session to create tabs");
 
   await shelvedTab.click();
 
@@ -1860,7 +1874,7 @@ test("tabs (#1855): switching away and back keeps activeTab on the visible pane 
   // it stays true across the session.updated rebuild the create publishes (#1812).
   await row(page, SESSION_WEB).click();
   await expect(page.locator(".af-main.af-main-term")).toBeVisible();
-  await tabbar.locator(".af-tab-new").click();
+  await createTerminalTab(page);
   const throwaway = tabbar.locator(".af-tab", { hasText: "Terminal" });
   await expect(throwaway).toHaveCount(1, { timeout: 30_000 });
   // The create attaches the new tab, so the pane is on it — which is what makes the
@@ -1873,11 +1887,11 @@ test("tabs (#1855): switching away and back keeps activeTab on the visible pane 
   await expect(page.locator(".af-tab.af-tab-active .af-tab-label")).toHaveText("external");
   await expect(frame).toHaveCount(1, { timeout: 15_000 });
 
-  // Switch away, and leave probe-b focused on its own tab 1 (+ creates AND attaches),
+  // Switch away, and leave probe-b focused on its own tab 1 (create also attaches),
   // so the last reported focused tab is 1 — the collision.
   await row(page, SESSION_B).click();
   await expect(page.locator(".af-main.af-main-term")).toBeVisible();
-  await tabbar.locator(".af-tab-new").click();
+  await createTerminalTab(page);
   await expect(tabbar.locator(".af-tab")).toHaveCount(2, { timeout: 30_000 });
   await expect(page.locator(".af-tab.af-tab-active .af-tab-label")).toHaveText("Terminal");
 
@@ -1912,7 +1926,7 @@ test("split panes (feat): logout clears retained trees — a fresh login shows t
   await row(page, SESSION_A).click();
   await expect(page.locator(".af-main.af-main-term")).toBeVisible();
   const tabbar = page.locator(".af-tabbar");
-  await tabbar.locator(".af-tab-new").click();
+  await createTerminalTab(page);
   await expect(tabbar.locator(".af-tab")).toHaveCount(2, { timeout: 30_000 });
   await dragTabToPane(page, "Agent", "right");
   await expect(page.locator(".af-term-host .af-pane")).toHaveCount(2, { timeout: 15_000 });
@@ -2407,7 +2421,7 @@ test.describe("create → kill (one session, two flows)", () => {
     // ?tab=1 stream URL for the brand-new session (which has only the agent tab).
     await row(page, SESSION_A).click();
     await expect(page.locator(".af-main.af-main-term")).toBeVisible();
-    await page.locator(".af-tabbar .af-tab-new").click();
+    await createTerminalTab(page);
     await expect(page.locator(".af-tabbar .af-tab")).toHaveCount(2, { timeout: 30_000 });
     await expect(page.locator(".af-tab.af-tab-active .af-tab-label")).toHaveText("Terminal");
 
@@ -4026,7 +4040,7 @@ test("dismissing the install affordance sticks across reloads — it must never 
   await ctx.close();
 });
 
-test("vscode tab (feat): the ▾ menu creates a VS Code tab and the daemon serves it through the proxy", async () => {
+test("vscode tab (#2077): the labelled New tab menu creates a VS Code tab and serves it through the proxy", async () => {
   // End to end, with no seeded fixture: pick VS Code from the tab bar's kind menu,
   // and the daemon spawns a code-server (the FAKE one on PATH — no CI box has a
   // real one) on a 0600 unix socket it names, rooted at THIS session's worktree,
@@ -4039,13 +4053,16 @@ test("vscode tab (feat): the ▾ menu creates a VS Code tab and the daemon serve
   await expect(page.locator(".af-main.af-main-term")).toBeVisible();
 
   const tabbar = page.locator(".af-tabbar");
-  // + still creates a terminal in one click; the kind picker is the ▾ beside it.
-  await expect(page.locator(".af-tab-new")).toHaveCount(1);
-  const caret = page.locator(".af-tab-new-kind");
-  await expect(caret).toHaveCount(1);
+  // The choice is named on the tab bar itself. The pre-#2077 split control exposed
+  // only `+` and an unlabeled caret, so a user had to know the hidden menu existed.
+  const newTab = page.locator(".af-tab-new");
+  await expect(newTab).toHaveCount(1);
+  await expect(newTab).toContainText("New tab");
+  await expect(newTab).toHaveAttribute("aria-label", "New tab · Terminal or VS Code");
+  await expect(page.locator(".af-tab-new-kind")).toHaveCount(0);
   await expect(page.locator(".af-tab-menu")).toBeHidden();
 
-  await caret.click();
+  await newTab.click();
   const menu = page.locator(".af-tab-menu");
   await expect(menu).toBeVisible();
   await expect(menu.locator(".af-tab-menu-item")).toHaveText(["Terminal", "VS Code"]);
@@ -4105,7 +4122,7 @@ test("vscode tab (feat): the ▾ menu creates a VS Code tab and the daemon serve
 
   // Escape closes the menu without creating anything (checked after, so a stray
   // tab from a mis-click can't be mistaken for the one above).
-  await caret.click();
+  await newTab.click();
   await expect(menu).toBeVisible();
   await page.keyboard.press("Escape");
   await expect(menu).toBeHidden();

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -728,7 +728,8 @@ function guardedTabRebind(
     .catch((e) => surfaceTabError(e));
 }
 
-/** Creates a $SHELL tab on the selected session (the `t` key / + button), then
+/** Creates the requested tab on the selected session (`t` sends shell; the
+ *  labelled New tab menu can also send vscode), then
  *  resyncs to pull the grown tab list, selects the new tab, and attaches it —
  *  mirroring the TUI's `t`, which opens the fresh tab as a pane. The resync is
  *  kept for THIS window's own mutation because it must select+attach the new tab

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1205,9 +1205,9 @@ body {
 
 /* Tab bar (#1592 Phase 5 PR7): a slim strip of the session's tabs between the pane
  * header and the terminal, mirroring the TUI's tab row (ui/tabbed_window.go). The
- * active tab is accent-underlined; each non-agent tab carries a × close, and a +
- * adds a shell tab. It scrolls horizontally rather than wrapping so a full row of
- * tabs never pushes the terminal down. */
+ * active tab is accent-underlined; each non-agent tab carries a × close, and the
+ * labelled New tab control offers Terminal / VS Code. It scrolls horizontally
+ * rather than wrapping so a full row of tabs never pushes the terminal down. */
 .af-tabbar {
   display: flex;
   align-items: stretch;
@@ -1332,38 +1332,15 @@ body {
   background: var(--af-danger-subtle);
 }
 
-/* The new-tab control: + (create a terminal tab) plus ▾ (pick a kind) and the
-   menu the caret opens. The wrap is the positioning context the absolutely-placed
-   menu hangs from. */
+/* The labelled new-tab control and its kind menu. The wrap is the positioning
+   context the absolutely-placed menu hangs from. */
 .af-tab-new-wrap {
   position: relative;
   display: inline-flex;
   align-items: center;
 }
 
-/* The ▾ kind picker: deliberately quieter than the +, which stays the primary
-   one-click action. */
-.af-tab-new-kind {
-  padding: 0.35rem 0.3rem;
-  background: transparent;
-  color: var(--af-text-2);
-  border: none;
-  font: inherit;
-  font-size: var(--af-fs-2xs);
-  line-height: 1;
-  cursor: pointer;
-}
-
-.af-tab-new-kind:hover {
-  color: var(--af-accent);
-}
-
-.af-tab-new-kind:focus-visible {
-  outline: 2px solid var(--af-accent);
-  outline-offset: 2px;
-}
-
-/* The + menu (Terminal / VS Code). Mirrors .af-project-menu's chrome so the two
+/* The new-tab menu (Terminal / VS Code). Mirrors .af-project-menu's chrome so the two
    dropdowns read as one component, but hangs from the LEFT: the + sits at the
    start of the free space after the tabs, so a right-anchored menu would drift
    away from its button as the tab count changes. */
@@ -1403,22 +1380,47 @@ body {
   outline-offset: -2px;
 }
 
-/* The + new-tab button: the tab-bar analogue of the rail's "+ New". */
+/* The labelled new-tab button: the tab-bar analogue of the rail's "+ New". */
 .af-tab-new {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
   padding: 0.35rem 0.55rem;
   background: transparent;
   color: var(--af-accent);
   border: none;
   border-radius: 0;
   font: inherit;
-  font-size: var(--af-fs-md);
+  font-size: var(--af-fs-xs);
   font-weight: 600;
   line-height: 1;
+  white-space: nowrap;
   cursor: pointer;
 }
 
 .af-tab-new:hover {
   color: var(--af-text);
+}
+
+.af-tab-new-plus {
+  font-size: var(--af-fs-md);
+  line-height: 0.8;
+}
+
+.af-tab-new-caret {
+  color: var(--af-text-2);
+  font-size: var(--af-fs-2xs);
+}
+
+/* Creation never vanishes silently: archived sessions, off-box runtimes, and a
+   full nine-tab roster each leave a concise, visible reason in the tab bar. */
+.af-tab-new-unavailable {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.55rem;
+  color: var(--af-text-2);
+  font-size: var(--af-fs-xs);
+  white-space: nowrap;
 }
 
 /* Tab-op error toast (#1592 Phase 5 PR7): a transient banner pinned bottom-right,

--- a/web/src/ui.test.ts
+++ b/web/src/ui.test.ts
@@ -8,7 +8,13 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { canManageTabs, documentTitle, supportsTabManagement, tabBarSig } from "./ui.js";
+import {
+  canManageTabs,
+  documentTitle,
+  supportsTabManagement,
+  tabBarSig,
+  tabCreationUnavailableReason,
+} from "./ui.js";
 import type { AppState } from "./ui.js";
 import { Liveness, type SessionData } from "./types.js";
 
@@ -113,6 +119,23 @@ test("supportsTabManagement: local and legacy records keep tab management", () =
   // backend_type is omitempty, so a pre-#1592 record carries none. It is a local
   // session; defaulting it to off-box would strip the + from every legacy row.
   assert.equal(supportsTabManagement(sess({})), true, "a record with no backend_type is local");
+});
+
+test("tab creation always explains archived, off-box, and full states (#2077)", () => {
+  assert.equal(tabCreationUnavailableReason(sess({ backend_type: "local" }), 1), null);
+  assert.equal(
+    tabCreationUnavailableReason(sess({ backend_type: "local", liveness: Liveness.Archived }), 1),
+    "Restore this session to create tabs",
+  );
+  assert.equal(tabCreationUnavailableReason(sess({ backend_type: "docker" }), 1), "Docker sessions have a fixed tab list");
+  assert.equal(tabCreationUnavailableReason(sess({ backend_type: "ssh" }), 1), "SSH sessions have a fixed tab list");
+  assert.equal(tabCreationUnavailableReason(sess({ backend_type: "remote" }), 1), "Remote sessions have a fixed tab list");
+  assert.equal(
+    tabCreationUnavailableReason(sess({ backend_type: "remote", liveness: Liveness.Archived }), 1),
+    "Archived · Remote sessions have a fixed tab list",
+    "restoring an off-box session must not falsely promise that tab creation will become available",
+  );
+  assert.equal(tabCreationUnavailableReason(sess({ backend_type: "local" }), 9), "Nine-tab limit reached");
 });
 
 test("archiving the selected session changes the sig — the bar must rebuild to drop the × (#1809)", () => {

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -226,8 +226,9 @@ export interface Actions {
 }
 
 /** The soft cap on tabs per session (session/tab.go maxTabs): the agent tab plus
- *  up to eight shell/process tabs, matching the 1-9 number-key range. The + button
- *  hides at the cap so the web never fires a guaranteed-to-fail CreateTab. */
+ *  up to eight additional tabs, matching the 1-9 number-key range. At the cap the
+ *  create control becomes an explanatory note, so the web never fires a
+ *  guaranteed-to-fail CreateTab. */
 const MAX_TABS = 9;
 
 /** The backend types whose workspace lives off-box (session/archive_sandbox.go
@@ -245,8 +246,9 @@ const OFF_BOX_BACKENDS = new Set(["docker", "ssh", "remote"]);
 
 /** Whether a session supports user tab management. Off-box sessions (docker/ssh/
  *  remote-hook) have a tab list their runtime fixes at launch — a single agent
- *  tab — so the web hides their + / × affordances and gates the `t`/`w` keys,
- *  mirroring the daemon's Capabilities().TabManagement.
+ *  tab — so the web withdraws their × controls, replaces new-tab with a visible
+ *  fixed-list explanation, and gates the `t`/`w` keys, mirroring the daemon's
+ *  Capabilities().TabManagement.
  *
  *  A record with no backend_type is a pre-#1592 local session (the field is
  *  omitempty), so it defaults to local — treating it as off-box would strip tab
@@ -258,12 +260,44 @@ export function supportsTabManagement(s: SessionData): boolean {
 /** Whether the web may offer tab management for a session RIGHT NOW: its backend
  *  must support it AND it must not be archived. An archived session is inert — the
  *  daemon refuses both CreateTab (since #1196) and CloseTab (#1809 follow-up) on
- *  one — so offering a + / × there can only produce a guaranteed-to-fail call, and
+ *  one — so offering mutable + / × controls there can only produce a guaranteed-to-fail call, and
  *  the × specifically would try to strip the web-tab URL that archive preserved for
  *  the restore. Every site that offers or fires a tab mutation reads THIS, not
  *  supportsTabManagement, so the affordances and the daemon's answer can't drift. */
 export function canManageTabs(s: SessionData): boolean {
   return supportsTabManagement(s) && !isArchived(s);
+}
+
+/** A visible explanation for every state in which the tab bar cannot offer its
+ *  new-tab control. Returning null means creation is available. This stays
+ *  separate from canManageTabs because "archived", "runtime-fixed", and "full"
+ *  have different next steps and must not collapse into one missing affordance. */
+export function tabCreationUnavailableReason(s: SessionData, tabCount = sessionTabs(s).length): string | null {
+  const supported = supportsTabManagement(s);
+  if (isArchived(s)) {
+    if (!supported) {
+      return `Archived · ${tabRuntimeLabel(s)} sessions have a fixed tab list`;
+    }
+    return "Restore this session to create tabs";
+  }
+  if (!supported) {
+    return `${tabRuntimeLabel(s)} sessions have a fixed tab list`;
+  }
+  if (tabCount >= MAX_TABS) {
+    return "Nine-tab limit reached";
+  }
+  return null;
+}
+
+function tabRuntimeLabel(s: SessionData): string {
+  switch (s.backend_type) {
+    case "docker":
+      return "Docker";
+    case "ssh":
+      return "SSH";
+    default:
+      return "Remote";
+  }
 }
 
 /** The selected session's tabs, always non-empty: a pre-#930 record with no tabs
@@ -1272,27 +1306,28 @@ export class AppShell {
     return item;
   }
 
-  /** The `+` button and its kind menu.
+  /** The visible `+ New tab` button and its kind menu.
    *
-   *  `+` still creates a terminal tab in ONE click — it is long-established muscle
-   *  memory (and the mouse twin of the TUI's `t`), so making it open a menu would
-   *  tax every existing user to surface a second kind. The `▾` beside it opens the
-   *  picker instead: the same split VS Code itself uses for its terminal + / ▾.
+   *  The old split control created a terminal from `+` and hid VS Code behind a
+   *  separate, unlabeled `▾`. Even the project's maintainer could not find that
+   *  path (#2077), so the labelled button now makes the choice explicit where the
+   *  editor will appear. The `t` shortcut remains the direct shell fast path.
    *
    *  Built per render (the tab bar is rebuilt wholesale), so the menu's listeners
    *  are bound to THIS instance and torn down with it — see the isConnected check
    *  in onDocMouseDown, which self-cleans if a rerender detaches an open menu. */
   private newTabControl(): HTMLElement {
     const wrap = h("div", { class: "af-tab-new-wrap" });
-    const add = h("button", { type: "button", class: "af-tab-new", title: "New terminal tab" }, "+");
-    add.addEventListener("click", (e) => {
-      e.stopPropagation();
-      this.actions.newTab("shell");
-    });
-    const caret = h("button", { type: "button", class: "af-tab-new-kind", title: "New tab…" }, "▾");
-    caret.setAttribute("aria-haspopup", "menu");
-    caret.setAttribute("aria-expanded", "false");
-    caret.setAttribute("aria-label", "Choose tab type");
+    const trigger = h(
+      "button",
+      { type: "button", class: "af-tab-new", title: "Create a terminal or VS Code tab" },
+      h("span", { class: "af-tab-new-plus" }, "+"),
+      h("span", {}, "New tab"),
+      h("span", { class: "af-tab-new-caret" }, "▾"),
+    );
+    trigger.setAttribute("aria-haspopup", "menu");
+    trigger.setAttribute("aria-expanded", "false");
+    trigger.setAttribute("aria-label", "New tab · Terminal or VS Code");
     const menu = h("div", { class: "af-tab-menu" });
     menu.setAttribute("role", "menu");
     menu.setAttribute("aria-label", "Tab type");
@@ -1300,7 +1335,7 @@ export class AppShell {
 
     const close = (): void => {
       menu.hidden = true;
-      caret.setAttribute("aria-expanded", "false");
+      trigger.setAttribute("aria-expanded", "false");
       document.removeEventListener("mousedown", onDocMouseDown);
       document.removeEventListener("keydown", onKeyDown, true);
     };
@@ -1320,11 +1355,11 @@ export class AppShell {
       // the terminal / drop rail focus the way a bare Escape does.
       e.stopPropagation();
       close();
-      caret.focus();
+      trigger.focus();
     };
     const open = (): void => {
       menu.hidden = false;
-      caret.setAttribute("aria-expanded", "true");
+      trigger.setAttribute("aria-expanded", "true");
       document.addEventListener("mousedown", onDocMouseDown);
       // CAPTURE phase, deliberately. The app's own keydown handler is a
       // capture-phase listener on document that stopPropagation()s Escape (so
@@ -1348,7 +1383,7 @@ export class AppShell {
     };
     menu.append(item("Terminal", "shell"), item("VS Code", "vscode"));
 
-    caret.addEventListener("click", (e) => {
+    trigger.addEventListener("click", (e) => {
       e.stopPropagation();
       if (menu.hidden) {
         open();
@@ -1356,7 +1391,7 @@ export class AppShell {
         close();
       }
     });
-    wrap.append(add, caret, menu);
+    wrap.append(trigger, menu);
     return wrap;
   }
 
@@ -1530,8 +1565,13 @@ export class AppShell {
     const children: HTMLElement[] = tabs.map((tab, i) =>
       tabButton(tab, i, i === active, shown.has(i), canManage, this.actions, () => this.liveTabIdentity(i), selected.id ?? ""),
     );
-    if (canManage && tabs.length < MAX_TABS) {
+    const unavailable = tabCreationUnavailableReason(selected, tabs.length);
+    if (unavailable === null) {
       children.push(this.newTabControl());
+    } else {
+      const reason = h("span", { class: "af-tab-new-unavailable", title: unavailable }, unavailable);
+      reason.setAttribute("aria-label", `New tab unavailable · ${unavailable}`);
+      children.push(reason);
     }
     bar.replaceChildren(...children);
     // The insertion indicator is absolutely positioned and sits outside the tab flow,
@@ -1764,7 +1804,7 @@ function selectedSession(state: AppState): SessionData | null {
 
 /** A signature of everything the tab BAR draws for the selected session: which session
  *  it is, the ordered tabs (kind + name), the active index, the shown-in-a-pane set, and
- *  whether tabs are manageable (the + / × affordances). The bar is rebuilt ONLY when
+ *  whether tabs are manageable (the create explanation / × affordances). The bar is rebuilt ONLY when
  *  this changes (ui update()), so an unrelated session-status snapshot — a rail event
  *  that leaves the tab list, highlight, and split layout alone — no longer
  *  replaceChildren()es the bar. That churn was the real cause of "a freshly-created tab
@@ -1799,8 +1839,9 @@ export function tabBarSig(state: AppState): string {
   const tabs = sessionTabs(selected);
   const active = Math.min(Math.max(state.activeTab, 0), tabs.length - 1);
   const canManage = canManageTabs(selected);
+  const createReason = tabCreationUnavailableReason(selected, tabs.length);
   const shown = [...new Set(state.shownTabs)].sort((a, b) => a - b);
-  return JSON.stringify([selected.id ?? "", tabs.map((t) => [t.kind, t.name]), active, shown, canManage]);
+  return JSON.stringify([selected.id ?? "", tabs.map((t) => [t.kind, t.name]), active, shown, canManage, createReason]);
 }
 
 /** The bar's tab buttons in render order. Excludes the + button and the insertion


### PR DESCRIPTION
## Summary

- Replace the hidden web + / unlabeled-caret split with a labeled + New tab ▾ menu beside the editor tabs.
- Keep that tab-bar location informative when creation is unavailable: archived sessions name Restore as the next step, off-box runtimes explain their fixed tab list, and full sessions name the nine-tab limit.
- Change the TUI t action to the existing two-item selection overlay, with Terminal as the default and VS Code routed through the same daemon CreateTab request shape as the CLI.
- Preserve narrow-terminal escape hatches, update the TUI driver, docs, tests, and the surface-parity ledger.

## Design

The TUI uses the existing enum-picker idiom because Terminal and VS Code are the two creation kinds that require no additional text. Process and web tabs remain on af sessions tab-create because they require a command, URL, or port; this avoids adding another text form and avoids the q-input failure class.

The web menu stays in the tab bar because that is where the resulting editor lives. The t keyboard shortcut remains the direct terminal fast path.

## What I verified

- Read-only live-host audit before implementation: all 11 non-archived live sessions were local and caret-eligible; 323 archived sessions rendered no creation control. No unsupported live backend was present, so those states are covered by unit tests rather than a production mutation.
- Web: make web-build reproduced the committed bundle; the real-daemon Chromium harness passed 103/103. I saw the labeled New tab menu create and proxy a VS Code editor, and the archived fixture display Restore this session to create tabs.
- TUI: the acceptance driver passed 61/61. In a separate named container sandbox, t → VS Code created kind 4 with no tmux session; af sessions tab-create picker --kind vscode created the identical kind/shape.
- Widths: 80×24 and 60×15 showed both choices plus esc cancel; 40×10 compacted to enter · esc cancel. The main hint row retained q quit at every checked width.

## Gates

Pushed head: e5b16eda225d5554c7b9a72db8595ca4721afa31

- golangci-lint run --timeout=3m --fast
- gofmt -l . — no output
- go build ./...
- make test-container — full suite
- deadcode -test ./... — no output
- scripts/lint-file-length.sh
- make web-test — 399/399
- make web-build
- make web-selftest-container — 103/103
- make tui-driver-selftest — 61/61

No required gate was skipped. Per the host-safety instruction, ./dev-install.sh was not run.

Fixes #2077

— Captain Claude