### PR TITLE
fix(runtime): keep Codex model through safety checks (#2181)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,6 +83,13 @@ pane_border_preview = "#DC8CC3"
 | `theme` | Optional TUI color table. Defaults to a Zenburn-derived palette and validates each value as `#RRGGBB`; invalid values fall back to the corresponding default with a warning. See [Theme colors](#theme-colors-theme). |
 | `keys` | Optional keymap overrides for the TUI. See [Key bindings](#key-bindings-keys). |
 
+Codex's **additional safety checks** model-routing picker is separate from
+`auto_yes` and from approval/sandbox flags. The daemon recognizes the known
+picker, navigates to **Keep waiting** by its label, confirms that row is selected
+before accepting it, and compares Codex's model status line before and after.
+The intervention and verification result are written to `agent-factory.log`; a
+changed picker that af cannot match safely is logged and left untouched.
+
 ### Theme colors (`theme`)
 
 The TUI palette defaults to Zenburn: low-contrast foreground/background colors

--- a/session/tmux/codex_safety.go
+++ b/session/tmux/codex_safety.go
@@ -1,0 +1,370 @@
+package tmux
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+const codexSafetyModelVerificationPolls = 30
+
+const (
+	codexSafetyRetryLabel       = "Retry with a faster model"
+	codexSafetyWaitLabel        = "Keep waiting"
+	codexSafetyDismissWaitLabel = "Dismiss and keep waiting"
+	codexSafetyLearnLabel       = "Learn more"
+)
+
+// codexSafetyBufferingState spans daemon Snapshot polls. Codex replaces its
+// normal composer with the picker, so its default model status line is no
+// longer visible by the time af has to decide. lastModel is therefore learned
+// from normal panes before the picker appears and compared with the first
+// normal footer after it closes.
+type codexSafetyBufferingState struct {
+	lastModel          string
+	expectedModel      string
+	verificationPolls  int
+	awaitingModelCheck bool
+	notified           bool
+}
+
+type codexSafetyDialog struct {
+	labels        []string
+	selectedIndex int
+	targetIndex   int
+	targetLabel   string
+}
+
+type codexPickerOption struct {
+	label    string
+	selected bool
+}
+
+// handleCodexSafetyBuffering detects and dismisses Codex's model-routing
+// picker without making the faster-model action reachable by accident.
+//
+// This is called by CheckAndHandleTrustPrompt on the daemon's continuous poll,
+// against arbitrary visible output. Detection is consequently anchored on the
+// complete dialog chrome, navigation targets the literal label (never its
+// displayed ordinal), and Enter is sent only after a second capture proves the
+// intended row is selected. A later poll compares Codex's default status-line
+// model with the pre-dialog value and surfaces the result in af's log.
+func (t *TmuxSession) handleCodexSafetyBuffering(content string) bool {
+	targetLabel, safetyPromptPresent := codexSafetyPromptTarget(content)
+	dialog, dialogPresent := parseCodexSafetyDialog(content)
+	model := codexStatusLineModel(content)
+	state := &t.codexSafety
+
+	if state.awaitingModelCheck {
+		t.verifyCodexSafetyModel(model, dialogPresent)
+		return false
+	}
+
+	if !dialogPresent {
+		if safetyPromptPresent {
+			if !state.notified {
+				log.WarningLog.Printf(
+					"Codex session %q is stalled on additional safety checks, but af could not safely select %q from the rendered options",
+					t.sanitizedName, targetLabel,
+				)
+				state.notified = true
+			}
+			return false
+		}
+		if model != "" {
+			state.lastModel = model
+		}
+		state.notified = false
+		return false
+	}
+
+	if model != "" {
+		// Some terminal layouts can leave the status line visible below a
+		// picker. Prefer that freshest baseline when it is available.
+		state.lastModel = model
+	}
+	if !state.notified {
+		log.WarningLog.Printf(
+			"Codex session %q hit additional safety checks; selecting %q and preserving the current model",
+			t.sanitizedName, dialog.targetLabel,
+		)
+		state.notified = true
+	}
+
+	keys := navigationKeys(dialog.selectedIndex, dialog.targetIndex)
+	if len(keys) > 0 {
+		if err := t.tapPromptKeys(keys...); err != nil {
+			log.ErrorLog.Printf("could not navigate Codex additional safety checks for session %q: %v", t.sanitizedName, err)
+			return false
+		}
+
+		// Selection is a terminal UI state, not a numbered form value. Read
+		// the pane again and require the literal wait label to own the cursor
+		// before Enter can possibly reach the picker (#2181).
+		selectedContent, err := t.CapturePaneContent()
+		if err != nil {
+			log.ErrorLog.Printf("could not verify Codex additional safety-check selection for session %q: %v", t.sanitizedName, err)
+			return true
+		}
+		selectedDialog, stillPresent := parseCodexSafetyDialog(selectedContent)
+		if !stillPresent {
+			if current := codexStatusLineModel(selectedContent); current != "" {
+				state.lastModel = current
+			}
+			state.notified = false
+			log.InfoLog.Printf("Codex session %q additional safety checks resolved before af accepted a choice", t.sanitizedName)
+			return true
+		}
+		dialog = selectedDialog
+	}
+
+	if dialog.selectedIndex != dialog.targetIndex ||
+		dialog.selectedIndex < 0 || dialog.labels[dialog.selectedIndex] != dialog.targetLabel {
+		log.ErrorLog.Printf(
+			"refusing to accept Codex additional safety checks for session %q: selected row is not %q",
+			t.sanitizedName, dialog.targetLabel,
+		)
+		return true
+	}
+
+	if err := t.tapPromptKeys("Enter"); err != nil {
+		log.ErrorLog.Printf("could not accept Codex additional safety checks for session %q: %v", t.sanitizedName, err)
+		return false
+	}
+	state.expectedModel = state.lastModel
+	state.verificationPolls = 0
+	state.awaitingModelCheck = true
+	return true
+}
+
+func (t *TmuxSession) verifyCodexSafetyModel(model string, dialogPresent bool) {
+	state := &t.codexSafety
+	if dialogPresent || model == "" {
+		state.verificationPolls++
+		if state.verificationPolls < codexSafetyModelVerificationPolls {
+			return
+		}
+		log.WarningLog.Printf(
+			"Codex session %q additional safety checks were answered, but af could not read a post-dialog model footer after %d polls",
+			t.sanitizedName, state.verificationPolls,
+		)
+		state.finishModelVerification(model)
+		return
+	}
+
+	switch {
+	case state.expectedModel == "":
+		log.WarningLog.Printf(
+			"Codex session %q additional safety checks were answered, but af had no pre-dialog model footer to compare with current model %q",
+			t.sanitizedName, model,
+		)
+	case model != state.expectedModel:
+		log.ErrorLog.Printf(
+			"Codex session %q model changed after additional safety checks: before %q, after %q; possible unintended downgrade",
+			t.sanitizedName, state.expectedModel, model,
+		)
+	default:
+		log.InfoLog.Printf(
+			"Codex session %q additional safety checks: verified model unchanged: %s",
+			t.sanitizedName, model,
+		)
+	}
+	state.finishModelVerification(model)
+}
+
+func (s *codexSafetyBufferingState) finishModelVerification(model string) {
+	if model == "" {
+		model = s.lastModel
+	}
+	*s = codexSafetyBufferingState{lastModel: model}
+}
+
+// parseCodexSafetyDialog admits the observed Codex 0.144.6 picker and the
+// current upstream rewording. Both forms require their full prose/chrome plus
+// all three exact actions. The selected and target rows are found by label;
+// numeric prefixes are parsed only as inert picker syntax.
+func parseCodexSafetyDialog(content string) (codexSafetyDialog, bool) {
+	clean := normalizeCodexPane(content)
+	targetLabel, promptPresent := codexSafetyPromptTarget(clean)
+	if !promptPresent {
+		return codexSafetyDialog{}, false
+	}
+
+	// The visible transcript above the modal is arbitrary agent output and can
+	// contain numbered lists. Only the final contiguous numbered block can be
+	// the picker: the recognized modal footer permits no numbered output after
+	// its option rows.
+	var (
+		pickerOptions  []codexPickerOption
+		currentOptions []codexPickerOption
+	)
+	for _, line := range strings.Split(clean, "\n") {
+		label, selected, ok := codexPickerRow(line)
+		if ok {
+			currentOptions = append(currentOptions, codexPickerOption{label: label, selected: selected})
+			continue
+		}
+		if len(currentOptions) > 0 {
+			pickerOptions = append(pickerOptions[:0], currentOptions...)
+			currentOptions = currentOptions[:0]
+		}
+	}
+	if len(currentOptions) > 0 {
+		pickerOptions = append(pickerOptions[:0], currentOptions...)
+	}
+
+	dialog := codexSafetyDialog{selectedIndex: -1, targetIndex: -1, targetLabel: targetLabel}
+	selectedCount := 0
+	for _, option := range pickerOptions {
+		dialog.labels = append(dialog.labels, option.label)
+		idx := len(dialog.labels) - 1
+		if option.selected {
+			dialog.selectedIndex = idx
+			selectedCount++
+		}
+		if option.label == targetLabel {
+			dialog.targetIndex = idx
+		}
+	}
+
+	if selectedCount != 1 || dialog.targetIndex < 0 || len(dialog.labels) != 3 {
+		return codexSafetyDialog{}, false
+	}
+	seen := make(map[string]bool, len(dialog.labels))
+	for _, label := range dialog.labels {
+		seen[label] = true
+	}
+	if !seen[codexSafetyRetryLabel] || !seen[targetLabel] || !seen[codexSafetyLearnLabel] {
+		return codexSafetyDialog{}, false
+	}
+	return dialog, true
+}
+
+// codexSafetyPromptTarget recognizes the whole modal shell independently from
+// its option rows. That lets af surface a changed/unhandled picker without
+// injecting any key, while parseCodexSafetyDialog remains the stricter action
+// gate. The unique footer must end the visible pane, apart from the one normal
+// Codex model status line that some terminal layouts retain below the picker.
+// Any other trailing output rejects the capture.
+func codexSafetyPromptTarget(content string) (string, bool) {
+	clean := normalizeCodexPane(content)
+	flat := strings.Join(strings.Fields(clean), " ")
+	const oldMessage = "Additional safety checks This request requires additional safety checks, which can take extra time. Hang tight or retry with a faster model for a quicker response, though it may be less capable of handling complex requests."
+	const oldFooter = "Press enter to confirm or esc to go back"
+	if strings.Contains(flat, oldMessage) && codexSafetyFooterEndsPane(clean, flat, oldFooter) {
+		return codexSafetyWaitLabel, true
+	}
+
+	const newMessage = "Our systems are thinking a bit more about this request before responding. Hang tight or retry with a faster model for a quicker response, though it may be less capable of handling complex requests."
+	const newFooter = "No action is required. Codex will keep waiting, and this menu will close when the response is ready."
+	if strings.Contains(flat, newMessage) && codexSafetyFooterEndsPane(clean, flat, newFooter) {
+		return codexSafetyDismissWaitLabel, true
+	}
+	return "", false
+}
+
+func codexSafetyFooterEndsPane(clean, flat, footer string) bool {
+	if strings.HasSuffix(flat, footer) {
+		return true
+	}
+
+	lines := strings.Split(clean, "\n")
+	for idx := len(lines) - 1; idx >= 0; idx-- {
+		statusLine := strings.TrimSpace(lines[idx])
+		if statusLine == "" {
+			continue
+		}
+		if codexStatusLineModel(statusLine) == "" {
+			return false
+		}
+		status := strings.Join(strings.Fields(statusLine), " ")
+		return strings.HasSuffix(flat, footer+" "+status)
+	}
+	return false
+}
+
+func codexPickerRow(line string) (label string, selected bool, ok bool) {
+	line = strings.TrimSpace(line)
+	if strings.HasPrefix(line, "›") {
+		selected = true
+		line = strings.TrimSpace(strings.TrimPrefix(line, "›"))
+	}
+	dot := strings.Index(line, ". ")
+	if dot <= 0 {
+		return "", false, false
+	}
+	for _, r := range line[:dot] {
+		if r < '0' || r > '9' {
+			return "", false, false
+		}
+	}
+	label = strings.TrimSpace(line[dot+2:])
+	return label, selected, label != ""
+}
+
+func navigationKeys(selected, target int) []string {
+	if selected < 0 || target < 0 || selected == target {
+		return nil
+	}
+	key, count := "Down", target-selected
+	if count < 0 {
+		key, count = "Up", -count
+	}
+	keys := make([]string, count)
+	for idx := range keys {
+		keys[idx] = key
+	}
+	return keys
+}
+
+// codexStatusLineModel reads Codex's default `model-with-reasoning ·
+// current-dir` status line. Requiring the path-shaped second segment and
+// searching only the bottom few visible rows avoids learning a model from
+// ordinary transcript prose that happens to contain a middle dot.
+func codexStatusLineModel(content string) string {
+	lines := strings.Split(normalizeCodexPane(content), "\n")
+	seen := 0
+	for idx := len(lines) - 1; idx >= 0 && seen < 6; idx-- {
+		line := strings.TrimSpace(lines[idx])
+		if line == "" {
+			continue
+		}
+		seen++
+		parts := strings.Split(line, " · ")
+		if len(parts) < 2 {
+			continue
+		}
+		directory := strings.TrimSpace(parts[1])
+		if directory != "~" && !strings.HasPrefix(directory, "~/") && !strings.HasPrefix(directory, "/") {
+			continue
+		}
+		model := strings.TrimSpace(parts[0])
+		if model != "" && !strings.ContainsAny(model, "›\r\n") {
+			return model
+		}
+	}
+	return ""
+}
+
+func normalizeCodexPane(content string) string {
+	return ansiCSISequence.ReplaceAllString(strings.ReplaceAll(content, "\r\n", "\n"), "")
+}
+
+func (t *TmuxSession) tapPromptKeys(keys ...string) error {
+	ctx, cancel := tmuxTimeoutContext()
+	defer cancel()
+	args := []string{"send-keys", "-t", exactTarget(t.sanitizedName)}
+	args = append(args, keys...)
+	if err := t.runTmuxBounded(ctx, args...); err != nil {
+		joined := strings.Join(keys, " ")
+		if ctx.Err() != nil {
+			return fmt.Errorf("%w: send-keys %s after %s", ErrTmuxTimeout, joined, tmuxCommandTimeout)
+		}
+		if !t.ExistsOrUnknown() {
+			return fmt.Errorf("%w: send-keys %s", ErrSessionGone, joined)
+		}
+		return fmt.Errorf("error sending %s keystroke(s): %w", joined, err)
+	}
+	return nil
+}

--- a/session/tmux/codex_safety.go
+++ b/session/tmux/codex_safety.go
@@ -51,14 +51,17 @@ type codexPickerOption struct {
 // intended row is selected. A later poll compares Codex's default status-line
 // model with the pre-dialog value and surfaces the result in af's log.
 func (t *TmuxSession) handleCodexSafetyBuffering(content string) bool {
-	targetLabel, safetyPromptPresent := codexSafetyPromptTarget(content)
-	dialog, dialogPresent := parseCodexSafetyDialog(content)
+	targetLabel, safetyPromptPresent, safetyPromptActive := t.inspectCodexSafetyPrompt(content)
+	dialog, dialogPresent := parseCodexSafetyDialog(content, targetLabel, safetyPromptActive)
 	model := codexStatusLineModel(content)
 	state := &t.codexSafety
 
 	if state.awaitingModelCheck {
 		t.verifyCodexSafetyModel(model, dialogPresent)
-		return false
+		// Startup treats false as permission to deliver the queued prompt. The
+		// accepted picker can take another frame to close, so keep blocking while
+		// its live modal shell remains visible.
+		return safetyPromptPresent
 	}
 
 	if !dialogPresent {
@@ -70,7 +73,7 @@ func (t *TmuxSession) handleCodexSafetyBuffering(content string) bool {
 				)
 				state.notified = true
 			}
-			return false
+			return true
 		}
 		if model != "" {
 			state.lastModel = model
@@ -96,7 +99,7 @@ func (t *TmuxSession) handleCodexSafetyBuffering(content string) bool {
 	if len(keys) > 0 {
 		if err := t.tapPromptKeys(keys...); err != nil {
 			log.ErrorLog.Printf("could not navigate Codex additional safety checks for session %q: %v", t.sanitizedName, err)
-			return false
+			return true
 		}
 
 		// Selection is a terminal UI state, not a numbered form value. Read
@@ -107,8 +110,16 @@ func (t *TmuxSession) handleCodexSafetyBuffering(content string) bool {
 			log.ErrorLog.Printf("could not verify Codex additional safety-check selection for session %q: %v", t.sanitizedName, err)
 			return true
 		}
-		selectedDialog, stillPresent := parseCodexSafetyDialog(selectedContent)
+		selectedTarget, selectedPromptPresent, selectedPromptActive := t.inspectCodexSafetyPrompt(selectedContent)
+		selectedDialog, stillPresent := parseCodexSafetyDialog(selectedContent, selectedTarget, selectedPromptActive)
 		if !stillPresent {
+			if selectedPromptPresent {
+				log.ErrorLog.Printf(
+					"refusing to accept Codex additional safety checks for session %q: could not prove the selected row while the picker remained visible",
+					t.sanitizedName,
+				)
+				return true
+			}
 			if current := codexStatusLineModel(selectedContent); current != "" {
 				state.lastModel = current
 			}
@@ -130,7 +141,7 @@ func (t *TmuxSession) handleCodexSafetyBuffering(content string) bool {
 
 	if err := t.tapPromptKeys("Enter"); err != nil {
 		log.ErrorLog.Printf("could not accept Codex additional safety checks for session %q: %v", t.sanitizedName, err)
-		return false
+		return true
 	}
 	state.expectedModel = state.lastModel
 	state.verificationPolls = 0
@@ -184,10 +195,9 @@ func (s *codexSafetyBufferingState) finishModelVerification(model string) {
 // current upstream rewording. Both forms require their full prose/chrome plus
 // all three exact actions. The selected and target rows are found by label;
 // numeric prefixes are parsed only as inert picker syntax.
-func parseCodexSafetyDialog(content string) (codexSafetyDialog, bool) {
+func parseCodexSafetyDialog(content, targetLabel string, promptActive bool) (codexSafetyDialog, bool) {
 	clean := normalizeCodexPane(content)
-	targetLabel, promptPresent := codexSafetyPromptTarget(clean)
-	if !promptPresent {
+	if !promptActive {
 		return codexSafetyDialog{}, false
 	}
 
@@ -239,6 +249,27 @@ func parseCodexSafetyDialog(content string) (codexSafetyDialog, bool) {
 		return codexSafetyDialog{}, false
 	}
 	return dialog, true
+}
+
+// inspectCodexSafetyPrompt separates transcript text that quotes the picker
+// from Codex's active bottom-pane ListSelectionView. Upstream's selection view
+// implements no cursor position, so Codex hides the terminal cursor while it is
+// active; the ordinary composer exposes one. The exact dialog shell remains a
+// fail-closed startup blocker if the cursor query fails, but it is never
+// actionable without the positive hidden-cursor signal.
+func (t *TmuxSession) inspectCodexSafetyPrompt(content string) (targetLabel string, promptPresent, promptActive bool) {
+	targetLabel, candidate := codexSafetyPromptTarget(content)
+	if !candidate {
+		return "", false, false
+	}
+	cursor, err := t.readPaneCursorState()
+	if err != nil {
+		return targetLabel, true, false
+	}
+	if cursor.Visible {
+		return "", false, false
+	}
+	return targetLabel, true, true
 }
 
 // codexSafetyPromptTarget recognizes the whole modal shell independently from

--- a/session/tmux/codex_safety.go
+++ b/session/tmux/codex_safety.go
@@ -258,7 +258,7 @@ func parseCodexSafetyDialog(content, targetLabel string, promptActive bool) (cod
 // fail-closed startup blocker if the cursor query fails, but it is never
 // actionable without the positive hidden-cursor signal.
 func (t *TmuxSession) inspectCodexSafetyPrompt(content string) (targetLabel string, promptPresent, promptActive bool) {
-	targetLabel, candidate := codexSafetyPromptTarget(content)
+	targetLabel, candidate := codexSafetyPromptCandidate(content)
 	if !candidate {
 		return "", false, false
 	}
@@ -272,30 +272,31 @@ func (t *TmuxSession) inspectCodexSafetyPrompt(content string) (targetLabel stri
 	return targetLabel, true, true
 }
 
-// codexSafetyPromptTarget recognizes the whole modal shell independently from
-// its option rows. That lets af surface a changed/unhandled picker without
-// injecting any key, while parseCodexSafetyDialog remains the stricter action
-// gate. The unique footer must end the visible pane, apart from the one normal
-// Codex model status line that some terminal layouts retain below the picker.
-// Any other trailing output rejects the capture.
-func codexSafetyPromptTarget(content string) (string, bool) {
+// codexSafetyPromptCandidate recognizes picker-shaped text independently from
+// its option rows. It deliberately does not claim the picker is active: quoted
+// transcript can have the same shell, so inspectCodexSafetyPrompt separately
+// requires Codex's hidden-cursor modal state before allowing input. The unique
+// footer must end the visible pane, apart from the one normal Codex model
+// status line that some terminal layouts retain below the picker. Any other
+// trailing output rejects the capture.
+func codexSafetyPromptCandidate(content string) (string, bool) {
 	clean := normalizeCodexPane(content)
 	flat := strings.Join(strings.Fields(clean), " ")
 	const oldMessage = "Additional safety checks This request requires additional safety checks, which can take extra time. Hang tight or retry with a faster model for a quicker response, though it may be less capable of handling complex requests."
 	const oldFooter = "Press enter to confirm or esc to go back"
-	if strings.Contains(flat, oldMessage) && codexSafetyFooterEndsPane(clean, flat, oldFooter) {
+	if strings.Contains(flat, oldMessage) && codexSafetyCandidateFooterEndsPane(clean, flat, oldFooter) {
 		return codexSafetyWaitLabel, true
 	}
 
 	const newMessage = "Our systems are thinking a bit more about this request before responding. Hang tight or retry with a faster model for a quicker response, though it may be less capable of handling complex requests."
 	const newFooter = "No action is required. Codex will keep waiting, and this menu will close when the response is ready."
-	if strings.Contains(flat, newMessage) && codexSafetyFooterEndsPane(clean, flat, newFooter) {
+	if strings.Contains(flat, newMessage) && codexSafetyCandidateFooterEndsPane(clean, flat, newFooter) {
 		return codexSafetyDismissWaitLabel, true
 	}
 	return "", false
 }
 
-func codexSafetyFooterEndsPane(clean, flat, footer string) bool {
+func codexSafetyCandidateFooterEndsPane(clean, flat, footer string) bool {
 	if strings.HasSuffix(flat, footer) {
 		return true
 	}
@@ -309,8 +310,8 @@ func codexSafetyFooterEndsPane(clean, flat, footer string) bool {
 		if codexStatusLineModel(statusLine) == "" {
 			return false
 		}
-		status := strings.Join(strings.Fields(statusLine), " ")
-		return strings.HasSuffix(flat, footer+" "+status)
+		candidateSuffix := footer + " " + strings.Join(strings.Fields(statusLine), " ")
+		return strings.HasSuffix(flat, candidateSuffix)
 	}
 	return false
 }

--- a/session/tmux/doc_trust_prompt_test.go
+++ b/session/tmux/doc_trust_prompt_test.go
@@ -1,6 +1,7 @@
 package tmux
 
 import (
+	"bytes"
 	"os/exec"
 	"strings"
 	"testing"
@@ -8,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	cmd_test "github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	aflog "github.com/sachiniyer/agent-factory/log"
 )
 
 // The non-Claude branch of CheckAndHandleTrustPrompt dismisses the aider/gemini
@@ -45,6 +47,46 @@ const codexDirectoryTrustDialog = `> You are in /tmp/af-home
 
   Press enter to continue`
 
+const codexSafetyBufferingDialog = `  Additional safety checks
+  This request requires additional safety checks, which can take extra time.
+  Hang tight or retry with a faster model for a quicker response, though it
+  may be less capable of handling complex requests.
+
+› 1. Retry with a faster model
+  2. Keep waiting
+  3. Learn more
+  Press enter to confirm or esc to go back`
+
+const codexSafetyBufferingKeepWaitingSelected = `  Additional safety checks
+  This request requires additional safety checks, which can take extra time.
+  Hang tight or retry with a faster model for a quicker response, though it
+  may be less capable of handling complex requests.
+
+  1. Retry with a faster model
+› 2. Keep waiting
+  3. Learn more
+  Press enter to confirm or esc to go back`
+
+const codexCurrentSafetyBufferingDialog = `  Our systems are thinking a bit more about this request before responding.
+  Hang tight or retry with a faster model for a quicker response, though it
+  may be less capable of handling complex requests.
+
+› 1. Retry with a faster model
+  2. Dismiss and keep waiting
+  3. Learn more
+  No action is required. Codex will keep waiting, and this menu will close when
+  the response is ready.`
+
+const codexCurrentSafetyBufferingWaitSelected = `  Our systems are thinking a bit more about this request before responding.
+  Hang tight or retry with a faster model for a quicker response, though it
+  may be less capable of handling complex requests.
+
+  1. Retry with a faster model
+› 2. Dismiss and keep waiting
+  3. Learn more
+  No action is required. Codex will keep waiting, and this menu will close when
+  the response is ready.`
+
 // runTrustPromptCheck drives CheckAndHandleTrustPrompt for a pane running
 // `program` and showing `content`, returning its verdict plus every tmux
 // command it issued.
@@ -59,6 +101,49 @@ func runTrustPromptCheck(t *testing.T, program, content string) (handled bool, c
 	}
 	session := newTmuxSession(toTmuxName("trust", ""), program, NewMockPtyFactory(t), cmdExec)
 	return session.CheckAndHandleTrustPrompt(), cmds
+}
+
+// runTrustPromptSequence feeds one pane capture per Output call while keeping
+// one TmuxSession alive across checks. The safety-buffering path is stateful in
+// production: it remembers the model footer from a normal poll, navigates and
+// re-captures the picker, then verifies the model on a later poll.
+func runTrustPromptSequence(t *testing.T, program string, contents ...string) (*TmuxSession, *[]string) {
+	t.Helper()
+	var (
+		cmds       []string
+		captureIdx int
+	)
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			cmds = append(cmds, strings.Join(c.Args, " "))
+			return nil
+		},
+		OutputFunc: func(*exec.Cmd) ([]byte, error) {
+			require.Less(t, captureIdx, len(contents), "unexpected extra pane capture")
+			content := contents[captureIdx]
+			captureIdx++
+			return []byte(content), nil
+		},
+	}
+	session := newTmuxSession(toTmuxName("trust", ""), program, NewMockPtyFactory(t), cmdExec)
+	return session, &cmds
+}
+
+func captureTrustPromptLogs(t *testing.T) (info, warnings, errors *bytes.Buffer) {
+	t.Helper()
+	info, warnings, errors = &bytes.Buffer{}, &bytes.Buffer{}, &bytes.Buffer{}
+	previousInfo := aflog.InfoLog.Writer()
+	previousWarnings := aflog.WarningLog.Writer()
+	previousErrors := aflog.ErrorLog.Writer()
+	aflog.InfoLog.SetOutput(info)
+	aflog.WarningLog.SetOutput(warnings)
+	aflog.ErrorLog.SetOutput(errors)
+	t.Cleanup(func() {
+		aflog.InfoLog.SetOutput(previousInfo)
+		aflog.WarningLog.SetOutput(previousWarnings)
+		aflog.ErrorLog.SetOutput(previousErrors)
+	})
+	return info, warnings, errors
 }
 
 // sentKeystrokes returns the send-keys commands issued, i.e. the input actually
@@ -78,6 +163,167 @@ func TestCheckAndHandleTrustPrompt_CodexDirectoryDialogIsDismissed(t *testing.T)
 	require.True(t, handled, "the observed Codex directory-trust dialog must be reported handled")
 	require.Contains(t, sentKeystrokes(cmds), "tmux send-keys -t =af_trust: Enter",
 		"the selected 'Yes, continue' option must be accepted before briefing delivery; got %v", cmds)
+}
+
+// Regression for #2181. The daemon's live Snapshot poll calls the real
+// CheckAndHandleTrustPrompt every second. Codex 0.144.6 starts this picker on
+// row 1. Delivering "2" as prompt text can leave that cursor untouched, after
+// which the delivery path's trailing Enter accepts the downgrade. The
+// unattended path must navigate by the literal target label, prove that row is
+// selected before accepting it, and compare the model footer after the modal
+// closes.
+func TestCheckAndHandleTrustPrompt_CodexSafetyBufferingKeepsModel(t *testing.T) {
+	info, warnings, _ := captureTrustPromptLogs(t)
+
+	const normalPane = `• Working
+
+  gpt-5.6-sol max · ~/agent-factory`
+	session, commands := runTrustPromptSequence(t, "/usr/local/bin/codex --profile work",
+		normalPane,
+		codexSafetyBufferingDialog,
+		codexSafetyBufferingKeepWaitingSelected,
+		normalPane,
+	)
+
+	require.False(t, session.CheckAndHandleTrustPrompt(), "a normal Codex pane is not a modal")
+	require.True(t, session.CheckAndHandleTrustPrompt(), "the safety-buffering picker must be handled")
+	require.Equal(t, []string{
+		"tmux send-keys -t =af_trust: Down",
+		"tmux send-keys -t =af_trust: Enter",
+	}, sentKeystrokes(*commands), "navigate to the label, verify it, then accept; never type an ordinal")
+	require.NotContains(t, strings.Join(sentKeystrokes(*commands), "\n"), " 2",
+		"a number key can submit Codex's current cursor row instead of selecting that numbered row")
+	require.False(t, session.CheckAndHandleTrustPrompt(), "verification observes; it does not inject another key")
+	require.Contains(t, warnings.String(), "additional safety checks")
+	require.Contains(t, info.String(), "verified model unchanged: gpt-5.6-sol max")
+}
+
+func TestCheckAndHandleTrustPrompt_CodexSafetyBufferingAcceptsVisibleModelFooter(t *testing.T) {
+	const modelFooter = "  gpt-5.6-sol max · ~/agent-factory"
+	session, commands := runTrustPromptSequence(t, ProgramCodex,
+		modelFooter,
+		codexSafetyBufferingDialog+"\n\n"+modelFooter,
+		codexSafetyBufferingKeepWaitingSelected+"\n\n"+modelFooter,
+	)
+
+	require.False(t, session.CheckAndHandleTrustPrompt())
+	require.True(t, session.CheckAndHandleTrustPrompt(),
+		"the picker remains active when Codex renders its normal model footer beneath it")
+	require.Equal(t, []string{
+		"tmux send-keys -t =af_trust: Down",
+		"tmux send-keys -t =af_trust: Enter",
+	}, sentKeystrokes(*commands))
+}
+
+func TestCheckAndHandleTrustPrompt_CodexSafetyBufferingIgnoresNumberedTranscript(t *testing.T) {
+	const transcript = `• Earlier output included an unrelated list:
+
+  1. inspect the request
+  2. explain the result
+
+`
+	session, commands := runTrustPromptSequence(t, ProgramCodex,
+		"gpt-5.6-sol max · ~/agent-factory",
+		transcript+codexSafetyBufferingDialog,
+		transcript+codexSafetyBufferingKeepWaitingSelected,
+	)
+
+	require.False(t, session.CheckAndHandleTrustPrompt())
+	require.True(t, session.CheckAndHandleTrustPrompt(),
+		"numbered transcript lines above the active modal are not picker options")
+	require.Equal(t, []string{
+		"tmux send-keys -t =af_trust: Down",
+		"tmux send-keys -t =af_trust: Enter",
+	}, sentKeystrokes(*commands))
+}
+
+func TestCheckAndHandleTrustPrompt_CodexSafetyBufferingFindsLabelAfterReorder(t *testing.T) {
+	const reordered = `  Additional safety checks
+  This request requires additional safety checks, which can take extra time.
+  Hang tight or retry with a faster model for a quicker response, though it may be less capable of handling complex requests.
+
+› 1. Retry with a faster model
+  2. Learn more
+  3. Keep waiting
+  Press enter to confirm or esc to go back`
+	const waitSelected = `  Additional safety checks
+  This request requires additional safety checks, which can take extra time.
+  Hang tight or retry with a faster model for a quicker response, though it may be less capable of handling complex requests.
+
+  1. Retry with a faster model
+  2. Learn more
+› 3. Keep waiting
+  Press enter to confirm or esc to go back`
+	session, commands := runTrustPromptSequence(t, ProgramCodex,
+		"gpt-5.6-sol max · ~/agent-factory",
+		reordered,
+		waitSelected,
+	)
+
+	require.False(t, session.CheckAndHandleTrustPrompt())
+	require.True(t, session.CheckAndHandleTrustPrompt())
+	require.Equal(t, []string{
+		"tmux send-keys -t =af_trust: Down Down",
+		"tmux send-keys -t =af_trust: Enter",
+	}, sentKeystrokes(*commands), "the label moved to row 3, so navigation must move with it")
+}
+
+func TestCheckAndHandleTrustPrompt_CurrentCodexSafetyWording(t *testing.T) {
+	session, commands := runTrustPromptSequence(t, ProgramCodex,
+		"gpt-5.6-sol max · ~/agent-factory",
+		codexCurrentSafetyBufferingDialog,
+		codexCurrentSafetyBufferingWaitSelected,
+	)
+
+	require.False(t, session.CheckAndHandleTrustPrompt())
+	require.True(t, session.CheckAndHandleTrustPrompt())
+	require.Equal(t, []string{
+		"tmux send-keys -t =af_trust: Down",
+		"tmux send-keys -t =af_trust: Enter",
+	}, sentKeystrokes(*commands))
+}
+
+func TestCheckAndHandleTrustPrompt_CodexSafetyModelDowngradeIsSurfaced(t *testing.T) {
+	_, _, errors := captureTrustPromptLogs(t)
+	session, _ := runTrustPromptSequence(t, ProgramCodex,
+		"gpt-5.6-sol max · ~/agent-factory",
+		codexSafetyBufferingDialog,
+		codexSafetyBufferingKeepWaitingSelected,
+		"gpt-5.6-luna low · ~/agent-factory",
+	)
+
+	require.False(t, session.CheckAndHandleTrustPrompt())
+	require.True(t, session.CheckAndHandleTrustPrompt())
+	require.False(t, session.CheckAndHandleTrustPrompt())
+	require.Contains(t, errors.String(), `model changed after additional safety checks: before "gpt-5.6-sol max", after "gpt-5.6-luna low"`)
+}
+
+func TestCheckAndHandleTrustPrompt_CodexChangedSafetyPickerIsSurfacedWithoutInput(t *testing.T) {
+	_, warnings, _ := captureTrustPromptLogs(t)
+	changed := strings.Replace(codexSafetyBufferingDialog, "2. Keep waiting", "2. Continue waiting", 1)
+	handled, commands := runTrustPromptCheck(t, ProgramCodex, changed)
+
+	require.False(t, handled, "an unknown action label must stay for a human instead of guessing")
+	require.Empty(t, sentKeystrokes(commands))
+	require.Contains(t, warnings.String(), "could not safely select \"Keep waiting\"")
+}
+
+func TestCheckAndHandleTrustPrompt_CodexSafetyFixtureInOutputInjectsNothing(t *testing.T) {
+	content := codexSafetyBufferingDialog + `
+
+The block above is a fixture quoted in source, not an active picker.`
+	handled, commands := runTrustPromptCheck(t, ProgramCodex, content)
+
+	require.False(t, handled)
+	require.Empty(t, sentKeystrokes(commands), "continued output after the modal footer proves the picker is not active")
+}
+
+func TestCheckAndHandleTrustPrompt_CodexSafetyDialogIsCodexOnly(t *testing.T) {
+	for _, program := range []string{ProgramClaude, ProgramAider, ProgramGemini, ProgramAmp, ProgramOpencode} {
+		handled, commands := runTrustPromptCheck(t, program, codexSafetyBufferingDialog)
+		require.False(t, handled, "%s must not inherit Codex picker behavior", program)
+		require.Empty(t, sentKeystrokes(commands), "%s received Codex-only input", program)
+	}
 }
 
 func TestCheckAndHandleTrustPrompt_CodexTrustProseAloneInjectsNothing(t *testing.T) {

--- a/session/tmux/doc_trust_prompt_test.go
+++ b/session/tmux/doc_trust_prompt_test.go
@@ -4,7 +4,10 @@ import (
 	"bytes"
 	"os/exec"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -97,7 +100,12 @@ func runTrustPromptCheck(t *testing.T, program, content string) (handled bool, c
 			cmds = append(cmds, strings.Join(c.Args, " "))
 			return nil
 		},
-		OutputFunc: func(c *exec.Cmd) ([]byte, error) { return []byte(content), nil },
+		OutputFunc: func(c *exec.Cmd) ([]byte, error) {
+			if strings.Contains(strings.Join(c.Args, " "), "display-message") {
+				return []byte("0 0 0"), nil
+			}
+			return []byte(content), nil
+		},
 	}
 	session := newTmuxSession(toTmuxName("trust", ""), program, NewMockPtyFactory(t), cmdExec)
 	return session.CheckAndHandleTrustPrompt(), cmds
@@ -118,7 +126,12 @@ func runTrustPromptSequence(t *testing.T, program string, contents ...string) (*
 			cmds = append(cmds, strings.Join(c.Args, " "))
 			return nil
 		},
-		OutputFunc: func(*exec.Cmd) ([]byte, error) {
+		OutputFunc: func(c *exec.Cmd) ([]byte, error) {
+			if strings.Contains(strings.Join(c.Args, " "), "display-message") {
+				// Codex's active ListSelectionView has no cursor position, so
+				// the TUI hides the terminal cursor while the picker is open.
+				return []byte("0 0 0"), nil
+			}
 			require.Less(t, captureIdx, len(contents), "unexpected extra pane capture")
 			content := contents[captureIdx]
 			captureIdx++
@@ -303,9 +316,126 @@ func TestCheckAndHandleTrustPrompt_CodexChangedSafetyPickerIsSurfacedWithoutInpu
 	changed := strings.Replace(codexSafetyBufferingDialog, "2. Keep waiting", "2. Continue waiting", 1)
 	handled, commands := runTrustPromptCheck(t, ProgramCodex, changed)
 
-	require.False(t, handled, "an unknown action label must stay for a human instead of guessing")
+	require.True(t, handled,
+		"an active picker that af cannot answer must block startup prompt delivery")
 	require.Empty(t, sentKeystrokes(commands))
 	require.Contains(t, warnings.String(), "could not safely select \"Keep waiting\"")
+}
+
+func TestCheckAndHandleTrustPrompt_CodexSafetyPickerStillVisibleBlocksDelivery(t *testing.T) {
+	session, _ := runTrustPromptSequence(t, ProgramCodex,
+		"gpt-5.6-sol max · ~/agent-factory",
+		codexSafetyBufferingDialog,
+		codexSafetyBufferingKeepWaitingSelected,
+		codexSafetyBufferingKeepWaitingSelected,
+	)
+
+	require.False(t, session.CheckAndHandleTrustPrompt())
+	require.True(t, session.CheckAndHandleTrustPrompt())
+	require.True(t, session.CheckAndHandleTrustPrompt(),
+		"the accepted picker is still visible, so startup must not paste through it")
+}
+
+func TestCheckAndHandleTrustPrompt_QuotedCodexSafetyPickerWithComposerCursorInjectsNothing(t *testing.T) {
+	const modelFooter = "  gpt-5.6-sol max · ~/agent-factory"
+	content := codexSafetyBufferingKeepWaitingSelected + "\n\n" + modelFooter
+	var commands []string
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			commands = append(commands, strings.Join(c.Args, " "))
+			return nil
+		},
+		OutputFunc: func(c *exec.Cmd) ([]byte, error) {
+			if strings.Contains(strings.Join(c.Args, " "), "display-message") {
+				// The ordinary Codex composer owns a visible cursor. The picker
+				// text above is quoted transcript, not the active bottom pane.
+				return []byte("20 0 1"), nil
+			}
+			return []byte(content), nil
+		},
+	}
+	session := newTmuxSession(toTmuxName("trust", ""), ProgramCodex, NewMockPtyFactory(t), cmdExec)
+
+	require.False(t, session.CheckAndHandleTrustPrompt())
+	require.Empty(t, sentKeystrokes(commands),
+		"quoted picker text above a live composer must never receive navigation or Enter")
+}
+
+func TestCheckAndHandleTrustPrompt_SerializesPickerInputWithPromptDelivery(t *testing.T) {
+	var (
+		captureCount atomic.Int32
+		pasted       atomic.Bool
+		loadOnce     sync.Once
+	)
+	selectionCaptureStarted := make(chan struct{})
+	releaseSelectionCapture := make(chan struct{})
+	promptDeliveryStarted := make(chan struct{})
+
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			command := strings.Join(c.Args, " ")
+			if strings.Contains(command, "load-buffer") {
+				loadOnce.Do(func() { close(promptDeliveryStarted) })
+			}
+			if strings.Contains(command, "paste-buffer") {
+				pasted.Store(true)
+			}
+			return nil
+		},
+		OutputFunc: func(c *exec.Cmd) ([]byte, error) {
+			command := strings.Join(c.Args, " ")
+			if strings.Contains(command, "display-message") {
+				return []byte("0 0 0"), nil
+			}
+			switch captureCount.Add(1) {
+			case 1:
+				return []byte(codexSafetyBufferingDialog), nil
+			case 2:
+				close(selectionCaptureStarted)
+				<-releaseSelectionCapture
+				return []byte(codexSafetyBufferingKeepWaitingSelected), nil
+			default:
+				if pasted.Load() {
+					return []byte("concurrent prompt"), nil
+				}
+				return nil, nil
+			}
+		},
+	}
+	session := newTmuxSession(toTmuxName("trust", ""), ProgramCodex, NewMockPtyFactory(t), cmdExec)
+
+	handlerDone := make(chan bool, 1)
+	go func() { handlerDone <- session.CheckAndHandleTrustPrompt() }()
+	select {
+	case <-selectionCaptureStarted:
+	case <-time.After(time.Second):
+		t.Fatal("picker handler did not reach its selection verification capture")
+	}
+
+	deliveryDone := make(chan error, 1)
+	go func() { deliveryDone <- session.SendKeysCommand("concurrent prompt") }()
+	interleaved := false
+	select {
+	case <-promptDeliveryStarted:
+		interleaved = true
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(releaseSelectionCapture)
+
+	select {
+	case handled := <-handlerDone:
+		require.True(t, handled)
+	case <-time.After(time.Second):
+		t.Fatal("picker handler did not finish")
+	}
+	select {
+	case err := <-deliveryDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("prompt delivery did not finish")
+	}
+	require.False(t, interleaved,
+		"prompt delivery started between picker selection and Enter")
 }
 
 func TestCheckAndHandleTrustPrompt_CodexSafetyFixtureInOutputInjectsNothing(t *testing.T) {

--- a/session/tmux/session.go
+++ b/session/tmux/session.go
@@ -59,6 +59,14 @@ type TmuxSession struct {
 	// submit must never clear the first submit's freshly pasted composer while
 	// that first call is still waiting to send Enter (#2178 review).
 	submitMu sync.Mutex
+	// promptMu serializes the daemon poll's capture/navigation/verification
+	// transaction. CheckAndHandleTrustPrompt also runs during startup, and two
+	// callers must never both navigate the same Codex picker (#2181).
+	promptMu sync.Mutex
+	// codexSafety remembers the last normal-pane model footer across polls so a
+	// safety-buffering intervention can prove it did not select the downgrade.
+	// Access only while promptMu is held.
+	codexSafety codexSafetyBufferingState
 	// lastPastedTail is the normalized distinctive tail of the most recent
 	// payload paste that tmux accepted. The next submit may use it only as
 	// provenance for the cleared-composer diagnostic: matching arbitrary pane

--- a/session/tmux/session.go
+++ b/session/tmux/session.go
@@ -55,23 +55,21 @@ type TmuxSession struct {
 	// accessors in program.go (#1254) — never touch these fields directly.
 	program   string
 	programMu sync.RWMutex
-	// submitMu serializes the whole clear → paste → Enter transaction. A second
-	// submit must never clear the first submit's freshly pasted composer while
-	// that first call is still waiting to send Enter (#2178 review).
-	submitMu sync.Mutex
-	// promptMu serializes the daemon poll's capture/navigation/verification
-	// transaction. CheckAndHandleTrustPrompt also runs during startup, and two
-	// callers must never both navigate the same Codex picker (#2181).
-	promptMu sync.Mutex
+	// inputMu serializes every multi-command transaction that injects pane input.
+	// A submit must not clear/paste between a prompt handler's selected-row
+	// capture and Enter, two submits must not clear each other's freshly pasted
+	// composers, and two prompt handlers must not navigate the same picker
+	// concurrently (#2178/#2181).
+	inputMu sync.Mutex
 	// codexSafety remembers the last normal-pane model footer across polls so a
 	// safety-buffering intervention can prove it did not select the downgrade.
-	// Access only while promptMu is held.
+	// Access only while inputMu is held.
 	codexSafety codexSafetyBufferingState
 	// lastPastedTail is the normalized distinctive tail of the most recent
 	// payload paste that tmux accepted. The next submit may use it only as
 	// provenance for the cleared-composer diagnostic: matching arbitrary pane
 	// text is not enough to claim that a prior delivery was stranded (#2225).
-	// Protected by submitMu; it never gates delivery.
+	// Protected by inputMu; it never gates delivery.
 	lastPastedTail string
 	// ptyFactory is used to create a PTY for the tmux session.
 	ptyFactory PtyFactory

--- a/session/tmux/start.go
+++ b/session/tmux/start.go
@@ -196,8 +196,8 @@ func (t *TmuxSession) Start(workDir string) error {
 // CheckAndHandleTrustPrompt checks the pane content once for a trust prompt and dismisses it if found.
 // Returns true if the prompt was found and handled.
 func (t *TmuxSession) CheckAndHandleTrustPrompt() bool {
-	t.promptMu.Lock()
-	defer t.promptMu.Unlock()
+	t.inputMu.Lock()
+	defer t.inputMu.Unlock()
 
 	content, err := t.CapturePaneContent()
 	if err != nil {

--- a/session/tmux/start.go
+++ b/session/tmux/start.go
@@ -196,6 +196,9 @@ func (t *TmuxSession) Start(workDir string) error {
 // CheckAndHandleTrustPrompt checks the pane content once for a trust prompt and dismisses it if found.
 // Returns true if the prompt was found and handled.
 func (t *TmuxSession) CheckAndHandleTrustPrompt() bool {
+	t.promptMu.Lock()
+	defer t.promptMu.Unlock()
+
 	content, err := t.CapturePaneContent()
 	if err != nil {
 		return false
@@ -214,6 +217,9 @@ func (t *TmuxSession) CheckAndHandleTrustPrompt() bool {
 			return true
 		}
 	case ProgramCodex:
+		if t.handleCodexSafetyBuffering(content) {
+			return true
+		}
 		if CodexTrustPromptPresent(content) {
 			if err := t.TapEnter(); err != nil {
 				log.ErrorLog.Printf("could not tap enter on Codex directory-trust screen: %v", err)

--- a/session/tmux/submit.go
+++ b/session/tmux/submit.go
@@ -118,8 +118,8 @@ func pasteBufferName(processToken, sanitizedName string, seq uint64) string {
 // Every pane gets the bracketed paste — there is no per-agent exception list.
 // See sendKeysPasteBuffer for why that is both necessary and safe (#1956).
 func (t *TmuxSession) SendKeysCommand(text string) error {
-	t.submitMu.Lock()
-	defer t.submitMu.Unlock()
+	t.inputMu.Lock()
+	defer t.inputMu.Unlock()
 	return t.sendKeysPasteBuffer(text)
 }
 
@@ -266,7 +266,7 @@ func (t *TmuxSession) sendKeysPasteBuffer(text string) error {
 	// probe's exact completion suffix keeps one source of truth for what tmux was
 	// asked to render. On the next submit it is provenance that distinguishes
 	// prior pasted input from a spinner, footer, or unrelated pane redraw.
-	// submitMu owns the field.
+	// inputMu owns the field.
 	t.lastPastedTail = probe.completion
 
 	// Confirm the paste actually LANDED in the pane before sending Enter, instead


### PR DESCRIPTION
## Summary

- detect the anchored Codex additional-safety-checks picker from the daemon Snapshot path, including the 0.144.6 wording and the current upstream wording
- navigate to the literal Keep waiting action, re-capture the pane to prove that action owns the cursor, and only then send Enter
- remember the pre-dialog Codex model status line, verify the post-dialog model is unchanged, and log both handled and safely-unhandled picker outcomes
- document that this model-routing picker is independent of auto_yes and approval/sandbox flags

## Reproduction

Before the implementation, the production-path regression failed in the isolated container with:

```
--- FAIL: TestCheckAndHandleTrustPrompt_CodexSafetyBufferingKeepsModel
Error: Should be true
the safety-buffering picker must be handled
```

The fixture is the observed pane and matches the official Codex 0.144.6 TUI snapshot. The official picker starts on Retry with a faster model. The regression drives the same `CheckAndHandleTrustPrompt` method that the local agent-server Snapshot calls on every daemon poll, through token-based detection of an override-style Codex command.

## Verification

Regression coverage proves:

- `Down`, verified re-capture, then `Enter`; no numeric key
- literal-label navigation follows Keep waiting when rows reorder
- the current upstream Dismiss and keep waiting wording is handled
- unchanged models are logged; changed models are surfaced as errors
- changed picker actions are logged and left untouched
- quoted fixtures and all non-Codex programs receive no input

Required gates passed on exact pushed head `08483877b29c6347c1e7870a7c4e409dfb6f370e`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (empty)
- `go build ./...`
- `make test-container`

Additional focused checks:

- full `session/tmux` package in the isolated container
- targeted race run for the Codex safety tests

Refs #2181