### PR TITLE
feat(projects): add durable local registry

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -569,11 +569,17 @@ func silenceCobraOutput() {
 	SessionsCmd.SilenceErrors = true
 	TasksCmd.SilenceUsage = true
 	TasksCmd.SilenceErrors = true
+	ProjectsCmd.SilenceUsage = true
+	ProjectsCmd.SilenceErrors = true
 	if root := SessionsCmd.Root(); root != nil {
 		root.SilenceUsage = true
 		root.SilenceErrors = true
 	}
 	if root := TasksCmd.Root(); root != nil {
+		root.SilenceUsage = true
+		root.SilenceErrors = true
+	}
+	if root := ProjectsCmd.Root(); root != nil {
 		root.SilenceUsage = true
 		root.SilenceErrors = true
 	}
@@ -681,6 +687,9 @@ func init() {
 
 	// Projects (repo groupings, #1735)
 	ProjectsCmd.PersistentFlags().BoolVar(&envelopeOutput, "json", false, jsonFlagUsage)
+	ProjectsCmd.AddCommand(projectsListCmd)
+	ProjectsCmd.AddCommand(projectsRegisterCmd)
+	ProjectsCmd.AddCommand(projectsRebindCmd)
 	ProjectsCmd.AddCommand(projectsDeleteCmd)
 
 	// Tasks

--- a/api/projects.go
+++ b/api/projects.go
@@ -82,19 +82,21 @@ var deleteProjectViaDaemon = daemon.DeleteProject
 
 var projectsDeleteCmd = &cobra.Command{
 	Use:   "delete [repo]",
-	Short: "Delete a project: archive its sessions and remove it (reversibly)",
-	Long: `Delete a project — the group of sessions sharing a git repository.
+	Short: "Archive and remove a project's sessions (reversibly)",
+	Long: `Archive and remove every live session for a git repository.
 
-This is ARCHIVE-THEN-REMOVE and reversible. Every live session of the repo is
+This is archive-then-remove and reversible. Every live session of the repo is
 archived (its tmux is torn down and its worktree moved to the archive dir, but
-its branch and uncommitted changes are preserved), the project drops out of the
-active projects list, and its always-on root agent (if any) is stopped and its
-root_agents opt-in removed. In-place sessions (the root agent, 'af sessions
-create --here') are torn down instead of archived — their cleanup never touches
-your working tree or branch.
+its branch and uncommitted changes are preserved), and its always-on root agent
+(if any) is stopped and its root-agent opt-in removed. In-place sessions (the
+root agent, 'af sessions create --here') are torn down instead of archived —
+their cleanup never touches your working tree or branch.
+
+The durable project registration, if any, is preserved. This command removes
+session state; it does not unregister the project.
 
 Your real git repository is never touched. To undo a mis-click, restore any
-archived session with 'af sessions restore <title>' — its project reappears.
+archived session with 'af sessions restore <title>'.
 
 [repo] is a path inside the repository to delete (default: the current repo).
 Deleting an unknown or already-empty project is a clean no-op. Prints how many

--- a/api/projects.go
+++ b/api/projects.go
@@ -11,12 +11,70 @@ import (
 	"github.com/sachiniyer/agent-factory/log"
 )
 
-// ProjectsCmd is the top-level command group for project (repo-grouping)
-// management (#1735). A "project" is derived: the set of sessions sharing a repo
-// root. Today the only verb is delete; more can join it as the surface grows.
+// ProjectsCmd is the top-level command group for project management.
 var ProjectsCmd = &cobra.Command{
 	Use:   "projects",
-	Short: "Manage projects (repo groupings of sessions)",
+	Short: "Manage projects and durable registrations",
+}
+
+var projectsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List registered projects",
+	Long: `List durable machine-local project bindings.
+
+path_exists reports only whether the last-known path is present. It does not
+claim that a new checkout at a reused path has the registered identity.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		projects, err := config.ListProjects()
+		if err != nil {
+			return jsonError(err)
+		}
+		return jsonOut(projects)
+	},
+}
+
+var projectsRegisterCmd = &cobra.Command{
+	Use:   "register <path>",
+	Short: "Register a project with a stable local identity",
+	Long: `Register a project directory with a stable, machine-local identity.
+
+The returned project id survives an explicit rebind after the checkout moves.
+Two clones remain separate projects. Any directory inside a checkout resolves
+to that checkout's canonical main-repo root, and registration is idempotent for
+the same checkout. Identity is anchored in agent-factory/checkout-id under the
+Git common directory; no working-tree file is created.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log.Initialize(false)
+		defer log.Close()
+
+		project, err := config.RegisterProject(args[0])
+		if err != nil {
+			return jsonError(err)
+		}
+		return jsonOut(project)
+	},
+}
+
+var projectsRebindCmd = &cobra.Command{
+	Use:   "rebind <project-id> <path>",
+	Short: "Rebind a registered project after its checkout moves",
+	Long: `Rebind a stable project id to a new checkout path.
+
+The project id is preserved. Rebinding refuses to take a path already owned by
+another registered project.`,
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log.Initialize(false)
+		defer log.Close()
+
+		project, err := config.RebindProject(args[0], args[1])
+		if err != nil {
+			return jsonError(err)
+		}
+		return jsonOut(project)
+	},
 }
 
 // deleteProjectViaDaemon is the daemon seam, overridable in tests.

--- a/api/projects.go
+++ b/api/projects.go
@@ -42,8 +42,10 @@ var projectsRegisterCmd = &cobra.Command{
 The returned project id survives an explicit rebind after the checkout moves.
 Two clones remain separate projects. Any directory inside a checkout resolves
 to that checkout's canonical main-repo root, and registration is idempotent for
-the same checkout. Identity is anchored in agent-factory/checkout-id under the
-Git common directory; no working-tree file is created.`,
+the same checkout. Identity is anchored in an AF-home-scoped
+agent-factory/checkout-id-<home-id> marker under the Git common directory, so
+one AF home's reset cannot remove another home's identity. No working-tree file
+is created.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Initialize(false)

--- a/api/projects_registry_test.go
+++ b/api/projects_registry_test.go
@@ -1,0 +1,27 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestProjectsRegistryCommandsRegistered is the production-wiring regression
+// for #2216's registry slice. A registry package exercised only by its own unit
+// tests would not make stable project identity reachable by users; these are
+// the actual Cobra commands wired into `af projects` at startup.
+func TestProjectsRegistryCommandsRegistered(t *testing.T) {
+	want := map[string]bool{
+		"list":     false,
+		"register": false,
+		"rebind":   false,
+	}
+	for _, cmd := range ProjectsCmd.Commands() {
+		if _, ok := want[cmd.Name()]; ok {
+			want[cmd.Name()] = true
+		}
+	}
+	for name, registered := range want {
+		require.Truef(t, registered, "af projects %s is not wired into the production command", name)
+	}
+}

--- a/api/projects_registry_test.go
+++ b/api/projects_registry_test.go
@@ -1,6 +1,9 @@
 package api
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -24,4 +27,16 @@ func TestProjectsRegistryCommandsRegistered(t *testing.T) {
 	for name, registered := range want {
 		require.Truef(t, registered, "af projects %s is not wired into the production command", name)
 	}
+}
+
+func TestProjectsListMissingHomeIsReadOnly(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "missing-af-home")
+	t.Setenv("AGENT_FACTORY_HOME", home)
+
+	out := captureJSON(t, func() error { return projectsListCmd.RunE(projectsListCmd, nil) })
+	var projects []map[string]any
+	require.NoError(t, json.Unmarshal(out, &projects))
+	require.Empty(t, projects)
+	_, err := os.Stat(home)
+	require.ErrorIs(t, err, os.ErrNotExist, "the production list command must not create config or log files")
 }

--- a/commands/configexplain_test.go
+++ b/commands/configexplain_test.go
@@ -117,7 +117,7 @@ codex = "/repo/codex"
 	assert.Contains(t, output, "repo-shared")
 	assert.Contains(t, output, "winner · highest-precedence present allowed source")
 
-	_, statErr := os.Stat(filepath.Join(home, "projects"))
+	_, statErr := os.Stat(filepath.Join(home, config.ProjectRegistryDirName))
 	assert.True(t, os.IsNotExist(statErr), "a path selector must not register durable identity in stage two")
 	_, statErr = os.Stat(filepath.Join(home, "repos"))
 	assert.True(t, os.IsNotExist(statErr), "a project config read must not persist load-observation state")

--- a/commands/reset.go
+++ b/commands/reset.go
@@ -88,6 +88,7 @@ type resetPlan struct {
 	sessions  int                 // live (non-archived) session records
 	archived  int                 // archived session records
 	tasks     int                 // scheduled cron/watch tasks
+	projects  int                 // durable project registrations for this AF home
 	worktrees int                 // AF-managed worktrees (excludes external --here trees)
 	repoRoots map[string]struct{} // distinct repos with AF records (display only)
 	branches  map[string][]string // repoRoot -> AF-created branch names to prune
@@ -130,6 +131,7 @@ type resetSummary struct {
 	sessions  int
 	archived  int
 	tasks     int
+	projects  int
 	worktrees int
 	branches  int // branches actually deleted (<= plan.branchCount())
 	corrupt   int // repos left intact because their records were unreadable
@@ -138,12 +140,13 @@ type resetSummary struct {
 
 var resetCmd = &cobra.Command{
 	Use:   "reset",
-	Short: "Factory-reset Agent Factory: remove ALL AF sessions, tasks, worktrees, and state (keeps your repos + config)",
+	Short: "Factory-reset Agent Factory: remove AF sessions, tasks, project registrations, worktrees, and state (keeps repos and config)",
 	Long: `Factory-reset Agent Factory.
 
 Removes every AF-created resource — all sessions (live and archived), all
-scheduled cron/watch tasks, all AF worktrees, the AF session branches AF
-created, and all stored state — returning AF to a clean slate.
+scheduled cron/watch tasks, registered-project bindings and their reachable
+checkout identity markers for this AF home, all AF worktrees, the AF session
+branches AF created, and all stored state — returning AF to a clean slate.
 
 Stops every af daemon running for this AF home — the managed one and any
 orphan left behind by an upgrade or a source build — and removes the daemon
@@ -566,6 +569,11 @@ func planFactoryReset() (*resetPlan, error) {
 		return nil, fmt.Errorf("failed to read tasks: %w", err)
 	}
 	plan.tasks = len(tasks)
+	projects, err := config.ListProjects()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read registered projects: %w", err)
+	}
+	plan.projects = len(projects)
 
 	return plan, nil
 }
