### PR TITLE
fix(doctor): detect recycled tmux server PIDs

### DIFF
--- a/doctor/checks.go
+++ b/doctor/checks.go
@@ -395,8 +395,10 @@ func checkOrphanedProcesses(ctx *scanContext, report *Report) {
 }
 
 // tmuxServerDead parses a TMUX env value ("socketPath,serverPID,sessionIdx")
-// and reports whether the server it names is gone. Unparseable values are
-// treated as alive (never accuse on garbage).
+// and reports whether the process identity it records still belongs to tmux.
+// Unparseable values are treated as alive (never accuse on garbage). The socket
+// path is deliberately not a liveness signal: a crashed server can leave it
+// behind after the kernel recycles the recorded PID to an unrelated process.
 func tmuxServerDead(ctx *scanContext, tmuxEnv string) bool {
 	parts := strings.Split(tmuxEnv, ",")
 	if len(parts) < 2 {
@@ -410,12 +412,8 @@ func tmuxServerDead(ctx *scanContext, tmuxEnv string) bool {
 	if alive && strings.HasPrefix(server.Comm, "tmux") {
 		return false
 	}
-	// PID gone or recycled to a non-tmux process; confirm via the socket.
-	if _, err := os.Stat(parts[0]); err == nil && alive {
-		// Socket still present and some process holds the PID — too
-		// ambiguous to call dead.
-		return false
-	}
+	// PID gone or recycled to a non-tmux process: the server named by this
+	// environment value is dead, regardless of any stale or reused socket path.
 	return true
 }
 

--- a/doctor/doctor_test.go
+++ b/doctor/doctor_test.go
@@ -518,6 +518,12 @@ func TestTmuxServerDeadParsing(t *testing.T) {
 	require.False(t, tmuxServerDead(ctx, "/tmp/sock,notanumber,0"))
 	// A PID that certainly exists but is not tmux, with no socket on disk.
 	require.True(t, tmuxServerDead(ctx, fmt.Sprintf("/nonexistent-sock-%d,%d,0", os.Getpid(), os.Getpid())))
+	// A crashed tmux server can leave its socket behind while the kernel recycles
+	// its PID to a non-tmux process. The stale path is not evidence that the
+	// process named by this TMUX value is still a tmux server (#2206).
+	staleSocket := filepath.Join(t.TempDir(), "stale-tmux.sock")
+	require.NoError(t, os.WriteFile(staleSocket, nil, 0o600))
+	require.True(t, tmuxServerDead(ctx, fmt.Sprintf("%s,%d,0", staleSocket, os.Getpid())))
 	// A dead PID.
 	c := exec.Command("true")
 	require.NoError(t, c.Run())


### PR DESCRIPTION
## Summary

- treat the PID/process identity recorded in `TMUX` as the tmux-server liveness source
- stop allowing a stale or reused socket path to make a recycled non-tmux PID look alive
- add the recycled-PID-plus-stale-path regression reported by Detail

## Verification against master

#2206 is real on current master:

- `doctor/checks.go:409-411` returns alive only when the recorded PID still belongs to a process whose command starts with `tmux`
- after that identity check has already failed, `doctor/checks.go:413-417` lets an existing socket plus any live process at the recycled PID override the result
- `doctor/checks.go:295` uses that false result to exclude the process from possible-orphan detection

A filesystem entry cannot restore the identity encoded in the process environment. A crashed tmux server may leave its socket path behind, and a different tmux server may later reuse the path; neither makes the old recorded server PID valid.

## Fail-first

`TestTmuxServerDeadParsing` now creates a stale path and pairs it with the current non-tmux process PID. Before the fix, `tmuxServerDead` returned false at `doctor/doctor_test.go:526`; after the fix it reports the recorded server dead. The full doctor package also passes.

Full gates are green on pushed SHA `e8c3d959`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh` (919 Go files checked; 0 grandfathered)

Closes #2206.

— Captain Claude