### PR TITLE
fix(tui): retain limit retry session identity

### DIFF
--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -461,8 +461,8 @@ func (m *home) handleInstanceArchived(msg instanceArchivedMsg) (tea.Model, tea.C
 // (#1146, `c`). On success the daemon cleared the limit and re-delivered the
 // prompt; a non-nil err is surfaced in the error box.
 type limitRetriedMsg struct {
-	title string
-	err   error
+	target sessionActionTarget
+	err    error
 }
 
 // handleLimitRetry is the usage-limit manual-retry verb (#1146, `c`): on a
@@ -483,21 +483,21 @@ func (m *home) handleLimitRetry() (tea.Model, tea.Cmd) {
 	if !selected.LimitReached() {
 		return m, m.handleError(fmt.Errorf("session '%s' is not blocked on a usage limit", selected.Title))
 	}
-	return m, m.resumeFromLimitCmd(selected.Title)
+	target := captureSessionActionTarget(selected, m.repoID)
+	return m, m.resumeFromLimitCmd(target)
 }
 
 // resumeFromLimitCmd runs the daemon resume (re-spawn if needed + re-deliver the
 // prompt + clear the limit state) off the event loop (#1146), mirroring
 // restoreInstanceCmd.
-func (m *home) resumeFromLimitCmd(title string) tea.Cmd {
-	repoID := m.repoID
+func (m *home) resumeFromLimitCmd(target sessionActionTarget) tea.Cmd {
 	resume := resumeFromLimitThroughDaemon
 	return func() tea.Msg {
-		if err := resume(title, repoID); err != nil {
-			log.ErrorLog.Printf("could not resume limited session %q: %v", title, err)
-			return limitRetriedMsg{title: title, err: err}
+		if err := resume(target.resumeFromLimitRequest()); err != nil {
+			log.ErrorLog.Printf("could not resume limited session %q: %v", target.title, err)
+			return limitRetriedMsg{target: target, err: err}
 		}
-		return limitRetriedMsg{title: title}
+		return limitRetriedMsg{target: target}
 	}
 }
 
@@ -507,13 +507,10 @@ func (m *home) resumeFromLimitCmd(title string) tea.Cmd {
 // the next snapshot reconcile). On failure the error lands in the error box.
 func (m *home) handleLimitRetried(msg limitRetriedMsg) (tea.Model, tea.Cmd) {
 	if msg.err != nil {
-		return m, m.handleError(fmt.Errorf("failed to resume session '%s': %w", msg.title, msg.err))
+		return m, m.handleError(fmt.Errorf("failed to resume session '%s': %w", msg.target.title, msg.err))
 	}
-	for _, inst := range m.store.GetInstances() {
-		if inst.Title == msg.title {
-			inst.ClearLimitReached()
-			break
-		}
+	if inst := m.resolveSessionActionTarget(msg.target); inst != nil {
+		inst.ClearLimitReached()
 	}
 	return m, nil
 }

--- a/app/limit_action_test.go
+++ b/app/limit_action_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/session"
 )
 
@@ -35,7 +36,7 @@ func TestHandleLimitRetry_NonLimitRow_NoDispatch(t *testing.T) {
 	h.sidebar.SetSelectedInstance(0)
 
 	called := false
-	restore := SetLimitResumerForTest(func(string, string) error { called = true; return nil })
+	restore := SetLimitResumerForTest(func(daemon.ResumeFromLimitRequest) error { called = true; return nil })
 	defer restore()
 
 	_, _ = h.handleLimitRetry()
@@ -50,8 +51,11 @@ func TestHandleLimitRetry_LimitRow_Dispatches(t *testing.T) {
 	h.store.AddInstance(inst)
 	h.sidebar.SetSelectedInstance(0)
 
-	var gotTitle string
-	restore := SetLimitResumerForTest(func(title, _ string) error { gotTitle = title; return nil })
+	var gotRequest daemon.ResumeFromLimitRequest
+	restore := SetLimitResumerForTest(func(request daemon.ResumeFromLimitRequest) error {
+		gotRequest = request
+		return nil
+	})
 	defer restore()
 
 	_, cmd := h.handleLimitRetry()
@@ -60,7 +64,8 @@ func TestHandleLimitRetry_LimitRow_Dispatches(t *testing.T) {
 	done, ok := msg.(limitRetriedMsg)
 	require.True(t, ok, "the command must emit limitRetriedMsg")
 	require.NoError(t, done.err)
-	require.Equal(t, "worker", gotTitle, "the resume command must call the daemon for the selected title")
+	require.Equal(t, daemon.ResumeFromLimitRequest{ID: inst.ID, Title: inst.Title, RepoID: h.repoID}, gotRequest,
+		"the resume command must preserve the selected session's stable identity")
 }
 
 // A manual retry retains its target while the tea.Cmd waits to run. If a
@@ -73,9 +78,9 @@ func TestHandleLimitRetry_DoesNotTargetSameTitleReplacement(t *testing.T) {
 	h.store.AddInstance(original)
 	h.sidebar.SetSelectedInstance(0)
 
-	var deliveredTo *session.Instance
-	restore := SetLimitResumerForTest(func(title, _ string) error {
-		deliveredTo = h.store.GetInstanceByTitle(title)
+	var gotRequest daemon.ResumeFromLimitRequest
+	restore := SetLimitResumerForTest(func(request daemon.ResumeFromLimitRequest) error {
+		gotRequest = request
 		return nil
 	})
 	defer restore()
@@ -88,8 +93,10 @@ func TestHandleLimitRetry_DoesNotTargetSameTitleReplacement(t *testing.T) {
 	require.True(t, h.store.ReplaceInstance(original, replacement))
 
 	_ = cmd()
-	require.NotSame(t, replacement, deliveredTo,
-		"a pending retry must not re-deliver the original prompt into a same-title replacement")
+	require.Equal(t, original.ID, gotRequest.ID,
+		"the pending retry must retain the original session's stable ID")
+	require.NotEqual(t, replacement.ID, gotRequest.ID,
+		"a same-title replacement must not inherit the pending retry")
 }
 
 // TestHandleLimitRetry_TearingDownRow_NoDispatch: pressing c on a limit-blocked
@@ -103,7 +110,7 @@ func TestHandleLimitRetry_TearingDownRow_NoDispatch(t *testing.T) {
 	h.sidebar.SetSelectedInstance(0)
 
 	called := false
-	restore := SetLimitResumerForTest(func(string, string) error { called = true; return nil })
+	restore := SetLimitResumerForTest(func(daemon.ResumeFromLimitRequest) error { called = true; return nil })
 	defer restore()
 
 	_, cmd := h.handleLimitRetry()
@@ -116,12 +123,13 @@ func TestHandleLimitRetry_TearingDownRow_NoDispatch(t *testing.T) {
 // completion message (handled into the error box, limit state left intact).
 func TestResumeFromLimitCmd_SurfacesError(t *testing.T) {
 	h := newTestHome(t)
-	restore := SetLimitResumerForTest(func(string, string) error {
+	restore := SetLimitResumerForTest(func(daemon.ResumeFromLimitRequest) error {
 		return errors.New("session is not blocked on a usage limit")
 	})
 	defer restore()
 
-	msg := h.resumeFromLimitCmd("worker")()
+	target := sessionActionTarget{id: "worker-id", title: "worker", repoID: h.repoID}
+	msg := h.resumeFromLimitCmd(target)()
 	done, ok := msg.(limitRetriedMsg)
 	require.True(t, ok)
 	require.Error(t, done.err)
@@ -135,7 +143,8 @@ func TestHandleLimitRetried_ClearsLocally(t *testing.T) {
 	h.store.AddInstance(inst)
 	require.True(t, inst.LimitReached())
 
-	_, _ = h.handleLimitRetried(limitRetriedMsg{title: "worker"})
+	target := captureSessionActionTarget(inst, h.repoID)
+	_, _ = h.handleLimitRetried(limitRetriedMsg{target: target})
 	require.False(t, inst.LimitReached(), "a successful retry must clear the local limit state")
 }
 
@@ -143,12 +152,13 @@ func TestHandleLimitRetried_DoesNotClearSameTitleReplacement(t *testing.T) {
 	h := newTestHome(t)
 	original := limitActionInstance(t, "worker", time.Now().Add(time.Hour))
 	h.store.AddInstance(original)
+	target := captureSessionActionTarget(original, h.repoID)
 
 	replacement := limitActionInstance(t, original.Title, time.Now().Add(2*time.Hour))
 	require.NotEqual(t, original.ID, replacement.ID)
 	require.True(t, h.store.ReplaceInstance(original, replacement))
 
-	_, _ = h.handleLimitRetried(limitRetriedMsg{title: original.Title})
+	_, _ = h.handleLimitRetried(limitRetriedMsg{target: target})
 	require.True(t, replacement.LimitReached(),
 		"the old retry completion must not clear a same-title replacement's limit state")
 }
@@ -157,7 +167,8 @@ func TestHandleLimitRetried_NoOpKeepsLimitLocally(t *testing.T) {
 	h := newTestHome(t)
 	inst := limitActionInstance(t, "worker", time.Now().Add(time.Hour))
 	h.store.AddInstance(inst)
+	target := captureSessionActionTarget(inst, h.repoID)
 
-	_, _ = h.handleLimitRetried(limitRetriedMsg{title: "worker", err: errors.New("resume was not performed: another operation owns the retry")})
+	_, _ = h.handleLimitRetried(limitRetriedMsg{target: target, err: errors.New("resume was not performed: another operation owns the retry")})
 	require.True(t, inst.LimitReached(), "a daemon no-op must not clear the local limit state")
 }

--- a/app/limit_action_test.go
+++ b/app/limit_action_test.go
@@ -63,6 +63,35 @@ func TestHandleLimitRetry_LimitRow_Dispatches(t *testing.T) {
 	require.Equal(t, "worker", gotTitle, "the resume command must call the daemon for the selected title")
 }
 
+// A manual retry retains its target while the tea.Cmd waits to run. If a
+// snapshot replaces the selected row with a different session that reused the
+// title in that window, the pending retry must not deliver the old prompt into
+// the replacement.
+func TestHandleLimitRetry_DoesNotTargetSameTitleReplacement(t *testing.T) {
+	h := newTestHome(t)
+	original := limitActionInstance(t, "worker", time.Now().Add(time.Hour))
+	h.store.AddInstance(original)
+	h.sidebar.SetSelectedInstance(0)
+
+	var deliveredTo *session.Instance
+	restore := SetLimitResumerForTest(func(title, _ string) error {
+		deliveredTo = h.store.GetInstanceByTitle(title)
+		return nil
+	})
+	defer restore()
+
+	_, cmd := h.handleLimitRetry()
+	require.NotNil(t, cmd)
+
+	replacement := limitActionInstance(t, original.Title, time.Now().Add(2*time.Hour))
+	require.NotEqual(t, original.ID, replacement.ID)
+	require.True(t, h.store.ReplaceInstance(original, replacement))
+
+	_ = cmd()
+	require.NotSame(t, replacement, deliveredTo,
+		"a pending retry must not re-deliver the original prompt into a same-title replacement")
+}
+
 // TestHandleLimitRetry_TearingDownRow_NoDispatch: pressing c on a limit-blocked
 // row that is already being deleted must not race a resume RPC against teardown.
 func TestHandleLimitRetry_TearingDownRow_NoDispatch(t *testing.T) {
@@ -108,6 +137,20 @@ func TestHandleLimitRetried_ClearsLocally(t *testing.T) {
 
 	_, _ = h.handleLimitRetried(limitRetriedMsg{title: "worker"})
 	require.False(t, inst.LimitReached(), "a successful retry must clear the local limit state")
+}
+
+func TestHandleLimitRetried_DoesNotClearSameTitleReplacement(t *testing.T) {
+	h := newTestHome(t)
+	original := limitActionInstance(t, "worker", time.Now().Add(time.Hour))
+	h.store.AddInstance(original)
+
+	replacement := limitActionInstance(t, original.Title, time.Now().Add(2*time.Hour))
+	require.NotEqual(t, original.ID, replacement.ID)
+	require.True(t, h.store.ReplaceInstance(original, replacement))
+
+	_, _ = h.handleLimitRetried(limitRetriedMsg{title: original.Title})
+	require.True(t, replacement.LimitReached(),
+		"the old retry completion must not clear a same-title replacement's limit state")
 }
 
 func TestHandleLimitRetried_NoOpKeepsLimitLocally(t *testing.T) {

--- a/app/session_action_target.go
+++ b/app/session_action_target.go
@@ -66,3 +66,7 @@ func (target sessionActionTarget) handoffRequest(to string) daemon.HandoffSessio
 		ID: target.id, Title: target.title, RepoID: target.repoID, To: to,
 	}
 }
+
+func (target sessionActionTarget) resumeFromLimitRequest() daemon.ResumeFromLimitRequest {
+	return daemon.ResumeFromLimitRequest{ID: target.id, Title: target.title, RepoID: target.repoID}
+}

--- a/app/session_control.go
+++ b/app/session_control.go
@@ -191,9 +191,9 @@ var deleteProjectThroughDaemon = func(repoRoot, repoID string) (daemon.DeletePro
 // the agent if it exited, re-delivers the pending prompt, and clears the limit
 // state. A package var so the app test suite can stub it without dialing a real
 // daemon.
-var resumeFromLimitThroughDaemon = func(title, repoID string) error {
+var resumeFromLimitThroughDaemon = func(request daemon.ResumeFromLimitRequest) error {
 	return withDaemonHTTP(func(c *apiclient.Client) error {
-		return c.ResumeFromLimit(daemon.ResumeFromLimitRequest{Title: title, RepoID: repoID})
+		return c.ResumeFromLimit(request)
 	})
 }
 
@@ -458,7 +458,7 @@ func SetTaskRemoverForTest(f func(id string) error) func() {
 
 // SetLimitResumerForTest swaps the usage-limit resume seam (#1146) so a test can
 // assert the TUI routes `c` through the daemon — without dialing a real one.
-func SetLimitResumerForTest(f func(title, repoID string) error) func() {
+func SetLimitResumerForTest(f func(daemon.ResumeFromLimitRequest) error) func() {
 	prev := resumeFromLimitThroughDaemon
 	resumeFromLimitThroughDaemon = f
 	return func() { resumeFromLimitThroughDaemon = prev }

--- a/daemon/limit.go
+++ b/daemon/limit.go
@@ -235,8 +235,8 @@ type ResumeFromLimitRequest struct {
 	// is the PRIMARY lookup key: the daemon resolves the target by id first and
 	// only falls back to {Title, RepoID} when it is empty. Same contract as
 	// KillSessionRequest.ID — web clients send it so a duplicate title across
-	// repos cannot target the wrong session, TUI/CLI callers omit it and resolve
-	// by title.
+	// repos cannot target the wrong session. Retained TUI retries send it;
+	// one-shot CLI callers resolve by repo-scoped title.
 	//
 	// Added when this verb was promoted out of internalHTTPRoutes for the web
 	// (#1934). It is not decoration: the verb re-delivers a prompt into a pane, so

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -423,7 +423,7 @@
       "title": "Address a session by its stable id rather than by title",
       "tui": {
         "status": "partial",
-        "pointer": "app/session_action_target.go captures stable identity; handle_actions.go sends it for kill/archive and handle_handoff.go sends it for handoff"
+        "pointer": "app/session_action_target.go captures stable identity; handle_actions.go sends it for kill/archive/limit retry and handle_handoff.go sends it for handoff"
       },
       "web": {
         "status": "yes",
@@ -435,7 +435,7 @@
       },
       "verdict": "real-gap",
       "issue": "#2358",
-      "notes": "#2322 disproved the old blanket 'repo-scoped title is enough' rationale for a TUI action that survives a modal: a killed/recreated row can reuse the title while the user's intent still names the prior stable session. Handoff, kill, and archive now carry one captured identity through modal, daemon dispatch, and completion. The remaining TUI mutations are still title-addressed and need an action-by-action audit; the CLI remains deliberately repo+title scoped because each invocation resolves and dispatches one command without retained UI intent."
+      "notes": "#2322 disproved the old blanket 'repo-scoped title is enough' rationale for a TUI action that survives a modal or async command: a killed/recreated row can reuse the title while the user's intent still names the prior stable session. Handoff, kill, archive, and usage-limit retry now carry one captured identity through daemon dispatch and completion. The remaining TUI mutations are still title-addressed and need an action-by-action audit; the CLI remains deliberately repo+title scoped because each invocation resolves and dispatches one command without retained UI intent."
     },
     {
       "id": "session.watch",
@@ -1870,11 +1870,6 @@
         "cli": {
           "id": {
             "ok": "The CLI resolves sessions by title under --repo scoping, exactly as kill/archive/send-prompt do; the stable id is the all-project web client's collision-proof key."
-          }
-        },
-        "tui": {
-          "id": {
-            "gap": "wire.id-addressing"
           }
         }
       },


### PR DESCRIPTION
## Summary

- capture the selected session's immutable identity when a manual usage-limit retry begins
- send one typed `ResumeFromLimitRequest` carrying stable ID, title, and repo scope
- carry the same target through async completion so an old success cannot clear a recreated same-title row's limit state
- remove the TUI's `ResumeFromLimitRequest.id` parity exception and update the wire contract commentary

## Reproduction

Two fail-first tests replace the selected usage-limited row with a different session carrying the same title while the retry is retained:

1. before the queued command runs, the old title-only request resolves to the replacement and can re-deliver the original pending prompt into it;
2. before completion lands, the old success clears the replacement's own usage-limit badge by title.

Both failed before the implementation. The retry now sends the original stable ID, and completion re-resolves only that captured identity. The ordinary path also proves the daemon request receives ID, title, and repo ID from one constructor.

## Scope

This is the async usage-limit retry slice of #2358. It is separate from the merged confirmation lifecycle slice (#2366) because it has no modal or optimistic teardown operation; its retained boundaries are queued prompt delivery and completion. Tab create/close remain a separate picker/tab-identity slice.

Part of #2358.

## Exact-head gates

Commit: `bf137f39ab3f193ba0d6ec8f1fd4a7d3d9349ef2`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (clean)
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh` (977 Go files, 0 grandfathered)
- `make test-container`

All passed on that exact pushed head.

— Captain Claude
