### PR TITLE
fix(session): make capture keeper cleanup single-owner

### DIFF
--- a/session/ptychannel_tmux.go
+++ b/session/ptychannel_tmux.go
@@ -41,14 +41,16 @@ type tmuxClientlessChannel struct {
 // never be confused with successful raw PTY output. Successful teardown never
 // injects a control byte.
 type captureReader struct {
-	f         *os.File
-	keepalive *os.File
-	dir       string
-	abort     atomic.Bool
-	eof       atomic.Bool
-	stopOnce  sync.Once
-	cleanOnce sync.Once
-	err       error
+	f          *os.File
+	keepalive  *os.File
+	dir        string
+	abort      atomic.Bool
+	eof        atomic.Bool
+	stopOnce   sync.Once
+	cleanOnce  sync.Once
+	keeperOnce sync.Once
+	err        error
+	keeperErr  error
 }
 
 func (r *captureReader) Read(p []byte) (int, error) {
@@ -95,11 +97,18 @@ func (r *captureReader) stop(drain bool) error {
 				_, _ = r.keepalive.Write([]byte{0})
 			}
 		}
-		if r.keepalive != nil {
-			r.err = r.keepalive.Close()
-		}
+		r.err = r.closeKeeper()
 	})
 	return r.err
+}
+
+func (r *captureReader) closeKeeper() error {
+	r.keeperOnce.Do(func() {
+		if r.keepalive != nil {
+			r.keeperErr = r.keepalive.Close()
+		}
+	})
+	return r.keeperErr
 }
 
 func (r *captureReader) finish() {
@@ -107,9 +116,7 @@ func (r *captureReader) finish() {
 		if r.f != nil {
 			_ = r.f.Close()
 		}
-		if r.keepalive != nil {
-			_ = r.keepalive.Close()
-		}
+		_ = r.closeKeeper()
 		if r.dir != "" {
 			_ = os.RemoveAll(r.dir)
 		}

--- a/session/ptychannel_tmux_test.go
+++ b/session/ptychannel_tmux_test.go
@@ -110,6 +110,26 @@ func TestCaptureReaderAbortWakesWithExternalWriterStillOpen(t *testing.T) {
 	}
 }
 
+func TestCaptureReaderCloseAfterAbortCleanup(t *testing.T) {
+	outputR, outputW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create output pipe: %v", err)
+	}
+	r := &captureReader{f: outputR, keepalive: outputW}
+
+	// Reproduce the losing stop interleaving deterministically: stop has latched
+	// abort, then the reader observes it and finishes cleanup before stop reaches
+	// the keeper close.
+	r.abort.Store(true)
+	buf := make([]byte, 1)
+	if _, err := r.Read(buf); !errors.Is(err, io.EOF) {
+		t.Fatalf("Read error = %v, want EOF after abort", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("Close after reader cleanup = %v, want nil", err)
+	}
+}
+
 // TestTmuxSnapshotRepaintCursorRealTmux is the #1688 end-to-end gate against a REAL
 // tmux server: it drives the actual capture → buildRepaint → emulator path and
 // asserts the restored cursor lands on its true pane row when the client emulator's


### PR DESCRIPTION
Closes #2344.

## Summary

- Route both capture stop and reader finalization through one synchronized keeper-close primitive.
- Preserve the failure-only abort wake and ordered FIFO EOF behavior from #2300.
- Preserve genuine keeper close errors while eliminating schedule-dependent duplicate-close errors.
- Add a deterministic regression for the interleaving where reader cleanup wins before `Close` reaches the keeper.

## Fail-first evidence

The new regression failed before the production change with:

`Close after reader cleanup = close |1: file already closed, want nil`

The existing full isolated suite had independently produced the same error twice in `TestCaptureReaderAbortWakesWithExternalWriterStillOpen`; the focused test passed, exposing the scheduling dependency.

## Gates

All required local gates passed on exact pushed head `60f647b93a00ff82c230e03add7d8b669535aeed`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`

Additional focused coverage: all capture-reader tests passed 25 times normally and 25 times under the race detector.

— Captain Claude
