### PR TITLE
fix(web): persist reconciled project selection

### DIFF
--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -12192,11 +12192,11 @@ function resetStatusFilter() {
   store.set({ statusFilter: next });
 }
 function switchProject(root2) {
+  persistProjectChoice(root2);
   if (store.get().selectedProject === root2) {
     return;
   }
   clearTabError();
-  persistProjectChoice(root2);
   const sel = selectedSessionData();
   const keep = sel && sel.worktree?.repo_path === root2 ? store.get().selectedId : null;
   splitView.blur();

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "aefa8c762798";
+const VERSION = "1c1d558f55e3";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -2368,6 +2368,33 @@ test("project switcher (redesign PR2): lists projects with counts; selecting one
   await expect(row(page, SESSION_B)).toBeVisible();
 });
 
+test("#2276: selecting the reconciled project repairs a stale persisted choice", REAL_FIXTURE, async ({ browser }) => {
+  const fixtureRepo = process.env.AF_MOCK_REPO;
+  expect(fixtureRepo, "the real-project persistence regression needs AF_MOCK_REPO").toBeTruthy();
+
+  const ctx = await browser.newContext();
+  try {
+    const p = await ctx.newPage();
+    await openTokenless(p);
+    await expect(p.locator(".af-project-switch-name")).toHaveText("mock-repo");
+
+    // Reproduce the state left by a project disappearing: reconciliation has already
+    // selected a valid fallback in memory, but localStorage still names the vanished
+    // project. Clicking the checked project is the user's explicit choice to keep it,
+    // so it must repair storage even though the in-memory scope does not change.
+    await p.evaluate((stale) => localStorage.setItem("af-project", stale), `${fixtureRepo}-deleted`);
+    await p.locator(".af-project-switch").click();
+    const current = projectItem(p, "mock-repo");
+    await expect(current).toHaveAttribute("aria-selected", "true");
+    await current.click();
+    await expect(p.locator(".af-project-menu")).toBeHidden();
+
+    expect(await p.evaluate(() => localStorage.getItem("af-project"))).toBe(fixtureRepo);
+  } finally {
+    await ctx.close();
+  }
+});
+
 test("task-only project (redesign PR2, Fix 1): a repo with a task but no session lists, scopes Tasks, and its delete is disabled", REAL_FIXTURE, async () => {
   // Select the task-only project (a third repo with a task but NO session). It lists in
   // the switcher (derived from sessions OR tasks), so its tasks stay reachable.

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -501,15 +501,18 @@ function resetStatusFilter(): void {
   store.set({ statusFilter: next });
 }
 
-/** Switches the active project (redesign PR2): scope the rail + views to `root`,
- *  persist it so a reload resumes it, and drop a selection that doesn't belong to the
- *  new project (its terminal detaches). A no-op when already on that project. */
+/** Switches the active project (redesign PR2): persist the explicit choice so a
+ *  reload resumes it, scope the rail + views to `root`, and drop a selection that
+ *  doesn't belong to the new project (its terminal detaches). The in-memory update
+ *  is a no-op when already on that project, but persistence is still load-bearing:
+ *  reconciliation can choose this valid fallback while storage names a project that
+ *  just disappeared (#2276). */
 function switchProject(root: string): void {
+  persistProjectChoice(root);
   if (store.get().selectedProject === root) {
     return;
   }
   clearTabError();
-  persistProjectChoice(root);
   // Keep the current selection only if it lives in the newly selected project; else
   // clear it so the main pane returns to its empty state instead of showing a session
   // hidden from the scoped rail.


### PR DESCRIPTION
Closes #2276.

## What changed

- Persist an explicit project choice before the in-memory no-op check.
- Keep the existing no-op behavior for rail/view state when the chosen project is already active.
- Add a real rendered-browser regression that seeds a vanished project in localStorage, clicks the already-selected reconciled fallback, and proves storage is repaired.
- Rebuild the committed web bundle.

## Reproduction and regression

The fail-first commit ran the full rendered browser suite against production `switchProject` through the project menu. All 113 existing cases passed; the new case alone failed because localStorage remained `/work/mock-repo-deleted` instead of `/work/mock-repo`.

On reviewed head `5d86c7d283fa716b8540c0e6ad3388e9c0dfefd1`, the rendered suite passes 114/114, including 320 px and 375 px mobile coverage. The production caller is the project switcher menu in `web/src/ui.ts`; its choices come from the reconciled project catalog, so persisting before the no-op check cannot introduce an unknown root.

## Exact-head gates

- `golangci-lint run --timeout=3m --fast`
- clean `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make web-test` — 404/404
- `make web-build` with clean committed `web/dist`
- `make web-selftest-container` — 114/114
- `make test-container`
