### PR TITLE
fix(preview): preserve scroll intent across history fills

### DIFF
--- a/app/home_panes.go
+++ b/app/home_panes.go
@@ -189,8 +189,8 @@ func (m *home) panesRefresh(attachedNow bool) tea.Cmd {
 		// one-shot off-loop scrollback fill MUST run even for a live pane —
 		// otherwise the viewport stays empty and the pane renders blank until
 		// scroll mode is left. NeedsScrollFill is true only until that single
-		// fill lands (it clears scrollFillPending), so a live pane resumes
-		// skipping capture for every subsequent scroll keystroke.
+		// fill lands (the controller transitions loading→ready), so a live pane
+		// resumes skipping capture for every subsequent scroll keystroke.
 		needsFill := w.NeedsScrollFill()
 		if w.HasLive() && !needsFill {
 			continue

--- a/app/scroll_fill_inflight_test.go
+++ b/app/scroll_fill_inflight_test.go
@@ -1,15 +1,112 @@
 package app
 
 import (
+	"fmt"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/ui"
+	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/layout/zones"
 )
+
+func appNumberedHistory(lines int) string {
+	out := make([]string, lines)
+	for i := range out {
+		out[i] = fmt.Sprintf("input-history-%03d", i+1)
+	}
+	return strings.Join(out, "\n")
+}
+
+func firstRenderedHistoryMarker(view string, maxLines int) int {
+	for i := 1; i <= maxLines; i++ {
+		if strings.Contains(view, fmt.Sprintf("input-history-%03d", i)) {
+			return i
+		}
+	}
+	return 0
+}
+
+// TestPreviewScrollFirstIntentConformanceKeyboardAndWheel proves both root
+// input paths submit the same semantic first intent to host-history preview.
+// The size matrix is the real outer-terminal contract requested by #2192; the
+// expected top marker is derived from each resulting pane height.
+func TestPreviewScrollFirstIntentConformanceKeyboardAndWheel(t *testing.T) {
+	const historyLines = 100
+	history := appNumberedHistory(historyLines)
+
+	for _, size := range []struct {
+		name          string
+		width, height int
+	}{
+		{name: "80x24", width: 80, height: 24},
+		{name: "120x40", width: 120, height: 40},
+	} {
+		for _, input := range []string{"keyboard", "wheel"} {
+			t.Run(size.name+"/"+input, func(t *testing.T) {
+				h := newTestHome(t)
+				h.previewFetcher = func(req daemon.PreviewRequest) (string, bool, error) {
+					if req.Full {
+						return history, false, nil
+					}
+					return "visible-line", false, nil
+				}
+				inst := instanceWithFakeBackend(t, "scroll-input")
+				inst.AddTabForTest("agent", session.TabKindAgent)
+				h.store.AddInstance(inst)
+				h.sidebar.SetSelectedInstance(0)
+				_ = h.selectionChanged()
+
+				resizeHome(h, size.width, size.height)
+				pane := openTestPane(t, h, inst, 0)
+				w := h.paneWindows[pane.ID()]
+				require.NotNil(t, w)
+
+				switch input {
+				case "keyboard":
+					_, _ = h.handleDefaultKeyPress(
+						tea.KeyMsg{Type: tea.KeyCtrlU}, keys.KeyShiftUp)
+				case "wheel":
+					region := layout.PaneRegion(pane.ID())
+					body := zoneRect(t, h, zones.PaneBody(region))
+					wheel(h, body.X+1, body.Y+1, true)
+				}
+
+				require.True(t, w.IsInScrollMode(), "first %s input enters scroll mode", input)
+				require.Equal(t, ui.ScrollOwnerHostHistory, w.ScrollOwner())
+				require.NoError(t, w.UpdateContent(inst))
+
+				_, paneHeight := w.GetPreviewSize()
+				// History has 100 rows plus the footer. Bottom's first marker is
+				// 102-paneHeight; one preserved up intent makes it 101-paneHeight.
+				require.Equal(t, 101-paneHeight, firstRenderedHistoryMarker(w.View(), historyLines),
+					"first %s intent must be visible after fill at %s", input, size.name)
+
+				// Exercise the matching down route too. Once history is ready this
+				// applies synchronously and must return to the newest viewport.
+				switch input {
+				case "keyboard":
+					_, _ = h.handleDefaultKeyPress(
+						tea.KeyMsg{Type: tea.KeyCtrlD}, keys.KeyShiftDown)
+				case "wheel":
+					region := layout.PaneRegion(pane.ID())
+					body := zoneRect(t, h, zones.PaneBody(region))
+					wheel(h, body.X+1, body.Y+1, false)
+				}
+				require.Equal(t, 102-paneHeight, firstRenderedHistoryMarker(w.View(), historyLines),
+					"%s down intent must return to bottom at %s", input, size.name)
+			})
+		}
+	}
+}
 
 // TestPanesRefreshNoRedundantScrollFillCapture is the #1709 regression: while a
 // scroll-fill capture is already in flight, a second panesRefresh cycle must NOT

--- a/ui/preview_scroll_fallback_test.go
+++ b/ui/preview_scroll_fallback_test.go
@@ -41,7 +41,7 @@ func enterScrollWithStaleViewport(p *TabPane, inst *session.Instance) {
 	// when UpdateContent(inst, 0) runs — we want to prove setFallbackState is
 	// what clears scroll mode, not the view-change guard.
 	p.currentTab = 0
-	p.isScrolling = true
+	p.scroll.Scroll(&p.viewport, scrollOneLineUp)
 	p.viewport.SetContent(staleScrollMarker)
 }
 
@@ -65,7 +65,7 @@ func TestPreviewScrollModeThenDeletingFallback(t *testing.T) {
 
 	require.NoError(t, p.UpdateContent(inst, 0))
 
-	require.False(t, p.isScrolling,
+	require.False(t, p.scroll.Active(),
 		"entering the Deleting fallback must exit scroll mode")
 	require.True(t, p.content.fallback,
 		"Deleting instance must render a fallback")
@@ -91,12 +91,12 @@ func TestPreviewScrollModeThenNilInstanceFallback(t *testing.T) {
 	// (nil==nil, tab unchanged) does not reset scroll itself — setFallbackState
 	// must.
 	p.currentTab = 0
-	p.isScrolling = true
+	p.scroll.Scroll(&p.viewport, scrollOneLineUp)
 	p.viewport.SetContent(staleScrollMarker)
 
 	require.NoError(t, p.UpdateContent(nil, 0))
 
-	require.False(t, p.isScrolling,
+	require.False(t, p.scroll.Active(),
 		"the nil-instance fallback must exit scroll mode")
 	require.True(t, p.content.fallback)
 	require.NotContains(t, p.viewport.View(), staleScrollMarker,
@@ -127,7 +127,7 @@ func TestPreviewScrollModeThenLoadingFallback(t *testing.T) {
 
 	require.NoError(t, p.UpdateContent(inst, 0))
 
-	require.False(t, p.isScrolling,
+	require.False(t, p.scroll.Active(),
 		"entering the Loading fallback must exit scroll mode")
 	require.True(t, p.content.fallback)
 	require.NotContains(t, p.viewport.View(), staleScrollMarker)
@@ -154,7 +154,7 @@ func TestPreviewScrollEntryDeletingShowsTeardownFallback(t *testing.T) {
 
 	require.NoError(t, p.ScrollUp(inst, 0))
 
-	require.False(t, p.isScrolling,
+	require.False(t, p.scroll.Active(),
 		"deleting agent tab must not enter empty scroll mode")
 	require.True(t, p.content.fallback,
 		"deleting agent tab must enter fallback state when scrolling starts")
@@ -188,7 +188,7 @@ func TestPreviewScrollModeViewportContentCleared(t *testing.T) {
 
 	require.NoError(t, p.UpdateContent(inst, 0))
 
-	require.False(t, p.isScrolling, "scroll mode must be exited")
+	require.False(t, p.scroll.Active(), "scroll mode must be exited")
 	require.NotContains(t, p.viewport.View(), staleScrollMarker,
 		"viewport content must be cleared when entering a fallback (#940)")
 }
@@ -250,7 +250,7 @@ func TestPreviewScrollModeThenSessionGoneFallback(t *testing.T) {
 	require.NoError(t, p.ScrollUp(setup.instance, 0))
 	require.NoError(t, p.UpdateContent(setup.instance, 0))
 
-	require.False(t, p.isScrolling,
+	require.False(t, p.scroll.Active(),
 		"session-gone while entering scroll mode must not leave the pane scrolling")
 	require.True(t, p.content.fallback,
 		"preview must enter fallback state when the session is gone")

--- a/ui/preview_scroll_offloop_test.go
+++ b/ui/preview_scroll_offloop_test.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"fmt"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -8,6 +10,147 @@ import (
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/stretchr/testify/require"
 )
+
+func numberedScrollHistory(lines int) string {
+	out := make([]string, lines)
+	for i := range out {
+		out[i] = fmt.Sprintf("history-%03d", i+1)
+	}
+	return strings.Join(out, "\n")
+}
+
+// TestFirstScrollIntentSurvivesPendingFill is the fail-first half of #2192:
+// the gesture that ENTERS scroll mode is still a scroll request. The history
+// capture remains off the event loop (#1637), but when it lands the viewport
+// must be one row above the bottom rather than discarding that first intent.
+func TestFirstScrollIntentSurvivesPendingFill(t *testing.T) {
+	inst := makeShellInstance(t, "first-intent", "visible-line")
+	defer func() { _ = inst.Kill() }()
+
+	const height = 10
+	history := numberedScrollHistory(40)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	src := func(_ *session.Instance, _ int, full bool) (string, error) {
+		if !full {
+			return "visible-line", nil
+		}
+		close(started)
+		<-release
+		return history, nil
+	}
+
+	p := NewTabPane(src)
+	p.SetSize(80, height)
+	require.NoError(t, p.ScrollUp(inst, 1))
+	p.BeginScrollFill()
+
+	filled := make(chan error, 1)
+	go func() { filled <- p.UpdateContent(inst, 1) }()
+	<-started
+	close(release)
+	require.NoError(t, <-filled)
+
+	// Forty history rows plus the one-row footer produce a bottom offset of 31.
+	// The initiating up intent must therefore land at offset 30.
+	require.Equal(t, 30, p.viewport.YOffset,
+		"the first scroll-up must be applied after the async history fill")
+}
+
+// TestQueuedScrollIntentsSurvivePendingFill is the latency-sensitive half of
+// #2192. Input can continue while the off-loop capture is pending; every
+// gesture must accumulate against the eventual history instead of operating on
+// the temporarily empty viewport and disappearing when the fill publishes.
+func TestQueuedScrollIntentsSurvivePendingFill(t *testing.T) {
+	inst := makeShellInstance(t, "queued-intents", "visible-line")
+	defer func() { _ = inst.Kill() }()
+
+	const height = 10
+	history := numberedScrollHistory(40)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	src := func(_ *session.Instance, _ int, full bool) (string, error) {
+		if !full {
+			return "visible-line", nil
+		}
+		close(started)
+		<-release
+		return history, nil
+	}
+
+	p := NewTabPane(src)
+	p.SetSize(80, height)
+	require.NoError(t, p.ScrollUp(inst, 1)) // initiating intent
+	p.BeginScrollFill()
+
+	filled := make(chan error, 1)
+	go func() { filled <- p.UpdateContent(inst, 1) }()
+	<-started
+	require.NoError(t, p.ScrollUp(inst, 1)) // queued while capture is blocked
+	require.NoError(t, p.ScrollUp(inst, 1)) // queued while capture is blocked
+	close(release)
+	require.NoError(t, <-filled)
+
+	// Bottom is 31; all three up intents must survive, yielding 28.
+	require.Equal(t, 28, p.viewport.YOffset,
+		"scroll intents queued during the pending fill must all be applied")
+}
+
+// TestHostHistoryScrollRetargetKeepsNewViewIntent pins the view-key boundary:
+// moving from A to B must discard A's ready viewport, but the wheel/key intent
+// that performs the retarget is B's first request and must survive B's fill.
+func TestHostHistoryScrollRetargetKeepsNewViewIntent(t *testing.T) {
+	instA := makeShellInstance(t, "retarget-a", "visible-a")
+	instB := makeShellInstance(t, "retarget-b", "visible-b")
+	defer func() { _ = instA.Kill() }()
+	defer func() { _ = instB.Kill() }()
+
+	historyA := strings.ReplaceAll(numberedScrollHistory(40), "history", "a-history")
+	historyB := strings.ReplaceAll(numberedScrollHistory(40), "history", "b-history")
+	aStarted := make(chan struct{})
+	releaseA := make(chan struct{})
+	src := func(inst *session.Instance, _ int, full bool) (string, error) {
+		if !full {
+			if inst == instA {
+				return "visible-a", nil
+			}
+			return "visible-b", nil
+		}
+		if inst == instA {
+			close(aStarted)
+			<-releaseA
+			return historyA, nil
+		}
+		return historyB, nil
+	}
+
+	p := NewTabPane(src)
+	p.SetSize(80, 10)
+	require.NoError(t, p.ScrollUp(instA, 1))
+	p.BeginScrollFill()
+	aFilled := make(chan error, 1)
+	go func() { aFilled <- p.UpdateContent(instA, 1) }()
+	<-aStarted
+
+	// Retarget while A is still captured off-loop. This gesture belongs to B.
+	require.NoError(t, p.ScrollUp(instB, 1))
+	require.NotContains(t, p.viewport.View(), "a-history",
+		"retarget must clear A before B's capture lands")
+	p.BeginScrollFill()
+	require.NoError(t, p.UpdateContent(instB, 1))
+	require.Contains(t, p.viewport.View(), "b-history")
+	require.NotContains(t, p.viewport.View(), "a-history")
+	require.Equal(t, 30, p.viewport.YOffset,
+		"the retargeting intent must be applied to B's host history")
+
+	// A's stale capture may return afterward, but cannot overwrite B or consume
+	// B's already-applied intent.
+	close(releaseA)
+	require.NoError(t, <-aFilled)
+	require.Contains(t, p.viewport.View(), "b-history")
+	require.NotContains(t, p.viewport.View(), "a-history")
+	require.Equal(t, 30, p.viewport.YOffset)
+}
 
 // TestScrollEntryExitNeverCapturesOnEventLoop is the #1637 regression: entering
 // and exiting scroll mode must NOT perform the full-scrollback capture inline.

--- a/ui/preview_test.go
+++ b/ui/preview_test.go
@@ -240,7 +240,7 @@ func TestPreviewScrolling(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify we're not in scrolling mode initially
-	require.False(t, previewPane.isScrolling, "Should not be in scrolling mode initially")
+	require.False(t, previewPane.scroll.Active(), "Should not be in scrolling mode initially")
 
 	// Step 2: Check that PreviewFullHistory returns all content
 	fullHistory, err := setup.instance.AgentServer().Preview(0, true)
@@ -255,7 +255,7 @@ func TestPreviewScrolling(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify we entered scrolling mode
-	require.True(t, previewPane.isScrolling, "Should be in scrolling mode after ScrollUp")
+	require.True(t, previewPane.scroll.Active(), "Should be in scrolling mode after ScrollUp")
 
 	// Step 4: Get the content directly from the viewport
 	viewportContent := previewPane.viewport.View()
@@ -289,7 +289,7 @@ func TestPreviewScrolling(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify we exited scrolling mode
-	require.False(t, previewPane.isScrolling, "Should not be in scrolling mode after reset")
+	require.False(t, previewPane.scroll.Active(), "Should not be in scrolling mode after reset")
 }
 
 // MockPtyFactory for testing tmux sessions
@@ -374,7 +374,7 @@ func TestPreviewContentWithoutScrolling(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify we're not in scrolling mode
-	require.False(t, previewPane.isScrolling, "Should not be in scrolling mode")
+	require.False(t, previewPane.scroll.Active(), "Should not be in scrolling mode")
 
 	// Verify that the preview state is not in fallback mode
 	require.False(t, previewPane.content.fallback, "Preview should not be in fallback mode")
@@ -505,10 +505,10 @@ func TestPreviewResetToNormalModeNilInstance(t *testing.T) {
 
 	// Simulate being in scroll mode with stale viewport content.
 	const staleContent = "stale-scroll-content-line\nanother-line"
-	p.isScrolling = true
+	p.scroll.Scroll(&p.viewport, scrollOneLineUp)
 	p.viewport.SetContent(staleContent)
 
-	require.True(t, p.isScrolling, "precondition: should be in scrolling mode")
+	require.True(t, p.scroll.Active(), "precondition: should be in scrolling mode")
 	require.Contains(t, p.viewport.View(), "stale-scroll-content-line",
 		"precondition: viewport should hold stale content")
 
@@ -516,7 +516,7 @@ func TestPreviewResetToNormalModeNilInstance(t *testing.T) {
 	err := p.ResetToNormalMode(nil, 0)
 	require.NoError(t, err)
 
-	require.False(t, p.isScrolling,
+	require.False(t, p.scroll.Active(),
 		"isScrolling must be false after ResetToNormalMode(nil)")
 
 	// The rendered output must no longer be the stale scroll-mode viewport.
@@ -550,10 +550,10 @@ func TestPreviewResetToNormalModeLoadingShowsFallback(t *testing.T) {
 		"precondition: Loading instance shows the fallback in normal mode")
 
 	require.NoError(t, p.ScrollUp(inst, 0))
-	require.True(t, p.isScrolling, "precondition: ScrollUp enters scroll mode")
+	require.True(t, p.scroll.Active(), "precondition: ScrollUp enters scroll mode")
 
 	require.NoError(t, p.ResetToNormalMode(inst, 0))
-	require.False(t, p.isScrolling,
+	require.False(t, p.scroll.Active(),
 		"isScrolling must be false after ResetToNormalMode")
 	require.True(t, p.content.fallback,
 		"exiting scroll mode on a Loading instance must keep the fallback state")
@@ -907,7 +907,7 @@ func TestResetToNormalModeDoesNotClearFallbackFlag(t *testing.T) {
 	p.setFallbackState("Setting up workspace…")
 	require.True(t, p.content.fallback,
 		"precondition: fallback should be true after setFallbackState")
-	p.isScrolling = true
+	p.scroll.Scroll(&p.viewport, scrollOneLineUp)
 	p.viewport.SetContent("ESC to exit scroll mode")
 
 	// Exit scroll mode. ResetToNormalMode clears scroll state without capturing
@@ -915,7 +915,7 @@ func TestResetToNormalModeDoesNotClearFallbackFlag(t *testing.T) {
 	// #577 bug. A live instance matches none of its synchronous fallback cases, so
 	// p.content is left exactly as it was (the fallback), consistently.
 	require.NoError(t, p.ResetToNormalMode(setup.instance, 0))
-	require.False(t, p.isScrolling, "should exit scroll mode")
+	require.False(t, p.scroll.Active(), "should exit scroll mode")
 	require.False(t, p.content.fallback && p.content.text == expectedContent,
 		"#577: ResetToNormalMode must never leave fallback==true holding real terminal text")
 
@@ -956,17 +956,17 @@ func TestPreviewSwitchInstanceResetsScroll(t *testing.T) {
 	// Render A normally, then enter scroll mode on A.
 	require.NoError(t, p.UpdateContent(instA, 0))
 	require.NoError(t, p.ScrollUp(instA, 0))
-	require.True(t, p.isScrolling, "should be scrolling after ScrollUp on A")
+	require.True(t, p.scroll.Active(), "should be scrolling after ScrollUp on A")
 
 	// Re-render the SAME instance while scrolling: scroll state must
 	// survive (this is the original behavior the #470 fix must not break).
 	require.NoError(t, p.UpdateContent(instA, 0))
-	require.True(t, p.isScrolling,
+	require.True(t, p.scroll.Active(),
 		"re-rendering the same instance must preserve scroll mode")
 
 	// Now switch to B. Scroll state must be cleared and B's content rendered.
 	require.NoError(t, p.UpdateContent(instB, 0))
-	require.False(t, p.isScrolling,
+	require.False(t, p.scroll.Active(),
 		"switching to a different instance must exit scroll mode")
 	require.False(t, p.content.fallback,
 		"B is a real running instance; preview must not be in fallback")
@@ -997,7 +997,7 @@ func TestScrollMouseDifferentInstanceResetsScrollMode(t *testing.T) {
 	// entry is I/O-free (#1637); the off-loop refresh (UpdateContent) fills the
 	// viewport from A — the two-step flow production drives after a wheel scroll.
 	require.NoError(t, p.ScrollUp(instA, 0))
-	require.True(t, p.isScrolling, "should be scrolling A after ScrollUp(A)")
+	require.True(t, p.scroll.Active(), "should be scrolling A after ScrollUp(A)")
 	require.NoError(t, p.UpdateContent(instA, 0))
 	require.Contains(t, p.viewport.View(), previewA,
 		"precondition: viewport should hold A's captured content")
@@ -1007,7 +1007,7 @@ func TestScrollMouseDifferentInstanceResetsScrollMode(t *testing.T) {
 	// drops scroll state and re-keys to B (dropStaleView clears the viewport at
 	// once), and the off-loop fill captures B's content — never stale A.
 	require.NoError(t, p.ScrollUp(instB, 0))
-	require.True(t, p.isScrolling,
+	require.True(t, p.scroll.Active(),
 		"should re-enter scroll mode for B after the switch")
 	require.NotContains(t, p.viewport.View(), previewA,
 		"stale viewport content from A must be cleared on the scroll path at once")

--- a/ui/scroll_controller.go
+++ b/ui/scroll_controller.go
@@ -1,0 +1,204 @@
+package ui
+
+import "github.com/charmbracelet/bubbles/viewport"
+
+// ScrollOwner identifies the subsystem that can truthfully satisfy a scroll
+// request for a pane. HostHistory is the captured-preview implementation; the
+// other values define the routing seam for child-owned history and surfaces
+// that cannot scroll.
+type ScrollOwner uint8
+
+const (
+	ScrollOwnerNone ScrollOwner = iota
+	ScrollOwnerHostHistory
+	ScrollOwnerChildApplication
+)
+
+// ScrollIntent is a semantic vertical displacement. Negative lines move toward
+// older content; positive lines move toward newer content. Mouse and keyboard
+// input are normalized to this type before the controller sees them.
+type ScrollIntent struct {
+	Lines int
+}
+
+var (
+	scrollOneLineUp   = ScrollIntent{Lines: -1}
+	scrollOneLineDown = ScrollIntent{Lines: 1}
+)
+
+// ScrollController is the pane-level ownership and transition contract. It is
+// deliberately independent of keys and mouse events: callers submit semantic
+// intents, and the implementation decides whether to apply immediately or hold
+// them across an asynchronous transition.
+//
+// Methods are called while TabPane.mu is held; implementations do not lock.
+type ScrollController interface {
+	Owner() ScrollOwner
+	Active() bool
+	Scroll(*viewport.Model, ScrollIntent)
+	Resize(*viewport.Model, int, int)
+	Reset(*viewport.Model)
+}
+
+// historyScrollController extends the owner contract with the asynchronous
+// fill lifecycle needed by tmux/host scrollback. Keeping this behind the base
+// interface leaves child-application implementations free of capture phases.
+type historyScrollController interface {
+	ScrollController
+	AwaitingHistory() bool
+	NeedsFill(viewportHeight int) bool
+	BeginFill()
+	FillGeneration() uint64
+	FillIsCurrent(uint64) bool
+	RearmFill()
+	CompleteFill(uint64, *viewport.Model, string) bool
+}
+
+type historyScrollPhase uint8
+
+const (
+	historyScrollIdle historyScrollPhase = iota
+	historyScrollLoading
+	historyScrollReady
+)
+
+// hostHistoryScrollController owns all state that used to be distributed over
+// TabPane's isScrolling/fill-pending/generation booleans. phase is the single
+// state-machine axis. pendingIntents is intentionally retained while capture
+// runs, so input latency cannot erase or reorder user intent (#2192).
+type hostHistoryScrollController struct {
+	phase          historyScrollPhase
+	pendingIntents []ScrollIntent
+	fillGen        uint64
+	dispatchedGen  uint64
+}
+
+var _ historyScrollController = (*hostHistoryScrollController)(nil)
+
+func newHostHistoryScrollController() historyScrollController {
+	return &hostHistoryScrollController{}
+}
+
+func (*hostHistoryScrollController) Owner() ScrollOwner {
+	return ScrollOwnerHostHistory
+}
+
+func (c *hostHistoryScrollController) Active() bool {
+	return c.phase != historyScrollIdle
+}
+
+func (c *hostHistoryScrollController) AwaitingHistory() bool {
+	return c.phase == historyScrollLoading
+}
+
+func (c *hostHistoryScrollController) NeedsFill(viewportHeight int) bool {
+	return c.phase == historyScrollLoading && viewportHeight > 0 &&
+		c.dispatchedGen != c.fillGen
+}
+
+func (c *hostHistoryScrollController) BeginFill() {
+	if c.phase == historyScrollLoading {
+		c.dispatchedGen = c.fillGen
+	}
+}
+
+func (c *hostHistoryScrollController) FillGeneration() uint64 {
+	return c.fillGen
+}
+
+func (c *hostHistoryScrollController) FillIsCurrent(gen uint64) bool {
+	return c.phase == historyScrollLoading && c.fillGen == gen
+}
+
+// Scroll either starts host-history acquisition, queues intent while that
+// acquisition is pending, or applies intent to the ready viewport. The first
+// request is recorded before the viewport is emptied: entering the mode is not
+// a substitute for performing the requested scroll.
+func (c *hostHistoryScrollController) Scroll(v *viewport.Model, intent ScrollIntent) {
+	if intent.Lines == 0 {
+		return
+	}
+	switch c.phase {
+	case historyScrollIdle:
+		v.SetContent("")
+		v.GotoTop()
+		c.phase = historyScrollLoading
+		c.pendingIntents = append(c.pendingIntents, intent)
+		c.fillGen++
+	case historyScrollLoading:
+		c.pendingIntents = append(c.pendingIntents, intent)
+	case historyScrollReady:
+		applyScrollIntent(v, intent)
+	}
+}
+
+// CompleteFill publishes only the capture generation that is still owed. The
+// target offset is derived in one transition: seed the viewport's newest valid
+// offset, then apply every intent accumulated during the capture. There is no
+// final unconditional GotoBottom that can overwrite those requests (#2192).
+func (c *hostHistoryScrollController) CompleteFill(
+	gen uint64,
+	v *viewport.Model,
+	content string,
+) bool {
+	if !c.FillIsCurrent(gen) {
+		return false
+	}
+	v.SetContent(content)
+	// Seed from the ready content and current geometry, then replay in order so
+	// boundary clamping is identical to input received after the fill. In
+	// particular, down-at-bottom followed by up must still move up.
+	v.SetYOffset(viewportBottomOffset(v))
+	for _, intent := range c.pendingIntents {
+		applyScrollIntent(v, intent)
+	}
+	c.pendingIntents = nil
+	c.phase = historyScrollReady
+	c.fillGen++
+	return true
+}
+
+// Resize keeps a ready history viewport at the same distance from its newest
+// row. Loading uses the eventual geometry when CompleteFill lands; idle has no
+// scroll position to preserve.
+func (c *hostHistoryScrollController) Resize(v *viewport.Model, width, height int) {
+	distanceFromBottom := 0
+	if c.phase == historyScrollReady {
+		distanceFromBottom = max(0, viewportBottomOffset(v)-v.YOffset)
+	}
+	v.Width = width
+	v.Height = height
+	if c.phase == historyScrollReady {
+		v.SetYOffset(viewportBottomOffset(v) - distanceFromBottom)
+	}
+}
+
+// RearmFill preserves pending intent but gives the retry a fresh generation.
+// A capture that could not publish must not either lose input or leave the pane
+// permanently masked as in-flight (#1709).
+func (c *hostHistoryScrollController) RearmFill() {
+	if c.phase == historyScrollLoading {
+		c.fillGen++
+	}
+}
+
+func (c *hostHistoryScrollController) Reset(v *viewport.Model) {
+	c.phase = historyScrollIdle
+	c.pendingIntents = nil
+	c.fillGen++
+	v.SetContent("")
+	v.GotoTop()
+}
+
+func applyScrollIntent(v *viewport.Model, intent ScrollIntent) {
+	switch {
+	case intent.Lines < 0:
+		v.LineUp(-intent.Lines)
+	case intent.Lines > 0:
+		v.LineDown(intent.Lines)
+	}
+}
+
+func viewportBottomOffset(v *viewport.Model) int {
+	return max(0, v.TotalLineCount()-v.Height)
+}

--- a/ui/scroll_controller_test.go
+++ b/ui/scroll_controller_test.go
@@ -1,0 +1,86 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/bubbles/viewport"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHostHistoryScrollControllerConformanceAtTerminalSizes(t *testing.T) {
+	history := lipgloss.JoinVertical(lipgloss.Left, numberedScrollHistory(100), scrollFooter())
+
+	for _, size := range []struct {
+		name          string
+		width, height int
+	}{
+		{name: "80x24", width: 80, height: 24},
+		{name: "120x40", width: 120, height: 40},
+	} {
+		t.Run(size.name, func(t *testing.T) {
+			v := viewport.New(size.width, size.height)
+			controller := newHostHistoryScrollController()
+			require.Equal(t, ScrollOwnerHostHistory, controller.Owner())
+
+			controller.Scroll(&v, scrollOneLineUp)
+			require.True(t, controller.Active())
+			require.True(t, controller.NeedsFill(size.height))
+			gen := controller.FillGeneration()
+			require.True(t, controller.CompleteFill(gen, &v, history))
+
+			bottom := 101 - size.height // 100 history rows + one footer row.
+			require.Equal(t, bottom-1, v.YOffset,
+				"first intent must land one row above bottom at %s", size.name)
+
+			controller.Scroll(&v, scrollOneLineDown)
+			require.Equal(t, bottom, v.YOffset,
+				"down intent must return to the newest host-history row")
+		})
+	}
+}
+
+func TestHostHistoryScrollControllerPreservesIntentAcrossPendingResize(t *testing.T) {
+	history := lipgloss.JoinVertical(lipgloss.Left, numberedScrollHistory(100), scrollFooter())
+	v := viewport.New(80, 24)
+	controller := newHostHistoryScrollController()
+
+	controller.Scroll(&v, scrollOneLineUp)
+	gen := controller.FillGeneration()
+
+	// The real TUI can resize while capture is in flight. The eventual offset is
+	// computed from the new geometry, while both pre/post-resize intents survive.
+	controller.Resize(&v, 120, 40)
+	controller.Scroll(&v, scrollOneLineUp)
+	require.True(t, controller.CompleteFill(gen, &v, history))
+	require.Equal(t, 59, v.YOffset, "120x40 bottom 61 minus two queued up intents")
+}
+
+func TestHostHistoryScrollControllerReplaysQueuedIntentInOrder(t *testing.T) {
+	history := lipgloss.JoinVertical(lipgloss.Left, numberedScrollHistory(100), scrollFooter())
+	v := viewport.New(80, 24)
+	controller := newHostHistoryScrollController()
+
+	// A down request at the newest row clamps there; the subsequent up request
+	// must still move one row. Reducing the queue to a net displacement would
+	// incorrectly cancel the two and lose their ordering semantics.
+	controller.Scroll(&v, scrollOneLineDown)
+	controller.Scroll(&v, scrollOneLineUp)
+	require.True(t, controller.CompleteFill(controller.FillGeneration(), &v, history))
+	require.Equal(t, 76, v.YOffset)
+}
+
+func TestHostHistoryScrollControllerPreservesDistanceAcrossReadyResize(t *testing.T) {
+	history := lipgloss.JoinVertical(lipgloss.Left, numberedScrollHistory(100), scrollFooter())
+	v := viewport.New(80, 24)
+	controller := newHostHistoryScrollController()
+
+	controller.Scroll(&v, scrollOneLineUp)
+	require.True(t, controller.CompleteFill(controller.FillGeneration(), &v, history))
+	require.Equal(t, 76, v.YOffset, "80x24 bottom 77 minus one")
+
+	controller.Resize(&v, 120, 40)
+	require.Equal(t, 60, v.YOffset, "120x40 bottom 61 minus the same one-row distance")
+	controller.Resize(&v, 80, 24)
+	require.Equal(t, 76, v.YOffset, "shrinking must preserve distance from bottom too")
+}

--- a/ui/tab_pane.go
+++ b/ui/tab_pane.go
@@ -49,7 +49,7 @@ type tabContentState struct {
 //     off the passed instance + slot (not a title cache), so there is no
 //     stale-session drift to attach/scroll the wrong thing.
 //   - #669/#672/#940 setFallbackState clears scroll state so fallback==true can
-//     never coexist with isScrolling==true (String() checks isScrolling first).
+//     never coexist with an active scroll controller (String() checks it first).
 //   - #496/#920/#935 session-gone / Deleting / Dead fallbacks.
 //   - #898/#649 trailing-newline strip + newest-lines truncation.
 type TabPane struct {
@@ -68,32 +68,12 @@ type TabPane struct {
 	// retargeting snapshots it so a grace-period expiry can replace stale content
 	// without racing and overwriting a capture that landed at the deadline.
 	renderRevision uint64
-	isScrolling    bool
-	// scrollFillPending is set when ScrollUp/ScrollDown enter scroll mode and
-	// cleared once the off-loop capture has populated the viewport. Scroll entry
-	// no longer captures on the bubbletea event loop (#1637); this flag is the
-	// deterministic "capture still owed" signal the updateAgent/updateShell
-	// lazy-fill and NeedsScrollFill key off — a sized viewport's View() is never
-	// the empty string (it renders padding), so viewport emptiness cannot serve.
-	scrollFillPending bool
-	// scrollFillGen / scrollFillDispatchedGen are the generation token that
-	// replaces a plain in-flight bool (#1709). scrollFillGen stamps the current
-	// scroll-fill lifecycle: it bumps on every scroll entry, every reset, and
-	// every re-arm, so each owed fill is a distinct request. scrollFillDispatchedGen
-	// records the generation panesRefresh has already dispatched a capture for.
-	//
-	// A generation, not a bool, because the in-flight state is shared across scroll
-	// EXIT and RE-ENTRY on the same instance/tab (unchanged render seq — scroll
-	// entry/exit does not bump ContentSeq). A capture stamps scrollFillGen at
-	// dispatch and, on return, applies its result only if the generation still
-	// matches; a slow capture from a previous scroll session finds the generation
-	// moved on and is ignored, so it can neither satisfy nor clear the newer
-	// entry's fill. Masking (no redundant dispatch) falls out of the same tokens:
-	// a fill is owed-and-undispatched only while scrollFillDispatchedGen != the
-	// current scrollFillGen.
-	scrollFillGen           uint64
-	scrollFillDispatchedGen uint64
-	viewport                viewport.Model
+	// scroll is the explicit scroll owner and transition controller (#2192).
+	// Captured tabs use host-history ownership. It owns active/loading/
+	// ready state, fill generations, and pending intent; TabPane owns only the
+	// rendered viewport it asks the controller to manipulate.
+	scroll   historyScrollController
+	viewport viewport.Model
 
 	// currentInstance + currentTab identify the (instance, tab-index) view
 	// currently rendered. UpdateContent/ScrollUp/ScrollDown reset scroll-mode
@@ -126,6 +106,7 @@ func NewTabPane(src PreviewSource) *TabPane {
 	return &TabPane{
 		viewport:   viewport.New(0, 0),
 		previewSrc: src,
+		scroll:     newHostHistoryScrollController(),
 	}
 }
 
@@ -134,7 +115,16 @@ func NewTabPane(src PreviewSource) *TabPane {
 func (p *TabPane) IsScrolling() bool {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	return p.isScrolling
+	return p.scroll.Active()
+}
+
+// ScrollOwner reports which subsystem is responsible for satisfying this
+// pane's scroll requests. The owner boundary lets child-owned terminals route
+// input without changing the host-history contract.
+func (p *TabPane) ScrollOwner() ScrollOwner {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.scroll.Owner()
 }
 
 // NeedsScrollFill reports whether the pane is in scroll mode with an unfilled
@@ -146,41 +136,19 @@ func (p *TabPane) IsScrolling() bool {
 func (p *TabPane) NeedsScrollFill() bool {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	// Owed AND not yet dispatched for the current generation: a dispatched capture
-	// (scrollFillDispatchedGen == scrollFillGen) masks the pane until it resolves
-	// or a new generation supersedes it, so no redundant capture fires (#1709).
-	return p.isScrolling && p.scrollFillPending &&
-		p.scrollFillDispatchedGen != p.scrollFillGen && p.viewport.Height > 0
+	return p.scroll.NeedsFill(p.viewport.Height)
 }
 
 // BeginScrollFill records that panesRefresh has dispatched a capture for the
 // current fill generation, so a refresh cycle in the dispatch→land window sees
 // NeedsScrollFill go false and does not fire a redundant one (#1709). It is
 // called synchronously on the event loop the instant the capture is dispatched.
-// A later scroll entry bumps scrollFillGen past this dispatched generation, which
-// both re-arms NeedsScrollFill and marks the in-flight capture stale.
+// A later scroll lifecycle has a new controller generation, which both re-arms
+// NeedsScrollFill and marks the prior in-flight capture stale.
 func (p *TabPane) BeginScrollFill() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.scrollFillDispatchedGen = p.scrollFillGen
-}
-
-// resetScrollFill clears the fill-owed flag and starts a new generation. Every
-// scroll-state reset and every completed fill funnels through it: bumping the
-// generation invalidates any capture still in flight against the old one, so a
-// stale completion can never satisfy or clear a later fill (#1709). Caller must
-// hold p.mu.
-func (p *TabPane) resetScrollFill() {
-	p.scrollFillPending = false
-	p.scrollFillGen++
-}
-
-// rearmScrollFill starts a new generation while leaving the fill owed, so a
-// capture that resolved but could not publish (render binding moved on, transient
-// error) re-dispatches instead of wedging the viewport blank, and its own stale
-// return is ignored (#1709). Caller must hold p.mu.
-func (p *TabPane) rearmScrollFill() {
-	p.scrollFillGen++
+	p.scroll.BeginFill()
 }
 
 func (p *TabPane) SetSize(width, maxHeight int) {
@@ -188,8 +156,7 @@ func (p *TabPane) SetSize(width, maxHeight int) {
 	defer p.mu.Unlock()
 	p.width = width
 	p.height = maxHeight
-	p.viewport.Width = width
-	p.viewport.Height = maxHeight
+	p.scroll.Resize(&p.viewport, width, maxHeight)
 	// Local session sizing is the WS stream's job now (last-resize-wins
 	// resize-window, #1592 Phase 2 PR6): the pane geometry rides the RESIZE frame,
 	// so the TabPane no longer resizes a detached tmux session itself.
@@ -207,11 +174,8 @@ func (p *TabPane) SetSize(width, maxHeight int) {
 // entry points consistent (the #669 motivation).
 func (p *TabPane) dropStaleView(instance *session.Instance, activeTab int) {
 	if instance != p.currentInstance || activeTab != p.currentTab {
-		if p.isScrolling {
-			p.isScrolling = false
-			p.resetScrollFill()
-			p.viewport.SetContent("")
-			p.viewport.GotoTop()
+		if p.scroll.Active() {
+			p.scroll.Reset(&p.viewport)
 		}
 		p.currentInstance = instance
 		p.currentTab = activeTab
@@ -229,19 +193,16 @@ func (p *TabPane) publishContent(content tabContentState) {
 // setFallbackState sets the pane to display a centered fallback message. Caller
 // must hold p.mu.
 //
-// Also resets scroll-mode state so fallback==true cannot coexist with
-// isScrolling==true. String() checks isScrolling before fallback, so leaving
-// scroll state intact when entering a fallback (nil/Loading/Deleting/Dead/
-// session-gone) would render the prior view's stale viewport instead of the
-// fallback message (#669/#672/#940).
+// Also resets scroll-mode state so fallback==true cannot coexist with an active
+// controller. String() checks scroll before fallback, so leaving it active when
+// entering a fallback (nil/Loading/Deleting/Dead/session-gone) would render the
+// prior view's stale viewport instead of the fallback message (#669/#672/#940).
 func (p *TabPane) setFallbackState(message string) {
 	p.publishContent(tabContentState{
 		fallback: true,
 		text:     lipgloss.JoinVertical(lipgloss.Center, FallBackText, "", message),
 	})
-	p.isScrolling = false
-	p.resetScrollFill()
-	p.viewport.SetContent("")
+	p.scroll.Reset(&p.viewport)
 }
 
 // RenderRevision returns the completed-render generation. It is safe to read
@@ -314,6 +275,44 @@ func (p *TabPane) UpdateContentGuarded(instance *session.Instance, activeTab int
 	return p.updateShell(instance, activeTab, guard)
 }
 
+// fillHostHistoryLocked performs the one asynchronous transition shared by
+// agent and shell previews. Caller holds p.mu; this method releases it around
+// capture and returns with it held. The controller keeps both the generation
+// token and every pending ScrollIntent, so a stale capture cannot publish and a
+// slow current capture cannot erase input (#1637/#1709/#2192).
+func (p *TabPane) fillHostHistoryLocked(
+	instance *session.Instance,
+	activeTab int,
+	guard contentGuard,
+	goneMessage string,
+) error {
+	gen := p.scroll.FillGeneration()
+	p.mu.Unlock()
+	content, err := p.previewSrc(instance, activeTab, true)
+	p.mu.Lock()
+
+	if !p.scroll.FillIsCurrent(gen) {
+		return nil
+	}
+	if !guardOK(guard) || !p.isCurrentViewLocked(instance, activeTab) {
+		p.scroll.RearmFill()
+		return nil
+	}
+	if err != nil {
+		if errors.Is(err, tmux.ErrSessionGone) {
+			p.setFallbackState(goneMessage)
+			return nil
+		}
+		p.scroll.RearmFill()
+		return err
+	}
+	content = lipgloss.JoinVertical(lipgloss.Left, content, scrollFooter())
+	if p.scroll.CompleteFill(gen, &p.viewport, content) {
+		p.renderRevision++
+	}
+	return nil
+}
+
 // updateAgent reproduces the former PreviewPane.UpdateContent.
 func (p *TabPane) updateAgent(instance *session.Instance, guard contentGuard) error {
 	p.mu.Lock()
@@ -357,56 +356,15 @@ func (p *TabPane) updateAgent(instance *session.Instance, guard contentGuard) er
 	// alive and its screen shows the limit message, so it falls through to the
 	// live Preview() below.
 
-	// If scroll mode was entered but the scrollback hasn't been captured yet,
-	// capture the full history now. ScrollUp/ScrollDown enter scroll mode WITHOUT
-	// any capture (that used to block the bubbletea event loop on a slow tmux
-	// capture / daemon RPC — #1637); the fill happens here instead, on the
-	// off-loop refresh goroutine, the first time UpdateContent runs with a
-	// pending scroll fill.
-	if p.isScrolling && p.scrollFillPending {
-		gen := p.scrollFillGen
+	// Scroll entry is I/O-free; the controller preserves pending intent while
+	// this off-loop full-history capture runs (#1637/#2192).
+	if p.scroll.AwaitingHistory() {
+		err := p.fillHostHistoryLocked(instance, 0, guard, "Session no longer running.")
 		p.mu.Unlock()
-		content, err := p.previewSrc(instance, 0, true)
-		p.mu.Lock()
-		defer p.mu.Unlock()
-		// A scroll exit+re-entry (or any reset) during the capture bumps the
-		// generation, handing the fill to a newer dispatch. Ignore this stale
-		// completion entirely: it must neither satisfy nor clear the newer entry's
-		// fill, and it must not publish its stale content (#1709 review). Every
-		// path that clears pending or exits scroll mode bumps the generation, so a
-		// matching generation here guarantees the fill is still owed and current.
-		if p.scrollFillGen != gen {
-			return nil
-		}
-		if !guardOK(guard) || !p.isCurrentViewLocked(instance, 0) {
-			// Could not publish for the live render binding: re-arm so the owed
-			// fill re-dispatches rather than wedging the viewport blank (#1709).
-			p.rearmScrollFill()
-			return nil
-		}
-		if err != nil {
-			if errors.Is(err, tmux.ErrSessionGone) {
-				// setFallbackState clears scroll state and the stale viewport, so
-				// the fallback renders even mid scroll-capture (#940).
-				p.setFallbackState("Session no longer running.")
-				return nil
-			}
-			p.rearmScrollFill()
-			return err
-		}
-		p.viewport.SetContent(lipgloss.JoinVertical(lipgloss.Left, content, scrollFooter()))
-		// First fill lands at the bottom (newest output), matching the live view
-		// the user was looking at when they entered scroll mode. This is the only
-		// place that pins the offset: subsequent LineUp/LineDown move it and the
-		// fill no longer runs (pending cleared), so the scroll position is
-		// preserved (#1637).
-		p.viewport.GotoBottom()
-		p.resetScrollFill()
-		p.renderRevision++
-		return nil
+		return err
 	}
 
-	if p.isScrolling {
+	if p.scroll.Active() {
 		p.mu.Unlock()
 		return nil
 	}
@@ -439,7 +397,7 @@ func (p *TabPane) updateAgent(instance *session.Instance, guard contentGuard) er
 
 // webTabPlaceholder is the TUI content for a web/iframe tab, which the terminal
 // cannot render: the target URL plus a pointer to where it can be viewed. Shared
-// by updateShell and enterScrollModeLocked so the two never diverge.
+// by updateShell and canEnterScrollModeLocked so the two never diverge.
 func webTabPlaceholder(url string) string {
 	return fmt.Sprintf("%s\n\nWeb tab — view in the web UI or open in a browser", url)
 }
@@ -454,7 +412,7 @@ func vscodeTabPlaceholder() string {
 
 // tabPlaceholder returns the TUI placeholder for a tab kind the terminal cannot
 // render, and ok=false for kinds it can (agent/shell/process, which have a PTY).
-// Shared by updateShell and enterScrollModeLocked so the two never diverge.
+// Shared by updateShell and canEnterScrollModeLocked so the two never diverge.
 func tabPlaceholder(tab *session.Tab) (string, bool) {
 	switch tab.Kind {
 	case session.TabKindWeb:
@@ -526,7 +484,7 @@ func (p *TabPane) updateShell(instance *session.Instance, activeTab int, guard c
 	// This runs BEFORE the scroll-mode guard below so a shell session killed
 	// externally while the user is scrolling transitions to the fallback instead
 	// of leaving stale scrollback pinned on screen forever (#977). setFallbackState
-	// clears scroll state, so String() (which checks isScrolling first) renders the
+	// clears scroll state, so String() (which checks the controller first) renders the
 	// fallback message. This mirrors the agent slot, whose Dead check also precedes
 	// its scroll guard in updateAgent.
 	if !instance.TabAlive(activeTab) {
@@ -535,50 +493,17 @@ func (p *TabPane) updateShell(instance *session.Instance, activeTab int, guard c
 		return nil
 	}
 
-	// Scroll mode with a pending fill: capture the tab's full scrollback here —
-	// off the event loop, exactly like the agent slot. ScrollUp/ScrollDown no
-	// longer capture inline (that blocked the bubbletea event loop on a slow tmux
-	// capture / daemon RPC — #1637); the shell slot fills lazily on this off-loop
-	// refresh goroutine, the first time UpdateContent runs with a pending fill.
-	if p.isScrolling && p.scrollFillPending {
-		gen := p.scrollFillGen
+	// The shell slot uses the same controller and off-loop fill transition as the
+	// agent slot; input queued during capture is applied when history publishes.
+	if p.scroll.AwaitingHistory() {
+		err := p.fillHostHistoryLocked(instance, activeTab, guard, "Terminal session no longer running.")
 		p.mu.Unlock()
-		content, err := p.previewSrc(instance, activeTab, true)
-		p.mu.Lock()
-		defer p.mu.Unlock()
-		// Stale-generation completion (scroll exit+re-entry during the capture):
-		// ignore it entirely, so this old capture can't satisfy or clear the newer
-		// scroll entry's fill nor publish its stale content (#1709 review). A
-		// matching generation guarantees the fill is still owed and current.
-		if p.scrollFillGen != gen {
-			return nil
-		}
-		if !guardOK(guard) || !p.isCurrentViewLocked(instance, activeTab) {
-			// Could not publish for the live render binding: re-arm so the owed
-			// fill re-dispatches rather than wedging the viewport blank (#1709).
-			p.rearmScrollFill()
-			return nil
-		}
-		if err != nil {
-			if errors.Is(err, tmux.ErrSessionGone) {
-				// setFallbackState clears scroll state and the stale viewport, so
-				// the fallback renders even mid scroll-capture (#940/#977).
-				p.setFallbackState("Terminal session no longer running.")
-				return nil
-			}
-			p.rearmScrollFill()
-			return err
-		}
-		p.viewport.SetContent(lipgloss.JoinVertical(lipgloss.Left, content, scrollFooter()))
-		p.viewport.GotoBottom()
-		p.resetScrollFill()
-		p.renderRevision++
-		return nil
+		return err
 	}
 
 	// Already-filled scroll viewport: leave it (and p.content) untouched so
 	// LineUp/LineDown keep their position.
-	if p.isScrolling {
+	if p.scroll.Active() {
 		p.mu.Unlock()
 		return nil
 	}
@@ -619,7 +544,7 @@ func (p *TabPane) String() string {
 	rect := layout.Rect{W: p.width, H: p.height}
 
 	// In scroll/copy mode always use the viewport.
-	if p.isScrolling {
+	if p.scroll.Active() {
 		return layout.ClampToRect(p.viewport.View(), rect)
 	}
 
@@ -666,6 +591,18 @@ func (p *TabPane) String() string {
 
 // ScrollUp enters scroll mode (if not already) and scrolls up.
 func (p *TabPane) ScrollUp(instance *session.Instance, activeTab int) error {
+	return p.scrollBy(instance, activeTab, scrollOneLineUp)
+}
+
+// ScrollDown enters scroll mode (if not already) and scrolls down.
+func (p *TabPane) ScrollDown(instance *session.Instance, activeTab int) error {
+	return p.scrollBy(instance, activeTab, scrollOneLineDown)
+}
+
+// scrollBy is the single keyboard/wheel-independent input path. It validates a
+// new host-history session, then hands the semantic intent to the controller;
+// the controller either applies it now or preserves it across the pending fill.
+func (p *TabPane) scrollBy(instance *session.Instance, activeTab int, intent ScrollIntent) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if instance == nil {
@@ -674,77 +611,41 @@ func (p *TabPane) ScrollUp(instance *session.Instance, activeTab int) error {
 	// Reset scroll mode if the view changed out from under us, so we capture the
 	// newly selected view's content rather than scrolling stale content (#702).
 	p.dropStaleView(instance, activeTab)
-	if !p.isScrolling {
-		if err := p.enterScrollModeLocked(instance, activeTab); err != nil {
-			return err
-		}
+	if !p.scroll.Active() && !p.canEnterScrollModeLocked(instance, activeTab) {
 		return nil
 	}
-	p.viewport.LineUp(1)
+	p.scroll.Scroll(&p.viewport, intent)
 	return nil
 }
 
-// ScrollDown enters scroll mode (if not already) and scrolls down.
-func (p *TabPane) ScrollDown(instance *session.Instance, activeTab int) error {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if instance == nil {
-		return nil
-	}
-	p.dropStaleView(instance, activeTab)
-	if !p.isScrolling {
-		if err := p.enterScrollModeLocked(instance, activeTab); err != nil {
-			return err
-		}
-		return nil
-	}
-	p.viewport.LineDown(1)
-	return nil
-}
-
-// enterScrollModeLocked switches the pane into scroll mode WITHOUT capturing.
+// canEnterScrollModeLocked validates a new scroll session WITHOUT capturing.
 // The full-scrollback capture used to run inline here, on the bubbletea event
 // loop — an unbounded tmux capture / daemon Preview RPC that froze the whole TUI
-// while entering scroll mode if that capture was slow or hung (#1637). It now
-// only flips scroll state and empties the viewport; the capture happens off the
-// event loop on the next UpdateContent (the updateAgent/updateShell lazy-fill,
-// keyed on an empty scroll viewport), which the app dispatches immediately on
-// scroll entry (panesRefresh bypasses its throttle while NeedsScrollFill). Caller
-// must hold p.mu. Validation uses in-memory state only, never I/O.
-func (p *TabPane) enterScrollModeLocked(instance *session.Instance, activeTab int) error {
+// while entering scroll mode if that capture was slow or hung (#1637). The
+// controller starts the lazy fill only after this in-memory validation succeeds.
+// Caller must hold p.mu.
+func (p *TabPane) canEnterScrollModeLocked(instance *session.Instance, activeTab int) bool {
 	if instance.IsTearingDown() {
 		p.setFallbackState("Tearing down session…")
-		return nil
+		return false
 	}
 	// A web/vscode tab has no scrollback (no PTY): keep the placeholder rather than
 	// entering scroll mode over an empty capture. Mirrors updateShell's branch.
 	if tabs := instance.GetTabs(); activeTab >= 0 && activeTab < len(tabs) {
 		if placeholder, ok := tabPlaceholder(tabs[activeTab]); ok {
 			p.setFallbackState(placeholder)
-			return nil
+			return false
 		}
 	}
 	// An already-dead shell tab transitions to the fallback rather than entering
-	// scroll mode over stale terminal output: leaving p.content intact with
-	// isScrolling==false would render the last capture instead of the dead-session
+	// scroll mode over stale terminal output: leaving normal content intact would
+	// render the last capture instead of the dead-session
 	// message. Mirrors updateShell's !TabAlive branch (#998, sibling of #977/#984).
 	if activeTab != 0 && !instance.TabAlive(activeTab) {
 		p.setFallbackState("Terminal session not available.")
-		return nil
+		return false
 	}
-	// Empty the viewport and mark a fill pending so the off-loop lazy-fill
-	// captures the full scrollback and pins it to the bottom. Capture is keyed off
-	// the passed instance + tab index there, never a cached title, so the wrong
-	// view can never be captured (#746/#384).
-	p.viewport.SetContent("")
-	p.isScrolling = true
-	p.scrollFillPending = true
-	// Start a new generation: this entry's fill is owed and undispatched
-	// (scrollFillDispatchedGen now trails scrollFillGen), and any capture still in
-	// flight from a previous scroll session is stamped an older generation, so it
-	// can't satisfy this entry (#1709).
-	p.scrollFillGen++
-	return nil
+	return true
 }
 
 // ResetToNormalMode exits scroll mode and returns to normal content display.
@@ -754,12 +655,9 @@ func (p *TabPane) ResetToNormalMode(instance *session.Instance, activeTab int) e
 	// Always clear scroll state first so pressing ESC while no instance is
 	// selected (e.g. the sidebar header) does not leave the pane stuck on stale
 	// viewport content.
-	wasScrolling := p.isScrolling
+	wasScrolling := p.scroll.Active()
 	if wasScrolling {
-		p.isScrolling = false
-		p.resetScrollFill()
-		p.viewport.SetContent("")
-		p.viewport.GotoTop()
+		p.scroll.Reset(&p.viewport)
 	}
 
 	if instance == nil || !wasScrolling {

--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -531,6 +531,13 @@ func (w *TabbedWindow) IsInScrollMode() bool {
 	return w.tab.IsScrolling()
 }
 
+// ScrollOwner reports which subsystem can satisfy scroll intent for this pane.
+// Exposing the owner at the window boundary is the routing seam for captured
+// host history and child-owned terminal history.
+func (w *TabbedWindow) ScrollOwner() ScrollOwner {
+	return w.tab.ScrollOwner()
+}
+
 // NeedsScrollFill reports whether the pane just entered scroll mode and is still
 // waiting for its off-loop scrollback capture — panesRefresh bypasses its
 // throttle for such a pane so the fill is immediate (#1637).

--- a/ui/terminal_test.go
+++ b/ui/terminal_test.go
@@ -227,7 +227,7 @@ func TestTabPaneShellFallbackResetsScrollMode(t *testing.T) {
 
 		p.mu.Lock()
 		require.True(t, p.content.fallback)
-		require.False(t, p.isScrolling, "fallback must clear scroll state (#669)")
+		require.False(t, p.scroll.Active(), "fallback must clear scroll state (#669)")
 		p.mu.Unlock()
 
 		rendered := p.String()
@@ -250,7 +250,7 @@ func TestTabPaneShellFallbackResetsScrollMode(t *testing.T) {
 
 		p.mu.Lock()
 		require.True(t, p.content.fallback)
-		require.False(t, p.isScrolling)
+		require.False(t, p.scroll.Active())
 		p.mu.Unlock()
 
 		rendered := p.String()
@@ -477,7 +477,7 @@ func TestTabPaneShellScrollModeSessionGoneExternally(t *testing.T) {
 		"a gone shell session must NOT bubble an error up to handleError")
 
 	p.mu.Lock()
-	stillScrolling := p.isScrolling
+	stillScrolling := p.scroll.Active()
 	hasFallback := p.content.fallback
 	fallbackText := p.content.text
 	p.mu.Unlock()
@@ -568,7 +568,7 @@ func TestTabPaneShellScrollModeAlreadyDead(t *testing.T) {
 		"entering scroll mode on a dead shell must not bubble an error")
 
 	p.mu.Lock()
-	stillScrolling := p.isScrolling
+	stillScrolling := p.scroll.Active()
 	hasFallback := p.content.fallback
 	fallbackText := p.content.text
 	p.mu.Unlock()


### PR DESCRIPTION
## Summary

- add a semantic `ScrollController` / `ScrollOwner` boundary so pane input is routed as scroll intent rather than encoded in unrelated UI flags
- migrate captured preview history to an explicit idle → loading → ready host-history controller
- retain and replay the initiating gesture plus every gesture received during the asynchronous fill, in order
- remove the fill's unconditional final `GotoBottom`; the controller seeds the newest valid offset and applies preserved intent before publishing
- preserve distance from newest output across resize and invalidate stale fills across view retarget/reset

## Root cause addressed

On current master, the gesture that entered preview scroll mode only started the async history fill. Further gestures arriving while that fill was pending operated on an empty viewport. When capture completed, an unconditional `GotoBottom` then erased any position those inputs could have established. Capture latency was therefore the exact discriminator for the intermittent feel.

The fail-first regressions both failed on master as required:

- first gesture: expected offset 30, got 31
- three gestures spanning a blocked fill: expected offset 28, got 31

Both pass with the controller transition.

## Scope

This is PR A for #2192.

Attach remains a raw child-owned pass-through. This does not intercept Ctrl-U, and it does not touch attach, submit, keymap, menu, or help behavior; #2195 remains separate.

Child/alt-screen preview ownership remains parked for PR B pending direct Codex verification. This PR does not infer child behavior from the captured host-history path.

## Verification

- `make test-container`
- `make test-container GOTESTARGS='-race ./ui ./app -run Scroll -count=1'`
- `make lint-file-length`
- isolated real-TUI sandbox at 80×24 and 120×40 with history larger than the viewport:
  - first keyboard and wheel gestures each moved exactly one row
  - three rapid initiating/queued Ctrl-U gestures moved exactly three rows
  - Ctrl-D / wheel-down returned to bottom
  - resizing 80×24 → 120×40 while scrolled preserved distance from newest output
  - no orphan attach clients; the exact sandbox container was removed and verified absent

Tests also cover delayed fill, ordered queued intent, agent and shell fill paths, view retarget with a stale capture returning late, pending and ready resize, and keyboard/wheel routing at both terminal sizes.