### PR TITLE
fix(daemon): count concurrently killed project targets

### DIFF
--- a/daemon/deleteproject.go
+++ b/daemon/deleteproject.go
@@ -102,6 +102,7 @@ func (m *Manager) DeleteProject(req DeleteProjectRequest) (DeleteProjectResult, 
 	// with the lock released — ArchiveSession/KillSession take their own
 	// per-session locks and would deadlock if called while holding m.mu.
 	type target struct {
+		id       string
 		title    string
 		external bool
 	}
@@ -115,7 +116,7 @@ func (m *Manager) DeleteProject(req DeleteProjectRequest) (DeleteProjectResult, 
 		if inst.GetLiveness() == session.LiveArchived {
 			continue
 		}
-		targets = append(targets, target{title: title, external: inst.IsExternalWorktree()})
+		targets = append(targets, target{id: inst.ID, title: title, external: inst.IsExternalWorktree()})
 	}
 	m.mu.Unlock()
 
@@ -126,7 +127,21 @@ func (m *Manager) DeleteProject(req DeleteProjectRequest) (DeleteProjectResult, 
 	var errs []error
 	for _, t := range targets {
 		if t.external {
-			killed, err := m.KillSession(KillSessionRequest{Title: t.title, RepoID: repoID})
+			// Carry the stable identity captured under m.mu into the destructive
+			// lookup. Besides making a concurrent completed kill distinguishable,
+			// this prevents a same-title replacement from being torn down in the
+			// original target's place. Legacy id-less rows retain title lookup.
+			killed, err := m.KillSession(KillSessionRequest{ID: t.id, Title: t.title, RepoID: repoID})
+			if errors.Is(err, errSessionNotFound) {
+				// This is idempotent success only because t came from DeleteProject's
+				// own under-lock snapshot: the target existed then and is gone now,
+				// which is precisely the requested end state (#2124). A standalone
+				// KillSession for a stale/never-existing target still returns the
+				// same not-found error. Report the snapshotted identity so counts and
+				// lifecycle events do not understate what the delete achieved.
+				killed = session.InstanceData{ID: t.id, Title: t.title}
+				err = nil
+			}
 			if err != nil {
 				errs = append(errs, fmt.Errorf("session %q: %w", t.title, err))
 				continue

--- a/daemon/deleteproject_test.go
+++ b/daemon/deleteproject_test.go
@@ -8,10 +8,23 @@ import (
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/session"
+	sessiongit "github.com/sachiniyer/agent-factory/session/git"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type killAnotherSessionBackend struct {
+	*session.FakeBackend
+	onKill func() error
+}
+
+func (b *killAnotherSessionBackend) Kill(instance *session.Instance) error {
+	if err := b.onKill(); err != nil {
+		return err
+	}
+	return b.FakeBackend.Kill(instance)
+}
 
 // liveProjectRoots mirrors the "active projects" derivation the TUI and web use
 // (live-only grouping by repo root): archived sessions do not keep a project in
@@ -285,4 +298,73 @@ func TestDeleteProject_GenuineArchiveFailureStillReportsPartialFailure(t *testin
 
 	assert.NotEqual(t, session.Archived, beta.GetStatus(), "the busy session is untouched")
 	assert.True(t, exists(betaSrc), "the busy session's worktree is untouched")
+}
+
+// TestDeleteProject_ConcurrentlyKilledExternalTargetIsSuccess is the external
+// counterpart to TestDeleteProject_ConcurrentlyArchivedTargetIsSuccess above.
+// DeleteProject's under-lock snapshot proves beta existed. If another kill
+// removes beta before the sorted loop reaches it, "not found" means beta is
+// already in the desired gone state — not a partial failure.
+func TestDeleteProject_ConcurrentlyKilledExternalTargetIsSuccess(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		legacyIDlessBeta bool
+	}{
+		{name: "stable id"},
+		{name: "legacy id-less row", legacyIDlessBeta: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			manager, repoID, repoPath := newStatusTestManager(t)
+
+			registerExternal := func(title string, backend session.Backend) *session.Instance {
+				gw, err := sessiongit.NewGitWorktreeFromStorage(repoPath, repoPath, title, "master", "", true, false)
+				require.NoError(t, err)
+				inst, err := session.NewInstance(session.InstanceOptions{Title: title, Path: repoPath, Program: "claude"})
+				require.NoError(t, err)
+				inst.SetBackend(backend)
+				inst.SetGitWorktreeForTest(gw)
+				inst.SetStartedForTest(true)
+				inst.SetStatusForTest(session.Ready)
+				manager.mu.Lock()
+				manager.instances[daemonInstanceKey(repoID, title)] = inst
+				manager.mu.Unlock()
+				return inst
+			}
+
+			beta := registerExternal("beta", session.NewFakeBackend())
+			if tc.legacyIDlessBeta {
+				beta.ID = ""
+			}
+			var concurrentKillErr error
+			alphaBackend := &killAnotherSessionBackend{
+				FakeBackend: session.NewFakeBackend(),
+				onKill: func() error {
+					_, concurrentKillErr = manager.KillSession(KillSessionRequest{ID: beta.ID, Title: beta.Title, RepoID: repoID})
+					return concurrentKillErr
+				},
+			}
+			alpha := registerExternal("alpha", alphaBackend)
+			require.NoError(t, manager.SaveInstances())
+
+			result, err := manager.DeleteProject(DeleteProjectRequest{RepoID: repoID, RepoPath: repoPath})
+			require.NoError(t, concurrentKillErr, "the competing kill must complete before DeleteProject reaches beta")
+			require.NoError(t, err, "a snapshotted target already in the desired gone state is success, not a partial failure")
+
+			wantIDs := map[string]string{"alpha": alpha.ID, "beta": beta.ID}
+			var titles []string
+			for _, data := range result.Killed {
+				titles = append(titles, data.Title)
+				assert.Equal(t, wantIDs[data.Title], data.ID,
+					"every reported kill carries the identity captured in the snapshot")
+			}
+			assert.ElementsMatch(t, []string{"alpha", "beta"}, titles,
+				"the concurrently killed session counts toward Killed instead of being undercounted")
+			assert.Empty(t, result.Archived)
+			assert.Empty(t, manager.Snapshot(repoID), "both external sessions are gone")
+
+			_, err = manager.KillSession(KillSessionRequest{ID: beta.ID, Title: beta.Title, RepoID: repoID})
+			require.Error(t, err, "a normal single-session caller must still see a stale target as not found")
+			assert.Contains(t, err.Error(), "not found")
+		})
+	}
 }

--- a/daemon/manager_persist.go
+++ b/daemon/manager_persist.go
@@ -226,7 +226,7 @@ func findInstanceDataByTitle(title, repoID string) (*session.InstanceData, strin
 				return &data[i], repoID, nil
 			}
 		}
-		return nil, "", fmt.Errorf("instance %q not found", title)
+		return nil, "", fmt.Errorf("instance %q %w", title, errSessionNotFound)
 	}
 
 	allInstances, err := config.LoadAllRepoInstances()
@@ -272,7 +272,7 @@ func findInstanceDataByTitle(title, repoID string) (*session.InstanceData, strin
 		sort.Strings(corrupted)
 		return nil, "", fmt.Errorf("instance %q not found; %d repo(s) have a corrupted instances.json that may be hiding it: %s", title, len(corrupted), strings.Join(corrupted, ", "))
 	}
-	return nil, "", fmt.Errorf("instance %q not found", title)
+	return nil, "", fmt.Errorf("instance %q %w", title, errSessionNotFound)
 }
 
 // ghostKillTmuxByName issues a tmux kill-session for a persisted sanitized

--- a/daemon/manager_sessions.go
+++ b/daemon/manager_sessions.go
@@ -10,6 +10,13 @@ import (
 	"github.com/sachiniyer/agent-factory/session"
 )
 
+// errSessionNotFound classifies only a resolver's authoritative miss. Its text
+// is deliberately "not found" so wrapping it preserves the existing messages
+// byte-for-byte. DeleteProject uses errors.Is on this in process because its own
+// under-lock snapshot proves the target existed; normal KillSession callers
+// still receive the same error, and the sentinel does not survive net/rpc.
+var errSessionNotFound = errors.New("not found")
+
 // KillSession tears down and deletes the resolved session. It returns the stable
 // identity (id + title) of the session it ACTUALLY resolved and acted on, so the
 // control server publishes the killed event for exactly that session — never the
@@ -439,7 +446,7 @@ func (m *Manager) resolveActionSession(id, title, repoID string) (*session.Insta
 			}
 		}
 		m.mu.Unlock()
