### PR TITLE
fix(attach): resolve only authoritative targets

### DIFF
--- a/app/help.go
+++ b/app/help.go
@@ -105,7 +105,7 @@ func helpStart(instance *session.Instance) helpText {
 func helpAttach(instance *session.Instance, tabIdx int) helpText {
 	agent := ""
 	if instance != nil && tabIdx == 0 {
-		agent = instance.ResolvedAgent()
+		agent = instance.ResolvedPaneAgent()
 	}
 	return helpTypeInstanceAttach{agent: agent}
 }

--- a/app/help_test.go
+++ b/app/help_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sachiniyer/agent-factory/keys"
+	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
@@ -142,8 +143,19 @@ func TestAttachedScrollHelpIsAgentSpecific(t *testing.T) {
 	}
 }
 
+type remoteHelpBackend struct{ *session.FakeBackend }
+
+func (b *remoteHelpBackend) Capabilities() session.Capabilities {
+	capabilities := b.FakeBackend.Capabilities()
+	capabilities.Workspace = session.WorkspaceRemote
+	return capabilities
+}
+
+func (b *remoteHelpBackend) Type() string { return "remote" }
+
 func TestHelpAttachOnlyNamesControlsForAgentTab(t *testing.T) {
 	instance := newStartedInstance(t, "claude-session")
+	instance.SetTmuxSession(tmux.NewTmuxSessionFromSanitizedName("af_help_claude", "claude"))
 
 	agentTab, ok := helpAttach(instance, 0).(helpTypeInstanceAttach)
 	require.True(t, ok)
@@ -158,6 +170,13 @@ func TestHelpAttachOnlyNamesControlsForAgentTab(t *testing.T) {
 	require.True(t, ok)
 	require.Empty(t, overriddenAgentTab.agent,
 		"a configured Claude slot overridden to bash must follow the resolved child, not guess from Instance.Program")
+
+	remote := newStartedInstance(t, "remote-claude")
+	remote.SetBackend(&remoteHelpBackend{FakeBackend: session.NewFakeBackend()})
+	remoteAgentTab, ok := helpAttach(remote, 0).(helpTypeInstanceAttach)
+	require.True(t, ok)
+	require.Empty(t, remoteAgentTab.agent,
+		"a remote tab with no local resolved command must not guess controls from Instance.Program")
 }
 
 func TestGeneralHelpSeparatesPreviewAndAttachedScrolling(t *testing.T) {

--- a/daemon/manager_sessions.go
+++ b/daemon/manager_sessions.go
@@ -338,28 +338,56 @@ func (m *Manager) agentServerForStream(idOrTitle, repoID string) (session.AgentS
 // stream can attach to. Both the stable-id and repo-scoped title paths consult
 // the daemon's already-restored map directly: Preview is a repaint hot path, so
 // re-scanning every persisted session before each capture makes its latency grow
-// with the whole session history. A miss still falls through to findSession,
-// preserving the disk restore and unscoped-title ambiguity checks for callers
-// that genuinely address an untracked session.
+// with the whole session history. A miss enters findSessionByStableID, whose one
+// refresh transaction scans the stable-id namespace BEFORE interpreting the
+// opaque value as a title; an earlier restore may have skipped a row that is now
+// recoverable (#2187). Only that post-refresh ID miss reaches the existing title
+// and ambiguity paths.
 func (m *Manager) resolveStreamSession(idOrTitle, repoID string) (*session.Instance, string, string, error) {
 	m.mu.Lock()
-	for key, instance := range m.instances {
-		if instance != nil && instance.ID != "" && instance.ID == idOrTitle {
-			rid, _ := splitDaemonInstanceKey(key)
-			title := instance.Title
-			m.mu.Unlock()
-			return instance, rid, title, nil
-		}
+	if instance, rid, title := m.trackedStreamSessionLocked(idOrTitle, repoID); instance != nil {
+		m.mu.Unlock()
+		return instance, rid, title, nil
+	}
+	m.mu.Unlock()
+	instance, resolvedRepoID, _, err := m.findSessionByStableID(idOrTitle, idOrTitle, repoID)
+	if instance == nil {
+		return nil, resolvedRepoID, idOrTitle, err
+	}
+	return instance, resolvedRepoID, instance.Title, err
+}
+
+// trackedStreamSessionLocked resolves only facts already materialized in
+// m.instances, with stable identity taking precedence over the legacy title
+// namespace. The caller holds m.mu. Keeping both the hot-path scan and the
+// post-refresh retry in this one helper prevents their precedence rules from
+// drifting apart.
+func (m *Manager) trackedStreamSessionLocked(idOrTitle, repoID string) (*session.Instance, string, string) {
+	if instance, rid := m.trackedSessionByIDLocked(idOrTitle); instance != nil {
+		return instance, rid, instance.Title
 	}
 	if repoID != "" {
 		if instance := m.instances[daemonInstanceKey(repoID, idOrTitle)]; instance != nil {
-			m.mu.Unlock()
-			return instance, repoID, instance.Title, nil
+			return instance, repoID, instance.Title
 		}
 	}
-	m.mu.Unlock()
-	instance, resolvedRepoID, _, err := m.findSession(idOrTitle, repoID)
-	return instance, resolvedRepoID, idOrTitle, err
+	return nil, "", ""
+}
+
+// trackedSessionByIDLocked resolves one stable identity in the materialized
+// instance map. The caller holds m.mu. Stream hot-path lookup and post-refresh
+// lookup share it so the stable namespace cannot drift between the two phases.
+func (m *Manager) trackedSessionByIDLocked(id string) (*session.Instance, string) {
+	if id == "" {
+		return nil, ""
+	}
+	for key, instance := range m.instances {
+		if instance != nil && instance.ID == id {
+			rid, _ := splitDaemonInstanceKey(key)
+			return instance, rid
+		}
+	}
+	return nil, ""
 }
 
 // resolveActionSession resolves a write-action target (kill/archive/send-prompt)
@@ -416,6 +444,16 @@ func (m *Manager) resolveActionSession(id, title, repoID string) (*session.Insta
 }
 
 func (m *Manager) findSession(title, repoID string) (*session.Instance, string, *session.InstanceData, error) {
+	return m.findSessionByStableID("", title, repoID)
+}
+
+// findSessionByStableID performs findSession's refresh exactly once, then gives
+// stableID first refusal on the refreshed map before any title lookup. Passing an
+// empty stableID preserves findSession's title-only behavior. The stream route
+// passes the same opaque segment as both values because it supports stable IDs and
+// legacy titles on one endpoint; this ordering is what prevents a newly-restored
+// ID from being reinterpreted as somebody else's title (#2187).
+func (m *Manager) findSessionByStableID(stableID, title, repoID string) (*session.Instance, string, *session.InstanceData, error) {
 	if title == "" {
 		return nil, "", nil, fmt.Errorf("session title is required")
 	}
@@ -424,6 +462,10 @@ func (m *Manager) findSession(title, repoID string) (*session.Instance, string, 
 	if err := m.refreshLocked(); err != nil {
 		m.mu.Unlock()
 		return nil, "", nil, err
+	}
+	if instance, rid := m.trackedSessionByIDLocked(stableID); instance != nil {
+		m.mu.Unlock()
+		return instance, rid, nil, nil
 	}
 	if repoID != "" {
 		key := daemonInstanceKey(repoID, title)

--- a/daemon/manager_sessions.go
+++ b/daemon/manager_sessions.go
@@ -298,14 +298,12 @@ func promptTargetLivenessError(title string, liveness session.Liveness) error {
 }
 
 // agentServerForStream resolves the /v1/sessions/{id}/stream target to its cached
-// agent-server for the WS PTY broker (#1592 Phase 2 PR5). The {id} segment is
-// resolved by the session's STABLE id first, then by title (with optional repoID)
-// as a fallback. The TUI/apiclient pass a title there (no id match → title path,
-// behavior unchanged); the browser web client (Phase 5 PR4) passes the
-// globally-unique session id, which sidesteps the rail's cross-repo title
-// collision — a title alone can name two sessions in two repos, an id names
-// exactly one. Both paths return the tracked instance's cached agent-server
-// singleton whose ring buffer/subscribers persist.
+// agent-server for the WS PTY broker (#1592 Phase 2 PR5). The route multiplexes
+// two authoritative request shapes: TUI/CLI send {title}+repo_id, while Web sends
+// a globally unique stable id with no repo_id. Presence of repo_id selects the
+// title namespace; only the unscoped shape tries stable identity first. Both
+// return the tracked instance's cached agent-server singleton whose ring
+// buffer/subscribers persist.
 func (m *Manager) agentServerForStream(idOrTitle, repoID string) (session.AgentServer, *session.Instance, error) {
 	instance, resolvedRepoID, title, err := m.resolveStreamSession(idOrTitle, repoID)
 	if err != nil {
@@ -330,46 +328,60 @@ func (m *Manager) agentServerForStream(idOrTitle, repoID string) (session.AgentS
 	return instance.AgentServer(), instance, nil
 }
 
-// resolveStreamSession resolves a stream target by the session's stable id first
-// (the web client's key), else by title (the TUI's key, with optional repoID). It
-// returns the instance, its resolved repoID, and its title — the last so the
-// killsInFlight gate keys off the real title even when the caller addressed the
-// session by id. The id scan only sees in-memory (live) instances, which is all a
-// stream can attach to. Both the stable-id and repo-scoped title paths consult
-// the daemon's already-restored map directly: Preview is a repaint hot path, so
-// re-scanning every persisted session before each capture makes its latency grow
-// with the whole session history. A miss enters findSessionByStableID, whose one
-// refresh transaction scans the stable-id namespace BEFORE interpreting the
-// opaque value as a title; an earlier restore may have skipped a row that is now
-// recoverable (#2187). Only that post-refresh ID miss reaches the existing title
-// and ambiguity paths.
+// resolveStreamSession returns the instance, its resolved repoID, and its title —
+// the last so the killsInFlight gate keys off the real title even when Web used a
+// stable id. Both request shapes consult the daemon's already-restored map
+// directly: Preview is a repaint hot path, so re-scanning every persisted session
+// before each capture makes its latency grow with the whole session history. A
+// miss refreshes exactly once, using the SAME streamTarget authority in both
+// phases: repo-scoped title lookup never detours through the global ID namespace,
+// while an unscoped Web ID gets first refusal after refresh before legacy title
+// fallback (#2187/#2279 review).
 func (m *Manager) resolveStreamSession(idOrTitle, repoID string) (*session.Instance, string, string, error) {
+	target := authoritativeStreamTarget(idOrTitle, repoID)
 	m.mu.Lock()
-	if instance, rid, title := m.trackedStreamSessionLocked(idOrTitle, repoID); instance != nil {
+	if instance, rid, title := m.trackedStreamSessionLocked(target); instance != nil {
 		m.mu.Unlock()
 		return instance, rid, title, nil
 	}
 	m.mu.Unlock()
-	instance, resolvedRepoID, _, err := m.findSessionByStableID(idOrTitle, idOrTitle, repoID)
+	instance, resolvedRepoID, _, err := m.findSessionByStableID(target.stableID, target.title, target.repoID)
 	if instance == nil {
-		return nil, resolvedRepoID, idOrTitle, err
+		return nil, resolvedRepoID, target.title, err
 	}
 	return instance, resolvedRepoID, instance.Title, err
 }
 
-// trackedStreamSessionLocked resolves only facts already materialized in
-// m.instances, with stable identity taking precedence over the legacy title
-// namespace. The caller holds m.mu. Keeping both the hot-path scan and the
-// post-refresh retry in this one helper prevents their precedence rules from
-// drifting apart.
-func (m *Manager) trackedStreamSessionLocked(idOrTitle, repoID string) (*session.Instance, string, string) {
-	if instance, rid := m.trackedSessionByIDLocked(idOrTitle); instance != nil {
-		return instance, rid, instance.Title
+// streamTarget makes the route's two authority shapes mutually exclusive. A
+// scoped target can carry only {repo,title}; an unscoped target may carry the
+// stable-id interpretation of the same opaque segment. No resolver phase can
+// accidentally give a foreign global ID precedence over an explicit repo scope.
+type streamTarget struct {
+	stableID string
+	title    string
+	repoID   string
+}
+
+func authoritativeStreamTarget(idOrTitle, repoID string) streamTarget {
+	target := streamTarget{title: idOrTitle, repoID: repoID}
+	if repoID == "" {
+		target.stableID = idOrTitle
 	}
-	if repoID != "" {
-		if instance := m.instances[daemonInstanceKey(repoID, idOrTitle)]; instance != nil {
-			return instance, repoID, instance.Title
+	return target
+}
+
+// trackedStreamSessionLocked resolves only facts already materialized in
+// m.instances. The caller holds m.mu. The streamTarget, rather than this helper,
+// decides the namespace so the hot path and post-refresh path cannot drift.
+func (m *Manager) trackedStreamSessionLocked(target streamTarget) (*session.Instance, string, string) {
+	if target.repoID != "" {
+		if instance := m.instances[daemonInstanceKey(target.repoID, target.title)]; instance != nil {
+			return instance, target.repoID, instance.Title
 		}
+		return nil, "", ""
+	}
+	if instance, rid := m.trackedSessionByIDLocked(target.stableID); instance != nil {
+		return instance, rid, instance.Title
 	}
 	return nil, "", ""
 }
@@ -405,12 +417,12 @@ func (m *Manager) trackedSessionByIDLocked(id string) (*session.Instance, string
 // this fix closes, just re-entered through a stale id. Erroring keeps a stale id
 // from ever silently retargeting; the id-less title path stays for legacy/CLI.
 //
-// It mirrors the stream path's id-first scan (resolveStreamSession): the id scan
-// sees only in-memory (live) instances — all a client's rail ever shows. It returns
-// the resolved instance, its repoID, its canonical title, its stable id, and (for
-// the title path) its on-disk data — so the caller keys teardown, storage, AND the
-// lifecycle event off the session actually resolved, never the request's own
-// (possibly stale) id/title.
+// Its ID-addressed arm mirrors the unscoped Web stream shape; repo-scoped stream
+// callers deliberately take the title arm instead. It returns the resolved
+// instance, its repoID, its canonical title, its stable id, and (for the title
+// path) its on-disk data — so the caller keys teardown, storage, AND the lifecycle
+// event off the session actually resolved, never the request's own (possibly
+// stale) id/title.
 func (m *Manager) resolveActionSession(id, title, repoID string) (*session.Instance, string, string, string, *session.InstanceData, error) {
 	if id != "" {
 		m.mu.Lock()
@@ -450,9 +462,10 @@ func (m *Manager) findSession(title, repoID string) (*session.Instance, string, 
 // findSessionByStableID performs findSession's refresh exactly once, then gives
 // stableID first refusal on the refreshed map before any title lookup. Passing an
 // empty stableID preserves findSession's title-only behavior. The stream route
-// passes the same opaque segment as both values because it supports stable IDs and
-// legacy titles on one endpoint; this ordering is what prevents a newly-restored
-// ID from being reinterpreted as somebody else's title (#2187).
+// supplies stableID only for its unscoped shape; this both prevents a newly
+// restored Web ID from being reinterpreted as somebody else's title (#2187) and
+// prevents a scoped TUI title from being reinterpreted as a foreign ID (#2279
+// review).
 func (m *Manager) findSessionByStableID(stableID, title, repoID string) (*session.Instance, string, *session.InstanceData, error) {
 	if title == "" {
 		return nil, "", nil, fmt.Errorf("session title is required")

--- a/daemon/stream_id_resolution_test.go
+++ b/daemon/stream_id_resolution_test.go
@@ -162,6 +162,109 @@ func TestResolveStreamSessionIDBeatsCrossRepoTitleCollision(t *testing.T) {
 	}
 }
 
+// TestResolveStreamSessionRepoScopedTitleBeatsForeignStableID pins the other
+// authoritative request shape: repo_id means the opaque segment is a title in
+// that repo, even when another repo happens to use the same bytes as its stable
+// ID. The hot path must never jump namespaces before checking the scoped target.
+func TestResolveStreamSessionRepoScopedTitleBeatsForeignStableID(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	repoA := setupControlRepo(t)
+	repoB := setupControlRepo(t)
+	ra, err := config.RepoFromPath(repoA)
+	if err != nil {
+		t.Fatalf("RepoFromPath A: %v", err)
+	}
+	rb, err := config.RepoFromPath(repoB)
+	if err != nil {
+		t.Fatalf("RepoFromPath B: %v", err)
+	}
+
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	const target = "scoped-title"
+	scoped, _ := newCountingInstance(t, target, repoA)
+	scoped.ID = "scoped-instance-id"
+	foreign, _ := newCountingInstance(t, "foreign", repoB)
+	foreign.ID = target
+	manager.mu.Lock()
+	manager.instances[daemonInstanceKey(ra.ID, target)] = scoped
+	manager.instances[daemonInstanceKey(rb.ID, foreign.Title)] = foreign
+	manager.mu.Unlock()
+
+	got, rid, title, err := manager.resolveStreamSession(target, ra.ID)
+	if err != nil {
+		t.Fatalf("resolve repo-scoped stream target: %v", err)
+	}
+	if got != scoped || rid != ra.ID || title != target {
+		t.Fatalf("repo-scoped target = (%p, %q, %q), want (%p, %q, %q); foreign stable ID won",
+			got, rid, title, scoped, ra.ID, target)
+	}
+}
+
+// TestResolveStreamSessionRepoScopedTitleBeatsForeignStableIDAfterRefresh pins
+// the same authority after a cache miss. Fixing only trackedStreamSessionLocked
+// still lets findSessionByStableID invert the target once refresh materializes
+// the foreign row, which was the review finding.
+func TestResolveStreamSessionRepoScopedTitleBeatsForeignStableIDAfterRefresh(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	repoA := setupControlRepo(t)
+	repoB := setupControlRepo(t)
+	ra, err := config.RepoFromPath(repoA)
+	if err != nil {
+		t.Fatalf("RepoFromPath A: %v", err)
+	}
+	rb, err := config.RepoFromPath(repoB)
+	if err != nil {
+		t.Fatalf("RepoFromPath B: %v", err)
+	}
+	const target = "refreshed-scoped-title"
+	rows := map[string]session.InstanceData{
+		ra.ID: {ID: "scoped-instance-id", Title: target, Path: repoA, Status: session.Running},
+		rb.ID: {ID: target, Title: "foreign", Path: repoB, Status: session.Running},
+	}
+	for rid, data := range rows {
+		raw, marshalErr := json.Marshal([]session.InstanceData{data})
+		if marshalErr != nil {
+			t.Fatalf("marshal %s: %v", rid, marshalErr)
+		}
+		if saveErr := config.LoadState().SaveInstances(rid, raw); saveErr != nil {
+			t.Fatalf("save %s: %v", rid, saveErr)
+		}
+	}
+
+	scoped, _ := newCountingInstance(t, target, repoA)
+	scoped.ID = rows[ra.ID].ID
+	foreign, _ := newCountingInstance(t, "foreign", repoB)
+	foreign.ID = rows[rb.ID].ID
+	prev := fromInstanceDataForRefresh
+	fromInstanceDataForRefresh = func(data session.InstanceData) (*session.Instance, error) {
+		switch data.ID {
+		case scoped.ID:
+			return scoped, nil
+		case foreign.ID:
+			return foreign, nil
+		default:
+			return nil, errors.New("unexpected persisted row")
+		}
+	}
+	t.Cleanup(func() { fromInstanceDataForRefresh = prev })
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	got, rid, title, err := manager.resolveStreamSession(target, ra.ID)
+	if err != nil {
+		t.Fatalf("resolve refreshed repo-scoped stream target: %v", err)
+	}
+	if got != scoped || rid != ra.ID || title != target {
+		t.Fatalf("refreshed repo-scoped target = (%p, %q, %q), want (%p, %q, %q); foreign stable ID won",
+			got, rid, title, scoped, ra.ID, target)
+	}
+}
+
 // TestResolveStreamSessionTrackedTitleSkipsDiskRefresh pins the TUI hot path: a
 // repo-scoped title already restored in the daemon resolves from m.instances
 // without walking persisted session history before every preview capture.

--- a/daemon/stream_id_resolution_test.go
+++ b/daemon/stream_id_resolution_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"encoding/json"
 	"errors"
 	"sync/atomic"
 	"testing"
@@ -51,6 +52,68 @@ func TestResolveStreamSessionByID(t *testing.T) {
 	}
 	if title != "worker" {
 		t.Fatalf("resolved title = %q, want %q (killsInFlight gate keys off title)", title, "worker")
+	}
+}
+
+// TestResolveStreamSessionByIDRehydratesOnMiss is the #2187 fail-first. A
+// stable-id request can arrive after an earlier refresh skipped a persisted row
+// and before the next poll. The resolver must refresh and scan the stable-id
+// namespace again before it reinterprets that opaque id as a title.
+func TestResolveStreamSessionByIDRehydratesOnMiss(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	const stableID = "id-restorable-worker"
+	const decoyID = "id-title-decoy"
+	seeded, err := json.Marshal([]session.InstanceData{
+		{ID: stableID, Title: "worker", Path: repoPath, Status: session.Running},
+		// The opaque stable ID is also a different row's title. After refresh,
+		// stable identity must win before title fallback is even considered.
+		{ID: decoyID, Title: stableID, Path: repoPath, Status: session.Running},
+	})
+	if err != nil {
+		t.Fatalf("marshal seed: %v", err)
+	}
+	if err := config.LoadState().SaveInstances(repo.ID, seeded); err != nil {
+		t.Fatalf("seed disk: %v", err)
+	}
+
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	canonical, _ := newCountingInstance(t, "worker", repoPath)
+	canonical.ID = stableID
+	decoy, _ := newCountingInstance(t, stableID, repoPath)
+	decoy.ID = decoyID
+	var diskBuilds atomic.Int32
+	prev := fromInstanceDataForRefresh
+	fromInstanceDataForRefresh = func(data session.InstanceData) (*session.Instance, error) {
+		diskBuilds.Add(1)
+		switch data.ID {
+		case stableID:
+			return canonical, nil
+		case decoyID:
+			return decoy, nil
+		default:
+			return nil, errors.New("unexpected persisted row")
+		}
+	}
+	t.Cleanup(func() { fromInstanceDataForRefresh = prev })
+
+	got, rid, title, err := manager.resolveStreamSession(stableID, "")
+	if err != nil {
+		t.Fatalf("resolveStreamSession after rehydration: %v", err)
+	}
+	if got != canonical || rid != repo.ID || title != "worker" {
+		t.Fatalf("rehydrated stable-id target = (%p, %q, %q), want (%p, %q, %q)",
+			got, rid, title, canonical, repo.ID, "worker")
+	}
+	if builds := diskBuilds.Load(); builds != 2 {
+		t.Fatalf("stable-id miss materialized %d persisted rows, want one refresh of both rows", builds)
 	}
 }
 

--- a/session/instance_accessors.go
+++ b/session/instance_accessors.go
@@ -275,6 +275,23 @@ func (i *Instance) ResolvedAgent() string {
 	return tmux.DetectAgentFromCommand(i.Program)
 }
 
+// ResolvedPaneAgent returns the canonical agent proven by this instance's
+// concrete local tmux binding, or "" when there is no such binding or its
+// command names no known agent. Unlike ResolvedAgent it deliberately never
+// falls back to Instance.Program: callers describing an already-attached pane
+// must not invent agent-specific behavior for remote tabs, whose real command
+// was resolved inside the sandbox and is not represented by a local tmux
+// session (#2210).
+func (i *Instance) ResolvedPaneAgent() string {
+	i.mu.RLock()
+	ts := i.tmuxLocked()
+	i.mu.RUnlock()
+	if ts == nil || strings.TrimSpace(ts.Program()) == "" {
+		return ""
+	}
+	return tmux.DetectAgentFromCommand(ts.Program())
+}
+
 // SetTmuxSession sets the agent tab's tmux session for testing purposes,
 // materializing the single Agent tab if needed.
 func (i *Instance) SetTmuxSession(session *tmux.TmuxSession) {


### PR DESCRIPTION
## Summary

Group the P2 findings from #2187 and #2210 under one rule: attachment may use only an authoritative runtime target, never a convenient fallback that guesses identity.

- A stream miss now performs one refresh transaction and rescans the stable-ID namespace before the opaque path segment can be interpreted as a title. The hot path still reads the tracked map without a disk scan.
- The initial and post-refresh stable-ID lookups share one helper, and the regression includes a different row whose title equals the requested stable ID; the ID wins.
- Attached help derives agent-specific controls only from the concrete local tmux command. Remote agent-server tabs have no local command, so they receive generic controls instead of guessing from the configured `Instance.Program` slot.

## Findings

- #2187 `daemon/manager_sessions.go`: real. A transient restore failure could make a valid browser reconnect 404 until an unrelated poll. Fixed with refresh-then-ID-before-title resolution.
- #2210 `app/help.go`: real. Remote overrides resolve inside the sandbox, so the daemon-side configured name is not evidence of the attached child. Fixed by separating pane-proven agent resolution from the broader readiness resolver.

## Verification

Full gates run after the final commit on pushed head `3a0df00f`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh` (919 Go files checked; 0 grandfathered)

Focused fail-first coverage pins stable-ID rehydration/precedence and suppresses guessed remote agent controls.

— Captain Claude
