### PR TITLE
feat(cli): add all-project session listing

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -656,6 +656,10 @@ func init() {
 	sessionsTabsCmd.AddCommand(sessionsTabsRenameCmd)
 	sessionsTabsCmd.AddCommand(sessionsTabsReorderCmd)
 
+	// Listing is project-scoped by default; --all is the explicit read-only
+	// opt-in to global breadth, matching `tasks list` (#2089).
+	sessionsListCmd.Flags().BoolVar(&sessionsListAllFlag, "all", false, "List sessions across every project instead of only the current one")
+
 	SessionsCmd.AddCommand(sessionsListCmd)
 	SessionsCmd.AddCommand(sessionsGetCmd)
 	SessionsCmd.AddCommand(sessionsCreateCmd)

--- a/api/scope_test.go
+++ b/api/scope_test.go
@@ -464,6 +464,7 @@ func resetScopeFlags(t *testing.T) {
 	t.Helper()
 	reset := func() {
 		repoFlag = ""
+		sessionsListAllFlag = false
 		tasksListAllFlag = false
 	}
 	t.Cleanup(reset)

--- a/api/sessions.go
+++ b/api/sessions.go
@@ -181,18 +181,33 @@ func resolveSelfSession() (*session.InstanceData, error) {
 	return whoamiSession(tmuxName)
 }
 
+var sessionsListAllFlag bool
+
 var sessionsListCmd = &cobra.Command{
 	Use:   "list",
-	Short: "List sessions",
+	Short: "List sessions in the current project",
+	Long: "List sessions in the current project.\n\n" +
+		"Scope follows the shared project-context contract: --repo names a project, " +
+		"otherwise the current directory's project is used, and --all spans every " +
+		"project. Run from outside a git repository with no --repo, there is no " +
+		"project context and every project's sessions are listed.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Initialize(false)
 		defer log.Close()
 
+		if sessionsListAllFlag && repoFlag != "" {
+			return jsonError(fmt.Errorf("--repo and --all are mutually exclusive: --repo names one project, --all spans every project"))
+		}
+
 		// Snapshot-based read: it follows --daemon-url to the remote, so it uses
 		// the lookup resolver (which ignores the client's cwd against a remote).
-		repoID, err := resolveRepoIDForLookup()
-		if err != nil {
-			return jsonError(err)
+		repoID := ""
+		if !sessionsListAllFlag {
+			var err error
+			repoID, err = resolveRepoIDForLookup()
+			if err != nil {
+				return jsonError(err)
+			}
 		}
 
 		// Read from the daemon's authoritative in-memory state when a daemon is

--- a/api/sessions_list_scope_test.go
+++ b/api/sessions_list_scope_test.go
@@ -1,0 +1,138 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/session"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSessionsList_AllSpansEveryProject is the headline #2089 regression: the
+// CLI flag must reach the Snapshot request as an empty repo id, which is the
+// daemon's explicit all-project scope. Before #2089 the flag was not registered
+// at all, so the test fails at the same Cobra boundary users hit.
+func TestSessionsList_AllSpansEveryProject(t *testing.T) {
+	useTempConfig(t)
+	resetScopeFlags(t)
+
+	fixture := newSessionsListScopeFixture(t)
+	t.Chdir(fixture.alpha)
+
+	allFlag := sessionsListCmd.Flags().Lookup("all")
+	require.NotNil(t, allFlag, "sessions list must expose an explicit --all flag")
+	require.NoError(t, sessionsListCmd.Flags().Set("all", "true"))
+	t.Cleanup(func() {
+		_ = sessionsListCmd.Flags().Set("all", "false")
+		allFlag.Changed = false
+	})
+
+	got := captureSessionsList(t)
+	require.Len(t, got, 2, "--all must request and return every project's sessions")
+	require.Equal(t, "", onlySessionsListRequest(t, fixture).RepoID)
+}
+
+func TestSessionsList_DefaultsToCurrentProject(t *testing.T) {
+	useTempConfig(t)
+	resetScopeFlags(t)
+
+	fixture := newSessionsListScopeFixture(t)
+	t.Chdir(fixture.alpha)
+
+	got := captureSessionsList(t)
+	require.Len(t, got, 1)
+	require.Equal(t, "alpha", got[0].Title)
+	require.Equal(t, fixture.alphaID, onlySessionsListRequest(t, fixture).RepoID)
+}
+
+func TestSessionsList_RepoScopesToNamedProject(t *testing.T) {
+	useTempConfig(t)
+	resetScopeFlags(t)
+
+	fixture := newSessionsListScopeFixture(t)
+	t.Chdir(fixture.alpha)
+	repoFlag = fixture.beta
+
+	got := captureSessionsList(t)
+	require.Len(t, got, 1)
+	require.Equal(t, "beta", got[0].Title)
+	require.Equal(t, fixture.betaID, onlySessionsListRequest(t, fixture).RepoID)
+}
+
+func TestSessionsList_RepoAndAllAreMutuallyExclusive(t *testing.T) {
+	useTempConfig(t)
+	resetScopeFlags(t)
+
+	fixture := newSessionsListScopeFixture(t)
+	repoFlag = fixture.alpha
+	sessionsListAllFlag = true
+
+	err := sessionsListCmd.RunE(sessionsListCmd, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mutually exclusive")
+	require.Empty(t, *fixture.requests, "invalid scope must fail before issuing a Snapshot request")
+}
+
+func TestSessionsList_OutsideRepoListsEveryProject(t *testing.T) {
+	useTempConfig(t)
+	resetScopeFlags(t)
+
+	fixture := newSessionsListScopeFixture(t)
+	t.Chdir(t.TempDir())
+
+	got := captureSessionsList(t)
+	require.Len(t, got, 2)
+	require.Equal(t, "", onlySessionsListRequest(t, fixture).RepoID)
+}
+
+type sessionsListScopeFixture struct {
+	alpha    string
+	beta     string
+	alphaID  string
+	betaID   string
+	requests *[]daemon.SnapshotRequest
+}
+
+func newSessionsListScopeFixture(t *testing.T) sessionsListScopeFixture {
+	t.Helper()
+	alpha := mkRepo(t, "alpha")
+	beta := mkRepo(t, "beta")
+	alphaRepo, err := config.RepoFromPath(alpha)
+	require.NoError(t, err)
+	betaRepo, err := config.RepoFromPath(beta)
+	require.NoError(t, err)
+
+	requests := stubSnapshot(t, func(req daemon.SnapshotRequest) ([]session.InstanceData, error) {
+		all := []session.InstanceData{{Title: "alpha"}, {Title: "beta"}}
+		switch req.RepoID {
+		case "":
+			return all, nil
+		case alphaRepo.ID:
+			return all[:1], nil
+		case betaRepo.ID:
+			return all[1:], nil
+		default:
+			return nil, nil
+		}
+	})
+	return sessionsListScopeFixture{
+		alpha: alpha, beta: beta, alphaID: alphaRepo.ID, betaID: betaRepo.ID, requests: requests,
+	}
+}
+
+func onlySessionsListRequest(t *testing.T, fixture sessionsListScopeFixture) daemon.SnapshotRequest {
+	t.Helper()
+	require.Len(t, *fixture.requests, 1)
+	return (*fixture.requests)[0]
+}
+
+func captureSessionsList(t *testing.T) []session.InstanceData {
+	t.Helper()
+	out := captureJSON(t, func() error { return sessionsListCmd.RunE(sessionsListCmd, nil) })
+	var got []session.InstanceData
+	require.NoError(t, json.Unmarshal(out, &got))
+	return got
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,9 +15,13 @@ Like the TUI and the web UI, **every `af sessions` and `af tasks` command is sco
     - Listing spans every project.
     - A `<title>` or task `<id>` resolves across projects, but a title held by several projects is ambiguous and errors rather than picking one.
 
-Acting on another project always takes an explicit `--repo`. The one exception is `af tasks list --all`, a read-only opt-in that spans every project.
+Acting on another project always takes an explicit `--repo`. The read-only list
+commands also accept `--all` as an explicit opt-in to span every project.
 
 ```bash
+af sessions list              # this project's sessions
+af sessions list --all        # every project's sessions
+af sessions list --repo /repos/beta
 af tasks list                 # this project's tasks
 af tasks list --all           # every project's tasks
 af tasks list --repo /repos/beta
@@ -66,7 +70,7 @@ Caveat for the reads: `--repo` becomes an id by hashing the path **as given on t
 One exception to per-project titles: **remote hook** sessions share a global name namespace, because the slug reaches `launch_cmd`/`delete_cmd` verbatim and external provisioners key real sandboxes on it — see [remote-hooks.md](remote-hooks.md#session-names).
 
 ```bash
-af sessions list                                          # list sessions in the repo
+af sessions list [--all]                                  # list this repo, or every repo explicitly
 af sessions get <title>                                   # fetch one session
 af sessions create --name <title> [--prompt "..."] [--program <agent>] [--here]
 af sessions send-prompt <title> "..."                     # append a prompt to a session
@@ -90,6 +94,7 @@ af sessions restore <title>                               # restore an archived/
 
 Flags:
 
+- `list`: `--all` spans every project's sessions explicitly; it is mutually exclusive with `--repo`.
 - `create`: `--name` (required), `--prompt` (initial prompt to send), `--program` (agent enum, defaults to the configured `default_program`). `--here` (alias `--in-place`) attaches the session to the repo's **existing working tree at its current branch** instead of cutting a new worktree+branch: the agent runs in the repo root, no branch is created, and killing the session never removes the working tree or branch. Requires a git repository (the current directory, or `--repo`); incompatible with remote sessions. The title `root` (any casing) is reserved for the daemon-managed root agent — see the `root_agents` key in [configuration.md](configuration.md#root-agents-always-ensured).
 - `send-prompt`: `--create` auto-creates the session if it doesn't exist; `--program` picks the agent when creating.
 - `tab-create`: creates a new tab in the session's worktree. By default, `--command` is run in the worktree as a process tab; `--name` sets the tab's name — the handle the other tab verbs address it by, not the label the TUI renders (defaults to the command's basename; sanitized to `[A-Za-z0-9_-]`, then auto-suffixed `-2`, `-3`, … on collision, so the name you pass is not always the name you get). With `--kind web`, creates an iframe tab targeting `--url` (or `--port` as a localhost:<port> convenience) instead. With `--kind vscode`, creates a VS Code editor tab on the session's own worktree — it takes no target, so `--url`/`--port`/`--command` are rejected, and it needs `code-server` (or `openvscode-server`) installed, which af detects rather than bundles. Both are browser panes with no PTY — see [web.md](web.md). The resolved tab name is printed as `{"name": "..."}` so scripts/agents can address it. The tab persists and reconnects across a daemon/`af` restart like every other tab. Refused once a session already holds 9 tabs. **Local sessions only:** an off-box session (docker/ssh/hook) has no daemon-side worktree to spawn a tab in, so the daemon rejects the request — its tab list is fixed at the single agent tab (see [remote-hooks.md](remote-hooks.md)).

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -39,7 +39,7 @@ Run `af <command> --help` for the same information at the terminal. For a narrat
 - [`af sessions get`](#af-sessions-get) — Get a session by title
 - [`af sessions handoff`](#af-sessions-handoff) — Continue a session under a different agent, in place
 - [`af sessions kill`](#af-sessions-kill) — Permanently destroy a session and prune its worktree branch
-- [`af sessions list`](#af-sessions-list) — List sessions
+- [`af sessions list`](#af-sessions-list) — List sessions in the current project
 - [`af sessions preview`](#af-sessions-preview) — Preview a session's terminal content
 - [`af sessions restore`](#af-sessions-restore) — Restore an archived, lost, or dead session
 - [`af sessions send-prompt`](#af-sessions-send-prompt) — Send a prompt to a session (or broadcast to all with --all)
@@ -958,7 +958,7 @@ af sessions
 - [`af sessions get`](#af-sessions-get) — Get a session by title
 - [`af sessions handoff`](#af-sessions-handoff) — Continue a session under a different agent, in place
 - [`af sessions kill`](#af-sessions-kill) — Permanently destroy a session and prune its worktree branch
-- [`af sessions list`](#af-sessions-list) — List sessions
+- [`af sessions list`](#af-sessions-list) — List sessions in the current project
 - [`af sessions preview`](#af-sessions-preview) — Preview a session's terminal content
 - [`af sessions restore`](#af-sessions-restore) — Restore an archived, lost, or dead session
 - [`af sessions send-prompt`](#af-sessions-send-prompt) — Send a prompt to a session (or broadcast to all with --all)
@@ -1186,11 +1186,21 @@ af sessions kill <title> [flags]
 
 ## af sessions list
 
-List sessions
+List sessions in the current project
+
+List sessions in the current project.
+
+Scope follows the shared project-context contract: --repo names a project, otherwise the current directory's project is used, and --all spans every project. Run from outside a git repository with no --repo, there is no project context and every project's sessions are listed.
 
 ```
-af sessions list
+af sessions list [flags]
 ```
+
+**Flags**
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--all` |  | List sessions across every project instead of only the current one |
 
 **Global flags**
 

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -177,7 +177,7 @@
       },
       "cli": {
         "status": "yes",
-        "pointer": "api/sessions.go:174 sessionsListCmd"
+        "pointer": "api/sessions.go:186 sessionsListCmd"
       },
       "verdict": "parity",
       "notes": ""
@@ -1548,6 +1548,7 @@
       "af sessions handoff --to": "session.handoff",
       "af sessions kill --force": "session.kill",
       "af sessions kill --help": "meta.discovery",
+      "af sessions list --all": "session.list",
       "af sessions list --help": "meta.discovery",
       "af sessions preview --full": "session.preview-full",
       "af sessions preview --help": "meta.discovery",


### PR DESCRIPTION
## Summary

- add `--all` to `af sessions list` so callers can request sessions across projects
- preserve current-project and explicit `--repo` scoping, and reject the ambiguous `--repo --all` combination
- update CLI documentation and the parity inventory for the new flag

## Reproduction and regression

Before this change, `go run . sessions list --all` failed with `unknown flag: --all`.

The regression tests invoke the production Cobra command and inspect the request sent to the API. They cover the default current-project scope, explicit repository scope, all-project scope (including outside a repository), and the conflicting flag pair. The new all-project case failed at flag parsing before the implementation.

## Exact-head gates

Gated commit: `a41ed361af66a389bbc8879333dfe62cef56f115`

- `go test ./api -run '^TestSessionsList_' -count=1`
- `go test ./parity -count=1`
- `scripts/gen-docs.sh` followed by `git diff --exit-code`
- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (empty)
- `go build ./...`
- `make test-container`

Fixes #2089
