### PR TITLE
fix(stream): linearize broker creation with tab close

### DIFF
--- a/session/agentserver_local.go
+++ b/session/agentserver_local.go
@@ -237,15 +237,22 @@ func (s *localAgentServer) SendPrompt(prompt string) error {
 // panicking.
 func (s *localAgentServer) ensureBroker(tab int) (*ptyBroker, error) {
 	// Resolve the caller's ordinal to the tab's STABLE id (#1738) and the tmux it
-	// currently backs in ONE instance-lock acquisition, BEFORE taking s.mu. Two
-	// lookups could pair b's ID with c's tmux if a close shifted the roster between
-	// them — then cache that wrong binding under b forever (#2200).
-	id, ts, ok := s.inst.tabTmuxTargetAt(tab)
+	// currently backs in ONE instance-lock acquisition. Keep i.mu held while
+	// taking s.mu so CloseTab cannot remove the tab and finish broker cleanup
+	// between resolution and insertion (#2327). The lock order is always i.mu →
+	// s.mu; neither closeTabStream nor another server path acquires them in the
+	// reverse order. Keeping this a single lookup also prevents pairing b's ID
+	// with c's tmux if a close shifts the roster between two resolutions (#2200).
+	s.inst.mu.RLock()
+	id, ts, ok := s.inst.tabTmuxTargetAtLocked(tab)
 	if s.afterTabResolve != nil {
 		s.afterTabResolve()
 	}
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	defer func() {
+		s.mu.Unlock()
+		s.inst.mu.RUnlock()
+	}()
 	if s.closed {
 		return nil, fmt.Errorf("session %q is being terminated", s.inst.Title)
 	}
@@ -296,13 +303,20 @@ func (s *localAgentServer) resetBrokerCaptures() {
 // is the direct route: no ordinal is involved at any point. A stale/unknown id is
 // ErrTabGone — a refusal, never a fall back to a positional tab.
 func (s *localAgentServer) ensureBrokerByID(tabID string) (*ptyBroker, error) {
-	// Resolve under i.mu BEFORE taking s.mu (never nest s.mu → i.mu).
-	ts, exists := s.inst.TabTmuxByID(tabID)
+	// Couple resolution to broker insertion under i.mu → s.mu. CloseTab removes
+	// the tab under i.mu before taking s.mu for stream teardown, so it either wins
+	// before this lookup (ErrTabGone) or waits and then removes the broker we
+	// insert. It can never clean up first and leave a later stale insertion.
+	s.inst.mu.RLock()
+	ts, exists := s.inst.tabTmuxByIDLocked(tabID)
 	if s.afterTabResolve != nil {
 		s.afterTabResolve()
 	}
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	defer func() {
+		s.mu.Unlock()
+		s.inst.mu.RUnlock()
+	}()
 	if s.closed {
 		return nil, fmt.Errorf("session %q is being terminated", s.inst.Title)
 	}

--- a/session/agentserver_local.go
+++ b/session/agentserver_local.go
@@ -27,6 +27,9 @@ type localAgentServer struct {
 	inst *Instance
 
 	mu sync.Mutex
+	// afterTabResolve is a deterministic race-test seam. Production leaves it
+	// nil; tests use it to pause between tab resolution and broker-map locking.
+	afterTabResolve func()
 	// brokers holds one lazy ptyBroker per tab, keyed by the tab's STABLE id
 	// (#1738), not its ordinal index (#1592 Phase 2 PR6, tab-aware streaming): the
 	// agent tab and each shell/process tab have their own clientless capture + ring
@@ -238,6 +241,9 @@ func (s *localAgentServer) ensureBroker(tab int) (*ptyBroker, error) {
 	// lookups could pair b's ID with c's tmux if a close shifted the roster between
 	// them — then cache that wrong binding under b forever (#2200).
 	id, ts, ok := s.inst.tabTmuxTargetAt(tab)
+	if s.afterTabResolve != nil {
+		s.afterTabResolve()
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.closed {
@@ -292,6 +298,9 @@ func (s *localAgentServer) resetBrokerCaptures() {
 func (s *localAgentServer) ensureBrokerByID(tabID string) (*ptyBroker, error) {
 	// Resolve under i.mu BEFORE taking s.mu (never nest s.mu → i.mu).
 	ts, exists := s.inst.TabTmuxByID(tabID)
+	if s.afterTabResolve != nil {
+		s.afterTabResolve()
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.closed {

--- a/session/agentserver_tab_close_race_test.go
+++ b/session/agentserver_tab_close_race_test.go
@@ -1,0 +1,95 @@
+package session
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #2327: resolving tab→tmux and then releasing i.mu before taking the broker
+// lock lets CloseTab remove/tear down the tab in between. The stale ensure then
+// creates a broker after closeTabStream has already done its cleanup, leaving
+// an orphan over the dead tmux target. Both ordinal and stable-ID callers share
+// this lock boundary and must be linearized against tab removal.
+func TestEnsureBrokerTabCloseRaceDoesNotOrphanBroker(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		ensure func(*localAgentServer, string) (*ptyBroker, error)
+	}{
+		{
+			name: "ordinal",
+			ensure: func(server *localAgentServer, _ string) (*ptyBroker, error) {
+				return server.ensureBroker(1)
+			},
+		},
+		{
+			name: "stable_id",
+			ensure: func(server *localAgentServer, id string) (*ptyBroker, error) {
+				return server.ensureBrokerByID(id)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			log.Initialize(false)
+			defer log.Close()
+
+			inst, _ := raceMockInstance(t, "af_broker_close_race_"+tc.name, func() {})
+			tab, err := inst.AddProcessTab("worker", "")
+			require.NoError(t, err)
+			server := inst.AgentServer().(*localAgentServer)
+
+			resolved := make(chan struct{})
+			release := make(chan struct{})
+			var pauseOnce sync.Once
+			server.afterTabResolve = func() {
+				pauseOnce.Do(func() {
+					close(resolved)
+					<-release
+				})
+			}
+
+			type ensureResult struct {
+				broker *ptyBroker
+				err    error
+			}
+			ensured := make(chan ensureResult, 1)
+			go func() {
+				broker, ensureErr := tc.ensure(server, tab.ID)
+				ensured <- ensureResult{broker: broker, err: ensureErr}
+			}()
+			<-resolved
+
+			closed := make(chan error, 1)
+			if inst.mu.TryLock() {
+				// On the buggy implementation the resolver already released i.mu,
+				// so remove and fully close the tab before broker creation resumes.
+				idx, exists := inst.tabIndexByIDLocked(tab.ID)
+				require.True(t, exists)
+				removed := inst.removeTabLocked(idx)
+				inst.mu.Unlock()
+				closed <- inst.closeRemovedTab(removed)
+			} else {
+				// The fixed implementation still owns i.mu.RLock. CloseTab waits
+				// until ensure has installed the broker, then removes and closes it.
+				go func() { closed <- inst.CloseTabByID(tab.ID) }()
+			}
+
+			close(release)
+			result := <-ensured
+			require.NoError(t, result.err)
+			require.NotNil(t, result.broker)
+			require.NoError(t, <-closed)
+
+			server.mu.Lock()
+			orphan := server.brokers[tab.ID]
+			server.mu.Unlock()
+			assert.Nil(t, orphan, "a broker created during tab close must be removed and closed")
+
+			_, err = server.ensureBrokerByID(tab.ID)
+			assert.ErrorIs(t, err, ErrTabGone, "a later caller must see the vanished tab, not a dead tmux session")
+		})
+	}
+}

--- a/session/instance.go
+++ b/session/instance.go
@@ -341,9 +341,9 @@ func (i *Instance) TabIDAt(idx int) (string, bool) {
 // tabTmuxTargetAt resolves an ordinal to both the stable broker key and its tmux
 // target under one lock. Reading those in separate calls can pair one tab's ID
 // with a sibling's tmux when a close shifts the roster between the calls (#2200).
-func (i *Instance) tabTmuxTargetAt(idx int) (id string, ts *tmux.TmuxSession, exists bool) {
-	i.mu.RLock()
-	defer i.mu.RUnlock()
+// tabTmuxTargetAtLocked resolves an ordinal and its stable stream target in one
+// snapshot. Callers must hold i.mu.
+func (i *Instance) tabTmuxTargetAtLocked(idx int) (id string, ts *tmux.TmuxSession, exists bool) {
 	if idx < 0 || idx >= len(i.Tabs) {
 		return "", nil, false
 	}
@@ -372,11 +372,17 @@ func (i *Instance) tabTmuxTargetAt(idx int) (id string, ts *tmux.TmuxSession, ex
 //     gone; a caller must not report it as such, since a not-yet-started tab may
 //     still come up and a client should keep addressing it.
 func (i *Instance) TabTmuxByID(id string) (ts *tmux.TmuxSession, exists bool) {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.tabTmuxByIDLocked(id)
+}
+
+// tabTmuxByIDLocked is TabTmuxByID for callers coupling the resolved target to
+// another lock-protected operation. Callers must hold i.mu.
+func (i *Instance) tabTmuxByIDLocked(id string) (ts *tmux.TmuxSession, exists bool) {
 	if id == "" {
 		return nil, false
 	}
-	i.mu.RLock()
-	defer i.mu.RUnlock()
 	for idx, t := range i.Tabs {
 		if t.ID != id {
 			continue


### PR DESCRIPTION
Closes #2327.

## Summary

- hold the instance read lock through stable tab/tmux resolution and broker-map insertion
- preserve the existing instance → agent-server lock order so tab close either wins first with `ErrTabGone`, or waits and then removes the broker that was just created
- apply the same boundary to ordinal and stable-ID stream callers
- delete the superseded unlocked ordinal resolver caught by `deadcode -test ./...`

## Reproduction

The fail-first test pauses each production resolver after it has selected the tab but before it acquires the broker lock. On the old code, tab close removes the tab and completes stream cleanup in that gap; the resolver then resumes and inserts an open broker over the dead tmux target. Both ordinal and stable-ID cases failed with an orphan remaining in `server.brokers`.

The fixed path holds `Instance.mu.RLock` across that boundary. If broker creation wins, close waits, removes the tab, and closes/removes the newly inserted broker. If close wins, the resolver returns `ErrTabGone`. A later call in the deterministic race test always sees `ErrTabGone`, never a stale tmux session.

## Validation

Exact pushed head: `b791b27f5d8a09960dd51bc3178c5b3342798967`

- deterministic fail-first regression observed before the fix
- `go test -race ./session -run '^TestEnsureBrokerTabCloseRaceDoesNotOrphanBroker$' -count=20`
- related tab/broker tests
- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (clean)
- `go build ./...`
- `deadcode -test ./...` (no output)
- `scripts/lint-file-length.sh`
- `make test-container`

All reproduction uses isolated fake tmux sessions; no live session or host tmux server was touched.
