### PR TITLE
fix(api): guard every project-binding command

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -146,20 +146,34 @@ func resolveRepoIDForLookup() (string, error) {
 	return repo.ID, nil
 }
 
-// resolveRepo resolves a *config.RepoContext for commands that require a repo
-// (sessions create, tasks add). It returns fully-formed, user-facing errors so
-// callers can surface them directly without re-deriving the cause: a provided
-// `--repo` that does not resolve names the path, while an absent `--repo` whose
-// cwd is also not a repo reports that `--repo is required` (#892). Wrapping any
-// resolution failure as "--repo is required" — as the callers used to — was
-// wrong precisely when the user did pass `--repo` but pointed it at a non-repo.
+// resolveRepo is the single binding resolver for commands that can create
+// persistent project state (sessions create, tasks add, and send-prompt
+// --create). Besides resolving the repo, it enforces the shared AF-home refusal;
+// putting that invariant here keeps a new caller from remembering resolution
+// while forgetting the destructive binding guard (#1891/#2205).
+//
+// Errors are fully formed for callers to surface directly: a provided `--repo`
+// that does not resolve names the path, while an absent `--repo` whose cwd is
+// also not a repo reports that `--repo is required` (#892). Wrapping every
+// failure as "--repo is required" would be wrong when the user did provide it.
 func resolveRepo() (*config.RepoContext, error) {
+	var (
+		repo *config.RepoContext
+		err  error
+	)
 	if repoFlag != "" {
-		return repoFromFlag()
+		repo, err = repoFromFlag()
+	} else {
+		repo, err = config.CurrentRepo()
+		if err != nil {
+			return nil, fmt.Errorf("--repo is required: current directory is not a git repository: %w", err)
+		}
 	}
-	repo, err := config.CurrentRepo()
 	if err != nil {
-		return nil, fmt.Errorf("--repo is required: current directory is not a git repository: %w", err)
+		return nil, err
+	}
+	if err := guardProjectBinding(repo, repoFlag != ""); err != nil {
+		return nil, err
 	}
 	return repo, nil
 }

--- a/api/scope_test.go
+++ b/api/scope_test.go
@@ -319,6 +319,84 @@ func TestTasksAdd_RefusesCloneInsideAfHome(t *testing.T) {
 	assert.Empty(t, tasks, "no task may be created by the refused add")
 }
 
+// TestSessionsCreate_RefusesCloneInsideAfHome pins the other binding command
+// named by the shared #1891 contract. A session created from the stray clone is
+// just as invisible from the intended project as a task, so it must stop before
+// the daemon sees a create request.
+func TestSessionsCreate_RefusesCloneInsideAfHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	silenceStdio(t)
+
+	clone := filepath.Join(home, "runtime", "detail-dlq-monitor")
+	require.NoError(t, os.MkdirAll(filepath.Dir(clone), 0o755))
+	require.NoError(t, exec.Command("git", "init", clone).Run())
+	require.NoError(t, exec.Command("git", "-C", clone, "config", "user.email", "t@e.com").Run())
+	require.NoError(t, exec.Command("git", "-C", clone, "config", "user.name", "T").Run())
+	require.NoError(t, exec.Command("git", "-C", clone, "commit", "--allow-empty", "-m", "init").Run())
+	t.Chdir(clone)
+
+	prevCreate := createSessionViaDaemon
+	createSessionViaDaemon = func(req daemon.CreateSessionRequest) (*session.InstanceData, error) {
+		t.Fatalf("daemon received refused AF-home binding: %+v", req)
+		return nil, nil
+	}
+	t.Cleanup(func() { createSessionViaDaemon = prevCreate })
+	setSessionsCreateFlags(t, "stray-session", "", false, false)
+
+	err := sessionsCreateCmd.RunE(sessionsCreateCmd, nil)
+	require.Error(t, err, "a cwd-derived session binding to a clone inside af's home must be refused")
+	assert.Contains(t, err.Error(), "--repo")
+	assert.Contains(t, strings.ToLower(err.Error()), "af's home")
+}
+
+func TestSessionsSendPromptCreate_RefusesCloneInsideAfHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	resetSendPromptState(t)
+	silenceStdio(t)
+
+	clone := filepath.Join(home, "runtime", "detail-dlq-monitor")
+	require.NoError(t, os.MkdirAll(filepath.Dir(clone), 0o755))
+	require.NoError(t, exec.Command("git", "init", clone).Run())
+	t.Chdir(clone)
+
+	prevDeliver := deliverPromptViaDaemon
+	deliverPromptViaDaemon = func(req daemon.DeliverPromptRequest) (string, error) {
+		t.Fatalf("daemon received refused send-prompt --create binding: %+v", req)
+		return "", nil
+	}
+	t.Cleanup(func() { deliverPromptViaDaemon = prevDeliver })
+	sendPromptCreateFlag = true
+
+	err := sessionsSendPromptCmd.RunE(sessionsSendPromptCmd, []string{"stray-session", "hello"})
+	require.Error(t, err, "send-prompt --create must share the AF-home binding refusal")
+	assert.Contains(t, err.Error(), "--repo")
+	assert.Contains(t, strings.ToLower(err.Error()), "af's home")
+}
+
+func TestSessionsCreate_ExplicitRepoInsideAfHomeIsAllowed(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	silenceStdio(t)
+
+	clone := filepath.Join(home, "runtime", "deliberate")
+	require.NoError(t, os.MkdirAll(filepath.Dir(clone), 0o755))
+	require.NoError(t, exec.Command("git", "init", clone).Run())
+
+	called := false
+	prevCreate := createSessionViaDaemon
+	createSessionViaDaemon = func(req daemon.CreateSessionRequest) (*session.InstanceData, error) {
+		called = true
+		return &session.InstanceData{Title: req.Title}, nil
+	}
+	t.Cleanup(func() { createSessionViaDaemon = prevCreate })
+	setSessionsCreateFlags(t, "deliberate-session", clone, false, false)
+
+	require.NoError(t, sessionsCreateCmd.RunE(sessionsCreateCmd, nil), "explicit --repo must remain the escape hatch")
+	assert.True(t, called, "explicit binding did not reach the daemon")
+}
+
 // TestTasksAdd_ExplicitRepoInsideAfHomeIsAllowed pins the escape hatch: a caller
 // who names the path has STATED the binding rather than inherited it, so
 // legitimate uses stay open.

