### PR TITLE
fix(tui): bind handoff picker to session identity

### DIFF
--- a/app/handle_handoff.go
+++ b/app/handle_handoff.go
@@ -129,9 +129,15 @@ func (m *home) handleStateSelectHandoffAgent(msg tea.KeyMsg) (tea.Model, tea.Cmd
 		"Same worktree and branch — nothing is discarded."
 
 	return m, m.confirmActionWithDetail(message, detail, func() tea.Msg {
+		// Confirmation is a second retained-intent boundary after the picker.
+		// Re-resolve the captured identity so an id-less legacy row replaced while
+		// the dialog was open cannot hand its title to the new session.
+		if m.resolveHandoffPickerTarget(pickerTarget) == nil {
+			return nil
+		}
 		return startHandoffMsg{request: daemon.HandoffSessionRequest{
 			ID: pickerTarget.id, Title: title, RepoID: pickerTarget.repoID, To: target,
-		}}
+		}, target: pickerTarget}
 	})
 }
 
@@ -167,6 +173,7 @@ func (m *home) resolveHandoffPickerTarget(target handoffPickerTarget) *session.I
 // another).
 type startHandoffMsg struct {
 	request daemon.HandoffSessionRequest
+	target  handoffPickerTarget
 }
 
 type handoffDoneMsg struct {

--- a/app/handle_handoff.go
+++ b/app/handle_handoff.go
@@ -5,12 +5,19 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 	"github.com/sachiniyer/agent-factory/ui"
 	"github.com/sachiniyer/agent-factory/ui/overlay"
 )
+
+type handoffPickerTarget struct {
+	id     string
+	title  string
+	repoID string
+}
 
 // handoffAgentChoices returns the agents the selected session may be handed to:
 // every supported agent except the one already running.
@@ -73,6 +80,7 @@ func (m *home) handleHandoff() (tea.Model, tea.Cmd) {
 	}
 
 	m.handoffChoices = choices
+	m.handoffTarget = handoffPickerTarget{id: selected.ID, title: selected.Title, repoID: m.repoID}
 	m.selectionOverlay = overlay.NewSelectionOverlay("Hand off to", choices)
 	m.state = stateSelectHandoffAgent
 	return m, nil
