### PR TITLE
fix(web): hide lifecycle actions from inert rows

### DIFF
--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -155,7 +155,7 @@ func (m *home) handleDefaultKeyPress(msg tea.KeyMsg, name keys.KeyName) (tea.Mod
 // so the event loop never blocks on it (#844).
 func (m *home) handleKill() (tea.Model, tea.Cmd) {
 	selected := m.sidebar.GetSelectedInstance()
-	if selected == nil || selected.IsCreating() {
+	if selected == nil || selected.LifecycleAction() == session.LifecycleActionNone {
 		return m, nil
 	}
 	if selected.IsTearingDown() {
@@ -327,7 +327,11 @@ func (m *home) handleInstanceKilled(msg instanceKilledMsg) (tea.Model, tea.Cmd) 
 // rules authoritatively.
 func (m *home) handleArchive() (tea.Model, tea.Cmd) {
 	selected := m.sidebar.GetSelectedInstance()
-	if selected == nil || selected.IsCreating() {
+	if selected == nil {
+		return m, nil
+	}
+	lifecycleAction := selected.LifecycleAction()
+	if lifecycleAction == session.LifecycleActionNone {
 		return m, nil
 	}
 	if selected.IsTearingDown() {
@@ -337,9 +341,7 @@ func (m *home) handleArchive() (tea.Model, tea.Cmd) {
 
 	// A resting (Archived/Lost/Dead) row has no live worktree/tmux to tear down;
 	// `a` does nothing. Restore is on its own key now (`r`).
-	if selected.GetLiveness() == session.LiveArchived ||
-		selected.GetLiveness() == session.LiveLost ||
-		selected.GetLiveness() == session.LiveDead {
+	if lifecycleAction != session.LifecycleActionArchive {
 		return m, nil
 	}
 
@@ -382,7 +384,11 @@ func (m *home) handleArchive() (tea.Model, tea.Cmd) {
 // row; a restore failure clears it in handleInstanceRestored.
 func (m *home) handleRestore() (tea.Model, tea.Cmd) {
 	selected := m.sidebar.GetSelectedInstance()
-	if selected == nil || selected.IsCreating() {
+	if selected == nil {
+		return m, nil
+	}
+	lifecycleAction := selected.LifecycleAction()
+	if lifecycleAction == session.LifecycleActionNone {
 		return m, nil
 	}
 	if selected.IsTearingDown() {
@@ -392,9 +398,7 @@ func (m *home) handleRestore() (tea.Model, tea.Cmd) {
 
 	// Only a resting (Archived/Lost/Dead) row can be restored; on a live row `r`
 	// does nothing (archive is on `a`).
-	if selected.GetLiveness() != session.LiveArchived &&
-		selected.GetLiveness() != session.LiveLost &&
-		selected.GetLiveness() != session.LiveDead {
+	if lifecycleAction != session.LifecycleActionRestore {
 		return m, nil
 	}
 	if selected.GetInFlightOp() == session.OpRestoring {

--- a/docs/web.md
+++ b/docs/web.md
@@ -343,9 +343,10 @@ header shows the session title, the terminal's connection state (`Live` /
 
 #### Per-session actions
 
-Each session's rail row reserves space for two quiet glyph actions. They stay visible
-on the selected row and reveal on hover or keyboard focus on any other row, without
-moving the title:
+Each actionable session's rail row reserves space for two quiet glyph actions. They
+stay visible on the selected row and reveal on hover or keyboard focus on any other
+row, without moving the title. A creating or legacy id-less row renders status only —
+the daemon projects no lifecycle action, so neither the TUI nor web invents one:
 
 - **`▪` Archive** — move a live session into the archived group. On an archived
   row the same slot becomes **`↶` Restore**.
@@ -357,9 +358,11 @@ header only when the selected session is blocked at a usage limit; it is the esc
 from that wall and stays hidden in every other state. Send follow-up instructions by
 typing in the attached terminal (or with `af sessions send-prompt`).
 
-**Create** a session with **`+ New`**; the new row appears in the rail and opens
-attached. Kill and archive resolve the row that exposed the action by its stable id,
-so acting on an unselected row and titles that collide across repos are unambiguous.
+**Create** a session with **`+ New`**; the pending row appears immediately without
+destructive controls, then opens attached when creation completes. Kill and archive
+resolve the row that exposed the action by its stable id, so acting on an unselected
+row and titles that collide across repos are unambiguous. Accessible action names also
+include that row's title.
 
 ### Tabs
 

--- a/session/instance_data.go
+++ b/session/instance_data.go
@@ -42,6 +42,7 @@ func (i *Instance) toInstanceDataLocked() InstanceData {
 		Status:              i.statusLocked(),
 		Liveness:            i.liveness,
 		InFlightOp:          i.inFlightOp,
+		LifecycleAction:     lifecycleActionFor(i.ID, i.liveness, i.inFlightOp),
 		Height:              i.Height,
 		Width:               i.Width,
 		CreatedAt:           i.CreatedAt,

--- a/session/liveness.go
+++ b/session/liveness.go
@@ -77,6 +77,45 @@ const (
 	OpRestoring
 )
 
+// LifecycleAction is the session domain's answer to which reversible lifecycle
+// verb a visible row supports. The zero value means no lifecycle controls at all;
+// a client must not infer one from liveness or from the fact that the row rendered.
+// It is serialized into daemon projections so the TUI and web consume one decision
+// instead of maintaining parallel state tables (#2234).
+type LifecycleAction string
+
+const (
+	LifecycleActionNone    LifecycleAction = ""
+	LifecycleActionArchive LifecycleAction = "archive"
+	LifecycleActionRestore LifecycleAction = "restore"
+)
+
+// lifecycleActionFor is the one policy shared by Instance (the TUI) and
+// ToInstanceData (the web projection). A creating row has a provisional identity
+// but no session to destroy yet. An id-less row cannot address a destructive API
+// unambiguously, so it also exposes nothing. Resting rows restore; every other
+// settled row archives. Kill is available whenever this result is non-zero.
+func lifecycleActionFor(id string, liveness Liveness, op InFlightOp) LifecycleAction {
+	if id == "" || op == OpCreating {
+		return LifecycleActionNone
+	}
+	switch liveness {
+	case LiveArchived, LiveLost, LiveDead:
+		return LifecycleActionRestore
+	default:
+		return LifecycleActionArchive
+	}
+}
+
+// LifecycleAction returns the shared lifecycle verb for this instance. TUI menus
+// and handlers use this method; browser clients receive the same value from
+// InstanceData.LifecycleAction.
+func (i *Instance) LifecycleAction() LifecycleAction {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return lifecycleActionFor(i.ID, i.liveness, i.inFlightOp)
+}
+
 // composeStatus derives the legacy Status enum from the two-axis model. An
 // in-flight op wins the composed value (it overlays the liveness), matching the
 // old single-field semantics where Loading/Deleting masked the underlying state.

--- a/session/liveness_test.go
+++ b/session/liveness_test.go
@@ -122,6 +122,46 @@ func TestSnapshotInFlightOpRoundTrips(t *testing.T) {
 		"legacy data without in_flight_op keeps the old Deleting fallback")
 }
 
+// TestLifecycleActionIsSharedAcrossInstanceAndProjection is #2234's parity
+// contract. The TUI reads Instance.LifecycleAction while the web reads the value
+// serialized by ToInstanceData; both must be the same domain decision, including
+// the two non-actionable rows that triggered the regression.
+func TestLifecycleActionIsSharedAcrossInstanceAndProjection(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		id   string
+		live Liveness
+		op   InFlightOp
+		want LifecycleAction
+	}{
+		{name: "ready archives", id: "ready-id", live: LiveReady, want: LifecycleActionArchive},
+		{name: "running archives", id: "running-id", live: LiveRunning, want: LifecycleActionArchive},
+		{name: "lost restores", id: "lost-id", live: LiveLost, want: LifecycleActionRestore},
+		{name: "dead restores", id: "dead-id", live: LiveDead, want: LifecycleActionRestore},
+		{name: "archived restores", id: "archived-id", live: LiveArchived, want: LifecycleActionRestore},
+		{name: "creating has no lifecycle action", id: "pending-id", live: LiveReady, op: OpCreating, want: LifecycleActionNone},
+		{name: "id-less has no lifecycle action", live: LiveReady, want: LifecycleActionNone},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			inst := &Instance{ID: tc.id, liveness: tc.live, inFlightOp: tc.op}
+			require.Equal(t, tc.want, inst.LifecycleAction(), "TUI domain decision")
+			require.Equal(t, tc.want, inst.ToInstanceData().LifecycleAction, "web projection decision")
+		})
+	}
+}
+
+func TestLifecycleActionIsProjectionOnly(t *testing.T) {
+	data := (&Instance{ID: "ready-id", liveness: LiveReady}).ToInstanceData()
+	require.Equal(t, LifecycleActionArchive, data.LifecycleAction)
+
+	stored := data.ForStorage()
+	require.Equal(t, LifecycleActionNone, stored.LifecycleAction)
+	raw, err := json.Marshal(stored)
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "lifecycle_action",
+		"instances.json must not persist a UI capability derived from live state")
+}
+
 func TestInFlightOpStrippedFromStorageRecords(t *testing.T) {
 	data := InstanceData{Status: Deleting, Liveness: LiveRunning, InFlightOp: OpArchiving}
 	stored := data.ForStorage()

--- a/session/storage.go
+++ b/session/storage.go
@@ -44,6 +44,12 @@ type InstanceData struct {
 	// at disk write/load boundaries: in-flight operations are process-local and
 	// must not be resurrected after a daemon restart.
 	InFlightOp InFlightOp `json:"in_flight_op,omitempty"`
+	// LifecycleAction is a projection-only capability shared by the TUI and web
+	// (#2234): "archive", "restore", or omitted when the row has no safe
+	// lifecycle target (creating or id-less). It is derived from live state by
+	// ToInstanceData and scrubbed by ForStorage; instances.json must not preserve
+	// a UI decision that can go stale across restart.
+	LifecycleAction LifecycleAction `json:"lifecycle_action,omitempty"`
 	// TaskRunActive records whether this session's task run is still in flight
 	// (#1892) — true from creation, false once the agent goes idle. It is the one
 	// fact the watch-task concurrency cap counts, and it is stored rather than
@@ -117,6 +123,7 @@ func (d InstanceData) ForStorage() InstanceData {
 	d.Status = composeStatus(lv, OpNone)
 	d.Liveness = lv
 	d.InFlightOp = OpNone
+	d.LifecycleAction = LifecycleActionNone
 	return d
 }
 

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -297,8 +297,14 @@ func (m *Menu) SetNamingHasPrompt(has bool) {
 }
 
 func (m *Menu) addInstanceOptions() {
-	// Creating (Loading) instances only get minimal options
-	if m.instance != nil && m.instance.IsCreating() {
+	// A row with no shared lifecycle action gets the same minimal menu on every
+	// surface (#2234). This includes a create still in flight and a legacy/id-less
+	// row whose destructive target cannot be addressed unambiguously.
+	lifecycleAction := session.LifecycleActionNone
+	if m.instance != nil {
+		lifecycleAction = m.instance.LifecycleAction()
+	}
+	if lifecycleAction == session.LifecycleActionNone {
 		m.options = []keys.KeyName{keys.KeyNew, keys.KeyHelp, keys.KeyQuit}
 		m.groups = []menuGroup{
 			{start: 0, end: 3, isAction: false},
@@ -311,11 +317,8 @@ func (m *Menu) addInstanceOptions() {
 	// (#1605) — the two verbs no longer share the `a` binding, so the footer
 	// shows exactly the one action the selected row supports.
 	mgmtVerb := keys.KeyArchive
-	if m.instance != nil {
-		switch m.instance.GetLiveness() {
-		case session.LiveArchived, session.LiveLost, session.LiveDead:
-			mgmtVerb = keys.KeyRestore
-		}
+	if lifecycleAction == session.LifecycleActionRestore {
+		mgmtVerb = keys.KeyRestore
 	}
 	mgmtGroup := []keys.KeyName{keys.KeyNew, keys.KeyKill, mgmtVerb}
 

--- a/ui/menu_test.go
+++ b/ui/menu_test.go
@@ -11,11 +11,13 @@ import (
 	"github.com/sachiniyer/agent-factory/ui/layout"
 )
 
-// readyUIInstance builds a Ready-status instance for ui-package render tests.
-// liveness is unexported, so it goes through the SetStatus shim rather than a
+// readyUIInstance builds an actionable Ready-status instance for ui-package
+// render tests. Real daemon-published sessions carry stable IDs; tests that need
+// the legacy inert shape construct an id-less Instance explicitly (#2234).
+// Liveness is unexported, so this goes through the SetStatus shim rather than a
 // struct literal (#1195 Phase 1b).
 func readyUIInstance() *session.Instance {
-	i := &session.Instance{}
+	i := &session.Instance{ID: "ui-test-session"}
 	i.SetStatusForTest(session.Ready)
 	return i
 }
@@ -81,23 +83,29 @@ func TestMenuAgentTabShowsBothScrollKeys(t *testing.T) {
 func TestMenuArchiveRestoreActionByRowState(t *testing.T) {
 	for _, tc := range []struct {
 		name        string
+		id          string
 		status      session.Status
+		wantKill    bool
 		wantArchive bool
 		wantRestore bool
 	}{
-		{name: "running archives", status: session.Running, wantArchive: true},
-		{name: "ready archives", status: session.Ready, wantArchive: true},
-		{name: "lost restores", status: session.Lost, wantRestore: true},
-		{name: "dead restores", status: session.Dead, wantRestore: true},
-		{name: "archived restores", status: session.Archived, wantRestore: true},
-		{name: "creating omits both", status: session.Loading, wantArchive: false, wantRestore: false},
+		{name: "running archives", id: "running-id", status: session.Running, wantKill: true, wantArchive: true},
+		{name: "ready archives", id: "ready-id", status: session.Ready, wantKill: true, wantArchive: true},
+		{name: "lost restores", id: "lost-id", status: session.Lost, wantKill: true, wantRestore: true},
+		{name: "dead restores", id: "dead-id", status: session.Dead, wantKill: true, wantRestore: true},
+		{name: "archived restores", id: "archived-id", status: session.Archived, wantKill: true, wantRestore: true},
+		{name: "creating omits lifecycle actions", id: "pending-id", status: session.Loading},
+		{name: "id-less omits lifecycle actions", status: session.Ready},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			inst := &session.Instance{}
+			inst := &session.Instance{ID: tc.id}
 			inst.SetStatusForTest(tc.status)
 			m := NewMenu()
 			m.SetInstance(inst)
 
+			if got := menuHasOption(m, keys.KeyKill); got != tc.wantKill {
+				t.Fatalf("KeyKill present = %v, want %v", got, tc.wantKill)
+			}
 			if got := menuHasOption(m, keys.KeyArchive); got != tc.wantArchive {
 				t.Fatalf("KeyArchive present = %v, want %v", got, tc.wantArchive)
 			}
@@ -126,7 +134,7 @@ func TestMenuArchiveRestoreHintByRowState(t *testing.T) {
 		{name: "archived shows restore", status: session.Archived, want: "r restore", reject: "a archive"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			inst := &session.Instance{}
+			inst := &session.Instance{ID: "ui-test-session"}
 			inst.SetStatusForTest(tc.status)
 			m := NewMenu()
 			m.SetInstance(inst)

--- a/ui/statusbar_test.go
+++ b/ui/statusbar_test.go
@@ -99,7 +99,7 @@ func TestMenuNarrowWidthKeepsHelpAndQuit(t *testing.T) {
 // hint and still let the row degrade instead of overflowing.
 func TestMenuLimitBlockedRowFitsNarrowWidths(t *testing.T) {
 	m := NewMenu()
-	inst := &session.Instance{}
+	inst := &session.Instance{ID: "ui-test-session"}
 	inst.SetLimitReached(time.Time{})
 	m.SetInstance(inst)
 

--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -785,6 +785,9 @@ body {
 .af-row:hover {
   background: var(--af-bg-inset);
 }
+.af-row-inert {
+  cursor: default;
+}
 .af-row-creating {
   cursor: progress;
 }

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -10233,6 +10233,9 @@ function reorderTargetIndex(from, insertion) {
 }
 
 // src/ui.ts
+function isActionableSession(s) {
+  return typeof s.id === "string" && s.id !== "" && (s.lifecycle_action === "archive" || s.lifecycle_action === "restore");
+}
 var MAX_TABS = 9;
 var OFF_BOX_BACKENDS = /* @__PURE__ */ new Set(["docker", "ssh", "remote"]);
 function supportsTabManagement(s) {
@@ -10619,13 +10622,13 @@ var AppShell = class {
   // Header text nodes for the selected pane, (re)created per selection.
   headTitle = null;
   headMeta = null;
-  // The selected rail row's archive/restore control and the archived-ness it currently
-  // shows (#1932, #2186). Every row owns controls now (#2223), but a session can flip
-  // archived⇄live WITHOUT a selection change, so patchMainHead still needs this one
-  // reference to swap the selected control's glyph + accessible verb in place. null
-  // when the selected row is not visible in the rail.
+  // The selected rail row's archive/restore control and the daemon-owned verb it
+  // currently shows (#1932, #2186, #2234). Every actionable row owns controls now
+  // (#2223), but a session can flip archive⇄restore WITHOUT a selection change, so
+  // patchMainHead still needs this reference to swap the selected control in place.
+  // null when the selected row is not visible/actionable in the rail.
   lifecycleBtn = null;
-  lifecycleArchived = false;
+  lifecycleAction = null;
   // The usage-limit Retry button and whether it is currently shown (#1934). Same
   // treatment, and for the same reason, as lifecycleBtn above: a session hits the
   // limit wall — or is resumed off it — WITHOUT a selection change, which is the
@@ -10827,6 +10830,7 @@ var AppShell = class {
     const scoped = scopeToProject(state.sessions, state.selectedProject);
     const visible = filterSessions(orderedSessions(scoped), state.statusFilter);
     this.lifecycleBtn = null;
+    this.lifecycleAction = null;
     this.railCount.textContent = String(visible.length);
     this.renderFilterMenu(state, scoped);
     const list = this.railList;
@@ -10844,15 +10848,14 @@ var AppShell = class {
     }
     const rows = visible.map((s) => {
       const selected = s.id === state.selectedId;
-      return sessionRow(s, selected, this.actions, this.rowActions(s, selected));
+      return sessionRow(s, selected, this.actions, (target) => this.rowActions(target, selected));
     });
     const notice = this.railNotice(state, scoped, visible);
     list.replaceChildren(...notice ? [notice, ...rows] : rows);
   }
-  /** Quiet per-session controls reserved beside every rail row (#2186, #2223).
-   *  CSS reveals the slot for selection, hover, or keyboard focus without changing
-   *  row geometry. Archive/Restore share one slot; its data-action is read at gesture
-   *  time so patchMainHead can change the selected row without rebuilding it. */
+  /** Quiet per-session controls reserved beside every ACTIONABLE rail row (#2186,
+   *  #2223, #2234). The Go projection chooses Archive vs Restore; the browser never
+   *  reconstructs that policy from row state. */
   rowActions(session, selected) {
     const lifecycleBtn = h2("button", { type: "button", class: "af-rail-action af-rail-lifecycle" });
     lifecycleBtn.addEventListener("click", (e) => {
@@ -10863,30 +10866,30 @@ var AppShell = class {
         this.actions.archive(session);
       }
     });
-    const archived = isArchived(session);
-    this.patchLifecycleButton(lifecycleBtn, archived);
+    this.patchLifecycleButton(lifecycleBtn, session.lifecycle_action, session.title);
     if (selected) {
       this.lifecycleBtn = lifecycleBtn;
-      this.lifecycleArchived = archived;
+      this.lifecycleAction = session.lifecycle_action;
     }
     const killBtn = h2("button", { type: "button", class: "af-rail-action af-rail-kill" }, "\u232B");
-    killBtn.setAttribute("aria-label", "Kill session");
-    killBtn.setAttribute("title", "Kill session");
+    const killLabel = `Kill session \u201C${session.title}\u201D`;
+    killBtn.setAttribute("aria-label", killLabel);
+    killBtn.setAttribute("title", killLabel);
     killBtn.addEventListener("click", (e) => {
       e.stopPropagation();
       this.actions.kill(session);
     });
     return h2("div", { class: "af-row-actions" }, lifecycleBtn, killBtn);
   }
-  /** Applies both the visible static glyph and the accessible reverse verb to the
-   *  lifecycle slot. Kept in one helper so render and selected-row live patching
-   *  cannot disagree about what an archived row offers or fires. */
-  patchLifecycleButton(btn, archived) {
-    const verb = archived ? "Restore session" : "Archive session";
-    btn.dataset.action = archived ? "restore" : "archive";
-    btn.textContent = archived ? "\u21B6" : "\u25AA";
-    btn.setAttribute("aria-label", verb);
-    btn.setAttribute("title", verb);
+  /** Applies the daemon-projected verb, glyph, and target-qualified accessible name
+   *  in one place so render and same-selection live patching cannot drift. */
+  patchLifecycleButton(btn, action, sessionTitle) {
+    const verb = action === "restore" ? "Restore session" : "Archive session";
+    const label = `${verb} \u201C${sessionTitle}\u201D`;
+    btn.dataset.action = action;
+    btn.textContent = action === "restore" ? "\u21B6" : "\u25AA";
+    btn.setAttribute("aria-label", label);
+    btn.setAttribute("title", label);
   }
   /**
    * The dim one-liner above the rows explaining what ISN'T there, or null when the
@@ -11382,10 +11385,10 @@ var AppShell = class {
     }
     this.headMeta.textContent = parts.join(" \xB7 ");
     this.headMeta.className = `af-term-meta af-term-${state.termStatus}`;
-    const nowArchived = isArchived(selected);
-    if (this.lifecycleBtn && nowArchived !== this.lifecycleArchived) {
-      this.patchLifecycleButton(this.lifecycleBtn, nowArchived);
-      this.lifecycleArchived = nowArchived;
+    const nowAction = selected.lifecycle_action ?? null;
+    if (this.lifecycleBtn && nowAction && nowAction !== this.lifecycleAction) {
+      this.patchLifecycleButton(this.lifecycleBtn, nowAction, selected.title);
+      this.lifecycleAction = nowAction;
     }
     const nowLimited = isLimitReached(selected);
     if (this.retryBtn && nowLimited !== this.retryVisible) {
@@ -11490,9 +11493,10 @@ function beginTabRename(btn, tab, actions2, editedId, editedSessionId) {
   input.focus();
   input.select();
 }
-function sessionRow(s, selected, actions2, rowActions) {
+function sessionRow(s, selected, actions2, buildActions) {
   const status = rowStatus(s);
   const creating = isCreating(s);
+  const actionable = isActionableSession(s);
   const title = h2("div", { class: "af-row-title" }, rowTitle(s));
   const branch = h2(
     "div",
@@ -11502,7 +11506,7 @@ function sessionRow(s, selected, actions2, rowActions) {
     s.branch || "\u2014"
   );
   const main = h2("div", { class: "af-row-main" }, title, branch);
-  const cls = `af-row${selected ? " af-row-selected" : ""}${isArchived(s) ? " af-row-archived" : ""}${creating ? " af-row-creating" : ""}`;
+  const cls = `af-row${selected ? " af-row-selected" : ""}${isArchived(s) ? " af-row-archived" : ""}${actionable ? "" : " af-row-inert"}${creating ? " af-row-creating" : ""}`;
   const row = h2("li", { class: cls });
   if (status.kind) {
     const dot = h2("span", { class: `af-dot af-dot-${status.kind}` }, status.glyph);
@@ -11510,15 +11514,16 @@ function sessionRow(s, selected, actions2, rowActions) {
     row.append(dot);
   }
   row.append(main);
-  row.append(rowActions);
+  if (actionable) {
+    row.append(buildActions(s));
+  }
   row.setAttribute("role", "option");
   row.setAttribute("aria-selected", selected ? "true" : "false");
   row.setAttribute("title", `${s.title} \u2014 ${status.label}`);
-  if (creating) {
+  if (!actionable) {
     row.setAttribute("aria-disabled", "true");
-  } else if (s.id) {
-    const id = s.id;
-    row.addEventListener("click", () => actions2.open(id));
+  } else {
+    row.addEventListener("click", () => actions2.open(s.id));
   }
   return row;
 }
@@ -11819,7 +11824,7 @@ function newSession() {
   );
 }
 function openConfirm(action, session) {
-  const target = { id: session.id ?? "", title: session.title };
+  const target = { id: session.id, title: session.title };
   openModal(
     confirmModal({
       action,

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "cf27d8b18ef1";
+const VERSION = "72ce4a97cf84";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -101,7 +101,7 @@ function row(page: Page, title: string): Locator {
 
 /** One of the quiet lifecycle glyphs revealed on the selected rail row (#2186). */
 function railAction(page: Page, title: string, name: "Archive session" | "Restore session" | "Kill session"): Locator {
-  return row(page, title).getByRole("button", { name, exact: true });
+  return row(page, title).getByRole("button", { name: `${name} “${title}”`, exact: true });
 }
 
 /** One state's checkbox in the rail's filter menu (feat: hide archived by default). */
@@ -875,6 +875,62 @@ test("status dots (#1766): waiting shows a green dot, working shows none, error 
   await ctx.close();
 });
 
+test("#2234: creating and id-less rows expose no lifecycle actions; the shared projection chooses the verb", async ({
+  browser,
+}) => {
+  const ctx = await browser.newContext();
+  const p = await ctx.newPage();
+  await p.route("**/v1/Snapshot", async (route) => {
+    const resp = await route.fetch();
+    const body = await resp.json();
+    const snap = body?.data as { instances?: Array<Record<string, unknown> & { title: string }> };
+    const list = snap?.instances ?? [];
+    const proto = { ...(list.find((s) => s.title === SESSION_A) ?? {}) };
+    const synth = (title: string, extra: Record<string, unknown>) => ({
+      ...proto,
+      id: `synth-${title}`,
+      title,
+      branch: `synth-${title}`,
+      liveness: 2,
+      in_flight_op: 0,
+      lifecycle_action: "archive",
+      ...extra,
+    });
+    list.push(
+      synth("probe-actionable", {}),
+      synth("probe-restorable", { liveness: 3, lifecycle_action: "restore" }),
+      synth("probe-creating", { in_flight_op: 1, lifecycle_action: undefined }),
+      synth("probe-idless", { id: undefined, lifecycle_action: undefined }),
+    );
+    if (snap) {
+      snap.instances = list;
+    }
+    await route.fulfill({ status: resp.status(), contentType: "application/json", body: JSON.stringify(body) });
+  });
+  await p.goto("/");
+  await expect(row(p, "probe-actionable")).toBeVisible({ timeout: 15_000 });
+
+  // These are visible status rows, but the Go projection withheld a lifecycle
+  // action. The web must not manufacture controls from their pixels/state.
+  for (const title of ["probe-creating", "probe-idless"]) {
+    const inert = row(p, title);
+    await expect(inert).toBeVisible();
+    await expect(inert).toHaveAttribute("aria-disabled", "true");
+    await inert.hover();
+    await expect(inert.locator(".af-row-actions")).toHaveCount(0);
+    await expect(inert.getByRole("button")).toHaveCount(0);
+  }
+
+  // The same server-owned value selects Archive vs Restore, and every accessible
+  // name carries its target now that unselected rows can own controls.
+  await expect(railAction(p, "probe-actionable", "Archive session")).toHaveCount(1);
+  await expect(railAction(p, "probe-actionable", "Kill session")).toHaveCount(1);
+  await expect(railAction(p, "probe-restorable", "Restore session")).toHaveCount(1);
+  await expect(railAction(p, "probe-restorable", "Archive session")).toHaveCount(0);
+
+  await ctx.close();
+});
+
 test("click-to-attach opens the xterm terminal and shows live output", async () => {
   await row(page, SESSION_A).click();
 
@@ -892,8 +948,8 @@ test("click-to-attach opens the xterm terminal and shows live output", async () 
   await expect(page.locator(".af-term-meta")).toContainText("Live");
   await expect(page.locator(".af-app.af-kb-terminal")).toBeVisible();
 
-  // Every instance reserves the quiet action slot, but only the selected row shows
-  // it at rest. Kill remains muted; af-danger is reserved for confirmation.
+  // Every actionable instance reserves the quiet action slot, but only the selected
+  // row shows it at rest. Kill remains muted; af-danger is reserved for confirmation.
   const visibleRows = page.locator(".af-rail-list .af-row");
   await expect(page.locator(".af-row-actions")).toHaveCount(await visibleRows.count());
   await expect(row(page, SESSION_A).locator(".af-row-actions")).toHaveCSS("opacity", "1");

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -75,6 +75,7 @@ import {
   canManageTabs,
   tabIdentity,
   tabRealId,
+  type ActionableSession,
   type AppState,
   type NewTabKind,
 } from "./ui.js";
@@ -603,8 +604,8 @@ function newSession(): void {
 /** Opens the kill/archive/restore confirm modal for the rail row that invoked it.
  *  This cannot derive its target from selection now that hover exposes actions on
  *  unselected rows (#2223). Restore remains the reverse of archive (#1932). */
-function openConfirm(action: "kill" | "archive" | "restore", session: SessionData): void {
-  const target = { id: session.id ?? "", title: session.title };
+function openConfirm(action: "kill" | "archive" | "restore", session: ActionableSession): void {
+  const target = { id: session.id, title: session.title };
   openModal(
     confirmModal({
       action,
@@ -1294,9 +1295,9 @@ const actions = {
   disconnect,
   open: openFromRail,
   newSession,
-  kill: (session: SessionData) => openConfirm("kill", session),
-  archive: (session: SessionData) => openConfirm("archive", session),
-  restore: (session: SessionData) => openConfirm("restore", session),
+  kill: (session: ActionableSession) => openConfirm("kill", session),
+  archive: (session: ActionableSession) => openConfirm("archive", session),
+  restore: (session: ActionableSession) => openConfirm("restore", session),
   retryLimit: doRetryLimit,
   switchTab,
   openTab,

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -983,6 +983,12 @@ body {
   background: var(--af-bg-inset);
 }
 
+/* A row without the daemon's lifecycle capability is visible status only. Creating
+ * rows share this class but override the cursor below with progress. */
+.af-row-inert {
+  cursor: default;
+}
+
 /* A daemon-published OpCreating row is visible but cannot attach yet. The progress
  * cursor is the web analogue of the TUI's inert Loading row; no local spinner or
  * optimistic state is involved. */
@@ -1007,11 +1013,11 @@ body {
   flex: 1;
 }
 
-/* Per-session lifecycle controls (#2186, #2223): every row reserves this slot, so
- * revealing it never shifts the title under the pointer. It is visually withdrawn at
- * rest but remains in the tab order; focusing either button makes :focus-within reveal
- * the whole slot for keyboard parity. Archive/Restore matches the rail filter's quiet
- * outlined-glyph treatment; Kill stays quieter still at rest. */
+/* Per-session lifecycle controls (#2186, #2223, #2234): every actionable row reserves
+ * this slot, so revealing it never shifts the title under the pointer. Inert rows do
+ * not render the slot or its buttons at all. It is visually withdrawn at rest but
+ * remains in the tab order; focusing either button makes :focus-within reveal the
+ * whole slot for keyboard parity. */
 .af-row-actions {
   display: flex;
   align-items: center;

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -50,6 +50,10 @@ export const InFlightOp = {
   Restoring: 4,
 } as const;
 
+/** session.LifecycleAction: the daemon-owned lifecycle verb for a row. Absence
+ *  means the row must expose no archive/restore/kill controls (#2234). */
+export type LifecycleAction = "archive" | "restore";
+
 /** session.Status (session/instance.go) — the legacy single-axis int, read ONLY
  *  as a defensive fallback when a projection somehow omits `liveness` (never
  *  expected from the daemon's live Snapshot, which always emits it). */
@@ -83,6 +87,9 @@ export interface SessionData {
   liveness?: number;
   /** Transient client-op axis; absent (→ None) in the steady state. */
   in_flight_op?: number;
+  /** Daemon-owned lifecycle capability. The web consumes this decision instead
+   *  of re-deriving TUI policy from liveness/in-flight fields. */
+  lifecycle_action?: LifecycleAction;
   /** Usage-limit reset time (RFC3339), present only for a LimitReached row. */
   limit_reset_at?: string;
   /** Backend discriminator; "remote" marks a remote-hook session (→ [remote]). */

--- a/web/src/ui.test.ts
+++ b/web/src/ui.test.ts
@@ -11,6 +11,7 @@ import assert from "node:assert/strict";
 import {
   canManageTabs,
   documentTitle,
+  isActionableSession,
   supportsTabManagement,
   tabBarSig,
   tabCreationUnavailableReason,
@@ -32,6 +33,24 @@ function state(over: Partial<AppState> = {}): AppState {
     ...over,
   } as AppState;
 }
+
+test("rail actionability is granted only by the daemon projection (#2234)", () => {
+  assert.equal(
+    isActionableSession(sess({ lifecycle_action: "archive" })),
+    true,
+    "a stable row with the projected verb is actionable",
+  );
+  assert.equal(
+    isActionableSession(sess()),
+    false,
+    "the browser must not infer an action from a settled-looking row",
+  );
+  assert.equal(
+    isActionableSession(sess({ id: undefined, lifecycle_action: "archive" })),
+    false,
+    "a malformed id-less capability fails closed",
+  );
+});
 
 test("an unrelated status/title snapshot on the selected session keeps the SAME sig", () => {
   const base = state();

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -47,12 +47,28 @@ import { insertionIndexAt, reorderTargetIndex } from "./tabreorder.js";
 import { TasksPane } from "./tasks.js";
 import { type ThemeChoice, THEME_CHOICES } from "./theme.js";
 import type { TerminalStatus } from "./terminal.js";
-import { type ConfigEntry, type SessionData, type TaskData, TabKind } from "./types.js";
+import { type ConfigEntry, type LifecycleAction, type SessionData, type TaskData, TabKind } from "./types.js";
 
 /** The tab kinds the web UI can create with no further input from the user. A
  *  web tab is deliberately absent: its target comes from whatever an agent is
  *  running, so it stays CLI/API-created (see docs/web.md). */
 export type NewTabKind = "shell" | "vscode";
+
+/** A row carrying the Go domain's positive lifecycle capability and a stable
+ *  destructive-action target. Lifecycle callbacks accept only this narrowed type,
+ *  so a visible but inert row cannot reach them through the normal code path. */
+export type ActionableSession = SessionData & { id: string; lifecycle_action: LifecycleAction };
+
+/** Fail-closed wire narrowing only — the policy itself lives in Go's
+ *  session.LifecycleAction (#2234). Exact values reject a malformed or stale
+ *  projection instead of manufacturing an action in the browser. */
+export function isActionableSession(s: SessionData): s is ActionableSession {
+  return (
+    typeof s.id === "string" &&
+    s.id !== "" &&
+    (s.lifecycle_action === "archive" || s.lifecycle_action === "restore")
+  );
+}
 
 /** The whole client state: which view to show, the login details, and — once
  *  authed — the live session projection plus the current selection. */
@@ -142,12 +158,12 @@ export interface Actions {
   /** Opens the new-session modal (#1592 Phase 5 PR5). */
   newSession(): void;
   /** Opens the kill-confirm modal for this rail row. */
-  kill(session: SessionData): void;
+  kill(session: ActionableSession): void;
   /** Opens the archive-confirm modal for this rail row. */
-  archive(session: SessionData): void;
+  archive(session: ActionableSession): void;
   /** Opens the restore-confirm modal for this rail row (an archived / Lost / Dead
    *  session): the reverse of archive (#1932). */
-  restore(session: SessionData): void;
+  restore(session: ActionableSession): void;
   /** Resumes the current selection from its usage-limit wall (#1934) — the web's
    *  analogue of the TUI's `c`. Fires immediately with NO confirm, matching the
    *  TUI: it is not destructive (it re-delivers the prompt the session was already
@@ -600,13 +616,13 @@ export class AppShell {
   // Header text nodes for the selected pane, (re)created per selection.
   private headTitle: HTMLElement | null = null;
   private headMeta: HTMLElement | null = null;
-  // The selected rail row's archive/restore control and the archived-ness it currently
-  // shows (#1932, #2186). Every row owns controls now (#2223), but a session can flip
-  // archived⇄live WITHOUT a selection change, so patchMainHead still needs this one
-  // reference to swap the selected control's glyph + accessible verb in place. null
-  // when the selected row is not visible in the rail.
+  // The selected rail row's archive/restore control and the daemon-owned verb it
+  // currently shows (#1932, #2186, #2234). Every actionable row owns controls now
+  // (#2223), but a session can flip archive⇄restore WITHOUT a selection change, so
+  // patchMainHead still needs this reference to swap the selected control in place.
+  // null when the selected row is not visible/actionable in the rail.
   private lifecycleBtn: HTMLElement | null = null;
-  private lifecycleArchived = false;
+  private lifecycleAction: LifecycleAction | null = null;
   // The usage-limit Retry button and whether it is currently shown (#1934). Same
   // treatment, and for the same reason, as lifecycleBtn above: a session hits the
   // limit wall — or is resumed off it — WITHOUT a selection change, which is the
@@ -1089,6 +1105,7 @@ export class AppShell {
     // selected row hidden by the project/status filter cannot leave patchMainHead
     // mutating a detached button.
     this.lifecycleBtn = null;
+    this.lifecycleAction = null;
     // The count is what the rail SHOWS, not what the project holds — a count that
     // disagrees with the rows under it is just a bug the user has to reconcile. The
     // filter menu carries the per-state totals for what's hidden.
@@ -1111,17 +1128,16 @@ export class AppShell {
     }
     const rows = visible.map((s) => {
       const selected = s.id === state.selectedId;
-      return sessionRow(s, selected, this.actions, this.rowActions(s, selected));
+      return sessionRow(s, selected, this.actions, (target) => this.rowActions(target, selected));
     });
     const notice = this.railNotice(state, scoped, visible);
     list.replaceChildren(...(notice ? [notice, ...rows] : rows));
   }
 
-  /** Quiet per-session controls reserved beside every rail row (#2186, #2223).
-   *  CSS reveals the slot for selection, hover, or keyboard focus without changing
-   *  row geometry. Archive/Restore share one slot; its data-action is read at gesture
-   *  time so patchMainHead can change the selected row without rebuilding it. */
-  private rowActions(session: SessionData, selected: boolean): HTMLElement {
+  /** Quiet per-session controls reserved beside every ACTIONABLE rail row (#2186,
+   *  #2223, #2234). The Go projection chooses Archive vs Restore; the browser never
+   *  reconstructs that policy from row state. */
+  private rowActions(session: ActionableSession, selected: boolean): HTMLElement {
     const lifecycleBtn = h("button", { type: "button", class: "af-rail-action af-rail-lifecycle" });
     lifecycleBtn.addEventListener("click", (e) => {
       e.stopPropagation();
@@ -1131,18 +1147,18 @@ export class AppShell {
         this.actions.archive(session);
       }
     });
-    const archived = isArchived(session);
-    this.patchLifecycleButton(lifecycleBtn, archived);
+    this.patchLifecycleButton(lifecycleBtn, session.lifecycle_action, session.title);
     if (selected) {
       this.lifecycleBtn = lifecycleBtn;
-      this.lifecycleArchived = archived;
+      this.lifecycleAction = session.lifecycle_action;
     }
 
     // Kill stays unmistakably destructive through its distinct ⌫ glyph and confirm,
     // but its resting rail treatment is deliberately muted instead of af-danger.
     const killBtn = h("button", { type: "button", class: "af-rail-action af-rail-kill" }, "⌫");
-    killBtn.setAttribute("aria-label", "Kill session");
-    killBtn.setAttribute("title", "Kill session");
+    const killLabel = `Kill session “${session.title}”`;
+    killBtn.setAttribute("aria-label", killLabel);
+    killBtn.setAttribute("title", killLabel);
     killBtn.addEventListener("click", (e) => {
       e.stopPropagation();
       this.actions.kill(session);
@@ -1150,15 +1166,15 @@ export class AppShell {
     return h("div", { class: "af-row-actions" }, lifecycleBtn, killBtn);
   }
 
-  /** Applies both the visible static glyph and the accessible reverse verb to the
-   *  lifecycle slot. Kept in one helper so render and selected-row live patching
-   *  cannot disagree about what an archived row offers or fires. */
-  private patchLifecycleButton(btn: HTMLElement, archived: boolean): void {
-    const verb = archived ? "Restore session" : "Archive session";
-    btn.dataset.action = archived ? "restore" : "archive";
-    btn.textContent = archived ? "↶" : "▪";
-    btn.setAttribute("aria-label", verb);
-    btn.setAttribute("title", verb);
+  /** Applies the daemon-projected verb, glyph, and target-qualified accessible name
+   *  in one place so render and same-selection live patching cannot drift. */
+  private patchLifecycleButton(btn: HTMLElement, action: LifecycleAction, sessionTitle: string): void {
+    const verb = action === "restore" ? "Restore session" : "Archive session";
+    const label = `${verb} “${sessionTitle}”`;
+    btn.dataset.action = action;
+    btn.textContent = action === "restore" ? "↶" : "▪";
+    btn.setAttribute("aria-label", label);
+    btn.setAttribute("title", label);
   }
 
   /**
@@ -1784,14 +1800,14 @@ export class AppShell {
     this.headMeta.textContent = parts.join(" · ");
     this.headMeta.className = `af-term-meta af-term-${state.termStatus}`;
 
-    // Flip the selected rail row's lifecycle glyph + accessible verb if it was
-    // archived or restored without a selection change (#1932, #2186). The rail is
-    // often rebuilt by a fresh Snapshot too, but that is not a safe prerequisite:
-    // this patch is what keeps a same-selection state change correct in place.
-    const nowArchived = isArchived(selected);
-    if (this.lifecycleBtn && nowArchived !== this.lifecycleArchived) {
-      this.patchLifecycleButton(this.lifecycleBtn, nowArchived);
-      this.lifecycleArchived = nowArchived;
+    // Flip the selected rail row's lifecycle glyph + accessible verb when the
+    // daemon-owned action changes without a selection change (#1932, #2186, #2234).
+    // A fresh Snapshot usually rebuilds the rail too, but this patch keeps the
+    // same-selection path correct without relying on that incidental repaint.
+    const nowAction = selected.lifecycle_action ?? null;
+    if (this.lifecycleBtn && nowAction && nowAction !== this.lifecycleAction) {
+      this.patchLifecycleButton(this.lifecycleBtn, nowAction, selected.title);
+      this.lifecycleAction = nowAction;
     }
 
     // Show/hide Retry as the selected session enters or leaves the usage-limit wall
@@ -2079,9 +2095,15 @@ function beginTabRename(
  *  slot for its quiet lifecycle actions (#2186, #2223). Clicking opens the session by
  *  its stable id (selects it and attaches its terminal, #1693); a row lacking an id
  *  (never expected from a live Snapshot) is rendered but inert. */
-function sessionRow(s: SessionData, selected: boolean, actions: Actions, rowActions: HTMLElement): HTMLElement {
+function sessionRow(
+  s: SessionData,
+  selected: boolean,
+  actions: Actions,
+  buildActions: (session: ActionableSession) => HTMLElement,
+): HTMLElement {
   const status = rowStatus(s);
   const creating = isCreating(s);
+  const actionable = isActionableSession(s);
 
   const title = h("div", { class: "af-row-title" }, rowTitle(s));
   const branch = h(
@@ -2094,8 +2116,8 @@ function sessionRow(s: SessionData, selected: boolean, actions: Actions, rowActi
   const main = h("div", { class: "af-row-main" }, title, branch);
 
   const cls = `af-row${selected ? " af-row-selected" : ""}${isArchived(s) ? " af-row-archived" : ""}${
-    creating ? " af-row-creating" : ""
-  }`;
+    actionable ? "" : " af-row-inert"
+  }${creating ? " af-row-creating" : ""}`;
   const row = h("li", { class: cls });
   // A working/busy row shows NO status dot (#1766) — only Ready/error states draw
   // one. When there is no dot the span is omitted entirely (kind is null), matching
@@ -2106,19 +2128,19 @@ function sessionRow(s: SessionData, selected: boolean, actions: Actions, rowActi
     row.append(dot);
   }
   row.append(main);
-  row.append(rowActions);
+  if (actionable) {
+    row.append(buildActions(s));
+  }
   row.setAttribute("role", "option");
   row.setAttribute("aria-selected", selected ? "true" : "false");
   row.setAttribute("title", `${s.title} — ${status.label}`);
-  if (creating) {
-    // The id is already the final stable id, but no terminal exists yet. Keeping
-    // the row inert also prevents selecting it before completion: if success then
-    // wrote the SAME selectedId, AppShell would see no selection change and retain
-    // the empty pane (the slow-create form of the invariant in index.ts newSession).
+  if (!actionable) {
+    // The server withheld a lifecycle action: a creating row has no session yet,
+    // while an id-less row has no unambiguous destructive target. Selection and
+    // lifecycle controls consume the same fail-closed capability.
     row.setAttribute("aria-disabled", "true");
-  } else if (s.id) {
-    const id = s.id;
-    row.addEventListener("click", () => actions.open(id));
+  } else {
+    row.addEventListener("click", () => actions.open(s.id));
   }
   return row;
 }


### PR DESCRIPTION
## Summary

- project one daemon-owned `LifecycleAction` decision into both the TUI and web instead of maintaining two lifecycle tables
- render no lifecycle controls for creating or ID-less rows, and require a stable-ID `ActionableSession` before web callbacks can open a destructive confirmation
- name every Archive, Restore, and Kill control with its target session title
- keep the derived capability out of `instances.json`, and rebuild the committed web bundle

## Why this shape

This is the emergent interaction between #2229 (daemon-published creating rows) and #2233 (actions on every visible row): each change was correct alone, but visibility accidentally became authority when combined.

The domain now makes the decision once. A stable, settled row projects `archive` or `restore`; a creating or ID-less row projects nothing. The TUI menu/handlers and browser consume that same result. The TypeScript narrowing is deliberately only fail-closed wire validation, not a second policy implementation. That removes the drift class behind the three late Codex findings on #2233.

## Fail-first evidence

Before the implementation:

- `go test ./session ./ui -run 'TestLifecycleAction|TestMenuArchiveRestoreAction'` failed because the shared lifecycle decision did not exist
- the TUI menu regression showed `KeyKill present = true, want false` for the ID-less case

The added Go parity table pins Ready/Running, Archived/Lost/Dead, Creating, and ID-less rows across `Instance` and `InstanceData`; the browser regression asserts that creating and ID-less rows have no action wrapper or buttons and that projected verbs plus target-qualified names render exactly.

## Verification

All required gates ran after final commit `f79481ad45cee1a279e744775e23b189d69092a4` was pushed, with local HEAD matching the remote branch:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (no output)
- `go build ./...`
- `make test-container`
- `deadcode -test ./...` (no output)
- `scripts/lint-file-length.sh`
- `make web-test` (401 passed, including typecheck)
- `make web-build` (committed bundle regenerated with no diff)
- `make web-selftest-container` (106 Chromium tests passed)

Closes #2234

— Captain Claude

Co-authored-by: Captain Claude <noreply@anthropic.com>
