### PR TITLE
fix(web): unclip the new-tab menu

### DIFF
--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -1046,8 +1046,8 @@ body {
   align-items: center;
 }
 .af-tab-menu {
-  position: absolute;
-  top: calc(100% + 6px);
+  position: fixed;
+  top: 0;
   left: 0;
   min-width: 9rem;
   background: var(--af-bg-raised);

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -11050,11 +11050,26 @@ var AppShell = class {
     menu.setAttribute("role", "menu");
     menu.setAttribute("aria-label", "Tab type");
     menu.hidden = true;
+    let scrollParent = null;
+    const positionMenu = () => {
+      const anchor = trigger.getBoundingClientRect();
+      const menuBox = menu.getBoundingClientRect();
+      const maxLeft = Math.max(0, window.innerWidth - menuBox.width);
+      const left = Math.min(Math.max(0, anchor.right - menuBox.width), maxLeft);
+      const below = anchor.bottom + 6;
+      const above = anchor.top - menuBox.height - 6;
+      const top = below + menuBox.height <= window.innerHeight ? below : Math.max(0, above);
+      menu.style.left = `${left}px`;
+      menu.style.top = `${top}px`;
+    };
     const close = () => {
       menu.hidden = true;
       trigger.setAttribute("aria-expanded", "false");
       document.removeEventListener("mousedown", onDocMouseDown);
       document.removeEventListener("keydown", onKeyDown, true);
+      scrollParent?.removeEventListener("scroll", positionMenu);
+      scrollParent = null;
+      window.removeEventListener("resize", positionMenu);
     };
     const onDocMouseDown = (e) => {
       if (!wrap.isConnected || !wrap.contains(e.target)) {
@@ -11071,7 +11086,11 @@ var AppShell = class {
     };
     const open = () => {
       menu.hidden = false;
+      positionMenu();
       trigger.setAttribute("aria-expanded", "true");
+      scrollParent = wrap.closest(".af-tabbar");
+      scrollParent?.addEventListener("scroll", positionMenu, { passive: true });
+      window.addEventListener("resize", positionMenu);
       document.addEventListener("mousedown", onDocMouseDown);
       document.addEventListener("keydown", onKeyDown, true);
     };

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "b8b009016aaf";
+const VERSION = "cf6c052286c1";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -234,6 +234,66 @@ async function createTerminalTab(page: Page): Promise<void> {
   await expect(menu).toBeHidden();
 }
 
+interface ElementBox {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** Waits for an open new-tab menu to settle, then proves it is pixels the user can
+ *  actually click — not merely a non-hidden box clipped by an ancestor's overflow.
+ *  Two identical geometry samples avoid accepting a transition's in-flight frame. */
+async function settledHitTestableTabMenu(
+  page: Page,
+  menu: Locator,
+  trigger: Locator,
+): Promise<{ menu: ElementBox; trigger: ElementBox }> {
+  let previous = "";
+  let settled: { menu: ElementBox; trigger: ElementBox } | null = null;
+  await expect
+    .poll(
+      async () => {
+        const menuBox = await menu.boundingBox();
+        const triggerBox = await trigger.boundingBox();
+        const itemBox = await menu.locator(".af-tab-menu-item").first().boundingBox();
+        const viewport = page.viewportSize();
+        if (!menuBox || !triggerBox || !itemBox || !viewport) {
+          return false;
+        }
+        const geometry = [menuBox, triggerBox]
+          .flatMap((box) => [box.x, box.y, box.width, box.height])
+          .map((value) => value.toFixed(2))
+          .join(":");
+        const stable = geometry === previous;
+        previous = geometry;
+        const insideViewport =
+          menuBox.x >= 0 &&
+          menuBox.y >= 0 &&
+          menuBox.x + menuBox.width <= viewport.width &&
+          menuBox.y + menuBox.height <= viewport.height;
+        const hitTestable = await page.evaluate(
+          ({ x, y }) => {
+            const hit = document.elementFromPoint(x, y);
+            return hit instanceof Element && hit.closest(".af-tab-menu-item") !== null;
+          },
+          { x: itemBox.x + itemBox.width / 2, y: itemBox.y + itemBox.height / 2 },
+        );
+        if (stable && insideViewport && hitTestable) {
+          settled = { menu: menuBox, trigger: triggerBox };
+          return true;
+        }
+        return false;
+      },
+      { message: "the settled new-tab menu must be inside the viewport and receive pointer hits", timeout: 5_000 },
+    )
+    .toBe(true);
+  if (!settled) {
+    throw new Error("new-tab menu geometry did not settle");
+  }
+  return settled;
+}
+
 /**
  * Dispatches a drop carrying a HAND-CRAFTED drag payload ({index, tabs}) onto the
  * (single) current pane — bypassing the real tab buttons so a stale / out-of-range /
@@ -4038,6 +4098,52 @@ test("dismissing the install affordance sticks across reloads — it must never 
   await fireInstallOffer(p);
   await expect(p.locator(".af-install")).toBeHidden();
   await ctx.close();
+});
+
+test("new-tab menu (#2219): stays visible, hit-testable, and anchored while the tab bar scrolls", async () => {
+  // The seeded reorder session has enough real tabs to overflow a phone-width bar.
+  // Select its project explicitly: after a worker restart the daemon's most-recent
+  // project can be the task-only fixture, and this regression must not inherit that.
+  await page.setViewportSize({ width: 1280, height: 720 });
+  if ((await page.locator(".af-project-switch-name").textContent()) !== "mock-repo") {
+    await page.locator(".af-project-switch").click();
+    await projectItem(page, "mock-repo").click();
+  }
+  await expect(page.locator(".af-project-switch-name")).toHaveText("mock-repo");
+  await row(page, SESSION_ORDER).click();
+  await expect(page.locator(".af-main.af-main-term")).toBeVisible();
+  await page.setViewportSize({ width: 375, height: 700 });
+
+  const tabbar = page.locator(".af-tabbar");
+  await expect
+    .poll(() => tabbar.evaluate((bar) => bar.scrollWidth > bar.clientWidth), {
+      message: "the real four-tab roster must overflow the narrow tab bar",
+    })
+    .toBe(true);
+  const trigger = tabbar.locator(".af-tab-new");
+  await trigger.click();
+  const menu = tabbar.locator(".af-tab-menu");
+  await expect(menu).toBeVisible();
+  const before = await settledHitTestableTabMenu(page, menu, trigger);
+
+  // Playwright scrolls the end-of-row trigger fully into view before clicking it.
+  // Move the bar back a few pixels with the menu OPEN: both the caret and its fixed
+  // menu should move together, while the menu remains clickable and in the viewport.
+  const scroll = await tabbar.evaluate((bar) => {
+    const before = bar.scrollLeft;
+    bar.scrollLeft = Math.max(0, before - 4);
+    return { before, after: bar.scrollLeft };
+  });
+  expect(scroll.after, "the overflow fixture must permit a real horizontal scroll").toBeLessThan(scroll.before);
+  const after = await settledHitTestableTabMenu(page, menu, trigger);
+  const triggerShift = after.trigger.x - before.trigger.x;
+  const menuShift = after.menu.x - before.menu.x;
+  expect(Math.abs(menuShift - triggerShift), "the menu must track the caret's horizontal scroll").toBeLessThan(1);
+  expect(Math.abs(after.menu.x + after.menu.width - (after.trigger.x + after.trigger.width))).toBeLessThan(1);
+
+  await page.keyboard.press("Escape");
+  await expect(menu).toBeHidden();
+  await page.setViewportSize({ width: 1280, height: 720 });
 });
 
 test("vscode tab (#2077): the labelled New tab menu creates a VS Code tab and serves it through the proxy", async () => {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1332,8 +1332,8 @@ body {
   background: var(--af-danger-subtle);
 }
 
-/* The labelled new-tab control and its kind menu. The wrap is the positioning
-   context the absolutely-placed menu hangs from. */
+/* The labelled new-tab control and its kind menu. The wrap keeps their lifecycle and
+   outside-click boundary together; the menu itself uses viewport coordinates below. */
 .af-tab-new-wrap {
   position: relative;
   display: inline-flex;
@@ -1341,12 +1341,12 @@ body {
 }
 
 /* The new-tab menu (Terminal / VS Code). Mirrors .af-project-menu's chrome so the two
-   dropdowns read as one component, but hangs from the LEFT: the + sits at the
-   start of the free space after the tabs, so a right-anchored menu would drift
-   away from its button as the tab count changes. */
+   dropdowns read as one component. Fixed positioning deliberately escapes the tab
+   bar's overflow clip; ui.ts aligns its right edge to the caret and recomputes the
+   viewport coordinates whenever the horizontal tab bar scrolls. */
 .af-tab-menu {
-  position: absolute;
-  top: calc(100% + 6px);
+  position: fixed;
+  top: 0;
   left: 0;
   min-width: 9rem;
   background: var(--af-bg-raised);

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -1333,11 +1333,28 @@ export class AppShell {
     menu.setAttribute("aria-label", "Tab type");
     menu.hidden = true;
 
+    let scrollParent: HTMLElement | null = null;
+    const positionMenu = (): void => {
+      // The menu is fixed so the tab bar's horizontal overflow cannot clip it. Anchor
+      // its right edge to the trigger's caret, then keep the whole box in the viewport.
+      const anchor = trigger.getBoundingClientRect();
+      const menuBox = menu.getBoundingClientRect();
+      const maxLeft = Math.max(0, window.innerWidth - menuBox.width);
+      const left = Math.min(Math.max(0, anchor.right - menuBox.width), maxLeft);
+      const below = anchor.bottom + 6;
+      const above = anchor.top - menuBox.height - 6;
+      const top = below + menuBox.height <= window.innerHeight ? below : Math.max(0, above);
+      menu.style.left = `${left}px`;
+      menu.style.top = `${top}px`;
+    };
     const close = (): void => {
       menu.hidden = true;
       trigger.setAttribute("aria-expanded", "false");
       document.removeEventListener("mousedown", onDocMouseDown);
       document.removeEventListener("keydown", onKeyDown, true);
+      scrollParent?.removeEventListener("scroll", positionMenu);
+      scrollParent = null;
+      window.removeEventListener("resize", positionMenu);
     };
     const onDocMouseDown = (e: MouseEvent): void => {
       // A rerender can detach this control while the menu is open; closing on a
@@ -1359,7 +1376,11 @@ export class AppShell {
     };
     const open = (): void => {
       menu.hidden = false;
+      positionMenu();
       trigger.setAttribute("aria-expanded", "true");
+      scrollParent = wrap.closest<HTMLElement>(".af-tabbar");
+      scrollParent?.addEventListener("scroll", positionMenu, { passive: true });
+      window.addEventListener("resize", positionMenu);
       document.addEventListener("mousedown", onDocMouseDown);
       // CAPTURE phase, deliberately. The app's own keydown handler is a
       // capture-phase listener on document that stopPropagation()s Escape (so


### PR DESCRIPTION
## Summary

- render the new-tab menu as a viewport-fixed popover, escaping the tab bar's overflow clip without changing the tab row's scrolling or drag-reorder containing block
- keep the menu right-aligned to the caret, clamp/flip it within the viewport, and recompute its coordinates while the tab bar scrolls or the window resizes
- add a browser regression that waits for settled geometry, proves the menu is visible and hit-testable inside the viewport, and verifies the caret/menu stay anchored during horizontal scrolling

## Why this approach

`.af-tabbar` needs both `overflow-x: auto` for long tab rows and `position: relative` for #1813's drag insertion marker. A fixed-position menu is the smallest lifecycle change that escapes that containing block's computed vertical overflow clipping while preserving those behaviors and the existing DOM ownership, outside-click handling, keyboard behavior, and ARIA state.

## Popover audit

I audited the other absolute-positioned UI layers against their containing blocks. The project and status-filter menus live in non-scrolling wrappers; the tab insertion marker and pane drop overlay are intentionally clipped to their local surfaces; and the mobile rail/scrim are layout layers rather than popovers. The new-tab menu was the only latent popover/scroll-container collision found.

## Verification

Rendered and inspected the committed bundle in light desktop and dark 375px layouts. The menu was visible and pointer-hit-testable; after scrolling the overflowing tab row, the caret and menu moved by the same 4px and retained right-edge alignment.

All gates passed after the final commit was pushed, against `5cf9d27a98d2ddf691b7056352d5786587e8e0e7`:

- `make web-build`
- `make web-test` (399 passed)
- `make web-selftest-container` (104 passed)
- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`

Fixes #2219.

— Captain Claude
