### PR TITLE
feat(daemon): add upgrade probation health surface

### DIFF
--- a/app/kill_hang_test.go
+++ b/app/kill_hang_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/sachiniyer/agent-factory/apiclient"
+	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/internal/testguard"
 )
 
@@ -86,7 +87,7 @@ func TestKillSessionThroughDaemon_WedgedDaemon_ReturnsActionableError(t *testing
 	}
 }
 
-// TestHTTPCallWarming_ContextErrorsAreNotRetryable guards the interaction between
+// TestHTTPCallRetryable_ContextErrorsAreNotRetryable guards the interaction between
 // the kill bound and withDaemonHTTP's warm-up retry, which the tests above cannot
 // see because they stub withDaemonHTTP.
 //
@@ -96,7 +97,7 @@ func TestKillSessionThroughDaemon_WedgedDaemon_ReturnsActionableError(t *testing
 // deadline would be re-issued for the whole 5s warm-up window against a context
 // that is already dead — every attempt failing instantly — before finally
 // reporting the timeout the user should have seen 5 seconds earlier.
-func TestHTTPCallWarming_ContextErrorsAreNotRetryable(t *testing.T) {
+func TestHTTPCallRetryable_ContextErrorsAreNotRetryable(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		err  error
@@ -112,7 +113,7 @@ func TestHTTPCallWarming_ContextErrorsAreNotRetryable(t *testing.T) {
 			if !apiclient.IsTransportError(wrapped) {
 				t.Fatal("precondition: a context failure does arrive as a TransportError, which is what the warm-up loop retries")
 			}
-			if httpCallWarming(wrapped) {
+			if httpCallRetryable(wrapped) {
 				t.Fatal("a caller's own deadline/cancel must not be retried as daemon warm-up: every retry re-issues the call with a dead context and fails instantly")
 			}
 		})
@@ -120,8 +121,31 @@ func TestHTTPCallWarming_ContextErrorsAreNotRetryable(t *testing.T) {
 
 	// The genuine warm-up condition must still retry, or a cold-start kill breaks.
 	stillWarming := &apiclient.TransportError{Err: errors.New("dial unix: connect: connection refused")}
-	if !httpCallWarming(stillWarming) {
+	if !httpCallRetryable(stillWarming) {
 		t.Fatal("a real transport failure must still be retried while the daemon's socket binds")
+	}
+}
+
+// TestHTTPCallRetryable_DaemonAdmissionParity pins the cross-transport
+// invariant behind the retry classifier. A new daemon admission phase belongs
+// in daemon.IsDaemonAdmissionRetryable once; both net/rpc and the TUI's HTTP
+// path then inherit it instead of maintaining parallel phase lists.
+func TestHTTPCallRetryable_DaemonAdmissionParity(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"startup warming", errDaemonStarting()},
+		{"upgrade probation", errors.New("agent-factory daemon is validating an upgrade (transaction tx-2212); retry shortly")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if !daemon.IsDaemonAdmissionRetryable(tc.err) {
+				t.Fatal("precondition: daemon admission classifier did not recognize the wire error")
+			}
+			if !httpCallRetryable(tc.err) {
+				t.Fatal("TUI HTTP retry drifted from the daemon admission classifier")
+			}
+		})
 	}
 }
 

--- a/app/session_control.go
+++ b/app/session_control.go
@@ -20,22 +20,21 @@ import (
 // (a lifecycle concern, transport-agnostic) survives from the old path, to spawn
 // the daemon at cold start exactly as callDaemon's implicit ensure used to.
 
-// daemonHTTPWarmup{Wait,Poll} bound the retry the TUI's HTTP calls tolerate
-// while a freshly-ensured daemon finishes coming up. Two transient conditions
-// need it and both clear inside this window: (1) the daemon reports the #829
-// "still restoring sessions" starting error, and (2) its HTTP socket has not
-// finished binding — the daemon binds daemon-http.sock microseconds AFTER the
-// control socket EnsureDaemon waits for (daemon boot order), so a call fired in
-// that sliver sees a transport refusal. The values mirror the net/rpc callDaemon
-// warm-up (daemonReadyTimeout / a 100ms cadence) so the switch is behavior-
-// preserving.
+// daemonHTTPRetry{Wait,Poll} bound the retry the TUI's HTTP calls tolerate for
+// transient daemon lifecycle admission and startup transport races. Three
+// conditions clear inside this window: (1) the daemon reports the #829 "still
+// restoring sessions" error, (2) an upgrade candidate is in validation
+// probation, or (3) daemon-http.sock has not finished binding — it binds
+// microseconds AFTER the control socket EnsureDaemon waits for. The values
+// mirror the net/rpc callDaemon admission retry (daemonReadyTimeout / a 100ms
+// cadence), preserving transport parity.
 const (
-	daemonHTTPWarmupWait = 5 * time.Second
-	daemonHTTPWarmupPoll = 100 * time.Millisecond
+	daemonHTTPRetryWait = 5 * time.Second
+	daemonHTTPRetryPoll = 100 * time.Millisecond
 )
 
 // withDaemonHTTP ensures a daemon is running, then invokes fn against a fresh
-// HTTP client, retrying while the daemon is warming (starting error) or its
+// HTTP client, retrying while lifecycle admission is transiently closed or its
 // HTTP socket has not yet bound (transport error). It is the HTTP twin of the
 // net/rpc callDaemon: EnsureDaemon spawns the daemon if absent (the TUI relied
 // on callDaemon's implicit ensure to boot the daemon at cold start — spawning is
@@ -57,31 +56,31 @@ var withDaemonHTTP = func(fn func(*apiclient.Client) error) error {
 		return err
 	}
 	err = fn(c)
-	deadline := time.Now().Add(daemonHTTPWarmupWait)
-	for httpCallWarming(err) && time.Now().Before(deadline) {
-		time.Sleep(daemonHTTPWarmupPoll)
+	deadline := time.Now().Add(daemonHTTPRetryWait)
+	for httpCallRetryable(err) && time.Now().Before(deadline) {
+		time.Sleep(daemonHTTPRetryPoll)
 		err = fn(c)
 	}
 	return err
 }
 
-// httpCallWarming reports whether an HTTP control error is a transient warm-up
-// condition worth retrying: the daemon's #829 starting error, or a transport
-// failure while its HTTP socket finishes binding. A daemon application error
-// (session not found, invalid repo) comes back as an envelope message — never a
+// httpCallRetryable reports whether an HTTP control error is transient: a
+// lifecycle admission refusal classified by daemon, or a transport failure
+// while its HTTP socket finishes binding. A daemon application error (session
+// not found, invalid repo) comes back as an envelope message — never a
 // TransportError — so it is never retried and surfaces to the caller at once.
 //
-// A cancelled or expired context is NOT warming, even though it arrives dressed
-// as a TransportError (http.Client reports it through the round-trip, which this
-// package tags). It means the CALLER gave up, so every retry re-issues the call
-// with the same dead context and fails instantly: a bounded call (killRPCTimeout)
-// would burn its entire warm-up window spinning on a request that cannot
-// succeed, and would report the deadline seconds after it actually fired.
-func httpCallWarming(err error) bool {
+// A cancelled or expired context is NOT retryable, even though it arrives
+// dressed as a TransportError (http.Client reports it through the round-trip,
+// which this package tags). It means the CALLER gave up, so every retry
+// re-issues the call with the same dead context and fails instantly: a bounded
+// call (killRPCTimeout) would burn its entire retry window spinning on a request
+// that cannot succeed, and would report the deadline seconds after it fired.
+func httpCallRetryable(err error) bool {
 	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 		return false
 	}
-	return daemon.IsDaemonStartingErr(err) || apiclient.IsTransportError(err)
+	return daemon.IsDaemonAdmissionRetryable(err) || apiclient.IsTransportError(err)
 }
 
 type sessionStartRequest struct {

--- a/commands/daemoncmd.go
+++ b/commands/daemoncmd.go
@@ -113,15 +113,20 @@ var daemonStatusJSON bool
 // no-spawn probe `af doctor` uses) plus an os.Stat of the HTTP socket, so the
 // command never dials or starts a daemon and needs no new RPC.
 type daemonStatusInfo struct {
-	Running           bool   `json:"running"`
-	ControlSocket     string `json:"control_socket"`
-	ControlSocketFile bool   `json:"control_socket_file"`
-	HTTPSocket        string `json:"http_socket"`
-	HTTPSocketFile    bool   `json:"http_socket_file"`
-	PID               int    `json:"pid"`
-	PIDVerified       bool   `json:"pid_verified"`
-	AutostartUnit     bool   `json:"autostart_unit"`
-	BinaryStale       bool   `json:"binary_stale"`
+	Running           bool                         `json:"running"`
+	Version           string                       `json:"version,omitempty"`
+	BootID            string                       `json:"boot_id,omitempty"`
+	TransactionID     string                       `json:"transaction_id,omitempty"`
+	Phase             daemon.DaemonPhase           `json:"phase,omitempty"`
+	Listeners         *daemon.DaemonListenerStatus `json:"listeners,omitempty"`
+	ControlSocket     string                       `json:"control_socket"`
+	ControlSocketFile bool                         `json:"control_socket_file"`
+	HTTPSocket        string                       `json:"http_socket"`
+	HTTPSocketFile    bool                         `json:"http_socket_file"`
+	PID               int                          `json:"pid"`
+	PIDVerified       bool                         `json:"pid_verified"`
+	AutostartUnit     bool                         `json:"autostart_unit"`
+	BinaryStale       bool                         `json:"binary_stale"`
 	// ExposureWarning is non-empty when the config on disk serves the control API
 	// unauthenticated on a network address (#2090) — an ALLOWED posture since
 	// #2168 Phase 0, so this reports it rather than predicting a failure.
@@ -142,12 +147,20 @@ func collectDaemonStatus() daemonStatusInfo {
 	h := daemon.Health()
 	info := daemonStatusInfo{
 		Running:           h.PingErr == nil,
+		Version:           h.DaemonVersion,
+		BootID:            h.BootID,
+		TransactionID:     h.TransactionID,
+		Phase:             h.Phase,
 		ControlSocket:     h.SocketPath,
 		ControlSocketFile: h.SocketExists,
 		PID:               h.PIDFilePID,
 		PIDVerified:       h.PIDVerified,
 		AutostartUnit:     h.AutostartUnit,
 		BinaryStale:       h.BinaryDeleted,
+	}
+	if h.PingErr == nil && h.Phase != "" {
+		listeners := h.Listeners
+		info.Listeners = &listeners
 	}
 	if httpPath, err := daemon.DaemonHTTPSocketPath(); err == nil {
 		info.HTTPSocket = httpPath
@@ -178,6 +191,33 @@ func printDaemonStatusHuman(cmd *cobra.Command, info daemonStatusInfo) {
 		// is no config the daemon refuses to start under, so there is no posture
 		// that makes this line a lie.
 		fmt.Fprintln(w, "daemon: not running (starts on demand when you run af with an enabled task)")
+	}
+	if info.Phase != "" {
+		fmt.Fprintf(w, "  phase:          %s\n", info.Phase)
+	}
+	if info.Version != "" {
+		fmt.Fprintf(w, "  version:        %s\n", info.Version)
+	}
+	if info.BootID != "" {
+		fmt.Fprintf(w, "  boot id:        %s\n", info.BootID)
+	}
+	if info.TransactionID != "" {
+		fmt.Fprintf(w, "  transaction:    %s\n", info.TransactionID)
+	}
+	if info.Listeners != nil {
+		httpState := "not bound"
+		if info.Listeners.HTTPUnixBound {
+			httpState = "bound"
+		}
+		fmt.Fprintf(w, "  http listener:  %s\n", httpState)
+		switch {
+		case !info.Listeners.TCPConfigured:
+			fmt.Fprintln(w, "  tcp listener:   disabled")
+		case info.Listeners.TCPBound:
+			fmt.Fprintf(w, "  tcp listener:   %s (bound)\n", info.Listeners.TCPBoundAddr)
+		default:
+			fmt.Fprintf(w, "  tcp listener:   %s (not bound)\n", info.Listeners.TCPListenAddr)
+		}
 	}
 	fmt.Fprintf(w, "  control socket: %s (%s)\n", info.ControlSocket, presence(info.ControlSocketFile))
 	if info.HTTPSocket != "" {

--- a/commands/daemonstatuscmd_test.go
+++ b/commands/daemonstatuscmd_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/internal/testguard"
 )
 
@@ -45,7 +46,17 @@ func TestPrintDaemonStatusHumanRunning(t *testing.T) {
 	cmd.SetOut(&out)
 
 	printDaemonStatusHuman(cmd, daemonStatusInfo{
-		Running:           true,
+		Running:       true,
+		Version:       "1.2.3",
+		BootID:        "boot-123",
+		TransactionID: "transaction-123",
+		Phase:         daemon.DaemonPhaseUpgradeProbation,
+		Listeners: &daemon.DaemonListenerStatus{
+			HTTPUnixBound: true,
+			TCPConfigured: true,
+			TCPBound:      true,
+			TCPBoundAddr:  "127.0.0.1:8443",
+		},
 		ControlSocket:     "/h/daemon.sock",
 		ControlSocketFile: true,
 		HTTPSocket:        "/h/daemon-http.sock",
@@ -58,6 +69,12 @@ func TestPrintDaemonStatusHumanRunning(t *testing.T) {
 	got := out.String()
 	for _, want := range []string{
 		"daemon: running",
+		"phase:          upgrade_probation",
+		"version:        1.2.3",
+		"boot id:        boot-123",
+		"transaction:    transaction-123",
+		"http listener:  bound",
+		"tcp listener:   127.0.0.1:8443 (bound)",
 		"control socket: /h/daemon.sock (present)",
 		"http socket:    /h/daemon-http.sock (present)",
 		"pid:            42 (verified)",

--- a/daemon/control_client.go
+++ b/daemon/control_client.go
@@ -24,6 +24,11 @@ var ensureDaemonMu sync.Mutex
 // against a sentinel value; IsDaemonStartingErr matches this text instead.
 const daemonStartingErrText = "agent-factory daemon is starting (restoring sessions); retry shortly"
 
+// daemonUpgradeProbationErrText is the stable portion of the wire-visible
+// probation refusal. The transaction ID follows it for diagnosis, so clients
+// match the prefix rather than one complete dynamic string.
+const daemonUpgradeProbationErrText = "agent-factory daemon is validating an upgrade"
+
 // errDaemonStarting is returned by state-dependent RPC handlers in the window
 // between the control-socket bind and the completion of the instance restore
 // (#829). The socket now binds before the restore, which can take minutes on
@@ -32,12 +37,28 @@ func errDaemonStarting() error {
 	return errors.New(daemonStartingErrText)
 }
 
+func errDaemonUpgradeProbation(transactionID string) error {
+	return fmt.Errorf("%s (transaction %s); retry shortly", daemonUpgradeProbationErrText, transactionID)
+}
+
 // IsDaemonStartingErr reports whether an RPC client error means the daemon is
 // up but still restoring instances. Callers should treat it as retryable: the
 // daemon is alive (EnsureDaemon's ping succeeds, so it must NOT spawn another)
 // and the same request succeeds once the restore finishes.
 func IsDaemonStartingErr(err error) bool {
 	return err != nil && strings.Contains(err.Error(), daemonStartingErrText)
+}
+
+// IsDaemonUpgradeProbationErr reports whether a daemon mutation was refused
+// because a candidate is restored but its previous-binary supervisor has not
+// released admission yet. Like the warm-up error, net/rpc flattens the server
+// error to text, so this classifier matches the stable wire prefix.
+func IsDaemonUpgradeProbationErr(err error) bool {
+	return err != nil && strings.Contains(err.Error(), daemonUpgradeProbationErrText)
+}
+
+func isDaemonAdmissionRetryable(err error) bool {
+	return IsDaemonStartingErr(err) || IsDaemonUpgradeProbationErr(err)
 }
 
 // DaemonSocketPath returns the Unix socket path used by the local control
@@ -162,12 +183,12 @@ func callDaemon(method string, req any, resp any) error {
 		return err
 	}
 	err := callDaemonNoEnsure(method, req, resp)
-	// A warming daemon rejects state-dependent RPCs until its instance
-	// restore completes (#829). Retry briefly so callers that race a fresh
-	// daemon spawn (CLI create right after boot, task runs after an upgrade
-	// respawn) succeed without every call site growing retry logic.
+	// A warming daemon rejects state-dependent RPCs until restore completes;
+	// an upgrade candidate rejects mutations until its validator releases
+	// probation. Both are alive and retryable, so callers share one bounded
+	// retry rather than growing per-call-site lifecycle logic.
 	deadline := time.Now().Add(daemonWarmupWait)
-	for IsDaemonStartingErr(err) && time.Now().Before(deadline) {
+	for isDaemonAdmissionRetryable(err) && time.Now().Before(deadline) {
 		time.Sleep(daemonWarmupPoll)
 		err = callDaemonNoEnsure(method, req, resp)
 	}

--- a/daemon/control_client.go
+++ b/daemon/control_client.go
@@ -57,7 +57,11 @@ func IsDaemonUpgradeProbationErr(err error) bool {
 	return err != nil && strings.Contains(err.Error(), daemonUpgradeProbationErrText)
 }
 
-func isDaemonAdmissionRetryable(err error) bool {
+// IsDaemonAdmissionRetryable reports whether err is a lifecycle admission
+// refusal expected to clear without restarting the daemon. Both the net/rpc
+// and HTTP/TUI transports use this predicate so a new admission phase cannot
+// become retryable on one transport while failing immediately on the other.
+func IsDaemonAdmissionRetryable(err error) bool {
 	return IsDaemonStartingErr(err) || IsDaemonUpgradeProbationErr(err)
 }
 
@@ -166,16 +170,16 @@ func pingDaemonResponse() (PingResponse, error) {
 	return resp, err
 }
 
-// daemonWarmupWait bounds how long RPC clients wait for a warming daemon
-// (socket bound, instance restore still running — #829) before surfacing the
-// typed starting error. It mirrors daemonReadyTimeout, the wait callers
-// already tolerated pre-#829 when EnsureDaemon polled for the socket: a local
-// restore completes well inside this window so CLI/TUI calls just work, while
-// a minutes-long remote-hook restore fails fast with an actionable message
-// instead of hanging the caller. daemonWarmupPoll is the retry cadence.
+// daemonAdmissionRetryWait bounds how long RPC clients wait for a transient
+// lifecycle admission refusal before surfacing it. It mirrors
+// daemonReadyTimeout, the wait callers already tolerated pre-#829 when
+// EnsureDaemon polled for the socket: a local restore or probation release
+// completes inside this window so calls just work, while a stuck transition
+// fails fast with its actionable message instead of hanging the caller.
+// daemonAdmissionRetryPoll is the retry cadence.
 const (
-	daemonWarmupWait = daemonReadyTimeout
-	daemonWarmupPoll = 100 * time.Millisecond
+	daemonAdmissionRetryWait = daemonReadyTimeout
+	daemonAdmissionRetryPoll = 100 * time.Millisecond
 )
 
 func callDaemon(method string, req any, resp any) error {
@@ -187,9 +191,9 @@ func callDaemon(method string, req any, resp any) error {
 	// an upgrade candidate rejects mutations until its validator releases
 	// probation. Both are alive and retryable, so callers share one bounded
 	// retry rather than growing per-call-site lifecycle logic.
-	deadline := time.Now().Add(daemonWarmupWait)
-	for isDaemonAdmissionRetryable(err) && time.Now().Before(deadline) {
-		time.Sleep(daemonWarmupPoll)
+	deadline := time.Now().Add(daemonAdmissionRetryWait)
+	for IsDaemonAdmissionRetryable(err) && time.Now().Before(deadline) {
+		time.Sleep(daemonAdmissionRetryPoll)
 		err = callDaemonNoEnsure(method, req, resp)
 	}
 	return err

--- a/daemon/control_server.go
+++ b/daemon/control_server.go
@@ -27,6 +27,13 @@ type controlServer struct {
 func (s *controlServer) Ping(_ PingRequest, resp *PingResponse) error {
 	resp.OK = true
 	resp.Version = Version()
+	if s.manager != nil && s.manager.lifecycle != nil {
+		state := s.manager.lifecycle.snapshot()
+		resp.BootID = state.bootID
+		resp.TransactionID = state.transactionID
+		resp.Phase = state.phase
+		resp.Listeners = state.listeners
+	}
 	return nil
 }
 
@@ -36,8 +43,12 @@ func (s *controlServer) Ping(_ PingRequest, resp *PingResponse) error {
 // m.mu), independent of the instance restore — a pause that lands during
 // warm-up is honored once the instance is restored, and it can never corrupt
 // state the way a create/kill racing the restore could. A nil manager (some
-// test control servers) is a no-op ack.
+// test control servers) is a no-op ack. Upgrade probation is different: every
+// mutation is closed there, so requireMutationAdmission still applies.
 func (s *controlServer) PauseStatusPoll(req PauseStatusPollRequest, resp *PauseStatusPollResponse) error {
+	if err := s.requireMutationAdmission(); err != nil {
+		return err
+	}
 	if s.manager != nil {
 		s.manager.PauseStatusPoll(req.RepoID, req.Title)
 	}
@@ -45,9 +56,12 @@ func (s *controlServer) PauseStatusPoll(req PauseStatusPollRequest, resp *PauseS
 	return nil
 }
 
-// ResumeStatusPoll clears a pause set by PauseStatusPoll (#1160). Same
-// lightweight, ungated conventions as PauseStatusPoll.
+// ResumeStatusPoll clears a pause set by PauseStatusPoll (#1160). Same restore
+// independence and probation gate as PauseStatusPoll.
 func (s *controlServer) ResumeStatusPoll(req ResumeStatusPollRequest, resp *ResumeStatusPollResponse) error {
+	if err := s.requireMutationAdmission(); err != nil {
+		return err
+	}
 	if s.manager != nil {
 		s.manager.ResumeStatusPoll(req.RepoID, req.Title)
 	}
@@ -87,6 +101,9 @@ func (s *controlServer) reloadTaskSchedules() error {
 }
 
 func (s *controlServer) ReloadTasks(_ ReloadTasksRequest, resp *ReloadTasksResponse) error {
+	if err := s.requireMutationAdmission(); err != nil {
+		return err
+	}
 	if err := s.reloadTaskSchedules(); err != nil {
 		return err
 	}
@@ -135,6 +152,9 @@ func (s *controlServer) GetConfig(_ GetConfigRequest, resp *GetConfigResponse) e
 // Errors (unknown key, invalid value) propagate verbatim so the web form shows
 // the validator's own message, which is the one the CLI prints.
 func (s *controlServer) SetConfigValue(req SetConfigValueRequest, resp *SetConfigValueResponse) error {
+	if err := s.requireMutationAdmission(); err != nil {
+		return err
+	}
 	result, err := config.SetGlobalConfigValue(req.Key, req.Value)
 	if err != nil {
 		return err
@@ -163,6 +183,9 @@ func (s *controlServer) ListTasks(_ ListTasksRequest, resp *ListTasksResponse) e
 // difference is the daemon now owns it and refreshes its own scheduler/watchers
 // in the same call.
 func (s *controlServer) AddTask(req AddTaskRequest, resp *AddTaskResponse) error {
+	if err := s.requireMutationAdmission(); err != nil {
+		return err
+	}
 	if err := task.AddTask(req.Task); err != nil {
 		return err
 	}
@@ -175,6 +198,9 @@ func (s *controlServer) AddTask(req AddTaskRequest, resp *AddTaskResponse) error
 }
 
 func (s *controlServer) UpdateTask(req UpdateTaskRequest, resp *UpdateTaskResponse) error {
+	if err := s.requireMutationAdmission(); err != nil {
+		return err
+	}
 	merged, err := task.UpdateTask(req.ID, req.Update, req.Expect)
 	if err != nil {
 		return err
@@ -191,6 +217,9 @@ func (s *controlServer) UpdateTask(req UpdateTaskRequest, resp *UpdateTaskRespon
 }
 
 func (s *controlServer) RemoveTask(req RemoveTaskRequest, resp *RemoveTaskResponse) error {
+	if err := s.requireMutationAdmission(); err != nil {
+		return err
+	}
 	if err := task.RemoveTask(req.ID, req.Expect); err != nil {
 		return err
 	}
@@ -209,6 +238,9 @@ func (s *controlServer) RemoveTask(req RemoveTaskRequest, resp *RemoveTaskRespon
 // (#1169-class fix). RunTask preserves the guards: watch tasks and disabled
 // tasks are refused.
 func (s *controlServer) TriggerTask(req TriggerTaskRequest, resp *TriggerTaskResponse) error {
+	if err := s.requireMutationAdmission(); err != nil {
+		return err
+	}
 	if err := RunTask(req.ID, req.Expect); err != nil {
 		return err
 	}
@@ -246,6 +278,27 @@ func (s *controlServer) requireManagerReady() error {
 	return errDaemonStarting()
 }
 
+// requireMutationAdmission is the probation gate for mutations that are safe
+// during ordinary restore (task/config writes and poll leases). A candidate
+// blocks them from socket bind onward so rollback can restore one coherent
+// metadata snapshot.
+func (s *controlServer) requireMutationAdmission() error {
+	if s.manager == nil || s.manager.lifecycle == nil {
+		return nil
+	}
+	return s.manager.lifecycle.mutationAdmissionError()
+}
+
+// requireStateMutationAdmission composes the existing restored-state barrier
+// with upgrade probation. Every session mutation uses this one entrypoint, so
+// neither phase can accidentally authorize what the other refuses.
+func (s *controlServer) requireStateMutationAdmission() error {
+	if err := s.requireManagerReady(); err != nil {
+		return err
+	}
+	return s.requireMutationAdmission()
+}
+
 // CreateSession is the net/rpc entrypoint. net/rpc gives no per-call context, so
 // it passes Background; the create is still bounded by WaitForReady's internal
 // timeout and torn down when this returns. The HTTP route wires the request
@@ -255,7 +308,7 @@ func (s *controlServer) CreateSession(req CreateSessionRequest, resp *CreateSess
 }
 
 func (s *controlServer) createSession(ctx context.Context, req CreateSessionRequest, resp *CreateSessionResponse) error {
-	if err := s.requireManagerReady(); err != nil {
+	if err := s.requireStateMutationAdmission(); err != nil {
 		return err
 	}
 	data, err := s.manager.CreateSession(ctx, req)
@@ -271,7 +324,7 @@ func (s *controlServer) createSession(ctx context.Context, req CreateSessionRequ
 // bounded by the readiness timeout inside WaitForReadyOn, and any failure tears
 // the session down before returning.
 func (s *controlServer) SpawnConfigAgent(req SpawnConfigAgentRequest, resp *SpawnConfigAgentResponse) error {
-	if err := s.requireManagerReady(); err != nil {
+	if err := s.requireStateMutationAdmission(); err != nil {
 		return err
 	}
 	name, socketPath, err := s.manager.SpawnConfigAgent(context.Background(), req)
@@ -286,14 +339,14 @@ func (s *controlServer) SpawnConfigAgent(req SpawnConfigAgentRequest, resp *Spaw
 // ReapConfigAgent tears down a config-agent session. No event is published: a
 // config agent is not a session, so nothing on the events plane models it.
 func (s *controlServer) ReapConfigAgent(req ReapConfigAgentRequest, _ *ReapConfigAgentResponse) error {
-	if err := s.requireManagerReady(); err != nil {
+	if err := s.requireStateMutationAdmission(); err != nil {
 		return err
 	}
 	return s.manager.ReapConfigAgent(req)
 }
 
 func (s *controlServer) CreateTab(req CreateTabRequest, resp *CreateTabResponse) error {
-	if err := s.requireManagerReady(); err != nil {
+	if err := s.requireStateMutationAdmission(); err != nil {
 		return err
 	}
 	if err := validateRPCRepoID(req.RepoID); err != nil {
@@ -309,7 +362,7 @@ func (s *controlServer) CreateTab(req CreateTabRequest, resp *CreateTabResponse)
 }
 
 func (s *controlServer) CloseTab(req CloseTabRequest, resp *CloseTabResponse) error {
-	if err := s.requireManagerReady(); err != nil {
+	if err := s.requireStateMutationAdmission(); err != nil {
 		return err
 	}
 	if err := validateRPCRepoID(req.RepoID); err != nil {
@@ -324,7 +377,7 @@ func (s *controlServer) CloseTab(req CloseTabRequest, resp *CloseTabResponse) er
 }
 
 func (s *controlServer) RenameTab(req RenameTabRequest, resp *RenameTabResponse) error {
-	if err := s.requireManagerReady(); err != nil {
+	if err := s.requireStateMutationAdmission(); err != nil {
 		return err
 	}
 	if err := validateRPCRepoID(req.RepoID); err != nil {
@@ -339,7 +392,7 @@ func (s *controlServer) RenameTab(req RenameTabRequest, resp *RenameTabResponse)
 }
 
 func (s *controlServer) ReorderTab(req ReorderTabRequest, resp *ReorderTabResponse) error {
-	if err := s.requireManagerReady(); err != nil {
+	if err := s.requireStateMutationAdmission(); err != nil {
 		return err
 	}
 	if err := validateRPCRepoID(req.RepoID); err != nil {
@@ -355,7 +408,7 @@ func (s *controlServer) ReorderTab(req ReorderTabRequest, resp *ReorderTabRespon
 }
 
 func (s *controlServer) SetPRInfo(req SetPRInfoRequest, resp *SetPRInfoResponse) error {
-	if err := s.requireManagerReady(); err != nil {
+	if err := s.requireStateMutationAdmission(); err != nil {
 		return err
 	}
 	if err := validateRPCRepoID(req.RepoID); err != nil {
@@ -381,7 +434,7 @@ func (s *controlServer) Snapshot(req SnapshotRequest, resp *SnapshotResponse) er
 }
 
 func (s *controlServer) KillSession(req KillSessionRequest, resp *KillSessionResponse) error {
-	if err := s.requireManagerReady(); err != nil {
+	if err := s.requireStateMutationAdmission(); err != nil {
 		return err
 	}
 	if err := validateRPCRepoID(req.RepoID); err != nil {
@@ -402,7 +455,7 @@ func (s *controlServer) KillSession(req KillSessionRequest, resp *KillSessionRes
 }
 
 func (s *controlServer) ArchiveSession(req ArchiveSessionRequest, resp *ArchiveSessionResponse) error {
-	if err := s.requireManagerReady(); err != nil {
+	if err := s.requireStateMutationAdmission(); err != nil {
 		return err
 	}
 	if err := validateRPCRepoID(req.RepoID); err != nil {
@@ -422,7 +475,7 @@ func (s *controlServer) ArchiveSession(req ArchiveSessionRequest, resp *ArchiveS
 }
 
 func (s *controlServer) RestoreArchived(req RestoreArchivedRequest, resp *RestoreArchivedResponse) error {
-	if err := s.requireManagerReady(); err != nil {
+	if err := s.requireStateMutationAdmission(); err != nil {
 		return err
 	}
 	if err := validateRPCRepoID(req.RepoID); err != nil {
@@ -442,7 +495,7 @@ func (s *controlServer) RestoreArchived(req RestoreArchivedRequest, resp *Restor
 }
 
 func (s *controlServer) RestoreSession(req RestoreSessionRequest, resp *RestoreSessionResponse) error {
-	if err := s.requireManagerReady(); err != nil {
+	if err := s.requireStateMutationAdmission(); err != nil {
 		return err
 	}
 	if err := validateRPCRepoID(req.RepoID); err != nil {
@@ -462,7 +515,7 @@ func (s *controlServer) RestoreSession(req RestoreSessionRequest, resp *RestoreS
 }
 
 func (s *controlServer) SendPrompt(req SendPromptRequest, resp *SendPromptResponse) error {
-	if err := s.requireManagerReady(); err != nil {
+	if err := s.requireStateMutationAdmission(); err != nil {
 		return err
 	}
 	if err := validateRPCRepoID(req.RepoID); err != nil {
@@ -484,7 +537,7 @@ func (s *controlServer) SendPrompt(req SendPromptRequest, resp *SendPromptRespon
 // projects view. On a partial failure it still publishes what DID happen before
 // surfacing the error, so the rail never lags reality.
 func (s *controlServer) DeleteProject(req DeleteProjectRequest, resp *DeleteProjectResponse) error {
-	if err := s.requireManagerReady(); err != nil {
+	if err := s.requireStateMutationAdmission(); err != nil {
 		return err
 	}
 	if err := validateRPCRepoID(req.RepoID); err != nil {
@@ -524,7 +577,7 @@ func validateRPCRepoID(repoID string) error {
 }
 
 func (s *controlServer) DeliverPrompt(req DeliverPromptRequest, resp *DeliverPromptResponse) error {
-	if err := s.requireManagerReady(); err != nil {
+	if err := s.requireStateMutationAdmission(); err != nil {
 		return err
 	}
 	status, err := s.manager.DeliverPrompt(req)

--- a/daemon/control_types.go
+++ b/daemon/control_types.go
@@ -465,6 +465,17 @@ type PingResponse struct {
 	// positive skew signal (the daemon predates version reporting, so it is
 	// older than this client), not merely an unknown.
 	Version string `json:"version"`
+	// BootID is unique to this daemon process start. TransactionID is retained
+	// for the full candidate boot, including after it reaches ready, so an
+	// upgrade supervisor can reject a different daemon that happened to answer
+	// the same socket (#1947).
+	BootID        string `json:"boot_id,omitempty"`
+	TransactionID string `json:"transaction_id,omitempty"`
+	// Phase distinguishes liveness from operational readiness. Ping answers
+	// while warming and in upgrade probation; only ready means daemon-owned work
+	// and ordinary mutations have been admitted.
+	Phase     DaemonPhase          `json:"phase,omitempty"`
+	Listeners DaemonListenerStatus `json:"listeners"`
 }
 
 type ReloadTasksRequest struct{}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -39,6 +39,14 @@ var restoreManagerForStartup = func(m *Manager) error { return m.RestoreInstance
 // scheduler, watcher supervisor, and AutoYes poll loop start only after the
 // restore because they act on restored state.
 func RunDaemon(cfg *config.Config) error {
+	return runDaemon(cfg, "")
+}
+
+// runDaemon carries the transaction identity used by the probation machinery.
+// The public daemon entrypoint deliberately supplies no transaction: only the
+// durable transaction layer may eventually select the unexported non-empty
+// path, so this stage cannot put an ordinary daemon into probation.
+func runDaemon(cfg *config.Config, upgradeTransactionID string) error {
 	log.InfoLog.Printf("starting daemon")
 
 	// No auth-posture gate here, deliberately (#2168 Phase 0). #2090 made a
@@ -94,7 +102,7 @@ func RunDaemon(cfg *config.Config) error {
 
 	// Shell only — no restore yet, so the bind below happens within
 	// milliseconds of process start.
-	manager, err := newManagerShell(cfg)
+	manager, err := newManagerShellForDaemon(cfg, upgradeTransactionID)
 	if err != nil {
 		return err
 	}
@@ -207,7 +215,17 @@ func RunDaemon(cfg *config.Config) error {
 		log.InfoLog.Printf("received shutdown request via control socket during instance restore; exiting")
 		return nil
 	}
-	log.InfoLog.Printf("instance restore complete; daemon ready")
+	if manager.lifecycle.isUpgradeProbation() {
+		log.InfoLog.Printf("instance restore complete; daemon is in upgrade probation")
+		select {
+		case sig := <-sigChan:
+			log.InfoLog.Printf("received signal %s during upgrade probation; exiting", sig.String())
+			return nil
+		case <-shutdownCh:
+			log.InfoLog.Printf("received shutdown request during upgrade probation; exiting")
+			return nil
+		}
+	}
 
 	// Remove per-task timer units left behind by pre-#782 versions; the
 	// in-process scheduler below replaces them.
@@ -305,6 +323,16 @@ func RunDaemon(cfg *config.Config) error {
 			watchDaemonHome(homeDir, stopCh, homeGoneCh)
 		}()
 	}
+
+	// This is the full operational barrier, later than Manager.Ready: the
+	// scheduler, watcher supervisor, status/AutoYes poll, and home watcher are
+	// all armed. Ping answering before here is liveness, never proof of health.
+	if err := manager.lifecycle.markReady(); err != nil {
+		close(stopCh)
+		wg.Wait()
+		return fmt.Errorf("failed to mark daemon ready: %w", err)
+	}
+	log.InfoLog.Printf("daemon ready")
 
 	// Block until a signal, a Shutdown RPC, or the home-deleted self-check
 	// ends the daemon (sigChan and shutdownCh were armed before the restore

--- a/daemon/handoff.go
+++ b/daemon/handoff.go
@@ -37,7 +37,7 @@ type HandoffSessionResponse struct {
 }
 
 func (s *controlServer) HandoffSession(req HandoffSessionRequest, resp *HandoffSessionResponse) error {
-	if err := s.requireManagerReady(); err != nil {
+	if err := s.requireStateMutationAdmission(); err != nil {
 		return err
 	}
 	if err := validateRPCRepoID(req.RepoID); err != nil {

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -27,6 +27,13 @@ type HealthStatus struct {
 	// client that can ask, which is exactly the skew that makes a newer
 	// client's requests fail with "unknown field <name>" (#1044).
 	DaemonVersion string
+	// BootID, TransactionID, Phase, and Listeners are the responding daemon's
+	// additive Ping health surface. Empty phase/IDs mean the responder predates
+	// these fields; read them only when PingErr is nil.
+	BootID        string
+	TransactionID string
+	Phase         DaemonPhase
+	Listeners     DaemonListenerStatus
 	// HTTPSocketPath is the daemon's HTTP/JSON socket location.
 	HTTPSocketPath string
 	// HTTPSocketExists reports whether HTTPSocketPath is present on disk.
@@ -75,6 +82,10 @@ func Health() HealthStatus {
 	h.PingErr = pingErr
 	if pingErr == nil {
 		h.DaemonVersion = ping.Version
+		h.BootID = ping.BootID
+		h.TransactionID = ping.TransactionID
+		h.Phase = ping.Phase
+		h.Listeners = ping.Listeners
 	}
 	h.HTTPSocketPath, h.HTTPSocketExists, h.HTTPListening = probeHTTPSocket()
 	h.AutostartUnit = AutostartInstalled()

--- a/daemon/httproutes.go
+++ b/daemon/httproutes.go
@@ -46,7 +46,7 @@ var httpRoutes = []HTTPRoute{
 	{
 		Method:      http.MethodGet,
 		Path:        "/v1/health",
-		Description: "Liveness probe (alias for the Ping RPC); answers even while the daemon is restoring sessions.",
+		Description: "Lifecycle health probe (alias for Ping): version, boot/transaction identity, phase, and bound listeners; answers before readiness.",
 		handler:     func(cs *controlServer) http.HandlerFunc { return healthHandler(cs) },
 	},
 

--- a/daemon/httpserver.go
+++ b/daemon/httpserver.go
@@ -306,7 +306,7 @@ func rpcHandlerCtx[Req any, Resp any](call func(context.Context, Req, *Resp) err
 		var resp Resp
 		if err := call(r.Context(), req, &resp); err != nil {
 			status := http.StatusInternalServerError
-			if isDaemonAdmissionRetryable(err) {
+			if IsDaemonAdmissionRetryable(err) {
 				status = http.StatusServiceUnavailable
 			}
 			writeHTTPError(w, r, status, err)

--- a/daemon/httpserver.go
+++ b/daemon/httpserver.go
@@ -29,7 +29,7 @@ import (
 //	POST /v1/<Method>   JSON body = the RPC request struct
 //	                    response  = the shared {data,error} envelope wrapping
 //	                                the RPC response struct
-//	GET  /v1/health     liveness alias for Ping
+//	GET  /v1/health     lifecycle-health alias for Ping
 //
 // Each route decodes the request body into the EXACT SAME request struct the
 // net/rpc handler uses and calls the SAME (*controlServer) method — there is no
@@ -94,6 +94,9 @@ func startHTTPServer(manager *Manager, scheduler *taskScheduler, watchers *watch
 		_ = listener.Close()
 		return nil, err
 	}
+	if manager.lifecycle != nil {
+		manager.lifecycle.setHTTPUnixBound(true)
+	}
 
 	cs := &controlServer{manager: manager, scheduler: scheduler, watchers: watchers}
 	// One mux, shared by both listeners, so the REST/RPC/WS handler graph is
@@ -111,7 +114,11 @@ func startHTTPServer(manager *Manager, scheduler *taskScheduler, watchers *watch
 	go func() {
 		// Serve returns ErrServerClosed on a clean Close/Shutdown; anything else
 		// is worth logging (the listener died unexpectedly).
-		if err := srv.Serve(listener); err != nil && err != http.ErrServerClosed {
+		err := srv.Serve(listener)
+		if manager.lifecycle != nil {
+			manager.lifecycle.setHTTPUnixBound(false)
+		}
+		if err != nil && err != http.ErrServerClosed {
 			log.WarningLog.Printf("daemon HTTP server stopped: %v", err)
 		}
 	}()
@@ -151,6 +158,13 @@ func startHTTPServer(manager *Manager, scheduler *taskScheduler, watchers *watch
 			log.WarningLog.Printf("failed to start daemon HTTP TCP listener on %q: %v", manager.cfg.ListenAddr, err)
 		} else {
 			closeTCP = closer
+			if manager.lifecycle != nil {
+				manager.lifecycle.setTCPBound(info.Addr)
+				go func() {
+					<-info.done
+					manager.lifecycle.clearTCPBound()
+				}()
+			}
 			log.InfoLog.Printf("daemon HTTP TCP listener enabled on %s (plain HTTP — terminate TLS at a proxy if needed)", info.Addr)
 			log.InfoLog.Printf("  bearer token: %s", info.Token)
 			switch {
@@ -176,6 +190,9 @@ func startHTTPServer(manager *Manager, scheduler *taskScheduler, watchers *watch
 		// default for a listener it created) and terminates active connections.
 		// Deliberately no explicit os.Remove: mirrors startControlServer's
 		// #718/#767 reasoning — a Remove could race a freshly bound socket.
+		if manager.lifecycle != nil {
+			manager.lifecycle.clearHTTPListeners()
+		}
 		tcpErr := closeTCP()
 		if err := srv.Close(); err != nil {
 			return err
@@ -250,7 +267,8 @@ func newHTTPMux(cs *controlServer) *http.ServeMux {
 //	400 — malformed / unreadable JSON request body, or unknown request field
 //	405 — wrong HTTP verb (not POST)
 //	413 — request body exceeds maxHTTPBodyBytes
-//	500 — the handler (validation or execution) returned an error
+//	503 — daemon warm-up or upgrade probation (typed, retryable)
+//	500 — any other handler (validation or execution) error
 //
 // 404 for unknown routes is handled by the mux's catch-all, not here. A rejected
 // body (400 or 413) short-circuits before the manager call, so an oversize or
@@ -287,15 +305,20 @@ func rpcHandlerCtx[Req any, Resp any](call func(context.Context, Req, *Resp) err
 		}
 		var resp Resp
 		if err := call(r.Context(), req, &resp); err != nil {
-			writeHTTPError(w, r, http.StatusInternalServerError, err)
+			status := http.StatusInternalServerError
+			if isDaemonAdmissionRetryable(err) {
+				status = http.StatusServiceUnavailable
+			}
+			writeHTTPError(w, r, status, err)
 			return
 		}
 		writeHTTPSuccess(w, r, resp)
 	}
 }
 
-// healthHandler answers GET /v1/health by calling Ping, giving a trivial
-// liveness probe (curl the socket, look for {"data":{"ok":true},"error":null}).
+// healthHandler answers GET /v1/health by calling Ping. OK establishes
+// liveness; the phase/identity/listener fields establish whether the responder
+// is the expected fully ready daemon.
 func healthHandler(cs *controlServer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {

--- a/daemon/lifecycle.go
+++ b/daemon/lifecycle.go
@@ -1,0 +1,166 @@
+package daemon
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// DaemonPhase is the daemon's startup/admission state reported by Ping. It is
+// deliberately separate from process liveness: the control socket answers in
+// every phase, but only DaemonPhaseReady admits ordinary daemon work.
+type DaemonPhase string
+
+const (
+	DaemonPhaseWarming          DaemonPhase = "warming"
+	DaemonPhaseUpgradeProbation DaemonPhase = "upgrade_probation"
+	DaemonPhaseReady            DaemonPhase = "ready"
+)
+
+// DaemonListenerStatus reports which auxiliary HTTP surfaces this daemon
+// actually bound. The control socket is omitted because receiving Ping already
+// proves that listener. TCPListenAddr is the configured address;
+// TCPBoundAddr is the concrete address (and port) returned by the kernel.
+type DaemonListenerStatus struct {
+	HTTPUnixBound bool   `json:"http_unix_bound"`
+	TCPConfigured bool   `json:"tcp_configured"`
+	TCPBound      bool   `json:"tcp_bound"`
+	TCPListenAddr string `json:"tcp_listen_addr,omitempty"`
+	TCPBoundAddr  string `json:"tcp_bound_addr,omitempty"`
+}
+
+type daemonLifecycleSnapshot struct {
+	bootID        string
+	transactionID string
+	phase         DaemonPhase
+	listeners     DaemonListenerStatus
+}
+
+// daemonLifecycle is the single source of truth for health and mutation
+// admission. Keeping those together prevents a candidate from reporting one
+// phase while enforcing another.
+type daemonLifecycle struct {
+	mu sync.RWMutex
+
+	bootID        string
+	transactionID string
+	phase         DaemonPhase
+	restored      bool
+	listeners     DaemonListenerStatus
+}
+
+const daemonBootIDBytes = 16
+
+func newDaemonLifecycle(transactionID, tcpListenAddr string) (*daemonLifecycle, error) {
+	if transactionID != "" && strings.TrimSpace(transactionID) == "" {
+		return nil, fmt.Errorf("upgrade transaction ID cannot be blank")
+	}
+	bootID, err := generateDaemonBootID()
+	if err != nil {
+		return nil, err
+	}
+	lifecycle := &daemonLifecycle{
+		bootID:        bootID,
+		transactionID: transactionID,
+		phase:         DaemonPhaseWarming,
+		listeners: DaemonListenerStatus{
+			TCPConfigured: tcpListenAddr != "",
+			TCPListenAddr: tcpListenAddr,
+		},
+	}
+	return lifecycle, nil
+}
+
+func generateDaemonBootID() (string, error) {
+	random := make([]byte, daemonBootIDBytes)
+	if _, err := rand.Read(random); err != nil {
+		return "", fmt.Errorf("generate daemon boot ID: %w", err)
+	}
+	return hex.EncodeToString(random), nil
+}
+
+// markRestoreComplete moves an upgrade launch into probation. A normal launch
+// remains warming until RunDaemon has armed its scheduler, watchers, and poll
+// loop; a restored Manager is not by itself a fully ready daemon.
+func (l *daemonLifecycle) markRestoreComplete() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.restored = true
+	if l.transactionID != "" {
+		l.phase = DaemonPhaseUpgradeProbation
+	}
+}
+
+func (l *daemonLifecycle) markReady() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if !l.restored {
+		return fmt.Errorf("cannot mark daemon ready before instance restore completes")
+	}
+	if l.transactionID != "" {
+		return fmt.Errorf("cannot mark a probationary daemon ready without a transaction supervisor")
+	}
+	l.phase = DaemonPhaseReady
+	return nil
+}
+
+func (l *daemonLifecycle) isUpgradeProbation() bool {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.transactionID != ""
+}
+
+// mutationAdmissionError blocks every mutation for an upgrade candidate until
+// its previous-binary supervisor releases probation. Normal warm-up deliberately
+// remains allowed here: disk-backed task/config writes have always been safe
+// during restore, while session-state mutations are separately gated on
+// Manager.Ready by requireStateMutationAdmission.
+func (l *daemonLifecycle) mutationAdmissionError() error {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	if l.transactionID != "" {
+		return errDaemonUpgradeProbation(l.transactionID)
+	}
+	return nil
+}
+
+func (l *daemonLifecycle) snapshot() daemonLifecycleSnapshot {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return daemonLifecycleSnapshot{
+		bootID:        l.bootID,
+		transactionID: l.transactionID,
+		phase:         l.phase,
+		listeners:     l.listeners,
+	}
+}
+
+func (l *daemonLifecycle) setHTTPUnixBound(bound bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.listeners.HTTPUnixBound = bound
+}
+
+func (l *daemonLifecycle) setTCPBound(addr string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.listeners.TCPBound = true
+	l.listeners.TCPBoundAddr = addr
+}
+
+func (l *daemonLifecycle) clearTCPBound() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.listeners.TCPBound = false
+	l.listeners.TCPBoundAddr = ""
+}
+
+func (l *daemonLifecycle) clearHTTPListeners() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.listeners.HTTPUnixBound = false
+	l.listeners.TCPBound = false
+	l.listeners.TCPBoundAddr = ""
+}

--- a/daemon/lifecycle_test.go
+++ b/daemon/lifecycle_test.go
@@ -1,0 +1,339 @@
+package daemon
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDaemonLifecycleNormalReadinessBarrier(t *testing.T) {
+	lifecycle, err := newDaemonLifecycle("", "127.0.0.1:8443")
+	require.NoError(t, err)
+
+	initial := lifecycle.snapshot()
+	require.Equal(t, DaemonPhaseWarming, initial.phase)
+	require.Len(t, initial.bootID, daemonBootIDBytes*2)
+	require.Empty(t, initial.transactionID)
+	require.True(t, initial.listeners.TCPConfigured)
+	require.Equal(t, "127.0.0.1:8443", initial.listeners.TCPListenAddr)
+	require.Error(t, lifecycle.markReady(), "liveness must not become readiness before restore")
+
+	lifecycle.markRestoreComplete()
+	require.Equal(t, DaemonPhaseWarming, lifecycle.snapshot().phase,
+		"restore alone is not the daemon's full operational barrier")
+	require.NoError(t, lifecycle.markReady())
+	require.Equal(t, DaemonPhaseReady, lifecycle.snapshot().phase)
+}
+
+func TestUpgradeProbationErrorIsTypedAndRetryable(t *testing.T) {
+	err := errDaemonUpgradeProbation("transaction-2212")
+	require.True(t, IsDaemonUpgradeProbationErr(err))
+	require.True(t, isDaemonAdmissionRetryable(err))
+	require.Contains(t, err.Error(), "transaction-2212")
+	require.False(t, IsDaemonUpgradeProbationErr(errDaemonStarting()))
+}
+
+func TestDaemonLifecycleProbationCannotSelfAdmit(t *testing.T) {
+	const transactionID = "transaction-2212"
+	lifecycle, err := newDaemonLifecycle(transactionID, "")
+	require.NoError(t, err)
+
+	require.True(t, IsDaemonUpgradeProbationErr(lifecycle.mutationAdmissionError()))
+
+	lifecycle.markRestoreComplete()
+	require.Equal(t, DaemonPhaseUpgradeProbation, lifecycle.snapshot().phase)
+	require.Error(t, lifecycle.markReady(),
+		"a candidate must not grade itself ready while admission is closed")
+	require.True(t, IsDaemonUpgradeProbationErr(lifecycle.mutationAdmissionError()))
+	require.Equal(t, transactionID, lifecycle.snapshot().transactionID)
+}
+
+func TestRunDaemonReportsReadyAtOperationalBarrier(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	cfg := config.DefaultConfig()
+	cfg.ListenAddr = ""
+
+	runDone := make(chan error, 1)
+	go func() { runDone <- RunDaemon(cfg) }()
+	stopped := false
+	defer func() {
+		if stopped {
+			return
+		}
+		var resp ShutdownResponse
+		_ = callDaemonNoEnsure("Shutdown", ShutdownRequest{}, &resp)
+		select {
+		case <-runDone:
+		case <-time.After(5 * time.Second):
+			t.Errorf("daemon did not stop during cleanup")
+		}
+	}()
+
+	ready := waitForDaemonPhase(t, DaemonPhaseReady)
+	require.Empty(t, ready.TransactionID)
+	require.NotEmpty(t, ready.BootID)
+	require.True(t, ready.Listeners.HTTPUnixBound)
+	require.False(t, ready.Listeners.TCPConfigured)
+
+	var shutdown ShutdownResponse
+	require.NoError(t, callDaemonNoEnsure("Shutdown", ShutdownRequest{}, &shutdown))
+	select {
+	case err := <-runDone:
+		require.NoError(t, err)
+		stopped = true
+	case <-time.After(5 * time.Second):
+		t.Fatal("ready daemon did not stop after Shutdown")
+	}
+}
+
+func TestRunDaemonUpgradeProbationEndToEnd(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	cfg := config.DefaultConfig()
+	cfg.ListenAddr = "" // keep this lifecycle test on AF-owned Unix sockets only
+	const transactionID = "transaction-e2e-2212"
+
+	runDone := make(chan error, 1)
+	go func() { runDone <- runDaemon(cfg, transactionID) }()
+	stopped := false
+	defer func() {
+		if stopped {
+			return
+		}
+		var resp ShutdownResponse
+		_ = callDaemonNoEnsure("Shutdown", ShutdownRequest{}, &resp)
+		select {
+		case <-runDone:
+		case <-time.After(5 * time.Second):
+			t.Errorf("probationary daemon did not stop during cleanup")
+		}
+	}()
+
+	probation := waitForDaemonPhase(t, DaemonPhaseUpgradeProbation)
+	require.Equal(t, transactionID, probation.TransactionID)
+	require.NotEmpty(t, probation.BootID)
+	require.True(t, probation.Listeners.HTTPUnixBound)
+	require.False(t, probation.Listeners.TCPConfigured)
+
+	// Read-only restored state remains available, while a mutation is rejected
+	// before it can validate or touch its zero-valued request.
+	var snapshot SnapshotResponse
+	require.NoError(t, callDaemonNoEnsure("Snapshot", SnapshotRequest{}, &snapshot))
+	var create CreateSessionResponse
+	err := callDaemonNoEnsure("CreateSession", CreateSessionRequest{}, &create)
+	require.True(t, IsDaemonUpgradeProbationErr(err), "mutation error = %v", err)
+
+	health := Health()
+	require.NoError(t, health.PingErr)
+	require.Equal(t, DaemonPhaseUpgradeProbation, health.Phase)
+	require.Equal(t, transactionID, health.TransactionID)
+
+	var shutdown ShutdownResponse
+	require.NoError(t, callDaemonNoEnsure("Shutdown", ShutdownRequest{}, &shutdown))
+	select {
+	case err := <-runDone:
+		require.NoError(t, err)
+		stopped = true
+	case <-time.After(5 * time.Second):
+		t.Fatal("probationary daemon did not stop after Shutdown")
+	}
+}
+
+func waitForDaemonPhase(t *testing.T, want DaemonPhase) PingResponse {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var last PingResponse
+	var lastErr error
+	for time.Now().Before(deadline) {
+		last, lastErr = pingDaemonResponse()
+		if lastErr == nil && last.Phase == want {
+			return last
+		}
+		select {
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	t.Fatalf("daemon never reached phase %q (last phase %q, error %v)", want, last.Phase, lastErr)
+	return PingResponse{}
+}
+
+func TestDaemonListenerHealthRecordsBindOutcomes(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		occupyTCP    bool
+		wantTCPBound bool
+	}{
+		{name: "configured TCP binds", wantTCPBound: true},
+		{name: "configured TCP bind fails", occupyTCP: true, wantTCPBound: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+			cfg := config.DefaultConfig()
+			cfg.ListenAddr = "127.0.0.1:0"
+			var occupied net.Listener
+			if tc.occupyTCP {
+				var err error
+				occupied, err = net.Listen("tcp", cfg.ListenAddr)
+				require.NoError(t, err)
+				t.Cleanup(func() { _ = occupied.Close() })
+				cfg.ListenAddr = occupied.Addr().String()
+			}
+
+			manager, err := NewManager(cfg)
+			require.NoError(t, err)
+			closeHTTP, err := startHTTPServer(manager, newTaskScheduler(), newWatcherSupervisor())
+			require.NoError(t, err, "the Unix HTTP surface remains available when TCP fails")
+
+			var ping PingResponse
+			require.NoError(t, (&controlServer{manager: manager}).Ping(PingRequest{}, &ping))
+			require.True(t, ping.Listeners.HTTPUnixBound)
+			require.True(t, ping.Listeners.TCPConfigured)
+			require.Equal(t, cfg.ListenAddr, ping.Listeners.TCPListenAddr)
+			require.Equal(t, tc.wantTCPBound, ping.Listeners.TCPBound)
+			if tc.wantTCPBound {
+				require.NotEmpty(t, ping.Listeners.TCPBoundAddr)
+			} else {
+				require.Empty(t, ping.Listeners.TCPBoundAddr)
+			}
+
+			require.NoError(t, closeHTTP())
+			require.NoError(t, (&controlServer{manager: manager}).Ping(PingRequest{}, &ping))
+			require.False(t, ping.Listeners.HTTPUnixBound)
+			require.False(t, ping.Listeners.TCPBound)
+		})
+	}
+}
+
+// controlMethodPolicies is an exhaustive parity ledger for the net/rpc method
+// set. Reflection makes a newly exported handler fail this test until its
+// admission class is chosen; the mutation loop then invokes every classified
+// mutation under probation, so a handler that forgets the gate fails before it
+// can become a production bypass.
+type probationPolicy uint8
+
+const (
+	allowedDuringProbation probationPolicy = iota
+	blockedDuringProbation
+)
+
+var controlMethodPolicies = map[string]probationPolicy{
+	"AddTask":          blockedDuringProbation,
+	"ArchiveSession":   blockedDuringProbation,
+	"CloseTab":         blockedDuringProbation,
+	"CreateSession":    blockedDuringProbation,
+	"CreateTab":        blockedDuringProbation,
+	"DeleteProject":    blockedDuringProbation,
+	"DeliverPrompt":    blockedDuringProbation,
+	"HandoffSession":   blockedDuringProbation,
+	"KillSession":      blockedDuringProbation,
+	"PauseStatusPoll":  blockedDuringProbation,
+	"ReapConfigAgent":  blockedDuringProbation,
+	"ReloadTasks":      blockedDuringProbation,
+	"RemoveTask":       blockedDuringProbation,
+	"RenameTab":        blockedDuringProbation,
+	"ReorderTab":       blockedDuringProbation,
+	"RestoreArchived":  blockedDuringProbation,
+	"RestoreSession":   blockedDuringProbation,
+	"ResumeFromLimit":  blockedDuringProbation,
+	"ResumeStatusPoll": blockedDuringProbation,
+	"SendPrompt":       blockedDuringProbation,
+	"SetConfigValue":   blockedDuringProbation,
+	"SetPRInfo":        blockedDuringProbation,
+	"SpawnConfigAgent": blockedDuringProbation,
+	"TriggerTask":      blockedDuringProbation,
+	"UpdateTask":       blockedDuringProbation,
+	"GetConfig":        allowedDuringProbation,
+	"ListBackends":     allowedDuringProbation,
+	"ListPrograms":     allowedDuringProbation,
+	"ListTasks":        allowedDuringProbation,
+	"Ping":             allowedDuringProbation,
+	"Preview":          allowedDuringProbation,
+	"Shutdown":         allowedDuringProbation,
+	"Snapshot":         allowedDuringProbation,
+}
+
+func TestControlServerProbationAdmissionLedger(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	manager, err := newManagerShellForDaemon(config.DefaultConfig(), "ledger-transaction")
+	require.NoError(t, err)
+	require.NoError(t, manager.RestoreInstances())
+	server := &controlServer{
+		manager: manager, scheduler: newTaskScheduler(), watchers: newWatcherSupervisor(),
+	}
+
+	typ := reflect.TypeOf(server)
+	seen := make(map[string]struct{}, typ.NumMethod())
+	for i := 0; i < typ.NumMethod(); i++ {
+		name := typ.Method(i).Name
+		seen[name] = struct{}{}
+		_, classified := controlMethodPolicies[name]
+		require.Truef(t, classified, "control method %s has no probation admission policy", name)
+	}
+	for name := range controlMethodPolicies {
+		_, exists := seen[name]
+		require.Truef(t, exists, "stale probation admission policy for removed method %s", name)
+	}
+
+	value := reflect.ValueOf(server)
+	for name, policy := range controlMethodPolicies {
+		if policy != blockedDuringProbation {
+			continue
+		}
+		t.Run(name, func(t *testing.T) {
+			method := value.MethodByName(name)
+			require.Equal(t, 2, method.Type().NumIn(), "control RPC signature changed")
+			request := reflect.Zero(method.Type().In(0))
+			response := reflect.New(method.Type().In(1).Elem())
+			result := method.Call([]reflect.Value{request, response})
+			require.Len(t, result, 1)
+			callErr, _ := result[0].Interface().(error)
+			require.True(t, IsDaemonUpgradeProbationErr(callErr),
+				"%s reached handler logic instead of the probation gate: %v", name, callErr)
+		})
+	}
+}
+
+func TestHTTPMutationAndInteractiveStreamReturnRetryableProbation(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	manager, err := newManagerShellForDaemon(config.DefaultConfig(), "http-transaction")
+	require.NoError(t, err)
+	require.NoError(t, manager.RestoreInstances())
+	server := &controlServer{manager: manager, scheduler: newTaskScheduler()}
+	mux := newHTTPMux(server)
+
+	request := httptest.NewRequest(http.MethodGet, "/v1/health", nil)
+	recorder := httptest.NewRecorder()
+	mux.ServeHTTP(recorder, request)
+	require.Equal(t, http.StatusOK, recorder.Code)
+	var health PingResponse
+	dataInto(t, decodeEnvelope(t, recorder), &health)
+	require.Equal(t, DaemonPhaseUpgradeProbation, health.Phase)
+	require.Equal(t, "http-transaction", health.TransactionID)
+	require.NotEmpty(t, health.BootID)
+
+	request = httptest.NewRequest(http.MethodPost, "/v1/SetConfigValue",
+		strings.NewReader(`{"key":"auto_update","value":"false"}`))
+	recorder = httptest.NewRecorder()
+	mux.ServeHTTP(recorder, request)
+	require.Equal(t, http.StatusServiceUnavailable, recorder.Code)
+	require.Contains(t, recorder.Body.String(), daemonUpgradeProbationErrText)
+
+	request = httptest.NewRequest(http.MethodGet, "/v1/sessions/session-id/stream", nil)
+	recorder = httptest.NewRecorder()
+	mux.ServeHTTP(recorder, request)
+	require.Equal(t, http.StatusServiceUnavailable, recorder.Code)
+	require.Contains(t, recorder.Body.String(), daemonUpgradeProbationErrText)
+
+	request = httptest.NewRequest(http.MethodGet, webtabPathPrefix+"session-id/tab-id/", nil)
+	recorder = httptest.NewRecorder()
+	mux.ServeHTTP(recorder, request)
+	require.Equal(t, http.StatusServiceUnavailable, recorder.Code)
+	require.Contains(t, recorder.Body.String(), "Validating upgrade")
+}

--- a/daemon/lifecycle_test.go
+++ b/daemon/lifecycle_test.go
@@ -36,7 +36,7 @@ func TestDaemonLifecycleNormalReadinessBarrier(t *testing.T) {
 func TestUpgradeProbationErrorIsTypedAndRetryable(t *testing.T) {
 	err := errDaemonUpgradeProbation("transaction-2212")
 	require.True(t, IsDaemonUpgradeProbationErr(err))
-	require.True(t, isDaemonAdmissionRetryable(err))
+	require.True(t, IsDaemonAdmissionRetryable(err))
 	require.Contains(t, err.Error(), "transaction-2212")
 	require.False(t, IsDaemonUpgradeProbationErr(errDaemonStarting()))
 }

--- a/daemon/limit.go
+++ b/daemon/limit.go
@@ -241,7 +241,7 @@ type ResumeFromLimitResponse struct {
 // below still serves the verb over both transports.
 
 func (s *controlServer) ResumeFromLimit(req ResumeFromLimitRequest, resp *ResumeFromLimitResponse) error {
-	if err := s.requireManagerReady(); err != nil {
+	if err := s.requireStateMutationAdmission(); err != nil {
 		return err
 	}
 	if err := validateRPCRepoID(req.RepoID); err != nil {

--- a/daemon/manager.go
+++ b/daemon/manager.go
@@ -25,6 +25,10 @@ type Manager struct {
 	// (#829) but state-dependent RPCs return errDaemonStarting.
 	ready     chan struct{}
 	readyOnce sync.Once
+	// lifecycle is the daemon-wide health/admission state. Manager readiness
+	// means persisted session state is safe to read; lifecycle readiness is the
+	// later barrier where scheduler/watch/AutoYes work may run.
+	lifecycle *daemonLifecycle
 
 	mu        sync.Mutex
 	storage   *session.Storage
@@ -196,12 +200,29 @@ func NewManager(cfg *config.Config) (*Manager, error) {
 	if err := manager.RestoreInstances(); err != nil {
 		return nil, err
 	}
+	// NewManager is used without RunDaemon's scheduler/watcher startup. For that
+	// standalone manager, restore completion is the full readiness barrier.
+	if err := manager.lifecycle.markReady(); err != nil {
+		return nil, err
+	}
 	return manager, nil
 }
 
 // newManagerShell constructs a Manager with no instances loaded. The manager
 // reports !Ready() until RestoreInstances completes.
 func newManagerShell(cfg *config.Config) (*Manager, error) {
+	return newManagerShellForDaemon(cfg, "")
+}
+
+// newManagerShellForDaemon constructs the same manager shell with an optional
+// upgrade transaction identity. The transaction-bearing path stays unexported:
+// an ordinary caller can construct only a normal shell, while runDaemon owns
+// the probation selection.
+func newManagerShellForDaemon(cfg *config.Config, transactionID string) (*Manager, error) {
+	lifecycle, err := newDaemonLifecycle(transactionID, cfg.ListenAddr)
+	if err != nil {
+		return nil, err
+	}
 	state := config.LoadState()
 	storage, err := session.NewStorage(state, "")
 	if err != nil {
@@ -221,6 +242,7 @@ func newManagerShell(cfg *config.Config) (*Manager, error) {
 		cfg:                 cfg,
 		limitDetector:       task.NewLimitDetector(cfg.LimitPatterns),
 		ready:               make(chan struct{}),
+		lifecycle:           lifecycle,
 		storage:             storage,
 		instances:           make(map[string]*session.Instance),
 		pendingCreates:      make(map[string]session.InstanceData),
@@ -264,6 +286,13 @@ func (m *Manager) RestoreInstances() error {
 	m.ghostTaskRuns = ghosts
 	m.mu.Unlock()
 	m.readyOnce.Do(func() { close(m.ready) })
+	// Publish the lifecycle phase only after the Manager readiness barrier is
+	// open. A Ping that says upgrade_probation must never race a Snapshot that
+	// still says the restore is in progress. Transaction-tagged mutations remain
+	// blocked independently of phase, so this ordering opens no write gap.
+	if m.lifecycle != nil {
+		m.lifecycle.markRestoreComplete()
+	}
 	return nil
 }
 

--- a/daemon/tcpserver.go
+++ b/daemon/tcpserver.go
@@ -37,6 +37,7 @@ import (
 type tcpListenerInfo struct {
 	Addr  string // the resolved bound address (host:port, port filled in for :0)
 	Token string // the bearer token clients must present
+	done  <-chan struct{}
 }
 
 // tokenGatePolicy is how a TCP listener's bearer-token gate treats peers. Its
@@ -161,7 +162,9 @@ func startTCPListener(mux http.Handler, cfg *config.Config, policy tokenGatePoli
 		Handler:           handler,
 		ReadHeaderTimeout: httpReadHeaderTimeout,
 	}
+	done := make(chan struct{})
 	go func() {
+		defer close(done)
 		if err := srv.Serve(listener); err != nil && err != http.ErrServerClosed {
 			log.WarningLog.Printf("daemon TCP listener stopped: %v", err)
 		}
@@ -170,6 +173,7 @@ func startTCPListener(mux http.Handler, cfg *config.Config, policy tokenGatePoli
 	info := tcpListenerInfo{
 		Addr:  listener.Addr().String(),
 		Token: token,
+		done:  done,
 	}
 	return srv.Close, info, nil
 }

--- a/daemon/warmup_test.go
+++ b/daemon/warmup_test.go
@@ -94,7 +94,7 @@ func TestControlServer_WarmupGatesStateRPCs(t *testing.T) {
 
 // TestCallDaemon_RetriesThroughWarmup verifies the client side of the warm-up
 // contract: a state-dependent call that lands during the warm-up window keeps
-// retrying (bounded by daemonWarmupWait) and succeeds once the restore
+// retrying (bounded by daemonAdmissionRetryWait) and succeeds once the restore
 // completes, so call sites racing a fresh daemon spawn — CLI create right
 // after boot, task runs after an upgrade respawn — need no retry logic of
 // their own.

--- a/daemon/webtab_proxy.go
+++ b/daemon/webtab_proxy.go
@@ -364,7 +364,11 @@ func (cs *controlServer) webTabProxyHandler(w http.ResponseWriter, r *http.Reque
 	// Kind-agnostic by necessity AND by rights: resolving the kind is the very thing
 	// that touches the manager, so it is not known here — and a dev-server preview
 	// must not be told VS Code is starting.
-	if err := cs.requireManagerReady(); err != nil {
+	if err := cs.requireStateMutationAdmission(); err != nil {
+		if IsDaemonUpgradeProbationErr(err) {
+			writeTabNoticePage(w, "Validating upgrade", "af is validating a daemon upgrade — this tab will reload when validation finishes.", true)
+			return
+		}
 		writeTabNoticePage(w, "Starting up", "af is starting up — this tab will load as soon as the daemon has restored its sessions.", true)
 		return
 	}

--- a/daemon/ws_pty.go
+++ b/daemon/ws_pty.go
@@ -91,7 +91,7 @@ func (cs *controlServer) streamHandler(w http.ResponseWriter, r *http.Request) {
 	// available is a close frame, which a client reads as a stream that DROPPED and
 	// handles on an entirely different path; a plain 503 is a retry it already
 	// understands, and matches every other pre-upgrade error on this route.
-	if err := cs.requireManagerReady(); err != nil {
+	if err := cs.requireStateMutationAdmission(); err != nil {
 		writeHTTPError(w, r, http.StatusServiceUnavailable, err)
 		return
 	}

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -12,7 +12,7 @@ Request fields are the JSON keys of each route's request body; a `—` means the
 
 | Method | Path | Request fields | Description |
 |--------|------|----------------|-------------|
-| `GET` | `/v1/health` | — | Liveness probe (alias for the Ping RPC); answers even while the daemon is restoring sessions. |
+| `GET` | `/v1/health` | — | Lifecycle health probe (alias for Ping): version, boot/transaction identity, phase, and bound listeners; answers before readiness. |
 | `POST` | `/v1/CreateSession` | `title`, `title_base`, `repo_path`, `program`, `prompt`, `auto_yes`, `in_place`, `force_remote`, `backend` | Create a new session (git worktree + agent) in a repo. |
 | `POST` | `/v1/ListBackends` | `repo_path` | List the runtimes a session in this repo can be created on, whether the repo's config supports each, and the backend an unspecified create defaults to. |
 | `POST` | `/v1/ListPrograms` | `repo_path` | List the agent programs a session can be created with, and the program an unspecified create defaults to. |

--- a/doctor/checks.go
+++ b/doctor/checks.go
@@ -122,7 +122,23 @@ func checkDaemonHealth(ctx *scanContext, report *Report, h daemon.HealthStatus, 
 	}
 	switch {
 	case h.PingErr == nil:
-		report.Pass(sectionDaemon, "daemon", "responding on "+h.SocketPath)
+		switch h.Phase {
+		case "", daemon.DaemonPhaseReady:
+			// Empty is a responding daemon from before the additive phase field.
+			report.Pass(sectionDaemon, "daemon", "responding on "+h.SocketPath)
+		case daemon.DaemonPhaseWarming:
+			report.Warn(sectionDaemon, "daemon",
+				"responding on "+h.SocketPath+" but startup is still in progress (phase warming)",
+				"wait for daemon startup to finish; if it remains warming, inspect the daemon log", false)
+		case daemon.DaemonPhaseUpgradeProbation:
+			report.Warn(sectionDaemon, "daemon",
+				fmt.Sprintf("responding on %s while upgrade transaction %s is in validation probation", h.SocketPath, h.TransactionID),
+				"wait for upgrade validation to commit or roll back; inspect the daemon log if the phase does not advance", false)
+		default:
+			report.Warn(sectionDaemon, "daemon",
+				fmt.Sprintf("responding on %s with unrecognized lifecycle phase %q", h.SocketPath, h.Phase),
+				"upgrade this af client before diagnosing daemon readiness", false)
+		}
 	case !h.SocketExists:
 		report.Pass(sectionDaemon, "daemon", "not running; starts on demand")
 	default:

--- a/doctor/doctor_test.go
+++ b/doctor/doctor_test.go
@@ -745,6 +745,33 @@ func TestDaemonPingTimeoutIsAdvisoryNotFail(t *testing.T) {
 	require.False(t, rows[0].Problem, "a timeout is advisory; it must not drive the exit code (#2040)")
 }
 
+func TestDaemonUpgradeProbationIsVisibleButNotAHealthFailure(t *testing.T) {
+	testguard.IsolateTmux(t)
+	opts := testOptions(t, false)
+	sockPath := filepath.Join(opts.ConfigDir, "daemon.sock")
+	httpPath := filepath.Join(opts.ConfigDir, "daemon-http.sock")
+	opts.daemonHealth = func() daemon.HealthStatus {
+		return daemon.HealthStatus{
+			SocketPath:       sockPath,
+			DaemonVersion:    "dev",
+			TransactionID:    "transaction-2212",
+			Phase:            daemon.DaemonPhaseUpgradeProbation,
+			HTTPSocketPath:   httpPath,
+			HTTPSocketExists: true,
+			HTTPListening:    daemon.AnswerYes(),
+		}
+	}
+
+	report, err := Run(opts)
+	require.NoError(t, err)
+	rows := findCheckRows(report, "daemon")
+	require.Len(t, rows, 1)
+	require.Equal(t, StatusWarn, rows[0].Status)
+	require.False(t, rows[0].Problem, "a live validation window is not itself a failed upgrade")
+	require.Contains(t, rows[0].Detail, "transaction-2212")
+	require.Contains(t, rows[0].Detail, "validation probation")
+}
+
 // TestDaemonPingRefusalStaysFail: a refusal (ECONNREFUSED) is a completed answer
 // — nobody is home — and must stay the definite Fail. The #2040 fix must demote
 // only timeouts, not blur a real refusal into an advisory warning.


### PR DESCRIPTION
## Summary

- expose daemon boot identity, binary version, transaction identity, lifecycle phase, and actual listener binding state through control `Ping`, HTTP `/v1/health`, `af daemon status`, and `af doctor`
- add an upgrade-probation startup mode: after restore, reads remain available but every mutation is rejected with one typed, retryable error; a candidate cannot admit itself to `ready`
- centralize lifecycle/admission state and add an exhaustive control-method policy ledger so a future mutation cannot silently bypass probation

## Behavior boundary

This is PR2 of the staged implementation for #2212. It does **not** discover, install, swap, restart, supervise, approve, or roll back a binary.

- ordinary `RunDaemon` starts remain `warming -> ready` and retain their current behavior
- the transaction-bearing startup path is not reachable from a shipped command in this PR; PR3's previous-binary supervisor will be its first production caller
- a probationary daemon can only report health, serve restored read paths, reject mutations, and accept targeted shutdown
- the existing TUI `autoUpdateOnLaunch` path remains intact
- the existing auto-update opt-out and throttle behavior remain unchanged

## Safety properties added here

- `upgrade_probation` is distinct from both startup warming and ready, carries a per-boot ID plus transaction ID, and cannot self-transition to ready
- all control mutations, handoff/resume operations, interactive PTY mutation, and web-tab proxying share the same admission decision; HTTP maps probation to 503
- read-only snapshot, preview, catalog, status, and health surfaces remain available after restore so the PR3 validator can assess the candidate
- Unix and optional TCP listener status reports configured and actually-bound state, including bind failure, close, and unexpected serve exit
- a reflection-backed policy test classifies every exported control method and invokes every blocked method under probation; adding a method without choosing an admission policy fails loudly

## Staged series

1. Shared discovery/cache/settings/staging extraction — merged in #2215
2. **This PR:** health/version/phase surfaces and upgrade probation
3. Transaction, durable previous-binary supervisor, takeover, boundary-loss recovery, and binary + metadata rollback
4. Daemon-owned update loop behind the existing opt-out

Only this PR is open; PR3 and PR4 are not stacked.

## Verification

- `make test-container GOTESTARGS="-race -count=1 ./..."`
- exact CI golangci-lint invocation
- `deadcode -test ./...`
- `go build ./...`
- `gofmt -l .`
- `scripts/lint-file-length.sh`
- auto-gate and stale-PR Node tests
- `make testbox-selftest`
- `make lifecycle-selftest`
- generated-artifact drift check plus `mkdocs build --strict`
- `make web-test`
- `make web-build` plus clean `web/dist`

Part of #2212.
