### PR TITLE
fix(tasks): preserve save baselines on reload failure

### DIFF
--- a/apiclient/client.go
+++ b/apiclient/client.go
@@ -266,7 +266,7 @@ func (c *Client) callCtx(ctx context.Context, method string, req any, resp any) 
 		// net/rpc client would carry, since both transports wrap the same
 		// controlServer error — except where the message is provably a version
 		// skew, which is unactionable in its raw form.
-		return interpretEnvelopeError(env.Error.Message)
+		return interpretEnvelopeError(env.Error.Message, env.Error.Code)
 	}
 	if resp != nil {
 		if err := json.Unmarshal(env.Data, resp); err != nil {

--- a/apiclient/client_test.go
+++ b/apiclient/client_test.go
@@ -151,3 +151,25 @@ func TestSnapshot_FailureEnvelope_SurfacesMessage(t *testing.T) {
 		t.Fatalf("want verbatim daemon message, got %v", err)
 	}
 }
+
+// A mutation_committed envelope keeps surfacing its human-readable failure,
+// while also preserving the durable outcome through the HTTP client boundary.
+func TestFailureEnvelope_PreservesMutationCommittedOutcome(t *testing.T) {
+	c := snapshotServer(t, func(daemon.SnapshotRequest) apiproto.Envelope {
+		return apiproto.FailureWithCode(
+			"task update committed, but scheduler reload failed",
+			apiproto.ErrorCodeMutationCommitted,
+		)
+	})
+
+	_, err := c.Snapshot(daemon.SnapshotRequest{})
+	if err == nil {
+		t.Fatal("want the post-commit failure to remain visible")
+	}
+	if !IsMutationCommitted(err) {
+		t.Fatalf("want mutation-committed outcome, got %T: %v", err, err)
+	}
+	if err.Error() != "task update committed, but scheduler reload failed" {
+		t.Fatalf("want verbatim daemon message, got %q", err)
+	}
+}

--- a/apiclient/skew.go
+++ b/apiclient/skew.go
@@ -1,8 +1,11 @@
 package apiclient
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
+
+	"github.com/sachiniyer/agent-factory/apiproto"
 )
 
 // unknownFieldPattern matches the daemon's strict-decoder rejection. It requires
