### PR TITLE
fix(tui): distinguish preview and attached scroll controls

### DIFF
--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -802,7 +802,7 @@ func (m *home) attachInstanceTab(instance *session.Instance, tabIdx int, agentLa
 		tabID, _ := instance.TabIDAt(tabIdx)
 		return attachStreamFn(context.Background(), instance.Title, repoID, tabID, tabIdx)
 	}
-	return m.showHelpScreen(helpTypeInstanceAttach{}, func() tea.Cmd {
+	return m.showHelpScreen(helpAttach(instance, tabIdx), func() tea.Cmd {
 		return m.beginAttachTransition(func() tea.Cmd {
 			return attachOverlayCallbackFn(m, instance.Title, label, "", attach)
 		})

--- a/app/help.go
+++ b/app/help.go
@@ -86,7 +86,9 @@ type helpTypeInstanceStart struct {
 	instance *session.Instance
 }
 
-type helpTypeInstanceAttach struct{}
+type helpTypeInstanceAttach struct {
+	agent string
+}
 
 // helpTypeInteractive is shown once, the first time the user enters a pane
 // (#1089 PR 2): the sharpest edge of the interaction change is that every
@@ -95,6 +97,33 @@ type helpTypeInteractive struct{}
 
 func helpStart(instance *session.Instance) helpText {
 	return helpTypeInstanceStart{instance: instance}
+}
+
+// helpAttach scopes agent-specific copy to the agent tab. Shell/process tabs
+// deliberately get no scroll hint: their child program is arbitrary, and a
+// confident guess there would repeat the exact honesty bug this notice fixes.
+func helpAttach(instance *session.Instance, tabIdx int) helpText {
+	agent := ""
+	if instance != nil && tabIdx == 0 {
+		agent = instance.ResolvedAgent()
+	}
+	return helpTypeInstanceAttach{agent: agent}
+}
+
+const (
+	claudeAttachedScrollControls = "pgup/pgdn · ctrl+home/end · mouse wheel"
+	codexAttachedScrollControls  = "ctrl+t opens transcript · then pgup/pgdn or home/end"
+)
+
+func attachedScrollControls(agent string) (string, string) {
+	switch agent {
+	case tmux.ProgramClaude:
+		return "Claude", claudeAttachedScrollControls
+	case tmux.ProgramCodex:
+		return "Codex", codexAttachedScrollControls
+	default:
+		return "", ""
+	}
 }
 
 func firstRunActionLine(actions string) string {
@@ -153,7 +182,11 @@ func (h helpTypeGeneral) toContent() string {
 			{helpKey(keys.KeyJumpTab), "Select a tab by number (s opens it, enter attaches)"},
 			{helpKey(keys.KeyNewTab), "Choose a terminal or VS Code tab"},
 			{helpKey(keys.KeyCloseTab), "Close the current tab (the agent tab can't be closed)"},
-			{helpKey(keys.KeyShiftUp) + "/" + helpKey(keys.KeyShiftDown), "Scroll in the current tab"},
+			{helpKey(keys.KeyShiftUp) + "/" + helpKey(keys.KeyShiftDown), "Scroll the current tab preview (navigation mode only)"},
+		}},
+		{title: "Full-screen scrolling:", rows: []helpRow{
+			{"Claude", claudeAttachedScrollControls},
+			{"Codex", codexAttachedScrollControls},
 		}},
 		{title: "Other:", rows: []helpRow{
 			{helpKey(keys.KeyQuit), "Quit the application"},
@@ -194,13 +227,21 @@ func (h helpTypeInstanceStart) toContent() string {
 }
 
 func (h helpTypeInstanceAttach) toContent() string {
-	content := lipgloss.JoinVertical(lipgloss.Left,
-		titleStyle.Render("Attaching to Instance"),
+	lines := []string{
+		titleStyle.Render("Attaching to instance"),
 		"",
-		firstRunActionLine("enter attach full-screen • esc cancel"),
+		descStyle.Render("The attached program owns input and scrolling."),
+		descStyle.Render("AF's ") + keyStyle.Render(helpKey(keys.KeyShiftUp)+"/"+helpKey(keys.KeyShiftDown)) + descStyle.Render(" preview scrolling works only in navigation mode."),
+	}
+	if agent, controls := attachedScrollControls(h.agent); agent != "" {
+		lines = append(lines, descStyle.Render(fmt.Sprintf("%s owns attached scrolling: %s.", agent, controls)))
+	}
+	lines = append(lines,
+		"",
+		firstRunActionLine("enter attach full-screen · esc cancel"),
 		descStyle.Render("Detach later with ")+keyStyle.Render(tmux.DetachKeyDisplay),
 	)
-	return content
+	return lipgloss.JoinVertical(lipgloss.Left, lines...)
 }
 
 func (h helpTypeInteractive) toContent() string {

--- a/app/help_test.go
+++ b/app/help_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sachiniyer/agent-factory/keys"
+	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
 // TestHelpReflectsKeymapRebinds is the regression guard for the #1141
@@ -86,8 +87,9 @@ func TestInstanceAttachHelpShowsProceedCancelAndDetach(t *testing.T) {
 	content := helpTypeInstanceAttach{}.toContent()
 
 	for _, want := range []string{
-		"enter attach full-screen",
-		"esc cancel",
+		"The attached program owns input and scrolling",
+		"preview scrolling works only in navigation mode",
+		"enter attach full-screen · esc cancel",
 		"Detach later with",
 		"ctrl-w",
 	} {
@@ -95,6 +97,78 @@ func TestInstanceAttachHelpShowsProceedCancelAndDetach(t *testing.T) {
 			t.Errorf("attach help missing %q; got:\n%s", want, content)
 		}
 	}
+}
+
+// TestAttachedScrollHelpIsAgentSpecific pins #2195's central honesty rule:
+// Claude and Codex do not share attached scroll controls, and an unknown child
+// gets no guessed hint. Codex PageUp works only after Ctrl-T opens transcript;
+// its wheel did not scroll in the real 0.144.6 TUI verification.
+func TestAttachedScrollHelpIsAgentSpecific(t *testing.T) {
+	tests := []struct {
+		name   string
+		agent  string
+		want   string
+		reject []string
+	}{
+		{
+			name:   "Claude",
+			agent:  tmux.ProgramClaude,
+			want:   "Claude owns attached scrolling: " + claudeAttachedScrollControls,
+			reject: []string{"ctrl+t opens transcript"},
+		},
+		{
+			name:   "Codex",
+			agent:  tmux.ProgramCodex,
+			want:   "Codex owns attached scrolling: " + codexAttachedScrollControls,
+			reject: []string{"mouse wheel", "ctrl+home/end"},
+		},
+		{
+			name:   "unknown child",
+			agent:  "aider",
+			reject: []string{"owns attached scrolling", "mouse wheel", "opens transcript"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			content := helpTypeInstanceAttach{agent: tc.agent}.toContent()
+			if tc.want != "" {
+				require.Contains(t, content, tc.want)
+			}
+			for _, reject := range tc.reject {
+				require.NotContains(t, content, reject)
+			}
+		})
+	}
+}
+
+func TestHelpAttachOnlyNamesControlsForAgentTab(t *testing.T) {
+	instance := newStartedInstance(t, "claude-session")
+
+	agentTab, ok := helpAttach(instance, 0).(helpTypeInstanceAttach)
+	require.True(t, ok)
+	require.Equal(t, tmux.ProgramClaude, agentTab.agent)
+
+	shellTab, ok := helpAttach(instance, 1).(helpTypeInstanceAttach)
+	require.True(t, ok)
+	require.Empty(t, shellTab.agent, "an arbitrary shell/process child must not get an agent-specific scroll guess")
+
+	instance.SetTmuxSession(tmux.NewTmuxSessionFromSanitizedName("af_help_override", "bash"))
+	overriddenAgentTab, ok := helpAttach(instance, 0).(helpTypeInstanceAttach)
+	require.True(t, ok)
+	require.Empty(t, overriddenAgentTab.agent,
+		"a configured Claude slot overridden to bash must follow the resolved child, not guess from Instance.Program")
+}
+
+func TestGeneralHelpSeparatesPreviewAndAttachedScrolling(t *testing.T) {
+	content := helpTypeGeneral{}.toContent()
+
+	require.Contains(t, content, "Scroll the current tab preview (navigation mode only)")
+	require.Contains(t, content, "Claude")
+	require.Contains(t, content, claudeAttachedScrollControls)
+	require.Contains(t, content, "Codex")
+	require.Contains(t, content, codexAttachedScrollControls)
+	require.NotContains(t, content, "Scroll in the current tab")
 }
 
 func TestGeneralHelpOverlayFitsAndMarksScrollAt80x24(t *testing.T) {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -195,7 +195,7 @@ Run `af keys` to see the effective bindings (defaults plus your rebinds).
 
 The default TUI keys changed to ergonomic lower-case bindings in #1027:
 archive is `a`, restore is `r` (#1605), the task manager is `m`, copy PR URL
-is `y`, hooks is `e`, and scrolling is `ctrl+u` / `ctrl+d`. The previous
+is `y`, hooks is `e`, and preview scrolling is `ctrl+u` / `ctrl+d`. The previous
 defaults are not built-in
 aliases; restore any old binding you still want by pinning it here:
 

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -175,8 +175,8 @@ type spec struct {
 var specs = []spec{
 	{name: KeyUp, configKey: "up", keys: []string{"up", "k"}, desc: "up", dispatch: true},
 	{name: KeyDown, configKey: "down", keys: []string{"down", "j"}, desc: "down", dispatch: true},
-	{name: KeyShiftUp, configKey: "scroll_up", keys: []string{"ctrl+u"}, desc: "scroll", dispatch: true},
-	{name: KeyShiftDown, configKey: "scroll_down", keys: []string{"ctrl+d"}, desc: "scroll", dispatch: true},
+	{name: KeyShiftUp, configKey: "scroll_up", keys: []string{"ctrl+u"}, desc: "preview scroll", dispatch: true},
+	{name: KeyShiftDown, configKey: "scroll_down", keys: []string{"ctrl+d"}, desc: "preview scroll", dispatch: true},
 	{name: KeyEnter, keys: []string{"enter"}, desc: "interact", dispatch: true},
 	// "o" was an Enter alias until #1089 PR 2 split the verbs: Enter enters
 	// the pane (interactive), o keeps the old full-screen attach.

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -454,15 +454,15 @@ func centerStart(box, content int) int {
 
 // hintDropOrder lists the options that may be dropped when the hint row is
 // wider than the status bar, least valuable first; options in the same inner
-// slice drop together (a lone "ctrl+d scroll" without its ctrl+u twin reads like a
-// bug). The full instance row is ~108 cells, so on narrow terminals something
-// has to go — and before this priority existed the CLAMP decided, silently
-// cutting the RIGHT edge, i.e. `? help` and `q quit` first: exactly the hints
-// a lost user needs (#1083 play-test). New, help, quit, and kill are
-// deliberately absent from this list: `n new` is the tree-focus affordance,
-// help/quit are the global escape hatches, and `D kill` is the selected-
-// instance affordance the containerized TUI driver uses to distinguish a real
-// row cursor from the sticky single-instance display selection (#1174/#1422
+// slice drop together (a lone "ctrl+d preview scroll" without its ctrl+u twin
+// reads like a bug). The full instance row is wider than common terminals, so
+// something has to go — and before this priority existed the CLAMP
+// decided, silently cutting the RIGHT edge, i.e. `? help` and `q quit` first:
+// exactly the hints a lost user needs (#1083 play-test). New, help, quit, and
+// kill are deliberately absent from this list: `n new` is the tree-focus
+// affordance, help/quit are the global escape hatches, and `D kill` is the
+// selected-instance affordance the containerized TUI driver uses to distinguish
+// a real row cursor from the sticky single-instance display selection (#1174/#1422
 // redo).
 //
 // The naming row used to be absent from this list because it was short. #1936

--- a/ui/statusbar_test.go
+++ b/ui/statusbar_test.go
@@ -74,9 +74,11 @@ func TestMenuNarrowWidthKeepsHelpAndQuit(t *testing.T) {
 		assert.Containsf(t, out, "? help", "width %d: help must survive", w)
 	}
 
-	// At a roomy width nothing is dropped: the scroll hints still render.
+	// At a roomy width nothing is dropped: the scroll hints still render, and
+	// their copy scopes the binding to AF's preview rather than attached input.
 	m.SetSize(200, 1)
-	assert.Contains(t, m.String(), "scroll", "no drops at full width")
+	assert.Contains(t, m.String(), "ctrl+u preview scroll", "no drops at full width")
+	assert.Contains(t, m.String(), "ctrl+d preview scroll", "no drops at full width")
 	assert.Contains(t, m.String(), "q quit")
 }
 


### PR DESCRIPTION
## Summary

- label `ctrl+u` / `ctrl+d` as **preview scroll** in the menu, help, and configuration copy so AF no longer implies those bindings survive full-screen attach
- make the existing one-time first-attach notice explain that the attached program owns input and scrolling
- document only verified agent controls:
  - Claude: `pgup/pgdn` · `ctrl+home/end` · mouse wheel
  - Codex: `ctrl+t` opens transcript · then `pgup/pgdn` or `home/end`
- resolve the actual child program before showing agent-specific copy; shell/process tabs, unknown agents, and agent slots overridden to another program get no guessed hint

The raw attach contract is unchanged. AF does not intercept or swallow `ctrl+u` or `ctrl+d`; both continue to reach the attached child.

## Root cause

AF's canonical binding descriptions called `ctrl+u` / `ctrl+d` simply “scroll.” That copy was reused by the footer and help even though full-screen attach is a raw proxy where the child owns those bytes. In Codex, `ctrl+u` can therefore clear a composer draft exactly when a user is following AF's ambiguous hint.

The existing first-attach overlay already provides the right one-time teaching moment, so this reuses it rather than adding another notice state machine. The persistent `?` help keeps the controls discoverable afterward.

## Real TUI verification

Verified after rebasing onto current `master` (including #2196), in the isolated play-test container with real Codex CLI 0.144.6:

- the wide footer renders `ctrl+u preview scroll` / `ctrl+d preview scroll`
- at 80, 60, and 45 columns the optional scroll hints shed first while `? help` and `q quit` remain intact
- the 80×24 first-attach overlay names the Codex transcript controls and explicitly limits AF preview scrolling to navigation mode
- at the Codex composer, PageUp and the wheel did not scroll
- `ctrl+t` opened `/TRANSCRIPT/`; PageUp moved 100% → 76%, Home moved to 0%, and End returned to 100%
- detach returned to AF with no orphan attach client
- `make tui-driver-selftest`: 61/61 steps green

Claude's controls are the set already verified in #2192. No controls are shown for agents we have not verified.

## Validation

All requested gates passed after the final commit was pushed, on `73ce5748337c8e8a9fcca8e6d6b01e6306e8d195`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`

The full suite's parity package passed; `parity/inventory.json` needs no update because this changes binding copy/context, not the capability or binding inventory.

Fixes #2195

— Captain Claude