### PR TITLE
fix(release): verify archive checksums

### DIFF
--- a/.github/scripts/write-sha256sums.sh
+++ b/.github/scripts/write-sha256sums.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# Build the release checksum manifest from the complete four-platform artifact set.
+# Kept in one script so stable and preview releases cannot drift.
+
+set -eu
+
+if [ "$#" -ne 1 ]; then
+	echo "usage: write-sha256sums.sh <artifact-directory>" >&2
+	exit 2
+fi
+
+artifact_dir=$1
+expected_assets="
+agent-factory-darwin-amd64.tar.gz
+agent-factory-darwin-arm64.tar.gz
+agent-factory-linux-amd64.tar.gz
+agent-factory-linux-arm64.tar.gz
+"
+
+for asset in $expected_assets; do
+	if [ ! -f "$artifact_dir/$asset" ]; then
+		echo "error: release artifact is missing: $artifact_dir/$asset" >&2
+		exit 1
+	fi
+done
+
+set -- "$artifact_dir"/agent-factory-*.tar.gz
+if [ "$#" -ne 4 ]; then
+	echo "error: expected exactly 4 release archives in $artifact_dir, found $#" >&2
+	exit 1
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+	hash_file() { sha256sum "$1" | awk '{print $1}'; }
+elif command -v shasum >/dev/null 2>&1; then
+	hash_file() { shasum -a 256 "$1" | awk '{print $1}'; }
+else
+	echo "error: sha256sum or shasum is required to build release checksums" >&2
+	exit 1
+fi
+
+manifest_tmp="$artifact_dir/.sha256sums.txt.$$"
+cleanup() { rm -f "$manifest_tmp"; }
+trap cleanup EXIT INT TERM
+
+: > "$manifest_tmp"
+for asset in $expected_assets; do
+	digest=$(hash_file "$artifact_dir/$asset")
+	printf '%s  %s\n' "$digest" "$asset" >> "$manifest_tmp"
+done
+mv "$manifest_tmp" "$artifact_dir/sha256sums.txt"
+trap - EXIT INT TERM

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -131,11 +131,18 @@ jobs:
     needs: [check-and-tag, build]
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v6
+      with:
+        ref: v${{ needs.check-and-tag.outputs.new_version }}
+
     - name: Download build artifacts
       uses: actions/download-artifact@v7
       with:
         path: dist
         merge-multiple: true
+
+    - name: Generate checksum manifest
+      run: .github/scripts/write-sha256sums.sh dist
 
     # Immutable releases require all assets to be attached before the release
     # is published: create as draft, upload assets into the draft, then publish.
@@ -153,5 +160,6 @@ jobs:
           --generate-notes \
           --prerelease \
           --draft \