--- a/api/sessions_inplace_test.go
+++ b/api/sessions_inplace_test.go
@@ -36,14 +36,14 @@ func silenceStdio(t *testing.T) {
 // sessionsCreateCmd and restores them afterwards.
 func setSessionsCreateFlags(t *testing.T, name, repo string, here, inPlace bool) {
 	t.Helper()
-	prevName, prevPrompt, prevProgram := createNameFlag, createPromptFlag, createProgramFlag
+	prevName, prevPrompt, prevProgram, prevBackend := createNameFlag, createPromptFlag, createProgramFlag, createBackendFlag
 	prevHere, prevInPlace, prevRepo := createHereFlag, createInPlaceFlag, repoFlag
 	prevPreflight := preflightLocalSession
-	createNameFlag, createPromptFlag, createProgramFlag = name, "do the thing", ""
+	createNameFlag, createPromptFlag, createProgramFlag, createBackendFlag = name, "do the thing", "", ""
 	createHereFlag, createInPlaceFlag, repoFlag = here, inPlace, repo
 	preflightLocalSession = func(*config.Config, string) error { return nil }
 	t.Cleanup(func() {
-		createNameFlag, createPromptFlag, createProgramFlag = prevName, prevPrompt, prevProgram
+		createNameFlag, createPromptFlag, createProgramFlag, createBackendFlag = prevName, prevPrompt, prevProgram, prevBackend
 		createHereFlag, createInPlaceFlag, repoFlag = prevHere, prevInPlace, prevRepo
 		preflightLocalSession = prevPreflight
 	})

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -180,14 +180,6 @@ var tasksAddCmd = &cobra.Command{
 			return jsonError(err)
 		}
 
-		// A cwd-derived binding to a clone inside af's home is the #1891
-		// accident: it creates a parallel automation project that the intended
-		// project's view never shows. An explicit --repo states the binding and
-		// is always honored.
-		if err := guardProjectBinding(repo, repoFlag != ""); err != nil {
-			return jsonError(err)
-		}
-
 		hasCron := strings.TrimSpace(taskAddCronFlag) != ""
 		hasWatch := strings.TrimSpace(taskAddWatchCmdFlag) != ""
 		if hasCron == hasWatch {


### PR DESCRIPTION
## Outcome

- enforce the AF-home project-binding refusal at the shared `resolveRepo` chokepoint
- cover `sessions create` and the adjacent `sessions send-prompt --create` path the issue inventory omitted
- keep `tasks add` on the same invariant without a caller-specific second check
- preserve explicit `--repo` as the deliberate escape hatch

## Verified against master

#2205 is real on current master:

- `api/scope.go:206-236` defines `guardProjectBinding` for a new session or task whose cwd-derived repository lives inside AF home
- `api/tasks.go:183-189` invokes that guard after `resolveRepo`
- `api/sessions.go:275-285` resolves the repository and proceeds without invoking the guard
- `api/sessions_sendprompt.go:162-175` has the same omission when `--create` can create a session
- `api/api.go:149-165` is the shared resolver all three creation paths already use, making it the binding chokepoint

The adjacent `send-prompt --create` defect shares the same root cause, so this PR fixes both paths together instead of adding another guard each caller must remember.

## Fail-first evidence

Before the implementation:

- `TestSessionsCreate_RefusesCloneInsideAfHome` reached the daemon with a repository under `$AGENT_FACTORY_HOME/runtime`
- `TestSessionsSendPromptCreate_RefusesCloneInsideAfHome` reached `DeliverPrompt` with the same invalid binding

Both now stop before the daemon call. `TestSessionsCreate_ExplicitRepoInsideAfHomeIsAllowed` pins the explicit override, and the existing task/worktree cases continue to cover the other invariants.

## Verification

Full required gates are green against exact pushed SHA `7d1d1d098e9b4df281d600a1771bcf07e98221b3`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh` (919 Go files checked; 0 grandfathered)

Closes #2205.

— Captain Claude
