### PR TITLE
fix(ui): preserve dead-agent fallback on scroll

### DIFF
--- a/ui/preview_scroll_fallback_test.go
+++ b/ui/preview_scroll_fallback_test.go
@@ -167,6 +167,49 @@ func TestPreviewScrollEntryDeletingShowsTeardownFallback(t *testing.T) {
 		"rendered frame must show the teardown fallback")
 }
 
+// TestPreviewScrollEntryDeadAgentShowsFallbackImmediately is the regression
+// for #2134. Scroll entry returns to Bubble Tea before the off-loop history
+// capture runs, so the frame rendered immediately after ScrollUp must already
+// carry the authoritative dead/lost fallback. Entering an empty viewport and
+// relying on UpdateContent to repair it produces one visible blank frame.
+func TestPreviewScrollEntryDeadAgentShowsFallbackImmediately(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	for _, tc := range []struct {
+		name     string
+		liveness session.Liveness
+		want     string
+	}{
+		{name: "dead", liveness: session.LiveDead, want: "Session no longer running."},
+		{name: "lost", liveness: session.LiveLost, want: "Session lost — its tmux session is gone."},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			inst, err := session.NewInstance(session.InstanceOptions{
+				Title: tc.name, Path: t.TempDir(), Program: "test",
+			})
+			require.NoError(t, err)
+			inst.SetBackend(session.NewFakeBackend())
+			require.NoError(t, inst.Transition(session.ObserveLiveness(tc.liveness)))
+
+			p := NewTabPane(previewFromInstance)
+			p.SetSize(80, 30)
+			enableHostHistory(p, inst, 0)
+
+			require.NoError(t, p.ScrollUp(inst, 0))
+
+			require.False(t, p.scroll.Active(),
+				"%s agent tab must reject scroll mode before the first frame", tc.name)
+			require.True(t, p.content.fallback,
+				"%s agent tab must publish its fallback synchronously", tc.name)
+			require.Empty(t, strings.TrimSpace(p.viewport.View()),
+				"a rejected scroll entry must not leave viewport content")
+			require.Contains(t, p.String(), tc.want,
+				"the immediate post-ScrollUp frame must render the %s fallback", tc.name)
+		})
+	}
+}
+
 // TestPreviewScrollModeViewportContentCleared focuses on the viewport-clearing
 // half of the invariant: after entering any fallback, viewport.View() must no
 // longer contain the captured scroll content. Without the fix the viewport is

--- a/ui/tab_pane.go
+++ b/ui/tab_pane.go
@@ -813,6 +813,20 @@ func (p *TabPane) canEnterScrollModeLocked(instance *session.Instance, activeTab
 		p.setFallbackState("Tearing down session…")
 		return false
 	}
+	// Agent liveness is already authoritative in memory. Reject scroll entry
+	// synchronously for dead/lost sessions so the immediate Bubble Tea frame
+	// renders the same fallback as updateAgent instead of an empty viewport while
+	// the off-loop history capture catches up (#2134).
+	if activeTab == 0 {
+		switch instance.GetLiveness() {
+		case session.LiveDead:
+			p.setFallbackState("Session no longer running.")
+			return false
+		case session.LiveLost:
+			p.setFallbackState("Session lost — its tmux session is gone.")
+			return false
+		}
+	}
 	// A web/vscode tab has no scrollback (no PTY): keep the placeholder rather than
 	// entering scroll mode over an empty capture. Mirrors updateShell's branch.
 	if tabs := instance.GetTabs(); activeTab >= 0 && activeTab < len(tabs) {


### PR DESCRIPTION
Fixes #2134.

## Summary

- Reject agent-tab scroll entry when the daemon projection already says the session is Dead or Lost.
- Publish the existing dead/lost fallback synchronously, before Bubble Tea renders the frame returned by the key event.
- Keep shell-tab liveness and teardown behavior unchanged.

## Reproduction and regression

The regression drives `TabPane.ScrollUp`, the production entry called by the global scroll key through `TabbedWindow.ScrollUp`. Before the fix, both Dead and Lost agent cases entered scroll mode with an empty viewport, so the immediate rendered frame was blank while the off-loop history capture caught up. The new test failed on both cases before the production change and passes afterward.

A real daemon-backed Lost session was also rendered and driven in the playtest container. Pressing `Ctrl-U` retained `Session lost — its tmux session is gone.` and did not show `SCROLL` at both 80x24 and 60x18.

## Validation

Exact pushed head: `af05d5ea4dea1b427ab69d48cac43b9162153072`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (no output)
- `go build ./...`
- `make test-container`
- `deadcode -test ./...` with v0.48.0 (no findings)
- file-length lint
- focused dead/lost, teardown, and session-gone scroll fallback tests
- rendered TUI at 80x24 and 60x18