@@ -601,12 +609,15 @@ func branchCreatedByAF(w session.GitWorktreeData) bool {
 // whatever a transient failure left behind.
 func executeFactoryReset(plan *resetPlan) (*resetSummary, error) {
 	var errs []error
+	projectsRemoved := 0
 
 	// Project records own checkout markers inside Git common directories. Clear
 	// both while every registered worktree still exists; a blind AF-home wipe
 	// cannot find or safely identify that repo-local state.
 	if err := config.ResetProjectRegistry(); err != nil {
 		errs = append(errs, fmt.Errorf("reset project registry: %w", err))
+	} else {
+		projectsRemoved = plan.projects
 	}
 
 	// Snapshot which AF-created branches exist up front, so the final count is
@@ -742,6 +753,7 @@ func executeFactoryReset(plan *resetPlan) (*resetSummary, error) {
 		sessions:  plan.sessions,
 		archived:  plan.archived,
 		tasks:     plan.tasks,
+		projects:  projectsRemoved,
 		worktrees: plan.worktrees,
 		branches:  branchesDeleted,
 		corrupt:   len(plan.corruptRepoIDs),
@@ -880,6 +892,7 @@ func printResetPlan(out io.Writer, plan *resetPlan) {
 	fmt.Fprintln(out, "WILL REMOVE:")
 	fmt.Fprintf(out, "  • %d session(s) and %d archived session(s)\n", plan.sessions, plan.archived)
 	fmt.Fprintf(out, "  • %d scheduled task(s)\n", plan.tasks)
+	fmt.Fprintf(out, "  • %d registered project record(s), plus reachable checkout identity marker(s) for this AF home\n", plan.projects)
 	fmt.Fprintf(out, "  • %d AF worktree(s) across %d repo(s)\n", plan.worktrees, len(plan.repoRoots))
 	fmt.Fprintf(out, "  • %d AF-created session branch(es)\n", plan.branchCount())
 	fmt.Fprintln(out, "  • all AF state (live sessions, archived sessions, events, logs, locks)")
@@ -895,6 +908,7 @@ func printResetSummary(out io.Writer, s *resetSummary) {
 	fmt.Fprintf(out, "  sessions:  %d\n", s.sessions)
 	fmt.Fprintf(out, "  archived:  %d\n", s.archived)
 	fmt.Fprintf(out, "  tasks:     %d\n", s.tasks)
+	fmt.Fprintf(out, "  projects:  %d\n", s.projects)
 	fmt.Fprintf(out, "  worktrees: %d\n", s.worktrees)
 	fmt.Fprintf(out, "  branches:  %d\n", s.branches)
 	if s.corrupt > 0 {
@@ -908,5 +922,5 @@ func printResetSummary(out io.Writer, s *resetSummary) {
 			"Run the recovery command shown with each one below, then re-run `af reset` to finish.\n", s.blocked)
 	}
 	fmt.Fprintln(out, "Preserved: your git repositories and daemon config (config.toml).")
-	fmt.Fprintln(out, "The supervised daemon will restart with empty session/task state and the same config.")
+	fmt.Fprintln(out, "The supervised daemon will restart with empty session/task/project-registration state and the same config.")
 }

--- a/commands/reset.go
+++ b/commands/reset.go
@@ -614,8 +614,9 @@ func executeFactoryReset(plan *resetPlan) (*resetSummary, error) {
 	// Project records own checkout markers inside Git common directories. Clear
 	// both while every registered worktree still exists; a blind AF-home wipe
 	// cannot find or safely identify that repo-local state.
-	if err := config.ResetProjectRegistry(); err != nil {
-		errs = append(errs, fmt.Errorf("reset project registry: %w", err))
+	registryErr := config.ResetProjectRegistry()
+	if registryErr != nil {
+		errs = append(errs, fmt.Errorf("reset project registry: %w", registryErr))
 	} else {
 		projectsRemoved = plan.projects
 	}

--- a/commands/reset.go
+++ b/commands/reset.go
@@ -85,13 +85,17 @@ var resetWipePaths = []string{
 type resetPlan struct {
 	configDir string
 	storage   *session.Storage
-	sessions  int                 // live (non-archived) session records
-	archived  int                 // archived session records
-	tasks     int                 // scheduled cron/watch tasks
-	projects  int                 // durable project registrations for this AF home
-	worktrees int                 // AF-managed worktrees (excludes external --here trees)
-	repoRoots map[string]struct{} // distinct repos with AF records (display only)
-	branches  map[string][]string // repoRoot -> AF-created branch names to prune
+	sessions  int // live (non-archived) session records
+	archived  int // archived session records
+	tasks     int // scheduled cron/watch tasks
+	projects  int // durable project registrations for this AF home
+	// projectCountUnavailable means the registry could not be decoded during
+	// read-only planning. ResetProjectRegistry reports the concrete error during
+	// execution, while the resilient reset still clears unrelated AF state.
+	projectCountUnavailable bool
+	worktrees               int                 // AF-managed worktrees (excludes external --here trees)
+	repoRoots               map[string]struct{} // distinct repos with AF records (display only)
+	branches                map[string][]string // repoRoot -> AF-created branch names to prune
 
 	// worktreeTargets are the SPECIFIC worktree dirs AF created for its sessions
 	// (from the records), each paired with its repo root. Reset removes exactly
@@ -571,9 +575,11 @@ func planFactoryReset() (*resetPlan, error) {
 	plan.tasks = len(tasks)
 	projects, err := config.ListProjects()
 	if err != nil {
-		return nil, fmt.Errorf("failed to read registered projects: %w", err)
+		plan.projectCountUnavailable = true
+		log.WarningLog.Printf("reset: registered project count unavailable; registry cleanup will still be attempted: %v", err)
+	} else {
+		plan.projects = len(projects)
 	}
-	plan.projects = len(projects)
 
 	return plan, nil
 }
@@ -893,7 +899,11 @@ func printResetPlan(out io.Writer, plan *resetPlan) {
 	fmt.Fprintln(out, "WILL REMOVE:")
 	fmt.Fprintf(out, "  • %d session(s) and %d archived session(s)\n", plan.sessions, plan.archived)
 	fmt.Fprintf(out, "  • %d scheduled task(s)\n", plan.tasks)
-	fmt.Fprintf(out, "  • %d registered project record(s), plus reachable checkout identity marker(s) for this AF home\n", plan.projects)
+	if plan.projectCountUnavailable {
+		fmt.Fprintln(out, "  • registered project record count unavailable; registry cleanup and reachable checkout identity marker removal will still be attempted")
+	} else {
+		fmt.Fprintf(out, "  • %d registered project record(s), plus reachable checkout identity marker(s) for this AF home\n", plan.projects)
+	}
 	fmt.Fprintf(out, "  • %d AF worktree(s) across %d repo(s)\n", plan.worktrees, len(plan.repoRoots))
 	fmt.Fprintf(out, "  • %d AF-created session branch(es)\n", plan.branchCount())
 	fmt.Fprintln(out, "  • all AF state (live sessions, archived sessions, events, logs, locks)")

--- a/commands/reset.go
+++ b/commands/reset.go
@@ -65,12 +65,13 @@ const worktreesResidueDir = "worktrees"
 // place (#2110), this blind delete would destroy the very directory git still
 // owns — so the wipe below skips it and prunes the tree entry-by-entry instead.
 var resetWipePaths = []string{
-	worktreesResidueDir,     // AF-managed worktree parent dir (residue after cleanup)
-	"events",                // daemon event queue
-	"logs",                  // per-task run logs
-	"locks",                 // per-task run locks
-	config.StateFileName,    // state.json (help-screen bitmask etc.)
-	config.TUIStateFileName, // tui-state.json (TUI layout state)
+	worktreesResidueDir,           // AF-managed worktree parent dir (residue after cleanup)
+	config.ProjectRegistryDirName, // durable project identity and personal project state
+	"events",                      // daemon event queue
+	"logs",                        // per-task run logs
+	"locks",                       // per-task run locks
+	config.StateFileName,          // state.json (help-screen bitmask etc.)
+	config.TUIStateFileName,       // tui-state.json (TUI layout state)
 }
 
 // resetPlan is the pre-computed, non-destructive picture of what a factory

--- a/commands/reset.go
+++ b/commands/reset.go
@@ -60,18 +60,21 @@ const worktreesResidueDir = "worktrees"
 // per-repo (removeArchivedDirs) so a preserved (corrupt/unreadable) record is
 // never left pointing at a deleted archive.
 //
+// NOTE: the project registry is deliberately NOT here. ResetProjectRegistry
+// validates its AF-owned directory and clears repo-local checkout markers before
+// any registered worktree can be removed.
+//
 // NOTE: "worktrees" is a wholesale removal only because the per-worktree pass is
 // expected to have emptied it. When that pass DELIBERATELY left a worktree in
 // place (#2110), this blind delete would destroy the very directory git still
 // owns — so the wipe below skips it and prunes the tree entry-by-entry instead.
 var resetWipePaths = []string{
-	worktreesResidueDir,           // AF-managed worktree parent dir (residue after cleanup)
-	config.ProjectRegistryDirName, // durable project identity and personal project state
-	"events",                      // daemon event queue
-	"logs",                        // per-task run logs
-	"locks",                       // per-task run locks
-	config.StateFileName,          // state.json (help-screen bitmask etc.)
-	config.TUIStateFileName,       // tui-state.json (TUI layout state)
+	worktreesResidueDir,     // AF-managed worktree parent dir (residue after cleanup)
+	"events",                // daemon event queue
+	"logs",                  // per-task run logs
+	"locks",                 // per-task run locks
+	config.StateFileName,    // state.json (help-screen bitmask etc.)
+	config.TUIStateFileName, // tui-state.json (TUI layout state)
 }
 
 // resetPlan is the pre-computed, non-destructive picture of what a factory
@@ -598,6 +601,13 @@ func branchCreatedByAF(w session.GitWorktreeData) bool {
 // whatever a transient failure left behind.
 func executeFactoryReset(plan *resetPlan) (*resetSummary, error) {
 	var errs []error
+
+	// Project records own checkout markers inside Git common directories. Clear
+	// both while every registered worktree still exists; a blind AF-home wipe
+	// cannot find or safely identify that repo-local state.
+	if err := config.ResetProjectRegistry(); err != nil {
+		errs = append(errs, fmt.Errorf("reset project registry: %w", err))
+	}
 
 	// Snapshot which AF-created branches exist up front, so the final count is
 	// accurate even though branch deletion happens AFTER worktree removal.

--- a/commands/reset_test.go
+++ b/commands/reset_test.go
@@ -375,6 +375,55 @@ func TestFactoryReset_PreservesUnownedProjectsDirectory(t *testing.T) {
 	}
 }
 
+func TestFactoryReset_MalformedProjectRegistryDoesNotBlockOtherCleanup(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	t.Chdir(t.TempDir())
+
+	const projectID = "prj_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	recordPath := filepath.Join(home, config.ProjectRegistryDirName, projectID, "project.json")
+	writeFile(t, recordPath, "{not valid json")
+	if err := task.AddTask(task.Task{
+		ID: "reset-task", CronExpr: "* * * * *", Prompt: "do", Enabled: true,
+	}); err != nil {
+		t.Fatalf("AddTask: %v", err)
+	}
+	eventsDir := filepath.Join(home, "events")
+	writeFile(t, filepath.Join(eventsDir, "pending.json"), "{}")
+
+	plan, err := planFactoryReset()
+	if err != nil {
+		t.Fatalf("a malformed project record must not block reset planning: %v", err)
+	}
+	if !plan.projectCountUnavailable {
+		t.Fatal("malformed registry should make the project count explicitly unavailable")
+	}
+	var planOutput strings.Builder
+	printResetPlan(&planOutput, plan)
+	if !strings.Contains(planOutput.String(), "project record count unavailable") ||
+		!strings.Contains(planOutput.String(), "cleanup") {
+		t.Fatalf("reset plan hid the unreadable registry:\n%s", planOutput.String())
+	}
+	summary, err := executeFactoryReset(plan)
+	if err == nil || !strings.Contains(err.Error(), "reset project registry") {
+		t.Fatalf("executeFactoryReset error = %v, want the deferred project-registry error", err)
+	}
+	if summary.tasks != 1 {
+		t.Fatalf("removed tasks = %d, want 1", summary.tasks)
+	}
+	tasks, loadErr := task.LoadTasks()
+	if loadErr != nil {
+		t.Fatalf("LoadTasks after reset: %v", loadErr)
+	}
+	if len(tasks) != 0 {
+		t.Fatalf("tasks after reset = %d, want 0", len(tasks))
+	}
+	assertGone(t, eventsDir)
+	if _, statErr := os.Stat(recordPath); statErr != nil {
+		t.Fatalf("malformed project record should remain for repair: %v", statErr)
+	}
+}
+
 func assertGone(t *testing.T, path string) {
 	t.Helper()
 	if _, err := os.Stat(path); !os.IsNotExist(err) {

--- a/commands/reset_test.go
+++ b/commands/reset_test.go
@@ -193,6 +193,13 @@ func TestFactoryReset_WipesEverythingKeepsRepoAndConfig(t *testing.T) {
 	repo, liveWT, reusedWT := seedMockRepo(t, home)
 	cfgBytes := seedAFState(t, home, repo, liveWT, reusedWT)
 	repoID := config.RepoIDFromRoot(repo)
+	registered, err := config.RegisterProject(repo)
+	if err != nil {
+		t.Fatalf("RegisterProject: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, "projects", registered.ID, "project.json")); err != nil {
+		t.Fatalf("registered sessionless project is not durable before reset: %v", err)
+	}
 
 	// --- Plan reflects the real scope ---
 	plan, err := planFactoryReset()
@@ -240,8 +247,16 @@ func TestFactoryReset_WipesEverythingKeepsRepoAndConfig(t *testing.T) {
 	assertGone(t, filepath.Join(home, config.StateFileName))
 	assertGone(t, filepath.Join(home, config.TUIStateFileName))
 	assertGone(t, filepath.Join(home, "tasks.json"))
+	assertGone(t, filepath.Join(home, "projects"))
 	assertGone(t, liveWT)
 	assertGone(t, reusedWT)
+	projects, err := config.ListProjects()
+	if err != nil {
+		t.Fatalf("ListProjects after reset: %v", err)
+	}
+	if len(projects) != 0 {
+		t.Errorf("projects after reset = %d, want 0", len(projects))
+	}
 
 	tasks, err := task.LoadTasks()
 	if err != nil {

--- a/commands/reset_test.go
+++ b/commands/reset_test.go
@@ -200,7 +200,11 @@ func TestFactoryReset_WipesEverythingKeepsRepoAndConfig(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(home, config.ProjectRegistryDirName, registered.ID, "project.json")); err != nil {
 		t.Fatalf("registered sessionless project is not durable before reset: %v", err)
 	}
-	checkoutMarker := filepath.Join(repo, ".git", "agent-factory", "checkout-id")
+	checkoutMarkers, err := filepath.Glob(filepath.Join(repo, ".git", "agent-factory", "checkout-id-????????????????????????????????"))
+	if err != nil || len(checkoutMarkers) != 1 {
+		t.Fatalf("registered checkout markers = %v, err = %v, want one", checkoutMarkers, err)
+	}
+	checkoutMarker := checkoutMarkers[0]
 	if _, err := os.Stat(checkoutMarker); err != nil {
 		t.Fatalf("registered checkout marker is not durable before reset: %v", err)
 	}
@@ -231,15 +235,21 @@ func TestFactoryReset_WipesEverythingKeepsRepoAndConfig(t *testing.T) {
 	if _, ok := plan.repoRoots[repo]; !ok || len(plan.repoRoots) != 1 {
 		t.Errorf("repoRoots = %v, want exactly {%s}", plan.repoRoots, repo)
 	}
+	var planOutput strings.Builder
+	printResetPlan(&planOutput, plan)
+	if !strings.Contains(planOutput.String(), "1 registered project record(s)") ||
+		!strings.Contains(planOutput.String(), "checkout identity marker(s)") {
+		t.Errorf("reset plan omitted the sessionless project registration it will remove:\n%s", planOutput.String())
+	}
 
 	// --- Execute ---
 	summary, err := executeFactoryReset(plan)
 	if err != nil {
 		t.Fatalf("executeFactoryReset: %v", err)
 	}
-	if summary.sessions != 3 || summary.archived != 1 || summary.tasks != 2 ||
+	if summary.sessions != 3 || summary.archived != 1 || summary.tasks != 2 || summary.projects != 1 ||
 		summary.worktrees != 3 || summary.branches != 2 || summary.corrupt != 0 {
-		t.Errorf("summary = %+v, want {3 1 2 3 2 0}", *summary)
+		t.Errorf("summary = %+v, want 3 sessions, 1 archived, 2 tasks, 1 project, 3 worktrees, 2 branches, no corruption", *summary)
 	}
 
 	// --- Everything AF is gone ---
@@ -314,14 +324,14 @@ func TestFactoryReset_WipesEverythingKeepsRepoAndConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("second planFactoryReset: %v", err)
 	}
-	if plan2.sessions != 0 || plan2.archived != 0 || plan2.tasks != 0 || plan2.branchCount() != 0 {
+	if plan2.sessions != 0 || plan2.archived != 0 || plan2.tasks != 0 || plan2.projects != 0 || plan2.branchCount() != 0 {
 		t.Errorf("second plan not empty: %+v", *plan2)
 	}
 	summary2, err := executeFactoryReset(plan2)
 	if err != nil {
 		t.Fatalf("second executeFactoryReset: %v", err)
 	}
-	if summary2.sessions != 0 || summary2.archived != 0 || summary2.tasks != 0 ||
+	if summary2.sessions != 0 || summary2.archived != 0 || summary2.tasks != 0 || summary2.projects != 0 ||
 		summary2.worktrees != 0 || summary2.branches != 0 {
 		t.Errorf("second summary not empty: %+v", *summary2)
 	}

--- a/commands/reset_test.go
+++ b/commands/reset_test.go
@@ -200,6 +200,10 @@ func TestFactoryReset_WipesEverythingKeepsRepoAndConfig(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(home, config.ProjectRegistryDirName, registered.ID, "project.json")); err != nil {
 		t.Fatalf("registered sessionless project is not durable before reset: %v", err)
 	}
+	checkoutMarker := filepath.Join(repo, ".git", "agent-factory", "checkout-id")
+	if _, err := os.Stat(checkoutMarker); err != nil {
+		t.Fatalf("registered checkout marker is not durable before reset: %v", err)
+	}
 
 	// --- Plan reflects the real scope ---
 	plan, err := planFactoryReset()
@@ -248,6 +252,8 @@ func TestFactoryReset_WipesEverythingKeepsRepoAndConfig(t *testing.T) {
 	assertGone(t, filepath.Join(home, config.TUIStateFileName))
 	assertGone(t, filepath.Join(home, "tasks.json"))
 	assertGone(t, filepath.Join(home, config.ProjectRegistryDirName))
+	assertGone(t, checkoutMarker)
+	assertGone(t, checkoutMarker+".lock")
 	assertGone(t, liveWT)
 	assertGone(t, reusedWT)
 	projects, err := config.ListProjects()
@@ -323,6 +329,39 @@ func TestFactoryReset_WipesEverythingKeepsRepoAndConfig(t *testing.T) {
 	got2, _ := os.ReadFile(filepath.Join(home, "config.toml"))
 	if string(got2) != string(cfgBytes) {
 		t.Errorf("config.toml changed on second reset")
+	}
+
+	reregistered, err := config.RegisterProject(repo)
+	if err != nil {
+		t.Fatalf("RegisterProject after reset: %v", err)
+	}
+	if reregistered.CheckoutID == registered.CheckoutID {
+		t.Errorf("checkout id after reset = %s, want a newly minted identity", reregistered.CheckoutID)
+	}
+}
+
+func TestFactoryReset_PreservesUnownedProjectsDirectory(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	t.Chdir(t.TempDir())
+
+	userFile := filepath.Join(home, "projects", "personal-repo", "README.md")
+	writeFile(t, userFile, "keep me")
+
+	plan, err := planFactoryReset()
+	if err != nil {
+		t.Fatalf("planFactoryReset: %v", err)
+	}
+	if _, err := executeFactoryReset(plan); err != nil {
+		t.Fatalf("executeFactoryReset: %v", err)
+	}
+
+	got, err := os.ReadFile(userFile)
+	if err != nil {
+		t.Fatalf("factory reset removed caller-owned projects directory: %v", err)
+	}
+	if string(got) != "keep me" {
+		t.Fatalf("caller-owned project changed to %q", got)
 	}
 }
 

--- a/commands/reset_test.go
+++ b/commands/reset_test.go
@@ -197,7 +197,7 @@ func TestFactoryReset_WipesEverythingKeepsRepoAndConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RegisterProject: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(home, "projects", registered.ID, "project.json")); err != nil {
+	if _, err := os.Stat(filepath.Join(home, config.ProjectRegistryDirName, registered.ID, "project.json")); err != nil {
 		t.Fatalf("registered sessionless project is not durable before reset: %v", err)
 	}
 
@@ -247,7 +247,7 @@ func TestFactoryReset_WipesEverythingKeepsRepoAndConfig(t *testing.T) {
 	assertGone(t, filepath.Join(home, config.StateFileName))
 	assertGone(t, filepath.Join(home, config.TUIStateFileName))
 	assertGone(t, filepath.Join(home, "tasks.json"))
-	assertGone(t, filepath.Join(home, "projects"))
+	assertGone(t, filepath.Join(home, config.ProjectRegistryDirName))
 	assertGone(t, liveWT)
 	assertGone(t, reusedWT)
 	projects, err := config.ListProjects()

--- a/config/project_registry.go
+++ b/config/project_registry.go
@@ -1,0 +1,499 @@
+package config
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+const (
+	projectRegistrySchemaVersion = 1
+	projectMetadataFileName      = "project.json"
+	checkoutMarkerDirName        = "agent-factory"
+	checkoutMarkerFileName       = "checkout-id"
+	projectIDPrefix              = "prj_"
+	checkoutIDPrefix             = "chk_"
+	opaqueIDBytes                = 16
+)
+
+var (
+	projectIDPattern  = regexp.MustCompile(`^prj_[0-9a-f]{32}$`)
+	checkoutIDPattern = regexp.MustCompile(`^chk_[0-9a-f]{32}$`)
+)
+
+// Project is a durable machine-local project binding. ID is stable across an
+// explicit rebind; Root is only the last-known path. CheckoutID distinguishes
+// two clones, and RelativeRoot reserves the checkout-relative identity axis for
+// a later monorepo slice (repo-root registrations use "."). No session or task
+// is required for a Project to exist.
+type Project struct {
+	ID           string `json:"id"`
+	CheckoutID   string `json:"checkout_id"`
+	Root         string `json:"root"`
+	RelativeRoot string `json:"relative_root"`
+	// PathExists is availability, not identity proof. The registry deliberately
+	// does not infer that a new checkout appearing at the same path is the old
+	// one; only the checkout marker provides that evidence.
+	PathExists bool `json:"path_exists"`
+}
+
+type projectRecord struct {
+	SchemaVersion int    `json:"schema_version"`
+	ID            string `json:"id"`
+	CheckoutID    string `json:"checkout_id"`
+	Root          string `json:"root"`
+	CheckoutRoot  string `json:"checkout_root"`
+	RelativeRoot  string `json:"relative_root"`
+}
+
+type projectBinding struct {
+	root           string
+	checkoutRoot   string
+	relativeRoot   string
+	checkoutMarker string
+}
+
+// ValidateProjectID rejects anything that is not an opaque ID minted by the
+// registry. Besides catching typos, this keeps IDs safe as directory names.
+func ValidateProjectID(id string) error {
+	if !projectIDPattern.MatchString(id) {
+		return fmt.Errorf("invalid project id %q (expected %s followed by 32 lowercase hex characters)", id, projectIDPrefix)
+	}
+	return nil
+}
+
+// ListProjects reads every durable binding without creating the AF home, the
+// projects directory, or a lock file. Initial registration uses an atomic
+// directory rename and rebinding uses AtomicWriteFile, so readers never need a
+// mutating read lock to avoid partially-written records.
+func ListProjects() ([]Project, error) {
+	dir, err := projectRegistryDir()
+	if err != nil {
+		return nil, err
+	}
+	records, err := loadProjectRecords(dir)
+	if err != nil {
+		return nil, err
+	}
+	projects := make([]Project, 0, len(records))
+	for _, record := range records {
+		projects = append(projects, projectFromRecord(record))
+	}
+	return projects, nil
+}
+
+// RegisterProject records path as a project and returns its opaque identity.
+// Registering the same checkout again is idempotent, including when path names
+// a subdirectory: registration resolves it to the canonical main repo root. A
+// path in a different clone gets both a distinct project ID and checkout ID.
+func RegisterProject(path string) (Project, error) {
+	binding, err := resolveProjectBinding(path)
+	if err != nil {
+		return Project{}, err
+	}
+	dir, err := projectRegistryDir()
+	if err != nil {
+		return Project{}, err
+	}
+
+	var registered Project
+	err = WithFileLock(projectRegistryLockPath(dir), func() error {
+		records, err := loadProjectRecords(dir)
+		if err != nil {
+			return err
+		}
+		checkoutID, err := ensureCheckoutID(binding.checkoutMarker, "")
+		if err != nil {
+			return err
+		}
+		for _, record := range records {
+			if record.CheckoutID == checkoutID && record.RelativeRoot == binding.relativeRoot {
+				if !sameProjectPath(record.Root, binding.root) {
+					if projectPathExists(record.Root) && projectPathExists(binding.root) {
+						return fmt.Errorf("checkout marker %s appears at both %s and %s — move or remove one copy; af will not choose between them", checkoutID, record.Root, binding.root)
+					}
+					record.Root = binding.root
+					record.CheckoutRoot = binding.checkoutRoot
+					if err := writeProjectRecord(dir, record); err != nil {
+						return err
+					}
+				}
+				registered = projectFromRecord(record)
+				return nil
+			}
+			if sameProjectPath(record.Root, binding.root) {
+				return fmt.Errorf("path %s is already the last-known root of project %s, but this checkout has marker %s instead of %s — run `af projects rebind %s <replacement-path>` if this checkout replaces it; otherwise move the new checkout", binding.root, record.ID, checkoutID, record.CheckoutID, record.ID)
+			}
+		}
+		projectID, err := newOpaqueID(projectIDPrefix)
+		if err != nil {
+			return err
+		}
+		record := projectRecord{
+			SchemaVersion: projectRegistrySchemaVersion,
+			ID:            projectID,
+			CheckoutID:    checkoutID,
+			Root:          binding.root,
+			CheckoutRoot:  binding.checkoutRoot,
+			RelativeRoot:  binding.relativeRoot,
+		}
+		if err := writeNewProjectRecord(dir, record); err != nil {
+			return err
+		}
+		registered = projectFromRecord(record)
+		return nil
+	})
+	if err != nil {
+		return Project{}, fmt.Errorf("register project: %w", err)
+	}
+	return registered, nil
+}
+
+// RebindProject moves an existing stable project identity to path. It refuses
+// to steal a root already owned by another project. When path belongs to a
+// checkout already present in the registry, the rebound project joins that
+// checkout's identity. A whole-checkout move carries its marker and therefore
+// its checkout ID; a genuine new clone receives a new checkout ID.
+func RebindProject(id, path string) (Project, error) {
+	if err := ValidateProjectID(id); err != nil {
+		return Project{}, err
+	}
+	binding, err := resolveProjectBinding(path)
+	if err != nil {
+		return Project{}, err
+	}
+	dir, err := projectRegistryDir()
+	if err != nil {
+		return Project{}, err
+	}
+
+	var rebound Project
+	err = WithFileLock(projectRegistryLockPath(dir), func() error {
+		records, err := loadProjectRecords(dir)
+		if err != nil {
+			return err
+		}
+		index := -1
+		for i, record := range records {
+			if record.ID == id {
+				index = i
+				continue
+			}
+			if sameProjectPath(record.Root, binding.root) {
+				return fmt.Errorf("path %s is already registered as project %s", binding.root, record.ID)
+			}
+		}
+		if index < 0 {
+			return fmt.Errorf("project %s is not registered", id)
+		}
+
+		record := records[index]
+		preferredCheckoutID := ""
+		if sameProjectPath(record.CheckoutRoot, binding.checkoutRoot) {
+			preferredCheckoutID = record.CheckoutID
+		}
+		checkoutID, err := ensureCheckoutID(binding.checkoutMarker, preferredCheckoutID)
+		if err != nil {
+			return err
+		}
+		for i, candidate := range records {
+			if i == index {
+				continue
+			}
+			if candidate.CheckoutID == checkoutID && candidate.RelativeRoot == binding.relativeRoot {
+				return fmt.Errorf("checkout root %s and relative root %s are already registered as project %s", binding.checkoutRoot, binding.relativeRoot, candidate.ID)
+			}
+		}
+		if record.CheckoutID == checkoutID && !sameProjectPath(record.Root, binding.root) &&
+			projectPathExists(record.Root) && projectPathExists(binding.root) {
+			return fmt.Errorf("checkout marker %s appears at both %s and %s — move or remove one copy; af will not choose between them", checkoutID, record.Root, binding.root)
+		}
+		record.CheckoutID = checkoutID
+		record.Root = binding.root
+		record.CheckoutRoot = binding.checkoutRoot
+		record.RelativeRoot = binding.relativeRoot
+		if err := writeProjectRecord(dir, record); err != nil {
+			return err
+		}
+		rebound = projectFromRecord(record)
+		return nil
+	})
+	if err != nil {
+		return Project{}, fmt.Errorf("rebind project: %w", err)
+	}
+	return rebound, nil
+}
+
+func projectRegistryDir() (string, error) {
+	home, err := GetConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve AF home: %w", err)
+	}
+	return filepath.Join(home, "projects"), nil
+}
+
+func projectRegistryLockPath(dir string) string {
+	return filepath.Join(dir, ".registry")
+}
+
+func projectRecordPath(dir, id string) string {
+	return filepath.Join(dir, id, projectMetadataFileName)
+}
+
+func loadProjectRecords(dir string) ([]projectRecord, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read project registry: %w", err)
+	}
+	records := make([]projectRecord, 0, len(entries))
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		if !entry.IsDir() {
+			return nil, fmt.Errorf("read project registry: unexpected file %s", filepath.Join(dir, entry.Name()))
+		}
+		if err := ValidateProjectID(entry.Name()); err != nil {
+			return nil, fmt.Errorf("read project registry: %w", err)
+		}
+		data, err := os.ReadFile(projectRecordPath(dir, entry.Name()))
+		if err != nil {
+			return nil, fmt.Errorf("read project %s: %w", entry.Name(), err)
+		}
+		var record projectRecord
+		if err := json.Unmarshal(data, &record); err != nil {
+			return nil, fmt.Errorf("parse project %s: %w", entry.Name(), err)
+		}
+		if err := validateProjectRecord(entry.Name(), record); err != nil {
+			return nil, err
+		}
+		records = append(records, record)
+	}
+	sort.Slice(records, func(i, j int) bool { return records[i].ID < records[j].ID })
+	return records, nil
+}
+
+func validateProjectRecord(directoryID string, record projectRecord) error {
+	if record.SchemaVersion != projectRegistrySchemaVersion {
+		if record.SchemaVersion > projectRegistrySchemaVersion {
+			return fmt.Errorf("project %s uses schema version %d, but this af supports up to %d — upgrade af", directoryID, record.SchemaVersion, projectRegistrySchemaVersion)
+		}
+		return fmt.Errorf("project %s has unsupported schema version %d", directoryID, record.SchemaVersion)
+	}
+	if err := ValidateProjectID(record.ID); err != nil {
+		return fmt.Errorf("project %s metadata: %w", directoryID, err)
+	}
+	if record.ID != directoryID {
+		return fmt.Errorf("project directory %s contains metadata for %s", directoryID, record.ID)
+	}
+	if !checkoutIDPattern.MatchString(record.CheckoutID) {
+		return fmt.Errorf("project %s has invalid checkout id %q", record.ID, record.CheckoutID)
+	}
+	if err := validateStoredProjectPath("root", record.Root); err != nil {
+		return fmt.Errorf("project %s: %w", record.ID, err)
+	}
+	if err := validateStoredProjectPath("checkout root", record.CheckoutRoot); err != nil {
+		return fmt.Errorf("project %s: %w", record.ID, err)
+	}
+	if record.RelativeRoot == "" || filepath.IsAbs(record.RelativeRoot) {
+		return fmt.Errorf("project %s has invalid relative root %q", record.ID, record.RelativeRoot)
+	}
+	cleanRelative := filepath.Clean(filepath.FromSlash(record.RelativeRoot))
+	if cleanRelative == ".." || strings.HasPrefix(cleanRelative, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("project %s has relative root outside its checkout: %q", record.ID, record.RelativeRoot)
+	}
+	wantRoot := filepath.Clean(filepath.Join(record.CheckoutRoot, cleanRelative))
+	if !sameProjectPath(wantRoot, record.Root) {
+		return fmt.Errorf("project %s root %s does not match checkout root %s plus relative root %s", record.ID, record.Root, record.CheckoutRoot, record.RelativeRoot)
+	}
+	return nil
+}
+
+func validateStoredProjectPath(field, path string) error {
+	if !filepath.IsAbs(path) || filepath.Clean(path) != path {
+		return fmt.Errorf("%s must be a clean absolute path, got %q", field, path)
+	}
+	return nil
+}
+
+func resolveProjectBinding(path string) (projectBinding, error) {
+	abs, err := ResolveUserPath(path)
+	if err != nil {
+		return projectBinding{}, fmt.Errorf("resolve project path %q: %w", path, err)
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return projectBinding{}, fmt.Errorf("resolve project path %q: %w", abs, err)
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return projectBinding{}, fmt.Errorf("inspect project path %q: %w", resolved, err)
+	}
+	if !info.IsDir() {
+		return projectBinding{}, fmt.Errorf("project path %q is not a directory", resolved)
+	}
+
+	checkoutRoot, err := resolveMainRepoRoot("-C", resolved)
+	if err != nil {
+		return projectBinding{}, fmt.Errorf("project path %q is not inside a git checkout: %w", resolved, err)
+	}
+	checkoutRoot, err = filepath.EvalSymlinks(checkoutRoot)
+	if err != nil {
+		return projectBinding{}, fmt.Errorf("resolve git checkout root: %w", err)
+	}
+	commonCmd := exec.Command("git", "-C", resolved, "rev-parse", "--show-toplevel", "--git-common-dir")
+	commonOut, err := commonCmd.Output()
+	if err != nil {
+		return projectBinding{}, fmt.Errorf("resolve git common directory: %w", err)
+	}
+	commonParts := strings.SplitN(strings.TrimSpace(string(commonOut)), "\n", 2)
+	if len(commonParts) != 2 {
+		return projectBinding{}, fmt.Errorf("resolve git common directory: unexpected git output %q", strings.TrimSpace(string(commonOut)))
+	}
+	commonDir := commonParts[1]
+	if !filepath.IsAbs(commonDir) {
+		// git reports --git-common-dir relative to the -C working directory,
+		// not relative to --show-toplevel (from a nested path it may be
+		// "../../.git").
+		commonDir = filepath.Join(resolved, commonDir)
+	}
+	commonDir, err = filepath.EvalSymlinks(commonDir)
+	if err != nil {
+		return projectBinding{}, fmt.Errorf("resolve git common directory: %w", err)
+	}
+	return projectBinding{
+		root:           filepath.Clean(checkoutRoot),
+		checkoutRoot:   filepath.Clean(checkoutRoot),
+		relativeRoot:   ".",
+		checkoutMarker: filepath.Join(commonDir, checkoutMarkerDirName, checkoutMarkerFileName),
+	}, nil
+}
+
+func ensureCheckoutID(markerPath, preferred string) (string, error) {
+	checkoutID := ""
+	err := WithFileLock(markerPath, func() error {
+		data, err := os.ReadFile(markerPath)
+		if err == nil {
+			checkoutID = strings.TrimSpace(string(data))
+			if !checkoutIDPattern.MatchString(checkoutID) {
+				return fmt.Errorf("checkout marker %s contains invalid id %q", markerPath, checkoutID)
+			}
+			return nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("read checkout marker %s: %w", markerPath, err)
+		}
+		checkoutID = preferred
+		if checkoutID == "" {
+			checkoutID, err = newOpaqueID(checkoutIDPrefix)
+			if err != nil {
+				return err
+			}
+		}
+		if !checkoutIDPattern.MatchString(checkoutID) {
+			return fmt.Errorf("invalid checkout id %q", checkoutID)
+		}
+		if err := AtomicWriteFile(markerPath, []byte(checkoutID+"\n"), 0o644); err != nil {
+			return fmt.Errorf("write checkout marker %s: %w", markerPath, err)
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return checkoutID, nil
+}
+
+func writeNewProjectRecord(dir string, record projectRecord) error {
+	if err := ensureStorageParent(filepath.Join(dir, ".registry")); err != nil {
+		return err
+	}
+	staging, err := os.MkdirTemp(dir, ".project-tmp-")
+	if err != nil {
+		return fmt.Errorf("create project staging directory: %w", err)
+	}
+	defer os.RemoveAll(staging)
+	data, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal project metadata: %w", err)
+	}
+	if err := AtomicWriteFile(filepath.Join(staging, projectMetadataFileName), append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("stage project metadata: %w", err)
+	}
+	destination := filepath.Join(dir, record.ID)
+	if err := os.Rename(staging, destination); err != nil {
+		return fmt.Errorf("publish project metadata: %w", err)
+	}
+	syncProjectRegistryDir(dir, record.ID)
+	return nil
+}
+
+func writeProjectRecord(dir string, record projectRecord) error {
+	data, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal project metadata: %w", err)
+	}
+	if err := AtomicWriteFile(projectRecordPath(dir, record.ID), append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("write project metadata: %w", err)
+	}
+	return nil
+}
+
+func syncProjectRegistryDir(dir, id string) {
+	handle, err := os.Open(dir)
+	if err != nil {
+		log.WarningLog.Printf("project registry: project %s is visible but directory sync failed: %v", id, err)
+		return
+	}
+	if err := handle.Sync(); err != nil {
+		log.WarningLog.Printf("project registry: project %s is visible but directory sync failed: %v", id, err)
+	}
+	if err := handle.Close(); err != nil {
+		log.WarningLog.Printf("project registry: project %s is visible but directory close failed: %v", id, err)
+	}
+}
+
+func newOpaqueID(prefix string) (string, error) {
+	random := make([]byte, opaqueIDBytes)
+	if _, err := rand.Read(random); err != nil {
+		return "", fmt.Errorf("generate %s identity: %w", strings.TrimSuffix(prefix, "_"), err)
+	}
+	return prefix + hex.EncodeToString(random), nil
+}
+
+func projectFromRecord(record projectRecord) Project {
+	return Project{
+		ID:           record.ID,
+		CheckoutID:   record.CheckoutID,
+		Root:         record.Root,
+		RelativeRoot: record.RelativeRoot,
+		PathExists:   projectPathExists(record.Root),
+	}
+}
+
+func projectPathExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+func sameProjectPath(left, right string) bool {
+	if filepath.Clean(left) == filepath.Clean(right) {
+		return true
+	}
+	leftInfo, leftErr := os.Stat(left)
+	rightInfo, rightErr := os.Stat(right)
+	return leftErr == nil && rightErr == nil && os.SameFile(leftInfo, rightInfo)
+}

--- a/config/project_registry.go
+++ b/config/project_registry.go
@@ -148,15 +148,9 @@ func ResetProjectRegistry() error {
 		}
 
 		for marker := range markers {
-			if err := os.Remove(marker); err != nil && !errors.Is(err, os.ErrNotExist) {
-				return fmt.Errorf("remove checkout marker %s: %w", marker, err)
+			if err := removeCheckoutMarker(marker); err != nil {
+				return err
 			}
-			if err := os.Remove(marker + ".lock"); err != nil && !errors.Is(err, os.ErrNotExist) {
-				return fmt.Errorf("remove checkout marker lock %s: %w", marker+".lock", err)
-			}
-			// The directory is AF-owned, but future marker files may share it.
-			// Remove it only when empty; any error is therefore a safe keep.
-			_ = os.Remove(filepath.Dir(marker))
 		}
 		if err := os.RemoveAll(dir); err != nil {
 			return fmt.Errorf("remove project registry %s: %w", dir, err)
@@ -607,13 +601,27 @@ func projectRootHasCheckoutID(root, checkoutID string) (bool, error) {
 		if _, statErr := os.Lstat(filepath.Join(root, ".git")); errors.Is(statErr, os.ErrNotExist) {
 			return false, nil
 		}
-		return false, fmt.Errorf("inspect last-known project root %s: %w", root, err)
+		return false, fmt.Errorf("inspect existing Git metadata at last-known project root %s: %w", root, err)
 	}
 	id, exists, err := readCheckoutID(binding.checkoutMarkerPath)
 	if err != nil {
 		return false, err
 	}
 	return exists && id == checkoutID, nil
+}
+
+// removeCheckoutMarker removes only the current AF home's marker path. The
+// containing directory is shared by other home-scoped markers, so it is removed
+// only if empty.
+func removeCheckoutMarker(marker string) error {
+	if err := os.Remove(marker); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove checkout marker %s: %w", marker, err)
+	}
+	if err := os.Remove(marker + ".lock"); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove checkout marker lock %s: %w", marker+".lock", err)
+	}
+	_ = os.Remove(filepath.Dir(marker))
+	return nil
 }
 
 func projectRootUsesGitCommonDir(root, commonDir string) bool {

--- a/config/project_registry.go
+++ b/config/project_registry.go
@@ -124,21 +124,24 @@ func ResetProjectRegistry() error {
 		}
 		markers := make(map[string]string, len(records))
 		for _, record := range records {
-			binding, err := resolveProjectBinding(record.Root)
+			marker, accessible, err := storedProjectMarkerPath(record.Root)
 			if err != nil {
 				return fmt.Errorf("locate checkout marker for project %s: %w", record.ID, err)
 			}
-			markerID, exists, err := readCheckoutID(binding.checkoutMarkerPath)
+			if !accessible {
+				continue
+			}
+			markerID, exists, err := readCheckoutID(marker)
 			if err != nil {
 				return err
 			}
 			if exists && markerID != record.CheckoutID {
-				return fmt.Errorf("project %s expects checkout marker %s, but %s contains %s", record.ID, record.CheckoutID, binding.checkoutMarkerPath, markerID)
+				return fmt.Errorf("project %s expects checkout marker %s, but %s contains %s", record.ID, record.CheckoutID, marker, markerID)
 			}
-			if prior, exists := markers[binding.checkoutMarkerPath]; exists && prior != record.CheckoutID {
-				return fmt.Errorf("checkout marker %s is claimed by both %s and %s", binding.checkoutMarkerPath, prior, record.CheckoutID)
+			if prior, exists := markers[marker]; exists && prior != record.CheckoutID {
+				return fmt.Errorf("checkout marker %s is claimed by both %s and %s", marker, prior, record.CheckoutID)
 			}
-			markers[binding.checkoutMarkerPath] = record.CheckoutID
+			markers[marker] = record.CheckoutID
 		}
 
 		for marker := range markers {
@@ -179,9 +182,20 @@ func RegisterProject(path string) (Project, error) {
 		if err != nil {
 			return err
 		}
-		checkoutID, err := ensureCheckoutID(binding.checkoutMarkerPath)
+		checkoutID, markerExists, err := readCheckoutID(binding.checkoutMarkerPath)
 		if err != nil {
 			return err
+		}
+		if !markerExists {
+			for _, record := range records {
+				if sameProjectPath(record.Root, binding.root) {
+					return fmt.Errorf("path %s is already the last-known root of project %s, but this checkout has no marker instead of %s — run `af projects rebind %s <replacement-path>` if this checkout replaces it; otherwise move the new checkout", binding.root, record.ID, record.CheckoutID, record.ID)
+				}
+			}
+			checkoutID, err = ensureCheckoutID(binding.checkoutMarkerPath)
+			if err != nil {
+				return err
+			}
 		}
 		for _, record := range records {
 			if record.CheckoutID == checkoutID && record.RelativeRoot == binding.relativeRoot {
@@ -521,6 +535,34 @@ func readCheckoutID(markerPath string) (id string, exists bool, err error) {
 		return "", false, fmt.Errorf("checkout marker %s contains invalid id %q", markerPath, id)
 	}
 	return id, true, nil
+}
+
+// storedProjectMarkerPath resolves a marker only while the record's last-known
+// root is still reachable. A moved/deleted checkout gives reset no safe path to
+// mutate, but must not strand AF's own registry. An existing root with a broken
+// Git entry remains an error because it may still contain identity state that
+// reset cannot validate.
+func storedProjectMarkerPath(root string) (string, bool, error) {
+	binding, err := resolveProjectBinding(root)
+	if err == nil {
+		return binding.checkoutMarkerPath, true, nil
+	}
+	info, statErr := os.Stat(root)
+	if errors.Is(statErr, os.ErrNotExist) {
+		return "", false, nil
+	}
+	if statErr != nil {
+		return "", false, fmt.Errorf("inspect last-known project root %s: %w", root, statErr)
+	}
+	if !info.IsDir() {
+		return "", false, nil
+	}
+	if _, gitErr := os.Lstat(filepath.Join(root, ".git")); errors.Is(gitErr, os.ErrNotExist) {
+		return "", false, nil
+	} else if gitErr != nil {
+		return "", false, fmt.Errorf("inspect last-known project Git entry %s: %w", root, gitErr)
+	}
+	return "", false, err
 }
 
 func projectRootHasCheckoutID(root, checkoutID string) (bool, error) {

--- a/config/project_registry.go
+++ b/config/project_registry.go
@@ -161,9 +161,10 @@ func RegisterProject(path string) (Project, error) {
 
 // RebindProject moves an existing stable project identity to path. It refuses
 // to steal a root already owned by another project. When path belongs to a
-// checkout already present in the registry, the rebound project joins that
-// checkout's identity. A whole-checkout move carries its marker and therefore
-// its checkout ID; a genuine new clone receives a new checkout ID.
+// checkout already present in the registry, its marker is reused unless that
+// would duplicate another project binding. A whole-checkout move carries its
+// marker and therefore its checkout ID; a genuine new clone receives a new
+// checkout ID.
 func RebindProject(id, path string) (Project, error) {
 	if err := ValidateProjectID(id); err != nil {
 		return Project{}, err

--- a/config/project_registry.go
+++ b/config/project_registry.go
@@ -16,6 +16,10 @@ import (
 	"github.com/sachiniyer/agent-factory/log"
 )
 
+// ProjectRegistryDirName is the AF-home directory containing durable project
+// identities and their future personal configuration.
+const ProjectRegistryDirName = "projects"
+
 const (
 	projectRegistrySchemaVersion = 1
 	projectMetadataFileName      = "project.json"
@@ -60,6 +64,7 @@ type projectBinding struct {
 	root           string
 	checkoutRoot   string
 	relativeRoot   string
+	gitCommonDir   string
 	checkoutMarker string
 }
 
@@ -112,20 +117,24 @@ func RegisterProject(path string) (Project, error) {
 		if err != nil {
 			return err
 		}
-		checkoutID, err := ensureCheckoutID(binding.checkoutMarker, "")
+		checkoutID, err := ensureCheckoutID(binding.checkoutMarker)
 		if err != nil {
 			return err
 		}
 		for _, record := range records {
 			if record.CheckoutID == checkoutID && record.RelativeRoot == binding.relativeRoot {
 				if !sameProjectPath(record.Root, binding.root) {
-					if projectPathExists(record.Root) && projectPathExists(binding.root) {
+					oldRootExists := projectPathExists(record.Root)
+					if oldRootExists && projectPathExists(binding.root) &&
+						!projectRootUsesGitCommonDir(record.Root, binding.gitCommonDir) {
 						return fmt.Errorf("checkout marker %s appears at both %s and %s — move or remove one copy; af will not choose between them", checkoutID, record.Root, binding.root)
 					}
-					record.Root = binding.root
-					record.CheckoutRoot = binding.checkoutRoot
-					if err := writeProjectRecord(dir, record); err != nil {
-						return err
+					if !oldRootExists {
+						record.Root = binding.root
+						record.CheckoutRoot = binding.checkoutRoot
+						if err := writeProjectRecord(dir, record); err != nil {
+							return err
+						}
 					}
 				}
 				registered = projectFromRecord(record)
@@ -199,11 +208,7 @@ func RebindProject(id, path string) (Project, error) {
 		}
 
 		record := records[index]
-		preferredCheckoutID := ""
-		if sameProjectPath(record.CheckoutRoot, binding.checkoutRoot) {
-			preferredCheckoutID = record.CheckoutID
-		}
-		checkoutID, err := ensureCheckoutID(binding.checkoutMarker, preferredCheckoutID)
+		checkoutID, err := ensureCheckoutID(binding.checkoutMarker)
 		if err != nil {
 			return err
 		}
@@ -216,7 +221,8 @@ func RebindProject(id, path string) (Project, error) {
 			}
 		}
 		if record.CheckoutID == checkoutID && !sameProjectPath(record.Root, binding.root) &&
-			projectPathExists(record.Root) && projectPathExists(binding.root) {
+			projectPathExists(record.Root) && projectPathExists(binding.root) &&
+			!projectRootUsesGitCommonDir(record.Root, binding.gitCommonDir) {
 			return fmt.Errorf("checkout marker %s appears at both %s and %s — move or remove one copy; af will not choose between them", checkoutID, record.Root, binding.root)
 		}
 		record.CheckoutID = checkoutID
@@ -240,7 +246,7 @@ func projectRegistryDir() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("resolve AF home: %w", err)
 	}
-	return filepath.Join(home, "projects"), nil
+	return filepath.Join(home, ProjectRegistryDirName), nil
 }
 
 func projectRegistryLockPath(dir string) string {
@@ -347,14 +353,6 @@ func resolveProjectBinding(path string) (projectBinding, error) {
 		return projectBinding{}, fmt.Errorf("project path %q is not a directory", resolved)
 	}
 
-	checkoutRoot, err := resolveMainRepoRoot("-C", resolved)
-	if err != nil {
-		return projectBinding{}, fmt.Errorf("project path %q is not inside a git checkout: %w", resolved, err)
-	}
-	checkoutRoot, err = filepath.EvalSymlinks(checkoutRoot)
-	if err != nil {
-		return projectBinding{}, fmt.Errorf("resolve git checkout root: %w", err)
-	}
 	commonCmd := exec.Command("git", "-C", resolved, "rev-parse", "--show-toplevel", "--git-common-dir")
 	commonOut, err := commonCmd.Output()
 	if err != nil {
@@ -363,6 +361,10 @@ func resolveProjectBinding(path string) (projectBinding, error) {
 	commonParts := strings.SplitN(strings.TrimSpace(string(commonOut)), "\n", 2)
 	if len(commonParts) != 2 {
 		return projectBinding{}, fmt.Errorf("resolve git common directory: unexpected git output %q", strings.TrimSpace(string(commonOut)))
+	}
+	worktreeRoot, err := filepath.EvalSymlinks(commonParts[0])
+	if err != nil {
+		return projectBinding{}, fmt.Errorf("resolve git worktree root: %w", err)
 	}
 	commonDir := commonParts[1]
 	if !filepath.IsAbs(commonDir) {
@@ -375,15 +377,36 @@ func resolveProjectBinding(path string) (projectBinding, error) {
 	if err != nil {
 		return projectBinding{}, fmt.Errorf("resolve git common directory: %w", err)
 	}
+	bareCmd := exec.Command("git", "--git-dir", commonDir, "rev-parse", "--is-bare-repository")
+	bareOut, err := bareCmd.Output()
+	if err != nil {
+		return projectBinding{}, fmt.Errorf("inspect git common directory: %w", err)
+	}
+	bare := strings.TrimSpace(string(bareOut))
+	if bare != "true" && bare != "false" {
+		return projectBinding{}, fmt.Errorf("inspect git common directory: unexpected git output %q", bare)
+	}
+	checkoutRoot := worktreeRoot
+	if bare == "false" {
+		checkoutRoot, err = resolveMainRepoRoot("-C", resolved)
+		if err != nil {
+			return projectBinding{}, fmt.Errorf("project path %q is not inside a git checkout: %w", resolved, err)
+		}
+		checkoutRoot, err = filepath.EvalSymlinks(checkoutRoot)
+		if err != nil {
+			return projectBinding{}, fmt.Errorf("resolve git checkout root: %w", err)
+		}
+	}
 	return projectBinding{
 		root:           filepath.Clean(checkoutRoot),
 		checkoutRoot:   filepath.Clean(checkoutRoot),
 		relativeRoot:   ".",
+		gitCommonDir:   filepath.Clean(commonDir),
 		checkoutMarker: filepath.Join(commonDir, checkoutMarkerDirName, checkoutMarkerFileName),
 	}, nil
 }
 
-func ensureCheckoutID(markerPath, preferred string) (string, error) {
+func ensureCheckoutID(markerPath string) (string, error) {
 	checkoutID := ""
 	err := WithFileLock(markerPath, func() error {
 		data, err := os.ReadFile(markerPath)
@@ -397,12 +420,9 @@ func ensureCheckoutID(markerPath, preferred string) (string, error) {
 		if !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("read checkout marker %s: %w", markerPath, err)
 		}
-		checkoutID = preferred
-		if checkoutID == "" {
-			checkoutID, err = newOpaqueID(checkoutIDPrefix)
-			if err != nil {
-				return err
-			}
+		checkoutID, err = newOpaqueID(checkoutIDPrefix)
+		if err != nil {
+			return err
 		}
 		if !checkoutIDPattern.MatchString(checkoutID) {
 			return fmt.Errorf("invalid checkout id %q", checkoutID)
@@ -416,6 +436,11 @@ func ensureCheckoutID(markerPath, preferred string) (string, error) {
 		return "", err
 	}
 	return checkoutID, nil
+}
+
+func projectRootUsesGitCommonDir(root, commonDir string) bool {
+	binding, err := resolveProjectBinding(root)
+	return err == nil && sameProjectPath(binding.gitCommonDir, commonDir)
 }
 
 func writeNewProjectRecord(dir string, record projectRecord) error {

--- a/config/project_registry.go
+++ b/config/project_registry.go
@@ -16,9 +16,12 @@ import (
 	"github.com/sachiniyer/agent-factory/log"
 )
 
-// ProjectRegistryDirName is the AF-home directory containing durable project
-// identities and their future personal configuration.
-const ProjectRegistryDirName = "projects"
+// ProjectRegistryDirName is the unmistakably AF-owned directory containing
+// durable project identities and their future personal configuration. The
+// explicit namespace matters when AGENT_FACTORY_HOME is a broad caller-owned
+// directory such as the user's home: reset must never confuse ~/projects with
+// AF state.
+const ProjectRegistryDirName = ".agent-factory-projects"
 
 const (
 	projectRegistrySchemaVersion = 1
@@ -97,6 +100,65 @@ func ListProjects() ([]Project, error) {
 	return projects, nil
 }
 
+// ResetProjectRegistry removes durable project records and the checkout
+// markers they own. It validates every record and marker before deleting
+// anything, then removes only the unmistakably AF-owned registry directory.
+// Callers must run this before deleting registered worktrees so their Git
+// common directories are still resolvable.
+func ResetProjectRegistry() error {
+	dir, err := projectRegistryDir()
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(dir); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("inspect project registry: %w", err)
+	}
+
+	return WithFileLock(projectRegistryLockPath(dir), func() error {
+		records, err := loadProjectRecords(dir)
+		if err != nil {
+			return err
+		}
+		markers := make(map[string]string, len(records))
+		for _, record := range records {
+			binding, err := resolveProjectBinding(record.Root)
+			if err != nil {
+				return fmt.Errorf("locate checkout marker for project %s: %w", record.ID, err)
+			}
+			markerID, exists, err := readCheckoutID(binding.checkoutMarker)
+			if err != nil {
+				return err
+			}
+			if exists && markerID != record.CheckoutID {
+				return fmt.Errorf("project %s expects checkout marker %s, but %s contains %s", record.ID, record.CheckoutID, binding.checkoutMarker, markerID)
+			}
+			if prior, exists := markers[binding.checkoutMarker]; exists && prior != record.CheckoutID {
+				return fmt.Errorf("checkout marker %s is claimed by both %s and %s", binding.checkoutMarker, prior, record.CheckoutID)
+			}
+			markers[binding.checkoutMarker] = record.CheckoutID
+		}
+
+		for marker := range markers {
+			if err := os.Remove(marker); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("remove checkout marker %s: %w", marker, err)
+			}
+			if err := os.Remove(marker + ".lock"); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("remove checkout marker lock %s: %w", marker+".lock", err)
+			}
+			// The directory is AF-owned, but future marker files may share it.
+			// Remove it only when empty; any error is therefore a safe keep.
+			_ = os.Remove(filepath.Dir(marker))
+		}
+		if err := os.RemoveAll(dir); err != nil {
+			return fmt.Errorf("remove project registry %s: %w", dir, err)
+		}
+		return nil
+	})
+}
+
 // RegisterProject records path as a project and returns its opaque identity.
 // Registering the same checkout again is idempotent, including when path names
 // a subdirectory: registration resolves it to the canonical main repo root. A
@@ -124,12 +186,15 @@ func RegisterProject(path string) (Project, error) {
 		for _, record := range records {
 			if record.CheckoutID == checkoutID && record.RelativeRoot == binding.relativeRoot {
 				if !sameProjectPath(record.Root, binding.root) {
-					oldRootExists := projectPathExists(record.Root)
-					if oldRootExists && projectPathExists(binding.root) &&
+					oldRootHasMarker, err := projectRootHasCheckoutID(record.Root, checkoutID)
+					if err != nil {
+						return err
+					}
+					if oldRootHasMarker && projectPathExists(binding.root) &&
 						!projectRootUsesGitCommonDir(record.Root, binding.gitCommonDir) {
 						return fmt.Errorf("checkout marker %s appears at both %s and %s — move or remove one copy; af will not choose between them", checkoutID, record.Root, binding.root)
 					}
-					if !oldRootExists {
+					if !oldRootHasMarker {
 						record.Root = binding.root
 						record.CheckoutRoot = binding.checkoutRoot
 						if err := writeProjectRecord(dir, record); err != nil {
@@ -220,10 +285,15 @@ func RebindProject(id, path string) (Project, error) {
 				return fmt.Errorf("checkout root %s and relative root %s are already registered as project %s", binding.checkoutRoot, binding.relativeRoot, candidate.ID)
 			}
 		}
-		if record.CheckoutID == checkoutID && !sameProjectPath(record.Root, binding.root) &&
-			projectPathExists(record.Root) && projectPathExists(binding.root) &&
-			!projectRootUsesGitCommonDir(record.Root, binding.gitCommonDir) {
-			return fmt.Errorf("checkout marker %s appears at both %s and %s — move or remove one copy; af will not choose between them", checkoutID, record.Root, binding.root)
+		if record.CheckoutID == checkoutID && !sameProjectPath(record.Root, binding.root) {
+			oldRootHasMarker, err := projectRootHasCheckoutID(record.Root, checkoutID)
+			if err != nil {
+				return err
+			}
+			if oldRootHasMarker && projectPathExists(binding.root) &&
+				!projectRootUsesGitCommonDir(record.Root, binding.gitCommonDir) {
+				return fmt.Errorf("checkout marker %s appears at both %s and %s — move or remove one copy; af will not choose between them", checkoutID, record.Root, binding.root)
+			}
 		}
 		record.CheckoutID = checkoutID
 		record.Root = binding.root
@@ -436,6 +506,38 @@ func ensureCheckoutID(markerPath string) (string, error) {
 		return "", err
 	}
 	return checkoutID, nil
+}
+
+func readCheckoutID(markerPath string) (id string, exists bool, err error) {
+	data, err := os.ReadFile(markerPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("read checkout marker %s: %w", markerPath, err)
+	}
+	id = strings.TrimSpace(string(data))
+	if !checkoutIDPattern.MatchString(id) {
+		return "", false, fmt.Errorf("checkout marker %s contains invalid id %q", markerPath, id)
+	}
+	return id, true, nil
+}
+
+func projectRootHasCheckoutID(root, checkoutID string) (bool, error) {
+	binding, err := resolveProjectBinding(root)
+	if err != nil {
+		// A caller-owned directory may legitimately reuse a moved checkout's
+		// old path. With no .git entry it cannot carry this checkout marker.
+		if _, statErr := os.Lstat(filepath.Join(root, ".git")); errors.Is(statErr, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("inspect last-known project root %s: %w", root, err)
+	}
+	id, exists, err := readCheckoutID(binding.checkoutMarker)
+	if err != nil {
+		return false, err
+	}
+	return exists && id == checkoutID, nil
 }
 
 func projectRootUsesGitCommonDir(root, commonDir string) bool {

--- a/config/project_registry.go
+++ b/config/project_registry.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -13,6 +14,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/sachiniyer/agent-factory/internal/pathutil"
 	"github.com/sachiniyer/agent-factory/log"
 )
 
@@ -27,7 +29,7 @@ const (
 	projectRegistrySchemaVersion = 1
 	projectMetadataFileName      = "project.json"
 	checkoutMarkerDirName        = "agent-factory"
-	checkoutMarkerFileName       = "checkout-id"
+	checkoutMarkerFilePrefix     = "checkout-id-"
 	projectIDPrefix              = "prj_"
 	checkoutIDPrefix             = "chk_"
 	opaqueIDBytes                = 16
@@ -40,9 +42,9 @@ var (
 
 // Project is a durable machine-local project binding. ID is stable across an
 // explicit rebind; Root is only the last-known path. CheckoutID distinguishes
-// two clones, and RelativeRoot reserves the checkout-relative identity axis for
-// a later monorepo slice (repo-root registrations use "."). No session or task
-// is required for a Project to exist.
+// two clones within this AF home, and RelativeRoot reserves the checkout-relative
+// identity axis for a later monorepo slice (repo-root registrations use "."). No
+// session or task is required for a Project to exist.
 type Project struct {
 	ID           string `json:"id"`
 	CheckoutID   string `json:"checkout_id"`
@@ -100,11 +102,12 @@ func ListProjects() ([]Project, error) {
 	return projects, nil
 }
 
-// ResetProjectRegistry removes durable project records and the checkout
-// markers they own. It validates every record and marker before deleting
-// anything, then removes only the unmistakably AF-owned registry directory.
-// Callers must run this before deleting registered worktrees so their Git
-// common directories are still resolvable.
+// ResetProjectRegistry removes durable project records and this AF home's
+// checkout markers. Markers are home-scoped so resetting one home cannot break
+// another home's registry for the same checkout. It validates every record and
+// marker before deleting anything, then removes only the unmistakably AF-owned
+// registry directory. Callers must run this before deleting registered
+// worktrees so their Git common directories are still resolvable.
 func ResetProjectRegistry() error {
 	dir, err := projectRegistryDir()
 	if err != nil {
@@ -470,6 +473,10 @@ func resolveProjectBinding(path string) (projectBinding, error) {
 	if bare != "true" && bare != "false" {
 		return projectBinding{}, fmt.Errorf("inspect git common directory: unexpected git output %q", bare)
 	}
+	markerName, err := checkoutMarkerName()
+	if err != nil {
+		return projectBinding{}, err
+	}
 	checkoutRoot := worktreeRoot
 	if bare == "false" {
 		checkoutRoot, err = resolveMainRepoRoot("-C", resolved)
@@ -486,8 +493,25 @@ func resolveProjectBinding(path string) (projectBinding, error) {
 		checkoutRoot:       filepath.Clean(checkoutRoot),
 		relativeRoot:       ".",
 		gitCommonDir:       filepath.Clean(commonDir),
-		checkoutMarkerPath: filepath.Join(commonDir, checkoutMarkerDirName, checkoutMarkerFileName),
+		checkoutMarkerPath: filepath.Join(commonDir, checkoutMarkerDirName, markerName),
 	}, nil
+}
+
+// checkoutMarkerName scopes a checkout identity to one canonical AF home. The
+// marker still moves with the Git common directory, while a factory reset of a
+// different home has a different file to remove. Hashing keeps an absolute
+// home path out of the repository's machine-local metadata.
+func checkoutMarkerName() (string, error) {
+	home, err := GetConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve AF home for checkout marker: %w", err)
+	}
+	absHome, err := filepath.Abs(home)
+	if err != nil {
+		return "", fmt.Errorf("resolve absolute AF home for checkout marker: %w", err)
+	}
+	digest := sha256.Sum256([]byte(pathutil.ResolveForCompare(absHome)))
+	return checkoutMarkerFilePrefix + hex.EncodeToString(digest[:opaqueIDBytes]), nil
 }
 
 func ensureCheckoutID(markerPath string) (string, error) {
@@ -566,6 +590,16 @@ func storedProjectMarkerPath(root string) (string, bool, error) {
 }
 
 func projectRootHasCheckoutID(root, checkoutID string) (bool, error) {
+	info, statErr := os.Stat(root)
+	if errors.Is(statErr, os.ErrNotExist) {
+		return false, nil
+	}
+	if statErr != nil {
+		return false, fmt.Errorf("inspect last-known project root %s: %w", root, statErr)
+	}
+	if !info.IsDir() {
+		return false, nil
+	}
 	binding, err := resolveProjectBinding(root)
 	if err != nil {
 		// A caller-owned directory may legitimately reuse a moved checkout's

--- a/config/project_registry.go
+++ b/config/project_registry.go
@@ -64,11 +64,11 @@ type projectRecord struct {
 }
 
 type projectBinding struct {
-	root           string
-	checkoutRoot   string
-	relativeRoot   string
-	gitCommonDir   string
-	checkoutMarker string
+	root               string
+	checkoutRoot       string
+	relativeRoot       string
+	gitCommonDir       string
+	checkoutMarkerPath string
 }
 
 // ValidateProjectID rejects anything that is not an opaque ID minted by the
@@ -128,17 +128,17 @@ func ResetProjectRegistry() error {
 			if err != nil {
 				return fmt.Errorf("locate checkout marker for project %s: %w", record.ID, err)
 			}
-			markerID, exists, err := readCheckoutID(binding.checkoutMarker)
+			markerID, exists, err := readCheckoutID(binding.checkoutMarkerPath)
 			if err != nil {
 				return err
 			}
 			if exists && markerID != record.CheckoutID {
-				return fmt.Errorf("project %s expects checkout marker %s, but %s contains %s", record.ID, record.CheckoutID, binding.checkoutMarker, markerID)
+				return fmt.Errorf("project %s expects checkout marker %s, but %s contains %s", record.ID, record.CheckoutID, binding.checkoutMarkerPath, markerID)
 			}
-			if prior, exists := markers[binding.checkoutMarker]; exists && prior != record.CheckoutID {
-				return fmt.Errorf("checkout marker %s is claimed by both %s and %s", binding.checkoutMarker, prior, record.CheckoutID)
+			if prior, exists := markers[binding.checkoutMarkerPath]; exists && prior != record.CheckoutID {
+				return fmt.Errorf("checkout marker %s is claimed by both %s and %s", binding.checkoutMarkerPath, prior, record.CheckoutID)
 			}
-			markers[binding.checkoutMarker] = record.CheckoutID
+			markers[binding.checkoutMarkerPath] = record.CheckoutID
 		}
 
 		for marker := range markers {
@@ -179,7 +179,7 @@ func RegisterProject(path string) (Project, error) {
 		if err != nil {
 			return err
 		}
-		checkoutID, err := ensureCheckoutID(binding.checkoutMarker)
+		checkoutID, err := ensureCheckoutID(binding.checkoutMarkerPath)
 		if err != nil {
 			return err
 		}
@@ -273,7 +273,7 @@ func RebindProject(id, path string) (Project, error) {
 		}
 
 		record := records[index]
-		checkoutID, err := ensureCheckoutID(binding.checkoutMarker)
+		checkoutID, err := ensureCheckoutID(binding.checkoutMarkerPath)
 		if err != nil {
 			return err
 		}
@@ -468,11 +468,11 @@ func resolveProjectBinding(path string) (projectBinding, error) {
 		}
 	}
 	return projectBinding{
-		root:           filepath.Clean(checkoutRoot),
-		checkoutRoot:   filepath.Clean(checkoutRoot),
-		relativeRoot:   ".",
-		gitCommonDir:   filepath.Clean(commonDir),
-		checkoutMarker: filepath.Join(commonDir, checkoutMarkerDirName, checkoutMarkerFileName),
+		root:               filepath.Clean(checkoutRoot),
+		checkoutRoot:       filepath.Clean(checkoutRoot),
+		relativeRoot:       ".",
+		gitCommonDir:       filepath.Clean(commonDir),
+		checkoutMarkerPath: filepath.Join(commonDir, checkoutMarkerDirName, checkoutMarkerFileName),
 	}, nil
 }
 
@@ -533,7 +533,7 @@ func projectRootHasCheckoutID(root, checkoutID string) (bool, error) {
 		}
 		return false, fmt.Errorf("inspect last-known project root %s: %w", root, err)
 	}
-	id, exists, err := readCheckoutID(binding.checkoutMarker)
+	id, exists, err := readCheckoutID(binding.checkoutMarkerPath)
 	if err != nil {
 		return false, err
 	}

--- a/config/project_registry_test.go
+++ b/config/project_registry_test.go
@@ -93,7 +93,7 @@ func TestProjectRegistryPersistsSessionlessRepoFromArbitraryPath(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []Project{registered}, projects,
 		"the registry must list an explicitly registered project with zero sessions and zero tasks")
-	_, err = os.Stat(filepath.Join(repo, ".git", checkoutMarkerDirName, checkoutMarkerFileName))
+	_, err = os.Stat(projectCheckoutMarkerPath(t, repo))
 	require.NoError(t, err, "registration must anchor identity in the Git common directory")
 }
 
@@ -105,7 +105,7 @@ func TestResetProjectRegistryRefusesMarkerItDoesNotOwn(t *testing.T) {
 	registered, err := RegisterProject(repo)
 	require.NoError(t, err)
 
-	marker := filepath.Join(repo, ".git", checkoutMarkerDirName, checkoutMarkerFileName)
+	marker := projectCheckoutMarkerPath(t, repo)
 	foreignID := "chk_ffffffffffffffffffffffffffffffff"
 	require.NoError(t, os.WriteFile(marker, []byte(foreignID+"\n"), 0o644))
 
@@ -280,6 +280,96 @@ func TestProjectRegistryMoveIgnoresReusedUnmarkedOldRoot(t *testing.T) {
 	}
 }
 
+func TestProjectRegistryMoveIgnoresReusedFileAtOldRoot(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		move func(Project, string) (Project, error)
+	}{
+		{
+			name: "register",
+			move: func(_ Project, movedRoot string) (Project, error) {
+				return RegisterProject(movedRoot)
+			},
+		},
+		{
+			name: "rebind",
+			move: func(project Project, movedRoot string) (Project, error) {
+				return RebindProject(project.ID, movedRoot)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			base := t.TempDir()
+			t.Setenv("AGENT_FACTORY_HOME", filepath.Join(base, "af-home"))
+			oldRoot := filepath.Join(base, "repo")
+			project, err := RegisterProject(initProjectRegistryRepo(t, oldRoot))
+			require.NoError(t, err)
+
+			movedRoot := filepath.Join(base, "moved")
+			require.NoError(t, os.Rename(oldRoot, movedRoot))
+			require.NoError(t, os.WriteFile(oldRoot, []byte("unrelated\n"), 0o644),
+				"an unrelated file now reuses the last-known path")
+
+			moved, err := tc.move(project, movedRoot)
+			require.NoError(t, err,
+				"a non-directory old path cannot contain this checkout's marker")
+			require.Equal(t, project.ID, moved.ID)
+			require.Equal(t, project.CheckoutID, moved.CheckoutID)
+			require.Equal(t, canonicalExistingPath(t, movedRoot), moved.Root)
+		})
+	}
+}
+
+func TestResetProjectRegistryPreservesAnotherHomesCheckoutIdentity(t *testing.T) {
+	base := t.TempDir()
+	repo := initProjectRegistryRepo(t, filepath.Join(base, "repo"))
+	firstHome := filepath.Join(base, "first-home")
+	secondHome := filepath.Join(base, "second-home")
+
+	t.Setenv("AGENT_FACTORY_HOME", firstHome)
+	_, err := RegisterProject(repo)
+	require.NoError(t, err)
+
+	t.Setenv("AGENT_FACTORY_HOME", secondHome)
+	second, err := RegisterProject(repo)
+	require.NoError(t, err)
+	secondBinding, err := resolveProjectBinding(repo)
+	require.NoError(t, err)
+
+	t.Setenv("AGENT_FACTORY_HOME", firstHome)
+	require.NoError(t, ResetProjectRegistry())
+
+	t.Setenv("AGENT_FACTORY_HOME", secondHome)
+	require.FileExists(t, secondBinding.checkoutMarkerPath,
+		"resetting one AF home must not remove another home's checkout identity")
+	again, err := RegisterProject(repo)
+	require.NoError(t, err,
+		"the untouched home must still resolve the checkout after the other home resets")
+	require.Equal(t, second.ID, again.ID)
+	require.Equal(t, second.CheckoutID, again.CheckoutID)
+}
+
+func TestProjectRegistryHomeAliasesShareCheckoutIdentity(t *testing.T) {
+	base := t.TempDir()
+	realHome := filepath.Join(base, "real-home")
+	require.NoError(t, os.MkdirAll(realHome, 0o755))
+	aliasHome := filepath.Join(base, "alias-home")
+	require.NoError(t, os.Symlink(realHome, aliasHome))
+	repo := initProjectRegistryRepo(t, filepath.Join(base, "repo"))
+
+	t.Setenv("AGENT_FACTORY_HOME", realHome)
+	registered, err := RegisterProject(repo)
+	require.NoError(t, err)
+	realMarker := projectCheckoutMarkerPath(t, repo)
+
+	t.Setenv("AGENT_FACTORY_HOME", aliasHome)
+	throughAlias, err := RegisterProject(repo)
+	require.NoError(t, err,
+		"two spellings of one AF home must not mint competing checkout identities")
+	require.Equal(t, registered, throughAlias)
+	require.Equal(t, realMarker, projectCheckoutMarkerPath(t, repo))
+}
+
 func TestRegisterProjectLinkedWorktreeUsesMainCheckoutIdentity(t *testing.T) {
 	base := t.TempDir()
 	t.Setenv("AGENT_FACTORY_HOME", filepath.Join(base, "af-home"))
@@ -336,7 +426,7 @@ func TestRejectedReplacementRegistrationDoesNotMintCheckoutMarker(t *testing.T) 
 	require.NoError(t, os.Rename(originalPath, filepath.Join(base, "old-checkout")))
 
 	replacement := initProjectRegistryRepo(t, originalPath)
-	marker := filepath.Join(replacement, ".git", checkoutMarkerDirName, checkoutMarkerFileName)
+	marker := projectCheckoutMarkerPath(t, replacement)
 	require.NoFileExists(t, marker)
 
 	_, err = RegisterProject(replacement)
@@ -357,13 +447,13 @@ func TestRegisterProjectRejectsCopiedCheckoutMarkerAtTwoLiveRoots(t *testing.T) 
 	firstRoot := initProjectRegistryRepo(t, filepath.Join(base, "first"))
 	first, err := RegisterProject(firstRoot)
 	require.NoError(t, err)
-	markerData, err := os.ReadFile(filepath.Join(firstRoot, ".git", checkoutMarkerDirName, checkoutMarkerFileName))
+	markerData, err := os.ReadFile(projectCheckoutMarkerPath(t, firstRoot))
 	require.NoError(t, err)
 
 	secondRoot := initProjectRegistryRepo(t, filepath.Join(base, "second"))
-	secondMarkerDir := filepath.Join(secondRoot, ".git", checkoutMarkerDirName)
-	require.NoError(t, os.MkdirAll(secondMarkerDir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(secondMarkerDir, checkoutMarkerFileName), markerData, 0o644))
+	secondMarker := projectCheckoutMarkerPath(t, secondRoot)
+	require.NoError(t, os.MkdirAll(filepath.Dir(secondMarker), 0o755))
+	require.NoError(t, os.WriteFile(secondMarker, markerData, 0o644))
 	_, err = RegisterProject(secondRoot)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), first.CheckoutID)
@@ -471,6 +561,13 @@ func runProjectRegistryGit(t *testing.T, root string, args ...string) {
 	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null")
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "git %v failed: %s", args, out)
+}
+
+func projectCheckoutMarkerPath(t *testing.T, root string) string {
+	t.Helper()
+	binding, err := resolveProjectBinding(root)
+	require.NoError(t, err)
+	return binding.checkoutMarkerPath
 }
 
 func canonicalExistingPath(t *testing.T, path string) string {

--- a/config/project_registry_test.go
+++ b/config/project_registry_test.go
@@ -1,0 +1,295 @@
+package config
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListProjectsMissingHomeIsReadOnly(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "missing-af-home")
+	t.Setenv("AGENT_FACTORY_HOME", home)
+
+	projects, err := ListProjects()
+	require.NoError(t, err)
+	require.Empty(t, projects)
+	_, statErr := os.Stat(home)
+	require.ErrorIs(t, statErr, os.ErrNotExist, "a read-only list must not materialize the AF home")
+}
+
+func TestProjectRegistryRebindPreservesIdentityAndClonesStayDistinct(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", filepath.Join(base, "af-home"))
+
+	originalRoot := initProjectRegistryRepo(t, filepath.Join(base, "checkout-before-move"))
+	registered, err := RegisterProject(originalRoot)
+	require.NoError(t, err)
+	require.Regexp(t, projectIDPattern, registered.ID)
+	require.Regexp(t, checkoutIDPattern, registered.CheckoutID)
+	require.True(t, registered.PathExists)
+	require.Equal(t, ".", registered.RelativeRoot)
+
+	again, err := RegisterProject(originalRoot)
+	require.NoError(t, err)
+	require.Equal(t, registered.ID, again.ID, "registration of one canonical root must be idempotent")
+
+	movedRoot := filepath.Join(base, "checkout-after-move")
+	require.NoError(t, os.Rename(originalRoot, movedRoot))
+	beforeRebind, err := ListProjects()
+	require.NoError(t, err)
+	require.Len(t, beforeRebind, 1)
+	require.False(t, beforeRebind[0].PathExists, "a moved checkout must retain only its unavailable path hint, not silently rebind")
+
+	rebound, err := RebindProject(registered.ID, movedRoot)
+	require.NoError(t, err)
+	require.Equal(t, registered.ID, rebound.ID)
+	require.Equal(t, registered.CheckoutID, rebound.CheckoutID)
+	require.True(t, rebound.PathExists)
+	require.Equal(t, canonicalExistingPath(t, movedRoot), rebound.Root)
+
+	secondClone := initProjectRegistryRepo(t, filepath.Join(base, "second-clone"))
+	second, err := RegisterProject(secondClone)
+	require.NoError(t, err)
+	require.NotEqual(t, rebound.ID, second.ID, "two clones need distinct project identities")
+	require.NotEqual(t, rebound.CheckoutID, second.CheckoutID, "two clones need distinct checkout identities")
+
+	projects, err := ListProjects()
+	require.NoError(t, err)
+	require.Len(t, projects, 2)
+	assert.ElementsMatch(t, []string{rebound.ID, second.ID}, []string{projects[0].ID, projects[1].ID})
+	for _, project := range projects {
+		_, err := os.Stat(projectRecordPath(filepath.Join(base, "af-home", "projects"), project.ID))
+		require.NoError(t, err, "each listed identity must come from durable project.json metadata")
+	}
+}
+
+func TestProjectRegistryPersistsSessionlessRepoFromArbitraryPath(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", filepath.Join(base, "af-home"))
+	repo := initProjectRegistryRepo(t, filepath.Join(base, "empty-repo"))
+	nestedPath := filepath.Join(repo, "services", "api")
+	require.NoError(t, os.MkdirAll(nestedPath, 0o755))
+
+	registered, err := RegisterProject(nestedPath)
+	require.NoError(t, err)
+	require.Equal(t, repo, registered.Root, "an arbitrary path inside the checkout must bind the git repo root")
+	require.Equal(t, ".", registered.RelativeRoot)
+
+	projects, err := ListProjects()
+	require.NoError(t, err)
+	require.Equal(t, []Project{registered}, projects,
+		"the registry must list an explicitly registered project with zero sessions and zero tasks")
+	_, err = os.Stat(filepath.Join(repo, ".git", checkoutMarkerDirName, checkoutMarkerFileName))
+	require.NoError(t, err, "registration must anchor identity in the Git common directory")
+}
+
+func TestProjectRegistryConcurrentRegistrationIsIdempotent(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", filepath.Join(base, "af-home"))
+	repo := initProjectRegistryRepo(t, filepath.Join(base, "repo"))
+
+	const workers = 8
+	ids := make(chan string, workers)
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			project, err := RegisterProject(repo)
+			if err != nil {
+				errs <- err
+				return
+			}
+			ids <- project.ID
+		}()
+	}
+	wg.Wait()
+	close(ids)
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	first := ""
+	for id := range ids {
+		if first == "" {
+			first = id
+		}
+		require.Equal(t, first, id)
+	}
+	projects, err := ListProjects()
+	require.NoError(t, err)
+	require.Len(t, projects, 1)
+}
+
+func TestProjectRegistryRebindRefusesAnotherProjectsRoot(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", filepath.Join(base, "af-home"))
+	first, err := RegisterProject(initProjectRegistryRepo(t, filepath.Join(base, "first")))
+	require.NoError(t, err)
+	secondRoot := initProjectRegistryRepo(t, filepath.Join(base, "second"))
+	second, err := RegisterProject(secondRoot)
+	require.NoError(t, err)
+
+	_, err = RebindProject(first.ID, secondRoot)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), second.ID)
+
+	projects, err := ListProjects()
+	require.NoError(t, err)
+	require.Len(t, projects, 2)
+}
+
+func TestRegisterProjectRediscoversWholeCheckoutMoveByMarker(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", filepath.Join(base, "af-home"))
+	originalRoot := initProjectRegistryRepo(t, filepath.Join(base, "before"))
+	original, err := RegisterProject(originalRoot)
+	require.NoError(t, err)
+
+	movedRoot := filepath.Join(base, "after")
+	require.NoError(t, os.Rename(originalRoot, movedRoot))
+	rediscovered, err := RegisterProject(movedRoot)
+	require.NoError(t, err)
+	require.Equal(t, original.ID, rediscovered.ID)
+	require.Equal(t, original.CheckoutID, rediscovered.CheckoutID)
+	require.Equal(t, canonicalExistingPath(t, movedRoot), rediscovered.Root)
+
+	projects, err := ListProjects()
+	require.NoError(t, err)
+	require.Equal(t, []Project{rediscovered}, projects)
+}
+
+func TestRegisterProjectLinkedWorktreeUsesMainCheckoutIdentity(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", filepath.Join(base, "af-home"))
+	mainRoot := initProjectRegistryRepo(t, filepath.Join(base, "main"))
+	runProjectRegistryGit(t, mainRoot, "config", "user.email", "test@example.com")
+	runProjectRegistryGit(t, mainRoot, "config", "user.name", "Test")
+	require.NoError(t, os.WriteFile(filepath.Join(mainRoot, "README.md"), []byte("test\n"), 0o644))
+	runProjectRegistryGit(t, mainRoot, "add", "README.md")
+	runProjectRegistryGit(t, mainRoot, "commit", "--quiet", "-m", "initial")
+	worktreeRoot := filepath.Join(base, "linked")
+	runProjectRegistryGit(t, mainRoot, "worktree", "add", "--quiet", "-b", "registry-linked", worktreeRoot)
+
+	fromMain, err := RegisterProject(mainRoot)
+	require.NoError(t, err)
+	fromWorktree, err := RegisterProject(worktreeRoot)
+	require.NoError(t, err)
+	require.Equal(t, fromMain.ID, fromWorktree.ID)
+	require.Equal(t, fromMain.CheckoutID, fromWorktree.CheckoutID)
+	require.Equal(t, mainRoot, fromWorktree.Root)
+}
+
+func TestRegisterProjectDoesNotAdoptDifferentCloneAtReusedPath(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", filepath.Join(base, "af-home"))
+	originalPath := filepath.Join(base, "repo")
+	originalRoot := initProjectRegistryRepo(t, originalPath)
+	original, err := RegisterProject(originalRoot)
+	require.NoError(t, err)
+
+	require.NoError(t, os.Rename(originalRoot, filepath.Join(base, "old-checkout")))
+	replacement := initProjectRegistryRepo(t, originalPath)
+	_, err = RegisterProject(replacement)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), original.ID)
+	require.Contains(t, err.Error(), "marker")
+	rebound, err := RebindProject(original.ID, replacement)
+	require.NoError(t, err, "the explicit repair named by the refusal must adopt the replacement")
+	require.Equal(t, original.ID, rebound.ID)
+	require.NotEqual(t, original.CheckoutID, rebound.CheckoutID)
+
+	projects, err := ListProjects()
+	require.NoError(t, err)
+	require.Len(t, projects, 1, "refusal followed by explicit rebind must leave one stable project record")
+	require.Equal(t, original.ID, projects[0].ID)
+}
+
+func TestRegisterProjectRejectsCopiedCheckoutMarkerAtTwoLiveRoots(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", filepath.Join(base, "af-home"))
+	firstRoot := initProjectRegistryRepo(t, filepath.Join(base, "first"))
+	first, err := RegisterProject(firstRoot)
+	require.NoError(t, err)
+	markerData, err := os.ReadFile(filepath.Join(firstRoot, ".git", checkoutMarkerDirName, checkoutMarkerFileName))
+	require.NoError(t, err)
+
+	secondRoot := initProjectRegistryRepo(t, filepath.Join(base, "second"))
+	secondMarkerDir := filepath.Join(secondRoot, ".git", checkoutMarkerDirName)
+	require.NoError(t, os.MkdirAll(secondMarkerDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(secondMarkerDir, checkoutMarkerFileName), markerData, 0o644))
+	_, err = RegisterProject(secondRoot)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), first.CheckoutID)
+	require.Contains(t, err.Error(), "appears at both")
+}
+
+func TestRebindProjectCarriesProjectIDToNewCheckoutIdentity(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", filepath.Join(base, "af-home"))
+	original, err := RegisterProject(initProjectRegistryRepo(t, filepath.Join(base, "original")))
+	require.NoError(t, err)
+	replacementRoot := initProjectRegistryRepo(t, filepath.Join(base, "replacement"))
+
+	rebound, err := RebindProject(original.ID, replacementRoot)
+	require.NoError(t, err)
+	require.Equal(t, original.ID, rebound.ID)
+	require.NotEqual(t, original.CheckoutID, rebound.CheckoutID,
+		"a reclone is a new checkout even when the user carries the stable project id forward")
+	require.Equal(t, replacementRoot, rebound.Root)
+}
+
+func TestProjectRegistryRefusesNewerMetadata(t *testing.T) {
+	base := t.TempDir()
+	home := filepath.Join(base, "af-home")
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	id := "prj_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	dir := filepath.Join(home, "projects", id)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	metadata := `{
+  "schema_version": 2,
+  "id": "prj_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "checkout_id": "chk_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "root": "/repo",
+  "checkout_root": "/repo",
+  "relative_root": "."
+}`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, projectMetadataFileName), []byte(metadata), 0o644))
+
+	_, err := ListProjects()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "upgrade af")
+}
+
+func initProjectRegistryRepo(t *testing.T, root string) string {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(root, 0o755))
+	cmd := exec.Command("git", "init", "--quiet")
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git init failed: %s", out)
+	return canonicalExistingPath(t, root)
+}
+
+func runProjectRegistryGit(t *testing.T, root string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v failed: %s", args, out)
+}
+
+func canonicalExistingPath(t *testing.T, path string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(path)
+	require.NoError(t, err)
+	return filepath.Clean(resolved)
+}

--- a/config/project_registry_test.go
+++ b/config/project_registry_test.go
@@ -119,6 +119,50 @@ func TestResetProjectRegistryRefusesMarkerItDoesNotOwn(t *testing.T) {
 	require.NoError(t, statErr, "the registry must remain retryable when marker validation fails")
 }
 
+func TestResetProjectRegistryClearsUnavailableRoots(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		makeAbsent func(*testing.T, string)
+	}{
+		{
+			name: "moved",
+			makeAbsent: func(t *testing.T, root string) {
+				t.Helper()
+				require.NoError(t, os.Rename(root, filepath.Join(filepath.Dir(root), "moved-repo")))
+			},
+		},
+		{
+			name: "deleted",
+			makeAbsent: func(t *testing.T, root string) {
+				t.Helper()
+				require.NoError(t, os.RemoveAll(root))
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			base := t.TempDir()
+			home := filepath.Join(base, "af-home")
+			t.Setenv("AGENT_FACTORY_HOME", home)
+			repo := initProjectRegistryRepo(t, filepath.Join(base, "repo"))
+			_, err := RegisterProject(repo)
+			require.NoError(t, err)
+			tc.makeAbsent(t, repo)
+
+			projects, err := ListProjects()
+			require.NoError(t, err)
+			require.Len(t, projects, 1)
+			require.False(t, projects[0].PathExists)
+
+			require.NoError(t, ResetProjectRegistry(),
+				"an unavailable last-known root must not strand AF's registry")
+			projects, err = ListProjects()
+			require.NoError(t, err)
+			require.Empty(t, projects)
+			require.NoDirExists(t, filepath.Join(home, ProjectRegistryDirName))
+		})
+	}
+}
+
 func TestProjectRegistryConcurrentRegistrationIsIdempotent(t *testing.T) {
 	base := t.TempDir()
 	t.Setenv("AGENT_FACTORY_HOME", filepath.Join(base, "af-home"))
@@ -280,6 +324,31 @@ func TestRegisterProjectDoesNotAdoptDifferentCloneAtReusedPath(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, projects, 1, "refusal followed by explicit rebind must leave one stable project record")
 	require.Equal(t, original.ID, projects[0].ID)
+}
+
+func TestRejectedReplacementRegistrationDoesNotMintCheckoutMarker(t *testing.T) {
+	base := t.TempDir()
+	home := filepath.Join(base, "af-home")
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	originalPath := filepath.Join(base, "repo")
+	original, err := RegisterProject(initProjectRegistryRepo(t, originalPath))
+	require.NoError(t, err)
+	require.NoError(t, os.Rename(originalPath, filepath.Join(base, "old-checkout")))
+
+	replacement := initProjectRegistryRepo(t, originalPath)
+	marker := filepath.Join(replacement, ".git", checkoutMarkerDirName, checkoutMarkerFileName)
+	require.NoFileExists(t, marker)
+
+	_, err = RegisterProject(replacement)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), original.ID)
+	require.NoFileExists(t, marker,
+		"a rejected registration must not mutate a different checkout")
+	require.NoFileExists(t, marker+".lock")
+
+	require.NoError(t, ResetProjectRegistry(),
+		"the rejected checkout must not poison cleanup of the original record")
+	require.NoDirExists(t, filepath.Join(home, ProjectRegistryDirName))
 }
 
 func TestRegisterProjectRejectsCopiedCheckoutMarkerAtTwoLiveRoots(t *testing.T) {

--- a/config/project_registry_test.go
+++ b/config/project_registry_test.go
@@ -63,7 +63,7 @@ func TestProjectRegistryRebindPreservesIdentityAndClonesStayDistinct(t *testing.
 	require.Len(t, projects, 2)
 	assert.ElementsMatch(t, []string{rebound.ID, second.ID}, []string{projects[0].ID, projects[1].ID})
 	for _, project := range projects {
-		_, err := os.Stat(projectRecordPath(filepath.Join(base, "af-home", "projects"), project.ID))
+		_, err := os.Stat(projectRecordPath(filepath.Join(base, "af-home", ProjectRegistryDirName), project.ID))
 		require.NoError(t, err, "each listed identity must come from durable project.json metadata")
 	}
 }
@@ -163,6 +163,46 @@ func TestRegisterProjectRediscoversWholeCheckoutMoveByMarker(t *testing.T) {
 	projects, err := ListProjects()
 	require.NoError(t, err)
 	require.Equal(t, []Project{rediscovered}, projects)
+}
+
+func TestProjectRegistryMoveIgnoresReusedUnmarkedOldRoot(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		move func(Project, string) (Project, error)
+	}{
+		{
+			name: "register",
+			move: func(_ Project, movedRoot string) (Project, error) {
+				return RegisterProject(movedRoot)
+			},
+		},
+		{
+			name: "rebind",
+			move: func(project Project, movedRoot string) (Project, error) {
+				return RebindProject(project.ID, movedRoot)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			base := t.TempDir()
+			t.Setenv("AGENT_FACTORY_HOME", filepath.Join(base, "af-home"))
+			oldRoot := filepath.Join(base, "repo")
+			project, err := RegisterProject(initProjectRegistryRepo(t, oldRoot))
+			require.NoError(t, err)
+
+			movedRoot := filepath.Join(base, "moved")
+			require.NoError(t, os.Rename(oldRoot, movedRoot))
+			require.NoError(t, os.Mkdir(oldRoot, 0o755),
+				"an unrelated directory now reuses the last-known path")
+
+			moved, err := tc.move(project, movedRoot)
+			require.NoError(t, err,
+				"an existing old path without this checkout's marker is not a duplicate identity")
+			require.Equal(t, project.ID, moved.ID)
+			require.Equal(t, project.CheckoutID, moved.CheckoutID)
+			require.Equal(t, canonicalExistingPath(t, movedRoot), moved.Root)
+		})
+	}
 }
 
 func TestRegisterProjectLinkedWorktreeUsesMainCheckoutIdentity(t *testing.T) {
@@ -296,7 +336,7 @@ func TestProjectRegistryRefusesNewerMetadata(t *testing.T) {
 	home := filepath.Join(base, "af-home")
 	t.Setenv("AGENT_FACTORY_HOME", home)
 	id := "prj_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-	dir := filepath.Join(home, "projects", id)
+	dir := filepath.Join(home, ProjectRegistryDirName, id)
 	require.NoError(t, os.MkdirAll(dir, 0o755))
 	metadata := `{
   "schema_version": 2,

--- a/config/project_registry_test.go
+++ b/config/project_registry_test.go
@@ -245,6 +245,52 @@ func TestRebindProjectCarriesProjectIDToNewCheckoutIdentity(t *testing.T) {
 	require.Equal(t, replacementRoot, rebound.Root)
 }
 
+func TestRebindProjectDoesNotReuseCheckoutIDAtReplacementPath(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", filepath.Join(base, "af-home"))
+	originalPath := filepath.Join(base, "repo")
+	original, err := RegisterProject(initProjectRegistryRepo(t, originalPath))
+	require.NoError(t, err)
+	require.NoError(t, os.Rename(originalPath, filepath.Join(base, "old-checkout")))
+
+	// A fresh clone now occupies the same spelling as the last-known root, but
+	// has no checkout marker. Path equality is not proof that it is the checkout
+	// moved aside above; explicit rebind preserves only the stable project ID.
+	replacement := initProjectRegistryRepo(t, originalPath)
+	rebound, err := RebindProject(original.ID, replacement)
+	require.NoError(t, err)
+	require.Equal(t, original.ID, rebound.ID)
+	require.NotEqual(t, original.CheckoutID, rebound.CheckoutID,
+		"a replacement clone must mint its own checkout identity even at the old path")
+}
+
+func TestRegisterProjectBareBackedWorktreesUseCheckedOutRoot(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", filepath.Join(base, "af-home"))
+	seed := initProjectRegistryRepo(t, filepath.Join(base, "seed"))
+	runProjectRegistryGit(t, seed, "config", "user.email", "test@example.com")
+	runProjectRegistryGit(t, seed, "config", "user.name", "Test")
+	require.NoError(t, os.WriteFile(filepath.Join(seed, "README.md"), []byte("test\n"), 0o644))
+	runProjectRegistryGit(t, seed, "add", "README.md")
+	runProjectRegistryGit(t, seed, "commit", "--quiet", "-m", "initial")
+
+	bare := filepath.Join(base, "backing.git")
+	runProjectRegistryGit(t, base, "clone", "--quiet", "--bare", seed, bare)
+	firstRoot := filepath.Join(base, "first-worktree")
+	secondRoot := filepath.Join(base, "second-worktree")
+	runProjectRegistryGit(t, base, "--git-dir", bare, "worktree", "add", "--quiet", "--detach", firstRoot)
+	runProjectRegistryGit(t, base, "--git-dir", bare, "worktree", "add", "--quiet", "--detach", secondRoot)
+
+	first, err := RegisterProject(firstRoot)
+	require.NoError(t, err)
+	require.Equal(t, canonicalExistingPath(t, firstRoot), first.Root,
+		"a bare backing repo has no main working tree, so its checked-out worktree is the usable root")
+	second, err := RegisterProject(secondRoot)
+	require.NoError(t, err)
+	require.Equal(t, first.ID, second.ID, "worktrees sharing one bare common directory share checkout identity")
+	require.Equal(t, first.Root, second.Root, "the first live registered worktree remains the canonical root")
+}
+
 func TestProjectRegistryRefusesNewerMetadata(t *testing.T) {
 	base := t.TempDir()
 	home := filepath.Join(base, "af-home")

--- a/config/project_registry_test.go
+++ b/config/project_registry_test.go
@@ -22,6 +22,15 @@ func TestListProjectsMissingHomeIsReadOnly(t *testing.T) {
 	require.ErrorIs(t, statErr, os.ErrNotExist, "a read-only list must not materialize the AF home")
 }
 
+func TestResetProjectRegistryMissingHomeIsReadOnly(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "missing-af-home")
+	t.Setenv("AGENT_FACTORY_HOME", home)
+
+	require.NoError(t, ResetProjectRegistry())
+	_, statErr := os.Stat(home)
+	require.ErrorIs(t, statErr, os.ErrNotExist, "an empty reset must not materialize the AF home")
+}
+
 func TestProjectRegistryRebindPreservesIdentityAndClonesStayDistinct(t *testing.T) {
 	base := t.TempDir()
 	t.Setenv("AGENT_FACTORY_HOME", filepath.Join(base, "af-home"))
@@ -86,6 +95,28 @@ func TestProjectRegistryPersistsSessionlessRepoFromArbitraryPath(t *testing.T) {
 		"the registry must list an explicitly registered project with zero sessions and zero tasks")
 	_, err = os.Stat(filepath.Join(repo, ".git", checkoutMarkerDirName, checkoutMarkerFileName))
 	require.NoError(t, err, "registration must anchor identity in the Git common directory")
+}
+
+func TestResetProjectRegistryRefusesMarkerItDoesNotOwn(t *testing.T) {
+	base := t.TempDir()
+	home := filepath.Join(base, "af-home")
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	repo := initProjectRegistryRepo(t, filepath.Join(base, "repo"))
+	registered, err := RegisterProject(repo)
+	require.NoError(t, err)
+
+	marker := filepath.Join(repo, ".git", checkoutMarkerDirName, checkoutMarkerFileName)
+	foreignID := "chk_ffffffffffffffffffffffffffffffff"
+	require.NoError(t, os.WriteFile(marker, []byte(foreignID+"\n"), 0o644))
+
+	err = ResetProjectRegistry()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), registered.ID)
+	data, readErr := os.ReadFile(marker)
+	require.NoError(t, readErr)
+	require.Equal(t, foreignID+"\n", string(data), "reset must not remove a marker it cannot validate")
+	_, statErr := os.Stat(filepath.Join(home, ProjectRegistryDirName, registered.ID, projectMetadataFileName))
+	require.NoError(t, statErr, "the registry must remain retryable when marker validation fails")
 }
 
 func TestProjectRegistryConcurrentRegistrationIsIdempotent(t *testing.T) {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -30,7 +30,7 @@ Run `af <command> --help` for the same information at the terminal. For a narrat
 - [`af doctor`](#af-doctor) — Diagnose setup, daemon health, and leaked session resources
 - [`af keys`](#af-keys) — Show the effective TUI key bindings (defaults plus [keys] rebinds)
 - [`af projects`](#af-projects) — Manage projects and durable registrations
-- [`af projects delete`](#af-projects-delete) — Delete a project: archive its sessions and remove it (reversibly)
+- [`af projects delete`](#af-projects-delete) — Archive and remove a project's sessions (reversibly)
 - [`af projects list`](#af-projects-list) — List registered projects
 - [`af projects rebind`](#af-projects-rebind) — Rebind a registered project after its checkout moves
 - [`af projects register`](#af-projects-register) — Register a project with a stable local identity
@@ -849,7 +849,7 @@ af projects
 
 **Subcommands**
 
-- [`af projects delete`](#af-projects-delete) — Delete a project: archive its sessions and remove it (reversibly)
+- [`af projects delete`](#af-projects-delete) — Archive and remove a project's sessions (reversibly)
 - [`af projects list`](#af-projects-list) — List registered projects
 - [`af projects rebind`](#af-projects-rebind) — Rebind a registered project after its checkout moves
 - [`af projects register`](#af-projects-register) — Register a project with a stable local identity
@@ -869,20 +869,22 @@ af projects
 
 ## af projects delete
 
-Delete a project: archive its sessions and remove it (reversibly)
+Archive and remove a project's sessions (reversibly)
 
-Delete a project — the group of sessions sharing a git repository.
+Archive and remove every live session for a git repository.
 
-This is ARCHIVE-THEN-REMOVE and reversible. Every live session of the repo is
+This is archive-then-remove and reversible. Every live session of the repo is
 archived (its tmux is torn down and its worktree moved to the archive dir, but
-its branch and uncommitted changes are preserved), the project drops out of the
-active projects list, and its always-on root agent (if any) is stopped and its
-root_agents opt-in removed. In-place sessions (the root agent, 'af sessions
-create --here') are torn down instead of archived — their cleanup never touches
-your working tree or branch.
+its branch and uncommitted changes are preserved), and its always-on root agent
+(if any) is stopped and its root-agent opt-in removed. In-place sessions (the
+root agent, 'af sessions create --here') are torn down instead of archived —
+their cleanup never touches your working tree or branch.
+
+The durable project registration, if any, is preserved. This command removes
+session state; it does not unregister the project.
 
 Your real git repository is never touched. To undo a mis-click, restore any
-archived session with 'af sessions restore <title>' — its project reappears.
+archived session with 'af sessions restore <title>'.
 
 [repo] is a path inside the repository to delete (default: the current repo).
 Deleting an unknown or already-empty project is a clean no-op. Prints how many

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -34,7 +34,7 @@ Run `af <command> --help` for the same information at the terminal. For a narrat
 - [`af projects list`](#af-projects-list) — List registered projects
 - [`af projects rebind`](#af-projects-rebind) — Rebind a registered project after its checkout moves
 - [`af projects register`](#af-projects-register) — Register a project with a stable local identity
-- [`af reset`](#af-reset) — Factory-reset Agent Factory: remove ALL AF sessions, tasks, worktrees, and state (keeps your repos + config)
+- [`af reset`](#af-reset) — Factory-reset Agent Factory: remove AF sessions, tasks, project registrations, worktrees, and state (keeps repos and config)
 - [`af sessions`](#af-sessions) — Manage sessions
 - [`af sessions archive`](#af-sessions-archive) — Finish with a session by archiving it for later restore
 - [`af sessions attach`](#af-sessions-attach) — Attach to a session's terminal
@@ -100,7 +100,7 @@ af [flags]
 - [`af doctor`](#af-doctor) — Diagnose setup, daemon health, and leaked session resources
 - [`af keys`](#af-keys) — Show the effective TUI key bindings (defaults plus [keys] rebinds)
 - [`af projects`](#af-projects) — Manage projects and durable registrations
-- [`af reset`](#af-reset) — Factory-reset Agent Factory: remove ALL AF sessions, tasks, worktrees, and state (keeps your repos + config)
+- [`af reset`](#af-reset) — Factory-reset Agent Factory: remove AF sessions, tasks, project registrations, worktrees, and state (keeps repos and config)
 - [`af sessions`](#af-sessions) — Manage sessions
 - [`af tasks`](#af-tasks) — Manage tasks
 - [`af token`](#af-token) — Manage the daemon's bearer token for the direct-TCP API
@@ -953,8 +953,10 @@ Register a project directory with a stable, machine-local identity.
 The returned project id survives an explicit rebind after the checkout moves.
 Two clones remain separate projects. Any directory inside a checkout resolves
 to that checkout's canonical main-repo root, and registration is idempotent for
-the same checkout. Identity is anchored in agent-factory/checkout-id under the
-Git common directory; no working-tree file is created.
+the same checkout. Identity is anchored in an AF-home-scoped
+agent-factory/checkout-id-<home-id> marker under the Git common directory, so
+one AF home's reset cannot remove another home's identity. No working-tree file
+is created.
 
 ```
 af projects register <path>
@@ -970,13 +972,14 @@ af projects register <path>
 
 ## af reset
 
-Factory-reset Agent Factory: remove ALL AF sessions, tasks, worktrees, and state (keeps your repos + config)
+Factory-reset Agent Factory: remove AF sessions, tasks, project registrations, worktrees, and state (keeps repos and config)
 
 Factory-reset Agent Factory.
 
 Removes every AF-created resource — all sessions (live and archived), all
-scheduled cron/watch tasks, all AF worktrees, the AF session branches AF
-created, and all stored state — returning AF to a clean slate.
+scheduled cron/watch tasks, registered-project bindings and their reachable
+checkout identity markers for this AF home, all AF worktrees, the AF session
+branches AF created, and all stored state — returning AF to a clean slate.
 
 Stops every af daemon running for this AF home — the managed one and any
 orphan left behind by an upgrade or a source build — and removes the daemon

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -29,8 +29,11 @@ Run `af <command> --help` for the same information at the terminal. For a narrat
 - [`af debug`](#af-debug) — Print debug information like config paths
 - [`af doctor`](#af-doctor) — Diagnose setup, daemon health, and leaked session resources
 - [`af keys`](#af-keys) — Show the effective TUI key bindings (defaults plus [keys] rebinds)
-- [`af projects`](#af-projects) — Manage projects (repo groupings of sessions)
+- [`af projects`](#af-projects) — Manage projects and durable registrations
 - [`af projects delete`](#af-projects-delete) — Delete a project: archive its sessions and remove it (reversibly)
+- [`af projects list`](#af-projects-list) — List registered projects
+- [`af projects rebind`](#af-projects-rebind) — Rebind a registered project after its checkout moves
+- [`af projects register`](#af-projects-register) — Register a project with a stable local identity
 - [`af reset`](#af-reset) — Factory-reset Agent Factory: remove ALL AF sessions, tasks, worktrees, and state (keeps your repos + config)
 - [`af sessions`](#af-sessions) — Manage sessions
 - [`af sessions archive`](#af-sessions-archive) — Finish with a session by archiving it for later restore
@@ -96,7 +99,7 @@ af [flags]
 - [`af debug`](#af-debug) — Print debug information like config paths
 - [`af doctor`](#af-doctor) — Diagnose setup, daemon health, and leaked session resources
 - [`af keys`](#af-keys) — Show the effective TUI key bindings (defaults plus [keys] rebinds)
-- [`af projects`](#af-projects) — Manage projects (repo groupings of sessions)
+- [`af projects`](#af-projects) — Manage projects and durable registrations
 - [`af reset`](#af-reset) — Factory-reset Agent Factory: remove ALL AF sessions, tasks, worktrees, and state (keeps your repos + config)
 - [`af sessions`](#af-sessions) — Manage sessions
 - [`af tasks`](#af-tasks) — Manage tasks
@@ -838,7 +841,7 @@ af keys
 
 ## af projects
 
-Manage projects (repo groupings of sessions)
+Manage projects and durable registrations
 
 ```
 af projects
@@ -847,6 +850,9 @@ af projects
 **Subcommands**
 
 - [`af projects delete`](#af-projects-delete) — Delete a project: archive its sessions and remove it (reversibly)
+- [`af projects list`](#af-projects-list) — List registered projects
+- [`af projects rebind`](#af-projects-rebind) — Rebind a registered project after its checkout moves
+- [`af projects register`](#af-projects-register) — Register a project with a stable local identity
 
 **Flags**
 
@@ -884,6 +890,72 @@ sessions were archived.
 
 ```
 af projects delete [repo]
+```
+
+**Global flags**
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--daemon-url` | `string` | Target a REMOTE daemon at this http:// or ws:// URL instead of the local unix socket (env: AF_DAEMON_URL). The daemon is HTTP-only; terminate TLS at your own proxy if needed. |
+| `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
+
+## af projects list
+
+List registered projects
+
+List durable machine-local project bindings.
+
+path_exists reports only whether the last-known path is present. It does not
+claim that a new checkout at a reused path has the registered identity.
+
+```
+af projects list
+```
+
+**Global flags**
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--daemon-url` | `string` | Target a REMOTE daemon at this http:// or ws:// URL instead of the local unix socket (env: AF_DAEMON_URL). The daemon is HTTP-only; terminate TLS at your own proxy if needed. |
+| `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
+
+## af projects rebind
+
+Rebind a registered project after its checkout moves
+
+Rebind a stable project id to a new checkout path.
+
+The project id is preserved. Rebinding refuses to take a path already owned by
+another registered project.
+
+```
+af projects rebind <project-id> <path>
+```
+
+**Global flags**
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--daemon-url` | `string` | Target a REMOTE daemon at this http:// or ws:// URL instead of the local unix socket (env: AF_DAEMON_URL). The daemon is HTTP-only; terminate TLS at your own proxy if needed. |
+| `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
+
+## af projects register
+
+Register a project with a stable local identity
+
+Register a project directory with a stable, machine-local identity.
+
+The returned project id survives an explicit rebind after the checkout moves.
+Two clones remain separate projects. Any directory inside a checkout resolves
+to that checkout's canonical main-repo root, and registration is idempotent for
+the same checkout. Identity is anchored in agent-factory/checkout-id under the
+Git common directory; no working-tree file is created.
+
+```
+af projects register <path>
 ```
 
 **Global flags**

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -582,21 +582,22 @@
     },
     {
       "id": "project.list",
-      "title": "See the list of projects",
+      "title": "See the list of durable projects",
       "tui": {
-        "status": "yes",
+        "status": "partial",
         "pointer": "keys/keys.go:172 (ctrl+p) -> app/switch_project.go:25"
       },
       "web": {
-        "status": "yes",
+        "status": "partial",
         "pointer": "web/src/ui.ts:1047 project switcher"
       },
       "cli": {
-        "status": "no",
-        "pointer": "af projects has only `delete` (derived)"
+        "status": "yes",
+        "pointer": "api/projects.go projectsListCmd"
       },
-      "verdict": "unclear",
-      "notes": "`af projects list` does not exist; projects are derivable from `af sessions list`. Low impact, but the group looks lopsided with a delete-only noun."
+      "verdict": "real-gap",
+      "issue": "#2216",
+      "notes": "The CLI reads the durable registry introduced in #2216's identity slice. The TUI and web still derive their switchers from sessions and legacy root-agent paths, so they expose only a partial, different set until the later #2216 UI/RPC slice consumes this registry."
     },
     {
       "id": "project.delete",
@@ -620,7 +621,7 @@
       "id": "project.add",
       "title": "Register a new project",
       "tui": {
-        "status": "yes",
+        "status": "partial",
         "pointer": "app/switch_project.go:196-216 (picker '+ Add project…' row)"
       },
       "web": {
@@ -628,11 +629,31 @@
         "pointer": "web/src/modals.ts:153-157 'No projects yet — create a session in the TUI first'"
       },
       "cli": {
-        "status": "no",
-        "pointer": "a project is implicitly registered by `af sessions create --repo`"
+        "status": "yes",
+        "pointer": "api/projects.go projectsRegisterCmd"
       },
-      "verdict": "unclear",
-      "notes": "The web's own empty state tells users to go to the TUI, which is an explicit parity admission in copy. But projects are implicit (any repo you create a session in), so 'add project' may not warrant a first-class verb. Owner call."
+      "verdict": "real-gap",
+      "issue": "#2216",
+      "notes": "The CLI now explicitly registers a sessionless project by path in the durable registry. The TUI's existing row persists a legacy root_agents entry instead of the new identity, and the web has no registration action; the later #2216 UI/RPC slice will build on the registry rather than create another one."
+    },
+    {
+      "id": "project.rebind",
+      "title": "Rebind a stable project identity to a replacement checkout",
+      "tui": {
+        "status": "no",
+        "pointer": ""
+      },
+      "web": {
+        "status": "no",
+        "pointer": ""
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/projects.go projectsRebindCmd"
+      },
+      "verdict": "real-gap",
+      "issue": "#2216",
+      "notes": "The CLI exposes the explicit repair required after a reclone. TUI/web status and repair actions remain part of the later #2216 project-identity integration."
     },
     {
       "id": "project.switch",
@@ -1298,6 +1319,9 @@
       "af hook-guard-tmux": "internal.hook-guard-tmux",
       "af keys": "meta.discovery",
       "af projects delete": "project.delete",
+      "af projects list": "project.list",
+      "af projects rebind": "project.rebind",
+      "af projects register": "project.add",
       "af reset": "install.reset",
       "af sessions archive": "session.archive",
       "af sessions attach": "session.attach",
@@ -1489,6 +1513,9 @@
       "af projects --help": "meta.discovery",
       "af projects --json": "cli.json-envelope",
       "af projects delete --help": "meta.discovery",
+      "af projects list --help": "meta.discovery",
+      "af projects rebind --help": "meta.discovery",
+      "af projects register --help": "meta.discovery",
       "af reset --force": "install.reset",
       "af reset --help": "meta.discovery",
       "af reset --yes": "install.reset",


### PR DESCRIPTION
Part of #2216.

## Summary

- add random stable project IDs and checkout IDs, persisted atomically under the resolved Agent Factory home
- anchor checkout identity in the Git common directory so whole-repo moves and linked worktrees retain identity while separate clones remain distinct
- add `af projects list`, `register`, and `rebind`; registration accepts any directory inside a Git checkout and persists projects with zero sessions or tasks
- keep `af projects list` read-only on a missing home, reject ambiguous copied markers, and clarify that `af projects delete` removes session state without unregistering durable identity
- record the transitional CLI/TUI/web split in the surface-parity inventory for the later #2216 integration slices

## Follow-on integration seam

A durable record is `<AGENT_FACTORY_HOME>/projects/<project-id>/project.json` with stable `id`, `checkout_id`, canonical `root`, and reserved `relative_root`. It exists independently of sessions and tasks. Follow-on RPC/UI work can call `config.RegisterProject(path)` and `config.ListProjects()`; it does not need another registry.

## Regression

The fail-first production-wiring test reported `af projects list is not wired into production command` before the implementation. The identity tests then cover moves, two clones, linked worktrees, copied-marker ambiguity, reused paths, explicit rebind, concurrent registration, future schema refusal, and a sessionless repository registered from a nested path.

The first full-container pass also found the new verbs missing from the surface-parity ledger. That deterministic gate failure was fixed by declaring the CLI foundation and the still-partial TUI/web consumers under #2216.

## Validation

Exact pushed head: `1fb47094e4a50fb41d1aed95d884390cacb7f049`

- `gofmt -l .` (clean)
- `golangci-lint run --timeout=3m --fast`
- `go build ./...`
- `deadcode -test ./...` (no output)
- `scripts/lint-file-length.sh`
- `go test ./parity ./config ./api -count=1`
- `make test-container`
- isolated real CLI registration/listing against a scratch `AGENT_FACTORY_HOME`
