### PR TITLE
fix(bugreport): close target title redaction gaps

### DIFF
--- a/bugreport/bugreport_test.go
+++ b/bugreport/bugreport_test.go
@@ -218,6 +218,50 @@ func TestRedactTaskDropsTargetSession(t *testing.T) {
 	}
 }
 
+// TestScrubLogRedactsShortTaskTarget is the first #2238 review regression. A
+// known three-byte title must be removed in both the task's %q log form and any
+// raw %s-style line; privacy cannot silently turn off below a length threshold.
+func TestScrubLogRedactsShortTaskTarget(t *testing.T) {
+	const target = "VIP"
+	r := &redactor{}
+	r.redactTask(task.Task{TargetSession: target})
+	logText := fmt.Sprintf("delivered to target session %q\nstarted as instance %s", target, target)
+
+	out := r.scrubLog(logText)
+
+	mustNotContain(t, "daemon log", out, target, fmt.Sprintf("%q", target))
+	mustContain(t, "daemon log", out, redactedMarker)
+}
+
+// TestScrubLogRedactsEscapedTaskTarget is the second #2238 review regression.
+// strconv.Quote must mirror the daemon's %q encoding so quotes and backslashes
+// cannot make the registered raw title miss its rendered representation.
+func TestScrubLogRedactsEscapedTaskTarget(t *testing.T) {
+	const target = `Confidential "Deal" \\ Alpha`
+	r := &redactor{}
+	r.redactTask(task.Task{TargetSession: target})
+	quoted := fmt.Sprintf("%q", target)
+
+	out := r.scrubLog("delivered to target session " + quoted)
+
+	mustNotContain(t, "daemon log", out, target, quoted)
+	mustContain(t, "daemon log", out, redactedMarker)
+}
+
+// TestRedactTaskScrubsTargetFromFailedRunStatus is the third #2238 review
+// regression. LastRunStatus is structured task data, not a log blob, but both
+// must cross the same unstructured-text sanitizer before rendering.
+func TestRedactTaskScrubsTargetFromFailedRunStatus(t *testing.T) {
+	const target = `Confidential "Deal" Alpha`
+	r := &redactor{}
+	status := fmt.Sprintf("errored: failed to deliver prompt to target session %q: connection reset", target)
+
+	got := r.redactTask(task.Task{TargetSession: target, LastRunStatus: status})
+
+	mustNotContain(t, "last_run_status", got.LastRunStatus, target, fmt.Sprintf("%q", target))
+	mustContain(t, "last_run_status", got.LastRunStatus, "errored:", "connection reset", redactedMarker)
+}
+
 // TestRedactInstanceDataRedactsNonLoopbackWebTabURL pins the #1954 fix: a web
 // tab's URL is user-supplied (any http/https target passes NormalizeWebTabURL)
 // and can name internal infrastructure or a private repo, exactly the class of

--- a/bugreport/redact.go
+++ b/bugreport/redact.go
@@ -6,6 +6,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/sachiniyer/agent-factory/session"
@@ -87,10 +88,11 @@ type redactor struct {
 	home  string
 	users []string
 	// tmuxNames and titles are the known session tmux names and raw session
-	// titles gathered while redacting instances (see noteSession). scrubLog uses
-	// them to redact bare titles and non-repo-scoped names (af_<title>, no hash,
-	// which the afTmuxSessionName shape can't match) out of the verbatim log
-	// tail — closing the #1584 leak the structured sections don't reach.
+	// titles gathered while redacting instances and tasks. scrubSessionTitles
+	// uses titles for both structured task status strings and the verbatim log;
+	// scrubLog additionally removes non-repo-scoped names (af_<title>, no hash,
+	// which the afTmuxSessionName shape can't match) — closing the #1584 leak the
+	// structured sections don't reach.
 	tmuxNames map[string]struct{}
 	titles    map[string]struct{}
 }
@@ -147,6 +149,17 @@ func (r *redactor) scrub(s string) string {
 	return s
 }
 
+// scrubUnstructured is the single sanitizer for a free-text scalar or blob
+// before it is embedded in any bug-report rendering. In addition to scrub's
+// credential/path policy, it removes every known representation of a session
+// title. Keeping this separate from scrub is intentional: scrub also runs over
+// already-encoded JSON documents, where treating a short title such as "id" as
+// bare text would rewrite structural keys. Call this while the value is still a
+// value; all later text/JSON renderings then inherit the safe form.
+func (r *redactor) scrubUnstructured(s string) string {
+	return r.scrub(r.scrubSessionTitles(s))
+}
+
 // scrubLog scrubs the daemon log tail. On top of the standard scrub() pass it
 // redacts the free-text <title> in every af_<hash>_<title> tmux session name and
 // any bare session title the log prints, so the verbatim log blob can't leak the
@@ -166,15 +179,23 @@ func (r *redactor) scrubLog(s string) string {
 			s = strings.ReplaceAll(s, name, tmuxPrefixMarker)
 		}
 	}
