### PR TITLE
fix(config-agent): confirm Codex briefing turn

### DIFF
--- a/daemon/configagent.go
+++ b/daemon/configagent.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 	"github.com/sachiniyer/agent-factory/task"
 )
@@ -41,6 +43,13 @@ const configAgentSessionPrefix = "af-config-"
 // two config agents CAN legitimately be asked for in one daemon lifetime (the
 // user closes one and presses C again).
 var configAgentSeq atomic.Uint64
+
+// configAgentPromptReceiptTimeout bounds the receiver-side acknowledgement
+// after tmux submission. Codex writes its user turn locally before model work
+// begins, so this is startup I/O, not an API-response budget. A missing receipt
+// closes and fails the config agent instead of attaching the user to an empty
+// composer (#2220). A var keeps the deliberate-drop regression fast.
+var configAgentPromptReceiptTimeout = 5 * time.Second
 
 // configAgentSupervisor owns every bare tmux session this daemon spawned for a
 // config agent, so none can outlive its use.
@@ -188,6 +197,14 @@ func (m *Manager) SpawnConfigAgent(ctx context.Context, req SpawnConfigAgentRequ
 	if req.Program == "" {
 		return "", "", fmt.Errorf("config agent: no program to run")
 	}
+	// Detect before launch so the Codex rollout snapshot below is taken before
+	// the process can create its conversation file. The command the pane actually
+	// runs remains the source of truth, matching regular sessions (#1116/#1131).
+	agent := tmux.DetectAgentFromCommand(req.Program)
+	var promptReceipt session.ConversationCaptureSnapshot
+	if agent == tmux.ProgramCodex && req.Prompt != "" {
+		promptReceipt = session.BeginConversationCapture()
+	}
 	home, err := config.GetConfigDir()
 	if err != nil {
 		return "", "", fmt.Errorf("config agent: cannot resolve the agent-factory home: %w", err)
@@ -237,11 +254,6 @@ func (m *Manager) SpawnConfigAgent(ctx context.Context, req SpawnConfigAgentRequ
 		socketPath = ""
 	}
 
-	// The agent the pane ACTUALLY runs, detected from the command — so an
-	// override pointing "claude" at something else gets that program's readiness
-	// heuristic and trust-prompt handling, not claude's (#1116, #1131).
-	agent := tmux.DetectAgentFromCommand(req.Program)
-
 	if err := task.WaitForReadyOn(ctx, tmuxReadinessTarget{ts: ts, agent: agent}); err != nil {
 		return fail(fmt.Errorf("config agent: %w", err))
 	}
@@ -255,6 +267,19 @@ func (m *Manager) SpawnConfigAgent(ctx context.Context, req SpawnConfigAgentRequ
 	if req.Prompt != "" {
 		if err := ts.SendKeysCommand(req.Prompt); err != nil {
 			return fail(fmt.Errorf("config agent: failed to deliver the briefing: %w", err))
+		}
+		// A successful tmux send is not a delivery receipt. In the #2220
+		// reproduction every load/paste/Enter command succeeded against Codex's
+		// directory-trust modal; Enter merely selected "Yes", Codex opened a bare
+		// composer, and the briefing never became a user turn. Codex's rollout is
+		// the receiver-owned boundary: do not report "started" until that exact
+		// prompt is recorded there. Pane pixels cannot substitute — real Codex
+		// renders the same `› [Pasted Content …]` for both a pending paste and a
+		// submitted user message.
+		if agent == tmux.ProgramCodex {
+			if err := session.WaitForPromptReceipt(ctx, agent, promptReceipt, req.Prompt, configAgentPromptReceiptTimeout); err != nil {
+				return fail(fmt.Errorf("config agent: could not verify that Codex accepted the briefing as a turn; the uncertain session was closed: %w", err))
+			}
 		}
 	}
 	log.InfoLog.Printf("config agent: started %s in %s on socket %q (agent %q)", sessionName, home, socketPath, agent)

--- a/daemon/configagent_codex_real_test.go
+++ b/daemon/configagent_codex_real_test.go
@@ -1,0 +1,135 @@
+package daemon_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/configagent"
+	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+)
+
+const realCodexConfigAgentSentinel = "AF_CONFIG_AGENT_2220_BRIEFING_SUBMITTED"
+
+// TestRealCodexConfigAgentSubmitsBriefing is an opt-in receiver-level gate for
+// #2220. It is not part of the hermetic suite because it needs an authenticated
+// real Codex binary. Run it only in the testbox with throwaway AF and Codex
+// homes; AF_REAL_CODEX_BIN names the binary mounted into that container.
+//
+// The assertion reads Codex's own rollout, not af's send return. A matching
+// user message can only exist after Codex accepted the composer as a turn, which
+// is the distinction the production failure exposed. The immediate pane capture
+// is logged as the other half of the diagnosis: on the failure it shows whether
+// the briefing is still sitting in the composer after Spawn reported success.
+func TestRealCodexConfigAgentSubmitsBriefing(t *testing.T) {
+	if os.Getenv("AF_REAL_CODEX_CONFIG_AGENT") != "1" {
+		t.Skip("set AF_REAL_CODEX_CONFIG_AGENT=1 inside the isolated Codex testbox")
+	}
+	codexBin := strings.TrimSpace(os.Getenv("AF_REAL_CODEX_BIN"))
+	if codexBin == "" {
+		t.Fatal("AF_REAL_CODEX_BIN must name the real Codex binary in the container")
+	}
+	if _, err := os.Stat(codexBin); err != nil {
+		t.Fatalf("real Codex binary: %v", err)
+	}
+	codexHome := strings.TrimSpace(os.Getenv("CODEX_HOME"))
+	if codexHome == "" {
+		t.Fatal("CODEX_HOME must be a throwaway directory in the container")
+	}
+
+	testguard.IsolateTmux(t)
+	afHome := testguard.SocketTempDir(t)
+	t.Setenv("AGENT_FACTORY_HOME", afHome)
+	if os.Getenv("AF_REAL_CODEX_PRETRUST") == "1" {
+		trustedProject := fmt.Sprintf("[projects.%q]\ntrust_level = \"trusted\"\n", afHome)
+		if err := os.WriteFile(filepath.Join(codexHome, "config.toml"), []byte(trustedProject), 0600); err != nil {
+			t.Fatalf("pre-trust disposable AF home: %v", err)
+		}
+	}
+
+	cfg := config.DefaultConfig()
+	manager, err := daemon.NewManager(cfg)
+	if err != nil {
+		t.Fatalf("construct manager: %v", err)
+	}
+	prompt := configagent.BuildBriefing(
+		configagent.ModeOnboard,
+		cfg,
+		filepath.Join(afHome, config.ConfigFileName),
+	) + "\n\n" + realCodexConfigAgentSentinel
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	sessionName, _, err := manager.SpawnConfigAgent(ctx, daemon.SpawnConfigAgentRequest{
+		Program: codexBin,
+		Prompt:  prompt,
+	})
+	if err != nil {
+		t.Fatalf("spawn real Codex config agent: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := manager.ReapConfigAgent(daemon.ReapConfigAgentRequest{SessionName: sessionName}); err != nil {
+			t.Errorf("reap real Codex config agent: %v", err)
+		}
+	})
+
+	immediate := captureConfigAgentPane(t, sessionName)
+	t.Logf("pane immediately after Spawn returned:\n%s", immediate)
+
+	rollouts := filepath.Join(codexHome, "sessions")
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		found, scanErr := treeContains(rollouts, realCodexConfigAgentSentinel)
+		if scanErr != nil {
+			t.Fatalf("scan Codex rollouts: %v", scanErr)
+		}
+		if found {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	t.Fatalf("Spawn returned success but Codex recorded no user turn containing the briefing sentinel; final pane:\n%s",
+		captureConfigAgentPane(t, sessionName))
+}
+
+func captureConfigAgentPane(t *testing.T, sessionName string) string {
+	t.Helper()
+	cmd := exec.Command("tmux", "capture-pane", "-p", "-J", "-S", "-", "-t", fmt.Sprintf("=%s:", sessionName))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("capture config-agent pane: %v: %s", err, out)
+	}
+	return string(out)
+}
+
+func treeContains(root, needle string) (bool, error) {
+	found := false
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || found {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		found = strings.Contains(string(data), needle)
+		return nil
+	})
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+	return found, err
+}

