### PR TITLE
fix(plugins): keep generated versions monotonic

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "agent-factory",
       "source": "./plugins/claude/agent-factory",
       "description": "Run and schedule AI coding agents in isolated git worktrees with the Agent Factory (af) CLI",
-      "version": "2.2501713274.1093626954"
+      "version": "3.1.2501713274+sha256.951d1d7a412f6c4a"
     }
   ]
 }

--- a/commands/plugins_gen.go
+++ b/commands/plugins_gen.go
@@ -37,6 +37,9 @@ const (
 	// then render once more with the content-derived version (#2179 review).
 	pluginVersionSeed = "0.0.0"
 
+	// Major 3 sorts after the unordered 2.<hash>.<hash> scheme shipped by #2243.
+	pluginVersionMajor = 3
+
 	// agentFactoryModule is the ownership proof writeAgentPlugins requires before
 	// its first write or prune. A random directory containing any go.mod is not an
 	// af checkout and must never become a destructive target (#2179 review).
@@ -53,6 +56,15 @@ const (
 	// generated README use.
 	pluginCategory = "Developer Tools"
 )
+
+// pluginReleaseDigests is an append-only release ledger. Its length is the
+// monotonic SemVer minor: a seeded payload/path/mode change must append the new
+// digest, which advances ordering automatically. pluginContentVersion refuses
+// to generate when the final entry does not match, so the ordinary fix for a
+// changed payload cannot update its identity without also moving forward.
+var pluginReleaseDigests = []string{
+	"951d1d7a412f6c4a28b9498c7b16bda79ff6fad12c5b40963b6cf68f637fcf91", // 3.1
+}
 
 // pluginGenBanner marks a generated Markdown/shell artifact. Like genBanner it
 // carries no version or timestamp, so regenerating an unchanged tree is
@@ -452,10 +464,10 @@ func pluginsReadme() string {
 	return b.String()
 }
 
-// generatedPluginFiles returns every generated artifact with a version derived
-// from the complete version-neutral tree. Content, path, or mode changes mint a
-// different semver, so Codex/Claude caches cannot keep serving old skill or hook
-// bytes under an unchanged manifest identity (#2179 review).
+// generatedPluginFiles returns every generated artifact with a version bound to
+// the complete version-neutral tree. The ordered release serial makes every
+// later release greater under SemVer; the pinned digest makes generation fail
+// until a payload change advances that serial (#2179/#2243 review).
 func generatedPluginFiles() []pluginFile {
 	seed := generatedPluginFilesAtVersion(pluginVersionSeed)
 	return generatedPluginFilesAtVersion(pluginContentVersion(seed))
@@ -477,17 +489,42 @@ func generatedPluginFilesAtVersion(version string) []pluginFile {
 	return files
 }
 
-// pluginContentVersion maps the seeded generated tree to a deterministic semver.
-// Two 32-bit SHA-256 words give a 64-bit content address while staying within
-// conservative semver numeric ranges. The fixed major separates this scheme
-// from the former manually frozen 1.0.0 without tying plugins to af releases.
+// pluginContentVersion validates the complete seeded tree against the release
+// pin, then gives it a monotonic SemVer identity. Minor is the ordered release
+// serial; patch plus build metadata retain a 64-bit content address. A payload
+// change without an explicit serial bump panics before any generated file is
+// written, turning the easy-to-forget cache invariant into a hard generation
+// gate rather than another maintainer convention.
 func pluginContentVersion(files []pluginFile) string {
+	sum := pluginContentSum(files)
+	digest := fmt.Sprintf("%x", sum)
+	release := uint64(len(pluginReleaseDigests))
+	if release == 0 || digest != pluginReleaseDigests[len(pluginReleaseDigests)-1] {
+		panic(fmt.Sprintf(
+			"plugin generator: release %d content digest is %s; append it to pluginReleaseDigests (do not replace existing entries) to advance the plugin version",
+			release, digest,
+		))
+	}
+	return pluginVersionForRelease(release, sum)
+}
+
+func pluginContentSum(files []pluginFile) [sha256.Size]byte {
 	h := sha256.New()
 	for _, f := range files {
 		_, _ = fmt.Fprintf(h, "%s\x00%o\x00%s\x00", f.path, f.mode, f.content)
 	}
-	sum := h.Sum(nil)
-	return fmt.Sprintf("2.%d.%d", binary.BigEndian.Uint32(sum[:4]), binary.BigEndian.Uint32(sum[4:8]))
+	var sum [sha256.Size]byte
+	copy(sum[:], h.Sum(nil))
+	return sum
+}
+
+func pluginVersionForRelease(release uint64, sum [sha256.Size]byte) string {
+	return fmt.Sprintf("%d.%d.%d+sha256.%x",
+		pluginVersionMajor,
+		release,
+		binary.BigEndian.Uint32(sum[:4]),
+		sum[:8],
+	)
 }
 
 // mustJSON renders a manifest as indented JSON with a trailing newline. The

--- a/commands/plugins_gen_test.go
+++ b/commands/plugins_gen_test.go
@@ -1,7 +1,9 @@
 package commands
 
 import (
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -342,6 +344,7 @@ func TestGeneratedFilesAreDeterministic(t *testing.T) {
 func TestGeneratedPluginVersionTracksEveryPayloadChange(t *testing.T) {
 	seed := generatedPluginFilesAtVersion(pluginVersionSeed)
 	version := pluginContentVersion(seed)
+	seedSum := pluginContentSum(seed)
 	mutated := append([]pluginFile(nil), seed...)
 	for i := range mutated {
 		if strings.HasSuffix(mutated[i].path, "SKILL.md") {
@@ -349,8 +352,20 @@ func TestGeneratedPluginVersionTracksEveryPayloadChange(t *testing.T) {
 			break
 		}
 	}
-	if got := pluginContentVersion(mutated); got == version {
-		t.Fatalf("content changed without changing plugin version %q", got)
+	mutatedSum := pluginContentSum(mutated)
+	if mutatedSum == seedSum {
+		t.Fatal("payload changed without changing the pinned content digest")
+	}
+	func() {
+		defer func() {
+			if recovered := recover(); recovered == nil || !strings.Contains(fmt.Sprint(recovered), "append it to pluginReleaseDigests") {
+				t.Fatalf("unversioned payload change did not fail with bump instructions: %v", recovered)
+			}
+		}()
+		_ = pluginContentVersion(mutated)
+	}()
+	if version == "" {
+		t.Fatal("current plugin version is empty")
 	}
 
 	files := generatedPluginFiles()
@@ -363,6 +378,48 @@ func TestGeneratedPluginVersionTracksEveryPayloadChange(t *testing.T) {
 	mustUnmarshalGenerated(t, files, claudePluginRoot+"/.claude-plugin/plugin.json", &claude)
 	if claude.Version != version {
 		t.Errorf("Claude manifest version = %q, want content version %q", claude.Version, version)
+	}
+}
+
+func TestGeneratedPluginVersionNeverMovesBackward(t *testing.T) {
+	seed := generatedPluginFilesAtVersion(pluginVersionSeed)
+	current := pluginContentVersion(seed)
+	var currentMajor, currentMinor, currentPatch uint64
+	if _, err := fmt.Sscanf(current, "%d.%d.%d", &currentMajor, &currentMinor, &currentPatch); err != nil {
+		t.Fatal(err)
+	}
+	if currentMajor != pluginVersionMajor || currentMinor != uint64(len(pluginReleaseDigests)) {
+		t.Fatalf("current plugin version %s is not bound to major %d and release ledger length %d", current, pluginVersionMajor, len(pluginReleaseDigests))
+	}
+	if currentMajor <= 2 {
+		t.Fatalf("current plugin version %s does not sort after published 2.2501713274.1093626954", current)
+	}
+	mutated := append([]pluginFile(nil), seed...)
+	mutated[0].content += "\nnext release\n"
+	next := pluginVersionForRelease(uint64(len(pluginReleaseDigests)+1), pluginContentSum(mutated))
+	var major, minor, patch uint64
+	if _, err := fmt.Sscanf(next, "%d.%d.%d", &major, &minor, &patch); err != nil {
+		t.Fatal(err)
+	}
+	if major < currentMajor || major == currentMajor && (minor < currentMinor || minor == currentMinor && patch <= currentPatch) {
+		t.Fatalf("next plugin release did not move forward: %s -> %s", current, next)
+	}
+}
+
+func TestPluginReleaseDigestLedgerIsValid(t *testing.T) {
+	if len(pluginReleaseDigests) == 0 {
+		t.Fatal("plugin release digest ledger is empty")
+	}
+	seen := make(map[string]bool, len(pluginReleaseDigests))
+	for idx, digest := range pluginReleaseDigests {
+		decoded, err := hex.DecodeString(digest)
+		if err != nil || len(decoded) != 32 {
+			t.Fatalf("plugin release %d digest %q is not SHA-256: decoded=%d err=%v", idx+1, digest, len(decoded), err)
+		}
+		if seen[digest] {
+			t.Fatalf("plugin release %d repeats an earlier content digest; do not mint a new version for unchanged bytes", idx+1)
+		}
+		seen[digest] = true
 	}
 }
 

--- a/plugins/claude/agent-factory/.claude-plugin/plugin.json
+++ b/plugins/claude/agent-factory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-factory",
   "description": "Run and schedule AI coding agents in isolated git worktrees with the Agent Factory (af) CLI",
-  "version": "2.2501713274.1093626954",
+  "version": "3.1.2501713274+sha256.951d1d7a412f6c4a",
   "author": {
     "name": "Agent Factory",
     "url": "https://github.com/sachiniyer/agent-factory"

--- a/plugins/codex/agent-factory/.codex-plugin/plugin.json
+++ b/plugins/codex/agent-factory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-factory",
-  "version": "2.2501713274.1093626954",
+  "version": "3.1.2501713274+sha256.951d1d7a412f6c4a",
   "description": "Run and schedule AI coding agents in isolated git worktrees with the Agent Factory (af) CLI",
   "author": {
     "name": "Agent Factory",


### PR DESCRIPTION
## Outcome

Generated plugin versions now preserve both properties update clients need:

- SemVer ordering is monotonic: major 3 sorts after the shipped unordered 2.x hash version, and an append-only release-digest ledger drives the minor component.
- Content identity remains explicit: patch/build metadata carry the seeded tree hash, and the full SHA-256 digest is pinned in the ledger.

Any generated payload, path, or mode change without a new ledger entry panics before writes with the exact digest and an instruction to append it. Appending the entry advances the release number automatically, so the normal repair cannot refresh content identity without also moving forward.

A fail-first regression reproduced the shipped bug: a payload mutation moved `2.2501713274.1093626954` backward to `2.1411168162.167345414`.

## Validation

Against pushed head `3008ac6c3eefb8a01426c3a7538c208b528cfc8a`, rebased on master after #2247 and #2248:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `go test -race ./commands`
- generated artifact drift check

All pass.

— Captain Claude