### PR TITLE
fix(tmux): make prompt submission atomic

### DIFF
--- a/session/tmux/program.go
+++ b/session/tmux/program.go
@@ -37,13 +37,17 @@ func (t *TmuxSession) preSubmitEchoBehavior() preSubmitEchoBehavior {
 	return t.preSubmitEcho
 }
 
-// notePreSubmitEchoObserved promotes an unknown/non-echoing capability only on
-// positive evidence. A missing tail can never demote it: absence is precisely
-// the ambiguous signal #2213 forbids us from treating as detection.
+// notePreSubmitEchoObserved promotes an UNKNOWN capability only on positive
+// evidence. A known non-echoing agent stays non-echoing even if unrelated pane
+// output happens to contain the same short tail (#2214 review). A missing tail
+// can never demote it: absence is precisely the ambiguous signal #2213 forbids
+// us from treating as detection.
 func (t *TmuxSession) notePreSubmitEchoObserved() {
 	t.programMu.Lock()
 	defer t.programMu.Unlock()
-	t.preSubmitEcho = preSubmitEchoes
+	if t.preSubmitEcho == preSubmitEchoUnknown {
+		t.preSubmitEcho = preSubmitEchoes
+	}
 }
 
 // setProgramCmd stores the pane's program command string under programMu.