--- a/daemon/configagent_delivery_test.go
+++ b/daemon/configagent_delivery_test.go
@@ -1,0 +1,265 @@
+package daemon
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/term"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+)
+
+const (
+	configAgentCodexFixtureEnv      = "AF_CONFIG_AGENT_CODEX_FIXTURE"
+	configAgentCodexFixtureModeEnv  = "AF_CONFIG_AGENT_CODEX_FIXTURE_MODE"
+	configAgentCodexFixtureSentinel = "AF_CONFIG_AGENT_2220_RECEIVER_SENTINEL"
+)
+
+// TestConfigAgentCodexFixtureProcess is re-exec'd through a symlink named
+// "codex" by the two tests below. It models the real Codex 0.144.6 terminal
+// contract at the byte boundary af drives:
+//
+//   - the new directory-trust modal contains a selected `› 1. Yes` row;
+//   - bracketed paste is enabled, but pasted data is ignored while that modal is
+//     active;
+//   - Enter accepts trust and reveals the composer;
+//   - only a bracketed paste followed by Enter at the composer creates a Codex
+//     rollout user_message event.
+//
+// The rollout is the receiver acknowledgement. Pane content is deliberately
+// not the oracle: real Codex renders `› [Pasted Content …]` both for a pending
+// composer paste and for a submitted user message (#2220).
+func TestConfigAgentCodexFixtureProcess(t *testing.T) {
+	if os.Getenv(configAgentCodexFixtureEnv) != "1" {
+		t.Skip("Codex terminal fixture; re-exec'd by config-agent delivery tests")
+	}
+	if err := runConfigAgentCodexFixture(os.Getenv(configAgentCodexFixtureModeEnv)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestConfigAgentCodexTrustModalSubmitsBriefing(t *testing.T) {
+	testguard.IsolateTmux(t)
+	manager, program, rollout := newConfigAgentCodexFixture(t, "accept")
+
+	prompt := strings.Repeat("config-agent briefing line\n", 256) + configAgentCodexFixtureSentinel
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	sessionName, _, err := manager.SpawnConfigAgent(ctx, SpawnConfigAgentRequest{
+		Program: program,
+		Prompt:  prompt,
+	})
+	if err != nil {
+		data, _ := os.ReadFile(rollout)
+		t.Fatalf("config-agent spawn: %v\nreceiver rollout:\n%s", err, data)
+	}
+	t.Cleanup(func() {
+		if err := manager.ReapConfigAgent(ReapConfigAgentRequest{SessionName: sessionName}); err != nil {
+			t.Errorf("reap config-agent fixture: %v", err)
+		}
+	})
+
+	data, err := os.ReadFile(rollout)
+	if err != nil {
+		t.Fatalf("read fake Codex rollout: %v", err)
+	}
+	if !strings.Contains(string(data), configAgentCodexFixtureSentinel) {
+		t.Fatalf("Spawn reported success without a receiver-side Codex user turn; rollout:\n%s", data)
+	}
+}
+
+func TestConfigAgentCodexMissingReceiptFailsSpawn(t *testing.T) {
+	testguard.IsolateTmux(t)
+	manager, program, _ := newConfigAgentCodexFixture(t, "drop")
+
+	oldTimeout := configAgentPromptReceiptTimeout
+	configAgentPromptReceiptTimeout = 250 * time.Millisecond
+	t.Cleanup(func() { configAgentPromptReceiptTimeout = oldTimeout })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	sessionName, _, err := manager.SpawnConfigAgent(ctx, SpawnConfigAgentRequest{
+		Program: program,
+		Prompt:  "briefing deliberately dropped by receiver",
+	})
+	if err == nil {
+		if sessionName != "" {
+			_ = manager.ReapConfigAgent(ReapConfigAgentRequest{SessionName: sessionName})
+		}
+		t.Fatal("a config agent whose receiver recorded no briefing turn reported success")
+	}
+	if !strings.Contains(err.Error(), "could not verify that Codex accepted the briefing") {
+		t.Fatalf("missing receiver receipt returned an unactionable error: %v", err)
+	}
+}
+
+func newConfigAgentCodexFixture(t *testing.T, mode string) (*Manager, string, string) {
+	t.Helper()
+	afHome := testguard.SocketTempDir(t)
+	codexHome := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", afHome)
+	t.Setenv("CODEX_HOME", codexHome)
+	t.Setenv(configAgentCodexFixtureEnv, "1")
+	t.Setenv(configAgentCodexFixtureModeEnv, mode)
+
+	binDir := testguard.SocketTempDir(t)
+	codexBin := filepath.Join(binDir, "codex")
+	if err := os.Symlink(os.Args[0], codexBin); err != nil {
+		t.Fatalf("symlink Codex fixture: %v", err)
+	}
+	program := codexBin + " -test.run=^TestConfigAgentCodexFixtureProcess$"
+
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("construct manager: %v", err)
+	}
+	return manager, program, configAgentCodexFixtureRollout(codexHome)
+}
+
+func configAgentCodexFixtureRollout(codexHome string) string {
+	return filepath.Join(
+		codexHome,
+		"sessions", "2026", "07", "20",
+		"rollout-2026-07-20T12-00-00-019f386f-7206-7fc2-803b-f7045e07a242.jsonl",
+	)
+}
+
+func runConfigAgentCodexFixture(mode string) error {
+	rollout := configAgentCodexFixtureRollout(os.Getenv("CODEX_HOME"))
+	if err := os.MkdirAll(filepath.Dir(rollout), 0755); err != nil {
+		return fmt.Errorf("create fake Codex sessions dir: %w", err)
+	}
+	if err := os.WriteFile(rollout, []byte(`{"type":"session_meta"}`+"\n"), 0600); err != nil {
+		return fmt.Errorf("create fake Codex rollout: %w", err)
+	}
+
+	oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
+	if err != nil {
+		return fmt.Errorf("put fake Codex tty in raw mode: %w", err)
+	}
+	defer func() { _ = term.Restore(int(os.Stdin.Fd()), oldState) }()
+
+	// Request bracketed-paste mode before drawing the marker. tmux has processed
+	// the DECSET by the time the trust text is capturable, so every test paste is
+	// framed exactly as it is for real Codex.
+	fmt.Print("\x1b[?2004h")
+	drawConfigAgentCodexTrust()
+
+	reader := bufio.NewReader(os.Stdin)
+	phase := "trust"
+	var draft strings.Builder
+	for {
+		b, readErr := reader.ReadByte()
+		if readErr != nil {
+			return readErr
+		}
+		if b == '\x1b' {
+			marker := make([]byte, 5)
+			if _, err := io.ReadFull(reader, marker); err != nil {
+				return err
+			}
+			switch string(marker) {
+			case "[200~":
+				pasted, err := readConfigAgentCodexPaste(reader)
+				if err != nil {
+					return err
+				}
+				if phase == "composer" {
+					draft.WriteString(pasted)
+				}
+			}
+			continue
+		}
+		switch b {
+		case 0x15: // C-u, af's pre-paste composer clear.
+			if phase == "composer" {
+				draft.Reset()
+			}
+		case '\r', '\n':
+			switch phase {
+			case "trust":
+				phase = "composer"
+				drawConfigAgentCodexComposer()
+			case "composer":
+				if mode == "drop" {
+					drawConfigAgentCodexComposer()
+					draft.Reset()
+					continue
+				}
+				if err := appendConfigAgentCodexUserTurn(rollout, draft.String()); err != nil {
+					return err
+				}
+				phase = "working"
+				fmt.Print("\x1b[2J\x1b[H› [Pasted Content]\r\n\r\n  esc to interrupt\r\n")
+			}
+		}
+	}
+}
+
+func readConfigAgentCodexPaste(reader *bufio.Reader) (string, error) {
+	var pasted strings.Builder
+	for {
+		b, err := reader.ReadByte()
+		if err != nil {
+			return "", err
+		}
+		if b != '\x1b' {
+			pasted.WriteByte(b)
+			continue
+		}
+		marker := make([]byte, 5)
+		if _, err := io.ReadFull(reader, marker); err != nil {
+			return "", err
+		}
+		if string(marker) == "[201~" {
+			return pasted.String(), nil
+		}
+		pasted.WriteByte(b)
+		pasted.Write(marker)
+	}
+}
+
+func drawConfigAgentCodexTrust() {
+	fmt.Print("\x1b[2J\x1b[H> You are in /tmp/throwaway-af-home\r\n\r\n" +
+		"  Do you trust the contents of this directory? Working with untrusted contents\r\n" +
+		"  comes with higher risk of prompt injection.\r\n\r\n" +
+		"› 1. Yes, continue\r\n" +
+		"  2. No, quit\r\n\r\n" +
+		"  Press enter to continue\r\n")
+}
+
+func drawConfigAgentCodexComposer() {
+	fmt.Print("\x1b[2J\x1b[H╭ OpenAI Codex (fixture) ╮\r\n\r\n› Use /skills to list available skills\r\n")
+}
+
+func appendConfigAgentCodexUserTurn(rollout, prompt string) error {
+	event := map[string]any{
+		"type": "event_msg",
+		"payload": map[string]any{
+			"type":    "user_message",
+			"message": prompt,
+		},
+	}
+	data, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+	f, err := os.OpenFile(rollout, os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if _, err := f.Write(append(data, '\n')); err != nil {
+		return err
+	}
+	return f.Sync()
+}

--- a/session/conversation_capture.go
+++ b/session/conversation_capture.go
@@ -1,6 +1,10 @@
 package session
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,6 +16,20 @@ import (
 )
 
 var codexRolloutFileRE = regexp.MustCompile(`(?i)^rollout-.+-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$`)
+
+var (
+	// ErrPromptReceiptUnavailable means the provider exposes no receiver-side
+	// acknowledgement af knows how to read. It is distinct from a missing
+	// receipt: unsupported is a capability question; not-observed means a
+	// provider that does expose receipts never recorded this prompt.
+	ErrPromptReceiptUnavailable = errors.New("prompt receipt unavailable")
+	// ErrPromptReceiptNotObserved means the receiver never recorded the prompt
+	// before the acknowledgement deadline. A tmux send returning nil does not
+	// override this observation (#2220).
+	ErrPromptReceiptNotObserved = errors.New("prompt receipt not observed")
+)
+
+const promptReceiptPollInterval = 50 * time.Millisecond
 
 // ConversationCaptureSnapshot records provider-local state before a pane is
 // spawned. It lets post-spawn capture identify a newly-created conversation
@@ -47,6 +65,60 @@ func CaptureAgentConversation(agent string, snap ConversationCaptureSnapshot, ti
 	}
 }
 
+// WaitForPromptReceipt waits for the agent's own durable conversation store to
+// record prompt as a user turn. This is deliberately receiver-side: successful
+// tmux load-buffer, paste-buffer and send-keys calls establish only that af's
+// input path did not error, not that a modal/composer accepted a turn (#2220).
+//
+// Codex is currently the only provider with a local receipt af can correlate to
+// a just-spawned process. Callers must take snap before spawning the pane. Other
+// providers return ErrPromptReceiptUnavailable rather than manufacturing an
+// acknowledgement from pane pixels.
+func WaitForPromptReceipt(
+	ctx context.Context,
+	agent string,
+	snap ConversationCaptureSnapshot,
+	prompt string,
+	timeout time.Duration,
+) error {
+	if agent != tmux.ProgramCodex {
+		return fmt.Errorf("%w for agent %q", ErrPromptReceiptUnavailable, agent)
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		received, err := codexPromptReceiptOnce(snap, prompt)
+		if err != nil {
+			return err
+		}
+		if received {
+			return nil
+		}
+		if timeout <= 0 || !time.Now().Before(deadline) {
+			return fmt.Errorf("%w in Codex rollout within %s", ErrPromptReceiptNotObserved, timeout)
+		}
+
+		wait := promptReceiptPollInterval
+		if remaining := time.Until(deadline); remaining < wait {
+			wait = remaining
+		}
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
 func codexHomeDir() string {
 	if home := strings.TrimSpace(os.Getenv("CODEX_HOME")); home != "" {
 		return home
@@ -72,6 +144,23 @@ func captureCodexConversation(snap ConversationCaptureSnapshot, timeout time.Dur
 }
 
 func captureCodexConversationOnce(snap ConversationCaptureSnapshot) (AgentConversationData, bool, error) {
+	candidates := newCodexRolloutFiles(snap)
+	switch len(candidates) {
+	case 0:
+		return AgentConversationData{}, true, nil
+	case 1:
+		return AgentConversationData{
+			Agent:       tmux.ProgramCodex,
+			ID:          codexConversationIDFromPath(candidates[0]),
+			CapturedAt:  time.Now(),
+			CaptureKind: ConversationCaptureCodexRollout,
+		}, false, nil
+	default:
+		return AgentConversationData{}, false, fmt.Errorf("codex conversation capture ambiguous: %d new rollout files appeared", len(candidates))
+	}
+}
+
+func newCodexRolloutFiles(snap ConversationCaptureSnapshot) []string {
 	after := codexRolloutFiles(snap.codexHome)
 	var candidates []string
 	for path := range after {
@@ -82,23 +171,108 @@ func captureCodexConversationOnce(snap ConversationCaptureSnapshot) (AgentConver
 		if err == nil && info.ModTime().Before(snap.startedAt.Add(-time.Second)) {
 			continue
 		}
-		if id := codexConversationIDFromPath(path); id != "" {
-			candidates = append(candidates, id)
+		candidates = append(candidates, path)
+	}
+	return candidates
+}
+
+func codexPromptReceiptOnce(snap ConversationCaptureSnapshot, prompt string) (bool, error) {
+	candidates := newCodexRolloutFiles(snap)
+	if len(candidates) == 0 {
+		return false, nil
+	}
+	matches := 0
+	for _, path := range candidates {
+		received, err := codexRolloutHasPrompt(path, prompt)
+		if err != nil {
+			return false, err
+		}
+		if received {
+			matches++
 		}
 	}
-	switch len(candidates) {
+	switch matches {
 	case 0:
-		return AgentConversationData{}, true, nil
+		// Another Codex process can create a rollout during this spawn. Do not
+		// fail merely because it exists: the exact briefing may appear in this
+		// config agent's rollout on the next poll.
+		return false, nil
 	case 1:
-		return AgentConversationData{
-			Agent:       tmux.ProgramCodex,
-			ID:          candidates[0],
-			CapturedAt:  time.Now(),
-			CaptureKind: ConversationCaptureCodexRollout,
-		}, false, nil
+		return true, nil
 	default:
-		return AgentConversationData{}, false, fmt.Errorf("codex conversation capture ambiguous: %d new rollout files appeared", len(candidates))
+		// Two new conversations recorded the exact same prompt, so af cannot
+		// prove which one belongs to this pane. Fail closed rather than let the
+		// other conversation acknowledge an unbriefed config agent.
+		return false, fmt.Errorf("codex prompt receipt ambiguous: %d new rollouts recorded the briefing", matches)
 	}
+}
+
+func codexRolloutHasPrompt(path, prompt string) (bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+	normalizedPrompt := normalizePromptReceiptText(prompt)
+	for _, line := range bytes.Split(data, []byte{'\n'}) {
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var event struct {
+			Type    string          `json:"type"`
+			Payload json.RawMessage `json:"payload"`
+		}
+		if err := json.Unmarshal(line, &event); err != nil {
+			// Codex appends JSONL while af polls it. A read can land between the
+			// write and newline of the newest event; an incomplete line is not a
+			// negative receipt and will be retried on the next poll.
+			continue
+		}
+		var payload struct {
+			Type string `json:"type"`
+			Role string `json:"role"`
+		}
+		if err := json.Unmarshal(event.Payload, &payload); err != nil {
+			continue
+		}
+		isUserTurn := event.Type == "event_msg" && payload.Type == "user_message"
+		isUserItem := event.Type == "response_item" && payload.Type == "message" && payload.Role == "user"
+		if !isUserTurn && !isUserItem {
+			continue
+		}
+		var value any
+		if err := json.Unmarshal(event.Payload, &value); err != nil {
+			continue
+		}
+		if jsonValueContainsPrompt(value, normalizedPrompt) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func jsonValueContainsPrompt(value any, prompt string) bool {
+	switch v := value.(type) {
+	case string:
+		return prompt != "" && strings.Contains(normalizePromptReceiptText(v), prompt)
+	case []any:
+		for _, item := range v {
+			if jsonValueContainsPrompt(item, prompt) {
+				return true
+			}
+		}
+	case map[string]any:
+		for _, item := range v {
+			if jsonValueContainsPrompt(item, prompt) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func normalizePromptReceiptText(text string) string {
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	return strings.ReplaceAll(text, "\r", "\n")
 }
 
 func codexRolloutFiles(codexHome string) map[string]struct{} {

--- a/session/conversation_capture_test.go
+++ b/session/conversation_capture_test.go
@@ -1,6 +1,9 @@
 package session
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -55,4 +58,90 @@ func TestCaptureAgentConversation_UnsupportedAgentGracefullyNoID(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, conv.HasID())
 	}
+}
+
+func appendCodexRolloutEvent(t *testing.T, path string, event any) {
+	t.Helper()
+	data, err := json.Marshal(event)
+	require.NoError(t, err)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0644)
+	require.NoError(t, err)
+	_, err = f.Write(append(data, '\n'))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+}
+
+func TestWaitForPromptReceipt_CodexUserMessage(t *testing.T) {
+	codexHome := t.TempDir()
+	t.Setenv("CODEX_HOME", codexHome)
+	snap := BeginConversationCapture()
+	path := writeCodexRolloutFile(t, codexHome, "rollout-2026-07-06T10-17-35-019f386f-7206-7fc2-803b-f7045e07a242.jsonl")
+
+	const prompt = "the exact config-agent briefing"
+	appendCodexRolloutEvent(t, path, map[string]any{
+		"type": "event_msg",
+		"payload": map[string]any{
+			"type":    "user_message",
+			"message": prompt,
+		},
+	})
+
+	require.NoError(t, WaitForPromptReceipt(context.Background(), tmux.ProgramCodex, snap, prompt, time.Second))
+}
+
+func TestWaitForPromptReceipt_SessionMetaIsNotAReceipt(t *testing.T) {
+	codexHome := t.TempDir()
+	t.Setenv("CODEX_HOME", codexHome)
+	snap := BeginConversationCapture()
+	writeCodexRolloutFile(t, codexHome, "rollout-2026-07-06T10-17-35-019f386f-7206-7fc2-803b-f7045e07a242.jsonl")
+
+	err := WaitForPromptReceipt(context.Background(), tmux.ProgramCodex, snap, "briefing never submitted", 0)
+	require.ErrorIs(t, err, ErrPromptReceiptNotObserved,
+		"a created Codex session is not proof that its composer accepted a user turn")
+}
+
+func TestWaitForPromptReceipt_DifferentUserTurnDoesNotConfirmBriefing(t *testing.T) {
+	codexHome := t.TempDir()
+	t.Setenv("CODEX_HOME", codexHome)
+	snap := BeginConversationCapture()
+	path := writeCodexRolloutFile(t, codexHome, "rollout-2026-07-06T10-17-35-019f386f-7206-7fc2-803b-f7045e07a242.jsonl")
+	appendCodexRolloutEvent(t, path, map[string]any{
+		"type": "response_item",
+		"payload": map[string]any{
+			"type": "message",
+			"role": "user",
+			"content": []map[string]any{{
+				"type": "input_text",
+				"text": "some other prompt",
+			}},
+		},
+	})
+
+	err := WaitForPromptReceipt(context.Background(), tmux.ProgramCodex, snap, "config briefing", 0)
+	require.ErrorIs(t, err, ErrPromptReceiptNotObserved,
+		"a concurrent/unrelated user turn must not acknowledge the config briefing")
+}
+
+func TestWaitForPromptReceipt_CorrelatesExactPromptAcrossConcurrentRollouts(t *testing.T) {
+	codexHome := t.TempDir()
+	t.Setenv("CODEX_HOME", codexHome)
+	snap := BeginConversationCapture()
+	other := writeCodexRolloutFile(t, codexHome, "rollout-2026-07-06T10-17-35-019f386f-7206-7fc2-803b-f7045e07a242.jsonl")
+	want := writeCodexRolloutFile(t, codexHome, "rollout-2026-07-06T10-17-36-029f386f-7206-7fc2-803b-f7045e07a243.jsonl")
+	appendCodexRolloutEvent(t, other, map[string]any{
+		"type":    "event_msg",
+		"payload": map[string]any{"type": "user_message", "message": "unrelated session"},
+	})
+	appendCodexRolloutEvent(t, want, map[string]any{
+		"type":    "event_msg",
+		"payload": map[string]any{"type": "user_message", "message": "config briefing"},
+	})
+
+	require.NoError(t, WaitForPromptReceipt(context.Background(), tmux.ProgramCodex, snap, "config briefing", 0),
+		"an unrelated concurrent rollout must not make an exact receiver receipt ambiguous")
+}
+
+func TestWaitForPromptReceipt_UnsupportedAgentDoesNotInventReceipt(t *testing.T) {
+	err := WaitForPromptReceipt(context.Background(), tmux.ProgramClaude, ConversationCaptureSnapshot{}, "briefing", 0)
+	require.True(t, errors.Is(err, ErrPromptReceiptUnavailable))
 }

--- a/session/tmux/doc_trust_prompt_test.go
+++ b/session/tmux/doc_trust_prompt_test.go
@@ -35,6 +35,16 @@ const aiderDocPhraseInOutput = `I read through the aider docs to answer your que
 The CLI prints "Open documentation url for more info" when it wants to open a
 link. Here is the summary you asked for, with no prompt waiting.`
 
+const codexDirectoryTrustDialog = `> You are in /tmp/af-home
+
+  Do you trust the contents of this directory? Working with untrusted contents
+  comes with higher risk of prompt injection.
+
+› 1. Yes, continue
+  2. No, quit
+
+  Press enter to continue`
+
 // runTrustPromptCheck drives CheckAndHandleTrustPrompt for a pane running
 // `program` and showing `content`, returning its verdict plus every tmux
 // command it issued.
@@ -61,6 +71,27 @@ func sentKeystrokes(cmds []string) []string {
 		}
 	}
 	return keys
+}
+
+func TestCheckAndHandleTrustPrompt_CodexDirectoryDialogIsDismissed(t *testing.T) {
+	handled, cmds := runTrustPromptCheck(t, ProgramCodex, codexDirectoryTrustDialog)
+	require.True(t, handled, "the observed Codex directory-trust dialog must be reported handled")
+	require.Contains(t, sentKeystrokes(cmds), "tmux send-keys -t =af_trust: Enter",
+		"the selected 'Yes, continue' option must be accepted before briefing delivery; got %v", cmds)
+}
+
+func TestCheckAndHandleTrustPrompt_CodexTrustProseAloneInjectsNothing(t *testing.T) {
+	fragments := []string{
+		"Do you trust the contents of this directory?",
+		"Do you trust the contents of this directory?\n› 1. Yes, continue",
+		"Yes, continue\n2. No, quit\nPress enter to continue",
+	}
+	for _, content := range fragments {
+		handled, cmds := runTrustPromptCheck(t, ProgramCodex, content)
+		require.False(t, handled, "a partial/modal prose fragment is not the anchored Codex dialog")
+		require.Empty(t, sentKeystrokes(cmds),
+			"a continuous live-session poll must not inject Enter from partial trust prose; got %v", cmds)
+	}
 }
 
 // The bug: ordinary agent output that happens to contain the documentation

--- a/session/tmux/start.go
+++ b/session/tmux/start.go
@@ -186,7 +186,8 @@ func (t *TmuxSession) CheckAndHandleTrustPrompt() bool {
 	// Key off the agent actually running in the pane, token-matched — a loose
 	// substring check would route e.g. /opt/claude-wrapper/run through the
 	// claude branch (#1116 defect class).
-	if DetectAgentFromCommand(t.programCmd()) == ProgramClaude {
+	switch DetectAgentFromCommand(t.programCmd()) {
+	case ProgramClaude:
 		if claudeTrustPromptPresent(content) {
 			if err := t.TapEnter(); err != nil {
 				log.ErrorLog.Printf("could not tap enter on trust/MCP screen: %v", err)
@@ -194,7 +195,15 @@ func (t *TmuxSession) CheckAndHandleTrustPrompt() bool {
 			}
 			return true
 		}
-	} else {
+	case ProgramCodex:
+		if CodexTrustPromptPresent(content) {
+			if err := t.TapEnter(); err != nil {
+				log.ErrorLog.Printf("could not tap enter on Codex directory-trust screen: %v", err)
+				return false
+			}
+			return true
+		}
+	default:
 		if DocTrustPromptPresent(content) {
 			if err := t.TapDAndEnter(); err != nil {
 				log.ErrorLog.Printf("could not tap enter on trust screen: %v", err)
@@ -204,6 +213,30 @@ func (t *TmuxSession) CheckAndHandleTrustPrompt() bool {
 		}
 	}
 	return false
+}
+
+// CodexTrustPromptPresent reports whether content shows Codex's directory-trust
+// modal introduced by 0.144.6:
+//
+//	Do you trust the contents of this directory?
+//	› 1. Yes, continue
+//	  2. No, quit
+//	Press enter to continue
+//
+// This modal is on the config-agent delivery path before the real composer.
+// Its selected option uses the SAME `›` glyph as Codex's composer, so the old
+// readiness check treated it as ready, pasted the briefing into the modal, and
+// used the trailing Enter to select Yes. Every tmux command succeeded while
+// Codex recorded no user turn, leaving an empty composer by attach time (#2220).
+//
+// The match is anchored on the question, both option labels and the affordance.
+// CheckAndHandleTrustPrompt also runs on live-session polls, so a prose mention
+// of one phrase must never inject Enter into a working agent.
+func CodexTrustPromptPresent(content string) bool {
+	return strings.Contains(content, "Do you trust the contents of this directory?") &&
+		strings.Contains(content, "Yes, continue") &&
+		strings.Contains(content, "No, quit") &&
+		strings.Contains(content, "Press enter to continue")
 }
 
 // DocTrustPromptPresent reports whether content shows the documentation-link

--- a/task/runner.go
+++ b/task/runner.go
@@ -164,12 +164,15 @@ func isReadyContent(content, agent string) bool {
 		// codex renders "›" (U+203A — distinct from claude's "❯" U+276F) as
 		// its input-prompt glyph after the banner (#714).
 		//
-		// The workspace-trust dialog ("Do you trust this folder") is
-		// deliberately NOT a ready signal (#729): there is no codex-specific
-		// dismissal in CheckAndHandleTrustPrompt, so treating it as ready let
-		// the next user prompt get typed into the dialog. Wait for the real
-		// "›" prompt instead.
-		return strings.Contains(content, "›")
+		// The older workspace-trust dialog ("Do you trust this folder") is
+		// deliberately NOT a ready signal (#729): af has no observed, anchored
+		// dismissal for it. Codex 0.144.6's newer directory-trust modal IS a
+		// readiness stop because tmux.CodexTrustPromptPresent positively
+		// identifies it and CheckAndHandleTrustPrompt dismisses it before any
+		// prompt can be sent (#2220). Its selected option also contains `›`, so
+		// name the handled case explicitly instead of pretending every glyph is
+		// necessarily the composer.
+		return tmux.CodexTrustPromptPresent(content) || strings.Contains(content, "›")
 	case tmux.ProgramAider:
 		// aider prints an "Aider v…" banner, then a line-start "> " prompt.
 		return strings.Contains(content, "\n> ") ||

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -86,6 +86,12 @@ func TestIsReadyContent(t *testing.T) {
 		// the dialog. Wait for the real "›" prompt. Regression from #714/#715.
 		{"codex trust folder prompt is not ready (#729)", "codex", "Do you trust this folder?\n> Yes", false},
 		{"codex trust dialog with later prompt is ready (#729)", "codex", "Do you trust this folder?\n› ", true},
+		{
+			name:    "codex directory trust modal is ready for anchored dismissal (#2220)",
+			agent:   "codex",
+			content: "Do you trust the contents of this directory?\n› 1. Yes, continue\n2. No, quit\nPress enter to continue",
+			want:    true,
+		},
 		// Codex must NOT be considered ready on claude's "❯" alone, and the
 		// banner box border ("╰") is not a codex ready signal by itself.
 		{"codex not ready on claude glyph", "codex", "rendering\n❯ ", false},


### PR DESCRIPTION
Fixes #2220.

## What happened

A real Codex 0.144.6 run in the isolated testbox reproduced the blank config agent from a fresh, throwaway `AGENT_FACTORY_HOME` and `CODEX_HOME`.

Codex was showing its newer directory-trust modal:

```
Do you trust the contents of this directory?
› 1. Yes, continue
  2. No, quit
Press enter to continue
```

The selected option uses the same `›` glyph as Codex's composer, so readiness stopped on the modal. The existing trust handler did not recognize this Codex dialog. af then ran its whole tmux send path against the modal; the trailing Enter selected “Yes,” every tmux command returned success, and Codex advanced to an empty composer. Its rollout contained `session_meta` but no briefing `user_message`.

This disproves the stranded-composer hypothesis for this reproduction. A pre-trusted control did submit the briefing, and its immediate pane still showed `› [Pasted Content …]`; pane pixels therefore cannot distinguish a pending paste from a submitted user turn. #2178 did not mask this instance—the receiver never recorded a composer turn in the first place.

## What changed

- Recognize the observed Codex trust modal with an anchored predicate and dismiss its selected “Yes, continue” option before briefing delivery.
- Snapshot Codex's rollout store before spawn and require the exact briefing to appear in a receiver-owned user-turn event after the tmux send.
- If that receipt is absent, unobservable, or ambiguous, reap the uncertain config-agent session and return a visible spawn error. The daemon's `config agent: started` log now remains behind that receipt.
- Add a raw-TTY Codex fixture that recreates the modal and a deliberate receiver-drop case, plus an opt-in authenticated real-Codex test.

Codex is the provider with a correlatable local receiver receipt today; the code returns “receipt unavailable” rather than inventing proof from pane contents for unsupported providers.

## Fail-first evidence

Before production changes, from the master-based checkout:

```
make test-container GOTESTARGS="./daemon -run 'TestConfigAgentCodex(TrustModalSubmitsBriefing|MissingReceiptFailsSpawn)' -v"
```

Both tests failed for the intended behavior: `Spawn` reported success with only `session_meta`, and it also reported success when the receiver deliberately recorded no briefing turn.

The authenticated Codex 0.144.6 test also failed before the fix with the trust modal captured immediately after `Spawn` and no briefing sentinel in any rollout. It passes after the fix with the full briefing recorded as a user turn and Codex already booting that turn.

## Validation

Pushed head: `f855b512b65f3524d9c5a9279e2d53bd67598dde`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- focused receiver/config-agent tests under `-race`
- authenticated Codex 0.144.6 container reproduction with throwaway homes

— Captain Claude