-		return nil, "", "", "", nil, fmt.Errorf("session with id %q not found", id)
+		return nil, "", "", "", nil, fmt.Errorf("session with id %q %w", id, errSessionNotFound)
 	}
 	// Legacy/CLI path: no id supplied, resolve by {title, repoID}.
 	instance, resolvedRepoID, data, err := m.findSession(title, repoID)


### PR DESCRIPTION
Fixes #2124

## Root cause

`DeleteProject` snapshots live sessions, releases `m.mu`, and then processes them one at a time. If another request completed the kill of a snapshotted external/in-place session before the loop reached it, `KillSession` returned `not found`. The bulk delete treated that desired already-gone state as a failure, undercounted `Killed`, and sent callers down the partial-failure path.

## Fix

- Carry the stable session ID captured in the project snapshot into `KillSession`, so a same-title replacement can never be torn down for the old target. Legacy id-less rows retain the scoped title path.
- Give authoritative resolver misses an internal typed sentinel while preserving every existing error string byte-for-byte.
- Only `DeleteProject`, whose own under-lock snapshot proves the target existed, treats that sentinel as idempotent success and reports the snapshotted identity. All other kill failures remain failures.

## Caller audit

Normal `KillSession` callers are unchanged: manager callers still receive an error, and control RPC / HTTP / CLI / TUI callers still receive the same `not found` text. The internal sentinel is only matched inside the daemon process and does not survive RPC serialization. Corrupt-storage and refresh failures are not tagged as authoritative misses, so they remain partial failures.

## Fail-first reproduction

The regression uses sorted targets `alpha` and `beta`. The fake backend for `alpha` completes a real `Manager.KillSession(beta)` while `DeleteProject` is processing `alpha`, deterministically placing `beta` in the exact race window without a timing-dependent goroutine. On unmodified master `8e7d6d81`, the stable-ID case failed as follows:

```text
Error: Received unexpected error:
       delete project 95acabc13019: archived 0, tore down 1, but 1 session(s) could not be removed (retry to finish): session "beta": instance "beta" not found
Messages: a snapshotted target already in the desired gone state is success, not a partial failure
```

The test now covers both modern stable-ID records and legacy id-less records. It also retries `KillSession` as an ordinary caller after the delete and verifies that caller still gets `not found`, guarding against a blanket swallow.

## Validation

Master advanced during each of the first two completed review cycles, so the branch was rebased again and every gate rerun before the force-with-lease push. All required gates are green on remote-verified head `0648fe886f9277e88c601711c225c35b810b4c8b`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (no output)
- `go build ./...`
- `make test-container` (full suite green; daemon 176.020s)

Focused fail-first and post-fix runs used the container testbox. No host daemon suite, daemon restart, tmux/af kill, sub-session, or `dev-install.sh` was used.