### PR TITLE
test(web): await settled mobile drawer layout

### DIFF
--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -6051,6 +6051,86 @@ async function horizontalOverflow(p: Page): Promise<number> {
   });
 }
 
+/** Waits on the browser's own drawer/descendant animation timeline, then captures the
+ *  CURRENT row and all relevant geometry in one page task. Live session events rebuild
+ *  the rail with replaceChildren(); resolving action locators and later measuring a row
+ *  in separate browser calls can otherwise inspect different row generations. */
+async function settledMobileDrawerGeometry(p: Page, title: string) {
+  return p.locator(".af-rail").evaluate(async (rail, expectedTitle) => {
+    const describeAnimation = (animation: Animation) => {
+      const target = animation.effect instanceof KeyframeEffect ? animation.effect.target : null;
+      return {
+        target: target instanceof Element ? target.getAttribute("class") : null,
+        playState: animation.playState,
+      };
+    };
+    const animations = rail.getAnimations({ subtree: true });
+    const waitedAnimations = animations.map(describeAnimation);
+    await Promise.allSettled(animations.map((animation) => animation.finished));
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+    const rect = (el: Element) => {
+      const box = el.getBoundingClientRect();
+      return {
+        x: box.x,
+        y: box.y,
+        width: box.width,
+        height: box.height,
+        right: box.right,
+        bottom: box.bottom,
+      };
+    };
+    const app = rail.closest(".af-app");
+    const toggle = app?.querySelector(".af-nav-toggle");
+    const rows = Array.from(rail.querySelectorAll<HTMLElement>(".af-row"));
+    const matches = rows.filter((candidate) => candidate.textContent?.includes(expectedTitle));
+    const selected = matches[0] ?? null;
+    const main = selected?.querySelector<HTMLElement>(".af-row-main") ?? null;
+    const actions = selected?.querySelector<HTMLElement>(".af-row-actions") ?? null;
+    const railStyle = getComputedStyle(rail);
+
+    return {
+      appOpen: app?.classList.contains("af-nav-open") ?? false,
+      toggleExpanded: toggle?.getAttribute("aria-expanded") ?? null,
+      waitedAnimations,
+      remainingAnimations: rail.getAnimations({ subtree: true }).map(describeAnimation),
+      rail: {
+        connected: rail.isConnected,
+        rect: rect(rail),
+        display: railStyle.display,
+        visibility: railStyle.visibility,
+        transform: railStyle.transform,
+      },
+      rows: rows.map((candidate) => ({
+        connected: candidate.isConnected,
+        text: candidate.textContent,
+        rect: rect(candidate),
+      })),
+      targetMatches: matches.length,
+      target:
+        selected && main && actions
+          ? {
+              connected: selected.isConnected,
+              rect: rect(selected),
+              main: rect(main),
+              actions: rect(actions),
+              actionStyle: {
+                display: getComputedStyle(actions).display,
+                opacity: getComputedStyle(actions).opacity,
+                visibility: getComputedStyle(actions).visibility,
+              },
+              buttons: Array.from(actions.querySelectorAll<HTMLButtonElement>("button")).map((button) => ({
+                label: button.getAttribute("aria-label"),
+                rect: rect(button),
+              })),
+              actionsInside: actions.getBoundingClientRect().right <= selected.getBoundingClientRect().right + 1,
+              overflow: selected.scrollWidth - selected.clientWidth,
+            }
+          : null,
+    };
+  }, title);
+}
+
 test("mobile (375px): the rail auto-collapses to a drawer; the hamburger reveals it as an overlay and picking a session folds it shut", REAL_FIXTURE, async ({
   browser,
 }) => {
@@ -6099,23 +6179,43 @@ test("mobile (375px): the rail auto-collapses to a drawer; the hamburger reveals
 
   // Re-open the narrow drawer with a selection: both quiet glyphs fit inside the row
   // without squeezing its title away or widening the page.
-  await toggle.click();
-  await expect(rail).toBeVisible();
-  await expect(railAction(p, SESSION_A, "Archive session")).toBeVisible();
-  await expect(railAction(p, SESSION_A, "Kill session")).toBeVisible();
-  const fit = await row(p, SESSION_A).evaluate((el) => {
-    const rowBox = el.getBoundingClientRect();
-    const mainBox = el.querySelector(".af-row-main")!.getBoundingClientRect();
-    const actionBox = el.querySelector(".af-row-actions")!.getBoundingClientRect();
-    return {
-      mainWidth: mainBox.width,
-      actionsInside: actionBox.right <= rowBox.right + 1,
-      overflow: el.scrollWidth - el.clientWidth,
-    };
+  //
+  // Controlled regression for #2331: browser/daemon load can leave a descendant's
+  // layout work behind the drawer's immediate visibility flip. Hold the flexible cell
+  // at zero basis on the browser animation timeline. The old visibility-only check
+  // deterministically read it mid-animation; the settled snapshot below waits on the
+  // actual work rather than sleeping or retrying the assertion.
+  await row(p, SESSION_A).evaluate((el) => {
+    const main = el.querySelector<HTMLElement>(".af-row-main")!;
+    main.animate(
+      [
+        { flexBasis: "0px", flexGrow: "0" },
+        { flexBasis: "0px", flexGrow: "1" },
+      ],
+      { duration: 1_000, easing: "steps(1, end)" },
+    );
   });
-  expect(fit.mainWidth, "the selected row keeps readable room for its title").toBeGreaterThan(80);
-  expect(fit.actionsInside, "the action glyphs stay inside the selected row").toBe(true);
-  expect(fit.overflow, "the selected row does not overflow at 375px").toBeLessThanOrEqual(1);
+  await toggle.click();
+  const fit = await settledMobileDrawerGeometry(p, SESSION_A);
+  const diagnostic = `settled mobile drawer geometry:\n${JSON.stringify(fit, null, 2)}`;
+  expect(fit.appOpen, diagnostic).toBe(true);
+  expect(fit.toggleExpanded, diagnostic).toBe("true");
+  expect(fit.remainingAnimations.filter((animation) => animation.playState !== "finished"), diagnostic).toEqual([]);
+  expect(fit.rail.connected, diagnostic).toBe(true);
+  expect(fit.rail.visibility, diagnostic).toBe("visible");
+  expect(fit.rail.rect.x, diagnostic).toBeGreaterThanOrEqual(-1);
+  expect(fit.targetMatches, diagnostic).toBe(1);
+  expect(fit.target, diagnostic).not.toBeNull();
+  if (!fit.target) throw new Error(diagnostic);
+  expect(
+    fit.target.buttons.map((button) => button.label),
+    diagnostic,
+  ).toEqual([`Archive session “${SESSION_A}”`, `Kill session “${SESSION_A}”`]);
+  expect(fit.target.buttons.every((button) => button.rect.width > 0 && button.rect.height > 0), diagnostic).toBe(true);
+  expect(fit.target.actionStyle, diagnostic).toMatchObject({ display: "flex", opacity: "1", visibility: "visible" });
+  expect(fit.target.main.width, diagnostic).toBeGreaterThan(80);
+  expect(fit.target.actionsInside, diagnostic).toBe(true);
+  expect(fit.target.overflow, diagnostic).toBeLessThanOrEqual(1);
 
   await ctx.close();
 });


### PR DESCRIPTION
## Summary

- wait for the browser's actual drawer-subtree animations before checking selected-row layout
- capture the current rail row and all geometry atomically, so a live `replaceChildren()` render cannot split readiness and measurement across row generations
- report app/drawer state, animation state, every rendered row, and row/main/action/button rectangles on any failed invariant

## Root cause and regression

The production drawer retains a fixed `min(85vw, 20rem)` width while its transform animates, so the transform itself cannot collapse `.af-row-main`. Live session updates do synchronously replace all rail row nodes, while the old test separately resolved action visibility and later evaluated a row. Under load, that made the harness capable of inspecting a stale or not-yet-settled descendant even though the current rendered rail was valid.

The regression creates a controlled browser animation that holds the selected row's flexible cell at zero basis while the drawer becomes visible. With the old visibility-only assertion, the focused case failed deterministically with `mainWidth` still 12.59375 px. The new helper waits on the animation objects themselves—no sleep, assertion retry, timeout increase, or threshold relaxation—then reads the current row in the same page task. The same controlled case passes with the original strict width and overflow invariants.

## Exact-head validation

Validated commit: `f6894b2eb4373a280c66a7c5c35d3da17b6cea44`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (empty)
- `go build ./...`
- `make web-test` (402 tests)
- `make web-build` after rebasing the latest merged web bundle (no diff)
- `scripts/lint-file-length.sh`
- `make test-container`
- focused real-browser regression: failed before the helper, passed after it
- full `make web-selftest-container`: this mobile case passed; the run independently reproduced #2330's already-tracked missing-`k2` event in the `#1815 review` case, so it was not retried or hidden

Fixes #2331
