### PR TITLE
fix(ui): distinguish duplicate terminal tabs in panes

### DIFF
--- a/app/handle_panes.go
+++ b/app/handle_panes.go
@@ -9,7 +9,6 @@ import (
 	"github.com/sachiniyer/agent-factory/ui"
 	"github.com/sachiniyer/agent-factory/ui/layout"
 	"github.com/sachiniyer/agent-factory/ui/store"
-	"github.com/sachiniyer/agent-factory/ui/tree"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/sachiniyer/agent-factory/internal/shellsuggest"
@@ -83,16 +82,8 @@ func (m *home) paneSelectionHint(p *store.OpenPane) string {
 	if m.paneMatchesSelection(p) {
 		return ""
 	}
-	tabLabel := ""
-	labels := tree.TabLabels(selected)
 	activeTab := m.store.ActiveTab()
-	if activeTab >= 0 && activeTab < len(labels) {
-		tabLabel = labels[activeTab]
-	}
-	if tabLabel == "" {
-		return selected.Title
-	}
-	return fmt.Sprintf("%s · %s", selected.Title, tabLabel)
+	return paneBindingLabel(paneBinding{instance: selected, tab: activeTab})
 }
 
 func (m *home) paneMatchesSelection(p *store.OpenPane) bool {

--- a/app/home_model.go
+++ b/app/home_model.go
@@ -707,8 +707,8 @@ func (m *home) clearStaleAutoHideStatus() {
 
 // paneStatusLabel names a pane for a user-facing message the way the pane's own
 // header names it — `instance · tab` (ui.TabbedWindow.renderHeader), reading the
-// tab through the same tree label source so the toast and the header can never
-// disagree about what a pane is called.
+// tab through the same disambiguated tree label source so the toast and the
+// header can never disagree about what a pane is called.
 //
 // It reports false rather than guessing. An instance title alone is not a pane
 // identity (#930), and tree.TabLabels answers with a placeholder "Agent" slot

--- a/app/pane_autohide_status_test.go
+++ b/app/pane_autohide_status_test.go
@@ -200,6 +200,31 @@ func TestPane_AutoHideStatusNamesDisplacedTab(t *testing.T) {
 	}
 }
 
+// TestPane_AutoHideStatusDisambiguatesDuplicateTerminalTabs covers the status
+// half of #2150. The pane header and the narrow-layout notice are two views of
+// the same pane identity; neither may collapse two default Terminal tabs back
+// to the same label after the tree has already exposed their jump slots.
+func TestPane_AutoHideStatusDisambiguatesDuplicateTerminalTabs(t *testing.T) {
+	h := paneTestHome(t)
+	resizeHome(h, 80, 24)
+
+	alpha := h.store.GetInstanceByTitle("alpha")
+	require.NotNil(t, alpha)
+	alpha.AddTabForTest("shell-2", session.TabKindShell)
+
+	_, _ = h.openOrFocusPane(alpha, 1)
+	_, _ = h.openOrFocusPane(alpha, 2)
+
+	require.Equal(t, 2, h.store.NumOpenPanes())
+	require.Len(t, h.visiblePanes, 1)
+	require.Equal(t, 2, h.visiblePanes[0].Tab(), "slot 3 remains visible")
+	rendered := h.errBox.String()
+	assert.Contains(t, rendered, "alpha · 2 › Terminal hidden",
+		"the notice identifies the displaced slot-2 terminal")
+	assert.NotContains(t, rendered, "alpha · › Terminal hidden",
+		"a generic Terminal label cannot identify the displaced pane")
+}
+
 // TestPane_AutoHideStatusUnnamableTabMakesNoClaim covers the other half of the
 // #1997 contract: when the pane's tab cannot be named, the toast says a pane is
 // hidden rather than naming the wrong one. An instance whose tabs have not

--- a/app/pane_duplicate_label_test.go
+++ b/app/pane_duplicate_label_test.go
@@ -1,0 +1,46 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPane_NumberJumpDisambiguatesDuplicateTerminalHeaders is the regression
+// for #2150. The tree already prefixes each tab with its 1-based jump slot, but
+// pane headers used only the non-unique presentation label. Jumping between two
+// default Terminal tabs therefore rendered the same pane identity both times.
+// Drive handleTabJump (the production 1-9 action) and assert on home.View so the
+// test crosses the committed pane binding and TabbedWindow header render paths.
+func TestPane_NumberJumpDisambiguatesDuplicateTerminalHeaders(t *testing.T) {
+	h := paneTestHome(t)
+	beta := h.store.GetInstanceByTitle("beta")
+	beta.AddTabForTest("shell-2", session.TabKindShell)
+
+	h.sidebar.SetSelectedInstance(1)
+	_ = h.selectionChanged()
+	_, _ = h.handleTabJump(3)
+	require.Equal(t, 2, h.store.ActiveTab(), "tree selection is pinned to slot 3")
+	pressKey(t, h, "s")
+	paneB := h.store.OpenPanes()[0]
+	require.Same(t, beta, paneB.Instance())
+	require.Equal(t, 2, paneB.Tab())
+
+	_, _ = h.handleTabJump(2)
+	require.Equal(t, 1, paneB.Tab())
+	view := h.View()
+	assert.Contains(t, view, "beta · 2 › Terminal · selected: beta · 3 › Terminal",
+		"the pane and tree identities remain distinct after jumping to slot 2")
+
+	_, _ = h.handleTabJump(3)
+	require.Equal(t, 2, paneB.Tab())
+	view = h.View()
+	assert.Contains(t, view, "beta · 3 › Terminal",
+		"slot 3 is visibly distinct after the next numbered jump")
+	assert.NotContains(t, view, "beta · 2 › Terminal",
+		"the slot-3 frame must not retain slot 2's identity")
+	assert.NotContains(t, view, "selected:",
+		"the divergence hint clears once the pane rejoins the selected slot")
+}

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -921,6 +921,43 @@ func TestPane_NumberJumpAnnotatesSelectedTabDivergence(t *testing.T) {
 	assert.Contains(t, view, "1 ◆ Agent *", "sidebar active-tab marker stays on the selected tab")
 }
 
+// TestPane_NumberJumpDisambiguatesDuplicateTerminalHeaders is the regression
+// for #2150. The tree already prefixes each tab with its 1-based jump slot, but
+// pane headers used only the non-unique presentation label. Jumping between two
+// default Terminal tabs therefore rendered the same pane identity both times.
+// Drive handleTabJump (the production 1-9 action) and assert on home.View so the
+// test crosses the committed pane binding and TabbedWindow header render paths.
+func TestPane_NumberJumpDisambiguatesDuplicateTerminalHeaders(t *testing.T) {
+	h := paneTestHome(t)
+	beta := h.store.GetInstanceByTitle("beta")
+	beta.AddTabForTest("shell-2", session.TabKindShell)
+
+	h.sidebar.SetSelectedInstance(1)
+	_ = h.selectionChanged()
+	_, _ = h.handleTabJump(3)
+	require.Equal(t, 2, h.store.ActiveTab(), "tree selection is pinned to slot 3")
+	pressKey(t, h, "s")
+	paneB := h.store.OpenPanes()[0]
+	require.Same(t, beta, paneB.Instance())
+	require.Equal(t, 2, paneB.Tab())
+
+	_, _ = h.handleTabJump(2)
+	require.Equal(t, 1, paneB.Tab())
+	view := h.View()
+	assert.Contains(t, view, "beta · 2 › Terminal · selected: beta · 3 › Terminal",
+		"the pane and tree identities remain distinct after jumping to slot 2")
+
+	_, _ = h.handleTabJump(3)
+	require.Equal(t, 2, paneB.Tab())
+	view = h.View()
+	assert.Contains(t, view, "beta · 3 › Terminal",
+		"slot 3 is visibly distinct after the next numbered jump")
+	assert.NotContains(t, view, "beta · 2 › Terminal",
+		"the slot-3 frame must not retain slot 2's identity")
+	assert.NotContains(t, view, "selected:",
+		"the divergence hint clears once the pane rejoins the selected slot")
+}
+
 // TestPane_FocusRingCyclesNPanes: with three panes open, Tab cycles
 // tree → pane 1 → pane 2 → pane 3 → automations → projects and wraps; Shift-Tab
 // reverses; with no panes the ring is tree → automations → projects.

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -921,43 +921,6 @@ func TestPane_NumberJumpAnnotatesSelectedTabDivergence(t *testing.T) {
 	assert.Contains(t, view, "1 ◆ Agent *", "sidebar active-tab marker stays on the selected tab")
 }
 
-// TestPane_NumberJumpDisambiguatesDuplicateTerminalHeaders is the regression
-// for #2150. The tree already prefixes each tab with its 1-based jump slot, but
-// pane headers used only the non-unique presentation label. Jumping between two
-// default Terminal tabs therefore rendered the same pane identity both times.
-// Drive handleTabJump (the production 1-9 action) and assert on home.View so the
-// test crosses the committed pane binding and TabbedWindow header render paths.
-func TestPane_NumberJumpDisambiguatesDuplicateTerminalHeaders(t *testing.T) {
-	h := paneTestHome(t)
-	beta := h.store.GetInstanceByTitle("beta")
-	beta.AddTabForTest("shell-2", session.TabKindShell)
-
-	h.sidebar.SetSelectedInstance(1)
-	_ = h.selectionChanged()
-	_, _ = h.handleTabJump(3)
-	require.Equal(t, 2, h.store.ActiveTab(), "tree selection is pinned to slot 3")
-	pressKey(t, h, "s")
-	paneB := h.store.OpenPanes()[0]
-	require.Same(t, beta, paneB.Instance())
-	require.Equal(t, 2, paneB.Tab())
-
-	_, _ = h.handleTabJump(2)
-	require.Equal(t, 1, paneB.Tab())
-	view := h.View()
-	assert.Contains(t, view, "beta · 2 › Terminal · selected: beta · 3 › Terminal",
-		"the pane and tree identities remain distinct after jumping to slot 2")
-
-	_, _ = h.handleTabJump(3)
-	require.Equal(t, 2, paneB.Tab())
-	view = h.View()
-	assert.Contains(t, view, "beta · 3 › Terminal",
-		"slot 3 is visibly distinct after the next numbered jump")
-	assert.NotContains(t, view, "beta · 2 › Terminal",
-		"the slot-3 frame must not retain slot 2's identity")
-	assert.NotContains(t, view, "selected:",
-		"the divergence hint clears once the pane rejoins the selected slot")
-}
-
 // TestPane_FocusRingCyclesNPanes: with three panes open, Tab cycles
 // tree → pane 1 → pane 2 → pane 3 → automations → projects and wraps; Shift-Tab
 // reverses; with no panes the ring is tree → automations → projects.

--- a/app/pane_preview.go
+++ b/app/pane_preview.go
@@ -457,10 +457,12 @@ func paneBindingLabel(binding paneBinding) string {
 	if binding.instance == nil {
 		return "no session"
 	}
-	label := ""
-	labels := tree.TabLabels(binding.instance)
-	if binding.tab >= 0 && binding.tab < len(labels) {
-		label = labels[binding.tab]
+	label, ok := tree.TabLabelAt(binding.instance, binding.tab)
+	if !ok {
+		labels := tree.TabLabels(binding.instance)
+		if binding.tab >= 0 && binding.tab < len(labels) {
+			label = labels[binding.tab]
+		}
 	}
 	if label == "" {
 		return binding.instance.Title

--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -300,14 +300,16 @@ func (w *TabbedWindow) SelectTab(idx int) {
 }
 
 // tabLabels returns the labels for the bound instance's tabs. The label
-// derivation lives in tree.TabLabels (#1024 PR 3) — the single source of truth
-// shared with the sidebar tree, so the pane header, the tree's child rows, and
-// the 1-9 jump keys always agree on slot numbering. Never empty.
+// derivation lives in tree.TabLabels (#1024 PR 3), shared with the sidebar tree
+// and the 1-9 jump keys. Never empty.
 func (w *TabbedWindow) tabLabels() []string {
 	return tree.TabLabels(w.boundInstance())
 }
 
 func tabLabelFor(inst *session.Instance, idx int) string {
+	if label, ok := tree.TabLabelAt(inst, idx); ok {
+		return label
+	}
 	labels := tree.TabLabels(inst)
 	if idx >= 0 && idx < len(labels) {
 		return labels[idx]
@@ -591,8 +593,9 @@ func (w *TabbedWindow) BeginScrollFill() {
 }
 
 // renderHeader renders the one-line `title · tab` header. The header is the
-// only place the pane's tab is named inside the pane (the tab bar is gone);
-// the highlight doubles as the pane's focus indicator.
+// only place the pane's tab is named inside the pane (the tab bar is gone), so
+// duplicate labels include their 1-based jump slot (#2150); the highlight
+// doubles as the pane's focus indicator.
 func (w *TabbedWindow) renderHeader(width int) string {
 	var text string
 	if w.preview != nil && w.preview.instance != nil {

--- a/ui/tree/labels.go
+++ b/ui/tree/labels.go
@@ -1,6 +1,8 @@
 package tree
 
 import (
+	"fmt"
+
 	"github.com/sachiniyer/agent-factory/session"
 )
 
@@ -105,13 +107,20 @@ func TabLabels(instance *session.Instance) []string {
 	return append([]string(nil), placeholderTabLabels...)
 }
 
-// TabLabelAt returns the display label for the instance's tab at idx, reporting
-// false when the instance's real tab list cannot answer: no tabs have
-// materialized yet, or idx is out of range. Unlike TabLabels it never falls
-// back to the placeholder slot — a caller that names a pane TO THE USER must be
-// able to tell "this is the Agent tab" from "no tab list exists yet", because
-// the placeholder's "Agent" is a guess and naming the wrong pane is worse than
-// not naming one (#1997).
+// TabLabelAt returns the presentation label for a real tab and prefixes its
+// 1-based jump slot when another tab has the same label. The tree already
+// renders that slot beside every child row; pane-facing surfaces need it only
+// when labels collide, so a numbered jump between two default Terminal tabs
+// produces a visibly different identity without adding noise to ordinary
+// single-Agent/single-Terminal panes (#2150).
+//
+// It reports false when the instance's real tab list cannot answer: no tabs have
+// materialized yet, or idx is out of range. Unlike TabLabels it never falls back
+// to the placeholder slot — a caller that names a pane TO THE USER must be able
+// to tell "this is the Agent tab" from "no tab list exists yet", because the
+// placeholder's "Agent" is a guess and naming the wrong pane is worse than not
+// naming one (#1997). Best-effort renderers may apply their existing placeholder
+// fallback after checking the bool.
 func TabLabelAt(instance *session.Instance, idx int) (string, bool) {
 	if instance == nil {
 		return "", false
@@ -120,7 +129,13 @@ func TabLabelAt(instance *session.Instance, idx int) (string, bool) {
 	if idx < 0 || idx >= len(tabs) {
 		return "", false
 	}
-	return labelForTab(tabs[idx]), true
+	label := labelForTab(tabs[idx])
+	for candidateIdx, candidate := range tabs {
+		if candidateIdx != idx && labelForTab(candidate) == label {
+			return fmt.Sprintf("%d %s", idx+1, label), true
+		}
+	}
+	return label, true
 }
 
 // labelForTab is the kind glyph, a space, then the tab's text. Every consumer


### PR DESCRIPTION
## Summary

- prefix pane-facing tab labels with their existing 1-based jump slot only when another real tab has the same presentation label
- keep pane headers, preview/selection hints, and narrow-layout auto-hide notices on the same disambiguated identity
- leave ordinary single-Agent and single-Terminal pane labels unchanged

## Regression coverage

- watched `TestPane_NumberJumpDisambiguatesDuplicateTerminalHeaders` fail because slot 2 and slot 3 both rendered as generic `› Terminal` after the production digit-jump changed the committed pane binding
- watched `TestPane_AutoHideStatusDisambiguatesDuplicateTerminalTabs` fail because the 80-column notice could not identify which Terminal pane was displaced
- retained the existing single-tab, ellipsis, unnamable-tab, and selection-divergence contracts

## Validation

Exact pushed head: `9013d6754eb946a07d15341c539d2d9aba476eeb`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- real rendered TUI at 80×24: jumping to slot 2 renders `docs · 2 › Terminal · selected: docs · 3 › Terminal`; jumping to slot 3 renders `docs · 3 › Terminal`; the auto-hide notice names slot 2
- real rendered TUI at 60×18: slot 2 and slot 3 remain visible before any header ellipsis

Closes #2150
