### PR TITLE
fix(web): use a funnel for session filters

### DIFF
--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -638,7 +638,11 @@ body {
   border-color: var(--af-accent);
 }
 .af-rail-filter-glyph {
-  font-size: 0.9em;
+  display: block;
+  width: 0.875rem;
+  height: 0.875rem;
+  flex: 0 0 auto;
+  fill: currentColor;
 }
 .af-rail-filter-dot {
   width: 4px;

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -10504,8 +10504,14 @@ var AppShell = class {
     this.railCount = h2("span", { class: "af-rail-count" }, "0");
     const newBtn = h2("button", { type: "button", class: "af-rail-new", title: "New session" }, "+ New");
     newBtn.addEventListener("click", () => this.actions.newSession());
-    const filterGlyph = h2("span", { class: "af-rail-filter-glyph" }, "\u25A4");
+    const filterGlyph = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    filterGlyph.classList.add("af-rail-filter-glyph");
+    filterGlyph.setAttribute("viewBox", "0 0 16 16");
     filterGlyph.setAttribute("aria-hidden", "true");
+    filterGlyph.setAttribute("focusable", "false");
+    const filterGlyphPath = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    filterGlyphPath.setAttribute("d", "M2 2h12L9.5 8v4.5L6.5 14V8L2 2Z");
+    filterGlyph.append(filterGlyphPath);
     this.filterDot = h2("span", { class: "af-rail-filter-dot" });
     this.filterDot.setAttribute("aria-hidden", "true");
     this.filterBtn = h2("button", { type: "button", class: "af-rail-filter" }, filterGlyph, this.filterDot);

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "cf6c052286c1";
+const VERSION = "13862272a0e1";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -803,7 +803,11 @@ body {
 }
 
 .af-rail-filter-glyph {
-  font-size: 0.9em;
+  display: block;
+  width: 0.875rem;
+  height: 0.875rem;
+  flex: 0 0 auto;
+  fill: currentColor;
 }
 
 /* A static 4px dot — the #1766 rule: state reads from a static glyph, never motion. */

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -778,12 +778,19 @@ export class AppShell {
     const newBtn = h("button", { type: "button", class: "af-rail-new", title: "New session" }, "+ New");
     newBtn.addEventListener("click", () => this.actions.newSession());
 
-    // The status filter (feat: hide archived by default). A small ▤ glyph button
-    // rather than a word, so the rail head still fits the count + New at 18rem; the
-    // dot beside it lights only when the filter is NARROWED from the default, so the
-    // normal state (archived hidden) never nags.
-    const filterGlyph = h("span", { class: "af-rail-filter-glyph" }, "▤");
+    // The status filter (feat: hide archived by default). A small funnel mark rather
+    // than a word, so the rail head still fits the count + New at 18rem; the dot beside
+    // it lights only when the filter is NARROWED from the default, so the normal state
+    // (archived hidden) never nags. This is deliberately an inline SVG: Unicode has no
+    // consistently rendered funnel, while currentColor preserves every button state.
+    const filterGlyph = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    filterGlyph.classList.add("af-rail-filter-glyph");
+    filterGlyph.setAttribute("viewBox", "0 0 16 16");
     filterGlyph.setAttribute("aria-hidden", "true");
+    filterGlyph.setAttribute("focusable", "false");
+    const filterGlyphPath = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    filterGlyphPath.setAttribute("d", "M2 2h12L9.5 8v4.5L6.5 14V8L2 2Z");
+    filterGlyph.append(filterGlyphPath);
     this.filterDot = h("span", { class: "af-rail-filter-dot" });
     this.filterDot.setAttribute("aria-hidden", "true");
     this.filterBtn = h("button", { type: "button", class: "af-rail-filter" }, filterGlyph, this.filterDot);


### PR DESCRIPTION
## Summary

- replace the rail's ambiguous `▤` mark with a compact filled funnel at the control's actual 14px size
- use `currentColor` so the mark inherits light/dark theme colors and the existing narrowed/active state
- preserve the quiet button, status dot, narrowed class, accessible label, and all filter behavior; rebuild the committed bundle

## Mark choice

This deliberately introduces the first UI-level inline SVG in af. The UI has no icon system, and Unicode offers no funnel that renders reliably across platform fonts. A simple filled silhouette stays crisp at 14px where a thin funnel outline turns into a grey smudge. The SVG is decorative and hidden from accessibility APIs; the button's existing accessible name remains authoritative.

## Verification

Rendered and inspected the committed bundle in all eight combinations of light/dark, default/narrowed, and desktop/compressed 320px rail layouts. The funnel rendered at 14×14px, remained quiet inside the existing 24px desktop / 36px narrow control, and its fill matched inherited text/state color in every case. The existing selftests locate the control and state by class rather than glyph text.

After #2221 merged, this branch was rebased and `web/dist` was regenerated from source rather than hand-merged. All gates then passed again against the final pushed SHA `7e0393797b2dd67de9a828d78b0a88c818c395ff`:

- `make web-build`
- `make web-test` (399 passed)
- `make web-selftest-container` (104 passed, including #2219's rendered-menu regression)
- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`

— Captain Claude