### PR TITLE
fix(web): reveal rail actions on hover and focus

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -343,8 +343,9 @@ header shows the session title, the terminal's connection state (`Live` /
 
 #### Per-session actions
 
-The selected session's rail row quietly reveals two glyph actions; unselected rows
-stay free of action chrome:
+Each session's rail row reserves space for two quiet glyph actions. They stay visible
+on the selected row and reveal on hover or keyboard focus on any other row, without
+moving the title:
 
 - **`▪` Archive** — move a live session into the archived group. On an archived
   row the same slot becomes **`↶` Restore**.
@@ -357,8 +358,8 @@ from that wall and stays hidden in every other state. Send follow-up instruction
 typing in the attached terminal (or with `af sessions send-prompt`).
 
 **Create** a session with **`+ New`**; the new row appears in the rail and opens
-attached. Kill and archive resolve the selected session by its stable id, so titles
-that collide across repos are never ambiguous.
+attached. Kill and archive resolve the row that exposed the action by its stable id,
+so acting on an unselected row and titles that collide across repos are unambiguous.
 
 ### Tabs
 

--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -807,6 +807,14 @@ body {
   align-self: center;
   flex: 0 0 auto;
   gap: 0.15rem;
+  opacity: 0;
+  pointer-events: none;
+}
+.af-row-selected > .af-row-actions,
+.af-row:hover > .af-row-actions,
+.af-row:focus-within > .af-row-actions {
+  opacity: 1;
+  pointer-events: auto;
 }
 .af-rail-action {
   display: inline-flex;

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -10620,10 +10620,10 @@ var AppShell = class {
   headTitle = null;
   headMeta = null;
   // The selected rail row's archive/restore control and the archived-ness it currently
-  // shows (#1932, #2186). A session can flip archived⇄live WITHOUT a selection change
-  // (archiving or restoring the row that is already selected — the common path), so
-  // patchMainHead swaps this control's glyph + accessible verb in place, exactly as it
-  // patches the header text. null when the selected row is not visible in the rail.
+  // shows (#1932, #2186). Every row owns controls now (#2223), but a session can flip
+  // archived⇄live WITHOUT a selection change, so patchMainHead still needs this one
+  // reference to swap the selected control's glyph + accessible verb in place. null
+  // when the selected row is not visible in the rail.
   lifecycleBtn = null;
   lifecycleArchived = false;
   // The usage-limit Retry button and whether it is currently shown (#1934). Same
@@ -10844,45 +10844,46 @@ var AppShell = class {
     }
     const rows = visible.map((s) => {
       const selected = s.id === state.selectedId;
-      return sessionRow(s, selected, this.actions, selected ? this.selectedRowActions(s) : null);
+      return sessionRow(s, selected, this.actions, this.rowActions(s, selected));
     });
     const notice = this.railNotice(state, scoped, visible);
     list.replaceChildren(...notice ? [notice, ...rows] : rows);
   }
-  /** Quiet per-session controls shown only beside the selected rail row (#2186).
-   *  Archive/Restore share one slot; the click reads lifecycleArchived at gesture
-   *  time so patchMainHead can change the action without rebuilding the row. */
-  selectedRowActions(selected) {
+  /** Quiet per-session controls reserved beside every rail row (#2186, #2223).
+   *  CSS reveals the slot for selection, hover, or keyboard focus without changing
+   *  row geometry. Archive/Restore share one slot; its data-action is read at gesture
+   *  time so patchMainHead can change the selected row without rebuilding it. */
+  rowActions(session, selected) {
     const lifecycleBtn = h2("button", { type: "button", class: "af-rail-action af-rail-lifecycle" });
     lifecycleBtn.addEventListener("click", (e) => {
       e.stopPropagation();
-      if (this.lifecycleArchived) {
-        this.actions.restore();
+      if (lifecycleBtn.dataset.action === "restore") {
+        this.actions.restore(session);
       } else {
-        this.actions.archive();
+        this.actions.archive(session);
       }
     });
-    this.lifecycleBtn = lifecycleBtn;
-    this.patchLifecycleButton(isArchived(selected));
+    const archived = isArchived(session);
+    this.patchLifecycleButton(lifecycleBtn, archived);
+    if (selected) {
+      this.lifecycleBtn = lifecycleBtn;
+      this.lifecycleArchived = archived;
+    }
     const killBtn = h2("button", { type: "button", class: "af-rail-action af-rail-kill" }, "\u232B");
     killBtn.setAttribute("aria-label", "Kill session");
     killBtn.setAttribute("title", "Kill session");
     killBtn.addEventListener("click", (e) => {
       e.stopPropagation();
-      this.actions.kill();
+      this.actions.kill(session);
     });
     return h2("div", { class: "af-row-actions" }, lifecycleBtn, killBtn);
   }
   /** Applies both the visible static glyph and the accessible reverse verb to the
-   *  selected row's lifecycle slot. Kept in one helper so render and live patching
-   *  cannot disagree about what an archived row offers. */
-  patchLifecycleButton(archived) {
-    const btn = this.lifecycleBtn;
-    if (!btn) {
-      return;
-    }
-    this.lifecycleArchived = archived;
+   *  lifecycle slot. Kept in one helper so render and selected-row live patching
+   *  cannot disagree about what an archived row offers or fires. */
+  patchLifecycleButton(btn, archived) {
     const verb = archived ? "Restore session" : "Archive session";
+    btn.dataset.action = archived ? "restore" : "archive";
     btn.textContent = archived ? "\u21B6" : "\u25AA";
     btn.setAttribute("aria-label", verb);
     btn.setAttribute("title", verb);
@@ -11383,7 +11384,8 @@ var AppShell = class {
     this.headMeta.className = `af-term-meta af-term-${state.termStatus}`;
     const nowArchived = isArchived(selected);
     if (this.lifecycleBtn && nowArchived !== this.lifecycleArchived) {
-      this.patchLifecycleButton(nowArchived);
+      this.patchLifecycleButton(this.lifecycleBtn, nowArchived);
+      this.lifecycleArchived = nowArchived;
     }
     const nowLimited = isLimitReached(selected);
     if (this.retryBtn && nowLimited !== this.retryVisible) {
@@ -11508,9 +11510,7 @@ function sessionRow(s, selected, actions2, rowActions) {
     row.append(dot);
   }
   row.append(main);
-  if (rowActions) {
-    row.append(rowActions);
-  }
+  row.append(rowActions);
   row.setAttribute("role", "option");
   row.setAttribute("aria-selected", selected ? "true" : "false");
   row.setAttribute("title", `${s.title} \u2014 ${status.label}`);
@@ -11818,15 +11818,12 @@ function newSession() {
     })
   );
 }
-function openConfirm(action) {
-  const sel = selectedSession2();
-  if (!sel) {
-    return;
-  }
+function openConfirm(action, session) {
+  const target = { id: session.id ?? "", title: session.title };
   openModal(
     confirmModal({
       action,
-      sessionTitle: sel.title,
+      sessionTitle: target.title,
       onConfirm: () => {
         const tok = token;
         if (tok === null || !modal) {
@@ -11834,7 +11831,7 @@ function openConfirm(action) {
         }
         const m = modal;
         m.setBusy(true);
-        const run = action === "kill" ? killSession(sel.id, sel.title, tok) : action === "archive" ? archiveSession(sel.id, sel.title, tok) : restoreSession(sel.title, tok);
+        const run = action === "kill" ? killSession(target.id, target.title, tok) : action === "archive" ? archiveSession(target.id, target.title, tok) : restoreSession(target.title, tok);
         void run.then(closeModal).catch((e) => {
           m.setBusy(false);
           m.setError(describeError(e));
@@ -12183,9 +12180,9 @@ var actions = {
   disconnect,
   open: openFromRail,
   newSession,
-  kill: () => openConfirm("kill"),
-  archive: () => openConfirm("archive"),
-  restore: () => openConfirm("restore"),
+  kill: (session) => openConfirm("kill", session),
+  archive: (session) => openConfirm("archive", session),
+  restore: (session) => openConfirm("restore", session),
   retryLimit: doRetryLimit,
   switchTab,
   openTab,

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "813f30130917";
+const VERSION = "cf27d8b18ef1";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -828,8 +828,47 @@ test("status dots (#1766): waiting shows a green dot, working shows none, error 
   await row(p, "probe-limit").click();
   const retry = p.locator(".af-term-head button", { hasText: "Retry" });
   await expect(retry).toBeVisible();
-  await expect(row(p, "probe-limit").locator(".af-row-actions")).toBeVisible();
-  await expect(row(p, "probe-waiting").locator(".af-row-actions")).toHaveCount(0);
+  const selectedActions = row(p, "probe-limit").locator(".af-row-actions");
+  const waitingActions = row(p, "probe-waiting").locator(".af-row-actions");
+  await expect(selectedActions).toHaveCSS("opacity", "1");
+  await expect(waitingActions).toHaveCount(1);
+  await expect(waitingActions).toHaveCSS("opacity", "0");
+
+  // #2223: selection, pointer hover, and keyboard focus all reveal the same quiet
+  // controls. Every row reserves the slot, so hovering an unselected row cannot move
+  // its text under the pointer.
+  await row(p, "probe-limit").hover();
+  await expect(selectedActions).toHaveCSS("opacity", "1");
+  await p.mouse.move(0, 0);
+  const geometry = () =>
+    row(p, "probe-waiting").evaluate((el) => {
+      const main = el.querySelector(".af-row-main")!.getBoundingClientRect();
+      const actions = el.querySelector(".af-row-actions")!.getBoundingClientRect();
+      return { mainLeft: main.left, mainWidth: main.width, actionsLeft: actions.left, actionsWidth: actions.width };
+    });
+  const beforeHover = await geometry();
+  await row(p, "probe-waiting").hover();
+  await expect(waitingActions).toHaveCSS("opacity", "1");
+  expect(await geometry(), "hover reveal keeps the reserved row geometry").toEqual(beforeHover);
+  await p.mouse.move(0, 0);
+  await expect(waitingActions).toHaveCSS("opacity", "0");
+
+  // Put focus on the preceding button in DOM order, then use a real Tab keystroke to
+  // enter this row. The opacity-zero action remains tabbable and :focus-within makes
+  // it visible as soon as focus arrives.
+  const keyboardTarget = railAction(p, "probe-waiting", "Archive session");
+  await keyboardTarget.evaluate((target) => {
+    const buttons = [...document.querySelectorAll<HTMLButtonElement>('button:not([disabled])')];
+    const before = buttons[buttons.indexOf(target as HTMLButtonElement) - 1];
+    if (!before) {
+      throw new Error("archive action has no preceding tab stop");
+    }
+    before.focus();
+  });
+  await p.keyboard.press("Tab");
+  await expect(keyboardTarget).toBeFocused();
+  await expect(waitingActions).toHaveCSS("opacity", "1");
+  await keyboardTarget.evaluate((el) => el.blur());
   await row(p, "probe-waiting").click();
   await expect(retry).toBeHidden();
 
@@ -853,12 +892,15 @@ test("click-to-attach opens the xterm terminal and shows live output", async () 
   await expect(page.locator(".af-term-meta")).toContainText("Live");
   await expect(page.locator(".af-app.af-kb-terminal")).toBeVisible();
 
-  // The quiet actions live beside the selected instance, not permanently in the
-  // terminal header or on every rail row. Kill is a muted glyph here; af-danger is
-  // reserved for the confirmation step.
-  await expect(page.locator(".af-row-actions")).toHaveCount(1);
-  await expect(row(page, SESSION_A).locator(".af-row-actions")).toBeVisible();
-  await expect(row(page, SESSION_B).locator(".af-row-actions")).toHaveCount(0);
+  // Every instance reserves the quiet action slot, but only the selected row shows
+  // it at rest. Kill remains muted; af-danger is reserved for confirmation.
+  const visibleRows = page.locator(".af-rail-list .af-row");
+  await expect(page.locator(".af-row-actions")).toHaveCount(await visibleRows.count());
+  await expect(row(page, SESSION_A).locator(".af-row-actions")).toHaveCSS("opacity", "1");
+  await page.mouse.move(0, 0);
+  await expect(row(page, SESSION_B).locator(".af-row-actions")).toHaveCSS("opacity", "0");
+  await row(page, SESSION_A).hover();
+  await expect(row(page, SESSION_A).locator(".af-row-actions")).toHaveCSS("opacity", "1");
   await expect(railAction(page, SESSION_A, "Archive session")).toHaveText("▪");
   await expect(railAction(page, SESSION_A, "Kill session")).toHaveText("⌫");
   await expect(railAction(page, SESSION_A, "Kill session")).not.toHaveClass(/af-danger/);
@@ -876,13 +918,14 @@ test("the #1694 keyboard model: j/k navigate, Enter attaches, Escape returns to 
 
   // j moves the selection off A to the next row; the terminal is NOT stolen — j/k
   // always navigate the rail in nav mode. (Pre-#1693 j/k silently fed the agent.)
+  await page.mouse.move(0, 0);
   await page.keyboard.press("j");
   await expect(row(page, SESSION_A)).not.toHaveClass(/af-row-selected/);
-  await expect(row(page, SESSION_A).locator(".af-row-actions")).toHaveCount(0);
+  await expect(row(page, SESSION_A).locator(".af-row-actions")).toHaveCSS("opacity", "0");
   const movedTo = page.locator(".af-rail-list .af-row.af-row-selected");
   await expect(movedTo).toHaveCount(1);
-  await expect(movedTo.locator(".af-row-actions")).toBeVisible();
-  await expect(page.locator(".af-row-actions")).toHaveCount(1);
+  await expect(movedTo.locator(".af-row-actions")).toHaveCSS("opacity", "1");
+  await expect(page.locator(".af-row-actions")).toHaveCount(await page.locator(".af-rail-list .af-row").count());
   await expect(page.locator(".af-app.af-kb-rail")).toBeVisible();
 
   // k moves back up to A — j/k are symmetric rail navigation.
@@ -2646,16 +2689,22 @@ test.describe("create → kill (one session, two flows)", () => {
   });
 });
 
-test("archive: the archive confirm retires the session out of the default rail", async () => {
-  // Archive session B. Select it (click attaches, which is fine), then archive +
-  // confirm.
-  await row(page, SESSION_B).click();
+test("archive: an unselected row's hover action retires that session, not the selection", async () => {
+  // Keep A selected, then invoke B's hover-revealed action. The modal target must be
+  // the row that owns the button; deriving it from the current selection would archive
+  // A instead (#2223).
+  await row(page, SESSION_A).click();
   await expect(page.locator(".af-main.af-main-term")).toBeVisible();
-
-  // Archive is the quiet ▪ glyph beside the selected row, not a labelled header chip.
+  await page.mouse.move(0, 0);
+  await expect(row(page, SESSION_B).locator(".af-row-actions")).toHaveCSS("opacity", "0");
+  await row(page, SESSION_B).hover();
+  await expect(row(page, SESSION_B).locator(".af-row-actions")).toHaveCSS("opacity", "1");
   await railAction(page, SESSION_B, "Archive session").click();
   const modal = page.locator(".af-modal-card");
   await expect(modal).toBeVisible();
+  await expect(modal).toContainText(SESSION_B);
+  await expect(row(page, SESSION_A)).toHaveClass(/af-row-selected/);
+  await expect(row(page, SESSION_B)).not.toHaveClass(/af-row-selected/);
   await modal.locator("button.af-primary").click();
 
   // B LEAVES the default rail (feat: hide archived by default) — archived sessions are
@@ -2673,6 +2722,14 @@ test("archive: the archive confirm retires the session out of the default rail",
   await expect(archivedDot).toHaveClass(/af-dot-archived/);
   await expect(archivedDot).toHaveText("▧");
   await expect(archivedDot).not.toHaveClass(/af-dot-spin/);
+  // An archived unselected row reserves the same quiet slot, reveals it on hover,
+  // and reverses the lifecycle action to Restore rather than Archive.
+  await page.mouse.move(0, 0);
+  await expect(row(page, SESSION_B).locator(".af-row-actions")).toHaveCSS("opacity", "0");
+  await expect(railAction(page, SESSION_B, "Archive session")).toHaveCount(0);
+  await expect(railAction(page, SESSION_B, "Restore session")).toHaveText("↶");
+  await row(page, SESSION_B).hover();
+  await expect(row(page, SESSION_B).locator(".af-row-actions")).toHaveCSS("opacity", "1");
 
   await resetFilter(page);
   await expect(row(page, SESSION_B)).toHaveCount(0);

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -600,18 +600,15 @@ function newSession(): void {
   );
 }
 
-/** Opens the kill/archive/restore confirm modal for the selected session. Restore
- *  is the reverse of archive (#1932): the archived row's lifecycle glyph becomes
- *  Restore, and confirming it POSTs RestoreSession. */
-function openConfirm(action: "kill" | "archive" | "restore"): void {
-  const sel = selectedSession();
-  if (!sel) {
-    return;
-  }
+/** Opens the kill/archive/restore confirm modal for the rail row that invoked it.
+ *  This cannot derive its target from selection now that hover exposes actions on
+ *  unselected rows (#2223). Restore remains the reverse of archive (#1932). */
+function openConfirm(action: "kill" | "archive" | "restore", session: SessionData): void {
+  const target = { id: session.id ?? "", title: session.title };
   openModal(
     confirmModal({
       action,
-      sessionTitle: sel.title,
+      sessionTitle: target.title,
       onConfirm: () => {
         const tok = token;
         // `=== null` not `!tok`: "" is the authorized-tokenless credential (#1696).
@@ -621,13 +618,13 @@ function openConfirm(action: "kill" | "archive" | "restore"): void {
         const m = modal;
         m.setBusy(true);
         // Restore resolves the target by TITLE only — its daemon request has no id
-        // field (see restoreSession), unlike kill/archive which key by sel.id.
+        // field (see restoreSession), unlike kill/archive which key by target.id.
         const run =
           action === "kill"
-            ? killSession(sel.id, sel.title, tok)
+            ? killSession(target.id, target.title, tok)
             : action === "archive"
-              ? archiveSession(sel.id, sel.title, tok)
-              : restoreSession(sel.title, tok);
+              ? archiveSession(target.id, target.title, tok)
+              : restoreSession(target.title, tok);
         void run.then(closeModal).catch((e) => {
           m.setBusy(false);
           m.setError(describeError(e));
@@ -1297,9 +1294,9 @@ const actions = {
   disconnect,
   open: openFromRail,
   newSession,
-  kill: () => openConfirm("kill"),
-  archive: () => openConfirm("archive"),
-  restore: () => openConfirm("restore"),
+  kill: (session: SessionData) => openConfirm("kill", session),
+  archive: (session: SessionData) => openConfirm("archive", session),
+  restore: (session: SessionData) => openConfirm("restore", session),
   retryLimit: doRetryLimit,
   switchTab,
   openTab,

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1007,16 +1007,26 @@ body {
   flex: 1;
 }
 
-/* Per-session lifecycle controls (#2186): only the selected row creates this slot.
- * Archive/Restore matches the rail filter's quiet outlined-glyph treatment; Kill is
- * quieter still at rest (a bare, muted ⌫) and becomes explicit through its distinct
- * glyph, accessible name, and the unchanged destructive confirm step. */
+/* Per-session lifecycle controls (#2186, #2223): every row reserves this slot, so
+ * revealing it never shifts the title under the pointer. It is visually withdrawn at
+ * rest but remains in the tab order; focusing either button makes :focus-within reveal
+ * the whole slot for keyboard parity. Archive/Restore matches the rail filter's quiet
+ * outlined-glyph treatment; Kill stays quieter still at rest. */
 .af-row-actions {
   display: flex;
   align-items: center;
   align-self: center;
   flex: 0 0 auto;
   gap: 0.15rem;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.af-row-selected > .af-row-actions,
+.af-row:hover > .af-row-actions,
+.af-row:focus-within > .af-row-actions {
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .af-rail-action {

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -141,13 +141,13 @@ export interface Actions {
   open(id: string): void;
   /** Opens the new-session modal (#1592 Phase 5 PR5). */
   newSession(): void;
-  /** Opens the kill-confirm modal for the current selection. */
-  kill(): void;
-  /** Opens the archive-confirm modal for the current selection. */
-  archive(): void;
-  /** Opens the restore-confirm modal for the current selection (an archived / Lost
-   *  / Dead session): the reverse of archive (#1932). */
-  restore(): void;
+  /** Opens the kill-confirm modal for this rail row. */
+  kill(session: SessionData): void;
+  /** Opens the archive-confirm modal for this rail row. */
+  archive(session: SessionData): void;
+  /** Opens the restore-confirm modal for this rail row (an archived / Lost / Dead
+   *  session): the reverse of archive (#1932). */
+  restore(session: SessionData): void;
   /** Resumes the current selection from its usage-limit wall (#1934) — the web's
    *  analogue of the TUI's `c`. Fires immediately with NO confirm, matching the
    *  TUI: it is not destructive (it re-delivers the prompt the session was already
@@ -601,10 +601,10 @@ export class AppShell {
   private headTitle: HTMLElement | null = null;
   private headMeta: HTMLElement | null = null;
   // The selected rail row's archive/restore control and the archived-ness it currently
-  // shows (#1932, #2186). A session can flip archived⇄live WITHOUT a selection change
-  // (archiving or restoring the row that is already selected — the common path), so
-  // patchMainHead swaps this control's glyph + accessible verb in place, exactly as it
-  // patches the header text. null when the selected row is not visible in the rail.
+  // shows (#1932, #2186). Every row owns controls now (#2223), but a session can flip
+  // archived⇄live WITHOUT a selection change, so patchMainHead still needs this one
+  // reference to swap the selected control's glyph + accessible verb in place. null
+  // when the selected row is not visible in the rail.
   private lifecycleBtn: HTMLElement | null = null;
   private lifecycleArchived = false;
   // The usage-limit Retry button and whether it is currently shown (#1934). Same
@@ -1111,27 +1111,32 @@ export class AppShell {
     }
     const rows = visible.map((s) => {
       const selected = s.id === state.selectedId;
-      return sessionRow(s, selected, this.actions, selected ? this.selectedRowActions(s) : null);
+      return sessionRow(s, selected, this.actions, this.rowActions(s, selected));
     });
     const notice = this.railNotice(state, scoped, visible);
     list.replaceChildren(...(notice ? [notice, ...rows] : rows));
   }
 
-  /** Quiet per-session controls shown only beside the selected rail row (#2186).
-   *  Archive/Restore share one slot; the click reads lifecycleArchived at gesture
-   *  time so patchMainHead can change the action without rebuilding the row. */
-  private selectedRowActions(selected: SessionData): HTMLElement {
+  /** Quiet per-session controls reserved beside every rail row (#2186, #2223).
+   *  CSS reveals the slot for selection, hover, or keyboard focus without changing
+   *  row geometry. Archive/Restore share one slot; its data-action is read at gesture
+   *  time so patchMainHead can change the selected row without rebuilding it. */
+  private rowActions(session: SessionData, selected: boolean): HTMLElement {
     const lifecycleBtn = h("button", { type: "button", class: "af-rail-action af-rail-lifecycle" });
     lifecycleBtn.addEventListener("click", (e) => {
       e.stopPropagation();
-      if (this.lifecycleArchived) {
-        this.actions.restore();
+      if (lifecycleBtn.dataset.action === "restore") {
+        this.actions.restore(session);
       } else {
-        this.actions.archive();
+        this.actions.archive(session);
       }
     });
-    this.lifecycleBtn = lifecycleBtn;
-    this.patchLifecycleButton(isArchived(selected));
+    const archived = isArchived(session);
+    this.patchLifecycleButton(lifecycleBtn, archived);
+    if (selected) {
+      this.lifecycleBtn = lifecycleBtn;
+      this.lifecycleArchived = archived;
+    }
 
     // Kill stays unmistakably destructive through its distinct ⌫ glyph and confirm,
     // but its resting rail treatment is deliberately muted instead of af-danger.
@@ -1140,21 +1145,17 @@ export class AppShell {
     killBtn.setAttribute("title", "Kill session");
     killBtn.addEventListener("click", (e) => {
       e.stopPropagation();
-      this.actions.kill();
+      this.actions.kill(session);
     });
     return h("div", { class: "af-row-actions" }, lifecycleBtn, killBtn);
   }
 
   /** Applies both the visible static glyph and the accessible reverse verb to the
-   *  selected row's lifecycle slot. Kept in one helper so render and live patching
-   *  cannot disagree about what an archived row offers. */
-  private patchLifecycleButton(archived: boolean): void {
-    const btn = this.lifecycleBtn;
-    if (!btn) {
-      return;
-    }
-    this.lifecycleArchived = archived;
+   *  lifecycle slot. Kept in one helper so render and selected-row live patching
+   *  cannot disagree about what an archived row offers or fires. */
+  private patchLifecycleButton(btn: HTMLElement, archived: boolean): void {
     const verb = archived ? "Restore session" : "Archive session";
+    btn.dataset.action = archived ? "restore" : "archive";
     btn.textContent = archived ? "↶" : "▪";
     btn.setAttribute("aria-label", verb);
     btn.setAttribute("title", verb);
@@ -1789,7 +1790,8 @@ export class AppShell {
     // this patch is what keeps a same-selection state change correct in place.
     const nowArchived = isArchived(selected);
     if (this.lifecycleBtn && nowArchived !== this.lifecycleArchived) {
-      this.patchLifecycleButton(nowArchived);
+      this.patchLifecycleButton(this.lifecycleBtn, nowArchived);
+      this.lifecycleArchived = nowArchived;
     }
 
     // Show/hide Retry as the selected session enters or leaves the usage-limit wall
@@ -2073,11 +2075,11 @@ function beginTabRename(
   input.select();
 }
 
-/** One session row: a status dot, the (prefixed) title, the branch line, and (only
- *  when selected) its quiet lifecycle actions (#2186). Clicking opens the session by
+/** One session row: a status dot, the (prefixed) title, the branch line, and a reserved
+ *  slot for its quiet lifecycle actions (#2186, #2223). Clicking opens the session by
  *  its stable id (selects it and attaches its terminal, #1693); a row lacking an id
  *  (never expected from a live Snapshot) is rendered but inert. */
-function sessionRow(s: SessionData, selected: boolean, actions: Actions, rowActions: HTMLElement | null): HTMLElement {
+function sessionRow(s: SessionData, selected: boolean, actions: Actions, rowActions: HTMLElement): HTMLElement {
   const status = rowStatus(s);
   const creating = isCreating(s);
 
@@ -2104,9 +2106,7 @@ function sessionRow(s: SessionData, selected: boolean, actions: Actions, rowActi
     row.append(dot);
   }
   row.append(main);
-  if (rowActions) {
-    row.append(rowActions);
-  }
+  row.append(rowActions);
   row.setAttribute("role", "option");
   row.setAttribute("aria-selected", selected ? "true" : "false");
   row.setAttribute("title", `${s.title} — ${status.label}`);


### PR DESCRIPTION
## Summary

- reserve the quiet Archive/Restore and Kill controls on every visible session row, revealing them for selection, pointer hover, and `:focus-within` without moving row text
- keep the hidden controls in the keyboard tab order, with the existing focus-visible treatment and destructive confirmation flow
- target lifecycle confirms from the row that exposed the action, rather than the current selection, so an unselected row can never archive or kill the wrong session
- preserve the conditional pane-header Retry path, the rail's muted treatment, the inline funnel, and the fixed new-tab popover behavior

## Why this shape

Rendering the reserved slot is the only simple shape that satisfies both no-layout-shift and keyboard reachability. Opacity withdraws inactive controls visually while leaving their native buttons tabbable; focus immediately activates the row's `:focus-within` reveal. Passing the row's `SessionData` through the typed `Actions` interface also removes the old selected-session sharp edge: a lifecycle action can no longer silently retarget itself just because the obvious caller is an unselected row.

## DOM cost

The implementation adds exactly one wrapper and two native buttons per visible row. In a disposable synthetic run with 1,000 added rows (1,008 visible including fixture rows), the page rendered 1,008 wrappers and 2,016 action buttons, with 9,203 total elements. Cold navigation-to-row-render samples were 388 ms, 414 ms, and 547 ms (414 ms median).

## Visual verification

Inspected the committed bundle at 1280px and 375px in light and dark. The selected and hovered rows used the same quiet controls, unselected hover did not change geometry, keyboard focus revealed an archived row's Restore action with a visible focus ring, and long-tab horizontal scroll kept the viewport-fixed new-tab menu visible and anchored.

## Verification

All commands below ran after final commit `432939004ca4c2fc04accead94f2bfd04a60780c` was pushed, with local HEAD matching the remote branch:

- `make web-build`
- `make web-test` (400 passed)
- `make web-selftest-container` (105 passed, including #2219's anchored-menu regression)
- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (no output)
- `go build ./...`
- `make test-container`
- `deadcode -test ./...` (no output)
- `scripts/lint-file-length.sh`

Closes #2223.

— Captain Claude