-          dist/*.tar.gz
+          dist/*.tar.gz \
+          dist/sha256sums.txt
         gh release edit "v${VERSION}" --draft=false

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -123,6 +123,9 @@ jobs:
         path: dist
         merge-multiple: true
 
+    - name: Generate checksum manifest
+      run: .github/scripts/write-sha256sums.sh dist
+
     - name: Bump version, commit, and tag
       env:
         NEW_VERSION: ${{ inputs.version }}
@@ -142,5 +145,6 @@ jobs:
           --title "v${VERSION}" \
           --generate-notes \
           --draft \
-          dist/*.tar.gz
+          dist/*.tar.gz \
+          dist/sha256sums.txt
         gh release edit "v${VERSION}" --draft=false --latest

--- a/commands/autoupdate.go
+++ b/commands/autoupdate.go
@@ -28,9 +28,10 @@ var (
 	autoUpdateCheckTimeout = 2 * time.Second
 	// manualCheckTimeout bounds the release lookup for `af upgrade`.
 	manualCheckTimeout = 10 * time.Second
-	// autoUpdateDownloadBudget bounds the launch-path download. Release
-	// tarballs are a few MB, so this clears a slow link with room to spare
-	// while capping how long a launch can stall behind a crawling transfer.
+	// autoUpdateDownloadBudget bounds the launch-path manifest and archive
+	// download. Release tarballs are a few MB, so this clears a slow link with
+	// room to spare while capping how long a launch can stall behind a crawling
+	// transfer.
 	autoUpdateDownloadBudget = 45 * time.Second
 )
 

--- a/commands/plugins_gen.go
+++ b/commands/plugins_gen.go
@@ -360,9 +360,10 @@ func codexTmuxGuardHook() string {
 // afPreflightHook reports whether af is on PATH, and nothing else.
 //
 // It deliberately does NOT download or install anything. A plugin hook runs as
-// the user, and af's releases carry no checksum or signature to verify against
-// (install.sh and `af upgrade` both check only that the tarball is a tarball),
-// so fetch-and-execute from inside an agent session is the wrong shape at any
+// the user. Af verifies release checksums, but those checksums are unsigned and
+// arrive through the same release channel as the archive, so they protect
+// against corruption rather than a compromised publisher or channel.
+// Fetch-and-execute from inside an agent session remains the wrong shape at any
 // convenience — see #2172 and #2174. Detect and instruct.
 func afPreflightHook() string {
 	return "#!/usr/bin/env bash\n" +

--- a/commands/plugins_gen_test.go
+++ b/commands/plugins_gen_test.go
@@ -229,9 +229,10 @@ func mustUnmarshalGenerated(t *testing.T, files []pluginFile, path string, out a
 }
 
 // TestPreflightHookNeverInstalls is the #2172/#2174 rule as a test: the hook
-// runs as the user, af's releases carry no checksum to verify, so the hook may
-// PRINT the install command and must never run it. Every mention of the
-// installer therefore has to sit inside an echo or a comment.
+// runs as the user, and an unsigned checksum delivered beside the archive does
+// not make unattended fetch-and-execute appropriate. The hook may PRINT the
+// install command and must never run it. Every mention of the installer
+// therefore has to sit inside an echo or a comment.
 func TestPreflightHookNeverInstalls(t *testing.T) {
 	hook := afPreflightHook()
 	if !strings.Contains(hook, session.AfInstallCommand) {

--- a/commands/upgrade.go
+++ b/commands/upgrade.go
@@ -35,8 +35,9 @@ const (
 // Download timeouts are variables (not consts) so tests can shrink them to
 // keep the stalled-server case under a few seconds.
 var (
-	// downloadTimeout caps the total time spent fetching the release tarball.
-	// Binaries are <10MB but we stay generous to tolerate slow links.
+	// downloadTimeout caps the total time spent fetching the checksum manifest
+	// and release tarball. Binaries are <10MB but we stay generous to tolerate
+	// slow links.
 	downloadTimeout = 5 * time.Minute
 	// downloadResponseHeaderTimeout caps the time spent waiting for response
 	// headers, so a server that accepts the TCP connection but never replies
@@ -48,9 +49,10 @@ var (
 // standing up an httptest server.
 var downloadBinaryFn = downloadBinary
 
-// downloadBinary fetches the release tarball at url and returns the embedded
-// `agent-factory` binary bytes. CandidateStager bounds both the overall fetch
-// and response-header wait so a stalled server cannot hang the caller (#471).
+// downloadBinary fetches the release tarball at url, verifies it against the
+// sibling checksum manifest, and returns the embedded `agent-factory` binary
+// bytes. CandidateStager bounds both the overall fetch and response-header wait
+// so a stalled server cannot hang the caller (#471).
 func downloadBinary(url string, timeout time.Duration) ([]byte, error) {
 	return candidateStager().Download(url, timeout)
 }

--- a/commands/upgrade_restart_test.go
+++ b/commands/upgrade_restart_test.go
@@ -3,8 +3,6 @@ package commands
 import (
 	"bytes"
 	"errors"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
@@ -47,15 +45,12 @@ func upgradeHarness(t *testing.T) (binPath string, url string) {
 		t.Fatalf("seed binary: %v", err)
 	}
 	archive := makeTarGz(t, map[string][]byte{"agent-factory": []byte("new-binary")})
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Write(archive)
-	}))
-	t.Cleanup(srv.Close)
+	url = verifiedUpgradeURL(t, archive)
 
 	prevExe := osExecutableFn
 	t.Cleanup(func() { osExecutableFn = prevExe })
 	osExecutableFn = func() (string, error) { return binPath, nil }
-	return binPath, srv.URL
+	return binPath, url
 }
 
 // stubShutdown pins what RequestShutdown reports and counts the calls.

--- a/commands/upgrade_test.go
+++ b/commands/upgrade_test.go
@@ -4,7 +4,9 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"crypto/sha256"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -14,7 +16,35 @@ import (
 	"time"
 
 	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/internal/autoupdate"
 )
+
+const testUpgradeArchiveName = "agent-factory-linux-amd64.tar.gz"
+
+func verifiedUpgradeURL(t *testing.T, archive []byte) string {
+	t.Helper()
+	return upgradeReleaseURL(t, archive, nil)
+}
+
+func upgradeReleaseURL(t *testing.T, archive []byte, archiveHandler http.HandlerFunc) string {
+	t.Helper()
+	checksum := sha256.Sum256(archive)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/"+autoupdate.ChecksumManifestName, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprintf(w, "%x  %s\n", checksum, testUpgradeArchiveName)
+	})
+	mux.HandleFunc("/"+testUpgradeArchiveName, func(w http.ResponseWriter, r *http.Request) {
+		if archiveHandler != nil {
+			archiveHandler(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/gzip")
+		_, _ = w.Write(archive)
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return server.URL + "/" + testUpgradeArchiveName
+}
 
 func TestExtractBinaryFromTarGz(t *testing.T) {
 	archive := makeTarGz(t, map[string][]byte{
@@ -69,14 +99,8 @@ func TestDownloadBinarySuccess(t *testing.T) {
 	archive := makeTarGz(t, map[string][]byte{
 		"agent-factory": []byte("binary-content"),
 	})
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/gzip")
-		w.WriteHeader(200)
-		w.Write(archive)
-	}))
-	defer srv.Close()
 
-	got, err := downloadBinary(srv.URL, downloadTimeout)
+	got, err := downloadBinary(verifiedUpgradeURL(t, archive), downloadTimeout)
 	if err != nil {
 		t.Fatalf("downloadBinary returned error: %v", err)
 	}
@@ -88,12 +112,11 @@ func TestDownloadBinarySuccess(t *testing.T) {
 // TestDownloadBinaryNon200 ensures a non-200 response surfaces as an error
 // rather than being fed to the gzip reader.
 func TestDownloadBinaryNon200(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	url := upgradeReleaseURL(t, []byte("unused archive"), func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "not found", http.StatusNotFound)
-	}))
-	defer srv.Close()
+	})
 
-	_, err := downloadBinary(srv.URL, downloadTimeout)
+	_, err := downloadBinary(url, downloadTimeout)
 	if err == nil || !strings.Contains(err.Error(), "404") {
 		t.Fatalf("expected HTTP 404 error, got %v", err)
 	}
@@ -114,7 +137,7 @@ func TestDownloadBinaryStalled(t *testing.T) {
 	downloadResponseHeaderTimeout = 500 * time.Millisecond
 
 	stalled := make(chan struct{})
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	url := upgradeReleaseURL(t, []byte("unused archive"), func(w http.ResponseWriter, _ *http.Request) {
 		// Send headers immediately, then hang until the test ends. The
 		// client should hit downloadTimeout while reading the body.
 		w.Header().Set("Content-Type", "application/gzip")
@@ -123,17 +146,14 @@ func TestDownloadBinaryStalled(t *testing.T) {
 			f.Flush()
 		}
 		<-stalled
-	}))
-	// Order matters: unblock handler goroutines before Close() waits on them.
-	t.Cleanup(func() {
-		close(stalled)
-		srv.Close()
 	})
+	// Order matters: unblock handler goroutines before the server cleanup waits.
+	t.Cleanup(func() { close(stalled) })
 
 	deadline := time.After(3 * time.Second)
 	done := make(chan error, 1)
 	go func() {
-		_, err := downloadBinary(srv.URL, downloadTimeout)
+		_, err := downloadBinary(url, downloadTimeout)
 		done <- err
 	}()
 
@@ -169,18 +189,15 @@ func TestDownloadBinaryStalledHeaders(t *testing.T) {
 	downloadResponseHeaderTimeout = 500 * time.Millisecond
 
 	stalled := make(chan struct{})
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	url := upgradeReleaseURL(t, []byte("unused archive"), func(_ http.ResponseWriter, _ *http.Request) {
 		<-stalled
-	}))
-	t.Cleanup(func() {
-		close(stalled)
-		srv.Close()
 	})
+	t.Cleanup(func() { close(stalled) })
 
 	deadline := time.After(3 * time.Second)
 	done := make(chan error, 1)
 	go func() {
-		_, err := downloadBinary(srv.URL, downloadTimeout)
+		_, err := downloadBinary(url, downloadTimeout)
 		done <- err
 	}()
 
@@ -205,10 +222,7 @@ func TestUpgradeCallsShutdownAfterBinarySwap(t *testing.T) {
 	}
 
 	archive := makeTarGz(t, map[string][]byte{"agent-factory": []byte("new-binary")})
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Write(archive)
-	}))
-	defer srv.Close()
+	url := verifiedUpgradeURL(t, archive)
 
 	prevExe := osExecutableFn
 	prevShutdown := requestDaemonShutdownFn
@@ -233,7 +247,7 @@ func TestUpgradeCallsShutdownAfterBinarySwap(t *testing.T) {
 	}
 
 	stubDaemonHealth(t, daemon.HealthStatus{})
-	if err := runUpgrade(io.Discard, io.Discard, srv.URL, false); err != nil {
+	if err := runUpgrade(io.Discard, io.Discard, url, false); err != nil {
 		t.Fatalf("runUpgrade: %v", err)
 	}
 	if shutdownCalls != 1 {
@@ -265,10 +279,7 @@ func TestUpgradeSucceedsWhenNoDaemon(t *testing.T) {
 	}
 
 	archive := makeTarGz(t, map[string][]byte{"agent-factory": []byte("new-binary")})
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Write(archive)
-	}))
-	defer srv.Close()
+	url := verifiedUpgradeURL(t, archive)
 
 	prevExe := osExecutableFn
 	prevShutdown := requestDaemonShutdownFn
@@ -291,7 +302,7 @@ func TestUpgradeSucceedsWhenNoDaemon(t *testing.T) {
 	}
 
 	stubDaemonHealth(t, daemon.HealthStatus{})
-	if err := runUpgrade(io.Discard, io.Discard, srv.URL, false); err != nil {
+	if err := runUpgrade(io.Discard, io.Discard, url, false); err != nil {
 		t.Fatalf("runUpgrade with absent daemon failed: %v", err)
 	}
 	if respawnCalls != 0 {
@@ -316,10 +327,7 @@ func TestUpgradeSucceedsWhenShutdownErrors(t *testing.T) {
 	}
 
 	archive := makeTarGz(t, map[string][]byte{"agent-factory": []byte("new-binary")})
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Write(archive)
-	}))
-	defer srv.Close()
+	url := verifiedUpgradeURL(t, archive)
 
 	prevExe := osExecutableFn
 	prevShutdown := requestDaemonShutdownFn
@@ -340,7 +348,7 @@ func TestUpgradeSucceedsWhenShutdownErrors(t *testing.T) {
 	}
 
 	stubDaemonHealth(t, daemon.HealthStatus{})
-	if err := runUpgrade(io.Discard, io.Discard, srv.URL, false); err != nil {
+	if err := runUpgrade(io.Discard, io.Discard, url, false); err != nil {
 		t.Fatalf("runUpgrade should not fail when Shutdown errors, got: %v", err)
 	}
 	got, err := os.ReadFile(tempBin)
@@ -363,10 +371,7 @@ func TestUpgradeReportsSIGTERMFallback(t *testing.T) {
 	}
 
 	archive := makeTarGz(t, map[string][]byte{"agent-factory": []byte("new-binary")})
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Write(archive)
-	}))
-	defer srv.Close()
+	url := verifiedUpgradeURL(t, archive)
 
 	prevExe := osExecutableFn
 	prevShutdown := requestDaemonShutdownFn
@@ -390,7 +395,7 @@ func TestUpgradeReportsSIGTERMFallback(t *testing.T) {
 
 	stubDaemonHealth(t, daemon.HealthStatus{})
 	var out, errOut bytes.Buffer
-	if err := runUpgrade(&out, &errOut, srv.URL, false); err != nil {
+	if err := runUpgrade(&out, &errOut, url, false); err != nil {
 		t.Fatalf("runUpgrade: %v", err)
 	}
 

--- a/docs/agent-plugins.md
+++ b/docs/agent-plugins.md
@@ -89,11 +89,11 @@ The Codex plugin ships two optional hooks:
   the command rather than silently dropping the guard.
 
 The preflight deliberately does not fetch or install anything. A plugin hook runs as you,
-with your permissions, and af's releases carry no checksum or signature to
-verify against — `install.sh` and `af upgrade` both check only that the download
-is a well-formed tarball. Downloading and executing a binary from inside an
-agent session, on the strength of nothing, is the wrong shape however convenient
-it would be. Detect and instruct instead.
+with your permissions. Af verifies release checksums, but those checksums are
+unsigned and arrive through the same release channel as the archive: they catch
+corruption, not a compromised publisher or release channel. Downloading and
+executing a binary from inside an agent session is the wrong shape however
+convenient it would be. Detect and instruct instead.
 
 ## Tmux guard coverage
 

--- a/docs/release-testing-plan.md
+++ b/docs/release-testing-plan.md
@@ -99,7 +99,8 @@ channel; verify a preview release by its `vX.Y.Z-preview-N` tag instead):
 
 ```bash
 gh release view --repo sachiniyer/agent-factory --latest   # or: gh release view <tag>
-gh release download --repo sachiniyer/agent-factory --latest --pattern 'agent-factory-*.tar.gz' --dir /tmp/af-release
+gh release download --repo sachiniyer/agent-factory --latest --pattern 'agent-factory-*.tar.gz' --pattern sha256sums.txt --dir /tmp/af-release
+(cd /tmp/af-release && sha256sum --check sha256sums.txt) # macOS: shasum -a 256 --check sha256sums.txt
 for archive in /tmp/af-release/*.tar.gz; do
   tar tzf "$archive"
 done
@@ -108,6 +109,7 @@ done
 Expected result:
 - Artifacts exist for `linux-amd64`, `linux-arm64`, `darwin-amd64`, and
   `darwin-arm64`.
+- `sha256sums.txt` has one matching entry for each archive and no mismatches.
 - Each archive contains one executable named `agent-factory`.
 - The host-platform binary runs `version` and reports the new tag.
 

--- a/install.sh
+++ b/install.sh
@@ -101,6 +101,28 @@ download() {
 	fi
 }
 
+# v1.0.206 predates published checksum manifests, but install.sh is served from
+# master immediately: requiring the new release asset unconditionally would
+# break the documented `.../master/install.sh | sh` path until the next stable
+# release exists. These are the SHA-256 digests GitHub records on the v1.0.206
+# release assets. The `latest` fallback is still fail-closed after a newer
+# release: only the exact v1.0.206 bytes can match these pinned values.
+pinned_pre_manifest_checksums() {
+	case "$VERSION" in
+	latest|v1.0.206)
+		cat <<'CHECKSUMS'
+f28be8db1a63bbfa082eb801d8a782f2fc4dd03e9b05d4fc7fbe78a9f2b02ec2  agent-factory-darwin-amd64.tar.gz
+a36f0cda68dd8838e8c4b990f84396665613cac35927b086259a56622b24e33a  agent-factory-darwin-arm64.tar.gz
+6db75e6ff648c3b8d75172a4720b9eb8b8477bd52cd753a85b2495b67ffc633b  agent-factory-linux-amd64.tar.gz
+bf62bb15e07e06594a34dfdc7c5a0408eb48e2d10fa858ea06d30689915ec982  agent-factory-linux-arm64.tar.gz
+CHECKSUMS
+		;;
+	*)
+		return 1
+		;;
+	esac
+}
+
 # --- download into a temp dir, verify, install -----------------------------
 tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/af-install.XXXXXX")"
 cleanup() { rm -rf "$tmpdir"; }
@@ -116,9 +138,12 @@ if ! download "$url" "$tarball"; then
 	exit 1
 fi
 if ! download "$checksums_url" "$checksums"; then
-	echo "error: checksum manifest download failed from $checksums_url" >&2
-	echo "The release is incomplete or predates checksum verification; refusing to install it." >&2
-	exit 1
+	if ! pinned_pre_manifest_checksums > "$checksums"; then
+		echo "error: checksum manifest download failed from $checksums_url" >&2
+		echo "The release is incomplete or predates checksum verification; refusing to install it." >&2
+		exit 1
+	fi
+	echo "Checksum manifest unavailable; verifying against pinned v1.0.206 checksums."
 fi
 
 # Select exactly one well-formed entry for this platform archive. A missing,

--- a/install.sh
+++ b/install.sh
@@ -80,10 +80,12 @@ esac
 
 asset="agent-factory-${os}-${arch}.tar.gz"
 if [ "$VERSION" = "latest" ]; then
-	url="https://github.com/$REPO/releases/latest/download/$asset"
+	release_url="https://github.com/$REPO/releases/latest/download"
 else
-	url="https://github.com/$REPO/releases/download/$VERSION/$asset"
+	release_url="https://github.com/$REPO/releases/download/$VERSION"
 fi
+url="$release_url/$asset"
+checksums_url="$release_url/sha256sums.txt"
 
 # --- downloader (curl, falling back to wget) -------------------------------
 download() {
@@ -105,11 +107,58 @@ cleanup() { rm -rf "$tmpdir"; }
 trap cleanup EXIT INT TERM
 
 tarball="$tmpdir/$asset"
+checksums="$tmpdir/sha256sums.txt"
 
 echo "Downloading $asset ($VERSION) for $os/$arch..."
 if ! download "$url" "$tarball"; then
 	echo "error: download failed from $url" >&2
 	echo "Check your network, or that the release/tag exists at https://github.com/$REPO/releases" >&2
+	exit 1
+fi
+if ! download "$checksums_url" "$checksums"; then
+	echo "error: checksum manifest download failed from $checksums_url" >&2
+	echo "The release is incomplete or predates checksum verification; refusing to install it." >&2
+	exit 1
+fi
+
+# Select exactly one well-formed entry for this platform archive. A missing,
+# malformed, or duplicate entry is an incomplete release, never permission to
+# install without verification.
+expected_checksum="$(awk -v target="$asset" '
+	{
+		if (NF != 2) next
+		name = $2
+		sub(/^\*/, "", name)
+		if (name == target) {
+			matches++
+			digest = $1
+		}
+	}
+	END {
+		if (matches != 1 || length(digest) != 64 || digest ~ /[^[:xdigit:]]/) exit 1
+		print tolower(digest)
+	}
+' "$checksums")" || {
+	echo "error: checksum manifest has no single valid SHA-256 entry for $asset" >&2
+	exit 1
+}
+
+if command -v sha256sum >/dev/null 2>&1; then
+	actual_checksum="$(sha256sum "$tarball" | awk '{print tolower($1)}')"
+elif command -v shasum >/dev/null 2>&1; then
+	actual_checksum="$(shasum -a 256 "$tarball" | awk '{print tolower($1)}')"
+elif command -v openssl >/dev/null 2>&1; then
+	actual_checksum="$(openssl dgst -sha256 "$tarball" | awk '{print tolower($NF)}')"
+else
+	echo "error: sha256sum, shasum, or openssl is required to verify the release" >&2
+	exit 1
+fi
+
+if [ "$actual_checksum" != "$expected_checksum" ]; then
+	echo "error: checksum mismatch for $asset" >&2
+	echo "Expected: $expected_checksum" >&2
+	echo "Actual:   $actual_checksum" >&2
+	echo "The download may be corrupted or tampered with; refusing to install it." >&2
 	exit 1
 fi
 

