### PR TITLE
fix(env): share fail-closed launch parsing

### DIFF
--- a/daemon/configagent.go
+++ b/daemon/configagent.go
@@ -296,10 +296,14 @@ func (m *Manager) SpawnConfigAgent(ctx context.Context, req SpawnConfigAgentRequ
 // configAgentCodexReceiptHome resolves the same CODEX_HOME the launched shell
 // command will give Codex. Command-local assignments win over daemon variables;
 // an unset CODEX_HOME falls back through the command-specific HOME. Relative
-// values resolve against the AF-home working directory passed to tmux.Start.
+// values resolve against the effective launch cwd, including GNU env -C.
 func configAgentCodexReceiptHome(program, workingDir string) (string, error) {
+	launch, err := tmux.CommandEnvironmentFromCommand(program, workingDir)
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve Codex receipt environment: %w", err)
+	}
 	effective := func(name string) (string, bool, error) {
-		override := tmux.EnvironmentOverrideFromCommand(program, name)
+		override := launch.Override(name)
 		if !override.Present {
 			value, set := os.LookupEnv(name)
 			return value, set, nil
@@ -313,7 +317,7 @@ func configAgentCodexReceiptHome(program, workingDir string) (string, error) {
 		if filepath.IsAbs(path) {
 			return filepath.Clean(path)
 		}
-		return filepath.Clean(filepath.Join(workingDir, path))
+		return filepath.Clean(filepath.Join(launch.WorkingDir, path))
 	}
 
 	if codexHome, set, err := effective("CODEX_HOME"); err != nil {

--- a/daemon/configagent_delivery_test.go
+++ b/daemon/configagent_delivery_test.go
@@ -128,6 +128,7 @@ func TestConfigAgentCodexInlineHomeSubmitsAndVerifiesBriefing(t *testing.T) {
 
 func TestConfigAgentCodexReceiptHome(t *testing.T) {
 	workDir := t.TempDir()
+	envChdir := t.TempDir()
 	daemonCodexHome := t.TempDir()
 	includeHome := t.TempDir()
 	t.Setenv("CODEX_HOME", daemonCodexHome)
@@ -143,8 +144,12 @@ func TestConfigAgentCodexReceiptHome(t *testing.T) {
 		{name: "inline absolute wins", program: "CODEX_HOME=/tmp/inline-codex codex", want: "/tmp/inline-codex"},
 		{name: "inline relative uses launch cwd", program: "CODEX_HOME=relative-codex codex", want: filepath.Join(workDir, "relative-codex")},
 		{name: "unset uses command home", program: "env -u CODEX_HOME HOME=/tmp/inline-home codex", want: "/tmp/inline-home/.codex"},
+		{name: "attached unset uses command home", program: "env -uCODEX_HOME HOME=/tmp/inline-home codex", want: "/tmp/inline-home/.codex"},
+		{name: "relative home uses env chdir", program: "env -C " + envChdir + " CODEX_HOME=relative-codex codex", want: filepath.Join(envChdir, "relative-codex")},
 		{name: "cleared environment without home", program: "env -i codex", wantErr: "no literal HOME fallback"},
 		{name: "dynamic path refused", program: "CODEX_HOME=$OTHER codex", wantErr: "uses shell expansion"},
+		{name: "dynamic env chdir refused", program: "env -C $OTHER CODEX_HOME=relative codex", wantErr: "use a literal value"},
+		{name: "unknown env option refused", program: "env --future-option CODEX_HOME=/tmp codex", wantErr: "unknown option"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/envcommand/envcommand.go
+++ b/internal/envcommand/envcommand.go
@@ -1,0 +1,198 @@
+// Package envcommand parses the closed subset of GNU env that Agent Factory
+// can reason about without executing it. Both tmux safety policy and receipt
+// routing use this package so option consumption cannot drift between them.
+package envcommand
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrUnsupported marks an env invocation whose effects cannot be established
+// statically. Callers must fail closed rather than guessing past this error.
+var ErrUnsupported = errors.New("unsupported env invocation")
+
+// Policy describes the one intentional consumer difference: the tmux guard
+// rejects every assignment because it cannot prove an assignment does not
+// change command resolution, while receipt routing must model literal ones.
+type Policy struct {
+	AllowAssignments bool
+}
+
+// Mutation is one ordered environment change made by env before its command.
+type Mutation struct {
+	Name  string
+	Value string
+	Unset bool
+}
+
+// Invocation is the statically known effect of one env process. CommandIndex
+// is relative to the argument slice passed to Parse, or -1 when no command was
+// present. Chdir is empty when env does not change directory.
+type Invocation struct {
+	ClearEnvironment bool
+	Chdir            string
+	Mutations        []Mutation
+	CommandIndex     int
+}
+
+// Parse recognizes a closed set of GNU env options. Split-string is rejected
+// because it performs another round of command construction; unknown options,
+// dynamic operands, missing operands, and options after assignments are also
+// rejected. This deliberately prefers an actionable refusal over silently
+// modeling a different process environment or cwd.
+func Parse(args []string, policy Policy) (Invocation, error) {
+	result := Invocation{CommandIndex: -1}
+	options := true
+	assignments := false
+	for idx := 0; idx < len(args); {
+		arg := args[idx]
+		if options {
+			switch {
+			case arg == "--":
+				options = false
+				idx++
+				continue
+			case arg == "-" || arg == "-i" || arg == "--ignore-environment":
+				result.ClearEnvironment = true
+				result.Mutations = nil
+				idx++
+				continue
+			case arg == "-0" || arg == "-v" || arg == "--null" || arg == "--debug" ||
+				arg == "--list-signal-handling" || arg == "--help" || arg == "--version":
+				idx++
+				continue
+			case arg == "-S" || strings.HasPrefix(arg, "-S") || arg == "--split-string" || strings.HasPrefix(arg, "--split-string="):
+				return result, unsupported(arg, "split-string constructs another command")
+			case arg == "-u" || arg == "--unset":
+				if idx+1 >= len(args) {
+					return result, unsupported(arg, "missing variable name")
+				}
+				name := args[idx+1]
+				if err := validateName(name); err != nil {
+					return result, err
+				}
+				result.Mutations = append(result.Mutations, Mutation{Name: name, Unset: true})
+				idx += 2
+				continue
+			case strings.HasPrefix(arg, "-u") && len(arg) > 2:
+				name := strings.TrimPrefix(arg, "-u")
+				if err := validateName(name); err != nil {
+					return result, err
+				}
+				result.Mutations = append(result.Mutations, Mutation{Name: name, Unset: true})
+				idx++
+				continue
+			case strings.HasPrefix(arg, "--unset="):
+				name := strings.TrimPrefix(arg, "--unset=")
+				if err := validateName(name); err != nil {
+					return result, err
+				}
+				result.Mutations = append(result.Mutations, Mutation{Name: name, Unset: true})
+				idx++
+				continue
+			case arg == "-C" || arg == "--chdir":
+				if idx+1 >= len(args) {
+					return result, unsupported(arg, "missing directory")
+				}
+				if err := validateNonEmptyLiteral(args[idx+1], "chdir"); err != nil {
+					return result, err
+				}
+				result.Chdir = args[idx+1]
+				idx += 2
+				continue
+			case strings.HasPrefix(arg, "-C") && len(arg) > 2:
+				dir := strings.TrimPrefix(arg, "-C")
+				if err := validateNonEmptyLiteral(dir, "chdir"); err != nil {
+					return result, err
+				}
+				result.Chdir = dir
+				idx++
+				continue
+			case strings.HasPrefix(arg, "--chdir="):
+				dir := strings.TrimPrefix(arg, "--chdir=")
+				if err := validateNonEmptyLiteral(dir, "chdir"); err != nil {
+					return result, err
+				}
+				result.Chdir = dir
+				idx++
+				continue
+			case signalOption(arg):
+				idx++
+				continue
+			case strings.HasPrefix(arg, "-"):
+				return result, unsupported(arg, "unknown option")
+			}
+		}
+
+		name, value, assignment := SplitAssignment(arg)
+		if assignment {
+			if !policy.AllowAssignments {
+				return result, unsupported(arg, "environment assignments are not allowed by this policy")
+			}
+			if err := validateLiteral(value, name); err != nil {
+				return result, err
+			}
+			assignments = true
+			options = false
+			result.Mutations = append(result.Mutations, Mutation{Name: name, Value: value})
+			idx++
+			continue
+		}
+		if assignments && strings.HasPrefix(arg, "-") {
+			return result, unsupported(arg, "option-like argument after an assignment")
+		}
+		result.CommandIndex = idx
+		return result, nil
+	}
+	return result, nil
+}
+
+// SplitAssignment recognizes an env NAME=VALUE operand. GNU env accepts names
+// beyond shell identifiers; only empty names and embedded '=' are impossible.
+func SplitAssignment(arg string) (name, value string, ok bool) {
+	name, value, ok = strings.Cut(arg, "=")
+	return name, value, ok && name != ""
+}
+
+// IsLiteral is conservative because the launch tokenizer removes quote
+// provenance. Rejecting a quoted literal '$' is preferable to interpreting an
+// expansion as a path and polling the wrong receipt store.
+func IsLiteral(value string) bool {
+	return !strings.ContainsAny(value, "$`;&|<>\n\r") && !strings.HasPrefix(value, "~")
+}
+
+func validateName(name string) error {
+	if name == "" || strings.ContainsRune(name, '=') || !IsLiteral(name) {
+		return unsupported(name, "invalid or dynamic variable name")
+	}
+	return nil
+}
+
+func validateLiteral(value, field string) error {
+	if !IsLiteral(value) {
+		return unsupported(value, fmt.Sprintf("%s uses shell expansion or control syntax; use a literal value", field))
+	}
+	return nil
+}
+
+func validateNonEmptyLiteral(value, field string) error {
+	if value == "" {
+		return unsupported(value, fmt.Sprintf("%s must not be empty", field))
+	}
+	return validateLiteral(value, field)
+}
+
+func signalOption(arg string) bool {
+	for _, option := range []string{"--block-signal", "--default-signal", "--ignore-signal"} {
+		if arg == option || strings.HasPrefix(arg, option+"=") {
+			return true
+		}
+	}
+	return false
+}
+
+func unsupported(token, reason string) error {
+	return fmt.Errorf("%w %q: %s", ErrUnsupported, token, reason)
+}

--- a/internal/envcommand/envcommand_test.go
+++ b/internal/envcommand/envcommand_test.go
@@ -1,0 +1,39 @@
+package envcommand
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   []string
+		policy Policy
+		want   Invocation
+		bad    bool
+	}{
+		{name: "attached unset", args: []string{"-uCODEX_HOME", "codex"}, want: Invocation{Mutations: []Mutation{{Name: "CODEX_HOME", Unset: true}}, CommandIndex: 1}},
+		{name: "separate unset", args: []string{"-u", "CODEX_HOME", "codex"}, want: Invocation{Mutations: []Mutation{{Name: "CODEX_HOME", Unset: true}}, CommandIndex: 2}},
+		{name: "attached chdir", args: []string{"-C/tmp", "codex"}, want: Invocation{Chdir: "/tmp", CommandIndex: 1}},
+		{name: "separate chdir", args: []string{"-C", "/tmp", "codex"}, want: Invocation{Chdir: "/tmp", CommandIndex: 2}},
+		{name: "clear assign and chdir", args: []string{"-i", "--chdir=/tmp", "HOME=/home/agent", "codex"}, policy: Policy{AllowAssignments: true}, want: Invocation{ClearEnvironment: true, Chdir: "/tmp", Mutations: []Mutation{{Name: "HOME", Value: "/home/agent"}}, CommandIndex: 3}},
+		{name: "guard rejects assignment", args: []string{"HOME=/tmp", "codex"}, bad: true},
+		{name: "resolver rejects dynamic assignment", args: []string{"HOME=$OTHER", "codex"}, policy: Policy{AllowAssignments: true}, bad: true},
+		{name: "resolver rejects dynamic chdir", args: []string{"-C", "$OTHER", "codex"}, policy: Policy{AllowAssignments: true}, bad: true},
+		{name: "reject split string", args: []string{"-S", "codex"}, bad: true},
+		{name: "reject unknown option", args: []string{"--future", "codex"}, bad: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Parse(tc.args, tc.policy)
+			if tc.bad {
+				require.ErrorIs(t, err, ErrUnsupported)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/tmuxguard/wrappers.go
+++ b/internal/tmuxguard/wrappers.go
@@ -1,62 +1,19 @@
 package tmuxguard
 
 import (
-	"fmt"
 	"strings"
-	"unicode"
+
+	"github.com/sachiniyer/agent-factory/internal/envcommand"
 )
 
 // validateEnvPrefix recognizes a closed set of GNU env options. Split-string
 // is intentionally unsupported because it performs a second round of command
 // construction; unknown spellings and future options fail closed.
 func validateEnvPrefix(words []string) error {
-	for len(words) > 0 {
-		arg := words[0]
-		switch {
-		case arg == "--":
-			return nil
-		case isAssignment(arg):
-			return errUnsupportedShell
-		case arg == "-" || arg == "-i" || arg == "-0" || arg == "-v":
-			words = words[1:]
-		case arg == "--ignore-environment" || arg == "--null" || arg == "--debug":
-			words = words[1:]
-		case arg == "--list-signal-handling" || arg == "--help" || arg == "--version":
-			words = words[1:]
-		case arg == "-S" || strings.HasPrefix(arg, "-S") || arg == "--split-string" || strings.HasPrefix(arg, "--split-string="):
-			return errUnsupportedShell
-		case arg == "-u" || arg == "-C":
-			if len(words) < 2 {
-				return errUnsupportedShell
-			}
-			words = words[2:]
-		case strings.HasPrefix(arg, "-u") || strings.HasPrefix(arg, "-C"):
-			words = words[1:]
-		case arg == "--unset" || arg == "--chdir":
-			if len(words) < 2 {
-				return errUnsupportedShell
-			}
-			words = words[2:]
-		case strings.HasPrefix(arg, "--unset=") || strings.HasPrefix(arg, "--chdir="):
-			words = words[1:]
-		case signalEnvOption(arg):
-			words = words[1:]
-		case strings.HasPrefix(arg, "-"):
-			return fmt.Errorf("%w: unknown env option", errUnsupportedShell)
-		default:
-			return nil
-		}
+	if _, err := envcommand.Parse(words, envcommand.Policy{}); err != nil {
+		return errUnsupportedShell
 	}
 	return nil
-}
-
-func signalEnvOption(arg string) bool {
-	for _, option := range []string{"--block-signal", "--default-signal", "--ignore-signal"} {
-		if arg == option || strings.HasPrefix(arg, option+"=") {
-			return true
-		}
-	}
-	return false
 }
 
 func shellCommandPayload(args []string) (string, bool, error) {
@@ -105,17 +62,4 @@ func knownShellFlags(flags string) bool {
 	return strings.IndexFunc(flags, func(flag rune) bool {
 		return !strings.ContainsRune("abefhkmnprstuvxBCEHPT", flag)
 	}) == -1
-}
-
-func isAssignment(word string) bool {
-	eq := strings.IndexByte(word, '=')
-	if eq <= 0 {
-		return false
-	}
-	for i, r := range word[:eq] {
-		if (i == 0 && !unicode.IsLetter(r) && r != '_') || (i > 0 && !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_') {
-			return false
-		}
-	}
-	return true
 }

--- a/session/tmux/environment.go
+++ b/session/tmux/environment.go
@@ -1,12 +1,18 @@
 package tmux
 
-import "strings"
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"unicode"
+
+	"github.com/sachiniyer/agent-factory/internal/envcommand"
+)
 
 // CommandEnvOverride describes how a shell command changes one environment
 // variable before the detected agent executable. Present=false means the child
-// inherits the daemon value. Present=true with Set=false means wrappers such as
-// `env -u NAME` or `env -i` remove it. Literal=false means shell expansion makes
-// the effective value unknowable without executing the command.
+// inherits the daemon value. Present=true with Set=false means env -u/-i removes
+// it. Values returned from a successful parse are always literal.
 type CommandEnvOverride struct {
 	Value   string
 	Present bool
@@ -14,65 +20,135 @@ type CommandEnvOverride struct {
 	Literal bool
 }
 
-// EnvironmentOverrideFromCommand finds the last command-local change to name
-// before the agent token. It covers leading shell assignment words and the env
-// forms that change inheritance. This deliberately shares splitShellTokens and
-// findAgentToken with agent detection: receipt routing must interpret the exact
-// command through the same lexical model as launch routing (#2228 review).
-func EnvironmentOverrideFromCommand(command, name string) CommandEnvOverride {
+// CommandEnvironment is the statically resolved launch context at the agent
+// executable. It carries environment changes and cwd together because GNU env
+// can change both in one invocation; resolving either in isolation recreates
+// the receipt-routing drift this model exists to prevent.
+type CommandEnvironment struct {
+	WorkingDir     string
+	clearInherited bool
+	overrides      map[string]CommandEnvOverride
+}
+
+// Override reports the final command-local state of name.
+func (e CommandEnvironment) Override(name string) CommandEnvOverride {
+	if override, ok := e.overrides[name]; ok {
+		return override
+	}
+	if e.clearInherited {
+		return CommandEnvOverride{Present: true, Literal: true}
+	}
+	return CommandEnvOverride{}
+}
+
+// CommandEnvironmentFromCommand resolves the environment and cwd inherited by
+// the first detected agent token. Every GNU env invocation is parsed by the
+// same closed-set parser used by internal/tmuxguard. The only policy difference
+// is explicit: receipt routing models literal assignments, while the guard
+// rejects all assignments because they may alter executable resolution.
+//
+// Unknown options, split-string, dynamic values/chdirs, misplaced assignments,
+// and an agent token consumed as an env operand return an error. Receipt callers
+// must surface that error and abort rather than polling a guessed path.
+func CommandEnvironmentFromCommand(command, workingDir string) (CommandEnvironment, error) {
 	tokens, _ := splitShellTokens(command)
 	agentIdx, agent := findAgentToken(tokens)
-	if agent == "" {
-		return CommandEnvOverride{}
+	result := CommandEnvironment{
+		WorkingDir: filepath.Clean(workingDir),
+		overrides:  make(map[string]CommandEnvOverride),
 	}
-	var result CommandEnvOverride
-	inEnv := false
-	for idx := 0; idx < agentIdx; idx++ {
+	if !filepath.IsAbs(workingDir) {
+		return result, fmt.Errorf("launch directory %q is not absolute; cannot resolve relative receipt paths", workingDir)
+	}
+	if agent == "" {
+		return result, fmt.Errorf("could not find a supported agent executable")
+	}
+
+	atShellPrefix := true
+	for idx := 0; idx < agentIdx; {
 		tok := tokens[idx]
 		if strings.EqualFold(baseCommand(tok), "env") {
-			inEnv = true
-			continue
-		}
-		if key, value, ok := strings.Cut(tok, "="); ok && key == name {
-			result = CommandEnvOverride{
-				Value: value, Present: true, Set: true, Literal: literalEnvironmentValue(value),
+			invocation, err := envcommand.Parse(tokens[idx+1:], envcommand.Policy{AllowAssignments: true})
+			if err != nil {
+				return result, fmt.Errorf("cannot resolve env invocation before %s: %w", agent, err)
 			}
-			continue
-		}
-		if !inEnv {
-			continue
-		}
-		switch {
-		case tok == "-i" || tok == "--ignore-environment" || tok == "-":
-			result = CommandEnvOverride{Present: true, Literal: true}
-		case tok == "-u" || tok == "--unset":
-			if idx+1 < agentIdx {
-				idx++
-				if tokens[idx] == name {
-					result = CommandEnvOverride{Present: true, Literal: true}
+			if invocation.CommandIndex < 0 {
+				return result, fmt.Errorf("cannot resolve env invocation before %s: env has no command", agent)
+			}
+			commandIdx := idx + 1 + invocation.CommandIndex
+			if commandIdx > agentIdx {
+				return result, fmt.Errorf("cannot resolve env invocation before %s: the agent token is an option operand, not env's command", agent)
+			}
+			if invocation.ClearEnvironment {
+				result.clearInherited = true
+				clear(result.overrides)
+			}
+			for _, mutation := range invocation.Mutations {
+				if mutation.Unset {
+					result.overrides[mutation.Name] = CommandEnvOverride{Present: true, Literal: true}
+				} else {
+					result.overrides[mutation.Name] = CommandEnvOverride{
+						Value: mutation.Value, Present: true, Set: true, Literal: true,
+					}
 				}
 			}
-		case strings.HasPrefix(tok, "--unset="):
-			if strings.TrimPrefix(tok, "--unset=") == name {
-				result = CommandEnvOverride{Present: true, Literal: true}
+			if invocation.Chdir != "" {
+				resolved, err := resolveCommandDir(result.WorkingDir, invocation.Chdir)
+				if err != nil {
+					return result, err
+				}
+				result.WorkingDir = resolved
 			}
+			idx = commandIdx
+			atShellPrefix = false
+			continue
+		}
+
+		if name, value, ok := shellAssignment(tok); ok {
+			if !atShellPrefix {
+				return result, fmt.Errorf("cannot resolve assignment %q after a command wrapper; use env with literal options and assignments", tok)
+			}
+			if !envcommand.IsLiteral(value) {
+				return result, fmt.Errorf("%s uses shell expansion; use a literal value so receipt verification can follow it", name)
+			}
+			result.overrides[name] = CommandEnvOverride{Value: value, Present: true, Set: true, Literal: true}
+			idx++
+			continue
+		}
+
+		atShellPrefix = false
+		idx++
+	}
+	return result, nil
+}
+
+func resolveCommandDir(current, requested string) (string, error) {
+	if filepath.IsAbs(requested) {
+		return filepath.Clean(requested), nil
+	}
+	if strings.TrimSpace(current) == "" || current == "." {
+		return "", fmt.Errorf("cannot resolve relative env chdir %q without an absolute launch directory", requested)
+	}
+	return filepath.Clean(filepath.Join(current, requested)), nil
+}
+
+func shellAssignment(token string) (name, value string, ok bool) {
+	name, value, ok = envcommand.SplitAssignment(token)
+	if !ok {
+		return "", "", false
+	}
+	for idx, r := range name {
+		if (idx == 0 && !unicode.IsLetter(r) && r != '_') ||
+			(idx > 0 && !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_') {
+			return "", "", false
 		}
 	}
-	return result
+	return name, value, true
 }
 
 func baseCommand(token string) string {
-	if slash := strings.LastIndexAny(token, `/\\`); slash >= 0 {
+	if slash := strings.LastIndexAny(token, `/\`); slash >= 0 {
 		return token[slash+1:]
 	}
 	return token
-}
-
-// literalEnvironmentValue is conservative because splitShellTokens removes
-// quote provenance. Values requiring expansion cannot be reproduced safely in
-// the daemon process; callers must fail loudly instead of inspecting the wrong
-// receiver store. Spaces are fine (they necessarily came from quoting), while
-// expansion/control metacharacters are not.
-func literalEnvironmentValue(value string) bool {
-	return !strings.ContainsAny(value, "$`;&|<>\n\r") && !strings.HasPrefix(value, "~")
 }

--- a/session/tmux/environment_test.go
+++ b/session/tmux/environment_test.go
@@ -1,31 +1,59 @@
 package tmux
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestEnvironmentOverrideFromCommand(t *testing.T) {
+func TestCommandEnvironmentFromCommand(t *testing.T) {
+	workDir := filepath.Join(string(filepath.Separator), "launch")
 	tests := []struct {
 		name    string
 		command string
 		key     string
 		want    CommandEnvOverride
+		wantDir string
+		launch  string
+		wantErr string
 	}{
 		{name: "leading assignment", command: "CODEX_HOME='/tmp/codex home' codex", key: "CODEX_HOME", want: CommandEnvOverride{Value: "/tmp/codex home", Present: true, Set: true, Literal: true}},
 		{name: "env assignment", command: "/usr/bin/env CODEX_HOME=/tmp/one codex", key: "CODEX_HOME", want: CommandEnvOverride{Value: "/tmp/one", Present: true, Set: true, Literal: true}},
 		{name: "last assignment wins", command: "CODEX_HOME=/tmp/one CODEX_HOME=/tmp/two codex", key: "CODEX_HOME", want: CommandEnvOverride{Value: "/tmp/two", Present: true, Set: true, Literal: true}},
 		{name: "unset separate", command: "env -u CODEX_HOME codex", key: "CODEX_HOME", want: CommandEnvOverride{Present: true, Literal: true}},
-		{name: "unset attached", command: "env --unset=CODEX_HOME codex", key: "CODEX_HOME", want: CommandEnvOverride{Present: true, Literal: true}},
+		{name: "unset attached short", command: "env -uCODEX_HOME codex", key: "CODEX_HOME", want: CommandEnvOverride{Present: true, Literal: true}},
+		{name: "unset attached long", command: "env --unset=CODEX_HOME codex", key: "CODEX_HOME", want: CommandEnvOverride{Present: true, Literal: true}},
 		{name: "clear then restore", command: "env -i HOME=/tmp/isolated codex", key: "HOME", want: CommandEnvOverride{Value: "/tmp/isolated", Present: true, Set: true, Literal: true}},
 		{name: "clear inherited variable", command: "env -i HOME=/tmp/isolated codex", key: "CODEX_HOME", want: CommandEnvOverride{Present: true, Literal: true}},
-		{name: "dynamic value unknown", command: "CODEX_HOME=$ALT_CODEX_HOME codex", key: "CODEX_HOME", want: CommandEnvOverride{Value: "$ALT_CODEX_HOME", Present: true, Set: true, Literal: false}},
-		{name: "inherited", command: "ionice -c 3 codex", key: "CODEX_HOME", want: CommandEnvOverride{}},
+		{name: "chdir separate", command: "env -C /tmp codex", key: "CODEX_HOME", wantDir: "/tmp"},
+		{name: "chdir attached", command: "env -Crelative codex", key: "CODEX_HOME", wantDir: filepath.Join(workDir, "relative")},
+		{name: "nested env cwd", command: "env -C /tmp env -C child CODEX_HOME=rel codex", key: "CODEX_HOME", want: CommandEnvOverride{Value: "rel", Present: true, Set: true, Literal: true}, wantDir: "/tmp/child"},
+		{name: "inherited", command: "ionice -c 3 codex", key: "CODEX_HOME"},
+		{name: "dynamic value refused", command: "CODEX_HOME=$ALT_CODEX_HOME codex", key: "CODEX_HOME", wantErr: "uses shell expansion"},
+		{name: "dynamic chdir refused", command: "env -C $OTHER codex", key: "CODEX_HOME", wantErr: "unsupported env invocation"},
+		{name: "unknown env option refused", command: "env --future-option codex", key: "CODEX_HOME", wantErr: "unknown option"},
+		{name: "split string refused", command: "env -S CODEX_HOME=/tmp codex", key: "CODEX_HOME", wantErr: "split-string"},
+		{name: "relative launch directory refused", command: "codex", key: "CODEX_HOME", launch: "relative", wantErr: "launch directory"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.want, EnvironmentOverrideFromCommand(tc.command, tc.key))
+			launchDir := workDir
+			if tc.launch != "" {
+				launchDir = tc.launch
+			}
+			got, err := CommandEnvironmentFromCommand(tc.command, launchDir)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got.Override(tc.key))
+			wantDir := tc.wantDir
+			if wantDir == "" {
+				wantDir = workDir
+			}
+			require.Equal(t, wantDir, got.WorkingDir)
 		})
 	}
 }


### PR DESCRIPTION
## Outcome

GNU `env` is now parsed by one closed-set implementation for both tmux safety policy and config-agent receipt routing. The shared model consumes option operands once, carries environment mutations and effective cwd together, handles `-uNAME` and every supported `-C` spelling, and rejects unknown, split-string, dynamic, or otherwise unresolvable forms instead of polling a guessed receipt path.

The policy difference is explicit: tmuxguard rejects all assignments because they can change executable resolution; receipt routing permits literal assignments because it must model `CODEX_HOME` and `HOME`. Both fail closed on everything outside the supported grammar.

## Fail-first regressions

- `env -uCODEX_HOME HOME=/tmp/inline-home codex` previously inherited daemon `CODEX_HOME`; it now resolves `/tmp/inline-home/.codex`.
- `env -C <dir> CODEX_HOME=relative-codex codex` previously resolved under the tmux start directory; it now resolves under `<dir>`.
- Unknown options, dynamic chdirs, split-string, relative launch roots, and dynamic assignments now return actionable errors before receipt polling.

## Validation

Against pushed head `cbf24353f9e4a9171a09ef8357150c5d9b5a8ac8` rebased on current master:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- targeted race suite for envcommand, tmuxguard, tmux, and daemon

All pass.

— Captain Claude