### PR TITLE
fix(tmux): require payload-specific delivery evidence

### DIFF
--- a/session/tmux/capture_wedge_test.go
+++ b/session/tmux/capture_wedge_test.go
@@ -238,7 +238,7 @@ func TestPasteDeliveryLoopHonorsItsOwnBudget(t *testing.T) {
 	done := make(chan time.Duration, 1)
 	go func() {
 		start := time.Now()
-		ts.waitForPasteDelivered("a-distinctive-tail", 0)
+		ts.waitForPasteDelivered(newDeliveryProbe("a-distinctive-tail"))
 		done <- time.Since(start)
 	}()
 
@@ -255,30 +255,6 @@ func TestPasteDeliveryLoopHonorsItsOwnBudget(t *testing.T) {
 	case <-time.After(30 * time.Second):
 		t.Fatal("waitForPasteDelivered hung against a stalled tmux (#2099): the capture inside " +
 			"its poll loop is unbounded, so the loop's deadline check never runs")
-	}
-}
-
-// TestPaneTailForLogDoesNotHangOnWedgedServer covers capturePaneForDelivery's
-// OTHER caller. paneTailForLog runs outside the poll loop and has no deadline of
-// its own, so a per-loop budget alone would leave it unbounded — it needs the
-// package's standard bound. It runs on the delivery-not-observed logging path,
-// i.e. precisely when the pane is already misbehaving.
-func TestPaneTailForLogDoesNotHangOnWedgedServer(t *testing.T) {
-	stallingTmuxOnPath(t)
-	shortTmuxTimeout(t, 200*time.Millisecond)
-	ts := NewTmuxSessionWithDeps("wedge-2099-tail", "sh", MakePtyFactory(), cmd.MakeExecutor())
-
-	done := make(chan string, 1)
-	go func() { done <- paneTailForLog(ts) }()
-
-	select {
-	case got := <-done:
-		if got != "<pane not capturable>" {
-			t.Fatalf("a wedged server must report the pane as not capturable, got %q", got)
-		}
-	case <-time.After(30 * time.Second):
-		t.Fatal("paneTailForLog hung against a stalled tmux (#2099): it calls " +
-			"capturePaneForDelivery outside the poll loop, with no deadline of its own")
 	}
 }
 

--- a/session/tmux/program.go
+++ b/session/tmux/program.go
@@ -4,8 +4,8 @@ package tmux
 //
 // program is the command the pane runs (override-resolved, flag-injected). It
 // is not immutable: Restore() rewrites it (resume-flag injection, #595) on the
-// restore goroutine while the status-poll and prompt-delivery goroutines read
-// it (readiness heuristics, submit routing). Every access therefore goes
+// restore goroutine while startup, status, and PTY-I/O paths read it for agent
+// detection and diagnostics. Every access therefore goes
 // through these helpers under programMu — the codex submit path reading program
 // is what first exposed this data race under `go test -race` (#1254).
 
@@ -29,31 +29,9 @@ func (t *TmuxSession) programCmd() string {
 	return t.program
 }
 
-// preSubmitEchoBehavior returns the cached behavior for the resolved program.
-// Agent detection happens when the program is set, not on every delivery.
-func (t *TmuxSession) preSubmitEchoBehavior() preSubmitEchoBehavior {
-	t.programMu.RLock()
-	defer t.programMu.RUnlock()
-	return t.preSubmitEcho
-}
-
-// notePreSubmitEchoObserved promotes an UNKNOWN capability only on positive
-// evidence. A known non-echoing agent stays non-echoing even if unrelated pane
-// output happens to contain the same short tail (#2214 review). A missing tail
-// can never demote it: absence is precisely the ambiguous signal #2213 forbids
-// us from treating as detection.
-func (t *TmuxSession) notePreSubmitEchoObserved() {
-	t.programMu.Lock()
-	defer t.programMu.Unlock()
-	if t.preSubmitEcho == preSubmitEchoUnknown {
-		t.preSubmitEcho = preSubmitEchoes
-	}
-}
-
 // setProgramCmd stores the pane's program command string under programMu.
 func (t *TmuxSession) setProgramCmd(program string) {
 	t.programMu.Lock()
 	defer t.programMu.Unlock()
 	t.program = program
-	t.preSubmitEcho = knownPreSubmitEchoBehavior(program)
 }

