### PR TITLE
fix(testbox): lease stable images through startup

### DIFF
--- a/docs/container-testing.md
+++ b/docs/container-testing.md
@@ -105,6 +105,15 @@ Nothing here ever runs `docker system prune` or an unfiltered
 images to do it. `make testbox-selftest` asserts exactly that, against a fake
 docker, in about a second — it gates every PR.
 
+Tagged-image cleanup is also serialized against the only unsafe window in a
+sibling run: from rebuilding a stable harness tag until Docker/Podman reports
+the first container using it as running. The lock is shared across worktrees and
+released at that positive engine observation, so suites still run concurrently;
+afterward the container reference itself prevents image deletion. This keeps
+`image prune -a` and the legacy exact-tag cleanup fallback from deleting a local-
+only image between build and `run`, and also keeps two sibling Dockerfile builds
+from retagging the name out from under a not-yet-created container.
+
 **Before a run**, if free space on the docker root filesystem is under 20GB
 (`AF_TESTBOX_MIN_FREE_GB`, `0` silences it), the harness says so and points at
 `make testbox-clean`. It warns and continues rather than refusing: nothing here

--- a/scripts/testbox-selftest.sh
+++ b/scripts/testbox-selftest.sh
@@ -55,11 +55,25 @@ cat >"$WORK/bin/docker" <<'SHIM'
 printf '%s\n' "$*" >>"$DOCKER_LOG"
 for a in "$@"; do
     case "$a" in
-    build) exec cat >/dev/null ;;
+    build)
+        cat >/dev/null
+        if [ -n "${FAKE_BUILD_ENTERED:-}" ]; then
+            : >"$FAKE_BUILD_ENTERED"
+        fi
+        if [ -n "${FAKE_BUILD_RELEASE:-}" ]; then
+            while [ ! -e "$FAKE_BUILD_RELEASE" ]; do sleep 0.02; done
+        fi
+        exit 0
+        ;;
     esac
 done
 case "$1 ${2:-}" in
 "info --format") printf '%s\n' "${FAKE_INFO_ROOT:-}" ;;
+"inspect -f")
+    if [ -n "${FAKE_RUNNING_MARKER:-}" ] && [ -e "$FAKE_RUNNING_MARKER" ]; then
+        printf 'true\n'
+    fi
+    ;;
 "builder prune")
     case "${*}" in
     *--help*) echo "  --max-used-space bytes  Maximum amount of disk space allowed to keep for cache" ;;
@@ -70,7 +84,18 @@ esac
 # Only the run under test fails, and only when asked to: a failing
 # fix_cache_perms would abort the script before the interesting part.
 case "${*}" in
-*run-tests.sh*) exit "${FAKE_RUN_RC:-0}" ;;
+*run-tests.sh*)
+    if [ -n "${FAKE_RUNNING_MARKER:-}" ]; then
+        : >"$FAKE_RUNNING_MARKER"
+    fi
+    if [ -n "${FAKE_RUN_ENTERED:-}" ]; then
+        : >"$FAKE_RUN_ENTERED"
+    fi
+    if [ -n "${FAKE_RUN_RELEASE:-}" ]; then
+        while [ ! -e "$FAKE_RUN_RELEASE" ]; do sleep 0.02; done
+    fi
+    exit "${FAKE_RUN_RC:-0}"
+    ;;
 esac
 exit 0
 SHIM
