### PR TITLE
fix(tui): retain destructive session identity

### DIFF
--- a/app/action_identity_test.go
+++ b/app/action_identity_test.go
@@ -1,0 +1,56 @@
+package app
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// A confirmation records intent about one session, not whichever row happens
+// to carry the same display title when the user eventually confirms. Snapshot
+// reconciliation may replace the original row while the modal is open after a
+// concurrent kill+recreate (#2358).
+func TestHandleKill_ConfirmationDoesNotTargetSameTitleReplacement(t *testing.T) {
+	h := newTestHome(t)
+	original := newKillableInstance(t, "worker")
+	h.store.AddInstance(original)
+	h.sidebar.SetSelectedInstance(0)
+
+	model, _ := h.handleKill()
+	h = model.(*home)
+	require.Equal(t, stateConfirm, h.state)
+
+	replacement := newKillableInstance(t, original.Title)
+	require.NotEqual(t, original.ID, replacement.ID)
+	require.True(t, h.store.ReplaceInstance(original, replacement))
+
+	model, cmd := h.handleStateConfirm(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	h = model.(*home)
+	require.Nil(t, cmd, "a stale confirmation must not dispatch a kill")
+	require.Equal(t, session.OpNone, replacement.GetInFlightOp(),
+		"a stale confirmation must not mark the replacement as deleting")
+}
+
+func TestHandleArchive_ConfirmationDoesNotTargetSameTitleReplacement(t *testing.T) {
+	h := newTestHome(t)
+	original := archiveActionInstance(t, "worker", session.Ready)
+	h.store.AddInstance(original)
+	h.sidebar.SetSelectedInstance(0)
+
+	model, _ := h.handleArchive()
+	h = model.(*home)
+	require.Equal(t, stateConfirm, h.state)
+
+	replacement := archiveActionInstance(t, original.Title, session.Ready)
+	require.NotEqual(t, original.ID, replacement.ID)
+	require.True(t, h.store.ReplaceInstance(original, replacement))
+
+	model, cmd := h.handleStateConfirm(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	h = model.(*home)
+	require.Nil(t, cmd, "a stale confirmation must not dispatch an archive")
+	require.Equal(t, session.OpNone, replacement.GetInFlightOp(),
+		"a stale confirmation must not mark the replacement as archiving")
+}

--- a/app/action_identity_test.go
+++ b/app/action_identity_test.go
@@ -1,11 +1,13 @@
 package app
 
 import (
+	"errors"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/session"
 )
 
@@ -62,11 +64,12 @@ func TestHandleInstanceKilled_CompletionDoesNotRemoveSameTitleReplacement(t *tes
 	h := newTestHome(t)
 	original := newKillableInstance(t, "worker")
 	h.store.AddInstance(original)
+	target := captureSessionActionTarget(original, h.repoID)
 
 	replacement := newKillableInstance(t, original.Title)
 	require.True(t, h.store.ReplaceInstance(original, replacement))
 
-	_, _ = h.handleInstanceKilled(instanceKilledMsg{title: original.Title})
+	_, _ = h.handleInstanceKilled(instanceKilledMsg{target: target})
 	require.Same(t, replacement, h.store.GetInstanceByTitle(original.Title),
 		"the old kill completion must not remove the replacement")
 }
@@ -75,11 +78,72 @@ func TestHandleInstanceArchived_CompletionDoesNotArchiveSameTitleReplacement(t *
 	h := newTestHome(t)
 	original := archiveActionInstance(t, "worker", session.Ready)
 	h.store.AddInstance(original)
+	target := captureSessionActionTarget(original, h.repoID)
 
 	replacement := archiveActionInstance(t, original.Title, session.Ready)
 	require.True(t, h.store.ReplaceInstance(original, replacement))
 
-	_, _ = h.handleInstanceArchived(instanceArchivedMsg{title: original.Title})
+	_, _ = h.handleInstanceArchived(instanceArchivedMsg{target: target})
 	require.Equal(t, session.Ready, replacement.GetStatus(),
 		"the old archive completion must not archive the replacement")
+}
+
+func TestKillInstanceCmd_PreservesCapturedStableIdentity(t *testing.T) {
+	h := newTestHome(t)
+	target := sessionActionTarget{id: "worker-id", title: "worker", repoID: h.repoID}
+
+	var got daemon.KillSessionRequest
+	previous := killSessionThroughDaemon
+	killSessionThroughDaemon = func(request daemon.KillSessionRequest) error {
+		got = request
+		return nil
+	}
+	t.Cleanup(func() { killSessionThroughDaemon = previous })
+
+	msg := h.killInstanceCmd(target)()
+	done, ok := msg.(instanceKilledMsg)
+	require.True(t, ok)
+	require.Equal(t, target.killRequest(), got)
+	require.Equal(t, target, done.target)
+}
+
+func TestFailedActionCompletionDoesNotClearSameTitleReplacementOperation(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		begin      session.TransitionEvent
+		wantOp     session.InFlightOp
+		completion func(*home, sessionActionTarget)
+	}{
+		{
+			name:   "kill",
+			begin:  session.BeginKill(),
+			wantOp: session.OpKilling,
+			completion: func(h *home, target sessionActionTarget) {
+				_, _ = h.handleInstanceKilled(instanceKilledMsg{target: target, err: errors.New("old kill failed")})
+			},
+		},
+		{
+			name:   "archive",
+			begin:  session.BeginArchive(),
+			wantOp: session.OpArchiving,
+			completion: func(h *home, target sessionActionTarget) {
+				_, _ = h.handleInstanceArchived(instanceArchivedMsg{target: target, err: errors.New("old archive failed")})
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHome(t)
+			original := archiveActionInstance(t, "worker", session.Ready)
+			h.store.AddInstance(original)
+			target := captureSessionActionTarget(original, h.repoID)
+
+			replacement := archiveActionInstance(t, original.Title, session.Ready)
+			require.NoError(t, replacement.Transition(tc.begin))
+			require.True(t, h.store.ReplaceInstance(original, replacement))
+
+			tc.completion(h, target)
+			require.Equal(t, tc.wantOp, replacement.GetInFlightOp(),
+				"the old failure must not clear the replacement's own operation")
+		})
+	}
 }

--- a/app/action_identity_test.go
+++ b/app/action_identity_test.go
@@ -54,3 +54,32 @@ func TestHandleArchive_ConfirmationDoesNotTargetSameTitleReplacement(t *testing.
 	require.Equal(t, session.OpNone, replacement.GetInFlightOp(),
 		"a stale confirmation must not mark the replacement as archiving")
 }
+
+// The RPC completion is another retained-intent boundary. A reconcile may swap
+// in a same-title replacement after the daemon call starts but before its result
+// reaches the event loop; the old completion must not mutate that new row.
+func TestHandleInstanceKilled_CompletionDoesNotRemoveSameTitleReplacement(t *testing.T) {
+	h := newTestHome(t)
+	original := newKillableInstance(t, "worker")
+	h.store.AddInstance(original)
+
+	replacement := newKillableInstance(t, original.Title)
+	require.True(t, h.store.ReplaceInstance(original, replacement))
+
+	_, _ = h.handleInstanceKilled(instanceKilledMsg{title: original.Title})
+	require.Same(t, replacement, h.store.GetInstanceByTitle(original.Title),
+		"the old kill completion must not remove the replacement")
+}
+
+func TestHandleInstanceArchived_CompletionDoesNotArchiveSameTitleReplacement(t *testing.T) {
+	h := newTestHome(t)
+	original := archiveActionInstance(t, "worker", session.Ready)
+	h.store.AddInstance(original)
+
+	replacement := archiveActionInstance(t, original.Title, session.Ready)
+	require.True(t, h.store.ReplaceInstance(original, replacement))
+
+	_, _ = h.handleInstanceArchived(instanceArchivedMsg{title: original.Title})
+	require.Equal(t, session.Ready, replacement.GetStatus(),
+		"the old archive completion must not archive the replacement")
+}

--- a/app/archive_action_test.go
+++ b/app/archive_action_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/session"
 )
