### PR TITLE
fix TUI section navigation from Projects

### DIFF
--- a/app/handle_overlay.go
+++ b/app/handle_overlay.go
@@ -158,6 +158,16 @@ func (m *home) handleProjectsFocus(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
 	if m.ring.Active() != layout.RegionProjects {
 		return m, nil, false
 	}
+	// A configured section-navigation key takes priority over this list's
+	// hardcoded vim/cursor aliases. For example, next_section = "j" suppresses
+	// the global down binding, so Projects must not reclaim j before the global
+	// dispatcher can honor the override.
+	if key.Matches(msg,
+		keys.GlobalKeyBindings[keys.KeyNextSection],
+		keys.GlobalKeyBindings[keys.KeyPrevSection],
+	) {
+		return m, nil, false
+	}
 	// The section owns its vim/cursor nav (j/k/up/down).
 	if _, consumed := m.projects.HandleKey(msg); consumed {
 		return m, nil, true
@@ -204,9 +214,10 @@ func (m *home) handleProjectsFocus(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
 }
 
 // projectsChromeFallthroughKey reports whether a key pressed with the Projects
-// section focused must still reach the global handler — focus-ring and section
-// navigation, help (?), quit (q), and the always-on ctrl+c hard exit. Every
-// other key is consumed as a no-op by handleProjectsFocus (#1620).
+// section focused must still reach the global handler — focus-ring navigation,
+// help (?), quit (q), and the always-on ctrl+c hard exit. Section navigation is
+// checked before the captive cursor handler above so rebound cursor keys work.
+// Every other key is consumed as a no-op by handleProjectsFocus (#1620).
 func projectsChromeFallthroughKey(msg tea.KeyMsg) bool {
 	if msg.String() == "ctrl+c" {
 		return true
@@ -214,8 +225,6 @@ func projectsChromeFallthroughKey(msg tea.KeyMsg) bool {
 	for _, name := range []keys.KeyName{
 		keys.KeyTab,
 		keys.KeyShiftTab,
-		keys.KeyNextSection,
-		keys.KeyPrevSection,
 		keys.KeyHelp,
 		keys.KeyQuit,
 	} {

--- a/app/handle_overlay.go
+++ b/app/handle_overlay.go
@@ -149,10 +149,11 @@ func (m *home) handleAutomationsFocus(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool)
 // key is a no-op here (consumed, never fired) so nothing can START a search or
 // filter from the section — notably the ctrl+p project-picker filter and the
 // session-create/tasks/collapse verbs that used to leak through when this handler
-// fell through to the global key map. Only the focus-ring and hard-exit chrome
-// (Tab/Shift-Tab, ? help, q quit, ctrl+c) is allowed to fall through, so the user
-// is never trapped in the section. Scoped to Projects focus; the Instances tree
-// and Automations section are untouched.
+// fell through to the global key map. Only focus-ring navigation, documented
+// section navigation, and hard-exit chrome (Tab/Shift-Tab, `[`/`]`, ? help, q quit,
+// ctrl+c) are allowed to fall through, so the user is never trapped and can
+// keep cycling across every rail region. Scoped to Projects focus; the Instances
+// tree and Automations section are untouched.
 func (m *home) handleProjectsFocus(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
 	if m.ring.Active() != layout.RegionProjects {
 		return m, nil, false
@@ -189,8 +190,9 @@ func (m *home) handleProjectsFocus(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
 		mod, cmd := m.showSearchOverlay()
 		return mod, cmd, true
 	}
-	// The focus ring and hard-exit chrome must keep working so the user can
-	// always leave the section; let only those fall through to the root handler.
+	// Focus and section navigation plus hard-exit chrome must keep working so the
+	// user can always leave the section; let only those fall through to the root
+	// handler.
 	if projectsChromeFallthroughKey(msg) {
 		return m, nil, false
 	}
@@ -202,10 +204,9 @@ func (m *home) handleProjectsFocus(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
 }
 
 // projectsChromeFallthroughKey reports whether a key pressed with the Projects
-// section focused must still reach the global handler — the focus ring
-// (Tab/Shift-Tab), help (?), quit (q), and the always-on ctrl+c hard exit. Every
-// other key is consumed as a no-op by handleProjectsFocus (#1620), so these are
-// the only escape hatches out of the captive section.
+// section focused must still reach the global handler — focus-ring and section
+// navigation, help (?), quit (q), and the always-on ctrl+c hard exit. Every
+// other key is consumed as a no-op by handleProjectsFocus (#1620).
 func projectsChromeFallthroughKey(msg tea.KeyMsg) bool {
 	if msg.String() == "ctrl+c" {
 		return true
@@ -213,6 +214,8 @@ func projectsChromeFallthroughKey(msg tea.KeyMsg) bool {
 	for _, name := range []keys.KeyName{
 		keys.KeyTab,
 		keys.KeyShiftTab,
+		keys.KeyNextSection,
+		keys.KeyPrevSection,
 		keys.KeyHelp,
 		keys.KeyQuit,
 	} {

--- a/app/pane_focus_ring_test.go
+++ b/app/pane_focus_ring_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sachiniyer/agent-factory/session"
@@ -209,6 +210,27 @@ func TestSectionNav_JumpsAcrossRailSections(t *testing.T) {
 	pressKey(t, h, "[")
 	require.Equal(t, layout.RegionProjects, h.ring.Active(),
 		"#1706: [ walks the sections in reverse")
+}
+
+// TestSectionNav_ProjectsFocusUsesGlobalBindings is the #2278 regression. The
+// focused Projects section owns most keys before the global dispatcher runs,
+// but the documented section-navigation bindings must fall through that
+// captive handler so they can keep cycling through every rail section.
+func TestSectionNav_ProjectsFocusUsesGlobalBindings(t *testing.T) {
+	h := paneTestHome(t)
+	h.focusRegion(layout.RegionProjects)
+	require.Equal(t, layout.RegionProjects, h.ring.Active())
+
+	// Drive Update rather than handleDefaultKeyPress directly: production sends
+	// this key through handleProjectsFocus before the global key map.
+	_, _ = h.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'['}})
+	require.Equal(t, layout.RegionAutomations, h.ring.Active(),
+		"#2278: [ from Projects must reach Automations")
+
+	h.focusRegion(layout.RegionProjects)
+	_, _ = h.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{']'}})
+	require.Equal(t, layout.RegionTree, h.ring.Active(),
+		"#2278: ] from Projects must wrap to Instances")
 }
 
 // TestSectionNav_SkipsWorkspacePanes proves `]` jumps SECTION to SECTION, not

--- a/app/pane_focus_ring_test.go
+++ b/app/pane_focus_ring_test.go
@@ -7,6 +7,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/ui/layout"
 )
@@ -231,6 +232,27 @@ func TestSectionNav_ProjectsFocusUsesGlobalBindings(t *testing.T) {
 	_, _ = h.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{']'}})
 	require.Equal(t, layout.RegionTree, h.ring.Active(),
 		"#2278: ] from Projects must wrap to Instances")
+}
+
+// A section-navigation override can intentionally take a Projects cursor alias
+// such as j or k. The configured global action must win before the captive list
+// consumes that physical key as cursor movement.
+func TestSectionNav_ProjectsFocusHonorsReboundCursorKeys(t *testing.T) {
+	require.NoError(t, keys.ApplyOverrides(map[string][]string{
+		"next_section": {"j"},
+		"prev_section": {"k"},
+	}))
+	t.Cleanup(func() { require.NoError(t, keys.ApplyOverrides(nil)) })
+
+	h := projectsHomeWithRows(t)
+	_, _ = h.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	require.Equal(t, layout.RegionTree, h.ring.Active(),
+		"a rebound next-section key must take priority over the Projects cursor")
+
+	h.focusRegion(layout.RegionProjects)
+	_, _ = h.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	require.Equal(t, layout.RegionAutomations, h.ring.Active(),
+		"a rebound previous-section key must take priority over the Projects cursor")
 }
 
 // TestSectionNav_SkipsWorkspacePanes proves `]` jumps SECTION to SECTION, not


### PR DESCRIPTION
## Summary

- let configured previous/next-section actions pass through the focused Projects handler
- prioritize configured section keys over the Projects list cursor aliases, including `j`, `k`, `up`, and `down` rebinds
- cover default and rebound keys through the real `home.Update` production dispatch path

## Root cause

The Projects rail owns input before the global key dispatcher and consumed every key outside a small chrome allowlist. `[` and `]` therefore never reached `focusAdjacentSection`. A first fix added those actions to the allowlist, but configured cursor-key aliases were still consumed earlier by the Projects list; the final ordering recognizes configured section actions before that captive cursor handler.

## Regression proof

Before the implementation change, `TestSectionNav_ProjectsFocusUsesGlobalBindings` failed with expected `automations`, actual `projects`. The review regression with `next_section = j` and `prev_section = k` also failed with expected `tree`, actual `projects`. Both now pass through the production `Update` path, along with the neighboring Projects/section-navigation tests.

## Rendered TUI validation

- 80×24 and 60×18: drove the default `[`/`]` transitions out of Projects
- 80×24 and 60×18: configured `next_section = j` and `prev_section = k`, entered Projects through the focus ring, then verified `k` reached Automations and `j` wrapped to Instances
- deterministic TUI driver self-test: 61/61 steps green

## Exact-head gates

Commit: `4c34766e954acc0e70d3e8eb48196f402827f134`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `make tui-driver-selftest`

Closes #2278

— Captain Claude