### PR TITLE
fix(events): reconnect slow subscribers after overflow

### DIFF
--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -456,10 +456,17 @@ func (m *Manager) archiveExclusiveTabLock(key string, instance *session.Instance
 // it must NEVER be called with m.mu held — see startLockForRepo. Under m.mu, call
 // persistInstanceData directly instead.
 func (m *Manager) persistInstanceErr(repoID string, instance *session.Instance) error {
+	return m.persistInstanceSnapshotErr(repoID, instance.ToInstanceData())
+}
+
+// persistInstanceSnapshotErr is persistInstanceErr for a caller-owned atomic
+// projection. Handoff uses it to checkpoint the durable post-swap facts while
+// retaining its process-local OpReplacing delivery fence in memory.
+func (m *Manager) persistInstanceSnapshotErr(repoID string, data session.InstanceData) error {
 	repoStartLock := m.startLockForRepo(repoID)
 	repoStartLock.Lock()
 	defer repoStartLock.Unlock()
-	return persistInstanceData(repoID, instance.ToInstanceData())
+	return persistInstanceData(repoID, data)
 }
 
 // persistInstance is the best-effort form of persistInstanceErr: a failed write

--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -456,12 +456,20 @@ func (m *Manager) archiveExclusiveTabLock(key string, instance *session.Instance
 // it must NEVER be called with m.mu held — see startLockForRepo. Under m.mu, call
 // persistInstanceData directly instead.
 func (m *Manager) persistInstanceErr(repoID string, instance *session.Instance) error {
-	return m.persistInstanceSnapshotErr(repoID, instance.ToInstanceData())
+	repoStartLock := m.startLockForRepo(repoID)
+	repoStartLock.Lock()
+	defer repoStartLock.Unlock()
+	// Snapshot only AFTER serialization. Taking ToInstanceData as an argument to
+	// a locking helper evaluates it before that helper acquires the lock, letting
+	// a stale status write erase a kill tombstone (#1917).
+	return persistInstanceData(repoID, instance.ToInstanceData())
 }
 
 // persistInstanceSnapshotErr is persistInstanceErr for a caller-owned atomic
 // projection. Handoff uses it to checkpoint the durable post-swap facts while
-// retaining its process-local OpReplacing delivery fence in memory.
+// retaining its process-local OpReplacing delivery fence in memory. It is
+// intentionally separate from persistInstanceErr: ordinary writers must take
+// their Instance snapshot only after acquiring this serialization lock.
 func (m *Manager) persistInstanceSnapshotErr(repoID string, data session.InstanceData) error {
 	repoStartLock := m.startLockForRepo(repoID)
 	repoStartLock.Lock()

--- a/daemon/configagent.go
+++ b/daemon/configagent.go
@@ -3,9 +3,6 @@ package daemon
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -298,41 +295,7 @@ func (m *Manager) SpawnConfigAgent(ctx context.Context, req SpawnConfigAgentRequ
 // an unset CODEX_HOME falls back through the command-specific HOME. Relative
 // values resolve against the effective launch cwd, including GNU env -C.
 func configAgentCodexReceiptHome(program, workingDir string) (string, error) {
-	launch, err := tmux.CommandEnvironmentFromCommand(program, workingDir)
-	if err != nil {
-		return "", fmt.Errorf("cannot resolve Codex receipt environment: %w", err)
-	}
-	effective := func(name string) (string, bool, error) {
-		override := launch.Override(name)
-		if !override.Present {
-			value, set := os.LookupEnv(name)
-			return value, set, nil
-		}
-		if !override.Literal {
-			return "", false, fmt.Errorf("%s uses shell expansion; use a literal path so receipt verification can follow it", name)
-		}
-		return override.Value, override.Set, nil
-	}
-	resolve := func(path string) string {
-		if filepath.IsAbs(path) {
-			return filepath.Clean(path)
-		}
-		return filepath.Clean(filepath.Join(launch.WorkingDir, path))
-	}
-
-	if codexHome, set, err := effective("CODEX_HOME"); err != nil {
-		return "", err
-	} else if set && strings.TrimSpace(codexHome) != "" {
-		return resolve(codexHome), nil
-	}
-	home, set, err := effective("HOME")
-	if err != nil {
-		return "", err
-	}
-	if !set || strings.TrimSpace(home) == "" {
-		return "", fmt.Errorf("CODEX_HOME is unset and the launched command has no literal HOME fallback")
-	}
-	return filepath.Join(resolve(home), ".codex"), nil
+	return tmux.CodexHomeFromCommand(program, workingDir)
 }
 
 // dismissConfigAgentTrustPrompt clears the agent's first-run trust dialog, the

--- a/daemon/conversation_capture.go
+++ b/daemon/conversation_capture.go
@@ -10,14 +10,18 @@ import (
 var conversationCaptureTimeout = 2 * time.Second
 
 func (m *Manager) captureAgentConversationAsync(repoID, key string, inst *session.Instance, snap session.ConversationCaptureSnapshot) {
-	go m.captureAgentConversation(repoID, key, inst, snap, conversationCaptureTimeout)
+	if inst == nil {
+		return
+	}
+	token := inst.AgentRuntimeToken()
+	go m.captureAgentConversation(repoID, key, inst, snap, token, conversationCaptureTimeout)
 }
 
-func (m *Manager) captureAgentConversation(repoID, key string, inst *session.Instance, snap session.ConversationCaptureSnapshot, timeout time.Duration) {
+func (m *Manager) captureAgentConversation(repoID, key string, inst *session.Instance, snap session.ConversationCaptureSnapshot, token session.AgentRuntimeToken, timeout time.Duration) {
 	if inst == nil || inst.UserKilled() || inst.AgentConversation().HasID() {
 		return
 	}
-	agent := inst.ResolvedAgent()
+	agent := token.Agent()
 	if agent == "" {
 		return
 	}
@@ -36,7 +40,7 @@ func (m *Manager) captureAgentConversation(repoID, key string, inst *session.Ins
 	if current != inst || inst.UserKilled() {
 		return
 	}
-	if !inst.SetAgentConversation(conv) {
+	if !inst.SetAgentConversationForRuntime(token, conv) {
 		return
 	}
 

--- a/daemon/conversation_capture_test.go
+++ b/daemon/conversation_capture_test.go
@@ -49,7 +49,7 @@ func TestCaptureAgentConversationPersistsCodexRolloutID(t *testing.T) {
 	snap := session.BeginConversationCapture()
 	writeDaemonCodexRolloutFile(t, codexHome, "rollout-2026-07-06T10-17-35-019f386f-7206-7fc2-803b-f7045e07a242.jsonl")
 
-	manager.captureAgentConversation(repo.ID, key, inst, snap, time.Second)
+	manager.captureAgentConversation(repo.ID, key, inst, snap, inst.AgentRuntimeToken(), time.Second)
 
 	raw, err := config.LoadRepoInstances(repo.ID)
 	require.NoError(t, err)

--- a/daemon/handoff.go
+++ b/daemon/handoff.go
@@ -67,9 +67,10 @@ func (s *controlServer) HandoffSession(req HandoffSessionRequest, resp *HandoffS
 //     stopped and why — so it must be built before Program is rewritten.
 //  4. Raise OpReplacing, then rewrite Program + append the ledger entry.
 //  5. Swap the runtime using the prepared plan: stop the old agent, confirm it
-//     stopped, launch the new one fresh, and commit the replacement fence.
-//  6. Persist the new durable goal/record and begin conversation capture.
-//  7. Wait for readiness, dismiss trust UI, and only then deliver the mission.
+//     stopped, and launch the new one fresh while KEEPING the fence raised.
+//  6. Wait for readiness, dismiss trust UI, and deliver the mission. A usage
+//     limit here atomically parks the incoming runtime with that mission pending.
+//  7. Settle the fence, then persist and begin generation-scoped capture.
 //
 // Rollback: if the runtime swap fails, step 4's state change is reverted, because
 // a record claiming the session runs claude while the pane still runs codex is
@@ -162,7 +163,7 @@ func (m *Manager) HandoffSession(req HandoffSessionRequest) (HandoffSessionRespo
 	}
 	brief := instance.BuildMissionBrief(target, req.Brief, reason)
 	headSHA := brief.Work.HeadSHA
-	conversationCapture := session.BeginConversationCapture()
+	conversationCapture := plan.ConversationCapture()
 
 	// Fence the close/start window before either the record or runtime changes.
 	// New polls skip OpReplacing; a poll already observing the outgoing pane sees
@@ -193,19 +194,18 @@ func (m *Manager) HandoffSession(req HandoffSessionRequest) (HandoffSessionRespo
 	// The runtime this session's failure history was about is gone (#1794).
 	m.noteRuntimeReplaced(repoID, instance)
 
-	// Any usage-limit block is already cleared at this point: SwapAgent commits
-	// the replacement as LiveRunning, which drops LiveLimitReached. That is the
-	// CORRECT outcome here, and it is the opposite of what the #1146 respawn arm
-	// does — that path deliberately re-applies the block, because there the same
-	// agent is coming back and stays parked until its pending prompt lands.
+	// A successful backend swap does not clear the replacement fence yet. That is
+	// intentional: a fresh idle prompt before delivery is not a completed task
+	// run, and the status poll must not observe it as one. Settling below clears
+	// any OUTGOING usage-limit block as part of the incoming agent's outcome. That
+	// is the opposite of what the #1146 respawn arm does — that path deliberately
+	// re-applies the block, because there the same agent is coming back and stays
+	// parked until its pending prompt lands.
 	//
-	// Here the pane is running a DIFFERENT agent, which is not at anyone's limit.
-	// The block described the outgoing agent's plan; re-applying it would badge a
-	// healthy session [limit] and hand it to the auto-resume scheduler, which
-	// would then "resume" an agent that was never blocked. This holds even if the
-	// delivery below fails — the session is then a running agent with no
-	// instructions, which is a different problem than a usage limit and should
-	// not be reported as one.
+	// Here the pane is running a DIFFERENT agent. The old block described the
+	// outgoing agent's plan; re-applying it would badge a healthy incoming session
+	// [limit]. A NEW limit observed while waiting for that incoming agent is a
+	// different fact and parks through ParkHandoff below.
 	//
 	// An operator-supplied brief becomes the durable goal for later limit resumes
 	// and handoffs; replaying the create-time prompt would send the new agent back
@@ -214,17 +214,49 @@ func (m *Manager) HandoffSession(req HandoffSessionRequest) (HandoffSessionRespo
 		instance.SetPrompt(override)
 	}
 
-	// Persist before delivering: the swap is the durable fact, and a delivery
-	// failure must not lose it (the #1854 lesson from the resume path).
-	m.persistInstance(repoID, instance)
-	m.captureAgentConversationAsync(repoID, key, instance, conversationCapture)
-
 	mission := brief.Render()
+	settle := func(event session.TransitionEvent) error {
+		if err := instance.Transition(event); err != nil {
+			return err
+		}
+		// Persist only settled outcomes. Disk persistence strips transient ops, so
+		// writing while OpReplacing is raised would manufacture an unfenced state
+		// no in-memory reader was ever allowed to observe.
+		m.persistInstance(repoID, instance)
+		m.captureAgentConversationAsync(repoID, key, instance, conversationCapture)
+		return nil
+	}
 	if serr := task.WaitForReadyAndSendPrompt(context.Background(), instance, mission); serr != nil {
+		var limitErr *task.LimitReachedError
+		if errors.As(serr, &limitErr) {
+			// The mission never reached the composer. Store the rendered takeover
+			// context — not the old create prompt or bare override — because the
+			// normal limit-resume path replays exactly Instance.Prompt.
+			instance.SetPrompt(mission)
+			if terr := settle(session.ParkHandoff(limitErr.ResetAt)); terr != nil {
+				return HandoffSessionResponse{}, fmt.Errorf(
+					"handed %q off to %s, which hit a usage limit before its mission could be delivered, and failed to park the handoff: %w",
+					req.Title, target, errors.Join(serr, terr))
+			}
+			return HandoffSessionResponse{}, fmt.Errorf(
+				"handed %q off to %s, which hit a usage limit before its mission could be delivered; "+
+					"the rendered mission is saved and will be sent by the normal limit-resume path: %w",
+				req.Title, target, serr)
+		}
+		if terr := settle(session.CommitHandoff()); terr != nil {
+			return HandoffSessionResponse{}, fmt.Errorf(
+				"handed %q off to %s, but its mission delivery and replacement-fence settlement both failed: %w",
+				req.Title, target, errors.Join(serr, terr))
+		}
 		return HandoffSessionResponse{}, fmt.Errorf(
 			"handed %q off to %s, but its mission brief could not be delivered (%w); "+
 				"the new agent is running with no instructions — re-send them with `af sessions send-prompt`",
 			req.Title, target, serr)
+	}
+	if err := settle(session.CommitHandoff()); err != nil {
+		return HandoffSessionResponse{}, fmt.Errorf(
+			"handed %q off to %s and delivered its mission, but could not settle the replacement fence: %w",
+			req.Title, target, err)
 	}
 	log.InfoLog.Printf("handoff: session %q swapped %s → %s at %s", instance.Title, outgoing, target, shortSHA(headSHA))
 

--- a/daemon/handoff.go
+++ b/daemon/handoff.go
@@ -1,12 +1,14 @@
 package daemon
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/task"
 )
 
 // HandoffSessionRequest asks the daemon to continue a session under a different
@@ -56,17 +58,18 @@ func (s *controlServer) HandoffSession(req HandoffSessionRequest, resp *HandoffS
 //
 // The sequence and why it is ordered this way:
 //
-//  1. Resolve and validate BEFORE touching anything. An unsupported backend, an
-//     unknown target, or a target that is already the running agent must fail
-//     without having killed a working agent.
+//  1. Resolve and preflight the exact launch command BEFORE touching anything.
+//     An unsupported backend, unknown/same target, missing executable, or env
+//     wrapper af cannot model must fail without having killed a working agent.
 //  2. Capture the branch tip. This is the attribution boundary, and it has to be
 //     read while the outgoing agent's work is the only work on the branch.
 //  3. Build the mission from the OUTGOING agent's perspective — it names who
 //     stopped and why — so it must be built before Program is rewritten.
-//  4. Rewrite Program + append the ledger entry (SwapAgentProgram).
-//  5. Swap the runtime (SwapAgent): stop the old agent, confirm it stopped,
-//     launch the new one fresh.
-//  6. Deliver the mission.
+//  4. Raise OpReplacing, then rewrite Program + append the ledger entry.
+//  5. Swap the runtime using the prepared plan: stop the old agent, confirm it
+//     stopped, launch the new one fresh, and commit the replacement fence.
+//  6. Persist the new durable goal/record and begin conversation capture.
+//  7. Wait for readiness, dismiss trust UI, and only then deliver the mission.
 //
 // Rollback: if the runtime swap fails, step 4's state change is reverted, because
 // a record claiming the session runs claude while the pane still runs codex is
@@ -144,6 +147,10 @@ func (m *Manager) HandoffSession(req HandoffSessionRequest) (HandoffSessionRespo
 	if err := instance.ValidateHandoffTarget(target); err != nil {
 		return HandoffSessionResponse{}, err
 	}
+	plan, err := instance.PrepareAgentSwap(target)
+	if err != nil {
+		return HandoffSessionResponse{}, fmt.Errorf("cannot hand %q off to %s without stopping its current agent: %w", req.Title, target, err)
+	}
 
 	outgoing := instance.CurrentAgentName()
 
@@ -155,27 +162,39 @@ func (m *Manager) HandoffSession(req HandoffSessionRequest) (HandoffSessionRespo
 	}
 	brief := instance.BuildMissionBrief(target, req.Brief, reason)
 	headSHA := brief.Work.HeadSHA
+	conversationCapture := session.BeginConversationCapture()
 
-	entry, err := instance.SwapAgentProgram(target, reason, headSHA, false)
+	// Fence the close/start window before either the record or runtime changes.
+	// New polls skip OpReplacing; a poll already observing the outgoing pane sees
+	// the bumped state epoch and cannot apply that stale result to the incoming one.
+	if err := instance.Transition(session.BeginHandoff()); err != nil {
+		return HandoffSessionResponse{}, err
+	}
+	entry, err := instance.RecordHandoffSwap(target, reason, headSHA, false)
 	if err != nil {
+		_ = instance.Transition(session.AbortHandoff())
 		return HandoffSessionResponse{}, err
 	}
 
-	if swapErr := instance.SwapAgent(); swapErr != nil {
-		// Put the record back: the pane still runs the outgoing agent, so a
-		// Program that says otherwise would mis-resolve every later respawn.
+	if swapErr := instance.SwapAgent(plan); swapErr != nil {
+		// Put the record back: SwapAgent did not confirm an incoming runtime, so
+		// recording a completed handoff would make later resume/readiness decisions
+		// target an agent af never established. Expected target/config failures were
+		// already rejected by PrepareAgentSwap before teardown; this is the narrow
+		// runtime/infrastructure failure path.
 		if rbErr := instance.RevertHandoff(entry); rbErr != nil {
 			log.ErrorLog.Printf("handoff %q: swap failed (%v) AND the record could not be reverted (%v); "+
 				"the session's recorded agent may not match its running one", req.Title, swapErr, rbErr)
 		}
+		_ = instance.Transition(session.AbortHandoff())
 		return HandoffSessionResponse{}, fmt.Errorf("failed to hand %q off to %s: %w", req.Title, target, swapErr)
 	}
 
 	// The runtime this session's failure history was about is gone (#1794).
 	m.noteRuntimeReplaced(repoID, instance)
 
-	// Any usage-limit block is already cleared at this point: SwapAgent ends in
-	// ConfirmLive, which drops LiveLimitReached and its reset time. That is the
+	// Any usage-limit block is already cleared at this point: SwapAgent commits
+	// the replacement as LiveRunning, which drops LiveLimitReached. That is the
 	// CORRECT outcome here, and it is the opposite of what the #1146 respawn arm
 	// does — that path deliberately re-applies the block, because there the same
 	// agent is coming back and stays parked until its pending prompt lands.
@@ -188,12 +207,20 @@ func (m *Manager) HandoffSession(req HandoffSessionRequest) (HandoffSessionRespo
 	// instructions, which is a different problem than a usage limit and should
 	// not be reported as one.
 	//
+	// An operator-supplied brief becomes the durable goal for later limit resumes
+	// and handoffs; replaying the create-time prompt would send the new agent back
+	// to an obsolete mission.
+	if override := strings.TrimSpace(req.Brief); override != "" {
+		instance.SetPrompt(override)
+	}
+
 	// Persist before delivering: the swap is the durable fact, and a delivery
 	// failure must not lose it (the #1854 lesson from the resume path).
 	m.persistInstance(repoID, instance)
+	m.captureAgentConversationAsync(repoID, key, instance, conversationCapture)
 
 	mission := brief.Render()
-	if serr := instance.AgentServer().SendPrompt(mission); serr != nil {
+	if serr := task.WaitForReadyAndSendPrompt(context.Background(), instance, mission); serr != nil {
 		return HandoffSessionResponse{}, fmt.Errorf(
 			"handed %q off to %s, but its mission brief could not be delivered (%w); "+
 				"the new agent is running with no instructions — re-send them with `af sessions send-prompt`",

--- a/daemon/handoff.go
+++ b/daemon/handoff.go
@@ -177,7 +177,8 @@ func (m *Manager) HandoffSession(req HandoffSessionRequest) (HandoffSessionRespo
 		return HandoffSessionResponse{}, err
 	}
 
-	if swapErr := instance.SwapAgent(plan); swapErr != nil {
+	checkpoint, swapErr := instance.SwapAgent(plan)
+	if swapErr != nil {
 		// Put the record back: SwapAgent did not confirm an incoming runtime, so
 		// recording a completed handoff would make later resume/readiness decisions
 		// target an agent af never established. Expected target/config failures were
@@ -212,6 +213,17 @@ func (m *Manager) HandoffSession(req HandoffSessionRequest) (HandoffSessionRespo
 	// to an obsolete mission.
 	if override := strings.TrimSpace(req.Brief); override != "" {
 		instance.SetPrompt(override)
+		checkpoint.Prompt = override
+	}
+	// The process swap is already irreversible, so checkpoint its durable facts
+	// before the readiness wait. Memory stays fenced, but a daemon crash in this
+	// window must restore the incoming Program rather than lie that the outgoing
+	// agent still owns the pane. The projection also clears any outgoing-provider
+	// limit state, matching CommitHandoff's recovery posture.
+	if err := m.persistInstanceSnapshotErr(repoID, checkpoint); err != nil {
+		// Preserve the existing best-effort persist contract: delivery can still
+		// make the live agent useful, and the final settled write retries below.
+		log.WarningLog.Printf("handoff %q: failed to persist the post-swap checkpoint before mission delivery: %v", req.Title, err)
 	}
 
 	mission := brief.Render()

--- a/daemon/handoff_test.go
+++ b/daemon/handoff_test.go
@@ -122,6 +122,27 @@ func (b *blockingSwapBackend) SwapAgent(i *session.Instance, plan session.AgentS
 	return b.handoffBackend.SwapAgent(i, plan)
 }
 
+type blockingReadinessHandoffBackend struct {
+	*handoffBackend
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (b *blockingReadinessHandoffBackend) Preview(i *session.Instance) (string, error) {
+	b.once.Do(func() { close(b.entered) })
+	<-b.release
+	return b.handoffBackend.Preview(i)
+}
+
+type limitHandoffBackend struct {
+	*handoffBackend
+}
+
+func (b *limitHandoffBackend) Preview(*session.Instance) (string, error) {
+	return "You've hit your usage limit. Try again at Jul 25th, 2026 5:55 PM.", nil
+}
+
 type stalePollHandoffBackend struct {
 	*handoffBackend
 	entered chan struct{}
@@ -419,6 +440,99 @@ func TestHandoffSession_ReplacementFenceSkipsStatusPoll(t *testing.T) {
 	}
 }
 
+// A successful process swap is only the middle of a handoff. The incoming
+// agent is still idle until its mission lands, so the replacement fence must
+// cover readiness and delivery too. Otherwise a status tick in this window can
+// observe Ready and end a task-backed run before the work has even been sent.
+func TestHandoffSession_ReplacementFenceCoversMissionDelivery(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	base := &handoffBackend{FakeBackend: session.NewFakeBackend()}
+	backend := &blockingReadinessHandoffBackend{
+		handoffBackend: base,
+		entered:        make(chan struct{}),
+		release:        make(chan struct{}),
+	}
+	inst := registerHandoffSubject(t, manager, repoID, repoPath, "fenced-delivery", backend)
+	done := make(chan error, 1)
+	go func() {
+		_, err := manager.HandoffSession(HandoffSessionRequest{
+			Title: "fenced-delivery", RepoID: repoID, To: tmux.ProgramGemini,
+		})
+		done <- err
+	}()
+
+	select {
+	case <-backend.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handoff never reached incoming-agent readiness")
+	}
+	opDuringReadiness := inst.GetInFlightOp()
+	manager.refreshInstanceStatus(repoID, inst)
+	_, _, statusPolls := base.eventSnapshot()
+	close(backend.release)
+	if err := <-done; err != nil {
+		t.Fatalf("HandoffSession: %v", err)
+	}
+
+	if opDuringReadiness != session.OpReplacing {
+		t.Fatalf("in-flight op while the incoming mission was still undelivered = %v, want OpReplacing", opDuringReadiness)
+	}
+	if statusPolls != 0 {
+		t.Fatalf("status poll probed %d times before the incoming mission landed; an idle prompt here is not a completed task run", statusPolls)
+	}
+	if got := inst.GetInFlightOp(); got != session.OpNone {
+		t.Fatalf("in-flight op after mission delivery = %v, want OpNone", got)
+	}
+}
+
+// A usage-limit banner can replace the incoming composer's ready prompt. That
+// is a parked handoff, not a generic delivery failure: the rendered takeover
+// brief must become the pending prompt so the normal limit-resume path sends
+// the context that never landed on this attempt.
+func TestHandoffSession_ParksIncomingLimitWithMissionPending(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	base := &handoffBackend{FakeBackend: session.NewFakeBackend()}
+	backend := &limitHandoffBackend{handoffBackend: base}
+	inst := registerHandoffSubject(t, manager, repoID, repoPath, "incoming-limit", backend)
+	inst.SetPrompt("finish the transaction without discarding the existing work")
+
+	_, err := manager.HandoffSession(HandoffSessionRequest{
+		Title: "incoming-limit", RepoID: repoID, To: tmux.ProgramCodex,
+	})
+	if !errors.Is(err, task.ErrLimitReached) {
+		t.Fatalf("HandoffSession error = %v, want a wrapped task.ErrLimitReached parked outcome", err)
+	}
+	if !inst.LimitReached() {
+		t.Fatal("incoming agent hit a limit during readiness but the handoff remained LiveRunning")
+	}
+	if _, ok := inst.LimitResetAt(); !ok {
+		t.Fatal("parked handoff lost the reset time parsed from the incoming agent's banner")
+	}
+	if got := inst.GetInFlightOp(); got != session.OpNone {
+		t.Fatalf("parked handoff retained in-flight op %v, want OpNone", got)
+	}
+	pending := inst.GetPrompt()
+	if !strings.Contains(pending, "continuing work") ||
+		!strings.Contains(pending, "finish the transaction without discarding the existing work") {
+		t.Fatalf("pending prompt is not the rendered takeover mission:\n%s", pending)
+	}
+	if _, prompts := base.snapshot(); len(prompts) != 0 {
+		t.Fatalf("sent %d prompts despite the incoming usage-limit banner, want 0", len(prompts))
+	}
+
+	raw, loadErr := config.LoadRepoInstances(repoID)
+	if loadErr != nil {
+		t.Fatalf("LoadRepoInstances: %v", loadErr)
+	}
+	var stored []session.InstanceData
+	if decodeErr := json.Unmarshal(raw, &stored); decodeErr != nil {
+		t.Fatalf("decode instances: %v", decodeErr)
+	}
+	if len(stored) != 1 || stored[0].Liveness != session.LiveLimitReached || stored[0].Prompt != pending {
+		t.Fatalf("persisted parked handoff = %+v, want LiveLimitReached with the rendered mission pending", stored)
+	}
+}
+
 func TestHandoffSession_StaleOutgoingPollCannotMarkIncomingAgentLost(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 	base := &handoffBackend{FakeBackend: session.NewFakeBackend()}
@@ -524,4 +638,39 @@ func TestHandoffSession_CapturesIncomingCodexConversation(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("incoming Codex conversation was never captured: %+v", inst.AgentConversation())
+}
+
+// Conversation capture is asynchronous. A capture started for one Codex
+// runtime must not write through two later handoffs merely because the session
+// pointer — and eventually even the agent name — match again.
+func TestConversationCapture_DropsResultAfterLaterHandoffs(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	codexHome := t.TempDir()
+	t.Setenv("CODEX_HOME", codexHome)
+	backend := &handoffBackend{FakeBackend: session.NewFakeBackend()}
+	inst := registerHandoffSubject(t, manager, repoID, repoPath, "capture-generation", backend)
+
+	if _, err := inst.SwapAgentProgram(tmux.ProgramCodex, session.HandoffReasonManual, "sha-1", false); err != nil {
+		t.Fatalf("move fixture to Codex: %v", err)
+	}
+	inst.SetTmuxSession(tmux.NewTmuxSession(inst.Title, tmux.ProgramCodex))
+	snap := session.BeginConversationCaptureAtCodexHome(codexHome)
+	token := inst.AgentRuntimeToken()
+
+	if _, err := inst.SwapAgentProgram(tmux.ProgramClaude, session.HandoffReasonManual, "sha-2", false); err != nil {
+		t.Fatalf("first later handoff: %v", err)
+	}
+	inst.SetTmuxSession(tmux.NewTmuxSession(inst.Title, tmux.ProgramClaude))
+	if _, err := inst.SwapAgentProgram(tmux.ProgramCodex, session.HandoffReasonManual, "sha-3", false); err != nil {
+		t.Fatalf("second later handoff: %v", err)
+	}
+	inst.SetTmuxSession(tmux.NewTmuxSession(inst.Title, tmux.ProgramCodex))
+
+	writeDaemonCodexRolloutFile(t, codexHome, "rollout-2026-07-21T10-17-35-019f386f-7206-7fc2-803b-f7045e07a242.jsonl")
+	manager.captureAgentConversation(
+		repoID, daemonInstanceKey(repoID, inst.Title), inst, snap, token, time.Second,
+	)
+	if conv := inst.AgentConversation(); conv.HasID() {
+		t.Fatalf("capture from the superseded Codex runtime overwrote the current live slot: %+v", conv)
+	}
 }

--- a/daemon/handoff_test.go
+++ b/daemon/handoff_test.go
@@ -453,6 +453,7 @@ func TestHandoffSession_ReplacementFenceCoversMissionDelivery(t *testing.T) {
 		release:        make(chan struct{}),
 	}
 	inst := registerHandoffSubject(t, manager, repoID, repoPath, "fenced-delivery", backend)
+	inst.SetLimitReached(time.Date(2026, 7, 22, 9, 0, 0, 0, time.UTC))
 	done := make(chan error, 1)
 	go func() {
 		_, err := manager.HandoffSession(HandoffSessionRequest{
@@ -469,6 +470,11 @@ func TestHandoffSession_ReplacementFenceCoversMissionDelivery(t *testing.T) {
 	opDuringReadiness := inst.GetInFlightOp()
 	manager.refreshInstanceStatus(repoID, inst)
 	_, _, statusPolls := base.eventSnapshot()
+	raw, checkpointErr := config.LoadRepoInstances(repoID)
+	var checkpoint []session.InstanceData
+	if checkpointErr == nil {
+		checkpointErr = json.Unmarshal(raw, &checkpoint)
+	}
 	close(backend.release)
 	if err := <-done; err != nil {
 		t.Fatalf("HandoffSession: %v", err)
@@ -479,6 +485,13 @@ func TestHandoffSession_ReplacementFenceCoversMissionDelivery(t *testing.T) {
 	}
 	if statusPolls != 0 {
 		t.Fatalf("status poll probed %d times before the incoming mission landed; an idle prompt here is not a completed task run", statusPolls)
+	}
+	if checkpointErr != nil {
+		t.Fatalf("load runtime-swap checkpoint: %v", checkpointErr)
+	}
+	if len(checkpoint) != 1 || checkpoint[0].Program != tmux.ProgramGemini ||
+		checkpoint[0].Liveness != session.LiveRunning || !checkpoint[0].LimitResetAt.IsZero() {
+		t.Fatalf("disk checkpoint during delivery fence = %+v; want incoming program as Running with the outgoing limit cleared", checkpoint)
 	}
 	if got := inst.GetInFlightOp(); got != session.OpNone {
 		t.Fatalf("in-flight op after mission delivery = %v, want OpNone", got)

--- a/daemon/handoff_test.go
+++ b/daemon/handoff_test.go
@@ -1,14 +1,19 @@
 package daemon
 
 import (
+	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/tmux"
+	"github.com/sachiniyer/agent-factory/task"
 )
 
 // registerHandoffSubject is registerStarted plus the agent tab a handoff needs:
@@ -16,6 +21,7 @@ import (
 // without one has nothing to hand off. SetTmuxSession materializes it.
 func registerHandoffSubject(t *testing.T, m *Manager, repoID, repoPath, title string, backend session.Backend) *session.Instance {
 	t.Helper()
+	t.Cleanup(task.SetTrustPromptTimingForTest(time.Millisecond))
 	inst := registerStarted(t, m, repoID, repoPath, title, backend, true, session.Running)
 	inst.SetTmuxSession(tmux.NewTmuxSession(title, tmux.ProgramClaude))
 	inst.SetAgentConversation(session.AgentConversationData{
@@ -31,11 +37,14 @@ func registerHandoffSubject(t *testing.T, m *Manager, repoID, repoPath, title st
 // swap so the rollback path is exercised.
 type handoffBackend struct {
 	*session.FakeBackend
-	mu          sync.Mutex
-	swapCalls   int
-	swapErr     error
-	sentPrompts []string
-	noHandoff   bool
+	mu              sync.Mutex
+	swapCalls       int
+	swapErr         error
+	sentPrompts     []string
+	previewCalls    int
+	hasUpdatedCalls int
+	events          []string
+	noHandoff       bool
 }
 
 func (b *handoffBackend) Capabilities() session.Capabilities {
@@ -46,23 +55,104 @@ func (b *handoffBackend) Capabilities() session.Capabilities {
 	return caps
 }
 
-func (b *handoffBackend) SwapAgent(i *session.Instance) error {
+func (b *handoffBackend) SwapAgent(i *session.Instance, _ session.AgentSwapPlan) error {
 	b.mu.Lock()
 	b.swapCalls++
+	b.events = append(b.events, "swap")
 	err := b.swapErr
 	b.mu.Unlock()
 	if err != nil {
 		return err
 	}
-	_ = i.Transition(session.ConfirmLive())
+	// Mirror the local backend's SetProgram: readiness and conversation capture
+	// must identify the incoming agent from the pane command, not stale tmux state.
+	i.SetTmuxSession(tmux.NewTmuxSession(i.Title, i.AgentProgram()))
 	return nil
+}
+
+func (b *handoffBackend) Preview(*session.Instance) (string, error) {
+	// One fixture containing each simple agent's ready glyph keeps these daemon
+	// orchestration tests independent of which supported target they choose.
+	b.mu.Lock()
+	b.previewCalls++
+	b.events = append(b.events, "ready")
+	b.mu.Unlock()
+	return "ready\n❯\n›\n> \n╰", nil
+}
+
+func (b *handoffBackend) HasUpdated(*session.Instance) (bool, bool, string) {
+	b.mu.Lock()
+	b.hasUpdatedCalls++
+	b.mu.Unlock()
+	return false, false, ""
 }
 
 func (b *handoffBackend) SendPromptCommand(_ *session.Instance, prompt string) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	b.events = append(b.events, "send")
 	b.sentPrompts = append(b.sentPrompts, prompt)
 	return nil
+}
+
+func (b *handoffBackend) eventSnapshot() (events []string, previews, statusPolls int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return append([]string(nil), b.events...), b.previewCalls, b.hasUpdatedCalls
+}
+
+type rejectingHandoffBackend struct {
+	*handoffBackend
+	err error
+}
+
+func (b *rejectingHandoffBackend) PrepareAgentSwap(*session.Instance, string) (session.AgentSwapPlan, error) {
+	return session.AgentSwapPlan{}, b.err
+}
+
+type blockingSwapBackend struct {
+	*handoffBackend
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (b *blockingSwapBackend) SwapAgent(i *session.Instance, plan session.AgentSwapPlan) error {
+	close(b.entered)
+	<-b.release
+	return b.handoffBackend.SwapAgent(i, plan)
+}
+
+type stalePollHandoffBackend struct {
+	*handoffBackend
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (b *stalePollHandoffBackend) HasUpdated(*session.Instance) (bool, bool, string) {
+	close(b.entered)
+	<-b.release
+	return false, false, ""
+}
+
+func (b *stalePollHandoffBackend) IsAlive(*session.Instance) (bool, error) {
+	return false, nil
+}
+
+type rolloutHandoffBackend struct {
+	*handoffBackend
+	codexHome string
+}
+
+func (b *rolloutHandoffBackend) SwapAgent(i *session.Instance, plan session.AgentSwapPlan) error {
+	if err := b.handoffBackend.SwapAgent(i, plan); err != nil {
+		return err
+	}
+	path := filepath.Join(b.codexHome, "sessions", "2026", "07", "21",
+		"rollout-2026-07-21T10-17-35-019f386f-7206-7fc2-803b-f7045e07a242.jsonl")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(`{"type":"session_meta"}`+"\n"), 0o644)
 }
 
 func (b *handoffBackend) snapshot() (swaps int, prompts []string) {
@@ -270,4 +360,168 @@ func TestHandoffSession_RefusesArchivedSession(t *testing.T) {
 	if got := inst.GetLiveness(); got != session.LiveArchived {
 		t.Fatalf("liveness = %v after refused handoff, want Archived", got)
 	}
+}
+
+func TestHandoffSession_PreflightFailureLeavesOutgoingAgentUntouched(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	base := &handoffBackend{FakeBackend: session.NewFakeBackend()}
+	backend := &rejectingHandoffBackend{handoffBackend: base, err: errors.New("gemini executable is missing")}
+	inst := registerHandoffSubject(t, manager, repoID, repoPath, "preflight-fails", backend)
+
+	_, err := manager.HandoffSession(HandoffSessionRequest{
+		Title: "preflight-fails", RepoID: repoID, To: tmux.ProgramGemini,
+	})
+	if err == nil || !strings.Contains(err.Error(), "without stopping its current agent") {
+		t.Fatalf("preflight error = %v, want an actionable refusal before teardown", err)
+	}
+	if swaps, prompts := base.snapshot(); swaps != 0 || len(prompts) != 0 {
+		t.Fatalf("failed preflight touched runtime: swaps=%d prompts=%d", swaps, len(prompts))
+	}
+	if inst.AgentProgram() != tmux.ProgramClaude || len(inst.Handoffs()) != 0 || inst.GetInFlightOp() != session.OpNone {
+		t.Fatalf("failed preflight mutated record: program=%q handoffs=%d op=%v",
+			inst.AgentProgram(), len(inst.Handoffs()), inst.GetInFlightOp())
+	}
+}
+
+func TestHandoffSession_ReplacementFenceSkipsStatusPoll(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	base := &handoffBackend{FakeBackend: session.NewFakeBackend()}
+	backend := &blockingSwapBackend{
+		handoffBackend: base,
+		entered:        make(chan struct{}),
+		release:        make(chan struct{}),
+	}
+	inst := registerHandoffSubject(t, manager, repoID, repoPath, "fenced", backend)
+	done := make(chan error, 1)
+	go func() {
+		_, err := manager.HandoffSession(HandoffSessionRequest{
+			Title: "fenced", RepoID: repoID, To: tmux.ProgramGemini,
+		})
+		done <- err
+	}()
+
+	select {
+	case <-backend.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handoff never reached the runtime swap")
+	}
+	if got := inst.GetInFlightOp(); got != session.OpReplacing {
+		t.Fatalf("in-flight op during swap = %v, want OpReplacing", got)
+	}
+	manager.refreshInstanceStatus(repoID, inst)
+	_, _, statusPolls := base.eventSnapshot()
+	if statusPolls != 0 {
+		t.Fatalf("status poll probed %d times during replacement; it can observe the intentional no-pane gap as Lost", statusPolls)
+	}
+	close(backend.release)
+	if err := <-done; err != nil {
+		t.Fatalf("HandoffSession: %v", err)
+	}
+}
+
+func TestHandoffSession_StaleOutgoingPollCannotMarkIncomingAgentLost(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	base := &handoffBackend{FakeBackend: session.NewFakeBackend()}
+	backend := &stalePollHandoffBackend{
+		handoffBackend: base,
+		entered:        make(chan struct{}),
+		release:        make(chan struct{}),
+	}
+	inst := registerHandoffSubject(t, manager, repoID, repoPath, "stale-poll", backend)
+	pollDone := make(chan struct{})
+	go func() {
+		manager.refreshInstanceStatus(repoID, inst)
+		close(pollDone)
+	}()
+	select {
+	case <-backend.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("status poll never captured the outgoing epoch")
+	}
+
+	if _, err := manager.HandoffSession(HandoffSessionRequest{
+		Title: "stale-poll", RepoID: repoID, To: tmux.ProgramGemini,
+	}); err != nil {
+		t.Fatalf("HandoffSession: %v", err)
+	}
+	close(backend.release)
+	select {
+	case <-pollDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stale status poll did not return")
+	}
+	if got := inst.GetLiveness(); got != session.LiveRunning {
+		t.Fatalf("stale outgoing observation changed incoming liveness to %v, want Running", got)
+	}
+}
+
+func TestHandoffSession_OverrideBecomesDurablePrompt(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &handoffBackend{FakeBackend: session.NewFakeBackend()}
+	inst := registerHandoffSubject(t, manager, repoID, repoPath, "new-goal", backend)
+	inst.SetPrompt("obsolete create-time goal")
+
+	const newGoal = "finish the receipt race without reverting the existing fix"
+	if _, err := manager.HandoffSession(HandoffSessionRequest{
+		Title: "new-goal", RepoID: repoID, To: tmux.ProgramGemini, Brief: newGoal,
+	}); err != nil {
+		t.Fatalf("HandoffSession: %v", err)
+	}
+	if got := inst.GetPrompt(); got != newGoal {
+		t.Fatalf("in-memory prompt = %q, want handoff override %q", got, newGoal)
+	}
+	raw, err := config.LoadRepoInstances(repoID)
+	if err != nil {
+		t.Fatalf("LoadRepoInstances: %v", err)
+	}
+	var stored []session.InstanceData
+	if err := json.Unmarshal(raw, &stored); err != nil {
+		t.Fatalf("decode instances: %v", err)
+	}
+	if len(stored) != 1 || stored[0].Prompt != newGoal {
+		t.Fatalf("persisted prompt = %+v, want %q", stored, newGoal)
+	}
+}
+
+func TestHandoffSession_WaitsForIncomingReadinessBeforeBriefing(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &handoffBackend{FakeBackend: session.NewFakeBackend()}
+	registerHandoffSubject(t, manager, repoID, repoPath, "ordered-delivery", backend)
+
+	if _, err := manager.HandoffSession(HandoffSessionRequest{
+		Title: "ordered-delivery", RepoID: repoID, To: tmux.ProgramGemini,
+	}); err != nil {
+		t.Fatalf("HandoffSession: %v", err)
+	}
+	events, previews, _ := backend.eventSnapshot()
+	if previews == 0 {
+		t.Fatalf("handoff sent a mission without a readiness probe: events=%v", events)
+	}
+	want := []string{"swap", "ready", "send"}
+	if len(events) < len(want) || events[0] != want[0] || events[1] != want[1] || events[len(events)-1] != want[2] {
+		t.Fatalf("handoff event order = %v, want runtime swap then readiness then send", events)
+	}
+}
+
+func TestHandoffSession_CapturesIncomingCodexConversation(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	codexHome := t.TempDir()
+	t.Setenv("CODEX_HOME", codexHome)
+	base := &handoffBackend{FakeBackend: session.NewFakeBackend()}
+	backend := &rolloutHandoffBackend{handoffBackend: base, codexHome: codexHome}
+	inst := registerHandoffSubject(t, manager, repoID, repoPath, "capture-codex", backend)
+
+	if _, err := manager.HandoffSession(HandoffSessionRequest{
+		Title: "capture-codex", RepoID: repoID, To: tmux.ProgramCodex,
+	}); err != nil {
+		t.Fatalf("HandoffSession: %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if conv := inst.AgentConversation(); conv.Agent == tmux.ProgramCodex && conv.ID == "019f386f-7206-7fc2-803b-f7045e07a242" {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("incoming Codex conversation was never captured: %+v", inst.AgentConversation())
 }

--- a/daemon/limit.go
+++ b/daemon/limit.go
@@ -22,11 +22,11 @@ import (
 //     the prompt so the resume machinery (the daemon auto-resume scheduler when
 //     limit_auto_resume is on, or the manual `c` retry) re-delivers it once the
 //     window resets. Return nil so CreateSession registers+persists it as a
-//     parked row, not a failed one, firing no failure side-effects. instance.Prompt
-//     is the only input resumeFromLimit re-delivers and is never otherwise set on
-//     a daemon-created instance (the initial prompt goes straight to
-//     StartAndSendPrompt), so it is set here so a parked task run resumes its OWN
-//     work rather than a bare "continue".
+//     parked row, not a failed one, firing no failure side-effects. The stored
+//     prompt is the only input resumeFromLimit re-delivers, so it is set here so
+//     a parked task run resumes its OWN work rather than a bare "continue". A
+//     later handoff brief may replace this durable goal; both paths use Instance's
+//     prompt accessors so the resume scheduler cannot race the handoff writer.
 //   - any other error: return it for CreateSession to surface after tearing the
 //     half-started session down.
 func finishCreateStart(instance *session.Instance, prompt string, startErr error) error {
@@ -38,7 +38,7 @@ func finishCreateStart(instance *session.Instance, prompt string, startErr error
 	var limitErr *task.LimitReachedError
 	if errors.As(startErr, &limitErr) {
 		instance.SetLimitReached(limitErr.ResetAt)
-		instance.Prompt = prompt
+		instance.SetPrompt(prompt)
 		return nil
 	}
 	return startErr
@@ -457,7 +457,7 @@ func (m *Manager) resumeFromLimitLocked(repoID, key string, instance *session.In
 		m.persistInstance(repoID, instance)
 	}
 
-	prompt := strings.TrimSpace(instance.Prompt)
+	prompt := strings.TrimSpace(instance.GetPrompt())
 	if prompt == "" {
 		// Interactive session with no stored prompt: the best we can do is
 		// un-stall it. Loses the agent's prior context (documented caveat).

--- a/daemon/manager_status.go
+++ b/daemon/manager_status.go
@@ -453,7 +453,7 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 		// Fresh output. Only a live pane produces bytes, and a dead one yields "" —
 		// so this is affirmative on its own, no probe needed.
 		observedAlive = true
-		_ = instance.Transition(session.ObserveLiveness(session.LiveRunning))
+		_ = instance.Transition(session.ObserveLiveness(session.LiveRunning).AtEpoch(epoch))
 	case hasPrompt:
 		// A matched prompt means the CAPTURE SUCCEEDED: hasPrompt is a substring test
 		// over content, and every failure path in HasUpdated returns content "". So
@@ -476,7 +476,7 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 			// AUTHORITATIVE: the agent-server (or local tmux) was asked and
 			// reports the agent gone. No debounce — the evidence is present and
 			// bad, not absent. #935's immediacy is unchanged for both runtimes.
-			_ = instance.Transition(session.ObserveLiveness(session.LiveLost))
+			_ = instance.Transition(session.ObserveLiveness(session.LiveLost).AtEpoch(epoch))
 		case probeUnknown:
 			// A REMOTE probe that never answered. It says nothing about the agent,
 			// and Lost here feeds a re-provision that orphans a possibly-live
@@ -493,7 +493,7 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 			// could not be answered" — so a degrading transport starts its episode
 			// at the first unanswered probe rather than the first failed Snapshot.
 			if m.noteRemoteProbeFailure(key, instance.Title) {
-				_ = instance.Transition(session.ObserveLiveness(session.LiveLost))
+				_ = instance.Transition(session.ObserveLiveness(session.LiveLost).AtEpoch(epoch))
 			}
 		case probeAlive:
 			// The agent-server was asked and reports its agent RUNNING — the

--- a/daemon/ws_events.go
+++ b/daemon/ws_events.go
@@ -26,15 +26,15 @@ import (
 // threaded through the auth/CORS seam and covered by the WS harness.
 
 // eventsBufferSize bounds one subscriber's pending-event queue. A subscriber that
-// falls this far behind has an event dropped (non-blocking publish) rather than
-// stalling the mutation that published it — a dropped state-change is recoverable
-// by a Snapshot, a blocked daemon mutation is not. Generous enough that a healthy
-// client never drops.
+// falls this far behind is disconnected (non-blocking publish) rather than
+// stalling the mutation that published it. Reconnect triggers the client's
+// authoritative Snapshot, so overflow is observable and self-healing instead of
+// leaving an open connection with silently stale state.
 const eventsBufferSize = 256
 
 // eventsHub is the Manager-owned fan-out of state-change events to every
-// connected /v1/events subscriber. Non-blocking on publish (drop-slow), so no
-// subscriber can back-pressure a daemon mutation.
+// connected /v1/events subscriber. Non-blocking on publish (disconnect-slow), so
+// no subscriber can back-pressure a daemon mutation.
 type eventsHub struct {
 	mu   sync.Mutex
 	subs map[uint64]chan agentproto.Event
@@ -60,20 +60,26 @@ func (h *eventsHub) subscribe() (uint64, <-chan agentproto.Event) {
 func (h *eventsHub) unsubscribe(id uint64) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	delete(h.subs, id)
+	if ch, ok := h.subs[id]; ok {
+		delete(h.subs, id)
+		close(ch)
+	}
 }
 
-// publish fans an event to every subscriber, dropping it for any whose buffer is
-// full (never blocking the mutation that published it).
+// publish fans an event to every subscriber. A full buffer removes that
+// subscriber and closes its channel (never blocking the mutation that published
+// it), making the client's existing reconnect/resync path authoritative.
 func (h *eventsHub) publish(ev agentproto.Event) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	for _, ch := range h.subs {
+	for id, ch := range h.subs {
 		select {
 		case ch <- ev:
 		default:
-			// Slow subscriber: drop this event rather than block the daemon. The
-			// client can re-Snapshot to resynchronise.
+			// Slow subscriber: close it rather than leave the client with a
+			// silently stale open connection. Reconnect causes a Snapshot.
+			delete(h.subs, id)
+			close(ch)
 		}
 	}
 }
@@ -146,7 +152,12 @@ func serveEvents(hub *eventsHub, conn *websocket.Conn) {
 			_ = conn.Close(websocket.StatusNormalClosure, "")
 			wg.Wait()
 			return
-		case ev := <-ch:
+		case ev, ok := <-ch:
+			if !ok {
+				_ = conn.Close(websocket.StatusPolicyViolation, "events subscriber fell behind; reconnecting")
+				wg.Wait()
+				return
+			}
 			wctx, wcancel := context.WithTimeout(ctx, wsWriteTimeout)
 			err := agentproto.WriteControl(wctx, conn, ev)
 			wcancel()

--- a/daemon/ws_events_test.go
+++ b/daemon/ws_events_test.go
@@ -14,11 +14,11 @@ import (
 	"github.com/sachiniyer/agent-factory/session"
 )
 
-// TestEventsHubFanoutAndDropSlow pins the hub contract: an event fans out to
-// every subscriber, and a subscriber whose bounded buffer is full drops events
-// rather than blocking publish (so a slow client can never back-pressure a daemon
-// mutation).
-func TestEventsHubFanoutAndDropSlow(t *testing.T) {
+// TestEventsHubFanoutAndDisconnectSlow pins the hub contract: an event fans out
+// to every subscriber, and a subscriber whose bounded buffer is full is closed
+// rather than blocking publish (so a slow client can never back-pressure a
+// daemon mutation or remain silently stale).
+func TestEventsHubFanoutAndDisconnectSlow(t *testing.T) {
 	hub := newEventsHub()
 	_, a := hub.subscribe()
 	_, b := hub.subscribe()
@@ -39,7 +39,8 @@ func TestEventsHubFanoutAndDropSlow(t *testing.T) {
 		}
 	}
 
-	// Overfill one subscriber's buffer: publish must not block (drop-slow).
+	// Overfill one subscriber's buffer: publish must not block and must close the
+	// slow subscriber so its reconnect path can request an authoritative Snapshot.
 	done := make(chan struct{})
 	go func() {
 		for i := 0; i < eventsBufferSize*3; i++ {
@@ -50,7 +51,18 @@ func TestEventsHubFanoutAndDropSlow(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):
-		t.Fatal("publish blocked on a full subscriber buffer (drop-slow broken)")
+		t.Fatal("publish blocked on a full subscriber buffer (disconnect-slow broken)")
+	}
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case _, ok := <-a:
+			if !ok {
+				return
+			}
+		case <-deadline:
+			t.Fatal("slow subscriber was not closed after its buffer filled")
+		}
 	}
 }
 

--- a/preflight/preflight.go
+++ b/preflight/preflight.go
@@ -11,6 +11,7 @@ import (
 	"unicode"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/envcommand"
 	"github.com/sachiniyer/agent-factory/internal/shellsuggest"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
@@ -80,7 +81,10 @@ func CheckCommand(command string) (*ProgramCheck, error) {
 	if err != nil {
 		return check, err
 	}
-	exe := firstExecutable(words)
+	exe, err := firstExecutable(words)
+	if err != nil {
+		return check, fmt.Errorf("could not resolve executable in command %q: %w", command, err)
+	}
 	check.Executable = exe
 	if exe == "" {
 		return check, fmt.Errorf("could not find an executable in command %q", command)
@@ -208,35 +212,30 @@ func isSupportedAgent(agent string) bool {
 	return false
 }
 
-func firstExecutable(words []string) string {
+func firstExecutable(words []string) (string, error) {
 	for len(words) > 0 && isAssignment(words[0]) {
 		words = words[1:]
 	}
 	if len(words) == 0 {
-		return ""
+		return "", nil
 	}
 	if words[0] != "env" {
-		return words[0]
+		return words[0], nil
 	}
-	words = words[1:]
-	for len(words) > 0 {
-		switch {
-		case words[0] == "--":
-			words = words[1:]
-		case isAssignment(words[0]):
-			words = words[1:]
-		case words[0] == "-u" || words[0] == "--unset" || words[0] == "-C" || words[0] == "--chdir":
-			if len(words) < 2 {
-				return ""
-			}
-			words = words[2:]
-		case strings.HasPrefix(words[0], "-"):
-			words = words[1:]
-		default:
-			return words[0]
-		}
+
+	// GNU env is parsed in one place. In particular, do not skip an unknown
+	// option and guess that the following token is the executable: the same
+	// command resolver is used to authorize a destructive handoff, so a guessed
+	// preflight can stop the outgoing agent before discovering the target was not
+	// runnable. Receipt routing and tmuxguard consume this parser as well.
+	invocation, err := envcommand.Parse(words[1:], envcommand.Policy{AllowAssignments: true})
+	if err != nil {
+		return "", err
 	}
-	return ""
+	if invocation.CommandIndex < 0 {
+		return "", nil
+	}
+	return words[1+invocation.CommandIndex], nil
 }
 
 func isAssignment(word string) bool {

--- a/preflight/preflight.go
+++ b/preflight/preflight.go
@@ -89,30 +89,46 @@ func CheckCommand(command string) (*ProgramCheck, error) {
 	if exe == "" {
 		return check, fmt.Errorf("could not find an executable in command %q", command)
 	}
+	// env is itself an executable as well as a command parser. Validate both
+	// halves: approving only the wrapper misses a missing target, while approving
+	// only the target turns a missing custom /path/to/env into a launch-time
+	// failure after a destructive handoff has already stopped the old agent.
+	if wrapper := envWrapperExecutable(words); wrapper != "" {
+		if _, err := resolveExecutable(wrapper); err != nil {
+			return check, fmt.Errorf("env wrapper %q cannot be executed: %w", wrapper, err)
+		}
+	}
+	path, err := resolveExecutable(exe)
+	if err != nil {
+		return check, err
+	}
+	check.Path = path
+	return check, nil
+}
+
+func resolveExecutable(exe string) (string, error) {
 	if strings.ContainsRune(exe, filepath.Separator) || strings.HasPrefix(exe, "~") {
 		path := config.ExpandTilde(exe)
 		info, err := os.Stat(path)
 		if err != nil {
 			if os.IsNotExist(err) {
-				return check, fmt.Errorf("%w: executable %q does not exist", errProgramNotFound, exe)
+				return "", fmt.Errorf("%w: executable %q does not exist", errProgramNotFound, exe)
 			}
-			return check, fmt.Errorf("executable %q could not be checked: %w", exe, err)
+			return "", fmt.Errorf("executable %q could not be checked: %w", exe, err)
 		}
 		if info.IsDir() {
-			return check, fmt.Errorf("executable %q is a directory, not a program", exe)
+			return "", fmt.Errorf("executable %q is a directory, not a program", exe)
 		}
 		if info.Mode().Perm()&0o111 == 0 {
-			return check, fmt.Errorf("%w: executable %q is not executable; run: %s", errProgramNotExecutable, exe, shellsuggest.Command("chmod", "+x", path))
+			return "", fmt.Errorf("%w: executable %q is not executable; run: %s", errProgramNotExecutable, exe, shellsuggest.Command("chmod", "+x", path))
 		}
-		check.Path = path
-		return check, nil
+		return path, nil
 	}
 	path, err := exec.LookPath(exe)
 	if err != nil {
-		return check, fmt.Errorf("%w: executable %q was not found on PATH", errProgramNotFound, exe)
+		return "", fmt.Errorf("%w: executable %q was not found on PATH", errProgramNotFound, exe)
 	}
-	check.Path = path
-	return check, nil
+	return path, nil
 }
 
 // LocalSessionPrereqs verifies the prerequisites needed before creating a
@@ -219,7 +235,7 @@ func firstExecutable(words []string) (string, error) {
 	if len(words) == 0 {
 		return "", nil
 	}
-	if words[0] != "env" {
+	if !isEnvExecutable(words[0]) {
 		return words[0], nil
 	}
 
@@ -236,6 +252,20 @@ func firstExecutable(words []string) (string, error) {
 		return "", nil
 	}
 	return words[1+invocation.CommandIndex], nil
+}
+
+func envWrapperExecutable(words []string) string {
+	for len(words) > 0 && isAssignment(words[0]) {
+		words = words[1:]
+	}
+	if len(words) > 0 && isEnvExecutable(words[0]) {
+		return words[0]
+	}
+	return ""
+}
+
+func isEnvExecutable(word string) bool {
+	return filepath.Base(config.ExpandTilde(word)) == "env"
 }
 
 func isAssignment(word string) bool {

--- a/preflight/preflight_test.go
+++ b/preflight/preflight_test.go
@@ -30,16 +30,31 @@ func TestFirstExecutable(t *testing.T) {
 		name  string
 		words []string
 		want  string
+		bad   bool
 	}{
-		{"bare", []string{"claude", "--flag"}, "claude"},
-		{"assignment", []string{"FOO=1", "codex"}, "codex"},
-		{"env assignment", []string{"env", "FOO=1", "gemini"}, "gemini"},
-		{"env unset", []string{"env", "-u", "FOO", "aider"}, "aider"},
-		{"env chdir", []string{"env", "-C", "/tmp", "claude"}, "claude"},
+		{"bare", []string{"claude", "--flag"}, "claude", false},
+		{"assignment", []string{"FOO=1", "codex"}, "codex", false},
+		{"env assignment", []string{"env", "FOO=1", "gemini"}, "gemini", false},
+		{"env unset", []string{"env", "-u", "FOO", "aider"}, "aider", false},
+		{"env attached unset", []string{"env", "-uFOO", "aider"}, "aider", false},
+		{"env chdir", []string{"env", "-C", "/tmp", "claude"}, "claude", false},
+		{"env attached chdir", []string{"env", "-C/tmp", "claude"}, "claude", false},
+		{name: "env split string fails closed", words: []string{"env", "-S", "claude"}, bad: true},
+		{name: "env unknown option fails closed", words: []string{"env", "--future", "claude"}, bad: true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := firstExecutable(tc.words); got != tc.want {
+			got, err := firstExecutable(tc.words)
+			if tc.bad {
+				if err == nil {
+					t.Fatalf("firstExecutable(%#v) accepted an env form the shared parser cannot model", tc.words)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("firstExecutable(%#v): %v", tc.words, err)
+			}
+			if got != tc.want {
 				t.Fatalf("firstExecutable(%#v) = %q, want %q", tc.words, got, tc.want)
 			}
 		})

--- a/preflight/preflight_test.go
+++ b/preflight/preflight_test.go
@@ -67,7 +67,7 @@ func TestCheckCommand(t *testing.T) {
 	if err := os.WriteFile(exe, []byte("#!/bin/sh\n"), 0o755); err != nil {
 		t.Fatalf("write executable: %v", err)
 	}
-	t.Setenv("PATH", dir)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	check, err := CheckCommand("env FOO=1 fake-agent --ready")
 	if err != nil {
@@ -75,6 +75,32 @@ func TestCheckCommand(t *testing.T) {
 	}
 	if check.Executable != "fake-agent" || check.Path != exe {
 		t.Fatalf("unexpected check: %+v", check)
+	}
+}
+
+func TestCheckCommandParsesAndValidatesAbsoluteEnvWrapper(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, "env")
+	if err := os.WriteFile(envPath, []byte("#!/bin/sh\nexec /usr/bin/env \"$@\"\n"), 0o755); err != nil {
+		t.Fatalf("write env wrapper: %v", err)
+	}
+
+	missingTarget := filepath.Join(dir, "missing-codex")
+	check, err := CheckCommand(envPath + " FOO=1 " + missingTarget)
+	if err == nil {
+		t.Fatalf("absolute env wrapper approved missing command %q", missingTarget)
+	}
+	if check.Executable != missingTarget {
+		t.Fatalf("checked executable = %q, want env's command %q", check.Executable, missingTarget)
+	}
+
+	validTarget := filepath.Join(dir, "codex")
+	if err := os.WriteFile(validTarget, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	missingEnv := filepath.Join(t.TempDir(), "env")
+	if _, err := CheckCommand(missingEnv + " " + validTarget); err == nil {
+		t.Fatalf("approved command whose env wrapper %q does not exist", missingEnv)
 	}
 }
 

--- a/session/activity.go
+++ b/session/activity.go
@@ -61,7 +61,7 @@ func ClassifyActivity(data InstanceData) (Activity, string) {
 	// is mid-transition; wait for it to settle rather than reporting the
 	// transient composed status.
 	switch data.InFlightOp {
-	case OpCreating, OpKilling, OpArchiving, OpRestoring:
+	case OpCreating, OpKilling, OpArchiving, OpRestoring, OpReplacing:
 		return ActivityPending, ""
 	}
 

--- a/session/activity_test.go
+++ b/session/activity_test.go
@@ -61,6 +61,7 @@ func TestClassifyActivity(t *testing.T) {
 		{"killing", InstanceData{InFlightOp: OpKilling, Liveness: LiveRunning}, ActivityPending},
 		{"archiving", InstanceData{InFlightOp: OpArchiving, Liveness: LiveRunning}, ActivityPending},
 		{"restoring", InstanceData{InFlightOp: OpRestoring, Liveness: LiveLost}, ActivityPending},
+		{"replacing", InstanceData{InFlightOp: OpReplacing, Liveness: LiveReady}, ActivityPending},
 
 		{"running", InstanceData{Liveness: LiveRunning}, ActivityPending},
 		// Parked at a usage limit the daemon auto-resumes (#1146): still the task's

--- a/session/backend.go
+++ b/session/backend.go
@@ -191,7 +191,11 @@ type Backend interface {
 	// agent inside a provisioned sandbox is a different lifecycle (re-launch
 	// inside the sandbox, not re-provision it), so they return
 	// ErrHandoffUnsupported and the Handoff capability bit is false.
-	SwapAgent(instance *Instance) error
+	// PrepareAgentSwap resolves and validates the exact command that a handoff
+	// would launch. It runs before the outgoing process is touched; SwapAgent must
+	// consume this plan rather than resolving configuration again after teardown.
+	PrepareAgentSwap(instance *Instance, target string) (AgentSwapPlan, error)
+	SwapAgent(instance *Instance, plan AgentSwapPlan) error
 
 	// Type returns the backend type identifier ("local" or "remote"). Since
 	// #1592 Phase 1 this is the persisted serialization discriminator only (the
@@ -204,4 +208,15 @@ type Backend interface {
 	// instance because some capabilities (TerminalTab) depend on per-session
 	// config.
 	Capabilities() Capabilities
+}
+
+// AgentSwapPlan is the immutable boundary between handoff preflight and runtime
+// replacement. Its fields are intentionally private: only a Backend can produce
+// a plan, and callers can only hand that same value back to SwapAgent. That makes
+// it impossible for the destructive half to silently launch a command different
+// from the one that was checked while the outgoing agent was still alive.
+type AgentSwapPlan struct {
+	target       string
+	program      string
+	conversation AgentConversationData
 }

--- a/session/backend.go
+++ b/session/backend.go
@@ -216,7 +216,15 @@ type Backend interface {
 // it impossible for the destructive half to silently launch a command different
 // from the one that was checked while the outgoing agent was still alive.
 type AgentSwapPlan struct {
-	target       string
-	program      string
-	conversation AgentConversationData
+	target              string
+	program             string
+	conversation        AgentConversationData
+	conversationCapture ConversationCaptureSnapshot
+}
+
+// ConversationCapture returns the provider-store before-image frozen by
+// preflight. The snapshot is opaque outside session: callers can pass it to the
+// capture API, but cannot retarget it after the outgoing runtime is stopped.
+func (p AgentSwapPlan) ConversationCapture() ConversationCaptureSnapshot {
+	return p.conversationCapture
 }

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -107,7 +107,21 @@ func (b *LocalBackend) PrepareAgentSwap(i *Instance, target string) (AgentSwapPl
 		return AgentSwapPlan{}, fmt.Errorf("handoff target %s failed launch preflight: %w", target,
 			preflight.ProgramError(target, resolved, err))
 	}
-	return AgentSwapPlan{target: target, program: program, conversation: conversation}, nil
+	var capture ConversationCaptureSnapshot
+	if tmux.DetectAgentFromCommand(program) == tmux.ProgramCodex {
+		workDir := i.GetWorktreePath()
+		if workDir == "" {
+			return AgentSwapPlan{}, fmt.Errorf("handoff target %s has no worktree path for resolving its Codex conversation store", target)
+		}
+		codexHome, err := tmux.CodexHomeFromCommand(program, workDir)
+		if err != nil {
+			return AgentSwapPlan{}, fmt.Errorf("handoff target %s has an unresolvable Codex conversation store: %w", target, err)
+		}
+		capture = BeginConversationCaptureAtCodexHome(codexHome)
+	}
+	return AgentSwapPlan{
+		target: target, program: program, conversation: conversation, conversationCapture: capture,
+	}, nil
 }
 
 // autoYesUnsupported explains, per agent, why AutoYes cannot be honored — and is
@@ -649,6 +663,7 @@ func (b *LocalBackend) respawn(i *Instance) error {
 // same stable tab; retaining a broker capture from either old pane strands every
 // existing and future subscriber on a silent read loop.
 func resetAgentBrokerCaptures(i *Instance) {
+	i.noteAgentRuntimeReplaced()
 	if as, ok := i.AgentServer().(*localAgentServer); ok {
 		as.resetBrokerCaptures()
 	}

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/preflight"
 	"github.com/sachiniyer/agent-factory/session/git"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
@@ -27,6 +28,13 @@ import (
 // falls back to the raw Program string so legacy free-form values still
 // reach tmux verbatim.
 func resolveProgramForInstance(i *Instance) string {
+	return resolveProgramForAgent(i, i.AgentProgram())
+}
+
+// resolveProgramForAgent is the target-explicit form used by handoff preflight.
+// It resolves configuration before Instance.Program is rewritten, so an invalid
+// incoming override can be rejected while the outgoing process is still alive.
+func resolveProgramForAgent(i *Instance, agent string) string {
 	var cfg *config.Config
 	if repo, err := config.RepoFromPath(i.Path); err == nil {
 		if resolved, rerr := config.ResolveConfig(repo.Root); rerr == nil {
@@ -47,7 +55,7 @@ func resolveProgramForInstance(i *Instance) string {
 	// rewrites Program in place while the instance is live and shared, so this
 	// is a genuinely concurrent read now. Every other reader of the field
 	// (ToInstanceData, ReconcileTabsFromData) already holds the instance lock.
-	resolved := config.ResolveProgram(cfg, i.AgentProgram())
+	resolved := config.ResolveProgram(cfg, agent)
 	// Key the claude-only flag off the agent the RESOLVED command actually
 	// runs, not the config-name enum: an override may point "claude" at a
 	// different program, which would exit on the unknown flag (#1116).
@@ -85,6 +93,21 @@ func resolveProgramForInstance(i *Instance) string {
 		noteAutoYesUnsupported(tmux.DetectAgentFromCommand(resolved), i.Title)
 	}
 	return resolved
+}
+
+// PrepareAgentSwap freezes and validates the exact first-launch command before
+// handoff tears down the outgoing pane. Configuration is resolved once here;
+// SwapAgent consumes the returned plan and cannot drift to a different override
+// in the destructive close/start gap.
+func (b *LocalBackend) PrepareAgentSwap(i *Instance, target string) (AgentSwapPlan, error) {
+	resolved := resolveProgramForAgent(i, target)
+	program := injectSystemPrompt(resolved)
+	program, conversation := planLaunchConversation(i.ID, program)
+	if _, err := preflight.CheckCommand(program); err != nil {
+		return AgentSwapPlan{}, fmt.Errorf("handoff target %s failed launch preflight: %w", target,
+			preflight.ProgramError(target, resolved, err))
+	}
+	return AgentSwapPlan{target: target, program: program, conversation: conversation}, nil
 }
 
 // autoYesUnsupported explains, per agent, why AutoYes cannot be honored — and is
@@ -475,10 +498,10 @@ func (b *LocalBackend) Respawn(i *Instance) error {
 //     is gone there is nothing to replace it with — and the wait is the #802
 //     ordering that keeps its final writes from racing the new agent's first
 //     ones in the same worktree.
-//  2. Only then start the new program, through the FIRST-LAUNCH path
-//     (prepareLaunchConversation + Start), never the resume path. The incoming
-//     agent has no conversation in this worktree; asking it to continue one
-//     would at best start fresh noisily and at worst fail to boot.
+//  2. Only then start the new program from the already-prepared FIRST-LAUNCH
+//     plan, never the resume path. The incoming agent has no conversation in
+//     this worktree; asking it to continue one would at best start fresh noisily
+//     and at worst fail to boot.
 //
 // A teardown whose outcome tmux could not confirm ABORTS the swap. This is the
 // one place the honest answer costs something: refusing leaves the session on
@@ -490,7 +513,7 @@ func (b *LocalBackend) Respawn(i *Instance) error {
 // The worktree is never cleaned up on failure, unlike the first-launch path this
 // otherwise mirrors: on a create, a failed Start means the workspace holds
 // nothing worth keeping; here it holds everything the outgoing agent did.
-func (b *LocalBackend) SwapAgent(i *Instance) error {
+func (b *LocalBackend) SwapAgent(i *Instance, plan AgentSwapPlan) error {
 	i.mu.RLock()
 	ts := i.tmuxLocked()
 	gw := i.gitWorktree
@@ -523,8 +546,7 @@ func (b *LocalBackend) SwapAgent(i *Instance) error {
 		return fmt.Errorf("swap agent: failed to stop the current agent for %q: %w", i.Title, closeErr)
 	}
 
-	program := prepareLaunchConversation(i, resolveProgramForInstance(i))
-	ts.SetProgram(injectSystemPrompt(program))
+	ts.SetProgram(plan.program)
 	if err := ts.Start(workDir); err != nil {
 		if cleanupErr := ts.CloseAttachOnly(); cleanupErr != nil {
 			err = fmt.Errorf("%v (cleanup error: %v)", err, cleanupErr)
@@ -532,9 +554,7 @@ func (b *LocalBackend) SwapAgent(i *Instance) error {
 		return fmt.Errorf("swap agent: failed to start %s for %q: %w", i.AgentProgram(), i.Title, err)
 	}
 
-	// The new agent is booting: Running, exactly like a fresh create. Mirrors the
-	// respawn completion so the daemon poll re-derives Ready/Running from here.
-	_ = i.Transition(ConfirmLive())
+	resetAgentBrokerCaptures(i)
 	return nil
 }
 
@@ -620,10 +640,18 @@ func (b *LocalBackend) respawn(i *Instance) error {
 	// the live pane rather than a parked, silent readLoop (#1682). The memoized
 	// accessor keeps this a no-op for sessions nobody ever streamed (empty broker
 	// map) and skips a remote runtime's agent-server (not a localAgentServer).
+	resetAgentBrokerCaptures(i)
+	return nil
+}
+
+// resetAgentBrokerCaptures is the single post-replacement hook for every local
+// pane respawn. A handoff and a recovery both replace the process behind the
+// same stable tab; retaining a broker capture from either old pane strands every
+// existing and future subscriber on a silent read loop.
+func resetAgentBrokerCaptures(i *Instance) {
 	if as, ok := i.AgentServer().(*localAgentServer); ok {
 		as.resetBrokerCaptures()
 	}
-	return nil
 }
 
 // setupTabs brings up an instance's non-agent tabs after its agent session is

--- a/session/backend_local_restore_test.go
+++ b/session/backend_local_restore_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 	"os"
@@ -15,9 +16,89 @@ import (
 
 	"github.com/sachiniyer/agent-factory/cmd"
 	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/session/git"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
+
+func TestLocalBackendPrepareAgentSwapRejectsMissingExecutableBeforeRuntime(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	cfg := config.DefaultConfig()
+	if cfg.ProgramOverrides == nil {
+		cfg.ProgramOverrides = make(map[string]string)
+	}
+	missing := filepath.Join(t.TempDir(), "missing-gemini")
+	cfg.ProgramOverrides[tmux.ProgramGemini] = missing
+	require.NoError(t, config.SaveConfig(cfg))
+
+	inst := handoffTestInstance(t, tmux.ProgramClaude)
+	plan, err := (&LocalBackend{}).PrepareAgentSwap(inst, tmux.ProgramGemini)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), missing)
+	require.Empty(t, plan.program, "a rejected preflight must not produce an executable swap plan")
+	require.Equal(t, tmux.ProgramClaude, inst.AgentProgram(), "preflight must not rewrite the live record")
+}
+
+func TestLocalBackendSwapAgentResetsBrokerCapture(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	ptyFactory := &recordingPtyFactory{t: t}
+	killed := false
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			joined := strings.Join(c.Args, " ")
+			switch {
+			case strings.Contains(joined, "kill-session"):
+				killed = true
+				return nil
+			case strings.Contains(joined, "has-session"):
+				if killed && len(ptyFactory.cmds) == 0 {
+					return errors.New("session absent after close")
+				}
+			}
+			return nil
+		},
+		OutputFunc: func(c *exec.Cmd) ([]byte, error) {
+			if strings.Contains(strings.Join(c.Args, " "), "display-message") {
+				return nil, errors.New("pane pid unavailable")
+			}
+			return nil, nil
+		},
+	}
+
+	repoRoot := initTempGitRepo(t)
+	worktreePath := t.TempDir()
+	gw, err := git.NewGitWorktreeFromStorage(repoRoot, worktreePath, "handoff-broker", "handoff-broker-branch", "", false, false)
+	require.NoError(t, err)
+	ts := tmux.NewTmuxSessionWithDeps("handoff-broker", tmux.ProgramClaude, ptyFactory, cmdExec)
+	backend := &LocalBackend{}
+	inst := &Instance{
+		ID:          "handoff-broker-id",
+		Title:       "handoff-broker",
+		Path:        repoRoot,
+		Program:     tmux.ProgramGemini,
+		backend:     backend,
+		Tabs:        []*Tab{newAgentTab(ts)},
+		gitWorktree: gw,
+		started:     true,
+		liveness:    LiveRunning,
+	}
+
+	channel := &fakeClientlessChannel{snapshot: []byte("old-pane")}
+	broker := newPTYBroker(channel)
+	sub, err := broker.subscribe(0)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = sub.Close()
+		broker.close()
+	})
+	server := inst.AgentServer().(*localAgentServer)
+	server.brokers = map[string]*ptyBroker{"agent": broker}
+
+	plan := AgentSwapPlan{target: tmux.ProgramGemini, program: tmux.ProgramGemini}
+	require.NoError(t, backend.SwapAgent(inst, plan))
+	require.Equal(t, 1, channel.stops, "handoff must stop the capture bound to the outgoing pane")
+	require.Equal(t, 2, channel.starts, "the attached subscriber must resume on the incoming pane without reconnecting")
+}
 
 // recordingPtyFactory is a tmux.PtyFactory that records each exec.Cmd passed
 // to Start, lets the caller inspect the new-session vs attach-session sequence

--- a/session/backend_local_restore_test.go
+++ b/session/backend_local_restore_test.go
@@ -39,6 +39,38 @@ func TestLocalBackendPrepareAgentSwapRejectsMissingExecutableBeforeRuntime(t *te
 	require.Equal(t, tmux.ProgramClaude, inst.AgentProgram(), "preflight must not rewrite the live record")
 }
 
+func TestLocalBackendPrepareAgentSwapSnapshotsCommandSpecificCodexHome(t *testing.T) {
+	afHome := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", afHome)
+	t.Setenv("CODEX_HOME", t.TempDir()) // deliberately not the launched store
+
+	binDir := t.TempDir()
+	codexBin := filepath.Join(binDir, "codex")
+	require.NoError(t, os.WriteFile(codexBin, []byte("#!/bin/sh\n"), 0o755))
+	launchedHome := filepath.Join(t.TempDir(), "command-codex-home")
+	cfg := config.DefaultConfig()
+	if cfg.ProgramOverrides == nil {
+		cfg.ProgramOverrides = make(map[string]string)
+	}
+	cfg.ProgramOverrides[tmux.ProgramCodex] = "env CODEX_HOME=" + launchedHome + " " + codexBin
+	require.NoError(t, config.SaveConfig(cfg))
+
+	repoRoot := initTempGitRepo(t)
+	gw, err := git.NewGitWorktreeFromStorage(
+		repoRoot, repoRoot, "handoff-capture", "handoff-capture", "", true, false,
+	)
+	require.NoError(t, err)
+	inst := handoffTestInstance(t, tmux.ProgramClaude)
+	inst.Path = repoRoot
+	inst.gitWorktree = gw
+	inst.SetBackend(&LocalBackend{})
+
+	plan, err := (&LocalBackend{}).PrepareAgentSwap(inst, tmux.ProgramCodex)
+	require.NoError(t, err)
+	require.Equal(t, launchedHome, plan.conversationCapture.codexHome,
+		"handoff capture must watch the incoming command's store, not daemon CODEX_HOME")
+}
+
 func TestLocalBackendSwapAgentResetsBrokerCapture(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 	ptyFactory := &recordingPtyFactory{t: t}

--- a/session/backend_remote_agent.go
+++ b/session/backend_remote_agent.go
@@ -34,7 +34,11 @@ func (b *remoteAgentBackend) Capabilities() Capabilities {
 // origin, which would discard unpushed work rather than hand it over. Wiring a
 // genuine in-sandbox relaunch is its own change; until then this says so instead
 // of quietly doing the destructive thing.
-func (b *remoteAgentBackend) SwapAgent(*Instance) error {
+func (b *remoteAgentBackend) PrepareAgentSwap(*Instance, string) (AgentSwapPlan, error) {
+	return AgentSwapPlan{}, ErrHandoffUnsupported
+}
+
+func (b *remoteAgentBackend) SwapAgent(*Instance, AgentSwapPlan) error {
 	return ErrHandoffUnsupported
 }
 

--- a/session/conversation.go
+++ b/session/conversation.go
@@ -23,6 +23,18 @@ type AgentConversationData struct {
 	CaptureKind string    `json:"capture_kind,omitempty"`
 }
 
+// AgentRuntimeToken binds asynchronous provider discovery to one concrete
+// process generation. Its fields stay private so callers can only obtain a
+// valid token from an Instance snapshot, not reconstruct one from a matching
+// agent name after the runtime has moved on.
+type AgentRuntimeToken struct {
+	agent      string
+	generation uint64
+}
+
+// Agent reports the provider the captured runtime actually launched.
+func (t AgentRuntimeToken) Agent() string { return t.agent }
+
 func (c AgentConversationData) Empty() bool {
 	return strings.TrimSpace(c.Agent) == "" &&
 		strings.TrimSpace(c.ID) == "" &&
@@ -59,6 +71,49 @@ func (i *Instance) SetAgentConversation(conv AgentConversationData) bool {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 	return i.setAgentConversationLocked(conv)
+}
+
+// AgentRuntimeToken snapshots the provider and runtime generation atomically.
+// Capture callers take it before starting their goroutine and must use
+// SetAgentConversationForRuntime to commit the eventual result.
+func (i *Instance) AgentRuntimeToken() AgentRuntimeToken {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return AgentRuntimeToken{
+		agent:      i.resolvedAgentLocked(),
+		generation: i.agentRuntimeGeneration,
+	}
+}
+
+// SetAgentConversationForRuntime commits conv only while token still names the
+// live process generation it was captured for. This catches A→B as well as
+// A→B→A handoffs; an agent-name comparison alone cannot distinguish the latter.
+func (i *Instance) SetAgentConversationForRuntime(token AgentRuntimeToken, conv AgentConversationData) bool {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.userKilled || token.agent == "" || token.generation != i.agentRuntimeGeneration ||
+		conv.Agent != token.agent || i.resolvedAgentLocked() != token.agent {
+		return false
+	}
+	return i.setAgentConversationLocked(conv)
+}
+
+// noteAgentRuntimeReplaced invalidates every capture bound to the prior process.
+// Handoff record mutation calls the locked increment before teardown; local
+// recovery calls this after re-spawn so both replacement paths close the edge.
+func (i *Instance) noteAgentRuntimeReplaced() {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.agentRuntimeGeneration++
+}
+
+func (i *Instance) resolvedAgentLocked() string {
+	if ts := i.tmuxLocked(); ts != nil {
+		if program := ts.Program(); strings.TrimSpace(program) != "" {
+			return tmux.DetectAgentFromCommand(program)
+		}
+	}
+	return tmux.DetectAgentFromCommand(i.Program)
 }
 
 func (i *Instance) setAgentConversationLocked(conv AgentConversationData) bool {

--- a/session/conversation.go
+++ b/session/conversation.go
@@ -92,24 +92,36 @@ func (i *Instance) SetTabConversation(name string, conv AgentConversationData) b
 }
 
 func prepareLaunchConversation(i *Instance, program string) string {
-	if tmux.DetectAgentFromCommand(program) != tmux.ProgramClaude {
-		return program
+	rewritten, conversation := planLaunchConversation(i.ID, program)
+	if conversation.HasID() {
+		i.SetAgentConversation(conversation)
 	}
-	id := i.ID
+	return rewritten
+}
+
+// planLaunchConversation is the side-effect-free half of
+// prepareLaunchConversation. Handoff preflight uses it to freeze the exact
+// first-launch command before the outgoing pane is stopped; the conversation is
+// committed to the instance only when that prepared plan is executed.
+func planLaunchConversation(instanceID, program string) (string, AgentConversationData) {
+	if tmux.DetectAgentFromCommand(program) != tmux.ProgramClaude {
+		return program, AgentConversationData{}
+	}
+	id := instanceID
 	if strings.TrimSpace(id) == "" {
 		id = newSessionID()
 	}
 	rewritten, injected := tmux.ClaudeProgramWithSessionID(program, id)
 	if !injected {
-		return program
+		return program, AgentConversationData{}
 	}
-	i.SetAgentConversation(AgentConversationData{
+	conversation := AgentConversationData{
 		Agent:       tmux.ProgramClaude,
 		ID:          id,
 		CapturedAt:  time.Now(),
 		CaptureKind: ConversationCaptureInjected,
-	})
-	return rewritten
+	}
+	return rewritten, conversation
 }
 
 func prepareResumeConversation(i *Instance, program string) string {

--- a/session/fake_backend.go
+++ b/session/fake_backend.go
@@ -114,8 +114,11 @@ func (b *FakeBackend) CheckAndHandleTrustPrompt(*Instance) bool     { return fal
 func (b *FakeBackend) TapEnter(*Instance)                           {}
 func (b *FakeBackend) Recover(*Instance) error                      { return nil }
 func (b *FakeBackend) Respawn(*Instance) error                      { return nil }
-func (b *FakeBackend) SwapAgent(*Instance) error                    { return nil }
-func (b *FakeBackend) Type() string                                 { return "local" }
+func (b *FakeBackend) PrepareAgentSwap(_ *Instance, target string) (AgentSwapPlan, error) {
+	return AgentSwapPlan{target: target, program: target}, nil
+}
+func (b *FakeBackend) SwapAgent(*Instance, AgentSwapPlan) error { return nil }
+func (b *FakeBackend) Type() string                             { return "local" }
 
 // Capabilities reports local full parity by default, mirroring LocalBackend so
 // the fake stands in for a local session (#1592 Phase 1). Test doubles that

--- a/session/fake_backend.go
+++ b/session/fake_backend.go
@@ -2,6 +2,8 @@ package session
 
 import (
 	"sync"
+
+	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
 // FakeBackend is a Backend implementation for tests that need to drive the
@@ -115,7 +117,11 @@ func (b *FakeBackend) TapEnter(*Instance)                           {}
 func (b *FakeBackend) Recover(*Instance) error                      { return nil }
 func (b *FakeBackend) Respawn(*Instance) error                      { return nil }
 func (b *FakeBackend) PrepareAgentSwap(_ *Instance, target string) (AgentSwapPlan, error) {
-	return AgentSwapPlan{target: target, program: target}, nil
+	plan := AgentSwapPlan{target: target, program: target}
+	if target == tmux.ProgramCodex {
+		plan.conversationCapture = BeginConversationCapture()
+	}
+	return plan, nil
 }
 func (b *FakeBackend) SwapAgent(*Instance, AgentSwapPlan) error { return nil }
 func (b *FakeBackend) Type() string                             { return "local" }

--- a/session/git/worktree_summary.go
+++ b/session/git/worktree_summary.go
@@ -54,20 +54,22 @@ func (g *GitWorktree) WorkSummary() (WorkSummary, error) {
 	}
 
 	head, err := g.runGitCommand(path, "rev-parse", "HEAD")
-	if err != nil {
-		// No HEAD means an unborn branch (a worktree cut but never committed to).
-		// That is a legitimate state to hand off from, so report the zero summary
-		// rather than an error the caller would have to special-case.
-		return summary, nil
-	}
-	summary.HeadSHA = strings.TrimSpace(head)
+	if err == nil {
+		summary.HeadSHA = strings.TrimSpace(head)
 
-	if summary.BaseSHA != "" {
-		if out, cErr := g.runGitCommand(path, "rev-list", "--count", summary.BaseSHA+"..HEAD"); cErr == nil {
-			if n, sErr := parseCount(out); sErr == nil {
-				summary.Commits = n
+		if summary.BaseSHA != "" {
+			if out, cErr := g.runGitCommand(path, "rev-list", "--count", summary.BaseSHA+"..HEAD"); cErr == nil {
+				if n, sErr := parseCount(out); sErr == nil {
+					summary.Commits = n
+				}
 			}
 		}
+	} else {
+		// No HEAD means an unborn branch (a worktree cut but never committed to).
+		// That is a legitimate state to hand off from, but it can still carry
+		// staged, unstaged, or untracked work. Continue to status instead of
+		// returning a fabricated clean summary merely because commit history is
+		// unavailable.
 	}
 
 	if out, sErr := g.runGitCommand(path, "status", "--porcelain"); sErr == nil {

--- a/session/git/worktree_summary_test.go
+++ b/session/git/worktree_summary_test.go
@@ -1,0 +1,29 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestWorkSummaryCountsDirtyFilesOnUnbornBranch(t *testing.T) {
+	root := t.TempDir()
+	cmd := exec.Command("git", "init")
+	cmd.Dir = root
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+	if err := os.WriteFile(filepath.Join(root, "first.txt"), []byte("uncommitted\n"), 0o644); err != nil {
+		t.Fatalf("write dirty file: %v", err)
+	}
+
+	worktree := &GitWorktree{worktreePath: root, branchName: "unborn-work"}
+	summary, err := worktree.WorkSummary()
+	if err != nil {
+		t.Fatalf("WorkSummary: %v", err)
+	}
+	if summary.HeadSHA != "" || summary.Commits != 0 || summary.DirtyFiles != 1 {
+		t.Fatalf("unborn dirty summary = %+v, want no HEAD/commits and one dirty file", summary)
+	}
+}

--- a/session/handoff.go
+++ b/session/handoff.go
@@ -231,6 +231,25 @@ func (i *Instance) RecordHandoffSwap(target, reason, headSHA string, automatic b
 	return i.recordHandoffSwapLocked(target, reason, headSHA, automatic)
 }
 
+// handoffStorageCheckpoint projects a runtime swap that has completed while its
+// in-memory delivery fence is still raised. Disk cannot retain process-local
+// operations, but it must not keep claiming the outgoing agent either: a daemon
+// crash during readiness would then restore the wrong Program over a pane that
+// already runs the target. The persisted recovery posture is the same one a
+// generic post-swap delivery failure takes — incoming agent, LiveRunning, no
+// outgoing-provider limit metadata — while memory remains OpReplacing until the
+// mission is delivered or explicitly parked.
+func (i *Instance) handoffStorageCheckpoint() InstanceData {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	data := i.toInstanceDataLocked()
+	data.Status = Running
+	data.Liveness = LiveRunning
+	data.InFlightOp = OpNone
+	data.LimitResetAt = time.Time{}
+	return data
+}
+
 func (i *Instance) recordHandoffSwapLocked(target, reason, headSHA string, automatic bool) (AgentHandoff, error) {
 
 	if len(i.Tabs) == 0 {

--- a/session/handoff.go
+++ b/session/handoff.go
@@ -209,6 +209,29 @@ func (i *Instance) SwapAgentProgram(target, reason, headSHA string, automatic bo
 	if err := i.lifecycleViewLocked().ValidateRuntimeAction(RuntimeActionHandoff); err != nil {
 		return AgentHandoff{}, err
 	}
+	return i.recordHandoffSwapLocked(target, reason, headSHA, automatic)
+}
+
+// RecordHandoffSwap is the transaction-owned mutation used by the daemon after
+// BeginHandoff has raised OpReplacing. Keeping it separate from
+// SwapAgentProgram makes both legal orderings explicit: ordinary state-only
+// tests require a settled live row, while production replacement requires the
+// fence and cannot accidentally validate itself as "busy".
+func (i *Instance) RecordHandoffSwap(target, reason, headSHA string, automatic bool) (AgentHandoff, error) {
+	target = strings.TrimSpace(target)
+
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.inFlightOp != OpReplacing {
+		return AgentHandoff{}, fmt.Errorf("session %q has no agent replacement in flight", i.Title)
+	}
+	if err := i.validateHandoffTargetLocked(target); err != nil {
+		return AgentHandoff{}, err
+	}
+	return i.recordHandoffSwapLocked(target, reason, headSHA, automatic)
+}
+
+func (i *Instance) recordHandoffSwapLocked(target, reason, headSHA string, automatic bool) (AgentHandoff, error) {
 
 	if len(i.Tabs) == 0 {
 		return AgentHandoff{}, fmt.Errorf("session %q has no agent tab to hand off", i.Title)
@@ -243,12 +266,12 @@ func (i *Instance) SwapAgentProgram(target, reason, headSHA string, automatic bo
 // restoring the outgoing agent as the recorded program and putting its
 // conversation id back.
 //
-// This exists because the record and the runtime must not disagree. If the pane
-// still runs codex while Program says claude, every later decision that keys off
-// the program — respawn flag injection, readiness heuristics, the next handoff's
-// same-agent check — is made against an agent that is not there. A stale ledger
-// entry for a swap that never happened is the same class of lie, so the entry
-// comes off too.
+// This exists because a failed replacement did not establish the incoming
+// runtime. Leaving Program set to that unconfirmed agent would make every later
+// decision — respawn flag injection, readiness heuristics, the next handoff's
+// same-agent check — act as though the swap committed. A stale ledger entry for
+// a swap that never completed is the same class of lie, so the entry comes off
+// too.
 //
 // It removes only the trailing entry, and only when it is the one passed in: if
 // anything else has appended since, this is no longer an unwind and refusing is

--- a/session/handoff.go
+++ b/session/handoff.go
@@ -258,6 +258,10 @@ func (i *Instance) recordHandoffSwapLocked(target, reason, headSHA string, autom
 	i.Tabs[0].Handoffs = append(i.Tabs[0].Handoffs, entry)
 	i.Tabs[0].Conversation = AgentConversationData{}
 	i.Program = target
+	// Invalidate outgoing-runtime capture BEFORE its pane is torn down. A capture
+	// already waiting on a rollout must not refill the live slot after this record
+	// has been rewritten for the incoming agent.
+	i.agentRuntimeGeneration++
 
 	return entry, nil
 }
@@ -296,5 +300,9 @@ func (i *Instance) RevertHandoff(entry AgentHandoff) error {
 	if from := strings.TrimSpace(entry.From.Agent); from != "" {
 		i.Program = from
 	}
+	// Generations are monotonic even on rollback. Reusing the old number would
+	// make a token from the abandoned target indistinguishable from the restored
+	// outgoing runtime.
+	i.agentRuntimeGeneration++
 	return nil
 }

--- a/session/handoff_mission.go
+++ b/session/handoff_mission.go
@@ -51,7 +51,7 @@ func (i *Instance) BuildMissionBrief(to, override, reason string) MissionBrief {
 	if goal := strings.TrimSpace(override); goal != "" {
 		brief.Goal = goal
 	} else {
-		brief.Goal = strings.TrimSpace(i.Prompt)
+		brief.Goal = strings.TrimSpace(i.GetPrompt())
 	}
 
 	i.mu.RLock()
@@ -105,9 +105,12 @@ func (m MissionBrief) Render() string {
 		default:
 			fmt.Fprintf(&b, "  %s, %s.\n", pluralize(m.Work.Commits, "commit"), pluralize(m.Work.DirtyFiles, "uncommitted file"))
 			if base := strings.TrimSpace(m.Work.BaseSHA); base != "" {
-				fmt.Fprintf(&b, "  Review it before you start:  git log %s..HEAD  ·  git diff %s...HEAD\n", base, base)
-			} else {
-				b.WriteString("  Review it before you start:  git log  ·  git status\n")
+				fmt.Fprintf(&b, "  Review committed work:  git log %s..HEAD  ·  git diff %s...HEAD\n", base, base)
+			} else if m.Work.Commits > 0 {
+				b.WriteString("  Review committed work:  git log\n")
+			}
+			if m.Work.DirtyFiles > 0 {
+				b.WriteString("  Review uncommitted work:  git status --short  ·  git diff HEAD\n")
 			}
 		}
 	}

--- a/session/handoff_mission.go
+++ b/session/handoff_mission.go
@@ -110,7 +110,14 @@ func (m MissionBrief) Render() string {
 				b.WriteString("  Review committed work:  git log\n")
 			}
 			if m.Work.DirtyFiles > 0 {
-				b.WriteString("  Review uncommitted work:  git status --short  ·  git diff HEAD\n")
+				if strings.TrimSpace(m.Work.HeadSHA) == "" && m.Work.Commits == 0 {
+					// An unborn branch has no HEAD to diff. Status is what exposes
+					// untracked work; the two HEAD-less diffs cover staged and
+					// unstaged tracked changes without manufacturing a bad revision.
+					b.WriteString("  Review uncommitted work:  git status --short  ·  git diff --cached  ·  git diff\n")
+				} else {
+					b.WriteString("  Review uncommitted work:  git status --short  ·  git diff HEAD\n")
+				}
 			}
 		}
 	}

--- a/session/handoff_test.go
+++ b/session/handoff_test.go
@@ -250,6 +250,26 @@ func TestMissionBrief_DirtyWorkIncludesWorkingTreeCommands(t *testing.T) {
 	}
 }
 
+func TestMissionBrief_UnbornDirtyWorkDoesNotReferenceHEAD(t *testing.T) {
+	brief := MissionBrief{
+		From: tmux.ProgramClaude,
+		To:   tmux.ProgramCodex,
+		Work: git.WorkSummary{
+			Branch:     "unborn-work",
+			DirtyFiles: 2,
+		},
+	}
+	rendered := brief.Render()
+	if strings.Contains(rendered, "git diff HEAD") {
+		t.Fatalf("unborn-branch brief tells the incoming agent to diff nonexistent HEAD:\n%s", rendered)
+	}
+	for _, command := range []string{"git status --short", "git diff --cached", "git diff"} {
+		if !strings.Contains(rendered, command) {
+			t.Fatalf("unborn dirty-work brief omits %q:\n%s", command, rendered)
+		}
+	}
+}
+
 // A session with no stored prompt must not have a goal invented for it. The
 // brief says it has none — an agent handed a fabricated goal would pursue the
 // fabrication.

--- a/session/handoff_test.go
+++ b/session/handoff_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sachiniyer/agent-factory/session/git"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
@@ -224,6 +225,28 @@ func TestMissionBrief_OverrideWinsOverStoredPrompt(t *testing.T) {
 	}
 	if strings.Contains(rendered, "the stale create-time prompt") {
 		t.Fatalf("brief carries BOTH the override and the stored prompt; two goals in one brief is the blended-context hazard #2013 names.\n%s", rendered)
+	}
+}
+
+// A base-to-HEAD diff contains only committed work. When the outgoing agent has
+// dirty files, the incoming agent must be pointed at both status (including
+// untracked files) and a working-tree diff or the most recent work is invisible.
+func TestMissionBrief_DirtyWorkIncludesWorkingTreeCommands(t *testing.T) {
+	brief := MissionBrief{
+		From: tmux.ProgramClaude,
+		To:   tmux.ProgramCodex,
+		Work: git.WorkSummary{
+			Branch:     "agent/in-progress",
+			BaseSHA:    "abc123",
+			Commits:    2,
+			DirtyFiles: 3,
+		},
+	}
+	rendered := brief.Render()
+	for _, command := range []string{"git diff abc123...HEAD", "git status --short", "git diff HEAD"} {
+		if !strings.Contains(rendered, command) {
+			t.Fatalf("dirty handoff brief omits %q; the incoming agent would see only committed work:\n%s", command, rendered)
+		}
 	}
 }
 

--- a/session/instance.go
+++ b/session/instance.go
@@ -156,6 +156,12 @@ type Instance struct {
 	// see state_epoch.go. Mutex-protected, in-memory only: it describes a window
 	// between an observation and its apply, and no such window survives a restart.
 	stateEpoch uint64
+	// agentRuntimeGeneration identifies the concrete agent process currently
+	// owning the Agent tab. Async conversation capture binds to this generation,
+	// so a result from a replaced process cannot write through a later handoff or
+	// recovery merely because the Instance pointer (or even agent name) matches.
+	// In-memory only: no capture goroutine survives a daemon restart.
+	agentRuntimeGeneration uint64
 	// Program is the program to run in the instance.
 	Program string
 	// Height is the height of the instance.

--- a/session/instance_accessors.go
+++ b/session/instance_accessors.go
@@ -292,14 +292,8 @@ func (i *Instance) TmuxAlive() bool {
 // "/home/foo/bin/claude --plugin-dir x" (#677).
 func (i *Instance) ResolvedAgent() string {
 	i.mu.RLock()
-	ts := i.tmuxLocked()
-	i.mu.RUnlock()
-	if ts != nil {
-		if p := ts.Program(); strings.TrimSpace(p) != "" {
-			return tmux.DetectAgentFromCommand(p)
-		}
-	}
-	return tmux.DetectAgentFromCommand(i.Program)
+	defer i.mu.RUnlock()
+	return i.resolvedAgentLocked()
 }
 
 // ResolvedPaneAgent returns the canonical agent proven by this instance's

--- a/session/instance_accessors.go
+++ b/session/instance_accessors.go
@@ -36,6 +36,22 @@ func (i *Instance) SetAutoYes(autoYes bool) {
 	i.AutoYes = autoYes
 }
 
+// SetPrompt replaces the durable goal used by later limit resumes and handoffs.
+// Prompt became mutable when handoff gained an operator-supplied brief, so the
+// write and every concurrent reader must use the instance lock.
+func (i *Instance) SetPrompt(prompt string) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.Prompt = prompt
+}
+
+// GetPrompt returns the session's current durable goal.
+func (i *Instance) GetPrompt() string {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.Prompt
+}
+
 // GetBranch returns the current worktree branch name under the Instance's
 // mutex. Readers that run from goroutines other than the one mutating the
 // instance (notably the bubbletea renderer) must use this accessor rather

--- a/session/instance_backend.go
+++ b/session/instance_backend.go
@@ -85,8 +85,8 @@ func (i *Instance) PrepareAgentSwap(target string) (AgentSwapPlan, error) {
 
 // SwapAgent executes a prepared runtime replacement. The daemon must already
 // have raised OpReplacing and recorded plan.target as Instance.Program. Success
-// commits that fence in this wrapper rather than relying on every backend to
-// remember the lifecycle transition.
+// deliberately leaves that fence raised: the replacement is not a completed
+// handoff until the daemon has delivered (or explicitly parked) its mission.
 func (i *Instance) SwapAgent(plan AgentSwapPlan) error {
 	view := i.LifecycleView()
 	if view.InFlightOp != OpReplacing {
@@ -104,7 +104,7 @@ func (i *Instance) SwapAgent(plan AgentSwapPlan) error {
 	if err := i.currentBackend().SwapAgent(i, plan); err != nil {
 		return err
 	}
-	return i.Transition(CommitHandoff())
+	return nil
 }
 
 // ArchiveTeardown tears down every tab's tmux session for an archive AND

--- a/session/instance_backend.go
+++ b/session/instance_backend.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"fmt"
+	"strings"
 )
 
 // currentBackend snapshots the instance's backend under i.mu (#2096). The
@@ -66,18 +67,44 @@ func (i *Instance) Respawn() error {
 	return i.currentBackend().Respawn(i)
 }
 
-// SwapAgent replaces the running agent process with the instance's current
-// program (#2013). Rewrite Instance.Program first (SwapAgentProgram); this only
-// performs the runtime half. Refuses unless this instance is live and eligible
-// for handoff, then separately refuses a backend whose workspace is off-box.
-func (i *Instance) SwapAgent() error {
+// PrepareAgentSwap resolves and validates the incoming launch while the outgoing
+// agent is still untouched. The returned immutable plan is the only value
+// SwapAgent accepts, so the checked command and the launched command cannot drift.
+func (i *Instance) PrepareAgentSwap(target string) (AgentSwapPlan, error) {
 	if err := i.ValidateRuntimeAction(RuntimeActionHandoff); err != nil {
-		return err
+		return AgentSwapPlan{}, err
+	}
+	if err := i.ValidateHandoffTarget(target); err != nil {
+		return AgentSwapPlan{}, err
+	}
+	if !i.Capabilities().Handoff {
+		return AgentSwapPlan{}, ErrHandoffUnsupported
+	}
+	return i.currentBackend().PrepareAgentSwap(i, target)
+}
+
+// SwapAgent executes a prepared runtime replacement. The daemon must already
+// have raised OpReplacing and recorded plan.target as Instance.Program. Success
+// commits that fence in this wrapper rather than relying on every backend to
+// remember the lifecycle transition.
+func (i *Instance) SwapAgent(plan AgentSwapPlan) error {
+	view := i.LifecycleView()
+	if view.InFlightOp != OpReplacing {
+		return fmt.Errorf("session %q has no agent replacement in flight", i.Title)
 	}
 	if !i.Capabilities().Handoff {
 		return ErrHandoffUnsupported
 	}
-	return i.currentBackend().SwapAgent(i)
+	if target := i.AgentProgram(); target != plan.target || strings.TrimSpace(plan.program) == "" {
+		return fmt.Errorf("session %q handoff plan no longer matches its recorded target", i.Title)
+	}
+	if plan.conversation.HasID() {
+		i.SetAgentConversation(plan.conversation)
+	}
+	if err := i.currentBackend().SwapAgent(i, plan); err != nil {
+		return err
+	}
+	return i.Transition(CommitHandoff())
 }
 
 // ArchiveTeardown tears down every tab's tmux session for an archive AND

--- a/session/instance_backend.go
+++ b/session/instance_backend.go
@@ -87,24 +87,27 @@ func (i *Instance) PrepareAgentSwap(target string) (AgentSwapPlan, error) {
 // have raised OpReplacing and recorded plan.target as Instance.Program. Success
 // deliberately leaves that fence raised: the replacement is not a completed
 // handoff until the daemon has delivered (or explicitly parked) its mission.
-func (i *Instance) SwapAgent(plan AgentSwapPlan) error {
+func (i *Instance) SwapAgent(plan AgentSwapPlan) (InstanceData, error) {
 	view := i.LifecycleView()
 	if view.InFlightOp != OpReplacing {
-		return fmt.Errorf("session %q has no agent replacement in flight", i.Title)
+		return InstanceData{}, fmt.Errorf("session %q has no agent replacement in flight", i.Title)
 	}
 	if !i.Capabilities().Handoff {
-		return ErrHandoffUnsupported
+		return InstanceData{}, ErrHandoffUnsupported
 	}
 	if target := i.AgentProgram(); target != plan.target || strings.TrimSpace(plan.program) == "" {
-		return fmt.Errorf("session %q handoff plan no longer matches its recorded target", i.Title)
+		return InstanceData{}, fmt.Errorf("session %q handoff plan no longer matches its recorded target", i.Title)
 	}
 	if plan.conversation.HasID() {
 		i.SetAgentConversation(plan.conversation)
 	}
 	if err := i.currentBackend().SwapAgent(i, plan); err != nil {
-		return err
+		return InstanceData{}, err
 	}
-	return nil
+	// Returning the durable projection from the successful runtime operation
+	// makes it impossible for a caller to checkpoint the target before the
+	// backend has actually established it.
+	return i.handoffStorageCheckpoint(), nil
 }
 
 // ArchiveTeardown tears down every tab's tmux session for an archive AND

--- a/session/liveness.go
+++ b/session/liveness.go
@@ -75,6 +75,10 @@ const (
 	// OpRestoring: an archive restore is in flight (replaces the RestoreFromArchive
 	// "park it in Lost to trigger the re-spawn loop" hack). Wired in 1c.
 	OpRestoring
+	// OpReplacing: an agent handoff is between its outgoing and incoming runtime.
+	// The status poll must not observe the close/start gap or settle a result from
+	// the outgoing pane after the incoming pane has taken its place.
+	OpReplacing
 )
 
 // LifecycleAction is the session domain's answer to which reversible lifecycle
@@ -94,12 +98,13 @@ const (
 // TUI) and ToInstanceData (the web projection). A creating row has a provisional
 // identity but no session to manage yet. An id-less row cannot address a mutation
 // API unambiguously, so it also exposes nothing. A startup-unknown row must not
-// reuse its unconfirmed runtime binding. Resting rows restore; every other settled
-// row archives. Kill addressability is intentionally independent (CanKill): a
-// retained startup-unknown row must remain removable without becoming attachable,
-// archivable, or restorable.
+// reuse its unconfirmed runtime binding, while a replacing row is inside one
+// transactional handoff and cannot admit a competing lifecycle mutation. Resting
+// rows restore; every other settled row archives. Kill addressability is
+// intentionally independent (CanKill): a retained startup-unknown row must remain
+// removable without becoming attachable, archivable, or restorable.
 func lifecycleActionFor(id string, liveness Liveness, op InFlightOp, startupStateUnknown bool) LifecycleAction {
-	if id == "" || op == OpCreating || startupStateUnknown {
+	if id == "" || op == OpCreating || op == OpReplacing || startupStateUnknown {
 		return LifecycleActionNone
 	}
 	switch liveness {
@@ -112,10 +117,11 @@ func lifecycleActionFor(id string, liveness Liveness, op InFlightOp, startupStat
 
 // canKillFor answers only whether a row has a stable teardown target. It does not
 // imply that the runtime binding is safe to reuse: startup-unknown rows are the
-// important counterexample. A creating row has no confirmed session to tear down,
-// and an id-less legacy row cannot address the destructive API without guessing.
+// important counterexample. A creating row has no confirmed session to tear down;
+// a replacing row already owns the runtime mutation fence; and an id-less legacy
+// row cannot address the destructive API without guessing.
 func canKillFor(id string, op InFlightOp) bool {
-	return id != "" && op != OpCreating
+	return id != "" && op != OpCreating && op != OpReplacing
 }
 
 // LifecycleAction returns the shared lifecycle verb for this instance. TUI menus
@@ -147,6 +153,8 @@ func composeStatus(lv Liveness, op InFlightOp) Status {
 		return Deleting
 	case OpRestoring:
 		return Lost
+	case OpReplacing:
+		return Loading
 	}
 	switch lv {
 	case LiveRunning:

--- a/session/liveness_test.go
+++ b/session/liveness_test.go
@@ -97,6 +97,7 @@ func TestSnapshotInFlightOpRoundTrips(t *testing.T) {
 	}{
 		{name: "archiving", op: OpArchiving, status: Deleting},
 		{name: "restoring", op: OpRestoring, status: Lost},
+		{name: "replacing", op: OpReplacing, status: Loading},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			i := &Instance{}
@@ -140,6 +141,7 @@ func TestLifecycleActionIsSharedAcrossInstanceAndProjection(t *testing.T) {
 		{name: "dead restores", id: "dead-id", live: LiveDead, want: LifecycleActionRestore},
 		{name: "archived restores", id: "archived-id", live: LiveArchived, want: LifecycleActionRestore},
 		{name: "creating has no lifecycle action", id: "pending-id", live: LiveReady, op: OpCreating, want: LifecycleActionNone},
+		{name: "replacing admits no competing lifecycle action", id: "handoff-id", live: LiveReady, op: OpReplacing, want: LifecycleActionNone},
 		{name: "id-less has no lifecycle action", live: LiveReady, want: LifecycleActionNone},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -177,6 +179,7 @@ func TestKillAddressabilityIsSharedAcrossInstanceAndProjection(t *testing.T) {
 		{name: "settled stable row", id: "ready-id", want: true},
 		{name: "startup unknown keeps teardown handle", id: "unknown-id", startupUnknown: true, want: true},
 		{name: "creating has no teardown target", id: "pending-id", op: OpCreating},
+		{name: "replacing already owns the teardown fence", id: "handoff-id", op: OpReplacing},
 		{name: "id-less cannot address teardown"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/session/tab_spawn_capability_test.go
+++ b/session/tab_spawn_capability_test.go
@@ -56,7 +56,7 @@ func TestSandboxBackendsDoNotAdvertiseHandoff(t *testing.T) {
 			assert.False(t, b.Capabilities().Handoff,
 				"%s advertises Handoff, but swapping the agent inside a provisioned sandbox is a re-launch its recover path does not do (#2013)", name)
 
-			err := b.SwapAgent(&Instance{Title: "sandbox-inst", backend: b, started: true, Tabs: []*Tab{newRemoteAgentTab()}})
+			err := b.SwapAgent(&Instance{Title: "sandbox-inst", backend: b, started: true, Tabs: []*Tab{newRemoteAgentTab()}}, AgentSwapPlan{})
 			require.Error(t, err, "%s must refuse a swap outright rather than half-perform it", name)
 			assert.ErrorIs(t, err, ErrHandoffUnsupported,
 				"%s must refuse with the typed sentinel so clients can render the restriction instead of matching prose", name)

--- a/session/tmux/environment.go
+++ b/session/tmux/environment.go
@@ -2,6 +2,7 @@ package tmux
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"unicode"
@@ -120,6 +121,48 @@ func CommandEnvironmentFromCommand(command, workingDir string) (CommandEnvironme
 		idx++
 	}
 	return result, nil
+}
+
+// CodexHomeFromCommand resolves the rollout store the launched command will
+// actually use. CODEX_HOME and HOME are interpreted in the same environment +
+// cwd model as GNU env itself, so receipt/capture callers never silently watch
+// the daemon's store while a wrapped Codex writes somewhere else.
+func CodexHomeFromCommand(command, workingDir string) (string, error) {
+	launch, err := CommandEnvironmentFromCommand(command, workingDir)
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve Codex environment: %w", err)
+	}
+	effective := func(name string) (string, bool, error) {
+		override := launch.Override(name)
+		if !override.Present {
+			value, set := os.LookupEnv(name)
+			return value, set, nil
+		}
+		if !override.Literal {
+			return "", false, fmt.Errorf("%s uses shell expansion; use a literal path so Codex storage can be followed", name)
+		}
+		return override.Value, override.Set, nil
+	}
+	resolve := func(path string) string {
+		if filepath.IsAbs(path) {
+			return filepath.Clean(path)
+		}
+		return filepath.Clean(filepath.Join(launch.WorkingDir, path))
+	}
+
+	if codexHome, set, err := effective("CODEX_HOME"); err != nil {
+		return "", err
+	} else if set && strings.TrimSpace(codexHome) != "" {
+		return resolve(codexHome), nil
+	}
+	home, set, err := effective("HOME")
+	if err != nil {
+		return "", err
+	}
+	if !set || strings.TrimSpace(home) == "" {
+		return "", fmt.Errorf("CODEX_HOME is unset and the launched command has no literal HOME fallback")
+	}
+	return filepath.Join(resolve(home), ".codex"), nil
 }
 
 func resolveCommandDir(current, requested string) (string, error) {

--- a/session/tmux/environment_test.go
+++ b/session/tmux/environment_test.go
@@ -57,3 +57,10 @@ func TestCommandEnvironmentFromCommand(t *testing.T) {
 		})
 	}
 }
+
+func TestCodexHomeFromCommandUsesEffectiveCwd(t *testing.T) {
+	launchDir := filepath.Join(string(filepath.Separator), "launch")
+	got, err := CodexHomeFromCommand("env -C /tmp CODEX_HOME=relative codex", launchDir)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(string(filepath.Separator), "tmp", "relative"), got)
+}

--- a/session/transition.go
+++ b/session/transition.go
@@ -52,6 +52,9 @@ const (
 	tkBeginRestore
 	tkAbortRestoreToLost
 	tkMarkRestoring
+	tkBeginHandoff
+	tkCommitHandoff
+	tkAbortHandoff
 	tkClearOp
 	numTransitionKinds
 )
@@ -80,6 +83,12 @@ func (k transitionKind) String() string {
 		return "AbortRestoreToLost"
 	case tkMarkRestoring:
 		return "MarkRestoring"
+	case tkBeginHandoff:
+		return "BeginHandoff"
+	case tkCommitHandoff:
+		return "CommitHandoff"
+	case tkAbortHandoff:
+		return "AbortHandoff"
 	case tkClearOp:
 		return "ClearOp"
 	}
@@ -164,6 +173,15 @@ func AbortRestoreToLost() TransitionEvent { return TransitionEvent{kind: tkAbort
 // sees the Archived→live transition and rebuilds the row (#1203), while
 // ShownArchived re-homes it into the live section eagerly (#1210).
 func MarkRestoring() TransitionEvent { return TransitionEvent{kind: tkMarkRestoring} }
+
+// BeginHandoff raises the OpReplacing fence before the outgoing pane is touched.
+func BeginHandoff() TransitionEvent { return TransitionEvent{kind: tkBeginHandoff} }
+
+// CommitHandoff settles a successfully launched incoming agent as Running.
+func CommitHandoff() TransitionEvent { return TransitionEvent{kind: tkCommitHandoff} }
+
+// AbortHandoff drops a replacement fence whose runtime swap did not complete.
+func AbortHandoff() TransitionEvent { return TransitionEvent{kind: tkAbortHandoff} }
 
 // ClearOp drops any in-flight optimistic op back to None, leaving liveness
 // untouched — the client-projection bookkeeping for when an optimistic op's
@@ -369,6 +387,25 @@ var transitionTable = map[transitionKind]edgeSpec{
 		// state and the daemon never counts caps off it.
 		run: runKeep,
 	},
+	tkBeginHandoff: {
+		allowedFrom: func(s stateAxes) bool {
+			return s.op == OpNone && (s.liveness == LiveRunning || s.liveness == LiveReady || s.liveness == LiveLimitReached)
+		},
+		target: func(s stateAxes, _ TransitionEvent) stateAxes { return stateAxes{s.liveness, OpReplacing} },
+		// Replacement continues the same task run under another agent.
+		run: runKeep,
+	},
+	tkCommitHandoff: {
+		allowedFrom: func(s stateAxes) bool { return s.op == OpReplacing },
+		target:      func(stateAxes, TransitionEvent) stateAxes { return stateAxes{LiveRunning, OpNone} },
+		run:         runKeep,
+	},
+	tkAbortHandoff: {
+		allowedFrom:      func(s stateAxes) bool { return s.op == OpReplacing },
+		target:           func(s stateAxes, _ TransitionEvent) stateAxes { return stateAxes{s.liveness, OpNone} },
+		yieldWhenBlocked: true, // a terminal kill may supersede the replacement
+		run:              runKeep,
+	},
 	tkClearOp: {
 		// Clearing an optimistic overlay back to None is always valid — it never
 		// resurrects or teardown-clobbers (liveness is untouched).
@@ -512,6 +549,8 @@ func opLabel(op InFlightOp) string {
 		return "Archiving"
 	case OpRestoring:
 		return "Restoring"
+	case OpReplacing:
+		return "Replacing"
 	}
 	return fmt.Sprintf("InFlightOp(%d)", int(op))
 }

--- a/session/transition.go
+++ b/session/transition.go
@@ -3,6 +3,7 @@ package session
 import (
 	"errors"
 	"fmt"
+	"time"
 )
 
 // The lifecycle transition chokepoint (#1195 Phase 2c).
@@ -54,6 +55,7 @@ const (
 	tkMarkRestoring
 	tkBeginHandoff
 	tkCommitHandoff
+	tkParkHandoff
 	tkAbortHandoff
 	tkClearOp
 	numTransitionKinds
@@ -87,6 +89,8 @@ func (k transitionKind) String() string {
 		return "BeginHandoff"
 	case tkCommitHandoff:
 		return "CommitHandoff"
+	case tkParkHandoff:
+		return "ParkHandoff"
 	case tkAbortHandoff:
 		return "AbortHandoff"
 	case tkClearOp:
@@ -101,6 +105,7 @@ func (k transitionKind) String() string {
 type TransitionEvent struct {
 	kind        transitionKind
 	lv          Liveness
+	resetAt     time.Time
 	epoch       uint64
 	epochScoped bool
 }
@@ -179,6 +184,12 @@ func BeginHandoff() TransitionEvent { return TransitionEvent{kind: tkBeginHandof
 
 // CommitHandoff settles a successfully launched incoming agent as Running.
 func CommitHandoff() TransitionEvent { return TransitionEvent{kind: tkCommitHandoff} }
+
+// ParkHandoff settles an incoming agent that launched but reached its own usage
+// limit before the takeover mission could be delivered.
+func ParkHandoff(resetAt time.Time) TransitionEvent {
+	return TransitionEvent{kind: tkParkHandoff, resetAt: resetAt}
+}
 
 // AbortHandoff drops a replacement fence whose runtime swap did not complete.
 func AbortHandoff() TransitionEvent { return TransitionEvent{kind: tkAbortHandoff} }
@@ -262,6 +273,14 @@ const (
 	runEnds
 )
 
+type limitResetEffect int
+
+const (
+	limitResetKeep limitResetEffect = iota
+	limitResetClear
+	limitResetFromEvent
+)
+
 // edgeSpec is one row of the allowed-edge table: which from-states an event is
 // legal from, the resulting state, and the event's side effects.
 type edgeSpec struct {
@@ -276,6 +295,10 @@ type edgeSpec struct {
 	// the zero value is invalid and the exhaustiveness test rejects it, so a new
 	// transition must state whether the run it lands in is still in flight.
 	run runEffect
+	// limitReset owns reset metadata only on edges that replace the provider
+	// state it described. Most transitions preserve the hidden value;
+	// LimitResetAt exposes it only while LiveLimitReached.
+	limitReset limitResetEffect
 	// yieldWhenBlocked makes an out-of-set from-state a silent no-op instead of a
 	// rejection — for the daemon-truth edge (ObserveLiveness is always allowed)
 	// and ConfirmLive (yields to an in-flight teardown rather than fighting it).
@@ -399,6 +422,15 @@ var transitionTable = map[transitionKind]edgeSpec{
 		allowedFrom: func(s stateAxes) bool { return s.op == OpReplacing },
 		target:      func(stateAxes, TransitionEvent) stateAxes { return stateAxes{LiveRunning, OpNone} },
 		run:         runKeep,
+		limitReset:  limitResetClear,
+	},
+	tkParkHandoff: {
+		allowedFrom: func(s stateAxes) bool { return s.op == OpReplacing },
+		target:      func(stateAxes, TransitionEvent) stateAxes { return stateAxes{LiveLimitReached, OpNone} },
+		// The incoming runtime exists but cannot accept its mission yet. Parking
+		// continues the same task run; resume will deliver the pending mission.
+		run:        runKeep,
+		limitReset: limitResetFromEvent,
 	},
 	tkAbortHandoff: {
 		allowedFrom:      func(s stateAxes) bool { return s.op == OpReplacing },
@@ -488,11 +520,18 @@ func (i *Instance) Transition(ev TransitionEvent) error {
 			}
 		}
 	}
+	prevResetAt := i.limitResetAt
 	i.liveness = to.liveness
 	i.inFlightOp = to.op
+	switch spec.limitReset {
+	case limitResetClear:
+		i.limitResetAt = time.Time{}
+	case limitResetFromEvent:
+		i.limitResetAt = ev.resetAt
+	}
 	// Every real change to the lifecycle state advances the epoch, so an observer
 	// holding an older one learns its in-flight decision is stale (#2135).
-	i.noteStateChangeLocked(from.liveness, from.op, i.limitResetAt)
+	i.noteStateChangeLocked(from.liveness, from.op, prevResetAt)
 	switch spec.started {
 	case startedSet:
 		i.started = true

--- a/session/transition_test.go
+++ b/session/transition_test.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -74,6 +75,7 @@ func TestTransitionTable_RunEffectsAreTheAgreedTable(t *testing.T) {
 		// which agent process owns it.
 		tkBeginHandoff:  runKeep,
 		tkCommitHandoff: runKeep,
+		tkParkHandoff:   runKeep,
 		tkAbortHandoff:  runKeep,
 		// Dropping an overlay reveals liveness; it does not change the agent's work.
 		tkClearOp: runKeep,
@@ -133,6 +135,7 @@ func TestTransition_LegalEdgesApply(t *testing.T) {
 		{"MarkRestoring keeps liveness", stateAxes{LiveArchived, OpNone}, false, false, MarkRestoring(), LiveArchived, OpRestoring, false},
 		{"BeginHandoff fences running agent", stateAxes{LiveRunning, OpNone}, true, false, BeginHandoff(), LiveRunning, OpReplacing, true},
 		{"CommitHandoff settles incoming agent", stateAxes{LiveReady, OpReplacing}, true, false, CommitHandoff(), LiveRunning, OpNone, true},
+		{"ParkHandoff settles incoming agent at limit", stateAxes{LiveRunning, OpReplacing}, true, false, ParkHandoff(time.Date(2026, 7, 25, 17, 55, 0, 0, time.UTC)), LiveLimitReached, OpNone, true},
 		{"AbortHandoff preserves outgoing liveness", stateAxes{LiveLimitReached, OpReplacing}, true, false, AbortHandoff(), LiveLimitReached, OpNone, true},
 		// ClearOp: drop any optimistic overlay to None, liveness untouched.
 		{"ClearOp from archiving", stateAxes{LiveReady, OpArchiving}, true, false, ClearOp(), LiveReady, OpNone, true},
@@ -147,6 +150,15 @@ func TestTransition_LegalEdgesApply(t *testing.T) {
 			assert.Equal(t, tc.wantStarted, i.started, "started")
 		})
 	}
+}
+
+func TestTransition_ParkHandoffStoresIncomingResetTime(t *testing.T) {
+	resetAt := time.Date(2026, 7, 25, 17, 55, 0, 0, time.UTC)
+	i := &Instance{liveness: LiveRunning, inFlightOp: OpReplacing}
+	require.NoError(t, i.Transition(ParkHandoff(resetAt)))
+	got, ok := i.LimitResetAt()
+	require.True(t, ok)
+	require.Equal(t, resetAt, got)
 }
 
 // I1 (tombstone-before-teardown) is intentionally NOT a chokepoint edge —

--- a/session/transition_test.go
+++ b/session/transition_test.go
@@ -70,6 +70,11 @@ func TestTransitionTable_RunEffectsAreTheAgreedTable(t *testing.T) {
 		tkBeginRestore:       runKeep,
 		tkAbortRestoreToLost: runKeep,
 		tkMarkRestoring:      runKeep,
+		// A handoff continues the same task run; begin/commit/abort only bracket
+		// which agent process owns it.
+		tkBeginHandoff:  runKeep,
+		tkCommitHandoff: runKeep,
+		tkAbortHandoff:  runKeep,
 		// Dropping an overlay reveals liveness; it does not change the agent's work.
 		tkClearOp: runKeep,
 	}
@@ -126,6 +131,9 @@ func TestTransition_LegalEdgesApply(t *testing.T) {
 		// MarkRestoring: optimistic restore overlay — OpRestoring, liveness KEPT
 		// Archived (unlike BeginRestore which flips to Lost), started untouched.
 		{"MarkRestoring keeps liveness", stateAxes{LiveArchived, OpNone}, false, false, MarkRestoring(), LiveArchived, OpRestoring, false},
+		{"BeginHandoff fences running agent", stateAxes{LiveRunning, OpNone}, true, false, BeginHandoff(), LiveRunning, OpReplacing, true},
+		{"CommitHandoff settles incoming agent", stateAxes{LiveReady, OpReplacing}, true, false, CommitHandoff(), LiveRunning, OpNone, true},
+		{"AbortHandoff preserves outgoing liveness", stateAxes{LiveLimitReached, OpReplacing}, true, false, AbortHandoff(), LiveLimitReached, OpNone, true},
 		// ClearOp: drop any optimistic overlay to None, liveness untouched.
 		{"ClearOp from archiving", stateAxes{LiveReady, OpArchiving}, true, false, ClearOp(), LiveReady, OpNone, true},
 		{"ClearOp from restoring keeps liveness", stateAxes{LiveArchived, OpRestoring}, false, false, ClearOp(), LiveArchived, OpNone, false},

--- a/task/start.go
+++ b/task/start.go
@@ -110,6 +110,17 @@ func StartAndSendPrompt(ctx context.Context, instance *session.Instance, prompt 
 	if err := instance.Start(true); err != nil {
 		return err
 	}
+	return WaitForReadyAndSendPrompt(ctx, instance, prompt)
+}
+
+// WaitForReadyAndSendPrompt is the post-launch half of StartAndSendPrompt. A
+// handoff has already launched its incoming pane, but it owes the same readiness
+// and trust-dialog contract as a fresh create before any mission text is typed.
+// Keeping that contract here prevents the two launch paths from drifting.
+func WaitForReadyAndSendPrompt(ctx context.Context, instance *session.Instance, prompt string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 
 	// Readiness polling, trust-prompt dismissal and prompt delivery below all
 	// drive the agent's PTY locally; a backend without interactive input (remote

--- a/task/start_test.go
+++ b/task/start_test.go
@@ -21,7 +21,10 @@ func (b *startBackend) Start(instance *session.Instance, _ bool) error {
 }
 
 func (b *startBackend) Provision(*session.Instance, bool) error { return nil }
-func (b *startBackend) SwapAgent(*session.Instance) error       { return nil }
+func (b *startBackend) PrepareAgentSwap(_ *session.Instance, _ string) (session.AgentSwapPlan, error) {
+	return session.AgentSwapPlan{}, nil
+}
+func (b *startBackend) SwapAgent(*session.Instance, session.AgentSwapPlan) error { return nil }
 
 func (b *startBackend) Launch(instance *session.Instance, _ bool) error {
 	instance.SetStartedForTest(true)


### PR DESCRIPTION
## Outcome

A full /v1/events subscriber buffer now closes that subscriber instead of silently dropping state-change events on an open connection. The existing browser reconnect path then requests an authoritative Snapshot.

Added a regression test proving overflow remains non-blocking and closes the slow subscriber.

Fixes #2274

— Captain Claude