--- a/session/tmux/session.go
+++ b/session/tmux/session.go
@@ -53,9 +53,8 @@ type TmuxSession struct {
 	// program is the command the pane runs. It is mutated by Restore() while
 	// other goroutines read it, so all access goes through the programMu-guarded
 	// accessors in program.go (#1254) — never touch these fields directly.
-	program       string
-	preSubmitEcho preSubmitEchoBehavior
-	programMu     sync.RWMutex
+	program   string
+	programMu sync.RWMutex
 	// submitMu serializes the whole clear → paste → Enter transaction. A second
 	// submit must never clear the first submit's freshly pasted composer while
 	// that first call is still waiting to send Enter (#2178 review).
@@ -192,7 +191,6 @@ func newTmuxSession(sanitizedName string, program string, ptyFactory PtyFactory,
 	return &TmuxSession{
 		sanitizedName: sanitizedName,
 		program:       program,
-		preSubmitEcho: knownPreSubmitEchoBehavior(program),
 		ptyFactory:    ptyFactory,
 		cmdExec:       cmdExec,
 	}

--- a/session/tmux/submit.go
+++ b/session/tmux/submit.go
@@ -36,54 +36,46 @@ var (
 const minDistinctiveTail = 8
 
 // deliveryOutcome is deliberately THREE-valued. "The pane did not show the
-// prompt" is an observed absence only when that agent is known to render pasted
-// input before Enter. A non-echoing pane and a failed capture both mean the
-// delivery could not be observed; neither may manufacture a negative.
+// prompt" is an observed absence only when the terminal capture proves THIS
+// payload began rendering but its completion tail did not. A collapsed paste,
+// a composer frame, and a failed capture all mean delivery could not be
+// observed; agent-wide rendering habits may never manufacture a negative.
 type deliveryOutcome int
 
 const (
 	// deliveryObservedLanded: the pasted text was observed to arrive.
 	deliveryObservedLanded deliveryOutcome = iota
-	// deliveryObservedAbsent: the pane is known to echo pasted input, capture
-	// succeeded at the deadline, and the text was not there. This is the genuine
-	// #1982 signal and must stay loud.
+	// deliveryObservedAbsent: capture succeeded at the deadline, a new prefix
+	// from this exact prompt was rendered, and its completion tail was not. This
+	// is the genuine #1982 signal and must stay loud.
 	deliveryObservedAbsent
-	// deliveryCouldNotObserve: the pane does not echo (or its behavior is not
-	// known), capture failed, or the prompt had no distinctive text. Nothing may
-	// be concluded about delivery.
+	// deliveryCouldNotObserve: capture failed, the prompt had no distinctive
+	// text, or the pane never rendered prompt-specific evidence. Nothing may be
+	// concluded about delivery.
 	deliveryCouldNotObserve
 )
 
-// preSubmitEchoBehavior records whether the agent renders pasted input before
-// Enter. It is cached with TmuxSession.program and reused for every delivery.
-type preSubmitEchoBehavior int
+// deliveryObservation keeps the classification and the exact terminal pane
+// frame together. An observed-absent diagnostic must print the same evidence
+// that authorized the decision, not recapture after Enter and describe a newer,
+// unrelated frame (#2255/#2266).
+type deliveryObservation struct {
+	outcome deliveryOutcome
+	pane    string
+}
 
-const (
-	preSubmitEchoUnknown preSubmitEchoBehavior = iota
-	preSubmitEchoes
-	preSubmitDoesNotEcho
-)
-
-// knownPreSubmitEchoBehavior returns only behavior established by real-agent
-// evidence. There is no sound generic runtime probe for the negative case:
-// terminal ECHO says nothing about a full-screen app that draws its own input,
-// while failing to see a test paste is the exact ambiguity this code must not
-// collapse. Sending a sentinel would also mutate the live composer. Therefore
-// unknown agents stay unknown instead of being guessed; any positively observed
-// delivery promotes that session to preSubmitEchoes.
-func knownPreSubmitEchoBehavior(command string) preSubmitEchoBehavior {
-	switch DetectAgentFromCommand(command) {
-	case ProgramClaude, ProgramAider:
-		// Claude visibly renders pasted composer input; #1982's positive-tail
-		// delivery guard depends on this behavior. Aider does too (#2214 review).
-		return preSubmitEchoes
-	case ProgramCodex:
-		// Codex consumes successful pastes without rendering them before Enter
-		// (#2213: 228 unobserved but successful deliveries in one day).
-		return preSubmitDoesNotEcho
-	default:
-		return preSubmitEchoUnknown
-	}
+// deliveryProbe binds every observation to one payload. completion is the
+// suffix whose appearance proves the whole paste drained; renderWitness is a
+// disjoint prefix whose appearance proves the pane DID render this payload and
+// can therefore support a terminal negative when completion is still absent.
+// Baselines prefer the capture after the pre-submit clear (and conservatively
+// fall back to the pre-clear frame if that capture fails), so old prompt text
+// in scrollback cannot be mistaken for evidence from this paste.
+type deliveryProbe struct {
+	completion            string
+	completionBaseline    int
+	renderWitness         string
+	renderWitnessBaseline int
 }
 
 // pasteBufferSeq makes each bracketed-paste buffer name unique per call so two
@@ -160,7 +152,7 @@ func (t *TmuxSession) sendKeysPasteBuffer(text string) error {
 	// after pasting so buffers never accumulate.
 	buf := pasteBufferName(pasteBufferProcessToken, t.sanitizedName, pasteBufferSeq.Add(1))
 
-	tail := deliveryTail(text)
+	probe := newDeliveryProbe(text)
 
 	// Load the payload BEFORE touching the live composer. A load failure means
 	// there is nothing we can deliver, so clearing first would destroy a user's
@@ -212,17 +204,14 @@ func (t *TmuxSession) sendKeysPasteBuffer(text string) error {
 	// post-clear is also what lets a re-delivery whose prior attempt stranded an
 	// identical tail still confirm — the clear removed that copy, so the tail
 	// genuinely re-appears.
-	baseline := 0
-	if tail != "" {
-		switch {
-		case afterOK:
-			baseline = strings.Count(normalizeDelivery(after), tail)
-		case beforeOK:
-			// A failed post-clear capture must not erase the usable pre-clear
-			// baseline. Reusing it is conservative: content the clear removed can
-			// only make confirmation harder, never create a false success.
-			baseline = strings.Count(normalizeDelivery(before), tail)
-		}
+	switch {
+	case afterOK:
+		probe = probe.withBaseline(after)
+	case beforeOK:
+		// A failed post-clear capture must not erase the usable pre-clear
+		// baseline. Reusing it is conservative: content the clear removed can
+		// only make confirmation harder, never create a false success.
+		probe = probe.withBaseline(before)
 	}
 
 	// `-d` deletes the buffer after pasting, `-p` brackets it (see the doc
@@ -265,21 +254,22 @@ func (t *TmuxSession) sendKeysPasteBuffer(text string) error {
 	// (usually well under the old 500ms) and, on the rare pane where capture
 	// cannot confirm it, falls back to sending Enter after the cap so delivery is
 	// never worse than the old blind sleep.
-	delivered := t.waitForPasteDelivered(tail, baseline)
+	observation := t.waitForPasteDelivered(probe)
 
 	// Send Enter separately to submit.
 	if err := t.sendEnter(); err != nil {
 		return err
 	}
 
-	if delivered == deliveryObservedAbsent {
+	if observation.outcome == deliveryObservedAbsent {
 		// This is deliberately the only ERROR emitted by delivery observation:
-		// unlike could-not-observe, a known echoing pane was successfully read and
-		// the prompt was absent. Keep the best-effort Enter, but make this signal
-		// actionable and unhedged so a genuine #1982 truncation is not buried.
-		log.ErrorLog.Printf("submit: prompt delivery observed absent for session %q after %s in a pane known to echo input; "+
+		// unlike could-not-observe, the final capture contains a new prefix from
+		// this prompt but not its completion tail. Keep the best-effort Enter, but
+		// make this signal actionable and unhedged so genuine #1982 truncation is
+		// not buried. The pane tail is load-bearing diagnostic evidence (#2266).
+		log.ErrorLog.Printf("submit: prompt delivery observed absent for session %q after %s; the pane rendered this prompt's prefix but not its completion tail; "+
 			"Enter sent best-effort. Pane tail: %s",
-			t.sanitizedName, pasteDeliveryMaxWait, paneTailForLog(t))
+			t.sanitizedName, pasteDeliveryMaxWait, oneLineTail(observation.pane))
 	}
 	return nil
 }
@@ -382,19 +372,48 @@ func noteClearedDraft(sessionName, before, after string) {
 		"Prior pane tail: %s", sessionName, oneLineTail(before))
 }
 
-// deliveryTail returns a distinctive whitespace/box-free suffix of text used to
-// confirm the WHOLE paste landed before submitting: a racing Enter drops the
-// TAIL, so the tail is exactly what must be visible. Whitespace and box-drawing
-// glyphs are removed so an agent composer that wraps the prompt inside its
-// border box (claude/aider render one) still reads back as one contiguous run.
-// A short tail keeps it within a single composer line so a wrap can't split it.
-func deliveryTail(text string) string {
+// newDeliveryProbe derives two disjoint, payload-specific witnesses. The suffix
+// confirms the WHOLE paste landed before submitting: a racing Enter drops the
+// tail, so the tail is exactly what must be visible. A disjoint prefix can prove
+// that this same payload began rendering even when the tail never arrived — the
+// high-signal #1982 truncation case.
+//
+// Short prompts have no disjoint pair and therefore cannot produce a terminal
+// negative. That is intentional: seeing none of a short prompt does not prove
+// the pane chose to render it. Positive delivery can still be confirmed by the
+// complete prompt, with the existing two-capture rule for weak short strings.
+func newDeliveryProbe(text string) deliveryProbe {
 	n := []rune(normalizeDelivery(text))
-	const tailRunes = 32
-	if len(n) > tailRunes {
-		n = n[len(n)-tailRunes:]
+	const (
+		completionRunes = 32
+		witnessRunes    = 24
+	)
+	if len(n) == 0 {
+		return deliveryProbe{}
 	}
-	return string(n)
+
+	completion := n
+	if len(completion) > completionRunes {
+		completion = completion[len(completion)-completionRunes:]
+	}
+	probe := deliveryProbe{completion: string(completion)}
+	if len(n) >= completionRunes+witnessRunes {
+		probe.renderWitness = string(n[:witnessRunes])
+	}
+	return probe
+}
+
+// withBaseline records how many copies of each witness were already visible
+// before this paste. A later observation is evidence only when its count grows.
+func (p deliveryProbe) withBaseline(content string) deliveryProbe {
+	normalized := normalizeDelivery(content)
+	if p.completion != "" {
+		p.completionBaseline = strings.Count(normalized, p.completion)
+	}
+	if p.renderWitness != "" {
+		p.renderWitnessBaseline = strings.Count(normalized, p.renderWitness)
+	}
+	return p
 }
 
 // normalizeDelivery strips whitespace and box-drawing / block-element glyphs so
@@ -466,92 +485,86 @@ func (t *TmuxSession) capturePaneForDeliveryContext(ctx context.Context) (string
 	return string(out), true
 }
 
-// waitForPasteDelivered blocks until the pasted prompt's tail newly appears in
-// the pane (count exceeds the pre-paste baseline), or pasteDeliveryMaxWait
-// elapses. Its result distinguishes a genuine absence in a known echoing pane
-// from an inability to observe delivery. The caller always sends Enter afterward,
-// so delivery is never worse than the fixed sleep this replaced (#1982).
-func (t *TmuxSession) waitForPasteDelivered(
-	tail string,
-	baseline int,
-) deliveryOutcome {
-	if tail == "" {
+// waitForPasteDelivered blocks until this payload's completion tail newly
+// appears in the pane, or pasteDeliveryMaxWait elapses. A terminal negative
+// requires a new, disjoint render witness from THIS payload in the final
+// successful capture. Agent identity, earlier frames, generic composer chrome,
+// and collapsed-paste placeholders cannot grant that authority (#2266).
+//
+// The caller always sends Enter afterward, so delivery is never worse than the
+// fixed sleep this replaced (#1982).
+func (t *TmuxSession) waitForPasteDelivered(probe deliveryProbe) deliveryObservation {
+	if probe.completion == "" {
 		// Nothing distinctive to confirm (empty/all-whitespace prompt). There is
 		// no positive check to make, so keep the ORIGINAL 500ms drain rather than
 		// quietly shortening it.
 		time.Sleep(emptyPromptDrain)
-		return deliveryCouldNotObserve
+		return deliveryObservation{outcome: deliveryCouldNotObserve}
 	}
 	deadline := time.Now().Add(pasteDeliveryMaxWait)
 	streak := 0
 	// A short tail is weak evidence, so require two consecutive sightings before
 	// trusting it (see minDistinctiveTail).
 	needed := 1
-	if len([]rune(tail)) < minDistinctiveTail {
+	if len([]rune(probe.completion)) < minDistinctiveTail {
 		needed = 2
 	}
-	lastObservation := deliveryCouldNotObserve
-	deadlineOutcome := func() deliveryOutcome {
-		if lastObservation == deliveryObservedAbsent && t.preSubmitEchoBehavior() == preSubmitEchoes {
-			return deliveryObservedAbsent
-		}
-		return deliveryCouldNotObserve
-	}
+	lastObservation := deliveryObservation{outcome: deliveryCouldNotObserve}
 	for {
 		// If the prior capture succeeded and the following poll interval carried
 		// us across the deadline, that prior read is the terminal observation. Do
 		// not launch an already-expired capture just to turn success into unknown.
 		if time.Until(deadline) <= 0 {
-			return deadlineOutcome()
+			return lastObservation
 		}
 
 		// Bound each capture by what is LEFT of this loop's budget, so a wedged
 		// server cannot push a single capture past the deadline below (#2099).
 		if content, ok := t.capturePaneForDeliveryWithin(time.Until(deadline)); ok {
-			if strings.Count(normalizeDelivery(content), tail) > baseline {
+			normalized := normalizeDelivery(content)
+			if strings.Count(normalized, probe.completion) > probe.completionBaseline {
 				streak++
 				if streak >= needed {
-					t.notePreSubmitEchoObserved()
-					return deliveryObservedLanded
+					return deliveryObservation{outcome: deliveryObservedLanded, pane: content}
 				}
 				// One weak short-tail sighting is neither confirmed delivery nor
 				// absence. A later failure must not combine with it.
-				lastObservation = deliveryCouldNotObserve
-			} else {
+				lastObservation = deliveryObservation{outcome: deliveryCouldNotObserve, pane: content}
+			} else if probe.renderWitness != "" &&
+				strings.Count(normalized, probe.renderWitness) > probe.renderWitnessBaseline {
 				streak = 0
-				lastObservation = deliveryObservedAbsent
+				lastObservation = deliveryObservation{outcome: deliveryObservedAbsent, pane: content}
+			} else {
+				// A successful capture is not automatically a negative. Unless it
+				// newly renders this prompt's prefix, it says only that the pane was
+				// readable — a collapsed placeholder and an empty composer are both
+				// deliberate examples of could-not-observe (#2266).
+				streak = 0
+				lastObservation = deliveryObservation{outcome: deliveryCouldNotObserve, pane: content}
 			}
 		} else {
 			// Observation continuity is load-bearing. The paste can land after an
 			// earlier absent frame, and a failed frame can separate two coincidental
 			// short-tail sightings, so unreadability invalidates both signals.
 			streak = 0
-			lastObservation = deliveryCouldNotObserve
+			lastObservation = deliveryObservation{outcome: deliveryCouldNotObserve}
 		}
 		if time.Now().After(deadline) {
-			// Only a terminal successful absence in a known echoing pane supports a
-			// negative. Earlier absence followed by unreadability is unknown: the
-			// paste may have drained after that frame.
-			return deadlineOutcome()
+			// Only a terminal successful capture with this prompt's new render
+			// witness supports a negative. Earlier evidence followed by an
+			// unbound or unreadable frame is unknown: the pane may have elided or
+			// drained the paste after that frame.
+			return lastObservation
 		}
 		time.Sleep(pasteDeliveryPollInterval)
 	}
 }
 
-// paneTailForLog returns a short, single-line excerpt of the pane so a failure
-// says what the pane actually looked like instead of only that something failed.
-func paneTailForLog(t *TmuxSession) string {
-	content, ok := t.capturePaneForDelivery()
-	if !ok {
-		return "<pane not capturable>"
-	}
-	return oneLineTail(content)
-}
-
 // oneLineTail condenses pane content to a short, single-line excerpt for a log
 // line: the last few non-blank rows, whitespace collapsed, row breaks marked
-// with ⏎, and truncated. Shared by paneTailForLog and noteClearedDraft so a
-// discarded-draft record and a delivery-failure record read the same.
+// with ⏎, and truncated. Shared by the terminal delivery observation and
+// noteClearedDraft so a discarded-draft record and a delivery-failure record
+// read the same.
 func oneLineTail(content string) string {
 	lines := strings.Split(strings.TrimRight(content, "\n \t"), "\n")
 	keep := lines

--- a/session/tmux/submit.go
+++ b/session/tmux/submit.go
@@ -27,13 +27,14 @@ var (
 	emptyPromptDrain = 500 * time.Millisecond
 )
 
-// minDistinctiveTail is the shortest tail treated as self-evidently distinctive.
-// A very short prompt ("ok", "y") yields a tail that unrelated pane churn could
-// plausibly emit, so a single sighting is weak evidence. Below this length the
-// delivery check additionally requires the tail to be seen in TWO consecutive
-// captures, so a one-frame coincidence cannot confirm delivery early and let
-// Enter race the paste after all.
-const minDistinctiveTail = 8
+// minDistinctiveFragment is the shortest payload fragment treated as
+// self-evidently prompt-specific. A very short prompt ("ok", "y") yields text
+// that unrelated pane churn could plausibly emit, so a single completion
+// sighting is weak evidence and cannot serve as a render witness. Below this
+// length the delivery check additionally requires the completion to be seen in
+// TWO consecutive captures, so a one-frame coincidence cannot confirm delivery
+// early and let Enter race the paste after all.
+const minDistinctiveFragment = 8
 
 // deliveryOutcome is deliberately THREE-valued. "The pane did not show the
 // prompt" is an observed absence only when the terminal capture proves THIS
@@ -381,10 +382,13 @@ func noteClearedDraft(sessionName, before, after string) {
 // that this same payload began rendering even when the tail never arrived — the
 // high-signal #1982 truncation case.
 //
-// Short prompts have no disjoint pair and therefore cannot produce a terminal
-// negative. That is intentional: seeing none of a short prompt does not prove
-// the pane chose to render it. Positive delivery can still be confirmed by the
-// complete prompt, with the existing two-capture rule for weak short strings.
+// Prefer a 32-rune completion and a 24-rune prefix. For prompts longer than the
+// completion but shorter than the preferred pair, shorten the completion only
+// enough to reserve a distinctive prefix: otherwise a 33–55-rune payload could
+// visibly render prompt-specific text yet lose #1982's terminal negative merely
+// because the preferred pair does not fit. Prompts of 32 runes or fewer keep
+// their entire text as the completion and therefore cannot produce a terminal
+// negative. The existing two-capture rule still protects weak short strings.
 func newDeliveryProbe(text string) deliveryProbe {
 	n := []rune(normalizeDelivery(text))
 	const (
@@ -395,13 +399,23 @@ func newDeliveryProbe(text string) deliveryProbe {
 		return deliveryProbe{}
 	}
 
-	completion := n
-	if len(completion) > completionRunes {
-		completion = completion[len(completion)-completionRunes:]
+	completionLen := len(n)
+	availablePrefix := 0
+	if len(n) > completionRunes {
+		completionLen = completionRunes
+		availablePrefix = len(n) - completionLen
+		if availablePrefix < minDistinctiveFragment {
+			completionLen = len(n) - minDistinctiveFragment
+			availablePrefix = minDistinctiveFragment
+		}
 	}
-	probe := deliveryProbe{completion: string(completion)}
-	if len(n) >= completionRunes+witnessRunes {
-		probe.renderWitness = string(n[:witnessRunes])
+
+	probe := deliveryProbe{completion: string(n[len(n)-completionLen:])}
+	if availablePrefix >= minDistinctiveFragment {
+		if availablePrefix > witnessRunes {
+			availablePrefix = witnessRunes
+		}
+		probe.renderWitness = string(n[:availablePrefix])
 	}
 	return probe
 }
@@ -509,9 +523,9 @@ func (t *TmuxSession) waitForPasteDelivered(probe deliveryProbe) deliveryObserva
 	deadline := time.Now().Add(pasteDeliveryMaxWait)
 	streak := 0
 	// A short tail is weak evidence, so require two consecutive sightings before
-	// trusting it (see minDistinctiveTail).
+	// trusting it (see minDistinctiveFragment).
 	needed := 1
-	if len([]rune(probe.completion)) < minDistinctiveTail {
+	if len([]rune(probe.completion)) < minDistinctiveFragment {
 		needed = 2
 	}
 	lastObservation := deliveryObservation{outcome: deliveryCouldNotObserve}

--- a/session/tmux/submit.go
+++ b/session/tmux/submit.go
@@ -70,8 +70,11 @@ type deliveryObservation struct {
 // can therefore support a terminal negative when completion is still absent.
 // Baselines prefer the capture after the pre-submit clear (and conservatively
 // fall back to the pre-clear frame if that capture fails), so old prompt text
-// in scrollback cannot be mistaken for evidence from this paste.
+// in scrollback cannot be mistaken for evidence from this paste. If neither
+// capture succeeds, baselineCaptured stays false and no count comparison may
+// claim either positive delivery or terminal absence.
 type deliveryProbe struct {
+	baselineCaptured      bool
 	completion            string
 	completionBaseline    int
 	renderWitness         string
@@ -403,10 +406,12 @@ func newDeliveryProbe(text string) deliveryProbe {
 	return probe
 }
 
-// withBaseline records how many copies of each witness were already visible
-// before this paste. A later observation is evidence only when its count grows.
+// withBaseline records that the pane was actually measured and how many copies
+// of each witness were already visible before this paste. A later observation
+// is evidence only when its count grows from this captured baseline.
 func (p deliveryProbe) withBaseline(content string) deliveryProbe {
 	normalized := normalizeDelivery(content)
+	p.baselineCaptured = true
 	if p.completion != "" {
 		p.completionBaseline = strings.Count(normalized, p.completion)
 	}
@@ -522,7 +527,8 @@ func (t *TmuxSession) waitForPasteDelivered(probe deliveryProbe) deliveryObserva
 		// server cannot push a single capture past the deadline below (#2099).
 		if content, ok := t.capturePaneForDeliveryWithin(time.Until(deadline)); ok {
 			normalized := normalizeDelivery(content)
-			if strings.Count(normalized, probe.completion) > probe.completionBaseline {
+			if probe.baselineCaptured &&
+				strings.Count(normalized, probe.completion) > probe.completionBaseline {
 				streak++
 				if streak >= needed {
 					return deliveryObservation{outcome: deliveryObservedLanded, pane: content}
@@ -530,7 +536,7 @@ func (t *TmuxSession) waitForPasteDelivered(probe deliveryProbe) deliveryObserva
 				// One weak short-tail sighting is neither confirmed delivery nor
 				// absence. A later failure must not combine with it.
 				lastObservation = deliveryObservation{outcome: deliveryCouldNotObserve, pane: content}
-			} else if probe.renderWitness != "" &&
+			} else if probe.baselineCaptured && probe.renderWitness != "" &&
 				strings.Count(normalized, probe.renderWitness) > probe.renderWitnessBaseline {
 				streak = 0
 				lastObservation = deliveryObservation{outcome: deliveryObservedAbsent, pane: content}

--- a/session/tmux/submit_test.go
+++ b/session/tmux/submit_test.go
@@ -645,6 +645,68 @@ func TestMissingPromptAfterPromptSpecificRenderingStaysLoud(t *testing.T) {
 	require.NotContains(t, got, "may be unsubmitted")
 }
 
+// TestMediumPromptPartialRenderingStaysLoud is the Codex review fail-first.
+// A medium prompt can still provide two disjoint, distinctive fragments even
+// though a fixed 32-rune completion tail leaves less than the preferred 24-rune
+// prefix. Seeing that prompt-specific prefix newly render must preserve #1982's
+// terminal negative instead of silently becoming could-not-observe.
+func TestMediumPromptPartialRenderingStaysLoud(t *testing.T) {
+	defer withPasteDeliveryTiming(20*time.Millisecond, time.Millisecond)()
+	errors := captureErrorLog(t)
+	pasted := false
+	prompt := "PFX12345" + strings.Repeat("completion", 3)
+	require.Equal(t, 38, len([]rune(normalizeDelivery(prompt))))
+
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			if strings.Contains(strings.Join(c.Args, " "), "paste-buffer") {
+				pasted = true
+			}
+			return nil
+		},
+		OutputFunc: func(*exec.Cmd) ([]byte, error) {
+			if pasted {
+				return []byte("╭─ composer ─╮\n│ > PFX12345 │\n╰────────────╯"), nil
+			}
+			return []byte("╭─ composer ─╮\n│ >          │\n╰────────────╯"), nil
+		},
+	}
+	session := newTmuxSession("af_proj", ProgramClaude, NewMockPtyFactory(t), cmdExec)
+
+	require.NoError(t, session.SendKeysCommand(prompt))
+	require.Contains(t, errors.String(), "prompt delivery observed absent",
+		"a newly rendered prompt-specific prefix must remain loud even when the prompt is shorter than the preferred witness pair")
+}
+
+func TestDeliveryProbeReservesTwoDistinctiveFragments(t *testing.T) {
+	tests := []struct {
+		name           string
+		promptRunes    int
+		wantCompletion int
+		wantWitness    int
+	}{
+		{name: "short prompt keeps full completion", promptRunes: 15, wantCompletion: 15},
+		{name: "completion-sized prompt stays conservative", promptRunes: 32, wantCompletion: 32},
+		{name: "lower reviewed range", promptRunes: 33, wantCompletion: 25, wantWitness: 8},
+		{name: "full completion fits", promptRunes: 40, wantCompletion: 32, wantWitness: 8},
+		{name: "upper reviewed range", promptRunes: 55, wantCompletion: 32, wantWitness: 23},
+		{name: "preferred pair", promptRunes: 56, wantCompletion: 32, wantWitness: 24},
+		{name: "long prompt caps both fragments", promptRunes: 100, wantCompletion: 32, wantWitness: 24},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			probe := newDeliveryProbe(strings.Repeat("x", tt.promptRunes))
+			require.Equal(t, tt.wantCompletion, len([]rune(probe.completion)))
+			require.Equal(t, tt.wantWitness, len([]rune(probe.renderWitness)))
+			require.LessOrEqual(t,
+				len([]rune(probe.completion))+len([]rune(probe.renderWitness)),
+				tt.promptRunes,
+				"the completion and render witness must remain disjoint")
+		})
+	}
+}
+
 func TestFailedPostClearCaptureKeepsPreClearBaseline(t *testing.T) {
 	defer withPasteDeliveryTiming(10*time.Millisecond, time.Millisecond)()
 	errors := captureErrorLog(t)

--- a/session/tmux/submit_test.go
+++ b/session/tmux/submit_test.go
@@ -670,6 +670,50 @@ func TestFailedPostClearCaptureKeepsPreClearBaseline(t *testing.T) {
 		"an old prompt retained across a failed post-clear capture proves neither new delivery nor new partial rendering")
 }
 
+// TestFailedBaselineCapturesCannotAuthorizeObservedAbsent is the Codex review
+// fail-first: when neither pre-paste capture succeeds, zero is not a measured
+// baseline. A prompt prefix already present in scrollback may appear in every
+// later frame, so its count above zero cannot prove this paste rendered it.
+func TestFailedBaselineCapturesCannotAuthorizeObservedAbsent(t *testing.T) {
+	defer withPasteDeliveryTiming(20*time.Millisecond, time.Millisecond)()
+	errors := captureErrorLog(t)
+	pasted := false
+	const prompt = "run bash -lc 'printf started && inspect every file before reporting DELIVERY_TAIL_COMPLETE'"
+
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			if strings.Contains(strings.Join(c.Args, " "), "paste-buffer") {
+				pasted = true
+			}
+			return nil
+		},
+		OutputFunc: func(*exec.Cmd) ([]byte, error) {
+			if !pasted {
+				return nil, fmt.Errorf("transient baseline capture failure")
+			}
+			return []byte("old scrollback: run bash -lc 'printf started"), nil
+		},
+	}
+	session := newTmuxSession("af_proj", ProgramClaude, NewMockPtyFactory(t), cmdExec)
+
+	require.NoError(t, session.SendKeysCommand(prompt))
+	require.NotContains(t, errors.String(), "prompt delivery observed absent",
+		"without a measured baseline, retained prefix text cannot be called new")
+}
+
+func TestUncapturedBaselineCannotConfirmOldCompletionTail(t *testing.T) {
+	defer withPasteDeliveryTiming(8*time.Millisecond, time.Millisecond)()
+	const prompt = "an old complete prompt with a distinctive DELIVERY_TAIL_ALREADY_IN_SCROLLBACK"
+	cmdExec := cmd_test.MockCmdExec{
+		OutputFunc: func(*exec.Cmd) ([]byte, error) { return []byte(prompt), nil },
+	}
+	session := newTmuxSession("af_proj", ProgramClaude, NewMockPtyFactory(t), cmdExec)
+
+	got := session.waitForPasteDelivered(newDeliveryProbe(prompt))
+	require.Equal(t, deliveryCouldNotObserve, got.outcome,
+		"without a measured baseline, retained completion text cannot prove this paste landed")
+}
+
 func TestFinalCaptureFailureMakesEarlierAbsenceUnobservable(t *testing.T) {
 	defer withPasteDeliveryTiming(8*time.Millisecond, time.Millisecond)()
 	captures := 0

--- a/session/tmux/submit_test.go
+++ b/session/tmux/submit_test.go
@@ -527,11 +527,75 @@ func TestSubmitDoesNotManufactureAFailureWhenThePaneIsUnreadable(t *testing.T) {
 		"a failed observation probe must not manufacture an ERROR")
 }
 
-// TestMissingPromptInKnownEchoingPaneStaysLoud protects the genuine #1982
-// signal. Unlike the Codex case above, Claude is known to render pasted input
-// before Enter. Successful captures that never contain the prompt are therefore
-// observed-absent, not could-not-observe, and must remain actionable at ERROR.
-func TestMissingPromptInKnownEchoingPaneStaysLoud(t *testing.T) {
+// TestSubmitRequiresPromptSpecificRenderingBeforeObservedAbsent is the #2266
+// fail-first pair. Claude's ability to render a composer is not proof that it
+// rendered THIS payload: long pastes are deliberately collapsed, while a
+// capture that contains only the composer's frame says nothing about the
+// payload at all. These are separate mechanisms seen in the live log and both
+// must stay could-not-observe rather than manufacturing a terminal negative.
+func TestSubmitRequiresPromptSpecificRenderingBeforeObservedAbsent(t *testing.T) {
+	tests := []struct {
+		name      string
+		paneAfter string
+	}{
+		{
+			name: "collapsed paste placeholder",
+			paneAfter: "╭─ composer ─────────────────╮\n" +
+				"│ ❯ [Pasted text #1 +10 lines] │\n" +
+				"╰──────────────────────────────╯\n" +
+				"paste again to expand",
+		},
+		{
+			name: "composer frame without payload text",
+			paneAfter: "╭──────────────────────────────╮\n" +
+				"│                              │\n" +
+				"╰──────────────────────────────╯\n" +
+				"-- INSERT --",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer withPasteDeliveryTiming(20*time.Millisecond, time.Millisecond)()
+			errors := captureErrorLog(t)
+			pasted := false
+			enterSent := false
+
+			cmdExec := cmd_test.MockCmdExec{
+				RunFunc: func(c *exec.Cmd) error {
+					joined := strings.Join(c.Args, " ")
+					if strings.Contains(joined, "paste-buffer") {
+						pasted = true
+					}
+					if strings.Contains(joined, "send-keys") && hasArg(c.Args, "Enter") {
+						enterSent = true
+					}
+					return nil
+				},
+				OutputFunc: func(*exec.Cmd) ([]byte, error) {
+					if pasted {
+						return []byte(tt.paneAfter), nil
+					}
+					return []byte("╭─ composer ─╮\n│ >          │\n╰────────────╯"), nil
+				},
+			}
+			session := newTmuxSession("af_proj", ProgramClaude, NewMockPtyFactory(t), cmdExec)
+			prompt := "deliver this long briefing\nwith enough hidden lines\nthat Claude may elide it\n" +
+				"while retaining a distinctive DELIVERY_TAIL_THAT_IS_NOT_RENDERED"
+
+			require.NoError(t, session.SendKeysCommand(prompt))
+			require.True(t, enterSent, "could-not-observe must retain the best-effort Enter")
+			require.NotContains(t, errors.String(), "prompt delivery observed absent",
+				"a pane that did not render prompt-specific text cannot prove the prompt absent")
+		})
+	}
+}
+
+// TestMissingPromptAfterPromptSpecificRenderingStaysLoud protects the genuine
+// #1982 signal. The pane renders a new prefix from this exact prompt but never
+// its disjoint completion tail. That is terminal observed-absent regardless of
+// agent identity and must remain actionable at ERROR.
+func TestMissingPromptAfterPromptSpecificRenderingStaysLoud(t *testing.T) {
 	defer withPasteDeliveryTiming(50*time.Millisecond, time.Millisecond)()
 	errors := captureErrorLog(t)
 	enterSent := false
@@ -551,8 +615,13 @@ func TestMissingPromptInKnownEchoingPaneStaysLoud(t *testing.T) {
 		},
 		// Capture works and sees a truncated prefix stranded inside an open quote,
 		// but never the distinctive tail: the genuine #1982 case that must stay
-		// loud even though Enter is still sent best-effort.
+		// loud even though Enter is still sent best-effort. After Enter, the pane
+		// changes; the diagnostic must retain THIS authorizing frame rather than
+		// recapturing unrelated pixels.
 		OutputFunc: func(c *exec.Cmd) ([]byte, error) {
+			if enterSent {
+				return []byte("post-Enter pane changed to an unrelated frame"), nil
+			}
 			if pasted {
 				return []byte("╭─ composer ─────────────────╮\n│ > run bash -lc 'printf started │\n╰────────────────────────────╯"), nil
 			}
@@ -566,10 +635,12 @@ func TestMissingPromptInKnownEchoingPaneStaysLoud(t *testing.T) {
 	got := errors.String()
 	require.Equal(t, 1, strings.Count(got, "prompt delivery observed absent"),
 		"a genuine missing prompt should emit one actionable ERROR, got %q", got)
-	require.Contains(t, got, "pane known to echo input")
+	require.Contains(t, got, "pane rendered this prompt's prefix but not its completion tail")
 	require.Contains(t, got, "Enter sent best-effort")
 	require.Contains(t, got, "run bash -lc 'printf started",
 		"the actionable ERROR should retain the observed truncated pane tail")
+	require.NotContains(t, got, "post-Enter pane changed",
+		"the diagnostic must print the frame that authorized observed-absent, not a later recapture")
 	require.NotContains(t, got, "may simply not echo")
 	require.NotContains(t, got, "may be unsubmitted")
 }
@@ -595,8 +666,8 @@ func TestFailedPostClearCaptureKeepsPreClearBaseline(t *testing.T) {
 	session := newTmuxSession("af_proj", ProgramClaude, NewMockPtyFactory(t), cmdExec)
 
 	require.NoError(t, session.SendKeysCommand(prompt))
-	require.Contains(t, errors.String(), "prompt delivery observed absent",
-		"a failed post-clear capture must fall back to the pre-clear count instead of falsely confirming an old tail")
+	require.NotContains(t, errors.String(), "prompt delivery observed absent",
+		"an old prompt retained across a failed post-clear capture proves neither new delivery nor new partial rendering")
 }
 
 func TestFinalCaptureFailureMakesEarlierAbsenceUnobservable(t *testing.T) {
@@ -613,8 +684,8 @@ func TestFinalCaptureFailureMakesEarlierAbsenceUnobservable(t *testing.T) {
 	}
 	session := newTmuxSession("af_proj", ProgramClaude, NewMockPtyFactory(t), cmdExec)
 
-	got := session.waitForPasteDelivered("DISTINCTIVE_DELIVERY_TAIL", 0)
-	require.Equal(t, deliveryCouldNotObserve, got,
+	got := session.waitForPasteDelivered(newDeliveryProbe("DISTINCTIVE_DELIVERY_TAIL"))
+	require.Equal(t, deliveryCouldNotObserve, got.outcome,
 		"an early absence followed by failed probes cannot say whether the paste landed later")
 }
 
@@ -634,72 +705,50 @@ func TestCaptureFailureBreaksShortTailSightingStreak(t *testing.T) {
 	}
 	session := newTmuxSession("af_proj", ProgramClaude, NewMockPtyFactory(t), cmdExec)
 
-	got := session.waitForPasteDelivered("ok", 0)
-	require.Equal(t, deliveryCouldNotObserve, got,
+	got := session.waitForPasteDelivered(newDeliveryProbe("ok"))
+	require.Equal(t, deliveryCouldNotObserve, got.outcome,
 		"two weak sightings separated by a failed probe are not consecutive delivery evidence")
 }
 
-// TestObservedDeliveryCachesEchoBehavior proves unknown programs are detected
-// only from positive evidence, then reuse that capability. The first visible
-// delivery promotes the session; a later genuinely absent prompt is therefore
-// loud without consulting a per-agent guess table.
-func TestObservedDeliveryCachesEchoBehavior(t *testing.T) {
+// TestPriorVisibleDeliveryDoesNotAuthorizeALaterNegative pins the payload scope
+// of observation. A pane rendering one prompt proves only that delivery. It
+// cannot grant an agent-wide capability that turns a later empty composer into
+// observed-absent (#2266's root sharp edge).
+func TestPriorVisibleDeliveryDoesNotAuthorizeALaterNegative(t *testing.T) {
 	defer withPasteDeliveryTiming(50*time.Millisecond, time.Millisecond)()
 	errors := captureErrorLog(t)
 
 	var loaded string
 	delivery := 0
+	loads := 0
 	cmdExec := cmd_test.MockCmdExec{
 		RunFunc: func(c *exec.Cmd) error {
 			joined := strings.Join(c.Args, " ")
 			if strings.Contains(joined, "load-buffer") && c.Stdin != nil {
 				b, _ := io.ReadAll(c.Stdin)
 				loaded = string(b)
+				loads++
 			}
 			if strings.Contains(joined, "paste-buffer") {
 				delivery++
 			}
 			return nil
 		},
-		OutputFunc: func(c *exec.Cmd) ([]byte, error) {
-			if delivery == 1 && loaded != "" {
+		OutputFunc: func(*exec.Cmd) ([]byte, error) {
+			if delivery == 1 && loads == 1 && loaded != "" {
 				return []byte("custom composer: " + loaded), nil
 			}
 			return []byte("custom composer ready"), nil
 		},
 	}
 	session := newTmuxSession("af_proj", "custom-agent", NewMockPtyFactory(t), cmdExec)
-	require.Equal(t, preSubmitEchoUnknown, session.preSubmitEchoBehavior())
 
 	require.NoError(t, session.SendKeysCommand("first prompt lands visibly"))
-	require.Equal(t, preSubmitEchoes, session.preSubmitEchoBehavior(),
-		"a positively observed delivery should be cached for this agent session")
 	require.Empty(t, errors.String())
 
 	require.NoError(t, session.SendKeysCommand("second prompt is genuinely absent"))
-	require.Contains(t, errors.String(), "prompt delivery observed absent",
-		"the cached echo capability must keep a later genuine failure loud")
-}
-
-func TestPreSubmitEchoBehaviorTracksResolvedProgram(t *testing.T) {
-	session := newTmuxSession("af_proj", "/usr/local/bin/codex --full-auto", NewMockPtyFactory(t), cmd_test.MockCmdExec{})
-	require.Equal(t, preSubmitDoesNotEcho, session.preSubmitEchoBehavior(),
-		"capability detection must use the resolved executable, including absolute paths")
-	session.notePreSubmitEchoObserved()
-	require.Equal(t, preSubmitDoesNotEcho, session.preSubmitEchoBehavior(),
-		"a coincidental tail match must not promote a known non-echoing Codex pane")
-
-	session.SetProgram("ionice -c 3 claude --model opus")
-	require.Equal(t, preSubmitEchoes, session.preSubmitEchoBehavior(),
-		"agent handoff must replace the cached capability with the new agent's behavior")
-
-	session.SetProgram("aider --model sonnet")
-	require.Equal(t, preSubmitEchoes, session.preSubmitEchoBehavior(),
-		"Aider visibly echoes pasted composer input and must keep missing delivery loud")
-
-	session.SetProgram("/opt/bin/claude-wrapper")
-	require.Equal(t, preSubmitEchoUnknown, session.preSubmitEchoBehavior(),
-		"an unknown override must stay unknown instead of substring-matching an agent name")
+	require.NotContains(t, errors.String(), "prompt delivery observed absent",
+		"one visible delivery cannot make a later payload terminal without prompt-specific evidence")
 }
 
 func captureRawPane(session *TmuxSession) (string, error) {


### PR DESCRIPTION
## Outcome

Replace the agent-wide “known echoing” model with one payload-bound rule:

> Delivery may be terminally observed absent only when the terminal both can and did render prompt-specific evidence from this payload.

Concretely:

- derive a disjoint normalized prefix witness (at least 8, up to 24 runes) and completion tail (up to 32 runes) for prompts longer than 32 runes, including the full 33–55-rune medium range;
- baseline both before paste, require an actually captured baseline before comparing counts, and thereby prevent old scrollback from becoming evidence for either delivery or absence;
- confirm landed when the completion tail newly appears;
- report observed-absent only when the exact terminal frame newly contains this prompt’s prefix but not its completion tail;
- classify a collapsed Claude `[Pasted text …]` placeholder, generic composer chrome, a failed capture, and short prompts without disjoint witnesses as could-not-observe;
- remove the cached per-agent echo capability entirely, so one visible short paste cannot authorize a negative for a later collapsed long paste;
- bind the diagnostic to the same terminal frame that authorized the decision, preserving the pane tail without a post-Enter recapture.

This keeps the genuine #1982 case loud: a newly rendered truncated prompt prefix with a missing completion tail still emits the actionable ERROR and sends Enter best-effort.

The four live occurrences were checked separately. The two placeholder tails are deliberate Claude elision. The two `af_0f8fc14c_root` tails contain only frame/footer glyphs; they are not assumed to share the placeholder cause, but independently lack prompt-specific rendering evidence and are therefore unobservable.

## Fail-first

Before the implementation, both new fixtures failed with `prompt delivery observed absent`:

- Claude collapsed-paste placeholder: `[Pasted text #1 +10 lines]`;
- composer frame/footer only, with no prompt-specific text.

After the implementation both stay could-not-observe, while the #1982 truncated-prefix fixture remains observed-absent. Separate regressions prove that a prior visible delivery grants no capability to a later payload and that failed baseline captures authorize neither a terminal negative from an old prefix nor a positive from an old completion tail. A review fail-first also proved that a 38-rune prompt rendering only its distinctive prefix previously lost the #1982 signal; boundary tests now pin conservative full-prompt handling at 32 runes and disjoint witnesses at 33, 40, 55, and 56 runes.

## Verification

Full gates run after the final commit on pushed head `35b26faa3bb64bf0f7990b46ccc7e50dbb9ab302`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh` (919 Go files checked; 0 grandfathered)
- `scripts/testbox.sh test -race ./session/tmux -count=1`

The first CI Web job failed only config-save ordering test 71 after observing `['off']` instead of `['off','on']`. A single rerun of that job on the identical head passed all 401 tests and bundle parity; no code, timeout, or retry policy changed:

- [original failed Web job](https://github.com/sachiniyer/agent-factory/actions/runs/29824382048/job/88614338273)
- [same-head green Web rerun](https://github.com/sachiniyer/agent-factory/actions/runs/29824382048/job/88615921721)

Closes #2266.

— Captain Claude