@@ -86,6 +111,7 @@ run_testbox() {
     local rc=0
     env PATH="$WORK/bin:$PATH" DOCKER_LOG="$LOG" FAKE_RUN_RC="${FAKE_RUN_RC:-0}" \
         AF_TESTBOX_IMAGE=af-selftest-image \
+        AF_TESTBOX_IMAGE_LOCK="$WORK/image-startup.lock" \
         bash "$TESTBOX" "$@" >/dev/null 2>&1 || rc=$?
     if [ "$rc" != "$want" ]; then
         no "$name: testbox exited $rc, want $want"
@@ -150,6 +176,81 @@ else
     no "a failing run skips the build-cache cap"
 fi
 unset FAKE_RUN_RC
+
+printf '\n=== tagged cleanup waits for sibling image startup ===\n'
+
+# Hold one invocation inside its image build — after it has acquired the
+# cross-worktree startup lock, before any container can protect the tag — and
+# start `clean` against the same lock. Before the fix, clean reaches both
+# `image prune -a` and exact-tag `rmi` in this window. It must now reach neither
+# until the sibling is allowed to create/run its container.
+START_LOG="$WORK/start-race.log"
+CLEAN_LOG="$WORK/clean-race.log"
+ENTERED="$WORK/build-entered"
+RELEASE="$WORK/build-release"
+RUN_ENTERED="$WORK/run-entered"
+RUN_RELEASE="$WORK/run-release"
+RUNNING="$WORK/container-running"
+: >"$START_LOG"
+: >"$CLEAN_LOG"
+env PATH="$WORK/bin:$PATH" DOCKER_LOG="$START_LOG" \
+    FAKE_BUILD_ENTERED="$ENTERED" FAKE_BUILD_RELEASE="$RELEASE" \
+    FAKE_RUN_ENTERED="$RUN_ENTERED" FAKE_RUN_RELEASE="$RUN_RELEASE" \
+    FAKE_RUNNING_MARKER="$RUNNING" \
+    AF_TESTBOX_IMAGE=af-selftest-image \
+    AF_TESTBOX_IMAGE_LOCK="$WORK/image-startup-race.lock" \
+    bash "$TESTBOX" test ./config/... >/dev/null 2>&1 &
+starter=$!
+for _ in $(seq 1 200); do
+    [ -e "$ENTERED" ] && break
+    sleep 0.01
+done
+if [ ! -e "$ENTERED" ]; then
+    no "startup-race: sibling never reached the held build"
+    kill "$starter" 2>/dev/null || true
+else
+    env PATH="$WORK/bin:$PATH" DOCKER_LOG="$CLEAN_LOG" \
+        AF_TESTBOX_IMAGE=af-selftest-image \
+        AF_TESTBOX_IMAGE_LOCK="$WORK/image-startup-race.lock" \
+        bash "$TESTBOX" clean >/dev/null 2>&1 &
+    cleaner=$!
+    sleep 0.2
+    if has "$CLEAN_LOG" "^(image prune -a|rmi )"; then
+        no "tagged cleanup ran while a sibling had built no image-protecting container"
+    else
+        ok "tagged cleanup waits through a sibling's build-to-container gap"
+    fi
+    : >"$RELEASE"
+    for _ in $(seq 1 200); do
+        [ -e "$RUN_ENTERED" ] && break
+        sleep 0.01
+    done
+    if [ ! -e "$RUN_ENTERED" ]; then
+        no "startup-race: sibling never reached its held test container"
+    fi
+    # The fake container stays running here. Once the observer sees that
+    # positive state, the image is protected by its container reference and
+    # cleanup should proceed without waiting for the suite to finish.
+    for _ in $(seq 1 200); do
+        if has "$CLEAN_LOG" "^rmi af-selftest-image$"; then
+            break
+        fi
+        sleep 0.01
+    done
+    if has "$CLEAN_LOG" "^rmi af-selftest-image$" && kill -0 "$starter" 2>/dev/null; then
+        ok "the startup lease ends at Running, not at the end of the test suite"
+    else
+        no "tagged cleanup stayed blocked after the sibling container was running"
+    fi
+    : >"$RUN_RELEASE"
+    wait "$starter" || no "startup-race: sibling testbox failed after release"
+    wait "$cleaner" || no "startup-race: clean failed after release"
+    if has "$CLEAN_LOG" "^image prune -af" && has "$CLEAN_LOG" "^rmi af-selftest-image$"; then
+        ok "tagged cleanup proceeds once the sibling startup is protected"
+    else
+        no "tagged cleanup never resumed after the sibling startup completed"
+    fi
+fi
 
 printf '\n=== cleanup can never reach an artifact the harness did not create ===\n'
 
@@ -288,6 +389,7 @@ LOG="$WORK/nodisk.log"
 rc=0
 env PATH="$WORK/bin:$PATH" DOCKER_LOG="$LOG" FAKE_INFO_ROOT=/nonexistent/docker-root \
     AF_TESTBOX_IMAGE=af-selftest-image \
+    AF_TESTBOX_IMAGE_LOCK="$WORK/image-startup.lock" \
     bash "$TESTBOX" test ./config/... >"$WORK/nodisk.out" 2>&1 || rc=$?
 if [ "$rc" -eq 0 ]; then
     ok "an unreadable engine root does not fail the run"
@@ -306,6 +408,7 @@ LOG="$WORK/off.log"
 : >"$LOG"
 env PATH="$WORK/bin:$PATH" DOCKER_LOG="$LOG" AF_TESTBOX_CACHE_MAX=off \
     AF_TESTBOX_IMAGE=af-selftest-image \
+    AF_TESTBOX_IMAGE_LOCK="$WORK/image-startup.lock" \
     bash "$TESTBOX" test ./config/... >/dev/null 2>&1 || true
 if has "$LOG" "^builder prune"; then
     no "AF_TESTBOX_CACHE_MAX=off still touched the build cache"

--- a/scripts/testbox.sh
+++ b/scripts/testbox.sh
@@ -51,12 +51,14 @@ _uniq() {
     printf '%s' "$$${r:+-$r}"
 }
 
+RUN_TOKEN="$(_uniq)"
+
 # The sandbox container name defaults to a UNIQUE per-run value so concurrent
 # play-tests can't `docker rm -f` each other mid-run (#1171). Pin it with
 # AF_PLAYTEST_NAME to reuse/target a specific container. Whatever the value,
 # every message, teardown hint, and `docker exec`/`rm` below uses THIS
 # resolved name — never a hardcoded 'af-playtest'.
-PLAYTEST_NAME="${AF_PLAYTEST_NAME:-af-playtest-$(_uniq)}"
+PLAYTEST_NAME="${AF_PLAYTEST_NAME:-af-playtest-$RUN_TOKEN}"
 
 # ---------------------------------------------------------------- disk (#2133)
 #
@@ -104,6 +106,128 @@ else
     echo "testbox: need docker or podman on PATH" >&2
     exit 1
 fi
+
+# ---------------------------------------------------------------- image lease
+#
+# IMAGE and WEB_IMAGE are stable, daemon-global tags shared by every checkout on
+# this box. A labelled `image prune -a` or exact-tag `rmi` from `testbox-clean`
+# can therefore delete a sibling's freshly-built image in the gap before its
+# first container exists. The engine has no reference to protect during that
+# gap; once the container is RUNNING, it does.
+#
+# Serialize only that critical section — build through the engine's positive
+# running observation — against tagged cleanup. The lock is host-global (not
+# under REPO_ROOT), so sibling worktrees share it. A background observer releases
+# it as soon as the named container is running; suites remain concurrent after
+# startup. This also stops two sibling Dockerfile builds from retagging the
+# stable name between another run's build and container creation.
+#
+# util-linux flock is the normal path on the shared Linux boxes. The mkdir
+# fallback keeps Docker Desktop/other hosts working without adding a dependency;
+# it records the owner PID and reaps a lock whose shell no longer exists.
+IMAGE_LOCK_PATH="${AF_TESTBOX_IMAGE_LOCK:-${TMPDIR:-/tmp}/agent-factory-testbox-image-${UID}.lock}"
+IMAGE_LOCK_DIR="${IMAGE_LOCK_PATH}.d"
+IMAGE_LOCK_REAPER="${IMAGE_LOCK_PATH}.reap"
+IMAGE_LOCK_HELD=no
+IMAGE_LOCK_KIND=""
+IMAGE_LOCK_FD=""
+IMAGE_LOCK_WATCHER=""
+
+acquire_image_lock_mkdir() {
+    local owner="" announced=no
+    while ! mkdir "$IMAGE_LOCK_DIR" 2>/dev/null; do
+        owner="$(cat "$IMAGE_LOCK_DIR/pid" 2>/dev/null || true)"
+        case "$owner" in
+        '' | *[!0-9]*) ;;
+        *)
+            if ! kill -0 "$owner" 2>/dev/null && mkdir "$IMAGE_LOCK_REAPER" 2>/dev/null; then
+                # Re-check under the reaper mutex. Another waiter may have
+                # already replaced the stale owner before we acquired it.
+                if [ "$(cat "$IMAGE_LOCK_DIR/pid" 2>/dev/null || true)" = "$owner" ] &&
+                    ! kill -0 "$owner" 2>/dev/null; then
+                    rm -f "$IMAGE_LOCK_DIR/pid"
+                    rmdir "$IMAGE_LOCK_DIR" 2>/dev/null || true
+                fi
+                rmdir "$IMAGE_LOCK_REAPER" 2>/dev/null || true
+                continue
+            fi
+            ;;
+        esac
+        if [ "$announced" = no ]; then
+            echo "testbox: waiting for another harness invocation to finish image startup..." >&2
+            announced=yes
+        fi
+        sleep 0.1
+    done
+    printf '%s\n' "$$" >"$IMAGE_LOCK_DIR/pid"
+    IMAGE_LOCK_KIND="mkdir"
+    IMAGE_LOCK_HELD=yes
+}
+
+acquire_image_lock() {
+    if [ "$IMAGE_LOCK_HELD" = yes ]; then
+        return 0
+    fi
+    if command -v flock >/dev/null 2>&1 && [ "${AF_TESTBOX_FORCE_MKDIR_LOCK:-0}" != 1 ]; then
+        # shellcheck disable=SC3045 # dynamic FDs are a bash feature; this is a bash script.
+        exec {IMAGE_LOCK_FD}>"$IMAGE_LOCK_PATH"
+        if ! flock -n "$IMAGE_LOCK_FD"; then
+            echo "testbox: waiting for another harness invocation to finish image startup..." >&2
+            flock "$IMAGE_LOCK_FD"
+        fi
+        IMAGE_LOCK_KIND=flock
+        IMAGE_LOCK_HELD=yes
+        return 0
+    fi
+    acquire_image_lock_mkdir
+}
+
+release_image_lock() {
+    if [ "$IMAGE_LOCK_HELD" != yes ]; then
+        return 0
+    fi
+    case "$IMAGE_LOCK_KIND" in
+    flock)
+        flock -u "$IMAGE_LOCK_FD" 2>/dev/null || true
+        ;;
+    mkdir)
+        if [ "$(cat "$IMAGE_LOCK_DIR/pid" 2>/dev/null || true)" = "$$" ]; then
+            rm -f "$IMAGE_LOCK_DIR/pid"
+            rmdir "$IMAGE_LOCK_DIR" 2>/dev/null || true
+        fi
+        ;;
+    esac
+    IMAGE_LOCK_HELD=no
+}
+
+# release_image_lock_when_running <container-name> — called in a subshell. Bash
+# keeps $$ equal to the parent shell there, so both flock and the mkdir owner
+# check release the parent's lease. If docker run fails before reaching Running,
+# the parent releases after the command returns instead.
+release_image_lock_when_running() {
+    local name="$1"
+    while :; do
+        if [ "$("$ENGINE" inspect -f '{{.State.Running}}' "$name" 2>/dev/null || true)" = true ]; then
+            release_image_lock
+            return 0
+        fi
+        sleep 0.05
+    done
+}
+
+watch_image_start() {
+    release_image_lock_when_running "$1" &
+    IMAGE_LOCK_WATCHER=$!
+}
+
+finish_image_start() {
+    if [ -n "$IMAGE_LOCK_WATCHER" ]; then
+        kill "$IMAGE_LOCK_WATCHER" 2>/dev/null || true
+        wait "$IMAGE_LOCK_WATCHER" 2>/dev/null || true
+        IMAGE_LOCK_WATCHER=""
+    fi
+    release_image_lock
+}
 
 build_image() {
     # Dockerfile via stdin: no build context is sent (the Dockerfile has no
@@ -198,6 +322,7 @@ warn_low_disk() {
 # that leaves residue behind can never be the red one. Nothing below may `exec`
 # for that reason: exec replaces this shell and the trap never fires.
 teardown() {
+    finish_image_start
     reap_dangling_images
     cap_build_cache
 }
@@ -277,12 +402,16 @@ fix_cache_perms() {
 # (#1596, regression of the #1498 opt-out). Override to `true` to exercise the
 # real auto-update path in the sandbox.
 start_playtest_detached() {
+    local rc=0
+    watch_image_start "$PLAYTEST_NAME"
     "$ENGINE" run -d \
         "${RUN_FLAGS[@]}" \
         --name "$PLAYTEST_NAME" \
         -e AGENT_FACTORY_HOME=/home/dev/sandbox/home \
         -e "AGENT_FACTORY_AUTO_UPDATE=${AGENT_FACTORY_AUTO_UPDATE:-false}" \
-        "$IMAGE" bash /src/scripts/container/playtest-entry.sh hold >/dev/null
+        "$IMAGE" bash /src/scripts/container/playtest-entry.sh hold >/dev/null || rc=$?
+    finish_image_start
+    return "$rc"
 }
 
 # ensure_playtest_up — start the detached sandbox if it is not already
@@ -295,11 +424,19 @@ ensure_playtest_up() {
         echo "testbox: starting sandbox '$PLAYTEST_NAME' (af builds on boot)..." >&2
         start_playtest_detached
     fi
+    # An existing sandbox already protects the image; a newly started one was
+    # positively observed by docker run -d / the startup watcher above.
+    finish_image_start
     "$ENGINE" exec "$PLAYTEST_NAME" sh -c 'until [ -x /home/dev/bin/af ]; do sleep 1; done'
 }
 
 cmd="${1:-test}"
 [ $# -gt 0 ] && shift
+
+# Every command can build/use a stable image tag, or (`clean`) remove one. Hold
+# the same cross-worktree lease until the case either observes its first running
+# container or completes tagged cleanup.
+acquire_image_lock
 
 # Every command but `clean` is about to consume disk; `clean` is the answer to
 # the warning, so warning there would just be noise.
@@ -310,6 +447,7 @@ fi
 case "$cmd" in
 build)
     "$ENGINE" build --label "$LABEL" -t "$IMAGE" - <"$REPO_ROOT/scripts/container/Dockerfile.test"
+    finish_image_start
     ;;
 test)
     build_image
@@ -317,8 +455,11 @@ test)
     # The one sanctioned home for a bare full-suite run on a shared box.
     # Not `exec`: the teardown trap has to survive the run (#2133).
     rc=0
-    "$ENGINE" run "${RUN_FLAGS[@]}" "$IMAGE" \
+    TESTBOX_NAME="af-testbox-test-$RUN_TOKEN"
+    watch_image_start "$TESTBOX_NAME"
+    "$ENGINE" run "${RUN_FLAGS[@]}" --name "$TESTBOX_NAME" "$IMAGE" \
         bash /src/scripts/container/run-tests.sh "$@" || rc=$?
+    finish_image_start
     exit "$rc"
     ;;
 playtest)
