### PR TITLE
feat(daemon): diagnose supervision and config skew

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ A fresh install has no autostart unit — run `af daemon install` to register on
 (a systemd user service on Linux, a launchd agent on macOS) so the daemon starts
 at login and task schedules keep running across reboots. Both are user-level
 units, so they cover login and reboot, not running while you are logged out.
-`af daemon status` reports whether one is installed.
+`af daemon status` reports whether one is installed and active, whether it owns
+the daemon that answered, and whether that daemon has applied the config on disk.
 
 ## Documentation
 

--- a/commands/daemoncmd.go
+++ b/commands/daemoncmd.go
@@ -110,9 +110,9 @@ var daemonUninstallCmd = &cobra.Command{
 var daemonStatusJSON bool
 
 // daemonStatusInfo is the read-only liveness/topology snapshot printed by
-// `af daemon status`. It is derived entirely from daemon.Health() (the same
-// no-spawn probe `af doctor` uses) plus an os.Stat of the HTTP socket, so the
-// command never dials or starts a daemon and needs no new RPC.
+// `af daemon status`. It is derived from daemon.Health() (the same no-spawn
+// Ping `af doctor` uses), a bounded read-only service-manager probe, and an
+// os.Stat of the HTTP socket. It never starts, stops, or reloads anything.
 type daemonStatusInfo struct {
 	Running           bool                         `json:"running"`
 	Version           string                       `json:"version,omitempty"`
@@ -126,7 +126,16 @@ type daemonStatusInfo struct {
 	HTTPSocketFile    bool                         `json:"http_socket_file"`
 	PID               int                          `json:"pid"`
 	PIDVerified       bool                         `json:"pid_verified"`
+	ServingPID        int                          `json:"serving_pid,omitempty"`
 	AutostartUnit     bool                         `json:"autostart_unit"`
+	AutostartEnabled  string                       `json:"autostart_enabled,omitempty"`
+	AutostartActive   string                       `json:"autostart_active,omitempty"`
+	UnitPID           int                          `json:"unit_pid,omitempty"`
+	Supervised        string                       `json:"serving_daemon_supervised,omitempty"`
+	SupervisionDetail string                       `json:"supervision_detail,omitempty"`
+	BootConfig        *daemon.DaemonBootConfig     `json:"boot_config,omitempty"`
+	ConfigMatches     string                       `json:"config_matches_running_daemon,omitempty"`
+	ConfigDetail      string                       `json:"config_detail,omitempty"`
 	BinaryStale       bool                         `json:"binary_stale"`
 	// ExposureWarning is non-empty when the config on disk serves the control API
 	// unauthenticated on a network address (#2090) — an ALLOWED posture since
@@ -145,7 +154,18 @@ type daemonStatusInfo struct {
 // stat'd; a missing config dir leaves the field empty rather than erroring, so
 // status still reports the control-plane facts.
 func collectDaemonStatus() daemonStatusInfo {
-	h := daemon.Health()
+	h := daemonHealthFn()
+	unitServesHome, unitInstalled := false, h.AutostartUnit
+	var unitScopeErr error
+	if configDir, err := configDirFn(); err != nil {
+		unitScopeErr = fmt.Errorf("cannot resolve the config dir to scope the autostart unit: %w", err)
+	} else {
+		unitServesHome, unitInstalled, unitScopeErr = autostartUnitServesHomeFn(configDir)
+	}
+	var supervision daemon.SupervisionInfo
+	if unitScopeErr == nil && unitServesHome {
+		supervision = daemonStatusSupervisionFn()
+	}
 	info := daemonStatusInfo{
 		Running:           h.PingErr == nil,
 		Version:           h.DaemonVersion,
@@ -156,8 +176,15 @@ func collectDaemonStatus() daemonStatusInfo {
 		ControlSocketFile: h.SocketExists,
 		PID:               h.PIDFilePID,
 		PIDVerified:       h.PIDVerified,
-		AutostartUnit:     h.AutostartUnit,
+		ServingPID:        h.ServingPID,
+		AutostartUnit:     unitServesHome || (unitScopeErr != nil && unitInstalled),
+		BootConfig:        h.BootConfig,
 		BinaryStale:       h.BinaryDeleted,
+	}
+	if unitServesHome {
+		info.AutostartEnabled = supervision.Enabled.String()
+		info.AutostartActive = supervision.Active.String()
+		info.UnitPID = supervision.MainPID
 	}
 	if h.PingErr == nil && h.Phase != "" {
 		listeners := h.Listeners
@@ -172,11 +199,31 @@ func collectDaemonStatus() daemonStatusInfo {
 	// Read-only (LoadConfigReadOnly materializes and converts nothing, so `af
 	// daemon status` never writes config as a side effect). Reported whether or
 	// not a daemon is running: an exposed listener is most worth saying when it is
-	// actually being served. This reads the config on disk, which a long-running
-	// daemon may predate — reporting the posture the RUNNING daemon booted with
-	// needs a Ping that carries it (#2168 Phase 4).
+	// actually being served. The comparison below pairs this disk read with the
+	// immutable posture returned by the running daemon's Ping (#2168 Phase 4).
+	var current *config.Config
 	if load, err := config.LoadConfigReadOnly(); err == nil {
-		info.ExposureWarning = config.ListenerExposureNotice(load.Config)
+		current = load.Config
+		info.ExposureWarning = config.ListenerExposureNotice(current)
+	}
+	if info.Running {
+		supervised := daemon.AnswerNo()
+		if unitScopeErr != nil {
+			supervised = daemon.Undetermined(fmt.Errorf("cannot tell whether the installed autostart unit serves this home: %w", unitScopeErr))
+		} else if unitServesHome {
+			supervised = daemon.ServingDaemonSupervised(h, supervision)
+		}
+		info.Supervised = supervised.String()
+		if cause := supervised.Cause(); cause != nil {
+			info.SupervisionDetail = cause.Error()
+		}
+		matches := daemon.RunningConfigMatches(h, current)
+		info.ConfigMatches = matches.String()
+		if cause := matches.Cause(); cause != nil {
+			info.ConfigDetail = cause.Error()
+		} else if info.ConfigMatches == daemon.AnswerNo().String() {
+			info.ConfigDetail = daemon.RunningConfigDifference(h.BootConfig, current)
+		}
 	}
 	return info
 }
@@ -233,10 +280,58 @@ func printDaemonStatusHuman(cmd *cobra.Command, info daemonStatusInfo) {
 	} else {
 		fmt.Fprintln(w, "  pid:            (no daemon.pid on disk)")
 	}
+	if info.ServingPID > 0 {
+		fmt.Fprintf(w, "  responder pid:  %d\n", info.ServingPID)
+	}
 	if info.AutostartUnit {
-		fmt.Fprintln(w, "  autostart:      installed")
+		enabled, active := info.AutostartEnabled, info.AutostartActive
+		if enabled == "" {
+			enabled = "unknown"
+		}
+		if active == "" {
+			active = "unknown"
+		}
+		fmt.Fprintf(w, "  autostart:      installed · enabled=%s · active=%s\n", enabled, active)
 	} else {
-		fmt.Fprintln(w, "  autostart:      not installed (`af daemon install` to keep schedules running across reboots)")
+		fmt.Fprintln(w, "  autostart:      no unit for this home (`af daemon install` to keep schedules running across reboots)")
+	}
+	if info.Running {
+		switch info.Supervised {
+		case "yes":
+			fmt.Fprintf(w, "  supervision:    installed unit owns responding daemon pid %d\n", info.ServingPID)
+		case "no":
+			switch {
+			case !info.AutostartUnit:
+				fmt.Fprintln(w, "  warning:        responding daemon is not supervised because no autostart unit serves this home")
+			case info.AutostartActive == "no" || info.AutostartActive == "not-found":
+				fmt.Fprintln(w, "  warning:        daemon is responding, but the installed unit is not running it — the responder is not supervised")
+			case info.UnitPID > 0:
+				fmt.Fprintf(w, "  warning:        responding daemon pid %d is not supervised by the installed unit, which owns pid %d\n",
+					info.ServingPID, info.UnitPID)
+			default:
+				fmt.Fprintln(w, "  warning:        responding daemon is not supervised by the installed unit")
+			}
+		default:
+			detail := info.SupervisionDetail
+			if detail == "" {
+				detail = "the service manager or responding daemon did not report enough identity information"
+			}
+			fmt.Fprintf(w, "  supervision:    unknown (%s)\n", detail)
+		}
+
+		switch info.ConfigMatches {
+		case "yes":
+			fmt.Fprintln(w, "  daemon config:  file matches the running daemon")
+		case "no":
+			fmt.Fprintf(w, "  warning:        config on disk differs from the running daemon (%s) — restart the daemon to apply it\n",
+				info.ConfigDetail)
+		default:
+			detail := info.ConfigDetail
+			if detail == "" {
+				detail = "the responding daemon did not report its boot config"
+			}
+			fmt.Fprintf(w, "  daemon config:  unknown (%s)\n", detail)
+		}
 	}
 	if info.BinaryStale {
 		fmt.Fprintf(w, "  warning:        pid %d is running a binary since replaced on disk — restart the daemon to pick up the new version\n", info.PID)
@@ -256,15 +351,15 @@ func presence(exists bool) string {
 
 var daemonStatusCmd = &cobra.Command{
 	Use:   "status",
-	Short: "Report daemon liveness, sockets, pid, and autostart",
+	Short: "Report daemon liveness, config freshness, and supervision",
 	Long: `Print a read-only snapshot of the background daemon: whether it is responding
 on the control socket, the control and HTTP socket paths (and whether their
-files are present), the recorded pid and whether it is a verified af daemon,
-whether the autostart unit is installed, and whether the running daemon is on a
-since-replaced binary.
+files are present), the recorded and responding pids, whether the installed
+autostart unit owns that responding process, whether the config on disk matches
+what the daemon booted with, and whether the running binary was replaced.
 
 It never contacts a paused daemon in a way that spawns one and never starts the
-daemon — it uses the same no-spawn health probe as af doctor. Use --json for a
+daemon. Service-manager inspection is bounded and read-only. Use --json for a
 machine-readable form wrapped in the shared {data,error} envelope.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -380,6 +475,7 @@ var (
 	refreshAutostartUnitFn      = daemon.RefreshAutostartUnit
 	configDirFn                 = config.GetConfigDir
 	daemonRestartPresenceFn     = probeDaemonRestartPresence
+	daemonStatusSupervisionFn   = daemon.AutostartSupervision
 )
 
 // probeDaemonRestartPresence gives the explicit restart command a three-value

--- a/commands/daemonstatuscmd_test.go
+++ b/commands/daemonstatuscmd_test.go
@@ -2,6 +2,8 @@ package commands
 
 import (
 	"bytes"
+	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -85,6 +87,183 @@ func TestPrintDaemonStatusHumanRunning(t *testing.T) {
 			t.Errorf("human output missing %q\n%s", want, got)
 		}
 	}
+}
+
+// A unit file on disk is not evidence that it owns the daemon which answered
+// Ping. Before #2168 Phase 4 status printed only "autostart: installed", the
+// exact reassurance shown during the incident while an ad-hoc daemon served.
+func TestPrintDaemonStatusHumanInstalledUnitDoesNotImplySupervision(t *testing.T) {
+	cmd := &cobra.Command{}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	printDaemonStatusHuman(cmd, daemonStatusInfo{
+		Running:       true,
+		PID:           42,
+		PIDVerified:   true,
+		AutostartUnit: true,
+	})
+
+	got := out.String()
+	require.Contains(t, got, "supervision:",
+		"status must distinguish an installed unit from a unit proven to own the responder")
+	require.Contains(t, got, "unknown",
+		"an absent service-manager answer is unknown, never an implied supervised yes")
+}
+
+func TestCollectDaemonStatusCorrelatesResponderUnitAndConfig(t *testing.T) {
+	home := testguard.SocketTempDir(t)
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	require.NoError(t, os.WriteFile(filepath.Join(home, config.TomlConfigFileName),
+		[]byte("listen_addr = '127.0.0.1:8443'\nrequire_token = true\n"), 0600))
+
+	previousHealth := daemonHealthFn
+	previousScope := autostartUnitServesHomeFn
+	previousSupervision := daemonStatusSupervisionFn
+	t.Cleanup(func() {
+		daemonHealthFn = previousHealth
+		autostartUnitServesHomeFn = previousScope
+		daemonStatusSupervisionFn = previousSupervision
+	})
+	daemonHealthFn = func() daemon.HealthStatus {
+		return daemon.HealthStatus{
+			ServingPID:    42,
+			BootConfig:    &daemon.DaemonBootConfig{ListenAddr: "0.0.0.0:8443", RequireToken: false},
+			AutostartUnit: true,
+		}
+	}
+	autostartUnitServesHomeFn = func(string) (bool, bool, error) { return true, true, nil }
+	daemonStatusSupervisionFn = func() daemon.SupervisionInfo {
+		return daemon.SupervisionInfo{
+			Supported: true, UnitPresent: true, Enabled: daemon.AnswerYes(), Active: daemon.AnswerYes(),
+			MainPID: 42, MainPIDPresent: daemon.AnswerYes(),
+		}
+	}
+
+	info := collectDaemonStatus()
+	require.True(t, info.Running)
+	require.Equal(t, "yes", info.Supervised)
+	require.Equal(t, "no", info.ConfigMatches)
+	require.Contains(t, info.ConfigDetail, "listen_addr")
+	require.Contains(t, info.ConfigDetail, "require_token")
+}
+
+func TestCollectDaemonStatusDoesNotAttributeForeignHomeUnit(t *testing.T) {
+	home := testguard.SocketTempDir(t)
+	t.Setenv("AGENT_FACTORY_HOME", home)
+
+	previousHealth := daemonHealthFn
+	previousScope := autostartUnitServesHomeFn
+	previousSupervision := daemonStatusSupervisionFn
+	t.Cleanup(func() {
+		daemonHealthFn = previousHealth
+		autostartUnitServesHomeFn = previousScope
+		daemonStatusSupervisionFn = previousSupervision
+	})
+	daemonHealthFn = func() daemon.HealthStatus {
+		return daemon.HealthStatus{ServingPID: 42, AutostartUnit: true}
+	}
+	autostartUnitServesHomeFn = func(got string) (bool, bool, error) {
+		require.Equal(t, home, got)
+		return false, true, nil
+	}
+	daemonStatusSupervisionFn = func() daemon.SupervisionInfo {
+		t.Fatal("status must not query or attribute another home's service-manager unit")
+		return daemon.SupervisionInfo{}
+	}
+
+	info := collectDaemonStatus()
+	require.False(t, info.AutostartUnit)
+	require.Empty(t, info.AutostartEnabled)
+	require.Empty(t, info.AutostartActive)
+	require.Zero(t, info.UnitPID)
+	require.Equal(t, "no", info.Supervised, "this home has no unit supervising its responder")
+}
+
+func TestCollectDaemonStatusNoUnitOmitsInapplicableManagerState(t *testing.T) {
+	home := testguard.SocketTempDir(t)
+	t.Setenv("AGENT_FACTORY_HOME", home)
+
+	previousHealth := daemonHealthFn
+	previousScope := autostartUnitServesHomeFn
+	previousSupervision := daemonStatusSupervisionFn
+	t.Cleanup(func() {
+		daemonHealthFn = previousHealth
+		autostartUnitServesHomeFn = previousScope
+		daemonStatusSupervisionFn = previousSupervision
+	})
+	daemonHealthFn = func() daemon.HealthStatus {
+		return daemon.HealthStatus{PingErr: errors.New("no daemon")}
+	}
+	autostartUnitServesHomeFn = func(string) (bool, bool, error) { return false, false, nil }
+	daemonStatusSupervisionFn = func() daemon.SupervisionInfo {
+		t.Fatal("no installed unit means there is no service-manager state to query")
+		return daemon.SupervisionInfo{}
+	}
+
+	data, err := json.Marshal(collectDaemonStatus())
+	require.NoError(t, err)
+	var wire map[string]any
+	require.NoError(t, json.Unmarshal(data, &wire))
+	require.Equal(t, false, wire["autostart_unit"])
+	require.NotContains(t, wire, "autostart_enabled")
+	require.NotContains(t, wire, "autostart_active")
+	require.NotContains(t, wire, "unit_pid")
+}
+
+func TestCollectDaemonStatusUnitScopeFailureStaysUnknown(t *testing.T) {
+	home := testguard.SocketTempDir(t)
+	t.Setenv("AGENT_FACTORY_HOME", home)
+
+	previousHealth := daemonHealthFn
+	previousScope := autostartUnitServesHomeFn
+	previousSupervision := daemonStatusSupervisionFn
+	t.Cleanup(func() {
+		daemonHealthFn = previousHealth
+		autostartUnitServesHomeFn = previousScope
+		daemonStatusSupervisionFn = previousSupervision
+	})
+	daemonHealthFn = func() daemon.HealthStatus {
+		return daemon.HealthStatus{ServingPID: 42, AutostartUnit: true}
+	}
+	autostartUnitServesHomeFn = func(string) (bool, bool, error) {
+		return false, true, errors.New("unit file is unreadable")
+	}
+	daemonStatusSupervisionFn = func() daemon.SupervisionInfo {
+		t.Fatal("an unscoped unit must not be attributed through the service manager")
+		return daemon.SupervisionInfo{}
+	}
+
+	info := collectDaemonStatus()
+	require.True(t, info.AutostartUnit, "the file is known to exist even though its home is unknown")
+	require.Equal(t, "unknown", info.Supervised)
+	require.Contains(t, info.SupervisionDetail, "unit file is unreadable")
+	require.Empty(t, info.AutostartEnabled)
+	require.Empty(t, info.AutostartActive)
+}
+
+func TestPrintDaemonStatusHumanNamesPIDMismatchAndStaleConfig(t *testing.T) {
+	cmd := &cobra.Command{}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	printDaemonStatusHuman(cmd, daemonStatusInfo{
+		Running:          true,
+		ServingPID:       42,
+		AutostartUnit:    true,
+		AutostartEnabled: "yes",
+		AutostartActive:  "yes",
+		UnitPID:          99,
+		Supervised:       "no",
+		ConfigMatches:    "no",
+		ConfigDetail:     `listen_addr: running "0.0.0.0:8443", file "127.0.0.1:8443"`,
+	})
+
+	got := out.String()
+	require.Contains(t, got, "responding daemon pid 42 is not supervised")
+	require.Contains(t, got, "installed unit, which owns pid 99")
+	require.Contains(t, got, "config on disk differs from the running daemon")
+	require.Contains(t, got, "restart the daemon to apply it")
 }
 
 func TestPrintDaemonStatusHumanNotRunning(t *testing.T) {

--- a/daemon/autostart_inspect.go
+++ b/daemon/autostart_inspect.go
@@ -7,6 +7,7 @@ import (
 	"html"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -170,6 +171,11 @@ type SupervisionInfo struct {
 	// Active reports whether the service manager is currently RUNNING the
 	// daemon — systemd is-active, or a launchd job with a live process.
 	Active ProbeAnswer
+	// MainPID is the live process owned by the service manager. It is meaningful
+	// only when MainPIDPresent is Yes. Keeping the answer separate preserves the
+	// difference between pid 0 and a query that never completed.
+	MainPID        int
+	MainPIDPresent ProbeAnswer
 	// Loaded reports that launchd knows the job in Domain. Loaded without
 	// Active is a real and quiet state: the agent is installed and registered,
 	// so everything looks configured, while no daemon process is running.
@@ -225,9 +231,18 @@ func AutostartSupervision() SupervisionInfo {
 		}
 		active, activeWord := systemdAsk(systemdIsActive)
 		info.Active = active
+		active.Match(
+			func() { info.MainPID, info.MainPIDPresent = systemdMainPID() },
+			func() { info.MainPIDPresent = AnswerNo() },
+			func() { info.MainPIDPresent = AnswerNotFound() },
+			func(cause error) { info.MainPIDPresent = Undetermined(cause) },
+		)
 		// The manager's own words, not our answer names: "failed" and
 		// "inactive" are both No, and the difference is the user's to see.
 		info.Detail = fmt.Sprintf("is-enabled=%s is-active=%s", enabledWord, activeWord)
+		if info.MainPID > 0 {
+			info.Detail += fmt.Sprintf(" main-pid=%d", info.MainPID)
+		}
 	case "darwin":
 		info.Domain = launchdDomainTarget()
 		info.Enabled = launchdEnabled()
@@ -246,11 +261,18 @@ func AutostartSupervision() SupervisionInfo {
 			// is alive: it reports the service's properties, including a state
 			// and last exit status, for a loaded job whose process has stopped.
 			info.Loaded, info.LoadedElsewhere = AnswerYes(), AnswerNo()
-			if launchdJobRunning(out) {
+			if pid, ok := launchdJobPID(out); ok {
 				info.Active = AnswerYes()
+				info.MainPID = pid
+				info.MainPIDPresent = AnswerYes()
+				info.Detail = "loaded and running in " + info.Domain
+			} else if launchdJobRunning(out) {
+				info.Active = AnswerYes()
+				info.MainPIDPresent = Undetermined(errors.New("launchd reports the job running but did not report its pid"))
 				info.Detail = "loaded and running in " + info.Domain
 			} else {
 				info.Active = AnswerNo()
+				info.MainPIDPresent = AnswerNo()
 				info.Detail = "loaded in " + info.Domain + " but no daemon process is running"
 			}
 		case launchdSaysNotFound(out, print.ExitCode()):
@@ -412,6 +434,30 @@ func systemdAsk(verb string) (ProbeAnswer, string) {
 	// what it means, and guessing in EITHER direction is how this bug family
 	// works.
 	return Undetermined(systemdProbeErr(verb, out)), "unknown"
+}
+
+// systemdMainPID asks the same manager which answered is-active for the exact
+// process it owns. The command is separately bounded by autostartProbeCommand;
+// a timeout or malformed answer stays unknown and can never become pid 0.
+func systemdMainPID() (int, ProbeAnswer) {
+	res := autostartProbeCommand("systemctl", "--user", "show", autostartUnitName, "--property=MainPID", "--value")
+	out, ok := res.Output()
+	if !ok {
+		return 0, Undetermined(fmt.Errorf("could not query systemd (show MainPID): %w", res.Cause()))
+	}
+	if !res.Succeeded() {
+		return 0, Undetermined(systemdProbeErr("show MainPID", out))
+	}
+	word := strings.TrimSpace(firstLine(out))
+	word = strings.TrimSpace(strings.TrimPrefix(word, "MainPID="))
+	pid, err := strconv.Atoi(word)
+	if err != nil || pid < 0 {
+		return 0, Undetermined(fmt.Errorf("systemd returned an invalid MainPID %q", word))
+	}
+	if pid == 0 {
+		return 0, AnswerNo()
+	}
+	return pid, AnswerYes()
 }
 
 const (
@@ -670,4 +716,21 @@ func launchdJobRunning(out string) bool {
 		}
 	}
 	return running
+}
+
+// launchdJobPID extracts the live pid from the same `launchctl print` block
+// used for Active, so ownership never depends on a second racy manager query.
+func launchdJobPID(out string) (int, bool) {
+	for _, line := range strings.Split(out, "\n") {
+		field := strings.TrimSpace(line)
+		raw, ok := strings.CutPrefix(field, "pid = ")
+		if !ok {
+			continue
+		}
+		pid, err := strconv.Atoi(strings.TrimSpace(raw))
+		if err == nil && pid > 0 {
+			return pid, true
+		}
+	}
+	return 0, false
 }

--- a/daemon/autostart_inspect_test.go
+++ b/daemon/autostart_inspect_test.go
@@ -177,6 +177,8 @@ func TestAutostartSupervision_LinuxEnabledActive(t *testing.T) {
 			return answered("enabled\n", 0)
 		case "is-active":
 			return answered("active\n", 0)
+		case "show":
+			return answered("4242\n", 0)
 		}
 		return neverAnswered(errFake)
 	})
@@ -185,6 +187,31 @@ func TestAutostartSupervision_LinuxEnabledActive(t *testing.T) {
 	require.True(t, info.UnitPresent)
 	requireAnswer(t, "yes", info.Enabled)
 	requireAnswer(t, "yes", info.Active)
+	requireAnswer(t, "yes", info.MainPIDPresent)
+	require.Equal(t, 4242, info.MainPID)
+}
+
+func TestAutostartSupervision_ActiveButMainPIDProbeFailsIsUnknown(t *testing.T) {
+	dir := withAutostartTestEnv(t, "linux")
+	writeUnitFile(t, filepath.Join(dir, autostartUnitName), systemdAutostartUnit("/usr/local/bin/af", "", "", ""))
+
+	withProbeCommand(t, func(_ string, args ...string) probeResult {
+		switch args[1] {
+		case "is-enabled":
+			return answered("enabled\n", 0)
+		case "is-active":
+			return answered("active\n", 0)
+		case "show":
+			return neverAnswered(errors.New("user bus disappeared"))
+		}
+		return neverAnswered(errFake)
+	})
+
+	info := AutostartSupervision()
+	requireAnswer(t, "yes", info.Active, "systemd did answer that the unit is active")
+	requireAnswer(t, "unknown", info.MainPIDPresent,
+		"losing the second query must not become pid 0 or a supervision mismatch")
+	require.Contains(t, info.MainPIDPresent.Cause().Error(), "user bus disappeared")
 }
 
 func TestAutostartSupervision_LinuxInactive(t *testing.T) {
@@ -284,6 +311,17 @@ func TestLaunchdJobRunning_ReadsState(t *testing.T) {
 	require.False(t, launchdJobRunning("\tpid = \n"), "an empty pid is not a pid")
 }
 
+func TestLaunchdJobPIDRequiresPositiveInteger(t *testing.T) {
+	pid, ok := launchdJobPID("\tstate = running\n\tpid = 4321\n")
+	require.True(t, ok)
+	require.Equal(t, 4321, pid)
+
+	for _, out := range []string{"\tstate = running\n", "\tpid = \n", "\tpid = nope\n", "\tpid = 0\n"} {
+		_, ok := launchdJobPID(out)
+		require.False(t, ok, "invalid launchd pid output must not become ownership evidence: %q", out)
+	}
+}
+
 func TestAutostartSupervision_DarwinLoadedInGUIDomain(t *testing.T) {
 	dir := withAutostartTestEnv(t, "darwin")
 	writeUnitFile(t, filepath.Join(dir, autostartLaunchdLabel+".plist"),
@@ -305,6 +343,8 @@ func TestAutostartSupervision_DarwinLoadedInGUIDomain(t *testing.T) {
 	requireAnswer(t, "yes", info.Loaded)
 	requireAnswer(t, "yes", info.Active)
 	requireAnswer(t, "no", info.LoadedElsewhere)
+	requireAnswer(t, "yes", info.MainPIDPresent)
+	require.Equal(t, 4321, info.MainPID)
 }
 
 func TestAutostartSupervision_DarwinNotLoaded(t *testing.T) {

--- a/daemon/control_server.go
+++ b/daemon/control_server.go
@@ -27,12 +27,20 @@ type controlServer struct {
 func (s *controlServer) Ping(_ PingRequest, resp *PingResponse) error {
 	resp.OK = true
 	resp.Version = Version()
+	resp.PID = os.Getpid()
 	if s.manager != nil && s.manager.lifecycle != nil {
 		state := s.manager.lifecycle.snapshot()
 		resp.BootID = state.bootID
 		resp.TransactionID = state.transactionID
 		resp.Phase = state.phase
 		resp.Listeners = state.listeners
+	}
+	if s.manager != nil && s.manager.cfg != nil {
+		resp.BootConfig = &DaemonBootConfig{
+			ListenAddr:           s.manager.cfg.ListenAddr,
+			RequireToken:         s.manager.cfg.RequireToken,
+			RequireLoopbackToken: s.manager.cfg.RequireLoopbackToken,
+		}
 	}
 	return nil
 }

--- a/daemon/control_types.go
+++ b/daemon/control_types.go
@@ -450,6 +450,17 @@ type ResumeStatusPollResponse struct {
 // #1145).
 
 type PingRequest struct{}
+
+// DaemonBootConfig is the small immutable config posture a running daemon
+// reports through Ping. It is deliberately narrower than config.Config: status
+// only needs the listener/auth values that can differ after a supported
+// hand-edit, and Ping must never become a general config or secret export.
+type DaemonBootConfig struct {
+	ListenAddr           string `json:"listen_addr"`
+	RequireToken         bool   `json:"require_token"`
+	RequireLoopbackToken bool   `json:"require_loopback_token"`
+}
+
 type PingResponse struct {
 	OK bool `json:"ok"`
 	// Version is the af build version the responding daemon is running, so a
@@ -474,6 +485,14 @@ type PingResponse struct {
 	// and ordinary mutations have been admitted.
 	Phase     DaemonPhase          `json:"phase,omitempty"`
 	Listeners DaemonListenerStatus `json:"listeners"`
+	// PID identifies the process which answered this Ping. daemon.pid is only a
+	// disk record and can be stale, so it cannot prove that the service manager's
+	// MainPID owns the responder (#2168 Phase 4).
+	PID int `json:"pid,omitempty"`
+	// BootConfig is nil only for a responder predating this additive field (or a
+	// synthetic test server with no manager). A pointer preserves the difference
+	// between an older daemon and the valid false value of RequireToken.
+	BootConfig *DaemonBootConfig `json:"boot_config,omitempty"`
 }
 
 type ReloadTasksRequest struct{}

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -34,6 +34,12 @@ type HealthStatus struct {
 	TransactionID string
 	Phase         DaemonPhase
 	Listeners     DaemonListenerStatus
+	// ServingPID and BootConfig come from the process that answered Ping. They
+	// are authoritative for supervision/config-skew diagnosis; PIDFilePID and a
+	// fresh config read cannot say which process answered or what it booted with.
+	// Zero/nil with PingErr == nil means the responder predates these fields.
+	ServingPID int
+	BootConfig *DaemonBootConfig
 	// HTTPSocketPath is the daemon's HTTP/JSON socket location.
 	HTTPSocketPath string
 	// HTTPSocketExists reports whether HTTPSocketPath is present on disk.
@@ -86,6 +92,8 @@ func Health() HealthStatus {
 		h.TransactionID = ping.TransactionID
 		h.Phase = ping.Phase
 		h.Listeners = ping.Listeners
+		h.ServingPID = ping.PID
+		h.BootConfig = ping.BootConfig
 	}
 	h.HTTPSocketPath, h.HTTPSocketExists, h.HTTPListening = probeHTTPSocket()
 	h.AutostartUnit = AutostartInstalled()

--- a/daemon/runtime_diagnostics.go
+++ b/daemon/runtime_diagnostics.go
@@ -1,0 +1,91 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+// ServingDaemonSupervised correlates the one process which answered Ping with
+// the installed unit's live MainPID. It never infers a negative from a failed
+// service-manager probe: missing evidence stays Undetermined.
+func ServingDaemonSupervised(h HealthStatus, supervision SupervisionInfo) ProbeAnswer {
+	if h.PingErr != nil {
+		return Undetermined(fmt.Errorf("no daemon answered Ping: %w", h.PingErr))
+	}
+	if !supervision.Supported {
+		return Undetermined(errors.New("this platform has no supported autostart supervision probe"))
+	}
+	if !supervision.UnitPresent {
+		return AnswerNo()
+	}
+
+	var result ProbeAnswer
+	supervision.Active.Match(
+		func() {
+			if h.ServingPID <= 0 {
+				result = Undetermined(errors.New("the responding daemon predates Ping PID reporting"))
+				return
+			}
+			supervision.MainPIDPresent.Match(
+				func() {
+					if supervision.MainPID == h.ServingPID {
+						result = AnswerYes()
+					} else {
+						result = AnswerNo()
+					}
+				},
+				func() { result = AnswerNo() },
+				func() { result = AnswerNo() },
+				func(cause error) { result = Undetermined(cause) },
+			)
+		},
+		func() { result = AnswerNo() },
+		func() { result = AnswerNo() },
+		func(cause error) { result = Undetermined(cause) },
+	)
+	return result
+}
+
+// RunningConfigMatches reports whether the listener/auth posture on disk is
+// the posture the responding daemon actually booted with. An older responder
+// or a failed config load is an evidence gap, not a mismatch.
+func RunningConfigMatches(h HealthStatus, current *config.Config) ProbeAnswer {
+	if h.PingErr != nil {
+		return Undetermined(fmt.Errorf("no daemon answered Ping: %w", h.PingErr))
+	}
+	if h.BootConfig == nil {
+		return Undetermined(errors.New("the responding daemon predates boot-config reporting"))
+	}
+	if current == nil {
+		return Undetermined(errors.New("the on-disk config could not be loaded"))
+	}
+	if strings.TrimSpace(h.BootConfig.ListenAddr) == strings.TrimSpace(current.ListenAddr) &&
+		h.BootConfig.RequireToken == current.RequireToken &&
+		h.BootConfig.RequireLoopbackToken == current.RequireLoopbackToken {
+		return AnswerYes()
+	}
+	return AnswerNo()
+}
+
+// RunningConfigDifference renders only the non-secret fields which differ.
+// Empty means no known difference (including unavailable evidence).
+func RunningConfigDifference(boot *DaemonBootConfig, current *config.Config) string {
+	if boot == nil || current == nil {
+		return ""
+	}
+	var diffs []string
+	if strings.TrimSpace(boot.ListenAddr) != strings.TrimSpace(current.ListenAddr) {
+		diffs = append(diffs, fmt.Sprintf("listen_addr: running %q, file %q", boot.ListenAddr, current.ListenAddr))
+	}
+	if boot.RequireToken != current.RequireToken {
+		diffs = append(diffs, fmt.Sprintf("require_token: running %t, file %t", boot.RequireToken, current.RequireToken))
+	}
+	if boot.RequireLoopbackToken != current.RequireLoopbackToken {
+		diffs = append(diffs, fmt.Sprintf("require_loopback_token: running %t, file %t",
+			boot.RequireLoopbackToken, current.RequireLoopbackToken))
+	}
+	return strings.Join(diffs, "; ")
+}

--- a/daemon/runtime_diagnostics_test.go
+++ b/daemon/runtime_diagnostics_test.go
@@ -1,0 +1,121 @@
+package daemon
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServingDaemonSupervised_CorrelatesResponderAndManager(t *testing.T) {
+	responding := HealthStatus{ServingPID: 42}
+	cases := []struct {
+		name string
+		h    HealthStatus
+		sup  SupervisionInfo
+		want string
+	}{
+		{
+			name: "same live pid",
+			h:    responding,
+			sup: SupervisionInfo{Supported: true, UnitPresent: true, Active: AnswerYes(),
+				MainPID: 42, MainPIDPresent: AnswerYes()},
+			want: "yes",
+		},
+		{
+			name: "different live pid",
+			h:    responding,
+			sup: SupervisionInfo{Supported: true, UnitPresent: true, Active: AnswerYes(),
+				MainPID: 99, MainPIDPresent: AnswerYes()},
+			want: "no",
+		},
+		{
+			name: "installed unit inactive",
+			h:    responding,
+			sup:  SupervisionInfo{Supported: true, UnitPresent: true, Active: AnswerNo()},
+			want: "no",
+		},
+		{
+			name: "no unit",
+			h:    responding,
+			sup:  SupervisionInfo{Supported: true},
+			want: "no",
+		},
+		{
+			name: "older responder has no pid",
+			h:    HealthStatus{},
+			sup: SupervisionInfo{Supported: true, UnitPresent: true, Active: AnswerYes(),
+				MainPID: 42, MainPIDPresent: AnswerYes()},
+			want: "unknown",
+		},
+		{
+			name: "manager query failed",
+			h:    responding,
+			sup: SupervisionInfo{Supported: true, UnitPresent: true,
+				Active: Undetermined(errors.New("user bus unavailable"))},
+			want: "unknown",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, ServingDaemonSupervised(tc.h, tc.sup).String())
+		})
+	}
+}
+
+func TestRunningConfigMatches_ThreeValued(t *testing.T) {
+	current := &config.Config{ListenAddr: "127.0.0.1:8443", RequireToken: true}
+	cases := []struct {
+		name string
+		h    HealthStatus
+		want string
+	}{
+		{
+			name: "same posture",
+			h: HealthStatus{BootConfig: &DaemonBootConfig{
+				ListenAddr: "127.0.0.1:8443", RequireToken: true,
+			}},
+			want: "yes",
+		},
+		{
+			name: "listener changed",
+			h: HealthStatus{BootConfig: &DaemonBootConfig{
+				ListenAddr: "0.0.0.0:8443", RequireToken: true,
+			}},
+			want: "no",
+		},
+		{
+			name: "auth changed",
+			h: HealthStatus{BootConfig: &DaemonBootConfig{
+				ListenAddr: "127.0.0.1:8443", RequireToken: false,
+			}},
+			want: "no",
+		},
+		{
+			name: "loopback auth changed",
+			h: HealthStatus{BootConfig: &DaemonBootConfig{
+				ListenAddr: "127.0.0.1:8443", RequireToken: true, RequireLoopbackToken: true,
+			}},
+			want: "no",
+		},
+		{name: "older responder", h: HealthStatus{}, want: "unknown"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, RunningConfigMatches(tc.h, current).String())
+		})
+	}
+}
+
+func TestRunningConfigDifference_NamesOnlyChangedPosture(t *testing.T) {
+	boot := &DaemonBootConfig{ListenAddr: "0.0.0.0:8443", RequireToken: false}
+	current := &config.Config{
+		ListenAddr: "127.0.0.1:8443", RequireToken: true, RequireLoopbackToken: true,
+	}
+
+	diff := RunningConfigDifference(boot, current)
+	require.Contains(t, diff, `listen_addr: running "0.0.0.0:8443", file "127.0.0.1:8443"`)
+	require.Contains(t, diff, "require_token: running false, file true")
+	require.Contains(t, diff, "require_loopback_token: running false, file true")
+}

--- a/daemon/version_test.go
+++ b/daemon/version_test.go
@@ -1,8 +1,11 @@
 package daemon
 
 import (
+	"encoding/json"
+	"os"
 	"testing"
 
+	"github.com/sachiniyer/agent-factory/config"
 	"github.com/stretchr/testify/require"
 )
 
@@ -38,6 +41,33 @@ func TestPing_UnsetVersionStaysEmpty(t *testing.T) {
 	require.NoError(t, s.Ping(PingRequest{}, &resp))
 	require.True(t, resp.OK)
 	require.Empty(t, resp.Version)
+}
+
+// Phase 4 of #2168 needs status and doctor to compare the daemon that actually
+// answered Ping with the installed unit and the config currently on disk. Pin
+// those facts on Ping itself: a PID file can be stale, and rereading config in
+// the client cannot reveal what the already-running daemon booted with.
+func TestPing_ReportsProcessAndBootConfig(t *testing.T) {
+	s := &controlServer{manager: &Manager{cfg: &config.Config{
+		ListenAddr:           "0.0.0.0:8443",
+		RequireToken:         true,
+		RequireLoopbackToken: true,
+	}}}
+
+	var resp PingResponse
+	require.NoError(t, s.Ping(PingRequest{}, &resp))
+
+	data, err := json.Marshal(resp)
+	require.NoError(t, err)
+	var wire map[string]any
+	require.NoError(t, json.Unmarshal(data, &wire))
+	require.Equal(t, float64(os.Getpid()), wire["pid"],
+		"the responding process, not daemon.pid, is the supervision identity")
+	require.Equal(t, map[string]any{
+		"listen_addr":            "0.0.0.0:8443",
+		"require_token":          true,
+		"require_loopback_token": true,
+	}, wire["boot_config"], "Ping must report the immutable config this daemon booted with")
 }
 
 func TestSetVersion_RoundTrips(t *testing.T) {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -159,10 +159,10 @@ The background daemon hosts task cron schedules, watch-task scripts, session mon
 af daemon install      # register autostart at login
 af daemon restart      # restart a running daemon and re-adopt live sessions
 af daemon uninstall    # remove the autostart unit (the daemon still starts on demand)
-af daemon status       # read-only health snapshot: running?, socket paths, pid, autostart (+ --json)
+af daemon status       # read-only health, supervision, and config freshness (+ --json)
 ```
 
-`af daemon status` uses the same no-spawn probe as `af doctor` — it reports whether the daemon answers on the control socket, the control/HTTP socket paths and file presence, the recorded (and verified) pid, whether the autostart unit is installed, and whether a running daemon is on a since-replaced binary. It never dials in a way that starts a daemon.
+`af daemon status` uses the same no-spawn Ping as `af doctor`, plus bounded read-only service-manager inspection. It reports the responder PID separately from the recorded PID, whether the installed unit owns that responder, and whether the listener/auth config on disk matches what the daemon booted with. Manager failures and older daemons render as `unknown`; they are never guessed into “unsupervised” or “current.” It never starts, stops, or reloads a daemon or unit.
 
 `af daemon restart` is safe to run after replacing the `af` binary. It asks a
 running daemon to shut down cleanly, restarts the autostart unit when one is

--- a/docs/concepts/daemon.md
+++ b/docs/concepts/daemon.md
@@ -55,7 +55,7 @@ daemon's autostart unit once:
 
 ```bash
 af daemon install     # systemd user service on Linux, launchd agent on macOS
-af daemon status      # liveness, sockets, pid, and autostart state
+af daemon status      # liveness, supervision ownership, and config freshness
 af daemon restart     # restart the daemon process; sessions are re-adopted
 af daemon uninstall   # remove the autostart unit
 ```
@@ -63,8 +63,10 @@ af daemon uninstall   # remove the autostart unit
 Because the daemon owns live state, you don't stop it by force while sessions
 are running; let `af` manage its lifecycle. `af daemon restart` restarts only
 the daemon process and re-adopts existing tmux sessions from persisted state.
-`af daemon status` is the right tool when you want to know whether it's up and
-where its sockets are.
+`af daemon status` is the right tool when you want to know whether it's up,
+whether the installed unit actually owns the responder, whether config edits
+have reached it, and where its sockets are. Those checks are read-only; an
+unavailable manager or older daemon is reported as unknown rather than guessed.
 
 ## Sockets
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -24,7 +24,7 @@ Run `af <command> --help` for the same information at the terminal. For a narrat
 - [`af daemon`](#af-daemon) — Manage the background daemon: serves the web UI and schedules tasks
 - [`af daemon install`](#af-daemon-install) — Register the daemon to start automatically at login
 - [`af daemon restart`](#af-daemon-restart) — Restart the running daemon without stopping live sessions
-- [`af daemon status`](#af-daemon-status) — Report daemon liveness, sockets, pid, and autostart
+- [`af daemon status`](#af-daemon-status) — Report daemon liveness, config freshness, and supervision
 - [`af daemon uninstall`](#af-daemon-uninstall) — Remove the daemon autostart unit
 - [`af debug`](#af-debug) — Print debug information like config paths
 - [`af doctor`](#af-doctor) — Diagnose setup, daemon health, and leaked session resources
@@ -631,7 +631,7 @@ af daemon
 
 - [`af daemon install`](#af-daemon-install) — Register the daemon to start automatically at login
 - [`af daemon restart`](#af-daemon-restart) — Restart the running daemon without stopping live sessions
-- [`af daemon status`](#af-daemon-status) — Report daemon liveness, sockets, pid, and autostart
+- [`af daemon status`](#af-daemon-status) — Report daemon liveness, config freshness, and supervision
 - [`af daemon uninstall`](#af-daemon-uninstall) — Remove the daemon autostart unit
 
 **Global flags**
@@ -683,16 +683,16 @@ af daemon restart [flags]
 
 ## af daemon status
 
-Report daemon liveness, sockets, pid, and autostart
+Report daemon liveness, config freshness, and supervision
 
 Print a read-only snapshot of the background daemon: whether it is responding
 on the control socket, the control and HTTP socket paths (and whether their
-files are present), the recorded pid and whether it is a verified af daemon,
-whether the autostart unit is installed, and whether the running daemon is on a
-since-replaced binary.
+files are present), the recorded and responding pids, whether the installed
+autostart unit owns that responding process, whether the config on disk matches
+what the daemon booted with, and whether the running binary was replaced.
 
 It never contacts a paused daemon in a way that spawns one and never starts the
-daemon — it uses the same no-spawn health probe as af doctor. Use --json for a
+daemon. Service-manager inspection is bounded and read-only. Use --json for a
 machine-readable form wrapped in the shared {data,error} envelope.
 
 ```

--- a/doctor/checks.go
+++ b/doctor/checks.go
@@ -169,6 +169,9 @@ func checkDaemonHealth(ctx *scanContext, report *Report, h daemon.HealthStatus, 
 			},
 		)
 	}
+	if h.PingErr == nil && cfg != nil {
+		checkRunningDaemonConfig(report, h, cfg)
+	}
 	// The #2090 exposure is INFORMATIONAL since #2168 Phase 0: a tokenless
 	// network listener is an allowed, deliberate configuration, so this is a Warn
 	// with problem=false — it never makes `af doctor` exit non-zero over a posture
@@ -178,8 +181,8 @@ func checkDaemonHealth(ctx *scanContext, report *Report, h daemon.HealthStatus, 
 	//
 	// Reported independently of daemon liveness, unlike the old row: the exposure
 	// matters MOST when the daemon is up, because then it is actually being
-	// served. (What doctor reads is the config on disk, which a running daemon may
-	// predate — naming the running daemon's booted posture is #2168 Phase 4.)
+	// served. The separate daemon-config row compares this disk value with the
+	// posture returned by the running daemon itself (#2168 Phase 4).
 	//
 	// cfg is nil when the config could not be loaded at all (doctor.Run passes
 	// what it got). Say nothing then rather than guessing a posture — the load
@@ -226,6 +229,33 @@ func checkDaemonHealth(ctx *scanContext, report *Report, h daemon.HealthStatus, 
 		report.Warn(sectionDaemon, "daemon binary", fmt.Sprintf("pid %d is running a binary that was replaced on disk", h.PIDFilePID),
 			"run `af daemon restart` to pick up the current binary", true)
 	}
+}
+
+// checkRunningDaemonConfig compares the file on disk with the immutable
+// listener/auth posture returned by the process which answered Ping. An older
+// responder is reported as unknown, not silently treated as current.
+func checkRunningDaemonConfig(report *Report, h daemon.HealthStatus, cfg *config.Config) {
+	matches := daemon.RunningConfigMatches(h, cfg)
+	matches.Match(
+		func() {
+			report.Pass(sectionDaemon, "daemon config", "on-disk listener/auth config matches the running daemon")
+		},
+		func() {
+			report.Warn(sectionDaemon, "daemon config",
+				"config on disk differs from the running daemon ("+daemon.RunningConfigDifference(h.BootConfig, cfg)+")",
+				"run `af daemon restart` to apply the config on disk", true)
+		},
+		func() {
+			report.Warn(sectionDaemon, "daemon config",
+				"the running daemon could not be compared with the config on disk because the responder was not identified",
+				"restart the daemon, then rerun `af doctor`", false)
+		},
+		func(cause error) {
+			report.Warn(sectionDaemon, "daemon config",
+				"whether the running daemon matches the config on disk is unknown: "+oneLine(cause),
+				"restart the daemon to apply the current config, or rerun `af doctor` after upgrading the daemon", false)
+		},
+	)
 }
 
 // checkOrphanedProcesses finds processes carrying the AF_SESSION ancestry

--- a/doctor/daemon_runtime_diagnostics_test.go
+++ b/doctor/daemon_runtime_diagnostics_test.go
@@ -1,0 +1,82 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+	"github.com/stretchr/testify/require"
+)
+
+// A responder built before boot-config reporting cannot be compared with the
+// file on disk. Doctor must expose that evidence gap instead of omitting the
+// check and leaving the user to assume the running daemon has applied edits.
+func TestDaemonConfig_OlderResponderIsExplicitlyUnknown(t *testing.T) {
+	testguard.IsolateTmux(t)
+
+	opts := testOptions(t, false)
+	require.NoError(t, os.WriteFile(filepath.Join(opts.ConfigDir, config.TomlConfigFileName),
+		[]byte("listen_addr = '127.0.0.1:8443'\nrequire_token = false\n"), 0600))
+	opts.daemonHealth = respondingDaemon("1.0.192")
+
+	report, err := Run(opts)
+	require.NoError(t, err)
+
+	c := findCheck(t, report, "daemon config")
+	require.Equal(t, StatusWarn, c.Status)
+	require.Contains(t, c.Detail, "unknown")
+	require.Contains(t, c.Detail, "predates")
+	require.False(t, c.Problem, "an older responder is missing evidence, not proven stale config")
+}
+
+func TestDaemonConfig_MismatchNamesRunningAndFileValues(t *testing.T) {
+	testguard.IsolateTmux(t)
+
+	opts := testOptions(t, false)
+	require.NoError(t, os.WriteFile(filepath.Join(opts.ConfigDir, config.TomlConfigFileName),
+		[]byte("listen_addr = '127.0.0.1:8443'\nrequire_token = true\nrequire_loopback_token = true\n"), 0600))
+	opts.daemonHealth = func() daemon.HealthStatus {
+		return daemon.HealthStatus{
+			DaemonVersion: "1.0.220",
+			ServingPID:    42,
+			BootConfig: &daemon.DaemonBootConfig{
+				ListenAddr: "0.0.0.0:8443", RequireToken: false,
+			},
+		}
+	}
+
+	report, err := Run(opts)
+	require.NoError(t, err)
+
+	c := findCheck(t, report, "daemon config")
+	require.Equal(t, StatusWarn, c.Status)
+	require.Contains(t, c.Detail, `listen_addr: running "0.0.0.0:8443", file "127.0.0.1:8443"`)
+	require.Contains(t, c.Detail, "require_token: running false, file true")
+	require.Contains(t, c.Detail, "require_loopback_token: running false, file true")
+	require.Contains(t, c.Remediation, "af daemon restart")
+	require.True(t, c.Problem)
+}
+
+func TestDaemonConfig_MatchPasses(t *testing.T) {
+	testguard.IsolateTmux(t)
+
+	opts := testOptions(t, false)
+	require.NoError(t, os.WriteFile(filepath.Join(opts.ConfigDir, config.TomlConfigFileName),
+		[]byte("listen_addr = '127.0.0.1:8443'\nrequire_token = true\n"), 0600))
+	opts.daemonHealth = func() daemon.HealthStatus {
+		return daemon.HealthStatus{
+			DaemonVersion: "1.0.220",
+			ServingPID:    42,
+			BootConfig: &daemon.DaemonBootConfig{
+				ListenAddr: "127.0.0.1:8443", RequireToken: true,
+			},
+		}
+	}
+
+	report, err := Run(opts)
+	require.NoError(t, err)
+	require.Equal(t, StatusPass, findCheck(t, report, "daemon config").Status)
+}

--- a/doctor/doctor.go
+++ b/doctor/doctor.go
@@ -326,7 +326,7 @@ func Run(opts Options) (*Report, error) {
 	checkAutostartPath(ctx, report)
 	checkSplitBrainBinaries(ctx, report)
 	checkStaleSockets(ctx, report, health)
-	checkAutostartSupervision(ctx, report)
+	checkAutostartSupervision(ctx, report, health)
 	checkOrphanedProcesses(ctx, report)
 	checkRunawayChildren(ctx, report)
 	checkLeakedTmuxSessions(ctx, report)

--- a/doctor/skew.go
+++ b/doctor/skew.go
@@ -626,7 +626,7 @@ func checkHTTPSocket(ctx *scanContext, report *Report, h daemon.HealthStatus) {
 // actually supervising the daemon. On macOS that includes an agent loaded in a
 // domain other than the gui/<uid> the restart path targets: restarts silently
 // miss it, so an old daemon keeps serving and skew never clears.
-func checkAutostartSupervision(ctx *scanContext, report *Report) {
+func checkAutostartSupervision(ctx *scanContext, report *Report, h daemon.HealthStatus) {
 	if !autostartUnitIsOurs(ctx) {
 		return
 	}
@@ -655,12 +655,16 @@ func checkAutostartSupervision(ctx *scanContext, report *Report) {
 	// Match has no default branch, so the "we could not ask" case cannot be
 	// forgotten here or in any future edit: the compiler demands it.
 	info.Active.Match(
-		func() { supervisionActive(ctx, report, info) },
-		func() { supervisionNotRunning(report, info) },
-		func() { supervisionUnitUnknownToManager(report, info) },
+		func() { supervisionActive(ctx, report, info, h) },
+		func() { supervisionNotRunning(report, info, h) },
+		func() { supervisionUnitUnknownToManager(report, info, h) },
 		func(cause error) {
+			detail := fmt.Sprintf("could not query the service manager, so supervision is unknown: %s", oneLine(cause))
+			if h.PingErr == nil {
+				detail = fmt.Sprintf("a daemon is responding, but the service manager could not be queried, so whether it is supervised is unknown: %s", oneLine(cause))
+			}
 			report.Warn(sectionDaemon, "autostart supervision",
-				fmt.Sprintf("could not query the service manager, so supervision is unknown: %s", oneLine(cause)),
+				detail,
 				"check that the service manager is reachable (`systemctl --user status` / `launchctl print`), then rerun `af doctor`", false)
 		},
 	)
@@ -668,10 +672,73 @@ func checkAutostartSupervision(ctx *scanContext, report *Report) {
 
 // supervisionActive renders the manager's "it is running" answer, which still
 // leaves the is-enabled question to report.
-func supervisionActive(ctx *scanContext, report *Report, info daemon.SupervisionInfo) {
+func supervisionActive(ctx *scanContext, report *Report, info daemon.SupervisionInfo, h daemon.HealthStatus) {
 	_ = ctx
+	enabledYes := false
+	enablement := ""
+	enablementProblem := false
 	info.Enabled.Match(
-		func() { report.Pass(sectionDaemon, "autostart supervision", "unit is enabled and running") },
+		func() { enabledYes, enablement = true, "unit is enabled" },
+		func() { enablement, enablementProblem = "unit is not enabled", true },
+		func() {
+			enablement, enablementProblem = "the service manager has no enablement record for the unit", true
+		},
+		func(cause error) { enablement = "whether the unit starts at login is unknown: " + oneLine(cause) },
+	)
+
+	if h.PingErr == nil {
+		ownership := daemon.ServingDaemonSupervised(h, info)
+		handled := false
+		ownership.Match(
+			func() {
+				if enabledYes {
+					report.Pass(sectionDaemon, "autostart supervision",
+						fmt.Sprintf("unit is enabled and running; it owns the responding daemon pid %d", h.ServingPID))
+				} else {
+					report.Warn(sectionDaemon, "autostart supervision",
+						fmt.Sprintf("the unit is running and owns responding daemon pid %d; %s", h.ServingPID, enablement),
+						"run `af daemon install` if the unit is not enabled, or check the service manager directly", enablementProblem)
+				}
+				handled = true
+			},
+			func() {
+				detail := fmt.Sprintf("the installed unit owns pid %d, but responding daemon pid %d is not supervised by it",
+					info.MainPID, h.ServingPID)
+				if info.MainPID == 0 {
+					detail = "the installed unit is active but owns no daemon process; the responding daemon is not supervised by it"
+				}
+				report.Warn(sectionDaemon, "autostart supervision", detail+"; "+enablement,
+					"run `af daemon install` to hand the daemon back to the installed unit", true)
+				handled = true
+			},
+			func() {
+				report.Warn(sectionDaemon, "autostart supervision",
+					"the service manager has no record of the installed unit, so the responding daemon is not supervised by it; "+enablement,
+					"reload the unit: `systemctl --user daemon-reload`, or reinstall it: af daemon install", true)
+				handled = true
+			},
+			func(cause error) {
+				if enabledYes {
+					report.Warn(sectionDaemon, "autostart supervision",
+						"the unit is enabled and active, but whether it owns the responding daemon is unknown: "+oneLine(cause),
+						"upgrade or restart the daemon and rerun `af doctor`", false)
+				} else {
+					report.Warn(sectionDaemon, "autostart supervision",
+						fmt.Sprintf("the unit is active, but whether it owns responding daemon pid %d is unknown: %s; %s",
+							h.ServingPID, oneLine(cause), enablement),
+						"run `af daemon install` if the unit is not enabled, or upgrade/restart the daemon and rerun `af doctor`", enablementProblem)
+				}
+				handled = true
+			},
+		)
+		if handled {
+			return
+		}
+	}
+	info.Enabled.Match(
+		func() {
+			report.Pass(sectionDaemon, "autostart supervision", "unit is enabled and running")
+		},
 		func() {
 			report.Warn(sectionDaemon, "autostart supervision",
 				fmt.Sprintf("the unit is running but not enabled, so it won't start at login (%s)", info.Detail),
@@ -691,13 +758,19 @@ func supervisionActive(ctx *scanContext, report *Report, info daemon.Supervision
 }
 
 // supervisionNotRunning renders an answered "it is not running".
-func supervisionNotRunning(report *Report, info daemon.SupervisionInfo) {
+func supervisionNotRunning(report *Report, info daemon.SupervisionInfo, h daemon.HealthStatus) {
 	if info.Err != nil {
 		// The unit is installed but unreadable AND it is not running: the
 		// unreadable file is the likely reason nothing is supervising.
 		report.Warn(sectionDaemon, "autostart supervision",
 			fmt.Sprintf("a unit file is installed but cannot be read (%v) and the service manager is not running it", info.Err),
 			"fix the unit file's permissions, or reinstall it: af daemon install", true)
+		return
+	}
+	if h.PingErr == nil {
+		report.Warn(sectionDaemon, "autostart supervision",
+			fmt.Sprintf("a daemon is responding, but the installed unit is not running it (%s); the responder is not supervised", info.Detail),
+			"run `af daemon install` to hand the daemon back to the installed unit", true)
 		return
 	}
 	loadedButDead := false
@@ -729,7 +802,13 @@ func supervisionNotRunning(report *Report, info daemon.SupervisionInfo) {
 // manager not knowing it means it was never loaded: `systemctl --user
 // daemon-reload` fixes it. Reported as "inactive" it sent users to reinstall
 // something that was already there; reported as "unknown" it told them nothing.
-func supervisionUnitUnknownToManager(report *Report, info daemon.SupervisionInfo) {
+func supervisionUnitUnknownToManager(report *Report, info daemon.SupervisionInfo, h daemon.HealthStatus) {
+	if h.PingErr == nil {
+		report.Warn(sectionDaemon, "autostart supervision",
+			fmt.Sprintf("a daemon is responding, but the service manager has no record of the installed unit (%s); the responder is not supervised", info.Detail),
+			"load it: `systemctl --user daemon-reload`, or reinstall it: af daemon install", true)
+		return
+	}
 	report.Warn(sectionDaemon, "autostart supervision",
 		fmt.Sprintf("a unit file is installed but the service manager has no record of it (%s), so nothing starts af at login", info.Detail),
 		"load it: `systemctl --user daemon-reload`, or reinstall it: af daemon install", true)

--- a/doctor/skew_autostart_test.go
+++ b/doctor/skew_autostart_test.go
@@ -364,6 +364,99 @@ func TestAutostartSupervision_UnitPresentButInactive_Warns(t *testing.T) {
 	require.True(t, c.Problem)
 }
 
+// This is the exact #2168 incident topology: Ping succeeds, but the installed
+// unit is inactive. The two facts must be correlated into "the responder is not
+// supervised" rather than emitted as an unrelated daemon pass and unit warning.
+func TestAutostartSupervision_RespondingDaemonWithInactiveUnitNamesUnsupervised(t *testing.T) {
+	testguard.IsolateTmux(t)
+
+	opts := testOptions(t, false)
+	ourAutostartUnit(&opts)
+	opts.daemonHealth = respondingDaemon("1.0.192")
+	opts.autostartSupervision = func() daemon.SupervisionInfo {
+		return daemon.SupervisionInfo{
+			Supported: true, UnitPresent: true, Enabled: daemon.AnswerYes(), Active: daemon.AnswerNo(),
+			Detail: "is-enabled=enabled is-active=inactive",
+		}
+	}
+
+	report, err := Run(opts)
+	require.NoError(t, err)
+
+	c := findCheck(t, report, "autostart supervision")
+	require.Equal(t, StatusWarn, c.Status)
+	require.Contains(t, c.Detail, "daemon is responding")
+	require.Contains(t, c.Detail, "not supervised")
+	require.True(t, c.Problem)
+}
+
+// An active unit plus a responder from an older daemon is not enough to prove
+// ownership: without the responder PID they may be two different processes.
+// The zero-value probe must remain unknown instead of preserving the old false
+// "unit is enabled and running" all-clear.
+func TestAutostartSupervision_OlderResponderWithoutPIDIsUnknown(t *testing.T) {
+	testguard.IsolateTmux(t)
+
+	opts := testOptions(t, false)
+	ourAutostartUnit(&opts)
+	opts.daemonHealth = respondingDaemon("1.0.192")
+	opts.autostartSupervision = func() daemon.SupervisionInfo {
+		return daemon.SupervisionInfo{
+			Supported: true, UnitPresent: true, Enabled: daemon.AnswerYes(), Active: daemon.AnswerYes(),
+			Detail: "is-enabled=enabled is-active=active",
+		}
+	}
+
+	report, err := Run(opts)
+	require.NoError(t, err)
+
+	c := findCheck(t, report, "autostart supervision")
+	require.Equal(t, StatusWarn, c.Status)
+	require.Contains(t, c.Detail, "unknown")
+	require.Contains(t, c.Detail, "PID")
+	require.False(t, c.Problem, "missing evidence is not proof of a supervision defect")
+}
+
+// Enablement and ownership are independent facts. A unit can be active but
+// disabled, and a different ad-hoc daemon can still own the control socket. The
+// existing enablement warning must not hide that the responder is unsupervised.
+func TestAutostartSupervision_DisabledActiveUnitStillReportsOwnership(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		unitPID int
+		want    string
+	}{
+		{name: "different responder", unitPID: 99, want: "not supervised"},
+		{name: "same responder", unitPID: 42, want: "owns responding daemon pid 42"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testguard.IsolateTmux(t)
+
+			opts := testOptions(t, false)
+			ourAutostartUnit(&opts)
+			opts.daemonHealth = func() daemon.HealthStatus {
+				return daemon.HealthStatus{DaemonVersion: "1.0.192", ServingPID: 42}
+			}
+			opts.autostartSupervision = func() daemon.SupervisionInfo {
+				return daemon.SupervisionInfo{
+					Supported: true, UnitPresent: true, Enabled: daemon.AnswerNo(), Active: daemon.AnswerYes(),
+					MainPID: tc.unitPID, MainPIDPresent: daemon.AnswerYes(), Detail: "is-enabled=disabled is-active=active",
+				}
+			}
+
+			report, err := Run(opts)
+			require.NoError(t, err)
+
+			c := findCheck(t, report, "autostart supervision")
+			require.Equal(t, StatusWarn, c.Status)
+			require.Contains(t, c.Detail, "responding daemon pid 42")
+			require.Contains(t, c.Detail, tc.want)
+			require.Contains(t, c.Detail, "not enabled")
+			require.True(t, c.Problem)
+		})
+	}
+}
+
 // Loaded is not running: the agent is installed and launchd knows it, so
 // everything looks configured while no daemon is actually up. Reporting PASS
 // here is a false all-clear on the platform where this was hit.

--- a/doctor/skew_test.go
+++ b/doctor/skew_test.go
@@ -1095,14 +1095,22 @@ func TestSkewChecks_HealthyMachine_AllPass(t *testing.T) {
 
 	opts := testOptions(t, false)
 	opts.Version = "1.0.192"
-	opts.daemonHealth = respondingDaemon("1.0.192")
+	healthyDaemon := respondingDaemon("1.0.192")
+	opts.daemonHealth = func() daemon.HealthStatus {
+		h := healthyDaemon()
+		h.ServingPID = 4242
+		return h
+	}
 	ourAutostartUnit(&opts)
 	opts.autostartUnit = func() daemon.AutostartUnitInfo {
 		return daemon.AutostartUnitInfo{Supported: true, Exists: true, ExecPath: bin}
 	}
 	ourAutostartUnit(&opts)
 	opts.autostartSupervision = func() daemon.SupervisionInfo {
-		return daemon.SupervisionInfo{Supported: true, UnitPresent: true, Enabled: daemon.AnswerYes(), Active: daemon.AnswerYes()}
+		return daemon.SupervisionInfo{
+			Supported: true, UnitPresent: true, Enabled: daemon.AnswerYes(), Active: daemon.AnswerYes(),
+			MainPID: 4242, MainPIDPresent: daemon.AnswerYes(),
+		}
 	}
 	opts.selfBinary = func() (string, error) { return bin, nil }
 	opts.binaryCandidates = func() []string { return []string{bin} }


### PR DESCRIPTION
## Summary

- add the responding process PID and its immutable listener/auth boot posture to the additive Ping response
- correlate that responder with bounded, read-only systemd/launchd process evidence instead of treating an installed unit as proof of supervision
- make `af daemon status` and `af doctor` distinguish supervised, unsupervised, stale-config, and explicitly unknown states

This is the approved Phase 4 diagnostics slice of #2168. It does not change daemon startup, shutdown, restart, `EnsureDaemon`, supervision precedence, or the CLI verb set.

## Reproduction and regression coverage

Before the implementation, the focused container tests failed because Ping had no responder PID or boot-config fields, `af daemon status` rendered only `autostart: installed`, doctor did not correlate a responding daemon with an inactive unit, and an older responder plus an active unit could still produce a false all-clear.

The production paths under test are:

- `af daemon status` → `collectDaemonStatus` → no-spawn `daemon.Health`/Ping plus bounded `AutostartSupervision`
- `af doctor` → one shared `HealthStatus` snapshot → daemon config and autostart-supervision checks
- Linux `systemctl --user show ... MainPID` and the existing macOS `launchctl print` snapshot → three-valued ownership correlation

Manager failures, malformed PID evidence, and responders predating the additive Ping fields stay `unknown`; they never become a fabricated supervision or config answer.

## Gates

Exact head: `8108c52803cd170f39e02c58c8586ae5aa8be4ab`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make docs` with a clean resulting tree
- `make test-container`

Part of #2168.
