### PR TITLE
fix(web): keep tabs on the pane title row

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -258,16 +258,15 @@ the top bar, the **project switcher** (top-right), or the `[` / `]` keys:
 ┌───────────────────────────────────────────────────────────────────────┐
 │  Agent Factory   [ Sessions ]  Tasks       project ▾   ● Live   Disconnect│  ← app bar
 ├──────────────────────┬────────────────────────────────────────────────┤
-│ Sessions      3 ▤ +New│  fix-login-flow · Live · fix/login             │  ← pane header
+│ Sessions      3 ▤ +New│ fix-login-flow · Live │ Agent │ Terminal │ + │  ← title + tabs
 │                       │ ┌────────────────────────────────────────────┐ │
-│ ● fix-login-flow      │ │ Agent │ Terminal │ +                       │ │  ← tab bar
-│   ⎇ fix/login         │ ├────────────────────────────────────────────┤ │
+│ ● fix-login-flow      │ │                                            │ │
+│   ⎇ fix/login         │ │                                            │ │
 │ ○ add-metrics         │ │                                            │ │
 │   ⎇ metrics           │ │   (live agent terminal — xterm.js)         │ │  ← attach terminal
 │ ◆ nightly-refactor    │ │                                            │ │
 │   ⎇ refactor          │ │                                            │ │
 │                       │ └────────────────────────────────────────────┘ │
-│                       │           [ Prompt ]  [ Archive ]  [ Kill ]     │  ← pane actions
 └──────────────────────┴────────────────────────────────────────────────┘
 ```
 
@@ -349,9 +348,11 @@ tapping the dimmed scrim dismisses the drawer directly.
 #### The attach terminal
 
 The main pane hosts a real terminal (xterm.js) streaming the agent's live output
-over the daemon's WebSocket PTY plane — the same bytes the TUI paints. The pane
-header shows the session title, the terminal's connection state (`Live` /
-`Connecting…` / `Reconnecting…` / `Agent exited`), and the branch.
+over the daemon's WebSocket PTY plane — the same bytes the TUI paints. One pane-header
+row holds the session title, terminal connection state (`Live` / `Connecting…` /
+`Reconnecting…` / `Agent exited`), horizontally scrolling tabs, and the conditional
+**Retry** escape. The title keeps a useful minimum and ellipsizes; Retry never shrinks;
+the tab strip owns the remaining width and scrolls rather than wrapping.
 
 #### Per-session actions
 
@@ -379,8 +380,8 @@ include that row's title.
 ### Tabs
 
 Just like the TUI, a session isn't limited to its agent — each one holds up to
-**nine tabs**, all running in the *same* worktree. The tab bar sits between the
-pane header and the terminal:
+**nine tabs**, all running in the *same* worktree. The tab bar shares the pane
+header row with the title at every viewport width:
 
 ```
 ┌──────────┬────────────┬──────────┬─────────────┐

