### PR TITLE
fix(bugreport): scrub multiline titles before legacy shapes

### DIFF
--- a/bugreport/bugreport_test.go
+++ b/bugreport/bugreport_test.go
@@ -338,6 +338,26 @@ func TestScrubLogRedactsPunctuationTitleWithoutDestroyingDiagnostics(t *testing.
 		`target session "."`, `target session "/"`, "instance .", "instance /;")
 }
 
+// A legacy task-start log rendered titles with %s. If a known title contains a
+// newline, scrub the exact title before the line-oriented legacy matcher can
+// destroy its first line and leave the remainder behind (#2249 late review).
+func TestScrubLogRedactsMultilineTaskTitleBeforeLegacyShape(t *testing.T) {
+	const title = "Confidential\nDeal"
+	r := &redactor{}
+	r.noteTitle(title)
+	in := strings.Join([]string{
+		"task t1 started successfully as instance " + title,
+		fmt.Sprintf("task t2 started successfully as instance %q", title),
+		"next diagnostic survives",
+	}, "\n")
+
+	out := r.scrubLog(in)
+
+	mustNotContain(t, "daemon log", out, "Confidential", "Deal", title)
+	mustContain(t, "daemon log", out, "task t1 started successfully as instance", redactedMarker,
+		"next diagnostic survives")
+}
+
 // A shorter title must never destroy the prefix of a longer title before that
 // longer secret is considered. Map iteration is randomized, so exercise the
 // sanitizer repeatedly: any surviving suffix is a privacy leak.

