### PR TITLE
fix(preview): preserve stable tab identity through capture

### DIFF
--- a/app/live_stream.go
+++ b/app/live_stream.go
@@ -29,8 +29,8 @@ func (m *home) newTabPaneSource() ui.PreviewSource {
 			return "", nil
 		}
 		// Address the capture by the tab's stable id (#1738) so it can't grab the
-		// wrong tab after a reorder/close; the daemon falls back to the ordinal Tab
-		// when the id is empty or no longer resolves.
+		// wrong tab after a reorder/close. Only an empty id uses the legacy ordinal;
+		// a non-empty id that no longer resolves is refused, never fallen back.
 		tabID, _ := instance.TabIDAt(tab)
 		content, gone, err := fetch(daemon.PreviewRequest{Title: instance.Title, RepoID: repoID, Tab: tab, TabID: tabID, Full: full})
 		if err != nil {

--- a/daemon/agentserver_headless_test.go
+++ b/daemon/agentserver_headless_test.go
@@ -52,8 +52,11 @@ func (f *fakeHeadlessAgentServer) Snapshot() (session.Observation, error) {
 	return session.Observation{Updated: true, HasPrompt: false, Content: f.snapshotText}, nil
 }
 func (f *fakeHeadlessAgentServer) Preview(int, bool) (string, error) { return "preview-body", nil }
-func (f *fakeHeadlessAgentServer) Alive() (bool, error)              { return true, nil }
-func (f *fakeHeadlessAgentServer) Archive() (string, error)          { return "session/fake", nil }
+func (f *fakeHeadlessAgentServer) PreviewByID(string, bool) (string, error) {
+	return "preview-body", nil
+}
+func (f *fakeHeadlessAgentServer) Alive() (bool, error)     { return true, nil }
+func (f *fakeHeadlessAgentServer) Archive() (string, error) { return "session/fake", nil }
 func (f *fakeHeadlessAgentServer) SendPrompt(p string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/daemon/manager_tabs.go
+++ b/daemon/manager_tabs.go
@@ -136,8 +136,9 @@ func (m *Manager) CreateTab(req CreateTabRequest) (string, string, error) {
 	data := instance.ToInstanceData()
 	if err := persistInstanceData(repoID, data); err != nil {
 		// Roll back the just-spawned tab so a persist failure does not leave a
-		// live tmux session that vanishes from the tab list on restart.
-		if closeErr := instance.CloseTab(instance.TabCount() - 1); closeErr != nil {
+		// live tmux session that vanishes from the tab list on restart. Carry the
+		// new tab's ID into rollback rather than assuming it is still the last slot.
+		if closeErr := instance.CloseTabByID(tab.ID); closeErr != nil {
 			log.WarningLog.Printf("CreateTab %q: rolling back unpersisted tab failed: %v", title, closeErr)
 		}
 		return "", "", fmt.Errorf("failed to persist new tab: %w", err)
@@ -225,8 +226,12 @@ func (m *Manager) CloseTab(req CloseTabRequest) (string, error) {
 	}
 
 	closedVSCode := tabs[idx].Kind == session.TabKindVSCode
+	targetID, err := stableTabTargetID(tabs[idx], title)
+	if err != nil {
+		return "", err
+	}
 
-	if err := instance.CloseTab(idx); err != nil {
+	if err := instance.CloseTabByID(targetID); err != nil {
 		return "", err
 	}
 

--- a/daemon/manager_tabs_arrange.go
+++ b/daemon/manager_tabs_arrange.go
@@ -141,10 +141,9 @@ func (m *Manager) tabMutationTarget(reqID, reqTitle, reqRepoID string, labels ta
 // rather than cross-checked: the name changing underneath the client is the
 // normal case this field exists to survive, so a mismatch is not an error.
 //
-// The id is matched against the SAME tabs slice the caller goes on to index,
-// rather than via instance.TabIndexByID: the caller resolves against a snapshot
-// it already holds, and a second lookup against the live list could return an
-// index that no longer addresses the same element of tabs.
+// The id is matched against the SAME snapshot the caller uses for validation.
+// The caller then carries tabs[idx].ID into an id-native Instance mutation; idx
+// must never be applied to the live roster after this function returns (#2200).
 func resolveTabTarget(tabs []*session.Tab, title, tabID, tabName string, tabIndex int) (int, string, error) {
 	// The PRECEDENCE and the refuse-never-fall-back rule live in
 	// session.ResolveTabIndex (#1948), because the daemon is no longer the only
@@ -173,6 +172,17 @@ func resolveTabTarget(tabs []*session.Tab, title, tabID, tabName string, tabInde
 		return 0, "", err
 	}
 	return idx, tabs[idx].Name, nil
+}
+
+// stableTabTargetID carries the identity selected from a snapshot into the
+// mutation itself. A daemon-owned tab should always have an ID (legacy rows are
+// backfilled on restore); refusing an impossible id-less row is safer than
+// degrading the operation back to its ordinal (#2200).
+func stableTabTargetID(tab *session.Tab, title string) (string, error) {
+	if tab == nil || tab.ID == "" {
+		return "", fmt.Errorf("session %q has a tab without a stable identity; reload its tabs and retry", title)
+	}
+	return tab.ID, nil
 }
 
 // Rollback on persist failure: rename and reorder DO roll back, CloseTab
@@ -225,8 +235,12 @@ func (m *Manager) RenameTab(req RenameTabRequest) (string, error) {
 	if !session.TabKindRenameable(tabs[idx].Kind) {
 		return "", fmt.Errorf("tab %q of session %q can't be renamed: shell tabs always display as %q. Only web, process and VS Code tabs show a custom name — create one with 'af sessions tab-create --kind web' or '--command'", prevName, title, "Terminal")
 	}
+	targetID, err := stableTabTargetID(tabs[idx], title)
+	if err != nil {
+		return "", err
+	}
 
-	name, err := instance.RenameTab(idx, req.NewName)
+	name, err := instance.RenameTabByID(targetID, req.NewName)
 	if err != nil {
 		return "", err
 	}
@@ -238,7 +252,7 @@ func (m *Manager) RenameTab(req RenameTabRequest) (string, error) {
 		// locks are still held, so prevName cannot have been taken in the window
 		// and resolves back exactly; a surprise means the roster changed underneath
 		// us, which is worth a log line rather than a silent wrong name.
-		if got, rerr := instance.RenameTab(idx, prevName); rerr != nil || got != prevName {
+		if got, rerr := instance.RenameTabByID(targetID, prevName); rerr != nil || got != prevName {
 			log.WarningLog.Printf("RenameTab %q: rolling back unpersisted rename of tab %q returned %q, %v", title, prevName, got, rerr)
 		}
 		return "", fmt.Errorf("failed to persist tab rename: %w", err)
@@ -287,8 +301,12 @@ func (m *Manager) ReorderTab(req ReorderTabRequest) (string, int, error) {
 	if req.NewIndex < 0 || req.NewIndex >= len(tabs) {
 		return "", 0, fmt.Errorf("session %q has no tab slot at index %d (valid: 1-%d)", title, req.NewIndex, len(tabs)-1)
 	}
+	targetID, err := stableTabTargetID(tabs[idx], title)
+	if err != nil {
+		return "", 0, err
+	}
 
-	if err := instance.ReorderTab(idx, req.NewIndex); err != nil {
+	if err := instance.ReorderTabByID(targetID, req.NewIndex); err != nil {
 		return "", 0, err
 	}
 
@@ -296,7 +314,7 @@ func (m *Manager) ReorderTab(req ReorderTabRequest) (string, int, error) {
 	if err := persistInstanceData(repoID, data); err != nil {
 		// Put the original order back (see the rollback note above). Moving the tab from its
 		// new index back to its old one is the exact inverse of the move above.
-		if rerr := instance.ReorderTab(req.NewIndex, idx); rerr != nil {
+		if rerr := instance.ReorderTabByID(targetID, idx); rerr != nil {
 			log.WarningLog.Printf("ReorderTab %q: rolling back unpersisted move of tab %q failed: %v", title, name, rerr)
 		}
 		return "", 0, fmt.Errorf("failed to persist tab reorder: %w", err)

--- a/daemon/preview.go
+++ b/daemon/preview.go
@@ -98,11 +98,11 @@ func (s *controlServer) Preview(req PreviewRequest, resp *PreviewResponse) error
 	if err != nil {
 		return err
 	}
-	// Address the capture by the stable tab id (#1738), or by name (#1948), when
-	// the client gives one: resolve it to the tab's CURRENT ordinal so a capture
-	// follows the tab across a reorder/close. The precedence — id, then name, then
-	// ordinal — is session.ResolveTabIndex's, shared with every other tab verb
-	// rather than restated here.
+	// Resolve the selector once, then carry the selected tab's stable identity all
+	// the way through AgentServer.PreviewByID. The precedence — id, then name, then
+	// ordinal — is session.ResolveTabIndex's, shared with every other tab verb;
+	// the resulting ordinal is used only to read the ID from this SAME snapshot.
+	// It is never applied to the live roster later (#2200).
 	//
 	// A non-empty id that no longer resolves is REFUSED as gone, NOT fallen back to
 	// req.Tab (#1779): the fallback previewed whatever tab had shifted into the
@@ -139,8 +139,16 @@ func (s *controlServer) Preview(req PreviewRequest, resp *PreviewResponse) error
 	case rerr != nil:
 		return rerr
 	}
-	content, err := as.Preview(tab, req.Full)
+	tabID := tabs[tab].ID
+	if tabID == "" {
+		return fmt.Errorf("session %q tab %d has no stable identity; reload the session before previewing it", req.Title, tab)
+	}
+	content, err := as.PreviewByID(tabID, req.Full)
 	if err != nil {
+		if errors.Is(err, session.ErrTabGone) {
+			resp.Gone, resp.TabGone = true, true
+			return nil
+		}
 		if errors.Is(err, tmux.ErrSessionGone) {
 			resp.Gone = true
 			return nil

--- a/daemon/ws_pty.go
+++ b/daemon/ws_pty.go
@@ -113,14 +113,12 @@ func (cs *controlServer) streamHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Address the tab by its STABLE id (#1738) when the client supplies ?tab_id=.
-	// The binding resolves the id atomically on EVERY operation — the initial
-	// Subscribe and each later Input/Resize — so a reorder/close on another client
-	// can never make this connection address a different tab. Crucially the id is
-	// NOT converted to an ordinal here: doing that and letting the agent-server map
-	// the ordinal back to an id reopened the very race the id closes, because a
-	// concurrent close between the two steps shifts a different tab under the
-	// ordinal (#1779). Without a ?tab_id= (legacy client) the binding pins the
-	// ?tab= ordinal, preserving the pre-#1738 positional behavior.
+	// An id-native runtime resolves the id atomically on EVERY operation — the
+	// initial Subscribe and each later Input/Resize — so a reorder/close on another
+	// client can never redirect the connection. The ordinal-only remote bridge
+	// re-resolves per operation and is safe while that runtime's roster remains
+	// immutable; bindTab documents that capability boundary. Without a ?tab_id=
+	// (legacy client) the binding pins ?tab=, preserving positional behavior.
 	binding, err := cs.bindTab(as, instance, r.URL.Query().Get("tab_id"), tab)
 	if err != nil {
 		writeHTTPError(w, r, httpStatusForTab(err), err)
@@ -199,10 +197,13 @@ func (b ordinalTabBinding) resize(rows, cols uint16) error {
 // the one it saw at bind time. Pinning would mean that if the addressed tab shifts
 // mid-connection, later input/resize keep hitting the old index — the positional
 // misroute the stable id exists to prevent, reintroduced on this path (#1779). This
-// still has a narrow window the local path does not (the resolve and the remote
-// server's own ordinal→broker lookup are not one atomic step), but it is the best
-// an ordinal-shaped protocol allows and is strictly better than a fixed ordinal. A
-// tab that no longer resolves is ErrTabGone — the op is refused, not re-pointed.
+// The resolve and remote ordinal lookup are not one atomic step, but this site is
+// exempt from #2200's shifting-roster race: remote workspaces advertise
+// TabManagement=false and the headless agent-server's tab roster is fixed for its
+// lifetime, so there is no close/reorder writer on either side. If remote tabs ever
+// become mutable, their wire protocol must gain an id-native plane before that
+// capability is enabled. A tab that no longer resolves is ErrTabGone — the op is
+// refused, not re-pointed.
 type resolvingTabBinding struct {
 	as       session.AgentServer
 	instance *session.Instance

--- a/session/agentserver.go
+++ b/session/agentserver.go
@@ -37,9 +37,10 @@ var ErrTabClosed = fmt.Errorf("tab closed: %w", io.EOF)
 //
 // The local runtime implements it (its brokers are already keyed by stable id, so
 // id-addressing is strictly simpler than the ordinal round-trip it replaces). A
-// runtime whose wire protocol is ordinal-shaped — the remote agent-server, whose
-// sessions stream through the daemon's Preview capture rather than this WS plane —
-// does not, and the handler falls back to the ordinal path for it.
+// runtime whose wire protocol is ordinal-shaped — the remote agent-server — does
+// not. Its roster is fixed (TabManagement=false), so the handler's compatibility
+// bridge cannot race a close/reorder; mutable remote tabs must add this id-native
+// plane before that capability is enabled.
 type TabAddressableServer interface {
 	// SubscribeTab is Subscribe addressed by stable tab id. ErrTabGone when the id
 	// names no live tab.
@@ -99,6 +100,12 @@ type AgentServer interface {
 	// can't stream live (remote/hook sessions, scroll-mode scrollback, the transient
 	// preview target) — the TUI no longer captures tmux itself (#1592 Phase 2 PR6).
 	Preview(tab int, full bool) (string, error)
+	// PreviewByID is Preview addressed by the tab's stable identity. Implementations
+	// must either bind directly to the identified capture target or keep identity
+	// resolution and the ordinal capture in one critical section; resolving first
+	// and using that ordinal against a later roster can expose another tab (#2200).
+	// ErrTabGone reports that the exact target no longer exists.
+	PreviewByID(tabID string, full bool) (string, error)
 	// Alive reports whether the underlying session process is still running, and
 	// whether the probe could be ANSWERED at all. Kept separate from Snapshot
 	// (rather than folded into Observation) so the daemon probes liveness ONLY on

--- a/session/agentserver_local.go
+++ b/session/agentserver_local.go
@@ -86,7 +86,7 @@ func (i *Instance) AgentServer() AgentServer {
 			// teardown reaps the sandbox this session runs in (docker rm -f) after
 			// the remote Kill tears the in-sandbox workspace down — nil for the PR2
 			// out-of-process case (no sandbox to reap), set for a docker session.
-			i.agentSrv = &remoteAgentServer{rc: i.remoteClient, teardown: i.runtimeTeardown}
+			i.agentSrv = &remoteAgentServer{rc: i.remoteClient, inst: i, teardown: i.runtimeTeardown}
 		case backendIsRemoteWorkspace(i.backend):
 			// A remote-workspace backend (docker/ssh/hook) with NO live client:
 			// remoteClient is nil because the runtime wiring was torn down — a
@@ -165,6 +165,12 @@ func (s *localAgentServer) Preview(tab int, full bool) (string, error) {
 	return s.inst.PreviewTab(tab)
 }
 
+// PreviewByID binds directly to the tmux/backend target selected under the
+// instance lock. No ordinal crosses that lock boundary (#2200).
+func (s *localAgentServer) PreviewByID(tabID string, full bool) (string, error) {
+	return s.inst.PreviewTabByID(tabID, full)
+}
+
 // ctxPreviewBackend is the optional backend capability for a pane capture bound to
 // a context (the local tmux runtime). When the backend supports it, PreviewContext
 // threads ctx down to the capture so a cancelled readiness wait kills the in-flight
@@ -216,12 +222,10 @@ func (s *localAgentServer) TapEnter() {
 // panicking.
 func (s *localAgentServer) ensureBroker(tab int) (*ptyBroker, error) {
 	// Resolve the caller's ordinal to the tab's STABLE id (#1738) and the tmux it
-	// currently backs, under the instance lock, BEFORE taking s.mu — so the broker
-	// map key is the identity that follows the tab across a reorder/close, not the
-	// shifting ordinal. tabTmuxSession and TabIDAt each take i.mu; call them before
-	// s.mu (never nest s.mu → i.mu).
-	id, ok := s.inst.TabIDAt(tab)
-	ts := s.inst.tabTmuxSession(tab)
+	// currently backs in ONE instance-lock acquisition, BEFORE taking s.mu. Two
+	// lookups could pair b's ID with c's tmux if a close shifted the roster between
+	// them — then cache that wrong binding under b forever (#2200).
+	id, ts, ok := s.inst.tabTmuxTargetAt(tab)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.closed {

--- a/session/agentserver_remote.go
+++ b/session/agentserver_remote.go
@@ -54,6 +54,11 @@ import (
 // starts a real `af agent-server` on loopback and drives it through here.
 type remoteAgentServer struct {
 	rc *remoteAgentClient
+	// inst owns the authoritative stable-id→ordinal roster for daemon-created
+	// remote runtimes. The in-sandbox protocol is ordinal-shaped, so PreviewByID
+	// holds inst's roster lock across the bounded REST capture (#2200). nil only
+	// for the transport-only NewRemoteAgentServer constructor used by integrations.
+	inst *Instance
 	// teardown reaps the sandbox the agent runs in AFTER the in-sandbox workspace
 	// is killed over REST (#1592 Phase 4 PR4): `docker rm -f` the container. nil
 	// for the PR2 out-of-process case (an `af agent-server` the test owns — nothing
@@ -132,6 +137,15 @@ func (s *remoteAgentServer) Snapshot() (Observation, error) {
 
 func (s *remoteAgentServer) Preview(tab int, full bool) (string, error) {
 	return s.rc.preview(tab, full)
+}
+
+func (s *remoteAgentServer) PreviewByID(tabID string, full bool) (string, error) {
+	if s.inst == nil {
+		return "", fmt.Errorf("remote session %q cannot resolve stable tab id %q without its owning instance", s.rc.title, tabID)
+	}
+	return s.inst.previewByIDAsOrdinal(tabID, func(tab int) (string, error) {
+		return s.rc.preview(tab, full)
+	})
 }
 
 // Alive asks the in-sandbox agent-server whether its agent is running. The error
@@ -277,6 +291,9 @@ func (s *deadRemoteAgentServer) Launch(bool) error                 { return s.er
 func (s *deadRemoteAgentServer) Expose() (StreamEndpoint, error)   { return StreamEndpoint{}, s.err() }
 func (s *deadRemoteAgentServer) Snapshot() (Observation, error)    { return Observation{}, s.err() }
 func (s *deadRemoteAgentServer) Preview(int, bool) (string, error) { return "", s.err() }
+func (s *deadRemoteAgentServer) PreviewByID(string, bool) (string, error) {
+	return "", s.err()
+}
 
 // Alive returns (false, err) = UNKNOWN, never an authoritative "the agent is gone":
 // there is no sandbox to answer, so a caller must not treat this false as proof of

--- a/session/archive_sandbox_test.go
+++ b/session/archive_sandbox_test.go
@@ -271,6 +271,7 @@ func (s *stubAgentServer) Launch(bool) error                           { return 
 func (s *stubAgentServer) Expose() (StreamEndpoint, error)             { return StreamEndpoint{}, nil }
 func (s *stubAgentServer) Snapshot() (Observation, error)              { return Observation{}, nil }
 func (s *stubAgentServer) Preview(int, bool) (string, error)           { return "", nil }
+func (s *stubAgentServer) PreviewByID(string, bool) (string, error)    { return "", nil }
 func (s *stubAgentServer) Alive() (bool, error)                        { return false, nil }
 func (s *stubAgentServer) SendPrompt(string) error                     { return nil }
 func (s *stubAgentServer) TapEnter()                                   {}

--- a/session/instance.go
+++ b/session/instance.go
@@ -247,19 +247,6 @@ type Instance struct {
 	runtimeTeardown func() error
 }
 
-// tabTmuxSession returns the tmux session backing the tab at idx (0 is the agent
-// tab), or nil when the instance is not started, is remote, or idx is out of
-// range. It is the tab-aware binding point the clientless data plane subscribes
-// per pane (#1592 Phase 2 PR6). Takes i.mu, so callers must not already hold it.
-func (i *Instance) tabTmuxSession(idx int) *tmux.TmuxSession {
-	i.mu.RLock()
-	defer i.mu.RUnlock()
-	if !i.started {
-		return nil
-	}
-	return i.tabTmuxAtLocked(idx)
-}
-
 // tmuxLocked returns the agent tab's tmux session, or nil when the instance has
 // no agent tab yet (not started) or is remote. Callers must hold i.mu (read or
 // write).
@@ -333,6 +320,22 @@ func (i *Instance) TabIDAt(idx int) (string, bool) {
 		return "", false
 	}
 	return i.Tabs[idx].ID, true
+}
+
+// tabTmuxTargetAt resolves an ordinal to both the stable broker key and its tmux
+// target under one lock. Reading those in separate calls can pair one tab's ID
+// with a sibling's tmux when a close shifts the roster between the calls (#2200).
+func (i *Instance) tabTmuxTargetAt(idx int) (id string, ts *tmux.TmuxSession, exists bool) {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	if idx < 0 || idx >= len(i.Tabs) {
+		return "", nil, false
+	}
+	tab := i.Tabs[idx]
+	if !i.started {
+		return tab.ID, nil, true
+	}
+	return tab.ID, tab.tmux, true
 }
 
 // TabTmuxByID resolves a tab's stable id (#1738) DIRECTLY to the tmux session it
@@ -412,46 +415,9 @@ func (i *Instance) TabTargetByID(id string) (kind TabKind, url string, exists bo
 // for what the caller actually needs: an ordinal handed back to a SECOND lookup
 // reopens the close/reorder window this resolution is meant to close.
 func (i *Instance) TabIndexByID(id string) (int, bool) {
-	if id == "" {
-		return 0, false
-	}
 	i.mu.RLock()
 	defer i.mu.RUnlock()
-	for idx, t := range i.Tabs {
-		if t.ID == id {
-			return idx, true
-		}
-	}
-	return 0, false
-}
-
-// PreviewTab captures the detached content of the tab at idx. Returns ("", nil)
-// when the instance is not started or the tab has no live session, and
-// tmux.ErrSessionGone when the session vanished — mirroring Instance.Preview for
-// the agent tab so the UI can degrade gracefully. idx is the same 0-based index
-// the UI tab bar uses (0 is the agent tab; 1+ are shell/process tabs).
-func (i *Instance) PreviewTab(idx int) (string, error) {
-	i.mu.RLock()
-	started := i.started
-	ts := i.tabTmuxAtLocked(idx)
-	i.mu.RUnlock()
-	if !started || ts == nil {
-		return "", nil
-	}
-	return ts.CapturePaneContent()
-}
-
-// PreviewTabFullHistory captures the full scrollback of the tab at idx, used
-// when entering scroll mode. Same nil/started guards as PreviewTab.
-func (i *Instance) PreviewTabFullHistory(idx int) (string, error) {
-	i.mu.RLock()
-	started := i.started
-	ts := i.tabTmuxAtLocked(idx)
-	i.mu.RUnlock()
-	if !started || ts == nil {
-		return "", nil
-	}
-	return ts.CapturePaneContentWithOptions("-", "-")
+	return i.tabIndexByIDLocked(id)
 }
 
 // TabAlive reports whether the tab at idx has a live tmux session, as a LOSSY

--- a/session/instance_backend_guard_test.go
+++ b/session/instance_backend_guard_test.go
@@ -21,6 +21,9 @@ import (
 //   - SetBackend / bindProvisionResult — the writers; both take i.mu.Lock.
 //   - AgentServer / reprovisionRemote / toInstanceDataLocked — read inside an
 //     i.mu section their callers established.
+//   - PreviewTabByID — snapshots the backend while its stable tab target is
+//     selected under i.mu, then performs the potentially blocking capture after
+//     releasing the lock.
 //   - FromInstanceData — a constructor. It populates a local *Instance that no
 //     other goroutine can observe yet, so there is nothing to synchronize with.
 var backendReadersUnderLock = map[string]bool{
@@ -31,6 +34,7 @@ var backendReadersUnderLock = map[string]bool{
 	"AgentServer":          true,
 	"reprovisionRemote":    true,
 	"toInstanceDataLocked": true,
+	"PreviewTabByID":       true,
 	"FromInstanceData":     true,
 }
 

--- a/session/preview.go
+++ b/session/preview.go
@@ -1,0 +1,106 @@
+package session
+
+import "fmt"
+
+// PreviewTab captures the detached content of the tab currently at idx. The
+// ordinal form exists for legacy callers that never supplied a stable tab id.
+// An out-of-range ordinal is an explicit error: returning ("", nil) would claim
+// that a nonexistent pane was merely blank (#2200).
+func (i *Instance) PreviewTab(idx int) (string, error) {
+	i.mu.RLock()
+	if idx < 0 || idx >= len(i.Tabs) {
+		i.mu.RUnlock()
+		return "", fmt.Errorf("session %q tab %d: %w", i.Title, idx, ErrTabIndexOutOfRange)
+	}
+	started := i.started
+	ts := i.tabTmuxAtLocked(idx)
+	i.mu.RUnlock()
+	if !started || ts == nil {
+		return "", nil
+	}
+	return ts.CapturePaneContent()
+}
+
+// PreviewTabFullHistory is PreviewTab's full-scrollback counterpart. It keeps
+// the same explicit out-of-range refusal.
+func (i *Instance) PreviewTabFullHistory(idx int) (string, error) {
+	i.mu.RLock()
+	if idx < 0 || idx >= len(i.Tabs) {
+		i.mu.RUnlock()
+		return "", fmt.Errorf("session %q tab %d: %w", i.Title, idx, ErrTabIndexOutOfRange)
+	}
+	started := i.started
+	ts := i.tabTmuxAtLocked(idx)
+	i.mu.RUnlock()
+	if !started || ts == nil {
+		return "", nil
+	}
+	return ts.CapturePaneContentWithOptions("-", "-")
+}
+
+// PreviewTabByID captures the tab named by stable id without ever converting
+// that identity into an ordinal used by a later live-list lookup. The instance
+// lock resolves the id directly to the target tmux pointer and stays held through
+// the bounded non-agent capture. A concurrent close/reorder therefore waits; it
+// cannot redirect the capture to a sibling or a same-name replacement (#2200).
+//
+// The agent tab retains the backend-specific preview path. It is pinned at slot
+// zero and cannot be closed or reordered, so snapshotting its backend under the
+// same lock preserves both its identity and the formatting contract.
+func (i *Instance) PreviewTabByID(tabID string, full bool) (string, error) {
+	i.mu.RLock()
+	idx, exists := i.tabIndexByIDLocked(tabID)
+	if !exists {
+		i.mu.RUnlock()
+		return "", fmt.Errorf("session %q tab id %q: %w", i.Title, tabID, ErrTabGone)
+	}
+	tab := i.Tabs[idx]
+	if !i.started {
+		i.mu.RUnlock()
+		return "", nil
+	}
+	if tab.Kind != TabKindAgent {
+		// Keep the roster read lock through the bounded tmux capture. Besides
+		// preventing an ordinal shift, this prevents a close+recreate from reusing
+		// the old tmux name between target selection and capture.
+		defer i.mu.RUnlock()
+		ts := tab.tmux
+		if ts == nil {
+			return "", nil
+		}
+		if full {
+			return ts.CapturePaneContentWithOptions("-", "-")
+		}
+		return ts.CapturePaneContent()
+	}
+
+	// Backend preview methods re-enter i.mu, so the pinned agent target snapshots
+	// the backend under the lock and performs the call after releasing it.
+	backend := i.backend
+	i.mu.RUnlock()
+	if backend == nil {
+		return "", fmt.Errorf("session %q has no preview backend", i.Title)
+	}
+	if full {
+		return backend.PreviewFullHistory(i)
+	}
+	return backend.Preview(i)
+}
+
+// previewByIDAsOrdinal is the compatibility bridge for a remote agent-server
+// whose private wire protocol is ordinal-shaped. The daemon-side Instance owns
+// the authoritative roster, so it holds that roster's read lock from stable-id
+// resolution until the bounded remote capture returns. A close or reorder
+// therefore cannot shift a new target under the ordinal in between (#2200).
+//
+// Local capture must not use this helper: its capture path re-enters i.mu. It has
+// PreviewTabByID above, which selects the tmux pointer directly instead.
+func (i *Instance) previewByIDAsOrdinal(tabID string, capture func(int) (string, error)) (string, error) {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	idx, exists := i.tabIndexByIDLocked(tabID)
+	if !exists {
+		return "", fmt.Errorf("session %q tab id %q: %w", i.Title, tabID, ErrTabGone)
+	}
+	return capture(idx)
+}

--- a/session/preview_identity_test.go
+++ b/session/preview_identity_test.go
@@ -1,0 +1,157 @@
+package session
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session/git"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// previewIdentityInstance returns each captured pane's exact tmux target as its
+// content. That makes an ordinal misroute observable: b and c cannot both answer
+// the fixture-wide "content" string used by the general tab lifecycle helper.
+func previewIdentityInstance(t *testing.T, agentName string) *Instance {
+	t.Helper()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	cmdExec, _ := raceHookExec(map[string]bool{agentName: true}, nil)
+	cmdExec.OutputFunc = func(cmd *exec.Cmd) ([]byte, error) {
+		for i, arg := range cmd.Args {
+			if arg == "-t" && i+1 < len(cmd.Args) {
+				target := strings.TrimSuffix(strings.TrimPrefix(cmd.Args[i+1], "="), ":")
+				return []byte(target), nil
+			}
+		}
+		return nil, nil
+	}
+	pty := persistPtyFactory{t: t, cmdExec: cmdExec}
+	repoPath := "/tmp/preview-tab-identity-" + agentName
+	gw, err := git.NewGitWorktreeFromStorage(
+		repoPath, filepath.Join(t.TempDir(), "wt"), agentName,
+		agentName+"-branch", "", false, true)
+	require.NoError(t, err)
+
+	agentTmux := tmux.NewTmuxSessionFromSanitizedNameWithDeps(agentName, "claude", pty, cmdExec)
+	return &Instance{
+		Title:       agentName,
+		Path:        repoPath,
+		Program:     "claude",
+		backend:     &LocalBackend{},
+		started:     true,
+		gitWorktree: gw,
+		Tabs:        []*Tab{newAgentTab(agentTmux)},
+	}
+}
+
+func tabTmuxName(t *testing.T, inst *Instance, id string) string {
+	t.Helper()
+	for _, tab := range inst.ToInstanceData().Tabs {
+		if tab.ID == id {
+			return tab.TmuxName
+		}
+	}
+	t.Fatalf("tab id %q is absent from instance data", id)
+	return ""
+}
+
+// TestPreview_TabIDSurvivesConcurrentOrdinalShift is the #2200 fail-first
+// scenario. The caller resolved b from [agent,a,b,c], then a concurrent close
+// shifted the live roster to [agent,b,c]. A capture addressed by b's stable id
+// may return b or an honest error if b itself vanished; it must never return c.
+func TestPreview_TabIDSurvivesConcurrentOrdinalShift(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	for _, tc := range []struct {
+		name string
+		full bool
+	}{
+		{name: "visible", full: false},
+		{name: "full history", full: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			inst := previewIdentityInstance(t, "af_preview_identity_"+strings.ReplaceAll(tc.name, " ", "_"))
+			_, err := inst.AddProcessTab("a", "a")
+			require.NoError(t, err)
+			b, err := inst.AddProcessTab("b", "b")
+			require.NoError(t, err)
+			c, err := inst.AddProcessTab("c", "c")
+			require.NoError(t, err)
+
+			snapshot := inst.GetTabs()
+			resolved, err := ResolveTabIndex(snapshot, b.ID, "", 0)
+			require.NoError(t, err)
+			require.Equal(t, 2, resolved)
+
+			closed := make(chan error, 1)
+			go func() { closed <- inst.CloseTab(1) }()
+			require.NoError(t, <-closed)
+			requireIndex(t, inst, b.ID, 1)
+			requireIndex(t, inst, c.ID, 2)
+
+			content, captureErr := inst.AgentServer().PreviewByID(b.ID, tc.full)
+			if captureErr == nil {
+				require.Equal(t, tabTmuxName(t, inst, b.ID), content,
+					"a preview resolved by b's stable id must never capture c after a shifts the ordinals")
+			}
+		})
+	}
+}
+
+func TestPreview_InvalidOrdinalAndStaleIDReturnErrors(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst := previewIdentityInstance(t, "af_preview_refusals")
+	a, err := inst.AddProcessTab("a", "a")
+	require.NoError(t, err)
+
+	for _, full := range []bool{false, true} {
+		for _, idx := range []int{-1, 2, 99} {
+			_, err := inst.AgentServer().Preview(idx, full)
+			require.ErrorIs(t, err, ErrTabIndexOutOfRange,
+				"an out-of-range capture must not fabricate a blank pane")
+		}
+	}
+
+	require.NoError(t, inst.CloseTabByID(a.ID))
+	_, err = inst.AgentServer().PreviewByID(a.ID, false)
+	require.ErrorIs(t, err, ErrTabGone, "a closed stable id must be refused")
+}
+
+// TestPreviewByIDAsOrdinalHoldsRosterAcrossCapture covers the remote-runtime
+// compatibility bridge. Its private wire is ordinal-shaped, so the daemon must
+// retain the roster read lock from ID resolution through the bounded capture.
+func TestPreviewByIDAsOrdinalHoldsRosterAcrossCapture(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst := previewIdentityInstance(t, "af_preview_remote_bridge")
+	_, err := inst.AddProcessTab("a", "a")
+	require.NoError(t, err)
+	b, err := inst.AddProcessTab("b", "b")
+	require.NoError(t, err)
+
+	closeDone := make(chan error, 1)
+	content, err := inst.previewByIDAsOrdinal(b.ID, func(idx int) (string, error) {
+		require.Equal(t, 2, idx)
+		go func() { closeDone <- inst.CloseTab(1) }()
+		select {
+		case err := <-closeDone:
+			t.Fatalf("tab close completed during the capture critical section: %v", err)
+		case <-time.After(25 * time.Millisecond):
+		}
+		return "remote-b", nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, "remote-b", content)
+	require.NoError(t, <-closeDone)
+	requireIndex(t, inst, b.ID, 1)
+}

--- a/session/tab.go
+++ b/session/tab.go
@@ -394,6 +394,21 @@ func ResolveTabIndex(tabs []*Tab, tabID, tabName string, tabIndex int) (int, err
 	return tabIndex, nil
 }
 
+// tabIndexByIDLocked resolves id against i.Tabs while the caller holds i.mu.
+// Returning an index is safe only inside that same critical section; callers
+// must finish selecting or mutating the target before releasing the lock.
+func (i *Instance) tabIndexByIDLocked(id string) (int, bool) {
+	if id == "" {
+		return 0, false
+	}
+	for idx, tab := range i.Tabs {
+		if tab.ID == id {
+			return idx, true
+		}
+	}
+	return 0, false
+}
+
 // TabIdentifiers renders a tab as the strings that help a user address it in an
 // error: its canonical Name, plus the label the UI shows when that differs.
 // Because the label is presentation-only and never accepted (TabMatches keys on

--- a/session/tab_arrange.go
+++ b/session/tab_arrange.go
@@ -61,6 +61,27 @@ func (i *Instance) RenameTab(idx int, requestedName string) (string, error) {
 
 	i.mu.Lock()
 	defer i.mu.Unlock()
+	return i.renameTabLocked(idx, base)
+}
+
+// RenameTabByID selects and renames the stable target under one write lock, so
+// a caller never applies an ordinal from an older roster to a different tab.
+func (i *Instance) RenameTabByID(tabID, requestedName string) (string, error) {
+	base := sanitizeTabName(requestedName)
+	if base == "" {
+		return "", fmt.Errorf("tab name %q has no usable characters: a name may contain only letters, digits, '_' and '-'", requestedName)
+	}
+
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	idx, exists := i.tabIndexByIDLocked(tabID)
+	if !exists {
+		return "", fmt.Errorf("session %q tab id %q: %w", i.Title, tabID, ErrTabGone)
+	}
+	return i.renameTabLocked(idx, base)
+}
+
+func (i *Instance) renameTabLocked(idx int, base string) (string, error) {
 	if idx < 0 || idx >= len(i.Tabs) {
 		return "", fmt.Errorf("tab cannot be renamed")
 	}
@@ -96,6 +117,21 @@ func (i *Instance) RenameTab(idx int, requestedName string) (string, error) {
 func (i *Instance) ReorderTab(from, to int) error {
 	i.mu.Lock()
 	defer i.mu.Unlock()
+	return i.reorderTabLocked(from, to)
+}
+
+// ReorderTabByID selects and moves the stable target under one write lock.
+func (i *Instance) ReorderTabByID(tabID string, to int) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	from, exists := i.tabIndexByIDLocked(tabID)
+	if !exists {
+		return fmt.Errorf("session %q tab id %q: %w", i.Title, tabID, ErrTabGone)
+	}
+	return i.reorderTabLocked(from, to)
+}
+
+func (i *Instance) reorderTabLocked(from, to int) error {
 	n := len(i.Tabs)
 	if from <= 0 || from >= n || to <= 0 || to >= n {
 		return fmt.Errorf("tab cannot be moved")

--- a/session/tab_close.go
+++ b/session/tab_close.go
@@ -23,10 +23,41 @@ func (i *Instance) CloseTab(idx int) error {
 		i.mu.Unlock()
 		return fmt.Errorf("tab cannot be closed")
 	}
+	tab := i.removeTabLocked(idx)
+	i.mu.Unlock()
+	return i.closeRemovedTab(tab)
+}
+
+// CloseTabByID removes the tab with stable id, selecting and removing it in the
+// same critical section. An ordinal resolved from an earlier snapshot is never
+// applied to the live roster (#2200).
+func (i *Instance) CloseTabByID(tabID string) error {
+	i.mu.Lock()
+	idx, exists := i.tabIndexByIDLocked(tabID)
+	if !exists {
+		i.mu.Unlock()
+		return fmt.Errorf("session %q tab id %q: %w", i.Title, tabID, ErrTabGone)
+	}
+	if idx == 0 {
+		i.mu.Unlock()
+		return fmt.Errorf("tab cannot be closed")
+	}
+	tab := i.removeTabLocked(idx)
+	i.mu.Unlock()
+	return i.closeRemovedTab(tab)
+}
+
+// removeTabLocked detaches idx from the roster and returns the exact tab object
+// whose stream/process teardown must continue after i.mu is released.
+func (i *Instance) removeTabLocked(idx int) *Tab {
 	tab := i.Tabs[idx]
 	i.Tabs = append(i.Tabs[:idx], i.Tabs[idx+1:]...)
-	i.mu.Unlock()
+	return tab
+}
 
+// closeRemovedTab finishes the irreversible half outside i.mu: stream shutdown
+// and tmux teardown may block and both can acquire their own locks.
+func (i *Instance) closeRemovedTab(tab *Tab) error {
 	// End this tab's stream BEFORE its tmux dies — the same order localAgentServer
 	// .Kill uses for the session-wide case (brokers first, then the backend), and
 	// for the same reason: a subscriber should be told the stream is over rather

--- a/session/tab_mutation_identity_test.go
+++ b/session/tab_mutation_identity_test.go
@@ -1,0 +1,67 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+func shiftedMutationTabs(t *testing.T, agentName string) (*Instance, *Tab, *Tab) {
+	t.Helper()
+	inst := startedMockInstance(t, agentName)
+	_, err := inst.AddProcessTab("a", "a")
+	require.NoError(t, err)
+	b, err := inst.AddProcessTab("b", "b")
+	require.NoError(t, err)
+	c, err := inst.AddProcessTab("c", "c")
+	require.NoError(t, err)
+
+	snapshot := inst.GetTabs()
+	resolved, err := ResolveTabIndex(snapshot, b.ID, "", 0)
+	require.NoError(t, err)
+	require.Equal(t, 2, resolved, "premise: b starts at ordinal 2")
+
+	closed := make(chan error, 1)
+	go func() { closed <- inst.CloseTab(1) }()
+	require.NoError(t, <-closed)
+	requireIndex(t, inst, b.ID, 1)
+	requireIndex(t, inst, c.ID, 2)
+	return inst, b, c
+}
+
+// TestTabMutationsByIDSurviveConcurrentOrdinalShift audits the other
+// ResolveTabIndex consumers from #2200. Rename, reorder, and close carry the
+// selected stable ID into the Instance mutation; none applies the stale ordinal
+// that now names c after a is closed.
+func TestTabMutationsByIDSurviveConcurrentOrdinalShift(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	t.Run("rename", func(t *testing.T) {
+		inst, b, c := shiftedMutationTabs(t, "af_mutation_id_rename")
+		name, err := inst.RenameTabByID(b.ID, "renamed")
+		require.NoError(t, err)
+		require.Equal(t, "renamed", name)
+		requireIndex(t, inst, b.ID, 1)
+		require.Equal(t, "renamed", inst.GetTabs()[1].Name)
+		require.Equal(t, "c", inst.GetTabs()[2].Name)
+		requireIndex(t, inst, c.ID, 2)
+	})
+
+	t.Run("reorder", func(t *testing.T) {
+		inst, b, c := shiftedMutationTabs(t, "af_mutation_id_reorder")
+		require.NoError(t, inst.ReorderTabByID(b.ID, 2))
+		requireIndex(t, inst, c.ID, 1)
+		requireIndex(t, inst, b.ID, 2)
+	})
+
+	t.Run("close", func(t *testing.T) {
+		inst, b, c := shiftedMutationTabs(t, "af_mutation_id_close")
+		require.NoError(t, inst.CloseTabByID(b.ID))
+		_, exists := inst.TabIndexByID(b.ID)
+		require.False(t, exists, "the selected b must be closed")
+		requireIndex(t, inst, c.ID, 1)
+	})
+}


### PR DESCRIPTION
## Summary

- carry every resolved preview target's stable tab ID through a new `AgentServer.PreviewByID` boundary instead of applying a snapshot ordinal to the live roster
- bind local capture to the identified tmux target under the instance lock; keep the ordinal-shaped remote capture atomic by holding the authoritative roster lock through the bounded call
- return explicit errors from legacy ordinal capture when the tab is out of range, rather than fabricating an empty pane
- carry stable IDs through rename, reorder, close, and create rollback, and atomically pair the legacy PTY broker's tab ID with its tmux target

Fixes #2200.

## Root cause

`daemon/preview.go` resolved `TabID` against an `Instance.GetTabs()` snapshot, discarded the ID, and passed the resulting ordinal to `AgentServer.Preview`. The local server then indexed the live roster under a later lock acquisition. Closing A between those operations changed `[agent,a,b,c]` into `[agent,b,c]`, so B's old ordinal selected C.

The fix makes stable identity the capture contract. Local capture selects the exact target and keeps the roster lock through the bounded non-agent capture; a close/reorder can wait or the capture can fail, but it cannot redirect to a sibling. The remote agent-server wire remains ordinal-shaped, so its daemon-side `PreviewByID` bridge holds the authoritative roster read lock from ID resolution through the bounded REST call.

## Fail-first

On rebased master `e7e9ed3d`, before the fix:

```text
$ go test ./session -run '^TestPreview_TabIDSurvivesConcurrentOrdinalShift$' -count=1 -v
=== RUN   TestPreview_TabIDSurvivesConcurrentOrdinalShift
    preview_identity_test.go:92:
        Error:       Not equal:
                     expected: "af_preview_identity__b"
                     actual  : "af_preview_identity__c"
        Messages:    a preview resolved by b's stable id must never capture c after a shifts the ordinals
--- FAIL: TestPreview_TabIDSurvivesConcurrentOrdinalShift (0.01s)
FAIL
FAIL    github.com/sachiniyer/agent-factory/session    0.028s
FAIL
```

The final regression runs the same close-between-resolve-and-capture scenario for both visible output and full history, accepting B's content or an honest error and rejecting C.

## Adjacent tab-action audit

- `ResolveTabIndex` production callers are Preview and `resolveTabTarget`. Preview now extracts the selected snapshot row's ID and calls `PreviewByID`. Rename, reorder, and close now extract that same ID and call ID-native Instance methods; rollback also uses the ID.
- Create rollback no longer assumes the new tab remains the last ordinal; it closes the created tab by ID.
- `localAgentServer.ensureBroker` previously called `TabIDAt` and `tabTmuxSession` under separate locks, which could cache C's tmux under B's ID. It now obtains the ID and tmux target in one lock acquisition.
- The remote PTY compatibility binding still resolves ID to ordinal per operation, but is exempt today: off-box runtimes enforce `TabManagement=false`, and the headless agent-server roster is immutable for its lifetime. The boundary is documented in code: mutable remote tabs require an ID-native wire plane before that capability can be enabled.
- Remaining `TabIndexByID` app callers reconcile UI selection/drag state, or convert ordinal to ID before an RPC; they do not resolve an ID and later invoke a tab backend action with that ordinal.

## Validation

All required gates were run after commit and push against `9fc42e0dc37b911b152da75a8adc358dbd1586a9`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (no output)
- `go build ./...`
- `make test-container` (full suite, including `parity`, passed)
- `deadcode -test ./...` (no output)
- `scripts/lint-file-length.sh` (887 Go files, 0 grandfathered)

Focused race coverage also passed for the preview identity shift, remote ordinal bridge, and adjacent ID-native mutations.

— Captain Claude
