### PR TITLE
fix(daemon): bound systemd restart bursts

### DIFF
--- a/daemon/autostart.go
+++ b/daemon/autostart.go
@@ -21,8 +21,10 @@ import (
 // longer exist (#782).
 
 const (
-	autostartUnitName     = systemdunit.DaemonUnitName
-	autostartLaunchdLabel = "com.agent-factory.daemon"
+	autostartUnitName           = systemdunit.DaemonUnitName
+	autostartLaunchdLabel       = "com.agent-factory.daemon"
+	autostartStartLimitInterval = "60"
+	autostartStartLimitBurst    = "5"
 	// autostartSystemdMarker lets the daemon distinguish its direct service
 	// process from descendants that merely inherited the unit's environment.
 	// session/tmux checks it together with SYSTEMD_EXEC_PID before asking the
@@ -111,6 +113,11 @@ func formatSystemdEnvLine(name, value string) string {
 // process exits, so it kills exactly the persistent tmux server #2176 needs to
 // protect. New servers leave the service cgroup through systemd-run; process
 // also protects servers an older daemon already placed there before upgrade.
+//
+// StartLimitInterval and StartLimitBurst deliberately use their pre-v229/v230
+// names and [Service] location. Newer systemd keeps that form as a compatibility
+// alias, while the modern StartLimitIntervalSec spelling in [Unit] would leave
+// older supported Linux hosts on the unbounded default policy (#2168).
 func systemdAutostartUnit(execPath, pathEnv, shellEnv, agentFactoryHome string) string {
 	envLines := formatSystemdEnvLine("PATH", pathEnv) + "\n" + formatSystemdEnvLine("SHELL", shellEnv)
 	if agentFactoryHome != "" {
@@ -121,6 +128,8 @@ Description=Agent Factory daemon (task scheduler + session monitor)
 
 [Service]
 KillMode=process
+StartLimitInterval=%s
+StartLimitBurst=%s
 ExecStart=%s --daemon
 Restart=on-failure
 RestartSec=5
@@ -128,7 +137,8 @@ RestartSec=5
 
 [Install]
 WantedBy=default.target
-`, quoteExecStartPath(execPath), formatSystemdEnvLine(autostartSystemdMarker, autostartUnitName)+"\n"+envLines)
+`, autostartStartLimitInterval, autostartStartLimitBurst,
+		quoteExecStartPath(execPath), formatSystemdEnvLine(autostartSystemdMarker, autostartUnitName)+"\n"+envLines)
 }
 
 // launchdAutostartPlist renders the launchd agent that keeps the daemon
@@ -197,11 +207,11 @@ func launchdAutostartPlist(execPath, pathEnv, shellEnv, agentFactoryHome, logPat
 //     daemon is left at worst enabled-but-inactive until the next login — far
 //     better than a present-but-not-enabled unit. (Previously a stop failure
 //     returned early, leaving the file on disk but never enabled.)
-//   - On a hard failure of the reload/enable/bootstrap step the just-written unit
-//     file is removed, so AutostartInstalled — which reports on file existence —
-//     can never misreport a not-enabled unit as installed and mislead the
-//     upgrade respawn path into RestartAutostartUnit on a unit that was never
-//     enabled.
+//   - On a hard failure of the reload/reset/enable/bootstrap step the
+//     just-written unit file is removed, so AutostartInstalled — which reports
+//     on file existence — can never misreport a not-enabled unit as installed
+//     and mislead the upgrade respawn path into RestartAutostartUnit on a unit
+//     that was never enabled.
 func InstallAutostart() (string, error) {
 	execPath, err := os.Executable()
 	if err != nil {
@@ -225,6 +235,10 @@ func InstallAutostart() (string, error) {
 		if out, err := autostartUnitCommand("systemctl", "--user", "daemon-reload"); err != nil {
 			removeAutostartUnitFile(unitPath)
 			return "", fmt.Errorf("failed to reload systemd user daemon: %w\n%s", err, strings.TrimSpace(string(out)))
+		}
+		if err := resetSystemdAutostartFailure(); err != nil {
+			removeAutostartUnitFile(unitPath)
+			return "", fmt.Errorf("failed to clear daemon service failure before enabling: %w", err)
 		}
 		// Hand any ad-hoc daemon over to the supervised one, but never let a
 		// stop failure block enabling — see the function comment (#974).
@@ -335,19 +349,20 @@ func AutostartInstalled() bool {
 }
 
 // RefreshAutostartUnit makes an already-installed Linux unit safe before an
-// upgrade or explicit restart stops its daemon (#2176). Older installs carry
-// the rendered unit on disk, so changing systemdAutostartUnit alone does
-// nothing for the machines at risk. Rewrite only KillMode, preserving the
-// captured executable, environment, and #2168's planned StartLimit policy,
-// then reload the user manager before a caller is allowed to restart.
+// upgrade or explicit restart stops its daemon (#2176, #2168). Older installs
+// carry the rendered unit on disk, so changing systemdAutostartUnit alone does
+// nothing for the machines at risk. Surgically enforce KillMode and AF's
+// restart-rate backstop while preserving the captured executable, environment,
+// and unrelated directives, then reload the user manager before restart.
 //
 // The reload runs even when the file already contains the safe directive. A
 // prior reload may have failed after the atomic write, leaving systemd's
 // in-memory unit stale; treating the on-disk text as sufficient would make the
 // next restart destructive again.
 //
-// launchd has no systemd cgroup KillMode equivalent. Its plist is deliberately
-// left byte-identical on Darwin rather than pretending this Linux fix applies.
+// launchd has neither systemd's cgroup KillMode nor its StartLimit directives.
+// Its plist is deliberately left byte-identical on Darwin rather than
+// pretending this Linux policy applies.
 func RefreshAutostartUnit() error {
 	if autostartGOOS != "linux" {
 		return nil
@@ -365,9 +380,32 @@ func RefreshAutostartUnit() error {
 		return fmt.Errorf("failed to read daemon autostart unit %s: %w", path, err)
 	}
 
-	content, changed, err := ensureSystemdServiceDirective(string(data), "KillMode", "process")
-	if err != nil {
-		return fmt.Errorf("cannot make daemon autostart unit restart-safe: %w", err)
+	content := string(data)
+	changed := false
+	for _, directive := range []struct {
+		key   string
+		value string
+	}{
+		{
+			key:   "StartLimitInterval",
+			value: autostartStartLimitInterval,
+		},
+		{
+			key:   "StartLimitBurst",
+			value: autostartStartLimitBurst,
+		},
+		{
+			key:   "KillMode",
+			value: "process",
+		},
+	} {
+		var directiveChanged bool
+		content, directiveChanged, err = ensureSystemdServiceDirective(
+			content, directive.key, directive.value)
+		if err != nil {
+			return fmt.Errorf("cannot make daemon autostart unit restart-safe: %w", err)
+		}
+		changed = changed || directiveChanged
 	}
 	if changed {
 		if err := config.AtomicWriteFile(path, []byte(content), 0644); err != nil {
@@ -382,8 +420,8 @@ func RefreshAutostartUnit() error {
 
 // ensureSystemdServiceDirective returns content with exactly one key=value in
 // [Service]. Other sections and directives remain byte-for-byte and in order;
-// this is a targeted safety migration, not a re-render that could overwrite an
-// install's captured PATH, home, executable, or future StartLimit settings.
+// this is a targeted migration, not a re-render that could overwrite an
+// install's captured PATH, home, executable, or unrelated policy.
 func ensureSystemdServiceDirective(content, key, value string) (string, bool, error) {
 	lines := strings.Split(content, "\n")
 	inService := false
@@ -694,6 +732,9 @@ func launchdPlistProgramPath(content string) (string, bool) {
 func RestartAutostartUnit() error {
 	switch autostartGOOS {
 	case "linux":
+		if err := resetSystemdAutostartFailure(); err != nil {
+			return fmt.Errorf("cannot restart daemon service: %w", err)
+		}
 		if out, err := autostartUnitCommand("systemctl", "--user", "restart", autostartUnitName); err != nil {
 			return fmt.Errorf("systemctl --user restart %s failed: %w\n%s", autostartUnitName, err, strings.TrimSpace(string(out)))
 		}
@@ -749,6 +790,9 @@ func PauseAutostartUnit() error {
 func ResumeAutostartUnit() error {
 	switch autostartGOOS {
 	case "linux":
+		if err := resetSystemdAutostartFailure(); err != nil {
+			return fmt.Errorf("cannot resume daemon service: %w", err)
+		}
 		if out, err := autostartUnitCommand("systemctl", "--user", "start", autostartUnitName); err != nil {
 			return fmt.Errorf("systemctl --user start %s failed: %w\n%s", autostartUnitName, err, strings.TrimSpace(string(out)))
 		}
@@ -768,6 +812,37 @@ func ResumeAutostartUnit() error {
 	default:
 		return fmt.Errorf("daemon autostart is not supported on %s", autostartGOOS)
 	}
+}
+
+// resetSystemdAutostartFailure clears both the failed state and the start-rate
+// counter before an AF command asks systemd to start the daemon. Without this,
+// the StartLimit backstop can make install, restart, and resume keep returning
+// "start-limit-hit" even after the underlying crash has been fixed (#2168).
+func resetSystemdAutostartFailure() error {
+	out, resetErr := autostartUnitCommand("systemctl", "--user", "reset-failed", autostartUnitName)
+	if resetErr == nil {
+		return nil
+	}
+
+	// A fresh or garbage-collected unit has no retained failed state or rate
+	// counter. systemd rejects its targeted reset as "not loaded"; probing it
+	// with show creates an inactive object only for that D-Bus connection, so
+	// trying reset again would race garbage collection. ActiveState is a stable
+	// machine value and lets this benign case proceed without parsing localized
+	// stderr. Any retained failed/active state still makes the reset mandatory.
+	stateOut, stateErr := autostartUnitCommand(
+		"systemctl", "--user", "show", autostartUnitName, "--property=ActiveState", "--value",
+	)
+	state := strings.TrimSpace(string(stateOut))
+	if stateErr == nil && state == "inactive" {
+		return nil
+	}
+	if stateErr != nil {
+		return fmt.Errorf("systemctl --user reset-failed %s failed: %w\n%s\nfailed to inspect unit state after reset failure: %v\n%s",
+			autostartUnitName, resetErr, strings.TrimSpace(string(out)), stateErr, state)
+	}
+	return fmt.Errorf("systemctl --user reset-failed %s failed while unit state was %q: %w\n%s",
+		autostartUnitName, state, resetErr, strings.TrimSpace(string(out)))
 }
 
 // UninstallAutostart removes the daemon autostart unit installed by

--- a/daemon/autostart_pause_test.go
+++ b/daemon/autostart_pause_test.go
@@ -26,6 +26,7 @@ func TestPauseAndResumeAutostartUnitLinux(t *testing.T) {
 
 	want := [][]string{
 		{"systemctl", "--user", "stop", autostartUnitName},
+		{"systemctl", "--user", "reset-failed", autostartUnitName},
 		{"systemctl", "--user", "start", autostartUnitName},
 	}
 	if !reflect.DeepEqual(*calls, want) {

--- a/daemon/autostart_restart_test.go
+++ b/daemon/autostart_restart_test.go
@@ -99,6 +99,9 @@ func calledWith(calls [][]string, want ...string) bool {
 // AutostartInstalled does not later report a never-enabled unit as installed.
 func TestInstallAutostartEnablesUnitWhenStopDaemonFailsLinux(t *testing.T) {
 	dir := withAutostartTestEnv(t, "linux")
+	if err := os.WriteFile(filepath.Join(dir, autostartUnitName), []byte("[Service]\n"), 0o644); err != nil {
+		t.Fatalf("seed existing unit: %v", err)
+	}
 	calls := stubAutostartUnitCommand(t, nil)
 	stubAutostartStopDaemon(t, false, errors.New("could not stop ad-hoc daemon"))
 
@@ -115,8 +118,44 @@ func TestInstallAutostartEnablesUnitWhenStopDaemonFailsLinux(t *testing.T) {
 	if !AutostartInstalled() {
 		t.Fatalf("AutostartInstalled() = false after a successful install")
 	}
-	if !calledWith(*calls, "systemctl", "--user", "enable", "--now", autostartUnitName) {
-		t.Fatalf("enable did not run after the stop failure; calls = %v", *calls)
+	wantCalls := [][]string{
+		{"systemctl", "--user", "daemon-reload"},
+		{"systemctl", "--user", "reset-failed", autostartUnitName},
+		{"systemctl", "--user", "enable", "--now", autostartUnitName},
+	}
+	if !reflect.DeepEqual(*calls, wantCalls) {
+		t.Fatalf("install must clear a start-limit failure before enabling after the stop failure; calls=%v want=%v", *calls, wantCalls)
+	}
+}
+
+// systemd rejects reset-failed for a fresh or garbage-collected unit, and a
+// read-only show only holds its newly loaded object for that command's D-Bus
+// connection. If the stable ActiveState is inactive, there is no failed state
+// to clear and install must continue without parsing localized stderr.
+func TestInstallAutostartToleratesResetForUnloadedInactiveUnitLinux(t *testing.T) {
+	withAutostartTestEnv(t, "linux")
+	stubAutostartStopDaemon(t, true, nil)
+	calls := stubAutostartUnitCommandFunc(t, func(_ string, args ...string) ([]byte, error) {
+		if len(args) > 1 && args[1] == "reset-failed" {
+			return []byte("Failed to reset failed state of unit " + autostartUnitName + ": Unit " + autostartUnitName + " not loaded."), errors.New("exit status 1")
+		}
+		if len(args) > 1 && args[1] == "show" {
+			return []byte("inactive\n"), nil
+		}
+		return nil, nil
+	})
+
+	if _, err := InstallAutostart(); err != nil {
+		t.Fatalf("fresh InstallAutostart treated an inactive unloaded unit as failed: %v", err)
+	}
+	want := [][]string{
+		{"systemctl", "--user", "daemon-reload"},
+		{"systemctl", "--user", "reset-failed", autostartUnitName},
+		{"systemctl", "--user", "show", autostartUnitName, "--property=ActiveState", "--value"},
+		{"systemctl", "--user", "enable", "--now", autostartUnitName},
+	}
+	if !reflect.DeepEqual(*calls, want) {
+		t.Fatalf("fresh install commands = %v, want %v", *calls, want)
 	}
 }
 
@@ -167,6 +206,71 @@ func TestInstallAutostartRemovesUnitWhenEnableFailsLinux(t *testing.T) {
 	}
 	if AutostartInstalled() {
 		t.Fatalf("AutostartInstalled() = true after a failed install left no enabled unit")
+	}
+}
+
+// If reset-failed fails and the manager cannot prove the unit is merely
+// inactive, install must surface that uncertainty rather than silently
+// treating a real failed unit as fresh.
+func TestInstallAutostartRemovesUnitWhenResetStateIsUnknownLinux(t *testing.T) {
+	dir := withAutostartTestEnv(t, "linux")
+	stubAutostartStopDaemon(t, true, nil)
+	calls := stubAutostartUnitCommandFunc(t, func(_ string, args ...string) ([]byte, error) {
+		if len(args) > 1 && args[1] == "reset-failed" {
+			return []byte("reset failed"), errors.New("exit status 1")
+		}
+		if len(args) > 1 && args[1] == "show" {
+			return []byte("state unavailable"), errors.New("manager unavailable")
+		}
+		return nil, nil
+	})
+
+	if _, err := InstallAutostart(); err == nil ||
+		!strings.Contains(err.Error(), "reset failed") ||
+		!strings.Contains(err.Error(), "manager unavailable") {
+		t.Fatalf("InstallAutostart unknown reset state = %v, want both failures surfaced", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, autostartUnitName)); !os.IsNotExist(statErr) {
+		t.Fatalf("unit file should be cleaned up after unknown reset state; stat err = %v", statErr)
+	}
+	if calledWith(*calls, "systemctl", "--user", "enable", "--now", autostartUnitName) {
+		t.Fatalf("install continued without a trustworthy reset result; calls=%v", *calls)
+	}
+}
+
+// systemd retains a failed unit after an earlier install cleans up its file.
+// If reset-failed still fails in that state, a new install must neither mask
+// it as a fresh inactive unit nor leave a file it could misreport as usable.
+func TestInstallAutostartDoesNotMaskRetainedFailedUnitLinux(t *testing.T) {
+	dir := withAutostartTestEnv(t, "linux")
+	stubAutostartStopDaemon(t, true, nil)
+	calls := stubAutostartUnitCommandFunc(t, func(_ string, args ...string) ([]byte, error) {
+		if len(args) > 1 && args[1] == "reset-failed" {
+			return []byte("reset failed"), errors.New("exit status 1")
+		}
+		if len(args) > 1 && args[1] == "show" {
+			return []byte("failed\n"), nil
+		}
+		return nil, nil
+	})
+
+	if _, err := InstallAutostart(); err == nil || !strings.Contains(err.Error(), "reset failed") {
+		t.Fatalf("InstallAutostart reset failure = %v, want surfaced command output", err)
+	}
+	unitPath := filepath.Join(dir, autostartUnitName)
+	if _, statErr := os.Stat(unitPath); !os.IsNotExist(statErr) {
+		t.Fatalf("unit file should be cleaned up after reset-failed failure; stat err = %v", statErr)
+	}
+	if calledWith(*calls, "systemctl", "--user", "enable", "--now", autostartUnitName) {
+		t.Fatalf("enable ran after reset-failed made the unit unstartable; calls=%v", *calls)
+	}
+	want := [][]string{
+		{"systemctl", "--user", "daemon-reload"},
+		{"systemctl", "--user", "reset-failed", autostartUnitName},
+		{"systemctl", "--user", "show", autostartUnitName, "--property=ActiveState", "--value"},
+	}
+	if !reflect.DeepEqual(*calls, want) {
+		t.Fatalf("retained failed unit commands = %v, want %v", *calls, want)
 	}
 }
 
@@ -238,11 +342,12 @@ func TestRefreshAutostartUnitRewritesLegacyLinuxUnit(t *testing.T) {
 	unitPath := filepath.Join(dir, autostartUnitName)
 	legacy := "[Unit]\n" +
 		"Description=Agent Factory daemon\n" +
-		"StartLimitIntervalSec=60\n" +
-		"StartLimitBurst=5\n\n" +
+		"\n" +
 		"[Service]\n" +
 		"ExecStart=\"/opt/af\" --daemon\n" +
 		"Restart=on-failure\n" +
+		"StartLimitInterval=60\n" +
+		"StartLimitBurst=5\n" +
 		"RestartPreventExitStatus=78\n" +
 		"Environment=PATH=/custom/bin\n\n" +
 		"[Install]\nWantedBy=default.target\n"
@@ -262,7 +367,7 @@ func TestRefreshAutostartUnitRewritesLegacyLinuxUnit(t *testing.T) {
 		t.Fatalf("refreshed unit must contain exactly one safe KillMode:\n%s", text)
 	}
 	for _, preserved := range []string{
-		"StartLimitIntervalSec=60",
+		"StartLimitInterval=60",
 		"StartLimitBurst=5",
 		"RestartPreventExitStatus=78",
 		"ExecStart=\"/opt/af\" --daemon",
@@ -274,6 +379,58 @@ func TestRefreshAutostartUnitRewritesLegacyLinuxUnit(t *testing.T) {
 	}
 	if !calledWith(*calls, "systemctl", "--user", "daemon-reload") {
 		t.Fatalf("rewritten unit was not reloaded; calls=%v", *calls)
+	}
+}
+
+// TestRefreshAutostartUnitAddsRestartRateLimit is the existing-install half
+// of #2168's Phase 1 backstop. A renderer change alone leaves every installed
+// unit on the unbounded legacy policy, so the restart/upgrade migration must
+// add the AF-owned limit without re-rendering captured install-time values.
+func TestRefreshAutostartUnitAddsRestartRateLimit(t *testing.T) {
+	dir := withAutostartTestEnv(t, "linux")
+	calls := stubAutostartUnitCommand(t, nil)
+	unitPath := filepath.Join(dir, autostartUnitName)
+	legacy := "[Unit]\n" +
+		"Description=Agent Factory daemon\n\n" +
+		"[Service]\n" +
+		"KillMode=process\n" +
+		"ExecStart=\"/opt/af with space\" --daemon\n" +
+		"Restart=on-failure\n" +
+		"Environment=PATH=/custom/bin\n" +
+		"Environment=AGENT_FACTORY_HOME=/srv/custom-af\n\n" +
+		"[Install]\nWantedBy=default.target\n"
+	if err := os.WriteFile(unitPath, []byte(legacy), 0644); err != nil {
+		t.Fatalf("seed legacy unit: %v", err)
+	}
+
+	if err := RefreshAutostartUnit(); err != nil {
+		t.Fatalf("RefreshAutostartUnit: %v", err)
+	}
+	got, err := os.ReadFile(unitPath)
+	if err != nil {
+		t.Fatalf("read refreshed unit: %v", err)
+	}
+	text := string(got)
+	for _, want := range []string{
+		"StartLimitInterval=60\n",
+		"StartLimitBurst=5\n",
+	} {
+		if strings.Count(text, want) != 1 {
+			t.Errorf("refreshed unit must contain exactly one %q:\n%s", strings.TrimSpace(want), text)
+		}
+	}
+	for _, preserved := range []string{
+		"ExecStart=\"/opt/af with space\" --daemon",
+		"Environment=PATH=/custom/bin",
+		"Environment=AGENT_FACTORY_HOME=/srv/custom-af",
+		"KillMode=process",
+	} {
+		if !strings.Contains(text, preserved) {
+			t.Errorf("migration dropped captured directive %q:\n%s", preserved, text)
+		}
+	}
+	if !calledWith(*calls, "systemctl", "--user", "daemon-reload") {
+		t.Fatalf("migrated unit was not reloaded; calls=%v", *calls)
 	}
 }
 
@@ -301,7 +458,11 @@ func TestRefreshAutostartUnitReloadsAlreadySafeUnit(t *testing.T) {
 	dir := withAutostartTestEnv(t, "linux")
 	calls := stubAutostartUnitCommand(t, nil)
 	unitPath := filepath.Join(dir, autostartUnitName)
-	unit := "[Service]\nKillMode=process\nExecStart=/opt/af --daemon\n"
+	unit := "[Service]\n" +
+		"KillMode=process\n" +
+		"StartLimitInterval=60\n" +
+		"StartLimitBurst=5\n" +
+		"ExecStart=/opt/af --daemon\n"
 	if err := os.WriteFile(unitPath, []byte(unit), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -351,8 +512,36 @@ func TestRestartAutostartUnitLinux(t *testing.T) {
 	if err := RestartAutostartUnit(); err != nil {
 		t.Fatalf("RestartAutostartUnit: %v", err)
 	}
-	want := [][]string{{"systemctl", "--user", "restart", autostartUnitName}}
-	if len(*calls) != 1 || strings.Join((*calls)[0], " ") != strings.Join(want[0], " ") {
+	want := [][]string{
+		{"systemctl", "--user", "reset-failed", autostartUnitName},
+		{"systemctl", "--user", "restart", autostartUnitName},
+	}
+	if !reflect.DeepEqual(*calls, want) {
+		t.Fatalf("unit commands = %v, want %v", *calls, want)
+	}
+}
+
+func TestRestartAutostartUnitToleratesUnloadedInactiveUnitLinux(t *testing.T) {
+	withAutostartTestEnv(t, "linux")
+	calls := stubAutostartUnitCommandFunc(t, func(_ string, args ...string) ([]byte, error) {
+		if len(args) > 1 && args[1] == "reset-failed" {
+			return []byte("unit is not loaded"), errors.New("exit status 1")
+		}
+		if len(args) > 1 && args[1] == "show" {
+			return []byte("inactive\n"), nil
+		}
+		return nil, nil
+	})
+
+	if err := RestartAutostartUnit(); err != nil {
+		t.Fatalf("RestartAutostartUnit treated an inactive unloaded unit as failed: %v", err)
+	}
+	want := [][]string{
+		{"systemctl", "--user", "reset-failed", autostartUnitName},
+		{"systemctl", "--user", "show", autostartUnitName, "--property=ActiveState", "--value"},
+		{"systemctl", "--user", "restart", autostartUnitName},
+	}
+	if !reflect.DeepEqual(*calls, want) {
 		t.Fatalf("unit commands = %v, want %v", *calls, want)
 	}
 }
@@ -431,7 +620,7 @@ func TestAutostartLaunchdCallsShareOneDomain(t *testing.T) {
 
 func TestRestartAutostartUnitFailureSurfacesOutput(t *testing.T) {
 	withAutostartTestEnv(t, "linux")
-	stubAutostartUnitCommand(t, errors.New("exit status 1"))
+	calls := stubAutostartUnitCommand(t, errors.New("exit status 1"))
 
 	err := RestartAutostartUnit()
 	if err == nil {
@@ -439,6 +628,13 @@ func TestRestartAutostartUnitFailureSurfacesOutput(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unit failure detail") {
 		t.Fatalf("error %q does not include the command output", err)
+	}
+	want := [][]string{
+		{"systemctl", "--user", "reset-failed", autostartUnitName},
+		{"systemctl", "--user", "show", autostartUnitName, "--property=ActiveState", "--value"},
+	}
+	if !reflect.DeepEqual(*calls, want) {
+		t.Fatalf("restart must stop after reset-failed fails; calls=%v want=%v", *calls, want)
 	}
 }
 

--- a/daemon/autostart_test.go
+++ b/daemon/autostart_test.go
@@ -16,6 +16,8 @@ Description=Agent Factory daemon (task scheduler + session monitor)
 
 [Service]
 KillMode=process
+StartLimitInterval=60
+StartLimitBurst=5
 ExecStart="/home/user/.local/bin/af" --daemon
 Restart=on-failure
 RestartSec=5
@@ -28,6 +30,26 @@ WantedBy=default.target
 `
 	if got != want {
 		t.Fatalf("systemd unit content mismatch.\n got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestSystemdAutostartUnitBoundsRestartBurstCompatibly is the new-install half
+// of #2168's Phase 1 backstop. RestartSec=5 outlives systemd's default
+// 10-second start-limit window, so the default limiter can never catch a
+// persistent crash. The legacy service-level spelling works before v229/v230
+// and remains accepted by newer systemd releases.
+func TestSystemdAutostartUnitBoundsRestartBurstCompatibly(t *testing.T) {
+	got := systemdAutostartUnit("/home/user/.local/bin/af", "/usr/bin:/bin", "/bin/zsh", "")
+	for _, want := range []string{
+		"StartLimitInterval=60\n",
+		"StartLimitBurst=5\n",
+	} {
+		if strings.Count(got, want) != 1 {
+			t.Errorf("systemd unit must contain exactly one %q:\n%s", strings.TrimSpace(want), got)
+		}
+	}
+	if strings.Contains(got, "StartLimitIntervalSec=") {
+		t.Fatalf("generated unit uses the v230-only interval spelling:\n%s", got)
 	}
 }
 
@@ -142,6 +164,8 @@ Description=Agent Factory daemon (task scheduler + session monitor)
 
 [Service]
 KillMode=process
+StartLimitInterval=60
+StartLimitBurst=5
 ExecStart="/home/user/.local/bin/af" --daemon
 Restart=on-failure
 RestartSec=5

--- a/integration/daemon_restart_cgroup_test.go
+++ b/integration/daemon_restart_cgroup_test.go
@@ -103,6 +103,9 @@ func TestDaemonRestartPreservesDaemonSpawnedTmux(t *testing.T) {
 	if !strings.Contains(string(log), "preserved scoped tmux server") {
 		t.Fatalf("forced control-group fault was not demonstrably survived; manager log:\n%s", log)
 	}
+	if got := strings.Count(string(log), "reset failed state"); got != 3 {
+		t.Fatalf("install and both restarts must clear a prior start-limit failure; reset count=%d log:\n%s", got, log)
+	}
 }
 
 func disposableLifecycleEnvironment() bool {
@@ -183,6 +186,10 @@ start_daemon() {
 
 case "${1:-}" in
     daemon-reload)
+        exit 0
+        ;;
+    reset-failed)
+        printf 'reset failed state\n' >>"$AF_FAKE_MANAGER_LOG"
         exit 0
         ;;
     enable)


### PR DESCRIPTION
## Summary

- give newly installed Linux daemon units an AF-owned restart-rate window: five starts in sixty seconds, using the service-level spelling accepted before v229/v230 and by current systemd
- extend the existing current-home-scoped restart migration so installed units receive the same backstop before an explicit restart or upgrade respawn
- clear retained failed/start-rate state before install, restart, or resume starts the unit; when systemd rejects the reset for an unloaded unit, tolerate only stable manager state `inactive` and keep failed/active/unknown states blocking
- preserve captured executable, environment, home, unrelated unit directives, and the existing tmux-safe `KillMode` policy

This is the approved Phase 1 slice of #2168 after Phase 0 removed the only known permanent startup refusal. It intentionally does not add an unused exit-78 class or `RestartPreventExitStatus`, and it does not change `EnsureDaemon`, launchd, supervision precedence, or CLI verbs.

## Reproduction and regression coverage

Before the implementation, both fail-first tests failed: the production renderer emitted `Restart=on-failure` with `RestartSec=5` but no `StartLimit` directives, and `RefreshAutostartUnit` left an installed legacy unit on that same unbounded policy.

The production paths under test are:

- `af daemon install` → `InstallAutostart` → `systemdAutostartUnit` for new units
- explicit restart and upgrade respawn → current-home ownership gate → `RefreshAutostartUnit` → bounded, surgical rewrite plus `systemctl --user daemon-reload`

The regressions require exactly one compatibility-safe `StartLimitInterval=60` and `StartLimitBurst=5` in both paths, cover a valid service file with no `[Unit]` section, and verify that install-time executable/environment/home values survive migration. Command-sequence tests require install, restart, and resume to attempt `reset-failed` before starting. A reset error is benign only when a read-only `systemctl --user show ... ActiveState` reports exact machine state `inactive`, which covers fresh or garbage-collected units without parsing localized stderr; retained `failed` state, unknown state, and inspection failures remain hard errors. The real-systemd lifecycle gate also exercises the full abrupt-failure reap ordering and exact tmux PID preservation on both supported Ubuntu runners.

## Gates

Exact head: `290cf21372222db2829b5b3d5967c019b905dcae`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make docs` with a clean resulting tree
- `make test-container`

Part of #2168.
