### PR TITLE
fix(tasks): restart watch commands without overlap

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -714,5 +714,6 @@ func init() {
 	TasksCmd.AddCommand(tasksAddCmd)
 	TasksCmd.AddCommand(tasksUpdateCmd)
 	TasksCmd.AddCommand(tasksRemoveCmd)
+	TasksCmd.AddCommand(tasksRestartCmd)
 	TasksCmd.AddCommand(tasksRunCmd)
 }

--- a/api/scope_test.go
+++ b/api/scope_test.go
@@ -247,6 +247,18 @@ func TestTasksTrigger_RefusesOtherProjectsTask(t *testing.T) {
 	assert.Empty(t, calls.triggered, "the trigger RPC must not fire")
 }
 
+func TestTasksRestart_RefusesOtherProjectsTask(t *testing.T) {
+	useTempConfig(t)
+	resetScopeFlags(t)
+	calls := stubDaemon(t)
+	seedTasksInTwoProjects(t) // cwd = alpha
+
+	err := tasksRestartCmd.RunE(tasksRestartCmd, []string{"bbbb2222"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "belongs to project")
+	assert.Empty(t, calls.restarted, "the restart RPC must not fire")
+}
+
 // TestTasksUpdate_RefusesOtherProjectsTask
 func TestTasksUpdate_RefusesOtherProjectsTask(t *testing.T) {
 	useTempConfig(t)
@@ -690,6 +702,17 @@ func TestTasksTrigger_CarriesExpectationToDaemon(t *testing.T) {
 	alpha, _ := seedTasksInTwoProjects(t)
 
 	require.NoError(t, tasksRunCmd.RunE(tasksRunCmd, []string{"aaaa1111"}))
+	assert.True(t, calls.lastExpect.Enforce)
+	assert.Equal(t, alpha, calls.lastExpect.ProjectPath)
+}
+
+func TestTasksRestart_CarriesExpectationToDaemon(t *testing.T) {
+	useTempConfig(t)
+	resetScopeFlags(t)
+	calls := stubDaemon(t)
+	alpha, _ := seedTasksInTwoProjects(t)
+
+	require.NoError(t, tasksRestartCmd.RunE(tasksRestartCmd, []string{"aaaa1111"}))
 	assert.True(t, calls.lastExpect.Enforce)
 	assert.Equal(t, alpha, calls.lastExpect.ProjectPath)
 }

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -33,6 +33,7 @@ var (
 	daemonAddTask          = daemon.AddTask
 	daemonUpdateTask       = daemon.UpdateTask
 	daemonRemoveTask       = daemon.RemoveTask
+	daemonRestartTask      = daemon.RestartTask
 	daemonTriggerTask      = daemon.TriggerTask
 )
 
@@ -360,6 +361,34 @@ var tasksRunCmd = &cobra.Command{
 			return jsonError(fmt.Errorf("failed to trigger task: %w", err))
 		}
 
+		return jsonOut(map[string]bool{"ok": true})
+	},
+}
+
+var tasksRestartCmd = &cobra.Command{
+	Use:   "restart <id>",
+	Short: "Restart an enabled watch task without process overlap",
+	Long: "Restart an enabled watch task in the current project. The command waits " +
+		"for the old process tree to exit before starting one replacement, so an " +
+		"edited script is re-read without double-emitting events.\n\n" +
+		"The task must belong to the resolved project: --repo when given, otherwise " +
+		"the current directory's project. Outside a git repository there is no " +
+		"project context and the id resolves globally.",
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log.Initialize(false)
+		defer log.Close()
+
+		if err := task.ValidateTaskID(args[0]); err != nil {
+			return jsonError(err)
+		}
+		expect, err := enforceTaskScope(args[0])
+		if err != nil {
+			return jsonError(err)
+		}
+		if err := daemonRestartTask(args[0], expect); err != nil {
+			return jsonError(fmt.Errorf("failed to restart task: %w", err))
+		}
 		return jsonOut(map[string]bool{"ok": true})
 	},
 }

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -24,12 +24,14 @@ import (
 // scheduler/watchers in-process, so `writes` counts successful add/update/remove
 // RPC dispatches (each of which subsumes the old separate reload poke).
 type daemonCalls struct {
-	writes    int
-	addErr    error
-	updateErr error
-	removeErr error
-	triggered []string
-	runErr    error
+	writes     int
+	addErr     error
+	updateErr  error
+	removeErr  error
+	triggered  []string
+	restarted  []string
+	restartErr error
+	runErr     error
 	// lastUpdate records the field-level patch the CLI sent on the most recent
 	// UpdateTask dispatch (#1700), so tests can assert `af tasks update` ships
 	// ONLY the flags the user passed and never a full-struct copy.
@@ -56,6 +58,7 @@ func stubDaemon(t *testing.T) *daemonCalls {
 	origAdd := daemonAddTask
 	origUpdate := daemonUpdateTask
 	origRemove := daemonRemoveTask
+	origRestart := daemonRestartTask
 	origTrigger := daemonTriggerTask
 	origList := daemonListTasksNoSpawn
 
@@ -93,6 +96,11 @@ func stubDaemon(t *testing.T) *daemonCalls {
 		calls.writes++
 		return nil
 	}
+	daemonRestartTask = func(id string, expect task.ProjectExpectation) error {
+		calls.restarted = append(calls.restarted, id)
+		calls.lastExpect = expect
+		return calls.restartErr
+	}
 	daemonTriggerTask = func(id string, expect task.ProjectExpectation) error {
 		calls.triggered = append(calls.triggered, id)
 		calls.lastExpect = expect
@@ -105,6 +113,7 @@ func stubDaemon(t *testing.T) *daemonCalls {
 		daemonAddTask = origAdd
 		daemonUpdateTask = origUpdate
 		daemonRemoveTask = origRemove
+		daemonRestartTask = origRestart
 		daemonTriggerTask = origTrigger
 		daemonListTasksNoSpawn = origList
 	})
@@ -614,6 +623,25 @@ func TestTasksTrigger_RejectsInvalidTaskID(t *testing.T) {
 	err := tasksRunCmd.RunE(tasksRunCmd, []string{"../evil"})
 	require.Error(t, err)
 	assert.Empty(t, calls.triggered, "invalid IDs must be rejected before reaching the daemon")
+}
+
+func TestTasksRestart_DispatchesThroughDaemon(t *testing.T) {
+	useTempConfig(t)
+	calls := stubDaemon(t)
+	seedTask(t, task.Task{ID: "feed0001", Name: "feed", WatchCmd: "./watch.sh", Enabled: true})
+
+	err := tasksRestartCmd.RunE(tasksRestartCmd, []string{"feed0001"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"feed0001"}, calls.restarted)
+}
+
+func TestTasksRestart_RejectsInvalidTaskIDBeforeDaemon(t *testing.T) {
+	useTempConfig(t)
+	calls := stubDaemon(t)
+
+	err := tasksRestartCmd.RunE(tasksRestartCmd, []string{"../evil"})
+	require.Error(t, err)
+	assert.Empty(t, calls.restarted)
 }
 
 // TestTasksAdd_ExactlyOneTrigger pins the #782 CLI contract: --cron and

--- a/daemon/control_client.go
+++ b/daemon/control_client.go
@@ -444,6 +444,13 @@ func RemoveTask(id string, expect task.ProjectExpectation) error {
 	return callDaemon("RemoveTask", RemoveTaskRequest{ID: id, Expect: expect}, &resp)
 }
 
+// RestartTask asks the daemon to stop and replace one enabled watch command,
+// waiting until the old process tree is gone and the replacement has started.
+func RestartTask(id string, expect task.ProjectExpectation) error {
+	var resp RestartTaskResponse
+	return callDaemon("RestartTask", RestartTaskRequest{ID: id, Expect: expect}, &resp)
+}
+
 // TriggerTask asks the daemon to fire a task now through the shared RunTask
 // firing path (the same entrypoint the in-daemon scheduler uses). Replaces the
 // old in-process daemon.RunTask CLI call so CLI, TUI, and scheduler triggers all

--- a/daemon/control_server.go
+++ b/daemon/control_server.go
@@ -80,6 +80,23 @@ func (s *controlServer) ResumeStatusPoll(req ResumeStatusPollRequest, resp *Resu
 // so a change just written is picked up then. It returns nil (nothing to
 // reload) instead of erroring — the write is already durable.
 func (s *controlServer) reloadTaskSchedules() error {
+	unlock, err := s.lockTaskControl()
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	return s.reloadTaskSchedulesLocked()
+}
+
+func (s *controlServer) lockTaskControl() (func(), error) {
+	if s.scheduler == nil {
+		return nil, fmt.Errorf("this daemon does not host a task scheduler")
+	}
+	s.scheduler.controlMu.Lock()
+	return s.scheduler.controlMu.Unlock, nil
+}
+
+func (s *controlServer) reloadTaskSchedulesLocked() error {
 	if s.scheduler == nil {
 		return fmt.Errorf("this daemon does not host a task scheduler")
 	}
@@ -186,10 +203,15 @@ func (s *controlServer) AddTask(req AddTaskRequest, resp *AddTaskResponse) error
 	if err := s.requireMutationAdmission(); err != nil {
 		return err
 	}
+	unlock, err := s.lockTaskControl()
+	if err != nil {
+		return err
+	}
+	defer unlock()
 	if err := task.AddTask(req.Task); err != nil {
 		return err
 	}
-	if err := s.reloadTaskSchedules(); err != nil {
+	if err := s.reloadTaskSchedulesLocked(); err != nil {
 		return err
 	}
 	resp.OK = true
@@ -201,11 +223,16 @@ func (s *controlServer) UpdateTask(req UpdateTaskRequest, resp *UpdateTaskRespon
 	if err := s.requireMutationAdmission(); err != nil {
 		return err
 	}
+	unlock, err := s.lockTaskControl()
+	if err != nil {
+		return err
+	}
+	defer unlock()
 	merged, err := task.UpdateTask(req.ID, req.Update, req.Expect)
 	if err != nil {
 		return err
 	}
-	if err := s.reloadTaskSchedules(); err != nil {
+	if err := s.reloadTaskSchedulesLocked(); err != nil {
 		return err
 	}
 	resp.OK = true
@@ -220,14 +247,50 @@ func (s *controlServer) RemoveTask(req RemoveTaskRequest, resp *RemoveTaskRespon
 	if err := s.requireMutationAdmission(); err != nil {
 		return err
 	}
+	unlock, err := s.lockTaskControl()
+	if err != nil {
+		return err
+	}
+	defer unlock()
 	if err := task.RemoveTask(req.ID, req.Expect); err != nil {
 		return err
 	}
-	if err := s.reloadTaskSchedules(); err != nil {
+	if err := s.reloadTaskSchedulesLocked(); err != nil {
 		return err
 	}
 	resp.OK = true
 	s.manager.publishEvent(agentproto.EventTaskRemoved, task.Task{ID: req.ID})
+	return nil
+}
+
+// RestartTask synchronously replaces one enabled watch command. The task-control
+// lock makes the scope re-check, stop/join, and replacement one operation with
+// respect to Add/Update/Remove/ReloadTasks, so a concurrent rebind cannot turn a
+// project-scoped restart into a different project's process.
+func (s *controlServer) RestartTask(req RestartTaskRequest, resp *RestartTaskResponse) error {
+	if err := s.requireStateMutationAdmission(); err != nil {
+		return err
+	}
+	if s.watchers == nil {
+		return fmt.Errorf("this daemon does not host a watch task supervisor")
+	}
+	unlock, err := s.lockTaskControl()
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	tsk, err := task.GetTask(req.ID)
+	if err != nil {
+		return err
+	}
+	if err := req.Expect.Verify(*tsk); err != nil {
+		return err
+	}
+	if err := s.watchers.restart(*tsk); err != nil {
+		return err
+	}
+	resp.OK = true
 	return nil
 }
 

--- a/daemon/control_types.go
+++ b/daemon/control_types.go
@@ -544,6 +544,17 @@ type RemoveTaskResponse struct {
 	OK bool `json:"ok"`
 }
 
+// RestartTaskRequest asks the daemon to stop and replace one enabled watch
+// task from its current on-disk definition. Expect carries the same project
+// compare-and-swap as the other id-addressed task mutations.
+type RestartTaskRequest struct {
+	ID     string                  `json:"id"`
+	Expect task.ProjectExpectation `json:"expect,omitempty"`
+}
+type RestartTaskResponse struct {
+	OK bool `json:"ok"`
+}
+
 // TriggerTaskRequest asks the daemon to fire a task NOW through the same
 // RunTask firing path the in-daemon scheduler uses (#1029 PR 3 / #1169-class
 // fix). The handler preserves RunTask's guards: watch tasks and disabled tasks

--- a/daemon/httproutes.go
+++ b/daemon/httproutes.go
@@ -233,6 +233,13 @@ var httpRoutes = []HTTPRoute{
 	},
 	{
 		Method:        http.MethodPost,
+		Path:          "/v1/RestartTask",
+		Description:   "Stop and replace one enabled watch task without overlapping its process tree.",
+		RequestFields: jsonFields(reflect.TypeOf(RestartTaskRequest{})),
+		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.RestartTask) },
+	},
+	{
+		Method:        http.MethodPost,
 		Path:          "/v1/TriggerTask",
 		Description:   "Fire a cron task now through the daemon's scheduler path (refuses disabled and watch tasks).",
 		RequestFields: jsonFields(reflect.TypeOf(TriggerTaskRequest{})),

--- a/daemon/lifecycle_test.go
+++ b/daemon/lifecycle_test.go
@@ -237,6 +237,7 @@ var controlMethodPolicies = map[string]probationPolicy{
 	"ReapConfigAgent":  blockedDuringProbation,
 	"ReloadTasks":      blockedDuringProbation,
 	"RemoveTask":       blockedDuringProbation,
+	"RestartTask":      blockedDuringProbation,
 	"RenameTab":        blockedDuringProbation,
 	"ReorderTab":       blockedDuringProbation,
 	"RestoreArchived":  blockedDuringProbation,

--- a/daemon/scheduler.go
+++ b/daemon/scheduler.go
@@ -16,9 +16,14 @@ import (
 // schedules atomically; TUI CRUD still writes tasks.json directly and pokes
 // ReloadTasks (tracked follow-up).
 type taskScheduler struct {
-	mu      sync.Mutex
-	cron    *cron.Cron
-	entries map[string]cron.EntryID // task ID → scheduled entry
+	// controlMu serializes task-file mutations and cron/watcher reconciliation
+	// across every daemon transport. The gob and HTTP control servers are
+	// distinct objects but share this scheduler, so the lock must live here
+	// rather than on either transport wrapper.
+	controlMu sync.Mutex
+	mu        sync.Mutex
+	cron      *cron.Cron
+	entries   map[string]cron.EntryID // task ID → scheduled entry
 
 	// Injection points for tests: loadTasks substitutes fixture task lists,
 	// parse allows a seconds-granularity parser so firing tests don't wait a

--- a/daemon/task_restart_rpc_test.go
+++ b/daemon/task_restart_rpc_test.go
@@ -1,0 +1,63 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+	"github.com/sachiniyer/agent-factory/task"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestControlRestartTaskStartsEnabledWatchTask(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	tsk := watchTask("feed0002", "sleep 60", t.TempDir())
+	require.NoError(t, task.AddTask(tsk))
+
+	watchers, _ := newTestSupervisor(t, task.LoadTasks)
+	server := &controlServer{scheduler: newTaskScheduler(), watchers: watchers}
+	var resp RestartTaskResponse
+	require.NoError(t, server.RestartTask(RestartTaskRequest{ID: tsk.ID}, &resp))
+	require.True(t, resp.OK)
+	require.Equal(t, []string{tsk.ID}, watchers.watchingTaskIDs())
+}
+
+func TestControlRestartTaskRefusesWrongScopeDisabledAndCronTasks(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", testguard.SocketTempDir(t))
+	disabled := watchTask("feed0003", "sleep 60", "/repos/alpha")
+	disabled.Enabled = false
+	cron := task.Task{
+		ID: "feed0004", Name: "cron", Prompt: "run", CronExpr: "0 3 * * *",
+		ProjectPath: "/repos/alpha", Enabled: true, CreatedAt: time.Now(),
+	}
+	enabledWatch := watchTask("feed0005", "sleep 60", "/repos/beta")
+	for _, tsk := range []task.Task{disabled, cron, enabledWatch} {
+		require.NoError(t, task.AddTask(tsk))
+	}
+
+	watchers, _ := newTestSupervisor(t, task.LoadTasks)
+	server := &controlServer{scheduler: newTaskScheduler(), watchers: watchers}
+	for _, tc := range []struct {
+		name   string
+		req    RestartTaskRequest
+		needle string
+	}{
+		{name: "disabled", req: RestartTaskRequest{ID: disabled.ID}, needle: "disabled"},
+		{name: "cron", req: RestartTaskRequest{ID: cron.ID}, needle: "not a watch task"},
+		{
+			name: "rebound",
+			req: RestartTaskRequest{
+				ID:     enabledWatch.ID,
+				Expect: task.ProjectExpectation{Enforce: true, ProjectPath: "/repos/alpha"},
+			},
+			needle: "re-bound",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := server.RestartTask(tc.req, &RestartTaskResponse{})
+			require.ErrorContains(t, err, tc.needle)
+			require.Empty(t, watchers.watchingTaskIDs())
+		})
+	}
+}

--- a/daemon/task_rpc_test.go
+++ b/daemon/task_rpc_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -126,6 +127,51 @@ func TestControlAddTask_WarmupSkipsReload(t *testing.T) {
 	require.Len(t, tasks, 1, "the write must land even during warm-up")
 	assert.Empty(t, srv.scheduler.scheduledTaskIDs(),
 		"warm-up must skip the reload; RunDaemon arms the scheduler after the restore")
+}
+
+func TestTaskControlLockIsSharedAcrossTransportServers(t *testing.T) {
+	scheduler := newTaskScheduler()
+	enteredLoad := make(chan int32, 2)
+	releaseFirst := make(chan struct{})
+	var calls atomic.Int32
+	scheduler.loadTasks = func() ([]task.Task, error) {
+		call := calls.Add(1)
+		enteredLoad <- call
+		if call == 1 {
+			<-releaseFirst
+		}
+		return nil, nil
+	}
+
+	// Production registers distinct controlServer values for gob and HTTP, but
+	// both carry this same scheduler pointer. The first transport is held inside
+	// task reconciliation; the second must not enter even the load phase.
+	rpcServer := &controlServer{scheduler: scheduler}
+	httpServer := &controlServer{scheduler: scheduler}
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- rpcServer.ReloadTasks(ReloadTasksRequest{}, &ReloadTasksResponse{})
+	}()
+	if call := <-enteredLoad; call != 1 {
+		t.Fatalf("first load call = %d, want 1", call)
+	}
+
+	secondDone := make(chan error, 1)
+	go func() {
+		secondDone <- httpServer.ReloadTasks(ReloadTasksRequest{}, &ReloadTasksResponse{})
+	}()
+	select {
+	case call := <-enteredLoad:
+		close(releaseFirst)
+		t.Fatalf("second transport entered task reconciliation as load call %d before the first released it", call)
+	case <-time.After(time.Second):
+		// Still blocked on the shared transport-independent control lock.
+	}
+
+	close(releaseFirst)
+	require.NoError(t, <-firstDone)
+	require.NoError(t, <-secondDone)
+	require.EqualValues(t, 2, calls.Load())
 }
 
 // TestControlTriggerTask_UsesSharedFiringPath pins the core #1169-class fix:

--- a/daemon/watcher.go
+++ b/daemon/watcher.go
@@ -304,6 +304,7 @@ func (s *watcherSupervisor) newTaskWatcher(t task.Task) *taskWatcher {
 		sup:           s,
 		stopCh:        make(chan struct{}),
 		doneCh:        make(chan struct{}),
+		startedCh:     make(chan struct{}),
 	}
 	// Resolve the repo the task belongs to so a delivery alarm can be scoped to
 	// the right repo's snapshot (#1238). A resolution failure only costs the
@@ -327,22 +328,6 @@ func (s *watcherSupervisor) newTaskWatcher(t task.Task) *taskWatcher {
 
 // watcherSignature captures the fields that define the watch process itself;
 // a change to any of them restarts the script on reload.
-func watcherSignature(t task.Task) string {
-	return t.WatchCmd + "\x00" + t.ProjectPath + "\x00" + t.Name
-}
-
-func stopWatchers(ws []*taskWatcher) {
-	var wg sync.WaitGroup
-	for _, w := range ws {
-		wg.Add(1)
-		go func(w *taskWatcher) {
-			defer wg.Done()
-			w.stop()
-		}(w)
-	}
-	wg.Wait()
-}
-
 // tailBuffer and its failure-summary helpers live in tailbuffer.go (extracted
 // to keep watcher.go under its file-length ceiling, #1145).
 
@@ -374,9 +359,11 @@ type taskWatcher struct {
 	// the pre-queue drop-with-log behavior.
 	queue *eventQueue
 
-	stopCh   chan struct{}
-	stopOnce sync.Once
-	doneCh   chan struct{}
+	stopCh      chan struct{}
+	stopOnce    sync.Once
+	doneCh      chan struct{}
+	startedCh   chan struct{}
+	startedOnce sync.Once
 	// wg counts the drainer goroutine so stop() can join it; drainers spawn
 	// lazily via ensureDrainer.
 	wg sync.WaitGroup
@@ -621,6 +608,9 @@ func (w *taskWatcher) runOnce() (*tailBuffer, error) {
 			_ = stderrW.Close()
 		}
 		return tail, err
+	}
+	if w.startedCh != nil {
+		w.startedOnce.Do(func() { close(w.startedCh) })
 	}
 	_ = pw.Close() // the child holds its own dup
 	if stderrW != nil {

--- a/daemon/watcher_restart.go
+++ b/daemon/watcher_restart.go
@@ -1,0 +1,66 @@
+package daemon
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/sachiniyer/agent-factory/task"
+)
+
+// restart replaces one enabled watch task even when its process-defining
+// configuration is unchanged. It is the explicit path for re-reading an edited
+// script at the same watch_cmd path. The old watcher is fully joined before the
+// replacement can start, so their process trees and queue drainers never
+// overlap.
+func (s *watcherSupervisor) restart(t task.Task) error {
+	if err := task.ValidateTaskID(t.ID); err != nil {
+		return err
+	}
+	if !t.Enabled {
+		return fmt.Errorf("task %q is disabled; enable it before restarting its watch command", t.ID)
+	}
+	if !t.IsWatch() {
+		return fmt.Errorf("task %q is not a watch task", t.ID)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.stopped {
+		return fmt.Errorf("watch task supervisor is shutting down")
+	}
+	if current := s.watchers[t.ID]; current != nil {
+		delete(s.watchers, t.ID)
+		current.stop()
+	}
+
+	replacement := s.newTaskWatcher(t)
+	s.watchers[t.ID] = replacement
+	go replacement.run()
+	select {
+	case <-replacement.startedCh:
+		return nil
+	case <-replacement.doneCh:
+		select {
+		case <-replacement.startedCh:
+			return nil
+		default:
+			return fmt.Errorf("watch task %q stopped before its replacement process could start; inspect the task log for the command error", t.ID)
+		}
+	}
+}
+
+func watcherSignature(t task.Task) string {
+	return t.WatchCmd + "\x00" + t.ProjectPath + "\x00" + t.Name
+}
+
+func stopWatchers(ws []*taskWatcher) {
+	var wg sync.WaitGroup
+	for _, w := range ws {
+		wg.Add(1)
+		go func(w *taskWatcher) {
+			defer wg.Done()
+			w.stop()
+		}(w)
+	}
+	wg.Wait()
+}

--- a/daemon/watcher_restart_test.go
+++ b/daemon/watcher_restart_test.go
@@ -1,0 +1,139 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/task"
+)
+
+func TestWatcherRestartLoadsEditedScriptWithoutProcessOverlap(t *testing.T) {
+	dir, versionPath, startsPath, overlapPath := newVersionedWatchScript(t)
+
+	tsk := watchTask("feed0001", "./watch.sh", dir)
+	s, _ := newTestSupervisor(t, staticTasks(tsk))
+	s.stopGrace = 2 * time.Second
+	if err := s.Reload(); err != nil {
+		t.Fatal(err)
+	}
+	waitUntil(t, 5*time.Second, "first script version to start", func() bool {
+		data, err := os.ReadFile(startsPath)
+		fields := strings.Fields(string(data))
+		return err == nil && len(fields) > 0 && fields[0] == "v1"
+	})
+
+	if err := os.WriteFile(versionPath, []byte("v2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.restart(tsk); err != nil {
+		t.Fatalf("restart edited watch script: %v", err)
+	}
+	waitUntil(t, 5*time.Second, "edited script version to start", func() bool {
+		data, err := os.ReadFile(startsPath)
+		fields := strings.Fields(string(data))
+		return err == nil && len(fields) > 0 && fields[len(fields)-1] == "v2"
+	})
+
+	data, err := os.ReadFile(startsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Fields(string(data)); len(got) != 2 || got[0] != "v1" || got[1] != "v2" {
+		t.Fatalf("script starts = %v, want exactly [v1 v2]", got)
+	}
+	if _, err := os.Stat(overlapPath); !os.IsNotExist(err) {
+		t.Fatalf("replacement overlapped the old process; overlap marker stat error = %v", err)
+	}
+	if ids := s.watchingTaskIDs(); len(ids) != 1 || ids[0] != tsk.ID {
+		t.Fatalf("watching IDs after restart = %v, want only %s", ids, tsk.ID)
+	}
+}
+
+func TestWatcherDisableThenEnableCannotOverlapOldProcess(t *testing.T) {
+	dir, versionPath, startsPath, overlapPath := newVersionedWatchScript(t)
+	tsk := watchTask("feed0006", "./watch.sh", dir)
+	current := struct {
+		sync.Mutex
+		task task.Task
+	}{task: tsk}
+	s, _ := newTestSupervisor(t, func() ([]task.Task, error) {
+		current.Lock()
+		defer current.Unlock()
+		return []task.Task{current.task}, nil
+	})
+	s.stopGrace = 2 * time.Second
+	if err := s.Reload(); err != nil {
+		t.Fatal(err)
+	}
+	waitForWatchVersion(t, startsPath, "v1")
+
+	current.Lock()
+	current.task.Enabled = false
+	current.Unlock()
+	if err := s.Reload(); err != nil {
+		t.Fatal(err)
+	}
+	if ids := s.watchingTaskIDs(); len(ids) != 0 {
+		t.Fatalf("disabled watcher still live after Reload returned: %v", ids)
+	}
+
+	if err := os.WriteFile(versionPath, []byte("v2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	current.Lock()
+	current.task.Enabled = true
+	current.Unlock()
+	if err := s.Reload(); err != nil {
+		t.Fatal(err)
+	}
+	waitForWatchVersion(t, startsPath, "v2")
+	if _, err := os.Stat(overlapPath); !os.IsNotExist(err) {
+		t.Fatalf("re-enabled watcher overlapped the disabled process; overlap marker stat error = %v", err)
+	}
+}
+
+func newVersionedWatchScript(t *testing.T) (dir, versionPath, startsPath, overlapPath string) {
+	t.Helper()
+	dir = t.TempDir()
+	versionPath = filepath.Join(dir, "version")
+	startsPath = filepath.Join(dir, "starts")
+	overlapPath = filepath.Join(dir, "overlap")
+	script := `#!/bin/sh
+version=$(cat version)
+if [ "$version" = v2 ] && [ -f pid-v1 ]; then
+  old_pid=$(cat pid-v1)
+  if old_state=$(ps -o state= -p "$old_pid" 2>/dev/null); then
+    case "$old_state" in
+      *Z*) ;;
+      *) : > overlap ;;
+    esac
+  elif kill -0 "$old_pid" 2>/dev/null; then
+    # Fail loud if the state oracle itself is unavailable while the PID exists.
+    : > overlap
+  fi
+fi
+echo $$ > "pid-$version"
+echo "$version" >> starts
+while :; do sleep 1; done
+`
+	if err := os.WriteFile(filepath.Join(dir, "watch.sh"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(versionPath, []byte("v1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir, versionPath, startsPath, overlapPath
+}
+
+func waitForWatchVersion(t *testing.T, startsPath, version string) {
+	t.Helper()
+	waitUntil(t, 5*time.Second, "script version "+version+" to start", func() bool {
+		data, err := os.ReadFile(startsPath)
+		fields := strings.Fields(string(data))
+		return err == nil && len(fields) > 0 && fields[len(fields)-1] == version
+	})
+}

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -37,5 +37,6 @@ Request fields are the JSON keys of each route's request body; a `—` means the
 | `POST` | `/v1/AddTask` | `task` | Append a new task and re-arm the scheduler. |
 | `POST` | `/v1/UpdateTask` | `id`, `update`, `expect` | Apply a field-level patch to a task (only the fields in `update` are changed), preserving every unspecified field and the scheduler-owned fields. |
 | `POST` | `/v1/RemoveTask` | `id`, `expect` | Remove a task by ID. |
+| `POST` | `/v1/RestartTask` | `id`, `expect` | Stop and replace one enabled watch task without overlapping its process tree. |
 | `POST` | `/v1/TriggerTask` | `id`, `expect` | Fire a cron task now through the daemon's scheduler path (refuses disabled and watch tasks). |
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -60,6 +60,7 @@ Run `af <command> --help` for the same information at the terminal. For a narrat
 - [`af tasks get`](#af-tasks-get) — Get a task in the current project by ID
 - [`af tasks list`](#af-tasks-list) — List tasks in the current project
 - [`af tasks remove`](#af-tasks-remove) — Remove a task in the current project
+- [`af tasks restart`](#af-tasks-restart) — Restart an enabled watch task without process overlap
 - [`af tasks trigger`](#af-tasks-trigger) — Trigger a task in the current project to run immediately
 - [`af tasks update`](#af-tasks-update) — Update a task in the current project
 - [`af token`](#af-token) — Manage the daemon's bearer token for the direct-TCP API
@@ -1740,6 +1741,7 @@ af tasks
 - [`af tasks get`](#af-tasks-get) — Get a task in the current project by ID
 - [`af tasks list`](#af-tasks-list) — List tasks in the current project
 - [`af tasks remove`](#af-tasks-remove) — Remove a task in the current project
+- [`af tasks restart`](#af-tasks-restart) — Restart an enabled watch task without process overlap
 - [`af tasks trigger`](#af-tasks-trigger) — Trigger a task in the current project to run immediately
 - [`af tasks update`](#af-tasks-update) — Update a task in the current project
 
@@ -1852,6 +1854,27 @@ The task must belong to the resolved project: --repo when given, otherwise the c
 
 ```
 af tasks remove <id>
+```
+
+**Global flags**
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--daemon-url` | `string` | Target a REMOTE daemon at this http:// or ws:// URL instead of the local unix socket (env: AF_DAEMON_URL). The daemon is HTTP-only; terminate TLS at your own proxy if needed. |
+| `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
+| `--repo` | `string` | Path to the project's git repository (default: the current directory's project) |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with 'af token show' on the daemon host. |
+
+## af tasks restart
+
+Restart an enabled watch task without process overlap
+
+Restart an enabled watch task in the current project. The command waits for the old process tree to exit before starting one replacement, so an edited script is re-read without double-emitting events.
+
+The task must belong to the resolved project: --repo when given, otherwise the current directory's project. Outside a git repository there is no project context and the id resolves globally.
+
+```
+af tasks restart <id>
 ```
 
 **Global flags**

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## Watch-task restart
+
+- `af tasks restart <id>` now reloads an edited watch script without manual
+  process signals. It waits for the old process group and queue drainer to exit
+  before starting one replacement, so restarts cannot double-emit events.
+- Task write/reload and restart operations are serialized in the daemon. A
+  disable returns only after its watcher is gone, and a project-scoped restart
+  cannot race a concurrent task rebind.
+
 ## Breaking: `auto_yes` removed
 
 The `auto_yes` config key, `af --autoyes` / `-y`, and

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -64,7 +64,7 @@ af tasks add --name "gh-issues" --watch-cmd "./watch-issues.sh" \
 - **Each newline-terminated stdout line is one event.** Lines over 64KB are truncated to the cap (the remainder is discarded with a logged note). Unterminated trailing output at exit is not an event. Silence is fine — a quiet watcher is healthy; there is no output timeout.
 - **stderr** appends to `~/.agent-factory/logs/task-<id>.log`, size-capped by the same `log_max_size_mb`/`log_max_backups` rotation as the main log. Use it for all logging — anything on stdout becomes an event.
 - **Environment**: the script receives `AF_TASK_ID`, `AF_TASK_NAME`, and `AF_PROJECT_PATH` on top of the daemon's environment.
-- **Exit 0 = intentional stop.** The task's status becomes `stopped` and the script is not restarted until the next daemon start, task edit, or re-enable.
+- **Exit 0 = intentional stop.** The task's status becomes `stopped` and the script is not restarted until the next daemon start, task edit, re-enable, or explicit `af tasks restart <id>`.
 - **Non-zero exit = failure.** The script is restarted with exponential backoff, 1s doubling to a 5-minute cap. A run that stays healthy for 10 minutes resets the backoff.
 - **Crash-loop breaker**: 5 or more non-zero exits within 10 minutes set the status to `errored` and stop restarts. Re-arm by editing the task, toggling it, or restarting the daemon.
 - **Rate limit**: at most 10 events per minute per task. Excess events are dropped — never silently: a warning is logged with a running drop counter. Rate-dropped events are not queued for replay (the limit is protective policy against a chatty script, not an outage signal). This is a limit on the event *rate*, and is independent of `max_concurrent_runs`, which bounds in-flight *sessions* and queues rather than drops — the two are never the binding constraint at the same time (see [Limiting concurrent sessions](#limiting-concurrent-sessions)).
@@ -76,7 +76,7 @@ af tasks add --name "gh-issues" --watch-cmd "./watch-issues.sh" \
   - **Bounds**: at most 500 events / 256KB queued per task — overflow drops the *oldest* with a logged count; events older than **72h** are expired at replay time, also logged. Sources worth watching re-emit on their next poll, so scripts that poll should still track their own cursor (see `examples/tasks/gh-issue-poll.sh`).
   - **Disabled vs deleted**: a disabled task keeps its backlog and replays it on re-enable; a deleted task's queue is removed.
 
-Edits to delivery fields (`prompt`, `target_session`, `program`) apply from the next event without restarting the script; edits to `watch_cmd`, `project_path`, or `name` restart it.
+Edits to delivery fields (`prompt`, `target_session`, `program`) apply from the next event without restarting the script; edits to `watch_cmd`, `project_path`, or `name` restart it. Editing the contents of a script at the same `watch_cmd` path is intentionally not polled. Run `af tasks restart <id>` after that edit: the command synchronously stops and joins the old process group, then starts exactly one replacement from the current script. A disable update uses the same stop-and-join path, so a subsequent enable cannot overlap the old watcher.
 
 ### Limiting concurrent sessions
 
@@ -142,6 +142,7 @@ af tasks add --name <n> --prompt <p> --cron "0 9 * * *" [--target-session <title
 af tasks add --name <n> --watch-cmd <cmd> [--prompt "… {{line}} …"] [--target-session <title>] [--max-concurrent-runs <n>]
 af tasks get <id>
 af tasks update <id> [--cron …|--watch-cmd …] [--prompt …] [--target-session …] [--max-concurrent-runs <n>] [--program <agent>] [--enabled true|false]
+af tasks restart <id>          # enabled watch tasks only; reloads an edited script
 af tasks trigger <id>          # cron tasks only
 af tasks remove <id>
 ```

--- a/parity/derive_go_test.go
+++ b/parity/derive_go_test.go
@@ -70,6 +70,7 @@ var auditedRequests = map[string]reflect.Type{
 	"RenameTabRequest":        reflect.TypeOf(daemon.RenameTabRequest{}),
 	"ReorderTabRequest":       reflect.TypeOf(daemon.ReorderTabRequest{}),
 	"RestoreSessionRequest":   reflect.TypeOf(daemon.RestoreSessionRequest{}),
+	"RestartTaskRequest":      reflect.TypeOf(daemon.RestartTaskRequest{}),
 	"ResumeFromLimitRequest":  reflect.TypeOf(daemon.ResumeFromLimitRequest{}),
 	"ResumeStatusPollRequest": reflect.TypeOf(daemon.ResumeStatusPollRequest{}),
 	"SendPromptRequest":       reflect.TypeOf(daemon.SendPromptRequest{}),

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -743,6 +743,24 @@
       "notes": ""
     },
     {
+      "id": "task.restart",
+      "title": "Restart an enabled watch task after editing its script",
+      "tui": {
+        "status": "no",
+        "pointer": ""
+      },
+      "web": {
+        "status": "no",
+        "pointer": ""
+      },
+      "cli": {
+        "status": "yes",
+        "pointer": "api/tasks.go:368 tasksRestartCmd"
+      },
+      "verdict": "deliberate",
+      "notes": "This is an operator workflow after editing an external script file, which neither UI owns. Both task UIs already expose the enabled toggle; its daemon update is synchronous and therefore remains a safe manual cycle. The dedicated one-command restart belongs in the scripting CLI."
+    },
+    {
       "id": "task.trigger",
       "title": "Trigger a task now",
       "tui": {
@@ -1324,6 +1342,7 @@
       "af tasks get": "task.get",
       "af tasks list": "task.list",
       "af tasks remove": "task.remove",
+      "af tasks restart": "task.restart",
       "af tasks trigger": "task.trigger",
       "af tasks update": "task.edit",
       "af token rotate": "daemon.token",
@@ -1347,6 +1366,7 @@
       "POST /v1/ListPrograms": "enum.agent-programs",
       "POST /v1/ListTasks": "task.list",
       "POST /v1/RemoveTask": "task.remove",
+      "POST /v1/RestartTask": "task.restart",
       "POST /v1/RenameTab": "session.tab.rename",
       "POST /v1/ReorderTab": "session.tab.reorder",
       "POST /v1/RestoreArchived": "session.restore",
@@ -1575,6 +1595,7 @@
       "af tasks list --all": "task.list",
       "af tasks list --help": "meta.discovery",
       "af tasks remove --help": "meta.discovery",
+      "af tasks restart --help": "meta.discovery",
       "af tasks trigger --help": "meta.discovery",
       "af tasks update --cron": "task.edit",
       "af tasks update --enabled": "task.toggle",


### PR DESCRIPTION
## Summary

- add `af tasks restart <id>` plus the matching daemon RPC and HTTP route
- stop and fully join the existing watcher process tree and queue drainer before starting one replacement
- serialize task CRUD, reload, and restart through shared daemon state across gob and HTTP transports
- register the new capability in the cross-surface parity audit and document the operator workflow

## Root cause

The watcher signature includes the command path but not the contents of the script at that path. Editing a long-running script therefore leaves the already-started process untouched, and there was no supported forced-restart operation.

Current master already performs a synchronous stop/join when a disabled task is reconciled; the new regression test pins that invariant. This change fills the remaining one-command restart gap by reusing the same supervisor transition instead of introducing a second process lifecycle.

## Regression coverage

- the fail-first restart test initially failed because the supervisor had no restart operation
- a versioned script proves version 1 stops executing before version 2 starts and that exactly two starts occur
- disable/re-enable is separately pinned to the same no-overlap invariant
- two distinct transport server objects sharing the production scheduler cannot enter task reconciliation concurrently
- RPC tests cover disabled tasks, cron tasks, wrong-project expectations, and success
- CLI tests cover daemon dispatch, invalid IDs, and project-scope compare-and-swap

## Codex review follow-up

- moved task-control serialization from the per-transport wrapper to the scheduler shared by both production listeners; scheduler-less task mutation now fails closed
- replaced the `kill -0` overlap oracle with process-state classification, so a reaped or zombie old shell is not mistaken for concurrent execution while an unclassifiable existing PID fails loud

## Gates

Exact pushed head: `a51a29ec773f43f7be5598cd037ef3282c721f92`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- generated docs clean after `make docs`

Closes #2353

— Captain Claude