### PR TITLE
fix(session): preserve worktrees on uncertain tmux startup

### DIFF
--- a/daemon/create_start_unknown_test.go
+++ b/daemon/create_start_unknown_test.go
@@ -1,0 +1,96 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// unknownStartBackend models a launcher that timed out after it may have
+// created a runtime. Kill deliberately reports success: if CreateSession asks
+// the same uncertain binding to tear down, that confident answer would let the
+// create path discard the only record of the workspace.
+type unknownStartBackend struct {
+	readyFakeBackend
+
+	mu        sync.Mutex
+	killCalls int
+}
+
+func (b *unknownStartBackend) Start(*session.Instance, bool) error {
+	return fmt.Errorf("startup readiness timed out: %w", session.ErrPaneMayBeLive)
+}
+
+func (b *unknownStartBackend) Kill(*session.Instance) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.killCalls++
+	return nil
+}
+
+func (b *unknownStartBackend) kills() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.killCalls
+}
+
+func TestCreateSession_UnknownStartDoesNotAttemptDestructiveCleanup(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	backend := &unknownStartBackend{readyFakeBackend: readyFakeBackend{session.NewFakeBackend()}}
+	restore := session.SetBackendFactoryForTest(func(session.InstanceOptions, string) (session.Backend, error) {
+		return backend, nil
+	})
+	t.Cleanup(restore)
+
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	_, createErr := manager.CreateSession(context.Background(), CreateSessionRequest{
+		Title: "uncertain-start", RepoPath: repoPath, Program: "claude",
+	})
+	if createErr == nil {
+		t.Fatal("CreateSession reported success though startup state is unknown")
+	}
+	if calls := backend.kills(); calls != 0 {
+		t.Fatalf("CreateSession attempted %d destructive cleanup(s) after startup already reported an unknown state; the same uncertain binding cannot prove the runtime absent", calls)
+	}
+
+	rec := recordFor(t, repo.ID, "uncertain-start")
+	if rec == nil {
+		t.Fatal("CreateSession discarded an uncertain startup with no record of the workspace")
+	}
+	if !rec.StartupStateUnknown {
+		t.Fatal("the retained record did not durably classify its startup as unknown")
+	}
+	if rec.UserKilled {
+		t.Fatal("an uncertain startup was recorded as a kill tombstone; the daemon would automatically retry destructive cleanup")
+	}
+	manager.mu.Lock()
+	inst, tracked := manager.instances[daemonInstanceKey(repo.ID, "uncertain-start")]
+	manager.mu.Unlock()
+	if !tracked {
+		t.Fatal("CreateSession did not keep the uncertain startup addressable in memory")
+	}
+
+	// Polling must leave the inert record alone. A tombstone would route this tick
+	// to finishUserKill, call the same suspect binding, and turn its false "absent"
+	// into workspace deletion after CreateSession had ostensibly preserved it.
+	manager.refreshInstanceStatus(repo.ID, inst)
+	if calls := backend.kills(); calls != 0 {
+		t.Fatalf("the daemon poll attempted %d destructive cleanup(s) against an uncertain startup", calls)
+	}
+	if rec := recordFor(t, repo.ID, "uncertain-start"); rec == nil || !rec.StartupStateUnknown {
+		t.Fatal("the daemon poll dropped the durable startup-unknown record")
+	}
+}

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -81,10 +81,27 @@ func (m *Manager) CreateSession(ctx context.Context, req CreateSessionRequest) (
 	// marked external — not the flow itself. finishCreateStart marks the instance
 	// live, PARKS it at a usage-limit wall (#1146 PR4), or returns a fatal error.
 	if serr := finishCreateStart(instance, req.Prompt, task.StartAndSendPrompt(ctx, instance, req.Prompt)); serr != nil {
-		// The create failed, so this instance is about to be discarded — it was never
-		// registered or persisted, and the deferred release() hands its title straight
-		// back out. That is only safe if the cleanup below actually removed what the
-		// create built (#1917).
+		// An unknown startup outcome is already a teardown boundary. Launch may have
+		// failed because the name it probed is not the name tmux stored; asking Kill
+		// through that same binding can then answer "absent" for the wrong name and
+		// delete a worktree whose real pane is still using it (#2207). A second probe
+		// cannot turn "I do not know" into proof that the session never started, so
+		// do not attempt cleanup in that case. Keep an inert, durable record of the
+		// uncertain workspace instead; unlike a kill tombstone, it never schedules an
+		// automatic retry through that suspect identity.
+		if session.TeardownStateUnknown(serr) {
+			if keepErr := m.keepUncertainCreate(repo.ID, title, instance); keepErr != nil {
+				return session.InstanceData{}, fmt.Errorf("failed to start instance %q, and its startup outcome could not be determined safely — its workspace may still be on disk at %s and could not be recorded, so it must be inspected and cleaned up by hand: %w",
+					title, instance.GetWorktreePath(), errors.Join(serr, keepErr))
+			}
+			return session.InstanceData{}, fmt.Errorf("failed to start instance %q, and its startup outcome could not be determined safely, so its workspace was left in place; the session is recorded for inspection and no automatic cleanup will run: %w",
+				title, serr)
+		}
+
+		// The create failed, so this instance would normally be discarded — it was
+		// never registered or persisted, and the deferred release() hands its title
+		// straight back out. That is only safe if startup was known not to have left a
+		// runtime and cleanup actually removed what the create built (#1917/#2207).
 		//
 		// Kill swallows everything tmux and git ANSWER for, so an error here means it
 		// could NOT: a pane whose liveness is unknown, or a worktree removal cut off
@@ -844,6 +861,19 @@ func (m *Manager) branchForTitle(title string) string {
 // takes that same non-reentrant lock).
 func (m *Manager) keepFailedCreate(repoID, title string, instance *session.Instance) error {
 	instance.MarkUserKilled()
+	return m.persistFailedCreate(repoID, title, instance)
+}
+
+// keepUncertainCreate retains a create whose runtime may exist under an identity
+// af could not confirm. It deliberately does NOT mark a kill tombstone: the
+// daemon must not retry teardown automatically through the same suspect binding
+// and let a false "absent" answer authorize workspace deletion (#2207).
+func (m *Manager) keepUncertainCreate(repoID, title string, instance *session.Instance) error {
+	instance.MarkStartupStateUnknown()
+	return m.persistFailedCreate(repoID, title, instance)
+}
+
+func (m *Manager) persistFailedCreate(repoID, title string, instance *session.Instance) error {
 	key := daemonInstanceKey(repoID, title)
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/daemon/manager_status.go
+++ b/daemon/manager_status.go
@@ -318,6 +318,15 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 		m.finishUserKill(repoID, instance)
 		return
 	}
+	// A startup-unknown record is intentionally inert (#2207). The create may
+	// have launched a tmux session under a spelling this binding cannot address;
+	// probing that requested name cannot establish liveness, and automatically
+	// killing after a false "absent" answer could delete its live worktree. Only an
+	// explicit user action may move this record into the UserKilled branch above.
+	if instance.StartupStateUnknown() {
+		m.clearRemoteLoss(key)
+		return
+	}
 	if !instance.Started() {
 		return
 	}

--- a/internal/shellsuggest/shellsuggest.go
+++ b/internal/shellsuggest/shellsuggest.go
@@ -3,12 +3,12 @@
 //
 // It exists because those commands are built from values a user chose — session
 // titles, filesystem paths, config values — and titles are not shell-safe by
-// construction: toTmuxName (session/tmux/session.go) rewrites only the characters
-// TMUX needs, and its own comment notes that other punctuation is "preserved
-// verbatim". So a session titled  deploy `id` ; echo hi  reaches these commands
-// intact. Interpolated raw, the printed command either fails or — worse — reads
-// like one thing and does another. It is printed exactly when someone is already
-// cleaning up a mess, which is when it most has to be right (#1978).
+// construction. A session's tmux handle is sanitized, but user-facing commands
+// still address the raw title, so  deploy `id` ; echo hi  reaches these command
+// suggestions intact. Interpolated raw, the printed command either fails or —
+// worse — reads like one thing and does another. It is printed exactly when
+// someone is already cleaning up a mess, which is when it most has to be right
+// (#1978).
 //
 // # Why a seam rather than "remember to quote"
 //

--- a/internal/shellsuggest/shellsuggest_test.go
+++ b/internal/shellsuggest/shellsuggest_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 // hostileTitle is the session title from the #1978 report: a space, a single
-// quote, a backtick, a `;`, and a `$`. Every one of these survives toTmuxName
-// (which only rewrites what tmux needs), so it reaches a printed command intact.
+// quote, a backtick, a `;`, and a `$`. The tmux handle is sanitized separately,
+// but title-addressed user commands still receive this raw value intact.
 //
 // Every payload here is INERT on purpose. These strings are handed to a real
 // shell, so if the quoting is broken they RUN — a destructive payload would make

--- a/session/backend.go
+++ b/session/backend.go
@@ -84,8 +84,9 @@ type Backend interface {
 
 	// Launch starts (or restores) WHAT runs in the workspace Provision established
 	// — the agent process and its tabs. The second half of Start; it owns the
-	// failure-cleanup scope (a launch failure tears down Provision's worktree on a
-	// fresh create).
+	// failure-cleanup scope. A fresh worktree is removed only when the launcher
+	// positively establishes that no runtime began; an unknown startup outcome
+	// leaves it in place for the caller to retain (#2207).
 	Launch(instance *Instance, firstTimeSetup bool) error
 
 	// Kill terminates the session and cleans up all associated resources.

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -267,13 +267,12 @@ func (b *LocalBackend) Provision(i *Instance, firstTimeSetup bool) error {
 // Launch starts (or restores) the agent PROCESS in the workspace Provision
 // established (#1592 Phase 1 PR4): it materializes the worktree on disk
 // (worktree.Setup on a fresh create), spawns or reconnects the tmux session, and
-// brings up the non-agent tabs. It owns the failure-cleanup scope — a launch
-// failure tears down provision's worktree via i.Kill on a fresh create, or
-// releases only the attach PTY on a restore. worktree.Setup deliberately stays
-// here rather than in provision: it is the first on-disk mutation, and its
-// failure needs the same teardown as any other launch failure, so it belongs
-// inside this cleanup scope. Behavior is identical to the pre-split Start — this
-// is exactly the code that followed provision's work in the monolithic form.
+// brings up the non-agent tabs. It owns the failure-cleanup scope: a fresh
+// worktree is removed only when the failure positively proves no runtime began,
+// while an unknown post-spawn outcome preserves it; a restore failure releases
+// only the attach PTY. worktree.Setup deliberately stays here rather than in
+// provision because it is the first on-disk mutation and therefore belongs
+// inside this cleanup scope.
 func (b *LocalBackend) Launch(i *Instance, firstTimeSetup bool) error {
 	i.mu.RLock()
 	tmuxSession := i.tmuxLocked()
@@ -341,7 +340,7 @@ func (b *LocalBackend) Launch(i *Instance, firstTimeSetup bool) error {
 		// loop or user-initiated restore (#1108 PR 2, #1300), never a
 		// load-time side effect; a tombstoned record's only future is
 		// having its kill finished.
-		if status := i.GetStatus(); status == Dead || status == Lost || i.UserKilled() {
+		if status := i.GetStatus(); status == Dead || status == Lost || i.UserKilled() || i.StartupStateUnknown() {
 			return nil
 		}
 
@@ -390,19 +389,18 @@ func (b *LocalBackend) Launch(i *Instance, firstTimeSetup bool) error {
 
 		// Create new session
 		if err := tmuxSession.Start(gw.GetWorktreePath()); err != nil {
-			// A Start that could not establish the session's fate must NOT lead to a
-			// worktree delete (#1917 round 7). The claim that used to stand here —
-			// "the tmux session never came up, so there is no live pane to race the
-			// removal" — is false against a wedged server: Start's own cleanup Close
-			// reports PaneStateUnknown precisely because a detached session may exist
-			// with its pane still running in this worktree. Deleting it then destroys
-			// live work on a guess, which is the whole thing this PR exists to stop.
-			if errors.Is(err, tmux.ErrTmuxTimeout) {
+			// Fail closed: only Start's positive "the new-session process never
+			// began" marker authorizes deleting this worktree. An unclassified
+			// error is unknown, not a confident negative; in particular, a readiness
+			// timeout may mean tmux created a differently escaped name that af's
+			// probes and cleanup never found (#2207). Defaulting new error paths to
+			// preservation keeps the destructive action behind affirmative proof.
+			if !errors.Is(err, tmux.ErrSessionNotStarted) {
 				return fmt.Errorf("failed to start new session: %w: %w: leaving its workspace at %s in place",
 					err, ErrPaneMayBeLive, gw.GetWorktreePath())
 			}
-			// Cleanup git worktree if tmux session creation fails. tmux ANSWERED, so
-			// the session is confirmed not running and the worktree is ours to remove.
+			// Start positively established that it never launched a new tmux
+			// session in this worktree, so the worktree is ours to remove.
 			//
 			// A cleanup cut off by its own deadline is surfaced as ErrWorkspaceLeftBehind
 			// rather than folded into a prose message (#1917): the worktree is still

--- a/session/backend_local_start_timeout_test.go
+++ b/session/backend_local_start_timeout_test.go
@@ -1,0 +1,132 @@
+package session
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	"github.com/sachiniyer/agent-factory/session/git"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// renamedTmuxWorld models the #2207 failure without touching a real tmux
+// server: new-session succeeds but tmux stores a different spelling, so every
+// probe and cleanup command using af's requested spelling gets a confident
+// "not found" while the created session remains live.
+type renamedTmuxWorld struct {
+	t *testing.T
+
+	mu      sync.Mutex
+	running map[string]bool
+}
+
+func newRenamedTmuxWorld(t *testing.T) *renamedTmuxWorld {
+	return &renamedTmuxWorld{t: t, running: make(map[string]bool)}
+}
+
+func (w *renamedTmuxWorld) Start(c *exec.Cmd) (*os.File, error) {
+	requested := argAfter(c.Args, "-s")
+	if requested == "" {
+		return nil, fmt.Errorf("new-session command has no -s name: %v", c.Args)
+	}
+
+	// tmux 3.4's utf8_stravis doubles a literal backslash while cleaning a
+	// session name. The requested spelling is therefore never found again.
+	stored := strings.ReplaceAll(requested, `\`, `\\`)
+	w.mu.Lock()
+	w.running[stored] = true
+	w.mu.Unlock()
+
+	return os.OpenFile(filepath.Join(w.t.TempDir(), "pty"), os.O_CREATE|os.O_RDWR, 0o600)
+}
+
+func (w *renamedTmuxWorld) Close() {}
+
+func (w *renamedTmuxWorld) exec() cmd_test.MockCmdExec {
+	return cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			target := tmuxTargetName(c.Args)
+			if target == "" {
+				return nil
+			}
+
+			w.mu.Lock()
+			defer w.mu.Unlock()
+			if !w.running[target] {
+				return errors.New("can't find session")
+			}
+			if slices.Contains(c.Args, "kill-session") {
+				delete(w.running, target)
+			}
+			return nil
+		},
+		OutputFunc: func(*exec.Cmd) ([]byte, error) {
+			return nil, nil
+		},
+	}
+}
+
+func (w *renamedTmuxWorld) isRunning(name string) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.running[name]
+}
+
+func tmuxTargetName(args []string) string {
+	for i, arg := range args {
+		var target string
+		switch {
+		case strings.HasPrefix(arg, "-t="):
+			target = strings.TrimPrefix(arg, "-t=")
+		case arg == "-t" && i+1 < len(args):
+			target = strings.TrimPrefix(args[i+1], "=")
+		default:
+			continue
+		}
+		return strings.TrimSuffix(target, ":")
+	}
+	return ""
+}
+
+func TestLocalBackendLaunchReadinessTimeoutPreservesWorktree(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	repoRoot := initInPlaceRepo(t, "main")
+	gw, _, err := git.NewGitWorktree(repoRoot, "start-timeout")
+	require.NoError(t, err)
+	worktreePath := gw.GetWorktreePath()
+	t.Cleanup(func() { _, _ = gw.Cleanup() })
+
+	const requestedName = `af_start\timeout`
+	const storedName = `af_start\\timeout`
+	world := newRenamedTmuxWorld(t)
+	ts := tmux.NewTmuxSessionFromSanitizedNameWithDeps(requestedName, "true", world, world.exec())
+	inst := &Instance{
+		Title:       "start-timeout",
+		Path:        repoRoot,
+		Program:     "true",
+		backend:     &LocalBackend{},
+		Tabs:        []*Tab{newAgentTab(ts)},
+		gitWorktree: gw,
+	}
+
+	err = (&LocalBackend{}).Launch(inst, true)
+	require.Error(t, err)
+	require.True(t, world.isRunning(storedName),
+		"the differently spelled tmux session should still be running in the model")
+	_, statErr := os.Stat(worktreePath)
+	require.NoError(t, statErr,
+		"a readiness timeout is unknown, not proof the session failed to start; Launch must preserve its worktree")
+	require.ErrorIs(t, err, tmux.ErrTmuxTimeout)
+	require.NotErrorIs(t, err, tmux.ErrSessionNotStarted)
+	require.ErrorIs(t, err, ErrPaneMayBeLive)
+}

--- a/session/instance.go
+++ b/session/instance.go
@@ -184,6 +184,13 @@ type Instance struct {
 	// daemon poll finishes a tombstoned record's teardown instead of probing it.
 	userKilled bool
 
+	// startupStateUnknown means a fresh create crossed the process-spawn boundary
+	// but af could not determine whether its runtime came up. The record is kept
+	// inert: no liveness probe, restore, or automatic teardown may turn that
+	// uncertainty into permission to delete its workspace (#2207). Persisted so a
+	// daemon restart cannot re-arm the destructive path.
+	startupStateUnknown bool
+
 	// prInfo stores the associated GitHub PR info
 	prInfo *git.PRInfo
 	// prInfoLastFetched is the wall-clock time of the most recent PR info

--- a/session/instance_accessors.go
+++ b/session/instance_accessors.go
@@ -62,6 +62,25 @@ func (i *Instance) UserKilled() bool {
 	return i.userKilled
 }
 
+// MarkStartupStateUnknown retains a failed create as an inert record. Clearing
+// started prevents attach/probe paths from treating the requested runtime name
+// as confirmed; StartupStateUnknown keeps storage checkpoints from dropping the
+// record merely because it is not started.
+func (i *Instance) MarkStartupStateUnknown() {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.startupStateUnknown = true
+	i.started = false
+}
+
+// StartupStateUnknown reports whether a create may have launched a runtime but
+// could not confirm its identity or liveness.
+func (i *Instance) StartupStateUnknown() bool {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.startupStateUnknown
+}
+
 // TaskRunActive reports whether this session's task run is still in flight
 // (#1892). Prefer LifecycleView when the answer is combined with any other piece
 // of state: a verdict assembled from separate accessor calls can straddle a

--- a/session/instance_data.go
+++ b/session/instance_data.go
@@ -39,17 +39,18 @@ func (i *Instance) toInstanceDataLocked() InstanceData {
 		// the daemon truth; InFlightOp rides daemon snapshots so secondary TUIs can
 		// cold-start into archive/restore operations without lossy Status
 		// reconstruction (#1436). Disk writers scrub InFlightOp before persistence.
-		Status:     i.statusLocked(),
-		Liveness:   i.liveness,
-		InFlightOp: i.inFlightOp,
-		Height:     i.Height,
-		Width:      i.Width,
-		CreatedAt:  i.CreatedAt,
-		UpdatedAt:  time.Now(),
-		Program:    i.Program,
-		AutoYes:    i.AutoYes,
-		Prompt:     i.Prompt,
-		UserKilled: i.userKilled,
+		Status:              i.statusLocked(),
+		Liveness:            i.liveness,
+		InFlightOp:          i.inFlightOp,
+		Height:              i.Height,
+		Width:               i.Width,
+		CreatedAt:           i.CreatedAt,
+		UpdatedAt:           time.Now(),
+		Program:             i.Program,
+		AutoYes:             i.AutoYes,
+		Prompt:              i.Prompt,
+		UserKilled:          i.userKilled,
+		StartupStateUnknown: i.startupStateUnknown,
 	}
 
 	if i.backend != nil {
@@ -161,16 +162,17 @@ func FromInstanceData(data InstanceData) (*Instance, error) {
 		// same event that restarts the daemon, so this fact has to come back from
 		// disk or the cap would re-decide it from a Lost state that cannot tell a
 		// finished run from an interrupted one.
-		taskRunActive: data.TaskRunActive,
-		limitResetAt:  data.LimitResetAt,
-		Height:        data.Height,
-		Width:         data.Width,
-		CreatedAt:     data.CreatedAt,
-		UpdatedAt:     data.UpdatedAt,
-		Program:       data.Program,
-		AutoYes:       data.AutoYes,
-		Prompt:        data.Prompt,
-		userKilled:    data.UserKilled,
+		taskRunActive:       data.TaskRunActive,
+		limitResetAt:        data.LimitResetAt,
+		Height:              data.Height,
+		Width:               data.Width,
+		CreatedAt:           data.CreatedAt,
+		UpdatedAt:           data.UpdatedAt,
+		Program:             data.Program,
+		AutoYes:             data.AutoYes,
+		Prompt:              data.Prompt,
+		userKilled:          data.UserKilled,
+		startupStateUnknown: data.StartupStateUnknown,
 	}
 
 	// Pick backend based on persisted BackendType.
@@ -241,6 +243,15 @@ func FromInstanceData(data InstanceData) (*Instance, error) {
 			URL:    data.PRInfo.URL,
 			State:  data.PRInfo.State,
 		}
+	}
+
+	// An uncertain startup loads INERT. Re-running Start(false) would probe or
+	// even re-spawn through the same tmux name whose identity was never confirmed,
+	// converting a daemon restart into a second destructive guess. The restored
+	// worktree and exact tmux binding above remain available for inspection and an
+	// explicit user kill, while the daemon status loop leaves the record alone.
+	if data.StartupStateUnknown {
+		return instance, nil
 	}
 
 	// An archived session (#1028) loads INERT: its tmux was torn down and its

--- a/session/startup_unknown_test.go
+++ b/session/startup_unknown_test.go
@@ -1,0 +1,50 @@
+package session
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+type forbiddenStartupPty struct{ t *testing.T }
+
+func (p forbiddenStartupPty) Start(*exec.Cmd) (*os.File, error) {
+	p.t.Fatal("loading a startup-unknown record attempted to open a tmux PTY")
+	return nil, fmt.Errorf("unreachable")
+}
+
+func (forbiddenStartupPty) Close() {}
+
+func TestFromInstanceData_StartupUnknownLoadsInert(t *testing.T) {
+	data := deadInstanceData(t, Running, "af_uncertain", "af_uncertain__shell")
+	data.StartupStateUnknown = true
+
+	forbiddenExec := cmd_test.MockCmdExec{
+		RunFunc: func(*exec.Cmd) error {
+			t.Fatal("loading a startup-unknown record attempted a tmux command")
+			return fmt.Errorf("unreachable")
+		},
+		OutputFunc: func(*exec.Cmd) ([]byte, error) {
+			t.Fatal("loading a startup-unknown record attempted a tmux query")
+			return nil, fmt.Errorf("unreachable")
+		},
+	}
+	prev := restoreTmuxSession
+	restoreTmuxSession = func(name, program string) *tmux.TmuxSession {
+		return tmux.NewTmuxSessionFromSanitizedNameWithDeps(name, program, forbiddenStartupPty{t}, forbiddenExec)
+	}
+	t.Cleanup(func() { restoreTmuxSession = prev })
+
+	restored, err := FromInstanceData(data)
+	require.NoError(t, err)
+	require.True(t, restored.StartupStateUnknown())
+	require.False(t, restored.Started(), "an uncertain runtime must remain inert after a daemon restart")
+	require.True(t, restored.ToInstanceData().StartupStateUnknown,
+		"the startup-unknown classification must survive another persistence round-trip")
+}

--- a/session/storage.go
+++ b/session/storage.go
@@ -81,9 +81,15 @@ type InstanceData struct {
 	// Manager.KillSession before teardown begins. Present only in the crash
 	// window between tombstone write and record deletion — a surviving
 	// tombstoned record means "finish this kill", never "restore this".
-	UserKilled bool      `json:"user_killed,omitempty"`
-	TmuxName   string    `json:"tmux_name,omitempty"`
-	Tabs       []TabData `json:"tabs,omitempty"`
+	UserKilled bool `json:"user_killed,omitempty"`
+	// StartupStateUnknown retains a create that crossed the launch boundary but
+	// whose runtime could not be confirmed. Unlike UserKilled, it does NOT commit
+	// an automatic teardown: retrying the same uncertain binding could mistake a
+	// differently stored tmux name for absence and delete a live workspace
+	// (#2207). Additive + omitempty keeps older records unchanged.
+	StartupStateUnknown bool      `json:"startup_state_unknown,omitempty"`
+	TmuxName            string    `json:"tmux_name,omitempty"`
+	Tabs                []TabData `json:"tabs,omitempty"`
 	// AgentConversation mirrors the Agent tab's provider conversation id for
 	// API/CLI consumers. The per-tab source of truth is TabData.Conversation.
 	AgentConversation *AgentConversationData `json:"agent_conversation,omitempty"`
@@ -259,16 +265,16 @@ func (s *Storage) SaveInstances(instances []*Instance) error {
 		// the same repo is saved — would silently orphan the archived worktree.
 		// (Lost is unaffected: it loads started=true, so it already survives.)
 		//
-		// A TOMBSTONED instance is the same shape and is kept for the same reason
-		// (#1917). A kill clears started BEFORE teardown, so a teardown that could
-		// not complete safely — tmux never confirmed the pane dead, or a worktree
-		// removal was cut off — leaves exactly this: started=false, not Archived,
-		// workspace still on disk, and the record deliberately RETAINED as its only
+		// TOMBSTONED and startup-unknown instances are also kept (#1917/#2207).
+		// Both are started=false and not Archived while their workspace may still be
+		// live: one because teardown could not confirm the pane dead or finish a
+		// worktree removal, the other because startup never established the runtime's
+		// identity. The record is deliberately RETAINED as that workspace's only
 		// handle. Without this clause the next checkpoint triggered by any other
 		// started session in the repo would silently drop it, undoing the retention
 		// in a layer that never heard of it, and orphaning the very workspace the
 		// retention exists to protect. Retention is a claim on this writer too.
-		if !inst.Started() && status != Archived && !inst.UserKilled() {
+		if !inst.Started() && status != Archived && !inst.UserKilled() && !inst.StartupStateUnknown() {
 			continue
 		}
 		root := inst.GetRepoPath()

--- a/session/storage_retain_test.go
+++ b/session/storage_retain_test.go
@@ -67,3 +67,50 @@ func TestSaveInstances_KeepsTombstonedRowAlongsideStartedSibling(t *testing.T) {
 			"and finishUserKill deliberately performed is undone by a writer in another layer (#1917 round 5)")
 	}
 }
+
+// TestSaveInstances_KeepsStartupUnknownRowAlongsideStartedSibling applies the
+// same retention rule to #2207's inert startup record. It has no kill tombstone
+// by design, so StartupStateUnknown must independently keep a wholesale storage
+// checkpoint from orphaning its workspace.
+func TestSaveInstances_KeepsStartupUnknownRowAlongsideStartedSibling(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoPath := t.TempDir()
+
+	alive := &Instance{Title: "alive", Path: repoPath, started: true}
+	alive.SetStatusForTest(Running)
+
+	uncertain := &Instance{Title: "uncertain", Path: repoPath, started: true}
+	uncertain.SetStatusForTest(Running)
+	uncertain.MarkStartupStateUnknown()
+
+	storage, err := NewStorage(config.LoadState(), "")
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+	if err := storage.SaveInstances([]*Instance{alive, uncertain}); err != nil {
+		t.Fatalf("SaveInstances: %v", err)
+	}
+
+	repoID := config.RepoIDFromRoot(repoPath)
+	scoped, err := NewStorage(config.LoadState(), repoID)
+	if err != nil {
+		t.Fatalf("NewStorage(scoped): %v", err)
+	}
+	rows, err := scoped.LoadInstanceData()
+	if err != nil {
+		t.Fatalf("LoadInstanceData: %v", err)
+	}
+	for _, row := range rows {
+		if row.Title != "uncertain" {
+			continue
+		}
+		if !row.StartupStateUnknown {
+			t.Fatal("the retained startup-unknown row lost its durable safety marker")
+		}
+		if row.UserKilled {
+			t.Fatal("the startup-unknown row became an automatic-cleanup tombstone")
+		}
+		return
+	}
+	t.Fatal("the daemon checkpoint dropped an inert startup-unknown row and orphaned its workspace")
+}

--- a/session/tab_names.go
+++ b/session/tab_names.go
@@ -137,10 +137,9 @@ func tabTmuxToken(agentPrefix string, t *Tab) string {
 
 // tabNameUnsafe matches any run of characters that must not appear in a tab's
 // derived tmux session name (the agent session name + "__" + the tab name).
-// tmux silently rewrites '.', ':', '#', '$' in session names, so a name
-// containing them would not round-trip on restore; whitespace and path
-// separators are likewise collapsed. Anything outside [A-Za-z0-9_-] becomes a
-// single '-'.
+// Keep the tab token inside the same conservative ASCII subset as the agent
+// name's positive tmux policy. Anything outside [A-Za-z0-9_-] becomes a single
+// '-'.
 var tabNameUnsafe = regexp.MustCompile(`[^A-Za-z0-9_-]+`)
 
 // sanitizeTabName converts a requested or derived tab name into a token safe to

--- a/session/tmux/bounded.go
+++ b/session/tmux/bounded.go
@@ -79,11 +79,12 @@ var tmuxCommandTimeout = 10 * time.Second
 // silently defeat the deadline above. Mirrors gitWaitDelay (#856/#896).
 const tmuxWaitDelay = 2 * time.Second
 
-// ErrTmuxTimeout marks a tmux command that was killed on tmuxCommandTimeout
-// rather than failing on its own. Callers distinguish it from ErrSessionGone:
-// a timeout means the server is wedged and the session's real state is UNKNOWN,
-// so it must never be mistaken for "the session is gone" (which would let a
-// caller tear down a session that is merely slow).
+// ErrTmuxTimeout marks a tmux operation whose deadline expired rather than
+// producing affirmative state. This includes a command killed on
+// tmuxCommandTimeout and Start's readiness deadline. Callers distinguish it
+// from ErrSessionGone: a timeout leaves the session's real state UNKNOWN, so it
+// must never be mistaken for "the session is gone" (which would let a caller
+// tear down a session that is merely slow or stored under another spelling).
 var ErrTmuxTimeout = errors.New("tmux command timed out")
 
 // boundedTmuxCommand builds a tmux command bound to ctx. It runs in its own

--- a/session/tmux/session.go
+++ b/session/tmux/session.go
@@ -5,9 +5,9 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"regexp"
 	"strings"
 	"sync"
+	"unicode"
 
 	"github.com/sachiniyer/agent-factory/cmd"
 )
@@ -88,6 +88,16 @@ const TmuxPrefix = "af_"
 // does not use this sentinel.
 var ErrSessionGone = errors.New("tmux session no longer exists")
 
+// ErrSessionNotStarted is positive evidence that Start failed before its
+// new-session process began. LocalBackend is allowed to remove a newly-created
+// worktree only when this marker is present; every other Start error is
+// conservatively treated as a session that may be running in that workspace.
+//
+// This is deliberately narrower than "Start returned an error". In particular,
+// a readiness timeout means af did not observe the session under the name it
+// probed; it does not prove tmux failed to create one (#2207).
+var ErrSessionNotStarted = errors.New("tmux session definitely did not start")
+
 // DetachKeyByte is the ASCII byte for the key used to detach from attached sessions.
 // Default is 23 (Ctrl-W). Set via SetDetachKey.
 var DetachKeyByte byte = 23
@@ -101,8 +111,6 @@ func SetDetachKey(b byte, display string) {
 	DetachKeyDisplay = display
 }
 
-var whiteSpaceRegex = regexp.MustCompile(`\s+`)
-
 // repoHash returns a short hex hash of the repo path for use in tmux session names.
 func repoHash(repoPath string) string {
 	h := sha256.Sum256([]byte(repoPath))
@@ -111,27 +119,30 @@ func repoHash(repoPath string) string {
 
 // toTmuxName builds the tmux session name from a user-supplied title.
 //
-// Characters that tmux does not preserve verbatim in session names must be
-// replaced here so ExistsOrUnknown() and kill paths match the name tmux
-// actually created (#574). Verified against tmux 3.4:
-//   - '.' and ':' are silently rewritten to '_'; using them as-is causes
-//     Start() to poll for a name tmux never created and time out, orphaning
-//     the session.
-//   - '$' is rewritten to a literal backslash+'$' (tmux uses '$' as the
-//     session-id prefix), which has the same round-trip failure.
-//   - '#' is preserved verbatim but is tmux's format-escape character, so
-//     it can corrupt status-line and display-message output that includes
-//     the session name. Sanitized defensively.
+// tmux 3.4's session_check_name rewrites '.' and ':', then utf8_stravis
+// escapes backslashes, variable-like '$' sequences, and control bytes. The
+// command layer also expands '#' formats before storing the name. Mirroring
+// those version-dependent transformations with a punctuation denylist has
+// repeatedly missed another character (#574, #2207), and a missed character
+// makes Start probe a different name from the one tmux created.
 //
-// Other punctuation (',', ';', '@', '%', '(', etc.) is preserved verbatim
-// by tmux and round-trips correctly, so we leave it alone to keep names
-// recognizable.
+// Use a positive policy instead: Unicode letters, numbers and combining marks
+// keep human-readable titles intact, while only '_' and '-' are admitted from
+// ASCII punctuation. Whitespace is removed for compatibility with the existing
+// naming scheme; every other rune becomes '_'. Persisted sessions bypass this
+// function through NewTmuxSessionFromSanitizedName, so their exact names remain
+// restorable across upgrades.
 func toTmuxName(title string, repoPath string) string {
-	title = whiteSpaceRegex.ReplaceAllString(title, "")
-	title = strings.ReplaceAll(title, ".", "_") // tmux silently rewrites '.' to '_'
-	title = strings.ReplaceAll(title, ":", "_") // tmux silently rewrites ':' to '_'
-	title = strings.ReplaceAll(title, "#", "_") // tmux treats '#' as format-escape
-	title = strings.ReplaceAll(title, "$", "_") // tmux escapes '$' to '\$' in session names
+	title = strings.Map(func(r rune) rune {
+		switch {
+		case unicode.IsLetter(r), unicode.IsNumber(r), unicode.IsMark(r), r == '_', r == '-':
+			return r
+		case unicode.IsSpace(r):
+			return -1
+		default:
+			return '_'
+		}
+	}, title)
 	if repoPath != "" {
 		return fmt.Sprintf("%s%s_%s", TmuxPrefix, repoHash(repoPath), title)
 	}

--- a/session/tmux/start.go
+++ b/session/tmux/start.go
@@ -21,7 +21,7 @@ func (t *TmuxSession) Start(workDir string) error {
 		return fmt.Errorf("%w: has-session probe for session %q did not answer", ErrTmuxTimeout, t.sanitizedName)
 	}
 	if exists {
-		return fmt.Errorf("tmux session already exists: %s", t.sanitizedName)
+		return fmt.Errorf("%w: tmux session already exists: %s", ErrSessionNotStarted, t.sanitizedName)
 	}
 
 	// Create a new detached tmux session and start claude in it. The -e
@@ -37,10 +37,11 @@ func (t *TmuxSession) Start(workDir string) error {
 		if systemdScoped {
 			err = fmt.Errorf("systemd-run --user --scope could not start: %w", err)
 		}
-		// Cleanup any partially created session if any exists. ExistsOrUnknown is
-		// safe here: the only action gated on true is a bounded best-effort
-		// kill-session, so a wedged→"exists" merely triggers a harmless cleanup
-		// attempt against a possibly-live session, never a false liveness claim.
+		// A failed PtyFactory.Start means the process did not begin, which is why
+		// this path may return ErrSessionNotStarted. Keep the historical defensive
+		// cleanup for injected factories or platform edges that expose a partial
+		// session. ExistsOrUnknown is safe here: the only action gated on true is a
+		// bounded best-effort kill-session, never a false liveness claim.
 		if t.ExistsOrUnknown() {
 			leaked := SessionProcessTrees(t.cmdExec, t.sanitizedName)
 			// Bound the cleanup kill-session (#2028): on bare exec.Command it could
@@ -58,7 +59,7 @@ func (t *TmuxSession) Start(workDir string) error {
 				go reapLeakedProcesses(t.sanitizedName, leaked, reapGraceWait, reapTermWait)
 			}
 		}
-		return fmt.Errorf("error starting tmux session: %w", err)
+		return fmt.Errorf("%w: error starting tmux session: %w", ErrSessionNotStarted, err)
 	}
 
 	// Poll for session existence with exponential backoff. Break only on a probe
@@ -98,22 +99,19 @@ func (t *TmuxSession) Start(workDir string) error {
 			if systemdScoped {
 				timeoutErr = fmt.Errorf("systemd-run --user --scope completed but the tmux session did not appear: %w", timeoutErr)
 			}
-			// The pane state is LOAD-BEARING here, and the comment that used to sit
-			// on this line said the opposite: "Start's failure path touches no
-			// worktree". It does. LocalBackend.Launch calls gw.Cleanup() the moment
-			// Start returns an error, so dropping an unknown here deletes the
-			// brand-new worktree out from under a pane that may still be RUNNING —
-			// tmux never confirmed this session's fate, and a detached session can
-			// exist even though the readiness poll never saw it (#1917 round 7).
-			// %w, never %v: flattening the error erases the sentinel Launch gates on.
-			state, cleanupErr := t.Close()
+			// The timeout classification is load-bearing: Launch uses it for
+			// diagnostics, and older callers may still distinguish an unknown tmux
+			// outcome from a clean pre-spawn failure. %w, never %v, so the sentinel
+			// survives every wrapping layer.
+			_, cleanupErr := t.Close()
 			if cleanupErr != nil {
 				timeoutErr = fmt.Errorf("%v (cleanup error: %v)", timeoutErr, cleanupErr)
 			}
-			if state != PaneStateKnown {
-				timeoutErr = fmt.Errorf("%w: %w", timeoutErr, ErrTmuxTimeout)
-			}
-			return timeoutErr
+			// The readiness deadline itself is the unknown. Even if Close
+			// confidently reports that the requested name is absent, tmux may
+			// have created a differently escaped name that Close never targeted
+			// (#2207). A timeout can therefore never authorize workspace deletion.
+			return fmt.Errorf("%w: %w", timeoutErr, ErrTmuxTimeout)
 		default:
 			time.Sleep(sleepDuration)
 			// Exponential backoff up to 50ms max
@@ -159,8 +157,8 @@ func (t *TmuxSession) Start(workDir string) error {
 		// claim against a merely-slow server. This only picks the error wording;
 		// no destructive action is gated on it (#1962).
 		vanished := !t.ExistsOrUnknown()
-		// Same rule as the timeout path above: a failed Start DOES lead to a worktree
-		// delete in Launch, so an unknown pane state must reach it (#1917 round 7).
+		// Preserve the teardown's unknown classification for callers even though
+		// Launch now independently fails closed on every post-spawn Start error.
 		state, cleanupErr := t.Close()
 		if cleanupErr != nil {
 			err = fmt.Errorf("%v (cleanup error: %v)", err, cleanupErr)

--- a/session/tmux/start_cleanup_bound_test.go
+++ b/session/tmux/start_cleanup_bound_test.go
@@ -1,6 +1,7 @@
 package tmux
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -110,6 +111,9 @@ func TestStartPtyFailureCleanupKillSessionIsBounded(t *testing.T) {
 		// own (timeout) cause to it — it does not replace or swallow the real error.
 		if !strings.Contains(err.Error(), "error starting tmux session") {
 			t.Fatalf("want the pty-start failure surfaced, got %v", err)
+		}
+		if !errors.Is(err, ErrSessionNotStarted) {
+			t.Fatalf("a PtyFactory.Start failure happens before the new-session process begins; got %v", err)
 		}
 	case <-time.After(30 * time.Second):
 		t.Fatal("Start hung on the pty-start-failure cleanup kill-session against a wedged tmux " +

--- a/session/tmux/start_unknown_test.go
+++ b/session/tmux/start_unknown_test.go
@@ -17,9 +17,9 @@ import (
 // The path that matters: has-session answers "no" (so Start proceeds), the spawn
 // SUCCEEDS — a detached session now exists and its pane may be RUNNING in the
 // worktree — and then the server wedges, so the readiness poll times out and the
-// cleanup Close cannot confirm the session's fate. LocalBackend.Launch calls
-// gw.Cleanup() the instant Start returns an error, so if this error does not carry
-// the unknown, the brand-new worktree is deleted out from under that live pane.
+// cleanup Close cannot confirm the session's fate. The sentinel is retained for
+// callers that distinguish a tmux deadline from other failures; Launch also
+// independently defaults every post-spawn failure to preservation (#2207).
 //
 // PRE-FIX BEHAVIOR THIS REPRODUCES: the returned error does not wrap ErrTmuxTimeout
 // (the state was dropped, and %v erased the sentinel even where it existed).
@@ -53,8 +53,10 @@ func TestStart_ReadinessTimeoutOnWedgedServer_PropagatesTheUnknown(t *testing.T)
 	}
 	if !errors.Is(err, ErrTmuxTimeout) {
 		t.Fatalf("Start dropped the unknown pane state: its cleanup Close could not confirm whether "+
-			"the session it just spawned is dead, but the error does not say so — LocalBackend.Launch "+
-			"then deletes the brand-new worktree out from under a possibly-live pane (#1917 round 7). "+
+			"the session it just spawned is dead, but the error does not say so (#1917 round 7). "+
 			"got: %v", err)
+	}
+	if errors.Is(err, ErrSessionNotStarted) {
+		t.Fatalf("a readiness timeout was misclassified as proof the session never started: %v", err)
 	}
 }

--- a/session/tmux/tmux_test.go
+++ b/session/tmux/tmux_test.go
@@ -102,11 +102,11 @@ func TestSanitizeName(t *testing.T) {
 	require.Equal(t, "af_custom_name", session3.sanitizedName)
 }
 
-// TestSanitizeNameTmuxRestrictedChars guards toTmuxName against the #574
-// failure mode: tmux silently rewrites or escapes certain characters in
-// session names, so a title containing them must be transformed before we
-// hand it to tmux. Otherwise ExistsOrUnknown() polls for a name tmux never
-// created and Start() times out, orphaning the session.
+// TestSanitizeNameTmuxRestrictedChars guards toTmuxName against the #574/#2207
+// failure mode: tmux silently rewrites, expands, or escapes parts of session
+// names. The positive policy must transform every rune outside the reviewed
+// safe set before tmux sees it; otherwise Start probes a different spelling
+// and times out while the created session keeps running.
 func TestSanitizeNameTmuxRestrictedChars(t *testing.T) {
 	cases := []struct {
 		name  string
@@ -122,8 +122,17 @@ func TestSanitizeNameTmuxRestrictedChars(t *testing.T) {
 		// '$' is tmux's session-id prefix — tmux escapes it to '\$' in the
 		// stored name, so has-session round-trips fail without sanitization.
 		{"dollar", "a$b", TmuxPrefix + "a_b"},
-		// All four together, plus whitespace stripping.
-		{"all-four-and-spaces", "a.b :c #d $e", TmuxPrefix + "a_b_c_d_e"},
+		// tmux 3.4 visually escapes a backslash in the stored session name.
+		{"backslash", `a\b`, TmuxPrefix + "a_b"},
+		// All tmux-special characters together, plus whitespace stripping.
+		{"tmux-specials-and-spaces", `a.b :c #d $e \f`, TmuxPrefix + "a_b_c_d_e_f"},
+		// The positive policy rejects punctuation even when one tmux version
+		// happens to preserve it, avoiding another parser-version denylist gap.
+		{"other-punctuation", "a/b,c;d@e%f(g)", TmuxPrefix + "a_b_c_d_e_f_g_"},
+		// tmux preserves valid UTF-8; keep letters and combining marks readable.
+		{"unicode", "日本語-e\u0301", TmuxPrefix + "日本語-e\u0301"},
+		// Non-whitespace controls are visually escaped by tmux and must not pass.
+		{"control", "a\x1bb", TmuxPrefix + "a_b"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -288,6 +297,8 @@ func TestStartTimeoutCleanupSucceeds(t *testing.T) {
 
 	err := session.Start(t.TempDir())
 	require.Error(t, err)
+	require.ErrorIs(t, err, ErrTmuxTimeout)
+	require.NotErrorIs(t, err, ErrSessionNotStarted)
 	require.Contains(t, err.Error(), "timed out waiting for tmux session af_timeout-ok")
 	require.NotContains(t, err.Error(), "<nil>")
 	require.NotContains(t, err.Error(), "cleanup error")
@@ -327,6 +338,8 @@ func TestStartTimeoutCleanupFails(t *testing.T) {
 
 	err := session.Start(t.TempDir())
 	require.Error(t, err)
+	require.ErrorIs(t, err, ErrTmuxTimeout)
+	require.NotErrorIs(t, err, ErrSessionNotStarted)
 	require.Contains(t, err.Error(), "timed out waiting for tmux session af_timeout-bad")
 	require.Contains(t, err.Error(), "cleanup error")
 	require.Contains(t, err.Error(), "kill-session exploded")


### PR DESCRIPTION
## Summary

- replace the repeatedly extended tmux punctuation denylist with a positive naming policy: Unicode letters, numbers, and marks plus ASCII underscore and hyphen; whitespace is removed and every other rune becomes an underscore
- add ErrSessionNotStarted as the only affirmative classification that allows LocalBackend.Launch to remove a freshly provisioned worktree
- classify every readiness timeout as ErrTmuxTimeout even when cleanup reports the requested name absent, because that probe may have targeted a different spelling than tmux stored
- retain unknown creates as durable, inert records instead of calling Kill through the same uncertain binding; daemon polling, storage checkpoints, and daemon reload all preserve them without automatic teardown

Fixes #2207.

## Safety boundary

The destructive invariant is now explicit:

> Launch may delete a worktree only when Start positively proves that the new tmux process never began.

ErrSessionNotStarted is emitted only by pre-spawn outcomes: an already-existing requested session and a PtyFactory.Start failure. Every other Start error fails closed and returns ErrPaneMayBeLive with the worktree path.

A readiness timeout is “I do not know,” not “the session is absent.” Start therefore always wraps ErrTmuxTimeout after its readiness deadline. In the reported case, Close confidently found the requested single-backslash name absent while the live session existed under tmux’s escaped spelling; that answer cannot authorize deletion.

The daemon had a second cleanup layer: after Launch preserved the workspace, CreateSession called Instance.Kill, which could repeat the same false-negative probe and delete it anyway. Unknown creates now receive a persisted startup_state_unknown marker, stay inert across poll/checkpoint/restart, reserve their title, and require explicit user cleanup. They are deliberately not kill tombstones, so no automatic cleanup retry can re-arm the destructive guess.

## Sanitizer audit

I audited tmux 3.4 rather than adding only backslash:

- session_check_name rewrites dot and colon, then runs the name through utf8_stravis: https://github.com/tmux/tmux/blob/3.4/session.c#L235-L250
- utf8_strvis doubles literal backslashes, escapes variable-like dollar sequences, C/octal-escapes controls, and preserves valid UTF-8: https://github.com/tmux/tmux/blob/3.4/utf8.c#L508-L538
- new-session expands the supplied -s value through the format layer before checking/storing it, which makes hash syntax special: https://github.com/tmux/tmux/blob/3.4/cmd-new-session.c#L102-L112

That behavior is both broader and more context/version-dependent than the old dot/colon/hash/dollar list. The code now uses an allowlist. Persisted names still bypass new sanitization and restore by their exact stored spelling.

## Fail-first output on master

Baseline was 34d4faa5df053a71cbc9aae2d17efcd75c483dc1, the master head when work began. No real tmux server was touched.

Backslash round-trip regression:

~~~text
$ go test ./session/tmux -run '^TestSanitizeNameTmuxRestrictedChars$' -count=1 -v
=== RUN   TestSanitizeNameTmuxRestrictedChars
=== RUN   TestSanitizeNameTmuxRestrictedChars/backslash
    tmux_test.go:133:
        Error:       Not equal:
                     expected: "af_a_b"
                     actual  : "af_a\\b"
--- FAIL: TestSanitizeNameTmuxRestrictedChars
    --- FAIL: TestSanitizeNameTmuxRestrictedChars/backslash
FAIL
FAIL    github.com/sachiniyer/agent-factory/session/tmux
exit=1
~~~

Real temporary-worktree deletion regression, using an in-memory tmux model that stores the requested single backslash as a double backslash and confidently reports the requested spelling absent:

~~~text
$ go test ./session -run '^TestLocalBackendLaunchReadinessTimeoutPreservesWorktree$' -count=1 -v
=== RUN   TestLocalBackendLaunchReadinessTimeoutPreservesWorktree
    backend_local_start_timeout_test.go:135:
        Received unexpected error:
            stat /tmp/TestLocalBackendLaunchReadinessTimeoutPreservesWorktree1880359086/002/repo-start-timeout: no such file or directory
        Messages: a readiness timeout is unknown, not proof the session failed to start; Launch must preserve its worktree
--- FAIL: TestLocalBackendLaunchReadinessTimeoutPreservesWorktree
FAIL
FAIL    github.com/sachiniyer/agent-factory/session
exit=1
~~~

Bug 2 is therefore real: master deleted the worktree while the modeled differently named tmux session remained live.

The added daemon-boundary test also failed before its guard with:

~~~text
CreateSession attempted 1 destructive cleanup(s) after startup already reported an unknown state; the same uncertain binding cannot prove the runtime absent
~~~

## Final verification

Rebased onto current master ba6ec57d. All requested gates ran after the final commit was pushed, against pushed head f8666b358f9113c5c70dd378be8821719e7f696e:

- golangci-lint run --timeout=3m --fast — exit 0, no output
- gofmt -l . — exit 0, no output
- go build ./... — exit 0, no output
- make test-container — exit 0, full suite green
- deadcode -test ./... — exit 0, no output
- scripts/lint-file-length.sh — exit 0; 877 Go files checked, 0 grandfathered

Per the host-safety requirements, I did not run host go test ./..., dev-install.sh, any daemon restart, any tmux kill, or any production session mutation.

— Captain Claude

Signed-off-by: Captain Claude