### PR TITLE
fix(web): show creating sessions immediately

### DIFF
--- a/daemon/control_server.go
+++ b/daemon/control_server.go
@@ -263,7 +263,6 @@ func (s *controlServer) createSession(ctx context.Context, req CreateSessionRequ
 		return err
 	}
 	resp.Instance = data
-	s.manager.publishEvent(agentproto.EventSessionCreated, data)
 	return nil
 }
 

--- a/daemon/create_projection_test.go
+++ b/daemon/create_projection_test.go
@@ -1,0 +1,182 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/agentproto"
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+type createCallResult struct {
+	resp CreateSessionResponse
+	err  error
+}
+
+// blockingCreateFactory stops inside NewInstance, the earliest slow boundary for
+// docker/ssh/hook provisioning. Seeing a row while this is blocked proves the
+// projection is daemon-owned and published before a concrete Instance exists.
+func blockingCreateFactory(
+	t *testing.T,
+	result session.Backend,
+	factoryErr error,
+) (<-chan session.InstanceOptions, func()) {
+	t.Helper()
+	entered := make(chan session.InstanceOptions, 1)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	unblock := func() { releaseOnce.Do(func() { close(release) }) }
+	t.Cleanup(unblock)
+	restore := session.SetBackendFactoryForTest(func(opts session.InstanceOptions, _ string) (session.Backend, error) {
+		entered <- opts
+		<-release
+		return result, factoryErr
+	})
+	t.Cleanup(restore)
+	return entered, unblock
+}
+
+func waitForCreateFactory(t *testing.T, entered <-chan session.InstanceOptions) session.InstanceOptions {
+	t.Helper()
+	select {
+	case opts := <-entered:
+		return opts
+	case <-time.After(3 * time.Second):
+		t.Fatal("create did not reach the blocked backend factory")
+		return session.InstanceOptions{}
+	}
+}
+
+func waitForCreateResult(t *testing.T, done <-chan createCallResult) createCallResult {
+	t.Helper()
+	select {
+	case result := <-done:
+		return result
+	case <-time.After(3 * time.Second):
+		t.Fatal("CreateSession did not return after the backend factory was released")
+		return createCallResult{}
+	}
+}
+
+func startCreateCall(cs *controlServer, req CreateSessionRequest) <-chan createCallResult {
+	done := make(chan createCallResult, 1)
+	go func() {
+		var resp CreateSessionResponse
+		err := cs.createSession(context.Background(), req, &resp)
+		done <- createCallResult{resp: resp, err: err}
+	}()
+	return done
+}
+
+func assertCreatingProjection(t *testing.T, got session.InstanceData, title, repoPath string) {
+	t.Helper()
+	if got.ID == "" {
+		t.Fatal("creating projection has no stable id")
+	}
+	if got.Title != title {
+		t.Fatalf("creating title = %q, want %q", got.Title, title)
+	}
+	if got.InFlightOp != session.OpCreating || got.Status != session.Loading {
+		t.Fatalf("creating state = (op %v, status %v), want (OpCreating, Loading)", got.InFlightOp, got.Status)
+	}
+	if got.Worktree.RepoPath != repoPath {
+		t.Fatalf("creating repo path = %q, want %q", got.Worktree.RepoPath, repoPath)
+	}
+}
+
+func TestCreateSessionPublishesAuthoritativeCreatingProjection(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	backend := session.NewFakeBackend()
+	backend.CompleteStart()
+	entered, unblock := blockingCreateFactory(t, readyFakeBackend{backend}, nil)
+	_, events := manager.events.subscribe()
+	done := startCreateCall(&controlServer{manager: manager}, CreateSessionRequest{
+		Title: "slow-create", RepoPath: repoPath, Program: "claude",
+	})
+	opts := waitForCreateFactory(t, entered)
+
+	pendingEvent := drainNextSessionEvent(t, events, agentproto.EventSessionUpdated)
+	assertCreatingProjection(t, pendingEvent, "slow-create", repoPath)
+	snapshot := manager.Snapshot(repo.ID)
+	if len(snapshot) != 1 {
+		t.Fatalf("Snapshot during create returned %d rows, want 1: %+v", len(snapshot), snapshot)
+	}
+	assertCreatingProjection(t, snapshot[0], "slow-create", repoPath)
+	if opts.ID != pendingEvent.ID || !opts.CreatedAt.Equal(pendingEvent.CreatedAt) {
+		t.Fatalf("constructor identity = (%q, %v), pending = (%q, %v)",
+			opts.ID, opts.CreatedAt, pendingEvent.ID, pendingEvent.CreatedAt)
+	}
+
+	unblock()
+	result := waitForCreateResult(t, done)
+	if result.err != nil {
+		t.Fatalf("CreateSession: %v", result.err)
+	}
+	if result.resp.Instance.ID != pendingEvent.ID || !result.resp.Instance.CreatedAt.Equal(pendingEvent.CreatedAt) {
+		t.Fatalf("completed identity = (%q, %v), pending = (%q, %v)",
+			result.resp.Instance.ID, result.resp.Instance.CreatedAt, pendingEvent.ID, pendingEvent.CreatedAt)
+	}
+	createdEvent := drainNextSessionEvent(t, events, agentproto.EventSessionCreated)
+	if createdEvent.ID != pendingEvent.ID || createdEvent.InFlightOp != session.OpNone {
+		t.Fatalf("created event did not settle pending identity: %+v", createdEvent)
+	}
+	settled := manager.Snapshot(repo.ID)
+	if len(settled) != 1 || settled[0].ID != pendingEvent.ID || settled[0].InFlightOp != session.OpNone {
+		t.Fatalf("settled Snapshot = %+v", settled)
+	}
+}
+
+func TestCreateSessionFailureRemovesCreatingProjection(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	backendErr := errors.New("slow provision failed with daemon detail")
+	entered, unblock := blockingCreateFactory(t, nil, backendErr)
+	_, events := manager.events.subscribe()
+	done := startCreateCall(&controlServer{manager: manager}, CreateSessionRequest{
+		Title: "failed-create", RepoPath: repoPath, Program: "claude",
+	})
+	waitForCreateFactory(t, entered)
+
+	pendingEvent := drainNextSessionEvent(t, events, agentproto.EventSessionUpdated)
+	assertCreatingProjection(t, pendingEvent, "failed-create", repoPath)
+	if got := manager.Snapshot(repo.ID); len(got) != 1 || got[0].ID != pendingEvent.ID {
+		t.Fatalf("Snapshot during failed create = %+v", got)
+	}
+
+	unblock()
+	result := waitForCreateResult(t, done)
+	if !errors.Is(result.err, backendErr) {
+		t.Fatalf("CreateSession error = %v, want daemon backend error %v", result.err, backendErr)
+	}
+	removedEvent := drainNextSessionEvent(t, events, agentproto.EventSessionKilled)
+	if removedEvent.ID != pendingEvent.ID || removedEvent.Title != pendingEvent.Title {
+		t.Fatalf("removal event = %+v, pending = %+v", removedEvent, pendingEvent)
+	}
+	if got := manager.Snapshot(repo.ID); len(got) != 0 {
+		t.Fatalf("failed create left a phantom Snapshot row: %+v", got)
+	}
+}

