### PR TITLE
fix(tmuxguard): inspect command separator chains

### DIFF
--- a/internal/tmuxguard/guard_test.go
+++ b/internal/tmuxguard/guard_test.go
@@ -89,6 +89,7 @@ func TestDenialReason(t *testing.T) {
 		{name: "socket path", command: "tmux -S /tmp/af-test.sock kill-server"},
 		{name: "abbreviated kill on named socket", command: "tmux -L af-test kill-se"},
 		{name: "socket option after command is too late", command: "tmux kill-server -L af-test", wantReason: broadTmuxReason},
+		{name: "attached separator after broad kill", command: `tmux kill-server\; list-sessions`, wantReason: broadTmuxReason},
 		{name: "empty socket", command: `tmux -L '' kill-server`, wantReason: unknownShellReason},
 		{name: "command-local socket-like option does not scope", command: `tmux list-sessions -L fake \; kill-server`, wantReason: broadTmuxReason},
 		{name: "other tmux command", command: "tmux list-sessions"},

--- a/internal/tmuxguard/guard_test.go
+++ b/internal/tmuxguard/guard_test.go
@@ -80,6 +80,7 @@ func TestDenialReason(t *testing.T) {
 		{name: "tmux config option", command: `tmux -f /tmp/tmux.conf list-sessions`, wantReason: unknownShellReason},
 		{name: "tmux run-shell", command: `tmux run-shell 'tmux kill-server'`, wantReason: unknownShellReason},
 		{name: "scoped tmux run-shell", command: `tmux -L af-test run-shell 'printf safe'`, wantReason: unknownShellReason},
+		{name: "tmux command builder after separator", command: `tmux list-sessions \; run-shell 'pkill tmux'`, wantReason: unknownShellReason},
 		{name: "tmux command format", command: `tmux display-message '#(tmux kill-server)'`, wantReason: unknownShellReason},
 		{name: "unscoped state-changing tmux command", command: `tmux new-session`, wantReason: unknownShellReason},
 

--- a/internal/tmuxguard/tmux.go
+++ b/internal/tmuxguard/tmux.go
@@ -7,7 +7,8 @@ func inspectTmux(args []string) string {
 	if err != nil {
 		return unknownShellReason
 	}
-	if tmuxKillServerIsBroad(args[commandAt:], scoped) {
+	commandArgs := args[commandAt:]
+	if tmuxKillServerIsBroad(commandArgs, scoped) {
 		return broadTmuxReason
 	}
 	for _, arg := range args {
@@ -22,17 +23,78 @@ func inspectTmux(args []string) string {
 		return unknownShellReason
 	}
 
-	command := strings.ToLower(args[commandAt])
-	if isKillServerCommand(command) {
-		return "" // A preceding literal -L/-S made this teardown socket-scoped.
-	}
-	if tmuxCommandBuildsCommands(command) {
+	commands, err := splitTmuxCommands(commandArgs)
+	if err != nil {
 		return unknownShellReason
 	}
-	if scoped || safeUnscopedTmuxCommand(command) {
-		return ""
+	for _, words := range commands {
+		command := strings.ToLower(words[0])
+		if isKillServerCommand(command) {
+			continue // A preceding literal -L/-S made this teardown socket-scoped.
+		}
+		if tmuxCommandBuildsCommands(command) {
+			return unknownShellReason
+		}
+		if !scoped && !safeUnscopedTmuxCommand(command) {
+			return unknownShellReason
+		}
 	}
-	return unknownShellReason
+	return ""
+}
+
+// splitTmuxCommands models tmux's command-sequence boundary. Shell quoting is
+// already gone here: an escaped or quoted semicolon reaches tmux as either its
+// own argument or an unescaped suffix. Reject empty sequence elements instead
+// of guessing how a particular tmux version interprets them.
+func splitTmuxCommands(args []string) ([][]string, error) {
+	var commands [][]string
+	var current []string
+	flush := func() error {
+		if len(current) == 0 {
+			return errUnsupportedShell
+		}
+		commands = append(commands, current)
+		current = nil
+		return nil
+	}
+
+	for _, arg := range args {
+		separator := arg == ";" || hasUnescapedTrailingSemicolon(arg)
+		if separator && arg != ";" {
+			arg = strings.TrimSuffix(arg, ";")
+			if arg == "" || hasUnescapedTrailingSemicolon(arg) {
+				return nil, errUnsupportedShell
+			}
+			current = append(current, arg)
+		} else if !separator {
+			current = append(current, arg)
+		}
+		if separator {
+			if err := flush(); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if len(current) > 0 {
+		if err := flush(); err != nil {
+			return nil, err
+		}
+	}
+	if len(commands) == 0 {
+		return nil, errUnsupportedShell
+	}
+	return commands, nil
+}
+
+func hasUnescapedTrailingSemicolon(arg string) bool {
+	if !strings.HasSuffix(arg, ";") {
+		return false
+	}
+	backslashes := 0
+	for i := len(arg) - 2; i >= 0 && arg[i] == '\\'; i-- {
+		backslashes++
+	}
+	return backslashes%2 == 0
 }
 
 func parseTmuxPrefix(args []string) (scoped bool, commandAt int, versionOnly bool, err error) {

--- a/internal/tmuxguard/tmux.go
+++ b/internal/tmuxguard/tmux.go
@@ -30,7 +30,10 @@ func inspectTmux(args []string) string {
 	for _, words := range commands {
 		command := strings.ToLower(words[0])
 		if isKillServerCommand(command) {
-			continue // A preceding literal -L/-S made this teardown socket-scoped.
+			if !scoped {
+				return broadTmuxReason
+			}
+			continue
 		}
 		if tmuxCommandBuildsCommands(command) {
 			return unknownShellReason


### PR DESCRIPTION
## What changed

Parse every command in a tmux command sequence instead of authorizing the entire invocation from its first verb. Empty or malformed sequences fail closed. Broad `kill-server` commands are rejected after separator normalization unless the tmux invocation selected an isolated socket. Regressions pin the late P1 finding from merged PR #2239 and the exact-head Codex follow-up.

## Root cause and impact

`inspectTmux` classified only the first tmux command. A read-only first command therefore authorized an unchecked command-builder after tmux's `\;` separator, allowing a nested shell payload to reach the shared host even though the guard was intended to stop that outage class.

The first implementation also scanned for broad kills before stripping an attached separator. A raw `kill-server;` token missed that scan, then normalized to `kill-server` and took the socket-scoped allow branch without checking whether the invocation was actually scoped.

Findings:

- https://github.com/sachiniyer/agent-factory/pull/2239#discussion_r3620419227
- https://github.com/sachiniyer/agent-factory/pull/2308#discussion_r3624818789

## Fail-first reproductions

Both regressions call `DenialReason` with strings only; they do not execute tmux or either payload.

Before the sequence fix on master:

```text
--- FAIL: TestDenialReason/tmux_command_builder_after_separator
DenialReason("tmux list-sessions \\; run-shell 'pkill tmux'") = "", want <denial>
```

Before the exact-head review fix:

```text
--- FAIL: TestDenialReason/attached_separator_after_broad_kill
DenialReason("tmux kill-server\\; list-sessions") = "", want <broad tmux denial>
```

Both focused regressions and the full `internal/tmuxguard` package now pass.

## Validation

All required gates pass on the exact pushed head `0a5393dd71ddbbf66486d31939728f9947c843bb`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (no output)
- `go build ./...`
- `make test-container`

The two distinct remaining P1s are tracked separately in #2304 and #2305.

— master-health watch