### PR TITLE
fix(kill): detect every locally orphaned commit

### DIFF
--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -197,8 +197,9 @@ func (m *home) handleKill() (tea.Model, tea.Cmd) {
 	severeLine := ""
 	if selected.Capabilities().Workspace == session.WorkspaceLocalWorktree {
 		// Both loss checks run under the SAME worktree-path gate so they cover the
-		// same session states. GetWorktreePath, GetBranch, and GetBaseCommitSHA are
-		// NOT gated on started (unlike GetGitWorktree), so a session that HAS a
+		// same session states. GetWorktreePath, GetWorktreeBranch, and
+		// GetBaseCommitSHA are intentionally not gated on started (unlike
+		// GetGitWorktree), so a session that HAS a
 		// worktree but was never started — e.g. a restore-failed session — still gets
 		// the unmerged-work warning the old GetGitWorktree gate skipped for it
 		// (#2029). Killing force-deletes its branch either way, so the same committed
@@ -212,7 +213,7 @@ func (m *home) handleKill() (tea.Model, tea.Cmd) {
 			if pr := selected.GetPRInfo(); pr != nil {
 				prState = pr.State
 			}
-			if line, severe := unmergedCommitWarning(wt, selected.GetBranch(), selected.GetBaseCommitSHA(), prState); line != "" {
+			if line, severe := unmergedCommitWarning(wt, selected.GetWorktreeBranch(), selected.GetBaseCommitSHA(), prState); line != "" {
 				if severe {
 					severeLine = line
 				} else {

--- a/app/kill_confirm.go
+++ b/app/kill_confirm.go
@@ -186,6 +186,28 @@ func unmergedCommitWarning(worktreePath, branchName, recordedBaseSHA, prState st
 	if strings.TrimSpace(worktreePath) == "" {
 		return unmergedFailClosedLine(branchName, fmt.Errorf("no worktree path")), false
 	}
+
+	// Branch reachability and detached-HEAD reachability are independent. An
+	// agent can detach from a clean recorded branch, create commits, and leave
+	// those commits reachable only through the worktree's HEAD. Cleanup removes
+	// that worktree, so a branch-only check would silently orphan them (#2210
+	// review). Assess both and preserve every warning in the confirmation.
+	branchLine, branchSevere := branchCommitWarning(worktreePath, branchName, recordedBaseSHA, prState)
+	detachedLine, detachedSevere := detachedHeadCommitWarning(worktreePath)
+	lines := make([]string, 0, 2)
+	for _, line := range []string{branchLine, detachedLine} {
+		if strings.TrimSpace(line) != "" {
+			lines = append(lines, line)
+		}
+	}
+	return strings.Join(lines, "\n\n"), branchSevere || detachedSevere
+}
+
+// branchCommitWarning is the recorded-branch half of
+// unmergedCommitWarning. branchName is the GitWorktree's canonical branch —
+// the exact ref Cleanup deletes — not Instance.Branch, which can be empty or
+// stale on legacy/restored records (#2209 review).
+func branchCommitWarning(worktreePath, branchName, recordedBaseSHA, prState string) (string, bool) {
 	branchName = strings.TrimSpace(branchName)
 	if branchName == "" {
 		return unmergedFailClosedLine(branchName, fmt.Errorf("no session branch name")), false
@@ -226,6 +248,40 @@ func unmergedCommitWarning(worktreePath, branchName, recordedBaseSHA, prState st
 		return "", false // every commit is pushed somewhere — recoverable
 	}
 	return unmergedSevereLine(branchName, localOnly, baseLabel), true
+}
+
+// detachedHeadCommitWarning reports commits that would lose their final ref
+// when the worktree is removed. `for-each-ref --contains=HEAD` asks the exact
+// durability question across every ref namespace (branches, remotes, tags,
+// stash, and custom refs) without guessing which namespaces a user relies on.
+// Empty output while HEAD is detached proves its tip is unreferenced; at least
+// that tip is then orphaned by cleanup even when the recorded branch is clean.
+func detachedHeadCommitWarning(worktreePath string) (string, bool) {
+	if _, err := runKillGit(worktreePath, "symbolic-ref", "--quiet", "HEAD"); err == nil {
+		return "", false // attached HEAD: the branch check owns committed loss
+	} else {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
+			return detachedHeadFailClosedLine(err), false
+		}
+	}
+	if _, err := runKillGit(worktreePath, "rev-parse", "--verify", "--quiet", "HEAD^{commit}"); err != nil {
+		return detachedHeadFailClosedLine(fmt.Errorf("HEAD could not be resolved: %w", err)), false
+	}
+	refs, err := runKillGit(worktreePath, "for-each-ref", "--contains=HEAD", "--format=%(refname)")
+	if err != nil {
+		return detachedHeadFailClosedLine(err), false
+	}
+	if strings.TrimSpace(string(refs)) != "" {
+		return "", false // some durable ref contains HEAD; removing the worktree preserves it
+	}
+	return "Detached HEAD points to one or more commits not reachable from any ref. " +
+		"Killing removes the worktree and permanently orphans them · this cannot be undone.", true
+}
+
+func detachedHeadFailClosedLine(err error) string {
+	return fmt.Sprintf("Could not verify whether detached HEAD contains local-only commits (%v); "+
+		"any unreferenced commits would be permanently orphaned when the worktree is removed.", err)
 }
 
 // resolveKillBase resolves the commit the branch is measured against for the

--- a/app/kill_confirm.go
+++ b/app/kill_confirm.go
@@ -191,16 +191,32 @@ func unmergedCommitWarning(worktreePath, branchName, recordedBaseSHA, prState st
 	// agent can detach from a clean recorded branch, create commits, and leave
 	// those commits reachable only through the worktree's HEAD. Cleanup removes
 	// that worktree, so a branch-only check would silently orphan them (#2210
-	// review). Assess both and preserve every warning in the confirmation.
-	branchLine, branchSevere := branchCommitWarning(worktreePath, branchName, recordedBaseSHA, prState)
-	detachedLine, detachedSevere := detachedHeadCommitWarning(worktreePath)
+	// review). Assess both independently and preserve every warning in the
+	// confirmation. They run concurrently because this path blocks the Bubble Tea
+	// event loop: adding a second serial chain would multiply the existing bounded
+	// Git-read latency and violate #2030's whole-confirmation responsiveness gate.
+	type warningResult struct {
+		line   string
+		severe bool
+	}
+	branchResult := make(chan warningResult, 1)
+	detachedResult := make(chan warningResult, 1)
+	go func() {
+		line, severe := branchCommitWarning(worktreePath, branchName, recordedBaseSHA, prState)
+		branchResult <- warningResult{line: line, severe: severe}
+	}()
+	go func() {
+		line, severe := detachedHeadCommitWarning(worktreePath)
+		detachedResult <- warningResult{line: line, severe: severe}
+	}()
+	branch, detached := <-branchResult, <-detachedResult
 	lines := make([]string, 0, 2)
-	for _, line := range []string{branchLine, detachedLine} {
+	for _, line := range []string{branch.line, detached.line} {
 		if strings.TrimSpace(line) != "" {
 			lines = append(lines, line)
 		}
 	}
-	return strings.Join(lines, "\n\n"), branchSevere || detachedSevere
+	return strings.Join(lines, "\n\n"), branch.severe || detached.severe
 }
 
 // branchCommitWarning is the recorded-branch half of

--- a/app/kill_unmerged_test.go
+++ b/app/kill_unmerged_test.go
@@ -191,6 +191,52 @@ func TestHandleKill_AgentSwitchesBranch_WarnsForSessionBranchCommits(t *testing.
 		"local-only work on the deleted branch must require deliberate confirmation")
 }
 
+// TestHandleKill_UsesCanonicalWorktreeBranch is the #2209 review regression.
+// Legacy/restored records can carry an empty or stale top-level Instance.Branch,
+// while cleanup deletes GitWorktree.BranchName. The confirmation must inspect
+// the latter or it can miss exactly the commits kill is about to orphan.
+func TestHandleKill_UsesCanonicalWorktreeBranch(t *testing.T) {
+	repoDir, baseSHA := initBaseRepo(t)
+	wt := addWorktree(t, repoDir, baseSHA, "dev/canonical")
+	commitInWorktree(t, wt)
+
+	inst := startedWorktreeInstance(t, "legacy", repoDir, wt, "dev/canonical", baseSHA)
+	inst.Branch = "stale-legacy-value"
+	_, hm := armKill(t, inst)
+
+	rendered := flatten(hm.confirmationOverlay.Render())
+	assert.Contains(t, rendered, "dev/canonical",
+		"warning must name the worktree branch cleanup will actually delete")
+	assert.NotContains(t, rendered, "stale-legacy-value")
+	assert.Contains(t, rendered, "1 commit")
+	assert.Equal(t, unmergedKillConfirmKey, hm.confirmationOverlay.ConfirmKey)
+}
+
+// TestHandleKill_DetachedLocalCommitEscalates is the #2210 review regression.
+// The recorded branch is level with base, but HEAD carries a new commit that no
+// ref contains. Removing the worktree drops the final reference to that commit,
+// so the branch-only check used to show the ordinary safe-looking confirmation.
+func TestHandleKill_DetachedLocalCommitEscalates(t *testing.T) {
+	repoDir, baseSHA := initBaseRepo(t)
+	wt := addWorktree(t, repoDir, baseSHA, "dev/detached")
+	killGit(t, wt, "checkout", "-q", "--detach", baseSHA)
+	commitInWorktree(t, wt)
+	require.Empty(t, killGit(t, wt, "status", "--porcelain"), "detached worktree must be clean")
+	require.Empty(t, killGit(t, wt, "for-each-ref", "--contains=HEAD", "--format=%(refname)"),
+		"the detached tip must exist only through the worktree HEAD")
+
+	inst := startedWorktreeInstance(t, "detached", repoDir, wt, "dev/detached", baseSHA)
+	_, hm := armKill(t, inst)
+
+	rendered := flatten(hm.confirmationOverlay.Render())
+	assert.Contains(t, rendered, "Detached HEAD")
+	assert.Contains(t, rendered, "not reachable from any ref")
+	assert.Contains(t, rendered, "permanently orphans")
+	assert.Contains(t, rendered, "cannot be undone")
+	assert.Equal(t, unmergedKillConfirmKey, hm.confirmationOverlay.ConfirmKey,
+		"an unreferenced detached commit must require deliberate confirmation")
+}
+
 // TestHandleKill_NoUniqueCommits_KeepsBareConfirmation guards against
 // over-warning: a clean worktree whose branch is level with base (no committed
 // work to lose) must kill behind the SAME bare confirmation and ordinary 'y' as
@@ -363,5 +409,25 @@ func TestUnmergedCommitWarning(t *testing.T) {
 		line, severe := unmergedCommitWarning(t.TempDir(), "dev/missing", "deadbeef", "")
 		assert.False(t, severe)
 		assert.Contains(t, line, "Could not verify")
+	})
+
+	t.Run("detached unreferenced commit is severe", func(t *testing.T) {
+		repoDir, baseSHA := initBaseRepo(t)
+		wt := addWorktree(t, repoDir, baseSHA, "dev/detached-direct")
+		killGit(t, wt, "checkout", "-q", "--detach", baseSHA)
+		commitInWorktree(t, wt)
+		line, severe := unmergedCommitWarning(wt, "dev/detached-direct", baseSHA, "")
+		assert.True(t, severe)
+		assert.Contains(t, line, "Detached HEAD")
+		assert.Contains(t, line, "permanently orphans")
+	})
+
+	t.Run("detached referenced commit is safe", func(t *testing.T) {
+		repoDir, baseSHA := initBaseRepo(t)
+		wt := addWorktree(t, repoDir, baseSHA, "dev/detached-referenced")
+		killGit(t, wt, "checkout", "-q", "--detach", baseSHA)
+		line, severe := unmergedCommitWarning(wt, "dev/detached-referenced", baseSHA, "")
+		assert.False(t, severe)
+		assert.Empty(t, line, "a detached HEAD still contained by the session branch survives worktree removal")
 	})
 }

--- a/session/instance_accessors.go
+++ b/session/instance_accessors.go
@@ -47,6 +47,21 @@ func (i *Instance) GetBranch() string {
 	return i.Branch
 }
 
+// GetWorktreeBranch returns the canonical branch recorded by the GitWorktree,
+// or empty when the instance has no worktree. Unlike GetGitWorktree, this is not
+// gated on started: kill/archive cleanup still acts on a restore-failed row's
+// recorded worktree and branch, so safety checks must be able to inspect the
+// exact ref cleanup would delete (#2209 review).
+func (i *Instance) GetWorktreeBranch() string {
+	i.mu.RLock()
+	gw := i.gitWorktree
+	i.mu.RUnlock()
+	if gw == nil {
+		return ""
+	}
+	return gw.GetBranchName()
+}
+
 // MarkUserKilled records kill intent on the instance (#1108). Callers persist
 // the instance afterwards so the tombstone survives a daemon crash mid-kill.
 func (i *Instance) MarkUserKilled() {


### PR DESCRIPTION
## Summary

- inspect the canonical `GitWorktree.BranchName` that cleanup actually deletes, rather than the stale legacy top-level branch field
- independently detect a detached `HEAD` whose tip is not contained by any Git ref, so removing the worktree cannot silently orphan its final commits
- preserve the existing deliberate `k` confirmation for every positively established loss and keep unverifiable states fail-closed
- run branch and detached-head reachability probes concurrently to preserve the TUI's whole-confirmation latency bound
- add rendered confirmation regressions for both unread Codex P2 findings from #2209

## Why this shape

The confirmation now asks the same two questions cleanup answers: which recorded branch will be deleted, and whether removing the worktree also removes the final reference to its current `HEAD`. `git for-each-ref --contains=HEAD` covers every ref namespace rather than guessing a partial branch/tag list.

## Verification

All required gates ran after final commit `33ef7610d59e9a692805ae1d3c3054132fef0597` was pushed, with local HEAD matching the remote branch:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (no output)
- `go build ./...`
- `make test-container`
- `deadcode -test ./...` (no output)
- `scripts/lint-file-length.sh`
- focused kill-loss and boundedness regressions under `go test -race`

— Captain Claude

Co-authored-by: Captain Claude <noreply@anthropic.com>
