### PR TITLE
fix(kill): match warnings to cleanup targets

### DIFF
--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -202,18 +202,20 @@ func (m *home) handleKill() (tea.Model, tea.Cmd) {
 		// GetGitWorktree), so a session that HAS a
 		// worktree but was never started — e.g. a restore-failed session — still gets
 		// the unmerged-work warning the old GetGitWorktree gate skipped for it
-		// (#2029). Killing force-deletes its branch either way, so the same committed
-		// work is at stake; the dirty-worktree check was already ungated, and the two
-		// must not diverge.
-		if wt := selected.GetWorktreePath(); wt != "" {
+		// (#2029). The cleanup-impact snapshot is the authority for ownership:
+		// external worktrees survive kill, and a reused user branch survives even
+		// when its linked worktree does not.
+		impact, hasWorktree := selected.GetWorktreeCleanupImpact()
+		if hasWorktree && impact.RemoveWorktree && impact.Path != "" {
+			wt := impact.Path
 			if w := killConfirmationWarning(wt); w != "" {
 				warnings = append(warnings, w)
 			}
 			prState := ""
-			if pr := selected.GetPRInfo(); pr != nil {
+			if pr := selected.GetPRInfo(); pr != nil && pr.Branch == impact.Branch {
 				prState = pr.State
 			}
-			if line, severe := unmergedCommitWarning(wt, selected.GetWorktreeBranch(), selected.GetBaseCommitSHA(), prState); line != "" {
+			if line, severe := unmergedCommitWarning(wt, impact.Branch, impact.BaseCommitSHA, prState, impact.DeleteBranch); line != "" {
 				if severe {
 					severeLine = line
 				} else {
@@ -234,7 +236,7 @@ func (m *home) handleKill() (tea.Model, tea.Cmd) {
 		// elaboration — goes in the clippable detail.
 		critical := killConfirmMessage(selectedTitle, joinWarnings(append([]string{severeLine}, warnings...)), reserved)
 		archiveKey := keys.GlobalKeyBindings[keys.KeyArchive].Help().Key
-		detail := fmt.Sprintf("Archive (%s) keeps the branch to restore later — kill removes it for good.", archiveKey)
+		detail := fmt.Sprintf("Archive (%s) preserves the worktree and its refs — kill removes the worktree for good.", archiveKey)
 		cmd := m.confirmActionWithDetail(critical, detail, killAction)
 		if m.confirmationOverlay != nil {
 			m.confirmationOverlay.SetConfirmKey(unmergedKillConfirmKey)

--- a/app/home_update.go
+++ b/app/home_update.go
@@ -113,7 +113,7 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// branch-specific, so applying a branch-X result to a branch-Y
 		// instance would show the wrong PR badge and persist it. Gate the
 		// apply on the captured branch still matching the resolved target.
-		if target.GetBranch() != msg.branch {
+		if target.GetWorktreeBranch() != msg.branch {
 			return m, nil
 		}
 		if msg.err != nil {
@@ -136,6 +136,7 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				Title:  msg.info.Title,
 				URL:    msg.info.URL,
 				State:  msg.info.State,
+				Branch: msg.info.Branch,
 			}
 		}
 		saveStart := time.Now()

--- a/app/kill_confirm.go
+++ b/app/kill_confirm.go
@@ -182,7 +182,7 @@ func killConfirmationWarning(wt string) string {
 // not whichever branch the agent has left checked out at HEAD. The fully
 // qualified local ref must resolve before an empty warning can be returned;
 // missing or unverifiable deletion targets fail closed (#2199).
-func unmergedCommitWarning(worktreePath, branchName, recordedBaseSHA, prState string) (string, bool) {
+func unmergedCommitWarning(worktreePath, branchName, recordedBaseSHA, prState string, deleteBranch bool) (string, bool) {
 	if strings.TrimSpace(worktreePath) == "" {
 		return unmergedFailClosedLine(branchName, fmt.Errorf("no worktree path")), false
 	}
@@ -201,12 +201,18 @@ func unmergedCommitWarning(worktreePath, branchName, recordedBaseSHA, prState st
 	}
 	branchResult := make(chan warningResult, 1)
 	detachedResult := make(chan warningResult, 1)
+	if deleteBranch {
+		go func() {
+			line, severe := branchCommitWarning(worktreePath, branchName, recordedBaseSHA, prState)
+			branchResult <- warningResult{line: line, severe: severe}
+		}()
+	} else {
+		// Cleanup preserves a user-owned branch, so commits reachable from that
+		// ref survive. Only worktree-private reachability remains at risk.
+		branchResult <- warningResult{}
+	}
 	go func() {
-		line, severe := branchCommitWarning(worktreePath, branchName, recordedBaseSHA, prState)
-		branchResult <- warningResult{line: line, severe: severe}
-	}()
-	go func() {
-		line, severe := detachedHeadCommitWarning(worktreePath)
+		line, severe := detachedHeadCommitWarning(worktreePath, branchName, deleteBranch)
 		detachedResult <- warningResult{line: line, severe: severe}
 	}()
 	branch, detached := <-branchResult, <-detachedResult
@@ -266,13 +272,11 @@ func branchCommitWarning(worktreePath, branchName, recordedBaseSHA, prState stri
 	return unmergedSevereLine(branchName, localOnly, baseLabel), true
 }
 
-// detachedHeadCommitWarning reports commits that would lose their final ref
-// when the worktree is removed. `for-each-ref --contains=HEAD` asks the exact
-// durability question across every ref namespace (branches, remotes, tags,
-// stash, and custom refs) without guessing which namespaces a user relies on.
-// Empty output while HEAD is detached proves its tip is unreferenced; at least
-// that tip is then orphaned by cleanup even when the recorded branch is clean.
-func detachedHeadCommitWarning(worktreePath string) (string, bool) {
+// detachedHeadCommitWarning reports commits that lose their final surviving ref
+// when cleanup runs. Per-worktree refs disappear with the linked worktree, and
+// Cleanup may delete the AF-created session branch, so neither can prove the tip
+// durable. A tag, remote, other branch, stash, or custom shared ref can.
+func detachedHeadCommitWarning(worktreePath, branchName string, deleteBranch bool) (string, bool) {
 	if _, err := runKillGit(worktreePath, "symbolic-ref", "--quiet", "HEAD"); err == nil {
 		return "", false // attached HEAD: the branch check owns committed loss
 	} else {
@@ -288,11 +292,30 @@ func detachedHeadCommitWarning(worktreePath string) (string, bool) {
 	if err != nil {
 		return detachedHeadFailClosedLine(err), false
 	}
-	if strings.TrimSpace(string(refs)) != "" {
-		return "", false // some durable ref contains HEAD; removing the worktree preserves it
+	for _, ref := range strings.Split(string(refs), "\n") {
+		if refSurvivesWorktreeCleanup(strings.TrimSpace(ref), branchName, deleteBranch) {
+			return "", false
+		}
 	}
-	return "Detached HEAD points to one or more commits not reachable from any ref. " +
+	return "Detached HEAD points to one or more commits not reachable from any ref that survives cleanup. " +
 		"Killing removes the worktree and permanently orphans them · this cannot be undone.", true
+}
+
+func refSurvivesWorktreeCleanup(ref, branchName string, deleteBranch bool) bool {
+	if ref == "" {
+		return false
+	}
+	// Git stores these namespaces per worktree. Removing the linked worktree
+	// removes its private ref store even though for-each-ref can see it now.
+	for _, private := range []string{"refs/bisect", "refs/worktree", "refs/rewritten"} {
+		if ref == private || strings.HasPrefix(ref, private+"/") {
+			return false
+		}
+	}
+	if deleteBranch && ref == "refs/heads/"+strings.TrimSpace(branchName) {
+		return false
+	}
+	return true
 }
 
 func detachedHeadFailClosedLine(err error) string {

--- a/app/kill_confirm_bound_test.go
+++ b/app/kill_confirm_bound_test.go
@@ -90,7 +90,7 @@ func TestUnmergedCommitWarningIsBounded(t *testing.T) {
 
 	done := make(chan struct{}, 1)
 	go func() {
-		_, _ = unmergedCommitWarning(wt, "dev/bounded", "deadbeef", "")
+		_, _ = unmergedCommitWarning(wt, "dev/bounded", "deadbeef", "", true)
 		done <- struct{}{}
 	}()
 

--- a/app/kill_unmerged_test.go
+++ b/app/kill_unmerged_test.go
@@ -212,6 +212,48 @@ func TestHandleKill_UsesCanonicalWorktreeBranch(t *testing.T) {
 	assert.Equal(t, unmergedKillConfirmKey, hm.confirmationOverlay.ConfirmKey)
 }
 
+// A merged PR is only evidence for the branch it was fetched from. Legacy
+// records can retain PR state for Instance.Branch while cleanup deletes the
+// GitWorktree branch; that stale state must not suppress a real loss warning.
+func TestHandleKill_StalePRBranchCannotSuppressCanonicalLoss(t *testing.T) {
+	repoDir, baseSHA := initBaseRepo(t)
+	wt := addWorktree(t, repoDir, baseSHA, "dev/canonical-pr")
+	commitInWorktree(t, wt)
+
+	inst := startedWorktreeInstance(t, "stale-pr", repoDir, wt, "dev/canonical-pr", baseSHA)
+	inst.Branch = "dev/legacy"
+	inst.SetPRInfo(&git.PRInfo{Number: 7, State: "MERGED", Branch: "dev/legacy"})
+	_, hm := armKill(t, inst)
+
+	rendered := flatten(hm.confirmationOverlay.Render())
+	assert.Contains(t, rendered, `Branch "dev/canonical-pr" has 1 commit`)
+	assert.Contains(t, rendered, "permanently deletes it")
+	assert.Equal(t, unmergedKillConfirmKey, hm.confirmationOverlay.ConfirmKey)
+}
+
+// Cleanup is a no-op for --here/legacy external worktrees. Their dirty files,
+// private refs, branches, and detached commits all remain after killing the
+// runtime, so destructive-worktree copy and escalation would be false.
+func TestHandleKill_ExternalWorktreeSkipsWorktreeLossWarnings(t *testing.T) {
+	repoDir, baseSHA := initBaseRepo(t)
+	wt := addWorktree(t, repoDir, baseSHA, "dev/external")
+	killGit(t, wt, "checkout", "-q", "--detach", baseSHA)
+	commitInWorktree(t, wt)
+	require.NoError(t, os.WriteFile(filepath.Join(wt, "dirty.txt"), []byte("kept\n"), 0o644))
+
+	inst := startedWorktreeInstance(t, "external", repoDir, wt, "dev/external", baseSHA)
+	gw, err := git.NewGitWorktreeFromStorage(repoDir, wt, "external", "dev/external", baseSHA, true, false)
+	require.NoError(t, err)
+	inst.SetGitWorktreeForTest(gw)
+	_, hm := armKill(t, inst)
+
+	rendered := flatten(hm.confirmationOverlay.Render())
+	assert.Contains(t, rendered, "Kill session 'external'?")
+	assert.NotContains(t, rendered, "will be lost")
+	assert.NotContains(t, rendered, "Detached HEAD")
+	assert.Equal(t, "y", hm.confirmationOverlay.ConfirmKey)
+}
+
 // TestHandleKill_DetachedLocalCommitEscalates is the #2210 review regression.
 // The recorded branch is level with base, but HEAD carries a new commit that no
 // ref contains. Removing the worktree drops the final reference to that commit,
@@ -288,7 +330,7 @@ func TestHandleKill_MergedPR_NotSevere(t *testing.T) {
 	commitInWorktree(t, wt) // unpushed locally, but the PR is merged
 
 	inst := startedWorktreeInstance(t, "merged", repoDir, wt, "dev/merged", baseSHA)
-	inst.SetPRInfo(&git.PRInfo{Number: 7, State: "MERGED"})
+	inst.SetPRInfo(&git.PRInfo{Number: 7, State: "MERGED", Branch: "dev/merged"})
 	_, hm := armKill(t, inst)
 
 	rendered := flatten(hm.confirmationOverlay.Render())
@@ -323,7 +365,7 @@ func TestUnmergedCommitWarning(t *testing.T) {
 		repoDir, baseSHA := initBaseRepo(t)
 		wt := addWorktree(t, repoDir, baseSHA, "dev/a")
 		commitInWorktree(t, wt)
-		line, severe := unmergedCommitWarning(wt, "dev/a", baseSHA, "")
+		line, severe := unmergedCommitWarning(wt, "dev/a", baseSHA, "", true)
 		assert.True(t, severe)
 		assert.Contains(t, line, "1 commit")
 		assert.Contains(t, line, "cannot be undone")
@@ -332,7 +374,7 @@ func TestUnmergedCommitWarning(t *testing.T) {
 	t.Run("no commits beyond base is safe", func(t *testing.T) {
 		repoDir, baseSHA := initBaseRepo(t)
 		wt := addWorktree(t, repoDir, baseSHA, "dev/b")
-		line, severe := unmergedCommitWarning(wt, "dev/b", baseSHA, "")
+		line, severe := unmergedCommitWarning(wt, "dev/b", baseSHA, "", true)
 		assert.False(t, severe)
 		assert.Empty(t, line)
 	})
@@ -345,7 +387,7 @@ func TestUnmergedCommitWarning(t *testing.T) {
 		killGit(t, repoDir, "init", "-q", "--bare", bare)
 		killGit(t, repoDir, "remote", "add", "origin", bare)
 		killGit(t, wt, "push", "-q", "origin", "dev/c")
-		line, severe := unmergedCommitWarning(wt, "dev/c", baseSHA, "")
+		line, severe := unmergedCommitWarning(wt, "dev/c", baseSHA, "", true)
 		assert.False(t, severe)
 		assert.Empty(t, line)
 	})
@@ -354,7 +396,7 @@ func TestUnmergedCommitWarning(t *testing.T) {
 		repoDir, baseSHA := initBaseRepo(t)
 		wt := addWorktree(t, repoDir, baseSHA, "dev/d")
 		commitInWorktree(t, wt)
-		line, severe := unmergedCommitWarning(wt, "dev/d", baseSHA, "MERGED")
+		line, severe := unmergedCommitWarning(wt, "dev/d", baseSHA, "MERGED", true)
 		assert.False(t, severe)
 		assert.Empty(t, line)
 	})
@@ -366,7 +408,7 @@ func TestUnmergedCommitWarning(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(wt, "second.txt"), []byte("more\n"), 0o644))
 		killGit(t, wt, "add", "-A")
 		killGit(t, wt, "commit", "-q", "-m", "agent: more work")
-		line, severe := unmergedCommitWarning(wt, "dev/e", baseSHA, "")
+		line, severe := unmergedCommitWarning(wt, "dev/e", baseSHA, "", true)
 		assert.True(t, severe)
 		assert.Contains(t, line, "2 commits")
 		assert.Contains(t, line, "deletes them")
@@ -376,7 +418,7 @@ func TestUnmergedCommitWarning(t *testing.T) {
 		repoDir, baseSHA := initBaseRepo(t)
 		wt := addWorktree(t, repoDir, baseSHA, "dev/f")
 		commitInWorktree(t, wt)
-		line, severe := unmergedCommitWarning(wt, "dev/f", "", "") // no recorded base, no origin
+		line, severe := unmergedCommitWarning(wt, "dev/f", "", "", true) // no recorded base, no origin
 		assert.False(t, severe, "unverifiable must not claim a proven loss")
 		assert.Contains(t, line, "Could not verify")
 	})
@@ -384,7 +426,7 @@ func TestUnmergedCommitWarning(t *testing.T) {
 	t.Run("missing session branch fails closed", func(t *testing.T) {
 		repoDir, baseSHA := initBaseRepo(t)
 		wt := addWorktree(t, repoDir, baseSHA, "dev/actual")
-		line, severe := unmergedCommitWarning(wt, "dev/missing", baseSHA, "")
+		line, severe := unmergedCommitWarning(wt, "dev/missing", baseSHA, "", true)
 		assert.False(t, severe, "unverifiable must not claim a proven loss")
 		assert.Contains(t, line, `session branch "dev/missing"`)
 		assert.Contains(t, line, "Could not verify")
@@ -393,20 +435,20 @@ func TestUnmergedCommitWarning(t *testing.T) {
 	t.Run("empty session branch fails closed", func(t *testing.T) {
 		repoDir, baseSHA := initBaseRepo(t)
 		wt := addWorktree(t, repoDir, baseSHA, "dev/actual")
-		line, severe := unmergedCommitWarning(wt, "", baseSHA, "")
+		line, severe := unmergedCommitWarning(wt, "", baseSHA, "", true)
 		assert.False(t, severe, "unverifiable must not claim a proven loss")
 		assert.Contains(t, line, "Could not verify whether the session branch")
 	})
 
 	t.Run("empty worktree path fails closed", func(t *testing.T) {
-		line, severe := unmergedCommitWarning("", "dev/missing", "deadbeef", "")
+		line, severe := unmergedCommitWarning("", "dev/missing", "deadbeef", "", true)
 		assert.False(t, severe)
 		assert.Contains(t, line, "Could not verify")
 	})
 
 	t.Run("git error fails closed", func(t *testing.T) {
 		// A non-repo directory makes the base rev-parse fail.
-		line, severe := unmergedCommitWarning(t.TempDir(), "dev/missing", "deadbeef", "")
+		line, severe := unmergedCommitWarning(t.TempDir(), "dev/missing", "deadbeef", "", true)
 		assert.False(t, severe)
 		assert.Contains(t, line, "Could not verify")
 	})
@@ -416,7 +458,7 @@ func TestUnmergedCommitWarning(t *testing.T) {
 		wt := addWorktree(t, repoDir, baseSHA, "dev/detached-direct")
 		killGit(t, wt, "checkout", "-q", "--detach", baseSHA)
 		commitInWorktree(t, wt)
-		line, severe := unmergedCommitWarning(wt, "dev/detached-direct", baseSHA, "")
+		line, severe := unmergedCommitWarning(wt, "dev/detached-direct", baseSHA, "", true)
 		assert.True(t, severe)
 		assert.Contains(t, line, "Detached HEAD")
 		assert.Contains(t, line, "permanently orphans")
@@ -426,8 +468,52 @@ func TestUnmergedCommitWarning(t *testing.T) {
 		repoDir, baseSHA := initBaseRepo(t)
 		wt := addWorktree(t, repoDir, baseSHA, "dev/detached-referenced")
 		killGit(t, wt, "checkout", "-q", "--detach", baseSHA)
-		line, severe := unmergedCommitWarning(wt, "dev/detached-referenced", baseSHA, "")
+		line, severe := unmergedCommitWarning(wt, "dev/detached-referenced", baseSHA, "", true)
 		assert.False(t, severe)
 		assert.Empty(t, line, "a detached HEAD still contained by the session branch survives worktree removal")
+	})
+
+	t.Run("user-owned session branch survives cleanup", func(t *testing.T) {
+		repoDir, baseSHA := initBaseRepo(t)
+		wt := addWorktree(t, repoDir, baseSHA, "dev/user-owned")
+		commitInWorktree(t, wt)
+		line, severe := unmergedCommitWarning(wt, "dev/user-owned", baseSHA, "", false)
+		assert.False(t, severe)
+		assert.Empty(t, line, "cleanup preserves a branch AF did not create")
+	})
+
+	t.Run("per-worktree ref does not make detached tip durable", func(t *testing.T) {
+		repoDir, baseSHA := initBaseRepo(t)
+		wt := addWorktree(t, repoDir, baseSHA, "dev/private-ref")
+		killGit(t, wt, "checkout", "-q", "--detach", baseSHA)
+		commitInWorktree(t, wt)
+		killGit(t, wt, "update-ref", "refs/worktree/keep", "HEAD")
+
+		line, severe := detachedHeadCommitWarning(wt, "dev/private-ref", true)
+		assert.True(t, severe)
+		assert.Contains(t, line, "permanently orphans")
+	})
+
+	t.Run("deleted session branch does not make detached tip durable", func(t *testing.T) {
+		repoDir, baseSHA := initBaseRepo(t)
+		wt := addWorktree(t, repoDir, baseSHA, "dev/doomed-ref")
+		commitInWorktree(t, wt)
+		killGit(t, wt, "checkout", "-q", "--detach", "HEAD")
+
+		line, severe := detachedHeadCommitWarning(wt, "dev/doomed-ref", true)
+		assert.True(t, severe)
+		assert.Contains(t, line, "permanently orphans")
+	})
+
+	t.Run("durable tag preserves detached tip", func(t *testing.T) {
+		repoDir, baseSHA := initBaseRepo(t)
+		wt := addWorktree(t, repoDir, baseSHA, "dev/tagged")
+		killGit(t, wt, "checkout", "-q", "--detach", baseSHA)
+		commitInWorktree(t, wt)
+		killGit(t, wt, "tag", "keep-detached", "HEAD")
+
+		line, severe := detachedHeadCommitWarning(wt, "dev/tagged", true)
+		assert.False(t, severe)
+		assert.Empty(t, line)
 	})
 }

--- a/app/pr_info_test.go
+++ b/app/pr_info_test.go
@@ -20,9 +20,13 @@ import (
 // that yields a non-empty repoPath from FetchPRInfoSnapshot). Use for tests
 // that need fetchPRInfoCmd to actually return a non-nil command.
 func newStartedInstanceWithWorktree(t *testing.T, title string) *session.Instance {
+	return newStartedInstanceWithWorktreeBranch(t, title, "feature/"+title)
+}
+
+func newStartedInstanceWithWorktreeBranch(t *testing.T, title, branch string) *session.Instance {
 	t.Helper()
 	inst := newStartedInstance(t, title)
-	inst.Branch = "feature/" + title
+	inst.Branch = branch
 	gw, err := git.NewGitWorktreeFromStorage(
 		t.TempDir(),
 		filepath.Join(t.TempDir(), "worktree"),
@@ -104,26 +108,28 @@ func TestFetchPRInfoCmd_NoGitWorktree_ReturnsNil(t *testing.T) {
 	assert.Nil(t, fetchPRInfoCmd(inst, "", false))
 }
 
-// TestFetchPRInfoCmd_DetachedHead_ReturnsNil — a detached-HEAD worktree has a
-// non-empty repoPath but an empty branch (#687). fetchPRInfoCmd must skip the
-// fetch entirely so it never spawns `gh pr view ""` every tick. We force the
-// fetch (bypassing the freshness debounce) and assert the fetcher is never
-// invoked even though the instance is started, local, and has a worktree.
-func TestFetchPRInfoCmd_DetachedHead_ReturnsNil(t *testing.T) {
-	inst := newStartedInstanceWithWorktree(t, "detached")
-	inst.Branch = "" // detached HEAD: no branch to look up
+// PR lookup is bound to GitWorktree.BranchName, the exact ref cleanup owns.
+// A restored row's legacy Instance.Branch can be empty or stale and must not
+// redirect the cached PR state used by destructive confirmation.
+func TestFetchPRInfoCmd_UsesCanonicalWorktreeBranch(t *testing.T) {
+	inst := newStartedInstanceWithWorktreeBranch(t, "restored", "feature/canonical")
+	inst.Branch = "stale-legacy-value"
 
-	var calls int32
+	var gotBranch string
 	restore := SetPRInfoFetcherForTest(func(repoPath, branch string) (*git.PRInfo, error) {
-		atomic.AddInt32(&calls, 1)
-		return nil, nil
+		gotBranch = branch
+		return &git.PRInfo{Number: 9, State: "MERGED"}, nil
 	})
 	defer restore()
 
-	assert.Nil(t, fetchPRInfoCmd(inst, "", true),
-		"detached-HEAD instance must not schedule a fetch")
-	assert.Equal(t, int32(0), atomic.LoadInt32(&calls),
-		"fetcher must not be invoked for an empty branch (no gh pr view \"\")")
+	cmd := fetchPRInfoCmd(inst, "", true)
+	require.NotNil(t, cmd)
+	msg, ok := cmd().(prInfoUpdatedMsg)
+	require.True(t, ok)
+	assert.Equal(t, "feature/canonical", gotBranch)
+	assert.Equal(t, "feature/canonical", msg.branch)
+	require.NotNil(t, msg.info)
+	assert.Equal(t, "feature/canonical", msg.info.Branch)
 }
 
 // TestFetchPRInfoCmd_Fresh_NotForced_DebouncesFetch — core laziness check:
@@ -425,15 +431,13 @@ func TestPrInfoUpdatedMsg_BranchMismatch_DropsUpdate(t *testing.T) {
 	h := newTestHome(t)
 
 	// The instance the fetch was kicked off for, on branch X.
-	orphan := newStartedInstance(t, "reused")
-	orphan.Branch = "feature/x"
+	orphan := newStartedInstanceWithWorktreeBranch(t, "reused", "feature/x")
 	h.store.AddInstance(orphan)
 	h.sidebar.SetSelectedInstance(0)
 
 	// User killed it and recreated a same-title instance on branch Y while the
 	// gh fetch was still running.
-	recreated := newStartedInstance(t, "reused")
-	recreated.Branch = "feature/y"
+	recreated := newStartedInstanceWithWorktreeBranch(t, "reused", "feature/y")
 	h.store.RemoveInstanceByTitle("reused")
 	h.store.AddInstance(recreated)
 
@@ -453,13 +457,11 @@ func TestPrInfoUpdatedMsg_BranchMismatch_DropsUpdate(t *testing.T) {
 func TestPrInfoUpdatedMsg_BranchMatch_AppliesUpdate(t *testing.T) {
 	h := newTestHome(t)
 
-	orphan := newStartedInstance(t, "reused")
-	orphan.Branch = "feature/x"
+	orphan := newStartedInstanceWithWorktreeBranch(t, "reused", "feature/x")
 	h.store.AddInstance(orphan)
 	h.sidebar.SetSelectedInstance(0)
 
-	live := newStartedInstance(t, "reused")
-	live.Branch = "feature/x"
+	live := newStartedInstanceWithWorktreeBranch(t, "reused", "feature/x")
 	h.store.RemoveInstanceByTitle("reused")
 	h.store.AddInstance(live)
 	require.NotSame(t, orphan, live, "sanity: swap must produce a distinct pointer")
@@ -497,8 +499,7 @@ func TestPrInfoUpdatedMsg_ProjectSwitch_DropsUpdate(t *testing.T) {
 	projectARepoID := h.repoID
 
 	// Project A: session "worker" on branch feature/x, PR fetch in flight.
-	orphan := newStartedInstance(t, "worker")
-	orphan.Branch = "feature/x"
+	orphan := newStartedInstanceWithWorktreeBranch(t, "worker", "feature/x")
 	h.store.AddInstance(orphan)
 
 	// The user switches projects in place (#1461): the store is reset and the
@@ -508,8 +509,7 @@ func TestPrInfoUpdatedMsg_ProjectSwitch_DropsUpdate(t *testing.T) {
 
 	// Project B happens to have a same-title session on the same branch — the
 	// case the #921 branch guard cannot distinguish.
-	repoBWorker := newStartedInstance(t, "worker")
-	repoBWorker.Branch = "feature/x"
+	repoBWorker := newStartedInstanceWithWorktreeBranch(t, "worker", "feature/x")
 	h.store.AddInstance(repoBWorker)
 
 	var persisted bool
@@ -539,15 +539,13 @@ func TestPrInfoUpdatedMsg_ProjectSwitch_ErrorDropsUpdate(t *testing.T) {
 	h := newTestHome(t)
 	projectARepoID := h.repoID
 
-	orphan := newStartedInstance(t, "worker")
-	orphan.Branch = "feature/x"
+	orphan := newStartedInstanceWithWorktreeBranch(t, "worker", "feature/x")
 	h.store.AddInstance(orphan)
 
 	h.store.ResetInstances()
 	h.repoID = projectARepoID + "-project-b"
 
-	repoBWorker := newStartedInstance(t, "worker")
-	repoBWorker.Branch = "feature/x"
+	repoBWorker := newStartedInstanceWithWorktreeBranch(t, "worker", "feature/x")
 	h.store.AddInstance(repoBWorker)
 	require.Greater(t, repoBWorker.PRInfoAge(), 365*24*time.Hour,
 		"precondition: project B's session is never-fetched")
@@ -581,6 +579,8 @@ func TestFetchPRInfoCmd_StampsRepoIDAtKickoff(t *testing.T) {
 	assert.Equal(t, "repo-a", msg.repoID,
 		"the fetch must carry the repoID captured at kickoff so the handler can drop it after a project switch")
 	assert.Equal(t, inst.GetBranch(), msg.branch)
+	require.NotNil(t, msg.info)
+	assert.Equal(t, msg.branch, msg.info.Branch)
 }
 
 // sanity: exercise config.DefaultConfig / AppState wiring so a compile

--- a/app/sync.go
+++ b/app/sync.go
@@ -282,6 +282,13 @@ func fetchPRInfoCmd(inst *session.Instance, repoID string, force bool) tea.Cmd {
 		fetchStart := time.Now()
 		detachTraceMark("fetchPRInfoCmd-goroutine-entry")
 		info, err := fetch(repoPath, branch)
+		if info != nil {
+			// Bind even test/custom fetchers to the captured lookup ref. A PR state
+			// without provenance must never authorize a destructive shortcut.
+			bound := *info
+			bound.Branch = branch
+			info = &bound
+		}
 		detachTrace(fetchStart, "fetchPRInfoCmd-prInfoFetcher-returned")
 		return prInfoUpdatedMsg{instance: inst, branch: branch, repoID: repoID, info: info, err: err}
 	}
@@ -752,7 +759,7 @@ func prInfoFromData(d session.PRInfoData) *git.PRInfo {
 	if d.Number == 0 {
 		return nil
 	}
-	return &git.PRInfo{Number: d.Number, Title: d.Title, URL: d.URL, State: d.State}
+	return &git.PRInfo{Number: d.Number, Title: d.Title, URL: d.URL, State: d.State, Branch: d.Branch}
 }
 
 // prInfoDiffersFromData reports whether an instance's in-memory PR info differs
@@ -766,7 +773,7 @@ func prInfoDiffersFromData(inst *session.Instance, d session.PRInfoData) bool {
 	if cur == nil {
 		return true
 	}
-	return cur.Number != d.Number || cur.Title != d.Title || cur.URL != d.URL || cur.State != d.State
+	return cur.Number != d.Number || cur.Title != d.Title || cur.URL != d.URL || cur.State != d.State || cur.Branch != d.Branch
 }
 
 // snapshotLiveness resolves the daemon-owned liveness a snapshot record carries

--- a/session/git/github.go
+++ b/session/git/github.go
@@ -33,6 +33,10 @@ type PRInfo struct {
 	Title  string `json:"title"`
 	URL    string `json:"url"`
 	State  string `json:"state"`
+	// Branch is the exact local branch this PR lookup was performed for. It is
+	// not supplied by `gh pr list`; FetchPRInfo binds it after parsing so callers
+	// can prove cached PR state still belongs to the ref they are acting on.
+	Branch string `json:"-"`
 }
 
 // FetchPRInfo runs `gh pr list --head <branch>` to look up a PR for the
@@ -81,7 +85,11 @@ func FetchPRInfo(repoPath, branchName string) (*PRInfo, error) {
 		return nil, fmt.Errorf("failed to fetch PR info: %w", err)
 	}
 
-	return parsePRList(out)
+	info, err := parsePRList(out)
+	if info != nil {
+		info.Branch = branchName
+	}
+	return info, err
 }
 
 // parsePRList parses the JSON array output from `gh pr list` and selects the

--- a/session/instance_accessors.go
+++ b/session/instance_accessors.go
@@ -195,6 +195,37 @@ func (i *Instance) IsExternalWorktree() bool {
 	return gw != nil && gw.IsExternalWorktree()
 }
 
+// WorktreeCleanupImpact snapshots exactly what GitWorktree.Cleanup will remove.
+// Destructive confirmation code consumes this instead of reconstructing cleanup
+// ownership from capability flags, which do not distinguish AF-owned linked
+// worktrees from in-place or user-branch worktrees.
+type WorktreeCleanupImpact struct {
+	Path           string
+	Branch         string
+	BaseCommitSHA  string
+	RemoveWorktree bool
+	DeleteBranch   bool
+}
+
+// GetWorktreeCleanupImpact returns a coherent description of Cleanup's targets.
+// The GitWorktree ownership fields are immutable after construction.
+func (i *Instance) GetWorktreeCleanupImpact() (WorktreeCleanupImpact, bool) {
+	i.mu.RLock()
+	gw := i.gitWorktree
+	i.mu.RUnlock()
+	if gw == nil {
+		return WorktreeCleanupImpact{}, false
+	}
+	external := gw.IsExternalWorktree()
+	return WorktreeCleanupImpact{
+		Path:           gw.GetWorktreePath(),
+		Branch:         gw.GetBranchName(),
+		BaseCommitSHA:  gw.GetBaseCommitSHA(),
+		RemoveWorktree: !external,
+		DeleteBranch:   !external && gw.BranchCreatedByUs(),
+	}, true
+}
+
 // SetTitle sets the title of the instance. Returns an error if the instance has started.
 // We cant change the title once it's been used for a tmux session etc.
 func (i *Instance) SetTitle(title string) error {

--- a/session/instance_data.go
+++ b/session/instance_data.go
@@ -130,6 +130,7 @@ func (i *Instance) toInstanceDataLocked() InstanceData {
 			Title:  i.prInfo.Title,
 			URL:    i.prInfo.URL,
 			State:  i.prInfo.State,
+			Branch: i.prInfo.Branch,
 		}
 	}
 
@@ -243,6 +244,7 @@ func FromInstanceData(data InstanceData) (*Instance, error) {
 			Title:  data.PRInfo.Title,
 			URL:    data.PRInfo.URL,
 			State:  data.PRInfo.State,
+			Branch: data.PRInfo.Branch,
 		}
 	}
 

--- a/session/instance_pr.go
+++ b/session/instance_pr.go
@@ -50,5 +50,8 @@ func (i *Instance) FetchPRInfoSnapshot() (repoPath, branch string) {
 	if !i.started || i.gitWorktree == nil {
 		return "", ""
 	}
-	return i.gitWorktree.GetRepoPath(), i.Branch
+	// The GitWorktree branch is the canonical ref cleanup owns. Instance.Branch
+	// is a legacy display field and can be stale on restored rows; fetching PR
+	// state for it can later suppress a warning about the canonical branch.
+	return i.gitWorktree.GetRepoPath(), i.gitWorktree.GetBranchName()
 }

--- a/session/storage.go
+++ b/session/storage.go
@@ -167,6 +167,9 @@ type PRInfoData struct {
 	Title  string `json:"title,omitempty"`
 	URL    string `json:"url,omitempty"`
 	State  string `json:"state,omitempty"`
+	// Branch binds cached state to the exact ref used for the lookup. Legacy
+	// records omit it and are therefore never trusted for destructive decisions.
+	Branch string `json:"branch,omitempty"`
 }
 
 // GitWorktreeData represents the serializable data of a GitWorktree.


### PR DESCRIPTION
## Outcome

Kill confirmation now evaluates the exact resources cleanup will destroy instead of approximating them from workspace capability and legacy branch fields.

- A single immutable cleanup-impact snapshot says whether the worktree and branch are actually deletion targets.
- External/in-place worktrees skip destructive-worktree warnings because cleanup preserves them.
- User-owned reused branches are not reported as branch deletion targets.
- Detached reachability ignores per-worktree refs and the AF-owned session branch because cleanup removes those refs.
- Cached PR state persists its lookup branch and only suppresses a warning when that provenance matches the canonical cleanup branch. Legacy branchless cache entries fail closed.
- PR refresh now fetches and reconciles against `GitWorktree.BranchName`, not stale `Instance.Branch`.

This addresses the P1 and three P2 findings posted after #2237 merged as one cleanup-invariant fix.

## Validation

Against pushed head `bdb4d188caf41238e1e9441253a0fc7a28f68245`, rebased on current master:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- targeted race tests for app, session, and session/git

All pass.

— Captain Claude