### PR TITLE
docs: align maintainer skills with safe PR gates

### DIFF
--- a/.claude/skills/create-pr.md
+++ b/.claude/skills/create-pr.md
@@ -12,9 +12,12 @@ Create a PR for the current branch against `master`.
 
 1. **Pre-flight checks** — before creating the PR, run these and fix any issues:
    ```bash
-   gofmt -l .          # fix any unformatted files with: gofmt -w <file>
-   go build ./...      # ensure compilation succeeds
-   go test ./...       # ensure all tests pass
+   golangci-lint run --timeout=3m --fast
+   gofmt -l .                    # fix any output with: gofmt -w <file>
+   go build ./...
+   make test-container           # never run bare go test ./... on a shared host
+   deadcode -test ./...
+   scripts/lint-file-length.sh
    ```
 
 2. **Review changes** — examine the diff against master:
@@ -37,8 +40,12 @@ Create a PR for the current branch against `master`.
 
    ## Test Plan
 
-   - [x] `go test ./...` passes
-   - [x] `gofmt` applied to changed files
+   - [x] `golangci-lint run --timeout=3m --fast` passes
+   - [x] `gofmt -l .` produces no output
+   - [x] `go build ./...` passes
+   - [x] `make test-container` passes
+   - [x] `deadcode -test ./...` produces no output
+   - [x] `scripts/lint-file-length.sh` passes
    - [ ] Manually tested in TUI (if applicable)
    EOF
    )"

--- a/.claude/skills/decompose-file.md
+++ b/.claude/skills/decompose-file.md
@@ -44,10 +44,12 @@ merges before the next file begins.
 6. **Run the gates**:
    ```bash
    gofmt -w <changed-go-files>
+   golangci-lint run --timeout=3m --fast
+   gofmt -l .
    go build ./...
    make test-container
-   scripts/lint-file-length.sh
    deadcode -test ./...
+   scripts/lint-file-length.sh
    ```
 
    If the change is TUI-visible, also play-test the affected flow before

--- a/.claude/skills/dispatch-af-session.md
+++ b/.claude/skills/dispatch-af-session.md
@@ -22,8 +22,11 @@ Captain Claude contract. Root verifies and merges; worker sessions do not.
    Do NOT merge. Root verifies the PR.
 
    Gates:
+   - golangci-lint run --timeout=3m --fast
+   - gofmt -l .
    - go build ./...
    - make test-container
+   - deadcode -test ./...
    - scripts/lint-file-length.sh
    - <any task-specific gate>
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,9 +60,10 @@ Working style:
   accumulate.
 - Never run `pkill tmux`/`pkill af` or bare `tmux kill-server` on a shared host; tmux teardown must name an isolated socket with `-L` or `-S`.
 - Run `golangci-lint run --timeout=3m --fast`, `gofmt -l .`, `go build ./...`,
-  and the full test suite before opening a PR — CI blocks on all four. On a
-  shared dev box run the suite as `make test-container` (never bare
-  `go test ./...` on the host; see docs/container-testing.md).
+  `make test-container`, `deadcode -test ./...`, and
+  `scripts/lint-file-length.sh` before opening a PR — CI blocks on all six. On
+  a shared dev box, never run bare `go test ./...` on the host; see
+  docs/container-testing.md.
 - Captain Claude is fully autonomous: ship without waiting for greenlight,
   merge own PRs after CI green, close issues that aren't worth doing. The
   audit trail is in PR descriptions and issue close-out comments, not
@@ -105,7 +106,7 @@ gofmt -w .
 ## Lint
 
 ```bash
-# Must pass before PR merge
+# Must pass before opening a PR
 golangci-lint run --timeout=3m --fast
 gofmt -l .   # should produce no output
 deadcode -test ./...   # should produce no output
@@ -147,7 +148,7 @@ new files to dodge the limit — split them. See `docs/file-length-lint.md`.
 - All Go files must be `gofmt`-formatted
 - PRs target `master` branch
 - Keep PRs focused and small
-- Run `go build ./...` and `go test ./...` before submitting
+- Run the full gate suite above before submitting
 - Version is stored in `main.go` (`version` var) and auto-bumped by CI
 
 ## Copy & glyph conventions


### PR DESCRIPTION
## Summary

- Replace the user-invocable PR skill's bare host `go test ./...` with the shared-box-safe `make test-container`.
- Align the create-PR, decomposition, and session-dispatch instructions with all six required pre-PR gates.
- Remove the contradictory `CLAUDE.md` convention that still prescribed the bare host suite.

## Why

The gate instructions predated the shared-box container policy and later CI gates. Following the old create-PR skill on a box with live Agent Factory sessions could run the daemon-heavy full suite on the host, while the partial gate lists could let dead code, formatting, lint, or file-length failures reach a PR.

## Code proof

- [The Makefile declares `make test-container` the one sanctioned full-suite path on a shared box](https://github.com/sachiniyer/agent-factory/blob/551d92899ce11294cebfda7879eb0e76e022022e/Makefile#L29-L33).
- [The testbox implementation fences the suite from host tmux, the real AF home, and repository worktrees](https://github.com/sachiniyer/agent-factory/blob/551d92899ce11294cebfda7879eb0e76e022022e/scripts/testbox.sh#L1-L19).
- [The required PR workflow runs golangci-lint, gofmt, deadcode, and file-length checks](https://github.com/sachiniyer/agent-factory/blob/551d92899ce11294cebfda7879eb0e76e022022e/.github/workflows/pr.yml#L44-L72), alongside the full test and build jobs.

## Validation

Run after the final commit was pushed, with local `HEAD` equal to `origin/siyer/docs-drift-audit` at `5257707f646a4afff8071265cd7404c82593ff05`:

- [x] `golangci-lint run --timeout=3m --fast`
- [x] `gofmt -l .` (no output)
- [x] `go build ./...`
- [x] `make test-container`
- [x] `deadcode -test ./...` (no output)
- [x] `scripts/lint-file-length.sh`

Generated reference docs were not edited. Separate config-surface drift found in the same audit is tracked in #2281.

— Captain Claude