### PR TITLE
fix(config): keep AF home private

### DIFF
--- a/config/config_load.go
+++ b/config/config_load.go
@@ -48,6 +48,13 @@ func LoadConfig() (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get config directory: %w", err)
 	}
+	// Establish the owner-only boundary before reading or materializing any
+	// state. Besides making first-run creation safe, this repairs a default AF
+	// home left 0755 by an older version even when config.toml already exists and
+	// this load would otherwise perform no write at all (#2197).
+	if err := secureAFHomeForPath(filepath.Join(configDir, TomlConfigFileName)); err != nil {
+		return nil, fmt.Errorf("failed to secure config directory: %w", err)
+	}
 
 	configPath := filepath.Join(configDir, ConfigFileName)
 	prettyConfigPath := prettyHomePath(configPath)
@@ -391,7 +398,7 @@ var writeConfigForceFailForTest func() error
 // when the file already exists, so a concurrently written config is never
 // overwritten.
 func writeConfigIfMissing(configPath string, config *Config) (bool, error) {
-	if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+	if err := ensureStorageParent(configPath); err != nil {
 		return false, fmt.Errorf("failed to create config directory: %w", err)
 	}
 	data, err := toml.Marshal(config)

--- a/config/filelock.go
+++ b/config/filelock.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -21,7 +22,7 @@ import (
 func TryWithFileLock(path string, fn func() error) (acquired bool, err error) {
 	lockPath := path + ".lock"
 
-	if err := os.MkdirAll(filepath.Dir(lockPath), 0755); err != nil {
+	if err := ensureStorageParent(lockPath); err != nil {
 		return false, fmt.Errorf("failed to create lock directory: %w", err)
 	}
 
@@ -68,7 +69,7 @@ var ErrLockTimeout = errors.New("timed out waiting for file lock")
 func WithFileLockTimeout(path string, timeout time.Duration, fn func() error) error {
 	lockPath := path + ".lock"
 
-	if err := os.MkdirAll(filepath.Dir(lockPath), 0755); err != nil {
+	if err := ensureStorageParent(lockPath); err != nil {
 		return fmt.Errorf("failed to create lock directory: %w", err)
 	}
 
@@ -114,7 +115,7 @@ func WithFileLock(path string, fn func() error) error {
 	lockPath := path + ".lock"
 
 	// Ensure the directory exists so the lock file can be created.
-	if err := os.MkdirAll(filepath.Dir(lockPath), 0755); err != nil {
+	if err := ensureStorageParent(lockPath); err != nil {
 		return fmt.Errorf("failed to create lock directory: %w", err)
 	}
 
@@ -137,7 +138,7 @@ func WithFileLock(path string, fn func() error) error {
 // visible to readers.
 func AtomicWriteFile(path string, data []byte, perm os.FileMode) error {
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := ensureStorageParent(path); err != nil {
 		return fmt.Errorf("failed to create directory %s: %w", dir, err)
 	}
 
@@ -195,6 +196,83 @@ func AtomicWriteFile(path string, data []byte, perm os.FileMode) error {
 	}
 	if err := dirFd.Close(); err != nil {
 		log.WarningLog.Printf("AtomicWriteFile: failed to close directory %s after post-rename sync of %s: %v", dir, path, err)
+	}
+	return nil
+}
+
+// ensureStorageParent creates path's parent without changing the historical
+// 0755 policy for generic callers (upgrade binaries, autostart files, repo
+// plugin files). When path is inside the AF home, it first secures that root.
+// Creating a descendant with MkdirAll(0755) can then never accidentally create
+// the default secret-bearing home world-readable (#2197).
+func ensureStorageParent(path string) error {
+	if err := secureAFHomeForPath(path); err != nil {
+		return err
+	}
+	return os.MkdirAll(filepath.Dir(path), 0o755)
+}
+
+// secureAFHomeForPath handles the single-owner boundary only for paths inside
+// the configured AF home. A newly created home is always 0700, and the default
+// ~/.agent-factory is tightened on upgrade. An existing custom home is left
+// alone: AGENT_FACTORY_HOME explicitly supports broad caller-owned directories
+// such as "~", and a file helper must never chmod those. AtomicWriteFile and the
+// lock helpers are generic, so paths elsewhere are left alone too.
+func secureAFHomeForPath(path string) error {
+	afHome, err := GetConfigDir()
+	if err != nil {
+		// A generic write outside config storage must not start depending on a
+		// resolvable AGENT_FACTORY_HOME. Callers writing inside it obtained their
+		// path from GetConfigDir already and will have surfaced that error there.
+		return nil
+	}
+	absHome, err := filepath.Abs(afHome)
+	if err != nil {
+		return fmt.Errorf("resolve AF home: %w", err)
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("resolve storage path: %w", err)
+	}
+	rel, err := filepath.Rel(absHome, absPath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return nil
+	}
+	info, statErr := os.Lstat(absHome)
+	created := false
+	if os.IsNotExist(statErr) {
+		if err := os.MkdirAll(absHome, 0o700); err != nil {
+			return fmt.Errorf("create AF home: %w", err)
+		}
+		// Reinspect after creation. Besides making chmod independent of umask,
+		// this catches another process winning the missing-path race with a
+		// symlink instead of blindly following it below.
+		info, statErr = os.Lstat(absHome)
+		created = true
+	}
+	if statErr != nil {
+		return fmt.Errorf("inspect AF home: %w", statErr)
+	}
+	if os.Getenv("AGENT_FACTORY_HOME") != "" && !created {
+		return nil
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		// Chmod follows symlinks. Never let a default ~/.agent-factory symlink
+		// trick this repair into changing an unrelated target directory.
+		target, err := os.Stat(absHome)
+		if err != nil {
+			return fmt.Errorf("inspect AF home symlink target: %w", err)
+		}
+		if !target.IsDir() || target.Mode().Perm() != 0o700 {
+			return fmt.Errorf("AF home %s is a symlink whose target is not an owner-only directory", absHome)
+		}
+		return nil
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("AF home %s is not a directory", absHome)
+	}
+	if err := os.Chmod(absHome, 0o700); err != nil {
+		return fmt.Errorf("secure AF home: %w", err)
 	}
 	return nil
 }

--- a/config/home_permissions_test.go
+++ b/config/home_permissions_test.go
@@ -1,0 +1,108 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestLoadConfigSecuresDefaultAFHome is the #2197 regression. The default
+// first-run path materializes config.toml before token creation, so it must
+// create the secret-bearing AF home owner-only and repair homes that an older
+// version already created 0755. A later MkdirAll(0700) does not tighten an
+// existing directory.
+func TestLoadConfigSecuresDefaultAFHome(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		legacyConfig   string
+		defaultProgram string
+	}{
+		{name: "fresh home"},
+		{
+			name:           "legacy 0755 home with existing config",
+			legacyConfig:   "default_program = 'codex'\n",
+			defaultProgram: "codex",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			userHome := t.TempDir()
+			afHome := filepath.Join(userHome, ".agent-factory")
+			t.Setenv("HOME", userHome)
+			t.Setenv("AGENT_FACTORY_HOME", "")
+			fastShell(t)
+
+			if tc.legacyConfig != "" {
+				require.NoError(t, os.Mkdir(afHome, 0o755))
+				require.NoError(t, os.Chmod(afHome, 0o755))
+				require.NoError(t, os.WriteFile(
+					filepath.Join(afHome, TomlConfigFileName),
+					[]byte(tc.legacyConfig), 0o644))
+			}
+
+			cfg, err := LoadConfig()
+			require.NoError(t, err)
+			if tc.defaultProgram != "" {
+				require.Equal(t, tc.defaultProgram, cfg.DefaultProgram,
+					"securing a legacy home must not replace its existing config")
+			}
+
+			info, err := os.Stat(afHome)
+			require.NoError(t, err)
+			require.Equal(t, os.FileMode(0o700), info.Mode().Perm(),
+				"the AF home contains world-readable config/state files and bearer credentials")
+		})
+	}
+}
+
+func TestAtomicWriteFileCreatesMissingCustomAFHomePrivate(t *testing.T) {
+	userHome := t.TempDir()
+	afHome := filepath.Join(userHome, "custom-af-home")
+	t.Setenv("HOME", userHome)
+	t.Setenv("AGENT_FACTORY_HOME", afHome)
+
+	require.NoError(t, AtomicWriteFile(filepath.Join(afHome, "state.json"), []byte("{}"), 0o644))
+	requireMode(t, afHome, 0o700)
+}
+
+// TestAtomicWriteFileSecuresOnlyAFHome pins the shared primitive that keeps a
+// state/task/token writer from recreating the same bug through another first
+// write. Its permission tightening is scoped: AtomicWriteFile also serves
+// autostart, upgrade, and repo-plugin paths whose parent modes it must preserve.
+func TestAtomicWriteFileSecuresOnlyAFHome(t *testing.T) {
+	userHome := t.TempDir()
+	afHome := filepath.Join(userHome, ".agent-factory")
+	outside := filepath.Join(userHome, "outside")
+	t.Setenv("HOME", userHome)
+	t.Setenv("AGENT_FACTORY_HOME", "")
+
+	require.NoError(t, AtomicWriteFile(filepath.Join(afHome, "state.json"), []byte("{}"), 0o644))
+	requireMode(t, afHome, 0o700)
+
+	require.NoError(t, os.Mkdir(outside, 0o755))
+	require.NoError(t, os.Chmod(outside, 0o755))
+	require.NoError(t, AtomicWriteFile(filepath.Join(outside, "artifact"), []byte("ok"), 0o644))
+	requireMode(t, outside, 0o755)
+}
+
+// AGENT_FACTORY_HOME explicitly supports broad caller-owned directories such
+// as "~". Securing the default must not chmod that directory as a side effect.
+func TestAtomicWriteFilePreservesExistingCustomAFHomeMode(t *testing.T) {
+	userHome := t.TempDir()
+	require.NoError(t, os.Chmod(userHome, 0o755))
+	t.Setenv("HOME", userHome)
+	t.Setenv("AGENT_FACTORY_HOME", "~")
+
+	path := filepath.Join(userHome, "state.json")
+	require.NoError(t, AtomicWriteFile(path, []byte("{}"), 0o644))
+	require.FileExists(t, path)
+	requireMode(t, userHome, 0o755)
+}
+
+func requireMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, want, info.Mode().Perm())
+}

--- a/daemon/token.go
+++ b/daemon/token.go
@@ -110,12 +110,11 @@ func LoadToken(path string) (string, error) {
 // This is the generate-if-absent entry point behind `af token show`, so the
 // token exists before the TCP listener is ever enabled.
 func EnsureToken(path string) (string, error) {
-	// Pre-create the AF home 0700 BEFORE taking the lock: config.WithFileLock's
-	// internal MkdirAll uses 0755 (it is shared by non-secret callers), and on a
-	// token-first fresh run it would otherwise create the AF home world-readable.
-	// The home holds secrets (daemon-token, daemon-tls.key, state.json), so it
-	// must be owner-only. MkdirAll never loosens an existing dir, so the lock's
-	// later 0755 MkdirAll no-ops once this has run.
+	// Pre-create the token directory 0700 even when a caller supplies a path
+	// outside AGENT_FACTORY_HOME. WithFileLock also secures the configured AF
+	// home, but bearer-token material must not rely on that path relationship.
+	// A legacy default home is tightened by WithFileLock after this MkdirAll,
+	// which cannot change an existing directory's mode on its own (#2197).
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return "", fmt.Errorf("create token directory: %w", err)
 	}
@@ -153,8 +152,8 @@ func EnsureToken(path string) (string, error) {
 // without a daemon RPC and no reader ever sees a partial token; existing
 // streams keep running until they reconnect.
 func RotateToken(path string) (string, error) {
-	// Pre-create the AF home 0700 before the lock, same reason as EnsureToken:
-	// WithFileLock's MkdirAll is 0755 and the home holds secrets.
+	// Preserve EnsureToken's owner-only guarantee for arbitrary token paths;
+	// WithFileLock handles legacy permission repair inside AGENT_FACTORY_HOME.
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return "", fmt.Errorf("create token directory: %w", err)
 	}


### PR DESCRIPTION
## Summary

- establish the default AF home's owner-only boundary before LoadConfig reads or materializes any state
- route config file locks, atomic writes, and first-run config creation through one storage-parent helper so another writer cannot recreate the same 0755 root
- repair legacy default homes even when config.toml already exists, while preserving existing custom AGENT_FACTORY_HOME directories and unrelated AtomicWriteFile callers
- create missing custom homes as 0700 and fail closed on an unsafe default-home symlink target

On current master `461ae6b4`, the first-run config path creates the directory with 0755 at [config/config_load.go:393-402](https://github.com/sachiniyer/agent-factory/blob/461ae6b4fce702614ee050539192b1cec5ce542a/config/config_load.go#L393-L402). The later token path only calls MkdirAll with 0700 at [daemon/token.go:112-123](https://github.com/sachiniyer/agent-factory/blob/461ae6b4fce702614ee050539192b1cec5ce542a/daemon/token.go#L112-L123); MkdirAll does not tighten an existing directory. That verifies #2197 against master.

The regression coverage exercises both a fresh default home and a legacy 0755 home containing an existing config, and proves the repair does not replace that config. It also pins the shared write primitive's behavior for default homes, missing and existing custom homes, and paths outside AF storage.

Closes #2197

## Verification

Full gates run after the final commit on pushed SHA `ade1e13514a6bdc80ad099ed544d3177aa7895ad`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh` (`902 Go files checked; 0 grandfathered`)

— Captain Claude