--- a/internal/autoupdate/staging.go
+++ b/internal/autoupdate/staging.go
@@ -2,10 +2,18 @@ package autoupdate
 
 import (
 	"archive/tar"
+	"bufio"
+	"bytes"
 	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"os"
+	"path"
 	"strings"
 	"time"
 )
@@ -13,10 +21,15 @@ import (
 const (
 	// CandidateBinaryName is the executable name embedded in release archives.
 	CandidateBinaryName = "agent-factory"
+	// ChecksumManifestName is the release asset that authenticates every platform
+	// archive before extraction.
+	ChecksumManifestName = "sha256sums.txt"
 	// DefaultResponseHeaderTimeout bounds a release server that accepts a
 	// connection but never begins its response.
 	DefaultResponseHeaderTimeout = 30 * time.Second
 	maxBinarySize                = 500 << 20 // 500 MB
+	maxArchiveSize               = 600 << 20 // compressed binary plus tar metadata
+	maxChecksumManifestSize      = 1 << 20   // four entries today; leave ample headroom
 )
 
 // CandidateStager downloads a release archive and extracts its candidate
@@ -49,27 +62,159 @@ func (stager CandidateStager) NewDownloadClient(timeout time.Duration) *http.Cli
 	}
 }
 
-// Download fetches url and returns the embedded candidate binary bytes.
-func (stager CandidateStager) Download(url string, timeout time.Duration) ([]byte, error) {
-	response, err := stager.NewDownloadClient(timeout).Get(url)
+// Download fetches a release archive and its sibling checksum manifest, verifies
+// the complete archive, and only then extracts the candidate binary. Verification
+// is intrinsic to the shared stager so manual upgrade and auto-update cannot
+// accidentally diverge on release integrity.
+func (stager CandidateStager) Download(archiveURL string, timeout time.Duration) ([]byte, error) {
+	manifestURL, archiveName, err := checksumLocation(archiveURL)
 	if err != nil {
-		return nil, fmt.Errorf("download failed: %w", err)
+		return nil, err
 	}
-	defer response.Body.Close()
+	ctx := context.Background()
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+	client := stager.NewDownloadClient(timeout)
 
-	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("download failed: HTTP %d from %s", response.StatusCode, url)
+	manifest, err := downloadBounded(ctx, client, manifestURL, maxChecksumManifestSize, "checksum manifest")
+	if err != nil {
+		return nil, err
+	}
+	expected, err := checksumForAsset(manifest, archiveName)
+	if err != nil {
+		return nil, fmt.Errorf("invalid checksum manifest: %w", err)
+	}
+	archive, err := os.CreateTemp("", "agent-factory-release-*.tar.gz")
+	if err != nil {
+		return nil, fmt.Errorf("create temporary release archive: %w", err)
+	}
+	archivePath := archive.Name()
+	defer func() {
+		_ = archive.Close()
+		_ = os.Remove(archivePath)
+	}()
+
+	hasher := sha256.New()
+	if err := downloadToBounded(
+		ctx,
+		client,
+		archiveURL,
+		maxArchiveSize,
+		"release archive",
+		io.MultiWriter(archive, hasher),
+	); err != nil {
+		return nil, err
+	}
+	actual := hasher.Sum(nil)
+	if !bytes.Equal(actual, expected[:]) {
+		return nil, fmt.Errorf("checksum mismatch for %s: expected %x, got %x", archiveName, expected, actual)
+	}
+	if _, err := archive.Seek(0, io.SeekStart); err != nil {
+		return nil, fmt.Errorf("rewind verified release archive: %w", err)
 	}
 
 	binaryName := stager.BinaryName
 	if binaryName == "" {
 		binaryName = CandidateBinaryName
 	}
-	binary, err := ExtractBinaryFromTarGz(response.Body, binaryName)
+	binary, err := ExtractBinaryFromTarGz(archive, binaryName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract binary: %w", err)
 	}
 	return binary, nil
+}
+
+func checksumLocation(archiveURL string) (manifestURL, archiveName string, err error) {
+	parsed, err := url.Parse(archiveURL)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid release archive URL: %w", err)
+	}
+	archiveName = path.Base(parsed.Path)
+	if archiveName == "" || archiveName == "." || archiveName == "/" {
+		return "", "", fmt.Errorf("release archive URL has no asset name: %s", archiveURL)
+	}
+	parsed.Path = path.Join(path.Dir(parsed.Path), ChecksumManifestName)
+	parsed.RawPath = ""
+	return parsed.String(), archiveName, nil
+}
+
+func downloadBounded(
+	ctx context.Context,
+	client *http.Client,
+	rawURL string,
+	maxBytes int64,
+	description string,
+) ([]byte, error) {
+	var data bytes.Buffer
+	if err := downloadToBounded(ctx, client, rawURL, maxBytes, description, &data); err != nil {
+		return nil, err
+	}
+	return data.Bytes(), nil
+}
+
+func downloadToBounded(
+	ctx context.Context,
+	client *http.Client,
+	rawURL string,
+	maxBytes int64,
+	description string,
+	destination io.Writer,
+) error {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return fmt.Errorf("%s download failed: %w", description, err)
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return fmt.Errorf("%s download failed: %w", description, err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("%s download failed: HTTP %d from %s", description, response.StatusCode, rawURL)
+	}
+	written, err := io.Copy(destination, io.LimitReader(response.Body, maxBytes+1))
+	if err != nil {
+		return fmt.Errorf("%s download failed: %w", description, err)
+	}
+	if written > maxBytes {
+		return fmt.Errorf("%s exceeds maximum size of %d bytes", description, maxBytes)
+	}
+	return nil
+}
+
+func checksumForAsset(manifest []byte, archiveName string) ([sha256.Size]byte, error) {
+	var checksum [sha256.Size]byte
+	found := false
+	scanner := bufio.NewScanner(bytes.NewReader(manifest))
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) != 2 {
+			continue
+		}
+		name := strings.TrimPrefix(fields[1], "*")
+		if name != archiveName {
+			continue
+		}
+		if found {
+			return checksum, fmt.Errorf("duplicate checksum entry for %s", archiveName)
+		}
+		decoded, err := hex.DecodeString(fields[0])
+		if err != nil || len(decoded) != sha256.Size {
+			return checksum, fmt.Errorf("malformed SHA-256 for %s", archiveName)
+		}
+		copy(checksum[:], decoded)
+		found = true
+	}
+	if err := scanner.Err(); err != nil {
+		return checksum, fmt.Errorf("read manifest: %w", err)
+	}
+	if !found {
+		return checksum, fmt.Errorf("no checksum for %s", archiveName)
+	}
+	return checksum, nil
 }
 
 // ExtractBinaryFromTarGz returns the regular file named binaryName, including

