### PR TITLE
fix(startup): make runtime outcomes explicit

### DIFF
--- a/app/archive_action_test.go
+++ b/app/archive_action_test.go
@@ -44,6 +44,23 @@ func TestHandleArchive_LiveRowConfirms(t *testing.T) {
 	require.False(t, called, "the archive RPC must not fire before confirmation")
 }
 
+// Startup uncertainty vetoes every operation that would reuse the unconfirmed
+// runtime binding, but it must not veto explicit teardown. Otherwise the retained
+// row is visible yet cannot be removed from either interactive client.
+func TestHandleKill_StartupUnknownStillConfirms(t *testing.T) {
+	h := newTestHome(t)
+	inst := archiveActionInstance(t, "uncertain", session.Ready)
+	inst.MarkStartupStateUnknown()
+	h.store.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+
+	model, _ := h.handleKill()
+	h = model.(*home)
+
+	require.Equal(t, stateConfirm, h.state, "startup-unknown row must remain killable")
+	require.NotNil(t, h.confirmationOverlay)
+}
+
 // TestHandleArchive_ConfirmationUsesEffectiveRestoreKey: the archive confirmation
 // tells the user how to bring the session back, so it must name the effective
 // RESTORE key (#1605), not the archive key — and it must track a [keys] rebind of

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -157,7 +157,7 @@ func (m *home) handleDefaultKeyPress(msg tea.KeyMsg, name keys.KeyName) (tea.Mod
 // so the event loop never blocks on it (#844).
 func (m *home) handleKill() (tea.Model, tea.Cmd) {
 	selected := m.sidebar.GetSelectedInstance()
-	if selected == nil || selected.LifecycleAction() == session.LifecycleActionNone {
+	if selected == nil || !selected.CanKill() {
 		return m, nil
 	}
 	if selected.IsTearingDown() {

--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -59,6 +59,9 @@ func (m *Manager) ArchiveSession(req ArchiveSessionRequest) (string, session.Ins
 		// relocate; there is nothing coherent to archive.
 		return "", session.InstanceData{}, fmt.Errorf("cannot archive session %q: it is not currently active", req.Title)
 	}
+	if instance.StartupStateUnknown() {
+		return "", session.InstanceData{}, fmt.Errorf("cannot archive session %q: its startup state is unknown, so af cannot safely move its workspace through an unconfirmed runtime binding; inspect it and explicitly remove it instead", req.Title)
+	}
 	if !instance.Capabilities().Archive {
 		return "", session.InstanceData{}, fmt.Errorf("cannot archive remote session %q: it has no local worktree to relocate", req.Title)
 	}

--- a/daemon/archive_test.go
+++ b/daemon/archive_test.go
@@ -89,6 +89,23 @@ func TestArchiveSession_MovesWorktreeAndMarksArchived(t *testing.T) {
 	assert.Contains(t, string(list), archivedPath, "git must still register the worktree at its new path")
 }
 
+// TestArchiveSessionRejectsStartupUnknown prevents archive from turning an
+// uncertain runtime identity into a destructive worktree move. The only safe
+// lifecycle operation on this record is an explicit kill/cleanup chosen by the
+// user after inspection.
+func TestArchiveSessionRejectsStartupUnknown(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst, srcPath := registerArchivable(t, manager, repoID, repoPath, "uncertain")
+	inst.MarkStartupStateUnknown()
+
+	_, _, err := manager.ArchiveSession(ArchiveSessionRequest{Title: "uncertain", RepoID: repoID})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "startup")
+	assert.Contains(t, err.Error(), "unknown")
+	assert.True(t, exists(srcPath), "archive moved a worktree whose runtime identity is unknown")
+	assert.NotEqual(t, session.Archived, inst.GetStatus())
+}
+
 // TestArchiveSession_MoveFailureMarksLost: when the worktree move fails, the
 // instance is marked Lost (not Archived) with started still true, so the
 // Lost-restore loop re-spawns the agent in place — and the worktree is left

--- a/daemon/archive_webtab_test.go
+++ b/daemon/archive_webtab_test.go
@@ -125,7 +125,7 @@ func TestArchiveSession_ReuseArchivedNameKeepsWebTabs(t *testing.T) {
 	disk, derr := loadRepoInstanceData(repoID)
 	require.NoError(t, derr)
 	manager.mu.Lock()
-	renamed, rerr := manager.renameArchivedForReuseLocked(repoID, repoPath, "worker", "claude", &disk)
+	renamed, rerr := manager.renameArchivedForReuseLocked(repoID, repoPath, "worker", "claude", runtimeNamespaceLocalTmux, &disk)
 	manager.mu.Unlock()
 	require.NoError(t, rerr)
 	require.NotNil(t, renamed, "the archived collision must be renamed out of the way")

--- a/daemon/control_test.go
+++ b/daemon/control_test.go
@@ -307,7 +307,7 @@ func TestValidateTitleAvailableLockedRejectsWhitespace(t *testing.T) {
 
 	for _, title := range []string{"", " ", "   ", "\t", "\n  \t"} {
 		manager.mu.Lock()
-		err := manager.validateTitleAvailableLocked("repo-id", "/tmp/repo", title, "claude", false, false, nil)
+		err := manager.validateTitleAvailableLocked("repo-id", "/tmp/repo", title, "claude", runtimeNamespaceLocalTmux, false, nil)
 		manager.mu.Unlock()
 		if err == nil {
 			t.Fatalf("expected whitespace-only title %q to be rejected", title)

--- a/daemon/create_branch_hold_test.go
+++ b/daemon/create_branch_hold_test.go
@@ -46,7 +46,7 @@ func TestNextAvailableTitle_SkipsBranchHeldByArchivedWorktree(t *testing.T) {
 	holdBranchInArchivedWorktree(t, repoPath, manager.branchForTitle("sweep-2"), "sweep-2")
 
 	manager.mu.Lock()
-	title, err := manager.nextAvailableTitleLocked(repoID, repoPath, "sweep", "claude", false, nil)
+	title, err := manager.nextAvailableTitleLocked(repoID, repoPath, "sweep", "claude", runtimeNamespaceLocalTmux, nil)
 	manager.mu.Unlock()
 	require.NoError(t, err)
 
@@ -67,7 +67,7 @@ func TestNextAvailableTitle_UncontestedNameKeepsBareForm(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 
 	manager.mu.Lock()
-	title, err := manager.nextAvailableTitleLocked(repoID, repoPath, "sweep", "claude", false, nil)
+	title, err := manager.nextAvailableTitleLocked(repoID, repoPath, "sweep", "claude", runtimeNamespaceLocalTmux, nil)
 	manager.mu.Unlock()
 
 	require.NoError(t, err)
@@ -86,7 +86,7 @@ func TestNextAvailableTitle_ExistingBranchIsNotAHold(t *testing.T) {
 	require.NoError(t, err, string(out))
 
 	manager.mu.Lock()
-	title, err := manager.nextAvailableTitleLocked(repoID, repoPath, "sweep", "claude", false, nil)
+	title, err := manager.nextAvailableTitleLocked(repoID, repoPath, "sweep", "claude", runtimeNamespaceLocalTmux, nil)
 	manager.mu.Unlock()
 
 	require.NoError(t, err)

--- a/daemon/create_reuse_archived_branch_hold_test.go
+++ b/daemon/create_reuse_archived_branch_hold_test.go
@@ -184,7 +184,7 @@ func TestReserveCreate_ArchivedBranchHoldSurvivesTheRename(t *testing.T) {
 	manager.mu.Lock()
 	diskData, lerr := loadRepoInstanceData(repoID)
 	require.NoError(t, lerr)
-	renamed, err := manager.renameArchivedForReuseLocked(repoID, repoPath, "foo", "claude", &diskData)
+	renamed, err := manager.renameArchivedForReuseLocked(repoID, repoPath, "foo", "claude", runtimeNamespaceLocalTmux, &diskData)
 	manager.mu.Unlock()
 	require.NoError(t, err)
 	require.NotNil(t, renamed, "the rename must have run for this test to say anything")

--- a/daemon/create_start_unknown_test.go
+++ b/daemon/create_start_unknown_test.go
@@ -2,10 +2,13 @@ package daemon
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/sachiniyer/agent-factory/agentproto"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/session"
 )
@@ -38,6 +41,23 @@ func (b *unknownStartBackend) kills() int {
 	return b.killCalls
 }
 
+func nextCreateLifecycleEvent(t *testing.T, events <-chan agentproto.Event) (agentproto.EventType, session.InstanceData) {
+	t.Helper()
+	select {
+	case event := <-events:
+		var data session.InstanceData
+		if len(event.Data) > 0 {
+			if err := json.Unmarshal(event.Data, &data); err != nil {
+				t.Fatalf("unmarshal %s payload: %v", event.Type, err)
+			}
+		}
+		return event.Type, data
+	case <-time.After(3 * time.Second):
+		t.Fatal("no create lifecycle event published within the deadline")
+		return "", session.InstanceData{}
+	}
+}
+
 func TestCreateSession_UnknownStartDoesNotAttemptDestructiveCleanup(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 	backend := &unknownStartBackend{readyFakeBackend: readyFakeBackend{session.NewFakeBackend()}}
@@ -55,12 +75,24 @@ func TestCreateSession_UnknownStartDoesNotAttemptDestructiveCleanup(t *testing.T
 	if err != nil {
 		t.Fatalf("NewManager: %v", err)
 	}
+	_, events := manager.events.subscribe()
 
 	_, createErr := manager.CreateSession(context.Background(), CreateSessionRequest{
 		Title: "uncertain-start", RepoPath: repoPath, Program: "claude",
 	})
 	if createErr == nil {
 		t.Fatal("CreateSession reported success though startup state is unknown")
+	}
+	pendingType, pending := nextCreateLifecycleEvent(t, events)
+	if pendingType != agentproto.EventSessionUpdated || pending.InFlightOp != session.OpCreating {
+		t.Fatalf("first create event = (%s, %+v), want pending session.updated", pendingType, pending)
+	}
+	settledType, settled := nextCreateLifecycleEvent(t, events)
+	if settledType != agentproto.EventSessionUpdated {
+		t.Fatalf("retained uncertain create event = %s, want session.updated; session.killed removes the only cleanup handle from live clients", settledType)
+	}
+	if settled.ID != pending.ID || !settled.StartupStateUnknown || settled.InFlightOp != session.OpNone {
+		t.Fatalf("retained uncertain create did not settle the pending identity: pending=%+v settled=%+v", pending, settled)
 	}
 	if calls := backend.kills(); calls != 0 {
 		t.Fatalf("CreateSession attempted %d destructive cleanup(s) after startup already reported an unknown state; the same uncertain binding cannot prove the runtime absent", calls)

--- a/daemon/create_start_unknown_test.go
+++ b/daemon/create_start_unknown_test.go
@@ -78,7 +78,7 @@ func TestCreateSession_UnknownStartDoesNotAttemptDestructiveCleanup(t *testing.T
 	_, events := manager.events.subscribe()
 
 	_, createErr := manager.CreateSession(context.Background(), CreateSessionRequest{
-		Title: "uncertain-start", RepoPath: repoPath, Program: "claude",
+		Title: "uncertain-start", RepoPath: repoPath, Program: "claude", TaskID: "task-uncertain",
 	})
 	if createErr == nil {
 		t.Fatal("CreateSession reported success though startup state is unknown")
@@ -94,6 +94,9 @@ func TestCreateSession_UnknownStartDoesNotAttemptDestructiveCleanup(t *testing.T
 	if settled.ID != pending.ID || !settled.StartupStateUnknown || settled.InFlightOp != session.OpNone {
 		t.Fatalf("retained uncertain create did not settle the pending identity: pending=%+v settled=%+v", pending, settled)
 	}
+	if !pending.TaskRunActive || settled.TaskRunActive {
+		t.Fatalf("startup-unknown must atomically release its task slot: pending=%+v settled=%+v", pending, settled)
+	}
 	if calls := backend.kills(); calls != 0 {
 		t.Fatalf("CreateSession attempted %d destructive cleanup(s) after startup already reported an unknown state; the same uncertain binding cannot prove the runtime absent", calls)
 	}
@@ -104,6 +107,9 @@ func TestCreateSession_UnknownStartDoesNotAttemptDestructiveCleanup(t *testing.T
 	}
 	if !rec.StartupStateUnknown {
 		t.Fatal("the retained record did not durably classify its startup as unknown")
+	}
+	if rec.TaskRunActive {
+		t.Fatal("the retained startup-unknown record still consumes its task's concurrency slot")
 	}
 	if rec.UserKilled {
 		t.Fatal("an uncertain startup was recorded as a kill tombstone; the daemon would automatically retry destructive cleanup")

--- a/daemon/create_tmux_name_collision_test.go
+++ b/daemon/create_tmux_name_collision_test.go
@@ -1,0 +1,152 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// TestReserveCreateRejectsConcurrentTmuxNameCollision exercises the real
+// reservation lifecycle: the first create owns its runtime name before it waits
+// on the per-repo start lock, so a second punctuation-variant create is refused
+// while that reservation is live.
+func TestReserveCreateRejectsConcurrentTmuxNameCollision(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	fakeBin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(fakeBin, "tmux"), []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	repoPath := setupControlRepo(t)
+	m, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	_, _, release, _, err := m.reserveCreate(CreateSessionRequest{
+		Title: "a/b", RepoPath: repoPath, Program: "claude",
+	})
+	if err != nil {
+		t.Fatalf("reserve first create: %v", err)
+	}
+	defer release()
+
+	_, _, _, _, err = m.reserveCreate(CreateSessionRequest{
+		Title: "a_b", RepoPath: repoPath, Program: "claude",
+	})
+	if err == nil {
+		t.Fatal("second create reserved the same repo-scoped tmux name")
+	}
+	if !strings.Contains(err.Error(), "tmux") {
+		t.Fatalf("collision error does not name the runtime namespace: %v", err)
+	}
+}
+
+// TestValidateTitleRejectsTmuxNameCollisions pins the runtime-name half of
+// create admission. Git can keep branches for "a/b" and "a_b" distinct, but
+// tmux's positive name policy maps both titles onto the same repo-scoped session
+// name. Every source of an existing claim must reject that collision before a
+// worktree is created: an in-flight reservation, a live instance, and a row that
+// exists only on disk.
+func TestValidateTitleRejectsTmuxNameCollisions(t *testing.T) {
+	fakeBin := t.TempDir()
+	tmuxPath := filepath.Join(fakeBin, "tmux")
+	if err := os.WriteFile(tmuxPath, []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	const (
+		repoID    = "repo-id"
+		existing  = "a/b"
+		candidate = "a_b"
+	)
+	repoPath := t.TempDir()
+
+	for _, tc := range []struct {
+		name  string
+		claim func(*Manager) []session.InstanceData
+	}{
+		{
+			name: "in-flight reservation",
+			claim: func(m *Manager) []session.InstanceData {
+				m.reservedTitles[daemonInstanceKey(repoID, existing)] = struct{}{}
+				return nil
+			},
+		},
+		{
+			name: "live instance",
+			claim: func(m *Manager) []session.InstanceData {
+				m.instances[daemonInstanceKey(repoID, existing)] = &session.Instance{Title: existing}
+				return nil
+			},
+		},
+		{
+			name: "disk row",
+			claim: func(*Manager) []session.InstanceData {
+				return []session.InstanceData{{Title: existing}}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &Manager{
+				cfg:               config.DefaultConfig(),
+				instances:         make(map[string]*session.Instance),
+				reservedTitles:    make(map[string]struct{}),
+				reservedTmuxNames: make(map[string]string),
+			}
+			if tc.name == "in-flight reservation" {
+				m.reservedTmuxNames[daemonInstanceKey(repoID, tmux.SanitizedNameForRepo(existing, repoPath))] = existing
+			}
+			disk := tc.claim(m)
+
+			err := m.validateTitleAvailableLocked(repoID, repoPath, candidate, "claude", runtimeNamespaceLocalTmux, false, disk)
+			if err == nil {
+				t.Fatal("accepted two titles that map to the same repo-scoped tmux session name")
+			}
+			for _, want := range []string{existing, candidate, "tmux"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("collision error %q does not name %q", err, want)
+				}
+			}
+		})
+	}
+}
+
+// TestTmuxNameCollisionIsScopedToTwoLocalRuntimes prevents the new admission
+// rule from becoming a phantom restriction on sandbox names. A runtime that has
+// no tmux session on this host neither owns nor conflicts in that namespace.
+func TestTmuxNameCollisionIsScopedToTwoLocalRuntimes(t *testing.T) {
+	fakeBin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(fakeBin, "tmux"), []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	const (
+		repoID    = "repo-id"
+		existing  = "a/b"
+		candidate = "a_b"
+	)
+	repoPath := t.TempDir()
+	m := &Manager{
+		cfg:               config.DefaultConfig(),
+		instances:         make(map[string]*session.Instance),
+		reservedTitles:    make(map[string]struct{}),
+		reservedTmuxNames: make(map[string]string),
+	}
+
+	localRow := []session.InstanceData{{Title: existing, BackendType: "local"}}
+	if err := m.validateTitleAvailableLocked(repoID, repoPath, candidate, "claude", runtimeNamespaceSandbox, false, localRow); err != nil {
+		t.Fatalf("sandbox create was blocked by a host tmux name it will not claim: %v", err)
+	}
+	remoteRow := []session.InstanceData{{Title: existing, BackendType: "docker"}}
+	if err := m.validateTitleAvailableLocked(repoID, repoPath, candidate, "claude", runtimeNamespaceLocalTmux, false, remoteRow); err != nil {
+		t.Fatalf("local create was blocked by a sandbox row with no host tmux name: %v", err)
+	}
+}

--- a/daemon/create_tmux_name_collision_test.go
+++ b/daemon/create_tmux_name_collision_test.go
@@ -150,3 +150,33 @@ func TestTmuxNameCollisionIsScopedToTwoLocalRuntimes(t *testing.T) {
 		t.Fatalf("local create was blocked by a sandbox row with no host tmux name: %v", err)
 	}
 }
+
+func TestReserveCreateRejectsMultipleArchivedTmuxCollisionsWithoutRename(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	seedArchivedSessionBranchFreed(t, manager, repoID, repoPath, "a/b", "slash-branch")
+	seedArchivedSessionBranchFreed(t, manager, repoID, repoPath, "a_b", "underscore-branch")
+
+	_, _, _, renamed, err := manager.reserveCreate(CreateSessionRequest{
+		RepoPath: repoPath,
+		Title:    "a/b",
+		Program:  tmux.ProgramClaude,
+	})
+	if err == nil {
+		t.Fatal("create accepted a runtime name claimed by two archived rows")
+	}
+	if renamed != nil {
+		t.Fatalf("failed create reported a rename: %+v", renamed)
+	}
+	if !strings.Contains(err.Error(), "both claim") {
+		t.Fatalf("collision error does not explain the ambiguous archived claims: %v", err)
+	}
+
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	for _, title := range []string{"a/b", "a_b"} {
+		inst := manager.instances[daemonInstanceKey(repoID, title)]
+		if inst == nil || inst.Title != title || inst.GetLiveness() != session.LiveArchived {
+			t.Fatalf("failed create mutated archived row %q: %+v", title, inst)
+		}
+	}
+}

--- a/daemon/create_tmux_name_collision_test.go
+++ b/daemon/create_tmux_name_collision_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/tmux"
@@ -179,4 +181,44 @@ func TestReserveCreateRejectsMultipleArchivedTmuxCollisionsWithoutRename(t *test
 			t.Fatalf("failed create mutated archived row %q: %+v", title, inst)
 		}
 	}
+}
+
+func TestReserveCreateRejectsDiskOnlyCollisionBeforeArchivedRename(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	archived, _ := seedArchivedSessionBranchFreed(t, manager, repoID, repoPath, "a/b", "slash-branch")
+	originalTitle := archived.Title
+	originalPath := archived.GetWorktreePath()
+
+	// This non-Loading row remains authoritative on disk but fails to materialize
+	// during refresh, reproducing a broken worktree/backend row. It shares the
+	// local tmux namespace with a/b even though its title differs.
+	const diskOnlyTitle = "a_b"
+	require.NoError(t, appendInstanceData(repoID, session.InstanceData{
+		ID:          "disk-only-collision",
+		Title:       diskOnlyTitle,
+		Path:        repoPath,
+		Status:      session.Ready,
+		Liveness:    session.LiveReady,
+		BackendType: "local",
+		Worktree:    session.GitWorktreeData{RepoPath: repoPath},
+	}))
+	failLoadFor(t, diskOnlyTitle)
+
+	_, _, _, renamed, err := manager.reserveCreate(CreateSessionRequest{
+		RepoPath: repoPath,
+		Title:    "a/b",
+		Program:  tmux.ProgramClaude,
+	})
+	require.Error(t, err)
+	require.Nil(t, renamed)
+	require.Contains(t, err.Error(), "both claim")
+
+	manager.mu.Lock()
+	tracked := manager.instances[daemonInstanceKey(repoID, originalTitle)]
+	manager.mu.Unlock()
+	require.Same(t, archived, tracked, "a refused create must keep the archived row under its original manager key")
+	require.Equal(t, originalTitle, archived.Title)
+	require.Equal(t, originalPath, archived.GetWorktreePath(), "a refused create must not relocate the archived worktree")
+	require.NotNil(t, recordFor(t, repoID, originalTitle), "the archived storage row must not be renamed")
+	require.NotNil(t, recordFor(t, repoID, diskOnlyTitle), "the disk-only claimant must remain untouched")
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -501,7 +501,11 @@ func refreshDaemonInstances(existing map[string]*session.Instance) (map[string]*
 				// flight if the persisted marker says so. Keep it counted against the
 				// task's cap (#1892), or a session we merely failed to LOAD would let the
 				// task admit a replacement beyond its limit.
-				if item.TaskID != "" && item.TaskRunActive {
+				// StartupStateUnknown is terminal by definition. New writers clear
+				// TaskRunActive on that transition, but keep this raw-row projection
+				// defensive for a record written by an intermediate/older build: a
+				// contradictory stale bit must not wedge max_concurrent_runs forever.
+				if item.TaskID != "" && item.TaskRunActive && !item.StartupStateUnknown {
 					ghostTaskRuns[taskRunReservationKey(repoID, item.TaskID)]++
 					log.WarningLog.Printf("watch task %s: session %q failed to load but its run is still counted against max_concurrent_runs (#1892); kill or repair the session to release its slot", item.TaskID, item.Title)
 				}

--- a/daemon/kill_commit_test.go
+++ b/daemon/kill_commit_test.go
@@ -366,6 +366,30 @@ func (b unsafeKillBackend) Kill(*session.Instance) error {
 	return fmt.Errorf("%w: leaving the workspace untouched", session.ErrPaneMayBeLive)
 }
 
+// retryFailedCreateBackend models a known startup failure whose first cleanup
+// cannot prove the workspace safe, followed by the successful retry
+// finishUserKill performs on a later status poll.
+type retryFailedCreateBackend struct {
+	readyFakeBackend
+	mu        sync.Mutex
+	killCalls int
+}
+
+func (b *retryFailedCreateBackend) Start(*session.Instance, bool) error {
+	return fmt.Errorf("agent program exited immediately")
+}
+
+func (b *retryFailedCreateBackend) Kill(instance *session.Instance) error {
+	b.mu.Lock()
+	b.killCalls++
+	call := b.killCalls
+	b.mu.Unlock()
+	if call == 1 {
+		return fmt.Errorf("%w: leaving the workspace untouched", session.ErrPaneMayBeLive)
+	}
+	return b.readyFakeBackend.Kill(instance)
+}
+
 // TestCreateSession_UnsafeCleanup_KeepsTheRecordAndTheTitle is round-3 finding (3).
 //
 // A failed create discards its instance and releases the title — correct, because
@@ -429,6 +453,61 @@ func TestCreateSession_UnsafeCleanup_KeepsTheRecordAndTheTitle(t *testing.T) {
 	manager.mu.Unlock()
 	if !tracked {
 		t.Fatal("the preserved session is not tracked, so the user cannot kill it through the product")
+	}
+}
+
+func TestFailedCreateCleanupRetryPublishesRemoval(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	backend := &retryFailedCreateBackend{readyFakeBackend: readyFakeBackend{session.NewFakeBackend()}}
+	restore := session.SetBackendFactoryForTest(func(session.InstanceOptions, string) (session.Backend, error) {
+		return backend, nil
+	})
+	t.Cleanup(restore)
+
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	_, events := manager.events.subscribe()
+
+	_, createErr := manager.CreateSession(context.Background(), CreateSessionRequest{
+		Title: "retry-cleanup", RepoPath: repoPath, Program: "claude",
+	})
+	if createErr == nil {
+		t.Fatal("CreateSession reported success though startup failed")
+	}
+	pendingType, pending := nextCreateLifecycleEvent(t, events)
+	settledType, settled := nextCreateLifecycleEvent(t, events)
+	if pendingType != agentproto.EventSessionUpdated || settledType != agentproto.EventSessionUpdated ||
+		settled.ID != pending.ID || !settled.UserKilled {
+		t.Fatalf("failed create did not publish one stable retained tombstone: pending=(%s, %+v) settled=(%s, %+v)", pendingType, pending, settledType, settled)
+	}
+
+	manager.mu.Lock()
+	inst := manager.instances[daemonInstanceKey(repo.ID, "retry-cleanup")]
+	manager.mu.Unlock()
+	if inst == nil {
+		t.Fatal("failed create was not retained for its cleanup retry")
+	}
+	manager.refreshInstanceStatus(repo.ID, inst)
+
+	removedType, removed := nextCreateLifecycleEvent(t, events)
+	if removedType != agentproto.EventSessionKilled || removed.ID != pending.ID || removed.Title != pending.Title {
+		t.Fatalf("cleanup retry removal event = (%s, %+v), want stable session.killed for %+v", removedType, removed, pending)
+	}
+	if rec := recordFor(t, repo.ID, "retry-cleanup"); rec != nil {
+		t.Fatalf("successful cleanup retry left storage row: %+v", rec)
+	}
+	manager.mu.Lock()
+	_, tracked := manager.instances[daemonInstanceKey(repo.ID, "retry-cleanup")]
+	manager.mu.Unlock()
+	if tracked {
+		t.Fatal("successful cleanup retry left the failed create tracked")
 	}
 }
 

--- a/daemon/kill_commit_test.go
+++ b/daemon/kill_commit_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sachiniyer/agent-factory/agentproto"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/git"
@@ -393,6 +394,7 @@ func TestCreateSession_UnsafeCleanup_KeepsTheRecordAndTheTitle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewManager: %v", err)
 	}
+	_, events := manager.events.subscribe()
 
 	_, cerr := manager.CreateSession(context.Background(), CreateSessionRequest{
 		Title: "leftover", RepoPath: repoPath, Program: "claude",
@@ -402,6 +404,17 @@ func TestCreateSession_UnsafeCleanup_KeepsTheRecordAndTheTitle(t *testing.T) {
 	}
 	if !strings.Contains(cerr.Error(), "recorded") {
 		t.Fatalf("the error must tell the user the session was preserved so they can act on it: %v", cerr)
+	}
+	pendingType, pending := nextCreateLifecycleEvent(t, events)
+	if pendingType != agentproto.EventSessionUpdated || pending.InFlightOp != session.OpCreating {
+		t.Fatalf("first create event = (%s, %+v), want pending session.updated", pendingType, pending)
+	}
+	settledType, settled := nextCreateLifecycleEvent(t, events)
+	if settledType != agentproto.EventSessionUpdated {
+		t.Fatalf("retained failed create event = %s, want session.updated; session.killed hides the cleanup tombstone from live clients", settledType)
+	}
+	if settled.ID != pending.ID || !settled.UserKilled || settled.InFlightOp != session.OpNone {
+		t.Fatalf("retained failed create did not settle the pending identity: pending=%+v settled=%+v", pending, settled)
 	}
 
 	// The leftovers must be addressable: a record holds the title, so the next

--- a/daemon/manager.go
+++ b/daemon/manager.go
@@ -40,6 +40,12 @@ type Manager struct {
 	// mutation lookups do not, so a half-built runtime cannot be acted on.
 	pendingCreates map[string]session.InstanceData
 	reservedTitles map[string]struct{}
+	// reservedTmuxNames closes the second namespace a local create claims. Titles
+	// such as "a/b" and "a_b" can derive distinct git branches but the same
+	// positive-policy tmux name; reserving only the raw title leaves that collision
+	// open until Start, after the worktree already exists. Keyed per repo by the
+	// exact sanitized tmux name; the value is the user-facing title for errors.
+	reservedTmuxNames map[string]string
 	// reservedRemoteNames holds in-flight remote-hook slug reservations, keyed by
 	// the BARE slug — deliberately global, unlike every other name a session owns.
 	//
@@ -247,6 +253,7 @@ func newManagerShellForDaemon(cfg *config.Config, transactionID string) (*Manage
 		instances:           make(map[string]*session.Instance),
 		pendingCreates:      make(map[string]session.InstanceData),
 		reservedTitles:      make(map[string]struct{}),
+		reservedTmuxNames:   make(map[string]string),
 		reservedRemoteNames: make(map[string]struct{}),
 		reservedTaskRuns:    make(map[string]int),
 		ghostTaskRuns:       make(map[string]int),

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -398,7 +398,10 @@ func (m *Manager) refuseHeldBranchReuseLocked(repoID, repoPath, title string, na
 	if namespace != runtimeNamespaceLocalTmux || inPlace {
 		return nil
 	}
-	archived, _ := m.findArchivedOnlyCollisionLocked(repoID, repoPath, title, namespace)
+	archived, _, err := m.findArchivedOnlyCollisionLocked(repoID, repoPath, title, namespace)
+	if err != nil {
+		return err
+	}
 	if archived == nil {
 		return nil
 	}
@@ -429,7 +432,10 @@ var reuseArchivedRenamePersist = renameInstanceDataTitle
 // the name, in which case the create is left to fail in validateTitleAvailableLocked
 // exactly as before. Runs under m.mu.
 func (m *Manager) renameArchivedForReuseLocked(repoID, repoPath, title, program string, namespace runtimeNameNamespace, diskData *[]session.InstanceData) (*session.InstanceData, error) {
-	archived, oldKey := m.findArchivedOnlyCollisionLocked(repoID, repoPath, title, namespace)
+	archived, oldKey, err := m.findArchivedOnlyCollisionLocked(repoID, repoPath, title, namespace)
+	if err != nil {
+		return nil, err
+	}
 	if archived == nil {
 		return nil, nil
 	}
@@ -531,25 +537,26 @@ func (m *Manager) renameArchivedForReuseLocked(repoID, repoPath, title, program 
 	return &renamed, nil
 }
 
-// findArchivedOnlyCollisionLocked returns the archived instance whose title
-// collides with `title`, together with its manager-map key — but ONLY when nothing
-// else claims the name: no LIVE (non-archived) instance and no in-flight
-// reservation collide with it. A live or reserved collision returns nil, so the
-// archived-name-reuse rename never runs around a name a real session still holds.
+// findArchivedOnlyCollisionLocked returns the ONE archived instance whose title
+// collides with `title`, together with its manager-map key — but only when it is
+// the sole claim. A live/reserved collision returns nil so ordinary availability
+// validation reports it. Multiple archived claims return an error immediately:
+// renaming an arbitrary map-iteration winner would mutate user state and still
+// leave the requested runtime name unavailable.
 // Runs under m.mu.
-func (m *Manager) findArchivedOnlyCollisionLocked(repoID, repoPath, title string, namespace runtimeNameNamespace) (*session.Instance, string) {
+func (m *Manager) findArchivedOnlyCollisionLocked(repoID, repoPath, title string, namespace runtimeNameNamespace) (*session.Instance, string, error) {
 	for key := range m.reservedTitles {
 		rid, existing := splitDaemonInstanceKey(key)
 		if rid == repoID && m.titlesCollide(existing, title) {
 			// A concurrent create is reserving a colliding name; let the
 			// availability check reject with errConcurrentCreate.
-			return nil, ""
+			return nil, "", nil
 		}
 	}
 	if namespace == runtimeNamespaceLocalTmux {
 		nameKey := daemonInstanceKey(repoID, tmux.SanitizedNameForRepo(title, repoPath))
 		if _, reserved := m.reservedTmuxNames[nameKey]; reserved {
-			return nil, ""
+			return nil, "", nil
 		}
 	}
 	var archived *session.Instance
@@ -565,12 +572,16 @@ func (m *Manager) findArchivedOnlyCollisionLocked(repoID, repoPath, title string
 		}
 		if inst.GetLiveness() != session.LiveArchived {
 			// A live session still holds the name — do not rename around it.
-			return nil, ""
+			return nil, "", nil
+		}
+		if archived != nil {
+			return nil, "", fmt.Errorf("cannot reuse session name %q: archived sessions %q and %q both claim its runtime namespace; rename or permanently delete one before retrying",
+				title, archived.Title, inst.Title)
 		}
 		archived = inst
 		archivedKey = key
 	}
-	return archived, archivedKey
+	return archived, archivedKey, nil
 }
 
 // uniqueArchivedTitleLocked returns the first free disambiguated title for an

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -302,7 +302,7 @@ func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, 
 		// discovering it at `git worktree add` leaves the archived session renamed
 		// for a create that then did not happen, which is exactly the state the
 		// admission comment above promises this function never produces.
-		if err := m.refuseHeldBranchReuseLocked(repo.ID, repo.Root, title, nameNamespace, req.InPlace); err != nil {
+		if err := m.refuseHeldBranchReuseLocked(repo.ID, repo.Root, title, nameNamespace, req.InPlace, diskData); err != nil {
 			return nil, "", nil, nil, err
 		}
 		renamedArchived, err = m.renameArchivedForReuseLocked(repo.ID, repo.Root, title, req.Program, nameNamespace, &diskData)
@@ -404,11 +404,11 @@ func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, 
 //     failed probe the create proceeds and, if the branch really is held, fails
 //     loudly at `git worktree add`: precisely the pre-guard behavior, which
 //     destroyed nothing. Only a branch git POSITIVELY reports as held refuses.
-func (m *Manager) refuseHeldBranchReuseLocked(repoID, repoPath, title string, namespace runtimeNameNamespace, inPlace bool) error {
+func (m *Manager) refuseHeldBranchReuseLocked(repoID, repoPath, title string, namespace runtimeNameNamespace, inPlace bool, diskData []session.InstanceData) error {
 	if namespace != runtimeNamespaceLocalTmux || inPlace {
 		return nil
 	}
-	archived, _, err := m.findArchivedOnlyCollisionLocked(repoID, repoPath, title, namespace)
+	archived, _, err := m.findArchivedOnlyCollisionLocked(repoID, repoPath, title, namespace, diskData)
 	if err != nil {
 		return err
 	}
@@ -442,7 +442,7 @@ var reuseArchivedRenamePersist = renameInstanceDataTitle
 // the name, in which case the create is left to fail in validateTitleAvailableLocked
 // exactly as before. Runs under m.mu.
 func (m *Manager) renameArchivedForReuseLocked(repoID, repoPath, title, program string, namespace runtimeNameNamespace, diskData *[]session.InstanceData) (*session.InstanceData, error) {
-	archived, oldKey, err := m.findArchivedOnlyCollisionLocked(repoID, repoPath, title, namespace)
+	archived, oldKey, err := m.findArchivedOnlyCollisionLocked(repoID, repoPath, title, namespace, *diskData)
 	if err != nil {
 		return nil, err
 	}
@@ -547,14 +547,15 @@ func (m *Manager) renameArchivedForReuseLocked(repoID, repoPath, title, program 
 	return &renamed, nil
 }
 
-// findArchivedOnlyCollisionLocked returns the ONE archived instance whose title
-// collides with `title`, together with its manager-map key — but only when it is
-// the sole claim. A live/reserved collision returns nil so ordinary availability
-// validation reports it. Multiple archived claims return an error immediately:
-// renaming an arbitrary map-iteration winner would mutate user state and still
-// leave the requested runtime name unavailable.
+// findArchivedOnlyCollisionLocked returns the ONE loaded archived instance whose
+// title collides with `title`, together with its manager-map key — but only when
+// it is the sole claim across reservations, loaded instances, and durable rows.
+// A live/reserved collision returns nil so ordinary availability validation
+// reports it. Multiple claims return an error immediately: renaming an arbitrary
+// loaded winner would mutate user state and still leave the requested runtime
+// name unavailable.
 // Runs under m.mu.
-func (m *Manager) findArchivedOnlyCollisionLocked(repoID, repoPath, title string, namespace runtimeNameNamespace) (*session.Instance, string, error) {
+func (m *Manager) findArchivedOnlyCollisionLocked(repoID, repoPath, title string, namespace runtimeNameNamespace, diskData []session.InstanceData) (*session.Instance, string, error) {
 	for key := range m.reservedTitles {
 		rid, existing := splitDaemonInstanceKey(key)
 		if rid == repoID && m.titlesCollide(existing, title) {
@@ -590,6 +591,32 @@ func (m *Manager) findArchivedOnlyCollisionLocked(repoID, repoPath, title string
 		}
 		archived = inst
 		archivedKey = key
+	}
+	if archived == nil {
+		// A disk-only claim will be rejected by the ordinary availability check.
+		// With no loaded archived row there is nothing this helper could mutate,
+		// so leave that path's established diagnostic in charge.
+		return nil, "", nil
+	}
+
+	// diskData contains the persisted copy of the loaded archived row as well as
+	// rows refreshLocked could not materialize. Consume exactly ONE matching copy
+	// of the loaded row; every other colliding non-Loading record is an independent
+	// namespace claim. Checking it before RenameArchived is load-bearing: the
+	// later availability check also sees disk-only rows, but by then the archive's
+	// worktree, title, manager key, and storage row have already been rewritten.
+	matchedPersistedCopy := false
+	for _, data := range diskData {
+		bothUseLocalTmux := namespace == runtimeNamespaceLocalTmux && data.UsesLocalTmux()
+		if m.titleCollisionNamespace(repoPath, data.Title, title, bothUseLocalTmux) == titleNamespaceNone || data.Status == session.Loading {
+			continue
+		}
+		if !matchedPersistedCopy && data.Title == archived.Title && data.ID == archived.ID {
+			matchedPersistedCopy = true
+			continue
+		}
+		return nil, "", fmt.Errorf("cannot reuse session name %q: archived session %q and stored session %q both claim its runtime namespace; rename or permanently delete one before retrying",
+			title, archived.Title, data.Title)
 	}
 	return archived, archivedKey, nil
 }

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -248,22 +248,23 @@ func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, 
 		return nil, "", nil, nil, err
 	}
 
-	// Whether this create lands on the HOOK backend — the one runtime whose name
-	// is a global namespace. ForceRemote is only ONE of three ways to get there:
-	// `--backend hook` and a repo's `backend = "hook"` config both select it with
-	// ForceRemote false, and gating the hook-name checks on ForceRemote alone let
-	// those creates hand scripts a colliding --name. Ask the factory the same
-	// question it will answer at provision time.
-	usesHook := req.ForceRemote
+	// Resolve the runtime once for every namespace decision below. Hook creates
+	// claim a global external slug; local creates claim a repo-scoped tmux name;
+	// docker/ssh claim neither on this host. ForceRemote is only one way to select
+	// hook, so ask the same resolver NewInstance uses.
+	runtimeKind := session.BackendLocal
+	if req.ForceRemote {
+		runtimeKind = session.BackendHook
+	}
 	if kind, kerr := session.BackendKindFor(session.InstanceOptions{
 		Backend:     session.BackendKind(req.Backend),
 		ForceRemote: req.ForceRemote,
 	}, repo.Root); kerr == nil {
-		usesHook = kind == session.BackendHook
+		runtimeKind = kind
 	}
-	// A kerr here means an invalid `backend` value; leave usesHook at the legacy
-	// ForceRemote answer and let NewInstance surface the canonical error rather
-	// than duplicating its wording at a different point in the flow.
+	// A kerr means an invalid backend value. Leave the conservative default above
+	// and let NewInstance surface the canonical error rather than duplicating it.
+	nameNamespace := runtimeNamespaceForKind(runtimeKind)
 
 	var renamedArchived *session.InstanceData
 	title := req.Title
@@ -275,7 +276,7 @@ func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, 
 		// A derived title_base keeps auto-suffixing around every existing session,
 		// archived rows included — the archived-name-reuse rename is reserved for an
 		// EXPLICIT title the caller asked for by name (below).
-		title, err = m.nextAvailableTitleLocked(repo.ID, repo.Root, base, req.Program, usesHook, diskData)
+		title, err = m.nextAvailableTitleLocked(repo.ID, repo.Root, base, req.Program, nameNamespace, diskData)
 		if err != nil {
 			return nil, "", nil, nil, err
 		}
@@ -291,21 +292,25 @@ func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, 
 		// discovering it at `git worktree add` leaves the archived session renamed
 		// for a create that then did not happen, which is exactly the state the
 		// admission comment above promises this function never produces.
-		if err := m.refuseHeldBranchReuseLocked(repo.ID, repo.Root, title, usesHook, req.InPlace); err != nil {
+		if err := m.refuseHeldBranchReuseLocked(repo.ID, repo.Root, title, nameNamespace, req.InPlace); err != nil {
 			return nil, "", nil, nil, err
 		}
-		renamedArchived, err = m.renameArchivedForReuseLocked(repo.ID, repo.Root, title, req.Program, &diskData)
+		renamedArchived, err = m.renameArchivedForReuseLocked(repo.ID, repo.Root, title, req.Program, nameNamespace, &diskData)
 		if err != nil {
 			return nil, "", nil, nil, err
 		}
-		if err := m.validateTitleAvailableLocked(repo.ID, repo.Root, title, req.Program, usesHook, req.allowReserved, diskData); err != nil {
+		if err := m.validateTitleAvailableLocked(repo.ID, repo.Root, title, req.Program, nameNamespace, req.allowReserved, diskData); err != nil {
 			return nil, "", nil, nil, err
 		}
 	}
 
 	key := daemonInstanceKey(repo.ID, title)
+	tmuxReservationKey := ""
+	if nameNamespace == runtimeNamespaceLocalTmux {
+		tmuxReservationKey = daemonInstanceKey(repo.ID, tmux.SanitizedNameForRepo(title, repo.Root))
+	}
 	remoteName := ""
-	if usesHook {
+	if nameNamespace == runtimeNamespaceRemoteHook {
 		// Keyed by the BARE slug on purpose: it is the exact string the hook
 		// scripts receive as --name, and that namespace is global (see
 		// reservedRemoteNames).
@@ -321,6 +326,12 @@ func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, 
 	// returns the release() only on success); m.mu has been held unbroken since
 	// admitTaskRunLocked, so the count is exactly what admission saw.
 	m.reservedTitles[key] = struct{}{}
+	if tmuxReservationKey != "" {
+		if m.reservedTmuxNames == nil {
+			m.reservedTmuxNames = make(map[string]string)
+		}
+		m.reservedTmuxNames[tmuxReservationKey] = title
+	}
 	if remoteName != "" {
 		m.reservedRemoteNames[remoteName] = struct{}{}
 	}
@@ -329,6 +340,9 @@ func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, 
 		m.mu.Lock()
 		defer m.mu.Unlock()
 		delete(m.reservedTitles, key)
+		if tmuxReservationKey != "" {
+			delete(m.reservedTmuxNames, tmuxReservationKey)
+		}
 		if remoteName != "" {
 			delete(m.reservedRemoteNames, remoteName)
 		}
@@ -380,11 +394,11 @@ func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, 
 //     failed probe the create proceeds and, if the branch really is held, fails
 //     loudly at `git worktree add`: precisely the pre-guard behavior, which
 //     destroyed nothing. Only a branch git POSITIVELY reports as held refuses.
-func (m *Manager) refuseHeldBranchReuseLocked(repoID, repoPath, title string, remote, inPlace bool) error {
-	if remote || inPlace {
+func (m *Manager) refuseHeldBranchReuseLocked(repoID, repoPath, title string, namespace runtimeNameNamespace, inPlace bool) error {
+	if namespace != runtimeNamespaceLocalTmux || inPlace {
 		return nil
 	}
-	archived, _ := m.findArchivedOnlyCollisionLocked(repoID, title)
+	archived, _ := m.findArchivedOnlyCollisionLocked(repoID, repoPath, title, namespace)
 	if archived == nil {
 		return nil
 	}
@@ -414,8 +428,8 @@ var reuseArchivedRenamePersist = renameInstanceDataTitle
 // rename happened — no archived collision, or a LIVE/reserved session also holds
 // the name, in which case the create is left to fail in validateTitleAvailableLocked
 // exactly as before. Runs under m.mu.
-func (m *Manager) renameArchivedForReuseLocked(repoID, repoPath, title, program string, diskData *[]session.InstanceData) (*session.InstanceData, error) {
-	archived, oldKey := m.findArchivedOnlyCollisionLocked(repoID, title)
+func (m *Manager) renameArchivedForReuseLocked(repoID, repoPath, title, program string, namespace runtimeNameNamespace, diskData *[]session.InstanceData) (*session.InstanceData, error) {
+	archived, oldKey := m.findArchivedOnlyCollisionLocked(repoID, repoPath, title, namespace)
 	if archived == nil {
 		return nil, nil
 	}
@@ -425,8 +439,13 @@ func (m *Manager) renameArchivedForReuseLocked(repoID, repoPath, title, program 
 	// Slugify(newTitle), so that slug has to be free in the GLOBAL hook namespace
 	// too — otherwise the rename quietly parks it on a name another project's
 	// sandbox already owns.
-	archivedIsHook := archived.ToInstanceData().IsRemoteHook()
-	newTitle, err := m.uniqueArchivedTitleLocked(repoID, repoPath, oldTitle, program, archivedIsHook, *diskData)
+	archivedNamespace := runtimeNamespaceSandbox
+	if archived.Capabilities().Workspace == session.WorkspaceLocalWorktree {
+		archivedNamespace = runtimeNamespaceLocalTmux
+	} else if archived.ToInstanceData().IsRemoteHook() {
+		archivedNamespace = runtimeNamespaceRemoteHook
+	}
+	newTitle, err := m.uniqueArchivedTitleLocked(repoID, repoPath, oldTitle, program, archivedNamespace, *diskData)
 	if err != nil {
 		return nil, err
 	}
@@ -518,12 +537,18 @@ func (m *Manager) renameArchivedForReuseLocked(repoID, repoPath, title, program 
 // reservation collide with it. A live or reserved collision returns nil, so the
 // archived-name-reuse rename never runs around a name a real session still holds.
 // Runs under m.mu.
-func (m *Manager) findArchivedOnlyCollisionLocked(repoID, title string) (*session.Instance, string) {
+func (m *Manager) findArchivedOnlyCollisionLocked(repoID, repoPath, title string, namespace runtimeNameNamespace) (*session.Instance, string) {
 	for key := range m.reservedTitles {
 		rid, existing := splitDaemonInstanceKey(key)
 		if rid == repoID && m.titlesCollide(existing, title) {
 			// A concurrent create is reserving a colliding name; let the
 			// availability check reject with errConcurrentCreate.
+			return nil, ""
+		}
+	}
+	if namespace == runtimeNamespaceLocalTmux {
+		nameKey := daemonInstanceKey(repoID, tmux.SanitizedNameForRepo(title, repoPath))
+		if _, reserved := m.reservedTmuxNames[nameKey]; reserved {
 			return nil, ""
 		}
 	}
@@ -534,7 +559,8 @@ func (m *Manager) findArchivedOnlyCollisionLocked(repoID, title string) (*sessio
 		if rid != repoID || inst == nil {
 			continue
 		}
-		if !m.titlesCollide(inst.Title, title) {
+		bothUseLocalTmux := namespace == runtimeNamespaceLocalTmux && inst.Capabilities().Workspace == session.WorkspaceLocalWorktree
+		if m.titleCollisionNamespace(repoPath, inst.Title, title, bothUseLocalTmux) == titleNamespaceNone {
 			continue
 		}
 		if inst.GetLiveness() != session.LiveArchived {
@@ -556,13 +582,13 @@ func (m *Manager) findArchivedOnlyCollisionLocked(repoID, title string) (*sessio
 // session, which keeps the branch it already has checked out. The new title is a
 // label, not a branch to be created, so "is this branch checked out somewhere" is
 // not a question about it.
-func (m *Manager) uniqueArchivedTitleLocked(repoID, repoPath, base, program string, remote bool, diskData []session.InstanceData) (string, error) {
+func (m *Manager) uniqueArchivedTitleLocked(repoID, repoPath, base, program string, namespace runtimeNameNamespace, diskData []session.InstanceData) (string, error) {
 	for i := 1; i <= 10000; i++ {
 		candidate := fmt.Sprintf("%s (archived)", base)
 		if i > 1 {
 			candidate = fmt.Sprintf("%s (archived %d)", base, i)
 		}
-		err := m.validateTitleAvailableLocked(repoID, repoPath, candidate, program, remote, false, diskData)
+		err := m.validateTitleAvailableLocked(repoID, repoPath, candidate, program, namespace, false, diskData)
 		if err == nil {
 			return candidate, nil
 		}
@@ -573,7 +599,7 @@ func (m *Manager) uniqueArchivedTitleLocked(repoID, repoPath, base, program stri
 	return "", fmt.Errorf("could not find an available archived name for %q", base)
 }
 
-func (m *Manager) nextAvailableTitleLocked(repoID, repoPath, baseTitle, program string, remote bool, diskData []session.InstanceData) (string, error) {
+func (m *Manager) nextAvailableTitleLocked(repoID, repoPath, baseTitle, program string, namespace runtimeNameNamespace, diskData []session.InstanceData) (string, error) {
 	// Session records are not the only thing that can make a candidate unusable
 	// (#2091). A branch already CHECKED OUT by some worktree cannot be checked
 	// out again, and archiving relocates a worktree rather than removing it
@@ -584,7 +610,7 @@ func (m *Manager) nextAvailableTitleLocked(repoID, repoPath, baseTitle, program 
 	// So ask the one component that knows which branches are checked out
 	// somewhere, ONCE per walk, and skip those rungs instead of discovering the
 	// collision at add time.
-	heldBranches := m.worktreeHeldBranchesLocked(repoPath, remote)
+	heldBranches := m.worktreeHeldBranchesLocked(repoPath, namespace != runtimeNamespaceLocalTmux)
 	for i := 1; i <= 10000; i++ {
 		candidate := baseTitle
 		if i > 1 {
@@ -596,7 +622,7 @@ func (m *Manager) nextAvailableTitleLocked(repoID, repoPath, baseTitle, program 
 				candidate, branch, holder)
 			continue
 		}
-		err := m.validateTitleAvailableLocked(repoID, repoPath, candidate, program, remote, false, diskData)
+		err := m.validateTitleAvailableLocked(repoID, repoPath, candidate, program, namespace, false, diskData)
 		if err == nil {
 			return candidate, nil
 		}
@@ -610,7 +636,7 @@ func (m *Manager) nextAvailableTitleLocked(repoID, repoPath, baseTitle, program 
 	return "", fmt.Errorf("could not find an available title for %q", baseTitle)
 }
 
-func (m *Manager) validateTitleAvailableLocked(repoID, repoPath, title, program string, remote, allowReserved bool, diskData []session.InstanceData) error {
+func (m *Manager) validateTitleAvailableLocked(repoID, repoPath, title, program string, namespace runtimeNameNamespace, allowReserved bool, diskData []session.InstanceData) error {
 	// Whitespace-only titles (e.g. "   ") are non-empty and so slip past a bare
 	// == "" check, creating sessions with effectively blank names (#973). Trim
 	// before the emptiness gate; the TUI naming flow applies the same check.
@@ -632,18 +658,20 @@ func (m *Manager) validateTitleAvailableLocked(repoID, repoPath, title, program 
 	// (#605) or "A B"/"a-b" (#741) both collide. The second worktree create
 	// would otherwise fail with a cryptic git error, so reject the conflict
 	// here, before any worktree or tmux setup runs.
-	if existing, kind := m.findTitleConflictLocked(repoID, title, diskData); existing != "" {
+	if existing, kind, collisionNamespace := m.findTitleConflictLocked(repoID, repoPath, title, namespace == runtimeNamespaceLocalTmux, diskData); existing != "" {
 		switch {
 		case existing == title:
 			if kind == titleConflictReserved {
 				return fmt.Errorf("session with title %q is already reserved: %w", title, errConcurrentCreate)
 			}
 			return fmt.Errorf("session with title %q already exists: %w", title, errConcurrentCreate)
+		case collisionNamespace == titleNamespaceTmux:
+			return fmt.Errorf("session titled %q conflicts with existing session %q: both map to tmux session %q", title, existing, tmux.SanitizedNameForRepo(title, repoPath))
 		default:
 			return fmt.Errorf("session titled %q conflicts with existing session %q: both sanitize to the same git branch %q", title, existing, m.branchForTitle(title))
 		}
 	}
-	if remote {
+	if namespace == runtimeNamespaceRemoteHook {
 		candidate := session.Slugify(title)
 		// Hook names are the ONE namespace that stays global while titles go
 		// per-repo: launch_cmd/delete_cmd receive `--name <slug>` verbatim, with
@@ -696,6 +724,9 @@ func (m *Manager) validateTitleAvailableLocked(repoID, repoPath, title, program 
 		if owner != "" {
 			return fmt.Errorf("remote session titled %q in project %s already maps to hook name %q; remote hook names are shared across projects because the hook scripts receive them verbatim as --name — pick another title for this remote session", owner, ownerRepo, candidate)
 		}
+		return nil
+	}
+	if namespace != runtimeNamespaceLocalTmux {
 		return nil
 	}
 	tmuxSession := tmux.NewTmuxSessionForRepo(title, repoPath, program)
@@ -778,64 +809,6 @@ func hookSlugOwnerInOtherRepos(candidate, repoID string) (string, string, error)
 // available title", swallowing the actionable corruption message. Callers check
 // errors.Is and surface it instead of suffixing around it.
 var errTitleCheckFatal = errors.New("cannot verify title availability")
-
-type titleConflictKind int
-
-const (
-	titleConflictNone titleConflictKind = iota
-	titleConflictReserved
-	titleConflictLive
-	titleConflictDisk
-)
-
-// findTitleConflictLocked returns the existing title that conflicts with the
-// given candidate, along with the source of the conflict. An empty result means
-// the title is available. Two titles conflict when they derive the same git
-// branch name: branches are produced by git.SanitizeBranchName, which lowercases
-// and normalizes (spaces -> dashes, unsafe chars stripped, dashes collapsed),
-// so distinct titles like "MyApp"/"myapp" (#605) or "A B"/"a-b" (#741) can map
-// to one branch. Rejecting the collision here keeps the second worktree create
-// from failing with a cryptic git error.
-func (m *Manager) findTitleConflictLocked(repoID, title string, diskData []session.InstanceData) (string, titleConflictKind) {
-	for key := range m.reservedTitles {
-		rid, existing := splitDaemonInstanceKey(key)
-		if rid == repoID && m.titlesCollide(existing, title) {
-			return existing, titleConflictReserved
-		}
-	}
-	for key, inst := range m.instances {
-		rid, _ := splitDaemonInstanceKey(key)
-		if rid != repoID || inst == nil {
-			continue
-		}
-		if m.titlesCollide(inst.Title, title) {
-			return inst.Title, titleConflictLive
-		}
-	}
-	for _, data := range diskData {
-		if !m.titlesCollide(data.Title, title) {
-			continue
-		}
-		// Loading entries are transient TUI state with an empty worktree
-		// path and cannot be restored. Older TUI binaries (#551) could
-		// persist them to disk on quit, where they would block title
-		// reuse forever. Treat them as ghosts that the next save will
-		// reap rather than as live reservations.
-		if data.Status == session.Loading {
-			continue
-		}
-		return data.Title, titleConflictDisk
-	}
-	return "", titleConflictNone
-}
-
-// titlesCollide reports whether two session titles cannot coexist in the same
-// repo because they would derive the same git branch. It delegates to the shared
-// git.TitlesCollide helper so the daemon's authoritative validation and the
-// TUI's naming pre-check stay in lockstep (#936).
-func (m *Manager) titlesCollide(a, b string) bool {
-	return git.TitlesCollide(a, b, m.cfg.BranchPrefix)
-}
 
 // branchesHeldByWorktrees is the git query worktreeHeldBranchesLocked runs. A
 // package var so tests can force the probe to FAIL in isolation — the answer

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -88,18 +88,26 @@ func (m *Manager) CreateSession(ctx context.Context, req CreateSessionRequest) (
 	m.mu.Unlock()
 	m.publishEvent(agentproto.EventSessionUpdated, pending)
 
-	createSucceeded := false
+	// Tracks whether the provisional client row was replaced by any durable
+	// outcome, not merely whether CreateSession returns nil. Retained failures are
+	// real rows too: deleting their provisional identity from live clients would
+	// hide the only handle that can inspect or clean up the uncertain workspace.
+	creatingProjectionSettled := false
 	defer func() {
 		m.mu.Lock()
 		delete(m.pendingCreates, key)
 		m.mu.Unlock()
-		if !createSucceeded {
+		if !creatingProjectionSettled {
 			// Delete-class events are id-keyed, so a client removes exactly the
 			// provisional row even when another repo has the same title. A missed
 			// event is repaired by Snapshot, which no longer contains the pending row.
 			m.publishEvent(agentproto.EventSessionKilled, session.InstanceData{ID: pending.ID, Title: title})
 		}
 	}()
+	settleRetainedCreate := func(instance *session.Instance) {
+		creatingProjectionSettled = true
+		m.publishEvent(agentproto.EventSessionUpdated, instance.ToInstanceData())
+	}
 
 	repoStartLock := m.startLockForRepo(repo.ID)
 	repoStartLock.Lock()
@@ -141,6 +149,7 @@ func (m *Manager) CreateSession(ctx context.Context, req CreateSessionRequest) (
 				return session.InstanceData{}, fmt.Errorf("failed to start instance %q, and its startup outcome could not be determined safely — its workspace may still be on disk at %s and could not be recorded, so it must be inspected and cleaned up by hand: %w",
 					title, instance.GetWorktreePath(), errors.Join(serr, keepErr))
 			}
+			settleRetainedCreate(instance)
 			return session.InstanceData{}, fmt.Errorf("failed to start instance %q, and its startup outcome could not be determined safely, so its workspace was left in place; the session is recorded for inspection and no automatic cleanup will run: %w",
 				title, serr)
 		}
@@ -170,6 +179,7 @@ func (m *Manager) CreateSession(ctx context.Context, req CreateSessionRequest) (
 				return session.InstanceData{}, fmt.Errorf("failed to start instance %q, and its cleanup could not complete safely — its workspace may still be on disk at %s and could not be recorded, so it must be cleaned up by hand: %w",
 					title, instance.GetWorktreePath(), errors.Join(serr, killErr, keepErr))
 			}
+			settleRetainedCreate(instance)
 			return session.InstanceData{}, fmt.Errorf("failed to start instance %q, and its cleanup could not complete safely, so its workspace was left in place; the session is recorded and the daemon will keep retrying the cleanup — it will clear once that succeeds: %w",
 				title, errors.Join(serr, killErr))
 		}
@@ -205,7 +215,7 @@ func (m *Manager) CreateSession(ctx context.Context, req CreateSessionRequest) (
 		return session.InstanceData{}, persistErr
 	}
 	m.captureAgentConversationAsync(repo.ID, key, instance, conversationCapture)
-	createSucceeded = true
+	creatingProjectionSettled = true
 	// Publish from the Manager, not only the control-server wrapper: task delivery
 	// and root-agent ensure call Manager.CreateSession directly. They announced the
 	// same pending row above and therefore must settle it on the same events plane.

--- a/daemon/manager_create_names.go
+++ b/daemon/manager_create_names.go
@@ -1,0 +1,116 @@
+package daemon
+
+import (
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/git"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// runtimeNameNamespace is the extra (non-title) name a backend claims during
+// create admission. The enum makes the alternatives exclusive: a create cannot
+// accidentally be treated as both a local tmux runtime and a remote hook, which
+// two independent booleans would permit.
+type runtimeNameNamespace uint8
+
+const (
+	runtimeNamespaceSandbox runtimeNameNamespace = iota
+	runtimeNamespaceLocalTmux
+	runtimeNamespaceRemoteHook
+)
+
+func runtimeNamespaceForKind(kind session.BackendKind) runtimeNameNamespace {
+	switch kind {
+	case session.BackendLocal:
+		return runtimeNamespaceLocalTmux
+	case session.BackendHook:
+		return runtimeNamespaceRemoteHook
+	default:
+		return runtimeNamespaceSandbox
+	}
+}
+
+type titleConflictKind int
+
+const (
+	titleConflictNone titleConflictKind = iota
+	titleConflictReserved
+	titleConflictLive
+	titleConflictDisk
+)
+
+type titleNamespace int
+
+const (
+	titleNamespaceNone titleNamespace = iota
+	titleNamespaceBranch
+	titleNamespaceTmux
+)
+
+// titleCollisionNamespace asks every name encoder a pair of local sessions will
+// actually claim. Git and tmux intentionally have different grammars, so either
+// one may collide while the other does not. The tmux half is enabled only when
+// both records use the host-local runtime.
+func (m *Manager) titleCollisionNamespace(repoPath, a, b string, bothUseLocalTmux bool) titleNamespace {
+	if m.titlesCollide(a, b) {
+		return titleNamespaceBranch
+	}
+	if bothUseLocalTmux && tmux.SanitizedNameForRepo(a, repoPath) == tmux.SanitizedNameForRepo(b, repoPath) {
+		return titleNamespaceTmux
+	}
+	return titleNamespaceNone
+}
+
+// findTitleConflictLocked returns the existing title that conflicts with the
+// given candidate, along with the source and namespace of the conflict. An empty
+// result means the title is available. Local sessions claim both a git branch and
+// a tmux session name; admission rejects either collision before creating a
+// worktree or launching a runtime.
+func (m *Manager) findTitleConflictLocked(repoID, repoPath, title string, localTmux bool, diskData []session.InstanceData) (string, titleConflictKind, titleNamespace) {
+	for key := range m.reservedTitles {
+		rid, existing := splitDaemonInstanceKey(key)
+		if rid == repoID && m.titlesCollide(existing, title) {
+			return existing, titleConflictReserved, titleNamespaceBranch
+		}
+	}
+	if localTmux {
+		nameKey := daemonInstanceKey(repoID, tmux.SanitizedNameForRepo(title, repoPath))
+		if existing, reserved := m.reservedTmuxNames[nameKey]; reserved {
+			return existing, titleConflictReserved, titleNamespaceTmux
+		}
+	}
+	for key, inst := range m.instances {
+		rid, _ := splitDaemonInstanceKey(key)
+		if rid != repoID || inst == nil {
+			continue
+		}
+		bothUseLocalTmux := localTmux && inst.Capabilities().Workspace == session.WorkspaceLocalWorktree
+		if namespace := m.titleCollisionNamespace(repoPath, inst.Title, title, bothUseLocalTmux); namespace != titleNamespaceNone {
+			return inst.Title, titleConflictLive, namespace
+		}
+	}
+	for _, data := range diskData {
+		bothUseLocalTmux := localTmux && data.UsesLocalTmux()
+		namespace := m.titleCollisionNamespace(repoPath, data.Title, title, bothUseLocalTmux)
+		if namespace == titleNamespaceNone {
+			continue
+		}
+		// Loading entries are transient TUI state with an empty worktree
+		// path and cannot be restored. Older TUI binaries (#551) could
+		// persist them to disk on quit, where they would block title
+		// reuse forever. Treat them as ghosts that the next save will
+		// reap rather than as live reservations.
+		if data.Status == session.Loading {
+			continue
+		}
+		return data.Title, titleConflictDisk, namespace
+	}
+	return "", titleConflictNone, titleNamespaceNone
+}
+
+// titlesCollide reports whether two session titles cannot coexist in the same
+// repo because they would derive the same git branch. It delegates to the shared
+// git.TitlesCollide helper so the daemon's authoritative validation and the
+// TUI's naming pre-check stay in lockstep (#936).
+func (m *Manager) titlesCollide(a, b string) bool {
+	return git.TitlesCollide(a, b, m.cfg.BranchPrefix)
+}

--- a/daemon/perrepo_title_test.go
+++ b/daemon/perrepo_title_test.go
@@ -219,7 +219,7 @@ func TestHookNameNamespaceIsGlobalAcrossRepos(t *testing.T) {
 	t.Run("concurrent create in another repo is refused", func(t *testing.T) {
 		manager.mu.Lock()
 		manager.reservedRemoteNames[session.Slugify(existingTitle)] = struct{}{}
-		err := manager.validateTitleAvailableLocked(repoB.ID, repoB.Root, newTitle, "claude", true, false, nil)
+		err := manager.validateTitleAvailableLocked(repoB.ID, repoB.Root, newTitle, "claude", runtimeNamespaceRemoteHook, false, nil)
 		delete(manager.reservedRemoteNames, session.Slugify(existingTitle))
 		manager.mu.Unlock()
 		if err == nil {
@@ -241,7 +241,7 @@ func TestHookNameNamespaceIsGlobalAcrossRepos(t *testing.T) {
 		manager.instances[daemonInstanceKey(repoA.ID, existingTitle)] = inst
 		// No reservation entry — the create in repo A has SETTLED. This is the
 		// sequential case the repo-filtered scan used to let through.
-		err = manager.validateTitleAvailableLocked(repoB.ID, repoB.Root, newTitle, "claude", true, false, nil)
+		err = manager.validateTitleAvailableLocked(repoB.ID, repoB.Root, newTitle, "claude", runtimeNamespaceRemoteHook, false, nil)
 		delete(manager.instances, daemonInstanceKey(repoA.ID, existingTitle))
 		manager.mu.Unlock()
 		if err == nil {
@@ -267,7 +267,7 @@ func TestHookNameNamespaceIsGlobalAcrossRepos(t *testing.T) {
 		t.Cleanup(func() { _ = config.SaveRepoInstances(repoA.ID, json.RawMessage("[]")) })
 
 		manager.mu.Lock()
-		err = manager.validateTitleAvailableLocked(repoB.ID, repoB.Root, newTitle, "claude", true, false, nil)
+		err = manager.validateTitleAvailableLocked(repoB.ID, repoB.Root, newTitle, "claude", runtimeNamespaceRemoteHook, false, nil)
 		manager.mu.Unlock()
 		if err == nil {
 			t.Fatalf("a persisted hook session in another repo must block the name")
@@ -316,7 +316,7 @@ func TestHookNameNamespaceIsGlobalAcrossRepos(t *testing.T) {
 
 	t.Run("a free hook name is still allowed", func(t *testing.T) {
 		manager.mu.Lock()
-		err := manager.validateTitleAvailableLocked(repoB.ID, repoB.Root, "totally-unused", "claude", true, false, nil)
+		err := manager.validateTitleAvailableLocked(repoB.ID, repoB.Root, "totally-unused", "claude", runtimeNamespaceRemoteHook, false, nil)
 		manager.mu.Unlock()
 		if err != nil {
 			t.Fatalf("an unused hook name must be available: %v", err)
@@ -445,7 +445,7 @@ func TestArchivedHookRenameChecksGlobalSlug(t *testing.T) {
 	// Picking a replacement name for an archived HOOK row must consult the global
 	// hook namespace and skip past the slug repo A owns.
 	manager.mu.Lock()
-	got, err := manager.uniqueArchivedTitleLocked(repoB.ID, repoB.Root, base, "claude", true, nil)
+	got, err := manager.uniqueArchivedTitleLocked(repoB.ID, repoB.Root, base, "claude", runtimeNamespaceRemoteHook, nil)
 	manager.mu.Unlock()
 	if err != nil {
 		t.Fatalf("uniqueArchivedTitleLocked: %v", err)
@@ -457,7 +457,7 @@ func TestArchivedHookRenameChecksGlobalSlug(t *testing.T) {
 	// A non-hook archived row is unaffected: titles are per-repo, so it may take
 	// the same name repo A's hook session uses.
 	manager.mu.Lock()
-	local, err := manager.uniqueArchivedTitleLocked(repoB.ID, repoB.Root, base, "claude", false, nil)
+	local, err := manager.uniqueArchivedTitleLocked(repoB.ID, repoB.Root, base, "claude", runtimeNamespaceLocalTmux, nil)
 	manager.mu.Unlock()
 	if err != nil {
 		t.Fatalf("local uniqueArchivedTitleLocked: %v", err)
@@ -494,7 +494,7 @@ func TestNextAvailableTitlePropagatesFatalHookCheckError(t *testing.T) {
 	}
 
 	manager.mu.Lock()
-	got, err := manager.nextAvailableTitleLocked(repoB.ID, repoB.Root, "base", "claude", true, nil)
+	got, err := manager.nextAvailableTitleLocked(repoB.ID, repoB.Root, "base", "claude", runtimeNamespaceRemoteHook, nil)
 	manager.mu.Unlock()
 
 	if err == nil {

--- a/daemon/rootkill.go
+++ b/daemon/rootkill.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"github.com/sachiniyer/agent-factory/agentproto"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 )
@@ -162,9 +163,11 @@ func (m *Manager) finishUserKill(repoID string, instance *session.Instance) {
 		log.InfoLog.Printf("finishing kill of %q skipped storage delete: current record has a different instance identity", instance.Title)
 		return
 	}
+	removed := false
 	m.mu.Lock()
 	if m.instances[key] == instance {
 		delete(m.instances, key)
+		removed = true
 	}
 	if session.IsReservedTitle(instance.Title) {
 		// Arm the grace window the interrupted KillSession never reached
@@ -179,4 +182,12 @@ func (m *Manager) finishUserKill(repoID string, instance *session.Instance) {
 		log.InfoLog.Printf("root agent for repo %s: finished an interrupted user kill; the ensure loop will re-create it in ~%s unless the repo is removed from root_agents", repoID, rootKillHealDelay)
 	}
 	m.mu.Unlock()
+	if removed {
+		// Explicit RPC kills publish this from control_server after their
+		// synchronous delete. A tombstone completed by the poll has no wrapper to
+		// do that, so publish at the point its durable row and authoritative map
+		// entry actually disappear. Stable-id payloads keep a delayed event from
+		// removing a replacement that reused the title.
+		m.publishEvent(agentproto.EventSessionKilled, session.InstanceData{ID: instance.ID, Title: instance.Title})
+	}
 }

--- a/daemon/watch_concurrency_ghost_test.go
+++ b/daemon/watch_concurrency_ghost_test.go
@@ -159,6 +159,54 @@ func TestGhostTaskRunReleasesWhenItsRunIsOver(t *testing.T) {
 	}
 }
 
+// TestStartupUnknownGhostDoesNotHoldTaskRunSlot covers contradictory rows from
+// the rollout window: StartupStateUnknown is terminal even if an older writer
+// left TaskRunActive set. Ghost accounting reads raw storage because the row did
+// not load, so it must honor the terminal marker directly rather than wedging a
+// task behind a bit no in-memory lifecycle transition can ever clear.
+func TestStartupUnknownGhostDoesNotHoldTaskRunSlot(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	const title = "startup-unknown-ghost"
+	if err := appendInstanceData(repo.ID, session.InstanceData{
+		ID:                  "startup-unknown-id",
+		TaskID:              "task1",
+		Title:               title,
+		Path:                repoPath,
+		Status:              session.Lost,
+		Liveness:            session.LiveLost,
+		TaskRunActive:       true,
+		StartupStateUnknown: true,
+		BackendType:         "local",
+		Worktree:            session.GitWorktreeData{RepoPath: repoPath},
+	}); err != nil {
+		t.Fatalf("append startup-unknown row: %v", err)
+	}
+	failLoadFor(t, title)
+
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if err := manager.RestoreInstances(); err != nil {
+		t.Fatalf("RestoreInstances: %v", err)
+	}
+	manager.mu.Lock()
+	counted := manager.countTaskRunsLocked(repo.ID, "task1")
+	admitErr := manager.admitTaskRunLocked(repo.ID, "task1", 1)
+	manager.mu.Unlock()
+	if counted != 0 {
+		t.Fatalf("startup-unknown ghost consumed %d task slot(s); terminal startup outcomes must release the cap", counted)
+	}
+	if admitErr != nil {
+		t.Fatalf("startup-unknown ghost blocked the next task event: %v", admitErr)
+	}
+}
+
 // TestGhostTaskRunClearsWhenTheRowLoadsAgain: the ghost set is a projection,
 // rebuilt every refresh — not bookkeeping. A row that starts loading again must
 // stop being a ghost, or its slot would be held twice: once by the ghost and once

--- a/session/activity.go
+++ b/session/activity.go
@@ -50,6 +50,13 @@ const (
 // mid-create session as idle — releasing a concurrency slot it should hold, and
 // telling `sessions watch` a session is ready before it ever started.
 func ClassifyActivity(data InstanceData) (Activity, string) {
+	// A failed create whose runtime identity could not be confirmed is a settled
+	// blocked outcome, not an idle LiveReady session. It wins even over a stale
+	// OpCreating persisted by the failure path: no automatic operation may settle
+	// this row, and watch must exit non-zero with an actionable explanation.
+	if data.StartupStateUnknown {
+		return ActivityTerminal, "session startup state is unknown (af could not confirm which runtime owns its workspace); inspect it and explicitly remove it before retrying"
+	}
 	// Any operation in flight (create, kill, archive, restore) means the session
 	// is mid-transition; wait for it to settle rather than reporting the
 	// transient composed status.
@@ -111,6 +118,10 @@ type LifecycleView struct {
 	Status     Status
 	Started    bool
 	UserKilled bool
+	// StartupStateUnknown is the retained-create fence: the launch may have
+	// succeeded under an identity af could not confirm, so no runtime or workspace
+	// action may infer ordinary LiveReady semantics from this view.
+	StartupStateUnknown bool
 	// TaskRunActive is whether this session's task run is still in flight — the one
 	// fact the concurrency cap counts. See Instance.taskRunActive.
 	TaskRunActive bool
@@ -135,13 +146,14 @@ func (i *Instance) LifecycleView() LifecycleView {
 // cannot observe different lifecycle states.
 func (i *Instance) lifecycleViewLocked() LifecycleView {
 	return LifecycleView{
-		Title:      i.Title,
-		TaskID:     i.TaskID,
-		Liveness:   i.liveness,
-		InFlightOp: i.inFlightOp,
-		Status:     i.statusLocked(),
-		Started:    i.started,
-		UserKilled: i.userKilled,
+		Title:               i.Title,
+		TaskID:              i.TaskID,
+		Liveness:            i.liveness,
+		InFlightOp:          i.inFlightOp,
+		Status:              i.statusLocked(),
+		Started:             i.started,
+		UserKilled:          i.userKilled,
+		StartupStateUnknown: i.startupStateUnknown,
 		// The already-locked variant, NOT Capabilities(): the backend is mutable
 		// (a restore rebinds it in bindProvisionResult), so Capabilities() now
 		// takes i.mu.RLock itself — and calling it while this snapshot holds the
@@ -161,7 +173,11 @@ func (i *Instance) lifecycleViewLocked() LifecycleView {
 // resolved liveness (NewInstance sets it, FromInstanceData rolls a legacy record
 // forward at load), so ClassifyActivity's LivenessUnset fallback never applies.
 func (v LifecycleView) Activity() Activity {
-	activity, _ := ClassifyActivity(InstanceData{Liveness: v.Liveness, InFlightOp: v.InFlightOp})
+	activity, _ := ClassifyActivity(InstanceData{
+		Liveness:            v.Liveness,
+		InFlightOp:          v.InFlightOp,
+		StartupStateUnknown: v.StartupStateUnknown,
+	})
 	return activity
 }
 

--- a/session/backend_local_start_answered_test.go
+++ b/session/backend_local_start_answered_test.go
@@ -36,11 +36,11 @@ func (f answeredLaunchPtyFactory) StartTracked(*exec.Cmd) (*os.File, <-chan erro
 
 func (answeredLaunchPtyFactory) Close() {}
 
-// TestLocalBackendAnsweredStartFailureCleansFreshWorktree is the user-visible
-// half of the answered-start classification. Once the post-exit probe confirms
-// no runtime remains, Launch removes the worktree instead of returning
-// ErrPaneMayBeLive and forcing the daemon to retain an inert uncertain record.
-func TestLocalBackendAnsweredStartFailureCleansFreshWorktree(t *testing.T) {
+// TestLocalBackendAnsweredStartFailurePreservesFreshWorktree is the user-visible
+// half of the pre-spawn-only cleanup invariant. A process that started and then
+// failed may have launched a pane which is still flushing even after the tmux
+// name disappears, so Launch must retain the worktree for explicit cleanup.
+func TestLocalBackendAnsweredStartFailurePreservesFreshWorktree(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 	repoRoot := initInPlaceRepo(t, "main")
 	gw, _, err := git.NewGitWorktree(repoRoot, "answered-start")
@@ -70,9 +70,9 @@ func TestLocalBackendAnsweredStartFailureCleansFreshWorktree(t *testing.T) {
 
 	err = (&LocalBackend{}).Launch(inst, true)
 	require.Error(t, err)
-	require.ErrorIs(t, err, tmux.ErrSessionNotStarted)
-	require.NotErrorIs(t, err, ErrPaneMayBeLive)
+	require.NotErrorIs(t, err, tmux.ErrSessionNotStarted)
+	require.ErrorIs(t, err, ErrPaneMayBeLive)
 	_, statErr := os.Stat(worktreePath)
-	require.ErrorIs(t, statErr, os.ErrNotExist,
-		"a confirmed-absent startup left its fresh worktree behind")
+	require.NoError(t, statErr,
+		"a post-spawn failure deleted a worktree whose pane may still be flushing")
 }

--- a/session/backend_local_start_answered_test.go
+++ b/session/backend_local_start_answered_test.go
@@ -1,0 +1,78 @@
+package session
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	"github.com/sachiniyer/agent-factory/session/git"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+type answeredLaunchPtyFactory struct {
+	t       *testing.T
+	waitErr error
+}
+
+func (f answeredLaunchPtyFactory) Start(*exec.Cmd) (*os.File, error) {
+	f.t.Fatal("Start called instead of StartTracked")
+	return nil, nil
+}
+
+func (f answeredLaunchPtyFactory) StartTracked(*exec.Cmd) (*os.File, <-chan error, error) {
+	ptmx, err := os.CreateTemp(f.t.TempDir(), "answered-launch-pty")
+	if err != nil {
+		return nil, nil, err
+	}
+	done := make(chan error, 1)
+	done <- f.waitErr
+	close(done)
+	return ptmx, done, nil
+}
+
+func (answeredLaunchPtyFactory) Close() {}
+
+// TestLocalBackendAnsweredStartFailureCleansFreshWorktree is the user-visible
+// half of the answered-start classification. Once the post-exit probe confirms
+// no runtime remains, Launch removes the worktree instead of returning
+// ErrPaneMayBeLive and forcing the daemon to retain an inert uncertain record.
+func TestLocalBackendAnsweredStartFailureCleansFreshWorktree(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoRoot := initInPlaceRepo(t, "main")
+	gw, _, err := git.NewGitWorktree(repoRoot, "answered-start")
+	require.NoError(t, err)
+	worktreePath := gw.GetWorktreePath()
+	t.Cleanup(func() { _, _ = gw.Cleanup() })
+
+	execu := cmd_test.MockCmdExec{
+		RunFunc: func(*exec.Cmd) error { return errors.New("session not found") },
+		OutputFunc: func(*exec.Cmd) ([]byte, error) {
+			return nil, nil
+		},
+	}
+	ptyFactory := answeredLaunchPtyFactory{
+		t:       t,
+		waitErr: errors.New("tmux new-session rejected the request"),
+	}
+	ts := tmux.NewTmuxSessionWithDeps("answered-start", "true", ptyFactory, execu)
+	inst := &Instance{
+		Title:       "answered-start",
+		Path:        repoRoot,
+		Program:     "true",
+		backend:     &LocalBackend{},
+		Tabs:        []*Tab{newAgentTab(ts)},
+		gitWorktree: gw,
+	}
+
+	err = (&LocalBackend{}).Launch(inst, true)
+	require.Error(t, err)
+	require.ErrorIs(t, err, tmux.ErrSessionNotStarted)
+	require.NotErrorIs(t, err, ErrPaneMayBeLive)
+	_, statErr := os.Stat(worktreePath)
+	require.ErrorIs(t, statErr, os.ErrNotExist,
+		"a confirmed-absent startup left its fresh worktree behind")
+}

--- a/session/backend_serialization_test.go
+++ b/session/backend_serialization_test.go
@@ -33,6 +33,23 @@ func TestToInstanceDataIncludesBackendType(t *testing.T) {
 	})
 }
 
+func TestInstanceDataUsesLocalTmux(t *testing.T) {
+	for _, tc := range []struct {
+		backendType string
+		want        bool
+	}{
+		{"", true}, // legacy rows predate the discriminator and were local
+		{"local", true},
+		{"remote", false},
+		{"docker", false},
+		{"ssh", false},
+	} {
+		t.Run(tc.backendType, func(t *testing.T) {
+			assert.Equal(t, tc.want, (InstanceData{BackendType: tc.backendType}).UsesLocalTmux())
+		})
+	}
+}
+
 func TestInstanceDataJSONRoundTrip(t *testing.T) {
 	t.Run("local backend serializes correctly", func(t *testing.T) {
 		data := InstanceData{

--- a/session/instance.go
+++ b/session/instance.go
@@ -112,8 +112,10 @@ type Instance struct {
 	inFlightOp InFlightOp
 	// taskRunActive is THE fact the watch-task concurrency cap is about (#1892):
 	// has this session's task run finished yet? It is true from creation for a
-	// task-spawned session and flips false — once, permanently — the first time the
-	// AGENT goes idle, which is the definition of the run being done.
+	// task-spawned session and flips false — once, permanently — when the AGENT
+	// first goes idle, or when startup settles terminal-unknown without ever
+	// establishing a runnable session. Either outcome means no run remains that a
+	// later poll could observe finishing.
 	//
 	// It is a stored fact rather than something derived at read time because every
 	// neighbouring signal answers a DIFFERENT question, and reconstructing the run
@@ -129,10 +131,10 @@ type Instance struct {
 	//     AbortArchiveToLost) look like an interrupted run and claim a slot.
 	//
 	// So the run's own lifetime is recorded on the run's own edges: it begins when
-	// the session is created for a delivery and ends when the agent goes idle.
-	// Neither of those is ambiguous, and neither has to be inferred later from a
-	// state that means something else. Persisted, because an outage that loses
-	// sessions is the same event that restarts the daemon.
+	// the session is created for a delivery and ends when the agent goes idle or
+	// startup reaches its explicit terminal-unknown boundary. Neither has to be
+	// inferred later from a neighbouring state. Persisted, because an outage that
+	// loses sessions is the same event that restarts the daemon.
 	//
 	// It never flips back to true: a capped task creates one session per event (a
 	// cap and a target_session are mutually exclusive — see task.ValidateTrigger),

--- a/session/instance_accessors.go
+++ b/session/instance_accessors.go
@@ -84,8 +84,14 @@ func (i *Instance) UserKilled() bool {
 func (i *Instance) MarkStartupStateUnknown() {
 	i.mu.Lock()
 	defer i.mu.Unlock()
+	lv, op, resetAt := i.lifecycleStateLocked()
 	i.startupStateUnknown = true
 	i.started = false
+	// The create attempt has settled into an explicit blocked outcome. Leaving
+	// OpCreating set makes projections report an operation that no goroutine owns
+	// and can keep old clients polling forever.
+	i.inFlightOp = OpNone
+	i.noteStateChangeLocked(lv, op, resetAt)
 }
 
 // StartupStateUnknown reports whether a create may have launched a runtime but

--- a/session/instance_accessors.go
+++ b/session/instance_accessors.go
@@ -87,6 +87,11 @@ func (i *Instance) MarkStartupStateUnknown() {
 	lv, op, resetAt := i.lifecycleStateLocked()
 	i.startupStateUnknown = true
 	i.started = false
+	// Startup-unknown is a terminal delivery outcome, not a run still consuming
+	// the task's concurrency budget. Store that fact on the same transition that
+	// stores the terminal marker so projections, persistence, and unloadable-row
+	// accounting cannot disagree about whether the slot was released.
+	i.taskRunActive = false
 	// The create attempt has settled into an explicit blocked outcome. Leaving
 	// OpCreating set makes projections report an operation that no goroutine owns
 	// and can keep old clients polling forever.

--- a/session/instance_data.go
+++ b/session/instance_data.go
@@ -42,7 +42,7 @@ func (i *Instance) toInstanceDataLocked() InstanceData {
 		Status:              i.statusLocked(),
 		Liveness:            i.liveness,
 		InFlightOp:          i.inFlightOp,
-		LifecycleAction:     lifecycleActionFor(i.ID, i.liveness, i.inFlightOp),
+		LifecycleAction:     lifecycleActionFor(i.ID, i.liveness, i.inFlightOp, i.startupStateUnknown),
 		Height:              i.Height,
 		Width:               i.Width,
 		CreatedAt:           i.CreatedAt,

--- a/session/instance_data.go
+++ b/session/instance_data.go
@@ -43,6 +43,7 @@ func (i *Instance) toInstanceDataLocked() InstanceData {
 		Liveness:            i.liveness,
 		InFlightOp:          i.inFlightOp,
 		LifecycleAction:     lifecycleActionFor(i.ID, i.liveness, i.inFlightOp, i.startupStateUnknown),
+		CanKill:             canKillFor(i.ID, i.inFlightOp),
 		Height:              i.Height,
 		Width:               i.Width,
 		CreatedAt:           i.CreatedAt,

--- a/session/liveness.go
+++ b/session/liveness.go
@@ -90,11 +90,14 @@ const (
 	LifecycleActionRestore LifecycleAction = "restore"
 )
 
-// lifecycleActionFor is the one policy shared by Instance (the TUI) and
-// ToInstanceData (the web projection). A creating row has a provisional identity
-// but no session to destroy yet. An id-less row cannot address a destructive API
-// unambiguously, so it also exposes nothing. Resting rows restore; every other
-// settled row archives. Kill is available whenever this result is non-zero.
+// lifecycleActionFor is the one archive/restore policy shared by Instance (the
+// TUI) and ToInstanceData (the web projection). A creating row has a provisional
+// identity but no session to manage yet. An id-less row cannot address a mutation
+// API unambiguously, so it also exposes nothing. A startup-unknown row must not
+// reuse its unconfirmed runtime binding. Resting rows restore; every other settled
+// row archives. Kill addressability is intentionally independent (CanKill): a
+// retained startup-unknown row must remain removable without becoming attachable,
+// archivable, or restorable.
 func lifecycleActionFor(id string, liveness Liveness, op InFlightOp, startupStateUnknown bool) LifecycleAction {
 	if id == "" || op == OpCreating || startupStateUnknown {
 		return LifecycleActionNone
@@ -107,6 +110,14 @@ func lifecycleActionFor(id string, liveness Liveness, op InFlightOp, startupStat
 	}
 }
 
+// canKillFor answers only whether a row has a stable teardown target. It does not
+// imply that the runtime binding is safe to reuse: startup-unknown rows are the
+// important counterexample. A creating row has no confirmed session to tear down,
+// and an id-less legacy row cannot address the destructive API without guessing.
+func canKillFor(id string, op InFlightOp) bool {
+	return id != "" && op != OpCreating
+}
+
 // LifecycleAction returns the shared lifecycle verb for this instance. TUI menus
 // and handlers use this method; browser clients receive the same value from
 // InstanceData.LifecycleAction.
@@ -114,6 +125,15 @@ func (i *Instance) LifecycleAction() LifecycleAction {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
 	return lifecycleActionFor(i.ID, i.liveness, i.inFlightOp, i.startupStateUnknown)
+}
+
+// CanKill reports whether interactive clients may offer explicit teardown for
+// this instance. It is a separate domain axis from LifecycleAction so exceptional
+// retained records do not become impossible to remove.
+func (i *Instance) CanKill() bool {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return canKillFor(i.ID, i.inFlightOp)
 }
 
 // composeStatus derives the legacy Status enum from the two-axis model. An

--- a/session/liveness.go
+++ b/session/liveness.go
@@ -95,8 +95,8 @@ const (
 // but no session to destroy yet. An id-less row cannot address a destructive API
 // unambiguously, so it also exposes nothing. Resting rows restore; every other
 // settled row archives. Kill is available whenever this result is non-zero.
-func lifecycleActionFor(id string, liveness Liveness, op InFlightOp) LifecycleAction {
-	if id == "" || op == OpCreating {
+func lifecycleActionFor(id string, liveness Liveness, op InFlightOp, startupStateUnknown bool) LifecycleAction {
+	if id == "" || op == OpCreating || startupStateUnknown {
 		return LifecycleActionNone
 	}
 	switch liveness {
@@ -113,7 +113,7 @@ func lifecycleActionFor(id string, liveness Liveness, op InFlightOp) LifecycleAc
 func (i *Instance) LifecycleAction() LifecycleAction {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
-	return lifecycleActionFor(i.ID, i.liveness, i.inFlightOp)
+	return lifecycleActionFor(i.ID, i.liveness, i.inFlightOp, i.startupStateUnknown)
 }
 
 // composeStatus derives the legacy Status enum from the two-axis model. An

--- a/session/liveness_test.go
+++ b/session/liveness_test.go
@@ -153,13 +153,38 @@ func TestLifecycleActionIsSharedAcrossInstanceAndProjection(t *testing.T) {
 func TestLifecycleActionIsProjectionOnly(t *testing.T) {
 	data := (&Instance{ID: "ready-id", liveness: LiveReady}).ToInstanceData()
 	require.Equal(t, LifecycleActionArchive, data.LifecycleAction)
+	require.True(t, data.CanKill)
 
 	stored := data.ForStorage()
 	require.Equal(t, LifecycleActionNone, stored.LifecycleAction)
+	require.False(t, stored.CanKill)
 	raw, err := json.Marshal(stored)
 	require.NoError(t, err)
 	assert.NotContains(t, string(raw), "lifecycle_action",
 		"instances.json must not persist a UI capability derived from live state")
+	assert.NotContains(t, string(raw), "can_kill",
+		"instances.json must not persist a UI capability derived from live state")
+}
+
+func TestKillAddressabilityIsSharedAcrossInstanceAndProjection(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		id             string
+		op             InFlightOp
+		startupUnknown bool
+		want           bool
+	}{
+		{name: "settled stable row", id: "ready-id", want: true},
+		{name: "startup unknown keeps teardown handle", id: "unknown-id", startupUnknown: true, want: true},
+		{name: "creating has no teardown target", id: "pending-id", op: OpCreating},
+		{name: "id-less cannot address teardown"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			inst := &Instance{ID: tc.id, liveness: LiveReady, inFlightOp: tc.op, startupStateUnknown: tc.startupUnknown}
+			require.Equal(t, tc.want, inst.CanKill(), "TUI domain decision")
+			require.Equal(t, tc.want, inst.ToInstanceData().CanKill, "web projection decision")
+		})
+	}
 }
 
 func TestInFlightOpStrippedFromStorageRecords(t *testing.T) {

--- a/session/runtime_action.go
+++ b/session/runtime_action.go
@@ -35,6 +35,9 @@ func (v LifecycleView) ValidateRuntimeAction(action RuntimeAction) error {
 	if v.UserKilled {
 		return fmt.Errorf("session %q has a pending kill", v.Title)
 	}
+	if v.StartupStateUnknown {
+		return fmt.Errorf("session %q has an unknown startup state; inspect its workspace and runtime before explicitly removing it", v.Title)
+	}
 
 	switch action {
 	case RuntimeActionRestoreArchived:

--- a/session/startup_unknown_lifecycle_test.go
+++ b/session/startup_unknown_lifecycle_test.go
@@ -26,7 +26,7 @@ func TestStartupUnknownIsTerminalAndKillableButHasNoLifecycleAction(t *testing.T
 	}
 
 	inst, err := NewInstance(InstanceOptions{
-		ID: "unknown-id", Title: "uncertain", Path: t.TempDir(), Program: "claude",
+		ID: "unknown-id", TaskID: "task-unknown", Title: "uncertain", Path: t.TempDir(), Program: "claude",
 	})
 	if err != nil {
 		t.Fatalf("NewInstance: %v", err)
@@ -38,6 +38,9 @@ func TestStartupUnknownIsTerminalAndKillableButHasNoLifecycleAction(t *testing.T
 	}
 	if view.Activity() != ActivityTerminal {
 		t.Fatalf("live startup-unknown instance classified as %v, want terminal", view.Activity())
+	}
+	if view.TaskRunActive {
+		t.Fatal("startup-unknown instance kept a task run slot no future poll can release")
 	}
 	if action := inst.LifecycleAction(); action != LifecycleActionNone {
 		t.Fatalf("startup-unknown instance advertises lifecycle action %q", action)

--- a/session/startup_unknown_lifecycle_test.go
+++ b/session/startup_unknown_lifecycle_test.go
@@ -1,0 +1,68 @@
+package session
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStartupUnknownIsTerminalAndHasNoLifecycleAction pins the shared view read
+// by sessions-watch, task concurrency, the TUI, and the web client. A retained
+// uncertain create is not an ordinary ready row just because LiveReady was the
+// instance's pre-launch default.
+func TestStartupUnknownIsTerminalAndHasNoLifecycleAction(t *testing.T) {
+	data := InstanceData{
+		ID:                  "unknown-id",
+		Title:               "uncertain",
+		Liveness:            LiveReady,
+		StartupStateUnknown: true,
+	}
+	activity, reason := ClassifyActivity(data)
+	if activity != ActivityTerminal {
+		t.Fatalf("startup-unknown record classified as %v, want terminal", activity)
+	}
+	if !strings.Contains(reason, "startup") || !strings.Contains(reason, "unknown") {
+		t.Fatalf("terminal reason %q does not explain the unknown startup", reason)
+	}
+
+	inst, err := NewInstance(InstanceOptions{
+		ID: "unknown-id", Title: "uncertain", Path: t.TempDir(), Program: "claude",
+	})
+	if err != nil {
+		t.Fatalf("NewInstance: %v", err)
+	}
+	inst.MarkStartupStateUnknown()
+	view := inst.LifecycleView()
+	if !view.StartupStateUnknown {
+		t.Fatal("LifecycleView dropped the startup-unknown state")
+	}
+	if view.Activity() != ActivityTerminal {
+		t.Fatalf("live startup-unknown instance classified as %v, want terminal", view.Activity())
+	}
+	if action := inst.LifecycleAction(); action != LifecycleActionNone {
+		t.Fatalf("startup-unknown instance advertises lifecycle action %q", action)
+	}
+	if action := inst.ToInstanceData().LifecycleAction; action != LifecycleActionNone {
+		t.Fatalf("startup-unknown projection advertises lifecycle action %q", action)
+	}
+}
+
+// TestStartupUnknownVetoesEveryRuntimeAction makes the exceptional state a
+// universal runtime-entry fence. A newly added restore/swap action cannot forget
+// the veto and act through the same binding whose identity was never confirmed.
+func TestStartupUnknownVetoesEveryRuntimeAction(t *testing.T) {
+	valid := map[RuntimeAction]LifecycleView{
+		RuntimeActionRestoreArchived:   {Title: "unknown", Liveness: LiveArchived},
+		RuntimeActionRestoreLostOrDead: {Title: "unknown", Liveness: LiveDead, Started: true},
+		RuntimeActionRecoverLost:       {Title: "unknown", Liveness: LiveLost, Started: true},
+		RuntimeActionResumeLimit:       {Title: "unknown", Liveness: LiveLimitReached, Started: true},
+		RuntimeActionHandoff:           {Title: "unknown", Liveness: LiveRunning, Started: true},
+	}
+	for action := RuntimeAction(0); action < numRuntimeActions; action++ {
+		view := valid[action]
+		view.StartupStateUnknown = true
+		err := view.ValidateRuntimeAction(action)
+		if err == nil || !strings.Contains(err.Error(), "startup") || !strings.Contains(err.Error(), "unknown") {
+			t.Fatalf("runtime action %d returned %v, want startup-unknown refusal", action, err)
+		}
+	}
+}

--- a/session/startup_unknown_lifecycle_test.go
+++ b/session/startup_unknown_lifecycle_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 )
 
-// TestStartupUnknownIsTerminalAndHasNoLifecycleAction pins the shared view read
-// by sessions-watch, task concurrency, the TUI, and the web client. A retained
-// uncertain create is not an ordinary ready row just because LiveReady was the
-// instance's pre-launch default.
-func TestStartupUnknownIsTerminalAndHasNoLifecycleAction(t *testing.T) {
+// TestStartupUnknownIsTerminalAndKillableButHasNoLifecycleAction pins the shared
+// view read by sessions-watch, task concurrency, the TUI, and the web client. A
+// retained uncertain create is not an ordinary ready row just because LiveReady
+// was the instance's pre-launch default, but its stable record must remain an
+// explicit teardown handle.
+func TestStartupUnknownIsTerminalAndKillableButHasNoLifecycleAction(t *testing.T) {
 	data := InstanceData{
 		ID:                  "unknown-id",
 		Title:               "uncertain",
@@ -41,8 +42,15 @@ func TestStartupUnknownIsTerminalAndHasNoLifecycleAction(t *testing.T) {
 	if action := inst.LifecycleAction(); action != LifecycleActionNone {
 		t.Fatalf("startup-unknown instance advertises lifecycle action %q", action)
 	}
-	if action := inst.ToInstanceData().LifecycleAction; action != LifecycleActionNone {
+	if !inst.CanKill() {
+		t.Fatal("startup-unknown instance lost its explicit teardown handle")
+	}
+	projection := inst.ToInstanceData()
+	if action := projection.LifecycleAction; action != LifecycleActionNone {
 		t.Fatalf("startup-unknown projection advertises lifecycle action %q", action)
+	}
+	if !projection.CanKill {
+		t.Fatal("startup-unknown projection lost its explicit teardown handle")
 	}
 }
 

--- a/session/storage.go
+++ b/session/storage.go
@@ -50,6 +50,11 @@ type InstanceData struct {
 	// ToInstanceData and scrubbed by ForStorage; instances.json must not preserve
 	// a UI decision that can go stale across restart.
 	LifecycleAction LifecycleAction `json:"lifecycle_action,omitempty"`
+	// CanKill is the independent projection-only teardown capability. It is true
+	// for any stable, non-creating row, including StartupStateUnknown: that state
+	// vetoes runtime reuse but must remain explicitly removable. Like
+	// LifecycleAction, this is derived live and scrubbed before disk persistence.
+	CanKill bool `json:"can_kill,omitempty"`
 	// TaskRunActive records whether this session's task run is still in flight
 	// (#1892) — true from creation, false once the agent goes idle. It is the one
 	// fact the watch-task concurrency cap counts, and it is stored rather than
@@ -133,6 +138,7 @@ func (d InstanceData) ForStorage() InstanceData {
 	d.Liveness = lv
 	d.InFlightOp = OpNone
 	d.LifecycleAction = LifecycleActionNone
+	d.CanKill = false
 	return d
 }
 

--- a/session/storage.go
+++ b/session/storage.go
@@ -115,6 +115,15 @@ func (d InstanceData) IsRemoteHook() bool {
 	return d.BackendType == "remote"
 }
 
+// UsesLocalTmux reports whether this persisted row belongs to the in-process
+// local backend and therefore claims a repo-scoped tmux name. Empty is the
+// pre-backend-discriminator legacy encoding and also means local. Keeping this
+// decoding beside BackendType prevents daemon admission from growing its own
+// backend-name list.
+func (d InstanceData) UsesLocalTmux() bool {
+	return d.BackendType == "" || d.BackendType == "local"
+}
+
 // ForStorage returns data suitable for instances.json. InstanceData is also the
 // daemon Snapshot payload, so it can carry transient in-flight operation state;
 // disk persistence must not.

--- a/session/storage.go
+++ b/session/storage.go
@@ -56,8 +56,9 @@ type InstanceData struct {
 	// LifecycleAction, this is derived live and scrubbed before disk persistence.
 	CanKill bool `json:"can_kill,omitempty"`
 	// TaskRunActive records whether this session's task run is still in flight
-	// (#1892) — true from creation, false once the agent goes idle. It is the one
-	// fact the watch-task concurrency cap counts, and it is stored rather than
+	// (#1892) — true from creation, false once the agent goes idle or startup
+	// settles terminal-unknown. It is the one fact the watch-task concurrency cap
+	// counts, and it is stored rather than
 	// re-derived because every neighbouring signal answers a different question:
 	// Lost cannot tell a finished run from an interrupted one, and an in-flight op
 	// means the DAEMON is busy (archiving a completed session is teardown, not

--- a/session/tmux/close.go
+++ b/session/tmux/close.go
@@ -66,6 +66,15 @@ type closeRun struct {
 	unknown bool
 }
 
+// closeProcessOutcome carries the process-tree half of teardown separately from
+// tmux's PaneState. Close remains latency-oriented and discards it; the destructive
+// CloseAndWaitForPaneExit path requires both answers before authorizing workspace
+// cleanup.
+type closeProcessOutcome struct {
+	captureErr error
+	remaining  []proctree.Process
+}
+
 // tmux runs one bounded tmux command and RECORDS a tripped deadline. The only
 // place in the close path that decides what a deadline means.
 func (r *closeRun) tmux(args ...string) error {
@@ -98,13 +107,21 @@ func (r *closeRun) state() PaneState {
 }
 
 func (t *TmuxSession) Close() (PaneState, error) {
+	state, err, _ := t.close(false)
+	return state, err
+}
+
+// close is the single tmux/process teardown implementation. waitForProcesses is
+// false for interactive teardown (the captured-tree reaper remains asynchronous)
+// and true only when a caller will mutate the worktree immediately afterward.
+func (t *TmuxSession) close(waitForProcesses bool) (PaneState, error, closeProcessOutcome) {
 	var errs []error
 	r := &closeRun{t: t}
 
 	// Capture the panes' process trees before kill-session — afterwards any
 	// survivor is reparented to init and its ancestry is unrecoverable
 	// (#1104).
-	leaked := SessionProcessTrees(t.cmdExec, t.sanitizedName)
+	leaked, captureErr := captureSessionProcessTrees(t.cmdExec, t.sanitizedName)
 
 	// Bounded by tmuxCommandTimeout (#1917), through the run so the deadline counts
 	// itself: an unbounded kill-session against a wedged server blocks
@@ -153,15 +170,20 @@ func (t *TmuxSession) Close() (PaneState, error) {
 	// Async so the SIGHUP grace period never adds latency to user-driven
 	// teardown; the daemon and TUI processes are long-lived, so the sweep
 	// always gets to finish. CLI kills run daemon-side (KillSession RPC).
+	processes := closeProcessOutcome{captureErr: captureErr}
 	if len(leaked) > 0 {
-		go reapLeakedProcesses(t.sanitizedName, leaked, reapGraceWait, reapTermWait)
+		if waitForProcesses {
+			processes.remaining = reapLeakedProcesses(t.sanitizedName, leaked, reapGraceWait, reapTermWait)
+		} else {
+			go reapLeakedProcesses(t.sanitizedName, leaked, reapGraceWait, reapTermWait)
+		}
 	}
 
 	// errors.Join, not a flattened string: the ErrTmuxTimeout sentinel has to stay
 	// reachable through errors.Is for callers that gate on it (#1917). The old
 	// hand-built message erased it. The state is DERIVED from the run — this
 	// function never names a PaneState constant.
-	return r.state(), errors.Join(errs...)
+	return r.state(), errors.Join(errs...), processes
 }
 
 // CloseAttachOnly is the non-destructive sibling of Close: it releases whatever
@@ -186,19 +208,20 @@ func (t *TmuxSession) CloseAttachOnly() error {
 // short enough that teardown of a wedged process doesn't hang the caller.
 var paneExitWait = 3 * time.Second
 
-// CloseAndWaitForPaneExit terminates the tmux session like Close, then waits
-// (bounded by paneExitWait) until the pane's root process has actually
-// exited. `tmux kill-session` only delivers SIGHUP and returns immediately;
-// an agent that is still flushing state files (.claude/, .turbo/, ...) races
-// any directory removal that follows and leaves a half-deleted worktree
-// behind ("Directory not empty", #802). Callers that delete the session's
+// CloseAndWaitForPaneExit terminates the tmux session like Close, then waits for
+// every process captured from the pane (root, descendants, and SID members) to
+// exit or finish the bounded TERM→KILL reaper. `tmux kill-session` only delivers
+// SIGHUP and returns immediately; any survivor that is still flushing state files
+// (.claude/, .turbo/, ...) races directory removal and leaves a half-deleted
+// worktree behind ("Directory not empty", #802). Callers that delete the session's
 // worktree right after teardown must use this instead of Close.
 //
-// paneExitWait bounds ONLY the waitForPIDExit poll below, NOT the whole call —
+// paneExitWait bounds ONLY the root fallback poll below, NOT the whole call —
 // a distinction #1917 was misread on. The tmux commands are what a wedged server
 // stalls, and each carries its own tmuxCommandTimeout: display-message (panePID),
-// then Close's list-panes, kill-session, and at most one has-session probe. So the
-// real worst case is ~4×tmuxCommandTimeout + paneExitWait, all of it finite —
+// then Close's list-panes, kill-session, and at most one has-session probe. The
+// captured-tree reaper adds at most reapGraceWait + reapTermWait + one final second.
+// So the real worst case remains finite —
 // which is the property daemon.KillSession needs, since it holds a per-session
 // kills-in-flight guard across this call with no deadline of its own.
 func (t *TmuxSession) CloseAndWaitForPaneExit() (PaneState, error) {
@@ -215,7 +238,7 @@ func (t *TmuxSession) CloseAndWaitForPaneExit() (PaneState, error) {
 		// both distinctions explicit.
 		paneProcess, waitForPane, processErr = capturePaneProcess(pid)
 	}
-	state, closeErr := t.Close()
+	state, closeErr, processes := t.close(true)
 	if pidErr != nil {
 		// A TIMED-OUT panePID is not "nothing to wait on" (#1917). It means the
 		// server never told us which process to wait for — so even if the
@@ -238,6 +261,23 @@ func (t *TmuxSession) CloseAndWaitForPaneExit() (PaneState, error) {
 		// prove that process stopped writing, so fail closed like a timed-out PID
 		// query rather than deleting the worktree on an existence guess.
 		return PaneStateUnknown, errors.Join(closeErr, processErr)
+	}
+	if processes.captureErr != nil {
+		// The pane leader was known, but the full process set was not. A child may
+		// already have detached/reparented and still be writing after the leader exits;
+		// leader death cannot manufacture proof about descendants we failed to see.
+		err := fmt.Errorf("could not establish the pane's complete process tree before kill-session: %w", processes.captureErr)
+		log.WarningLog.Printf("tmux session %s: %v; refusing worktree cleanup", t.sanitizedName, err)
+		return PaneStateUnknown, errors.Join(closeErr, err)
+	}
+	if len(processes.remaining) > 0 {
+		pids := make([]string, 0, len(processes.remaining))
+		for _, process := range processes.remaining {
+			pids = append(pids, strconv.Itoa(process.PID))
+		}
+		err := fmt.Errorf("pane processes %s are still alive after bounded teardown", strings.Join(pids, ", "))
+		log.WarningLog.Printf("tmux session %s: %v; refusing worktree cleanup", t.sanitizedName, err)
+		return PaneStateUnknown, errors.Join(closeErr, err)
 	}
 	if waitForPane && !waitForProcessExit(paneProcess, paneExitWait) {
 		// kill-session returning establishes only that SIGHUP was sent, not that the

--- a/session/tmux/close.go
+++ b/session/tmux/close.go
@@ -31,10 +31,10 @@ type PaneState int
 
 const (
 	// PaneStateUnknown (the ZERO VALUE): a bounded tmux command tripped its
-	// deadline, so the server never answered and the session may still be RUNNING —
-	// or nobody established its state at all. No caller may take a destructive step
-	// on this: deleting or moving a workspace an agent is still writing to destroys
-	// the user's work on a guess. Retry instead.
+	// deadline, the pane process remained alive after bounded teardown, or nobody
+	// established its state at all. No caller may take a destructive step on this:
+	// deleting or moving a workspace an agent is still writing to destroys the
+	// user's work on a guess. Retry instead.
 	//
 	// Unknown is the zero value deliberately (#1917). The safe outcome must be the
 	// LAZY outcome: a state nobody set refuses to destroy rather than permitting it.
@@ -184,7 +184,7 @@ func (t *TmuxSession) CloseAttachOnly() error {
 // paneExitWait bounds how long CloseAndWaitForPaneExit blocks for the pane
 // process to die. Long enough for an agent to handle SIGHUP and flush state,
 // short enough that teardown of a wedged process doesn't hang the caller.
-const paneExitWait = 3 * time.Second
+var paneExitWait = 3 * time.Second
 
 // CloseAndWaitForPaneExit terminates the tmux session like Close, then waits
 // (bounded by paneExitWait) until the pane's root process has actually
@@ -221,12 +221,12 @@ func (t *TmuxSession) CloseAndWaitForPaneExit() (PaneState, error) {
 		return state, closeErr
 	}
 	if !waitForPIDExit(pid, paneExitWait) {
-		// Pre-existing #802 behavior, deliberately unchanged: kill-session was
-		// CONFIRMED delivered, so this pane is dying — it is merely slow. Treating a
-		// slow flush as unknown would defer routine kills of any agent that takes
-		// >3s to exit. The unknown cases above are the ones where tmux never spoke.
-		log.WarningLog.Printf("tmux session %s: pane process %d still alive %v after kill-session; "+
-			"worktree cleanup may race with its in-flight writes", t.sanitizedName, pid, paneExitWait)
+		// kill-session returning establishes only that SIGHUP was sent, not that the
+		// process stopped writing. Unknown is the only state that keeps every
+		// destructive caller from deleting/moving the worktree on that assumption.
+		err := fmt.Errorf("pane process %d is still alive %v after kill-session", pid, paneExitWait)
+		log.WarningLog.Printf("tmux session %s: %v; refusing worktree cleanup", t.sanitizedName, err)
+		return PaneStateUnknown, errors.Join(closeErr, err)
 	}
 	return state, closeErr
 }

--- a/session/tmux/close.go
+++ b/session/tmux/close.go
@@ -3,12 +3,12 @@ package tmux
 import (
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"syscall"
 	"time"
 
+	"github.com/sachiniyer/agent-factory/internal/proctree"
 	"github.com/sachiniyer/agent-factory/log"
 )
 
@@ -203,6 +203,18 @@ var paneExitWait = 3 * time.Second
 // kills-in-flight guard across this call with no deadline of its own.
 func (t *TmuxSession) CloseAndWaitForPaneExit() (PaneState, error) {
 	pid, pidErr := t.panePID()
+	var (
+		paneProcess proctree.Process
+		waitForPane bool
+		processErr  error
+	)
+	if pidErr == nil {
+		// Capture the process IDENTITY before kill-session. Polling the bare PID
+		// afterwards confuses both an unreaped zombie and a recycled PID with the
+		// original pane still running (#2103). The process-table identity makes
+		// both distinctions explicit.
+		paneProcess, waitForPane, processErr = capturePaneProcess(pid)
+	}
 	state, closeErr := t.Close()
 	if pidErr != nil {
 		// A TIMED-OUT panePID is not "nothing to wait on" (#1917). It means the
@@ -220,7 +232,14 @@ func (t *TmuxSession) CloseAndWaitForPaneExit() (PaneState, error) {
 		// and Close's own state stands.
 		return state, closeErr
 	}
-	if !waitForPIDExit(pid, paneExitWait) {
+	if processErr != nil {
+		// We knew which PID tmux owned, but could not establish a process identity
+		// to follow across teardown. A successful kill-session is not enough to
+		// prove that process stopped writing, so fail closed like a timed-out PID
+		// query rather than deleting the worktree on an existence guess.
+		return PaneStateUnknown, errors.Join(closeErr, processErr)
+	}
+	if waitForPane && !waitForProcessExit(paneProcess, paneExitWait) {
 		// kill-session returning establishes only that SIGHUP was sent, not that the
 		// process stopped writing. Unknown is the only state that keeps every
 		// destructive caller from deleting/moving the worktree on that assumption.
@@ -229,6 +248,27 @@ func (t *TmuxSession) CloseAndWaitForPaneExit() (PaneState, error) {
 		return PaneStateUnknown, errors.Join(closeErr, err)
 	}
 	return state, closeErr
+}
+
+// capturePaneProcess turns tmux's bare pane PID into a process-table identity
+// before teardown. A PID absent from a successful snapshot is accepted as gone
+// only when the kernel agrees with ESRCH. If the PID still exists, the snapshot
+// was unable to identify it (or it became a zombie in the observation gap), and
+// callers must keep cleanup unsafe rather than manufacturing an exit.
+func capturePaneProcess(pid int) (proctree.Process, bool, error) {
+	snap, err := proctree.Snapshot()
+	if err != nil {
+		return proctree.Process{}, false, fmt.Errorf("cannot inspect pane process %d before kill-session: %w", pid, err)
+	}
+	if process, ok := snap[pid]; ok {
+		return process, true, nil
+	}
+	if err := syscall.Kill(pid, 0); errors.Is(err, syscall.ESRCH) {
+		return proctree.Process{}, false, nil
+	} else if err != nil {
+		return proctree.Process{}, false, fmt.Errorf("cannot establish whether pane process %d already exited: %w", pid, err)
+	}
+	return proctree.Process{}, false, fmt.Errorf("pane process %d still exists but was absent from the process-table snapshot", pid)
 }
 
 // panePID returns the PID of the root process running in the session's pane
@@ -258,24 +298,9 @@ func (t *TmuxSession) panePID() (int, error) {
 	return pid, nil
 }
 
-// waitForPIDExit polls pid with signal 0 until the process is gone or the
-// timeout elapses. Returns true when the process exited within the timeout.
-// The tmux server reaps its dead children promptly, so a lingering zombie
-// (signal 0 succeeds on zombies) does not realistically pin this to the full
-// timeout.
-func waitForPIDExit(pid int, timeout time.Duration) bool {
-	deadline := time.Now().Add(timeout)
-	for {
-		proc, err := os.FindProcess(pid)
-		if err != nil {
-			return true
-		}
-		if err := proc.Signal(syscall.Signal(0)); err != nil {
-			return true
-		}
-		if time.Now().After(deadline) {
-			return false
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
+// waitForProcessExit waits on the pre-teardown process identity, not merely its
+// PID. proctree treats zombies as exited and PID reuse as a different identity,
+// so neither can masquerade as a pane that is still writing (#2103).
+func waitForProcessExit(process proctree.Process, timeout time.Duration) bool {
+	return len(proctree.WaitForExits([]proctree.Process{process}, timeout)) == 0
 }

--- a/session/tmux/close_wait_test.go
+++ b/session/tmux/close_wait_test.go
@@ -36,6 +36,28 @@ func TestWaitForPIDExit_AliveProcessTimesOut(t *testing.T) {
 		"a live PID must report not-exited once the timeout elapses")
 }
 
+func TestCloseAndWaitForPaneExit_AlivePaneKeepsCleanupUnsafe(t *testing.T) {
+	oldWait := paneExitWait
+	paneExitWait = 20 * time.Millisecond
+	t.Cleanup(func() { paneExitWait = oldWait })
+
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(*exec.Cmd) error { return nil },
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+			if strings.Contains(cmd.String(), "display-message") {
+				return []byte(fmt.Sprintf("%d\n", os.Getpid())), nil
+			}
+			return nil, nil
+		},
+	}
+	session := newTmuxSession(toTmuxName("close-wait-live", ""), "claude", NewMockPtyFactory(t), cmdExec)
+
+	state, err := session.CloseAndWaitForPaneExit()
+	require.Error(t, err)
+	require.Equal(t, PaneStateUnknown, state,
+		"a pane still flushing after kill-session must veto worktree cleanup")
+}
+
 // TestCloseAndWaitForPaneExit_QueriesPaneBeforeKill verifies the #802
 // ordering contract: the pane PID is captured via display-message BEFORE
 // kill-session runs (afterwards there is nothing left to query), and the

--- a/session/tmux/close_wait_test.go
+++ b/session/tmux/close_wait_test.go
@@ -4,7 +4,10 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -12,7 +15,65 @@ import (
 
 	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
 	"github.com/sachiniyer/agent-factory/internal/proctree"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
 )
+
+func TestCloseAndWaitForPaneExit_ReapsLivingDescendantBeforeReturning(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux is not installed")
+	}
+	testguard.IsolateTmux(t)
+	shrinkReapWaits(t)
+	name := fmt.Sprintf("af_test_close_desc_%d", time.Now().UnixNano())
+	childFile := filepath.Join(t.TempDir(), "child.pid")
+	// The pane leader exits on tmux's SIGHUP. Its child inherits ignored HUP/TERM
+	// dispositions and therefore survives until the captured-tree reaper reaches
+	// SIGKILL — exactly the process the old leader-only wait returned ahead of.
+	command := fmt.Sprintf("sh -c 'trap \"\" HUP TERM; echo $$ > %s; exec sleep 300' & exec sleep 300", strconv.Quote(childFile))
+	require.NoError(t, exec.Command("tmux", "new-session", "-d", "-s", name, command).Run())
+	t.Cleanup(func() { _ = exec.Command("tmux", "kill-session", "-t", name).Run() })
+
+	var childPID int
+	require.Eventually(t, func() bool {
+		raw, err := os.ReadFile(childFile)
+		if err != nil {
+			return false
+		}
+		childPID, err = strconv.Atoi(strings.TrimSpace(string(raw)))
+		return err == nil && childPID > 1
+	}, 3*time.Second, 20*time.Millisecond)
+	child := processIdentity(t, childPID)
+	t.Cleanup(func() { _ = syscall.Kill(childPID, syscall.SIGKILL) })
+
+	s := NewTmuxSessionFromSanitizedName(name, "sh")
+	state, err := s.CloseAndWaitForPaneExit()
+	require.NoError(t, err)
+	require.Equal(t, PaneStateKnown, state)
+	require.False(t, proctree.AliveSame(child),
+		"destructive teardown returned while a captured pane descendant could still write to the worktree")
+}
+
+func TestCloseAndWaitForPaneExit_UnobservableProcessTreeKeepsCleanupUnsafe(t *testing.T) {
+	process := exitedProcess(t)
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(*exec.Cmd) error { return nil },
+		OutputFunc: func(command *exec.Cmd) ([]byte, error) {
+			if strings.Contains(command.String(), "display-message") {
+				return []byte(fmt.Sprintf("%d\n", process.PID)), nil
+			}
+			if strings.Contains(command.String(), "list-panes") {
+				return []byte("not-a-pane-pid\n"), nil
+			}
+			return nil, nil
+		},
+	}
+
+	s := newTmuxSession(toTmuxName("close-wait-unobservable-tree", ""), "claude", NewMockPtyFactory(t), cmdExec)
+	state, err := s.CloseAndWaitForPaneExit()
+	require.ErrorContains(t, err, "complete process tree")
+	require.Equal(t, PaneStateUnknown, state,
+		"an unreadable descendant set must not be reduced to the observed exit of the pane leader")
+}
 
 func processIdentity(t *testing.T, pid int) proctree.Process {
 	t.Helper()

--- a/session/tmux/close_wait_test.go
+++ b/session/tmux/close_wait_test.go
@@ -11,29 +11,56 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	"github.com/sachiniyer/agent-factory/internal/proctree"
 )
 
-// deadPID returns a PID that is guaranteed to have exited and been reaped:
-// we spawn a trivial process and wait for it ourselves.
-func deadPID(t *testing.T) int {
+func processIdentity(t *testing.T, pid int) proctree.Process {
 	t.Helper()
-	cmd := exec.Command("true")
-	require.NoError(t, cmd.Run())
-	return cmd.Process.Pid
+	snap, err := proctree.Snapshot()
+	require.NoError(t, err)
+	process, ok := snap[pid]
+	require.True(t, ok, "pid %d missing from process snapshot", pid)
+	return process
 }
 
-func TestWaitForPIDExit_ExitedProcess(t *testing.T) {
+// exitedProcess returns the captured identity of a process that is now fully
+// exited and reaped, so a later PID reuse cannot change the expected answer.
+func exitedProcess(t *testing.T) proctree.Process {
+	t.Helper()
+	cmd := exec.Command("sleep", "300")
+	require.NoError(t, cmd.Start())
+	process := processIdentity(t, cmd.Process.Pid)
+	require.NoError(t, cmd.Process.Kill())
+	_, _ = cmd.Process.Wait()
+	return process
+}
+
+func TestWaitForProcessExit_ExitedProcess(t *testing.T) {
 	start := time.Now()
-	require.True(t, waitForPIDExit(deadPID(t), 2*time.Second),
+	require.True(t, waitForProcessExit(exitedProcess(t), 2*time.Second),
 		"an already-exited PID must report exited")
 	require.Less(t, time.Since(start), time.Second,
 		"a dead PID must be detected without burning the timeout")
 }
 
-func TestWaitForPIDExit_AliveProcessTimesOut(t *testing.T) {
+func TestWaitForProcessExit_AliveProcessTimesOut(t *testing.T) {
 	// Our own PID is alive for the duration of the test.
-	require.False(t, waitForPIDExit(os.Getpid(), 120*time.Millisecond),
+	require.False(t, waitForProcessExit(processIdentity(t, os.Getpid()), 120*time.Millisecond),
 		"a live PID must report not-exited once the timeout elapses")
+}
+
+func TestWaitForProcessExit_ZombieCountsAsExited(t *testing.T) {
+	cmd := exec.Command("sleep", "300")
+	require.NoError(t, cmd.Start())
+	process := processIdentity(t, cmd.Process.Pid)
+	t.Cleanup(func() { _, _ = cmd.Process.Wait() })
+	require.NoError(t, cmd.Process.Kill())
+
+	start := time.Now()
+	require.True(t, waitForProcessExit(process, 500*time.Millisecond),
+		"a pane that exited but remains an unreaped zombie is no longer writing")
+	require.Less(t, time.Since(start), 250*time.Millisecond,
+		"an exited pane must not burn the teardown wait budget")
 }
 
 func TestCloseAndWaitForPaneExit_AlivePaneKeepsCleanupUnsafe(t *testing.T) {
@@ -63,7 +90,8 @@ func TestCloseAndWaitForPaneExit_AlivePaneKeepsCleanupUnsafe(t *testing.T) {
 // kill-session runs (afterwards there is nothing left to query), and the
 // wait happens on that PID after the session is gone.
 func TestCloseAndWaitForPaneExit_QueriesPaneBeforeKill(t *testing.T) {
-	pid := deadPID(t)
+	process := exitedProcess(t)
+	pid := process.PID
 	var calls []string
 
 	cmdExec := cmd_test.MockCmdExec{

--- a/session/tmux/reap.go
+++ b/session/tmux/reap.go
@@ -1,6 +1,8 @@
 package tmux
 
 import (
+	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -49,8 +51,11 @@ var (
 // tmux session's panes: each pane root (verified to be a live child of a
 // tmux server), its ppid-descendants, and its kernel-session members. The
 // teardown paths call it BEFORE kill-session; `af doctor` uses it to map a
-// live session's legitimate processes. Returns nil on any failure — callers
-// treat it as strictly best-effort.
+// live session's legitimate processes. This public diagnostic form is strictly
+// best-effort: a command/snapshot failure returns nil, while malformed individual
+// pane rows are omitted and any independently verified panes are still returned.
+// Destructive teardown uses captureSessionProcessTrees below so it also receives
+// the completeness error and can refuse workspace cleanup.
 //
 // The list-panes probe is bounded by tmuxCommandTimeout (#1917): it runs first
 // on the kill teardown, so an unbounded stall here wedges the kill before
@@ -58,19 +63,31 @@ var (
 // nil (best-effort) result — nothing is reaped, which is the safe direction: a
 // wedged server has told us nothing about which processes are actually leaked.
 func SessionProcessTrees(cmdExec cmd.Executor, sanitizedName string) []proctree.Process {
+	procs, _ := captureSessionProcessTrees(cmdExec, sanitizedName)
+	return procs
+}
+
+// captureSessionProcessTrees is the evidence-bearing half of
+// SessionProcessTrees. Ordinary user-driven teardown remains best-effort and uses
+// any partial result, but a caller about to delete or move the worktree also needs
+// to know whether the capture itself was complete. Returning that answer separately
+// prevents "no descendants" from being confused with "the process table/list-panes
+// could not be read" (#2260 review).
+func captureSessionProcessTrees(cmdExec cmd.Executor, sanitizedName string) ([]proctree.Process, error) {
 	ctx, cancel := tmuxTimeoutContext()
 	defer cancel()
 	out, err := outputTmuxBoundedWith(ctx, cmdExec,
 		"list-panes", "-s", "-t", exactTarget(sanitizedName), "-F", "#{pane_pid}")
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("cannot list panes before teardown: %w", err)
 	}
 	snap, err := proctree.Snapshot()
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("cannot snapshot pane process trees before teardown: %w", err)
 	}
 	seen := make(map[int]bool)
 	var procs []proctree.Process
+	var captureErrs []error
 	add := func(p proctree.Process) {
 		if !seen[p.PID] {
 			seen[p.PID] = true
@@ -80,10 +97,12 @@ func SessionProcessTrees(cmdExec cmd.Executor, sanitizedName string) []proctree.
 	for _, field := range strings.Fields(string(out)) {
 		panePID, err := strconv.Atoi(field)
 		if err != nil || panePID <= 1 {
+			captureErrs = append(captureErrs, fmt.Errorf("invalid pane pid %q in list-panes output", field))
 			continue
 		}
 		root, ok := snap[panePID]
 		if !ok {
+			captureErrs = append(captureErrs, fmt.Errorf("pane process %d disappeared before its descendants could be captured", panePID))
 			continue
 		}
 		// A real pane root is a direct child of a tmux server. Anything
@@ -92,6 +111,7 @@ func SessionProcessTrees(cmdExec cmd.Executor, sanitizedName string) []proctree.
 		// isn't ours.
 		parent, ok := snap[root.PPID]
 		if !ok || !strings.HasPrefix(parent.Comm, "tmux") {
+			captureErrs = append(captureErrs, fmt.Errorf("pane process %d is not a verified child of a tmux server", panePID))
 			continue
 		}
 		for _, p := range proctree.TreeOf(snap, panePID) {
@@ -104,7 +124,7 @@ func SessionProcessTrees(cmdExec cmd.Executor, sanitizedName string) []proctree.
 			add(p)
 		}
 	}
-	return procs
+	return procs, errors.Join(captureErrs...)
 }
 
 // reapLeakedProcesses waits for the captured processes to exit after
@@ -112,8 +132,8 @@ func SessionProcessTrees(cmdExec cmd.Executor, sanitizedName string) []proctree.
 // verified — see proctree.KillEscalating). Runs synchronously; teardown
 // paths that must stay snappy call it in a goroutine. Every signal is logged
 // per-process.
-func reapLeakedProcesses(sanitizedName string, procs []proctree.Process, grace, termWait time.Duration) {
-	proctree.KillEscalating(procs, grace, termWait, func(format string, args ...any) {
+func reapLeakedProcesses(sanitizedName string, procs []proctree.Process, grace, termWait time.Duration) []proctree.Process {
+	return proctree.KillEscalating(procs, grace, termWait, func(format string, args ...any) {
 		// sanitizedName is a runtime value that deliberately preserves `%` (see
 		// tmux name sanitization), so it must be a `%s` ARGUMENT — never spliced
 		// into the format string, where its `%` sequences would be interpreted

--- a/session/tmux/server_scope_linux_test.go
+++ b/session/tmux/server_scope_linux_test.go
@@ -104,11 +104,14 @@ func (f refusingTrackedPtyFactory) StartTracked(*exec.Cmd) (*os.File, <-chan err
 
 func (refusingTrackedPtyFactory) Close() {}
 
-// TestSystemdRunRefusalIsActionable covers the severe failure mode where the
-// wrapper binary exists but the user manager refuses the transient scope. Pty
-// used to discard that exit status, so Start waited two seconds and blamed tmux
-// readiness; the CreateSession RPC now carries systemd-run's role and failure.
-func TestSystemdRunRefusalIsActionable(t *testing.T) {
+// TestSystemdRunRefusalIsActionableButCleanupUnsafe covers the severe failure
+// mode where the wrapper binary exists but the user manager refuses the
+// transient scope. Pty used to discard that exit status, so Start waited two
+// seconds and blamed tmux readiness; the CreateSession RPC now carries
+// systemd-run's role and failure. The wait channel cannot prove whether a
+// generic non-zero wrapper status came from systemd-run itself or the scoped
+// tmux child, though, so it must not authorize fresh-worktree deletion.
+func TestSystemdRunRefusalIsActionableButCleanupUnsafe(t *testing.T) {
 	t.Setenv(systemdDaemonMarkerEnv, systemdDaemonUnit)
 	t.Setenv("SYSTEMD_EXEC_PID", strconv.Itoa(os.Getpid()))
 	stubSelfCgroup(t, "", errors.New("proc unavailable"))
@@ -133,8 +136,8 @@ func TestSystemdRunRefusalIsActionable(t *testing.T) {
 	if err == nil {
 		t.Fatal("Start succeeded after systemd-run refused the transient scope")
 	}
-	if !errors.Is(err, ErrSessionNotStarted) {
-		t.Fatalf("systemd-run exited and the follow-up probe confirmed the session absent, but the outcome remained unknown: %v", err)
+	if errors.Is(err, ErrSessionNotStarted) {
+		t.Fatalf("a systemd-run exit was mistaken for proof that its scoped child never started: %v", err)
 	}
 	for _, want := range []string{
 		"systemd-run --user --scope failed",

--- a/session/tmux/server_scope_linux_test.go
+++ b/session/tmux/server_scope_linux_test.go
@@ -133,6 +133,9 @@ func TestSystemdRunRefusalIsActionable(t *testing.T) {
 	if err == nil {
 		t.Fatal("Start succeeded after systemd-run refused the transient scope")
 	}
+	if !errors.Is(err, ErrSessionNotStarted) {
+		t.Fatalf("systemd-run exited and the follow-up probe confirmed the session absent, but the outcome remained unknown: %v", err)
+	}
 	for _, want := range []string{
 		"systemd-run --user --scope failed",
 		"Failed to start transient scope unit: Access denied",

--- a/session/tmux/session.go
+++ b/session/tmux/session.go
@@ -98,14 +98,17 @@ const TmuxPrefix = "af_"
 // does not use this sentinel.
 var ErrSessionGone = errors.New("tmux session no longer exists")
 
-// ErrSessionNotStarted is positive evidence that Start failed before its
-// new-session process began. LocalBackend is allowed to remove a newly-created
-// worktree only when this marker is present; every other Start error is
-// conservatively treated as a session that may be running in that workspace.
+// ErrSessionNotStarted is positive evidence that a failed Start left no tmux
+// session running under the fresh launch identity. The process may have failed
+// before it began, its answered launch command may have left the name absent, or
+// a readiness-timeout cleanup may have confirmed the name gone. LocalBackend is
+// allowed to remove a newly-created worktree only when this marker is present;
+// every other Start error is conservatively treated as a session that may be
+// running in that workspace.
 //
-// This is deliberately narrower than "Start returned an error". In particular,
-// a readiness timeout means af did not observe the session under the name it
-// probed; it does not prove tmux failed to create one (#2207).
+// A readiness timeout for a legacy spelling still does not prove tmux failed to
+// create one: tmux may have rewritten that spelling (#2207). Only names admitted
+// by hasStableTmuxSpelling can turn a confirmed absence into this marker.
 var ErrSessionNotStarted = errors.New("tmux session definitely did not start")
 
 // DetachKeyByte is the ASCII byte for the key used to detach from attached sessions.
@@ -145,7 +148,7 @@ func repoHash(repoPath string) string {
 func toTmuxName(title string, repoPath string) string {
 	title = strings.Map(func(r rune) rune {
 		switch {
-		case unicode.IsLetter(r), unicode.IsNumber(r), unicode.IsMark(r), r == '_', r == '-':
+		case stableTmuxNameRune(r):
 			return r
 		case unicode.IsSpace(r):
 			return -1
@@ -159,6 +162,37 @@ func toTmuxName(title string, repoPath string) string {
 	return fmt.Sprintf("%s%s", TmuxPrefix, title)
 }
 
+// stableTmuxNameRune is the positive punctuation policy shared by fresh-name
+// construction and the post-start proof that tmux could not have rewritten the
+// name. Keeping one predicate makes widening or narrowing that policy atomic.
+func stableTmuxNameRune(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsNumber(r) || unicode.IsMark(r) || r == '_' || r == '-'
+}
+
+// SanitizedNameForRepo returns the exact tmux session name a fresh local
+// session with title will use in repoPath. Admission checks call this same
+// derivation as NewTmuxSessionForRepo so the namespace they reserve cannot drift
+// from the namespace Start eventually claims.
+func SanitizedNameForRepo(title, repoPath string) string {
+	return toTmuxName(title, repoPath)
+}
+
+// hasStableTmuxSpelling reports whether tmux stores name byte-for-byte. Fresh
+// names produced by toTmuxName satisfy this positive policy. Legacy persisted
+// exact names may not; Start must keep treating an apparently absent legacy name
+// as unknown because tmux may have rewritten it when it was created (#2207).
+func hasStableTmuxSpelling(name string) bool {
+	if !strings.HasPrefix(name, TmuxPrefix) {
+		return false
+	}
+	for _, r := range name {
+		if !stableTmuxNameRune(r) {
+			return false
+		}
+	}
+	return true
+}
+
 // NewTmuxSession creates a new TmuxSession with the given name and program (no repo scoping).
 func NewTmuxSession(name string, program string) *TmuxSession {
 	return newTmuxSession(toTmuxName(name, ""), program, MakePtyFactory(), cmd.MakeExecutor())
@@ -166,7 +200,7 @@ func NewTmuxSession(name string, program string) *TmuxSession {
 
 // NewTmuxSessionForRepo creates a new TmuxSession with a repo-scoped name to avoid collisions.
 func NewTmuxSessionForRepo(name string, repoPath string, program string) *TmuxSession {
-	return newTmuxSession(toTmuxName(name, repoPath), program, MakePtyFactory(), cmd.MakeExecutor())
+	return newTmuxSession(SanitizedNameForRepo(name, repoPath), program, MakePtyFactory(), cmd.MakeExecutor())
 }
 
 // NewTmuxSessionFromSanitizedName creates a new TmuxSession with an exact pre-computed name.

--- a/session/tmux/session.go
+++ b/session/tmux/session.go
@@ -98,13 +98,14 @@ const TmuxPrefix = "af_"
 // does not use this sentinel.
 var ErrSessionGone = errors.New("tmux session no longer exists")
 
-// ErrSessionNotStarted is positive evidence that a failed Start left no tmux
-// session running under the fresh launch identity. The process may have failed
-// before it began, its answered launch command may have left the name absent, or
-// a readiness-timeout cleanup may have confirmed the name gone. LocalBackend is
-// allowed to remove a newly-created worktree only when this marker is present;
-// every other Start error is conservatively treated as a session that may be
-// running in that workspace.
+// ErrSessionNotStarted is positive evidence that a failed Start left no pane
+// process able to write into the fresh worktree. The launch may have failed
+// before its process began, or bounded readiness-timeout cleanup may have both
+// removed the session and confirmed its pane exited. An answered launch failure
+// is not enough: later name absence cannot prove that a pane never ran or finished
+// flushing. LocalBackend may remove a newly-created worktree only when this marker
+// is present; every other Start error is conservatively treated as a session that
+// may still be using that workspace.
 //
 // A readiness timeout for a legacy spelling still does not prove tmux failed to
 // create one: tmux may have rewritten that spelling (#2207). Only names admitted

--- a/session/tmux/start.go
+++ b/session/tmux/start.go
@@ -122,15 +122,20 @@ func (t *TmuxSession) Start(workDir string) error {
 			// diagnostics, and older callers may still distinguish an unknown tmux
 			// outcome from a clean pre-spawn failure. %w, never %v, so the sentinel
 			// survives every wrapping layer.
-			cleanupState, cleanupErr := t.Close()
+			// A timeout may happen after tmux created a pane but before has-session
+			// observed it. Teardown alone is not cleanup proof: kill-session returns
+			// before the pane process finishes flushing. Wait for that process here,
+			// and keep the outcome unknown if it outlives the bound, so LocalBackend
+			// cannot remove the fresh worktree underneath its final writes.
+			cleanupState, cleanupErr := t.CloseAndWaitForPaneExit()
 			if cleanupErr != nil {
 				timeoutErr = fmt.Errorf("%v (cleanup error: %v)", timeoutErr, cleanupErr)
 			}
-			// A successful Close on a positive-policy name establishes that the
-			// exact launch identity is gone. The old blanket timeout classification
-			// was necessary only while a fresh title could contain spellings tmux
-			// rewrote (#2207); legacy exact names still stay on that conservative
-			// path through hasStableTmuxSpelling.
+			// A successful close+pane-exit confirmation on a positive-policy name
+			// establishes that the exact launch identity is gone. The old blanket
+			// timeout classification was necessary only while a fresh title could
+			// contain spellings tmux rewrote (#2207); legacy exact names still stay
+			// on that conservative path through hasStableTmuxSpelling.
 			if cleanupState == PaneStateKnown && cleanupErr == nil && hasStableTmuxSpelling(t.sanitizedName) {
 				return fmt.Errorf("%w: %w", timeoutErr, ErrSessionNotStarted)
 			}

--- a/session/tmux/start.go
+++ b/session/tmux/start.go
@@ -85,10 +85,28 @@ func (t *TmuxSession) Start(workDir string) error {
 			commandDone = nil
 			if commandErr != nil {
 				_ = ptmx.Close()
+				var launchErr error
 				if systemdScoped {
-					return fmt.Errorf("error starting tmux session: systemd-run --user --scope failed to create session %q: %w", t.sanitizedName, commandErr)
+					launchErr = fmt.Errorf("error starting tmux session: systemd-run --user --scope failed to create session %q: %w", t.sanitizedName, commandErr)
+				} else {
+					launchErr = fmt.Errorf("error starting tmux session: tmux new-session for %q failed: %w", t.sanitizedName, commandErr)
 				}
-				return fmt.Errorf("error starting tmux session: tmux new-session for %q failed: %w", t.sanitizedName, commandErr)
+
+				// The launch process began, so its exit status alone is not proof that
+				// no runtime remains. Ask once more AFTER receiving that status. For a
+				// fresh positive-policy name, an answered "absent" is conclusive and
+				// authorizes LocalBackend to remove the just-created worktree. A live,
+				// unanswered, or legacy-rewritten name remains conservative.
+				if hasStableTmuxSpelling(t.sanitizedName) {
+					exists, known := t.ProbeSession()
+					switch {
+					case known && !exists:
+						return fmt.Errorf("%w: %w", launchErr, ErrSessionNotStarted)
+					case !known:
+						return fmt.Errorf("%w: follow-up has-session probe did not answer: %w", launchErr, ErrTmuxTimeout)
+					}
+				}
+				return launchErr
 			}
 		case <-timeout:
 			ptmx.Close()
@@ -104,14 +122,18 @@ func (t *TmuxSession) Start(workDir string) error {
 			// diagnostics, and older callers may still distinguish an unknown tmux
 			// outcome from a clean pre-spawn failure. %w, never %v, so the sentinel
 			// survives every wrapping layer.
-			_, cleanupErr := t.Close()
+			cleanupState, cleanupErr := t.Close()
 			if cleanupErr != nil {
 				timeoutErr = fmt.Errorf("%v (cleanup error: %v)", timeoutErr, cleanupErr)
 			}
-			// The readiness deadline itself is the unknown. Even if Close
-			// confidently reports that the requested name is absent, tmux may
-			// have created a differently escaped name that Close never targeted
-			// (#2207). A timeout can therefore never authorize workspace deletion.
+			// A successful Close on a positive-policy name establishes that the
+			// exact launch identity is gone. The old blanket timeout classification
+			// was necessary only while a fresh title could contain spellings tmux
+			// rewrote (#2207); legacy exact names still stay on that conservative
+			// path through hasStableTmuxSpelling.
+			if cleanupState == PaneStateKnown && cleanupErr == nil && hasStableTmuxSpelling(t.sanitizedName) {
+				return fmt.Errorf("%w: %w", timeoutErr, ErrSessionNotStarted)
+			}
 			return fmt.Errorf("%w: %w", timeoutErr, ErrTmuxTimeout)
 		default:
 			time.Sleep(sleepDuration)

--- a/session/tmux/start.go
+++ b/session/tmux/start.go
@@ -92,20 +92,10 @@ func (t *TmuxSession) Start(workDir string) error {
 					launchErr = fmt.Errorf("error starting tmux session: tmux new-session for %q failed: %w", t.sanitizedName, commandErr)
 				}
 
-				// The launch process began, so its exit status alone is not proof that
-				// no runtime remains. Ask once more AFTER receiving that status. For a
-				// fresh positive-policy name, an answered "absent" is conclusive and
-				// authorizes LocalBackend to remove the just-created worktree. A live,
-				// unanswered, or legacy-rewritten name remains conservative.
-				if hasStableTmuxSpelling(t.sanitizedName) {
-					exists, known := t.ProbeSession()
-					switch {
-					case known && !exists:
-						return fmt.Errorf("%w: %w", launchErr, ErrSessionNotStarted)
-					case !known:
-						return fmt.Errorf("%w: follow-up has-session probe did not answer: %w", launchErr, ErrTmuxTimeout)
-					}
-				}
+				// The launch process began. Its exit status, even paired with later
+				// name absence, cannot prove a pane never ran and is not still flushing
+				// after tmux removed its session. Keep every answered post-spawn failure
+				// outside ErrSessionNotStarted so LocalBackend preserves the worktree.
 				return launchErr
 			}
 		case <-timeout:

--- a/session/tmux/start_answered_failure_test.go
+++ b/session/tmux/start_answered_failure_test.go
@@ -69,11 +69,11 @@ func (f answeredFailurePtyFactory) StartTracked(*exec.Cmd) (*os.File, <-chan err
 
 func (answeredFailurePtyFactory) Close() {}
 
-// TestStartAnsweredCommandFailureConfirmsAbsence covers a new-session (or its
-// systemd-run wrapper) that exits non-zero and a follow-up exact probe that
-// answers that no session exists. The launch process did begin, but the runtime
-// outcome is known absent, so callers may remove the just-created worktree.
-func TestStartAnsweredCommandFailureConfirmsAbsence(t *testing.T) {
+// TestStartAnsweredCommandFailureDoesNotClaimPreSpawn covers a new-session (or
+// its systemd-run wrapper) that exits non-zero while exact probes answer that no
+// session exists. The launch process began, so later name absence is not proof
+// that a pane never ran or finished flushing into the worktree.
+func TestStartAnsweredCommandFailureDoesNotClaimPreSpawn(t *testing.T) {
 	forceNewSessionEnvMarkers(t, false)
 	cmdExec := cmd_test.MockCmdExec{
 		RunFunc: func(*exec.Cmd) error { return errors.New("session not found") },
@@ -91,7 +91,7 @@ func TestStartAnsweredCommandFailureConfirmsAbsence(t *testing.T) {
 	if err == nil {
 		t.Fatal("Start succeeded after its launch command exited non-zero")
 	}
-	if !errors.Is(err, ErrSessionNotStarted) {
-		t.Fatalf("an answered follow-up probe confirmed the session absent, but Start left the outcome unknown: %v", err)
+	if errors.Is(err, ErrSessionNotStarted) {
+		t.Fatalf("a post-spawn failure was misclassified as proof the process never began: %v", err)
 	}
 }

--- a/session/tmux/start_answered_failure_test.go
+++ b/session/tmux/start_answered_failure_test.go
@@ -1,0 +1,97 @@
+package tmux
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"sync/atomic"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+)
+
+type answeredFailurePtyFactory struct {
+	t       *testing.T
+	waitErr error
+}
+
+// TestStartAnsweredCommandFailureDoesNotOverrideObservedSession proves the exit
+// status is not itself the cleanup marker. If the post-exit probe sees the
+// runtime, the workspace must remain protected even though new-session failed.
+func TestStartAnsweredCommandFailureDoesNotOverrideObservedSession(t *testing.T) {
+	forceNewSessionEnvMarkers(t, false)
+	var probes atomic.Int32
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			for _, arg := range c.Args {
+				if arg != "has-session" {
+					continue
+				}
+				if probes.Add(1) >= 3 {
+					return nil
+				}
+				return errors.New("session not found")
+			}
+			return nil
+		},
+		OutputFunc: func(*exec.Cmd) ([]byte, error) { return nil, nil },
+	}
+	ptyFactory := answeredFailurePtyFactory{
+		t:       t,
+		waitErr: errors.New("new-session returned a late failure"),
+	}
+	ts := NewTmuxSessionWithDeps("answered-start-live", "sh", ptyFactory, cmdExec)
+
+	err := ts.Start(t.TempDir())
+	if err == nil {
+		t.Fatal("Start succeeded after its launch command exited non-zero")
+	}
+	if errors.Is(err, ErrSessionNotStarted) {
+		t.Fatalf("Start marked the workspace cleanup-safe even though its post-exit probe saw the session: %v", err)
+	}
+}
+
+func (f answeredFailurePtyFactory) Start(*exec.Cmd) (*os.File, error) {
+	f.t.Fatal("Start called instead of StartTracked")
+	return nil, nil
+}
+
+func (f answeredFailurePtyFactory) StartTracked(*exec.Cmd) (*os.File, <-chan error, error) {
+	ptmx, err := os.CreateTemp(f.t.TempDir(), "answered-start-pty")
+	if err != nil {
+		return nil, nil, err
+	}
+	done := make(chan error, 1)
+	done <- f.waitErr
+	close(done)
+	return ptmx, done, nil
+}
+
+func (answeredFailurePtyFactory) Close() {}
+
+// TestStartAnsweredCommandFailureConfirmsAbsence covers a new-session (or its
+// systemd-run wrapper) that exits non-zero and a follow-up exact probe that
+// answers that no session exists. The launch process did begin, but the runtime
+// outcome is known absent, so callers may remove the just-created worktree.
+func TestStartAnsweredCommandFailureConfirmsAbsence(t *testing.T) {
+	forceNewSessionEnvMarkers(t, false)
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(*exec.Cmd) error { return errors.New("session not found") },
+		OutputFunc: func(*exec.Cmd) ([]byte, error) {
+			return nil, nil
+		},
+	}
+	ptyFactory := answeredFailurePtyFactory{
+		t:       t,
+		waitErr: errors.New("new-session refused the request"),
+	}
+	ts := NewTmuxSessionWithDeps("answered-start-failure", "sh", ptyFactory, cmdExec)
+
+	err := ts.Start(t.TempDir())
+	if err == nil {
+		t.Fatal("Start succeeded after its launch command exited non-zero")
+	}
+	if !errors.Is(err, ErrSessionNotStarted) {
+		t.Fatalf("an answered follow-up probe confirmed the session absent, but Start left the outcome unknown: %v", err)
+	}
+}

--- a/session/tmux/tmux_test.go
+++ b/session/tmux/tmux_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	cmd2 "github.com/sachiniyer/agent-factory/cmd"
 
@@ -302,6 +303,34 @@ func TestStartTimeoutCleanupSucceeds(t *testing.T) {
 	require.Contains(t, err.Error(), "timed out waiting for tmux session af_timeout-ok")
 	require.NotContains(t, err.Error(), "<nil>")
 	require.NotContains(t, err.Error(), "cleanup error")
+}
+
+func TestStartTimeoutKeepsCleanupUnsafeWhileKilledPaneStillRuns(t *testing.T) {
+	oldWait := paneExitWait
+	paneExitWait = 20 * time.Millisecond
+	t.Cleanup(func() { paneExitWait = oldWait })
+	ptyFactory := NewMockPtyFactory(t)
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			if strings.Contains(cmd.String(), "has-session") {
+				return fmt.Errorf("session not found")
+			}
+			return nil
+		},
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+			if strings.Contains(cmd.String(), "display-message") {
+				return []byte(fmt.Sprintf("%d\n", os.Getpid())), nil
+			}
+			return nil, nil
+		},
+	}
+	session := newTmuxSession(toTmuxName("timeout-live-pane", ""), "claude", ptyFactory, cmdExec)
+
+	err := session.Start(t.TempDir())
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrTmuxTimeout)
+	require.NotErrorIs(t, err, ErrSessionNotStarted,
+		"a pane that has not exited must never authorize fresh-worktree removal")
 }
 
 // TestStartTimeoutCleanupFails is the companion to the #696 guard: when

--- a/session/tmux/tmux_test.go
+++ b/session/tmux/tmux_test.go
@@ -276,9 +276,10 @@ func TestStartTmuxSession(t *testing.T) {
 	require.Error(t, err)
 }
 
-// TestStartTimeoutCleanupSucceeds guards issue #696: when the session never
-// appears before the startup timeout and cleanup succeeds, the error must
-// describe the timeout without rendering a nil error as the literal "<nil>".
+// TestStartTimeoutCleanupSucceeds guards issue #696: when the positively
+// sanitized session never appears before the startup timeout and cleanup
+// confirms it absent, the error must authorize cleanup without rendering a nil
+// error as the literal "<nil>".
 func TestStartTimeoutCleanupSucceeds(t *testing.T) {
 	ptyFactory := NewMockPtyFactory(t)
 
@@ -297,8 +298,7 @@ func TestStartTimeoutCleanupSucceeds(t *testing.T) {
 
 	err := session.Start(t.TempDir())
 	require.Error(t, err)
-	require.ErrorIs(t, err, ErrTmuxTimeout)
-	require.NotErrorIs(t, err, ErrSessionNotStarted)
+	require.ErrorIs(t, err, ErrSessionNotStarted)
 	require.Contains(t, err.Error(), "timed out waiting for tmux session af_timeout-ok")
 	require.NotContains(t, err.Error(), "<nil>")
 	require.NotContains(t, err.Error(), "cleanup error")

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -312,17 +312,23 @@ func (m *Menu) SetNamingHasPrompt(has bool) {
 }
 
 func (m *Menu) addInstanceOptions() {
-	// A row with no shared lifecycle action gets the same minimal menu on every
-	// surface (#2234). This includes a create still in flight and a legacy/id-less
-	// row whose destructive target cannot be addressed unambiguously.
+	// Archive/restore and explicit teardown are separate capabilities. A retained
+	// startup-unknown row cannot safely reuse its runtime binding, but its stable
+	// record must still expose Kill so the user can remove it.
 	lifecycleAction := session.LifecycleActionNone
+	canKill := false
 	if m.instance != nil {
 		lifecycleAction = m.instance.LifecycleAction()
+		canKill = m.instance.CanKill()
 	}
 	if lifecycleAction == session.LifecycleActionNone {
-		m.options = []keys.KeyName{keys.KeyNew, keys.KeyHelp, keys.KeyQuit}
+		m.options = []keys.KeyName{keys.KeyNew}
+		if canKill {
+			m.options = append(m.options, keys.KeyKill)
+		}
+		m.options = append(m.options, keys.KeyHelp, keys.KeyQuit)
 		m.groups = []menuGroup{
-			{start: 0, end: 3, isAction: false},
+			{start: 0, end: len(m.options), isAction: false},
 		}
 		return
 	}

--- a/ui/menu_test.go
+++ b/ui/menu_test.go
@@ -148,6 +148,29 @@ func TestMenuArchiveRestoreActionByRowState(t *testing.T) {
 	}
 }
 
+// A create whose launch crossed the uncertainty boundary is deliberately inert:
+// af cannot safely attach, archive, or restore it because the runtime identity was
+// never confirmed. Its stable record is still the only cleanup handle the user
+// has, though, so the footer must keep Kill available as a separate capability.
+func TestMenuStartupUnknownOffersKillWithoutRuntimeActions(t *testing.T) {
+	inst := readyUIInstance()
+	inst.MarkStartupStateUnknown()
+	m := NewMenu()
+	m.SetInstance(inst)
+
+	if !menuHasOption(m, keys.KeyKill) {
+		t.Fatal("startup-unknown row has no Kill action")
+	}
+	for _, forbidden := range []keys.KeyName{
+		keys.KeyArchive, keys.KeyRestore, keys.KeyEnter, keys.KeyAttach,
+		keys.KeyNewTab, keys.KeyCloseTab, keys.KeyOpenPane,
+	} {
+		if menuHasOption(m, forbidden) {
+			t.Fatalf("startup-unknown row exposes unsafe action %q", forbidden)
+		}
+	}
+}
+
 // TestMenuArchiveRestoreHintByRowState verifies the mgmt-group footer hint
 // (#1605): a live row advertises `a archive`; a resting (archived/lost/dead) row
 // advertises the dedicated `r restore` key instead. The two verbs live on

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -11854,6 +11854,11 @@ function openFromRail(id) {
   focusTerminal();
 }
 function focusTerminal() {
+  const selected = selectedSessionData();
+  if (!selected || !isActionableSession(selected)) {
+    focusRail();
+    return;
+  }
   if (!splitView.focus()) {
     focusRail();
     return;
@@ -12346,14 +12351,16 @@ function syncSplit(state) {
   const tok = token;
   const initialTab = clampActiveTab(state.sessions, selId, state.activeTab);
   const selected = selId ? state.sessions.find((s) => s.id === selId) : null;
-  const tabIds = selected ? sessionTabs(selected).map(tabIdentity) : ["0:"];
-  const tabRealIds = selected ? sessionTabs(selected).map(tabRealId) : [""];
-  const tabTargets = selected ? sessionTabs(selected).map((t) => t.url) : [];
-  const tabKinds = selected ? sessionTabs(selected).map((t) => t.kind) : [];
-  const tabNames = selected ? sessionTabs(selected).map((t) => t.name) : [];
-  const archived = selected ? isArchived(selected) : false;
+  const runtimeSelected = selected && isActionableSession(selected) ? selected : null;
+  const runtimeSessionId = runtimeSelected ? selId : null;
+  const tabIds = runtimeSelected ? sessionTabs(runtimeSelected).map(tabIdentity) : ["0:"];
+  const tabRealIds = runtimeSelected ? sessionTabs(runtimeSelected).map(tabRealId) : [""];
+  const tabTargets = runtimeSelected ? sessionTabs(runtimeSelected).map((t) => t.url) : [];
+  const tabKinds = runtimeSelected ? sessionTabs(runtimeSelected).map((t) => t.kind) : [];
+  const tabNames = runtimeSelected ? sessionTabs(runtimeSelected).map((t) => t.name) : [];
+  const archived = runtimeSelected ? isArchived(runtimeSelected) : false;
   splitView.setSession(
-    tok !== null ? selId : null,
+    tok !== null ? runtimeSessionId : null,
     tok,
     tabIds,
     initialTab,
@@ -12448,8 +12455,9 @@ function onKeydown(e) {
   if (!inTerminal && e.key !== "Escape" && isNativeControl(target)) {
     return;
   }
-  const focus = state.selectedId && state.view === "sessions" ? state.focus : "rail";
   const selected = selectedSessionData();
+  const actionableSelected = selected && isActionableSession(selected) ? selected : null;
+  const focus = state.selectedId && actionableSelected && state.view === "sessions" ? state.focus : "rail";
   const action = decideKey(
     e.key,
     {
@@ -12465,11 +12473,11 @@ function onKeydown(e) {
       orderedIds: filterSessions(
         orderedSessions(scopeToProject(state.sessions, state.selectedProject)),
         state.statusFilter
-      ).filter((s) => !isCreating(s)).map((s) => s.id ?? "").filter((id) => id !== ""),
-      selectedId: state.selectedId,
-      tabCount: selected ? sessionTabs(selected).length : 1,
+      ).filter(isActionableSession).map((s) => s.id),
+      selectedId: actionableSelected ? state.selectedId : null,
+      tabCount: actionableSelected ? sessionTabs(actionableSelected).length : 1,
       activeTab: state.activeTab,
-      tabManagement: selected ? canManageTabs(selected) : false
+      tabManagement: actionableSelected ? canManageTabs(actionableSelected) : false
     },
     { alt: e.altKey }
   );

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -10236,6 +10236,9 @@ function reorderTargetIndex(from, insertion) {
 function isActionableSession(s) {
   return typeof s.id === "string" && s.id !== "" && (s.lifecycle_action === "archive" || s.lifecycle_action === "restore");
 }
+function isKillableSession(s) {
+  return typeof s.id === "string" && s.id !== "" && s.can_kill === true;
+}
 var MAX_TABS = 9;
 var OFF_BOX_BACKENDS = /* @__PURE__ */ new Set(["docker", "ssh", "remote"]);
 function supportsTabManagement(s) {
@@ -10924,33 +10927,42 @@ var AppShell = class {
     const notice = this.railNotice(state, scoped, visible);
     list.replaceChildren(...notice ? [notice, ...rows] : rows);
   }
-  /** Quiet per-session controls reserved beside every ACTIONABLE rail row (#2186,
-   *  #2223, #2234). The Go projection chooses Archive vs Restore; the browser never
-   *  reconstructs that policy from row state. */
+  /** Quiet controls reserved beside every row carrying at least one daemon-owned
+   *  capability (#2186, #2223, #2234). Archive/Restore and Kill narrow separately;
+   *  the browser never reconstructs either policy from status pixels. */
   rowActions(session, selected) {
-    const lifecycleBtn = h2("button", { type: "button", class: "af-rail-action af-rail-lifecycle" });
-    lifecycleBtn.addEventListener("click", (e) => {
-      e.stopPropagation();
-      if (lifecycleBtn.dataset.action === "restore") {
-        this.runRailExit(() => this.actions.restore(session));
-      } else {
-        this.runRailExit(() => this.actions.archive(session));
+    const buttons = [];
+    if (isActionableSession(session)) {
+      const lifecycleSession = session;
+      const lifecycleBtn = h2("button", { type: "button", class: "af-rail-action af-rail-lifecycle" });
+      lifecycleBtn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        if (lifecycleBtn.dataset.action === "restore") {
+          this.runRailExit(() => this.actions.restore(lifecycleSession));
+        } else {
+          this.runRailExit(() => this.actions.archive(lifecycleSession));
+        }
+      });
+      this.patchLifecycleButton(lifecycleBtn, lifecycleSession.lifecycle_action, lifecycleSession.title);
+      if (selected) {
+        this.lifecycleBtn = lifecycleBtn;
+        this.lifecycleAction = lifecycleSession.lifecycle_action;
       }
-    });
-    this.patchLifecycleButton(lifecycleBtn, session.lifecycle_action, session.title);
-    if (selected) {
-      this.lifecycleBtn = lifecycleBtn;
-      this.lifecycleAction = session.lifecycle_action;
+      buttons.push(lifecycleBtn);
     }
-    const killBtn = h2("button", { type: "button", class: "af-rail-action af-rail-kill" }, "\u232B");
-    const killLabel = `Kill session \u201C${session.title}\u201D`;
-    killBtn.setAttribute("aria-label", killLabel);
-    killBtn.setAttribute("title", killLabel);
-    killBtn.addEventListener("click", (e) => {
-      e.stopPropagation();
-      this.runRailExit(() => this.actions.kill(session));
-    });
-    return h2("div", { class: "af-row-actions" }, lifecycleBtn, killBtn);
+    if (isKillableSession(session)) {
+      const killSession2 = session;
+      const killBtn = h2("button", { type: "button", class: "af-rail-action af-rail-kill" }, "\u232B");
+      const killLabel = `Kill session \u201C${killSession2.title}\u201D`;
+      killBtn.setAttribute("aria-label", killLabel);
+      killBtn.setAttribute("title", killLabel);
+      killBtn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        this.runRailExit(() => this.actions.kill(killSession2));
+      });
+      buttons.push(killBtn);
+    }
+    return h2("div", { class: "af-row-actions" }, ...buttons);
   }
   /** Applies the daemon-projected verb, glyph, and target-qualified accessible name
    *  in one place so render and same-selection live patching cannot drift. */
@@ -11616,6 +11628,8 @@ function sessionRow(s, selected, openSession, buildActions) {
   const status = rowStatus(s);
   const creating = isCreating(s);
   const actionable = isActionableSession(s);
+  const killable = isKillableSession(s);
+  const managed = actionable || killable;
   const title = h2("div", { class: "af-row-title" }, rowTitle(s));
   const branch = h2(
     "div",
@@ -11633,15 +11647,15 @@ function sessionRow(s, selected, openSession, buildActions) {
     row.append(dot);
   }
   row.append(main);
-  if (actionable) {
+  if (managed) {
     row.append(buildActions(s));
   }
   row.setAttribute("role", "option");
   row.setAttribute("aria-selected", selected ? "true" : "false");
   row.setAttribute("title", `${s.title} \u2014 ${status.label}`);
-  if (!actionable) {
+  if (!actionable && !managed) {
     row.setAttribute("aria-disabled", "true");
-  } else {
+  } else if (actionable) {
     row.addEventListener("click", () => openSession(s.id));
   }
   return row;

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "d1d878ae42be";
+const VERSION = "241bcf5ad359";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "241bcf5ad359";
+const VERSION = "210c24a53bef";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -932,6 +932,19 @@ test("#2234: creating and id-less rows expose no lifecycle actions; the shared p
   await expect(railAction(p, "probe-startup-unknown", "Archive session")).toHaveCount(0);
   await expect(railAction(p, "probe-startup-unknown", "Restore session")).toHaveCount(0);
 
+  // Keyboard navigation must apply the same runtime-entry fence as row clicks.
+  // Walk the entire visible rail in both directions: a kill-only retained row may
+  // own its explicit Kill button, but j/k must never make it the terminal target.
+  const visibleRows = await p.locator(".af-rail .af-row").count();
+  let uncertainSelected = false;
+  for (const key of ["j", "k"]) {
+    for (let i = 0; i <= visibleRows; i += 1) {
+      await p.keyboard.press(key);
+      uncertainSelected ||= (await uncertain.getAttribute("aria-selected")) === "true";
+    }
+  }
+  expect(uncertainSelected).toBe(false);
+
   // The same server-owned value selects Archive vs Restore, and every accessible
   // name carries its target now that unselected rows can own controls.
   await expect(railAction(p, "probe-actionable", "Archive session")).toHaveCount(1);

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -894,13 +894,15 @@ test("#2234: creating and id-less rows expose no lifecycle actions; the shared p
       liveness: 2,
       in_flight_op: 0,
       lifecycle_action: "archive",
+      can_kill: true,
       ...extra,
     });
     list.push(
       synth("probe-actionable", {}),
       synth("probe-restorable", { liveness: 3, lifecycle_action: "restore" }),
-      synth("probe-creating", { in_flight_op: 1, lifecycle_action: undefined }),
-      synth("probe-idless", { id: undefined, lifecycle_action: undefined }),
+      synth("probe-startup-unknown", { startup_state_unknown: true, lifecycle_action: undefined }),
+      synth("probe-creating", { in_flight_op: 1, lifecycle_action: undefined, can_kill: undefined }),
+      synth("probe-idless", { id: undefined, lifecycle_action: undefined, can_kill: undefined }),
     );
     if (snap) {
       snap.instances = list;
@@ -920,6 +922,15 @@ test("#2234: creating and id-less rows expose no lifecycle actions; the shared p
     await expect(inert.locator(".af-row-actions")).toHaveCount(0);
     await expect(inert.getByRole("button")).toHaveCount(0);
   }
+
+  // Runtime uncertainty is not a reversible lifecycle action and cannot attach,
+  // but its stable retained record remains explicitly removable.
+  const uncertain = row(p, "probe-startup-unknown");
+  await expect(uncertain).toBeVisible();
+  await uncertain.hover();
+  await expect(railAction(p, "probe-startup-unknown", "Kill session")).toHaveCount(1);
+  await expect(railAction(p, "probe-startup-unknown", "Archive session")).toHaveCount(0);
+  await expect(railAction(p, "probe-startup-unknown", "Restore session")).toHaveCount(0);
 
   // The same server-owned value selects Archive vs Restore, and every accessible
   // name carries its target now that unselected rows can own controls.

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -77,6 +77,7 @@ import {
   tabRealId,
   type ActionableSession,
   type AppState,
+  type KillableSession,
   type NewTabKind,
 } from "./ui.js";
 import type { SessionData, TaskData, WireEvent } from "./types.js";
@@ -604,7 +605,7 @@ function newSession(): void {
 /** Opens the kill/archive/restore confirm modal for the rail row that invoked it.
  *  This cannot derive its target from selection now that hover exposes actions on
  *  unselected rows (#2223). Restore remains the reverse of archive (#1932). */
-function openConfirm(action: "kill" | "archive" | "restore", session: ActionableSession): void {
+function openConfirm(action: "kill" | "archive" | "restore", session: ActionableSession | KillableSession): void {
   const target = { id: session.id, title: session.title };
   openModal(
     confirmModal({
@@ -1295,7 +1296,7 @@ const actions = {
   disconnect,
   open: openFromRail,
   newSession,
-  kill: (session: ActionableSession) => openConfirm("kill", session),
+  kill: (session: KillableSession) => openConfirm("kill", session),
   archive: (session: ActionableSession) => openConfirm("archive", session),
   restore: (session: ActionableSession) => openConfirm("restore", session),
   retryLimit: doRetryLimit,

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -59,7 +59,7 @@ import {
   upsertSession,
 } from "./sessions.js";
 import { SplitView } from "./split.js";
-import { isArchived, isCreating, type RowKind } from "./status.js";
+import { isArchived, type RowKind } from "./status.js";
 import { isRenameableTab } from "./tablabel.js";
 import { Store } from "./store.js";
 import { registerServiceWorker } from "./serviceworker.js";
@@ -69,6 +69,7 @@ import type { ProgramCatalog } from "./programs.js";
 import type { TerminalStatus } from "./terminal.js";
 import {
   AppShell,
+  isActionableSession,
   orderedSessions,
   renderLogin,
   sessionTabs,
@@ -424,6 +425,15 @@ function openFromRail(id: string): void {
  *  there, and a cross-origin iframe's focus is not reliably observable anyway.
  *  switchTab already sets focus:"rail" for exactly this reason. */
 function focusTerminal(): void {
+  const selected = selectedSessionData();
+  if (!selected || !isActionableSession(selected)) {
+    // A kill-only startup-unknown row has a stable management target but no
+    // confirmed runtime binding. Keep every caller behind the same daemon-owned
+    // lifecycle fence as row clicks; focusing whatever SplitView happens to
+    // retain would turn an explicit teardown capability into attach authority.
+    focusRail();
+    return;
+  }
   if (!splitView.focus()) {
     focusRail();
     return;
@@ -1335,32 +1345,39 @@ function syncSplit(state: AppState): void {
   // stale index can never bind a pane to a tab that doesn't exist.
   const initialTab = clampActiveTab(state.sessions, selId, state.activeTab);
   const selected = selId ? state.sessions.find((s) => s.id === selId) : null;
+  // Selection is presentation state; it is not proof that a runtime may be
+  // entered. Startup-unknown rows remain selectable as durable cleanup records,
+  // so bind SplitView only when the daemon also projected a lifecycle capability.
+  // This is the stream-side choke point complement to focusTerminal's keyboard
+  // fence: neither merely selecting nor attaching can reuse an uncertain binding.
+  const runtimeSelected = selected && isActionableSession(selected) ? selected : null;
+  const runtimeSessionId = runtimeSelected ? selId : null;
   // The ordered tab identities, so the split view can (a) know the live tab count and
   // (b) reject a drop whose drag-time snapshot no longer matches (a mid-drag reorder).
-  const tabIds = selected ? sessionTabs(selected).map(tabIdentity) : ["0:"];
+  const tabIds = runtimeSelected ? sessionTabs(runtimeSelected).map(tabIdentity) : ["0:"];
   // The REAL daemon ids ("" where a tab has none), parallel to tabIds. The split view
   // needs BOTH: tabIds is its local identity/change-detection key (always non-empty,
   // synthesized when needed), while these are the only values it may send as a
   // ?tab_id= or trust as collision-proof (#1779).
-  const tabRealIds = selected ? sessionTabs(selected).map(tabRealId) : [""];
+  const tabRealIds = runtimeSelected ? sessionTabs(runtimeSelected).map(tabRealId) : [""];
   // The per-tab iframe target for web tabs (undefined for terminal tabs), parallel
   // to tabIds, so the split view can iframe a web leaf.
-  const tabTargets = selected ? sessionTabs(selected).map((t) => t.url) : [];
+  const tabTargets = runtimeSelected ? sessionTabs(runtimeSelected).map((t) => t.url) : [];
   // The kind of each tab, parallel to tabIds — the split view reads it to tell a web
   // tab from a terminal one now that the identity is the opaque stable id (#1738).
-  const tabKinds = selected ? sessionTabs(selected).map((t) => t.kind) : [];
+  const tabKinds = runtimeSelected ? sessionTabs(runtimeSelected).map((t) => t.kind) : [];
   // Each tab's NAME, parallel to tabIds — what the pane headers render, with the kind,
   // through the same tablabel.ts derivation the tab bar uses (#1813). Before this the
   // panes had no name to render and drew a positional "Tab N" instead.
-  const tabNames = selected ? sessionTabs(selected).map((t) => t.name) : [];
+  const tabNames = runtimeSelected ? sessionTabs(runtimeSelected).map((t) => t.name) : [];
   // Whether the shown session is archived (#1809 follow-up): an archived session's
   // preserved web tabs render an inert placeholder rather than a live frame, and the
   // flip re-renders them on archive/restore even when the tab list is unchanged.
-  const archived = selected ? isArchived(selected) : false;
+  const archived = runtimeSelected ? isArchived(runtimeSelected) : false;
   // `tok !== null` not `tok`: "" is the authorized-tokenless credential (#1696), so a
   // loopback client still attaches its live panes.
   splitView.setSession(
-    tok !== null ? selId : null,
+    tok !== null ? runtimeSessionId : null,
     tok,
     tabIds,
     initialTab,
@@ -1524,9 +1541,11 @@ function onKeydown(e: KeyboardEvent): void {
   // to the projects/tasks view (which hides the panes) must not leave the stored focus
   // stale, so we never honor terminal mode without a live, visible pane. The pure state
   // machine (nav.ts) decides the rest; index.ts only performs the effect.
-  const focus: KeyboardFocus = state.selectedId && state.view === "sessions" ? state.focus : "rail";
-  // The selected session's tab shape drives the nav-mode tab keys (1-9 / t / w).
   const selected = selectedSessionData();
+  const actionableSelected = selected && isActionableSession(selected) ? selected : null;
+  const focus: KeyboardFocus =
+    state.selectedId && actionableSelected && state.view === "sessions" ? state.focus : "rail";
+  // The selected session's tab shape drives the nav-mode tab keys (1-9 / t / w).
   const action = decideKey(
     e.key,
     {
@@ -1543,16 +1562,16 @@ function onKeydown(e: KeyboardEvent): void {
         orderedSessions(scopeToProject(state.sessions, state.selectedProject)),
         state.statusFilter,
       )
-        // Creating rows are visible daemon state but not selectable: no terminal
-        // exists until CreateSession resolves, and success owns the one atomic
-        // upsert+selection that opens it attached.
-        .filter((s) => !isCreating(s))
-        .map((s) => s.id ?? "")
-        .filter((id) => id !== ""),
-      selectedId: state.selectedId,
-      tabCount: selected ? sessionTabs(selected).length : 1,
+        // Keyboard selection is a runtime-entry path: walk only rows carrying the
+        // daemon's lifecycle capability, exactly like pointer-open. A kill-only
+        // startup-unknown row remains visible/removable but cannot become a pane
+        // target through j/k.
+        .filter(isActionableSession)
+        .map((s) => s.id),
+      selectedId: actionableSelected ? state.selectedId : null,
+      tabCount: actionableSelected ? sessionTabs(actionableSelected).length : 1,
       activeTab: state.activeTab,
-      tabManagement: selected ? canManageTabs(selected) : false,
+      tabManagement: actionableSelected ? canManageTabs(actionableSelected) : false,
     },
     { alt: e.altKey },
   );

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1034,8 +1034,8 @@ body {
   background: var(--af-bg-inset);
 }
 
-/* A row without the daemon's lifecycle capability is visible status only. Creating
- * rows share this class but override the cursor below with progress. */
+/* A row that cannot attach is visible status only, though it may still contain an
+ * independently projected Kill button. Creating rows override the cursor below. */
 .af-row-inert {
   cursor: default;
 }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -50,8 +50,10 @@ export const InFlightOp = {
   Restoring: 4,
 } as const;
 
-/** session.LifecycleAction: the daemon-owned lifecycle verb for a row. Absence
- *  means the row must expose no archive/restore/kill controls (#2234). */
+/** session.LifecycleAction: the daemon-owned archive/restore verb for a row.
+ *  Absence means the row must expose neither reversible lifecycle control. Kill
+ *  addressability is projected independently because startup-unknown rows may be
+ *  torn down but must not reuse their unconfirmed runtime binding. */
 export type LifecycleAction = "archive" | "restore";
 
 /** session.Status (session/instance.go) — the legacy single-axis int, read ONLY
@@ -90,6 +92,9 @@ export interface SessionData {
   /** Daemon-owned lifecycle capability. The web consumes this decision instead
    *  of re-deriving TUI policy from liveness/in-flight fields. */
   lifecycle_action?: LifecycleAction;
+  /** Daemon-owned explicit teardown capability. True means the row has a stable
+   *  non-creating target; absence/false fails closed. */
+  can_kill?: boolean;
   /** Usage-limit reset time (RFC3339), present only for a LimitReached row. */
   limit_reset_at?: string;
   /** Backend discriminator; "remote" marks a remote-hook session (→ [remote]). */

--- a/web/src/ui.test.ts
+++ b/web/src/ui.test.ts
@@ -12,6 +12,7 @@ import {
   canManageTabs,
   documentTitle,
   isActionableSession,
+  isKillableSession,
   supportsTabManagement,
   tabBarSig,
   tabCreationUnavailableReason,
@@ -49,6 +50,24 @@ test("rail actionability is granted only by the daemon projection (#2234)", () =
     isActionableSession(sess({ id: undefined, lifecycle_action: "archive" })),
     false,
     "a malformed id-less capability fails closed",
+  );
+});
+
+test("kill addressability is independent and fails closed", () => {
+  assert.equal(
+    isKillableSession(sess({ can_kill: true })),
+    true,
+    "a stable row with the projected teardown capability is killable",
+  );
+  assert.equal(
+    isKillableSession(sess({ lifecycle_action: "archive" })),
+    false,
+    "the lifecycle verb must not implicitly grant teardown",
+  );
+  assert.equal(
+    isKillableSession(sess({ id: undefined, can_kill: true })),
+    false,
+    "an id-less teardown capability fails closed",
   );
 });
 

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -59,6 +59,13 @@ export type NewTabKind = "shell" | "vscode";
  *  so a visible but inert row cannot reach them through the normal code path. */
 export type ActionableSession = SessionData & { id: string; lifecycle_action: LifecycleAction };
 
+/** A row carrying the Go domain's positive teardown capability and stable target.
+ *  This is intentionally not implied by ActionableSession: startup-unknown rows
+ *  are killable while archive/restore and attach remain unavailable. */
+export type KillableSession = SessionData & { id: string; can_kill: true };
+
+type ManagedSession = ActionableSession | KillableSession;
+
 /** Fail-closed wire narrowing only — the policy itself lives in Go's
  *  session.LifecycleAction (#2234). Exact values reject a malformed or stale
  *  projection instead of manufacturing an action in the browser. */
@@ -68,6 +75,11 @@ export function isActionableSession(s: SessionData): s is ActionableSession {
     s.id !== "" &&
     (s.lifecycle_action === "archive" || s.lifecycle_action === "restore")
   );
+}
+
+/** Fail-closed narrowing for the daemon's independent teardown capability. */
+export function isKillableSession(s: SessionData): s is KillableSession {
+  return typeof s.id === "string" && s.id !== "" && s.can_kill === true;
 }
 
 /** The whole client state: which view to show, the login details, and — once
@@ -157,8 +169,8 @@ export interface Actions {
   open(id: string): void;
   /** Opens the new-session modal (#1592 Phase 5 PR5). */
   newSession(): void;
-  /** Opens the kill-confirm modal for this rail row. */
-  kill(session: ActionableSession): void;
+  /** Opens the kill-confirm modal for this stably-addressed rail row. */
+  kill(session: KillableSession): void;
   /** Opens the archive-confirm modal for this rail row. */
   archive(session: ActionableSession): void;
   /** Opens the restore-confirm modal for this rail row (an archived / Lost / Dead
@@ -1207,36 +1219,45 @@ export class AppShell {
     list.replaceChildren(...(notice ? [notice, ...rows] : rows));
   }
 
-  /** Quiet per-session controls reserved beside every ACTIONABLE rail row (#2186,
-   *  #2223, #2234). The Go projection chooses Archive vs Restore; the browser never
-   *  reconstructs that policy from row state. */
-  private rowActions(session: ActionableSession, selected: boolean): HTMLElement {
-    const lifecycleBtn = h("button", { type: "button", class: "af-rail-action af-rail-lifecycle" });
-    lifecycleBtn.addEventListener("click", (e) => {
-      e.stopPropagation();
-      if (lifecycleBtn.dataset.action === "restore") {
-        this.runRailExit(() => this.actions.restore(session));
-      } else {
-        this.runRailExit(() => this.actions.archive(session));
+  /** Quiet controls reserved beside every row carrying at least one daemon-owned
+   *  capability (#2186, #2223, #2234). Archive/Restore and Kill narrow separately;
+   *  the browser never reconstructs either policy from status pixels. */
+  private rowActions(session: ManagedSession, selected: boolean): HTMLElement {
+    const buttons: HTMLElement[] = [];
+    if (isActionableSession(session)) {
+      const lifecycleSession = session;
+      const lifecycleBtn = h("button", { type: "button", class: "af-rail-action af-rail-lifecycle" });
+      lifecycleBtn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        if (lifecycleBtn.dataset.action === "restore") {
+          this.runRailExit(() => this.actions.restore(lifecycleSession));
+        } else {
+          this.runRailExit(() => this.actions.archive(lifecycleSession));
+        }
+      });
+      this.patchLifecycleButton(lifecycleBtn, lifecycleSession.lifecycle_action, lifecycleSession.title);
+      if (selected) {
+        this.lifecycleBtn = lifecycleBtn;
+        this.lifecycleAction = lifecycleSession.lifecycle_action;
       }
-    });
-    this.patchLifecycleButton(lifecycleBtn, session.lifecycle_action, session.title);
-    if (selected) {
-      this.lifecycleBtn = lifecycleBtn;
-      this.lifecycleAction = session.lifecycle_action;
+      buttons.push(lifecycleBtn);
     }
 
-    // Kill stays unmistakably destructive through its distinct ⌫ glyph and confirm,
-    // but its resting rail treatment is deliberately muted instead of af-danger.
-    const killBtn = h("button", { type: "button", class: "af-rail-action af-rail-kill" }, "⌫");
-    const killLabel = `Kill session “${session.title}”`;
-    killBtn.setAttribute("aria-label", killLabel);
-    killBtn.setAttribute("title", killLabel);
-    killBtn.addEventListener("click", (e) => {
-      e.stopPropagation();
-      this.runRailExit(() => this.actions.kill(session));
-    });
-    return h("div", { class: "af-row-actions" }, lifecycleBtn, killBtn);
+    if (isKillableSession(session)) {
+      const killSession = session;
+      // Kill stays unmistakably destructive through its distinct ⌫ glyph and
+      // confirm, but its resting rail treatment remains muted instead of af-danger.
+      const killBtn = h("button", { type: "button", class: "af-rail-action af-rail-kill" }, "⌫");
+      const killLabel = `Kill session “${killSession.title}”`;
+      killBtn.setAttribute("aria-label", killLabel);
+      killBtn.setAttribute("title", killLabel);
+      killBtn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        this.runRailExit(() => this.actions.kill(killSession));
+      });
+      buttons.push(killBtn);
+    }
+    return h("div", { class: "af-row-actions" }, ...buttons);
   }
 
   /** Applies the daemon-projected verb, glyph, and target-qualified accessible name
@@ -2241,18 +2262,20 @@ function beginTabRename(
 }
 
 /** One session row: a status dot, the (prefixed) title, the branch line, and a reserved
- *  slot for its quiet lifecycle actions (#2186, #2223). Clicking opens the session by
- *  its stable id (selects it and attaches its terminal, #1693); a row lacking an id
- *  (never expected from a live Snapshot) is rendered but inert. */
+ *  slot for its daemon-projected management actions (#2186, #2223). Clicking opens
+ *  only a lifecycle-actionable session by stable id; a kill-only startup-unknown row
+ *  retains its button without becoming attachable. */
 function sessionRow(
   s: SessionData,
   selected: boolean,
   openSession: (id: string) => void,
-  buildActions: (session: ActionableSession) => HTMLElement,
+  buildActions: (session: ManagedSession) => HTMLElement,
 ): HTMLElement {
   const status = rowStatus(s);
   const creating = isCreating(s);
   const actionable = isActionableSession(s);
+  const killable = isKillableSession(s);
+  const managed = actionable || killable;
 
   const title = h("div", { class: "af-row-title" }, rowTitle(s));
   const branch = h(
@@ -2277,18 +2300,17 @@ function sessionRow(
     row.append(dot);
   }
   row.append(main);
-  if (actionable) {
+  if (managed) {
     row.append(buildActions(s));
   }
   row.setAttribute("role", "option");
   row.setAttribute("aria-selected", selected ? "true" : "false");
   row.setAttribute("title", `${s.title} — ${status.label}`);
-  if (!actionable) {
-    // The server withheld a lifecycle action: a creating row has no session yet,
-    // while an id-less row has no unambiguous destructive target. Selection and
-    // lifecycle controls consume the same fail-closed capability.
+  if (!actionable && !managed) {
+    // The server withheld both capabilities: a creating row has no session yet,
+    // while an id-less row has no unambiguous mutation target.
     row.setAttribute("aria-disabled", "true");
-  } else {
+  } else if (actionable) {
     row.addEventListener("click", () => openSession(s.id));
   }
   return row;


### PR DESCRIPTION
## Summary

Treat the four late #2211 startup findings as one identity/outcome invariant:

- reserve the exact repo-scoped tmux name before waiting on the per-repo start lock, so punctuation variants cannot create the same runtime after both have made worktrees;
- classify cleanup as safe only with proof that no pane process can still write into the fresh worktree; a generic answered post-spawn failure—including a non-zero `systemd-run` status—remains cleanup-unsafe because the wait status does not identify whether the wrapper or child failed;
- let readiness-timeout cleanup authorize worktree removal only when teardown answered, returned no error, the fresh name cannot be rewritten by tmux, and any created pane has actually exited; legacy persisted spellings remain fail-closed;
- project retained startup-unknown rows as terminal/blocked, expose no archive/restore action, veto every runtime-entry action, and keep explicit Kill independently available.

The runtime namespace is an enum (local tmux / remote hook / sandbox), so admission cannot accidentally enable incompatible name policies together. Fresh-name construction, collision reservation, and post-start identity proof share the same tmux naming policy.

## Review and CI follow-up

- Pane exit is part of timeout cleanup proof; a still-live pane preserves the unknown outcome and blocks fresh-worktree deletion.
- More than one archived row claiming the same tmux namespace is rejected before any rename, so a failed create cannot mutate unrelated archived state.
- Kill is an independent projected capability, so a stable startup-unknown row is removable without making attach/archive/restore available.
- Retained startup-unknown and failed-cleanup creates publish their durable replacement projection instead of deleting the provisional row from connected clients.
- Post-spawn answered failures stay outside the cleanup-safe sentinel, including an actionable `systemd-run` refusal.
- The Linux Docker failure exposed an unreaped-zombie false positive in the new proof. Teardown now follows the pane's pre-kill process identity through the existing zombie-aware process library; process-table blindness fails closed and PID reuse cannot impersonate the original pane.
- The Web client applies the daemon-owned lifecycle fence to rail navigation, terminal focus, and stream binding, so a kill-only uncertain row cannot be attached by keyboard or by stale selection.

## Verification

Full gates run after the final commit on pushed head `ef367d4f39a29d90cd679235a2b33b1cc58e0592`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh` (924 Go files checked; 0 grandfathered)
- `make web-build` and `make web-test` (402/402)
- `make web-selftest-container` (109/109)
- `go test ./integration -run '^TestDockerBackendArchiveRestore$' -count=1` (real Docker archive → reap → fresh restore → interactive drive)

Fail-first coverage reproduced the startup findings, the retained-row event deletion, the zombie false-liveness result, and keyboard selection of a kill-only row before their fixes.

— Captain Claude
