### PR TITLE
test(web): exercise mobile Restore through selection

### DIFF
--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -5702,11 +5702,18 @@ test("#2226 mobile (375px): drawer dismissal follows action intent, not click pr
   await expect(p.locator(".af-filter-menu")).toBeVisible();
   await expect(app).toHaveClass(/af-nav-open/);
 
-  // Restore is the archived row's version of the same lifecycle action. It must
-  // leave the drawer too; keeping this leg in the browser guard prevents the two
-  // branches in rowActions from drifting apart.
+  // Restore is the archived row's version of the same lifecycle action. On touch,
+  // an unselected row has no hover reveal: select the now-visible archived row,
+  // let that navigation close the drawer, then reopen it so the selected-row action
+  // is exposed. This is the real phone path pinned by #2223's reveal model.
   await expect(row(p, SESSION_B)).toHaveClass(/af-row-archived/);
-  await railAction(p, SESSION_B, "Restore session").click();
+  await row(p, SESSION_B).click();
+  await expectDrawerClosed();
+  await expect(row(p, SESSION_B)).toHaveClass(/af-row-selected/);
+  await openDrawer();
+  const restore = railAction(p, SESSION_B, "Restore session");
+  await expect(restore).toBeVisible();
+  await restore.click();
   await expectDrawerClosed();
   await expect(modal).toContainText(`Restore ${SESSION_B}?`);
   await modal.getByRole("button", { name: "Cancel", exact: true }).click();


### PR DESCRIPTION
## Summary

- correct #2245's mobile Restore regression to use the touch-accessible reveal path
- after exposing archived rows, select the archived row, assert that selection dismisses the drawer, reopen it, then use the selected row's Restore action
- assert Restore is visible before clicking so a reveal regression fails directly instead of spending the test timeout retrying an intercepted click

## Evidence: test wrong, product current

This is conclusion **(a): the test was wrong**.

The failed run had already passed the archived-row assertion. Its log then resolved the current #2241-projected button:

```
<button data-action="restore" aria-label="Restore session “probe-b”">↶</button>
```

inside an archived but unselected row (`aria-selected="false"`). The row intercepted pointer events because #2223 deliberately reveals actions on selection, hover, or focus-within; a phone has no hover. The supported touch path is therefore show archived → select row → reopen drawer → Restore. The archived filter's default remains intentional and consistent across widths.

## Verification

All local gates ran after final commit `eb1a09a10c32bcecfdc736559821e81e1da33953`; that exact commit is the pushed head:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` — clean
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh` — 899 Go files, 0 grandfathered
- `make web-test` — 401 passed
- `make web-selftest-container` — 107 passed; #2226 passed in 5.2s
- `make web-build` — deterministic; committed bundle clean

GitHub's post-push Web selftest also passed on this SHA.

Follow-up to #2245 and #2226.

Authored with Captain Claude.
