### PR TITLE
fix(config): preserve global map replacement semantics

### DIFF
--- a/config/manifest_policy_test.go
+++ b/config/manifest_policy_test.go
@@ -129,7 +129,6 @@ func TestAllManifestScalarDefaultsMatchBuiltInResolution(t *testing.T) {
 	computed, err := resolveManifest(entries, []sourceDocument{{
 		layer:   SourceBuiltIn,
 		schemas: []any{DefaultConfig(), defaultInRepoConfig()},
-		builtIn: true,
 	}}, false)
 	if err != nil {
 		t.Fatalf("resolve union built-in defaults: %v", err)

--- a/config/provenance.go
+++ b/config/provenance.go
@@ -52,10 +52,25 @@ type ResolvedValue struct {
 }
 
 type sourceDocument struct {
-	layer    ConfigSource
-	metadata sourceMetadata
-	schemas  []any
-	builtIn  bool
+	layer          ConfigSource
+	metadata       sourceMetadata
+	schemas        []any
+	valueSemantics sourceValueSemantics
+}
+
+// sourceValueSemantics says whether a decoded schema is one source's delta or
+// the complete effective snapshot through that source. Global Config is
+// decoded on top of DefaultConfig, so treating it as a delta can resurrect a
+// built-in map entry that the loader removed (for example a TOML inline map).
+type sourceValueSemantics uint8
+
+const (
+	sourceValueDelta sourceValueSemantics = iota
+	sourceValueSnapshot
+)
+
+func (d sourceDocument) isBuiltIn() bool {
+	return d.layer == SourceBuiltIn
 }
 
 type computedValue struct {
@@ -64,13 +79,13 @@ type computedValue struct {
 }
 
 type sourceCandidate struct {
-	document        sourceDocument
-	traceIndex      int
-	typed           reflect.Value
-	leaves          map[string]reflect.Value
-	configuredCount int
-	normalizedCount int
-	materialized    bool
+	document         sourceDocument
+	traceIndex       int
+	typed            reflect.Value
+	leaves           map[string]reflect.Value
+	configuredCount  int
+	normalizedCount  int
+	removedInherited int
 }
 
 func resolveManifest(entries []ManifestEntry, documents []sourceDocument, requireAllSources bool) ([]computedValue, error) {
@@ -83,6 +98,9 @@ func resolveManifest(entries []ManifestEntry, documents []sourceDocument, requir
 	})
 	byLayer := make(map[ConfigSource]bool, len(documents))
 	for _, document := range documents {
+		if document.valueSemantics != sourceValueDelta && document.valueSemantics != sourceValueSnapshot {
+			return nil, fmt.Errorf("config resolver received invalid value semantics %d for %s source", document.valueSemantics, document.layer)
+		}
 		if byLayer[document.layer] {
 			return nil, fmt.Errorf("config resolver received duplicate %s source", document.layer)
 		}
@@ -128,7 +146,7 @@ func resolveManifestEntry(entry ManifestEntry, documents []sourceDocument) (comp
 	for _, document := range documents {
 		allowed := sourceInPrecedence(document.layer, entry.Precedence)
 		configured, present := document.metadata.topLevel(entry.Key)
-		if document.builtIn {
+		if document.isBuiltIn() {
 			present = allowed
 		}
 		trace := CandidateTrace{
@@ -141,7 +159,7 @@ func resolveManifestEntry(entry ManifestEntry, documents []sourceDocument) (comp
 			Value:   nil,
 		}
 		if present {
-			if document.builtIn {
+			if document.isBuiltIn() {
 				value, ok := valueFromSchemas(document.schemas, entry.Key)
 				if !ok {
 					return computedValue{}, fmt.Errorf("built-in source has no typed field")
@@ -189,7 +207,7 @@ func resolveReplace(entry ManifestEntry, result ResolvedValue, candidates []sour
 	winnerTrace := &result.Candidates[candidates[winner].traceIndex]
 	winnerTrace.Result = "winner"
 	winnerTrace.Reason = "highest-precedence present allowed source"
-	if !candidates[winner].document.builtIn &&
+	if !candidates[winner].document.isBuiltIn() &&
 		!jsonEquivalent(winnerTrace.Value, clonedInterface(candidates[winner].typed)) {
 		winnerTrace.Reason += "; load-time normalization changed the configured value before resolution"
 	}
@@ -218,7 +236,7 @@ func resolveComposite(entry ManifestEntry, result ResolvedValue, candidates []so
 
 	leafValues := make(map[string]reflect.Value)
 	origins := make(map[string]SourceRef)
-	anyMaterialized := false
+	materialized := false
 	for i := range candidates {
 		candidate := &candidates[i]
 		trace := &result.Candidates[candidate.traceIndex]
@@ -228,15 +246,47 @@ func resolveComposite(entry ManifestEntry, result ResolvedValue, candidates []so
 		}
 
 		configured, _ := candidate.document.metadata.topLevel(entry.Key)
-		leaves, configuredCount, normalizedCount, materialized, err := compositeLeaves(candidate.typed, configured, candidate.document.builtIn)
+		leaves, configuredCount, normalizedCount, candidateMaterialized, err := compositeLeaves(
+			candidate.typed, configured, candidate.document.isBuiltIn())
 		if err != nil {
 			return computedValue{}, err
 		}
 		candidate.leaves = leaves
 		candidate.configuredCount = configuredCount
 		candidate.normalizedCount = normalizedCount
-		candidate.materialized = materialized
-		anyMaterialized = anyMaterialized || materialized
+
+		if candidate.document.valueSemantics == sourceValueSnapshot {
+			full, _, _, snapshotMaterialized, err := compositeLeaves(candidate.typed, nil, true)
+			if err != nil {
+				return computedValue{}, fmt.Errorf("read materialized %s snapshot: %w", candidate.document.layer, err)
+			}
+			for leaf := range leafValues {
+				if _, retained := full[leaf]; retained {
+					continue
+				}
+				delete(leafValues, leaf)
+				delete(origins, leaf)
+				candidate.removedInherited++
+			}
+			for leaf, value := range full {
+				if explicit, configuredHere := leaves[leaf]; configuredHere {
+					leafValues[leaf] = cloneExportedValue(explicit)
+					origins[leaf] = sourceReference(candidate.document, leafKeyPath(entry.Key, leaf))
+					continue
+				}
+				inherited, present := leafValues[leaf]
+				if !present {
+					return computedValue{}, fmt.Errorf("%s snapshot materialized unconfigured leaf %q with no lower-precedence origin", candidate.document.layer, leaf)
+				}
+				if !jsonEquivalent(clonedInterface(inherited), clonedInterface(value)) {
+					return computedValue{}, fmt.Errorf("%s snapshot changed unconfigured inherited leaf %q", candidate.document.layer, leaf)
+				}
+			}
+			materialized = snapshotMaterialized
+			continue
+		}
+
+		materialized = materialized || candidateMaterialized
 		for leaf, value := range leaves {
 			leafValues[leaf] = cloneExportedValue(value)
 			origins[leaf] = sourceReference(candidate.document, leafKeyPath(entry.Key, leaf))
@@ -257,12 +307,20 @@ func resolveComposite(entry ManifestEntry, result ResolvedValue, candidates []so
 		}
 		ignored := candidate.configuredCount - len(candidate.leaves)
 		switch {
+		case len(candidate.leaves) == 0 && candidate.removedInherited > 0:
+			trace.Result = "replaced"
+			trace.Reason = fmt.Sprintf("loaded value removes %d lower-precedence %s and contributes no entries",
+				candidate.removedInherited, pluralize("entry", candidate.removedInherited))
+			if ignored > 0 {
+				trace.Reason += fmt.Sprintf("; load-time validation removed %d configured %s",
+					ignored, pluralize("entry", ignored))
+			}
 		case len(candidate.leaves) == 0 && ignored > 0:
 			trace.Result = "ignored"
 			trace.Reason = "all configured entries were removed by load-time validation"
 		case len(candidate.leaves) == 0:
 			trace.Result = "empty"
-			trace.Reason = "present but contains no entries; lower-priority entries remain"
+			trace.Reason = "present but contains no entries"
 		case surviving == len(candidate.leaves):
 			trace.Result = "contributed"
 			trace.Reason = fmt.Sprintf("contributes %d effective %s", surviving, pluralize("entry", surviving))
@@ -277,13 +335,17 @@ func resolveComposite(entry ManifestEntry, result ResolvedValue, candidates []so
 		if ignored > 0 && len(candidate.leaves) > 0 {
 			trace.Reason += fmt.Sprintf("; load-time validation removed %d configured %s", ignored, pluralize("entry", ignored))
 		}
+		if candidate.removedInherited > 0 && len(candidate.leaves) > 0 {
+			trace.Reason += fmt.Sprintf("; loaded value also removes %d lower-precedence %s",
+				candidate.removedInherited, pluralize("entry", candidate.removedInherited))
+		}
 		if candidate.normalizedCount > 0 {
 			trace.Reason += fmt.Sprintf("; load-time normalization changed %d configured %s",
 				candidate.normalizedCount, pluralize("entry", candidate.normalizedCount))
 		}
 	}
 
-	value, err := buildComposite(targetType, leafValues, anyMaterialized)
+	value, err := buildComposite(targetType, leafValues, materialized)
 	if err != nil {
 		return computedValue{}, err
 	}

--- a/config/provenance_test.go
+++ b/config/provenance_test.go
@@ -19,6 +19,15 @@ func setupProvenanceTest(t *testing.T, globalTOML string) string {
 	return t.TempDir()
 }
 
+func setupProvenanceTestWithDetectedClaude(t *testing.T, globalTOML string) string {
+	t.Helper()
+	bin := t.TempDir()
+	claudePath := filepath.Join(bin, "claude")
+	require.NoError(t, os.WriteFile(claudePath, []byte("#!/bin/sh\nexit 0\n"), 0755))
+	t.Setenv("PATH", bin)
+	return setupProvenanceTest(t, globalTOML)
+}
+
 func requireResolvedValue(t *testing.T, cfg *ResolvedConfig, key string) ResolvedValue {
 	t.Helper()
 	value, ok := cfg.ResolvedValue(key)
@@ -86,6 +95,82 @@ limit_patterns = {}
 	globalPatterns := candidateForLayer(t, patterns, SourceGlobal)
 	assert.True(t, globalPatterns.Present)
 	assert.Equal(t, "empty", globalPatterns.Result)
+}
+
+func TestResolveGlobalConfigPreservesLoadedMapReplacementSemantics(t *testing.T) {
+	tests := []struct {
+		name       string
+		globalTOML string
+		wantClaude bool
+		wantCodex  bool
+	}{
+		{
+			name: "inline map replaces detected default entry",
+			globalTOML: `
+schema_version = 1
+program_overrides = { codex = "/bin/codex" }
+`,
+			wantCodex: true,
+		},
+		{
+			name: "inline empty map clears detected default entry",
+			globalTOML: `
+schema_version = 1
+program_overrides = {}
+`,
+		},
+		{
+			name: "table merges with detected default entry",
+			globalTOML: `
+schema_version = 1
+
+[program_overrides]
+codex = "/bin/codex"
+`,
+			wantClaude: true,
+			wantCodex:  true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			repoRoot := setupProvenanceTestWithDetectedClaude(t, test.globalTOML)
+
+			loaded, err := LoadConfig()
+			require.NoError(t, err)
+			resolved, err := ResolveGlobalConfig()
+			require.NoError(t, err)
+			projectResolved, err := ResolveConfig(repoRoot)
+			require.NoError(t, err)
+			assert.Equal(t, loaded.ProgramOverrides, projectResolved.ProgramOverrides,
+				"project resolution must preserve the global loader's replacement semantics")
+
+			for _, entry := range Manifest() {
+				loadedField, loadedOK := taggedFieldByKey(reflect.ValueOf(loaded), entry.Key)
+				resolvedField, resolvedOK := taggedFieldByKey(reflect.ValueOf(&resolved.Config), entry.Key)
+				require.True(t, loadedOK && resolvedOK, "manifest field %q must exist on both configs", entry.Key)
+				assert.True(t, jsonEquivalent(clonedInterface(loadedField), clonedInterface(resolvedField)),
+					"resolution changed LoadConfig's effective value for %s", entry.Key)
+			}
+
+			_, hasClaude := resolved.ProgramOverrides["claude"]
+			_, hasCodex := resolved.ProgramOverrides["codex"]
+			assert.Equal(t, test.wantClaude, hasClaude)
+			assert.Equal(t, test.wantCodex, hasCodex)
+
+			value := requireResolvedValue(t, resolved, "program_overrides")
+			if test.wantClaude {
+				assert.Equal(t, SourceBuiltIn.String(), value.Origins["claude"].Layer)
+			} else {
+				_, hasOrigin := value.Origins["claude"]
+				assert.False(t, hasOrigin)
+				_, hasLeaf := resolved.ResolvedValuePath("program_overrides.claude")
+				assert.False(t, hasLeaf)
+				assert.Contains(t, candidateForLayer(t, value, SourceGlobal).Reason,
+					"removes 1 lower-precedence entry")
+			}
+		})
+	}
 }
 
 func TestResolveConfigReportsPerLeafMapOrigins(t *testing.T) {
@@ -311,19 +396,19 @@ delete_cmd = "hook-delete"
 
 func TestResolvedValuePathExplainsHigherCandidateRemovedByNormalization(t *testing.T) {
 	builtIn := &Config{ProgramOverrides: map[string]string{"codex": "built-in"}}
-	global := &Config{ProgramOverrides: map[string]string{}}
+	repo := &InRepoConfig{ProgramOverrides: map[string]string{}}
 	computed, err := resolveManifest([]ManifestEntry{{
 		Key:        "program_overrides",
-		Precedence: []ConfigSource{SourceBuiltIn, SourceGlobal},
+		Precedence: []ConfigSource{SourceBuiltIn, SourceRepoShared},
 		Merge:      MergeMapByKey,
 	}}, []sourceDocument{
-		{layer: SourceBuiltIn, schemas: []any{builtIn}, builtIn: true},
+		{layer: SourceBuiltIn, schemas: []any{builtIn}},
 		{
-			layer: SourceGlobal,
+			layer: SourceRepoShared,
 			metadata: sourceMetadata{shape: map[string]any{
 				"program_overrides": map[string]any{"codex": "discarded"},
 			}},
-			schemas: []any{global},
+			schemas: []any{repo},
 		},
 	}, true)
 	require.NoError(t, err)
@@ -334,10 +419,10 @@ func TestResolvedValuePathExplainsHigherCandidateRemovedByNormalization(t *testi
 	leaf, ok := resolved.ResolvedValuePath("program_overrides.codex")
 	require.True(t, ok)
 	assert.Equal(t, "built-in", leaf.Value)
-	globalCandidate := candidateForLayer(t, leaf, SourceGlobal)
-	assert.Equal(t, "ignored", globalCandidate.Result)
-	assert.Contains(t, globalCandidate.Reason, "did not survive load-time normalization")
-	assert.Contains(t, globalCandidate.Reason, "lower-precedence built-in")
+	repoCandidate := candidateForLayer(t, leaf, SourceRepoShared)
+	assert.Equal(t, "ignored", repoCandidate.Result)
+	assert.Contains(t, repoCandidate.Reason, "did not survive load-time normalization")
+	assert.Contains(t, repoCandidate.Reason, "lower-precedence built-in")
 }
 
 func TestResolveConfigResolutionCoversManifestAndDoesNotAliasSources(t *testing.T) {

--- a/config/resolve.go
+++ b/config/resolve.go
@@ -195,12 +195,12 @@ func globalResolutionDocuments(global *Config) ([]sourceDocument, error) {
 		{
 			layer:   SourceBuiltIn,
 			schemas: []any{global.source.builtIn, defaultInRepoConfig()},
-			builtIn: true,
 		},
 		{
-			layer:    SourceGlobal,
-			metadata: metadata,
-			schemas:  []any{global},
+			layer:          SourceGlobal,
+			metadata:       metadata,
+			schemas:        []any{global},
+			valueSemantics: sourceValueSnapshot,
 		},
 	}, nil
 }


### PR DESCRIPTION
Follow-up to #2246 for the P1 found by Codex after that PR merged: https://github.com/sachiniyer/agent-factory/pull/2246#discussion_r3621248704

## Problem

LoadConfig decodes global TOML on top of DefaultConfig. An inline program_overrides map is a complete replacement, while a normal TOML table merges into the existing detected-Claude map. The provenance resolver treated every decoded source as a delta, so it could resurrect a built-in Claude override that the loader had removed and silently change session behavior.

## Change

- Model decoded source values explicitly as deltas or cumulative snapshots.
- Treat global Config as the effective snapshot through the global layer; keep repo sources as per-key deltas.
- Use resolved snapshot membership to remove inherited leaves while retaining lower origins only for unchanged inherited leaves.
- Explain replacement removals in the candidate trace.
- Derive built-in status from ConfigSource instead of a second boolean that could drift.
- Cover inline replacement, inline empty replacement, and table merge with a hermetic detected-Claude regression; assert both global and project resolution preserve LoadConfig values.

## Verification

- go test ./config ./commands ./parity
- golangci-lint, go build, deadcode, gofmt, file-length lint
- make test-container