### PR TITLE
use sentence case for TUI titles

### DIFF
--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -140,7 +140,7 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				selectedIdx = i
 			}
 		}
-		m.selectionOverlay = overlay.NewSelectionOverlay("Select Program", items)
+		m.selectionOverlay = overlay.NewSelectionOverlay("Select program", items)
 		m.selectionOverlay.SetWidth(40)
 		m.selectionOverlay.SetSelectedIndex(selectedIdx)
 		m.layoutSelectionOverlay()

--- a/app/handle_input_test.go
+++ b/app/handle_input_test.go
@@ -86,6 +86,20 @@ func TestHandleMenuHighlightingDoesNotInterceptNamingText(t *testing.T) {
 	assert.Nil(t, cmd)
 }
 
+func TestNamingProgramPickerTitleUsesSentenceCase(t *testing.T) {
+	h := newTestHome(t)
+	resizeHome(h, 80, 24)
+	_, _ = h.startNewInstance(false)
+	require.Equal(t, stateNew, h.state)
+
+	_, _ = h.handleStateNew(tea.KeyMsg{Type: tea.KeyTab})
+
+	require.Equal(t, stateSelectProgram, h.state)
+	require.NotNil(t, h.selectionOverlay)
+	assert.Contains(t, h.selectionOverlay.Render(), "Select program")
+	assert.NotContains(t, h.selectionOverlay.Render(), "Select Program")
+}
+
 // TestHandleMenuHighlightingNewInstanceActions is the regression guard for
 // issue #691/#1413: pressing Enter, Tab, Shift-Tab, or Esc while naming a new
 // instance must drive the menu highlight animation. The bug (commit f294e5b)