@@ -92,9 +100,11 @@ func (m *home) handleStateSelectHandoffAgent(msg tea.KeyMsg) (tea.Model, tea.Cmd
 	submitted := m.selectionOverlay.IsSubmitted()
 	idx := m.selectionOverlay.GetSelectedIndex()
 	choices := m.handoffChoices
+	pickerTarget := m.handoffTarget
 
 	m.selectionOverlay = nil
 	m.handoffChoices = nil
+	m.handoffTarget = handoffPickerTarget{}
 	m.state = stateDefault
 	m.menu.SetState(ui.StateDefault)
 
@@ -103,7 +113,7 @@ func (m *home) handleStateSelectHandoffAgent(msg tea.KeyMsg) (tea.Model, tea.Cmd
 	}
 	target := choices[idx]
 
-	selected := m.sidebar.GetSelectedInstance()
+	selected := m.resolveHandoffPickerTarget(pickerTarget)
 	if selected == nil {
 		return m, nil
 	}
@@ -115,8 +125,28 @@ func (m *home) handleStateSelectHandoffAgent(msg tea.KeyMsg) (tea.Model, tea.Cmd
 		"Same worktree and branch — nothing is discarded."
 
 	return m, m.confirmActionWithDetail(message, detail, func() tea.Msg {
-		return startHandoffMsg{title: title, target: target}
+		return startHandoffMsg{request: daemon.HandoffSessionRequest{
+			ID: pickerTarget.id, Title: title, RepoID: pickerTarget.repoID, To: target,
+		}}
 	})
+}
+
+func (m *home) resolveHandoffPickerTarget(target handoffPickerTarget) *session.Instance {
+	if target.repoID == "" || target.repoID != m.repoID {
+		return nil
+	}
+	if target.id == "" {
+		// Compatibility for records written before stable session IDs existed.
+		// Current sessions take the ID arm below, which is what prevents a killed
+		// and recreated same-title row from inheriting the pending action.
+		return m.store.GetInstanceByTitle(target.title)
+	}
+	for _, inst := range m.store.GetInstances() {
+		if inst.ID == target.id {
+			return inst
+		}
+	}
+	return nil
 }
 
 // startHandoffMsg is emitted by the confirmation action and turned into the
@@ -124,8 +154,7 @@ func (m *home) handleStateSelectHandoffAgent(msg tea.KeyMsg) (tea.Model, tea.Cmd
 // event loop never blocks on the swap (which stops a process and starts
 // another).
 type startHandoffMsg struct {
-	title  string
-	target string
+	request daemon.HandoffSessionRequest
 }
 
 type handoffDoneMsg struct {
@@ -136,15 +165,14 @@ type handoffDoneMsg struct {
 }
 
 // handoffCmd runs the daemon handoff off the event loop.
-func (m *home) handoffCmd(title, target string) tea.Cmd {
-	repoID := m.repoID
+func (m *home) handoffCmd(request daemon.HandoffSessionRequest) tea.Cmd {
 	handoff := handoffSessionThroughDaemon
 	return func() tea.Msg {
-		from, err := handoff(title, repoID, target)
+		from, err := handoff(request)
 		if err != nil {
-			log.ErrorLog.Printf("could not hand session %q off to %s: %v", title, target, err)
+			log.ErrorLog.Printf("could not hand session %q off to %s: %v", request.Title, request.To, err)
 		}
-		return handoffDoneMsg{title: title, from: from, target: target, err: err}
+		return handoffDoneMsg{title: request.Title, from: from, target: request.To, err: err}
 	}
 }
 

--- a/app/handle_handoff.go
+++ b/app/handle_handoff.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -14,9 +15,10 @@ import (
 )
 
 type handoffPickerTarget struct {
-	id     string
-	title  string
-	repoID string
+	id        string
+	title     string
+	repoID    string
+	createdAt time.Time
 }
 
 // handoffAgentChoices returns the agents the selected session may be handed to:
@@ -80,7 +82,9 @@ func (m *home) handleHandoff() (tea.Model, tea.Cmd) {
 	}
 
 	m.handoffChoices = choices
-	m.handoffTarget = handoffPickerTarget{id: selected.ID, title: selected.Title, repoID: m.repoID}
+	m.handoffTarget = handoffPickerTarget{
+		id: selected.ID, title: selected.Title, repoID: m.repoID, createdAt: selected.CreatedAt,
+	}
 	m.selectionOverlay = overlay.NewSelectionOverlay("Hand off to", choices)
 	m.state = stateSelectHandoffAgent
 	return m, nil
@@ -137,9 +141,17 @@ func (m *home) resolveHandoffPickerTarget(target handoffPickerTarget) *session.I
 	}
 	if target.id == "" {
 		// Compatibility for records written before stable session IDs existed.
-		// Current sessions take the ID arm below, which is what prevents a killed
-		// and recreated same-title row from inheriting the pending action.
-		return m.store.GetInstanceByTitle(target.title)
+		// CreatedAt is the same legacy discriminator snapshot reconciliation uses;
+		// a zero timestamp proves no identity, so fail closed instead of letting
+		// title reuse inherit a retained destructive action (#2322/#2358).
+		if target.createdAt.IsZero() {
+			return nil
+		}
+		inst := m.store.GetInstanceByTitle(target.title)
+		if inst != nil && inst.CreatedAt.Equal(target.createdAt) {
+			return inst
+		}
+		return nil
 	}
 	for _, inst := range m.store.GetInstances() {
 		if inst.ID == target.id {

--- a/app/handle_handoff.go
+++ b/app/handle_handoff.go
@@ -21,6 +21,12 @@ type handoffPickerTarget struct {
 	createdAt time.Time
 }
 
+func (target handoffPickerTarget) request(to string) daemon.HandoffSessionRequest {
+	return daemon.HandoffSessionRequest{
+		ID: target.id, Title: target.title, RepoID: target.repoID, To: to,
+	}
+}
+
 // handoffAgentChoices returns the agents the selected session may be handed to:
 // every supported agent except the one already running.
 //
@@ -135,9 +141,7 @@ func (m *home) handleStateSelectHandoffAgent(msg tea.KeyMsg) (tea.Model, tea.Cmd
 		if m.resolveHandoffPickerTarget(pickerTarget) == nil {
 			return nil
 		}
-		return startHandoffMsg{request: daemon.HandoffSessionRequest{
-			ID: pickerTarget.id, Title: title, RepoID: pickerTarget.repoID, To: target,
-		}, target: pickerTarget}
+		return startHandoffMsg{request: pickerTarget.request(target), target: pickerTarget}
 	})
 }
 

--- a/app/handoff_action_test.go
+++ b/app/handoff_action_test.go
@@ -7,6 +7,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
@@ -43,7 +44,7 @@ func TestHandleHandoff_OpensPickerWithoutDispatching(t *testing.T) {
 	h.sidebar.SetSelectedInstance(0)
 
 	called := false
-	restore := SetHandoffRunnerForTest(func(string, string, string) (string, error) {
+	restore := SetHandoffRunnerForTest(func(daemon.HandoffSessionRequest) (string, error) {
 		called = true
 		return "", nil
 	})
@@ -76,12 +77,13 @@ func TestHandleHandoff_RefusesArchivedSessionBeforePicker(t *testing.T) {
 // hand off to the wrong agent — silently, and to a plausible-looking one.
 func TestHandleStateSelectHandoffAgent_ConfirmsThenSwapsTheChosenAgent(t *testing.T) {
 	h := newTestHome(t)
-	h.store.AddInstance(handoffActionInstance(t, "worker", tmux.ProgramClaude))
+	worker := handoffActionInstance(t, "worker", tmux.ProgramClaude)
+	h.store.AddInstance(worker)
 	h.sidebar.SetSelectedInstance(0)
 
-	var gotTitle, gotTarget string
-	restore := SetHandoffRunnerForTest(func(title, _, target string) (string, error) {
-		gotTitle, gotTarget = title, target
+	var gotRequest daemon.HandoffSessionRequest
+	restore := SetHandoffRunnerForTest(func(req daemon.HandoffSessionRequest) (string, error) {
+		gotRequest = req
 		return tmux.ProgramClaude, nil
 	})
 	defer restore()
@@ -98,7 +100,7 @@ func TestHandleStateSelectHandoffAgent_ConfirmsThenSwapsTheChosenAgent(t *testin
 
 	// Picking does not swap — it raises the confirmation.
 	require.Equal(t, stateConfirm, h.state, "a handoff must be confirmed before it runs")
-	require.Empty(t, gotTarget, "the swap must not fire before confirmation")
+	require.Empty(t, gotRequest.To, "the swap must not fire before confirmation")
 	require.NotNil(t, h.confirmationOverlay)
 
 	// Press the confirm key, which forwards the stashed message into the loop.
@@ -106,14 +108,16 @@ func TestHandleStateSelectHandoffAgent_ConfirmsThenSwapsTheChosenAgent(t *testin
 	require.NotNil(t, cmd, "confirming must forward the handoff message")
 	start, ok := cmd().(startHandoffMsg)
 	require.True(t, ok, "confirming must emit startHandoffMsg")
-	require.Equal(t, tmux.ProgramGemini, start.target)
+	require.Equal(t, tmux.ProgramGemini, start.request.To)
 
-	msg := h.handoffCmd(start.title, start.target)()
+	msg := h.handoffCmd(start.request)()
 	done, ok := msg.(handoffDoneMsg)
 	require.True(t, ok, "expected handoffDoneMsg, got %T", msg)
 	require.NoError(t, done.err)
-	require.Equal(t, "worker", gotTitle)
-	require.Equal(t, tmux.ProgramGemini, gotTarget, "the swap must target the agent the user picked")
+	require.Equal(t, "worker", gotRequest.Title)
+	require.Equal(t, h.repoID, gotRequest.RepoID)
+	require.Equal(t, worker.ID, gotRequest.ID, "the TUI must carry the stable session identity to the daemon")
+	require.Equal(t, tmux.ProgramGemini, gotRequest.To, "the swap must target the agent the user picked")
 }
 
 func TestHandleStateSelectHandoffAgent_KeepsTheSessionThatOpenedThePicker(t *testing.T) {
@@ -139,8 +143,31 @@ func TestHandleStateSelectHandoffAgent_KeepsTheSessionThatOpenedThePicker(t *tes
 	require.NotNil(t, cmd)
 	start, ok := cmd().(startHandoffMsg)
 	require.True(t, ok, "confirming must emit startHandoffMsg")
-	require.Equal(t, alpha.Title, start.title,
+	require.Equal(t, alpha.Title, start.request.Title,
 		"a background selection change must not retarget the handoff")
+	require.Equal(t, alpha.ID, start.request.ID)
+	require.Equal(t, h.repoID, start.request.RepoID)
+}
+
+func TestHandleStateSelectHandoffAgent_DropsARecreatedSameTitleTarget(t *testing.T) {
+	h := newTestHome(t)
+	original := handoffActionInstance(t, "worker", tmux.ProgramClaude)
+	h.store.AddInstance(original)
+	h.sidebar.SetSelectedInstance(0)
+
+	_, _ = h.handleHandoff()
+	require.True(t, h.store.RemoveInstanceByTitle(original.Title))
+	replacement := handoffActionInstance(t, original.Title, tmux.ProgramClaude)
+	require.NotEqual(t, original.ID, replacement.ID, "fixture requires a replacement session identity")
+	h.store.AddInstance(replacement)
+	h.selectionOverlay.SetSelectedIndex(0)
+
+	_, cmd := h.handleStateSelectHandoffAgent(tea.KeyMsg{Type: tea.KeyEnter})
+
+	require.Nil(t, cmd)
+	require.Equal(t, stateDefault, h.state)
+	require.Nil(t, h.confirmationOverlay,
+		"a replacement that reused the title must not inherit the pending handoff")
 }
 
 // Cancelling the picker must leave the session untouched.
@@ -150,7 +177,7 @@ func TestHandleStateSelectHandoffAgent_CancelDoesNotSwap(t *testing.T) {
 	h.sidebar.SetSelectedInstance(0)
 
 	called := false
-	restore := SetHandoffRunnerForTest(func(string, string, string) (string, error) {
+	restore := SetHandoffRunnerForTest(func(daemon.HandoffSessionRequest) (string, error) {
 		called = true
 		return "", nil
 	})
@@ -161,6 +188,7 @@ func TestHandleStateSelectHandoffAgent_CancelDoesNotSwap(t *testing.T) {
 
 	require.Equal(t, stateDefault, h.state, "cancelling returns to the default state")
 	require.Nil(t, h.confirmationOverlay, "cancelling must not raise a confirmation")
+	require.Equal(t, handoffPickerTarget{}, h.handoffTarget)
 	require.False(t, called)
 }
 

--- a/app/handoff_action_test.go
+++ b/app/handoff_action_test.go
@@ -193,6 +193,27 @@ func TestHandleStateSelectHandoffAgent_DropsARecreatedLegacyTarget(t *testing.T)
 		"a replacement must not inherit an id-less session's pending handoff")
 }
 
+func TestHandleStateSelectHandoffAgent_KeepsARebuiltLegacyTarget(t *testing.T) {
+	h := newTestHome(t)
+	original := handoffActionInstance(t, "worker", tmux.ProgramClaude)
+	original.ID = ""
+	h.store.AddInstance(original)
+	h.sidebar.SetSelectedInstance(0)
+
+	_, _ = h.handleHandoff()
+	rebuilt := handoffActionInstance(t, original.Title, tmux.ProgramClaude)
+	rebuilt.ID = ""
+	rebuilt.CreatedAt = original.CreatedAt
+	require.True(t, h.store.ReplaceInstance(original, rebuilt))
+	h.selectionOverlay.SetSelectedIndex(0)
+
+	_, _ = h.handleStateSelectHandoffAgent(tea.KeyMsg{Type: tea.KeyEnter})
+
+	require.Equal(t, stateConfirm, h.state,
+		"a snapshot rebuild with the same legacy discriminator remains the same target")
+	require.NotNil(t, h.confirmationOverlay)
+}
+
 // Cancelling the picker must leave the session untouched.
 func TestHandleStateSelectHandoffAgent_CancelDoesNotSwap(t *testing.T) {
 	h := newTestHome(t)

--- a/app/handoff_action_test.go
+++ b/app/handoff_action_test.go
@@ -216,6 +216,51 @@ func TestHandleStateSelectHandoffAgent_KeepsARebuiltLegacyTarget(t *testing.T) {
 	require.NotNil(t, h.confirmationOverlay)
 }
 
+func legacyHandoffAtConfirmation(t *testing.T) (*home, *session.Instance) {
+	t.Helper()
+	h := newTestHome(t)
+	original := handoffActionInstance(t, "worker", tmux.ProgramClaude)
+	original.ID = ""
+	h.store.AddInstance(original)
+	h.sidebar.SetSelectedInstance(0)
+
+	_, _ = h.handleHandoff()
+	h.selectionOverlay.SetSelectedIndex(0)
+	_, _ = h.handleStateSelectHandoffAgent(tea.KeyMsg{Type: tea.KeyEnter})
+	require.Equal(t, stateConfirm, h.state)
+	return h, original
+}
+
+func replaceLegacyHandoffTarget(t *testing.T, h *home, original *session.Instance) {
+	t.Helper()
+	require.True(t, h.store.RemoveInstanceByTitle(original.Title))
+	replacement := handoffActionInstance(t, original.Title, tmux.ProgramClaude)
+	replacement.CreatedAt = original.CreatedAt.Add(time.Second)
+	h.store.AddInstance(replacement)
+}
+
+func TestHandleStateSelectHandoffAgent_RechecksLegacyTargetAtConfirmation(t *testing.T) {
+	h, original := legacyHandoffAtConfirmation(t)
+	replaceLegacyHandoffTarget(t, h, original)
+
+	_, cmd := h.handleStateConfirm(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+
+	require.Nil(t, cmd, "a replacement during confirmation must not inherit the pending handoff")
+}
+
+func TestStartHandoffMsg_RechecksLegacyTargetAtDispatch(t *testing.T) {
+	h, original := legacyHandoffAtConfirmation(t)
+	_, cmd := h.handleStateConfirm(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	require.NotNil(t, cmd)
+	start, ok := cmd().(startHandoffMsg)
+	require.True(t, ok)
+
+	replaceLegacyHandoffTarget(t, h, original)
+	_, dispatch := h.Update(start)
+
+	require.Nil(t, dispatch, "a replacement before async dispatch must not inherit the pending handoff")
+}
+
 // Cancelling the picker must leave the session untouched.
 func TestHandleStateSelectHandoffAgent_CancelDoesNotSwap(t *testing.T) {
 	h := newTestHome(t)

--- a/app/handoff_action_test.go
+++ b/app/handoff_action_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"strings"
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/require"
@@ -180,6 +181,7 @@ func TestHandleStateSelectHandoffAgent_DropsARecreatedLegacyTarget(t *testing.T)
 	_, _ = h.handleHandoff()
 	require.True(t, h.store.RemoveInstanceByTitle(original.Title))
 	replacement := handoffActionInstance(t, original.Title, tmux.ProgramClaude)
+	replacement.CreatedAt = original.CreatedAt.Add(time.Second)
 	require.False(t, replacement.CreatedAt.Equal(original.CreatedAt),
 		"fixture requires a distinct legacy identity")
 	h.store.AddInstance(replacement)

--- a/app/handoff_action_test.go
+++ b/app/handoff_action_test.go
@@ -170,6 +170,29 @@ func TestHandleStateSelectHandoffAgent_DropsARecreatedSameTitleTarget(t *testing
 		"a replacement that reused the title must not inherit the pending handoff")
 }
 
+func TestHandleStateSelectHandoffAgent_DropsARecreatedLegacyTarget(t *testing.T) {
+	h := newTestHome(t)
+	original := handoffActionInstance(t, "worker", tmux.ProgramClaude)
+	original.ID = "" // persisted before stable session IDs existed
+	h.store.AddInstance(original)
+	h.sidebar.SetSelectedInstance(0)
+
+	_, _ = h.handleHandoff()
+	require.True(t, h.store.RemoveInstanceByTitle(original.Title))
+	replacement := handoffActionInstance(t, original.Title, tmux.ProgramClaude)
+	require.False(t, replacement.CreatedAt.Equal(original.CreatedAt),
+		"fixture requires a distinct legacy identity")
+	h.store.AddInstance(replacement)
+	h.selectionOverlay.SetSelectedIndex(0)
+
+	_, cmd := h.handleStateSelectHandoffAgent(tea.KeyMsg{Type: tea.KeyEnter})
+
+	require.Nil(t, cmd)
+	require.Equal(t, stateDefault, h.state)
+	require.Nil(t, h.confirmationOverlay,
+		"a replacement must not inherit an id-less session's pending handoff")
+}
+
 // Cancelling the picker must leave the session untouched.
 func TestHandleStateSelectHandoffAgent_CancelDoesNotSwap(t *testing.T) {
 	h := newTestHome(t)

--- a/app/handoff_action_test.go
+++ b/app/handoff_action_test.go
@@ -116,6 +116,33 @@ func TestHandleStateSelectHandoffAgent_ConfirmsThenSwapsTheChosenAgent(t *testin
 	require.Equal(t, tmux.ProgramGemini, gotTarget, "the swap must target the agent the user picked")
 }
 
+func TestHandleStateSelectHandoffAgent_KeepsTheSessionThatOpenedThePicker(t *testing.T) {
+	h := newTestHome(t)
+	alpha := handoffActionInstance(t, "alpha", tmux.ProgramClaude)
+	beta := handoffActionInstance(t, "beta", tmux.ProgramCodex)
+	h.store.AddInstance(alpha)
+	h.store.AddInstance(beta)
+	h.sidebar.SetSelectedInstance(0)
+
+	_, _ = h.handleHandoff()
+	require.Equal(t, tmux.ProgramCodex, h.handoffChoices[0], "fixture assumption: codex is offered for alpha")
+
+	// A snapshot can reconcile the sidebar while the modal owns the keyboard.
+	// Moving the cursor reproduces the consequential part of that update: the
+	// current selection is now beta even though alpha opened the picker.
+	h.sidebar.SetSelectedInstance(1)
+	h.selectionOverlay.SetSelectedIndex(0)
+	_, _ = h.handleStateSelectHandoffAgent(tea.KeyMsg{Type: tea.KeyEnter})
+
+	require.Equal(t, stateConfirm, h.state)
+	_, cmd := h.handleStateConfirm(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	require.NotNil(t, cmd)
+	start, ok := cmd().(startHandoffMsg)
+	require.True(t, ok, "confirming must emit startHandoffMsg")
+	require.Equal(t, alpha.Title, start.title,
+		"a background selection change must not retarget the handoff")
+}
+
 // Cancelling the picker must leave the session untouched.
 func TestHandleStateSelectHandoffAgent_CancelDoesNotSwap(t *testing.T) {
 	h := newTestHome(t)

--- a/app/home_model.go
+++ b/app/home_model.go
@@ -394,6 +394,11 @@ type home struct {
 	// omits the running agent), so the overlay's selected index cannot be mapped
 	// back through tmux.SupportedPrograms the way the create-time picker's can.
 	handoffChoices []string
+	// handoffTarget is the immutable session identity that opened the picker.
+	// Background snapshots may move the sidebar cursor or replace a same-title
+	// row while the modal owns the keyboard; submit must never re-read that
+	// mutable selection and retarget a destructive runtime swap (#2322).
+	handoffTarget handoffPickerTarget
 	// pendingProgram tracks the program selected during new instance naming
 	pendingProgram string
 	// promptOverlay handles initial-prompt entry during new-instance naming

--- a/app/home_update.go
+++ b/app/home_update.go
@@ -259,7 +259,7 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case startHandoffMsg:
 		// Handoff confirmed; run the daemon swap off the event loop, mirroring the
 		// kill/archive dispatch — it stops one agent process and starts another.
-		return m, m.handoffCmd(msg.title, msg.target)
+		return m, m.handoffCmd(msg.request)
 	case handoffDoneMsg:
 		return m.handleHandoffDone(msg)
 	case instanceRestoredMsg:

--- a/app/home_update.go
+++ b/app/home_update.go
@@ -259,6 +259,11 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case startHandoffMsg:
 		// Handoff confirmed; run the daemon swap off the event loop, mirroring the
 		// kill/archive dispatch — it stops one agent process and starts another.
+		// Recheck identity at this final event-loop boundary: a snapshot can land
+		// after confirmation produced the message but before Update receives it.
+		if m.resolveHandoffPickerTarget(msg.target) == nil {
+			return m, nil
+		}
 		return m, m.handoffCmd(msg.request)
 	case handoffDoneMsg:
 		return m.handleHandoffDone(msg)

--- a/app/session_control.go
+++ b/app/session_control.go
@@ -204,10 +204,10 @@ var resumeFromLimitThroughDaemon = func(title, repoID string) error {
 // swap that happened rather than the one it assumed: the picker's idea of the
 // current agent can be a poll tick stale. A package var so the app test suite can
 // stub it without dialing a real daemon.
-var handoffSessionThroughDaemon = func(title, repoID, target string) (string, error) {
+var handoffSessionThroughDaemon = func(req daemon.HandoffSessionRequest) (string, error) {
 	var from string
 	err := withDaemonHTTP(func(c *apiclient.Client) error {
-		resp, e := c.HandoffSession(daemon.HandoffSessionRequest{Title: title, RepoID: repoID, To: target})
+		resp, e := c.HandoffSession(req)
 		if e != nil {
 			return e
 		}
@@ -219,7 +219,7 @@ var handoffSessionThroughDaemon = func(title, repoID, target string) (string, er
 
 // SetHandoffRunnerForTest swaps the handoff seam (#2013) so a test can assert the
 // TUI routes its handoff through the daemon — without dialing a real one.
-func SetHandoffRunnerForTest(fn func(title, repoID, target string) (string, error)) func() {
+func SetHandoffRunnerForTest(fn func(daemon.HandoffSessionRequest) (string, error)) func() {
 	prev := handoffSessionThroughDaemon
 	handoffSessionThroughDaemon = fn
 	return func() { handoffSessionThroughDaemon = prev }

--- a/daemon/handoff.go
+++ b/daemon/handoff.go
@@ -15,8 +15,9 @@ type HandoffSessionRequest struct {
 	Title  string `json:"title"`
 	RepoID string `json:"repo_id"`
 	// ID is the session's stable id; see KillSessionRequest.ID. When non-empty
-	// the daemon resolves by id first, so a web/CLI handoff cannot land on the
-	// wrong session under a cross-repo title collision.
+	// the daemon resolves by id first. The TUI sends it so picker intent cannot
+	// move to a same-title replacement while a modal is open; the repo-scoped CLI
+	// keeps the legacy title path.
 	ID string `json:"id"`
 	// To is the incoming agent (a supported agent enum name).
 	To string `json:"to"`

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -422,8 +422,8 @@
       "id": "wire.id-addressing",
       "title": "Address a session by its stable id rather than by title",
       "tui": {
-        "status": "no",
-        "pointer": "app/session_control.go:139 et al send {Title, RepoID}"
+        "status": "partial",
+        "pointer": "app/handle_handoff.go:127-130 sends HandoffSessionRequest.ID; other TUI mutations still send {Title, RepoID}"
       },
       "web": {
         "status": "yes",
@@ -433,8 +433,9 @@
         "status": "no",
         "pointer": "api/sessions.go:733 et al send {Title, RepoID}"
       },
-      "verdict": "deliberate",
-      "notes": "Documented at daemon/control_types.go:226-230 and :48-54: 'TUI/CLI callers omit it and resolve by {Title, RepoID}'. The web sends the stable id because it is an all-repos client where a duplicate title across repos could target the wrong session; the TUI and CLI are repo-scoped (--repo / the focused project) so title resolution is unambiguous for them. The ID field being unset by the Go surfaces is by design, not drift."
+      "verdict": "real-gap",
+      "issue": "#2358",
+      "notes": "#2322 disproved the old blanket 'repo-scoped title is enough' rationale for a TUI action that survives a modal: a killed/recreated row can reuse the title while the user's intent still names the prior stable session. Handoff now carries ID from picker-open through daemon dispatch. The remaining TUI mutations are still title-addressed and need an action-by-action audit; the CLI remains deliberately repo+title scoped because each invocation resolves and dispatches one command without retained UI intent."
     },
     {
       "id": "session.watch",
@@ -1873,9 +1874,6 @@
           }
         },
         "tui": {
-          "id": {
-            "ok": "The TUI operates on the row the user selected in a single-repo rail, so title+repoID already names it unambiguously - the same resolution kill/archive/restore use from this surface."
-          },
           "brief": {
             "ok": "Deliberate. The TUI handoff is pick-agent-then-confirm; the mission defaults to the session's stored prompt, which the TUI can now set at create time (session.create.opt.prompt, shipped in #2075) and change any time via send-prompt. Putting a free-text field inside a confirmation dialog is a different interaction from a form field, and the confirm is deliberately one decision. `af sessions handoff --brief` is the surface for overriding the mission inline."
           }


### PR DESCRIPTION
Closes #2322.

## Verified defect

The generated report was still applicable on master. `handleHandoff` built its choices from the selected session, but `handleStateSelectHandoffAgent` re-read mutable sidebar state only after the modal submitted. The fail-first test opens the picker on `alpha`, moves selection to `beta`, and observes a daemon action for the wrong session.

## Change

- Capture the selected session's stable ID, title, repo ID, and legacy creation timestamp when the picker opens.
- Resolve that captured identity when the picker submits, again when confirmation fires, and once more when `startHandoffMsg` reaches the event loop.
- Drop the action if the target disappeared, the project changed, or a different session reused the title during any retained interval.
- Derive one typed `HandoffSessionRequest` from the captured target, keeping its ID/title/repo fields inseparable from the discriminator the guards validated.
- Clear picker identity on every close, including cancellation.
- Correct parity evidence: TUI stable-ID addressing is partial, and #2358 tracks the remaining focused action audit.

Current records resolve only by stable ID and never fall back from a stale non-empty ID to title. Pre-ID records require a non-zero matching `CreatedAt`; a zero or changed legacy identity fails closed.

## Regression coverage

- Selection drift while the picker is open does not retarget the action.
- A current or legacy same-title replacement cannot inherit the picker, confirmation, or dispatch intent.
- A same-session legacy snapshot rebuild remains usable.
- The normal path sends ID, title, repo ID, and chosen agent from one target.
- Cancellation clears pending identity without dispatch.
- Whole-program parity verifies the newly reachable request field and updated capability verdict.

## Exact-head gates

Commit: `51f6748ddd75c20e75e9d0a7aa16cd9b4428b2fb`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (clean)
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh` (959 Go files, 0 grandfathered)

All passed on that exact pushed head.

— Captain Claude
