### PR TITLE
fix(web): reconnect event streams after overflow

### DIFF
--- a/daemon/limit.go
+++ b/daemon/limit.go
@@ -192,7 +192,7 @@ func (m *Manager) persistPollChange(repoID string, instance *session.Instance, b
 	// this older payload landed last and clients re-projected the tab right back out of
 	// existence, until some later update happened to repair it (post-merge Codex finding
 	// on #1815). Serializing publish with persist makes the last event the newest state.
-	// publishEvent is non-blocking (drop-slow), so a wedged subscriber can't stall the poll.
+	// publishEvent is non-blocking (disconnect-slow), so a wedged subscriber can't stall the poll.
 	testHookPollBeforePublish()
 	m.publishEvent(agentproto.EventSessionUpdated, data)
 	repoStartLock.Unlock()

--- a/daemon/manager_tabs.go
+++ b/daemon/manager_tabs.go
@@ -157,7 +157,7 @@ func (m *Manager) CreateTab(req CreateTabRequest) (string, string, error) {
 	// ReconcileTabsFromData), so this needs no client change. Published after the
 	// persist so no client can observe a tab that isn't durable yet, and while
 	// still holding the repo start lock so concurrent tab mutations announce in
-	// the same order they persisted. publishEvent is non-blocking (drop-slow), so
+	// the same order they persisted. publishEvent is non-blocking (disconnect-slow), so
 	// a wedged subscriber can't stall the mutation.
 	m.publishEvent(agentproto.EventSessionUpdated, data)
 	// Report the tmux session the tab actually spawned under, read out of the very

--- a/daemon/ws_events.go
+++ b/daemon/ws_events.go
@@ -26,34 +26,49 @@ import (
 // threaded through the auth/CORS seam and covered by the WS harness.
 
 // eventsBufferSize bounds one subscriber's pending-event queue. A subscriber that
-// falls this far behind has an event dropped (non-blocking publish) rather than
-// stalling the mutation that published it — a dropped state-change is recoverable
-// by a Snapshot, a blocked daemon mutation is not. Generous enough that a healthy
-// client never drops.
+// falls this far behind is disconnected (non-blocking publish) rather than
+// stalling the mutation that published it. Reconnecting clients take a fresh
+// Snapshot, so the missed state change cannot leave them silently stale. Generous
+// enough that a healthy client is never disconnected.
 const eventsBufferSize = 256
 
 // eventsHub is the Manager-owned fan-out of state-change events to every
-// connected /v1/events subscriber. Non-blocking on publish (drop-slow), so no
-// subscriber can back-pressure a daemon mutation.
+// connected /v1/events subscriber. Non-blocking on publish (disconnect-slow), so
+// no subscriber can back-pressure a daemon mutation or silently miss an event.
 type eventsHub struct {
 	mu   sync.Mutex
-	subs map[uint64]chan agentproto.Event
+	subs map[uint64]*eventsSubscriber
 	next uint64
 }
 
+type eventsSubscriber struct {
+	events   chan agentproto.Event
+	overflow chan struct{}
+}
+
 func newEventsHub() *eventsHub {
-	return &eventsHub{subs: make(map[uint64]chan agentproto.Event)}
+	return &eventsHub{subs: make(map[uint64]*eventsSubscriber)}
 }
 
 // subscribe registers a subscriber and returns its id and receive channel.
 func (h *eventsHub) subscribe() (uint64, <-chan agentproto.Event) {
+	id, events, _ := h.subscribeWithOverflow()
+	return id, events
+}
+
+// subscribeWithOverflow also returns the signal serveEvents uses to turn a
+// missed event into a reconnect and authoritative Snapshot.
+func (h *eventsHub) subscribeWithOverflow() (uint64, <-chan agentproto.Event, <-chan struct{}) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.next++
 	id := h.next
-	ch := make(chan agentproto.Event, eventsBufferSize)
-	h.subs[id] = ch
-	return id, ch
+	sub := &eventsSubscriber{
+		events:   make(chan agentproto.Event, eventsBufferSize),
+		overflow: make(chan struct{}),
+	}
+	h.subs[id] = sub
+	return id, sub.events, sub.overflow
 }
 
 // unsubscribe removes a subscriber.
@@ -63,17 +78,20 @@ func (h *eventsHub) unsubscribe(id uint64) {
 	delete(h.subs, id)
 }
 
-// publish fans an event to every subscriber, dropping it for any whose buffer is
-// full (never blocking the mutation that published it).
+// publish fans an event to every subscriber, evicting any whose buffer is full
+// (never blocking the mutation that published it). Closing both channels makes
+// the gap observable to direct subscribers and lets serveEvents promptly close
+// the WebSocket instead of leaving the client silently stale.
 func (h *eventsHub) publish(ev agentproto.Event) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	for _, ch := range h.subs {
+	for id, sub := range h.subs {
 		select {
-		case ch <- ev:
+		case sub.events <- ev:
 		default:
-			// Slow subscriber: drop this event rather than block the daemon. The
-			// client can re-Snapshot to resynchronise.
+			delete(h.subs, id)
+			close(sub.overflow)
+			close(sub.events)
 		}
 	}
 }
@@ -122,7 +140,7 @@ func serveEvents(hub *eventsHub, conn *websocket.Conn) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	id, ch := hub.subscribe()
+	id, ch, overflow := hub.subscribeWithOverflow()
 	defer hub.unsubscribe(id)
 
 	var wg sync.WaitGroup
@@ -139,14 +157,38 @@ func serveEvents(hub *eventsHub, conn *websocket.Conn) {
 		}
 	}()
 	go func() { defer wg.Done(); defer cancel(); keepalivePTY(ctx, conn) }()
+	closeOverflow := func() {
+		// Send the close frame before canceling the read context. Canceling first
+		// can tear down coder/websocket as a raw EOF and hide the retryable 1013
+		// status from the client.
+		_ = conn.Close(websocket.StatusTryAgainLater, "event subscriber overflow")
+		cancel()
+		wg.Wait()
+	}
 
 	for {
+		// Prefer the overflow signal over draining buffered events: once a gap
+		// exists, no delta sequence can repair it, and the client needs a fresh
+		// Snapshot as soon as possible.
+		select {
+		case <-overflow:
+			closeOverflow()
+			return
+		default:
+		}
 		select {
 		case <-ctx.Done():
 			_ = conn.Close(websocket.StatusNormalClosure, "")
 			wg.Wait()
 			return
-		case ev := <-ch:
+		case <-overflow:
+			closeOverflow()
+			return
+		case ev, ok := <-ch:
+			if !ok {
+				closeOverflow()
+				return
+			}
 			wctx, wcancel := context.WithTimeout(ctx, wsWriteTimeout)
 			err := agentproto.WriteControl(wctx, conn, ev)
 			wcancel()

--- a/daemon/ws_events_test.go
+++ b/daemon/ws_events_test.go
@@ -14,11 +14,11 @@ import (
 	"github.com/sachiniyer/agent-factory/session"
 )
 
-// TestEventsHubFanoutAndDropSlow pins the hub contract: an event fans out to
-// every subscriber, and a subscriber whose bounded buffer is full drops events
-// rather than blocking publish (so a slow client can never back-pressure a daemon
-// mutation).
-func TestEventsHubFanoutAndDropSlow(t *testing.T) {
+// TestEventsHubFanoutAndDisconnectSlow pins the hub contract: an event fans out
+// to every subscriber, and a subscriber whose bounded buffer is full is
+// disconnected rather than blocking publish (so a slow client can never
+// back-pressure a daemon mutation).
+func TestEventsHubFanoutAndDisconnectSlow(t *testing.T) {
 	hub := newEventsHub()
 	_, a := hub.subscribe()
 	_, b := hub.subscribe()
@@ -39,7 +39,8 @@ func TestEventsHubFanoutAndDropSlow(t *testing.T) {
 		}
 	}
 
-	// Overfill one subscriber's buffer: publish must not block (drop-slow).
+	// Overfill one subscriber's buffer: publish must not block
+	// (disconnect-slow).
 	done := make(chan struct{})
 	go func() {
 		for i := 0; i < eventsBufferSize*3; i++ {
@@ -50,7 +51,96 @@ func TestEventsHubFanoutAndDropSlow(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):
-		t.Fatal("publish blocked on a full subscriber buffer (drop-slow broken)")
+		t.Fatal("publish blocked on a full subscriber buffer (disconnect-slow broken)")
+	}
+}
+
+// TestEventsHubOverflowDisconnectsSubscriber is the server half of the web
+// client's reconnect/resync invariant (#2274): once a subscriber misses an
+// event, keeping its stream open would leave its projection stale forever. The
+// hub must evict it and close its event channel so serveEvents can close the
+// WebSocket; EventStream then reconnects and requests an authoritative Snapshot.
+func TestEventsHubOverflowDisconnectsSubscriber(t *testing.T) {
+	hub := newEventsHub()
+	id, ch := hub.subscribe()
+
+	ev, err := agentproto.NewEvent(agentproto.EventSessionUpdated, session.InstanceData{Title: "overflow"})
+	if err != nil {
+		t.Fatalf("NewEvent: %v", err)
+	}
+	for i := 0; i < eventsBufferSize; i++ {
+		hub.publish(ev)
+	}
+
+	// This mutation cannot fit. It must make the gap observable instead of
+	// silently dropping the event while leaving the subscriber live.
+	hub.publish(ev)
+
+	hub.mu.Lock()
+	_, live := hub.subs[id]
+	hub.mu.Unlock()
+	if live {
+		t.Error("overflowed subscriber remains registered")
+	}
+
+	for i := 0; i < eventsBufferSize; i++ {
+		<-ch
+	}
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Fatal("overflowed subscriber received an event after its buffer drained")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("overflowed subscriber channel stayed open, so its WebSocket cannot reconnect/resync")
+	}
+}
+
+// TestServeEventsOverflowClosesWebSocket pins the transport half of #2274. The
+// hub test above proves saturation emits the overflow signal; this test proves
+// serveEvents turns that signal into a retryable close, which is what the web
+// EventStream observes before reconnecting and calling onResync.
+func TestServeEventsOverflowClosesWebSocket(t *testing.T) {
+	hub := newEventsHub()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+		if err != nil {
+			return
+		}
+		serveEvents(hub, conn)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(srv.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("dial events ws: %v", err)
+	}
+	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "") }()
+
+	var overflow chan struct{}
+	deadline := time.Now().Add(time.Second)
+	for overflow == nil && time.Now().Before(deadline) {
+		hub.mu.Lock()
+		for _, sub := range hub.subs {
+			overflow = sub.overflow
+			break
+		}
+		hub.mu.Unlock()
+		if overflow == nil {
+			time.Sleep(time.Millisecond)
+		}
+	}
+	if overflow == nil {
+		t.Fatal("serveEvents did not register its subscriber")
+	}
+
+	// publish closes this exact signal when the bounded event channel fills.
+	close(overflow)
+	_, _, err = conn.Read(ctx)
+	if got := websocket.CloseStatus(err); got != websocket.StatusTryAgainLater {
+		t.Fatalf("overflow close status = %v (err %v), want %v", got, err, websocket.StatusTryAgainLater)
 	}
 }
 

--- a/web/src/events.ts
+++ b/web/src/events.ts
@@ -19,8 +19,8 @@
 // (the socket wasn't yet subscribed to receive it). Re-Snapshotting once the
 // socket is open — after which every subsequent event IS delivered — makes the
 // rail whole regardless of what happened in that gap. Reconnect opens resync for
-// the same reason (events published while the socket was down are dropped by
-// design — the hub is drop-slow, not replayed). The resync is debounced in
+// the same reason (events published while the socket was down are not replayed
+// by the hub). The resync is debounced in
 // index.ts, so the extra first-open refetch collapses with any burst.
 
 import type { WireEvent } from "./types.js";

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -601,7 +601,7 @@ function newSession(): void {
           })
           .catch((e) => {
             // The daemon publishes session.killed for the provisional id. Resync as a
-            // drop-slow/reconnect fallback so even a missed delete event cannot strand a
+            // direct fallback so even a missed delete event cannot strand a
             // phantom creating row, and surface the daemon's unmodified error text.
             requestResync();
             surfaceTabError(e);


### PR DESCRIPTION
## Summary

- evict an events-plane subscriber when its bounded queue overflows
- close the affected WebSocket with retryable status 1013 so web clients reconnect
- preserve non-blocking daemon mutations while forcing the existing Snapshot resync path
- add saturation and WebSocket-close regression coverage

## Root cause

The hub silently dropped an event when a subscriber queue filled but left that subscriber and its socket live. The browser only requests an authoritative Snapshot when the socket opens, so a silent gap could leave its session projection stale indefinitely.

## Validation

Exact pushed head: `12bb2e0babe7dbbd124da90e6fb72b9dc54255f7`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `make web-test` (401 tests)
- `make web-build` (committed bundle remained reproducible)
- focused events tests under `-race -count=10`

Fixes #2274