### PR TITLE
fix(tui): make scroll ownership explicit

### DIFF
--- a/agentproto/doc.go
+++ b/agentproto/doc.go
@@ -6,7 +6,8 @@
 // broker and events plane (Phase 2 PR5), and the TUI/CLI/web clients import it to
 // speak the same wire format; so agentproto must depend on NEITHER daemon nor any
 // client package, or those importers would form a cycle. It imports only the
-// standard library and github.com/coder/websocket.
+// standard library, github.com/coder/websocket, and the leaf terminal mode
+// value shared by stream producers and consumers.
 //
 // # Reuse, not re-declaration, of the control plane
 //
@@ -18,8 +19,8 @@
 // authoritative one, and importing the daemon package here would create the
 // import cycle described above. The control action contract therefore has exactly
 // one definition, in package daemon, and this package adds only what is genuinely
-// new to Phase 2 — the PTY data plane, the resize/exit/detach control frames, the
-// events plane, and the auth-readiness seam.
+// new to Phase 2 — the PTY data plane, the resize/terminal-modes/exit/detach
+// control frames, the events plane, and the auth-readiness seam.
 //
 // # Multi-writer, no lease
 //
@@ -34,8 +35,9 @@
 // # What is defined here
 //
 //   - frame.go   — binary PTY frames: PTY_OUT / INPUT / RESIZE opcodes + codec.
-//   - message.go — JSON control frames (resize/exit/detach) carried as WS text
-//     frames on the PTY stream, and the events-plane Event envelope.
+//   - message.go — JSON control frames (resize/terminal-modes/exit/detach)
+//     carried as WS text frames on the PTY stream, and the events-plane Event
+//     envelope.
 //   - auth.go    — transport-carried bearer-token extraction (Authorization
 //     header + ?access_token= query fallback per §4.4). Types and pure helpers
 //     only; Phase 2 enforces nothing (the unix-socket peer is trusted, #1029).

--- a/agentproto/frame.go
+++ b/agentproto/frame.go
@@ -26,10 +26,12 @@ const (
 	// OpRepaint (server → client) prefixes a one-shot screen repaint (clear + the
 	// current pane content) sent to a FRESH subscriber before any live output —
 	// pipe-pane carries no history, so without it a just-opened pane renders blank
-	// (#1592 Phase 2 PR6). The client feeds it to the emulator exactly like OpPTYOut
-	// but must NOT count it toward its replay cursor: a repaint is per-subscriber and
-	// is not part of the shared ring's monotonic seq, so counting it would desync the
-	// ?since arithmetic.
+	// (#1592 Phase 2 PR6). An authoritative MsgTerminalModes immediately precedes
+	// it when the source can report modes; the repaint bytes also carry the same
+	// DEC mode restore for terminal-only clients. The client feeds the repaint to
+	// the emulator exactly like OpPTYOut but must NOT count it toward its replay
+	// cursor: a repaint is per-subscriber and is not part of the shared ring's
+	// monotonic seq, so counting it would desync the ?since arithmetic.
 	OpRepaint Opcode = 0x03
 	// OpHello (server → client) carries the subscription's AUTHORITATIVE output
 	// cursor: an 8-byte big-endian uint64 the client adopts verbatim as its replay

--- a/agentproto/message.go
+++ b/agentproto/message.go
@@ -3,11 +3,13 @@ package agentproto
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/sachiniyer/agent-factory/terminal"
 )
 
 // MessageType is the discriminator of a JSON control frame carried as a WS text
 // frame on the PTY stream (§4.2). Binary frames (frame.go) carry the hot path;
-// these text frames carry size/lifecycle control.
+// these text frames carry terminal snapshot, size, and lifecycle control.
 //
 // Multi-writer model (Sachin, supersedes the design doc's lease sections §3-Q3 /
 // §4.2): af is single-owner, so there is NO attach lease and no interactive/observer
@@ -29,6 +31,11 @@ const (
 	// MsgDetach (client → server) is a clean-close signal; also implicit on socket
 	// close.
 	MsgDetach MessageType = "detach"
+	// MsgTerminalModes (server → client) accompanies a fresh/recovery repaint
+	// with the modes that were already active before the subscriber existed.
+	// Older clients safely ignore this additive control frame; the repaint also
+	// contains DEC restore bytes for terminal-only consumers.
+	MsgTerminalModes MessageType = "terminal_modes"
 )
 
 // ResizeMessage is the server's authoritative size echo (last-resize-wins, §6.2).
@@ -41,6 +48,19 @@ type ResizeMessage struct {
 // NewResizeMessage builds a size echo.
 func NewResizeMessage(rows, cols uint16) ResizeMessage {
 	return ResizeMessage{Type: MsgResize, Rows: rows, Cols: cols}
+}
+
+// TerminalModesMessage carries the ownership-affecting mode half of a pane
+// snapshot. Presence is significant: an all-false Modes value truthfully means
+// primary screen with no mouse tracking, unlike a source that could not report.
+type TerminalModesMessage struct {
+	Type  MessageType    `json:"type"`
+	Modes terminal.Modes `json:"modes"`
+}
+
+// NewTerminalModesMessage builds terminal mode snapshot metadata.
+func NewTerminalModesMessage(modes terminal.Modes) TerminalModesMessage {
+	return TerminalModesMessage{Type: MsgTerminalModes, Modes: modes}
 }
 
 // ExitReason says WHY a MsgExit ended the stream. It is an additive

--- a/agentproto/message_test.go
+++ b/agentproto/message_test.go
@@ -3,6 +3,8 @@ package agentproto
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/sachiniyer/agent-factory/terminal"
 )
 
 // TestControlMessageWireShapes pins the exact JSON each control frame serializes
