### PR TITLE
fix(ui): key tab state by stable identity

### DIFF
--- a/app/handle_panes.go
+++ b/app/handle_panes.go
@@ -443,13 +443,11 @@ func (r tabSlotResolver) resolve(key tabSlotKey) (int, bool) {
 // opened). Re-resolving the pre-change key is what makes the selection move WITH
 // its tab instead.
 //
-// The sidebar cursor is remapped in the same breath, and that is load-bearing
-// rather than cosmetic: a tab row is keyed by SLOT (rowIdentity), so the cursor
-// has the same exposure, and pushSelection reads the cursor's slot straight back
-// into store.ActiveTab — leaving it behind would let the next read CLOBBER this
-// remap back onto the wrong tab. SyncCursorToActiveTab no-ops unless the cursor
-// really rests on a tab row, so a cursor parked on a header or an instance row is
-// untouched.
+// The caller remaps a tab-row cursor after this returns. That separation is
+// load-bearing for a same-title replacement: ReplaceInstanceByTitle may re-sort
+// the projection, so the sidebar's flattened indices are stale until the final
+// selection assertion rebuilds them. Syncing here would read a neighbor through
+// the stale index and overwrite the durable last-cursor identity.
 //
 // Only the STORE's selected instance has an active tab to carry (the same
 // question handleCloseTab answers with treeIsSelected), and a tab that is truly
@@ -469,7 +467,6 @@ func (m *home) reconcileActiveTabForTabs(instance *session.Instance, oldKeys []t
 	}
 	m.store.SetActiveTab(idx)
 	m.clampSelectionTab()
-	m.sidebar.SyncCursorToActiveTab()
 	return true
 }
 

--- a/app/handle_panes.go
+++ b/app/handle_panes.go
@@ -431,7 +431,7 @@ func (r tabSlotResolver) resolve(key tabSlotKey) (int, bool) {
 	return idx, ok
 }
 
-// reconcileActiveTabForTabs carries the TREE's selection across a tab-set change
+// remapActiveTabForTabs carries the TREE's selection across a tab-set change
 // — the selection twin of reconcilePanesForTabs, keyed by the same identity
 // through the same resolver.
 //
@@ -453,7 +453,7 @@ func (r tabSlotResolver) resolve(key tabSlotKey) (int, bool) {
 // question handleCloseTab answers with treeIsSelected), and a tab that is truly
 // gone is left to the existing clamp — this fixes where the selection LANDS under
 // a permutation, and deliberately does not change what an out-of-band close does.
-func (m *home) reconcileActiveTabForTabs(instance *session.Instance, oldKeys []tabSlotKey, domain tabIdentityDomain) bool {
+func (m *home) remapActiveTabForTabs(instance *session.Instance, oldKeys []tabSlotKey, domain tabIdentityDomain) bool {
 	if instance == nil || instance != m.store.GetSelectedInstance() {
 		return false
 	}

--- a/app/handle_panes.go
+++ b/app/handle_panes.go
@@ -469,7 +469,6 @@ func (m *home) reconcileActiveTabForTabs(instance *session.Instance, oldKeys []t
 	}
 	m.store.SetActiveTab(idx)
 	m.clampSelectionTab()
-	m.menu.SetActiveTab(m.store.ActiveTab())
 	m.sidebar.SyncCursorToActiveTab()
 	return true
 }

--- a/app/handle_tabs.go
+++ b/app/handle_tabs.go
@@ -140,7 +140,6 @@ func (m *home) createNewTab(selected *session.Instance, kind session.TabKind) (t
 	// the browser renders the editor itself.
 	newIdx := len(tree.TabLabels(selected)) - 1
 	m.store.SetActiveTab(newIdx)
-	m.menu.SetActiveTab(newIdx)
 	m.sidebar.SyncCursorToActiveTab()
 	return m.openOrFocusPane(selected, newIdx)
 }
@@ -287,7 +286,6 @@ func (m *home) handleCloseTab() (tea.Model, tea.Cmd) {
 		}
 		m.store.SetActiveTab(next)
 		m.clampSelectionTab()
-		m.menu.SetActiveTab(m.store.ActiveTab())
 		m.sidebar.SyncCursorToActiveTab()
 	}
 	return m, m.selectionChanged()
@@ -330,7 +328,6 @@ func (m *home) handleTabJump(oneBased int) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	m.store.SetActiveTab(idx)
-	m.menu.SetActiveTab(idx)
 	m.sidebar.SyncCursorToActiveTab()
 	return m, m.selectionChanged()
 }