--- a/internal/autoupdate/staging_test.go
+++ b/internal/autoupdate/staging_test.go
@@ -4,18 +4,27 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"crypto/sha256"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
 
+const testReleaseArchiveName = "agent-factory-linux-amd64.tar.gz"
+
 func TestCandidateStagerDownloadsNestedBinary(t *testing.T) {
 	archive := testTarGz(t, "dist/agent-factory", []byte("candidate-binary"))
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		if _, err := w.Write(archive); err != nil {
-			t.Errorf("write archive: %v", err)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/sha256sums.txt":
+			_, _ = w.Write(testChecksumManifest(testReleaseArchiveName, archive))
+		case "/" + testReleaseArchiveName:
+			_, _ = w.Write(archive)
+		default:
+			http.NotFound(w, r)
 		}
 	}))
 	t.Cleanup(server.Close)
@@ -24,7 +33,7 @@ func TestCandidateStagerDownloadsNestedBinary(t *testing.T) {
 		BinaryName:            "agent-factory",
 		ResponseHeaderTimeout: time.Second,
 	}
-	candidate, err := stager.Download(server.URL, time.Second)
+	candidate, err := stager.Download(server.URL+"/"+testReleaseArchiveName, time.Second)
 	if err != nil {
 		t.Fatalf("Download: %v", err)
 	}