@@ -334,12 +475,14 @@ playtest)
         echo "  tear down:    $ENGINE rm -f $PLAYTEST_NAME"
     else
         rc=0
+        watch_image_start "$PLAYTEST_NAME"
         "$ENGINE" run -it \
             "${RUN_FLAGS[@]}" \
             --name "$PLAYTEST_NAME" \
             -e AGENT_FACTORY_HOME=/home/dev/sandbox/home \
             -e "AGENT_FACTORY_AUTO_UPDATE=${AGENT_FACTORY_AUTO_UPDATE:-false}" \
             "$IMAGE" bash /src/scripts/container/playtest-entry.sh || rc=$?
+        finish_image_start
         exit "$rc"
     fi
     ;;
@@ -405,6 +548,7 @@ lifecycle)
     "$ENGINE" build -q --label "$LABEL" -t "$LIFECYCLE_IMAGE" - <"$REPO_ROOT/scripts/container/Dockerfile.test" >/dev/null
     fix_cache_perms "$LIFECYCLE_IMAGE"
     rc=0
+    watch_image_start "$LIFECYCLE_NAME"
     "$ENGINE" run --rm \
         "${RUN_FLAGS[@]}" \
         --name "$LIFECYCLE_NAME" \
@@ -412,6 +556,7 @@ lifecycle)
         -e "AF_LIFECYCLE_INJECT=${AF_LIFECYCLE_INJECT:-}" \
         -e "AF_LIFECYCLE_ALLOW_PARTIAL=${AF_LIFECYCLE_ALLOW_PARTIAL:-1}" \
         "$LIFECYCLE_IMAGE" bash /src/scripts/container/lifecycle-entry.sh "$@" || rc=$?
