### PR TITLE
fix(restore): account for failed manual attempts

### DIFF
--- a/daemon/lostrestore.go
+++ b/daemon/lostrestore.go
@@ -94,6 +94,13 @@ type lostRestoreState struct {
 	vanishedWorktreesLogged map[string]struct{}
 }
 
+type lostRestoreTrigger uint8
+
+const (
+	lostRestoreAutomatic lostRestoreTrigger = iota
+	lostRestoreManual
+)
+
 // RestoreLostSessions runs one restore pass over every Lost session the
 // manager owns. Called from the daemon poll loop after EnsureRootAgents (which
 // owns the reserved root title); a no-op until the initial restore finishes.
@@ -340,8 +347,7 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 		// now exists) and the flag stays wrong, so kill never deletes the branch and
 		// it is orphaned. persistInstance is best-effort (logs on write failure).
 		m.persistInstance(repoID, inst)
-		m.logVanishedWorktreeOnce(key, repoID, st, inst, err)
-		m.lostRestoreFailed(key, st, inst.Title, err)
+		m.recordLostRestoreFailure(key, repoID, inst, err, lostRestoreAutomatic)
 		return
 	}
 
@@ -441,7 +447,32 @@ func (m *Manager) lostRestoreFailed(key string, st *lostRestoreState, title stri
 	log.WarningLog.Printf("restore of lost session %q failed (attempt %d), retrying in %s: %v", title, st.consecutiveFailures, backoff, err)
 }
 
