### PR TITLE
fix(tui): preserve scroll authority continuity

### DIFF
--- a/agentproto/message.go
+++ b/agentproto/message.go
@@ -54,13 +54,23 @@ func NewResizeMessage(rows, cols uint16) ResizeMessage {
 // snapshot. Presence is significant: an all-false Modes value truthfully means
 // primary screen with no mouse tracking, unlike a source that could not report.
 type TerminalModesMessage struct {
-	Type  MessageType    `json:"type"`
-	Modes terminal.Modes `json:"modes"`
+	Type             MessageType    `json:"type"`
+	Modes            terminal.Modes `json:"modes"`
+	CoversNextCursor bool           `json:"covers_next_cursor,omitempty"`
 }
 
 // NewTerminalModesMessage builds terminal mode snapshot metadata.
 func NewTerminalModesMessage(modes terminal.Modes) TerminalModesMessage {
 	return TerminalModesMessage{Type: MsgTerminalModes, Modes: modes}
+}
+
+// NewTerminalModesMessageCoveringNextCursor marks the recovery-barrier snapshot
+// that describes the cursor re-seed emitted immediately after its repaint. A
+// fresh repaint uses NewTerminalModesMessage and grants no future-gap coverage.
+func NewTerminalModesMessageCoveringNextCursor(modes terminal.Modes) TerminalModesMessage {
+	msg := NewTerminalModesMessage(modes)
+	msg.CoversNextCursor = true
+	return msg
 }
 
 // ExitReason says WHY a MsgExit ended the stream. It is an additive

--- a/agentproto/message_test.go
+++ b/agentproto/message_test.go
@@ -2,6 +2,7 @@ package agentproto
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/sachiniyer/agent-factory/terminal"
@@ -38,7 +39,7 @@ func TestControlMessageWireShapes(t *testing.T) {
 }
 
 func TestTerminalModesMessageRoundTrip(t *testing.T) {
-	want := NewTerminalModesMessage(terminal.Modes{
+	want := NewTerminalModesMessageCoveringNextCursor(terminal.Modes{
 		AlternateScreen: true,
 		MouseTracking:   true,
 		MouseButton:     true,
@@ -57,6 +58,16 @@ func TestTerminalModesMessageRoundTrip(t *testing.T) {
 	}
 	if got != want {
 		t.Fatalf("round trip = %+v, want %+v", got, want)
+	}
+}
+
+func TestFreshTerminalModesMessageOmitsCursorCoverage(t *testing.T) {
+	raw, err := json.Marshal(NewTerminalModesMessage(terminal.Modes{}))
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if strings.Contains(string(raw), "covers_next_cursor") {
+		t.Fatalf("fresh mode snapshot granted recovery cursor coverage: %s", raw)
 	}
 }
 

--- a/app/live_stream.go
+++ b/app/live_stream.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/tmux"
-	"github.com/sachiniyer/agent-factory/terminal"
 	"github.com/sachiniyer/agent-factory/ui"
 	"github.com/sachiniyer/agent-factory/ui/termpane"
 )
@@ -42,7 +41,7 @@ func (m *home) newTabPaneSource() ui.PreviewSource {
 		}
 		return ui.PreviewSnapshot{
 			Content: resp.Content,
-			Owner:   scrollOwnerForModes(resp.Modes, resp.HasModes),
+			Owner:   scrollOwnerForSnapshot(resp.Modes, resp.HasModes),
 		}, nil
 	}
 }
@@ -78,7 +77,7 @@ func streamDialer(title, repoID, tabID string, tab int) termpane.Dialer {
 // binary frames.
 type apiStream struct {
 	sc           *apiclient.StreamConn
-	pendingModes *terminal.Modes
+	pendingModes *agentproto.TerminalModesMessage
 }
 
 var _ termpane.Stream = (*apiStream)(nil)
@@ -101,7 +100,10 @@ func (s *apiStream) Recv(ctx context.Context) (termpane.Event, error) {
 			case agentproto.OpRepaint:
 				ev := termpane.Event{Kind: termpane.EventRepaint, Data: msg.Frame.Data}
 				if s.pendingModes != nil {
-					ev.Modes, ev.HasModes = *s.pendingModes, true
+					ev.Modes, ev.HasModes = s.pendingModes.Modes, true
+					if s.pendingModes.CoversNextCursor {
+						ev.CursorCoverage = termpane.RepaintCoversNextCursor
+					}
 					s.pendingModes = nil
 				}
 				return ev, nil
@@ -121,8 +123,7 @@ func (s *apiStream) Recv(ctx context.Context) (termpane.Event, error) {
 			// the next grid. Clear first so ownership metadata is fail-closed.
 			s.pendingModes = nil
 			if json.Unmarshal(msg.Text, &mm) == nil {
-				modes := mm.Modes
-				s.pendingModes = &modes
+				s.pendingModes = &mm
 			}
 			// Modes and repaint are emitted consecutively by the daemon. Keep
 			// reading so termpane applies both under one emulator lock.

--- a/app/live_stream_modes_test.go
+++ b/app/live_stream_modes_test.go
@@ -69,6 +69,26 @@ func TestAPIStreamBindsTerminalModesToRepaint(t *testing.T) {
 	}
 }
 
+func TestAPIStreamBindsRecoveryCursorCoverageToRepaint(t *testing.T) {
+	want := terminal.Modes{AlternateScreen: true}
+	stream := testAPIStream(t, func(ctx context.Context, conn *websocket.Conn) error {
+		if err := agentproto.WriteControl(
+			ctx, conn, agentproto.NewTerminalModesMessageCoveringNextCursor(want),
+		); err != nil {
+			return err
+		}
+		return agentproto.WriteFrame(ctx, conn, agentproto.RepaintFrame([]byte("RECOVERED-GRID")))
+	})
+
+	ev, err := stream.Recv(context.Background())
+	if err != nil {
+		t.Fatalf("Recv: %v", err)
+	}
+	if ev.Kind != termpane.EventRepaint || ev.CursorCoverage != termpane.RepaintCoversNextCursor {
+		t.Fatalf("event = %+v, want recovery repaint covering its next cursor", ev)
+	}
+}
+
 func TestAPIStreamMalformedModesCannotReusePriorSnapshot(t *testing.T) {
 	stream := testAPIStream(t, func(ctx context.Context, conn *websocket.Conn) error {
 		if err := agentproto.WriteControl(ctx, conn, agentproto.NewTerminalModesMessage(terminal.Modes{AlternateScreen: true})); err != nil {

--- a/app/live_termpane.go
+++ b/app/live_termpane.go
@@ -48,8 +48,9 @@ type liveTermAttachment interface {
 	// the inner app only if it enabled mouse tracking, and is dropped otherwise.
 	SendMouse(msg tea.MouseMsg, x, y int) bool
 	// TerminalModes reports the ownership-affecting terminal snapshot and whether
-	// it is known. A fresh/reconnected client stays unknown until its repaint
-	// lands; zero modes are otherwise a valid primary-screen state.
+	// it is known. A disconnected client is unknown; continuous replay or a fresh
+	// authoritative repaint re-establishes it. Zero modes are a valid primary-screen
+	// state.
 	TerminalModes() (terminal.Modes, bool)
 }
 

--- a/app/mouse_test.go
+++ b/app/mouse_test.go
@@ -688,6 +688,38 @@ func TestKeyboardScrollResolvesLiveOwnerAtInputTime(t *testing.T) {
 		"returning to the primary screen must restore host keyboard scrolling")
 }
 
+func TestUnknownLiveModesPreserveActiveHostScroll(t *testing.T) {
+	h, _ := liveTestHome(t)
+	resizeHome(h, 120, 40)
+	fakes, _ := stubLiveTermFactory(t)
+	h.syncLiveTermPane()
+	require.Len(t, *fakes, 1)
+	fake := (*fakes)[0]
+	p := h.focusedOpenPane()
+	require.NotNil(t, p)
+	w := h.paneWindows[p.ID()]
+	require.NotNil(t, w)
+
+	h.syncPaneScrollOwners()
+	require.Equal(t, ui.ScrollOwnerHostHistory, w.ScrollOwner())
+	w.ScrollUp()
+	require.True(t, w.IsInScrollMode(), "precondition: AF owns an active history transaction")
+
+	fake.modesKnown = false
+	h.syncPaneScrollOwners()
+	require.True(t, w.IsInScrollMode(),
+		"a transient reconnect gap must not discard an active history transaction")
+	require.Equal(t, ui.ScrollOwnerHostHistory, w.ScrollOwner())
+
+	// Unknown is only a preservation rule. Once the stream authoritatively reports
+	// a child owner, that new decision replaces the old host-history transaction.
+	fake.modes = terminal.Modes{AlternateScreen: true}
+	fake.modesKnown = true
+	h.syncPaneScrollOwners()
+	require.False(t, w.IsInScrollMode())
+	require.Equal(t, ui.ScrollOwnerChildApplication, w.ScrollOwner())
+}
+
 func TestMouse_TransientPreviewUsesTargetSnapshotOwner(t *testing.T) {
 	h := newTestHome(t)
 	for _, title := range []string{"alpha", "beta", "gamma"} {

--- a/app/scroll_ownership.go
+++ b/app/scroll_ownership.go
@@ -6,19 +6,22 @@ import (
 	"github.com/sachiniyer/agent-factory/ui/store"
 )
 
-// scrollOwnerForModes is the one terminal ownership decision used by nav
-// preview and interactive mouse routing. Alternate-screen applications own
-// their private history even when they do not track the mouse (Codex transcript);
-// a primary-screen application that explicitly tracks mouse also owns wheel
-// input. Unknown is never guessed as host history.
-func scrollOwnerForModes(modes terminal.Modes, known bool) ui.ScrollOwner {
-	if !known {
-		return ui.ScrollOwnerNone
-	}
+// scrollOwnerForKnownModes is the one authoritative terminal ownership decision
+// used by nav preview and interactive mouse routing. Alternate-screen applications
+// own their private history even when they do not track the mouse (Codex transcript);
+// a primary-screen application that explicitly tracks mouse also owns wheel input.
+func scrollOwnerForKnownModes(modes terminal.Modes) ui.ScrollOwner {
 	if modes.AlternateScreen || modes.MouseTrackingEnabled() {
 		return ui.ScrollOwnerChildApplication
 	}
 	return ui.ScrollOwnerHostHistory
+}
+
+func scrollOwnerForSnapshot(modes terminal.Modes, known bool) ui.ScrollOwner {
+	if !known {
+		return ui.ScrollOwnerNone
+	}
+	return scrollOwnerForKnownModes(modes)
 }
 
 // paneScrollOwnership is the input-time decision for one target. childMouse is
@@ -41,9 +44,12 @@ func (m *home) resolvePaneScrollOwnership(p *store.OpenPane, w *ui.TabbedWindow)
 	}
 	if lt := m.liveTerms[p.ID()]; lt != nil {
 		modes, known := lt.TerminalModes()
+		if !known {
+			return paneScrollOwnership{owner: w.ObserveScrollOwnerUnknown()}
+		}
 		decision := paneScrollOwnership{
-			owner:      scrollOwnerForModes(modes, known),
-			childMouse: known && modes.MouseTrackingEnabled(),
+			owner:      scrollOwnerForKnownModes(modes),
+			childMouse: modes.MouseTrackingEnabled(),
 		}
 		w.SetScrollOwner(decision.owner)
 		return decision

--- a/daemon/ws_pty.go
+++ b/daemon/ws_pty.go
@@ -355,7 +355,18 @@ func writePTYStream(ctx context.Context, sub session.PTYSubscription, conn *webs
 			// the repaint's DEC restore prefix keeps terminal-only/older clients
 			// correct too.
 			if ev.HasModes {
-				err = agentproto.WriteControl(wctx, conn, agentproto.NewTerminalModesMessage(ev.Modes))
+				var modeMessage agentproto.TerminalModesMessage
+				switch ev.RepaintProvenance {
+				case session.PTYRepaintFresh:
+					modeMessage = agentproto.NewTerminalModesMessage(ev.Modes)
+				case session.PTYRepaintRecovery:
+					modeMessage = agentproto.NewTerminalModesMessageCoveringNextCursor(ev.Modes)
+				default:
+					err = fmt.Errorf("unknown PTY repaint provenance %d", ev.RepaintProvenance)
+				}
+				if err == nil {
+					err = agentproto.WriteControl(wctx, conn, modeMessage)
+				}
 			}
 			if err == nil {
 				err = agentproto.WriteFrame(wctx, conn, agentproto.RepaintFrame(ev.Data))

--- a/session/agentserver.go
+++ b/session/agentserver.go
@@ -256,6 +256,17 @@ const (
 	PTYCursor
 )
 
+// PTYRepaintProvenance distinguishes a fresh/reconnect snapshot from the
+// recovery barrier repaint that intentionally covers the immediately following
+// cursor jump. Defaulting to Fresh is fail-closed for callers that construct an
+// event without provenance.
+type PTYRepaintProvenance uint8
+
+const (
+	PTYRepaintFresh PTYRepaintProvenance = iota
+	PTYRepaintRecovery
+)
+
 // PTYEvent is one event delivered to a subscriber: output bytes, the authoritative
 // resize echo, a screen repaint, or a cursor re-seed, selected by Kind.
 type PTYEvent struct {
@@ -270,6 +281,7 @@ type PTYEvent struct {
 	Seq Seq
 	// Modes accompany PTYRepaint when HasModes is true. They are snapshot
 	// metadata, not ring bytes, and therefore do not advance Seq.
-	Modes    terminal.Modes
-	HasModes bool
+	Modes             terminal.Modes
+	HasModes          bool
+	RepaintProvenance PTYRepaintProvenance
 }

--- a/session/ptybroker.go
+++ b/session/ptybroker.go
@@ -97,9 +97,10 @@ type PaneSnapshot struct {
 // modes captured with it. The daemon emits the modes immediately before Data,
 // and Data also restores them as DEC sequences for terminal-only clients.
 type repaintSnapshot struct {
-	data     []byte
-	modes    terminal.Modes
-	hasModes bool
+	data       []byte
+	modes      terminal.Modes
+	hasModes   bool
+	provenance PTYRepaintProvenance
 }
 
 // ptyBroker is the per-session data plane. Guarded by mu; the ring buffer, the
@@ -522,6 +523,7 @@ func (b *ptyBroker) recoveryRepaint() *repaintSnapshot {
 		return nil
 	}
 	rp := buildRepaintSnapshot(snap)
+	rp.provenance = PTYRepaintRecovery
 	return &rp
 }
 
@@ -746,10 +748,11 @@ func (s *ptySub) NextEvent(ctx context.Context) (PTYEvent, error) {
 			s.pendingRepaint = nil
 			s.br.mu.Unlock()
 			return PTYEvent{
-				Kind:     PTYRepaint,
-				Data:     rp.data,
-				Modes:    rp.modes,
-				HasModes: rp.hasModes,
+				Kind:              PTYRepaint,
+				Data:              rp.data,
+				Modes:             rp.modes,
+				HasModes:          rp.hasModes,
+				RepaintProvenance: rp.provenance,
 			}, nil
 		}
 		// A recovery is in flight and this subscriber's repaint of the recovered screen

--- a/session/ptybroker_recovery_test.go
+++ b/session/ptybroker_recovery_test.go
@@ -358,6 +358,9 @@ func TestPTYBrokerRecoveryRepaintPrecedesLiveBytes(t *testing.T) {
 				"the recovered screen: pane output delivered before the recovery repaint "+
 				"renders a stale frame the repaint then wipes (the flicker)", ev.Kind, ev.Data)
 		}
+		if ev.RepaintProvenance != PTYRepaintRecovery {
+			t.Fatalf("recovery repaint provenance = %d, want recovery", ev.RepaintProvenance)
+		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("no post-recovery event: A was never re-seeded")
 	}

--- a/session/ptybroker_test.go
+++ b/session/ptybroker_test.go
@@ -248,6 +248,9 @@ func TestPTYBrokerRepaintCarriesTerminalModes(t *testing.T) {
 	if ev.Kind != PTYRepaint || !ev.HasModes || ev.Modes != modes {
 		t.Fatalf("repaint metadata = %+v, want modes %+v", ev, modes)
 	}
+	if ev.RepaintProvenance != PTYRepaintFresh {
+		t.Fatalf("initial repaint provenance = %d, want fresh", ev.RepaintProvenance)
+	}
 	if !strings.HasPrefix(string(ev.Data), string(modes.RestoreSequence())) {
 		t.Fatalf("repaint data = %q, want terminal-mode restore prefix %q", ev.Data, modes.RestoreSequence())
 	}

--- a/ui/preview_scroll_offloop_test.go
+++ b/ui/preview_scroll_offloop_test.go
@@ -263,6 +263,35 @@ func TestOwnerSwitchInvalidatesPendingHostHistoryFill(t *testing.T) {
 	require.Equal(t, 0, p.viewport.YOffset)
 }
 
+func TestUnknownOwnerObservationPreservesOnlyActiveHostHistory(t *testing.T) {
+	inst := makeShellInstance(t, "unknown-active-host", "visible-line")
+	defer func() { _ = inst.Kill() }()
+
+	p := NewTabPane(func(_ *session.Instance, _ int, full bool) (PreviewSnapshot, error) {
+		if full {
+			return hostPreview(numberedScrollHistory(40)), nil
+		}
+		return hostPreview("visible-line"), nil
+	})
+	p.SetScrollOwnerFor(inst, 1, ScrollOwnerHostHistory)
+	p.SetSize(80, 10)
+	require.NoError(t, p.ScrollUp(inst, 1))
+	p.BeginScrollFill()
+	require.NoError(t, p.UpdateContent(inst, 1))
+	beforeOffset, beforeView := p.viewport.YOffset, p.viewport.View()
+
+	owner := p.ObserveScrollOwnerUnknownFor(inst, 1)
+	require.Equal(t, ScrollOwnerHostHistory, owner)
+	require.True(t, p.IsScrolling())
+	require.Equal(t, beforeOffset, p.viewport.YOffset)
+	require.Equal(t, beforeView, p.viewport.View(),
+		"transient unknown authority must preserve the active history position")
+
+	require.NoError(t, p.ResetToNormalMode(inst, 1))
+	require.Equal(t, ScrollOwnerNone, p.ObserveScrollOwnerUnknownFor(inst, 1),
+		"an idle host owner must fail closed so stale modes cannot start new history")
+}
+
 func TestLateNormalSnapshotCannotOverrideNewerChildOwnership(t *testing.T) {
 	inst := makeShellInstance(t, "late-normal-owner", "visible-line")
 	defer func() { _ = inst.Kill() }()

--- a/ui/tab_pane.go
+++ b/ui/tab_pane.go
@@ -160,6 +160,21 @@ func (p *TabPane) SetScrollOwnerFor(instance *session.Instance, activeTab int, o
 	p.setScrollOwnerLocked(owner)
 }
 
+// ObserveScrollOwnerUnknownFor applies a transient lack of stream authority
+// without destroying an already-active AF host-history transaction. Unknown is
+// still fail-closed everywhere else, including an idle host owner, so a new
+// scroll cannot begin from stale terminal modes during a reconnect.
+func (p *TabPane) ObserveScrollOwnerUnknownFor(instance *session.Instance, activeTab int) ScrollOwner {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.dropStaleView(instance, activeTab)
+	if p.scroll.Owner() == ScrollOwnerHostHistory && p.scroll.Active() {
+		return ScrollOwnerHostHistory
+	}
+	p.setScrollOwnerLocked(ScrollOwnerNone)
+	return p.scroll.Owner()
+}
+
 // SetScrollOwnerResolvingFor starts an ownership probe for a capture-backed
 // target. Scroll intent may queue while modes are unknown; the full snapshot
 // either resolves it to HostHistory and applies it, or rejects the wrong buffer.

--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -558,6 +558,12 @@ func (w *TabbedWindow) SetScrollOwner(owner ScrollOwner) {
 	w.tab.SetScrollOwnerFor(w.effectiveInstance(), w.effectiveTab(), owner)
 }
 
+// ObserveScrollOwnerUnknown records a transient stream-authority gap. An active
+// AF history transaction remains usable; every idle pane becomes unavailable.
+func (w *TabbedWindow) ObserveScrollOwnerUnknown() ScrollOwner {
+	return w.tab.ObserveScrollOwnerUnknownFor(w.effectiveInstance(), w.effectiveTab())
+}
+
 // SetScrollOwnerResolving makes the effective capture target own the pending
 // ownership probe without inheriting the committed/previous target's decision.
 func (w *TabbedWindow) SetScrollOwnerResolving() {

--- a/ui/termpane/modes.go
+++ b/ui/termpane/modes.go
@@ -13,13 +13,31 @@ type terminalModesAuthority uint8
 const (
 	terminalModesUnknown terminalModesAuthority = iota
 	// terminalModesDisconnected retains an authoritative base only so an exact
-	// replay can continue evolving it. It is never exposed to input routing.
+	// or tail-clamped continuous replay can keep evolving it. It is never exposed
+	// to input routing.
 	terminalModesDisconnected
 	terminalModesCurrent
 	// terminalModesCursorCovered is current and permits exactly one recovery
 	// cursor re-seed immediately after the authoritative repaint that established it.
 	terminalModesCursorCovered
 )
+
+type terminalModeReplayContinuity uint8
+
+const (
+	terminalModeReplayContinuous terminalModeReplayContinuity = iota
+	terminalModeReplayMissingBytes
+)
+
+// terminalModeReplayContinuityFor classifies direction, not merely inequality.
+// Starting ahead of the requested cursor skipped bytes; starting at or behind it
+// is exact replay or the broker's harmless clamp down to its live tail.
+func terminalModeReplayContinuityFor(requestedSince, actualStart uint64) terminalModeReplayContinuity {
+	if actualStart > requestedSince {
+		return terminalModeReplayMissingBytes
+	}
+	return terminalModeReplayContinuous
+}
 
 // TerminalModes returns the most recent terminal ownership modes and whether a
 // complete authoritative base is known. Live DECSET/DECRST callbacks evolve a
@@ -34,11 +52,21 @@ func (t *TermPane) TerminalModes() (terminal.Modes, bool) {
 }
 
 // installTerminalModesLocked makes one repaint the authoritative base for every
-// ownership mode. It also covers a cursor re-seed delivered immediately after
-// that repaint (the broker's recovery ordering is repaint -> cursor -> data).
-func (t *TermPane) installTerminalModesLocked(modes terminal.Modes) {
+// ownership mode. Only explicit recovery provenance covers a cursor re-seed;
+// fresh repaints cannot predict a later eviction gap.
+func (t *TermPane) installTerminalModesLocked(
+	modes terminal.Modes,
+	coverage RepaintCursorCoverage,
+) {
 	t.terminalModes = modes
-	t.modeAuthority = terminalModesCursorCovered
+	switch coverage {
+	case RepaintCoversNoCursor:
+		t.modeAuthority = terminalModesCurrent
+	case RepaintCoversNextCursor:
+		t.modeAuthority = terminalModesCursorCovered
+	default:
+		panic("termpane: unknown repaint cursor coverage")
+	}
 }
 
 // invalidateTerminalModesLocked is the single authority-loss transition. The
@@ -49,13 +77,19 @@ func (t *TermPane) invalidateTerminalModesLocked() {
 	t.modeAuthority = terminalModesUnknown
 }
 
-// connectTerminalModesLocked makes a retained base public only when the broker
-// accepted the exact cursor. A clamp crossed bytes that may contain mode changes,
-// so it discards authority until a fresh metadata-bearing repaint arrives.
-func (t *TermPane) connectTerminalModesLocked(exactReplay bool) {
-	if !exactReplay {
+// connectTerminalModesLocked makes a retained base public after continuous
+// replay. A forward clamp crossed bytes that may contain mode changes, so it
+// discards authority until a fresh metadata-bearing repaint arrives.
+func (t *TermPane) connectTerminalModesLocked(continuity terminalModeReplayContinuity) {
+	switch continuity {
+	case terminalModeReplayMissingBytes:
 		t.invalidateTerminalModesLocked()
 		return
+	case terminalModeReplayContinuous:
+		// Retained authority can evolve through exact replay or a harmless
+		// clamp down to the broker's current tail.
+	default:
+		panic("termpane: unknown replay continuity")
 	}
 	if t.modeAuthority == terminalModesDisconnected {
 		t.modeAuthority = terminalModesCurrent

--- a/ui/termpane/modes_test.go
+++ b/ui/termpane/modes_test.go
@@ -8,6 +8,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestTerminalModeReplayContinuityClassifiesClampDirection(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		requested, start uint64
+		want             terminalModeReplayContinuity
+	}{
+		{name: "exact", requested: 10, start: 10, want: terminalModeReplayContinuous},
+		{name: "tail clamp", requested: 10, start: 8, want: terminalModeReplayContinuous},
+		{name: "forward gap", requested: 8, start: 10, want: terminalModeReplayMissingBytes},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, terminalModeReplayContinuityFor(tc.requested, tc.start))
+		})
+	}
+}
+
 func TestRepaintRestoresTerminalOwnershipModes(t *testing.T) {
 	tp, stream := newSingleStreamPane(t, 40, 8)
 	if _, known := tp.TerminalModes(); known {
@@ -126,14 +142,71 @@ func TestClampedReconnectRequiresFreshTerminalModes(t *testing.T) {
 		"a fresh authoritative repaint must restore ownership after the gap")
 }
 
-func TestCursorJumpInvalidatesModesUnlessFreshRepaintCoversIt(t *testing.T) {
+func TestClampToTailReconnectPreservesTerminalModes(t *testing.T) {
+	first := newFakeStream(0)
+	second := newFakeStream(2)
+	dialer := &queueDialer{streams: []*fakeStream{first, second}}
+	tp := New(dialer.dial, 40, 8)
+	t.Cleanup(func() { _ = tp.Close() })
+
+	child := terminal.Modes{AlternateScreen: true}
+	first.events <- Event{
+		Kind:     EventRepaint,
+		Data:     child.RestoreSequence(),
+		Modes:    child,
+		HasModes: true,
+	}
+	require.Eventually(t, func() bool {
+		got, known := tp.TerminalModes()
+		return known && got == child
+	}, 2*time.Second, 5*time.Millisecond)
+	first.feed("abc")
+	waitForRender(t, tp, 40, 8, "abc")
+
+	require.NoError(t, first.Close())
+	require.Eventually(t, func() bool {
+		_, connected := second.lastResize()
+		return connected
+	}, 2*time.Second, 5*time.Millisecond, "the pane must establish the tail-clamped reconnect")
+	got, known := tp.TerminalModes()
+	require.True(t, known,
+		"a cursor clamped backward to the broker tail did not skip retained bytes")
+	require.Equal(t, child, got)
+}
+
+func TestFreshRepaintDoesNotCoverLaterCursorJump(t *testing.T) {
 	tp, stream := newSingleStreamPane(t, 40, 8)
 	child := terminal.Modes{AlternateScreen: true}
 	stream.events <- Event{
 		Kind:     EventRepaint,
-		Data:     append(child.RestoreSequence(), []byte("\x1b[2J\x1b[Htranscript")...),
+		Data:     child.RestoreSequence(),
 		Modes:    child,
 		HasModes: true,
+	}
+	require.Eventually(t, func() bool {
+		_, known := tp.TerminalModes()
+		return known
+	}, 2*time.Second, 5*time.Millisecond)
+
+	// Unlike a recovery repaint, a fresh subscriber repaint does not describe
+	// bytes evicted later. Its first non-opening cursor jump must fail closed.
+	stream.feedCursor(99)
+	require.Eventually(t, func() bool {
+		_, known := tp.TerminalModes()
+		return !known
+	}, 2*time.Second, 5*time.Millisecond,
+		"a fresh repaint must not bless a later eviction gap")
+}
+
+func TestRecoveryRepaintCoversExactlyOneCursorJump(t *testing.T) {
+	tp, stream := newSingleStreamPane(t, 40, 8)
+	child := terminal.Modes{AlternateScreen: true}
+	stream.events <- Event{
+		Kind:           EventRepaint,
+		Data:           append(child.RestoreSequence(), []byte("\x1b[2J\x1b[Htranscript")...),
+		Modes:          child,
+		HasModes:       true,
+		CursorCoverage: RepaintCoversNextCursor,
 	}
 	require.Eventually(t, func() bool {
 		_, known := tp.TerminalModes()

--- a/ui/termpane/termpane.go
+++ b/ui/termpane/termpane.go
@@ -82,6 +82,16 @@ const (
 	EventCursor
 )
 
+// RepaintCursorCoverage says whether a mode-bearing repaint authoritatively
+// describes the next cursor jump. Zero is deliberately no coverage: fresh
+// subscriber repaints cannot bless bytes evicted later.
+type RepaintCursorCoverage uint8
+
+const (
+	RepaintCoversNoCursor RepaintCursorCoverage = iota
+	RepaintCoversNextCursor
+)
+
 // Event is one inbound stream event, selected by Kind: output bytes or a repaint
 // (Data), the authoritative size echo (Rows/Cols), or a cursor re-seed (Seq).
 type Event struct {
@@ -94,6 +104,9 @@ type Event struct {
 	// not observe in the live byte ring.
 	Modes    terminal.Modes
 	HasModes bool
+	// CursorCoverage is nonzero only for a recovery-barrier repaint that
+	// authoritatively describes its immediately following cursor re-seed.
+	CursorCoverage RepaintCursorCoverage
 	// Seq is the server's authoritative replay cursor, valid only when
 	// Kind == EventCursor.
 	Seq uint64
@@ -255,9 +268,9 @@ func (t *TermPane) run() {
 		t.connMu.Unlock()
 
 		t.gridMu.Lock()
-		// A clamped cursor crossed an unretained gap. A fresh repaint will
-		// normally follow, but the prior owner is unsafe until it does.
-		t.connectTerminalModesLocked(stream.StartSeq() == since)
+		// Direction matters: a start ahead of our request crossed an unretained
+		// gap, while a start behind it is the broker's harmless clamp to live tail.
+		t.connectTerminalModesLocked(terminalModeReplayContinuityFor(since, stream.StartSeq()))
 		t.gridMu.Unlock()
 
 		// (Re)assert our desired size so the server sizes this tab's window to us —
@@ -316,7 +329,7 @@ func (t *TermPane) readStream(stream Stream) {
 				// modes. Assign the snapshot as the authority as well: tmux can
 				// report UTF-8 encoding even when an emulator does not expose a
 				// callback for it, and all-false is meaningful.
-				t.installTerminalModesLocked(ev.Modes)
+				t.installTerminalModesLocked(ev.Modes, ev.CursorCoverage)
 			} else {
 				// A recovery repaint can jump over unretained DEC mode changes.
 				// Without snapshot metadata the old decision is no longer safe.


### PR DESCRIPTION
## Why this follow-up exists

Codex review arrived after #2267 auto-merged and posted three legitimate P2 findings. This follow-up treats them as shipped defects and closes the late-review loop for #2192.

## Structural fixes

- Reconnect continuity now has a typed direction classifier. A start cursor ahead of the request means missing bytes and invalidates mode authority; an exact start or a clamp backward to the broker tail is continuous and preserves the retained base. Inequality can no longer silently conflate opposite clamp directions.
- Cursor coverage now carries explicit recovery provenance end-to-end: broker repaint snapshot, PTY event, additive terminal-modes wire field, stream adapter, and emulator event. Fresh repaint is the zero/default state and covers no future cursor. Only the recovery barrier constructor grants one-shot coverage to the cursor it describes.
- Transient unknown ownership now has a distinct transition from authoritative owner replacement. It preserves an already-active AF host-history transaction and its viewport position, while idle panes still fail closed so stale modes cannot start a new scroll.

## Fail-first evidence

All three new regressions failed on current master before implementation:

- clamp-to-tail reconnect incorrectly made terminal modes unknown
- a fresh repaint incorrectly preserved authority across a later cursor gap
- transient unknown live modes discarded an active host-history controller

They pass after the changes. Additional conformance cases pin exact, backward, and forward replay direction; fresh versus recovery repaint provenance; single-use recovery coverage; active viewport preservation; idle fail-closed behavior; and authoritative child takeover after reconnect.

## Product boundaries

Attach remains a raw child-owned proxy and Ctrl-U is never intercepted. Detached fullscreen child-owned history still exposes no false capture-pane scroll affordance.

## Validation

- Full make test-container suite: green on the patched tree
- Race suite for agentproto, app, daemon, session, ui, and ui/termpane: green
- After the final unrelated master fast-forward: all five focused behavioral and transport cases green
- golangci-lint, gofmt, deadcode, file-length lint, go vet, and go build: green

Follow-up to #2267 and #2257. Related to #2192.