### PR TITLE
fix(web): harden mobile appbar interaction order

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -278,12 +278,12 @@ Tasks view to the selected project), a **Live** pip showing the daemon
 event-stream state (`Live` / `Connecting…` / `Reconnecting…`), and
 **Disconnect**.
 
-On a phone, width is assigned by function rather than desktop order: the first row
-keeps the session-drawer toggle, the current **project**, and one **More** button;
-the view tabs share an aligned row below. Long project names end in an ellipsis but
-keep the largest flexible slot. The decorative brand disappears, while Live status,
-install, theme, and Disconnect remain available as comfortable touch targets inside
-**More** instead of being squeezed or removed.
+On a phone, width is assigned by function rather than desktop shrink behavior: the
+session-drawer toggle and view tabs share one aligned row in their keyboard order;
+the current **project** gets the wide slot on the next row beside one **More** button.
+Long project names end in an ellipsis. The decorative brand disappears, while Live
+status, install, theme, and Disconnect remain available as comfortable touch targets
+inside **More** instead of being squeezed or removed.
 
 ### Sessions view
 

--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -67,6 +67,10 @@
   --af-shadow-2: 0 4px 10px rgba(16, 24, 40, 0.08), 0 2px 4px rgba(16, 24, 40, 0.06);
   --af-shadow-overlay: 0 16px 48px rgba(16, 24, 40, 0.22), 0 4px 12px rgba(16, 24, 40, 0.12);
   --af-backdrop: rgba(23, 32, 46, 0.42);
