### PR TITLE
fix(web): dismiss mobile drawer by action intent

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -334,6 +334,11 @@ keyboard never surprises you:
 The pane you're driving is highlighted with an accent border, so the active mode is
 always legible.
 
+On a phone the rail is a drawer over the main pane. Actions that take you somewhere
+else — **+ New**, selecting a session, and Archive/Restore/Kill — close it before
+opening the terminal or modal. The state filter stays open while you change it, and
+tapping the dimmed scrim dismisses the drawer directly.
+
 #### The attach terminal
 
 The main pane hosts a real terminal (xterm.js) streaming the agent's live output

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -10509,7 +10509,7 @@ var AppShell = class {
     );
     this.railCount = h2("span", { class: "af-rail-count" }, "0");
     const newBtn = h2("button", { type: "button", class: "af-rail-new", title: "New session" }, "+ New");
-    newBtn.addEventListener("click", () => this.actions.newSession());
+    newBtn.addEventListener("click", () => this.runRailExit(() => this.actions.newSession()));
     const filterGlyph = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     filterGlyph.classList.add("af-rail-filter-glyph");
     filterGlyph.setAttribute("viewBox", "0 0 16 16");
@@ -10549,7 +10549,6 @@ var AppShell = class {
     this.railList = h2("ul", { class: "af-rail-list" });
     this.railList.setAttribute("role", "listbox");
     this.railList.setAttribute("aria-label", "Sessions");
-    this.railList.addEventListener("click", () => this.setNav(false));
     const rail = h2("nav", { class: "af-rail", id: "af-rail" }, railHead, this.railList);
     this.main = h2("section", { class: "af-main" });
     this.navScrim = h2("div", { class: "af-nav-scrim" });
@@ -10682,7 +10681,8 @@ var AppShell = class {
   // phone gives the terminal the full width. This is the ONLY piece of the responsive
   // work that needs JS — everything else is @media CSS. `navOpen` is pure UI ephemera
   // (never store state): the drawer is closed on load, opens on the toggle, and
-  // auto-closes when a session is selected (reveal the terminal) or the view changes.
+  // auto-closes when an action leaves the rail (create/select/lifecycle) or the view
+  // changes. Filtering stays in the rail and deliberately keeps it open (#2226).
   // On desktop the CSS ignores the class, so setNav is an inert no-op there.
   navToggle;
   navScrim;
@@ -10708,6 +10708,15 @@ var AppShell = class {
     this.navOpen = open;
     this.el.classList.toggle("af-nav-open", open);
     this.navToggle.setAttribute("aria-expanded", open ? "true" : "false");
+  }
+  /** Runs an action whose result lives outside the session drawer (#2226). Drawer
+   *  dismissal belongs to the action's intent, not to where its click happened or
+   *  whether it bubbled: Create and lifecycle controls stop at different DOM nodes,
+   *  while both must expose the modal they open. Filter actions bypass this helper
+   *  because their result remains inside the rail. */
+  runRailExit(action) {
+    this.setNav(false);
+    action();
   }
   toggleNav() {
     this.setNav(!this.navOpen);
@@ -10848,7 +10857,12 @@ var AppShell = class {
     }
     const rows = visible.map((s) => {
       const selected = s.id === state.selectedId;
-      return sessionRow(s, selected, this.actions, (target) => this.rowActions(target, selected));
+      return sessionRow(
+        s,
+        selected,
+        (id) => this.runRailExit(() => this.actions.open(id)),
+        (target) => this.rowActions(target, selected)
+      );
     });
     const notice = this.railNotice(state, scoped, visible);
     list.replaceChildren(...notice ? [notice, ...rows] : rows);
@@ -10861,9 +10875,9 @@ var AppShell = class {
     lifecycleBtn.addEventListener("click", (e) => {
       e.stopPropagation();
       if (lifecycleBtn.dataset.action === "restore") {
-        this.actions.restore(session);
+        this.runRailExit(() => this.actions.restore(session));
       } else {
-        this.actions.archive(session);
+        this.runRailExit(() => this.actions.archive(session));
       }
     });
     this.patchLifecycleButton(lifecycleBtn, session.lifecycle_action, session.title);
@@ -10877,7 +10891,7 @@ var AppShell = class {
     killBtn.setAttribute("title", killLabel);
     killBtn.addEventListener("click", (e) => {
       e.stopPropagation();
-      this.actions.kill(session);
+      this.runRailExit(() => this.actions.kill(session));
     });
     return h2("div", { class: "af-row-actions" }, lifecycleBtn, killBtn);
   }
@@ -10909,7 +10923,7 @@ var AppShell = class {
     const hasActive = scoped.some((s) => !isArchived(s));
     if (!hasActive) {
       const newBtn = h2("button", { type: "button", class: "af-rail-empty-new", title: "New session" }, "+ New");
-      newBtn.addEventListener("click", () => this.actions.newSession());
+      newBtn.addEventListener("click", () => this.runRailExit(() => this.actions.newSession()));
       const empty = h2("li", { class: "af-rail-empty-project" }, `No active sessions in ${name} \u2014 `, newBtn);
       const archived = scoped.filter(isArchived).length;
       if (archived > 0 && !state.statusFilter.archived) {
@@ -11493,7 +11507,7 @@ function beginTabRename(btn, tab, actions2, editedId, editedSessionId) {
   input.focus();
   input.select();
 }
-function sessionRow(s, selected, actions2, buildActions) {
+function sessionRow(s, selected, openSession, buildActions) {
   const status = rowStatus(s);
   const creating = isCreating(s);
   const actionable = isActionableSession(s);
@@ -11523,7 +11537,7 @@ function sessionRow(s, selected, actions2, buildActions) {
   if (!actionable) {
     row.setAttribute("aria-disabled", "true");
   } else {
-    row.addEventListener("click", () => actions2.open(s.id));
+    row.addEventListener("click", () => openSession(s.id));
   }
   return row;
 }

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "72ce4a97cf84";
+const VERSION = "c4e5a7f8b67e";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -5628,6 +5628,103 @@ test("mobile (375px): the rail auto-collapses to a drawer; the hamburger reveals
   await ctx.close();
 });
 
+test("#2226 mobile (375px): drawer dismissal follows action intent, not click propagation", async ({ browser }) => {
+  const { ctx, p } = await openAt(browser, 375, 667);
+  const app = p.locator(".af-app");
+  const rail = p.locator(".af-rail");
+  const toggle = p.locator(".af-nav-toggle");
+  const modal = p.locator(".af-modal-card");
+  const lifecyclePosts: string[] = [];
+  p.on("request", (request) => {
+    if (/\/v1\/(?:KillSession|ArchiveSession|RestoreSession)$/.test(request.url())) {
+      lifecyclePosts.push(request.url());
+    }
+  });
+
+  const openDrawer = async () => {
+    await toggle.click();
+    await expect(app).toHaveClass(/af-nav-open/);
+    await expect(rail).toBeVisible();
+  };
+  const expectDrawerClosed = async () => {
+    await expect(app).not.toHaveClass(/af-nav-open/);
+    await expect(rail).not.toBeVisible();
+  };
+
+  // Create lives in the rail HEAD, outside the old delegated list handler. Opening
+  // its form is a leave-the-rail action: fold the drawer first so the form can take
+  // focus instead of sitting under the overlay.
+  await openDrawer();
+  await p.locator(".af-rail-new").click();
+  await expectDrawerClosed();
+  await expect(modal).toBeVisible();
+  const titleInput = modal.locator('input[aria-label="Session title"]');
+  await titleInput.click();
+  await expect(titleInput).toBeFocused();
+  await modal.getByRole("button", { name: "Cancel", exact: true }).click();
+  await expect(modal).toBeHidden();
+
+  // Selecting a row leaves the rail for its terminal. This used to pass only because
+  // its click happened to bubble to railList; the same action must stay explicit.
+  await openDrawer();
+  await row(p, SESSION_A).click();
+  await expectDrawerClosed();
+  await expect(p.locator(".af-main.af-main-term")).toBeVisible();
+
+  // Row actions MUST keep stopPropagation (otherwise they also select the row), so
+  // Kill and Archive have to dismiss by intent before opening their own confirms.
+  await openDrawer();
+  await railAction(p, SESSION_A, "Kill session").click();
+  await expectDrawerClosed();
+  await expect(modal).toContainText(`Kill ${SESSION_A}?`);
+  await modal.getByRole("button", { name: "Cancel", exact: true }).click();
+  await expect(modal).toBeHidden();
+  expect(lifecyclePosts, "cancelling Kill must not post a lifecycle mutation").toEqual([]);
+  await expect(row(p, SESSION_A)).toHaveCount(1);
+
+  await openDrawer();
+  await railAction(p, SESSION_A, "Archive session").click();
+  await expectDrawerClosed();
+  await expect(modal).toContainText(`Archive ${SESSION_A}?`);
+  await modal.getByRole("button", { name: "Cancel", exact: true }).click();
+  await expect(modal).toBeHidden();
+  expect(lifecyclePosts, "cancelling Archive must not post a lifecycle mutation").toEqual([]);
+  await expect(row(p, SESSION_A)).toHaveCount(1);
+
+  // Filtering is a stay-in-the-rail action. Both opening the filter and toggling the
+  // archived projection keep the drawer and menu open so several states can be set.
+  await openDrawer();
+  await p.locator(".af-rail-filter").click();
+  await expect(p.locator(".af-filter-menu")).toBeVisible();
+  await expect(app).toHaveClass(/af-nav-open/);
+  await filterItem(p, "archived").click();
+  await expect(filterItem(p, "archived")).toHaveAttribute("aria-checked", "true");
+  await expect(p.locator(".af-filter-menu")).toBeVisible();
+  await expect(app).toHaveClass(/af-nav-open/);
+
+  // Restore is the archived row's version of the same lifecycle action. It must
+  // leave the drawer too; keeping this leg in the browser guard prevents the two
+  // branches in rowActions from drifting apart.
+  await expect(row(p, SESSION_B)).toHaveClass(/af-row-archived/);
+  await railAction(p, SESSION_B, "Restore session").click();
+  await expectDrawerClosed();
+  await expect(modal).toContainText(`Restore ${SESSION_B}?`);
+  await modal.getByRole("button", { name: "Cancel", exact: true }).click();
+  await expect(modal).toBeHidden();
+  expect(lifecyclePosts, "cancelling Restore must not post a lifecycle mutation").toEqual([]);
+
+  // The escape hatch remains location-based by design: the scrim's action IS drawer
+  // dismissal. Tap its exposed right edge (the left side sits behind the drawer).
+  await openDrawer();
+  const scrim = p.locator(".af-nav-scrim");
+  const scrimBox = await scrim.boundingBox();
+  expect(scrimBox, "the open mobile drawer exposes a scrim").not.toBeNull();
+  await scrim.click({ position: { x: scrimBox!.width - 5, y: scrimBox!.height / 2 } });
+  await expectDrawerClosed();
+
+  await ctx.close();
+});
+
 for (const width of [375, 768]) {
   test(`mobile (${width}px): the page never scrolls sideways, drawer closed or open`, async ({ browser }) => {
     const { ctx, p } = await openAt(browser, width, 812);

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -678,7 +678,8 @@ export class AppShell {
   // phone gives the terminal the full width. This is the ONLY piece of the responsive
   // work that needs JS — everything else is @media CSS. `navOpen` is pure UI ephemera
   // (never store state): the drawer is closed on load, opens on the toggle, and
-  // auto-closes when a session is selected (reveal the terminal) or the view changes.
+  // auto-closes when an action leaves the rail (create/select/lifecycle) or the view
+  // changes. Filtering stays in the rail and deliberately keeps it open (#2226).
   // On desktop the CSS ignores the class, so setNav is an inert no-op there.
   private readonly navToggle: HTMLButtonElement;
   private readonly navScrim: HTMLElement;
@@ -800,7 +801,7 @@ export class AppShell {
 
     this.railCount = h("span", { class: "af-rail-count" }, "0");
     const newBtn = h("button", { type: "button", class: "af-rail-new", title: "New session" }, "+ New");
-    newBtn.addEventListener("click", () => this.actions.newSession());
+    newBtn.addEventListener("click", () => this.runRailExit(() => this.actions.newSession()));
 
     // The status filter (feat: hide archived by default). A small funnel mark rather
     // than a word, so the rail head still fits the count + New at 18rem; the dot beside
@@ -850,11 +851,6 @@ export class AppShell {
     this.railList = h("ul", { class: "af-rail-list" });
     this.railList.setAttribute("role", "listbox");
     this.railList.setAttribute("aria-label", "Sessions");
-    // Tapping a row on a phone should reveal the terminal, so any click that reaches a
-    // rail row closes the drawer (the row's own handler still attaches). Delegated on
-    // the list — not the rail head — so filtering/creating stays possible with the
-    // drawer open. Idempotent and inert on desktop (setNav no-ops there).
-    this.railList.addEventListener("click", () => this.setNav(false));
     const rail = h("nav", { class: "af-rail", id: "af-rail" }, railHead, this.railList);
 
     this.main = h("section", { class: "af-main" });
@@ -911,6 +907,16 @@ export class AppShell {
     this.navOpen = open;
     this.el.classList.toggle("af-nav-open", open);
     this.navToggle.setAttribute("aria-expanded", open ? "true" : "false");
+  }
+
+  /** Runs an action whose result lives outside the session drawer (#2226). Drawer
+   *  dismissal belongs to the action's intent, not to where its click happened or
+   *  whether it bubbled: Create and lifecycle controls stop at different DOM nodes,
+   *  while both must expose the modal they open. Filter actions bypass this helper
+   *  because their result remains inside the rail. */
+  private runRailExit(action: () => void): void {
+    this.setNav(false);
+    action();
   }
 
   private toggleNav(): void {
@@ -1128,7 +1134,12 @@ export class AppShell {
     }
     const rows = visible.map((s) => {
       const selected = s.id === state.selectedId;
-      return sessionRow(s, selected, this.actions, (target) => this.rowActions(target, selected));
+      return sessionRow(
+        s,
+        selected,
+        (id) => this.runRailExit(() => this.actions.open(id)),
+        (target) => this.rowActions(target, selected),
+      );
     });
     const notice = this.railNotice(state, scoped, visible);
     list.replaceChildren(...(notice ? [notice, ...rows] : rows));
@@ -1142,9 +1153,9 @@ export class AppShell {
     lifecycleBtn.addEventListener("click", (e) => {
       e.stopPropagation();
       if (lifecycleBtn.dataset.action === "restore") {
-        this.actions.restore(session);
+        this.runRailExit(() => this.actions.restore(session));
       } else {
-        this.actions.archive(session);
+        this.runRailExit(() => this.actions.archive(session));
       }
     });
     this.patchLifecycleButton(lifecycleBtn, session.lifecycle_action, session.title);
@@ -1161,7 +1172,7 @@ export class AppShell {
     killBtn.setAttribute("title", killLabel);
     killBtn.addEventListener("click", (e) => {
       e.stopPropagation();
-      this.actions.kill(session);
+      this.runRailExit(() => this.actions.kill(session));
     });
     return h("div", { class: "af-row-actions" }, lifecycleBtn, killBtn);
   }
@@ -1195,7 +1206,7 @@ export class AppShell {
     const hasActive = scoped.some((s) => !isArchived(s));
     if (!hasActive) {
       const newBtn = h("button", { type: "button", class: "af-rail-empty-new", title: "New session" }, "+ New");
-      newBtn.addEventListener("click", () => this.actions.newSession());
+      newBtn.addEventListener("click", () => this.runRailExit(() => this.actions.newSession()));
       const empty = h("li", { class: "af-rail-empty-project" }, `No active sessions in ${name} — `, newBtn);
       const archived = scoped.filter(isArchived).length;
       if (archived > 0 && !state.statusFilter.archived) {
@@ -2098,7 +2109,7 @@ function beginTabRename(
 function sessionRow(
   s: SessionData,
   selected: boolean,
-  actions: Actions,
+  openSession: (id: string) => void,
   buildActions: (session: ActionableSession) => HTMLElement,
 ): HTMLElement {
   const status = rowStatus(s);
@@ -2140,7 +2151,7 @@ function sessionRow(
     // lifecycle controls consume the same fail-closed capability.
     row.setAttribute("aria-disabled", "true");
   } else {
-    row.addEventListener("click", () => actions.open(s.id));
+    row.addEventListener("click", () => openSession(s.id));
   }
   return row;
 }


### PR DESCRIPTION
## Summary

- replace rail-list click delegation with one explicit drawer-exit path for actions that leave the rail
- dismiss for Create, session selection, Kill, Archive, and Restore while filter controls stay open
- keep lifecycle `stopPropagation()` intact so a row action never also selects its row
- add a real 375px browser regression covering the modal/terminal destinations, filter behavior, and scrim dismissal

## Gotcha removed

Drawer dismissal now belongs to action intent instead of DOM location or event bubbling. Head controls and propagation-stopping row controls therefore cannot silently bypass the mobile behavior in opposite ways again.

## Fail-first evidence

With the browser regression added before the implementation, the existing 106 cases passed and the new #2226 case failed on `+ New`: `.af-app` still carried `af-nav-open`, leaving the dialog under the drawer. The test also pins that cancelling lifecycle confirms sends no mutation request.

## Verification

Final gates are running against pushed head `5c885dce51ef8cae90418982126774353cada591`; results will be posted here before merge.

Closes #2226

Authored with Captain Claude.