@@ -39,10 +48,82 @@ func TestCandidateStagerRejectsNonSuccessResponse(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	_, err := (CandidateStager{ResponseHeaderTimeout: time.Second}).Download(server.URL, time.Second)
+	_, err := (CandidateStager{ResponseHeaderTimeout: time.Second}).Download(
+		server.URL+"/"+testReleaseArchiveName,
+		time.Second,
+	)
 	if err == nil {
 		t.Fatal("Download returned nil error for HTTP 404")
 	}
+}
+
+func TestCandidateStagerRejectsChecksumMismatch(t *testing.T) {
+	archive := []byte("not even a gzip archive")
+	mux := http.NewServeMux()
+	mux.HandleFunc("/sha256sums.txt", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(strings.Repeat("0", 64) + "  " + testReleaseArchiveName + "\n"))
+	})
+	mux.HandleFunc("/"+testReleaseArchiveName, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(archive)
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	_, err := (CandidateStager{ResponseHeaderTimeout: time.Second}).Download(
+		server.URL+"/"+testReleaseArchiveName,
+		time.Second,
+	)
+	if err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("Download error = %v, want checksum mismatch", err)
+	}
+}
+
+func TestCandidateStagerRejectsMissingChecksumEntryBeforeArchiveDownload(t *testing.T) {
+	archiveRequested := make(chan struct{}, 1)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/sha256sums.txt", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(testChecksumManifest("some-other-asset.tar.gz", []byte("other")))
+	})
+	mux.HandleFunc("/"+testReleaseArchiveName, func(w http.ResponseWriter, _ *http.Request) {
+		archiveRequested <- struct{}{}
+		_, _ = w.Write([]byte("untrusted archive"))
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	_, err := (CandidateStager{ResponseHeaderTimeout: time.Second}).Download(
+		server.URL+"/"+testReleaseArchiveName,
+		time.Second,
+	)
+	if err == nil || !strings.Contains(err.Error(), "no checksum") {
+		t.Fatalf("Download error = %v, want missing checksum entry", err)
+	}
+	select {
+	case <-archiveRequested:
+		t.Fatal("archive was downloaded before its checksum entry was validated")
+	default:
+	}
+}
+
+func TestCandidateStagerRejectsMalformedChecksum(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/sha256sums.txt", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprintf(w, "not-a-sha256  %s\n", testReleaseArchiveName)
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	_, err := (CandidateStager{ResponseHeaderTimeout: time.Second}).Download(
+		server.URL+"/"+testReleaseArchiveName,
+		time.Second,
+	)
+	if err == nil || !strings.Contains(err.Error(), "malformed SHA-256") {
+		t.Fatalf("Download error = %v, want malformed checksum", err)
+	}
+}
+
+func testChecksumManifest(archiveName string, archive []byte) []byte {
+	return []byte(fmt.Sprintf("%x  %s\n", sha256.Sum256(archive), archiveName))
 }
 
 func testTarGz(t *testing.T, name string, contents []byte) []byte {

--- a/scripts/release_checksums_test.go
+++ b/scripts/release_checksums_test.go
@@ -123,3 +123,71 @@ esac
 		t.Fatalf("install.sh error = %v, output = %q; want checksum mismatch", err, output)
 	}
 }
