### PR TITLE
feat(upgrade): add crash-durable rollback transaction

### DIFF
--- a/internal/upgradetxn/activation.go
+++ b/internal/upgradetxn/activation.go
@@ -1,0 +1,135 @@
+package upgradetxn
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type activationApproval struct {
+	SchemaVersion int    `json:"schema_version"`
+	TransactionID string `json:"transaction_id"`
+	Nonce         string `json:"nonce"`
+	ActorID       string `json:"actor_id"`
+}
+
+func newRecoveryActorID() (string, error) {
+	value := make([]byte, recoveryNonceBytes)
+	if _, err := rand.Read(value); err != nil {
+		return "", fmt.Errorf("generate upgrade recovery actor identity: %w", err)
+	}
+	return hex.EncodeToString(value), nil
+}
+
+// AuthorizeActivation completes the old process -> previous-binary actor
+// handshake. The approval is bound to the exact recovery-lock acquisition
+// whose supervisor_ready proof was validated, not merely to the transaction.
+func (t *Transaction) AuthorizeActivation(transactionID, nonce string) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	current, err := readJournal(activeJournalPath(t.journal.HomeDir))
+	if err != nil {
+		return err
+	}
+	if err := validateJournal(t.journal.HomeDir, current); err != nil {
+		return err
+	}
+	if current.ID != transactionID || current.RecoveryNonce != nonce {
+		return errors.New("upgrade activation handshake does not match the active transaction")
+	}
+	if current.Phase != PhaseSupervisorReady {
+		return fmt.Errorf("upgrade supervisor is not ready for activation (phase %s)", current.Phase)
+	}
+	status, err := validateActivationRecoveryProof(current, time.Now().UTC())
+	if err != nil {
+		return err
+	}
+	approval := activationApproval{
+		SchemaVersion: journalSchemaVersion,
+		TransactionID: current.ID,
+		Nonce:         current.RecoveryNonce,
+		ActorID:       status.ActorID,
+	}
+	data, err := json.MarshalIndent(approval, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode upgrade activation approval: %w", err)
+	}
+	data = append(data, '\n')
+	approvalPath := filepath.Join(transactionDir(current.HomeDir, current.ID), "activation.approved")
+	if err := durableAtomicWriteFile(approvalPath, data, journalFileMode); err != nil {
+		return fmt.Errorf("persist upgrade activation approval: %w", err)
+	}
+	t.journal = current
+	return nil
+}
+
+func validateActivationRecoveryProof(current Journal, now time.Time) (RecoveryStatus, error) {
+	lockPath := filepath.Join(transactionDir(current.HomeDir, current.ID), "recovery.lock")
+	probe, err := acquireFileLock(lockPath, true)
+	if err == nil {
+		_ = releaseFileLock(probe)
+		return RecoveryStatus{}, errors.New("upgrade activation cannot be authorized without a live recovery actor")
+	}
+	if !errors.Is(err, ErrRecoveryActive) {
+		return RecoveryStatus{}, fmt.Errorf("verify recovery actor before activation: %w", err)
+	}
+	readyPath := filepath.Join(transactionDir(current.HomeDir, current.ID), "recovery.ready.lock")
+	readyProbe, err := acquireFileLock(readyPath, true)
+	if err == nil {
+		_ = releaseFileLock(readyProbe)
+		return RecoveryStatus{}, errors.New("upgrade recovery actor has not published its current readiness proof")
+	}
+	if !errors.Is(err, ErrRecoveryActive) {
+		return RecoveryStatus{}, fmt.Errorf("verify recovery actor readiness before activation: %w", err)
+	}
+	status, err := readRecoveryStatusForJournal(current)
+	if err != nil {
+		return RecoveryStatus{}, err
+	}
+	if status.Phase != PhaseSupervisorReady {
+		return RecoveryStatus{}, fmt.Errorf(
+			"upgrade recovery actor has not reached supervisor_ready (status %s)", status.Phase)
+	}
+	if !now.Before(status.Deadline) {
+		return RecoveryStatus{}, fmt.Errorf(
+			"upgrade recovery actor's supervisor_ready deadline expired at %s", status.Deadline.Format(time.RFC3339Nano))
+	}
+	return status, nil
+}
+
+// ActivationAuthorized may only be consumed through the still-held recovery
+// lease to which the old process granted approval. A missing approval or one
+// for a predecessor is a normal not-yet result: a takeover must publish a new
+// readiness proof and obtain its own approval before it can stop the daemon.
+func (l *RecoveryLease) ActivationAuthorized() (bool, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.released || l.file == nil || l.readyFile == nil {
+		return false, errors.New("upgrade recovery lease is released")
+	}
+	path := filepath.Join(filepath.Dir(l.path), "activation.approved")
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("read upgrade activation approval: %w", err)
+	}
+	var approval activationApproval
+	if err := json.Unmarshal(data, &approval); err != nil {
+		return false, fmt.Errorf("decode upgrade activation approval: %w", err)
+	}
+	if approval.SchemaVersion != journalSchemaVersion ||
+		approval.TransactionID != l.txnID || approval.Nonce != l.nonce || !validDigest(approval.ActorID) {
+		return false, errors.New("upgrade activation approval does not match the transaction")
+	}
+	if approval.ActorID != l.actorID {
+		return false, nil
+	}
+	return true, nil
+}

--- a/internal/upgradetxn/activation.go
+++ b/internal/upgradetxn/activation.go
@@ -1,6 +1,7 @@
 package upgradetxn
 
 import (
+	"bytes"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
@@ -61,10 +62,31 @@ func (t *Transaction) AuthorizeActivation(transactionID, nonce string) error {
 	}
 	data = append(data, '\n')
 	approvalPath := filepath.Join(transactionDir(current.HomeDir, current.ID), "activation.approved")
-	if err := durableAtomicWriteFile(approvalPath, data, journalFileMode); err != nil {
-		return fmt.Errorf("persist upgrade activation approval: %w", err)
+	if err := publishActivationApproval(approvalPath, data); err != nil {
+		return err
 	}
 	t.journal = current
+	return nil
+}
+
+func publishActivationApproval(path string, data []byte) error {
+	writeErr := durableAtomicWriteFile(path, data, journalFileMode)
+	if writeErr == nil {
+		return nil
+	}
+	// A directory-sync failure happens after rename, so the exact approval can
+	// be visible even though the durable writer reports an error. Complete that
+	// barrier here when possible; ActivationAuthorized repeats it before use.
+	visible, readErr := os.ReadFile(path)
+	if readErr != nil || !bytes.Equal(visible, data) {
+		return fmt.Errorf("persist upgrade activation approval: %w", writeErr)
+	}
+	if syncErr := syncTransactionDirectory(filepath.Dir(path)); syncErr != nil {
+		return errors.Join(
+			fmt.Errorf("persist upgrade activation approval: %w", writeErr),
+			fmt.Errorf("confirm visible upgrade activation approval: %w", syncErr),
+		)
+	}
 	return nil
 }
 

--- a/internal/upgradetxn/activation.go
+++ b/internal/upgradetxn/activation.go
@@ -69,8 +69,8 @@ func (t *Transaction) AuthorizeActivation(transactionID, nonce string) error {
 }
 
 func validateActivationRecoveryProof(current Journal, now time.Time) (RecoveryStatus, error) {
-	lockPath := filepath.Join(transactionDir(current.HomeDir, current.ID), "recovery.lock")
-	probe, err := acquireFileLock(lockPath, true)
+	lockPath := recoveryLockPath(current.HomeDir, current.ID)
+	probe, err := acquireRecoveryLock(lockPath, current.RecoveryLockIdentity, true)
 	if err == nil {
 		_ = releaseFileLock(probe)
 		return RecoveryStatus{}, errors.New("upgrade activation cannot be authorized without a live recovery actor")
@@ -130,6 +130,9 @@ func (l *RecoveryLease) ActivationAuthorized() (bool, error) {
 	}
 	if approval.ActorID != l.actorID {
 		return false, nil
+	}
+	if err := syncTransactionDirectory(filepath.Dir(path)); err != nil {
+		return false, fmt.Errorf("confirm durable upgrade activation approval: %w", err)
 	}
 	return true, nil
 }

--- a/internal/upgradetxn/lock.go
+++ b/internal/upgradetxn/lock.go
@@ -1,0 +1,135 @@
+package upgradetxn
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+func recoveryLockPath(home, id string) string {
+	return filepath.Join(upgradeRoot(home), ".recovery-"+id+".lock")
+}
+
+func validateRecoveryLockStorage(home string, journal Journal) error {
+	path := recoveryLockPath(home, journal.ID)
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("inspect upgrade recovery lock: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() || info.Mode().Perm() != journalFileMode {
+		return errors.New("upgrade recovery lock is not a private regular file")
+	}
+	identity, err := fileIdentity(info)
+	if err != nil {
+		return fmt.Errorf("identify upgrade recovery lock: %w", err)
+	}
+	if identity != journal.RecoveryLockIdentity {
+		return errors.New("upgrade recovery lock identity does not match the journal")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read upgrade recovery lock: %w", err)
+	}
+	if strings.TrimSpace(string(data)) != journal.RecoveryNonce {
+		return errors.New("upgrade recovery lock nonce does not match the journal")
+	}
+	return nil
+}
+
+func fileIdentity(info os.FileInfo) (FileIdentity, error) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return FileIdentity{}, errors.New("file has no device/inode identity")
+	}
+	identity := FileIdentity{Device: uint64(stat.Dev), Inode: uint64(stat.Ino)}
+	if identity.Inode == 0 {
+		return FileIdentity{}, errors.New("file has an invalid inode identity")
+	}
+	return identity, nil
+}
+
+func acquireFileLock(path string, nonblocking bool) (*os.File, error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, journalFileMode)
+	if err != nil {
+		return nil, err
+	}
+	operation := syscall.LOCK_EX
+	if nonblocking {
+		operation |= syscall.LOCK_NB
+	}
+	if err := syscall.Flock(int(file.Fd()), operation); err != nil {
+		_ = file.Close()
+		if nonblocking && (errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN)) {
+			return nil, ErrRecoveryActive
+		}
+		return nil, err
+	}
+	return file, nil
+}
+
+func acquireRecoveryLock(
+	path string, expected FileIdentity, nonblocking bool,
+) (*os.File, error) {
+	file, err := os.OpenFile(path, os.O_RDWR, journalFileMode)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateRecoveryLockHandle(file, path, expected); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	operation := syscall.LOCK_EX
+	if nonblocking {
+		operation |= syscall.LOCK_NB
+	}
+	if err := syscall.Flock(int(file.Fd()), operation); err != nil {
+		_ = file.Close()
+		if nonblocking && (errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN)) {
+			return nil, ErrRecoveryActive
+		}
+		return nil, err
+	}
+	if err := validateRecoveryLockHandle(file, path, expected); err != nil {
+		_ = releaseFileLock(file)
+		return nil, err
+	}
+	return file, nil
+}
+
+func validateRecoveryLockHandle(file *os.File, path string, expected FileIdentity) error {
+	openedInfo, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("inspect opened recovery lock: %w", err)
+	}
+	pathInfo, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("inspect recovery lock path: %w", err)
+	}
+	if pathInfo.Mode()&os.ModeSymlink != 0 || !openedInfo.Mode().IsRegular() || !pathInfo.Mode().IsRegular() {
+		return errors.New("upgrade recovery lock path is not a regular file")
+	}
+	openedIdentity, err := fileIdentity(openedInfo)
+	if err != nil {
+		return err
+	}
+	pathIdentity, err := fileIdentity(pathInfo)
+	if err != nil {
+		return err
+	}
+	if openedIdentity != expected || pathIdentity != expected || !os.SameFile(openedInfo, pathInfo) {
+		return errors.New("upgrade recovery lock path was replaced")
+	}
+	return nil
+}
+
+func releaseFileLock(file *os.File) error {
+	if file == nil {
+		return nil
+	}
+	unlockErr := syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+	closeErr := file.Close()
+	return errors.Join(unlockErr, closeErr)
+}

--- a/internal/upgradetxn/storage.go
+++ b/internal/upgradetxn/storage.go
@@ -11,8 +11,11 @@ import (
 	"runtime"
 	"strings"
 	"syscall"
+)
 