-func (m *Manager) logVanishedWorktreeOnce(key, repoID string, st *lostRestoreState, inst *session.Instance, restoreErr error) {
+// recordLostRestoreFailure is the single failure-accounting path for automatic
+// and user-triggered Lost-session restores. A manual restore can be the first
+// attempt in an episode, so the state is created here rather than relying on the
+// automatic loop to have visited the session first.
+//
+// The trigger distinguishes the manual path's own killsInFlight entry
+// from an independently requested teardown. That map is also the daemon's broad
+// per-session operation gate despite its historical name; treating the manual
+// restore's marker as kill intent would label a vanished worktree
+// "expected_teardown" in the diagnostic emitted for that very restore.
+func (m *Manager) recordLostRestoreFailure(key, repoID string, inst *session.Instance, restoreErr error, trigger lostRestoreTrigger) {
+	m.mu.Lock()
+	st := m.lostRestoreStates[key]
+	if st == nil {
+		st = &lostRestoreState{}
+		m.lostRestoreStates[key] = st
+	}
+	_, operationInFlight := m.killsInFlight[key]
+	m.mu.Unlock()
+
+	teardownInFlight := operationInFlight && trigger != lostRestoreManual
+	m.logVanishedWorktreeOnce(repoID, st, inst, restoreErr, teardownInFlight)
+	m.lostRestoreFailed(key, st, inst.Title, restoreErr)
+}
+
+func (m *Manager) logVanishedWorktreeOnce(repoID string, st *lostRestoreState, inst *session.Instance, restoreErr error, teardownInFlight bool) {
 	worktreePath, ok := missingWorktreePath(restoreErr)
 	if !ok {
 		return
@@ -455,7 +486,6 @@ func (m *Manager) logVanishedWorktreeOnce(key, repoID string, st *lostRestoreSta
 		}
 		st.vanishedWorktreesLogged[worktreePath] = struct{}{}
 	}
-	_, killInFlight := m.killsInFlight[key]
 	m.mu.Unlock()
 	if alreadyLogged {
 		return
@@ -476,7 +506,7 @@ func (m *Manager) logVanishedWorktreeOnce(key, repoID string, st *lostRestoreSta
 	liveness := inst.GetLiveness()
 	op := inst.GetInFlightOp()
 	userKilled := inst.UserKilled()
-	teardownIntent := userKilled || killInFlight || op == session.OpKilling || op == session.OpArchiving
+	teardownIntent := userKilled || teardownInFlight || op == session.OpKilling || op == session.OpArchiving
 	classification := classifyMissingWorktree(diag.WorktreeRegistrationKnown, diag.WorktreeRegistered, teardownIntent)
 
 	log.ErrorLog.Printf(
@@ -492,7 +522,7 @@ func (m *Manager) logVanishedWorktreeOnce(key, repoID string, st *lostRestoreSta
 		statusLabel(inst.GetStatus()),
 		inst.Started(),
 		userKilled,
-		killInFlight,
+		teardownInFlight,
 		op,
 		diag.ExternalWorktree,
 		diag.BranchCreatedByUs,

--- a/daemon/manual_restore_backoff_test.go
+++ b/daemon/manual_restore_backoff_test.go
@@ -1,8 +1,17 @@
 package daemon
 
 import (
+	"bytes"
+	"errors"
+	stdlog "log"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+	aflog "github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 )
 
@@ -117,5 +126,75 @@ func TestRestoreSession_LongLivedThenDied_ResetsBackoff(t *testing.T) {
 	if failures > 0 {
 		t.Fatalf("a runtime confirmed alive after a manual restore was charged %d failure(s) from "+
 			"the PREVIOUS episode when it later died: a genuine re-loss must start a fresh backoff", failures)
+	}
+}
+
+// TestRestoreSession_FailedManualRestoresShareDiagnosticsAndBackoff pins the
+// failure half of the same manual/automatic restore contract. A user-triggered
+// Recover failure is still a failed restore attempt: it must advance the retry
+// episode exactly once, arm the automatic loop's backoff, and emit the same
+// one-shot missing-worktree diagnostic as an automatic attempt.
+func TestRestoreSession_FailedManualRestoresShareDiagnosticsAndBackoff(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	worktreePath := filepath.Join(testguard.CanonicalTempDir(t), "missing-manual-restore")
+	restoreErr := &session.WorktreeUnavailableError{
+		Title:        "manual-failure",
+		WorktreePath: worktreePath,
+		Err:          &os.PathError{Op: "stat", Path: worktreePath, Err: os.ErrNotExist},
+	}
+	backend := &recoverFakeBackend{FakeBackend: session.NewFakeBackend(), failWith: restoreErr}
+	registerStarted(t, manager, repoID, repoPath, "manual-failure", backend, true, session.Lost)
+
+	key := daemonInstanceKey(repoID, "manual-failure")
+	manager.mu.Lock()
+	manager.lostRestoreStates[key] = &lostRestoreState{consecutiveFailures: 2}
+	manager.mu.Unlock()
+
+	var warnings, diagnostics bytes.Buffer
+	previousWarning, previousError := aflog.WarningLog, aflog.ErrorLog
+	aflog.WarningLog = stdlog.New(&warnings, "WARNING: ", 0)
+	aflog.ErrorLog = stdlog.New(&diagnostics, "ERROR: ", 0)
+	t.Cleanup(func() {
+		aflog.WarningLog = previousWarning
+		aflog.ErrorLog = previousError
+	})
+
+	for attempt := 0; attempt < 2; attempt++ {
+		if _, err := manager.RestoreSession(RestoreSessionRequest{Title: "manual-failure", RepoID: repoID}); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("manual restore %d error = %v, want missing-worktree cause", attempt+1, err)
+		}
+	}
+	if got := backend.recoverCalls(); got != 2 {
+		t.Fatalf("manual Recover calls = %d, want 2", got)
+	}
+
+	manager.mu.Lock()
+	state := manager.lostRestoreStates[key]
+	manager.mu.Unlock()
+	if state == nil {
+		t.Fatal("manual restore failures were not entered into the shared lost-restore retry state")
+	}
+	if state.consecutiveFailures != 4 {
+		t.Fatalf("consecutiveFailures = %d, want 4: each of two manual attempts must add exactly one to the two existing failures", state.consecutiveFailures)
+	}
+	if !state.nextAttempt.After(time.Now()) {
+		t.Fatalf("nextAttempt = %v, want a future automatic-retry backoff", state.nextAttempt)
+	}
+
+	manager.RestoreLostSessions()
+	if got := backend.recoverCalls(); got != 2 {
+		t.Fatalf("automatic loop ignored the backoff recorded by manual restore: Recover calls = %d, want 2", got)
+	}
+
+	if got := strings.Count(diagnostics.String(), "WORKTREE_MISSING_DETECTED"); got != 1 {
+		t.Fatalf("missing-worktree diagnostic count = %d, want one per loss episode; logs:\n%s", got, diagnostics.String())
+	}
+	if strings.Contains(diagnostics.String(), `classification="expected_teardown"`) {
+		t.Fatalf("manual restore's own busy marker was misreported as teardown intent; logs:\n%s", diagnostics.String())
+	}
+	for _, want := range []string{"attempt 3", "attempt 4"} {
+		if !strings.Contains(warnings.String(), want) {
+			t.Fatalf("missing %q in shared failure-accounting logs:\n%s", want, warnings.String())
+		}
 	}
 }

--- a/daemon/restore.go
+++ b/daemon/restore.go
@@ -101,6 +101,7 @@ func (m *Manager) restoreLostOrDeadSession(req RestoreSessionRequest, repoID str
 
 	if err := instance.Recover(); err != nil {
 		m.persistInstance(repoID, instance)
+		m.recordLostRestoreFailure(key, repoID, instance, err, lostRestoreManual)
 		return "", err
 	}
 	// Reset FIRST, before the persist below: recovery replaced the runtime the


### PR DESCRIPTION
Closes #2326.

## Summary

- route automatic and manual Lost-session recovery errors through one failure-accounting path
- create or advance the shared retry episode for user-triggered failures, including exponential backoff and escalation logs
- preserve the one-shot `WORKTREE_MISSING_DETECTED` diagnostic without misclassifying the manual restore's own operation marker as teardown intent

## Regression proof

The new test failed first on current master: two manual recovery failures left `consecutiveFailures` unchanged at 2. It now proves both attempts advance the same episode exactly once, the automatic loop honors the resulting backoff, the vanished-worktree diagnostic appears once, and the diagnostic does not claim an expected teardown.

## Exact-head gates

All passed on `68419798edeb19359868160bbe8b38efcdb0deff`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- documentation diff clean

— Captain Claude
