### PR TITLE
fix(web): proxy rooted localhost targets

### DIFF
--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7832,6 +7832,7 @@ function isLoopbackWebUrl(raw) {
   try {
     let host = new URL(raw).hostname.toLowerCase();
     host = host.replace(/^\[|\]$/g, "");
+    host = host.replace(/\.$/, "");
     return host === "localhost" || host === "::1" || host === "127.0.0.1" || host.startsWith("127.");
   } catch {
     return false;

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "b74eb19ef9df";
+const VERSION = "71d483dec607";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/src/stable_tab_addressing.test.ts
+++ b/web/src/stable_tab_addressing.test.ts
@@ -20,7 +20,7 @@ import { tabBarSig, tabIdentity, tabRealId } from "./ui.js";
 import type { AppState } from "./ui.js";
 import { type SessionData, TabKind } from "./types.js";
 import { leaves, remapByIdentity, resolveDragTab, tabsRebound } from "./layout.js";
-import { iframeIdentity, iframeIsProxied, paneAddressUsesOrdinal, webProxyPath } from "./tabaddr.js";
+import { iframeIdentity, iframeIsProxied, isLoopbackWebUrl, paneAddressUsesOrdinal, webProxyPath } from "./tabaddr.js";
 
 // --- tabRealId: the real id, never a synthesized one -----------------------
 
@@ -432,6 +432,20 @@ test("a VSCODE pane is always proxied — it has no target to classify", () => {
   assert.equal(iframeIsProxied({ kind: TabKind.Web, target: "http://localhost:3000" }), true);
   assert.equal(iframeIsProxied({ kind: TabKind.Web, target: "https://example.com" }), false);
   assert.equal(iframeIsProxied({ kind: TabKind.Web, target: "" }), false);
+});
+
+test("#2202: rooted localhost follows the same loopback proxy path as Go", () => {
+  const target = "http://localhost.:3000";
+
+  // DNS permits a trailing root dot, and the Go classifier already strips it.
+  // Pin both the pure parity rule and the production decision that chooses the
+  // daemon-proxied iframe instead of the external fallback.
+  assert.equal(isLoopbackWebUrl(target), true);
+  assert.equal(iframeIsProxied({ kind: TabKind.Web, target }), true);
+
+  // Stripping one root dot must not broaden malformed or external hosts.
+  assert.equal(isLoopbackWebUrl("http://localhost..:3000"), false);
+  assert.equal(isLoopbackWebUrl("https://example.com."), false);
 });
 
 test("a VSCODE pane's identity is constant, so a reconcile never reloads the editor", () => {

--- a/web/src/tabaddr.ts
+++ b/web/src/tabaddr.ts
@@ -47,6 +47,9 @@ export function isLoopbackWebUrl(raw: string): boolean {
   try {
     let host = new URL(raw).hostname.toLowerCase();
     host = host.replace(/^\[|\]$/g, ""); // strip IPv6 brackets
+    // A single trailing dot is the DNS root label. Strip exactly one to mirror
+    // session.IsLoopbackWebTarget; a doubled dot remains malformed/fail-closed.
+    host = host.replace(/\.$/, "");
     return host === "localhost" || host === "::1" || host === "127.0.0.1" || host.startsWith("127.");
   } catch {
     return false;


### PR DESCRIPTION
## Summary

- normalize one trailing DNS root label before the web loopback classification
- keep malformed double-dot and external rooted hosts fail-closed
- cover both the pure parity rule and the production iframe proxy decision
- regenerate the committed web bundle

## Reproduction and root cause

Before the fix, the focused `#2202` regression failed with `false !== true` for `http://localhost.:3000`. The browser URL parser preserves the trailing root dot, while Go's `session.IsLoopbackWebTarget` strips exactly one before classifying the host. The TypeScript classifier therefore sent a loopback preview down the external fallback path.

The regression calls `iframeIsProxied`, which is the production decision consumed by `SplitView.mountWebPane`, so it cannot pass solely against an unused helper.

## Validation

Exact pushed head: `383d6dfe78c32d08b6a19281857c292573a67b19`

- focused `#2202` regression (watched fail before the fix, passes after)
- `make web-test` (402 passed)
- `make web-build` (committed bundle reproducible)
- `make web-selftest-container` (110 passed)
- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (no output)
- `go build ./...`
- `make test-container`

Fixes #2202
