### PR TITLE
fix(config-agent): trust only process-owned receipts

### DIFF
--- a/daemon/configagent.go
+++ b/daemon/configagent.go
@@ -3,6 +3,9 @@ package daemon
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -197,17 +200,21 @@ func (m *Manager) SpawnConfigAgent(ctx context.Context, req SpawnConfigAgentRequ
 	if req.Program == "" {
 		return "", "", fmt.Errorf("config agent: no program to run")
 	}
-	// Detect before launch so the Codex rollout snapshot below is taken before
-	// the process can create its conversation file. The command the pane actually
-	// runs remains the source of truth, matching regular sessions (#1116/#1131).
-	agent := tmux.DetectAgentFromCommand(req.Program)
-	var promptReceipt session.ConversationCaptureSnapshot
-	if agent == tmux.ProgramCodex && req.Prompt != "" {
-		promptReceipt = session.BeginConversationCapture()
-	}
 	home, err := config.GetConfigDir()
 	if err != nil {
 		return "", "", fmt.Errorf("config agent: cannot resolve the agent-factory home: %w", err)
+	}
+	// Detect and snapshot before launch so Codex cannot create its rollout between
+	// the before-image and tmux start. The receipt path is resolved from the exact
+	// command environment, not the daemon's CODEX_HOME (#2228 review).
+	agent := tmux.DetectAgentFromCommand(req.Program)
+	var promptReceipt session.ConversationCaptureSnapshot
+	if agent == tmux.ProgramCodex && req.Prompt != "" {
+		codexHome, rerr := configAgentCodexReceiptHome(req.Program, home)
+		if rerr != nil {
+			return "", "", fmt.Errorf("config agent: cannot locate the launched Codex receipt store: %w", rerr)
+		}
+		promptReceipt = session.BeginConversationCaptureAtCodexHome(codexHome)
 	}
 
 	// seq is only for uniqueness within this daemon; the tmux session NewTmuxSession
@@ -284,6 +291,44 @@ func (m *Manager) SpawnConfigAgent(ctx context.Context, req SpawnConfigAgentRequ
 	}
 	log.InfoLog.Printf("config agent: started %s in %s on socket %q (agent %q)", sessionName, home, socketPath, agent)
 	return sessionName, socketPath, nil
+}
+
+// configAgentCodexReceiptHome resolves the same CODEX_HOME the launched shell
+// command will give Codex. Command-local assignments win over daemon variables;
+// an unset CODEX_HOME falls back through the command-specific HOME. Relative
+// values resolve against the AF-home working directory passed to tmux.Start.
+func configAgentCodexReceiptHome(program, workingDir string) (string, error) {
+	effective := func(name string) (string, bool, error) {
+		override := tmux.EnvironmentOverrideFromCommand(program, name)
+		if !override.Present {
+			value, set := os.LookupEnv(name)
+			return value, set, nil
+		}
+		if !override.Literal {
+			return "", false, fmt.Errorf("%s uses shell expansion; use a literal path so receipt verification can follow it", name)
+		}
+		return override.Value, override.Set, nil
+	}
+	resolve := func(path string) string {
+		if filepath.IsAbs(path) {
+			return filepath.Clean(path)
+		}
+		return filepath.Clean(filepath.Join(workingDir, path))
+	}
+
+	if codexHome, set, err := effective("CODEX_HOME"); err != nil {
+		return "", err
+	} else if set && strings.TrimSpace(codexHome) != "" {
+		return resolve(codexHome), nil
+	}
+	home, set, err := effective("HOME")
+	if err != nil {
+		return "", err
+	}
+	if !set || strings.TrimSpace(home) == "" {
+		return "", fmt.Errorf("CODEX_HOME is unset and the launched command has no literal HOME fallback")
+	}
+	return filepath.Join(resolve(home), ".codex"), nil
 }
 
 // dismissConfigAgentTrustPrompt clears the agent's first-run trust dialog, the

--- a/daemon/configagent_delivery_test.go
+++ b/daemon/configagent_delivery_test.go
@@ -102,6 +102,69 @@ func TestConfigAgentCodexMissingReceiptFailsSpawn(t *testing.T) {
 	}
 }
 
