### PR TITLE
fix(config): recognize symlinked default home

### DIFF
--- a/config/filelock.go
+++ b/config/filelock.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/sachiniyer/agent-factory/internal/pathutil"
 	"github.com/sachiniyer/agent-factory/log"
 )
 
@@ -216,8 +217,10 @@ func ensureStorageParent(path string) error {
 // the configured AF home. A newly created home is always 0700, and the default
 // ~/.agent-factory is tightened on upgrade. An existing custom home is left
 // alone: AGENT_FACTORY_HOME explicitly supports broad caller-owned directories
-// such as "~", and a file helper must never chmod those. AtomicWriteFile and the
-// lock helpers are generic, so paths elsewhere are left alone too.
+// such as "~", and a file helper must never chmod those. A default-name symlink
+// is custom ownership too: AF neither chmods its target nor blocks startup over
+// that mode. AtomicWriteFile and the lock helpers are generic, so paths elsewhere
+// are left alone too.
 func secureAFHomeForPath(path string) error {
 	afHome, err := GetConfigDir()
 	if err != nil {
@@ -253,13 +256,13 @@ func secureAFHomeForPath(path string) error {
 	if statErr != nil {
 		return fmt.Errorf("inspect AF home: %w", statErr)
 	}
-	// Environment presence does not make a path custom: users commonly export
-	// AGENT_FACTORY_HOME=$HOME/.agent-factory to pin the default explicitly. Base
-	// the permission policy on the resolved location so that spelling receives
-	// the same legacy repair, while genuinely custom broad directories (notably
-	// AGENT_FACTORY_HOME=~) retain their caller-owned mode.
-	isDefaultHome := os.Getenv("AGENT_FACTORY_HOME") == "" || resolvesToDefaultAFHome(absHome)
-	if !isDefaultHome && !created {
+	// Environment presence does not make a path custom: users commonly export an
+	// alias of $HOME/.agent-factory to pin the default explicitly. Direction does
+	// matter, though. An alias INTO a concrete default is AF-owned and repairable;
+	// when the default name itself is a symlink, its target remains caller-owned.
+	// concreteDefaultAFHome returns the path AF may safely chmod, never the alias.
+	defaultRepairPath := concreteDefaultAFHome(absHome)
+	if defaultRepairPath == "" && !created {
 		return nil
 	}
 	if info.Mode()&os.ModeSymlink != 0 {
@@ -269,28 +272,54 @@ func secureAFHomeForPath(path string) error {
 		if err != nil {
 			return fmt.Errorf("inspect AF home symlink target: %w", err)
 		}
-		if !target.IsDir() || target.Mode().Perm() != 0o700 {
+		if !target.IsDir() {
 			return fmt.Errorf("AF home %s is a symlink whose target is not an owner-only directory", absHome)
+		}
+		if target.Mode().Perm() != 0o700 {
+			if defaultRepairPath == "" {
+				return fmt.Errorf("AF home %s is a symlink whose target is not an owner-only directory", absHome)
+			}
+			// Repair the concrete default, not the user-provided alias. That keeps a
+			// retargeted alias from redirecting chmod to a caller-owned directory.
+			if err := os.Chmod(defaultRepairPath, 0o700); err != nil {
+				return fmt.Errorf("secure AF home: %w", err)
+			}
 		}
 		return nil
 	}
 	if !info.IsDir() {
 		return fmt.Errorf("AF home %s is not a directory", absHome)
 	}
-	if err := os.Chmod(absHome, 0o700); err != nil {
+	repairPath := absHome
+	if defaultRepairPath != "" {
+		repairPath = defaultRepairPath
+	}
+	if err := os.Chmod(repairPath, 0o700); err != nil {
 		return fmt.Errorf("secure AF home: %w", err)
 	}
 	return nil
 }
 
-func resolvesToDefaultAFHome(absHome string) bool {
+// concreteDefaultAFHome returns the concrete default directory when absHome is
+// another spelling of it. The direction is intentional: if the default name is
+// itself a symlink, its target is caller-owned and no spelling of that target is
+// permission-repairable here. This resolves both sides of the policy without
+// turning symmetric path equality into symmetric ownership.
+func concreteDefaultAFHome(absHome string) string {
 	defaultHome, err := ConfigDirFor("")
 	if err != nil {
-		return false
+		return ""
 	}
 	absDefault, err := filepath.Abs(defaultHome)
 	if err != nil {
-		return false
+		return ""
 	}
-	return filepath.Clean(absHome) == filepath.Clean(absDefault)
+	defaultInfo, err := os.Lstat(absDefault)
+	if err != nil || !defaultInfo.IsDir() || defaultInfo.Mode()&os.ModeSymlink != 0 {
+		return ""
+	}
+	if pathutil.ResolveForCompare(absHome) != pathutil.ResolveForCompare(absDefault) {
+		return ""
+	}
+	return absDefault
 }

--- a/config/home_permissions_test.go
+++ b/config/home_permissions_test.go
@@ -67,6 +67,99 @@ func TestLoadConfigSecuresDefaultAFHome(t *testing.T) {
 	}
 }
 
+// An explicit AGENT_FACTORY_HOME may spell the default through a symlinked
+// ancestor (including macOS /var -> /private/var). Path identity, not the raw
+// spelling, decides whether the legacy default-home repair applies.
+func TestLoadConfigSecuresExplicitDefaultAFHomeThroughSymlink(t *testing.T) {
+	base := t.TempDir()
+	realHome := filepath.Join(base, "real-home")
+	require.NoError(t, os.Mkdir(realHome, 0o755))
+	linkHome := filepath.Join(base, "link-home")
+	require.NoError(t, os.Symlink(realHome, linkHome))
+
+	afHome := filepath.Join(realHome, ".agent-factory")
+	require.NoError(t, os.Mkdir(afHome, 0o755))
+	require.NoError(t, os.Chmod(afHome, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(afHome, TomlConfigFileName),
+		[]byte("default_program = 'codex'\n"), 0o644))
+	t.Setenv("HOME", realHome)
+	t.Setenv("AGENT_FACTORY_HOME", filepath.Join(linkHome, ".agent-factory"))
+	fastShell(t)
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	require.Equal(t, "codex", cfg.DefaultProgram,
+		"securing the symlink-spelled default must preserve its config")
+	requireMode(t, afHome, 0o700)
+}
+
+// A final-component alias pointing INTO a concrete default home is another
+// spelling of the directory AF owns. Repair the concrete default path rather
+// than refusing the alias merely because chmod would follow it.
+func TestLoadConfigRepairsExplicitAliasToConcreteDefaultAFHome(t *testing.T) {
+	base := t.TempDir()
+	userHome := filepath.Join(base, "home")
+	require.NoError(t, os.Mkdir(userHome, 0o755))
+	afHome := filepath.Join(userHome, ".agent-factory")
+	require.NoError(t, os.Mkdir(afHome, 0o755))
+	require.NoError(t, os.Chmod(afHome, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(afHome, TomlConfigFileName),
+		[]byte("default_program = 'codex'\n"), 0o644))
+	alias := filepath.Join(base, "af-home-alias")
+	require.NoError(t, os.Symlink(afHome, alias))
+	t.Setenv("HOME", userHome)
+	t.Setenv("AGENT_FACTORY_HOME", alias)
+	fastShell(t)
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	require.Equal(t, "codex", cfg.DefaultProgram)
+	requireMode(t, afHome, 0o700)
+}
+
+// Direction matters when the default name is itself a symlink. Its target is
+// caller-owned; pointing the default name at a broad directory must not grant AF
+// permission to chmod that directory when AGENT_FACTORY_HOME names it directly.
+func TestAtomicWriteFilePreservesCustomTargetOfDefaultSymlink(t *testing.T) {
+	base := t.TempDir()
+	userHome := filepath.Join(base, "home")
+	require.NoError(t, os.Mkdir(userHome, 0o755))
+	customHome := filepath.Join(base, "shared-af-home")
+	require.NoError(t, os.Mkdir(customHome, 0o755))
+	require.NoError(t, os.Chmod(customHome, 0o755))
+	require.NoError(t, os.Symlink(customHome, filepath.Join(userHome, ".agent-factory")))
+	t.Setenv("HOME", userHome)
+	t.Setenv("AGENT_FACTORY_HOME", customHome)
+
+	path := filepath.Join(customHome, "state.json")
+	require.NoError(t, AtomicWriteFile(path, []byte("{}"), 0o644))
+	require.FileExists(t, path)
+	requireMode(t, customHome, 0o755)
+}
+
+// When AF is addressed through a default-name symlink, preserve the permissive
+// target rather than chmodding caller-owned storage or failing startup. The safe
+// alias repair above must not reverse this direction.
+func TestAtomicWriteFilePreservesPermissiveDefaultSymlinkTarget(t *testing.T) {
+	base := t.TempDir()
+	userHome := filepath.Join(base, "home")
+	require.NoError(t, os.Mkdir(userHome, 0o755))
+	customHome := filepath.Join(base, "shared-af-home")
+	require.NoError(t, os.Mkdir(customHome, 0o755))
+	require.NoError(t, os.Chmod(customHome, 0o755))
+	defaultHome := filepath.Join(userHome, ".agent-factory")
+	require.NoError(t, os.Symlink(customHome, defaultHome))
+	t.Setenv("HOME", userHome)
+	t.Setenv("AGENT_FACTORY_HOME", "")
+
+	path := filepath.Join(defaultHome, "state.json")
+	require.NoError(t, AtomicWriteFile(path, []byte("{}"), 0o644))
+	require.FileExists(t, path)
+	requireMode(t, customHome, 0o755)
+}
+
 func TestAtomicWriteFileCreatesMissingCustomAFHomePrivate(t *testing.T) {
 	userHome := t.TempDir()
 	afHome := filepath.Join(userHome, "custom-af-home")


### PR DESCRIPTION
## Summary

- treat permission ownership directionally instead of equating every resolved spelling: an alias into a concrete default home is AF-owned, while a default-name symlink points at caller-owned storage
- repair a legacy 0755 concrete default even when AGENT_FACTORY_HOME uses a final-component symlink alias
- preserve a deliberate custom mode behind the default symlink, whether addressed through the default name or the target, and never fail startup solely because that caller-owned target is broader than 0700

## Verification of the findings

Both P2s are real on the prior head. `config/filelock.go` used symmetric resolved-path equality to classify ownership, then its symlink branch rejected a repairable alias while its non-symlink branch chmodded a caller-owned target.

The ownership rule is now explicit at `config/filelock.go:259-324`. A concrete default directory is the only repair target. If the default name itself is a symlink, `concreteDefaultAFHome` returns no repair authority, so `config/filelock.go:265` preserves the target mode and lets startup continue. Tests at `config/home_permissions_test.go:97-160` pin both directions.

Fail-first reproduced both defects: the alias-to-default case failed startup with the symlink target error, while the default-symlink custom target changed from 0755 to 0700. Both now pass, including a write through the permissive default symlink.

Full gates are green on pushed SHA `3a46fcb667f71c6bb5b4b4467ed4af9bf4f3c1c2`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh` (912 Go files checked)

Follow-up to the late Codex P2 on #2258.

— Captain Claude
