### PR TITLE
test(integration): isolate scheduled rerun triggers

### DIFF
--- a/integration/cli_daemon_test.go
+++ b/integration/cli_daemon_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/internal/testguard"
 	"github.com/sachiniyer/agent-factory/session/tmux"
+	"github.com/sachiniyer/agent-factory/task"
 )
 
 type harness struct {
@@ -162,7 +163,7 @@ func TestScheduledTaskRunnerUsesDaemonAndAllocatesRerunTitle(t *testing.T) {
 			"id":           "task-one",
 			"name":         "nightly",
 			"prompt":       "",
-			"cron_expr":    "* * * * *",
+			"cron_expr":    manualTriggerFixtureCron(time.Now()),
 			"project_path": h.repo,
 			"program":      tmux.ProgramClaude,
 			"enabled":      true,
@@ -190,6 +191,27 @@ func TestScheduledTaskRunnerUsesDaemonAndAllocatesRerunTitle(t *testing.T) {
 	tasks := tasksFile.Tasks
 	if len(tasks) != 1 || tasks[0].LastRunAt == nil || tasks[0].LastRunStatus != "started" {
 		t.Fatalf("task status was not updated after run: %+v", tasks)
+	}
+}
+
+// manualTriggerFixtureCron keeps the task enabled and schedulable while placing
+// its next automatic fire outside this test's manual-trigger window. An
+// every-minute fixture lets robfig/cron race h.run below for the same nonblocking
+// task lock, so either manual invocation can fail without exercising title
+// allocation at all (#2163).
+func manualTriggerFixtureCron(now time.Time) string {
+	future := now.Add(24 * time.Hour)
+	return fmt.Sprintf("%d %d %d %d *", future.Minute(), future.Hour(), future.Day(), future.Month())
+}
+
+func TestScheduledTaskManualTriggerFixtureCannotRaceTheScheduler(t *testing.T) {
+	now := time.Date(2026, time.July, 21, 20, 33, 42, 0, time.UTC)
+	schedule, err := task.ParseCron(manualTriggerFixtureCron(now))
+	if err != nil {
+		t.Fatalf("parse fixture cron: %v", err)
+	}
+	if next := schedule.Next(now); next.Before(now.Add(12 * time.Hour)) {
+		t.Fatalf("fixture can fire during manual triggers: next run is %s after %s", next, now)
 	}
 }
 


### PR DESCRIPTION
## Summary

- replace the every-minute scheduled-task fixture with a valid schedule whose next fire is one day outside the manual-trigger test window
- add a deterministic regression that parses the fixture cron and rejects any next run within 12 hours
- leave production scheduling, task locking, and rerun-title allocation unchanged

The bot report’s worktree-state hypothesis did not hold. Historical failed-attempt logs show the actual failure: the daemon’s cron scheduler races one of the two manual `tasks trigger` calls and the nonblocking per-task lock returns `another run is already active for task task-one`.

## Verification

Fail-first on the old fixture:

`fixture can fire during manual triggers: next run is 2026-07-21 20:34:00 +0000 UTC after 2026-07-21 20:33:42 +0000 UTC`

Focused verification on the fix:

- deterministic fixture invariant passes
- `TestScheduledTaskRunnerUsesDaemonAndAllocatesRerunTitle` passes 50 consecutive container runs (`113.124s`)

All required gates passed on exact pushed head `7d3522ecf4437c82c4765ccd5488a95c882bf6d5`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (no output)
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`

Closes #2163

— Captain Claude
