### PR TITLE
fix(kill): inspect the branch cleanup deletes

### DIFF
--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -197,12 +197,13 @@ func (m *home) handleKill() (tea.Model, tea.Cmd) {
 	severeLine := ""
 	if selected.Capabilities().Workspace == session.WorkspaceLocalWorktree {
 		// Both loss checks run under the SAME worktree-path gate so they cover the
-		// same session states. GetWorktreePath and GetBaseCommitSHA are NOT gated on
-		// started (unlike GetGitWorktree), so a session that HAS a worktree but was
-		// never started — e.g. a restore-failed session — still gets the unmerged-work
-		// warning the old GetGitWorktree gate skipped for it (#2029). Killing force-
-		// deletes its branch either way, so the same committed work is at stake; the
-		// dirty-worktree check was already ungated, and the two must not diverge.
+		// same session states. GetWorktreePath, GetBranch, and GetBaseCommitSHA are
+		// NOT gated on started (unlike GetGitWorktree), so a session that HAS a
+		// worktree but was never started — e.g. a restore-failed session — still gets
+		// the unmerged-work warning the old GetGitWorktree gate skipped for it
+		// (#2029). Killing force-deletes its branch either way, so the same committed
+		// work is at stake; the dirty-worktree check was already ungated, and the two
+		// must not diverge.
 		if wt := selected.GetWorktreePath(); wt != "" {
 			if w := killConfirmationWarning(wt); w != "" {
 				warnings = append(warnings, w)
@@ -211,7 +212,7 @@ func (m *home) handleKill() (tea.Model, tea.Cmd) {
 			if pr := selected.GetPRInfo(); pr != nil {
 				prState = pr.State
 			}
-			if line, severe := unmergedCommitWarning(wt, selected.GetBaseCommitSHA(), prState); line != "" {
+			if line, severe := unmergedCommitWarning(wt, selected.GetBranch(), selected.GetBaseCommitSHA(), prState); line != "" {
 				if severe {
 					severeLine = line
 				} else {

--- a/app/kill_confirm.go
+++ b/app/kill_confirm.go
@@ -177,19 +177,34 @@ func killConfirmationWarning(wt string) string {
 // tracking ref is stale, reads as local-only and over-warns. Over-warning is the
 // conservative side — the loud path still kills on one keystroke — so we accept
 // it rather than risk staying silent on genuine loss.
-func unmergedCommitWarning(worktreePath, recordedBaseSHA, prState string) (string, bool) {
+//
+// branchName is the session's recorded branch — the exact ref Cleanup deletes —
+// not whichever branch the agent has left checked out at HEAD. The fully
+// qualified local ref must resolve before an empty warning can be returned;
+// missing or unverifiable deletion targets fail closed (#2199).
+func unmergedCommitWarning(worktreePath, branchName, recordedBaseSHA, prState string) (string, bool) {
 	if strings.TrimSpace(worktreePath) == "" {
-		return unmergedFailClosedLine(fmt.Errorf("no worktree path")), false
+		return unmergedFailClosedLine(branchName, fmt.Errorf("no worktree path")), false
+	}
+	branchName = strings.TrimSpace(branchName)
+	if branchName == "" {
+		return unmergedFailClosedLine(branchName, fmt.Errorf("no session branch name")), false
+	}
+	branchRef := "refs/heads/" + branchName
+	if _, err := runKillGit(worktreePath, "rev-parse", "--verify", "--quiet", branchRef+"^{commit}"); err != nil {
+		return unmergedFailClosedLine(branchName, fmt.Errorf("session branch could not be resolved: %w", err)), false
 	}
 	base, baseLabel, ok := resolveKillBase(worktreePath, recordedBaseSHA)
 	if !ok {
-		return unmergedFailClosedLine(fmt.Errorf("base branch/commit could not be determined")), false
+		return unmergedFailClosedLine(branchName, fmt.Errorf("base branch/commit could not be determined")), false
 	}
-	// Commits reachable from the branch tip (HEAD is the branch, checked out in
-	// the worktree) but not from base: the session's own commits.
-	uniqueOut, err := runKillGit(worktreePath, "log", "--oneline", base+"..HEAD")
+	// Commits reachable from the recorded session branch but not from base: the
+	// commits kill will orphan when Cleanup force-deletes that exact branch. An
+	// agent may have checked out a different branch in the worktree, so HEAD is
+	// deliberately not used here (#2199).
+	uniqueOut, err := runKillGit(worktreePath, "log", "--oneline", base+".."+branchRef)
 	if err != nil {
-		return unmergedFailClosedLine(err), false
+		return unmergedFailClosedLine(branchName, err), false
 	}
 	if countGitLines(uniqueOut) == 0 {
 		return "", false // nothing beyond base — kill loses no committed work
@@ -202,25 +217,25 @@ func unmergedCommitWarning(worktreePath, recordedBaseSHA, prState string) (strin
 	}
 	// Of the session's commits, those NOT reachable from any remote-tracking ref
 	// are the ones that exist only here. branch -D orphans exactly these.
-	localOut, err := runKillGit(worktreePath, "log", "--oneline", base+"..HEAD", "--not", "--remotes")
+	localOut, err := runKillGit(worktreePath, "log", "--oneline", base+".."+branchRef, "--not", "--remotes")
 	if err != nil {
-		return unmergedFailClosedLine(err), false
+		return unmergedFailClosedLine(branchName, err), false
 	}
 	localOnly := countGitLines(localOut)
 	if localOnly == 0 {
 		return "", false // every commit is pushed somewhere — recoverable
 	}
-	return unmergedSevereLine(localOnly, baseLabel), true
+	return unmergedSevereLine(branchName, localOnly, baseLabel), true
 }
 
 // resolveKillBase resolves the commit the branch is measured against for the
 // unmerged-work check, offline. It mirrors the base resolution the worktree code
 // already uses (session/git/worktree_ops.go): the recorded base commit first,
-// then origin's default branch. It deliberately does NOT fall back to HEAD —
-// HEAD is the branch tip itself, which would make every branch look zero commits
-// ahead and fabricate a "nothing to lose" negative. When neither resolves, ok is
-// false and the caller fails closed. baseLabel names the base branch when known
-// (for the copy), else "".
+// then origin's default branch. It deliberately does NOT fall back to HEAD:
+// HEAD may be the recorded branch tip (which would fabricate a zero-commits
+// result) or an unrelated branch the agent checked out. When neither resolves,
+// ok is false and the caller fails closed. baseLabel names the base branch when
+// known (for the copy), else "".
 func resolveKillBase(worktreePath, recordedBaseSHA string) (base, baseLabel string, ok bool) {
 	commitExists := func(rev string) bool {
 		_, err := runKillGit(worktreePath, "rev-parse", "--verify", "--quiet", rev+"^{commit}")
@@ -243,10 +258,10 @@ func resolveKillBase(worktreePath, recordedBaseSHA string) (base, baseLabel stri
 	return "", "", false
 }
 
-// unmergedSevereLine is the #2022 data-loss headline: it names the exact count
-// of commits that would be permanently deleted and that the loss is final. It is
-// the critical (never-clipped, #1973) line of the confirmation.
-func unmergedSevereLine(n int, baseLabel string) string {
+// unmergedSevereLine is the #2022 data-loss headline: it names the exact branch
+// and count of commits that would be permanently deleted and that the loss is
+// final. It is the critical (never-clipped, #1973) line of the confirmation.
+func unmergedSevereLine(branchName string, n int, baseLabel string) string {
 	commitWord, pronoun := "commits", "them"
 	where := "that aren't merged or pushed anywhere"
 	if n == 1 {
@@ -256,14 +271,18 @@ func unmergedSevereLine(n int, baseLabel string) string {
 	if baseLabel != "" {
 		where = fmt.Sprintf("not on %s and not pushed anywhere", baseLabel)
 	}
-	return fmt.Sprintf("This branch has %d %s %s. Killing permanently deletes %s · this cannot be undone.", n, commitWord, where, pronoun)
+	return fmt.Sprintf("Branch %q has %d %s %s. Killing permanently deletes %s · this cannot be undone.", branchName, n, commitWord, where, pronoun)
 }
 
 // unmergedFailClosedLine mirrors the #815 could-not-verify warning for the
 // committed-work check: when we cannot prove the branch is free of local-only
 // commits, we say so rather than showing the bare, safe-looking prompt.
-func unmergedFailClosedLine(err error) string {
-	return fmt.Sprintf("Could not verify whether this branch has unmerged commits (%v); any that exist only here would be permanently deleted.", err)
+func unmergedFailClosedLine(branchName string, err error) string {
+	branchLabel := "the session branch"
+	if branchName = strings.TrimSpace(branchName); branchName != "" {
+		branchLabel = fmt.Sprintf("session branch %q", branchName)
+	}
+	return fmt.Sprintf("Could not verify whether %s has unmerged commits (%v); any that exist only here would be permanently deleted.", branchLabel, err)
 }
 
 // countGitLines counts non-empty lines in git command output.

--- a/app/kill_confirm_bound_test.go
+++ b/app/kill_confirm_bound_test.go
@@ -90,7 +90,7 @@ func TestUnmergedCommitWarningIsBounded(t *testing.T) {
 
 	done := make(chan struct{}, 1)
 	go func() {
-		_, _ = unmergedCommitWarning(wt, "deadbeef", "")
+		_, _ = unmergedCommitWarning(wt, "dev/bounded", "deadbeef", "")
 		done <- struct{}{}
 	}()
 

--- a/app/kill_nonstarted_test.go
+++ b/app/kill_nonstarted_test.go
@@ -27,6 +27,7 @@ func nonStartedWorktreeInstance(t *testing.T, title, repoDir, worktreePath, bran
 	t.Helper()
 	inst, err := session.NewInstance(session.InstanceOptions{Title: title, Path: repoDir, Program: "test"})
 	require.NoError(t, err)
+	inst.Branch = branch
 	inst.SetBackend(session.NewFakeBackend())
 	inst.SetStatusForTest(session.Ready) // clears OpCreating; started stays false
 	gw, err := git.NewGitWorktreeFromStorage(repoDir, worktreePath, title, branch, baseSHA, false, true)

--- a/app/kill_unmerged_test.go
+++ b/app/kill_unmerged_test.go
@@ -78,6 +78,7 @@ func startedWorktreeInstance(t *testing.T, title, repoDir, worktreePath, branch,
 	t.Helper()
 	inst, err := session.NewInstance(session.InstanceOptions{Title: title, Path: repoDir, Program: "test"})
 	require.NoError(t, err)
+	inst.Branch = branch
 	inst.SetBackend(session.NewFakeBackend())
 	inst.SetStartedForTest(true)
 	inst.SetStatusForTest(session.Ready)
@@ -154,6 +155,42 @@ func TestHandleKill_UnmergedUnpushedCommit_EscalatesAndNamesLoss(t *testing.T) {
 	assert.Equal(t, "gamma", startMsg.title)
 }
 
+// TestHandleKill_AgentSwitchesBranch_WarnsForSessionBranchCommits is the #2199
+// regression. An agent may check out another branch inside its worktree, but
+// kill still force-deletes the branch recorded for the session. The confirmation
+// must therefore inspect and name that recorded branch, not the worktree's
+// current HEAD, or committed work on the deleted branch is silently orphaned.
+func TestHandleKill_AgentSwitchesBranch_WarnsForSessionBranchCommits(t *testing.T) {
+	repoDir, baseSHA := initBaseRepo(t)
+	wt := addWorktree(t, repoDir, baseSHA, "dev/session-work")
+	commitInWorktree(t, wt)
+
+	// Simulate the agent switching away after committing on the session branch.
+	// HEAD is now level with base, while the ref kill will delete remains one
+	// local-only commit ahead.
+	killGit(t, wt, "checkout", "-q", "-b", "agent-scratch", baseSHA)
+	require.Empty(t, killGit(t, wt, "log", "--oneline", baseSHA+"..HEAD"),
+		"detoured HEAD must look safe to the buggy confirmation")
+	sessionLog := killGit(t, wt, "log", "--oneline", baseSHA+"..refs/heads/dev/session-work")
+	require.NotEmpty(t, sessionLog, "the session branch must retain committed work")
+	require.Len(t, strings.Split(sessionLog, "\n"), 1,
+		"the session branch kill deletes must retain the unique commit")
+
+	inst := startedWorktreeInstance(t, "switched", repoDir, wt, "dev/session-work", baseSHA)
+	_, hm := armKill(t, inst)
+
+	rendered := flatten(hm.confirmationOverlay.Render())
+	assert.Contains(t, rendered, "dev/session-work",
+		"confirmation must identify the branch that kill will delete")
+	assert.NotContains(t, rendered, "agent-scratch",
+		"confirmation must not describe the branch merely checked out at HEAD")
+	assert.Contains(t, rendered, "1 commit",
+		"confirmation must count commits on the branch that kill will delete")
+	assert.Contains(t, rendered, "permanently deletes it")
+	assert.Equal(t, unmergedKillConfirmKey, hm.confirmationOverlay.ConfirmKey,
+		"local-only work on the deleted branch must require deliberate confirmation")
+}
+
 // TestHandleKill_NoUniqueCommits_KeepsBareConfirmation guards against
 // over-warning: a clean worktree whose branch is level with base (no committed
 // work to lose) must kill behind the SAME bare confirmation and ordinary 'y' as
@@ -228,7 +265,7 @@ func TestHandleKill_BaseUndeterminable_FailsClosed(t *testing.T) {
 	_, hm := armKill(t, inst)
 
 	rendered := flatten(hm.confirmationOverlay.Render())
-	assert.Contains(t, rendered, "Could not verify whether this branch has unmerged commits")
+	assert.Contains(t, rendered, `Could not verify whether session branch "dev/nobody" has unmerged commits`)
 	assert.Equal(t, "y", hm.confirmationOverlay.ConfirmKey,
 		"unverifiable is a warning, not a proven loss — keep the ordinary confirm")
 }
@@ -240,7 +277,7 @@ func TestUnmergedCommitWarning(t *testing.T) {
 		repoDir, baseSHA := initBaseRepo(t)
 		wt := addWorktree(t, repoDir, baseSHA, "dev/a")
 		commitInWorktree(t, wt)
-		line, severe := unmergedCommitWarning(wt, baseSHA, "")
+		line, severe := unmergedCommitWarning(wt, "dev/a", baseSHA, "")
 		assert.True(t, severe)
 		assert.Contains(t, line, "1 commit")
 		assert.Contains(t, line, "cannot be undone")
@@ -249,7 +286,7 @@ func TestUnmergedCommitWarning(t *testing.T) {
 	t.Run("no commits beyond base is safe", func(t *testing.T) {
 		repoDir, baseSHA := initBaseRepo(t)
 		wt := addWorktree(t, repoDir, baseSHA, "dev/b")
-		line, severe := unmergedCommitWarning(wt, baseSHA, "")
+		line, severe := unmergedCommitWarning(wt, "dev/b", baseSHA, "")
 		assert.False(t, severe)
 		assert.Empty(t, line)
 	})
@@ -262,7 +299,7 @@ func TestUnmergedCommitWarning(t *testing.T) {
 		killGit(t, repoDir, "init", "-q", "--bare", bare)
 		killGit(t, repoDir, "remote", "add", "origin", bare)
 		killGit(t, wt, "push", "-q", "origin", "dev/c")
-		line, severe := unmergedCommitWarning(wt, baseSHA, "")
+		line, severe := unmergedCommitWarning(wt, "dev/c", baseSHA, "")
 		assert.False(t, severe)
 		assert.Empty(t, line)
 	})
@@ -271,7 +308,7 @@ func TestUnmergedCommitWarning(t *testing.T) {
 		repoDir, baseSHA := initBaseRepo(t)
 		wt := addWorktree(t, repoDir, baseSHA, "dev/d")
 		commitInWorktree(t, wt)
-		line, severe := unmergedCommitWarning(wt, baseSHA, "MERGED")
+		line, severe := unmergedCommitWarning(wt, "dev/d", baseSHA, "MERGED")
 		assert.False(t, severe)
 		assert.Empty(t, line)
 	})
@@ -283,7 +320,7 @@ func TestUnmergedCommitWarning(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(wt, "second.txt"), []byte("more\n"), 0o644))
 		killGit(t, wt, "add", "-A")
 		killGit(t, wt, "commit", "-q", "-m", "agent: more work")
-		line, severe := unmergedCommitWarning(wt, baseSHA, "")
+		line, severe := unmergedCommitWarning(wt, "dev/e", baseSHA, "")
 		assert.True(t, severe)
 		assert.Contains(t, line, "2 commits")
 		assert.Contains(t, line, "deletes them")
@@ -293,20 +330,37 @@ func TestUnmergedCommitWarning(t *testing.T) {
 		repoDir, baseSHA := initBaseRepo(t)
 		wt := addWorktree(t, repoDir, baseSHA, "dev/f")
 		commitInWorktree(t, wt)
-		line, severe := unmergedCommitWarning(wt, "", "") // no recorded base, no origin
+		line, severe := unmergedCommitWarning(wt, "dev/f", "", "") // no recorded base, no origin
 		assert.False(t, severe, "unverifiable must not claim a proven loss")
 		assert.Contains(t, line, "Could not verify")
 	})
 
+	t.Run("missing session branch fails closed", func(t *testing.T) {
+		repoDir, baseSHA := initBaseRepo(t)
+		wt := addWorktree(t, repoDir, baseSHA, "dev/actual")
+		line, severe := unmergedCommitWarning(wt, "dev/missing", baseSHA, "")
+		assert.False(t, severe, "unverifiable must not claim a proven loss")
+		assert.Contains(t, line, `session branch "dev/missing"`)
+		assert.Contains(t, line, "Could not verify")
+	})
+
+	t.Run("empty session branch fails closed", func(t *testing.T) {
+		repoDir, baseSHA := initBaseRepo(t)
+		wt := addWorktree(t, repoDir, baseSHA, "dev/actual")
+		line, severe := unmergedCommitWarning(wt, "", baseSHA, "")
+		assert.False(t, severe, "unverifiable must not claim a proven loss")
+		assert.Contains(t, line, "Could not verify whether the session branch")
+	})
+
 	t.Run("empty worktree path fails closed", func(t *testing.T) {
-		line, severe := unmergedCommitWarning("", "deadbeef", "")
+		line, severe := unmergedCommitWarning("", "dev/missing", "deadbeef", "")
 		assert.False(t, severe)
 		assert.Contains(t, line, "Could not verify")
 	})
 
 	t.Run("git error fails closed", func(t *testing.T) {
 		// A non-repo directory makes the base rev-parse fail.
-		line, severe := unmergedCommitWarning(t.TempDir(), "deadbeef", "")
+		line, severe := unmergedCommitWarning(t.TempDir(), "dev/missing", "deadbeef", "")
 		assert.False(t, severe)
 		assert.Contains(t, line, "Could not verify")
 	})


### PR DESCRIPTION
## Summary

- make the kill confirmation inspect `base..refs/heads/<session-branch>` in both the unique-commit and unpushed-commit probes, matching the ref cleanup actually force-deletes
- resolve that local branch ref before returning a confident negative; an empty, missing, or unreadable session branch now fails closed with a warning
- name the deleted session branch alongside the commit count so the confirmation cannot describe a detoured `HEAD`
- cover the real divergence: the agent checks out a scratch branch at base while the recorded session branch retains one local-only commit

## Root cause

Kill cleanup runs `git branch -D g.branchName`, but the confirmation measured `base..HEAD`. Agents can and do run `git checkout` inside their worktrees, so those refs can diverge. The only irreversible session verb could therefore render the ordinary safe-looking prompt while force-deleting the unseen branch that still held unique work.

Fixes #2199.

## Fail-first reproduction

The new UI-level fixture was run before the production change on `origin/master` at `cbbe22da23905c6ed4a0a385b5ed878df10b0870`. It failed as required:

```text
rendered: "[!] Kill session 'switched'? Press y to confirm, n or esc to cancel"
does not contain "dev/session-work"
does not contain "1 commit"
expected confirm key: "k"
actual confirm key:   "y"
```

With this change the confirmation names `dev/session-work`, reports its one local-only commit, and requires the deliberate `k` confirmation even though `HEAD` is on `agent-scratch`.

## Adjacent `branch -D` audit

- `setupNewWorktree` is exempt: `Setup` reaches it only after probing the exact stored `refs/heads/<branch>` and finding it absent; its best-effort delete targets that same stored name before creating a worktree. It makes no safety decision from `HEAD`.
- `CleanupWorktreesForRepo` is exempt: it obtains `wt.branch` from the same `git worktree list --porcelain` record it removes, then deletes that exact reported branch. There is no separate recorded session branch or `HEAD`-based probe to diverge. The helper currently has test callers only.
- the active factory-reset deletion path is also explicit: `DeleteLocalBranch` receives AF-owned branch names collected from stored session records and never probes `HEAD`.

The per-session kill path was the lone site where one ref was interrogated and a different stored ref was deleted.

## Validation

All gates passed after commit `3a1eb512f6caa03a49c95b3186e04c9c483363fb` was pushed, with local `HEAD`, its upstream tracking ref, and the remote branch all verified at that SHA:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`

— Captain Claude