-	"github.com/sachiniyer/agent-factory/config"
+var (
+	syncTransactionDirectory = syncDirectory
+	removeTransactionFile    = os.Remove
 )
 
 func snapshotMetadata(home, txnDir string, paths []string) ([]MetadataSnapshot, error) {
@@ -28,10 +31,14 @@ func snapshotMetadata(home, txnDir string, paths []string) ([]MetadataSnapshot, 
 			return nil, fmt.Errorf("metadata path %q is listed more than once", relative)
 		}
 		seen[relative] = struct{}{}
+		parents, err := snapshotMetadataParents(home, relative)
+		if err != nil {
+			return nil, err
+		}
 
 		info, err := os.Lstat(target)
 		if errors.Is(err, os.ErrNotExist) {
-			snapshots = append(snapshots, MetadataSnapshot{Path: relative})
+			snapshots = append(snapshots, MetadataSnapshot{Path: relative, Parents: parents})
 			continue
 		}
 		if err != nil {
@@ -45,7 +52,7 @@ func snapshotMetadata(home, txnDir string, paths []string) ([]MetadataSnapshot, 
 			return nil, fmt.Errorf("read metadata %s: %w", relative, err)
 		}
 		snapshotPath := filepath.Join(metadataDir, fmt.Sprintf("%04d.snapshot", index))
-		if err := config.AtomicWriteFile(snapshotPath, data, info.Mode().Perm()); err != nil {
+		if err := durableAtomicWriteFile(snapshotPath, data, info.Mode().Perm()); err != nil {
 			return nil, fmt.Errorf("snapshot metadata %s: %w", relative, err)
 		}
 		snapshots = append(snapshots, MetadataSnapshot{
@@ -54,9 +61,111 @@ func snapshotMetadata(home, txnDir string, paths []string) ([]MetadataSnapshot, 
 			Mode:         uint32(info.Mode().Perm()),
 			SHA256:       digest(data),
 			SnapshotPath: snapshotPath,
+			Parents:      parents,
 		})
 	}
 	return snapshots, nil
+}
+
+func snapshotMetadataParents(home, relative string) ([]MetadataParentSnapshot, error) {
+	paths := metadataParentPaths(relative)
+	parents := make([]MetadataParentSnapshot, 0, len(paths))
+	for _, path := range paths {
+		info, err := os.Lstat(filepath.Join(home, path))
+		if errors.Is(err, os.ErrNotExist) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("inspect metadata parent %s: %w", path, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return nil, fmt.Errorf("metadata parent %s is not a directory", path)
+		}
+		parents = append(parents, MetadataParentSnapshot{Path: path, Mode: uint32(info.Mode().Perm())})
+	}
+	return parents, nil
+}
+
+func prepareMetadataParents(home string, parents []MetadataParentSnapshot) (int, error) {
+	for index, parent := range parents {
+		path := filepath.Join(home, parent.Path)
+		info, err := os.Lstat(path)
+		if errors.Is(err, os.ErrNotExist) {
+			if err := validateDirectoryNoSymlink(filepath.Dir(path)); err != nil {
+				return index, fmt.Errorf("validate parent of %s: %w", parent.Path, err)
+			}
+			if err := os.Mkdir(path, os.FileMode(parent.Mode)|0o700); err != nil {
+				return index, fmt.Errorf("recreate metadata parent %s: %w", parent.Path, err)
+			}
+			if err := os.Chmod(path, os.FileMode(parent.Mode)|0o700); err != nil {
+				return index + 1, fmt.Errorf("make recreated metadata parent %s writable: %w", parent.Path, err)
+			}
+			if err := syncTransactionDirectory(path); err != nil {
+				return index + 1, fmt.Errorf("sync recreated metadata parent %s: %w", parent.Path, err)
+			}
+			if err := syncTransactionDirectory(filepath.Dir(path)); err != nil {
+				return index + 1, fmt.Errorf("sync parent after recreating %s: %w", parent.Path, err)
+			}
+		} else if err != nil {
+			return index, fmt.Errorf("inspect metadata parent %s: %w", parent.Path, err)
+		} else if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return index, fmt.Errorf("metadata parent %s is not a real directory", parent.Path)
+		}
+		if err := os.Chmod(path, os.FileMode(parent.Mode)|0o700); err != nil {
+			return index + 1, fmt.Errorf("make metadata parent %s writable for restoration: %w", parent.Path, err)
+		}
+	}
+	return len(parents), nil
+}
+
+func restoreMetadataParentModes(home string, parents []MetadataParentSnapshot) error {
+	var result error
+	for index := len(parents) - 1; index >= 0; index-- {
+		parent := parents[index]
+		path := filepath.Join(home, parent.Path)
+		if err := os.Chmod(path, os.FileMode(parent.Mode)); err != nil {
+			result = errors.Join(result, fmt.Errorf("restore metadata parent mode %s: %w", parent.Path, err))
+			continue
+		}
+		if err := syncTransactionDirectory(path); err != nil {
+			result = errors.Join(result, fmt.Errorf("sync metadata parent mode %s: %w", parent.Path, err))
+		}
+	}
+	return result
+}
+
+func restoreMetadataEntry(home string, metadata MetadataSnapshot) (retErr error) {
+	prepared, err := prepareMetadataParents(home, metadata.Parents)
+	defer func() {
+		retErr = errors.Join(retErr, restoreMetadataParentModes(home, metadata.Parents[:prepared]))
+	}()
+	if err != nil {
+		return err
+	}
+	target := filepath.Join(home, metadata.Path)
+	if err := ensureNoSymlinkParents(home, target); err != nil {
+		return fmt.Errorf("validate rollback path %s: %w", metadata.Path, err)
+	}
+	if !metadata.Existed {
+		if err := os.Remove(target); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return nil
+			}
+			return fmt.Errorf("restore absence of %s: %w", metadata.Path, err)
+		}
+		if err := syncTransactionDirectory(filepath.Dir(target)); err != nil {
+			return fmt.Errorf("sync restored absence of %s: %w", metadata.Path, err)
+		}
+		return nil
+	}
+	data, err := readAndVerify(metadata.SnapshotPath, metadata.SHA256)
+	if err != nil {
+		return fmt.Errorf("verify metadata snapshot %s: %w", metadata.Path, err)
+	}
+	if err := durableAtomicWriteFile(target, data, os.FileMode(metadata.Mode)); err != nil {
+		return fmt.Errorf("restore metadata %s: %w", metadata.Path, err)
+	}
+	return nil
 }
 
 func validateJournal(home string, journal Journal) error {
@@ -104,6 +213,12 @@ func validateJournal(home string, journal Journal) error {
 	if err := validateRecoveryJob(journal.ID, journal.RecoveryJob); err != nil {
 		return err
 	}
+	if err := validateDaemonRecoveryPair(journal.Daemon, journal.RecoveryJob); err != nil {
+		return err
+	}
+	if err := validateTransactionStorage(home, journal); err != nil {
+		return err
+	}
 
 	seen := make(map[string]struct{}, len(journal.Metadata))
 	txnDir := transactionDir(home, journal.ID)
@@ -119,6 +234,17 @@ func validateJournal(home string, journal Journal) error {
 			return fmt.Errorf("metadata path %q is duplicated", relative)
 		}
 		seen[relative] = struct{}{}
+		expectedParents := metadataParentPaths(relative)
+		if len(metadata.Parents) > len(expectedParents) ||
+			(metadata.Existed && len(metadata.Parents) != len(expectedParents)) {
+			return fmt.Errorf("metadata snapshot %q has an invalid parent manifest", relative)
+		}
+		for parentIndex, parent := range metadata.Parents {
+			if parent.Path != expectedParents[parentIndex] ||
+				parent.Mode == 0 || os.FileMode(parent.Mode)&^os.ModePerm != 0 {
+				return fmt.Errorf("metadata snapshot %q has an invalid parent manifest", relative)
+			}
+		}
 		if !metadata.Existed {
 			if metadata.Mode != 0 || metadata.SHA256 != "" || metadata.SnapshotPath != "" {
 				return fmt.Errorf("absent metadata %q has snapshot data", relative)
@@ -134,6 +260,42 @@ func validateJournal(home string, journal Journal) error {
 		}
 	}
 	return nil
+}
+
+func validateDaemonRecoveryPair(snapshot DaemonSnapshot, job RecoveryJob) error {
+	expected := RecoveryJobDetached
+	if snapshot.WasRunning {
+		switch snapshot.Owner.Kind {
+		case SupervisionAdHoc:
+			expected = RecoveryJobDetached
+		case SupervisionSystemd:
+			expected = RecoveryJobSystemd
+		case SupervisionLaunchd:
+			expected = RecoveryJobLaunchd
+		}
+	}
+	if job.Kind != expected {
+		return fmt.Errorf("daemon owner %q requires recovery job kind %q, got %q",
+			snapshot.Owner.Kind, expected, job.Kind)
+	}
+	return nil
+}
+
+func validateTransactionStorage(home string, journal Journal) error {
+	for _, path := range []string{upgradeRoot(home), filepath.Join(upgradeRoot(home), "transactions")} {
+		if err := validateDirectoryNoSymlink(path); err != nil {
+			return fmt.Errorf("validate upgrade storage %s: %w", path, err)
+		}
+	}
+	txnDir := transactionDir(home, journal.ID)
+	err := validateDirectoryNoSymlink(txnDir)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, os.ErrNotExist) && terminalPhase(journal.Phase) {
+		return nil
+	}
+	return fmt.Errorf("validate upgrade transaction directory %s: %w", txnDir, err)
 }
 
 func validateDaemonSnapshot(snapshot DaemonSnapshot) error {
@@ -239,6 +401,82 @@ func validPhase(phase Phase) bool {
 func validateTransactionID(id string) error {
 	if !transactionIDPattern.MatchString(id) || id == "." || id == ".." {
 		return fmt.Errorf("invalid upgrade transaction ID %q", id)
+	}
+	return nil
+}
+
+func metadataParentPaths(relative string) []string {
+	dir := filepath.Dir(relative)
+	if dir == "." {
+		return nil
+	}
+	components := strings.Split(dir, string(filepath.Separator))
+	paths := make([]string, 0, len(components))
+	current := ""
+	for _, component := range components {
+		current = filepath.Join(current, component)
+		paths = append(paths, current)
+	}
+	return paths
+}
+
+func terminalPhase(phase Phase) bool {
+	return phase == PhaseCommitted || phase == PhaseRolledBack || phase == PhaseAborted
+}
+
+func validateDirectoryNoSymlink(path string) error {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return err
+	}
+	if filepath.Clean(resolved) != filepath.Clean(path) {
+		return errors.New("directory path contains a symlink")
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return errors.New("path is not a real directory")
+	}
+	return nil
+}
+
+func ensureDurableDirectory(parent, path string, mode os.FileMode) error {
+	if filepath.Dir(path) != parent {
+		return fmt.Errorf("directory %s is not an immediate child of %s", path, parent)
+	}
+	err := validateDirectoryNoSymlink(path)
+	if err == nil {
+		if err := os.Chmod(path, mode); err != nil {
+			return fmt.Errorf("secure directory %s: %w", path, err)
+		}
+		return syncTransactionDirectory(path)
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return createDurableDirectory(parent, path, mode)
+}
+
+func createDurableDirectory(parent, path string, mode os.FileMode) error {
+	if filepath.Dir(path) != parent {
+		return fmt.Errorf("directory %s is not an immediate child of %s", path, parent)
+	}
+	if err := validateDirectoryNoSymlink(parent); err != nil {
+		return fmt.Errorf("validate parent directory %s: %w", parent, err)
+	}
+	if err := os.Mkdir(path, mode); err != nil {
+		return err
+	}
+	if err := os.Chmod(path, mode); err != nil {
+		return fmt.Errorf("secure new directory %s: %w", path, err)
+	}
+	if err := syncTransactionDirectory(path); err != nil {
+		return fmt.Errorf("sync new directory %s: %w", path, err)
+	}
+	if err := syncTransactionDirectory(parent); err != nil {
+		return fmt.Errorf("sync parent directory %s after creating %s: %w", parent, path, err)
 	}
 	return nil
 }
@@ -352,7 +590,131 @@ func persistJournal(path string, journal Journal) error {
 		return fmt.Errorf("encode upgrade journal: %w", err)
 	}
 	data = append(data, '\n')
-	return config.AtomicWriteFile(path, data, journalFileMode)
+	return durableAtomicWriteFile(path, data, journalFileMode)
+}
+
+func durableAtomicWriteFile(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	if err := validateDirectoryNoSymlink(dir); err != nil {
+		return fmt.Errorf("validate durable write directory %s: %w", dir, err)
+	}
+	temporary, err := os.CreateTemp(dir, filepath.Base(path)+".tmp.*")
+	if err != nil {
+		return fmt.Errorf("create durable temporary file: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	renamed := false
+	defer func() {
+		if !renamed {
+			_ = os.Remove(temporaryPath)
+		}
+	}()
+	if _, err := temporary.Write(data); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("write durable temporary file: %w", err)
+	}
+	if err := temporary.Chmod(mode); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("set durable temporary file mode: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("sync durable temporary file: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close durable temporary file: %w", err)
+	}
+	if err := os.Rename(temporaryPath, path); err != nil {
+		return fmt.Errorf("install durable file %s: %w", path, err)
+	}
+	renamed = true
+	if err := syncTransactionDirectory(dir); err != nil {
+		return fmt.Errorf("sync durable file directory %s: %w", dir, err)
+	}
+	return nil
+}
+
+func removeDurableFile(path string) error {
+	if err := validateDirectoryNoSymlink(filepath.Dir(path)); err != nil {
+		return fmt.Errorf("validate file removal directory: %w", err)
+	}
+	if err := removeTransactionFile(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	return syncTransactionDirectory(filepath.Dir(path))
+}
+
+func removeRequiredDurableFile(path string) error {
+	if err := validateDirectoryNoSymlink(filepath.Dir(path)); err != nil {
+		return fmt.Errorf("validate required file removal directory: %w", err)
+	}
+	if err := removeTransactionFile(path); err != nil {
+		return err
+	}
+	return syncTransactionDirectory(filepath.Dir(path))
+}
+
+func removeDurableTree(path string) error {
+	parent := filepath.Dir(path)
+	if err := validateDirectoryNoSymlink(parent); err != nil {
+		return fmt.Errorf("validate tree removal parent: %w", err)
+	}
+	if err := validateDirectoryNoSymlink(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("validate tree removal target: %w", err)
+	}
+	if err := os.RemoveAll(path); err != nil {
+		return err
+	}
+	return syncTransactionDirectory(parent)
+}
+
+// cleanup keeps both the flock path and previous-binary actor until active.json
+// is durably gone. After that authority marker disappears, leftover artifacts
+// are inert and cleanup is best-effort across process loss.
+func (t *Transaction) cleanup() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if !terminalPhase(t.journal.Phase) {
+		return fmt.Errorf("cannot clean up upgrade in phase %s", t.journal.Phase)
+	}
+
+	current, err := readJournal(activeJournalPath(t.journal.HomeDir))
+	if errors.Is(err, ErrNoActiveTransaction) {
+		return t.cleanupInactiveArtifacts()
+	}
+	if err != nil {
+		return err
+	}
+	if err := validateJournal(t.journal.HomeDir, current); err != nil {
+		return fmt.Errorf("validate journal before cleanup: %w", err)
+	}
+	if current.ID != t.journal.ID || current.Phase != t.journal.Phase {
+		return errors.New("active upgrade transaction changed before cleanup")
+	}
+	if err := removeDurableFile(t.journal.CandidatePath); err != nil {
+		return fmt.Errorf("remove candidate upgrade artifact: %w", err)
+	}
+	activePath := activeJournalPath(t.journal.HomeDir)
+	if err := removeRequiredDurableFile(activePath); err != nil {
+		return fmt.Errorf("remove active upgrade journal: %w", err)
+	}
+	return t.cleanupInactiveArtifacts()
+}
+
+func (t *Transaction) cleanupInactiveArtifacts() error {
+	if err := removeDurableFile(t.journal.CandidatePath); err != nil {
+		return fmt.Errorf("remove inactive candidate artifact: %w", err)
+	}
+	if err := removeDurableTree(transactionDir(t.journal.HomeDir, t.journal.ID)); err != nil {
+		return fmt.Errorf("remove inactive transaction directory: %w", err)
+	}
+	if err := removeDurableFile(t.journal.PreviousBinaryPath); err != nil {
+		return fmt.Errorf("remove previous-binary cleanup actor: %w", err)
+	}
+	return nil
 }
 
 func readJournal(path string) (Journal, error) {

--- a/internal/upgradetxn/storage.go
+++ b/internal/upgradetxn/storage.go
@@ -118,6 +118,32 @@ func prepareMetadataParents(home string, parents []MetadataParentSnapshot) (int,
 	return len(parents), nil
 }
 
+func prepareCandidateMetadataParents(
+	home, relative string, snapshotted int,
+) ([]MetadataParentSnapshot, error) {
+	paths := metadataParentPaths(relative)
+	prepared := make([]MetadataParentSnapshot, 0, len(paths)-snapshotted)
+	for _, relativePath := range paths[snapshotted:] {
+		path := filepath.Join(home, relativePath)
+		info, err := os.Lstat(path)
+		if errors.Is(err, os.ErrNotExist) {
+			break
+		}
+		if err != nil {
+			return prepared, fmt.Errorf("inspect candidate-created metadata parent %s: %w", relativePath, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return prepared, fmt.Errorf("candidate-created metadata parent %s is not a real directory", relativePath)
+		}
+		parent := MetadataParentSnapshot{Path: relativePath, Mode: uint32(info.Mode().Perm())}
+		if err := os.Chmod(path, info.Mode().Perm()|0o700); err != nil {
+			return prepared, fmt.Errorf("make candidate-created metadata parent %s writable: %w", relativePath, err)
+		}
+		prepared = append(prepared, parent)
+	}
+	return prepared, nil
+}
+
 func restoreMetadataParentModes(home string, parents []MetadataParentSnapshot) error {
 	var result error
 	for index := len(parents) - 1; index >= 0; index-- {
@@ -141,6 +167,15 @@ func restoreMetadataEntry(home string, metadata MetadataSnapshot) (retErr error)
 	}()
 	if err != nil {
 		return err
+	}
+	if !metadata.Existed {
+		candidateParents, err := prepareCandidateMetadataParents(home, metadata.Path, len(metadata.Parents))
+		defer func() {
+			retErr = errors.Join(retErr, restoreMetadataParentModes(home, candidateParents))
+		}()
+		if err != nil {
+			return err
+		}
 	}
 	target := filepath.Join(home, metadata.Path)
 	if err := ensureNoSymlinkParents(home, target); err != nil {

--- a/internal/upgradetxn/storage.go
+++ b/internal/upgradetxn/storage.go
@@ -1,0 +1,467 @@
+package upgradetxn
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+func snapshotMetadata(home, txnDir string, paths []string) ([]MetadataSnapshot, error) {
+	seen := make(map[string]struct{}, len(paths))
+	snapshots := make([]MetadataSnapshot, 0, len(paths))
+	metadataDir := filepath.Join(txnDir, "metadata")
+	for index, path := range paths {
+		relative, target, err := validateMetadataPath(home, path)
+		if err != nil {
+			return nil, err
+		}
+		if _, exists := seen[relative]; exists {
+			return nil, fmt.Errorf("metadata path %q is listed more than once", relative)
+		}
+		seen[relative] = struct{}{}
+
+		info, err := os.Lstat(target)
+		if errors.Is(err, os.ErrNotExist) {
+			snapshots = append(snapshots, MetadataSnapshot{Path: relative})
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("inspect metadata %s: %w", relative, err)
+		}
+		if !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("metadata %s is not a regular file", relative)
+		}
+		data, err := os.ReadFile(target)
+		if err != nil {
+			return nil, fmt.Errorf("read metadata %s: %w", relative, err)
+		}
+		snapshotPath := filepath.Join(metadataDir, fmt.Sprintf("%04d.snapshot", index))
+		if err := config.AtomicWriteFile(snapshotPath, data, info.Mode().Perm()); err != nil {
+			return nil, fmt.Errorf("snapshot metadata %s: %w", relative, err)
+		}
+		snapshots = append(snapshots, MetadataSnapshot{
+			Path:         relative,
+			Existed:      true,
+			Mode:         uint32(info.Mode().Perm()),
+			SHA256:       digest(data),
+			SnapshotPath: snapshotPath,
+		})
+	}
+	return snapshots, nil
+}
+
+func validateJournal(home string, journal Journal) error {
+	if journal.SchemaVersion != journalSchemaVersion {
+		return fmt.Errorf("unsupported upgrade journal schema %d", journal.SchemaVersion)
+	}
+	if err := validateTransactionID(journal.ID); err != nil {
+		return err
+	}
+	if journal.HomeDir != home {
+		return fmt.Errorf("journal home %q does not match %q", journal.HomeDir, home)
+	}
+	if !filepath.IsAbs(journal.ExecutablePath) || filepath.Clean(journal.ExecutablePath) != journal.ExecutablePath {
+		return errors.New("journal executable path is not canonical")
+	}
+	previousPath, candidatePath := binaryArtifactPaths(journal.ExecutablePath, journal.ID)
+	if journal.PreviousBinaryPath != previousPath || journal.CandidatePath != candidatePath {
+		return errors.New("journal binary artifact paths do not match the transaction")
+	}
+	if !validDigest(journal.PreviousBinarySHA256) || !validDigest(journal.CandidateSHA256) {
+		return errors.New("journal contains an invalid binary digest")
+	}
+	if len(journal.RecoveryNonce) != recoveryNonceBytes*2 {
+		return errors.New("journal contains an invalid recovery nonce")
+	}
+	if _, err := hex.DecodeString(journal.RecoveryNonce); err != nil {
+		return errors.New("journal contains an invalid recovery nonce")
+	}
+	if journal.ExecutableMode == 0 || os.FileMode(journal.ExecutableMode)&^os.ModePerm != 0 {
+		return errors.New("journal contains an invalid executable mode")
+	}
+	if !validPhase(journal.Phase) {
+		return fmt.Errorf("journal contains invalid phase %q", journal.Phase)
+	}
+	if journal.RollbackProgress.MetadataRestored < 0 ||
+		journal.RollbackProgress.MetadataRestored > len(journal.Metadata) {
+		return errors.New("journal contains invalid rollback metadata progress")
+	}
+	if !journal.RollbackProgress.BinaryRestored && journal.RollbackProgress.MetadataRestored != 0 {
+		return errors.New("journal restores metadata only after the previous binary")
+	}
+	if err := validateDaemonSnapshot(journal.Daemon); err != nil {
+		return err
+	}
+	if err := validateRecoveryJob(journal.ID, journal.RecoveryJob); err != nil {
+		return err
+	}
+
+	seen := make(map[string]struct{}, len(journal.Metadata))
+	txnDir := transactionDir(home, journal.ID)
+	for index, metadata := range journal.Metadata {
+		relative, _, err := validateMetadataPath(home, metadata.Path)
+		if err != nil {
+			return err
+		}
+		if relative != metadata.Path {
+			return fmt.Errorf("metadata path %q is not canonical", metadata.Path)
+		}
+		if _, exists := seen[relative]; exists {
+			return fmt.Errorf("metadata path %q is duplicated", relative)
+		}
+		seen[relative] = struct{}{}
+		if !metadata.Existed {
+			if metadata.Mode != 0 || metadata.SHA256 != "" || metadata.SnapshotPath != "" {
+				return fmt.Errorf("absent metadata %q has snapshot data", relative)
+			}
+			continue
+		}
+		expectedSnapshot := filepath.Join(txnDir, "metadata", fmt.Sprintf("%04d.snapshot", index))
+		if metadata.SnapshotPath != expectedSnapshot || !validDigest(metadata.SHA256) {
+			return fmt.Errorf("metadata snapshot %q does not match the transaction", relative)
+		}
+		if metadata.Mode == 0 || os.FileMode(metadata.Mode)&^os.ModePerm != 0 {
+			return fmt.Errorf("metadata snapshot %q has invalid mode", relative)
+		}
+	}
+	return nil
+}
+
+func validateDaemonSnapshot(snapshot DaemonSnapshot) error {
+	if !snapshot.WasRunning {
+		if snapshot != (DaemonSnapshot{}) {
+			return errors.New("journal records daemon details when no daemon was running")
+		}
+		return nil
+	}
+	if strings.TrimSpace(snapshot.BootID) == "" {
+		return errors.New("journal omits the previous daemon boot identity")
+	}
+	switch snapshot.Owner.Kind {
+	case SupervisionAdHoc:
+		if snapshot.Owner.ServiceName != "" {
+			return errors.New("ad-hoc daemon owner cannot name a service")
+		}
+	case SupervisionSystemd, SupervisionLaunchd:
+		if strings.TrimSpace(snapshot.Owner.ServiceName) == "" {
+			return errors.New("service-managed daemon owner omits its service name")
+		}
+	default:
+		return fmt.Errorf("journal contains invalid daemon supervision kind %q", snapshot.Owner.Kind)
+	}
+	listeners := snapshot.Listeners
+	if !listeners.TCPConfigured {
+		if listeners.TCPListenAddr != "" || listeners.TCPBound {
+			return errors.New("journal records a TCP listener without TCP configuration")
+		}
+	} else if strings.TrimSpace(listeners.TCPListenAddr) == "" {
+		return errors.New("journal omits the configured TCP listen address")
+	}
+	return nil
+}
+
+// NewRecoveryJob derives the only accepted identity for a transaction. Keeping
+// this constructor beside journal validation prevents the daemon-side unit
+// renderer and the previous-binary cleanup path from inventing two subtly
+// different names.
+func NewRecoveryJob(kind RecoveryJobKind, transactionID, unitDir string) (RecoveryJob, error) {
+	if err := validateTransactionID(transactionID); err != nil {
+		return RecoveryJob{}, err
+	}
+	job := RecoveryJob{Kind: kind}
+	switch kind {
+	case RecoveryJobDetached:
+		if unitDir != "" {
+			return RecoveryJob{}, errors.New("detached recovery job cannot have a unit directory")
+		}
+	case RecoveryJobSystemd:
+		job.Name = "agent-factory-upgrade-recovery-" + transactionID + ".service"
+		job.UnitPath = filepath.Join(unitDir, job.Name)
+	case RecoveryJobLaunchd:
+		job.Name = "com.agent-factory.upgrade-recovery." + transactionID
+		job.UnitPath = filepath.Join(unitDir, job.Name+".plist")
+	default:
+		return RecoveryJob{}, fmt.Errorf("unsupported upgrade recovery job kind %q", kind)
+	}
+	if err := validateRecoveryJob(transactionID, job); err != nil {
+		return RecoveryJob{}, err
+	}
+	return job, nil
+}
+
+func validateRecoveryJob(transactionID string, job RecoveryJob) error {
+	switch job.Kind {
+	case RecoveryJobDetached:
+		if job.Name != "" || job.UnitPath != "" {
+			return errors.New("detached recovery job cannot name a service or unit path")
+		}
+		return nil
+	case RecoveryJobSystemd, RecoveryJobLaunchd:
+		if job.Name == "" || !filepath.IsAbs(job.UnitPath) || filepath.Clean(job.UnitPath) != job.UnitPath {
+			return errors.New("persistent recovery job requires an absolute canonical unit path")
+		}
+		expectedName := "agent-factory-upgrade-recovery-" + transactionID + ".service"
+		expectedBase := expectedName
+		if job.Kind == RecoveryJobLaunchd {
+			expectedName = "com.agent-factory.upgrade-recovery." + transactionID
+			expectedBase = expectedName + ".plist"
+		}
+		if job.Name != expectedName || filepath.Base(job.UnitPath) != expectedBase {
+			return errors.New("recovery job identity does not match the transaction")
+		}
+		return nil
+	default:
+		return fmt.Errorf("journal contains invalid recovery job kind %q", job.Kind)
+	}
+}
+
+func validPhase(phase Phase) bool {
+	switch phase {
+	case PhasePrepared, PhaseSupervisorReady, PhaseDaemonStopped,
+		PhaseCandidateInstalled, PhaseCandidateStarting, PhaseCandidateValidating,
+		PhaseCommitted, PhaseAborted, PhaseRollingBack, PhaseRollbackRestored,
+		PhasePreviousStarting, PhasePreviousValidating, PhaseRolledBack, PhaseRollbackFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+func validateTransactionID(id string) error {
+	if !transactionIDPattern.MatchString(id) || id == "." || id == ".." {
+		return fmt.Errorf("invalid upgrade transaction ID %q", id)
+	}
+	return nil
+}
+
+func validateMetadataPath(home, path string) (string, string, error) {
+	if path == "" || filepath.IsAbs(path) {
+		return "", "", fmt.Errorf("metadata path %q must be relative to the upgrade home", path)
+	}
+	relative := filepath.Clean(path)
+	if relative == "." || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return "", "", fmt.Errorf("metadata path %q escapes the upgrade home", path)
+	}
+	target := filepath.Join(home, relative)
+	inside, err := filepath.Rel(home, target)
+	if err != nil || inside != relative {
+		return "", "", fmt.Errorf("metadata path %q escapes the upgrade home", path)
+	}
+	if err := ensureNoSymlinkParents(home, target); err != nil {
+		return "", "", fmt.Errorf("metadata path %q is unsafe: %w", path, err)
+	}
+	return relative, target, nil
+}
+
+func ensureNoSymlinkParents(home, target string) error {
+	relative, err := filepath.Rel(home, filepath.Dir(target))
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return errors.New("parent escapes the upgrade home")
+	}
+	current := home
+	if relative == "." {
+		return nil
+	}
+	for _, component := range strings.Split(relative, string(filepath.Separator)) {
+		current = filepath.Join(current, component)
+		info, err := os.Lstat(current)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("parent %s is a symlink", current)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("parent %s is not a directory", current)
+		}
+	}
+	return nil
+}
+
+func canonicalExistingDir(path string) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", errors.New("path is blank")
+	}
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	canonical, err := filepath.EvalSymlinks(absolute)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(canonical)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("%s is not a directory", canonical)
+	}
+	return filepath.Clean(canonical), nil
+}
+
+func canonicalExistingFile(path string) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", errors.New("path is blank")
+	}
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	canonical, err := filepath.EvalSymlinks(absolute)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(canonical), nil
+}
+
+func upgradeRoot(home string) string {
+	return filepath.Join(home, "upgrade")
+}
+
+func activeJournalPath(home string) string {
+	return filepath.Join(upgradeRoot(home), "active.json")
+}
+
+func transactionDir(home, id string) string {
+	return filepath.Join(upgradeRoot(home), "transactions", id)
+}
+
+func binaryArtifactPaths(executable, id string) (string, string) {
+	dir := filepath.Dir(executable)
+	base := filepath.Base(executable)
+	prefix := "." + base + ".af-upgrade-" + id
+	return filepath.Join(dir, prefix+".previous"), filepath.Join(dir, prefix+".candidate")
+}
+
+func persistJournal(path string, journal Journal) error {
+	data, err := json.MarshalIndent(journal, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode upgrade journal: %w", err)
+	}
+	data = append(data, '\n')
+	return config.AtomicWriteFile(path, data, journalFileMode)
+}
+
+func readJournal(path string) (Journal, error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return Journal{}, ErrNoActiveTransaction
+	}
+	if err != nil {
+		return Journal{}, fmt.Errorf("read active upgrade journal: %w", err)
+	}
+	var journal Journal
+	if err := json.Unmarshal(data, &journal); err != nil {
+		return Journal{}, fmt.Errorf("decode active upgrade journal: %w", err)
+	}
+	return journal, nil
+}
+
+func digest(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func validDigest(value string) bool {
+	if len(value) != sha256.Size*2 {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil
+}
+
+func readAndVerify(path, expectedDigest string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if digest(data) != expectedDigest {
+		return nil, fmt.Errorf("digest mismatch for %s", path)
+	}
+	return data, nil
+}
+
+func acquireFileLock(path string, nonblocking bool) (*os.File, error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, journalFileMode)
+	if err != nil {
+		return nil, err
+	}
+	operation := syscall.LOCK_EX
+	if nonblocking {
+		operation |= syscall.LOCK_NB
+	}
+	if err := syscall.Flock(int(file.Fd()), operation); err != nil {
+		_ = file.Close()
+		if nonblocking && (errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN)) {
+			return nil, ErrRecoveryActive
+		}
+		return nil, err
+	}
+	return file, nil
+}
+
+func releaseFileLock(file *os.File) error {
+	if file == nil {
+		return nil
+	}
+	unlockErr := syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+	closeErr := file.Close()
+	return errors.Join(unlockErr, closeErr)
+}
+
+func syncDirectory(path string) error {
+	directory, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open directory for sync: %w", err)
+	}
+	defer directory.Close()
+	if err := directory.Sync(); err != nil {
+		return fmt.Errorf("sync directory: %w", err)
+	}
+	return nil
+}
+
+func processStartIdentity() string {
+	if runtime.GOOS != "linux" {
+		return ""
+	}
+	data, err := os.ReadFile("/proc/self/stat")
+	if err != nil {
+		return ""
+	}
+	closingParen := strings.LastIndexByte(string(data), ')')
+	if closingParen < 0 || closingParen+1 >= len(data) {
+		return ""
+	}
+	fields := strings.Fields(string(data[closingParen+1:]))
+	// The suffix starts with field 3 (state), so field 22 (starttime) is
+	// suffix index 19.
+	if len(fields) <= 19 {
+		return ""
+	}
+	return fields[19]
+}
+
+func kernelBootID() string {
+	if runtime.GOOS != "linux" {
+		return ""
+	}
+	data, err := os.ReadFile("/proc/sys/kernel/random/boot_id")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}

