### PR TITLE
fix(tmux): distinguish unobservable prompt delivery

### DIFF
--- a/session/tmux/program.go
+++ b/session/tmux/program.go
@@ -29,9 +29,27 @@ func (t *TmuxSession) programCmd() string {
 	return t.program
 }
 
+// preSubmitEchoBehavior returns the cached behavior for the resolved program.
+// Agent detection happens when the program is set, not on every delivery.
+func (t *TmuxSession) preSubmitEchoBehavior() preSubmitEchoBehavior {
+	t.programMu.RLock()
+	defer t.programMu.RUnlock()
+	return t.preSubmitEcho
+}
+
+// notePreSubmitEchoObserved promotes an unknown/non-echoing capability only on
+// positive evidence. A missing tail can never demote it: absence is precisely
+// the ambiguous signal #2213 forbids us from treating as detection.
+func (t *TmuxSession) notePreSubmitEchoObserved() {
+	t.programMu.Lock()
+	defer t.programMu.Unlock()
+	t.preSubmitEcho = preSubmitEchoes
+}
+
 // setProgramCmd stores the pane's program command string under programMu.
 func (t *TmuxSession) setProgramCmd(program string) {
 	t.programMu.Lock()
 	defer t.programMu.Unlock()
 	t.program = program
+	t.preSubmitEcho = knownPreSubmitEchoBehavior(program)
 }