--- a/session/tmux/session.go
+++ b/session/tmux/session.go
@@ -56,6 +56,10 @@ type TmuxSession struct {
 	program       string
 	preSubmitEcho preSubmitEchoBehavior
 	programMu     sync.RWMutex
+	// submitMu serializes the whole clear → paste → Enter transaction. A second
+	// submit must never clear the first submit's freshly pasted composer while
+	// that first call is still waiting to send Enter (#2178 review).
+	submitMu sync.Mutex
 	// ptyFactory is used to create a PTY for the tmux session.
 	ptyFactory PtyFactory
 	// cmdExec is used to execute commands in the tmux session.

--- a/session/tmux/submit.go
+++ b/session/tmux/submit.go
@@ -73,9 +73,9 @@ const (
 // delivery promotes that session to preSubmitEchoes.
 func knownPreSubmitEchoBehavior(command string) preSubmitEchoBehavior {
 	switch DetectAgentFromCommand(command) {
-	case ProgramClaude:
+	case ProgramClaude, ProgramAider:
 		// Claude visibly renders pasted composer input; #1982's positive-tail
-		// delivery guard depends on this behavior.
+		// delivery guard depends on this behavior. Aider does too (#2214 review).
 		return preSubmitEchoes
 	case ProgramCodex:
 		// Codex consumes successful pastes without rendering them before Enter
@@ -122,6 +122,8 @@ func pasteBufferName(processToken, sanitizedName string, seq uint64) string {
 // Every pane gets the bracketed paste — there is no per-agent exception list.
 // See sendKeysPasteBuffer for why that is both necessary and safe (#1956).
 func (t *TmuxSession) SendKeysCommand(text string) error {
+	t.submitMu.Lock()
+	defer t.submitMu.Unlock()
 	return t.sendKeysPasteBuffer(text)
 }
 
@@ -160,6 +162,21 @@ func (t *TmuxSession) sendKeysPasteBuffer(text string) error {
 
 	tail := deliveryTail(text)
 
+	// Load the payload BEFORE touching the live composer. A load failure means
+	// there is nothing we can deliver, so clearing first would destroy a user's
+	// draft and then return without replacing it (#2178 review). Streaming via
+	// stdin also avoids ARG_MAX for arbitrarily large prompts.
+	loadCtx, loadCancel := tmuxTimeoutContext()
+	err := runTmuxBoundedStdin(loadCtx, t.cmdExec, strings.NewReader(text), "load-buffer", "-b", buf, "-")
+	loadTimedOut := loadCtx.Err() != nil
+	loadCancel()
+	if err != nil {
+		if loadTimedOut {
+			return fmt.Errorf("%w: load-buffer after %s", ErrTmuxTimeout, tmuxCommandTimeout)
+		}
+		return fmt.Errorf("error loading paste buffer: %w", err)
+	}
+
 	// Clear any draft stranded in the composer BEFORE this paste (#2070/#1982
 	// half b). A prior send whose Enter never took leaves its full text sitting in
 	// the composer; without a clear, this paste appends to it and the receiver
@@ -183,7 +200,7 @@ func (t *TmuxSession) sendKeysPasteBuffer(text string) error {
 	// stall one extra bound before giving up. That is the price of the
 	// discarded-draft record; if it ever matters, the `before` capture is the
 	// droppable half (it feeds only the log, never the baseline).
-	before, _ := t.capturePaneForDelivery()
+	before, beforeOK := t.capturePaneForDelivery()
 	t.clearComposerDraft()
 	after, afterOK := t.capturePaneForDelivery()
 	noteClearedDraft(t.sanitizedName, before, after)
@@ -196,23 +213,16 @@ func (t *TmuxSession) sendKeysPasteBuffer(text string) error {
 	// identical tail still confirm — the clear removed that copy, so the tail
 	// genuinely re-appears.
 	baseline := 0
-	if tail != "" && afterOK {
-		baseline = strings.Count(normalizeDelivery(after), tail)
-	}
-
-	// load-buffer streams the prompt in on stdin, so it needs the stdin-carrying
-	// bounded runner rather than the shared one — and deliberately does NOT treat
-	// exec.ErrWaitDelay as success, because a force-closed stdin pipe means the
-	// payload may be truncated. See runTmuxBoundedStdin.
-	loadCtx, loadCancel := tmuxTimeoutContext()
-	err := runTmuxBoundedStdin(loadCtx, t.cmdExec, strings.NewReader(text), "load-buffer", "-b", buf, "-")
-	loadTimedOut := loadCtx.Err() != nil
-	loadCancel()
-	if err != nil {
-		if loadTimedOut {
-			return fmt.Errorf("%w: load-buffer after %s", ErrTmuxTimeout, tmuxCommandTimeout)
+	if tail != "" {
+		switch {
+		case afterOK:
+			baseline = strings.Count(normalizeDelivery(after), tail)
+		case beforeOK:
+			// A failed post-clear capture must not erase the usable pre-clear
+			// baseline. Reusing it is conservative: content the clear removed can
+			// only make confirmation harder, never create a false success.
+			baseline = strings.Count(normalizeDelivery(before), tail)
 		}
-		return fmt.Errorf("error loading paste buffer: %w", err)
 	}
 
 	// `-d` deletes the buffer after pasting, `-p` brackets it (see the doc
@@ -480,13 +490,13 @@ func (t *TmuxSession) waitForPasteDelivered(
 	if len([]rune(tail)) < minDistinctiveTail {
 		needed = 2
 	}
-	lastCaptureOK := false
+	sawAbsentCapture := false
 	for {
 		// If the prior capture succeeded and the following poll interval carried
 		// us across the deadline, that prior read is the terminal observation. Do
 		// not launch an already-expired capture just to turn success into unknown.
 		if time.Until(deadline) <= 0 {
-			if lastCaptureOK && t.preSubmitEchoBehavior() == preSubmitEchoes {
+			if sawAbsentCapture && t.preSubmitEchoBehavior() == preSubmitEchoes {
 				return deliveryObservedAbsent
 			}
 			return deliveryCouldNotObserve
@@ -495,7 +505,6 @@ func (t *TmuxSession) waitForPasteDelivered(
 		// Bound each capture by what is LEFT of this loop's budget, so a wedged
 		// server cannot push a single capture past the deadline below (#2099).
 		if content, ok := t.capturePaneForDeliveryWithin(time.Until(deadline)); ok {
-			lastCaptureOK = true
 			if strings.Count(normalizeDelivery(content), tail) > baseline {
 				streak++
 				if streak >= needed {
@@ -504,15 +513,14 @@ func (t *TmuxSession) waitForPasteDelivered(
 				}
 			} else {
 				streak = 0
+				sawAbsentCapture = true
 			}
-		} else {
-			lastCaptureOK = false
 		}
 		if time.Now().After(deadline) {
-			// A failed final capture is "could not look", even if an earlier poll
-			// succeeded. Likewise, missing text in an agent not known to echo says
-			// nothing about whether the paste landed. Neither is an ERROR (#2213).
-			if !lastCaptureOK || t.preSubmitEchoBehavior() != preSubmitEchoes {
+			// A final failed capture must not erase earlier successful observations
+			// of absence (#2214 review). Missing text in an agent not known to echo
+			// still says nothing about whether the paste landed (#2213).
+			if !sawAbsentCapture || t.preSubmitEchoBehavior() != preSubmitEchoes {
 				return deliveryCouldNotObserve
 			}
 			return deliveryObservedAbsent

--- a/session/tmux/submit_test.go
+++ b/session/tmux/submit_test.go
@@ -98,20 +98,18 @@ func TestCodexSubmitUsesBracketedPaste(t *testing.T) {
 	cmds := recordTmuxCommands(t, "codex", prompt)
 	joined := joinedArgs(cmds)
 
-	require.Len(t, cmds, 4, "codex submit is clear, load-buffer, paste-buffer, send-keys Enter; got %v", joined)
+	require.Len(t, cmds, 4, "codex submit is load-buffer, clear, paste-buffer, send-keys Enter; got %v", joined)
 
-	// 0. A stranded draft in the composer is cleared with keystrokes BEFORE the
-	//    paste (#2070) so a prior lost Enter cannot fuse with this prompt. It must
-	//    be a keystroke clear, never a paste (a clear is a command, #1956), and it
-	//    must precede the load so the payload lands in an empty composer.
-	require.Contains(t, joined[0], "send-keys", "first command must clear the composer; got %v", joined)
-	require.Contains(t, joined[0], "C-u", "the clear must send C-u to kill the pending line (#2070); got %v", joined)
-	require.NotContains(t, joined[0], "load-buffer", "the clear must precede the load; got %v", joined)
+	// 0. Text is loaded before the destructive clear. If load-buffer fails, the
+	//    user's existing composer remains untouched (#2178 review).
+	require.Contains(t, joined[0], "load-buffer", "first command must load the paste buffer; got %v", joined)
+	require.Equal(t, prompt, cmds[0].stdin, "paste text must be streamed on stdin")
 
-	// 1. Text is streamed into a buffer via stdin (not an argv arg → no ARG_MAX
-	//    ceiling for large prompts) and never as `send-keys -l`.
-	require.Contains(t, joined[1], "load-buffer", "second command must load the paste buffer; got %v", joined)
-	require.Equal(t, prompt, cmds[1].stdin, "paste text must be streamed on stdin")
+	// 1. A stranded draft in the composer is cleared with keystrokes AFTER a
+	//    replacement payload exists but BEFORE it is pasted (#2070/#2178).
+	require.Contains(t, joined[1], "send-keys", "second command must clear the composer; got %v", joined)
+	require.Contains(t, joined[1], "C-u", "the clear must send C-u to kill the pending line (#2070); got %v", joined)
+	require.NotContains(t, joined[1], "load-buffer", "the clear must be distinct from the load; got %v", joined)
 	for _, j := range joined {
 		require.NotContains(t, j, "send-keys -t =af_proj: -l",
 			"codex must not use the plain literal send-keys path that gets swallowed (#1254); got %v", joined)
@@ -123,7 +121,7 @@ func TestCodexSubmitUsesBracketedPaste(t *testing.T) {
 	require.Contains(t, joined[2], "paste-buffer", "third command must paste the buffer; got %v", joined)
 	require.Contains(t, joined[2], "-p", "paste must be bracketed (-p) so codex sees the paste boundary")
 	require.Contains(t, joined[2], "-d", "paste must delete the buffer afterward (-d)")
-	loadBuf, pasteBuf := bufferOf(cmds[1].args), bufferOf(cmds[2].args)
+	loadBuf, pasteBuf := bufferOf(cmds[0].args), bufferOf(cmds[2].args)
 	require.NotEmpty(t, loadBuf, "load-buffer must name a buffer; got %v", joined)
 	require.Equal(t, loadBuf, pasteBuf, "paste must read back the buffer the load wrote; got %v", joined)
 
@@ -160,12 +158,12 @@ func TestEveryAgentSubmitUsesBracketedPasteBuffer(t *testing.T) {
 			cmds := recordTmuxCommands(t, program, prompt)
 			joined := joinedArgs(cmds)
 
-			require.Len(t, cmds, 4, "paste path is clear, load-buffer, paste-buffer, send-keys Enter; got %v", joined)
-			require.Contains(t, joined[0], "send-keys", "first command must clear the composer; got %v", joined)
-			require.Contains(t, joined[0], "C-u",
+			require.Len(t, cmds, 4, "paste path is load-buffer, clear, paste-buffer, send-keys Enter; got %v", joined)
+			require.Contains(t, joined[0], "load-buffer", "first command must load the paste buffer; got %v", joined)
+			require.Equal(t, prompt, cmds[0].stdin, "paste text must be streamed on stdin")
+			require.Contains(t, joined[1], "send-keys", "second command must clear the composer; got %v", joined)
+			require.Contains(t, joined[1], "C-u",
 				"a stranded draft must be cleared with C-u before the paste so it can't fuse with this prompt (#2070); got %v", joined)
-			require.Contains(t, joined[1], "load-buffer", "second command must load the paste buffer; got %v", joined)
-			require.Equal(t, prompt, cmds[1].stdin, "paste text must be streamed on stdin")
 			require.Contains(t, joined[2], "paste-buffer", "third command must paste the buffer; got %v", joined)
 			require.Contains(t, joined[2], "-d", "paste must delete the buffer afterward (-d)")
 			require.True(t, hasArg(cmds[2].args, "-p"),
@@ -179,7 +177,7 @@ func TestEveryAgentSubmitUsesBracketedPasteBuffer(t *testing.T) {
 					"no pane may use the literal send-keys path that redraws wrapped bash input (#1292); got %v", joined)
 			}
 
-			loadBuf, pasteBuf := bufferOf(cmds[1].args), bufferOf(cmds[2].args)
+			loadBuf, pasteBuf := bufferOf(cmds[0].args), bufferOf(cmds[2].args)
 			require.NotEmpty(t, loadBuf, "load-buffer must name a buffer; got %v", joined)
 			require.Equal(t, loadBuf, pasteBuf, "paste must read back the buffer the load wrote; got %v", joined)
 
@@ -218,6 +216,84 @@ func TestClearNeverSendsEscapeTheInterruptKey(t *testing.T) {
 						"delivery to a working agent would abort its turn (#2070); got %q", j)
 			}
 		})
+	}
+}
+
+func TestSubmitLoadsPayloadBeforeClearingComposer(t *testing.T) {
+	loadErr := fmt.Errorf("load rejected")
+	clearSent := false
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			joined := strings.Join(c.Args, " ")
+			if strings.Contains(joined, "load-buffer") {
+				return loadErr
+			}
+			if strings.Contains(joined, "send-keys") && hasArg(c.Args, "C-u") {
+				clearSent = true
+			}
+			return nil
+		},
+	}
+	session := newTmuxSession("af_proj", ProgramClaude, NewMockPtyFactory(t), cmdExec)
+
+	err := session.SendKeysCommand("replacement prompt")
+	require.ErrorIs(t, err, loadErr)
+	require.False(t, clearSent,
+		"a failed load must leave the user's existing composer untouched (#2178 review)")
+}
+
+func TestSubmitSerializesClearPasteAndEnter(t *testing.T) {
+	defer withPasteDeliveryTiming(5*time.Millisecond, time.Millisecond)()
+
+	firstPasteStarted := make(chan struct{})
+	releaseFirstPaste := make(chan struct{})
+	secondLoadStarted := make(chan struct{})
+	var mu sync.Mutex
+	bufferPayload := make(map[string]string)
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			joined := strings.Join(c.Args, " ")
+			switch {
+			case strings.Contains(joined, "load-buffer"):
+				payload, _ := io.ReadAll(c.Stdin)
+				mu.Lock()
+				bufferPayload[bufferOf(c.Args)] = string(payload)
+				mu.Unlock()
+				if string(payload) == "second prompt" {
+					close(secondLoadStarted)
+				}
+			case strings.Contains(joined, "paste-buffer"):
+				mu.Lock()
+				payload := bufferPayload[bufferOf(c.Args)]
+				mu.Unlock()
+				if payload == "first prompt" {
+					close(firstPasteStarted)
+					<-releaseFirstPaste
+				}
+			}
+			return nil
+		},
+		OutputFunc: func(*exec.Cmd) ([]byte, error) { return []byte("composer ready"), nil },
+	}
+	session := newTmuxSession("af_proj", ProgramCodex, NewMockPtyFactory(t), cmdExec)
+	errCh := make(chan error, 2)
+
+	go func() { errCh <- session.SendKeysCommand("first prompt") }()
+	<-firstPasteStarted
+	go func() { errCh <- session.SendKeysCommand("second prompt") }()
+
+	select {
+	case <-secondLoadStarted:
+		t.Fatal("a concurrent submit started before the first paste could send Enter; its clear can erase the first prompt")
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(releaseFirstPaste)
+	require.NoError(t, <-errCh)
+	require.NoError(t, <-errCh)
+	select {
+	case <-secondLoadStarted:
+	default:
+		t.Fatal("the second submit never ran after the first transaction completed")
 	}
 }
 
@@ -498,6 +574,50 @@ func TestMissingPromptInKnownEchoingPaneStaysLoud(t *testing.T) {
 	require.NotContains(t, got, "may be unsubmitted")
 }
 
+func TestFailedPostClearCaptureKeepsPreClearBaseline(t *testing.T) {
+	defer withPasteDeliveryTiming(10*time.Millisecond, time.Millisecond)()
+	errors := captureErrorLog(t)
+	const prompt = "identical re-delivery with a distinctive DELIVERY_BASELINE_TAIL"
+
+	captures := 0
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(*exec.Cmd) error { return nil },
+		OutputFunc: func(*exec.Cmd) ([]byte, error) {
+			captures++
+			if captures == 2 {
+				return nil, fmt.Errorf("transient post-clear capture failure")
+			}
+			// The same tail was already present before the clear and remains in
+			// every later capture. It is not evidence that this paste arrived.
+			return []byte(prompt), nil
+		},
+	}
+	session := newTmuxSession("af_proj", ProgramClaude, NewMockPtyFactory(t), cmdExec)
+
+	require.NoError(t, session.SendKeysCommand(prompt))
+	require.Contains(t, errors.String(), "prompt delivery observed absent",
+		"a failed post-clear capture must fall back to the pre-clear count instead of falsely confirming an old tail")
+}
+
+func TestFinalCaptureFailureKeepsEarlierObservedAbsence(t *testing.T) {
+	defer withPasteDeliveryTiming(8*time.Millisecond, time.Millisecond)()
+	captures := 0
+	cmdExec := cmd_test.MockCmdExec{
+		OutputFunc: func(*exec.Cmd) ([]byte, error) {
+			captures++
+			if captures == 1 {
+				return []byte("composer is visibly empty"), nil
+			}
+			return nil, fmt.Errorf("capture failed")
+		},
+	}
+	session := newTmuxSession("af_proj", ProgramClaude, NewMockPtyFactory(t), cmdExec)
+
+	got := session.waitForPasteDelivered("DISTINCTIVE_DELIVERY_TAIL", 0)
+	require.Equal(t, deliveryObservedAbsent, got,
+		"a failed final probe must not erase an earlier successful observation of absence (#2214 review)")
+}
+
 // TestObservedDeliveryCachesEchoBehavior proves unknown programs are detected
 // only from positive evidence, then reuse that capability. The first visible
 // delivery promotes the session; a later genuinely absent prompt is therefore
@@ -544,10 +664,17 @@ func TestPreSubmitEchoBehaviorTracksResolvedProgram(t *testing.T) {
 	session := newTmuxSession("af_proj", "/usr/local/bin/codex --full-auto", NewMockPtyFactory(t), cmd_test.MockCmdExec{})
 	require.Equal(t, preSubmitDoesNotEcho, session.preSubmitEchoBehavior(),
 		"capability detection must use the resolved executable, including absolute paths")
+	session.notePreSubmitEchoObserved()
+	require.Equal(t, preSubmitDoesNotEcho, session.preSubmitEchoBehavior(),
+		"a coincidental tail match must not promote a known non-echoing Codex pane")
 
 	session.SetProgram("ionice -c 3 claude --model opus")
 	require.Equal(t, preSubmitEchoes, session.preSubmitEchoBehavior(),
 		"agent handoff must replace the cached capability with the new agent's behavior")
+
+	session.SetProgram("aider --model sonnet")
+	require.Equal(t, preSubmitEchoes, session.preSubmitEchoBehavior(),
+		"Aider visibly echoes pasted composer input and must keep missing delivery loud")
 
 	session.SetProgram("/opt/bin/claude-wrapper")
 	require.Equal(t, preSubmitEchoUnknown, session.preSubmitEchoBehavior(),


### PR DESCRIPTION
## Summary

- serialize each prompt submission from buffer load through composer clear, paste, and Enter, so concurrent sends cannot erase one another
- load the replacement payload before the destructive clear, preserving a user's draft when `load-buffer` fails
- retain the pre-clear delivery baseline when the post-clear capture fails, and retain earlier successful absence observations when a final probe fails
- classify Aider as known-echoing while preventing coincidental pane text from promoting known non-echoing Codex sessions
- add regressions for all six unread Codex P2 findings from #2178 and #2214, including a race-detector concurrency test

## Why this shape

The public submit method now owns one mutex-protected transaction. Callers cannot accidentally clear or submit half of another caller's prompt, and the ordering makes the destructive step unreachable until the replacement bytes are safely resident in tmux. Delivery evidence is monotonic: a failed observation can no longer erase a usable earlier fact.

## Verification

All required gates ran after final commit `f5b91bfc2946858a3ca40cbbb57c1dfc4270784e` was pushed, with local HEAD matching the remote branch:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (no output)
- `go build ./...`
- `make test-container`
- `deadcode -test ./...` (no output)
- `scripts/lint-file-length.sh`
- focused submission regressions under `go test -race`

— Captain Claude

Co-authored-by: Captain Claude <noreply@anthropic.com>
