### PR TITLE
config: unify manifest source policy

### DIFF
--- a/config/inrepo.go
+++ b/config/inrepo.go
@@ -87,73 +87,16 @@ func (c *InRepoConfig) CommandBearingFields() []string {
 	return fields
 }
 
-// inRepoAllowedKeys is the full set of top-level keys an in-repo config may
-// contain. Anything else is rejected so typos fail loudly instead of being
-// silently ignored in a file that can execute shell commands.
-var inRepoAllowedKeys = []string{
-	"backend",
-	"default_program",
-	"docker",
-	"post_worktree_commands",
-	"program_overrides",
-	"remote_hooks",
-	"ssh",
-}
-
-// inRepoGlobalOnlyKeys maps keys that configure the host or daemon — not the
-// repository — to rejection reasons. They are only meaningful machine-wide,
-// so an in-repo value would either silently do nothing or, worse, let a repo
-// flip host-level behavior like autoyes.
-var inRepoGlobalOnlyKeys = map[string]bool{
-	"auto_update":   true,
-	"auto_yes":      true,
-	"branch_prefix": true,
-	// The daemon's network surface is configured by the host, never a
-	// repository — a cloned repo must never be able to open a port or widen the
-	// CORS allow-list (#1592 Phase 3).
-	"cors_allowed_origins": true,
-	"daemon_poll_interval": true,
-	"detach_keys":          true,
-	// What af writes into your HOME directory is a user/host decision; a
-	// cloned repo must never be able to opt you into af editing your global
-	// codex/gemini/amp config (#1977).
-	"global_agent_skills": true,
-	"listen_addr":         true,
-	// The [keys] keymap is a user/host preference: a cloned repo must never
-	// be able to rebind someone's terminal (#1026).
-	"keys":                 true,
-	"limit_auto_resume":    true,
-	"limit_retry_interval": true,
-	"log_max_backups":      true,
-	"log_max_size_mb":      true,
-	// Disabling the bearer token — or tightening the loopback exemption — is a
-	// daemon-network-surface decision; a cloned repo must never be able to turn
-	// off web auth (#1696) or flip the loopback token requirement.
-	"require_token":          true,
-	"require_loopback_token": true,
-	"root_agents":            true,
-	// The [theme] table is a user/host visual preference; repositories must
-	// not be able to recolor a cloned user's TUI (#1389).
-	"theme":          true,
-	"update_channel": true,
-	// The value names a binary the DAEMON executes, so honoring it from a
-	// repo's checked-in config would let merely cloning a repo choose what af
-	// runs on your machine (#1817). It is already absent from
-	// inRepoAllowedKeys — a repo cannot hijack the binary either way — so
-	// listing it here is purely about the error the user gets: the actionable
-	// "global setting … move it to <global config>" instead of the generic
-	// "unknown key".
-	"vscode_server_binary": true,
-	"worktree_root":        true,
-}
-
-// tomlOnlyGlobalKeys is the subset of inRepoGlobalOnlyKeys that exists only in
-// config.toml (#1026/#1030), so their in-repo rejection message must direct
-// the user to config.toml rather than the resolved global config file.
-var tomlOnlyGlobalKeys = map[string]bool{
-	"keys":  true,
-	"theme": true,
-}
+// These are compatibility views of the manifest, not independent policy
+// registries. Anything outside inRepoAllowedKeys is rejected so typos fail
+// loudly in a checked-in file that can execute commands. Known global-only keys
+// get the more actionable "move it to global config" error. Format metadata
+// decides whether that destination must specifically be config.toml.
+var (
+	inRepoAllowedKeys    = manifestKeysForSource(SourceRepoShared)
+	inRepoGlobalOnlyKeys = manifestGlobalOnlyKeySet()
+	tomlOnlyGlobalKeys   = manifestTOMLOnlyGlobalKeySet()
+)
 
 // InRepoConfigPath returns the path of the in-repo JSON config file for a
 // repo root. The file is optional; callers should use LoadInRepoConfig rather