@@ -52,9 +55,33 @@ func (e *VersionSkewError) Error() string {
 // upgrading a provable version skew into an actionable VersionSkewError and
 // passing everything else through verbatim so existing callers that match on
 // daemon message text are unaffected.
-func interpretEnvelopeError(msg string) error {
+func interpretEnvelopeError(msg, code string) error {
+	if code == apiproto.ErrorCodeMutationCommitted {
+		return &mutationCommittedError{detail: msg}
+	}
 	if m := unknownFieldPattern.FindStringSubmatch(msg); m != nil {
 		return &VersionSkewError{Field: m[1], Detail: msg}
 	}
 	return fmt.Errorf("%s", msg)
+}
+
+// mutationCommittedError tells mutation callers that the daemon durably wrote
+// their change before the reported follow-up failure. Its marker method keeps
+// the classification usable through errors.Join and other wrappers.
+type mutationCommittedError struct {
+	detail string
+}
+
+func (e *mutationCommittedError) Error() string           { return e.detail }
+func (e *mutationCommittedError) MutationCommitted() bool { return true }
+
+// IsMutationCommitted distinguishes a rejected mutation from a durable one
+// whose post-commit work failed. The latter still surfaces as an error, but a
+// caller must advance its persistence baseline instead of retrying the write.
+func IsMutationCommitted(err error) bool {
+	type committed interface {
+		MutationCommitted() bool
+	}
+	var outcome committed
+	return errors.As(err, &outcome) && outcome.MutationCommitted()
 }

--- a/apiproto/envelope.go
+++ b/apiproto/envelope.go
@@ -32,11 +32,18 @@ type Envelope struct {
 }
 
 // EnvelopeError is the error member of an Envelope. Message is a human-readable
-// description; the struct leaves room to grow additional fields (e.g. a machine
-// code) later without breaking the additive contract.
+// description. Code is an optional machine-readable outcome; omitting it keeps
+// ordinary failure envelopes byte-for-byte compatible with older clients.
 type EnvelopeError struct {
 	Message string `json:"message"`
+	Code    string `json:"code,omitempty"`
 }
+
+// ErrorCodeMutationCommitted says the requested mutation reached durable
+// storage before a later, non-transactional follow-up failed. A caller must
+// still surface the failure, but must not retry the mutation as though it never
+// happened.
+const ErrorCodeMutationCommitted = "mutation_committed"
 
 // Success wraps a payload as a successful Envelope (Error nil).
 func Success(data any) Envelope {
@@ -46,6 +53,12 @@ func Success(data any) Envelope {
 // Failure wraps a message as a failed Envelope (Data nil).
 func Failure(msg string) Envelope {
 	return Envelope{Data: nil, Error: &EnvelopeError{Message: msg}}
+}
+
+// FailureWithCode wraps a failure with an additive machine-readable outcome.
+// Older clients ignore Code and retain the existing human-readable error.
+func FailureWithCode(msg, code string) Envelope {
+	return Envelope{Data: nil, Error: &EnvelopeError{Message: msg, Code: code}}
 }
 
 // MarshalIndented is the single JSON-encoding primitive the CLI and HTTP output

--- a/apiproto/envelope.go
+++ b/apiproto/envelope.go
@@ -36,7 +36,7 @@ type Envelope struct {
 // ordinary failure envelopes byte-for-byte compatible with older clients.
 type EnvelopeError struct {
 	Message string `json:"message"`
-	Code    string `json:"code,omitempty"`
+	Code    string `json:"code,omitempty"` // Clients preserve this for retry safety.
 }
 
 // ErrorCodeMutationCommitted says the requested mutation reached durable

--- a/app/content_persistence.go
+++ b/app/content_persistence.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/sachiniyer/agent-factory/apiclient"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/task"
@@ -94,9 +95,9 @@ func (m *home) saveContentPaneState() error {
 	// writer of tasks.json among clients (#960), so a TUI edit/delete goes
 	// through the same RPC wrappers the CLI uses instead of touching the file
 	// directly. Each CRUD RPC re-arms the daemon's scheduler + watchers
-	// in-process, so there is no separate ReloadTasks poke here — the write and
-	// its schedule refresh are one atomic daemon call (removing the old
-	// double-reload).
+	// in-process, so there is no separate ReloadTasks poke here. The write lands
+	// before the refresh; a post-commit refresh failure is classified below so
+	// the error remains visible without retrying a durable edit.
 	//
 	// Persist ONLY the tasks the user actually edited (ConsumeDirty), and only
 	// the FIELDS they changed: each edit carries a field-level patch (diffed
@@ -107,7 +108,14 @@ func (m *home) saveContentPaneState() error {
 	// harmless no-op the daemon still validates.
 	for _, edit := range sp.ConsumeDirty() {
 		if err := updateTaskThroughDaemon(edit.ID, edit.Update); err != nil {
-			sp.RestoreFailedEdit(edit.ID)
+			if apiclient.IsMutationCommitted(err) {
+				// The task write landed; only the daemon's schedule refresh
+				// failed. Keep surfacing that failure, but advance this task's
+				// baseline so a later edit is diffed against durable state.
+				sp.AcknowledgeSavedEdit(edit.ID)
+			} else {
+				sp.RestoreFailedEdit(edit.ID)
+			}
 			log.ErrorLog.Printf("failed to update task: %v", err)
 			saveErr = errors.Join(saveErr, fmt.Errorf("failed to save task %q: %w", edit.ID, err))
 			continue

--- a/app/content_persistence.go
+++ b/app/content_persistence.go
@@ -49,16 +49,14 @@ func (m *home) handleQuit() (tea.Model, tea.Cmd) {
 // destructive action and surface it via handleError; the dirty pane preserves
 // the edit so the user can retry from where they left off.
 //
-// Recovery semantics on a task-save failure (#934): we reload BOTH the sidebar
-// and the TaskPane from disk so the two panes always agree and always reflect
-// the committed on-disk state — never a mix of stale in-memory edits in one
-// pane and disk state in the other. Reloading clears the TaskPane's dirty flag,
-// which means a failed edit is discarded rather than left dangling; we
-// therefore return the error so callers surface it (via handleError) and the
-// dropped edit is never silent. We deliberately do NOT keep dirty=true for an
-// in-place retry: after the reload the in-memory edits are gone, so a lingering
-// dirty flag would point at nothing. The user re-applies the edit from a
-// known-consistent state instead.
+// Recovery semantics on a task-save failure (#934): when the final reload
+// succeeds, we replace BOTH the sidebar and TaskPane from disk so they agree on
+// committed state. Reloading clears the TaskPane's dirty flag; a failed edit is
+// discarded, and the returned error makes that loss visible. If the reload
+// itself fails (#2324), each successful task update has already advanced its
+// diff baseline, while each failed update remains dirty and retryable. That is
+// the only state that neither resends an old successful field nor treats an
+// unpersisted edit as saved.
 func (m *home) saveContentPaneState() error {
 	// Accumulate failures across both panes so a hooks error and a task error
 	// can never clobber one another (#1001).
@@ -109,9 +107,12 @@ func (m *home) saveContentPaneState() error {
 	// harmless no-op the daemon still validates.
 	for _, edit := range sp.ConsumeDirty() {
 		if err := updateTaskThroughDaemon(edit.ID, edit.Update); err != nil {
+			sp.RestoreFailedEdit(edit.ID)
 			log.ErrorLog.Printf("failed to update task: %v", err)
 			saveErr = errors.Join(saveErr, fmt.Errorf("failed to save task %q: %w", edit.ID, err))
+			continue
 		}
+		sp.AcknowledgeSavedEdit(edit.ID)
 	}
 	for _, tsk := range sp.ConsumeDeleted() {
 		if err := removeTaskThroughDaemon(tsk.ID); err != nil {

--- a/app/content_persistence_baseline_test.go
+++ b/app/content_persistence_baseline_test.go
@@ -1,0 +1,86 @@
+package app
+
+import (
+	"fmt"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/sachiniyer/agent-factory/task"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #2324: a successful daemon update followed by a failed reload must still
+// advance the TaskPane's diff baseline. Otherwise toggling the same field back
+// to its original value looks like an empty diff and the second edit is lost.
+func TestSaveContentPaneStateAdvancesSuccessfulEditWhenReloadFails(t *testing.T) {
+	h, pane := taskPaneWithEnabledTask(t)
+	var updates []task.TaskUpdate
+	t.Cleanup(SetTaskUpdaterForTest(func(_ string, update task.TaskUpdate) error {
+		updates = append(updates, update)
+		return nil
+	}))
+
+	require.True(t, pane.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")}))
+	err := h.saveContentPaneState()
+	require.ErrorContains(t, err, "failed to reload tasks after save")
+	require.Len(t, updates, 1)
+	require.NotNil(t, updates[0].Enabled)
+	assert.False(t, *updates[0].Enabled)
+
+	// The first write committed false. Toggling back to true must therefore be
+	// a real second patch even though true was the pane's initial value.
+	require.True(t, pane.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")}))
+	err = h.saveContentPaneState()
+	require.ErrorContains(t, err, "failed to reload tasks after save")
+	require.Len(t, updates, 2,
+		"a stale pre-save baseline incorrectly drops the edit that returns to the original value")
+	require.NotNil(t, updates[1].Enabled)
+	assert.True(t, *updates[1].Enabled)
+}
+
+// A failed write and failed reload is the opposite edge of #2324: the pane
+// must not advance its baseline or clear its only retry signal. The user-facing
+// error aborts focus release/quit, so keeping the edit dirty lets that retry
+// persist exactly the patch that did not commit.
+func TestSaveContentPaneStateKeepsFailedEditDirtyWhenReloadFails(t *testing.T) {
+	h, pane := taskPaneWithEnabledTask(t)
+	attempts := 0
+	t.Cleanup(SetTaskUpdaterForTest(func(_ string, update task.TaskUpdate) error {
+		attempts++
+		require.NotNil(t, update.Enabled)
+		assert.False(t, *update.Enabled)
+		return fmt.Errorf("daemon update failed")
+	}))
+
+	require.True(t, pane.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")}))
+	err := h.saveContentPaneState()
+	require.ErrorContains(t, err, "failed to save task")
+	require.ErrorContains(t, err, "failed to reload tasks after save")
+	assert.True(t, pane.IsDirty(), "an unpersisted edit needs to remain retryable when reload cannot recover it")
+
+	err = h.saveContentPaneState()
+	require.ErrorContains(t, err, "failed to save task")
+	assert.Equal(t, 2, attempts, "the second save must retry the unpersisted patch")
+}
+
+func taskPaneWithEnabledTask(t *testing.T) (*home, taskPaneSaveSurface) {
+	t.Helper()
+	h := newTestHome(t)
+	pane := h.automations.TaskPane()
+	pane.SetTasks([]task.Task{{ID: "task-2324", Name: "task", Enabled: true}})
+	pane.SetFocus(true)
+
+	// saveContentPaneState's production reload resolves the current Git repo.
+	// A fresh non-repo directory makes that final read fail deterministically,
+	// after the daemon update seam has reported its independent outcome.
+	t.Chdir(t.TempDir())
+	return h, pane
+}
+
+// taskPaneSaveSurface keeps the helper's return type limited to the production
+// methods the regression drives, rather than exposing TaskPane internals here.
+type taskPaneSaveSurface interface {
+	HandleKeyPress(tea.KeyMsg) bool
+	IsDirty() bool
+}

--- a/app/content_persistence_baseline_test.go
+++ b/app/content_persistence_baseline_test.go
@@ -64,6 +64,40 @@ func TestSaveContentPaneStateKeepsFailedEditDirtyWhenReloadFails(t *testing.T) {
 	assert.Equal(t, 2, attempts, "the second save must retry the unpersisted patch")
 }
 
+// A daemon update can durably commit tasks.json and then fail while reloading
+// its scheduler. That error must still surface, but it is not an unpersisted
+// edit: retaining the old baseline would make the next edit diff against stale
+// state and can drop a user's revert.
+func TestSaveContentPaneStateAdvancesPostCommitErrorWhenReloadFails(t *testing.T) {
+	h, pane := taskPaneWithEnabledTask(t)
+	var updates []task.TaskUpdate
+	t.Cleanup(SetTaskUpdaterForTest(func(_ string, update task.TaskUpdate) error {
+		updates = append(updates, update)
+		return committedUpdateTestError{}
+	}))
+
+	require.True(t, pane.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")}))
+	err := h.saveContentPaneState()
+	require.ErrorContains(t, err, "scheduler reload failed after commit")
+	require.ErrorContains(t, err, "failed to reload tasks after save")
+	assert.False(t, pane.IsDirty(), "a committed edit must not remain queued as an unpersisted retry")
+
+	// The first write committed false. Returning to true is therefore a second
+	// real edit, even though true was the pane's pre-save value.
+	require.True(t, pane.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")}))
+	err = h.saveContentPaneState()
+	require.ErrorContains(t, err, "scheduler reload failed after commit")
+	require.Len(t, updates, 2,
+		"a post-commit error must advance the baseline before the next edit is diffed")
+	require.NotNil(t, updates[1].Enabled)
+	assert.True(t, *updates[1].Enabled)
+}
+
+type committedUpdateTestError struct{}
+
+func (committedUpdateTestError) Error() string           { return "scheduler reload failed after commit" }
+func (committedUpdateTestError) MutationCommitted() bool { return true }
+
 func taskPaneWithEnabledTask(t *testing.T) (*home, taskPaneSaveSurface) {
 	t.Helper()
 	h := newTestHome(t)

--- a/app/session_control.go
+++ b/app/session_control.go
@@ -249,8 +249,10 @@ var triggerTaskThroughDaemon = func(taskID string) error {
 // task.AddTask/UpdateTask/RemoveTask and then poked ReloadTasks; now they go
 // through the SAME spawning RPC wrappers the CLI uses (api/tasks.go's
 // daemonAddTask/…), and because the daemon's CRUD handlers re-arm the scheduler
-// and watchers in-process (#1029 PR 3), the separate ReloadTasks poke is gone —
-// the write and its schedule refresh are one atomic daemon call. Like the tab
+// and watchers in-process (#1029 PR 3), the separate ReloadTasks poke is gone.
+// Persistence happens before that refresh; UpdateTask reports the committed
+// outcome explicitly if the refresh fails so the pane advances its baseline.
+// Like the tab
 // create/close RPCs (handleNewTab/handleCloseTab), these are quick daemon writes
 // dispatched synchronously on the event loop — not the tens-of-seconds ssh
 // teardowns that motivate the async kill/archive cmds — so saveContentPaneState

--- a/daemon/control_server.go
+++ b/daemon/control_server.go
@@ -257,13 +257,15 @@ func (s *controlServer) UpdateTask(req UpdateTaskRequest, resp *UpdateTaskRespon
 	}
 	resp.OK = true
 	resp.Task = merged
+	// Publish at the durable commit boundary, before the non-transactional
+	// schedule refresh. If refresh fails, the caller receives the committed
+	// outcome below and every other client still learns to refetch this value.
+	// The payload is the authoritative merged record, not the partial patch.
+	s.manager.publishEvent(agentproto.EventTaskUpdated, merged)
 	if err := s.reloadTaskSchedulesLocked(); err != nil {
 		return &mutationCommittedError{err: fmt.Errorf(
 			"task update committed, but failed to reload task schedules: %w", err)}
 	}
-	// Publish the merged record — the authoritative post-edit task — not the
-	// partial patch, so subscribers (TUI/web) receive the full updated task.
-	s.manager.publishEvent(agentproto.EventTaskUpdated, merged)
 	return nil
 }
 

--- a/daemon/control_server.go
+++ b/daemon/control_server.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/sachiniyer/agent-factory/agentproto"
+	"github.com/sachiniyer/agent-factory/apiproto"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/task"
@@ -22,6 +23,19 @@ type controlServer struct {
 	watchers     *watcherSupervisor
 	shutdownCh   chan struct{}
 	shutdownOnce sync.Once
+}
+
+// mutationCommittedError preserves the otherwise-ambiguous outcome of a
+// durable mutation whose non-transactional follow-up failed. HTTP exposes its
+// code additively; net/rpc clients retain the same human-readable error text.
+type mutationCommittedError struct {
+	err error
+}
+
+func (e *mutationCommittedError) Error() string { return e.err.Error() }
+func (e *mutationCommittedError) Unwrap() error { return e.err }
+func (e *mutationCommittedError) APIErrorCode() string {
+	return apiproto.ErrorCodeMutationCommitted
 }
 
 func (s *controlServer) Ping(_ PingRequest, resp *PingResponse) error {
@@ -79,9 +93,10 @@ func (s *controlServer) ResumeStatusPoll(req ResumeStatusPollRequest, resp *Resu
 
 // reloadTaskSchedules re-arms the daemon's cron scheduler and watcher
 // supervisor from tasks.json. It is the shared refresh the ReloadTasks poke and
-// the task CRUD RPCs (Add/Update/RemoveTask) both invoke after a write, so the
-// write and its schedule refresh happen atomically in-daemon and no separate
-// ReloadTasks poke is needed for CRUD.
+// the task CRUD RPCs (Add/Update/RemoveTask) both invoke after a write, so one
+// daemon call owns both steps and no separate ReloadTasks poke is needed for
+// CRUD. The steps are not transactional: persistence happens first, and update
+// callers receive a machine-readable committed outcome if the refresh fails.
 //
 // During warm-up (#829) the scheduler and watcher supervisor have not started
 // yet; RunDaemon reloads both from tasks.json right after the restore completes,
@@ -240,11 +255,12 @@ func (s *controlServer) UpdateTask(req UpdateTaskRequest, resp *UpdateTaskRespon
 	if err != nil {
 		return err
 	}
-	if err := s.reloadTaskSchedulesLocked(); err != nil {
-		return err
-	}
 	resp.OK = true
 	resp.Task = merged
+	if err := s.reloadTaskSchedulesLocked(); err != nil {
+		return &mutationCommittedError{err: fmt.Errorf(
+			"task update committed, but failed to reload task schedules: %w", err)}
+	}
 	// Publish the merged record — the authoritative post-edit task — not the
 	// partial patch, so subscribers (TUI/web) receive the full updated task.
 	s.manager.publishEvent(agentproto.EventTaskUpdated, merged)

--- a/daemon/control_server.go
+++ b/daemon/control_server.go
@@ -262,11 +262,12 @@ func (s *controlServer) UpdateTask(req UpdateTaskRequest, resp *UpdateTaskRespon
 	// outcome below and every other client still learns to refetch this value.
 	// The payload is the authoritative merged record, not the partial patch.
 	s.manager.publishEvent(agentproto.EventTaskUpdated, merged)
-	if err := s.reloadTaskSchedulesLocked(); err != nil {
-		return &mutationCommittedError{err: fmt.Errorf(
-			"task update committed, but failed to reload task schedules: %w", err)}
+	reloadErr := s.reloadTaskSchedulesLocked()
+	if reloadErr == nil {
+		return nil
 	}
-	return nil
+	return &mutationCommittedError{err: fmt.Errorf(
+		"task update committed, but failed to reload task schedules: %w", reloadErr)}
 }
 
 func (s *controlServer) RemoveTask(req RemoveTaskRequest, resp *RemoveTaskResponse) error {

--- a/daemon/httpserver.go
+++ b/daemon/httpserver.go
@@ -405,6 +405,14 @@ func writeHTTPSuccess(w http.ResponseWriter, r *http.Request, data any) {
 // writeHTTPError encodes err in a failure envelope with the given status. The
 // envelope body is always returned on error, never a bare status.
 func writeHTTPError(w http.ResponseWriter, r *http.Request, status int, err error) {
+	type codedError interface {
+		APIErrorCode() string
+	}
+	var coded codedError
+	if errors.As(err, &coded) {
+		writeHTTPEnvelope(w, r, status, apiproto.FailureWithCode(err.Error(), coded.APIErrorCode()))
+		return
+	}
 	writeHTTPEnvelope(w, r, status, apiproto.Failure(err.Error()))
 }
 

--- a/daemon/httpserver_test.go
+++ b/daemon/httpserver_test.go
@@ -128,6 +128,40 @@ func TestHTTP_AddTask_MutationRoute(t *testing.T) {
 		"AddTask route must re-arm the scheduler like the RPC handler")
 }
 
+// An UpdateTask write happens before the scheduler reload. If that reload
+// fails, the HTTP client needs a machine-readable outcome so it does not treat
+// the durable edit as rejected and retry it against a stale baseline.
+func TestHTTP_UpdateTask_PostCommitErrorCarriesOutcome(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	require.NoError(t, task.AddTask(enabledCronTask("bbbb1002", "")))
+
+	disabled := false
+	body, err := json.Marshal(UpdateTaskRequest{
+		ID:     "bbbb1002",
+		Update: task.TaskUpdate{Enabled: &disabled},
+	})
+	require.NoError(t, err)
+
+	// A nil scheduler deterministically fails only after task.UpdateTask has
+	// written the patch, reproducing the ambiguous production outcome.
+	rec := doHTTP(&controlServer{}, http.MethodPost, "/v1/UpdateTask", string(body))
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	var env struct {
+		Error *struct {
+			Message string `json:"message"`
+			Code    string `json:"code"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &env))
+	require.NotNil(t, env.Error)
+	assert.Equal(t, "mutation_committed", env.Error.Code)
+
+	got, err := task.GetTask("bbbb1002")
+	require.NoError(t, err)
+	assert.False(t, got.Enabled, "the test must prove the write committed before the reload error")
+}
+
 // TestHTTP_TriggerTask_HandlerError covers the TriggerTask mutation route and the
 // handler-error → 500 mapping: RunTask refuses a disabled task, and the envelope
 // still carries the error message.

--- a/daemon/httpserver_test.go
+++ b/daemon/httpserver_test.go
@@ -142,9 +142,12 @@ func TestHTTP_UpdateTask_PostCommitErrorCarriesOutcome(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// A nil scheduler deterministically fails only after task.UpdateTask has
-	// written the patch, reproducing the ambiguous production outcome.
-	rec := doHTTP(&controlServer{}, http.MethodPost, "/v1/UpdateTask", string(body))
+	// The scheduler admits the mutation's control lock, then fails while
+	// reloading after task.UpdateTask has written the patch. That reproduces the
+	// ambiguous production outcome without turning the failure into a pre-write
+	// admission error.
+	rec := doHTTP(&controlServer{scheduler: failingReloadTaskScheduler()},
+		http.MethodPost, "/v1/UpdateTask", string(body))
 	require.Equal(t, http.StatusInternalServerError, rec.Code)
 
 	var env struct {

--- a/daemon/task_rpc_test.go
+++ b/daemon/task_rpc_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"encoding/json"
+	"errors"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -31,6 +32,14 @@ func enabledCronTask(id, repoPath string) task.Task {
 		Enabled:     true,
 		CreatedAt:   time.Now(),
 	}
+}
+
+func failingReloadTaskScheduler() *taskScheduler {
+	scheduler := newTaskScheduler()
+	scheduler.loadTasks = func() ([]task.Task, error) {
+		return nil, errors.New("forced task reload failure")
+	}
+	return scheduler
 }
 
 // TestControlListTasks_ReadsDisk pins that the ListTasks handler returns the
@@ -97,9 +106,14 @@ func TestControlUpdateTask_PostCommitFailureStillPublishes(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
 	require.NoError(t, task.AddTask(enabledCronTask("cccc0002", "")))
 
-	manager := &Manager{events: newEventsHub()}
+	ready := make(chan struct{})
+	close(ready)
+	manager := &Manager{events: newEventsHub(), ready: ready}
 	_, events := manager.events.subscribe()
-	srv := &controlServer{manager: manager} // nil scheduler fails after the write
+	srv := &controlServer{
+		manager:   manager,
+		scheduler: failingReloadTaskScheduler(),
+	}
 	disabled := false
 
 	var resp UpdateTaskResponse

--- a/daemon/task_rpc_test.go
+++ b/daemon/task_rpc_test.go
@@ -1,10 +1,12 @@
 package daemon
 
 import (
+	"encoding/json"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/sachiniyer/agent-factory/agentproto"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/internal/testguard"
 	"github.com/sachiniyer/agent-factory/task"
@@ -85,6 +87,38 @@ func TestControlUpdateTask_WritesAndRearms(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "30 6 * * 1", got.CronExpr, "UpdateTask must persist the edit")
 	assert.Contains(t, srv.scheduler.scheduledTaskIDs(), "cccc0001")
+}
+
+// A schedule reload failure happens after UpdateTask has committed. Even though
+// the RPC must still report that failure, every other client needs the
+// task.updated event so it can refetch the durable value instead of staying
+// stale after its own promise rejects.
+func TestControlUpdateTask_PostCommitFailureStillPublishes(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	require.NoError(t, task.AddTask(enabledCronTask("cccc0002", "")))
+
+	manager := &Manager{events: newEventsHub()}
+	_, events := manager.events.subscribe()
+	srv := &controlServer{manager: manager} // nil scheduler fails after the write
+	disabled := false
+
+	var resp UpdateTaskResponse
+	err := srv.UpdateTask(UpdateTaskRequest{
+		ID:     "cccc0002",
+		Update: task.TaskUpdate{Enabled: &disabled},
+	}, &resp)
+	require.ErrorContains(t, err, "task update committed")
+
+	select {
+	case event := <-events:
+		require.Equal(t, agentproto.EventTaskUpdated, event.Type)
+		var updated task.Task
+		require.NoError(t, json.Unmarshal(event.Data, &updated))
+		assert.Equal(t, "cccc0002", updated.ID)
+		assert.False(t, updated.Enabled)
+	default:
+		t.Fatal("committed task update was not published before the post-commit error returned")
+	}
 }
 
 // TestControlRemoveTask_WritesAndDisarms pins that RemoveTask deletes the task

--- a/ui/task_pane_state.go
+++ b/ui/task_pane_state.go
@@ -99,15 +99,43 @@ func (s *TaskPane) ConsumeDirty() []task.TaskEdit {
 	return edits
 }
 
+// AcknowledgeSavedEdit advances one task's diff baseline after its daemon
+// update succeeds. The update contains every user-editable field that differs
+// from the previous baseline, so the pane's current value is exactly the new
+// baseline for later edits even if the caller's final disk reload fails.
+func (s *TaskPane) AcknowledgeSavedEdit(id string) {
+	for _, current := range s.tasks {
+		if current.ID != id {
+			continue
+		}
+		if s.originals == nil {
+			s.originals = make(map[string]task.Task)
+		}
+		s.originals[id] = current
+		delete(s.dirtyIDs, id)
+		return
+	}
+}
+
+// RestoreFailedEdit makes a consumed edit retryable when its daemon update
+// fails. A successful final reload will still replace the pane and clear this
+// state; if that reload also fails, the in-memory edit remains the only copy
+// and must stay dirty rather than being mistaken for a persisted baseline.
+func (s *TaskPane) RestoreFailedEdit(id string) {
+	s.markTaskDirty(id)
+}
+
 // ConsumeDeleted returns the tasks pending deletion and clears the pane's
-// dirty state so a subsequent save can't reprocess already-deleted tasks. The
-// deletion loop in saveContentPaneState removes task records as a side
-// effect, so re-running it would call RemoveTask on records that no longer
-// exist and log spurious errors (fixes #763).
+// deletion state so a subsequent save can't reprocess already-deleted tasks.
+// Failed edits restored after ConsumeDirty keep the pane dirty until the final
+// reload succeeds or a later save retries them. The deletion loop in
+// saveContentPaneState removes task records as a side effect, so re-running it
+// would call RemoveTask on records that no longer exist and log spurious errors
+// (fixes #763).
 func (s *TaskPane) ConsumeDeleted() []task.Task {
 	deleted := s.deleted
 	s.deleted = nil
-	s.dirty = false
+	s.dirty = len(s.dirtyIDs) > 0
 	return deleted
 }
 

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -6183,14 +6183,27 @@ function envelopeErrorText(err, statusLine) {
   }
   return errorText(err, statusLine);
 }
+function envelopeErrorCode(err) {
+  if (err === null || typeof err !== "object") {
+    return "";
+  }
+  const code = err.code;
+  return typeof code === "string" ? code : "";
+}
+var MUTATION_COMMITTED_ERROR_CODE = "mutation_committed";
 var ApiError = class extends Error {
   status;
-  constructor(status, message) {
+  code;
+  constructor(status, message, code = "") {
     super(message);
     this.name = "ApiError";
     this.status = status;
+    this.code = code;
   }
 };
+function isMutationCommittedError(e) {
+  return e instanceof ApiError && e.code === MUTATION_COMMITTED_ERROR_CODE;
+}
 async function af(method, body, token2) {
   const headers = { "Content-Type": "application/json" };
   if (token2 !== "") {
@@ -6213,10 +6226,10 @@ async function af(method, body, token2) {
   }
   const statusLine = `${resp.status} ${resp.statusText}`.trim();
   if (!resp.ok) {
-    throw new ApiError(resp.status, envelopeErrorText(env?.error, statusLine));
+    throw new ApiError(resp.status, envelopeErrorText(env?.error, statusLine), envelopeErrorCode(env?.error));
   }
   if (env && env.error != null) {
-    throw new ApiError(resp.status, envelopeErrorText(env.error, statusLine));
+    throw new ApiError(resp.status, envelopeErrorText(env.error, statusLine), envelopeErrorCode(env.error));
   }
   return env?.data;
 }
@@ -12803,6 +12816,12 @@ function openEditTask(task) {
           closeModal();
           refreshTasks();
         }).catch((e) => {
+          if (isMutationCommittedError(e)) {
+            closeModal();
+            refreshTasks();
+            surfaceTabError(e);
+            return;
+          }
           m.setBusy(false);
           m.setError(describeError(e));
         });
@@ -12816,7 +12835,12 @@ function toggleTask(task) {
   if (tok === null) {
     return;
   }
-  void updateTask(task.id, { enabled: !task.enabled }, tok).then(refreshTasks).catch((e) => surfaceTabError(e));
+  void updateTask(task.id, { enabled: !task.enabled }, tok).then(refreshTasks).catch((e) => {
+    if (isMutationCommittedError(e)) {
+      refreshTasks();
+    }
+    surfaceTabError(e);
+  });
 }
 function doTriggerTask(task) {
   const tok = token;

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "18b1f4a1a1fa";
+const VERSION = "73bddb934200";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -380,6 +380,27 @@ test("an envelope error object renders its message, never [object Object]", asyn
   assert.doesNotMatch(err.message, /\[object Object\]/);
 });
 
+test("an envelope error preserves its machine-readable outcome code", async () => {
+  stubFetchResponse({
+    ok: false,
+    status: 500,
+    statusText: "Internal Server Error",
+    json: async () => ({
+      data: null,
+      error: {
+        message: "task update committed, but schedule refresh failed",
+        code: "mutation_committed",
+      },
+    }),
+  });
+  const err = await updateTask("t-committed", { enabled: false }, "tok").then(
+    () => null,
+    (e: unknown) => e,
+  );
+  assert.ok(err instanceof ApiError);
+  assert.equal((err as ApiError & { code?: string }).code, "mutation_committed");
+});
+
 test("a 200 carrying an envelope error still surfaces the real message", async () => {
   stubFetchResponse({
     ok: true,

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -15,6 +15,7 @@ import {
   type CreateSessionInput,
   createTab,
   errorText,
+  isMutationCommittedError,
   killSession,
   listBackends,
   listPrograms,
@@ -398,7 +399,8 @@ test("an envelope error preserves its machine-readable outcome code", async () =
     (e: unknown) => e,
   );
   assert.ok(err instanceof ApiError);
-  assert.equal((err as ApiError & { code?: string }).code, "mutation_committed");
+  assert.equal(err.code, "mutation_committed");
+  assert.equal(isMutationCommittedError(err), true);
 });
 
 test("a 200 carrying an envelope error still surfaces the real message", async () => {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -100,13 +100,15 @@ export function shouldForgetToken(e: unknown): boolean {
 
 /**
  * The `error` member of the shared envelope. It is an OBJECT, not a string:
- * apiproto.Failure() marshals `EnvelopeError{Message string}`, so the wire shape
- * is `{"error":{"message":"..."}}`. Getting this wrong is what rendered
+ * apiproto.Failure() marshals `EnvelopeError{Message, Code}`, so the wire shape
+ * is `{"error":{"message":"...","code":"..."}}` when a machine-readable
+ * outcome exists. Getting this wrong is what rendered
  * "[object Object]" at every error site — a bare `${env.error}` stringifies the
  * object. Mirrors apiclient/client.go, which reads env.Error.Message.
  */
 interface EnvelopeError {
   message: string;
+  code?: string;
 }
 
 /** The shared REST envelope every /v1/ route returns (apiproto/envelope.go). */
@@ -176,17 +178,33 @@ function envelopeErrorText(err: EnvelopeError | null | undefined, statusLine: st
   return errorText(err, statusLine);
 }
 
+function envelopeErrorCode(err: unknown): string {
+  if (err === null || typeof err !== "object") {
+    return "";
+  }
+  const code = (err as { code?: unknown }).code;
+  return typeof code === "string" ? code : "";
+}
+
+export const MUTATION_COMMITTED_ERROR_CODE = "mutation_committed";
+
 /**
  * A failed API call. `status` is the HTTP status (0 for a network/transport
- * failure) so callers can distinguish 401-unauthorized from a genuine error.
+ * failure), while `code` preserves an optional machine-readable daemon outcome.
  */
 export class ApiError extends Error {
   readonly status: number;
-  constructor(status: number, message: string) {
+  readonly code: string;
+  constructor(status: number, message: string, code = "") {
     super(message);
     this.name = "ApiError";
     this.status = status;
+    this.code = code;
   }
+}
+
+export function isMutationCommittedError(e: unknown): e is ApiError {
+  return e instanceof ApiError && e.code === MUTATION_COMMITTED_ERROR_CODE;
 }
 
 /**
@@ -227,10 +245,10 @@ export async function af<T>(method: string, body: unknown, token: string): Promi
 
   const statusLine = `${resp.status} ${resp.statusText}`.trim();
   if (!resp.ok) {
-    throw new ApiError(resp.status, envelopeErrorText(env?.error, statusLine));
+    throw new ApiError(resp.status, envelopeErrorText(env?.error, statusLine), envelopeErrorCode(env?.error));
   }
   if (env && env.error != null) {
-    throw new ApiError(resp.status, envelopeErrorText(env.error, statusLine));
+    throw new ApiError(resp.status, envelopeErrorText(env.error, statusLine), envelopeErrorCode(env.error));
   }
   return env?.data as T;
 }

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -26,6 +26,7 @@ import {
   fetchSnapshot,
   killSession,
   getConfig,
+  isMutationCommittedError,
   listBackends,
   listPrograms,
   listTasks,
@@ -1193,6 +1194,12 @@ function openEditTask(task: TaskData): void {
             refreshTasks();
           })
           .catch((e) => {
+            if (isMutationCommittedError(e)) {
+              closeModal();
+              refreshTasks();
+              surfaceTabError(e);
+              return;
+            }
             m.setBusy(false);
             m.setError(describeError(e));
           });
@@ -1215,7 +1222,12 @@ function toggleTask(task: TaskData): void {
   // concurrent edit another client made to the prompt/trigger/target.
   void updateTask(task.id, { enabled: !task.enabled }, tok)
     .then(refreshTasks)
-    .catch((e) => surfaceTabError(e));
+    .catch((e) => {
+      if (isMutationCommittedError(e)) {
+        refreshTasks();
+      }
+      surfaceTabError(e);
+    });
 }
 
 /** Fires a task now (TriggerTask), then refetches to pick up the new last-run. The


### PR DESCRIPTION
Closes #2324.

## Summary

- acknowledge each successful task-update RPC immediately so its in-memory diff baseline remains correct when the final disk reload fails
- restore a consumed edit to the dirty set when its RPC fails, making it retryable if the reload also fails
- preserve the existing recovery behavior when reload succeeds: disk state replaces both panes and clears transient dirty state
- keep mixed outcomes field-safe instead of applying the generated report's blanket baseline reset, which would incorrectly treat failed writes as persisted

## Reproduction

The fail-first production-caller regressions exercise both outcomes with the final `LoadTasksForCurrentRepo` forced to fail from a non-Git directory:

1. A successful toggle from true to false was followed by a failed reload. Toggling back to true produced no second RPC because the stale original baseline still said true.
2. A failed toggle RPC followed by a failed reload cleared `IsDirty`; a second save returned nil and never retried the unpersisted patch.

Both failed on current master before the implementation. They now pass through `saveContentPaneState`, the caller that consumes and dispatches TaskPane edits.

## Validation

Exact pushed head: `e87f7efd887191eacd164bd77bed38fea3e754d8`

- `gofmt -l .` (clean)
- `golangci-lint run --timeout=3m --fast`
- `go build ./...`
- `deadcode -test ./...` (no output)
- `scripts/lint-file-length.sh`
- `go test ./app ./ui -count=1`
- `make test-container`
