### PR TITLE
fix(tui): close scroll authority gaps

### DIFF
--- a/ui/preview_scroll_offloop_test.go
+++ b/ui/preview_scroll_offloop_test.go
@@ -137,11 +137,61 @@ func TestQueuedScrollIntentsSurvivePendingFill(t *testing.T) {
 		"scroll intents queued during the pending fill must all be applied")
 }
 
-// TestOwnershipSnapshotPreservesPendingScrollIntent pins the other ordering of
-// the asynchronous race: a normal capture may already be in flight when the
-// user scrolls. Its terminal modes establish HostHistory, but must promote the
-// existing probe rather than replace the controller that holds queued input.
-func TestOwnershipSnapshotPreservesPendingScrollIntent(t *testing.T) {
+// TestDuplicateRefreshCannotStarveCurrentScrollFill pins the regular-refresh
+// ordering Codex Review found on #2257. BeginScrollFill masks the urgent refresh,
+// but a normal 100ms refresh may still call UpdateContent while the first fill is
+// pending. The controller must reject that duplicate before it launches another
+// full capture, leaving the initiating fill authoritative.
+func TestDuplicateRefreshCannotStarveCurrentScrollFill(t *testing.T) {
+	inst := makeShellInstance(t, "duplicate-scroll-fill", "visible-line")
+	defer func() { _ = inst.Kill() }()
+
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var fullCalls int32
+	src := func(_ *session.Instance, _ int, full bool) (PreviewSnapshot, error) {
+		if !full {
+			return hostPreview("visible-line"), nil
+		}
+		switch atomic.AddInt32(&fullCalls, 1) {
+		case 1:
+			close(firstStarted)
+			<-releaseFirst
+			return hostPreview(strings.ReplaceAll(
+				numberedScrollHistory(40), "history-", "first-history-")), nil
+		case 2:
+			return hostPreview(strings.ReplaceAll(
+				numberedScrollHistory(40), "history-", "second-history-")), nil
+		default:
+			return PreviewSnapshot{}, fmt.Errorf("unexpected full-history capture")
+		}
+	}
+
+	p := NewTabPane(src)
+	p.SetScrollOwnerFor(inst, 1, ScrollOwnerHostHistory)
+	p.SetSize(80, 10)
+	require.NoError(t, p.ScrollUp(inst, 1))
+	p.BeginScrollFill()
+
+	firstDone := make(chan error, 1)
+	go func() { firstDone <- p.UpdateContent(inst, 1) }()
+	<-firstStarted
+	require.NoError(t, p.UpdateContent(inst, 1),
+		"a periodic duplicate must return without waiting for the active fill")
+
+	close(releaseFirst)
+	require.NoError(t, <-firstDone)
+	require.Equal(t, int32(1), atomic.LoadInt32(&fullCalls),
+		"one fill lifecycle must launch exactly one full-history capture")
+	require.Contains(t, p.viewport.View(), "first-history-",
+		"the initiating fill must remain authoritative after a duplicate refresh")
+}
+
+// TestScrollEntryInvalidatesOlderNormalSnapshotWithoutLosingIntent pins the
+// other ordering of the asynchronous race: a normal capture may already be in
+// flight when the user scrolls. Scroll entry makes that older normal snapshot
+// stale, while the controller retains both intents for its full snapshot.
+func TestScrollEntryInvalidatesOlderNormalSnapshotWithoutLosingIntent(t *testing.T) {
 	inst := makeShellInstance(t, "ownership-snapshot", "visible-line")
 	defer func() { _ = inst.Kill() }()
 
@@ -163,13 +213,15 @@ func TestOwnershipSnapshotPreservesPendingScrollIntent(t *testing.T) {
 	go func() { normalDone <- p.UpdateContent(inst, 1) }()
 	<-normalStarted
 
-	// Both requests land while ownership is still unknown. The normal snapshot
-	// resolves the probe, then the full capture must replay both requests.
+	// Both requests land while ownership is still unknown. The older normal
+	// snapshot must not publish after scroll entry; the full capture resolves the
+	// same controller to HostHistory and replays both requests.
 	require.NoError(t, p.ScrollUp(inst, 1))
 	require.NoError(t, p.ScrollUp(inst, 1))
 	close(releaseNormal)
 	require.NoError(t, <-normalDone)
-	require.Equal(t, ScrollOwnerHostHistory, p.ScrollOwner())
+	require.Equal(t, ScrollOwnerNone, p.ScrollOwner(),
+		"scroll entry must invalidate the older normal snapshot")
 	require.True(t, p.NeedsScrollFill())
 
 	p.BeginScrollFill()

--- a/ui/scroll_controller.go
+++ b/ui/scroll_controller.go
@@ -47,12 +47,21 @@ type historyScrollController interface {
 	ScrollController
 	AwaitingHistory() bool
 	NeedsFill(viewportHeight int) bool
-	BeginFill()
-	FillGeneration() uint64
-	FillIsCurrent(uint64) bool
-	RearmFill()
+	MarkFillDispatched()
+	ClaimFill() (scrollFillToken, bool)
+	FillIsCurrent(scrollFillToken) bool
+	RearmFill(scrollFillToken)
 	ResolveHost()
-	CompleteFill(uint64, *viewport.Model, string) bool
+	CompleteFill(scrollFillToken, *viewport.Model, string) bool
+}
+
+// scrollFillToken is the controller-issued capability for one asynchronous
+// history capture. A generation number alone could order completions but could
+// not stop periodic refreshes from launching duplicate full captures. ClaimFill
+// makes that wrong state unrepresentable: only one caller can hold the current
+// lifecycle's token.
+type scrollFillToken struct {
+	generation uint64
 }
 
 type historyScrollPhase uint8
@@ -74,6 +83,7 @@ type captureHistoryScrollController struct {
 	pendingIntents []ScrollIntent
 	fillGen        uint64
 	dispatchedGen  uint64
+	fillInFlight   bool
 }
 
 var _ historyScrollController = (*captureHistoryScrollController)(nil)
@@ -154,18 +164,24 @@ func (c *captureHistoryScrollController) NeedsFill(viewportHeight int) bool {
 		c.dispatchedGen != c.fillGen
 }
 
-func (c *captureHistoryScrollController) BeginFill() {
+func (c *captureHistoryScrollController) MarkFillDispatched() {
 	if c.phase == historyScrollLoading {
 		c.dispatchedGen = c.fillGen
 	}
 }
 
-func (c *captureHistoryScrollController) FillGeneration() uint64 {
-	return c.fillGen
+func (c *captureHistoryScrollController) ClaimFill() (scrollFillToken, bool) {
+	if c.phase != historyScrollLoading || c.fillInFlight {
+		return scrollFillToken{}, false
+	}
+	c.dispatchedGen = c.fillGen
+	c.fillInFlight = true
+	return scrollFillToken{generation: c.fillGen}, true
 }
 
-func (c *captureHistoryScrollController) FillIsCurrent(gen uint64) bool {
-	return c.phase == historyScrollLoading && c.fillGen == gen
+func (c *captureHistoryScrollController) FillIsCurrent(token scrollFillToken) bool {
+	return c.phase == historyScrollLoading && c.fillInFlight &&
+		c.fillGen == token.generation
 }
 
 // Scroll either starts host-history acquisition, queues intent while that
@@ -183,6 +199,7 @@ func (c *captureHistoryScrollController) Scroll(v *viewport.Model, intent Scroll
 		c.phase = historyScrollLoading
 		c.pendingIntents = append(c.pendingIntents, intent)
 		c.fillGen++
+		c.fillInFlight = false
 	case historyScrollLoading:
 		c.pendingIntents = append(c.pendingIntents, intent)
 	case historyScrollReady:
@@ -195,11 +212,11 @@ func (c *captureHistoryScrollController) Scroll(v *viewport.Model, intent Scroll
 // offset, then apply every intent accumulated during the capture. There is no
 // final unconditional GotoBottom that can overwrite those requests (#2192).
 func (c *captureHistoryScrollController) CompleteFill(
-	gen uint64,
+	token scrollFillToken,
 	v *viewport.Model,
 	content string,
 ) bool {
-	if !c.FillIsCurrent(gen) {
+	if !c.FillIsCurrent(token) {
 		return false
 	}
 	v.SetContent(content)
@@ -213,6 +230,7 @@ func (c *captureHistoryScrollController) CompleteFill(
 	c.pendingIntents = nil
 	c.phase = historyScrollReady
 	c.fillGen++
+	c.fillInFlight = false
 	return true
 }
 
@@ -234,9 +252,10 @@ func (c *captureHistoryScrollController) Resize(v *viewport.Model, width, height
 // RearmFill preserves pending intent but gives the retry a fresh generation.
 // A capture that could not publish must not either lose input or leave the pane
 // permanently masked as in-flight (#1709).
-func (c *captureHistoryScrollController) RearmFill() {
-	if c.phase == historyScrollLoading {
+func (c *captureHistoryScrollController) RearmFill(token scrollFillToken) {
+	if c.FillIsCurrent(token) {
 		c.fillGen++
+		c.fillInFlight = false
 	}
 }
 
@@ -248,6 +267,7 @@ func (c *captureHistoryScrollController) Reset(v *viewport.Model) {
 	c.phase = historyScrollIdle
 	c.pendingIntents = nil
 	c.fillGen++
+	c.fillInFlight = false
 	v.SetContent("")
 	v.GotoTop()
 }

--- a/ui/scroll_controller_test.go
+++ b/ui/scroll_controller_test.go
@@ -25,8 +25,9 @@ func TestHostHistoryScrollControllerConformanceAtTerminalSizes(t *testing.T) {
 			controller.Scroll(&v, scrollOneLineUp)
 			require.True(t, controller.Active())
 			require.True(t, controller.NeedsFill(size.height))
-			gen := controller.FillGeneration()
-			require.True(t, controller.CompleteFill(gen, &v, history))
+			token, claimed := controller.ClaimFill()
+			require.True(t, claimed)
+			require.True(t, controller.CompleteFill(token, &v, history))
 
 			bottom := 100 - size.height
 			require.Equal(t, bottom-1, v.YOffset,
@@ -45,13 +46,14 @@ func TestHostHistoryScrollControllerPreservesIntentAcrossPendingResize(t *testin
 	controller := newHostHistoryScrollController()
 
 	controller.Scroll(&v, scrollOneLineUp)
-	gen := controller.FillGeneration()
+	token, claimed := controller.ClaimFill()
+	require.True(t, claimed)
 
 	// The real TUI can resize while capture is in flight. The eventual offset is
 	// computed from the new geometry, while both pre/post-resize intents survive.
 	controller.Resize(&v, 120, 40)
 	controller.Scroll(&v, scrollOneLineUp)
-	require.True(t, controller.CompleteFill(gen, &v, history))
+	require.True(t, controller.CompleteFill(token, &v, history))
 	require.Equal(t, 58, v.YOffset, "120x40 bottom 60 minus two queued up intents")
 }
 
@@ -65,7 +67,9 @@ func TestHostHistoryScrollControllerReplaysQueuedIntentInOrder(t *testing.T) {
 	// incorrectly cancel the two and lose their ordering semantics.
 	controller.Scroll(&v, scrollOneLineDown)
 	controller.Scroll(&v, scrollOneLineUp)
-	require.True(t, controller.CompleteFill(controller.FillGeneration(), &v, history))
+	token, claimed := controller.ClaimFill()
+	require.True(t, claimed)
+	require.True(t, controller.CompleteFill(token, &v, history))
 	require.Equal(t, 75, v.YOffset)
 }
 
@@ -75,7 +79,9 @@ func TestHostHistoryScrollControllerPreservesDistanceAcrossReadyResize(t *testin
 	controller := newHostHistoryScrollController()
 
 	controller.Scroll(&v, scrollOneLineUp)
-	require.True(t, controller.CompleteFill(controller.FillGeneration(), &v, history))
+	token, claimed := controller.ClaimFill()
+	require.True(t, claimed)
+	require.True(t, controller.CompleteFill(token, &v, history))
 	require.Equal(t, 75, v.YOffset, "80x24 bottom 76 minus one")
 
 	controller.Resize(&v, 120, 40)

--- a/ui/tab_pane.go
+++ b/ui/tab_pane.go
@@ -65,12 +65,12 @@ type TabPane struct {
 	// retargeting snapshots it so a grace-period expiry can replace stale content
 	// without racing and overwriting a capture that landed at the deadline.
 	renderRevision uint64
-	// captureGeneration orders same-target preview snapshots. Every capture
-	// dispatch and every state transition that invalidates pending captures
-	// advances it; only the current generation may publish. A slow older capture
-	// therefore cannot overwrite a newer terminal-owner decision merely because
-	// it finished last.
-	captureGeneration uint64
+	// normalCaptureGeneration orders same-target normal preview snapshots. Full
+	// history captures deliberately use a controller-issued single-flight token:
+	// periodic duplicate requests cannot launch a competing capture or starve the
+	// viewport. Owner/target changes and scroll entry advance this generation so
+	// an older normal snapshot cannot overwrite them.
+	normalCaptureGeneration uint64
 	// scroll is the explicit scroll owner and transition controller (#2192).
 	// Capture-backed tabs begin with an ownership probe and resolve to host or
 	// child ownership from the same snapshot as their content. The controller
@@ -209,7 +209,7 @@ func (p *TabPane) setScrollOwnerLocked(owner ScrollOwner) {
 		}
 	}
 	p.scroll.Reset(&p.viewport)
-	p.captureGeneration++
+	p.normalCaptureGeneration++
 	switch owner {
 	case ScrollOwnerHostHistory:
 		p.scroll = newHostHistoryScrollController()
@@ -223,7 +223,7 @@ func (p *TabPane) setScrollOwnerLocked(owner ScrollOwner) {
 
 func (p *TabPane) installOwnershipProbeLocked() {
 	p.scroll.Reset(&p.viewport)
-	p.captureGeneration++
+	p.normalCaptureGeneration++
 	p.scroll = newOwnershipProbeScrollController()
 	p.scroll.Resize(&p.viewport, p.width, p.height)
 }
@@ -256,7 +256,7 @@ func (p *TabPane) BeginScrollFill() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if history, ok := p.historyScrollLocked(); ok {
-		history.BeginFill()
+		history.MarkFillDispatched()
 	}
 }
 
@@ -312,7 +312,7 @@ func (p *TabPane) setFallbackState(message string) {
 	// Reset unconditionally: an already-None controller can still have viewport
 	// data left by a prior owner or a test seam. Fallback must make stale scroll
 	// rendering impossible even when the ownership enum does not change (#940).
-	p.captureGeneration++
+	p.normalCaptureGeneration++
 	p.scroll.Reset(&p.viewport)
 	p.setScrollOwnerLocked(ScrollOwnerNone)
 }
@@ -331,9 +331,9 @@ func guardOK(guard contentGuard) bool {
 	return guard == nil || guard()
 }
 
-func (p *TabPane) beginCaptureLocked() uint64 {
-	p.captureGeneration++
-	return p.captureGeneration
+func (p *TabPane) beginNormalCaptureLocked() uint64 {
+	p.normalCaptureGeneration++
+	return p.normalCaptureGeneration
 }
 
 // capturePaneHistoryRows removes capture-pane's one output-record separator.
@@ -415,23 +415,27 @@ func (p *TabPane) fillHostHistoryLocked(
 	if !ok {
 		return nil
 	}
-	gen := history.FillGeneration()
-	captureGeneration := p.beginCaptureLocked()
+	token, claimed := history.ClaimFill()
+	if !claimed {
+		// A periodic refresh may reach this path after the event-loop dispatch
+		// claimed the lifecycle. The controller admits exactly one full capture;
+		// duplicates return without competing with the in-flight fill.
+		return nil
+	}
 	p.mu.Unlock()
 	snapshot, err := p.previewSrc(instance, activeTab, true)
 	p.mu.Lock()
 
-	// Ownership can switch while capture is off-loop. A child transition replaces
-	// the controller and resets the old generation; never publish that host buffer.
-	if p.captureGeneration != captureGeneration {
-		return nil
-	}
+	// Ownership/target changes replace the controller, and a new scroll lifecycle
+	// advances its fill generation. Those are the authoritative stale checks for
+	// full history. ClaimFill prevents periodic refreshes in this SAME lifecycle
+	// from launching a second full capture in the first place.
 	current, stillHost := p.historyScrollLocked()
-	if !stillHost || current != history || !history.FillIsCurrent(gen) {
+	if !stillHost || current != history || !history.FillIsCurrent(token) {
 		return nil
 	}
 	if !guardOK(guard) || !p.isCurrentViewLocked(instance, activeTab) {
-		history.RearmFill()
+		history.RearmFill(token)
 		return nil
 	}
 	if err != nil {
@@ -439,7 +443,7 @@ func (p *TabPane) fillHostHistoryLocked(
 			p.setFallbackState(goneMessage)
 			return nil
 		}
-		history.RearmFill()
+		history.RearmFill(token)
 		return err
 	}
 	if snapshot.Owner != ScrollOwnerHostHistory {
@@ -453,7 +457,7 @@ func (p *TabPane) fillHostHistoryLocked(
 	// value too; TabbedWindow renders the scroll cue in its header, outside the
 	// child's history coordinate system.
 	content := capturePaneHistoryRows(snapshot.Content)
-	if history.CompleteFill(gen, &p.viewport, content) {
+	if history.CompleteFill(token, &p.viewport, content) {
 		p.renderRevision++
 	}
 	return nil
@@ -514,13 +518,13 @@ func (p *TabPane) updateAgent(instance *session.Instance, guard contentGuard) er
 		p.mu.Unlock()
 		return nil
 	}
-	captureGeneration := p.beginCaptureLocked()
+	captureGeneration := p.beginNormalCaptureLocked()
 	p.mu.Unlock()
 
 	snapshot, err := p.previewSrc(instance, 0, false)
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if p.captureGeneration != captureGeneration ||
+	if p.normalCaptureGeneration != captureGeneration ||
 		!guardOK(guard) || !p.isCurrentViewLocked(instance, 0) {
 		return nil
 	}
@@ -656,13 +660,13 @@ func (p *TabPane) updateShell(instance *session.Instance, activeTab int, guard c
 		p.mu.Unlock()
 		return nil
 	}
-	captureGeneration := p.beginCaptureLocked()
+	captureGeneration := p.beginNormalCaptureLocked()
 	p.mu.Unlock()
 
 	snapshot, err := p.previewSrc(instance, activeTab, false)
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if p.captureGeneration != captureGeneration ||
+	if p.normalCaptureGeneration != captureGeneration ||
 		!guardOK(guard) || !p.isCurrentViewLocked(instance, activeTab) {
 		return nil
 	}
@@ -770,7 +774,14 @@ func (p *TabPane) scrollBy(instance *session.Instance, activeTab int, intent Scr
 	if !p.scroll.Active() && !p.canEnterScrollModeLocked(instance, activeTab) {
 		return nil
 	}
+	wasActive := history.Active()
 	history.Scroll(&p.viewport, intent)
+	if !wasActive && history.Active() {
+		// Scroll entry starts a controller-owned full-history lifecycle. Invalidate
+		// any older normal capture now; full captures themselves must not compete on
+		// this generation or duplicate periodic refreshes can starve the fill.
+		p.normalCaptureGeneration++
+	}
 	return nil
 }
 

--- a/ui/termpane/modes.go
+++ b/ui/termpane/modes.go
@@ -5,6 +5,22 @@ import (
 	"github.com/sachiniyer/agent-factory/terminal"
 )
 
+// terminalModesAuthority is the complete ownership-snapshot state machine. A
+// single enum prevents independent "known", "connected", and cursor-coverage
+// booleans from drifting into combinations that falsely advertise an owner.
+type terminalModesAuthority uint8
+
+const (
+	terminalModesUnknown terminalModesAuthority = iota
+	// terminalModesDisconnected retains an authoritative base only so an exact
+	// replay can continue evolving it. It is never exposed to input routing.
+	terminalModesDisconnected
+	terminalModesCurrent
+	// terminalModesCursorCovered is current and permits exactly one recovery
+	// cursor re-seed immediately after the authoritative repaint that established it.
+	terminalModesCursorCovered
+)
+
 // TerminalModes returns the most recent terminal ownership modes and whether a
 // complete authoritative base is known. Live DECSET/DECRST callbacks evolve a
 // known base, but cannot create one: observing one changed mode does not prove
@@ -12,7 +28,65 @@ import (
 func (t *TermPane) TerminalModes() (terminal.Modes, bool) {
 	t.gridMu.RLock()
 	defer t.gridMu.RUnlock()
-	return t.terminalModes, t.modesKnown
+	known := t.modeAuthority == terminalModesCurrent ||
+		t.modeAuthority == terminalModesCursorCovered
+	return t.terminalModes, known
+}
+
+// installTerminalModesLocked makes one repaint the authoritative base for every
+// ownership mode. It also covers a cursor re-seed delivered immediately after
+// that repaint (the broker's recovery ordering is repaint -> cursor -> data).
+func (t *TermPane) installTerminalModesLocked(modes terminal.Modes) {
+	t.terminalModes = modes
+	t.modeAuthority = terminalModesCursorCovered
+}
+
+// invalidateTerminalModesLocked is the single authority-loss transition. The
+// last values remain for a seamless replay to evolve, but callers cannot use
+// them as an ownership decision until another complete snapshot establishes a
+// base.
+func (t *TermPane) invalidateTerminalModesLocked() {
+	t.modeAuthority = terminalModesUnknown
+}
+
+// connectTerminalModesLocked makes a retained base public only when the broker
+// accepted the exact cursor. A clamp crossed bytes that may contain mode changes,
+// so it discards authority until a fresh metadata-bearing repaint arrives.
+func (t *TermPane) connectTerminalModesLocked(exactReplay bool) {
+	if !exactReplay {
+		t.invalidateTerminalModesLocked()
+		return
+	}
+	if t.modeAuthority == terminalModesDisconnected {
+		t.modeAuthority = terminalModesCurrent
+	}
+}
+
+func (t *TermPane) disconnectTerminalModesLocked() {
+	switch t.modeAuthority {
+	case terminalModesCurrent, terminalModesCursorCovered:
+		t.modeAuthority = terminalModesDisconnected
+	}
+}
+
+func (t *TermPane) observeTerminalDataLocked() {
+	if t.modeAuthority == terminalModesCursorCovered {
+		t.modeAuthority = terminalModesCurrent
+	}
+}
+
+// observeTerminalCursorLocked accepts only the broker's opening hello and the
+// one recovery cursor covered by an immediately preceding authoritative repaint.
+// Every other jump may cross unretained DECSET/DECRST bytes and fails closed.
+func (t *TermPane) observeTerminalCursorLocked(opening bool) {
+	if opening {
+		return
+	}
+	if t.modeAuthority == terminalModesCursorCovered {
+		t.modeAuthority = terminalModesCurrent
+		return
+	}
+	t.invalidateTerminalModesLocked()
 }
 
 // setTerminalMode mirrors ownership-relevant emulator callbacks into the

--- a/ui/termpane/modes_test.go
+++ b/ui/termpane/modes_test.go
@@ -61,3 +61,108 @@ func TestRepaintRestoresTerminalOwnershipModes(t *testing.T) {
 	}, 2*time.Second, 5*time.Millisecond,
 		"a metadata-free recovery repaint must invalidate the prior owner")
 }
+
+func TestTerminalModesBecomeUnknownWhileStreamIsDisconnected(t *testing.T) {
+	tp, stream := newSingleStreamPane(t, 40, 8)
+	child := terminal.Modes{AlternateScreen: true}
+	stream.events <- Event{
+		Kind:     EventRepaint,
+		Data:     append(child.RestoreSequence(), []byte("\x1b[2J\x1b[Htranscript")...),
+		Modes:    child,
+		HasModes: true,
+	}
+	require.Eventually(t, func() bool {
+		got, known := tp.TerminalModes()
+		return known && got == child
+	}, 2*time.Second, 5*time.Millisecond)
+
+	require.NoError(t, stream.Close())
+	require.Eventually(t, func() bool {
+		_, known := tp.TerminalModes()
+		return !known
+	}, 2*time.Second, 5*time.Millisecond,
+		"a dropped stream must not keep advertising an owner that may change during the outage")
+}
+
+func TestClampedReconnectRequiresFreshTerminalModes(t *testing.T) {
+	first := newFakeStream(0)
+	second := newFakeStream(42)
+	dialer := &queueDialer{streams: []*fakeStream{first, second}}
+	tp := New(dialer.dial, 40, 8)
+	t.Cleanup(func() { _ = tp.Close() })
+
+	child := terminal.Modes{AlternateScreen: true}
+	first.events <- Event{
+		Kind:     EventRepaint,
+		Data:     child.RestoreSequence(),
+		Modes:    child,
+		HasModes: true,
+	}
+	require.Eventually(t, func() bool {
+		got, known := tp.TerminalModes()
+		return known && got == child
+	}, 2*time.Second, 5*time.Millisecond)
+
+	require.NoError(t, first.Close())
+	require.Eventually(t, func() bool {
+		_, connected := second.lastResize()
+		return connected
+	}, 2*time.Second, 5*time.Millisecond, "the pane must establish the clamped reconnect")
+	_, known := tp.TerminalModes()
+	require.False(t, known,
+		"a reconnect clamped over unretained bytes must not reuse the pre-gap owner")
+
+	host := terminal.Modes{}
+	second.events <- Event{
+		Kind:     EventRepaint,
+		Data:     host.RestoreSequence(),
+		Modes:    host,
+		HasModes: true,
+	}
+	require.Eventually(t, func() bool {
+		got, current := tp.TerminalModes()
+		return current && got == host
+	}, 2*time.Second, 5*time.Millisecond,
+		"a fresh authoritative repaint must restore ownership after the gap")
+}
+
+func TestCursorJumpInvalidatesModesUnlessFreshRepaintCoversIt(t *testing.T) {
+	tp, stream := newSingleStreamPane(t, 40, 8)
+	child := terminal.Modes{AlternateScreen: true}
+	stream.events <- Event{
+		Kind:     EventRepaint,
+		Data:     append(child.RestoreSequence(), []byte("\x1b[2J\x1b[Htranscript")...),
+		Modes:    child,
+		HasModes: true,
+	}
+	require.Eventually(t, func() bool {
+		_, known := tp.TerminalModes()
+		return known
+	}, 2*time.Second, 5*time.Millisecond)
+
+	// Recovery ordering is repaint -> cursor -> data. The repaint describes the
+	// post-gap terminal, so its immediately following cursor jump is covered and
+	// must not throw away the authority that just arrived.
+	stream.feedCursor(77)
+	require.Eventually(t, func() bool {
+		tp.connMu.Lock()
+		defer tp.connMu.Unlock()
+		return tp.cursor == 77
+	}, 2*time.Second, 5*time.Millisecond)
+	_, known := tp.TerminalModes()
+	require.True(t, known, "an authoritative repaint covers its recovery cursor jump")
+
+	// Coverage is single-use. A subsequent jump can skip an unretained mode
+	// transition even if no printable data arrived between the two cursor frames.
+	stream.feedCursor(99)
+	require.Eventually(t, func() bool {
+		tp.connMu.Lock()
+		defer tp.connMu.Unlock()
+		return tp.cursor == 99
+	}, 2*time.Second, 5*time.Millisecond)
+	require.Eventually(t, func() bool {
+		_, known := tp.TerminalModes()
+		return !known
+	}, 2*time.Second, 5*time.Millisecond,
+		"an uncovered cursor jump may have skipped a mode change")
+}

--- a/ui/termpane/termpane.go
+++ b/ui/termpane/termpane.go
@@ -150,7 +150,9 @@ type TermPane struct {
 	// can never stay stuck forwarding to a program that reset the terminal (#1748).
 	mouseModes    map[ansi.Mode]bool
 	terminalModes terminal.Modes
-	modesKnown    bool
+	// modeAuthority is the complete visibility/connection/recovery state for the
+	// snapshot above; modes.go owns every transition so independent flags cannot drift.
+	modeAuthority terminalModesAuthority
 	width, height int
 
 	dial Dialer
@@ -252,6 +254,12 @@ func (t *TermPane) run() {
 		rows, cols := t.wantRows, t.wantCols
 		t.connMu.Unlock()
 
+		t.gridMu.Lock()
+		// A clamped cursor crossed an unretained gap. A fresh repaint will
+		// normally follow, but the prior owner is unsafe until it does.
+		t.connectTerminalModesLocked(stream.StartSeq() == since)
+		t.gridMu.Unlock()
+
 		// (Re)assert our desired size so the server sizes this tab's window to us —
 		// the pane may have resized while we were disconnected (last-resize-wins).
 		wctx, cancelW := context.WithTimeout(t.ctx, writeTimeout)
@@ -259,6 +267,13 @@ func (t *TermPane) run() {
 		cancelW()
 
 		t.readStream(stream)
+
+		// Recv failed or Close cancelled it. The child may change ownership while
+		// there is no byte stream to observe, so input routing must fail closed for
+		// the entire disconnected window. Keep the value itself for exact replay.
+		t.gridMu.Lock()
+		t.disconnectTerminalModesLocked()
+		t.gridMu.Unlock()
 
 		t.connMu.Lock()
 		if t.stream == stream {
@@ -272,15 +287,21 @@ func (t *TermPane) run() {
 // readStream pumps one connection's inbound events into the emulator until it
 // errors (drop) or the context is cancelled (Close).
 func (t *TermPane) readStream(stream Stream) {
+	firstInbound := true
 	for {
 		ev, err := stream.Recv(t.ctx)
 		if err != nil {
 			return
 		}
+		openingCursor := firstInbound && ev.Kind == EventCursor && ev.Seq == stream.StartSeq()
+		firstInbound = false
 		switch ev.Kind {
 		case EventData:
 			t.gridMu.Lock()
 			_, _ = t.emu.Write(ev.Data)
+			// Live callbacks evolve a known base in the no-gap case, while any data
+			// consumes the repaint's one-shot recovery-cursor coverage.
+			t.observeTerminalDataLocked()
 			t.gridMu.Unlock()
 			t.connMu.Lock()
 			t.cursor += uint64(len(ev.Data))
@@ -295,15 +316,17 @@ func (t *TermPane) readStream(stream Stream) {
 				// modes. Assign the snapshot as the authority as well: tmux can
 				// report UTF-8 encoding even when an emulator does not expose a
 				// callback for it, and all-false is meaningful.
-				t.terminalModes = ev.Modes
-				t.modesKnown = true
+				t.installTerminalModesLocked(ev.Modes)
 			} else {
 				// A recovery repaint can jump over unretained DEC mode changes.
 				// Without snapshot metadata the old decision is no longer safe.
-				t.modesKnown = false
+				t.invalidateTerminalModesLocked()
 			}
 			t.gridMu.Unlock()
 		case EventCursor:
+			t.gridMu.Lock()
+			t.observeTerminalCursorLocked(openingCursor)
+			t.gridMu.Unlock()
 			// The server moved our cursor over bytes it no longer holds (an eviction or
 			// a recovery discard). Adopt its position verbatim — our own
 			// start + bytes-received count is now stale, and reconnecting on it would ask


### PR DESCRIPTION
## Why this follow-up exists

Codex inline review arrived after #2257 had already auto-merged. All three P2 findings were legitimate, so this follow-up treats them as shipped defects rather than leaving findings on a closed PR. It continues the structural work for #2192.

## Structural fixes

- Host-history fill is now controller-enforced single-flight. A controller-issued typed token admits exactly one full capture per fill lifecycle; periodic preview refreshes cannot start a competing capture. Normal preview publication keeps a separate generation, and entering scroll mode invalidates any older normal snapshot.
- Terminal mode ownership is now one explicit authority state machine: unknown, disconnected, current, or current-with-one-recovery-cursor-covered. This replaces independent flags that could drift into an unsafe combination.
- A disconnected stream never advertises an owner. Only an exact replay may reactivate its retained base; a clamped reconnect and every uncovered cursor jump fail closed until a metadata-bearing repaint establishes a new base.
- Recovery repaint to cursor ordering is represented as one-shot coverage, so the repaint remains authoritative for the cursor it describes but cannot bless a later gap.

## Fail-first evidence

Before the implementation, the regressions demonstrated all three defects on the #2257 tree: a duplicate refresh displaced the initiating fill and left the viewport blank, a dropped stream continued reporting known terminal modes, and a cursor jump retained a stale child or host owner. They pass after the state-machine changes.

## Product boundary

This does not reopen attach routing: attach remains a raw child-owned proxy and Ctrl-U is never intercepted. It also does not restore a false detached-preview scroll affordance for fullscreen child-owned history; capture-pane still cannot construct that private conversation.

## Validation

- Full make test-container suite: green on the patched tree before the final unrelated master fast-forward
- After rebasing to current master: make test-container GOTESTARGS=./ui\ ./ui/termpane: green
- Race: UI and termpane packages green
- golangci-lint, gofmt, deadcode, file-length lint, go vet, and go build: green
- Fail-first cases cover duplicate refresh, delayed queued intent, disconnect, exact versus clamped reconnect authority, and covered versus uncovered cursor jumps

Follow-up to #2257. Related to #2192.