--- a/config/manifest.go
+++ b/config/manifest.go
@@ -1,12 +1,14 @@
 package config
 
 import (
+	"sort"
+
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
-// The config manifest: the single source of truth describing every user-facing
-// GLOBAL config key — its type, default, one-line purpose, importance tier, and
-// whether `af config set` accepts it.
+// The config manifest: the single source of truth describing the union of every
+// user-facing configuration key — its shape, supported locations and formats,
+// precedence and merge policy, and editor-facing description.
 //
 // It exists to be READ BY AN AGENT. A config agent gets RenderBriefing(cfg) as
 // its briefing document (manifest_briefing.go), so every Purpose here is written
@@ -19,11 +21,12 @@ import (
 // comments at runtime, so deriving this from config_types.go would need a
 // build-time go/ast generator, and it would still emit the multi-line prose a
 // briefing cannot use. The anti-drift guarantee that generation would buy is
-// bought instead by TestManifestCoversEveryConfigKey, which reflects over
-// Config and fails when a toml-tagged field has no entry here (and when an
-// entry names a field that does not exist). Adding a config key without
-// touching this file is therefore a test failure, not a silent omission —
-// the same guarantee, a fraction of the machinery.
+// bought instead by TestManifestCoversEveryConfigKey, which reflects over both
+// Config and InRepoConfig and fails when a decoded field has no correctly
+// sourced entry here (and when an entry names no field). Adding a config key or
+// admitting it at another source without touching this file is therefore a test
+// failure, not a silent omission — the same guarantee, a fraction of the
+// machinery.
 //
 // Two further locks keep the table honest: TestManifestAgreesWithSettableKeys
 // pins Settable against the real `af config set` allowlist (settableKeySpecs),
@@ -32,7 +35,7 @@ import (
 
 // ConfigTier ranks a config key by how likely a user is to need it, so an agent
 // briefing (and any future `af config` surface) can lead with what matters
-// instead of listing 24 keys flat.
+// instead of listing every key flat.
 type ConfigTier int
 
 const (
@@ -48,11 +51,13 @@ const (
 	TierAdvanced ConfigTier = 3
 )
 
-// ManifestEntry describes one user-facing global config key.
+// ManifestEntry describes one user-facing config key across every location in
+// which that key is supported. A key shared by Config and InRepoConfig has one
+// entry with multiple Sources, never one entry per struct.
 type ManifestEntry struct {
 	// Key is the toml key as written in config.toml (e.g. "default_program").
-	// It must match the toml tag of a Config field — TestManifestCoversEveryConfigKey
-	// rejects a key that names no field.
+	// It must match a decoded field in at least one supported schema —
+	// TestManifestCoversEveryConfigKey rejects a key that names no field.
 	Key string
 	// Type is the value's shape: "string", "bool", "int", "table", or "list".
 	Type string
@@ -67,16 +72,31 @@ type ManifestEntry struct {
 	Purpose string
 	// Tier ranks the key for ordering and for what an agent surfaces first.
 	Tier ConfigTier
-	// Settable reports whether `af config set` accepts this key — for a dynamic
-	// family (program_overrides, limit_patterns) that means its leaves, e.g.
+	// Settable reports whether the current global `af config set` accepts this
+	// key — for a dynamic family (program_overrides, limit_patterns) that means
+	// its leaves, e.g.
 	// `af config set program_overrides.claude …`. It is pinned against the real
 	// allowlist by TestManifestAgreesWithSettableKeys, so it can never become a
-	// claim the CLI does not honor. A false here means the key is hand-edited in
-	// config.toml.
+	// claim the CLI does not honor. A false here means the key must be changed
+	// through another writer or by hand in an allowed config location.
 	Settable bool
 	// Enum is the allowed values, when they are enumerated. Nil when the value
 	// is free-form (a path, a duration, an address) or a plain bool.
 	Enum []string
+	// Sources is the set of supported user-facing locations that may declare
+	// this key. Built-in and read-only compatibility candidates belong only in
+	// Precedence. Zero is invalid.
+	Sources SourceSet
+	// Precedence lists this key's resolver candidates from lowest to highest.
+	// It always starts with SourceBuiltIn and may include a compatibility source
+	// that is deliberately not an allowed write target. Zero/empty is invalid.
+	Precedence []ConfigSource
+	// Merge says how present values from successive sources combine. Zero is
+	// invalid, including for keys that currently have only one configured source.
+	Merge MergePolicy
+	// Formats lists the encodings recognized across this key's supported
+	// Sources. Zero is invalid.
+	Formats FormatSet
 }
 
 // manifestSkippedKeys are the toml-tagged Config fields deliberately absent
@@ -96,228 +116,438 @@ var manifestSkippedKeys = map[string]string{
 	"schema_version": "machine-managed migration bookkeeping, never user-set",
 }
 
-// configManifest is the curated table, in tier order (and, within a tier, in
-// the order a user meets the keys). Manifest() returns it; nothing else should
-// touch it directly.
+// configManifest is the curated union table, in tier order (and, within a tier,
+// in the order a user meets the keys). AllManifest returns the whole table;
+// Manifest preserves its historical global-only view for the config agent and
+// editors. Nothing outside the manifest implementation should touch this slice
+// directly.
 var configManifest = []ManifestEntry{
 	// ---- Tier 1: the onboarding core ----
 	{
-		Key:      "default_program",
-		Type:     "string",
-		Default:  "claude",
-		Purpose:  "The coding agent a new session starts.",
-		Tier:     TierCore,
-		Settable: true,
-		Enum:     tmux.SupportedPrograms,
+		Key:        "default_program",
+		Type:       "string",
+		Default:    "claude",
+		Purpose:    "The coding agent a new session starts.",
+		Tier:       TierCore,
+		Settable:   true,
+		Enum:       tmux.SupportedPrograms,
+		Sources:    sourceGlobalRepo,
+		Precedence: precedenceGlobalRepo,
+		Merge:      MergeReplace,
+		Formats:    formatTOMLJSON,
 	},
 	{
-		Key:      "listen_addr",
-		Type:     "string",
-		Default:  "127.0.0.1:8443",
-		Purpose:  "Address the browser interface and HTTP API are served on · set it to \"\" to turn the web server off entirely.",
-		Tier:     TierCore,
-		Settable: true,
+		Key:        "listen_addr",
+		Type:       "string",
+		Default:    "127.0.0.1:8443",
+		Purpose:    "Address the browser interface and HTTP API are served on · set it to \"\" to turn the web server off entirely.",
+		Tier:       TierCore,
+		Settable:   true,
+		Sources:    sourceGlobalOnly,
+		Precedence: precedenceGlobal,
+		Merge:      MergeReplace,
+		Formats:    formatTOMLJSON,
 	},
 	{
-		Key:      "require_token",
-		Type:     "bool",
-		Default:  "false",
-		Purpose:  "Require an access token from other machines on the network · off by default, so the browser interface opens with no login.",
-		Tier:     TierCore,
-		Settable: true,
+		Key:        "require_token",
+		Type:       "bool",
+		Default:    "false",
+		Purpose:    "Require an access token from other machines on the network · off by default, so the browser interface opens with no login.",
+		Tier:       TierCore,
+		Settable:   true,
+		Sources:    sourceGlobalOnly,
+		Precedence: precedenceGlobal,
+		Merge:      MergeReplace,
+		Formats:    formatTOMLJSON,
 	},
 	{
-		Key:      "require_loopback_token",
-		Type:     "bool",
-		Default:  "false",
-		Purpose:  "Also require the token from browsers on this same machine · has no effect on its own, since it only tightens a token that require_token must first turn on.",
-		Tier:     TierCore,
-		Settable: true,
+		Key:        "require_loopback_token",
+		Type:       "bool",
+		Default:    "false",
+		Purpose:    "Also require the token from browsers on this same machine · has no effect on its own, since it only tightens a token that require_token must first turn on.",
+		Tier:       TierCore,
+		Settable:   true,
+		Sources:    sourceGlobalOnly,
+		Precedence: precedenceGlobal,
+		Merge:      MergeReplace,
+		Formats:    formatTOMLJSON,
 	},
 	{
-		Key:      "update_channel",
-		Type:     "string",
-		Default:  "stable",
-		Purpose:  "Which releases updates come from · stable, or preview for early builds cut every few hours.",
-		Tier:     TierCore,
-		Settable: true,
-		Enum:     []string{UpdateChannelStable, UpdateChannelPreview},
+		Key:        "update_channel",
+		Type:       "string",
+		Default:    "stable",
+		Purpose:    "Which releases updates come from · stable, or preview for early builds cut every few hours.",
+		Tier:       TierCore,
+		Settable:   true,
+		Enum:       []string{UpdateChannelStable, UpdateChannelPreview},
+		Sources:    sourceGlobalOnly,
+		Precedence: precedenceGlobal,
+		Merge:      MergeReplace,
+		Formats:    formatTOMLJSON,
 	},
 	{
-		Key:      "auto_update",
-		Type:     "bool",
-		Default:  "true",
-		Purpose:  "Check for a newer version on launch and install it automatically.",
-		Tier:     TierCore,
-		Settable: true,
+		Key:        "auto_update",
+		Type:       "bool",
+		Default:    "true",
+		Purpose:    "Check for a newer version on launch and install it automatically.",
+		Tier:       TierCore,
+		Settable:   true,
+		Sources:    sourceGlobalOnly,
+		Precedence: precedenceGlobal,
+		Merge:      MergeReplace,
+		Formats:    formatTOMLJSON,
 	},
 
 	// ---- Tier 2 ----
 	{
-		Key:      "theme",
-		Type:     "table",
-		Default:  "the Zenburn palette",
-		Purpose:  "Colors the terminal interface uses · one #RRGGBB value per slot, and any slot you leave out keeps its default.",
-		Tier:     TierCommon,
-		Settable: false,
+		Key:        "theme",
+		Type:       "table",
+		Default:    "the Zenburn palette",
+		Purpose:    "Colors the terminal interface uses · one #RRGGBB value per slot, and any slot you leave out keeps its default.",
+		Tier:       TierCommon,
+		Settable:   false,
+		Sources:    sourceGlobalOnly,
+		Precedence: precedenceGlobal,
+		Merge:      MergeTableByField,
+		Formats:    formatTOMLOnly,
 	},
 	{
-		Key:      "vscode_server_binary",
-		Type:     "string",
-		Default:  `""`,
-		Purpose:  "Which editor program a VS Code tab runs · empty finds code-server or openvscode-server on your PATH.",
-		Tier:     TierCommon,
-		Settable: true,
+		Key:        "vscode_server_binary",
+		Type:       "string",
+		Default:    `""`,
+		Purpose:    "Which editor program a VS Code tab runs · empty finds code-server or openvscode-server on your PATH.",
+		Tier:       TierCommon,
+		Settable:   true,
+		Sources:    sourceGlobalOnly,
+		Precedence: precedenceGlobal,
+		Merge:      MergeReplace,
+		Formats:    formatTOMLJSON,
 	},
 
 	// ---- Tier 3: everything else user-facing ----
 	{
-		Key:      "auto_yes",
-		Type:     "bool",
-		Default:  "false",
-		Purpose:  "Accept an agent's prompts automatically instead of waiting for you to confirm each one · experimental.",
-		Tier:     TierAdvanced,
-		Settable: true,
+		Key:        "auto_yes",
+		Type:       "bool",
+		Default:    "false",
+		Purpose:    "Accept an agent's prompts automatically instead of waiting for you to confirm each one · experimental.",
+		Tier:       TierAdvanced,
+		Settable:   true,
+		Sources:    sourceGlobalOnly,
+		Precedence: precedenceGlobal,
+		Merge:      MergeReplace,
+		Formats:    formatTOMLJSON,
 	},
 	{
-		Key:      "daemon_poll_interval",
-		Type:     "int",
-		Default:  "1000",
-		Purpose:  "How often the background service checks sessions for new output, in milliseconds.",
-		Tier:     TierAdvanced,
-		Settable: true,
+		Key:        "daemon_poll_interval",
+		Type:       "int",
+		Default:    "1000",
+		Purpose:    "How often the background service checks sessions for new output, in milliseconds.",
+		Tier:       TierAdvanced,
+		Settable:   true,
+		Sources:    sourceGlobalOnly,
+		Precedence: precedenceGlobal,
+		Merge:      MergeReplace,
+		Formats:    formatTOMLJSON,
 	},
 	{
-		Key:      "log_max_size_mb",
-		Type:     "int",
-		Default:  "50",
-		Purpose:  "How large the log may grow, in MB, before it is rotated into a backup file.",
-		Tier:     TierAdvanced,
-		Settable: true,
+		Key:        "log_max_size_mb",
+		Type:       "int",
+		Default:    "50",
+		Purpose:    "How large the log may grow, in MB, before it is rotated into a backup file.",
+		Tier:       TierAdvanced,
+		Settable:   true,
+		Sources:    sourceGlobalOnly,
+		Precedence: precedenceGlobal,
+		Merge:      MergeReplace,
+		Formats:    formatTOMLJSON,
 	},
 	{
-		Key:      "log_max_backups",
-		Type:     "int",
-		Default:  "2",
-		Purpose:  "How many rotated log files to keep before the oldest is deleted · 0 keeps none.",
-		Tier:     TierAdvanced,
-		Settable: true,
+		Key:        "log_max_backups",
+		Type:       "int",
+		Default:    "2",
+		Purpose:    "How many rotated log files to keep before the oldest is deleted · 0 keeps none.",
+		Tier:       TierAdvanced,
+		Settable:   true,
+		Sources:    sourceGlobalOnly,
+		Precedence: precedenceGlobal,
+		Merge:      MergeReplace,
+		Formats:    formatTOMLJSON,
 	},
 	{
-		Key:      "branch_prefix",
-		Type:     "string",
-		Default:  "your username, followed by a slash",
-		Purpose:  "Prefix for the git branch each new session creates.",
-		Tier:     TierAdvanced,
-		Settable: true,
+		Key:        "branch_prefix",
+		Type:       "string",
+		Default:    "your username, followed by a slash",
+		Purpose:    "Prefix for the git branch each new session creates.",
+		Tier:       TierAdvanced,
+		Settable:   true,
+		Sources:    sourceGlobalOnly,
+		Precedence: precedenceGlobal,
+		Merge:      MergeReplace,
+		Formats:    formatTOMLJSON,
 	},
 	{
-		Key:      "worktree_root",
-		Type:     "string",
-		Default:  WorktreeRootSibling,
-		Purpose:  "Where a session's copy of the repository is created · sibling puts it next to the repository, subdirectory puts it under the agent-factory home.",
-		Tier:     TierAdvanced,
-		Settable: true,
-		Enum:     []string{WorktreeRootSubdirectory, WorktreeRootSibling},
+		Key:        "worktree_root",
+		Type:       "string",
+		Default:    WorktreeRootSibling,
+		Purpose:    "Where a session's copy of the repository is created · sibling puts it next to the repository, subdirectory puts it under the agent-factory home.",
+		Tier:       TierAdvanced,
+		Settable:   true,
+		Enum:       []string{WorktreeRootSubdirectory, WorktreeRootSibling},
+		Sources:    sourceGlobalOnly,
+		Precedence: precedenceGlobal,
+		Merge:      MergeReplace,
+		Formats:    formatTOMLJSON,
 	},
 	{
-		Key:      "detach_keys",
-		Type:     "string",
-		Default:  "ctrl-w",
-		Purpose:  "The key that leaves a session you are attached to and returns you to the session list.",
-		Tier:     TierAdvanced,
-		Settable: true,
+		Key:        "detach_keys",
+		Type:       "string",
+		Default:    "ctrl-w",
+		Purpose:    "The key that leaves a session you are attached to and returns you to the session list.",
+		Tier:       TierAdvanced,
+		Settable:   true,
+		Sources:    sourceGlobalOnly,
+		Precedence: precedenceGlobal,
+		Merge:      MergeReplace,
+		Formats:    formatTOMLJSON,
 	},
 	{
-		Key:      "program_overrides",
-		Type:     "table",
-		Default:  "claude, pointed at the claude command found when af first ran",
-		Purpose:  "The full command to run for an agent, when it needs a specific path or extra flags · one entry per agent.",
-		Tier:     TierAdvanced,
-		Settable: true,
-		Enum:     tmux.SupportedPrograms,
+		Key:        "program_overrides",
+		Type:       "table",
+		Default:    "claude, pointed at the claude command found when af first ran",
+		Purpose:    "The full command to run for an agent, when it needs a specific path or extra flags · one entry per agent.",
+		Tier:       TierAdvanced,
+		Settable:   true,
+		Enum:       tmux.SupportedPrograms,
+		Sources:    sourceGlobalRepo,
+		Precedence: precedenceGlobalRepo,
+		Merge:      MergeMapByKey,
+		Formats:    formatTOMLJSON,
 	},
 	{
-		Key:      "limit_patterns",
-		Type:     "table",
-		Default:  "none · the built-in patterns are used",
-		Purpose:  "A custom regular expression for recognizing an agent's usage-limit message, replacing the built-in one · one entry per agent.",
-		Tier:     TierAdvanced,
-		Settable: true,
-		Enum:     tmux.SupportedPrograms,
+		Key:        "limit_patterns",
+		Type:       "table",
+		Default:    "none · the built-in patterns are used",
+		Purpose:    "A custom regular expression for recognizing an agent's usage-limit message, replacing the built-in one · one entry per agent.",
+		Tier:       TierAdvanced,
+		Settable:   true,
+		Enum:       tmux.SupportedPrograms,
+		Sources:    sourceGlobalOnly,
+		Precedence: precedenceGlobal,
+		Merge:      MergeMapByKey,
+		Formats:    formatTOMLJSON,
 	},
 	{
-		Key:      "limit_auto_resume",
-		Type:     "bool",
-		Default:  "false",
-		Purpose:  "Let a session that hit its usage limit resume on its own once the limit resets.",
-		Tier:     TierAdvanced,
-		Settable: true,
+		Key:        "limit_auto_resume",
+		Type:       "bool",
+		Default:    "false",
+		Purpose:    "Let a session that hit its usage limit resume on its own once the limit resets.",
+		Tier:       TierAdvanced,
+		Settable:   true,
+		Sources:    sourceGlobalOnly,
+		Precedence: precedenceGlobal,
+		Merge:      MergeReplace,
+		Formats:    formatTOMLJSON,
 	},
 	{
-		Key:      "global_agent_skills",
-		Type:     "bool",
-		Default:  "false",
-		Purpose:  "Let af add its af-usage skill to your own codex/gemini/amp config folders · off means those agents are not told about af.",
-		Tier:     TierAdvanced,
-		Settable: true,
+		Key:        "global_agent_skills",
+		Type:       "bool",
+		Default:    "false",
+		Purpose:    "Let af add its af-usage skill to your own codex/gemini/amp config folders · off means those agents are not told about af.",
+		Tier:       TierAdvanced,
+		Settable:   true,
+		Sources:    sourceGlobalOnly,
+		Precedence: precedenceGlobal,
+		Merge:      MergeReplace,
+		Formats:    formatTOMLJSON,
 	},
 	{
-		Key:      "limit_retry_interval",
-		Type:     "string",
-		Default:  "30m",
-		Purpose:  "How long to wait before retrying a usage-limited session whose message gave no reset time · empty or 0 means never retry it.",
-		Tier:     TierAdvanced,
-		Settable: true,
+		Key:        "limit_retry_interval",
+		Type:       "string",
+		Default:    "30m",
+		Purpose:    "How long to wait before retrying a usage-limited session whose message gave no reset time · empty or 0 means never retry it.",
+		Tier:       TierAdvanced,
+		Settable:   true,
+		Sources:    sourceGlobalOnly,
+		Precedence: precedenceGlobal,
+		Merge:      MergeReplace,
+		Formats:    formatTOMLJSON,
 	},
 	{
-		Key:      "cors_allowed_origins",
-		Type:     "list",
-		Default:  "none",
-		Purpose:  "Other websites allowed to call this machine's API from a browser · empty blocks every one of them.",
-		Tier:     TierAdvanced,
-		Settable: false,
+		Key:        "cors_allowed_origins",
+		Type:       "list",
+		Default:    "none",
+		Purpose:    "Other websites allowed to call this machine's API from a browser · empty blocks every one of them.",
+		Tier:       TierAdvanced,
+		Settable:   false,
+		Sources:    sourceGlobalOnly,
+		Precedence: precedenceGlobal,
+		Merge:      MergeListReplace,
+		Formats:    formatTOMLJSON,
 	},
 	{
-		Key:      "root_agents",
-		Type:     "table",
-		Default:  "none",
-		Purpose:  "Repositories that always keep a session named root running · one entry per repository path.",
-		Tier:     TierAdvanced,
-		Settable: false,
+		Key:        "root_agents",
+		Type:       "table",
+		Default:    "none",
+		Purpose:    "Repositories that always keep a session named root running · one entry per repository path.",
+		Tier:       TierAdvanced,
+		Settable:   false,
+		Sources:    sourceGlobalOnly,
+		Precedence: precedenceGlobal,
+		Merge:      MergeMapByKey,
+		Formats:    formatTOMLJSON,
 	},
 	{
-		Key:      "keys",
-		Type:     "table",
-		Default:  "none · the built-in bindings are used",
-		Purpose:  "Which key triggers each action in the terminal interface · one entry per action, replacing that action's default.",
-		Tier:     TierAdvanced,
-		Settable: false,
+		Key:        "keys",
+		Type:       "table",
+		Default:    "none · the built-in bindings are used",
+		Purpose:    "Which key triggers each action in the terminal interface · one entry per action, replacing that action's default.",
+		Tier:       TierAdvanced,
+		Settable:   false,
+		Sources:    sourceGlobalOnly,
+		Precedence: precedenceGlobal,
+		Merge:      MergeMapByKey,
+		Formats:    formatTOMLOnly,
+	},
+	{
+		Key:        "backend",
+		Type:       "string",
+		Default:    BackendLocal,
+		Purpose:    "The runtime used for this repository's sessions.",
+		Tier:       TierAdvanced,
+		Settable:   false,
+		Enum:       SupportedBackends,
+		Sources:    sourceRepoOnly,
+		Precedence: precedenceRepo,
+		Merge:      MergeReplace,
+		Formats:    formatTOMLJSON,
+	},
+	{
+		Key:        "docker",
+		Type:       "table",
+		Default:    "none",
+		Purpose:    "Container image and run arguments for repositories that use the docker backend.",
+		Tier:       TierAdvanced,
+		Settable:   false,
+		Sources:    sourceRepoOnly,
+		Precedence: precedenceRepo,
+		Merge:      MergeTableByField,
+		Formats:    formatTOMLJSON,
+	},
+	{
+		Key:        "post_worktree_commands",
+		Type:       "list",
+		Default:    "none",
+		Purpose:    "Commands run after af creates a worktree for this repository.",
+		Tier:       TierAdvanced,
+		Settable:   false,
+		Sources:    sourceRepoOnly,
+		Precedence: precedenceLegacyRepo,
+		Merge:      MergeListReplace,
+		Formats:    formatTOMLJSON,
+	},
+	{
+		Key:        "remote_hooks",
+		Type:       "table",
+		Default:    "none",
+		Purpose:    "Commands that provision and tear down this repository's hook-backed remote workspace.",
+		Tier:       TierAdvanced,
+		Settable:   false,
+		Sources:    sourceRepoOnly,
+		Precedence: precedenceLegacyRepo,
+		Merge:      MergeReplace,
+		Formats:    formatTOMLJSON,
+	},
+	{
+		Key:        "ssh",
+		Type:       "table",
+		Default:    "none",
+		Purpose:    "Connection details for repositories that run sessions through the SSH backend.",
+		Tier:       TierAdvanced,
+		Settable:   false,
+		Sources:    sourceRepoOnly,
+		Precedence: precedenceRepo,
+		Merge:      MergeTableByField,
+		Formats:    formatTOMLJSON,
 	},
 }
 
-// Manifest returns every user-facing global config key in tier order.
+// Manifest returns every user-facing GLOBAL config key in tier order. It keeps
+// the historical global-only contract used by the config agent and editors;
+// callers that need the schema union use AllManifest.
 //
-// The result is DEEP-copied: the entries and their Enum slices both. A shallow
-// copy would be a trap rather than a nicety — three entries take their Enum
-// straight from tmux.SupportedPrograms (the canonical agent list that
-// ValidateProgramEnum and program resolution read), so a caller that sorted or
-// rewrote the Enum of a returned entry would silently corrupt agent validation
-// process-wide. A picker UI sorting the values it was handed is an entirely
-// reasonable thing to write, so the copy is the manifest's job, not the
-// caller's.
+// The result is DEEP-copied, including Enum and Precedence slices. A shallow
+// copy would let an ordinary consumer sort corrupt the process-wide agent list
+// or the manifest's resolution policy.
 func Manifest() []ManifestEntry {
-	out := make([]ManifestEntry, len(configManifest))
-	copy(out, configManifest)
-	for i := range out {
-		if out[i].Enum == nil {
-			continue
+	return manifestForSource(SourceGlobal)
+}
+
+// AllManifest returns the union of user-facing keys across every supported
+// config schema, in tier order. Like Manifest, its result is deep-copied.
+func AllManifest() []ManifestEntry {
+	return cloneManifest(configManifest)
+}
+
+func manifestForSource(source ConfigSource) []ManifestEntry {
+	entries := make([]ManifestEntry, 0, len(configManifest))
+	for _, entry := range configManifest {
+		if entry.Sources.Has(source) {
+			entries = append(entries, entry)
 		}
-		enum := make([]string, len(out[i].Enum))
-		copy(enum, out[i].Enum)
-		out[i].Enum = enum
+	}
+	return cloneManifest(entries)
+}
+
+func cloneManifest(entries []ManifestEntry) []ManifestEntry {
+	out := make([]ManifestEntry, len(entries))
+	copy(out, entries)
+	for i := range out {
+		if out[i].Enum != nil {
+			enum := make([]string, len(out[i].Enum))
+			copy(enum, out[i].Enum)
+			out[i].Enum = enum
+		}
+		if out[i].Precedence != nil {
+			precedence := make([]ConfigSource, len(out[i].Precedence))
+			copy(precedence, out[i].Precedence)
+			out[i].Precedence = precedence
+		}
 	}
 	return out
+}
+
+// manifestKeysForSource is the sorted key projection used by source-specific
+// decoders. Sorting here keeps errors deterministic even though table order is
+// presentation order rather than alphabetical order.
+func manifestKeysForSource(source ConfigSource) []string {
+	var keys []string
+	for _, entry := range configManifest {
+		if entry.Sources.Has(source) {
+			keys = append(keys, entry.Key)
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func manifestGlobalOnlyKeySet() map[string]bool {
+	keys := make(map[string]bool)
+	for _, entry := range configManifest {
+		if entry.Sources.Has(SourceGlobal) && !entry.Sources.Has(SourceRepoShared) {
+			keys[entry.Key] = true
+		}
+	}
+	return keys
+}
+
+func manifestTOMLOnlyGlobalKeySet() map[string]bool {
+	keys := make(map[string]bool)
+	for _, entry := range configManifest {
+		if entry.Sources.Has(SourceGlobal) && !entry.Formats.Has(FormatJSON) {
+			keys[entry.Key] = true
+		}
+	}
+	return keys
 }
 
 // ManifestTiers is the tier order a briefing (and any future `af config`

--- a/config/manifest_briefing.go
+++ b/config/manifest_briefing.go
@@ -78,7 +78,7 @@ func RenderBriefing(cfg *Config, configPath string) string {
 // order.
 func manifestEntriesForTier(tier ConfigTier) []ManifestEntry {
 	var out []ManifestEntry
-	for _, e := range configManifest {
+	for _, e := range Manifest() {
 		if e.Tier == tier {
 			out = append(out, e)
 		}
@@ -169,8 +169,8 @@ func briefingSetHint(e ManifestEntry) string {
 // BRIEFING form, found by reflecting over Config's toml tags (never a
 // hand-written key → field map, see RenderBriefing). Returns "unknown" for a nil
 // cfg and for a key that names no field — the latter is unreachable while
-// TestManifestCoversEveryConfigKey passes, since it rejects a manifest key with
-// no matching field.
+// TestGlobalManifestCoversEveryGlobalConfigKey passes, since it rejects a key
+// in the global Manifest() view with no matching Config field.
 //
 // The field lookup is shared with CurrentValue (manifest_value.go); only the
 // rendering differs, because a briefing and an editable field want different

--- a/config/manifest_policy.go
+++ b/config/manifest_policy.go
@@ -1,0 +1,155 @@
+package config
+
+// ConfigSource identifies one layer that may participate in resolving a
+// configuration value. The order of these constants is the canonical
+// low-to-high precedence order; an entry's Precedence contains only the layers
+// that actually participate for that key.
+type ConfigSource uint8
+
+const (
+	// SourceInvalid is the zero value. It is never a real source: keeping zero
+	// invalid makes an omitted precedence choice fail the manifest tests.
+	SourceInvalid ConfigSource = iota
+	// SourceBuiltIn is the value compiled into af.
+	SourceBuiltIn
+	// SourceGlobal is the user's machine-wide config under AGENT_FACTORY_HOME.
+	SourceGlobal
+	// SourceLegacyRepo is the deprecated machine-local repos/<path-hash> source.
+	// It remains a read-only compatibility candidate for the two keys that used
+	// to live there, but is not an allowed destination in ManifestEntry.Sources.
+	SourceLegacyRepo
+	// SourceRepoShared is <repo-root>/.agent-factory/config.{toml,json}.
+	SourceRepoShared
+	// SourceProjectPersonal is the approved future machine-local project layer.
+	// Stage one defines the vocabulary but no entry admits it until that schema
+	// and its read/write paths exist.
+	SourceProjectPersonal
+	// SourceInvocation is an explicit value supplied by the operation being
+	// resolved. There is no universal CLI/environment layer today, so no entry
+	// includes it until a real caller supplies one.
+	SourceInvocation
+
+	configSourceCount
+)
+
+func (s ConfigSource) String() string {
+	switch s {
+	case SourceBuiltIn:
+		return "built-in"
+	case SourceGlobal:
+		return "global"
+	case SourceLegacyRepo:
+		return "legacy repo"
+	case SourceRepoShared:
+		return "repo-shared"
+	case SourceProjectPersonal:
+		return "personal project"
+	case SourceInvocation:
+		return "invocation"
+	default:
+		return "invalid"
+	}
+}
+
+// SourceSet is the set of supported configuration locations in which a key
+// may be declared. Built-in values and read-only compatibility candidates can
+// appear in Precedence, but are deliberately absent from Sources: this field
+// describes real user-facing configuration surfaces, not every resolver input.
+type SourceSet uint16
+
+// Has reports whether source is present in the set. Invalid and out-of-range
+// sources are always absent.
+func (s SourceSet) Has(source ConfigSource) bool {
+	if source <= SourceInvalid || source >= configSourceCount {
+		return false
+	}
+	return s&(SourceSet(1)<<source) != 0
+}
+
+const (
+	sourceGlobalOnly SourceSet = SourceSet(1) << SourceGlobal
+	sourceRepoOnly   SourceSet = SourceSet(1) << SourceRepoShared
+	sourceGlobalRepo SourceSet = sourceGlobalOnly | sourceRepoOnly
+)
+
+// MergePolicy says how successively higher-precedence present values combine.
+// Its zero value is invalid so every new manifest entry must choose explicitly.
+type MergePolicy uint8
+
+const (
+	MergeInvalid MergePolicy = iota
+	// MergeReplace means the higher source replaces the lower value as a unit.
+	MergeReplace
+	// MergeMapByKey means map entries resolve independently by key.
+	MergeMapByKey
+	// MergeTableByField means fields of a structured value resolve independently.
+	MergeTableByField
+	// MergeListReplace means a present higher list replaces the lower list; it
+	// never appends implicitly.
+	MergeListReplace
+)
+
+func (m MergePolicy) String() string {
+	switch m {
+	case MergeReplace:
+		return "replace"
+	case MergeMapByKey:
+		return "map-by-key"
+	case MergeTableByField:
+		return "table-by-field"
+	case MergeListReplace:
+		return "list-replace"
+	default:
+		return "invalid"
+	}
+}
+
+// ConfigFormat identifies an on-disk config encoding.
+type ConfigFormat uint8
+
+const (
+	// FormatInvalid is the zero value, never a real format.
+	FormatInvalid ConfigFormat = iota
+	FormatTOML
+	FormatJSON
+
+	configFormatCount
+)
+
+func (f ConfigFormat) String() string {
+	switch f {
+	case FormatTOML:
+		return "TOML"
+	case FormatJSON:
+		return "JSON"
+	default:
+		return "invalid"
+	}
+}
+
+// FormatSet is the set of on-disk encodings in which an entry is recognized
+// across its supported Sources. Its zero value is invalid.
+type FormatSet uint8
+
+// Has reports whether format is present in the set. Invalid and out-of-range
+// formats are always absent.
+func (s FormatSet) Has(format ConfigFormat) bool {
+	if format <= FormatInvalid || format >= configFormatCount {
+		return false
+	}
+	return s&(FormatSet(1)<<format) != 0
+}
+
+const (
+	formatTOMLOnly FormatSet = FormatSet(1) << FormatTOML
+	formatTOMLJSON FormatSet = formatTOMLOnly | FormatSet(1)<<FormatJSON
+)
+
+// Shared precedence slices are immutable package data. Every public manifest
+// accessor deep-copies them before returning entries to a caller.
+var (
+	precedenceGlobal     = []ConfigSource{SourceBuiltIn, SourceGlobal}
+	precedenceGlobalRepo = []ConfigSource{SourceBuiltIn, SourceGlobal, SourceRepoShared}
+	precedenceRepo       = []ConfigSource{SourceBuiltIn, SourceRepoShared}
+	precedenceLegacyRepo = []ConfigSource{SourceBuiltIn, SourceLegacyRepo, SourceRepoShared}
+)

--- a/config/manifest_policy_test.go
+++ b/config/manifest_policy_test.go
@@ -1,0 +1,309 @@
+package config
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+type manifestSchema struct {
+	name   string
+	source ConfigSource
+	typeOf reflect.Type
+}
+
+func currentManifestSchemas() []manifestSchema {
+	return []manifestSchema{
+		{name: "Config", source: SourceGlobal, typeOf: reflect.TypeOf(Config{})},
+		{name: "InRepoConfig", source: SourceRepoShared, typeOf: reflect.TypeOf(InRepoConfig{})},
+	}
+}
+
+// manifestSchemaFields returns every exported top-level field decoded by a
+// schema, indexed by its TOML key. Empty tags fail rather than disappear: the
+// TOML decoder binds an untagged exported field by Go name, which would create
+// a live config key that neither the manifest nor a user can name deliberately.
+func manifestSchemaFields(t *testing.T, schema manifestSchema) map[string]reflect.StructField {
+	t.Helper()
+	fields := make(map[string]reflect.StructField)
+	for i := range schema.typeOf.NumField() {
+		field := schema.typeOf.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+		key := tomlTagName(field.Tag.Get("toml"))
+		switch key {
+		case "-":
+			continue
+		case "":
+			t.Errorf("config.%s field %s has no toml key; add a toml tag or explicitly opt out with toml:\"-\"",
+				schema.name, field.Name)
+			continue
+		}
+		if previous, duplicate := fields[key]; duplicate {
+			t.Errorf("config.%s fields %s and %s both decode top-level key %q",
+				schema.name, previous.Name, field.Name, key)
+			continue
+		}
+		fields[key] = field
+	}
+	return fields
+}
+
+func allManifestKeyIndex(t *testing.T) map[string]ManifestEntry {
+	t.Helper()
+	byKey := make(map[string]ManifestEntry)
+	for _, entry := range AllManifest() {
+		if _, duplicate := byKey[entry.Key]; duplicate {
+			t.Fatalf("duplicate union manifest entry for key %q", entry.Key)
+		}
+		byKey[entry.Key] = entry
+	}
+	return byKey
+}
+
+// TestManifestCoversEveryConfigKey is the union anti-drift lock. It checks both
+// Config and InRepoConfig in both directions, including the source claim: adding
+// a field, dropping a source from a shared key, or claiming a source whose
+// decoder has no field all fail here.
+func TestManifestCoversEveryConfigKey(t *testing.T) {
+	byKey := allManifestKeyIndex(t)
+	schemas := currentManifestSchemas()
+	fieldsBySource := make(map[ConfigSource]map[string]reflect.StructField, len(schemas))
+
+	for _, schema := range schemas {
+		fields := manifestSchemaFields(t, schema)
+		fieldsBySource[schema.source] = fields
+		for key, field := range fields {
+			if reason, skipped := manifestSkippedKeys[key]; skipped {
+				if _, present := byKey[key]; present {
+					t.Errorf("config.%s field %s (%q) is both manifested and skipped (%s)",
+						schema.name, field.Name, key, reason)
+				}
+				continue
+			}
+			entry, present := byKey[key]
+			if !present {
+				t.Errorf("config.%s field %s (toml:%q) has no union manifest entry",
+					schema.name, field.Name, key)
+				continue
+			}
+			if !entry.Sources.Has(schema.source) {
+				t.Errorf("manifest entry %q exists for config.%s.%s but does not admit source %s",
+					key, schema.name, field.Name, schema.source)
+			}
+		}
+	}
+
+	knownSchemaSources := sourceGlobalOnly | sourceRepoOnly
+	for _, entry := range AllManifest() {
+		if unsupported := entry.Sources &^ knownSchemaSources; unsupported != 0 {
+			t.Errorf("manifest entry %q claims source bits %#x with no schema in the union coverage test",
+				entry.Key, unsupported)
+		}
+		matched := false
+		for _, schema := range schemas {
+			_, fieldExists := fieldsBySource[schema.source][entry.Key]
+			if entry.Sources.Has(schema.source) && !fieldExists {
+				t.Errorf("manifest entry %q admits %s, but config.%s has no decoded field for it",
+					entry.Key, schema.source, schema.name)
+			}
+			if fieldExists && entry.Sources.Has(schema.source) {
+				matched = true
+			}
+		}
+		if !matched {
+			t.Errorf("manifest entry %q names no field in any claimed config schema", entry.Key)
+		}
+	}
+}
+
+func formatsForManifestField(field reflect.StructField) FormatSet {
+	var formats FormatSet
+	if key := tomlTagName(field.Tag.Get("toml")); key != "" && key != "-" {
+		formats |= FormatSet(1) << FormatTOML
+	}
+	if key := jsonTagName(field.Tag.Get("json")); key != "" && key != "-" {
+		formats |= FormatSet(1) << FormatJSON
+	}
+	return formats
+}
+
+func expectedManifestTypeForField(field reflect.StructField) string {
+	typeOf := field.Type
+	for typeOf.Kind() == reflect.Pointer {
+		typeOf = typeOf.Elem()
+	}
+	return expectedManifestType(typeOf.Kind())
+}
+
+// TestManifestFormatsAndTypesMatchSchemas pins metadata against the actual
+// decoders. FormatSet is the union across a key's supported sources, so the two
+// overlap keys still have one format policy rather than duplicate entries.
+func TestManifestFormatsAndTypesMatchSchemas(t *testing.T) {
+	schemas := currentManifestSchemas()
+	fieldsBySource := make(map[ConfigSource]map[string]reflect.StructField, len(schemas))
+	for _, schema := range schemas {
+		fieldsBySource[schema.source] = manifestSchemaFields(t, schema)
+	}
+
+	for _, entry := range AllManifest() {
+		var wantFormats FormatSet
+		for _, schema := range schemas {
+			if !entry.Sources.Has(schema.source) {
+				continue
+			}
+			field, present := fieldsBySource[schema.source][entry.Key]
+			if !present {
+				continue // the coverage test owns the missing-field diagnostic
+			}
+			wantFormats |= formatsForManifestField(field)
+			wantType := expectedManifestTypeForField(field)
+			if wantType == "" {
+				t.Errorf("%s: config.%s field %s has unsupported kind %s",
+					entry.Key, schema.name, field.Name, field.Type.Kind())
+			} else if entry.Type != wantType {
+				t.Errorf("%s: manifest type %q disagrees with config.%s.%s (%s, want %q)",
+					entry.Key, entry.Type, schema.name, field.Name, field.Type, wantType)
+			}
+		}
+		if entry.Formats != wantFormats {
+			t.Errorf("%s: manifest formats %#x do not match decoder tags %#x",
+				entry.Key, entry.Formats, wantFormats)
+		}
+	}
+}
+
+func expectedPrecedence(entry ManifestEntry) []ConfigSource {
+	switch entry.Key {
+	case "post_worktree_commands", "remote_hooks":
+		return precedenceLegacyRepo
+	case "default_program", "program_overrides":
+		return precedenceGlobalRepo
+	default:
+		if entry.Sources == sourceGlobalOnly {
+			return precedenceGlobal
+		}
+		return precedenceRepo
+	}
+}
+
+func expectedMerge(entry ManifestEntry) MergePolicy {
+	switch entry.Key {
+	case "program_overrides", "limit_patterns", "root_agents", "keys":
+		return MergeMapByKey
+	case "theme", "docker", "ssh":
+		return MergeTableByField
+	case "cors_allowed_origins", "post_worktree_commands":
+		return MergeListReplace
+	default:
+		return MergeReplace
+	}
+}
+
+// TestManifestResolutionPoliciesAreComplete makes every new entry choose a
+// real source order and merge rule. It also pins the two deprecated repo-state
+// candidates so stage two cannot silently omit behavior that still resolves
+// today.
+func TestManifestResolutionPoliciesAreComplete(t *testing.T) {
+	for _, entry := range AllManifest() {
+		if entry.Sources == 0 {
+			t.Errorf("%s: Sources is empty", entry.Key)
+		}
+		if len(entry.Precedence) == 0 {
+			t.Errorf("%s: Precedence is empty", entry.Key)
+			continue
+		}
+		if entry.Precedence[0] != SourceBuiltIn {
+			t.Errorf("%s: precedence starts with %s, want built-in", entry.Key, entry.Precedence[0])
+		}
+
+		seen := make(map[ConfigSource]bool)
+		last := SourceInvalid
+		for _, source := range entry.Precedence {
+			if source <= SourceInvalid || source >= configSourceCount {
+				t.Errorf("%s: precedence contains invalid source %d", entry.Key, source)
+				continue
+			}
+			if seen[source] {
+				t.Errorf("%s: precedence repeats source %s", entry.Key, source)
+			}
+			seen[source] = true
+			if source <= last {
+				t.Errorf("%s: precedence is not low-to-high: %s follows %s", entry.Key, source, last)
+			}
+			last = source
+		}
+		for source := SourceGlobal; source < configSourceCount; source++ {
+			if entry.Sources.Has(source) && !seen[source] {
+				t.Errorf("%s: source %s is admitted but absent from precedence", entry.Key, source)
+			}
+		}
+		if want := expectedPrecedence(entry); !reflect.DeepEqual(entry.Precedence, want) {
+			t.Errorf("%s: precedence = %v, want %v", entry.Key, entry.Precedence, want)
+		}
+		if want := expectedMerge(entry); entry.Merge != want {
+			t.Errorf("%s: merge = %s, want %s", entry.Key, entry.Merge, want)
+		}
+		if entry.Merge <= MergeInvalid || entry.Merge > MergeListReplace {
+			t.Errorf("%s: merge policy %d is invalid", entry.Key, entry.Merge)
+		}
+		if entry.Formats == 0 {
+			t.Errorf("%s: Formats is empty", entry.Key)
+		}
+	}
+}
+
+// TestManifestDerivedInRepoPolicyViews compares the generated compatibility
+// views directly with both schemas. This is the lock that replaces the three
+// old literals: allowed/global-only is source policy, while TOML-only is format
+// compatibility.
+func TestManifestDerivedInRepoPolicyViews(t *testing.T) {
+	schemas := currentManifestSchemas()
+	globalFields := manifestSchemaFields(t, schemas[0])
+	repoFields := manifestSchemaFields(t, schemas[1])
+
+	wantAllowed := make([]string, 0, len(repoFields))
+	for key := range repoFields {
+		wantAllowed = append(wantAllowed, key)
+	}
+	sort.Strings(wantAllowed)
+	if !reflect.DeepEqual(inRepoAllowedKeys, wantAllowed) {
+		t.Errorf("inRepoAllowedKeys = %v, want schema-derived %v", inRepoAllowedKeys, wantAllowed)
+	}
+
+	wantGlobalOnly := make(map[string]bool)
+	wantTOMLOnly := make(map[string]bool)
+	for key, field := range globalFields {
+		if _, skipped := manifestSkippedKeys[key]; skipped {
+			continue
+		}
+		if _, shared := repoFields[key]; !shared {
+			wantGlobalOnly[key] = true
+		}
+		if jsonTagName(field.Tag.Get("json")) == "-" {
+			wantTOMLOnly[key] = true
+		}
+	}
+	if !reflect.DeepEqual(inRepoGlobalOnlyKeys, wantGlobalOnly) {
+		t.Errorf("inRepoGlobalOnlyKeys = %v, want schema-derived %v", inRepoGlobalOnlyKeys, wantGlobalOnly)
+	}
+	if !reflect.DeepEqual(tomlOnlyGlobalKeys, wantTOMLOnly) {
+		t.Errorf("tomlOnlyGlobalKeys = %v, want format-derived %v", tomlOnlyGlobalKeys, wantTOMLOnly)
+	}
+}
+
+// TestManifestKeepsGlobalConsumerView ensures expanding the underlying table
+// cannot leak repo-only keys into CurrentValue, the config agent, or either
+// existing global editor before those consumers gain source selection.
+func TestManifestKeepsGlobalConsumerView(t *testing.T) {
+	var want []ManifestEntry
+	for _, entry := range AllManifest() {
+		if entry.Sources.Has(SourceGlobal) {
+			want = append(want, entry)
+		}
+	}
+	if got := Manifest(); !reflect.DeepEqual(got, want) {
+		t.Errorf("Manifest() global view differs from SourceGlobal projection\ngot:  %v\nwant: %v", got, want)
+	}
+}

--- a/config/manifest_test.go
+++ b/config/manifest_test.go
@@ -77,8 +77,10 @@ func configTomlFields(t *testing.T) map[string]string {
 	return fields
 }
 
-// TestManifestCoversEveryConfigKey is the anti-drift lock that justifies
-// curating the manifest by hand instead of generating it. It asserts both
+// TestGlobalManifestCoversEveryGlobalConfigKey preserves Manifest's historical
+// global-only view for the config agent and editors. The union/source parity
+// lock lives in TestManifestCoversEveryConfigKey (manifest_policy_test.go).
+// This test asserts both
 // directions:
 //
 //  1. every toml-tagged field of Config has a manifest entry, unless it is in
@@ -92,7 +94,7 @@ func configTomlFields(t *testing.T) map[string]string {
 // Direction 2 matters as much as direction 1: a manifest that describes keys
 // which do not exist is worse than no manifest, because an agent would try to
 // set them.
-func TestManifestCoversEveryConfigKey(t *testing.T) {
+func TestGlobalManifestCoversEveryGlobalConfigKey(t *testing.T) {
 	byKey := manifestKeyIndex(t)
 	fields := configTomlFields(t)
 
@@ -107,7 +109,7 @@ func TestManifestCoversEveryConfigKey(t *testing.T) {
 		if _, present := byKey[key]; !present {
 			t.Errorf("config.Config field %s (toml:%q) has no manifest entry: a config agent briefed from "+
 				"the manifest would never know %q exists. Add an entry to configManifest in config/manifest.go "+
-				"(key, type, default, a one-line purpose, tier, settable), or — if it is machine-managed and no "+
+				"(including source, precedence, merge, and format metadata), or — if it is machine-managed and no "+
 				"user should ever set it — add it to manifestSkippedKeys with a reason.",
 				fieldName, key, key)
 		}
@@ -300,7 +302,7 @@ func TestManifestEntriesAreWellFormed(t *testing.T) {
 	validTypes := map[string]bool{"string": true, "bool": true, "int": true, "table": true, "list": true}
 	validTiers := map[ConfigTier]bool{TierCore: true, TierCommon: true, TierAdvanced: true}
 
-	for _, e := range Manifest() {
+	for _, e := range AllManifest() {
 		if e.Key == "" {
 			t.Fatalf("manifest entry with an empty key: %+v", e)
 		}
@@ -331,7 +333,7 @@ func TestManifestEntriesAreWellFormed(t *testing.T) {
 // bury a core key under the advanced ones.
 func TestManifestIsTierOrdered(t *testing.T) {
 	last := ConfigTier(0)
-	for _, e := range Manifest() {
+	for _, e := range AllManifest() {
 		if e.Tier < last {
 			t.Errorf("manifest is not tier-ordered: %q (tier %d) follows a tier-%d entry — "+
 				"move it into its tier's block in config/manifest.go", e.Key, e.Tier, last)
@@ -479,39 +481,48 @@ func TestRenderBriefingNilConfig(t *testing.T) {
 	}
 }
 
-// TestManifestDoesNotAliasTheAgentList pins that Manifest() hands back a deep
-// copy. It is not a hypothetical: three entries take their Enum directly from
-// tmux.SupportedPrograms — the canonical agent list ValidateProgramEnum and
-// ResolveProgram read — so under a shallow copy, a caller sorting or rewriting
-// the Enum it was handed would silently corrupt agent validation for the whole
-// process.
+// TestManifestDoesNotAliasSharedMetadata pins that the public accessors hand
+// back deep copies. Enum slices alias canonical agent/backend registries in the
+// table, and Precedence slices are shared by many entries, so either kind of
+// shallow copy would let an ordinary caller corrupt process-wide policy.
 //
 // A picker UI sorting its options is a completely ordinary thing to write, and
 // the manifest exists to be consumed by exactly that kind of surface, so the
 // copy has to be the manifest's job. In production nothing mutates Enum today —
 // this locks the property before the first consumer relies on it.
-func TestManifestDoesNotAliasTheAgentList(t *testing.T) {
-	before := make([]string, len(tmux.SupportedPrograms))
-	copy(before, tmux.SupportedPrograms)
+func TestManifestDoesNotAliasSharedMetadata(t *testing.T) {
+	beforePrograms := append([]string(nil), tmux.SupportedPrograms...)
+	beforeBackends := append([]string(nil), SupportedBackends...)
 
 	// A consumer doing something entirely reasonable with what it was handed.
-	for _, e := range Manifest() {
+	for _, e := range AllManifest() {
 		for i := range e.Enum {
 			e.Enum[i] = "corrupted"
 		}
+		for i := range e.Precedence {
+			e.Precedence[i] = SourceInvalid
+		}
 	}
 
-	if !reflect.DeepEqual(tmux.SupportedPrograms, before) {
-		t.Fatalf("mutating a Manifest() entry's Enum corrupted tmux.SupportedPrograms: got %v, want %v — "+
-			"Manifest() must deep-copy Enum, or every agent-name validation in the process is one "+
-			"caller's sort away from breaking", tmux.SupportedPrograms, before)
+	if !reflect.DeepEqual(tmux.SupportedPrograms, beforePrograms) {
+		t.Fatalf("mutating an AllManifest() Enum corrupted tmux.SupportedPrograms: got %v, want %v",
+			tmux.SupportedPrograms, beforePrograms)
+	}
+	if !reflect.DeepEqual(SupportedBackends, beforeBackends) {
+		t.Fatalf("mutating an AllManifest() Enum corrupted SupportedBackends: got %v, want %v",
+			SupportedBackends, beforeBackends)
 	}
 
-	// The manifest's own table must be intact too, not just the package global.
-	for _, e := range Manifest() {
+	// The manifest's own table and shared precedence slices must remain intact.
+	for _, e := range AllManifest() {
 		for _, v := range e.Enum {
 			if v == "corrupted" {
 				t.Fatalf("manifest entry %q kept a mutated Enum across calls", e.Key)
+			}
+		}
+		for _, source := range e.Precedence {
+			if source == SourceInvalid {
+				t.Fatalf("manifest entry %q kept a mutated Precedence across calls", e.Key)
 			}
 		}
 	}

--- a/config/manifest_value.go
+++ b/config/manifest_value.go
@@ -5,8 +5,9 @@ import (
 	"strconv"
 )
 
-// This file is the manifest's value-reading half: given a manifest key, what is
-// the user's live value, and in what form?
+// This file is the GLOBAL manifest view's value-reading half: given a key from
+// Manifest(), what is the user's live global value, and in what form? Repo-only
+// entries from AllManifest() resolve through the per-repo resolver instead.
 //
 // There are two forms, and the distinction is the whole reason this file is
 // separate from manifest_briefing.go:
@@ -28,8 +29,9 @@ import (
 //
 // It is the single reflection walk behind every value read — the briefing, the
 // TUI editor, and the web editor all land here. ok is false for a key that
-// names no toml-tagged field, which TestManifestCoversEveryConfigKey makes
-// unreachable for a manifest key.
+// names no toml-tagged field, which
+// TestGlobalManifestCoversEveryGlobalConfigKey makes unreachable for a key
+// returned by Manifest().
 func configFieldByTomlKey(cfg *Config, key string) (reflect.Value, bool) {
 	if cfg == nil {
 		return reflect.Value{}, false
@@ -49,8 +51,8 @@ func configFieldByTomlKey(cfg *Config, key string) (reflect.Value, bool) {
 	return reflect.Value{}, false
 }
 
-// CurrentValue returns cfg's live value for one manifest key in the form an
-// editor should show and `af config set` would accept back: a string bare, a
+// CurrentValue returns cfg's live value for one global manifest key in the form
+// an editor should show and `af config set` would accept back: a string bare, a
 // bool as "true"/"false", an int in decimal, and a composite (a table or list)
 // as compact JSON.
 //
@@ -80,8 +82,8 @@ func CurrentValue(cfg *Config, key string) (string, bool) {
 // config_types.go reaches both without either UI being touched.
 //
 // No single test pins that end to end; one per link in the chain does:
-//   - TestManifestCoversEveryConfigKey (config) — every toml-tagged Config field
-//     has a manifest entry.
+//   - TestGlobalManifestCoversEveryGlobalConfigKey (config) — every toml-tagged
+//     Config field is in the global Manifest() view.
 //   - TestCurrentValueCoversEveryManifestKey (config) — every entry's Key
 //     resolves through the reflection walk both surfaces read values with, so an
 //     entry with a typo'd Key cannot render as "unknown" in both UIs.
@@ -145,8 +147,9 @@ type ConfigEntry struct {
 	RequiresRestart bool `json:"requires_restart"`
 }
 
-// ManifestWithValues returns the manifest zipped with cfg's live values: the
-// single description of config that BOTH editor surfaces render from.
+// ManifestWithValues returns the global Manifest() view zipped with cfg's live
+// values: the single description of config that BOTH current editor surfaces
+// render from.
 //
 // A nil cfg (or a key that will not resolve) yields an empty Value rather than a
 // default, for the reason CurrentValue documents: an editor that pre-filled a


### PR DESCRIPTION
## What changed

This is stage 1 of #2216: expand the config manifest from the global schema to the union of the current global and checked-in schemas.

- add source, precedence, merge, and format metadata with invalid zero values
- add the five repo-only keys that were absent from the global manifest
- preserve `Manifest()` as the existing global editor/config-agent view and expose `AllManifest()` for the union
- derive `inRepoAllowedKeys`, `inRepoGlobalOnlyKeys`, and `tomlOnlyGlobalKeys` from manifest metadata
- represent the deprecated path-hash repo file as a read-only precedence candidate for hooks and post-worktree commands
- add bidirectional schema/source/format/type coverage and policy parity tests

No personal-project schema or resolver/provenance behavior lands in this PR. Those remain later, separately revertible stages.

## Why

Scope and format policy currently live in three manually synchronized lists while the manifest covers only `Config`. That shape already allowed known keys to drift out of actionable in-repo diagnostics. The union makes source policy declarative and makes omissions fail loudly before the resolver starts consuming it.

Effective configuration resolution and the current global editor payload remain unchanged. A checked-in `limit_patterns` key is now rejected as a known global-only key instead of the less useful unknown-key error.

## Validation

- `make test-container`
- `golangci-lint run --timeout=3m --fast`
- `go build ./...`
- `deadcode -test ./...`
- `gofmt -l .`
- `scripts/lint-file-length.sh`

Part of #2216.
