### PR TITLE
fix(daemon): reap owned children after abrupt failure

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -152,9 +152,11 @@ jobs:
       - name: Enable the systemd user manager
         run: |
           sudo loginctl enable-linger "$USER"
-          echo "XDG_RUNTIME_DIR=/run/user/$(id -u)" >> "$GITHUB_ENV"
+          XDG_RUNTIME_DIR="/run/user/$(id -u)"
+          export XDG_RUNTIME_DIR
+          echo "XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR" >> "$GITHUB_ENV"
           for _ in $(seq 1 30); do
-            [ -d "/run/user/$(id -u)" ] && break
+            [ -d "$XDG_RUNTIME_DIR" ] && break
             sleep 1
           done
           systemd --version | head -1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -121,6 +121,50 @@ jobs:
       - name: Run tests
         run: go test -v -race -count=1 ./...
 
+  # KillMode=process is the compatibility fence that keeps pre-scope tmux
+  # servers alive, so the daemon's abrupt-failure cleanup cannot be proven by
+  # the ordinary testbox (it has no systemd user manager). Exercise the actual
+  # cgroup transaction on both systemd generations shipped by the supported
+  # Ubuntu runners: a stubborn watcher tree must be reaped before replacement,
+  # while the exact tmux server and pane PIDs survive.
+  test-systemd:
+    name: Test (systemd, ${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.25"
+          cache: true
+
+      - name: Install lifecycle dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends tmux
+
+      - name: Enable the systemd user manager
+        run: |
+          sudo loginctl enable-linger "$USER"
+          echo "XDG_RUNTIME_DIR=/run/user/$(id -u)" >> "$GITHUB_ENV"
+          for _ in $(seq 1 30); do
+            [ -d "/run/user/$(id -u)" ] && break
+            sleep 1
+          done
+          systemd --version | head -1
+          systemctl --user show-environment >/dev/null
+
+      - name: Test abrupt daemon failure ownership
+        env:
+          AF_SYSTEMD_LIFECYCLE_TEST: "1"
+        run: go test -v -count=1 ./integration -run '^TestAbruptDaemonFailureReapsOwnedChildrenAndPreservesTmux$'
+
   # The web client's deterministic gates (#2069). Until this landed, NOTHING in
   # GitHub Actions ran them: the schedule/frame/icons parity tests, the typecheck,
   # and the committed-bundle reproducibility check were enforced only by a human
@@ -259,7 +303,7 @@ jobs:
     # blocks anyway, since it demands conclusion === "success", but the native path
     # would not.) So: run ALWAYS, and fail loudly on any unsuccessful need. Now a
     # red macOS job turns the REQUIRED check red instead of quietly skipping it.
-    needs: [lint, test, test-macos, web]
+    needs: [lint, test, test-systemd, test-macos, web]
     if: always()
     steps:
       - name: Gate on the jobs this check stands in for
@@ -268,7 +312,7 @@ jobs:
           echo "::error::A required job failed — failing Build so the required check goes RED rather than skipping."
           # needs['test-macos'], not needs.test-macos: a hyphen in a property path is
           # parsed as subtraction, so the dotted form silently yields an empty string.
-          echo "lint=${{ needs.lint.result }} test=${{ needs.test.result }} test-macos=${{ needs['test-macos'].result }} web=${{ needs.web.result }}"
+          echo "lint=${{ needs.lint.result }} test=${{ needs.test.result }} test-systemd=${{ needs['test-systemd'].result }} test-macos=${{ needs['test-macos'].result }} web=${{ needs.web.result }}"
           exit 1
 
       - uses: actions/checkout@v6

--- a/daemon/autostart.go
+++ b/daemon/autostart.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/systemdunit"
 	"github.com/sachiniyer/agent-factory/log"
 )
 
@@ -20,13 +21,13 @@ import (
 // longer exist (#782).
 
 const (
-	autostartUnitName     = "agent-factory-daemon.service"
+	autostartUnitName     = systemdunit.DaemonUnitName
 	autostartLaunchdLabel = "com.agent-factory.daemon"
 	// autostartSystemdMarker lets the daemon distinguish its direct service
 	// process from descendants that merely inherited the unit's environment.
 	// session/tmux checks it together with SYSTEMD_EXEC_PID before asking the
 	// user manager to put a newly-created tmux server in its own scope (#2176).
-	autostartSystemdMarker = "AGENT_FACTORY_SYSTEMD_UNIT"
+	autostartSystemdMarker = systemdunit.DaemonMarkerEnv
 )
 
 // Every launchctl call af makes names the gui/<uid> domain explicitly, and

--- a/daemon/child_scope_linux.go
+++ b/daemon/child_scope_linux.go
@@ -1,0 +1,43 @@
+//go:build linux
+
+package daemon
+
+import (
+	"os/exec"
+
+	"github.com/sachiniyer/agent-factory/internal/systemdunit"
+)
+
+// systemdBoundChildStopTimeout is shorter than the unit's RestartSec, but the
+// correctness barrier does not depend on that gap: BindsTo+After puts stopping
+// the old scope and restarting its owner in one ordered transaction. The bound
+// keeps a TERM-ignoring child from delaying recovery for systemd's default 90s.
+const systemdBoundChildStopTimeout = "4s"
+
+// newDaemonChildCommand places every long-lived daemon-owned process tree in a
+// transient scope bound to the daemon service. The service itself intentionally
+// uses KillMode=process so legacy tmux servers trapped in its cgroup survive an
+// upgrade. A separate bound scope gives systemd authoritative ownership of
+// watchers/editors without putting those unrelated lifetime classes back in one
+// kill domain.
+//
+// BindsTo stops the scope when the daemon unit becomes inactive after a panic,
+// SIGKILL, or OOM. After supplies both halves of the ordering guarantee: the
+// child cannot start before its owner, and on restart the old child scope is
+// fully stopped before the replacement daemon may start. There is therefore no
+// startup reconciliation window in which two watcher/editor generations run.
+func newDaemonChildCommand(name string, args ...string) *exec.Cmd {
+	if !systemdunit.RunningDaemonProcess() {
+		return exec.Command(name, args...)
+	}
+	scopeArgs := []string{
+		"--user", "--scope", "--quiet", "--collect",
+		"--property=BindsTo=" + systemdunit.DaemonUnitName,
+		"--property=After=" + systemdunit.DaemonUnitName,
+		"--property=KillMode=control-group",
+		"--property=TimeoutStopSec=" + systemdBoundChildStopTimeout,
+		"--", name,
+	}
+	scopeArgs = append(scopeArgs, args...)
+	return exec.Command("systemd-run", scopeArgs...)
+}

--- a/daemon/child_scope_linux.go
+++ b/daemon/child_scope_linux.go
@@ -3,7 +3,9 @@
 package daemon
 
 import (
+	"bytes"
 	"os/exec"
+	"sync"
 
 	"github.com/sachiniyer/agent-factory/internal/systemdunit"
 )
@@ -13,6 +15,22 @@ import (
 // the old scope and restarting its owner in one ordered transaction. The bound
 // keeps a TERM-ignoring child from delaying recovery for systemd's default 90s.
 const systemdBoundChildStopTimeout = "4s"
+
+const systemdRunNoExpandFlag = "--expand-environment=no"
+
+// systemdRunNoExpandOption is feature-detected because environment expansion
+// and the switch that disables it were both added in systemd 254. Ubuntu 22.04
+// predates the option, while newer releases may rewrite ${NAME} in every child
+// argument unless it is explicitly disabled. Cache the answer for the daemon's
+// lifetime; if help itself fails, pass the option and let the spawn fail closed
+// instead of running a potentially rewritten command.
+var systemdRunNoExpandOption = sync.OnceValue(func() string {
+	help, err := exec.Command("systemd-run", "--help").Output()
+	if err != nil || bytes.Contains(help, []byte("--expand-environment=")) {
+		return systemdRunNoExpandFlag
+	}
+	return ""
+})
 
 // newDaemonChildCommand places every long-lived daemon-owned process tree in a
 // transient scope bound to the daemon service. The service itself intentionally
@@ -32,12 +50,17 @@ func newDaemonChildCommand(name string, args ...string) *exec.Cmd {
 	}
 	scopeArgs := []string{
 		"--user", "--scope", "--quiet", "--collect",
-		"--property=BindsTo=" + systemdunit.DaemonUnitName,
-		"--property=After=" + systemdunit.DaemonUnitName,
-		"--property=KillMode=control-group",
-		"--property=TimeoutStopSec=" + systemdBoundChildStopTimeout,
-		"--", name,
 	}
-	scopeArgs = append(scopeArgs, args...)
-	return exec.Command("systemd-run", scopeArgs...)
+	if option := systemdRunNoExpandOption(); option != "" {
+		scopeArgs = append(scopeArgs, option)
+	}
+	scopeArgs = append(scopeArgs,
+		"--property=BindsTo="+systemdunit.DaemonUnitName,
+		"--property=After="+systemdunit.DaemonUnitName,
+		"--property=KillMode=control-group",
+		"--property=TimeoutStopSec="+systemdBoundChildStopTimeout,
+		"--", name,
+	)
+	commandArgs := append(scopeArgs, args...)
+	return exec.Command("systemd-run", commandArgs...)
 }

--- a/daemon/child_scope_linux_test.go
+++ b/daemon/child_scope_linux_test.go
@@ -22,16 +22,29 @@ func installBoundScopeShim(t *testing.T) string {
 	shim := filepath.Join(dir, "systemd-run")
 	script := `#!/bin/sh
 set -eu
+if [ "${1:-}" = "--help" ]; then
+    printf '%s\n' '    --expand-environment=BOOL'
+    exit 0
+fi
 printf '%s\n' "$*" >> "$AF_TEST_SCOPE_LOG"
+expand=yes
 while [ "$#" -gt 0 ]; do
     case "$1" in
         --user|--scope|--quiet|--collect) shift ;;
+        --expand-environment=no) expand=no; shift ;;
         --property=*) shift ;;
         --) shift; break ;;
         *) echo "unexpected systemd-run argument: $1" >&2; exit 64 ;;
     esac
 done
 export AF_TEST_BOUND_DAEMON_CHILD=1
+# systemd expansion sees the whole sh -c argument without understanding shell
+# quotes. Emulate the destructive case so this test proves argv preservation,
+# rather than merely checking that a flag happens to be present.
+if [ "$expand" = yes ] && [ "${1:-}" = sh ] && [ "${2:-}" = -c ]; then
+    rewritten="$(printf '%s' "${3:-}" | sed 's/\${AF_SYSTEMD_RUN_LITERAL}/expanded-by-systemd-run/g')"
+    exec "$1" "$2" "$rewritten"
+fi
 exec "$@"
 `
 	if err := os.WriteFile(shim, []byte(script), 0o700); err != nil {
@@ -52,7 +65,7 @@ func assertBoundScopeInvocation(t *testing.T, logPath, command string) {
 	}
 	got := string(raw)
 	for _, want := range []string{
-		"--user --scope --quiet --collect",
+		"--user --scope --quiet --collect --expand-environment=no",
 		"--property=BindsTo=" + autostartUnitName,
 		"--property=After=" + autostartUnitName,
 		"--property=KillMode=control-group",
@@ -70,7 +83,7 @@ func TestWatcherSpawnUsesDaemonBoundSystemdScope(t *testing.T) {
 	dir := t.TempDir()
 	s, rec := newTestSupervisor(t, staticTasks(watchTask(
 		"scope001",
-		`printf 'scope=%s\n' "${AF_TEST_BOUND_DAEMON_CHILD:-}"`,
+		`printf 'scope=%s literal=%s\n' "${AF_TEST_BOUND_DAEMON_CHILD:-}" '${AF_SYSTEMD_RUN_LITERAL}'`,
 		dir,
 	)))
 
@@ -80,8 +93,8 @@ func TestWatcherSpawnUsesDaemonBoundSystemdScope(t *testing.T) {
 	waitUntil(t, 5*time.Second, "scoped watcher to exit", func() bool {
 		return len(rec.statusesSnapshot()) > 0
 	})
-	if got := rec.eventsSnapshot(); len(got) != 1 || got[0] != "scope001:scope=1" {
-		t.Fatalf("watcher did not execute inside the bound scope shim: events=%v", got)
+	if got := rec.eventsSnapshot(); len(got) != 1 || got[0] != "scope001:scope=1 literal=${AF_SYSTEMD_RUN_LITERAL}" {
+		t.Fatalf("watcher argv changed while entering the bound scope: events=%v", got)
 	}
 	assertBoundScopeInvocation(t, logPath, "sh -c")
 }

--- a/daemon/child_scope_linux_test.go
+++ b/daemon/child_scope_linux_test.go
@@ -1,0 +1,99 @@
+//go:build linux
+
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// installBoundScopeShim replaces systemd-run with a recording shim that marks
+// the command it eventually execs. The tests below deliberately exercise the
+// real watcher/editor spawn paths: a helper-only argv test could stay green if
+// either production caller later regressed to exec.Command.
+func installBoundScopeShim(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "systemd-run.log")
+	shim := filepath.Join(dir, "systemd-run")
+	script := `#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "$AF_TEST_SCOPE_LOG"
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --user|--scope|--quiet|--collect) shift ;;
+        --property=*) shift ;;
+        --) shift; break ;;
+        *) echo "unexpected systemd-run argument: $1" >&2; exit 64 ;;
+    esac
+done
+export AF_TEST_BOUND_DAEMON_CHILD=1
+exec "$@"
+`
+	if err := os.WriteFile(shim, []byte(script), 0o700); err != nil {
+		t.Fatalf("write systemd-run shim: %v", err)
+	}
+	t.Setenv("AF_TEST_SCOPE_LOG", logPath)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv(autostartSystemdMarker, autostartUnitName)
+	t.Setenv("SYSTEMD_EXEC_PID", strconv.Itoa(os.Getpid()))
+	return logPath
+}
+
+func assertBoundScopeInvocation(t *testing.T, logPath, command string) {
+	t.Helper()
+	raw, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("daemon-owned child bypassed systemd-run: %v", err)
+	}
+	got := string(raw)
+	for _, want := range []string{
+		"--user --scope --quiet --collect",
+		"--property=BindsTo=" + autostartUnitName,
+		"--property=After=" + autostartUnitName,
+		"--property=KillMode=control-group",
+		"--property=TimeoutStopSec=4s",
+		"-- " + command,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("systemd-run invocation %q does not contain %q", strings.TrimSpace(got), want)
+		}
+	}
+}
+
+func TestWatcherSpawnUsesDaemonBoundSystemdScope(t *testing.T) {
+	logPath := installBoundScopeShim(t)
+	dir := t.TempDir()
+	s, rec := newTestSupervisor(t, staticTasks(watchTask(
+		"scope001",
+		`printf 'scope=%s\n' "${AF_TEST_BOUND_DAEMON_CHILD:-}"`,
+		dir,
+	)))
+
+	if err := s.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	waitUntil(t, 5*time.Second, "scoped watcher to exit", func() bool {
+		return len(rec.statusesSnapshot()) > 0
+	})
+	if got := rec.eventsSnapshot(); len(got) != 1 || got[0] != "scope001:scope=1" {
+		t.Fatalf("watcher did not execute inside the bound scope shim: events=%v", got)
+	}
+	assertBoundScopeInvocation(t, logPath, "sh -c")
+}
+
+func TestVSCodeSpawnUsesDaemonBoundSystemdScope(t *testing.T) {
+	logPath := installBoundScopeShim(t)
+	binary := writeFakeVSCodeBinary(t, "code-server", nil)
+	v := newTestVSCodeSupervisor(t, binary)
+	worktree := t.TempDir()
+
+	if _, err := v.ensureServer("scope-editor", worktree); err != nil {
+		t.Fatalf("ensureServer: %v", err)
+	}
+	assertBoundScopeInvocation(t, logPath, binary)
+}

--- a/daemon/child_scope_other.go
+++ b/daemon/child_scope_other.go
@@ -1,0 +1,11 @@
+//go:build !linux
+
+package daemon
+
+import "os/exec"
+
+// launchd has no shared service cgroup and no systemd transient scopes. Keep
+// the existing direct child launch on Darwin and other non-Linux platforms.
+func newDaemonChildCommand(name string, args ...string) *exec.Cmd {
+	return exec.Command(name, args...)
+}

--- a/daemon/vscode_server.go
+++ b/daemon/vscode_server.go
@@ -675,7 +675,7 @@ func (v *vscodeSupervisor) startOne(binary string, flavor vscodeFlavor, socketPa
 	if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
 		return nil, fmt.Errorf("clearing the stale VS Code socket %s failed: %w", socketPath, err)
 	}
-	cmd := exec.Command(binary, vscodeArgs(flavor, socketPath, worktree)...)
+	cmd := newDaemonChildCommand(binary, vscodeArgs(flavor, socketPath, worktree)...)
 	cmd.Dir = worktree
 	cmd.Env = vscodeChildEnv()
 	// Own process group so the editor's whole tree (extension host, terminal

--- a/daemon/watcher.go
+++ b/daemon/watcher.go
@@ -543,7 +543,7 @@ func exitedFromSignal(err error, sig syscall.Signal) bool {
 // run's output tail (never nil) for the caller's failure logging.
 func (w *taskWatcher) runOnce() (*tailBuffer, error) {
 	tail := &tailBuffer{}
-	cmd := exec.Command(w.sup.shell, "-c", w.cmdStr)
+	cmd := newDaemonChildCommand(w.sup.shell, "-c", w.cmdStr)
 	cmd.Dir = w.dir
 	cmd.Env = append(os.Environ(),
 		"AF_TASK_ID="+w.taskID,

--- a/integration/daemon_failure_cgroup_systemd_test.go
+++ b/integration/daemon_failure_cgroup_systemd_test.go
@@ -1,0 +1,258 @@
+//go:build linux
+
+package integration_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/internal/systemdunit"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+const systemdLifecycleTestEnv = "AF_SYSTEMD_LIFECYCLE_TEST"
+
+// TestAbruptDaemonFailureReapsOwnedChildrenAndPreservesTmux is the real-systemd
+// #2284 boundary test. It is destructive to Agent Factory's fixed user-unit
+// name, so it runs only on an explicitly prepared ephemeral CI runner. The
+// ordinary suite skips it even inside the testbox (which has no user manager).
+//
+// One TERM-ignoring watcher tree makes the old failure observable: with the
+// unit's necessary KillMode=process, a direct child survives the daemon's
+// SIGKILL and overlaps the watcher started by systemd's replacement. The fixed
+// path puts that tree in a BindsTo+After scope, so systemd reaps the whole old
+// scope before it starts the replacement daemon. At the same time, the tmux
+// server and pane must retain their exact PIDs across the failure.
+func TestAbruptDaemonFailureReapsOwnedChildrenAndPreservesTmux(t *testing.T) {
+	if os.Getenv(systemdLifecycleTestEnv) != "1" || os.Getenv("CI") != "true" {
+		t.Skip("real systemd lifecycle test requires an explicitly prepared ephemeral CI runner")
+	}
+	requireTool(t, "systemctl")
+	requireTool(t, "systemd-run")
+	realTmux, err := exec.LookPath("tmux")
+	if err != nil {
+		t.Fatalf("tmux is required: %v", err)
+	}
+	if out, err := exec.Command("systemctl", "--user", "show-environment").CombinedOutput(); err != nil {
+		t.Fatalf("the opted-in runner has no reachable systemd user manager: %v\n%s", err, out)
+	}
+
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatalf("resolve user config dir: %v", err)
+	}
+	unitPath := filepath.Join(configDir, "systemd", "user", systemdunit.DaemonUnitName)
+	if _, err := os.Stat(unitPath); !os.IsNotExist(err) {
+		t.Fatalf("refusing to replace a pre-existing %s on the CI runner (stat err=%v)", unitPath, err)
+	}
+
+	h := newHarness(t)
+	// A unit does not inherit the test process's TMUX_TMPDIR. Put a tmux shim
+	// first in the PATH captured by the unit so both the daemon and this test use
+	// one explicitly named, throwaway socket. Cleanup therefore never needs a
+	// bare kill-server.
+	tmuxDir := testguard.SocketTempDir(t)
+	tmuxSocket := filepath.Join(tmuxDir, "tmux.sock")
+	shimDir := t.TempDir()
+	tmuxShim := filepath.Join(shimDir, "tmux")
+	writeFile(t, tmuxShim, "#!/bin/sh\nexec "+shellSingleQuote(realTmux)+" -S "+shellSingleQuote(tmuxSocket)+" \"$@\"\n", 0o700)
+	t.Setenv("PATH", shimDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	watchRootLog := filepath.Join(h.home, "watch-roots")
+	watchChildLog := filepath.Join(h.home, "watch-children")
+	watchScript := filepath.Join(h.home, "stubborn-watch.sh")
+	writeFile(t, watchScript, fmt.Sprintf(`#!/bin/sh
+set -eu
+trap '' TERM
+printf '%%s\n' "$$" >> %s
+sh -c 'trap "" TERM; while :; do sleep 600; done' &
+child=$!
+printf '%%s\n' "$child" >> %s
+wait "$child"
+`, shellSingleQuote(watchRootLog), shellSingleQuote(watchChildLog)), 0o700)
+	writeTasksFile(t, h.home, []map[string]interface{}{
+		{
+			"id":           "scope2284",
+			"name":         "scope lifecycle",
+			"prompt":       "",
+			"watch_cmd":    shellSingleQuote(watchScript),
+			"project_path": h.repo,
+			"program":      tmux.ProgramClaude,
+			"enabled":      true,
+			"created_at":   time.Now().Format(time.RFC3339Nano),
+		},
+	})
+
+	// Register the safety cleanup before installing anything. It names only the
+	// fixed unit this test first proved absent, the private AF home, and the
+	// explicit tmux socket above.
+	t.Cleanup(func() {
+		_ = os.WriteFile(filepath.Join(h.home, "tasks.json"), []byte("[]\n"), 0o600)
+		_ = exec.Command("systemctl", "--user", "disable", "--now", systemdunit.DaemonUnitName).Run()
+		_ = os.Remove(unitPath)
+		_ = exec.Command("systemctl", "--user", "daemon-reload").Run()
+		_ = exec.Command(realTmux, "-S", tmuxSocket, "kill-server").Run()
+	})
+
+	h.run("daemon", "install")
+	waitUntil(t, 15*time.Second, "initial watcher tree", func() bool {
+		return len(readPIDLog(watchRootLog)) == 1 && len(readPIDLog(watchChildLog)) == 1
+	})
+	oldRoots := readPIDLog(watchRootLog)
+	oldChildren := readPIDLog(watchChildLog)
+	oldWatchRoot, oldWatchChild := oldRoots[0], oldChildren[0]
+	if !pidAlive(oldWatchRoot) || !pidAlive(oldWatchChild) {
+		t.Fatalf("initial watcher tree is not alive: root=%d child=%d", oldWatchRoot, oldWatchChild)
+	}
+
+	watchScope := processUnitComponent(t, oldWatchRoot, ".scope")
+	show := runExternal(t, "", "systemctl", "--user", "show", watchScope,
+		"-p", "BindsTo", "-p", "After", "-p", "KillMode", "-p", "TimeoutStopUSec")
+	for _, dependency := range []string{"BindsTo", "After"} {
+		if !systemdPropertyHasWord(show, dependency, systemdunit.DaemonUnitName) {
+			t.Fatalf("watcher scope %s %s does not include %s:\n%s",
+				watchScope, dependency, systemdunit.DaemonUnitName, show)
+		}
+	}
+	for _, want := range []string{
+		"KillMode=control-group",
+		"TimeoutStopUSec=4s",
+	} {
+		if !strings.Contains(show, want) {
+			t.Fatalf("watcher scope %s is missing %q:\n%s", watchScope, want, show)
+		}
+	}
+
+	created := h.createSession("failure-survivor")
+	if created.TmuxName == "" {
+		t.Fatal("daemon-created session reported no tmux name")
+	}
+	oldServerPID, oldPanePID := tmuxProcessIDs(t, created.TmuxName)
+	if unit := processUnitComponent(t, oldServerPID, ".scope"); unit == watchScope {
+		t.Fatalf("tmux server and watcher share a kill domain %s", unit)
+	}
+
+	oldDaemon := readDaemonPID(t, h.home)
+	mainPIDText := strings.TrimSpace(runExternal(t, "", "systemctl", "--user", "show",
+		systemdunit.DaemonUnitName, "-p", "MainPID", "--value"))
+	mainPID, err := strconv.Atoi(mainPIDText)
+	if err != nil || mainPID != oldDaemon {
+		t.Fatalf("serving daemon pid=%d, systemd MainPID=%q", oldDaemon, mainPIDText)
+	}
+	if err := syscall.Kill(oldDaemon, syscall.SIGKILL); err != nil {
+		t.Fatalf("SIGKILL disposable daemon pid %d: %v", oldDaemon, err)
+	}
+
+	// Observe continuously, not just at the end: a replacement that briefly
+	// overlaps the old watcher and cleans it later still violates the invariant.
+	overlapped := false
+	var newDaemon, newWatchRoot, newWatchChild int
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		roots := readPIDLog(watchRootLog)
+		children := readPIDLog(watchChildLog)
+		if len(roots) >= 2 {
+			newWatchRoot = roots[1]
+		}
+		if len(children) >= 2 {
+			newWatchChild = children[1]
+		}
+		if newWatchRoot > 1 && (pidAlive(oldWatchRoot) || pidAlive(oldWatchChild)) {
+			overlapped = true
+		}
+		if pid, ok := daemonPID(h.home); ok && pid != oldDaemon && pidAlive(pid) {
+			newDaemon = pid
+		}
+		if newDaemon > 1 && newWatchRoot > 1 && newWatchChild > 1 &&
+			pidAlive(newWatchRoot) && pidAlive(newWatchChild) &&
+			!pidAlive(oldWatchRoot) && !pidAlive(oldWatchChild) {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if overlapped {
+		t.Fatalf("replacement watcher pid %d started while old tree %d/%d was still alive", newWatchRoot, oldWatchRoot, oldWatchChild)
+	}
+	if newDaemon <= 1 || newWatchRoot <= 1 || newWatchChild <= 1 {
+		t.Fatalf("replacement did not become healthy: daemon=%d watcher=%d/%d roots=%v children=%v",
+			newDaemon, newWatchRoot, newWatchChild, readPIDLog(watchRootLog), readPIDLog(watchChildLog))
+	}
+
+	newServerPID, newPanePID := tmuxProcessIDs(t, created.TmuxName)
+	if newServerPID != oldServerPID || newPanePID != oldPanePID {
+		t.Fatalf("abrupt daemon failure replaced the live tmux tree: server %d -> %d, pane %d -> %d",
+			oldServerPID, newServerPID, oldPanePID, newPanePID)
+	}
+	if roots := readPIDLog(watchRootLog); len(roots) != 2 {
+		t.Fatalf("watcher generations=%v, want exactly old+replacement", roots)
+	}
+
+	// Leave normal teardown observable too; the fallback cleanup above remains
+	// for every earlier fatal path.
+	h.run("tasks", "remove", "scope2284")
+	h.run("sessions", "kill", "failure-survivor")
+	h.run("daemon", "uninstall")
+}
+
+func shellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+func readPIDLog(path string) []int {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var pids []int
+	for _, field := range strings.Fields(string(raw)) {
+		pid, err := strconv.Atoi(field)
+		if err == nil && pid > 1 {
+			pids = append(pids, pid)
+		}
+	}
+	return pids
+}
+
+func systemdPropertyHasWord(show, property, want string) bool {
+	prefix := property + "="
+	for _, line := range strings.Split(show, "\n") {
+		if !strings.HasPrefix(line, prefix) {
+			continue
+		}
+		for _, value := range strings.Fields(strings.TrimPrefix(line, prefix)) {
+			if value == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func processUnitComponent(t *testing.T, pid int, suffix string) string {
+	t.Helper()
+	raw, err := os.ReadFile(fmt.Sprintf("/proc/%d/cgroup", pid))
+	if err != nil {
+		t.Fatalf("read cgroup for pid %d: %v", pid, err)
+	}
+	for _, line := range strings.Split(string(raw), "\n") {
+		parts := strings.SplitN(line, ":", 3)
+		if len(parts) != 3 {
+			continue
+		}
+		for _, component := range strings.Split(parts[2], "/") {
+			if strings.HasSuffix(component, suffix) {
+				return component
+			}
+		}
+	}
+	t.Fatalf("pid %d cgroup has no %s unit component: %s", pid, suffix, raw)
+	return ""
+}

--- a/internal/systemdunit/daemon_linux.go
+++ b/internal/systemdunit/daemon_linux.go
@@ -1,0 +1,53 @@
+//go:build linux
+
+// Package systemdunit identifies the process that systemd started as the Agent
+// Factory daemon. Both tmux escape scopes and daemon-child cleanup scopes must
+// use the same process-specific answer: descendants inherit the unit marker,
+// while legacy installed units have no marker and require the kernel cgroup.
+package systemdunit
+
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+const (
+	DaemonUnitName  = "agent-factory-daemon.service"
+	DaemonMarkerEnv = "AGENT_FACTORY_SYSTEMD_UNIT"
+)
+
+var readSelfCgroup = os.ReadFile
+
+// RunningDaemonProcess reports whether the current process is the main process
+// of Agent Factory's systemd user service. It deliberately rejects descendants
+// that merely inherited DaemonMarkerEnv.
+func RunningDaemonProcess() bool {
+	if os.Getenv(DaemonMarkerEnv) == DaemonUnitName {
+		pid, err := strconv.Atoi(os.Getenv("SYSTEMD_EXEC_PID"))
+		if err == nil && pid == os.Getpid() {
+			return true
+		}
+	}
+
+	// Units installed by an older af have no marker until reinstalled. Kernel
+	// cgroup membership is authoritative for that upgrade path and works for
+	// unified and legacy/hybrid /proc/self/cgroup formats.
+	data, err := readSelfCgroup("/proc/self/cgroup")
+	return err == nil && cgroupContainsUnit(string(data), DaemonUnitName)
+}
+
+func cgroupContainsUnit(content, unit string) bool {
+	for _, line := range strings.Split(content, "\n") {
+		parts := strings.SplitN(line, ":", 3)
+		if len(parts) != 3 {
+			continue
+		}
+		for _, component := range strings.Split(parts[2], "/") {
+			if component == unit {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/systemdunit/daemon_linux_test.go
+++ b/internal/systemdunit/daemon_linux_test.go
@@ -1,0 +1,56 @@
+//go:build linux
+
+package systemdunit
+
+import (
+	"errors"
+	"os"
+	"strconv"
+	"testing"
+)
+
+func stubSelfCgroup(t *testing.T, content string, err error) {
+	t.Helper()
+	previous := readSelfCgroup
+	readSelfCgroup = func(string) ([]byte, error) { return []byte(content), err }
+	t.Cleanup(func() { readSelfCgroup = previous })
+}
+
+func TestRunningDaemonProcessUsesProcessSpecificMarker(t *testing.T) {
+	t.Setenv(DaemonMarkerEnv, DaemonUnitName)
+	t.Setenv("SYSTEMD_EXEC_PID", strconv.Itoa(os.Getpid()))
+	stubSelfCgroup(t, "", errors.New("proc unavailable"))
+	if !RunningDaemonProcess() {
+		t.Fatal("systemd's marked main process was not recognized")
+	}
+
+	t.Setenv("SYSTEMD_EXEC_PID", strconv.Itoa(os.Getpid()+1))
+	if RunningDaemonProcess() {
+		t.Fatal("descendant with an inherited marker was mistaken for the daemon")
+	}
+}
+
+func TestRunningDaemonProcessRecognizesLegacyUnitCgroup(t *testing.T) {
+	t.Setenv(DaemonMarkerEnv, "")
+	t.Setenv("SYSTEMD_EXEC_PID", "")
+	stubSelfCgroup(t, "0::/user.slice/user-1001.slice/user@1001.service/app.slice/agent-factory-daemon.service\n", nil)
+	if !RunningDaemonProcess() {
+		t.Fatal("legacy daemon cgroup was not recognized")
+	}
+}
+
+func TestCgroupContainsUnitRequiresExactPathComponent(t *testing.T) {
+	for _, content := range []string{
+		"0::/user.slice/session-7.scope\n",
+		"0::/user.slice/not-agent-factory-daemon.service\n",
+		"12:memory:/agent-factory-daemon.service-old\n",
+		"malformed\n",
+	} {
+		if cgroupContainsUnit(content, DaemonUnitName) {
+			t.Errorf("cgroupContainsUnit(%q) = true for no exact unit component", content)
+		}
+	}
+	if !cgroupContainsUnit("12:memory:/x/agent-factory-daemon.service/y\n", DaemonUnitName) {
+		t.Error("exact legacy/hybrid cgroup component was not recognized")
+	}
+}

--- a/internal/systemdunit/daemon_other.go
+++ b/internal/systemdunit/daemon_other.go
@@ -1,0 +1,10 @@
+//go:build !linux
+
+package systemdunit
+
+const (
+	DaemonUnitName  = "agent-factory-daemon.service"
+	DaemonMarkerEnv = "AGENT_FACTORY_SYSTEMD_UNIT"
+)
+
+func RunningDaemonProcess() bool { return false }

--- a/session/tmux/server_scope_linux.go
+++ b/session/tmux/server_scope_linux.go
@@ -3,18 +3,10 @@
 package tmux
 
 import (
-	"os"
 	"os/exec"
-	"strconv"
-	"strings"
-)
 
-const (
-	systemdDaemonUnit      = "agent-factory-daemon.service"
-	systemdDaemonMarkerEnv = "AGENT_FACTORY_SYSTEMD_UNIT"
+	"github.com/sachiniyer/agent-factory/internal/systemdunit"
 )
-
-var readSelfCgroup = os.ReadFile
 
 // newTmuxServerCommand wraps the only command that can create tmux's server in
 // a transient user scope when af itself is the systemd-supervised daemon
@@ -25,43 +17,10 @@ var readSelfCgroup = os.ReadFile
 // Existing tmux servers are unaffected: new-session is merely a client in the
 // short-lived scope and connects to the server that already owns the socket.
 func newTmuxServerCommand(args ...string) (*exec.Cmd, bool) {
-	if !runningInSystemdDaemonUnit() {
+	if !systemdunit.RunningDaemonProcess() {
 		return exec.Command("tmux", args...), false
 	}
 	scopeArgs := []string{"--user", "--scope", "--quiet", "--collect", "--", "tmux"}
 	scopeArgs = append(scopeArgs, args...)
 	return exec.Command("systemd-run", scopeArgs...), true
-}
-
-func runningInSystemdDaemonUnit() bool {
-	// New unit templates carry an explicit marker. SYSTEMD_EXEC_PID makes the
-	// check process-specific: tmux panes inherit the environment, but their pid
-	// differs, so a nested af does not mistake itself for the daemon.
-	if os.Getenv(systemdDaemonMarkerEnv) == systemdDaemonUnit {
-		pid, err := strconv.Atoi(os.Getenv("SYSTEMD_EXEC_PID"))
-		if err == nil && pid == os.Getpid() {
-			return true
-		}
-	}
-
-	// Units installed by an older af have no marker until reinstalled. The
-	// kernel's membership is authoritative for those upgrades and works for
-	// both unified and legacy/hybrid /proc/self/cgroup formats.
-	data, err := readSelfCgroup("/proc/self/cgroup")
-	return err == nil && cgroupContainsUnit(string(data), systemdDaemonUnit)
-}
-
-func cgroupContainsUnit(content, unit string) bool {
-	for _, line := range strings.Split(content, "\n") {
-		parts := strings.SplitN(line, ":", 3)
-		if len(parts) != 3 {
-			continue
-		}
-		for _, component := range strings.Split(parts[2], "/") {
-			if component == unit {
-				return true
-			}
-		}
-	}
-	return false
 }

--- a/session/tmux/server_scope_linux_test.go
+++ b/session/tmux/server_scope_linux_test.go
@@ -11,21 +11,12 @@ import (
 	"testing"
 
 	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	"github.com/sachiniyer/agent-factory/internal/systemdunit"
 )
 
-func stubSelfCgroup(t *testing.T, content string, err error) {
-	t.Helper()
-	previous := readSelfCgroup
-	readSelfCgroup = func(string) ([]byte, error) {
-		return []byte(content), err
-	}
-	t.Cleanup(func() { readSelfCgroup = previous })
-}
-
 func TestNewTmuxServerCommandScopesDaemonUnitSpawn(t *testing.T) {
-	t.Setenv(systemdDaemonMarkerEnv, systemdDaemonUnit)
+	t.Setenv(systemdunit.DaemonMarkerEnv, systemdunit.DaemonUnitName)
 	t.Setenv("SYSTEMD_EXEC_PID", strconv.Itoa(os.Getpid()))
-	stubSelfCgroup(t, "", errors.New("proc unavailable"))
 
 	cmd, scoped := newTmuxServerCommand("new-session", "-d", "-s", "af_worker")
 	if !scoped {
@@ -37,24 +28,9 @@ func TestNewTmuxServerCommandScopesDaemonUnitSpawn(t *testing.T) {
 	}
 }
 
-func TestRunningInSystemdDaemonUnitRecognizesLegacyUnitCgroup(t *testing.T) {
-	t.Setenv(systemdDaemonMarkerEnv, "")
-	t.Setenv("SYSTEMD_EXEC_PID", "")
-	stubSelfCgroup(t, "0::/user.slice/user-1001.slice/user@1001.service/app.slice/agent-factory-daemon.service\n", nil)
-
-	cmd, scoped := newTmuxServerCommand("new-session")
-	if !scoped {
-		t.Fatal("legacy daemon cgroup command was not marked systemd-scoped")
-	}
-	if got := cmd.Args[0]; got != "systemd-run" {
-		t.Fatalf("legacy unit cgroup launched %q, want systemd-run scope", got)
-	}
-}
-
 func TestNewTmuxServerCommandDoesNotTrustInheritedSystemdMarker(t *testing.T) {
-	t.Setenv(systemdDaemonMarkerEnv, systemdDaemonUnit)
+	t.Setenv(systemdunit.DaemonMarkerEnv, systemdunit.DaemonUnitName)
 	t.Setenv("SYSTEMD_EXEC_PID", strconv.Itoa(os.Getpid()+1))
-	stubSelfCgroup(t, "0::/user.slice/user-1001.slice/session-7.scope\n", nil)
 
 	cmd, scoped := newTmuxServerCommand("new-session")
 	if scoped {
@@ -62,22 +38,6 @@ func TestNewTmuxServerCommandDoesNotTrustInheritedSystemdMarker(t *testing.T) {
 	}
 	if got := strings.Join(cmd.Args, " "); got != "tmux new-session" {
 		t.Fatalf("descendant with inherited marker launched %q, want direct tmux client", got)
-	}
-}
-
-func TestCgroupContainsUnitRequiresExactPathComponent(t *testing.T) {
-	for _, content := range []string{
-		"0::/user.slice/session-7.scope\n",
-		"0::/user.slice/not-agent-factory-daemon.service\n",
-		"12:memory:/agent-factory-daemon.service-old\n",
-		"malformed\n",
-	} {
-		if cgroupContainsUnit(content, systemdDaemonUnit) {
-			t.Errorf("cgroupContainsUnit(%q) = true for no exact unit component", content)
-		}
-	}
-	if !cgroupContainsUnit("12:memory:/x/agent-factory-daemon.service/y\n", systemdDaemonUnit) {
-		t.Error("exact legacy/hybrid cgroup component was not recognized")
 	}
 }
 
@@ -112,9 +72,8 @@ func (refusingTrackedPtyFactory) Close() {}
 // generic non-zero wrapper status came from systemd-run itself or the scoped
 // tmux child, though, so it must not authorize fresh-worktree deletion.
 func TestSystemdRunRefusalIsActionableButCleanupUnsafe(t *testing.T) {
-	t.Setenv(systemdDaemonMarkerEnv, systemdDaemonUnit)
+	t.Setenv(systemdunit.DaemonMarkerEnv, systemdunit.DaemonUnitName)
 	t.Setenv("SYSTEMD_EXEC_PID", strconv.Itoa(os.Getpid()))
-	stubSelfCgroup(t, "", errors.New("proc unavailable"))
 	forceNewSessionEnvMarkers(t, false)
 
 	cmdExec := cmd_test.MockCmdExec{


### PR DESCRIPTION
Fixes #2284.

## Root cause

`KillMode=process` is necessary while a pre-#2176 tmux server may still live in `agent-factory-daemon.service`: any cgroup-wide service stop can destroy that server and every live pane. But it also means systemd cannot reap watcher and editor descendants when the daemon dies before its Go defers run. The replacement daemon then reloads the same watcher/editor generation alongside the orphan.

Those two lifetime classes shared one cgroup even though they require opposite stop policies.

## What changed

- put each long-lived daemon-owned watcher/editor tree in a transient systemd scope with authoritative `BindsTo=agent-factory-daemon.service` ownership
- add `After=agent-factory-daemon.service`, which reverses on stop: the old child scope is fully reaped before systemd may start the replacement daemon, so startup cannot briefly overlap generations
- use `KillMode=control-group` and a bounded four-second scope stop for TERM-ignoring descendants
- keep tmux in its independent persistent scope and keep the daemon unit itself on `KillMode=process`, preserving legacy servers already trapped in that unit
- centralize the process-specific unit detector used by both persistent tmux scopes and daemon-owned cleanup scopes so the marker, unit name, and legacy-cgroup fallback cannot drift

## Regression evidence

The call-path regressions were watched failing before the production change:

```text
watcher did not execute inside the bound scope shim: events=[scope001:scope=]
daemon-owned child bypassed systemd-run: .../systemd-run.log: no such file or directory
```

They now prove both watcher and VS Code production spawns cross the bound-scope constructor.

A new opt-in real-systemd integration test runs on Ubuntu 22.04 (systemd 249) and Ubuntu 24.04 (systemd 255). It installs a disposable real user unit, starts a TERM-ignoring watcher tree and a daemon-created tmux pane, SIGKILLs the exact systemd MainPID, and proves simultaneously that:

- no replacement watcher starts while either old watcher PID remains alive;
- the old watcher root and descendant are reaped and exactly one replacement starts;
- the tmux server PID and pane PID are unchanged.

The fixed unit name is guarded: the test runs only with an explicit CI opt-in and refuses to replace any pre-existing unit. Its tmux server uses an explicit throwaway socket.

## Validation

All required pre-push gates passed on rebased exact head `4066b23ab50c9e4bf16b718e915cc351518a14d6`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (no output)
- `go build ./...`
- `make test-container`

Additional checks passed: Darwin arm64 cross-build, `deadcode -test ./...`, file-length lint, and `actionlint .github/workflows/pr.yml`.

— Captain Claude