### PR TITLE
fix(tmux): preserve final capture output

### DIFF
--- a/session/ptychannel_tmux.go
+++ b/session/ptychannel_tmux.go
@@ -1,7 +1,6 @@
 package session
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -12,7 +11,6 @@ import (
 	"syscall"
 
 	"github.com/sachiniyer/agent-factory/session/tmux"
-	"golang.org/x/sys/unix"
 )
 
 // tmuxClientlessChannel is the local runtime's clientlessChannel (#1592 Phase 2
@@ -37,16 +35,14 @@ type tmuxClientlessChannel struct {
 // pane bytes (including NULs and chunks larger than the broker buffer) are read
 // first, then EOF arrives after the real writer closes.
 //
-// A separate anonymous pipe is the failure-only escape hatch. Go cannot put a
-// FIFO into the darwin netpoller, and close(2) does not interrupt an in-flight
-// FIFO read, so Read uses poll(2) on both descriptors. If disabling pipe-pane
-// fails and the external writer may remain open forever, Close wakes the poll
-// out of band instead of placing an ambiguous sentinel in the raw PTY stream.
+// If disabling pipe-pane fails, its writer may remain open forever. That
+// already-aborted path writes one wake byte through the keeper before closing
+// it; Read sees the abort latch and discards the whole read, so the byte can
+// never be confused with successful raw PTY output. Successful teardown never
+// injects a control byte.
 type captureReader struct {
 	f         *os.File
 	keepalive *os.File
-	wakeR     *os.File
-	wakeW     *os.File
 	dir       string
 	abort     atomic.Bool
 	eof       atomic.Bool
@@ -63,55 +59,24 @@ func (r *captureReader) Read(p []byte) (int, error) {
 		return 0, nil
 	}
 
-	for {
-		if r.abort.Load() {
-			r.eof.Store(true)
-			r.finish()
-			return 0, io.EOF
-		}
-		pollFDs := []unix.PollFd{
-			{Fd: int32(r.f.Fd()), Events: unix.POLLIN},
-			{Fd: int32(r.wakeR.Fd()), Events: unix.POLLIN},
-		}
-		if _, err := unix.Poll(pollFDs, -1); err != nil {
-			if errors.Is(err, unix.EINTR) {
-				continue
-			}
-			r.finish()
-			return 0, fmt.Errorf("poll pty stream fifo: %w", err)
-		}
-
-		outputEvents := pollFDs[0].Revents
-		if outputEvents&(unix.POLLIN|unix.POLLHUP) != 0 {
-			n, err := r.f.Read(p)
-			if n > 0 {
-				return n, err
-			}
-			if errors.Is(err, syscall.EAGAIN) {
-				continue
-			}
-			if errors.Is(err, io.EOF) || outputEvents&unix.POLLHUP != 0 {
-				r.eof.Store(true)
-				r.finish()
-				return 0, io.EOF
-			}
-			if err != nil {
-				r.finish()
-				return 0, err
-			}
-		}
-		if outputEvents&(unix.POLLERR|unix.POLLNVAL) != 0 {
-			r.finish()
-			return 0, fmt.Errorf("poll pty stream fifo: events %#x", outputEvents)
-		}
-
-		wakeEvents := pollFDs[1].Revents
-		if wakeEvents&(unix.POLLIN|unix.POLLHUP|unix.POLLERR|unix.POLLNVAL) != 0 && r.abort.Load() {
-			r.eof.Store(true)
-			r.finish()
-			return 0, io.EOF
-		}
+	if r.abort.Load() {
+		r.eof.Store(true)
+		r.finish()
+		return 0, io.EOF
 	}
+	n, err := r.f.Read(p)
+	if r.abort.Load() {
+		r.eof.Store(true)
+		r.finish()
+		return 0, io.EOF
+	}
+	if err != nil {
+		if err == io.EOF {
+			r.eof.Store(true)
+		}
+		r.finish()
+	}
+	return n, err
 }
 
 func (r *captureReader) Close() error {
@@ -120,17 +85,18 @@ func (r *captureReader) Close() error {
 
 // stop closes the FIFO's private keeper. When tmux positively disabled its
 // writer, drain=true lets Read consume through the kernel EOF. Otherwise the
-// out-of-band wake prevents an unknown external writer from wedging teardown.
+// keeper's failure-only byte prevents an unknown external writer from wedging
+// teardown; Read discards it because abort is already latched.
 func (r *captureReader) stop(drain bool) error {
 	r.stopOnce.Do(func() {
-		if r.keepalive != nil {
-			r.err = r.keepalive.Close()
-		}
 		if !drain {
 			r.abort.Store(true)
-			if r.wakeW != nil {
-				_, _ = r.wakeW.Write([]byte{1})
+			if r.keepalive != nil {
+				_, _ = r.keepalive.Write([]byte{0})
 			}
+		}
+		if r.keepalive != nil {
+			r.err = r.keepalive.Close()
 		}
 	})
 	return r.err
@@ -143,12 +109,6 @@ func (r *captureReader) finish() {
 		}
 		if r.keepalive != nil {
 			_ = r.keepalive.Close()
-		}
-		if r.wakeR != nil {
-			_ = r.wakeR.Close()
-		}
-		if r.wakeW != nil {
-			_ = r.wakeW.Close()
 		}
 		if r.dir != "" {
 			_ = os.RemoveAll(r.dir)
@@ -183,33 +143,35 @@ func (c *tmuxClientlessChannel) StartCapture() (io.ReadCloser, error) {
 		_ = os.RemoveAll(dir)
 		return nil, fmt.Errorf("mkfifo pty stream: %w", err)
 	}
-	f, err := os.OpenFile(fifo, os.O_RDONLY|syscall.O_NONBLOCK, 0600)
+	// Open the read side nonblocking only long enough to establish the keeper;
+	// wrapping the descriptor after restoring blocking mode deliberately keeps
+	// FIFOs out of Go's kqueue/netpoll path on Darwin (where writer close does not
+	// produce a readiness event).
+	fd, err := syscall.Open(fifo, syscall.O_RDONLY|syscall.O_NONBLOCK|syscall.O_CLOEXEC, 0600)
 	if err != nil {
 		_ = os.RemoveAll(dir)
 		return nil, fmt.Errorf("open pty stream fifo: %w", err)
 	}
 	keepalive, err := os.OpenFile(fifo, os.O_WRONLY|syscall.O_NONBLOCK, 0600)
 	if err != nil {
-		_ = f.Close()
+		_ = syscall.Close(fd)
 		_ = os.RemoveAll(dir)
 		return nil, fmt.Errorf("keep pty stream fifo open: %w", err)
 	}
-	wakeR, wakeW, err := os.Pipe()
-	if err != nil {
+	if err := syscall.SetNonblock(fd, false); err != nil {
 		_ = keepalive.Close()
-		_ = f.Close()
+		_ = syscall.Close(fd)
 		_ = os.RemoveAll(dir)
-		return nil, fmt.Errorf("create pty stream wake pipe: %w", err)
+		return nil, fmt.Errorf("make pty stream fifo blocking: %w", err)
 	}
+	f := os.NewFile(uintptr(fd), fifo)
 	if err := c.ts.EnablePipePane(pipePaneCommand(fifo)); err != nil {
-		_ = wakeW.Close()
-		_ = wakeR.Close()
 		_ = keepalive.Close()
 		_ = f.Close()
 		_ = os.RemoveAll(dir)
 		return nil, err
 	}
-	rc := &captureReader{f: f, keepalive: keepalive, wakeR: wakeR, wakeW: wakeW, dir: dir}
+	rc := &captureReader{f: f, keepalive: keepalive, dir: dir}
 	c.dir, c.fifo, c.rc = dir, fifo, rc
 	return rc, nil
 }

--- a/session/ptychannel_tmux.go
+++ b/session/ptychannel_tmux.go
@@ -39,12 +39,14 @@ type tmuxClientlessChannel struct {
 // return. Read reports io.EOF once stopped, so the sentinel never reaches the
 // broker ring.
 type captureReader struct {
-	f       *os.File
+	f       io.ReadCloser
 	fifo    string
 	stopped atomic.Bool
 	once    sync.Once
 	err     error
 }
+
+const captureStopSentinel byte = 0
 
 func (r *captureReader) Read(p []byte) (int, error) {
 	if r.stopped.Load() {
@@ -52,6 +54,17 @@ func (r *captureReader) Read(p []byte) (int, error) {
 	}
 	n, err := r.f.Read(p)
 	if r.stopped.Load() {
+		// Close writes exactly one sentinel after latching stopped. StopCapture has
+		// already disabled pipe-pane, so when that byte shares a FIFO read with the
+		// pane's final buffered output it is the tail. Consume only that private wake
+		// byte; bytes the read already obtained still belong to the broker ring and
+		// must be returned before EOF.
+		if n > 0 && p[n-1] == captureStopSentinel {
+			n--
+		}
+		if n > 0 {
+			return n, io.EOF
+		}
 		return 0, io.EOF
 	}
 	return n, err
@@ -61,7 +74,7 @@ func (r *captureReader) Close() error {
 	r.once.Do(func() {
 		r.stopped.Store(true)
 		if w, err := os.OpenFile(r.fifo, os.O_WRONLY|syscall.O_NONBLOCK, 0); err == nil {
-			_, _ = w.Write([]byte{0})
+			_, _ = w.Write([]byte{captureStopSentinel})
 			_ = w.Close()
 		}
 		r.err = r.f.Close()

--- a/session/ptychannel_tmux.go
+++ b/session/ptychannel_tmux.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"syscall"
 
 	"github.com/sachiniyer/agent-factory/session/tmux"
+	"golang.org/x/sys/unix"
 )
 
 // tmuxClientlessChannel is the local runtime's clientlessChannel (#1592 Phase 2
@@ -22,64 +24,136 @@ type tmuxClientlessChannel struct {
 	ts *tmux.TmuxSession
 
 	mu   sync.Mutex
-	dir  string         // temp dir holding the FIFO, removed on StopCapture
+	dir  string         // temp dir holding the FIFO, removed after its reader drains
 	fifo string         // FIFO path pipe-pane writes to
 	rc   *captureReader // read end of the FIFO
 }
 
-// captureReader wraps the FIFO's read end so Close wakes a Read parked in
-// read(2). The FIFO cannot enter Go's netpoller on darwin (kqueue does not
-// work with fifos — see os/file_unix.go), so the fd is a plain blocking
-// descriptor and close(2) does NOT interrupt an in-flight read: with pipe-pane
-// already gone no byte would ever arrive, and the teardown join in
-// ptyBroker.stopCapture hung forever, wedging session delete and with it the
-// whole daemon (#1943). Close latches stopped, then writes one sentinel byte
-// into the FIFO — the O_RDWR read end keeps a reader registered, so the
-// nonblocking writer open cannot fail with ENXIO — forcing any parked read to
-// return. Read reports io.EOF once stopped, so the sentinel never reaches the
-// broker ring.
+// captureReader wraps the FIFO's read end so capture teardown can drain every
+// byte the pipe-pane writer committed before reporting EOF. The FIFO reader is
+// opened read-only and a private keeper writer prevents transient writer exits
+// from ending a live capture. Once tmux has disabled pipe-pane, closing that
+// keeper lets the kernel's ordered FIFO EOF become the drain boundary: queued
+// pane bytes (including NULs and chunks larger than the broker buffer) are read
+// first, then EOF arrives after the real writer closes.
+//
+// A separate anonymous pipe is the failure-only escape hatch. Go cannot put a
+// FIFO into the darwin netpoller, and close(2) does not interrupt an in-flight
+// FIFO read, so Read uses poll(2) on both descriptors. If disabling pipe-pane
+// fails and the external writer may remain open forever, Close wakes the poll
+// out of band instead of placing an ambiguous sentinel in the raw PTY stream.
 type captureReader struct {
-	f       io.ReadCloser
-	fifo    string
-	stopped atomic.Bool
-	once    sync.Once
-	err     error
+	f         *os.File
+	keepalive *os.File
+	wakeR     *os.File
+	wakeW     *os.File
+	dir       string
+	abort     atomic.Bool
+	eof       atomic.Bool
+	stopOnce  sync.Once
+	cleanOnce sync.Once
+	err       error
 }
 
-const captureStopSentinel byte = 0
-
 func (r *captureReader) Read(p []byte) (int, error) {
-	if r.stopped.Load() {
+	if r.eof.Load() {
 		return 0, io.EOF
 	}
-	n, err := r.f.Read(p)
-	if r.stopped.Load() {
-		// Close writes exactly one sentinel after latching stopped. StopCapture has
-		// already disabled pipe-pane, so when that byte shares a FIFO read with the
-		// pane's final buffered output it is the tail. Consume only that private wake
-		// byte; bytes the read already obtained still belong to the broker ring and
-		// must be returned before EOF.
-		if n > 0 && p[n-1] == captureStopSentinel {
-			n--
-		}
-		if n > 0 {
-			return n, io.EOF
-		}
-		return 0, io.EOF
+	if len(p) == 0 {
+		return 0, nil
 	}
-	return n, err
+
+	for {
+		if r.abort.Load() {
+			r.eof.Store(true)
+			r.finish()
+			return 0, io.EOF
+		}
+		pollFDs := []unix.PollFd{
+			{Fd: int32(r.f.Fd()), Events: unix.POLLIN},
+			{Fd: int32(r.wakeR.Fd()), Events: unix.POLLIN},
+		}
+		if _, err := unix.Poll(pollFDs, -1); err != nil {
+			if errors.Is(err, unix.EINTR) {
+				continue
+			}
+			r.finish()
+			return 0, fmt.Errorf("poll pty stream fifo: %w", err)
+		}
+
+		outputEvents := pollFDs[0].Revents
+		if outputEvents&(unix.POLLIN|unix.POLLHUP) != 0 {
+			n, err := r.f.Read(p)
+			if n > 0 {
+				return n, err
+			}
+			if errors.Is(err, syscall.EAGAIN) {
+				continue
+			}
+			if errors.Is(err, io.EOF) || outputEvents&unix.POLLHUP != 0 {
+				r.eof.Store(true)
+				r.finish()
+				return 0, io.EOF
+			}
+			if err != nil {
+				r.finish()
+				return 0, err
+			}
+		}
+		if outputEvents&(unix.POLLERR|unix.POLLNVAL) != 0 {
+			r.finish()
+			return 0, fmt.Errorf("poll pty stream fifo: events %#x", outputEvents)
+		}
+
+		wakeEvents := pollFDs[1].Revents
+		if wakeEvents&(unix.POLLIN|unix.POLLHUP|unix.POLLERR|unix.POLLNVAL) != 0 && r.abort.Load() {
+			r.eof.Store(true)
+			r.finish()
+			return 0, io.EOF
+		}
+	}
 }
 
 func (r *captureReader) Close() error {
-	r.once.Do(func() {
-		r.stopped.Store(true)
-		if w, err := os.OpenFile(r.fifo, os.O_WRONLY|syscall.O_NONBLOCK, 0); err == nil {
-			_, _ = w.Write([]byte{captureStopSentinel})
-			_ = w.Close()
+	return r.stop(false)
+}
+
+// stop closes the FIFO's private keeper. When tmux positively disabled its
+// writer, drain=true lets Read consume through the kernel EOF. Otherwise the
+// out-of-band wake prevents an unknown external writer from wedging teardown.
+func (r *captureReader) stop(drain bool) error {
+	r.stopOnce.Do(func() {
+		if r.keepalive != nil {
+			r.err = r.keepalive.Close()
 		}
-		r.err = r.f.Close()
+		if !drain {
+			r.abort.Store(true)
+			if r.wakeW != nil {
+				_, _ = r.wakeW.Write([]byte{1})
+			}
+		}
 	})
 	return r.err
+}
+
+func (r *captureReader) finish() {
+	r.cleanOnce.Do(func() {
+		if r.f != nil {
+			_ = r.f.Close()
+		}
+		if r.keepalive != nil {
+			_ = r.keepalive.Close()
+		}
+		if r.wakeR != nil {
+			_ = r.wakeR.Close()
+		}
+		if r.wakeW != nil {
+			_ = r.wakeW.Close()
+		}
+		if r.dir != "" {
+			_ = os.RemoveAll(r.dir)
+		}
+	})
 }
 
 var _ clientlessChannel = (*tmuxClientlessChannel)(nil)
@@ -89,10 +163,10 @@ func newTmuxClientlessChannel(ts *tmux.TmuxSession) *tmuxClientlessChannel {
 }
 
 // StartCapture makes a private FIFO, opens its read end, and enables pipe-pane to
-// write the pane's raw output into it. The FIFO is opened O_RDWR so the reader
-// stays valid even across the brief window before tmux's `cat` opens the write
-// end (and never sees EOF from a transient writer close) — StopCapture is the
-// only thing that ends the stream.
+// write the pane's raw output into it. A private writer keeps the FIFO live across
+// the brief window before tmux opens its writer and across transient writer exits;
+// StopCapture closes the keeper only after disabling pipe-pane, making FIFO EOF
+// an ordered end-of-stream marker rather than injecting one into the PTY bytes.
 func (c *tmuxClientlessChannel) StartCapture() (io.ReadCloser, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -109,22 +183,39 @@ func (c *tmuxClientlessChannel) StartCapture() (io.ReadCloser, error) {
 		_ = os.RemoveAll(dir)
 		return nil, fmt.Errorf("mkfifo pty stream: %w", err)
 	}
-	f, err := os.OpenFile(fifo, os.O_RDWR, 0600)
+	f, err := os.OpenFile(fifo, os.O_RDONLY|syscall.O_NONBLOCK, 0600)
 	if err != nil {
 		_ = os.RemoveAll(dir)
 		return nil, fmt.Errorf("open pty stream fifo: %w", err)
 	}
+	keepalive, err := os.OpenFile(fifo, os.O_WRONLY|syscall.O_NONBLOCK, 0600)
+	if err != nil {
+		_ = f.Close()
+		_ = os.RemoveAll(dir)
+		return nil, fmt.Errorf("keep pty stream fifo open: %w", err)
+	}
+	wakeR, wakeW, err := os.Pipe()
+	if err != nil {
+		_ = keepalive.Close()
+		_ = f.Close()
+		_ = os.RemoveAll(dir)
+		return nil, fmt.Errorf("create pty stream wake pipe: %w", err)
+	}
 	if err := c.ts.EnablePipePane(pipePaneCommand(fifo)); err != nil {
+		_ = wakeW.Close()
+		_ = wakeR.Close()
+		_ = keepalive.Close()
 		_ = f.Close()
 		_ = os.RemoveAll(dir)
 		return nil, err
 	}
-	rc := &captureReader{f: f, fifo: fifo}
+	rc := &captureReader{f: f, keepalive: keepalive, wakeR: wakeR, wakeW: wakeW, dir: dir}
 	c.dir, c.fifo, c.rc = dir, fifo, rc
 	return rc, nil
 }
 
-// StopCapture disables pipe-pane, closes the read end, and removes the FIFO dir.
+// StopCapture disables pipe-pane and starts an ordered drain. The capture reader
+// closes its descriptors and removes the FIFO directory when it reaches EOF.
 func (c *tmuxClientlessChannel) StopCapture() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -132,10 +223,7 @@ func (c *tmuxClientlessChannel) StopCapture() error {
 		return nil
 	}
 	err := c.ts.DisablePipePane()
-	_ = c.rc.Close()
-	if c.dir != "" {
-		_ = os.RemoveAll(c.dir)
-	}
+	_ = c.rc.stop(err == nil)
 	c.dir, c.fifo, c.rc = "", "", nil
 	return err
 }

--- a/session/ptychannel_tmux_test.go
+++ b/session/ptychannel_tmux_test.go
@@ -1,6 +1,8 @@
 package session
 
 import (
+	"errors"
+	"io"
 	"os/exec"
 	"strings"
 	"testing"
@@ -10,6 +12,79 @@ import (
 
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
+
+type stagedCaptureReadCloser struct {
+	started chan struct{}
+	release chan struct{}
+	data    []byte
+}
+
+func (r *stagedCaptureReadCloser) Read(p []byte) (int, error) {
+	close(r.started)
+	<-r.release
+	return copy(p, r.data), nil
+}
+
+func (*stagedCaptureReadCloser) Close() error { return nil }
+
+type captureReadResult struct {
+	n   int
+	err error
+	buf []byte
+}
+
+func readAcrossCaptureStop(t *testing.T, data []byte) captureReadResult {
+	t.Helper()
+	f := &stagedCaptureReadCloser{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+		data:    data,
+	}
+	r := &captureReader{f: f}
+	result := make(chan captureReadResult, 1)
+	go func() {
+		buf := make([]byte, 64)
+		n, err := r.Read(buf)
+		result <- captureReadResult{n: n, err: err, buf: buf}
+	}()
+
+	<-f.started
+	r.stopped.Store(true)
+	close(f.release)
+	return <-result
+}
+
+func TestCaptureReaderPreservesBytesReadAsCloseStarts(t *testing.T) {
+	const finalOutput = "final pane output"
+	got := readAcrossCaptureStop(t, []byte(finalOutput))
+	if string(got.buf[:got.n]) != finalOutput {
+		t.Fatalf("Read data = %q (n=%d), want final pane output %q", got.buf[:got.n], got.n, finalOutput)
+	}
+	if !errors.Is(got.err, io.EOF) {
+		t.Fatalf("Read error = %v, want io.EOF after returning final pane output", got.err)
+	}
+}
+
+func TestCaptureReaderAbsorbsStopSentinelAfterFinalBytes(t *testing.T) {
+	const finalOutput = "final pane output"
+	got := readAcrossCaptureStop(t, append([]byte(finalOutput), captureStopSentinel))
+	if string(got.buf[:got.n]) != finalOutput {
+		t.Fatalf("Read data = %q (n=%d), want final pane output %q without sentinel", got.buf[:got.n], got.n, finalOutput)
+	}
+	if !errors.Is(got.err, io.EOF) {
+		t.Fatalf("Read error = %v, want io.EOF after returning final pane output", got.err)
+	}
+}
+
+func TestCaptureReaderAbsorbsStopSentinelAlone(t *testing.T) {
+	got := readAcrossCaptureStop(t, []byte{captureStopSentinel})
+	if got.n != 0 {
+		t.Fatalf("Read returned %d sentinel bytes, want none", got.n)
+	}
+	if !errors.Is(got.err, io.EOF) {
+		t.Fatalf("Read error = %v, want io.EOF for the stop sentinel", got.err)
+	}
+}
 
 // TestTmuxSnapshotRepaintCursorRealTmux is the #1688 end-to-end gate against a REAL
 // tmux server: it drives the actual capture → buildRepaint → emulator path and

--- a/session/ptychannel_tmux_test.go
+++ b/session/ptychannel_tmux_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -26,13 +27,7 @@ func readAcrossCaptureStop(t *testing.T, data []byte) captureReadResult {
 	if err != nil {
 		t.Fatalf("create output pipe: %v", err)
 	}
-	wakeR, wakeW, err := os.Pipe()
-	if err != nil {
-		_ = outputR.Close()
-		_ = outputW.Close()
-		t.Fatalf("create wake pipe: %v", err)
-	}
-	r := &captureReader{f: outputR, keepalive: outputW, wakeR: wakeR, wakeW: wakeW}
+	r := &captureReader{f: outputR, keepalive: outputW}
 	result := make(chan captureReadResult, 1)
 	go func() {
 		buf, readErr := io.ReadAll(r)
@@ -86,13 +81,15 @@ func TestCaptureReaderAbortWakesWithExternalWriterStillOpen(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create output pipe: %v", err)
 	}
-	t.Cleanup(func() { _ = outputW.Close() })
-	wakeR, wakeW, err := os.Pipe()
+	externalFD, err := syscall.Dup(int(outputW.Fd()))
 	if err != nil {
 		_ = outputR.Close()
-		t.Fatalf("create wake pipe: %v", err)
+		_ = outputW.Close()
+		t.Fatalf("duplicate external writer: %v", err)
 	}
-	r := &captureReader{f: outputR, wakeR: wakeR, wakeW: wakeW}
+	externalW := os.NewFile(uintptr(externalFD), "capture-external-writer")
+	t.Cleanup(func() { _ = externalW.Close() })
+	r := &captureReader{f: outputR, keepalive: outputW}
 	result := make(chan error, 1)
 	go func() {
 		buf := make([]byte, 1)
@@ -106,7 +103,7 @@ func TestCaptureReaderAbortWakesWithExternalWriterStillOpen(t *testing.T) {
 	select {
 	case err := <-result:
 		if !errors.Is(err, io.EOF) {
-			t.Fatalf("Read error = %v, want EOF from out-of-band abort", err)
+			t.Fatalf("Read error = %v, want EOF from failure-only abort wake", err)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("capture reader stayed blocked with an external writer open")

--- a/session/ptychannel_tmux_test.go
+++ b/session/ptychannel_tmux_test.go
@@ -1,8 +1,10 @@
 package session
 
 import (
+	"bytes"
 	"errors"
 	"io"
+	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -13,76 +15,101 @@ import (
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
-type stagedCaptureReadCloser struct {
-	started chan struct{}
-	release chan struct{}
-	data    []byte
-}
-
-func (r *stagedCaptureReadCloser) Read(p []byte) (int, error) {
-	close(r.started)
-	<-r.release
-	return copy(p, r.data), nil
-}
-
-func (*stagedCaptureReadCloser) Close() error { return nil }
-
 type captureReadResult struct {
-	n   int
-	err error
 	buf []byte
+	err error
 }
 
 func readAcrossCaptureStop(t *testing.T, data []byte) captureReadResult {
 	t.Helper()
-	f := &stagedCaptureReadCloser{
-		started: make(chan struct{}),
-		release: make(chan struct{}),
-		data:    data,
+	outputR, outputW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create output pipe: %v", err)
 	}
-	r := &captureReader{f: f}
+	wakeR, wakeW, err := os.Pipe()
+	if err != nil {
+		_ = outputR.Close()
+		_ = outputW.Close()
+		t.Fatalf("create wake pipe: %v", err)
+	}
+	r := &captureReader{f: outputR, keepalive: outputW, wakeR: wakeR, wakeW: wakeW}
 	result := make(chan captureReadResult, 1)
 	go func() {
-		buf := make([]byte, 64)
-		n, err := r.Read(buf)
-		result <- captureReadResult{n: n, err: err, buf: buf}
+		buf, readErr := io.ReadAll(r)
+		result <- captureReadResult{buf: buf, err: readErr}
 	}()
 
-	<-f.started
-	r.stopped.Store(true)
-	close(f.release)
-	return <-result
+	if _, err := outputW.Write(data); err != nil {
+		t.Fatalf("write final output: %v", err)
+	}
+	if err := r.stop(true); err != nil {
+		t.Fatalf("stop capture reader: %v", err)
+	}
+	select {
+	case got := <-result:
+		return got
+	case <-time.After(2 * time.Second):
+		t.Fatal("capture reader did not reach FIFO EOF after graceful stop")
+		return captureReadResult{}
+	}
 }
 
 func TestCaptureReaderPreservesBytesReadAsCloseStarts(t *testing.T) {
 	const finalOutput = "final pane output"
 	got := readAcrossCaptureStop(t, []byte(finalOutput))
-	if string(got.buf[:got.n]) != finalOutput {
-		t.Fatalf("Read data = %q (n=%d), want final pane output %q", got.buf[:got.n], got.n, finalOutput)
+	if string(got.buf) != finalOutput {
+		t.Fatalf("Read data = %q (n=%d), want final pane output %q", got.buf, len(got.buf), finalOutput)
 	}
-	if !errors.Is(got.err, io.EOF) {
-		t.Fatalf("Read error = %v, want io.EOF after returning final pane output", got.err)
-	}
-}
-
-func TestCaptureReaderAbsorbsStopSentinelAfterFinalBytes(t *testing.T) {
-	const finalOutput = "final pane output"
-	got := readAcrossCaptureStop(t, append([]byte(finalOutput), captureStopSentinel))
-	if string(got.buf[:got.n]) != finalOutput {
-		t.Fatalf("Read data = %q (n=%d), want final pane output %q without sentinel", got.buf[:got.n], got.n, finalOutput)
-	}
-	if !errors.Is(got.err, io.EOF) {
-		t.Fatalf("Read error = %v, want io.EOF after returning final pane output", got.err)
+	if got.err != nil {
+		t.Fatalf("ReadAll error = %v", got.err)
 	}
 }
 
-func TestCaptureReaderAbsorbsStopSentinelAlone(t *testing.T) {
-	got := readAcrossCaptureStop(t, []byte{captureStopSentinel})
-	if got.n != 0 {
-		t.Fatalf("Read returned %d sentinel bytes, want none", got.n)
+func TestCaptureReaderPreservesRealTrailingNULAtStop(t *testing.T) {
+	finalOutput := []byte("final pane output\x00")
+	got := readAcrossCaptureStop(t, finalOutput)
+	if !bytes.Equal(got.buf, finalOutput) {
+		t.Fatalf("Read data = %q (n=%d), want raw final pane output %q", got.buf, len(got.buf), finalOutput)
 	}
-	if !errors.Is(got.err, io.EOF) {
-		t.Fatalf("Read error = %v, want io.EOF for the stop sentinel", got.err)
+}
+
+func TestCaptureReaderDrainsMoreThanOneBufferBeforeStop(t *testing.T) {
+	finalOutput := bytes.Repeat([]byte("pane-output-"), 8*1024)
+	got := readAcrossCaptureStop(t, finalOutput)
+	if !bytes.Equal(got.buf, finalOutput) {
+		t.Fatalf("ReadAll returned %d bytes, want all %d final pane bytes", len(got.buf), len(finalOutput))
+	}
+}
+
+func TestCaptureReaderAbortWakesWithExternalWriterStillOpen(t *testing.T) {
+	outputR, outputW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create output pipe: %v", err)
+	}
+	t.Cleanup(func() { _ = outputW.Close() })
+	wakeR, wakeW, err := os.Pipe()
+	if err != nil {
+		_ = outputR.Close()
+		t.Fatalf("create wake pipe: %v", err)
+	}
+	r := &captureReader{f: outputR, wakeR: wakeR, wakeW: wakeW}
+	result := make(chan error, 1)
+	go func() {
+		buf := make([]byte, 1)
+		_, readErr := r.Read(buf)
+		result <- readErr
+	}()
+
+	if err := r.Close(); err != nil {
+		t.Fatalf("close capture reader: %v", err)
+	}
+	select {
+	case err := <-result:
+		if !errors.Is(err, io.EOF) {
+			t.Fatalf("Read error = %v, want EOF from out-of-band abort", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("capture reader stayed blocked with an external writer open")
 	}
 }
 
@@ -176,11 +203,10 @@ func TestTmuxSnapshotRepaintCursorRealTmux(t *testing.T) {
 
 // TestClientlessCaptureCloseWakesBlockedRead is the #1943 gate: tearing down the
 // clientless capture must wake a read loop that is parked inside a blocking
-// read(2) on the pipe-pane FIFO. The FIFO is opened O_RDWR and darwin's kqueue
-// cannot poll fifos, so the fd never enters the netpoller and closing it does
-// not interrupt an in-flight read — before the fix, the teardown join below
-// hangs forever, which is exactly how a session delete wedged the daemon
-// (KillSession → ptyBroker.close blocks on captureMu behind the stuck join).
+// FIFO wait. Darwin's kqueue cannot poll FIFOs through Go's netpoller, and
+// close(2) does not interrupt an in-flight FIFO read. Before the original fix,
+// the teardown join below hung forever and wedged session delete; the current
+// implementation must preserve that wake guarantee while draining to FIFO EOF.
 func TestClientlessCaptureCloseWakesBlockedRead(t *testing.T) {
 	if _, err := exec.LookPath("tmux"); err != nil {
 		t.Skipf("tmux not available: %v", err)
@@ -194,9 +220,7 @@ func TestClientlessCaptureCloseWakesBlockedRead(t *testing.T) {
 		t.Fatalf("start tmux session: %v", err)
 	}
 	// Pane state deliberately ignored: this is #1944's FIFO-wake regression test
-	// tearing down its own fixture session; nothing destructive follows. The second
-	// return is new in this PR (tmux.PaneState) — the production captureReader from
-	// #1944 is untouched, only this call site acknowledges the added value.
+	// tearing down its own fixture session; nothing destructive follows.
 	t.Cleanup(func() { _, _ = ts.Close() })
 
 	ch := newTmuxClientlessChannel(ts)


### PR DESCRIPTION
## Summary

- replace the in-band NUL stop sentinel with FIFO EOF as the successful capture boundary, preserving every raw pane byte and draining tails larger than the broker buffer
- keep the read-only FIFO alive with a private writer until tmux positively disables pipe-pane; only the failed-disable path uses an abort-latched wake byte, which is discarded before it can reach the raw stream
- keep the FIFO descriptor blocking when it is wrapped by Go so Darwin does not route it through kqueue, while retaining close-on-exec descriptor hygiene

## Verification against master

#2204 is real on current master:

- `session/ptychannel_tmux.go:53-55` reads `n` bytes and then returns `(0, io.EOF)` when teardown flips `stopped`, discarding that successful read
- `session/ptychannel_tmux.go:60-65` injects a bare NUL into the same arbitrary byte stream, so the reader cannot distinguish control from real pane output
- `session/ptybroker.go:556-563` reads in 32 KiB chunks, feeds `n > 0`, and exits on any error; reporting EOF on the first post-stop read therefore truncates any larger queued tail

The two late P2 findings share one root: an in-band one-byte marker cannot delimit an arbitrary raw stream. Successful teardown now uses FIFO EOF, which the kernel orders after queued writes. Failed teardown retains a no-hang escape hatch without placing control data on any successful stream.

## Fail-first coverage

- a final pane chunk ending in a real NUL lost that byte before the fix and now round-trips unchanged
- a 98,304-byte final payload stopped after the first `io.ReadAll` buffer before the fix and now drains in full across repeated reads
- an external writer deliberately left open cannot wedge a failed teardown; the already-aborted path wakes and discards its failure-only byte
- the existing real-tmux blocked-read regression remains green, and the focused capture tests pass repeatedly under the race detector
- the full session package passes, and the package cross-compiles for Darwin

The first out-of-band implementation exposed a real macOS failure: Darwin's FIFO writer-close event did not wake the polling read. The final implementation keeps successful reads blocking and lets kernel EOF end them, while preserving an explicit failure-only wake.

## Verification

All required local gates passed after the final commit on pushed SHA `3a1a2ce379eb186089322d2065b6af537ba0d96e` against master `0a9b4d302e6548d9c4f0b5301f17031cd4e49fb7`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh` (`936 Go files checked; 0 grandfathered`)

Closes #2204.

— Captain Claude
