### PR TITLE
fix(bugreport): make title scrubbing deterministic

### DIFF
--- a/bugreport/bugreport.go
+++ b/bugreport/bugreport.go
@@ -153,8 +153,14 @@ func Build(in Inputs) (Result, error) {
 		bundlePath:  in.BundlePath,
 	}
 
-	b.Tasks, b.Errors = collectTasks(r, b.Errors)
+	// Task statuses can mention a historical target that differs from the
+	// task's current TargetSession. Keep raw tasks local until instances have
+	// registered every persisted title, then sanitize all task statuses against
+	// the complete known-title set. No raw task enters Bundle.
+	tasks, errs := loadTasksForRedaction(b.Errors)
+	b.Errors = errs
 	b.Instances, b.Errors = collectInstances(r, b.Errors)
+	b.Tasks = r.redactTasks(tasks)
 	b.Config, b.Errors = collectConfig(r, b.Errors)
 	b.Log, b.Errors = collectLog(r, b.Errors)
 
@@ -498,17 +504,14 @@ func countInstances(repos []repoInstances) int {
 	return total
 }
 
-// collectTasks loads and redacts the configured tasks.
-func collectTasks(r *redactor, errs []string) ([]redactedTask, []string) {
+// loadTasksForRedaction keeps raw tasks out of Bundle while allowing Build to
+// discover instance titles before task statuses are sanitized.
+func loadTasksForRedaction(errs []string) ([]task.Task, []string) {
 	tasks, err := task.LoadTasks()
 	if err != nil {
 		return nil, append(errs, fmt.Sprintf("tasks: %v", err))
 	}
-	out := make([]redactedTask, 0, len(tasks))
-	for _, t := range tasks {
-		out = append(out, r.redactTask(t))
-	}
-	return out, errs
+	return tasks, errs
 }
 
 // collectInstances loads every repo's instances.json and redacts each, sorted

--- a/bugreport/bugreport_test.go
+++ b/bugreport/bugreport_test.go
@@ -262,6 +262,110 @@ func TestRedactTaskScrubsTargetFromFailedRunStatus(t *testing.T) {
 	mustContain(t, "last_run_status", got.LastRunStatus, "errored:", "connection reset", redactedMarker)
 }
 
+// A task edit preserves LastRunStatus, so its historical target can differ from
+// its current TargetSession. Build must discover every instance/task title
+// before it sanitizes any status; collecting instances later leaves this title
+// in the text and JSON bundles even though instances.json still knows it.
+func TestBuildScrubsHistoricalTaskTargetAfterEdit(t *testing.T) {
+	const (
+		historicalTarget = "HistoricalConfidentialTarget"
+		currentTarget    = "Current Target"
+	)
+	home := t.TempDir()
+	afHome := filepath.Join(home, ".agent-factory")
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_FACTORY_HOME", afHome)
+
+	instances, err := json.Marshal([]session.InstanceData{{
+		ID:    "legacy-instance",
+		Title: historicalTarget,
+	}})
+	if err != nil {
+		t.Fatalf("marshal instances: %v", err)
+	}
+	instDir := filepath.Join(afHome, "instances", "testrepo")
+	if err := os.MkdirAll(instDir, 0o755); err != nil {
+		t.Fatalf("create instances directory: %v", err)
+	}
+	writeFile(t, filepath.Join(instDir, "instances.json"), string(instances))
+
+	status := fmt.Sprintf("errored: failed to deliver prompt to target session %q: connection reset", historicalTarget)
+	tasks, err := json.Marshal([]task.Task{{
+		ID:            "edited-task",
+		TargetSession: currentTarget,
+		LastRunStatus: status,
+	}})
+	if err != nil {
+		t.Fatalf("marshal tasks: %v", err)
+	}
+	writeFile(t, filepath.Join(afHome, "tasks.json"), string(tasks))
+
+	res, err := Build(Inputs{AFVersion: "test", GeneratedAt: "now"})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	for surface, out := range map[string]string{
+		"text": res.Text,
+		"json": string(res.JSON),
+	} {
+		mustContain(t, surface, out, "edited-task", "connection reset")
+		mustNotContain(t, surface, out, historicalTarget, fmt.Sprintf("%q", historicalTarget))
+	}
+}
+
+// Punctuation-only titles are legal. They must still be redacted when emitted
+// as %q or as a bare title token, without turning every path separator or period
+// in the rest of the diagnostic bundle into a redaction marker.
+func TestScrubLogRedactsPunctuationTitleWithoutDestroyingDiagnostics(t *testing.T) {
+	r := &redactor{}
+	r.noteTitle(".")
+	r.noteTitle("/")
+	in := strings.Join([]string{
+		`version 1.2.3 at /tmp/agent-factory.log via https://example.test/api`,
+		`task t1 delivered prompt to target session "." (sent)`,
+		`task t1 delivered prompt to target session "/" (sent)`,
+		`task t2 started successfully as instance .`,
+		`task t3 parked at a usage limit as instance /; waiting for the limit window to reset`,
+	}, "\n")
+
+	out := r.scrubLog(in)
+
+	mustContain(t, "daemon log", out,
+		"version 1.2.3", "/tmp/agent-factory.log", "https://example.test/api",
+		`target session "[redacted]"`, "instance [redacted]",
+		"instance [redacted]; waiting for the limit window to reset")
+	mustNotContain(t, "daemon log", out,
+		`target session "."`, `target session "/"`, "instance .", "instance /;")
+}
+
+// A shorter title must never destroy the prefix of a longer title before that
+// longer secret is considered. Map iteration is randomized, so exercise the
+// sanitizer repeatedly: any surviving suffix is a privacy leak.
+func TestScrubSessionTitlesRedactsOverlappingTitlesDeterministically(t *testing.T) {
+	r := &redactor{}
+	r.noteTitle("VIP")
+	r.noteTitle("VIP migration")
+
+	for i := 0; i < 256; i++ {
+		out := r.scrubSessionTitles(`started VIP migration for target session "VIP migration"`)
+		if strings.Contains(out, "VIP") || strings.Contains(out, "migration") {
+			t.Fatalf("overlapping title leaked on pass %d: %q", i, out)
+		}
+	}
+}
+
+func TestScrubSessionTitlesDoesNotRewriteItsOwnMarker(t *testing.T) {
+	r := &redactor{}
+	r.noteTitle("Confidential migration")
+	r.noteTitle("redacted")
+
+	once := r.scrubSessionTitles(`target session "Confidential migration"`)
+	twice := r.scrubSessionTitles(once)
+	if once != `target session "[redacted]"` || twice != once {
+		t.Fatalf("title scrub rewrote its own marker: once=%q twice=%q", once, twice)
+	}
+}
+
 // TestRedactInstanceDataRedactsNonLoopbackWebTabURL pins the #1954 fix: a web
 // tab's URL is user-supplied (any http/https target passes NormalizeWebTabURL)
 // and can name internal infrastructure or a private repo, exactly the class of

--- a/bugreport/redact.go
+++ b/bugreport/redact.go
@@ -6,8 +6,11 @@ import (
 	"os/user"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/task"
@@ -78,6 +81,16 @@ var privateKeyBlock = regexp.MustCompile(`(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY--
 // truncating a real title mid-way and leaving a fragment behind. Keys on the
 // name *shape*, so it scrubs archived/killed sessions no live set still knows.
 var afTmuxSessionName = regexp.MustCompile(`af_[0-9a-f]{8}_[^\s:]+`)
+
+// taskStartedInstanceTitle and taskParkedInstanceTitle are the only daemon log
+// shapes that render a raw session title with %s rather than %q. Match the field
+// by its fixed surrounding syntax so punctuation-only legal titles can be
+// removed without treating "." or "/" as a global search pattern. The parked
+// form keeps its diagnostic suffix; the started form owns the rest of its line.
+var (
+	taskStartedInstanceTitle = regexp.MustCompile(`(?m)(task \S+ started successfully as instance )[^\r\n]+$`)
+	taskParkedInstanceTitle  = regexp.MustCompile(`(?m)(task \S+ parked at a usage limit as instance )(.+)(; waiting for the limit window to reset)$`)
+)
 
 // redactor holds the per-run redaction context — the home directory to
 // collapse to "~" and the username token(s) to blank to "[user]" — resolved
@@ -179,21 +192,40 @@ func (r *redactor) scrubLog(s string) string {
 			s = strings.ReplaceAll(s, name, tmuxPrefixMarker)
 		}
 	}
+	// taskrun.go has two raw %s title emitters. Their syntax is a safer
+	// boundary than a global punctuation matcher and also catches historical
+	// task-created titles no longer present in instances.json.
+	s = taskStartedInstanceTitle.ReplaceAllString(s, `${1}`+redactedMarker)
+	s = taskParkedInstanceTitle.ReplaceAllString(s, `${1}`+redactedMarker+`${3}`)
 	return r.scrubUnstructured(s)
 }
 
 // scrubSessionTitles removes exact Go-quoted forms of every known title, then
-// applies the conservative bare-title matcher. The quoted form is the important
-// invariant for task targets: daemon delivery logs and persisted delivery errors
-// both format them with %q. Matching strconv.Quote therefore covers every legal
-// title byte-for-byte, including short names that are unsafe to replace as bare
-// words and quotes/backslashes that %q escapes (#2238 review).
+// applies the conservative word-bearing bare-title matcher. The quoted form is
+// the important invariant for task targets: daemon delivery logs and persisted
+// delivery errors both format them with %q. Matching strconv.Quote therefore
+// covers every legal title byte-for-byte, including short names and punctuation
+// that are unsafe to replace globally, plus quotes/backslashes that %q escapes
+// (#2238 review). scrubLog handles the two actual raw punctuation emitters by
+// their fixed field syntax.
 func (r *redactor) scrubSessionTitles(s string) string {
+	titles := make([]string, 0, len(r.titles))
 	for title := range r.titles {
-		s = strings.ReplaceAll(s, strconv.Quote(title), strconv.Quote(redactedMarker))
-		if re := bareTitleRegexp(title); re != nil {
-			s = re.ReplaceAllString(s, redactedMarker)
+		titles = append(titles, title)
+	}
+	// A shorter title may be a prefix of a longer one. Redacting the prefix
+	// first destroys the only exact match for the longer secret and leaves its
+	// suffix behind, so the order is part of the privacy invariant. The lexical
+	// tie-break makes output deterministic even though titles are stored in a map.
+	sort.Slice(titles, func(i, j int) bool {
+		if len(titles[i]) != len(titles[j]) {
+			return len(titles[i]) > len(titles[j])
 		}
+		return titles[i] < titles[j]
+	})
+	for _, title := range titles {
+		s = strings.ReplaceAll(s, strconv.Quote(title), strconv.Quote(redactedMarker))
+		s = replaceBareTitle(s, title)
 	}
 	return s
 }
@@ -209,46 +241,97 @@ func redactAFTmuxTitle(match string) string {
 	return match[:12] + redactedMarker
 }
 
-// bareTitleRegexp compiles a boundary-anchored matcher for any non-empty bare
-// session title. Short titles can collide with ordinary words, but silently
-// publishing a known secret is worse than losing some diagnostic prose. Exact
-// Go-quoted matching above handles the common short-title path without that
-// collateral; this matcher closes raw %s-style log paths too (#2238 review).
+// replaceBareTitle removes a title only when it occupies a complete text token.
+// The logger's raw %s form is always delimited by surrounding prose/newlines, so
+// this covers that representation without compiling punctuation-only titles
+// such as "." or "/" into an unbounded regexp that erases every period or path
+// separator in the bundle. Exact %q forms are handled above before this pass.
 //
-// A `\b` anchor is only emitted on the edge where the title's own boundary
-// character is a word char ([A-Za-z0-9_]); `\b` matches only at a word↔non-word
-// transition, so anchoring an edge whose title char is itself non-word (e.g. the
-// trailing `]` of "client[prod]") never matches and the title leaks (#1639). The
-// per-edge anchor still guards word-char edges against partial-word mangling
-// (title "test" won't match inside "testing") while a non-word edge is already
-// self-delimiting and needs no anchor.
-func bareTitleRegexp(title string) *regexp.Regexp {
+// A token boundary means start/end of text or a neighboring rune that is not a
+// letter, number, combining mark, or underscore. Checking both edges regardless
+// of the title's own first/last character handles titles such as "client[prod]"
+// while refusing to match "." inside "1.2" or "/" inside "repo/path".
+func replaceBareTitle(s, title string) string {
 	title = strings.TrimSpace(title)
-	if title == "" {
-		return nil
+	if title == "" || !containsWordRune(title) {
+		return s
 	}
-	var left, right string
-	if isWordByte(title[0]) {
-		left = `\b`
+	var out strings.Builder
+	scan, copied := 0, 0
+	changed := false
+	for scan <= len(s)-len(title) {
+		rel := strings.Index(s[scan:], title)
+		if rel < 0 {
+			break
+		}
+		start := scan + rel
+		end := start + len(title)
+		if titleTokenBoundary(s, start, end) && !insideRedactionMarker(s, start, end) {
+			out.WriteString(s[copied:start])
+			out.WriteString(redactedMarker)
+			copied = end
+			scan = end
+			changed = true
+			continue
+		}
+		// Advance one byte past this rejected occurrence. strings.Index remains
+		// byte-based too, so this cannot skip a later exact byte sequence.
+		scan = start + 1
 	}
-	if isWordByte(title[len(title)-1]) {
-		right = `\b`
+	if !changed {
+		return s
 	}
-	re, err := regexp.Compile(left + regexp.QuoteMeta(title) + right)
-	if err != nil {
-		return nil
-	}
-	return re
+	out.WriteString(s[copied:])
+	return out.String()
 }
 
-// isWordByte reports whether b is a regex word character ([A-Za-z0-9_]), i.e. a
-// byte across which `\b` forms a boundary. ASCII-only, matching RE2's default
-// `\b` semantics.
-func isWordByte(b byte) bool {
-	return b == '_' ||
-		(b >= 'a' && b <= 'z') ||
-		(b >= 'A' && b <= 'Z') ||
-		(b >= '0' && b <= '9')
+func titleTokenBoundary(s string, start, end int) bool {
+	if start > 0 {
+		r, _ := utf8.DecodeLastRuneInString(s[:start])
+		if isWordRune(r) {
+			return false
+		}
+	}
+	if end < len(s) {
+		r, _ := utf8.DecodeRuneInString(s[end:])
+		if isWordRune(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func isWordRune(r rune) bool {
+	return r == '_' || unicode.IsLetter(r) || unicode.IsNumber(r) || unicode.IsMark(r)
+}
+
+func containsWordRune(s string) bool {
+	for _, r := range s {
+		if isWordRune(r) {
+			return true
+		}
+	}
+	return false
+}
+
+// insideRedactionMarker keeps the title sanitizer idempotent when a legal title
+// is itself "redacted", "secret", or another substring of a marker emitted by
+// an earlier title. Such a match is already inside public replacement text; it
+// must not grow the marker or destroy its recognizable shape.
+func insideRedactionMarker(s string, start, end int) bool {
+	for _, marker := range []string{redactedMarker, secretMarker, userMarker} {
+		first := start - len(marker) + 1
+		if first < 0 {
+			first = 0
+		}
+		for candidate := first; candidate <= start; candidate++ {
+			markerEnd := candidate + len(marker)
+			if markerEnd >= end && markerEnd <= len(s) && s[candidate:markerEnd] == marker {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // noteSession records a session's tmux name(s) and raw title(s) before they are
@@ -604,4 +687,18 @@ func (r *redactor) redactTask(t task.Task) redactedTask {
 		rt.WatchCmd = redactedMarker
 	}
 	return rt
+}
+
+// redactTasks first registers every current task target, then creates the
+// secret-free projections. The two passes make task order irrelevant: one
+// task's historical status may mention another task's current target.
+func (r *redactor) redactTasks(tasks []task.Task) []redactedTask {
+	for _, t := range tasks {
+		r.noteTitle(t.TargetSession)
+	}
+	out := make([]redactedTask, 0, len(tasks))
+	for _, t := range tasks {
+		out = append(out, r.redactTask(t))
+	}
+	return out
 }


### PR DESCRIPTION
## Summary

- defer task projection until every persisted instance title and every current task target has been registered
- sort known titles longest-first before any destructive replacement
- protect punctuation-only titles through exact `%q` matching and the fixed syntax of the only two raw `%s` title log fields, preserving unrelated paths, URLs, and punctuation

This is one shared-root follow-up to the three legitimate late P2 findings on #2244. On shipped master `e5682f78`, task projection ran before instance discovery at [`bugreport/bugreport.go:156-157`](https://github.com/sachiniyer/agent-factory/blob/e5682f78b1642f281bc2866969211fd30e624c13/bugreport/bugreport.go#L156-L157), title replacement iterated an unordered map at [`bugreport/redact.go:192-195`](https://github.com/sachiniyer/agent-factory/blob/e5682f78b1642f281bc2866969211fd30e624c13/bugreport/redact.go#L192-L195), and punctuation-only titles compiled without boundaries at [`bugreport/redact.go:225-237`](https://github.com/sachiniyer/agent-factory/blob/e5682f78b1642f281bc2866969211fd30e624c13/bugreport/redact.go#L225-L237).

The fix changes the construction and ordering of the redaction set rather than patching three outputs. Raw tasks stay local until instance discovery completes, `redactedTask` remains secret-free, task targets are registered in a first pass, and every consumer receives one deterministic ordered title set.

## Fail-first evidence

All three focused regressions failed against shipped master before implementation:

- an edited task retained `HistoricalConfidentialTarget` in text and JSON because only the later instance record knew that title
- registering `.` erased `1.2.3` and `/tmp/agent-factory.log`
- overlapping `VIP` / `VIP migration` titles left `migration` behind depending on map iteration

The regressions now pass, including `.` and `/` in both `%q` and the two real raw task log forms.

## Verification

Full gates run after the final commit on pushed SHA `95f3436fcded11e96c22e38c89ba96a1f71c4027`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh` (`899 Go files checked; 0 grandfathered`)

— Captain Claude