### PR TITLE
fix(ui): omit fallback logo in narrow panes

### DIFF
--- a/ui/fallback.go
+++ b/ui/fallback.go
@@ -25,8 +25,7 @@ func TerminalTooSmall(width, height int) string {
 //
 // The text is rendered (and therefore wrapped) at the target width before the
 // vertical padding is computed, so centering uses the wrapped line count
-// rather than the pre-wrap count — on narrow panes the fallback ASCII art
-// wraps and padding computed from the raw line count miscenters it (#699).
+// rather than the pre-wrap count (#699).
 //
 // When the wrapped text is taller than the box it is clamped to the bottom
 // height lines — keeping the trailing message visible, matching the
@@ -53,4 +52,16 @@ func renderCenteredFallback(style lipgloss.Style, text string, width, height int
 	out = append(out, lines...)
 	out = append(out, make([]string, height-len(lines)-topPadding)...)
 	return strings.Join(out, "\n")
+}
+
+// paneFallbackContent adds the full Agent Factory logo only when it fits
+// without wrapping. At ordinary 80-column terminals the workspace pane is
+// narrower than the logo; omitting it keeps transient setup/name fallbacks calm
+// and leaves their actionable message intact instead of rendering art fragments
+// (#2146).
+func paneFallbackContent(message string, width int) string {
+	if width < lipgloss.Width(FallBackText) {
+		return message
+	}
+	return lipgloss.JoinVertical(lipgloss.Center, FallBackText, "", message)
 }

--- a/ui/layout_height_test.go
+++ b/ui/layout_height_test.go
@@ -44,17 +44,16 @@ func blankRuns(s string) (top, bottom int) {
 	return top, bottom
 }
 
-// TestPreviewFallbackWrappedArtMatchesAllocatedHeight is the regression test
-// for #699. At an 80-column terminal the preview pane is ~48 columns wide and
-// the 58-column fallback ASCII art wraps, increasing the rendered line count.
-// Centering math that counts pre-wrap lines then under-pads and the overall
-// output overflows the pane allocation (49 lines for a 30-line pane).
-func TestPreviewFallbackWrappedArtMatchesAllocatedHeight(t *testing.T) {
+// TestPreviewFallbackWidthAwareContentMatchesAllocatedHeight covers both sides
+// of the #2146 fallback: narrow panes render the message without logo fragments,
+// while wide panes retain the full art. Both still honor the #699 exact-height
+// contract.
+func TestPreviewFallbackWidthAwareContentMatchesAllocatedHeight(t *testing.T) {
 	for _, tc := range []struct{ w, h int }{
-		{48, 15}, // 80x24 terminal: real preview pane content size
+		{48, 15}, // 80x24 terminal: message-only fallback
 		{48, 30},
 		{48, 60},
-		{80, 30}, // wide enough that the art does not wrap
+		{80, 30}, // wide enough for the full logo
 	} {
 		p := NewTabPane(previewFromInstance)
 		p.SetSize(tc.w, tc.h)
@@ -66,13 +65,12 @@ func TestPreviewFallbackWrappedArtMatchesAllocatedHeight(t *testing.T) {
 	}
 }
 
-// TestPreviewFallbackCentersWrappedLineCount verifies the padding is computed
-// from the wrapped (rendered) line count: the top and bottom padding runs must
-// be balanced even when wrapping changes the art's height (#699).
-func TestPreviewFallbackCentersWrappedLineCount(t *testing.T) {
+// TestPreviewFallbackCentersWidthAwareContent verifies that padding is balanced
+// for both the narrow message-only and wide full-logo variants.
+func TestPreviewFallbackCentersWidthAwareContent(t *testing.T) {
 	for _, tc := range []struct{ w, h int }{
-		{48, 60}, // art wraps at this width
-		{80, 30}, // art does not wrap
+		{48, 60}, // logo omitted at this width
+		{80, 30}, // logo retained at this width
 	} {
 		p := NewTabPane(previewFromInstance)
 		p.SetSize(tc.w, tc.h)
@@ -82,7 +80,8 @@ func TestPreviewFallbackCentersWrappedLineCount(t *testing.T) {
 
 		// Inspect the centering math pre-clamp: the final exact-rect clamp
 		// space-pads every line, which would hide which lines are padding.
-		out := renderCenteredFallback(tabPaneStyle, p.content.text, tc.w, tc.h)
+		out := renderCenteredFallback(tabPaneStyle,
+			paneFallbackContent(p.content.text, tc.w), tc.w, tc.h)
 		top, bottom := blankRuns(out)
 		require.Greater(t, top, 0,
 			"%dx%d: content shorter than the box must be padded down from the top", tc.w, tc.h)
@@ -113,10 +112,9 @@ func TestTerminalFallbackMatchesNormalModeHeight(t *testing.T) {
 	}
 }
 
-// TestTerminalFallbackWrappedArtMatchesAllocatedHeight covers the terminal
-// pane's variant of #699: at narrow widths the fallback art wraps, and the
-// pre-fix centering math both miscentered and overflowed the allocation.
-func TestTerminalFallbackWrappedArtMatchesAllocatedHeight(t *testing.T) {
+// TestTerminalFallbackWidthAwareContentMatchesAllocatedHeight covers the same
+// narrow-message/wide-logo contract for terminal-tab fallbacks.
+func TestTerminalFallbackWidthAwareContentMatchesAllocatedHeight(t *testing.T) {
 	for _, tc := range []struct{ w, h int }{
 		{48, 15},
 		{48, 30},

--- a/ui/preview_test.go
+++ b/ui/preview_test.go
@@ -616,10 +616,7 @@ func TestPreviewFallbackHeightNoDoubleCounting(t *testing.T) {
 
 	// Count the number of lines in the fallback text itself so we can make
 	// assertions that depend on the ASCII art surviving the layout math.
-	fallbackTextLines := len(strings.Split(
-		lipgloss.JoinVertical(lipgloss.Center, FallBackText, "", "msg"),
-		"\n",
-	))
+	fallbackTextLines := len(strings.Split(paneFallbackContent("msg", 80), "\n"))
 
 	t.Run("renders full content at comfortable height", func(t *testing.T) {
 		p := NewTabPane(previewFromInstance)
@@ -662,6 +659,30 @@ func TestPreviewFallbackHeightNoDoubleCounting(t *testing.T) {
 				"height=%d: fallback message must remain visible", h)
 		}
 	})
+}
+
+func TestPreviewFallbackOmitsLogoWhenItCannotFit(t *testing.T) {
+	for _, tc := range []struct{ width, height int }{
+		{56, 20}, // content box in the reported 80x24 layout
+		{48, 15}, // compact 80x24 layout variants
+		{36, 16}, // content box in a narrower terminal
+	} {
+		p := NewTabPane(previewFromInstance)
+		p.SetSize(tc.width, tc.height)
+		p.setFallbackState("Setting up workspace…")
+
+		rendered := p.String()
+		require.Contains(t, rendered, "Setting up workspace…")
+		require.NotContains(t, rendered, "████",
+			"%d-cell panes must omit, not hard-wrap, the fallback logo", tc.width)
+		require.Equal(t, tc.height, len(strings.Split(rendered, "\n")))
+	}
+
+	p := NewTabPane(previewFromInstance)
+	p.SetSize(lipgloss.Width(FallBackText), 30)
+	p.setFallbackState("Setting up workspace…")
+	require.Contains(t, p.String(), "████",
+		"the full fallback logo remains at widths where it fits")
 }
 
 // TestPreviewFallbackMatchesNormalModeHeight is the regression test for #616.

--- a/ui/tab_pane.go
+++ b/ui/tab_pane.go
@@ -19,10 +19,11 @@ var tabPaneStyle = lipgloss.NewStyle().
 
 // tabContentState holds the rendered content of the tab pane.
 //
-// Invariant: fallback==true iff text is a centered fallback message
-// (loading / error / inactive). Writers MUST replace the whole struct rather
-// than mutate fields individually, so the two fields can never disagree about
-// which rendering branch String() should take (#577).
+// Invariant: fallback==true iff text is a fallback message (loading / error /
+// inactive); String adds width-appropriate branding and centers it. Writers
+// MUST replace the whole struct rather than mutate fields individually, so the
+// two fields can never disagree about which rendering branch String() should
+// take (#577).
 type tabContentState struct {
 	fallback bool
 	text     string
@@ -322,7 +323,7 @@ func (p *TabPane) publishContent(content tabContentState) {
 func (p *TabPane) setFallbackState(message string) {
 	p.publishContent(tabContentState{
 		fallback: true,
-		text:     lipgloss.JoinVertical(lipgloss.Center, FallBackText, "", message),
+		text:     message,
 	})
 	// Reset unconditionally: an already-None controller can still have viewport
 	// data left by a prior owner or a test seam. Fallback must make stale scroll
@@ -723,10 +724,11 @@ func (p *TabPane) String() string {
 		// TabbedWindow.SetRect already subtracts borders/margins/padding from
 		// p.height, so use it directly to match normal mode. Subtracting again
 		// would double-count chrome and leave a trailing blank line (#616/#703).
-		// renderCenteredFallback centers using the wrapped line count so narrow
-		// panes don't miscenter (#699).
+		// paneFallbackContent omits the logo when it cannot fit unwrapped (#2146),
+		// then renderCenteredFallback centers the remaining width-aware content.
 		return layout.ClampToRect(
-			renderCenteredFallback(tabPaneStyle, p.content.text, p.width, p.height), rect)
+			renderCenteredFallback(tabPaneStyle,
+				paneFallbackContent(p.content.text, p.width), p.width, p.height), rect)
 	}
 
 	lines := strings.Split(p.content.text, "\n")


### PR DESCRIPTION
## Summary

- omit the large fallback logo when a workspace pane is too narrow to render it intact
- keep the centered setup or status message visible while preserving the full logo at widths where it fits
- preserve the fallback pane’s exact-height and centering contracts

## Regression coverage

- watched `TestPreviewFallbackOmitsLogoWhenItCannotFit` fail against the previous production rendering path because narrow panes contained wrapped `████` fragments
- verified narrow pane widths of 56, 48, and 36 cells omit the logo
- verified a pane exactly as wide as the logo still renders it

## Validation

Exact pushed head: `4efab8835a499e4e0d5b5d0b03b24a92a5de6c18`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `make tui-driver-selftest` — 61/61 steps green
- real rendered TUI at 80×24: naming and post-submit setup states show a centered message with no logo fragments
- real rendered TUI at 60×18: naming and post-submit setup states show a centered, unwrapped message with no logo fragments
- real rendered TUI at 100×30: the full logo remains because it fits

Closes #2146
