### PR TITLE
fix(config): repair explicitly pinned default home

### DIFF
--- a/config/filelock.go
+++ b/config/filelock.go
@@ -253,7 +253,13 @@ func secureAFHomeForPath(path string) error {
 	if statErr != nil {
 		return fmt.Errorf("inspect AF home: %w", statErr)
 	}
-	if os.Getenv("AGENT_FACTORY_HOME") != "" && !created {
+	// Environment presence does not make a path custom: users commonly export
+	// AGENT_FACTORY_HOME=$HOME/.agent-factory to pin the default explicitly. Base
+	// the permission policy on the resolved location so that spelling receives
+	// the same legacy repair, while genuinely custom broad directories (notably
+	// AGENT_FACTORY_HOME=~) retain their caller-owned mode.
+	isDefaultHome := os.Getenv("AGENT_FACTORY_HOME") == "" || resolvesToDefaultAFHome(absHome)
+	if !isDefaultHome && !created {
 		return nil
 	}
 	if info.Mode()&os.ModeSymlink != 0 {
@@ -275,4 +281,16 @@ func secureAFHomeForPath(path string) error {
 		return fmt.Errorf("secure AF home: %w", err)
 	}
 	return nil
+}
+
+func resolvesToDefaultAFHome(absHome string) bool {
+	defaultHome, err := ConfigDirFor("")
+	if err != nil {
+		return false
+	}
+	absDefault, err := filepath.Abs(defaultHome)
+	if err != nil {
+		return false
+	}
+	return filepath.Clean(absHome) == filepath.Clean(absDefault)
 }

--- a/config/home_permissions_test.go
+++ b/config/home_permissions_test.go
@@ -18,6 +18,7 @@ func TestLoadConfigSecuresDefaultAFHome(t *testing.T) {
 		name           string
 		legacyConfig   string
 		defaultProgram string
+		explicitHome   bool
 	}{
 		{name: "fresh home"},
 		{
@@ -25,12 +26,22 @@ func TestLoadConfigSecuresDefaultAFHome(t *testing.T) {
 			legacyConfig:   "default_program = 'codex'\n",
 			defaultProgram: "codex",
 		},
+		{
+			name:           "legacy 0755 home explicitly pinned as AGENT_FACTORY_HOME",
+			legacyConfig:   "default_program = 'codex'\n",
+			defaultProgram: "codex",
+			explicitHome:   true,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			userHome := t.TempDir()
 			afHome := filepath.Join(userHome, ".agent-factory")
 			t.Setenv("HOME", userHome)
-			t.Setenv("AGENT_FACTORY_HOME", "")
+			if tc.explicitHome {
+				t.Setenv("AGENT_FACTORY_HOME", afHome)
+			} else {
+				t.Setenv("AGENT_FACTORY_HOME", "")
+			}
 			fastShell(t)
 
 			if tc.legacyConfig != "" {


### PR DESCRIPTION
## Summary

- treat an explicitly configured path that resolves to the default Agent Factory home as the default home
- repair legacy permissive modes on that path while preserving the existing opt-out for genuinely custom pre-existing directories
- add the fail-first regression for `AGENT_FACTORY_HOME=$HOME/.agent-factory`

## Why

The late Codex P2 on #2254 is valid: keying the repair policy only on whether `AGENT_FACTORY_HOME` is present leaves an explicitly pinned default home at its legacy mode. The resolved path, not environment-variable presence, determines whether this is the default security boundary.

## Verification

Fail-first on the parent behavior:

```
go test ./config -run TestLoadConfigSecuresDefaultAFHome -count=1
```

The explicit-default subtest failed with `expected default AF home mode 0700, got 0755` before the fix and passes afterward.

Full gates are green on pushed SHA `7fefd2b1f1be183f731d4cab1741a77d3b07d197`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh` (904 files checked)

Follow-up to #2254.

— Captain Claude