@@ -34,7 +35,7 @@ func TestHandleArchive_LiveRowConfirms(t *testing.T) {
 
 	called := false
 	prev := archiveSessionThroughDaemon
-	archiveSessionThroughDaemon = func(string, string) (string, error) { called = true; return "", nil }
+	archiveSessionThroughDaemon = func(daemon.ArchiveSessionRequest) (string, error) { called = true; return "", nil }
 	defer func() { archiveSessionThroughDaemon = prev }()
 
 	model, _ := h.handleArchive()
@@ -188,20 +189,22 @@ func TestHandleRestore_LiveRowIsNoOp(t *testing.T) {
 func TestArchiveInstanceCmd_CallsDaemon(t *testing.T) {
 	h := newTestHome(t)
 
-	var gotTitle string
+	var gotRequest daemon.ArchiveSessionRequest
 	prev := archiveSessionThroughDaemon
-	archiveSessionThroughDaemon = func(title, repoID string) (string, error) {
-		gotTitle = title
+	archiveSessionThroughDaemon = func(request daemon.ArchiveSessionRequest) (string, error) {
+		gotRequest = request
 		return "/archive/path", nil
 	}
 	defer func() { archiveSessionThroughDaemon = prev }()
 
-	msg := h.archiveInstanceCmd("worker")()
-	require.Equal(t, "worker", gotTitle, "the archive command must call the daemon for the given title")
+	target := sessionActionTarget{id: "session-id", title: "worker", repoID: h.repoID}
+	msg := h.archiveInstanceCmd(target)()
+	require.Equal(t, daemon.ArchiveSessionRequest{ID: target.id, Title: target.title, RepoID: target.repoID}, gotRequest,
+		"the archive command must preserve the captured stable identity")
 	done, ok := msg.(instanceArchivedMsg)
 	require.True(t, ok, "the command must emit instanceArchivedMsg")
 	require.NoError(t, done.err)
-	require.Equal(t, "worker", done.title)
+	require.Equal(t, target, done.target)
 }
 
 // TestArchiveInstanceCmd_SurfacesError: a daemon rejection is carried back as an
@@ -209,12 +212,12 @@ func TestArchiveInstanceCmd_CallsDaemon(t *testing.T) {
 func TestArchiveInstanceCmd_SurfacesError(t *testing.T) {
 	h := newTestHome(t)
 	prev := archiveSessionThroughDaemon
-	archiveSessionThroughDaemon = func(string, string) (string, error) {
+	archiveSessionThroughDaemon = func(daemon.ArchiveSessionRequest) (string, error) {
 		return "", errors.New("cannot archive in-place session")
 	}
 	defer func() { archiveSessionThroughDaemon = prev }()
 
-	msg := h.archiveInstanceCmd("worker")()
+	msg := h.archiveInstanceCmd(sessionActionTarget{title: "worker", repoID: h.repoID})()
 	done := msg.(instanceArchivedMsg)
 	require.Error(t, done.err)
 }

--- a/app/archive_panes_test.go
+++ b/app/archive_panes_test.go
@@ -23,7 +23,7 @@ func TestArchive_ClosesOpenPanesViaFinalize(t *testing.T) {
 	_, _ = h.openOrFocusPane(inst, 0) // open the agent pane
 	require.Equal(t, 1, h.store.NumOpenPanes(), "precondition: a pane is open on the session")
 
-	h.handleInstanceArchived(instanceArchivedMsg{title: inst.Title})
+	h.handleInstanceArchived(instanceArchivedMsg{target: captureSessionActionTarget(inst, h.repoID)})
 
 	require.Equal(t, session.Archived, inst.GetStatus())
 	require.True(t, h.store.ContainsInstance(inst),
@@ -71,7 +71,7 @@ func TestRestore_LeavesNoStalePaneBinding(t *testing.T) {
 	require.Equal(t, 1, h.store.NumOpenPanes())
 
 	// Archive closes the pane bound to the (about-to-be) archived session.
-	h.handleInstanceArchived(instanceArchivedMsg{title: inst.Title})
+	h.handleInstanceArchived(instanceArchivedMsg{target: captureSessionActionTarget(inst, h.repoID)})
 	require.Equal(t, 0, h.store.NumOpenPanes(),
 		"archive closes the session's panes — no live pane on an archived row")
 

--- a/app/archive_reconcile_test.go
+++ b/app/archive_reconcile_test.go
@@ -312,7 +312,7 @@ func TestHandleInstanceArchived_FinalizesRowImmediately(t *testing.T) {
 	inst.SetInFlightOpForTest(session.OpArchiving) // as left by the optimistic archive action
 	h.store.AddInstance(inst)
 
-	h.handleInstanceArchived(instanceArchivedMsg{title: "worker"})
+	h.handleInstanceArchived(instanceArchivedMsg{target: captureSessionActionTarget(inst, h.repoID)})
 
 	require.Equal(t, session.OpNone, inst.GetInFlightOp(), "the op is cleared on finalize")
 	require.Equal(t, session.Archived, inst.GetStatus(),

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -164,9 +164,11 @@ func (m *home) handleKill() (tea.Model, tea.Cmd) {
 		return m, m.handleError(fmt.Errorf("session '%s' is already being deleted", selected.Title))
 	}
 
-	// Capture the title at confirmation time so that background tick events
-	// cannot change which instance we operate on.
+	// Capture stable identity at confirmation-open time. A title may be reused
+	// while the modal is open, so every later phase resolves this target instead
+	// of whichever current row happens to carry the display title (#2358).
 	selectedTitle := selected.Title
+	target := captureSessionActionTarget(selected, m.repoID)
 
 	// Runs synchronously in the confirmation overlay's OnConfirm, on the
 	// event loop — keep it fast. Raising the optimistic OpKilling op here (not in
@@ -175,11 +177,10 @@ func (m *home) handleKill() (tea.Model, tea.Cmd) {
 	// overlay (the daemon does not emit a kill op; it drops the record), so it
 	// composes to Deleting for rendering and survives non-terminal reconciles.
 	killAction := func() tea.Msg {
-		for _, inst := range m.store.GetInstances() {
-			if inst.Title == selectedTitle {
-				_ = inst.Transition(session.BeginKill())
-				return startKillMsg{title: selectedTitle}
-			}
+		inst := m.resolveSessionActionTarget(target)
+		if inst != nil {
+			_ = inst.Transition(session.BeginKill())
+			return startKillMsg{target: target}
 		}
 		// The row was removed (e.g. by an external kill picked up by the
 		// background refresh) while the dialog was open; nothing to do.
@@ -266,8 +267,7 @@ func (m *home) handleKill() (tea.Model, tea.Cmd) {
 // is unchanged: it goes through the killSessionThroughDaemon seam — now the HTTP
 // apiclient's KillSession (#1592 Phase 2 PR3) — which keeps the title blocked
 // against reuse until the teardown completes.
-func (m *home) killInstanceCmd(title string) tea.Cmd {
-	repoID := m.repoID
+func (m *home) killInstanceCmd(target sessionActionTarget) tea.Cmd {
 	// Capture the kill seam on the event loop, before the goroutine: it is a
 	// package var swapped by test seams, so reading it inside the cmd goroutine
 	// would race a sibling parallel test's swap (#960 PR 4 race-fix class).
@@ -276,11 +276,11 @@ func (m *home) killInstanceCmd(title string) tea.Cmd {
 		// The shell tab's tmux session is owned by the instance and torn down by
 		// LocalBackend.Kill (looping all tabs) inside the daemon teardown — there
 		// is no longer a UI-side terminal cache to clean up (#930 PR 2).
-		if err := kill(title, repoID); err != nil {
+		if err := kill(target.killRequest()); err != nil {
 			log.ErrorLog.Printf("could not kill instance: %v", err)
-			return instanceKilledMsg{title: title, err: err}
+			return instanceKilledMsg{target: target, err: err}
 		}
-		return instanceKilledMsg{title: title}
+		return instanceKilledMsg{target: target}
 	}
 }
 
@@ -290,34 +290,21 @@ func (m *home) killInstanceCmd(title string) tea.Cmd {
 // kill, and the underlying error — the evidence, per #797 — lands in the
 // error box.
 func (m *home) handleInstanceKilled(msg instanceKilledMsg) (tea.Model, tea.Cmd) {
+	inst := m.resolveSessionActionTarget(msg.target)
 	if msg.err != nil {
-		for _, inst := range m.store.GetInstances() {
-			if inst.Title == msg.title && inst.GetInFlightOp() == session.OpKilling {
-				// Clear the optimistic kill op: the row reverts to its underlying
-				// daemon liveness so the user can retry the kill.
-				_ = inst.Transition(session.RevertKill())
-				break
-			}
+		if inst != nil && inst.GetInFlightOp() == session.OpKilling {
+			// Clear the optimistic kill op: the row reverts to its underlying
+			// daemon liveness so the user can retry the kill.
+			_ = inst.Transition(session.RevertKill())
 		}
-		return m, m.handleError(fmt.Errorf("failed to kill session '%s': %w", msg.title, msg.err))
+		return m, m.handleError(fmt.Errorf("failed to kill session '%s': %w", msg.target.title, msg.err))
 	}
 
-	// The TUI's in-memory instance is untouched by the daemon-side teardown,
-	// so its repo name is still resolvable here for repo-section bookkeeping.
-	// The row may already be gone when the background refresh noticed the
-	// deleted disk record first — both removals are no-ops then.
-	var repoName string
-	var repoErr error = fmt.Errorf("instance not found")
-	for _, inst := range m.store.GetInstances() {
-		if inst.Title == msg.title {
-			repoName, repoErr = inst.RepoName()
-			break
-		}
-	}
-	if repoErr == nil {
-		m.store.RemoveInstanceByTitleWithRepo(msg.title, repoName)
-	} else {
-		m.store.RemoveInstanceByTitle(msg.title)
+	// A refresh may already have removed the row, or replaced it with a new
+	// same-title session while the RPC was in flight. Remove only the captured
+	// identity; both missing cases are intentional no-ops.
+	if inst != nil {
+		m.store.RemoveInstance(inst)
 	}
 	return m, m.selectionChanged()
 }
@@ -342,6 +329,7 @@ func (m *home) handleArchive() (tea.Model, tea.Cmd) {
 		return m, m.handleError(fmt.Errorf("session '%s' is being deleted", selected.Title))
 	}
 	title := selected.Title
+	target := captureSessionActionTarget(selected, m.repoID)
 
 	// A resting (Archived/Lost/Dead) row has no live worktree/tmux to tear down;
 	// `a` does nothing. Restore is on its own key now (`r`).
@@ -365,13 +353,12 @@ func (m *home) handleArchive() (tea.Model, tea.Cmd) {
 		// while the RPC runs (#1195). It composes to Deleting for rendering; the
 		// reconcile clears it once the daemon liveness settles on Archived, and the
 		// completion handler finalizes it — so the row can never strand (#1187).
-		for _, inst := range m.store.GetInstances() {
-			if inst.Title == title {
-				_ = inst.Transition(session.BeginArchive())
-				break
-			}
+		inst := m.resolveSessionActionTarget(target)
+		if inst == nil {
+			return nil
 		}
-		return startArchiveMsg{title: title}
+		_ = inst.Transition(session.BeginArchive())
+		return startArchiveMsg{target: target}
 	})
 }
 
@@ -415,15 +402,14 @@ func (m *home) handleRestore() (tea.Model, tea.Cmd) {
 // archiveInstanceCmd runs the daemon archive (tmux teardown + worktree move) off
 // the event loop (#1028), mirroring killInstanceCmd — the RPC blocks for the
 // whole operation, so it must not run on the Update goroutine.
-func (m *home) archiveInstanceCmd(title string) tea.Cmd {
-	repoID := m.repoID
+func (m *home) archiveInstanceCmd(target sessionActionTarget) tea.Cmd {
 	archive := archiveSessionThroughDaemon
 	return func() tea.Msg {
-		if _, err := archive(title, repoID); err != nil {
-			log.ErrorLog.Printf("could not archive instance %q: %v", title, err)
-			return instanceArchivedMsg{title: title, err: err}
+		if _, err := archive(target.archiveRequest()); err != nil {
+			log.ErrorLog.Printf("could not archive instance %q: %v", target.title, err)
+			return instanceArchivedMsg{target: target, err: err}
 		}
-		return instanceArchivedMsg{title: title}
+		return instanceArchivedMsg{target: target}
 	}
 }
 
@@ -449,29 +435,24 @@ func (m *home) restoreInstanceCmd(title string) tea.Cmd {
 // never strand on "Tearing down session…" even if a poll caught it mid-fence.
 // On failure the error lands in the error box.
 func (m *home) handleInstanceArchived(msg instanceArchivedMsg) (tea.Model, tea.Cmd) {
+	inst := m.resolveSessionActionTarget(msg.target)
 	if msg.err != nil {
 		// Archive failed: clear the optimistic op so the row reverts to its
 		// underlying daemon liveness rather than stranding as archiving.
-		for _, inst := range m.store.GetInstances() {
-			if inst.Title == msg.title && inst.GetInFlightOp() == session.OpArchiving {
-				_ = inst.Transition(session.ClearOp())
-				break
-			}
+		if inst != nil && inst.GetInFlightOp() == session.OpArchiving {
+			_ = inst.Transition(session.ClearOp())
 		}
-		return m, m.handleError(fmt.Errorf("failed to archive session '%s': %w", msg.title, msg.err))
+		return m, m.handleError(fmt.Errorf("failed to archive session '%s': %w", msg.target.title, msg.err))
 	}
-	for _, inst := range m.store.GetInstances() {
-		if inst.Title == msg.title {
-			// SetArchived is an unconditional projection-mirror: it copies the
-			// daemon's already-committed Archived state (started=false,
-			// liveness=Archived, op cleared) onto the read-only row. It is NOT the
-			// fenced CommitArchive transition (that's the daemon's I2 enforcement
-			// point) — the TUI row may be in any state here (optimistic OpArchiving,
-			// or already Archived if the reconcile settled first), so it stays a
-			// direct unconditional mirror rather than a fenced edge (#1195 Phase 2d).
-			inst.SetArchived()
-			break
-		}
+	if inst != nil {
+		// SetArchived is an unconditional projection-mirror: it copies the
+		// daemon's already-committed Archived state (started=false,
+		// liveness=Archived, op cleared) onto the read-only row. It is NOT the
+		// fenced CommitArchive transition (that's the daemon's I2 enforcement
+		// point) — the TUI row may be in any state here (optimistic OpArchiving,
+		// or already Archived if the reconcile settled first), so it stays a
+		// direct unconditional mirror rather than a fenced edge (#1195 Phase 2d).
+		inst.SetArchived()
 	}
 	return m, m.selectionChanged()
 }

--- a/app/handle_handoff.go
+++ b/app/handle_handoff.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"fmt"
-	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -14,12 +13,7 @@ import (
 	"github.com/sachiniyer/agent-factory/ui/overlay"
 )
 
-type handoffPickerTarget struct {
-	id        string
-	title     string
-	repoID    string
-	createdAt time.Time
-}
+type handoffPickerTarget = sessionActionTarget
 
 func (target handoffPickerTarget) request(to string) daemon.HandoffSessionRequest {
 	return daemon.HandoffSessionRequest{
@@ -88,9 +82,7 @@ func (m *home) handleHandoff() (tea.Model, tea.Cmd) {
 	}
 
 	m.handoffChoices = choices
-	m.handoffTarget = handoffPickerTarget{
-		id: selected.ID, title: selected.Title, repoID: m.repoID, createdAt: selected.CreatedAt,
-	}
+	m.handoffTarget = captureSessionActionTarget(selected, m.repoID)
 	m.selectionOverlay = overlay.NewSelectionOverlay("Hand off to", choices)
 	m.state = stateSelectHandoffAgent
 	return m, nil
@@ -123,7 +115,7 @@ func (m *home) handleStateSelectHandoffAgent(msg tea.KeyMsg) (tea.Model, tea.Cmd
 	}
 	target := choices[idx]
 
-	selected := m.resolveHandoffPickerTarget(pickerTarget)
+	selected := m.resolveSessionActionTarget(pickerTarget)
 	if selected == nil {
 		return m, nil
 	}
@@ -143,32 +135,6 @@ func (m *home) handleStateSelectHandoffAgent(msg tea.KeyMsg) (tea.Model, tea.Cmd
 		}
 		return startHandoffMsg{request: pickerTarget.request(target), target: pickerTarget}
 	})
-}
-
-func (m *home) resolveHandoffPickerTarget(target handoffPickerTarget) *session.Instance {
-	if target.repoID == "" || target.repoID != m.repoID {
-		return nil
-	}
-	if target.id == "" {
-		// Compatibility for records written before stable session IDs existed.
-		// CreatedAt is the same legacy discriminator snapshot reconciliation uses;
-		// a zero timestamp proves no identity, so fail closed instead of letting
-		// title reuse inherit a retained destructive action (#2322/#2358).
-		if target.createdAt.IsZero() {
-			return nil
-		}
-		inst := m.store.GetInstanceByTitle(target.title)
-		if inst != nil && inst.CreatedAt.Equal(target.createdAt) {
-			return inst
-		}
-		return nil
-	}
-	for _, inst := range m.store.GetInstances() {
-		if inst.ID == target.id {
-			return inst
-		}
-	}
-	return nil
 }
 
 // startHandoffMsg is emitted by the confirmation action and turned into the

--- a/app/handle_handoff.go
+++ b/app/handle_handoff.go
@@ -130,7 +130,7 @@ func (m *home) handleStateSelectHandoffAgent(msg tea.KeyMsg) (tea.Model, tea.Cmd
 		// Confirmation is a second retained-intent boundary after the picker.
 		// Re-resolve the captured identity so an id-less legacy row replaced while
 		// the dialog was open cannot hand its title to the new session.
-		if m.resolveHandoffPickerTarget(pickerTarget) == nil {
+		if m.resolveSessionActionTarget(pickerTarget) == nil {
 			return nil
 		}
 		return startHandoffMsg{request: pickerTarget.request(target), target: pickerTarget}

--- a/app/handle_handoff.go
+++ b/app/handle_handoff.go
@@ -15,12 +15,6 @@ import (
 
 type handoffPickerTarget = sessionActionTarget
 
-func (target handoffPickerTarget) request(to string) daemon.HandoffSessionRequest {
-	return daemon.HandoffSessionRequest{
-		ID: target.id, Title: target.title, RepoID: target.repoID, To: to,
-	}
-}
-
 // handoffAgentChoices returns the agents the selected session may be handed to:
 // every supported agent except the one already running.
 //
@@ -133,7 +127,7 @@ func (m *home) handleStateSelectHandoffAgent(msg tea.KeyMsg) (tea.Model, tea.Cmd
 		if m.resolveSessionActionTarget(pickerTarget) == nil {
 			return nil
 		}
-		return startHandoffMsg{request: pickerTarget.request(target), target: pickerTarget}
+		return startHandoffMsg{request: pickerTarget.handoffRequest(target), target: pickerTarget}
 	})
 }
 

--- a/app/home_update.go
+++ b/app/home_update.go
@@ -261,7 +261,7 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// kill/archive dispatch — it stops one agent process and starts another.
 		// Recheck identity at this final event-loop boundary: a snapshot can land
 		// after confirmation produced the message but before Update receives it.
-		if m.resolveHandoffPickerTarget(msg.target) == nil {
+		if m.resolveSessionActionTarget(msg.target) == nil {
 			return m, nil
 		}
 		return m, m.handoffCmd(msg.request)

--- a/app/home_update.go
+++ b/app/home_update.go
@@ -247,13 +247,13 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case startKillMsg:
 		// The row was already flipped to Deleting synchronously by the kill
 		// confirmation; dispatch the slow teardown off the event loop (#844).
-		return m, m.killInstanceCmd(msg.title)
+		return m, m.killInstanceCmd(msg.target)
 	case instanceKilledMsg:
 		return m.handleInstanceKilled(msg)
 	case startArchiveMsg:
 		// Archive confirmed; run the daemon teardown+move off the event loop
 		// (#1028), mirroring the kill dispatch.
-		return m, m.archiveInstanceCmd(msg.title)
+		return m, m.archiveInstanceCmd(msg.target)
 	case instanceArchivedMsg:
 		return m.handleInstanceArchived(msg)
 	case startHandoffMsg:

--- a/app/kill_async_test.go
+++ b/app/kill_async_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/session"
 )
 
@@ -26,7 +27,9 @@ import (
 func setKillerForTest(t *testing.T, f func(title, repoID string) error) {
 	t.Helper()
 	prev := killSessionThroughDaemon
-	killSessionThroughDaemon = f
+	killSessionThroughDaemon = func(request daemon.KillSessionRequest) error {
+		return f(request.Title, request.RepoID)
+	}
 	t.Cleanup(func() { killSessionThroughDaemon = prev })
 }
 
@@ -213,6 +216,6 @@ func TestHandleEnter_DeletingInstanceIsNoOp(t *testing.T) {
 // The handler must tolerate the missing row.
 func TestInstanceKilled_RowAlreadyRemoved(t *testing.T) {
 	h := newTestHome(t)
-	_, _ = h.Update(instanceKilledMsg{title: "already-gone"})
+	_, _ = h.Update(instanceKilledMsg{target: sessionActionTarget{title: "already-gone", repoID: h.repoID}})
 	assert.Empty(t, h.store.GetInstances())
 }

--- a/app/kill_hang_test.go
+++ b/app/kill_hang_test.go
@@ -63,7 +63,9 @@ func TestKillSessionThroughDaemon_WedgedDaemon_ReturnsActionableError(t *testing
 	killRPCTimeout = 250 * time.Millisecond
 
 	done := make(chan error, 1)
-	go func() { done <- killSessionThroughDaemon("alpha", "repo-1") }()
+	go func() {
+		done <- killSessionThroughDaemon(daemon.KillSessionRequest{ID: "alpha-id", Title: "alpha", RepoID: "repo-1"})
+	}()
 
 	select {
 	case err := <-done:
@@ -174,7 +176,9 @@ func TestKillSessionThroughDaemon_DaemonError_SurfacesVerbatim(t *testing.T) {
 	}
 
 	done := make(chan error, 1)
-	go func() { done <- killSessionThroughDaemon("ghost", "repo-1") }()
+	go func() {
+		done <- killSessionThroughDaemon(daemon.KillSessionRequest{ID: "ghost-id", Title: "ghost", RepoID: "repo-1"})
+	}()
 	select {
 	case err := <-done:
 		if err == nil || !strings.Contains(err.Error(), `session "ghost" not found`) {

--- a/app/kill_unmerged_test.go
+++ b/app/kill_unmerged_test.go
@@ -152,7 +152,8 @@ func TestHandleKill_UnmergedUnpushedCommit_EscalatesAndNamesLoss(t *testing.T) {
 	assert.Equal(t, session.Deleting, inst.GetStatus())
 	startMsg, ok := cmd().(startKillMsg)
 	require.True(t, ok, "confirm must emit startKillMsg")
-	assert.Equal(t, "gamma", startMsg.title)
+	assert.Equal(t, "gamma", startMsg.target.title)
+	assert.Equal(t, inst.ID, startMsg.target.id)
 }
 
 // TestHandleKill_AgentSwitchesBranch_WarnsForSessionBranchCommits is the #2199

--- a/app/messages.go
+++ b/app/messages.go
@@ -14,22 +14,22 @@ type previewTickMsg struct{}
 // dispatches killInstanceCmd, which runs the slow teardown in a background
 // goroutine (#844).
 type startKillMsg struct {
-	title string
+	target sessionActionTarget
 }
 
 // instanceKilledMsg reports completion of an async kill. A nil err means the
 // daemon tore the session down and deleted its record; a non-nil err means
 // the session is still alive and the row must become retryable again.
 type instanceKilledMsg struct {
-	title string
-	err   error
+	target sessionActionTarget
+	err    error
 }
 
 // startArchiveMsg is emitted by the archive confirmation (#1028); its handler
 // dispatches archiveInstanceCmd to run the daemon teardown+move off the event
 // loop, mirroring startKillMsg → killInstanceCmd.
 type startArchiveMsg struct {
-	title string
+	target sessionActionTarget
 }
 
 // startDeleteProjectMsg is emitted by the delete-project confirmation (#1735);
@@ -62,8 +62,8 @@ type projectDeletedMsg struct {
 // next daemon Snapshot reconcile (which re-partitions it into / out of the
 // Archived folder); a non-nil err is surfaced in the error box.
 type instanceArchivedMsg struct {
-	title string
-	err   error
+	target sessionActionTarget
+	err    error
 }
 
 type instanceRestoredMsg struct {

--- a/app/root_kill_guard_test.go
+++ b/app/root_kill_guard_test.go
@@ -87,7 +87,7 @@ func TestHandleKill_RootRequiresDistinctConfirmKey(t *testing.T) {
 		"root row must be marked Deleting once confirmed")
 	startMsg, ok := cmd().(startKillMsg)
 	require.True(t, ok, "confirm must emit startKillMsg, got a different msg")
-	assert.Equal(t, session.RootSessionTitle, startMsg.title)
+	assert.Equal(t, session.RootSessionTitle, startMsg.target.title)
 }
 
 // TestHandleKill_NonReservedKeepsOrdinaryConfirm guards the acceptance criterion

--- a/app/session_action_target.go
+++ b/app/session_action_target.go
@@ -60,3 +60,9 @@ func (target sessionActionTarget) killRequest() daemon.KillSessionRequest {
 func (target sessionActionTarget) archiveRequest() daemon.ArchiveSessionRequest {
 	return daemon.ArchiveSessionRequest{ID: target.id, Title: target.title, RepoID: target.repoID}
 }
+
+func (target sessionActionTarget) handoffRequest(to string) daemon.HandoffSessionRequest {
+	return daemon.HandoffSessionRequest{
+		ID: target.id, Title: target.title, RepoID: target.repoID, To: to,
+	}
+}

--- a/app/session_action_target.go
+++ b/app/session_action_target.go
@@ -10,27 +10,26 @@ import (
 // sessionActionTarget is the immutable identity captured when a retained TUI
 // action begins. A title is display text and may be reused while a picker,
 // confirmation, or daemon call is in flight; current records therefore resolve
-// only by stable ID. The pointer/CreatedAt fields keep pre-ID records usable
-// without letting a zero timestamp turn title reuse back into identity.
+// only by stable ID. CreatedAt keeps pre-ID records usable without letting a
+// zero timestamp turn title reuse back into identity.
 type sessionActionTarget struct {
 	id        string
 	title     string
 	repoID    string
 	createdAt time.Time
-	instance  *session.Instance
 }
 
 func captureSessionActionTarget(inst *session.Instance, repoID string) sessionActionTarget {
 	return sessionActionTarget{
 		id: inst.ID, title: inst.Title, repoID: repoID,
-		createdAt: inst.CreatedAt, instance: inst,
+		createdAt: inst.CreatedAt,
 	}
 }
 
 // resolveSessionActionTarget resolves target only inside the project that
 // captured it. A non-empty ID is authoritative and never falls back to title.
-// Legacy records first retain pointer identity across a modal and otherwise use
-// the same non-zero CreatedAt fallback as snapshot reconciliation.
+// Legacy records use the same non-zero CreatedAt fallback as snapshot
+// reconciliation.
 func (m *home) resolveSessionActionTarget(target sessionActionTarget) *session.Instance {
 	if target.repoID == "" || target.repoID != m.repoID {
 		return nil
@@ -42,9 +41,6 @@ func (m *home) resolveSessionActionTarget(target sessionActionTarget) *session.I
 			}
 		}
 		return nil
-	}
-	if target.instance != nil && m.store.ContainsInstance(target.instance) {
-		return target.instance
 	}
 	if target.createdAt.IsZero() {
 		return nil

--- a/app/session_action_target.go
+++ b/app/session_action_target.go
@@ -1,0 +1,66 @@
+package app
+
+import (
+	"time"
+
+	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// sessionActionTarget is the immutable identity captured when a retained TUI
+// action begins. A title is display text and may be reused while a picker,
+// confirmation, or daemon call is in flight; current records therefore resolve
+// only by stable ID. The pointer/CreatedAt fields keep pre-ID records usable
+// without letting a zero timestamp turn title reuse back into identity.
+type sessionActionTarget struct {
+	id        string
+	title     string
+	repoID    string
+	createdAt time.Time
+	instance  *session.Instance
+}
+
+func captureSessionActionTarget(inst *session.Instance, repoID string) sessionActionTarget {
+	return sessionActionTarget{
+		id: inst.ID, title: inst.Title, repoID: repoID,
+		createdAt: inst.CreatedAt, instance: inst,
+	}
+}
+
+// resolveSessionActionTarget resolves target only inside the project that
+// captured it. A non-empty ID is authoritative and never falls back to title.
+// Legacy records first retain pointer identity across a modal and otherwise use
+// the same non-zero CreatedAt fallback as snapshot reconciliation.
+func (m *home) resolveSessionActionTarget(target sessionActionTarget) *session.Instance {
+	if target.repoID == "" || target.repoID != m.repoID {
+		return nil
+	}
+	if target.id != "" {
+		for _, inst := range m.store.GetInstances() {
+			if inst.ID == target.id {
+				return inst
+			}
+		}
+		return nil
+	}
+	if target.instance != nil && m.store.ContainsInstance(target.instance) {
+		return target.instance
+	}
+	if target.createdAt.IsZero() {
+		return nil
+	}
+	for _, inst := range m.store.GetInstances() {
+		if inst.Title == target.title && inst.CreatedAt.Equal(target.createdAt) {
+			return inst
+		}
+	}
+	return nil
+}
+
+func (target sessionActionTarget) killRequest() daemon.KillSessionRequest {
+	return daemon.KillSessionRequest{ID: target.id, Title: target.title, RepoID: target.repoID}
+}
+
+func (target sessionActionTarget) archiveRequest() daemon.ArchiveSessionRequest {
+	return daemon.ArchiveSessionRequest{ID: target.id, Title: target.title, RepoID: target.repoID}
+}

--- a/app/session_control.go
+++ b/app/session_control.go
@@ -129,11 +129,11 @@ var startSessionThroughDaemon = func(_ *session.Instance, req sessionStartReques
 // actually fires rather than waiting a real minute.
 var killRPCTimeout = 60 * time.Second
 
-var killSessionThroughDaemon = func(title, repoID string) error {
+var killSessionThroughDaemon = func(request daemon.KillSessionRequest) error {
 	ctx, cancel := context.WithTimeout(context.Background(), killRPCTimeout)
 	defer cancel()
 	err := withDaemonHTTP(func(c *apiclient.Client) error {
-		return c.KillSession(ctx, daemon.KillSessionRequest{Title: title, RepoID: repoID})
+		return c.KillSession(ctx, request)
 	})
 	// A deadline here means the daemon took the request and went quiet, so this
 	// client genuinely does not know whether the teardown happened — say exactly
@@ -152,11 +152,11 @@ var killSessionThroughDaemon = func(title, repoID string) error {
 // archiveSessionThroughDaemon / restoreSessionThroughDaemon route archive and
 // restore verbs through the daemon (the single writer). Package vars so the app
 // test suite can stub them without dialing a real daemon.
-var archiveSessionThroughDaemon = func(title, repoID string) (string, error) {
+var archiveSessionThroughDaemon = func(request daemon.ArchiveSessionRequest) (string, error) {
 	var path string
 	err := withDaemonHTTP(func(c *apiclient.Client) error {
 		var e error
-		path, e = c.ArchiveSession(daemon.ArchiveSessionRequest{Title: title, RepoID: repoID})
+		path, e = c.ArchiveSession(request)
 		return e
 	})
 	return path, err

--- a/daemon/control_types.go
+++ b/daemon/control_types.go
@@ -72,7 +72,8 @@ type KillSessionRequest struct {
 	// only falls back to {Title, RepoID} when it is empty. Web clients send it so
 	// a duplicate title across repos can't target the wrong session on this
 	// destructive action — the write-path analogue of the id-keyed read/stream
-	// paths (#1592 Phase 5 PR5). TUI/CLI callers omit it and resolve by title.
+	// paths (#1592 Phase 5 PR5). Retained TUI actions send it; one-shot CLI
+	// callers resolve by repo-scoped title.
 	ID string `json:"id"`
 	// No force field: kill always destroys the session since the unmerged-work
 	// guard was dropped (#1579). The CLI `--force` flag is accepted as a no-op
@@ -94,7 +95,8 @@ type ArchiveSessionRequest struct {
 	// ID is the session's stable id; see KillSessionRequest.ID. When non-empty
 	// the daemon resolves the archive target by id first, so a web archive can't
 	// hit the wrong session under a cross-repo title collision (#1592 Phase 5
-	// follow-up). TUI/CLI callers omit it and resolve by {Title, RepoID}.
+	// follow-up). Retained TUI actions send it; one-shot CLI callers resolve by
+	// {Title, RepoID}.
 	ID string `json:"id"`
 }
 

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -423,7 +423,7 @@
       "title": "Address a session by its stable id rather than by title",
       "tui": {
         "status": "partial",
-        "pointer": "app/handle_handoff.go:127-130 sends HandoffSessionRequest.ID; other TUI mutations still send {Title, RepoID}"
+        "pointer": "app/session_action_target.go captures stable identity; handle_actions.go sends it for kill/archive and handle_handoff.go sends it for handoff"
       },
       "web": {
         "status": "yes",
@@ -435,7 +435,7 @@
       },
       "verdict": "real-gap",
       "issue": "#2358",
-      "notes": "#2322 disproved the old blanket 'repo-scoped title is enough' rationale for a TUI action that survives a modal: a killed/recreated row can reuse the title while the user's intent still names the prior stable session. Handoff now carries ID from picker-open through daemon dispatch. The remaining TUI mutations are still title-addressed and need an action-by-action audit; the CLI remains deliberately repo+title scoped because each invocation resolves and dispatches one command without retained UI intent."
+      "notes": "#2322 disproved the old blanket 'repo-scoped title is enough' rationale for a TUI action that survives a modal: a killed/recreated row can reuse the title while the user's intent still names the prior stable session. Handoff, kill, and archive now carry one captured identity through modal, daemon dispatch, and completion. The remaining TUI mutations are still title-addressed and need an action-by-action audit; the CLI remains deliberately repo+title scoped because each invocation resolves and dispatches one command without retained UI intent."
     },
     {
       "id": "session.watch",
@@ -1722,7 +1722,7 @@
         },
         "tui": {
           "id": {
-            "gap": "wire.id-addressing"
+            "ok": "The TUI captures the selected session ID before confirmation and carries it through the daemon request and async completion."
           }
         }
       },
@@ -1734,7 +1734,7 @@
         },
         "tui": {
           "id": {
-            "gap": "wire.id-addressing"
+            "ok": "The TUI captures the selected session ID before confirmation and carries it through the daemon request and async completion."
           }
         }
       },

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -1719,22 +1719,12 @@
           "id": {
             "gap": "wire.id-addressing"
           }
-        },
-        "tui": {
-          "id": {
-            "ok": "The TUI captures the selected session ID before confirmation and carries it through the daemon request and async completion."
-          }
         }
       },
       "ArchiveSessionRequest": {
         "cli": {
           "id": {
             "gap": "wire.id-addressing"
-          }
-        },
-        "tui": {
-          "id": {
-            "ok": "The TUI captures the selected session ID before confirmation and carries it through the daemon request and async completion."
           }
         }
       },

--- a/ui/store/projection.go
+++ b/ui/store/projection.go
@@ -149,7 +149,9 @@ func (p *Projection) GetInstanceTitles() map[string]bool {
 // background sync may have removed the captured instance and rebuilt a fresh
 // same-title copy via FromInstanceData while the fetch was in flight (#765),
 // orphaning the original pointer. Re-resolving by title lands the update on
-// the instance that currently represents the session (#862).
+// the instance that currently represents the session (#862). It is NOT safe
+// for retained mutation intent: a title can be reused by a different session;
+// those flows capture and resolve sessionActionTarget in app (#2358).
 func (p *Projection) GetInstanceByTitle(title string) *session.Instance {
 	for _, inst := range p.instances {
 		if inst.Title == title {
@@ -350,11 +352,13 @@ func (p *Projection) ReplaceInstanceByTitle(title string, replacement *session.I
 	return false
 }
 
-// RemoveInstanceByTitle removes an instance by title without killing it (the
-// external process already cleaned up tmux/worktree).
-func (p *Projection) RemoveInstanceByTitle(title string) bool {
+// RemoveInstance removes target by pointer identity without killing it (the
+// external process already cleaned up tmux/worktree). Retained action
+// completions use this form so a new row that reused the title cannot inherit
+// the old session's removal (#2358).
+func (p *Projection) RemoveInstance(target *session.Instance) bool {
 	for i, inst := range p.instances {
-		if inst.Title == title {
+		if inst == target {
 			if inst.Started() {
 				repoName, err := inst.RepoName()
 				if err != nil {
@@ -371,18 +375,12 @@ func (p *Projection) RemoveInstanceByTitle(title string) bool {
 	return false
 }
 
-// RemoveInstanceByTitleWithRepo removes an instance by title using the
-// supplied repoName instead of calling RepoName() on the instance. This is
-// useful when the caller has already killed the instance (which causes
-// RepoName() to fail) but captured the repo name beforehand, ensuring the
-// repo count is still decremented correctly.
-func (p *Projection) RemoveInstanceByTitleWithRepo(title, repoName string) bool {
-	for i, inst := range p.instances {
+// RemoveInstanceByTitle removes an instance by title without killing it (the
+// external process already cleaned up tmux/worktree).
+func (p *Projection) RemoveInstanceByTitle(title string) bool {
+	for _, inst := range p.instances {
 		if inst.Title == title {
-			p.rmRepo(repoName)
-			p.instances = append(p.instances[:i], p.instances[i+1:]...)
-			p.bump()
-			return true
+			return p.RemoveInstance(inst)
 		}
 	}
 	return false


### PR DESCRIPTION
## Summary

- capture one immutable session target when kill/archive confirmation opens
- resolve that target by stable ID at confirmation and completion, with the shared non-zero `CreatedAt` policy for pre-ID handoff records
- send typed `KillSessionRequest` / `ArchiveSessionRequest` values carrying ID, title, and repo scope
- remove completion-by-title so an old RPC result cannot remove, archive, or clear the operation of a recreated same-title row
- remove the now-unused title-based projection removal helper and update derived parity evidence

## Reproduction

The fail-first tests replace the selected row with a different session carrying the same title at each retained boundary:

1. while kill/archive confirmation is open, confirming dispatches against and marks the replacement;
2. while the daemon RPC is in flight, the old success removes/archives the replacement;
3. an old failure can clear the replacement's own kill/archive operation.

Each case failed before the implementation and now fails closed by captured identity. Transport tests also prove both daemon requests receive the captured ID, title, and repo ID.

## Scope

This is the shared destructive-lifecycle slice of #2358. Handoff is fixed by #2360. Remaining ID-aware TUI mutations have different interaction lifetimes and stay as focused follow-ups under #2358: limit retry, tab create/close, and the actions whose wire request does not yet expose a session ID.

Part of #2358.

## Exact-head gates

Commit: `c7407fabd366a10020c0d0a0e9b7f1fc71c0fb1a`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (clean)
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh` (975 Go files, 0 grandfathered)
- `make test-container`

All passed on that exact pushed head.

— Captain Claude
