### PR TITLE
fix(ci): retarget auto-gate review to Codex

### DIFF
--- a/.github/scripts/auto-gate.js
+++ b/.github/scripts/auto-gate.js
@@ -4,6 +4,7 @@ const DOCS_DEPLOY_PATHS = ["docs/", "mkdocs.yml"];
 const CODEX_REVIEWER = "chatgpt-codex-connector[bot]";
 const CODEX_REVIEW_RE = /\bCodex Review\b/i;
 const CODEX_RATE_LIMIT_RE = /reached your Codex usage limits for code reviews/i;
+const CODEX_BODY_FINDING_RE = /\bP[0-3]\b/i;
 const REVIEWED_COMMIT_RE = /\*\*Reviewed commit:\*\*\s*`([0-9a-f]{7,40})`/i;
 // Docs/Deploy is deliberately conditional and is skipped on pull_request runs.
 const ALLOWED_SKIPPED_CHECKS = new Set(["Deploy"]);
@@ -505,10 +506,11 @@ async function evaluateCodex({ github, context, number, sha, lastCommitDate }) {
   const codexReviewArtifacts = [...codexComments, ...reviews]
     .filter((comment) => comment.user?.login === CODEX_REVIEWER)
     .sort((a, b) => reviewArtifactTime(b) - reviewArtifactTime(a));
-  const verdict = codexReviewArtifacts.find((comment) => {
+  const matchingReviewArtifacts = codexReviewArtifacts.filter((comment) => {
     const reviewedCommit = parseReviewedCommit(comment.body || "");
     return reviewedCommit != null && reviewedCommitMatchesHead(reviewedCommit, sha);
   });
+  const verdict = matchingReviewArtifacts[0];
 
   if (!verdict) {
     const latestCodexComment = codexComments.sort((a, b) => reviewArtifactTime(b) - reviewArtifactTime(a))[0];
@@ -522,6 +524,13 @@ async function evaluateCodex({ github, context, number, sha, lastCommitDate }) {
     } else {
       notes.push(`Codex verdict matches head ${sha}`);
     }
+  }
+
+  const bodyFindings = matchingReviewArtifacts.filter((artifact) =>
+    CODEX_BODY_FINDING_RE.test(artifact.body || ""),
+  );
+  if (bodyFindings.length > 0) {
+    reasons.push(`${bodyFindings.length} exact-head Codex review body finding(s)`);
   }
 
   const reviewComments = await github.paginate(github.rest.pulls.listReviewComments, {

--- a/.github/scripts/auto-gate.js
+++ b/.github/scripts/auto-gate.js
@@ -1,7 +1,13 @@
 const ALLOWED_AUTHORS = new Set(["sachiniyer", "app-detail-app", "app-detail-app[bot]"]);
 const TUI_PATH_PREFIXES = ["app/", "ui/", "session/tmux/"];
 const DOCS_DEPLOY_PATHS = ["docs/", "mkdocs.yml"];
-const GREPTILE_RE = /greptile/i;
+const CODEX_REVIEWER = "chatgpt-codex-connector[bot]";
+const CODEX_REVIEW_RE = /\bCodex Review\b/i;
+const CODEX_RATE_LIMIT_RE = /reached your Codex usage limits for code reviews/i;
+const REVIEWED_COMMIT_RE = /\*\*Reviewed commit:\*\*\s*`([0-9a-f]{7,40})`/i;
+// Docs/Deploy is deliberately conditional and is skipped on pull_request runs.
+const ALLOWED_SKIPPED_CHECKS = new Set(["Deploy"]);
+const AUTO_GATE_CHECK_NAME = "Evaluate auto-merge gate";
 const RESOLUTION_MARKER_RE = /\b(?:RESOLVED|ACCEPTED)\b/;
 
 async function evaluate({ github, context, core, prNumber, setOutputs = true }) {
@@ -43,6 +49,10 @@ async function evaluatePullRequest({ github, context, core, prNumber, setOutputs
   core.info(`Base: ${pr.baseRefName}; head SHA: ${pr.headRefOid}`);
   core.info(`Mergeable: ${pr.mergeable}; merge state: ${pr.mergeStateStatus}`);
 
+  if (pr.state !== "OPEN" || pr.merged) {
+    reasons.push(`PR is ${pr.merged ? "already merged" : pr.state.toLowerCase()}, not open`);
+  }
+
   if (pr.baseRefName !== "master") {
     reasons.push(`base branch is ${pr.baseRefName}, not master`);
   }
@@ -57,8 +67,8 @@ async function evaluatePullRequest({ github, context, core, prNumber, setOutputs
 
   if (pr.mergeable === "CONFLICTING" || pr.mergeStateStatus === "DIRTY") {
     reasons.push(`mergeability is blocked (${pr.mergeable}/${pr.mergeStateStatus})`);
-  } else if (pr.mergeable === "UNKNOWN") {
-    reasons.push("mergeability is still UNKNOWN");
+  } else if (pr.mergeable !== "MERGEABLE") {
+    reasons.push(`mergeability is still ${pr.mergeable}`);
   }
 
   const files = await listPullRequestFiles({ github, context, number: pr.number });
@@ -92,18 +102,17 @@ async function evaluatePullRequest({ github, context, core, prNumber, setOutputs
   }
   notes.push(...requiredChecks.notes);
 
-  const greptile = await evaluateGreptile({
+  const codex = await evaluateCodex({
     github,
     context,
     number: pr.number,
     sha: pr.headRefOid,
     lastCommitDate: pr.lastCommitDate,
-    core,
   });
-  if (!greptile.ok) {
-    reasons.push(...greptile.reasons);
+  if (!codex.ok) {
+    reasons.push(...codex.reasons);
   }
-  notes.push(...greptile.notes);
+  notes.push(...codex.notes);
 
   return finish(core, setOutputs, {
     prNumber: String(pr.number),
@@ -160,6 +169,10 @@ async function findPullRequestNumber({ github, context, core }) {
     return payload.pull_request.number;
   }
 
+  if (payload.issue?.pull_request && payload.issue.number) {
+    return payload.issue.number;
+  }
+
   const checkSuitePrs = payload.check_suite?.pull_requests || [];
   const checkSuitePr = checkSuitePrs.find((pr) => pr.base?.ref === "master") || checkSuitePrs[0];
   if (checkSuitePr?.number) {
@@ -201,6 +214,8 @@ async function getPullRequest({ github, context, number }) {
           headRefName
           headRefOid
           isDraft
+          state
+          merged
           mergeable
           mergeStateStatus
           author {
@@ -236,6 +251,8 @@ async function getPullRequest({ github, context, number }) {
     baseRefName: pr.baseRefName,
     headRefOid: pr.headRefOid,
     isDraft: pr.isDraft,
+    state: pr.state,
+    merged: pr.merged,
     mergeable: pr.mergeable,
     mergeStateStatus: pr.mergeStateStatus,
     author: pr.author?.login || "",
@@ -262,14 +279,10 @@ async function evaluateRequiredChecks({ github, context, branch, sha, core }) {
   const reasons = [...required.errors];
 
   if (specs.length === 0) {
-    if (reasons.length > 0) {
-      return { ok: false, reasons, notes };
-    }
     notes.push("No required status checks configured for branch");
-    return { ok: true, reasons, notes };
+  } else {
+    notes.push(`Required status checks: ${specs.map(formatCheckSpec).join(", ")}`);
   }
-
-  notes.push(`Required status checks: ${specs.map(formatCheckSpec).join(", ")}`);
 
   const { owner, repo } = context.repo;
   const checkRuns = await github.paginate(github.rest.checks.listForRef, {
@@ -294,7 +307,21 @@ async function evaluateRequiredChecks({ github, context, branch, sha, core }) {
 
     notes.push(`${formatCheckSpec(spec)}: ${state.description}`);
     if (!state.ok) {
-      reasons.push(`required check ${formatCheckSpec(spec)} is not completed successfully (${state.description})`);
+      const stateDescription = state.waiting ? "is still settling" : "did not succeed";
+      reasons.push(`required check ${formatCheckSpec(spec)} ${stateDescription} (${state.description})`);
+    }
+  }
+
+  for (const run of latestCheckRuns(checkRuns)) {
+    if (run.name === AUTO_GATE_CHECK_NAME || specs.some((spec) => checkRunMatchesSpec(run, spec))) {
+      continue;
+    }
+
+    const state = checkRunState(run);
+    notes.push(`Head check ${run.name}: ${state.description}`);
+    if (!state.ok) {
+      const stateDescription = state.waiting ? "is still settling" : "did not succeed";
+      reasons.push(`head check ${run.name} ${stateDescription} (${state.description})`);
     }
   }
 
@@ -379,16 +406,13 @@ function latestRequiredState(spec, checkRuns, statuses) {
   const candidates = [];
 
   for (const run of checkRuns) {
-    if (run.name !== spec.context) {
+    if (!checkRunMatchesSpec(run, spec)) {
       continue;
     }
-    if (spec.sourceAppId && Number(run.app?.id) !== spec.sourceAppId) {
-      continue;
-    }
+    const state = checkRunState(run);
     candidates.push({
       date: parseTimestamp(run.completed_at || run.started_at || run.created_at) || 0,
-      ok: run.status === "completed" && run.conclusion === "success",
-      description: `check run ${run.status}/${run.conclusion || "no conclusion"} from ${formatRunSource(run)}`,
+      ...state,
     });
   }
 
@@ -400,6 +424,7 @@ function latestRequiredState(spec, checkRuns, statuses) {
       candidates.push({
         date: parseTimestamp(status.created_at) || 0,
         ok: status.state === "success",
+        waiting: status.state === "pending",
         description: `commit status ${status.state}`,
       });
     }
@@ -407,6 +432,43 @@ function latestRequiredState(spec, checkRuns, statuses) {
 
   candidates.sort((a, b) => b.date - a.date);
   return candidates[0] || null;
+}
+
+function checkRunMatchesSpec(run, spec) {
+  if (run.name !== spec.context) {
+    return false;
+  }
+  return !spec.sourceAppId || Number(run.app?.id) === spec.sourceAppId;
+}
+
+function checkRunState(run) {
+  const description = `check run ${run.status}/${run.conclusion || "no conclusion"} from ${formatRunSource(run)}`;
+  const successful = run.status === "completed" && run.conclusion === "success";
+  const conditionalSkip =
+    run.status === "completed" &&
+    run.conclusion === "skipped" &&
+    ALLOWED_SKIPPED_CHECKS.has(run.name) &&
+    run.app?.slug === "github-actions";
+
+  return {
+    ok: successful || conditionalSkip,
+    // GitHub Advanced Security reports CodeQL neutral while its Analyze jobs run,
+    // then updates the same head check to success when analysis settles.
+    waiting: run.status !== "completed" || (run.name === "CodeQL" && run.conclusion === "neutral"),
+    description,
+  };
+}
+
+function latestCheckRuns(checkRuns) {
+  const latest = new Map();
+  for (const run of checkRuns) {
+    const key = `${run.name}\0${run.app?.id || ""}`;
+    const current = latest.get(key);
+    if (!current || latestRunTime(run) > latestRunTime(current)) {
+      latest.set(key, run);
+    }
+  }
+  return [...latest.values()].sort((a, b) => a.name.localeCompare(b.name));
 }
 
 function formatRunSource(run) {
@@ -417,34 +479,14 @@ function formatRunSource(run) {
   return `${name} (${run.app.id || "unknown app id"})`;
 }
 
-async function evaluateGreptile({ github, context, number, sha, lastCommitDate, core }) {
+async function evaluateCodex({ github, context, number, sha, lastCommitDate }) {
   const notes = [];
   const reasons = [];
   const { owner, repo } = context.repo;
   const lastPushTime = parseTimestamp(lastCommitDate);
 
   if (lastPushTime == null) {
-    reasons.push("last commit timestamp was unavailable, so Greptile freshness cannot be verified");
-  }
-
-  const checkRuns = await github.paginate(github.rest.checks.listForRef, {
-    owner,
-    repo,
-    ref: sha,
-    per_page: 100,
-  });
-  const greptileRuns = checkRuns
-    .filter((run) => GREPTILE_RE.test(run.name) || GREPTILE_RE.test(run.app?.slug || run.app?.name || ""))
-    .sort((a, b) => latestRunTime(b) - latestRunTime(a));
-  const latestRun = greptileRuns[0];
-
-  if (!latestRun) {
-    reasons.push("Greptile Review check run was not found");
-  } else {
-    notes.push(`Greptile check: ${latestRun.name} ${latestRun.status}/${latestRun.conclusion || "no conclusion"}`);
-    if (latestRun.status !== "completed" || latestRun.conclusion !== "success") {
-      reasons.push(`Greptile Review is not completed successfully (${latestRun.status}/${latestRun.conclusion || "no conclusion"})`);
-    }
+    reasons.push("last commit timestamp was unavailable, so Codex freshness cannot be verified");
   }
 
   const comments = await github.paginate(github.rest.issues.listComments, {
@@ -453,29 +495,24 @@ async function evaluateGreptile({ github, context, number, sha, lastCommitDate, 
     issue_number: number,
     per_page: 100,
   });
-  const latestGreptileComment = comments
-    .filter((comment) => GREPTILE_RE.test(comment.user?.login || ""))
-    .sort((a, b) => {
-      const bTime = parseTimestamp(b.updated_at || b.created_at) || 0;
-      const aTime = parseTimestamp(a.updated_at || a.created_at) || 0;
-      return bTime - aTime;
-    })[0];
+  const codexComments = comments
+    .filter((comment) => comment.user?.login === CODEX_REVIEWER)
+    .sort((a, b) => commentTime(b) - commentTime(a));
+  const verdict = codexComments.find((comment) => {
+    const reviewedCommit = parseReviewedCommit(comment.body || "");
+    return reviewedCommit != null && reviewedCommitMatchesHead(reviewedCommit, sha);
+  });
 
-  if (!latestGreptileComment) {
-    reasons.push("latest greptile-apps summary comment was not found");
+  if (!verdict) {
+    const rateLimited = CODEX_RATE_LIMIT_RE.test(codexComments[0]?.body || "");
+    const suffix = rateLimited ? "; the latest Codex response was usage-limited" : "";
+    reasons.push(`Codex has not reviewed head ${sha} yet${suffix}`);
   } else {
-    const summaryTime = parseTimestamp(latestGreptileComment.updated_at || latestGreptileComment.created_at);
-    if (lastPushTime == null || summaryTime == null || summaryTime <= lastPushTime) {
-      reasons.push("latest greptile-apps summary comment is older than the head commit");
-    }
-
-    const score = parseConfidenceScore(latestGreptileComment.body || "");
-    if (score == null) {
-      reasons.push("latest greptile-apps summary comment did not include a Confidence Score");
-    } else if (score < 4) {
-      reasons.push(`Greptile Confidence Score is ${score}/5, below 4/5`);
+    const verdictTime = commentTime(verdict);
+    if (lastPushTime == null || verdictTime === 0 || verdictTime <= lastPushTime) {
+      reasons.push("Codex verdict for the head commit is older than the head commit timestamp");
     } else {
-      notes.push(`Greptile Confidence Score: ${score}/5`);
+      notes.push(`Codex verdict matches head ${sha}`);
     }
   }
 
@@ -497,49 +534,41 @@ async function evaluateGreptile({ github, context, number, sha, lastCommitDate, 
       .map((comment) => comment.in_reply_to_id),
   );
   const unresolvedFindings = reviewComments.filter((comment) => {
-    if (!GREPTILE_RE.test(comment.user?.login || "")) {
+    if (comment.user?.login !== CODEX_REVIEWER) {
       return false;
     }
     if (comment.in_reply_to_id) {
       return false;
     }
-    if (lastPushTime == null || parseTimestamp(comment.created_at) == null || parseTimestamp(comment.created_at) <= lastPushTime) {
-      return false;
-    }
-    if (!/\bP[12]\b/i.test(comment.body || "")) {
-      return false;
-    }
-    if (comment.position == null) {
+    if (comment.line == null) {
       return false;
     }
     return !resolvedByAllowedReply.has(comment.id);
   });
 
   if (unresolvedFindings.length > 0) {
-    reasons.push(`${unresolvedFindings.length} unresolved Greptile P1/P2 inline finding(s) after the last push`);
+    reasons.push(`${unresolvedFindings.length} unresolved live Codex inline finding(s)`);
   } else {
-    notes.push("No unresolved Greptile P1/P2 inline findings after the last push");
+    notes.push("No unresolved live Codex inline findings");
   }
 
   return { ok: reasons.length === 0, reasons, notes };
 }
 
-function parseConfidenceScore(body) {
-  const normalized = body.replace(/\s+/g, " ");
-  const patterns = [
-    /confidence\s*score\D{0,40}([0-5](?:\.\d+)?)\s*\/\s*5/i,
-    /confidence\D{0,40}([0-5](?:\.\d+)?)\s*\/\s*5/i,
-    /([0-5](?:\.\d+)?)\s*\/\s*5\D{0,40}confidence/i,
-  ];
-
-  for (const pattern of patterns) {
-    const match = normalized.match(pattern);
-    if (match) {
-      return Number.parseFloat(match[1]);
-    }
+function parseReviewedCommit(body) {
+  if (!CODEX_REVIEW_RE.test(body) || CODEX_RATE_LIMIT_RE.test(body)) {
+    return null;
   }
+  return body.match(REVIEWED_COMMIT_RE)?.[1]?.toLowerCase() || null;
+}
 
-  return null;
+function reviewedCommitMatchesHead(reviewedCommit, headSha) {
+  const normalizedHead = String(headSha || "").toLowerCase();
+  return /^[0-9a-f]{40}$/.test(normalizedHead) && normalizedHead.startsWith(reviewedCommit);
+}
+
+function commentTime(comment) {
+  return parseTimestamp(comment.updated_at || comment.created_at) || 0;
 }
 
 function hasResolutionMarker(body) {
@@ -593,9 +622,11 @@ module.exports = {
   evaluate,
   merge,
   __test: {
-    evaluateGreptile,
+    evaluateCodex,
+    evaluateRequiredChecks,
     hasResolutionMarker,
     latestRequiredState,
-    parseConfidenceScore,
+    parseReviewedCommit,
+    reviewedCommitMatchesHead,
   },
 };

--- a/.github/scripts/auto-gate.js
+++ b/.github/scripts/auto-gate.js
@@ -8,7 +8,6 @@ const CODEX_BODY_FINDING_RE = /\bP[0-3]\b/i;
 const REVIEWED_COMMIT_RE = /\*\*Reviewed commit:\*\*\s*`([0-9a-f]{7,40})`/i;
 // Docs/Deploy is deliberately conditional and is skipped on pull_request runs.
 const ALLOWED_SKIPPED_CHECKS = new Set(["Deploy"]);
-const AUTO_GATE_CHECK_NAME = "Evaluate auto-merge gate";
 const RESOLUTION_MARKER_RE = /\b(?:RESOLVED|ACCEPTED)\b/;
 
 async function evaluate({ github, context, core, prNumber, setOutputs = true }) {
@@ -313,19 +312,6 @@ async function evaluateRequiredChecks({ github, context, branch, sha, core }) {
     }
   }
 
-  for (const run of latestCheckRuns(checkRuns)) {
-    if (run.name === AUTO_GATE_CHECK_NAME || specs.some((spec) => checkRunMatchesSpec(run, spec))) {
-      continue;
-    }
-
-    const state = checkRunState(run);
-    notes.push(`Head check ${run.name}: ${state.description}`);
-    if (!state.ok) {
-      const stateDescription = state.waiting ? "is still settling" : "did not succeed";
-      reasons.push(`head check ${run.name} ${stateDescription} (${state.description})`);
-    }
-  }
-
   return { ok: reasons.length === 0, reasons, notes };
 }
 
@@ -460,18 +446,6 @@ function checkRunState(run) {
   };
 }
 
-function latestCheckRuns(checkRuns) {
-  const latest = new Map();
-  for (const run of checkRuns) {
-    const key = `${run.name}\0${run.app?.id || ""}`;
-    const current = latest.get(key);
-    if (!current || latestRunTime(run) > latestRunTime(current)) {
-      latest.set(key, run);
-    }
-  }
-  return [...latest.values()].sort((a, b) => a.name.localeCompare(b.name));
-}
-
 function formatRunSource(run) {
   if (!run.app) {
     return "unknown source";
@@ -526,11 +500,8 @@ async function evaluateCodex({ github, context, number, sha, lastCommitDate }) {
     }
   }
 
-  const bodyFindings = matchingReviewArtifacts.filter((artifact) =>
-    CODEX_BODY_FINDING_RE.test(artifact.body || ""),
-  );
-  if (bodyFindings.length > 0) {
-    reasons.push(`${bodyFindings.length} exact-head Codex review body finding(s)`);
+  if (verdict && CODEX_BODY_FINDING_RE.test(verdict.body || "")) {
+    reasons.push("latest exact-head Codex review body contains a P0-P3 finding");
   }
 
   const reviewComments = await github.paginate(github.rest.pulls.listReviewComments, {

--- a/.github/scripts/auto-gate.js
+++ b/.github/scripts/auto-gate.js
@@ -495,20 +495,28 @@ async function evaluateCodex({ github, context, number, sha, lastCommitDate }) {
     issue_number: number,
     per_page: 100,
   });
-  const codexComments = comments
+  const reviews = await github.paginate(github.rest.pulls.listReviews, {
+    owner,
+    repo,
+    pull_number: number,
+    per_page: 100,
+  });
+  const codexComments = comments.filter((comment) => comment.user?.login === CODEX_REVIEWER);
+  const codexReviewArtifacts = [...codexComments, ...reviews]
     .filter((comment) => comment.user?.login === CODEX_REVIEWER)
-    .sort((a, b) => commentTime(b) - commentTime(a));
-  const verdict = codexComments.find((comment) => {
+    .sort((a, b) => reviewArtifactTime(b) - reviewArtifactTime(a));
+  const verdict = codexReviewArtifacts.find((comment) => {
     const reviewedCommit = parseReviewedCommit(comment.body || "");
     return reviewedCommit != null && reviewedCommitMatchesHead(reviewedCommit, sha);
   });
 
   if (!verdict) {
-    const rateLimited = CODEX_RATE_LIMIT_RE.test(codexComments[0]?.body || "");
+    const latestCodexComment = codexComments.sort((a, b) => reviewArtifactTime(b) - reviewArtifactTime(a))[0];
+    const rateLimited = CODEX_RATE_LIMIT_RE.test(latestCodexComment?.body || "");
     const suffix = rateLimited ? "; the latest Codex response was usage-limited" : "";
     reasons.push(`Codex has not reviewed head ${sha} yet${suffix}`);
   } else {
-    const verdictTime = commentTime(verdict);
+    const verdictTime = reviewArtifactTime(verdict);
     if (lastPushTime == null || verdictTime === 0 || verdictTime <= lastPushTime) {
       reasons.push("Codex verdict for the head commit is older than the head commit timestamp");
     } else {
@@ -567,8 +575,8 @@ function reviewedCommitMatchesHead(reviewedCommit, headSha) {
   return /^[0-9a-f]{40}$/.test(normalizedHead) && normalizedHead.startsWith(reviewedCommit);
 }
 
-function commentTime(comment) {
-  return parseTimestamp(comment.updated_at || comment.created_at) || 0;
+function reviewArtifactTime(artifact) {
+  return parseTimestamp(artifact.updated_at || artifact.submitted_at || artifact.created_at) || 0;
 }
 
 function hasResolutionMarker(body) {

--- a/.github/scripts/auto-gate.js
+++ b/.github/scripts/auto-gate.js
@@ -5,7 +5,7 @@ const CODEX_REVIEWER = "chatgpt-codex-connector[bot]";
 const CODEX_REVIEW_RE = /\bCodex Review\b/i;
 const CODEX_RATE_LIMIT_RE = /reached your Codex usage limits for code reviews/i;
 const CODEX_BODY_FINDING_RE = /\bP[0-3]\b/i;
-const REVIEWED_COMMIT_RE = /\*\*Reviewed commit:\*\*\s*`([0-9a-f]{7,40})`/i;
+const REVIEWED_COMMIT_RE = /(?:\*\*Reviewed commit:\*\*|Reviewed commit:)\s*`([0-9a-f]{7,40})`/i;
 // Docs/Deploy is deliberately conditional and is skipped on pull_request runs.
 const ALLOWED_SKIPPED_CHECKS = new Set(["Deploy"]);
 const RESOLUTION_MARKER_RE = /\b(?:RESOLVED|ACCEPTED)\b/;

--- a/.github/scripts/auto-gate.test.js
+++ b/.github/scripts/auto-gate.test.js
@@ -268,6 +268,12 @@ test("draft and closed pull requests cannot merge", async () => {
 test("Codex verdict parsing requires a real verdict and matches its short SHA", () => {
   assert.equal(__test.parseReviewedCommit(codexRateLimit().body), null);
   assert.equal(__test.parseReviewedCommit(codexVerdict(HEAD_SHA).body), HEAD_SHA.slice(0, 10));
+  assert.equal(
+    __test.parseReviewedCommit(
+      `Codex Review: clean\n\nReviewed commit: \`${HEAD_SHA.slice(0, 10)}\``,
+    ),
+    HEAD_SHA.slice(0, 10),
+  );
   assert.equal(__test.reviewedCommitMatchesHead(HEAD_SHA.slice(0, 10), HEAD_SHA), true);
   assert.equal(__test.reviewedCommitMatchesHead(OTHER_SHA.slice(0, 10), HEAD_SHA), false);
 });

--- a/.github/scripts/auto-gate.test.js
+++ b/.github/scripts/auto-gate.test.js
@@ -3,160 +3,170 @@ const test = require("node:test");
 const autoGate = require("./auto-gate.js");
 const { __test } = autoGate;
 
+const HEAD_SHA = "0a5393dd71ddbbf66486d31939728f9947c843bb";
+const OTHER_SHA = "da0a05ea3b9036a12f67a3b3877d16dd0dac893d";
+const ACTIONS_APP_ID = 15368;
+
 test("required check matching respects the required source app", () => {
-  const spec = { context: "Build", sourceAppId: 15368 };
+  const spec = { context: "Build", sourceAppId: ACTIONS_APP_ID };
   const checkRuns = [
-    {
-      name: "Build",
-      app: { id: 999, slug: "spoof" },
-      status: "completed",
-      conclusion: "success",
-      completed_at: "2026-07-09T01:00:00Z",
-    },
-    {
-      name: "Build",
-      app: { id: 15368, slug: "github-actions" },
-      status: "in_progress",
-      conclusion: null,
-      started_at: "2026-07-09T00:59:00Z",
-    },
+    checkRun({ name: "Build", conclusion: "success", appId: 999, appSlug: "spoof" }),
+    checkRun({ name: "Build", status: "in_progress", conclusion: null }),
   ];
 
   const state = __test.latestRequiredState(spec, checkRuns, []);
 
   assert.equal(state.ok, false);
+  assert.equal(state.waiting, true);
   assert.match(state.description, /github-actions \(15368\)/);
 });
 
-test("stale Greptile confidence summary blocks even with a passing score", async () => {
-  const result = await __test.evaluateGreptile({
-    github: fakeGithub({
-      checkRuns: [greptileRun()],
-      issueComments: [
-        {
-          user: { login: "greptile-apps" },
-          body: "Confidence Score: 5/5",
-          created_at: "2026-07-09T00:00:00Z",
-          updated_at: "2026-07-09T00:00:00Z",
-        },
-      ],
-      reviewComments: [],
-    }),
-    context: fakeContext(),
-    number: 1465,
-    sha: "abc123",
-    lastCommitDate: "2026-07-09T01:00:00Z",
-    core: fakeCore(),
+test("a cancelled required check blocks the gate", async () => {
+  const result = await evaluateGate({
+    checkRuns: [
+      checkRun({ name: "Lint", conclusion: "cancelled" }),
+      checkRun({ name: "Build", conclusion: "success" }),
+    ],
   });
 
-  assert.equal(result.ok, false);
-  assert.match(result.reasons.join("\n"), /summary comment is older than the head commit/);
+  assert.equal(result.shouldMerge, false);
+  assert.match(result.reasons.join("\n"), /required check Lint.*cancelled/);
 });
 
-test("external replies do not resolve Greptile P1/P2 findings", async () => {
-  const result = await __test.evaluateGreptile({
-    github: fakeGithub({
-      checkRuns: [greptileRun()],
-      issueComments: [freshGreptileSummary()],
-      reviewComments: [
-        greptileFinding({ id: 10 }),
-        {
-          id: 11,
-          in_reply_to_id: 10,
-          user: { login: "outside-user" },
-          body: "Looks fine to me.",
-          created_at: "2026-07-09T01:03:00Z",
-        },
-      ],
-    }),
-    context: fakeContext(),
-    number: 1465,
-    sha: "abc123",
-    lastCommitDate: "2026-07-09T01:00:00Z",
-    core: fakeCore(),
+test("an absent required check blocks the gate", async () => {
+  const result = await evaluateGate({
+    checkRuns: [checkRun({ name: "Build", conclusion: "success" })],
   });
 
-  assert.equal(result.ok, false);
-  assert.match(result.reasons.join("\n"), /1 unresolved Greptile P1\/P2 inline finding/);
+  assert.equal(result.shouldMerge, false);
+  assert.match(result.reasons.join("\n"), /required check Lint.*missing/);
 });
 
-test("maintainer discussion replies do not resolve Greptile P1/P2 findings without a marker", async () => {
-  const result = await __test.evaluateGreptile({
-    github: fakeGithub({
-      checkRuns: [greptileRun()],
-      issueComments: [freshGreptileSummary()],
-      reviewComments: [
-        greptileFinding({ id: 10 }),
-        {
-          id: 11,
-          in_reply_to_id: 10,
-          user: { login: "sachiniyer" },
-          body: "I see the tradeoff and will think about it.",
-          created_at: "2026-07-09T01:03:00Z",
-        },
-      ],
-    }),
-    context: fakeContext(),
-    number: 1465,
-    sha: "abc123",
-    lastCommitDate: "2026-07-09T01:00:00Z",
-    core: fakeCore(),
+test("terminal non-success conclusions never verify a required check", () => {
+  const spec = { context: "Lint", sourceAppId: ACTIONS_APP_ID };
+
+  for (const conclusion of ["cancelled", "timed_out", "neutral", "action_required"]) {
+    const state = __test.latestRequiredState(
+      spec,
+      [checkRun({ name: "Lint", conclusion })],
+      [],
+    );
+    assert.equal(state.ok, false, `${conclusion} must not verify the check`);
+  }
+});
+
+test("only the known conditional Deploy check may be skipped", async () => {
+  const allowed = await evaluateGate();
+  assert.equal(allowed.shouldMerge, true);
+
+  const blocked = await evaluateGate({
+    checkRuns: [
+      ...requiredSuccessRuns(),
+      checkRun({ name: "Deploy", conclusion: "skipped" }),
+      checkRun({ name: "Security scan", conclusion: "skipped" }),
+    ],
+  });
+  assert.equal(blocked.shouldMerge, false);
+  assert.match(blocked.reasons.join("\n"), /head check Security scan.*skipped/);
+});
+
+test("transient CodeQL neutral waits for Analyze jobs and later passes", async () => {
+  const settling = await evaluateGate({
+    checkRuns: [
+      ...requiredSuccessRuns(),
+      checkRun({
+        name: "CodeQL",
+        conclusion: "neutral",
+        appId: 57789,
+        appSlug: "github-advanced-security",
+      }),
+      checkRun({ name: "Analyze (go)", status: "in_progress", conclusion: null }),
+      checkRun({ name: "Deploy", conclusion: "skipped" }),
+    ],
   });
 
-  assert.equal(result.ok, false);
-  assert.match(result.reasons.join("\n"), /1 unresolved Greptile P1\/P2 inline finding/);
-});
+  assert.equal(settling.shouldMerge, false);
+  assert.match(settling.reasons.join("\n"), /head check CodeQL is still settling.*neutral/);
 
-test("maintainer replies resolve Greptile P1/P2 findings only with an explicit marker", async () => {
-  const result = await __test.evaluateGreptile({
-    github: fakeGithub({
-      checkRuns: [greptileRun()],
-      issueComments: [freshGreptileSummary()],
-      reviewComments: [
-        greptileFinding({ id: 10 }),
-        {
-          id: 11,
-          in_reply_to_id: 10,
-          user: { login: "sachiniyer" },
-          body: "Documented tradeoff ACCEPTED.",
-          created_at: "2026-07-09T01:03:00Z",
-        },
-      ],
-    }),
-    context: fakeContext(),
-    number: 1465,
-    sha: "abc123",
-    lastCommitDate: "2026-07-09T01:00:00Z",
-    core: fakeCore(),
+  const settled = await evaluateGate({
+    checkRuns: [
+      ...requiredSuccessRuns(),
+      checkRun({
+        name: "CodeQL",
+        conclusion: "success",
+        appId: 57789,
+        appSlug: "github-advanced-security",
+      }),
+      checkRun({ name: "Analyze (go)", conclusion: "success" }),
+      checkRun({ name: "Deploy", conclusion: "skipped" }),
+    ],
   });
 
-  assert.equal(result.ok, true);
+  assert.equal(settled.shouldMerge, true);
 });
 
-test("gate-ack token is an explicit Greptile finding resolution marker", () => {
-  assert.equal(__test.hasResolutionMarker("Root accepts this [gate-ack]."), true);
-  assert.equal(__test.hasResolutionMarker("accepted in discussion, not marked"), false);
+test("a Codex rate-limit message waits without becoming a verdict", async () => {
+  const result = await evaluateGate({ issueComments: [codexRateLimit()] });
+
+  assert.equal(result.shouldMerge, false);
+  assert.match(result.reasons.join("\n"), /has not reviewed head.*usage-limited/);
 });
 
-test("outdated Greptile findings are not counted as unresolved", async () => {
-  const result = await __test.evaluateGreptile({
-    github: fakeGithub({
-      checkRuns: [greptileRun()],
-      issueComments: [freshGreptileSummary()],
-      reviewComments: [greptileFinding({ id: 10, position: null })],
-    }),
-    context: fakeContext(),
-    number: 1465,
-    sha: "abc123",
-    lastCommitDate: "2026-07-09T01:00:00Z",
-    core: fakeCore(),
+test("a clean exact-head verdict cannot override live Codex findings", async () => {
+  const result = await evaluateGate({
+    issueComments: [codexVerdict(HEAD_SHA)],
+    reviewComments: [codexFinding({ id: 10, line: 32 })],
   });
 
-  assert.equal(result.ok, true);
+  assert.equal(result.shouldMerge, false);
+  assert.match(result.reasons.join("\n"), /1 unresolved live Codex inline finding/);
 });
 
-test("merge pins the squash merge to the evaluated head SHA", async () => {
-  const github = fakeMergeGithub({ headSha: "sha-that-passed" });
+test("a stale Codex finding with a null line does not block", async () => {
+  const result = await evaluateGate({
+    reviewComments: [codexFinding({ id: 10, line: null })],
+  });
+
+  assert.equal(result.shouldMerge, true);
+});
+
+test("an allowed author resolves a live finding only with an explicit marker", async () => {
+  const finding = codexFinding({ id: 10, line: 32 });
+  const discussionOnly = await evaluateGate({
+    reviewComments: [finding, findingReply({ id: 11, inReplyToId: 10, body: "I understand the tradeoff." })],
+  });
+  assert.equal(discussionOnly.shouldMerge, false);
+
+  const resolved = await evaluateGate({
+    reviewComments: [
+      finding,
+      findingReply({ id: 12, inReplyToId: 10, body: "The documented tradeoff is ACCEPTED." }),
+    ],
+  });
+  assert.equal(resolved.shouldMerge, true);
+});
+
+test("a verdict for an older head does not verify the current head", async () => {
+  const result = await evaluateGate({ issueComments: [codexVerdict(OTHER_SHA)] });
+
+  assert.equal(result.shouldMerge, false);
+  assert.match(result.reasons.join("\n"), /Codex has not reviewed head/);
+});
+
+test("issue-comment events resolve their pull request number", async () => {
+  const result = await autoGate.evaluate({
+    github: fakeGateGithub(),
+    context: fakeContext({ issue: { number: 1465, pull_request: {}, state: "open" } }),
+    core: fakeCore(),
+    setOutputs: false,
+  });
+
+  assert.equal(result.prNumber, "1465");
+  assert.equal(result.shouldMerge, true);
+});
+
+test("the happy path squash-merges the exact evaluated head", async () => {
+  const github = fakeGateGithub();
 
   await autoGate.merge({
     github,
@@ -165,63 +175,62 @@ test("merge pins the squash merge to the evaluated head SHA", async () => {
     prNumber: 1465,
   });
 
-  assert.equal(github.mergedWith.sha, "sha-that-passed");
+  assert.equal(github.mergedWith.sha, HEAD_SHA);
+  assert.equal(github.mergedWith.merge_method, "squash");
 });
 
-// The workflow-level guard skips drafts for events carrying a pull_request
-// payload, but check_suite/status events carry none and still reach the helper,
-// so this block is the only thing stopping a draft from auto-merging (#1907).
-test("an otherwise-mergeable PR is blocked for being a draft", async () => {
-  const result = await autoGate.evaluate({
-    github: fakeMergeGithub({ headSha: "abc123", isDraft: true }),
+test("draft and closed pull requests cannot merge", async () => {
+  const draft = await evaluateGate({ isDraft: true });
+  assert.equal(draft.shouldMerge, false);
+  assert.match(draft.reasons.join("\n"), /PR is a draft/);
+
+  const closed = await evaluateGate({ state: "CLOSED" });
+  assert.equal(closed.shouldMerge, false);
+  assert.match(closed.reasons.join("\n"), /PR is closed, not open/);
+});
+
+test("Codex verdict parsing requires a real verdict and matches its short SHA", () => {
+  assert.equal(__test.parseReviewedCommit(codexRateLimit().body), null);
+  assert.equal(__test.parseReviewedCommit(codexVerdict(HEAD_SHA).body), HEAD_SHA.slice(0, 10));
+  assert.equal(__test.reviewedCommitMatchesHead(HEAD_SHA.slice(0, 10), HEAD_SHA), true);
+  assert.equal(__test.reviewedCommitMatchesHead(OTHER_SHA.slice(0, 10), HEAD_SHA), false);
+});
+
+test("gate-ack remains an explicit finding resolution marker", () => {
+  assert.equal(__test.hasResolutionMarker("Root accepts this [gate-ack]."), true);
+  assert.equal(__test.hasResolutionMarker("accepted in discussion, not marked"), false);
+});
+
+async function evaluateGate(options = {}) {
+  return autoGate.evaluate({
+    github: fakeGateGithub(options),
     context: fakeContext(),
     core: fakeCore(),
     prNumber: 1465,
     setOutputs: false,
   });
-
-  assert.equal(result.shouldMerge, false);
-  assert.match(result.reasons.join("\n"), /PR is a draft/);
-});
-
-// Pins the control: the same fixture merges when isDraft flips off, so the test
-// above can only fail for the draft reason and not some unrelated block.
-test("the same PR is mergeable once it is not a draft", async () => {
-  const result = await autoGate.evaluate({
-    github: fakeMergeGithub({ headSha: "abc123", isDraft: false }),
-    context: fakeContext(),
-    core: fakeCore(),
-    prNumber: 1465,
-    setOutputs: false,
-  });
-
-  assert.deepEqual(result.reasons, []);
-  assert.equal(result.shouldMerge, true);
-});
-
-function fakeGithub({ checkRuns, issueComments, reviewComments }) {
-  const listForRef = function listForRef() {};
-  const listComments = function listComments() {};
-  const listReviewComments = function listReviewComments() {};
-  const responses = new Map([
-    [listForRef, checkRuns],
-    [listComments, issueComments],
-    [listReviewComments, reviewComments],
-  ]);
-
-  return {
-    rest: {
-      checks: { listForRef },
-      issues: { listComments },
-      pulls: { listReviewComments },
-    },
-    paginate: async (fn) => responses.get(fn) || [],
-  };
 }
 
-function fakeMergeGithub({ headSha, isDraft = false }) {
+function fakeGateGithub({
+  headSha = HEAD_SHA,
+  isDraft = false,
+  state = "OPEN",
+  merged = false,
+  mergeable = "MERGEABLE",
+  mergeStateStatus = "CLEAN",
+  checkRuns = happyCheckRuns(),
+  statuses = [],
+  issueComments = [codexVerdict(headSha)],
+  reviewComments = [],
+  files = [],
+  requiredChecks = [
+    { context: "Lint", integration_id: ACTIONS_APP_ID },
+    { context: "Build", integration_id: ACTIONS_APP_ID },
+  ],
+} = {}) {
   const listFiles = function listFiles() {};
   const listForRef = function listForRef() {};
+  const listCommitStatusesForRef = function listCommitStatusesForRef() {};
   const listComments = function listComments() {};
   const listReviewComments = function listReviewComments() {};
   const merge = async function merge(options) {
@@ -229,53 +238,54 @@ function fakeMergeGithub({ headSha, isDraft = false }) {
     return { data: { sha: "merge-sha" } };
   };
   const responses = new Map([
-    [listFiles, []],
-    [listForRef, [greptileRun()]],
-    [listComments, [freshGreptileSummary()]],
-    [listReviewComments, []],
+    [listFiles, files.map((filename) => ({ filename }))],
+    [listForRef, checkRuns],
+    [listCommitStatusesForRef, statuses],
+    [listComments, issueComments],
+    [listReviewComments, reviewComments],
   ]);
 
   const github = {
     mergedWith: null,
     rest: {
-      actions: {
-        createWorkflowDispatch: async () => {},
-      },
+      actions: { createWorkflowDispatch: async () => {} },
       checks: { listForRef },
       issues: { listComments },
+      repos: { listCommitStatusesForRef },
       pulls: { listFiles, listReviewComments, merge },
     },
-    graphql: async () => {
-      return {
-        repository: {
-          pullRequest: {
-            number: 1465,
-            title: "Gate test",
-            url: "https://example.invalid/pr/1465",
-            baseRefName: "master",
-            headRefOid: headSha,
-            isDraft,
-            mergeable: "MERGEABLE",
-            mergeStateStatus: "CLEAN",
-            author: { login: "sachiniyer" },
-            labels: { nodes: [] },
-            commits: {
-              nodes: [
-                {
-                  commit: {
-                    committedDate: "2026-07-09T01:00:00Z",
-                  },
-                },
-              ],
-            },
+    graphql: async () => ({
+      repository: {
+        pullRequest: {
+          number: 1465,
+          title: "Gate test",
+          url: "https://example.invalid/pr/1465",
+          baseRefName: "master",
+          headRefOid: headSha,
+          isDraft,
+          state,
+          merged,
+          mergeable,
+          mergeStateStatus,
+          author: { login: "sachiniyer" },
+          labels: { nodes: [] },
+          commits: {
+            nodes: [{ commit: { committedDate: "2026-07-09T01:00:00Z" } }],
           },
         },
-      };
-    },
+      },
+    }),
     paginate: async (fn) => responses.get(fn) || [],
     request: async (route) => {
       if (route.includes("/rules/branches/")) {
-        return { data: [] };
+        return {
+          data: [
+            {
+              type: "required_status_checks",
+              parameters: { required_status_checks: requiredChecks },
+            },
+          ],
+        };
       }
       const error = new Error("not protected");
       error.status = 404;
@@ -286,8 +296,12 @@ function fakeMergeGithub({ headSha, isDraft = false }) {
   return github;
 }
 
-function fakeContext() {
-  return { repo: { owner: "sachiniyer", repo: "agent-factory" } };
+function fakeContext(payload = {}) {
+  return {
+    repo: { owner: "sachiniyer", repo: "agent-factory" },
+    payload,
+    eventName: "pull_request",
+  };
 }
 
 function fakeCore() {
@@ -299,31 +313,81 @@ function fakeCore() {
   };
 }
 
-function greptileRun() {
+function happyCheckRuns() {
+  return [
+    ...requiredSuccessRuns(),
+    checkRun({
+      name: "CodeQL",
+      conclusion: "success",
+      appId: 57789,
+      appSlug: "github-advanced-security",
+    }),
+    checkRun({ name: "Analyze (go)", conclusion: "success" }),
+    checkRun({ name: "Deploy", conclusion: "skipped" }),
+    checkRun({ name: "Evaluate auto-merge gate", status: "in_progress", conclusion: null }),
+  ];
+}
+
+function requiredSuccessRuns() {
+  return [
+    checkRun({ name: "Lint", conclusion: "success" }),
+    checkRun({ name: "Build", conclusion: "success" }),
+  ];
+}
+
+function checkRun({
+  name,
+  status = "completed",
+  conclusion,
+  appId = ACTIONS_APP_ID,
+  appSlug = "github-actions",
+}) {
   return {
-    name: "Greptile Review",
-    app: { id: 123, slug: "greptile" },
-    status: "completed",
-    conclusion: "success",
-    completed_at: "2026-07-09T01:05:00Z",
+    name,
+    app: { id: appId, slug: appSlug },
+    status,
+    conclusion,
+    created_at: "2026-07-09T01:05:00Z",
+    started_at: "2026-07-09T01:06:00Z",
+    completed_at: status === "completed" ? "2026-07-09T01:10:00Z" : null,
   };
 }
 
-function freshGreptileSummary() {
+function codexVerdict(sha) {
   return {
-    user: { login: "greptile-apps" },
-    body: "Confidence Score: 4/5",
-    created_at: "2026-07-09T01:02:00Z",
-    updated_at: "2026-07-09T01:02:00Z",
+    user: { login: "chatgpt-codex-connector[bot]" },
+    body: `Codex Review: Didn't find any major issues.\n\n**Reviewed commit:** \`${sha.slice(0, 10)}\``,
+    created_at: "2026-07-09T01:20:00Z",
+    updated_at: "2026-07-09T01:20:00Z",
   };
 }
 
-function greptileFinding({ id, position = 7 }) {
+function codexRateLimit() {
+  return {
+    user: { login: "chatgpt-codex-connector[bot]" },
+    body: "You have reached your Codex usage limits for code reviews.",
+    created_at: "2026-07-09T01:20:00Z",
+    updated_at: "2026-07-09T01:20:00Z",
+  };
+}
+
+function codexFinding({ id, line }) {
   return {
     id,
-    user: { login: "greptile-apps" },
+    user: { login: "chatgpt-codex-connector[bot]" },
     body: "P1: this needs attention",
-    created_at: "2026-07-09T01:01:00Z",
-    position,
+    created_at: "2026-07-09T01:15:00Z",
+    line,
+  };
+}
+
+function findingReply({ id, inReplyToId, body }) {
+  return {
+    id,
+    in_reply_to_id: inReplyToId,
+    user: { login: "sachiniyer" },
+    body,
+    created_at: "2026-07-09T01:16:00Z",
+    line: 32,
   };
 }

--- a/.github/scripts/auto-gate.test.js
+++ b/.github/scripts/auto-gate.test.js
@@ -160,6 +160,16 @@ test("an exact-head Codex PR review proves review after its finding is resolved"
   assert.equal(result.shouldMerge, true);
 });
 
+test("an exact-head Codex review body finding overrides a clean verdict", async () => {
+  const result = await evaluateGate({
+    reviews: [codexReview(HEAD_SHA, "P1: a finding present only in the review body")],
+    reviewComments: [],
+  });
+
+  assert.equal(result.shouldMerge, false);
+  assert.match(result.reasons.join("\n"), /1 exact-head Codex review body finding/);
+});
+
 test("a verdict for an older head does not verify the current head", async () => {
   const result = await evaluateGate({ issueComments: [codexVerdict(OTHER_SHA)] });
 
@@ -388,10 +398,10 @@ function codexRateLimit() {
   };
 }
 
-function codexReview(sha) {
+function codexReview(sha, summary = "Here are some suggestions.") {
   return {
     user: { login: "chatgpt-codex-connector[bot]" },
-    body: `### Codex Review\n\nHere are some suggestions.\n\n**Reviewed commit:** \`${sha.slice(0, 10)}\``,
+    body: `### Codex Review\n\n${summary}\n\n**Reviewed commit:** \`${sha.slice(0, 10)}\``,
     submitted_at: "2026-07-09T01:20:00Z",
   };
 }

--- a/.github/scripts/auto-gate.test.js
+++ b/.github/scripts/auto-gate.test.js
@@ -56,7 +56,13 @@ test("terminal non-success conclusions never verify a required check", () => {
 });
 
 test("only the known conditional Deploy check may be skipped", async () => {
-  const allowed = await evaluateGate();
+  const allowed = await evaluateGate({
+    requiredChecks: [
+      { context: "Lint", integration_id: ACTIONS_APP_ID },
+      { context: "Build", integration_id: ACTIONS_APP_ID },
+      { context: "Deploy", integration_id: ACTIONS_APP_ID },
+    ],
+  });
   assert.equal(allowed.shouldMerge, true);
 
   const blocked = await evaluateGate({
@@ -65,9 +71,22 @@ test("only the known conditional Deploy check may be skipped", async () => {
       checkRun({ name: "Deploy", conclusion: "skipped" }),
       checkRun({ name: "Security scan", conclusion: "skipped" }),
     ],
+    requiredChecks: [
+      { context: "Lint", integration_id: ACTIONS_APP_ID },
+      { context: "Build", integration_id: ACTIONS_APP_ID },
+      { context: "Security scan", integration_id: ACTIONS_APP_ID },
+    ],
   });
   assert.equal(blocked.shouldMerge, false);
-  assert.match(blocked.reasons.join("\n"), /head check Security scan.*skipped/);
+  assert.match(blocked.reasons.join("\n"), /required check Security scan.*skipped/);
+});
+
+test("a failing optional Web selftest does not become a merge requirement", async () => {
+  const result = await evaluateGate({
+    checkRuns: [...happyCheckRuns(), checkRun({ name: "Web selftest", conclusion: "failure" })],
+  });
+
+  assert.equal(result.shouldMerge, true);
 });
 
 test("transient CodeQL neutral waits for Analyze jobs and later passes", async () => {
@@ -83,10 +102,15 @@ test("transient CodeQL neutral waits for Analyze jobs and later passes", async (
       checkRun({ name: "Analyze (go)", status: "in_progress", conclusion: null }),
       checkRun({ name: "Deploy", conclusion: "skipped" }),
     ],
+    requiredChecks: [
+      { context: "Lint", integration_id: ACTIONS_APP_ID },
+      { context: "Build", integration_id: ACTIONS_APP_ID },
+      { context: "CodeQL", integration_id: 57789 },
+    ],
   });
 
   assert.equal(settling.shouldMerge, false);
-  assert.match(settling.reasons.join("\n"), /head check CodeQL is still settling.*neutral/);
+  assert.match(settling.reasons.join("\n"), /required check CodeQL.*still settling.*neutral/);
 
   const settled = await evaluateGate({
     checkRuns: [
@@ -99,6 +123,11 @@ test("transient CodeQL neutral waits for Analyze jobs and later passes", async (
       }),
       checkRun({ name: "Analyze (go)", conclusion: "success" }),
       checkRun({ name: "Deploy", conclusion: "skipped" }),
+    ],
+    requiredChecks: [
+      { context: "Lint", integration_id: ACTIONS_APP_ID },
+      { context: "Build", integration_id: ACTIONS_APP_ID },
+      { context: "CodeQL", integration_id: 57789 },
     ],
   });
 
@@ -162,12 +191,35 @@ test("an exact-head Codex PR review proves review after its finding is resolved"
 
 test("an exact-head Codex review body finding overrides a clean verdict", async () => {
   const result = await evaluateGate({
-    reviews: [codexReview(HEAD_SHA, "P1: a finding present only in the review body")],
+    issueComments: [codexVerdict(HEAD_SHA, "2026-07-09T01:20:00Z")],
+    reviews: [
+      codexReview(
+        HEAD_SHA,
+        "P1: a finding present only in the review body",
+        "2026-07-09T01:21:00Z",
+      ),
+    ],
     reviewComments: [],
   });
 
   assert.equal(result.shouldMerge, false);
-  assert.match(result.reasons.join("\n"), /1 exact-head Codex review body finding/);
+  assert.match(result.reasons.join("\n"), /latest exact-head Codex review body.*P0-P3 finding/);
+});
+
+test("a newer clean exact-head verdict supersedes an older body-only finding", async () => {
+  const result = await evaluateGate({
+    issueComments: [codexVerdict(HEAD_SHA, "2026-07-09T01:21:00Z")],
+    reviews: [
+      codexReview(
+        HEAD_SHA,
+        "P1: an older body-only finding",
+        "2026-07-09T01:20:00Z",
+      ),
+    ],
+    reviewComments: [],
+  });
+
+  assert.equal(result.shouldMerge, true);
 });
 
 test("a verdict for an older head does not verify the current head", async () => {
@@ -380,12 +432,12 @@ function checkRun({
   };
 }
 
-function codexVerdict(sha) {
+function codexVerdict(sha, timestamp = "2026-07-09T01:20:00Z") {
   return {
     user: { login: "chatgpt-codex-connector[bot]" },
     body: `Codex Review: Didn't find any major issues.\n\n**Reviewed commit:** \`${sha.slice(0, 10)}\``,
-    created_at: "2026-07-09T01:20:00Z",
-    updated_at: "2026-07-09T01:20:00Z",
+    created_at: timestamp,
+    updated_at: timestamp,
   };
 }
 
@@ -398,11 +450,11 @@ function codexRateLimit() {
   };
 }
 
-function codexReview(sha, summary = "Here are some suggestions.") {
+function codexReview(sha, summary = "Here are some suggestions.", timestamp = "2026-07-09T01:20:00Z") {
   return {
     user: { login: "chatgpt-codex-connector[bot]" },
     body: `### Codex Review\n\n${summary}\n\n**Reviewed commit:** \`${sha.slice(0, 10)}\``,
-    submitted_at: "2026-07-09T01:20:00Z",
+    submitted_at: timestamp,
   };
 }
 

--- a/.github/scripts/auto-gate.test.js
+++ b/.github/scripts/auto-gate.test.js
@@ -146,6 +146,20 @@ test("an allowed author resolves a live finding only with an explicit marker", a
   assert.equal(resolved.shouldMerge, true);
 });
 
+test("an exact-head Codex PR review proves review after its finding is resolved", async () => {
+  const finding = codexFinding({ id: 10, line: 32 });
+  const result = await evaluateGate({
+    issueComments: [],
+    reviews: [codexReview(HEAD_SHA)],
+    reviewComments: [
+      finding,
+      findingReply({ id: 12, inReplyToId: 10, body: "The documented tradeoff is ACCEPTED." }),
+    ],
+  });
+
+  assert.equal(result.shouldMerge, true);
+});
+
 test("a verdict for an older head does not verify the current head", async () => {
   const result = await evaluateGate({ issueComments: [codexVerdict(OTHER_SHA)] });
 
@@ -221,6 +235,7 @@ function fakeGateGithub({
   checkRuns = happyCheckRuns(),
   statuses = [],
   issueComments = [codexVerdict(headSha)],
+  reviews = [],
   reviewComments = [],
   files = [],
   requiredChecks = [
@@ -232,6 +247,7 @@ function fakeGateGithub({
   const listForRef = function listForRef() {};
   const listCommitStatusesForRef = function listCommitStatusesForRef() {};
   const listComments = function listComments() {};
+  const listReviews = function listReviews() {};
   const listReviewComments = function listReviewComments() {};
   const merge = async function merge(options) {
     github.mergedWith = options;
@@ -242,6 +258,7 @@ function fakeGateGithub({
     [listForRef, checkRuns],
     [listCommitStatusesForRef, statuses],
     [listComments, issueComments],
+    [listReviews, reviews],
     [listReviewComments, reviewComments],
   ]);
 
@@ -252,7 +269,7 @@ function fakeGateGithub({
       checks: { listForRef },
       issues: { listComments },
       repos: { listCommitStatusesForRef },
-      pulls: { listFiles, listReviewComments, merge },
+      pulls: { listFiles, listReviews, listReviewComments, merge },
     },
     graphql: async () => ({
       repository: {
@@ -368,6 +385,14 @@ function codexRateLimit() {
     body: "You have reached your Codex usage limits for code reviews.",
     created_at: "2026-07-09T01:20:00Z",
     updated_at: "2026-07-09T01:20:00Z",
+  };
+}
+
+function codexReview(sha) {
+  return {
+    user: { login: "chatgpt-codex-connector[bot]" },
+    body: `### Codex Review\n\nHere are some suggestions.\n\n**Reviewed commit:** \`${sha.slice(0, 10)}\``,
+    submitted_at: "2026-07-09T01:20:00Z",
   };
 }
 

--- a/.github/workflows/auto-gate.yml
+++ b/.github/workflows/auto-gate.yml
@@ -3,7 +3,11 @@ name: Auto Gate
 on:
   check_suite:
     types: [completed]
+  issue_comment:
+    types: [created, edited, deleted]
   pull_request_review:
+  pull_request_review_comment:
+    types: [created, edited, deleted]
   pull_request:
     types: [labeled]
   status:
@@ -17,7 +21,7 @@ permissions:
   issues: read
 
 concurrency:
-  group: auto-gate-${{ github.event.pull_request.number || github.event.check_suite.head_sha || github.event.sha || github.run_id }}
+  group: auto-gate-${{ github.event.pull_request.number || github.event.issue.number || github.event.check_suite.pull_requests[0].number || github.event.check_suite.head_sha || github.event.sha || github.run_id }}
   cancel-in-progress: false
 
 jobs:
@@ -28,12 +32,14 @@ jobs:
     # against a stale head (#1876). Drafts are never merge-eligible, so review
     # traffic on a held-open draft is pure evaluation waste (#1907) — the helper
     # blocks them anyway, this just skips before the checkout and API calls.
-    # Events that carry no pull_request payload (check_suite, status) resolve the
-    # PR by head SHA and already filter to open PRs, so they must not be skipped
-    # here; the helper's own isDraft check remains the backstop for those.
+    # check_suite/status events resolve the PR by head SHA and already filter to
+    # open PRs. issue_comment events are limited to comments on open PRs here.
+    # The helper's own state/draft checks remain the backstop for every event.
     if: >-
-      github.event.pull_request == null ||
-      (github.event.pull_request.state == 'open' && github.event.pull_request.draft != true)
+      (github.event_name != 'issue_comment' ||
+       (github.event.issue.pull_request != null && github.event.issue.state == 'open')) &&
+      (github.event.pull_request == null ||
+       (github.event.pull_request.state == 'open' && github.event.pull_request.draft != true))
     steps:
       - name: Check out gate logic
         uses: actions/checkout@v6


### PR DESCRIPTION
## What changed

- Retarget Auto Gate from the retired Greptile app to `chatgpt-codex-connector[bot]`.
- Require a Codex review artifact whose `Reviewed commit` short SHA matches the exact current head: a clean issue-comment verdict or a suggestions PR review body.
- Query Codex pull-request review comments independently and block on every unresolved live inline finding (`line != null`), even when the same head has a clean verdict; preserve explicit maintainer resolution-marker replies.
- Independently block P0-P3 findings embedded in the newest exact-head Codex review body, including when a clean issue verdict coexists and the inline endpoint is empty; a later clean exact-head verdict supersedes an older body-only finding.
- Require every configured required check to be present and successful. The genuinely conditional Docs `Deploy` job is the only accepted required-check skip; optional signals such as `Web selftest` remain advisory.
- Treat transient required CodeQL `neutral` and Codex usage-limit replies as wait states, with no merge and no retry loop.
- Trigger the gate on Codex verdict issue comments and inline-comment replies, and explicitly reject drafts, closed/merged PRs, conflicts, and unknown mergeability.

## Merge-without-human-review risk

Once this lands and `AUTO_GATE_ENABLED == true`, Auto Gate will squash-merge an allowlisted-author PR to `master` **without human review** when the PR is open, non-draft, and mergeable; every configured required check is present and successful (apart from the genuinely conditional Docs `Deploy` skip); Codex has posted a review artifact for that exact head; and there are zero unresolved live Codex inline findings or findings in the newest exact-head review body. Optional check signals do not become merge requirements. Existing path policy still requires `play-tested` for visible TUI/pane changes.

This intentionally removes a human approval from that merge path. The safety boundary is the exact-head Codex review artifact plus the independent inline and newest-review-body finding queries, not clean-verdict text alone.

## Validation

- `node --test .github/scripts/auto-gate.test.js` (20 focused cases)
- `actionlint .github/workflows/auto-gate.yml`
- `scripts/lint-file-length.sh`
- `make test-container` on each final pushed head