+
+func runInstallWithoutChecksumManifest(t *testing.T, version string) (string, error) {
+	t.Helper()
+	dir := t.TempDir()
+	fakeBin := filepath.Join(dir, "fakebin")
+	writeExecutable(t, filepath.Join(fakeBin, "uname"), `#!/bin/sh
+case "$1" in
+	-s) echo Linux ;;
+	-m) echo x86_64 ;;
+	*) exit 2 ;;
+esac
+`)
+	writeExecutable(t, filepath.Join(fakeBin, "curl"), `#!/bin/sh
+out=
+while [ "$#" -gt 0 ]; do
+	if [ "$1" = "-o" ]; then
+		out="$2"
+		break
+	fi
+	shift
+done
+[ -n "$out" ] || exit 2
+case "$out" in
+	*/sha256sums.txt) exit 22 ;;
+	*) printf legacy-archive > "$out" ;;
+esac
+`)
+	writeExecutable(t, filepath.Join(fakeBin, "sha256sum"), `#!/bin/sh
+printf '%s  %s\n' '6db75e6ff648c3b8d75172a4720b9eb8b8477bd52cd753a85b2495b67ffc633b' "$1"
+`)
+
+	root := repoRoot(t)
+	args := []string{filepath.Join(root, "install.sh")}
+	if version != "" {
+		args = append(args, "--version", version)
+	}
+	cmd := exec.Command("sh", args...)
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(),
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"AF_INSTALL_DIR="+filepath.Join(dir, "install"),
+	)
+	output, err := cmd.CombinedOutput()
+	return string(output), err
+}
+
+func TestInstallScriptUsesPinnedChecksumForPreManifestLatest(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("install.sh is POSIX sh; not run on Windows")
+	}
+	output, err := runInstallWithoutChecksumManifest(t, "")
+	if err == nil || !strings.Contains(output, "not a valid gzip/tar archive") {
+		t.Fatalf("install.sh error = %v, output = %q; want checksum verification to reach archive validation", err, output)
+	}
+	if strings.Contains(output, "checksum manifest download failed") {
+		t.Fatalf("default install rejected the pinned pre-manifest release: %q", output)
+	}
+}
+
+func TestInstallScriptRejectsMissingManifestForUnpinnedRelease(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("install.sh is POSIX sh; not run on Windows")
+	}
+	output, err := runInstallWithoutChecksumManifest(t, "v9.9.9")
+	if err == nil || !strings.Contains(output, "checksum manifest download failed") {
+		t.Fatalf("install.sh error = %v, output = %q; want missing-manifest rejection", err, output)
+	}
+}