+func TestConfigAgentCodexInlineHomeSubmitsAndVerifiesBriefing(t *testing.T) {
+	testguard.IsolateTmux(t)
+	manager, program, rollout := newConfigAgentCodexFixture(t, "accept-inline-home")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	sessionName, _, err := manager.SpawnConfigAgent(ctx, SpawnConfigAgentRequest{
+		Program: program,
+		Prompt:  "briefing whose receipt lives under the inline CODEX_HOME",
+	})
+	if err != nil {
+		t.Fatalf("config-agent spawn with inline CODEX_HOME: %v", err)
+	}
+	t.Cleanup(func() { _ = manager.ReapConfigAgent(ReapConfigAgentRequest{SessionName: sessionName}) })
+
+	data, err := os.ReadFile(rollout)
+	if err != nil {
+		t.Fatalf("read inline-home rollout: %v", err)
+	}
+	if !strings.Contains(string(data), "briefing whose receipt lives under the inline CODEX_HOME") {
+		t.Fatalf("receiver did not record the briefing under the command-specific CODEX_HOME:\n%s", data)
+	}
+}
+
+func TestConfigAgentCodexReceiptHome(t *testing.T) {
+	workDir := t.TempDir()
+	daemonCodexHome := t.TempDir()
+	includeHome := t.TempDir()
+	t.Setenv("CODEX_HOME", daemonCodexHome)
+	t.Setenv("HOME", includeHome)
+
+	tests := []struct {
+		name    string
+		program string
+		want    string
+		wantErr string
+	}{
+		{name: "inherits daemon", program: "codex", want: daemonCodexHome},
+		{name: "inline absolute wins", program: "CODEX_HOME=/tmp/inline-codex codex", want: "/tmp/inline-codex"},
+		{name: "inline relative uses launch cwd", program: "CODEX_HOME=relative-codex codex", want: filepath.Join(workDir, "relative-codex")},
+		{name: "unset uses command home", program: "env -u CODEX_HOME HOME=/tmp/inline-home codex", want: "/tmp/inline-home/.codex"},
+		{name: "cleared environment without home", program: "env -i codex", wantErr: "no literal HOME fallback"},
+		{name: "dynamic path refused", program: "CODEX_HOME=$OTHER codex", wantErr: "uses shell expansion"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := configAgentCodexReceiptHome(tc.program, workDir)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error = %v, want substring %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolve receipt home: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("receipt home = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func newConfigAgentCodexFixture(t *testing.T, mode string) (*Manager, string, string) {
 	t.Helper()
 	afHome := testguard.SocketTempDir(t)
@@ -117,6 +180,12 @@ func newConfigAgentCodexFixture(t *testing.T, mode string) (*Manager, string, st
 		t.Fatalf("symlink Codex fixture: %v", err)
 	}
 	program := codexBin + " -test.run=^TestConfigAgentCodexFixtureProcess$"
+	if strings.Contains(mode, "inline-home") {
+		// The daemon environment intentionally points elsewhere. Only parsing the
+		// exact launched command finds the rollout the fixture will write.
+		t.Setenv("CODEX_HOME", t.TempDir())
+		program = "CODEX_HOME=" + shSingleQuote(codexHome) + " " + program
+	}
 
 	manager, err := NewManager(config.DefaultConfig())
 	if err != nil {

--- a/session/conversation_capture.go
+++ b/session/conversation_capture.go
@@ -27,6 +27,10 @@ var (
 	// before the acknowledgement deadline. A tmux send returning nil does not
 	// override this observation (#2220).
 	ErrPromptReceiptNotObserved = errors.New("prompt receipt not observed")
+	// ErrPromptReceiptAmbiguous means more than one new receiver conversation
+	// appeared after the snapshot. Prompt text cannot identify which process owns
+	// which rollout, even when only one has recorded it so far (#2228 review).
+	ErrPromptReceiptAmbiguous = errors.New("prompt receipt ambiguous")
 )
 
 const promptReceiptPollInterval = 50 * time.Millisecond
@@ -45,7 +49,14 @@ type ConversationCaptureSnapshot struct {
 // other providers degrade to their existing latest-session resume path unless a
 // deterministic id was injected before spawn (Claude).
 func BeginConversationCapture() ConversationCaptureSnapshot {
-	home := codexHomeDir()
+	return BeginConversationCaptureAtCodexHome(codexHomeDir())
+}
+
+// BeginConversationCaptureAtCodexHome snapshots an exact Codex store rather
+// than the daemon's inherited CODEX_HOME. Config-agent commands can carry an
+// inline environment assignment, so the process-specific path must be resolved
+// before launch and supplied here (#2228 review).
+func BeginConversationCaptureAtCodexHome(home string) ConversationCaptureSnapshot {
 	return ConversationCaptureSnapshot{
 		startedAt:   time.Now(),
 		codexHome:   home,
@@ -181,6 +192,9 @@ func codexPromptReceiptOnce(snap ConversationCaptureSnapshot, prompt string) (bo
 	if len(candidates) == 0 {
 		return false, nil
 	}
+	if len(candidates) > 1 {
+		return false, fmt.Errorf("%w: %d new Codex rollout files appeared", ErrPromptReceiptAmbiguous, len(candidates))
+	}
 	matches := 0
 	for _, path := range candidates {
 		received, err := codexRolloutHasPrompt(path, prompt)
@@ -200,10 +214,9 @@ func codexPromptReceiptOnce(snap ConversationCaptureSnapshot, prompt string) (bo
 	case 1:
 		return true, nil
 	default:
-		// Two new conversations recorded the exact same prompt, so af cannot
-		// prove which one belongs to this pane. Fail closed rather than let the
-		// other conversation acknowledge an unbriefed config agent.
-		return false, fmt.Errorf("codex prompt receipt ambiguous: %d new rollouts recorded the briefing", matches)
+		// One candidate can contribute at most one match. Keep this defensive arm
+		// so future receipt formats cannot silently weaken that invariant.
+		return false, fmt.Errorf("%w: one rollout produced %d matches", ErrPromptReceiptAmbiguous, matches)
 	}
 }
 

--- a/session/conversation_capture_test.go
+++ b/session/conversation_capture_test.go
@@ -38,6 +38,20 @@ func TestCaptureAgentConversation_CodexRolloutFile(t *testing.T) {
 	require.False(t, conv.CapturedAt.IsZero())
 }
 
+func TestBeginConversationCaptureAtCodexHomeIgnoresDaemonEnvironment(t *testing.T) {
+	t.Setenv("CODEX_HOME", t.TempDir())
+	exactHome := t.TempDir()
+	snap := BeginConversationCaptureAtCodexHome(exactHome)
+	require.Equal(t, exactHome, snap.codexHome)
+
+	path := writeCodexRolloutFile(t, exactHome, "rollout-2026-07-06T10-17-35-019f386f-7206-7fc2-803b-f7045e07a242.jsonl")
+	appendCodexRolloutEvent(t, path, map[string]any{
+		"type":    "event_msg",
+		"payload": map[string]any{"type": "user_message", "message": "inline-home briefing"},
+	})
+	require.NoError(t, WaitForPromptReceipt(context.Background(), tmux.ProgramCodex, snap, "inline-home briefing", 0))
+}
+
 func TestCaptureAgentConversation_CodexAmbiguousConcurrentRollouts(t *testing.T) {
 	codexHome := t.TempDir()
 	t.Setenv("CODEX_HOME", codexHome)
@@ -122,7 +136,7 @@ func TestWaitForPromptReceipt_DifferentUserTurnDoesNotConfirmBriefing(t *testing
 		"a concurrent/unrelated user turn must not acknowledge the config briefing")
 }
 
-func TestWaitForPromptReceipt_CorrelatesExactPromptAcrossConcurrentRollouts(t *testing.T) {
+func TestWaitForPromptReceipt_ConcurrentRolloutsRemainAmbiguous(t *testing.T) {
 	codexHome := t.TempDir()
 	t.Setenv("CODEX_HOME", codexHome)
 	snap := BeginConversationCapture()
@@ -137,8 +151,9 @@ func TestWaitForPromptReceipt_CorrelatesExactPromptAcrossConcurrentRollouts(t *t
 		"payload": map[string]any{"type": "user_message", "message": "config briefing"},
 	})
 
-	require.NoError(t, WaitForPromptReceipt(context.Background(), tmux.ProgramCodex, snap, "config briefing", 0),
-		"an unrelated concurrent rollout must not make an exact receiver receipt ambiguous")
+	err := WaitForPromptReceipt(context.Background(), tmux.ProgramCodex, snap, "config briefing", 0)
+	require.ErrorIs(t, err, ErrPromptReceiptAmbiguous,
+		"prompt coincidence cannot prove which new rollout belongs to the launched pane")
 }
 
 func TestWaitForPromptReceipt_UnsupportedAgentDoesNotInventReceipt(t *testing.T) {

--- a/session/tmux/doc_trust_prompt_test.go
+++ b/session/tmux/doc_trust_prompt_test.go
@@ -94,6 +94,27 @@ func TestCheckAndHandleTrustPrompt_CodexTrustProseAloneInjectsNothing(t *testing
 	}
 }
 
+func TestCheckAndHandleTrustPrompt_CodexModalSourceInOutputInjectsNothing(t *testing.T) {
+	content := codexDirectoryTrustDialog + `
+
+func CodexTrustPromptPresent(content string) bool {
+    // The agent is displaying source after quoting the fixture above.
+    return false
+}`
+	handled, cmds := runTrustPromptCheck(t, ProgramCodex, content)
+	require.False(t, handled,
+		"four phrases somewhere in ordinary output are not proof the selected modal is active")
+	require.Empty(t, sentKeystrokes(cmds),
+		"the live-session poll must not inject Enter into ordinary output containing the fixture; got %v", cmds)
+}
+
+func TestCheckAndHandleTrustPrompt_CodexUnselectedYesInjectsNothing(t *testing.T) {
+	content := strings.Replace(codexDirectoryTrustDialog, "› 1. Yes, continue", "  1. Yes, continue", 1)
+	handled, cmds := runTrustPromptCheck(t, ProgramCodex, content)
+	require.False(t, handled, "the predicate must require the actual selected Yes row")
+	require.Empty(t, sentKeystrokes(cmds))
+}
+
 // The bug: ordinary agent output that happens to contain the documentation
 // phrase must NOT get keystrokes injected into it.
 func TestCheckAndHandleTrustPrompt_DocPhraseInOutputInjectsNothing(t *testing.T) {

--- a/session/tmux/environment.go
+++ b/session/tmux/environment.go
@@ -1,0 +1,78 @@
+package tmux
+
+import "strings"
+
+// CommandEnvOverride describes how a shell command changes one environment
+// variable before the detected agent executable. Present=false means the child
+// inherits the daemon value. Present=true with Set=false means wrappers such as
+// `env -u NAME` or `env -i` remove it. Literal=false means shell expansion makes
+// the effective value unknowable without executing the command.
+type CommandEnvOverride struct {
+	Value   string
+	Present bool
+	Set     bool
+	Literal bool
+}
+
+// EnvironmentOverrideFromCommand finds the last command-local change to name
+// before the agent token. It covers leading shell assignment words and the env
+// forms that change inheritance. This deliberately shares splitShellTokens and
+// findAgentToken with agent detection: receipt routing must interpret the exact
+// command through the same lexical model as launch routing (#2228 review).
+func EnvironmentOverrideFromCommand(command, name string) CommandEnvOverride {
+	tokens, _ := splitShellTokens(command)
+	agentIdx, agent := findAgentToken(tokens)
+	if agent == "" {
+		return CommandEnvOverride{}
+	}
+	var result CommandEnvOverride
+	inEnv := false
+	for idx := 0; idx < agentIdx; idx++ {
+		tok := tokens[idx]
+		if strings.EqualFold(baseCommand(tok), "env") {
+			inEnv = true
+			continue
+		}
+		if key, value, ok := strings.Cut(tok, "="); ok && key == name {
+			result = CommandEnvOverride{
+				Value: value, Present: true, Set: true, Literal: literalEnvironmentValue(value),
+			}
+			continue
+		}
+		if !inEnv {
+			continue
+		}
+		switch {
+		case tok == "-i" || tok == "--ignore-environment" || tok == "-":
+			result = CommandEnvOverride{Present: true, Literal: true}
+		case tok == "-u" || tok == "--unset":
+			if idx+1 < agentIdx {
+				idx++
+				if tokens[idx] == name {
+					result = CommandEnvOverride{Present: true, Literal: true}
+				}
+			}
+		case strings.HasPrefix(tok, "--unset="):
+			if strings.TrimPrefix(tok, "--unset=") == name {
+				result = CommandEnvOverride{Present: true, Literal: true}
+			}
+		}
+	}
+	return result
+}
+
+func baseCommand(token string) string {
+	if slash := strings.LastIndexAny(token, `/\\`); slash >= 0 {
+		return token[slash+1:]
+	}
+	return token
+}
+
+// literalEnvironmentValue is conservative because splitShellTokens removes
+// quote provenance. Values requiring expansion cannot be reproduced safely in
+// the daemon process; callers must fail loudly instead of inspecting the wrong
+// receiver store. Spaces are fine (they necessarily came from quoting), while
+// expansion/control metacharacters are not.
+func literalEnvironmentValue(value string) bool {
+	return !strings.ContainsAny(value, "$`;&|<>\n\r") && !strings.HasPrefix(value, "~")
+}

--- a/session/tmux/environment_test.go
+++ b/session/tmux/environment_test.go
@@ -1,0 +1,31 @@
+package tmux
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvironmentOverrideFromCommand(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		key     string
+		want    CommandEnvOverride
+	}{
+		{name: "leading assignment", command: "CODEX_HOME='/tmp/codex home' codex", key: "CODEX_HOME", want: CommandEnvOverride{Value: "/tmp/codex home", Present: true, Set: true, Literal: true}},
+		{name: "env assignment", command: "/usr/bin/env CODEX_HOME=/tmp/one codex", key: "CODEX_HOME", want: CommandEnvOverride{Value: "/tmp/one", Present: true, Set: true, Literal: true}},
+		{name: "last assignment wins", command: "CODEX_HOME=/tmp/one CODEX_HOME=/tmp/two codex", key: "CODEX_HOME", want: CommandEnvOverride{Value: "/tmp/two", Present: true, Set: true, Literal: true}},
+		{name: "unset separate", command: "env -u CODEX_HOME codex", key: "CODEX_HOME", want: CommandEnvOverride{Present: true, Literal: true}},
+		{name: "unset attached", command: "env --unset=CODEX_HOME codex", key: "CODEX_HOME", want: CommandEnvOverride{Present: true, Literal: true}},
+		{name: "clear then restore", command: "env -i HOME=/tmp/isolated codex", key: "HOME", want: CommandEnvOverride{Value: "/tmp/isolated", Present: true, Set: true, Literal: true}},
+		{name: "clear inherited variable", command: "env -i HOME=/tmp/isolated codex", key: "CODEX_HOME", want: CommandEnvOverride{Present: true, Literal: true}},
+		{name: "dynamic value unknown", command: "CODEX_HOME=$ALT_CODEX_HOME codex", key: "CODEX_HOME", want: CommandEnvOverride{Value: "$ALT_CODEX_HOME", Present: true, Set: true, Literal: false}},
+		{name: "inherited", command: "ionice -c 3 codex", key: "CODEX_HOME", want: CommandEnvOverride{}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, EnvironmentOverrideFromCommand(tc.command, tc.key))
+		})
+	}
+}

--- a/session/tmux/start.go
+++ b/session/tmux/start.go
@@ -2,6 +2,7 @@ package tmux
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -232,11 +233,30 @@ func (t *TmuxSession) CheckAndHandleTrustPrompt() bool {
 // The match is anchored on the question, both option labels and the affordance.
 // CheckAndHandleTrustPrompt also runs on live-session polls, so a prose mention
 // of one phrase must never inject Enter into a working agent.
+var ansiCSISequence = regexp.MustCompile(`\x1b\[[0-?]*[ -/]*[@-~]`)
+
 func CodexTrustPromptPresent(content string) bool {
-	return strings.Contains(content, "Do you trust the contents of this directory?") &&
-		strings.Contains(content, "Yes, continue") &&
-		strings.Contains(content, "No, quit") &&
-		strings.Contains(content, "Press enter to continue")
+	content = ansiCSISequence.ReplaceAllString(strings.ReplaceAll(content, "\r\n", "\n"), "")
+	question, selectedYes, noOption, affordance, last := -1, -1, -1, -1, -1
+	for idx, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(strings.TrimSuffix(line, "\r"))
+		if line == "" {
+			continue
+		}
+		last = idx
+		switch {
+		case strings.HasPrefix(line, "Do you trust the contents of this directory?"):
+			question = idx
+		case line == "› 1. Yes, continue":
+			selectedYes = idx
+		case line == "2. No, quit":
+			noOption = idx
+		case line == "Press enter to continue":
+			affordance = idx
+		}
+	}
+	return question >= 0 && question < selectedYes && selectedYes < noOption &&
+		noOption < affordance && affordance == last
 }
 
 // DocTrustPromptPresent reports whether content shows the documentation-link


### PR DESCRIPTION
## Summary

- resolve Codex's receiver store from the exact launch command, including literal `CODEX_HOME`, `HOME`, `env -u`, and `env -i` semantics, instead of inheriting the daemon's path
- fail before launch when shell expansion makes the receipt path unknowable, with an actionable literal-path error
- require Codex's selected Yes row and ordered trust-modal layout at the bottom of the pane before injecting Enter
- reject every receipt with multiple new rollout candidates; prompt text is not process identity even when only one candidate currently matches
- add raw tmux, receiver-store, command-environment, and ambiguity regressions for the three unread Codex P2 findings from #2228

## Why this shape

All three findings were the same sharp edge: treating correlating text or inherited process state as ownership. The receipt snapshot now follows the launched process's literal environment, the modal predicate follows selected terminal structure, and rollout ownership is accepted only when one new receiver exists.

## Verification

All required gates ran after final commit `79582e9b6c2f2de21564fb6ec1ebc6c0486f8692` was pushed, with local HEAD matching the remote branch:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (no output)
- `go build ./...`
- `make test-container`
- `deadcode -test ./...` (no output)
- `scripts/lint-file-length.sh`
- focused config-agent, tmux-modal, and receipt tests under `go test -race`

— Captain Claude

Co-authored-by: Captain Claude <noreply@anthropic.com>
