### PR TITLE
fix(schedule): recognize zero-padded hour presets

### DIFF
--- a/app/schedule_picker_leading_zero_test.go
+++ b/app/schedule_picker_leading_zero_test.go
@@ -1,0 +1,43 @@
+package app
+
+import (
+	"fmt"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/sachiniyer/agent-factory/task"
+	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTaskEditorRendersLeadingZeroEveryNHoursAsPreset(t *testing.T) {
+	for _, size := range []struct {
+		width  int
+		height int
+	}{{width: 80, height: 24}, {width: 72, height: 20}} {
+		t.Run(fmt.Sprintf("%dx%d", size.width, size.height), func(t *testing.T) {
+			h := newTestHome(t)
+			tasks := []task.Task{{
+				ID:       "leading-zero-hours",
+				Name:     "poller",
+				CronExpr: "00 */2 * * *",
+				Enabled:  true,
+			}}
+			h.store.SetTasks(tasks)
+			h.automations.TaskPane().SetTasks(tasks)
+			resizeHome(h, size.width, size.height)
+			h.focusRegion(layout.RegionAutomations)
+
+			_, _, consumed := h.handleAutomationsFocus(tea.KeyMsg{Type: tea.KeyEnter})
+			require.True(t, consumed)
+			require.True(t, h.automations.TaskPane().IsEditing())
+
+			frame := h.View()
+			requireViewSized(t, frame, size.width, size.height)
+			require.Contains(t, frame, "Every 2 hours",
+				"the production task editor must seed the semantic preset")
+			require.NotContains(t, frame, "Custom: 00 */2 * * *",
+				"the equivalent cron must not fall back to the raw editor")
+		})
+	}
+}

--- a/schedule/leading_zero_test.go
+++ b/schedule/leading_zero_test.go
@@ -1,0 +1,25 @@
+package schedule
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseCronEveryNHoursAcceptsLeadingZeroMinute(t *testing.T) {
+	got, ok := ParseCron("00 */2 * * *")
+
+	require.True(t, ok, "a numeric zero minute must select the every-N-hours preset")
+	require.Equal(t, Schedule{Type: EveryNHours, Interval: 2}, got)
+}
+
+func TestParseCronEveryNHoursRejectsNonzeroMinute(t *testing.T) {
+	for _, expr := range []string{"01 */2 * * *", "60 */2 * * *"} {
+		t.Run(expr, func(t *testing.T) {
+			got, ok := ParseCron(expr)
+
+			require.False(t, ok)
+			require.Equal(t, Schedule{Type: Custom, Raw: expr}, got)
+		})
+	}
+}

--- a/schedule/schedule.go
+++ b/schedule/schedule.go
@@ -111,9 +111,10 @@ func (s Schedule) Describe() string {
 }
 
 // ParseCron best-effort maps a 5-field cron expression back to a structured
-// Schedule. It recognizes exactly the shapes Cron emits — so a task saved by
-// the picker re-opens as its matching preset — plus a Sunday day-of-week alias
-// (7). Anything else (ranges, multi-value minute/hour fields, month
+// Schedule. It recognizes the shapes Cron emits — so a task saved by the
+// picker re-opens as its matching preset — plus equivalent zero-padded numeric
+// fields and a Sunday day-of-week alias (7). Anything else (ranges,
+// multi-value minute/hour fields, month
 // restrictions, step forms we don't emit, or a malformed expression) returns
 // {Type: Custom, Raw: expr} with ok=false, signalling the UI to fall back to
 // the raw-cron editor. It deliberately does NOT parse arbitrary cron.
@@ -133,9 +134,12 @@ func ParseCron(expr string) (Schedule, bool) {
 	if n, ok := stepOfStar(minute, 59); ok && hour == "*" && dom == "*" && dow == "*" {
 		return Schedule{Type: EveryNMinutes, Interval: n}, true
 	}
-	// every N hours: 0 */N * * * (N in 1-23)
-	if n, ok := stepOfStar(hour, 23); ok && minute == "0" && dom == "*" && dow == "*" {
-		return Schedule{Type: EveryNHours, Interval: n}, true
+	// every N hours: 0 */N * * * (N in 1-23). Parse the minute
+	// numerically so an equivalent zero-padded field selects the same preset.
+	if n, ok := stepOfStar(hour, 23); ok && dom == "*" && dow == "*" {
+		if m, ok := singleInt(minute, 0, 59); ok && m == 0 {
+			return Schedule{Type: EveryNHours, Interval: n}, true
+		}
 	}
 	// hourly: M * * * *
 	if m, ok := singleInt(minute, 0, 59); ok && hour == "*" && dom == "*" && dow == "*" {


### PR DESCRIPTION
## Summary

- parse the every-N-hours minute field numerically, so `00 */2 * * *` selects the same preset as `0 */2 * * *`
- keep nonzero and out-of-range minute fields in the Custom editor
- cover the production task editor through full root-TUI renders at 80×24 and 72×20

## Reproduction

Before the fix, the parser regression returned `Custom`, and the real task editor visibly rendered `Schedule: Custom (cron)` plus the raw expression at both required terminal sizes.

## Testing

- focused parser regression
- focused root-TUI rendering regression at 80×24 and 72×20
- `golangci-lint run --timeout=3m --fast`
- clean `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...` with no output
- `scripts/lint-file-length.sh`
- `make test-container`

Exact gated head: `60f012754c00e26ea6b5662429d7f11821686606`

Closes #2325