--- a/scripts/release_checksums_test.go
+++ b/scripts/release_checksums_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+var checksumReleaseAssets = []string{
+	"agent-factory-darwin-amd64.tar.gz",
+	"agent-factory-darwin-arm64.tar.gz",
+	"agent-factory-linux-amd64.tar.gz",
+	"agent-factory-linux-arm64.tar.gz",
+}
+
+func TestReleaseWorkflowsPublishChecksumManifest(t *testing.T) {
+	for _, workflow := range []string{"stable-release.yml", "auto-release.yml"} {
+		workflow := workflow
+		t.Run(workflow, func(t *testing.T) {
+			contents, err := os.ReadFile(filepath.Join(repoRoot(t), ".github", "workflows", workflow))
+			if err != nil {
+				t.Fatalf("read workflow: %v", err)
+			}
+			text := string(contents)
+			if !strings.Contains(text, ".github/scripts/write-sha256sums.sh dist") {
+				t.Fatal("release workflow does not generate the shared checksum manifest")
+			}
+			if !strings.Contains(text, "dist/sha256sums.txt") {
+				t.Fatal("release workflow does not upload sha256sums.txt")
+			}
+		})
+	}
+}
+
+func TestWriteSHA256SumsScript(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("write-sha256sums.sh is POSIX sh; not run on Windows")
+	}
+	dist := t.TempDir()
+	var expected strings.Builder
+	for _, asset := range checksumReleaseAssets {
+		contents := []byte("archive-" + asset)
+		writeFile(t, filepath.Join(dist, asset), string(contents))
+		_, _ = fmt.Fprintf(&expected, "%x  %s\n", sha256.Sum256(contents), asset)
+	}
+
+	cmd := exec.Command("sh", filepath.Join(repoRoot(t), ".github", "scripts", "write-sha256sums.sh"), dist)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("write-sha256sums.sh failed: %v\n%s", err, output)
+	}
+	manifest, err := os.ReadFile(filepath.Join(dist, "sha256sums.txt"))
+	if err != nil {
+		t.Fatalf("read checksum manifest: %v", err)
+	}
+	if string(manifest) != expected.String() {
+		t.Fatalf("manifest = %q, want %q", manifest, expected.String())
+	}
+}
+
+func TestWriteSHA256SumsScriptRejectsMissingArtifact(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("write-sha256sums.sh is POSIX sh; not run on Windows")
+	}
+	dist := t.TempDir()
+	for _, asset := range checksumReleaseAssets[:len(checksumReleaseAssets)-1] {
+		writeFile(t, filepath.Join(dist, asset), "archive")
+	}
+
+	cmd := exec.Command("sh", filepath.Join(repoRoot(t), ".github", "scripts", "write-sha256sums.sh"), dist)
+	output, err := cmd.CombinedOutput()
+	if err == nil || !strings.Contains(string(output), "release artifact is missing") {
+		t.Fatalf("write-sha256sums.sh error = %v, output = %q; want missing-artifact failure", err, output)
+	}
+}
+
+func TestInstallScriptRejectsChecksumMismatch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("install.sh is POSIX sh; not run on Windows")
+	}
+	dir := t.TempDir()
+	fakeBin := filepath.Join(dir, "fakebin")
+	writeExecutable(t, filepath.Join(fakeBin, "uname"), `#!/bin/sh
+case "$1" in
+	-s) echo Linux ;;
+	-m) echo x86_64 ;;
+	*) exit 2 ;;
+esac
+`)
+	writeExecutable(t, filepath.Join(fakeBin, "curl"), `#!/bin/sh
+out=
+while [ "$#" -gt 0 ]; do
+	if [ "$1" = "-o" ]; then
+		out="$2"
+		break
+	fi
+	shift
+done
+[ -n "$out" ] || exit 2
+case "$out" in
+	*/sha256sums.txt)
+		printf '%s\n' '0000000000000000000000000000000000000000000000000000000000000000  agent-factory-linux-amd64.tar.gz' > "$out"
+		;;
+	*)
+		printf untrusted-archive > "$out"
+		;;
+esac
+`)
+
+	root := repoRoot(t)
+	cmd := exec.Command("sh", filepath.Join(root, "install.sh"), "--version", "v9.9.9")
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(),
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"AF_INSTALL_DIR="+filepath.Join(dir, "install"),
+	)
+	output, err := cmd.CombinedOutput()
+	if err == nil || !strings.Contains(string(output), "checksum mismatch") {
+		t.Fatalf("install.sh error = %v, output = %q; want checksum mismatch", err, output)
+	}
+}

