### PR TITLE
fix(bugreport): redact task target sessions

### DIFF
--- a/bugreport/bugreport.go
+++ b/bugreport/bugreport.go
@@ -153,7 +153,7 @@ func Build(in Inputs) (Result, error) {
 		bundlePath:  in.BundlePath,
 	}
 
-	b.Tasks, b.Errors = collectTasks(b.Errors)
+	b.Tasks, b.Errors = collectTasks(r, b.Errors)
 	b.Instances, b.Errors = collectInstances(r, b.Errors)
 	b.Config, b.Errors = collectConfig(r, b.Errors)
 	b.Log, b.Errors = collectLog(r, b.Errors)
@@ -499,14 +499,14 @@ func countInstances(repos []repoInstances) int {
 }
 
 // collectTasks loads and redacts the configured tasks.
-func collectTasks(errs []string) ([]redactedTask, []string) {
+func collectTasks(r *redactor, errs []string) ([]redactedTask, []string) {
 	tasks, err := task.LoadTasks()
 	if err != nil {
 		return nil, append(errs, fmt.Sprintf("tasks: %v", err))
 	}
 	out := make([]redactedTask, 0, len(tasks))
 	for _, t := range tasks {
-		out = append(out, redactTask(t))
+		out = append(out, r.redactTask(t))
 	}
 	return out, errs
 }

--- a/bugreport/bugreport_test.go
+++ b/bugreport/bugreport_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/task"
 )
 
 // A realistic 40-hex git SHA that must survive redaction — the "keep
@@ -190,6 +191,30 @@ func TestRedactInstanceDataKeepsStructuralDropsFreeText(t *testing.T) {
 	}
 	if d.Worktree.SessionName != redactedMarker {
 		t.Errorf("worktree session name not redacted: %q", d.Worktree.SessionName)
+	}
+}
+
+// TestRedactTaskDropsTargetSession pins that a task's delivery target is a raw
+// session title, not a safe routing id. Bug reports promise to drop session
+// titles, so the structured task projection must never carry it verbatim.
+func TestRedactTaskDropsTargetSession(t *testing.T) {
+	const target = "ConfidentialCustomerMigration"
+
+	r := &redactor{}
+	got := r.redactTask(task.Task{
+		ID:            "task-2201",
+		Name:          "nightly",
+		CronExpr:      "0 9 * * *",
+		TargetSession: target,
+		Program:       "claude",
+		Enabled:       true,
+	})
+
+	if got.TargetSession != redactedMarker {
+		t.Fatalf("task target session leaked: got %q, want %q", got.TargetSession, redactedMarker)
+	}
+	if got.ID != "task-2201" || got.CronExpr != "0 9 * * *" || got.Program != "claude" || !got.Enabled {
+		t.Fatalf("safe structural task fields changed: %+v", got)
 	}
 }
 