--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -961,7 +961,7 @@ body {
 .af-term-head {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: 0.6rem;
   padding: var(--af-sp-2) 0.9rem;
   border-bottom: 1px solid var(--af-border);
@@ -971,15 +971,13 @@ body {
   display: flex;
   align-items: baseline;
   gap: 0.6rem;
-  min-width: 0;
-}
-.af-term-actions {
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-  flex: 0 0 auto;
+  flex: 0 1 auto;
+  min-width: 7.5rem;
+  max-width: min(18rem, 34vw);
+  overflow: hidden;
 }
 .af-term-action {
+  flex: 0 0 auto;
   padding: 0.3rem 0.6rem;
   font-size: var(--af-fs-xs);
 }
@@ -987,6 +985,8 @@ body {
   display: none;
 }
 .af-term-title {
+  flex: 1 1 auto;
+  min-width: 5.5rem;
   font-size: var(--af-fs-md);
   font-weight: 600;
   white-space: nowrap;
@@ -994,9 +994,13 @@ body {
   text-overflow: ellipsis;
 }
 .af-term-meta {
+  flex: 0 1 auto;
+  min-width: 0;
   font-size: var(--af-fs-xs);
   color: var(--af-text-2);
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .af-term-meta.af-term-open {
   color: var(--af-dot-ready);
@@ -1011,10 +1015,12 @@ body {
 .af-tabbar {
   display: flex;
   align-items: stretch;
+  flex: 1 1 0;
+  min-width: 6rem;
   gap: 0.15rem;
-  padding: 0 0.6rem;
-  background: var(--af-bg-surface);
-  border-bottom: 1px solid var(--af-border);
+  padding: 0;
+  background: transparent;
+  border: 0;
   overflow-x: auto;
   scrollbar-width: thin;
   position: relative;

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -11260,18 +11260,19 @@ var AppShell = class {
     this.retryBtn = retryBtn;
     this.retryVisible = isLimitReached(selected);
     retryBtn.hidden = !this.retryVisible;
-    const actions2 = h2("div", { class: "af-term-actions" }, retryBtn);
-    const head = h2("div", { class: "af-term-head" }, titleBox, actions2);
-    this.tabBar = h2("div", { class: "af-tabbar" });
-    this.tabBar.setAttribute("role", "tablist");
-    this.tabBar.setAttribute("aria-label", "Session tabs");
-    this.attachTabDrag(this.tabBar);
+    const tabBar = h2("div", { class: "af-tabbar" });
+    this.tabBar = tabBar;
+    tabBar.setAttribute("role", "tablist");
+    tabBar.setAttribute("aria-label", "Session tabs");
+    this.attachTabDrag(tabBar);
     this.tabInsert = h2("div", { class: "af-tab-insert" });
     this.tabInsert.hidden = true;
     this.tabInsert.setAttribute("aria-hidden", "true");
-    this.attachTabReorder(this.tabBar);
+    this.attachTabReorder(tabBar);
+    this.attachTabRename(tabBar);
+    const head = h2("div", { class: "af-term-head" }, titleBox, tabBar, retryBtn);
     this.main.className = "af-main af-main-term";
-    this.main.replaceChildren(head, this.tabBar, this.termHost);
+    this.main.replaceChildren(head, this.termHost);
     this.renderTabBar(state);
     this.patchMainHead(state);
   }
@@ -11319,11 +11320,13 @@ var AppShell = class {
       reason.setAttribute("aria-label", `New tab unavailable \xB7 ${unavailable}`);
       children.push(reason);
     }
+    const scrollLeft = bar.scrollLeft;
     bar.replaceChildren(...children);
     if (this.tabInsert) {
       this.tabInsert.hidden = true;
       bar.append(this.tabInsert);
     }
+    bar.scrollLeft = scrollLeft;
     document.body.classList.remove("af-dragging-tab");
     this.dragFromIndex = null;
     this.lastTabBarSig = tabBarSig(state);
@@ -11357,13 +11360,55 @@ var AppShell = class {
       this.hideTabInsert();
     });
   }
+  /** Owns inline rename on the stable bar rather than on an individual button.
+   *  Activating an inactive tab rebuilds the buttons synchronously on the first
+   *  click of a double-click. Depending on geometry, Chromium may then target the
+   *  second click at the replacement button or at the gap it moved away from, and
+   *  may emit no useful dblclick at all. Capture the first click's stable identity,
+   *  then consume click #2 before its button handler can rebuild again. This makes
+   *  the intended tab — not a transient DOM node or coordinate — own the gesture. */
+  attachTabRename(bar) {
+    let firstIdentity = null;
+    bar.addEventListener(
+      "click",
+      (e) => {
+        const target = e.target instanceof Element ? e.target.closest(".af-tab") : null;
+        const button = target && bar.contains(target) ? target : null;
+        const targetIntent = button ? tabRenameIntents.get(button) : void 0;
+        if (e.detail === 1) {
+          firstIdentity = targetIntent?.identity() ?? null;
+          return;
+        }
+        if (e.detail !== 2) {
+          firstIdentity = null;
+          return;
+        }
+        const intendedIdentity = firstIdentity;
+        firstIdentity = null;
+        if (!intendedIdentity) {
+          return;
+        }
+        const current = barTabs(bar).find(
+          (candidate) => tabRenameIntents.get(candidate)?.identity() === intendedIdentity
+        );
+        const intent = current ? tabRenameIntents.get(current) : void 0;
+        if (!intent) {
+          return;
+        }
+        e.preventDefault();
+        e.stopPropagation();
+        intent.begin();
+      },
+      { capture: true }
+    );
+  }
   /**
    * Wires the tab bar as a drop TARGET, for reordering tabs within it (#1813).
    *
    * The gesture is disambiguated from drag-to-split by WHERE the drag is released,
-   * and the two regions are disjoint DOM subtrees that never overlap: the bar is a
-   * sibling of the terminal host (renderMain appends head, tabBar, termHost), and
-   * every split drop handler is bound inside a .af-pane within that host (split.ts
+   * and the two regions are disjoint DOM subtrees that never overlap: the bar sits
+   * inside the header, which is a sibling of the terminal host, and every split drop
+   * handler is bound inside a .af-pane within that host (split.ts
    * wireDrop). A drag released over the strip reorders; over a pane it splits or
    * replaces. Neither handler can see the other's event — there is no shared
    * ancestor between them below <main>, so no bubbling to suppress and no
@@ -11500,6 +11545,7 @@ function tabBarSig(state) {
 function barTabs(bar) {
   return [...bar.querySelectorAll(".af-tab")];
 }
+var tabRenameIntents = /* @__PURE__ */ new WeakMap();
 function tabCenters(bar) {
   return barTabs(bar).map((t) => {
     const r = t.getBoundingClientRect();
@@ -11519,9 +11565,11 @@ function tabButton(tab, index, active, shown, canManage, actions2, liveIdentity,
   const renameable = canManage && isRenameableTab(tab.kind);
   btn.title = renameable ? `${tabDisplayLabel(tab)} \u2014 double-click to rename` : tabDisplayLabel(tab);
   if (renameable) {
-    btn.addEventListener("dblclick", (e) => {
-      e.preventDefault();
-      beginTabRename(btn, tab, actions2, liveIdentity(), selectedSessionId);
+    tabRenameIntents.set(btn, {
+      identity: liveIdentity,
+      begin: () => {
+        beginTabRename(btn, tab, actions2, liveIdentity(), selectedSessionId);
+      }
     });
   }
   if (index > 0 && canManage) {

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "626eafba7e68";
+const VERSION = "d1d878ae42be";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -4281,6 +4281,225 @@ test("new-tab menu (#2219): stays visible, hit-testable, and anchored while the 
   await page.setViewportSize({ width: 1280, height: 720 });
 });
 
+test("#2224: title and tabs share one scrolling header row at every width", async ({ browser }, testInfo) => {
+  const mockRepo = process.env.AF_MOCK_REPO;
+  test.skip(!mockRepo, "AF_MOCK_REPO is set only by web-selftest-entry.sh");
+
+  // Eight long tabs overflow even the desktop allocation while leaving the ninth
+  // slot available, so the New-tab caret whose anchoring we verify still exists.
+  const longTabs = Array.from({ length: 8 }, (_, i) => ({
+    id: `title-row-tab-${i}`,
+    name: i === 0 ? "agent" : `distinguishing-long-tab-${i}`,
+    kind: i === 0 ? 0 : 2,
+    command: i === 0 ? undefined : `sleep ${300 + i}`,
+  }));
+  const oneTab = [longTabs[0]];
+
+  for (const width of [1280, 375]) {
+    for (const theme of ["light", "dark"] as const) {
+      for (const roster of ["one", "overflow"] as const) {
+        await test.step(`${width}px · ${theme} · ${roster}`, async () => {
+          const ctx = await browser.newContext({ viewport: { width, height: 720 } });
+          try {
+            await ctx.addInitScript(
+              ({ root, savedTheme }) => {
+                localStorage.setItem("af-project", root);
+                localStorage.setItem("af-theme", savedTheme);
+              },
+              { root: mockRepo!, savedTheme: theme },
+            );
+            const p = await ctx.newPage();
+            const title = `title-row-${roster}-${width}-${theme}-with-a-useful-distinguishing-suffix`;
+            await p.route("**/v1/Snapshot", async (route) => {
+              const resp = await route.fetch();
+              const body = await resp.json();
+              const snap = body?.data as { instances?: Array<Record<string, unknown> & { title: string }> };
+              const list = snap?.instances ?? [];
+              const proto = { ...(list.find((s) => s.title === SESSION_A) ?? {}) };
+              list.push({
+                ...proto,
+                id: `synth-${title}`,
+                title,
+                branch: `synth-${roster}-${width}-${theme}`,
+                liveness: roster === "overflow" ? 6 : 2,
+                in_flight_op: 0,
+                lifecycle_action: "archive",
+                limit_reset_at: roster === "overflow" ? "2099-01-01T00:00:00Z" : undefined,
+                tabs: roster === "overflow" ? longTabs : oneTab,
+                worktree: { ...(proto.worktree as Record<string, unknown>), repo_path: mockRepo },
+              });
+              if (snap) {
+                snap.instances = list;
+              }
+              await route.fulfill({ status: resp.status(), contentType: "application/json", body: JSON.stringify(body) });
+            });
+            // The synthetic row cannot be reordered by the real daemon. The browser
+            // assertion only needs the delegated dragover path and its marker, but a
+            // successful-shaped response keeps that gesture free of unrelated toasts.
+            await p.route("**/v1/ReorderTab", async (route) => {
+              await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ data: {} }) });
+            });
+            await p.goto("/");
+            await expect(p.locator(".af-app")).toBeVisible();
+            if (width <= 768) {
+              await p.locator(".af-nav-toggle").click();
+              await expect(p.locator(".af-app")).toHaveClass(/af-nav-open/);
+            }
+            await row(p, title).click();
+            await expect(p.locator(".af-main.af-main-term")).toBeVisible();
+
+            const head = p.locator(".af-term-head");
+            const titleBox = head.locator(":scope > .af-term-head-main");
+            const titleNode = titleBox.locator(".af-term-title");
+            const tabbar = head.locator(":scope > .af-tabbar");
+            const retry = head.getByRole("button", { name: "Retry", exact: true });
+            await expect(tabbar, "the strip belongs to the title row, not a second row").toHaveCount(1);
+            await expect(titleNode).toHaveText(title);
+            if (roster === "overflow") {
+              await expect(retry, "Retry remains reachable at the usage-limit wall").toBeVisible();
+            } else {
+              await expect(retry, "the common path spends no width on hidden actions").toBeHidden();
+            }
+
+            const layout = await p.evaluate(() => {
+              const rect = (selector: string) => {
+                const box = document.querySelector(selector)!.getBoundingClientRect();
+                return {
+                  left: box.left,
+                  right: box.right,
+                  top: box.top,
+                  bottom: box.bottom,
+                  width: box.width,
+                  height: box.height,
+                  centerY: box.top + box.height / 2,
+                };
+              };
+              const titleEl = document.querySelector<HTMLElement>(".af-term-title")!;
+              const bar = document.querySelector<HTMLElement>(".af-tabbar")!;
+              const retryEl = document.querySelector<HTMLElement>(".af-term-action:not([hidden])");
+              const titleStyle = getComputedStyle(titleEl);
+              const barStyle = getComputedStyle(bar);
+              return {
+                head: rect(".af-term-head"),
+                titleBox: rect(".af-term-head-main"),
+                title: rect(".af-term-title"),
+                bar: rect(".af-tabbar"),
+                retry: retryEl ? rect(".af-term-action:not([hidden])") : null,
+                host: rect(".af-term-host"),
+                titleClientWidth: titleEl.clientWidth,
+                titleScrollWidth: titleEl.scrollWidth,
+                titleOverflow: titleStyle.overflow,
+                titleTextOverflow: titleStyle.textOverflow,
+                titleWhiteSpace: titleStyle.whiteSpace,
+                barClientWidth: bar.clientWidth,
+                barScrollWidth: bar.scrollWidth,
+                barOverflowX: barStyle.overflowX,
+                barPosition: barStyle.position,
+                barParent: bar.parentElement?.className ?? "",
+                hostPrevious: document.querySelector(".af-term-host")?.previousElementSibling?.className ?? "",
+              };
+            });
+            expect(layout.barParent).toContain("af-term-head");
+            expect(layout.hostPrevious).toContain("af-term-head");
+            expect(layout.head.height, "one row reclaims the old stacked chrome height").toBeLessThan(64);
+            expect(Math.abs(layout.titleBox.centerY - layout.bar.centerY), "title and tabs share a baseline row").toBeLessThanOrEqual(1);
+            expect(layout.bar.top).toBeGreaterThanOrEqual(layout.head.top);
+            expect(layout.bar.bottom).toBeLessThanOrEqual(layout.head.bottom);
+            expect(layout.host.top).toBeGreaterThanOrEqual(layout.head.bottom - 1);
+            expect(layout.titleBox.width, "the title keeps a useful allocation").toBeGreaterThanOrEqual(120);
+            expect(layout.titleClientWidth, "the readable title itself never collapses to a token").toBeGreaterThanOrEqual(88);
+            expect(layout.titleScrollWidth, "the long title really needs truncation").toBeGreaterThan(layout.titleClientWidth);
+            expect({
+              overflow: layout.titleOverflow,
+              textOverflow: layout.titleTextOverflow,
+              whiteSpace: layout.titleWhiteSpace,
+            }).toEqual({ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" });
+            expect(layout.barClientWidth, "the scrolling strip keeps an operable viewport").toBeGreaterThanOrEqual(96);
+            expect(layout.barOverflowX).toBe("auto");
+            expect(layout.barPosition, "#1813 marker keeps the tab bar as its containing block").toBe("relative");
+            expect(await horizontalOverflow(p), "the combined row never widens the page").toBeLessThanOrEqual(1);
+            if (layout.retry) {
+              expect(Math.abs(layout.retry.centerY - layout.bar.centerY), "Retry stays aligned with the tab strip").toBeLessThanOrEqual(1);
+              expect(layout.retry.width, "Retry is fixed-size rather than squeezed").toBeGreaterThan(40);
+              expect(layout.retry.right).toBeLessThanOrEqual(layout.head.right);
+            }
+
+            if (roster === "one") {
+              expect(layout.barScrollWidth, "one tab fits without a vestigial second row").toBeLessThanOrEqual(
+                layout.barClientWidth + 1,
+              );
+            } else {
+              expect(layout.barScrollWidth, "the long roster genuinely overflows").toBeGreaterThan(layout.barClientWidth);
+              const trigger = tabbar.locator(".af-tab-new");
+              await trigger.click();
+              const menu = tabbar.locator(".af-tab-menu");
+              await expect(menu).toBeVisible();
+              const before = await settledHitTestableTabMenu(p, menu, trigger);
+              const scroll = await tabbar.evaluate((bar) => {
+                const before = bar.scrollLeft;
+                bar.scrollLeft = Math.max(0, before - 4);
+                return { before, after: bar.scrollLeft };
+              });
+              expect(scroll.after).toBeLessThan(scroll.before);
+              const after = await settledHitTestableTabMenu(p, menu, trigger);
+              expect(Math.abs(after.menu.x - before.menu.x - (after.trigger.x - before.trigger.x))).toBeLessThan(1);
+              await p.keyboard.press("Escape");
+              await expect(menu).toBeHidden();
+
+              // Activating a tab rebuilds every button. The stable strip must retain
+              // its viewport across that rebuild instead of snapping back to Agent —
+              // otherwise the row moves under the pointer midway through a gesture.
+              const farTab = tabByLabel(p, "distinguishing-long-tab-7");
+              await farTab.scrollIntoViewIfNeeded();
+              const beforeActivationScroll = await tabbar.evaluate((bar) => bar.scrollLeft);
+              expect(beforeActivationScroll, "the activation starts from a genuinely scrolled viewport").toBeGreaterThan(0);
+              await farTab.click();
+              await expect(tabByLabel(p, "distinguishing-long-tab-7")).toHaveClass(/af-tab-active/);
+              const afterActivationScroll = await tabbar.evaluate((bar) => bar.scrollLeft);
+              expect(
+                Math.abs(afterActivationScroll - beforeActivationScroll),
+                "activating a tab preserves the strip's horizontal viewport",
+              ).toBeLessThanOrEqual(1);
+
+              await tabbar.evaluate((bar) => {
+                bar.scrollLeft = 0;
+              });
+              const drag = await dragTabWithinBar(
+                p,
+                "distinguishing-long-tab-2",
+                "distinguishing-long-tab-1",
+                "before",
+              );
+              expect(drag.dropAllowed, "the nested strip remains a reorder target").toBe(true);
+              expect(drag.markerShown, "the nested strip still draws its insertion marker").toBe(true);
+
+              // The first click of a double-click activates an inactive tab and
+              // synchronously rebuilds every button. Rename therefore belongs to the
+              // stable bar, not to the button that may disappear halfway through the
+              // gesture. Escape avoids mutating the synthetic daemon fixture while
+              // proving the replacement button still enters edit mode.
+              const renameTarget = tabByLabel(p, "distinguishing-long-tab-2");
+              await renameTarget.dblclick();
+              const edit = tabbar.locator(".af-tab-edit");
+              await expect(edit, "an inactive tab remains renameable after activation rebuilds the bar").toBeVisible();
+              await p.keyboard.press("Escape");
+              await expect(edit).toBeHidden();
+              await expect(tabByLabel(p, "distinguishing-long-tab-2")).toHaveCount(1);
+            }
+
+            await testInfo.attach(`2224-${width}-${theme}-${roster}`, {
+              body: await p.screenshot(),
+              contentType: "image/png",
+            });
+          } finally {
+            await ctx.close();
+          }
+        });
+      }
+    }
+  }
+});
+
 test("vscode tab (#2077): the labelled New tab menu creates a VS Code tab and serves it through the proxy", async () => {
   // End to end, with no seeded fixture: pick VS Code from the tab bar's kind menu,
   // and the daemon spawns a code-server (the FAKE one on PATH — no CI box has a
@@ -4904,10 +5123,10 @@ test("#1813: a close+recreate of the same name mid-edit renames NOTHING — neve
 test("#1813: a double-click renames an INACTIVE tab, not only the active one", async () => {
   // The first click of a double-click switches tabs, which changes tabBarSig (active)
   // and so REPLACES the very button the gesture began on — a shape that has broken real
-  // gestures here before (#1737). It does not break this one: Chromium targets dblclick
-  // at the node both halves of the SECOND click hit, which is the fresh button, and
-  // tabButton binds the listener on every button it builds. So rename-by-double-click
-  // works from any tab, active or not.
+  // gestures here before (#1737). Rename is therefore owned by the stable bar: it
+  // captures the first click's tab identity, then resolves the replacement button on
+  // click two. So rename-by-double-click works from any tab, active or not, even when
+  // the replacement shifts away from the original pointer coordinate.
   //
   // Pinned because the reasoning is not local to this file — it is a property of how
   // Blink resolves a click target across a DOM swap — and because the specs above all

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1206,7 +1206,7 @@ body {
   font-size: var(--af-fs-md);
 }
 
-/* Terminal pane: a slim header (session title + connection status) over the xterm
+/* Terminal pane: one slim title + tabs + conditional-Retry header over the xterm
  * host, which fills the remaining height so the FitAddon has real dimensions. */
 .af-main-term {
   min-height: 0;
@@ -1215,7 +1215,7 @@ body {
 .af-term-head {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: 0.6rem;
   padding: var(--af-sp-2) 0.9rem;
   border-bottom: 1px solid var(--af-border);
@@ -1226,17 +1226,14 @@ body {
   display: flex;
   align-items: baseline;
   gap: 0.6rem;
-  min-width: 0;
-}
-
-.af-term-actions {
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-  flex: 0 0 auto;
+  flex: 0 1 auto;
+  min-width: 7.5rem;
+  max-width: min(18rem, 34vw);
+  overflow: hidden;
 }
 
 .af-term-action {
+  flex: 0 0 auto;
   padding: 0.3rem 0.6rem;
   font-size: var(--af-fs-xs);
 }
@@ -1254,6 +1251,8 @@ body {
 }
 
 .af-term-title {
+  flex: 1 1 auto;
+  min-width: 5.5rem;
   font-size: var(--af-fs-md);
   font-weight: 600;
   white-space: nowrap;
@@ -1262,9 +1261,13 @@ body {
 }
 
 .af-term-meta {
+  flex: 0 1 auto;
+  min-width: 0;
   font-size: var(--af-fs-xs);
   color: var(--af-text-2);
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /* Status tints on the pane header, matching the live-pip vocabulary. */
@@ -1281,18 +1284,19 @@ body {
   color: var(--af-dot-dead);
 }
 
-/* Tab bar (#1592 Phase 5 PR7): a slim strip of the session's tabs between the pane
- * header and the terminal, mirroring the TUI's tab row (ui/tabbed_window.go). The
- * active tab is accent-underlined; each non-agent tab carries a × close, and the
- * labelled New tab control offers Terminal / VS Code. It scrolls horizontally
- * rather than wrapping so a full row of tabs never pushes the terminal down. */
+/* Tab bar (#1592 Phase 5 PR7, #2224): the flexible middle of the pane's single
+ * header row, mirroring the TUI's tab row (ui/tabbed_window.go). The title keeps a
+ * useful minimum, Retry never shrinks, and this bar consumes the remainder and
+ * scrolls horizontally rather than wrapping or pushing the terminal down. */
 .af-tabbar {
   display: flex;
   align-items: stretch;
+  flex: 1 1 0;
+  min-width: 6rem;
   gap: 0.15rem;
-  padding: 0 0.6rem;
-  background: var(--af-bg-surface);
-  border-bottom: 1px solid var(--af-border);
+  padding: 0;
+  background: transparent;
+  border: 0;
   overflow-x: auto;
   scrollbar-width: thin;
   /* The containing block for the reorder insertion indicator (#1813), which is

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -1603,32 +1603,40 @@ export class AppShell {
     this.retryVisible = isLimitReached(selected);
     retryBtn.hidden = !this.retryVisible;
 
-    const actions = h("div", { class: "af-term-actions" }, retryBtn);
-
-    const head = h("div", { class: "af-term-head" }, titleBox, actions);
-
-    // The tab bar sits between the header and the terminal, mirroring the TUI's
-    // tab row (ui/tabbed_window.go): one button per tab, the active one highlighted,
-    // a × on closable (non-agent) tabs, and a + to add a shell tab.
-    this.tabBar = h("div", { class: "af-tabbar" });
-    this.tabBar.setAttribute("role", "tablist");
-    this.tabBar.setAttribute("aria-label", "Session tabs");
+    // The tab bar is the flexible middle of the single pane-header row (#2224):
+    // title first, the same horizontally scrolling bar, then the fixed Retry escape
+    // when a limit wall makes it visible. Keeping the real bar node here (rather
+    // than projecting a second mobile/desktop copy) preserves one drag/drop and
+    // popover-anchoring path at every width.
+    const tabBar = h("div", { class: "af-tabbar" });
+    this.tabBar = tabBar;
+    tabBar.setAttribute("role", "tablist");
+    tabBar.setAttribute("aria-label", "Session tabs");
     // The drag source is wired ONCE here on the (stable) bar container via delegation,
     // not per button — so EVERY tab, including one created after load, is a drag source
     // by construction, with no per-button binding to forget on a re-render (#1737).
-    this.attachTabDrag(this.tabBar);
+    this.attachTabDrag(tabBar);
     // ...and the bar is also a drop TARGET, for reordering (#1813). Same delegation,
     // same reason. See attachTabReorder for how this stays unambiguous against the
     // drag-to-split drop the panes wire.
     this.tabInsert = h("div", { class: "af-tab-insert" });
     this.tabInsert.hidden = true;
     this.tabInsert.setAttribute("aria-hidden", "true");
-    this.attachTabReorder(this.tabBar);
+    this.attachTabReorder(tabBar);
+    // Rename is delegated from the same stable container. The first click of a
+    // double-click can activate an inactive tab and synchronously replace every
+    // button; a listener owned by the old button cannot receive the final dblclick.
+    this.attachTabRename(tabBar);
+
+    // Retry is the only pane-level action. Append it directly instead of keeping a
+    // wrapper box: hidden controls create no flex item and therefore no phantom gap
+    // on the common path, while the visible button cannot shrink behind the tabs.
+    const head = h("div", { class: "af-term-head" }, titleBox, tabBar, retryBtn);
 
     this.main.className = "af-main af-main-term";
     // The persistent terminal host is (re)mounted here; renderMain runs only on a
     // selection change, so this reparent is rare and never happens mid-type.
-    this.main.replaceChildren(head, this.tabBar, this.termHost);
+    this.main.replaceChildren(head, this.termHost);
     this.renderTabBar(state);
     this.patchMainHead(state);
   }
@@ -1699,6 +1707,10 @@ export class AppShell {
       reason.setAttribute("aria-label", `New tab unavailable · ${unavailable}`);
       children.push(reason);
     }
+    // Replacing every child resets a horizontally scrolled bar to its left edge.
+    // Preserve the stable container's viewport so activating an off-screen tab does
+    // not snap the row — or move a different tab under the second half of a gesture.
+    const scrollLeft = bar.scrollLeft;
     bar.replaceChildren(...children);
     // The insertion indicator is absolutely positioned and sits outside the tab flow,
     // so it simply rides along as a last child — but replaceChildren above just
@@ -1708,6 +1720,7 @@ export class AppShell {
       this.tabInsert.hidden = true;
       bar.append(this.tabInsert);
     }
+    bar.scrollLeft = scrollLeft;
     // Rebuilding the bar detaches EVERY tab button — including the source of an
     // in-flight drag. A native dragend can't fire on a detached node, so the delegated
     // dragend (on the bar) would never run and the drag flag would stick, leaving the UI
@@ -1758,13 +1771,68 @@ export class AppShell {
     });
   }
 
+  /** Owns inline rename on the stable bar rather than on an individual button.
+   *  Activating an inactive tab rebuilds the buttons synchronously on the first
+   *  click of a double-click. Depending on geometry, Chromium may then target the
+   *  second click at the replacement button or at the gap it moved away from, and
+   *  may emit no useful dblclick at all. Capture the first click's stable identity,
+   *  then consume click #2 before its button handler can rebuild again. This makes
+   *  the intended tab — not a transient DOM node or coordinate — own the gesture. */
+  private attachTabRename(bar: HTMLElement): void {
+    let firstIdentity: string | null = null;
+    bar.addEventListener(
+      "click",
+      (e) => {
+        const target = e.target instanceof Element ? e.target.closest<HTMLElement>(".af-tab") : null;
+        const button = target && bar.contains(target) ? target : null;
+        const targetIntent = button ? tabRenameIntents.get(button) : undefined;
+
+        if (e.detail === 1) {
+          firstIdentity = targetIntent?.identity() ?? null;
+          return;
+        }
+        if (e.detail !== 2) {
+          firstIdentity = null;
+          return;
+        }
+
+        const intendedIdentity = firstIdentity;
+        firstIdentity = null;
+        if (!intendedIdentity) {
+          return;
+        }
+
+        // `detail === 2` is the browser's declaration that this is one multi-click
+        // gesture. Its DOM target is not authoritative: rebuilding an overflowed bar
+        // can reset scroll between the two clicks, putting an entirely different tab
+        // under the unchanged pointer. Resolve the CURRENT button from the FIRST
+        // click's identity, so the visual jump cannot turn rename into a second tab
+        // selection or rename the neighbour that happened to move underneath it.
+        const current = barTabs(bar).find(
+          (candidate) => tabRenameIntents.get(candidate)?.identity() === intendedIdentity,
+        );
+        const intent = current ? tabRenameIntents.get(current) : undefined;
+        if (!intent) {
+          return;
+        }
+
+        // The first click already selected the tab. Stop the second click before its
+        // ordinary openTab handler can replace the button whose edit is opening.
+        e.preventDefault();
+        e.stopPropagation();
+        intent.begin();
+      },
+      { capture: true },
+    );
+  }
+
   /**
    * Wires the tab bar as a drop TARGET, for reordering tabs within it (#1813).
    *
    * The gesture is disambiguated from drag-to-split by WHERE the drag is released,
-   * and the two regions are disjoint DOM subtrees that never overlap: the bar is a
-   * sibling of the terminal host (renderMain appends head, tabBar, termHost), and
-   * every split drop handler is bound inside a .af-pane within that host (split.ts
+   * and the two regions are disjoint DOM subtrees that never overlap: the bar sits
+   * inside the header, which is a sibling of the terminal host, and every split drop
+   * handler is bound inside a .af-pane within that host (split.ts
    * wireDrop). A drag released over the strip reorders; over a pane it splits or
    * replaces. Neither handler can see the other's event — there is no shared
    * ancestor between them below <main>, so no bubbling to suppress and no
@@ -1977,6 +2045,12 @@ function barTabs(bar: HTMLElement): HTMLElement[] {
   return [...bar.querySelectorAll<HTMLElement>(".af-tab")];
 }
 
+/** The rename intent captured by each currently rendered tab button. The stable bar
+ *  carries a double-click across a button replacement by matching these identities;
+ *  WeakMap ownership means detached buttons and their stale captures disappear
+ *  together. */
+const tabRenameIntents = new WeakMap<HTMLElement, { identity: () => string; begin: () => void }>();
+
 /** Each tab's horizontal centre, in viewport px — the geometry the pure insertion
  *  math takes (tabreorder.ts). Measured rather than derived: tab widths vary with
  *  their labels, and a bar can scroll. */
@@ -2041,12 +2115,14 @@ function tabButton(
   const renameable = canManage && isRenameableTab(tab.kind);
   btn.title = renameable ? `${tabDisplayLabel(tab)} — double-click to rename` : tabDisplayLabel(tab);
   if (renameable) {
-    btn.addEventListener("dblclick", (e) => {
-      e.preventDefault();
-      // Resolved HERE, as the edit OPENS — the identity is captured, never a getter
-      // the commit could re-read against a roster the user never saw. See
-      // beginTabRename. The session id is captured with it, for the same reason.
-      beginTabRename(btn, tab, actions, liveIdentity(), selectedSessionId);
+    tabRenameIntents.set(btn, {
+      identity: liveIdentity,
+      begin: () => {
+        // Resolved HERE, as the edit OPENS — the identity is captured, never a getter
+        // the commit could re-read against a roster the user never saw. See
+        // beginTabRename. The session id is captured with it, for the same reason.
+        beginTabRename(btn, tab, actions, liveIdentity(), selectedSessionId);
+      },
     });
   }
   // The agent tab (index 0) is unclosable — killing the session tears it down.


### PR DESCRIPTION
## Outcome

- render the session title, horizontally scrolling tab strip, and conditional Retry escape in one pane-header row at every width
- encode the scarce-width priority as fixed Retry, useful ellipsized title, then a flexible scrolling tab viewport
- retain both overflow-x: auto for long rosters and position: relative for the drag insertion marker
- preserve horizontal scroll across tab-button rebuilds and carry double-click rename by stable tab identity, so a re-render cannot redirect the second click
- update the web layout documentation and regenerate the committed bundle

## Evidence

The new browser matrix failed first on master because the tab strip had no direct pane-header parent. It now covers 1280 px and 375 px, light and dark, one tab and an overflowing roster. It asserts title truncation, usable tab width, fixed Retry reachability, real horizontal scrolling, fixed-popover anchoring, drag insertion, scroll retention, and inactive-tab rename.

Visual inspection covered the same desktop/mobile and light/dark matrix, including the open new-tab menu and visible insertion marker.

The complete post-push gate set is running against ed8e9e45; exact results will be posted before merge.

Closes #2224

— Captain Claude