### PR TITLE
fix(limit): make no-op retries observable

### DIFF
--- a/apiclient/control.go
+++ b/apiclient/control.go
@@ -2,6 +2,7 @@ package apiclient
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/session"
@@ -72,7 +73,14 @@ func (c *Client) DeleteProject(req daemon.DeleteProjectRequest) (daemon.DeletePr
 // (#1146) — the action behind the TUI's `c` key and the web's Retry button.
 // The CLI reaches the same public handler over its gob control transport.
 func (c *Client) ResumeFromLimit(req daemon.ResumeFromLimitRequest) error {
-	return c.call("ResumeFromLimit", req, &daemon.ResumeFromLimitResponse{})
+	var resp daemon.ResumeFromLimitResponse
+	if err := c.call("ResumeFromLimit", req, &resp); err != nil {
+		return err
+	}
+	if !resp.OK {
+		return fmt.Errorf("resume was not performed: %s", resp.Reason)
+	}
+	return nil
 }
 
 // HandoffSession asks the daemon to continue a session under a different agent,

--- a/apiclient/control_test.go
+++ b/apiclient/control_test.go
@@ -119,6 +119,14 @@ func TestControlRoundTrips(t *testing.T) {
 			t.Fatalf("ResumeFromLimit: %v", err)
 		}
 	})