--- a/daemon/manager.go
+++ b/daemon/manager.go
@@ -26,9 +26,15 @@ type Manager struct {
 	ready     chan struct{}
 	readyOnce sync.Once
 
-	mu             sync.Mutex
-	storage        *session.Storage
-	instances      map[string]*session.Instance
+	mu        sync.Mutex
+	storage   *session.Storage
+	instances map[string]*session.Instance
+	// pendingCreates is the daemon-owned projection of creates that have passed
+	// admission but have not finished provisioning. It is intentionally separate
+	// from instances: a docker/ssh/hook backend may block inside NewInstance before
+	// a concrete Instance exists. Snapshot and the events plane expose these rows;
+	// mutation lookups do not, so a half-built runtime cannot be acted on.
+	pendingCreates map[string]session.InstanceData
 	reservedTitles map[string]struct{}
 	// reservedRemoteNames holds in-flight remote-hook slug reservations, keyed by
 	// the BARE slug — deliberately global, unlike every other name a session owns.
@@ -217,6 +223,7 @@ func newManagerShell(cfg *config.Config) (*Manager, error) {
 		ready:               make(chan struct{}),
 		storage:             storage,
 		instances:           make(map[string]*session.Instance),
+		pendingCreates:      make(map[string]session.InstanceData),
 		reservedTitles:      make(map[string]struct{}),
 		reservedRemoteNames: make(map[string]struct{}),
 		reservedTaskRuns:    make(map[string]int),
@@ -288,16 +295,17 @@ func (m *Manager) SaveInstances() error {
 
 // Snapshot returns the authoritative InstanceData for every session the manager
 // owns, scoped to repoID (all repos when repoID is empty). It is the read side
-// of the single-writer model (#960 PR 3): the manager's in-memory instance map
-// IS the source of truth, so the TUI mirrors this projection instead of
-// re-reading instances.json. Pure read — it copies the instance pointers under
-// m.mu, then serializes each via ToInstanceData (which takes the instance's own
-// lock) OUTSIDE m.mu so a slow serialize never blocks a concurrent mutation.
-// Results are ordered by (repo, title) key for a stable diff, so the TUI
-// reconcile does not repaint on map-iteration jitter.
+// of the single-writer model (#960 PR 3): the manager's settled instance map plus
+// its daemon-owned pending-create map ARE the source of truth, so clients mirror
+// this projection instead of re-reading instances.json or inventing optimistic
+// rows. Pure read — it copies the instance pointers/pending values under m.mu,
+// then serializes each Instance via ToInstanceData (which takes its own lock)
+// OUTSIDE m.mu so a slow serialize never blocks a concurrent mutation. Results
+// are ordered by (repo, title) key for a stable diff, so the TUI reconcile does
+// not repaint on map-iteration jitter.
 func (m *Manager) Snapshot(repoID string) []session.InstanceData {
 	m.mu.Lock()
-	keys := make([]string, 0, len(m.instances))
+	keys := make([]string, 0, len(m.instances)+len(m.pendingCreates))
 	for key := range m.instances {
 		if repoID != "" {
 			rid, _ := splitDaemonInstanceKey(key)
@@ -307,18 +315,42 @@ func (m *Manager) Snapshot(repoID string) []session.InstanceData {
 		}
 		keys = append(keys, key)
 	}
+	for key := range m.pendingCreates {
+		if _, settled := m.instances[key]; settled {
+			continue
+		}
+		if repoID != "" {
+			rid, _ := splitDaemonInstanceKey(key)
+			if rid != repoID {
+				continue
+			}
+		}
+		keys = append(keys, key)
+	}
 	sort.Strings(keys)
-	insts := make([]*session.Instance, 0, len(keys))
+	type snapshotEntry struct {
+		instance *session.Instance
+		pending  session.InstanceData
+	}
+	entries := make([]snapshotEntry, 0, len(keys))
 	for _, key := range keys {
 		if inst := m.instances[key]; inst != nil {
-			insts = append(insts, inst)
+			entries = append(entries, snapshotEntry{instance: inst})
+			continue
+		}
+		if pending, ok := m.pendingCreates[key]; ok {
+			entries = append(entries, snapshotEntry{pending: pending})
 		}
 	}
 	m.mu.Unlock()
 
-	data := make([]session.InstanceData, 0, len(insts))
-	for _, inst := range insts {
-		data = append(data, inst.ToInstanceData())
+	data := make([]session.InstanceData, 0, len(entries))
+	for _, entry := range entries {
+		if entry.instance != nil {
+			data = append(data, entry.instance.ToInstanceData())
+			continue
+		}
+		data = append(data, entry.pending)
 	}
 	return data
 }

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/sachiniyer/agent-factory/agentproto"
 	"github.com/sachiniyer/agent-factory/config"
@@ -56,11 +57,57 @@ func (m *Manager) CreateSession(ctx context.Context, req CreateSessionRequest) (
 		m.publishEvent(agentproto.EventSessionUpdated, *renamedArchived)
 	}
 
+	// Publish the daemon's real in-flight state before anything that can be slow:
+	// waiting behind another create in this repo, provisioning docker/ssh/hook in
+	// NewInstance, creating the local worktree, and waiting for agent readiness.
+	// A raw projection lives separately from m.instances because off-box runtime
+	// provisioning happens inside NewInstance — there may be no concrete Instance
+	// to register yet. It still carries the final stable id and creation time, which
+	// the completed Instance inherits below, so clients upsert rather than replacing
+	// one identity with another.
+	createdAt := time.Now()
+	pending := session.InstanceData{
+		ID:            session.NewInstanceID(),
+		TaskID:        req.TaskID,
+		Title:         title,
+		Path:          repo.Root,
+		Status:        session.Loading,
+		Liveness:      session.LiveReady,
+		InFlightOp:    session.OpCreating,
+		TaskRunActive: req.TaskID != "",
+		CreatedAt:     createdAt,
+		UpdatedAt:     createdAt,
+		AutoYes:       req.AutoYes,
+		Prompt:        req.Prompt,
+		Program:       req.Program,
+		Worktree:      session.GitWorktreeData{RepoPath: repo.Root},
+	}
+	key := daemonInstanceKey(repo.ID, title)
+	m.mu.Lock()
+	m.pendingCreates[key] = pending
+	m.mu.Unlock()
+	m.publishEvent(agentproto.EventSessionUpdated, pending)
+
+	createSucceeded := false
+	defer func() {
+		m.mu.Lock()
+		delete(m.pendingCreates, key)
+		m.mu.Unlock()
+		if !createSucceeded {
+			// Delete-class events are id-keyed, so a client removes exactly the
+			// provisional row even when another repo has the same title. A missed
+			// event is repaired by Snapshot, which no longer contains the pending row.
+			m.publishEvent(agentproto.EventSessionKilled, session.InstanceData{ID: pending.ID, Title: title})
+		}
+	}()
+
 	repoStartLock := m.startLockForRepo(repo.ID)
 	repoStartLock.Lock()
 	defer repoStartLock.Unlock()
 
 	instance, err := session.NewInstance(session.InstanceOptions{
+		ID:          pending.ID,
+		CreatedAt:   pending.CreatedAt,
 		Title:       title,
 		TaskID:      req.TaskID,
 		Path:        repo.Root,
@@ -137,7 +184,6 @@ func (m *Manager) CreateSession(ctx context.Context, req CreateSessionRequest) (
 	// not in memory would let refresh construct a duplicate Instance
 	// (opening a fresh PTY in the tmux backend) that gets orphaned when
 	// the original is later stored under the same key.
-	key := daemonInstanceKey(repo.ID, title)
 	persistErr := func() error {
 		m.mu.Lock()
 		defer m.mu.Unlock()
@@ -159,6 +205,11 @@ func (m *Manager) CreateSession(ctx context.Context, req CreateSessionRequest) (
 		return session.InstanceData{}, persistErr
 	}
 	m.captureAgentConversationAsync(repo.ID, key, instance, conversationCapture)
+	createSucceeded = true
+	// Publish from the Manager, not only the control-server wrapper: task delivery
+	// and root-agent ensure call Manager.CreateSession directly. They announced the
+	// same pending row above and therefore must settle it on the same events plane.
+	m.publishEvent(agentproto.EventSessionCreated, data)
 
 	return data, nil
 }

--- a/scripts/container/web-selftest-entry.sh
+++ b/scripts/container/web-selftest-entry.sh
@@ -133,6 +133,15 @@ go build -buildvcs=false -o "$BIN" .
 # ready as soon as it shows output (#1116/#1131).
 cat >"$HOME_DIR/fake-agent.sh" <<EOF
 #!/bin/sh
+# Creation-state probes deliberately hold the REAL backend path open. The web test
+# keys behavior by its throwaway session title, which appears in the worktree path:
+# one agent starts slowly but succeeds, and one stays alive long enough for the
+# creating row to be observed before exiting with no ready output. Every seeded and
+# ordinary fast-create session remains on the millisecond path below.
+case "\$PWD" in
+    *probe-create-slow*) sleep 8 ;;
+    *probe-create-fail*) sleep 4; exit 42 ;;
+esac
 printf '%s\n' "$READY_MARKER"
 exec cat
 EOF

--- a/session/instance_factory.go
+++ b/session/instance_factory.go
@@ -9,6 +9,15 @@ import (
 
 // Options for creating a new instance
 type InstanceOptions struct {
+	// ID, when set, is the stable identity already announced for this instance.
+	// The daemon uses it to keep an OpCreating projection and the completed
+	// instance on one identity across slow provisioning. Empty mints a new id,
+	// which remains the normal path for every direct constructor call.
+	ID string
+	// CreatedAt, when set, is the creation time already announced with ID. The
+	// daemon supplies both together so a pending row does not jump in rail order
+	// when provisioning completes. Zero uses the current time.
+	CreatedAt time.Time
 	// Title is the title of the instance.
 	Title string
 	// TaskID marks the session as spawned by a task's delivery (#1892). Empty for
@@ -165,8 +174,22 @@ var newSessionID = func() string {
 	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
 }
 
+// NewInstanceID reserves the same stable identity NewInstance would mint. The
+// daemon calls it before a potentially slow backend factory so it can publish an
+// authoritative OpCreating projection whose id the finished Instance inherits.
+func NewInstanceID() string {
+	return newSessionID()
+}
+
 func NewInstance(opts InstanceOptions) (*Instance, error) {
-	t := time.Now()
+	t := opts.CreatedAt
+	if t.IsZero() {
+		t = time.Now()
+	}
+	id := opts.ID
+	if id == "" {
+		id = NewInstanceID()
+	}
 
 	// An in-place session runs in the repo's local working tree; a remote
 	// session has no local worktree at all — the two are contradictory. This
@@ -214,7 +237,7 @@ func NewInstance(opts InstanceOptions) (*Instance, error) {
 	}
 
 	return &Instance{
-		ID:     newSessionID(),
+		ID:     id,
 		TaskID: opts.TaskID,
 		Title:  opts.Title,
 		// A task delivery's run begins here and ends when the agent goes idle

--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -785,6 +785,9 @@ body {
 .af-row:hover {
   background: var(--af-bg-inset);
 }
+.af-row-creating {
+  cursor: progress;
+}
 .af-row-selected {
   background: var(--af-accent-subtle);
 }

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7238,6 +7238,9 @@ function rowStatus(s) {
 function isWorking(s) {
   return rowStatus(s).kind === null;
 }
+function isCreating(s) {
+  return (s.in_flight_op ?? InFlightOp.None) === InFlightOp.Creating;
+}
 function rowKind(s) {
   return rowStatus(s).kind ?? "working";
 }
@@ -11487,6 +11490,7 @@ function beginTabRename(btn, tab, actions2, editedId, editedSessionId) {
 }
 function sessionRow(s, selected, actions2, rowActions) {
   const status = rowStatus(s);
+  const creating = isCreating(s);
   const title = h2("div", { class: "af-row-title" }, rowTitle(s));
   const branch = h2(
     "div",
@@ -11496,7 +11500,7 @@ function sessionRow(s, selected, actions2, rowActions) {
     s.branch || "\u2014"
   );
   const main = h2("div", { class: "af-row-main" }, title, branch);
-  const cls = `af-row${selected ? " af-row-selected" : ""}${isArchived(s) ? " af-row-archived" : ""}`;
+  const cls = `af-row${selected ? " af-row-selected" : ""}${isArchived(s) ? " af-row-archived" : ""}${creating ? " af-row-creating" : ""}`;
   const row = h2("li", { class: cls });
   if (status.kind) {
     const dot = h2("span", { class: `af-dot af-dot-${status.kind}` }, status.glyph);
@@ -11510,7 +11514,9 @@ function sessionRow(s, selected, actions2, rowActions) {
   row.setAttribute("role", "option");
   row.setAttribute("aria-selected", selected ? "true" : "false");
   row.setAttribute("title", `${s.title} \u2014 ${status.label}`);
-  if (s.id) {
+  if (creating) {
+    row.setAttribute("aria-disabled", "true");
+  } else if (s.id) {
     const id = s.id;
     row.addEventListener("click", () => actions2.open(id));
   }
@@ -11795,16 +11801,17 @@ function newSession() {
           return;
         }
         const m = modal;
+        clearTabError();
         m.setBusy(true);
+        closeModal();
         void createSession(values, tok).then((created) => {
-          closeModal();
           if (created.id) {
             const sessions = upsertSession(store.get().sessions, created);
             store.set({ sessions, selectedId: created.id, activeTab: 0, tabError: null });
           }
         }).catch((e) => {
-          m.setBusy(false);
-          m.setError(describeError(e));
+          requestResync();
+          surfaceTabError(e);
         });
       },
       onCancel: closeModal
@@ -11981,7 +11988,7 @@ function reorderSessionTab(from, to) {
 }
 function surfaceTabError(e) {
   const msg = errorText(e);
-  console.error("af-web: tab operation failed:", msg);
+  console.error("af-web: operation failed:", msg);
   if (tabErrorTimer !== null) {
     window.clearTimeout(tabErrorTimer);
   }
@@ -12323,7 +12330,7 @@ function onKeydown(e) {
       orderedIds: filterSessions(
         orderedSessions(scopeToProject(state.sessions, state.selectedProject)),
         state.statusFilter
-      ).map((s) => s.id ?? "").filter((id) => id !== ""),
+      ).filter((s) => !isCreating(s)).map((s) => s.id ?? "").filter((id) => id !== ""),
       selectedId: state.selectedId,
       tabCount: selected ? sessionTabs(selected).length : 1,
       activeTab: state.activeTab,

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "13862272a0e1";
+const VERSION = "813f30130917";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -2462,6 +2462,80 @@ test("schedule picker (#2057): a preset generates the cron, an edit re-opens as 
   await expect(page.locator(".af-rail-list")).toBeVisible();
 });
 
+test("#2218: slow create closes immediately, shows daemon state, then opens attached", async () => {
+  const created = `probe-create-slow-${Date.now().toString(36)}`;
+  await row(page, SESSION_A).click();
+  await expect(page.locator(".af-main.af-main-term")).toBeVisible();
+
+  await page.locator("button.af-rail-new").click();
+  const modal = page.locator(".af-modal-card");
+  await expect(modal).toBeVisible();
+  await modal.locator('input[aria-label="Session title"]').fill(created);
+  await modal.locator("button.af-primary").click();
+
+  // The fake agent sleeps for eight seconds, so neither assertion can be hidden by
+  // a fast local create. Submit synchronously releases the modal; the row arrives
+  // separately from the daemon's session.updated projection with OpCreating.
+  await expect(modal, "submit must release the modal before provisioning finishes").toBeHidden({ timeout: 3000 });
+  const creating = row(page, created);
+  await expect(creating, "the daemon's pending row must arrive during the slow backend").toHaveClass(/af-row-creating/, {
+    timeout: 6000,
+  });
+  await expect(creating).toHaveAttribute("aria-disabled", "true");
+
+  // A pending row has its final id but no terminal. It must stay inert so a click
+  // cannot pre-select that id and suppress the success-time selection change that
+  // builds the pane (the exact slow-only regression guarded by index.ts's comment).
+  const selectedAfterClick = await creating.evaluate((row) => {
+    row.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    return row.getAttribute("aria-selected");
+  });
+  expect(selectedAfterClick).toBe("false");
+
+  // Completion replaces the same id, selects it in the same store update, and opens
+  // the Agent tab attached. A stuck empty pane here is the naive async regression.
+  await expect(creating).not.toHaveClass(/af-row-creating/, { timeout: 30_000 });
+  await expect(creating).toHaveAttribute("aria-selected", "true");
+  await expect(page.locator(".af-tabbar .af-tab")).toHaveCount(1);
+  await expect(page.locator(".af-tab.af-tab-active .af-tab-label")).toHaveText("Agent");
+  await expect(page.locator(".af-term-host")).toContainText(READY_MARKER, { timeout: 30_000 });
+
+  // Leave no successful probe behind for later shared-page tests.
+  await railAction(page, created, "Kill session").click();
+  const killModal = page.locator(".af-modal-card");
+  await expect(killModal).toBeVisible();
+  await killModal.locator("button.af-danger").click();
+  await expect(row(page, created)).toHaveCount(0, { timeout: 30_000 });
+});
+
+test("#2218: failing slow create shows the daemon error and leaves no phantom row", async () => {
+  const created = `probe-create-fail-${Date.now().toString(36)}`;
+  await page.locator("button.af-rail-new").click();
+  const modal = page.locator(".af-modal-card");
+  await expect(modal).toBeVisible();
+  await modal.locator('input[aria-label="Session title"]').fill(created);
+  const response = page.waitForResponse((r) => r.url().endsWith("/v1/CreateSession") && r.request().method() === "POST");
+  await modal.locator("button.af-primary").click();
+
+  await expect(modal, "a failing backend must not hold the form open either").toBeHidden({ timeout: 3000 });
+  const creating = row(page, created);
+  await expect(creating, "failure must still expose the real in-flight window").toHaveClass(/af-row-creating/, {
+    timeout: 6000,
+  });
+
+  const failed = await response;
+  const envelope = (await failed.json()) as { error?: { message?: string } };
+  const daemonMessage = envelope.error?.message ?? "";
+  expect(daemonMessage).toContain("failed to start instance");
+  await expect(page.locator(".af-toast"), "the web must render the daemon's exact failure").toHaveText(daemonMessage);
+  await expect(creating, "the failed provisional id must be removed").toHaveCount(0, { timeout: 30_000 });
+
+  // A fresh authoritative Snapshot must agree: reload cannot resurrect a phantom.
+  await page.reload();
+  await expect(page.locator(".af-app")).toBeVisible();
+  await expect(row(page, created)).toHaveCount(0);
+});
+
 test.describe("create → kill (one session, two flows)", () => {
   // The ONE genuine ordering dependency in this file, and the only place serial
   // mode is warranted: create stashes the title it invented and kill consumes it,
@@ -2532,10 +2606,10 @@ test.describe("create → kill (one session, two flows)", () => {
     await modal.locator('input[aria-label="Session title"]').fill(created);
     await modal.locator("button.af-primary").click();
 
-    // The created row lands in the rail (createSession returns the full projection,
-    // which index.ts upserts + selects immediately).
-    await expect(row(page, created)).toBeVisible({ timeout: 30_000 });
+    // The fast path may cross OpCreating between animation frames, but it must still
+    // close immediately and settle to the daemon's completed projection.
     await expect(modal).toBeHidden();
+    await expect(row(page, created)).toBeVisible({ timeout: 30_000 });
 
     // The new session is auto-selected AND attached at its AGENT tab (index 0), not
     // the tab-2 we were on: its tab bar has just the agent tab, and its terminal
@@ -2658,58 +2732,6 @@ test("restore (#1932): the selected rail row's Restore action brings an archived
   // the archive test left it.
   await resetFilter(page);
   await expect(row(page, SESSION_B)).toHaveCount(0);
-});
-
-test("#1933: a backend availability refresh must not re-enable Create mid-submit", async () => {
-  // The race: a ListBackends is in flight when the user submits, and its response
-  // lands DURING the create. Re-rendering the choices must not decide, on its own,
-  // whether Create is clickable — the busy state is a separate reason it is
-  // disabled, and clobbering it re-arms the button under an in-flight create (a
-  // double-create is one Enter away).
-  //
-  // Both sides are held with route interception so the ordering is deterministic
-  // rather than a timing hope. The create is aborted, never forwarded, so this test
-  // makes no session.
-  let releaseCatalog: () => void = () => {};
-  const catalogHeld = new Promise<void>((resolve) => {
-    releaseCatalog = resolve;
-  });
-  await page.route("**/v1/ListBackends", async (route) => {
-    await catalogHeld;
-    await route.continue();
-  });
-  await page.route("**/v1/CreateSession", async (route) => {
-    // Held open so the modal stays busy across the assertion, then aborted so the
-    // request never reaches the daemon.
-    await new Promise((resolve) => setTimeout(resolve, 2000));
-    await route.abort();
-  });
-
-  await page.locator("button.af-rail-new").click();
-  const modal = page.locator(".af-modal-card");
-  await expect(modal).toBeVisible();
-  await modal.locator('input[aria-label="Session title"]').fill("probe-busy-race");
-
-  const createBtn = modal.locator("button.af-primary");
-  await expect(createBtn).toBeEnabled();
-  await createBtn.click();
-  await expect(createBtn).toBeDisabled();
-
-  // Let the catalog land mid-create, then look AFTER the re-render has run — the
-  // assertion has to outlast the event, or it would pass on the pre-render state.
-  const catalogResponse = page.waitForResponse("**/v1/ListBackends");
-  releaseCatalog();
-  await catalogResponse;
-  await page.waitForTimeout(300);
-  await expect(createBtn, "an availability refresh must not re-enable Create while a create is in flight").toBeDisabled();
-
-  // And once the create actually fails, the button comes back — the busy gate must
-  // not strand the form either.
-  await expect(createBtn).toBeEnabled({ timeout: 15_000 });
-  await page.keyboard.press("Escape");
-  await expect(modal).toBeHidden();
-  await page.unroute("**/v1/ListBackends");
-  await page.unroute("**/v1/CreateSession");
 });
 
 // --- the status filter (feat: hide archived by default) --------------------

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -59,7 +59,7 @@ import {
   upsertSession,
 } from "./sessions.js";
 import { SplitView } from "./split.js";
-import { isArchived, type RowKind } from "./status.js";
+import { isArchived, isCreating, type RowKind } from "./status.js";
 import { isRenameableTab } from "./tablabel.js";
 import { Store } from "./store.js";
 import { registerServiceWorker } from "./serviceworker.js";
@@ -152,7 +152,7 @@ let resyncTimer: number | null = null;
 // Debounces the ListTasks refetch that task.* events trigger (#1592 Phase 5 PR8),
 // so a burst of task deltas collapses into one authoritative refetch.
 let taskResyncTimer: number | null = null;
-// The auto-dismiss timer for the tab-error toast, and how long it shows.
+// The auto-dismiss timer for the operation-error toast, and how long it shows.
 let tabErrorTimer: number | null = null;
 const TAB_ERROR_MS = 6000;
 
@@ -540,9 +540,11 @@ function openModal(m: ModalHandle): void {
   modalHost.replaceChildren(m.el);
 }
 
-/** Opens the new-session modal, its picker seeded from the live projects. On
- *  submit it creates the session via the daemon; the created row arrives via the
- *  events stream. Errors (e.g. a bad repo) surface in the modal for a retry. */
+/** Opens the new-session modal, its picker seeded from the live projects. Submit
+ *  closes immediately: the daemon publishes its authoritative OpCreating row on
+ *  the events stream, then either replaces it with the completed projection or
+ *  removes it. A failure surfaces through the shared operation toast because the
+ *  form is deliberately no longer held open by the RPC. */
 function newSession(): void {
   const projects = pickerProjects(store.get().sessions, store.get().tasks);
   openModal(
@@ -561,10 +563,14 @@ function newSession(): void {
           return;
         }
         const m = modal;
+        clearTabError();
+        // Latch the detached form against a duplicate submit, then release the UI
+        // immediately. The row that follows is NOT synthesized here: it comes from
+        // the daemon's session.updated OpCreating projection.
         m.setBusy(true);
+        closeModal();
         void createSession(values, tok)
           .then((created) => {
-            closeModal();
             // Upsert the created row AND select it in one update, so it opens
             // attached immediately. Upserting here (not just setting selectedId)
             // matters: the async created event may not have landed yet, and
@@ -582,8 +588,11 @@ function newSession(): void {
             }
           })
           .catch((e) => {
-            m.setBusy(false);
-            m.setError(describeError(e));
+            // The daemon publishes session.killed for the provisional id. Resync as a
+            // drop-slow/reconnect fallback so even a missed delete event cannot strand a
+            // phantom creating row, and surface the daemon's unmodified error text.
+            requestResync();
+            surfaceTabError(e);
           });
       },
       onCancel: closeModal,
@@ -952,16 +961,16 @@ function reorderSessionTab(from: number, to: number): void {
     .catch((e) => surfaceTabError(e));
 }
 
-/** Surfaces a failed tab mutation as a transient toast (there is no modal for tab
- *  ops, unlike create/kill/archive). The terminal keeps streaming; the message is
- *  the cue to fix the cause (e.g. the tab cap or a remote session). It auto-clears
- *  after a few seconds, and a fresh failure resets the timer. */
+/** Surfaces a failed asynchronous operation as a transient toast. Tab mutations
+ *  have no modal, and session creation closes its modal before awaiting the daemon;
+ *  the message is therefore the visible failure path for both. It auto-clears after
+ *  a few seconds, and a fresh failure resets the timer. */
 function surfaceTabError(e: unknown): void {
   // The raw error message — NOT describeError, whose "Login failed…/Couldn't reach
-  // the daemon…" framing is for the login probe. A tab op carries the daemon's own
-  // message (e.g. the tab cap) or the fail-closed "no stable id" refusal verbatim.
+  // the daemon…" framing is for the login probe. Operations carry the daemon's own
+  // message (e.g. create failure or tab cap) or a fail-closed refusal verbatim.
   const msg = errorText(e);
-  console.error("af-web: tab operation failed:", msg);
+  console.error("af-web: operation failed:", msg);
   if (tabErrorTimer !== null) {
     window.clearTimeout(tabErrorTimer);
   }
@@ -1535,6 +1544,10 @@ function onKeydown(e: KeyboardEvent): void {
         orderedSessions(scopeToProject(state.sessions, state.selectedProject)),
         state.statusFilter,
       )
+        // Creating rows are visible daemon state but not selectable: no terminal
+        // exists until CreateSession resolves, and success owns the one atomic
+        // upsert+selection that opens it attached.
+        .filter((s) => !isCreating(s))
         .map((s) => s.id ?? "")
         .filter((id) => id !== ""),
       selectedId: state.selectedId,

--- a/web/src/status.test.ts
+++ b/web/src/status.test.ts
@@ -7,7 +7,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { type DotKind, isArchived, isLimitReached, isWorking, rowStatus, rowTitle } from "./status.js";
+import { type DotKind, isArchived, isCreating, isLimitReached, isWorking, rowStatus, rowTitle } from "./status.js";
 import { InFlightOp, Liveness, Status, type SessionData } from "./types.js";
 
 function sess(over: Partial<SessionData> = {}): SessionData {
@@ -52,6 +52,14 @@ test("any in-flight op overlays the liveness and reads as working (no dot)", () 
     assert.equal(st.glyph, "", `op ${op} draws no glyph`);
     assert.equal(isWorking(sess({ liveness: Liveness.Ready, in_flight_op: op })), true);
   }
+});
+
+test("isCreating distinguishes the daemon create operation from other working states", () => {
+  assert.equal(isCreating(sess({ in_flight_op: InFlightOp.Creating })), true);
+  assert.equal(isCreating(sess({ liveness: Liveness.Running })), false, "a running agent is working, not creating");
+  assert.equal(isCreating(sess({ in_flight_op: InFlightOp.Killing })), false);
+  assert.equal(isCreating(sess({ in_flight_op: InFlightOp.Archiving })), false);
+  assert.equal(isCreating(sess({ in_flight_op: InFlightOp.Restoring })), false);
 });
 
 test("liveness absent falls back to the legacy status int", () => {

--- a/web/src/status.ts
+++ b/web/src/status.ts
@@ -87,6 +87,13 @@ export function isWorking(s: SessionData): boolean {
   return rowStatus(s).kind === null;
 }
 
+/** True only for the daemon-owned create operation. Unlike isWorking (which also
+ * includes a running agent and every other in-flight operation), this is used to
+ * keep a not-yet-attachable row inert until its completed projection arrives. */
+export function isCreating(s: SessionData): boolean {
+  return (s.in_flight_op ?? InFlightOp.None) === InFlightOp.Creating;
+}
+
 /**
  * The state bucket a row READS AS, the key the rail's status filter partitions by
  * (filter.ts). Deliberately derived from rowStatus — the DISPLAYED status — and not

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -983,6 +983,13 @@ body {
   background: var(--af-bg-inset);
 }
 
+/* A daemon-published OpCreating row is visible but cannot attach yet. The progress
+ * cursor is the web analogue of the TUI's inert Loading row; no local spinner or
+ * optimistic state is involved. */
+.af-row-creating {
+  cursor: progress;
+}
+
 .af-row-selected {
   background: var(--af-accent-subtle);
 }
@@ -1427,9 +1434,9 @@ body {
   white-space: nowrap;
 }
 
-/* Tab-op error toast (#1592 Phase 5 PR7): a transient banner pinned bottom-right,
- * shown only while `tabError` is set. Tab ops have no modal, so this is where a
- * create/close failure surfaces instead of being swallowed. */
+/* Operation-error toast (#1592 Phase 5 PR7): a transient banner pinned bottom-right,
+ * shown only while `tabError` is set. Tab ops and asynchronous session creation have
+ * no open modal, so this is where their real daemon errors surface. */
 .af-toast {
   position: fixed;
   right: var(--af-sp-5);

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -32,7 +32,15 @@ import {
   type StatusFilter,
 } from "./filter.js";
 import { projectMeta, projectName, type ProjectSummary, projectSummaries, scopeToProject } from "./project.js";
-import { compareSessionsForRail, isArchived, isLimitReached, type RowKind, rowStatus, rowTitle } from "./status.js";
+import {
+  compareSessionsForRail,
+  isArchived,
+  isCreating,
+  isLimitReached,
+  type RowKind,
+  rowStatus,
+  rowTitle,
+} from "./status.js";
 import { ConfigPane, type ConfigStatus } from "./config.js";
 import { isRenameableTab, tabDisplayLabel, tabGlyph, tabLabel } from "./tablabel.js";
 import { insertionIndexAt, reorderTargetIndex } from "./tabreorder.js";
@@ -2071,6 +2079,7 @@ function beginTabRename(
  *  (never expected from a live Snapshot) is rendered but inert. */
 function sessionRow(s: SessionData, selected: boolean, actions: Actions, rowActions: HTMLElement | null): HTMLElement {
   const status = rowStatus(s);
+  const creating = isCreating(s);
 
   const title = h("div", { class: "af-row-title" }, rowTitle(s));
   const branch = h(
@@ -2082,7 +2091,9 @@ function sessionRow(s: SessionData, selected: boolean, actions: Actions, rowActi
   );
   const main = h("div", { class: "af-row-main" }, title, branch);
 
-  const cls = `af-row${selected ? " af-row-selected" : ""}${isArchived(s) ? " af-row-archived" : ""}`;
+  const cls = `af-row${selected ? " af-row-selected" : ""}${isArchived(s) ? " af-row-archived" : ""}${
+    creating ? " af-row-creating" : ""
+  }`;
   const row = h("li", { class: cls });
   // A working/busy row shows NO status dot (#1766) — only Ready/error states draw
   // one. When there is no dot the span is omitted entirely (kind is null), matching
@@ -2099,7 +2110,13 @@ function sessionRow(s: SessionData, selected: boolean, actions: Actions, rowActi
   row.setAttribute("role", "option");
   row.setAttribute("aria-selected", selected ? "true" : "false");
   row.setAttribute("title", `${s.title} — ${status.label}`);
-  if (s.id) {
+  if (creating) {
+    // The id is already the final stable id, but no terminal exists yet. Keeping
+    // the row inert also prevents selecting it before completion: if success then
+    // wrote the SAME selectedId, AppShell would see no selection change and retain
+    // the empty pane (the slow-create form of the invariant in index.ts newSession).
+    row.setAttribute("aria-disabled", "true");
+  } else if (s.id) {
     const id = s.id;
     row.addEventListener("click", () => actions.open(id));
   }


### PR DESCRIPTION
Fixes #2218

## Summary

- Publish daemon-owned `OpCreating` projections before slow provisioning begins, then settle or remove the same stable session identity.
- Close the web create modal immediately and render an inert creating row solely from daemon activity state.
- Preserve the atomic success upsert and selection update, while surfacing the daemon's exact failure and resyncing to prevent phantom rows.
- Cover fast, intentionally slow, and failing creates in the rendered web UI, plus daemon projection lifecycle tests.

## Validation

- `gofmt -l .`
- `golangci-lint run --timeout=3m --fast`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make web-test` (400/400)
- `make web-build` (committed bundle regenerated and clean)
- `make web-selftest-container` (105/105, including fast, slow, and failing create flows)

— Captain Claude
