### PR TITLE
fix(status): use the current Opencode composer

### DIFF
--- a/task/opencode_ready_test.go
+++ b/task/opencode_ready_test.go
@@ -254,3 +254,31 @@ func TestOpencodeWorkingIgnoresIndicatorTextInTranscript(t *testing.T) {
 		t.Error("\"esc interrupt\" in the status bar below the composer must read as working")
 	}
 }
+
+// A rendered composer copied into the transcript is indistinguishable from the
+// real composer by glyph shape alone. The current frame is therefore the LAST
+// complete frame in the visible pane: only status rendered below that frame may
+// decide whether the current turn is running.
+func TestOpencodeWorkingUsesBottomMostCompleteComposer(t *testing.T) {
+	transcriptFrame := "┃  copied composer in agent output\n" +
+		"╹▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀\n"
+	liveFrame := "┃  Build · Claude Opus 4.5 (latest) Anthropic\n" +
+		"╹▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀\n"
+
+	idle := transcriptFrame +
+		"   ⬝⬝⬝⬝⬝⬝⬝⬝  esc interrupt\n" +
+		"┃  The text above was an example, not the live status.\n" +
+		liveFrame +
+		"                            tab agents  ctrl+p commands\n"
+	if IsWorkingContent(idle, "opencode") {
+		t.Error("a busy-looking transcript frame above an idle live composer must not pin the session at Running")
+	}
+
+	busy := transcriptFrame +
+		"                            tab agents  ctrl+p commands\n" +
+		liveFrame +
+		"   ⬝⬝⬝⬝⬝⬝⬝⬝  esc interrupt                    tab agents  ctrl+p commands\n"
+	if !IsWorkingContent(busy, "opencode") {
+		t.Error("a busy indicator below the bottom-most live composer must still read as working")
+	}
+}

--- a/task/runner.go
+++ b/task/runner.go
@@ -255,18 +255,23 @@ func isAmpPromptFrame(content string) bool {
 // opencode's composer has no labeled top rule (unlike amp's "╭──── medium ────╮"),
 // so the walk anchors on the distinctive bottom rule and steps UP one line: a real
 // composer always has a "┃" box-interior row directly above its rule. Requiring
-// that pairing rather than matching a lone "╹" anywhere is what keeps a stray
-// glyph in agent output from reading as a live composer.
+// that pairing rather than matching a lone "╹" anywhere excludes stray glyphs.
+// A transcript can still contain a complete copied frame, so the CURRENT frame
+// is the bottom-most complete pairing in the visible pane, never the first.
 func opencodeFrameLines(content string) (lines []string, ruleIdx int, ok bool) {
 	plain := paneAnsiEscape.ReplaceAllString(content, "")
 	lines = strings.Split(plain, "\n")
+	lastRuleIdx := -1
 	for i, line := range lines {
 		if !opencodeFrameBottomRule.MatchString(line) {
 			continue
 		}
 		if i > 0 && strings.Contains(lines[i-1], "┃") {
-			return lines, i, true
+			lastRuleIdx = i
 		}
+	}
+	if lastRuleIdx >= 0 {
+		return lines, lastRuleIdx, true
 	}
 	return lines, -1, false
 }


### PR DESCRIPTION
## Summary

- make Opencode status classification use the bottom-most complete composer frame in the visible pane
- ignore a complete busy-looking composer copied into earlier transcript output
- preserve Running when the actual bottom composer carries Opencode's busy indicator

## Root cause

`opencodeFrameLines` claimed to locate the current composer but returned the first complete `┃` plus `╹▀▀` pairing. Agent output can contain that complete shape. If nearby transcript text also included `esc interrupt`, an idle session was classified as Running indefinitely and `af sessions watch` never unblocked.

The current composer is the bottom-most complete frame: transcript output is above it, and only the status rendered below that frame describes the live turn.

## Regression coverage

The fail-first two-frame test reproduced the false Running result with a busy-looking transcript frame above an idle live composer. The inverse case proves a busy indicator below the bottom frame remains positive evidence of a running turn.

## Gates

Exact pushed head: `54b44218a8fa5aafe5c685aa20e7626f8b6c5db8`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- generated docs clean after `make docs`

Closes #2321

— Captain Claude
