### PR TITLE
fix(daemon): scope restart-safety refreshes

### DIFF
--- a/commands/autoupdate.go
+++ b/commands/autoupdate.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"runtime"
@@ -162,12 +163,17 @@ func autoUpdateForChannel(channel string, checkTimeout, downloadBudget time.Dura
 			return fmt.Errorf("failed to write new binary: %w", err)
 		}
 
-		unitRefreshErr := refreshAutostartUnitFn()
+		unitRefreshErr := refreshAutostartUnitForCurrentHome()
 		if unitRefreshErr != nil {
 			// The new binary is already on disk, but stopping through a stale
 			// control-group unit is worse than leaving the old daemon running:
 			// it can take every daemon-spawned tmux pane with it (#2176).
-			log.WarningLog.Printf("auto-update: updated to %s but left the running daemon alone because its autostart unit could not be made restart-safe: %v; run af daemon install, then af daemon restart", latestVersion, unitRefreshErr)
+			var scopeErr *autostartRefreshScopeError
+			if errors.As(unitRefreshErr, &scopeErr) {
+				log.WarningLog.Printf("auto-update: updated to %s but left the running daemon alone because af could not prove the installed autostart unit belongs to this home: %v; run af daemon install", latestVersion, unitRefreshErr)
+			} else {
+				log.WarningLog.Printf("auto-update: updated to %s but left the running daemon alone because its autostart unit could not be made restart-safe: %v; run af daemon install, then af daemon restart", latestVersion, unitRefreshErr)
+			}
 		}
 
 		// Same rationale as `af upgrade` (#498/#1386): restart the running daemon

