### PR TITLE
fix(web): prioritize project context on phones

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -278,6 +278,13 @@ Tasks view to the selected project), a **Live** pip showing the daemon
 event-stream state (`Live` / `Connecting…` / `Reconnecting…`), and
 **Disconnect**.
 
+On a phone, width is assigned by function rather than desktop order: the first row
+keeps the session-drawer toggle, the current **project**, and one **More** button;
+the view tabs share an aligned row below. Long project names end in an ellipsis but
+keep the largest flexible slot. The decorative brand disappears, while Live status,
+install, theme, and Disconnect remain available as comfortable touch targets inside
+**More** instead of being squeezed or removed.
+
 ### Sessions view
 
 The default view: a **rail** of the selected project's sessions on the left, a

--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -211,6 +211,7 @@ body {
 .af-tab-new:focus-visible,
 .af-viewtab:focus-visible,
 .af-theme-opt:focus-visible,
+.af-appbar-more:focus-visible,
 .af-project-switch:focus-visible,
 .af-project-item:focus-visible,
 .af-rail-filter:focus-visible,
@@ -352,6 +353,7 @@ body {
 .af-project-switch-wrap {
   position: relative;
   margin-left: auto;
+  min-width: 0;
 }
 .af-project-switch {
   display: inline-flex;
@@ -376,10 +378,18 @@ body {
   color: var(--af-text-3);
 }
 .af-project-glyph {
+  flex: 0 0 auto;
   color: var(--af-accent);
   font-weight: 700;
 }
+.af-project-switch-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .af-project-caret {
+  flex: 0 0 auto;
   color: var(--af-text-3);
   font-size: 0.6em;
 }
@@ -495,6 +505,33 @@ body {
 .af-live-pip.af-live-reconnecting {
   background: var(--af-dot-lost);
   animation: af-pulse 1.2s ease-in-out infinite;
+}
+.af-appbar-tools-wrap,
+.af-appbar-tools {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--af-sp-4);
+  flex: 0 0 auto;
+}
+.af-appbar-more {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  padding: 0;
+  background: transparent;
+  color: var(--af-text);
+  border: 1px solid var(--af-border);
+  border-radius: var(--af-r-md);
+  font: inherit;
+  font-size: var(--af-fs-lg);
+  line-height: 1;
+  cursor: pointer;
+}
+.af-appbar-more:hover {
+  background: var(--af-bg-inset);
+  border-color: var(--af-border-strong);
 }
 .af-ghost {
   padding: 0.4rem var(--af-sp-3);
@@ -1749,6 +1786,19 @@ body {
   font-size: var(--af-fs-xs);
 }
 @media (max-width: 768px) {
+  .af-appbar {
+    position: relative;
+    z-index: 40;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    grid-template-areas: "nav project tools" "views views views";
+    align-items: center;
+    gap: var(--af-sp-2);
+    padding: max(var(--af-sp-2), env(safe-area-inset-top)) max(var(--af-sp-2), env(safe-area-inset-right)) var(--af-sp-2) max(var(--af-sp-2), env(safe-area-inset-left));
+  }
+  .af-nav-toggle {
+    grid-area: nav;
+  }
   .af-app.af-view-sessions .af-nav-toggle {
     display: inline-flex;
   }
@@ -1786,6 +1836,96 @@ body {
   }
   .af-brand {
     display: none;
+  }
+  .af-project-switch-wrap {
+    grid-area: project;
+    width: 100%;
+    min-width: 0;
+    margin-left: 0;
+  }
+  .af-project-switch {
+    width: 100%;
+    min-width: 0;
+    height: 2.75rem;
+  }
+  .af-project-switch-name {
+    flex: 1 1 auto;
+    text-align: left;
+  }
+  .af-project-menu {
+    right: calc(-2.75rem - var(--af-sp-2));
+    width: calc(100vw - var(--af-sp-2) - var(--af-sp-2));
+    min-width: 0;
+    max-width: none;
+    max-height: calc(100dvh - 7rem);
+    overflow-y: auto;
+    z-index: 60;
+  }
+  .af-viewnav {
+    grid-area: views;
+    width: 100%;
+    margin-left: 0;
+  }
+  .af-viewtab {
+    flex: 1 1 0;
+    min-width: 0;
+    min-height: 2.5rem;
+    padding-inline: var(--af-sp-2);
+  }
+  .af-appbar-tools-wrap {
+    grid-area: tools;
+    position: relative;
+    display: block;
+  }
+  .af-appbar-more {
+    display: inline-flex;
+  }
+  .af-appbar-tools {
+    display: none;
+    position: absolute;
+    top: calc(100% + 6px);
+    right: 0;
+    z-index: 60;
+    width: min(17rem, calc(100vw - var(--af-sp-2) - var(--af-sp-2)));
+    max-height: calc(100dvh - 4rem);
+    overflow-y: auto;
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--af-sp-2);
+    padding: var(--af-sp-2);
+    background: var(--af-bg-raised);
+    border: 1px solid var(--af-border);
+    border-radius: var(--af-r-lg);
+    box-shadow: var(--af-shadow-overlay);
+  }
+  .af-appbar-tools-open > .af-appbar-tools {
+    display: flex;
+  }
+  .af-appbar-tools .af-live {
+    min-height: 2.75rem;
+    padding-inline: var(--af-sp-3);
+  }
+  .af-appbar-tools .af-install {
+    width: 100%;
+  }
+  .af-appbar-tools .af-install__go {
+    flex: 1 1 auto;
+    min-height: 2.75rem;
+  }
+  .af-appbar-tools .af-install__dismiss {
+    min-width: 2.75rem;
+    min-height: 2.75rem;
+  }
+  .af-appbar-tools .af-theme-toggle {
+    width: 100%;
+  }
+  .af-appbar-tools .af-theme-opt {
+    flex: 1 1 0;
+    min-height: 2.5rem;
+  }
+  .af-appbar-tools > .af-ghost {
+    width: 100%;
+    min-height: 2.75rem;
   }
   .af-tab {
     min-height: 2.5rem;

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -10438,7 +10438,6 @@ var AppShell = class {
     live.setAttribute("role", "status");
     const disconnect2 = h2("button", { type: "button", class: "af-ghost" }, "Disconnect");
     disconnect2.setAttribute("title", "Disconnect and forget the saved token");
-    disconnect2.addEventListener("click", () => this.actions.disconnect());
     const themeToggle = h2("div", { class: "af-theme-toggle" });
     themeToggle.setAttribute("role", "group");
     themeToggle.setAttribute("aria-label", "Theme");
@@ -10495,6 +10494,63 @@ var AppShell = class {
     this.navToggle.setAttribute("aria-controls", "af-rail");
     this.navToggle.setAttribute("aria-expanded", "false");
     this.navToggle.addEventListener("click", () => this.toggleNav());
+    const appbarTools = h2(
+      "div",
+      { class: "af-appbar-tools", id: "af-appbar-tools" },
+      live,
+      ...this.installEl ? [this.installEl] : [],
+      themeToggle,
+      disconnect2
+    );
+    appbarTools.setAttribute("role", "group");
+    appbarTools.setAttribute("aria-label", "App controls");
+    const appbarMore = h2("button", { type: "button", class: "af-appbar-more" }, "\u22EF");
+    appbarMore.setAttribute("aria-label", "More app controls");
+    appbarMore.setAttribute("title", "More app controls");
+    appbarMore.setAttribute("aria-haspopup", "true");
+    appbarMore.setAttribute("aria-controls", "af-appbar-tools");
+    appbarMore.setAttribute("aria-expanded", "false");
+    const appbarToolsWrap = h2("div", { class: "af-appbar-tools-wrap" }, appbarMore, appbarTools);
+    let appbarToolsOpen = false;
+    const setAppbarToolsOpen = (open) => {
+      if (appbarToolsOpen === open) {
+        return;
+      }
+      appbarToolsOpen = open;
+      appbarToolsWrap.classList.toggle("af-appbar-tools-open", open);
+      appbarMore.setAttribute("aria-expanded", open ? "true" : "false");
+      if (open) {
+        document.addEventListener("mousedown", onAppbarToolsMouseDown);
+        document.addEventListener("keydown", onAppbarToolsKeyDown, true);
+        window.addEventListener("resize", onAppbarToolsResize);
+      } else {
+        document.removeEventListener("mousedown", onAppbarToolsMouseDown);
+        document.removeEventListener("keydown", onAppbarToolsKeyDown, true);
+        window.removeEventListener("resize", onAppbarToolsResize);
+      }
+    };
+    const onAppbarToolsMouseDown = (e) => {
+      if (!appbarToolsWrap.isConnected || !appbarToolsWrap.contains(e.target)) {
+        setAppbarToolsOpen(false);
+      }
+    };
+    const onAppbarToolsKeyDown = (e) => {
+      if (e.key !== "Escape") {
+        return;
+      }
+      e.stopPropagation();
+      setAppbarToolsOpen(false);
+      appbarMore.focus();
+    };
+    const onAppbarToolsResize = () => setAppbarToolsOpen(false);
+    appbarMore.addEventListener("click", (e) => {
+      e.stopPropagation();
+      setAppbarToolsOpen(!appbarToolsOpen);
+    });
+    disconnect2.addEventListener("click", () => {
+      setAppbarToolsOpen(false);
+      this.actions.disconnect();
+    });
     const header = h2(
       "header",
       { class: "af-appbar" },
@@ -10502,10 +10558,7 @@ var AppShell = class {
       h2("span", { class: "af-brand" }, "Agent Factory"),
       viewNav,
       this.projectSwitchWrap,
-      live,
-      ...this.installEl ? [this.installEl] : [],
-      themeToggle,
-      disconnect2
+      appbarToolsWrap
     );
     this.railCount = h2("span", { class: "af-rail-count" }, "0");
     const newBtn = h2("button", { type: "button", class: "af-rail-new", title: "New session" }, "+ New");

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "c4e5a7f8b67e";
+const VERSION = "5289eb0d4b3b";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -5732,6 +5732,160 @@ test("#2226 mobile (375px): drawer dismissal follows action intent, not click pr
   await ctx.close();
 });
 
+test("#2227 mobile appbar: project context wins scarce width at 320px and 375px", async ({ browser }, testInfo) => {
+  const LONG_PROJECT = "project-with-a-deliberately-long-distinguishing-name";
+  const LONG_ROOT = `/work/${LONG_PROJECT}`;
+
+  for (const width of [320, 375]) {
+    for (const theme of ["light", "dark"] as const) {
+      await test.step(`${width}px · ${theme}`, async () => {
+        const ctx = await browser.newContext({ viewport: { width, height: 812 } });
+        await ctx.addInitScript(
+          ({ root, savedTheme }) => {
+            localStorage.setItem("af-project", root);
+            localStorage.setItem("af-theme", savedTheme);
+          },
+          { root: LONG_ROOT, savedTheme: theme },
+        );
+        const p = await ctx.newPage();
+        await p.route("**/v1/Snapshot", async (route) => {
+          const resp = await route.fetch();
+          const body = await resp.json();
+          const snap = body?.data as { instances?: Array<Record<string, unknown> & { title: string }> };
+          const list = snap?.instances ?? [];
+          const proto = { ...(list.find((s) => s.title === SESSION_A) ?? {}) };
+          list.push({
+            ...proto,
+            id: `synth-mobile-appbar-${width}-${theme}`,
+            title: `mobile-appbar-${width}-${theme}`,
+            branch: `mobile-appbar-${width}-${theme}`,
+            liveness: 2,
+            in_flight_op: 0,
+            lifecycle_action: "archive",
+            worktree: { ...(proto.worktree as Record<string, unknown>), repo_path: LONG_ROOT },
+          });
+          if (snap) {
+            snap.instances = list;
+          }
+          await route.fulfill({ status: resp.status(), contentType: "application/json", body: JSON.stringify(body) });
+        });
+        await p.goto("/");
+        await expect(p.locator(".af-app")).toBeVisible();
+        await expect(p.locator(".af-project-switch-name")).toHaveText(LONG_PROJECT);
+        await expect(p.locator("html")).toHaveAttribute("data-theme", theme);
+
+        const brand = p.locator(".af-brand");
+        const toggle = p.locator(".af-nav-toggle");
+        const project = p.locator(".af-project-switch");
+        const projectName = p.locator(".af-project-switch-name");
+        const more = p.locator(".af-appbar-more");
+        const tools = p.locator(".af-appbar-tools");
+        await expect(brand, "decoration yields before project context").toBeHidden();
+        await expect(toggle).toBeVisible();
+        await expect(project).toBeVisible();
+        await expect(more, "secondary appbar tools collapse behind one touch target").toBeVisible();
+        await expect(tools).toBeHidden();
+
+        const primary = await p.evaluate(() => {
+          const rect = (selector: string) => {
+            const box = document.querySelector(selector)!.getBoundingClientRect();
+            return { left: box.left, right: box.right, top: box.top, height: box.height, width: box.width };
+          };
+          return {
+            toggle: rect(".af-nav-toggle"),
+            project: rect(".af-project-switch"),
+            more: rect(".af-appbar-more"),
+          };
+        });
+        for (const [name, box] of Object.entries(primary)) {
+          expect(box.left, `${name} starts inside ${width}px`).toBeGreaterThanOrEqual(0);
+          expect(box.right, `${name} ends inside ${width}px`).toBeLessThanOrEqual(width);
+          expect(box.height, `${name} keeps a comfortable tap height`).toBeGreaterThanOrEqual(44);
+        }
+        expect(primary.project.width, "project context owns the flexible middle of the primary row").toBeGreaterThan(150);
+        expect(Math.abs(primary.toggle.top - primary.project.top), "primary controls share one top edge").toBeLessThanOrEqual(1);
+        expect(Math.abs(primary.more.top - primary.project.top), "primary controls share one top edge").toBeLessThanOrEqual(1);
+
+        const truncation = await projectName.evaluate((el) => {
+          const css = getComputedStyle(el);
+          return {
+            clientWidth: el.clientWidth,
+            scrollWidth: el.scrollWidth,
+            overflow: css.overflow,
+            textOverflow: css.textOverflow,
+            whiteSpace: css.whiteSpace,
+          };
+        });
+        expect(truncation.scrollWidth, "the long name genuinely exceeds its visible slot").toBeGreaterThan(
+          truncation.clientWidth,
+        );
+        expect(truncation).toMatchObject({ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" });
+        expect(await horizontalOverflow(p), "the closed drawer never widens the page").toBeLessThanOrEqual(1);
+
+        // The project popover itself must remain inside the phone and offer several
+        // projects. Clicking the current long-name item proves it is hit-testable.
+        await project.click();
+        const projectMenu = p.locator(".af-project-menu");
+        await expect(projectMenu).toBeVisible();
+        expect(
+          await projectMenu.locator(".af-project-item").count(),
+          "the phone menu keeps several projects operable",
+        ).toBeGreaterThanOrEqual(3);
+        const menuBox = await projectMenu.boundingBox();
+        expect(menuBox, "project menu has phone geometry").not.toBeNull();
+        expect(menuBox!.x).toBeGreaterThanOrEqual(0);
+        expect(menuBox!.x + menuBox!.width).toBeLessThanOrEqual(width);
+        await projectItem(p, LONG_PROJECT).click();
+        await expect(projectMenu).toBeHidden();
+
+        // Rare chrome remains operable rather than consuming the primary row.
+        await more.click();
+        await expect(tools).toBeVisible();
+        await expect(tools.locator(`.af-theme-opt[data-theme-opt="${theme}"]`)).toHaveClass(/af-theme-opt-active/);
+        const disconnect = tools.getByRole("button", { name: "Disconnect" });
+        await expect(disconnect).toBeVisible();
+        const toolsBox = await tools.boundingBox();
+        expect(toolsBox, "More popover has phone geometry").not.toBeNull();
+        expect(toolsBox!.x).toBeGreaterThanOrEqual(0);
+        expect(toolsBox!.x + toolsBox!.width).toBeLessThanOrEqual(width);
+        for (const control of [disconnect, ...(await tools.locator(".af-theme-opt").all())]) {
+          const box = await control.boundingBox();
+          expect(box, "every More action has geometry").not.toBeNull();
+          expect(box!.height, "More actions keep comfortable tap heights").toBeGreaterThanOrEqual(40);
+        }
+        await p.keyboard.press("Escape");
+        await expect(tools).toBeHidden();
+        await expect(more).toBeFocused();
+
+        await testInfo.attach(`2227-${width}-${theme}-drawer-closed`, {
+          body: await p.screenshot(),
+          contentType: "image/png",
+        });
+
+        // Opening the drawer must not reflow the bar, and its z-index must not cover
+        // the project menu: selecting the same project while open proves both.
+        await toggle.click();
+        await expect(p.locator(".af-app")).toHaveClass(/af-nav-open/);
+        const openProjectBox = await project.boundingBox();
+        expect(openProjectBox, "drawer-open project switch has geometry").not.toBeNull();
+        expect(openProjectBox!.x).toBeCloseTo(primary.project.left, 0);
+        expect(openProjectBox!.width).toBeCloseTo(primary.project.width, 0);
+        await project.click();
+        await expect(projectMenu).toBeVisible();
+        await projectItem(p, LONG_PROJECT).click();
+        await expect(projectMenu).toBeHidden();
+        expect(await horizontalOverflow(p), "the open drawer never widens the page").toBeLessThanOrEqual(1);
+
+        await testInfo.attach(`2227-${width}-${theme}-drawer-open`, {
+          body: await p.screenshot(),
+          contentType: "image/png",
+        });
+        await ctx.close();
+      });
+    }
+  }
+});
+
 for (const width of [375, 768]) {
   test(`mobile (${width}px): the page never scrolls sideways, drawer closed or open`, async ({ browser }) => {
     const { ctx, p } = await openAt(browser, width, 812);
@@ -5759,6 +5913,9 @@ test("desktop (1280px): the mobile drawer never engages — the rail stays in vi
   const { ctx, p } = await openAt(browser, 1280, 800);
   await expect(p.locator(".af-rail")).toBeVisible();
   await expect(p.locator(".af-nav-toggle")).toBeHidden();
+  await expect(p.locator(".af-brand")).toBeVisible();
+  await expect(p.locator(".af-appbar-more")).toBeHidden();
+  await expect(p.locator(".af-appbar-tools")).toBeVisible();
   await expect(p.locator(".af-app")).not.toHaveClass(/af-nav-open/);
   await ctx.close();
 });

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -249,6 +249,7 @@ body {
 .af-tab-new:focus-visible,
 .af-viewtab:focus-visible,
 .af-theme-opt:focus-visible,
+.af-appbar-more:focus-visible,
 .af-project-switch:focus-visible,
 .af-project-item:focus-visible,
 .af-rail-filter:focus-visible,
@@ -435,6 +436,7 @@ body {
 .af-project-switch-wrap {
   position: relative;
   margin-left: auto;
+  min-width: 0;
 }
 
 /* Project switcher (redesign PR2): the top-right control that shows the current
@@ -467,11 +469,20 @@ body {
 }
 
 .af-project-glyph {
+  flex: 0 0 auto;
   color: var(--af-accent);
   font-weight: 700;
 }
 
+.af-project-switch-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .af-project-caret {
+  flex: 0 0 auto;
   color: var(--af-text-3);
   font-size: 0.6em;
 }
@@ -607,6 +618,39 @@ body {
 .af-live-pip.af-live-reconnecting {
   background: var(--af-dot-lost);
   animation: af-pulse 1.2s ease-in-out infinite;
+}
+
+/* The trailing appbar controls are one semantic group. It stays inline on desktop;
+ * the narrow breakpoint turns the wrapper into a single More trigger + popover so
+ * project context gets the phone's scarce primary-row width (#2227). */
+.af-appbar-tools-wrap,
+.af-appbar-tools {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--af-sp-4);
+  flex: 0 0 auto;
+}
+
+.af-appbar-more {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  padding: 0;
+  background: transparent;
+  color: var(--af-text);
+  border: 1px solid var(--af-border);
+  border-radius: var(--af-r-md);
+  font: inherit;
+  font-size: var(--af-fs-lg);
+  line-height: 1;
+  cursor: pointer;
+}
+
+.af-appbar-more:hover {
+  background: var(--af-bg-inset);
+  border-color: var(--af-border-strong);
 }
 
 .af-ghost {
@@ -2309,9 +2353,31 @@ body {
  * so the main pane keeps the full body width whether the drawer is open or shut, and the
  * terminal's own ResizeObserver never sees a width change when it toggles. */
 @media (max-width: 768px) {
+  /* Phone priority, high to low: drawer navigation, current project, access to rare
+   * tools, then the top-level view row. The decorative brand yields entirely. A grid
+   * makes that order structural rather than relying on whichever flex child happens
+   * to shrink or wrap first. */
+  .af-appbar {
+    position: relative;
+    z-index: 40;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    grid-template-areas:
+      "nav project tools"
+      "views views views";
+    align-items: center;
+    gap: var(--af-sp-2);
+    padding: max(var(--af-sp-2), env(safe-area-inset-top)) max(var(--af-sp-2), env(safe-area-inset-right))
+      var(--af-sp-2) max(var(--af-sp-2), env(safe-area-inset-left));
+  }
+
   /* The hamburger is meaningful only where there is a rail to reveal — the sessions
    * view. In tasks/config the body (and its drawer) is display:none, so the toggle
    * would be a dead control; hide it there. */
+  .af-nav-toggle {
+    grid-area: nav;
+  }
+
   .af-app.af-view-sessions .af-nav-toggle {
     display: inline-flex;
   }
@@ -2371,6 +2437,122 @@ body {
    * controls (hamburger, view nav, project switch) have room before they wrap. */
   .af-brand {
     display: none;
+  }
+
+  /* Project context owns the flexible centre of the primary row. The explicit
+   * min-width chain (grid track → wrapper → button → name) is what lets the browser
+   * draw a real ellipsis instead of clipping a flex item at an arbitrary glyph. */
+  .af-project-switch-wrap {
+    grid-area: project;
+    width: 100%;
+    min-width: 0;
+    margin-left: 0;
+  }
+
+  .af-project-switch {
+    width: 100%;
+    min-width: 0;
+    height: 2.75rem;
+  }
+
+  .af-project-switch-name {
+    flex: 1 1 auto;
+    text-align: left;
+  }
+
+  /* The menu spans the usable phone width and extends across the More column. This
+   * keeps a right-anchored menu inside both 320px and 375px viewports, whether the
+   * drawer is open or closed. The appbar's stacking context keeps it above the drawer. */
+  .af-project-menu {
+    right: calc(-2.75rem - var(--af-sp-2));
+    width: calc(100vw - var(--af-sp-2) - var(--af-sp-2));
+    min-width: 0;
+    max-width: none;
+    max-height: calc(100dvh - 7rem);
+    overflow-y: auto;
+    z-index: 60;
+  }
+
+  .af-viewnav {
+    grid-area: views;
+    width: 100%;
+    margin-left: 0;
+  }
+
+  .af-viewtab {
+    flex: 1 1 0;
+    min-width: 0;
+    min-height: 2.5rem;
+    padding-inline: var(--af-sp-2);
+  }
+
+  /* Live/install/theme/disconnect are useful but secondary. One 44px trigger keeps
+   * every function reachable without letting four desktop controls squeeze the
+   * project name. The popover is a vertical touch-target stack, not a shrunken bar. */
+  .af-appbar-tools-wrap {
+    grid-area: tools;
+    position: relative;
+    display: block;
+  }
+
+  .af-appbar-more {
+    display: inline-flex;
+  }
+
+  .af-appbar-tools {
+    display: none;
+    position: absolute;
+    top: calc(100% + 6px);
+    right: 0;
+    z-index: 60;
+    width: min(17rem, calc(100vw - var(--af-sp-2) - var(--af-sp-2)));
+    max-height: calc(100dvh - 4rem);
+    overflow-y: auto;
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--af-sp-2);
+    padding: var(--af-sp-2);
+    background: var(--af-bg-raised);
+    border: 1px solid var(--af-border);
+    border-radius: var(--af-r-lg);
+    box-shadow: var(--af-shadow-overlay);
+  }
+
+  .af-appbar-tools-open > .af-appbar-tools {
+    display: flex;
+  }
+
+  .af-appbar-tools .af-live {
+    min-height: 2.75rem;
+    padding-inline: var(--af-sp-3);
+  }
+
+  .af-appbar-tools .af-install {
+    width: 100%;
+  }
+
+  .af-appbar-tools .af-install__go {
+    flex: 1 1 auto;
+    min-height: 2.75rem;
+  }
+
+  .af-appbar-tools .af-install__dismiss {
+    min-width: 2.75rem;
+    min-height: 2.75rem;
+  }
+
+  .af-appbar-tools .af-theme-toggle {
+    width: 100%;
+  }
+
+  .af-appbar-tools .af-theme-opt {
+    flex: 1 1 0;
+    min-height: 2.5rem;
+  }
+
+  .af-appbar-tools > .af-ghost {
+    width: 100%;
+    min-height: 2.75rem;
   }
 
   /* Touch targets: lift the primary controls to a ~40-44px tap area so nothing on the

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -707,7 +707,6 @@ export class AppShell {
     // transport action, not a logout.
     const disconnect = h("button", { type: "button", class: "af-ghost" }, "Disconnect");
     disconnect.setAttribute("title", "Disconnect and forget the saved token");
-    disconnect.addEventListener("click", () => this.actions.disconnect());
 
     // The theme toggle: a compact Auto/Light/Dark segmented control. A click routes
     // through actions.setTheme, which persists the choice and re-themes the terminals.
@@ -783,6 +782,71 @@ export class AppShell {
     this.navToggle.setAttribute("aria-expanded", "false");
     this.navToggle.addEventListener("click", () => this.toggleNav());
 
+    // Secondary appbar chrome stays inline on desktop, but a phone cannot give all
+    // four controls scarce primary-row width without clipping the project context
+    // (#2227). Group them behind one More trigger at the narrow breakpoint instead
+    // of deleting functionality or shrinking touch targets. The listeners exist only
+    // while the popover is open, so logout/login cannot accumulate document handlers.
+    const appbarTools = h(
+      "div",
+      { class: "af-appbar-tools", id: "af-appbar-tools" },
+      live,
+      ...(this.installEl ? [this.installEl] : []),
+      themeToggle,
+      disconnect,
+    );
+    appbarTools.setAttribute("role", "group");
+    appbarTools.setAttribute("aria-label", "App controls");
+    const appbarMore = h("button", { type: "button", class: "af-appbar-more" }, "⋯");
+    appbarMore.setAttribute("aria-label", "More app controls");
+    appbarMore.setAttribute("title", "More app controls");
+    appbarMore.setAttribute("aria-haspopup", "true");
+    appbarMore.setAttribute("aria-controls", "af-appbar-tools");
+    appbarMore.setAttribute("aria-expanded", "false");
+    const appbarToolsWrap = h("div", { class: "af-appbar-tools-wrap" }, appbarMore, appbarTools);
+    let appbarToolsOpen = false;
+    const setAppbarToolsOpen = (open: boolean): void => {
+      if (appbarToolsOpen === open) {
+        return;
+      }
+      appbarToolsOpen = open;
+      appbarToolsWrap.classList.toggle("af-appbar-tools-open", open);
+      appbarMore.setAttribute("aria-expanded", open ? "true" : "false");
+      if (open) {
+        document.addEventListener("mousedown", onAppbarToolsMouseDown);
+        document.addEventListener("keydown", onAppbarToolsKeyDown, true);
+        window.addEventListener("resize", onAppbarToolsResize);
+      } else {
+        document.removeEventListener("mousedown", onAppbarToolsMouseDown);
+        document.removeEventListener("keydown", onAppbarToolsKeyDown, true);
+        window.removeEventListener("resize", onAppbarToolsResize);
+      }
+    };
+    const onAppbarToolsMouseDown = (e: MouseEvent): void => {
+      if (!appbarToolsWrap.isConnected || !appbarToolsWrap.contains(e.target as Node)) {
+        setAppbarToolsOpen(false);
+      }
+    };
+    const onAppbarToolsKeyDown = (e: KeyboardEvent): void => {
+      if (e.key !== "Escape") {
+        return;
+      }
+      e.stopPropagation();
+      setAppbarToolsOpen(false);
+      appbarMore.focus();
+    };
+    const onAppbarToolsResize = (): void => setAppbarToolsOpen(false);
+    appbarMore.addEventListener("click", (e) => {
+      e.stopPropagation();
+      setAppbarToolsOpen(!appbarToolsOpen);
+    });
+    // Disconnect replaces the shell synchronously. Close first so the temporary
+    // document/window listeners cannot outlive the DOM subtree they describe.
+    disconnect.addEventListener("click", () => {
+      setAppbarToolsOpen(false);
+      this.actions.disconnect();
+    });
+
     const header = h(
       "header",
       { class: "af-appbar" },
@@ -790,13 +854,7 @@ export class AppShell {
       h("span", { class: "af-brand" }, "Agent Factory"),
       viewNav,
       this.projectSwitchWrap,
-      live,
-      // Install sits with the other trailing appbar controls. It carries `hidden`
-      // unless the browser reports the app installable, which on most loads (and
-      // always over plain-HTTP Tailscale) means it contributes nothing to the bar.
-      ...(this.installEl ? [this.installEl] : []),
-      themeToggle,
-      disconnect,
+      appbarToolsWrap,
     );
 
     this.railCount = h("span", { class: "af-rail-count" }, "0");


### PR DESCRIPTION
## Outcome

- give scarce phone width an explicit order: drawer navigation → current project → one More disclosure → the full-width view row
- hide the decorative brand first, truncate long project names with a real ellipsis, and keep the primary controls on one 44 px line
- collapse Live, install, theme, and Disconnect into one structural control group on phones while preserving their inline desktop layout
- keep both project and More popovers inside 320 px and 375 px viewports, including while the navigation drawer is open

## Gotcha removed

The narrow layout no longer depends on whichever child of a desktop flex row happens to shrink first. A mobile grid encodes the width priority, and secondary chrome moves as one DOM group rather than a hand-maintained list of individually hidden controls. Browser assertions pin the project slot, ellipsis contract, popover bounds, tap heights, drawer stability, and unchanged desktop projection.

## Fail-first evidence

The new 320/375 × light/dark browser case failed against the old bundle at its first structural assertion because the mobile More control did not exist; all 107 pre-existing browser cases passed in that run.

## Visual verification

Inspected 320 px and 375 px in light and dark with a deliberately long project name and four projects: project/More menus open and remain operable, the drawer does not reflow the appbar, and no horizontal clipping appears. Also inspected desktop at 1280 px in light and dark; the original single-row chrome remains aligned.

## Validation

Final full gates are running against pushed head fd72411a738a747d58552736e6970352ce38ed55 after rebasing onto current master. Results will be posted before merge.

Closes #2227

— Captain Claude