### PR TITLE
fix(bugreport): scrub wordless multiline titles

### DIFF
--- a/bugreport/bugreport_test.go
+++ b/bugreport/bugreport_test.go
@@ -358,6 +358,30 @@ func TestScrubLogRedactsMultilineTaskTitleBeforeLegacyShape(t *testing.T) {
 		"next diagnostic survives")
 }
 
+// A multiline title does not become safe merely because it contains no word
+// runes. The legacy matcher is line-oriented, so it can consume line one and
+// strand the rest unless the exact full title is removed first. Include a
+// leading-newline title to pin byte-identical matching rather than TrimSpace.
+func TestScrubLogRedactsWordlessMultilineTitlesBeforeLegacyShape(t *testing.T) {
+	for _, title := range []string{"---\n///", "🔒\n🕵", "\n---"} {
+		t.Run(fmt.Sprintf("%q", title), func(t *testing.T) {
+			r := &redactor{}
+			r.noteTitle(title)
+			in := "task t1 started successfully as instance " + title + "\nnext diagnostic survives"
+
+			out := r.scrubLog(in)
+
+			mustNotContain(t, "daemon log", out, title)
+			for _, line := range strings.Split(title, "\n") {
+				if line != "" {
+					mustNotContain(t, "daemon log", out, line)
+				}
+			}
+			mustContain(t, "daemon log", out, redactedMarker, "next diagnostic survives")
+		})
+	}
+}
+
 // A shorter title must never destroy the prefix of a longer title before that
 // longer secret is considered. Map iteration is randomized, so exercise the
 // sanitizer repeatedly: any surviving suffix is a privacy leak.

--- a/bugreport/redact.go
+++ b/bugreport/redact.go
@@ -250,17 +250,18 @@ func redactAFTmuxTitle(match string) string {
 
 // replaceBareTitle removes a title only when it occupies a complete text token.
 // The legacy logger's raw %s form is delimited by surrounding prose/newlines, so
-// this covers that representation without compiling punctuation-only titles
-// such as "." or "/" into an unbounded regexp that erases every period or path
-// separator in the bundle. Exact %q forms are handled above before this pass.
+// this covers that representation without compiling single-line punctuation-only
+// titles such as "." or "/" into an unbounded matcher that erases every period
+// or path separator in the bundle. A multiline title is different: its exact,
+// byte-identical cross-line sequence must be removed before a legacy line matcher
+// can consume line one and strand the rest. Exact %q forms are handled above.
 //
 // A token boundary means start/end of text or a neighboring rune that is not a
 // letter, number, combining mark, or underscore. Checking both edges regardless
 // of the title's own first/last character handles titles such as "client[prod]"
 // while refusing to match "." inside "1.2" or "/" inside "repo/path".
 func replaceBareTitle(s, title string) string {
-	title = strings.TrimSpace(title)
-	if title == "" || !containsWordRune(title) {
+	if strings.TrimSpace(title) == "" || (!containsWordRune(title) && !strings.ContainsAny(title, "\r\n")) {
 		return s
 	}
 	var out strings.Builder


### PR DESCRIPTION
## Summary

- scrub exact byte-identical multiline titles before any line-oriented legacy log matcher, even when the title contains no word runes
- keep single-line punctuation titles scoped to quoted/fixed-shape renderings so ordinary periods and path separators remain useful
- pin punctuation-only, emoji-only, and leading-newline title regressions

## Verification of the late #2256 finding

The finding is real on merged master: `bugreport/redact.go:190` sends the log through the full-title pre-pass, but `bugreport/redact.go:233-235` delegates raw forms to `replaceBareTitle`, whose `bugreport/redact.go:261-264` guard declines titles without word runes. The later legacy matcher is line-oriented, while `daemon/manager_create.go:617` rejects only all-whitespace titles.

Fail-first left `///`, `🕵`, and `---` in the bundle for the three new cases. The same focused test and the full `bugreport` package pass after the fix.

Full gates are green on pushed SHA `b9596d6a8c9aceba612d89b3ca16be5068baa0cc`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh` (912 Go files checked)

Follow-up to the late Codex P2 on #2256.

— Captain Claude