### PR TITLE
test(web): await config queue completion

### DIFF
--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -6748,6 +6748,7 @@ function createKeyedQueue() {
         tails.delete(key);
       }
     });
+    return next;
   };
 }
 var ConfigPane = class {

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "71d483dec607";
+const VERSION = "1fb36ba3e9ca";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/src/config.test.ts
+++ b/web/src/config.test.ts
@@ -190,8 +190,8 @@ test("saves for one key run in the order the user made them, however slow the ne
   };
 
   queue("auto_yes", save("off"));
-  queue("auto_yes", save("on"));
-  await new Promise((r) => setTimeout(r, 80));
+  const done = queue("auto_yes", save("on"));
+  await done;
 
   assert.deepEqual(started, ["off", "on"], "the second save must not start until the first settles");
   assert.deepEqual(finished, ["off", "on"], "the LAST value the user chose must be the last one written");
@@ -204,10 +204,10 @@ test("a rejected save does not wedge the queue for that key", async () => {
   queue("update_channel", async () => {
     throw new Error('update_channel must be one of [stable, preview], got "nightly"');
   });
-  queue("update_channel", async () => {
+  const done = queue("update_channel", async () => {
     finished.push("preview");
   });
-  await new Promise((r) => setTimeout(r, 20));
+  await done;
 
   assert.deepEqual(finished, ["preview"], "a refused value must not block the user's next attempt on that key");
 });
@@ -217,14 +217,14 @@ test("different keys are not queued behind each other", async () => {
   const queue = createKeyedQueue();
 
   // A slow save on one key must not hold up an unrelated one.
-  queue("listen_addr", async () => {
+  const slow = queue("listen_addr", async () => {
     await new Promise((r) => setTimeout(r, 40));
     finished.push("listen_addr");
   });
-  queue("auto_yes", async () => {
+  const fast = queue("auto_yes", async () => {
     finished.push("auto_yes");
   });
-  await new Promise((r) => setTimeout(r, 80));
+  await Promise.all([slow, fast]);
 
   assert.deepEqual(finished, ["auto_yes", "listen_addr"], "keys have no ordering relationship; they must not block each other");
 });

--- a/web/src/config.ts
+++ b/web/src/config.ts
@@ -132,8 +132,12 @@ export function canCommit(shown: string, current: string): boolean {
  * Per KEY, not global: two different keys have no ordering relationship, and
  * queueing them behind each other would make a slow write block an unrelated one
  * for no gain.
+ *
+ * The returned promise settles when this item (and anything ahead of it for the
+ * same key) settles. Production may ignore it; tests and other coordination
+ * points can await real queue completion instead of guessing with a timer.
  */
-export function createKeyedQueue(): (key: string, run: () => Promise<void>) => void {
+export function createKeyedQueue(): (key: string, run: () => Promise<void>) => Promise<void> {
   const tails = new Map<string, Promise<void>>();
   return (key, run) => {
     const prev = tails.get(key) ?? Promise.resolve();
@@ -153,6 +157,7 @@ export function createKeyedQueue(): (key: string, run: () => Promise<void>) => v
         tails.delete(key);
       }
     });
+    return next;
   };
 }
 


### PR DESCRIPTION
Closes #2275.

Summary:
- Return the config queue’s existing settled tail promise without changing its per-key ordering or rejection-swallowing behavior.
- Await that real completion boundary in all three queue tests instead of sleeping for 20–80 ms before assertions.
- Rebuild the committed web bundle.

Regression proof:
- With only the ordering test changed to await the queue call, the old `void` API failed deterministically before the second save started (`actual: ["off"]`, expected `["off", "on"]`).
- Returning the settled tail made that exact test pass; the rejection and independent-key tests now use the same completion boundary.

Exact-head gates on `10eac60f624de7967b556d6fd9d1118f3b5a5add`:
- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make web-test` (402 tests)
- `make web-build`
- `make test-container`
