### PR TITLE
refactor(upgrade): share auto-update primitives

### DIFF
--- a/commands/autoupdate.go
+++ b/commands/autoupdate.go
@@ -1,29 +1,21 @@
 package commands
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
-	"os"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/internal/autoupdate"
 	"github.com/sachiniyer/agent-factory/log"
 )
 
 const (
-	// autoUpdateCheckInterval throttles the launch check. Releases now cut
-	// several times a day, so a day-long window left users pinned to a build
-	// well behind their channel; six hours keeps them close to the tip while
-	// still collapsing a burst of launches into a single GitHub call.
-	autoUpdateCheckInterval = 6 * time.Hour
-	lastCheckFile           = "last_update_check"
-	autoUpdateEnv           = "AGENT_FACTORY_AUTO_UPDATE"
+	lastCheckFile = autoupdate.CheckCacheFileName
+	autoUpdateEnv = autoupdate.EnvironmentVariable
 )
 
 // Timeouts differ by who is waiting. The launch check runs synchronously in
@@ -50,7 +42,7 @@ var (
 	// here — with a preview cut every 3 hours, page 1 fills with
 	// prereleases within days and the newest stable falls off it, so a
 	// stable-channel client would resolve nothing (Greptile review, #1078).
-	githubAPILatestReleaseURL = "https://api.github.com/repos/sachiniyer/agent-factory/releases/latest"
+	githubAPILatestReleaseURL = autoupdate.DefaultLatestReleaseAPIURL
 	// githubAPIReleasesURL answers the preview channel: /releases/latest
 	// never returns prereleases, so previews must come from the list. One
 	// page of 100 suffices: under the release scheme versions are only ever
@@ -58,7 +50,7 @@ var (
 	// releases are validated strictly greater), so the version-newest
 	// release is always among the most recently created — and the whole
 	// page is scanned for the max rather than trusting item order.
-	githubAPIReleasesURL = "https://api.github.com/repos/sachiniyer/agent-factory/releases?per_page=100"
+	githubAPIReleasesURL = autoupdate.DefaultReleasesAPIURL
 )
 
 // runtimeGOOS is a variable so tests can override the value reported by
@@ -230,81 +222,24 @@ func latestDownloadURL(channel, goos, goarch string, timeout time.Duration) (tag
 	if err != nil {
 		return "", "", fmt.Errorf("failed to fetch latest release: %w", err)
 	}
-	url = fmt.Sprintf("%s/download/%s/agent-factory-%s-%s.tar.gz",
-		releaseBaseURL, tag, goos, goarch)
+	url = autoupdate.DownloadURL(tag, goos, goarch)
 	return tag, url, nil
 }
 
 // releaseEntry is the subset of the GitHub release object needed to pick an
 // update target.
-type releaseEntry struct {
-	TagName    string `json:"tag_name"`
-	Draft      bool   `json:"draft"`
-	Prerelease bool   `json:"prerelease"`
-}
+type releaseEntry = autoupdate.Release
 
 // fetchLatestReleaseTag queries the GitHub API for the newest release tag on
 // the given channel (#1041): the stable channel resolves directly through
 // /releases/latest, the preview channel through the release list (see the
 // endpoint docs above for why each channel needs its own endpoint).
 func fetchLatestReleaseTag(channel string, timeout time.Duration) (string, error) {
-	if channel == config.UpdateChannelPreview {
-		return fetchLatestPreviewChannelTag(timeout)
+	discovery := autoupdate.Discovery{
+		LatestReleaseURL: githubAPILatestReleaseURL,
+		ReleasesURL:      githubAPIReleasesURL,
 	}
-	return fetchLatestStableTag(timeout)
-}
-
-// fetchLatestStableTag resolves the newest stable release via
-// /releases/latest. The endpoint already excludes prereleases and drafts;
-// the shape checks below are a tripwire against a stable release published
-// with an off-scheme tag, which must fail loudly rather than become an
-// update target.
-func fetchLatestStableTag(timeout time.Duration) (string, error) {
-	var release releaseEntry
-	if err := getGitHubJSON(githubAPILatestReleaseURL, timeout, &release); err != nil {
-		return "", err
-	}
-	parsed := parseSemver(strings.TrimPrefix(release.TagName, "v"))
-	if parsed == nil || parsed.preview || release.Prerelease || release.Draft {
-		return "", fmt.Errorf("releases/latest returned unusable tag %q for the stable channel", release.TagName)
-	}
-	return release.TagName, nil
-}
-
-// fetchLatestPreviewChannelTag resolves the newest release including
-// prereleases from the release list.
-func fetchLatestPreviewChannelTag(timeout time.Duration) (string, error) {
-	var releases []releaseEntry
-	if err := getGitHubJSON(githubAPIReleasesURL, timeout, &releases); err != nil {
-		return "", err
-	}
-	tag := pickLatestReleaseTag(config.UpdateChannelPreview, releases)
-	if tag == "" {
-		return "", fmt.Errorf("no published release with a parseable version tag found on the preview channel")
-	}
-	return tag, nil
-}
-
-// getGitHubJSON fetches url from the GitHub API and decodes the JSON
-// response into out, giving up after timeout.
-func getGitHubJSON(url string, timeout time.Duration, out any) error {
-	client := &http.Client{Timeout: timeout}
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Accept", "application/vnd.github.v3+json")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		return fmt.Errorf("GitHub API returned %d", resp.StatusCode)
-	}
-	return json.NewDecoder(resp.Body).Decode(out)
+	return discovery.LatestReleaseTag(channel, timeout)
 }
 
 // pickLatestReleaseTag returns the version-newest non-draft release tag on
@@ -313,32 +248,7 @@ func getGitHubJSON(url string, timeout time.Duration, out any) error {
 // -preview-N suffix marks it as a preview; the preview channel includes
 // everything.
 func pickLatestReleaseTag(channel string, releases []releaseEntry) string {
-	best := ""
-	for _, r := range releases {
-		if r.Draft {
-			continue
-		}
-		v := strings.TrimPrefix(r.TagName, "v")
-		parsed := parseSemver(v)
-		if parsed == nil {
-			continue
-		}
-		if channel != config.UpdateChannelPreview && (r.Prerelease || parsed.preview) {
-			continue
-		}
-		if best == "" || isNewer(v, strings.TrimPrefix(best, "v")) {
-			best = r.TagName
-		}
-	}
-	return best
-}
-
-// semver is a parsed version under the two-channel scheme (#1041):
-// MAJOR.MINOR.PATCH with an optional "-preview-N" prerelease suffix.
-type semver struct {
-	nums    [3]int
-	preview bool
-	z       int
+	return autoupdate.PickLatestReleaseTag(channel, releases)
 }
 
 // isNewer returns true if latest is strictly newer than current under the
@@ -347,107 +257,22 @@ type semver struct {
 // precedence), and previews order by their preview number:
 // 1.2.0 < 1.2.1-preview-1 < 1.2.1-preview-2 < 1.2.1.
 func isNewer(latest, current string) bool {
-	l := parseSemver(latest)
-	c := parseSemver(current)
-	if l == nil || c == nil {
-		return false
-	}
-	for i := 0; i < 3; i++ {
-		if l.nums[i] != c.nums[i] {
-			return l.nums[i] > c.nums[i]
-		}
-	}
-	if l.preview != c.preview {
-		// Equal base: the stable release outranks its previews.
-		return c.preview
-	}
-	return l.preview && l.z > c.z
-}
-
-// parseSemver parses "X.Y.Z" or "X.Y.Z-preview-N". Any other shape —
-// including unknown prerelease suffixes — returns nil so that unrecognized
-// tags are never treated as update targets.
-func parseSemver(v string) *semver {
-	core := v
-	var preview bool
-	var z int
-	if i := strings.IndexByte(v, '-'); i >= 0 {
-		core = v[:i]
-		numStr, ok := strings.CutPrefix(v[i+1:], "preview-")
-		if !ok {
-			return nil
-		}
-		n, err := strconv.Atoi(numStr)
-		if err != nil || n < 0 {
-			return nil
-		}
-		preview = true
-		z = n
-	}
-	parts := strings.Split(core, ".")
-	if len(parts) != 3 {
-		return nil
-	}
-	out := &semver{preview: preview, z: z}
-	for i, p := range parts {
-		n, err := strconv.Atoi(p)
-		if err != nil || n < 0 {
-			return nil
-		}
-		out.nums[i] = n
-	}
-	return out
+	return autoupdate.IsNewer(latest, current)
 }
 
 func lastCheckPath() string {
-	dir, err := config.GetConfigDir()
-	if err != nil {
-		return ""
-	}
-	return filepath.Join(dir, lastCheckFile)
+	return autoupdate.CheckCachePath()
 }
 
 func autoUpdateEnabled(cfg *config.Config) bool {
-	enabled := true
-	if cfg != nil {
-		enabled = cfg.AutoUpdate
-	}
-	raw, ok := os.LookupEnv(autoUpdateEnv)
-	if !ok {
-		return enabled
-	}
-	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "1", "true", "t", "yes", "y", "on":
-		return true
-	case "0", "false", "f", "no", "n", "off":
-		return false
-	case "":
-		return enabled
-	default:
-		log.WarningLog.Printf("auto-update: ignoring invalid %s=%q (expected true/false, 1/0, yes/no, on/off)", autoUpdateEnv, raw)
-		return enabled
-	}
+	return autoupdate.Enabled(cfg)
 }
 
 func normalizeUpdateChannel(channel string) string {
-	if channel == config.UpdateChannelPreview {
-		return config.UpdateChannelPreview
-	}
-	return config.UpdateChannelStable
+	return autoupdate.NormalizeChannel(channel)
 }
 
-type updateCheckCache struct {
-	path          string
-	SchemaVersion int                          `json:"schema_version,omitempty"`
-	LastChannel   string                       `json:"last_channel,omitempty"`
-	Channels      map[string]updateCheckRecord `json:"channels,omitempty"`
-}
-
-type updateCheckRecord struct {
-	CheckedAt      time.Time `json:"checked_at"`
-	LastSeenTag    string    `json:"last_seen_tag,omitempty"`
-	CurrentVersion string    `json:"current_version,omitempty"`
-}
+type updateCheckCache = autoupdate.CheckCache
 
 // withUpdateCheckLock runs fn against the throttle cache under the update
 // lock. The lock is taken without waiting: when another `af` is already
@@ -456,14 +281,7 @@ type updateCheckRecord struct {
 // lose, since this now sits in front of the TUI and a blocking wait would read
 // as a hang for as long as that download takes.
 func withUpdateCheckLock(fn func(cache *updateCheckCache, now time.Time) error) error {
-	path := lastCheckPath()
-	if path == "" {
-		return fn(&updateCheckCache{}, time.Now().UTC())
-	}
-	acquired, err := config.TryWithFileLock(path, func() error {
-		cache := readUpdateCheckCache(path)
-		return fn(cache, time.Now().UTC())
-	})
+	acquired, err := autoupdate.TryWithCheckCache(lastCheckPath(), fn)
 	if err != nil {
 		return err
 	}
@@ -474,22 +292,7 @@ func withUpdateCheckLock(fn func(cache *updateCheckCache, now time.Time) error) 
 }
 
 func readUpdateCheckCache(path string) *updateCheckCache {
-	cache := &updateCheckCache{path: path}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return cache
-	}
-	if err := json.Unmarshal(data, cache); err == nil {
-		cache.path = path
-		if cache.Channels == nil {
-			cache.Channels = map[string]updateCheckRecord{}
-		}
-		return cache
-	}
-	// Legacy cache files were a bare RFC3339 timestamp with no channel. Treat
-	// them as stale so the first new build re-checks and writes channel-aware
-	// metadata instead of letting a prior stable check suppress preview (#1466).
-	return cache
+	return autoupdate.ReadCheckCache(path)
 }
 
 func shouldCheck(channel string) bool {
@@ -502,58 +305,13 @@ func shouldCheck(channel string) bool {
 }
 
 func updateCheckDue(cache *updateCheckCache, channel, currentVersion string, now time.Time) bool {
-	channel = normalizeUpdateChannel(channel)
-	if cache == nil {
-		return true
-	}
-	if cache.LastChannel != "" && cache.LastChannel != channel {
-		return true
-	}
-	rec, ok := cache.Channels[channel]
-	if !ok {
-		return true
-	}
-	if rec.CurrentVersion != "" && rec.CurrentVersion != currentVersion {
-		return true
-	}
-	if rec.CheckedAt.IsZero() || rec.CheckedAt.After(now) {
-		return true
-	}
-	return now.Sub(rec.CheckedAt) >= autoUpdateCheckInterval
+	return cache.Due(channel, currentVersion, now)
 }
 
 func recordCheck(channel, lastSeenTag, currentVersion string) {
-	path := lastCheckPath()
-	if path == "" {
-		return
-	}
-	_ = config.WithFileLock(path, func() error {
-		return recordCheckLocked(readUpdateCheckCache(path), channel, lastSeenTag, currentVersion, time.Now().UTC())
-	})
+	_ = autoupdate.RecordCheck(lastCheckPath(), channel, lastSeenTag, currentVersion)
 }
 
 func recordCheckLocked(cache *updateCheckCache, channel, lastSeenTag, currentVersion string, now time.Time) error {
-	if cache == nil {
-		cache = &updateCheckCache{}
-	}
-	if cache.path == "" {
-		return nil
-	}
-	channel = normalizeUpdateChannel(channel)
-	if cache.Channels == nil {
-		cache.Channels = map[string]updateCheckRecord{}
-	}
-	cache.SchemaVersion = 1
-	cache.LastChannel = channel
-	cache.Channels[channel] = updateCheckRecord{
-		CheckedAt:      now.UTC(),
-		LastSeenTag:    lastSeenTag,
-		CurrentVersion: strings.TrimPrefix(currentVersion, "v"),
-	}
-	data, err := json.MarshalIndent(cache, "", "  ")
-	if err != nil {
-		return err
-	}
-	data = append(data, '\n')
-	return config.AtomicWriteFile(cache.path, data, 0644)
+	return cache.Record(channel, lastSeenTag, currentVersion, now)
 }

--- a/commands/upgrade.go
+++ b/commands/upgrade.go
@@ -1,11 +1,8 @@
 package commands
 
 import (
-	"archive/tar"
-	"compress/gzip"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -14,6 +11,7 @@ import (
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/internal/autoupdate"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/spf13/cobra"
 )
@@ -30,7 +28,7 @@ var requestDaemonShutdownFn = daemon.RequestShutdown
 var osExecutableFn = os.Executable
 
 const (
-	releaseBaseURL = "https://github.com/sachiniyer/agent-factory/releases"
+	releaseBaseURL = autoupdate.ReleaseBaseURL
 )
 
 // Download timeouts are variables (not consts) so tests can shrink them to
@@ -42,52 +40,24 @@ var (
 	// downloadResponseHeaderTimeout caps the time spent waiting for response
 	// headers, so a server that accepts the TCP connection but never replies
 	// fails fast instead of consuming the full downloadTimeout budget.
-	downloadResponseHeaderTimeout = 30 * time.Second
+	downloadResponseHeaderTimeout = autoupdate.DefaultResponseHeaderTimeout
 )
-
-// newDownloadClient builds an *http.Client suitable for fetching a release
-// tarball, with both an overall request timeout and a header timeout so a
-// stalled server can't hang the upgrade indefinitely (#471). The overall
-// budget is a parameter: a launch-path auto-update gives up far sooner than
-// a `af upgrade` the user is sitting and watching.
-func newDownloadClient(timeout time.Duration) *http.Client {
-	// A header timeout longer than the whole budget would never fire; keep it
-	// under the budget so a silent server still fails fast on short budgets.
-	headerTimeout := downloadResponseHeaderTimeout
-	if timeout < headerTimeout {
-		headerTimeout = timeout
-	}
-	return &http.Client{
-		Timeout: timeout,
-		Transport: &http.Transport{
-			ResponseHeaderTimeout: headerTimeout,
-		},
-	}
-}
 
 // downloadBinaryFn is indirected so tests can stub the download without
 // standing up an httptest server.
 var downloadBinaryFn = downloadBinary
 
 // downloadBinary fetches the release tarball at url and returns the embedded
-// `agent-factory` binary bytes. It uses newDownloadClient() to bound the
-// fetch with a timeout.
+// `agent-factory` binary bytes. CandidateStager bounds both the overall fetch
+// and response-header wait so a stalled server cannot hang the caller (#471).
 func downloadBinary(url string, timeout time.Duration) ([]byte, error) {
-	resp, err := newDownloadClient(timeout).Get(url)
-	if err != nil {
-		return nil, fmt.Errorf("download failed: %w", err)
-	}
-	defer resp.Body.Close()
+	return candidateStager().Download(url, timeout)
+}
 
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("download failed: HTTP %d from %s", resp.StatusCode, url)
-	}
-
-	binary, err := extractBinaryFromTarGz(resp.Body, "agent-factory")
-	if err != nil {
-		return nil, fmt.Errorf("failed to extract binary: %w", err)
-	}
-	return binary, nil
+func candidateStager() autoupdate.CandidateStager {
+	stager := autoupdate.DefaultCandidateStager()
+	stager.ResponseHeaderTimeout = downloadResponseHeaderTimeout
+	return stager
 }
 
 // upgradeAllowDowngrade is the opt-in for intentional channel-switch
@@ -165,7 +135,7 @@ on the old binary until you restart it yourself with 'af daemon restart'.`,
 		// Guard against silently downgrading (#1212): switching from a newer
 		// preview to an older stable resolves an older tag here, and without
 		// this check runUpgrade would happily install it. shouldUpgrade
-		// reuses the same isNewer/parseSemver precedence auto-update relies on.
+		// reuses the same version validation and ordering as auto-update.
 		proceed, msg := shouldUpgrade(latestTag, version, channel, upgradeAllowDowngrade)
 		if msg != "" {
 			fmt.Println(msg)
@@ -182,7 +152,8 @@ on the old binary until you restart it yourself with 'af daemon restart'.`,
 // shouldUpgrade decides whether `af upgrade` should install latestTag over the
 // currently running version, and returns a user-facing message to print
 // (empty when there is nothing to say beyond the normal download line). It
-// reuses parseSemver/isNewer so preview precedence matches auto-update
+// reuses the shared version validation and isNewer ordering so preview
+// precedence matches auto-update
 // exactly: 1.2.0 < 1.2.1-preview-1 < 1.2.1-preview-2 < 1.2.1 (#1212).
 //
 //   - latest newer than current  -> proceed (normal upgrade).
@@ -196,7 +167,7 @@ func shouldUpgrade(latestTag, current, channel string, allowDowngrade bool) (pro
 	latest := strings.TrimPrefix(latestTag, "v")
 	cur := strings.TrimPrefix(current, "v")
 
-	if parseSemver(latest) == nil {
+	if !autoupdate.IsValidVersion(latest) {
 		return false, fmt.Sprintf(
 			"Cannot compare latest release %q against the current %s; refusing to upgrade to avoid an accidental downgrade.",
 			latestTag, current)
@@ -399,42 +370,5 @@ func reportUpgradeRestart(out, errOut io.Writer, outcome restartOutcome, restart
 // extractBinaryFromTarGz reads a tar.gz stream and returns the contents of the
 // file whose name matches binaryName (or ends with /binaryName).
 func extractBinaryFromTarGz(r io.Reader, binaryName string) ([]byte, error) {
-	gz, err := gzip.NewReader(r)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create gzip reader: %w", err)
-	}
-	defer gz.Close()
-
-	tr := tar.NewReader(gz)
-	for {
-		hdr, err := tr.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return nil, fmt.Errorf("failed to read tar entry: %w", err)
-		}
-
-		name := hdr.Name
-		if hdr.Typeflag == tar.TypeReg && (name == binaryName || strings.HasSuffix(name, "/"+binaryName)) {
-			const maxBinarySize = 500 << 20 // 500 MB
-			if hdr.Size > maxBinarySize {
-				return nil, fmt.Errorf("binary too large: %d bytes (max %d)", hdr.Size, maxBinarySize)
-			}
-			data, err := io.ReadAll(io.LimitReader(tr, maxBinarySize+1))
-			if err != nil {
-				return nil, fmt.Errorf("failed to read binary from archive: %w", err)
-			}
-			if int64(len(data)) > maxBinarySize {
-				return nil, fmt.Errorf("binary exceeds maximum size of %d bytes", maxBinarySize)
-			}
-			// Drain remaining gzip data to trigger CRC32 validation
-			if _, err := io.Copy(io.Discard, gz); err != nil {
-				return nil, fmt.Errorf("gzip integrity check failed: %w", err)
-			}
-			return data, nil
-		}
-	}
-
-	return nil, fmt.Errorf("binary %q not found in archive", binaryName)
+	return autoupdate.ExtractBinaryFromTarGz(r, binaryName)
 }

--- a/internal/autoupdate/cache.go
+++ b/internal/autoupdate/cache.go
@@ -1,0 +1,143 @@
+package autoupdate
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+const (
+	// CheckInterval is the existing release-check throttle window. Releases cut
+	// several times a day, so six hours keeps clients near their channel while
+	// collapsing bursts of activity into one GitHub call. Failures and successes
+	// both close this window.
+	CheckInterval = 6 * time.Hour
+	// CheckCacheFileName is the channel-aware release-check cache.
+	CheckCacheFileName = "last_update_check"
+)
+
+// CheckCache is the on-disk throttle state shared by all update triggers.
+// path is deliberately omitted from JSON so the existing file format remains
+// unchanged.
+type CheckCache struct {
+	path          string
+	SchemaVersion int                    `json:"schema_version,omitempty"`
+	LastChannel   string                 `json:"last_channel,omitempty"`
+	Channels      map[string]CheckRecord `json:"channels,omitempty"`
+}
+
+// CheckRecord describes the last attempted check for one release channel.
+type CheckRecord struct {
+	CheckedAt      time.Time `json:"checked_at"`
+	LastSeenTag    string    `json:"last_seen_tag,omitempty"`
+	CurrentVersion string    `json:"current_version,omitempty"`
+}
+
+// CheckCachePath returns the shared throttle cache path, or "" if the AF
+// configuration directory cannot be resolved.
+func CheckCachePath() string {
+	dir, err := config.GetConfigDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(dir, CheckCacheFileName)
+}
+
+// NewCheckCache returns an empty cache associated with path.
+func NewCheckCache(path string) *CheckCache {
+	return &CheckCache{path: path}
+}
+
+// ReadCheckCache reads path. Missing, malformed, and legacy timestamp-only
+// files are treated as stale empty caches so the next caller performs a check.
+func ReadCheckCache(path string) *CheckCache {
+	cache := NewCheckCache(path)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return cache
+	}
+	if err := json.Unmarshal(data, cache); err == nil {
+		cache.path = path
+		if cache.Channels == nil {
+			cache.Channels = map[string]CheckRecord{}
+		}
+		return cache
+	}
+	return cache
+}
+
+// TryWithCheckCache runs fn against the latest cache state while holding the
+// non-blocking update lock. acquired is false when another process owns the
+// check; fn is not called in that case.
+func TryWithCheckCache(path string, fn func(cache *CheckCache, now time.Time) error) (acquired bool, err error) {
+	if path == "" {
+		return true, fn(NewCheckCache(""), time.Now().UTC())
+	}
+	return config.TryWithFileLock(path, func() error {
+		return fn(ReadCheckCache(path), time.Now().UTC())
+	})
+}
+
+// Due reports whether channel should perform a release check for
+// currentVersion at now. A channel switch, running-version change, future
+// timestamp, or absent record invalidates the throttle.
+func (cache *CheckCache) Due(channel, currentVersion string, now time.Time) bool {
+	channel = NormalizeChannel(channel)
+	if cache == nil {
+		return true
+	}
+	if cache.LastChannel != "" && cache.LastChannel != channel {
+		return true
+	}
+	record, ok := cache.Channels[channel]
+	if !ok {
+		return true
+	}
+	if record.CurrentVersion != "" && record.CurrentVersion != currentVersion {
+		return true
+	}
+	if record.CheckedAt.IsZero() || record.CheckedAt.After(now) {
+		return true
+	}
+	return now.Sub(record.CheckedAt) >= CheckInterval
+}
+
+// Record stores one attempted check. It records failures too: LastSeenTag may
+// be empty, but CheckedAt still closes the throttle window.
+func (cache *CheckCache) Record(channel, lastSeenTag, currentVersion string, now time.Time) error {
+	if cache == nil || cache.path == "" {
+		return nil
+	}
+	channel = NormalizeChannel(channel)
+	if cache.Channels == nil {
+		cache.Channels = map[string]CheckRecord{}
+	}
+	cache.SchemaVersion = 1
+	cache.LastChannel = channel
+	cache.Channels[channel] = CheckRecord{
+		CheckedAt:      now.UTC(),
+		LastSeenTag:    lastSeenTag,
+		CurrentVersion: strings.TrimPrefix(currentVersion, "v"),
+	}
+	data, err := json.MarshalIndent(cache, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return config.AtomicWriteFile(cache.path, data, 0644)
+}
+
+// RecordCheck updates path under the blocking cache lock. This is for
+// bookkeeping outside an already-locked update cycle.
+func RecordCheck(path, channel, lastSeenTag, currentVersion string) error {
+	if path == "" {
+		return nil
+	}
+	return config.WithFileLock(path, func() error {
+		return ReadCheckCache(path).Record(channel, lastSeenTag, currentVersion, time.Now().UTC())
+	})
+}

--- a/internal/autoupdate/cache_test.go
+++ b/internal/autoupdate/cache_test.go
@@ -1,0 +1,87 @@
+package autoupdate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+func TestCheckCachePreservesThrottleContract(t *testing.T) {
+	path := filepath.Join(t.TempDir(), CheckCacheFileName)
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+
+	cache := NewCheckCache(path)
+	if !cache.Due(config.UpdateChannelStable, "1.0.0", now) {
+		t.Fatal("empty cache must be due")
+	}
+	if err := cache.Record(config.UpdateChannelStable, "", "v1.0.0", now); err != nil {
+		t.Fatalf("record failed check: %v", err)
+	}
+
+	cache = ReadCheckCache(path)
+	if cache.Due(config.UpdateChannelStable, "1.0.0", now.Add(CheckInterval-time.Second)) {
+		t.Fatal("a failed attempt must close the six-hour throttle window")
+	}
+	if !cache.Due(config.UpdateChannelStable, "1.0.0", now.Add(CheckInterval)) {
+		t.Fatal("cache must be due when the throttle window expires")
+	}
+	if !cache.Due(config.UpdateChannelPreview, "1.0.0", now.Add(time.Second)) {
+		t.Fatal("a channel switch must invalidate the throttle")
+	}
+	if !cache.Due(config.UpdateChannelStable, "1.0.1", now.Add(time.Second)) {
+		t.Fatal("a current-version change must invalidate the throttle")
+	}
+
+	record := cache.Channels[config.UpdateChannelStable]
+	if record.LastSeenTag != "" || record.CurrentVersion != "1.0.0" {
+		t.Fatalf("failed-check record = %#v, want empty tag and normalized current version", record)
+	}
+}
+
+func TestReadCheckCacheTreatsLegacyAndMalformedFilesAsStale(t *testing.T) {
+	for name, contents := range map[string]string{
+		"legacy timestamp": "2026-07-20T12:00:00Z\n",
+		"malformed JSON":   "{not-json",
+	} {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), CheckCacheFileName)
+			if err := os.WriteFile(path, []byte(contents), 0644); err != nil {
+				t.Fatalf("seed cache: %v", err)
+			}
+			cache := ReadCheckCache(path)
+			if !cache.Due(config.UpdateChannelStable, "1.0.0", time.Now().UTC()) {
+				t.Fatal("legacy or malformed cache must be stale")
+			}
+		})
+	}
+}
+
+func TestTryWithCheckCachePersistsExistingJSONShape(t *testing.T) {
+	path := filepath.Join(t.TempDir(), CheckCacheFileName)
+	called := false
+	acquired, err := TryWithCheckCache(path, func(cache *CheckCache, now time.Time) error {
+		called = true
+		return cache.Record(config.UpdateChannelPreview, "v1.2.3-preview-1", "v1.2.2", now)
+	})
+	if err != nil {
+		t.Fatalf("TryWithCheckCache: %v", err)
+	}
+	if !acquired || !called {
+		t.Fatalf("acquired/called = %v/%v, want true/true", acquired, called)
+	}
+
+	cache := ReadCheckCache(path)
+	if cache.SchemaVersion != 1 || cache.LastChannel != config.UpdateChannelPreview {
+		t.Fatalf("cache header = schema %d, channel %q", cache.SchemaVersion, cache.LastChannel)
+	}
+	record, ok := cache.Channels[config.UpdateChannelPreview]
+	if !ok {
+		t.Fatalf("preview record missing from %#v", cache.Channels)
+	}
+	if record.LastSeenTag != "v1.2.3-preview-1" || record.CurrentVersion != "1.2.2" || record.CheckedAt.IsZero() {
+		t.Fatalf("preview record = %#v", record)
+	}
+}

--- a/internal/autoupdate/discovery.go
+++ b/internal/autoupdate/discovery.go
@@ -43,14 +43,6 @@ type Discovery struct {
 	ReleasesURL      string
 }
 
-// DefaultDiscovery returns the production GitHub release discovery endpoints.
-func DefaultDiscovery() Discovery {
-	return Discovery{
-		LatestReleaseURL: DefaultLatestReleaseAPIURL,
-		ReleasesURL:      DefaultReleasesAPIURL,
-	}
-}
-
 // LatestReleaseTag returns the newest published tag on channel. Stable uses
 // /releases/latest so frequent previews cannot push the newest stable release
 // off the first page of the release list; preview scans the release list.

--- a/internal/autoupdate/discovery.go
+++ b/internal/autoupdate/discovery.go
@@ -1,0 +1,214 @@
+// Package autoupdate contains the release discovery, throttle cache, and
+// candidate staging primitives shared by interactive and daemon-owned update
+// paths. It deliberately does not decide when to check or install a candidate.
+package autoupdate
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+const (
+	// ReleaseBaseURL is the GitHub release page used to address versioned
+	// release assets.
+	ReleaseBaseURL = "https://github.com/sachiniyer/agent-factory/releases"
+
+	// DefaultLatestReleaseAPIURL answers the stable channel. GitHub pins
+	// /releases/latest to the newest non-prerelease release.
+	DefaultLatestReleaseAPIURL = "https://api.github.com/repos/sachiniyer/agent-factory/releases/latest"
+	// DefaultReleasesAPIURL answers the preview channel. One page of 100 is
+	// sufficient because releases are created in increasing version order,
+	// and the entire page is scanned for the greatest version.
+	DefaultReleasesAPIURL = "https://api.github.com/repos/sachiniyer/agent-factory/releases?per_page=100"
+)
+
+// Release is the subset of a GitHub release needed to select an update target.
+type Release struct {
+	TagName    string `json:"tag_name"`
+	Draft      bool   `json:"draft"`
+	Prerelease bool   `json:"prerelease"`
+}
+
+// Discovery resolves release tags from channel-specific GitHub API endpoints.
+// Endpoint fields are configurable so callers can exercise the real HTTP path
+// against a local server.
+type Discovery struct {
+	LatestReleaseURL string
+	ReleasesURL      string
+}
+
+// DefaultDiscovery returns the production GitHub release discovery endpoints.
+func DefaultDiscovery() Discovery {
+	return Discovery{
+		LatestReleaseURL: DefaultLatestReleaseAPIURL,
+		ReleasesURL:      DefaultReleasesAPIURL,
+	}
+}
+
+// LatestReleaseTag returns the newest published tag on channel. Stable uses
+// /releases/latest so frequent previews cannot push the newest stable release
+// off the first page of the release list; preview scans the release list.
+func (d Discovery) LatestReleaseTag(channel string, timeout time.Duration) (string, error) {
+	if channel == config.UpdateChannelPreview {
+		return d.latestPreviewTag(timeout)
+	}
+	return d.latestStableTag(timeout)
+}
+
+func (d Discovery) latestStableTag(timeout time.Duration) (string, error) {
+	var release Release
+	if err := getJSON(d.LatestReleaseURL, timeout, &release); err != nil {
+		return "", err
+	}
+	parsed := parseVersion(strings.TrimPrefix(release.TagName, "v"))
+	if parsed == nil || parsed.preview || release.Prerelease || release.Draft {
+		return "", fmt.Errorf("releases/latest returned unusable tag %q for the stable channel", release.TagName)
+	}
+	return release.TagName, nil
+}
+
+func (d Discovery) latestPreviewTag(timeout time.Duration) (string, error) {
+	var releases []Release
+	if err := getJSON(d.ReleasesURL, timeout, &releases); err != nil {
+		return "", err
+	}
+	tag := PickLatestReleaseTag(config.UpdateChannelPreview, releases)
+	if tag == "" {
+		return "", fmt.Errorf("no published release with a parseable version tag found on the preview channel")
+	}
+	return tag, nil
+}
+
+func getJSON(url string, timeout time.Duration, out any) error {
+	client := &http.Client{Timeout: timeout}
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("GitHub API returned %d", resp.StatusCode)
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+// PickLatestReleaseTag returns the version-newest non-draft release tag on
+// channel, or "" when no release qualifies. Stable excludes a release when
+// either GitHub or the tag itself marks it as a preview.
+func PickLatestReleaseTag(channel string, releases []Release) string {
+	best := ""
+	for _, release := range releases {
+		if release.Draft {
+			continue
+		}
+		version := strings.TrimPrefix(release.TagName, "v")
+		parsed := parseVersion(version)
+		if parsed == nil {
+			continue
+		}
+		if channel != config.UpdateChannelPreview && (release.Prerelease || parsed.preview) {
+			continue
+		}
+		if best == "" || IsNewer(version, strings.TrimPrefix(best, "v")) {
+			best = release.TagName
+		}
+	}
+	return best
+}
+
+// DownloadURL returns the version-addressed release asset URL for a platform.
+// Preview assets must use their tag because releases/latest/download always
+// resolves to a stable release.
+func DownloadURL(tag, goos, goarch string) string {
+	return fmt.Sprintf("%s/download/%s/%s-%s-%s.tar.gz",
+		ReleaseBaseURL, tag, CandidateBinaryName, goos, goarch)
+}
+
+// releaseVersion is a parsed release version under the two-channel scheme:
+// MAJOR.MINOR.PATCH with an optional "-preview-N" suffix.
+type releaseVersion struct {
+	nums          [3]int
+	preview       bool
+	previewNumber int
+}
+
+// IsNewer reports whether latest is strictly newer than current. Stable
+// releases outrank previews of the same base; previews order by their number.
+func IsNewer(latest, current string) bool {
+	latestVersion := parseVersion(latest)
+	currentVersion := parseVersion(current)
+	if latestVersion == nil || currentVersion == nil {
+		return false
+	}
+	for i := 0; i < 3; i++ {
+		if latestVersion.nums[i] != currentVersion.nums[i] {
+			return latestVersion.nums[i] > currentVersion.nums[i]
+		}
+	}
+	if latestVersion.preview != currentVersion.preview {
+		return currentVersion.preview
+	}
+	return latestVersion.preview && latestVersion.previewNumber > currentVersion.previewNumber
+}
+
+// IsValidVersion reports whether value follows the release version scheme.
+func IsValidVersion(value string) bool {
+	return parseVersion(value) != nil
+}
+
+// parseVersion parses "X.Y.Z" or "X.Y.Z-preview-N". Other shapes return nil
+// so an unrecognized tag is never selected as an update target.
+func parseVersion(value string) *releaseVersion {
+	core := value
+	var preview bool
+	var previewNumber int
+	if i := strings.IndexByte(value, '-'); i >= 0 {
+		core = value[:i]
+		number, ok := strings.CutPrefix(value[i+1:], "preview-")
+		if !ok {
+			return nil
+		}
+		parsed, err := strconv.Atoi(number)
+		if err != nil || parsed < 0 {
+			return nil
+		}
+		preview = true
+		previewNumber = parsed
+	}
+
+	parts := strings.Split(core, ".")
+	if len(parts) != 3 {
+		return nil
+	}
+	version := &releaseVersion{preview: preview, previewNumber: previewNumber}
+	for i, part := range parts {
+		parsed, err := strconv.Atoi(part)
+		if err != nil || parsed < 0 {
+			return nil
+		}
+		version.nums[i] = parsed
+	}
+	return version
+}
+
+// NormalizeChannel treats preview as the sole opt-in channel and defaults all
+// other values to stable.
+func NormalizeChannel(channel string) string {
+	if channel == config.UpdateChannelPreview {
+		return config.UpdateChannelPreview
+	}
+	return config.UpdateChannelStable
+}

--- a/internal/autoupdate/discovery_test.go
+++ b/internal/autoupdate/discovery_test.go
@@ -1,0 +1,102 @@
+package autoupdate
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+func TestDiscoveryUsesChannelSpecificEndpoints(t *testing.T) {
+	previews := make([]Release, 0, 100)
+	for i := 100; i >= 1; i-- {
+		previews = append(previews, Release{
+			TagName:    fmt.Sprintf("v1.9.10-preview-%d", i),
+			Prerelease: true,
+		})
+	}
+
+	listCalls := 0
+	latestCalls := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/releases", func(w http.ResponseWriter, _ *http.Request) {
+		listCalls++
+		if err := json.NewEncoder(w).Encode(previews); err != nil {
+			t.Errorf("encode releases: %v", err)
+		}
+	})
+	mux.HandleFunc("/releases/latest", func(w http.ResponseWriter, _ *http.Request) {
+		latestCalls++
+		if err := json.NewEncoder(w).Encode(Release{TagName: "v1.9.9"}); err != nil {
+			t.Errorf("encode latest release: %v", err)
+		}
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	discovery := Discovery{
+		LatestReleaseURL: server.URL + "/releases/latest",
+		ReleasesURL:      server.URL + "/releases?per_page=100",
+	}
+	stable, err := discovery.LatestReleaseTag(config.UpdateChannelStable, time.Second)
+	if err != nil {
+		t.Fatalf("stable discovery: %v", err)
+	}
+	if stable != "v1.9.9" {
+		t.Fatalf("stable tag = %q, want v1.9.9", stable)
+	}
+	preview, err := discovery.LatestReleaseTag(config.UpdateChannelPreview, time.Second)
+	if err != nil {
+		t.Fatalf("preview discovery: %v", err)
+	}
+	if preview != "v1.9.10-preview-100" {
+		t.Fatalf("preview tag = %q, want v1.9.10-preview-100", preview)
+	}
+	if latestCalls != 1 || listCalls != 1 {
+		t.Fatalf("endpoint calls latest/list = %d/%d, want 1/1", latestCalls, listCalls)
+	}
+}
+
+func TestVersionOrderingAndReleaseSelection(t *testing.T) {
+	comparisons := []struct {
+		latest  string
+		current string
+		want    bool
+	}{
+		{latest: "1.0.10", current: "1.0.9", want: true},
+		{latest: "1.2.0-preview-10", current: "1.2.0-preview-9", want: true},
+		{latest: "1.2.0", current: "1.2.0-preview-10", want: true},
+		{latest: "1.2.0-preview-1", current: "1.2.0", want: false},
+		{latest: "1.2.0-rc-1", current: "1.0.0", want: false},
+	}
+	for _, test := range comparisons {
+		if got := IsNewer(test.latest, test.current); got != test.want {
+			t.Errorf("IsNewer(%q, %q) = %v, want %v", test.latest, test.current, got, test.want)
+		}
+	}
+
+	releases := []Release{
+		{TagName: "v2.0.0", Draft: true},
+		{TagName: "v1.4.0-preview-2", Prerelease: true},
+		{TagName: "v1.4.0-preview-1", Prerelease: true},
+		{TagName: "v1.3.9"},
+	}
+	if got := PickLatestReleaseTag(config.UpdateChannelStable, releases); got != "v1.3.9" {
+		t.Fatalf("stable selection = %q, want v1.3.9", got)
+	}
+	if got := PickLatestReleaseTag(config.UpdateChannelPreview, releases); got != "v1.4.0-preview-2" {
+		t.Fatalf("preview selection = %q, want v1.4.0-preview-2", got)
+	}
+}
+
+func TestDownloadURLIsTagAddressed(t *testing.T) {
+	got := DownloadURL("v1.2.3-preview-4", "linux", "amd64")
+	want := ReleaseBaseURL + "/download/v1.2.3-preview-4/agent-factory-linux-amd64.tar.gz"
+	if got != want {
+		t.Fatalf("DownloadURL = %q, want %q", got, want)
+	}
+}

--- a/internal/autoupdate/settings.go
+++ b/internal/autoupdate/settings.go
@@ -1,0 +1,38 @@
+package autoupdate
+
+import (
+	"os"
+	"strings"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+// EnvironmentVariable is the process-level auto-update override. The global
+// config remains the persistent operator-facing switch.
+const EnvironmentVariable = "AGENT_FACTORY_AUTO_UPDATE"
+
+// Enabled applies the existing config and environment opt-out contract. A
+// valid environment value overrides config; an invalid value is reported and
+// leaves the config value in force.
+func Enabled(cfg *config.Config) bool {
+	enabled := true
+	if cfg != nil {
+		enabled = cfg.AutoUpdate
+	}
+	raw, ok := os.LookupEnv(EnvironmentVariable)
+	if !ok {
+		return enabled
+	}
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "1", "true", "t", "yes", "y", "on":
+		return true
+	case "0", "false", "f", "no", "n", "off":
+		return false
+	case "":
+		return enabled
+	default:
+		log.WarningLog.Printf("auto-update: ignoring invalid %s=%q (expected true/false, 1/0, yes/no, on/off)", EnvironmentVariable, raw)
+		return enabled
+	}
+}

--- a/internal/autoupdate/staging.go
+++ b/internal/autoupdate/staging.go
@@ -1,0 +1,116 @@
+package autoupdate
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	// CandidateBinaryName is the executable name embedded in release archives.
+	CandidateBinaryName = "agent-factory"
+	// DefaultResponseHeaderTimeout bounds a release server that accepts a
+	// connection but never begins its response.
+	DefaultResponseHeaderTimeout = 30 * time.Second
+	maxBinarySize                = 500 << 20 // 500 MB
+)
+
+// CandidateStager downloads a release archive and extracts its candidate
+// binary into memory. Persisting a transactional candidate is intentionally a
+// later layer; this primitive preserves today's install behavior.
+type CandidateStager struct {
+	BinaryName            string
+	ResponseHeaderTimeout time.Duration
+}
+
+// DefaultCandidateStager returns the production release-archive settings.
+func DefaultCandidateStager() CandidateStager {
+	return CandidateStager{
+		BinaryName:            CandidateBinaryName,
+		ResponseHeaderTimeout: DefaultResponseHeaderTimeout,
+	}
+}
+
+// NewDownloadClient builds a client with overall and response-header budgets.
+func (stager CandidateStager) NewDownloadClient(timeout time.Duration) *http.Client {
+	headerTimeout := stager.ResponseHeaderTimeout
+	if timeout < headerTimeout {
+		headerTimeout = timeout
+	}
+	return &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			ResponseHeaderTimeout: headerTimeout,
+		},
+	}
+}
+
+// Download fetches url and returns the embedded candidate binary bytes.
+func (stager CandidateStager) Download(url string, timeout time.Duration) ([]byte, error) {
+	response, err := stager.NewDownloadClient(timeout).Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("download failed: %w", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("download failed: HTTP %d from %s", response.StatusCode, url)
+	}
+
+	binaryName := stager.BinaryName
+	if binaryName == "" {
+		binaryName = CandidateBinaryName
+	}
+	binary, err := ExtractBinaryFromTarGz(response.Body, binaryName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract binary: %w", err)
+	}
+	return binary, nil
+}
+
+// ExtractBinaryFromTarGz returns the regular file named binaryName, including
+// when nested in an archive directory. Reads are bounded and the remainder of
+// the gzip stream is drained so its integrity checksum is verified.
+func ExtractBinaryFromTarGz(reader io.Reader, binaryName string) ([]byte, error) {
+	gzipReader, err := gzip.NewReader(reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gzip reader: %w", err)
+	}
+	defer gzipReader.Close()
+
+	tarReader := tar.NewReader(gzipReader)
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to read tar entry: %w", err)
+		}
+
+		name := header.Name
+		if header.Typeflag != tar.TypeReg || (name != binaryName && !strings.HasSuffix(name, "/"+binaryName)) {
+			continue
+		}
+		if header.Size > maxBinarySize {
+			return nil, fmt.Errorf("binary too large: %d bytes (max %d)", header.Size, maxBinarySize)
+		}
+		data, err := io.ReadAll(io.LimitReader(tarReader, maxBinarySize+1))
+		if err != nil {
+			return nil, fmt.Errorf("failed to read binary from archive: %w", err)
+		}
+		if int64(len(data)) > maxBinarySize {
+			return nil, fmt.Errorf("binary exceeds maximum size of %d bytes", maxBinarySize)
+		}
+		if _, err := io.Copy(io.Discard, gzipReader); err != nil {
+			return nil, fmt.Errorf("gzip integrity check failed: %w", err)
+		}
+		return data, nil
+	}
+
+	return nil, fmt.Errorf("binary %q not found in archive", binaryName)
+}

