### PR TITLE
refactor(commands): remove auto-update test shims

### DIFF
--- a/commands/autoupdate.go
+++ b/commands/autoupdate.go
@@ -13,11 +13,6 @@ import (
 	"github.com/sachiniyer/agent-factory/log"
 )
 
-const (
-	lastCheckFile = autoupdate.CheckCacheFileName
-	autoUpdateEnv = autoupdate.EnvironmentVariable
-)
-
 // Timeouts differ by who is waiting. The launch check runs synchronously in
 // front of the TUI, so it is bounded hard enough that a black-holed network
 // costs a blink rather than a stall; `af upgrade` was asked for explicitly
@@ -291,25 +286,8 @@ func withUpdateCheckLock(fn func(cache *updateCheckCache, now time.Time) error) 
 	return nil
 }
 
-func readUpdateCheckCache(path string) *updateCheckCache {
-	return autoupdate.ReadCheckCache(path)
-}
-
-func shouldCheck(channel string) bool {
-	path := lastCheckPath()
-	if path == "" {
-		return true
-	}
-	cache := readUpdateCheckCache(path)
-	return updateCheckDue(cache, normalizeUpdateChannel(channel), strings.TrimPrefix(version, "v"), time.Now().UTC())
-}
-
 func updateCheckDue(cache *updateCheckCache, channel, currentVersion string, now time.Time) bool {
 	return cache.Due(channel, currentVersion, now)
-}
-
-func recordCheck(channel, lastSeenTag, currentVersion string) {
-	_ = autoupdate.RecordCheck(lastCheckPath(), channel, lastSeenTag, currentVersion)
 }
 
 func recordCheckLocked(cache *updateCheckCache, channel, lastSeenTag, currentVersion string, now time.Time) error {

--- a/commands/autoupdate_test.go
+++ b/commands/autoupdate_test.go
@@ -16,8 +16,14 @@ import (
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/internal/autoupdate"
 	"github.com/sachiniyer/agent-factory/internal/testguard"
 	aflog "github.com/sachiniyer/agent-factory/log"
+)
+
+const (
+	lastCheckFile = autoupdate.CheckCacheFileName
+	autoUpdateEnv = autoupdate.EnvironmentVariable
 )
 
 // captureLogs redirects InfoLog and ErrorLog to in-memory buffers for the
@@ -70,6 +76,21 @@ func TestMain(m *testing.M) {
 // autoUpdateOnLaunch instead.
 func runAutoUpdate() (string, error) {
 	return autoUpdateForChannel(config.UpdateChannelStable, autoUpdateCheckTimeout, autoUpdateDownloadBudget)
+}
+
+func updateCheckDueForTest(channel string) bool {
+	return autoupdate.ReadCheckCache(autoupdate.CheckCachePath()).Due(
+		channel,
+		strings.TrimPrefix(version, "v"),
+		time.Now().UTC(),
+	)
+}
+
+func recordCheckForTest(t *testing.T, channel, lastSeenTag, currentVersion string) {
+	t.Helper()
+	if err := autoupdate.RecordCheck(autoupdate.CheckCachePath(), channel, lastSeenTag, currentVersion); err != nil {
+		t.Fatalf("record update check: %v", err)
+	}
 }
 
 // withTestHome points config.GetConfigDir at a temp dir for the duration of
@@ -141,13 +162,13 @@ func TestAutoUpdateWindowsRecordsCheckWhenUpdateAvailable(t *testing.T) {
 	if fetchCalls != 0 {
 		t.Fatalf("fetchLatestReleaseTagFn called %d times on Windows; expected 0 (network must be skipped before the GitHub check)", fetchCalls)
 	}
-	// last_update_check must exist so shouldCheck() returns false.
+	// last_update_check must exist and close the throttle window.
 	if _, err := os.Stat(filepath.Join(dir, lastCheckFile)); err != nil {
 		t.Fatalf("expected %s to be written after Windows early-return, got: %v",
 			lastCheckFile, err)
 	}
-	if shouldCheck(config.UpdateChannelStable) {
-		t.Fatalf("shouldCheck() returned true after recordCheck(); throttle is broken")
+	if updateCheckDueForTest(config.UpdateChannelStable) {
+		t.Fatalf("update check is still due after the Windows decision was recorded; throttle is broken")
 	}
 	// Windows skips the actual update, so the misleading "updating from X to Y"
 	// line must not appear in any log stream (issue #519).
@@ -286,8 +307,8 @@ func TestAutoUpdateRecordsCheckOnFetchFailure(t *testing.T) {
 		t.Fatalf("expected %s to be written after fetch failure, got: %v",
 			lastCheckFile, err)
 	}
-	if shouldCheck(config.UpdateChannelStable) {
-		t.Fatalf("shouldCheck() returned true after a failed check; failures must close the throttle window so a broken network can't re-check on every launch (#459)")
+	if updateCheckDueForTest(config.UpdateChannelStable) {
+		t.Fatalf("update check is still due after a failed check; failures must close the throttle window so a broken network can't re-check on every launch (#459)")
 	}
 }
 
@@ -324,8 +345,8 @@ func TestAutoUpdateRecordsCheckOnDownloadFailure(t *testing.T) {
 		t.Fatalf("expected %s to be written after download failure, got: %v",
 			lastCheckFile, err)
 	}
-	if shouldCheck(config.UpdateChannelStable) {
-		t.Fatalf("shouldCheck() returned true after a failed download; failures must close the throttle window (#459)")
+	if updateCheckDueForTest(config.UpdateChannelStable) {
+		t.Fatalf("update check is still due after a failed download; failures must close the throttle window (#459)")
 	}
 }
 
@@ -847,11 +868,11 @@ func TestAutoUpdateThrottleIsChannelAware(t *testing.T) {
 	t.Cleanup(func() { version = prevVersion })
 	version = "1.0.0"
 
-	recordCheck(config.UpdateChannelStable, "v1.0.0", "1.0.0")
-	if shouldCheck(config.UpdateChannelStable) {
+	recordCheckForTest(t, config.UpdateChannelStable, "v1.0.0", "1.0.0")
+	if updateCheckDueForTest(config.UpdateChannelStable) {
 		t.Fatalf("stable channel should be throttled by its own fresh record")
 	}
-	if !shouldCheck(config.UpdateChannelPreview) {
+	if !updateCheckDueForTest(config.UpdateChannelPreview) {
 		t.Fatalf("preview channel must not be throttled by a stable-channel record")
 	}
 }
@@ -870,7 +891,7 @@ func TestAutoUpdatePreviewCheckRunsAfterStableThrottleRecord(t *testing.T) {
 
 	runtimeGOOS = "linux"
 	version = "1.0.0"
-	recordCheck(config.UpdateChannelStable, "v1.0.0", "1.0.0")
+	recordCheckForTest(t, config.UpdateChannelStable, "v1.0.0", "1.0.0")
 
 	var gotChannel string
 	fetchLatestReleaseTagFn = func(channel string, _ time.Duration) (string, error) {
@@ -893,16 +914,16 @@ func TestAutoUpdateChannelSwitchRechecksImmediately(t *testing.T) {
 	t.Cleanup(func() { version = prevVersion })
 	version = "1.0.0"
 
-	recordCheck(config.UpdateChannelPreview, "v1.0.1-preview-1", "1.0.0")
-	if shouldCheck(config.UpdateChannelPreview) {
+	recordCheckForTest(t, config.UpdateChannelPreview, "v1.0.1-preview-1", "1.0.0")
+	if updateCheckDueForTest(config.UpdateChannelPreview) {
 		t.Fatalf("preview channel should be throttled by its own fresh record")
 	}
 
-	recordCheck(config.UpdateChannelStable, "v1.0.0", "1.0.0")
-	if shouldCheck(config.UpdateChannelStable) {
+	recordCheckForTest(t, config.UpdateChannelStable, "v1.0.0", "1.0.0")
+	if updateCheckDueForTest(config.UpdateChannelStable) {
 		t.Fatalf("stable channel should be throttled after recording a stable check")
 	}
-	if !shouldCheck(config.UpdateChannelPreview) {
+	if !updateCheckDueForTest(config.UpdateChannelPreview) {
 		t.Fatalf("switching back to preview must re-check immediately, not reuse the older preview record")
 	}
 }


### PR DESCRIPTION
## What changed

- Removed auto-update cache/settings aliases and read/record/query helpers from `commands` that were used only by command tests after the shared `internal/autoupdate` extraction.
- Pointed the command tests at the owning `internal/autoupdate` API through test-only setup/assertion helpers.
- Made test cache seeding fail on write errors instead of silently discarding them.

## Why this is simpler

The #2215 extraction moved cache and settings ownership into `internal/autoupdate`, but the production command package retained a shadow surface solely to preserve old test names. This removes that post-migration layer: runtime orchestration stays in `commands`, while cache behavior has one owner.

## Behavior preservation

No runtime path referenced the deleted helpers or aliases. The tests now invoke the same `autoupdate.CheckCachePath`, `ReadCheckCache`, `CheckCache.Due`, and `RecordCheck` functions that those helpers forwarded to. The cache filename, environment variable, disk format, throttling decisions, and update flow are unchanged.

## Validation

- `make test-container GOTESTARGS='./commands'`
- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (empty)
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh` (919 files, 0 grandfathered)

Refs #1241.
Relates to #1195.
Follow-up to #2215.

— Captain Claude