--- a/bugreport/redact.go
+++ b/bugreport/redact.go
@@ -82,10 +82,11 @@ var privateKeyBlock = regexp.MustCompile(`(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY--
 // name *shape*, so it scrubs archived/killed sessions no live set still knows.
 var afTmuxSessionName = regexp.MustCompile(`af_[0-9a-f]{8}_[^\s:]+`)
 
-// taskStartedInstanceTitle and taskParkedInstanceTitle are the only daemon log
-// shapes that render a raw session title with %s rather than %q. Match the field
-// by its fixed surrounding syntax so punctuation-only legal titles can be
-// removed without treating "." or "/" as a global search pattern. The parked
+// taskStartedInstanceTitle and taskParkedInstanceTitle recognize the two legacy
+// daemon log shapes that rendered a raw session title with %s. New logs use %q,
+// but a bundled tail can contain lines written by an older binary. Match the
+// legacy field by its fixed surrounding syntax so punctuation-only titles can
+// be removed without treating "." or "/" as a global search pattern. The parked
 // form keeps its diagnostic suffix; the started form owns the rest of its line.
 var (
 	taskStartedInstanceTitle = regexp.MustCompile(`(?m)(task \S+ started successfully as instance )[^\r\n]+$`)
@@ -181,6 +182,12 @@ func (r *redactor) scrubUnstructured(s string) string {
 // the log section; it ends by delegating to scrub() for the usual
 // $HOME/username/secret pass.
 func (r *redactor) scrubLog(s string) string {
+	// Remove every known full title representation before any shape-based pass
+	// can consume only part of it. In particular, the legacy raw task-start
+	// matcher is line-oriented while a legal title may contain newlines; running
+	// that matcher first replaced line one and made the original full-title match
+	// impossible, leaking the remaining lines (#2249 late review).
+	s = r.scrubSessionTitles(s)
 	// Redact the title in every af_<hash>_<title> name. Keys on the name shape,
 	// so it catches current AND historical (archived/killed) sessions the live
 	// instance set no longer references.
@@ -192,12 +199,12 @@ func (r *redactor) scrubLog(s string) string {
 			s = strings.ReplaceAll(s, name, tmuxPrefixMarker)
 		}
 	}
-	// taskrun.go has two raw %s title emitters. Their syntax is a safer
-	// boundary than a global punctuation matcher and also catches historical
-	// task-created titles no longer present in instances.json.
+	// Retain compatibility with the two legacy raw %s taskrun.go forms. Their
+	// syntax is a safer boundary than a global punctuation matcher and also
+	// catches historical task-created titles no longer present in instances.json.
 	s = taskStartedInstanceTitle.ReplaceAllString(s, `${1}`+redactedMarker)
 	s = taskParkedInstanceTitle.ReplaceAllString(s, `${1}`+redactedMarker+`${3}`)
-	return r.scrubUnstructured(s)
+	return r.scrub(s)
 }
 
 // scrubSessionTitles removes exact Go-quoted forms of every known title, then
@@ -206,8 +213,8 @@ func (r *redactor) scrubLog(s string) string {
 // delivery errors both format them with %q. Matching strconv.Quote therefore
 // covers every legal title byte-for-byte, including short names and punctuation
 // that are unsafe to replace globally, plus quotes/backslashes that %q escapes
-// (#2238 review). scrubLog handles the two actual raw punctuation emitters by
-// their fixed field syntax.
+// (#2238 review). scrubLog handles legacy raw punctuation emitters by their
+// fixed field syntax.
 func (r *redactor) scrubSessionTitles(s string) string {
 	titles := make([]string, 0, len(r.titles))
 	for title := range r.titles {
@@ -242,7 +249,7 @@ func redactAFTmuxTitle(match string) string {
 }
 
 // replaceBareTitle removes a title only when it occupies a complete text token.
-// The logger's raw %s form is always delimited by surrounding prose/newlines, so
+// The legacy logger's raw %s form is delimited by surrounding prose/newlines, so
 // this covers that representation without compiling punctuation-only titles
 // such as "." or "/" into an unbounded regexp that erases every period or path
 // separator in the bundle. Exact %q forms are handled above before this pass.

--- a/daemon/taskrun.go
+++ b/daemon/taskrun.go
@@ -100,10 +100,10 @@ func deliverTaskPrompt(t *task.Task, prompt string, deferWhileAttached bool) (st
 		// is NOT counted as a failure; the resume machinery re-delivers the
 		// prompt once the limit window resets.
 		if data.Liveness == session.LiveLimitReached {
-			log.InfoLog.Printf("task %s parked at a usage limit as instance %s; waiting for the limit window to reset", t.ID, data.Title)
+			log.InfoLog.Print(taskParkedLogMessage(t.ID, data.Title))
 			return TaskStatusLimitParked, nil
 		}
-		log.InfoLog.Printf("task %s started successfully as instance %s", t.ID, data.Title)
+		log.InfoLog.Print(taskStartedLogMessage(t.ID, data.Title))
 		return "started", nil
 	}
 
@@ -131,6 +131,18 @@ func deliverTaskPrompt(t *task.Task, prompt string, deferWhileAttached bool) (st
 	}
 	log.InfoLog.Printf("task %s delivered prompt to target session %q (%s)", t.ID, target, status)
 	return status, nil
+}
+
+// Keep task-created title logging on the same %q encoding as target-session
+// delivery errors. Besides preventing multiline titles from forging extra log
+// lines, one encoding lets the bug-report redactor register and scrub the title
+// once instead of maintaining another raw representation.
+func taskStartedLogMessage(taskID, title string) string {
+	return fmt.Sprintf("task %s started successfully as instance %q", taskID, title)
+}
+
+func taskParkedLogMessage(taskID, title string) string {
+	return fmt.Sprintf("task %s parked at a usage limit as instance %q; waiting for the limit window to reset", taskID, title)
 }
 
 // deliverCronTaskPrompt delivers a cron task's prompt, waiting out a #1586

--- a/daemon/taskrun_test.go
+++ b/daemon/taskrun_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -14,6 +15,21 @@ import (
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/task"
 )
+
+func TestTaskInstanceLogMessagesQuoteMultilineTitle(t *testing.T) {
+	const title = "Confidential\nDeal"
+	for name, message := range map[string]string{
+		"started": taskStartedLogMessage("task-1", title),
+		"parked":  taskParkedLogMessage("task-2", title),
+	} {
+		if strings.Contains(message, title) || strings.ContainsRune(message, '\n') {
+			t.Fatalf("%s task log contains a raw multiline title: %q", name, message)
+		}
+		if !strings.Contains(message, strconv.Quote(title)) {
+			t.Fatalf("%s task log does not carry the uniform %%q title encoding: %q", name, message)
+		}
+	}
+}
 
 func seedDisabledTask(id string) error {
 	return task.AddTask(task.Task{


### PR DESCRIPTION
## Summary

- scrub every known full title representation before any line-oriented legacy log matcher can consume only part of it
- encode both task-created session log messages with `%q`, collapsing future task-title logs onto the same representation already used by delivery logs and persisted errors
- retain the legacy raw `%s` matchers after the exact-title pass so old log tails and punctuation-only historical titles remain protected

This addresses the legitimate late P2 on #2249. In shipped commit `95f3436f`, the legacy task-start matcher ran before the full-title sanitizer at [bugreport/redact.go:192-201](https://github.com/sachiniyer/agent-factory/blob/95f3436fcded11e96c22e38c89ba96a1f71c4027/bugreport/redact.go#L192-L201). A legal title such as `Confidential\nDeal` therefore lost its first line to the matcher before the exact title could match, leaving `Deal` in the bundle. The source emitters were also still raw at [daemon/taskrun.go:103-106](https://github.com/sachiniyer/agent-factory/blob/461ae6b4fce702614ee050539192b1cec5ce542a/daemon/taskrun.go#L103-L106).

## Fail-first evidence

`TestScrubLogRedactsMultilineTaskTitleBeforeLegacyShape` failed on master because the output still contained `Deal`. It now covers both the shipped raw form and the unified `%q` form while proving the following diagnostic survives. A daemon-side regression also pins that task-started and task-parked messages contain no literal newline and carry exactly `strconv.Quote(title)`.

## Verification

Full gates run after the final commit on pushed SHA `4f7ed8d8033ecae48c198e72844745b21168261e`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh` (`904 Go files checked; 0 grandfathered`)

— Captain Claude