### PR TITLE
fix(config): quote detected alias executable path

### DIFF
--- a/config/claude_probe.go
+++ b/config/claude_probe.go
@@ -91,6 +91,40 @@ func GetClaudeCommand() (string, error) {
 	return path, err
 }
 
+// shellQuoteDetectedCommand quotes the filesystem-backed executable at the
+// front of a shell-probed command while preserving any alias-provided argument
+// suffix byte-for-byte. The probe cannot return argv: shell aliases are free-form
+// text, and an unquoted path containing spaces is indistinguishable from several
+// words by syntax alone. Filesystem existence supplies the missing boundary.
+//
+// Search longest-first so an existing directory or file that is merely a prefix
+// of the real executable cannot win over the executable itself. Prefix candidates
+// must not be directories; if no file-backed prefix can be proved, leave the
+// command unchanged rather than guessing at shell syntax.
+func shellQuoteDetectedCommand(command string) string {
+	if command == "" {
+		return command
+	}
+	if info, err := os.Stat(command); err == nil && !info.IsDir() {
+		return ShellQuotePath(command)
+	}
+	for boundary := len(command) - 1; boundary >= 0; boundary-- {
+		if command[boundary] != ' ' && command[boundary] != '\t' {
+			continue
+		}
+		candidate := command[:boundary]
+		if candidate == "" {
+			continue
+		}
+		info, err := os.Stat(candidate)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		return ShellQuotePath(candidate) + command[boundary:]
+	}
+	return command
+}
+
 // probeClaudeCommand performs the actual shell probe for the claude command.
 // GetClaudeCommand wraps it with per-environment memoization.
 func probeClaudeCommand() (string, error) {

--- a/config/config_types.go
+++ b/config/config_types.go
@@ -448,13 +448,10 @@ func DefaultConfig() *Config {
 
 	if claudePath, err := GetClaudeCommand(); err == nil && claudePath != "" {
 		// An alias can resolve to a full command with flags (e.g. "claude
-		// --model opus"), which is already shell syntax and must not be
-		// re-quoted wholesale. Only a bare path that exists on disk gets the
-		// space/apostrophe quoting treatment (#569).
-		command := claudePath
-		if _, statErr := os.Stat(claudePath); statErr == nil {
-			command = ShellQuotePath(claudePath)
-		}
+		// --model opus"), which is already shell syntax and must not be quoted
+		// wholesale. Quote only a provable executable-path prefix and preserve
+		// the alias-provided argument suffix (#569, #2323).
+		command := shellQuoteDetectedCommand(claudePath)
 		cfg.ProgramOverrides = map[string]string{
 			tmux.ProgramClaude: command + " --dangerously-skip-permissions",
 		}

--- a/config/space_alias_with_flags_test.go
+++ b/config/space_alias_with_flags_test.go
@@ -1,0 +1,69 @@
+package config
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/session/tmux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultConfigQuotesAliasPathWithSpacesBeforeFlags(t *testing.T) {
+	// The shell probe returns the alias expansion as one string. Statting that
+	// whole string fails once flags are present, but leaving it unquoted makes
+	// sh split the executable path at its first space. Execute the resulting
+	// override so this test pins the launch behavior, not merely formatting.
+	bashPath := requireBash(t)
+	homeDir := t.TempDir()
+	binDir := filepath.Join(t.TempDir(), "Claude Code")
+	require.NoError(t, os.MkdirAll(binDir, 0755))
+	target := filepath.Join(binDir, "claude")
+	require.NoError(t, os.WriteFile(target, []byte("#!/bin/sh\nprintf '%s\\n' \"$@\"\n"), 0755))
+	writeGuardedBashrc(t, homeDir, target+" --model opus")
+
+	t.Setenv("HOME", homeDir)
+	t.Setenv("SHELL", bashPath)
+	t.Setenv("PATH", t.TempDir())
+
+	cfg := DefaultConfig()
+	require.NotNil(t, cfg)
+	override := cfg.ProgramOverrides[tmux.ProgramClaude]
+	assert.Equal(t,
+		"'"+target+"' --model opus --dangerously-skip-permissions",
+		override)
+
+	output, err := exec.Command("/bin/sh", "-c", override).CombinedOutput()
+	require.NoError(t, err, "resolved override failed to launch the detected executable: %s", output)
+	assert.Equal(t, "--model\nopus\n--dangerously-skip-permissions\n", string(output))
+}
+
+func TestShellQuoteDetectedCommandUsesFilesystemBoundary(t *testing.T) {
+	binDir := filepath.Join(t.TempDir(), "Claude's Tools")
+	require.NoError(t, os.MkdirAll(binDir, 0755))
+	target := filepath.Join(binDir, "claude")
+	require.NoError(t, os.WriteFile(target, []byte("#!/bin/sh\n"), 0755))
+
+	quoted := ShellQuotePath(target)
+	tests := []struct {
+		name    string
+		command string
+		want    string
+	}{
+		{name: "bare path", command: target, want: quoted},
+		{name: "flags preserved", command: target + " --model opus", want: quoted + " --model opus"},
+		{name: "tab delimiter preserved", command: target + "\t--model opus", want: quoted + "\t--model opus"},
+		{name: "already quoted", command: quoted + " --model opus", want: quoted + " --model opus"},
+		{name: "unproved shell command", command: "claude --model opus", want: "claude --model opus"},
+		{name: "bare directory is not executable", command: binDir, want: binDir},
+		{name: "directory is not executable prefix", command: binDir + " --model opus", want: binDir + " --model opus"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, shellQuoteDetectedCommand(tt.command))
+		})
+	}
+}


### PR DESCRIPTION
Closes #2323.

## Summary

- locate the longest existing non-directory prefix in a shell-probed Claude command
- quote only that proven executable path while preserving the alias's argument suffix byte-for-byte
- leave unproved or already-quoted shell syntax unchanged instead of guessing at an argv split

## Regression proof

The execution-level test failed first on current master: the generated override split the temporary `Claude Code/claude` path and `/bin/sh` reported the truncated executable as missing. It now launches that exact stub and delivers `--model opus --dangerously-skip-permissions` as three intact arguments. A boundary table also covers tabs, apostrophes, already-quoted commands, unproved commands, and directory false positives.

## Exact-head gates

All passed on `7b1c8a4845427aa3874b3277b9ee41e4f18fd7b6`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- documentation diff clean

— Captain Claude
