### PR TITLE
test(web): await config save queue completion

### DIFF
--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -6748,6 +6748,7 @@ function createKeyedQueue() {
         tails.delete(key);
       }
     });
+    return next;
   };
 }
 var ConfigPane = class {
@@ -12226,7 +12227,7 @@ function applyConfigValue(key, value) {
   if (tok === null) {
     return;
   }
-  queueConfigSave(key, () => applyConfigValueNow(key, value, tok));
+  void queueConfigSave(key, () => applyConfigValueNow(key, value, tok));
 }
 function applyConfigValueNow(key, value, tok) {
   return setConfigValue(key, value, tok).then((resp) => {

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "71d483dec607";
+const VERSION = "5730bc93f6ab";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/src/config.test.ts
+++ b/web/src/config.test.ts
@@ -180,18 +180,27 @@ test("saves for one key run in the order the user made them, however slow the ne
   const finished: string[] = [];
   const queue = createKeyedQueue();
 
-  // The first save is slow, the second fast — unqueued, the second would finish
-  // first and lose.
-  const delays: Record<string, number> = { off: 30, on: 0 };
+  // Hold the first save behind a gate, without relying on a timer. Unqueued, the
+  // second would finish first and lose.
+  let releaseOff = () => {};
+  const offBlocked = new Promise<void>((resolve) => {
+    releaseOff = resolve;
+  });
   const save = (v: string) => async () => {
     started.push(v);
-    await new Promise((r) => setTimeout(r, delays[v]));
+    if (v === "off") {
+      await offBlocked;
+    }
     finished.push(v);
   };
 
-  queue("auto_yes", save("off"));
-  queue("auto_yes", save("on"));
-  await new Promise((r) => setTimeout(r, 80));
+  const offDone = queue("auto_yes", save("off"));
+  const onDone = queue("auto_yes", save("on"));
+  await Promise.resolve();
+
+  assert.deepEqual(started, ["off"], "the second save must not start while the first is blocked");
+  releaseOff();
+  await Promise.all([offDone, onDone]);
 
   assert.deepEqual(started, ["off", "on"], "the second save must not start until the first settles");
   assert.deepEqual(finished, ["off", "on"], "the LAST value the user chose must be the last one written");
@@ -201,13 +210,13 @@ test("a rejected save does not wedge the queue for that key", async () => {
   const finished: string[] = [];
   const queue = createKeyedQueue();
 
-  queue("update_channel", async () => {
+  const rejectedDone = queue("update_channel", async () => {
     throw new Error('update_channel must be one of [stable, preview], got "nightly"');
   });
-  queue("update_channel", async () => {
+  const previewDone = queue("update_channel", async () => {
     finished.push("preview");
   });
-  await new Promise((r) => setTimeout(r, 20));
+  await Promise.all([rejectedDone, previewDone]);
 
   assert.deepEqual(finished, ["preview"], "a refused value must not block the user's next attempt on that key");
 });
@@ -217,14 +226,22 @@ test("different keys are not queued behind each other", async () => {
   const queue = createKeyedQueue();
 
   // A slow save on one key must not hold up an unrelated one.
-  queue("listen_addr", async () => {
-    await new Promise((r) => setTimeout(r, 40));
+  let releaseListen = () => {};
+  const listenBlocked = new Promise<void>((resolve) => {
+    releaseListen = resolve;
+  });
+  const listenDone = queue("listen_addr", async () => {
+    await listenBlocked;
     finished.push("listen_addr");
   });
-  queue("auto_yes", async () => {
+  const autoYesDone = queue("auto_yes", async () => {
     finished.push("auto_yes");
   });
-  await new Promise((r) => setTimeout(r, 80));
+  await Promise.resolve();
+
+  assert.deepEqual(finished, ["auto_yes"], "an unrelated key must finish while listen_addr is blocked");
+  releaseListen();
+  await Promise.all([listenDone, autoYesDone]);
 
   assert.deepEqual(finished, ["auto_yes", "listen_addr"], "keys have no ordering relationship; they must not block each other");
 });

--- a/web/src/config.ts
+++ b/web/src/config.ts
@@ -132,8 +132,11 @@ export function canCommit(shown: string, current: string): boolean {
  * Per KEY, not global: two different keys have no ordering relationship, and
  * queueing them behind each other would make a slow write block an unrelated one
  * for no gain.
+ *
+ * The returned promise settles when this queued run settles (and never rejects),
+ * giving tests and other completion-sensitive callers a deterministic barrier.
  */
-export function createKeyedQueue(): (key: string, run: () => Promise<void>) => void {
+export function createKeyedQueue(): (key: string, run: () => Promise<void>) => Promise<void> {
   const tails = new Map<string, Promise<void>>();
   return (key, run) => {
     const prev = tails.get(key) ?? Promise.resolve();
@@ -153,6 +156,7 @@ export function createKeyedQueue(): (key: string, run: () => Promise<void>) => v
         tails.delete(key);
       }
     });
+    return next;
   };
 }
 

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -1054,7 +1054,7 @@ function applyConfigValue(key: string, value: string): void {
   if (tok === null) {
     return;
   }
-  queueConfigSave(key, () => applyConfigValueNow(key, value, tok));
+  void queueConfigSave(key, () => applyConfigValueNow(key, value, tok));
 }
 
 function applyConfigValueNow(key: string, value: string, tok: string): Promise<void> {


### PR DESCRIPTION
## Summary

- return a non-rejecting completion promise from the per-key config save queue
- keep the production config-save caller explicitly fire-and-forget
- replace fixed assertion sleeps with controlled promise gates and queue completion awaits
- rebuild the committed web bundle

## Root cause

The save-order test slept for a fixed 80 ms and assumed the test runner had scheduled both timer callbacks and promise continuations by then. Under load, elapsed wall time did not guarantee queue completion, so the assertion could observe only the first save on an unchanged commit.

## Validation

Regression proof: with only the test changed to await queue completion, the old API resolved immediately and failed with actual `[`off`]`; after the queue returned its tail promise, the same test passed.

Exact pushed head: `89d801347dad9d53c158001ae31e89fdb6ef8d26`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `make web-test` (401 tests)
- `make web-build` (committed bundle reproducible after rebase)

Fixes #2275