### PR TITLE
fix(web): refit terminals on pane activation

### DIFF
--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -8271,6 +8271,14 @@ function viewportAnchorLine(anchor, baseY) {
 function shouldRestoreViewport(intent) {
   return intent.scheduledUserScroll === intent.currentUserScroll;
 }
+function terminalUserScrollPlan(source, hasScheduledVisibleFit) {
+  switch (source) {
+    case "wheel":
+    case "touch":
+    case "scrollbar":
+      return { cancelScheduledVisibleFit: hasScheduledVisibleFit };
+  }
+}
 
 // src/theme.ts
 var THEME_CHOICES = ["auto", "light", "dark"];
@@ -8456,6 +8464,8 @@ var AttachTerminal = class {
     document.addEventListener("visibilitychange", this.onVisibilityChange);
     container.addEventListener("pointerenter", this.onPointerEnter);
     container.addEventListener("wheel", this.onWheel, { capture: true, passive: true });
+    container.addEventListener("touchmove", this.onTouchMove, { capture: true, passive: true });
+    container.addEventListener("pointerdown", this.onPointerDown, true);
     this.scheduleVisibleFit();
   }
   term;
@@ -8472,9 +8482,9 @@ var AttachTerminal = class {
   resizeTimer = null;
   visibleFitFrame = null;
   viewportRestoreFrame = null;
-  // Incremented only by an actual wheel while a peer-owned anchor is pending.
-  // Output and resize reflows can move viewportY too, so position deltas alone do
-  // not prove that a user intended to override the saved reading line.
+  // Incremented only by an actual user scroll input while a peer-owned anchor is
+  // pending. Output and resize reflows can move viewportY too, so position deltas
+  // alone do not prove that a user intended to override the saved reading line.
   userScrollRevision = 0;
   // The absolute replay cursor: seeded from OpHello, advanced by OpPTYOut byte
   // counts (never by OpRepaint). `seeded` gates whether a reconnect can pass a
@@ -8505,16 +8515,28 @@ var AttachTerminal = class {
   // clients: reconcile before the wheel gesture arrives so xterm can consume that
   // first gesture rather than making the user scroll twice.
   onPointerEnter = () => this.fitVisibleHost();
-  // Wheel can target an already-focused window after another client resized the PTY
-  // without the pointer ever leaving this pane. Capture repairs that less-common
+  // A scroll can target an already-focused window after another client resized the
+  // PTY without the pointer ever leaving this pane. Capture repairs that less-common
   // path; pointer entry above handles the ordinary first gesture. The pending-peer
-  // gate makes every ordinary wheel a no-op before even measuring layout.
-  onWheel = () => {
-    if (this.pendingViewport !== null) {
-      this.fitVisibleHost();
-      this.userScrollRevision += 1;
+  // gate makes every ordinary input a no-op before even measuring layout.
+  onWheel = () => this.handleUserScroll("wheel");
+  onTouchMove = () => this.handleUserScroll("touch");
+  onPointerDown = (event) => {
+    if (event.target === this.container.querySelector(".xterm-viewport")) {
+      this.handleUserScroll("scrollbar");
     }
   };
+  handleUserScroll(source) {
+    if (this.pendingViewport === null) {
+      return;
+    }
+    const plan = terminalUserScrollPlan(source, this.visibleFitFrame !== null);
+    if (plan.cancelScheduledVisibleFit) {
+      this.cancelVisibleFitFrame();
+    }
+    this.fitVisibleHost();
+    this.userScrollRevision += 1;
+  }
   /** Permanently closes the terminal: stops the reconnect loop, drops the socket,
    *  disconnects the observer, and disposes xterm (freeing its DOM/renderer). */
   dispose() {
@@ -8527,10 +8549,7 @@ var AttachTerminal = class {
       window.clearTimeout(this.resizeTimer);
       this.resizeTimer = null;
     }
-    if (this.visibleFitFrame !== null) {
-      window.cancelAnimationFrame(this.visibleFitFrame);
-      this.visibleFitFrame = null;
-    }
+    this.cancelVisibleFitFrame();
     this.clearPendingViewport();
     this.ro.disconnect();
     this.io.disconnect();
@@ -8538,6 +8557,8 @@ var AttachTerminal = class {
     document.removeEventListener("visibilitychange", this.onVisibilityChange);
     this.container.removeEventListener("pointerenter", this.onPointerEnter);
     this.container.removeEventListener("wheel", this.onWheel, true);
+    this.container.removeEventListener("touchmove", this.onTouchMove, true);
+    this.container.removeEventListener("pointerdown", this.onPointerDown, true);
     this.closeSocket();
     this.term.dispose();
   }
@@ -8699,6 +8720,16 @@ var AttachTerminal = class {
       this.visibleFitFrame = null;
       this.fitVisibleHost();
     });
+  }
+  /** Drops activation work queued before a direct user scroll. Leaving that frame
+   * alive lets it run after the input fit and rebase the restore onto the new user
+   * revision, which makes the first gesture appear inert. */
+  cancelVisibleFitFrame() {
+    if (this.visibleFitFrame === null) {
+      return;
+    }
+    window.cancelAnimationFrame(this.visibleFitFrame);
+    this.visibleFitFrame = null;
   }
   /** Reconciles xterm's grid with this host only when the host is measurable and the
    *  FitAddon proposes a real change. A peer-owned MsgResize remains authoritative

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -8250,14 +8250,20 @@ function decode(raw) {
 }
 
 // src/terminal-geometry.ts
+function hasVisibleTerminalGeometry(host, proposed) {
+  return host.width > 0 && host.height > 0 && !!proposed && proposed.rows > 0 && proposed.cols > 0;
+}
 function shouldRefitVisibleTerminal(host, current, proposed) {
-  if (host.width <= 0 || host.height <= 0 || !proposed || proposed.rows <= 0 || proposed.cols <= 0) {
+  if (!hasVisibleTerminalGeometry(host, proposed)) {
     return false;
   }
   return proposed.rows !== current.rows || proposed.cols !== current.cols;
 }
-function viewportLineFromBottom(baseY, distanceFromBottom) {
-  return Math.max(0, baseY - Math.max(0, distanceFromBottom));
+function viewportMarkerOffset(position) {
+  return position.viewportY - (position.baseY + position.cursorY);
+}
+function shouldRestoreViewport(scheduledViewportY, currentViewportY) {
+  return scheduledViewportY === currentViewportY;
 }
 
 // src/theme.ts
@@ -8445,7 +8451,6 @@ var AttachTerminal = class {
     container.addEventListener("pointerenter", this.onPointerEnter);
     container.addEventListener("wheel", this.onWheel, { capture: true, passive: true });
     this.scheduleVisibleFit();
-    this.connect();
   }
   term;
   fit;
@@ -8456,6 +8461,7 @@ var AttachTerminal = class {
   stopped = false;
   everOpened = false;
   retry = 0;
+  initialConnectStarted = false;
   reconnectTimer = null;
   resizeTimer = null;
   visibleFitFrame = null;
@@ -8470,10 +8476,10 @@ var AttachTerminal = class {
   lastRows = 0;
   lastCols = 0;
   // A peer resize can temporarily collapse this client's scrollback (for example,
-  // 60 lines fit in a peer's 111-row grid). Preserve the user's local reading
-  // position independently of that reflow so the next visible-host fit can restore
-  // it. Null means no peer-owned grid is pending reconciliation.
-  pendingViewportDistance = null;
+  // 60 lines fit in a peer's 111-row grid). Anchor the actual visible buffer line,
+  // not a one-time distance from the bottom: output can keep arriving while this
+  // client is inactive. Null means no peer-owned grid is pending reconciliation.
+  pendingViewport = null;
   exited = false;
   // A peer is allowed to resize the one shared PTY and every client obeys that
   // authoritative echo. When this window becomes active again, its visible host
@@ -8494,7 +8500,7 @@ var AttachTerminal = class {
   // path; pointer entry above handles the ordinary first gesture. The pending-peer
   // gate makes every ordinary wheel a no-op before even measuring layout.
   onWheel = () => {
-    if (this.pendingViewportDistance !== null) {
+    if (this.pendingViewport !== null) {
       this.fitVisibleHost();
     }
   };
@@ -8514,10 +8520,7 @@ var AttachTerminal = class {
       window.cancelAnimationFrame(this.visibleFitFrame);
       this.visibleFitFrame = null;
     }
-    if (this.viewportRestoreFrame !== null) {
-      window.cancelAnimationFrame(this.viewportRestoreFrame);
-      this.viewportRestoreFrame = null;
-    }
+    this.clearPendingViewport();
     this.ro.disconnect();
     this.io.disconnect();
     window.removeEventListener("focus", this.onWindowFocus);
@@ -8585,6 +8588,15 @@ var AttachTerminal = class {
       } catch {
       }
     };
+  }
+  /** Starts the first connection only after a real visible-host fit. Reconnects
+   * continue through connect() directly once this boundary has been crossed. */
+  connectAfterInitialFit() {
+    if (this.initialConnectStarted || this.stopped) {
+      return;
+    }
+    this.initialConnectStarted = true;
+    this.connect();
   }
   onMessage(data) {
     if (typeof data === "string") {
@@ -8691,45 +8703,62 @@ var AttachTerminal = class {
     } catch {
       return;
     }
-    if (!shouldRefitVisibleTerminal(
-      { width: this.container.clientWidth, height: this.container.clientHeight },
-      { rows: this.term.rows, cols: this.term.cols },
-      proposed
-    )) {
+    const host = { width: this.container.clientWidth, height: this.container.clientHeight };
+    if (!hasVisibleTerminalGeometry(host, proposed)) {
       return;
     }
-    try {
-      this.fit.fit();
-    } catch {
-      return;
+    const needsFit = shouldRefitVisibleTerminal(host, { rows: this.term.rows, cols: this.term.cols }, proposed);
+    if (needsFit) {
+      try {
+        this.fit.fit();
+      } catch {
+        return;
+      }
+      this.scheduleViewportRestore(this.term.rows, this.term.cols);
+      this.sendResize(this.term.rows, this.term.cols, false);
     }
-    this.scheduleViewportRestore(this.term.rows, this.term.cols);
-    this.sendResize(this.term.rows, this.term.cols, false);
+    this.connectAfterInitialFit();
   }
   /** Restores the pre-peer reading position after xterm has rendered its new grid.
    *  resize() schedules the buffer reflow: reading baseY synchronously after fit can
    *  still see the peer-collapsed zero. The next painted frame is the first settled
-   *  value. A newer peer grid cancels this frame and leaves the distance pending for
+   *  value. A newer peer grid cancels this frame and leaves the anchor pending for
    *  the next local activation. */
   scheduleViewportRestore(rows, cols) {
-    if (this.pendingViewportDistance === null) {
+    if (this.pendingViewport === null) {
       return;
     }
-    if (this.viewportRestoreFrame !== null) {
-      window.cancelAnimationFrame(this.viewportRestoreFrame);
-    }
+    this.cancelViewportRestoreFrame();
+    const scheduledViewportY = this.term.buffer.active.viewportY;
     this.viewportRestoreFrame = window.requestAnimationFrame(() => {
       this.viewportRestoreFrame = null;
       if (this.stopped || this.term.rows !== rows || this.term.cols !== cols) {
         return;
       }
-      const distance = this.pendingViewportDistance;
-      if (distance === null) {
+      const anchor = this.pendingViewport;
+      if (anchor === null) {
         return;
       }
-      this.pendingViewportDistance = null;
-      this.term.scrollToLine(viewportLineFromBottom(this.term.buffer.active.baseY, distance));
+      const buffer = this.term.buffer.active;
+      if (!shouldRestoreViewport(scheduledViewportY, buffer.viewportY)) {
+        this.clearPendingViewport();
+        return;
+      }
+      const target = anchor.atBottom ? buffer.baseY : anchor.marker?.line ?? anchor.line;
+      this.clearPendingViewport();
+      this.term.scrollToLine(Math.max(0, target));
     });
+  }
+  cancelViewportRestoreFrame() {
+    if (this.viewportRestoreFrame !== null) {
+      window.cancelAnimationFrame(this.viewportRestoreFrame);
+      this.viewportRestoreFrame = null;
+    }
+  }
+  clearPendingViewport() {
+    this.cancelViewportRestoreFrame();
+    this.pendingViewport?.marker?.dispose();
+    this.pendingViewport = null;
   }
   scheduleFit() {
     if (this.resizeTimer !== null) {
@@ -8763,14 +8792,19 @@ var AttachTerminal = class {
     this.lastRows = rows;
     this.lastCols = cols;
     if (rows !== this.term.rows || cols !== this.term.cols) {
-      if (this.pendingViewportDistance === null) {
+      if (this.pendingViewport === null) {
         const buffer = this.term.buffer.active;
-        this.pendingViewportDistance = Math.max(0, buffer.baseY - buffer.viewportY);
+        const atBottom = buffer.viewportY >= buffer.baseY;
+        let marker = null;
+        if (!atBottom) {
+          try {
+            marker = this.term.registerMarker(viewportMarkerOffset(buffer));
+          } catch {
+          }
+        }
+        this.pendingViewport = { marker, line: buffer.viewportY, atBottom };
       }
-      if (this.viewportRestoreFrame !== null) {
-        window.cancelAnimationFrame(this.viewportRestoreFrame);
-        this.viewportRestoreFrame = null;
-      }
+      this.cancelViewportRestoreFrame();
       try {
         this.term.resize(cols, rows);
       } catch {

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -8262,8 +8262,14 @@ function shouldRefitVisibleTerminal(host, current, proposed) {
 function viewportMarkerOffset(position) {
   return position.viewportY - (position.baseY + position.cursorY);
 }
-function shouldRestoreViewport(scheduledViewportY, currentViewportY) {
-  return scheduledViewportY === currentViewportY;
+function viewportAnchorLine(anchor, baseY) {
+  if (anchor.atBottom) {
+    return baseY;
+  }
+  return anchor.markerLine !== null && anchor.markerLine >= 0 ? anchor.markerLine : anchor.fallbackLine;
+}
+function shouldRestoreViewport(intent) {
+  return intent.scheduledUserScroll === intent.currentUserScroll;
 }
 
 // src/theme.ts
@@ -8466,6 +8472,10 @@ var AttachTerminal = class {
   resizeTimer = null;
   visibleFitFrame = null;
   viewportRestoreFrame = null;
+  // Incremented only by an actual wheel while a peer-owned anchor is pending.
+  // Output and resize reflows can move viewportY too, so position deltas alone do
+  // not prove that a user intended to override the saved reading line.
+  userScrollRevision = 0;
   // The absolute replay cursor: seeded from OpHello, advanced by OpPTYOut byte
   // counts (never by OpRepaint). `seeded` gates whether a reconnect can pass a
   // real ?since; the first connect omits it (live tail + a fresh-screen repaint).
@@ -8502,6 +8512,7 @@ var AttachTerminal = class {
   onWheel = () => {
     if (this.pendingViewport !== null) {
       this.fitVisibleHost();
+      this.userScrollRevision += 1;
     }
   };
   /** Permanently closes the terminal: stops the reconnect loop, drops the socket,
@@ -8714,9 +8725,9 @@ var AttachTerminal = class {
       } catch {
         return;
       }
-      this.scheduleViewportRestore(this.term.rows, this.term.cols);
       this.sendResize(this.term.rows, this.term.cols, false);
     }
+    this.scheduleViewportRestore(this.term.rows, this.term.cols);
     this.connectAfterInitialFit();
   }
   /** Restores the pre-peer reading position after xterm has rendered its new grid.
@@ -8729,7 +8740,7 @@ var AttachTerminal = class {
       return;
     }
     this.cancelViewportRestoreFrame();
-    const scheduledViewportY = this.term.buffer.active.viewportY;
+    const scheduledUserScroll = this.userScrollRevision;
     this.viewportRestoreFrame = window.requestAnimationFrame(() => {
       this.viewportRestoreFrame = null;
       if (this.stopped || this.term.rows !== rows || this.term.cols !== cols) {
@@ -8740,11 +8751,21 @@ var AttachTerminal = class {
         return;
       }
       const buffer = this.term.buffer.active;
-      if (!shouldRestoreViewport(scheduledViewportY, buffer.viewportY)) {
+      if (!shouldRestoreViewport({
+        scheduledUserScroll,
+        currentUserScroll: this.userScrollRevision
+      })) {
         this.clearPendingViewport();
         return;
       }
-      const target = anchor.atBottom ? buffer.baseY : anchor.marker?.line ?? anchor.line;
+      const target = viewportAnchorLine(
+        {
+          atBottom: anchor.atBottom,
+          markerLine: anchor.marker?.line ?? null,
+          fallbackLine: anchor.line
+        },
+        buffer.baseY
+      );
       this.clearPendingViewport();
       this.term.scrollToLine(Math.max(0, target));
     });

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -8249,6 +8249,17 @@ function decode(raw) {
   }
 }
 
+// src/terminal-geometry.ts
+function shouldRefitVisibleTerminal(host, current, proposed) {
+  if (host.width <= 0 || host.height <= 0 || !proposed || proposed.rows <= 0 || proposed.cols <= 0) {
+    return false;
+  }
+  return proposed.rows !== current.rows || proposed.cols !== current.cols;
+}
+function viewportLineFromBottom(baseY, distanceFromBottom) {
+  return Math.max(0, baseY - Math.max(0, distanceFromBottom));
+}
+
 // src/theme.ts
 var THEME_CHOICES = ["auto", "light", "dark"];
 var STORAGE_KEY = "af-theme";
@@ -8377,6 +8388,7 @@ function wsScheme2() {
 }
 var AttachTerminal = class {
   constructor(container, sessionId, token2, tabId, tab, cb) {
+    this.container = container;
     this.sessionId = sessionId;
     this.token = token2;
     this.tabId = tabId;
@@ -8397,7 +8409,6 @@ var AttachTerminal = class {
     this.fit = new import_addon_fit.FitAddon();
     this.term.loadAddon(this.fit);
     this.term.open(container);
-    this.fit.fit();
     const textarea = this.term.textarea;
     if (textarea) {
       textarea.addEventListener("focus", () => {
@@ -8423,18 +8434,32 @@ var AttachTerminal = class {
     );
     this.ro = new ResizeObserver(() => this.scheduleFit());
     this.ro.observe(container);
+    this.io = new IntersectionObserver((entries) => {
+      if (entries.some((entry) => entry.target === container && entry.isIntersecting)) {
+        this.scheduleVisibleFit();
+      }
+    });
+    this.io.observe(container);
+    window.addEventListener("focus", this.onWindowFocus);
+    document.addEventListener("visibilitychange", this.onVisibilityChange);
+    container.addEventListener("pointerenter", this.onPointerEnter);
+    container.addEventListener("wheel", this.onWheel, { capture: true, passive: true });
+    this.scheduleVisibleFit();
     this.connect();
   }
   term;
   fit;
   enc = new TextEncoder();
   ro;
+  io;
   ws = null;
   stopped = false;
   everOpened = false;
   retry = 0;
   reconnectTimer = null;
   resizeTimer = null;
+  visibleFitFrame = null;
+  viewportRestoreFrame = null;
   // The absolute replay cursor: seeded from OpHello, advanced by OpPTYOut byte
   // counts (never by OpRepaint). `seeded` gates whether a reconnect can pass a
   // real ?since; the first connect omits it (live tail + a fresh-screen repaint).
@@ -8444,7 +8469,35 @@ var AttachTerminal = class {
   // an authoritative echo that matches is a no-op.
   lastRows = 0;
   lastCols = 0;
+  // A peer resize can temporarily collapse this client's scrollback (for example,
+  // 60 lines fit in a peer's 111-row grid). Preserve the user's local reading
+  // position independently of that reflow so the next visible-host fit can restore
+  // it. Null means no peer-owned grid is pending reconciliation.
+  pendingViewportDistance = null;
   exited = false;
+  // A peer is allowed to resize the one shared PTY and every client obeys that
+  // authoritative echo. When this window becomes active again, its visible host
+  // becomes the local writer: refit once instead of leaving a peer-sized emulator in
+  // an unchanged container until the user physically resizes the window (#2347).
+  onWindowFocus = () => this.scheduleVisibleFit();
+  onVisibilityChange = () => {
+    if (document.visibilityState === "visible") {
+      this.scheduleVisibleFit();
+    }
+  };
+  // Entering a pane is the earliest reliable activation signal for side-by-side
+  // clients: reconcile before the wheel gesture arrives so xterm can consume that
+  // first gesture rather than making the user scroll twice.
+  onPointerEnter = () => this.fitVisibleHost();
+  // Wheel can target an already-focused window after another client resized the PTY
+  // without the pointer ever leaving this pane. Capture repairs that less-common
+  // path; pointer entry above handles the ordinary first gesture. The pending-peer
+  // gate makes every ordinary wheel a no-op before even measuring layout.
+  onWheel = () => {
+    if (this.pendingViewportDistance !== null) {
+      this.fitVisibleHost();
+    }
+  };
   /** Permanently closes the terminal: stops the reconnect loop, drops the socket,
    *  disconnects the observer, and disposes xterm (freeing its DOM/renderer). */
   dispose() {
@@ -8457,13 +8510,27 @@ var AttachTerminal = class {
       window.clearTimeout(this.resizeTimer);
       this.resizeTimer = null;
     }
+    if (this.visibleFitFrame !== null) {
+      window.cancelAnimationFrame(this.visibleFitFrame);
+      this.visibleFitFrame = null;
+    }
+    if (this.viewportRestoreFrame !== null) {
+      window.cancelAnimationFrame(this.viewportRestoreFrame);
+      this.viewportRestoreFrame = null;
+    }
     this.ro.disconnect();
+    this.io.disconnect();
+    window.removeEventListener("focus", this.onWindowFocus);
+    document.removeEventListener("visibilitychange", this.onVisibilityChange);
+    this.container.removeEventListener("pointerenter", this.onPointerEnter);
+    this.container.removeEventListener("wheel", this.onWheel, true);
     this.closeSocket();
     this.term.dispose();
   }
   /** Gives the terminal the keyboard (focuses xterm's helper textarea) so typed
    *  keys reach the agent — the attach half of the #1693 nav/attach model. */
   focus() {
+    this.fitVisibleHost();
     this.term.focus();
   }
   /** Takes the keyboard away from the terminal (blurs it) so document-level rail
@@ -8598,6 +8665,72 @@ var AttachTerminal = class {
     this.ws = null;
   }
   // --- resize ----------------------------------------------------------------
+  /** Fits on the next painted frame, after visibility/layout changes have settled.
+   *  Repeated activation signals coalesce into one frame; unlike the resize debounce,
+   *  this is not a time guess and never repeats on its own. */
+  scheduleVisibleFit() {
+    if (this.stopped || this.visibleFitFrame !== null) {
+      return;
+    }
+    this.visibleFitFrame = window.requestAnimationFrame(() => {
+      this.visibleFitFrame = null;
+      this.fitVisibleHost();
+    });
+  }
+  /** Reconciles xterm's grid with this host only when the host is measurable and the
+   *  FitAddon proposes a real change. A peer-owned MsgResize remains authoritative
+   *  while this client is inactive; activation/wheel makes this client the newest
+   *  writer once, without a resize-echo ping-pong between visible clients. */
+  fitVisibleHost() {
+    if (this.stopped) {
+      return;
+    }
+    let proposed;
+    try {
+      proposed = this.fit.proposeDimensions();
+    } catch {
+      return;
+    }
+    if (!shouldRefitVisibleTerminal(
+      { width: this.container.clientWidth, height: this.container.clientHeight },
+      { rows: this.term.rows, cols: this.term.cols },
+      proposed
+    )) {
+      return;
+    }
+    try {
+      this.fit.fit();
+    } catch {
+      return;
+    }
+    this.scheduleViewportRestore(this.term.rows, this.term.cols);
+    this.sendResize(this.term.rows, this.term.cols, false);
+  }
+  /** Restores the pre-peer reading position after xterm has rendered its new grid.
+   *  resize() schedules the buffer reflow: reading baseY synchronously after fit can
+   *  still see the peer-collapsed zero. The next painted frame is the first settled
+   *  value. A newer peer grid cancels this frame and leaves the distance pending for
+   *  the next local activation. */
+  scheduleViewportRestore(rows, cols) {
+    if (this.pendingViewportDistance === null) {
+      return;
+    }
+    if (this.viewportRestoreFrame !== null) {
+      window.cancelAnimationFrame(this.viewportRestoreFrame);
+    }
+    this.viewportRestoreFrame = window.requestAnimationFrame(() => {
+      this.viewportRestoreFrame = null;
+      if (this.stopped || this.term.rows !== rows || this.term.cols !== cols) {
+        return;
+      }
+      const distance = this.pendingViewportDistance;
+      if (distance === null) {
+        return;
+      }
+      this.pendingViewportDistance = null;
+      this.term.scrollToLine(viewportLineFromBottom(this.term.buffer.active.baseY, distance));
+    });
+  }
   scheduleFit() {
     if (this.resizeTimer !== null) {
       window.clearTimeout(this.resizeTimer);
@@ -8607,12 +8740,7 @@ var AttachTerminal = class {
       if (this.stopped) {
         return;
       }
-      try {
-        this.fit.fit();
-      } catch {
-        return;
-      }
-      this.sendResize(this.term.rows, this.term.cols, false);
+      this.fitVisibleHost();
     }, RESIZE_DEBOUNCE_MS);
   }
   /** Sends an OpResize for the given size unless it's unchanged. `force` re-sends
@@ -8635,6 +8763,14 @@ var AttachTerminal = class {
     this.lastRows = rows;
     this.lastCols = cols;
     if (rows !== this.term.rows || cols !== this.term.cols) {
+      if (this.pendingViewportDistance === null) {
+        const buffer = this.term.buffer.active;
+        this.pendingViewportDistance = Math.max(0, buffer.baseY - buffer.viewportY);
+      }
+      if (this.viewportRestoreFrame !== null) {
+        window.cancelAnimationFrame(this.viewportRestoreFrame);
+        this.viewportRestoreFrame = null;
+      }
       try {
         this.term.resize(cols, rows);
       } catch {

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "afb686417ebb";
+const VERSION = "1670578992fd";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "f2e4fc884343";
+const VERSION = "afb686417ebb";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -3945,6 +3945,47 @@ test("#2347: the mobile agent terminal also reclaims peer-owned geometry", REAL_
     await expect(row(second, sessionName)).toBeVisible({ timeout: 15_000 });
     await row(second, sessionName).click();
     await expect(second.locator(".af-term-meta")).toContainText("Live");
+    const secondHost = second.locator(".af-term-host");
+
+    // Touch and scrollbar input can begin while the browser still considers the
+    // peer window active (for example, a phone swipe delivered as the tab becomes
+    // foreground, or a scrollbar drag in a side-by-side window). Exercise the real
+    // xterm DOM listeners while the peer-owned grid is still stranded: neither path
+    // may wait for a later focus/resize signal to rebuild scrollback.
+    await expect
+      .poll(firstRows, { message: "the tall peer must strand the mobile client before direct-input checks" })
+      .toBeGreaterThan(lineCount);
+    await test.step("touch scroll input reclaims the peer grid", async () => {
+      await firstHost.locator(".af-pane-host").dispatchEvent("touchmove", {
+        bubbles: true,
+        cancelable: true,
+        touches: [{ identifier: 1, clientX: 180, clientY: 300 }],
+        changedTouches: [{ identifier: 1, clientX: 180, clientY: 300 }],
+      });
+      await expect
+        .poll(firstRows, { message: "touchmove must synchronously reclaim the measurable local grid" })
+        .toBeLessThan(lineCount);
+    });
+
+    const letTallPeerReclaim = async (label: string): Promise<void> => {
+      await second.mouse.move(0, 0);
+      await secondHost.locator(".af-pane-host").hover();
+      await expect.poll(firstRows, { message: label }).toBeGreaterThan(lineCount);
+    };
+    await letTallPeerReclaim("the tall peer must reclaim the grid after the touch check");
+    await test.step("scrollbar input reclaims the peer grid", async () => {
+      await firstHost.locator(".xterm-viewport").dispatchEvent("pointerdown", {
+        bubbles: true,
+        cancelable: true,
+        pointerType: "mouse",
+        button: 0,
+        buttons: 1,
+      });
+      await expect
+        .poll(firstRows, { message: "a pointer on xterm's scrollbar viewport must reclaim the local grid" })
+        .toBeLessThan(lineCount);
+    });
+    await letTallPeerReclaim("the tall peer must reclaim the grid before the immediate-wheel check");
 
     await assertActiveTerminalReclaimsPeerGeometry(
       first,

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -3665,6 +3665,8 @@ async function assertActiveTerminalReclaimsPeerGeometry(
   lastLine: string,
   lineCount: number,
   scenario: string,
+  expectedFirstRow?: string,
+  wheelImmediately = false,
 ): Promise<void> {
   const firstViewport = firstHost.locator(".xterm-viewport");
   const firstRows = (): Promise<number> => firstHost.locator(".xterm-rows > div").count();
@@ -3696,7 +3698,38 @@ async function assertActiveTerminalReclaimsPeerGeometry(
   // The tall peer is already the active page after construction. Re-focusing it
   // here would queue another local fit immediately before the first page's fit;
   // that synthetic race would correctly let the peer win last-writer-wins again.
+  if (wheelImmediately) {
+    // The peer's authoritative grid persists after disconnect. Close only this
+    // page so a delayed tall-host activation cannot win again while this branch
+    // isolates the first-wheel-vs-deferred-restore ordering.
+    await second.close();
+  }
   await first.bringToFront();
+  if (wheelImmediately) {
+    // Target the actual pane with a trusted pointer transition, then send the real
+    // wheel immediately—without polling for the deferred anchor frame in between.
+    await firstHost.locator(".af-pane-host").hover();
+    await first.mouse.wheel(0, -900);
+    await expect
+      .poll(firstRows, { message: `${scenario}: the first wheel must refit the peer-owned grid` })
+      .toBeLessThan(lineCount);
+    await first.evaluate(
+      () =>
+        new Promise<void>((resolve) => {
+          requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+        }),
+    );
+    const repaired = await terminalGeometry(firstHost);
+    expect(
+      repaired.scrollHeight,
+      `${scenario}: the first wheel must recreate scrollback; geometry=${JSON.stringify({ stranded, repaired })}`,
+    ).toBeGreaterThan(repaired.viewportHeight);
+    expect(
+      repaired.scrollTop,
+      `${scenario}: deferred restore must not erase the first wheel; geometry=${JSON.stringify({ stranded, repaired })}`,
+    ).toBeLessThan(repaired.scrollHeight - repaired.viewportHeight);
+    return;
+  }
   // Target the actual xterm mount, not its full split-layout wrapper. On narrow
   // layouts the wrapper also spans drawer/scrim stacking surfaces; the production
   // activation listener lives on .af-pane-host.
@@ -3714,8 +3747,15 @@ async function assertActiveTerminalReclaimsPeerGeometry(
       message: `${scenario}: activation must restore the pre-peer position; geometry=${JSON.stringify({ stranded, refit })}`,
     })
     .toBeGreaterThan(0);
+  if (expectedFirstRow !== undefined) {
+    await expect(firstHost.locator(".xterm-rows > div").first()).toHaveText(expectedFirstRow);
+  } else {
+    // A bottom-following viewport must still show the newest output. A deliberately
+    // scrolled-up viewport proved that output before activation and must not be
+    // yanked down merely so the newest line remains in xterm's rendered DOM.
+    await expect(firstHost).toContainText(lastLine);
+  }
   const repaired = await terminalGeometry(firstHost);
-  await expect(firstHost).toContainText(lastLine);
   await first.mouse.wheel(0, -900);
   await expect
     .poll(() => firstViewport.evaluate((el) => el.scrollTop), {
@@ -3757,6 +3797,16 @@ test("#2347: activating a terminal repairs peer-owned geometry before scrolling"
     await first.keyboard.type("for i in $(seq 1 60); do echo peer-fit-line-$i; done");
     await first.keyboard.press("Enter");
     await expect(firstHost).toContainText("peer-fit-line-60", { timeout: 15_000 });
+    const firstViewport = firstHost.locator(".xterm-viewport");
+    await first.mouse.wheel(0, -180);
+    await expect
+      .poll(async () => {
+        const { scrollHeight, viewportHeight, scrollTop } = await terminalGeometry(firstHost);
+        return scrollTop > 0 && scrollTop < scrollHeight - viewportHeight;
+      }, { message: "desktop shell setup must pause on a real middle scrollback line" })
+      .toBe(true);
+    const readingLine = (await firstHost.locator(".xterm-rows > div").first().textContent()) ?? "";
+    expect(readingLine.trim(), "desktop shell setup must anchor a non-empty visible line").not.toBe("");
     // Leave the pane for the peer window. Returning across this boundary is the
     // pointer-activation path a side-by-side user takes before their first wheel.
     await first.mouse.move(0, 0);
@@ -3769,13 +3819,22 @@ test("#2347: activating a terminal repairs peer-owned geometry before scrolling"
     await expect(secondShell).toHaveCount(1, { timeout: 15_000 });
     await secondShell.click();
     await expect(second.locator(".af-term-meta")).toContainText("Live");
+    const secondHost = second.locator(".af-term-host");
+    await expect.poll(firstRows).toBeGreaterThan(60);
+    // New output while the first client is inactive must not stale its reading
+    // anchor. A one-time distance from the bottom jumps down by these ten lines.
+    await secondHost.click();
+    await second.keyboard.type("for i in $(seq 61 70); do echo peer-fit-line-$i; done");
+    await second.keyboard.press("Enter");
+    await expect(firstHost).toContainText("peer-fit-line-70", { timeout: 15_000 });
     await assertActiveTerminalReclaimsPeerGeometry(
       first,
       second,
       firstHost,
-      "peer-fit-line-60",
+      "peer-fit-line-70",
       60,
       "desktop shell",
+      readingLine,
     );
   } finally {
     await secondCtx?.close();
@@ -3855,6 +3914,8 @@ test("#2347: the mobile agent terminal also reclaims peer-owned geometry", REAL_
       lastLine,
       lineCount,
       "mobile agent",
+      undefined,
+      true,
     );
   } finally {
     await secondCtx?.close();

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -3630,6 +3630,243 @@ test("theme (redesign PR1): toggling Light vs Dark changes token-driven colors l
   await page.evaluate(() => localStorage.removeItem("af-theme"));
 });
 
+interface TerminalGeometry {
+  hostHeight?: number;
+  viewportHeight: number;
+  scrollHeight: number;
+  scrollTop: number;
+  rows: number;
+}
+
+async function terminalGeometry(host: Locator, includeHost = false): Promise<TerminalGeometry> {
+  return host.evaluate(
+    (root, withHost) => {
+      const pane = root.querySelector<HTMLElement>(".af-pane-host");
+      const viewport = root.querySelector<HTMLElement>(".xterm-viewport");
+      return {
+        ...(withHost ? { hostHeight: pane?.clientHeight ?? -1 } : {}),
+        viewportHeight: viewport?.clientHeight ?? -1,
+        scrollHeight: viewport?.scrollHeight ?? -1,
+        scrollTop: viewport?.scrollTop ?? -1,
+        rows: root.querySelectorAll(".xterm-rows > div").length,
+      };
+    },
+    includeHost,
+  );
+}
+
+/** Proves the #2347 failure boundary and the user-visible repair against two real
+ *  browser subscribers to one PTY. The tall peer deliberately owns a grid larger
+ *  than all emitted output, collapsing the first client's scroll range to zero. */
+async function assertActiveTerminalReclaimsPeerGeometry(
+  first: Page,
+  second: Page,
+  firstHost: Locator,
+  lastLine: string,
+  lineCount: number,
+  scenario: string,
+): Promise<void> {
+  const firstViewport = firstHost.locator(".xterm-viewport");
+  const firstRows = (): Promise<number> => firstHost.locator(".xterm-rows > div").count();
+
+  // On a phone the drawer closes underneath the pointer that selected the row,
+  // leaving that pointer over the newly exposed terminal. Move it to inert appbar
+  // chrome and cross two paint boundaries so a delayed pointerenter from the drawer
+  // transition cannot reassert the tall peer after we return to the first page.
+  await second.mouse.move(0, 0);
+  await second.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      }),
+  );
+  await expect
+    .poll(firstRows, { message: `${scenario}: the authoritative peer resize must reach the first client` })
+    .toBeGreaterThan(lineCount);
+  const stranded = await terminalGeometry(firstHost, true);
+  expect(stranded.rows, `${scenario}: the peer must overwrite the local row count`).toBeGreaterThan(lineCount);
+  expect(stranded.scrollHeight, `${scenario}: the oversized grid must remove the local scroll range`).toBe(
+    stranded.viewportHeight,
+  );
+
+  // The pointer comes back to the first window before the user reaches for the
+  // wheel. Its container never changed, so ResizeObserver has nothing to report;
+  // pointer activation must reclaim local geometry. Before #2347, rows stayed at
+  // the peer's size, every wheel was dead, and only a physical resize fixed them.
+  // The tall peer is already the active page after construction. Re-focusing it
+  // here would queue another local fit immediately before the first page's fit;
+  // that synthetic race would correctly let the peer win last-writer-wins again.
+  await first.bringToFront();
+  // Target the actual xterm mount, not its full split-layout wrapper. On narrow
+  // layouts the wrapper also spans drawer/scrim stacking surfaces; the production
+  // activation listener lives on .af-pane-host.
+  await firstHost.locator(".af-pane-host").hover();
+  await expect
+    .poll(firstRows, { message: `${scenario}: pointer activation must refit; stranded=${JSON.stringify(stranded)}` })
+    .toBeLessThan(lineCount);
+  const refit = await terminalGeometry(firstHost);
+  expect(
+    refit.scrollHeight,
+    `${scenario}: the local grid must recreate scrollback; geometry=${JSON.stringify({ stranded, refit })}`,
+  ).toBeGreaterThan(refit.viewportHeight);
+  await expect
+    .poll(() => firstViewport.evaluate((el) => el.scrollTop), {
+      message: `${scenario}: activation must restore the pre-peer position; geometry=${JSON.stringify({ stranded, refit })}`,
+    })
+    .toBeGreaterThan(0);
+  const repaired = await terminalGeometry(firstHost);
+  await expect(firstHost).toContainText(lastLine);
+  await first.mouse.wheel(0, -900);
+  await expect
+    .poll(() => firstViewport.evaluate((el) => el.scrollTop), {
+      message: `${scenario}: wheel must work without a resize; geometry=${JSON.stringify({ stranded, repaired })}`,
+    })
+    .toBeLessThan(repaired.scrollTop);
+}
+
+test("#2347: activating a terminal repairs peer-owned geometry before scrolling", REAL_FIXTURE, async ({
+  browser,
+}) => {
+  const afBin = process.env.AF_BIN;
+  const mockRepo = process.env.AF_MOCK_REPO;
+  test.skip(!afBin || !mockRepo, "AF_BIN/AF_MOCK_REPO are set only by web-selftest-entry.sh");
+  const { execFileSync } = await import("node:child_process");
+  const af = (...args: string[]): void => {
+    execFileSync(afBin as string, ["--repo", mockRepo as string, ...args], { stdio: "pipe" });
+  };
+  const shellName = "peer-fit-2347";
+
+  const firstCtx = await browser.newContext({ viewport: { width: 1280, height: 720 } });
+  let secondCtx: BrowserContext | null = null;
+  let created = false;
+  try {
+    const first = await firstCtx.newPage();
+    await openTokenless(first);
+    await row(first, SESSION_A).click();
+    af("sessions", "tab-create", SESSION_A, "--command", "bash", "--name", shellName);
+    created = true;
+    const firstShell = first.locator(".af-tabbar .af-tab", { hasText: shellName });
+    await expect(firstShell).toHaveCount(1, { timeout: 15_000 });
+    await firstShell.click();
+    await expect(first.locator(".af-term-meta")).toContainText("Live");
+    const firstHost = first.locator(".af-term-host");
+    const firstRows = (): Promise<number> => firstHost.locator(".xterm-rows > div").count();
+    await expect.poll(firstRows).toBeGreaterThan(24);
+
+    await firstHost.click();
+    await first.keyboard.type("for i in $(seq 1 60); do echo peer-fit-line-$i; done");
+    await first.keyboard.press("Enter");
+    await expect(firstHost).toContainText("peer-fit-line-60", { timeout: 15_000 });
+    // Leave the pane for the peer window. Returning across this boundary is the
+    // pointer-activation path a side-by-side user takes before their first wheel.
+    await first.mouse.move(0, 0);
+
+    secondCtx = await browser.newContext({ viewport: { width: 1280, height: 2000 } });
+    const second = await secondCtx.newPage();
+    await openTokenless(second);
+    await row(second, SESSION_A).click();
+    const secondShell = second.locator(".af-tabbar .af-tab", { hasText: shellName });
+    await expect(secondShell).toHaveCount(1, { timeout: 15_000 });
+    await secondShell.click();
+    await expect(second.locator(".af-term-meta")).toContainText("Live");
+    await assertActiveTerminalReclaimsPeerGeometry(
+      first,
+      second,
+      firstHost,
+      "peer-fit-line-60",
+      60,
+      "desktop shell",
+    );
+  } finally {
+    await secondCtx?.close();
+    await firstCtx.close();
+    if (created) {
+      try {
+        af("sessions", "tab-delete", SESSION_A, "--name", shellName);
+      } catch {
+        // The throwaway daemon may already have removed a failed startup.
+      }
+    }
+  }
+});
+
+test("#2347: the mobile agent terminal also reclaims peer-owned geometry", REAL_FIXTURE, async ({ browser }) => {
+  const afBin = process.env.AF_BIN;
+  const mockRepo = process.env.AF_MOCK_REPO;
+  test.skip(!afBin || !mockRepo, "AF_BIN/AF_MOCK_REPO are set only by web-selftest-entry.sh");
+  const { execFileSync } = await import("node:child_process");
+  const af = (...args: string[]): void => {
+    execFileSync(afBin as string, ["--repo", mockRepo as string, ...args], { stdio: "pipe" });
+  };
+  const sessionName = "peer-agent-2347";
+  const lineCount = 40;
+  const lastLine = `peer-agent-line-${lineCount}`;
+  af("sessions", "create", "--name", sessionName, "--program", "claude");
+
+  const firstCtx = await browser.newContext({ viewport: { width: 375, height: 667 } });
+  let secondCtx: BrowserContext | null = null;
+  try {
+    const first = await firstCtx.newPage();
+    await openTokenless(first);
+    await first.locator(".af-nav-toggle").click();
+    await expect(row(first, sessionName)).toBeVisible({ timeout: 15_000 });
+    await row(first, sessionName).click();
+    await expect(first.locator(".af-term-meta")).toContainText("Live");
+    const firstHost = first.locator(".af-term-host");
+    const firstRows = (): Promise<number> => firstHost.locator(".xterm-rows > div").count();
+    await expect.poll(firstRows).toBeGreaterThan(0);
+    await expect.poll(firstRows).toBeLessThan(lineCount);
+
+    // The fixture's `claude` is the real agent-tab PTY path with a deterministic
+    // cat-shaped agent. Feed it many lines directly so this test covers the agent
+    // terminal without polluting SESSION_A's marker-dependent serial flows. Use
+    // real Enter key events: insertText("\\n") writes literal LF bytes and does
+    // not exercise the PTY line discipline, so it can paint text without creating
+    // the row progression/scrollback that this regression needs.
+    await firstHost.click();
+    for (let i = 1; i <= lineCount; i += 1) {
+      await first.keyboard.type(`peer-agent-line-${i}`);
+      await first.keyboard.press("Enter");
+    }
+    await expect(firstHost).toContainText(lastLine, { timeout: 15_000 });
+    const local = await terminalGeometry(firstHost);
+    expect(
+      local.scrollHeight,
+      `mobile agent setup must have scrollback; geometry=${JSON.stringify(local)}`,
+    ).toBeGreaterThan(local.viewportHeight);
+    expect(
+      local.scrollTop,
+      `mobile agent setup must start at the bottom; geometry=${JSON.stringify(local)}`,
+    ).toBeGreaterThan(0);
+    await first.mouse.move(0, 0);
+
+    secondCtx = await browser.newContext({ viewport: { width: 375, height: 2000 } });
+    const second = await secondCtx.newPage();
+    await openTokenless(second);
+    await second.locator(".af-nav-toggle").click();
+    await expect(row(second, sessionName)).toBeVisible({ timeout: 15_000 });
+    await row(second, sessionName).click();
+    await expect(second.locator(".af-term-meta")).toContainText("Live");
+
+    await assertActiveTerminalReclaimsPeerGeometry(
+      first,
+      second,
+      firstHost,
+      lastLine,
+      lineCount,
+      "mobile agent",
+    );
+  } finally {
+    await secondCtx?.close();
+    await firstCtx.close();
+    try {
+      af("sessions", "kill", sessionName);
+    } catch {
+      // The throwaway daemon may already have removed a failed startup.
+    }
+  }
+});
+
 // The #1812 regression guard: a tab created or deleted by ANY actor other than
 // this browser window — an agent running `af sessions tab-create` inside its own
 // session, the TUI, a script, a second window — must reach an already-open client

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -3792,6 +3792,9 @@ test("#2347: activating a terminal repairs peer-owned geometry before scrolling"
     const firstHost = first.locator(".af-term-host");
     const firstRows = (): Promise<number> => firstHost.locator(".xterm-rows > div").count();
     await expect.poll(firstRows).toBeGreaterThan(24);
+    const localRows = await firstRows();
+    const localViewport = first.viewportSize();
+    expect(localViewport, "desktop peer test needs a fixed local viewport").not.toBeNull();
 
     await firstHost.click();
     await first.keyboard.type("for i in $(seq 1 60); do echo peer-fit-line-$i; done");
@@ -3836,6 +3839,42 @@ test("#2347: activating a terminal repairs peer-owned geometry before scrolling"
       "desktop shell",
       readingLine,
     );
+
+    await test.step("a second peer resize already matching the local grid still restores the reading anchor", async () => {
+      const secondReadingLine = (await firstHost.locator(".xterm-rows > div").first().textContent()) ?? "";
+      expect(secondReadingLine.trim(), "second peer setup must anchor a visible line").not.toBe("");
+      await first.mouse.move(0, 0);
+
+      // The tall peer reclaims the shared PTY, so the first client records a fresh
+      // pending anchor. Then the SAME peer resizes to the first page's viewport and
+      // broadcasts the local grid before the first page becomes active again.
+      await second.bringToFront();
+      await secondHost.locator(".af-pane-host").hover();
+      await expect
+        .poll(firstRows, { message: "the tall peer must own the grid before returning it to local size" })
+        .toBeGreaterThan(60);
+      await second.setViewportSize(localViewport!);
+      await expect
+        .poll(firstRows, { message: "the peer's second resize must already match the first host's local rows" })
+        .toBe(localRows);
+      const alreadyLocal = await terminalGeometry(firstHost, true);
+
+      // No FitAddon resize is needed now, but the peer reflows above still displaced
+      // the viewport. Activation must consume the pending marker independently of
+      // whether `needsFit` is true.
+      await first.bringToFront();
+      await firstHost.locator(".af-pane-host").hover();
+      await first.evaluate(
+        () =>
+          new Promise<void>((resolve) => {
+            requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+          }),
+      );
+      await expect(
+        firstHost.locator(".xterm-rows > div").first(),
+        `already-local activation must restore the named reading row; geometry=${JSON.stringify(alreadyLocal)}`,
+      ).toHaveText(secondReadingLine);
+    });
   } finally {
     await secondCtx?.close();
     await firstCtx.close();

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -3938,23 +3938,47 @@ test("#2347: the mobile agent terminal also reclaims peer-owned geometry", REAL_
     ).toBeGreaterThan(0);
     await first.mouse.move(0, 0);
 
-    secondCtx = await browser.newContext({ viewport: { width: 375, height: 2000 } });
-    const second = await secondCtx.newPage();
-    await openTokenless(second);
-    await second.locator(".af-nav-toggle").click();
-    await expect(row(second, sessionName)).toBeVisible({ timeout: 15_000 });
-    await row(second, sessionName).click();
-    await expect(second.locator(".af-term-meta")).toContainText("Live");
-    const secondHost = second.locator(".af-term-host");
+    const peerContext = await browser.newContext({ viewport: { width: 375, height: 2000 } });
+    secondCtx = peerContext;
+    const openTallPeer = async (label: string): Promise<Page> => {
+      const peer = await peerContext.newPage();
+      await openTokenless(peer);
+      await peer.locator(".af-nav-toggle").click();
+      await expect(row(peer, sessionName)).toBeVisible({ timeout: 15_000 });
+      await row(peer, sessionName).click();
+      await expect(peer.locator(".af-term-meta")).toContainText("Live");
+      await expect.poll(firstRows, { message: label }).toBeGreaterThan(lineCount);
+      const stranded = await terminalGeometry(firstHost, true);
+      expect(stranded.rows, `${label}; peer geometry=${JSON.stringify(stranded)}`).toBeGreaterThan(lineCount);
+      expect(stranded.scrollHeight, `${label}; peer geometry=${JSON.stringify(stranded)}`).toBe(
+        stranded.viewportHeight,
+      );
+      return peer;
+    };
+    const expectSettledLocalGeometry = async (label: string): Promise<void> => {
+      let observed = await terminalGeometry(firstHost, true);
+      try {
+        await expect
+          .poll(
+            async () => {
+              observed = await terminalGeometry(firstHost, true);
+              return observed.rows < lineCount && observed.scrollHeight > observed.viewportHeight;
+            },
+            { message: label },
+          )
+          .toBe(true);
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        throw new Error(`${label}; last geometry=${JSON.stringify(observed)}\n${detail}`);
+      }
+    };
 
-    // Touch and scrollbar input can begin while the browser still considers the
-    // peer window active (for example, a phone swipe delivered as the tab becomes
-    // foreground, or a scrollbar drag in a side-by-side window). Exercise the real
-    // xterm DOM listeners while the peer-owned grid is still stranded: neither path
-    // may wait for a later focus/resize signal to rebuild scrollback.
-    await expect
-      .poll(firstRows, { message: "the tall peer must strand the mobile client before direct-input checks" })
-      .toBeGreaterThan(lineCount);
+    // Each tall peer leaves its authoritative grid behind, then disconnects. That
+    // isolates the direct-input path under test: an activation still queued in a
+    // live peer is a legitimate later writer, not evidence that this host failed to
+    // fit. Exercise the real xterm DOM listeners while the stale peer grid remains.
+    let peer = await openTallPeer("the tall peer must strand the mobile client before the touch check");
+    await peer.close();
     await test.step("touch scroll input reclaims the peer grid", async () => {
       await firstHost.locator(".af-pane-host").dispatchEvent("touchmove", {
         bubbles: true,
@@ -3962,17 +3986,11 @@ test("#2347: the mobile agent terminal also reclaims peer-owned geometry", REAL_
         touches: [{ identifier: 1, clientX: 180, clientY: 300 }],
         changedTouches: [{ identifier: 1, clientX: 180, clientY: 300 }],
       });
-      await expect
-        .poll(firstRows, { message: "touchmove must synchronously reclaim the measurable local grid" })
-        .toBeLessThan(lineCount);
+      await expectSettledLocalGeometry("touchmove must reclaim the measurable local grid and rebuild scrollback");
     });
 
-    const letTallPeerReclaim = async (label: string): Promise<void> => {
-      await second.mouse.move(0, 0);
-      await secondHost.locator(".af-pane-host").hover();
-      await expect.poll(firstRows, { message: label }).toBeGreaterThan(lineCount);
-    };
-    await letTallPeerReclaim("the tall peer must reclaim the grid after the touch check");
+    peer = await openTallPeer("the next tall peer must strand the mobile client before the scrollbar check");
+    await peer.close();
     await test.step("scrollbar input reclaims the peer grid", async () => {
       await firstHost.locator(".xterm-viewport").dispatchEvent("pointerdown", {
         bubbles: true,
@@ -3981,15 +3999,14 @@ test("#2347: the mobile agent terminal also reclaims peer-owned geometry", REAL_
         button: 0,
         buttons: 1,
       });
-      await expect
-        .poll(firstRows, { message: "a pointer on xterm's scrollbar viewport must reclaim the local grid" })
-        .toBeLessThan(lineCount);
+      await expectSettledLocalGeometry("a pointer on xterm's scrollbar viewport must reclaim the local grid");
     });
-    await letTallPeerReclaim("the tall peer must reclaim the grid before the immediate-wheel check");
+
+    peer = await openTallPeer("the final tall peer must strand the mobile client before the immediate-wheel check");
 
     await assertActiveTerminalReclaimsPeerGeometry(
       first,
-      second,
+      peer,
       firstHost,
       lastLine,
       lineCount,

--- a/web/src/terminal-geometry.test.ts
+++ b/web/src/terminal-geometry.test.ts
@@ -4,6 +4,7 @@ import {
   hasVisibleTerminalGeometry,
   shouldRefitVisibleTerminal,
   shouldRestoreViewport,
+  viewportAnchorLine,
   viewportMarkerOffset,
 } from "./terminal-geometry.js";
 
@@ -39,8 +40,14 @@ test("#2347: a scrollback marker anchors the visible line, not a stale bottom di
   assert.equal(viewportMarkerOffset({ baseY: 100, cursorY: 24, viewportY: 91 }), -33);
 });
 
-test("#2347: a wheel movement wins over a deferred viewport restore", () => {
-  assert.equal(shouldRestoreViewport(12, 12), true);
-  assert.equal(shouldRestoreViewport(12, 11), false);
-  assert.equal(shouldRestoreViewport(12, 13), false);
+test("#2347: a disposed marker falls back to the saved line instead of the top", () => {
+  assert.equal(viewportAnchorLine({ atBottom: false, markerLine: 42, fallbackLine: 17 }, 83), 42);
+  assert.equal(viewportAnchorLine({ atBottom: false, markerLine: -1, fallbackLine: 17 }, 83), 17);
+  assert.equal(viewportAnchorLine({ atBottom: false, markerLine: null, fallbackLine: 17 }, 83), 17);
+  assert.equal(viewportAnchorLine({ atBottom: true, markerLine: -1, fallbackLine: 17 }, 83), 83);
+});
+
+test("#2347: only user scroll intent cancels a deferred viewport restore", () => {
+  assert.equal(shouldRestoreViewport({ scheduledUserScroll: 4, currentUserScroll: 4 }), true);
+  assert.equal(shouldRestoreViewport({ scheduledUserScroll: 4, currentUserScroll: 5 }), false);
 });

--- a/web/src/terminal-geometry.test.ts
+++ b/web/src/terminal-geometry.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { shouldRefitVisibleTerminal, viewportLineFromBottom } from "./terminal-geometry.js";
+
+const local = { rows: 36, cols: 120 };
+const peer = { rows: 111, cols: 120 };
+
+test("#2347: a visible host reclaims a different peer-owned grid", () => {
+  assert.equal(shouldRefitVisibleTerminal({ width: 992, height: 620 }, peer, local), true);
+});
+
+test("#2347: zero-size and unresolved hosts never fit", () => {
+  assert.equal(shouldRefitVisibleTerminal({ width: 0, height: 620 }, peer, local), false);
+  assert.equal(shouldRefitVisibleTerminal({ width: 992, height: 0 }, peer, local), false);
+  assert.equal(shouldRefitVisibleTerminal({ width: 992, height: 620 }, peer, undefined), false);
+  assert.equal(shouldRefitVisibleTerminal({ width: 992, height: 620 }, peer, { rows: 0, cols: 120 }), false);
+  assert.equal(shouldRefitVisibleTerminal({ width: 992, height: 620 }, peer, { rows: 36, cols: 0 }), false);
+});
+
+test("#2347: an already-local grid does not emit resize churn", () => {
+  assert.equal(shouldRefitVisibleTerminal({ width: 992, height: 620 }, local, local), false);
+});
+
+test("#2347: a peer reflow restores the user's distance from the bottom", () => {
+  assert.equal(viewportLineFromBottom(24, 0), 24);
+  assert.equal(viewportLineFromBottom(24, 5), 19);
+  assert.equal(viewportLineFromBottom(24, 99), 0);
+  assert.equal(viewportLineFromBottom(24, -3), 24);
+});

--- a/web/src/terminal-geometry.test.ts
+++ b/web/src/terminal-geometry.test.ts
@@ -4,6 +4,7 @@ import {
   hasVisibleTerminalGeometry,
   shouldRefitVisibleTerminal,
   shouldRestoreViewport,
+  terminalUserScrollPlan,
   viewportAnchorLine,
   viewportMarkerOffset,
 } from "./terminal-geometry.js";
@@ -50,4 +51,14 @@ test("#2347: a disposed marker falls back to the saved line instead of the top",
 test("#2347: only user scroll intent cancels a deferred viewport restore", () => {
   assert.equal(shouldRestoreViewport({ scheduledUserScroll: 4, currentUserScroll: 4 }), true);
   assert.equal(shouldRestoreViewport({ scheduledUserScroll: 4, currentUserScroll: 5 }), false);
+});
+
+test("#2347: every direct scroll input supersedes the saved peer anchor", () => {
+  for (const source of ["wheel", "touch", "scrollbar"] as const) {
+    assert.deepEqual(terminalUserScrollPlan(source, false), { cancelScheduledVisibleFit: false });
+  }
+});
+
+test("#2347: a direct scroll cancels a stale queued activation fit", () => {
+  assert.deepEqual(terminalUserScrollPlan("wheel", true), { cancelScheduledVisibleFit: true });
 });

--- a/web/src/terminal-geometry.test.ts
+++ b/web/src/terminal-geometry.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { shouldRefitVisibleTerminal, viewportLineFromBottom } from "./terminal-geometry.js";
+import {
+  hasVisibleTerminalGeometry,
+  shouldRefitVisibleTerminal,
+  shouldRestoreViewport,
+  viewportMarkerOffset,
+} from "./terminal-geometry.js";
 
 const local = { rows: 36, cols: 120 };
 const peer = { rows: 111, cols: 120 };
@@ -21,9 +26,21 @@ test("#2347: an already-local grid does not emit resize churn", () => {
   assert.equal(shouldRefitVisibleTerminal({ width: 992, height: 620 }, local, local), false);
 });
 
-test("#2347: a peer reflow restores the user's distance from the bottom", () => {
-  assert.equal(viewportLineFromBottom(24, 0), 24);
-  assert.equal(viewportLineFromBottom(24, 5), 19);
-  assert.equal(viewportLineFromBottom(24, 99), 0);
-  assert.equal(viewportLineFromBottom(24, -3), 24);
+test("#2347: a measured local grid is ready before the first socket resize", () => {
+  assert.equal(hasVisibleTerminalGeometry({ width: 992, height: 620 }, local), true);
+  assert.equal(hasVisibleTerminalGeometry({ width: 0, height: 620 }, local), false);
+  assert.equal(hasVisibleTerminalGeometry({ width: 992, height: 620 }, undefined), false);
+});
+
+test("#2347: a scrollback marker anchors the visible line, not a stale bottom distance", () => {
+  // Cursor absolute line = baseY + cursorY = 124. The viewport starts at line
+  // 91, so a marker 33 lines above the cursor follows that content as output is
+  // appended while this client is inactive.
+  assert.equal(viewportMarkerOffset({ baseY: 100, cursorY: 24, viewportY: 91 }), -33);
+});
+
+test("#2347: a wheel movement wins over a deferred viewport restore", () => {
+  assert.equal(shouldRestoreViewport(12, 12), true);
+  assert.equal(shouldRestoreViewport(12, 11), false);
+  assert.equal(shouldRestoreViewport(12, 13), false);
 });

--- a/web/src/terminal-geometry.ts
+++ b/web/src/terminal-geometry.ts
@@ -8,19 +8,41 @@ export interface TerminalHostSize {
   height: number;
 }
 
+export interface TerminalBufferPosition {
+  baseY: number;
+  cursorY: number;
+  viewportY: number;
+}
+
+/** Whether FitAddon has a real grid for a non-hidden host. This also gates the
+ * first socket connect, so a newly opened client never advertises xterm's 80x24
+ * constructor default to the shared PTY before layout has produced its real grid. */
+export function hasVisibleTerminalGeometry(
+  host: TerminalHostSize,
+  proposed: TerminalGrid | undefined,
+): proposed is TerminalGrid {
+  return host.width > 0 && host.height > 0 && !!proposed && proposed.rows > 0 && proposed.cols > 0;
+}
+
 /** Whether an active terminal should reclaim the grid that fits its visible host. */
 export function shouldRefitVisibleTerminal(
   host: TerminalHostSize,
   current: TerminalGrid,
   proposed: TerminalGrid | undefined,
 ): boolean {
-  if (host.width <= 0 || host.height <= 0 || !proposed || proposed.rows <= 0 || proposed.cols <= 0) {
+  if (!hasVisibleTerminalGeometry(host, proposed)) {
     return false;
   }
   return proposed.rows !== current.rows || proposed.cols !== current.cols;
 }
 
-/** Restores the same reading distance from the bottom after a grid reflow. */
-export function viewportLineFromBottom(baseY: number, distanceFromBottom: number): number {
-  return Math.max(0, baseY - Math.max(0, distanceFromBottom));
+/** Offset from xterm's absolute cursor line to the visible viewport's first line.
+ * An xterm marker registered here follows that content as output adds/removes lines. */
+export function viewportMarkerOffset(position: TerminalBufferPosition): number {
+  return position.viewportY - (position.baseY + position.cursorY);
+}
+
+/** A real scroll after fitting wins over the deferred anchor restore. */
+export function shouldRestoreViewport(scheduledViewportY: number, currentViewportY: number): boolean {
+  return scheduledViewportY === currentViewportY;
 }

--- a/web/src/terminal-geometry.ts
+++ b/web/src/terminal-geometry.ts
@@ -25,6 +25,12 @@ export interface ViewportRestoreIntent {
   currentUserScroll: number;
 }
 
+export type TerminalUserScrollSource = "wheel" | "touch" | "scrollbar";
+
+export interface TerminalUserScrollPlan {
+  cancelScheduledVisibleFit: boolean;
+}
+
 /** Whether FitAddon has a real grid for a non-hidden host. This also gates the
  * first socket connect, so a newly opened client never advertises xterm's 80x24
  * constructor default to the shared PTY before layout has produced its real grid. */
@@ -66,4 +72,20 @@ export function viewportAnchorLine(anchor: ViewportAnchorTarget, baseY: number):
  * may move viewportY on its own and must not pose as user intent. */
 export function shouldRestoreViewport(intent: ViewportRestoreIntent): boolean {
   return intent.scheduledUserScroll === intent.currentUserScroll;
+}
+
+/** Plans the activation work for an explicit user scroll while a peer anchor is
+ * pending. Wheel, touch, and a scrollbar gesture are equally authoritative. A
+ * queued focus/visibility fit must be cancelled before the synchronous input fit,
+ * or it can reschedule restoration from the newly incremented revision. */
+export function terminalUserScrollPlan(
+  source: TerminalUserScrollSource,
+  hasScheduledVisibleFit: boolean,
+): TerminalUserScrollPlan {
+  switch (source) {
+    case "wheel":
+    case "touch":
+    case "scrollbar":
+      return { cancelScheduledVisibleFit: hasScheduledVisibleFit };
+  }
 }

--- a/web/src/terminal-geometry.ts
+++ b/web/src/terminal-geometry.ts
@@ -14,6 +14,17 @@ export interface TerminalBufferPosition {
   viewportY: number;
 }
 
+export interface ViewportAnchorTarget {
+  atBottom: boolean;
+  markerLine: number | null;
+  fallbackLine: number;
+}
+
+export interface ViewportRestoreIntent {
+  scheduledUserScroll: number;
+  currentUserScroll: number;
+}
+
 /** Whether FitAddon has a real grid for a non-hidden host. This also gates the
  * first socket connect, so a newly opened client never advertises xterm's 80x24
  * constructor default to the shared PTY before layout has produced its real grid. */
@@ -42,7 +53,17 @@ export function viewportMarkerOffset(position: TerminalBufferPosition): number {
   return position.viewportY - (position.baseY + position.cursorY);
 }
 
-/** A real scroll after fitting wins over the deferred anchor restore. */
-export function shouldRestoreViewport(scheduledViewportY: number, currentViewportY: number): boolean {
-  return scheduledViewportY === currentViewportY;
+/** Resolves a saved viewport anchor. xterm leaves a disposed marker object alive
+ * with line=-1, so only a non-negative marker can outrank the absolute fallback. */
+export function viewportAnchorLine(anchor: ViewportAnchorTarget, baseY: number): number {
+  if (anchor.atBottom) {
+    return baseY;
+  }
+  return anchor.markerLine !== null && anchor.markerLine >= 0 ? anchor.markerLine : anchor.fallbackLine;
+}
+
+/** A real user scroll after fitting wins over the deferred anchor restore. Output
+ * may move viewportY on its own and must not pose as user intent. */
+export function shouldRestoreViewport(intent: ViewportRestoreIntent): boolean {
+  return intent.scheduledUserScroll === intent.currentUserScroll;
 }

--- a/web/src/terminal-geometry.ts
+++ b/web/src/terminal-geometry.ts
@@ -1,0 +1,26 @@
+export interface TerminalGrid {
+  rows: number;
+  cols: number;
+}
+
+export interface TerminalHostSize {
+  width: number;
+  height: number;
+}
+
+/** Whether an active terminal should reclaim the grid that fits its visible host. */
+export function shouldRefitVisibleTerminal(
+  host: TerminalHostSize,
+  current: TerminalGrid,
+  proposed: TerminalGrid | undefined,
+): boolean {
+  if (host.width <= 0 || host.height <= 0 || !proposed || proposed.rows <= 0 || proposed.cols <= 0) {
+    return false;
+  }
+  return proposed.rows !== current.rows || proposed.cols !== current.cols;
+}
+
+/** Restores the same reading distance from the bottom after a grid reflow. */
+export function viewportLineFromBottom(baseY: number, distanceFromBottom: number): number {
+  return Math.max(0, baseY - Math.max(0, distanceFromBottom));
+}

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -41,6 +41,7 @@ import { type ITheme, Terminal } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
 import { handleClipboardKeydown } from "./clipboard.js";
 import { decode, encode, inputFrame, Op, resizeFrame } from "./frame.js";
+import { shouldRefitVisibleTerminal, viewportLineFromBottom } from "./terminal-geometry.js";
 import { currentXtermTheme } from "./theme.js";
 
 /** The attach terminal's connection state, surfaced for a small status line. */
@@ -83,6 +84,7 @@ export class AttachTerminal {
   private readonly fit: FitAddon;
   private readonly enc = new TextEncoder();
   private readonly ro: ResizeObserver;
+  private readonly io: IntersectionObserver;
 
   private ws: WebSocket | null = null;
   private stopped = false;
@@ -90,6 +92,8 @@ export class AttachTerminal {
   private retry = 0;
   private reconnectTimer: number | null = null;
   private resizeTimer: number | null = null;
+  private visibleFitFrame: number | null = null;
+  private viewportRestoreFrame: number | null = null;
 
   // The absolute replay cursor: seeded from OpHello, advanced by OpPTYOut byte
   // counts (never by OpRepaint). `seeded` gates whether a reconnect can pass a
@@ -100,10 +104,39 @@ export class AttachTerminal {
   // an authoritative echo that matches is a no-op.
   private lastRows = 0;
   private lastCols = 0;
+  // A peer resize can temporarily collapse this client's scrollback (for example,
+  // 60 lines fit in a peer's 111-row grid). Preserve the user's local reading
+  // position independently of that reflow so the next visible-host fit can restore
+  // it. Null means no peer-owned grid is pending reconciliation.
+  private pendingViewportDistance: number | null = null;
   private exited = false;
 
+  // A peer is allowed to resize the one shared PTY and every client obeys that
+  // authoritative echo. When this window becomes active again, its visible host
+  // becomes the local writer: refit once instead of leaving a peer-sized emulator in
+  // an unchanged container until the user physically resizes the window (#2347).
+  private readonly onWindowFocus = (): void => this.scheduleVisibleFit();
+  private readonly onVisibilityChange = (): void => {
+    if (document.visibilityState === "visible") {
+      this.scheduleVisibleFit();
+    }
+  };
+  // Entering a pane is the earliest reliable activation signal for side-by-side
+  // clients: reconcile before the wheel gesture arrives so xterm can consume that
+  // first gesture rather than making the user scroll twice.
+  private readonly onPointerEnter = (): void => this.fitVisibleHost();
+  // Wheel can target an already-focused window after another client resized the PTY
+  // without the pointer ever leaving this pane. Capture repairs that less-common
+  // path; pointer entry above handles the ordinary first gesture. The pending-peer
+  // gate makes every ordinary wheel a no-op before even measuring layout.
+  private readonly onWheel = (): void => {
+    if (this.pendingViewportDistance !== null) {
+      this.fitVisibleHost();
+    }
+  };
+
   constructor(
-    container: HTMLElement,
+    private readonly container: HTMLElement,
     private readonly sessionId: string,
     private readonly token: string,
     private readonly tabId: string,
@@ -125,7 +158,6 @@ export class AttachTerminal {
     this.fit = new FitAddon();
     this.term.loadAddon(this.fit);
     this.term.open(container);
-    this.fit.fit();
 
     // Report focus/blur of xterm's helper textarea so index.ts can track which pane
     // owns the keyboard (#1693) even when the user clicks straight into the terminal
@@ -169,6 +201,25 @@ export class AttachTerminal {
     this.ro = new ResizeObserver(() => this.scheduleFit());
     this.ro.observe(container);
 
+    // ResizeObserver alone cannot express two important transitions:
+    //   * xterm is opened before its first painted cell metrics exist, even when the
+    //     host already has its final border-box; and
+    //   * a peer's authoritative resize changes xterm's grid, not this host's box.
+    // Intersection/activation schedule a one-frame-later fit at those boundaries.
+    // A zero-size hidden pane is rejected by fitVisibleHost and retried when it
+    // intersects; there is no polling timer.
+    this.io = new IntersectionObserver((entries) => {
+      if (entries.some((entry) => entry.target === container && entry.isIntersecting)) {
+        this.scheduleVisibleFit();
+      }
+    });
+    this.io.observe(container);
+    window.addEventListener("focus", this.onWindowFocus);
+    document.addEventListener("visibilitychange", this.onVisibilityChange);
+    container.addEventListener("pointerenter", this.onPointerEnter);
+    container.addEventListener("wheel", this.onWheel, { capture: true, passive: true });
+    this.scheduleVisibleFit();
+
     this.connect();
   }
 
@@ -184,7 +235,20 @@ export class AttachTerminal {
       window.clearTimeout(this.resizeTimer);
       this.resizeTimer = null;
     }
+    if (this.visibleFitFrame !== null) {
+      window.cancelAnimationFrame(this.visibleFitFrame);
+      this.visibleFitFrame = null;
+    }
+    if (this.viewportRestoreFrame !== null) {
+      window.cancelAnimationFrame(this.viewportRestoreFrame);
+      this.viewportRestoreFrame = null;
+    }
     this.ro.disconnect();
+    this.io.disconnect();
+    window.removeEventListener("focus", this.onWindowFocus);
+    document.removeEventListener("visibilitychange", this.onVisibilityChange);
+    this.container.removeEventListener("pointerenter", this.onPointerEnter);
+    this.container.removeEventListener("wheel", this.onWheel, true);
     this.closeSocket();
     this.term.dispose();
   }
@@ -192,6 +256,7 @@ export class AttachTerminal {
   /** Gives the terminal the keyboard (focuses xterm's helper textarea) so typed
    *  keys reach the agent — the attach half of the #1693 nav/attach model. */
   focus(): void {
+    this.fitVisibleHost();
     this.term.focus();
   }
 
@@ -359,6 +424,77 @@ export class AttachTerminal {
 
   // --- resize ----------------------------------------------------------------
 
+  /** Fits on the next painted frame, after visibility/layout changes have settled.
+   *  Repeated activation signals coalesce into one frame; unlike the resize debounce,
+   *  this is not a time guess and never repeats on its own. */
+  private scheduleVisibleFit(): void {
+    if (this.stopped || this.visibleFitFrame !== null) {
+      return;
+    }
+    this.visibleFitFrame = window.requestAnimationFrame(() => {
+      this.visibleFitFrame = null;
+      this.fitVisibleHost();
+    });
+  }
+
+  /** Reconciles xterm's grid with this host only when the host is measurable and the
+   *  FitAddon proposes a real change. A peer-owned MsgResize remains authoritative
+   *  while this client is inactive; activation/wheel makes this client the newest
+   *  writer once, without a resize-echo ping-pong between visible clients. */
+  private fitVisibleHost(): void {
+    if (this.stopped) {
+      return;
+    }
+    let proposed;
+    try {
+      proposed = this.fit.proposeDimensions();
+    } catch {
+      return; // xterm has not painted metrics yet, or the container detached
+    }
+    if (
+      !shouldRefitVisibleTerminal(
+        { width: this.container.clientWidth, height: this.container.clientHeight },
+        { rows: this.term.rows, cols: this.term.cols },
+        proposed,
+      )
+    ) {
+      return;
+    }
+    try {
+      this.fit.fit();
+    } catch {
+      return; // container detached between proposal and fit
+    }
+    this.scheduleViewportRestore(this.term.rows, this.term.cols);
+    this.sendResize(this.term.rows, this.term.cols, false);
+  }
+
+  /** Restores the pre-peer reading position after xterm has rendered its new grid.
+   *  resize() schedules the buffer reflow: reading baseY synchronously after fit can
+   *  still see the peer-collapsed zero. The next painted frame is the first settled
+   *  value. A newer peer grid cancels this frame and leaves the distance pending for
+   *  the next local activation. */
+  private scheduleViewportRestore(rows: number, cols: number): void {
+    if (this.pendingViewportDistance === null) {
+      return;
+    }
+    if (this.viewportRestoreFrame !== null) {
+      window.cancelAnimationFrame(this.viewportRestoreFrame);
+    }
+    this.viewportRestoreFrame = window.requestAnimationFrame(() => {
+      this.viewportRestoreFrame = null;
+      if (this.stopped || this.term.rows !== rows || this.term.cols !== cols) {
+        return;
+      }
+      const distance = this.pendingViewportDistance;
+      if (distance === null) {
+        return;
+      }
+      this.pendingViewportDistance = null;
+      this.term.scrollToLine(viewportLineFromBottom(this.term.buffer.active.baseY, distance));
+    });
+  }
+
   private scheduleFit(): void {
     if (this.resizeTimer !== null) {
       window.clearTimeout(this.resizeTimer);
@@ -368,12 +504,7 @@ export class AttachTerminal {
       if (this.stopped) {
         return;
       }
-      try {
-        this.fit.fit(); // resizes xterm locally to the container; onResize fires
-      } catch {
-        return; // container detached mid-resize
-      }
-      this.sendResize(this.term.rows, this.term.cols, false);
+      this.fitVisibleHost();
     }, RESIZE_DEBOUNCE_MS);
   }
 
@@ -398,6 +529,18 @@ export class AttachTerminal {
     this.lastRows = rows;
     this.lastCols = cols;
     if (rows !== this.term.rows || cols !== this.term.cols) {
+      // Capture only the FIRST peer-owned resize in a run. Further peer echoes may
+      // already have collapsed/reflowed the buffer, but the first boundary still
+      // knows where this client was reading in its own grid. The active-host fit
+      // consumes and clears this value before its own echo comes back.
+      if (this.pendingViewportDistance === null) {
+        const buffer = this.term.buffer.active;
+        this.pendingViewportDistance = Math.max(0, buffer.baseY - buffer.viewportY);
+      }
+      if (this.viewportRestoreFrame !== null) {
+        window.cancelAnimationFrame(this.viewportRestoreFrame);
+        this.viewportRestoreFrame = null;
+      }
       try {
         this.term.resize(cols, rows);
       } catch {

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -37,11 +37,16 @@
 // daemon/webserve.go.)
 
 import { FitAddon } from "@xterm/addon-fit";
-import { type ITheme, Terminal } from "@xterm/xterm";
+import { type IMarker, type ITheme, Terminal } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
 import { handleClipboardKeydown } from "./clipboard.js";
 import { decode, encode, inputFrame, Op, resizeFrame } from "./frame.js";
-import { shouldRefitVisibleTerminal, viewportLineFromBottom } from "./terminal-geometry.js";
+import {
+  hasVisibleTerminalGeometry,
+  shouldRefitVisibleTerminal,
+  shouldRestoreViewport,
+  viewportMarkerOffset,
+} from "./terminal-geometry.js";
 import { currentXtermTheme } from "./theme.js";
 
 /** The attach terminal's connection state, surfaced for a small status line. */
@@ -61,6 +66,15 @@ const BACKOFF_MAX_MS = 10_000;
 // Debounce the fit→OpResize send so dragging a window edge sends one resize on
 // settle, not one per animation frame. The server echoes the winning size back.
 const RESIZE_DEBOUNCE_MS = 120;
+
+interface PendingViewportAnchor {
+  /** A marker follows the actual line while inactive output shifts the buffer. */
+  marker: IMarker | null;
+  /** Absolute fallback for a buffer where xterm cannot register a marker. */
+  line: number;
+  /** A reader already at the bottom should follow new output to the new bottom. */
+  atBottom: boolean;
+}
 
 /** ws: matching the page origin — the daemon serves the SPA over plain HTTP, so
  *  this is normally ws:. If a reverse proxy fronts the daemon and serves the page
@@ -90,6 +104,7 @@ export class AttachTerminal {
   private stopped = false;
   private everOpened = false;
   private retry = 0;
+  private initialConnectStarted = false;
   private reconnectTimer: number | null = null;
   private resizeTimer: number | null = null;
   private visibleFitFrame: number | null = null;
@@ -105,10 +120,10 @@ export class AttachTerminal {
   private lastRows = 0;
   private lastCols = 0;
   // A peer resize can temporarily collapse this client's scrollback (for example,
-  // 60 lines fit in a peer's 111-row grid). Preserve the user's local reading
-  // position independently of that reflow so the next visible-host fit can restore
-  // it. Null means no peer-owned grid is pending reconciliation.
-  private pendingViewportDistance: number | null = null;
+  // 60 lines fit in a peer's 111-row grid). Anchor the actual visible buffer line,
+  // not a one-time distance from the bottom: output can keep arriving while this
+  // client is inactive. Null means no peer-owned grid is pending reconciliation.
+  private pendingViewport: PendingViewportAnchor | null = null;
   private exited = false;
 
   // A peer is allowed to resize the one shared PTY and every client obeys that
@@ -130,7 +145,7 @@ export class AttachTerminal {
   // path; pointer entry above handles the ordinary first gesture. The pending-peer
   // gate makes every ordinary wheel a no-op before even measuring layout.
   private readonly onWheel = (): void => {
-    if (this.pendingViewportDistance !== null) {
+    if (this.pendingViewport !== null) {
       this.fitVisibleHost();
     }
   };
@@ -219,8 +234,6 @@ export class AttachTerminal {
     container.addEventListener("pointerenter", this.onPointerEnter);
     container.addEventListener("wheel", this.onWheel, { capture: true, passive: true });
     this.scheduleVisibleFit();
-
-    this.connect();
   }
 
   /** Permanently closes the terminal: stops the reconnect loop, drops the socket,
@@ -239,10 +252,7 @@ export class AttachTerminal {
       window.cancelAnimationFrame(this.visibleFitFrame);
       this.visibleFitFrame = null;
     }
-    if (this.viewportRestoreFrame !== null) {
-      window.cancelAnimationFrame(this.viewportRestoreFrame);
-      this.viewportRestoreFrame = null;
-    }
+    this.clearPendingViewport();
     this.ro.disconnect();
     this.io.disconnect();
     window.removeEventListener("focus", this.onWindowFocus);
@@ -329,6 +339,16 @@ export class AttachTerminal {
         // already closing
       }
     };
+  }
+
+  /** Starts the first connection only after a real visible-host fit. Reconnects
+   * continue through connect() directly once this boundary has been crossed. */
+  private connectAfterInitialFit(): void {
+    if (this.initialConnectStarted || this.stopped) {
+      return;
+    }
+    this.initialConnectStarted = true;
+    this.connect();
   }
 
   private onMessage(data: unknown): void {
@@ -451,48 +471,68 @@ export class AttachTerminal {
     } catch {
       return; // xterm has not painted metrics yet, or the container detached
     }
-    if (
-      !shouldRefitVisibleTerminal(
-        { width: this.container.clientWidth, height: this.container.clientHeight },
-        { rows: this.term.rows, cols: this.term.cols },
-        proposed,
-      )
-    ) {
+    const host = { width: this.container.clientWidth, height: this.container.clientHeight };
+    if (!hasVisibleTerminalGeometry(host, proposed)) {
       return;
     }
-    try {
-      this.fit.fit();
-    } catch {
-      return; // container detached between proposal and fit
+    const needsFit = shouldRefitVisibleTerminal(host, { rows: this.term.rows, cols: this.term.cols }, proposed);
+    if (needsFit) {
+      try {
+        this.fit.fit();
+      } catch {
+        return; // container detached between proposal and fit
+      }
+      this.scheduleViewportRestore(this.term.rows, this.term.cols);
+      this.sendResize(this.term.rows, this.term.cols, false);
     }
-    this.scheduleViewportRestore(this.term.rows, this.term.cols);
-    this.sendResize(this.term.rows, this.term.cols, false);
+    this.connectAfterInitialFit();
   }
 
   /** Restores the pre-peer reading position after xterm has rendered its new grid.
    *  resize() schedules the buffer reflow: reading baseY synchronously after fit can
    *  still see the peer-collapsed zero. The next painted frame is the first settled
-   *  value. A newer peer grid cancels this frame and leaves the distance pending for
+   *  value. A newer peer grid cancels this frame and leaves the anchor pending for
    *  the next local activation. */
   private scheduleViewportRestore(rows: number, cols: number): void {
-    if (this.pendingViewportDistance === null) {
+    if (this.pendingViewport === null) {
       return;
     }
-    if (this.viewportRestoreFrame !== null) {
-      window.cancelAnimationFrame(this.viewportRestoreFrame);
-    }
+    this.cancelViewportRestoreFrame();
+    const scheduledViewportY = this.term.buffer.active.viewportY;
     this.viewportRestoreFrame = window.requestAnimationFrame(() => {
       this.viewportRestoreFrame = null;
       if (this.stopped || this.term.rows !== rows || this.term.cols !== cols) {
         return;
       }
-      const distance = this.pendingViewportDistance;
-      if (distance === null) {
+      const anchor = this.pendingViewport;
+      if (anchor === null) {
         return;
       }
-      this.pendingViewportDistance = null;
-      this.term.scrollToLine(viewportLineFromBottom(this.term.buffer.active.baseY, distance));
+      const buffer = this.term.buffer.active;
+      // xterm handles wheel after our capture listener. If that changed the
+      // viewport before this frame, the user's gesture is newer than the saved
+      // anchor and must win.
+      if (!shouldRestoreViewport(scheduledViewportY, buffer.viewportY)) {
+        this.clearPendingViewport();
+        return;
+      }
+      const target = anchor.atBottom ? buffer.baseY : anchor.marker?.line ?? anchor.line;
+      this.clearPendingViewport();
+      this.term.scrollToLine(Math.max(0, target));
     });
+  }
+
+  private cancelViewportRestoreFrame(): void {
+    if (this.viewportRestoreFrame !== null) {
+      window.cancelAnimationFrame(this.viewportRestoreFrame);
+      this.viewportRestoreFrame = null;
+    }
+  }
+
+  private clearPendingViewport(): void {
+    this.cancelViewportRestoreFrame();
+    this.pendingViewport?.marker?.dispose();
+    this.pendingViewport = null;
   }
 
   private scheduleFit(): void {
@@ -533,14 +573,21 @@ export class AttachTerminal {
       // already have collapsed/reflowed the buffer, but the first boundary still
       // knows where this client was reading in its own grid. The active-host fit
       // consumes and clears this value before its own echo comes back.
-      if (this.pendingViewportDistance === null) {
+      if (this.pendingViewport === null) {
         const buffer = this.term.buffer.active;
-        this.pendingViewportDistance = Math.max(0, buffer.baseY - buffer.viewportY);
+        const atBottom = buffer.viewportY >= buffer.baseY;
+        let marker: IMarker | null = null;
+        if (!atBottom) {
+          try {
+            marker = this.term.registerMarker(viewportMarkerOffset(buffer));
+          } catch {
+            // Alternate buffers cannot register markers; the absolute line below
+            // is still safer than a bottom distance that grows stale with output.
+          }
+        }
+        this.pendingViewport = { marker, line: buffer.viewportY, atBottom };
       }
-      if (this.viewportRestoreFrame !== null) {
-        window.cancelAnimationFrame(this.viewportRestoreFrame);
-        this.viewportRestoreFrame = null;
-      }
+      this.cancelViewportRestoreFrame();
       try {
         this.term.resize(cols, rows);
       } catch {

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -45,6 +45,7 @@ import {
   hasVisibleTerminalGeometry,
   shouldRefitVisibleTerminal,
   shouldRestoreViewport,
+  viewportAnchorLine,
   viewportMarkerOffset,
 } from "./terminal-geometry.js";
 import { currentXtermTheme } from "./theme.js";
@@ -109,6 +110,10 @@ export class AttachTerminal {
   private resizeTimer: number | null = null;
   private visibleFitFrame: number | null = null;
   private viewportRestoreFrame: number | null = null;
+  // Incremented only by an actual wheel while a peer-owned anchor is pending.
+  // Output and resize reflows can move viewportY too, so position deltas alone do
+  // not prove that a user intended to override the saved reading line.
+  private userScrollRevision = 0;
 
   // The absolute replay cursor: seeded from OpHello, advanced by OpPTYOut byte
   // counts (never by OpRepaint). `seeded` gates whether a reconnect can pass a
@@ -147,6 +152,10 @@ export class AttachTerminal {
   private readonly onWheel = (): void => {
     if (this.pendingViewport !== null) {
       this.fitVisibleHost();
+      // fitVisibleHost schedules from the pre-wheel revision. xterm consumes the
+      // wheel after this capture listener, so the deferred callback sees a newer
+      // explicit user intent and leaves that first gesture authoritative.
+      this.userScrollRevision += 1;
     }
   };
 
@@ -482,9 +491,11 @@ export class AttachTerminal {
       } catch {
         return; // container detached between proposal and fit
       }
-      this.scheduleViewportRestore(this.term.rows, this.term.cols);
       this.sendResize(this.term.rows, this.term.cols, false);
     }
+    // A second peer can already have returned xterm to this host's local grid. No
+    // fit is needed in that case, but its reflow still displaced the saved line.
+    this.scheduleViewportRestore(this.term.rows, this.term.cols);
     this.connectAfterInitialFit();
   }
 
@@ -498,7 +509,7 @@ export class AttachTerminal {
       return;
     }
     this.cancelViewportRestoreFrame();
-    const scheduledViewportY = this.term.buffer.active.viewportY;
+    const scheduledUserScroll = this.userScrollRevision;
     this.viewportRestoreFrame = window.requestAnimationFrame(() => {
       this.viewportRestoreFrame = null;
       if (this.stopped || this.term.rows !== rows || this.term.cols !== cols) {
@@ -509,14 +520,23 @@ export class AttachTerminal {
         return;
       }
       const buffer = this.term.buffer.active;
-      // xterm handles wheel after our capture listener. If that changed the
-      // viewport before this frame, the user's gesture is newer than the saved
-      // anchor and must win.
-      if (!shouldRestoreViewport(scheduledViewportY, buffer.viewportY)) {
+      if (
+        !shouldRestoreViewport({
+          scheduledUserScroll,
+          currentUserScroll: this.userScrollRevision,
+        })
+      ) {
         this.clearPendingViewport();
         return;
       }
-      const target = anchor.atBottom ? buffer.baseY : anchor.marker?.line ?? anchor.line;
+      const target = viewportAnchorLine(
+        {
+          atBottom: anchor.atBottom,
+          markerLine: anchor.marker?.line ?? null,
+          fallbackLine: anchor.line,
+        },
+        buffer.baseY,
+      );
       this.clearPendingViewport();
       this.term.scrollToLine(Math.max(0, target));
     });

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -45,6 +45,8 @@ import {
   hasVisibleTerminalGeometry,
   shouldRefitVisibleTerminal,
   shouldRestoreViewport,
+  terminalUserScrollPlan,
+  type TerminalUserScrollSource,
   viewportAnchorLine,
   viewportMarkerOffset,
 } from "./terminal-geometry.js";
@@ -110,9 +112,9 @@ export class AttachTerminal {
   private resizeTimer: number | null = null;
   private visibleFitFrame: number | null = null;
   private viewportRestoreFrame: number | null = null;
-  // Incremented only by an actual wheel while a peer-owned anchor is pending.
-  // Output and resize reflows can move viewportY too, so position deltas alone do
-  // not prove that a user intended to override the saved reading line.
+  // Incremented only by an actual user scroll input while a peer-owned anchor is
+  // pending. Output and resize reflows can move viewportY too, so position deltas
+  // alone do not prove that a user intended to override the saved reading line.
   private userScrollRevision = 0;
 
   // The absolute replay cursor: seeded from OpHello, advanced by OpPTYOut byte
@@ -145,19 +147,35 @@ export class AttachTerminal {
   // clients: reconcile before the wheel gesture arrives so xterm can consume that
   // first gesture rather than making the user scroll twice.
   private readonly onPointerEnter = (): void => this.fitVisibleHost();
-  // Wheel can target an already-focused window after another client resized the PTY
-  // without the pointer ever leaving this pane. Capture repairs that less-common
+  // A scroll can target an already-focused window after another client resized the
+  // PTY without the pointer ever leaving this pane. Capture repairs that less-common
   // path; pointer entry above handles the ordinary first gesture. The pending-peer
-  // gate makes every ordinary wheel a no-op before even measuring layout.
-  private readonly onWheel = (): void => {
-    if (this.pendingViewport !== null) {
-      this.fitVisibleHost();
-      // fitVisibleHost schedules from the pre-wheel revision. xterm consumes the
-      // wheel after this capture listener, so the deferred callback sees a newer
-      // explicit user intent and leaves that first gesture authoritative.
-      this.userScrollRevision += 1;
+  // gate makes every ordinary input a no-op before even measuring layout.
+  private readonly onWheel = (): void => this.handleUserScroll("wheel");
+  private readonly onTouchMove = (): void => this.handleUserScroll("touch");
+  private readonly onPointerDown = (event: PointerEvent): void => {
+    // The xterm screen is a sibling of its scrollable viewport. A pointer whose
+    // target is the viewport itself is therefore a scrollbar/track gesture, while
+    // an ordinary terminal click targets the screen and keeps the saved anchor.
+    if (event.target === this.container.querySelector(".xterm-viewport")) {
+      this.handleUserScroll("scrollbar");
     }
   };
+
+  private handleUserScroll(source: TerminalUserScrollSource): void {
+    if (this.pendingViewport === null) {
+      return;
+    }
+    const plan = terminalUserScrollPlan(source, this.visibleFitFrame !== null);
+    if (plan.cancelScheduledVisibleFit) {
+      this.cancelVisibleFitFrame();
+    }
+    this.fitVisibleHost();
+    // fitVisibleHost schedules from the pre-input revision. xterm consumes the
+    // user gesture after this capture listener, so the deferred callback sees a
+    // newer explicit intent and leaves that first gesture authoritative.
+    this.userScrollRevision += 1;
+  }
 
   constructor(
     private readonly container: HTMLElement,
@@ -242,6 +260,8 @@ export class AttachTerminal {
     document.addEventListener("visibilitychange", this.onVisibilityChange);
     container.addEventListener("pointerenter", this.onPointerEnter);
     container.addEventListener("wheel", this.onWheel, { capture: true, passive: true });
+    container.addEventListener("touchmove", this.onTouchMove, { capture: true, passive: true });
+    container.addEventListener("pointerdown", this.onPointerDown, true);
     this.scheduleVisibleFit();
   }
 
@@ -257,10 +277,7 @@ export class AttachTerminal {
       window.clearTimeout(this.resizeTimer);
       this.resizeTimer = null;
     }
-    if (this.visibleFitFrame !== null) {
-      window.cancelAnimationFrame(this.visibleFitFrame);
-      this.visibleFitFrame = null;
-    }
+    this.cancelVisibleFitFrame();
     this.clearPendingViewport();
     this.ro.disconnect();
     this.io.disconnect();
@@ -268,6 +285,8 @@ export class AttachTerminal {
     document.removeEventListener("visibilitychange", this.onVisibilityChange);
     this.container.removeEventListener("pointerenter", this.onPointerEnter);
     this.container.removeEventListener("wheel", this.onWheel, true);
+    this.container.removeEventListener("touchmove", this.onTouchMove, true);
+    this.container.removeEventListener("pointerdown", this.onPointerDown, true);
     this.closeSocket();
     this.term.dispose();
   }
@@ -464,6 +483,17 @@ export class AttachTerminal {
       this.visibleFitFrame = null;
       this.fitVisibleHost();
     });
+  }
+
+  /** Drops activation work queued before a direct user scroll. Leaving that frame
+   * alive lets it run after the input fit and rebase the restore onto the new user
+   * revision, which makes the first gesture appear inert. */
+  private cancelVisibleFitFrame(): void {
+    if (this.visibleFitFrame === null) {
+      return;
+    }
+    window.cancelAnimationFrame(this.visibleFitFrame);
+    this.visibleFitFrame = null;
   }
 
   /** Reconciles xterm's grid with this host only when the host is measurable and the


### PR DESCRIPTION
Closes #2347.

## Reproduction and root cause

The persistent failure reproduced in a real Chromium browser with two subscribers to one PTY:

- The first desktop terminal fit its 620px host at 36 rows and rendered 60 output lines with working scrollback.
- A tall second subscriber became the last resize writer and broadcast its authoritative 111-row grid back to the first client.
- The first host did not change size, so its `ResizeObserver` had no reason to fire. Its xterm stayed at 111 rows with `scrollHeight == viewportHeight`, every wheel was inert, and a 1px window resize immediately repaired it.

The suggested construction-time hypothesis was adjacent but not the persistent cause in Chromium: a terminal opened before its pane settled initially had xterm's 24 default rows, then the observer corrected it to 36 rows on the first layout delivery and scrolling worked. The durable dead-wheel state came from an authoritative peer resize changing xterm's grid without changing the local host box.

## Change

- Refit a measurable terminal when its pane becomes visible or active: intersection, window/document activation, pane focus, pointer entry, and a peer-owned first-wheel fallback. Zero-size hosts never fit, and there is no periodic timer.
- Delay the first WebSocket connection until FitAddon has produced the visible host's real nonzero grid, so a fast connection cannot advertise xterm's constructor-default 80x24 size to other subscribers.
- Keep last-writer-wins intact while a client is inactive; activation makes the visible host the newest writer exactly once, without resize ping-pong.
- Anchor the actual visible buffer line with an xterm marker while inactive output arrives, then restore it after the local reflow even when a second peer has already returned xterm to the local grid. A wheel-intent revision—not incidental viewport motion from output—decides whether the user superseded restoration, and a disposed marker falls back to the saved absolute line.
- Treat wheel, touchmove, and scrollbar input as the same explicit user scroll intent, cancelling any older queued activation fit before it can rebase restoration over that gesture.
- Rebase over current master, including #2343's latest web bundle, and regenerate the committed bundle from the combined source.

## Regression coverage

- Unit coverage fails closed for zero-size/unresolved hosts, proves different peer geometry refits, proves matching local geometry creates no churn, gates the first connection on real geometry, anchors a visible line rather than a stale bottom distance, distinguishes explicit wheel intent from output motion, and rejects disposed marker line `-1`.
- A real desktop shell regression creates scrollback, pauses on a named visible line, lets a tall peer collapse the grid and emit more output, then proves activation restores the exact reading line without a physical resize. A second phase has the peer return the exact local grid before activation and proves restoration still runs when no fit is needed.
- A 375px real agent-terminal regression drives the actual agent PTY and gives touchmove, xterm-scrollbar input, and the first trusted wheel independent peer-owned grids. Each peer disconnects after stranding the mobile client so the assertion measures local recovery rather than a later legitimate peer resize; every input repairs the grid and scroll range without a deferred restore erasing the gesture.
- Both browser cases report host height, viewport height, scroll height, scroll position, and rendered row count at the failing boundary. Each fixture cleans up its own tab/session so a failure cannot cascade.

## Exact-head gates

Commit: `0d700a80f9b6dcbf557ac3ded6ede99bc5ca5acb`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (clean)
- `go build ./...`
- `make lint-file-length`
- `make web-test` (413/413 plus typecheck)
- `make web-build` (committed bundle clean)
- `make test-container`
- `make web-selftest-container` (116/116 real-browser scenarios)