+  --af-z-drawer: 30;
+  --af-z-appbar: 40;
+  --af-z-popover: 60;
+  --af-z-modal: 100;
 }
 @media (prefers-color-scheme: dark) {
   :root {
@@ -1458,7 +1462,7 @@ body {
 }
 .af-modal-host {
   position: relative;
-  z-index: 20;
+  z-index: var(--af-z-modal);
 }
 .af-modal-backdrop {
   position: fixed;
@@ -1468,7 +1472,7 @@ body {
   align-items: center;
   justify-content: center;
   padding: var(--af-sp-5);
-  z-index: 20;
+  z-index: var(--af-z-modal);
 }
 .af-modal-card {
   width: 100%;
@@ -1788,10 +1792,10 @@ body {
 @media (max-width: 768px) {
   .af-appbar {
     position: relative;
-    z-index: 40;
+    z-index: var(--af-z-appbar);
     display: grid;
     grid-template-columns: auto minmax(0, 1fr) auto;
-    grid-template-areas: "nav project tools" "views views views";
+    grid-template-areas: "nav views views" "project project tools";
     align-items: center;
     gap: var(--af-sp-2);
     padding: max(var(--af-sp-2), env(safe-area-inset-top)) max(var(--af-sp-2), env(safe-area-inset-right)) var(--af-sp-2) max(var(--af-sp-2), env(safe-area-inset-left));
@@ -1807,7 +1811,7 @@ body {
     top: 0;
     left: 0;
     bottom: 0;
-    z-index: 30;
+    z-index: var(--af-z-drawer);
     width: min(85vw, 20rem);
     flex: none;
     transform: translateX(-100%);
@@ -1824,7 +1828,7 @@ body {
     display: block;
     position: absolute;
     inset: 0;
-    z-index: 29;
+    z-index: calc(var(--af-z-drawer) - 1);
     background: var(--af-backdrop);
     opacity: 0;
     pointer-events: none;
@@ -1859,17 +1863,20 @@ body {
     max-width: none;
     max-height: calc(100dvh - 7rem);
     overflow-y: auto;
-    z-index: 60;
+    z-index: var(--af-z-popover);
   }
   .af-viewnav {
     grid-area: views;
     width: 100%;
     margin-left: 0;
+    padding: 0;
+    border: 0;
+    box-shadow: inset 0 0 0 1px var(--af-border-subtle);
   }
-  .af-viewtab {
+  .af-appbar .af-viewtab {
     flex: 1 1 0;
     min-width: 0;
-    min-height: 2.5rem;
+    min-height: 2.75rem;
     padding-inline: var(--af-sp-2);
   }
   .af-appbar-tools-wrap {
@@ -1885,7 +1892,7 @@ body {
     position: absolute;
     top: calc(100% + 6px);
     right: 0;
-    z-index: 60;
+    z-index: var(--af-z-popover);
     width: min(17rem, calc(100vw - var(--af-sp-2) - var(--af-sp-2)));
     max-height: calc(100dvh - 4rem);
     overflow-y: auto;

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -10477,6 +10477,7 @@ var AppShell = class {
     this.projectSwitchBtn.setAttribute("aria-label", "Switch project");
     this.projectSwitchBtn.addEventListener("click", (e) => {
       e.stopPropagation();
+      setAppbarToolsOpen(false);
       this.toggleProjectMenu();
     });
     this.projectMenu = h2("div", { class: "af-project-menu" });
@@ -10507,12 +10508,11 @@ var AppShell = class {
     const appbarMore = h2("button", { type: "button", class: "af-appbar-more" }, "\u22EF");
     appbarMore.setAttribute("aria-label", "More app controls");
     appbarMore.setAttribute("title", "More app controls");
-    appbarMore.setAttribute("aria-haspopup", "true");
     appbarMore.setAttribute("aria-controls", "af-appbar-tools");
     appbarMore.setAttribute("aria-expanded", "false");
     const appbarToolsWrap = h2("div", { class: "af-appbar-tools-wrap" }, appbarMore, appbarTools);
     let appbarToolsOpen = false;
-    const setAppbarToolsOpen = (open) => {
+    function setAppbarToolsOpen(open) {
       if (appbarToolsOpen === open) {
         return;
       }
@@ -10528,7 +10528,7 @@ var AppShell = class {
         document.removeEventListener("keydown", onAppbarToolsKeyDown, true);
         window.removeEventListener("resize", onAppbarToolsResize);
       }
-    };
+    }
     const onAppbarToolsMouseDown = (e) => {
       if (!appbarToolsWrap.isConnected || !appbarToolsWrap.contains(e.target)) {
         setAppbarToolsOpen(false);
@@ -10545,7 +10545,11 @@ var AppShell = class {
     const onAppbarToolsResize = () => setAppbarToolsOpen(false);
     appbarMore.addEventListener("click", (e) => {
       e.stopPropagation();
-      setAppbarToolsOpen(!appbarToolsOpen);
+      const opening = !appbarToolsOpen;
+      if (opening) {
+        this.closeProjectMenu();
+      }
+      setAppbarToolsOpen(opening);
     });
     disconnect2.addEventListener("click", () => {
       setAppbarToolsOpen(false);

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "5289eb0d4b3b";
+const VERSION = "b17f8f1bb691";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "b17f8f1bb691";
+const VERSION = "626eafba7e68";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -5658,6 +5658,22 @@ test("#2226 mobile (375px): drawer dismissal follows action intent, not click pr
   await p.locator(".af-rail-new").click();
   await expectDrawerClosed();
   await expect(modal).toBeVisible();
+  const modalLayer = await p.evaluate(() => {
+    const appbar = document.querySelector(".af-appbar")!;
+    const host = document.querySelector(".af-modal-host")!;
+    const covered = [".af-project-switch", ".af-appbar-more"].map((selector) => {
+      const box = document.querySelector(selector)!.getBoundingClientRect();
+      const hit = document.elementFromPoint(box.left + box.width / 2, box.top + box.height / 2);
+      return hit?.closest(".af-modal-backdrop") !== null;
+    });
+    return {
+      appbarZ: Number.parseInt(getComputedStyle(appbar).zIndex, 10),
+      modalZ: Number.parseInt(getComputedStyle(host).zIndex, 10),
+      covered,
+    };
+  });
+  expect(modalLayer.modalZ, "aria-modal content owns the top interaction layer").toBeGreaterThan(modalLayer.appbarZ);
+  expect(modalLayer.covered, "the modal backdrop blocks every appbar action").toEqual([true, true]);
   const titleInput = modal.locator('input[aria-label="Session title"]');
   await titleInput.click();
   await expect(titleInput).toBeFocused();
@@ -5780,6 +5796,7 @@ test("#2227 mobile appbar: project context wins scarce width at 320px and 375px"
         const projectName = p.locator(".af-project-switch-name");
         const more = p.locator(".af-appbar-more");
         const tools = p.locator(".af-appbar-tools");
+        const viewTabs = p.locator(".af-viewtab");
         await expect(brand, "decoration yields before project context").toBeHidden();
         await expect(toggle).toBeVisible();
         await expect(project).toBeVisible();
@@ -5793,6 +5810,7 @@ test("#2227 mobile appbar: project context wins scarce width at 320px and 375px"
           };
           return {
             toggle: rect(".af-nav-toggle"),
+            views: rect(".af-viewnav"),
             project: rect(".af-project-switch"),
             more: rect(".af-appbar-more"),
           };
@@ -5802,9 +5820,25 @@ test("#2227 mobile appbar: project context wins scarce width at 320px and 375px"
           expect(box.right, `${name} ends inside ${width}px`).toBeLessThanOrEqual(width);
           expect(box.height, `${name} keeps a comfortable tap height`).toBeGreaterThanOrEqual(44);
         }
-        expect(primary.project.width, "project context owns the flexible middle of the primary row").toBeGreaterThan(150);
-        expect(Math.abs(primary.toggle.top - primary.project.top), "primary controls share one top edge").toBeLessThanOrEqual(1);
-        expect(Math.abs(primary.more.top - primary.project.top), "primary controls share one top edge").toBeLessThanOrEqual(1);
+        expect(primary.project.width, "project context owns nearly the whole second row").toBeGreaterThan(200);
+        expect(Math.abs(primary.toggle.top - primary.views.top), "top-level navigation shares one top edge").toBeLessThanOrEqual(1);
+        expect(Math.abs(primary.more.top - primary.project.top), "project and More share one top edge").toBeLessThanOrEqual(1);
+        expect(primary.project.top, "the project row follows the top-level navigation row").toBeGreaterThan(
+          primary.toggle.top + primary.toggle.height,
+        );
+
+        // Visual and focus order must agree at the responsive breakpoint. Positive
+        // tabindex or CSS-only reordering would still leave assistive technology
+        // jumping between rows, so walk the native DOM sequence end to end.
+        await toggle.focus();
+        for (let i = 0; i < 3; i++) {
+          await p.keyboard.press("Tab");
+          await expect(viewTabs.nth(i), `view tab ${i + 1} follows the drawer toggle`).toBeFocused();
+        }
+        await p.keyboard.press("Tab");
+        await expect(project, "project follows the view row in DOM and pixels").toBeFocused();
+        await p.keyboard.press("Tab");
+        await expect(more, "More follows the project in DOM and pixels").toBeFocused();
 
         const truncation = await projectName.evaluate((el) => {
           const css = getComputedStyle(el);
@@ -5852,7 +5886,7 @@ test("#2227 mobile appbar: project context wins scarce width at 320px and 375px"
         await projectItem(p, LONG_PROJECT).click();
         await expect(projectMenu).toBeHidden();
 
-        // Rare chrome remains operable rather than consuming the primary row.
+        // Rare chrome remains operable rather than consuming the project row.
         await more.click();
         await expect(tools).toBeVisible();
         await expect(tools.locator(`.af-theme-opt[data-theme-opt="${theme}"]`)).toHaveClass(/af-theme-opt-active/);

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -5835,6 +5835,20 @@ test("#2227 mobile appbar: project context wins scarce width at 320px and 375px"
         expect(menuBox, "project menu has phone geometry").not.toBeNull();
         expect(menuBox!.x).toBeGreaterThanOrEqual(0);
         expect(menuBox!.x + menuBox!.width).toBeLessThanOrEqual(width);
+
+        // Disclosure exclusivity belongs to the actions, not pointer bubbling. The
+        // More click stops propagation and keyboard activation has no mousedown, so
+        // both directions would otherwise leave overlapping panels open (#2226's
+        // event-path gotcha in miniature).
+        await more.click();
+        await expect(projectMenu).toBeHidden();
+        await expect(tools).toBeVisible();
+        await expect(more).toHaveAttribute("aria-expanded", "true");
+        await project.focus();
+        await p.keyboard.press("Enter");
+        await expect(tools).toBeHidden();
+        await expect(more).toHaveAttribute("aria-expanded", "false");
+        await expect(projectMenu).toBeVisible();
         await projectItem(p, LONG_PROJECT).click();
         await expect(projectMenu).toBeHidden();
 
@@ -5855,6 +5869,7 @@ test("#2227 mobile appbar: project context wins scarce width at 320px and 375px"
         }
         await p.keyboard.press("Escape");
         await expect(tools).toBeHidden();
+        await expect(more).toHaveAttribute("aria-expanded", "false");
         await expect(more).toBeFocused();
 
         await testInfo.attach(`2227-${width}-${theme}-drawer-closed`, {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -81,6 +81,13 @@
   --af-shadow-2: 0 4px 10px rgba(16, 24, 40, 0.08), 0 2px 4px rgba(16, 24, 40, 0.06);
   --af-shadow-overlay: 0 16px 48px rgba(16, 24, 40, 0.22), 0 4px 12px rgba(16, 24, 40, 0.12);
   --af-backdrop: rgba(23, 32, 46, 0.42);
+
+  /* Layer contract: a drawer may cover the body, appbar disclosures may cover the
+   * drawer, and an aria-modal surface must cover and block every one of them. */
+  --af-z-drawer: 30;
+  --af-z-appbar: 40;
+  --af-z-popover: 60;
+  --af-z-modal: 100;
 }
 
 /* --- Design tokens: DARK via OS preference (Auto) ------------------------ */
@@ -1926,7 +1933,7 @@ body {
  * mounts into it. */
 .af-modal-host {
   position: relative;
-  z-index: 20;
+  z-index: var(--af-z-modal);
 }
 
 .af-modal-backdrop {
@@ -1937,7 +1944,7 @@ body {
   align-items: center;
   justify-content: center;
   padding: var(--af-sp-5);
-  z-index: 20;
+  z-index: var(--af-z-modal);
 }
 
 .af-modal-card {
@@ -2353,18 +2360,18 @@ body {
  * so the main pane keeps the full body width whether the drawer is open or shut, and the
  * terminal's own ResizeObserver never sees a width change when it toggles. */
 @media (max-width: 768px) {
-  /* Phone priority, high to low: drawer navigation, current project, access to rare
-   * tools, then the top-level view row. The decorative brand yields entirely. A grid
-   * makes that order structural rather than relying on whichever flex child happens
+  /* The decorative brand yields entirely. The remaining controls keep DOM/focus
+   * order in the grid: drawer + top-level views, then a wider project row + rare
+   * tools. Width allocation is structural rather than whichever flex child happens
    * to shrink or wrap first. */
   .af-appbar {
     position: relative;
-    z-index: 40;
+    z-index: var(--af-z-appbar);
     display: grid;
     grid-template-columns: auto minmax(0, 1fr) auto;
     grid-template-areas:
-      "nav project tools"
-      "views views views";
+      "nav views views"
+      "project project tools";
     align-items: center;
     gap: var(--af-sp-2);
     padding: max(var(--af-sp-2), env(safe-area-inset-top)) max(var(--af-sp-2), env(safe-area-inset-right))
@@ -2394,7 +2401,7 @@ body {
     top: 0;
     left: 0;
     bottom: 0;
-    z-index: 30;
+    z-index: var(--af-z-drawer);
     width: min(85vw, 20rem);
     flex: none;
     transform: translateX(-100%);
@@ -2421,7 +2428,7 @@ body {
     display: block;
     position: absolute;
     inset: 0;
-    z-index: 29;
+    z-index: calc(var(--af-z-drawer) - 1);
     background: var(--af-backdrop);
     opacity: 0;
     pointer-events: none;
@@ -2439,7 +2446,7 @@ body {
     display: none;
   }
 
-  /* Project context owns the flexible centre of the primary row. The explicit
+  /* Project context owns nearly the whole second row. The explicit
    * min-width chain (grid track → wrapper → button → name) is what lets the browser
    * draw a real ellipsis instead of clipping a flex item at an arbitrary glyph. */
   .af-project-switch-wrap {
@@ -2470,19 +2477,22 @@ body {
     max-width: none;
     max-height: calc(100dvh - 7rem);
     overflow-y: auto;
-    z-index: 60;
+    z-index: var(--af-z-popover);
   }
 
   .af-viewnav {
     grid-area: views;
     width: 100%;
     margin-left: 0;
+    padding: 0;
+    border: 0;
+    box-shadow: inset 0 0 0 1px var(--af-border-subtle);
   }
 
-  .af-viewtab {
+  .af-appbar .af-viewtab {
     flex: 1 1 0;
     min-width: 0;
-    min-height: 2.5rem;
+    min-height: 2.75rem;
     padding-inline: var(--af-sp-2);
   }
 
@@ -2504,7 +2514,7 @@ body {
     position: absolute;
     top: calc(100% + 6px);
     right: 0;
-    z-index: 60;
+    z-index: var(--af-z-popover);
     width: min(17rem, calc(100vw - var(--af-sp-2) - var(--af-sp-2)));
     max-height: calc(100dvh - 4rem);
     overflow-y: auto;

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -757,6 +757,7 @@ export class AppShell {
     this.projectSwitchBtn.setAttribute("aria-label", "Switch project");
     this.projectSwitchBtn.addEventListener("click", (e) => {
       e.stopPropagation();
+      setAppbarToolsOpen(false);
       this.toggleProjectMenu();
     });
     this.projectMenu = h("div", { class: "af-project-menu" });
@@ -800,12 +801,11 @@ export class AppShell {
     const appbarMore = h("button", { type: "button", class: "af-appbar-more" }, "⋯");
     appbarMore.setAttribute("aria-label", "More app controls");
     appbarMore.setAttribute("title", "More app controls");
-    appbarMore.setAttribute("aria-haspopup", "true");
     appbarMore.setAttribute("aria-controls", "af-appbar-tools");
     appbarMore.setAttribute("aria-expanded", "false");
     const appbarToolsWrap = h("div", { class: "af-appbar-tools-wrap" }, appbarMore, appbarTools);
     let appbarToolsOpen = false;
-    const setAppbarToolsOpen = (open: boolean): void => {
+    function setAppbarToolsOpen(open: boolean): void {
       if (appbarToolsOpen === open) {
         return;
       }
@@ -821,7 +821,7 @@ export class AppShell {
         document.removeEventListener("keydown", onAppbarToolsKeyDown, true);
         window.removeEventListener("resize", onAppbarToolsResize);
       }
-    };
+    }
     const onAppbarToolsMouseDown = (e: MouseEvent): void => {
       if (!appbarToolsWrap.isConnected || !appbarToolsWrap.contains(e.target as Node)) {
         setAppbarToolsOpen(false);
@@ -838,7 +838,11 @@ export class AppShell {
     const onAppbarToolsResize = (): void => setAppbarToolsOpen(false);
     appbarMore.addEventListener("click", (e) => {
       e.stopPropagation();
-      setAppbarToolsOpen(!appbarToolsOpen);
+      const opening = !appbarToolsOpen;
+      if (opening) {
+        this.closeProjectMenu();
+      }
+      setAppbarToolsOpen(opening);
     });
     // Disconnect replaces the shell synchronously. Close first so the temporary
     // document/window listeners cannot outlive the DOM subtree they describe.


### PR DESCRIPTION
## Outcome

- make project and More disclosures mutually exclusive by action for pointer and keyboard activation
- align the phone grid with native DOM focus order: drawer and views first, project and More second
- centralize drawer, appbar, popover, and modal layers so aria-modal surfaces always block header actions
- pin disclosure state, focus order, geometry, and modal hit testing in the real browser harness

## Why this is separate

#2259 merged manually before its delayed Codex inline findings arrived. This follow-up owns all three late findings: two valid P2s and one valid P3. Replies on every original thread identify the fix.

## Gotchas removed

Disclosure exclusivity no longer depends on event propagation. Responsive visual order no longer differs from native focus order. Overlay precedence no longer lives as unrelated numeric z-index values; one token contract encodes modal > popover > appbar > drawer. Browser regressions make each invariant fail loudly.

## Visual verification

Inspected 320px and 375px in light and dark, drawer closed and fully open, with a deliberately long project name. Controls align, the project remains distinguishable through an ellipsis, popovers stay operable, and no horizontal clipping appears. At 375px the New session modal visibly covers the full appbar.

## Validation

The focused web tests and all 108 containerized browser cases pass locally. The complete post-push gate set is running against 0c67af3feb01df7a1921a34c7a6959326f11a272; exact results will be posted before merge.

Follow-up to #2227 and #2259.

— Captain Claude