### PR TITLE
Adopt a self-hosted Lucide SVG icon subset

### DIFF
--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -228,6 +228,13 @@ body {
 #app {
   min-height: 100vh;
 }
+.af-icon {
+  display: block;
+  width: 1em;
+  height: 1em;
+  flex: 0 0 auto;
+  pointer-events: none;
+}
 .af-login {
   min-height: 100vh;
   display: flex;
@@ -384,7 +391,6 @@ body {
 .af-project-glyph {
   flex: 0 0 auto;
   color: var(--af-accent);
-  font-weight: 700;
 }
 .af-project-switch-name {
   min-width: 0;
@@ -448,7 +454,6 @@ body {
   flex: 0 0 auto;
   width: 0.8rem;
   color: var(--af-accent);
-  font-weight: 700;
 }
 .af-project-item-label {
   min-width: 0;
@@ -560,6 +565,9 @@ body {
   display: none;
 }
 .af-install__dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   padding: 0 0.3rem;
   background: transparent;
   color: var(--af-text-3);
@@ -683,7 +691,6 @@ body {
   width: 0.875rem;
   height: 0.875rem;
   flex: 0 0 auto;
-  fill: currentColor;
 }
 .af-rail-filter-dot {
   width: 4px;
@@ -739,7 +746,6 @@ body {
   flex: 0 0 auto;
   width: 0.8rem;
   color: var(--af-accent);
-  font-weight: 700;
 }
 .af-filter-item-label {
   flex: 1;
@@ -802,6 +808,9 @@ body {
   line-height: 1.5;
 }
 .af-rail-empty-new {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
   padding: 0.1rem 0.5rem;
   background: var(--af-accent-subtle);
   color: var(--af-accent);
@@ -903,12 +912,21 @@ body {
   text-overflow: ellipsis;
 }
 .af-branch-icon {
+  display: inline-block;
+  width: 0.85rem;
+  height: 0.85rem;
+  margin-right: 0.2rem;
+  vertical-align: -0.15rem;
   opacity: 0.8;
 }
 .af-dot {
   flex: 0 0 auto;
   line-height: 1.4;
   font-size: var(--af-fs-sm);
+}
+.af-dot-ready .af-icon,
+.af-dot-limit .af-icon {
+  fill: currentColor;
 }
 .af-dot-ready {
   color: var(--af-dot-ready);
@@ -1071,8 +1089,9 @@ body {
 }
 .af-tab-glyph {
   flex: 0 0 auto;
+  width: 0.8rem;
+  height: 0.8rem;
   color: var(--af-text-3, var(--af-text-2));
-  line-height: 1;
 }
 .af-tab-label {
   overflow: hidden;
@@ -1116,6 +1135,10 @@ body {
 .af-tab-close:hover {
   color: var(--af-danger);
   background: var(--af-danger-subtle);
+}
+.af-tab-close .af-icon {
+  width: 0.75rem;
+  height: 0.75rem;
 }
 .af-tab-new-wrap {
   position: relative;
@@ -1175,7 +1198,6 @@ body {
 }
 .af-tab-new-plus {
   font-size: var(--af-fs-md);
-  line-height: 0.8;
 }
 .af-tab-new-caret {
   color: var(--af-text-2);
@@ -1297,6 +1319,9 @@ body {
   text-overflow: ellipsis;
 }
 .af-pane-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   flex: 0 0 auto;
   padding: 0 var(--af-sp-1);
   background: transparent;
@@ -1342,6 +1367,7 @@ body {
   flex: 0 0 auto;
   display: inline-flex;
   align-items: center;
+  gap: 0.25rem;
   padding: 0.1rem 0.4rem;
   font-size: var(--af-fs-xs);
   line-height: 1.4;
@@ -1383,6 +1409,9 @@ body {
   display: none;
 }
 .af-webpane-fallback-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
   color: var(--af-accent);
 }
 .af-webpane-dead {
@@ -1447,6 +1476,9 @@ body {
   height: 50%;
 }
 .af-rail-new {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
   padding: var(--af-sp-1) 0.55rem;
   background: transparent;
   color: var(--af-accent);
@@ -1729,6 +1761,9 @@ body {
   padding: 0.05rem var(--af-sp-2);
 }
 .af-tasks-add {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
   margin-left: auto;
   padding: var(--af-sp-1) 0.55rem;
   background: transparent;
@@ -1766,6 +1801,11 @@ body {
   font-size: var(--af-fs-sm);
   color: var(--af-text-2);
   line-height: 1.5;
+}
+.af-task-target {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
 }
 .af-task-enabled.af-task-on {
   color: var(--af-dot-ready);

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -1438,31 +1438,31 @@ WARNING: This link could potentially be dangerous`)) {
                 const t4 = j;
                 j = K, K = t4;
               }
-              let V, G, X, J = false;
+              let V, G, X2, J = false;
               switch (this._decorationService.forEachDecorationAtCell(M, t3, void 0, ((e4) => {
                 "top" !== e4.options.layer && J || (e4.backgroundColorRGB && (K = 50331648, z = e4.backgroundColorRGB.rgba >> 8 & 16777215, V = e4.backgroundColorRGB), e4.foregroundColorRGB && (j = 50331648, $ = e4.foregroundColorRGB.rgba >> 8 & 16777215, G = e4.foregroundColorRGB), J = "top" === e4.options.layer);
               })), !J && H && (V = this._coreBrowserService.isFocused ? S.selectionBackgroundOpaque : S.selectionInactiveBackgroundOpaque, z = V.rgba >> 8 & 16777215, K = 50331648, J = true, S.selectionForeground && (j = 50331648, $ = S.selectionForeground.rgba >> 8 & 16777215, G = S.selectionForeground)), J && B.push("xterm-decoration-top"), K) {
                 case 16777216:
                 case 33554432:
-                  X = S.ansi[z], B.push(`xterm-bg-${z}`);
+                  X2 = S.ansi[z], B.push(`xterm-bg-${z}`);
                   break;
                 case 50331648:
-                  X = c.channels.toColor(z >> 16, z >> 8 & 255, 255 & z), this._addStyle(C, `background-color:#${v((z >>> 0).toString(16), "0", 6)}`);
+                  X2 = c.channels.toColor(z >> 16, z >> 8 & 255, 255 & z), this._addStyle(C, `background-color:#${v((z >>> 0).toString(16), "0", 6)}`);
                   break;
                 default:
-                  q ? (X = S.foreground, B.push(`xterm-bg-${n.INVERTED_DEFAULT_COLOR}`)) : X = S.background;
+                  q ? (X2 = S.foreground, B.push(`xterm-bg-${n.INVERTED_DEFAULT_COLOR}`)) : X2 = S.background;
               }
-              switch (V || I.isDim() && (V = c.color.multiplyOpacity(X, 0.5)), j) {
+              switch (V || I.isDim() && (V = c.color.multiplyOpacity(X2, 0.5)), j) {
                 case 16777216:
                 case 33554432:
-                  I.isBold() && $ < 8 && this._optionsService.rawOptions.drawBoldTextInBrightColors && ($ += 8), this._applyMinimumContrast(C, X, S.ansi[$], I, V, void 0) || B.push(`xterm-fg-${$}`);
+                  I.isBold() && $ < 8 && this._optionsService.rawOptions.drawBoldTextInBrightColors && ($ += 8), this._applyMinimumContrast(C, X2, S.ansi[$], I, V, void 0) || B.push(`xterm-fg-${$}`);
                   break;
                 case 50331648:
                   const e4 = c.channels.toColor($ >> 16 & 255, $ >> 8 & 255, 255 & $);
-                  this._applyMinimumContrast(C, X, e4, I, V, G) || this._addStyle(C, `color:#${v($.toString(16), "0", 6)}`);
+                  this._applyMinimumContrast(C, X2, e4, I, V, G) || this._addStyle(C, `color:#${v($.toString(16), "0", 6)}`);
                   break;
                 default:
-                  this._applyMinimumContrast(C, X, S.foreground, I, V, G) || q && B.push(`xterm-fg-${n.INVERTED_DEFAULT_COLOR}`);
+                  this._applyMinimumContrast(C, X2, S.foreground, I, V, G) || q && B.push(`xterm-fg-${n.INVERTED_DEFAULT_COLOR}`);
               }
               B.length && (C.className = B.join(" "), B.length = 0), F || O || U ? C.textContent = y : w++, A !== this.defaultSpacing && (C.style.letterSpacing = `${A}px`), g.push(C), M = P;
             }
@@ -7013,6 +7013,222 @@ var EventStream = class {
   }
 };
 
+// node_modules/lucide/dist/esm/icons/archive-restore.mjs
+var ArchiveRestore = [
+  ["rect", { width: "20", height: "5", x: "2", y: "3", rx: "1" }],
+  ["path", { d: "M4 8v11a2 2 0 0 0 2 2h2" }],
+  ["path", { d: "M20 8v11a2 2 0 0 1-2 2h-2" }],
+  ["path", { d: "m9 15 3-3 3 3" }],
+  ["path", { d: "M12 12v9" }]
+];
+
+// node_modules/lucide/dist/esm/icons/archive.mjs
+var Archive = [
+  ["rect", { width: "20", height: "5", x: "2", y: "3", rx: "1" }],
+  ["path", { d: "M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8" }],
+  ["path", { d: "M10 12h4" }]
+];
+
+// node_modules/lucide/dist/esm/icons/arrow-right.mjs
+var ArrowRight = [
+  ["path", { d: "M5 12h14" }],
+  ["path", { d: "m12 5 7 7-7 7" }]
+];
+
+// node_modules/lucide/dist/esm/icons/bot.mjs
+var Bot = [
+  ["path", { d: "M12 8V4H8" }],
+  ["rect", { width: "16", height: "12", x: "4", y: "8", rx: "2" }],
+  ["path", { d: "M2 14h2" }],
+  ["path", { d: "M20 14h2" }],
+  ["path", { d: "M15 13v2" }],
+  ["path", { d: "M9 13v2" }]
+];
+
+// node_modules/lucide/dist/esm/icons/check.mjs
+var Check = [["path", { d: "M20 6 9 17l-5-5" }]];
+
+// node_modules/lucide/dist/esm/icons/chevron-down.mjs
+var ChevronDown = [["path", { d: "m6 9 6 6 6-6" }]];
+
+// node_modules/lucide/dist/esm/icons/circle-dashed.mjs
+var CircleDashed = [
+  ["path", { d: "M10.1 2.182a10 10 0 0 1 3.8 0" }],
+  ["path", { d: "M13.9 21.818a10 10 0 0 1-3.8 0" }],
+  ["path", { d: "M17.609 3.721a10 10 0 0 1 2.69 2.7" }],
+  ["path", { d: "M2.182 13.9a10 10 0 0 1 0-3.8" }],
+  ["path", { d: "M20.279 17.609a10 10 0 0 1-2.7 2.69" }],
+  ["path", { d: "M21.818 10.1a10 10 0 0 1 0 3.8" }],
+  ["path", { d: "M3.721 6.391a10 10 0 0 1 2.7-2.69" }],
+  ["path", { d: "M6.391 20.279a10 10 0 0 1-2.69-2.7" }]
+];
+
+// node_modules/lucide/dist/esm/icons/circle.mjs
+var Circle = [["circle", { cx: "12", cy: "12", r: "10" }]];
+
+// node_modules/lucide/dist/esm/icons/diamond.mjs
+var Diamond = [
+  [
+    "path",
+    {
+      d: "M2.7 10.3a2.41 2.41 0 0 0 0 3.41l7.59 7.59a2.41 2.41 0 0 0 3.41 0l7.59-7.59a2.41 2.41 0 0 0 0-3.41l-7.59-7.59a2.41 2.41 0 0 0-3.41 0Z"
+    }
+  ]
+];
+
+// node_modules/lucide/dist/esm/icons/ellipsis.mjs
+var Ellipsis = [
+  ["circle", { cx: "12", cy: "12", r: "1" }],
+  ["circle", { cx: "19", cy: "12", r: "1" }],
+  ["circle", { cx: "5", cy: "12", r: "1" }]
+];
+
+// node_modules/lucide/dist/esm/icons/external-link.mjs
+var ExternalLink = [
+  ["path", { d: "M15 3h6v6" }],
+  ["path", { d: "M10 14 21 3" }],
+  ["path", { d: "M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" }]
+];
+
+// node_modules/lucide/dist/esm/icons/folder-git-2.mjs
+var FolderGit2 = [
+  ["path", { d: "M18 19a5 5 0 0 1-5-5v8" }],
+  [
+    "path",
+    {
+      d: "M9 20H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h3.9a2 2 0 0 1 1.69.9l.81 1.2a2 2 0 0 0 1.67.9H20a2 2 0 0 1 2 2v5"
+    }
+  ],
+  ["circle", { cx: "13", cy: "12", r: "2" }],
+  ["circle", { cx: "20", cy: "19", r: "2" }]
+];
+
+// node_modules/lucide/dist/esm/icons/funnel.mjs
+var Funnel = [
+  [
+    "path",
+    {
+      d: "M10 20a1 1 0 0 0 .553.895l2 1A1 1 0 0 0 14 21v-7a2 2 0 0 1 .517-1.341L21.74 4.67A1 1 0 0 0 21 3H3a1 1 0 0 0-.742 1.67l7.225 7.989A2 2 0 0 1 10 14z"
+    }
+  ]
+];
+
+// node_modules/lucide/dist/esm/icons/git-branch.mjs
+var GitBranch = [
+  ["path", { d: "M15 6a9 9 0 0 0-9 9V3" }],
+  ["circle", { cx: "18", cy: "6", r: "3" }],
+  ["circle", { cx: "6", cy: "18", r: "3" }]
+];
+
+// node_modules/lucide/dist/esm/icons/menu.mjs
+var Menu = [
+  ["path", { d: "M4 5h16" }],
+  ["path", { d: "M4 12h16" }],
+  ["path", { d: "M4 19h16" }]
+];
+
+// node_modules/lucide/dist/esm/icons/octagon-x.mjs
+var OctagonX = [
+  ["path", { d: "m15 9-6 6" }],
+  [
+    "path",
+    {
+      d: "M2.586 16.726A2 2 0 0 1 2 15.312V8.688a2 2 0 0 1 .586-1.414l4.688-4.688A2 2 0 0 1 8.688 2h6.624a2 2 0 0 1 1.414.586l4.688 4.688A2 2 0 0 1 22 8.688v6.624a2 2 0 0 1-.586 1.414l-4.688 4.688a2 2 0 0 1-1.414.586H8.688a2 2 0 0 1-1.414-.586z"
+    }
+  ],
+  ["path", { d: "m9 9 6 6" }]
+];
+
+// node_modules/lucide/dist/esm/icons/panels-top-left.mjs
+var PanelsTopLeft = [
+  ["rect", { width: "18", height: "18", x: "3", y: "3", rx: "2" }],
+  ["path", { d: "M3 9h18" }],
+  ["path", { d: "M9 21V9" }]
+];
+
+// node_modules/lucide/dist/esm/icons/plus.mjs
+var Plus = [
+  ["path", { d: "M5 12h14" }],
+  ["path", { d: "M12 5v14" }]
+];
+
+// node_modules/lucide/dist/esm/icons/refresh-cw.mjs
+var RefreshCw = [
+  ["path", { d: "M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" }],
+  ["path", { d: "M21 3v5h-5" }],
+  ["path", { d: "M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" }],
+  ["path", { d: "M8 16H3v5" }]
+];
+
+// node_modules/lucide/dist/esm/icons/square-check-big.mjs
+var SquareCheckBig = [
+  ["path", { d: "M21 10.656V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h12.344" }],
+  ["path", { d: "m9 11 3 3L22 4" }]
+];
+
+// node_modules/lucide/dist/esm/icons/square.mjs
+var Square = [["rect", { width: "18", height: "18", x: "3", y: "3", rx: "2" }]];
+
+// node_modules/lucide/dist/esm/icons/terminal.mjs
+var Terminal = [
+  ["path", { d: "M12 19h8" }],
+  ["path", { d: "m4 17 6-6-6-6" }]
+];
+
+// node_modules/lucide/dist/esm/icons/x.mjs
+var X = [
+  ["path", { d: "M18 6 6 18" }],
+  ["path", { d: "m6 6 12 12" }]
+];
+
+// src/icon.ts
+var ICONS = {
+  archive: Archive,
+  "archive-restore": ArchiveRestore,
+  "arrow-right": ArrowRight,
+  bot: Bot,
+  check: Check,
+  "chevron-down": ChevronDown,
+  circle: Circle,
+  "circle-dashed": CircleDashed,
+  diamond: Diamond,
+  ellipsis: Ellipsis,
+  "external-link": ExternalLink,
+  "folder-git": FolderGit2,
+  funnel: Funnel,
+  "git-branch": GitBranch,
+  menu: Menu,
+  "octagon-x": OctagonX,
+  panels: PanelsTopLeft,
+  plus: Plus,
+  reload: RefreshCw,
+  square: Square,
+  "square-check": SquareCheckBig,
+  terminal: Terminal,
+  x: X
+};
+function icon(name, className = "") {
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute("class", `af-icon${className ? ` ${className}` : ""}`);
+  svg.setAttribute("data-icon", name);
+  svg.setAttribute("viewBox", "0 0 24 24");
+  svg.setAttribute("fill", "none");
+  svg.setAttribute("stroke", "currentColor");
+  svg.setAttribute("stroke-width", "2");
+  svg.setAttribute("stroke-linecap", "round");
+  svg.setAttribute("stroke-linejoin", "round");
+  svg.setAttribute("aria-hidden", "true");
+  svg.setAttribute("focusable", "false");
+  for (const [tag, attrs] of ICONS[name]) {
+    const child = document.createElementNS("http://www.w3.org/2000/svg", tag);
+    for (const [attr, value] of Object.entries(attrs)) {
+      child.setAttribute(attr, String(value));
+    }
+    svg.append(child);
+  }
+  return svg;
+}
+
 // src/install.ts
 var DISMISS_KEY = "af-install-dismissed";
 function shouldShowInstall(state) {
@@ -7046,7 +7262,7 @@ var InstallAffordance = class {
     const dismiss = document.createElement("button");
     dismiss.type = "button";
     dismiss.className = "af-install__dismiss";
-    dismiss.textContent = "\xD7";
+    dismiss.append(icon("x"));
     dismiss.setAttribute("aria-label", "Dismiss install");
     dismiss.title = "Dismiss";
     dismiss.addEventListener("click", () => this.dismiss());
@@ -7223,12 +7439,12 @@ var ROW_KIND_LABELS = {
   limit: "Limit reached",
   archived: "Archived"
 };
-var READY_GLYPH = "\u25CF";
-var DEAD_GLYPH = "\u25CB";
-var LOST_GLYPH = "\u25CC";
-var ARCHIVED_GLYPH = "\u25A7";
-var LIMIT_GLYPH = "\u25C6";
-var WORKING = { glyph: "", kind: null, label: ROW_KIND_LABELS.working };
+var READY_ICON = "circle";
+var DEAD_ICON = "circle";
+var LOST_ICON = "circle-dashed";
+var ARCHIVED_ICON = "archive";
+var LIMIT_ICON = "diamond";
+var WORKING = { icon: null, kind: null, label: ROW_KIND_LABELS.working };
 function rowStatus(s) {
   const op = s.in_flight_op ?? InFlightOp.None;
   if (op !== InFlightOp.None) {
@@ -7268,15 +7484,15 @@ function livenessOf(s) {
 function dotForLiveness(lv) {
   switch (lv) {
     case Liveness.Ready:
-      return { glyph: READY_GLYPH, kind: "ready", label: ROW_KIND_LABELS.ready };
+      return { icon: READY_ICON, kind: "ready", label: ROW_KIND_LABELS.ready };
     case Liveness.Lost:
-      return { glyph: LOST_GLYPH, kind: "lost", label: ROW_KIND_LABELS.lost };
+      return { icon: LOST_ICON, kind: "lost", label: ROW_KIND_LABELS.lost };
     case Liveness.Dead:
-      return { glyph: DEAD_GLYPH, kind: "dead", label: ROW_KIND_LABELS.dead };
+      return { icon: DEAD_ICON, kind: "dead", label: ROW_KIND_LABELS.dead };
     case Liveness.Archived:
-      return { glyph: ARCHIVED_GLYPH, kind: "archived", label: ROW_KIND_LABELS.archived };
+      return { icon: ARCHIVED_ICON, kind: "archived", label: ROW_KIND_LABELS.archived };
     case Liveness.LimitReached:
-      return { glyph: LIMIT_GLYPH, kind: "limit", label: ROW_KIND_LABELS.limit };
+      return { icon: LIMIT_ICON, kind: "limit", label: ROW_KIND_LABELS.limit };
     // LiveRunning and LivenessUnset both render as working (render.go:285, 297).
     case Liveness.Running:
     case Liveness.Unset:
@@ -7877,16 +8093,16 @@ function paneAddressUsesOrdinal(webTarget, realId) {
 }
 
 // src/tablabel.ts
-function tabGlyph(kind) {
+function tabIcon(kind) {
   switch (kind) {
     case TabKind.Agent:
-      return "\u25C6";
+      return "bot";
     case TabKind.Shell:
-      return "\u203A";
+      return "terminal";
     case TabKind.Process:
-      return "\u203A";
-    // VS Code (#1817) shares the WEB glyph deliberately, on the same rule that has
-    // shell and process share `›`: the glyph names what a tab IS, and a VS Code tab
+      return "terminal";
+    // VS Code (#1817) shares the web icon deliberately, on the same rule that has
+    // shell and process share the terminal icon: the icon names what a tab IS, and a VS Code tab
     // is an embedded browser surface with no PTY — a web pane whose page happens to
     // be an editor. What separates them is the text beside the glyph ("VS Code" vs
     // the target's name), exactly as the command name separates a process tab from a
@@ -7894,9 +8110,9 @@ function tabGlyph(kind) {
     // which is the one thing it is not.
     case TabKind.Web:
     case TabKind.VSCode:
-      return "\u25F1";
+      return "panels";
     default:
-      return "\u203A";
+      return "terminal";
   }
 }
 function tabLabel(tab) {
@@ -7914,7 +8130,7 @@ function tabLabel(tab) {
   }
 }
 function tabDisplayLabel(tab) {
-  return `${tabGlyph(tab.kind)} ${tabLabel(tab)}`;
+  return tabLabel(tab);
 }
 function isRenameableTab(kind) {
   return kind === TabKind.Web || kind === TabKind.Process || kind === TabKind.VSCode;
@@ -8929,7 +9145,7 @@ var SplitView = class {
       pane.container.classList.toggle("af-pane-multi", multi);
       pane.container.setAttribute("data-tab-id", realId);
       const named = { name: this.tabNames[leaf.tab] ?? "", kind: this.tabKinds[leaf.tab] ?? TabKind.Agent };
-      pane.glyph.textContent = tabGlyph(named.kind);
+      pane.glyph.replaceChildren(icon(tabIcon(named.kind)));
       pane.label.textContent = tabLabel(named);
     }
     this.applyFocusClass();
@@ -8946,7 +9162,7 @@ var SplitView = class {
     closeBtn.className = "af-pane-close";
     closeBtn.title = "Close pane";
     closeBtn.setAttribute("aria-label", "Close pane");
-    closeBtn.textContent = "\xD7";
+    closeBtn.append(icon("x"));
     closeBtn.addEventListener("click", (e) => {
       e.stopPropagation();
       this.closePane(leaf.id);
@@ -9019,7 +9235,7 @@ var SplitView = class {
     reload.className = "af-ghost af-webpane-reload";
     reload.title = "Reload";
     reload.setAttribute("aria-label", isVSCode ? "Reload VS Code" : "Reload web tab");
-    reload.textContent = "\u21BB";
+    reload.append(icon("reload"));
     const urlText = el("span", "af-webpane-url");
     urlText.textContent = isVSCode ? "VS Code \u2014 session worktree" : target || "(no URL)";
     urlText.title = urlText.textContent;
@@ -9028,7 +9244,7 @@ var SplitView = class {
     open.href = openHref;
     open.target = "_blank";
     open.rel = "noopener noreferrer";
-    open.textContent = "Open \u2197";
+    open.append("Open", icon("external-link"));
     bar.append(reload, urlText, open);
     const frame = document.createElement("iframe");
     frame.className = "af-webframe";
@@ -9049,7 +9265,7 @@ var SplitView = class {
     fbLink.href = openHref;
     fbLink.target = "_blank";
     fbLink.rel = "noopener noreferrer";
-    fbLink.textContent = "Open in a new tab \u2197";
+    fbLink.append("Open in a new tab", icon("external-link"));
     const fbRetry = document.createElement("button");
     fbRetry.type = "button";
     fbRetry.className = "af-ghost af-webpane-fallback-retry";
@@ -9105,7 +9321,7 @@ var SplitView = class {
       fallback.classList.add("af-webpane-external");
       fbMsg.textContent = "This site may block embedding.";
       fbLink.hidden = false;
-      fbLink.textContent = "Open it in a new tab \u2197";
+      fbLink.replaceChildren("Open it in a new tab", icon("external-link"));
       fbRetry.hidden = true;
       reload.hidden = true;
       fallback.hidden = false;
@@ -9698,7 +9914,12 @@ var TasksPane = class {
     this.render(scoped);
   }
   render(tasks) {
-    const addBtn = h("button", { type: "button", class: "af-tasks-add", title: "Add task" }, "+ Add");
+    const addBtn = h(
+      "button",
+      { type: "button", class: "af-tasks-add", title: "Add task" },
+      icon("plus"),
+      "Add"
+    );
     addBtn.addEventListener("click", () => this.actions.add());
     const head = h(
       "div",
@@ -9722,17 +9943,23 @@ var TasksPane = class {
     this.el.replaceChildren(head, h("ul", { class: "af-tasks-list" }, ...rows));
   }
   taskRow(t) {
-    const glyph = t.enabled ? "[\u2713]" : "[ ]";
-    const enabledDot = h("span", { class: `af-task-enabled${t.enabled ? " af-task-on" : ""}` }, glyph);
+    const enabledDot = h(
+      "span",
+      { class: `af-task-enabled${t.enabled ? " af-task-on" : ""}` },
+      icon(t.enabled ? "square-check" : "square")
+    );
     enabledDot.setAttribute("aria-hidden", "true");
     const name = h("div", { class: "af-task-name" }, t.name && t.name.trim() !== "" ? t.name : "(unnamed task)");
     const trigger = h("div", { class: "af-task-trigger" }, triggerSummary(t));
     const metaParts = [];
     if (t.target_session && t.target_session.trim() !== "") {
-      metaParts.push(`\u2192 ${t.target_session}`);
+      metaParts.push(
+        h("span", { class: "af-task-target" }, icon("arrow-right"), t.target_session),
+        " \xB7 "
+      );
     }
     metaParts.push(lastRunSummary(t));
-    const meta = h("div", { class: "af-task-meta" }, metaParts.join("  \xB7  "));
+    const meta = h("div", { class: "af-task-meta" }, ...metaParts);
     const main = h("div", { class: "af-task-main" }, name, trigger, meta);
     const toggleBtn = h(
       "button",
@@ -10470,10 +10697,8 @@ var AppShell = class {
       viewNav.append(tab);
     }
     this.projectSwitchName = h2("span", { class: "af-project-switch-name" }, "\u2014");
-    const switchGlyph = h2("span", { class: "af-project-glyph" }, "\u25A3");
-    switchGlyph.setAttribute("aria-hidden", "true");
-    const switchCaret = h2("span", { class: "af-project-caret" }, "\u25BC");
-    switchCaret.setAttribute("aria-hidden", "true");
+    const switchGlyph = icon("folder-git", "af-project-glyph");
+    const switchCaret = icon("chevron-down", "af-project-caret");
     this.projectSwitchBtn = h2(
       "button",
       { type: "button", class: "af-project-switch" },
@@ -10499,7 +10724,7 @@ var AppShell = class {
         this.closeProjectMenu();
       }
     });
-    this.navToggle = h2("button", { type: "button", class: "af-nav-toggle" }, "\u2630");
+    this.navToggle = h2("button", { type: "button", class: "af-nav-toggle" }, icon("menu"));
     this.navToggle.setAttribute("aria-label", "Toggle sessions");
     this.navToggle.setAttribute("aria-controls", "af-rail");
     this.navToggle.setAttribute("aria-expanded", "false");
@@ -10514,7 +10739,7 @@ var AppShell = class {
     );
     appbarTools.setAttribute("role", "group");
     appbarTools.setAttribute("aria-label", "App controls");
-    const appbarMore = h2("button", { type: "button", class: "af-appbar-more" }, "\u22EF");
+    const appbarMore = h2("button", { type: "button", class: "af-appbar-more" }, icon("ellipsis"));
     appbarMore.setAttribute("aria-label", "More app controls");
     appbarMore.setAttribute("title", "More app controls");
     appbarMore.setAttribute("aria-controls", "af-appbar-tools");
@@ -10574,16 +10799,14 @@ var AppShell = class {
       appbarToolsWrap
     );
     this.railCount = h2("span", { class: "af-rail-count" }, "0");
-    const newBtn = h2("button", { type: "button", class: "af-rail-new", title: "New session" }, "+ New");
+    const newBtn = h2(
+      "button",
+      { type: "button", class: "af-rail-new", title: "New session" },
+      icon("plus"),
+      "New"
+    );
     newBtn.addEventListener("click", () => this.runRailExit(() => this.actions.newSession()));
-    const filterGlyph = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-    filterGlyph.classList.add("af-rail-filter-glyph");
-    filterGlyph.setAttribute("viewBox", "0 0 16 16");
-    filterGlyph.setAttribute("aria-hidden", "true");
-    filterGlyph.setAttribute("focusable", "false");
-    const filterGlyphPath = document.createElementNS("http://www.w3.org/2000/svg", "path");
-    filterGlyphPath.setAttribute("d", "M2 2h12L9.5 8v4.5L6.5 14V8L2 2Z");
-    filterGlyph.append(filterGlyphPath);
+    const filterGlyph = icon("funnel", "af-rail-filter-glyph");
     this.filterDot = h2("span", { class: "af-rail-filter-dot" });
     this.filterDot.setAttribute("aria-hidden", "true");
     this.filterBtn = h2("button", { type: "button", class: "af-rail-filter" }, filterGlyph, this.filterDot);
@@ -10973,7 +11196,11 @@ var AppShell = class {
     if (isKillableSession(session)) {
       const killSession2 = session;
       const killClass = surface === "rail" ? "af-rail-action af-rail-kill" : "af-ghost af-term-action af-term-kill";
-      const killBtn = h2("button", { type: "button", class: killClass }, surface === "rail" ? "\u232B" : "Kill");
+      const killBtn = h2(
+        "button",
+        { type: "button", class: killClass },
+        ...surface === "rail" ? [icon("octagon-x")] : ["Kill"]
+      );
       const killLabel = `Kill session \u201C${killSession2.title}\u201D`;
       killBtn.setAttribute("aria-label", killLabel);
       killBtn.setAttribute("title", killLabel);
@@ -10989,13 +11216,17 @@ var AppShell = class {
     }
     return buttons;
   }
-  /** Applies the daemon-projected verb, glyph, and target-qualified accessible name
+  /** Applies the daemon-projected verb, icon, and target-qualified accessible name
    *  in one place so render and same-selection live patching cannot drift. */
   patchLifecycleButton(btn, action, sessionTitle, surface = "rail") {
     const verb = action === "restore" ? "Restore session" : "Archive session";
     const label = `${verb} \u201C${sessionTitle}\u201D`;
     btn.dataset.action = action;
-    btn.textContent = surface === "rail" ? action === "restore" ? "\u21B6" : "\u25AA" : verb.replace(" session", "");
+    if (surface === "rail") {
+      btn.replaceChildren(icon(action === "restore" ? "archive-restore" : "archive"));
+    } else {
+      btn.textContent = verb.replace(" session", "");
+    }
     btn.setAttribute("aria-label", label);
     btn.setAttribute("title", label);
   }
@@ -11016,7 +11247,12 @@ var AppShell = class {
     const name = projectName(state.selectedProject ?? "");
     const hasActive = scoped.some((s) => !isArchived(s));
     if (!hasActive) {
-      const newBtn = h2("button", { type: "button", class: "af-rail-empty-new", title: "New session" }, "+ New");
+      const newBtn = h2(
+        "button",
+        { type: "button", class: "af-rail-empty-new", title: "New session" },
+        icon("plus"),
+        "New"
+      );
       newBtn.addEventListener("click", () => this.runRailExit(() => this.actions.newSession()));
       const empty = h2("li", { class: "af-rail-empty-project" }, `No active sessions in ${name} \u2014 `, newBtn);
       const archived = scoped.filter(isArchived).length;
@@ -11066,7 +11302,7 @@ var AppShell = class {
    *  (the row's own word — status.ts ROW_KIND_LABELS), and how many sessions in this
    *  project are in it. Clicking toggles just that state and leaves the menu open. */
   filterItem(kind, on, count) {
-    const check = h2("span", { class: "af-filter-check" }, on ? "\u2713" : "");
+    const check = h2("span", { class: "af-filter-check" }, ...on ? [icon("check")] : []);
     check.setAttribute("aria-hidden", "true");
     const item = h2(
       "button",
@@ -11126,7 +11362,7 @@ var AppShell = class {
    *  switches the active project and closes the menu. */
   projectItem(p, current) {
     const cls = `af-project-item${current ? " af-project-item-current" : ""}`;
-    const check = h2("span", { class: "af-project-check" }, current ? "\u2713" : "");
+    const check = h2("span", { class: "af-project-check" }, ...current ? [icon("check")] : []);
     check.setAttribute("aria-hidden", "true");
     const label = h2(
       "span",
@@ -11145,10 +11381,10 @@ var AppShell = class {
     });
     return item;
   }
-  /** The visible `+ New tab` button and its kind menu.
+  /** The visible New tab button and its kind menu.
    *
-   *  The old split control created a terminal from `+` and hid VS Code behind a
-   *  separate, unlabeled `▾`. Even the project's maintainer could not find that
+   *  The old split control created a terminal from a plus and hid VS Code behind a
+   *  separate, unlabeled caret. Even the project's maintainer could not find that
    *  path (#2077), so the labelled button now makes the choice explicit where the
    *  editor will appear. The `t` shortcut remains the direct shell fast path.
    *
@@ -11160,9 +11396,9 @@ var AppShell = class {
     const trigger = h2(
       "button",
       { type: "button", class: "af-tab-new", title: "Create a terminal or VS Code tab" },
-      h2("span", { class: "af-tab-new-plus" }, "+"),
+      icon("plus", "af-tab-new-plus"),
       h2("span", {}, "New tab"),
-      h2("span", { class: "af-tab-new-caret" }, "\u25BE")
+      icon("chevron-down", "af-tab-new-caret")
     );
     trigger.setAttribute("aria-haspopup", "menu");
     trigger.setAttribute("aria-expanded", "false");
@@ -11633,9 +11869,7 @@ function tabButton(tab, index, active, shown, canManage, actions2, liveIdentity,
   btn.setAttribute("role", "tab");
   btn.setAttribute("aria-selected", active ? "true" : "false");
   btn.dataset.tabIndex = String(index);
-  const glyph = h2("span", { class: "af-tab-glyph" }, tabGlyph(tab.kind));
-  glyph.setAttribute("aria-hidden", "true");
-  btn.append(glyph, h2("span", { class: "af-tab-label" }, tabLabel(tab)));
+  btn.append(icon(tabIcon(tab.kind), "af-tab-glyph"), h2("span", { class: "af-tab-label" }, tabLabel(tab)));
   btn.addEventListener("click", () => actions2.openTab(index));
   const renameable = canManage && isRenameableTab(tab.kind);
   btn.title = renameable ? `${tabDisplayLabel(tab)} \u2014 double-click to rename` : tabDisplayLabel(tab);
@@ -11648,7 +11882,7 @@ function tabButton(tab, index, active, shown, canManage, actions2, liveIdentity,
     });
   }
   if (index > 0 && canManage) {
-    const close = h2("span", { class: "af-tab-close", title: "Close tab" }, "\xD7");
+    const close = h2("span", { class: "af-tab-close", title: "Close tab" }, icon("x"));
     close.setAttribute("aria-hidden", "true");
     close.addEventListener("click", (e) => {
       e.stopPropagation();
@@ -11697,15 +11931,14 @@ function sessionRow(s, selected, openSession, buildActions) {
   const branch = h2(
     "div",
     { class: "af-row-branch" },
-    h2("span", { class: "af-branch-icon" }, "\u2387"),
-    " ",
+    icon("git-branch", "af-branch-icon"),
     s.branch || "\u2014"
   );
   const main = h2("div", { class: "af-row-main" }, title, branch);
   const cls = `af-row${selected ? " af-row-selected" : ""}${isArchived(s) ? " af-row-archived" : ""}${actionable ? "" : " af-row-inert"}${creating ? " af-row-creating" : ""}`;
   const row = h2("li", { class: cls });
-  if (status.kind) {
-    const dot = h2("span", { class: `af-dot af-dot-${status.kind}` }, status.glyph);
+  if (status.kind && status.icon) {
+    const dot = h2("span", { class: `af-dot af-dot-${status.kind}` }, icon(status.icon));
     dot.setAttribute("aria-hidden", "true");
     row.append(dot);
   }
@@ -12599,3 +12832,36 @@ if (document.readyState === "loading") {
 } else {
   mount();
 }
+/*! Bundled license information:
+
+lucide/dist/esm/icons/archive-restore.mjs:
+lucide/dist/esm/icons/archive.mjs:
+lucide/dist/esm/icons/arrow-right.mjs:
+lucide/dist/esm/icons/bot.mjs:
+lucide/dist/esm/icons/check.mjs:
+lucide/dist/esm/icons/chevron-down.mjs:
+lucide/dist/esm/icons/circle-dashed.mjs:
+lucide/dist/esm/icons/circle.mjs:
+lucide/dist/esm/icons/diamond.mjs:
+lucide/dist/esm/icons/ellipsis.mjs:
+lucide/dist/esm/icons/external-link.mjs:
+lucide/dist/esm/icons/folder-git-2.mjs:
+lucide/dist/esm/icons/funnel.mjs:
+lucide/dist/esm/icons/git-branch.mjs:
+lucide/dist/esm/icons/menu.mjs:
+lucide/dist/esm/icons/octagon-x.mjs:
+lucide/dist/esm/icons/panels-top-left.mjs:
+lucide/dist/esm/icons/plus.mjs:
+lucide/dist/esm/icons/refresh-cw.mjs:
+lucide/dist/esm/icons/square-check-big.mjs:
+lucide/dist/esm/icons/square.mjs:
+lucide/dist/esm/icons/terminal.mjs:
+lucide/dist/esm/icons/x.mjs:
+lucide/dist/esm/lucide.mjs:
+  (**
+   * @license lucide v1.25.0 - ISC
+   *
+   * This source code is licensed under the ISC license.
+   * See the LICENSE file in the root directory of this source tree.
+   *)
+*/

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "1fb36ba3e9ca";
+const VERSION = "590058e34134";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,6 +13,7 @@
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/xterm": "^5.5.0",
         "esbuild": "^0.25.10",
+        "lucide": "1.25.0",
         "tsx": "^4.20.6",
         "typescript": "5.7.2"
       }
@@ -571,6 +572,13 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/lucide": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/lucide/-/lucide-1.25.0.tgz",
+      "integrity": "sha512-Pg/9Ga1xTbrnI6GY/7J9krIYmJIkAf3PkK6wPmsAeUtAQsBdGxs1+dfvLqjf9nPI5aFm9+VquT75JGpO3QXSpQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/playwright": {
       "version": "1.56.1",

--- a/web/package.json
+++ b/web/package.json
@@ -17,6 +17,7 @@
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",
     "esbuild": "^0.25.10",
+    "lucide": "1.25.0",
     "tsx": "^4.20.6",
     "typescript": "5.7.2"
   }

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -989,16 +989,16 @@ test("status dots (#1766): waiting shows a green dot, working shows none, error 
   // would pass for the wrong reason.
   await expect(row(p, "probe-working")).toBeVisible({ timeout: 15_000 });
   await expect(row(p, "probe-working").locator(".af-dot")).toHaveCount(0);
-  // Waiting row: the static green ● dot, in the ready color bucket, never spinning.
+  // Waiting row: the static filled circle, in the ready color bucket, never spinning.
   const readyDot = row(p, "probe-waiting").locator(".af-dot");
   await expect(readyDot).toHaveClass(/af-dot-ready/);
-  await expect(readyDot).toHaveText("●");
+  await expect(readyDot.locator('.af-icon[data-icon="circle"]')).toHaveCount(1);
   await expect(readyDot).not.toHaveClass(/af-dot-spin/);
-  // Error/terminal states keep their STATIC glyphs (◌/○/◆), copied from the TUI.
-  await expect(row(p, "probe-lost").locator(".af-dot")).toHaveText("◌");
+  // Error/terminal states keep distinct STATIC shapes.
+  await expect(row(p, "probe-lost").locator('.af-icon[data-icon="circle-dashed"]')).toHaveCount(1);
   await expect(row(p, "probe-lost").locator(".af-dot")).toHaveClass(/af-dot-lost/);
-  await expect(row(p, "probe-dead").locator(".af-dot")).toHaveText("○");
-  await expect(row(p, "probe-limit").locator(".af-dot")).toHaveText("◆");
+  await expect(row(p, "probe-dead").locator('.af-icon[data-icon="circle"]')).toHaveCount(1);
+  await expect(row(p, "probe-limit").locator('.af-icon[data-icon="diamond"]')).toHaveCount(1);
   // The animation class is gone from every status row, and the removed "working" dot
   // kind never renders anywhere.
   await expect(p.locator(".af-dot-spin")).toHaveCount(0);
@@ -1163,8 +1163,8 @@ test("click-to-attach opens the xterm terminal and shows live output", REAL_FIXT
   await expect(row(page, SESSION_B).locator(".af-row-actions")).toHaveCSS("opacity", "0");
   await row(page, SESSION_A).hover();
   await expect(row(page, SESSION_A).locator(".af-row-actions")).toHaveCSS("opacity", "1");
-  await expect(railAction(page, SESSION_A, "Archive session")).toHaveText("▪");
-  await expect(railAction(page, SESSION_A, "Kill session")).toHaveText("⌫");
+  await expect(railAction(page, SESSION_A, "Archive session").locator('.af-icon[data-icon="archive"]')).toHaveCount(1);
+  await expect(railAction(page, SESSION_A, "Kill session").locator('.af-icon[data-icon="octagon-x"]')).toHaveCount(1);
   await expect(railAction(page, SESSION_A, "Kill session")).not.toHaveClass(/af-danger/);
   await expect(page.locator(".af-term-head button", { hasText: "Prompt" })).toHaveCount(0);
   await expect(page.locator(".af-term-head button", { hasText: "Archive" })).toHaveCount(0);
@@ -2980,20 +2980,22 @@ test("archive: an unselected row's hover action retires that session, not the se
   await expect(row(page, SESSION_B)).toHaveCount(0, { timeout: 30_000 });
 
   // B is NOT killed, though — revealing the archive brings the very same row back,
-  // muted, carrying the static ▧ archived dot (no spinner): the error/terminal states
-  // keep their static glyphs (#1766).
+  // muted, carrying the static archive shape (no spinner): the error/terminal states
+  // keep distinct static icons (#1766).
   await setFilter(page, "archived", true);
   await expect(row(page, SESSION_B)).toHaveClass(/af-row-archived/, { timeout: 30_000 });
   const archivedDot = row(page, SESSION_B).locator(".af-dot");
   await expect(archivedDot).toHaveClass(/af-dot-archived/);
-  await expect(archivedDot).toHaveText("▧");
+  await expect(archivedDot.locator('.af-icon[data-icon="archive"]')).toHaveCount(1);
   await expect(archivedDot).not.toHaveClass(/af-dot-spin/);
   // An archived unselected row reserves the same quiet slot, reveals it on hover,
   // and reverses the lifecycle action to Restore rather than Archive.
   await page.mouse.move(0, 0);
   await expect(row(page, SESSION_B).locator(".af-row-actions")).toHaveCSS("opacity", "0");
   await expect(railAction(page, SESSION_B, "Archive session")).toHaveCount(0);
-  await expect(railAction(page, SESSION_B, "Restore session")).toHaveText("↶");
+  await expect(
+    railAction(page, SESSION_B, "Restore session").locator('.af-icon[data-icon="archive-restore"]'),
+  ).toHaveCount(1);
   await row(page, SESSION_B).hover();
   await expect(row(page, SESSION_B).locator(".af-row-actions")).toHaveCSS("opacity", "1");
 
@@ -3022,7 +3024,9 @@ test("restore (#1932): the selected rail row's Restore action brings an archived
   // An archived session's lifecycle slot IS Restore, not Archive — one selected-row
   // slot whose accessible verb and static glyph both reverse.
   await expect(railAction(page, SESSION_B, "Archive session")).toHaveCount(0);
-  await expect(railAction(page, SESSION_B, "Restore session")).toHaveText("↶");
+  await expect(
+    railAction(page, SESSION_B, "Restore session").locator('.af-icon[data-icon="archive-restore"]'),
+  ).toHaveCount(1);
   await railAction(page, SESSION_B, "Restore session").click();
 
   // Restore is a confirm (mirroring kill/archive), so it inherits their busy/error
@@ -3038,7 +3042,7 @@ test("restore (#1932): the selected rail row's Restore action brings an archived
   // ...and its rail row — STILL selected, never reselected — flips its verb back to
   // Archive in place: the patchMainHead path remains load-bearing after the move.
   await expect(railAction(page, SESSION_B, "Restore session")).toHaveCount(0, { timeout: 30_000 });
-  await expect(railAction(page, SESSION_B, "Archive session")).toHaveText("▪");
+  await expect(railAction(page, SESSION_B, "Archive session").locator('.af-icon[data-icon="archive"]')).toHaveCount(1);
 
   // Re-archive from that same live-flipped button (NO reselect): restores the fixture
   // the downstream filter tests need (B archived) and re-proves both the archive leg
@@ -3049,7 +3053,9 @@ test("restore (#1932): the selected rail row's Restore action brings an archived
   await archiveModal.locator("button.af-primary").click();
   await expect(row(page, SESSION_B)).toHaveClass(/af-row-archived/, { timeout: 30_000 });
   await expect(railAction(page, SESSION_B, "Archive session")).toHaveCount(0);
-  await expect(railAction(page, SESSION_B, "Restore session")).toHaveText("↶");
+  await expect(
+    railAction(page, SESSION_B, "Restore session").locator('.af-icon[data-icon="archive-restore"]'),
+  ).toHaveCount(1);
 
   // Back to the default filter (archived hidden): B drops from the rail, exactly as
   // the archive test left it.
@@ -4771,6 +4777,104 @@ test("#2224: title and tabs share one scrolling header row at every width", REAL
   }
 });
 
+test("icons: the Lucide subset is inline, accessible, and currentColor-themed at desktop and 375px", REAL_FIXTURE, async ({
+  browser,
+}, testInfo) => {
+  const accentByTheme = new Map<string, string>();
+  for (const width of [1280, 375]) {
+    for (const theme of ["light", "dark"] as const) {
+      await test.step(`${width}px · ${theme}`, async () => {
+        const ctx = await browser.newContext({ viewport: { width, height: 720 } });
+        try {
+          await ctx.addInitScript((savedTheme) => localStorage.setItem("af-theme", savedTheme), theme);
+          const p = await ctx.newPage();
+          await openTokenless(p);
+          if (width === 375) {
+            await p.getByRole("button", { name: "Toggle sessions" }).click();
+            await expect(p.locator(".af-rail")).toBeVisible();
+          }
+
+          const projectIcon = p.locator(".af-project-glyph");
+          const filterIcon = p.locator(".af-rail-filter-glyph");
+          await expect(projectIcon).toBeVisible();
+          await expect(filterIcon).toBeVisible();
+          const projectPaint = await projectIcon.evaluate((node) => {
+            const style = getComputedStyle(node);
+            const box = node.getBoundingClientRect();
+            return { color: style.color, stroke: style.stroke, width: box.width, height: box.height };
+          });
+          expect(projectPaint.stroke, "stroke=currentColor must resolve to the icon's theme color").toBe(
+            projectPaint.color,
+          );
+          expect(projectPaint.width).toBeGreaterThanOrEqual(12);
+          expect(projectPaint.width).toBeLessThanOrEqual(16);
+          expect(projectPaint.height).toBe(projectPaint.width);
+          accentByTheme.set(theme, projectPaint.color);
+
+          const audit = await p.locator(".af-icon").evaluateAll((nodes) => {
+            const visible = nodes.filter((node) => {
+              const style = getComputedStyle(node);
+              const box = node.getBoundingClientRect();
+              return style.display !== "none" && style.visibility !== "hidden" && box.width > 0 && box.height > 0;
+            });
+            const unnamedIconControls = Array.from(document.querySelectorAll<HTMLElement>("button:has(.af-icon), a:has(.af-icon)"))
+              .filter((control) => {
+                const style = getComputedStyle(control);
+                const box = control.getBoundingClientRect();
+                return (
+                  style.display !== "none" &&
+                  style.visibility !== "hidden" &&
+                  box.width > 0 &&
+                  box.height > 0 &&
+                  (control.innerText ?? "").trim() === ""
+                );
+              })
+              .filter((control) => (control.getAttribute("aria-label") ?? "").trim() === "")
+              .map((control) => control.className);
+            const fontFaces = Array.from(document.styleSheets).flatMap((sheet) => {
+              try {
+                return Array.from(sheet.cssRules).filter((rule) => rule instanceof CSSFontFaceRule);
+              } catch {
+                return [];
+              }
+            }).length;
+            return {
+              count: visible.length,
+              allHiddenFromAT: visible.every(
+                (node) => node.getAttribute("aria-hidden") === "true" && node.getAttribute("focusable") === "false",
+              ),
+              allCurrentColor: visible.every((node) => getComputedStyle(node).stroke === getComputedStyle(node).color),
+              unnamedIconControls,
+              fontFaces,
+              fontRequests: performance
+                .getEntriesByType("resource")
+                .map((entry) => entry.name)
+                .filter((name) => /\.(?:woff2?|ttf|otf)(?:[?#]|$)/i.test(name)),
+            };
+          });
+          expect(audit.count, "the live shell must exercise several real icon placements").toBeGreaterThan(5);
+          expect(audit.allHiddenFromAT, "decorative SVGs stay out of the accessibility tree").toBe(true);
+          expect(audit.allCurrentColor, "every visible icon inherits the active theme color").toBe(true);
+          expect(audit.unnamedIconControls, "icon-only controls need an explicit accessible name").toEqual([]);
+          expect(audit.fontFaces, "the SVG subset must not smuggle in an icon font").toBe(0);
+          expect(audit.fontRequests, "the icon surface must make no font/network request").toEqual([]);
+          expect(await horizontalOverflow(p), "icons must not widen the desktop or phone layout").toBeLessThanOrEqual(1);
+
+          await testInfo.attach(`icons-${width}-${theme}`, {
+            body: await p.screenshot(),
+            contentType: "image/png",
+          });
+        } finally {
+          await ctx.close();
+        }
+      });
+    }
+  }
+  expect(accentByTheme.get("light"), "light and dark tokens must paint distinct icon colors").not.toBe(
+    accentByTheme.get("dark"),
+  );
+});
+
 test("vscode tab (#2077): the labelled New tab menu creates a VS Code tab and serves it through the proxy", REAL_FIXTURE, async () => {
   // End to end, with no seeded fixture: pick VS Code from the tab bar's kind menu,
   // and the daemon spawns a code-server (the FAKE one on PATH — no CI box has a
@@ -4953,7 +5057,7 @@ async function dragTabWithinBar(
   );
 }
 
-test("#1813: a pane header names its TAB — glyph + name — not a positional 'Tab N'", REAL_FIXTURE, async () => {
+test("#1813: a pane header names its tab — icon + name — not a positional 'Tab N'", REAL_FIXTURE, async () => {
   // The bug: every pane header read `Tab ${leaf.tab + 1}`, so at the exact moment the
   // label matters — several panes open, which is the whole point of splits — it told
   // you nothing, and it silently meant a different tab after a close.
@@ -4967,8 +5071,12 @@ test("#1813: a pane header names its TAB — glyph + name — not a positional '
 
   // Each header names its own tab, in pane order.
   await expect(page.locator(".af-term-host .af-pane-label")).toHaveText(["Agent", "alpha"]);
-  // ...with the kind glyph beside it, the same mark the tab bar draws (ui/tree/labels.go).
-  await expect(page.locator(".af-term-host .af-pane-glyph")).toHaveText(["◆", "◱"]);
+  // ...with the kind icon beside it, the same mark the tab bar draws.
+  expect(
+    await page.locator(".af-term-host .af-pane-glyph .af-icon").evaluateAll((nodes) =>
+      nodes.map((node) => node.getAttribute("data-icon")),
+    ),
+  ).toEqual(["bot", "panels"]);
   // The positional label is GONE — the assertion that would have failed before #1813.
   // Scoped to the pane host, which holds the panes and nothing else (the tab bar is
   // its sibling), and asserted on that single container rather than on the two
@@ -4976,10 +5084,10 @@ test("#1813: a pane header names its TAB — glyph + name — not a positional '
   await expect(page.locator(".af-term-host")).not.toContainText("Tab 1");
   await expect(page.locator(".af-term-host")).not.toContainText("Tab 2");
 
-  // The tab bar carries the same glyphs, so the two surfaces agree.
-  await expect(tabByLabel(page, "alpha").locator(".af-tab-glyph")).toHaveText("◱");
-  await expect(tabByLabel(page, "Agent").locator(".af-tab-glyph")).toHaveText("◆");
-  await expect(tabByLabel(page, "beta").locator(".af-tab-glyph")).toHaveText("›");
+  // The tab bar carries the same icons, so the two surfaces agree.
+  await expect(tabByLabel(page, "alpha").locator('.af-tab-glyph[data-icon="panels"]')).toHaveCount(1);
+  await expect(tabByLabel(page, "Agent").locator('.af-tab-glyph[data-icon="bot"]')).toHaveCount(1);
+  await expect(tabByLabel(page, "beta").locator('.af-tab-glyph[data-icon="terminal"]')).toHaveCount(1);
 });
 
 test("#1813: dragging a tab within the bar reorders it, and the order survives a reload", REAL_FIXTURE, async () => {

--- a/web/src/icon.ts
+++ b/web/src/icon.ts
@@ -1,0 +1,86 @@
+// The web UI's one icon surface: a deliberately small Lucide SVG subset. Named
+// imports let esbuild tree-shake the other ~1,600 icons, while inline SVG avoids a
+// font request, a private-use glyph fallback, and screen-reader pronunciation.
+// Lucide 1.25.0 is ISC licensed (some inherited Feather icons are MIT); the exact
+// upstream notice is committed at web/src/licenses/lucide/LICENSE.
+
+import {
+  Archive,
+  ArchiveRestore,
+  ArrowRight,
+  Bot,
+  Check,
+  ChevronDown,
+  Circle,
+  CircleDashed,
+  Diamond,
+  Ellipsis,
+  ExternalLink,
+  FolderGit2,
+  Funnel,
+  GitBranch,
+  Menu,
+  OctagonX,
+  PanelsTopLeft,
+  Plus,
+  RefreshCw,
+  Square,
+  SquareCheckBig,
+  Terminal,
+  X,
+  type IconNode,
+} from "lucide";
+
+const ICONS = {
+  archive: Archive,
+  "archive-restore": ArchiveRestore,
+  "arrow-right": ArrowRight,
+  bot: Bot,
+  check: Check,
+  "chevron-down": ChevronDown,
+  circle: Circle,
+  "circle-dashed": CircleDashed,
+  diamond: Diamond,
+  ellipsis: Ellipsis,
+  "external-link": ExternalLink,
+  "folder-git": FolderGit2,
+  funnel: Funnel,
+  "git-branch": GitBranch,
+  menu: Menu,
+  "octagon-x": OctagonX,
+  panels: PanelsTopLeft,
+  plus: Plus,
+  reload: RefreshCw,
+  square: Square,
+  "square-check": SquareCheckBig,
+  terminal: Terminal,
+  x: X,
+} as const satisfies Record<string, IconNode>;
+
+export type IconName = keyof typeof ICONS;
+
+/** Builds a decorative inline SVG that inherits the surrounding currentColor.
+ * Meaning stays on the adjacent text or the containing control's accessible name;
+ * callers cannot accidentally expose a private icon name to assistive technology. */
+export function icon(name: IconName, className = ""): SVGSVGElement {
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute("class", `af-icon${className ? ` ${className}` : ""}`);
+  svg.setAttribute("data-icon", name);
+  svg.setAttribute("viewBox", "0 0 24 24");
+  svg.setAttribute("fill", "none");
+  svg.setAttribute("stroke", "currentColor");
+  svg.setAttribute("stroke-width", "2");
+  svg.setAttribute("stroke-linecap", "round");
+  svg.setAttribute("stroke-linejoin", "round");
+  svg.setAttribute("aria-hidden", "true");
+  svg.setAttribute("focusable", "false");
+
+  for (const [tag, attrs] of ICONS[name]) {
+    const child = document.createElementNS("http://www.w3.org/2000/svg", tag);
+    for (const [attr, value] of Object.entries(attrs)) {
+      child.setAttribute(attr, String(value));
+    }
+    svg.append(child);
+  }
+  return svg;
+}

--- a/web/src/install.ts
+++ b/web/src/install.ts
@@ -26,6 +26,8 @@
 // Firefox and iOS Safari never fire beforeinstallprompt at all, so they simply never
 // see the button and use the browser's own add-to-home-screen. Nothing to do.
 
+import { icon } from "./icon.js";
+
 /** The Chromium-only event behind the install flow. Not in lib.dom, so it is declared
  *  here to the shape the spec gives it. */
 interface BeforeInstallPromptEvent extends Event {
@@ -104,7 +106,7 @@ export class InstallAffordance {
     const dismiss = document.createElement("button");
     dismiss.type = "button";
     dismiss.className = "af-install__dismiss";
-    dismiss.textContent = "×";
+    dismiss.append(icon("x"));
     dismiss.setAttribute("aria-label", "Dismiss install");
     dismiss.title = "Dismiss";
     dismiss.addEventListener("click", () => this.dismiss());

--- a/web/src/licenses/lucide/LICENSE
+++ b/web/src/licenses/lucide/LICENSE
@@ -1,0 +1,43 @@
+ISC License
+
+Copyright (c) 2026 Lucide Icons and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+---
+
+The following Lucide icons are derived from the Feather project:
+
+airplay, alert-circle, alert-octagon, alert-triangle, aperture, arrow-down-circle, arrow-down-left, arrow-down-right, arrow-down, arrow-left-circle, arrow-left, arrow-right-circle, arrow-right, arrow-up-circle, arrow-up-left, arrow-up-right, arrow-up, at-sign, calendar, cast, check, chevron-down, chevron-left, chevron-right, chevron-up, chevrons-down, chevrons-left, chevrons-right, chevrons-up, circle, clipboard, clock, code, columns, command, compass, corner-down-left, corner-down-right, corner-left-down, corner-left-up, corner-right-down, corner-right-up, corner-up-left, corner-up-right, crosshair, database, divide-circle, divide-square, dollar-sign, download, external-link, feather, frown, hash, headphones, help-circle, info, italic, key, layout, life-buoy, link-2, link, loader, lock, log-in, log-out, maximize, meh, minimize, minimize-2, minus-circle, minus-square, minus, monitor, moon, more-horizontal, more-vertical, move, music, navigation-2, navigation, octagon, pause-circle, percent, plus-circle, plus-square, plus, power, radio, rss, search, server, share, shopping-bag, sidebar, smartphone, smile, square, table-2, tablet, target, terminal, trash-2, trash, triangle, tv, type, upload, x-circle, x-octagon, x-square, x, zoom-in, zoom-out
+
+The MIT License (MIT) (for the icons listed above)
+
+Copyright (c) 2013-present Cole Bemis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/web/src/split.ts
+++ b/web/src/split.ts
@@ -49,6 +49,7 @@ import {
   validate,
 } from "./layout.js";
 import { probeWebTab } from "./api.js";
+import { icon } from "./icon.js";
 // isLoopbackWebUrl is deliberately NOT imported any more: #1817 folded that test into
 // iframeIsProxied, which also answers it for a vscode tab (always proxied, and with no
 // target to classify). Calling it directly here would re-fork the question.
@@ -61,7 +62,7 @@ import {
   paneAddressUsesOrdinal,
   webProxyPath,
 } from "./tabaddr.js";
-import { tabGlyph, tabLabel } from "./tablabel.js";
+import { tabIcon, tabLabel } from "./tablabel.js";
 import { AttachTerminal, type TerminalStatus } from "./terminal.js";
 import { currentXtermTheme } from "./theme.js";
 import { TabKind } from "./types.js";
@@ -89,7 +90,7 @@ interface Pane {
   container: HTMLElement;
   host: HTMLElement;
   label: HTMLElement;
-  /** The decorative kind glyph beside the label (#1813) — the same pair the tab bar
+  /** The decorative kind icon beside the label (#1813) — the same pair the tab bar
    *  draws, from the same two functions (tablabel.ts). */
   glyph: HTMLElement;
   overlay: HTMLElement;
@@ -710,7 +711,7 @@ export class SplitView {
       // changes this string and nothing else, so a label written once at build time
       // would keep showing the old name for the life of the pane.
       const named = { name: this.tabNames[leaf.tab] ?? "", kind: this.tabKinds[leaf.tab] ?? TabKind.Agent };
-      pane.glyph.textContent = tabGlyph(named.kind);
+      pane.glyph.replaceChildren(icon(tabIcon(named.kind)));
       pane.label.textContent = tabLabel(named);
     }
 
@@ -721,7 +722,7 @@ export class SplitView {
     const container = el("div", "af-pane");
     container.setAttribute("data-leaf", leaf.id);
     const head = el("div", "af-pane-head");
-    // The kind glyph is a decorative sibling of the label, exactly as in the tab bar
+    // The kind icon is a decorative sibling of the label, exactly as in the tab bar
     // (#1813): same two functions, same pair, so the two surfaces cannot drift.
     const glyph = el("span", "af-pane-glyph");
     glyph.setAttribute("aria-hidden", "true");
@@ -731,7 +732,7 @@ export class SplitView {
     closeBtn.className = "af-pane-close";
     closeBtn.title = "Close pane";
     closeBtn.setAttribute("aria-label", "Close pane");
-    closeBtn.textContent = "×";
+    closeBtn.append(icon("x"));
     closeBtn.addEventListener("click", (e) => {
       e.stopPropagation();
       this.closePane(leaf.id);
@@ -840,7 +841,7 @@ export class SplitView {
     reload.className = "af-ghost af-webpane-reload";
     reload.title = "Reload";
     reload.setAttribute("aria-label", isVSCode ? "Reload VS Code" : "Reload web tab");
-    reload.textContent = "↻"; // ↻
+    reload.append(icon("reload"));
     const urlText = el("span", "af-webpane-url");
     // A vscode tab has no URL worth showing (an ephemeral loopback port the user
     // can neither predict nor use); name what the pane IS instead.
@@ -851,7 +852,7 @@ export class SplitView {
     open.href = openHref;
     open.target = "_blank";
     open.rel = "noopener noreferrer";
-    open.textContent = "Open ↗"; // ↗
+    open.append("Open", icon("external-link"));
     bar.append(reload, urlText, open);
 
     const frame = document.createElement("iframe");
@@ -897,7 +898,7 @@ export class SplitView {
     fbLink.href = openHref;
     fbLink.target = "_blank";
     fbLink.rel = "noopener noreferrer";
-    fbLink.textContent = "Open in a new tab ↗";
+    fbLink.append("Open in a new tab", icon("external-link"));
     // The retry affordance, shown ONLY in the dead-server state (#1813) — the other
     // fallbacks (archived, no-URL, blocked embedding) have nothing to retry: they
     // resolve by restoring a session, fixing a record, or leaving the frame.
@@ -1048,7 +1049,7 @@ export class SplitView {
       fallback.classList.add("af-webpane-external");
       fbMsg.textContent = "This site may block embedding.";
       fbLink.hidden = false;
-      fbLink.textContent = "Open it in a new tab ↗"; // ↗
+      fbLink.replaceChildren("Open it in a new tab", icon("external-link"));
       fbRetry.hidden = true;
       // ↻ is withdrawn here for the same reason fbRetry is, and it is the same
       // judgement: this state is not a failure to recover from but the DESIGNED

--- a/web/src/status.test.ts
+++ b/web/src/status.test.ts
@@ -7,6 +7,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
+import type { IconName } from "./icon.js";
 import { type DotKind, isArchived, isCreating, isLimitReached, isWorking, rowStatus, rowTitle } from "./status.js";
 import { InFlightOp, Liveness, Status, type SessionData } from "./types.js";
 
@@ -15,28 +16,28 @@ function sess(over: Partial<SessionData> = {}): SessionData {
 }
 
 test("liveness → dot kind mirrors render.go's TOTAL switch", () => {
-  // Working (LiveRunning / the Unset sentinel) shows NO dot (#1766): null kind, empty
-  // glyph. Ready is the only positive/green dot; the error states keep static glyphs.
-  const cases: Array<[number, DotKind | null, string]> = [
-    [Liveness.Ready, "ready", "●"],
-    [Liveness.Lost, "lost", "◌"],
-    [Liveness.Dead, "dead", "○"],
-    [Liveness.Archived, "archived", "▧"],
-    [Liveness.LimitReached, "limit", "◆"],
-    [Liveness.Running, null, ""],
-    [Liveness.Unset, null, ""], // stray zero renders like Running (render.go:297)
+  // Working (LiveRunning / the Unset sentinel) shows NO dot (#1766): null kind and
+  // icon. Ready is the only positive/green dot; error states keep static shapes.
+  const cases: Array<[number, DotKind | null, IconName | null]> = [
+    [Liveness.Ready, "ready", "circle"],
+    [Liveness.Lost, "lost", "circle-dashed"],
+    [Liveness.Dead, "dead", "circle"],
+    [Liveness.Archived, "archived", "archive"],
+    [Liveness.LimitReached, "limit", "diamond"],
+    [Liveness.Running, null, null],
+    [Liveness.Unset, null, null], // stray zero renders like Running (render.go:297)
   ];
-  for (const [lv, kind, glyph] of cases) {
+  for (const [lv, kind, icon] of cases) {
     const st = rowStatus(sess({ liveness: lv }));
     assert.equal(st.kind, kind, `liveness ${lv} → ${kind}`);
-    assert.equal(st.glyph, glyph, `liveness ${lv} glyph`);
+    assert.equal(st.icon, icon, `liveness ${lv} icon`);
   }
 });
 
 test("a working row has no dot; Ready/error states do (#1766)", () => {
   const running = rowStatus(sess({ liveness: Liveness.Running }));
   assert.equal(running.kind, null, "Running is working → no dot");
-  assert.equal(running.glyph, "", "a working row draws no glyph");
+  assert.equal(running.icon, null, "a working row draws no icon");
   assert.equal(isWorking(sess({ liveness: Liveness.Running })), true);
   assert.equal(isWorking(sess({ liveness: Liveness.Unset })), true);
   assert.equal(isWorking(sess({ liveness: Liveness.Ready })), false);
@@ -49,7 +50,7 @@ test("any in-flight op overlays the liveness and reads as working (no dot)", () 
     // Even a Ready liveness reads as working while an op is in flight (render.go:280).
     const st = rowStatus(sess({ liveness: Liveness.Ready, in_flight_op: op }));
     assert.equal(st.kind, null, `op ${op} → working (no dot)`);
-    assert.equal(st.glyph, "", `op ${op} draws no glyph`);
+    assert.equal(st.icon, null, `op ${op} draws no icon`);
     assert.equal(isWorking(sess({ liveness: Liveness.Ready, in_flight_op: op })), true);
   }
 });
@@ -79,7 +80,7 @@ test("title prefixes match render.go precedence", () => {
     "[deleting] w",
   );
   assert.equal(rowTitle(sess({ title: "w", in_flight_op: InFlightOp.Archiving })), "[deleting] w");
-  // Archived carries NO word prefix (render.go:326-338) — the glyph + dimming say it.
+  // Archived carries NO word prefix (render.go:326-338) — the icon + dimming say it.
   assert.equal(rowTitle(sess({ title: "w", liveness: Liveness.Archived })), "w");
   // [remote] is outermost.
   assert.equal(

--- a/web/src/status.ts
+++ b/web/src/status.ts
@@ -6,12 +6,13 @@
 // in pixels (design §3). Adding a Liveness value forces a deliberate choice here,
 // mirroring the TUI's TOTAL liveness switch (render.go:274-301).
 //
-// Glyph shapes are copied from render.go so the state survives low contrast and
-// color-blindness the same way the TUI intends (its #935 discipline): a filled ●
-// for Ready, hollow ○/◌ for Dead/Lost, ▧ for Archived, ◆ for LimitReached. Colors
-// (the `kind`) map to the exact hexes render.go paints (see styles.css .af-dot-*).
+// SVG shapes preserve the TUI's low-contrast/color-blindness discipline: filled and
+// hollow circles for Ready/Dead, a dashed circle for Lost, an archive for Archived,
+// and a filled diamond for LimitReached. Colors (the `kind`) map to the exact hexes
+// render.go paints (see styles.css .af-dot-*).
 
 import { InFlightOp, Liveness, Status, type SessionData } from "./types.js";
+import type { IconName } from "./icon.js";
 
 /** The visual kind of a status dot, one per color bucket the TUI paints. Drives
  *  the .af-dot-<kind> CSS class whose color matches render.go's lipgloss styles.
@@ -40,27 +41,25 @@ export const ROW_KIND_LABELS: Record<RowKind, string> = {
  *  human label (used for the row's aria/title so the state is legible to a
  *  screen reader, not only by color — the same intent as the TUI's text prefixes). */
 export interface RowStatus {
-  /** The glyph to draw, or "" for a working/busy row which shows no dot (#1766). */
-  glyph: string;
+  /** The icon to draw, or null for a working/busy row which shows no dot (#1766). */
+  icon: IconName | null;
   /** The dot's color bucket, or null for a working row (the dot is omitted). */
   kind: DotKind | null;
   /** Accessible one-word state label, e.g. "Ready", "Working", "Lost". */
   label: string;
 }
 
-// Glyphs copied verbatim from ui/tree/render.go (readyIcon/deadIcon/lostIcon/
-// archivedIcon/limitIcon), minus the trailing pad space the terminal adds.
-const READY_GLYPH = "●";
-const DEAD_GLYPH = "○";
-const LOST_GLYPH = "◌";
-const ARCHIVED_GLYPH = "▧";
-const LIMIT_GLYPH = "◆";
+const READY_ICON: IconName = "circle";
+const DEAD_ICON: IconName = "circle";
+const LOST_ICON: IconName = "circle-dashed";
+const ARCHIVED_ICON: IconName = "archive";
+const LIMIT_ICON: IconName = "diamond";
 
 // A working/busy row shows NO status dot (#1766): the TUI renders a blank status
 // cell for LiveRunning / any in-flight op, and the web omits the dot entirely.
-// Kept as a resolved status (empty glyph, null kind) so rowStatus stays total and
+// Kept as a resolved status (null icon and kind) so rowStatus stays total and
 // callers can still detect the working state (isWorking, the project glance count).
-const WORKING: RowStatus = { glyph: "", kind: null, label: ROW_KIND_LABELS.working };
+const WORKING: RowStatus = { icon: null, kind: null, label: ROW_KIND_LABELS.working };
 
 /**
  * Resolves a session's status dot from its two axes, mirroring render.go exactly:
@@ -134,15 +133,15 @@ function livenessOf(s: SessionData): number {
 function dotForLiveness(lv: number): RowStatus {
   switch (lv) {
     case Liveness.Ready:
-      return { glyph: READY_GLYPH, kind: "ready", label: ROW_KIND_LABELS.ready };
+      return { icon: READY_ICON, kind: "ready", label: ROW_KIND_LABELS.ready };
     case Liveness.Lost:
-      return { glyph: LOST_GLYPH, kind: "lost", label: ROW_KIND_LABELS.lost };
+      return { icon: LOST_ICON, kind: "lost", label: ROW_KIND_LABELS.lost };
     case Liveness.Dead:
-      return { glyph: DEAD_GLYPH, kind: "dead", label: ROW_KIND_LABELS.dead };
+      return { icon: DEAD_ICON, kind: "dead", label: ROW_KIND_LABELS.dead };
     case Liveness.Archived:
-      return { glyph: ARCHIVED_GLYPH, kind: "archived", label: ROW_KIND_LABELS.archived };
+      return { icon: ARCHIVED_ICON, kind: "archived", label: ROW_KIND_LABELS.archived };
     case Liveness.LimitReached:
-      return { glyph: LIMIT_GLYPH, kind: "limit", label: ROW_KIND_LABELS.limit };
+      return { icon: LIMIT_ICON, kind: "limit", label: ROW_KIND_LABELS.limit };
     // LiveRunning and LivenessUnset both render as working (render.go:285, 297).
     case Liveness.Running:
     case Liveness.Unset:
@@ -151,13 +150,13 @@ function dotForLiveness(lv: number): RowStatus {
   }
 }
 
-/** True when the row is an archived session (dimmed, no text prefix — the ▧ glyph
- *  and dimming already convey it), mirroring render.go:335. */
+/** True when the row is an archived session (dimmed, no text prefix — the archive
+ *  icon and dimming already convey it), mirroring render.go:335. */
 export function isArchived(s: SessionData): boolean {
   return livenessOf(s) === Liveness.Archived;
 }
 
-/** True when the session is parked at a usage-limit wall — the state the ◆ glyph
+/** True when the session is parked at a usage-limit wall — the state the diamond
  *  and the "[limit] resets …" title prefix already render.
  *
  *  It gates the Retry action (#1934), mirroring the TUI, which advertises `c` only

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -271,6 +271,16 @@ body {
   min-height: 100vh;
 }
 
+/* All interface icons are inline Lucide SVGs. One sizing primitive keeps their
+ * 24px source grid crisp and lets every state inherit the surrounding currentColor. */
+.af-icon {
+  display: block;
+  width: 1em;
+  height: 1em;
+  flex: 0 0 auto;
+  pointer-events: none;
+}
+
 /* Login view */
 .af-login {
   min-height: 100vh;
@@ -478,7 +488,6 @@ body {
 .af-project-glyph {
   flex: 0 0 auto;
   color: var(--af-accent);
-  font-weight: 700;
 }
 
 .af-project-switch-name {
@@ -551,7 +560,6 @@ body {
   flex: 0 0 auto;
   width: 0.8rem;
   color: var(--af-accent);
-  font-weight: 700;
 }
 
 .af-project-item-label {
@@ -694,6 +702,9 @@ body {
 }
 
 .af-install__dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   padding: 0 0.3rem;
   background: transparent;
   color: var(--af-text-3);
@@ -823,7 +834,7 @@ body {
   display: flex;
 }
 
-/* The status filter control (feat: hide archived by default). A quiet glyph button —
+/* The status filter control (feat: hide archived by default). A quiet icon button —
  * it sits beside the accent-outlined + New, and two competing outlines in a 18rem
  * head would read as two primary actions. */
 .af-rail-filter {
@@ -858,7 +869,6 @@ body {
   width: 0.875rem;
   height: 0.875rem;
   flex: 0 0 auto;
-  fill: currentColor;
 }
 
 /* A static 4px dot — the #1766 rule: state reads from a static glyph, never motion. */
@@ -929,7 +939,6 @@ body {
   flex: 0 0 auto;
   width: 0.8rem;
   color: var(--af-accent);
-  font-weight: 700;
 }
 
 .af-filter-item-label {
@@ -1006,6 +1015,9 @@ body {
 }
 
 .af-rail-empty-new {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
   padding: 0.1rem 0.5rem;
   background: var(--af-accent-subtle);
   color: var(--af-accent);
@@ -1135,15 +1147,25 @@ body {
 }
 
 .af-branch-icon {
+  display: inline-block;
+  width: 0.85rem;
+  height: 0.85rem;
+  margin-right: 0.2rem;
+  vertical-align: -0.15rem;
   opacity: 0.8;
 }
 
-/* Status dot: the glyph itself carries shape (● / ○ / ◌ / ▧ / ◆ — copied from the
- * TUI so state survives color-blindness), the class carries the matching color. */
+/* Status icon: shape carries the state so it survives color-blindness; the class
+ * carries the matching TUI color. Every shape is static (#1766). */
 .af-dot {
   flex: 0 0 auto;
   line-height: 1.4;
   font-size: var(--af-fs-sm);
+}
+
+.af-dot-ready .af-icon,
+.af-dot-limit .af-icon {
+  fill: currentColor;
 }
 
 .af-dot-ready {
@@ -1367,13 +1389,14 @@ body {
   cursor: grabbing;
 }
 
-/* The tab's kind glyph (#1813): a quiet mark that tells agent / terminal / web apart
+/* The tab's kind icon (#1813): a quiet mark that tells agent / terminal / web apart
  * at a glance, mirroring the TUI (ui/tree/labels.go). Dimmer than the label even on
  * the active tab — it classifies, it doesn't compete with the name. */
 .af-tab-glyph {
   flex: 0 0 auto;
+  width: 0.8rem;
+  height: 0.8rem;
   color: var(--af-text-3, var(--af-text-2));
-  line-height: 1;
 }
 
 .af-tab-label {
@@ -1413,7 +1436,7 @@ body {
   display: none;
 }
 
-/* The × close affordance on a non-agent tab: dim until hovered, and it must not
+/* The close affordance on a non-agent tab: dim until hovered, and it must not
  * also trigger the tab's switch/attach (stopPropagation in ui.ts). */
 .af-tab-close {
   display: inline-flex;
@@ -1430,6 +1453,11 @@ body {
 .af-tab-close:hover {
   color: var(--af-danger);
   background: var(--af-danger-subtle);
+}
+
+.af-tab-close .af-icon {
+  width: 0.75rem;
+  height: 0.75rem;
 }
 
 /* The labelled new-tab control and its kind menu. The wrap keeps their lifecycle and
@@ -1504,7 +1532,6 @@ body {
 
 .af-tab-new-plus {
   font-size: var(--af-fs-md);
-  line-height: 0.8;
 }
 
 .af-tab-new-caret {
@@ -1657,7 +1684,7 @@ body {
   line-height: 1;
 }
 
-/* Takes the free space, so the glyph stays beside it and only the × is pushed right
+/* Takes the free space, so the icon stays beside it and only close is pushed right
  * (the head is space-between, and it has three children since #1813). min-width:0 is
  * what lets a long tab name actually ellipsize inside a flex item. */
 .af-pane-label {
@@ -1672,6 +1699,9 @@ body {
 }
 
 .af-pane-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   flex: 0 0 auto;
   padding: 0 var(--af-sp-1);
   background: transparent;
@@ -1732,6 +1762,7 @@ body {
   flex: 0 0 auto;
   display: inline-flex;
   align-items: center;
+  gap: 0.25rem;
   padding: 0.1rem 0.4rem;
   font-size: var(--af-fs-xs);
   line-height: 1.4;
@@ -1799,6 +1830,9 @@ body {
 }
 
 .af-webpane-fallback-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
   color: var(--af-accent);
 }
 
@@ -1912,6 +1946,9 @@ body {
 /* Rail "+ New" button (#1592 Phase 5 PR5): a compact accent-outlined action in
  * the rail header, beside the session count. */
 .af-rail-new {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
   padding: var(--af-sp-1) 0.55rem;
   background: transparent;
   color: var(--af-accent);
@@ -2278,6 +2315,9 @@ body {
 /* The tasks "+ Add" button, styled like the rail's "+ New" and pushed to the far
  * right of its header (its own class so the rail's .af-rail-new stays unambiguous). */
 .af-tasks-add {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
   margin-left: auto;
   padding: var(--af-sp-1) 0.55rem;
   background: transparent;
@@ -2322,6 +2362,12 @@ body {
   font-size: var(--af-fs-sm);
   color: var(--af-text-2);
   line-height: 1.5;
+}
+
+.af-task-target {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
 }
 
 .af-task-enabled.af-task-on {

--- a/web/src/tablabel.ts
+++ b/web/src/tablabel.ts
@@ -15,6 +15,7 @@
 // isRenameableTab): a rename would change a name no surface renders.
 
 import { TabKind } from "./types.js";
+import type { IconName } from "./icon.js";
 
 /** The fields any tab-shaped record must carry to be named. Structural, so both a
  *  wire TabData and split.ts's parallel kind/name arrays satisfy it. */
@@ -24,24 +25,22 @@ export interface NamedTab {
 }
 
 /**
- * The per-kind glyph a tab is prefixed with, mirroring the TUI's tab glyphs
- * (ui/tree/labels.go). Copied verbatim from that file — the Go side owns this map;
- * this is a mirror, not a second source of truth, exactly as status.ts mirrors
- * ui/tree/render.go's status glyphs.
+ * The per-kind icon a tab is prefixed with. It preserves the TUI's semantic groups
+ * (agent, terminal/process, browser surface) while using the web's Lucide subset.
  *
- * An unknown kind takes the process glyph, matching labelForTab's own default
+ * An unknown kind takes the process icon, matching labelForTab's own default
  * branch (which names an unknown kind like a process).
  */
-export function tabGlyph(kind: number): string {
+export function tabIcon(kind: number): IconName {
   switch (kind) {
     case TabKind.Agent:
-      return "◆";
+      return "bot";
     case TabKind.Shell:
-      return "›";
+      return "terminal";
     case TabKind.Process:
-      return "›";
-    // VS Code (#1817) shares the WEB glyph deliberately, on the same rule that has
-    // shell and process share `›`: the glyph names what a tab IS, and a VS Code tab
+      return "terminal";
+    // VS Code (#1817) shares the web icon deliberately, on the same rule that has
+    // shell and process share the terminal icon: the icon names what a tab IS, and a VS Code tab
     // is an embedded browser surface with no PTY — a web pane whose page happens to
     // be an editor. What separates them is the text beside the glyph ("VS Code" vs
     // the target's name), exactly as the command name separates a process tab from a
@@ -49,9 +48,9 @@ export function tabGlyph(kind: number): string {
     // which is the one thing it is not.
     case TabKind.Web:
     case TabKind.VSCode:
-      return "◱";
+      return "panels";
     default:
-      return "›";
+      return "terminal";
   }
 }
 
@@ -78,12 +77,11 @@ export function tabLabel(tab: NamedTab): string {
   }
 }
 
-/** The glyph and the label as one string — the tab's full display name, for a
- *  surface that renders it as a single run of text (a title/aria-label). Surfaces
- *  that render the glyph as its own decorative (aria-hidden) node compose
- *  tabGlyph + tabLabel themselves; this is the same string either way. */
+/** The tab's plain-text display name for titles and accessible names. The icon is
+ *  deliberately absent: every visual instance is a decorative aria-hidden SVG, so
+ *  assistive technology hears the meaningful label rather than an icon name. */
 export function tabDisplayLabel(tab: NamedTab): string {
-  return `${tabGlyph(tab.kind)} ${tabLabel(tab)}`;
+  return tabLabel(tab);
 }
 
 /**

--- a/web/src/tabux.test.ts
+++ b/web/src/tabux.test.ts
@@ -11,33 +11,33 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 
 import { cacheBustedWebSrc, nextReloadNonce } from "./tabaddr.js";
-import { isRenameableTab, tabDisplayLabel, tabGlyph, tabLabel } from "./tablabel.js";
+import { isRenameableTab, tabDisplayLabel, tabIcon, tabLabel } from "./tablabel.js";
 import { insertionIndexAt, PINNED_TABS, reorderTargetIndex } from "./tabreorder.js";
 import { TabKind } from "./types.js";
 
-// --- the kind → glyph map (mirrors ui/tree/labels.go) -----------------------
+// --- the kind → icon map ----------------------------------------------------
 
-test("tabGlyph: each kind gets the TUI's glyph", () => {
-  assert.equal(tabGlyph(TabKind.Agent), "◆");
-  assert.equal(tabGlyph(TabKind.Shell), "›");
-  assert.equal(tabGlyph(TabKind.Process), "›");
-  assert.equal(tabGlyph(TabKind.Web), "◱");
+test("tabIcon: each kind gets its semantic Lucide icon", () => {
+  assert.equal(tabIcon(TabKind.Agent), "bot");
+  assert.equal(tabIcon(TabKind.Shell), "terminal");
+  assert.equal(tabIcon(TabKind.Process), "terminal");
+  assert.equal(tabIcon(TabKind.Web), "panels");
 });
 
-test("tabGlyph: a VS Code tab shares the WEB glyph, not the process fallback (#1817)", () => {
-  // The rule that has shell and process share `›`: the glyph names what a tab IS, and
+test("tabIcon: a VS Code tab shares the web icon, not the process fallback (#1817)", () => {
+  // The rule that has shell and process share an icon: the icon names what a tab IS, and
   // a VS Code tab is an embedded browser surface with no PTY. Pinned explicitly
   // because the failure mode is SILENT — VSCode landing on the default arm would
-  // render `›` and call the editor a terminal, which is the one thing it is not.
-  assert.equal(tabGlyph(TabKind.VSCode), "◱");
-  assert.equal(tabGlyph(TabKind.VSCode), tabGlyph(TabKind.Web));
-  assert.notEqual(tabGlyph(TabKind.VSCode), tabGlyph(TabKind.Shell));
+  // render a terminal icon and call the editor a terminal, which it is not.
+  assert.equal(tabIcon(TabKind.VSCode), "panels");
+  assert.equal(tabIcon(TabKind.VSCode), tabIcon(TabKind.Web));
+  assert.notEqual(tabIcon(TabKind.VSCode), tabIcon(TabKind.Shell));
 });
 
-test("tabGlyph: an unknown kind falls back to the process glyph, as labelForTab does", () => {
+test("tabIcon: an unknown kind falls back to the process icon, as labelForTab does", () => {
   // ui/tree/labels.go's default branch names an unknown kind like a process; the
-  // glyph follows the same branch rather than rendering a blank.
-  assert.equal(tabGlyph(99), "›");
+  // icon follows the same branch rather than rendering a blank.
+  assert.equal(tabIcon(99), "terminal");
 });
 
 // --- the kind + name → label map (mirrors ui/tree/labels.go labelForTab) ----
@@ -70,19 +70,15 @@ test("tabLabel: a VS Code tab shows its name, or VS Code when it has none (#1817
   assert.equal(tabLabel({ name: "", kind: TabKind.VSCode }), "VS Code");
 });
 
-test("a VS Code tab reads as the web glyph plus its own text (#1817)", () => {
-  // The pair, composed: the glyph says "browser surface, no PTY", the text says which
-  // one. That division is the whole reason VSCode shares Web's glyph.
-  assert.equal(tabDisplayLabel({ name: "", kind: TabKind.VSCode }), "◱ VS Code");
-  assert.equal(tabDisplayLabel({ name: "editor", kind: TabKind.VSCode }), "◱ editor");
+test("a VS Code tab's text label stays independent of its decorative icon (#1817)", () => {
+  assert.equal(tabDisplayLabel({ name: "", kind: TabKind.VSCode }), "VS Code");
+  assert.equal(tabDisplayLabel({ name: "editor", kind: TabKind.VSCode }), "editor");
 });
 
-test("tabDisplayLabel: the glyph, one space, then the label", () => {
-  // The exact string both surfaces compose — the tab bar as two nodes, a pane header
-  // as two nodes, a title attribute as one. They must be the same pair either way.
-  assert.equal(tabDisplayLabel({ name: "preview", kind: TabKind.Web }), "◱ preview");
-  assert.equal(tabDisplayLabel({ name: "agent", kind: TabKind.Agent }), "◆ Agent");
-  assert.equal(tabDisplayLabel({ name: "x", kind: TabKind.Shell }), "› Terminal");
+test("tabDisplayLabel: accessible titles contain text, never icon glyphs", () => {
+  assert.equal(tabDisplayLabel({ name: "preview", kind: TabKind.Web }), "preview");
+  assert.equal(tabDisplayLabel({ name: "agent", kind: TabKind.Agent }), "Agent");
+  assert.equal(tabDisplayLabel({ name: "x", kind: TabKind.Shell }), "Terminal");
 });
 
 // --- pane label derivation --------------------------------------------------
@@ -96,7 +92,7 @@ test("pane label: a pane names its TAB, not its position (#1813)", () => {
     { name: "preview", kind: TabKind.Web },
     { name: "logs", kind: TabKind.Process },
   ];
-  assert.deepEqual(tabs.map(tabDisplayLabel), ["◆ Agent", "◱ preview", "› logs"]);
+  assert.deepEqual(tabs.map(tabDisplayLabel), ["Agent", "preview", "logs"]);
 });
 
 test("pane label: a rename changes the label the pane renders", () => {

--- a/web/src/tasks.ts
+++ b/web/src/tasks.ts
@@ -21,6 +21,7 @@
 // picker's Custom type.
 
 import { asForm, field, h, modalChrome, type ModalHandle, projectLabel } from "./modals.js";
+import { icon } from "./icon.js";
 import { PROGRAM_REPO_DEFAULT, type ProgramCatalog, type ProgramChoice, programChoices } from "./programs.js";
 import { SCHEDULE_TYPE_OPTIONS, type Schedule, type ScheduleType, cron as scheduleCron, describe as scheduleDescribe, parseCron } from "./schedule.js";
 import type { TaskData } from "./types.js";
@@ -142,7 +143,12 @@ export class TasksPane {
   }
 
   private render(tasks: TaskData[]): void {
-    const addBtn = h("button", { type: "button", class: "af-tasks-add", title: "Add task" }, "+ Add");
+    const addBtn = h(
+      "button",
+      { type: "button", class: "af-tasks-add", title: "Add task" },
+      icon("plus"),
+      "Add",
+    );
     addBtn.addEventListener("click", () => this.actions.add());
     const head = h(
       "div",
@@ -169,18 +175,24 @@ export class TasksPane {
   }
 
   private taskRow(t: TaskData): HTMLElement {
-    const glyph = t.enabled ? "[✓]" : "[ ]";
-    const enabledDot = h("span", { class: `af-task-enabled${t.enabled ? " af-task-on" : ""}` }, glyph);
+    const enabledDot = h(
+      "span",
+      { class: `af-task-enabled${t.enabled ? " af-task-on" : ""}` },
+      icon(t.enabled ? "square-check" : "square"),
+    );
     enabledDot.setAttribute("aria-hidden", "true");
 
     const name = h("div", { class: "af-task-name" }, t.name && t.name.trim() !== "" ? t.name : "(unnamed task)");
     const trigger = h("div", { class: "af-task-trigger" }, triggerSummary(t));
-    const metaParts: string[] = [];
+    const metaParts: (Node | string)[] = [];
     if (t.target_session && t.target_session.trim() !== "") {
-      metaParts.push(`→ ${t.target_session}`);
+      metaParts.push(
+        h("span", { class: "af-task-target" }, icon("arrow-right"), t.target_session),
+        " · ",
+      );
     }
     metaParts.push(lastRunSummary(t));
-    const meta = h("div", { class: "af-task-meta" }, metaParts.join("  ·  "));
+    const meta = h("div", { class: "af-task-meta" }, ...metaParts);
     const main = h("div", { class: "af-task-main" }, name, trigger, meta);
 
     const toggleBtn = h(

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -19,6 +19,7 @@
 // session changes (a deliberate user act that rebuilds the terminal anyway).
 
 import type { EventStreamStatus } from "./events.js";
+import { icon } from "./icon.js";
 import type { KeyboardFocus, View } from "./nav.js";
 import { VIEWS } from "./nav.js";
 import { resolveDragTab, TAB_DND_MIME } from "./layout.js";
@@ -42,7 +43,7 @@ import {
   rowTitle,
 } from "./status.js";
 import { ConfigPane, type ConfigStatus } from "./config.js";
-import { isRenameableTab, tabDisplayLabel, tabGlyph, tabLabel } from "./tablabel.js";
+import { isRenameableTab, tabDisplayLabel, tabIcon, tabLabel } from "./tablabel.js";
 import { insertionIndexAt, reorderTargetIndex } from "./tabreorder.js";
 import { TasksPane } from "./tasks.js";
 import { type ThemeChoice, THEME_CHOICES } from "./theme.js";
@@ -768,10 +769,8 @@ export class AppShell {
     // dropdown listing every project with counts. `margin-left:auto` (the wrap) pushes
     // it — and everything after it — to the right of the segmented view nav.
     this.projectSwitchName = h("span", { class: "af-project-switch-name" }, "—");
-    const switchGlyph = h("span", { class: "af-project-glyph" }, "▣");
-    switchGlyph.setAttribute("aria-hidden", "true");
-    const switchCaret = h("span", { class: "af-project-caret" }, "▼");
-    switchCaret.setAttribute("aria-hidden", "true");
+    const switchGlyph = icon("folder-git", "af-project-glyph");
+    const switchCaret = icon("chevron-down", "af-project-caret");
     this.projectSwitchBtn = h(
       "button",
       { type: "button", class: "af-project-switch" },
@@ -804,7 +803,7 @@ export class AppShell {
     // session drawer over the terminal. CSS keeps it display:none on desktop and shows
     // it only in the sessions view on a phone (the tasks/config views have no rail), so
     // it never competes with the appbar controls on a comfortable width.
-    this.navToggle = h("button", { type: "button", class: "af-nav-toggle" }, "☰");
+    this.navToggle = h("button", { type: "button", class: "af-nav-toggle" }, icon("menu"));
     this.navToggle.setAttribute("aria-label", "Toggle sessions");
     this.navToggle.setAttribute("aria-controls", "af-rail");
     this.navToggle.setAttribute("aria-expanded", "false");
@@ -825,7 +824,7 @@ export class AppShell {
     );
     appbarTools.setAttribute("role", "group");
     appbarTools.setAttribute("aria-label", "App controls");
-    const appbarMore = h("button", { type: "button", class: "af-appbar-more" }, "⋯");
+    const appbarMore = h("button", { type: "button", class: "af-appbar-more" }, icon("ellipsis"));
     appbarMore.setAttribute("aria-label", "More app controls");
     appbarMore.setAttribute("title", "More app controls");
     appbarMore.setAttribute("aria-controls", "af-appbar-tools");
@@ -889,22 +888,20 @@ export class AppShell {
     );
 
     this.railCount = h("span", { class: "af-rail-count" }, "0");
-    const newBtn = h("button", { type: "button", class: "af-rail-new", title: "New session" }, "+ New");
+    const newBtn = h(
+      "button",
+      { type: "button", class: "af-rail-new", title: "New session" },
+      icon("plus"),
+      "New",
+    );
     newBtn.addEventListener("click", () => this.runRailExit(() => this.actions.newSession()));
 
     // The status filter (feat: hide archived by default). A small funnel mark rather
     // than a word, so the rail head still fits the count + New at 18rem; the dot beside
     // it lights only when the filter is NARROWED from the default, so the normal state
-    // (archived hidden) never nags. This is deliberately an inline SVG: Unicode has no
-    // consistently rendered funnel, while currentColor preserves every button state.
-    const filterGlyph = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-    filterGlyph.classList.add("af-rail-filter-glyph");
-    filterGlyph.setAttribute("viewBox", "0 0 16 16");
-    filterGlyph.setAttribute("aria-hidden", "true");
-    filterGlyph.setAttribute("focusable", "false");
-    const filterGlyphPath = document.createElementNS("http://www.w3.org/2000/svg", "path");
-    filterGlyphPath.setAttribute("d", "M2 2h12L9.5 8v4.5L6.5 14V8L2 2Z");
-    filterGlyph.append(filterGlyphPath);
+    // (archived hidden) never nags. The shared icon helper keeps the funnel aligned
+    // with every other control and currentColor preserves every button state.
+    const filterGlyph = icon("funnel", "af-rail-filter-glyph");
     this.filterDot = h("span", { class: "af-rail-filter-dot" });
     this.filterDot.setAttribute("aria-hidden", "true");
     this.filterBtn = h("button", { type: "button", class: "af-rail-filter" }, filterGlyph, this.filterDot);
@@ -1276,10 +1273,14 @@ export class AppShell {
 
     if (isKillableSession(session)) {
       const killSession = session;
-      // Kill stays unmistakably destructive through its distinct ⌫ glyph and
+      // Kill stays unmistakably destructive through its distinct octagon-x icon and
       // confirm, but its resting rail treatment remains muted instead of af-danger.
       const killClass = surface === "rail" ? "af-rail-action af-rail-kill" : "af-ghost af-term-action af-term-kill";
-      const killBtn = h("button", { type: "button", class: killClass }, surface === "rail" ? "⌫" : "Kill");
+      const killBtn = h(
+        "button",
+        { type: "button", class: killClass },
+        ...(surface === "rail" ? [icon("octagon-x")] : ["Kill"]),
+      );
       const killLabel = `Kill session “${killSession.title}”`;
       killBtn.setAttribute("aria-label", killLabel);
       killBtn.setAttribute("title", killLabel);
@@ -1296,7 +1297,7 @@ export class AppShell {
     return buttons;
   }
 
-  /** Applies the daemon-projected verb, glyph, and target-qualified accessible name
+  /** Applies the daemon-projected verb, icon, and target-qualified accessible name
    *  in one place so render and same-selection live patching cannot drift. */
   private patchLifecycleButton(
     btn: HTMLElement,
@@ -1307,7 +1308,11 @@ export class AppShell {
     const verb = action === "restore" ? "Restore session" : "Archive session";
     const label = `${verb} “${sessionTitle}”`;
     btn.dataset.action = action;
-    btn.textContent = surface === "rail" ? (action === "restore" ? "↶" : "▪") : verb.replace(" session", "");
+    if (surface === "rail") {
+      btn.replaceChildren(icon(action === "restore" ? "archive-restore" : "archive"));
+    } else {
+      btn.textContent = verb.replace(" session", "");
+    }
     btn.setAttribute("aria-label", label);
     btn.setAttribute("title", label);
   }
@@ -1329,7 +1334,12 @@ export class AppShell {
     const name = projectName(state.selectedProject ?? "");
     const hasActive = scoped.some((s) => !isArchived(s));
     if (!hasActive) {
-      const newBtn = h("button", { type: "button", class: "af-rail-empty-new", title: "New session" }, "+ New");
+      const newBtn = h(
+        "button",
+        { type: "button", class: "af-rail-empty-new", title: "New session" },
+        icon("plus"),
+        "New",
+      );
       newBtn.addEventListener("click", () => this.runRailExit(() => this.actions.newSession()));
       const empty = h("li", { class: "af-rail-empty-project" }, `No active sessions in ${name} — `, newBtn);
       const archived = scoped.filter(isArchived).length;
@@ -1381,7 +1391,7 @@ export class AppShell {
    *  (the row's own word — status.ts ROW_KIND_LABELS), and how many sessions in this
    *  project are in it. Clicking toggles just that state and leaves the menu open. */
   private filterItem(kind: RowKind, on: boolean, count: number): HTMLElement {
-    const check = h("span", { class: "af-filter-check" }, on ? "✓" : "");
+    const check = h("span", { class: "af-filter-check" }, ...(on ? [icon("check")] : []));
     check.setAttribute("aria-hidden", "true");
     const item = h(
       "button",
@@ -1453,7 +1463,7 @@ export class AppShell {
    *  switches the active project and closes the menu. */
   private projectItem(p: ProjectSummary, current: boolean): HTMLElement {
     const cls = `af-project-item${current ? " af-project-item-current" : ""}`;
-    const check = h("span", { class: "af-project-check" }, current ? "✓" : "");
+    const check = h("span", { class: "af-project-check" }, ...(current ? [icon("check")] : []));
     check.setAttribute("aria-hidden", "true");
     const label = h(
       "span",
@@ -1473,10 +1483,10 @@ export class AppShell {
     return item;
   }
 
-  /** The visible `+ New tab` button and its kind menu.
+  /** The visible New tab button and its kind menu.
    *
-   *  The old split control created a terminal from `+` and hid VS Code behind a
-   *  separate, unlabeled `▾`. Even the project's maintainer could not find that
+   *  The old split control created a terminal from a plus and hid VS Code behind a
+   *  separate, unlabeled caret. Even the project's maintainer could not find that
    *  path (#2077), so the labelled button now makes the choice explicit where the
    *  editor will appear. The `t` shortcut remains the direct shell fast path.
    *
@@ -1488,9 +1498,9 @@ export class AppShell {
     const trigger = h(
       "button",
       { type: "button", class: "af-tab-new", title: "Create a terminal or VS Code tab" },
-      h("span", { class: "af-tab-new-plus" }, "+"),
+      icon("plus", "af-tab-new-plus"),
       h("span", {}, "New tab"),
-      h("span", { class: "af-tab-new-caret" }, "▾"),
+      icon("chevron-down", "af-tab-new-caret"),
     );
     trigger.setAttribute("aria-haspopup", "menu");
     trigger.setAttribute("aria-expanded", "false");
@@ -2204,15 +2214,14 @@ function tabButton(
   btn.setAttribute("aria-selected", active ? "true" : "false");
   // The index the delegated dragstart reads to build the drag payload.
   btn.dataset.tabIndex = String(index);
-  // The kind glyph (#1813), a DECORATIVE sibling of the label rather than part of
-  // its text: the pane headers render the very same glyph+label pair from the very
+  // The kind icon (#1813), a DECORATIVE sibling of the label rather than part of
+  // its text: the pane headers render the very same icon+label pair from the very
   // same two functions, so the two surfaces agree by construction — but keeping the
-  // glyph out of .af-tab-label leaves that node's text the bare label, which is what
+  // icon out of .af-tab-label leaves that node's text the bare label, which is what
   // both the bar's own aria-selected semantics and every existing label assertion
-  // read. tabDisplayLabel() is the same pair as one string, used for the title.
-  const glyph = h("span", { class: "af-tab-glyph" }, tabGlyph(tab.kind));
-  glyph.setAttribute("aria-hidden", "true");
-  btn.append(glyph, h("span", { class: "af-tab-label" }, tabLabel(tab)));
+  // read. tabDisplayLabel() supplies the plain-text title without leaking an icon
+  // name into the accessible surface.
+  btn.append(icon(tabIcon(tab.kind), "af-tab-glyph"), h("span", { class: "af-tab-label" }, tabLabel(tab)));
   btn.addEventListener("click", () => actions.openTab(index));
   // Rename-in-place (#1813), offered ONLY where a name is actually rendered: an
   // agent/shell tab draws a fixed label and ignores its name, so an edit there could
@@ -2234,7 +2243,7 @@ function tabButton(
   }
   // The agent tab (index 0) is unclosable — killing the session tears it down.
   if (index > 0 && canManage) {
-    const close = h("span", { class: "af-tab-close", title: "Close tab" }, "×");
+    const close = h("span", { class: "af-tab-close", title: "Close tab" }, icon("x"));
     close.setAttribute("aria-hidden", "true");
     close.addEventListener("click", (e) => {
       e.stopPropagation();
@@ -2367,8 +2376,7 @@ function sessionRow(
   const branch = h(
     "div",
     { class: "af-row-branch" },
-    h("span", { class: "af-branch-icon" }, "⎇"),
-    " ",
+    icon("git-branch", "af-branch-icon"),
     s.branch || "—",
   );
   const main = h("div", { class: "af-row-main" }, title, branch);
@@ -2380,8 +2388,8 @@ function sessionRow(
   // A working/busy row shows NO status dot (#1766) — only Ready/error states draw
   // one. When there is no dot the span is omitted entirely (kind is null), matching
   // the TUI's blank status cell.
-  if (status.kind) {
-    const dot = h("span", { class: `af-dot af-dot-${status.kind}` }, status.glyph);
+  if (status.kind && status.icon) {
+    const dot = h("span", { class: `af-dot af-dot-${status.kind}` }, icon(status.icon));
     dot.setAttribute("aria-hidden", "true");
     row.append(dot);
   }


### PR DESCRIPTION
## Summary

- Replaces every web UI Unicode/emoji icon and the one hand-drawn funnel with a 23-node Lucide 1.25.0 inline SVG subset.
- Keeps the daemon fully self-hosted: the selected SVG nodes are compiled into `web/dist/af-web.js`; there is no font file, CDN, runtime fetch, inline HTML injection, or CSP dependency.
- Centralizes icon construction so every SVG inherits `currentColor`, is static, and is decorative by default (`aria-hidden="true"`, `focusable="false"`). Icon-only buttons retain explicit accessible names.
- Commits the rebuilt `web/dist` output and the exact upstream license notice.

## Selection

The real inventory needs project/navigation, lifecycle, tab-kind, status, task, and web-pane symbols. It is not just a set of generic arrows and close marks.

| Candidate | Coverage of this inventory | At 14–16px | License | Subset/size posture | Dense terminal-adjacent fit |
| --- | --- | --- | --- | --- | --- |
| [Lucide](https://lucide.dev/) | Direct semantic match for all 23 shipped nodes | Consistent 24px grid and 2px rounded stroke | ISC; inherited Feather nodes retain MIT notices | Named imports tree-shake to an actual **+8,081-byte** `web/dist` delta; no font | Best balance: quiet, legible outlines without making the rail feel like a toolbar |
| [Feather](https://github.com/feathericons/feather) | Covers primitives, but lacks strong matches for bot, folder-git, archive restore, dashed status, and pane kind | Excellent 24px/2px baseline | MIT | Small as individual SVGs, but gaps require custom or misleading substitutions | Clean, but too sparse semantically for the real list |
| [Phosphor](https://github.com/phosphor-icons/core) | Broad coverage across the list | Consistent, but its 256-unit grid and weight choices require more tuning at this size | MIT | Subsetting is practical; multiple weight variants add avoidable choice/weight | More expressive and rounded than this compact utility surface needs |
| [Heroicons](https://github.com/tailwindlabs/heroicons) | Gaps around bot, git-branch, and lifecycle/status semantics | Strong 16px mini set, but coverage would mix mini/solid/24px outline families | MIT | Per-icon delivery is small | Family mixing would make adjacent rail and tab icons inconsistent |
| [Bootstrap Icons](https://github.com/twbs/icons) | Broad coverage | Native 16px grid is crisp | MIT | Individual SVGs can be small; the full icon font is unnecessary | Fill-heavy language is louder and less consistent with the current UI |
| [Material Symbols](https://github.com/google/material-design-icons/tree/master/variablefont) | Broad coverage | Optical-size axis starts at 20px, above the main 14–16px use | Apache-2.0 | A self-hosted variable-font subset still keeps font loading/fallback failure modes | Familiar, but visually heavier and less terminal-adjacent |

Lucide wins, but **inline SVG wins over an icon font**. A font can fail to a blank/private-use glyph, can be pronounced strangely, and adds a font request and CSP surface. The SVG helper creates real DOM nodes without `innerHTML`, embeds only the selected paths, inherits theme color, and leaves room for multi-tone icons later without changing delivery.

## Before/after inventory

| Before | Meaning and surface | After |
| --- | --- | --- |
| `▣` | Current project / project switcher | `folder-git` |
| `▼`, `▾` | Project and New tab menu disclosure | `chevron-down` |
| `☰` | Mobile session drawer | `menu` |
| `⋯` | More app controls | `ellipsis` |
| Hand-authored funnel path | Session status filter | `funnel` |
| `+` | New session, empty-state New, New tab, Add task | `plus` |
| `⌫` | Kill session | `octagon-x` |
| `▪` | Archive session | `archive` |
| `↶` | Restore session | `archive-restore` |
| `✓` | Selected project / enabled filter | `check` |
| `[✓]`, `[ ]` | Enabled / disabled scheduled task | `square-check`, `square` |
| `×` | Tab close, pane close, install dismissal | `x` |
| `⎇` | Session git branch | `git-branch` |
| `●`, `○`, `◌` | Ready, dead, lost status | Filled `circle`, outline `circle`, `circle-dashed` |
| `▧` | Archived status | `archive` |
| `◆` | Usage-limit status | Filled `diamond` |
| `◆` | Agent tab kind | `bot` |
| `›` | Shell/process tab kind | `terminal` |
| `◱` | Web/VS Code tab kind | `panels` |
| `↻` | Reload embedded web pane | `refresh-cw` |
| `↗` | Open embedded page externally | `external-link` |
| `→` | Scheduled-task target session | `arrow-right` |

Working status intentionally remains blank, and punctuation used as copy (`…`, `—`, and ` · `) remains text rather than being misclassified as an icon. Status remains readable from static shape plus color; no spinner or pulsing state was introduced.

## License

Lucide 1.25.0 is under the permissive ISC license. The upstream distribution also identifies its Feather-derived icons and carries their MIT license. The complete notice is vendored verbatim at `web/src/licenses/lucide/LICENSE`.

## Committed bundle delta

Measured from the rebased `origin/master` tree to head `291e6ed2f174fa04377418401715f2cb14f9d877`:

| `web/dist` file | Before | After | Delta |
| --- | ---: | ---: | ---: |
| `af-web.js` | 643,729 B | 651,044 B | +7,315 B |
| `af-web.css` | 50,120 B | 50,886 B | +766 B |
| `sw.js` | 10,775 B | 10,775 B | 0 B (cache hash only) |
| **All of `web/dist`** | **728,647 B** | **736,728 B** | **+8,081 B (+1.11%)** |

No WOFF/WOFF2/TTF/OTF or other icon asset is added.

## Browser and accessibility verification

The real Chromium harness now exercises the icon surface at 1280px and 375px in both light and dark themes. It verifies that visible icons resolve `stroke: currentColor` to the surrounding theme color, stay in the 12–16px range, make no font/network request, remain hidden from assistive technology, leave no visible unnamed icon-only button/link, and introduce no horizontal overflow. Existing mobile geometry coverage also checks 320px, 375px, and the open drawer action row.

## Test plan

- [x] Rebased onto `origin/master`, then ran `make web-build`; committed output reproduces cleanly
- [x] `make web-test` — 402/402, including TypeScript typecheck
- [x] `make web-selftest-container` — 112/112 real Chromium tests
- [x] `make test-container`
- [x] `golangci-lint run --timeout=3m --fast`
- [x] `gofmt -l .` — no output
- [x] `go build ./...`
- [x] `deadcode -test ./...` — no output
- [x] `scripts/lint-file-length.sh`
- [x] TUI manual test not applicable; no TUI behavior changed

— Captain Claude