--- a/internal/autoupdate/staging_test.go
+++ b/internal/autoupdate/staging_test.go
@@ -1,0 +1,71 @@
+package autoupdate
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestCandidateStagerDownloadsNestedBinary(t *testing.T) {
+	archive := testTarGz(t, "dist/agent-factory", []byte("candidate-binary"))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write(archive); err != nil {
+			t.Errorf("write archive: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	stager := CandidateStager{
+		BinaryName:            "agent-factory",
+		ResponseHeaderTimeout: time.Second,
+	}
+	candidate, err := stager.Download(server.URL, time.Second)
+	if err != nil {
+		t.Fatalf("Download: %v", err)
+	}
+	if string(candidate) != "candidate-binary" {
+		t.Fatalf("candidate = %q, want candidate-binary", candidate)
+	}
+}
+
+func TestCandidateStagerRejectsNonSuccessResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "missing", http.StatusNotFound)
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := (CandidateStager{ResponseHeaderTimeout: time.Second}).Download(server.URL, time.Second)
+	if err == nil {
+		t.Fatal("Download returned nil error for HTTP 404")
+	}
+}
+
+func testTarGz(t *testing.T, name string, contents []byte) []byte {
+	t.Helper()
+	var buffer bytes.Buffer
+	gzipWriter := gzip.NewWriter(&buffer)
+	tarWriter := tar.NewWriter(gzipWriter)
+	if err := tarWriter.WriteHeader(&tar.Header{
+		Name:     name,
+		Mode:     0755,
+		Size:     int64(len(contents)),
+		Typeflag: tar.TypeReg,
+	}); err != nil {
+		t.Fatalf("write tar header: %v", err)
+	}
+	if _, err := tarWriter.Write(contents); err != nil {
+		t.Fatalf("write tar body: %v", err)
+	}
+	if err := tarWriter.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		t.Fatalf("close gzip: %v", err)
+	}
+	return buffer.Bytes()
+}


