### PR TITLE
fix(tmuxguard): deny unknown scoped commands

### DIFF
--- a/internal/tmuxguard/README.md
+++ b/internal/tmuxguard/README.md
@@ -1,0 +1,26 @@
+# tmux teardown guardrail
+
+This hook is a best-effort safety interlock. Its primary job is to stop the
+direct mistake that caused the original incident: a bare `tmux kill-server`
+against the host's shared server. It recognizes common shell-mediated forms and
+denies unmodeled tmux verbs even when they target a scoped server.
+
+It is not a security boundary. A developer session can invoke shells and tools
+that load commands or code from files, configuration, hooks, plugins,
+environment variables, and future options. A string-level guard cannot fully
+model those execution surfaces, and an allow decision must not be treated as
+proof that a command is safe.
+
+Accordingly:
+
+- a denial means the command matched a known hazard or was outside a modeled
+  guardrail shape;
+- an allow means only that no currently modeled hazard was found;
+- reviewers and operators must not relax a real isolation control because this
+  hook allowed a command.
+
+The actual security boundary is containment: an agent that cannot reach the
+host tmux socket cannot destroy the shared server regardless of which shell or
+developer-tool escape hatch it finds. That work is tracked in
+[#2194](https://github.com/sachiniyer/agent-factory/issues/2194). Until it lands,
+this hook reduces accidental risk but does not eliminate it.

--- a/internal/tmuxguard/guard.go
+++ b/internal/tmuxguard/guard.go
@@ -1,5 +1,8 @@
-// Package tmuxguard implements the agent hook policy that prevents an
-// af-managed agent from tearing down the host's shared tmux server.
+// Package tmuxguard implements a best-effort guardrail against an agent
+// accidentally tearing down the host's shared tmux server. It is not a
+// security boundary: permitted shells and developer tools expose execution
+// surfaces this string-level policy cannot completely model. Host containment
+// tracked in #2194 must provide that boundary.
 package tmuxguard
 
 import (
@@ -81,8 +84,9 @@ func writeDenial(w io.Writer, reason string) error {
 
 // DenialReason returns an actionable reason when command contains a broad
 // tmux teardown or uses shell syntax the guard cannot prove safe. An empty
-// result means every shell word was statically resolved and no teardown was
-// found. The parser is agent-neutral so #2184 can reuse one policy everywhere.
+// result means no modeled hazard was found; it is not proof that arbitrary
+// shell or developer-tool execution is safe. The parser is agent-neutral so
+// #2184 can reuse one guardrail everywhere.
 func DenialReason(command string) string {
 	return denialReason(command, 0)
 }

--- a/internal/tmuxguard/guard_test.go
+++ b/internal/tmuxguard/guard_test.go
@@ -118,6 +118,71 @@ func TestDenialReason(t *testing.T) {
 	}
 }
 
+func TestDenialReasonChecksKillServerInEveryTmuxChainPosition(t *testing.T) {
+	positions := []struct {
+		name string
+		args string
+	}{
+		{name: "first", args: `kill-server \; list-sessions`},
+		{name: "first with attached terminator", args: `kill-server\; list-sessions`},
+		{name: "middle", args: `list-sessions \; kill-server \; list-windows`},
+		{name: "middle with attached terminator", args: `list-sessions \; kill-server\; list-windows`},
+		{name: "last", args: `list-sessions \; kill-server`},
+		{name: "after attached separator", args: `list-sessions\; kill-server`},
+	}
+	for _, position := range positions {
+		for _, scoped := range []bool{false, true} {
+			name := "unscoped"
+			prefix := "tmux"
+			wantReason := broadTmuxReason
+			if scoped {
+				name = "scoped"
+				prefix = "tmux -L af-test"
+				wantReason = ""
+			}
+			t.Run(position.name+"/"+name, func(t *testing.T) {
+				command := prefix + " " + position.args
+				if got := DenialReason(command); got != wantReason {
+					t.Fatalf("DenialReason(%q) = %q, want %q", command, got, wantReason)
+				}
+			})
+		}
+	}
+}
+
+func TestDenialReasonDeniesUnmodeledCommandsOnScopedTmuxServers(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+	}{
+		// P1 reproductions from #2305: documented aliases must not escape a
+		// canonical-name denylist.
+		{name: "new-window alias", command: `tmux -L af-test neww 'pkill tmux'`},
+		{name: "split-window alias", command: `tmux -L af-test splitw 'pkill tmux'`},
+		{name: "display-popup alias", command: `tmux -L af-test popup 'pkill tmux'`},
+
+		// P1 reproductions from #2304: a verb absent from a denylist must not
+		// become an implicit allow merely because the tmux server is scoped.
+		{name: "new-pane", command: `tmux -L af-test new-pane 'pkill tmux'`},
+		{name: "detach-client shell", command: `tmux -L af-test detach-client -E 'pkill tmux'`},
+
+		// tmux accepts unambiguous command prefixes. Matching only canonical
+		// spellings would leave the same bug under a shorter token.
+		{name: "new-window prefix", command: `tmux -L af-test new-w 'pkill tmux'`},
+
+		// Intersection with #2308: every sequence element must inherit the
+		// scoped-server deny-by-default policy after separator normalization.
+		{name: "unknown after separator", command: `tmux -L af-test list-sessions \; some-unknown-verb 'pkill tmux'`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DenialReason(tt.command); got != unknownShellReason {
+				t.Fatalf("DenialReason(%q) = %q, want %q", tt.command, got, unknownShellReason)
+			}
+		})
+	}
+}
+
 func TestDenialReasonsAreActionable(t *testing.T) {
 	tests := []struct {
 		command string

--- a/internal/tmuxguard/tmux.go
+++ b/internal/tmuxguard/tmux.go
@@ -8,16 +8,13 @@ func inspectTmux(args []string) string {
 		return unknownShellReason
 	}
 	commandArgs := args[commandAt:]
-	if tmuxKillServerIsBroad(commandArgs, scoped) {
-		return broadTmuxReason
-	}
 	for _, arg := range args {
 		if strings.Contains(arg, "#(") {
 			return unknownShellReason
 		}
 	}
 	if commandAt == len(args) {
-		if scoped || versionOnly {
+		if versionOnly {
 			return ""
 		}
 		return unknownShellReason
@@ -28,21 +25,34 @@ func inspectTmux(args []string) string {
 		return unknownShellReason
 	}
 	for _, words := range commands {
-		command := strings.ToLower(words[0])
-		if isKillServerCommand(command) {
-			if !scoped {
-				return broadTmuxReason
-			}
-			continue
-		}
-		if tmuxCommandBuildsCommands(command) {
-			return unknownShellReason
-		}
-		if !scoped && !safeUnscopedTmuxCommand(command) {
-			return unknownShellReason
+		if reason := inspectTmuxSequenceCommand(words[0], scoped); reason != "" {
+			return reason
 		}
 	}
 	return ""
+}
+
+// inspectTmuxSequenceCommand is the only command-level policy decision. It is
+// called after separator normalization, so the first, middle, and last command
+// in a chain cannot be judged by different token shapes.
+func inspectTmuxSequenceCommand(rawCommand string, scoped bool) string {
+	command := strings.ToLower(rawCommand)
+	if isKillServerCommand(command) {
+		if scoped {
+			return ""
+		}
+		return broadTmuxReason
+	}
+	if safeUnscopedTmuxCommand(command) {
+		return ""
+	}
+	if scoped && safeScopedTmuxCommand(command) {
+		return ""
+	}
+	// Socket scope limits which tmux server a verb can mutate, but tmux verbs
+	// may still launch host shell commands. Unknown verbs therefore deny until
+	// they are explicitly audited and added to the small safe set below.
+	return unknownShellReason
 }
 
 // splitTmuxCommands models tmux's command-sequence boundary. Shell quoting is
@@ -137,33 +147,9 @@ func isTmuxFlagCluster(arg string) bool {
 	}) == -1
 }
 
-func tmuxKillServerIsBroad(args []string, socketScoped bool) bool {
-	for _, arg := range args {
-		if isKillServerCommand(arg) {
-			return !socketScoped
-		}
-	}
-	return false
-}
-
 func isKillServerCommand(arg string) bool {
 	arg = strings.ToLower(arg)
 	return arg != "" && strings.HasPrefix("kill-server", arg)
-}
-
-func tmuxCommandBuildsCommands(command string) bool {
-	commands := []string{
-		"bind-key", "choose-buffer", "choose-client", "choose-tree", "command-prompt",
-		"confirm-before", "display-menu", "display-popup", "if-shell", "new-session",
-		"new-window", "pipe-pane", "respawn-pane", "respawn-window", "run-shell",
-		"set-hook", "source-file", "split-window",
-	}
-	for _, opaque := range commands {
-		if command != "" && strings.HasPrefix(opaque, command) {
-			return true
-		}
-	}
-	return false
 }
 
 func safeUnscopedTmuxCommand(command string) bool {
@@ -173,6 +159,23 @@ func safeUnscopedTmuxCommand(command string) bool {
 		"list-commands", "lscm", "list-keys", "lsk", "list-panes", "lsp",
 		"list-sessions", "ls", "list-windows", "lsw", "show-environment", "showenv",
 		"show-hooks", "show-messages", "show-options", "show", "show-window-options", "showw":
+		return true
+	default:
+		return false
+	}
+}
+
+// safeScopedTmuxCommand is intentionally exact and small. A scoped server is
+// safe to mutate with these verbs, but scope does not make a verb that can
+// launch a host process safe. Aliases, abbreviations, and future tmux verbs
+// remain denied until audited rather than inheriting an allow by default.
+func safeScopedTmuxCommand(command string) bool {
+	switch command {
+	case "clock-mode", "copy-mode", "kill-pane", "kill-session", "kill-window",
+		"last-pane", "last-window", "next-layout", "next-window", "previous-layout",
+		"previous-window", "refresh-client", "rename-session", "rename-window",
+		"resize-pane", "resize-window", "rotate-window", "select-layout", "select-pane",
+		"select-window", "swap-pane", "swap-window", "switch-client", "unlink-window":
 		return true
 	default:
 		return false


### PR DESCRIPTION
Closes #2304.
Closes #2305.

This inverts the scoped-tmux policy from an incomplete command-builder denylist to a small exact safe set with deny-by-default fallback. Documented aliases, unlisted verbs, unambiguous prefixes, and future tmux verbs can no longer inherit an allow merely because `-L` or `-S` is present.

The package documentation now states the actual contract plainly: this hook is a best-effort guardrail against accidents, not a security boundary. Containment tracked in #2194 must provide the boundary.

#2308 landed first as `0a9b4d302e6548d9c4f0b5301f17031cd4e49fb7`; this PR is based on that merge. I verified the combined result explicitly:

1. Deny-by-default survives: an unrecognized verb on a scoped server returns `unknownShellReason`.
2. Separator splitting survives: every element is inspected, including attached terminators such as `kill-server\; list-sessions` and `list-sessions\; kill-server`, in first, middle, and last positions.
3. Both regression sets remain: #2308 chain/attached-separator coverage and the #2304/#2305 alias, unlisted-verb, and prefix coverage are all present as string-only `DenialReason` assertions.
4. The intersection is locked: `tmux -L af-test list-sessions \; some-unknown-verb 'pkill tmux'` denies.

The chain regression failed before the #2308 follow-up for attached first/middle terminators. Against current master, the #2304/#2305 regression failed for `neww`, `splitw`, `popup`, `new-pane`, `detach-client -E`, and the scoped unknown-after-separator case; all pass after this change. No payload was executed.

This focused successor supersedes the broad closed draft #2251 without carrying its unrelated dispatcher rewrite.

Required local gates passed on exact pushed head `66186becef6baeabf944c309e5889d49df2b49de`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (no output)
- `go build ./...`
- `make test-container`

Production delivery-seam tests for both generated Codex and injected Claude plugins also pass.
