### PR TITLE
fix(web): fence reconnect snapshots against events

### DIFF
--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -11998,6 +11998,8 @@ var token = null;
 var stream = null;
 var loadPrograms = (repoPath) => token === null ? Promise.reject(new Error("not authorized")) : listPrograms(repoPath, token);
 var resyncTimer = null;
+var sessionEventGeneration = 0;
+var resyncRequestGeneration = 0;
 var taskResyncTimer = null;
 var tabErrorTimer = null;
 var TAB_ERROR_MS = 6e3;
@@ -12684,6 +12686,7 @@ function startStream(tok) {
   stream.start();
 }
 function stopStream() {
+  resyncRequestGeneration += 1;
   if (resyncTimer !== null) {
     window.clearTimeout(resyncTimer);
     resyncTimer = null;
@@ -12702,6 +12705,7 @@ function onEvent(ev) {
     requestTaskResync();
     return;
   }
+  sessionEventGeneration += 1;
   const { sessions, needsResync } = applyEvent(store.get().sessions, ev);
   applySessions(sessions);
   if (needsResync) {
@@ -12726,13 +12730,22 @@ function requestResync() {
   if (resyncTimer !== null) {
     return;
   }
+  const requestGeneration = ++resyncRequestGeneration;
   resyncTimer = window.setTimeout(() => {
     resyncTimer = null;
     const tok = token;
     if (tok === null) {
       return;
     }
+    const eventGeneration = sessionEventGeneration;
     void fetchSnapshot(tok).then((sessions) => {
+      if (requestGeneration !== resyncRequestGeneration || token !== tok) {
+        return;
+      }
+      if (eventGeneration !== sessionEventGeneration) {
+        requestResync();
+        return;
+      }
       applySessions(sessions);
     }).catch(() => {
     });

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "205618698e0d";
+const VERSION = "7983595171dd";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -3651,6 +3651,89 @@ test("#1812: a tab created/deleted out-of-band reaches the open client with no r
   expect(await notReloaded()).toBe(true);
 });
 
+test("#2330: an older reconnect Snapshot cannot overwrite a newer session event", REAL_FIXTURE, async ({ browser }) => {
+  const afBin = process.env.AF_BIN;
+  const mockRepo = process.env.AF_MOCK_REPO;
+  test.skip(!afBin || !mockRepo, "AF_BIN/AF_MOCK_REPO are set only by web-selftest-entry.sh");
+  const { execFileSync } = await import("node:child_process");
+  const af = (...args: string[]): void => {
+    execFileSync(afBin as string, ["--repo", mockRepo as string, "sessions", ...args], { stdio: "pipe" });
+  };
+
+  const ctx = await browser.newContext();
+  const p = await ctx.newPage();
+  const tabName = "resync-race-2330";
+  let created = false;
+  let snapshotCalls = 0;
+  let releaseStale = (): void => {};
+  const staleGate = new Promise<void>((resolve) => {
+    releaseStale = resolve;
+  });
+  let staleCaptured = (): void => {};
+  const staleStarted = new Promise<void>((resolve) => {
+    staleCaptured = resolve;
+  });
+  let staleResponseCaptured = false;
+  let staleSettled = (): void => {};
+  const staleFinished = new Promise<void>((resolve) => {
+    staleSettled = resolve;
+  });
+
+  try {
+    await openTokenless(p);
+    await p.route("**/v1/Snapshot", async (route) => {
+      const call = ++snapshotCalls;
+      try {
+        const response = await route.fetch();
+        const body = await response.body();
+        if (call === 2) {
+          staleResponseCaptured = true;
+          staleCaptured();
+          await staleGate;
+        }
+        await route.fulfill({ status: response.status(), headers: response.headers(), body });
+      } finally {
+        if (call === 2) {
+          staleSettled();
+        }
+      }
+    });
+
+    // Reload performs one bootstrap Snapshot, then the newly-open events socket asks
+    // for an authoritative resync. Hold that SECOND response after the daemon has
+    // already produced it, making it provably older than the event below.
+    await p.reload();
+    await expect(p.locator(".af-app")).toBeVisible();
+    await row(p, SESSION_A).click();
+    await expect(p.locator(".af-tabbar")).toBeVisible();
+    await staleStarted;
+
+    af("tab-create", SESSION_A, "--kind", "web", "--url", WEBTAB_EXTERNAL_URL, "--name", tabName);
+    created = true;
+    const liveTab = p.locator(".af-tabbar .af-tab", { hasText: tabName });
+    await expect(liveTab, "the real session.updated event lands while the older Snapshot is held").toHaveCount(1);
+
+    releaseStale();
+    await expect
+      .poll(() => snapshotCalls, {
+        message: "discarding a Snapshot crossed by an event schedules a fresh authoritative resync",
+        timeout: 5_000,
+      })
+      .toBeGreaterThanOrEqual(3);
+    await expect(liveTab, "the older Snapshot must not rewind the newer event").toHaveCount(1);
+  } finally {
+    releaseStale();
+    if (staleResponseCaptured) {
+      await staleFinished;
+    }
+    await p.unroute("**/v1/Snapshot");
+    if (created) {
+      af("tab-delete", SESSION_A, "--name", tabName);
+    }
+    await ctx.close();
+  }
+});
+
 // The other half of #1812/#1815's bill: the event must arrive WITHOUT disturbing
 // what the user is doing. Delivering a tab into the open window is only half the
 // feature if it rips the pane they are reading out from under them.

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -3680,7 +3680,6 @@ test("#2330: an older reconnect Snapshot cannot overwrite a newer session event"
   });
 
   try {
-    await openTokenless(p);
     await p.route("**/v1/Snapshot", async (route) => {
       const call = ++snapshotCalls;
       try {
@@ -3699,11 +3698,12 @@ test("#2330: an older reconnect Snapshot cannot overwrite a newer session event"
       }
     });
 
-    // Reload performs one bootstrap Snapshot, then the newly-open events socket asks
-    // for an authoritative resync. Hold that SECOND response after the daemon has
-    // already produced it, making it provably older than the event below.
-    await p.reload();
-    await expect(p.locator(".af-app")).toBeVisible();
+    // Install the route BEFORE first navigation: connect performs one bootstrap
+    // Snapshot, then the newly-open events socket asks for an authoritative resync.
+    // Hold that SECOND response after the daemon has already produced it, making it
+    // provably older than the event below. There is no prior page whose delayed
+    // first-open resync can steal either call number (Codex review P2).
+    await openTokenless(p);
     await row(p, SESSION_A).click();
     await expect(p.locator(".af-tabbar")).toBeVisible();
     await staleStarted;

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -152,6 +152,11 @@ const loadPrograms = (repoPath: string): Promise<ProgramCatalog> =>
 // Debounces the re-Snapshot that archived/restored events and reconnects trigger,
 // so a burst of events collapses into a single authoritative refetch.
 let resyncTimer: number | null = null;
+// Snapshot and events are two asynchronous projections of the same session state.
+// Fence them independently so a Snapshot requested before a session event cannot
+// resolve afterwards and rewind the event's newer roster (#2330).
+let sessionEventGeneration = 0;
+let resyncRequestGeneration = 0;
 // Debounces the ListTasks refetch that task.* events trigger (#1592 Phase 5 PR8),
 // so a burst of task deltas collapses into one authoritative refetch.
 let taskResyncTimer: number | null = null;
@@ -1407,6 +1412,10 @@ function startStream(tok: string): void {
 }
 
 function stopStream(): void {
+  // Invalidate a Snapshot that is already in flight. Clearing the timer alone only
+  // prevents a request that has not started; a response from the previous stream
+  // must not land in a newly-connected (possibly differently-authorized) app.
+  resyncRequestGeneration += 1;
   if (resyncTimer !== null) {
     window.clearTimeout(resyncTimer);
     resyncTimer = null;
@@ -1438,6 +1447,7 @@ function onEvent(ev: WireEvent): void {
     requestTaskResync();
     return;
   }
+  sessionEventGeneration += 1;
   const { sessions, needsResync } = applyEvent(store.get().sessions, ev);
   applySessions(sessions);
   if (needsResync) {
@@ -1484,6 +1494,10 @@ function requestResync(): void {
   if (resyncTimer !== null) {
     return;
   }
+  // Allocate the generation when the request is scheduled, not after the debounce:
+  // a newer scheduled resync must invalidate an older request that is already in
+  // flight even before the newer request reaches fetchSnapshot.
+  const requestGeneration = ++resyncRequestGeneration;
   resyncTimer = window.setTimeout(() => {
     resyncTimer = null;
     const tok = token;
@@ -1491,8 +1505,21 @@ function requestResync(): void {
     if (tok === null) {
       return;
     }
+    const eventGeneration = sessionEventGeneration;
     void fetchSnapshot(tok)
       .then((sessions) => {
+        // A stop/reconnect or a newer resync owns the result now.
+        if (requestGeneration !== resyncRequestGeneration || token !== tok) {
+          return;
+        }
+        // An event that crossed this request may be newer than the response. Do not
+        // guess which reached the daemon first: preserve the event and ask for one
+        // fresh authoritative projection. If the event itself already scheduled a
+        // newer resync, the request-generation check above leaves that one alone.
+        if (eventGeneration !== sessionEventGeneration) {
+          requestResync();
+          return;
+        }
         applySessions(sessions);
       })
       .catch(() => {


### PR DESCRIPTION
## Summary

- fence reconnect Snapshot responses by both resync-request generation and session-event generation
- discard a response invalidated by disconnect, a newer resync, or an event that crossed the request; after the event case, request one fresh authoritative Snapshot
- add a deterministic real-daemon/browser regression and regenerate the committed web bundle

## Root cause

The REST Snapshot and WebSocket session events both replace or reduce the same browser store, but the reconnect resync had no ordering guard. A Snapshot produced before `session.updated` could resolve afterward and call `applySessions` with the older roster. The live event had already rendered the new tab, yet the stale response removed it again while the socket remained healthy, so no later update repaired the UI.

This is a production race, not a harness timeout. The regression intercepts the second reconnect Snapshot after its body is produced, holds it, creates a real tab through the CLI, and observes the real event render that tab. Releasing the older response failed before this change because only two Snapshot calls occurred; the fixed client discards it, performs a third authoritative fetch, and keeps the tab rendered. No retry, timeout increase, or relaxed assertion is involved.

The issue's historical failures had more than one failure mode. #2311 addressed project-selection rail loss and #2334 addressed mobile layout measurement. An unchanged full-suite run also reproduced the cited `#1815 review` missing-tab timeout under concurrent container load; this PR addresses that shared Snapshot/event ordering cause without claiming the independent assertion mismatch was the same race.

## Exact-head validation

Validated commit: `9ed6b34e4a0713f850577b42ba0a8d5e300cd46c`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (empty)
- `go build ./...`
- `make web-test` (402 passed)
- `make web-build` followed by a clean worktree diff
- `scripts/lint-file-length.sh`
- `make test-container`
- focused real-browser regression: failed before the source fix, passed after rebuilding the production bundle
- full `make web-selftest-container` under concurrent container-suite load (112 passed)

Fixes #2330