@@ -804,7 +829,7 @@ func TestBuildEndToEnd(t *testing.T) {
 	writeFile(t, filepath.Join(instDir, "instances.json"), string(instances))
 
 	// tasks.json
-	tasks := `[{"id": "t1", "name": "nightly", "prompt": "run with sk-TASKSECRET0123456789ABCD", "cron_expr": "0 9 * * *", "enabled": true, "project_path": "` + home + `/Desktop/proj", "program": "claude"}]`
+	tasks := `[{"id": "t1", "name": "nightly", "prompt": "run with sk-TASKSECRET0123456789ABCD", "cron_expr": "0 9 * * *", "target_session": "ConfidentialTaskTargetAlpha", "enabled": true, "project_path": "` + home + `/Desktop/proj", "program": "claude"}]`
 	writeFile(t, filepath.Join(afHome, "tasks.json"), tasks)
 
 	// config.toml with planted credentials and a home path.
@@ -817,7 +842,8 @@ func TestBuildEndToEnd(t *testing.T) {
 	// log tail with a home path, a secret, and a verbatim tmux session name
 	// (the #1584 leak vector: the session title rides in on the log blob).
 	logLine := "2026-01-01 boot at " + home + "/Desktop key sk-LOGSECRET0123456789ABCDEF sha " + testSHA + "\n" +
-		"2026-01-01 tmux session af_0f8fc14c_myproprietarysession is gone\n"
+		"2026-01-01 tmux session af_0f8fc14c_myproprietarysession is gone\n" +
+		"2026-01-01 task t1 delivered prompt to target session \"ConfidentialTaskTargetAlpha\" (sent)\n"
 	writeFile(t, filepath.Join(afHome, "agent-factory.log"), logLine)
 
 	res, err := Build(Inputs{
@@ -854,6 +880,7 @@ func TestBuildEndToEnd(t *testing.T) {
 		"Project Nightingale",
 		"customer launch details",
 		"secret pr",
+		"ConfidentialTaskTargetAlpha",      // task target title, in both task JSON and daemon log (#2201)
 		"myproprietarysession",             // session title, leaked via the log tmux name (#1584)
 		"af_0f8fc14c_myproprietarysession", // the verbatim tmux name itself
 		home,                               // raw home path (username-revealing) must never appear verbatim

--- a/bugreport/redact.go
+++ b/bugreport/redact.go
@@ -556,17 +556,22 @@ type redactedTask struct {
 	LastRunStatus string `json:"last_run_status,omitempty"`
 }
 
-// redactTask maps a task.Task to its redacted projection.
-func redactTask(t task.Task) redactedTask {
+// redactTask maps a task.Task to its redacted projection. Recording the target
+// here keeps both title defenses inseparable: the structured task field is
+// dropped below, and scrubLog removes the same title from daemon log lines.
+func (r *redactor) redactTask(t task.Task) redactedTask {
+	r.noteTitle(t.TargetSession)
 	rt := redactedTask{
 		ID:            t.ID,
 		Name:          t.Name,
 		CronExpr:      t.CronExpr,
-		TargetSession: t.TargetSession,
 		ProjectPath:   t.ProjectPath,
 		Program:       t.Program,
 		Enabled:       t.Enabled,
 		LastRunStatus: t.LastRunStatus,
+	}
+	if t.TargetSession != "" {
+		rt.TargetSession = redactedMarker
 	}
 	if strings.TrimSpace(t.Prompt) != "" {
 		rt.HasPrompt = true


### PR DESCRIPTION
## Summary

- redact every non-empty task `TargetSession` as `[redacted]` in bug-report task projections
- register that target with the existing session-title scrubber, so daemon log lines that print the target cannot reintroduce it
- keep task IDs, schedules, program, and other structural diagnostics intact

Fixes #2201

## Verification against master

Verified against `a84dfa577e33468a934f4bc55641ddd17387eb4d` before changing code.

- The policy says session titles are always dropped at `bugreport/redact.go:15-18`, while `redactTask` copied `t.TargetSession` verbatim at `bugreport/redact.go:565`. This claim is real.
- The same title can reach the bundled daemon log at `daemon/taskrun.go:130-132`; coupling title registration to task redaction closes that adjacent path too.
- The bot's delivery-alarm claim is not an executing bug-report path. The sole production `bugreport.Build` call passes `daemonStatusInfo` at `commands/bugreportcmd.go:93-99`, and that type's complete field list at `commands/daemoncmd.go:115-135` contains no snapshots or alarms. `daemon.DeliveryAlarm.TargetSession` exists at `daemon/snapshot.go:48-60`, but that snapshot is not supplied to bug reports. This PR therefore does not add a speculative alarm redactor.

## Regression proof

Before the fix, the new focused regression failed with:

```
task target session leaked: got "ConfidentialCustomerMigration", want "[redacted]"
```

The end-to-end bundle test now plants a distinct task target in both `tasks.json` and the daemon log and asserts it is absent from the text bundle, issue draft, and JSON manifest.

## Validation

All gates passed after the final commit on pushed head `97f58fe8991b72c514117ead5829acb060374f98`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh` (894 Go files, 0 grandfathered)

— Captain Claude