### PR TITLE
fix(web): keep action and parity surfaces honest

### DIFF
--- a/parity/honesty_test.go
+++ b/parity/honesty_test.go
@@ -128,6 +128,29 @@ func TestDerivationSeesWebCreateOptions(t *testing.T) {
 	}
 }
 
+// TestWebPromptParityNamesTheLiveTerminalTransport pins the distinction exposed
+// by the #2188 review: the browser CAN send a prompt, but it does so by typing on
+// the attached PTY. A dead af("SendPrompt", ...) wrapper is not a production
+// surface and must not keep that RPC in the web reachability ledger. The daemon
+// route remains public for the CLI, so this asserts both sides instead of
+// deleting the capability itself.
+func TestWebPromptParityNamesTheLiveTerminalTransport(t *testing.T) {
+	inv := loadInventory(t)
+	if deriveWebRPCs(t)["SendPrompt"] {
+		t.Fatal("web prompt delivery is reaching SendPrompt RPC again; either remove the dead wrapper or deliberately update the terminal-transport parity decision")
+	}
+	if _, stale := inv.Ledger.WebRPCs["SendPrompt"]; stale {
+		t.Fatal("web_rpcs still counts SendPrompt even though the browser reaches prompt delivery through its live terminal")
+	}
+	if got := inv.Ledger.Routes["POST /v1/SendPrompt"]; got != "session.send-prompt" {
+		t.Fatalf("the daemon/CLI SendPrompt route disappeared with the dead web wrapper: route maps to %q", got)
+	}
+	capability, ok := inv.byID()["session.send-prompt"]
+	if !ok || capability.Web.Status != "yes" || !strings.Contains(capability.Web.Pointer, "terminal.ts") {
+		t.Fatalf("session.send-prompt must remain a web capability through terminal input, got %+v", capability.Web)
+	}
+}
+
 // TestDerivationSeesTUIBackendGap pins the other half of #1933 through the Go
 // AST: the TUI's sessionStartRequest has no Backend field at all.
 func TestDerivationSeesTUIBackendGap(t *testing.T) {

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -1459,7 +1459,6 @@
       "RenameTab": "session.tab.rename",
       "ReorderTab": "session.tab.reorder",
       "RestoreSession": "session.restore",
-      "SendPrompt": "session.send-prompt",
       "ResumeFromLimit": "session.limit-retry",
       "SetConfigValue": "config.write",
       "Snapshot": "session.list",

--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -981,7 +981,19 @@ body {
   padding: 0.3rem 0.6rem;
   font-size: var(--af-fs-xs);
 }
+.af-term-actions {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  gap: 0.3rem;
+}
+.af-term-kill:hover {
+  color: var(--af-danger);
+}
 .af-term-action[hidden] {
+  display: none;
+}
+.af-term-actions[hidden] {
   display: none;
 }
 .af-term-title {

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -10322,6 +10322,10 @@ function h2(tag, props = {}, ...children) {
 function orderedSessions(sessions) {
   return [...sessions].sort(compareSessionsForRail);
 }
+function visibleRailSessions(state) {
+  const scoped = scopeToProject(state.sessions, state.selectedProject);
+  return filterSessions(orderedSessions(scoped), state.statusFilter);
+}
 function renderLogin(root2, state, actions2) {
   root2.replaceChildren(loginView(state, actions2));
 }
@@ -10681,13 +10685,19 @@ var AppShell = class {
   // Header text nodes for the selected pane, (re)created per selection.
   headTitle = null;
   headMeta = null;
-  // The selected rail row's archive/restore control and the daemon-owned verb it
+  // The selected visible rail row's archive/restore control and daemon-owned verb it
   // currently shows (#1932, #2186, #2234). Every actionable row owns controls now
   // (#2223), but a session can flip archive⇄restore WITHOUT a selection change, so
   // patchMainHead still needs this reference to swap the selected control in place.
   // null when the selected row is not visible/actionable in the rail.
   lifecycleBtn = null;
   lifecycleAction = null;
+  // A selected session deliberately survives a status-filter change so its terminal
+  // keeps streaming. When that hides its rail row, this stable pane-header container
+  // becomes the one visible management surface (#2188). Its children use the same
+  // capability-narrowed builder as the rail; only their presentation differs.
+  headActions = null;
+  headActionSig = "";
   // The usage-limit Retry button and whether it is currently shown (#1934). Same
   // treatment, and for the same reason, as lifecycleBtn above: a session hits the
   // limit wall — or is resumed off it — WITHOUT a selection change, which is the
@@ -10897,7 +10907,7 @@ var AppShell = class {
    *  rows, under a notice when there is something worth saying about what's missing. */
   renderRail(state) {
     const scoped = scopeToProject(state.sessions, state.selectedProject);
-    const visible = filterSessions(orderedSessions(scoped), state.statusFilter);
+    const visible = visibleRailSessions(state);
     this.lifecycleBtn = null;
     this.lifecycleAction = null;
     this.railCount.textContent = String(visible.length);
@@ -10931,20 +10941,28 @@ var AppShell = class {
    *  capability (#2186, #2223, #2234). Archive/Restore and Kill narrow separately;
    *  the browser never reconstructs either policy from status pixels. */
   rowActions(session, selected) {
+    return h2("div", { class: "af-row-actions" }, ...this.sessionActionButtons(session, "rail", selected));
+  }
+  /** Builds both rail and fallback-header controls from the same daemon capabilities.
+   *  Placement chooses only presentation and whether a mobile rail exit is needed;
+   *  target narrowing, labels, and callbacks remain one path. */
+  sessionActionButtons(session, surface, selected = false) {
     const buttons = [];
     if (isActionableSession(session)) {
       const lifecycleSession = session;
-      const lifecycleBtn = h2("button", { type: "button", class: "af-rail-action af-rail-lifecycle" });
+      const lifecycleClass = surface === "rail" ? "af-rail-action af-rail-lifecycle" : "af-ghost af-term-action af-term-lifecycle";
+      const lifecycleBtn = h2("button", { type: "button", class: lifecycleClass });
       lifecycleBtn.addEventListener("click", (e) => {
         e.stopPropagation();
-        if (lifecycleBtn.dataset.action === "restore") {
-          this.runRailExit(() => this.actions.restore(lifecycleSession));
+        const run = lifecycleBtn.dataset.action === "restore" ? () => this.actions.restore(lifecycleSession) : () => this.actions.archive(lifecycleSession);
+        if (surface === "rail") {
+          this.runRailExit(run);
         } else {
-          this.runRailExit(() => this.actions.archive(lifecycleSession));
+          run();
         }
       });
-      this.patchLifecycleButton(lifecycleBtn, lifecycleSession.lifecycle_action, lifecycleSession.title);
-      if (selected) {
+      this.patchLifecycleButton(lifecycleBtn, lifecycleSession.lifecycle_action, lifecycleSession.title, surface);
+      if (surface === "rail" && selected) {
         this.lifecycleBtn = lifecycleBtn;
         this.lifecycleAction = lifecycleSession.lifecycle_action;
       }
@@ -10952,25 +10970,30 @@ var AppShell = class {
     }
     if (isKillableSession(session)) {
       const killSession2 = session;
-      const killBtn = h2("button", { type: "button", class: "af-rail-action af-rail-kill" }, "\u232B");
+      const killClass = surface === "rail" ? "af-rail-action af-rail-kill" : "af-ghost af-term-action af-term-kill";
+      const killBtn = h2("button", { type: "button", class: killClass }, surface === "rail" ? "\u232B" : "Kill");
       const killLabel = `Kill session \u201C${killSession2.title}\u201D`;
       killBtn.setAttribute("aria-label", killLabel);
       killBtn.setAttribute("title", killLabel);
       killBtn.addEventListener("click", (e) => {
         e.stopPropagation();
-        this.runRailExit(() => this.actions.kill(killSession2));
+        if (surface === "rail") {
+          this.runRailExit(() => this.actions.kill(killSession2));
+        } else {
+          this.actions.kill(killSession2);
+        }
       });
       buttons.push(killBtn);
     }
-    return h2("div", { class: "af-row-actions" }, ...buttons);
+    return buttons;
   }
   /** Applies the daemon-projected verb, glyph, and target-qualified accessible name
    *  in one place so render and same-selection live patching cannot drift. */
-  patchLifecycleButton(btn, action, sessionTitle) {
+  patchLifecycleButton(btn, action, sessionTitle, surface = "rail") {
     const verb = action === "restore" ? "Restore session" : "Archive session";
     const label = `${verb} \u201C${sessionTitle}\u201D`;
     btn.dataset.action = action;
-    btn.textContent = action === "restore" ? "\u21B6" : "\u25AA";
+    btn.textContent = surface === "rail" ? action === "restore" ? "\u21B6" : "\u25AA" : verb.replace(" session", "");
     btn.setAttribute("aria-label", label);
     btn.setAttribute("title", label);
   }
@@ -11253,6 +11276,8 @@ var AppShell = class {
     if (!selected) {
       this.headTitle = null;
       this.headMeta = null;
+      this.headActions = null;
+      this.headActionSig = "";
       this.retryBtn = null;
       this.retryVisible = false;
       this.tabBar = null;
@@ -11272,6 +11297,10 @@ var AppShell = class {
     this.retryBtn = retryBtn;
     this.retryVisible = isLimitReached(selected);
     retryBtn.hidden = !this.retryVisible;
+    const headActions = h2("div", { class: "af-term-actions" });
+    headActions.hidden = true;
+    this.headActions = headActions;
+    this.headActionSig = "";
     const tabBar = h2("div", { class: "af-tabbar" });
     this.tabBar = tabBar;
     tabBar.setAttribute("role", "tablist");
@@ -11282,7 +11311,7 @@ var AppShell = class {
     this.tabInsert.setAttribute("aria-hidden", "true");
     this.attachTabReorder(tabBar);
     this.attachTabRename(tabBar);
-    const head = h2("div", { class: "af-term-head" }, titleBox, tabBar, retryBtn);
+    const head = h2("div", { class: "af-term-head" }, titleBox, tabBar, headActions, retryBtn);
     this.main.className = "af-main af-main-term";
     this.main.replaceChildren(head, this.termHost);
     this.renderTabBar(state);
@@ -11513,6 +11542,7 @@ var AppShell = class {
     }
     this.headMeta.textContent = parts.join(" \xB7 ");
     this.headMeta.className = `af-term-meta af-term-${state.termStatus}`;
+    this.patchHeadActions(state, selected);
     const nowAction = selected.lifecycle_action ?? null;
     if (this.lifecycleBtn && nowAction && nowAction !== this.lifecycleAction) {
       this.patchLifecycleButton(this.lifecycleBtn, nowAction, selected.title);
@@ -11523,6 +11553,37 @@ var AppShell = class {
       this.retryVisible = nowLimited;
       this.retryBtn.hidden = !nowLimited;
     }
+  }
+  /** Keeps management reachable when the selected session's rail row is filtered
+   *  out, and only then. Capability and row visibility are both positive evidence:
+   *  malformed/inert projections gain no controls, while a visible row remains the
+   *  sole action surface. */
+  patchHeadActions(state, selected) {
+    const host = this.headActions;
+    if (!host) {
+      return;
+    }
+    const managed = isActionableSession(selected) || isKillableSession(selected) ? selected : null;
+    const rowVisible = visibleRailSessions(state).some((s) => s.id === selected.id);
+    if (!managed || rowVisible) {
+      if (this.headActionSig !== "") {
+        host.replaceChildren();
+        this.headActionSig = "";
+      }
+      host.hidden = true;
+      return;
+    }
+    const sig = JSON.stringify([
+      managed.id,
+      managed.title,
+      managed.lifecycle_action ?? null,
+      managed.can_kill === true
+    ]);
+    if (sig !== this.headActionSig) {
+      host.replaceChildren(...this.sessionActionButtons(managed, "head"));
+      this.headActionSig = sig;
+    }
+    host.hidden = false;
   }
 };
 var APP_NAME = "Agent Factory";

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "210c24a53bef";
+const VERSION = "b74eb19ef9df";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -3047,6 +3047,59 @@ test("filter (feat): the default hides ONLY archived, and each state's box hides
   await ctx.close();
 });
 
+test("#2188: a filtered selected session keeps one visible management surface", async ({ browser }) => {
+  // Use a separate context because the filter is persisted, but a REAL session: the
+  // invariant matters precisely while its terminal keeps streaming. Hiding every
+  // live state makes the final absence deterministic even if the agent transitions
+  // Ready↔Working while the check is in flight.
+  const title = SESSION_A;
+  const ctx = await browser.newContext();
+  try {
+    const p = await ctx.newPage();
+    await p.goto("/");
+    await expect(p.locator(".af-app")).toBeVisible();
+
+    await expect(row(p, title)).toBeVisible({ timeout: 15_000 });
+    await row(p, title).click();
+    await expect(p.locator(".af-term-title")).toHaveText(title);
+    await expect(p.locator(".af-main.af-main-term .xterm")).toBeVisible();
+
+    // While the selected row is visible, its rail controls are the one action
+    // surface; the pane header must not duplicate them.
+    await expect(railAction(p, title, "Archive session")).toBeVisible();
+    await expect(railAction(p, title, "Kill session")).toBeVisible();
+    await expect(p.locator(".af-term-actions")).toBeHidden();
+
+    // Hide every non-archived state. Selection and the terminal pane intentionally
+    // survive this display filter, so management must move with them instead of
+    // disappearing with the row.
+    for (const kind of ["working", "ready", "lost", "dead", "limit"]) {
+      await setFilter(p, kind, false);
+    }
+    await expect(row(p, title)).toHaveCount(0);
+    await expect(p.locator(".af-term-title")).toHaveText(title);
+    await expect(p.locator(".af-main.af-main-term .xterm")).toBeVisible();
+    const headActions = p.locator(".af-term-actions");
+    await expect(headActions).toBeVisible();
+    await expect(headActions.getByRole("button", { name: `Archive session “${title}”`, exact: true })).toBeVisible();
+    await expect(headActions.getByRole("button", { name: `Kill session “${title}”`, exact: true })).toBeVisible();
+
+    // The fallback is the same action path, not decorative recovery copy: both
+    // buttons open the existing target-qualified confirmations. Cancelling keeps the
+    // seeded fixture unchanged for every later flow.
+    const modal = p.locator(".af-modal-card");
+    await headActions.getByRole("button", { name: `Archive session “${title}”`, exact: true }).click();
+    await expect(modal).toContainText(`Archive ${title}?`);
+    await modal.getByRole("button", { name: "Cancel", exact: true }).click();
+    await expect(modal).toBeHidden();
+    await headActions.getByRole("button", { name: `Kill session “${title}”`, exact: true }).click();
+    await expect(modal).toContainText(`Kill ${title}?`);
+    await modal.getByRole("button", { name: "Cancel", exact: true }).click();
+  } finally {
+    await ctx.close();
+  }
+});
+
 test("filter (feat): keyboard nav walks the VISIBLE rows — j never lands on a hidden one", async () => {
   // The rail's j/k order must be the rows on screen. If nav still walked the archived
   // rows the rail hides, j would select something invisible: the pane would swap to a

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -1,7 +1,7 @@
 // Tests for the write-side lifecycle callers (#1592 Phase 5 follow-up): they must
 // send the session's STABLE id as the primary lookup key, not just the title. The
 // daemon resolves the action target by id first, so a cross-repo duplicate title
-// can't make a web kill/archive/prompt hit the wrong session. These pin the id in
+// can't make a web kill/archive hit the wrong session. These pin the id in
 // the request body without a daemon (fetch is stubbed).
 
 import { test, afterEach } from "node:test";
@@ -24,7 +24,6 @@ import {
   reorderTab,
   restoreSession,
   resumeFromLimit,
-  sendPrompt,
   triggerTask,
   updateTask,
 } from "./api.js";
@@ -181,16 +180,6 @@ test("restoreSession does NOT send an id (RestoreSessionRequest has no id field)
   // not know would be rejected as a 400 "unknown field". Archive/kill send `id`
   // only because THEIR request structs accept it — restore's does not.
   assert.equal("id" in cap.body, false, "no id key may reach the daemon, or DisallowUnknownFields 400s the restore");
-});
-
-test("sendPrompt posts the stable id alongside the title and prompt", async () => {
-  const cap = stubFetch();
-  await sendPrompt("id-repoB", "feature", "do the thing", "tok");
-  assert.equal(cap.url, "/v1/SendPrompt");
-  assert.equal(cap.body.id, "id-repoB");
-  assert.equal(cap.body.title, "feature");
-  assert.equal(cap.body.prompt, "do the thing");
-  assert.equal(cap.body.repo_id, "");
 });
 
 test("createTab / closeTab post the stable id alongside the title", async () => {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -364,14 +364,9 @@ export async function createSession(input: CreateSessionInput, token: string): P
 // The lifecycle mutations send the session's stable `id` as the primary lookup
 // key alongside the (display) title, with an empty repo_id. The daemon resolves
 // the target by id FIRST, so a duplicate title across repos can never make the
-// web kill/archive/prompt the wrong session — the write-path analogue of the
+// web kill/archive the wrong session — the write-path analogue of the
 // id-keyed read/stream paths (#1592 Phase 5 PR5). The title is still sent so the
 // daemon's lifecycle event and any title-only fallback stay correct.
-
-/** Sends a prompt to an existing session (mirrors `af sessions send-prompt`). */
-export async function sendPrompt(id: string, title: string, prompt: string, token: string): Promise<void> {
-  await af("SendPrompt", { id, title, repo_id: "", prompt }, token);
-}
 
 /** Kills a session (mirrors `af sessions kill`). The session.killed event removes
  *  its row from the rail live. */

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1238,6 +1238,20 @@ body {
   font-size: var(--af-fs-xs);
 }
 
+/* The pane owns management controls only while the selected rail row is filtered
+ * out (#2188). This is one compact fixed-width group beside the scrolling tab bar;
+ * the buttons themselves come from the rail's shared capability-narrowed builder. */
+.af-term-actions {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  gap: 0.3rem;
+}
+
+.af-term-kill:hover {
+  color: var(--af-danger);
+}
+
 /* The usage-limit Retry action (#1934) is shown by toggling `hidden`, so pin the
  * hidden case as an AUTHOR rule rather than relying on the UA `[hidden]` default.
  * Nothing outranks it today — neither .af-term-action nor .af-ghost sets `display`
@@ -1247,6 +1261,10 @@ body {
  * exact hazard three times (.af-install[hidden], .af-webpane-*[hidden],
  * .af-viewport > [hidden]); one rule now makes the fourth impossible. */
 .af-term-action[hidden] {
+  display: none;
+}
+
+.af-term-actions[hidden] {
   display: none;
 }
 

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -432,6 +432,15 @@ export function orderedSessions(sessions: SessionData[]): SessionData[] {
   return [...sessions].sort(compareSessionsForRail);
 }
 
+/** The exact rows the rail renders after project scope, order, and status filtering.
+ *  Both the rail itself and the selected-session action fallback consume this one
+ *  derivation: if either grows a new display rule, they cannot disagree about whether
+ *  the selected row has a visible management surface (#2188). */
+function visibleRailSessions(state: AppState): SessionData[] {
+  const scoped = scopeToProject(state.sessions, state.selectedProject);
+  return filterSessions(orderedSessions(scoped), state.statusFilter);
+}
+
 /** Renders the paste-token login view, replacing the root's contents. */
 export function renderLogin(root: HTMLElement, state: AppState, actions: Actions): void {
   root.replaceChildren(loginView(state, actions));
@@ -628,13 +637,19 @@ export class AppShell {
   // Header text nodes for the selected pane, (re)created per selection.
   private headTitle: HTMLElement | null = null;
   private headMeta: HTMLElement | null = null;
-  // The selected rail row's archive/restore control and the daemon-owned verb it
+  // The selected visible rail row's archive/restore control and daemon-owned verb it
   // currently shows (#1932, #2186, #2234). Every actionable row owns controls now
   // (#2223), but a session can flip archive⇄restore WITHOUT a selection change, so
   // patchMainHead still needs this reference to swap the selected control in place.
   // null when the selected row is not visible/actionable in the rail.
   private lifecycleBtn: HTMLElement | null = null;
   private lifecycleAction: LifecycleAction | null = null;
+  // A selected session deliberately survives a status-filter change so its terminal
+  // keeps streaming. When that hides its rail row, this stable pane-header container
+  // becomes the one visible management surface (#2188). Its children use the same
+  // capability-narrowed builder as the rail; only their presentation differs.
+  private headActions: HTMLElement | null = null;
+  private headActionSig = "";
   // The usage-limit Retry button and whether it is currently shown (#1934). Same
   // treatment, and for the same reason, as lifecycleBtn above: a session hits the
   // limit wall — or is resumed off it — WITHOUT a selection change, which is the
@@ -1180,7 +1195,7 @@ export class AppShell {
    *  rows, under a notice when there is something worth saying about what's missing. */
   private renderRail(state: AppState): void {
     const scoped = scopeToProject(state.sessions, state.selectedProject);
-    const visible = filterSessions(orderedSessions(scoped), state.statusFilter);
+    const visible = visibleRailSessions(state);
     // Every rebuild replaces the row controls. Drop the old reference first so a
     // selected row hidden by the project/status filter cannot leave patchMainHead
     // mutating a detached button.
@@ -1223,20 +1238,36 @@ export class AppShell {
    *  capability (#2186, #2223, #2234). Archive/Restore and Kill narrow separately;
    *  the browser never reconstructs either policy from status pixels. */
   private rowActions(session: ManagedSession, selected: boolean): HTMLElement {
+    return h("div", { class: "af-row-actions" }, ...this.sessionActionButtons(session, "rail", selected));
+  }
+
+  /** Builds both rail and fallback-header controls from the same daemon capabilities.
+   *  Placement chooses only presentation and whether a mobile rail exit is needed;
+   *  target narrowing, labels, and callbacks remain one path. */
+  private sessionActionButtons(
+    session: ManagedSession,
+    surface: "rail" | "head",
+    selected = false,
+  ): HTMLElement[] {
     const buttons: HTMLElement[] = [];
     if (isActionableSession(session)) {
       const lifecycleSession = session;
-      const lifecycleBtn = h("button", { type: "button", class: "af-rail-action af-rail-lifecycle" });
+      const lifecycleClass =
+        surface === "rail" ? "af-rail-action af-rail-lifecycle" : "af-ghost af-term-action af-term-lifecycle";
+      const lifecycleBtn = h("button", { type: "button", class: lifecycleClass });
       lifecycleBtn.addEventListener("click", (e) => {
         e.stopPropagation();
-        if (lifecycleBtn.dataset.action === "restore") {
-          this.runRailExit(() => this.actions.restore(lifecycleSession));
+        const run = lifecycleBtn.dataset.action === "restore"
+          ? () => this.actions.restore(lifecycleSession)
+          : () => this.actions.archive(lifecycleSession);
+        if (surface === "rail") {
+          this.runRailExit(run);
         } else {
-          this.runRailExit(() => this.actions.archive(lifecycleSession));
+          run();
         }
       });
-      this.patchLifecycleButton(lifecycleBtn, lifecycleSession.lifecycle_action, lifecycleSession.title);
-      if (selected) {
+      this.patchLifecycleButton(lifecycleBtn, lifecycleSession.lifecycle_action, lifecycleSession.title, surface);
+      if (surface === "rail" && selected) {
         this.lifecycleBtn = lifecycleBtn;
         this.lifecycleAction = lifecycleSession.lifecycle_action;
       }
@@ -1247,26 +1278,36 @@ export class AppShell {
       const killSession = session;
       // Kill stays unmistakably destructive through its distinct ⌫ glyph and
       // confirm, but its resting rail treatment remains muted instead of af-danger.
-      const killBtn = h("button", { type: "button", class: "af-rail-action af-rail-kill" }, "⌫");
+      const killClass = surface === "rail" ? "af-rail-action af-rail-kill" : "af-ghost af-term-action af-term-kill";
+      const killBtn = h("button", { type: "button", class: killClass }, surface === "rail" ? "⌫" : "Kill");
       const killLabel = `Kill session “${killSession.title}”`;
       killBtn.setAttribute("aria-label", killLabel);
       killBtn.setAttribute("title", killLabel);
       killBtn.addEventListener("click", (e) => {
         e.stopPropagation();
-        this.runRailExit(() => this.actions.kill(killSession));
+        if (surface === "rail") {
+          this.runRailExit(() => this.actions.kill(killSession));
+        } else {
+          this.actions.kill(killSession);
+        }
       });
       buttons.push(killBtn);
     }
-    return h("div", { class: "af-row-actions" }, ...buttons);
+    return buttons;
   }
 
   /** Applies the daemon-projected verb, glyph, and target-qualified accessible name
    *  in one place so render and same-selection live patching cannot drift. */
-  private patchLifecycleButton(btn: HTMLElement, action: LifecycleAction, sessionTitle: string): void {
+  private patchLifecycleButton(
+    btn: HTMLElement,
+    action: LifecycleAction,
+    sessionTitle: string,
+    surface: "rail" | "head" = "rail",
+  ): void {
     const verb = action === "restore" ? "Restore session" : "Archive session";
     const label = `${verb} “${sessionTitle}”`;
     btn.dataset.action = action;
-    btn.textContent = action === "restore" ? "↶" : "▪";
+    btn.textContent = surface === "rail" ? (action === "restore" ? "↶" : "▪") : verb.replace(" session", "");
     btn.setAttribute("aria-label", label);
     btn.setAttribute("title", label);
   }
@@ -1588,6 +1629,8 @@ export class AppShell {
     if (!selected) {
       this.headTitle = null;
       this.headMeta = null;
+      this.headActions = null;
+      this.headActionSig = "";
       this.retryBtn = null;
       this.retryVisible = false;
       this.tabBar = null;
@@ -1624,6 +1667,14 @@ export class AppShell {
     this.retryVisible = isLimitReached(selected);
     retryBtn.hidden = !this.retryVisible;
 
+    // Empty while the selected row is visible; patchMainHead fills it only when the
+    // shared rail derivation says filtering/scoping removed that row. Keeping the
+    // container stable avoids touching the terminal host as that condition flips.
+    const headActions = h("div", { class: "af-term-actions" });
+    headActions.hidden = true;
+    this.headActions = headActions;
+    this.headActionSig = "";
+
     // The tab bar is the flexible middle of the single pane-header row (#2224):
     // title first, the same horizontally scrolling bar, then the fixed Retry escape
     // when a limit wall makes it visible. Keeping the real bar node here (rather
@@ -1649,10 +1700,10 @@ export class AppShell {
     // button; a listener owned by the old button cannot receive the final dblclick.
     this.attachTabRename(tabBar);
 
-    // Retry is the only pane-level action. Append it directly instead of keeping a
-    // wrapper box: hidden controls create no flex item and therefore no phantom gap
-    // on the common path, while the visible button cannot shrink behind the tabs.
-    const head = h("div", { class: "af-term-head" }, titleBox, tabBar, retryBtn);
+    // Retry and the filtered-selection fallback are fixed pane-level actions. Their
+    // hidden containers create no flex items on the common path, while visible
+    // controls cannot shrink behind the tabs.
+    const head = h("div", { class: "af-term-head" }, titleBox, tabBar, headActions, retryBtn);
 
     this.main.className = "af-main af-main-term";
     // The persistent terminal host is (re)mounted here; renderMain runs only on a
@@ -1962,6 +2013,8 @@ export class AppShell {
     this.headMeta.textContent = parts.join(" · ");
     this.headMeta.className = `af-term-meta af-term-${state.termStatus}`;
 
+    this.patchHeadActions(state, selected);
+
     // Flip the selected rail row's lifecycle glyph + accessible verb when the
     // daemon-owned action changes without a selection change (#1932, #2186, #2234).
     // A fresh Snapshot usually rebuilds the rail too, but this patch keeps the
@@ -1983,6 +2036,39 @@ export class AppShell {
       this.retryVisible = nowLimited;
       this.retryBtn.hidden = !nowLimited;
     }
+  }
+
+  /** Keeps management reachable when the selected session's rail row is filtered
+   *  out, and only then. Capability and row visibility are both positive evidence:
+   *  malformed/inert projections gain no controls, while a visible row remains the
+   *  sole action surface. */
+  private patchHeadActions(state: AppState, selected: SessionData): void {
+    const host = this.headActions;
+    if (!host) {
+      return;
+    }
+    const managed = isActionableSession(selected) || isKillableSession(selected) ? selected : null;
+    const rowVisible = visibleRailSessions(state).some((s) => s.id === selected.id);
+    if (!managed || rowVisible) {
+      if (this.headActionSig !== "") {
+        host.replaceChildren();
+        this.headActionSig = "";
+      }
+      host.hidden = true;
+      return;
+    }
+
+    const sig = JSON.stringify([
+      managed.id,
+      managed.title,
+      managed.lifecycle_action ?? null,
+      managed.can_kill === true,
+    ]);
+    if (sig !== this.headActionSig) {
+      host.replaceChildren(...this.sessionActionButtons(managed, "head"));
+      this.headActionSig = sig;
+    }
+    host.hidden = false;
   }
 }
 


### PR DESCRIPTION
## Summary

- keep Archive/Restore and Kill reachable in the terminal header only while the selected session's rail row is hidden by project/status filtering
- build rail and header controls through one daemon-capability-narrowed path, so inert projections never gain browser-invented actions
- remove the dead `SendPrompt` browser RPC wrapper; web prompt parity is the live terminal input path, not an unreachable API helper

## Codex findings addressed

Both P2 findings from merged PR #2188 are legitimate and addressed together as one browser action-surface/parity theme:

- keep session actions available for filtered selections
- stop counting the dead `SendPrompt` wrapper as a production web surface

## Verification

- `make web-test`: 401/401 passed, including the config-save ordering discriminator
- `make web-build`: committed `web/dist` reproduced with no diff

The required full post-push gates and browser selftest are running against `9050e608573d0f37c701530e3c475eb0e3025431`.

— Captain Claude