+    finish_image_start
     exit "$rc"
     ;;
 web-selftest)
@@ -427,13 +572,17 @@ web-selftest)
     # can't write. Chromium wants more memory + pids than the default suite.
     ensure_cache_volumes af-web-selftest-gomod af-web-selftest-gobuild
     rc=0
+    WEB_SELFTEST_NAME="af-web-selftest-$RUN_TOKEN"
+    watch_image_start "$WEB_SELFTEST_NAME"
     "$ENGINE" run --rm --label "$LABEL" --init \
+        --name "$WEB_SELFTEST_NAME" \
         -v "$REPO_ROOT":/src:ro \
         -v af-web-selftest-gomod:/cache/gomod \
         -v af-web-selftest-gobuild:/cache/gobuild \
         --pids-limit "${AF_TESTBOX_PIDS:-2048}" \
         --memory "${AF_WEB_TESTBOX_MEMORY:-4g}" \
         "$WEB_IMAGE" bash /src/scripts/container/web-selftest-entry.sh || rc=$?
+    finish_image_start
     exit "$rc"
     ;;
 clean)


### PR DESCRIPTION
## Summary
- serialize stable testbox-image startup against tagged cleanup across worktrees
- release the lease at Docker/Podman’s positive Running observation so test suites remain concurrent
- cover both util-linux flock and the portable PID-owned fallback with a fake-engine concurrency regression

## Finding
Addresses the legitimate Codex P2 on merged #2183: `image prune -a` and the exact-tag `rmi` fallback could delete a sibling’s local-only image between its stable-tag build and first container creation.

## Verification
- fail-first concurrency case: cleanup reaches neither tagged prune path while a sibling is held after build; it does proceed before that sibling suite exits once the fake engine reports Running
- `make testbox-selftest`
- `AF_TESTBOX_FORCE_MKDIR_LOCK=1 make testbox-selftest`
- shellcheck and bash syntax checks

Full repository gates are running against the pushed head and will be reported on this PR.

— Captain Claude