--- a/app/handle_overlay_test.go
+++ b/app/handle_overlay_test.go
@@ -25,7 +25,7 @@ import (
 func TestHandleStateSelectProgramSelectsEnum(t *testing.T) {
 	h := newTestHome(t)
 	h.program = tmux.ProgramClaude
-	h.selectionOverlay = overlay.NewSelectionOverlay("Select Program", tmux.SupportedPrograms)
+	h.selectionOverlay = overlay.NewSelectionOverlay("Select program", tmux.SupportedPrograms)
 	h.selectionOverlay.SetSelectedIndex(0) // claude
 	h.state = stateSelectProgram
 
@@ -40,7 +40,7 @@ func TestHandleStateSelectProgramSelectsEnum(t *testing.T) {
 func TestHandleStateSelectProgramSwitchesAgent(t *testing.T) {
 	h := newTestHome(t)
 	h.program = tmux.ProgramClaude
-	h.selectionOverlay = overlay.NewSelectionOverlay("Select Program", tmux.SupportedPrograms)
+	h.selectionOverlay = overlay.NewSelectionOverlay("Select program", tmux.SupportedPrograms)
 	// Walk to codex (index 1 in SupportedPrograms).
 	h.selectionOverlay.SetSelectedIndex(1)
 	h.state = stateSelectProgram

--- a/app/help.go
+++ b/app/help.go
@@ -206,7 +206,7 @@ func (h helpTypeInstanceStart) toContent() string {
 		tabHelp = keyStyle.Render("1-9 jump") + descStyle.Render(fmt.Sprintf(" - Select a tab (%s opens it; tabs live in the tree)", openPane))
 	}
 	content := lipgloss.JoinVertical(lipgloss.Left,
-		titleStyle.Render("Instance Created"),
+		titleStyle.Render("Instance created"),
 		"",
 		descStyle.Render("New session created:"),
 		descStyle.Render(fmt.Sprintf("• Git branch: %s (isolated worktree)",
@@ -246,7 +246,7 @@ func (h helpTypeInstanceAttach) toContent() string {
 
 func (h helpTypeInteractive) toContent() string {
 	content := lipgloss.JoinVertical(lipgloss.Left,
-		titleStyle.Render("Interactive Pane"),
+		titleStyle.Render("Interactive pane"),
 		"",
 		descStyle.Render("You are typing INTO this pane's terminal: every key — including tab —"),
 		descStyle.Render("goes to the agent/shell. The pane's frame turns green while it has the"),

--- a/app/help_test.go
+++ b/app/help_test.go
@@ -84,6 +84,26 @@ func TestInstanceStartHelpShowsFirstRunActionsAndGenericAgentCopy(t *testing.T) 
 	}
 }
 
+func TestFirstRunHelpTitlesUseSentenceCase(t *testing.T) {
+	local := newStartedInstance(t, "local")
+	tests := []struct {
+		name    string
+		content string
+		want    string
+		old     string
+	}{
+		{"instance created", helpStart(local).toContent(), "Instance created", "Instance Created"},
+		{"attach", helpTypeInstanceAttach{}.toContent(), "Attaching to instance", "Attaching to Instance"},
+		{"interactive pane", helpTypeInteractive{}.toContent(), "Interactive pane", "Interactive Pane"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Contains(t, tc.content, tc.want)
+			require.NotContains(t, tc.content, tc.old)
+		})
+	}
+}
+
 func TestInstanceAttachHelpShowsProceedCancelAndDetach(t *testing.T) {
 	content := helpTypeInstanceAttach{}.toContent()
 

--- a/app/layout_cutover_test.go
+++ b/app/layout_cutover_test.go
@@ -185,8 +185,9 @@ func TestLayoutCutover_EnterOpensTaskInEditMode(t *testing.T) {
 
 	view := h.View()
 	requireViewSized(t, view, 100, 30)
-	assert.Contains(t, view, "Edit Task 2",
+	assert.Contains(t, view, "Edit task 2",
 		"the overlay opens the cursor's task straight into its edit form")
+	assert.NotContains(t, view, "Edit Task 2")
 	assert.Contains(t, view, "beta-task", "the form is prefilled with the selected task")
 	assert.Contains(t, view, "run now",
 		"the first edit screen must keep the documented run-now path visible (#1288)")
@@ -282,6 +283,8 @@ func TestLayoutCutover_TaskKeysOpenOverlay(t *testing.T) {
 
 	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
 	assert.True(t, h.automations.TaskPane().IsCreating(), "n inside the overlay opens the create form")
+	assert.Contains(t, h.View(), "New task", "the create-form title follows the sentence-case convention")
+	assert.NotContains(t, h.View(), "New Task")
 }
 
 // TestE2E_LayoutCutover_FocusRingAndHooksOverlay drives the real tea.Program

--- a/app/mouse_test.go
+++ b/app/mouse_test.go
@@ -903,7 +903,7 @@ func TestMouse_SelectionOverlayRowClick(t *testing.T) {
 	newFakeClock(h)
 	// The submit handler maps the row index into tmux.SupportedPrograms, so
 	// the overlay must carry the real list (as handleStateNew builds it).
-	h.selectionOverlay = overlay.NewSelectionOverlay("Select Program", tmux.SupportedPrograms)
+	h.selectionOverlay = overlay.NewSelectionOverlay("Select program", tmux.SupportedPrograms)
 	h.selectionOverlay.SetWidth(60)
 	h.state = stateSelectProgram
 

--- a/app/tinyclip_overlay_test.go
+++ b/app/tinyclip_overlay_test.go
@@ -103,7 +103,7 @@ func TestTinyClipTasksOverlayFits(t *testing.T) {
 	// #1431 property this test pins. The marker is `↓ more` rather than the
 	// `↑ more` this asserted before #1821: at 40x10 the overlay is now
 	// full-screen, so the form has the terminal's whole height instead of 60%
-	// of it, and the top of the form (New Task / Essentials / the focused Name
+	// of it, and the top of the form (New task / Essentials / the focused Name
 	// field) now fits without scrolling off the top. Strictly more of the form
 	// is visible; the hidden remainder moved below the window, so the marker
 	// moved with it. `↑`/`↓` marker semantics are pinned directly, and

--- a/docs/tui-manual-testing.md
+++ b/docs/tui-manual-testing.md
@@ -288,7 +288,7 @@ af_boot
 af_ensure_nav; af_focus_tree
 af_send n; af_wait_for 'submit name'
 af_wait_for 'initial prompt'                  # the field is advertised
-af_send Tab; af_wait_for 'Select Program'     # sibling field still opens
+af_send Tab; af_wait_for 'Select program'     # sibling field still opens
 af_send Escape; af_wait_for 'submit name'
 af_send BTab; af_wait_for 'enter newline'     # shift+tab opens the field
 af_send_literal 'first line'; af_send Enter   # enter is a NEWLINE here…

--- a/scripts/tui-driver.sh
+++ b/scripts/tui-driver.sh
@@ -984,8 +984,8 @@ af_add_task() {
     af_open_tasks || return 1
     af_send n
     # Sync on the form title, not the footer: the footer's "enter create" hint
-    # collapses away at a narrow overlay width, but "New Task" is always shown.
-    af_wait_for 'New Task' "$AF_DRIVER_TIMEOUT" 'task create form' || return 1
+    # collapses away at a narrow overlay width, but "New task" is always shown.
+    af_wait_for 'New task' "$AF_DRIVER_TIMEOUT" 'task create form' || return 1
     af_send_literal "$name"
     af_send Tab                    # name -> trigger selector (cron is default)
     af_send Tab                    # -> trigger value (cron expression)

--- a/ui/overlay/modal_opacity_test.go
+++ b/ui/overlay/modal_opacity_test.go
@@ -151,7 +151,7 @@ func taskEditModal(t *testing.T, frameW, frameH int) string {
 	return style.Render(pane.String())
 }
 
-// taskCreateModal renders the real "New Task" form (the `n` path) in the same
+// taskCreateModal renders the real "New task" form (the `n` path) in the same
 // frame, so the adjacent-surface audit covers create as well as edit.
 func taskCreateModal(t *testing.T, frameW, frameH int) string {
 	t.Helper()

--- a/ui/overlay/zones_test.go
+++ b/ui/overlay/zones_test.go
@@ -90,7 +90,7 @@ func TestConfirmationOverlayZonesFollowCustomKeys(t *testing.T) {
 
 func TestSelectionOverlayRegistersRowZones(t *testing.T) {
 	items := []string{"claude", "aider", "codex"}
-	s := NewSelectionOverlay("Select Program", items)
+	s := NewSelectionOverlay("Select program", items)
 	s.SetWidth(50)
 	reg := zones.NewRegistry()
 	origin := layout.Point{X: 8, Y: 4}

--- a/ui/task_pane_edit.go
+++ b/ui/task_pane_edit.go
@@ -295,10 +295,10 @@ func (s *TaskPane) renderEditMode() string {
 	}
 
 	if s.creating {
-		b.WriteString(editTitleStyle.Render("New Task"))
+		b.WriteString(editTitleStyle.Render("New task"))
 	} else {
 		tsk := s.tasks[s.selectedIdx]
-		b.WriteString(editTitleStyle.Render(fmt.Sprintf("Edit Task %s", tsk.ID)))
+		b.WriteString(editTitleStyle.Render(fmt.Sprintf("Edit task %s", tsk.ID)))
 	}
 	b.WriteString("\n")
 


### PR DESCRIPTION
## Summary

- change the five remaining reported TUI titles to sentence case: `New task`, `Edit task`, `Instance created`, `Interactive pane`, and `Select program`
- keep the already-correct `Attaching to instance` title and cover it in the same regression table
- update the deterministic driver, manual test recipe, and production-path render assertions to use the canonical copy

## Root cause

These overlays were added with independent static title strings, so five retained Title Case despite the repository-wide sentence-case convention in `CLAUDE.md`. The sixth title listed in the issue had already been corrected on current master.

## Regression proof

Before the string changes, the new production-render assertions failed on all five current violations. The program-picker test is sized through the real 80×24 layout path so it sees the actual title rather than passing or failing on a clipped ellipsis. After the change, each assertion requires the sentence-case title and rejects its old Title Case form.

## Rendered TUI validation

On the exact head, each changed title was opened through its real key path and checked at both 80×24 and 60×18:

- task create and edit forms
- program picker
- first-session help
- first interactive-pane help

The one-time help flags were reset between relaunches so both help overlays were genuinely rendered. The deterministic TUI driver self-test also passed 61/61 steps.

## Exact-head gates

Commit: `cc22bac53fe0a15299d1ad1f9cc8dcb01723e671`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `make tui-driver-selftest`

Closes #2021

— Captain Claude