--- a/app/home_panes.go
+++ b/app/home_panes.go
@@ -50,10 +50,6 @@ func (m *home) selectionChanged() tea.Cmd {
 		m.store.SetSelectedInstance(selected)
 		m.clampSelectionTab()
 		m.menu.SetInstance(selected)
-		// The tree cursor drives the active tab too (landing on a tab row
-		// selects that tab — #1024 PR 3), so mirror it into the menu here, not
-		// just in the explicit tab-jump handlers.
-		m.menu.SetActiveTab(m.store.ActiveTab())
 		m.maybeAutoOpenInitialPane(selected)
 		previewTab := m.store.ActiveTab()
 		previewTabSpecific := previewTab != 0

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -400,7 +400,6 @@ func TestPanePreviewEscFromScrollRevertsOriginalCommittedTab(t *testing.T) {
 	require.Equal(t, 1, paneA.Tab(), "precondition: original pane is alpha's terminal tab")
 
 	h.store.SetActiveTab(0)
-	h.menu.SetActiveTab(0)
 	h.sidebar.SetSelectedInstance(1)
 	_ = h.selectionChanged()
 	require.NotNil(t, h.panePreviewTxn)
@@ -503,7 +502,6 @@ func TestPanePreviewInstanceRowUsesSelectedTerminalTab(t *testing.T) {
 
 	h.sidebar.SetSelectedInstance(1)
 	h.store.SetActiveTab(1)
-	h.menu.SetActiveTab(1)
 	_ = h.selectionChanged()
 
 	sel := h.sidebar.GetSelection()
@@ -1000,7 +998,6 @@ func TestPaneArrowKeysSwitchFocusedPaneAndClamp(t *testing.T) {
 
 	h.focusRegion(layout.RegionTree)
 	h.store.SetActiveTab(1) // Unopened terminal tab: isolate tree routing from #1493 open-pane focus.
-	h.menu.SetActiveTab(1)
 	_, _ = h.handleKeyPress(tea.KeyMsg{Type: tea.KeyLeft})
 	assert.Equal(t, layout.RegionTree, h.ring.Active(), "left/right on the tree stay sidebar navigation, not pane switching")
 	_, _ = h.handleKeyPress(tea.KeyMsg{Type: tea.KeyRight})

--- a/app/pane_preview.go
+++ b/app/pane_preview.go
@@ -71,9 +71,10 @@ func paneBindingIdentityOf(binding paneBinding) paneBindingIdentity {
 	if tab.Kind != session.TabKindAgent {
 		identity.tabID = tab.ID
 	}
-	if identity.tabID == "" {
-		identity.tabName = tab.Name
-	}
+	// Keep the name even when an ID is present. A freshly-created tab is locally
+	// ID-less until the daemon snapshot backfills it; a suppression captured on
+	// one side of that transition needs the name as its shared identity bridge.
+	identity.tabName = tab.Name
 	return identity
 }
 
@@ -81,8 +82,8 @@ func samePaneBindingIdentity(a, b paneBindingIdentity) bool {
 	if a.instance != b.instance {
 		return false
 	}
-	if a.tabID != "" || b.tabID != "" {
-		return a.tabID != "" && a.tabID == b.tabID
+	if a.tabID != "" && b.tabID != "" {
+		return a.tabID == b.tabID
 	}
 	if a.tabName != "" || b.tabName != "" {
 		return a.tabName != "" && a.tabName == b.tabName

--- a/app/pane_preview.go
+++ b/app/pane_preview.go
@@ -25,8 +25,20 @@ type panePreviewTxn struct {
 }
 
 type panePreviewSuppression struct {
-	original paneBinding
-	target   paneBinding
+	original paneBindingIdentity
+	target   paneBindingIdentity
+}
+
+// paneBindingIdentity is the durable comparison key for a dismissed preview.
+// The binding itself still carries the current ordinal needed to render, but a
+// suppression survives an out-of-band reorder by keying non-agent tabs on their
+// stable ID. Agent and legacy/id-less tabs use the same name fallback as pane
+// reconciliation; the slot remains only for an invalid/incomplete binding.
+type paneBindingIdentity struct {
+	instance *session.Instance
+	tabID    string
+	tabName  string
+	tab      int
 }
 
 // Two capture cadences give a retarget suppressed by the per-pane throttle one
@@ -44,6 +56,38 @@ type panePreviewStaleExpiredMsg struct {
 
 func samePaneBinding(a, b paneBinding) bool {
 	return a.instance == b.instance && a.tab == b.tab
+}
+
+func paneBindingIdentityOf(binding paneBinding) paneBindingIdentity {
+	identity := paneBindingIdentity{instance: binding.instance, tab: binding.tab}
+	if binding.instance == nil {
+		return identity
+	}
+	tabs := binding.instance.GetTabs()
+	if binding.tab < 0 || binding.tab >= len(tabs) {
+		return identity
+	}
+	tab := tabs[binding.tab]
+	if tab.Kind != session.TabKindAgent {
+		identity.tabID = tab.ID
+	}
+	if identity.tabID == "" {
+		identity.tabName = tab.Name
+	}
+	return identity
+}
+
+func samePaneBindingIdentity(a, b paneBindingIdentity) bool {
+	if a.instance != b.instance {
+		return false
+	}
+	if a.tabID != "" || b.tabID != "" {
+		return a.tabID != "" && a.tabID == b.tabID
+	}
+	if a.tabName != "" || b.tabName != "" {
+		return a.tabName != "" && a.tabName == b.tabName
+	}
+	return a.tab == b.tab
 }
 
 // updatePanePreview returns a tea.Cmd the caller MUST dispatch: the
@@ -244,8 +288,8 @@ func (m *home) suppressPanePreview(original, target paneBinding) {
 		return
 	}
 	m.panePreviewSuppression = &panePreviewSuppression{
-		original: original,
-		target:   target,
+		original: paneBindingIdentityOf(original),
+		target:   paneBindingIdentityOf(target),
 	}
 }
 
@@ -309,11 +353,11 @@ func (m *home) isPanePreviewSuppressed(original, target paneBinding) bool {
 	if suppressed == nil {
 		return false
 	}
-	if !samePaneBinding(suppressed.target, target) {
+	if !samePaneBindingIdentity(suppressed.target, paneBindingIdentityOf(target)) {
 		m.panePreviewSuppression = nil
 		return false
 	}
-	return samePaneBinding(suppressed.original, original)
+	return samePaneBindingIdentity(suppressed.original, paneBindingIdentityOf(original))
 }
 
 func (m *home) commitPanePreviewReplace() (*store.OpenPane, tea.Cmd) {

--- a/app/pane_preview.go
+++ b/app/pane_preview.go
@@ -78,17 +78,22 @@ func paneBindingIdentityOf(binding paneBinding) paneBindingIdentity {
 	return identity
 }
 
-func samePaneBindingIdentity(a, b paneBindingIdentity) bool {
-	if a.instance != b.instance {
+// suppressionIdentityMatches compares the identity captured when a preview was
+// dismissed with its current binding. The direction matters: an ID-less saved
+// identity may match a later ID-bearing snapshot by name (daemon backfill), but
+// a saved stable ID must never fall back to name when a different, newly
+// attached tab is still locally ID-less.
+func suppressionIdentityMatches(saved, current paneBindingIdentity) bool {
+	if saved.instance != current.instance {
 		return false
 	}
-	if a.tabID != "" && b.tabID != "" {
-		return a.tabID == b.tabID
+	if saved.tabID != "" {
+		return current.tabID != "" && saved.tabID == current.tabID
 	}
-	if a.tabName != "" || b.tabName != "" {
-		return a.tabName != "" && a.tabName == b.tabName
+	if saved.tabName != "" || current.tabName != "" {
+		return saved.tabName != "" && saved.tabName == current.tabName
 	}
-	return a.tab == b.tab
+	return saved.tab == current.tab
 }
 
 // updatePanePreview returns a tea.Cmd the caller MUST dispatch: the
@@ -354,11 +359,11 @@ func (m *home) isPanePreviewSuppressed(original, target paneBinding) bool {
 	if suppressed == nil {
 		return false
 	}
-	if !samePaneBindingIdentity(suppressed.target, paneBindingIdentityOf(target)) {
+	if !suppressionIdentityMatches(suppressed.target, paneBindingIdentityOf(target)) {
 		m.panePreviewSuppression = nil
 		return false
 	}
-	return samePaneBindingIdentity(suppressed.original, paneBindingIdentityOf(original))
+	return suppressionIdentityMatches(suppressed.original, paneBindingIdentityOf(original))
 }
 
 func (m *home) commitPanePreviewReplace() (*store.OpenPane, tea.Cmd) {

--- a/app/sync.go
+++ b/app/sync.go
@@ -611,7 +611,7 @@ func (m *home) swapInstanceFromSnapshot(d session.InstanceData) bool {
 	// The tree selection is another binding into the same replaced-session
 	// roster. Carry it through the same name domain as panes: every ID is freshly
 	// minted, while the equivalent replacement tab keeps its name (#1991).
-	m.reconcileActiveTabForTabs(inst, oldKeys, replacedSessionTabs)
+	m.remapActiveTabForTabs(inst, oldKeys, replacedSessionTabs)
 	return true
 }
 
@@ -686,7 +686,7 @@ func (m *home) updateInstanceFromSnapshot(inst *session.Instance, d session.Inst
 			// entirely here (no local action, #1813), and the clamps only keep the
 			// index in range — which a permutation never violates — so an
 			// index-keyed selection silently becomes a different tab.
-			if m.reconcileActiveTabForTabs(inst, oldKeys, sameSessionTabs) {
+			if m.remapActiveTabForTabs(inst, oldKeys, sameSessionTabs) {
 				// An in-place roster update never re-sorts the projection, so the
 				// sidebar indices are current and can follow the remapped tab now.
 				m.sidebar.SyncCursorToActiveTab()

--- a/app/sync.go
+++ b/app/sync.go
@@ -608,6 +608,10 @@ func (m *home) swapInstanceFromSnapshot(d session.InstanceData) bool {
 	if m.reconcilePanesForTabs(inst, oldKeys, replacedSessionTabs) {
 		m.relayout()
 	}
+	// The tree selection is another binding into the same replaced-session
+	// roster. Carry it through the same name domain as panes: every ID is freshly
+	// minted, while the equivalent replacement tab keeps its name (#1991).
+	m.reconcileActiveTabForTabs(inst, oldKeys, replacedSessionTabs)
 	return true
 }
 

--- a/app/sync.go
+++ b/app/sync.go
@@ -687,6 +687,9 @@ func (m *home) updateInstanceFromSnapshot(inst *session.Instance, d session.Inst
 			// index in range — which a permutation never violates — so an
 			// index-keyed selection silently becomes a different tab.
 			if m.reconcileActiveTabForTabs(inst, oldKeys, sameSessionTabs) {
+				// An in-place roster update never re-sorts the projection, so the
+				// sidebar indices are current and can follow the remapped tab now.
+				m.sidebar.SyncCursorToActiveTab()
 				changed = true
 			}
 		}

--- a/app/tab_multitab_test.go
+++ b/app/tab_multitab_test.go
@@ -62,7 +62,6 @@ func TestPaneJump_StaysPut_NoPreviewRepaint(t *testing.T) {
 	// the repaint needs (a same-instance non-tab-specific selection is already
 	// cancelled by the #1289 guard, so it would hide the bug).
 	h.store.SetActiveTab(1) // tree active tab = shell (slot 1)
-	h.menu.SetActiveTab(1)
 
 	// Open alpha's shell pane and focus it, then jump it elsewhere.
 	pane := openTestPane(t, h, alpha, 1)
@@ -111,7 +110,6 @@ func TestCloseTab_ActsOnFocusedPaneTab(t *testing.T) {
 	// Tree active tab = shell (slot 1) — a closable tab, the destructive
 	// precondition.
 	h.store.SetActiveTab(1)
-	h.menu.SetActiveTab(1)
 
 	// Open a pane and jump it to shell-3 (slot 3) — the tab on screen.
 	pane := openTestPane(t, h, alpha, 1)
@@ -135,7 +133,6 @@ func TestCloseTab_FocusedAgentPaneRefuses(t *testing.T) {
 
 	// Tree active tab = shell-2 (slot 2), a closable tab.
 	h.store.SetActiveTab(2)
-	h.menu.SetActiveTab(2)
 
 	// Focused pane on the agent tab (slot 0) — the tab actually on screen.
 	pane := openTestPane(t, h, alpha, 0)
@@ -158,7 +155,6 @@ func TestCloseTab_TreeFocusUnchanged(t *testing.T) {
 	h, _ := multiTabHome(t)
 	h.focusRegion(layout.RegionTree)
 	h.store.SetActiveTab(2) // shell-2
-	h.menu.SetActiveTab(2)
 	require.Nil(t, h.focusedOpenPane(), "precondition: no pane holds focus")
 
 	closerCalls := recordCloseTab(t, h)
@@ -318,7 +314,6 @@ func TestEnterTabA_Esc_EnterTabB_RoutesAndRenders(t *testing.T) {
 func TestCloseTab_PaneFocusedClosePreservesTreeTab(t *testing.T) {
 	h, alpha := multiTabHome(t)
 	h.store.SetActiveTab(1) // tree on shell (slot 1)
-	h.menu.SetActiveTab(1)
 
 	pane := openTestPane(t, h, alpha, 1)
 	_, _ = h.handleTabJump(4) // pane jumps to shell-3 (slot 3); tree stays on slot 1
@@ -341,7 +336,6 @@ func TestCloseTab_PaneFocusedClosePreservesTreeTab(t *testing.T) {
 func TestCloseTab_ClosingBelowTreeTabShiftsIt(t *testing.T) {
 	h, alpha := multiTabHome(t)
 	h.store.SetActiveTab(3) // tree on shell-3 (slot 3)
-	h.menu.SetActiveTab(3)
 
 	pane := openTestPane(t, h, alpha, 3)
 	_, _ = h.handleTabJump(2) // pane jumps DOWN to shell (slot 1)
@@ -363,7 +357,6 @@ func TestCloseTab_ClosingTheTreesOwnTabFallsBackToNeighbor(t *testing.T) {
 	h, _ := multiTabHome(t)
 	h.focusRegion(layout.RegionTree)
 	h.store.SetActiveTab(2)
-	h.menu.SetActiveTab(2)
 
 	recordCloseTab(t, h)
 	_, _ = h.handleCloseTab()
@@ -380,7 +373,6 @@ func TestCloseTab_ClosingTheTreesOwnTabFallsBackToNeighbor(t *testing.T) {
 func TestPaneJump_PinSurvivesUnseededEpoch(t *testing.T) {
 	h, alpha := multiTabHome(t)
 	h.store.SetActiveTab(1)
-	h.menu.SetActiveTab(1)
 	pane := openTestPane(t, h, alpha, 1)
 
 	// Simulate the startup / restored-pane window: no selectionChanged has primed
@@ -407,7 +399,6 @@ func TestPaneJump_PinSurvivesUnseededEpoch(t *testing.T) {
 func TestPaneJump_TreeTabChangeStalesThePin(t *testing.T) {
 	h, alpha := multiTabHome(t)
 	h.store.SetActiveTab(1)
-	h.menu.SetActiveTab(1)
 	pane := openTestPane(t, h, alpha, 1)
 
 	_, _ = h.handleTabJump(4) // pane-focused: pins intent
@@ -555,7 +546,6 @@ func TestCloseTab_IDLessTreeTabTracksByOrdinal(t *testing.T) {
 
 	// The tree sits on shell-3 (slot 3) — the newest tab.
 	h.store.SetActiveTab(3)
-	h.menu.SetActiveTab(3)
 
 	// The focused pane is jumped BACK to an older tab, shell (slot 1), and closes it.
 	pane := openTestPane(t, h, alpha, 3)
@@ -694,7 +684,6 @@ func TestCloseTab_StickySelectionShiftsActiveTab(t *testing.T) {
 
 	// The tree's active tab is shell-3 (slot 3) — ABOVE the tab about to close.
 	h.store.SetActiveTab(3)
-	h.menu.SetActiveTab(3)
 
 	// A pane on shell (slot 1), the lower-numbered tab that will be closed.
 	pane := openTestPane(t, h, alpha, 1)

--- a/app/tui_state.go
+++ b/app/tui_state.go
@@ -63,6 +63,10 @@ func (m *home) restoreTUIViewPanes(saved []config.TUIStateOpenPane) int {
 	}
 	var restored []restoredPane
 	seen := make(map[string]bool, len(saved))
+	savedFocusPaneKey := ""
+	if m.pendingTUIViewFocus != nil && m.pendingTUIViewFocus.Region == tuiFocusRegionPane {
+		savedFocusPaneKey = m.pendingTUIViewFocus.PaneKey
+	}
 	for _, paneState := range saved {
 		inst := m.resolveTUIStateInstance(paneState.InstanceID, paneState.Title)
 		if inst == nil || inst.GetLiveness() == session.LiveArchived {
@@ -91,8 +95,7 @@ func (m *home) restoreTUIViewPanes(saved []config.TUIStateOpenPane) int {
 		// compatibility. If ID-first restore followed a renamed tab, translate
 		// the pending focus from its saved key to that pane's current name key so
 		// the first sized relayout can still restore keyboard focus.
-		if m.pendingTUIViewFocus != nil && m.pendingTUIViewFocus.Region == tuiFocusRegionPane &&
-			m.pendingTUIViewFocus.PaneKey == key {
+		if savedFocusPaneKey != "" && savedFocusPaneKey == key {
 			m.pendingTUIViewFocus.PaneKey = tuiPaneKeyForOpenPane(pane)
 		}
 		restored = append(restored, restoredPane{saved: paneState, pane: pane})

--- a/app/tui_state.go
+++ b/app/tui_state.go
@@ -33,12 +33,12 @@ func (m *home) restoreTUIViewStateOnLaunch() int {
 }
 
 func (m *home) applyTUIViewState(state config.TUIRepoViewState) int {
-	restored := m.restoreTUIViewPanes(state.OpenPanes)
-	m.restoreTUISelection(state)
 	if state.Focus != nil {
 		focusCopy := *state.Focus
 		m.pendingTUIViewFocus = &focusCopy
 	}
+	restored := m.restoreTUIViewPanes(state.OpenPanes)
+	m.restoreTUISelection(state)
 	// A persisted selection that resolved to an archived row (or to nothing)
 	// leaves the store with no display selection, yet a live pane may have been
 	// restored above — an incoherent mix where the sidebar highlights nothing (or
@@ -68,7 +68,7 @@ func (m *home) restoreTUIViewPanes(saved []config.TUIStateOpenPane) int {
 		if inst == nil || inst.GetLiveness() == session.LiveArchived {
 			continue
 		}
-		tab, ok := tabIndexByName(inst, paneState.TabName)
+		tab, ok := tabIndexByIdentity(inst, paneState.TabID, paneState.TabName)
 		if !ok {
 			continue
 		}
@@ -86,6 +86,14 @@ func (m *home) restoreTUIViewPanes(saved []config.TUIStateOpenPane) int {
 		}
 		if pane == nil {
 			continue
+		}
+		// Pane keys intentionally stay name-based for persisted-state backward
+		// compatibility. If ID-first restore followed a renamed tab, translate
+		// the pending focus from its saved key to that pane's current name key so
+		// the first sized relayout can still restore keyboard focus.
+		if m.pendingTUIViewFocus != nil && m.pendingTUIViewFocus.Region == tuiFocusRegionPane &&
+			m.pendingTUIViewFocus.PaneKey == key {
+			m.pendingTUIViewFocus.PaneKey = tuiPaneKeyForOpenPane(pane)
 		}
 		restored = append(restored, restoredPane{saved: paneState, pane: pane})
 	}
@@ -106,15 +114,16 @@ func (m *home) restoreTUISelection(state config.TUIRepoViewState) {
 	if inst == nil || inst.GetLiveness() == session.LiveArchived {
 		return
 	}
+	tabID := state.Selected.TabID
 	tabName := state.Selected.TabName
 	if state.ActiveTab != nil && sameTUIStateInstance(*state.Selected, *state.ActiveTab) {
+		tabID = state.ActiveTab.TabID
 		tabName = state.ActiveTab.TabName
 	}
-	tab := tabIndexOrDefault(inst, tabName)
+	tab := tabIndexOrDefault(inst, tabID, tabName)
 	m.sidebar.SelectInstance(inst)
 	m.store.SetActiveTab(tab)
 	m.menu.SetInstance(inst)
-	m.menu.SetActiveTab(tab)
 	m.sidebar.SelectTabRow(inst.Title, tab)
 }
 
@@ -148,7 +157,6 @@ func (m *home) reconcileRestoredSelectionWithWorkspace() {
 	m.sidebar.SelectInstance(inst)
 	m.store.SetActiveTab(tab)
 	m.menu.SetInstance(inst)
-	m.menu.SetActiveTab(tab)
 	m.sidebar.SelectTabRow(inst.Title, tab)
 }
 
@@ -209,7 +217,7 @@ func (m *home) captureTUIViewState() config.TUIRepoViewState {
 		if inst == nil || !m.store.ContainsInstance(inst) {
 			continue
 		}
-		tabName, ok := tabNameAt(inst, p.Tab())
+		tabID, tabName, ok := tabIdentityAt(inst, p.Tab())
 		if !ok {
 			continue
 		}
@@ -217,6 +225,7 @@ func (m *home) captureTUIViewState() config.TUIRepoViewState {
 			Key:        tuiPaneKeyForInstance(inst, tabName),
 			InstanceID: inst.ID,
 			Title:      inst.Title,
+			TabID:      tabID,
 			TabName:    tabName,
 			FocusRank:  p.LastFocus(),
 		})
@@ -235,10 +244,11 @@ func (m *home) captureTUISelectedTarget() *config.TUIStateTarget {
 	if inst == nil || !m.store.ContainsInstance(inst) {
 		return nil
 	}
-	tabName, _ := tabNameAt(inst, m.store.ActiveTab())
+	tabID, tabName, _ := tabIdentityAt(inst, m.store.ActiveTab())
 	return &config.TUIStateTarget{
 		InstanceID: inst.ID,
 		Title:      inst.Title,
+		TabID:      tabID,
 		TabName:    tabName,
 	}
 }
@@ -350,15 +360,28 @@ func (m *home) openPaneByKey(key string) *store.OpenPane {
 }
 
 func tabNameAt(inst *session.Instance, idx int) (string, bool) {
-	tabs := inst.GetTabs()
-	if idx < 0 || idx >= len(tabs) {
-		return "", false
-	}
-	return tabs[idx].Name, true
+	_, name, ok := tabIdentityAt(inst, idx)
+	return name, ok
 }
 
-func tabIndexByName(inst *session.Instance, name string) (int, bool) {
-	for i, tab := range inst.GetTabs() {
+func tabIdentityAt(inst *session.Instance, idx int) (string, string, bool) {
+	tabs := inst.GetTabs()
+	if idx < 0 || idx >= len(tabs) {
+		return "", "", false
+	}
+	return tabs[idx].ID, tabs[idx].Name, true
+}
+
+func tabIndexByIdentity(inst *session.Instance, id, name string) (int, bool) {
+	tabs := inst.GetTabs()
+	if id != "" {
+		for i, tab := range tabs {
+			if tab.ID == id {
+				return i, true
+			}
+		}
+	}
+	for i, tab := range tabs {
 		if tab.Name == name {
 			return i, true
 		}
@@ -366,8 +389,8 @@ func tabIndexByName(inst *session.Instance, name string) (int, bool) {
 	return 0, false
 }
 
-func tabIndexOrDefault(inst *session.Instance, name string) int {
-	if idx, ok := tabIndexByName(inst, name); ok {
+func tabIndexOrDefault(inst *session.Instance, id, name string) int {
+	if idx, ok := tabIndexByIdentity(inst, id, name); ok {
 		return idx
 	}
 	return 0

--- a/app/tui_tab_state_identity_test.go
+++ b/app/tui_tab_state_identity_test.go
@@ -1,0 +1,192 @@
+package app
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPanePreviewSuppressionFollowsTabIdentityAcrossReorder is the row-2
+// regression from #1991. Dismissing a preview suppresses that exact
+// original/target pair. If the target moves slots before the next preview tick,
+// the suppression must follow its stable tab ID rather than accidentally
+// re-opening the preview because the stored ordinal went stale.
+func TestPanePreviewSuppressionFollowsTabIdentityAcrossReorder(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		idless bool
+	}{
+		{name: "stable ID"},
+		{name: "legacy ID-less name fallback", idless: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h, alpha := multiTabHome(t)
+			pane := openTestPane(t, h, alpha, 1)
+
+			h.sidebar.SelectTabRow(alpha.Title, 2)
+			_ = h.selectionChanged()
+			require.NotNil(t, h.panePreviewTxn, "precondition: tab 3 is being previewed")
+			require.Equal(t, 2, h.panePreviewTxn.target.tab)
+			targetName := alpha.GetTabs()[2].Name
+			if tc.idless {
+				alpha.GetTabs()[2].ID = ""
+			} else {
+				require.NotEmpty(t, alpha.GetTabs()[2].ID)
+			}
+
+			h.suppressActivePanePreview()
+			h.cancelPanePreview(false)
+			require.NotNil(t, h.panePreviewSuppression)
+			require.Nil(t, h.panePreviewTxn)
+
+			require.NoError(t, alpha.ReorderTab(2, 3))
+			require.Equal(t, targetName, alpha.GetTabs()[3].Name,
+				"precondition: the suppressed target moved from slot 2 to slot 3")
+			_ = h.updatePanePreview(alpha, 3, true, false)
+
+			assert.Nil(t, h.panePreviewTxn,
+				"the next production preview pass must still suppress the same target after its reorder")
+			assert.False(t, h.paneWindows[pane.ID()].Previewing())
+		})
+	}
+}
+
+// TestTUIViewStateRestorePrefersTabIDAcrossNameReuse is the row-3 regression
+// from #1991. The payload is decoded from JSON so it compiles against the old
+// schema: before TabID support the additive field is ignored and restore binds
+// the pane and selection to whichever different tab now owns the stale name.
+func TestTUIViewStateRestorePrefersTabIDAcrossNameReuse(t *testing.T) {
+	h := newTestHome(t)
+	h.initialPaneOpened = false
+	inst := instanceWithFakeBackend(t, "alpha")
+	inst.AddTabForTest("agent", session.TabKindAgent)
+	inst.GetTabs()[0].ID = "id-agent"
+	inst.AddWebTabForTest("metrics", "http://localhost:3000")
+	inst.AddWebTabForTest("shell", "http://localhost:3001")
+	h.store.AddInstance(inst)
+
+	targetID := inst.GetTabs()[1].ID
+	staleNameOwnerID := inst.GetTabs()[2].ID
+	require.NotEmpty(t, targetID)
+	require.NotEqual(t, targetID, staleNameOwnerID)
+
+	payload := map[string]any{
+		"selected": map[string]any{
+			"instance_id": inst.ID,
+			"title":       inst.Title,
+			"tab_id":      targetID,
+			"tab_name":    "shell",
+		},
+		"active_tab": map[string]any{
+			"instance_id": inst.ID,
+			"title":       inst.Title,
+			"tab_id":      targetID,
+			"tab_name":    "shell",
+		},
+		"focus": map[string]any{
+			"region":   tuiFocusRegionPane,
+			"pane_key": tuiPaneKeyForInstance(inst, "shell"),
+		},
+		"open_panes": []map[string]any{{
+			"key":         tuiPaneKeyForInstance(inst, "shell"),
+			"instance_id": inst.ID,
+			"title":       inst.Title,
+			"tab_id":      targetID,
+			"tab_name":    "shell",
+			"focus_rank":  1,
+		}},
+	}
+	raw, err := json.Marshal(payload)
+	require.NoError(t, err)
+	var state config.TUIRepoViewState
+	require.NoError(t, json.Unmarshal(raw, &state))
+
+	require.Equal(t, 1, h.applyTUIViewState(state))
+	require.Len(t, h.store.OpenPanes(), 1)
+	pane := h.store.OpenPanes()[0]
+	assert.Equal(t, targetID, inst.GetTabs()[pane.Tab()].ID,
+		"the restored pane follows its saved tab ID, not the new owner of its stale name")
+	assert.Equal(t, targetID, inst.GetTabs()[h.store.ActiveTab()].ID,
+		"the restored selection follows its saved tab ID, not the new owner of its stale name")
+
+	resizeHome(h, 120, 30)
+	focused := h.focusedOpenPane()
+	require.NotNil(t, focused, "the persisted pane focus survives the target tab's rename")
+	assert.Equal(t, targetID, inst.GetTabs()[focused.Tab()].ID,
+		"focus follows the ID-resolved pane, not the stale name embedded in its persisted key")
+}
+
+// TestTUIViewStateRestoreFallsBackToNameForUnresolvedTabID pins the deliberate
+// best-effort exception: unlike a mutation RPC, view restoration should retain
+// the user's layout when its saved ID no longer exists, so it falls back to the
+// legacy name rather than dropping the pane and selection.
+func TestTUIViewStateRestoreFallsBackToNameForUnresolvedTabID(t *testing.T) {
+	h := newTestHome(t)
+	inst := instanceWithFakeBackend(t, "alpha")
+	inst.AddTabForTest("agent", session.TabKindAgent)
+	inst.AddWebTabForTest("shell", "http://localhost:3000")
+	h.store.AddInstance(inst)
+
+	state := config.TUIRepoViewState{
+		Selected: &config.TUIStateTarget{
+			InstanceID: inst.ID, Title: inst.Title, TabID: "gone-tab", TabName: "shell",
+		},
+		ActiveTab: &config.TUIStateTarget{
+			InstanceID: inst.ID, Title: inst.Title, TabID: "gone-tab", TabName: "shell",
+		},
+		OpenPanes: []config.TUIStateOpenPane{{
+			Key: tuiPaneKeyForInstance(inst, "shell"), InstanceID: inst.ID, Title: inst.Title,
+			TabID: "gone-tab", TabName: "shell",
+		}},
+	}
+
+	require.Equal(t, 1, h.applyTUIViewState(state))
+	require.Len(t, h.store.OpenPanes(), 1)
+	assert.Equal(t, "shell", inst.GetTabs()[h.store.OpenPanes()[0].Tab()].Name)
+	assert.Equal(t, "shell", inst.GetTabs()[h.store.ActiveTab()].Name)
+}
+
+// TestSwapSameTitleActiveTabFollowsReplacementName is the row-4 regression
+// from #1991. A replacement session has all-new tab IDs, so its equivalent tab
+// is resolved in the replacement name domain, just like open panes already are.
+func TestSwapSameTitleActiveTabFollowsReplacementName(t *testing.T) {
+	h := newTestHome(t)
+	stale := instanceWithFakeBackend(t, "dup")
+	for i, name := range []string{"agent", "a", "b"} {
+		kind := session.TabKindShell
+		if i == 0 {
+			kind = session.TabKindAgent
+		}
+		stale.AddTabForTest(name, kind)
+		stale.GetTabs()[i].ID = "stale-" + name
+	}
+	h.store.AddInstance(stale)
+	h.sidebar.SetSelectedInstance(0)
+	h.sidebar.SelectTabRow(stale.Title, 1)
+	require.Equal(t, "a", stale.GetTabs()[h.store.ActiveTab()].Name)
+
+	recreated := instanceWithFakeBackend(t, "dup")
+	for i, name := range []string{"agent", "b", "a"} {
+		kind := session.TabKindShell
+		if i == 0 {
+			kind = session.TabKindAgent
+		}
+		recreated.AddTabForTest(name, kind)
+		recreated.GetTabs()[i].ID = "fresh-" + name
+	}
+	t.Cleanup(SetInstanceBuilderForTest(func(session.InstanceData) (*session.Instance, error) {
+		return recreated, nil
+	}))
+
+	require.True(t, h.swapInstanceFromSnapshot(recreated.ToInstanceData()))
+	assert.Equal(t, "a", recreated.GetTabs()[h.store.ActiveTab()].Name,
+		"the active tab follows its equivalent name across the replaced-session reorder")
+	sel := h.sidebar.GetSelection()
+	require.True(t, sel.IsTab)
+	assert.Equal(t, "a", recreated.GetTabs()[sel.TabIndex].Name,
+		"the cursor and active tab stay on the same replacement tab")
+}

--- a/app/tui_tab_state_identity_test.go
+++ b/app/tui_tab_state_identity_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/session"
@@ -17,11 +18,13 @@ import (
 // re-opening the preview because the stored ordinal went stale.
 func TestPanePreviewSuppressionFollowsTabIdentityAcrossReorder(t *testing.T) {
 	for _, tc := range []struct {
-		name   string
-		idless bool
+		name       string
+		idless     bool
+		backfillID bool
 	}{
 		{name: "stable ID"},
 		{name: "legacy ID-less name fallback", idless: true},
+		{name: "ID backfill after dismissal", idless: true, backfillID: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			h, alpha := multiTabHome(t)
@@ -42,6 +45,9 @@ func TestPanePreviewSuppressionFollowsTabIdentityAcrossReorder(t *testing.T) {
 			h.cancelPanePreview(false)
 			require.NotNil(t, h.panePreviewSuppression)
 			require.Nil(t, h.panePreviewTxn)
+			if tc.backfillID {
+				alpha.GetTabs()[2].ID = "daemon-backfilled-target"
+			}
 
 			require.NoError(t, alpha.ReorderTab(2, 3))
 			require.Equal(t, targetName, alpha.GetTabs()[3].Name,
@@ -182,11 +188,70 @@ func TestSwapSameTitleActiveTabFollowsReplacementName(t *testing.T) {
 		return recreated, nil
 	}))
 
-	require.True(t, h.swapInstanceFromSnapshot(recreated.ToInstanceData()))
+	require.True(t, h.reconcileSnapshot([]session.InstanceData{recreated.ToInstanceData()}))
 	assert.Equal(t, "a", recreated.GetTabs()[h.store.ActiveTab()].Name,
 		"the active tab follows its equivalent name across the replaced-session reorder")
 	sel := h.sidebar.GetSelection()
 	require.True(t, sel.IsTab)
 	assert.Equal(t, "a", recreated.GetTabs()[sel.TabIndex].Name,
 		"the cursor and active tab stay on the same replacement tab")
+}
+
+// TestSwapSameTitleTabCursorSurvivesReplacementResort is the stale-index edge
+// behind row 4: ReplaceInstanceByTitle re-sorts by CreatedAt. The sidebar still
+// carries the pre-sort projection index until the snapshot's final selection
+// assertion rebuilds it, so synchronizing the cursor inside the swap can record
+// the neighbor as lastCursor* and lose the selected replacement tab.
+func TestSwapSameTitleTabCursorSurvivesReplacementResort(t *testing.T) {
+	h := newTestHome(t)
+	base := time.Now().Add(-4 * time.Hour)
+
+	first := instanceWithFakeBackend(t, "first")
+	first.ID = "first-id"
+	first.CreatedAt = base
+	stale := instanceWithFakeBackend(t, "dup")
+	stale.ID = "stale-dup"
+	stale.CreatedAt = base.Add(time.Hour)
+	last := instanceWithFakeBackend(t, "last")
+	last.ID = "last-id"
+	last.CreatedAt = base.Add(2 * time.Hour)
+	for i, name := range []string{"agent", "a", "b"} {
+		kind := session.TabKindShell
+		if i == 0 {
+			kind = session.TabKindAgent
+		}
+		stale.AddTabForTest(name, kind)
+		stale.GetTabs()[i].ID = "stale-" + name
+	}
+	h.store.AddInstance(first)
+	h.store.AddInstance(stale)
+	h.store.AddInstance(last)
+	h.sidebar.SelectInstance(stale)
+	h.sidebar.SelectTabRow(stale.Title, 1)
+	require.Equal(t, "a", stale.GetTabs()[h.store.ActiveTab()].Name)
+
+	recreated := instanceWithFakeBackend(t, "dup")
+	recreated.ID = "fresh-dup"
+	recreated.CreatedAt = base.Add(3 * time.Hour) // moves after "last"
+	for i, name := range []string{"agent", "b", "a"} {
+		kind := session.TabKindShell
+		if i == 0 {
+			kind = session.TabKindAgent
+		}
+		recreated.AddTabForTest(name, kind)
+		recreated.GetTabs()[i].ID = "fresh-" + name
+	}
+	t.Cleanup(SetInstanceBuilderForTest(func(session.InstanceData) (*session.Instance, error) {
+		return recreated, nil
+	}))
+
+	require.True(t, h.reconcileSnapshot([]session.InstanceData{
+		first.ToInstanceData(), recreated.ToInstanceData(), last.ToInstanceData(),
+	}))
+	require.Same(t, recreated, h.sidebar.GetSelectedInstance(),
+		"the snapshot's final assertion re-pins the replacement after it moves")
+	sel := h.sidebar.GetSelection()
+	require.True(t, sel.IsTab, "the cursor must stay on its replacement tab row")
+	assert.Equal(t, "a", recreated.GetTabs()[sel.TabIndex].Name)
+	assert.Equal(t, "a", recreated.GetTabs()[h.store.ActiveTab()].Name)
 }

--- a/app/tui_tab_state_identity_test.go
+++ b/app/tui_tab_state_identity_test.go
@@ -61,6 +61,38 @@ func TestPanePreviewSuppressionFollowsTabIdentityAcrossReorder(t *testing.T) {
 	}
 }
 
+// TestPanePreviewSuppressionDoesNotTransferAcrossStableIDReuse covers the
+// close/recreate window after a stable target was dismissed. AttachShellTab
+// leaves the replacement locally ID-less until the daemon snapshot arrives;
+// reusing the old name must not make that distinct tab inherit the old tab's
+// suppression.
+func TestPanePreviewSuppressionDoesNotTransferAcrossStableIDReuse(t *testing.T) {
+	h, alpha := multiTabHome(t)
+	pane := openTestPane(t, h, alpha, 1)
+
+	h.sidebar.SelectTabRow(alpha.Title, 2)
+	_ = h.selectionChanged()
+	require.NotNil(t, h.panePreviewTxn, "precondition: shell-2 is being previewed")
+	targetName := alpha.GetTabs()[2].Name
+	require.NotEmpty(t, alpha.GetTabs()[2].ID, "precondition: the dismissed tab has stable identity")
+
+	h.suppressActivePanePreview()
+	h.cancelPanePreview(false)
+	require.NotNil(t, h.panePreviewSuppression)
+	require.NoError(t, alpha.CloseTab(2))
+	alpha.AddTabForTest(targetName, session.TabKindShell)
+	replacement := len(alpha.GetTabs()) - 1
+	require.Empty(t, alpha.GetTabs()[replacement].ID,
+		"precondition: the locally attached replacement is awaiting ID backfill")
+
+	_ = h.updatePanePreview(alpha, replacement, true, false)
+
+	require.NotNil(t, h.panePreviewTxn,
+		"a distinct ID-less replacement must not inherit a stable tab's suppression")
+	assert.Equal(t, replacement, h.panePreviewTxn.target.tab)
+	assert.True(t, h.paneWindows[pane.ID()].Previewing())
+}
+
 // TestTUIViewStateRestorePrefersTabIDAcrossNameReuse is the row-3 regression
 // from #1991. The payload is decoded from JSON so it compiles against the old
 // schema: before TabID support the additive field is ignored and restore binds
@@ -154,6 +186,45 @@ func TestTUIViewStateRestoreFallsBackToNameForUnresolvedTabID(t *testing.T) {
 	require.Len(t, h.store.OpenPanes(), 1)
 	assert.Equal(t, "shell", inst.GetTabs()[h.store.OpenPanes()[0].Tab()].Name)
 	assert.Equal(t, "shell", inst.GetTabs()[h.store.ActiveTab()].Name)
+}
+
+// TestTUIViewStateFocusSurvivesSwappedTabNames covers two restored panes whose
+// stable IDs survive while their names swap. Translating the first pane's saved
+// focus key must not let the translated key match and redirect focus to the
+// second saved pane.
+func TestTUIViewStateFocusSurvivesSwappedTabNames(t *testing.T) {
+	h := newTestHome(t)
+	h.initialPaneOpened = false
+	inst := instanceWithFakeBackend(t, "alpha")
+	inst.AddTabForTest("agent", session.TabKindAgent)
+	inst.AddWebTabForTest("b", "http://localhost:3000")
+	inst.AddWebTabForTest("a", "http://localhost:3001")
+	inst.GetTabs()[1].ID = "id-a"
+	inst.GetTabs()[2].ID = "id-b"
+	h.store.AddInstance(inst)
+
+	state := config.TUIRepoViewState{
+		Focus: &config.TUIStateFocus{
+			Region: tuiFocusRegionPane, PaneKey: tuiPaneKeyForInstance(inst, "a"),
+		},
+		OpenPanes: []config.TUIStateOpenPane{
+			{
+				Key: tuiPaneKeyForInstance(inst, "a"), InstanceID: inst.ID, Title: inst.Title,
+				TabID: "id-a", TabName: "a", FocusRank: 2,
+			},
+			{
+				Key: tuiPaneKeyForInstance(inst, "b"), InstanceID: inst.ID, Title: inst.Title,
+				TabID: "id-b", TabName: "b", FocusRank: 1,
+			},
+		},
+	}
+
+	require.Equal(t, 2, h.applyTUIViewState(state))
+	resizeHome(h, 120, 30)
+	focused := h.focusedOpenPane()
+	require.NotNil(t, focused)
+	assert.Equal(t, "id-a", inst.GetTabs()[focused.Tab()].ID,
+		"focus must follow the originally saved key, not a translated key reused by another pane")
 }
 
 // TestSwapSameTitleActiveTabFollowsReplacementName is the row-4 regression

--- a/config/tui_state.go
+++ b/config/tui_state.go
@@ -27,10 +27,11 @@ type TUIRepoViewState struct {
 }
 
 // TUIStateTarget identifies a session/tab by stable identity, falling back to
-// title for older records that did not carry a session ID.
+// title/name for older records that did not carry IDs.
 type TUIStateTarget struct {
 	InstanceID string `json:"instance_id,omitempty"`
 	Title      string `json:"title,omitempty"`
+	TabID      string `json:"tab_id,omitempty"`
 	TabName    string `json:"tab_name,omitempty"`
 }
 
@@ -46,6 +47,7 @@ type TUIStateOpenPane struct {
 	Key        string `json:"key"`
 	InstanceID string `json:"instance_id,omitempty"`
 	Title      string `json:"title,omitempty"`
+	TabID      string `json:"tab_id,omitempty"`
 	TabName    string `json:"tab_name"`
 	FocusRank  uint64 `json:"focus_rank,omitempty"`
 }

--- a/config/tui_state_test.go
+++ b/config/tui_state_test.go
@@ -22,17 +22,18 @@ func TestSaveTUIRepoViewStateWritesSchemaAndPreservesRepos(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 
 	stateA := TUIRepoViewState{
-		Selected: &TUIStateTarget{InstanceID: "id-a", Title: "alpha", TabName: "agent"},
+		Selected: &TUIStateTarget{InstanceID: "id-a", Title: "alpha", TabID: "tab-agent-a", TabName: "agent"},
 		OpenPanes: []TUIStateOpenPane{{
 			Key:        "title:alpha:tab:agent",
 			InstanceID: "id-a",
 			Title:      "alpha",
+			TabID:      "tab-agent-a",
 			TabName:    "agent",
 			FocusRank:  1,
 		}},
 	}
 	stateB := TUIRepoViewState{
-		Selected: &TUIStateTarget{InstanceID: "id-b", Title: "beta", TabName: "shell"},
+		Selected: &TUIStateTarget{InstanceID: "id-b", Title: "beta", TabID: "tab-shell-b", TabName: "shell"},
 	}
 
 	require.NoError(t, SaveTUIRepoViewState("repo-a", stateA))
@@ -49,7 +50,10 @@ func TestSaveTUIRepoViewStateWritesSchemaAndPreservesRepos(t *testing.T) {
 	require.Contains(t, file.Repos, "repo-a")
 	require.Contains(t, file.Repos, "repo-b")
 	assert.Equal(t, "alpha", file.Repos["repo-a"].Selected.Title)
+	assert.Equal(t, "tab-agent-a", file.Repos["repo-a"].Selected.TabID)
+	assert.Equal(t, "tab-agent-a", file.Repos["repo-a"].OpenPanes[0].TabID)
 	assert.Equal(t, "beta", file.Repos["repo-b"].Selected.Title)
+	assert.Contains(t, string(raw), `"tab_id"`)
 	assert.NotContains(t, string(raw), `"version"`)
 }
 

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -48,7 +48,6 @@ type Menu struct {
 	height, width int
 	state         MenuState
 	instance      *session.Instance
-	activeTab     int
 
 	// focusRegion is the focus-ring region the hints are rendered for
 	// (layout.RegionTree / RegionAutomations / a layout.PaneRegion id). The
@@ -126,10 +125,9 @@ var interactiveMenuOptions = []keys.KeyName{keys.KeyExitInteractive}
 
 func NewMenu() *Menu {
 	m := &Menu{
-		options:   defaultMenuOptions,
-		state:     StateEmpty,
-		activeTab: 0,
-		keyDown:   -1,
+		options: defaultMenuOptions,
+		state:   StateEmpty,
+		keyDown: -1,
 	}
 	m.updateOptions()
 	return m
@@ -171,12 +169,6 @@ func (m *Menu) SetInstance(instance *session.Instance) {
 // workspace share the instance/default sets driven by SetInstance.
 func (m *Menu) SetFocusRegion(region string) {
 	m.focusRegion = region
-	m.updateOptions()
-}
-
-// SetActiveTab updates the currently active tab
-func (m *Menu) SetActiveTab(tab int) {
-	m.activeTab = tab
 	m.updateOptions()
 }
 

--- a/ui/menu_test.go
+++ b/ui/menu_test.go
@@ -22,15 +22,15 @@ func readyUIInstance() *session.Instance {
 	return i
 }
 
-// TestMenuTerminalTabShowsBothScrollKeys verifies that a terminal tab with
-// authoritative host history surfaces both scroll shortcuts. Regression test
-// for issue #270.
-func TestMenuTerminalTabShowsBothScrollKeys(t *testing.T) {
+// TestMenuShowsBothScrollKeysWhenControllerProvidesHistory verifies that the
+// controller's explicit history capability surfaces both scroll shortcuts.
+// Menu never owned a tab binding; its old activeTab mirror was unread dead state
+// that made the former agent/terminal variants of this test identical (#1991).
+func TestMenuShowsBothScrollKeysWhenControllerProvidesHistory(t *testing.T) {
 	m := NewMenu()
 	m.SetScrollAvailable(true)
 	// Use a non-loading instance so addInstanceOptions renders the full menu.
 	m.SetInstance(readyUIInstance())
-	m.SetActiveTab(1)
 
 	var gotShiftUp, gotShiftDown int
 	for _, k := range m.options {
@@ -47,34 +47,6 @@ func TestMenuTerminalTabShowsBothScrollKeys(t *testing.T) {
 	}
 	if gotShiftDown != 1 {
 		t.Errorf("expected exactly 1 KeyShiftDown in terminal tab menu, got %d", gotShiftDown)
-	}
-}
-
-// TestMenuAgentTabShowsBothScrollKeys verifies that the Agent tab also
-// surfaces both scroll shortcuts — the agent output supports scrolling identically to
-// terminal, and the help screen documents the shortcuts for both. Regression
-// test for issue #467.
-func TestMenuAgentTabShowsBothScrollKeys(t *testing.T) {
-	m := NewMenu()
-	m.SetScrollAvailable(true)
-	m.SetInstance(readyUIInstance())
-	m.SetActiveTab(0)
-
-	var gotShiftUp, gotShiftDown int
-	for _, k := range m.options {
-		switch k {
-		case keys.KeyShiftUp:
-			gotShiftUp++
-		case keys.KeyShiftDown:
-			gotShiftDown++
-		}
-	}
-
-	if gotShiftUp != 1 {
-		t.Errorf("expected exactly 1 KeyShiftUp in agent tab menu, got %d", gotShiftUp)
-	}
-	if gotShiftDown != 1 {
-		t.Errorf("expected exactly 1 KeyShiftDown in agent tab menu, got %d", gotShiftDown)
 	}
 }
 

--- a/ui/sidebar_model.go
+++ b/ui/sidebar_model.go
@@ -153,13 +153,17 @@ type Sidebar struct {
 	// auto-expanded (collapse-by-default applies to non-selected instances).
 	treeCollapsed string
 
-	// lastCursorTitle/lastCursorTab remember the identity of the last
-	// instance-section row the cursor rested on (tab -1 = the instance row
-	// itself). The reconcile's #969 re-pin asserts only the instance; this memo
-	// restores the tab SUB-selection too, so a snapshot arriving while the
-	// cursor sits on a tab row doesn't yank it up to the instance row.
-	lastCursorTitle string
-	lastCursorTab   int
+	// lastCursor* remember the identity of the last instance-section row the
+	// cursor rested on (tab -1 = the instance row itself). The reconcile's #969
+	// re-pin asserts only the instance; this memo restores the tab sub-selection
+	// too. Stable IDs carry same-session reorders; names cover the same-title
+	// replacement domain plus agent/legacy ID-less tabs. Slot is only the final
+	// fallback when the older memo has no usable identity.
+	lastCursorTitle      string
+	lastCursorInstanceID string
+	lastCursorTabID      string
+	lastCursorTabName    string
+	lastCursorTab        int
 
 	// scrollOffset is the index into visibleItems of the first rendered row
 	// when the list is too tall for the allocation. It is adjusted lazily in

--- a/ui/sidebar_nav.go
+++ b/ui/sidebar_nav.go
@@ -16,7 +16,7 @@ import (
 //   - a pending SelectInstance assertion (the reconcile's #969 re-pin, the
 //     search overlay, an explicit re-select) moves the cursor onto the
 //     asserted instance's row — restoring the tab sub-selection when the
-//     cursor was on one of its tab rows (lastCursorTab); a dangling or nil
+//     cursor was on one of its tab rows (lastCursor*); a dangling or nil
 //     assertion leaves the clamped cursor as-is, matching the old "selected
 //     title gone → sidebar clamp behavior" rule.
 //
@@ -47,8 +47,8 @@ func (s *Sidebar) afterCursorMove() {
 
 // moveCursorToInstance places the cursor on the row of target, if it is in
 // the projection and its row is visible. When the cursor last rested on one of
-// target's tab rows (lastCursorTab), the same tab row is preferred so the #969
-// re-pin keeps the tab dimension; a vanished tab slot falls back to the
+// target's tab rows, the same tab identity is preferred so the #969 re-pin
+// keeps the tab dimension across a reorder; a vanished tab falls back to the
 // instance row. No-op otherwise.
 func (s *Sidebar) moveCursorToInstance(target *session.Instance) {
 	instIdx := -1
@@ -63,7 +63,44 @@ func (s *Sidebar) moveCursorToInstance(target *session.Instance) {
 	}
 	wantTab := -1
 	if s.lastCursorTitle == target.Title {
-		wantTab = s.lastCursorTab
+		tabs := target.GetTabs()
+		replacedSession := s.lastCursorInstanceID != "" && target.ID != "" &&
+			s.lastCursorInstanceID != target.ID
+		switch {
+		case replacedSession:
+			// A same-title kill/recreate mints fresh tab IDs. Preserve the
+			// equivalent replacement tab by name, matching the pane reconcile.
+			for i, tab := range tabs {
+				if tab.Name == s.lastCursorTabName {
+					wantTab = i
+					break
+				}
+			}
+		case s.lastCursorTabID != "":
+			// Within one session, an ID that vanished means the tab vanished. Do
+			// not hijack the cursor onto a different tab that reused its name.
+			for i, tab := range tabs {
+				if tab.ID == s.lastCursorTabID {
+					wantTab = i
+					break
+				}
+			}
+		case s.lastCursorTabName != "":
+			// Agent and legacy/id-less rows still have unique names. Prefer that
+			// identity across a reorder, then retain the historical ordinal
+			// fallback.
+			for i, tab := range tabs {
+				if tab.Name == s.lastCursorTabName {
+					wantTab = i
+					break
+				}
+			}
+			if wantTab < 0 {
+				wantTab = s.lastCursorTab
+			}
+		default:
+			wantTab = s.lastCursorTab
+		}
 	}
 	instRow := -1
 	for j, item := range s.visibleItems {
@@ -108,11 +145,28 @@ func (s *Sidebar) pushSelection() {
 	inst := instances[sel.ItemIndex]
 	prev := s.proj.GetSelectedInstance()
 	s.proj.SetSelectedInstance(inst)
+	s.lastCursorInstanceID = inst.ID
 	if sel.IsTab {
 		s.proj.SetActiveTab(sel.TabIndex)
 		s.lastCursorTab = sel.TabIndex
+		tabs := inst.GetTabs()
+		if sel.TabIndex >= 0 && sel.TabIndex < len(tabs) {
+			tab := tabs[sel.TabIndex]
+			s.lastCursorTabID = tab.ID
+			if tab.Kind == session.TabKindAgent {
+				// The daemon may heal the locally minted agent ID in place. Its
+				// unique fixed name is the stable identity in that domain.
+				s.lastCursorTabID = ""
+			}
+			s.lastCursorTabName = tab.Name
+		} else {
+			s.lastCursorTabID = ""
+			s.lastCursorTabName = ""
+		}
 	} else {
 		s.lastCursorTab = -1
+		s.lastCursorTabID = ""
+		s.lastCursorTabName = ""
 	}
 	s.lastCursorTitle = inst.Title
 	if prev != inst {

--- a/ui/sidebar_tab_identity_test.go
+++ b/ui/sidebar_tab_identity_test.go
@@ -1,0 +1,97 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSidebarTreeRepinTracksTabIdentityAcrossReorder is the row-1 regression
+// from #1991. The display selection remains sticky while the cursor is parked
+// on the section header; a later SelectInstance assertion must re-pin the cursor
+// to the tab it last occupied, even if an out-of-band reorder moved that tab to
+// another slot in the meantime.
+func TestSidebarTreeRepinTracksTabIdentityAcrossReorder(t *testing.T) {
+	s := newTreeSidebar(t, 1)
+	inst := s.proj.GetInstances()[0]
+	inst.AddWebTabForTest("a", "http://localhost:3000")
+	inst.AddWebTabForTest("b", "http://localhost:3001")
+	s.SetSelectedInstance(0)
+
+	s.SelectTabRow(inst.Title, 2)
+	wantID := inst.GetTabs()[2].ID
+	require.NotEmpty(t, wantID)
+	require.Equal(t, wantID, inst.GetTabs()[s.GetSelection().TabIndex].ID)
+
+	// Clicking the Instances header twice collapses then re-expands the section,
+	// leaving the cursor on the header while its previous instance/tab selection
+	// remains sticky — a real public navigation path to the latent state.
+	s.ClickHeader()
+	s.ClickHeader()
+	require.True(t, s.GetSelection().IsHeader,
+		"precondition: the cursor is off the tab rows while the instance selection stays sticky")
+	require.Same(t, inst, s.proj.GetSelectedInstance())
+
+	require.NoError(t, inst.ReorderTab(2, 3))
+	require.Equal(t, wantID, inst.GetTabs()[3].ID, "precondition: tab a moved from slot 2 to slot 3")
+	s.proj.SelectInstance(inst)
+
+	sel := s.GetSelection()
+	require.True(t, sel.IsTab, "the instance re-pin restores a tab row")
+	assert.Equal(t, wantID, inst.GetTabs()[sel.TabIndex].ID,
+		"the re-pin follows the last cursor tab by stable identity, not its stale slot")
+}
+
+// TestSidebarTreeRepinDoesNotHijackReusedTabName is the destructive complement:
+// within one session, a stable ID that left the roster means the old tab is
+// gone. A newly created tab may reuse its name, but the re-pin must fall back to
+// the instance row rather than silently selecting that imposter.
+func TestSidebarTreeRepinDoesNotHijackReusedTabName(t *testing.T) {
+	s := newTreeSidebar(t, 1)
+	inst := s.proj.GetInstances()[0]
+	inst.AddWebTabForTest("a", "http://localhost:3000")
+	inst.AddWebTabForTest("b", "http://localhost:3001")
+	s.SetSelectedInstance(0)
+	s.SelectTabRow(inst.Title, 2)
+	oldID := inst.GetTabs()[2].ID
+	require.NotEmpty(t, oldID)
+
+	s.ClickHeader()
+	s.ClickHeader()
+	require.True(t, s.GetSelection().IsHeader)
+
+	require.NoError(t, inst.DropClosedTab(2))
+	inst.AddWebTabForTest("a", "http://localhost:3002")
+	require.NotEqual(t, oldID, inst.GetTabs()[3].ID,
+		"precondition: the freed name belongs to a newly created tab")
+	s.proj.SelectInstance(inst)
+
+	sel := s.GetSelection()
+	assert.False(t, sel.IsTab,
+		"an unresolved stable ID falls back to the instance row, never a reused name or stale slot")
+	assert.Equal(t, 0, sel.ItemIndex)
+}
+
+// TestSidebarTreeRepinAgentUsesNameAcrossIDHealing protects the agent-tab
+// exception shared with pane reconciliation: its locally minted ID may be
+// replaced by the daemon's authoritative ID in place, while the positional
+// singleton itself remains the same tab.
+func TestSidebarTreeRepinAgentUsesNameAcrossIDHealing(t *testing.T) {
+	s := newTreeSidebar(t, 1)
+	inst := s.proj.GetInstances()[0]
+	inst.GetTabs()[0].ID = "local-agent-id"
+	s.SetSelectedInstance(0)
+	s.SelectTabRow(inst.Title, 0)
+
+	s.ClickHeader()
+	s.ClickHeader()
+	require.True(t, s.GetSelection().IsHeader)
+
+	inst.GetTabs()[0].ID = "daemon-agent-id"
+	s.proj.SelectInstance(inst)
+
+	sel := s.GetSelection()
+	require.True(t, sel.IsTab, "the re-pin keeps the agent tab across its ID heal")
+	assert.Equal(t, 0, sel.TabIndex)
+}


### PR DESCRIPTION
Closes #1991.

Summary:
- Re-pin sidebar rows and pane-preview suppression by stable tab identity, with the existing Agent and legacy ID-less name domains preserved.
- Persist additive tab IDs in TUI view state and restore panes, selection, and pane focus ID-first with name fallback. The schema version and name-based pane-key format remain unchanged.
- Carry the active tab through same-title session replacement in the existing replacement-name domain, and delete the unread menu active-tab mirror.

Review fixes:
- Preserve dismissed preview suppression while an ID-less tab receives its daemon ID by retaining the name bridge until both identities have IDs.
- Keep active-tab remapping separate from cursor synchronization. In-place roster updates sync immediately; replacement snapshots wait until the final rebuilt selection, after any instance re-sort.

Regression coverage:
- Sidebar re-pin after reorder, reused-name rejection, and Agent ID healing.
- Preview suppression after stable-ID and legacy ID-less reorders, including ID backfill after dismissal.
- Down-time tab-name reuse restores pane, selection, and focus to the saved ID, plus unresolved-ID legacy fallback.
- Same-title replacement with reordered tabs and a changed creation time preserves the selected tab through the production snapshot path.

Exact-head gates on `c5522455b84168e66e6b42a66f21cd2463cbc8ff`:
- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `make lint-file-length`
- Focused production-path regressions
- `make test-container`
- `make tui-driver-selftest` — 61/61 steps green

Real TUI verification from the exact commit:
- The driver exercised the rendered TUI at 80×24 and 60×18, including multi-tab selection, pane retargeting, restart, and keyboard paths.
