### PR TITLE
fix(session): resolve create capture from the exact launch

### DIFF
--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -129,13 +129,12 @@ func (m *Manager) CreateSession(ctx context.Context, req CreateSessionRequest) (
 		return session.InstanceData{}, err
 	}
 
-	conversationCapture := session.BeginConversationCapture()
-
 	// Single creation flow (#930 PR 3): every instance owns its worktree 1:1.
 	// InPlace only changes WHICH worktree that is — the repo's own working tree,
 	// marked external — not the flow itself. finishCreateStart marks the instance
 	// live, PARKS it at a usage-limit wall (#1146 PR4), or returns a fatal error.
-	if serr := finishCreateStart(instance, req.Prompt, task.StartAndSendPrompt(ctx, instance, req.Prompt)); serr != nil {
+	conversationCapture, startErr := task.StartAndSendPromptWithConversationCapture(ctx, instance, req.Prompt)
+	if serr := finishCreateStart(instance, req.Prompt, startErr); serr != nil {
 		// An unknown startup outcome is already a teardown boundary. Launch may have
 		// failed because the name it probed is not the name tmux stored; asking Kill
 		// through that same binding can then answer "absent" for the wrong name and

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -281,6 +281,10 @@ func (b *LocalBackend) Provision(i *Instance, firstTimeSetup bool) error {
 // provision because it is the first on-disk mutation and therefore belongs
 // inside this cleanup scope.
 func (b *LocalBackend) Launch(i *Instance, firstTimeSetup bool) error {
+	return b.launch(i, firstTimeSetup, nil)
+}
+
+func (b *LocalBackend) launch(i *Instance, firstTimeSetup bool, prepared *CreateLaunchPlan) error {
 	i.mu.RLock()
 	tmuxSession := i.tmuxLocked()
 	i.mu.RUnlock()
@@ -387,12 +391,24 @@ func (b *LocalBackend) Launch(i *Instance, firstTimeSetup bool) error {
 			return setupErr
 		}
 
-		// Inject Agent Factory instructions into the session. On a first launch
-		// only, seed provider conversation identity when a supported agent offers
-		// an explicit id flag; restore/respawn paths keep their existing latest-
-		// session behavior until PR2 wires resume-by-recorded-id.
-		program := prepareLaunchConversation(i, resolveProgramForInstance(i))
-		tmuxSession.SetProgram(injectSystemPrompt(program))
+		// Inject Agent Factory instructions into the session. The daemon create
+		// path supplies a command frozen after provisioning and before process
+		// launch; direct Start callers retain the established inline preparation.
+		var program string
+		if prepared != nil {
+			if prepared.workDir != gw.GetWorktreePath() || strings.TrimSpace(prepared.program) == "" {
+				setupErr = fmt.Errorf("prepared create launch no longer matches session %q", i.Title)
+				return setupErr
+			}
+			program = prepared.program
+			if prepared.conversation.HasID() {
+				i.SetAgentConversation(prepared.conversation)
+			}
+		} else {
+			program = prepareLaunchConversation(i, resolveProgramForInstance(i))
+			program = injectSystemPrompt(program)
+		}
+		tmuxSession.SetProgram(program)
 
 		// Create new session
 		if err := tmuxSession.Start(gw.GetWorktreePath()); err != nil {

--- a/session/backend_local_create.go
+++ b/session/backend_local_create.go
@@ -1,0 +1,63 @@
+package session
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+func (b *LocalBackend) prepareCreateLaunch(i *Instance) (CreateLaunchPlan, error) {
+	workDir := i.GetWorktreePath()
+	if workDir == "" {
+		return CreateLaunchPlan{}, fmt.Errorf("cannot prepare session %q: local provisioning produced no launch directory", i.Title)
+	}
+
+	resolved := resolveProgramForInstance(i)
+	program, conversation := planLaunchConversation(i.ID, resolved)
+	program = injectSystemPrompt(program)
+	plan := CreateLaunchPlan{
+		program:      program,
+		workDir:      workDir,
+		conversation: conversation,
+	}
+
+	// Key capture off the executable the pane will actually run, never the
+	// configured enum. An override may point "codex" at an opaque wrapper; its
+	// private environment and storage contract are unknowable here, so polling a
+	// daemon-inherited Codex home would manufacture a path we have no evidence the
+	// child uses (#1116/#2290). Keep parser failure distinct from a positively
+	// opaque command, though: DetectAgentFromCommand deliberately collapses both
+	// to "", while a configured Codex command with unsupported env syntax must
+	// still fail closed instead of silently losing capture.
+	actualAgent := tmux.DetectAgentFromCommand(program)
+	if actualAgent != tmux.ProgramCodex {
+		if i.AgentProgram() != tmux.ProgramCodex {
+			return plan, nil
+		}
+		launch, err := tmux.CommandEnvironmentFromCommand(program, workDir)
+		if err != nil {
+			return CreateLaunchPlan{}, fmt.Errorf(
+				"cannot prepare Codex conversation capture for session %q: %w; use literal CODEX_HOME/HOME values and supported env options",
+				i.Title, err)
+		}
+		if launch.Agent != tmux.ProgramCodex {
+			return plan, nil
+		}
+	}
+	codexHome, err := tmux.CodexHomeFromCommand(program, workDir)
+	if err != nil {
+		return CreateLaunchPlan{}, fmt.Errorf(
+			"cannot prepare Codex conversation capture for session %q: %w; use literal CODEX_HOME/HOME values and supported env options",
+			i.Title, err)
+	}
+	if strings.TrimSpace(codexHome) == "" {
+		return CreateLaunchPlan{}, fmt.Errorf("cannot prepare Codex conversation capture for session %q: resolved store is empty", i.Title)
+	}
+	plan.conversationCapture = BeginConversationCaptureAtCodexHome(codexHome)
+	return plan, nil
+}
+
+func (b *LocalBackend) launchPreparedCreate(i *Instance, plan CreateLaunchPlan) error {
+	return b.launch(i, true, &plan)
+}

--- a/session/backend_local_create_test.go
+++ b/session/backend_local_create_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/pathutil"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
@@ -85,13 +86,15 @@ func TestPrepareCreateLaunchResolvesCommandSpecificCodexHome(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, repoRoot, plan.workDir,
+			expectedWorkDir := pathutil.ResolveForCompare(repoRoot)
+			expectedCodexHome := pathutil.ResolveForCompare(tc.want(repoRoot))
+			require.Equal(t, expectedWorkDir, pathutil.ResolveForCompare(plan.workDir),
 				"the capture plan must be prepared only after provisioning fixes the launch cwd")
-			require.Equal(t, tc.want(repoRoot), plan.conversationCapture.codexHome)
+			require.Equal(t, expectedCodexHome, pathutil.ResolveForCompare(plan.conversationCapture.codexHome))
 			require.False(t, plan.conversationCapture.startedAt.IsZero(),
 				"the before-image must be taken during prepare, before launch")
 
-			writeCodexRolloutFile(t, tc.want(repoRoot),
+			writeCodexRolloutFile(t, expectedCodexHome,
 				"rollout-2026-07-06T10-17-35-019f386f-7206-7fc2-803b-f7045e07a242.jsonl")
 			conv, captureErr := CaptureAgentConversation(tmux.ProgramCodex, plan.ConversationCapture(), time.Second)
 			require.NoError(t, captureErr)

--- a/session/backend_local_create_test.go
+++ b/session/backend_local_create_test.go
@@ -1,0 +1,235 @@
+package session
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+func TestPrepareCreateLaunchResolvesCommandSpecificCodexHome(t *testing.T) {
+	tests := []struct {
+		name    string
+		command func(repoRoot string) string
+		want    func(repoRoot string) string
+		wantErr string
+	}{
+		{
+			name: "absolute CODEX_HOME",
+			command: func(repoRoot string) string {
+				return "CODEX_HOME=" + filepath.Join(repoRoot, "absolute-store") + " codex"
+			},
+			want: func(repoRoot string) string { return filepath.Join(repoRoot, "absolute-store") },
+		},
+		{
+			name:    "relative CODEX_HOME",
+			command: func(string) string { return "CODEX_HOME=relative-store codex" },
+			want:    func(repoRoot string) string { return filepath.Join(repoRoot, "relative-store") },
+		},
+		{
+			name:    "env chdir precedes relative CODEX_HOME",
+			command: func(string) string { return "env -C nested CODEX_HOME=relative-store codex" },
+			want: func(repoRoot string) string {
+				return filepath.Join(repoRoot, "nested", "relative-store")
+			},
+		},
+		{
+			name:    "unset CODEX_HOME uses command HOME",
+			command: func(string) string { return "env -uCODEX_HOME HOME=relative-home codex" },
+			want: func(repoRoot string) string {
+				return filepath.Join(repoRoot, "relative-home", ".codex")
+			},
+		},
+		{
+			name:    "dynamic CODEX_HOME fails closed",
+			command: func(string) string { return "CODEX_HOME=$ALT_CODEX_HOME codex" },
+			wantErr: "shell expansion",
+		},
+		{
+			name:    "split-string env fails closed",
+			command: func(string) string { return "env -S 'CODEX_HOME=/tmp/create-codex codex'" },
+			wantErr: "split-string",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+			t.Setenv("CODEX_HOME", t.TempDir())
+			t.Setenv("HOME", t.TempDir())
+			repoRoot := initInPlaceRepo(t, "prepared-create")
+			require.NoError(t, os.Mkdir(filepath.Join(repoRoot, "nested"), 0o755))
+
+			cfg := config.DefaultConfig()
+			cfg.ProgramOverrides = map[string]string{tmux.ProgramCodex: tc.command(repoRoot)}
+			require.NoError(t, config.SaveConfig(cfg))
+
+			inst, err := NewInstance(InstanceOptions{
+				Title:   "prepared-create",
+				Path:    repoRoot,
+				Program: tmux.ProgramCodex,
+				InPlace: true,
+			})
+			require.NoError(t, err)
+
+			plan, err := inst.PrepareCreateLaunch()
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, repoRoot, plan.workDir,
+				"the capture plan must be prepared only after provisioning fixes the launch cwd")
+			require.Equal(t, tc.want(repoRoot), plan.conversationCapture.codexHome)
+			require.False(t, plan.conversationCapture.startedAt.IsZero(),
+				"the before-image must be taken during prepare, before launch")
+
+			writeCodexRolloutFile(t, tc.want(repoRoot),
+				"rollout-2026-07-06T10-17-35-019f386f-7206-7fc2-803b-f7045e07a242.jsonl")
+			conv, captureErr := CaptureAgentConversation(tmux.ProgramCodex, plan.ConversationCapture(), time.Second)
+			require.NoError(t, captureErr)
+			require.Equal(t, "019f386f-7206-7fc2-803b-f7045e07a242", conv.ID,
+				"post-launch capture must observe the store frozen by the create plan")
+		})
+	}
+}
+
+func TestPrepareCreateLaunchUsesProvisionedLinkedWorktreeCwd(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	t.Setenv("CODEX_HOME", t.TempDir())
+	repoRoot := initInPlaceRepo(t, "linked-create")
+
+	cfg := config.DefaultConfig()
+	cfg.ProgramOverrides = map[string]string{tmux.ProgramCodex: "CODEX_HOME=relative-store codex"}
+	require.NoError(t, config.SaveConfig(cfg))
+	inst, err := NewInstance(InstanceOptions{
+		Title: "linked-create", Path: repoRoot, Program: tmux.ProgramCodex,
+	})
+	require.NoError(t, err)
+
+	plan, err := inst.PrepareCreateLaunch()
+	require.NoError(t, err)
+	require.NotEqual(t, repoRoot, plan.workDir, "regular create must use its linked worktree, not the source repo")
+	require.Equal(t, inst.GetWorktreePath(), plan.workDir)
+	require.Equal(t, filepath.Join(plan.workDir, "relative-store"), plan.conversationCapture.codexHome)
+}
+
+func TestPreparedCreateLaunchConsumesFrozenCommand(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	t.Setenv("CODEX_HOME", t.TempDir())
+	repoRoot := initInPlaceRepo(t, "frozen-create")
+	oldHome := filepath.Join(repoRoot, "old-store")
+	newHome := filepath.Join(repoRoot, "new-store")
+
+	cfg := config.DefaultConfig()
+	cfg.ProgramOverrides = map[string]string{tmux.ProgramCodex: "CODEX_HOME=" + oldHome + " codex"}
+	require.NoError(t, config.SaveConfig(cfg))
+	inst, err := NewInstance(InstanceOptions{
+		Title: "frozen-create", Path: repoRoot, Program: tmux.ProgramCodex, InPlace: true,
+	})
+	require.NoError(t, err)
+	world := newInPlaceTmuxWorld(t)
+	inst.SetTmuxSession(tmux.NewTmuxSessionWithDeps("frozen-create", tmux.ProgramCodex, world, world.exec()))
+
+	plan, err := inst.PrepareCreateLaunch()
+	require.NoError(t, err)
+	require.Equal(t, oldHome, plan.conversationCapture.codexHome)
+
+	cfg.ProgramOverrides[tmux.ProgramCodex] = "CODEX_HOME=" + newHome + " codex"
+	require.NoError(t, config.SaveConfig(cfg))
+	require.NoError(t, inst.LaunchPreparedCreate(plan))
+	t.Cleanup(func() { _ = inst.CloseAttachOnly() })
+
+	world.mu.Lock()
+	commands := append([]*exec.Cmd(nil), world.commands...)
+	world.mu.Unlock()
+	var launched string
+	for _, command := range commands {
+		joined := strings.Join(command.Args, " ")
+		if strings.Contains(joined, "new-session") && strings.Contains(joined, "codex") {
+			launched = joined
+			break
+		}
+	}
+	require.Contains(t, launched, oldHome, "launch must consume the command frozen before config changed")
+	require.NotContains(t, launched, newHome, "launch must not resolve configuration again after capture")
+}
+
+type observingCreatePtyFactory struct {
+	base        *inPlaceTmuxWorld
+	beforeStart func(*exec.Cmd)
+}
+
+func (f *observingCreatePtyFactory) Start(command *exec.Cmd) (*os.File, error) {
+	if f.beforeStart != nil {
+		f.beforeStart(command)
+	}
+	return f.base.Start(command)
+}
+
+func (f *observingCreatePtyFactory) Close() { f.base.Close() }
+
+func TestPreparedCreateLaunchSnapshotsBeforeAgentProcessStart(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoRoot := initInPlaceRepo(t, "ordered-create")
+	codexHome := filepath.Join(repoRoot, "ordered-store")
+	const rollout = "rollout-2026-07-06T10-17-35-019f386f-7206-7fc2-803b-f7045e07a242.jsonl"
+
+	cfg := config.DefaultConfig()
+	cfg.ProgramOverrides = map[string]string{tmux.ProgramCodex: "CODEX_HOME=" + codexHome + " codex"}
+	require.NoError(t, config.SaveConfig(cfg))
+	inst, err := NewInstance(InstanceOptions{
+		Title: "ordered-create", Path: repoRoot, Program: tmux.ProgramCodex, InPlace: true,
+	})
+	require.NoError(t, err)
+
+	world := newInPlaceTmuxWorld(t)
+	pty := &observingCreatePtyFactory{base: world}
+	pty.beforeStart = func(command *exec.Cmd) {
+		joined := strings.Join(command.Args, " ")
+		if strings.Contains(joined, "new-session") && strings.Contains(joined, "codex") {
+			writeCodexRolloutFile(t, codexHome, rollout)
+		}
+	}
+	inst.SetTmuxSession(tmux.NewTmuxSessionWithDeps("ordered-create", tmux.ProgramCodex, pty, world.exec()))
+
+	plan, err := inst.PrepareCreateLaunch()
+	require.NoError(t, err)
+	require.Empty(t, newCodexRolloutFiles(plan.ConversationCapture()),
+		"the rollout should not exist when the before-image is taken")
+	require.NoError(t, inst.LaunchPreparedCreate(plan))
+	t.Cleanup(func() { _ = inst.CloseAttachOnly() })
+
+	conv, err := CaptureAgentConversation(tmux.ProgramCodex, plan.ConversationCapture(), time.Second)
+	require.NoError(t, err)
+	require.Equal(t, "019f386f-7206-7fc2-803b-f7045e07a242", conv.ID,
+		"a rollout created at process start must be newer than the frozen before-image")
+}
+
+func TestPrepareCreateLaunchDoesNotGuessCodexStoreForOpaqueOverride(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	t.Setenv("CODEX_HOME", filepath.Join(t.TempDir(), "daemon-store"))
+	repoRoot := initInPlaceRepo(t, "opaque-create")
+
+	cfg := config.DefaultConfig()
+	cfg.ProgramOverrides = map[string]string{
+		tmux.ProgramCodex: filepath.Join(t.TempDir(), "opaque-agent-wrapper"),
+	}
+	require.NoError(t, config.SaveConfig(cfg))
+	inst, err := NewInstance(InstanceOptions{
+		Title: "opaque-create", Path: repoRoot, Program: tmux.ProgramCodex, InPlace: true,
+	})
+	require.NoError(t, err)
+
+	plan, err := inst.PrepareCreateLaunch()
+	require.NoError(t, err)
+	require.Empty(t, plan.conversationCapture.codexHome,
+		"a config label is not evidence that an opaque wrapper writes Codex rollouts")
+}

--- a/session/create_launch.go
+++ b/session/create_launch.go
@@ -1,0 +1,75 @@
+package session
+
+import "fmt"
+
+// CreateLaunchPlan freezes the provider-local facts that must be decided after
+// provisioning fixes the final workspace path but before the agent process is
+// spawned. Its fields are private so a caller cannot retarget a capture or swap
+// the checked command between the two halves.
+type CreateLaunchPlan struct {
+	instance            *Instance
+	launcher            Backend
+	prepared            bool
+	program             string
+	workDir             string
+	conversation        AgentConversationData
+	conversationCapture ConversationCaptureSnapshot
+}
+
+// ConversationCapture returns the provider-store before-image frozen before
+// process launch. The daemon passes it unchanged to generation-scoped capture.
+func (p CreateLaunchPlan) ConversationCapture() ConversationCaptureSnapshot {
+	return p.conversationCapture
+}
+
+// preparedCreateBackend is the optional exact-launch boundary implemented by
+// the real local backend. Test and off-box backends retain their established
+// Start behavior; an off-box process has no daemon-local transcript store to
+// capture.
+type preparedCreateBackend interface {
+	prepareCreateLaunch(instance *Instance) (CreateLaunchPlan, error)
+	launchPreparedCreate(instance *Instance, plan CreateLaunchPlan) error
+}
+
+// PrepareCreateLaunch snapshots the create's launch context without spawning
+// its agent. A backend with an exact prepared boundary is provisioned first so
+// relative paths resolve against the final workspace path. Other local test
+// backends preserve the legacy daemon-environment snapshot and Start path.
+func (i *Instance) PrepareCreateLaunch() (CreateLaunchPlan, error) {
+	backend := i.currentBackend()
+	plan := CreateLaunchPlan{instance: i, launcher: backend}
+	prepared, ok := backend.(preparedCreateBackend)
+	if !ok {
+		if backend.Capabilities().Workspace == WorkspaceLocalWorktree {
+			plan.conversationCapture = BeginConversationCapture()
+		}
+		return plan, nil
+	}
+	if err := backend.Provision(i, true); err != nil {
+		return CreateLaunchPlan{}, err
+	}
+	plan, err := prepared.prepareCreateLaunch(i)
+	if err != nil {
+		return CreateLaunchPlan{}, err
+	}
+	plan.instance = i
+	plan.launcher = backend
+	plan.prepared = true
+	return plan, nil
+}
+
+// LaunchPreparedCreate consumes exactly the plan returned above. The instance
+// pointer fence prevents a valid plan from being replayed against another row.
+func (i *Instance) LaunchPreparedCreate(plan CreateLaunchPlan) error {
+	if plan.instance != i || plan.launcher == nil {
+		return fmt.Errorf("create launch plan does not belong to this instance")
+	}
+	if !plan.prepared {
+		return plan.launcher.Start(i, true)
+	}
+	prepared, ok := plan.launcher.(preparedCreateBackend)
+	if !ok {
+		return fmt.Errorf("create launch backend no longer supports its prepared plan")
+	}
+	return prepared.launchPreparedCreate(i, plan)
+}

--- a/session/inplace_test.go
+++ b/session/inplace_test.go
@@ -24,8 +24,9 @@ import (
 // lets LocalBackend.Start(true) — agent session AND the default shell tab —
 // run end-to-end with no real tmux server.
 type inPlaceTmuxWorld struct {
-	t  *testing.T
-	mu sync.Mutex
+	t        *testing.T
+	mu       sync.Mutex
+	commands []*exec.Cmd
 	// created holds sanitized session names spawned via new-session.
 	created map[string]bool
 }
@@ -45,6 +46,9 @@ func argAfter(args []string, flag string) string {
 }
 
 func (w *inPlaceTmuxWorld) Start(c *exec.Cmd) (*os.File, error) {
+	w.mu.Lock()
+	w.commands = append(w.commands, c)
+	w.mu.Unlock()
 	if name := argAfter(c.Args, "-s"); name != "" {
 		w.mu.Lock()
 		w.created[name] = true

--- a/task/start.go
+++ b/task/start.go
@@ -116,13 +116,31 @@ func (t instanceTrustTarget) CheckAndHandleTrustPrompt() bool {
 // pane-poll instead of spinning to the timeout (see WaitForReady). A nil ctx is
 // treated as context.Background().
 func StartAndSendPrompt(ctx context.Context, instance *session.Instance, prompt string) error {
+	_, err := StartAndSendPromptWithConversationCapture(ctx, instance, prompt)
+	return err
+}
+
+// StartAndSendPromptWithConversationCapture is the daemon create path. It
+// separates provisioning from launch so a local backend can snapshot the exact
+// command-specific provider store after the final cwd exists in the model but
+// before the agent process can create a transcript there.
+func StartAndSendPromptWithConversationCapture(
+	ctx context.Context,
+	instance *session.Instance,
+	prompt string,
+) (session.ConversationCaptureSnapshot, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if err := instance.Start(true); err != nil {
-		return err
+	plan, err := instance.PrepareCreateLaunch()
+	if err != nil {
+		return session.ConversationCaptureSnapshot{}, err
 	}
-	return WaitForReadyAndSendPrompt(ctx, instance, prompt)
+	capture := plan.ConversationCapture()
+	if err := instance.LaunchPreparedCreate(plan); err != nil {
+		return capture, err
+	}
+	return capture, WaitForReadyAndSendPrompt(ctx, instance, prompt)
 }
 
 // WaitForReadyAndSendPrompt is the post-launch half of StartAndSendPrompt. A


### PR DESCRIPTION
Closes #2290.

## Summary

- Add a prepared create-launch boundary for local sessions: provision fixes the final workspace, then one plan freezes the injected command, effective cwd, provider conversation identity, and transcript before-image before any agent process starts.
- Resolve Codex storage through the shared closed-set command/environment parser, including relative `CODEX_HOME`, `env -C`, and compact `env -uCODEX_HOME` forms.
- Fail closed with an actionable error when a configured Codex command uses dynamic or unsupported environment syntax; do not silently poll the daemon’s ambient store.
- Treat opaque wrappers honestly: a Codex configuration label is not evidence that an unknown executable writes Codex rollouts.
- Pass the frozen before-image through the existing generation-scoped asynchronous capture path after the create is persisted.

## Regression coverage

The fail-first cases pin:

- absolute and cwd-relative command-local `CODEX_HOME`;
- `env -C` changing the base for a relative home;
- compact unset falling back to command-local `HOME`;
- dynamic expansion and `env -S` failing closed;
- linked-worktree cwd rather than source-repo cwd;
- config changes between prepare and launch cannot retarget the command;
- a rollout created at process start is newer than the before-image;
- opaque wrappers never fall back to the daemon’s ambient Codex store.

The first isolated-suite run also exposed that provider-less containers can return a nil default override map; the fixtures now initialize their override map explicitly, and the focused container reproduction plus the complete suite pass.

## Gates

All required local gates passed on exact pushed head `d6231701aa2c8ef007b25839c90a49d16debbd35`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`

— Captain Claude