--- a/session/tmux/session.go
+++ b/session/tmux/session.go
@@ -52,9 +52,10 @@ type TmuxSession struct {
 	sanitizedName string
 	// program is the command the pane runs. It is mutated by Restore() while
 	// other goroutines read it, so all access goes through the programMu-guarded
-	// accessors in program.go (#1254) — never touch these two fields directly.
-	program   string
-	programMu sync.RWMutex
+	// accessors in program.go (#1254) — never touch these fields directly.
+	program       string
+	preSubmitEcho preSubmitEchoBehavior
+	programMu     sync.RWMutex
 	// ptyFactory is used to create a PTY for the tmux session.
 	ptyFactory PtyFactory
 	// cmdExec is used to execute commands in the tmux session.
@@ -187,6 +188,7 @@ func newTmuxSession(sanitizedName string, program string, ptyFactory PtyFactory,
 	return &TmuxSession{
 		sanitizedName: sanitizedName,
 		program:       program,
+		preSubmitEcho: knownPreSubmitEchoBehavior(program),
 		ptyFactory:    ptyFactory,
 		cmdExec:       cmdExec,
 	}

--- a/session/tmux/submit.go
+++ b/session/tmux/submit.go
@@ -35,28 +35,56 @@ var (
 // Enter race the paste after all.
 const minDistinctiveTail = 8
 
-// deliveryOutcome is deliberately THREE-valued. A probe that cannot see the pane
-// must never manufacture a negative — the failure mode this repo keeps
-// re-learning — so "I could not look" stays distinct from "I looked and it was
-// not there". Only the latter is evidence of a failed delivery.
+// deliveryOutcome is deliberately THREE-valued. "The pane did not show the
+// prompt" is an observed absence only when that agent is known to render pasted
+// input before Enter. A non-echoing pane and a failed capture both mean the
+// delivery could not be observed; neither may manufacture a negative.
 type deliveryOutcome int
 
 const (
-	// deliveryConfirmed: the pasted text was observed to arrive.
-	deliveryConfirmed deliveryOutcome = iota
-	// deliveryNotObserved: captures were working and the text never appeared on
-	// screen. Note the name — this is NOT "it did not arrive". A pane is free to
-	// consume input without echoing it (anything with echo off, e.g. a password
-	// prompt; the #1956 receiver-pane gate is exactly such a program, and its
-	// bytes provably arrive while the screen only ever shows AF-RECEIVER-READY).
-	// Arrival and echo are different facts, so this stays a loud WARNING and
-	// never an error: treating it as a delivery failure would condemn every
-	// non-echoing pane.
-	deliveryNotObserved
-	// deliveryUnknown: capture itself failed (headless/transient), or there was
-	// nothing assertable. Nothing may be concluded.
-	deliveryUnknown
+	// deliveryObservedLanded: the pasted text was observed to arrive.
+	deliveryObservedLanded deliveryOutcome = iota
+	// deliveryObservedAbsent: the pane is known to echo pasted input, capture
+	// succeeded at the deadline, and the text was not there. This is the genuine
+	// #1982 signal and must stay loud.
+	deliveryObservedAbsent
+	// deliveryCouldNotObserve: the pane does not echo (or its behavior is not
+	// known), capture failed, or the prompt had no distinctive text. Nothing may
+	// be concluded about delivery.
+	deliveryCouldNotObserve
 )
+
+// preSubmitEchoBehavior records whether the agent renders pasted input before
+// Enter. It is cached with TmuxSession.program and reused for every delivery.
+type preSubmitEchoBehavior int
+
+const (
+	preSubmitEchoUnknown preSubmitEchoBehavior = iota
+	preSubmitEchoes
+	preSubmitDoesNotEcho
+)
+
+// knownPreSubmitEchoBehavior returns only behavior established by real-agent
+// evidence. There is no sound generic runtime probe for the negative case:
+// terminal ECHO says nothing about a full-screen app that draws its own input,
+// while failing to see a test paste is the exact ambiguity this code must not
+// collapse. Sending a sentinel would also mutate the live composer. Therefore
+// unknown agents stay unknown instead of being guessed; any positively observed
+// delivery promotes that session to preSubmitEchoes.
+func knownPreSubmitEchoBehavior(command string) preSubmitEchoBehavior {
+	switch DetectAgentFromCommand(command) {
+	case ProgramClaude:
+		// Claude visibly renders pasted composer input; #1982's positive-tail
+		// delivery guard depends on this behavior.
+		return preSubmitEchoes
+	case ProgramCodex:
+		// Codex consumes successful pastes without rendering them before Enter
+		// (#2213: 228 unobserved but successful deliveries in one day).
+		return preSubmitDoesNotEcho
+	default:
+		return preSubmitEchoUnknown
+	}
+}
 
 // pasteBufferSeq makes each bracketed-paste buffer name unique per call so two
 // concurrent deliveries to the same session can never race on a shared tmux
@@ -234,14 +262,14 @@ func (t *TmuxSession) sendKeysPasteBuffer(text string) error {
 		return err
 	}
 
-	if delivered == deliveryNotObserved {
-		// Loud, but NOT an error — see deliveryNotObserved. This is the "silent
-		// success" half of #1982 addressed as far as this layer soundly can:
-		// the operator gets a record that the prompt was never seen to land,
-		// without a delivery failure being invented for every non-echoing pane.
-		log.ErrorLog.Printf("submit: prompt for session %q was never observed on screen; "+
-			"if this pane echoes input, the prompt may be unsubmitted. Pane tail: %s",
-			t.sanitizedName, paneTailForLog(t))
+	if delivered == deliveryObservedAbsent {
+		// This is deliberately the only ERROR emitted by delivery observation:
+		// unlike could-not-observe, a known echoing pane was successfully read and
+		// the prompt was absent. Keep the best-effort Enter, but make this signal
+		// actionable and unhedged so a genuine #1982 truncation is not buried.
+		log.ErrorLog.Printf("submit: prompt delivery observed absent for session %q after %s in a pane known to echo input; "+
+			"Enter sent best-effort. Pane tail: %s",
+			t.sanitizedName, pasteDeliveryMaxWait, paneTailForLog(t))
 	}
 	return nil
 }
@@ -430,18 +458,21 @@ func (t *TmuxSession) capturePaneForDeliveryContext(ctx context.Context) (string
 
 // waitForPasteDelivered blocks until the pasted prompt's tail newly appears in
 // the pane (count exceeds the pre-paste baseline), or pasteDeliveryMaxWait
-// elapses. On expiry it logs and returns so Enter is still sent best-effort —
-// delivery is never worse than the fixed sleep it replaces (#1982).
-func (t *TmuxSession) waitForPasteDelivered(tail string, baseline int) deliveryOutcome {
+// elapses. Its result distinguishes a genuine absence in a known echoing pane
+// from an inability to observe delivery. The caller always sends Enter afterward,
+// so delivery is never worse than the fixed sleep this replaced (#1982).
+func (t *TmuxSession) waitForPasteDelivered(
+	tail string,
+	baseline int,
+) deliveryOutcome {
 	if tail == "" {
 		// Nothing distinctive to confirm (empty/all-whitespace prompt). There is
 		// no positive check to make, so keep the ORIGINAL 500ms drain rather than
 		// quietly shortening it.
 		time.Sleep(emptyPromptDrain)
-		return deliveryUnknown
+		return deliveryCouldNotObserve
 	}
 	deadline := time.Now().Add(pasteDeliveryMaxWait)
-	sawCapture := false
 	streak := 0
 	// A short tail is weak evidence, so require two consecutive sightings before
 	// trusting it (see minDistinctiveTail).
@@ -449,30 +480,42 @@ func (t *TmuxSession) waitForPasteDelivered(tail string, baseline int) deliveryO
 	if len([]rune(tail)) < minDistinctiveTail {
 		needed = 2
 	}
+	lastCaptureOK := false
 	for {
+		// If the prior capture succeeded and the following poll interval carried
+		// us across the deadline, that prior read is the terminal observation. Do
+		// not launch an already-expired capture just to turn success into unknown.
+		if time.Until(deadline) <= 0 {
+			if lastCaptureOK && t.preSubmitEchoBehavior() == preSubmitEchoes {
+				return deliveryObservedAbsent
+			}
+			return deliveryCouldNotObserve
+		}
+
 		// Bound each capture by what is LEFT of this loop's budget, so a wedged
 		// server cannot push a single capture past the deadline below (#2099).
 		if content, ok := t.capturePaneForDeliveryWithin(time.Until(deadline)); ok {
-			sawCapture = true
+			lastCaptureOK = true
 			if strings.Count(normalizeDelivery(content), tail) > baseline {
 				streak++
 				if streak >= needed {
-					return deliveryConfirmed
+					t.notePreSubmitEchoObserved()
+					return deliveryObservedLanded
 				}
 			} else {
 				streak = 0
 			}
+		} else {
+			lastCaptureOK = false
 		}
 		if time.Now().After(deadline) {
-			if !sawCapture {
-				// Never saw the pane at all — unknown, not absent.
-				log.ErrorLog.Printf("submit: could not capture pane for session %q while confirming delivery; sending Enter best-effort",
-					t.sanitizedName)
-				return deliveryUnknown
+			// A failed final capture is "could not look", even if an earlier poll
+			// succeeded. Likewise, missing text in an agent not known to echo says
+			// nothing about whether the paste landed. Neither is an ERROR (#2213).
+			if !lastCaptureOK || t.preSubmitEchoBehavior() != preSubmitEchoes {
+				return deliveryCouldNotObserve
 			}
-			log.ErrorLog.Printf("submit: paste delivery for session %q NOT observed within %s (the pane may simply not echo input); sending Enter best-effort",
-				t.sanitizedName, pasteDeliveryMaxWait)
-			return deliveryNotObserved
+			return deliveryObservedAbsent
 		}
 		time.Sleep(pasteDeliveryPollInterval)
 	}

--- a/session/tmux/submit_test.go
+++ b/session/tmux/submit_test.go
@@ -401,20 +401,30 @@ func TestPasteBufferNameProcessTokenPreventsCrossProcessCollision(t *testing.T) 
 // #1956 receiver gate writes its bytes to a FILE while the screen only shows
 // AF-RECEIVER-READY). "Not echoed" is not "not delivered" — arrival and echo are
 // different facts, and any echo-off pane, a password prompt being the everyday
-// case, looks identical. So an unobserved paste is logged loudly and never
-// turned into an error.
+// case, looks identical. So an unobserved paste is could-not-observe: Enter is
+// still sent best-effort, but the absence of evidence must not become an ERROR.
 func TestSubmitDoesNotManufactureAFailureWhenThePaneDoesNotEcho(t *testing.T) {
 	defer withPasteDeliveryTiming(50*time.Millisecond, time.Millisecond)()
+	errors := captureErrorLog(t)
+	enterSent := false
 
 	cmdExec := cmd_test.MockCmdExec{
-		RunFunc: func(c *exec.Cmd) error { return nil },
+		RunFunc: func(c *exec.Cmd) error {
+			if strings.Contains(strings.Join(c.Args, " "), "send-keys") && hasArg(c.Args, "Enter") {
+				enterSent = true
+			}
+			return nil
+		},
 		// A pane that never renders what it receives.
 		OutputFunc: func(c *exec.Cmd) ([]byte, error) { return []byte("AF-RECEIVER-READY"), nil },
 	}
-	session := newTmuxSession("af_proj", "claude", NewMockPtyFactory(t), cmdExec)
+	session := newTmuxSession("af_proj", ProgramCodex, NewMockPtyFactory(t), cmdExec)
 
 	require.NoError(t, session.SendKeysCommand("a prompt to a pane that does not echo"),
 		"a non-echoing pane must NOT be reported as a failed delivery — the bytes still arrive")
+	require.True(t, enterSent, "could-not-observe must retain the best-effort Enter")
+	require.Empty(t, errors.String(),
+		"a successful delivery to a non-echoing agent must not manufacture an ERROR")
 }
 
 // TestSubmitDoesNotManufactureAFailureWhenThePaneIsUnreadable is the polarity
@@ -425,6 +435,7 @@ func TestSubmitDoesNotManufactureAFailureWhenThePaneDoesNotEcho(t *testing.T) {
 // behaviour and report SUCCESS rather than invent a delivery failure.
 func TestSubmitDoesNotManufactureAFailureWhenThePaneIsUnreadable(t *testing.T) {
 	defer withPasteDeliveryTiming(50*time.Millisecond, time.Millisecond)()
+	errors := captureErrorLog(t)
 
 	cmdExec := cmd_test.MockCmdExec{
 		RunFunc: func(c *exec.Cmd) error { return nil },
@@ -436,6 +447,111 @@ func TestSubmitDoesNotManufactureAFailureWhenThePaneIsUnreadable(t *testing.T) {
 
 	require.NoError(t, session.SendKeysCommand("a prompt to an unreadable pane"),
 		"an unreadable pane is NOT evidence of a failed delivery; it must stay best-effort")
+	require.Empty(t, errors.String(),
+		"a failed observation probe must not manufacture an ERROR")
+}
+
+// TestMissingPromptInKnownEchoingPaneStaysLoud protects the genuine #1982
+// signal. Unlike the Codex case above, Claude is known to render pasted input
+// before Enter. Successful captures that never contain the prompt are therefore
+// observed-absent, not could-not-observe, and must remain actionable at ERROR.
+func TestMissingPromptInKnownEchoingPaneStaysLoud(t *testing.T) {
+	defer withPasteDeliveryTiming(50*time.Millisecond, time.Millisecond)()
+	errors := captureErrorLog(t)
+	enterSent := false
+	pasted := false
+	const prompt = "run bash -lc 'printf started && inspect every file before reporting DELIVERY_TAIL_COMPLETE'"
+
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			joined := strings.Join(c.Args, " ")
+			if strings.Contains(joined, "paste-buffer") {
+				pasted = true
+			}
+			if strings.Contains(joined, "send-keys") && hasArg(c.Args, "Enter") {
+				enterSent = true
+			}
+			return nil
+		},
+		// Capture works and sees a truncated prefix stranded inside an open quote,
+		// but never the distinctive tail: the genuine #1982 case that must stay
+		// loud even though Enter is still sent best-effort.
+		OutputFunc: func(c *exec.Cmd) ([]byte, error) {
+			if pasted {
+				return []byte("╭─ composer ─────────────────╮\n│ > run bash -lc 'printf started │\n╰────────────────────────────╯"), nil
+			}
+			return []byte("╭─ composer ─╮\n│ >          │\n╰────────────╯"), nil
+		},
+	}
+	session := newTmuxSession("af_proj", ProgramClaude, NewMockPtyFactory(t), cmdExec)
+
+	require.NoError(t, session.SendKeysCommand(prompt))
+	require.True(t, enterSent, "observed-absent must retain the best-effort Enter")
+	got := errors.String()
+	require.Equal(t, 1, strings.Count(got, "prompt delivery observed absent"),
+		"a genuine missing prompt should emit one actionable ERROR, got %q", got)
+	require.Contains(t, got, "pane known to echo input")
+	require.Contains(t, got, "Enter sent best-effort")
+	require.Contains(t, got, "run bash -lc 'printf started",
+		"the actionable ERROR should retain the observed truncated pane tail")
+	require.NotContains(t, got, "may simply not echo")
+	require.NotContains(t, got, "may be unsubmitted")
+}
+
+// TestObservedDeliveryCachesEchoBehavior proves unknown programs are detected
+// only from positive evidence, then reuse that capability. The first visible
+// delivery promotes the session; a later genuinely absent prompt is therefore
+// loud without consulting a per-agent guess table.
+func TestObservedDeliveryCachesEchoBehavior(t *testing.T) {
+	defer withPasteDeliveryTiming(50*time.Millisecond, time.Millisecond)()
+	errors := captureErrorLog(t)
+
+	var loaded string
+	delivery := 0
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			joined := strings.Join(c.Args, " ")
+			if strings.Contains(joined, "load-buffer") && c.Stdin != nil {
+				b, _ := io.ReadAll(c.Stdin)
+				loaded = string(b)
+			}
+			if strings.Contains(joined, "paste-buffer") {
+				delivery++
+			}
+			return nil
+		},
+		OutputFunc: func(c *exec.Cmd) ([]byte, error) {
+			if delivery == 1 && loaded != "" {
+				return []byte("custom composer: " + loaded), nil
+			}
+			return []byte("custom composer ready"), nil
+		},
+	}
+	session := newTmuxSession("af_proj", "custom-agent", NewMockPtyFactory(t), cmdExec)
+	require.Equal(t, preSubmitEchoUnknown, session.preSubmitEchoBehavior())
+
+	require.NoError(t, session.SendKeysCommand("first prompt lands visibly"))
+	require.Equal(t, preSubmitEchoes, session.preSubmitEchoBehavior(),
+		"a positively observed delivery should be cached for this agent session")
+	require.Empty(t, errors.String())
+
+	require.NoError(t, session.SendKeysCommand("second prompt is genuinely absent"))
+	require.Contains(t, errors.String(), "prompt delivery observed absent",
+		"the cached echo capability must keep a later genuine failure loud")
+}
+
+func TestPreSubmitEchoBehaviorTracksResolvedProgram(t *testing.T) {
+	session := newTmuxSession("af_proj", "/usr/local/bin/codex --full-auto", NewMockPtyFactory(t), cmd_test.MockCmdExec{})
+	require.Equal(t, preSubmitDoesNotEcho, session.preSubmitEchoBehavior(),
+		"capability detection must use the resolved executable, including absolute paths")
+
+	session.SetProgram("ionice -c 3 claude --model opus")
+	require.Equal(t, preSubmitEchoes, session.preSubmitEchoBehavior(),
+		"agent handoff must replace the cached capability with the new agent's behavior")
+
+	session.SetProgram("/opt/bin/claude-wrapper")
+	require.Equal(t, preSubmitEchoUnknown, session.preSubmitEchoBehavior(),
+		"an unknown override must stay unknown instead of substring-matching an agent name")
 }
 
 func captureRawPane(session *TmuxSession) (string, error) {


### PR DESCRIPTION
Fixes #2213.

## Root cause

Delivery verification already tracked capture success separately, but it still collapsed two different facts after a successful capture:

- the prompt is absent from a pane known to render pasted input;
- the pane does not render pasted input, so delivery cannot be observed.

Both paths emitted ERROR, including twice per normal Codex delivery. The messages admitted the ambiguity while still presenting it as a negative finding.

## Fix

- Make delivery verification explicitly three-valued: `observed-landed`, `observed-absent`, and `could-not-observe`.
- Emit one actionable ERROR only for `observed-absent`. Capture failure and non-echoing/unknown panes are `could-not-observe` and intentionally emit nothing: this package has no debug sink, and an INFO line per delivery would recreate the same 228/day noise for a condition with no operator action.
- Cache pre-submit echo behavior beside the resolved pane program under the existing program mutex. It is reused across deliveries, refreshed on agent handoff, and an unknown agent is promoted to echoing only after a positive observation.
- Keep the best-effort Enter exactly as before.

## Why the capability is evidence-backed

A generic negative detector would repeat the bug in a new place. TTY `ECHO` cannot describe a full-screen app that draws its own composer, and typing a sentinel would mutate a live pane. Failing to see a real paste is the ambiguity this issue exists to preserve, so it cannot soundly prove non-echoing behavior.

The code therefore seeds only behavior established by real-pane evidence: Claude renders pre-submit input (#1982), while Codex consumes successful pastes without rendering them before Enter (#2213). Other programs remain unknown rather than being guessed; a visible successful delivery promotes that session using positive evidence. Agent identity comes from `DetectAgentFromCommand`, so absolute paths, wrappers, overrides, and handoffs follow the executable actually running rather than a config-name substring.

## #1982 remains loud

`TestMissingPromptInKnownEchoingPaneStaysLoud` models the genuine failure: a Claude pane is capturable and shows only a truncated prompt prefix stranded inside an open quote, never the distinctive tail. The path still sends Enter best-effort and emits exactly one ERROR with the observed truncated pane tail. The old hedges are forbidden by the test.

## Fail-first on master

Baseline: `7ddae281025f8c32558950bc695706061ca2156d` (then-current `origin/master`). The fixture uses a mock executor; no real tmux server or session was touched.

~~~text
$ go test ./session/tmux -run '^TestSubmitDoesNotManufactureAFailureWhenThePaneDoesNotEcho$' -count=1 -v
=== RUN   TestSubmitDoesNotManufactureAFailureWhenThePaneDoesNotEcho
    submit_test.go:426:
        Error: Should be empty, but was
        ERROR: submit: paste delivery for session "af_proj" NOT observed within 50ms (the pane may simply not echo input); sending Enter best-effort
        ERROR: submit: prompt for session "af_proj" was never observed on screen; if this pane echoes input, the prompt may be unsubmitted. Pane tail: AF-RECEIVER-READY
        Messages: a successful delivery to a non-echoing agent must not manufacture an ERROR
--- FAIL: TestSubmitDoesNotManufactureAFailureWhenThePaneDoesNotEcho (0.05s)
FAIL
FAIL    github.com/sachiniyer/agent-factory/session/tmux
~~~

The same test also proved the best-effort Enter was sent before failing on the fabricated ERROR output.

## Verification

All required gates were rerun after the final commit was pushed, against remote-verified head `40ec99a6dd56fc2aeab78c1c10252cc9eca737c2`:

- `golangci-lint run --timeout=3m --fast` — exit 0, no output
- `gofmt -l .` — exit 0, no output
- `go build ./...` — exit 0, no output
- `make test-container` — exit 0, full suite green
- `deadcode -test ./...` — exit 0, no output
- `scripts/lint-file-length.sh` — exit 0; 877 Go files checked, 0 grandfathered

The focused regression set also passed under `go test -race`.

Per the host-safety requirements, I did not run host `go test ./...`, `dev-install.sh`, any daemon restart, any tmux/af kill, or any production-session mutation.

— Captain Claude

Signed-off-by: Captain Claude