--- a/internal/upgradetxn/storage.go
+++ b/internal/upgradetxn/storage.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"syscall"
 )
 
 var (
@@ -182,13 +181,10 @@ func restoreMetadataEntry(home string, metadata MetadataSnapshot) (retErr error)
 		return fmt.Errorf("validate rollback path %s: %w", metadata.Path, err)
 	}
 	if !metadata.Existed {
-		if removeErr := os.Remove(target); removeErr != nil {
-			if errors.Is(removeErr, os.ErrNotExist) {
-				return nil
-			}
+		if removeErr := os.Remove(target); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
 			return fmt.Errorf("restore absence of %s: %w", metadata.Path, removeErr)
 		}
-		if err := syncTransactionDirectory(filepath.Dir(target)); err != nil {
+		if err := syncMetadataAbsence(home, target); err != nil {
 			return fmt.Errorf("sync restored absence of %s: %w", metadata.Path, err)
 		}
 		return nil
@@ -201,6 +197,30 @@ func restoreMetadataEntry(home string, metadata MetadataSnapshot) (retErr error)
 		return fmt.Errorf("restore metadata %s: %w", metadata.Path, err)
 	}
 	return nil
+}
+
+func syncMetadataAbsence(home, target string) error {
+	directory := filepath.Dir(target)
+	for {
+		info, err := os.Lstat(directory)
+		if err == nil {
+			if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+				return fmt.Errorf("metadata absence parent %s is not a real directory", directory)
+			}
+			return syncTransactionDirectory(directory)
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		if directory == home {
+			return errors.New("upgrade home disappeared while restoring metadata absence")
+		}
+		parent := filepath.Dir(directory)
+		if parent == directory {
+			return errors.New("metadata absence parent escapes the upgrade home")
+		}
+		directory = parent
+	}
 }
 
 func validateJournal(home string, journal Journal) error {
@@ -229,6 +249,9 @@ func validateJournal(home string, journal Journal) error {
 	if _, err := hex.DecodeString(journal.RecoveryNonce); err != nil {
 		return errors.New("journal contains an invalid recovery nonce")
 	}
+	if journal.RecoveryLockIdentity.Inode == 0 {
+		return errors.New("journal contains an invalid recovery lock identity")
+	}
 	if journal.ExecutableMode == 0 || os.FileMode(journal.ExecutableMode)&^os.ModePerm != 0 {
 		return errors.New("journal contains an invalid executable mode")
 	}
@@ -249,6 +272,9 @@ func validateJournal(home string, journal Journal) error {
 		return err
 	}
 	if err := validateTransactionStorage(home, journal); err != nil {
+		return err
+	}
+	if err := validateRecoveryLockStorage(home, journal); err != nil {
 		return err
 	}
 
@@ -730,6 +756,13 @@ func (t *Transaction) cleanup() error {
 
 	current, err := readJournal(activeJournalPath(t.journal.HomeDir))
 	if errors.Is(err, ErrNoActiveTransaction) {
+		root := upgradeRoot(t.journal.HomeDir)
+		if err := validateDirectoryNoSymlink(root); err != nil {
+			return fmt.Errorf("validate inactive upgrade root: %w", err)
+		}
+		if err := syncTransactionDirectory(root); err != nil {
+			return fmt.Errorf("confirm durable active journal absence: %w", err)
+		}
 		return t.cleanupInactiveArtifacts()
 	}
 	if err != nil {
@@ -760,6 +793,9 @@ func (t *Transaction) cleanupInactiveArtifacts() error {
 	}
 	if err := removeDurableFile(t.journal.PreviousBinaryPath); err != nil {
 		return fmt.Errorf("remove previous-binary cleanup actor: %w", err)
+	}
+	if err := removeDurableFile(recoveryLockPath(t.journal.HomeDir, t.journal.ID)); err != nil {
+		return fmt.Errorf("remove inactive recovery lock: %w", err)
 	}
 	return nil
 }
@@ -801,34 +837,6 @@ func readAndVerify(path, expectedDigest string) ([]byte, error) {
 		return nil, fmt.Errorf("digest mismatch for %s", path)
 	}
 	return data, nil
-}
-
-func acquireFileLock(path string, nonblocking bool) (*os.File, error) {
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, journalFileMode)
-	if err != nil {
-		return nil, err
-	}
-	operation := syscall.LOCK_EX
-	if nonblocking {
-		operation |= syscall.LOCK_NB
-	}
-	if err := syscall.Flock(int(file.Fd()), operation); err != nil {
-		_ = file.Close()
-		if nonblocking && (errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN)) {
-			return nil, ErrRecoveryActive
-		}
-		return nil, err
-	}
-	return file, nil
-}
-
-func releaseFileLock(file *os.File) error {
-	if file == nil {
-		return nil
-	}
-	unlockErr := syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
-	closeErr := file.Close()
-	return errors.Join(unlockErr, closeErr)
 }
 
 func syncDirectory(path string) error {

--- a/internal/upgradetxn/storage.go
+++ b/internal/upgradetxn/storage.go
@@ -223,7 +223,7 @@ func validateJournal(home string, journal Journal) error {
 	seen := make(map[string]struct{}, len(journal.Metadata))
 	txnDir := transactionDir(home, journal.ID)
 	for index, metadata := range journal.Metadata {
-		relative, _, err := validateMetadataPath(home, metadata.Path)
+		relative, _, err := resolveMetadataPath(home, metadata.Path)
 		if err != nil {
 			return err
 		}
@@ -481,7 +481,7 @@ func createDurableDirectory(parent, path string, mode os.FileMode) error {
 	return nil
 }
 
-func validateMetadataPath(home, path string) (string, string, error) {
+func resolveMetadataPath(home, path string) (string, string, error) {
 	if path == "" || filepath.IsAbs(path) {
 		return "", "", fmt.Errorf("metadata path %q must be relative to the upgrade home", path)
 	}
@@ -493,6 +493,14 @@ func validateMetadataPath(home, path string) (string, string, error) {
 	inside, err := filepath.Rel(home, target)
 	if err != nil || inside != relative {
 		return "", "", fmt.Errorf("metadata path %q escapes the upgrade home", path)
+	}
+	return relative, target, nil
+}
+
+func validateMetadataPath(home, path string) (string, string, error) {
+	relative, target, err := resolveMetadataPath(home, path)
+	if err != nil {
+		return "", "", err
 	}
 	if err := ensureNoSymlinkParents(home, target); err != nil {
 		return "", "", fmt.Errorf("metadata path %q is unsafe: %w", path, err)

--- a/internal/upgradetxn/storage.go
+++ b/internal/upgradetxn/storage.go
@@ -210,10 +210,7 @@ func validateJournal(home string, journal Journal) error {
 	if err := validateDaemonSnapshot(journal.Daemon); err != nil {
 		return err
 	}
-	if err := validateRecoveryJob(journal.ID, journal.RecoveryJob); err != nil {
-		return err
-	}
-	if err := validateDaemonRecoveryPair(journal.Daemon, journal.RecoveryJob); err != nil {
+	if err := validateRecoveryConfiguration(journal.ID, journal.Daemon, journal.RecoveryJob); err != nil {
 		return err
 	}
 	if err := validateTransactionStorage(home, journal); err != nil {
@@ -260,6 +257,13 @@ func validateJournal(home string, journal Journal) error {
 		}
 	}
 	return nil
+}
+
+func validateRecoveryConfiguration(transactionID string, snapshot DaemonSnapshot, job RecoveryJob) error {
+	if err := validateRecoveryJob(transactionID, job); err != nil {
+		return err
+	}
+	return validateDaemonRecoveryPair(snapshot, job)
 }
 
 func validateDaemonRecoveryPair(snapshot DaemonSnapshot, job RecoveryJob) error {

--- a/internal/upgradetxn/storage.go
+++ b/internal/upgradetxn/storage.go
@@ -756,14 +756,7 @@ func (t *Transaction) cleanup() error {
 
 	current, err := readJournal(activeJournalPath(t.journal.HomeDir))
 	if errors.Is(err, ErrNoActiveTransaction) {
-		root := upgradeRoot(t.journal.HomeDir)
-		if err := validateDirectoryNoSymlink(root); err != nil {
-			return fmt.Errorf("validate inactive upgrade root: %w", err)
-		}
-		if err := syncTransactionDirectory(root); err != nil {
-			return fmt.Errorf("confirm durable active journal absence: %w", err)
-		}
-		return t.cleanupInactiveArtifacts()
+		return t.cleanupAfterConfirmedJournalAbsence()
 	}
 	if err != nil {
 		return err
@@ -780,6 +773,17 @@ func (t *Transaction) cleanup() error {
 	activePath := activeJournalPath(t.journal.HomeDir)
 	if err := removeRequiredDurableFile(activePath); err != nil {
 		return fmt.Errorf("remove active upgrade journal: %w", err)
+	}
+	return t.cleanupInactiveArtifacts()
+}
+
+func (t *Transaction) cleanupAfterConfirmedJournalAbsence() error {
+	root := upgradeRoot(t.journal.HomeDir)
+	if err := validateDirectoryNoSymlink(root); err != nil {
+		return fmt.Errorf("validate inactive upgrade root: %w", err)
+	}
+	if err := syncTransactionDirectory(root); err != nil {
+		return fmt.Errorf("confirm durable active journal absence: %w", err)
 	}
 	return t.cleanupInactiveArtifacts()
 }

--- a/internal/upgradetxn/storage.go
+++ b/internal/upgradetxn/storage.go
@@ -182,11 +182,11 @@ func restoreMetadataEntry(home string, metadata MetadataSnapshot) (retErr error)
 		return fmt.Errorf("validate rollback path %s: %w", metadata.Path, err)
 	}
 	if !metadata.Existed {
-		if err := os.Remove(target); err != nil {
-			if errors.Is(err, os.ErrNotExist) {
+		if removeErr := os.Remove(target); removeErr != nil {
+			if errors.Is(removeErr, os.ErrNotExist) {
 				return nil
 			}
-			return fmt.Errorf("restore absence of %s: %w", metadata.Path, err)
+			return fmt.Errorf("restore absence of %s: %w", metadata.Path, removeErr)
 		}
 		if err := syncTransactionDirectory(filepath.Dir(target)); err != nil {
 			return fmt.Errorf("sync restored absence of %s: %w", metadata.Path, err)

--- a/internal/upgradetxn/transaction.go
+++ b/internal/upgradetxn/transaction.go
@@ -1,0 +1,995 @@
+// Package upgradetxn owns the crash-durable filesystem transaction used to
+// replace the running af binary. The transaction is deliberately independent
+// of the candidate binary: only the already-running (previous) binary may
+// supervise, commit, or roll back an upgrade.
+package upgradetxn
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+const (
+	journalSchemaVersion = 1
+	journalFileMode      = 0o600
+	transactionDirMode   = 0o700
+	recoveryNonceBytes   = 32
+)
+
+var (
+	// ErrNoActiveTransaction means no upgrade journal is published for the AF
+	// home. It is a normal result for entrypoints outside an upgrade.
+	ErrNoActiveTransaction = errors.New("no active upgrade transaction")
+	// ErrRecoveryActive means a live process holds the kernel recovery lock.
+	// Timestamps are diagnostic only and never override this result.
+	ErrRecoveryActive = errors.New("upgrade recovery is active")
+	// ErrRecoveryActorMismatch means code that is not executing from the
+	// transaction's immutable previous-binary artifact attempted to acquire
+	// mutation authority. Candidates may observe or wake recovery, but they can
+	// never supervise, commit, or roll back themselves.
+	ErrRecoveryActorMismatch = errors.New("upgrade recovery actor is not the preserved previous binary")
+
+	// errRecoveryCheckpointInterrupted is returned only by the in-package
+	// crash-injection seam. A real actor death returns nothing; keeping the
+	// phase at rolling_back models that durable state rather than mislabeling
+	// the interruption as a failed restoration.
+	errRecoveryCheckpointInterrupted = errors.New("upgrade recovery actor interrupted after checkpoint")
+
+	transactionIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
+)
+
+// Phase is a durable upgrade boundary. Every phase is persisted before a
+// supervisor takes an action whose recovery meaning differs from the prior
+// phase.
+type Phase string
+
+const (
+	PhasePrepared            Phase = "prepared"
+	PhaseSupervisorReady     Phase = "supervisor_ready"
+	PhaseDaemonStopped       Phase = "daemon_stopped"
+	PhaseCandidateInstalled  Phase = "candidate_installed"
+	PhaseCandidateStarting   Phase = "candidate_starting"
+	PhaseCandidateValidating Phase = "candidate_validating"
+	PhaseCommitted           Phase = "committed"
+	PhaseAborted             Phase = "aborted"
+	PhaseRollingBack         Phase = "rolling_back"
+	PhaseRollbackRestored    Phase = "rollback_restored"
+	PhasePreviousStarting    Phase = "previous_starting"
+	PhasePreviousValidating  Phase = "previous_validating"
+	PhaseRolledBack          Phase = "rolled_back"
+	PhaseRollbackFailed      Phase = "rollback_failed"
+)
+
+// RollbackProgress makes restoration resumable at file granularity. A
+// checkpoint is persisted only after its atomic write/removal completes, so a
+// crash before the checkpoint safely repeats that one idempotent operation.
+type RollbackProgress struct {
+	BinaryRestored   bool `json:"binary_restored"`
+	MetadataRestored int  `json:"metadata_restored"`
+}
+
+// Plan contains all bytes and paths whose pre-upgrade state must be captured
+// before the transaction becomes visible to another process.
+type Plan struct {
+	ID             string
+	HomeDir        string
+	ExecutablePath string
+	FromVersion    string
+	ToVersion      string
+	Candidate      []byte
+	Daemon         DaemonSnapshot
+	RecoveryJob    RecoveryJob
+	// MetadataPaths are paths relative to HomeDir. Existing regular files are
+	// snapshotted; absence is recorded so rollback removes files created by a
+	// candidate.
+	MetadataPaths []string
+}
+
+// SupervisionKind is the captured owner used for both candidate activation
+// and previous-daemon restoration. Recovery never guesses a different owner.
+type SupervisionKind string
+
+const (
+	SupervisionNone    SupervisionKind = ""
+	SupervisionAdHoc   SupervisionKind = "ad_hoc"
+	SupervisionSystemd SupervisionKind = "systemd"
+	SupervisionLaunchd SupervisionKind = "launchd"
+)
+
+// DaemonOwner is the service-manager identity captured before shutdown.
+// ServiceName is empty only for an ad-hoc daemon.
+type DaemonOwner struct {
+	Kind        SupervisionKind `json:"kind"`
+	ServiceName string          `json:"service_name,omitempty"`
+}
+
+// ListenerExpectation records only surfaces proven healthy before handoff.
+// Candidate and rollback validation must restore each true surface.
+type ListenerExpectation struct {
+	HTTPUnixBound bool   `json:"http_unix_bound"`
+	TCPConfigured bool   `json:"tcp_configured"`
+	TCPListenAddr string `json:"tcp_listen_addr,omitempty"`
+	TCPBound      bool   `json:"tcp_bound"`
+}
+
+// DaemonSnapshot is the exact pre-handoff daemon and supervision identity.
+type DaemonSnapshot struct {
+	WasRunning bool                `json:"was_running"`
+	BootID     string              `json:"boot_id,omitempty"`
+	Owner      DaemonOwner         `json:"owner"`
+	Listeners  ListenerExpectation `json:"listeners"`
+}
+
+// RecoveryJobKind names the durable actor launcher selected before an upgrade
+// becomes active. Service-managed daemons use a persistent transaction unit;
+// ad-hoc daemons use a detached actor and rely on the all-entrypoint takeover
+// gate after logout or reboot.
+type RecoveryJobKind string
+
+const (
+	RecoveryJobDetached RecoveryJobKind = "detached"
+	RecoveryJobSystemd  RecoveryJobKind = "systemd"
+	RecoveryJobLaunchd  RecoveryJobKind = "launchd"
+)
+
+// RecoveryJob is persisted rather than re-derived after a reboot. UnitPath is
+// exact and Name is the service-manager identity; both are empty for the
+// detached fallback. The transaction ID determines the only valid name.
+type RecoveryJob struct {
+	Kind     RecoveryJobKind `json:"kind"`
+	Name     string          `json:"name,omitempty"`
+	UnitPath string          `json:"unit_path,omitempty"`
+}
+
+// MetadataSnapshot describes one rollback input. SnapshotPath is empty when
+// the metadata file did not exist at prepare time.
+type MetadataSnapshot struct {
+	Path         string `json:"path"`
+	Existed      bool   `json:"existed"`
+	Mode         uint32 `json:"mode,omitempty"`
+	SHA256       string `json:"sha256,omitempty"`
+	SnapshotPath string `json:"snapshot_path,omitempty"`
+}
+
+// Journal is the fsynced recovery authority. Artifact paths are recorded for
+// diagnostics but validated against paths derived from the transaction ID on
+// every Load before they are used.
+type Journal struct {
+	SchemaVersion        int                `json:"schema_version"`
+	ID                   string             `json:"id"`
+	HomeDir              string             `json:"home_dir"`
+	ExecutablePath       string             `json:"executable_path"`
+	FromVersion          string             `json:"from_version"`
+	ToVersion            string             `json:"to_version"`
+	Phase                Phase              `json:"phase"`
+	RecoveryNonce        string             `json:"recovery_nonce"`
+	PreviousBinaryPath   string             `json:"previous_binary_path"`
+	PreviousBinarySHA256 string             `json:"previous_binary_sha256"`
+	CandidatePath        string             `json:"candidate_path"`
+	CandidateSHA256      string             `json:"candidate_sha256"`
+	ExecutableMode       uint32             `json:"executable_mode"`
+	Daemon               DaemonSnapshot     `json:"daemon"`
+	RecoveryJob          RecoveryJob        `json:"recovery_job"`
+	Metadata             []MetadataSnapshot `json:"metadata"`
+	RollbackProgress     RollbackProgress   `json:"rollback_progress,omitempty"`
+	UpdatedAt            time.Time          `json:"updated_at"`
+}
+
+// Transaction is a loaded, validated journal. The mutex only protects callers
+// in one process; TryAcquireRecovery is the cross-process single-actor rule.
+type Transaction struct {
+	mu                      sync.Mutex
+	journal                 Journal
+	afterRollbackCheckpoint func(RollbackProgress) error
+}
+
+// ExecutableRole identifies bytes without granting recovery authority.
+type ExecutableRole uint8
+
+const (
+	ExecutableUnknown ExecutableRole = iota
+	ExecutablePrevious
+	ExecutableCandidate
+)
+
+// RecoveryLease is the kernel-held death test for the upgrade supervisor.
+// Heartbeats aid diagnosis and deadline enforcement by the lock owner, but
+// they never grant another process permission to take over while flock lives.
+type RecoveryLease struct {
+	mu         sync.Mutex
+	file       *os.File
+	path       string
+	txnID      string
+	nonce      string
+	executable string
+	txn        *Transaction
+	released   bool
+}
+
+// RecoveryStatus is the diagnostic handshake written by the live previous-
+// binary actor. The flock, not these fields, decides whether that actor is
+// alive; callers validate both independently.
+type RecoveryStatus struct {
+	SchemaVersion int       `json:"schema_version"`
+	TransactionID string    `json:"transaction_id"`
+	Nonce         string    `json:"nonce"`
+	PID           int       `json:"pid"`
+	ProcessStart  string    `json:"process_start,omitempty"`
+	BootID        string    `json:"boot_id,omitempty"`
+	Executable    string    `json:"executable"`
+	Phase         Phase     `json:"phase"`
+	HeartbeatAt   time.Time `json:"heartbeat_at"`
+	Deadline      time.Time `json:"deadline"`
+}
+
+// Prepare snapshots every rollback input and publishes active.json last. A
+// process crash before publication therefore leaves no transaction that a
+// recovery actor could mistake for complete.
+func Prepare(plan Plan) (_ *Transaction, retErr error) {
+	home, err := canonicalExistingDir(plan.HomeDir)
+	if err != nil {
+		return nil, fmt.Errorf("validate upgrade home: %w", err)
+	}
+	if err := validateTransactionID(plan.ID); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(plan.FromVersion) == "" || strings.TrimSpace(plan.ToVersion) == "" {
+		return nil, errors.New("upgrade versions cannot be blank")
+	}
+	if len(plan.Candidate) == 0 {
+		return nil, errors.New("candidate binary cannot be empty")
+	}
+	nonceBytes := make([]byte, recoveryNonceBytes)
+	if _, err := rand.Read(nonceBytes); err != nil {
+		return nil, fmt.Errorf("generate upgrade recovery nonce: %w", err)
+	}
+
+	executable, err := canonicalExistingFile(plan.ExecutablePath)
+	if err != nil {
+		return nil, fmt.Errorf("validate running executable: %w", err)
+	}
+	executableInfo, err := os.Stat(executable)
+	if err != nil {
+		return nil, fmt.Errorf("stat running executable: %w", err)
+	}
+	if !executableInfo.Mode().IsRegular() {
+		return nil, fmt.Errorf("running executable %s is not a regular file", executable)
+	}
+	previousBinary, err := os.ReadFile(executable)
+	if err != nil {
+		return nil, fmt.Errorf("read running executable: %w", err)
+	}
+
+	root := upgradeRoot(home)
+	if err := os.MkdirAll(root, transactionDirMode); err != nil {
+		return nil, fmt.Errorf("create upgrade root: %w", err)
+	}
+	if err := os.Chmod(root, transactionDirMode); err != nil {
+		return nil, fmt.Errorf("secure upgrade root: %w", err)
+	}
+
+	preparationLock, err := acquireFileLock(filepath.Join(root, "prepare.lock"), false)
+	if err != nil {
+		return nil, fmt.Errorf("lock upgrade preparation: %w", err)
+	}
+	defer func() {
+		retErr = errors.Join(retErr, releaseFileLock(preparationLock))
+	}()
+
+	activePath := activeJournalPath(home)
+	if _, err := os.Lstat(activePath); err == nil {
+		return nil, fmt.Errorf("an upgrade transaction is already active at %s", activePath)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("inspect active upgrade journal: %w", err)
+	}
+
+	txnDir := transactionDir(home, plan.ID)
+	transactionsRoot := filepath.Dir(txnDir)
+	if err := os.MkdirAll(transactionsRoot, transactionDirMode); err != nil {
+		return nil, fmt.Errorf("create transactions root: %w", err)
+	}
+	if err := os.Chmod(transactionsRoot, transactionDirMode); err != nil {
+		return nil, fmt.Errorf("secure transactions root: %w", err)
+	}
+	if err := os.Mkdir(txnDir, transactionDirMode); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return nil, fmt.Errorf("upgrade transaction artifacts already exist for %q", plan.ID)
+		}
+		return nil, fmt.Errorf("create transaction directory: %w", err)
+	}
+	published := false
+	previousPath, candidatePath := binaryArtifactPaths(executable, plan.ID)
+	var createdArtifacts []string
+	defer func() {
+		if published {
+			return
+		}
+		for _, path := range createdArtifacts {
+			_ = os.Remove(path)
+		}
+		_ = os.RemoveAll(txnDir)
+	}()
+
+	for _, path := range []string{previousPath, candidatePath} {
+		if _, err := os.Lstat(path); err == nil {
+			return nil, fmt.Errorf("upgrade binary artifact already exists at %s", path)
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("inspect upgrade binary artifact %s: %w", path, err)
+		}
+	}
+
+	mode := executableInfo.Mode().Perm()
+	if err := config.AtomicWriteFile(previousPath, previousBinary, mode); err != nil {
+		return nil, fmt.Errorf("snapshot previous binary: %w", err)
+	}
+	createdArtifacts = append(createdArtifacts, previousPath)
+	if err := config.AtomicWriteFile(candidatePath, plan.Candidate, mode); err != nil {
+		return nil, fmt.Errorf("stage candidate binary: %w", err)
+	}
+	createdArtifacts = append(createdArtifacts, candidatePath)
+
+	metadata, err := snapshotMetadata(home, txnDir, plan.MetadataPaths)
+	if err != nil {
+		return nil, err
+	}
+
+	journal := Journal{
+		SchemaVersion:        journalSchemaVersion,
+		ID:                   plan.ID,
+		HomeDir:              home,
+		ExecutablePath:       executable,
+		FromVersion:          plan.FromVersion,
+		ToVersion:            plan.ToVersion,
+		Phase:                PhasePrepared,
+		RecoveryNonce:        hex.EncodeToString(nonceBytes),
+		PreviousBinaryPath:   previousPath,
+		PreviousBinarySHA256: digest(previousBinary),
+		CandidatePath:        candidatePath,
+		CandidateSHA256:      digest(plan.Candidate),
+		ExecutableMode:       uint32(mode),
+		Daemon:               plan.Daemon,
+		RecoveryJob:          plan.RecoveryJob,
+		Metadata:             metadata,
+		UpdatedAt:            time.Now().UTC(),
+	}
+	if err := validateJournal(home, journal); err != nil {
+		return nil, fmt.Errorf("validate prepared journal: %w", err)
+	}
+	if err := persistJournal(activePath, journal); err != nil {
+		return nil, fmt.Errorf("publish upgrade journal: %w", err)
+	}
+	published = true
+	return &Transaction{journal: journal}, nil
+}
+
+// Load validates the active journal and every derived path before returning
+// anything that can mutate the filesystem.
+func Load(homeDir string) (*Transaction, error) {
+	home, err := canonicalExistingDir(homeDir)
+	if err != nil {
+		return nil, fmt.Errorf("validate upgrade home: %w", err)
+	}
+	journal, err := readJournal(activeJournalPath(home))
+	if err != nil {
+		return nil, err
+	}
+	if err := validateJournal(home, journal); err != nil {
+		return nil, fmt.Errorf("validate active upgrade journal: %w", err)
+	}
+	return &Transaction{journal: journal}, nil
+}
+
+// ReadRecoveryStatus validates the live actor's diagnostic handshake. It does
+// not claim the actor is alive; callers must separately observe the kernel
+// lock through RecoveryActorLive because timestamps and PIDs are never death
+// authority.
+func ReadRecoveryStatus(homeDir string) (RecoveryStatus, error) {
+	txn, err := Load(homeDir)
+	if err != nil {
+		return RecoveryStatus{}, err
+	}
+	journal := txn.Journal()
+	return readRecoveryStatusForJournal(journal)
+}
+
+func readRecoveryStatusForJournal(journal Journal) (RecoveryStatus, error) {
+	path := filepath.Join(transactionDir(journal.HomeDir, journal.ID), "recovery.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return RecoveryStatus{}, fmt.Errorf("read upgrade recovery status: %w", err)
+	}
+	var status RecoveryStatus
+	if err := json.Unmarshal(data, &status); err != nil {
+		return RecoveryStatus{}, fmt.Errorf("decode upgrade recovery status: %w", err)
+	}
+	if status.SchemaVersion != journalSchemaVersion ||
+		status.TransactionID != journal.ID ||
+		status.Nonce != journal.RecoveryNonce ||
+		status.PID <= 0 ||
+		!validPhase(status.Phase) ||
+		status.HeartbeatAt.IsZero() ||
+		status.Deadline.IsZero() {
+		return RecoveryStatus{}, errors.New("upgrade recovery status does not match the active transaction")
+	}
+	executable, err := canonicalExistingFile(status.Executable)
+	if err != nil || executable != journal.PreviousBinaryPath {
+		return RecoveryStatus{}, errors.New("upgrade recovery status is not from the preserved previous binary")
+	}
+	return status, nil
+}
+
+// Journal returns a copy suitable for health reporting and diagnostics.
+func (t *Transaction) Journal() Journal {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	journal := t.journal
+	journal.Metadata = append([]MetadataSnapshot(nil), t.journal.Metadata...)
+	return journal
+}
+
+// RoleForExecutable hashes a regular executable and compares it with the two
+// immutable transaction identities. This lets an entrypoint distinguish a
+// canonical candidate daemon from a canonical previous daemon after rollback;
+// it does not grant a RecoveryLease.
+func (t *Transaction) RoleForExecutable(path string) (ExecutableRole, error) {
+	canonical, err := canonicalExistingFile(path)
+	if err != nil {
+		return ExecutableUnknown, fmt.Errorf("validate upgrade executable role: %w", err)
+	}
+	data, err := os.ReadFile(canonical)
+	if err != nil {
+		return ExecutableUnknown, fmt.Errorf("read upgrade executable role: %w", err)
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	switch digest(data) {
+	case t.journal.PreviousBinarySHA256:
+		return ExecutablePrevious, nil
+	case t.journal.CandidateSHA256:
+		return ExecutableCandidate, nil
+	default:
+		return ExecutableUnknown, nil
+	}
+}
+
+// RecoveryActorLive reports only the kernel lock fact. A false result is a
+// point-in-time observation; the caller must still race safely when waking a
+// previous-binary takeover actor.
+func (t *Transaction) RecoveryActorLive() (bool, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if err := t.ensureRecoveryLockDirectoryLocked(); err != nil {
+		return false, err
+	}
+	lockPath := filepath.Join(transactionDir(t.journal.HomeDir, t.journal.ID), "recovery.lock")
+	file, err := acquireFileLock(lockPath, true)
+	if errors.Is(err, ErrRecoveryActive) {
+		return true, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("probe upgrade recovery lock: %w", err)
+	}
+	return false, releaseFileLock(file)
+}
+
+// AuthorizeActivation completes the old process -> previous-binary actor nonce
+// handshake. It succeeds only while a recovery actor holds the kernel lock and
+// its validated status reports supervisor_ready for this exact transaction.
+func (t *Transaction) AuthorizeActivation(transactionID, nonce string) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	current, err := readJournal(activeJournalPath(t.journal.HomeDir))
+	if err != nil {
+		return err
+	}
+	if err := validateJournal(t.journal.HomeDir, current); err != nil {
+		return err
+	}
+	if current.ID != transactionID || current.RecoveryNonce != nonce {
+		return errors.New("upgrade activation handshake does not match the active transaction")
+	}
+	if current.Phase != PhaseSupervisorReady {
+		return fmt.Errorf("upgrade supervisor is not ready for activation (phase %s)", current.Phase)
+	}
+	lockPath := filepath.Join(transactionDir(current.HomeDir, current.ID), "recovery.lock")
+	probe, err := acquireFileLock(lockPath, true)
+	if err == nil {
+		_ = releaseFileLock(probe)
+		return errors.New("upgrade activation cannot be authorized without a live recovery actor")
+	}
+	if !errors.Is(err, ErrRecoveryActive) {
+		return fmt.Errorf("verify recovery actor before activation: %w", err)
+	}
+	status, err := readRecoveryStatusForJournal(current)
+	if err != nil {
+		return err
+	}
+	if status.Phase != PhaseSupervisorReady {
+		return fmt.Errorf("upgrade recovery actor has not reached supervisor_ready (status %s)", status.Phase)
+	}
+	approvalPath := filepath.Join(transactionDir(current.HomeDir, current.ID), "activation.approved")
+	if err := config.AtomicWriteFile(approvalPath, []byte(current.RecoveryNonce+"\n"), journalFileMode); err != nil {
+		return fmt.Errorf("persist upgrade activation approval: %w", err)
+	}
+	t.journal = current
+	return nil
+}
+
+// ActivationAuthorized is read by the previous-binary actor before it stops
+// the old daemon. A missing file is a normal not-yet result; mismatched content
+// is a hard error rather than permission to proceed.
+func (t *Transaction) ActivationAuthorized() (bool, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	path := filepath.Join(transactionDir(t.journal.HomeDir, t.journal.ID), "activation.approved")
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("read upgrade activation approval: %w", err)
+	}
+	if strings.TrimSpace(string(data)) != t.journal.RecoveryNonce {
+		return false, errors.New("upgrade activation approval nonce does not match the transaction")
+	}
+	return true, nil
+}
+
+// Advance persists a state-machine boundary that does not itself modify the
+// candidate or rollback inputs.
+func (t *Transaction) advance(next Phase) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.journal.Phase == next {
+		return nil
+	}
+	allowed := map[Phase]Phase{
+		PhasePrepared:           PhaseSupervisorReady,
+		PhaseSupervisorReady:    PhaseDaemonStopped,
+		PhaseCandidateInstalled: PhaseCandidateStarting,
+		PhaseCandidateStarting:  PhaseCandidateValidating,
+		PhaseRollbackRestored:   PhasePreviousStarting,
+		PhasePreviousStarting:   PhasePreviousValidating,
+		PhasePreviousValidating: PhaseRolledBack,
+	}
+	if allowed[t.journal.Phase] != next {
+		return fmt.Errorf("invalid upgrade phase transition %s -> %s", t.journal.Phase, next)
+	}
+	return t.persistPhaseLocked(next)
+}
+
+// InstallCandidate atomically replaces the executable only after the durable
+// journal proves the previous daemon was stopped. If the process died after
+// rename but before phase persistence, the candidate hash makes retry safe.
+func (t *Transaction) installCandidate() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.journal.Phase == PhaseCandidateInstalled {
+		return t.verifyInstalledCandidateLocked()
+	}
+	if t.journal.Phase != PhaseDaemonStopped {
+		return fmt.Errorf("cannot install candidate from upgrade phase %s", t.journal.Phase)
+	}
+	previous, err := readAndVerify(t.journal.PreviousBinaryPath, t.journal.PreviousBinarySHA256)
+	if err != nil {
+		return fmt.Errorf("verify previous binary snapshot: %w", err)
+	}
+	candidate, err := readAndVerify(t.journal.CandidatePath, t.journal.CandidateSHA256)
+	if err != nil {
+		return fmt.Errorf("verify candidate binary: %w", err)
+	}
+	current, err := os.ReadFile(t.journal.ExecutablePath)
+	if err != nil {
+		return fmt.Errorf("read installed executable: %w", err)
+	}
+	switch digest(current) {
+	case t.journal.CandidateSHA256:
+		// Resume after the atomic rename but before phase persistence.
+	case t.journal.PreviousBinarySHA256:
+		if digest(previous) != t.journal.PreviousBinarySHA256 {
+			return errors.New("previous binary snapshot changed during install")
+		}
+		if err := config.AtomicWriteFile(
+			t.journal.ExecutablePath, candidate, os.FileMode(t.journal.ExecutableMode)); err != nil {
+			return fmt.Errorf("install candidate binary: %w", err)
+		}
+	default:
+		return errors.New("installed executable matches neither the previous nor candidate binary")
+	}
+	return t.persistPhaseLocked(PhaseCandidateInstalled)
+}
+
+func (t *Transaction) verifyInstalledCandidateLocked() error {
+	_, err := readAndVerify(t.journal.ExecutablePath, t.journal.CandidateSHA256)
+	if err != nil {
+		return fmt.Errorf("verify installed candidate: %w", err)
+	}
+	return nil
+}
+
+// Commit records the validation verdict durably before Cleanup may remove any
+// rollback material.
+func (t *Transaction) commit() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.journal.Phase == PhaseCommitted {
+		return nil
+	}
+	if t.journal.Phase != PhaseCandidateValidating {
+		return fmt.Errorf("cannot commit upgrade from phase %s", t.journal.Phase)
+	}
+	if err := t.verifyInstalledCandidateLocked(); err != nil {
+		return err
+	}
+	return t.persistPhaseLocked(PhaseCommitted)
+}
+
+// abort records that activation ended before the previous daemon stopped.
+// It deliberately restores nothing: overwriting metadata while the proven
+// live previous daemon may still be writing it would turn a safe refusal into
+// data loss.
+func (t *Transaction) abort() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.journal.Phase == PhaseAborted {
+		return nil
+	}
+	if t.journal.Phase != PhasePrepared && t.journal.Phase != PhaseSupervisorReady {
+		return fmt.Errorf("cannot abort upgrade from phase %s", t.journal.Phase)
+	}
+	return t.persistPhaseLocked(PhaseAborted)
+}
+
+// Rollback restores the binary, every metadata snapshot, and every recorded
+// absence. Artifacts remain until a caller proves the previous daemon healthy
+// and explicitly invokes Cleanup.
+func (t *Transaction) rollback() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	switch t.journal.Phase {
+	case PhaseRollbackRestored, PhasePreviousStarting, PhasePreviousValidating, PhaseRolledBack:
+		return nil
+	case PhaseCommitted:
+		return errors.New("cannot roll back a committed upgrade")
+	case PhaseRollingBack:
+		// Resume an interrupted restoration.
+	default:
+		if err := t.persistPhaseLocked(PhaseRollingBack); err != nil {
+			return err
+		}
+	}
+
+	if err := t.restoreLocked(); err != nil {
+		if errors.Is(err, errRecoveryCheckpointInterrupted) {
+			return err
+		}
+		phaseErr := t.persistPhaseLocked(PhaseRollbackFailed)
+		return errors.Join(err, phaseErr)
+	}
+	return t.persistPhaseLocked(PhaseRollbackRestored)
+}
+
+func (t *Transaction) restoreLocked() error {
+	if !t.journal.RollbackProgress.BinaryRestored {
+		previous, err := readAndVerify(t.journal.PreviousBinaryPath, t.journal.PreviousBinarySHA256)
+		if err != nil {
+			return fmt.Errorf("verify previous binary snapshot: %w", err)
+		}
+		if err := config.AtomicWriteFile(
+			t.journal.ExecutablePath, previous, os.FileMode(t.journal.ExecutableMode)); err != nil {
+			return fmt.Errorf("restore previous binary: %w", err)
+		}
+		journal := t.journal
+		journal.RollbackProgress.BinaryRestored = true
+		if err := t.persistJournalLocked(journal); err != nil {
+			return fmt.Errorf("checkpoint restored previous binary: %w", err)
+		}
+		if t.afterRollbackCheckpoint != nil {
+			if err := t.afterRollbackCheckpoint(t.journal.RollbackProgress); err != nil {
+				return err
+			}
+		}
+	}
+
+	for index := t.journal.RollbackProgress.MetadataRestored; index < len(t.journal.Metadata); index++ {
+		metadata := t.journal.Metadata[index]
+		target := filepath.Join(t.journal.HomeDir, metadata.Path)
+		if err := ensureNoSymlinkParents(t.journal.HomeDir, target); err != nil {
+			return fmt.Errorf("validate rollback path %s: %w", metadata.Path, err)
+		}
+		if !metadata.Existed {
+			if err := os.Remove(target); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("restore absence of %s: %w", metadata.Path, err)
+			}
+		} else {
+			data, err := readAndVerify(metadata.SnapshotPath, metadata.SHA256)
+			if err != nil {
+				return fmt.Errorf("verify metadata snapshot %s: %w", metadata.Path, err)
+			}
+			if err := config.AtomicWriteFile(target, data, os.FileMode(metadata.Mode)); err != nil {
+				return fmt.Errorf("restore metadata %s: %w", metadata.Path, err)
+			}
+		}
+		journal := t.journal
+		journal.RollbackProgress.MetadataRestored = index + 1
+		if err := t.persistJournalLocked(journal); err != nil {
+			return fmt.Errorf("checkpoint restored metadata %s: %w", metadata.Path, err)
+		}
+		if t.afterRollbackCheckpoint != nil {
+			if err := t.afterRollbackCheckpoint(t.journal.RollbackProgress); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// Cleanup removes only paths re-derived from a validated terminal journal and
+// removes active.json last. A crash during cleanup therefore resumes cleanup;
+// it can never reinterpret a committed candidate as needing rollback.
+func (t *Transaction) cleanup() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.journal.Phase != PhaseCommitted &&
+		t.journal.Phase != PhaseRolledBack &&
+		t.journal.Phase != PhaseAborted {
+		return fmt.Errorf("cannot clean up upgrade in phase %s", t.journal.Phase)
+	}
+
+	current, err := readJournal(activeJournalPath(t.journal.HomeDir))
+	if errors.Is(err, ErrNoActiveTransaction) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if err := validateJournal(t.journal.HomeDir, current); err != nil {
+		return fmt.Errorf("validate journal before cleanup: %w", err)
+	}
+	if current.ID != t.journal.ID || current.Phase != t.journal.Phase {
+		return errors.New("active upgrade transaction changed before cleanup")
+	}
+
+	for _, path := range []string{t.journal.PreviousBinaryPath, t.journal.CandidatePath} {
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("remove upgrade artifact %s: %w", path, err)
+		}
+	}
+	if err := os.RemoveAll(transactionDir(t.journal.HomeDir, t.journal.ID)); err != nil {
+		return fmt.Errorf("remove upgrade transaction directory: %w", err)
+	}
+	activePath := activeJournalPath(t.journal.HomeDir)
+	if err := os.Remove(activePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove active upgrade journal: %w", err)
+	}
+	return syncDirectory(filepath.Dir(activePath))
+}
+
+// TryAcquireRecovery obtains the only authority to advance or recover this
+// transaction. It never waits: callers that lose the race must leave the live
+// supervisor alone.
+func (t *Transaction) TryAcquireRecovery() (*RecoveryLease, error) {
+	executable, err := os.Executable()
+	if err != nil {
+		return nil, fmt.Errorf("resolve upgrade recovery executable: %w", err)
+	}
+	return t.tryAcquireRecoveryAs(executable)
+}
+
+// tryAcquireRecoveryAs is the test seam for the structural actor check.
+// Production has only TryAcquireRecovery, which supplies os.Executable and
+// therefore cannot nominate some other path on the candidate's behalf.
+func (t *Transaction) tryAcquireRecoveryAs(actorExecutable string) (*RecoveryLease, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if err := t.ensureRecoveryLockDirectoryLocked(); err != nil {
+		return nil, err
+	}
+	lockPath := filepath.Join(transactionDir(t.journal.HomeDir, t.journal.ID), "recovery.lock")
+	file, err := acquireFileLock(lockPath, true)
+	if err != nil {
+		if errors.Is(err, ErrRecoveryActive) {
+			return nil, err
+		}
+		return nil, fmt.Errorf("acquire upgrade recovery lock: %w", err)
+	}
+	// Load happened before the flock and may be arbitrarily stale. Refresh only
+	// after becoming the single recovery actor so a takeover resumes the last
+	// fsynced phase rather than publishing an older in-memory phase over it.
+	current, err := readJournal(activeJournalPath(t.journal.HomeDir))
+	if err != nil {
+		_ = releaseFileLock(file)
+		return nil, fmt.Errorf("reload upgrade journal after recovery lock: %w", err)
+	}
+	if err := validateJournal(t.journal.HomeDir, current); err != nil {
+		_ = releaseFileLock(file)
+		return nil, fmt.Errorf("validate upgrade journal after recovery lock: %w", err)
+	}
+	if current.ID != t.journal.ID {
+		_ = releaseFileLock(file)
+		return nil, errors.New("active upgrade transaction changed before recovery lock acquisition")
+	}
+	t.journal = current
+	actorPath, err := canonicalExistingFile(actorExecutable)
+	if err != nil {
+		_ = releaseFileLock(file)
+		return nil, fmt.Errorf("validate upgrade recovery actor: %w", err)
+	}
+	if actorPath != t.journal.PreviousBinaryPath {
+		_ = releaseFileLock(file)
+		return nil, fmt.Errorf("%w: got %s", ErrRecoveryActorMismatch, actorPath)
+	}
+	if _, err := readAndVerify(actorPath, t.journal.PreviousBinarySHA256); err != nil {
+		_ = releaseFileLock(file)
+		return nil, fmt.Errorf("%w: %v", ErrRecoveryActorMismatch, err)
+	}
+	return &RecoveryLease{
+		file:       file,
+		path:       filepath.Join(filepath.Dir(lockPath), "recovery.json"),
+		txnID:      t.journal.ID,
+		nonce:      t.journal.RecoveryNonce,
+		executable: actorPath,
+		txn:        t,
+	}, nil
+}
+
+// ensureRecoveryLockDirectoryLocked makes terminal cleanup recoverable across
+// the narrow crash boundary where a previous actor removed the transaction
+// directory but died before removing active.json. Nonterminal transactions
+// never recreate missing rollback storage: losing that storage is a hard error.
+func (t *Transaction) ensureRecoveryLockDirectoryLocked() error {
+	txnDir := transactionDir(t.journal.HomeDir, t.journal.ID)
+	info, err := os.Lstat(txnDir)
+	if err == nil {
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return errors.New("upgrade transaction lock path is not a directory")
+		}
+		return nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect upgrade transaction lock directory: %w", err)
+	}
+
+	current, err := readJournal(activeJournalPath(t.journal.HomeDir))
+	if err != nil {
+		return fmt.Errorf("read terminal journal before recreating recovery lock: %w", err)
+	}
+	if err := validateJournal(t.journal.HomeDir, current); err != nil {
+		return fmt.Errorf("validate terminal journal before recreating recovery lock: %w", err)
+	}
+	if current.ID != t.journal.ID {
+		return errors.New("active upgrade transaction changed before recovery lock recreation")
+	}
+	if current.Phase != PhaseCommitted && current.Phase != PhaseRolledBack && current.Phase != PhaseAborted {
+		return fmt.Errorf("recovery storage is missing in nonterminal phase %s", current.Phase)
+	}
+	parent := filepath.Dir(txnDir)
+	if err := os.MkdirAll(parent, transactionDirMode); err != nil {
+		return fmt.Errorf("recreate transactions root for terminal cleanup: %w", err)
+	}
+	if err := os.Chmod(parent, transactionDirMode); err != nil {
+		return fmt.Errorf("secure recreated transactions root: %w", err)
+	}
+	if err := os.Mkdir(txnDir, transactionDirMode); err != nil && !errors.Is(err, os.ErrExist) {
+		return fmt.Errorf("recreate terminal transaction lock directory: %w", err)
+	}
+	info, err = os.Lstat(txnDir)
+	if err != nil {
+		return fmt.Errorf("inspect recreated transaction lock directory: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return errors.New("recreated upgrade transaction lock path is not a directory")
+	}
+	t.journal = current
+	return nil
+}
+
+// Advance records a state-machine boundary while this lease owns recovery.
+func (l *RecoveryLease) Advance(next Phase) error {
+	return l.withTransaction(func(txn *Transaction) error { return txn.advance(next) })
+}
+
+// InstallCandidate atomically replaces the executable after DaemonStopped.
+func (l *RecoveryLease) InstallCandidate() error {
+	return l.withTransaction(func(txn *Transaction) error { return txn.installCandidate() })
+}
+
+// Commit persists the candidate validation verdict before cleanup.
+func (l *RecoveryLease) Commit() error {
+	return l.withTransaction(func(txn *Transaction) error { return txn.commit() })
+}
+
+// Rollback restores the previous binary and metadata snapshots.
+func (l *RecoveryLease) Rollback() error {
+	return l.withTransaction(func(txn *Transaction) error { return txn.rollback() })
+}
+
+// Cleanup removes terminal transaction artifacts.
+func (l *RecoveryLease) Cleanup() error {
+	return l.withTransaction(func(txn *Transaction) error { return txn.cleanup() })
+}
+
+// Abort terminates activation before the previous daemon stopped, without
+// restoring binary or metadata over that still-live owner.
+func (l *RecoveryLease) Abort() error {
+	return l.withTransaction(func(txn *Transaction) error { return txn.abort() })
+}
+
+func (l *RecoveryLease) withTransaction(action func(*Transaction) error) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.released || l.file == nil || l.txn == nil {
+		return errors.New("upgrade recovery lease is released")
+	}
+	return action(l.txn)
+}
+
+// Heartbeat records diagnostics and the lock owner's own deadline. The lease's
+// open file descriptor, not this timestamp, remains the takeover authority.
+func (l *RecoveryLease) Heartbeat(phase Phase, deadline time.Time) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.released || l.file == nil {
+		return errors.New("upgrade recovery lease is released")
+	}
+	heartbeat := RecoveryStatus{
+		SchemaVersion: journalSchemaVersion,
+		TransactionID: l.txnID,
+		Nonce:         l.nonce,
+		PID:           os.Getpid(),
+		ProcessStart:  processStartIdentity(),
+		BootID:        kernelBootID(),
+		Executable:    l.executable,
+		Phase:         phase,
+		HeartbeatAt:   time.Now().UTC(),
+		Deadline:      deadline.UTC(),
+	}
+	data, err := json.MarshalIndent(heartbeat, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode recovery heartbeat: %w", err)
+	}
+	data = append(data, '\n')
+	if err := config.AtomicWriteFile(l.path, data, journalFileMode); err != nil {
+		return fmt.Errorf("persist recovery heartbeat: %w", err)
+	}
+	return nil
+}
+
+// Release relinquishes the kernel death test. It is idempotent.
+func (l *RecoveryLease) Release() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.released {
+		return nil
+	}
+	l.released = true
+	err := releaseFileLock(l.file)
+	l.file = nil
+	return err
+}
+
+func (t *Transaction) persistPhaseLocked(phase Phase) error {
+	journal := t.journal
+	journal.Phase = phase
+	return t.persistJournalLocked(journal)
+}
+
+func (t *Transaction) persistJournalLocked(journal Journal) error {
+	journal.UpdatedAt = time.Now().UTC()
+	if err := persistJournal(activeJournalPath(journal.HomeDir), journal); err != nil {
+		return fmt.Errorf("persist upgrade phase %s: %w", journal.Phase, err)
+	}
+	t.journal = journal
+	return nil
+}

--- a/internal/upgradetxn/transaction.go
+++ b/internal/upgradetxn/transaction.go
@@ -15,8 +15,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/sachiniyer/agent-factory/config"
 )
 
 const (
@@ -151,14 +149,22 @@ type RecoveryJob struct {
 	UnitPath string          `json:"unit_path,omitempty"`
 }
 
+// MetadataParentSnapshot preserves the permissions of a metadata file's
+// pre-existing parent directories so rollback never recreates them as 0755.
+type MetadataParentSnapshot struct {
+	Path string `json:"path"`
+	Mode uint32 `json:"mode"`
+}
+
 // MetadataSnapshot describes one rollback input. SnapshotPath is empty when
 // the metadata file did not exist at prepare time.
 type MetadataSnapshot struct {
-	Path         string `json:"path"`
-	Existed      bool   `json:"existed"`
-	Mode         uint32 `json:"mode,omitempty"`
-	SHA256       string `json:"sha256,omitempty"`
-	SnapshotPath string `json:"snapshot_path,omitempty"`
+	Path         string                   `json:"path"`
+	Existed      bool                     `json:"existed"`
+	Mode         uint32                   `json:"mode,omitempty"`
+	SHA256       string                   `json:"sha256,omitempty"`
+	SnapshotPath string                   `json:"snapshot_path,omitempty"`
+	Parents      []MetadataParentSnapshot `json:"parents,omitempty"`
 }
 
 // Journal is the fsynced recovery authority. Artifact paths are recorded for
@@ -274,11 +280,8 @@ func Prepare(plan Plan) (_ *Transaction, retErr error) {
 	}
 
 	root := upgradeRoot(home)
-	if err := os.MkdirAll(root, transactionDirMode); err != nil {
-		return nil, fmt.Errorf("create upgrade root: %w", err)
-	}
-	if err := os.Chmod(root, transactionDirMode); err != nil {
-		return nil, fmt.Errorf("secure upgrade root: %w", err)
+	if err := ensureDurableDirectory(home, root, transactionDirMode); err != nil {
+		return nil, fmt.Errorf("prepare upgrade root: %w", err)
 	}
 
 	preparationLock, err := acquireFileLock(filepath.Join(root, "prepare.lock"), false)
@@ -298,16 +301,14 @@ func Prepare(plan Plan) (_ *Transaction, retErr error) {
 
 	txnDir := transactionDir(home, plan.ID)
 	transactionsRoot := filepath.Dir(txnDir)
-	if err := os.MkdirAll(transactionsRoot, transactionDirMode); err != nil {
-		return nil, fmt.Errorf("create transactions root: %w", err)
+	if err := ensureDurableDirectory(root, transactionsRoot, transactionDirMode); err != nil {
+		return nil, fmt.Errorf("prepare transactions root: %w", err)
 	}
-	if err := os.Chmod(transactionsRoot, transactionDirMode); err != nil {
-		return nil, fmt.Errorf("secure transactions root: %w", err)
-	}
-	if err := os.Mkdir(txnDir, transactionDirMode); err != nil {
+	if err := createDurableDirectory(transactionsRoot, txnDir, transactionDirMode); err != nil {
 		if errors.Is(err, os.ErrExist) {
 			return nil, fmt.Errorf("upgrade transaction artifacts already exist for %q", plan.ID)
 		}
+		_ = os.Remove(txnDir)
 		return nil, fmt.Errorf("create transaction directory: %w", err)
 	}
 	published := false
@@ -322,6 +323,10 @@ func Prepare(plan Plan) (_ *Transaction, retErr error) {
 		}
 		_ = os.RemoveAll(txnDir)
 	}()
+	metadataDir := filepath.Join(txnDir, "metadata")
+	if err := createDurableDirectory(txnDir, metadataDir, transactionDirMode); err != nil {
+		return nil, fmt.Errorf("create metadata snapshot directory: %w", err)
+	}
 
 	for _, path := range []string{previousPath, candidatePath} {
 		if _, err := os.Lstat(path); err == nil {
@@ -332,14 +337,14 @@ func Prepare(plan Plan) (_ *Transaction, retErr error) {
 	}
 
 	mode := executableInfo.Mode().Perm()
-	if err := config.AtomicWriteFile(previousPath, previousBinary, mode); err != nil {
+	createdArtifacts = append(createdArtifacts, previousPath)
+	if err := durableAtomicWriteFile(previousPath, previousBinary, mode); err != nil {
 		return nil, fmt.Errorf("snapshot previous binary: %w", err)
 	}
-	createdArtifacts = append(createdArtifacts, previousPath)
-	if err := config.AtomicWriteFile(candidatePath, plan.Candidate, mode); err != nil {
+	createdArtifacts = append(createdArtifacts, candidatePath)
+	if err := durableAtomicWriteFile(candidatePath, plan.Candidate, mode); err != nil {
 		return nil, fmt.Errorf("stage candidate binary: %w", err)
 	}
-	createdArtifacts = append(createdArtifacts, candidatePath)
 
 	metadata, err := snapshotMetadata(home, txnDir, plan.MetadataPaths)
 	if err != nil {
@@ -369,6 +374,9 @@ func Prepare(plan Plan) (_ *Transaction, retErr error) {
 		return nil, fmt.Errorf("validate prepared journal: %w", err)
 	}
 	if err := persistJournal(activePath, journal); err != nil {
+		if _, statErr := os.Lstat(activePath); statErr == nil {
+			published = true
+		}
 		return nil, fmt.Errorf("publish upgrade journal: %w", err)
 	}
 	published = true
@@ -437,6 +445,10 @@ func (t *Transaction) Journal() Journal {
 	defer t.mu.Unlock()
 	journal := t.journal
 	journal.Metadata = append([]MetadataSnapshot(nil), t.journal.Metadata...)
+	for index := range journal.Metadata {
+		journal.Metadata[index].Parents = append(
+			[]MetadataParentSnapshot(nil), journal.Metadata[index].Parents...)
+	}
 	return journal
 }
 
@@ -524,7 +536,7 @@ func (t *Transaction) AuthorizeActivation(transactionID, nonce string) error {
 		return fmt.Errorf("upgrade recovery actor's supervisor_ready deadline expired at %s", status.Deadline.Format(time.RFC3339Nano))
 	}
 	approvalPath := filepath.Join(transactionDir(current.HomeDir, current.ID), "activation.approved")
-	if err := config.AtomicWriteFile(approvalPath, []byte(current.RecoveryNonce+"\n"), journalFileMode); err != nil {
+	if err := durableAtomicWriteFile(approvalPath, []byte(current.RecoveryNonce+"\n"), journalFileMode); err != nil {
 		return fmt.Errorf("persist upgrade activation approval: %w", err)
 	}
 	t.journal = current
@@ -605,7 +617,7 @@ func (t *Transaction) installCandidate() error {
 		if digest(previous) != t.journal.PreviousBinarySHA256 {
 			return errors.New("previous binary snapshot changed during install")
 		}
-		if err := config.AtomicWriteFile(
+		if err := durableAtomicWriteFile(
 			t.journal.ExecutablePath, candidate, os.FileMode(t.journal.ExecutableMode)); err != nil {
 			return fmt.Errorf("install candidate binary: %w", err)
 		}
@@ -669,10 +681,12 @@ func (t *Transaction) rollback() error {
 		return errors.New("cannot roll back a committed upgrade")
 	case PhaseRollingBack:
 		// Resume an interrupted restoration.
-	default:
+	case PhaseDaemonStopped, PhaseCandidateInstalled, PhaseCandidateStarting, PhaseCandidateValidating:
 		if err := t.persistPhaseLocked(PhaseRollingBack); err != nil {
 			return err
 		}
+	default:
+		return fmt.Errorf("cannot roll back upgrade from phase %s", t.journal.Phase)
 	}
 
 	if err := t.restoreLocked(); err != nil {
@@ -691,7 +705,7 @@ func (t *Transaction) restoreLocked() error {
 		if err != nil {
 			return fmt.Errorf("verify previous binary snapshot: %w", err)
 		}
-		if err := config.AtomicWriteFile(
+		if err := durableAtomicWriteFile(
 			t.journal.ExecutablePath, previous, os.FileMode(t.journal.ExecutableMode)); err != nil {
 			return fmt.Errorf("restore previous binary: %w", err)
 		}
@@ -709,22 +723,8 @@ func (t *Transaction) restoreLocked() error {
 
 	for index := t.journal.RollbackProgress.MetadataRestored; index < len(t.journal.Metadata); index++ {
 		metadata := t.journal.Metadata[index]
-		target := filepath.Join(t.journal.HomeDir, metadata.Path)
-		if err := ensureNoSymlinkParents(t.journal.HomeDir, target); err != nil {
-			return fmt.Errorf("validate rollback path %s: %w", metadata.Path, err)
-		}
-		if !metadata.Existed {
-			if err := os.Remove(target); err != nil && !errors.Is(err, os.ErrNotExist) {
-				return fmt.Errorf("restore absence of %s: %w", metadata.Path, err)
-			}
-		} else {
-			data, err := readAndVerify(metadata.SnapshotPath, metadata.SHA256)
-			if err != nil {
-				return fmt.Errorf("verify metadata snapshot %s: %w", metadata.Path, err)
-			}
-			if err := config.AtomicWriteFile(target, data, os.FileMode(metadata.Mode)); err != nil {
-				return fmt.Errorf("restore metadata %s: %w", metadata.Path, err)
-			}
+		if err := restoreMetadataEntry(t.journal.HomeDir, metadata); err != nil {
+			return err
 		}
 		journal := t.journal
 		journal.RollbackProgress.MetadataRestored = index + 1
@@ -738,47 +738,6 @@ func (t *Transaction) restoreLocked() error {
 		}
 	}
 	return nil
-}
-
-// Cleanup removes only paths re-derived from a validated terminal journal and
-// removes active.json last. A crash during cleanup therefore resumes cleanup;
-// it can never reinterpret a committed candidate as needing rollback.
-func (t *Transaction) cleanup() error {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	if t.journal.Phase != PhaseCommitted &&
-		t.journal.Phase != PhaseRolledBack &&
-		t.journal.Phase != PhaseAborted {
-		return fmt.Errorf("cannot clean up upgrade in phase %s", t.journal.Phase)
-	}
-
-	current, err := readJournal(activeJournalPath(t.journal.HomeDir))
-	if errors.Is(err, ErrNoActiveTransaction) {
-		return nil
-	}
-	if err != nil {
-		return err
-	}
-	if err := validateJournal(t.journal.HomeDir, current); err != nil {
-		return fmt.Errorf("validate journal before cleanup: %w", err)
-	}
-	if current.ID != t.journal.ID || current.Phase != t.journal.Phase {
-		return errors.New("active upgrade transaction changed before cleanup")
-	}
-
-	for _, path := range []string{t.journal.PreviousBinaryPath, t.journal.CandidatePath} {
-		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("remove upgrade artifact %s: %w", path, err)
-		}
-	}
-	if err := os.RemoveAll(transactionDir(t.journal.HomeDir, t.journal.ID)); err != nil {
-		return fmt.Errorf("remove upgrade transaction directory: %w", err)
-	}
-	activePath := activeJournalPath(t.journal.HomeDir)
-	if err := os.Remove(activePath); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("remove active upgrade journal: %w", err)
-	}
-	return syncDirectory(filepath.Dir(activePath))
 }
 
 // TryAcquireRecovery obtains the only authority to advance or recover this
@@ -880,13 +839,10 @@ func (t *Transaction) ensureRecoveryLockDirectoryLocked() error {
 		return fmt.Errorf("recovery storage is missing in nonterminal phase %s", current.Phase)
 	}
 	parent := filepath.Dir(txnDir)
-	if err := os.MkdirAll(parent, transactionDirMode); err != nil {
-		return fmt.Errorf("recreate transactions root for terminal cleanup: %w", err)
+	if err := validateDirectoryNoSymlink(parent); err != nil {
+		return fmt.Errorf("validate transactions root for terminal cleanup: %w", err)
 	}
-	if err := os.Chmod(parent, transactionDirMode); err != nil {
-		return fmt.Errorf("secure recreated transactions root: %w", err)
-	}
-	if err := os.Mkdir(txnDir, transactionDirMode); err != nil && !errors.Is(err, os.ErrExist) {
+	if err := createDurableDirectory(parent, txnDir, transactionDirMode); err != nil && !errors.Is(err, os.ErrExist) {
 		return fmt.Errorf("recreate terminal transaction lock directory: %w", err)
 	}
 	info, err = os.Lstat(txnDir)
@@ -965,7 +921,7 @@ func (l *RecoveryLease) Heartbeat(phase Phase, deadline time.Time) error {
 		return fmt.Errorf("encode recovery heartbeat: %w", err)
 	}
 	data = append(data, '\n')
-	if err := config.AtomicWriteFile(l.path, data, journalFileMode); err != nil {
+	if err := durableAtomicWriteFile(l.path, data, journalFileMode); err != nil {
 		return fmt.Errorf("persist recovery heartbeat: %w", err)
 	}
 	return nil

--- a/internal/upgradetxn/transaction.go
+++ b/internal/upgradetxn/transaction.go
@@ -76,6 +76,14 @@ type RollbackProgress struct {
 	MetadataRestored int  `json:"metadata_restored"`
 }
 
+// FileIdentity pins a durable lock pathname to the inode created before the
+// transaction is published. A lock held on an unlinked inode cannot protect a
+// replacement pathname, so every recovery acquisition verifies both values.
+type FileIdentity struct {
+	Device uint64 `json:"device"`
+	Inode  uint64 `json:"inode"`
+}
+
 // Plan contains all bytes and paths whose pre-upgrade state must be captured
 // before the transaction becomes visible to another process.
 type Plan struct {
@@ -179,6 +187,7 @@ type Journal struct {
 	ToVersion            string             `json:"to_version"`
 	Phase                Phase              `json:"phase"`
 	RecoveryNonce        string             `json:"recovery_nonce"`
+	RecoveryLockIdentity FileIdentity       `json:"recovery_lock_identity"`
 	PreviousBinaryPath   string             `json:"previous_binary_path"`
 	PreviousBinarySHA256 string             `json:"previous_binary_sha256"`
 	CandidatePath        string             `json:"candidate_path"`
@@ -263,6 +272,7 @@ func Prepare(stablePlan Plan) (_ *Transaction, retErr error) {
 	if _, err := rand.Read(nonceBytes); err != nil {
 		return nil, fmt.Errorf("generate upgrade recovery nonce: %w", err)
 	}
+	recoveryNonce := hex.EncodeToString(nonceBytes)
 
 	executable, err := canonicalExistingFile(stablePlan.ExecutablePath)
 	if err != nil {
@@ -331,6 +341,26 @@ func Prepare(stablePlan Plan) (_ *Transaction, retErr error) {
 	if err := createDurableDirectory(txnDir, metadataDir, transactionDirMode); err != nil {
 		return nil, fmt.Errorf("create metadata snapshot directory: %w", err)
 	}
+	lockPath := recoveryLockPath(home, stablePlan.ID)
+	if _, err := os.Lstat(lockPath); err == nil {
+		return nil, fmt.Errorf("upgrade recovery lock already exists at %s", lockPath)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("inspect upgrade recovery lock: %w", err)
+	}
+	createdArtifacts = append(createdArtifacts, lockPath)
+	if err := durableAtomicWriteFile(
+		lockPath, []byte(recoveryNonce+"\n"), journalFileMode,
+	); err != nil {
+		return nil, fmt.Errorf("create durable upgrade recovery lock: %w", err)
+	}
+	recoveryLockInfo, err := os.Lstat(lockPath)
+	if err != nil {
+		return nil, fmt.Errorf("inspect durable upgrade recovery lock: %w", err)
+	}
+	recoveryLockIdentity, err := fileIdentity(recoveryLockInfo)
+	if err != nil {
+		return nil, fmt.Errorf("identify durable upgrade recovery lock: %w", err)
+	}
 
 	for _, path := range []string{previousPath, candidatePath} {
 		if _, err := os.Lstat(path); err == nil {
@@ -363,7 +393,8 @@ func Prepare(stablePlan Plan) (_ *Transaction, retErr error) {
 		FromVersion:          stablePlan.FromVersion,
 		ToVersion:            stablePlan.ToVersion,
 		Phase:                PhasePrepared,
-		RecoveryNonce:        hex.EncodeToString(nonceBytes),
+		RecoveryNonce:        recoveryNonce,
+		RecoveryLockIdentity: recoveryLockIdentity,
 		PreviousBinaryPath:   previousPath,
 		PreviousBinarySHA256: digest(previousBinary),
 		CandidatePath:        candidatePath,
@@ -491,8 +522,8 @@ func (t *Transaction) RecoveryActorLive() (bool, error) {
 	if err := t.ensureRecoveryLockDirectoryLocked(); err != nil {
 		return false, err
 	}
-	lockPath := filepath.Join(transactionDir(t.journal.HomeDir, t.journal.ID), "recovery.lock")
-	file, err := acquireFileLock(lockPath, true)
+	lockPath := recoveryLockPath(t.journal.HomeDir, t.journal.ID)
+	file, err := acquireRecoveryLock(lockPath, t.journal.RecoveryLockIdentity, true)
 	if errors.Is(err, ErrRecoveryActive) {
 		return true, nil
 	}
@@ -710,8 +741,8 @@ func (t *Transaction) tryAcquireRecoveryAs(actorExecutable string) (*RecoveryLea
 	if err := t.ensureRecoveryLockDirectoryLocked(); err != nil {
 		return nil, err
 	}
-	lockPath := filepath.Join(transactionDir(t.journal.HomeDir, t.journal.ID), "recovery.lock")
-	file, err := acquireFileLock(lockPath, true)
+	lockPath := recoveryLockPath(t.journal.HomeDir, t.journal.ID)
+	file, err := acquireRecoveryLock(lockPath, t.journal.RecoveryLockIdentity, true)
 	if err != nil {
 		if errors.Is(err, ErrRecoveryActive) {
 			return nil, err
@@ -748,7 +779,7 @@ func (t *Transaction) tryAcquireRecoveryAs(actorExecutable string) (*RecoveryLea
 		_ = releaseFileLock(file)
 		return nil, fmt.Errorf("%w: %v", ErrRecoveryActorMismatch, err)
 	}
-	statusPath := filepath.Join(filepath.Dir(lockPath), "recovery.json")
+	statusPath := filepath.Join(transactionDir(t.journal.HomeDir, t.journal.ID), "recovery.json")
 	// recovery.json belongs to the former flock owner. Remove it while holding
 	// the newly acquired lock so no caller can combine this actor's liveness
 	// with a dead actor's future-dated supervisor_ready heartbeat.
@@ -756,7 +787,7 @@ func (t *Transaction) tryAcquireRecoveryAs(actorExecutable string) (*RecoveryLea
 		_ = releaseFileLock(file)
 		return nil, fmt.Errorf("invalidate previous upgrade recovery status: %w", err)
 	}
-	readyPath := filepath.Join(filepath.Dir(lockPath), "recovery.ready.lock")
+	readyPath := filepath.Join(transactionDir(t.journal.HomeDir, t.journal.ID), "recovery.ready.lock")
 	readyFile, err := acquireFileLock(readyPath, true)
 	if err != nil {
 		_ = releaseFileLock(file)

--- a/internal/upgradetxn/transaction.go
+++ b/internal/upgradetxn/transaction.go
@@ -218,6 +218,7 @@ type RecoveryLease struct {
 	path       string
 	txnID      string
 	nonce      string
+	actorID    string
 	executable string
 	txn        *Transaction
 	released   bool
@@ -230,6 +231,7 @@ type RecoveryStatus struct {
 	SchemaVersion int       `json:"schema_version"`
 	TransactionID string    `json:"transaction_id"`
 	Nonce         string    `json:"nonce"`
+	ActorID       string    `json:"actor_id"`
 	PID           int       `json:"pid"`
 	ProcessStart  string    `json:"process_start,omitempty"`
 	BootID        string    `json:"boot_id,omitempty"`
@@ -428,6 +430,7 @@ func readRecoveryStatusForJournal(journal Journal) (RecoveryStatus, error) {
 	if status.SchemaVersion != journalSchemaVersion ||
 		status.TransactionID != journal.ID ||
 		status.Nonce != journal.RecoveryNonce ||
+		!validDigest(status.ActorID) ||
 		status.PID <= 0 ||
 		!validPhase(status.Phase) ||
 		status.HeartbeatAt.IsZero() ||
@@ -499,88 +502,6 @@ func (t *Transaction) RecoveryActorLive() (bool, error) {
 	return false, releaseFileLock(file)
 }
 
-// AuthorizeActivation completes the old process -> previous-binary actor nonce
-// handshake. It succeeds only while a recovery actor holds the kernel lock and
-// its validated status reports supervisor_ready for this exact transaction.
-func (t *Transaction) AuthorizeActivation(transactionID, nonce string) error {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	current, err := readJournal(activeJournalPath(t.journal.HomeDir))
-	if err != nil {
-		return err
-	}
-	if err := validateJournal(t.journal.HomeDir, current); err != nil {
-		return err
-	}
-	if current.ID != transactionID || current.RecoveryNonce != nonce {
-		return errors.New("upgrade activation handshake does not match the active transaction")
-	}
-	if current.Phase != PhaseSupervisorReady {
-		return fmt.Errorf("upgrade supervisor is not ready for activation (phase %s)", current.Phase)
-	}
-	if err := validateActivationRecoveryProof(current, time.Now().UTC()); err != nil {
-		return err
-	}
-	approvalPath := filepath.Join(transactionDir(current.HomeDir, current.ID), "activation.approved")
-	if err := durableAtomicWriteFile(approvalPath, []byte(current.RecoveryNonce+"\n"), journalFileMode); err != nil {
-		return fmt.Errorf("persist upgrade activation approval: %w", err)
-	}
-	t.journal = current
-	return nil
-}
-
-func validateActivationRecoveryProof(current Journal, now time.Time) error {
-	lockPath := filepath.Join(transactionDir(current.HomeDir, current.ID), "recovery.lock")
-	probe, err := acquireFileLock(lockPath, true)
-	if err == nil {
-		_ = releaseFileLock(probe)
-		return errors.New("upgrade activation cannot be authorized without a live recovery actor")
-	}
-	if !errors.Is(err, ErrRecoveryActive) {
-		return fmt.Errorf("verify recovery actor before activation: %w", err)
-	}
-	readyPath := filepath.Join(transactionDir(current.HomeDir, current.ID), "recovery.ready.lock")
-	readyProbe, err := acquireFileLock(readyPath, true)
-	if err == nil {
-		_ = releaseFileLock(readyProbe)
-		return errors.New("upgrade recovery actor has not published its current readiness proof")
-	}
-	if !errors.Is(err, ErrRecoveryActive) {
-		return fmt.Errorf("verify recovery actor readiness before activation: %w", err)
-	}
-	status, err := readRecoveryStatusForJournal(current)
-	if err != nil {
-		return err
-	}
-	if status.Phase != PhaseSupervisorReady {
-		return fmt.Errorf("upgrade recovery actor has not reached supervisor_ready (status %s)", status.Phase)
-	}
-	if !now.Before(status.Deadline) {
-		return fmt.Errorf("upgrade recovery actor's supervisor_ready deadline expired at %s", status.Deadline.Format(time.RFC3339Nano))
-	}
-	return nil
-}
-
-// ActivationAuthorized is read by the previous-binary actor before it stops
-// the old daemon. A missing file is a normal not-yet result; mismatched content
-// is a hard error rather than permission to proceed.
-func (t *Transaction) ActivationAuthorized() (bool, error) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	path := filepath.Join(transactionDir(t.journal.HomeDir, t.journal.ID), "activation.approved")
-	data, err := os.ReadFile(path)
-	if errors.Is(err, os.ErrNotExist) {
-		return false, nil
-	}
-	if err != nil {
-		return false, fmt.Errorf("read upgrade activation approval: %w", err)
-	}
-	if strings.TrimSpace(string(data)) != t.journal.RecoveryNonce {
-		return false, errors.New("upgrade activation approval nonce does not match the transaction")
-	}
-	return true, nil
-}
-
 // Advance persists a state-machine boundary that does not itself modify the
 // candidate or rollback inputs.
 func (t *Transaction) advance(next Phase) error {
@@ -646,7 +567,18 @@ func (t *Transaction) installCandidate() error {
 }
 
 func (t *Transaction) verifyInstalledCandidateLocked() error {
-	_, err := readAndVerify(t.journal.ExecutablePath, t.journal.CandidateSHA256)
+	info, err := os.Lstat(t.journal.ExecutablePath)
+	if err != nil {
+		return fmt.Errorf("inspect installed candidate: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return errors.New("installed candidate is not a regular file")
+	}
+	if info.Mode().Perm() != os.FileMode(t.journal.ExecutableMode) {
+		return fmt.Errorf("installed candidate mode is %04o, want %04o",
+			info.Mode().Perm(), os.FileMode(t.journal.ExecutableMode))
+	}
+	_, err = readAndVerify(t.journal.ExecutablePath, t.journal.CandidateSHA256)
 	if err != nil {
 		return fmt.Errorf("verify installed candidate: %w", err)
 	}
@@ -830,12 +762,19 @@ func (t *Transaction) tryAcquireRecoveryAs(actorExecutable string) (*RecoveryLea
 		_ = releaseFileLock(file)
 		return nil, fmt.Errorf("acquire upgrade recovery readiness lock: %w", err)
 	}
+	actorID, err := newRecoveryActorID()
+	if err != nil {
+		_ = releaseFileLock(readyFile)
+		_ = releaseFileLock(file)
+		return nil, err
+	}
 	return &RecoveryLease{
 		file:       file,
 		readyFile:  readyFile,
 		path:       statusPath,
 		txnID:      t.journal.ID,
 		nonce:      t.journal.RecoveryNonce,
+		actorID:    actorID,
 		executable: actorPath,
 		txn:        t,
 	}, nil
@@ -941,6 +880,7 @@ func (l *RecoveryLease) Heartbeat(phase Phase, deadline time.Time) error {
 		SchemaVersion: journalSchemaVersion,
 		TransactionID: l.txnID,
 		Nonce:         l.nonce,
+		ActorID:       l.actorID,
 		PID:           os.Getpid(),
 		ProcessStart:  processStartIdentity(),
 		BootID:        kernelBootID(),

--- a/internal/upgradetxn/transaction.go
+++ b/internal/upgradetxn/transaction.go
@@ -208,12 +208,13 @@ const (
 	ExecutableCandidate
 )
 
-// RecoveryLease is the kernel-held death test for the upgrade supervisor.
-// Heartbeats aid diagnosis and deadline enforcement by the lock owner, but
-// they never grant another process permission to take over while flock lives.
+// RecoveryLease holds the kernel death-test flock and a second readiness flock.
+// Acquisition first deletes stale status; Heartbeat then publishes this actor's
+// status. Authorization requires both flocks and that current publication.
 type RecoveryLease struct {
 	mu         sync.Mutex
 	file       *os.File
+	readyFile  *os.File
 	path       string
 	txnID      string
 	nonce      string
@@ -240,7 +241,8 @@ type RecoveryStatus struct {
 
 // Prepare snapshots every rollback input and publishes active.json last. A
 // process crash before publication therefore leaves no transaction that a
-// recovery actor could mistake for complete.
+// recovery actor could mistake for complete. Prepare does not quiesce a live
+// daemon; a production caller must first prove the metadata manifest is stable.
 func Prepare(plan Plan) (_ *Transaction, retErr error) {
 	home, err := canonicalExistingDir(plan.HomeDir)
 	if err != nil {
@@ -525,6 +527,15 @@ func (t *Transaction) AuthorizeActivation(transactionID, nonce string) error {
 	if !errors.Is(err, ErrRecoveryActive) {
 		return fmt.Errorf("verify recovery actor before activation: %w", err)
 	}
+	readyPath := filepath.Join(transactionDir(current.HomeDir, current.ID), "recovery.ready.lock")
+	readyProbe, err := acquireFileLock(readyPath, true)
+	if err == nil {
+		_ = releaseFileLock(readyProbe)
+		return errors.New("upgrade recovery actor has not published its current readiness proof")
+	}
+	if !errors.Is(err, ErrRecoveryActive) {
+		return fmt.Errorf("verify recovery actor readiness before activation: %w", err)
+	}
 	status, err := readRecoveryStatusForJournal(current)
 	if err != nil {
 		return err
@@ -798,9 +809,24 @@ func (t *Transaction) tryAcquireRecoveryAs(actorExecutable string) (*RecoveryLea
 		_ = releaseFileLock(file)
 		return nil, fmt.Errorf("%w: %v", ErrRecoveryActorMismatch, err)
 	}
+	statusPath := filepath.Join(filepath.Dir(lockPath), "recovery.json")
+	// recovery.json belongs to the former flock owner. Remove it while holding
+	// the newly acquired lock so no caller can combine this actor's liveness
+	// with a dead actor's future-dated supervisor_ready heartbeat.
+	if err := removeDurableFile(statusPath); err != nil {
+		_ = releaseFileLock(file)
+		return nil, fmt.Errorf("invalidate previous upgrade recovery status: %w", err)
+	}
+	readyPath := filepath.Join(filepath.Dir(lockPath), "recovery.ready.lock")
+	readyFile, err := acquireFileLock(readyPath, true)
+	if err != nil {
+		_ = releaseFileLock(file)
+		return nil, fmt.Errorf("acquire upgrade recovery readiness lock: %w", err)
+	}
 	return &RecoveryLease{
 		file:       file,
-		path:       filepath.Join(filepath.Dir(lockPath), "recovery.json"),
+		readyFile:  readyFile,
+		path:       statusPath,
 		txnID:      t.journal.ID,
 		nonce:      t.journal.RecoveryNonce,
 		executable: actorPath,
@@ -896,12 +922,12 @@ func (l *RecoveryLease) withTransaction(action func(*Transaction) error) error {
 	return action(l.txn)
 }
 
-// Heartbeat records diagnostics and the lock owner's own deadline. The lease's
-// open file descriptor, not this timestamp, remains the takeover authority.
+// Heartbeat records the lock owner's diagnostics and deadline. The readiness
+// flock was acquired only after stale status was durably invalidated.
 func (l *RecoveryLease) Heartbeat(phase Phase, deadline time.Time) error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	if l.released || l.file == nil {
+	if l.released || l.file == nil || l.readyFile == nil {
 		return errors.New("upgrade recovery lease is released")
 	}
 	heartbeat := RecoveryStatus{
@@ -935,9 +961,11 @@ func (l *RecoveryLease) Release() error {
 		return nil
 	}
 	l.released = true
+	readyErr := releaseFileLock(l.readyFile)
+	l.readyFile = nil
 	err := releaseFileLock(l.file)
 	l.file = nil
-	return err
+	return errors.Join(readyErr, err)
 }
 
 func (t *Transaction) persistPhaseLocked(phase Phase) error {

--- a/internal/upgradetxn/transaction.go
+++ b/internal/upgradetxn/transaction.go
@@ -243,18 +243,18 @@ type RecoveryStatus struct {
 // process crash before publication therefore leaves no transaction that a
 // recovery actor could mistake for complete. Prepare does not quiesce a live
 // daemon; a production caller must first prove the metadata manifest is stable.
-func Prepare(plan Plan) (_ *Transaction, retErr error) {
-	home, err := canonicalExistingDir(plan.HomeDir)
+func Prepare(stablePlan Plan) (_ *Transaction, retErr error) {
+	home, err := canonicalExistingDir(stablePlan.HomeDir)
 	if err != nil {
 		return nil, fmt.Errorf("validate upgrade home: %w", err)
 	}
-	if err := validateTransactionID(plan.ID); err != nil {
+	if err := validateTransactionID(stablePlan.ID); err != nil {
 		return nil, err
 	}
-	if strings.TrimSpace(plan.FromVersion) == "" || strings.TrimSpace(plan.ToVersion) == "" {
+	if strings.TrimSpace(stablePlan.FromVersion) == "" || strings.TrimSpace(stablePlan.ToVersion) == "" {
 		return nil, errors.New("upgrade versions cannot be blank")
 	}
-	if len(plan.Candidate) == 0 {
+	if len(stablePlan.Candidate) == 0 {
 		return nil, errors.New("candidate binary cannot be empty")
 	}
 	nonceBytes := make([]byte, recoveryNonceBytes)
@@ -262,7 +262,7 @@ func Prepare(plan Plan) (_ *Transaction, retErr error) {
 		return nil, fmt.Errorf("generate upgrade recovery nonce: %w", err)
 	}
 
-	executable, err := canonicalExistingFile(plan.ExecutablePath)
+	executable, err := canonicalExistingFile(stablePlan.ExecutablePath)
 	if err != nil {
 		return nil, fmt.Errorf("validate running executable: %w", err)
 	}
@@ -277,7 +277,7 @@ func Prepare(plan Plan) (_ *Transaction, retErr error) {
 	if err != nil {
 		return nil, fmt.Errorf("read running executable: %w", err)
 	}
-	if digest(previousBinary) == digest(plan.Candidate) {
+	if digest(previousBinary) == digest(stablePlan.Candidate) {
 		return nil, errors.New("candidate binary is byte-identical to the previous binary")
 	}
 
@@ -301,20 +301,20 @@ func Prepare(plan Plan) (_ *Transaction, retErr error) {
 		return nil, fmt.Errorf("inspect active upgrade journal: %w", err)
 	}
 
-	txnDir := transactionDir(home, plan.ID)
+	txnDir := transactionDir(home, stablePlan.ID)
 	transactionsRoot := filepath.Dir(txnDir)
 	if err := ensureDurableDirectory(root, transactionsRoot, transactionDirMode); err != nil {
 		return nil, fmt.Errorf("prepare transactions root: %w", err)
 	}
 	if err := createDurableDirectory(transactionsRoot, txnDir, transactionDirMode); err != nil {
 		if errors.Is(err, os.ErrExist) {
-			return nil, fmt.Errorf("upgrade transaction artifacts already exist for %q", plan.ID)
+			return nil, fmt.Errorf("upgrade transaction artifacts already exist for %q", stablePlan.ID)
 		}
 		_ = os.Remove(txnDir)
 		return nil, fmt.Errorf("create transaction directory: %w", err)
 	}
 	published := false
-	previousPath, candidatePath := binaryArtifactPaths(executable, plan.ID)
+	previousPath, candidatePath := binaryArtifactPaths(executable, stablePlan.ID)
 	var createdArtifacts []string
 	defer func() {
 		if published {
@@ -344,31 +344,31 @@ func Prepare(plan Plan) (_ *Transaction, retErr error) {
 		return nil, fmt.Errorf("snapshot previous binary: %w", err)
 	}
 	createdArtifacts = append(createdArtifacts, candidatePath)
-	if err := durableAtomicWriteFile(candidatePath, plan.Candidate, mode); err != nil {
+	if err := durableAtomicWriteFile(candidatePath, stablePlan.Candidate, mode); err != nil {
 		return nil, fmt.Errorf("stage candidate binary: %w", err)
 	}
 
-	metadata, err := snapshotMetadata(home, txnDir, plan.MetadataPaths)
+	metadata, err := snapshotMetadata(home, txnDir, stablePlan.MetadataPaths)
 	if err != nil {
 		return nil, err
 	}
 
 	journal := Journal{
 		SchemaVersion:        journalSchemaVersion,
-		ID:                   plan.ID,
+		ID:                   stablePlan.ID,
 		HomeDir:              home,
 		ExecutablePath:       executable,
-		FromVersion:          plan.FromVersion,
-		ToVersion:            plan.ToVersion,
+		FromVersion:          stablePlan.FromVersion,
+		ToVersion:            stablePlan.ToVersion,
 		Phase:                PhasePrepared,
 		RecoveryNonce:        hex.EncodeToString(nonceBytes),
 		PreviousBinaryPath:   previousPath,
 		PreviousBinarySHA256: digest(previousBinary),
 		CandidatePath:        candidatePath,
-		CandidateSHA256:      digest(plan.Candidate),
+		CandidateSHA256:      digest(stablePlan.Candidate),
 		ExecutableMode:       uint32(mode),
-		Daemon:               plan.Daemon,
-		RecoveryJob:          plan.RecoveryJob,
+		Daemon:               stablePlan.Daemon,
+		RecoveryJob:          stablePlan.RecoveryJob,
 		Metadata:             metadata,
 		UpdatedAt:            time.Now().UTC(),
 	}
@@ -518,6 +518,18 @@ func (t *Transaction) AuthorizeActivation(transactionID, nonce string) error {
 	if current.Phase != PhaseSupervisorReady {
 		return fmt.Errorf("upgrade supervisor is not ready for activation (phase %s)", current.Phase)
 	}
+	if err := validateActivationRecoveryProof(current, time.Now().UTC()); err != nil {
+		return err
+	}
+	approvalPath := filepath.Join(transactionDir(current.HomeDir, current.ID), "activation.approved")
+	if err := durableAtomicWriteFile(approvalPath, []byte(current.RecoveryNonce+"\n"), journalFileMode); err != nil {
+		return fmt.Errorf("persist upgrade activation approval: %w", err)
+	}
+	t.journal = current
+	return nil
+}
+
+func validateActivationRecoveryProof(current Journal, now time.Time) error {
 	lockPath := filepath.Join(transactionDir(current.HomeDir, current.ID), "recovery.lock")
 	probe, err := acquireFileLock(lockPath, true)
 	if err == nil {
@@ -543,14 +555,9 @@ func (t *Transaction) AuthorizeActivation(transactionID, nonce string) error {
 	if status.Phase != PhaseSupervisorReady {
 		return fmt.Errorf("upgrade recovery actor has not reached supervisor_ready (status %s)", status.Phase)
 	}
-	if !time.Now().UTC().Before(status.Deadline) {
+	if !now.Before(status.Deadline) {
 		return fmt.Errorf("upgrade recovery actor's supervisor_ready deadline expired at %s", status.Deadline.Format(time.RFC3339Nano))
 	}
-	approvalPath := filepath.Join(transactionDir(current.HomeDir, current.ID), "activation.approved")
-	if err := durableAtomicWriteFile(approvalPath, []byte(current.RecoveryNonce+"\n"), journalFileMode); err != nil {
-		return fmt.Errorf("persist upgrade activation approval: %w", err)
-	}
-	t.journal = current
 	return nil
 }
 

--- a/internal/upgradetxn/transaction.go
+++ b/internal/upgradetxn/transaction.go
@@ -1,7 +1,6 @@
 // Package upgradetxn owns the crash-durable filesystem transaction used to
-// replace the running af binary. The transaction is deliberately independent
-// of the candidate binary: only the already-running (previous) binary may
-// supervise, commit, or roll back an upgrade.
+// replace af. It is independent of the candidate: only the already-running
+// previous binary may supervise, commit, or roll back an upgrade.
 package upgradetxn
 
 import (
@@ -270,6 +269,9 @@ func Prepare(plan Plan) (_ *Transaction, retErr error) {
 	if err != nil {
 		return nil, fmt.Errorf("read running executable: %w", err)
 	}
+	if digest(previousBinary) == digest(plan.Candidate) {
+		return nil, errors.New("candidate binary is byte-identical to the previous binary")
+	}
 
 	root := upgradeRoot(home)
 	if err := os.MkdirAll(root, transactionDirMode); err != nil {
@@ -517,6 +519,9 @@ func (t *Transaction) AuthorizeActivation(transactionID, nonce string) error {
 	}
 	if status.Phase != PhaseSupervisorReady {
 		return fmt.Errorf("upgrade recovery actor has not reached supervisor_ready (status %s)", status.Phase)
+	}
+	if !time.Now().UTC().Before(status.Deadline) {
+		return fmt.Errorf("upgrade recovery actor's supervisor_ready deadline expired at %s", status.Deadline.Format(time.RFC3339Nano))
 	}
 	approvalPath := filepath.Join(transactionDir(current.HomeDir, current.ID), "activation.approved")
 	if err := config.AtomicWriteFile(approvalPath, []byte(current.RecoveryNonce+"\n"), journalFileMode); err != nil {

--- a/internal/upgradetxn/transaction_test.go
+++ b/internal/upgradetxn/transaction_test.go
@@ -628,7 +628,12 @@ func TestPersistJournalReturnsDirectorySyncFailure(t *testing.T) {
 	syncTransactionDirectory = func(string) error { return injected }
 	t.Cleanup(func() { syncTransactionDirectory = previousSync })
 
-	err := persistJournal(filepath.Join(t.TempDir(), "active.json"), Journal{ID: "durability"})
+	// Production journal paths are derived from Prepare's canonical AF home.
+	// Mirror that boundary because macOS exposes its temp root through /var,
+	// which is a symlink to /private/var.
+	directory, err := canonicalExistingDir(t.TempDir())
+	require.NoError(t, err)
+	err = persistJournal(filepath.Join(directory, "active.json"), Journal{ID: "durability"})
 	require.ErrorIs(t, err, injected)
 }
 

--- a/internal/upgradetxn/transaction_test.go
+++ b/internal/upgradetxn/transaction_test.go
@@ -212,6 +212,24 @@ func TestActivationRequiresLivePreviousBinaryNonceHandshake(t *testing.T) {
 	require.NoError(t, lease.Release())
 }
 
+func TestActivationRejectsExpiredSupervisorLease(t *testing.T) {
+	txn, _, _ := prepareFixture(t)
+	journal := txn.Journal()
+	lease, err := txn.tryAcquireRecoveryAs(journal.PreviousBinaryPath)
+	require.NoError(t, err)
+	require.NoError(t, lease.Advance(PhaseSupervisorReady))
+	require.NoError(t, lease.Heartbeat(PhaseSupervisorReady, time.Now().Add(-time.Second)))
+
+	err = txn.AuthorizeActivation(journal.ID, journal.RecoveryNonce)
+	require.Error(t, err,
+		"a live-but-stuck actor whose own phase deadline expired is not ready to own shutdown")
+	require.ErrorContains(t, err, "deadline expired")
+	authorized, readErr := txn.ActivationAuthorized()
+	require.NoError(t, readErr)
+	require.False(t, authorized)
+	require.NoError(t, lease.Release())
+}
+
 func TestRecoveryTakeoverReloadsJournalAfterActorDeath(t *testing.T) {
 	txn, home, _ := prepareFixture(t)
 	stale, err := Load(home)
@@ -330,4 +348,19 @@ func TestPrepareNeverDeletesPreexistingRecoveryArtifact(t *testing.T) {
 	require.NoError(t, readErr)
 	require.Equal(t, "owned-by-an-earlier-recovery", string(got),
 		"refusing a collision must never clean up an artifact this call did not create")
+}
+
+func TestPrepareRejectsByteIdenticalCandidateIdentity(t *testing.T) {
+	home := t.TempDir()
+	executable := filepath.Join(t.TempDir(), "af")
+	require.NoError(t, os.WriteFile(executable, []byte("same-binary"), 0o755))
+
+	_, err := Prepare(Plan{
+		ID: "identical", HomeDir: home, ExecutablePath: executable,
+		FromVersion: "1", ToVersion: "2", Candidate: []byte("same-binary"),
+		RecoveryJob: RecoveryJob{Kind: RecoveryJobDetached},
+	})
+	require.Error(t, err,
+		"previous and candidate roles must remain structurally distinguishable by digest")
+	require.ErrorContains(t, err, "byte-identical")
 }

--- a/internal/upgradetxn/transaction_test.go
+++ b/internal/upgradetxn/transaction_test.go
@@ -364,3 +364,357 @@ func TestPrepareRejectsByteIdenticalCandidateIdentity(t *testing.T) {
 		"previous and candidate roles must remain structurally distinguishable by digest")
 	require.ErrorContains(t, err, "byte-identical")
 }
+
+func TestRollbackRefusesBeforeDaemonStop(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		ready bool
+	}{
+		{name: "prepared"},
+		{name: "supervisor ready", ready: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			txn, home, _ := prepareFixture(t)
+			lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+			require.NoError(t, err)
+			defer lease.Release()
+			if test.ready {
+				require.NoError(t, lease.Advance(PhaseSupervisorReady))
+			}
+			statePath := filepath.Join(home, "state.json")
+			require.NoError(t, os.WriteFile(statePath, []byte("live-daemon-write"), 0o640))
+
+			err = lease.Rollback()
+			require.Error(t, err, "rollback must not overwrite metadata before daemon shutdown is proven")
+			got, readErr := os.ReadFile(statePath)
+			require.NoError(t, readErr)
+			require.Equal(t, "live-daemon-write", string(got))
+		})
+	}
+}
+
+func TestCleanupKeepsPreviousActorUntilActiveJournalIsRemoved(t *testing.T) {
+	txn, home, _ := prepareFixture(t)
+	lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+	defer lease.Release()
+	require.NoError(t, lease.Advance(PhaseSupervisorReady))
+	require.NoError(t, lease.Advance(PhaseDaemonStopped))
+	require.NoError(t, lease.InstallCandidate())
+	require.NoError(t, lease.Advance(PhaseCandidateStarting))
+	require.NoError(t, lease.Advance(PhaseCandidateValidating))
+	require.NoError(t, lease.Commit())
+
+	injected := errors.New("injected active journal removal failure")
+	activePath := activeJournalPath(txn.Journal().HomeDir)
+	previousRemove := removeTransactionFile
+	removeTransactionFile = func(path string) error {
+		if path == activePath {
+			return injected
+		}
+		return previousRemove(path)
+	}
+	t.Cleanup(func() { removeTransactionFile = previousRemove })
+	err = lease.Cleanup()
+	require.ErrorIs(t, err, injected, "the injected active-journal removal failure must be observed")
+	require.DirExists(t, transactionDir(home, txn.Journal().ID),
+		"the flock inode must not be unlinked while active.json can still authorize takeover")
+	require.FileExists(t, txn.Journal().PreviousBinaryPath,
+		"the only executable authorized to resume terminal cleanup must remain while active.json exists")
+}
+
+func TestPrepareRejectsSymlinkedUpgradeStorage(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		link func(t *testing.T, home, external string)
+	}{
+		{
+			name: "upgrade root",
+			link: func(t *testing.T, home, external string) {
+				require.NoError(t, os.Symlink(external, upgradeRoot(home)))
+			},
+		},
+		{
+			name: "transactions root",
+			link: func(t *testing.T, home, external string) {
+				require.NoError(t, os.Mkdir(upgradeRoot(home), 0o700))
+				require.NoError(t, os.Symlink(external, filepath.Join(upgradeRoot(home), "transactions")))
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			home := t.TempDir()
+			external := t.TempDir()
+			test.link(t, home, external)
+			plan := basicPreparePlan(t, home, "symlink-storage")
+
+			_, err := Prepare(plan)
+			require.Error(t, err, "upgrade transaction storage must remain inside the canonical AF home")
+		})
+	}
+}
+
+func TestCleanupRejectsStorageRootReplacedBySymlink(t *testing.T) {
+	txn, _, _ := prepareFixture(t)
+	lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+	defer lease.Release()
+	require.NoError(t, lease.Advance(PhaseSupervisorReady))
+	require.NoError(t, lease.Advance(PhaseDaemonStopped))
+	require.NoError(t, lease.InstallCandidate())
+	require.NoError(t, lease.Advance(PhaseCandidateStarting))
+	require.NoError(t, lease.Advance(PhaseCandidateValidating))
+	require.NoError(t, lease.Commit())
+
+	journal := txn.Journal()
+	root := upgradeRoot(journal.HomeDir)
+	realRoot := root + ".real"
+	require.NoError(t, os.Rename(root, realRoot))
+	external := t.TempDir()
+	externalTxn := filepath.Join(external, "transactions", journal.ID)
+	require.NoError(t, os.MkdirAll(externalTxn, 0o700))
+	sentinel := filepath.Join(externalTxn, "must-survive")
+	require.NoError(t, os.WriteFile(sentinel, []byte("foreign"), 0o600))
+	require.NoError(t, os.Symlink(external, root))
+
+	err = lease.Cleanup()
+	require.Error(t, err)
+	require.FileExists(t, sentinel, "cleanup must never traverse a symlinked storage ancestor")
+	require.FileExists(t, journal.PreviousBinaryPath)
+}
+
+func TestPrepareRejectsRecoveryJobMismatchedToDaemonOwner(t *testing.T) {
+	for _, owner := range []DaemonOwner{
+		{Kind: SupervisionSystemd, ServiceName: "agent-factory-daemon.service"},
+		{Kind: SupervisionLaunchd, ServiceName: "com.agent-factory.daemon"},
+	} {
+		t.Run(string(owner.Kind), func(t *testing.T) {
+			home := t.TempDir()
+			plan := basicPreparePlan(t, home, "owner-job-mismatch")
+			plan.Daemon = DaemonSnapshot{WasRunning: true, BootID: "boot-1", Owner: owner}
+
+			_, err := Prepare(plan)
+			require.Error(t, err, "service-managed daemons require the matching persistent recovery job kind")
+		})
+	}
+}
+
+func TestRollbackRestoresPrivateMetadataParentModes(t *testing.T) {
+	home := t.TempDir()
+	privateDir := filepath.Join(home, "private")
+	nestedDir := filepath.Join(privateDir, "nested")
+	require.NoError(t, os.Mkdir(privateDir, 0o710))
+	require.NoError(t, os.Mkdir(nestedDir, 0o700))
+	metadataPath := filepath.Join(nestedDir, "state.json")
+	require.NoError(t, os.WriteFile(metadataPath, []byte("private-state"), 0o600))
+	plan := basicPreparePlan(t, home, "parent-modes")
+	plan.MetadataPaths = []string{filepath.Join("private", "nested", "state.json")}
+	txn, err := Prepare(plan)
+	require.NoError(t, err)
+	lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+	defer lease.Release()
+	require.NoError(t, lease.Advance(PhaseSupervisorReady))
+	require.NoError(t, lease.Advance(PhaseDaemonStopped))
+	require.NoError(t, lease.InstallCandidate())
+	require.NoError(t, os.RemoveAll(privateDir))
+
+	require.NoError(t, lease.Rollback())
+	privateInfo, err := os.Stat(privateDir)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o710), privateInfo.Mode().Perm())
+	nestedInfo, err := os.Stat(nestedDir)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o700), nestedInfo.Mode().Perm())
+}
+
+func TestPersistJournalReturnsDirectorySyncFailure(t *testing.T) {
+	injected := errors.New("injected directory sync failure")
+	previousSync := syncTransactionDirectory
+	syncTransactionDirectory = func(string) error { return injected }
+	t.Cleanup(func() { syncTransactionDirectory = previousSync })
+
+	err := persistJournal(filepath.Join(t.TempDir(), "active.json"), Journal{ID: "durability"})
+	require.ErrorIs(t, err, injected)
+}
+
+func TestPrepareFsyncsCreatedTransactionDirectoriesBeforePublishing(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		target func(home string) string
+	}{
+		{
+			name: "transaction directory entry",
+			target: func(home string) string {
+				return filepath.Join(upgradeRoot(home), "transactions")
+			},
+		},
+		{
+			name: "metadata directory entry",
+			target: func(home string) string {
+				return transactionDir(home, "directory-fsync")
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			home := t.TempDir()
+			canonicalHome, err := canonicalExistingDir(home)
+			require.NoError(t, err)
+			injected := errors.New("injected directory creation sync failure")
+			target := test.target(canonicalHome)
+			previousSync := syncTransactionDirectory
+			targetSyncs := 0
+			syncTransactionDirectory = func(path string) error {
+				if path == target {
+					targetSyncs++
+					if targetSyncs == 2 {
+						return injected
+					}
+				}
+				return nil
+			}
+			t.Cleanup(func() { syncTransactionDirectory = previousSync })
+
+			_, err = Prepare(basicPreparePlan(t, home, "directory-fsync"))
+			require.ErrorIs(t, err, injected)
+			require.Equal(t, 2, targetSyncs,
+				"the newly-created child must be made durable through its parent after that parent is durable itself")
+			_, statErr := os.Stat(activeJournalPath(canonicalHome))
+			require.ErrorIs(t, statErr, os.ErrNotExist,
+				"the transaction must not be published after a directory durability failure")
+		})
+	}
+}
+
+func TestCleanupKeepsRecoveryAuthorityWhenActiveRemovalSyncFails(t *testing.T) {
+	txn, home, _ := prepareFixture(t)
+	lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+	defer lease.Release()
+	require.NoError(t, lease.Advance(PhaseSupervisorReady))
+	require.NoError(t, lease.Advance(PhaseDaemonStopped))
+	require.NoError(t, lease.InstallCandidate())
+	require.NoError(t, lease.Advance(PhaseCandidateStarting))
+	require.NoError(t, lease.Advance(PhaseCandidateValidating))
+	require.NoError(t, lease.Commit())
+
+	injected := errors.New("injected active removal sync failure")
+	previousSync := syncTransactionDirectory
+	root := upgradeRoot(txn.Journal().HomeDir)
+	syncTransactionDirectory = func(path string) error {
+		if path == root {
+			return injected
+		}
+		return previousSync(path)
+	}
+	t.Cleanup(func() { syncTransactionDirectory = previousSync })
+	err = lease.Cleanup()
+	require.ErrorIs(t, err, injected)
+	require.DirExists(t, transactionDir(home, txn.Journal().ID))
+	require.FileExists(t, txn.Journal().PreviousBinaryPath)
+}
+
+func TestPrepareRetainsRecoveryInputsWhenJournalPublishSyncFails(t *testing.T) {
+	home := t.TempDir()
+	canonicalHome, err := canonicalExistingDir(home)
+	require.NoError(t, err)
+	plan := basicPreparePlan(t, home, "publish-sync-failure")
+	injected := errors.New("injected active journal sync failure")
+	previousSync := syncTransactionDirectory
+	rootSyncs := 0
+	syncTransactionDirectory = func(path string) error {
+		if path == upgradeRoot(canonicalHome) {
+			rootSyncs++
+			if rootSyncs == 3 {
+				return injected
+			}
+		}
+		return previousSync(path)
+	}
+	t.Cleanup(func() { syncTransactionDirectory = previousSync })
+
+	_, err = Prepare(plan)
+	require.ErrorIs(t, err, injected)
+	require.Equal(t, 3, rootSyncs)
+	journal, readErr := readJournal(activeJournalPath(canonicalHome))
+	require.NoError(t, readErr, "a visible journal must retain everything needed for later recovery")
+	require.FileExists(t, journal.PreviousBinaryPath)
+	require.FileExists(t, journal.CandidatePath)
+	require.DirExists(t, transactionDir(home, journal.ID))
+}
+
+func TestMetadataParentModesAreRestoredEvenWhenRollbackFails(t *testing.T) {
+	home := t.TempDir()
+	privateDir := filepath.Join(home, "private")
+	nestedDir := filepath.Join(privateDir, "nested")
+	require.NoError(t, os.Mkdir(privateDir, 0o710))
+	require.NoError(t, os.Mkdir(nestedDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(nestedDir, "state.json"), []byte("state"), 0o600))
+	plan := basicPreparePlan(t, home, "parent-mode-failure")
+	plan.MetadataPaths = []string{filepath.Join("private", "nested", "state.json")}
+	txn, err := Prepare(plan)
+	require.NoError(t, err)
+	lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+	defer lease.Release()
+	require.NoError(t, lease.Advance(PhaseSupervisorReady))
+	require.NoError(t, lease.Advance(PhaseDaemonStopped))
+	require.NoError(t, lease.InstallCandidate())
+	require.NoError(t, os.RemoveAll(privateDir))
+
+	injected := errors.New("injected recreated parent sync failure")
+	previousSync := syncTransactionDirectory
+	canonicalPrivateDir := filepath.Join(txn.Journal().HomeDir, "private")
+	syncTransactionDirectory = func(path string) error {
+		if path == canonicalPrivateDir {
+			return injected
+		}
+		return previousSync(path)
+	}
+	t.Cleanup(func() { syncTransactionDirectory = previousSync })
+	err = lease.Rollback()
+	require.ErrorIs(t, err, injected)
+	info, statErr := os.Stat(privateDir)
+	require.NoError(t, statErr)
+	require.Equal(t, os.FileMode(0o710), info.Mode().Perm(),
+		"a failed rollback must not leave private parents broadened")
+}
+
+func TestPrepareAcceptsRecoveryJobMatchingDaemonOwner(t *testing.T) {
+	for _, test := range []struct {
+		owner DaemonOwner
+		kind  RecoveryJobKind
+	}{
+		{
+			owner: DaemonOwner{Kind: SupervisionSystemd, ServiceName: "agent-factory-daemon.service"},
+			kind:  RecoveryJobSystemd,
+		},
+		{
+			owner: DaemonOwner{Kind: SupervisionLaunchd, ServiceName: "com.agent-factory.daemon"},
+			kind:  RecoveryJobLaunchd,
+		},
+	} {
+		t.Run(string(test.kind), func(t *testing.T) {
+			home := t.TempDir()
+			plan := basicPreparePlan(t, home, "matching-owner-job")
+			plan.Daemon = DaemonSnapshot{WasRunning: true, BootID: "boot-1", Owner: test.owner}
+			job, err := NewRecoveryJob(test.kind, plan.ID, t.TempDir())
+			require.NoError(t, err)
+			plan.RecoveryJob = job
+
+			_, err = Prepare(plan)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func basicPreparePlan(t *testing.T, home, id string) Plan {
+	t.Helper()
+	executable := filepath.Join(t.TempDir(), "af")
+	require.NoError(t, os.WriteFile(executable, []byte("known-running"), 0o755))
+	return Plan{
+		ID: id, HomeDir: home, ExecutablePath: executable,
+		FromVersion: "1", ToVersion: "2", Candidate: []byte("candidate"),
+		RecoveryJob: RecoveryJob{Kind: RecoveryJobDetached},
+	}
+}

--- a/internal/upgradetxn/transaction_test.go
+++ b/internal/upgradetxn/transaction_test.go
@@ -352,6 +352,39 @@ func TestActivationApprovalRequiresConsumerDirectorySync(t *testing.T) {
 	require.False(t, authorized)
 }
 
+func TestActivationApprovalCompletesVisibleDirectorySync(t *testing.T) {
+	txn, _, _ := prepareFixture(t)
+	journal := txn.Journal()
+	lease, err := txn.tryAcquireRecoveryAs(journal.PreviousBinaryPath)
+	require.NoError(t, err)
+	defer lease.Release()
+	require.NoError(t, lease.Advance(PhaseSupervisorReady))
+	require.NoError(t, lease.Heartbeat(PhaseSupervisorReady, time.Now().Add(time.Minute)))
+
+	injected := errors.New("injected first approval directory sync failure")
+	previousSync := syncTransactionDirectory
+	txnDir := transactionDir(journal.HomeDir, journal.ID)
+	approvalSyncs := 0
+	syncTransactionDirectory = func(path string) error {
+		if path == txnDir {
+			approvalSyncs++
+			if approvalSyncs == 1 {
+				return injected
+			}
+		}
+		return previousSync(path)
+	}
+	t.Cleanup(func() { syncTransactionDirectory = previousSync })
+
+	require.NoError(t, txn.AuthorizeActivation(journal.ID, journal.RecoveryNonce),
+		"a visible exact approval should complete its interrupted durability barrier")
+	authorized, err := lease.ActivationAuthorized()
+	require.NoError(t, err)
+	require.True(t, authorized)
+	require.GreaterOrEqual(t, approvalSyncs, 3,
+		"the writer retry and consumer must each confirm the approval directory")
+}
+
 func TestActivationRejectsExpiredSupervisorLease(t *testing.T) {
 	txn, _, _ := prepareFixture(t)
 	journal := txn.Journal()

--- a/internal/upgradetxn/transaction_test.go
+++ b/internal/upgradetxn/transaction_test.go
@@ -144,6 +144,43 @@ func TestRollbackRemovesAbsentMetadataUnderCandidatePrivateParent(t *testing.T) 
 		"temporary rollback permissions must not broaden a surviving candidate-created directory")
 }
 
+func TestRollbackResyncsAlreadyAbsentMetadataBeforeCheckpoint(t *testing.T) {
+	home := t.TempDir()
+	plan := basicPreparePlan(t, home, "absence-retry-sync")
+	plan.MetadataPaths = []string{"tasks.json"}
+	txn, err := Prepare(plan)
+	require.NoError(t, err)
+	lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+	defer lease.Release()
+	require.NoError(t, lease.Advance(PhaseSupervisorReady))
+	require.NoError(t, lease.Advance(PhaseDaemonStopped))
+	require.NoError(t, lease.InstallCandidate())
+	require.NoError(t, os.WriteFile(filepath.Join(home, "tasks.json"), []byte("candidate-state"), 0o600))
+
+	previousSync := syncTransactionDirectory
+	canonicalHome := txn.Journal().HomeDir
+	syncTransactionDirectory = func(path string) error {
+		if path == canonicalHome {
+			return errRecoveryCheckpointInterrupted
+		}
+		return previousSync(path)
+	}
+	t.Cleanup(func() { syncTransactionDirectory = previousSync })
+
+	err = lease.Rollback()
+	require.ErrorIs(t, err, errRecoveryCheckpointInterrupted)
+	require.NoFileExists(t, filepath.Join(home, "tasks.json"))
+	require.Equal(t, PhaseRollingBack, txn.Journal().Phase)
+	require.Equal(t, 0, txn.Journal().RollbackProgress.MetadataRestored)
+
+	err = lease.Rollback()
+	require.ErrorIs(t, err, errRecoveryCheckpointInterrupted,
+		"a retry must make the already-observed absence durable before checkpointing it")
+	require.Equal(t, PhaseRollingBack, txn.Journal().Phase)
+	require.Equal(t, 0, txn.Journal().RollbackProgress.MetadataRestored)
+}
+
 func TestRollbackResumesFromDurablePerFileCheckpoints(t *testing.T) {
 	txn, home, executable := prepareFixture(t)
 	lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
@@ -220,6 +257,30 @@ func TestRecoveryLockIsTheDeathTest(t *testing.T) {
 	require.NoError(t, second.Release())
 }
 
+func TestRecoveryLockReplacementCannotCreateSecondActor(t *testing.T) {
+	txn, home, _ := prepareFixture(t)
+	stale, err := Load(home)
+	require.NoError(t, err)
+	first, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+	defer first.Release()
+
+	journal := txn.Journal()
+	lockPath := first.file.Name()
+	readyPath := filepath.Join(transactionDir(journal.HomeDir, journal.ID), "recovery.ready.lock")
+	require.NoError(t, os.Remove(lockPath))
+	require.NoError(t, os.WriteFile(lockPath, []byte(journal.RecoveryNonce+"\n"), journalFileMode))
+	require.NoError(t, os.Remove(readyPath))
+	require.NoError(t, os.WriteFile(readyPath, nil, journalFileMode))
+
+	second, err := stale.tryAcquireRecoveryAs(stale.Journal().PreviousBinaryPath)
+	if second != nil {
+		defer second.Release()
+	}
+	require.Error(t, err,
+		"replacing lock pathnames must not create a second recovery authority over new inodes")
+}
+
 func TestActivationRequiresLivePreviousBinaryNonceHandshake(t *testing.T) {
 	txn, _, _ := prepareFixture(t)
 	journal := txn.Journal()
@@ -261,6 +322,34 @@ func TestActivationApprovalCannotBeConsumedByTakeoverActor(t *testing.T) {
 	authorized, err = takeover.ActivationAuthorized()
 	require.NoError(t, err)
 	require.True(t, authorized, "the old daemon can explicitly authorize the new lock owner")
+}
+
+func TestActivationApprovalRequiresConsumerDirectorySync(t *testing.T) {
+	txn, _, _ := prepareFixture(t)
+	journal := txn.Journal()
+	lease, err := txn.tryAcquireRecoveryAs(journal.PreviousBinaryPath)
+	require.NoError(t, err)
+	defer lease.Release()
+	require.NoError(t, lease.Advance(PhaseSupervisorReady))
+	require.NoError(t, lease.Heartbeat(PhaseSupervisorReady, time.Now().Add(time.Minute)))
+
+	injected := errors.New("injected approval directory sync failure")
+	previousSync := syncTransactionDirectory
+	txnDir := transactionDir(journal.HomeDir, journal.ID)
+	syncTransactionDirectory = func(path string) error {
+		if path == txnDir {
+			return injected
+		}
+		return previousSync(path)
+	}
+	t.Cleanup(func() { syncTransactionDirectory = previousSync })
+
+	err = txn.AuthorizeActivation(journal.ID, journal.RecoveryNonce)
+	require.ErrorIs(t, err, injected)
+	authorized, readErr := lease.ActivationAuthorized()
+	require.ErrorIs(t, readErr, injected,
+		"a visible approval is not authority until its directory entry is durable")
+	require.False(t, authorized)
 }
 
 func TestActivationRejectsExpiredSupervisorLease(t *testing.T) {
@@ -447,7 +536,11 @@ func TestTerminalCleanupRecoversAfterTransactionDirectoryDisappears(t *testing.T
 	got, err := os.ReadFile(executable)
 	require.NoError(t, err)
 	require.Equal(t, "candidate-binary", string(got))
-	for _, artifact := range []string{journal.PreviousBinaryPath, journal.CandidatePath} {
+	for _, artifact := range []string{
+		journal.PreviousBinaryPath,
+		journal.CandidatePath,
+		recoveryLockPath(journal.HomeDir, journal.ID),
+	} {
 		_, err = os.Stat(artifact)
 		require.ErrorIs(t, err, os.ErrNotExist)
 	}
@@ -781,6 +874,15 @@ func TestCleanupKeepsRecoveryAuthorityWhenActiveRemovalSyncFails(t *testing.T) {
 	require.ErrorIs(t, err, injected)
 	require.DirExists(t, transactionDir(home, txn.Journal().ID))
 	require.FileExists(t, txn.Journal().PreviousBinaryPath)
+
+	err = lease.Cleanup()
+	require.ErrorIs(t, err, injected,
+		"a retry must durably confirm active.json absence before deleting recovery authority")
+	require.DirExists(t, transactionDir(home, txn.Journal().ID))
+	require.FileExists(t, txn.Journal().PreviousBinaryPath)
+
+	syncTransactionDirectory = previousSync
+	require.NoError(t, lease.Cleanup())
 }
 
 func TestPrepareRetainsRecoveryInputsWhenJournalPublishSyncFails(t *testing.T) {
@@ -790,11 +892,12 @@ func TestPrepareRetainsRecoveryInputsWhenJournalPublishSyncFails(t *testing.T) {
 	plan := basicPreparePlan(t, home, "publish-sync-failure")
 	injected := errors.New("injected active journal sync failure")
 	previousSync := syncTransactionDirectory
-	rootSyncs := 0
+	activePath := activeJournalPath(canonicalHome)
+	publishSyncs := 0
 	syncTransactionDirectory = func(path string) error {
 		if path == upgradeRoot(canonicalHome) {
-			rootSyncs++
-			if rootSyncs == 3 {
+			if _, statErr := os.Lstat(activePath); statErr == nil {
+				publishSyncs++
 				return injected
 			}
 		}
@@ -804,8 +907,8 @@ func TestPrepareRetainsRecoveryInputsWhenJournalPublishSyncFails(t *testing.T) {
 
 	_, err = Prepare(plan)
 	require.ErrorIs(t, err, injected)
-	require.Equal(t, 3, rootSyncs)
-	journal, readErr := readJournal(activeJournalPath(canonicalHome))
+	require.Equal(t, 1, publishSyncs)
+	journal, readErr := readJournal(activePath)
 	require.NoError(t, readErr, "a visible journal must retain everything needed for later recovery")
 	require.FileExists(t, journal.PreviousBinaryPath)
 	require.FileExists(t, journal.CandidatePath)

--- a/internal/upgradetxn/transaction_test.go
+++ b/internal/upgradetxn/transaction_test.go
@@ -230,6 +230,69 @@ func TestActivationRejectsExpiredSupervisorLease(t *testing.T) {
 	require.NoError(t, lease.Release())
 }
 
+func TestTakeoverInvalidatesPreviousActorsSupervisorReadyHeartbeat(t *testing.T) {
+	txn, _, _ := prepareFixture(t)
+	journal := txn.Journal()
+	first, err := txn.tryAcquireRecoveryAs(journal.PreviousBinaryPath)
+	require.NoError(t, err)
+	require.NoError(t, first.Advance(PhaseSupervisorReady))
+	require.NoError(t, first.Heartbeat(PhaseSupervisorReady, time.Now().Add(time.Hour)))
+	require.NoError(t, first.Release())
+
+	takeover, err := txn.tryAcquireRecoveryAs(journal.PreviousBinaryPath)
+	require.NoError(t, err)
+	defer takeover.Release()
+	err = txn.AuthorizeActivation(journal.ID, journal.RecoveryNonce)
+	require.Error(t, err,
+		"the new flock owner must publish its own heartbeat before it can authorize shutdown")
+}
+
+func TestTakeoverCannotBorrowStaleHeartbeatBeforeInvalidationFinishes(t *testing.T) {
+	txn, home, _ := prepareFixture(t)
+	journal := txn.Journal()
+	first, err := txn.tryAcquireRecoveryAs(journal.PreviousBinaryPath)
+	require.NoError(t, err)
+	require.NoError(t, first.Advance(PhaseSupervisorReady))
+	require.NoError(t, first.Heartbeat(PhaseSupervisorReady, time.Now().Add(time.Hour)))
+	require.NoError(t, first.Release())
+	takeoverTxn, err := Load(home)
+	require.NoError(t, err)
+
+	statusPath := filepath.Join(transactionDir(journal.HomeDir, journal.ID), "recovery.json")
+	removeStarted := make(chan struct{})
+	continueRemove := make(chan struct{})
+	previousRemove := removeTransactionFile
+	removeTransactionFile = func(path string) error {
+		if path == statusPath {
+			close(removeStarted)
+			<-continueRemove
+		}
+		return previousRemove(path)
+	}
+	t.Cleanup(func() { removeTransactionFile = previousRemove })
+	type acquisition struct {
+		lease *RecoveryLease
+		err   error
+	}
+	acquired := make(chan acquisition, 1)
+	go func() {
+		lease, acquireErr := takeoverTxn.tryAcquireRecoveryAs(journal.PreviousBinaryPath)
+		acquired <- acquisition{lease: lease, err: acquireErr}
+	}()
+	select {
+	case <-removeStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("takeover did not reach stale-status invalidation")
+	}
+	authorizeErr := txn.AuthorizeActivation(journal.ID, journal.RecoveryNonce)
+	close(continueRemove)
+	result := <-acquired
+	require.NoError(t, result.err)
+	require.NoError(t, result.lease.Release())
+	require.Error(t, authorizeErr,
+		"holding the death-test lock is insufficient until this actor publishes its own readiness proof")
+}
+
 func TestRecoveryTakeoverReloadsJournalAfterActorDeath(t *testing.T) {
 	txn, home, _ := prepareFixture(t)
 	stale, err := Load(home)
@@ -481,6 +544,37 @@ func TestCleanupRejectsStorageRootReplacedBySymlink(t *testing.T) {
 	require.Error(t, err)
 	require.FileExists(t, sentinel, "cleanup must never traverse a symlinked storage ancestor")
 	require.FileExists(t, journal.PreviousBinaryPath)
+}
+
+func TestRecoveryLoadsJournalWhenCandidateReplacesMetadataParentWithSymlink(t *testing.T) {
+	txn, home, executable := prepareFixture(t)
+	lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+	require.NoError(t, lease.Advance(PhaseSupervisorReady))
+	require.NoError(t, lease.Advance(PhaseDaemonStopped))
+	require.NoError(t, lease.InstallCandidate())
+	require.NoError(t, lease.Release())
+
+	instancesDir := filepath.Join(home, "instances")
+	require.NoError(t, os.RemoveAll(instancesDir))
+	external := t.TempDir()
+	sentinel := filepath.Join(external, "must-survive")
+	require.NoError(t, os.WriteFile(sentinel, []byte("foreign"), 0o600))
+	require.NoError(t, os.Symlink(external, instancesDir))
+
+	loaded, err := Load(home)
+	require.NoError(t, err,
+		"mutable candidate state must not prevent the previous binary from loading its recovery journal")
+	recovery, err := loaded.tryAcquireRecoveryAs(loaded.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+	err = recovery.Rollback()
+	require.Error(t, err, "rollback must reject rather than traverse the candidate-created symlink")
+	require.NoError(t, recovery.Release())
+	require.Equal(t, PhaseRollbackFailed, loaded.Journal().Phase)
+	require.FileExists(t, sentinel)
+	got, readErr := os.ReadFile(executable)
+	require.NoError(t, readErr)
+	require.Equal(t, "known-running-binary", string(got))
 }
 
 func TestPrepareRejectsRecoveryJobMismatchedToDaemonOwner(t *testing.T) {

--- a/internal/upgradetxn/transaction_test.go
+++ b/internal/upgradetxn/transaction_test.go
@@ -116,6 +116,34 @@ func TestRollbackRestoresBinaryMetadataAndAbsence(t *testing.T) {
 	require.NoError(t, lease.Rollback())
 }
 
+func TestRollbackRemovesAbsentMetadataUnderCandidatePrivateParent(t *testing.T) {
+	home := t.TempDir()
+	plan := basicPreparePlan(t, home, "candidate-private-parent")
+	plan.MetadataPaths = []string{filepath.Join("candidate", "tasks.json")}
+	txn, err := Prepare(plan)
+	require.NoError(t, err)
+	lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+	defer lease.Release()
+	require.NoError(t, lease.Advance(PhaseSupervisorReady))
+	require.NoError(t, lease.Advance(PhaseDaemonStopped))
+	require.NoError(t, lease.InstallCandidate())
+
+	parent := filepath.Join(home, "candidate")
+	require.NoError(t, os.Mkdir(parent, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(parent, "tasks.json"), []byte("candidate-state"), 0o600))
+	require.NoError(t, os.Chmod(parent, 0o500))
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o700) })
+
+	require.NoError(t, lease.Rollback(),
+		"rollback must temporarily make candidate-created parents writable to restore recorded absence")
+	require.NoFileExists(t, filepath.Join(parent, "tasks.json"))
+	info, err := os.Stat(parent)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o500), info.Mode().Perm(),
+		"temporary rollback permissions must not broaden a surviving candidate-created directory")
+}
+
 func TestRollbackResumesFromDurablePerFileCheckpoints(t *testing.T) {
 	txn, home, executable := prepareFixture(t)
 	lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
@@ -206,10 +234,33 @@ func TestActivationRequiresLivePreviousBinaryNonceHandshake(t *testing.T) {
 	require.NoError(t, lease.Heartbeat(PhaseSupervisorReady, time.Now().Add(time.Minute)))
 	require.Error(t, txn.AuthorizeActivation(journal.ID, "wrong-nonce"))
 	require.NoError(t, txn.AuthorizeActivation(journal.ID, journal.RecoveryNonce))
-	authorized, err := txn.ActivationAuthorized()
+	authorized, err := lease.ActivationAuthorized()
 	require.NoError(t, err)
 	require.True(t, authorized)
 	require.NoError(t, lease.Release())
+}
+
+func TestActivationApprovalCannotBeConsumedByTakeoverActor(t *testing.T) {
+	txn, _, _ := prepareFixture(t)
+	journal := txn.Journal()
+	first, err := txn.tryAcquireRecoveryAs(journal.PreviousBinaryPath)
+	require.NoError(t, err)
+	require.NoError(t, first.Advance(PhaseSupervisorReady))
+	require.NoError(t, first.Heartbeat(PhaseSupervisorReady, time.Now().Add(time.Minute)))
+	require.NoError(t, txn.AuthorizeActivation(journal.ID, journal.RecoveryNonce))
+	require.NoError(t, first.Release())
+
+	takeover, err := txn.tryAcquireRecoveryAs(journal.PreviousBinaryPath)
+	require.NoError(t, err)
+	defer takeover.Release()
+	require.NoError(t, takeover.Heartbeat(PhaseSupervisorReady, time.Now().Add(time.Minute)))
+	authorized, err := takeover.ActivationAuthorized()
+	require.NoError(t, err)
+	require.False(t, authorized)
+	require.NoError(t, txn.AuthorizeActivation(journal.ID, journal.RecoveryNonce))
+	authorized, err = takeover.ActivationAuthorized()
+	require.NoError(t, err)
+	require.True(t, authorized, "the old daemon can explicitly authorize the new lock owner")
 }
 
 func TestActivationRejectsExpiredSupervisorLease(t *testing.T) {
@@ -224,7 +275,7 @@ func TestActivationRejectsExpiredSupervisorLease(t *testing.T) {
 	require.Error(t, err,
 		"a live-but-stuck actor whose own phase deadline expired is not ready to own shutdown")
 	require.ErrorContains(t, err, "deadline expired")
-	authorized, readErr := txn.ActivationAuthorized()
+	authorized, readErr := lease.ActivationAuthorized()
 	require.NoError(t, readErr)
 	require.False(t, authorized)
 	require.NoError(t, lease.Release())
@@ -348,6 +399,25 @@ func TestCommitIsDurableBeforeCleanup(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "candidate-binary", string(got),
 		"cleanup after commit must never restore the previous binary")
+}
+
+func TestCommitRejectsCandidateWithChangedExecutableMode(t *testing.T) {
+	txn, _, executable := prepareFixture(t)
+	lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+	defer lease.Release()
+	require.NoError(t, lease.Advance(PhaseSupervisorReady))
+	require.NoError(t, lease.Advance(PhaseDaemonStopped))
+	require.NoError(t, lease.InstallCandidate())
+	require.NoError(t, lease.Advance(PhaseCandidateStarting))
+	require.NoError(t, lease.Advance(PhaseCandidateValidating))
+	require.NoError(t, os.Chmod(executable, 0o644))
+
+	err = lease.Commit()
+	require.Error(t, err, "validation must not commit a candidate that cannot be executed on restart")
+	require.Equal(t, PhaseCandidateValidating, txn.Journal().Phase)
+	require.FileExists(t, txn.Journal().PreviousBinaryPath,
+		"rollback material must remain after refusing the candidate")
 }
 
 func TestTerminalCleanupRecoversAfterTransactionDirectoryDisappears(t *testing.T) {

--- a/internal/upgradetxn/transaction_test.go
+++ b/internal/upgradetxn/transaction_test.go
@@ -1,0 +1,333 @@
+package upgradetxn
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func prepareFixture(t *testing.T) (*Transaction, string, string) {
+	t.Helper()
+	home := t.TempDir()
+	binDir := t.TempDir()
+	executable := filepath.Join(binDir, "af")
+	require.NoError(t, os.WriteFile(executable, []byte("known-running-binary"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(home, "state.json"), []byte("old-state"), 0o640))
+	require.NoError(t, os.MkdirAll(filepath.Join(home, "instances", "repo-a"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(home, "instances", "repo-a", "instances.json"),
+		[]byte("old-instances"), 0o600))
+
+	txn, err := Prepare(Plan{
+		ID:             "txn-2212",
+		HomeDir:        home,
+		ExecutablePath: executable,
+		FromVersion:    "1.0.206",
+		ToVersion:      "1.0.207",
+		Candidate:      []byte("candidate-binary"),
+		RecoveryJob:    RecoveryJob{Kind: RecoveryJobDetached},
+		MetadataPaths: []string{
+			"state.json",
+			"tasks.json", // absent is a fact rollback must restore
+			filepath.Join("instances", "repo-a", "instances.json"),
+		},
+	})
+	require.NoError(t, err)
+	return txn, home, executable
+}
+
+func TestRecoveryJobIdentityIsTransactionScopedAndJournaled(t *testing.T) {
+	unitDir := t.TempDir()
+	systemd, err := NewRecoveryJob(RecoveryJobSystemd, "txn-2212", unitDir)
+	require.NoError(t, err)
+	require.Equal(t, "agent-factory-upgrade-recovery-txn-2212.service", systemd.Name)
+	require.Equal(t, filepath.Join(unitDir, systemd.Name), systemd.UnitPath)
+	require.NoError(t, validateRecoveryJob("txn-2212", systemd))
+
+	launchd, err := NewRecoveryJob(RecoveryJobLaunchd, "txn-2212", unitDir)
+	require.NoError(t, err)
+	require.Equal(t, "com.agent-factory.upgrade-recovery.txn-2212", launchd.Name)
+	require.Equal(t, filepath.Join(unitDir, launchd.Name+".plist"), launchd.UnitPath)
+	require.NoError(t, validateRecoveryJob("txn-2212", launchd))
+
+	tampered := systemd
+	tampered.Name = "agent-factory-upgrade-recovery-another.service"
+	require.Error(t, validateRecoveryJob("txn-2212", tampered))
+}
+
+func TestRecoveryMutationAuthorityRequiresPreservedBinary(t *testing.T) {
+	txn, _, _ := prepareFixture(t)
+	lease, err := txn.TryAcquireRecovery()
+	if lease != nil {
+		t.Cleanup(func() { require.NoError(t, lease.Release()) })
+	}
+	require.Error(t, err,
+		"code running from any executable other than the preserved previous binary must not receive mutation authority")
+	require.ErrorIs(t, err, ErrRecoveryActorMismatch)
+}
+
+func TestRollbackRestoresBinaryMetadataAndAbsence(t *testing.T) {
+	txn, home, executable := prepareFixture(t)
+	lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+	defer lease.Release()
+	journal := txn.Journal()
+	require.Equal(t, PhasePrepared, journal.Phase)
+	require.FileExists(t, journal.PreviousBinaryPath)
+	require.FileExists(t, journal.CandidatePath)
+	require.Equal(t, "txn-2212", journal.ID)
+
+	require.NoError(t, lease.Advance(PhaseSupervisorReady))
+	require.NoError(t, lease.Advance(PhaseDaemonStopped))
+	require.NoError(t, lease.InstallCandidate())
+	require.NoError(t, os.WriteFile(filepath.Join(home, "state.json"), []byte("new-state"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(home, "tasks.json"), []byte("new-tasks"), 0o600))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(home, "instances", "repo-a", "instances.json"),
+		[]byte("new-instances"), 0o600))
+
+	require.NoError(t, lease.Rollback())
+	require.Equal(t, PhaseRollbackRestored, txn.Journal().Phase)
+	require.FileExists(t, journal.PreviousBinaryPath,
+		"recovery artifacts remain until the previous daemon is healthy")
+
+	got, err := os.ReadFile(executable)
+	require.NoError(t, err)
+	require.Equal(t, "known-running-binary", string(got))
+	got, err = os.ReadFile(filepath.Join(home, "state.json"))
+	require.NoError(t, err)
+	require.Equal(t, "old-state", string(got))
+	info, err := os.Stat(filepath.Join(home, "state.json"))
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o640), info.Mode().Perm())
+	got, err = os.ReadFile(filepath.Join(home, "instances", "repo-a", "instances.json"))
+	require.NoError(t, err)
+	require.Equal(t, "old-instances", string(got))
+	_, err = os.Stat(filepath.Join(home, "tasks.json"))
+	require.ErrorIs(t, err, os.ErrNotExist,
+		"a file created during probation must be removed when it was absent at prepare time")
+
+	// Every recovery operation is resumable after actor loss.
+	require.NoError(t, lease.Rollback())
+}
+
+func TestRollbackResumesFromDurablePerFileCheckpoints(t *testing.T) {
+	txn, home, executable := prepareFixture(t)
+	lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+	require.NoError(t, lease.Advance(PhaseSupervisorReady))
+	require.NoError(t, lease.Advance(PhaseDaemonStopped))
+	require.NoError(t, lease.InstallCandidate())
+	require.NoError(t, os.WriteFile(filepath.Join(home, "state.json"), []byte("new-state"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(home, "tasks.json"), []byte("new-tasks"), 0o600))
+
+	checkpointErr := fmt.Errorf("simulated supervisor death: %w", errRecoveryCheckpointInterrupted)
+	txn.afterRollbackCheckpoint = func(progress RollbackProgress) error {
+		if progress.BinaryRestored && progress.MetadataRestored == 1 {
+			return checkpointErr
+		}
+		return nil
+	}
+	err = lease.Rollback()
+	require.ErrorIs(t, err, checkpointErr)
+	require.Equal(t, PhaseRollingBack, txn.Journal().Phase)
+	require.Equal(t, RollbackProgress{BinaryRestored: true, MetadataRestored: 1},
+		txn.Journal().RollbackProgress)
+	require.NoError(t, lease.Release())
+
+	resumed, err := Load(home)
+	require.NoError(t, err)
+	takeover, err := resumed.tryAcquireRecoveryAs(resumed.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+	require.NoError(t, takeover.Rollback())
+	require.Equal(t, PhaseRollbackRestored, resumed.Journal().Phase)
+	require.NoError(t, takeover.Release())
+
+	got, err := os.ReadFile(executable)
+	require.NoError(t, err)
+	require.Equal(t, "known-running-binary", string(got))
+	got, err = os.ReadFile(filepath.Join(home, "state.json"))
+	require.NoError(t, err)
+	require.Equal(t, "old-state", string(got))
+	_, err = os.Stat(filepath.Join(home, "tasks.json"))
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestRecoveryLockIsTheDeathTest(t *testing.T) {
+	txn, home, _ := prepareFixture(t)
+	live, err := txn.RecoveryActorLive()
+	require.NoError(t, err)
+	require.False(t, live)
+	lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+	require.NotNil(t, lease)
+	require.NoError(t, lease.Heartbeat(PhaseSupervisorReady, time.Now().Add(time.Minute)))
+	live, err = txn.RecoveryActorLive()
+	require.NoError(t, err)
+	require.True(t, live)
+	status, err := ReadRecoveryStatus(home)
+	require.NoError(t, err)
+	require.Equal(t, txn.Journal().RecoveryNonce, status.Nonce)
+	require.Equal(t, txn.Journal().PreviousBinaryPath, status.Executable)
+
+	loaded, err := Load(home)
+	require.NoError(t, err)
+	second, err := loaded.tryAcquireRecoveryAs(loaded.Journal().PreviousBinaryPath)
+	require.Nil(t, second)
+	require.ErrorIs(t, err, ErrRecoveryActive,
+		"a fresh or stale timestamp cannot override a kernel-held recovery lock")
+
+	require.NoError(t, lease.Release())
+	live, err = txn.RecoveryActorLive()
+	require.NoError(t, err)
+	require.False(t, live)
+	second, err = loaded.tryAcquireRecoveryAs(loaded.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+	require.NotNil(t, second, "actor death/release makes the lock acquirable")
+	require.NoError(t, second.Release())
+}
+
+func TestActivationRequiresLivePreviousBinaryNonceHandshake(t *testing.T) {
+	txn, _, _ := prepareFixture(t)
+	journal := txn.Journal()
+	require.Error(t, txn.AuthorizeActivation(journal.ID, journal.RecoveryNonce),
+		"a journal without a live recovery actor is not a handshake")
+
+	lease, err := txn.tryAcquireRecoveryAs(journal.PreviousBinaryPath)
+	require.NoError(t, err)
+	require.NoError(t, lease.Advance(PhaseSupervisorReady))
+	require.Error(t, txn.AuthorizeActivation(journal.ID, journal.RecoveryNonce),
+		"the actor must publish its exact supervisor_ready status before authorization")
+	require.NoError(t, lease.Heartbeat(PhaseSupervisorReady, time.Now().Add(time.Minute)))
+	require.Error(t, txn.AuthorizeActivation(journal.ID, "wrong-nonce"))
+	require.NoError(t, txn.AuthorizeActivation(journal.ID, journal.RecoveryNonce))
+	authorized, err := txn.ActivationAuthorized()
+	require.NoError(t, err)
+	require.True(t, authorized)
+	require.NoError(t, lease.Release())
+}
+
+func TestRecoveryTakeoverReloadsJournalAfterActorDeath(t *testing.T) {
+	txn, home, _ := prepareFixture(t)
+	stale, err := Load(home)
+	require.NoError(t, err)
+
+	first, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+	require.NoError(t, first.Advance(PhaseSupervisorReady))
+	require.NoError(t, first.Release())
+
+	second, err := stale.tryAcquireRecoveryAs(stale.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+	require.Equal(t, PhaseSupervisorReady, stale.Journal().Phase,
+		"a takeover must resume the durable phase, not overwrite it from a stale pre-lock read")
+	require.NoError(t, second.Release())
+}
+
+func TestReleasedRecoveryLeaseCannotMutateTransaction(t *testing.T) {
+	txn, home, _ := prepareFixture(t)
+	lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+	require.NoError(t, lease.Release())
+
+	err = lease.Advance(PhaseSupervisorReady)
+	require.Error(t, err)
+	loaded, loadErr := Load(home)
+	require.NoError(t, loadErr)
+	require.Equal(t, PhasePrepared, loaded.Journal().Phase,
+		"releasing the kernel death-test lock must revoke phase mutation authority")
+}
+
+func TestCommitIsDurableBeforeCleanup(t *testing.T) {
+	txn, home, executable := prepareFixture(t)
+	lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+	defer lease.Release()
+	require.NoError(t, lease.Advance(PhaseSupervisorReady))
+	require.NoError(t, lease.Advance(PhaseDaemonStopped))
+	require.NoError(t, lease.InstallCandidate())
+	require.NoError(t, lease.Advance(PhaseCandidateStarting))
+	require.NoError(t, lease.Advance(PhaseCandidateValidating))
+	require.NoError(t, lease.Commit())
+
+	loaded, err := Load(home)
+	require.NoError(t, err)
+	require.Equal(t, PhaseCommitted, loaded.Journal().Phase,
+		"a crash before cleanup must resume cleanup, never rollback")
+	require.NoError(t, lease.Cleanup())
+
+	_, err = Load(home)
+	require.True(t, errors.Is(err, ErrNoActiveTransaction))
+	got, err := os.ReadFile(executable)
+	require.NoError(t, err)
+	require.Equal(t, "candidate-binary", string(got),
+		"cleanup after commit must never restore the previous binary")
+}
+
+func TestTerminalCleanupRecoversAfterTransactionDirectoryDisappears(t *testing.T) {
+	txn, home, executable := prepareFixture(t)
+	lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+	require.NoError(t, lease.Advance(PhaseSupervisorReady))
+	require.NoError(t, lease.Advance(PhaseDaemonStopped))
+	require.NoError(t, lease.InstallCandidate())
+	require.NoError(t, lease.Advance(PhaseCandidateStarting))
+	require.NoError(t, lease.Advance(PhaseCandidateValidating))
+	require.NoError(t, lease.Commit())
+	require.NoError(t, lease.Release())
+
+	journal := txn.Journal()
+	require.NoError(t, os.RemoveAll(transactionDir(home, journal.ID)),
+		"simulate actor death after terminal transaction-directory cleanup but before active.json removal")
+	loaded, err := Load(home)
+	require.NoError(t, err)
+	recovery, err := loaded.tryAcquireRecoveryAs(loaded.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+	require.NoError(t, recovery.Cleanup())
+	require.NoError(t, recovery.Release())
+
+	_, err = Load(home)
+	require.ErrorIs(t, err, ErrNoActiveTransaction)
+	got, err := os.ReadFile(executable)
+	require.NoError(t, err)
+	require.Equal(t, "candidate-binary", string(got))
+	for _, artifact := range []string{journal.PreviousBinaryPath, journal.CandidatePath} {
+		_, err = os.Stat(artifact)
+		require.ErrorIs(t, err, os.ErrNotExist)
+	}
+}
+
+func TestPrepareRefusesEscapingMetadataPath(t *testing.T) {
+	home := t.TempDir()
+	executable := filepath.Join(t.TempDir(), "af")
+	require.NoError(t, os.WriteFile(executable, []byte("old"), 0o755))
+	_, err := Prepare(Plan{
+		ID: "escape", HomeDir: home, ExecutablePath: executable,
+		FromVersion: "1", ToVersion: "2", Candidate: []byte("new"),
+		MetadataPaths: []string{"../foreign"},
+	})
+	require.Error(t, err)
+}
+
+func TestPrepareNeverDeletesPreexistingRecoveryArtifact(t *testing.T) {
+	home := t.TempDir()
+	executable := filepath.Join(t.TempDir(), "af")
+	require.NoError(t, os.WriteFile(executable, []byte("old"), 0o755))
+	previousPath, _ := binaryArtifactPaths(executable, "collision")
+	require.NoError(t, os.WriteFile(previousPath, []byte("owned-by-an-earlier-recovery"), 0o600))
+
+	_, err := Prepare(Plan{
+		ID: "collision", HomeDir: home, ExecutablePath: executable,
+		FromVersion: "1", ToVersion: "2", Candidate: []byte("new"),
+	})
+	require.Error(t, err)
+	got, readErr := os.ReadFile(previousPath)
+	require.NoError(t, readErr)
+	require.Equal(t, "owned-by-an-earlier-recovery", string(got),
+		"refusing a collision must never clean up an artifact this call did not create")
+}


### PR DESCRIPTION
## Summary

Adds the crash-durable filesystem transaction at the center of #2212's approved staged design:

- publishes an fsynced journal only after immutable previous/candidate artifacts, durable transaction directories, and the rollback manifest exist
- grants mutation authority only to the preserved previous-binary artifact while it holds the kernel death-test flock, whose pathname is pinned to the journaled device/inode so replacement cannot create a second actor
- requires a second readiness flock plus this actor's nonce-matched, unexpired `supervisor_ready` publication before activation, binds approval to a unique lock-acquisition identity, and confirms a visible approval is durable before consuming it
- makes candidate installation and binary/metadata rollback atomic, digest-checked, idempotent, and resumable at each file checkpoint
- preserves metadata parent modes and syncs recorded-absence removals before every checkpoint attempt, including retries where the target is already absent
- rejects a byte-identical candidate so previous and candidate executable roles remain structurally distinguishable
- keeps the flock path and previous actor until `active.json` is durably removed, re-confirms that absence on cleanup retries, then cleans inert artifacts
- validates every derived path, rejects symlinked transaction storage, and refuses artifact collisions rather than overwriting them

This is the transaction-core slice only. It intentionally has no production activation caller yet: the existing upgrade paths still behave exactly as before. `Prepare` cannot quiesce a live daemon, so wiring it before the approved drain barrier would make the rollback snapshot race live metadata writes. The next #2212 slice adds the previous-binary supervisor and recovery jobs; production activation remains disabled until the quiesce/drain barrier exists.

## Reproduction and regression proof

The parent revision has only a direct canonical-binary replacement and no durable journal, immutable previous artifact, recovery lease, metadata rollback, or crash-resume state. The transaction tests were written against that baseline first and failed because those guarantees did not exist.

Additional fail-first regressions were run against earlier PR heads and reproduced:

- activation accepted an expired supervisor deadline
- preparation accepted byte-identical previous/candidate identities
- journal and directory fsync failures were suppressed or omitted
- cleanup deleted the only recovery actor and flock path before `active.json`
- rollback could overwrite live metadata before daemon shutdown
- symlinked transaction roots redirected storage and cleanup
- service-managed daemon owners accepted detached recovery jobs
- rollback recreated private metadata parents as 0755
- takeover could borrow a dead actor's future-dated readiness publication, including the lock-acquired/status-not-yet-cleared race
- a candidate-created metadata-parent symlink prevented the previous binary from loading the journal at all
- the direct fsync-failure seam failed on macOS before reaching the injected error because `/var` is a symlink; the test now mirrors production home canonicalization
- rollback could not remove an absence marker beneath a candidate-created `0500` parent
- a takeover actor could consume activation approval granted to its dead predecessor
- commit accepted candidate bytes after the installed executable mode changed to `0644`
- a visible but not directory-synced activation approval could be consumed after its writer reported failure
- an exact approval made visible by a failed post-rename sync could not complete that durability barrier idempotently
- an already-absent metadata rollback retry could checkpoint without re-establishing durable absence
- cleanup could delete recovery authority on retry after `active.json` unlink succeeded but its parent sync failed
- unlinking and recreating the recovery lock pathname could establish a second flock owner on a different inode

Regression coverage now proves these fail closed, plus crash-resumable per-file rollback, released-lease revocation, terminal cleanup recovery, absence restoration, and late symlink-swap containment.

## Exact-head gates

Gated commit: `42759b65f8d347e8b3af8603e28394b5c8f8b295`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (empty)
- `go build ./...`
- `make test-container`
- `scripts/lint-file-length.sh`
- `go test -race ./internal/upgradetxn -count=1`
- `go test ./internal/upgradetxn -count=20`
- Darwin arm64 test cross-compilation

All passed on that exact commit. No daemon tests were run on the host.

Part of #2212; this PR does not close the issue.