@@ -32,6 +34,29 @@ func TestControlMessageWireShapes(t *testing.T) {
 				t.Fatalf("wire shape mismatch:\n got  = %s\n want = %s", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestTerminalModesMessageRoundTrip(t *testing.T) {
+	want := NewTerminalModesMessage(terminal.Modes{
+		AlternateScreen: true,
+		MouseTracking:   true,
+		MouseButton:     true,
+		MouseSGR:        true,
+	})
+	raw, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if typ, err := MessageTypeOf(raw); err != nil || typ != MsgTerminalModes {
+		t.Fatalf("MessageTypeOf = %q, %v; want %q", typ, err, MsgTerminalModes)
+	}
+	var got TerminalModesMessage
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got != want {
+		t.Fatalf("round trip = %+v, want %+v", got, want)
 	}
 }
 

--- a/agentproto/wsconn.go
+++ b/agentproto/wsconn.go
@@ -22,7 +22,8 @@ func WriteFrame(ctx context.Context, c *websocket.Conn, f Frame) error {
 }
 
 // WriteControl marshals a JSON control frame (ResizeMessage, ExitMessage,
-// DetachMessage) or an events-plane Event and sends it as a WS text message.
+// DetachMessage, TerminalModesMessage) or an events-plane Event and sends it as
+// a WS text message.
 func WriteControl(ctx context.Context, c *websocket.Conn, msg any) error {
 	b, err := json.Marshal(msg)
 	if err != nil {

--- a/apiclient/stream.go
+++ b/apiclient/stream.go
@@ -119,9 +119,20 @@ const streamSeqHeader = "X-Af-Stream-Seq"
 // Callers that let a user ADDRESS a tab need it to avoid reporting a healthy
 // session as dead — a distinction the daemon can make and a client cannot (#1948).
 func (c *Client) Preview(req daemon.PreviewRequest) (content string, gone, tabGone bool, err error) {
-	var resp daemon.PreviewResponse
-	if err := c.call("Preview", req, &resp); err != nil {
+	resp, err := c.PreviewSnapshot(req)
+	if err != nil {
 		return "", false, false, err
 	}
 	return resp.Content, resp.Gone, resp.TabGone, nil
+}
+
+// PreviewSnapshot is the typed preview response used by terminal-aware clients.
+// Keeping modes beside content prevents a preview target from inheriting the
+// ownership state of whichever pane happened to render before it.
+func (c *Client) PreviewSnapshot(req daemon.PreviewRequest) (daemon.PreviewResponse, error) {
+	var resp daemon.PreviewResponse
+	if err := c.call("Preview", req, &resp); err != nil {
+		return daemon.PreviewResponse{}, err
+	}
+	return resp, nil
 }

--- a/apiclient/stream_test.go
+++ b/apiclient/stream_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sachiniyer/agent-factory/apiproto"
 	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/internal/testguard"
+	"github.com/sachiniyer/agent-factory/terminal"
 )
 
 // previewServer stands up a Unix-socket HTTP server answering POST /v1/Preview
@@ -63,6 +64,29 @@ func TestPreview_CarriesTabAndReturnsContent(t *testing.T) {
 	}
 	if got.Title != "alpha" || got.RepoID != "r" || got.Tab != 2 || !got.Full {
 		t.Fatalf("request lost fields: %+v", *got)
+	}
+}
+
+func TestPreviewSnapshotCarriesTerminalModes(t *testing.T) {
+	wantModes := terminal.Modes{
+		AlternateScreen: true,
+		MouseButton:     true,
+		MouseSGR:        true,
+	}
+	c, _ := previewServer(t, func(daemon.PreviewRequest) apiproto.Envelope {
+		return apiproto.Success(daemon.PreviewResponse{
+			Content:  "ALT-GRID",
+			Modes:    wantModes,
+			HasModes: true,
+		})
+	})
+
+	snapshot, err := c.PreviewSnapshot(daemon.PreviewRequest{Title: "alpha"})
+	if err != nil {
+		t.Fatalf("PreviewSnapshot: %v", err)
+	}
+	if snapshot.Content != "ALT-GRID" || !snapshot.HasModes || snapshot.Modes != wantModes {
+		t.Fatalf("PreviewSnapshot = %+v, want content and modes %+v", snapshot, wantModes)
 	}
 }
 

--- a/app/creation_test.go
+++ b/app/creation_test.go
@@ -126,26 +126,31 @@ func newTestHome(t *testing.T) *home {
 // testPreviewFetcher resolves a Preview request's title back to the in-store
 // instance and captures from it, the test stand-in for the daemon's server-side
 // capture. tmux.ErrSessionGone maps to gone=true, mirroring the daemon handler.
-func testPreviewFetcher(h *home) func(daemon.PreviewRequest) (string, bool, error) {
-	return func(req daemon.PreviewRequest) (string, bool, error) {
+func testPreviewResponse(content string) daemon.PreviewResponse {
+	return daemon.PreviewResponse{Content: content, HasModes: true}
+}
+
+func testPreviewFetcher(h *home) func(daemon.PreviewRequest) (daemon.PreviewResponse, error) {
+	return func(req daemon.PreviewRequest) (daemon.PreviewResponse, error) {
 		inst := h.store.GetInstanceByTitle(req.Title)
 		if inst == nil {
-			return "", false, nil
+			return daemon.PreviewResponse{}, nil
 		}
 		var content string
 		var err error
 		switch {
 		case req.Tab == 0:
-			content, err = inst.AgentServer().Preview(req.Tab, req.Full)
+			snapshot, snapshotErr := inst.AgentServer().Preview(req.Tab, req.Full)
+			content, err = snapshot.Content, snapshotErr
 		case req.Full:
 			content, err = inst.PreviewTabFullHistory(req.Tab)
 		default:
 			content, err = inst.PreviewTab(req.Tab)
 		}
 		if errors.Is(err, tmux.ErrSessionGone) {
-			return "", true, nil
+			return daemon.PreviewResponse{Gone: true}, nil
 		}
-		return content, false, err
+		return testPreviewResponse(content), err
 	}
 }
 

--- a/app/detach_trace_test.go
+++ b/app/detach_trace_test.go
@@ -42,9 +42,9 @@ func TestRefreshPaneBindingCmd_SuppressesTearingDownError(t *testing.T) {
 	inst, err := session.NewInstance(session.InstanceOptions{Title: "closing", Path: t.TempDir(), Program: "test"})
 	require.NoError(t, err)
 
-	tw := ui.NewTabbedWindow(ui.NewTabPane(func(*session.Instance, int, bool) (string, error) {
+	tw := ui.NewTabbedWindow(ui.NewTabPane(func(*session.Instance, int, bool) (ui.PreviewSnapshot, error) {
 		inst.SetStatusForTest(session.Deleting)
-		return "", errors.New("session \"closing\" is being deleted")
+		return ui.PreviewSnapshot{}, errors.New("session \"closing\" is being deleted")
 	}), nil)
 	warnings := captureWarningLog(t)
 
@@ -57,8 +57,8 @@ func TestRefreshPaneBindingCmd_LogsUnexpectedError(t *testing.T) {
 	inst, err := session.NewInstance(session.InstanceOptions{Title: "active", Path: t.TempDir(), Program: "test"})
 	require.NoError(t, err)
 
-	tw := ui.NewTabbedWindow(ui.NewTabPane(func(*session.Instance, int, bool) (string, error) {
-		return "", errors.New("unexpected capture failure")
+	tw := ui.NewTabbedWindow(ui.NewTabPane(func(*session.Instance, int, bool) (ui.PreviewSnapshot, error) {
+		return ui.PreviewSnapshot{}, errors.New("unexpected capture failure")
 	}), nil)
 	warnings := captureWarningLog(t)
 

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -100,11 +100,13 @@ func (m *home) handleDefaultKeyPress(msg tea.KeyMsg, name keys.KeyName) (tea.Mod
 
 	// Scrolling (each pane scrolls its own view, #1088)
 	case keys.KeyShiftUp:
+		m.syncPaneScrollOwners()
 		if pane, _ := m.focusedContentPane(); pane != nil {
 			pane.ScrollUp()
 		}
 		return m, m.selectionChanged()
 	case keys.KeyShiftDown:
+		m.syncPaneScrollOwners()
 		if pane, _ := m.focusedContentPane(); pane != nil {
 			pane.ScrollDown()
 		}

--- a/app/handle_mouse.go
+++ b/app/handle_mouse.go
@@ -338,17 +338,51 @@ func (m *home) forwardInteractiveMouse(msg tea.MouseMsg) bool {
 		return false
 	}
 	if kind == zones.PaneKindTerm {
-		// The wheel belongs to the inner app ONLY when it has enabled mouse
-		// reporting (tmux semantics): otherwise it falls through to handleWheel so
-		// the wheel scrolls the pane scrollback instead of being swallowed by a
-		// program sitting at a prompt (#1024 wheel fix). Clicks/motion/release stay
-		// forwarded regardless — this narrows the change to the wheel alone.
-		if isWheelButton(msg.Button) && !lt.MouseTrackingEnabled() {
-			return false
+		if isWheelButton(msg.Button) {
+			w := m.paneWindows[p.ID()]
+			if m.routePaneWheel(p, w, msg, local, true) {
+				// Host history owns this wheel even while keyboard input continues
+				// to forward through the raw interactive contract.
+				return false
+			}
+			return true
 		}
 		lt.SendMouse(msg, local.X, local.Y)
 	}
 	return true
+}
+
+// routePaneWheel is the single nav/interactive ownership router. It returns
+// true only when AF's host-history controller should receive the gesture.
+// ChildApplication forwards through the child protocol when the same terminal
+// snapshot says tracking is active; an untracked child is consumed so AF never
+// reveals its background primary buffer.
+func (m *home) routePaneWheel(
+	p *store.OpenPane,
+	w *ui.TabbedWindow,
+	msg tea.MouseMsg,
+	local layout.Point,
+	childInput bool,
+) bool {
+	decision := m.resolvePaneScrollOwnership(p, w)
+	switch decision.owner {
+	case ui.ScrollOwnerHostHistory:
+		return true
+	case ui.ScrollOwnerChildApplication:
+		if decision.childMouse && childInput {
+			if lt := m.liveTerms[p.ID()]; lt != nil {
+				lt.SendMouse(msg, local.X, local.Y)
+			}
+		}
+		return false
+	case ui.ScrollOwnerNone:
+		// Capture-backed targets can queue the gesture while their full snapshot
+		// resolves ownership. Fresh live streams install an unavailable controller
+		// and wait for their authoritative repaint instead of guessing.
+		return w != nil && w.CanResolveScrollOwner()
+	default:
+		return false
+	}
 }
 
 // isWheelButton reports whether b is any mouse-wheel button. Wheel events are the
@@ -372,14 +406,17 @@ func (m *home) handleWheel(msg tea.MouseMsg) tea.Cmd {
 	if m.state != stateDefault {
 		return nil
 	}
-	id, _, ok := m.zones.Resolve(msg.X, msg.Y)
+	id, local, ok := m.zones.Resolve(msg.X, msg.Y)
 	if !ok {
 		return nil
 	}
 	up := msg.Button == tea.MouseButtonWheelUp
-	if region, _, isPane := zones.PaneZone(id); isPane {
+	if region, kind, isPane := zones.PaneZone(id); isPane {
 		p, w := m.paneByRegion(region)
 		if p == nil || w == nil || p.Instance() == nil {
+			return nil
+		}
+		if !m.routePaneWheel(p, w, msg, local, kind == zones.PaneKindTerm) {
 			return nil
 		}
 		if up {

--- a/app/home_model.go
+++ b/app/home_model.go
@@ -100,7 +100,7 @@ type home struct {
 	// TabPane's capture runs on the refreshPaneBindingCmd goroutine, so a package
 	// global swapped by a test would race under `go test -parallel`. Defaults to
 	// previewThroughDaemon; tests assign a fake directly.
-	previewFetcher func(req daemon.PreviewRequest) (content string, gone bool, err error)
+	previewFetcher func(req daemon.PreviewRequest) (daemon.PreviewResponse, error)
 	// pauseStatusPoll / resumeStatusPoll are the daemon poll-pause seams for the
 	// attach heartbeat (#1160). PER-home fields, not package globals, for the
 	// same reason as snapshotFetcher: the heartbeat reads the seam from an
@@ -787,6 +787,7 @@ func (m *home) syncFocus() {
 	}
 	m.menu.SetFocusRegion(active)
 	m.syncSplitPaneHint()
+	m.syncScrollHint()
 }
 
 // focusRegion moves focus directly to the given region and re-solves the

--- a/app/home_panes.go
+++ b/app/home_panes.go
@@ -24,6 +24,7 @@ import (
 // reads it. Synchronous fields touched here (selection binding, menu state)
 // stay on the event loop.
 func (m *home) selectionChanged() tea.Cmd {
+	defer m.syncScrollHint()
 	selectionStart := time.Now()
 	detachTraceMark("selectionChanged-entry")
 	sel := m.sidebar.GetSelection()

--- a/app/home_update.go
+++ b/app/home_update.go
@@ -314,6 +314,7 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// so any in-flight watchdog should stop. No-op when no detach is
 		// currently in flight.
 		endDetachWatchdog()
+		m.syncScrollHint()
 		return m, nil
 	case panePreviewStaleExpiredMsg:
 		m.expireStalePanePreview(msg)

--- a/app/live_stream.go
+++ b/app/live_stream.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/tmux"
+	"github.com/sachiniyer/agent-factory/terminal"
 	"github.com/sachiniyer/agent-factory/ui"
 	"github.com/sachiniyer/agent-factory/ui/termpane"
 )
@@ -24,22 +25,25 @@ import (
 func (m *home) newTabPaneSource() ui.PreviewSource {
 	repoID := m.repoID
 	fetch := m.previewFetcher
-	return func(instance *session.Instance, tab int, full bool) (string, error) {
+	return func(instance *session.Instance, tab int, full bool) (ui.PreviewSnapshot, error) {
 		if instance == nil || fetch == nil {
-			return "", nil
+			return ui.PreviewSnapshot{}, nil
 		}
 		// Address the capture by the tab's stable id (#1738) so it can't grab the
 		// wrong tab after a reorder/close. Only an empty id uses the legacy ordinal;
 		// a non-empty id that no longer resolves is refused, never fallen back.
 		tabID, _ := instance.TabIDAt(tab)
-		content, gone, err := fetch(daemon.PreviewRequest{Title: instance.Title, RepoID: repoID, Tab: tab, TabID: tabID, Full: full})
+		resp, err := fetch(daemon.PreviewRequest{Title: instance.Title, RepoID: repoID, Tab: tab, TabID: tabID, Full: full})
 		if err != nil {
-			return "", err
+			return ui.PreviewSnapshot{}, err
 		}
-		if gone {
-			return "", tmux.ErrSessionGone
+		if resp.Gone {
+			return ui.PreviewSnapshot{}, tmux.ErrSessionGone
 		}
-		return content, nil
+		return ui.PreviewSnapshot{
+			Content: resp.Content,
+			Owner:   scrollOwnerForModes(resp.Modes, resp.HasModes),
+		}, nil
 	}
 }
 
@@ -73,7 +77,8 @@ func streamDialer(title, repoID, tabID string, tab int) termpane.Dialer {
 // authoritative resize control frame becomes EventResize, and INPUT/RESIZE go out as
 // binary frames.
 type apiStream struct {
-	sc *apiclient.StreamConn
+	sc           *apiclient.StreamConn
+	pendingModes *terminal.Modes
 }
 
 var _ termpane.Stream = (*apiStream)(nil)
@@ -94,7 +99,12 @@ func (s *apiStream) Recv(ctx context.Context) (termpane.Event, error) {
 			case agentproto.OpPTYOut:
 				return termpane.Event{Kind: termpane.EventData, Data: msg.Frame.Data}, nil
 			case agentproto.OpRepaint:
-				return termpane.Event{Kind: termpane.EventRepaint, Data: msg.Frame.Data}, nil
+				ev := termpane.Event{Kind: termpane.EventRepaint, Data: msg.Frame.Data}
+				if s.pendingModes != nil {
+					ev.Modes, ev.HasModes = *s.pendingModes, true
+					s.pendingModes = nil
+				}
+				return ev, nil
 			case agentproto.OpHello:
 				// The server's authoritative cursor. The opening hello merely restates the
 				// X-Af-Stream-Seq header the pane already adopted (harmlessly idempotent);
@@ -104,7 +114,21 @@ func (s *apiStream) Recv(ctx context.Context) (termpane.Event, error) {
 			}
 			continue // INPUT/RESIZE are client→server; ignore any echoed back
 		}
-		if typ, _ := agentproto.MessageTypeOf(msg.Text); typ == agentproto.MsgResize {
+		typ, _ := agentproto.MessageTypeOf(msg.Text)
+		if typ == agentproto.MsgTerminalModes {
+			var mm agentproto.TerminalModesMessage
+			// A malformed replacement must not lend the prior repaint's modes to
+			// the next grid. Clear first so ownership metadata is fail-closed.
+			s.pendingModes = nil
+			if json.Unmarshal(msg.Text, &mm) == nil {
+				modes := mm.Modes
+				s.pendingModes = &modes
+			}
+			// Modes and repaint are emitted consecutively by the daemon. Keep
+			// reading so termpane applies both under one emulator lock.
+			continue
+		}
+		if typ == agentproto.MsgResize {
 			var rm agentproto.ResizeMessage
 			if json.Unmarshal(msg.Text, &rm) == nil {
 				return termpane.Event{Kind: termpane.EventResize, Rows: rm.Rows, Cols: rm.Cols}, nil

--- a/app/live_stream_modes_test.go
+++ b/app/live_stream_modes_test.go
@@ -1,0 +1,90 @@
+package app
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/sachiniyer/agent-factory/agentproto"
+	"github.com/sachiniyer/agent-factory/apiclient"
+	"github.com/sachiniyer/agent-factory/terminal"
+	"github.com/sachiniyer/agent-factory/ui/termpane"
+)
+
+func testAPIStream(t *testing.T, write func(context.Context, *websocket.Conn) error) *apiStream {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+	serverErr := make(chan error, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		defer conn.Close(websocket.StatusNormalClosure, "")
+		if err := write(ctx, conn); err != nil {
+			serverErr <- err
+		}
+	}))
+	t.Cleanup(srv.Close)
+	wsURL := "ws" + srv.URL[len("http"):]
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close(websocket.StatusNormalClosure, "") })
+
+	select {
+	case err := <-serverErr:
+		t.Fatalf("stream server: %v", err)
+	default:
+	}
+	return &apiStream{sc: &apiclient.StreamConn{Conn: conn}}
+}
+
+func TestAPIStreamBindsTerminalModesToRepaint(t *testing.T) {
+	want := terminal.Modes{
+		AlternateScreen: true,
+		MouseTracking:   true,
+		MouseButton:     true,
+		MouseSGR:        true,
+	}
+	stream := testAPIStream(t, func(ctx context.Context, conn *websocket.Conn) error {
+		if err := agentproto.WriteControl(ctx, conn, agentproto.NewTerminalModesMessage(want)); err != nil {
+			return err
+		}
+		return agentproto.WriteFrame(ctx, conn, agentproto.RepaintFrame([]byte("ALT-GRID")))
+	})
+
+	ev, err := stream.Recv(context.Background())
+	if err != nil {
+		t.Fatalf("Recv: %v", err)
+	}
+	if ev.Kind != termpane.EventRepaint || string(ev.Data) != "ALT-GRID" || !ev.HasModes || ev.Modes != want {
+		t.Fatalf("event = %+v, want repaint and modes %+v", ev, want)
+	}
+}
+
+func TestAPIStreamMalformedModesCannotReusePriorSnapshot(t *testing.T) {
+	stream := testAPIStream(t, func(ctx context.Context, conn *websocket.Conn) error {
+		if err := agentproto.WriteControl(ctx, conn, agentproto.NewTerminalModesMessage(terminal.Modes{AlternateScreen: true})); err != nil {
+			return err
+		}
+		if err := conn.Write(ctx, websocket.MessageText, []byte(`{"type":"terminal_modes","modes":"bad"}`)); err != nil {
+			return err
+		}
+		return agentproto.WriteFrame(ctx, conn, agentproto.RepaintFrame([]byte("GRID")))
+	})
+
+	ev, err := stream.Recv(context.Background())
+	if err != nil {
+		t.Fatalf("Recv: %v", err)
+	}
+	if ev.Kind != termpane.EventRepaint || ev.HasModes {
+		t.Fatalf("event = %+v, malformed replacement must fail closed", ev)
+	}
+}

--- a/app/live_termpane.go
+++ b/app/live_termpane.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/terminal"
+	"github.com/sachiniyer/agent-factory/ui"
 	"github.com/sachiniyer/agent-factory/ui/store"
 	"github.com/sachiniyer/agent-factory/ui/termpane"
 )
@@ -45,11 +47,10 @@ type liveTermAttachment interface {
 	// in-pane mouse path (#1024 R4). The emulator is mode-aware: the event reaches
 	// the inner app only if it enabled mouse tracking, and is dropped otherwise.
 	SendMouse(msg tea.MouseMsg, x, y int) bool
-	// MouseTrackingEnabled reports whether the inner app has requested mouse
-	// reporting (a mouse-tracking DECMode is active). The router uses it to decide
-	// wheel ownership: an app that has not enabled tracking leaves the wheel to
-	// pane scrollback rather than swallowing it (#1024 wheel fix).
-	MouseTrackingEnabled() bool
+	// TerminalModes reports the ownership-affecting terminal snapshot and whether
+	// it is known. A fresh/reconnected client stays unknown until its repaint
+	// lands; zero modes are otherwise a valid primary-screen state.
+	TerminalModes() (terminal.Modes, bool)
 }
 
 // newLiveTermPaneFn is the attachment creation seam. Production dials the daemon
@@ -65,6 +66,7 @@ var newLiveTermPaneFn = func(title, repoID, tabID string, tab, width, height int
 // steady-state cost is a per-visible-pane eligibility check plus map lookups.
 func (m *home) syncLiveTermPane() {
 	m.reconcileLiveTermPanes()
+	m.syncPaneScrollOwners()
 	m.enforceInteractiveInvariant()
 }
 
@@ -161,6 +163,9 @@ func (m *home) bindLiveTermPaneFor(p *store.OpenPane, create bool) (string, bool
 	m.liveTerms[p.ID()] = tp
 	m.liveKeys[p.ID()] = key
 	w.SetLive(tp)
+	// Do not guess primary-screen ownership during the fresh-subscribe window.
+	// The stream repaint carries an explicit all-off state when that is true.
+	w.SetScrollOwner(ui.ScrollOwnerNone)
 	return key, true
 }
 
@@ -386,6 +391,9 @@ func (m *home) closeLiveTermPaneFor(paneID int) {
 	}
 	if w := m.paneWindows[paneID]; w != nil {
 		w.SetLive(nil)
+		// The pane is capture-backed again. Preserve an immediate scroll gesture
+		// while its next detached snapshot resolves the current target's owner.
+		w.SetScrollOwnerResolving()
 	}
 	if err := lt.Close(); err != nil {
 		log.WarningLog.Printf("termpane: close pane %d: %v", paneID, err)

--- a/app/live_termpane_test.go
+++ b/app/live_termpane_test.go
@@ -11,6 +11,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/terminal"
 )
 
 // fakeLiveTerm drives the per-pane live-attachment state machine (#1592 Phase 2
@@ -24,11 +25,9 @@ type fakeLiveTerm struct {
 	keys []string
 	// mice records every event forwarded through SendMouse with its grid-local
 	// coordinates (#1024 R4 interactive forwarding).
-	mice []forwardedMouse
-	// mouseTracking is what MouseTrackingEnabled reports — the fake's stand-in for
-	// the inner app having requested mouse reporting (#1024 wheel fix). Off by
-	// default: a program sitting at a prompt owns no wheel.
-	mouseTracking bool
+	mice       []forwardedMouse
+	modes      terminal.Modes
+	modesKnown bool
 }
 
 // forwardedMouse is one SendMouse call as the fake recorded it.
@@ -37,7 +36,7 @@ type forwardedMouse struct {
 	x, y int
 }
 
-func newFakeLiveTerm() *fakeLiveTerm { return &fakeLiveTerm{} }
+func newFakeLiveTerm() *fakeLiveTerm { return &fakeLiveTerm{modesKnown: true} }
 
 // Render stands in for the streamed grid, echoing whatever has been SendKey'd
 // into it. The echo lets a test assert the pane RENDERS what the user typed —
@@ -60,7 +59,9 @@ func (f *fakeLiveTerm) SendMouse(msg tea.MouseMsg, x, y int) bool {
 	return true
 }
 
-func (f *fakeLiveTerm) MouseTrackingEnabled() bool { return f.mouseTracking }
+func (f *fakeLiveTerm) TerminalModes() (terminal.Modes, bool) {
+	return f.modes, f.modesKnown
+}
 
 // stubLiveTermFactory points the attachment seam at fake attachments and returns
 // the created fakes + the session titles they were created for.

--- a/app/mouse_test.go
+++ b/app/mouse_test.go
@@ -8,10 +8,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 	"github.com/sachiniyer/agent-factory/task"
+	"github.com/sachiniyer/agent-factory/terminal"
+	"github.com/sachiniyer/agent-factory/ui"
 	"github.com/sachiniyer/agent-factory/ui/layout"
 	"github.com/sachiniyer/agent-factory/ui/layout/zones"
 	"github.com/sachiniyer/agent-factory/ui/overlay"
@@ -574,6 +577,8 @@ func TestMouse_WheelScrollsRegionUnderCursor(t *testing.T) {
 	p := openTestPane(t, h, alpha, 0)
 	region := layout.PaneRegion(p.ID())
 	h.focusRegion(region)
+	require.NoError(t, h.paneWindows[p.ID()].UpdateContent(alpha),
+		"the first detached snapshot establishes host ownership")
 	require.False(t, h.sidebar.GetSelection().IsTab)
 
 	// Over the tree: the cursor walks down (alpha → its first tab row) and
@@ -604,6 +609,151 @@ func TestMouse_WheelScrollsRegionUnderCursor(t *testing.T) {
 		"wheel over the pane scrolls the pane")
 	assert.Equal(t, 1, h.automations.SelectedTaskIndex(),
 		"pane scroll must not leak into the task selection")
+}
+
+func TestMouse_NavWheelUsesTerminalScrollOwner(t *testing.T) {
+	h, inst := liveTestHome(t)
+	resizeHome(h, 200, 40)
+	fakes, _ := stubLiveTermFactory(t)
+	h.syncLiveTermPane()
+	require.Len(t, *fakes, 1)
+	fake := (*fakes)[0]
+	p := h.focusedOpenPane()
+	require.NotNil(t, p)
+	w := h.paneWindows[p.ID()]
+	require.NotNil(t, w)
+	term := zoneRect(t, h, zones.PaneTerm(layout.PaneRegion(p.ID())))
+
+	// Claude-style fullscreen: the alternate-screen child explicitly tracks
+	// mouse, so nav wheel goes to that child instead of capture-pane history.
+	fake.modes = terminal.Modes{
+		AlternateScreen: true,
+		MouseTracking:   true,
+		MouseButton:     true,
+		MouseSGR:        true,
+	}
+	h.syncPaneScrollOwners()
+	wheel(h, term.X+4, term.Y+2, true)
+	require.Len(t, fake.mice, 1)
+	assert.Equal(t, ui.ScrollOwnerChildApplication, w.ScrollOwner())
+	assert.False(t, w.IsInScrollMode(), "child wheel must not enter host history")
+
+	// Codex transcript: alternate-screen remains child-owned, but Codex requests
+	// no mouse protocol. The wheel is unavailable rather than silently scrolling
+	// the primary composer history behind the transcript.
+	fake.modes = terminal.Modes{AlternateScreen: true}
+	h.syncPaneScrollOwners()
+	wheel(h, term.X+4, term.Y+2, true)
+	assert.Len(t, fake.mice, 1, "untracked child wheel must not be fabricated")
+	assert.False(t, w.IsInScrollMode(), "untracked child must not fall back to host history")
+	assert.NotContains(t, h.menu.String(), "ctrl+u",
+		"child-owned preview must not advertise AF history scrolling")
+	_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyCtrlU}, keys.KeyShiftUp)
+	assert.False(t, w.IsInScrollMode(), "advertised-off keyboard scroll must also be a controller no-op")
+
+	// The same process returns to Codex's primary composer: ownership switches
+	// back to tmux history without a pane rebind.
+	fake.modes = terminal.Modes{}
+	h.syncPaneScrollOwners()
+	assert.Equal(t, ui.ScrollOwnerHostHistory, w.ScrollOwner())
+	assert.Contains(t, h.menu.String(), "ctrl+u")
+	wheel(h, term.X+4, term.Y+2, true)
+	assert.True(t, w.IsInScrollMode(), "primary-screen Codex must regain host history")
+	assert.Same(t, inst, p.Instance())
+}
+
+func TestKeyboardScrollResolvesLiveOwnerAtInputTime(t *testing.T) {
+	h, _ := liveTestHome(t)
+	resizeHome(h, 120, 40)
+	fakes, _ := stubLiveTermFactory(t)
+	h.syncLiveTermPane()
+	require.Len(t, *fakes, 1)
+	fake := (*fakes)[0]
+	p := h.focusedOpenPane()
+	require.NotNil(t, p)
+	w := h.paneWindows[p.ID()]
+
+	// Switch after the last preview tick. The key handler must read the current
+	// stream snapshot itself, not trust the controller installed by that tick.
+	fake.modes = terminal.Modes{AlternateScreen: true}
+	_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyCtrlU}, keys.KeyShiftUp)
+	require.Equal(t, ui.ScrollOwnerChildApplication, w.ScrollOwner())
+	require.False(t, w.IsInScrollMode(),
+		"a mode switch immediately before Ctrl-U must not expose primary history")
+
+	fake.modes = terminal.Modes{}
+	_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyCtrlU}, keys.KeyShiftUp)
+	require.Equal(t, ui.ScrollOwnerHostHistory, w.ScrollOwner())
+	require.True(t, w.IsInScrollMode(),
+		"returning to the primary screen must restore host keyboard scrolling")
+}
+
+func TestMouse_TransientPreviewUsesTargetSnapshotOwner(t *testing.T) {
+	h := newTestHome(t)
+	for _, title := range []string{"alpha", "beta", "gamma"} {
+		inst := instanceWithFakeBackend(t, title)
+		inst.AddTabForTest("agent", session.TabKindAgent)
+		h.store.AddInstance(inst)
+	}
+	h.previewFetcher = func(req daemon.PreviewRequest) (daemon.PreviewResponse, error) {
+		content := req.Title + "-visible"
+		if req.Full {
+			content = appNumberedHistory(100)
+		}
+		resp := testPreviewResponse(content)
+		if req.Title == "beta" {
+			resp.Modes = terminal.Modes{AlternateScreen: true}
+		}
+		return resp, nil
+	}
+	h.sidebar.SetSelectedInstance(0)
+	_ = h.selectionChanged()
+	resizeHome(h, 200, 40)
+
+	alpha := h.store.GetInstanceByTitle("alpha")
+	p := openTestPane(t, h, alpha, 0)
+	w := h.paneWindows[p.ID()]
+	require.NotNil(t, w)
+	h.focusRegion(layout.PaneRegion(p.ID()))
+	require.NoError(t, w.UpdateContent(alpha))
+	require.Equal(t, ui.ScrollOwnerHostHistory, w.ScrollOwner())
+
+	// Retarget the pane to an alternate-screen target. The target capture, not
+	// alpha's committed binding, supplies the ownership decision.
+	h.sidebar.SetSelectedInstance(1)
+	_ = h.selectionChanged()
+	beta := h.store.GetInstanceByTitle("beta")
+	require.NotNil(t, h.panePreviewTxn)
+	require.IsType(t, panesRefreshedMsg{},
+		refreshPaneBindingCmd(w, beta, 0, h.panePreviewTxn.seq)())
+	h.syncScrollHint()
+	require.Equal(t, ui.ScrollOwnerChildApplication, w.ScrollOwner())
+	assert.NotContains(t, h.menu.String(), "ctrl+u")
+
+	_ = h.View()
+	body := zoneRect(t, h, zones.PaneBody(layout.PaneRegion(p.ID())))
+	wheel(h, body.X+2, body.Y+3, true)
+	assert.False(t, w.IsInScrollMode(),
+		"an alt-screen transient preview must not expose the committed pane's host history")
+	_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyCtrlU}, keys.KeyShiftUp)
+	assert.False(t, w.IsInScrollMode(), "hidden keyboard scroll must be a no-op too")
+
+	// A later primary-screen target establishes HostHistory from its own capture
+	// and immediately regains both input paths.
+	h.sidebar.SetSelectedInstance(2)
+	_ = h.selectionChanged()
+	gamma := h.store.GetInstanceByTitle("gamma")
+	require.NotNil(t, h.panePreviewTxn)
+	require.IsType(t, panesRefreshedMsg{},
+		refreshPaneBindingCmd(w, gamma, 0, h.panePreviewTxn.seq)())
+	h.syncScrollHint()
+	require.Equal(t, ui.ScrollOwnerHostHistory, w.ScrollOwner())
+	assert.Contains(t, h.menu.String(), "ctrl+u")
+
+	_ = h.View()
+	body = zoneRect(t, h, zones.PaneBody(layout.PaneRegion(p.ID())))
+	wheel(h, body.X+2, body.Y+3, true)
+	assert.True(t, w.IsInScrollMode(), "host-owned transient preview must retain scrolling")
 }
 
 // TestMouse_ConfirmOverlayClicks: the kill confirmation's y/n words act as
@@ -838,7 +988,7 @@ func TestMouse_InteractiveForwardsGridEvents(t *testing.T) {
 
 	// The wheel forwards ONLY when the inner app enabled mouse reporting (#1024
 	// wheel fix). With tracking on it owns the wheel, exactly like a click.
-	fake.mouseTracking = true
+	fake.modes.MouseTracking = true
 	wheel(h, term.X+5, term.Y+3, true)
 	require.Len(t, fake.mice, 2, "with tracking enabled the inner app owns the wheel (§2.5)")
 	assert.Equal(t, tea.MouseButtonWheelUp, fake.mice[1].msg.Button)
@@ -857,7 +1007,8 @@ func TestMouse_InteractiveForwardsGridEvents(t *testing.T) {
 // semantics) — the #1024 regression where the wheel was swallowed at a prompt.
 func TestMouse_InteractiveWheelWithoutTrackingScrollsScrollback(t *testing.T) {
 	h, fake, region := interactiveMouseHome(t)
-	require.False(t, fake.mouseTracking, "the inner app owns no wheel until it enables tracking")
+	require.False(t, fake.modes.MouseTrackingEnabled(),
+		"the inner app owns no wheel until it enables tracking")
 
 	term := zoneRect(t, h, zones.PaneTerm(region))
 	wheel(h, term.X+5, term.Y+3, true)
@@ -872,6 +1023,20 @@ func TestMouse_InteractiveWheelWithoutTrackingScrollsScrollback(t *testing.T) {
 	press(h, term.X+5, term.Y+3)
 	require.Len(t, fake.mice, 1, "clicks forward unchanged — only the wheel falls through")
 	assert.Equal(t, tea.MouseButtonLeft, fake.mice[0].msg.Button)
+}
+
+func TestMouse_InteractiveUntrackedAltScreenDoesNotScrollBackgroundHistory(t *testing.T) {
+	h, fake, region := interactiveMouseHome(t)
+	fake.modes = terminal.Modes{AlternateScreen: true}
+	h.syncPaneScrollOwners()
+
+	term := zoneRect(t, h, zones.PaneTerm(region))
+	wheel(h, term.X+5, term.Y+3, true)
+
+	assert.Empty(t, fake.mice, "Codex transcript did not request mouse reports")
+	assert.False(t, h.paneWindows[h.focusedOpenPane().ID()].IsInScrollMode(),
+		"alternate-screen wheel must never reveal the background primary buffer")
+	assert.True(t, h.interactive, "unsupported wheel must not change keyboard ownership")
 }
 
 func TestMouse_InteractiveTabDragConsumesTerminalMotionAndDrop(t *testing.T) {

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -405,6 +405,8 @@ func TestPanePreviewEscFromScrollRevertsOriginalCommittedTab(t *testing.T) {
 	_ = h.selectionChanged()
 	require.NotNil(t, h.panePreviewTxn)
 	require.True(t, w.Previewing())
+	require.IsType(t, panesRefreshedMsg{},
+		refreshPaneBindingCmd(w, beta, 0, h.panePreviewTxn.seq)())
 
 	_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyCtrlU}, keys.KeyShiftUp)
 	require.True(t, w.IsInScrollMode(), "precondition: preview pane is in scroll mode")

--- a/app/scroll_fill_inflight_test.go
+++ b/app/scroll_fill_inflight_test.go
@@ -53,11 +53,11 @@ func TestPreviewScrollFirstIntentConformanceKeyboardAndWheel(t *testing.T) {
 		for _, input := range []string{"keyboard", "wheel"} {
 			t.Run(size.name+"/"+input, func(t *testing.T) {
 				h := newTestHome(t)
-				h.previewFetcher = func(req daemon.PreviewRequest) (string, bool, error) {
+				h.previewFetcher = func(req daemon.PreviewRequest) (daemon.PreviewResponse, error) {
 					if req.Full {
-						return history, false, nil
+						return testPreviewResponse(history), nil
 					}
-					return "visible-line", false, nil
+					return testPreviewResponse("visible-line"), nil
 				}
 				inst := instanceWithFakeBackend(t, "scroll-input")
 				inst.AddTabForTest("agent", session.TabKindAgent)
@@ -69,6 +69,8 @@ func TestPreviewScrollFirstIntentConformanceKeyboardAndWheel(t *testing.T) {
 				pane := openTestPane(t, h, inst, 0)
 				w := h.paneWindows[pane.ID()]
 				require.NotNil(t, w)
+				require.NoError(t, w.UpdateContent(inst),
+					"the first detached snapshot establishes host ownership")
 
 				switch input {
 				case "keyboard":
@@ -85,9 +87,10 @@ func TestPreviewScrollFirstIntentConformanceKeyboardAndWheel(t *testing.T) {
 				require.NoError(t, w.UpdateContent(inst))
 
 				_, paneHeight := w.GetPreviewSize()
-				// History has 100 rows plus the footer. Bottom's first marker is
-				// 102-paneHeight; one preserved up intent makes it 101-paneHeight.
-				require.Equal(t, 101-paneHeight, firstRenderedHistoryMarker(w.View(), historyLines),
+				// AF chrome lives in the pane header, outside these 100 terminal
+				// rows. Bottom's first marker is 101-paneHeight; one preserved up
+				// intent makes it 100-paneHeight.
+				require.Equal(t, 100-paneHeight, firstRenderedHistoryMarker(w.View(), historyLines),
 					"first %s intent must be visible after fill at %s", input, size.name)
 
 				// Exercise the matching down route too. Once history is ready this
@@ -101,7 +104,7 @@ func TestPreviewScrollFirstIntentConformanceKeyboardAndWheel(t *testing.T) {
 					body := zoneRect(t, h, zones.PaneBody(region))
 					wheel(h, body.X+1, body.Y+1, false)
 				}
-				require.Equal(t, 102-paneHeight, firstRenderedHistoryMarker(w.View(), historyLines),
+				require.Equal(t, 101-paneHeight, firstRenderedHistoryMarker(w.View(), historyLines),
 					"%s down intent must return to bottom at %s", input, size.name)
 			})
 		}
@@ -132,17 +135,19 @@ func TestPanesRefreshNoRedundantScrollFillCapture(t *testing.T) {
 	// how many times it is dispatched. The non-full path is left unblocked.
 	release := make(chan struct{})
 	var fullCaptures int32
-	h.previewFetcher = func(req daemon.PreviewRequest) (string, bool, error) {
+	h.previewFetcher = func(req daemon.PreviewRequest) (daemon.PreviewResponse, error) {
 		if req.Full {
 			atomic.AddInt32(&fullCaptures, 1)
 			<-release
 		}
-		return "scrollback-line", false, nil
+		return testPreviewResponse("scrollback-line"), nil
 	}
 
 	pane := openTestPane(t, h, inst, 0) // captures the gated fetcher above
 	w := h.paneWindows[pane.ID()]
 	require.NotNil(t, w)
+	require.NoError(t, w.UpdateContent(inst),
+		"the first detached snapshot establishes host ownership")
 
 	// Enter scroll mode: marks a pending off-loop fill, no capture on the loop.
 	w.ScrollUp()

--- a/app/scroll_ownership.go
+++ b/app/scroll_ownership.go
@@ -1,0 +1,78 @@
+package app
+
+import (
+	"github.com/sachiniyer/agent-factory/terminal"
+	"github.com/sachiniyer/agent-factory/ui"
+	"github.com/sachiniyer/agent-factory/ui/store"
+)
+
+// scrollOwnerForModes is the one terminal ownership decision used by nav
+// preview and interactive mouse routing. Alternate-screen applications own
+// their private history even when they do not track the mouse (Codex transcript);
+// a primary-screen application that explicitly tracks mouse also owns wheel
+// input. Unknown is never guessed as host history.
+func scrollOwnerForModes(modes terminal.Modes, known bool) ui.ScrollOwner {
+	if !known {
+		return ui.ScrollOwnerNone
+	}
+	if modes.AlternateScreen || modes.MouseTrackingEnabled() {
+		return ui.ScrollOwnerChildApplication
+	}
+	return ui.ScrollOwnerHostHistory
+}
+
+// paneScrollOwnership is the input-time decision for one target. childMouse is
+// derived from the same mode snapshot as owner so nav and interactive routing
+// cannot disagree by consulting two independently updated flags.
+type paneScrollOwnership struct {
+	owner      ui.ScrollOwner
+	childMouse bool
+}
+
+func (m *home) resolvePaneScrollOwnership(p *store.OpenPane, w *ui.TabbedWindow) paneScrollOwnership {
+	if p == nil || w == nil {
+		return paneScrollOwnership{}
+	}
+	if m.paneIsPreviewing(p) {
+		// SetPreview starts at None; the target's detached PreviewSnapshot replaces
+		// it when content and terminal modes land together. Never consult the
+		// committed pane's live stream for a transient target.
+		return paneScrollOwnership{owner: w.ScrollOwner()}
+	}
+	if lt := m.liveTerms[p.ID()]; lt != nil {
+		modes, known := lt.TerminalModes()
+		decision := paneScrollOwnership{
+			owner:      scrollOwnerForModes(modes, known),
+			childMouse: known && modes.MouseTrackingEnabled(),
+		}
+		w.SetScrollOwner(decision.owner)
+		return decision
+	}
+	// Capture-only tabs receive ownership from their latest PreviewSnapshot.
+	// Unknown stays unknown rather than being inferred as host scrollback.
+	return paneScrollOwnership{owner: w.ScrollOwner()}
+}
+
+// syncPaneScrollOwner resolves and installs the current owner for one pane.
+// Applications can switch owners without changing process or pane identity, so
+// callers use this at input time as well as on the preview tick.
+func (m *home) syncPaneScrollOwner(p *store.OpenPane, w *ui.TabbedWindow) ui.ScrollOwner {
+	return m.resolvePaneScrollOwnership(p, w).owner
+}
+
+func (m *home) syncPaneScrollOwners() {
+	for _, p := range m.visiblePanes {
+		if w := m.paneWindows[p.ID()]; w != nil {
+			m.syncPaneScrollOwner(p, w)
+		}
+	}
+	m.syncScrollHint()
+}
+
+// syncScrollHint keeps Ctrl-U/Ctrl-D honest. Child-owned or unknown previews
+// cannot provide a non-mutating AF history view, so they do not advertise those
+// keys. Mouse tracking is routed independently at input time.
+func (m *home) syncScrollHint() {
+	w, _ := m.focusedContentPane()
+	m.menu.SetScrollAvailable(w != nil && w.ScrollOwner() == ui.ScrollOwnerHostHistory)
+}

--- a/app/session_control.go
+++ b/app/session_control.go
@@ -380,15 +380,13 @@ func snapshotThroughDaemon(repoID string) (daemon.SnapshotResponse, error) {
 // (refreshPaneBindingCmd), so a mutable global would race a test seam swap under
 // `go test -parallel`; the fetcher lives per-home instead, and tests assign a fake
 // to home.previewFetcher directly (the #960 PR4 / snapshot-fetcher race lesson).
-func previewThroughDaemon(req daemon.PreviewRequest) (content string, gone bool, err error) {
+func previewThroughDaemon(req daemon.PreviewRequest) (resp daemon.PreviewResponse, err error) {
 	err = withDaemonHTTP(func(c *apiclient.Client) error {
 		var e error
-		// tabGone is deliberately dropped here: the TUI renders its session-gone
-		// fallback for either cause, and it addresses tabs it can see (#1948).
-		content, gone, _, e = c.Preview(req)
+		resp, e = c.PreviewSnapshot(req)
 		return e
 	})
-	return content, gone, err
+	return resp, err
 }
 
 // allReposSnapshotFetcher returns the daemon's session list across EVERY repo

--- a/daemon/agentserver_headless.go
+++ b/daemon/agentserver_headless.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/terminal"
 )
 
 // The headless single-workspace agent-server (#1592 Phase 4 PR1) — the process
@@ -297,15 +298,19 @@ type agentPreviewRequest struct {
 }
 
 type agentPreviewResponse struct {
-	Content string `json:"content"`
+	Content  string         `json:"content"`
+	Modes    terminal.Modes `json:"terminal_modes,omitempty"`
+	HasModes bool           `json:"has_terminal_modes,omitempty"`
 }
 
 func (hs *headlessServer) Preview(req agentPreviewRequest, resp *agentPreviewResponse) error {
-	content, err := hs.as.Preview(req.Tab, req.Full)
+	snapshot, err := hs.as.Preview(req.Tab, req.Full)
 	if err != nil {
 		return err
 	}
-	resp.Content = content
+	resp.Content = snapshot.Content
+	resp.Modes = snapshot.Modes
+	resp.HasModes = snapshot.HasModes
 	return nil
 }
 

--- a/daemon/agentserver_headless_test.go
+++ b/daemon/agentserver_headless_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/internal/testguard"
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/terminal"
 )
 
 // fakeHeadlessAgentServer is an in-memory session.AgentServer for the headless
@@ -51,9 +52,15 @@ func (f *fakeHeadlessAgentServer) Snapshot() (session.Observation, error) {
 	defer f.mu.Unlock()
 	return session.Observation{Updated: true, HasPrompt: false, Content: f.snapshotText}, nil
 }
-func (f *fakeHeadlessAgentServer) Preview(int, bool) (string, error) { return "preview-body", nil }
-func (f *fakeHeadlessAgentServer) PreviewByID(string, bool) (string, error) {
-	return "preview-body", nil
+func (f *fakeHeadlessAgentServer) Preview(int, bool) (session.PreviewSnapshot, error) {
+	return session.PreviewSnapshot{
+		Content:  "preview-body",
+		Modes:    terminal.Modes{AlternateScreen: true, MouseButton: true, MouseSGR: true},
+		HasModes: true,
+	}, nil
+}
+func (f *fakeHeadlessAgentServer) PreviewByID(string, bool) (session.PreviewSnapshot, error) {
+	return f.Preview(0, false)
 }
 func (f *fakeHeadlessAgentServer) Alive() (bool, error)     { return true, nil }
 func (f *fakeHeadlessAgentServer) Archive() (string, error) { return "session/fake", nil }
@@ -195,6 +202,17 @@ func TestHeadlessAgentServer_HTTPTokenRoundTrip(t *testing.T) {
 	decodeData(resp, &snap)
 	require.Equal(t, "❯ ready", snap.Content)
 	require.True(t, snap.Updated)
+
+	// --- control REST: preview carries terminal ownership with the grid ------
+	resp, err = post("/v1/agent/preview", `{"tab":0,"full":false}`)
+	require.NoError(t, err)
+	var preview agentPreviewResponse
+	decodeData(resp, &preview)
+	require.Equal(t, "preview-body", preview.Content)
+	require.True(t, preview.HasModes)
+	require.True(t, preview.Modes.AlternateScreen)
+	require.True(t, preview.Modes.MouseButton)
+	require.True(t, preview.Modes.MouseSGR)
 
 	// --- control REST: alive / send-prompt / tap-enter ----------------------
 	resp, err = post("/v1/agent/alive", ``)

--- a/daemon/outage_e2e_test.go
+++ b/daemon/outage_e2e_test.go
@@ -112,9 +112,9 @@ func TestOutageEndToEnd_LostRestoreAndReplay(t *testing.T) {
 		if err != nil {
 			return false
 		}
-		i1 := strings.Index(content, "replay-e1")
-		i2 := strings.Index(content, "replay-e2")
-		i3 := strings.Index(content, "replay-e3")
+		i1 := strings.Index(content.Content, "replay-e1")
+		i2 := strings.Index(content.Content, "replay-e2")
+		i3 := strings.Index(content.Content, "replay-e3")
 		return i1 >= 0 && i2 > i1 && i3 > i2
 	})
 	waitUntil(t, 10*time.Second, "the drained queue files to clean up", func() bool {

--- a/daemon/preview.go
+++ b/daemon/preview.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/tmux"
+	"github.com/sachiniyer/agent-factory/terminal"
 )
 
 // The Preview RPC (#1592 Phase 2 PR6) is the daemon's SOLE capture path for the
@@ -68,6 +69,12 @@ type PreviewRequest struct {
 type PreviewResponse struct {
 	Content string `json:"content"`
 	Gone    bool   `json:"gone,omitempty"`
+	// Modes and HasModes travel with the captured target so preview input can use
+	// the same ownership decision as the live stream. HasModes distinguishes an
+	// authoritative primary-screen/no-mouse observation from an older or
+	// incapable runtime that supplied no mode data.
+	Modes    terminal.Modes `json:"terminal_modes,omitempty"`
+	HasModes bool           `json:"has_terminal_modes,omitempty"`
 	// TabGone NARROWS Gone: the session is alive and well, but the TAB the request
 	// addressed is not there — an id that no longer resolves, or an ordinal that is
 	// not a slot. Gone is always set alongside it, so a client that only knows
@@ -143,7 +150,7 @@ func (s *controlServer) Preview(req PreviewRequest, resp *PreviewResponse) error
 	if tabID == "" {
 		return fmt.Errorf("session %q tab %d has no stable identity; reload the session before previewing it", req.Title, tab)
 	}
-	content, err := as.PreviewByID(tabID, req.Full)
+	snapshot, err := as.PreviewByID(tabID, req.Full)
 	if err != nil {
 		if errors.Is(err, session.ErrTabGone) {
 			resp.Gone, resp.TabGone = true, true
@@ -155,6 +162,8 @@ func (s *controlServer) Preview(req PreviewRequest, resp *PreviewResponse) error
 		}
 		return err
 	}
-	resp.Content = content
+	resp.Content = snapshot.Content
+	resp.Modes = snapshot.Modes
+	resp.HasModes = snapshot.HasModes
 	return nil
 }

--- a/daemon/ws_pty.go
+++ b/daemon/ws_pty.go
@@ -348,7 +348,18 @@ func writePTYStream(ctx context.Context, sub session.PTYSubscription, conn *webs
 		case session.PTYData:
 			err = agentproto.WriteFrame(wctx, conn, agentproto.PTYOutFrame(ev.Data))
 		case session.PTYRepaint:
-			err = agentproto.WriteFrame(wctx, conn, agentproto.RepaintFrame(ev.Data))
+			// Snapshot modes must precede the repaint they describe. A fresh client
+			// did not observe the application's earlier alternate-screen/mouse
+			// DECSETs, and a recovered client may have lost them with the ring gap.
+			// The additive text control lets AF make an explicit ownership decision;
+			// the repaint's DEC restore prefix keeps terminal-only/older clients
+			// correct too.
+			if ev.HasModes {
+				err = agentproto.WriteControl(wctx, conn, agentproto.NewTerminalModesMessage(ev.Modes))
+			}
+			if err == nil {
+				err = agentproto.WriteFrame(wctx, conn, agentproto.RepaintFrame(ev.Data))
+			}
 		case session.PTYCursor:
 			// The broker fast-forwarded this subscriber over bytes that no longer exist
 			// (a ring eviction or the #1840 recovery discard). Re-seed the client's

--- a/integration/agent_server_remote_test.go
+++ b/integration/agent_server_remote_test.go
@@ -159,8 +159,11 @@ func TestRemoteAgentServerRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Preview over the wire: %v", err)
 	}
-	if !strings.Contains(preview, "hello-remote") {
-		t.Fatalf("Preview did not reflect the typed input: %q", preview)
+	if !strings.Contains(preview.Content, "hello-remote") {
+		t.Fatalf("Preview did not reflect the typed input: %q", preview.Content)
+	}
+	if !preview.HasModes {
+		t.Fatal("Preview over the remote agent-server lost terminal ownership modes")
 	}
 
 	// --- Alive reports the remote workspace is running ----------------------

--- a/integration/backend_docker_test.go
+++ b/integration/backend_docker_test.go
@@ -158,8 +158,8 @@ func TestDockerBackendRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Preview over the wire: %v", err)
 	}
-	if !strings.Contains(preview, marker) {
-		t.Fatalf("Preview did not reflect the typed input: %q", preview)
+	if !strings.Contains(preview.Content, marker) {
+		t.Fatalf("Preview did not reflect the typed input: %q", preview.Content)
 	}
 	if alive, err := as.Alive(); err != nil || !alive {
 		t.Fatal("expected the in-container workspace to report Alive")

--- a/integration/backend_ssh_test.go
+++ b/integration/backend_ssh_test.go
@@ -184,8 +184,8 @@ func TestSSHBackendRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Preview over the wire: %v", err)
 	}
-	if !strings.Contains(preview, marker) {
-		t.Fatalf("Preview did not reflect the typed input: %q", preview)
+	if !strings.Contains(preview.Content, marker) {
+		t.Fatalf("Preview did not reflect the typed input: %q", preview.Content)
 	}
 	if alive, err := as.Alive(); err != nil || !alive {
 		t.Fatal("expected the remote workspace to report Alive")

--- a/integration/remote_roundtrip_test.go
+++ b/integration/remote_roundtrip_test.go
@@ -166,8 +166,8 @@ func TestRemoteHookRoundTripMockRemote(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Preview over the wire: %v", err)
 	}
-	if !strings.Contains(preview, marker) {
-		t.Fatalf("Preview did not reflect the typed input: %q", preview)
+	if !strings.Contains(preview.Content, marker) {
+		t.Fatalf("Preview did not reflect the typed input: %q", preview.Content)
 	}
 	if alive, err := as.Alive(); err != nil || !alive {
 		t.Fatal("expected the workspace to report Alive")

--- a/integration/ws_pty_test.go
+++ b/integration/ws_pty_test.go
@@ -84,13 +84,13 @@ func TestWSPTYBrokerRoundTrip(t *testing.T) {
 	// server's ping times out and drops it. It must NOT take the session or the live
 	// subscriber down.
 	dead := h.dialWSRaw(t, streamPath)
-	// A fresh subscriber receives two leading server→client frames before it goes
-	// silent: the OpHello start-seq (#1592 Phase 5 PR1) then the one-shot initial
-	// screen repaint (#1592 PR6). Drain BOTH first, otherwise the keepalive diagnostic
-	// below would read one of those still-buffered frames (a non-error) instead of the
-	// eventual close. After draining them the client stops reading, so the next ping
-	// goes unanswered and the server drops it.
-	for _, what := range []string{"hello", "repaint"} {
+	// A fresh subscriber receives three leading server→client frames before it
+	// goes silent: the OpHello start-seq (#1592 Phase 5 PR1), terminal ownership
+	// modes, then the one-shot initial screen repaint (#1592 PR6). Drain all three
+	// first, otherwise the keepalive diagnostic below would read a buffered frame
+	// (a non-error) instead of the eventual close. After draining them the client
+	// stops reading, so the next ping goes unanswered and the server drops it.
+	for _, what := range []string{"hello", "terminal modes", "repaint"} {
 		if err := dead.readErrWithin(2 * time.Second); err != nil {
 			t.Fatalf("dead subscriber never received its initial %s frame: %v", what, err)
 		}

--- a/session/agentserver.go
+++ b/session/agentserver.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+
+	"github.com/sachiniyer/agent-factory/terminal"
 )
 
 // ErrTabGone reports that a stable tab id (#1738) names no live tab — it was
@@ -99,13 +101,13 @@ type AgentServer interface {
 	// shell/process tab. This is the daemon's SOLE capture path for content the TUI
 	// can't stream live (remote/hook sessions, scroll-mode scrollback, the transient
 	// preview target) — the TUI no longer captures tmux itself (#1592 Phase 2 PR6).
-	Preview(tab int, full bool) (string, error)
+	Preview(tab int, full bool) (PreviewSnapshot, error)
 	// PreviewByID is Preview addressed by the tab's stable identity. Implementations
 	// must either bind directly to the identified capture target or keep identity
 	// resolution and the ordinal capture in one critical section; resolving first
 	// and using that ordinal against a later roster can expose another tab (#2200).
 	// ErrTabGone reports that the exact target no longer exists.
-	PreviewByID(tabID string, full bool) (string, error)
+	PreviewByID(tabID string, full bool) (PreviewSnapshot, error)
 	// Alive reports whether the underlying session process is still running, and
 	// whether the probe could be ANSWERED at all. Kept separate from Snapshot
 	// (rather than folded into Observation) so the daemon probes liveness ONLY on
@@ -266,4 +268,8 @@ type PTYEvent struct {
 	// Seq is the subscription's authoritative output cursor, valid only when
 	// Kind == PTYCursor.
 	Seq Seq
+	// Modes accompany PTYRepaint when HasModes is true. They are snapshot
+	// metadata, not ring bytes, and therefore do not advance Seq.
+	Modes    terminal.Modes
+	HasModes bool
 }

--- a/session/agentserver_local.go
+++ b/session/agentserver_local.go
@@ -148,27 +148,37 @@ func (s *localAgentServer) Snapshot() (Observation, error) {
 	return Observation{Updated: updated, HasPrompt: hasPrompt, Content: content}, nil
 }
 
-func (s *localAgentServer) Preview(tab int, full bool) (string, error) {
+func (s *localAgentServer) Preview(tab int, full bool) (PreviewSnapshot, error) {
 	// The agent tab (0) keeps the backend preview path — a backend may format its
 	// agent output specially (e.g. the remote hook's sanitized stream). Shell/process
 	// tabs (>0) capture their own tmux session, mirroring TabPane's former
 	// updateAgent/updateShell split now that the daemon is the sole capturer.
-	if tab == 0 {
-		if full {
-			return s.inst.currentBackend().PreviewFullHistory(s.inst)
-		}
-		return s.inst.currentBackend().Preview(s.inst)
+	if tab != 0 {
+		return s.inst.PreviewTabSnapshot(tab, full)
 	}
+	b := s.inst.currentBackend()
+	var (
+		content string
+		err     error
+	)
 	if full {
-		return s.inst.PreviewTabFullHistory(tab)
+		content, err = b.PreviewFullHistory(s.inst)
+	} else {
+		content, err = b.Preview(s.inst)
 	}
-	return s.inst.PreviewTab(tab)
+	if err != nil {
+		return PreviewSnapshot{}, err
+	}
+	s.inst.mu.RLock()
+	ts := s.inst.tmuxLocked()
+	s.inst.mu.RUnlock()
+	return previewSnapshotWithModes(content, ts), nil
 }
 
 // PreviewByID binds directly to the tmux/backend target selected under the
 // instance lock. No ordinal crosses that lock boundary (#2200).
-func (s *localAgentServer) PreviewByID(tabID string, full bool) (string, error) {
-	return s.inst.PreviewTabByID(tabID, full)
+func (s *localAgentServer) PreviewByID(tabID string, full bool) (PreviewSnapshot, error) {
+	return s.inst.PreviewTabSnapshotByID(tabID, full)
 }
 
 // ctxPreviewBackend is the optional backend capability for a pane capture bound to
@@ -189,7 +199,8 @@ func (s *localAgentServer) PreviewContext(ctx context.Context, tab int, full boo
 			return cb.PreviewContext(ctx, s.inst)
 		}
 	}
-	return s.Preview(tab, full)
+	snapshot, err := s.Preview(tab, full)
+	return snapshot.Content, err
 }
 
 // Alive probes the local backend in-process, so the answer is always definitive

--- a/session/agentserver_local_test.go
+++ b/session/agentserver_local_test.go
@@ -101,11 +101,11 @@ func TestLocalAgentServerAlive(t *testing.T) {
 func TestLocalAgentServerPreview(t *testing.T) {
 	inst, _ := newProbeInstance(t)
 	as := inst.AgentServer()
-	if got, _ := as.Preview(0, false); got != "short" {
-		t.Errorf("Preview(false) = %q, want the visible-pane capture", got)
+	if got, _ := as.Preview(0, false); got.Content != "short" {
+		t.Errorf("Preview(false) = %q, want the visible-pane capture", got.Content)
 	}
-	if got, _ := as.Preview(0, true); got != "full" {
-		t.Errorf("Preview(true) = %q, want the full scrollback", got)
+	if got, _ := as.Preview(0, true); got.Content != "full" {
+		t.Errorf("Preview(true) = %q, want the full scrollback", got.Content)
 	}
 }
 

--- a/session/agentserver_remote.go
+++ b/session/agentserver_remote.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/sachiniyer/agent-factory/agentproto"
 	"github.com/sachiniyer/agent-factory/apiproto"
+	"github.com/sachiniyer/agent-factory/terminal"
 )
 
 // remoteAgentServer is the daemon-side AgentServer for a runtime whose agent runs
@@ -135,17 +136,21 @@ func (s *remoteAgentServer) Snapshot() (Observation, error) {
 	return Observation{Updated: resp.Updated, HasPrompt: resp.HasPrompt, Content: resp.Content}, nil
 }
 
-func (s *remoteAgentServer) Preview(tab int, full bool) (string, error) {
+func (s *remoteAgentServer) Preview(tab int, full bool) (PreviewSnapshot, error) {
 	return s.rc.preview(tab, full)
 }
 
-func (s *remoteAgentServer) PreviewByID(tabID string, full bool) (string, error) {
+func (s *remoteAgentServer) PreviewByID(tabID string, full bool) (PreviewSnapshot, error) {
 	if s.inst == nil {
-		return "", fmt.Errorf("remote session %q cannot resolve stable tab id %q without its owning instance", s.rc.title, tabID)
+		return PreviewSnapshot{}, fmt.Errorf("remote session %q cannot resolve stable tab id %q without its owning instance", s.rc.title, tabID)
 	}
-	return s.inst.previewByIDAsOrdinal(tabID, func(tab int) (string, error) {
-		return s.rc.preview(tab, full)
+	var snapshot PreviewSnapshot
+	_, err := s.inst.previewByIDAsOrdinal(tabID, func(tab int) (string, error) {
+		var err error
+		snapshot, err = s.rc.preview(tab, full)
+		return snapshot.Content, err
 	})
+	return snapshot, err
 }
 
 // Alive asks the in-sandbox agent-server whether its agent is running. The error
@@ -286,13 +291,15 @@ func (s *deadRemoteAgentServer) err() error {
 	return fmt.Errorf("session %q has no live agent-server: its sandbox is not provisioned", s.title)
 }
 
-func (s *deadRemoteAgentServer) Provision(bool) error              { return s.err() }
-func (s *deadRemoteAgentServer) Launch(bool) error                 { return s.err() }
-func (s *deadRemoteAgentServer) Expose() (StreamEndpoint, error)   { return StreamEndpoint{}, s.err() }
-func (s *deadRemoteAgentServer) Snapshot() (Observation, error)    { return Observation{}, s.err() }
-func (s *deadRemoteAgentServer) Preview(int, bool) (string, error) { return "", s.err() }
-func (s *deadRemoteAgentServer) PreviewByID(string, bool) (string, error) {
-	return "", s.err()
+func (s *deadRemoteAgentServer) Provision(bool) error            { return s.err() }
+func (s *deadRemoteAgentServer) Launch(bool) error               { return s.err() }
+func (s *deadRemoteAgentServer) Expose() (StreamEndpoint, error) { return StreamEndpoint{}, s.err() }
+func (s *deadRemoteAgentServer) Snapshot() (Observation, error)  { return Observation{}, s.err() }
+func (s *deadRemoteAgentServer) Preview(int, bool) (PreviewSnapshot, error) {
+	return PreviewSnapshot{}, s.err()
+}
+func (s *deadRemoteAgentServer) PreviewByID(string, bool) (PreviewSnapshot, error) {
+	return PreviewSnapshot{}, s.err()
 }
 
 // Alive returns (false, err) = UNKNOWN, never an authoritative "the agent is gone":
@@ -450,7 +457,7 @@ func (c *remoteClientlessChannel) Resize(rows, cols uint16) error {
 // the first live byte, mirroring tmux capture-pane. The WS stream carries only
 // future output, so without this a just-opened remote pane would render blank.
 func (c *remoteClientlessChannel) Snapshot() (PaneSnapshot, error) {
-	content, err := c.rc.preview(c.tab, false)
+	snapshot, err := c.rc.preview(c.tab, false)
 	if err != nil {
 		return PaneSnapshot{}, err
 	}
@@ -462,7 +469,11 @@ func (c *remoteClientlessChannel) Snapshot() (PaneSnapshot, error) {
 	// limitation of the still-dark remote runtime (no cursor cascade to corrupt, since
 	// HasCursor is false); productizing it needs the agent-server to expose a grid
 	// capture + cursor over REST, mirroring tmuxClientlessChannel.Snapshot.
-	return PaneSnapshot{Screen: []byte(content)}, nil
+	return PaneSnapshot{
+		Screen:   []byte(snapshot.Content),
+		Modes:    snapshot.Modes,
+		HasModes: snapshot.HasModes,
+	}, nil
 }
 
 // activeConn returns the live capture socket and its context, or an error if
@@ -590,12 +601,16 @@ func (c *remoteAgentClient) call(path string, req, resp any) error {
 
 // preview fetches tab `tab`'s content over the control REST — shared by the
 // AgentServer.Preview surface and the broker's fresh-subscriber repaint (Snapshot).
-func (c *remoteAgentClient) preview(tab int, full bool) (string, error) {
+func (c *remoteAgentClient) preview(tab int, full bool) (PreviewSnapshot, error) {
 	var resp agentPreviewResp
 	if err := c.call("/v1/agent/preview", agentPreviewReq{Tab: tab, Full: full}, &resp); err != nil {
-		return "", err
+		return PreviewSnapshot{}, err
 	}
-	return resp.Content, nil
+	return PreviewSnapshot{
+		Content:  resp.Content,
+		Modes:    resp.Modes,
+		HasModes: resp.HasModes,
+	}, nil
 }
 
 // dialStream opens the WS PTY subscription to tab `tab` (from the live tail). The
@@ -679,7 +694,9 @@ type agentPreviewReq struct {
 }
 
 type agentPreviewResp struct {
-	Content string `json:"content"`
+	Content  string         `json:"content"`
+	Modes    terminal.Modes `json:"terminal_modes,omitempty"`
+	HasModes bool           `json:"has_terminal_modes,omitempty"`
 }
 
 type agentAliveResp struct {

--- a/session/archive_sandbox_test.go
+++ b/session/archive_sandbox_test.go
@@ -266,12 +266,16 @@ type stubAgentServer struct {
 func (s *stubAgentServer) Archive() (string, error) { return s.branch, nil }
 func (s *stubAgentServer) Kill() error              { s.killCalls++; return s.killErr }
 
-func (s *stubAgentServer) Provision(bool) error                        { return nil }
-func (s *stubAgentServer) Launch(bool) error                           { return nil }
-func (s *stubAgentServer) Expose() (StreamEndpoint, error)             { return StreamEndpoint{}, nil }
-func (s *stubAgentServer) Snapshot() (Observation, error)              { return Observation{}, nil }
-func (s *stubAgentServer) Preview(int, bool) (string, error)           { return "", nil }
-func (s *stubAgentServer) PreviewByID(string, bool) (string, error)    { return "", nil }
+func (s *stubAgentServer) Provision(bool) error            { return nil }
+func (s *stubAgentServer) Launch(bool) error               { return nil }
+func (s *stubAgentServer) Expose() (StreamEndpoint, error) { return StreamEndpoint{}, nil }
+func (s *stubAgentServer) Snapshot() (Observation, error)  { return Observation{}, nil }
+func (s *stubAgentServer) Preview(int, bool) (PreviewSnapshot, error) {
+	return PreviewSnapshot{}, nil
+}
+func (s *stubAgentServer) PreviewByID(string, bool) (PreviewSnapshot, error) {
+	return PreviewSnapshot{}, nil
+}
 func (s *stubAgentServer) Alive() (bool, error)                        { return false, nil }
 func (s *stubAgentServer) SendPrompt(string) error                     { return nil }
 func (s *stubAgentServer) TapEnter()                                   {}

--- a/session/backend_remote_agent.go
+++ b/session/backend_remote_agent.go
@@ -85,11 +85,13 @@ func (b *remoteAgentBackend) CloseAttachOnly(i *Instance) error {
 }
 
 func (b *remoteAgentBackend) Preview(i *Instance) (string, error) {
-	return i.AgentServer().Preview(0, false)
+	snapshot, err := i.AgentServer().Preview(0, false)
+	return snapshot.Content, err
 }
 
 func (b *remoteAgentBackend) PreviewFullHistory(i *Instance) (string, error) {
-	return i.AgentServer().Preview(0, true)
+	snapshot, err := i.AgentServer().Preview(0, true)
+	return snapshot.Content, err
 }
 
 func (b *remoteAgentBackend) HasUpdated(i *Instance) (updated bool, hasPrompt bool, content string) {

--- a/session/instance_backend_guard_test.go
+++ b/session/instance_backend_guard_test.go
@@ -21,21 +21,21 @@ import (
 //   - SetBackend / bindProvisionResult — the writers; both take i.mu.Lock.
 //   - AgentServer / reprovisionRemote / toInstanceDataLocked — read inside an
 //     i.mu section their callers established.
-//   - PreviewTabByID — snapshots the backend while its stable tab target is
-//     selected under i.mu, then performs the potentially blocking capture after
-//     releasing the lock.
+//   - PreviewTabSnapshotByID — snapshots the backend while its stable tab target
+//     is selected under i.mu, then performs the potentially blocking capture
+//     after releasing the lock.
 //   - FromInstanceData — a constructor. It populates a local *Instance that no
 //     other goroutine can observe yet, so there is nothing to synchronize with.
 var backendReadersUnderLock = map[string]bool{
-	"currentBackend":       true,
-	"capabilitiesLocked":   true,
-	"SetBackend":           true,
-	"bindProvisionResult":  true,
-	"AgentServer":          true,
-	"reprovisionRemote":    true,
-	"toInstanceDataLocked": true,
-	"PreviewTabByID":       true,
-	"FromInstanceData":     true,
+	"currentBackend":         true,
+	"capabilitiesLocked":     true,
+	"SetBackend":             true,
+	"bindProvisionResult":    true,
+	"AgentServer":            true,
+	"reprovisionRemote":      true,
+	"toInstanceDataLocked":   true,
+	"PreviewTabSnapshotByID": true,
+	"FromInstanceData":       true,
 }
 
 // TestBackendFieldIsOnlyReadUnderLock is a source-level guard for #2096/#2165.

--- a/session/preview.go
+++ b/session/preview.go
@@ -1,41 +1,79 @@
 package session
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/sachiniyer/agent-factory/session/tmux"
+	"github.com/sachiniyer/agent-factory/terminal"
+)
+
+// PreviewSnapshot keeps a captured terminal grid and the ownership-affecting
+// modes observed for that same target in one value. HasModes is explicit: the
+// zero-value Modes is a valid primary-screen/no-mouse observation, not an
+// invitation for a client to guess. Runtimes that cannot report modes leave it
+// false and scrolling remains unavailable until an authoritative snapshot lands.
+type PreviewSnapshot struct {
+	Content  string
+	Modes    terminal.Modes
+	HasModes bool
+}
+
+func previewSnapshotWithModes(content string, ts *tmux.TmuxSession) PreviewSnapshot {
+	snapshot := PreviewSnapshot{Content: content}
+	if ts == nil {
+		return snapshot
+	}
+	state, err := ts.ReadTerminalState()
+	if err != nil {
+		return snapshot
+	}
+	snapshot.Modes = state.Modes
+	snapshot.HasModes = true
+	return snapshot
+}
 
 // PreviewTab captures the detached content of the tab currently at idx. The
 // ordinal form exists for legacy callers that never supplied a stable tab id.
 // An out-of-range ordinal is an explicit error: returning ("", nil) would claim
 // that a nonexistent pane was merely blank (#2200).
 func (i *Instance) PreviewTab(idx int) (string, error) {
+	snapshot, err := i.PreviewTabSnapshot(idx, false)
+	return snapshot.Content, err
+}
+
+// PreviewTabSnapshot is PreviewTab with an authoritative terminal-mode
+// observation when the selected runtime exposes a tmux pane.
+func (i *Instance) PreviewTabSnapshot(idx int, full bool) (PreviewSnapshot, error) {
 	i.mu.RLock()
 	if idx < 0 || idx >= len(i.Tabs) {
 		i.mu.RUnlock()
-		return "", fmt.Errorf("session %q tab %d: %w", i.Title, idx, ErrTabIndexOutOfRange)
+		return PreviewSnapshot{}, fmt.Errorf("session %q tab %d: %w", i.Title, idx, ErrTabIndexOutOfRange)
 	}
 	started := i.started
 	ts := i.tabTmuxAtLocked(idx)
 	i.mu.RUnlock()
 	if !started || ts == nil {
-		return "", nil
+		return PreviewSnapshot{}, nil
 	}
-	return ts.CapturePaneContent()
+
+	var content string
+	var err error
+	if full {
+		content, err = ts.CapturePaneContentWithOptions("-", "-")
+	} else {
+		content, err = ts.CapturePaneContent()
+	}
+	if err != nil {
+		return PreviewSnapshot{}, err
+	}
+	return previewSnapshotWithModes(content, ts), nil
 }
 
 // PreviewTabFullHistory is PreviewTab's full-scrollback counterpart. It keeps
 // the same explicit out-of-range refusal.
 func (i *Instance) PreviewTabFullHistory(idx int) (string, error) {
-	i.mu.RLock()
-	if idx < 0 || idx >= len(i.Tabs) {
-		i.mu.RUnlock()
-		return "", fmt.Errorf("session %q tab %d: %w", i.Title, idx, ErrTabIndexOutOfRange)
-	}
-	started := i.started
-	ts := i.tabTmuxAtLocked(idx)
-	i.mu.RUnlock()
-	if !started || ts == nil {
-		return "", nil
-	}
-	return ts.CapturePaneContentWithOptions("-", "-")
+	snapshot, err := i.PreviewTabSnapshot(idx, true)
+	return snapshot.Content, err
 }
 
 // PreviewTabByID captures the tab named by stable id without ever converting
@@ -48,16 +86,24 @@ func (i *Instance) PreviewTabFullHistory(idx int) (string, error) {
 // zero and cannot be closed or reordered, so snapshotting its backend under the
 // same lock preserves both its identity and the formatting contract.
 func (i *Instance) PreviewTabByID(tabID string, full bool) (string, error) {
+	snapshot, err := i.PreviewTabSnapshotByID(tabID, full)
+	return snapshot.Content, err
+}
+
+// PreviewTabSnapshotByID binds content and terminal modes to one stable tab
+// identity. A mode read can fail without losing a valid capture; HasModes=false
+// makes that uncertainty explicit to routing clients.
+func (i *Instance) PreviewTabSnapshotByID(tabID string, full bool) (PreviewSnapshot, error) {
 	i.mu.RLock()
 	idx, exists := i.tabIndexByIDLocked(tabID)
 	if !exists {
 		i.mu.RUnlock()
-		return "", fmt.Errorf("session %q tab id %q: %w", i.Title, tabID, ErrTabGone)
+		return PreviewSnapshot{}, fmt.Errorf("session %q tab id %q: %w", i.Title, tabID, ErrTabGone)
 	}
 	tab := i.Tabs[idx]
 	if !i.started {
 		i.mu.RUnlock()
-		return "", nil
+		return PreviewSnapshot{}, nil
 	}
 	if tab.Kind != TabKindAgent {
 		// Keep the roster read lock through the bounded tmux capture. Besides
@@ -66,25 +112,44 @@ func (i *Instance) PreviewTabByID(tabID string, full bool) (string, error) {
 		defer i.mu.RUnlock()
 		ts := tab.tmux
 		if ts == nil {
-			return "", nil
+			return PreviewSnapshot{}, nil
 		}
+		var (
+			content string
+			err     error
+		)
 		if full {
-			return ts.CapturePaneContentWithOptions("-", "-")
+			content, err = ts.CapturePaneContentWithOptions("-", "-")
+		} else {
+			content, err = ts.CapturePaneContent()
 		}
-		return ts.CapturePaneContent()
+		if err != nil {
+			return PreviewSnapshot{}, err
+		}
+		return previewSnapshotWithModes(content, ts), nil
 	}
 
 	// Backend preview methods re-enter i.mu, so the pinned agent target snapshots
 	// the backend under the lock and performs the call after releasing it.
 	backend := i.backend
+	ts := tab.tmux
 	i.mu.RUnlock()
 	if backend == nil {
-		return "", fmt.Errorf("session %q has no preview backend", i.Title)
+		return PreviewSnapshot{}, fmt.Errorf("session %q has no preview backend", i.Title)
 	}
+	var (
+		content string
+		err     error
+	)
 	if full {
-		return backend.PreviewFullHistory(i)
+		content, err = backend.PreviewFullHistory(i)
+	} else {
+		content, err = backend.Preview(i)
 	}
-	return backend.Preview(i)
+	if err != nil {
+		return PreviewSnapshot{}, err
+	}
+	return previewSnapshotWithModes(content, ts), nil
 }
 
 // previewByIDAsOrdinal is the compatibility bridge for a remote agent-server

--- a/session/preview_identity_test.go
+++ b/session/preview_identity_test.go
@@ -23,6 +23,9 @@ func previewIdentityInstance(t *testing.T, agentName string) *Instance {
 
 	cmdExec, _ := raceHookExec(map[string]bool{agentName: true}, nil)
 	cmdExec.OutputFunc = func(cmd *exec.Cmd) ([]byte, error) {
+		if strings.Contains(cmd.String(), "display-message") {
+			return []byte("7 11 1 1 0 1 0 0 1"), nil
+		}
 		for i, arg := range cmd.Args {
 			if arg == "-t" && i+1 < len(cmd.Args) {
 				target := strings.TrimSuffix(strings.TrimPrefix(cmd.Args[i+1], "="), ":")
@@ -48,6 +51,19 @@ func previewIdentityInstance(t *testing.T, agentName string) *Instance {
 		gitWorktree: gw,
 		Tabs:        []*Tab{newAgentTab(agentTmux)},
 	}
+}
+
+func TestPreviewSnapshotCarriesModesForTheStableTarget(t *testing.T) {
+	inst := previewIdentityInstance(t, "af_preview_snapshot_modes")
+	tabID, ok := inst.TabIDAt(0)
+	require.True(t, ok)
+
+	snapshot, err := inst.AgentServer().PreviewByID(tabID, false)
+	require.NoError(t, err)
+	require.True(t, snapshot.HasModes)
+	require.True(t, snapshot.Modes.AlternateScreen)
+	require.True(t, snapshot.Modes.MouseButton)
+	require.True(t, snapshot.Modes.MouseSGR)
 }
 
 func tabTmuxName(t *testing.T, inst *Instance, id string) string {
@@ -98,7 +114,7 @@ func TestPreview_TabIDSurvivesConcurrentOrdinalShift(t *testing.T) {
 
 			content, captureErr := inst.AgentServer().PreviewByID(b.ID, tc.full)
 			if captureErr == nil {
-				require.Equal(t, tabTmuxName(t, inst, b.ID), content,
+				require.Equal(t, tabTmuxName(t, inst, b.ID), content.Content,
 					"a preview resolved by b's stable id must never capture c after a shifts the ordinals")
 			}
 		})

--- a/session/ptybroker.go
+++ b/session/ptybroker.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/terminal"
 )
 
 // The WS PTY broker's server-side data plane (#1592 Phase 2 PR5). A ptyBroker
@@ -85,6 +86,20 @@ type PaneSnapshot struct {
 	CursorRow int
 	CursorCol int
 	HasCursor bool
+	// Modes are the ownership-affecting terminal modes that were already active
+	// before this subscriber existed. HasModes distinguishes a truthful all-off
+	// primary-screen snapshot from a source that cannot report modes.
+	Modes    terminal.Modes
+	HasModes bool
+}
+
+// repaintSnapshot is one atomic broker event: the grid repaint plus the terminal
+// modes captured with it. The daemon emits the modes immediately before Data,
+// and Data also restores them as DEC sequences for terminal-only clients.
+type repaintSnapshot struct {
+	data     []byte
+	modes    terminal.Modes
+	hasModes bool
 }
 
 // ptyBroker is the per-session data plane. Guarded by mu; the ring buffer, the
@@ -216,10 +231,10 @@ func (b *ptyBroker) subscribe(since Seq) (*ptySub, error) {
 	// the snapshot and the cursor: bytes in that tiny window are simply in both the
 	// snapshot and the replayed tail (a harmless double-render), never dropped.
 	if needRepaint {
-		if snap, err := b.ch.Snapshot(); err == nil && len(snap.Screen) > 0 {
-			rp := buildRepaint(snap)
+		if snap, err := b.ch.Snapshot(); err == nil && snapshotHasRepaintState(snap) {
+			rp := buildRepaintSnapshot(snap)
 			b.mu.Lock()
-			sub.pendingRepaint = rp
+			sub.pendingRepaint = &rp
 			b.mu.Unlock()
 			sub.wake()
 		}
@@ -254,7 +269,11 @@ func (b *ptyBroker) subscribe(since Seq) (*ptySub, error) {
 // line) renders at the bottom while a stale copy sits at the top. The restore lands
 // the emulator cursor on the real position so that redraw overwrites in place.
 func buildRepaint(snap PaneSnapshot) []byte {
-	out := []byte("\x1b[2J")
+	var out []byte
+	if snap.HasModes {
+		out = append(out, snap.Modes.RestoreSequence()...)
+	}
+	out = append(out, []byte("\x1b[2J")...)
 	// capture-pane emits ONE trailing "\n" after the last row and strips trailing
 	// blank rows, so that final "\n" is a row SEPARATOR, not a real empty row.
 	// Splitting without trimming it would yield a phantom trailing "" element and emit
@@ -271,6 +290,21 @@ func buildRepaint(snap PaneSnapshot) []byte {
 		out = append(out, []byte(fmt.Sprintf("\x1b[%d;%dH", snap.CursorRow+1, snap.CursorCol+1))...)
 	}
 	return out
+}
+
+func buildRepaintSnapshot(snap PaneSnapshot) repaintSnapshot {
+	return repaintSnapshot{
+		data:     buildRepaint(snap),
+		modes:    snap.Modes,
+		hasModes: snap.HasModes,
+	}
+}
+
+// snapshotHasRepaintState keeps authoritative metadata from disappearing merely
+// because the grid is blank. A fresh primary-screen pane can have no printable
+// cells while its all-false mode snapshot is exactly what resolves ownership.
+func snapshotHasRepaintState(snap PaneSnapshot) bool {
+	return len(snap.Screen) > 0 || snap.HasCursor || snap.HasModes
 }
 
 // ensureCaptureStarted brings the clientless output capture up if it is not
@@ -406,7 +440,7 @@ func (b *ptyBroker) resetCapture() {
 	// waiting for a repaint that never comes. rp is read when the deferred call runs,
 	// so this single exit point both installs whatever repaint the recovery managed to
 	// build and lifts the barrier, atomically under b.mu.
-	var rp []byte
+	var rp *repaintSnapshot
 	defer func() { b.releaseRecoveryRepaint(armed, rp) }()
 
 	if stop != nil {
@@ -478,26 +512,27 @@ func (b *ptyBroker) armRecoveryRepaintLocked() []*ptySub {
 // screen yields nil, and the release degrades to just lifting the barrier and waking
 // the subscribers — the restarted capture's next live byte still reaches them — rather
 // than failing the recovery. Caller holds captureMu.
-func (b *ptyBroker) recoveryRepaint() []byte {
+func (b *ptyBroker) recoveryRepaint() *repaintSnapshot {
 	snap, err := b.ch.Snapshot()
 	if err != nil {
 		log.WarningLog.Printf("pty broker: snapshot for recovery re-seed: %v", err)
 		return nil
 	}
-	if len(snap.Screen) == 0 {
+	if !snapshotHasRepaintState(snap) {
 		return nil
 	}
-	return buildRepaint(snap)
+	rp := buildRepaintSnapshot(snap)
+	return &rp
 }
 
 // releaseRecoveryRepaint installs rp on every armed subscriber and lifts the barrier —
 // both under ONE b.mu hold, so a subscriber can never observe the lifted barrier
 // without also seeing the repaint that was owed to it. Waking is what makes a parked
 // subscriber re-read that state.
-func (b *ptyBroker) releaseRecoveryRepaint(armed []*ptySub, rp []byte) {
+func (b *ptyBroker) releaseRecoveryRepaint(armed []*ptySub, rp *repaintSnapshot) {
 	b.mu.Lock()
 	for _, s := range armed {
-		if len(rp) > 0 {
+		if rp != nil && len(rp.data) > 0 {
 			s.pendingRepaint = rp
 		}
 		s.repaintArmed = false
@@ -663,7 +698,7 @@ type ptySub struct {
 	resizeSeen uint64 // last resizeGen echoed to this subscriber
 	// pendingRepaint is a one-shot initial screen repaint delivered before any
 	// other event to a fresh subscriber (set by subscribe). Read/written under br.mu.
-	pendingRepaint []byte
+	pendingRepaint *repaintSnapshot
 	// repaintArmed marks this subscriber as held at a recovery boundary: a repaint of
 	// the recovered screen is being captured for it, so NextEvent must emit NOTHING
 	// until it lands (#1975). Set/cleared under br.mu by resetCapture's arm/release
@@ -706,11 +741,16 @@ func (s *ptySub) NextEvent(ctx context.Context) (PTYEvent, error) {
 		// subscriber paints the current screen before the first live byte lands. It
 		// is a PTYRepaint (not PTYData) so the client renders it without advancing its
 		// replay cursor — the repaint is per-subscriber and not part of the ring seq.
-		if len(s.pendingRepaint) > 0 {
-			data := s.pendingRepaint
+		if s.pendingRepaint != nil {
+			rp := s.pendingRepaint
 			s.pendingRepaint = nil
 			s.br.mu.Unlock()
-			return PTYEvent{Kind: PTYRepaint, Data: data}, nil
+			return PTYEvent{
+				Kind:     PTYRepaint,
+				Data:     rp.data,
+				Modes:    rp.modes,
+				HasModes: rp.hasModes,
+			}, nil
 		}
 		// A recovery is in flight and this subscriber's repaint of the recovered screen
 		// is still being captured: emit NOTHING until it lands (#1975). Everything this

--- a/session/ptybroker_test.go
+++ b/session/ptybroker_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/x/vt"
+	"github.com/sachiniyer/agent-factory/terminal"
 )
 
 // fakeClientlessChannel is an in-memory clientlessChannel: StartCapture hands
@@ -35,6 +36,8 @@ type fakeClientlessChannel struct {
 	cursorRow int
 	cursorCol int
 	hasCursor bool
+	modes     terminal.Modes
+	hasModes  bool
 	// wClosed reports whether the CURRENT capture writer (f.w) has been closed by a
 	// StopCapture — the test proxy for "the pane pipe was disabled". Reset on each
 	// StartCapture. Used by the #1661 teardown-clobber regression test.
@@ -115,6 +118,8 @@ func (f *fakeClientlessChannel) Snapshot() (PaneSnapshot, error) {
 		CursorRow: f.cursorRow,
 		CursorCol: f.cursorCol,
 		HasCursor: f.hasCursor,
+		Modes:     f.modes,
+		HasModes:  f.hasModes,
 	}, nil
 }
 
@@ -217,6 +222,54 @@ func TestPTYBrokerInitialRepaint(t *testing.T) {
 	}
 	ch.emit(t, []byte("live"))
 	mustData(t, re, "live")
+}
+
+func TestPTYBrokerRepaintCarriesTerminalModes(t *testing.T) {
+	modes := terminal.Modes{
+		AlternateScreen: true,
+		MouseTracking:   true,
+		MouseButton:     true,
+		MouseSGR:        true,
+	}
+	ch := &fakeClientlessChannel{
+		snapshot: []byte("ALT-SCREEN"),
+		modes:    modes,
+		hasModes: true,
+	}
+	br := newPTYBroker(ch)
+	sub, err := br.subscribe(0)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	ev, err := nextWithin(t, sub, 2*time.Second)
+	if err != nil {
+		t.Fatalf("NextEvent: %v", err)
+	}
+	if ev.Kind != PTYRepaint || !ev.HasModes || ev.Modes != modes {
+		t.Fatalf("repaint metadata = %+v, want modes %+v", ev, modes)
+	}
+	if !strings.HasPrefix(string(ev.Data), string(modes.RestoreSequence())) {
+		t.Fatalf("repaint data = %q, want terminal-mode restore prefix %q", ev.Data, modes.RestoreSequence())
+	}
+}
+
+func TestPTYBrokerBlankRepaintStillCarriesTerminalModes(t *testing.T) {
+	// An all-false mode value is authoritative HostHistory, not missing data.
+	// A fresh pane is commonly blank before its first prompt; suppressing this
+	// repaint would leave that client ownership-unknown indefinitely.
+	ch := &fakeClientlessChannel{hasModes: true}
+	br := newPTYBroker(ch)
+	sub, err := br.subscribe(0)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	ev, err := nextWithin(t, sub, 2*time.Second)
+	if err != nil {
+		t.Fatalf("NextEvent: %v", err)
+	}
+	if ev.Kind != PTYRepaint || !ev.HasModes || ev.Modes != (terminal.Modes{}) {
+		t.Fatalf("blank repaint = %+v, want authoritative all-false modes", ev)
+	}
 }
 
 // gridRows renders a vt emulator's grid to plain-text rows (cell contents, blanks

--- a/session/ptychannel_tmux.go
+++ b/session/ptychannel_tmux.go
@@ -147,9 +147,15 @@ func (c *tmuxClientlessChannel) Snapshot() (PaneSnapshot, error) {
 		return PaneSnapshot{}, err
 	}
 	snap := PaneSnapshot{Screen: []byte(content)}
-	// The cursor position is best-effort: a failure to read it degrades to a
-	// screen-only repaint (the pre-fix behavior) rather than failing the subscribe.
-	if row, col, curErr := c.ts.CursorPosition(); curErr == nil {
+	// Cursor and terminal modes are best-effort: a failure degrades to the old
+	// screen-only repaint rather than failing the subscription. ReadTerminalState
+	// gets both in one tmux request so a fresh client receives a coherent owner.
+	if state, stateErr := c.ts.ReadTerminalState(); stateErr == nil {
+		snap.CursorRow, snap.CursorCol, snap.HasCursor = state.CursorRow, state.CursorCol, true
+		snap.Modes, snap.HasModes = state.Modes, true
+	} else if row, col, curErr := c.ts.CursorPosition(); curErr == nil {
+		// Preserve the cursor-only fallback for tmux versions/sources that cannot
+		// expose the mode formats.
 		snap.CursorRow, snap.CursorCol, snap.HasCursor = row, col, true
 	}
 	return snap, nil

--- a/session/tmux/bounded_test.go
+++ b/session/tmux/bounded_test.go
@@ -53,6 +53,7 @@ func TestBoundedTmuxCommandsDoNotHang(t *testing.T) {
 	}{
 		{"CaptureVisiblePaneGrid", func(ts *TmuxSession) error { _, err := ts.CaptureVisiblePaneGrid(); return err }},
 		{"CursorPosition", func(ts *TmuxSession) error { _, _, err := ts.CursorPosition(); return err }},
+		{"ReadTerminalState", func(ts *TmuxSession) error { _, err := ts.ReadTerminalState(); return err }},
 		{"EnablePipePane", func(ts *TmuxSession) error { return ts.EnablePipePane("dd of=/dev/null") }},
 		{"DisablePipePane", func(ts *TmuxSession) error { return ts.DisablePipePane() }},
 		// Not named in #1787, but the same unbounded pattern on the same WS data
@@ -96,7 +97,7 @@ func TestBoundedTmuxCommandsSucceedWhenTmuxIsHealthy(t *testing.T) {
 	dir := t.TempDir()
 	// display-message drives CursorPosition, which parses "row col"; every other
 	// command just needs a clean exit.
-	script := "#!/bin/sh\nif [ \"$1\" = \"display-message\" ]; then echo '3 7'; else echo 'pane line'; fi\n"
+	script := "#!/bin/sh\nif [ \"$1\" = \"display-message\" ]; then echo '3 7 0 0 0 0 0 0 0'; else echo 'pane line'; fi\n"
 	if err := os.WriteFile(filepath.Join(dir, "tmux"), []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake tmux: %v", err)
 	}
@@ -110,6 +111,10 @@ func TestBoundedTmuxCommandsSucceedWhenTmuxIsHealthy(t *testing.T) {
 	row, col, err := ts.CursorPosition()
 	if err != nil || row != 3 || col != 7 {
 		t.Fatalf("CursorPosition: got (%d,%d) err %v, want (3,7)", row, col, err)
+	}
+	state, err := ts.ReadTerminalState()
+	if err != nil || state.CursorRow != 3 || state.CursorCol != 7 {
+		t.Fatalf("ReadTerminalState: got %+v err %v, want cursor (3,7)", state, err)
 	}
 	if err := ts.EnablePipePane("dd of=/dev/null"); err != nil {
 		t.Fatalf("EnablePipePane: %v", err)

--- a/session/tmux/terminal_modes.go
+++ b/session/tmux/terminal_modes.go
@@ -1,0 +1,60 @@
+package tmux
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/sachiniyer/agent-factory/terminal"
+)
+
+// TerminalState is the part of a tmux pane snapshot capture-pane cannot carry:
+// the real cursor and the ownership-affecting terminal modes. Applications can
+// switch these modes without repainting them for a later subscriber, so the WS
+// stream snapshots them explicitly.
+type TerminalState struct {
+	CursorRow int
+	CursorCol int
+	Modes     terminal.Modes
+}
+
+const terminalStateFormat = "#{cursor_y} #{cursor_x} #{alternate_on} #{mouse_any_flag} #{mouse_standard_flag} #{mouse_button_flag} #{mouse_all_flag} #{mouse_utf8_flag} #{mouse_sgr_flag}"
+
+// ReadTerminalState reads cursor, alternate-screen, mouse tracking, and mouse
+// encoding in one bounded tmux request. One display-message keeps those fields
+// from describing different instants and avoids multiplying subscribe latency.
+func (t *TmuxSession) ReadTerminalState() (TerminalState, error) {
+	ctx, cancel := tmuxTimeoutContext()
+	defer cancel()
+	output, err := t.outputTmuxBounded(ctx, "display-message", "-p", "-t", exactTarget(t.sanitizedName), terminalStateFormat)
+	if err != nil {
+		if ctx.Err() != nil {
+			return TerminalState{}, fmt.Errorf("%w: terminal-state display-message after %s", ErrTmuxTimeout, tmuxCommandTimeout)
+		}
+		return TerminalState{}, fmt.Errorf("failed to read tmux terminal state: %v", err)
+	}
+	fields := strings.Fields(string(output))
+	if len(fields) != 9 {
+		return TerminalState{}, fmt.Errorf("failed to parse tmux terminal state %q: want 9 fields, got %d", string(output), len(fields))
+	}
+	values := make([]int, len(fields))
+	for i, field := range fields {
+		values[i], err = strconv.Atoi(field)
+		if err != nil {
+			return TerminalState{}, fmt.Errorf("failed to parse tmux terminal state %q: field %d: %v", string(output), i, err)
+		}
+	}
+	return TerminalState{
+		CursorRow: values[0],
+		CursorCol: values[1],
+		Modes: terminal.Modes{
+			AlternateScreen: values[2] != 0,
+			MouseTracking:   values[3] != 0,
+			MouseStandard:   values[4] != 0,
+			MouseButton:     values[5] != 0,
+			MouseAll:        values[6] != 0,
+			MouseUTF8:       values[7] != 0,
+			MouseSGR:        values[8] != 0,
+		},
+	}, nil
+}

--- a/session/tmux/terminal_modes_test.go
+++ b/session/tmux/terminal_modes_test.go
@@ -1,0 +1,33 @@
+package tmux
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/cmd"
+)
+
+func TestReadTerminalState(t *testing.T) {
+	dir := t.TempDir()
+	script := "#!/bin/sh\nprintf '7 11 1 1 0 1 0 0 1\\n'\n"
+	if err := os.WriteFile(filepath.Join(dir, "tmux"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	ts := NewTmuxSessionWithDeps("terminal-state", "sh", MakePtyFactory(), cmd.MakeExecutor())
+
+	state, err := ts.ReadTerminalState()
+	if err != nil {
+		t.Fatalf("ReadTerminalState: %v", err)
+	}
+	if state.CursorRow != 7 || state.CursorCol != 11 {
+		t.Fatalf("cursor = (%d,%d), want (7,11)", state.CursorRow, state.CursorCol)
+	}
+	if !state.Modes.AlternateScreen || !state.Modes.MouseButton || !state.Modes.MouseSGR {
+		t.Fatalf("modes = %+v, want alternate + button tracking + SGR", state.Modes)
+	}
+	if state.Modes.MouseStandard || state.Modes.MouseAll || state.Modes.MouseUTF8 {
+		t.Fatalf("modes = %+v, enabled a flag the snapshot reported off", state.Modes)
+	}
+}

--- a/task/runner.go
+++ b/task/runner.go
@@ -632,7 +632,9 @@ func capturePreview(ctx context.Context, instance *session.Instance) (string, er
 		if cp, ok := server.(contextPreviewer); ok {
 			content, err = cp.PreviewContext(cctx, 0, false)
 		} else {
-			content, err = server.Preview(0, false)
+			var snapshot session.PreviewSnapshot
+			snapshot, err = server.Preview(0, false)
+			content = snapshot.Content
 		}
 		ch <- previewResult{content: content, err: err}
 	}()

--- a/terminal/modes.go
+++ b/terminal/modes.go
@@ -1,0 +1,63 @@
+// Package terminal defines terminal state shared by PTY producers and clients.
+package terminal
+
+import "strings"
+
+// Modes are the terminal modes that determine which side owns scrolling and
+// how mouse input must be encoded. They are a snapshot of the child terminal,
+// not AF configuration: applications may change them at runtime.
+type Modes struct {
+	AlternateScreen bool `json:"alternate_screen"`
+	MouseTracking   bool `json:"mouse_tracking"`
+	MouseStandard   bool `json:"mouse_standard"`
+	MouseButton     bool `json:"mouse_button"`
+	MouseAll        bool `json:"mouse_all"`
+	MouseUTF8       bool `json:"mouse_utf8"`
+	MouseSGR        bool `json:"mouse_sgr"`
+}
+
+// MouseTrackingEnabled reports whether the child requested mouse events. The
+// UTF-8 and SGR flags only select an encoding; neither claims the mouse alone.
+func (m Modes) MouseTrackingEnabled() bool {
+	return m.MouseTracking || m.MouseStandard || m.MouseButton || m.MouseAll
+}
+
+// RestoreSequence returns DEC mode bytes that replace, rather than merge with,
+// a client's current ownership modes. A fresh subscriber did not observe the
+// application's earlier DECSETs, while a repaint after a lost replay gap may
+// have stale modes; reset-first makes the snapshot authoritative in both cases.
+func (m Modes) RestoreSequence() []byte {
+	var b strings.Builder
+	// Normalize the alternate buffer before selecting the captured one. This is
+	// idempotent for a fresh emulator and also drops a stale alternate buffer on
+	// a reconnect repaint before the captured grid is installed.
+	b.WriteString("\x1b[?1049l")
+	// tmux exposes exactly these mutually-exclusive tracking modes plus the two
+	// independent encoding flags. Reset every one before applying the snapshot.
+	b.WriteString("\x1b[?9l\x1b[?1000l\x1b[?1001l\x1b[?1002l\x1b[?1003l\x1b[?1005l\x1b[?1006l")
+	if m.AlternateScreen {
+		b.WriteString("\x1b[?1049h")
+	}
+	if m.MouseStandard {
+		b.WriteString("\x1b[?1000h")
+	}
+	if m.MouseButton {
+		b.WriteString("\x1b[?1002h")
+	}
+	if m.MouseAll {
+		b.WriteString("\x1b[?1003h")
+	}
+	if m.MouseTracking && !m.MouseStandard && !m.MouseButton && !m.MouseAll {
+		// tmux normally reports the exact standard/button/all flag alongside
+		// mouse_any. Keep an aggregate-only producer useful without inventing a
+		// motion mode: normal tracking is the least permissive representation.
+		b.WriteString("\x1b[?1000h")
+	}
+	if m.MouseUTF8 {
+		b.WriteString("\x1b[?1005h")
+	}
+	if m.MouseSGR {
+		b.WriteString("\x1b[?1006h")
+	}
+	return []byte(b.String())
+}

--- a/terminal/modes_test.go
+++ b/terminal/modes_test.go
@@ -1,0 +1,44 @@
+package terminal
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestModesRestoreSequenceReplacesOwnershipModes(t *testing.T) {
+	m := Modes{
+		AlternateScreen: true,
+		MouseButton:     true,
+		MouseSGR:        true,
+	}
+	got := string(m.RestoreSequence())
+	for _, want := range []string{
+		"\x1b[?1049l",
+		"\x1b[?9l",
+		"\x1b[?1000l",
+		"\x1b[?1001l",
+		"\x1b[?1002l",
+		"\x1b[?1003l",
+		"\x1b[?1005l",
+		"\x1b[?1006l",
+		"\x1b[?1049h",
+		"\x1b[?1002h",
+		"\x1b[?1006h",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("RestoreSequence() = %q, missing %q", got, want)
+		}
+	}
+	if strings.Contains(got, "\x1b[?1000h") || strings.Contains(got, "\x1b[?1003h") {
+		t.Fatalf("RestoreSequence() enabled a tracking mode absent from the snapshot: %q", got)
+	}
+}
+
+func TestMouseEncodingDoesNotClaimTracking(t *testing.T) {
+	if (Modes{MouseSGR: true, MouseUTF8: true}).MouseTrackingEnabled() {
+		t.Fatal("encoding flags alone must not claim mouse ownership")
+	}
+	if !(Modes{MouseStandard: true}).MouseTrackingEnabled() {
+		t.Fatal("a tracking flag must claim mouse ownership")
+	}
+}

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -60,6 +60,10 @@ type Menu struct {
 	// interactive: every keystroke is forwarding into the focused pane's
 	// terminal (#1089, RFC §2.3), so the bar shows only the escape hatch.
 	interactive bool
+	// scrollAvailable says the current pane action target has truthful AF-owned
+	// history. Child-owned/unknown terminals hide Ctrl-U/Ctrl-D instead of
+	// advertising a capture-pane view of the wrong buffer.
+	scrollAvailable bool
 
 	// splitPaneAvailable is true only while there is an active preview that
 	// `S` can commit as another pane. Without that preview the key no-ops, so
@@ -180,6 +184,17 @@ func (m *Menu) SetActiveTab(tab int) {
 // the Ctrl-] escape hatch shows while keystrokes forward to the pane (#1089).
 func (m *Menu) SetInteractive(on bool) {
 	m.interactive = on
+	m.updateOptions()
+}
+
+// SetScrollAvailable controls whether pane/instance options advertise the AF
+// preview scroll keys. The key binding remains global; its controller is also a
+// no-op for child/unknown owners, so menu and behavior share the same truth.
+func (m *Menu) SetScrollAvailable(available bool) {
+	if m.scrollAvailable == available {
+		return
+	}
+	m.scrollAvailable = available
 	m.updateOptions()
 }
 
@@ -325,11 +340,12 @@ func (m *Menu) addInstanceOptions() {
 	// Action group: enter interacts in-pane, o attaches full-screen (#1089).
 	actionGroup := []keys.KeyName{keys.KeyEnter, keys.KeyAttach}
 
-	// Navigation group: every tab is a captured tmux session and supports
-	// scroll mode (#930 PR 2 — the Agent tab and the terminal tab
-	// both scroll), so the scroll keys always show for an instance.
-	actionGroup = append(actionGroup, keys.KeyShiftUp)
-	actionGroup = append(actionGroup, keys.KeyShiftDown)
+	// Navigation group: agent and terminal tabs use the same scroll controller,
+	// but only an authoritative host-history owner can honor these keys.
+	if m.scrollAvailable {
+		actionGroup = append(actionGroup, keys.KeyShiftUp)
+		actionGroup = append(actionGroup, keys.KeyShiftDown)
+	}
 
 	// Usage-limit retry (#1146): advertised only when the selected session is
 	// actually blocked at a limit wall — c re-spawns (if the agent exited) and
@@ -399,7 +415,10 @@ func (m *Menu) addInstanceOptions() {
 func (m *Menu) setPaneFocusOptions() {
 	// Action group: enter interacts in-pane / o attaches full-screen (#1089),
 	// and scroll acts on this pane's binding.
-	actionGroup := []keys.KeyName{keys.KeyEnter, keys.KeyAttach, keys.KeyShiftUp, keys.KeyShiftDown}
+	actionGroup := []keys.KeyName{keys.KeyEnter, keys.KeyAttach}
+	if m.scrollAvailable {
+		actionGroup = append(actionGroup, keys.KeyShiftUp, keys.KeyShiftDown)
+	}
 	focusGroup := []keys.KeyName{keys.KeyPanePrev, keys.KeyPaneNext}
 	paneGroup := []keys.KeyName{keys.KeyOpenPane}
 	if m.splitPaneAvailable {

--- a/ui/menu_test.go
+++ b/ui/menu_test.go
@@ -22,11 +22,12 @@ func readyUIInstance() *session.Instance {
 	return i
 }
 
-// TestMenuTerminalTabShowsBothScrollKeys verifies that when the terminal tab
-// is active, the instance menu surfaces both scroll shortcuts. Regression test
+// TestMenuTerminalTabShowsBothScrollKeys verifies that a terminal tab with
+// authoritative host history surfaces both scroll shortcuts. Regression test
 // for issue #270.
 func TestMenuTerminalTabShowsBothScrollKeys(t *testing.T) {
 	m := NewMenu()
+	m.SetScrollAvailable(true)
 	// Use a non-loading instance so addInstanceOptions renders the full menu.
 	m.SetInstance(readyUIInstance())
 	m.SetActiveTab(1)
@@ -55,6 +56,7 @@ func TestMenuTerminalTabShowsBothScrollKeys(t *testing.T) {
 // test for issue #467.
 func TestMenuAgentTabShowsBothScrollKeys(t *testing.T) {
 	m := NewMenu()
+	m.SetScrollAvailable(true)
 	m.SetInstance(readyUIInstance())
 	m.SetActiveTab(0)
 
@@ -73,6 +75,36 @@ func TestMenuAgentTabShowsBothScrollKeys(t *testing.T) {
 	}
 	if gotShiftDown != 1 {
 		t.Errorf("expected exactly 1 KeyShiftDown in agent tab menu, got %d", gotShiftDown)
+	}
+}
+
+func TestMenuHidesScrollKeysWhenControllerCannotProvideHistory(t *testing.T) {
+	m := NewMenu()
+	m.SetInstance(readyUIInstance())
+	m.SetScrollAvailable(false)
+
+	assertAbsent := func() {
+		t.Helper()
+		for _, k := range m.options {
+			if k == keys.KeyShiftUp || k == keys.KeyShiftDown {
+				t.Fatalf("unavailable scroll key leaked into options: %v", m.options)
+			}
+		}
+	}
+	m.SetFocusRegion(layout.RegionTree)
+	assertAbsent()
+	m.SetFocusRegion(layout.PaneRegion(7))
+	assertAbsent()
+
+	m.SetScrollAvailable(true)
+	var found int
+	for _, k := range m.options {
+		if k == keys.KeyShiftUp || k == keys.KeyShiftDown {
+			found++
+		}
+	}
+	if found != 2 {
+		t.Fatalf("restoring host ownership yielded %d scroll keys, want 2: %v", found, m.options)
 	}
 }
 

--- a/ui/preview_scroll_fallback_test.go
+++ b/ui/preview_scroll_fallback_test.go
@@ -36,6 +36,7 @@ const staleScrollMarker = "STALE-SCROLL-VIEWPORT-CONTENT"
 // reset scroll mode on its own — we want to prove setFallbackState is what
 // clears it.
 func enterScrollWithStaleViewport(p *TabPane, inst *session.Instance) {
+	enableHostHistory(p, inst, 0)
 	p.currentInstance = inst
 	// Adopt the agent slot too, so dropStaleView sees no (instance, tab) change
 	// when UpdateContent(inst, 0) runs — we want to prove setFallbackState is
@@ -151,6 +152,7 @@ func TestPreviewScrollEntryDeletingShowsTeardownFallback(t *testing.T) {
 
 	p := NewTabPane(previewFromInstance)
 	p.SetSize(80, 30)
+	enableHostHistory(p, inst, 0)
 
 	require.NoError(t, p.ScrollUp(inst, 0))
 
@@ -159,8 +161,8 @@ func TestPreviewScrollEntryDeletingShowsTeardownFallback(t *testing.T) {
 	require.True(t, p.content.fallback,
 		"deleting agent tab must enter fallback state when scrolling starts")
 	require.Contains(t, p.content.text, "Tearing down session…")
-	require.NotContains(t, p.viewport.View(), scrollFooter(),
-		"scroll footer must not be the only visible content")
+	require.Empty(t, strings.TrimSpace(p.viewport.View()),
+		"a rejected scroll entry must not leave viewport content")
 	require.Contains(t, p.String(), "Tearing down session…",
 		"rendered frame must show the teardown fallback")
 }

--- a/ui/preview_scroll_offloop_test.go
+++ b/ui/preview_scroll_offloop_test.go
@@ -19,6 +19,45 @@ func numberedScrollHistory(lines int) string {
 	return strings.Join(out, "\n")
 }
 
+// TestFirstScrollIntentRevealsAnOlderTerminalRow pins the user-visible contract,
+// not just the controller's internal offset. tmux terminates capture-pane output
+// with a newline; that record separator and AF's own scroll-mode chrome must not
+// become rows in the terminal's history coordinate system. With a ten-row pane,
+// the normal bottom view is history-031..040, so one upward gesture must reveal
+// history-030 immediately.
+func TestFirstScrollIntentRevealsAnOlderTerminalRow(t *testing.T) {
+	inst := makeShellInstance(t, "visible-first-intent", "visible-line")
+	defer func() { _ = inst.Kill() }()
+
+	src := func(_ *session.Instance, _ int, full bool) (PreviewSnapshot, error) {
+		if !full {
+			return hostPreview("visible-line"), nil
+		}
+		return hostPreview(numberedScrollHistory(40) + "\n"), nil
+	}
+	p := NewTabPane(src)
+	p.SetScrollOwnerFor(inst, 1, ScrollOwnerHostHistory)
+	p.SetSize(80, 10)
+	require.NoError(t, p.ScrollUp(inst, 1))
+	p.BeginScrollFill()
+	require.NoError(t, p.UpdateContent(inst, 1))
+
+	rendered := p.String()
+	require.Contains(t, rendered, "history-030",
+		"the first gesture must reveal a row older than the normal bottom view")
+	require.NotContains(t, rendered, "history-040",
+		"scrolling up one row must move the newest row out of the viewport")
+	require.NotContains(t, rendered, "SCROLL",
+		"AF scroll-mode chrome must not be part of terminal history")
+}
+
+func TestCapturePaneHistoryRowsRemovesOnlyTheRecordSeparator(t *testing.T) {
+	require.Equal(t, "history", capturePaneHistoryRows("history\n"))
+	require.Equal(t, "history\n", capturePaneHistoryRows("history\n\n"),
+		"an intentional blank terminal row must survive")
+	require.Equal(t, "history", capturePaneHistoryRows("history"))
+}
+
 // TestFirstScrollIntentSurvivesPendingFill is the fail-first half of #2192:
 // the gesture that ENTERS scroll mode is still a scroll request. The history
 // capture remains off the event loop (#1637), but when it lands the viewport
@@ -31,16 +70,17 @@ func TestFirstScrollIntentSurvivesPendingFill(t *testing.T) {
 	history := numberedScrollHistory(40)
 	started := make(chan struct{})
 	release := make(chan struct{})
-	src := func(_ *session.Instance, _ int, full bool) (string, error) {
+	src := func(_ *session.Instance, _ int, full bool) (PreviewSnapshot, error) {
 		if !full {
-			return "visible-line", nil
+			return hostPreview("visible-line"), nil
 		}
 		close(started)
 		<-release
-		return history, nil
+		return hostPreview(history), nil
 	}
 
 	p := NewTabPane(src)
+	p.SetScrollOwnerFor(inst, 1, ScrollOwnerHostHistory)
 	p.SetSize(80, height)
 	require.NoError(t, p.ScrollUp(inst, 1))
 	p.BeginScrollFill()
@@ -51,9 +91,9 @@ func TestFirstScrollIntentSurvivesPendingFill(t *testing.T) {
 	close(release)
 	require.NoError(t, <-filled)
 
-	// Forty history rows plus the one-row footer produce a bottom offset of 31.
-	// The initiating up intent must therefore land at offset 30.
-	require.Equal(t, 30, p.viewport.YOffset,
+	// Forty terminal rows produce a bottom offset of 30. The initiating up
+	// intent must therefore land at offset 29.
+	require.Equal(t, 29, p.viewport.YOffset,
 		"the first scroll-up must be applied after the async history fill")
 }
 
@@ -69,16 +109,17 @@ func TestQueuedScrollIntentsSurvivePendingFill(t *testing.T) {
 	history := numberedScrollHistory(40)
 	started := make(chan struct{})
 	release := make(chan struct{})
-	src := func(_ *session.Instance, _ int, full bool) (string, error) {
+	src := func(_ *session.Instance, _ int, full bool) (PreviewSnapshot, error) {
 		if !full {
-			return "visible-line", nil
+			return hostPreview("visible-line"), nil
 		}
 		close(started)
 		<-release
-		return history, nil
+		return hostPreview(history), nil
 	}
 
 	p := NewTabPane(src)
+	p.SetScrollOwnerFor(inst, 1, ScrollOwnerHostHistory)
 	p.SetSize(80, height)
 	require.NoError(t, p.ScrollUp(inst, 1)) // initiating intent
 	p.BeginScrollFill()
@@ -91,9 +132,193 @@ func TestQueuedScrollIntentsSurvivePendingFill(t *testing.T) {
 	close(release)
 	require.NoError(t, <-filled)
 
-	// Bottom is 31; all three up intents must survive, yielding 28.
-	require.Equal(t, 28, p.viewport.YOffset,
+	// Bottom is 30; all three up intents must survive, yielding 27.
+	require.Equal(t, 27, p.viewport.YOffset,
 		"scroll intents queued during the pending fill must all be applied")
+}
+
+// TestOwnershipSnapshotPreservesPendingScrollIntent pins the other ordering of
+// the asynchronous race: a normal capture may already be in flight when the
+// user scrolls. Its terminal modes establish HostHistory, but must promote the
+// existing probe rather than replace the controller that holds queued input.
+func TestOwnershipSnapshotPreservesPendingScrollIntent(t *testing.T) {
+	inst := makeShellInstance(t, "ownership-snapshot", "visible-line")
+	defer func() { _ = inst.Kill() }()
+
+	const height = 10
+	normalStarted := make(chan struct{})
+	releaseNormal := make(chan struct{})
+	src := func(_ *session.Instance, _ int, full bool) (PreviewSnapshot, error) {
+		if full {
+			return hostPreview(numberedScrollHistory(40)), nil
+		}
+		close(normalStarted)
+		<-releaseNormal
+		return hostPreview("visible-line"), nil
+	}
+
+	p := NewTabPane(src)
+	p.SetSize(80, height)
+	normalDone := make(chan error, 1)
+	go func() { normalDone <- p.UpdateContent(inst, 1) }()
+	<-normalStarted
+
+	// Both requests land while ownership is still unknown. The normal snapshot
+	// resolves the probe, then the full capture must replay both requests.
+	require.NoError(t, p.ScrollUp(inst, 1))
+	require.NoError(t, p.ScrollUp(inst, 1))
+	close(releaseNormal)
+	require.NoError(t, <-normalDone)
+	require.Equal(t, ScrollOwnerHostHistory, p.ScrollOwner())
+	require.True(t, p.NeedsScrollFill())
+
+	p.BeginScrollFill()
+	require.NoError(t, p.UpdateContent(inst, 1))
+	require.Equal(t, 28, p.viewport.YOffset,
+		"an ownership snapshot must not erase input queued by its capture probe")
+}
+
+func TestOwnerSwitchInvalidatesPendingHostHistoryFill(t *testing.T) {
+	inst := makeShellInstance(t, "owner-switch", "visible-line")
+	defer func() { _ = inst.Kill() }()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	src := func(_ *session.Instance, _ int, full bool) (PreviewSnapshot, error) {
+		if !full {
+			return hostPreview("visible-line"), nil
+		}
+		close(started)
+		<-release
+		return hostPreview(numberedScrollHistory(40)), nil
+	}
+	p := NewTabPane(src)
+	p.SetScrollOwnerFor(inst, 1, ScrollOwnerHostHistory)
+	p.SetSize(80, 10)
+	require.NoError(t, p.ScrollUp(inst, 1))
+	p.BeginScrollFill()
+
+	filled := make(chan error, 1)
+	go func() { filled <- p.UpdateContent(inst, 1) }()
+	<-started
+	p.SetScrollOwnerFor(inst, 1, ScrollOwnerChildApplication)
+	close(release)
+	require.NoError(t, <-filled)
+
+	require.Equal(t, ScrollOwnerChildApplication, p.ScrollOwner())
+	require.False(t, p.IsScrolling(),
+		"a late host capture must not paint over a child-owned terminal")
+	require.Equal(t, 0, p.viewport.YOffset)
+}
+
+func TestLateNormalSnapshotCannotOverrideNewerChildOwnership(t *testing.T) {
+	inst := makeShellInstance(t, "late-normal-owner", "visible-line")
+	defer func() { _ = inst.Kill() }()
+
+	normalStarted := make(chan struct{})
+	releaseNormal := make(chan struct{})
+	src := func(_ *session.Instance, _ int, full bool) (PreviewSnapshot, error) {
+		if full {
+			return PreviewSnapshot{
+				Content: numberedScrollHistory(40),
+				Owner:   ScrollOwnerChildApplication,
+			}, nil
+		}
+		close(normalStarted)
+		<-releaseNormal
+		return hostPreview("stale-primary-grid"), nil
+	}
+
+	p := NewTabPane(src)
+	p.SetSize(80, 10)
+	normalDone := make(chan error, 1)
+	go func() { normalDone <- p.UpdateContent(inst, 1) }()
+	<-normalStarted
+
+	// The gesture starts a newer full snapshot. It observes an alternate-screen
+	// child and rejects tmux's background primary buffer.
+	require.NoError(t, p.ScrollUp(inst, 1))
+	p.BeginScrollFill()
+	require.NoError(t, p.UpdateContent(inst, 1))
+	require.Equal(t, ScrollOwnerChildApplication, p.ScrollOwner())
+
+	// The older primary-screen snapshot finishes last. Completion order must not
+	// let it reclassify the pane as HostHistory.
+	close(releaseNormal)
+	require.NoError(t, <-normalDone)
+	require.Equal(t, ScrollOwnerChildApplication, p.ScrollOwner(),
+		"a stale normal capture must not overwrite the newer full snapshot")
+	require.False(t, p.IsScrolling())
+}
+
+func TestSameTargetPreviewPublishesByDispatchOrderNotCompletionOrder(t *testing.T) {
+	inst := makeShellInstance(t, "same-target-preview-order", "visible-line")
+	defer func() { _ = inst.Kill() }()
+
+	firstStarted := make(chan struct{})
+	secondStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	releaseSecond := make(chan struct{})
+	var calls int32
+	src := func(_ *session.Instance, _ int, full bool) (PreviewSnapshot, error) {
+		require.False(t, full)
+		switch atomic.AddInt32(&calls, 1) {
+		case 1:
+			close(firstStarted)
+			<-releaseFirst
+			return hostPreview("older-grid"), nil
+		case 2:
+			close(secondStarted)
+			<-releaseSecond
+			return hostPreview("newer-grid"), nil
+		default:
+			return PreviewSnapshot{}, fmt.Errorf("unexpected preview capture")
+		}
+	}
+
+	p := NewTabPane(src)
+	p.SetSize(80, 10)
+	firstDone := make(chan error, 1)
+	secondDone := make(chan error, 1)
+	go func() { firstDone <- p.UpdateContent(inst, 1) }()
+	<-firstStarted
+	go func() { secondDone <- p.UpdateContent(inst, 1) }()
+	<-secondStarted
+
+	close(releaseSecond)
+	require.NoError(t, <-secondDone)
+	require.Contains(t, p.String(), "newer-grid")
+
+	close(releaseFirst)
+	require.NoError(t, <-firstDone)
+	require.Contains(t, p.String(), "newer-grid",
+		"an older capture finishing last must not replace the newer snapshot")
+	require.NotContains(t, p.String(), "older-grid")
+}
+
+func TestFullCaptureCannotPublishAfterTargetBecomesChildOwned(t *testing.T) {
+	inst := makeShellInstance(t, "owner-from-fill", "visible-line")
+	defer func() { _ = inst.Kill() }()
+
+	src := func(_ *session.Instance, _ int, full bool) (PreviewSnapshot, error) {
+		if !full {
+			return hostPreview("visible-line"), nil
+		}
+		return PreviewSnapshot{
+			Content: numberedScrollHistory(40),
+			Owner:   ScrollOwnerChildApplication,
+		}, nil
+	}
+	p := NewTabPane(src)
+	p.SetSize(80, 10)
+	enableHostHistory(p, inst, 1)
+	require.NoError(t, p.ScrollUp(inst, 1))
+	require.NoError(t, p.UpdateContent(inst, 1))
+
+	require.Equal(t, ScrollOwnerChildApplication, p.ScrollOwner())
+	require.False(t, p.IsScrolling())
+	require.NotContains(t, p.viewport.View(), "history-",
+		"a full capture from an alternate-screen target is the wrong buffer")
 }
 
 // TestHostHistoryScrollRetargetKeepsNewViewIntent pins the view-key boundary:
@@ -109,22 +334,23 @@ func TestHostHistoryScrollRetargetKeepsNewViewIntent(t *testing.T) {
 	historyB := strings.ReplaceAll(numberedScrollHistory(40), "history", "b-history")
 	aStarted := make(chan struct{})
 	releaseA := make(chan struct{})
-	src := func(inst *session.Instance, _ int, full bool) (string, error) {
+	src := func(inst *session.Instance, _ int, full bool) (PreviewSnapshot, error) {
 		if !full {
 			if inst == instA {
-				return "visible-a", nil
+				return hostPreview("visible-a"), nil
 			}
-			return "visible-b", nil
+			return hostPreview("visible-b"), nil
 		}
 		if inst == instA {
 			close(aStarted)
 			<-releaseA
-			return historyA, nil
+			return hostPreview(historyA), nil
 		}
-		return historyB, nil
+		return hostPreview(historyB), nil
 	}
 
 	p := NewTabPane(src)
+	p.SetScrollOwnerFor(instA, 1, ScrollOwnerHostHistory)
 	p.SetSize(80, 10)
 	require.NoError(t, p.ScrollUp(instA, 1))
 	p.BeginScrollFill()
@@ -140,7 +366,7 @@ func TestHostHistoryScrollRetargetKeepsNewViewIntent(t *testing.T) {
 	require.NoError(t, p.UpdateContent(instB, 1))
 	require.Contains(t, p.viewport.View(), "b-history")
 	require.NotContains(t, p.viewport.View(), "a-history")
-	require.Equal(t, 30, p.viewport.YOffset,
+	require.Equal(t, 29, p.viewport.YOffset,
 		"the retargeting intent must be applied to B's host history")
 
 	// A's stale capture may return afterward, but cannot overwrite B or consume
@@ -149,7 +375,7 @@ func TestHostHistoryScrollRetargetKeepsNewViewIntent(t *testing.T) {
 	require.NoError(t, <-aFilled)
 	require.Contains(t, p.viewport.View(), "b-history")
 	require.NotContains(t, p.viewport.View(), "a-history")
-	require.Equal(t, 30, p.viewport.YOffset)
+	require.Equal(t, 29, p.viewport.YOffset)
 }
 
 // TestScrollEntryExitNeverCapturesOnEventLoop is the #1637 regression: entering
@@ -169,13 +395,14 @@ func TestScrollEntryExitNeverCapturesOnEventLoop(t *testing.T) {
 
 	release := make(chan struct{})
 	var calls int32
-	blockingSrc := func(_ *session.Instance, _ int, _ bool) (string, error) {
+	blockingSrc := func(_ *session.Instance, _ int, _ bool) (PreviewSnapshot, error) {
 		atomic.AddInt32(&calls, 1)
 		<-release // stand in for a slow/hung tmux capture or daemon Preview RPC
-		return "scrollback-line", nil
+		return hostPreview("scrollback-line"), nil
 	}
 
 	p := NewTabPane(blockingSrc)
+	p.SetScrollOwnerFor(inst, 1, ScrollOwnerHostHistory)
 	p.SetSize(80, 30)
 
 	// mustReturnPromptly runs fn on another goroutine and fails if it does not
@@ -237,11 +464,12 @@ func TestBeginScrollFillMasksNeedsScrollFill(t *testing.T) {
 	defer func() { _ = inst.Kill() }()
 
 	var calls int32
-	countingSrc := func(_ *session.Instance, _ int, _ bool) (string, error) {
+	countingSrc := func(_ *session.Instance, _ int, _ bool) (PreviewSnapshot, error) {
 		atomic.AddInt32(&calls, 1)
-		return "scrollback-line", nil
+		return hostPreview("scrollback-line"), nil
 	}
 	p := NewTabPane(countingSrc)
+	p.SetScrollOwnerFor(inst, 1, ScrollOwnerHostHistory)
 	p.SetSize(80, 30)
 
 	// Enter scroll mode: a fill is owed, none dispatched yet.
@@ -289,14 +517,15 @@ func TestStaleScrollFillDoesNotSatisfyNewEntry(t *testing.T) {
 	type gate struct{ ch chan struct{} }
 	gates := make(chan *gate, 4)
 	var calls int32
-	blockingSrc := func(_ *session.Instance, _ int, _ bool) (string, error) {
+	blockingSrc := func(_ *session.Instance, _ int, _ bool) (PreviewSnapshot, error) {
 		atomic.AddInt32(&calls, 1)
 		g := &gate{ch: make(chan struct{})}
 		gates <- g
 		<-g.ch
-		return "scrollback-line", nil
+		return hostPreview("scrollback-line"), nil
 	}
 	p := NewTabPane(blockingSrc)
+	p.SetScrollOwnerFor(inst, 1, ScrollOwnerHostHistory)
 	p.SetSize(80, 30)
 
 	// Session #1: enter scroll mode and dispatch its fill (still in flight).

--- a/ui/preview_test.go
+++ b/ui/preview_test.go
@@ -247,8 +247,8 @@ func TestPreviewScrolling(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify that the full history contains both the command and early output
-	require.Contains(t, fullHistory, "$ seq 100", "Full history should contain the command")
-	require.Contains(t, fullHistory, "1", "Full history should contain earliest output")
+	require.Contains(t, fullHistory.Content, "$ seq 100", "Full history should contain the command")
+	require.Contains(t, fullHistory.Content, "1", "Full history should contain earliest output")
 
 	// Step 3: Enter scroll mode
 	err = previewPane.ScrollUp(setup.instance, 0)
@@ -502,6 +502,7 @@ func TestPreviewResetToNormalModeNilInstance(t *testing.T) {
 
 	p := NewTabPane(previewFromInstance)
 	p.SetSize(80, 30)
+	enableHostHistory(p, nil, 0)
 
 	// Simulate being in scroll mode with stale viewport content.
 	const staleContent = "stale-scroll-content-line\nanother-line"
@@ -549,6 +550,7 @@ func TestPreviewResetToNormalModeLoadingShowsFallback(t *testing.T) {
 	require.True(t, p.content.fallback,
 		"precondition: Loading instance shows the fallback in normal mode")
 
+	enableHostHistory(p, inst, 0)
 	require.NoError(t, p.ScrollUp(inst, 0))
 	require.True(t, p.scroll.Active(), "precondition: ScrollUp enters scroll mode")
 
@@ -992,6 +994,7 @@ func TestScrollMouseDifferentInstanceResetsScrollMode(t *testing.T) {
 
 	p := NewTabPane(previewFromInstance)
 	p.SetSize(80, 30)
+	enableHostHistory(p, instA, 0)
 
 	// Enter scroll mode on A via the mouse path (no prior UpdateContent). Scroll
 	// entry is I/O-free (#1637); the off-loop refresh (UpdateContent) fills the

--- a/ui/scroll_controller.go
+++ b/ui/scroll_controller.go
@@ -51,6 +51,7 @@ type historyScrollController interface {
 	FillGeneration() uint64
 	FillIsCurrent(uint64) bool
 	RearmFill()
+	ResolveHost()
 	CompleteFill(uint64, *viewport.Model, string) bool
 }
 
@@ -62,51 +63,108 @@ const (
 	historyScrollReady
 )
 
-// hostHistoryScrollController owns all state that used to be distributed over
-// TabPane's isScrolling/fill-pending/generation booleans. phase is the single
-// state-machine axis. pendingIntents is intentionally retained while capture
-// runs, so input latency cannot erase or reorder user intent (#2192).
-type hostHistoryScrollController struct {
+// captureHistoryScrollController owns all state that used to be distributed
+// over TabPane's isScrolling/fill-pending/generation booleans. It begins either
+// as an ownership probe or as established HostHistory; ResolveHost promotes a
+// probe without replacing it, which preserves intent queued while terminal
+// modes were in flight. phase is the single state-machine axis.
+type captureHistoryScrollController struct {
+	owner          ScrollOwner
 	phase          historyScrollPhase
 	pendingIntents []ScrollIntent
 	fillGen        uint64
 	dispatchedGen  uint64
 }
 
-var _ historyScrollController = (*hostHistoryScrollController)(nil)
+var _ historyScrollController = (*captureHistoryScrollController)(nil)
 
 func newHostHistoryScrollController() historyScrollController {
-	return &hostHistoryScrollController{}
+	return &captureHistoryScrollController{owner: ScrollOwnerHostHistory}
 }
 
-func (*hostHistoryScrollController) Owner() ScrollOwner {
-	return ScrollOwnerHostHistory
+// newOwnershipProbeScrollController preserves input for a capture-backed target
+// whose terminal modes have not arrived yet. Its full capture resolves the same
+// controller to HostHistory, or TabPane replaces it with a non-host owner without
+// ever painting the captured buffer.
+func newOwnershipProbeScrollController() historyScrollController {
+	return &captureHistoryScrollController{owner: ScrollOwnerNone}
 }
 
-func (c *hostHistoryScrollController) Active() bool {
+// inactiveScrollController is the shared no-host-capture behavior for the two
+// non-host owners. Concrete owner types embed it so no constructor can pair this
+// behavior with HostHistory or an invalid enum value.
+type inactiveScrollController struct{}
+
+func (*inactiveScrollController) Active() bool { return false }
+func (*inactiveScrollController) Scroll(*viewport.Model, ScrollIntent) {
+}
+func (*inactiveScrollController) Resize(v *viewport.Model, width, height int) {
+	v.Width = width
+	v.Height = height
+}
+func (*inactiveScrollController) Reset(v *viewport.Model) {
+	v.SetContent("")
+	v.GotoTop()
+}
+
+// childApplicationScrollController prevents AF from entering capture history
+// while a fullscreen application owns the conversation. Input routing can still
+// forward a tracked wheel directly to the child.
+type childApplicationScrollController struct{ inactiveScrollController }
+
+func (*childApplicationScrollController) Owner() ScrollOwner {
+	return ScrollOwnerChildApplication
+}
+
+// unavailableScrollController is used by fresh live streams while they wait for
+// an authoritative repaint, and by surfaces with no truthful implementation.
+// Capture-backed previews use captureHistoryScrollController while resolving so
+// an initiating gesture can survive the asynchronous ownership snapshot.
+type unavailableScrollController struct{ inactiveScrollController }
+
+func (*unavailableScrollController) Owner() ScrollOwner { return ScrollOwnerNone }
+
+var (
+	_ ScrollController = (*childApplicationScrollController)(nil)
+	_ ScrollController = (*unavailableScrollController)(nil)
+)
+
+func newChildApplicationScrollController() ScrollController {
+	return &childApplicationScrollController{}
+}
+
+func newUnavailableScrollController() ScrollController {
+	return &unavailableScrollController{}
+}
+
+func (c *captureHistoryScrollController) Owner() ScrollOwner {
+	return c.owner
+}
+
+func (c *captureHistoryScrollController) Active() bool {
 	return c.phase != historyScrollIdle
 }
 
-func (c *hostHistoryScrollController) AwaitingHistory() bool {
+func (c *captureHistoryScrollController) AwaitingHistory() bool {
 	return c.phase == historyScrollLoading
 }
 
-func (c *hostHistoryScrollController) NeedsFill(viewportHeight int) bool {
+func (c *captureHistoryScrollController) NeedsFill(viewportHeight int) bool {
 	return c.phase == historyScrollLoading && viewportHeight > 0 &&
 		c.dispatchedGen != c.fillGen
 }
 
-func (c *hostHistoryScrollController) BeginFill() {
+func (c *captureHistoryScrollController) BeginFill() {
 	if c.phase == historyScrollLoading {
 		c.dispatchedGen = c.fillGen
 	}
 }
 
-func (c *hostHistoryScrollController) FillGeneration() uint64 {
+func (c *captureHistoryScrollController) FillGeneration() uint64 {
 	return c.fillGen
 }
 
-func (c *hostHistoryScrollController) FillIsCurrent(gen uint64) bool {
+func (c *captureHistoryScrollController) FillIsCurrent(gen uint64) bool {
 	return c.phase == historyScrollLoading && c.fillGen == gen
 }
 
@@ -114,7 +172,7 @@ func (c *hostHistoryScrollController) FillIsCurrent(gen uint64) bool {
 // acquisition is pending, or applies intent to the ready viewport. The first
 // request is recorded before the viewport is emptied: entering the mode is not
 // a substitute for performing the requested scroll.
-func (c *hostHistoryScrollController) Scroll(v *viewport.Model, intent ScrollIntent) {
+func (c *captureHistoryScrollController) Scroll(v *viewport.Model, intent ScrollIntent) {
 	if intent.Lines == 0 {
 		return
 	}
@@ -136,7 +194,7 @@ func (c *hostHistoryScrollController) Scroll(v *viewport.Model, intent ScrollInt
 // target offset is derived in one transition: seed the viewport's newest valid
 // offset, then apply every intent accumulated during the capture. There is no
 // final unconditional GotoBottom that can overwrite those requests (#2192).
-func (c *hostHistoryScrollController) CompleteFill(
+func (c *captureHistoryScrollController) CompleteFill(
 	gen uint64,
 	v *viewport.Model,
 	content string,
@@ -161,7 +219,7 @@ func (c *hostHistoryScrollController) CompleteFill(
 // Resize keeps a ready history viewport at the same distance from its newest
 // row. Loading uses the eventual geometry when CompleteFill lands; idle has no
 // scroll position to preserve.
-func (c *hostHistoryScrollController) Resize(v *viewport.Model, width, height int) {
+func (c *captureHistoryScrollController) Resize(v *viewport.Model, width, height int) {
 	distanceFromBottom := 0
 	if c.phase == historyScrollReady {
 		distanceFromBottom = max(0, viewportBottomOffset(v)-v.YOffset)
@@ -176,13 +234,17 @@ func (c *hostHistoryScrollController) Resize(v *viewport.Model, width, height in
 // RearmFill preserves pending intent but gives the retry a fresh generation.
 // A capture that could not publish must not either lose input or leave the pane
 // permanently masked as in-flight (#1709).
-func (c *hostHistoryScrollController) RearmFill() {
+func (c *captureHistoryScrollController) RearmFill() {
 	if c.phase == historyScrollLoading {
 		c.fillGen++
 	}
 }
 
-func (c *hostHistoryScrollController) Reset(v *viewport.Model) {
+func (c *captureHistoryScrollController) ResolveHost() {
+	c.owner = ScrollOwnerHostHistory
+}
+
+func (c *captureHistoryScrollController) Reset(v *viewport.Model) {
 	c.phase = historyScrollIdle
 	c.pendingIntents = nil
 	c.fillGen++

--- a/ui/scroll_controller_test.go
+++ b/ui/scroll_controller_test.go
@@ -4,12 +4,11 @@ import (
 	"testing"
 
 	"github.com/charmbracelet/bubbles/viewport"
-	"github.com/charmbracelet/lipgloss"
 	"github.com/stretchr/testify/require"
 )
 
 func TestHostHistoryScrollControllerConformanceAtTerminalSizes(t *testing.T) {
-	history := lipgloss.JoinVertical(lipgloss.Left, numberedScrollHistory(100), scrollFooter())
+	history := numberedScrollHistory(100)
 
 	for _, size := range []struct {
 		name          string
@@ -29,7 +28,7 @@ func TestHostHistoryScrollControllerConformanceAtTerminalSizes(t *testing.T) {
 			gen := controller.FillGeneration()
 			require.True(t, controller.CompleteFill(gen, &v, history))
 
-			bottom := 101 - size.height // 100 history rows + one footer row.
+			bottom := 100 - size.height
 			require.Equal(t, bottom-1, v.YOffset,
 				"first intent must land one row above bottom at %s", size.name)
 
@@ -41,7 +40,7 @@ func TestHostHistoryScrollControllerConformanceAtTerminalSizes(t *testing.T) {
 }
 
 func TestHostHistoryScrollControllerPreservesIntentAcrossPendingResize(t *testing.T) {
-	history := lipgloss.JoinVertical(lipgloss.Left, numberedScrollHistory(100), scrollFooter())
+	history := numberedScrollHistory(100)
 	v := viewport.New(80, 24)
 	controller := newHostHistoryScrollController()
 
@@ -53,11 +52,11 @@ func TestHostHistoryScrollControllerPreservesIntentAcrossPendingResize(t *testin
 	controller.Resize(&v, 120, 40)
 	controller.Scroll(&v, scrollOneLineUp)
 	require.True(t, controller.CompleteFill(gen, &v, history))
-	require.Equal(t, 59, v.YOffset, "120x40 bottom 61 minus two queued up intents")
+	require.Equal(t, 58, v.YOffset, "120x40 bottom 60 minus two queued up intents")
 }
 
 func TestHostHistoryScrollControllerReplaysQueuedIntentInOrder(t *testing.T) {
-	history := lipgloss.JoinVertical(lipgloss.Left, numberedScrollHistory(100), scrollFooter())
+	history := numberedScrollHistory(100)
 	v := viewport.New(80, 24)
 	controller := newHostHistoryScrollController()
 
@@ -67,20 +66,47 @@ func TestHostHistoryScrollControllerReplaysQueuedIntentInOrder(t *testing.T) {
 	controller.Scroll(&v, scrollOneLineDown)
 	controller.Scroll(&v, scrollOneLineUp)
 	require.True(t, controller.CompleteFill(controller.FillGeneration(), &v, history))
-	require.Equal(t, 76, v.YOffset)
+	require.Equal(t, 75, v.YOffset)
 }
 
 func TestHostHistoryScrollControllerPreservesDistanceAcrossReadyResize(t *testing.T) {
-	history := lipgloss.JoinVertical(lipgloss.Left, numberedScrollHistory(100), scrollFooter())
+	history := numberedScrollHistory(100)
 	v := viewport.New(80, 24)
 	controller := newHostHistoryScrollController()
 
 	controller.Scroll(&v, scrollOneLineUp)
 	require.True(t, controller.CompleteFill(controller.FillGeneration(), &v, history))
-	require.Equal(t, 76, v.YOffset, "80x24 bottom 77 minus one")
+	require.Equal(t, 75, v.YOffset, "80x24 bottom 76 minus one")
 
 	controller.Resize(&v, 120, 40)
-	require.Equal(t, 60, v.YOffset, "120x40 bottom 61 minus the same one-row distance")
+	require.Equal(t, 59, v.YOffset, "120x40 bottom 60 minus the same one-row distance")
 	controller.Resize(&v, 80, 24)
-	require.Equal(t, 76, v.YOffset, "shrinking must preserve distance from bottom too")
+	require.Equal(t, 75, v.YOffset, "shrinking must preserve distance from bottom too")
+}
+
+func TestPassiveScrollControllersNeverEnterHostHistory(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		owner      ScrollOwner
+		controller func() ScrollController
+	}{
+		{name: "child application", owner: ScrollOwnerChildApplication, controller: newChildApplicationScrollController},
+		{name: "unknown", owner: ScrollOwnerNone, controller: newUnavailableScrollController},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v := viewport.New(80, 24)
+			controller := tc.controller()
+			controller.Scroll(&v, scrollOneLineUp)
+			require.Equal(t, tc.owner, controller.Owner())
+			require.False(t, controller.Active())
+			require.Equal(t, 0, v.YOffset)
+		})
+	}
+}
+
+func TestUnknownScrollOwnerFailsLoudly(t *testing.T) {
+	p := NewTabPane(nil)
+	require.PanicsWithValue(t, "ui: unknown scroll owner 255", func() {
+		p.SetScrollOwnerFor(nil, 0, ScrollOwner(255))
+	})
 }

--- a/ui/statusbar_test.go
+++ b/ui/statusbar_test.go
@@ -63,6 +63,7 @@ func TestMenuFocusRegionSwitchesHints(t *testing.T) {
 // lower-frequency session actions, but help/quit remain the hard floor.
 func TestMenuNarrowWidthKeepsHelpAndQuit(t *testing.T) {
 	m := NewMenu()
+	m.SetScrollAvailable(true)
 	m.SetInstance(readyUIInstance())
 
 	for _, w := range []int{110, 80, 60, 45} {

--- a/ui/store_helpers_test.go
+++ b/ui/store_helpers_test.go
@@ -10,20 +10,36 @@ import (
 // TabPane state-machine tests exercise the same content path they did before the
 // daemon became the sole capturer (#1592 Phase 2 PR6). Production injects the
 // daemon-backed source instead.
-func previewFromInstance(instance *session.Instance, tab int, full bool) (string, error) {
+func hostPreview(content string) PreviewSnapshot {
+	return PreviewSnapshot{Content: content, Owner: ScrollOwnerHostHistory}
+}
+
+func enableHostHistory(p *TabPane, instance *session.Instance, tab int) {
+	p.SetScrollOwnerFor(instance, tab, ScrollOwnerHostHistory)
+}
+
+func previewFromInstance(instance *session.Instance, tab int, full bool) (PreviewSnapshot, error) {
 	if tab == 0 {
-		return instance.AgentServer().Preview(tab, full)
+		snapshot, err := instance.AgentServer().Preview(tab, full)
+		return hostPreview(snapshot.Content), err
 	}
+	var (
+		content string
+		err     error
+	)
 	if full {
-		return instance.PreviewTabFullHistory(tab)
+		content, err = instance.PreviewTabFullHistory(tab)
+	} else {
+		content, err = instance.PreviewTab(tab)
 	}
-	return instance.PreviewTab(tab)
+	return hostPreview(content), err
 }
 
 // newTestTabbedWindow builds an unbound TabbedWindow; tests bind an instance
 // via setWindowInstance.
 func newTestTabbedWindow() *TabbedWindow {
-	return NewTabbedWindow(NewTabPane(previewFromInstance), nil)
+	pane := NewTabPane(previewFromInstance)
+	return NewTabbedWindow(pane, nil)
 }
 
 // setWindowInstance is the test wiring for binding a window: give it an open

--- a/ui/tab_pane.go
+++ b/ui/tab_pane.go
@@ -17,9 +17,6 @@ import (
 var tabPaneStyle = lipgloss.NewStyle().
 	Foreground(activeTheme.Foreground)
 
-var tabPaneFooterStyle = lipgloss.NewStyle().
-	Foreground(activeTheme.ForegroundMuted)
-
 // tabContentState holds the rendered content of the tab pane.
 //
 // Invariant: fallback==true iff text is a centered fallback message
@@ -68,11 +65,18 @@ type TabPane struct {
 	// retargeting snapshots it so a grace-period expiry can replace stale content
 	// without racing and overwriting a capture that landed at the deadline.
 	renderRevision uint64
+	// captureGeneration orders same-target preview snapshots. Every capture
+	// dispatch and every state transition that invalidates pending captures
+	// advances it; only the current generation may publish. A slow older capture
+	// therefore cannot overwrite a newer terminal-owner decision merely because
+	// it finished last.
+	captureGeneration uint64
 	// scroll is the explicit scroll owner and transition controller (#2192).
-	// Captured tabs use host-history ownership. It owns active/loading/
-	// ready state, fill generations, and pending intent; TabPane owns only the
-	// rendered viewport it asks the controller to manipulate.
-	scroll   historyScrollController
+	// Capture-backed tabs begin with an ownership probe and resolve to host or
+	// child ownership from the same snapshot as their content. The controller
+	// owns active/loading/ready state, fill generations, and pending intent;
+	// TabPane owns only the rendered viewport it asks it to manipulate.
+	scroll   ScrollController
 	viewport viewport.Model
 
 	// currentInstance + currentTab identify the (instance, tab-index) view
@@ -94,11 +98,20 @@ type TabPane struct {
 	previewSrc PreviewSource
 }
 
-// PreviewSource captures a session tab's content for a TabPane. tab 0 is the agent
-// tab (formatted by the backend preview); tab>0 is a shell/process tab. full=true
-// returns the entire scrollback history (the scroll-mode source). It returns
-// tmux.ErrSessionGone when the session's tmux vanished mid-capture.
-type PreviewSource func(instance *session.Instance, tab int, full bool) (string, error)
+// PreviewSnapshot binds rendered content to the owner that can truthfully scroll
+// that exact terminal target. Owner=None means the capture source could not
+// establish ownership; callers must not infer HostHistory from the content.
+type PreviewSnapshot struct {
+	Content string
+	Owner   ScrollOwner
+}
+
+// PreviewSource captures a session tab's content and scroll owner for a TabPane.
+// tab 0 is the agent tab (formatted by the backend preview); tab>0 is a
+// shell/process tab. full=true returns the entire scrollback history (the
+// scroll-mode source). It returns tmux.ErrSessionGone when the session's tmux
+// vanished mid-capture.
+type PreviewSource func(instance *session.Instance, tab int, full bool) (PreviewSnapshot, error)
 
 // NewTabPane creates a TabPane whose content is captured through src — the
 // daemon-backed capture in production (#1592 Phase 2 PR6).
@@ -106,7 +119,7 @@ func NewTabPane(src PreviewSource) *TabPane {
 	return &TabPane{
 		viewport:   viewport.New(0, 0),
 		previewSrc: src,
-		scroll:     newHostHistoryScrollController(),
+		scroll:     newOwnershipProbeScrollController(),
 	}
 }
 
@@ -127,6 +140,99 @@ func (p *TabPane) ScrollOwner() ScrollOwner {
 	return p.scroll.Owner()
 }
 
+// CanResolveScrollOwner reports whether this capture-backed target can preserve
+// an intent while ownership is unknown. It is false for a fresh live stream,
+// where only the stream repaint may establish ownership.
+func (p *TabPane) CanResolveScrollOwner() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	_, ok := p.historyScrollLocked()
+	return ok
+}
+
+// SetScrollOwnerFor installs an authoritative owner for one exact render target.
+// Keying the transition prevents a retargeted pane from borrowing the prior
+// target's owner during the capture window.
+func (p *TabPane) SetScrollOwnerFor(instance *session.Instance, activeTab int, owner ScrollOwner) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.dropStaleView(instance, activeTab)
+	p.setScrollOwnerLocked(owner)
+}
+
+// SetScrollOwnerResolvingFor starts an ownership probe for a capture-backed
+// target. Scroll intent may queue while modes are unknown; the full snapshot
+// either resolves it to HostHistory and applies it, or rejects the wrong buffer.
+func (p *TabPane) SetScrollOwnerResolvingFor(instance *session.Instance, activeTab int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !p.isCurrentViewLocked(instance, activeTab) {
+		p.dropStaleView(instance, activeTab)
+		return
+	}
+	if history, ok := p.historyScrollLocked(); ok && history.Owner() == ScrollOwnerNone {
+		return
+	}
+	p.installOwnershipProbeLocked()
+}
+
+// setScrollOwnerLocked is the single controller replacement path. Both live
+// stream updates and detached preview snapshots use it, so changing ownership
+// always invalidates a pending/ready host viewport in exactly the same way.
+func (p *TabPane) setScrollOwnerLocked(owner ScrollOwner) {
+	switch owner {
+	case ScrollOwnerNone, ScrollOwnerHostHistory, ScrollOwnerChildApplication:
+		// Exhaustive below.
+	default:
+		panic(fmt.Sprintf("ui: unknown scroll owner %d", owner))
+	}
+	switch owner {
+	case ScrollOwnerHostHistory:
+		// An authoritative normal snapshot can land after a gesture has already
+		// queued against the capture-backed ownership probe. Promote that exact
+		// controller instead of replacing it, or the snapshot silently erases
+		// both the initiating gesture and any later queued gestures.
+		if history, ok := p.historyScrollLocked(); ok && history.Owner() == ScrollOwnerNone {
+			history.ResolveHost()
+			return
+		}
+		if p.scroll.Owner() == ScrollOwnerHostHistory {
+			return
+		}
+	case ScrollOwnerChildApplication:
+		if _, ok := p.scroll.(*childApplicationScrollController); ok {
+			return
+		}
+	case ScrollOwnerNone:
+		if _, ok := p.scroll.(*unavailableScrollController); ok {
+			return
+		}
+	}
+	p.scroll.Reset(&p.viewport)
+	p.captureGeneration++
+	switch owner {
+	case ScrollOwnerHostHistory:
+		p.scroll = newHostHistoryScrollController()
+	case ScrollOwnerChildApplication:
+		p.scroll = newChildApplicationScrollController()
+	case ScrollOwnerNone:
+		p.scroll = newUnavailableScrollController()
+	}
+	p.scroll.Resize(&p.viewport, p.width, p.height)
+}
+
+func (p *TabPane) installOwnershipProbeLocked() {
+	p.scroll.Reset(&p.viewport)
+	p.captureGeneration++
+	p.scroll = newOwnershipProbeScrollController()
+	p.scroll.Resize(&p.viewport, p.width, p.height)
+}
+
+func (p *TabPane) historyScrollLocked() (historyScrollController, bool) {
+	history, ok := p.scroll.(historyScrollController)
+	return history, ok
+}
+
 // NeedsScrollFill reports whether the pane is in scroll mode with an unfilled
 // viewport — ScrollUp/ScrollDown just entered scroll mode and the off-loop
 // capture that populates the scrollback (updateAgent/updateShell lazy-fill) has
@@ -136,7 +242,8 @@ func (p *TabPane) ScrollOwner() ScrollOwner {
 func (p *TabPane) NeedsScrollFill() bool {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	return p.scroll.NeedsFill(p.viewport.Height)
+	history, ok := p.historyScrollLocked()
+	return ok && history.NeedsFill(p.viewport.Height)
 }
 
 // BeginScrollFill records that panesRefresh has dispatched a capture for the
@@ -148,7 +255,9 @@ func (p *TabPane) NeedsScrollFill() bool {
 func (p *TabPane) BeginScrollFill() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.scroll.BeginFill()
+	if history, ok := p.historyScrollLocked(); ok {
+		history.BeginFill()
+	}
 }
 
 func (p *TabPane) SetSize(width, maxHeight int) {
@@ -174,9 +283,7 @@ func (p *TabPane) SetSize(width, maxHeight int) {
 // entry points consistent (the #669 motivation).
 func (p *TabPane) dropStaleView(instance *session.Instance, activeTab int) {
 	if instance != p.currentInstance || activeTab != p.currentTab {
-		if p.scroll.Active() {
-			p.scroll.Reset(&p.viewport)
-		}
+		p.installOwnershipProbeLocked()
 		p.currentInstance = instance
 		p.currentTab = activeTab
 	}
@@ -202,7 +309,12 @@ func (p *TabPane) setFallbackState(message string) {
 		fallback: true,
 		text:     lipgloss.JoinVertical(lipgloss.Center, FallBackText, "", message),
 	})
+	// Reset unconditionally: an already-None controller can still have viewport
+	// data left by a prior owner or a test seam. Fallback must make stale scroll
+	// rendering impossible even when the ownership enum does not change (#940).
+	p.captureGeneration++
 	p.scroll.Reset(&p.viewport)
+	p.setScrollOwnerLocked(ScrollOwnerNone)
 }
 
 // RenderRevision returns the completed-render generation. It is safe to read
@@ -217,6 +329,19 @@ type contentGuard func() bool
 
 func guardOK(guard contentGuard) bool {
 	return guard == nil || guard()
+}
+
+func (p *TabPane) beginCaptureLocked() uint64 {
+	p.captureGeneration++
+	return p.captureGeneration
+}
+
+// capturePaneHistoryRows removes capture-pane's one output-record separator.
+// The separator is not a terminal row; removing exactly one newline preserves
+// every intentional blank row in the pane while keeping viewport coordinates
+// aligned with tmux history_size.
+func capturePaneHistoryRows(content string) string {
+	return strings.TrimSuffix(content, "\n")
 }
 
 func (p *TabPane) isCurrentViewLocked(instance *session.Instance, activeTab int) bool {
@@ -286,16 +411,27 @@ func (p *TabPane) fillHostHistoryLocked(
 	guard contentGuard,
 	goneMessage string,
 ) error {
-	gen := p.scroll.FillGeneration()
+	history, ok := p.historyScrollLocked()
+	if !ok {
+		return nil
+	}
+	gen := history.FillGeneration()
+	captureGeneration := p.beginCaptureLocked()
 	p.mu.Unlock()
-	content, err := p.previewSrc(instance, activeTab, true)
+	snapshot, err := p.previewSrc(instance, activeTab, true)
 	p.mu.Lock()
 
-	if !p.scroll.FillIsCurrent(gen) {
+	// Ownership can switch while capture is off-loop. A child transition replaces
+	// the controller and resets the old generation; never publish that host buffer.
+	if p.captureGeneration != captureGeneration {
+		return nil
+	}
+	current, stillHost := p.historyScrollLocked()
+	if !stillHost || current != history || !history.FillIsCurrent(gen) {
 		return nil
 	}
 	if !guardOK(guard) || !p.isCurrentViewLocked(instance, activeTab) {
-		p.scroll.RearmFill()
+		history.RearmFill()
 		return nil
 	}
 	if err != nil {
@@ -303,11 +439,21 @@ func (p *TabPane) fillHostHistoryLocked(
 			p.setFallbackState(goneMessage)
 			return nil
 		}
-		p.scroll.RearmFill()
+		history.RearmFill()
 		return err
 	}
-	content = lipgloss.JoinVertical(lipgloss.Left, content, scrollFooter())
-	if p.scroll.CompleteFill(gen, &p.viewport, content) {
+	if snapshot.Owner != ScrollOwnerHostHistory {
+		p.setScrollOwnerLocked(snapshot.Owner)
+		return nil
+	}
+	history.ResolveHost()
+	// capture-pane terminates its output with a record-separator newline. It is
+	// not a terminal row: admitting it into the viewport makes the first upward
+	// gesture disappear into a phantom blank line. Keep AF chrome out of this
+	// value too; TabbedWindow renders the scroll cue in its header, outside the
+	// child's history coordinate system.
+	content := capturePaneHistoryRows(snapshot.Content)
+	if history.CompleteFill(gen, &p.viewport, content) {
 		p.renderRevision++
 	}
 	return nil
@@ -358,7 +504,7 @@ func (p *TabPane) updateAgent(instance *session.Instance, guard contentGuard) er
 
 	// Scroll entry is I/O-free; the controller preserves pending intent while
 	// this off-loop full-history capture runs (#1637/#2192).
-	if p.scroll.AwaitingHistory() {
+	if history, ok := p.historyScrollLocked(); ok && history.AwaitingHistory() {
 		err := p.fillHostHistoryLocked(instance, 0, guard, "Session no longer running.")
 		p.mu.Unlock()
 		return err
@@ -368,12 +514,14 @@ func (p *TabPane) updateAgent(instance *session.Instance, guard contentGuard) er
 		p.mu.Unlock()
 		return nil
 	}
+	captureGeneration := p.beginCaptureLocked()
 	p.mu.Unlock()
 
-	content, err := p.previewSrc(instance, 0, false)
+	snapshot, err := p.previewSrc(instance, 0, false)
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if !guardOK(guard) || !p.isCurrentViewLocked(instance, 0) {
+	if p.captureGeneration != captureGeneration ||
+		!guardOK(guard) || !p.isCurrentViewLocked(instance, 0) {
 		return nil
 	}
 	if err != nil {
@@ -385,12 +533,13 @@ func (p *TabPane) updateAgent(instance *session.Instance, guard contentGuard) er
 		}
 		return err
 	}
+	p.setScrollOwnerLocked(snapshot.Owner)
 	// Always update with content, even if empty, so a newly created instance
 	// displays immediately.
-	if len(content) == 0 && !instance.Started() {
+	if len(snapshot.Content) == 0 && !instance.Started() {
 		p.setFallbackState("Please enter a name for the instance.")
 	} else {
-		p.publishContent(tabContentState{fallback: false, text: content})
+		p.publishContent(tabContentState{fallback: false, text: snapshot.Content})
 	}
 	return nil
 }
@@ -495,7 +644,7 @@ func (p *TabPane) updateShell(instance *session.Instance, activeTab int, guard c
 
 	// The shell slot uses the same controller and off-loop fill transition as the
 	// agent slot; input queued during capture is applied when history publishes.
-	if p.scroll.AwaitingHistory() {
+	if history, ok := p.historyScrollLocked(); ok && history.AwaitingHistory() {
 		err := p.fillHostHistoryLocked(instance, activeTab, guard, "Terminal session no longer running.")
 		p.mu.Unlock()
 		return err
@@ -507,12 +656,14 @@ func (p *TabPane) updateShell(instance *session.Instance, activeTab int, guard c
 		p.mu.Unlock()
 		return nil
 	}
+	captureGeneration := p.beginCaptureLocked()
 	p.mu.Unlock()
 
-	content, err := p.previewSrc(instance, activeTab, false)
+	snapshot, err := p.previewSrc(instance, activeTab, false)
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if !guardOK(guard) || !p.isCurrentViewLocked(instance, activeTab) {
+	if p.captureGeneration != captureGeneration ||
+		!guardOK(guard) || !p.isCurrentViewLocked(instance, activeTab) {
 		return nil
 	}
 	if err != nil {
@@ -524,7 +675,8 @@ func (p *TabPane) updateShell(instance *session.Instance, activeTab int, guard c
 		}
 		return fmt.Errorf("tab pane: failed to capture terminal content: %w", err)
 	}
-	p.publishContent(tabContentState{fallback: false, text: content})
+	p.setScrollOwnerLocked(snapshot.Owner)
+	p.publishContent(tabContentState{fallback: false, text: snapshot.Content})
 	return nil
 }
 
@@ -611,10 +763,14 @@ func (p *TabPane) scrollBy(instance *session.Instance, activeTab int, intent Scr
 	// Reset scroll mode if the view changed out from under us, so we capture the
 	// newly selected view's content rather than scrolling stale content (#702).
 	p.dropStaleView(instance, activeTab)
+	history, canResolve := p.historyScrollLocked()
+	if !canResolve {
+		return nil
+	}
 	if !p.scroll.Active() && !p.canEnterScrollModeLocked(instance, activeTab) {
 		return nil
 	}
-	p.scroll.Scroll(&p.viewport, intent)
+	history.Scroll(&p.viewport, intent)
 	return nil
 }
 
@@ -691,8 +847,4 @@ func (p *TabPane) ResetToNormalMode(instance *session.Instance, activeTab int) e
 		p.setFallbackState("Session lost — its tmux session is gone.")
 	}
 	return nil
-}
-
-func scrollFooter() string {
-	return tabPaneFooterStyle.Render("ESC to exit scroll mode")
 }

--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"strings"
 	"sync/atomic"
 
 	"github.com/sachiniyer/agent-factory/log"
@@ -206,6 +207,12 @@ func (w *TabbedWindow) setActiveTab(idx int) {
 		return
 	}
 	w.pane.SetTab(idx)
+	if w.preview == nil {
+		// Ownership belongs to the rendered tab, not the window. The next live or
+		// detached snapshot will establish the new tab's owner. A transient preview
+		// still renders its own target and therefore keeps its current owner.
+		w.SetScrollOwnerResolving()
+	}
 	w.bumpContentSeq()
 }
 
@@ -229,6 +236,10 @@ func (w *TabbedWindow) SetPreview(instance *session.Instance, tab int, original 
 		return w.ContentSeq()
 	}
 	w.preview = &windowPreview{instance: instance, tab: tab, original: original}
+	// A transient preview has no live stream and therefore no authoritative
+	// terminal-mode snapshot. Unknown must not inherit the committed pane's owner
+	// and accidentally capture a fullscreen target's background primary history.
+	w.SetScrollOwnerResolving()
 	return w.bumpContentSeq()
 }
 
@@ -240,6 +251,9 @@ func (w *TabbedWindow) ClearPreview() uint64 {
 		return w.ContentSeq()
 	}
 	w.preview = nil
+	// The app will replace this with the freshly rebound live stream's owner (or
+	// HostHistory for a capture-only pane). Until then there is no truthful owner.
+	w.SetScrollOwnerResolving()
 	return w.bumpContentSeq()
 }
 
@@ -538,6 +552,24 @@ func (w *TabbedWindow) ScrollOwner() ScrollOwner {
 	return w.tab.ScrollOwner()
 }
 
+// SetScrollOwner switches the pane's controller to the terminal's current owner.
+// It is event-loop safe; TabPane serializes against an off-loop history fill.
+func (w *TabbedWindow) SetScrollOwner(owner ScrollOwner) {
+	w.tab.SetScrollOwnerFor(w.effectiveInstance(), w.effectiveTab(), owner)
+}
+
+// SetScrollOwnerResolving makes the effective capture target own the pending
+// ownership probe without inheriting the committed/previous target's decision.
+func (w *TabbedWindow) SetScrollOwnerResolving() {
+	w.tab.SetScrollOwnerResolvingFor(w.effectiveInstance(), w.effectiveTab())
+}
+
+// CanResolveScrollOwner distinguishes a capture-backed unknown target from a
+// live stream still waiting for its authoritative repaint.
+func (w *TabbedWindow) CanResolveScrollOwner() bool {
+	return w.tab.CanResolveScrollOwner()
+}
+
 // NeedsScrollFill reports whether the pane just entered scroll mode and is still
 // waiting for its off-loop scrollback capture — panesRefresh bypasses its
 // throttle for such a pane so the fill is immediate (#1637).
@@ -569,6 +601,12 @@ func (w *TabbedWindow) renderHeader(width int) string {
 		}
 	} else {
 		text = " no session selected "
+	}
+	if w.IsInScrollMode() {
+		// Scroll mode is pane chrome, not terminal history. Keeping this cue in
+		// the header prevents an AF-owned footer row from consuming the first
+		// scroll gesture or changing the child's history coordinates (#2192).
+		text = strings.TrimSuffix(text, " ") + " · SCROLL · Esc exits "
 	}
 	style := paneHeaderStyle
 	switch {

--- a/ui/tabbed_window_test.go
+++ b/ui/tabbed_window_test.go
@@ -85,6 +85,8 @@ func TestTabbedWindowResetPreviewScrollUsesCommittedBinding(t *testing.T) {
 
 	w.SetPreview(beta, 0, "alpha · › Terminal")
 	w.InvalidateContent(beta, 0, "Loading preview…")
+	require.NoError(t, w.UpdateContentAt(beta, 0, w.ContentSeq()),
+		"the detached snapshot establishes the preview target's host owner")
 	w.ScrollUp()
 	require.True(t, w.IsInScrollMode(), "precondition: preview target is scrolled")
 
@@ -128,4 +130,19 @@ func TestTabbedWindowHeaderEllipsizesAtNarrowWidth(t *testing.T) {
 	assert.LessOrEqual(t, lipgloss.Width(header), 16, "header must fit the pane width")
 	assert.Contains(t, header, "…", "the cut must be marked with an ellipsis")
 	assert.NotContains(t, header, "Agent", "the tail is truncated")
+}
+
+func TestTabbedWindowScrollCueIsPaneChrome(t *testing.T) {
+	inst := startedWindowInstance(t, "scroll-cue")
+	w := newTestTabbedWindow()
+	setWindowInstance(w, inst)
+	setWindowSize(w, 100, 30)
+	w.SetScrollOwner(ScrollOwnerHostHistory)
+
+	require.NotContains(t, w.renderHeader(98), "SCROLL")
+	w.ScrollUp()
+	require.True(t, w.IsInScrollMode())
+	header := w.renderHeader(98)
+	require.Contains(t, header, "SCROLL")
+	require.Contains(t, header, "Esc exits")
 }

--- a/ui/terminal_test.go
+++ b/ui/terminal_test.go
@@ -115,6 +115,7 @@ func TestTabPaneShellUpdateContent(t *testing.T) {
 
 	p := NewTabPane(previewFromInstance)
 	p.SetSize(80, 30)
+	enableHostHistory(p, inst, 1)
 
 	require.NoError(t, p.UpdateContent(inst, 1))
 
@@ -188,6 +189,7 @@ func TestTabPaneShellScrolling(t *testing.T) {
 
 	p := NewTabPane(previewFromInstance)
 	p.SetSize(80, 30)
+	enableHostHistory(p, inst, 1)
 
 	require.False(t, p.IsScrolling(), "should not be scrolling initially")
 
@@ -217,6 +219,7 @@ func TestTabPaneShellFallbackResetsScrollMode(t *testing.T) {
 	t.Run("nil instance", func(t *testing.T) {
 		p := NewTabPane(previewFromInstance)
 		p.SetSize(80, 30)
+		enableHostHistory(p, prior, 1)
 		require.NoError(t, p.ScrollUp(prior, 1))
 		require.True(t, p.IsScrolling(), "precondition: in scroll mode")
 		// Scroll entry is I/O-free (#1637); the off-loop refresh fills the viewport.
@@ -238,6 +241,7 @@ func TestTabPaneShellFallbackResetsScrollMode(t *testing.T) {
 	t.Run("not started instance", func(t *testing.T) {
 		p := NewTabPane(previewFromInstance)
 		p.SetSize(80, 30)
+		enableHostHistory(p, prior, 1)
 		require.NoError(t, p.ScrollUp(prior, 1))
 		require.True(t, p.IsScrolling())
 
@@ -277,6 +281,7 @@ func TestTabPaneShellScrollUsesSelectedView(t *testing.T) {
 
 	p := NewTabPane(previewFromInstance)
 	p.SetSize(80, 30)
+	enableHostHistory(p, instA, 1)
 
 	// A is rendered first, so it becomes the current view.
 	require.NoError(t, p.UpdateContent(instA, 1))
@@ -312,6 +317,7 @@ func TestTabPaneSwitchTabResetsScroll(t *testing.T) {
 
 	p := NewTabPane(previewFromInstance)
 	p.SetSize(80, 30)
+	enableHostHistory(p, inst, 0)
 
 	// Scroll on the agent slot.
 	require.NoError(t, p.ScrollUp(inst, 0))
@@ -461,6 +467,7 @@ func TestTabPaneShellScrollModeSessionGoneExternally(t *testing.T) {
 
 	p := NewTabPane(previewFromInstance)
 	p.SetSize(80, 30)
+	enableHostHistory(p, inst, 1)
 
 	// Enter scroll mode on the live shell tab, then let the off-loop refresh fill
 	// the viewport with scrollback (scroll entry itself is I/O-free — #1637).

--- a/ui/termpane/modes.go
+++ b/ui/termpane/modes.go
@@ -1,0 +1,38 @@
+package termpane
+
+import (
+	"github.com/charmbracelet/x/ansi"
+	"github.com/sachiniyer/agent-factory/terminal"
+)
+
+// TerminalModes returns the most recent terminal ownership modes and whether a
+// complete authoritative base is known. Live DECSET/DECRST callbacks evolve a
+// known base, but cannot create one: observing one changed mode does not prove
+// every unmentioned mode was off before this client subscribed.
+func (t *TermPane) TerminalModes() (terminal.Modes, bool) {
+	t.gridMu.RLock()
+	defer t.gridMu.RUnlock()
+	return t.terminalModes, t.modesKnown
+}
+
+// setTerminalMode mirrors ownership-relevant emulator callbacks into the
+// transport-neutral mode snapshot.
+func setTerminalMode(m *terminal.Modes, mode ansi.Mode, on bool) {
+	switch mode {
+	case ansi.ModeMouseNormal:
+		m.MouseStandard = on
+	case ansi.ModeMouseButtonEvent:
+		m.MouseButton = on
+	case ansi.ModeMouseAnyEvent:
+		m.MouseAll = on
+	case ansi.ModeMouseExtUtf8:
+		m.MouseUTF8 = on
+	case ansi.ModeMouseExtSgr:
+		m.MouseSGR = on
+	case ansi.ModeMouseX10, ansi.ModeMouseHighlight:
+		// tmux has no individual format for these legacy tracking variants.
+		// The aggregate MouseTracking field below still preserves ownership.
+	default:
+		return
+	}
+}

--- a/ui/termpane/modes_test.go
+++ b/ui/termpane/modes_test.go
@@ -1,0 +1,63 @@
+package termpane
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/terminal"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRepaintRestoresTerminalOwnershipModes(t *testing.T) {
+	tp, stream := newSingleStreamPane(t, 40, 8)
+	if _, known := tp.TerminalModes(); known {
+		t.Fatal("fresh pane guessed ownership before the stream snapshot")
+	}
+	stream.events <- Event{Kind: EventData, Data: []byte("\x1b[?1006h")}
+	require.Eventually(t, func() bool {
+		got, known := tp.TerminalModes()
+		return got.MouseSGR && !known
+	}, 2*time.Second, 5*time.Millisecond,
+		"one live mode change must not pretend every pre-existing mode is known")
+
+	child := terminal.Modes{
+		AlternateScreen: true,
+		MouseTracking:   true,
+		MouseButton:     true,
+		MouseSGR:        true,
+	}
+	stream.events <- Event{
+		Kind:     EventRepaint,
+		Data:     append(child.RestoreSequence(), []byte("\x1b[2J\x1b[Htranscript")...),
+		Modes:    child,
+		HasModes: true,
+	}
+	require.Eventually(t, func() bool {
+		got, known := tp.TerminalModes()
+		return known && got == child && tp.MouseTrackingEnabled()
+	}, 2*time.Second, 5*time.Millisecond,
+		"fresh repaint must restore alternate-screen, tracking, and mouse encoding")
+
+	// A recovery repaint is authoritative in the other direction too: stale
+	// child ownership cannot survive after the pane returned to the primary
+	// screen while this subscriber missed output.
+	host := terminal.Modes{}
+	stream.events <- Event{
+		Kind:     EventRepaint,
+		Data:     append(host.RestoreSequence(), []byte("\x1b[2J\x1b[Hcomposer")...),
+		Modes:    host,
+		HasModes: true,
+	}
+	require.Eventually(t, func() bool {
+		got, known := tp.TerminalModes()
+		return known && got == host && !tp.MouseTrackingEnabled()
+	}, 2*time.Second, 5*time.Millisecond,
+		"recovery repaint must clear stale alternate-screen and mouse ownership")
+
+	stream.events <- Event{Kind: EventRepaint, Data: []byte("\x1b[2J\x1b[Hlegacy")}
+	require.Eventually(t, func() bool {
+		_, known := tp.TerminalModes()
+		return !known
+	}, 2*time.Second, 5*time.Millisecond,
+		"a metadata-free recovery repaint must invalidate the prior owner")
+}

--- a/ui/termpane/termpane.go
+++ b/ui/termpane/termpane.go
@@ -36,6 +36,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/charmbracelet/x/vt"
+	"github.com/sachiniyer/agent-factory/terminal"
 )
 
 const (
@@ -88,6 +89,11 @@ type Event struct {
 	Data []byte
 	Rows uint16
 	Cols uint16
+	// Modes accompany EventRepaint when HasModes is true. They are the
+	// authoritative pre-existing state a fresh/recovered stream subscriber did
+	// not observe in the live byte ring.
+	Modes    terminal.Modes
+	HasModes bool
 	// Seq is the server's authoritative replay cursor, valid only when
 	// Kind == EventCursor.
 	Seq uint64
@@ -143,6 +149,8 @@ type TermPane struct {
 	// mode and thus fires DisableMode for each — clearing this set — so the wheel
 	// can never stay stuck forwarding to a program that reset the terminal (#1748).
 	mouseModes    map[ansi.Mode]bool
+	terminalModes terminal.Modes
+	modesKnown    bool
 	width, height int
 
 	dial Dialer
@@ -183,6 +191,9 @@ func New(dial Dialer, width, height int) *TermPane {
 	// field write is ordered against Render's locked reads.
 	t.emu.SetCallbacks(vt.Callbacks{
 		CursorVisibility: func(visible bool) { t.cursorVisible = visible },
+		AltScreen: func(on bool) {
+			t.terminalModes.AlternateScreen = on
+		},
 		// Track the inner app's mouse-reporting requests so the host can tell
 		// whether the wheel belongs to the program or to pane scrollback (#1024
 		// wheel fix). Both callbacks fire from emu.Write under gridMu's write lock,
@@ -190,10 +201,14 @@ func New(dial Dialer, width, height int) *TermPane {
 		EnableMode: func(mode ansi.Mode) {
 			if isMouseTrackingMode(mode) {
 				t.mouseModes[mode] = true
+				t.terminalModes.MouseTracking = true
 			}
+			setTerminalMode(&t.terminalModes, mode, true)
 		},
 		DisableMode: func(mode ansi.Mode) {
 			delete(t.mouseModes, mode)
+			t.terminalModes.MouseTracking = len(t.mouseModes) > 0
+			setTerminalMode(&t.terminalModes, mode, false)
 		},
 	})
 
@@ -275,6 +290,18 @@ func (t *TermPane) readStream(stream Stream) {
 			// per-subscriber and not part of the server's ring seq (§ EventRepaint).
 			t.gridMu.Lock()
 			_, _ = t.emu.Write(ev.Data)
+			if ev.HasModes {
+				// The repaint's DEC prefix already updated supported emulator
+				// modes. Assign the snapshot as the authority as well: tmux can
+				// report UTF-8 encoding even when an emulator does not expose a
+				// callback for it, and all-false is meaningful.
+				t.terminalModes = ev.Modes
+				t.modesKnown = true
+			} else {
+				// A recovery repaint can jump over unretained DEC mode changes.
+				// Without snapshot metadata the old decision is no longer safe.
+				t.modesKnown = false
+			}
 			t.gridMu.Unlock()
 		case EventCursor:
 			// The server moved our cursor over bytes it no longer holds (an eviction or

--- a/ui/theme.go
+++ b/ui/theme.go
@@ -171,7 +171,6 @@ func applyThemeStyles() {
 	menuStyle = lipgloss.NewStyle().Foreground(activeTheme.Purple)
 
 	tabPaneStyle = lipgloss.NewStyle().Foreground(activeTheme.Foreground)
-	tabPaneFooterStyle = lipgloss.NewStyle().Foreground(activeTheme.ForegroundMuted)
 
 	taskPlaceholderStyle = lipgloss.NewStyle().
 		Faint(true).


### PR DESCRIPTION
Closes #2192.

## Root cause

Scrolling kept recurring because AF had no single answer to “who owns history for the terminal currently rendered here?” The preview viewport assumed every tmux capture was host scrollback, while interactive mouse routing independently consulted a live emulator flag. Terminal ownership modes were also absent from fresh/recovery snapshots, so reconnecting clients had to infer state from future bytes. That let the same target be classified differently by surface, completion order, and connection age.

The async preview path had two additional coordinate/order bugs:

- the controller dropped the gesture that initiated a delayed history fill and could overwrite queued gestures with an unconditional bottom jump;
- tmux’s capture record separator and AF’s own scroll footer occupied viewport rows, making the first real gesture appear to do nothing.

## Structural change

- Add one `ScrollOwner` decision: primary/no-mouse is `HostHistory`; alternate-screen or mouse-tracking is `ChildApplication`; missing evidence is unavailable, never guessed.
- Put host capture, ownership probing, child ownership, and unavailable behavior behind one `ScrollController` contract.
- Route nav wheel, interactive wheel, keyboard scroll, preview affordances, and menu hints through that same decision.
- Carry alt-screen and mouse tracking/encoding modes with preview snapshots and fresh/recovery stream repaints, including authoritative all-off state. A fresh or reconnected client therefore receives ownership with its first grid.
- Preserve every semantic scroll intent during an async fill, publish same-target captures by dispatch order rather than completion order, and invalidate stale fills on owner/target changes.
- Keep AF chrome outside terminal history and remove only capture-pane’s single output-record separator.

Attach remains a raw child-owned proxy. This PR does not intercept Ctrl-U or otherwise interpret attach keyboard input.

## Direct agent observations

Observed in the isolated TUI container with real Codex CLI 0.144.6:

- Codex composer: `alternate_on=0`, all mouse flags off. tmux `history_size` was 88 after the 80×24 run and 69 after reflow at 120×40; capture-pane contained the conversation.
- Codex transcript (Ctrl-T): `alternate_on=1`, all mouse flags still off, while `history_size` stayed at the same primary-buffer value. PageUp moved Codex from 100% to 84% at 80×24 and to 56% at 120×40 without changing tmux history.
- Therefore Codex uses host/tmux history in its composer and its own conversation model in transcript mode.
- The earlier real-Claude reproduction observed fullscreen alt-screen + mouse tracking with `history_size=0`; Claude owns both its conversation history and tracked wheel.

The contract encodes terminal modes, not agent identity, so it accommodates both models.

## Behavior after this PR

- Codex composer preview: Ctrl-U/Ctrl-D and wheel scroll truthful tmux history.
- Codex transcript: AF does not offer or paint a fake nav-preview scroll. Interactive PageUp remains a raw child keystroke; an untracked wheel is consumed without exposing the background primary buffer.
- A tracked fullscreen child such as Claude receives wheel input through the live child protocol.
- Detached fullscreen preview has no scroll affordance because capture-pane cannot construct the child’s private offscreen conversation.

That last point is the honest product boundary: a non-mutating fullscreen transcript preview requires an agent transcript API or another child-aware history source. It cannot be implemented from capture-pane, so this PR removes the misleading control instead of scrolling the wrong buffer.

## Validation

Fail-first regressions pinned the initiating gesture and queued-gesture losses on the prior implementation; the same-target late-snapshot test also failed before the publication-generation fix.

Automated:

- `make test-container`
- `make test-container GOTESTARGS='-race ./ui ./ui/termpane ./terminal ./agentproto ./apiclient ./app'`
- `make web-selftest-container` — 107/107
- exact CI golangci-lint, deadcode, gofmt, file-length lint, `go vet ./...`, and `go build ./...`
- conformance coverage for delayed fill with multiple gestures, host history larger than viewport, retarget, 80×24/120×40 resize, keyboard + wheel, child tracked/untracked routing, blank/fresh/recovery mode snapshots, and remote preview propagation

Real TUI, isolated container:

- At 120×40, normal top row 51; the first Ctrl-U and wheel each exposed row 50.
- At 80×24, normal top row 67; the first Ctrl-U and wheel each exposed row 66.
- In Codex transcript at both sizes, nav Ctrl-U/wheel showed no AF scroll mode; interactive PageUp moved child history while untracked wheel left it unchanged.
- Restarting AF while Codex was already at transcript 56% preserved child ownership from the initial repaint.
- Driver orphan-client assertion passed; the exact throwaway container was removed and verified gone.
