### PR TITLE
fix(tmux): keep delivery failures unobservable

### DIFF
--- a/session/tmux/submit.go
+++ b/session/tmux/submit.go
@@ -490,16 +490,19 @@ func (t *TmuxSession) waitForPasteDelivered(
 	if len([]rune(tail)) < minDistinctiveTail {
 		needed = 2
 	}
-	sawAbsentCapture := false
+	lastObservation := deliveryCouldNotObserve
+	deadlineOutcome := func() deliveryOutcome {
+		if lastObservation == deliveryObservedAbsent && t.preSubmitEchoBehavior() == preSubmitEchoes {
+			return deliveryObservedAbsent
+		}
+		return deliveryCouldNotObserve
+	}
 	for {
 		// If the prior capture succeeded and the following poll interval carried
 		// us across the deadline, that prior read is the terminal observation. Do
 		// not launch an already-expired capture just to turn success into unknown.
 		if time.Until(deadline) <= 0 {
-			if sawAbsentCapture && t.preSubmitEchoBehavior() == preSubmitEchoes {
-				return deliveryObservedAbsent
-			}
-			return deliveryCouldNotObserve
+			return deadlineOutcome()
 		}
 
 		// Bound each capture by what is LEFT of this loop's budget, so a wedged
@@ -511,19 +514,25 @@ func (t *TmuxSession) waitForPasteDelivered(
 					t.notePreSubmitEchoObserved()
 					return deliveryObservedLanded
 				}
+				// One weak short-tail sighting is neither confirmed delivery nor
+				// absence. A later failure must not combine with it.
+				lastObservation = deliveryCouldNotObserve
 			} else {
 				streak = 0
-				sawAbsentCapture = true
+				lastObservation = deliveryObservedAbsent
 			}
+		} else {
+			// Observation continuity is load-bearing. The paste can land after an
+			// earlier absent frame, and a failed frame can separate two coincidental
+			// short-tail sightings, so unreadability invalidates both signals.
+			streak = 0
+			lastObservation = deliveryCouldNotObserve
 		}
 		if time.Now().After(deadline) {
-			// A final failed capture must not erase earlier successful observations
-			// of absence (#2214 review). Missing text in an agent not known to echo
-			// still says nothing about whether the paste landed (#2213).
-			if !sawAbsentCapture || t.preSubmitEchoBehavior() != preSubmitEchoes {
-				return deliveryCouldNotObserve
-			}
-			return deliveryObservedAbsent
+			// Only a terminal successful absence in a known echoing pane supports a
+			// negative. Earlier absence followed by unreadability is unknown: the
+			// paste may have drained after that frame.
+			return deadlineOutcome()
 		}
 		time.Sleep(pasteDeliveryPollInterval)
 	}

--- a/session/tmux/submit_test.go
+++ b/session/tmux/submit_test.go
@@ -599,7 +599,7 @@ func TestFailedPostClearCaptureKeepsPreClearBaseline(t *testing.T) {
 		"a failed post-clear capture must fall back to the pre-clear count instead of falsely confirming an old tail")
 }
 
-func TestFinalCaptureFailureKeepsEarlierObservedAbsence(t *testing.T) {
+func TestFinalCaptureFailureMakesEarlierAbsenceUnobservable(t *testing.T) {
 	defer withPasteDeliveryTiming(8*time.Millisecond, time.Millisecond)()
 	captures := 0
 	cmdExec := cmd_test.MockCmdExec{
@@ -614,8 +614,29 @@ func TestFinalCaptureFailureKeepsEarlierObservedAbsence(t *testing.T) {
 	session := newTmuxSession("af_proj", ProgramClaude, NewMockPtyFactory(t), cmdExec)
 
 	got := session.waitForPasteDelivered("DISTINCTIVE_DELIVERY_TAIL", 0)
-	require.Equal(t, deliveryObservedAbsent, got,
-		"a failed final probe must not erase an earlier successful observation of absence (#2214 review)")
+	require.Equal(t, deliveryCouldNotObserve, got,
+		"an early absence followed by failed probes cannot say whether the paste landed later")
+}
+
+func TestCaptureFailureBreaksShortTailSightingStreak(t *testing.T) {
+	defer withPasteDeliveryTiming(8*time.Millisecond, time.Millisecond)()
+	captures := 0
+	cmdExec := cmd_test.MockCmdExec{
+		OutputFunc: func(*exec.Cmd) ([]byte, error) {
+			captures++
+			switch captures {
+			case 1, 3:
+				return []byte("ok"), nil
+			default:
+				return nil, fmt.Errorf("capture failed")
+			}
+		},
+	}
+	session := newTmuxSession("af_proj", ProgramClaude, NewMockPtyFactory(t), cmdExec)
+
+	got := session.waitForPasteDelivered("ok", 0)
+	require.Equal(t, deliveryCouldNotObserve, got,
+		"two weak sightings separated by a failed probe are not consecutive delivery evidence")
 }
 
 // TestObservedDeliveryCachesEchoBehavior proves unknown programs are detected


### PR DESCRIPTION
## Outcome

Prompt-delivery observation now reflects the terminal evidence, not any earlier frame:

- A known-echoing pane is reported observed-absent only when the latest terminal capture succeeded and lacked the prompt.
- A capture failure invalidates earlier absence because the paste may have landed after that frame.
- Unreadable frames reset the short-tail sighting streak, so two weak sightings separated by failure are not treated as consecutive proof.
- The genuine loud case remains intact: a terminal successful absence in Claude/Aider still logs the actionable #1982 error and sends Enter best-effort.

Both bugs failed first: early absence followed by failed captures returned `deliveryObservedAbsent`, and weak `ok` sightings around a failed capture returned `deliveryObservedLanded`.

## Validation

Against pushed head `65d509a31107594409932caeaac5815e519a169e`, after rebasing on the #2247-corrected master and merged #2250/#2252 changes:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `go test -race ./session/tmux`

All pass.

— Captain Claude