### PR TITLE
fix(backends): label configured hooks by launcher

### DIFF
--- a/daemon/backends.go
+++ b/daemon/backends.go
@@ -2,6 +2,8 @@ package daemon
 
 import (
 	"fmt"
+	"path/filepath"
+	"strings"
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/session"
@@ -57,6 +59,10 @@ type ListBackendsRequest struct {
 type BackendOption struct {
 	// Name is the wire value: what a client sends back as CreateSessionRequest.Backend.
 	Name string `json:"name"`
+	// Label is the user-facing name clients render. It normally matches Name, but
+	// the hook backend names the remote sandbox launcher the repo configured while
+	// retaining "hook" as the literal CLI/config key.
+	Label string `json:"label"`
 	// Status is the checked answer; see BackendAvailability.
 	Status BackendAvailability `json:"status"`
 	// Reason is the actionable, user-facing explanation whenever Status is not
@@ -137,7 +143,7 @@ func backendCatalog(names []string, cfg *config.ResolvedConfig, cfgErr error, re
 // fabricated finding: docker.image might be set perfectly well in a file with a
 // stray comma elsewhere. The user needs to hear about the comma.
 func backendOptionFor(kind session.BackendKind, cfg *config.ResolvedConfig, cfgErr error, repoRoot string) BackendOption {
-	opt := BackendOption{Name: string(kind)}
+	opt := BackendOption{Name: string(kind), Label: backendLabel(kind, cfg)}
 
 	if cfgErr != nil {
 		// local is the one backend that reads nothing from the repo config, so an
@@ -160,6 +166,24 @@ func backendOptionFor(kind session.BackendKind, cfg *config.ResolvedConfig, cfgE
 	}
 	opt.Status = BackendAvailable
 	return opt
+}
+
+// backendLabel turns the daemon's resolved repo config into presentation text so
+// every client describes a backend the same way. "hook" is an implementation key;
+// the configured launcher's basename is the useful identity. The key stays visible
+// because users still select it through `--backend hook` and `backend = "hook"`.
+func backendLabel(kind session.BackendKind, cfg *config.ResolvedConfig) string {
+	if kind != session.BackendHook {
+		return string(kind)
+	}
+
+	if cfg != nil && cfg.RemoteHooks != nil {
+		launcher := filepath.Base(strings.TrimSpace(cfg.RemoteHooks.LaunchCmd))
+		if launcher != "" && launcher != "." {
+			return fmt.Sprintf("Remote sandbox · %s (hook)", launcher)
+		}
+	}
+	return "Remote sandbox (hook)"
 }
 
 // defaultFor reports the backend an unspecified create resolves to, and whether

--- a/daemon/backends_test.go
+++ b/daemon/backends_test.go
@@ -74,6 +74,7 @@ func TestListBackends_OffersEverySupportedBackend(t *testing.T) {
 	names := make([]string, 0, len(resp.Backends))
 	for _, opt := range resp.Backends {
 		names = append(names, opt.Name)
+		assert.NotEmptyf(t, opt.Label, "%s must carry a user-facing label", opt.Name)
 	}
 	assert.Equal(t, config.SupportedBackends, names, "the catalog is the canonical enum, in canonical order")
 	// The RPC feeds the canonical enum straight into the catalog builder and does no
@@ -240,6 +241,43 @@ func TestListBackends_HookAvailableWhenCommandsResolve(t *testing.T) {
 	assert.Empty(t, opt.Reason)
 }
 
+// TestListBackends_HookLabelNamesConfiguredLauncher is the regression for #2189:
+// "hook" describes af's plumbing, not the remote sandbox a repo configured. The
+// daemon owns the resolved repo config, so its wire response must carry the human
+// label rather than making each client reverse-engineer launch_cmd independently.
+func TestListBackends_HookLabelNamesConfiguredLauncher(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	stubLookPath(t)
+	repo := setupControlRepo(t)
+	writeRepoBackendConfig(t, repo, map[string]any{
+		"remote_hooks": map[string]any{
+			"launch_cmd": "./infra/coder-launch.sh",
+			"delete_cmd": "./infra/coder-delete.sh",
+		},
+	})
+
+	// Decode the public JSON shape rather than reaching for a Go field that the
+	// old response did not have. That lets this regression compile against the
+	// broken implementation and fail on the actual missing wire contract.
+	blob, err := json.Marshal(listBackends(t, repo))
+	require.NoError(t, err)
+	var wire struct {
+		Backends []struct {
+			Name  string `json:"name"`
+			Label string `json:"label"`
+		} `json:"backends"`
+	}
+	require.NoError(t, json.Unmarshal(blob, &wire))
+
+	for _, opt := range wire.Backends {
+		if opt.Name == config.BackendHook {
+			assert.Equal(t, "Remote sandbox · coder-launch.sh (hook)", opt.Label)
+			return
+		}
+	}
+	t.Fatalf("backend %q missing from the catalog %+v", config.BackendHook, wire.Backends)
+}
+
 // TestListBackends_EmptyHookCommandIsNotAvailable: remote_hooks present but
 // launch_cmd empty. RemoteHooks.Validate is what create runs, so reusing it here is
 // what stops "configured" from ever again meaning merely "the section exists".
@@ -322,6 +360,7 @@ func TestListBackends_NewBackendReachesClientsWithNoClientChange(t *testing.T) {
 
 	fargate := catalog[len(catalog)-1]
 	assert.Equal(t, "fargate", fargate.Name, "a newly added backend lands in enum order, not appended by a special case")
+	assert.Equal(t, "fargate", fargate.Label, "an unknown backend keeps its daemon-provided wire name as the label")
 	assert.Equal(t, BackendAvailable, fargate.Status, "a backend with no repo-config requirement is selectable as soon as it is in the enum")
 	assert.Empty(t, fargate.Reason)
 }

--- a/scripts/container/web-selftest-entry.sh
+++ b/scripts/container/web-selftest-entry.sh
@@ -172,6 +172,32 @@ for repo in "$MOCK" "$MOCK2" "$MOCK3"; do
     fi
 done
 
+# #2189: the primary repo has a real, versioned remote-hook configuration. The
+# commands only need to be discoverable for ListBackends' side-effect-free
+# availability check; the browser test never provisions a remote workspace.
+# Keeping the executable's real name in launch_cmd is what lets the daemon turn
+# af's internal "hook" key into the intent-bearing picker label.
+mkdir -p "$MOCK/.agent-factory"
+cat >"$MOCK/.agent-factory/config.json" <<'EOF'
+{
+  "remote_hooks": {
+    "launch_cmd": "coder-launch.sh",
+    "delete_cmd": "coder-delete.sh"
+  }
+}
+EOF
+git -C "$MOCK" add .agent-factory/config.json
+git -C "$MOCK" commit -qm "configure mock remote sandbox"
+
+for hook in coder-launch.sh coder-delete.sh; do
+    cat >"/usr/local/bin/$hook" <<'EOF'
+#!/bin/sh
+# The web selftest only probes availability; provisioning would be a fixture bug.
+exit 99
+EOF
+    chmod +x "/usr/local/bin/$hook"
+done
+
 # --- start the daemon + wait for the HTTP listener --------------------------
 # Both are functions because the harness restarts the daemon once, to seed a record
 # no API can mint (see the URL-less web tab below); the restart must reuse this exact

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -6392,7 +6392,7 @@ function backendChoices(catalog) {
       // "Repo default" with no parenthetical when the daemon reports no default:
       // that is the misconfigured case, where naming a backend would be inventing
       // one. The reason says what is wrong with the key.
-      label: catalog.default === "" ? "Repo default" : `Repo default (${catalog.default})`,
+      label: catalog.default === "" ? "Repo default" : `Repo default (${catalog.backends.find((opt) => opt.name === catalog.default)?.label ?? catalog.default})`,
       // Taken from the daemon, not inferred here. A repo whose declared default is
       // broken resolves to that broken backend and FAILS — it does not quietly run
       // local — so the default is not automatically a safe harbour.
@@ -6403,7 +6403,7 @@ function backendChoices(catalog) {
   for (const opt of catalog.backends) {
     choices.push({
       value: opt.name,
-      label: opt.name,
+      label: opt.label,
       status: opt.status,
       reason: opt.status === "available" ? "" : opt.reason ?? ""
     });

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "1ae52e8c1ecd";
+const VERSION = "aefa8c762798";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -2891,7 +2891,7 @@ test.describe("create → kill (one session, two flows)", () => {
     // "repo default"-only placeholder the field is built with.
     await expect(backendSelect.locator("option")).not.toHaveCount(1, { timeout: 30_000 });
     await expect(backendSelect.locator("option")).toHaveText(
-      [/^Repo default \(local\)$/, "local", "docker", "ssh", "hook"],
+      [/^Repo default \(local\)$/, "local", "docker", "ssh", "Remote sandbox · coder-launch.sh (hook)"],
       { timeout: 30_000 },
     );
     // The mock repo configures no docker.image. Picking docker must state the missing
@@ -2901,6 +2901,12 @@ test.describe("create → kill (one session, two flows)", () => {
     await backendSelect.selectOption("docker");
     await expect(modal.locator(".af-modal-hint")).toHaveText(/docker\.image/);
     await expect(modal.locator("button.af-primary")).toBeDisabled();
+
+    // The repo's versioned remote_hooks config is available, and the option names
+    // its launcher while retaining "hook" as the submitted CLI/config key.
+    await backendSelect.selectOption("hook");
+    await expect(modal.locator(".af-modal-hint")).toHaveText("");
+    await expect(modal.locator("button.af-primary")).toBeEnabled();
 
     // Back to the repo default: the notice clears, Create is live again, and the
     // submit below sends NO backend — so this create stays local.

--- a/web/src/backends.test.ts
+++ b/web/src/backends.test.ts
@@ -15,10 +15,10 @@ function catalog(over: Partial<BackendCatalog> = {}): BackendCatalog {
     default: "local",
     default_status: "available",
     backends: [
-      { name: "local", status: "available" },
-      { name: "docker", status: "unavailable", reason: "backend=docker requires docker.image to be set in this repo's .agent-factory/config.json" },
-      { name: "ssh", status: "unavailable", reason: "backend=ssh requires ssh.host to be set in this repo's .agent-factory/config.json" },
-      { name: "hook", status: "unavailable", reason: "backend=hook requires remote_hooks to be configured" },
+      { name: "local", label: "local", status: "available" },
+      { name: "docker", label: "docker", status: "unavailable", reason: "backend=docker requires docker.image to be set in this repo's .agent-factory/config.json" },
+      { name: "ssh", label: "ssh", status: "unavailable", reason: "backend=ssh requires ssh.host to be set in this repo's .agent-factory/config.json" },
+      { name: "hook", label: "Remote sandbox (hook)", status: "unavailable", reason: "backend=hook requires remote_hooks to be configured" },
     ],
     ...over,
   };
@@ -43,8 +43,8 @@ test("the picker offers every backend the daemon lists, in the daemon's order", 
 test("a backend the web has never heard of is offered without a web change", () => {
   const withNewBackend = catalog({
     backends: [
-      { name: "local", status: "available" },
-      { name: "fargate", status: "available" },
+      { name: "local", label: "local", status: "available" },
+      { name: "fargate", label: "fargate", status: "available" },
     ],
   });
 
@@ -73,7 +73,7 @@ test("an unconfigured backend is offered, explained, and blocked from submitting
 
 test("a configured backend is selectable with nothing to explain", () => {
   const choices = backendChoices(
-    catalog({ backends: [{ name: "docker", status: "available" }] }),
+    catalog({ backends: [{ name: "docker", label: "docker", status: "available" }] }),
   );
 
   const docker = choices.find((c) => c.value === "docker");
@@ -84,10 +84,23 @@ test("a configured backend is selectable with nothing to explain", () => {
 });
 
 test("the repo default is labelled with the backend it resolves to", () => {
-  const choices = backendChoices(catalog({ default: "docker", backends: [{ name: "docker", status: "available" }] }));
+  const choices = backendChoices(catalog({ default: "docker", backends: [{ name: "docker", label: "docker", status: "available" }] }));
 
   assert.equal(choices[0].value, REPO_DEFAULT, "the default choice always sends nothing");
   assert.equal(choices[0].label, "Repo default (docker)", "a repo that defaults to docker says so, so the user need not pick docker to get it");
+});
+
+test("the picker renders the daemon's repo-derived backend label", () => {
+  const hook = {
+    name: "hook",
+    label: "Remote sandbox · coder-launch.sh (hook)",
+    status: "available",
+  } satisfies BackendCatalog["backends"][number];
+  const choices = backendChoices(catalog({ default: "hook", backends: [hook] }));
+
+  assert.equal(choices[0].label, "Repo default (Remote sandbox · coder-launch.sh (hook))");
+  assert.equal(choices[1].value, "hook", "the CLI/config key stays the submitted value");
+  assert.equal(choices[1].label, hook.label, "the web renders the daemon's label instead of its internal key");
 });
 
 test("a repo whose declared default is unconfigured is explained, not silently broken", () => {
@@ -117,8 +130,8 @@ test("an unknown backend is never offered as usable, and says why", () => {
   const choices = backendChoices(
     catalog({
       backends: [
-        { name: "local", status: "available" },
-        { name: "docker", status: "unknown", reason: "cannot tell whether this repo can use backend=docker: its .agent-factory/config.toml could not be read (unexpected comma)" },
+        { name: "local", label: "local", status: "available" },
+        { name: "docker", label: "docker", status: "unknown", reason: "cannot tell whether this repo can use backend=docker: its .agent-factory/config.toml could not be read (unexpected comma)" },
       ],
     }),
   );

--- a/web/src/backends.ts
+++ b/web/src/backends.ts
@@ -23,6 +23,8 @@ export type BackendAvailability = "available" | "unavailable" | "unknown";
 export interface BackendOption {
   /** The wire value sent back as CreateSession's `backend`. */
   name: string;
+  /** User-facing text derived by the daemon from this repo's configuration. */
+  label: string;
   /** The checked answer for this repo. */
   status: BackendAvailability;
   /** Actionable reason whenever `status` is not "available" — the same text the
@@ -54,9 +56,9 @@ export const REPO_DEFAULT = "";
 export interface BackendChoice {
   /** The <option> value: REPO_DEFAULT, or a backend name to send verbatim. */
   value: string;
-  /** The visible label. It is the daemon's backend name verbatim — deliberately
-   *  NOT looked up in a local name→label map, which is what would silently render
-   *  a newly added backend as blank. */
+  /** The visible label supplied by the daemon — deliberately NOT looked up in a
+   *  local name→label map, which would drift from repo-aware labels and silently
+   *  render a newly added backend as blank. */
   label: string;
   /** The daemon's checked answer. Only "available" may be offered as usable: both
    *  "unavailable" (checked, will fail) and "unknown" (could not be checked) are
@@ -93,7 +95,9 @@ export function backendChoices(catalog: BackendCatalog | null): BackendChoice[] 
       // "Repo default" with no parenthetical when the daemon reports no default:
       // that is the misconfigured case, where naming a backend would be inventing
       // one. The reason says what is wrong with the key.
-      label: catalog.default === "" ? "Repo default" : `Repo default (${catalog.default})`,
+      label: catalog.default === ""
+        ? "Repo default"
+        : `Repo default (${catalog.backends.find((opt) => opt.name === catalog.default)?.label ?? catalog.default})`,
       // Taken from the daemon, not inferred here. A repo whose declared default is
       // broken resolves to that broken backend and FAILS — it does not quietly run
       // local — so the default is not automatically a safe harbour.
@@ -105,7 +109,7 @@ export function backendChoices(catalog: BackendCatalog | null): BackendChoice[] 
   for (const opt of catalog.backends) {
     choices.push({
       value: opt.name,
-      label: opt.name,
+      label: opt.label,
       status: opt.status,
       reason: opt.status === "available" ? "" : (opt.reason ?? ""),
     });


### PR DESCRIPTION
Closes #2189.

Summary:
- Add a daemon-owned user-facing label to every `ListBackends` option while keeping the existing backend name as the wire/config key.
- Describe a configured hook as `Remote sandbox · <launcher> (hook)`, using the resolved launch command’s basename; unconfigured hooks fall back to `Remote sandbox (hook)`.
- Render daemon labels in the web picker and in its repo-default choice, with no client-side backend label map and no change to backend selection defaults.
- Give the real browser fixture a versioned remote-hook configuration so the rendered picker proves the available choice by label and still submits `hook`.

Reproduction and regression:
- Before the change, the real create-session modal displayed the available configured backend as raw `hook`.
- The daemon JSON regression failed because `label` was absent; the web regression failed because the choice rendered the internal name.
- The daemon catalog test also asserts every supported backend receives a non-empty label, so future backends cannot silently render blank.

Surface note:
- Current master has no general TUI backend picker. The TUI exposes remote creation through its dedicated, already user-facing `N` action, so this PR does not invent a second picker or change TUI behavior. Keeping the label in the daemon makes future catalog consumers share the same repo-derived copy.

Exact-head gates on `c8723d1023674b13404204857231250644f075e6`:
- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `make lint-file-length`
- `make web-build` with a clean committed `web/dist`
- `make web-test` — 403/403 tests passed
- `make test-container`
- `make web-selftest-container` — 111/111 rendered browser scenarios passed
