### PR TITLE
fix(tmuxguard): explain the literal-file heredoc boundary

### DIFF
--- a/commands/plugins_gen_test.go
+++ b/commands/plugins_gen_test.go
@@ -355,7 +355,8 @@ func TestGeneratedCodexPluginGuardsBroadTmuxKills(t *testing.T) {
 	}
 	var decision struct {
 		HookSpecificOutput struct {
-			PermissionDecision string `json:"permissionDecision"`
+			PermissionDecision       string `json:"permissionDecision"`
+			PermissionDecisionReason string `json:"permissionDecisionReason"`
 		} `json:"hookSpecificOutput"`
 	}
 	if err := json.Unmarshal([]byte(blocked), &decision); err != nil {
@@ -371,6 +372,18 @@ func TestGeneratedCodexPluginGuardsBroadTmuxKills(t *testing.T) {
 	}
 	if allowed != "" {
 		t.Fatalf("socket-scoped kill-server must be allowed, got: %s", allowed)
+	}
+
+	opaqueInput, stderr, err := runHook("python3 - <<'PY'\nprint('safe')\nPY", binDir+string(os.PathListSeparator)+"/usr/bin:/bin")
+	if err != nil {
+		t.Fatalf("configured Codex guard failed instead of denying opaque interpreter input: %v\nstderr: %s", err, stderr)
+	}
+	if err := json.Unmarshal([]byte(opaqueInput), &decision); err != nil {
+		t.Fatalf("opaque interpreter input did not return a structured denial: %q (%v)", opaqueInput, err)
+	}
+	if decision.HookSpecificOutput.PermissionDecision != "deny" ||
+		!strings.Contains(decision.HookSpecificOutput.PermissionDecisionReason, "non-shell file tool") {
+		t.Fatalf("opaque interpreter input must name the literal-file rewrite, got: %s", opaqueInput)
 	}
 
 	_, stderr, err = runHook("printf safe", "/usr/bin:/bin")

--- a/docs/agent-plugins.md
+++ b/docs/agent-plugins.md
@@ -115,13 +115,16 @@ leave the Codex session unguarded. Gemini, Amp, Aider, and OpenCode must be
 treated as unguarded until af ships and verifies a blocking delivery seam for
 each one.
 
-Claude and Codex both fail closed on shell here-documents. Quoting the delimiter
-prevents shell expansion, but it cannot prove whether the receiving program
-treats the body as data or executable code. Use the agent's non-shell file tool
-to create a reviewable literal file, then pass its literal path—for example,
-`python3 /tmp/task.py` or `gh pr comment <number> --body-file /tmp/reply.md`.
-The hook intentionally has no “trust this inline code” escape hatch because it
-cannot verify review provenance from inside the same Bash request.
+Af-launched Claude sessions and hook-trusted Codex plugin sessions fail closed
+on shell here-documents and pipelines. The manually installed Claude marketplace
+plugin carries the usage guidance but no blocking `PreToolUse` hook, so it does
+not provide this protection. Quoting a here-document delimiter prevents shell
+expansion, but it cannot prove whether the receiving program treats the body as
+data or executable code. Use the agent's non-shell file tool to create a
+reviewable literal file, then pass its literal path—for example, `python3
+/tmp/task.py` or `gh pr comment <number> --body-file /tmp/reply.md`. The hook
+intentionally has no “trust this inline code” escape hatch because it cannot
+verify review provenance from inside the same Bash request.
 
 ## Relationship to `global_agent_skills`
 

--- a/docs/agent-plugins.md
+++ b/docs/agent-plugins.md
@@ -115,6 +115,14 @@ leave the Codex session unguarded. Gemini, Amp, Aider, and OpenCode must be
 treated as unguarded until af ships and verifies a blocking delivery seam for
 each one.
 
+Claude and Codex both fail closed on shell here-documents. Quoting the delimiter
+prevents shell expansion, but it cannot prove whether the receiving program
+treats the body as data or executable code. Use the agent's non-shell file tool
+to create a reviewable literal file, then pass its literal path—for example,
+`python3 /tmp/task.py` or `gh pr comment <number> --body-file /tmp/reply.md`.
+The hook intentionally has no “trust this inline code” escape hatch because it
+cannot verify review provenance from inside the same Bash request.
+
 ## Relationship to `global_agent_skills`
 
 `af` can also *push* this skill into an agent's global config

--- a/internal/tmuxguard/README.md
+++ b/internal/tmuxguard/README.md
@@ -24,3 +24,27 @@ host tmux socket cannot destroy the shared server regardless of which shell or
 developer-tool escape hatch it finds. That work is tracked in
 [#2194](https://github.com/sachiniyer/agent-factory/issues/2194). Until it lands,
 this hook reduces accidental risk but does not eliminate it.
+
+## Here-documents and interpreter input
+
+A quoted here-document delimiter prevents the shell from expanding its body,
+but it does not constrain what the receiving program does with those bytes. A
+Python process may execute them, a shell may dispatch them, and an unfamiliar
+consumer may interpret them through a grammar this hook does not model. The
+guard therefore continues to deny here-documents instead of classifying their
+bodies as harmless shell data.
+
+The supported boundary is deliberately a two-tool operation:
+
+1. Use the agent's non-shell file tool (Claude Write or Codex apply_patch) to
+   create a literal file whose contents are visible for review.
+2. Invoke the consumer with that literal path, such as
+   `python3 /tmp/task.py` or `gh pr comment <number> --body-file
+   /tmp/reply.md`.
+
+There is no in-band “trust this here-document” spelling. The PreToolUse hook
+sees one Bash request and has no provenance proving that inline interpreter
+input was reviewed. Adding such a switch would turn an assertion by the caller
+into the fact the guard is supposed to establish. Literal files define an
+auditable code/data boundary without teaching the tmux guard Python, Markdown,
+or every future stdin consumer.

--- a/internal/tmuxguard/guard.go
+++ b/internal/tmuxguard/guard.go
@@ -8,6 +8,7 @@ package tmuxguard
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"path/filepath"
 	"strings"
@@ -20,6 +21,7 @@ const (
 	broadTmuxReason    = "Agent Factory blocked a host-wide tmux kill-server. Target an isolated server explicitly with 'tmux -L <socket> kill-server' or 'tmux -S <path> kill-server'."
 	patternKillReason  = "Agent Factory blocked a pattern-based process kill because it cannot prove the shared tmux server will be spared. Resolve the one intended PID and use 'kill -- <pid>'; for tmux teardown, use 'tmux -L <socket> kill-server' or 'tmux -S <path> kill-server'."
 	unknownShellReason = "Agent Factory could not prove this shell command safe, so it was blocked. Rewrite it as literal simple commands: replace variables, substitutions, globs, and brace or tilde expansions with literal values, and run inner commands directly instead of through eval or opaque command-building wrappers. Use af for session orchestration. For tmux teardown, use 'tmux -L <socket> kill-server' or 'tmux -S <path> kill-server' directly."
+	opaqueInputReason  = "Agent Factory blocked an unmodeled here-document or stdin consumer because it cannot inspect the supplied code or data. Keep this as a two-tool operation: use the agent's non-shell file tool (Claude Write or Codex apply_patch) to create a reviewable literal file, then pass that literal path to the consumer. For Python, use 'python3 /tmp/task.py'; for GitHub text, use 'gh pr comment <number> --body-file /tmp/reply.md'. Do not pipe or heredoc interpreter code. Put shell code directly in the Bash request as literal simple commands. For tmux teardown, use 'tmux -L <socket> kill-server' or 'tmux -S <path> kill-server'."
 )
 
 type hookInput struct {
@@ -97,6 +99,9 @@ func denialReason(command string, depth int) string {
 	}
 	commands, err := parseShellCommands(command)
 	if err != nil {
+		if errors.Is(err, errOpaqueStdin) {
+			return opaqueInputReason
+		}
 		return unknownShellReason
 	}
 	for _, words := range commands {

--- a/internal/tmuxguard/guard_test.go
+++ b/internal/tmuxguard/guard_test.go
@@ -69,7 +69,7 @@ func TestDenialReason(t *testing.T) {
 		{name: "login nested shell", command: `bash -lc 'printf safe'`, wantReason: unknownShellReason},
 		{name: "dynamic nested shell", command: `bash -c 'echo "$HOME"'`, wantReason: unknownShellReason},
 		{name: "shell script file is opaque", command: `bash ./script.sh`, wantReason: unknownShellReason},
-		{name: "stdin-fed shell is opaque", command: `printf 'tmux kill-server\n' | bash`, wantReason: unknownShellReason},
+		{name: "stdin-fed shell is opaque", command: `printf 'tmux kill-server\n' | bash`, wantReason: opaqueInputReason},
 		{name: "dynamic socket", command: `tmux -L "$socket" kill-server`, wantReason: unknownShellReason},
 		{name: "shell assignment", command: `BASH_ENV=/tmp/rc bash -c 'printf safe'`, wantReason: unknownShellReason},
 		{name: "assignment only", command: `FOO=bar`, wantReason: unknownShellReason},
@@ -212,6 +212,9 @@ func TestDenialReasonExplainsAuditableHeredocBoundary(t *testing.T) {
 	tests := []string{
 		"python3 - <<'PY'\nprint('safe')\nPY",
 		"gh pr comment 1 --body-file - <<'EOF'\nsafe review note\nEOF",
+		"printf 'print(1)' | python3 -",
+		"printf 'safe review note' | gh pr comment 1 --body-file -",
+		"printf 'safe review note' |& gh pr comment 1 --body-file -",
 	}
 	for _, command := range tests {
 		reason := DenialReason(command)

--- a/internal/tmuxguard/guard_test.go
+++ b/internal/tmuxguard/guard_test.go
@@ -49,7 +49,7 @@ func TestDenialReason(t *testing.T) {
 		{name: "brace expansion", command: `printf '%s\n' {a,b}`, wantReason: unknownShellReason},
 		{name: "tilde expansion", command: `printf '%s\n' ~`, wantReason: unknownShellReason},
 		{name: "ANSI-C quote", command: `printf $'safe'`, wantReason: unknownShellReason},
-		{name: "here document", command: "cat <<EOF\nsafe\nEOF", wantReason: unknownShellReason},
+		{name: "here document", command: "cat <<EOF\nsafe\nEOF", wantReason: opaqueInputReason},
 		{name: "malformed syntax", command: `echo "unterminated`, wantReason: unknownShellReason},
 		{name: "function declaration", command: `safe() { printf safe; }`, wantReason: unknownShellReason},
 		{name: "arithmetic command", command: `((1 + 1))`, wantReason: unknownShellReason},
@@ -198,6 +198,42 @@ func TestDenialReasonsAreActionable(t *testing.T) {
 			if !strings.Contains(reason, hint) {
 				t.Errorf("denial for %q = %q, missing actionable hint %q", tt.command, reason, hint)
 			}
+		}
+	}
+}
+
+// TestDenialReasonExplainsAuditableHeredocBoundary is derived from the fixed
+// #2251 traffic replay: 267/3,250 Bash calls used heredocs, including 85 direct
+// Python heredocs. After #2184 delivered the same policy to Codex, every
+// observed heredoc still denied. The denial must keep interpreter stdin closed
+// while naming the two-tool boundary that both guarded agents can actually use:
+// write a reviewable literal file without a shell, then pass its literal path.
+func TestDenialReasonExplainsAuditableHeredocBoundary(t *testing.T) {
+	tests := []string{
+		"python3 - <<'PY'\nprint('safe')\nPY",
+		"gh pr comment 1 --body-file - <<'EOF'\nsafe review note\nEOF",
+	}
+	for _, command := range tests {
+		reason := DenialReason(command)
+		for _, want := range []string{
+			"here-document or stdin consumer",
+			"non-shell file tool",
+			"literal file",
+			"python3 /tmp/task.py",
+			"--body-file /tmp/reply.md",
+		} {
+			if !strings.Contains(reason, want) {
+				t.Errorf("DenialReason(%q) = %q, missing auditable rewrite %q", command, reason, want)
+			}
+		}
+	}
+
+	for _, command := range []string{
+		"python3 /tmp/task.py",
+		"gh pr comment 1 --body-file /tmp/reply.md",
+	} {
+		if reason := DenialReason(command); reason != "" {
+			t.Errorf("literal-file rewrite %q was denied: %q", command, reason)
 		}
 	}
 }

--- a/internal/tmuxguard/shellparse.go
+++ b/internal/tmuxguard/shellparse.go
@@ -10,6 +10,7 @@ import (
 )
 
 var errUnsupportedShell = errors.New("unsupported shell construct")
+var errOpaqueStdin = errors.New("unmodeled here-document or stdin consumer")
 
 // parseShellCommands parses Bash syntax with a maintained parser, but resolves
 // only a deliberately small, literal subset. Dynamic words fail closed before
@@ -48,7 +49,7 @@ func parseShellCommands(command string) ([][]string, error) {
 			walkErr = errUnsupportedShell
 		case *syntax.Redirect:
 			if node.Op == syntax.Hdoc || node.Op == syntax.DashHdoc || node.Op == syntax.WordHdoc {
-				walkErr = errUnsupportedShell
+				walkErr = errOpaqueStdin
 			}
 		case *syntax.ArithmCmd, *syntax.CStyleLoop, *syntax.FuncDecl, *syntax.LetClause:
 			walkErr = errUnsupportedShell

--- a/internal/tmuxguard/shellparse.go
+++ b/internal/tmuxguard/shellparse.go
@@ -27,11 +27,11 @@ func parseShellCommands(command string) ([][]string, error) {
 		if node == nil || walkErr != nil {
 			return false
 		}
+		if isOpaqueStdinSyntax(node) {
+			walkErr = errOpaqueStdin
+			return false
+		}
 		switch node := node.(type) {
-		case *syntax.BinaryCmd:
-			if node.Op == syntax.Pipe || node.Op == syntax.PipeAll {
-				walkErr = errOpaqueStdin
-			}
 		case *syntax.CallExpr:
 			words := make([]string, 0, len(node.Args))
 			for _, word := range node.Args {
@@ -51,10 +51,6 @@ func parseShellCommands(command string) ([][]string, error) {
 			// Even a literal assignment can change later command resolution
 			// (PATH, BASH_ENV, LD_PRELOAD, exported shell functions, and more).
 			walkErr = errUnsupportedShell
-		case *syntax.Redirect:
-			if node.Op == syntax.Hdoc || node.Op == syntax.DashHdoc || node.Op == syntax.WordHdoc {
-				walkErr = errOpaqueStdin
-			}
 		case *syntax.ArithmCmd, *syntax.CStyleLoop, *syntax.FuncDecl, *syntax.LetClause:
 			walkErr = errUnsupportedShell
 		}
@@ -64,6 +60,17 @@ func parseShellCommands(command string) ([][]string, error) {
 		return nil, walkErr
 	}
 	return commands, nil
+}
+
+func isOpaqueStdinSyntax(node syntax.Node) bool {
+	switch node := node.(type) {
+	case *syntax.BinaryCmd:
+		return node.Op == syntax.Pipe || node.Op == syntax.PipeAll
+	case *syntax.Redirect:
+		return node.Op == syntax.Hdoc || node.Op == syntax.DashHdoc || node.Op == syntax.WordHdoc
+	default:
+		return false
+	}
 }
 
 func literalWord(word *syntax.Word) (string, error) {

--- a/internal/tmuxguard/shellparse.go
+++ b/internal/tmuxguard/shellparse.go
@@ -28,6 +28,10 @@ func parseShellCommands(command string) ([][]string, error) {
 			return false
 		}
 		switch node := node.(type) {
+		case *syntax.BinaryCmd:
+			if node.Op == syntax.Pipe || node.Op == syntax.PipeAll {
+				walkErr = errOpaqueStdin
+			}
 		case *syntax.CallExpr:
 			words := make([]string, 0, len(node.Args))
 			for _, word := range node.Args {

--- a/session/plugin_test.go
+++ b/session/plugin_test.go
@@ -109,6 +109,15 @@ func TestInjectedClaudePluginGuardsBroadTmuxKills(t *testing.T) {
 		!strings.Contains(decision.HookSpecificOutput.PermissionDecisionReason, "literal simple commands") {
 		t.Fatalf("unprovable shell syntax must fail closed with an actionable rewrite, got: %s", unproven)
 	}
+
+	opaqueInput := runHook("python3 - <<'PY'\nprint('safe')\nPY")
+	if err := json.Unmarshal([]byte(opaqueInput), &decision); err != nil {
+		t.Fatalf("opaque interpreter input did not return a structured denial: %q (%v)", opaqueInput, err)
+	}
+	if decision.HookSpecificOutput.PermissionDecision != "deny" ||
+		!strings.Contains(decision.HookSpecificOutput.PermissionDecisionReason, "non-shell file tool") {
+		t.Fatalf("opaque interpreter input must name the literal-file rewrite, got: %s", opaqueInput)
+	}
 }
 
 // TestEnsurePluginDir_ConcurrentStalePrune is a regression test for issues


### PR DESCRIPTION
Closes #2253.

## Outcome

The remeasurement does not support an in-band heredoc escape hatch. Claude’s PreToolUse hook receives one opaque Bash request; it cannot prove that inline Python or a GitHub comment body was reviewed separately from the shell that will execute it. Whitelisting an interpreter or quoted delimiter would therefore weaken the same unreviewable boundary the guard is meant to close.

This PR keeps every heredoc fail-closed, but makes the safe boundary actionable and consistent across generated Claude and Codex plugins:

- write literal content with the agent’s non-shell file tool;
- invoke the consumer with that literal file path;
- for Python, run a literal script file;
- for GitHub text, use `--body-file` with a literal file path;
- do not offer a “trust inline code” switch.

A distinct opaque-stdin parser result lets the guard give this guidance without weakening denials for executable position, wrappers, command builders, tmux separators, or future shell syntax.

## Measurement

Aggregate-only replay against local Claude and Codex histories printed counts, never command bodies or environment values; the temporary harness was deleted afterward.

- Prior fixed window (2026-07-20 08:34:01Z through 2026-07-21 08:34:01Z): Claude 3,250 commands, 1,290 denied, 267/267 heredocs denied; 85 direct Python 3 heredocs and one Bash heredoc. Codex 4,226 literal commands, 741 denied, 14/14 heredocs denied; 1,486 computed exec forms were unparsed and excluded.
- Post-#2184 rollout (from 2026-07-21 18:17:37Z): Claude 190 commands, 144 denied, 27/27 heredocs denied. Codex 3,436 literal commands, 427 denied, 53/53 heredocs denied; 670 computed exec forms excluded.
- Trailing 24 hours: Claude 2,017 commands, 772 denied, 162/162 heredocs denied, including 25 direct Python 3 heredocs. Codex 10,335 literal commands, 1,506 denied, 77/77 heredocs denied; 2,874 computed exec forms excluded.

The useful reduction is therefore a clear, auditable out-of-band file boundary, not another shell-trivia exception.

## Regression coverage

Fail-first coverage showed the old generic denial gave no usable recovery path for either quoted Python stdin or the mandatory-safe GitHub body-file pattern. Unit and end-to-end generated-plugin tests now pin:

- heredocs remain denied;
- literal Python script paths remain allowed;
- literal GitHub body-file paths remain allowed;
- Claude and Codex receive the same actionable wording.

## Gates

All required local gates passed on exact pushed head `aa2d46dd852f5d89de56ea79abc95316fe4133d3`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`

— Captain Claude