### PR DESCRIPTION
## Summary

- extract release discovery, channel/version selection, the shared throttle cache, opt-out evaluation, and candidate download/extraction into `internal/autoupdate`
- keep the existing command-level test seams while routing both `af` launch auto-update and explicit `af upgrade` through the shared primitives
- add package-level tests for channel-specific discovery, semver ordering, cache compatibility/throttling, and bounded candidate extraction

## Behavior boundary

This is PR1 of the staged implementation for #2212. It intentionally changes no trigger or lifecycle behavior:

- `autoUpdateOnLaunch` remains enabled and in the same call site
- `af upgrade` still installs, refreshes the unit, and restarts the daemon in the same order
- the cache remains `last_update_check` with the same JSON schema and adjacent non-blocking lock
- failures still close the fixed six-hour window; channel and current-version changes still force a check
- `auto_update = false` and `AGENT_FACTORY_AUTO_UPDATE` keep their existing precedence and accepted values
- no daemon loop, health surface, probation, supervisor, transaction, binary rollback, or metadata rollback is introduced here

`CandidateStager` is the existing bounded archive download/extraction moved behind a shared API. It stages bytes in memory exactly as today; durable on-disk transactional staging belongs to the later transaction PR.

## Staged series

1. **This PR:** shared discovery/cache/settings/staging extraction, behavior-neutral
2. Health/version/phase surfaces and upgrade probation
3. Transaction, durable previous-binary supervisor, takeover, and rollback
4. Daemon-owned loop behind the existing opt-out

Only this PR is open; the later stages are not stacked.

## Verification

- `make test-container GOTESTARGS="./internal/autoupdate ./commands"`
- `make test-container`
- `scripts/lint-file-length.sh`

Part of #2212.