-	// Bare raw titles the log prints verbatim (e.g. via a %q-formatted Title).
-	// Best-effort: only titles long enough to redact without mangling unrelated
-	// words, matched on word boundaries.
+	return r.scrubUnstructured(s)
+}
+
+// scrubSessionTitles removes exact Go-quoted forms of every known title, then
+// applies the conservative bare-title matcher. The quoted form is the important
+// invariant for task targets: daemon delivery logs and persisted delivery errors
+// both format them with %q. Matching strconv.Quote therefore covers every legal
+// title byte-for-byte, including short names that are unsafe to replace as bare
+// words and quotes/backslashes that %q escapes (#2238 review).
+func (r *redactor) scrubSessionTitles(s string) string {
 	for title := range r.titles {
+		s = strings.ReplaceAll(s, strconv.Quote(title), strconv.Quote(redactedMarker))
 		if re := bareTitleRegexp(title); re != nil {
 			s = re.ReplaceAllString(s, redactedMarker)
 		}
 	}
-	return r.scrub(s)
+	return s
 }
 
 // tmuxPrefixMarker is the redaction of an af tmux session name whose title
@@ -188,11 +209,11 @@ func redactAFTmuxTitle(match string) string {
 	return match[:12] + redactedMarker
 }
 
-// bareTitleRegexp compiles a boundary-anchored matcher for a bare session title,
-// or nil when the title is too short (< 4 chars) to redact without risking
-// mangling unrelated log text. Best-effort by design — the tmux-name redaction
-// above is the primary defense; this catches raw titles the log prints outside a
-// name.
+// bareTitleRegexp compiles a boundary-anchored matcher for any non-empty bare
+// session title. Short titles can collide with ordinary words, but silently
+// publishing a known secret is worse than losing some diagnostic prose. Exact
+// Go-quoted matching above handles the common short-title path without that
+// collateral; this matcher closes raw %s-style log paths too (#2238 review).
 //
 // A `\b` anchor is only emitted on the edge where the title's own boundary
 // character is a word char ([A-Za-z0-9_]); `\b` matches only at a word↔non-word
@@ -203,7 +224,7 @@ func redactAFTmuxTitle(match string) string {
 // self-delimiting and needs no anchor.
 func bareTitleRegexp(title string) *regexp.Regexp {
 	title = strings.TrimSpace(title)
-	if len(title) < 4 {
+	if title == "" {
 		return nil
 	}
 	var left, right string
@@ -242,7 +263,8 @@ func (r *redactor) noteSession(d *session.InstanceData) {
 	}
 }
 
-// noteTitle records one raw session title for scrubLog, skipping blanks.
+// noteTitle records one raw session title for structured-string and log
+// scrubbing, skipping blanks.
 func (r *redactor) noteTitle(title string) {
 	if strings.TrimSpace(title) == "" {
 		return
@@ -538,9 +560,9 @@ func redactInstanceData(d *session.InstanceData) {
 
 // redactedTask is the structural, secret-free projection of a task.Task. The
 // prompt and watch command — both free-text that can carry secrets — collapse
-// to a marker (and a boolean recording that one was present); everything else
-// is scheduling metadata safe to keep. ProjectPath survives here and is
-// scrubbed for $HOME/username by the text pass.
+// to a marker (and a boolean recording that one was present). LastRunStatus is
+// kept for diagnostics after known session titles are removed. ProjectPath
+// survives here and is scrubbed for $HOME/username by the text pass.
 type redactedTask struct {
 	ID            string `json:"id"`
 	Name          string `json:"name,omitempty"`
@@ -568,7 +590,7 @@ func (r *redactor) redactTask(t task.Task) redactedTask {
 		ProjectPath:   t.ProjectPath,
 		Program:       t.Program,
 		Enabled:       t.Enabled,
-		LastRunStatus: t.LastRunStatus,
+		LastRunStatus: r.scrubUnstructured(t.LastRunStatus),
 	}
 	if t.TargetSession != "" {
 		rt.TargetSession = redactedMarker


### PR DESCRIPTION
## Summary

- centralize session-title scrubbing for unstructured bug-report values
- scrub both raw titles and the exact `fmt %q` representation with `strconv.Quote`
- remove the silent four-byte exemption and sanitize persisted `last_run_status` before JSON/text rendering

This is the follow-up to the three legitimate late P2 findings on #2238. It closes the shared gap instead of adding three call-site patches: session-title representations are handled once at the unstructured-value chokepoint, so logs and task status fields inherit the same policy.

## Fail-first evidence

The focused regressions failed against shipped master before the implementation:

- a legal short title (`VIP`) survived raw and `%q` log lines
- `Confidential "Deal" \\ Alpha` survived in its `%q`-escaped form
- a failed target-session run retained the title in `last_run_status`

All three now pass.

## Verification

Full gates run after the final commit on pushed SHA `2778abd6127157792e2c0bb95bac2aae14c9cb7b`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh` (`899 Go files checked; 0 grandfathered`)

— Captain Claude