--- a/scripts/release_scripts_test.go
+++ b/scripts/release_scripts_test.go
@@ -487,6 +487,13 @@ func TestInstallScriptRestartsDaemonWithInstalledBinary(t *testing.T) {
 	installDir := filepath.Join(dir, "install")
 	callsFile := filepath.Join(dir, "af-calls")
 
+	writeExecutable(t, filepath.Join(fakeBin, "uname"), `#!/bin/sh
+case "$1" in
+	-s) echo Linux ;;
+	-m) echo x86_64 ;;
+	*) exit 2 ;;
+esac
+`)
 	writeExecutable(t, filepath.Join(fakeBin, "curl"), `#!/bin/sh
 out=
 while [ "$#" -gt 0 ]; do
@@ -497,7 +504,14 @@ while [ "$#" -gt 0 ]; do
 	shift
 done
 [ -n "$out" ] || exit 2
-printf fake-tarball > "$out"
+case "$out" in
+	*/sha256sums.txt)
+		printf '%s\n' '746e8948ec0a7b6e150cc34446bad2bd0d0e2e3f0bd8f03f0edef7467a38e3b6  agent-factory-linux-amd64.tar.gz' > "$out"
+		;;
+	*)
+		printf fake-tarball > "$out"
+		;;
+esac
 `)
 	writeExecutable(t, filepath.Join(fakeBin, "tar"), `#!/bin/sh
 case "$1" in


### PR DESCRIPTION
## Summary

- publish one deterministic `sha256sums.txt` asset for all four stable and preview release archives
- make `install.sh`, `af upgrade`, and auto-update fail closed through their shared checksum-verification choke point
- verify the complete archive before extraction without buffering it twice in memory
- keep the security documentation honest: checksums detect corruption, while signing remains a separate authenticity decision

## Verified defect

On the master version this branch started from, the stable and preview workflows uploaded only `dist/*.tar.gz` (`.github/workflows/stable-release.yml:142-145`, `.github/workflows/auto-release.yml:153-156`), `install.sh:116-123` checked only tar structure, and `internal/autoupdate/staging.go:77` passed the unverified response directly to gzip extraction. The shared stager is used by both manual upgrade and auto-update.

## Regression coverage

- valid manifest and archive
- checksum mismatch before archive parsing
- missing target entry before archive download
- malformed digest
- installer mismatch refusal
- incomplete release artifact set
- both release workflows generate and upload the manifest

## Exact-head gates

Head: `b3b88db4a8bbdd4e50f4db47a43d9a748a488703`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- supplemental: `shellcheck install.sh .github/scripts/write-sha256sums.sh`
- supplemental: `actionlint .github/workflows/stable-release.yml .github/workflows/auto-release.yml`

All passed on the pushed head.

Closes #2174

— Captain Claude
