### PR TITLE
fix(session): enforce lifecycle guards before runtime actions

### DIFF
--- a/app/handle_handoff.go
+++ b/app/handle_handoff.go
@@ -6,6 +6,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 	"github.com/sachiniyer/agent-factory/ui"
 	"github.com/sachiniyer/agent-factory/ui/overlay"
@@ -58,8 +59,8 @@ func (m *home) handleHandoff() (tea.Model, tea.Cmd) {
 	if selected == nil || selected.IsCreating() {
 		return m, nil
 	}
-	if selected.IsTearingDown() {
-		return m, m.handleError(fmt.Errorf("session '%s' is being deleted", selected.Title))
+	if err := selected.ValidateRuntimeAction(session.RuntimeActionHandoff); err != nil {
+		return m, m.handleError(err)
 	}
 	if !selected.Capabilities().Handoff {
 		return m, m.handleError(fmt.Errorf("session '%s' cannot be handed off: only local-worktree sessions can swap their agent", selected.Title))

--- a/app/handoff_action_test.go
+++ b/app/handoff_action_test.go
@@ -56,6 +56,21 @@ func TestHandleHandoff_OpensPickerWithoutDispatching(t *testing.T) {
 	require.False(t, called, "opening the picker must not swap the agent")
 }
 
+func TestHandleHandoff_RefusesArchivedSessionBeforePicker(t *testing.T) {
+	h := newTestHome(t)
+	inst := handoffActionInstance(t, "archived", tmux.ProgramClaude)
+	inst.SetStatusForTest(session.Archived)
+	inst.SetStartedForTest(false)
+	h.store.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+
+	_, _ = h.handleHandoff()
+
+	require.Equal(t, stateDefault, h.state, "an inert row must not enter the handoff flow")
+	require.Nil(t, h.selectionOverlay, "the user should not pick a target for an impossible handoff")
+	require.Contains(t, strings.ToLower(h.errBox.FullError()), "archived")
+}
+
 // The picker's selected index must be resolved against the FILTERED choice list
 // it was built from. Resolving it against tmux.SupportedPrograms instead would
 // hand off to the wrong agent — silently, and to a plausible-looking one.

--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -327,8 +327,8 @@ func (m *Manager) RestoreArchived(req RestoreArchivedRequest) (string, error) {
 	if instance == nil {
 		return "", fmt.Errorf("cannot restore session %q: no such session", req.Title)
 	}
-	if instance.GetLiveness() != session.LiveArchived {
-		return "", fmt.Errorf("session %q is not archived", req.Title)
+	if err := instance.ValidateRuntimeAction(session.RuntimeActionRestoreArchived); err != nil {
+		return "", fmt.Errorf("cannot restore: %w", err)
 	}
 
 	key := daemonInstanceKey(repoID, req.Title)
@@ -353,8 +353,15 @@ func (m *Manager) RestoreArchived(req RestoreArchivedRequest) (string, error) {
 	m.mu.Lock()
 	current := m.instances[key]
 	m.mu.Unlock()
-	if current != instance || instance.GetLiveness() != session.LiveArchived {
+	if current != instance {
 		return "", fmt.Errorf("session %q changed state before restore could start", req.Title)
+	}
+	// Re-run the shared runtime-entry guard under the operation lock, before the
+	// worktree move. A durable kill tombstone is terminal intent: restoring
+	// around it would appear to succeed, then finishUserKill would reap the
+	// replacement on the next poll (#2208).
+	if err := instance.ValidateRuntimeAction(session.RuntimeActionRestoreArchived); err != nil {
+		return "", fmt.Errorf("cannot restore: %w", err)
 	}
 
 	// A sandbox session (docker/ssh) restores by re-provisioning a fresh sandbox

--- a/daemon/archive_test.go
+++ b/daemon/archive_test.go
@@ -290,6 +290,37 @@ func TestRestoreArchived_RejectsNonArchived(t *testing.T) {
 	assert.Contains(t, err.Error(), "not archived")
 }
 
+// TestRestoreArchived_RejectsPendingKill is the #2208 regression: an archived
+// row whose kill teardown was uncertain keeps its record and durable tombstone.
+// Restore must honor that terminal intent before moving the worktree or starting
+// a replacement runtime; otherwise the next status poll immediately finishes the
+// kill that restore just appeared to undo.
+func TestRestoreArchived_RejectsPendingKill(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst, _ := registerArchivable(t, manager, repoID, repoPath, "worker")
+
+	_, _, err := manager.ArchiveSession(ArchiveSessionRequest{Title: "worker", RepoID: repoID})
+	require.NoError(t, err)
+	archivedPath := inst.GetWorktreePath()
+
+	// Model the only failed-kill shape that retains a record: teardown did not
+	// establish whether the pane/workspace is gone, so KillSession records the
+	// tombstone and leaves the archived row addressable for its retry loop.
+	backend := session.NewFakeBackend()
+	backend.CompleteStart()
+	inst.SetBackend(failKillBackend{readyFakeBackend{backend}})
+	_, err = manager.KillSession(KillSessionRequest{Title: "worker", RepoID: repoID})
+	require.Error(t, err)
+	require.True(t, inst.UserKilled(), "the failed kill must leave its terminal intent on the retained row")
+
+	_, err = manager.RestoreArchived(RestoreArchivedRequest{Title: "worker", RepoID: repoID})
+	require.Error(t, err, "restore must not revive a session whose kill is pending")
+	assert.Contains(t, err.Error(), "pending kill", "the refusal must explain why retrying restore cannot work")
+	assert.Equal(t, session.Archived, inst.GetStatus())
+	assert.Equal(t, archivedPath, inst.GetWorktreePath(), "a refused restore must not move the archived worktree")
+	assert.True(t, exists(archivedPath), "the archived worktree must stay intact for the pending kill retry")
+}
+
 // TestRestoreArchived_RepoGoneLeavesArchiveIntact: when the origin repo has been
 // deleted, restore fails with an actionable message and leaves the archived
 // worktree and the Archived status untouched.

--- a/daemon/handoff.go
+++ b/daemon/handoff.go
@@ -94,6 +94,17 @@ func (m *Manager) HandoffSession(req HandoffSessionRequest) (HandoffSessionRespo
 	// session actually being swapped.
 	req.Title = title
 
+	// Capability answers whether this backend IMPLEMENTS handoff. The shared
+	// runtime-action guard answers the prior question: whether this row currently
+	// has a live runtime that may be replaced. Keeping state first prevents an
+	// Archived/Lost/Dead row from being reanimated through a capable backend
+	// instead of its restore path (#2231).
+	if err := instance.ValidateRuntimeAction(session.RuntimeActionHandoff); err != nil {
+		return HandoffSessionResponse{}, err
+	}
+	if session.IsReservedTitle(instance.Title) {
+		return HandoffSessionResponse{}, fmt.Errorf("session %q cannot be handed off", req.Title)
+	}
 	target := strings.TrimSpace(req.To)
 	if err := instance.ValidateHandoffTarget(target); err != nil {
 		return HandoffSessionResponse{}, err
@@ -101,10 +112,6 @@ func (m *Manager) HandoffSession(req HandoffSessionRequest) (HandoffSessionRespo
 	if !instance.Capabilities().Handoff {
 		return HandoffSessionResponse{}, session.ErrHandoffUnsupported
 	}
-	if instance.UserKilled() || session.IsReservedTitle(instance.Title) {
-		return HandoffSessionResponse{}, fmt.Errorf("session %q cannot be handed off", req.Title)
-	}
-
 	key := daemonInstanceKey(repoID, instance.Title)
 	m.mu.Lock()
 	if _, killing := m.killsInFlight[key]; killing {
@@ -128,8 +135,11 @@ func (m *Manager) HandoffSession(req HandoffSessionRequest) (HandoffSessionRespo
 	current := m.instances[key]
 	_, killing := m.killsInFlight[key]
 	m.mu.Unlock()
-	if killing || current != instance || instance.IsTearingDown() {
+	if killing || current != instance {
 		return HandoffSessionResponse{}, fmt.Errorf("session %q is no longer available to hand off", req.Title)
+	}
+	if err := instance.ValidateRuntimeAction(session.RuntimeActionHandoff); err != nil {
+		return HandoffSessionResponse{}, err
 	}
 	if err := instance.ValidateHandoffTarget(target); err != nil {
 		return HandoffSessionResponse{}, err

--- a/daemon/handoff_test.go
+++ b/daemon/handoff_test.go
@@ -237,3 +237,37 @@ func TestHandoffSession_RefusesBackendWithoutHandoffCapability(t *testing.T) {
 		t.Fatalf("SwapAgent called %d times on an unsupported backend, want 0", swaps)
 	}
 }
+
+// TestHandoffSession_RefusesArchivedSession is the #2231 regression. Backend
+// capability says what the runtime implementation can do; it does not say that
+// this particular session currently has a runtime. An archived row is inert and
+// its worktree is in archive storage, so handoff must not turn it live in place.
+func TestHandoffSession_RefusesArchivedSession(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &handoffBackend{FakeBackend: session.NewFakeBackend()}
+	inst := registerHandoffSubject(t, manager, repoID, repoPath, "archived", backend)
+	inst.SetStatusForTest(session.Archived)
+	inst.SetStartedForTest(false)
+
+	_, err := manager.HandoffSession(HandoffSessionRequest{
+		Title: "archived", RepoID: repoID, To: tmux.ProgramGemini,
+	})
+	if err == nil {
+		t.Fatal("handoff accepted an archived session and reanimated it outside the restore lifecycle")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "archived") {
+		t.Fatalf("error = %q, want an actionable archived-session refusal", err)
+	}
+	if swaps, prompts := backend.snapshot(); swaps != 0 || len(prompts) != 0 {
+		t.Fatalf("archived handoff touched the runtime (swaps=%d prompts=%d), want neither", swaps, len(prompts))
+	}
+	if got := inst.AgentProgram(); got != tmux.ProgramClaude {
+		t.Fatalf("Program = %q after refused handoff, want %q", got, tmux.ProgramClaude)
+	}
+	if ledger := inst.Handoffs(); len(ledger) != 0 {
+		t.Fatalf("refused archived handoff wrote %d ledger entries, want 0", len(ledger))
+	}
+	if got := inst.GetLiveness(); got != session.LiveArchived {
+		t.Fatalf("liveness = %v after refused handoff, want Archived", got)
+	}
+}

--- a/daemon/lostrestore.go
+++ b/daemon/lostrestore.go
@@ -180,10 +180,10 @@ func (m *Manager) RestoreLostSessions() {
 // lock, so a caller could see Lost on one read and Running on the next and fall
 // through every arm (#1892).
 func lostSessionWantsRestore(v session.LifecycleView) bool {
-	if !v.Started || v.Status != session.Lost {
+	if v.ValidateRuntimeAction(session.RuntimeActionRecoverLost) != nil {
 		return false
 	}
-	return !v.UserKilled && !session.IsReservedTitle(v.Title)
+	return !session.IsReservedTitle(v.Title)
 }
 
 // canAutoRestoreLostSession reports whether RestoreLostSessions will keep trying
@@ -300,7 +300,7 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 	current := m.instances[key]
 	_, killing := m.killsInFlight[key]
 	m.mu.Unlock()
-	if killing || current != inst || inst.UserKilled() || inst.GetStatus() != session.Lost {
+	if killing || current != inst || inst.ValidateRuntimeAction(session.RuntimeActionRecoverLost) != nil {
 		return
 	}
 

--- a/daemon/restore.go
+++ b/daemon/restore.go
@@ -30,17 +30,14 @@ func (m *Manager) RestoreSession(req RestoreSessionRequest) (string, error) {
 }
 
 func (m *Manager) restoreLostOrDeadSession(req RestoreSessionRequest, repoID string, instance *session.Instance) (string, error) {
-	if instance.UserKilled() {
-		return "", fmt.Errorf("cannot restore session %q: it is being deleted", req.Title)
+	if err := instance.ValidateRuntimeAction(session.RuntimeActionRestoreLostOrDead); err != nil {
+		return "", fmt.Errorf("cannot restore: %w", err)
 	}
 	if session.IsReservedTitle(instance.Title) {
 		return "", fmt.Errorf("cannot manually restore reserved session %q", req.Title)
 	}
 	if !instance.Capabilities().Recover {
 		return "", fmt.Errorf("cannot restore remote session %q: reconnect is not supported", req.Title)
-	}
-	if !instance.Started() {
-		return "", fmt.Errorf("cannot restore session %q: it is not started", req.Title)
 	}
 
 	key := daemonInstanceKey(repoID, req.Title)
@@ -67,7 +64,11 @@ func (m *Manager) restoreLostOrDeadSession(req RestoreSessionRequest, repoID str
 	if current != instance {
 		return "", fmt.Errorf("session %q changed state before restore could start", req.Title)
 	}
-	switch instance.GetLiveness() {
+	view := instance.LifecycleView()
+	if err := view.ValidateRuntimeAction(session.RuntimeActionRestoreLostOrDead); err != nil {
+		return "", fmt.Errorf("cannot restore: %w", err)
+	}
+	switch view.Liveness {
 	case session.LiveLost:
 	case session.LiveDead:
 		_ = instance.Transition(session.ObserveLiveness(session.LiveLost))

--- a/session/activity.go
+++ b/session/activity.go
@@ -126,6 +126,14 @@ type LifecycleView struct {
 func (i *Instance) LifecycleView() LifecycleView {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
+	return i.lifecycleViewLocked()
+}
+
+// lifecycleViewLocked is LifecycleView's already-locked half. Callers must hold
+// i.mu for reading or writing. Runtime-action chokepoints use it while making a
+// state mutation under the same critical section, so validation and mutation
+// cannot observe different lifecycle states.
+func (i *Instance) lifecycleViewLocked() LifecycleView {
 	return LifecycleView{
 		Title:      i.Title,
 		TaskID:     i.TaskID,

--- a/session/handoff.go
+++ b/session/handoff.go
@@ -109,6 +109,15 @@ func (i *Instance) LastHandoff() (AgentHandoff, bool) {
 // documented to return "" for a wrapper script, which silently disables this
 // guard exactly when a user has customized their setup.
 func (i *Instance) ValidateHandoffTarget(target string) error {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.validateHandoffTargetLocked(target)
+}
+
+// validateHandoffTargetLocked is ValidateHandoffTarget's already-locked half.
+// Keeping target identity and runtime eligibility checks in the same instance
+// critical section lets SwapAgentProgram validate and mutate one state snapshot.
+func (i *Instance) validateHandoffTargetLocked(target string) error {
 	target = strings.TrimSpace(target)
 	if target == "" {
 		return fmt.Errorf("handoff target agent is required (one of %s)", tmux.SupportedProgramsString())
@@ -116,7 +125,7 @@ func (i *Instance) ValidateHandoffTarget(target string) error {
 	if !tmux.IsSupportedProgram(target) {
 		return fmt.Errorf("unknown agent %q: handoff target must be one of %s", target, tmux.SupportedProgramsString())
 	}
-	if current := i.CurrentAgentName(); current == target {
+	if current := i.currentAgentNameLocked(); current == target {
 		return fmt.Errorf("session is already running %s", target)
 	}
 	return nil
@@ -190,13 +199,16 @@ func (i *Instance) currentAgentNameLocked() string {
 // The caller must hold whatever serialization the daemon requires; this method
 // takes only the instance lock.
 func (i *Instance) SwapAgentProgram(target, reason, headSHA string, automatic bool) (AgentHandoff, error) {
-	if err := i.ValidateHandoffTarget(target); err != nil {
-		return AgentHandoff{}, err
-	}
 	target = strings.TrimSpace(target)
 
 	i.mu.Lock()
 	defer i.mu.Unlock()
+	if err := i.validateHandoffTargetLocked(target); err != nil {
+		return AgentHandoff{}, err
+	}
+	if err := i.lifecycleViewLocked().ValidateRuntimeAction(RuntimeActionHandoff); err != nil {
+		return AgentHandoff{}, err
+	}
 
 	if len(i.Tabs) == 0 {
 		return AgentHandoff{}, fmt.Errorf("session %q has no agent tab to hand off", i.Title)

--- a/session/handoff_test.go
+++ b/session/handoff_test.go
@@ -23,6 +23,7 @@ func handoffTestInstance(t *testing.T, program string) *Instance {
 		t.Fatalf("NewInstance: %v", err)
 	}
 	inst.SetBackend(NewFakeBackend())
+	inst.SetStartedForTest(true)
 	inst.Tabs = []*Tab{{
 		ID:   "tab-1",
 		Name: "agent",
@@ -123,6 +124,23 @@ func TestValidateHandoffTarget(t *testing.T) {
 	}
 	if err := inst.ValidateHandoffTarget(tmux.ProgramGemini); err != nil {
 		t.Fatalf("valid target rejected: %v", err)
+	}
+}
+
+func TestSwapAgentProgram_RejectsArchivedSessionWithoutMutatingRecord(t *testing.T) {
+	inst := handoffTestInstance(t, tmux.ProgramClaude)
+	inst.SetStatusForTest(Archived)
+	inst.SetStartedForTest(false)
+
+	_, err := inst.SwapAgentProgram(tmux.ProgramGemini, HandoffReasonManual, "sha", false)
+	if err == nil {
+		t.Fatal("SwapAgentProgram accepted an archived row")
+	}
+	if got := inst.AgentProgram(); got != tmux.ProgramClaude {
+		t.Fatalf("Program = %q after refusal, want %q", got, tmux.ProgramClaude)
+	}
+	if ledger := inst.Handoffs(); len(ledger) != 0 {
+		t.Fatalf("archived refusal wrote %d handoff records, want 0", len(ledger))
 	}
 }
 

--- a/session/instance_backend.go
+++ b/session/instance_backend.go
@@ -43,8 +43,13 @@ func (i *Instance) Kill() error {
 
 // Recover re-establishes a Lost instance's backing session (#1108). Called by
 // the daemon's restore loop and by user-initiated restore (#1300); loads stay
-// side-effect free (#970).
+// side-effect free (#970). Lifecycle eligibility is enforced here, before any
+// backend can provision or spawn a runtime; backend capability alone is never
+// permission to revive a row.
 func (i *Instance) Recover() error {
+	if err := i.ValidateRuntimeAction(RuntimeActionRecoverLost); err != nil {
+		return fmt.Errorf("recover: %w", err)
+	}
 	return i.currentBackend().Recover(i)
 }
 
@@ -53,16 +58,22 @@ func (i *Instance) Recover() error {
 // manual-retry (#1146, resumeFromLimit) uses it to re-spawn an agent that exited
 // while blocked at a limit wall: that session is LiveLimitReached, which Recover's
 // !Lost guard rejects, but the re-spawn mechanics are identical. The caller owns
-// the precondition.
+// the precondition, enforced here before the guard-free backend core runs.
 func (i *Instance) Respawn() error {
+	if err := i.ValidateRuntimeAction(RuntimeActionResumeLimit); err != nil {
+		return fmt.Errorf("respawn: %w", err)
+	}
 	return i.currentBackend().Respawn(i)
 }
 
 // SwapAgent replaces the running agent process with the instance's current
 // program (#2013). Rewrite Instance.Program first (SwapAgentProgram); this only
-// performs the runtime half, and the caller owns every precondition. Refuses on
-// a backend whose workspace is off-box.
+// performs the runtime half. Refuses unless this instance is live and eligible
+// for handoff, then separately refuses a backend whose workspace is off-box.
 func (i *Instance) SwapAgent() error {
+	if err := i.ValidateRuntimeAction(RuntimeActionHandoff); err != nil {
+		return err
+	}
 	if !i.Capabilities().Handoff {
 		return ErrHandoffUnsupported
 	}
@@ -115,6 +126,10 @@ func (i *Instance) SetArchived() {
 // when the repo has been deleted so the caller can leave the archive intact.
 func (i *Instance) RestoreArchivedWorktree(dest string) error {
 	i.mu.RLock()
+	if err := i.lifecycleViewLocked().ValidateRuntimeAction(RuntimeActionRestoreArchived); err != nil {
+		i.mu.RUnlock()
+		return err
+	}
 	gw := i.gitWorktree
 	i.mu.RUnlock()
 	if gw == nil {
@@ -174,6 +189,9 @@ func (i *Instance) RenameArchived(newTitle, dest string) error {
 // out from under the restore. This replaces the old "park it in Lost purely to
 // trigger the re-spawn loop" overload (#1195).
 func (i *Instance) RestoreFromArchive() error {
+	if err := i.ValidateRuntimeAction(RuntimeActionRestoreArchived); err != nil {
+		return err
+	}
 	// Enter the restore fence through the chokepoint (#1195 Phase 2d): BeginRestore
 	// is legal only from Archived and sets started=true + Lost + OpRestoring — the
 	// exact head this used to write by hand, now enforcing I3 (a restore may begin

--- a/session/runtime_action.go
+++ b/session/runtime_action.go
@@ -1,0 +1,107 @@
+package session
+
+import "fmt"
+
+// RuntimeAction names every operation that can start, replace, or resume a
+// session runtime after creation. Backend capability and lifecycle eligibility
+// are deliberately separate questions: a backend can know how to perform an
+// action while this particular row is Archived, Lost, or pending deletion.
+//
+// Keep this list exhaustive. Every production runtime-entry chokepoint validates
+// one of these actions before delegating to a backend:
+//   - RestoreArchivedWorktree / RestoreFromArchive: RuntimeActionRestoreArchived
+//   - the daemon's manual Lost/Dead router: RuntimeActionRestoreLostOrDead
+//   - Instance.Recover: RuntimeActionRecoverLost
+//   - Instance.Respawn: RuntimeActionResumeLimit
+//   - SwapAgentProgram / Instance.SwapAgent: RuntimeActionHandoff
+//
+// The universal pending-kill veto lives in ValidateRuntimeAction, outside the
+// per-action switch, so adding a new action cannot accidentally omit it.
+type RuntimeAction int
+
+const (
+	RuntimeActionRestoreArchived RuntimeAction = iota
+	RuntimeActionRestoreLostOrDead
+	RuntimeActionRecoverLost
+	RuntimeActionResumeLimit
+	RuntimeActionHandoff
+	numRuntimeActions
+)
+
+// ValidateRuntimeAction checks whether one consistent lifecycle snapshot may
+// perform action. It returns user-facing errors because callers must explain why
+// retrying cannot work, especially when a durable kill tombstone owns the row.
+func (v LifecycleView) ValidateRuntimeAction(action RuntimeAction) error {
+	if v.UserKilled {
+		return fmt.Errorf("session %q has a pending kill", v.Title)
+	}
+
+	switch action {
+	case RuntimeActionRestoreArchived:
+		if v.Liveness != LiveArchived {
+			return fmt.Errorf("session %q is not archived", v.Title)
+		}
+		if v.InFlightOp != OpNone {
+			return runtimeActionBusyError(v)
+		}
+	case RuntimeActionRestoreLostOrDead:
+		if v.Liveness != LiveLost && v.Liveness != LiveDead {
+			return fmt.Errorf("session %q is not lost or dead", v.Title)
+		}
+		if !v.Started {
+			return fmt.Errorf("session %q is not started", v.Title)
+		}
+		if v.InFlightOp != OpNone {
+			return runtimeActionBusyError(v)
+		}
+	case RuntimeActionRecoverLost:
+		if v.Liveness != LiveLost {
+			return fmt.Errorf("session %q is not lost", v.Title)
+		}
+		if !v.Started {
+			return fmt.Errorf("session %q is not started", v.Title)
+		}
+		if v.InFlightOp != OpNone {
+			return runtimeActionBusyError(v)
+		}
+	case RuntimeActionResumeLimit:
+		if v.Liveness != LiveLimitReached {
+			return fmt.Errorf("session %q is not blocked on a usage limit", v.Title)
+		}
+		if !v.Started {
+			return fmt.Errorf("session %q is not started", v.Title)
+		}
+		if v.InFlightOp != OpNone {
+			return runtimeActionBusyError(v)
+		}
+	case RuntimeActionHandoff:
+		if v.InFlightOp != OpNone {
+			return runtimeActionBusyError(v)
+		}
+		switch v.Liveness {
+		case LiveRunning, LiveReady, LiveLimitReached:
+			// A live, idle, or limit-parked agent has a runtime to replace.
+			if !v.Started {
+				return fmt.Errorf("session %q is not running and cannot be handed off", v.Title)
+			}
+		case LiveArchived:
+			return fmt.Errorf("session %q is archived and cannot be handed off; restore it first", v.Title)
+		case LiveLost, LiveDead:
+			return fmt.Errorf("session %q is not running and cannot be handed off; restore it first", v.Title)
+		default:
+			return fmt.Errorf("session %q is not available to hand off", v.Title)
+		}
+	default:
+		return fmt.Errorf("unknown runtime action %d", action)
+	}
+	return nil
+}
+
+// ValidateRuntimeAction is the locking form for live instances.
+func (i *Instance) ValidateRuntimeAction(action RuntimeAction) error {
+	return i.LifecycleView().ValidateRuntimeAction(action)
+}
+
+func runtimeActionBusyError(v LifecycleView) error {
+	return fmt.Errorf("session %q is busy (%v); try again in a moment", v.Title, v.Status)
+}

--- a/session/runtime_action_test.go
+++ b/session/runtime_action_test.go
@@ -1,0 +1,61 @@
+package session
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRuntimeAction_EveryActionHasAnEligibleState is the exhaustiveness ledger
+// for runtime-entry actions. A new action must name its valid lifecycle state in
+// ValidateRuntimeAction instead of falling through to accidental permission.
+func TestRuntimeAction_EveryActionHasAnEligibleState(t *testing.T) {
+	valid := map[RuntimeAction]LifecycleView{
+		RuntimeActionRestoreArchived:   {Title: "archived", Liveness: LiveArchived},
+		RuntimeActionRestoreLostOrDead: {Title: "dead", Liveness: LiveDead, Started: true},
+		RuntimeActionRecoverLost:       {Title: "lost", Liveness: LiveLost, Started: true},
+		RuntimeActionResumeLimit:       {Title: "limited", Liveness: LiveLimitReached, Started: true},
+		RuntimeActionHandoff:           {Title: "live", Liveness: LiveRunning, Started: true},
+	}
+	for action := RuntimeAction(0); action < numRuntimeActions; action++ {
+		view, ok := valid[action]
+		if !ok {
+			t.Fatalf("runtime action %d is missing from the eligibility ledger", action)
+		}
+		if err := view.ValidateRuntimeAction(action); err != nil {
+			t.Fatalf("runtime action %d rejected its canonical state: %v", action, err)
+		}
+	}
+	if len(valid) != int(numRuntimeActions) {
+		t.Fatalf("eligibility ledger has %d entries for %d runtime actions", len(valid), numRuntimeActions)
+	}
+}
+
+// TestRuntimeAction_PendingKillVetoesEveryAction pins the shared invariant that
+// a kill tombstone is terminal intent. It is asserted across the exhaustive
+// action ledger so no future runtime-starting verb can forget the veto.
+func TestRuntimeAction_PendingKillVetoesEveryAction(t *testing.T) {
+	valid := []LifecycleView{
+		{Title: "archived", Liveness: LiveArchived},
+		{Title: "dead", Liveness: LiveDead, Started: true},
+		{Title: "lost", Liveness: LiveLost, Started: true},
+		{Title: "limited", Liveness: LiveLimitReached, Started: true},
+		{Title: "live", Liveness: LiveRunning, Started: true},
+	}
+	for action := RuntimeAction(0); action < numRuntimeActions; action++ {
+		view := valid[action]
+		view.UserKilled = true
+		err := view.ValidateRuntimeAction(action)
+		if err == nil || !strings.Contains(err.Error(), "pending kill") {
+			t.Fatalf("runtime action %d with a tombstone returned %v, want a pending-kill refusal", action, err)
+		}
+	}
+}
+
+func TestRuntimeAction_HandoffRejectsTerminalStates(t *testing.T) {
+	for _, liveness := range []Liveness{LiveArchived, LiveLost, LiveDead} {
+		view := LifecycleView{Title: "terminal", Liveness: liveness, Started: true}
+		if err := view.ValidateRuntimeAction(RuntimeActionHandoff); err == nil {
+			t.Fatalf("handoff accepted terminal liveness %v", liveness)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #2208
Fixes #2231

## Summary

- Add one lifecycle-action validator for every post-create runtime entry; its pending-kill veto applies before the action-specific state table.
- Reject archived restore before moving the worktree, with an actionable `pending kill` error, and re-check under the per-session operation lock.
- Reject handoff unless the row is actually live (`Running`, `Ready`, or `LimitReached`), both in the daemon and before the TUI opens its picker.
- Enforce the same guard at the session leaf methods (`Recover`, `Respawn`, `RestoreFromArchive`, `RestoreArchivedWorktree`, `SwapAgentProgram`, and `SwapAgent`) so a future caller cannot bypass the daemon checks.

## Verified against master

Verified on `origin/master` at `0de7d2fe` before changing code:

- `daemon/archive.go:110` rejects `instance.UserKilled()` before archive, while sibling restore at `daemon/archive.go:356` checks only identity + `LiveArchived`.
- `daemon/handoff.go:101` asks `Capabilities().Handoff`, and the locked recheck at `daemon/handoff.go:131` rejects only kill/archive teardown—not `Archived`, `Lost`, or `Dead`.
- `session/instance_backend.go:47-69` delegates Recover/Respawn/SwapAgent while leaving lifecycle preconditions to callers; local swap then starts in the recorded worktree and marks the row live at `session/backend_local.go:493-537`.

Both new daemon regressions failed first on master: tombstoned archive restore returned nil, and archived handoff performed a swap.

## Resurrection-path audit

| Path | Tombstone/state result |
|---|---|
| Explicit Archived restore | **Fixed:** shared `RuntimeActionRestoreArchived` guard before move and again under the op lock; leaf move/restore methods also enforce it. |
| Explicit Lost/Dead restore | Already guarded; now uses `RuntimeActionRestoreLostOrDead`, then the guarded `Instance.Recover` leaf. |
| Automatic Lost recovery | Already guarded in eligibility and locked recheck; both now use `RuntimeActionRecoverLost`, plus the guarded leaf. |
| Manual limit resume | Already rejects tombstones in `resumeFromLimitLocked`; any runtime restart now also passes `RuntimeActionResumeLimit` at `Instance.Respawn`. |
| Automatic limit resume | Already rejects tombstones before and under locks; shares the same guarded respawn leaf. |
| Handoff | **Fixed:** tombstone was checked, lifecycle was not. It now requires a live state before record mutation and runtime swap. |
| Archive-persist rollback | Exempt internal state repair: it starts no runtime, runs inside ArchiveSession's `killsInFlight` + op lock after the tombstone recheck, and later recovery passes the shared guard. |
| Root self-heal | Exempt intentional policy: it reaps a terminal record and creates a distinct config-owned root after the explicit kill grace period; it does not revive the tombstoned instance. |
| Restore from disk | Already refuses to start tombstoned or Archived rows; no terminal-to-live transition occurs on load. |

No third unguarded resurrection path was found.

## Validation

On commit `dfa1b77bab5c8341742e99df18c59734859c0141`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh` (894 Go files, 0 grandfathered)

— Captain Claude
