### PR TITLE
fix(ui): normalize interval on schedule type switch

### DIFF
--- a/ui/schedule_picker.go
+++ b/ui/schedule_picker.go
@@ -288,6 +288,7 @@ func (p *schedulePicker) adjust(dir int) {
 		n := len(scheduleTypes)
 		p.typ = (p.typ + dir + n) % n
 		p.clampCursor()
+		p.normalizeInterval()
 		// Switching into Custom prefills the raw field with the cron the
 		// previous preset generated, so the escape hatch starts from a working
 		// expression rather than blank.
@@ -372,15 +373,33 @@ func (p *schedulePicker) intervalMax() int {
 	return 59
 }
 
+// intervalValue is the one canonical projection of the shared interval field.
+// Both save-time materialization and a type transition use it, so the editable
+// chip cannot retain a value that the selected schedule type will save
+// differently.
+func (p *schedulePicker) intervalValue() int {
+	if p.kind() == schedule.EveryNHours {
+		return atoiClamp(p.interval, 1, p.intervalMax(), 1)
+	}
+	return atoiClamp(p.interval, 1, p.intervalMax(), 15)
+}
+
+func (p *schedulePicker) normalizeInterval() {
+	switch p.kind() {
+	case schedule.EveryNMinutes, schedule.EveryNHours:
+		p.interval = strconv.Itoa(p.intervalValue())
+	}
+}
+
 // toSchedule materializes the current picker state into a canonical Schedule,
 // clamping numeric fields into valid ranges so the generated cron is always
 // well-formed (custom raw text excepted — it is validated separately).
 func (p *schedulePicker) toSchedule() schedule.Schedule {
 	switch p.kind() {
 	case schedule.EveryNMinutes:
-		return schedule.Schedule{Type: schedule.EveryNMinutes, Interval: atoiClamp(p.interval, 1, 59, 15)}
+		return schedule.Schedule{Type: schedule.EveryNMinutes, Interval: p.intervalValue()}
 	case schedule.EveryNHours:
-		return schedule.Schedule{Type: schedule.EveryNHours, Interval: atoiClamp(p.interval, 1, 23, 1)}
+		return schedule.Schedule{Type: schedule.EveryNHours, Interval: p.intervalValue()}
 	case schedule.Hourly:
 		return schedule.Schedule{Type: schedule.Hourly, Minute: atoiClamp(p.minuteStr, 0, 59, 0)}
 	case schedule.Daily:

--- a/ui/schedule_picker_test.go
+++ b/ui/schedule_picker_test.go
@@ -127,6 +127,22 @@ func TestSchedulePickerTypeSwitchChangesCron(t *testing.T) {
 	assert.Equal(t, "0 9 1 * *", p.Cron())
 }
 
+func TestSchedulePickerTypeSwitchNormalizesDisplayedInterval(t *testing.T) {
+	p := newSchedulePicker()
+	p.seed(schedule.Schedule{Type: schedule.EveryNMinutes, Interval: 50})
+	p.setWidth(80)
+	p.setFocused(true)
+
+	p.handleKey(keyType(tea.KeyRight)) // Every 50 minutes -> Every N hours.
+
+	require.Equal(t, schedule.EveryNHours, p.kind())
+	assert.Equal(t, "23", p.interval, "the editable chip must match the canonical value")
+	assert.Equal(t, 23, p.toSchedule().Interval, "the saved schedule must match the chip")
+	out := p.render()
+	assert.Contains(t, out, "Every 23 hours")
+	assert.NotContains(t, out, "Every 50 hours")
+}
+
 // TestSchedulePickerNumericAndMeridiemEntry drives the daily contextual inputs:
 // move to the hour/minute cells, type values, and flip AM->PM.
 func TestSchedulePickerNumericAndMeridiemEntry(t *testing.T) {


### PR DESCRIPTION
## Summary

- normalize the shared interval field immediately after switching schedule type, so the editable chip reflects the value that will be saved
- route both transition-time normalization and save-time materialization through one canonical interval projection
- preserve permissive raw numeric input while the user is actively editing; normalization occurs only at the type boundary

## Verification against master

#2203 is real on current master:

- `ui/schedule_picker.go:286-298` changes the selected type without normalizing the shared interval string
- `ui/schedule_picker.go:368-372` gives hours and minutes different maxima
- `ui/schedule_picker.go:378-384` clamps only when materializing the saved schedule, allowing the editable chip and saved value to disagree

## Fail-first coverage

`TestSchedulePickerTypeSwitchNormalizesDisplayedInterval` starts at Every 50 minutes, switches to Every N hours, and pins the full invariant: the editable field is 23, the materialized schedule saves 23, the rendered picker shows Every 23 hours, and the stale Every 50 hours text is absent.

The focused transition tests pass repeatedly under the race detector.

## Verification

All required local gates passed after the final commit on pushed SHA `83a31c4e80e8916a47b57967d8ad9d6151517a73`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh` (`936 Go files checked; 0 grandfathered`)

Closes #2203.

— Captain Claude