--- a/commands/autoupdate_test.go
+++ b/commands/autoupdate_test.go
@@ -337,6 +337,7 @@ func TestAutoUpdateCallsShutdownAfterBinarySwap(t *testing.T) {
 	withTestHome(t)
 	infoBuf, errBuf := captureLogs(t)
 	refreshCalls := stubAutostartRefresh(t, nil)
+	stubAutostartScope(t, true, true, nil)
 
 	tempBin := tempBinPath(t)
 	if err := os.WriteFile(tempBin, []byte("old-binary"), 0755); err != nil {
@@ -420,6 +421,7 @@ func TestAutoUpdateRefreshFailureSkipsDaemonRestart(t *testing.T) {
 	aflog.WarningLog.SetOutput(errBuf)
 	t.Cleanup(func() { aflog.WarningLog.SetOutput(previousWarningOut) })
 	refreshCalls := stubAutostartRefresh(t, errors.New("daemon-reload failed"))
+	stubAutostartScope(t, true, true, nil)
 
 	tempBin := tempBinPath(t)
 	if err := os.WriteFile(tempBin, []byte("old-binary"), 0755); err != nil {

--- a/commands/daemoncmd.go
+++ b/commands/daemoncmd.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -294,40 +295,62 @@ daemon is running, this command exits successfully without starting one.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Initialize(false)
 		defer log.Close()
+		return runDaemonRestart(cmd.OutOrStdout())
+	},
+}
 
-		execPath, err := osExecutableFn()
-		if err != nil {
-			return fmt.Errorf("failed to find current executable: %w", err)
-		}
-		resolvedPath, err := filepath.EvalSymlinks(execPath)
-		if err != nil {
-			return fmt.Errorf("failed to resolve executable path: %w", err)
-		}
-		// Existing Linux installs carry their rendered unit on disk. Make that
-		// unit restart-safe before the Shutdown RPC: refreshing it afterwards is
-		// too late, because systemd may already have cgroup-killed tmux (#2176).
-		if err := refreshAutostartUnitFn(); err != nil {
-			return fmt.Errorf("refusing to restart through an unsafe daemon autostart unit: %w", err)
-		}
-
-		result, err := restartDaemonFromPath(resolvedPath)
-		if err != nil {
-			return err
-		}
-
-		w := cmd.OutOrStdout()
-		switch result {
-		case daemon.ShutdownNoDaemon:
-			if !daemonRestartQuiet {
-				fmt.Fprintln(w, "no running daemon to restart")
-			}
-		case daemon.ShutdownViaSIGTERM:
-			fmt.Fprintln(w, "daemon restarted (stopped old daemon via SIGTERM fallback)")
-		default:
-			fmt.Fprintln(w, "daemon restarted")
+func runDaemonRestart(w io.Writer) error {
+	// Preserve this command's documented no-op before touching the installed
+	// unit. A stale or foreign unit is irrelevant when there is no daemon to
+	// stop, and failing to parse/reload it must not turn an idempotent restart
+	// into an error (#2185). Undetermined deliberately falls through to the
+	// fail-closed refresh path; only a completed negative authorizes the no-op.
+	absent := false
+	daemonRestartPresenceFn().Match(
+		func() {},
+		func() { absent = true },
+		func() { absent = true },
+		func(error) {},
+	)
+	if absent {
+		if !daemonRestartQuiet {
+			fmt.Fprintln(w, "no running daemon to restart")
 		}
 		return nil
-	},
+	}
+
+	execPath, err := osExecutableFn()
+	if err != nil {
+		return fmt.Errorf("failed to find current executable: %w", err)
+	}
+	resolvedPath, err := filepath.EvalSymlinks(execPath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve executable path: %w", err)
+	}
+	// Existing Linux installs carry their rendered unit on disk. Make a unit
+	// serving THIS home restart-safe before the Shutdown RPC: refreshing it
+	// afterwards is too late, because systemd may already have cgroup-killed
+	// tmux (#2176). A foreign unit cannot own this daemon and is left untouched.
+	if err := refreshAutostartUnitForCurrentHome(); err != nil {
+		return fmt.Errorf("refusing to restart through an unsafe daemon autostart unit: %w", err)
+	}
+
+	result, err := restartDaemonFromPath(resolvedPath)
+	if err != nil {
+		return err
+	}
+
+	switch result {
+	case daemon.ShutdownNoDaemon:
+		if !daemonRestartQuiet {
+			fmt.Fprintln(w, "no running daemon to restart")
+		}
+	case daemon.ShutdownViaSIGTERM:
+		fmt.Fprintln(w, "daemon restarted (stopped old daemon via SIGTERM fallback)")
+	default:
+		fmt.Fprintln(w, "daemon restarted")
+	}
+	return nil
 }
 
 func init() {
@@ -356,7 +379,52 @@ var (
 	autostartUnitExecPathFn     = daemon.AutostartUnitExecPath
 	refreshAutostartUnitFn      = daemon.RefreshAutostartUnit
 	configDirFn                 = config.GetConfigDir
+	daemonRestartPresenceFn     = probeDaemonRestartPresence
 )
+
+// probeDaemonRestartPresence gives the explicit restart command a three-value
+// read-only answer before it mutates an installed unit. A responding daemon or
+// a verified daemon PID is positive evidence. Only RequestShutdown's own
+// kernel-level absent answers are negative; every other failure to look remains
+// Undetermined, so it cannot silently authorize the no-op.
+func probeDaemonRestartPresence() daemon.ProbeAnswer {
+	h := daemonHealthFn()
+	if h.PIDVerified {
+		return daemon.AnswerYes()
+	}
+	return daemon.ClassifyShutdownTarget(h.PingErr)
+}
+
+// autostartRefreshScopeError means we could not prove that the installed unit
+// belongs to this home. It is distinct from a refresh failure: reinstalling is
+// the only honest repair, while suggesting `af daemon restart` would re-enter
+// the same unprovable gate.
+type autostartRefreshScopeError struct{ err error }
+
+func (e *autostartRefreshScopeError) Error() string { return e.err.Error() }
+func (e *autostartRefreshScopeError) Unwrap() error { return e.err }
+
+// refreshAutostartUnitForCurrentHome applies the restart-safety migration only
+// to the installed unit that can actually own the daemon being stopped. Unit
+// presence, unit ownership, and refresh now share AutostartUnitServesHome's
+// single parser instead of letting an alternate AGENT_FACTORY_HOME rewrite or
+// reload an unrelated user's unit (#2185).
+func refreshAutostartUnitForCurrentHome() error {
+	configDir, err := configDirFn()
+	if err != nil {
+		return &autostartRefreshScopeError{err: fmt.Errorf(
+			"cannot resolve the config dir to scope the autostart unit refresh: %w", err)}
+	}
+	serves, installed, err := autostartUnitServesHomeFn(configDir)
+	if err != nil {
+		return &autostartRefreshScopeError{err: fmt.Errorf(
+			"cannot tell whether the autostart unit serves %s: %w", configDir, err)}
+	}
+	if !installed || !serves {
+		return nil
+	}
+	return refreshAutostartUnitFn()
+}
 
 // respawnResult reports the ways a respawn can succeed and still leave the
 // user worse off than they think, so callers can say so instead of assuming

--- a/commands/daemoncmd_test.go
+++ b/commands/daemoncmd_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"bytes"
 	"errors"
 	"testing"
 
@@ -8,6 +9,20 @@ import (
 )
 
 const testUpgradeDaemonPath = "/tmp/af-upgraded"
+
+func stubAutostartScope(t *testing.T, serves, installed bool, gateErr error) {
+	t.Helper()
+	prevServes := autostartUnitServesHomeFn
+	prevConfigDir := configDirFn
+	t.Cleanup(func() {
+		autostartUnitServesHomeFn = prevServes
+		configDirFn = prevConfigDir
+	})
+	configDirFn = func() (string, error) { return "/tmp/af-test-home", nil }
+	autostartUnitServesHomeFn = func(string) (bool, bool, error) {
+		return serves, installed, gateErr
+	}
+}
 
 // Tests for the unit-aware upgrade respawn (#796) and the unconditional
 // fallback (#813). All collaborators are stubbed so nothing here
@@ -251,5 +266,46 @@ func TestRestartDaemonFromPathRespawnsStoppedDaemon(t *testing.T) {
 	}
 	if gotPath != "/opt/af/current" {
 		t.Fatalf("respawn path = %q, want /opt/af/current", gotPath)
+	}
+}
+
+// The command promises an idempotent no-op when no daemon is running. That
+// answer must be established before reading, rewriting, or reloading an
+// installed unit: a broken stale unit is irrelevant when nothing will stop.
+func TestRunDaemonRestartNoDaemonSkipsUnsafeUnitRefresh(t *testing.T) {
+	prevPresence := daemonRestartPresenceFn
+	prevRefresh := refreshAutostartUnitFn
+	prevExecutable := osExecutableFn
+	prevConfigDir := configDirFn
+	prevQuiet := daemonRestartQuiet
+	t.Cleanup(func() {
+		daemonRestartPresenceFn = prevPresence
+		refreshAutostartUnitFn = prevRefresh
+		osExecutableFn = prevExecutable
+		configDirFn = prevConfigDir
+		daemonRestartQuiet = prevQuiet
+	})
+
+	daemonRestartPresenceFn = func() daemon.ProbeAnswer { return daemon.AnswerNo() }
+	refreshAutostartUnitFn = func() error {
+		t.Fatal("no-daemon restart touched the stale autostart unit")
+		return errors.New("daemon-reload failed")
+	}
+	osExecutableFn = func() (string, error) {
+		t.Fatal("no-daemon restart resolved an executable despite being a no-op")
+		return "", nil
+	}
+	configDirFn = func() (string, error) {
+		t.Fatal("no-daemon restart tried to scope an irrelevant autostart unit")
+		return "", nil
+	}
+	daemonRestartQuiet = false
+
+	var out bytes.Buffer
+	if err := runDaemonRestart(&out); err != nil {
+		t.Fatalf("runDaemonRestart: %v", err)
+	}
+	if got := out.String(); got != "no running daemon to restart\n" {
+		t.Fatalf("restart output = %q, want documented no-op", got)
 	}
 }

--- a/commands/upgrade.go
+++ b/commands/upgrade.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -220,12 +221,16 @@ func runUpgrade(out, errOut io.Writer, downloadURL string, noRestart bool) error
 		return fmt.Errorf("failed to write new binary: %w", err)
 	}
 
-	if err := refreshAutostartUnitFn(); err != nil {
+	if err := refreshAutostartUnitForCurrentHome(); err != nil {
 		fmt.Fprintln(out, "Upgraded successfully!")
 		fmt.Fprintf(errOut, "The daemon autostart unit could not be made restart-safe: %v\n", err)
-		if noRestart {
+		var scopeErr *autostartRefreshScopeError
+		switch {
+		case errors.As(err, &scopeErr):
+			fmt.Fprintln(errOut, "The running daemon was left alone because af could not prove the installed unit belongs to this home. Run `af daemon install` to restore an authoritative unit before restarting.")
+		case noRestart:
 			fmt.Fprintln(errOut, "The running daemon was left alone as requested, but the installed unit still needs repair. Run `af daemon install` before restarting it.")
-		} else {
+		default:
 			fmt.Fprintln(errOut, "The running daemon was left alone because restarting through the stale unit could stop live tmux sessions. Run `af daemon install`, then `af daemon restart`.")
 		}
 		return nil

--- a/commands/upgrade_restart_test.go
+++ b/commands/upgrade_restart_test.go
@@ -179,6 +179,7 @@ func TestUpgrade_NoRestartSkipsRestart(t *testing.T) {
 	binPath, url := upgradeHarness(t)
 	shutdownCalls := stubShutdown(t, daemon.ShutdownViaRPC, nil)
 	refreshCalls := stubAutostartRefresh(t, nil)
+	stubAutostartScope(t, true, true, nil)
 	stubDaemonHealth(t, daemon.HealthStatus{})
 
 	var out, errOut bytes.Buffer
@@ -209,7 +210,7 @@ func TestUpgrade_NoRestartSkipsRestart(t *testing.T) {
 func TestUpgradeRefreshesAutostartBeforeStoppingDaemon(t *testing.T) {
 	_, url := upgradeHarness(t)
 	stubDaemonHealth(t, daemon.HealthStatus{})
-	stubRespawnCollaborators(t, false, nil)
+	stubRespawnCollaborators(t, true, nil)
 
 	previousRefresh := refreshAutostartUnitFn
 	previousShutdown := requestDaemonShutdownFn
@@ -239,6 +240,7 @@ func TestUpgradeRefreshFailureLeavesDaemonRunning(t *testing.T) {
 	_, url := upgradeHarness(t)
 	refreshCalls := stubAutostartRefresh(t, errors.New("daemon-reload failed"))
 	shutdownCalls := stubShutdown(t, daemon.ShutdownViaRPC, nil)
+	stubAutostartScope(t, true, true, nil)
 	stubDaemonHealth(t, daemon.HealthStatus{})
 
 	var out, errOut bytes.Buffer
@@ -255,6 +257,36 @@ func TestUpgradeRefreshFailureLeavesDaemonRunning(t *testing.T) {
 		if !strings.Contains(errOut.String(), want) {
 			t.Fatalf("refresh failure stderr missing %q:\n%s", want, errOut.String())
 		}
+	}
+}
+
+// An installed unit for another AGENT_FACTORY_HOME cannot own the daemon this
+// upgrade is about. Its parser/reload errors therefore must not block the
+// current home's ad-hoc restart after the binary swap (#2185).
+func TestUpgradeForeignHomeSkipsUnrelatedUnitRefresh(t *testing.T) {
+	_, url := upgradeHarness(t)
+	refreshCalls := stubAutostartRefresh(t, errors.New("foreign unit is malformed"))
+	shutdownCalls := stubShutdown(t, daemon.ShutdownViaRPC, nil)
+	restartCalls, ensureCalls := stubRespawnCollaborators(t, true, nil)
+	stubAutostartScope(t, false, true, nil)
+	stubDaemonHealth(t, daemon.HealthStatus{})
+
+	var out, errOut bytes.Buffer
+	if err := runUpgrade(&out, &errOut, url, false); err != nil {
+		t.Fatalf("runUpgrade: %v", err)
+	}
+	if *refreshCalls != 0 {
+		t.Fatalf("foreign-unit refresh calls = %d, want 0", *refreshCalls)
+	}
+	if *shutdownCalls != 1 {
+		t.Fatalf("shutdown calls = %d, want 1 for the current home's daemon", *shutdownCalls)
+	}
+	if *restartCalls != 0 || *ensureCalls != 1 {
+		t.Fatalf("respawn branches: unit=%d ad-hoc=%d, want foreign unit untouched and one ad-hoc spawn",
+			*restartCalls, *ensureCalls)
+	}
+	if strings.Contains(errOut.String(), "foreign unit is malformed") {
+		t.Fatalf("unrelated unit failure leaked into this home's upgrade: %q", errOut.String())
 	}
 }
 
@@ -361,13 +393,11 @@ func TestUpgrade_StaleUnitBinaryIsLoud(t *testing.T) {
 }
 
 // TestUpgrade_UnprovableUnitGateIsLoud: when we cannot TELL whether the unit
-// serves this home we refuse to restart it — the right call, but it costs a
-// supervised daemon its supervision, so it cannot be a log-only warning. The
-// quiet "no unit serves this home" case is a different thing entirely and is
-// locked below.
+// serves this home, neither refresh nor shutdown is safe. Leave the current
+// daemon running and name the one repair that makes unit ownership authoritative.
 func TestUpgrade_UnprovableUnitGateIsLoud(t *testing.T) {
 	_, url := upgradeHarness(t)
-	stubShutdown(t, daemon.ShutdownViaRPC, nil)
+	shutdownCalls := stubShutdown(t, daemon.ShutdownViaRPC, nil)
 	stubDaemonHealth(t, daemon.HealthStatus{})
 	stubRespawnCollaborators(t, true, nil)
 	autostartUnitServesHomeFn = func(string) (bool, bool, error) {
@@ -385,10 +415,11 @@ func TestUpgrade_UnprovableUnitGateIsLoud(t *testing.T) {
 	if !strings.Contains(errOut.String(), "permission denied") {
 		t.Fatalf("stderr must say why the unit was left alone.\ngot=%q", errOut.String())
 	}
-	// `af daemon restart` re-enters this same respawn, hits this same gate,
-	// and falls back to an ad-hoc daemon AGAIN — it looks like it worked and
-	// leaves supervision just as broken. Only a reinstall re-registers the
-	// unit for this home.
+	if *shutdownCalls != 0 {
+		t.Fatalf("shutdown calls = %d, want 0 when unit ownership is unprovable", *shutdownCalls)
+	}
+	// `af daemon restart` re-enters this same ownership gate and cannot repair
+	// it. Only a reinstall re-registers an authoritative unit for this home.
 	if strings.Contains(errOut.String(), "af daemon restart") {
 		t.Fatalf("`af daemon restart` re-hits this gate and silently demotes to ad-hoc again; it does not restore supervision.\ngot=%q", errOut.String())
 	}

--- a/daemon/control_shutdown.go
+++ b/daemon/control_shutdown.go
@@ -107,6 +107,22 @@ func RequestShutdown() (ShutdownResult, error) {
 	return ShutdownViaRPC, nil
 }
 
+// ClassifyShutdownTarget turns the read-only ping made before a restart into
+// the exact presence answer RequestShutdown will rely on. Only the two kernel
+// answers that RequestShutdown already treats as daemon-absent — ENOENT and
+// ECONNREFUSED — become No. Permission errors, resets, timeouts, and every
+// other failure remain Undetermined, so a failed observation cannot authorize
+// a supposedly harmless no-op before restart-safety checks run.
+func ClassifyShutdownTarget(pingErr error) ProbeAnswer {
+	if pingErr == nil {
+		return AnswerYes()
+	}
+	if isDaemonAbsentErr(pingErr) {
+		return AnswerNo()
+	}
+	return Undetermined(fmt.Errorf("cannot determine whether a daemon is available to shut down: %w", pingErr))
+}
+
 // shutdownCompleteGrace bounds how long WaitForShutdownCompletion polls for
 // the control socket to stop answering; shutdownCompletePoll is the cadence.
 // Package vars rather than constants so tests can shorten the timeout path,

--- a/daemon/control_shutdown_probe_test.go
+++ b/daemon/control_shutdown_probe_test.go
@@ -1,0 +1,33 @@
+package daemon
+
+import (
+	"errors"
+	"os"
+	"syscall"
+	"testing"
+)
+
+func TestClassifyShutdownTargetOnlyCompletedAbsenceIsNo(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "answered", err: nil, want: "yes"},
+		{name: "missing socket", err: os.ErrNotExist, want: "no"},
+		{name: "refused socket", err: syscall.ECONNREFUSED, want: "no"},
+		{name: "timeout", err: os.ErrDeadlineExceeded, want: "unknown"},
+		{name: "permission", err: os.ErrPermission, want: "unknown"},
+		{name: "reset", err: syscall.ECONNRESET, want: "unknown"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ClassifyShutdownTarget(tc.err)
+			if got.String() != tc.want {
+				t.Fatalf("ClassifyShutdownTarget(%v) = %s, want %s", tc.err, got.String(), tc.want)
+			}
+			if tc.want == "unknown" && !errors.Is(got.Cause(), tc.err) {
+				t.Fatalf("unknown cause = %v, want it to retain %v", got.Cause(), tc.err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- preserve `af daemon restart`’s documented no-op before parsing, rewriting, or reloading an irrelevant stale unit
- gate restart-safety refreshes through the same `AutostartUnitServesHome` authority used by respawn, across explicit restart, manual upgrade, and auto-update
- keep non-answers fail closed: only ENOENT/ECONNREFUSED can establish daemon absence; timeouts, permission failures, and resets stay unknown

## Findings
Addresses two legitimate Codex P2s on merged #2185:

1. an absent daemon could still make `af daemon restart` fail while refreshing a stale malformed unit
2. an alternate `AGENT_FACTORY_HOME` could refresh an unrelated installed unit and let its failure block this home’s restart

The third #2185 P2 is also real but requires a cgroup/process-ownership design to fix without killing legacy in-unit tmux panes. It is quoted and filed with code pointers and acceptance criteria as #2284.

## Verification
- fail-first: a definite no-daemon result reaches the documented no-op without executable resolution, home-scope parsing, refresh, or shutdown
- fail-first: a foreign installed unit with a deliberately failing refresh is never touched; the current daemon still stops and respawns ad hoc
- unknown unit ownership prevents both refresh and shutdown and recommends reinstall, never a misleading restart loop
- `go test ./daemon ./commands`
- focused classification and command/upgrade/auto-update regressions

Full repository gates are running against the pushed head and will be reported here.

— Captain Claude