+	t.Run("ResumeFromLimit rejects a daemon no-op", func(t *testing.T) {
+		c := routeServer(t, "ResumeFromLimit", func([]byte) apiproto.Envelope {
+			return apiproto.Success(daemon.ResumeFromLimitResponse{Reason: "another operation owns the retry"})
+		})
+		if err := c.ResumeFromLimit(daemon.ResumeFromLimitRequest{Title: "alpha"}); err == nil {
+			t.Fatal("ResumeFromLimit must not report success when the daemon performed no retry")
+		}
+	})
 
 	t.Run("PauseStatusPoll rides internal route", func(t *testing.T) {
 		c := routeServer(t, "PauseStatusPoll", func([]byte) apiproto.Envelope {

--- a/app/limit_action_test.go
+++ b/app/limit_action_test.go
@@ -109,3 +109,12 @@ func TestHandleLimitRetried_ClearsLocally(t *testing.T) {
 	_, _ = h.handleLimitRetried(limitRetriedMsg{title: "worker"})
 	require.False(t, inst.LimitReached(), "a successful retry must clear the local limit state")
 }
+
+func TestHandleLimitRetried_NoOpKeepsLimitLocally(t *testing.T) {
+	h := newTestHome(t)
+	inst := limitActionInstance(t, "worker", time.Now().Add(time.Hour))
+	h.store.AddInstance(inst)
+
+	_, _ = h.handleLimitRetried(limitRetriedMsg{title: "worker", err: errors.New("resume was not performed: another operation owns the retry")})
+	require.True(t, inst.LimitReached(), "a daemon no-op must not clear the local limit state")
+}

--- a/daemon/control_client.go
+++ b/daemon/control_client.go
@@ -342,6 +342,9 @@ func ResumeFromLimit(req ResumeFromLimitRequest) error {
 	if err := callDaemon("ResumeFromLimit", req, &resp); err != nil {
 		return err
 	}
+	if !resp.OK {
+		return fmt.Errorf("resume was not performed: %s", resp.Reason)
+	}
 	return nil
 }
 

--- a/daemon/limit.go
+++ b/daemon/limit.go
@@ -232,8 +232,16 @@ type ResumeFromLimitRequest struct {
 }
 
 type ResumeFromLimitResponse struct {
-	OK bool `json:"ok"`
+	OK     bool   `json:"ok"`
+	Reason string `json:"reason,omitempty"`
 }
+
+type resumeFromLimitOutcome uint8
+
+const (
+	resumeNotPerformed resumeFromLimitOutcome = iota
+	resumePerformed
+)
 
 // The TUI and web reach this handler through apiclient/HTTP. The CLI reaches the
 // same handler through daemon.ResumeFromLimit on the gob control socket; only
@@ -246,10 +254,14 @@ func (s *controlServer) ResumeFromLimit(req ResumeFromLimitRequest, resp *Resume
 	if err := validateRPCRepoID(req.RepoID); err != nil {
 		return err
 	}
-	if err := s.manager.resumeFromLimit(req); err != nil {
+	outcome, err := s.manager.resumeFromLimitOutcome(req)
+	if err != nil {
 		return err
 	}
-	resp.OK = true
+	resp.OK = outcome == resumePerformed
+	if !resp.OK {
+		resp.Reason = "the session changed or another operation owns its retry"
+	}
 	return nil
 }
 
@@ -286,6 +298,11 @@ func (s *controlServer) ResumeFromLimit(req ResumeFromLimitRequest, resp *Resume
 var testHookResumeAfterFirstLock = func() {}
 
 func (m *Manager) resumeFromLimit(req ResumeFromLimitRequest) error {
+	_, err := m.resumeFromLimitOutcome(req)
+	return err
+}
+
+func (m *Manager) resumeFromLimitOutcome(req ResumeFromLimitRequest) (resumeFromLimitOutcome, error) {
 	// resolveActionSession, not findSession: id-first with a {title, repoID}
 	// fallback, the same resolver kill/archive/restore and the tab verbs use. This
 	// verb re-delivers a prompt INTO a pane, so resolving it by title alone would
@@ -296,20 +313,20 @@ func (m *Manager) resumeFromLimit(req ResumeFromLimitRequest) error {
 	// id-keyed request may leave empty.
 	instance, repoID, title, _, _, err := m.resolveActionSession(req.ID, req.Title, req.RepoID)
 	if err != nil {
-		return err
+		return resumeNotPerformed, err
 	}
 	if instance == nil {
-		return fmt.Errorf("session %q not found", title)
+		return resumeNotPerformed, fmt.Errorf("session %q not found", title)
 	}
 	if !instance.LimitReached() {
-		return fmt.Errorf("session %q is not blocked on a usage limit", title)
+		return resumeNotPerformed, fmt.Errorf("session %q is not blocked on a usage limit", title)
 	}
 
 	key := daemonInstanceKey(repoID, instance.Title)
 	m.mu.Lock()
 	if _, killing := m.killsInFlight[key]; killing {
 		m.mu.Unlock()
-		return nil
+		return resumeNotPerformed, nil
 	}
 	m.mu.Unlock()
 
@@ -326,7 +343,7 @@ func (m *Manager) resumeFromLimit(req ResumeFromLimitRequest) error {
 
 	opLock := m.opLockFor(key)
 	if !opLock.TryLock() {
-		return nil
+		return resumeNotPerformed, nil
 	}
 	defer opLock.Unlock()
 
@@ -335,10 +352,10 @@ func (m *Manager) resumeFromLimit(req ResumeFromLimitRequest) error {
 	_, killing := m.killsInFlight[key]
 	m.mu.Unlock()
 	if killing || current != instance || instance.IsTearingDown() {
-		return nil
+		return resumeNotPerformed, nil
 	}
 
-	return m.resumeFromLimitLocked(repoID, key, instance, title)
+	return m.resumeFromLimitLockedOutcome(repoID, key, instance, title)
 }
 
 // resumeFromLimitLocked performs the shared limit-resume action. The caller must
@@ -349,20 +366,25 @@ func (m *Manager) resumeFromLimit(req ResumeFromLimitRequest) error {
 // points (resumeFromLimit and the auto-resume scheduler) take the two locks before
 // calling in, so this body never touches the lock helpers itself.
 func (m *Manager) resumeFromLimitLocked(repoID, key string, instance *session.Instance, requestedTitle string) error {
+	_, err := m.resumeFromLimitLockedOutcome(repoID, key, instance, requestedTitle)
+	return err
+}
+
+func (m *Manager) resumeFromLimitLockedOutcome(repoID, key string, instance *session.Instance, requestedTitle string) (resumeFromLimitOutcome, error) {
 	// Re-verify under the lock: a self-recovery or the poll may have cleared the
 	// limit between the check above and the lock.
 	if !instance.LimitReached() {
-		return nil
+		return resumeNotPerformed, nil
 	}
 	m.mu.Lock()
 	current := m.instances[key]
 	_, killing := m.killsInFlight[key]
 	m.mu.Unlock()
 	if killing || current != instance || instance.IsTearingDown() {
-		return nil
+		return resumeNotPerformed, nil
 	}
 	if instance.UserKilled() || session.IsReservedTitle(instance.Title) {
-		return fmt.Errorf("session %q cannot be resumed", requestedTitle)
+		return resumeNotPerformed, fmt.Errorf("session %q cannot be resumed", requestedTitle)
 	}
 
 	// Re-spawn only when the agent's session actually exited while blocked (the
@@ -396,7 +418,7 @@ func (m *Manager) resumeFromLimitLocked(repoID, key string, instance *session.In
 		// A live stall — the common claude/codex case. No re-spawn; the un-stall
 		// prompt below is all it needs.
 	case probeUnknown:
-		return fmt.Errorf("cannot resume %q: its agent-server did not answer the liveness probe; not re-spawning, because re-provisioning a sandbox that may still be running would orphan it and discard its unpushed work", requestedTitle)
+		return resumeNotPerformed, fmt.Errorf("cannot resume %q: its agent-server did not answer the liveness probe; not re-spawning, because re-provisioning a sandbox that may still be running would orphan it and discard its unpushed work", requestedTitle)
 	case probeDead:
 		// Capture the limit window BEFORE the re-spawn: Respawn ends in ConfirmLive,
 		// which drops both the LiveLimitReached liveness and its reset time, and
@@ -405,7 +427,7 @@ func (m *Manager) resumeFromLimitLocked(repoID, key string, instance *session.In
 		// auto-resume scheduler schedules off it (reset + grace).
 		resetAt, _ := instance.LimitResetAt()
 		if rerr := instance.Respawn(); rerr != nil {
-			return fmt.Errorf("failed to re-spawn agent for %q: %w", requestedTitle, rerr)
+			return resumeNotPerformed, fmt.Errorf("failed to re-spawn agent for %q: %w", requestedTitle, rerr)
 		}
 		// The runtime this session's failure history was about is gone; the fresh
 		// sandbox must not inherit it (#1794).
@@ -463,7 +485,7 @@ func (m *Manager) resumeFromLimitLocked(repoID, key string, instance *session.In
 		prompt = "continue"
 	}
 	if serr := as.SendPrompt(prompt); serr != nil {
-		return fmt.Errorf("failed to resume %q: %w", requestedTitle, serr)
+		return resumeNotPerformed, fmt.Errorf("failed to resume %q: %w", requestedTitle, serr)
 	}
 	// The prompt landed: this is the resume's single completion point, and the only
 	// place the limit block is lifted on either arm.
@@ -474,5 +496,5 @@ func (m *Manager) resumeFromLimitLocked(repoID, key string, instance *session.In
 	// rebuilt worktree of a session still parked at the wall, this one records the
 	// resume that actually landed.
 	m.persistInstance(repoID, instance)
-	return nil
+	return resumePerformed, nil
 }

--- a/daemon/limit_retry_surface_test.go
+++ b/daemon/limit_retry_surface_test.go
@@ -92,6 +92,28 @@ func TestResumeFromLimit_BrowserBodyDecodes(t *testing.T) {
 	assert.NotContains(t, env.Error.Message, "malformed JSON")
 }
 
+// TestResumeFromLimit_NoOpIsNotSuccess pins the shared outcome contract: a kill
+// that already owns the target may make ResumeFromLimit do nothing, but every
+// client must be told not to announce a retry or clear its local limit state.
+func TestResumeFromLimit_NoOpIsNotSuccess(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &limitResumeBackend{FakeBackend: session.NewFakeBackend(), alive: true}
+	inst := registerStarted(t, manager, repoID, repoPath, "parked", backend, true, session.Running)
+	inst.SetLimitReached(time.Now().Add(time.Hour))
+	key := daemonInstanceKey(repoID, inst.Title)
+	manager.mu.Lock()
+	manager.killsInFlight[key] = struct{}{}
+	manager.mu.Unlock()
+
+	var resp ResumeFromLimitResponse
+	err := (&controlServer{manager: manager}).ResumeFromLimit(
+		ResumeFromLimitRequest{ID: inst.ID}, &resp)
+	require.NoError(t, err)
+	assert.False(t, resp.OK)
+	assert.NotEmpty(t, resp.Reason)
+	assert.True(t, inst.LimitReached())
+}
+
 // TestResumeFromLimit_ResolvesByStableID pins the id-first addressing the web
 // needs, and the reason the request grew an ID field at all.
 //

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -6275,7 +6275,7 @@ async function restoreSession(title, token2) {
   await af("RestoreSession", { title, repo_id: "" }, token2);
 }
 async function resumeFromLimit(id, title, token2) {
-  await af("ResumeFromLimit", { id, title, repo_id: "" }, token2);
+  return af("ResumeFromLimit", { id, title, repo_id: "" }, token2);
 }
 async function deleteProject(root2, token2) {
   return af("DeleteProject", { repo_path: root2, repo_id: "" }, token2);
@@ -12578,7 +12578,11 @@ function doRetryLimit() {
   if (!sel || tok === null) {
     return;
   }
-  void resumeFromLimit(sel.id, sel.title, tok).catch((e) => surfaceTabError(e));
+  void resumeFromLimit(sel.id, sel.title, tok).then((result) => {
+    if (!result.ok) {
+      throw new Error(result.reason || "resume was not performed");
+    }
+  }).catch((e) => surfaceTabError(e));
 }
 function doRemoveTask(task) {
   const tok = token;

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -6275,7 +6275,10 @@ async function restoreSession(title, token2) {
   await af("RestoreSession", { title, repo_id: "" }, token2);
 }
 async function resumeFromLimit(id, title, token2) {
-  return af("ResumeFromLimit", { id, title, repo_id: "" }, token2);
+  const result = await af("ResumeFromLimit", { id, title, repo_id: "" }, token2);
+  if (!result.ok) {
+    throw new Error(result.reason || "resume was not performed");
+  }
 }
 async function deleteProject(root2, token2) {
   return af("DeleteProject", { repo_path: root2, repo_id: "" }, token2);
@@ -12578,11 +12581,7 @@ function doRetryLimit() {
   if (!sel || tok === null) {
     return;
   }
-  void resumeFromLimit(sel.id, sel.title, tok).then((result) => {
-    if (!result.ok) {
-      throw new Error(result.reason || "resume was not performed");
-    }
-  }).catch((e) => surfaceTabError(e));
+  void resumeFromLimit(sel.id, sel.title, tok).catch((e) => surfaceTabError(e));
 }
 function doRemoveTask(task) {
   const tok = token;

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "78949d046c3e";
+const VERSION = "205618698e0d";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "590058e34134";
+const VERSION = "78949d046c3e";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -118,7 +118,7 @@ test("resumeFromLimit posts the stable id, so a duplicate title cannot misroute 
   assert.equal(cap.body.repo_id, "", "an all-repos web client scopes by id, not repo");
 });
 
-test("resumeFromLimit returns the daemon's no-op outcome", async () => {
+test("resumeFromLimit rejects the daemon's no-op outcome", async () => {
   (globalThis as { fetch: unknown }).fetch = async (): Promise<Response> =>
     ({
       ok: true,
@@ -127,8 +127,11 @@ test("resumeFromLimit returns the daemon's no-op outcome", async () => {
       json: async () => ({ data: { ok: false, reason: "another operation owns the retry" }, error: null }),
     }) as unknown as Response;
 
-  const result = await resumeFromLimit("id-repoB", "feature", "tok");
-  assert.deepEqual(result, { ok: false, reason: "another operation owns the retry" });
+  await assert.rejects(
+    resumeFromLimit("id-repoB", "feature", "tok"),
+    /another operation owns the retry/,
+    "a successful HTTP envelope must not turn a daemon no-op into a successful web action",
+  );
 });
 
 test("listPrograms asks the daemon for the agent catalog (#1970)", async () => {

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -118,6 +118,19 @@ test("resumeFromLimit posts the stable id, so a duplicate title cannot misroute 
   assert.equal(cap.body.repo_id, "", "an all-repos web client scopes by id, not repo");
 });
 
+test("resumeFromLimit returns the daemon's no-op outcome", async () => {
+  (globalThis as { fetch: unknown }).fetch = async (): Promise<Response> =>
+    ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({ data: { ok: false, reason: "another operation owns the retry" }, error: null }),
+    }) as unknown as Response;
+
+  const result = await resumeFromLimit("id-repoB", "feature", "tok");
+  assert.deepEqual(result, { ok: false, reason: "another operation owns the retry" });
+});
+
 test("listPrograms asks the daemon for the agent catalog (#1970)", async () => {
   const cap = stubFetch();
   await listPrograms("/repos/af", "tok");

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -410,8 +410,13 @@ export async function restoreSession(title: string, token: string): Promise<void
  *  The daemon refuses a session that is not actually limit-blocked, so a stale
  *  click (the limit cleared itself between render and click) surfaces as an error
  *  rather than an unwanted prompt. */
-export async function resumeFromLimit(id: string, title: string, token: string): Promise<void> {
-  await af("ResumeFromLimit", { id, title, repo_id: "" }, token);
+export interface ResumeFromLimitResult {
+  ok: boolean;
+  reason?: string;
+}
+
+export async function resumeFromLimit(id: string, title: string, token: string): Promise<ResumeFromLimitResult> {
+  return af<ResumeFromLimitResult>("ResumeFromLimit", { id, title, repo_id: "" }, token);
 }
 
 /** The daemon's DeleteProject response: how many sessions it archived vs tore

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -415,8 +415,11 @@ export interface ResumeFromLimitResult {
   reason?: string;
 }
 
-export async function resumeFromLimit(id: string, title: string, token: string): Promise<ResumeFromLimitResult> {
-  return af<ResumeFromLimitResult>("ResumeFromLimit", { id, title, repo_id: "" }, token);
+export async function resumeFromLimit(id: string, title: string, token: string): Promise<void> {
+  const result = await af<ResumeFromLimitResult>("ResumeFromLimit", { id, title, repo_id: "" }, token);
+  if (!result.ok) {
+    throw new Error(result.reason || "resume was not performed");
+  }
 }
 
 /** The daemon's DeleteProject response: how many sessions it archived vs tore

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -1247,13 +1247,7 @@ function doRetryLimit(): void {
   if (!sel || tok === null) {
     return;
   }
-  void resumeFromLimit(sel.id, sel.title, tok)
-    .then((result) => {
-      if (!result.ok) {
-        throw new Error(result.reason || "resume was not performed");
-      }
-    })
-    .catch((e) => surfaceTabError(e));
+  void resumeFromLimit(sel.id, sel.title, tok).catch((e) => surfaceTabError(e));
 }
 
 /** Removes a task (RemoveTask), then refetches. Keys off the stable id. */

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -1247,7 +1247,13 @@ function doRetryLimit(): void {
   if (!sel || tok === null) {
     return;
   }
-  void resumeFromLimit(sel.id, sel.title, tok).catch((e) => surfaceTabError(e));
+  void resumeFromLimit(sel.id, sel.title, tok)
+    .then((result) => {
+      if (!result.ok) {
+        throw new Error(result.reason || "resume was not performed");
+      }
+    })
+    .catch((e) => surfaceTabError(e));
 }
 
 /** Removes a task (RemoveTask), then refetches. Keys off the stable id. */


### PR DESCRIPTION
## Outcome

ResumeFromLimit now returns an explicit ok=false response when an interlock or stale instance prevents a retry. TUI and CLI surface that result as an error and preserve the limit state; Web surfaces the same reason instead of implying success.

This is stacked on #2289, which adds the CLI retry surface.

Regression coverage covers daemon wire outcome, TUI preservation, Web decoding, and CLI rejection.

Fixes #2288

— Captain Claude