### PR TITLE
fix(status): surface Codex model changes

### DIFF
--- a/app/sync.go
+++ b/app/sync.go
@@ -646,6 +646,12 @@ func (m *home) updateInstanceFromSnapshot(inst *session.Instance, d session.Inst
 			changed = true
 		}
 	}
+	// Mirror the daemon's live model diagnostic on its own projection axis. It
+	// can appear or clear while liveness stays Ready/Running, so folding it into
+	// the status compare above would leave the TUI stale until an unrelated event.
+	if inst.SetAgentModelChange(d.ModelChange) {
+		changed = true
+	}
 	// Backends without user-managed tabs (the off-box docker/ssh/hook runtimes)
 	// have a tab list their runtime owns — a single agent tab, fixed at Launch —
 	// so there is nothing for the snapshot to reconcile against. Skipping is a

--- a/app/sync.go
+++ b/app/sync.go
@@ -649,7 +649,7 @@ func (m *home) updateInstanceFromSnapshot(inst *session.Instance, d session.Inst
 	// Mirror the daemon's live model diagnostic on its own projection axis. It
 	// can appear or clear while liveness stays Ready/Running, so folding it into
 	// the status compare above would leave the TUI stale until an unrelated event.
-	if inst.SetAgentModelChange(d.ModelChange) {
+	if inst.ReconcileAgentModelChange(d.ModelChange) {
 		changed = true
 	}
 	// Backends without user-managed tabs (the off-box docker/ssh/hook runtimes)

--- a/app/sync_test.go
+++ b/app/sync_test.go
@@ -10,6 +10,20 @@ import (
 	"github.com/sachiniyer/agent-factory/session"
 )
 
+func TestSnapshotReconcilesModelChangeWithoutLivenessChange(t *testing.T) {
+	h := newTestHome(t)
+	inst := instanceWithFakeBackend(t, "model-change")
+	data := inst.ToInstanceData()
+	data.ModelChange = session.NewAgentModelChange("gpt-5.6-sol max", "gpt-5.6-luna low")
+
+	require.True(t, h.updateInstanceFromSnapshot(inst, data))
+	require.Equal(t, data.ModelChange, inst.AgentModelChange())
+
+	data.ModelChange = nil
+	require.True(t, h.updateInstanceFromSnapshot(inst, data), "clearing the live diagnostic is itself a visible change")
+	require.Nil(t, inst.AgentModelChange())
+}
+
 // instanceWithFakeBackend builds an instance backed by FakeBackend, marked
 // Started and Running. Used by metadata-tick tests to exercise the loop body
 // without spinning up real tmux sessions.

--- a/daemon/agentserver_headless.go
+++ b/daemon/agentserver_headless.go
@@ -273,9 +273,10 @@ func (hs *headlessServer) Expose(_ struct{}, resp *agentExposeResponse) error {
 // agentSnapshotResponse is Observation over the wire — the non-interactive poll
 // the daemon reads each tick.
 type agentSnapshotResponse struct {
-	Updated   bool   `json:"updated"`
-	HasPrompt bool   `json:"has_prompt"`
-	Content   string `json:"content"`
+	Updated     bool                      `json:"updated"`
+	HasPrompt   bool                      `json:"has_prompt"`
+	Content     string                    `json:"content"`
+	ModelChange *session.AgentModelChange `json:"model_change,omitempty"`
 }
 
 func (hs *headlessServer) Snapshot(_ struct{}, resp *agentSnapshotResponse) error {
@@ -286,6 +287,7 @@ func (hs *headlessServer) Snapshot(_ struct{}, resp *agentSnapshotResponse) erro
 	resp.Updated = obs.Updated
 	resp.HasPrompt = obs.HasPrompt
 	resp.Content = obs.Content
+	resp.ModelChange = obs.ModelChange
 	return nil
 }
 

--- a/daemon/agentserver_headless_test.go
+++ b/daemon/agentserver_headless_test.go
@@ -34,6 +34,7 @@ type fakeHeadlessAgentServer struct {
 	lastPrompt   string
 	subs         map[*fakeSub]struct{}
 	snapshotText string
+	modelChange  *session.AgentModelChange
 }
 
 func newFakeHeadlessAgentServer() *fakeHeadlessAgentServer {
@@ -50,7 +51,9 @@ func (f *fakeHeadlessAgentServer) Expose() (session.StreamEndpoint, error) {
 func (f *fakeHeadlessAgentServer) Snapshot() (session.Observation, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	return session.Observation{Updated: true, HasPrompt: false, Content: f.snapshotText}, nil
+	return session.Observation{
+		Updated: true, HasPrompt: false, Content: f.snapshotText, ModelChange: f.modelChange,
+	}, nil
 }
 func (f *fakeHeadlessAgentServer) Preview(int, bool) (session.PreviewSnapshot, error) {
 	return session.PreviewSnapshot{
@@ -190,12 +193,14 @@ func TestHeadlessAgentServer_HTTPTokenRoundTrip(t *testing.T) {
 	require.True(t, fake.launched)
 
 	// --- control REST: snapshot ---------------------------------------------
+	fake.modelChange = session.NewAgentModelChange("gpt-5.6-sol max", "gpt-5.6-luna low")
 	resp, err = post("/v1/agent/snapshot", ``)
 	require.NoError(t, err)
 	var snap agentSnapshotResponse
 	decodeData(resp, &snap)
 	require.Equal(t, "❯ ready", snap.Content)
 	require.True(t, snap.Updated)
+	require.Equal(t, fake.modelChange, snap.ModelChange)
 
 	// --- control REST: preview carries terminal ownership with the grid ------
 	resp, err = post("/v1/agent/preview", `{"tab":0,"full":false}`)

--- a/daemon/limit.go
+++ b/daemon/limit.go
@@ -115,11 +115,11 @@ func (m *Manager) resolveIdleLiveness(instance *session.Instance, content string
 // tab roster. No-op in production.
 var testHookPollBeforePublish = func() {}
 
-// testHookPollBeforePersistLock runs in persistPollChange after it has read the
-// payload it intends to write and BEFORE it takes the repo start lock — the exact
-// window a concurrent transition (a usage-limit resume) can land in and be
-// overwritten by this poll's older payload. Tests substitute it to land that
-// transition deterministically, with no goroutines or sleeps. No-op in production.
+// testHookPollBeforePersistLock runs in persistPollChange after it has decided to
+// write or publish and BEFORE it takes the repo start lock — the exact window a
+// concurrent transition or tab mutation can land in and be overwritten by this
+// poll's older payload. Tests substitute it to land that mutation
+// deterministically, with no goroutines or sleeps. No-op in production.
 var testHookPollBeforePersistLock = func() {}
 
 // persistPollChange writes an instance's state to disk when the poll changed
@@ -138,13 +138,19 @@ var testHookPollBeforePersistLock = func() {}
 // would have no time to schedule against once the daemon restarts and reloads
 // from disk. beforeReset is the reset time captured before this tick's poll.
 //
+// projectionChanged additionally announces a live-only diagnostic change without
+// writing it to disk. This is the event-plane half of projection-only state: a
+// quiet session can change its diagnostic while liveness and reset time remain
+// identical, and already-open clients must not wait for an unrelated transition.
+//
 // A concurrent client op (create/kill/archive) means that op's executor owns the
 // durable state, so the poll never persists over it. Split from
 // refreshInstanceStatus so control.go stays under its length ceiling (#1145).
 //
-// WHAT IS WRITTEN IS WHAT IS TRUE AT WRITE TIME (#2135). The change test above is
-// a decision about a payload read at one instant, and the write happens at
-// another — after a repo start lock that a session create can hold for seconds.
+// WHAT IS WRITTEN OR PUBLISHED IS WHAT IS TRUE UNDER THE ORDERING LOCK (#2135).
+// The change test above is a decision about a payload read at one instant, and
+// the write/publish happens at another — after a repo start lock that a session
+// create can hold for seconds.
 // An authoritative transition landing in between (a usage-limit resume clearing
 // the block and persisting LiveRunning, above all) would otherwise be overwritten
 // by the intermediate this poll decided from, and the reset-time arm is what
@@ -152,33 +158,42 @@ var testHookPollBeforePersistLock = func() {}
 // liveness compare read "unchanged" (LimitReached → LimitReached) still flushed —
 // planting a limit-blocked row on disk for a session that was working.
 //
-// So the payload is re-read under the lock whenever the state epoch shows it
-// moved: the poll's gate decides WHETHER to write, never WHAT. Deliberately not
-// the reverse (take the lock, then read once): the lock is uncontended only when
-// nothing is being created, and taking it on every tick of every session would
-// park the whole poll behind an unrelated create. The epoch keeps the hot path
-// lock-free and costs a second read only in the rare superseded case.
-func (m *Manager) persistPollChange(repoID string, instance *session.Instance, before session.Liveness, beforeReset time.Time) {
+// So the payload is ALWAYS re-read under the lock once the lock-free gate decides
+// there is something to announce: the gate decides WHETHER to write/publish,
+// never WHAT. A lifecycle epoch cannot safely optimize this re-read because the
+// payload also contains projection state outside that epoch — notably the tab
+// roster. Deliberately do not take the lock before the gate: taking it on every
+// tick of every session would park the whole poll behind an unrelated create.
+func (m *Manager) persistPollChange(
+	repoID string,
+	instance *session.Instance,
+	before session.Liveness,
+	beforeReset time.Time,
+	projectionChanged bool,
+) {
 	if instance.GetInFlightOp() != session.OpNone {
 		return
 	}
-	data, epoch := instance.ToInstanceDataWithEpoch()
+	data := instance.ToInstanceData()
 	livenessChanged := data.Liveness != before
 	resetChanged := !data.LimitResetAt.Equal(beforeReset)
-	if !livenessChanged && !resetChanged {
+	durableChanged := livenessChanged || resetChanged
+	publishChanged := durableChanged || projectionChanged
+	if !publishChanged {
 		return
 	}
 	repoStartLock := m.startLockForRepo(repoID)
 	testHookPollBeforePersistLock()
 	repoStartLock.Lock()
-	if current, now := instance.ToInstanceDataWithEpoch(); now != epoch {
-		// Superseded while we waited for the lock. Persist and publish what is true
-		// NOW — the transition that beat us owns this state, and both the disk row
-		// and the session.updated payload must show it, not the intermediate this
-		// tick decided from.
-		data = current
+	// Re-read the WHOLE projection after joining the same ordering domain as tab
+	// mutations and session creation. StateEpoch intentionally covers lifecycle
+	// state only, so using it as a whole-payload change detector lets an untracked
+	// roster mutation publish first and then get erased by this stale event.
+	data = instance.ToInstanceData()
+	var err error
+	if durableChanged {
+		err = persistInstanceData(repoID, data)
 	}
-	err := persistInstanceData(repoID, data)
 	// Push the change onto the events plane (#1592 PR5): this is the single choke
 	// point every liveness/limit transition already flows through, so one publish
 	// here covers session.updated without threading it through each caller.

--- a/daemon/limit_resume_poll_race_test.go
+++ b/daemon/limit_resume_poll_race_test.go
@@ -188,7 +188,7 @@ func TestPersistPollChange_ResumeDuringWriteWindowIsNotOverwritten(t *testing.T)
 		}
 	}
 
-	manager.persistPollChange(repoID, inst, before, beforeReset)
+	manager.persistPollChange(repoID, inst, before, beforeReset, false)
 
 	if got := persistedLiveness(t, repoID, "limited"); got != session.LiveRunning {
 		t.Errorf("persisted liveness = %v, want LiveRunning: the poll must not overwrite a resume that landed while it waited for the write lock (#2135)", got)

--- a/daemon/limit_status_test.go
+++ b/daemon/limit_status_test.go
@@ -88,7 +88,7 @@ func TestPersistPollChange_LaterResetTime_PersistsIndependentOfLiveness(t *testi
 	before1 := inst.GetLiveness()
 	beforeReset1, _ := inst.LimitResetAt()
 	inst.SetLimitReached(time.Time{})
-	manager.persistPollChange(repoID, inst, before1, beforeReset1)
+	manager.persistPollChange(repoID, inst, before1, beforeReset1, false)
 
 	if got := persistedLiveness(t, repoID, "limited"); got != session.LiveLimitReached {
 		t.Fatalf("after tick 1 persisted liveness = %v, want LiveLimitReached", got)
@@ -104,7 +104,7 @@ func TestPersistPollChange_LaterResetTime_PersistsIndependentOfLiveness(t *testi
 	before2 := inst.GetLiveness()
 	beforeReset2, _ := inst.LimitResetAt()
 	inst.SetLimitReached(resetAt)
-	manager.persistPollChange(repoID, inst, before2, beforeReset2)
+	manager.persistPollChange(repoID, inst, before2, beforeReset2, false)
 
 	got := persistedLimitReset(t, repoID, "limited")
 	if !got.Equal(resetAt) {

--- a/daemon/manager_status.go
+++ b/daemon/manager_status.go
@@ -221,16 +221,21 @@ func (m *Manager) observeTaskRunWhilePaused(repoID, key string, instance *sessio
 	obs, err := instance.AgentServer().Snapshot()
 	// Whatever happened, no loss episode survives an attach (see above).
 	m.clearRemoteLoss(key)
-	if err != nil || obs.Updated || obs.HasPrompt {
-		// Unanswerable, still working, or waiting on the user: either way the run
-		// has not finished, so there is nothing for the cap to learn this tick.
+	if err != nil {
+		return
+	}
+	projectionChanged := instance.SetAgentModelChange(obs.ModelChange)
+	if obs.Updated || obs.HasPrompt {
+		// Still working or waiting on the user: either way the run has not
+		// finished, so there is nothing for the cap to learn this tick.
+		m.persistPollChange(repoID, instance, before, beforeReset, projectionChanged)
 		return
 	}
 	// Idle output. The normal poll would probe liveness here to tell a healthy idle
 	// session from a vanished one; this path deliberately does not, because it must
 	// never conclude death. The attach already answers that question.
 	m.resolveIdleLiveness(instance, obs.Content, epoch)
-	m.persistPollChange(repoID, instance, before, beforeReset)
+	m.persistPollChange(repoID, instance, before, beforeReset, projectionChanged)
 }
 
 func (m *Manager) RefreshStatuses() {
@@ -415,6 +420,7 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 		m.settleRemoteProbeFailure(repoID, key, instance, before, beforeReset)
 		return
 	}
+	projectionChanged := instance.SetAgentModelChange(obs.ModelChange)
 	updated, hasPrompt, content := obs.Updated, obs.HasPrompt, obs.Content
 	// The Snapshot answered, so the transport works and any loss episode is over.
 	// This is the ONLY thing the debounce tracks — see remoteloss.go: it counts
@@ -498,7 +504,7 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 	}
 
 	// Persist a liveness OR usage-limit reset-time change (#1146); see limit.go.
-	m.persistPollChange(repoID, instance, before, beforeReset)
+	m.persistPollChange(repoID, instance, before, beforeReset, projectionChanged)
 }
 
 // SaveInstances writes the manager's authoritative in-memory instances to disk

--- a/daemon/manager_status.go
+++ b/daemon/manager_status.go
@@ -224,7 +224,7 @@ func (m *Manager) observeTaskRunWhilePaused(repoID, key string, instance *sessio
 	if err != nil {
 		return
 	}
-	projectionChanged := instance.SetAgentModelChange(obs.ModelChange)
+	projectionChanged := instance.SetAgentModelChangeAtEpoch(obs.ModelChange, epoch)
 	if obs.Updated || obs.HasPrompt {
 		// Still working or waiting on the user: either way the run has not
 		// finished, so there is nothing for the cap to learn this tick.
@@ -386,14 +386,17 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 	// (#1592 Phase 2 PR4) — never the tmux-shaped Backend probes directly, so this
 	// poll makes no assumption that the session is local tmux. For the local
 	// runtime the agent-server drives tmux in-process.
-	as := instance.AgentServer()
-	before := instance.GetLiveness()
-	beforeReset, _ := instance.LimitResetAt()
 	// Captured BEFORE the observation below, so the idle resolve can tell whether
 	// the conclusion it draws from that capture is still about the state it
 	// observed — or whether a resume/kill/archive has moved the session on since
 	// (#2135). See resolveIdleLiveness and session/state_epoch.go.
 	epoch := instance.StateEpoch()
+	// Select the AgentServer only after capturing the epoch. A remote runtime swap
+	// replaces this handle; taking the handle first could pair the outgoing server
+	// with the incoming runtime's epoch and make a stale observation look current.
+	as := instance.AgentServer()
+	before := instance.GetLiveness()
+	beforeReset, _ := instance.LimitResetAt()
 	// Snapshot dismisses a pending trust prompt then reads the pane in one probe
 	// (the exact order the poll used to run CheckAndHandleTrustPrompt then
 	// HasUpdated). Content is the capture handed back so the idle branch runs the
@@ -420,7 +423,7 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 		m.settleRemoteProbeFailure(repoID, key, instance, before, beforeReset)
 		return
 	}
-	projectionChanged := instance.SetAgentModelChange(obs.ModelChange)
+	projectionChanged := instance.SetAgentModelChangeAtEpoch(obs.ModelChange, epoch)
 	updated, hasPrompt, content := obs.Updated, obs.HasPrompt, obs.Content
 	// The Snapshot answered, so the transport works and any loss episode is over.
 	// This is the ONLY thing the debounce tracks — see remoteloss.go: it counts

--- a/daemon/model_change_status_test.go
+++ b/daemon/model_change_status_test.go
@@ -18,6 +18,24 @@ func (b *modelChangeBackend) AgentModelChange(*session.Instance) *session.AgentM
 	return b.change
 }
 
+type runtimeSwapModelChangeBackend struct {
+	*session.FakeBackend
+	change *session.AgentModelChange
+	onRead func()
+}
+
+func (b *runtimeSwapModelChangeBackend) HasUpdated(*session.Instance) (bool, bool, string) {
+	return true, false, "working"
+}
+
+func (b *runtimeSwapModelChangeBackend) AgentModelChange(*session.Instance) *session.AgentModelChange {
+	change := b.change
+	if b.onRead != nil {
+		b.onRead()
+	}
+	return change
+}
+
 func TestRefreshStatusPublishesProjectionOnlyModelChange(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 	backend := &modelChangeBackend{
@@ -47,11 +65,30 @@ func TestRuntimeReplacementClearsPriorModelChange(t *testing.T) {
 	inst := registerStarted(
 		t, manager, repoID, repoPath, "model-change-replaced", session.NewFakeBackend(), true, session.Ready,
 	)
-	require.True(t, inst.SetAgentModelChange(
+	require.True(t, inst.SetAgentModelChangeAtEpoch(
 		session.NewAgentModelChange("gpt-5.6-sol max", "gpt-5.6-luna low"),
+		inst.StateEpoch(),
 	))
 
 	manager.noteRuntimeReplaced(repoID, inst)
 
 	require.Nil(t, inst.AgentModelChange(), "a replacement runtime must not inherit its predecessor's warning")
+}
+
+func TestRefreshStatusDropsModelChangeFromReplacedRuntime(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &runtimeSwapModelChangeBackend{
+		FakeBackend: session.NewFakeBackend(),
+		change:      session.NewAgentModelChange("gpt-5.6-sol max", "gpt-5.6-luna low"),
+	}
+	inst := registerStarted(t, manager, repoID, repoPath, "model-change-race", backend, true, session.Ready)
+	backend.onRead = func() {
+		require.NoError(t, inst.Transition(session.BeginHandoff()))
+		manager.noteRuntimeReplaced(repoID, inst)
+	}
+
+	manager.refreshInstanceStatus(repoID, inst)
+
+	require.Nil(t, inst.AgentModelChange(),
+		"an observation from the outgoing runtime must not cross the handoff boundary")
 }

--- a/daemon/model_change_status_test.go
+++ b/daemon/model_change_status_test.go
@@ -1,0 +1,57 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/agentproto"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+type modelChangeBackend struct {
+	*session.FakeBackend
+	change *session.AgentModelChange
+}
+
+func (b *modelChangeBackend) AgentModelChange(*session.Instance) *session.AgentModelChange {
+	return b.change
+}
+
+func TestRefreshStatusPublishesProjectionOnlyModelChange(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &modelChangeBackend{
+		FakeBackend: session.NewFakeBackend(),
+		change:      session.NewAgentModelChange("gpt-5.6-sol max", "gpt-5.6-luna low"),
+	}
+	inst := registerStarted(t, manager, repoID, repoPath, "model-change", backend, true, session.Ready)
+	_, events := manager.events.subscribe()
+
+	manager.refreshInstanceStatus(repoID, inst)
+
+	updated := drainNextSessionEvent(t, events, agentproto.EventSessionUpdated)
+	require.Equal(t, backend.change, updated.ModelChange,
+		"a quiet Ready row needs an event even though no durable status changed")
+	require.Equal(t, backend.change, manager.Snapshot(repoID)[0].ModelChange)
+	require.Equal(t, session.LiveReady, inst.GetLiveness())
+
+	backend.change = nil
+	manager.refreshInstanceStatus(repoID, inst)
+	cleared := drainNextSessionEvent(t, events, agentproto.EventSessionUpdated)
+	require.Nil(t, cleared.ModelChange, "returning to the original model must clear open clients")
+	require.Nil(t, inst.AgentModelChange())
+}
+
+func TestRuntimeReplacementClearsPriorModelChange(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst := registerStarted(
+		t, manager, repoID, repoPath, "model-change-replaced", session.NewFakeBackend(), true, session.Ready,
+	)
+	require.True(t, inst.SetAgentModelChange(
+		session.NewAgentModelChange("gpt-5.6-sol max", "gpt-5.6-luna low"),
+	))
+
+	manager.noteRuntimeReplaced(repoID, inst)
+
+	require.Nil(t, inst.AgentModelChange(), "a replacement runtime must not inherit its predecessor's warning")
+}

--- a/daemon/remoteloss.go
+++ b/daemon/remoteloss.go
@@ -206,7 +206,7 @@ func (m *Manager) noteRuntimeReplaced(repoID string, instance *session.Instance)
 	// recovery/re-provision/handoff already crosses this chokepoint, so retire both
 	// predecessor-owned facts together rather than making each caller remember a
 	// second reset site.
-	instance.SetAgentModelChange(nil)
+	instance.ClearAgentModelChange()
 	m.clearRemoteLoss(remoteLossKey(repoID, instance))
 }
 

--- a/daemon/remoteloss.go
+++ b/daemon/remoteloss.go
@@ -170,9 +170,10 @@ func (m *Manager) remoteSandboxAnswersAlive(instance *session.Instance) bool {
 	return aliveWithin(instance.AgentServer(), remoteLostConfirmTimeout) == probeAlive
 }
 
-// noteRuntimeReplaced resets a session's remote-loss debounce after a lifecycle
-// event that REPLACED the runtime its failures were about: a Recover, a
-// Respawn, an archive-restore's re-provision.
+// noteRuntimeReplaced retires observations owned by the prior runtime after a
+// lifecycle event that REPLACED it: a Recover, a Respawn, an archive-restore's
+// re-provision. Today those are the remote-loss debounce and the live model
+// diagnostic.
 //
 // Call it the INSTANT the swap succeeds — before any persist, log, or other
 // work. The poll goroutine does not hold the op-lock and does not skip a session
@@ -200,6 +201,12 @@ func (m *Manager) remoteSandboxAnswersAlive(instance *session.Instance) bool {
 // lostrestore.go (automatic Recover), restore.go (manual Recover RPC),
 // limit.go (limit-resume Respawn), archive.go (archive-restore re-provision).
 func (m *Manager) noteRuntimeReplaced(repoID string, instance *session.Instance) {
+	// Model diagnostics are observations of one concrete agent process, just like
+	// the remote-loss episode is an observation of one concrete sandbox. Every
+	// recovery/re-provision/handoff already crosses this chokepoint, so retire both
+	// predecessor-owned facts together rather than making each caller remember a
+	// second reset site.
+	instance.SetAgentModelChange(nil)
 	m.clearRemoteLoss(remoteLossKey(repoID, instance))
 }
 
@@ -287,7 +294,7 @@ func (m *Manager) settleRemoteProbeFailure(repoID, key string, instance *session
 		log.WarningLog.Printf("remote session %q: agent-server unreachable and still unanswerable after %s — marking it Lost", instance.Title, remoteLostGracePeriod)
 	}
 	_ = instance.Transition(session.ObserveLiveness(session.LiveLost))
-	m.persistPollChange(repoID, instance, before, beforeReset)
+	m.persistPollChange(repoID, instance, before, beforeReset, false)
 }
 
 // livenessProbe is the outcome of a liveness probe. It is a tri-state, not a

--- a/daemon/tab_event_order_test.go
+++ b/daemon/tab_event_order_test.go
@@ -60,7 +60,7 @@ func TestPersistPollChange_PublishesUnderRepoLock(t *testing.T) {
 
 	// A liveness that differs from the instance's own makes the poll treat this tick
 	// as a real transition, which is what drives it to persist + publish at all.
-	manager.persistPollChange(repo.ID, instance, otherLiveness(instance.GetLiveness()), time.Time{})
+	manager.persistPollChange(repo.ID, instance, otherLiveness(instance.GetLiveness()), time.Time{}, false)
 
 	if !probed {
 		t.Fatal("the poll never reached its publish: persistPollChange returned without announcing a change")
@@ -84,17 +84,31 @@ func TestPersistPollChange_PublishesRosterAsOfItsLock(t *testing.T) {
 		t.Fatalf("session %q missing from the manager", title)
 	}
 
-	name, _, err := manager.CreateTab(CreateTabRequest{
-		Title: title, RepoID: repo.ID, Kind: "web", URL: "http://localhost:5173", Name: "livepreview",
-	})
-	if err != nil {
-		t.Fatalf("CreateTab(web): %v", err)
+	// Make the tab mutation land in the exact stale-snapshot window: after the
+	// projection-only poll decided to publish and captured its payload, but before
+	// it acquires the ordering lock. Tab mutations do not move the lifecycle epoch,
+	// so an epoch-conditional re-read misses this change.
+	var name string
+	prev := testHookPollBeforePersistLock
+	t.Cleanup(func() { testHookPollBeforePersistLock = prev })
+	testHookPollBeforePersistLock = func() {
+		var err error
+		name, _, err = manager.CreateTab(CreateTabRequest{
+			Title: title, RepoID: repo.ID, Kind: "web", URL: "http://localhost:5173", Name: "livepreview",
+		})
+		if err != nil {
+			t.Fatalf("CreateTab(web): %v", err)
+		}
 	}
 
-	// Subscribe after the create so the only event drained is the poll's.
 	_, ch := manager.events.subscribe()
-	manager.persistPollChange(repo.ID, instance, otherLiveness(instance.GetLiveness()), time.Time{})
+	beforeReset, _ := instance.LimitResetAt()
+	manager.persistPollChange(repo.ID, instance, instance.GetLiveness(), beforeReset, true)
 
+	created := drainNextSessionEvent(t, ch, agentproto.EventSessionUpdated)
+	if !tabNamed(created, name) {
+		t.Fatalf("the tab-create event roster %v is missing its new tab %q", created.Tabs, name)
+	}
 	got := drainNextSessionEvent(t, ch, agentproto.EventSessionUpdated)
 	if !tabNamed(got, name) {
 		t.Fatalf("the poll published roster %v without the already-created tab %q: "+

--- a/session/agent_diagnostic.go
+++ b/session/agent_diagnostic.go
@@ -51,12 +51,40 @@ func (i *Instance) AgentModelChange() *AgentModelChange {
 	return cloneAgentModelChange(i.agentModelChange)
 }
 
-// SetAgentModelChange replaces the live projection diagnostic and reports
-// whether clients need a refreshed snapshot. Invalid transitions normalize to
-// nil so malformed wire data fails closed instead of rendering a false alarm.
-func (i *Instance) SetAgentModelChange(change *AgentModelChange) bool {
+// SetAgentModelChangeAtEpoch applies a diagnostic observed from the running
+// agent only while the lifecycle epoch still matches the one captured before
+// that observation. Every runtime replacement crosses a lifecycle transition,
+// so an outgoing process cannot write its warning back after handoff/recovery
+// retired it. Invalid transitions normalize to nil so malformed wire data fails
+// closed instead of rendering a false alarm.
+func (i *Instance) SetAgentModelChangeAtEpoch(change *AgentModelChange, observedEpoch uint64) bool {
 	i.mu.Lock()
 	defer i.mu.Unlock()
+	if i.stateEpoch != observedEpoch {
+		return false
+	}
+	return i.setAgentModelChangeLocked(change)
+}
+
+// ReconcileAgentModelChange applies the daemon's already-correlated projection
+// to a client-side Instance. It is intentionally separate from the epoch-bound
+// observation API above: a client's local lifecycle epoch is unrelated to the
+// daemon epoch that validated the observation.
+func (i *Instance) ReconcileAgentModelChange(change *AgentModelChange) bool {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.setAgentModelChangeLocked(change)
+}
+
+// ClearAgentModelChange retires the diagnostic at an authoritative runtime
+// boundary. Positive observations must use SetAgentModelChangeAtEpoch instead.
+func (i *Instance) ClearAgentModelChange() bool {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.setAgentModelChangeLocked(nil)
+}
+
+func (i *Instance) setAgentModelChangeLocked(change *AgentModelChange) bool {
 	// Archived rows have no running agent whose observation could be current.
 	// Normalize under the same lock as the liveness check so an in-flight poll
 	// cannot reinsert the retired runtime's warning after archive commits.

--- a/session/agent_diagnostic.go
+++ b/session/agent_diagnostic.go
@@ -1,0 +1,75 @@
+package session
+
+// AgentModelChange is the live, verified model transition observed after Agent
+// Factory handled an agent safety dialog. It is projection state: clients need
+// the before/after values to explain a degraded-looking healthy row, but the
+// daemon derives it from the running agent and never restores it from disk.
+type AgentModelChange struct {
+	Before string `json:"before"`
+	After  string `json:"after"`
+}
+
+// NewAgentModelChange constructs only meaningful transitions. Keeping invalid
+// equal/empty pairs out at the boundary means every renderer can treat a non-nil
+// value as an actionable diagnostic without duplicating validation policy.
+func NewAgentModelChange(before, after string) *AgentModelChange {
+	if before == "" || after == "" || before == after {
+		return nil
+	}
+	return &AgentModelChange{Before: before, After: after}
+}
+
+func cloneAgentModelChange(change *AgentModelChange) *AgentModelChange {
+	if change == nil {
+		return nil
+	}
+	return NewAgentModelChange(change.Before, change.After)
+}
+
+// agentModelChangeForLiveness is the one projection boundary for this
+// runtime-owned fact. An archived row has no live process whose observation can
+// still be current, including when consuming a snapshot produced by an older
+// daemon that did not clear the field itself.
+func agentModelChangeForLiveness(change *AgentModelChange, liveness Liveness) *AgentModelChange {
+	if liveness == LiveArchived {
+		return nil
+	}
+	return cloneAgentModelChange(change)
+}
+
+func sameAgentModelChange(a, b *AgentModelChange) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return a.Before == b.Before && a.After == b.After
+}
+
+// AgentModelChange returns an isolated copy of the active model diagnostic.
+func (i *Instance) AgentModelChange() *AgentModelChange {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return cloneAgentModelChange(i.agentModelChange)
+}
+
+// SetAgentModelChange replaces the live projection diagnostic and reports
+// whether clients need a refreshed snapshot. Invalid transitions normalize to
+// nil so malformed wire data fails closed instead of rendering a false alarm.
+func (i *Instance) SetAgentModelChange(change *AgentModelChange) bool {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	// Archived rows have no running agent whose observation could be current.
+	// Normalize under the same lock as the liveness check so an in-flight poll
+	// cannot reinsert the retired runtime's warning after archive commits.
+	normalized := agentModelChangeForLiveness(change, i.liveness)
+	if sameAgentModelChange(i.agentModelChange, normalized) {
+		return false
+	}
+	i.agentModelChange = normalized
+	return true
+}
+
+// clearAgentModelChangeLocked retires projection state owned by an agent process
+// when that runtime is archived or replaced. Caller holds i.mu.
+func (i *Instance) clearAgentModelChangeLocked() {
+	i.agentModelChange = nil
+}

--- a/session/agent_diagnostic_test.go
+++ b/session/agent_diagnostic_test.go
@@ -1,0 +1,58 @@
+package session
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgentModelChangeProjectionIsTypedAndStorageSafe(t *testing.T) {
+	inst := &Instance{ID: "session-id", liveness: LiveReady}
+	change := NewAgentModelChange("gpt-5.6-sol max", "gpt-5.6-luna low")
+	require.NotNil(t, change)
+	require.True(t, inst.SetAgentModelChange(change))
+
+	// The live API/CLI projection carries the exact explanation.
+	projected := inst.ToInstanceData()
+	require.Equal(t, change, projected.ModelChange)
+	rawProjection, err := json.Marshal(projected)
+	require.NoError(t, err)
+	require.Contains(t, string(rawProjection), `"model_change":{"before":"gpt-5.6-sol max","after":"gpt-5.6-luna low"}`)
+
+	// instances.json cannot resurrect a warning derived from a replaced runtime.
+	stored := projected.ForStorage()
+	require.Nil(t, stored.ModelChange)
+	rawStorage, err := json.Marshal(stored)
+	require.NoError(t, err)
+	require.NotContains(t, string(rawStorage), "model_change")
+
+	// Constructors/setters reject values that do not describe a transition.
+	require.Nil(t, NewAgentModelChange("same", "same"))
+	require.True(t, inst.SetAgentModelChange(&AgentModelChange{Before: "", After: "unknown"}))
+	require.Nil(t, inst.AgentModelChange())
+}
+
+func TestAgentModelChangeDoesNotCrossArchiveRestoreRuntimeBoundary(t *testing.T) {
+	change := NewAgentModelChange("gpt-5.6-sol max", "gpt-5.6-luna low")
+	inst := &Instance{liveness: LiveRunning, started: true}
+	require.True(t, inst.SetAgentModelChange(change))
+
+	require.NoError(t, inst.Transition(BeginArchive()))
+	require.NoError(t, inst.Transition(CommitArchive()))
+	require.Nil(t, inst.AgentModelChange(), "an archived row has no runtime whose diagnostic is current")
+	require.Nil(t, inst.ToInstanceData().ModelChange)
+
+	// Also reject a stale projection injected while the row is archived. Restore
+	// creates a new runtime under the same Instance identity, so its first snapshot
+	// must not inherit a warning observed from the retired process.
+	require.False(t, inst.SetAgentModelChange(change), "an archived row must reject runtime diagnostics")
+	require.Nil(t, inst.AgentModelChange())
+
+	// Simulate stale in-memory state from an older process/version so BeginRestore
+	// itself remains the final boundary guard, independent of setter behavior.
+	inst.agentModelChange = cloneAgentModelChange(change)
+	require.NoError(t, inst.Transition(BeginRestore()))
+	require.Nil(t, inst.AgentModelChange(), "a newly restored runtime must start without its predecessor's diagnostic")
+	require.Nil(t, inst.ToInstanceData().ModelChange)
+}

--- a/session/agent_diagnostic_test.go
+++ b/session/agent_diagnostic_test.go
@@ -11,7 +11,7 @@ func TestAgentModelChangeProjectionIsTypedAndStorageSafe(t *testing.T) {
 	inst := &Instance{ID: "session-id", liveness: LiveReady}
 	change := NewAgentModelChange("gpt-5.6-sol max", "gpt-5.6-luna low")
 	require.NotNil(t, change)
-	require.True(t, inst.SetAgentModelChange(change))
+	require.True(t, inst.SetAgentModelChangeAtEpoch(change, inst.StateEpoch()))
 
 	// The live API/CLI projection carries the exact explanation.
 	projected := inst.ToInstanceData()
@@ -29,14 +29,16 @@ func TestAgentModelChangeProjectionIsTypedAndStorageSafe(t *testing.T) {
 
 	// Constructors/setters reject values that do not describe a transition.
 	require.Nil(t, NewAgentModelChange("same", "same"))
-	require.True(t, inst.SetAgentModelChange(&AgentModelChange{Before: "", After: "unknown"}))
+	require.True(t, inst.SetAgentModelChangeAtEpoch(
+		&AgentModelChange{Before: "", After: "unknown"}, inst.StateEpoch(),
+	))
 	require.Nil(t, inst.AgentModelChange())
 }
 
 func TestAgentModelChangeDoesNotCrossArchiveRestoreRuntimeBoundary(t *testing.T) {
 	change := NewAgentModelChange("gpt-5.6-sol max", "gpt-5.6-luna low")
 	inst := &Instance{liveness: LiveRunning, started: true}
-	require.True(t, inst.SetAgentModelChange(change))
+	require.True(t, inst.SetAgentModelChangeAtEpoch(change, inst.StateEpoch()))
 
 	require.NoError(t, inst.Transition(BeginArchive()))
 	require.NoError(t, inst.Transition(CommitArchive()))
@@ -46,7 +48,8 @@ func TestAgentModelChangeDoesNotCrossArchiveRestoreRuntimeBoundary(t *testing.T)
 	// Also reject a stale projection injected while the row is archived. Restore
 	// creates a new runtime under the same Instance identity, so its first snapshot
 	// must not inherit a warning observed from the retired process.
-	require.False(t, inst.SetAgentModelChange(change), "an archived row must reject runtime diagnostics")
+	require.False(t, inst.SetAgentModelChangeAtEpoch(change, inst.StateEpoch()),
+		"an archived row must reject runtime diagnostics")
 	require.Nil(t, inst.AgentModelChange())
 
 	// Simulate stale in-memory state from an older process/version so BeginRestore

--- a/session/agentserver.go
+++ b/session/agentserver.go
@@ -203,6 +203,10 @@ type Observation struct {
 	// run the usage-limit detector without a second capture (#1146). Empty for a
 	// runtime with no live pane.
 	Content string
+	// ModelChange is the retained, verified model transition observed after an
+	// agent safety dialog. The runtime reports it on every snapshot until the
+	// model returns to Before, so no consumer has to race a one-shot log line.
+	ModelChange *AgentModelChange
 }
 
 // PTYSubscription is one subscriber's read side of a session's PTY stream

--- a/session/agentserver_local.go
+++ b/session/agentserver_local.go
@@ -145,7 +145,12 @@ func (s *localAgentServer) Snapshot() (Observation, error) {
 	b := s.inst.currentBackend()
 	b.CheckAndHandleTrustPrompt(s.inst)
 	updated, hasPrompt, content := b.HasUpdated(s.inst)
-	return Observation{Updated: updated, HasPrompt: hasPrompt, Content: content}, nil
+	return Observation{
+		Updated:     updated,
+		HasPrompt:   hasPrompt,
+		Content:     content,
+		ModelChange: b.AgentModelChange(s.inst),
+	}, nil
 }
 
 func (s *localAgentServer) Preview(tab int, full bool) (PreviewSnapshot, error) {

--- a/session/agentserver_local_test.go
+++ b/session/agentserver_local_test.go
@@ -17,11 +17,18 @@ type probeBackend struct {
 	launchFirst    *bool
 	sentPrompt     string
 	killed         bool
+	modelChange    *AgentModelChange
+	diagnosticRead bool
 }
 
 func (b *probeBackend) CheckAndHandleTrustPrompt(*Instance) bool {
 	b.trustChecked = true
 	return false
+}
+
+func (b *probeBackend) AgentModelChange(*Instance) *AgentModelChange {
+	b.diagnosticRead = true
+	return b.modelChange
 }
 
 // HasUpdated returns a distinct triple so Snapshot's field mapping is verifiable.
@@ -68,6 +75,7 @@ func newProbeInstance(t *testing.T) (*Instance, *probeBackend) {
 
 func TestLocalAgentServerSnapshot(t *testing.T) {
 	inst, b := newProbeInstance(t)
+	b.modelChange = NewAgentModelChange("gpt-5.6-sol max", "gpt-5.6-luna low")
 	obs, err := inst.AgentServer().Snapshot()
 	if err != nil {
 		t.Fatalf("Snapshot: %v", err)
@@ -77,6 +85,9 @@ func TestLocalAgentServerSnapshot(t *testing.T) {
 	}
 	if !obs.Updated || !obs.HasPrompt || obs.Content != "captured-pane" {
 		t.Errorf("Observation mismapped: got %+v", obs)
+	}
+	if !b.diagnosticRead || !sameAgentModelChange(obs.ModelChange, b.modelChange) {
+		t.Errorf("Snapshot dropped the backend model diagnostic: got %+v", obs.ModelChange)
 	}
 }
 

--- a/session/agentserver_remote.go
+++ b/session/agentserver_remote.go
@@ -133,7 +133,12 @@ func (s *remoteAgentServer) Snapshot() (Observation, error) {
 	if err := s.rc.call("/v1/agent/snapshot", struct{}{}, &resp); err != nil {
 		return Observation{}, err
 	}
-	return Observation{Updated: resp.Updated, HasPrompt: resp.HasPrompt, Content: resp.Content}, nil
+	return Observation{
+		Updated:     resp.Updated,
+		HasPrompt:   resp.HasPrompt,
+		Content:     resp.Content,
+		ModelChange: cloneAgentModelChange(resp.ModelChange),
+	}, nil
 }
 
 func (s *remoteAgentServer) Preview(tab int, full bool) (PreviewSnapshot, error) {
@@ -685,9 +690,10 @@ type agentLifecycleReq struct {
 }
 
 type agentSnapshotResp struct {
-	Updated   bool   `json:"updated"`
-	HasPrompt bool   `json:"has_prompt"`
-	Content   string `json:"content"`
+	Updated     bool              `json:"updated"`
+	HasPrompt   bool              `json:"has_prompt"`
+	Content     string            `json:"content"`
+	ModelChange *AgentModelChange `json:"model_change,omitempty"`
 }
 
 type agentPreviewReq struct {

--- a/session/agentserver_remote_test.go
+++ b/session/agentserver_remote_test.go
@@ -1,6 +1,9 @@
 package session
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -73,6 +76,37 @@ func TestNewRemoteAgentServer_ValidatesEndpoint(t *testing.T) {
 		if _, ok := as.(*remoteAgentServer); !ok {
 			t.Fatalf("expected *remoteAgentServer, got %T", as)
 		}
+	}
+}
+
+func TestRemoteAgentServerSnapshotCarriesModelChange(t *testing.T) {
+	want := NewAgentModelChange("gpt-5.6-sol max", "gpt-5.6-luna low")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/agent/snapshot" {
+			t.Errorf("path = %q, want snapshot route", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"data": agentSnapshotResp{
+				Updated: true, Content: "ready", ModelChange: want,
+			},
+			"error": nil,
+		}); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	as, err := NewRemoteAgentServer(AgentServerEndpoint{URL: server.URL, Token: "test-token"}, "remote")
+	if err != nil {
+		t.Fatalf("NewRemoteAgentServer: %v", err)
+	}
+	obs, err := as.Snapshot()
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if !obs.Updated || obs.Content != "ready" || !sameAgentModelChange(obs.ModelChange, want) {
+		t.Fatalf("remote snapshot dropped model change: %+v", obs)
 	}
 }
 

--- a/session/backend.go
+++ b/session/backend.go
@@ -143,6 +143,10 @@ type Backend interface {
 	// for supported programs.
 	CheckAndHandleTrustPrompt(instance *Instance) bool
 
+	// AgentModelChange returns the active, runtime-derived model diagnostic after
+	// prompt handling has had a chance to observe a safety dialog. It is read by
+	// AgentServer.Snapshot so local and off-box runtimes cross the same choke point.
+	AgentModelChange(instance *Instance) *AgentModelChange
 	// Recover re-establishes a Lost session's backing resources — the tmux
 	// session vanished out from under a live record with no kill on record
 	// (#1108) — re-spawning the program in the instance's worktree. It is

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -815,3 +815,17 @@ func (b *LocalBackend) CheckAndHandleTrustPrompt(i *Instance) bool {
 	}
 	return false
 }
+
+func (b *LocalBackend) AgentModelChange(i *Instance) *AgentModelChange {
+	i.mu.RLock()
+	ts := i.tmuxLocked()
+	i.mu.RUnlock()
+	if ts == nil {
+		return nil
+	}
+	before, after, changed := ts.CodexSafetyModelChange()
+	if !changed {
+		return nil
+	}
+	return NewAgentModelChange(before, after)
+}

--- a/session/backend_remote_agent.go
+++ b/session/backend_remote_agent.go
@@ -124,6 +124,10 @@ func (b *remoteAgentBackend) IsAlive(i *Instance) (bool, error) {
 // handles it before returning a snapshot.
 func (b *remoteAgentBackend) CheckAndHandleTrustPrompt(*Instance) bool { return false }
 
+// AgentModelChange is carried by the remote AgentServer's Snapshot; asking the
+// daemon-side backend would recurse through that same server.
+func (b *remoteAgentBackend) AgentModelChange(*Instance) *AgentModelChange { return nil }
+
 // Recover and Respawn both re-provision a disposable remote workspace from the
 // session branch, then launch it again.
 func (b *remoteAgentBackend) Recover(i *Instance) error { return recoverSandbox(i) }

--- a/session/conversation.go
+++ b/session/conversation.go
@@ -105,6 +105,7 @@ func (i *Instance) noteAgentRuntimeReplaced() {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 	i.agentRuntimeGeneration++
+	i.clearAgentModelChangeLocked()
 }
 
 func (i *Instance) resolvedAgentLocked() string {

--- a/session/fake_backend.go
+++ b/session/fake_backend.go
@@ -113,6 +113,7 @@ func (b *FakeBackend) HasUpdated(*Instance) (bool, bool, string)    { return fal
 func (b *FakeBackend) SendPromptCommand(*Instance, string) error    { return nil }
 func (b *FakeBackend) IsAlive(*Instance) (bool, error)              { return true, nil }
 func (b *FakeBackend) CheckAndHandleTrustPrompt(*Instance) bool     { return false }
+func (b *FakeBackend) AgentModelChange(*Instance) *AgentModelChange { return nil }
 func (b *FakeBackend) Recover(*Instance) error                      { return nil }
 func (b *FakeBackend) Respawn(*Instance) error                      { return nil }
 func (b *FakeBackend) PrepareAgentSwap(_ *Instance, target string) (AgentSwapPlan, error) {

--- a/session/instance.go
+++ b/session/instance.go
@@ -149,6 +149,10 @@ type Instance struct {
 	// carried in the daemon snapshot so the badge survives a restart; PR3's
 	// auto-resume scheduler reads it. Mutex-protected.
 	limitResetAt time.Time
+	// agentModelChange is a live, projection-only diagnostic supplied by the
+	// running agent-server. It is mutex-protected and deliberately omitted from
+	// durable restore state; see AgentModelChange and InstanceData.ForStorage.
+	agentModelChange *AgentModelChange
 	// stateEpoch is the generation counter for the lifecycle state above — the two
 	// axes plus limitResetAt — bumped by every writer that actually changes one of
 	// them (#2135). It is how an observer that decided from a captured pane learns

--- a/session/instance_backend.go
+++ b/session/instance_backend.go
@@ -148,6 +148,7 @@ func (i *Instance) SetArchived() {
 	i.started = false
 	i.liveness = LiveArchived
 	i.inFlightOp = OpNone
+	i.clearAgentModelChangeLocked()
 	i.noteStateChangeLocked(lv, op, resetAt)
 }
 

--- a/session/instance_data.go
+++ b/session/instance_data.go
@@ -15,12 +15,12 @@ func (i *Instance) ToInstanceData() InstanceData {
 	return i.toInstanceDataLocked()
 }
 
-// ToInstanceDataWithEpoch returns the serializable form together with the state
-// epoch it was read at, both under ONE hold of i.mu (#2135). A writer that
-// persists what it read uses it so the epoch it re-checks before the write
-// provably belongs to the payload it is about to write — reading the two
-// separately would leave a window in which the state moves between them, which is
-// the very thing the epoch exists to detect.
+// ToInstanceDataWithEpoch returns the serializable form together with the
+// lifecycle epoch it was read at, both under ONE hold of i.mu (#2135). The epoch
+// deliberately does not cover every field in InstanceData (tabs are the notable
+// example), so it may correlate lifecycle observations but must not be used as a
+// whole-projection freshness guard. Writers of the whole payload re-read it in
+// their ordering domain instead; see daemon.persistPollChange.
 func (i *Instance) ToInstanceDataWithEpoch() (InstanceData, uint64) {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
@@ -44,6 +44,7 @@ func (i *Instance) toInstanceDataLocked() InstanceData {
 		InFlightOp:            i.inFlightOp,
 		LifecycleAction:       lifecycleActionFor(i.ID, i.liveness, i.inFlightOp, i.startupStateUnknown),
 		CanKill:               canKillFor(i.ID, i.inFlightOp),
+		ModelChange:           agentModelChangeForLiveness(i.agentModelChange, i.liveness),
 		Height:                i.Height,
 		Width:                 i.Width,
 		CreatedAt:             i.CreatedAt,
@@ -181,6 +182,7 @@ func FromInstanceData(data InstanceData) (*Instance, error) {
 		// finished run from an interrupted one.
 		taskRunActive:         data.TaskRunActive,
 		limitResetAt:          data.LimitResetAt,
+		agentModelChange:      agentModelChangeForLiveness(data.ModelChange, liveness),
 		Height:                data.Height,
 		Width:                 data.Width,
 		CreatedAt:             data.CreatedAt,

--- a/session/state_epoch_test.go
+++ b/session/state_epoch_test.go
@@ -109,9 +109,10 @@ func TestTransitionAtEpoch_DropsSupersededObservation(t *testing.T) {
 	}
 }
 
-// TestToInstanceDataWithEpoch_ReadsBothUnderOneLock: the payload and the epoch a
-// writer re-checks before persisting must describe the same instant, or the
-// re-check proves nothing about what is being written (#2135).
+// TestToInstanceDataWithEpoch_ReadsBothUnderOneLock: the lifecycle portion of
+// the payload and its lifecycle epoch must describe the same instant. The method
+// is not a whole-projection freshness guard; tabs and other projection fields do
+// not advance this epoch (#2135).
 func TestToInstanceDataWithEpoch_ReadsBothUnderOneLock(t *testing.T) {
 	inst := newEpochTestInstance(t)
 	resetAt := time.Date(2026, 7, 20, 18, 0, 0, 0, time.UTC)

--- a/session/storage.go
+++ b/session/storage.go
@@ -55,6 +55,11 @@ type InstanceData struct {
 	// vetoes runtime reuse but must remain explicitly removable. Like
 	// LifecycleAction, this is derived live and scrubbed before disk persistence.
 	CanKill bool `json:"can_kill,omitempty"`
+	// ModelChange is the projection-only agent diagnostic carried to the CLI,
+	// TUI, and web row. It is derived from the live runtime's Observation and
+	// scrubbed by ForStorage so a resolved or replaced process cannot inherit a
+	// stale warning after daemon restart.
+	ModelChange *AgentModelChange `json:"model_change,omitempty"`
 	// TaskRunActive records whether this session's task run is still in flight
 	// (#1892) — true from creation, false once the agent goes idle or startup
 	// settles terminal-unknown. It is the one fact the watch-task concurrency cap
@@ -150,6 +155,7 @@ func (d InstanceData) ForStorage() InstanceData {
 	d.InFlightOp = OpNone
 	d.LifecycleAction = LifecycleActionNone
 	d.CanKill = false
+	d.ModelChange = nil
 	switch {
 	case lv == LiveArchived:
 		// Archived rows have already reaped their runtime, so retaining a teardown

--- a/session/tmux/codex_safety.go
+++ b/session/tmux/codex_safety.go
@@ -24,6 +24,8 @@ const (
 type codexSafetyBufferingState struct {
 	lastModel          string
 	expectedModel      string
+	modelChangedFrom   string
+	modelChangedTo     string
 	verificationPolls  int
 	awaitingModelCheck bool
 	notified           bool
@@ -49,7 +51,8 @@ type codexPickerOption struct {
 // complete dialog chrome, navigation targets the literal label (never its
 // displayed ordinal), and Enter is sent only after a second capture proves the
 // intended row is selected. A later poll compares Codex's default status-line
-// model with the pre-dialog value and surfaces the result in af's log.
+// model with the pre-dialog value and retains a verified change for the shared
+// session observation, as well as logging it.
 func (t *TmuxSession) handleCodexSafetyBuffering(content string) bool {
 	targetLabel, safetyPromptPresent, safetyPromptActive := t.inspectCodexSafetyPrompt(content)
 	dialog, dialogPresent := parseCodexSafetyDialog(content, targetLabel, safetyPromptActive)
@@ -76,7 +79,7 @@ func (t *TmuxSession) handleCodexSafetyBuffering(content string) bool {
 			return true
 		}
 		if model != "" {
-			state.lastModel = model
+			state.observeModel(model)
 		}
 		state.notified = false
 		return false
@@ -121,7 +124,7 @@ func (t *TmuxSession) handleCodexSafetyBuffering(content string) bool {
 				return true
 			}
 			if current := codexStatusLineModel(selectedContent); current != "" {
-				state.lastModel = current
+				state.observeModel(current)
 			}
 			state.notified = false
 			log.InfoLog.Printf("Codex session %q additional safety checks resolved before af accepted a choice", t.sanitizedName)
@@ -175,12 +178,14 @@ func (t *TmuxSession) verifyCodexSafetyModel(model string, dialogPresent bool) {
 			"Codex session %q model changed after additional safety checks: before %q, after %q; possible unintended downgrade",
 			t.sanitizedName, state.expectedModel, model,
 		)
+		state.recordModelChange(state.expectedModel, model)
 	default:
 		log.InfoLog.Printf(
 			"Codex session %q additional safety checks: verified model unchanged: %s",
 			t.sanitizedName, model,
 		)
 	}
+	state.observeModel(model)
 	state.finishModelVerification(model)
 }
 
@@ -188,7 +193,61 @@ func (s *codexSafetyBufferingState) finishModelVerification(model string) {
 	if model == "" {
 		model = s.lastModel
 	}
-	*s = codexSafetyBufferingState{lastModel: model}
+	*s = codexSafetyBufferingState{
+		lastModel:        model,
+		modelChangedFrom: s.modelChangedFrom,
+		modelChangedTo:   s.modelChangedTo,
+	}
+}
+
+// observeModel keeps a verified model-change diagnostic live while Codex stays
+// on the changed model, updates its current value if Codex changes again, and
+// clears it only when the original pre-dialog model is visible again. A later
+// safety dialog that preserves the already-changed model therefore cannot erase
+// the earlier warning merely by comparing equal to its newer local baseline.
+func (s *codexSafetyBufferingState) observeModel(model string) {
+	if model == "" {
+		return
+	}
+	s.lastModel = model
+	if s.modelChangedFrom == "" {
+		return
+	}
+	if model == s.modelChangedFrom {
+		s.modelChangedFrom = ""
+		s.modelChangedTo = ""
+		return
+	}
+	s.modelChangedTo = model
+}
+
+func (s *codexSafetyBufferingState) recordModelChange(before, after string) {
+	if before == "" || after == "" || before == after {
+		return
+	}
+	if s.modelChangedFrom == "" {
+		s.modelChangedFrom = before
+	}
+	s.modelChangedTo = after
+}
+
+// CodexSafetyModelChange returns the active post-safety-dialog model change.
+// It is retained across pane polls so every observation surface can render the
+// same state, rather than trying to rediscover a one-shot log message.
+func (t *TmuxSession) CodexSafetyModelChange() (before, after string, changed bool) {
+	t.inputMu.Lock()
+	defer t.inputMu.Unlock()
+	state := &t.codexSafety
+	if state.modelChangedFrom == "" || state.modelChangedTo == "" {
+		return "", "", false
+	}
+	return state.modelChangedFrom, state.modelChangedTo, true
+}
+
+func (t *TmuxSession) resetCodexSafetyState() {
+	t.inputMu.Lock()
+	defer t.inputMu.Unlock()
+	t.codexSafety = codexSafetyBufferingState{}
 }
 
 // parseCodexSafetyDialog admits the observed Codex 0.144.6 picker and the

--- a/session/tmux/doc_trust_prompt_test.go
+++ b/session/tmux/doc_trust_prompt_test.go
@@ -2,6 +2,7 @@ package tmux
 
 import (
 	"bytes"
+	"errors"
 	"os/exec"
 	"strings"
 	"sync"
@@ -303,12 +304,54 @@ func TestCheckAndHandleTrustPrompt_CodexSafetyModelDowngradeIsSurfaced(t *testin
 		codexSafetyBufferingDialog,
 		codexSafetyBufferingKeepWaitingSelected,
 		"gpt-5.6-luna low · ~/agent-factory",
+		"gpt-5.6-luna low · ~/agent-factory",
+		"gpt-5.6-sol max · ~/agent-factory",
 	)
 
 	require.False(t, session.CheckAndHandleTrustPrompt())
 	require.True(t, session.CheckAndHandleTrustPrompt())
 	require.False(t, session.CheckAndHandleTrustPrompt())
 	require.Contains(t, errors.String(), `model changed after additional safety checks: before "gpt-5.6-sol max", after "gpt-5.6-luna low"`)
+	before, after, changed := session.CodexSafetyModelChange()
+	require.True(t, changed, "a logged model change must survive as observable session state")
+	require.Equal(t, "gpt-5.6-sol max", before)
+	require.Equal(t, "gpt-5.6-luna low", after)
+
+	require.False(t, session.CheckAndHandleTrustPrompt())
+	before, after, changed = session.CodexSafetyModelChange()
+	require.True(t, changed, "ordinary polls on the changed model must retain the warning")
+	require.Equal(t, "gpt-5.6-sol max", before)
+	require.Equal(t, "gpt-5.6-luna low", after)
+
+	require.False(t, session.CheckAndHandleTrustPrompt())
+	_, _, changed = session.CodexSafetyModelChange()
+	require.False(t, changed, "seeing the original model again resolves the live warning")
+}
+
+func TestCodexSafetyModelChangeClearsWhenRuntimeIsReplaced(t *testing.T) {
+	session, _ := runTrustPromptSequence(t, ProgramCodex,
+		"gpt-5.6-sol max · ~/agent-factory",
+		codexSafetyBufferingDialog,
+		codexSafetyBufferingKeepWaitingSelected,
+		"gpt-5.6-luna low · ~/agent-factory",
+	)
+	require.False(t, session.CheckAndHandleTrustPrompt())
+	require.True(t, session.CheckAndHandleTrustPrompt())
+	require.False(t, session.CheckAndHandleTrustPrompt())
+	_, _, changed := session.CodexSafetyModelChange()
+	require.True(t, changed)
+
+	forceNewSessionEnvMarkers(t, false)
+	session.ptyFactory = failingPtyFactory{}
+	session.cmdExec = cmd_test.MockCmdExec{
+		RunFunc: func(*exec.Cmd) error { return errors.New("session not found") },
+		OutputFunc: func(*exec.Cmd) ([]byte, error) {
+			return nil, nil
+		},
+	}
+	require.Error(t, session.Start(t.TempDir()))
+	_, _, changed = session.CodexSafetyModelChange()
+	require.False(t, changed, "a replacement process must not inherit the old runtime's warning")
 }
 
 func TestCheckAndHandleTrustPrompt_CodexChangedSafetyPickerIsSurfacedWithoutInput(t *testing.T) {

--- a/session/tmux/start.go
+++ b/session/tmux/start.go
@@ -24,6 +24,11 @@ func (t *TmuxSession) Start(workDir string) error {
 	if exists {
 		return fmt.Errorf("%w: tmux session already exists: %s", ErrSessionNotStarted, t.sanitizedName)
 	}
+	// The name is positively absent, so any Start from here creates a new pane
+	// process. Drop diagnostics owned by the prior process at that proven runtime
+	// boundary. SetProgram cannot do this: the live-session Restore path rewrites
+	// the command string without re-execing the existing pane.
+	t.resetCodexSafetyState()
 
 	// Create a new detached tmux session and start claude in it. The -e
 	// markers (when supported) let `af doctor` trace any process the pane

--- a/session/transition.go
+++ b/session/transition.go
@@ -538,6 +538,13 @@ func (i *Instance) Transition(ev TransitionEvent) error {
 	case startedClear:
 		i.started = false
 	}
+	// A model-change diagnostic belongs to one concrete agent process. Archive
+	// retires that process, and restore starts a new one under the same Instance
+	// identity; neither boundary may carry the predecessor's warning across.
+	switch ev.kind {
+	case tkCommitArchive, tkBeginRestore:
+		i.clearAgentModelChangeLocked()
+	}
 	return nil
 }
 

--- a/task/start_test.go
+++ b/task/start_test.go
@@ -66,9 +66,10 @@ func (b *startBackend) CheckAndHandleTrustPrompt(*session.Instance) bool {
 	b.trustPrompts--
 	return true
 }
-func (b *startBackend) Recover(*session.Instance) error { return nil }
-func (b *startBackend) Respawn(*session.Instance) error { return nil }
-func (b *startBackend) Type() string                    { return "local" }
+func (b *startBackend) AgentModelChange(*session.Instance) *session.AgentModelChange { return nil }
+func (b *startBackend) Recover(*session.Instance) error                              { return nil }
+func (b *startBackend) Respawn(*session.Instance) error                              { return nil }
+func (b *startBackend) Type() string                                                 { return "local" }
 func (b *startBackend) Capabilities() session.Capabilities {
 	return session.Capabilities{
 		Workspace:        session.WorkspaceLocalWorktree,

--- a/ui/tree/render.go
+++ b/ui/tree/render.go
@@ -361,6 +361,13 @@ func (r *InstanceRenderer) Render(i *session.Instance, _ int, selected bool, has
 	if liveness == session.LiveLimitReached {
 		titleText = limitBadgePrefix(i) + titleText
 	}
+	// A verified post-safety-dialog model change is orthogonal to liveness: the
+	// session can keep working and otherwise look healthy. Add it LAST so it is
+	// the outermost prefix; narrow rails retain the reason before lower-priority
+	// remote/lifecycle context or the title can be clipped (#2307).
+	if i.AgentModelChange() != nil {
+		titleText = "[model changed] " + titleText
+	}
 	prefixSepWidth := 0
 	if prefix != "" {
 		prefixSepWidth = 1

--- a/ui/tree/render_test.go
+++ b/ui/tree/render_test.go
@@ -315,7 +315,7 @@ func TestInstanceRendererModelChangeMarker(t *testing.T) {
 		Program: "codex",
 	})
 	require.NoError(t, err)
-	require.True(t, inst.SetAgentModelChange(session.NewAgentModelChange(
+	require.True(t, inst.ReconcileAgentModelChange(session.NewAgentModelChange(
 		"gpt-5.6-sol max",
 		"gpt-5.6-luna low",
 	)))

--- a/ui/tree/render_test.go
+++ b/ui/tree/render_test.go
@@ -308,6 +308,29 @@ func TestInstanceRendererLimitReachedMarker(t *testing.T) {
 	assert.Contains(t, out, "throttled", "the title must remain visible")
 }
 
+func TestInstanceRendererModelChangeMarker(t *testing.T) {
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title:   "security-review",
+		Path:    t.TempDir(),
+		Program: "codex",
+	})
+	require.NoError(t, err)
+	require.True(t, inst.SetAgentModelChange(session.NewAgentModelChange(
+		"gpt-5.6-sol max",
+		"gpt-5.6-luna low",
+	)))
+
+	out, _ := renderForTerminal(t, 160, inst)
+	assert.Contains(t, ansiEscape.ReplaceAllString(out, ""), "[model changed] security-review",
+		"a healthy-looking session must still surface its verified model change")
+
+	inst.SetBackend(&session.HookBackend{})
+	_ = inst.Transition(session.ObserveLiveness(session.LiveLost))
+	out, _ = renderForTerminal(t, 160, inst)
+	assert.Contains(t, ansiEscape.ReplaceAllString(out, ""), "[model changed] [lost] [remote]",
+		"the diagnostic stays outermost when lower-priority row prefixes coexist")
+}
+
 // TestInstanceRendererStatusGlyphs pins the #1766 status-cell contract, the same
 // (Liveness, InFlightOp)→glyph mapping the web mirrors (web/src/status.ts): only a
 // waiting/Ready session shows the green ● dot; every working/busy state — LiveRunning

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -7533,6 +7533,9 @@ function rowTitle(s) {
   if (s.backend_type === "remote") {
     title = "[remote] " + title;
   }
+  if (s.model_change) {
+    title = "[model changed] " + title;
+  }
   return title;
 }
 function limitBadgePrefix(s) {
@@ -11946,7 +11949,8 @@ function sessionRow(s, selected, openSession, buildActions) {
   }
   row.setAttribute("role", "option");
   row.setAttribute("aria-selected", selected ? "true" : "false");
-  row.setAttribute("title", `${s.title} \u2014 ${status.label}`);
+  const modelChange = s.model_change ? `; model changed from ${s.model_change.before} to ${s.model_change.after}` : "";
+  row.setAttribute("title", `${s.title} \u2014 ${status.label}${modelChange}`);
   if (!actionable && !managed) {
     row.setAttribute("aria-disabled", "true");
   } else if (actionable) {

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "1c1d558f55e3";
+const VERSION = "f2e4fc884343";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/src/status.test.ts
+++ b/web/src/status.test.ts
@@ -87,6 +87,28 @@ test("title prefixes match render.go precedence", () => {
     rowTitle(sess({ title: "w", liveness: Liveness.Lost, backend_type: "remote" })),
     "[remote] [lost] w",
   );
+  assert.equal(
+    rowTitle(
+      sess({
+        title: "w",
+        model_change: { before: "gpt-5.6-sol max", after: "gpt-5.6-luna low" },
+      }),
+    ),
+    "[model changed] w",
+    "a model change is visible even when the liveness remains healthy",
+  );
+  assert.equal(
+    rowTitle(
+      sess({
+        title: "w",
+        liveness: Liveness.Lost,
+        backend_type: "remote",
+        model_change: { before: "gpt-5.6-sol max", after: "gpt-5.6-luna low" },
+      }),
+    ),
+    "[model changed] [remote] [lost] w",
+    "the diagnostic remains outermost when state and backend prefixes coexist",
+  );
 });
 
 test("[limit] badge shows the reset time like render.go's limitBadgePrefix", () => {

--- a/web/src/status.ts
+++ b/web/src/status.ts
@@ -1,7 +1,8 @@
 // The status-dot + title mapping for a sidebar row (#1592 Phase 5 PR3). This is a
 // line-for-line port of the TUI renderer, ui/tree/render.go — the single source of
 // truth for how (Liveness, InFlightOp) become a glyph, a color, and the [lost] /
-// [deleting] / [limit] / [remote] title prefixes. The web MUST match it exactly:
+// [deleting] / [limit] / [remote] / [model changed] title prefixes. The web MUST
+// match it exactly:
 // two thin clients of the same projection cannot diverge in status semantics, only
 // in pixels (design §3). Adding a Liveness value forces a deliberate choice here,
 // mirroring the TUI's TOTAL liveness switch (render.go:274-301).
@@ -200,9 +201,10 @@ export function compareSessionsForRail(a: SessionData, b: SessionData): number {
 
 /**
  * Builds the row title with the same prefixes the TUI prepends (render.go:304-345),
- * in the same precedence: [remote] outermost, then the state marker. Archived rows
- * deliberately carry NO word prefix (render.go:326-338) — the glyph + dimming say
- * it, and an 11-char prefix would eat the title cell.
+ * in the same precedence for ordinary status prefixes, with the orthogonal model
+ * diagnostic outermost so narrow rows cannot hide it. Archived rows carry NO
+ * word prefix (render.go:326-338) — the glyph + dimming say it, and an 11-char
+ * prefix would eat the title cell.
  */
 export function rowTitle(s: SessionData): string {
   const lv = livenessOf(s);
@@ -217,6 +219,9 @@ export function rowTitle(s: SessionData): string {
   }
   if (s.backend_type === "remote") {
     title = "[remote] " + title;
+  }
+  if (s.model_change) {
+    title = "[model changed] " + title;
   }
   return title;
 }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -56,6 +56,12 @@ export const InFlightOp = {
  *  torn down but must not reuse their unconfirmed runtime binding. */
 export type LifecycleAction = "archive" | "restore";
 
+/** A verified model transition observed after af handled an agent safety dialog. */
+export interface AgentModelChange {
+  before: string;
+  after: string;
+}
+
 /** session.Status (session/instance.go) — the legacy single-axis int, read ONLY
  *  as a defensive fallback when a projection somehow omits `liveness` (never
  *  expected from the daemon's live Snapshot, which always emits it). */
@@ -95,6 +101,8 @@ export interface SessionData {
   /** Daemon-owned explicit teardown capability. True means the row has a stable
    *  non-creating target; absence/false fails closed. */
   can_kill?: boolean;
+  /** Live, projection-only model diagnostic; never restored from instances.json. */
+  model_change?: AgentModelChange;
   /** Usage-limit reset time (RFC3339), present only for a LimitReached row. */
   limit_reset_at?: string;
   /** Backend discriminator; "remote" marks a remote-hook session (→ [remote]). */

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -2399,7 +2399,10 @@ function sessionRow(
   }
   row.setAttribute("role", "option");
   row.setAttribute("aria-selected", selected ? "true" : "false");
-  row.setAttribute("title", `${s.title} — ${status.label}`);
+  const modelChange = s.model_change
+    ? `; model changed from ${s.model_change.before} to ${s.model_change.after}`
+    : "";
+  row.setAttribute("title", `${s.title} — ${status.label}${modelChange}`);
   if (!actionable && !managed) {
     // The server withheld both capabilities: a creating row has no session yet,
     // while an id-less row has no unambiguous mutation target.


### PR DESCRIPTION
Closes #2307.

## Verified defect

Current master retained a detected post-safety-dialog Codex model change only in the one-shot log at `session/tmux/codex_safety.go`; the daemon session projection had no corresponding state, so `af sessions list`, the TUI rail, and the web row continued to look healthy. #2309 already shipped the prevention half by selecting the literal safe wait action. This PR closes the remaining visibility gap without changing picker navigation.

## Change

- Retain one validated before/after model transition at the tmux runtime boundary, update it as the current model changes, clear it when the original model returns, and reset it only at a positively established new-process boundary.
- Carry that typed live-only diagnostic through the local and remote agent-server snapshot chokepoint into `InstanceData`; scrub it from durable storage and retire it at archive, restore, recovery, and handoff runtime boundaries so a replacement process cannot inherit stale state.
- Bind every daemon-side diagnostic write to the lifecycle epoch captured before selecting and querying the AgentServer, so an outgoing runtime's observation cannot cross a concurrent handoff/recovery boundary; keep client snapshot reconciliation and authoritative clearing as separately named APIs.
- Publish projection-only appearance and clearance events even when liveness does not change.
- Re-read every whole-session event payload after acquiring the repo ordering lock, so an untracked tab mutation cannot be overwritten by a projection-only event captured before the lock.
- Surface `[model changed]` outermost in the TUI and web rows so narrow rails cannot clip the warning; expose exact before/after values in the CLI JSON projection and web tooltip.
- Rebuilt committed `web/dist` after rebasing the web change onto current master.

## Regression coverage

- Fail-first coverage for detection, retention, resolution, and replacement reset.
- Local, remote, and headless snapshot wire coverage.
- Live projection and storage-scrub coverage.
- Daemon event publication for appearance and clearance without a liveness transition.
- Deterministic pre-lock tab mutation coverage proving a later projection-only event retains the current roster.
- Archive/restore and general runtime-replacement coverage proving diagnostics cannot outlive their process.
- A deterministic poll/replacement interleaving proving an outgoing runtime cannot repopulate the diagnostic after the replacement boundary.
- TUI reconciliation/row and web row precedence coverage.

## Exact-head gates

Commit: `542daa8e82c263b62fc3d9ae205aa38615e65cf8`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (clean)
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh` (959 files, 0 grandfathered)

All passed after the final commit; the pushed branch resolves to the same SHA.

Gate note: an earlier post-rebase head hit an unrelated `TestCaptureReaderAbortWakesWithExternalWriterStillOpen` close race (`file already closed`). The exact test then passed 100 consecutive container runs; subsequent full suites passed. PR #2345 independently landed the single-owner keeper fix and closed follow-up #2346; no timeout, retry, or capture-test code was changed here.

— Captain Claude
