### PR TITLE
feat(upgrade): add durable recovery launch gate

### DIFF
--- a/internal/upgradetxn/entrypoint.go
+++ b/internal/upgradetxn/entrypoint.go
@@ -1,0 +1,214 @@
+package upgradetxn
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+)
+
+const (
+	defaultEntrypointTakeoverTimeout = 5 * time.Second
+	defaultEntrypointPollInterval    = 50 * time.Millisecond
+)
+
+// UpgradeInProgressError is the typed result for a kernel-live recovery
+// actor. Normal entrypoints must not start a daemon over this transaction.
+type UpgradeInProgressError struct {
+	TransactionID string
+	ToVersion     string
+	Phase         Phase
+	Deadline      time.Time
+}
+
+func (e *UpgradeInProgressError) Error() string {
+	if e.Deadline.IsZero() {
+		return fmt.Sprintf(
+			"daemon upgrade to %s is in progress (transaction %s, phase %s; recovery actor is starting)",
+			e.ToVersion, e.TransactionID, e.Phase,
+		)
+	}
+	return fmt.Sprintf(
+		"daemon upgrade to %s is in progress (transaction %s, phase %s, recovery deadline %s)",
+		e.ToVersion, e.TransactionID, e.Phase, e.Deadline.Format(time.RFC3339Nano),
+	)
+}
+
+// UpgradeRecoveryBlockedError is a hard fail-closed result. It prevents an
+// ordinary daemon from starting when recovery identity, takeover, or the
+// rollback circuit breaker cannot be proven safe.
+type UpgradeRecoveryBlockedError struct {
+	TransactionID string
+	ToVersion     string
+	Phase         Phase
+	Reason        string
+}
+
+func (e *UpgradeRecoveryBlockedError) Error() string {
+	return fmt.Sprintf(
+		"daemon upgrade recovery for %s is blocked (transaction %s, phase %s): %s; "+
+			"no daemon was started; run af doctor --fix",
+		e.ToVersion, e.TransactionID, e.Phase, e.Reason,
+	)
+}
+
+// EntrypointGate is the all-entrypoint decision boundary for an active
+// transaction. It never acquires recovery authority itself. If the flock is
+// free, it wakes the immutable previous binary and waits only for that actor
+// to take the flock or finish cleanup.
+type EntrypointGate struct {
+	WakeRecovery    func(context.Context, *Transaction) error
+	Now             func() time.Time
+	Sleep           func(context.Context, time.Duration) error
+	TakeoverTimeout time.Duration
+	PollInterval    time.Duration
+}
+
+// Check returns nil only when no active transaction remains. Every other
+// result forbids normal command/daemon startup until the previous-binary actor
+// commits, rolls back, or cleans up the journal.
+func (g EntrypointGate) Check(ctx context.Context, homeDir string) error {
+	if _, err := os.Stat(homeDir); errors.Is(err, os.ErrNotExist) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("inspect AF home before upgrade entrypoint gate: %w", err)
+	}
+	txn, err := Load(homeDir)
+	if errors.Is(err, ErrNoActiveTransaction) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect active daemon upgrade before entrypoint startup: %w", err)
+	}
+	journal := txn.Journal()
+	if journal.Phase == PhaseRollbackFailed {
+		return blockedRecovery(journal, "automatic rollback reached the rollback_failed circuit breaker")
+	}
+
+	live, err := txn.RecoveryActorLive()
+	if err != nil {
+		return blockedRecovery(journal, fmt.Sprintf("cannot prove recovery actor liveness: %v", err))
+	}
+	if live {
+		return g.liveRecoveryResult(journal)
+	}
+
+	wake := g.WakeRecovery
+	if wake == nil {
+		controller := RecoveryJobController{}
+		wake = controller.Wake
+	}
+	if err := wake(ctx, txn); err != nil && !errors.Is(err, ErrRecoveryActive) {
+		return blockedRecovery(journal, fmt.Sprintf("could not wake the preserved previous binary: %v", err))
+	}
+
+	timeout := g.TakeoverTimeout
+	if timeout <= 0 {
+		timeout = defaultEntrypointTakeoverTimeout
+	}
+	deadline := g.now().Add(timeout)
+	for {
+		current, loadErr := Load(homeDir)
+		if errors.Is(loadErr, ErrNoActiveTransaction) {
+			return nil
+		}
+		if loadErr != nil {
+			return blockedRecovery(journal, fmt.Sprintf("cannot reload recovery journal after wake: %v", loadErr))
+		}
+		currentJournal := current.Journal()
+		if currentJournal.ID != journal.ID {
+			return blockedRecovery(currentJournal, "active transaction changed during recovery takeover")
+		}
+		if currentJournal.Phase == PhaseRollbackFailed {
+			return blockedRecovery(currentJournal,
+				"automatic rollback reached the rollback_failed circuit breaker")
+		}
+		live, liveErr := current.RecoveryActorLive()
+		if liveErr != nil {
+			return blockedRecovery(currentJournal,
+				fmt.Sprintf("cannot prove recovery actor liveness after wake: %v", liveErr))
+		}
+		if live {
+			return g.liveRecoveryResult(currentJournal)
+		}
+		if !g.now().Before(deadline) {
+			return blockedRecovery(currentJournal,
+				"the preserved previous binary did not acquire the recovery lock")
+		}
+		if err := g.sleep(ctx, g.pollInterval()); err != nil {
+			return err
+		}
+	}
+}
+
+func (g EntrypointGate) liveRecoveryResult(journal Journal) error {
+	status, err := ReadRecoveryStatus(journal.HomeDir)
+	if err != nil {
+		if errors.Is(err, ErrNoActiveTransaction) {
+			return nil
+		}
+		if errors.Is(err, os.ErrNotExist) {
+			return &UpgradeInProgressError{
+				TransactionID: journal.ID,
+				ToVersion:     journal.ToVersion,
+				Phase:         journal.Phase,
+			}
+		}
+		return blockedRecovery(journal,
+			fmt.Sprintf("a live recovery actor has an invalid identity record: %v", err))
+	}
+	if status.TransactionID != journal.ID || status.Nonce != journal.RecoveryNonce {
+		return blockedRecovery(journal,
+			"the live recovery identity changed while the entrypoint was checking it")
+	}
+	if !g.now().Before(status.Deadline) {
+		return blockedRecovery(journal, fmt.Sprintf(
+			"the recovery deadline %s expired but its actor still owns the recovery lock",
+			status.Deadline.Format(time.RFC3339Nano),
+		))
+	}
+	return &UpgradeInProgressError{
+		TransactionID: journal.ID,
+		ToVersion:     journal.ToVersion,
+		Phase:         status.Phase,
+		Deadline:      status.Deadline,
+	}
+}
+
+func blockedRecovery(journal Journal, reason string) error {
+	return &UpgradeRecoveryBlockedError{
+		TransactionID: journal.ID,
+		ToVersion:     journal.ToVersion,
+		Phase:         journal.Phase,
+		Reason:        reason,
+	}
+}
+
+func (g EntrypointGate) now() time.Time {
+	if g.Now != nil {
+		return g.Now()
+	}
+	return time.Now().UTC()
+}
+
+func (g EntrypointGate) pollInterval() time.Duration {
+	if g.PollInterval > 0 {
+		return g.PollInterval
+	}
+	return defaultEntrypointPollInterval
+}
+
+func (g EntrypointGate) sleep(ctx context.Context, duration time.Duration) error {
+	if g.Sleep != nil {
+		return g.Sleep(ctx, duration)
+	}
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/upgradetxn/entrypoint_test.go
+++ b/internal/upgradetxn/entrypoint_test.go
@@ -1,0 +1,186 @@
+package upgradetxn
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEntrypointGateProceedsWhenNoTransactionExists(t *testing.T) {
+	home := t.TempDir()
+	wakeCalls := 0
+	gate := EntrypointGate{
+		WakeRecovery: func(context.Context, *Transaction) error {
+			wakeCalls++
+			return nil
+		},
+	}
+
+	require.NoError(t, gate.Check(context.Background(), home))
+	require.Zero(t, wakeCalls)
+}
+
+func TestEntrypointGateProceedsBeforeAFirstRunHomeExists(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "not-created-yet")
+	wakeCalls := 0
+	gate := EntrypointGate{
+		WakeRecovery: func(context.Context, *Transaction) error {
+			wakeCalls++
+			return nil
+		},
+	}
+
+	require.NoError(t, gate.Check(context.Background(), home))
+	require.Zero(t, wakeCalls)
+}
+
+func TestEntrypointGateReportsFreshLiveRecoveryWithoutWakingARival(t *testing.T) {
+	txn, home, _ := prepareFixture(t)
+	lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+	defer lease.Release()
+	now := time.Date(2026, 7, 22, 1, 2, 3, 0, time.UTC)
+	require.NoError(t, lease.Heartbeat(PhasePrepared, now.Add(time.Minute)))
+	wakeCalls := 0
+	gate := EntrypointGate{
+		Now: func() time.Time { return now },
+		WakeRecovery: func(context.Context, *Transaction) error {
+			wakeCalls++
+			return nil
+		},
+	}
+
+	err = gate.Check(context.Background(), home)
+	var inProgress *UpgradeInProgressError
+	require.ErrorAs(t, err, &inProgress)
+	require.Equal(t, PhasePrepared, inProgress.Phase)
+	require.Equal(t, txn.Journal().ToVersion, inProgress.ToVersion)
+	require.Zero(t, wakeCalls)
+}
+
+func TestEntrypointGateTreatsFlockAsLifeEvenAfterHeartbeatDeadline(t *testing.T) {
+	txn, home, _ := prepareFixture(t)
+	lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+	defer lease.Release()
+	now := time.Date(2026, 7, 22, 1, 2, 3, 0, time.UTC)
+	require.NoError(t, lease.Heartbeat(PhaseCandidateValidating, now.Add(-time.Second)))
+	wakeCalls := 0
+	gate := EntrypointGate{
+		Now: func() time.Time { return now },
+		WakeRecovery: func(context.Context, *Transaction) error {
+			wakeCalls++
+			return nil
+		},
+	}
+
+	err = gate.Check(context.Background(), home)
+	var blocked *UpgradeRecoveryBlockedError
+	require.ErrorAs(t, err, &blocked)
+	require.ErrorContains(t, err, "still owns the recovery lock")
+	require.Zero(t, wakeCalls,
+		"an expired timestamp is never authority to start or signal another actor")
+}
+
+func TestEntrypointGateWakesPreviousBinaryAfterKernelProvesActorDeath(t *testing.T) {
+	txn, home, _ := prepareFixture(t)
+	var takeover *RecoveryLease
+	wakeCalls := 0
+	gate := EntrypointGate{
+		Now: func() time.Time { return time.Now().UTC() },
+		WakeRecovery: func(_ context.Context, loaded *Transaction) error {
+			wakeCalls++
+			var err error
+			takeover, err = loaded.tryAcquireRecoveryAs(loaded.Journal().PreviousBinaryPath)
+			if err != nil {
+				return err
+			}
+			return takeover.Heartbeat(loaded.Journal().Phase, time.Now().Add(time.Minute))
+		},
+	}
+	defer func() {
+		if takeover != nil {
+			require.NoError(t, takeover.Release())
+		}
+	}()
+
+	err := gate.Check(context.Background(), home)
+	var inProgress *UpgradeInProgressError
+	require.ErrorAs(t, err, &inProgress)
+	require.Equal(t, 1, wakeCalls)
+	require.Equal(t, txn.Journal().ID, inProgress.TransactionID)
+}
+
+func TestEntrypointGateLosingTakeoverRaceObservesWinner(t *testing.T) {
+	_, home, _ := prepareFixture(t)
+	var winner *RecoveryLease
+	wakeCalls := 0
+	gate := EntrypointGate{
+		WakeRecovery: func(_ context.Context, loaded *Transaction) error {
+			wakeCalls++
+			var err error
+			winner, err = loaded.tryAcquireRecoveryAs(loaded.Journal().PreviousBinaryPath)
+			if err != nil {
+				return err
+			}
+			return winner.Heartbeat(loaded.Journal().Phase, time.Now().Add(time.Minute))
+		},
+	}
+	defer func() {
+		if winner != nil {
+			require.NoError(t, winner.Release())
+		}
+	}()
+
+	err := gate.Check(context.Background(), home)
+	require.Error(t, err)
+	require.True(t, errors.As(err, new(*UpgradeInProgressError)))
+	require.Equal(t, 1, wakeCalls)
+	// A second entrant sees the winner's flock and never launches again.
+	err = gate.Check(context.Background(), home)
+	require.Error(t, err)
+	require.Equal(t, 1, wakeCalls)
+}
+
+func TestEntrypointGateDoesNotRestartTerminalRollbackFailure(t *testing.T) {
+	txn, home, _ := prepareFixture(t)
+	lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+	require.NoError(t, lease.Advance(PhaseSupervisorReady))
+	require.NoError(t, lease.Advance(PhaseDaemonStopping))
+	require.NoError(t, lease.Advance(PhaseDaemonStopped))
+	require.NoError(t, lease.Rollback())
+	require.NoError(t, lease.MarkRollbackFailed())
+	require.NoError(t, lease.Release())
+	wakeCalls := 0
+	gate := EntrypointGate{
+		WakeRecovery: func(context.Context, *Transaction) error {
+			wakeCalls++
+			return nil
+		},
+	}
+
+	err = gate.Check(context.Background(), home)
+	var blocked *UpgradeRecoveryBlockedError
+	require.ErrorAs(t, err, &blocked)
+	require.ErrorContains(t, err, "rollback_failed")
+	require.ErrorContains(t, err, "af doctor --fix")
+	require.Zero(t, wakeCalls, "the terminal circuit breaker must stop automatic recovery")
+}
+
+func TestEntrypointGateFailsClosedWhenWakeDoesNotTakeTheLock(t *testing.T) {
+	_, home, _ := prepareFixture(t)
+	gate := EntrypointGate{
+		TakeoverTimeout: time.Nanosecond,
+		WakeRecovery:    func(context.Context, *Transaction) error { return nil },
+	}
+
+	err := gate.Check(context.Background(), home)
+	var blocked *UpgradeRecoveryBlockedError
+	require.ErrorAs(t, err, &blocked)
+	require.ErrorContains(t, err, "did not acquire the recovery lock")
+}

--- a/internal/upgradetxn/recovery_actor.go
+++ b/internal/upgradetxn/recovery_actor.go
@@ -1,0 +1,106 @@
+package upgradetxn
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+)
+
+// RecoveryInvocation is the strict internal command rendered into persistent
+// recovery jobs. HomeDir and TransactionID are both checked against the active
+// journal before the process attempts to acquire recovery authority.
+type RecoveryInvocation struct {
+	HomeDir       string
+	TransactionID string
+}
+
+// ParseRecoveryInvocation recognizes only the exact argument vector emitted
+// by recoveryCommand. matched is false for every ordinary af invocation, so a
+// caller can perform this check before Cobra or config startup without
+// reinterpreting public commands.
+func ParseRecoveryInvocation(args []string) (invocation RecoveryInvocation, matched bool, err error) {
+	if len(args) == 0 || args[0] != recoveryModeArgument {
+		return RecoveryInvocation{}, false, nil
+	}
+	if len(args) != 5 || args[1] != "--home" || args[3] != "--transaction" {
+		return RecoveryInvocation{}, true, errors.New("invalid internal upgrade recovery arguments")
+	}
+	home := args[2]
+	if strings.TrimSpace(home) == "" || !filepath.IsAbs(home) || filepath.Clean(home) != home {
+		return RecoveryInvocation{}, true, errors.New("internal upgrade recovery home must be absolute and canonical")
+	}
+	if err := validateTransactionID(args[4]); err != nil {
+		return RecoveryInvocation{}, true, err
+	}
+	return RecoveryInvocation{HomeDir: home, TransactionID: args[4]}, true, nil
+}
+
+// RunRecoveryActor loads the named transaction, obtains recovery authority as
+// os.Executable (which TryAcquireRecovery requires to be the immutable
+// previous-binary artifact), and runs the supervisor. A duplicate launcher
+// exits successfully after losing the flock so Restart=on-failure does not
+// turn an ordinary service-manager race into a process storm.
+func RunRecoveryActor(ctx context.Context, invocation RecoveryInvocation, supervisor Supervisor) error {
+	return runRecoveryActorWith(
+		ctx,
+		invocation,
+		func(txn *Transaction) (*RecoveryLease, error) { return txn.TryAcquireRecovery() },
+		supervisor.Run,
+	)
+}
+
+func runRecoveryActorWith(
+	ctx context.Context,
+	invocation RecoveryInvocation,
+	acquire func(*Transaction) (*RecoveryLease, error),
+	supervise func(context.Context, *Transaction, *RecoveryLease) error,
+) (retErr error) {
+	if acquire == nil || supervise == nil {
+		return errors.New("upgrade recovery actor requires acquisition and supervision operations")
+	}
+	txn, err := Load(invocation.HomeDir)
+	if errors.Is(err, ErrNoActiveTransaction) {
+		// A disabled job may receive one final runtime restart after cleanup
+		// removed active.json. There is no recovery authority left; exit 0 so
+		// Restart=on-failure cannot turn that harmless tail into a loop.
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	journal := txn.Journal()
+	if journal.ID != invocation.TransactionID {
+		// A stale transaction-named job has no authority over the newer active
+		// transaction and must stand down cleanly instead of restart-looping.
+		return nil
+	}
+	lease, err := acquire(txn)
+	if errors.Is(err, ErrRecoveryActive) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if lease == nil {
+		return errors.New("upgrade recovery acquisition returned no lease")
+	}
+	defer func() { retErr = errors.Join(retErr, lease.Release()) }()
+
+	err = supervise(ctx, txn, lease)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, ErrRecoveryJobDisableFailed) {
+		return err
+	}
+	if errors.Is(err, ErrUpgradeAborted) ||
+		errors.Is(err, ErrUpgradeRolledBack) ||
+		errors.Is(err, ErrRollbackRecoveryFailed) {
+		// Each expected terminal result is returned by Supervisor only after
+		// the persistent job was disarmed. Exit 0 so the loaded unit's runtime
+		// Restart policy cannot undo that circuit breaker.
+		return nil
+	}
+	return err
+}

--- a/internal/upgradetxn/recovery_actor.go
+++ b/internal/upgradetxn/recovery_actor.go
@@ -36,20 +36,10 @@ func ParseRecoveryInvocation(args []string) (invocation RecoveryInvocation, matc
 	return RecoveryInvocation{HomeDir: home, TransactionID: args[4]}, true, nil
 }
 
-// RunRecoveryActor loads the named transaction, obtains recovery authority as
-// os.Executable (which TryAcquireRecovery requires to be the immutable
-// previous-binary artifact), and runs the supervisor. A duplicate launcher
-// exits successfully after losing the flock so Restart=on-failure does not
-// turn an ordinary service-manager race into a process storm.
-func RunRecoveryActor(ctx context.Context, invocation RecoveryInvocation, supervisor Supervisor) error {
-	return runRecoveryActorWith(
-		ctx,
-		invocation,
-		func(txn *Transaction) (*RecoveryLease, error) { return txn.TryAcquireRecovery() },
-		supervisor.Run,
-	)
-}
-
+// runRecoveryActorWith is the runner core for the later production entrypoint
+// binding. The binding must supply TryAcquireRecovery (which derives identity
+// from os.Executable) and Supervisor.Run together; keeping that wrapper out of
+// this production-disabled slice avoids publishing an unreachable API.
 func runRecoveryActorWith(
 	ctx context.Context,
 	invocation RecoveryInvocation,

--- a/internal/upgradetxn/recovery_actor_test.go
+++ b/internal/upgradetxn/recovery_actor_test.go
@@ -1,0 +1,133 @@
+package upgradetxn
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecoveryInvocationParserAcceptsOnlyExactInternalShape(t *testing.T) {
+	invocation, matched, err := ParseRecoveryInvocation([]string{
+		recoveryModeArgument,
+		"--home", "/tmp/af home",
+		"--transaction", "txn-2212",
+	})
+	require.NoError(t, err)
+	require.True(t, matched)
+	require.Equal(t, RecoveryInvocation{
+		HomeDir:       "/tmp/af home",
+		TransactionID: "txn-2212",
+	}, invocation)
+
+	_, matched, err = ParseRecoveryInvocation([]string{"sessions", "list"})
+	require.NoError(t, err)
+	require.False(t, matched)
+
+	for _, args := range [][]string{
+		{recoveryModeArgument},
+		{recoveryModeArgument, "--home", "/tmp/home", "--transaction", "../escape"},
+		{recoveryModeArgument, "--transaction", "txn", "--home", "/tmp/home"},
+		{recoveryModeArgument, "--home", "", "--transaction", "txn"},
+	} {
+		_, matched, err = ParseRecoveryInvocation(args)
+		require.True(t, matched)
+		require.Error(t, err)
+	}
+}
+
+func TestRecoveryActorRunnerStandsDownWhenAnotherActorWon(t *testing.T) {
+	txn, home, _ := prepareFixture(t)
+	invocation := RecoveryInvocation{HomeDir: home, TransactionID: txn.Journal().ID}
+	superviseCalls := 0
+
+	err := runRecoveryActorWith(
+		context.Background(), invocation,
+		func(*Transaction) (*RecoveryLease, error) { return nil, ErrRecoveryActive },
+		func(context.Context, *Transaction, *RecoveryLease) error {
+			superviseCalls++
+			return nil
+		},
+	)
+
+	require.NoError(t, err,
+		"a service-manager duplicate must exit successfully instead of entering Restart=on-failure")
+	require.Zero(t, superviseCalls)
+}
+
+func TestRecoveryActorRunnerStandsDownForStaleTransactionBeforeAcquiring(t *testing.T) {
+	_, home, _ := prepareFixture(t)
+	acquireCalls := 0
+	err := runRecoveryActorWith(
+		context.Background(),
+		RecoveryInvocation{HomeDir: home, TransactionID: "different-transaction"},
+		func(*Transaction) (*RecoveryLease, error) {
+			acquireCalls++
+			return nil, nil
+		},
+		func(context.Context, *Transaction, *RecoveryLease) error { return nil },
+	)
+
+	require.NoError(t, err,
+		"a stale transaction job must not enter its service manager's restart policy")
+	require.Zero(t, acquireCalls)
+}
+
+func TestRecoveryActorRunnerExitsCleanlyAfterJournalCleanup(t *testing.T) {
+	home := t.TempDir()
+	acquireCalls := 0
+	err := runRecoveryActorWith(
+		context.Background(),
+		RecoveryInvocation{HomeDir: home, TransactionID: "already-cleaned"},
+		func(*Transaction) (*RecoveryLease, error) {
+			acquireCalls++
+			return nil, nil
+		},
+		func(context.Context, *Transaction, *RecoveryLease) error { return nil },
+	)
+
+	require.NoError(t, err)
+	require.Zero(t, acquireCalls)
+}
+
+func TestRecoveryActorRunnerMapsOnlyDisarmedTerminalOutcomesToCleanExit(t *testing.T) {
+	tests := []struct {
+		name      string
+		runErr    error
+		wantError bool
+	}{
+		{name: "commit", runErr: nil},
+		{name: "abort", runErr: ErrUpgradeAborted},
+		{name: "rollback", runErr: ErrUpgradeRolledBack},
+		{name: "rollback failed circuit breaker", runErr: ErrRollbackRecoveryFailed},
+		{
+			name:      "circuit breaker could not disable job",
+			runErr:    errors.Join(ErrRollbackRecoveryFailed, ErrRecoveryJobDisableFailed),
+			wantError: true,
+		},
+		{name: "ordinary supervisor failure", runErr: errors.New("health probe failed"), wantError: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			txn, home, _ := prepareFixture(t)
+			invocation := RecoveryInvocation{HomeDir: home, TransactionID: txn.Journal().ID}
+			lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+			require.NoError(t, err)
+
+			err = runRecoveryActorWith(
+				context.Background(), invocation,
+				func(*Transaction) (*RecoveryLease, error) { return lease, nil },
+				func(context.Context, *Transaction, *RecoveryLease) error { return tc.runErr },
+			)
+			if tc.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			live, liveErr := txn.RecoveryActorLive()
+			require.NoError(t, liveErr)
+			require.False(t, live, "runner must release the flock on every exit path")
+		})
+	}
+}

--- a/internal/upgradetxn/recovery_job.go
+++ b/internal/upgradetxn/recovery_job.go
@@ -1,0 +1,477 @@
+package upgradetxn
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"html"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// recoveryModeArgument is intentionally not a Cobra flag or public command.
+// The previous-binary entrypoint consumes it before normal command startup;
+// candidates may wake this exact command but cannot acquire its RecoveryLease.
+const recoveryModeArgument = "__upgrade-recovery"
+
+const recoveryUnitMode = 0o600
+
+// RecoveryJobController owns only the platform launcher around the recovery
+// state machine. Supervisor owns all daemon and transaction decisions. The
+// seams keep tests from invoking the host's service manager or starting a
+// process, while zero values use the real platform operations.
+type RecoveryJobController struct {
+	RunCommand    func(context.Context, string, ...string) error
+	StartDetached func(string, ...string) error
+	UserID        func() int
+}
+
+// InstallAndStart publishes the transaction-scoped persistent launcher and
+// starts the immutable previous-binary actor. It is valid only before the
+// daemon begins shutdown. Once published, an exact unit remains recovery
+// state even when the service-manager call reports an ambiguous failure.
+func (c RecoveryJobController) InstallAndStart(ctx context.Context, txn *Transaction) error {
+	journal, err := currentRecoveryJournal(txn)
+	if err != nil {
+		return err
+	}
+	if journal.Phase != PhasePrepared {
+		return fmt.Errorf("cannot install upgrade recovery job in phase %s", journal.Phase)
+	}
+	if err := verifyRecoveryActorArtifact(journal); err != nil {
+		return err
+	}
+	live, err := txn.RecoveryActorLive()
+	if err != nil {
+		return err
+	}
+	if live {
+		return nil
+	}
+
+	switch journal.RecoveryJob.Kind {
+	case RecoveryJobDetached:
+		return c.startDetached(journal)
+	case RecoveryJobSystemd:
+		_, err := ensureExactRecoveryUnit(
+			journal.RecoveryJob.UnitPath, []byte(renderSystemdRecoveryUnit(journal)))
+		if err != nil {
+			return err
+		}
+		if err := c.run(ctx, "systemctl", "--user", "daemon-reload"); err != nil {
+			return fmt.Errorf("reload systemd recovery job: %w", err)
+		}
+		if err := c.run(ctx, "systemctl", "--user", "enable", "--now", journal.RecoveryJob.Name); err != nil {
+			return fmt.Errorf("enable systemd recovery job: %w", err)
+		}
+		return nil
+	case RecoveryJobLaunchd:
+		_, err := ensureExactRecoveryUnit(
+			journal.RecoveryJob.UnitPath, []byte(renderLaunchdRecoveryPlist(journal)))
+		if err != nil {
+			return err
+		}
+		return c.armAndStartLaunchd(ctx, journal)
+	default:
+		return fmt.Errorf("unsupported upgrade recovery job kind %q", journal.RecoveryJob.Kind)
+	}
+}
+
+// Wake asks the journaled launcher to start an inactive recovery actor. It
+// never uses restart, kickstart -k, or another operation that can replace a
+// live owner. The flock is checked first, then the service manager arbitrates
+// the unavoidable probe-to-start race.
+func (c RecoveryJobController) Wake(ctx context.Context, txn *Transaction) error {
+	journal, err := currentRecoveryJournal(txn)
+	if err != nil {
+		return err
+	}
+	if journal.Phase == PhaseRollbackFailed {
+		return ErrRollbackRecoveryFailed
+	}
+	if err := verifyRecoveryActorArtifact(journal); err != nil {
+		return err
+	}
+	live, err := txn.RecoveryActorLive()
+	if err != nil {
+		return err
+	}
+	if live {
+		return ErrRecoveryActive
+	}
+
+	switch journal.RecoveryJob.Kind {
+	case RecoveryJobDetached:
+		return c.startDetached(journal)
+	case RecoveryJobSystemd:
+		_, err := ensureExactRecoveryUnit(
+			journal.RecoveryJob.UnitPath, []byte(renderSystemdRecoveryUnit(journal)))
+		if err != nil {
+			return err
+		}
+		// The unit file may have survived a process death before daemon-reload,
+		// or the job may have been disabled immediately before cleanup died.
+		// File existence therefore proves neither registration nor enablement.
+		if err := c.run(ctx, "systemctl", "--user", "daemon-reload"); err != nil {
+			return fmt.Errorf("reload systemd recovery job for takeover: %w", err)
+		}
+		if err := c.run(ctx, "systemctl", "--user", "enable", journal.RecoveryJob.Name); err != nil {
+			return fmt.Errorf("enable systemd recovery job for takeover: %w", err)
+		}
+		if err := c.run(ctx, "systemctl", "--user", "start", journal.RecoveryJob.Name); err != nil {
+			return fmt.Errorf("start systemd recovery job for takeover: %w", err)
+		}
+		return nil
+	case RecoveryJobLaunchd:
+		_, err := ensureExactRecoveryUnit(
+			journal.RecoveryJob.UnitPath, []byte(renderLaunchdRecoveryPlist(journal)))
+		if err != nil {
+			return err
+		}
+		return c.armAndStartLaunchd(ctx, journal)
+	default:
+		return fmt.Errorf("unsupported upgrade recovery job kind %q", journal.RecoveryJob.Kind)
+	}
+}
+
+// Disable disarms restart without stopping the current recovery actor. The
+// actor still owns the flock and must remove the active journal afterward, so
+// systemctl --now and launchctl bootout are deliberately forbidden by shape.
+// Transaction cleanup removes the exact unit only after active.json is gone.
+func (c RecoveryJobController) Disable(ctx context.Context, journal Journal) error {
+	current, err := currentJournalCopy(journal)
+	if err != nil {
+		return err
+	}
+	if !terminalPhase(current.Phase) && current.Phase != PhaseRollbackFailed {
+		return fmt.Errorf("cannot disable upgrade recovery job in phase %s", current.Phase)
+	}
+
+	switch current.RecoveryJob.Kind {
+	case RecoveryJobDetached:
+		return nil
+	case RecoveryJobSystemd:
+		if err := c.run(ctx, "systemctl", "--user", "disable", current.RecoveryJob.Name); err != nil {
+			return fmt.Errorf("disable systemd recovery job: %w", err)
+		}
+		return nil
+	case RecoveryJobLaunchd:
+		target := launchdRecoveryDomain(c.userID()) + "/" + current.RecoveryJob.Name
+		if err := c.run(ctx, "launchctl", "disable", target); err != nil {
+			return fmt.Errorf("disable launchd recovery job: %w", err)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported upgrade recovery job kind %q", current.RecoveryJob.Kind)
+	}
+}
+
+func currentRecoveryJournal(txn *Transaction) (Journal, error) {
+	if txn == nil {
+		return Journal{}, errors.New("upgrade recovery job requires a transaction")
+	}
+	return currentJournalCopy(txn.Journal())
+}
+
+func currentJournalCopy(expected Journal) (Journal, error) {
+	if err := validateRecoveryJob(expected.ID, expected.RecoveryJob); err != nil {
+		return Journal{}, err
+	}
+	loaded, err := Load(expected.HomeDir)
+	if err != nil {
+		return Journal{}, err
+	}
+	current := loaded.Journal()
+	if current.ID != expected.ID || current.RecoveryNonce != expected.RecoveryNonce {
+		return Journal{}, errors.New("active upgrade transaction changed before recovery job operation")
+	}
+	return current, nil
+}
+
+func verifyRecoveryActorArtifact(journal Journal) error {
+	info, err := os.Lstat(journal.PreviousBinaryPath)
+	if err != nil {
+		return fmt.Errorf("inspect preserved recovery binary: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return errors.New("preserved recovery binary is not a regular file")
+	}
+	if _, err := readAndVerify(journal.PreviousBinaryPath, journal.PreviousBinarySHA256); err != nil {
+		return fmt.Errorf("verify preserved recovery binary: %w", err)
+	}
+	return nil
+}
+
+func ensureExactRecoveryUnit(path string, content []byte) (bool, error) {
+	for attempt := 0; attempt < 3; attempt++ {
+		exists, err := inspectExactRecoveryUnit(path, content)
+		if err != nil {
+			return false, err
+		}
+		if exists {
+			return false, nil
+		}
+		if err := publishRecoveryUnitNoReplace(path, content); err != nil {
+			if errors.Is(err, os.ErrExist) {
+				continue
+			}
+			return false, fmt.Errorf("publish upgrade recovery unit: %w", err)
+		}
+		return true, nil
+	}
+	return false, errors.New("upgrade recovery unit path changed repeatedly during publication")
+}
+
+func inspectExactRecoveryUnit(path string, content []byte) (bool, error) {
+	data, err := os.ReadFile(path)
+	if err == nil {
+		info, statErr := os.Lstat(path)
+		if statErr != nil {
+			return false, statErr
+		}
+		if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+			return false, errors.New("upgrade recovery unit is not a regular file")
+		}
+		if info.Mode().Perm() != recoveryUnitMode {
+			return false, fmt.Errorf("existing upgrade recovery unit %s has mode %04o, want %04o",
+				path, info.Mode().Perm(), os.FileMode(recoveryUnitMode))
+		}
+		if !bytes.Equal(data, content) {
+			return false, fmt.Errorf("existing upgrade recovery unit %s does not match the transaction", path)
+		}
+		return true, nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return false, fmt.Errorf("read upgrade recovery unit: %w", err)
+	}
+	return false, nil
+}
+
+func publishRecoveryUnitNoReplace(path string, content []byte) (retErr error) {
+	directory := filepath.Dir(path)
+	if err := validateDirectoryNoSymlink(directory); err != nil {
+		return fmt.Errorf("validate recovery unit directory: %w", err)
+	}
+	file, err := os.CreateTemp(directory, "."+filepath.Base(path)+".tmp.*")
+	if err != nil {
+		return err
+	}
+	temporaryPath := file.Name()
+	cleaned := false
+	closed := false
+	defer func() {
+		var closeErr error
+		if !closed {
+			closeErr = file.Close()
+		}
+		if !cleaned {
+			removeErr := os.Remove(temporaryPath)
+			if errors.Is(removeErr, os.ErrNotExist) {
+				removeErr = nil
+			}
+			retErr = errors.Join(retErr, closeErr, removeErr, syncTransactionDirectory(directory))
+		}
+	}()
+	if err := file.Chmod(recoveryUnitMode); err != nil {
+		return fmt.Errorf("secure recovery unit: %w", err)
+	}
+	if _, err := file.Write(content); err != nil {
+		return fmt.Errorf("write recovery unit: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("sync recovery unit: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close recovery unit: %w", err)
+	}
+	closed = true
+	// Link publishes the fully-written inode without replacing anything that
+	// won the pathname race. Unlike O_EXCL followed by writes, another process
+	// can never observe a partial unit and mistake it for tampering.
+	if err := os.Link(temporaryPath, path); err != nil {
+		return err
+	}
+	if err := os.Remove(temporaryPath); err != nil {
+		return fmt.Errorf("remove linked recovery unit staging file: %w", err)
+	}
+	cleaned = true
+	if err := syncTransactionDirectory(directory); err != nil {
+		return fmt.Errorf("sync recovery unit directory: %w", err)
+	}
+	return nil
+}
+
+func (c RecoveryJobController) run(ctx context.Context, name string, args ...string) error {
+	if c.RunCommand != nil {
+		return c.RunCommand(ctx, name, args...)
+	}
+	return exec.CommandContext(ctx, name, args...).Run()
+}
+
+func (c RecoveryJobController) armAndStartLaunchd(ctx context.Context, journal Journal) error {
+	domain := launchdRecoveryDomain(c.userID())
+	target := domain + "/" + journal.RecoveryJob.Name
+	if err := c.run(ctx, "launchctl", "enable", target); err != nil {
+		return fmt.Errorf("enable launchd recovery job: %w", err)
+	}
+	// bootstrap closes the published-but-never-registered crash window. An
+	// already registered service rejects bootstrap, in which case a non-killing
+	// kickstart is the idempotent wake operation.
+	bootstrapErr := c.run(ctx, "launchctl", "bootstrap", domain, journal.RecoveryJob.UnitPath)
+	if bootstrapErr == nil {
+		return nil
+	}
+	if kickstartErr := c.run(ctx, "launchctl", "kickstart", target); kickstartErr != nil {
+		return errors.Join(
+			fmt.Errorf("bootstrap launchd recovery job: %w", bootstrapErr),
+			fmt.Errorf("kickstart registered launchd recovery job: %w", kickstartErr),
+		)
+	}
+	return nil
+}
+
+func (c RecoveryJobController) startDetached(journal Journal) error {
+	command := recoveryCommand(journal)
+	if c.StartDetached != nil {
+		return c.StartDetached(command[0], command[1:]...)
+	}
+	return startDetachedRecovery(command[0], command[1:]...)
+}
+
+func (c RecoveryJobController) userID() int {
+	if c.UserID != nil {
+		return c.UserID()
+	}
+	return os.Getuid()
+}
+
+func startDetachedRecovery(name string, args ...string) error {
+	command := exec.Command(name, args...)
+	command.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	null, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
+	if err != nil {
+		return err
+	}
+	defer null.Close()
+	command.Stdin = null
+	command.Stdout = null
+	command.Stderr = null
+	if err := command.Start(); err != nil {
+		return err
+	}
+	go func() { _ = command.Wait() }()
+	return nil
+}
+
+func recoveryCommand(journal Journal) []string {
+	return []string{
+		journal.PreviousBinaryPath,
+		recoveryModeArgument,
+		"--home", journal.HomeDir,
+		"--transaction", journal.ID,
+	}
+}
+
+func renderSystemdRecoveryUnit(journal Journal) string {
+	command := recoveryCommand(journal)
+	quoted := make([]string, len(command))
+	for index, argument := range command {
+		quoted[index] = systemdQuoteArgument(argument)
+	}
+	return fmt.Sprintf(`[Unit]
+Description=Agent Factory upgrade recovery (%s)
+Before=%s
+StartLimitIntervalSec=300
+StartLimitBurst=3
+
+[Service]
+Type=simple
+ExecStart=%s
+Restart=on-failure
+RestartSec=2
+UMask=0077
+
+[Install]
+WantedBy=default.target
+`, journal.ID, journal.Daemon.Owner.ServiceName, strings.Join(quoted, " "))
+}
+
+func systemdQuoteArgument(value string) string {
+	var quoted strings.Builder
+	quoted.WriteByte('"')
+	for index := 0; index < len(value); index++ {
+		character := value[index]
+		switch character {
+		case '\\':
+			quoted.WriteString(`\\`)
+		case '"':
+			quoted.WriteString(`\"`)
+		case '$':
+			quoted.WriteString("$$")
+		case '%':
+			quoted.WriteString("%%")
+		case '\n':
+			quoted.WriteString(`\n`)
+		case '\r':
+			quoted.WriteString(`\r`)
+		case '\t':
+			quoted.WriteString(`\t`)
+		default:
+			if character < 0x20 || character == 0x7f {
+				fmt.Fprintf(&quoted, `\x%02x`, character)
+			} else {
+				quoted.WriteByte(character)
+			}
+		}
+	}
+	quoted.WriteByte('"')
+	return quoted.String()
+}
+
+func renderLaunchdRecoveryPlist(journal Journal) string {
+	var arguments strings.Builder
+	for _, argument := range recoveryCommand(journal) {
+		fmt.Fprintf(&arguments, "        <string>%s</string>\n", xmlEscape(argument))
+	}
+	logPath := xmlEscape(filepath.Join(transactionDir(journal.HomeDir, journal.ID), "recovery.log"))
+	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>%s</string>
+    <key>ProgramArguments</key>
+    <array>
+%s    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+    <key>ProcessType</key>
+    <string>Background</string>
+    <key>ThrottleInterval</key>
+    <integer>2</integer>
+    <key>StandardOutPath</key>
+    <string>%s</string>
+    <key>StandardErrorPath</key>
+    <string>%s</string>
+</dict>
+</plist>
+`, xmlEscape(journal.RecoveryJob.Name), arguments.String(), logPath, logPath)
+}
+
+func xmlEscape(value string) string {
+	return html.EscapeString(value)
+}
+
+func launchdRecoveryDomain(uid int) string {
+	return "gui/" + strconv.Itoa(uid)
+}

--- a/internal/upgradetxn/recovery_job.go
+++ b/internal/upgradetxn/recovery_job.go
@@ -228,15 +228,8 @@ func ensureExactRecoveryUnit(path string, content []byte) (bool, error) {
 }
 
 func inspectExactRecoveryUnit(path string, content []byte) (bool, error) {
-	data, err := os.ReadFile(path)
+	data, info, err := readRegularRecoveryUnit(path)
 	if err == nil {
-		info, statErr := os.Lstat(path)
-		if statErr != nil {
-			return false, statErr
-		}
-		if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
-			return false, errors.New("upgrade recovery unit is not a regular file")
-		}
 		if info.Mode().Perm() != recoveryUnitMode {
 			return false, fmt.Errorf("existing upgrade recovery unit %s has mode %04o, want %04o",
 				path, info.Mode().Perm(), os.FileMode(recoveryUnitMode))
@@ -247,7 +240,7 @@ func inspectExactRecoveryUnit(path string, content []byte) (bool, error) {
 		return true, nil
 	}
 	if !errors.Is(err, os.ErrNotExist) {
-		return false, fmt.Errorf("read upgrade recovery unit: %w", err)
+		return false, fmt.Errorf("inspect upgrade recovery unit: %w", err)
 	}
 	return false, nil
 }

--- a/internal/upgradetxn/recovery_job_test.go
+++ b/internal/upgradetxn/recovery_job_test.go
@@ -1,0 +1,436 @@
+package upgradetxn
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type recoveryCommandCall struct {
+	name string
+	args []string
+}
+
+type fakeRecoveryJobRuntime struct {
+	commands       []recoveryCommandCall
+	detached       []recoveryCommandCall
+	commandErr     error
+	commandResults []error
+	detachedErr    error
+	launchdUserID  int
+}
+
+func (f *fakeRecoveryJobRuntime) controller() RecoveryJobController {
+	return RecoveryJobController{
+		RunCommand: func(_ context.Context, name string, args ...string) error {
+			f.commands = append(f.commands, recoveryCommandCall{name: name, args: append([]string(nil), args...)})
+			if len(f.commandResults) > 0 {
+				result := f.commandResults[0]
+				f.commandResults = f.commandResults[1:]
+				return result
+			}
+			return f.commandErr
+		},
+		StartDetached: func(name string, args ...string) error {
+			f.detached = append(f.detached, recoveryCommandCall{name: name, args: append([]string(nil), args...)})
+			return f.detachedErr
+		},
+		UserID: func() int { return f.launchdUserID },
+	}
+}
+
+func prepareRecoveryJobFixture(t *testing.T, kind RecoveryJobKind) *Transaction {
+	t.Helper()
+	home := t.TempDir()
+	binDir := t.TempDir()
+	executable := filepath.Join(binDir, "af")
+	require.NoError(t, os.WriteFile(executable, []byte("known-running-binary"), 0o755))
+	unitDir := ""
+	if kind != RecoveryJobDetached {
+		unitDir = t.TempDir()
+	}
+	job, err := NewRecoveryJob(kind, "txn-recovery-job", unitDir)
+	require.NoError(t, err)
+	owner := DaemonOwner{Kind: SupervisionAdHoc}
+	if kind == RecoveryJobSystemd {
+		owner = DaemonOwner{Kind: SupervisionSystemd, ServiceName: "agent-factory-daemon.service"}
+	}
+	if kind == RecoveryJobLaunchd {
+		owner = DaemonOwner{Kind: SupervisionLaunchd, ServiceName: "com.agent-factory.daemon"}
+	}
+	txn, err := Prepare(Plan{
+		ID:             "txn-recovery-job",
+		HomeDir:        home,
+		ExecutablePath: executable,
+		FromVersion:    "1.0.206",
+		ToVersion:      "1.0.207",
+		Candidate:      []byte("candidate-binary"),
+		Daemon: DaemonSnapshot{
+			WasRunning: true,
+			BootID:     "previous-boot-id",
+			Owner:      owner,
+		},
+		RecoveryJob: job,
+	})
+	require.NoError(t, err)
+	return txn
+}
+
+func TestSystemdRecoveryJobIsPersistentAndRunsOnlyPreviousBinary(t *testing.T) {
+	txn := prepareRecoveryJobFixture(t, RecoveryJobSystemd)
+	runtime := &fakeRecoveryJobRuntime{}
+
+	require.NoError(t, runtime.controller().InstallAndStart(context.Background(), txn))
+
+	journal := txn.Journal()
+	content, err := os.ReadFile(journal.RecoveryJob.UnitPath)
+	require.NoError(t, err)
+	info, err := os.Stat(journal.RecoveryJob.UnitPath)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(recoveryUnitMode), info.Mode().Perm())
+	unit := string(content)
+	require.Contains(t, unit, "Before="+journal.Daemon.Owner.ServiceName)
+	require.Contains(t, unit, "Restart=on-failure")
+	require.Contains(t, unit, "WantedBy=default.target")
+	require.Contains(t, unit, systemdQuoteArgument(journal.PreviousBinaryPath))
+	require.Contains(t, unit, systemdQuoteArgument(journal.HomeDir))
+	require.NotContains(t, unit, systemdQuoteArgument(journal.ExecutablePath),
+		"the replaceable canonical binary must never be the recovery actor")
+	require.Equal(t, journal.PreviousBinaryPath, recoveryCommand(journal)[0])
+	require.Equal(t, []recoveryCommandCall{
+		{name: "systemctl", args: []string{"--user", "daemon-reload"}},
+		{name: "systemctl", args: []string{"--user", "enable", "--now", journal.RecoveryJob.Name}},
+	}, runtime.commands)
+}
+
+func TestLaunchdRecoveryJobSurvivesActorLossAndUsesTokenizedArguments(t *testing.T) {
+	txn := prepareRecoveryJobFixture(t, RecoveryJobLaunchd)
+	runtime := &fakeRecoveryJobRuntime{launchdUserID: 501}
+
+	require.NoError(t, runtime.controller().InstallAndStart(context.Background(), txn))
+
+	journal := txn.Journal()
+	content, err := os.ReadFile(journal.RecoveryJob.UnitPath)
+	require.NoError(t, err)
+	plist := string(content)
+	for _, value := range recoveryCommand(journal) {
+		require.Contains(t, plist, "<string>"+xmlEscape(value)+"</string>")
+	}
+	require.Contains(t, plist, "<key>RunAtLoad</key>")
+	require.Contains(t, plist, "<key>KeepAlive</key>")
+	require.Contains(t, plist, "<key>SuccessfulExit</key>")
+	require.NotContains(t, plist, "<key>PathState</key>",
+		"a clean lock loser must not be relaunched while the winning actor is live")
+	require.Equal(t, []recoveryCommandCall{{
+		name: "launchctl", args: []string{"enable", "gui/501/" + journal.RecoveryJob.Name},
+	}, {
+		name: "launchctl", args: []string{"bootstrap", "gui/501", journal.RecoveryJob.UnitPath},
+	}}, runtime.commands)
+}
+
+func TestDetachedRecoveryJobStartsASeparatePreviousBinaryActor(t *testing.T) {
+	txn := prepareRecoveryJobFixture(t, RecoveryJobDetached)
+	runtime := &fakeRecoveryJobRuntime{}
+
+	require.NoError(t, runtime.controller().InstallAndStart(context.Background(), txn))
+
+	command := recoveryCommand(txn.Journal())
+	require.Equal(t, []recoveryCommandCall{{name: command[0], args: command[1:]}}, runtime.detached)
+	require.Empty(t, runtime.commands)
+}
+
+func TestRecoveryJobWakeUsesNonDestructiveManagerStartVerbs(t *testing.T) {
+	tests := []struct {
+		kind           RecoveryJobKind
+		want           func(Journal) []recoveryCommandCall
+		commandResults []error
+	}{
+		{
+			kind: RecoveryJobSystemd,
+			want: func(Journal) []recoveryCommandCall {
+				return []recoveryCommandCall{
+					{name: "systemctl", args: []string{"--user", "daemon-reload"}},
+					{name: "systemctl", args: []string{"--user", "enable", "agent-factory-upgrade-recovery-txn-recovery-job.service"}},
+					{name: "systemctl", args: []string{"--user", "start", "agent-factory-upgrade-recovery-txn-recovery-job.service"}},
+				}
+			},
+		},
+		{
+			kind: RecoveryJobLaunchd,
+			want: func(journal Journal) []recoveryCommandCall {
+				return []recoveryCommandCall{
+					{name: "launchctl", args: []string{"enable", "gui/502/com.agent-factory.upgrade-recovery.txn-recovery-job"}},
+					{name: "launchctl", args: []string{"bootstrap", "gui/502", journal.RecoveryJob.UnitPath}},
+					{name: "launchctl", args: []string{"kickstart", "gui/502/com.agent-factory.upgrade-recovery.txn-recovery-job"}},
+				}
+			},
+			commandResults: []error{nil, errors.New("already bootstrapped"), nil},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(string(tc.kind), func(t *testing.T) {
+			txn := prepareRecoveryJobFixture(t, tc.kind)
+			runtime := &fakeRecoveryJobRuntime{launchdUserID: 502}
+			controller := runtime.controller()
+			require.NoError(t, controller.InstallAndStart(context.Background(), txn))
+			runtime.commands = nil
+			runtime.commandResults = append([]error(nil), tc.commandResults...)
+
+			require.NoError(t, controller.Wake(context.Background(), txn))
+			require.Equal(t, tc.want(txn.Journal()), runtime.commands)
+			for _, call := range runtime.commands {
+				require.NotContains(t, call.args, "restart")
+				require.NotContains(t, call.args, "-k")
+			}
+		})
+	}
+}
+
+func TestRecoveryJobWakeRepairsPublishedButUnregisteredJobAfterCrash(t *testing.T) {
+	tests := []struct {
+		kind RecoveryJobKind
+		want func(Journal) []recoveryCommandCall
+	}{
+		{
+			kind: RecoveryJobSystemd,
+			want: func(Journal) []recoveryCommandCall {
+				return []recoveryCommandCall{
+					{name: "systemctl", args: []string{"--user", "daemon-reload"}},
+					{name: "systemctl", args: []string{"--user", "enable", "agent-factory-upgrade-recovery-txn-recovery-job.service"}},
+					{name: "systemctl", args: []string{"--user", "start", "agent-factory-upgrade-recovery-txn-recovery-job.service"}},
+				}
+			},
+		},
+		{
+			kind: RecoveryJobLaunchd,
+			want: func(journal Journal) []recoveryCommandCall {
+				return []recoveryCommandCall{
+					{name: "launchctl", args: []string{"enable", "gui/504/com.agent-factory.upgrade-recovery.txn-recovery-job"}},
+					{name: "launchctl", args: []string{"bootstrap", "gui/504", journal.RecoveryJob.UnitPath}},
+				}
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(string(tc.kind), func(t *testing.T) {
+			txn := prepareRecoveryJobFixture(t, tc.kind)
+			journal := txn.Journal()
+			var content []byte
+			switch tc.kind {
+			case RecoveryJobSystemd:
+				content = []byte(renderSystemdRecoveryUnit(journal))
+			case RecoveryJobLaunchd:
+				content = []byte(renderLaunchdRecoveryPlist(journal))
+			}
+			created, err := ensureExactRecoveryUnit(journal.RecoveryJob.UnitPath, content)
+			require.NoError(t, err)
+			require.True(t, created)
+			runtime := &fakeRecoveryJobRuntime{launchdUserID: 504}
+
+			require.NoError(t, runtime.controller().Wake(context.Background(), txn))
+			require.Equal(t, tc.want(journal), runtime.commands,
+				"a durable unit file does not prove the service manager registered or enabled it")
+		})
+	}
+}
+
+func TestRecoveryJobWakeLeavesKernelLiveActorAlone(t *testing.T) {
+	txn := prepareRecoveryJobFixture(t, RecoveryJobSystemd)
+	runtime := &fakeRecoveryJobRuntime{}
+	controller := runtime.controller()
+	require.NoError(t, controller.InstallAndStart(context.Background(), txn))
+	lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+	defer lease.Release()
+	runtime.commands = nil
+
+	err = controller.Wake(context.Background(), txn)
+	require.ErrorIs(t, err, ErrRecoveryActive)
+	require.Empty(t, runtime.commands,
+		"a positive flock observation must precede and suppress every manager wake")
+}
+
+func TestRecoveryJobInstallRetryAcceptsAnAlreadyLiveActor(t *testing.T) {
+	txn := prepareRecoveryJobFixture(t, RecoveryJobSystemd)
+	runtime := &fakeRecoveryJobRuntime{}
+	controller := runtime.controller()
+	require.NoError(t, controller.InstallAndStart(context.Background(), txn))
+	lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+	defer lease.Release()
+	runtime.commands = nil
+
+	require.NoError(t, controller.InstallAndStart(context.Background(), txn))
+	require.Empty(t, runtime.commands,
+		"an ambiguous first start may have succeeded; retry must trust the flock instead of starting again")
+}
+
+func TestDisableRecoveryJobDisarmsRestartWithoutStoppingCurrentActor(t *testing.T) {
+	tests := []struct {
+		kind RecoveryJobKind
+		want []recoveryCommandCall
+	}{
+		{
+			kind: RecoveryJobSystemd,
+			want: []recoveryCommandCall{{
+				name: "systemctl",
+				args: []string{"--user", "disable", "agent-factory-upgrade-recovery-txn-recovery-job.service"},
+			}},
+		},
+		{
+			kind: RecoveryJobLaunchd,
+			want: []recoveryCommandCall{{
+				name: "launchctl",
+				args: []string{"disable", "gui/503/com.agent-factory.upgrade-recovery.txn-recovery-job"},
+			}},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(string(tc.kind), func(t *testing.T) {
+			txn := prepareRecoveryJobFixture(t, tc.kind)
+			runtime := &fakeRecoveryJobRuntime{launchdUserID: 503}
+			controller := runtime.controller()
+			require.NoError(t, controller.InstallAndStart(context.Background(), txn))
+			runtime.commands = nil
+			lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+			require.NoError(t, err)
+			require.NoError(t, lease.Abort())
+
+			require.NoError(t, controller.Disable(context.Background(), txn.Journal()))
+
+			require.Equal(t, tc.want, runtime.commands)
+			for _, call := range runtime.commands {
+				require.NotContains(t, call.args, "--now",
+					"disable must not kill the actor before it removes the active journal")
+				require.NotContains(t, call.args, "bootout",
+					"launchd bootout would kill the actor which still owns cleanup")
+			}
+			_, err = os.Stat(txn.Journal().RecoveryJob.UnitPath)
+			require.NoError(t, err,
+				"disable disarms the manager, but active-journal cleanup owns artifact removal")
+			require.NoError(t, lease.Cleanup())
+			_, err = os.Stat(txn.Journal().RecoveryJob.UnitPath)
+			require.ErrorIs(t, err, os.ErrNotExist)
+			require.NoError(t, lease.Release())
+		})
+	}
+}
+
+func TestRecoveryJobManagerFailureRetainsTheDurableUnitForTakeover(t *testing.T) {
+	txn := prepareRecoveryJobFixture(t, RecoveryJobSystemd)
+	runtime := &fakeRecoveryJobRuntime{commandErr: errors.New("manager unavailable")}
+
+	err := runtime.controller().InstallAndStart(context.Background(), txn)
+	require.ErrorContains(t, err, "reload systemd recovery job")
+	exact, readErr := os.ReadFile(txn.Journal().RecoveryJob.UnitPath)
+	require.NoError(t, readErr,
+		"an ambiguous service-manager failure must not erase durable recovery state")
+
+	// The exact file is idempotent across both successful and failed retries.
+	runtime.commandErr = nil
+	require.NoError(t, runtime.controller().InstallAndStart(context.Background(), txn))
+	got, err := os.ReadFile(txn.Journal().RecoveryJob.UnitPath)
+	require.NoError(t, err)
+	require.Equal(t, exact, got)
+	runtime.commandErr = errors.New("manager unavailable")
+	err = runtime.controller().InstallAndStart(context.Background(), txn)
+	require.Error(t, err)
+	stillThere, err := os.ReadFile(txn.Journal().RecoveryJob.UnitPath)
+	require.NoError(t, err)
+	require.Equal(t, exact, stillThere)
+}
+
+func TestRecoveryJobRefusesToOverwriteUnexpectedUnitContent(t *testing.T) {
+	txn := prepareRecoveryJobFixture(t, RecoveryJobSystemd)
+	path := txn.Journal().RecoveryJob.UnitPath
+	require.NoError(t, os.WriteFile(path, []byte("foreign unit\n"), 0o600))
+	runtime := &fakeRecoveryJobRuntime{}
+
+	err := runtime.controller().InstallAndStart(context.Background(), txn)
+	require.ErrorContains(t, err, "does not match")
+	require.Empty(t, runtime.commands)
+	content, readErr := os.ReadFile(path)
+	require.NoError(t, readErr)
+	require.Equal(t, "foreign unit\n", string(content))
+}
+
+func TestRecoveryUnitPublicationIsAtomicAcrossEntrypointRaces(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "recovery.service")
+	content := []byte("complete unit\n")
+	const contenders = 20
+	start := make(chan struct{})
+	results := make(chan bool, contenders)
+	errorsCh := make(chan error, contenders)
+	var wait sync.WaitGroup
+	for range contenders {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			<-start
+			created, err := ensureExactRecoveryUnit(path, content)
+			results <- created
+			errorsCh <- err
+		}()
+	}
+	close(start)
+	wait.Wait()
+	close(results)
+	close(errorsCh)
+	createdCount := 0
+	for created := range results {
+		if created {
+			createdCount++
+		}
+	}
+	for err := range errorsCh {
+		require.NoError(t, err)
+	}
+	require.Equal(t, 1, createdCount)
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, content, got)
+}
+
+func TestRecoveryCleanupRefusesToDeleteAReplacedUnit(t *testing.T) {
+	txn := prepareRecoveryJobFixture(t, RecoveryJobSystemd)
+	runtime := &fakeRecoveryJobRuntime{}
+	controller := runtime.controller()
+	require.NoError(t, controller.InstallAndStart(context.Background(), txn))
+	lease, err := txn.tryAcquireRecoveryAs(txn.Journal().PreviousBinaryPath)
+	require.NoError(t, err)
+	defer lease.Release()
+	require.NoError(t, lease.Abort())
+	require.NoError(t, controller.Disable(context.Background(), txn.Journal()))
+	path := txn.Journal().RecoveryJob.UnitPath
+	require.NoError(t, os.WriteFile(path, []byte("replacement unit\n"), recoveryUnitMode))
+
+	err = lease.Cleanup()
+	require.ErrorContains(t, err, "refusing to remove")
+	content, readErr := os.ReadFile(path)
+	require.NoError(t, readErr)
+	require.Equal(t, "replacement unit\n", string(content))
+}
+
+func TestRecoveryCommandEscapesServiceManagerMetacharacters(t *testing.T) {
+	journal := Journal{
+		ID:                 "txn-escape",
+		HomeDir:            `/tmp/home with $dollar%percent"quote&xml`,
+		PreviousBinaryPath: `/tmp/bin with $dollar%percent"quote&xml`,
+	}
+	unit := renderSystemdRecoveryUnit(journal)
+	require.NotContains(t, unit, journal.PreviousBinaryPath)
+	require.NotContains(t, unit, journal.HomeDir)
+	require.Contains(t, unit, `$$dollar%%percent\"quote&xml`)
+	plist := renderLaunchdRecoveryPlist(journal)
+	require.NotContains(t, plist, `&xml`)
+	require.Contains(t, plist, `&amp;xml`)
+	require.True(t, strings.Contains(plist, `&#34;quote`))
+	require.NotContains(t, systemdQuoteArgument("safe\n[Service]\nExecStart=/tmp/evil"), "\n",
+		"a newline in a path must not inject another unit directive")
+}

--- a/internal/upgradetxn/recovery_job_test.go
+++ b/internal/upgradetxn/recovery_job_test.go
@@ -432,7 +432,12 @@ func TestRecoveryJobRefusesToOverwriteUnexpectedUnitContent(t *testing.T) {
 }
 
 func TestRecoveryUnitPublicationIsAtomicAcrossEntrypointRaces(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "recovery.service")
+	// Production unit paths are derived from NewRecoveryJob's canonicalized
+	// directory. Mirror that boundary because macOS exposes its temp root through
+	// /var, which is a symlink to /private/var.
+	directory, err := canonicalExistingDir(t.TempDir())
+	require.NoError(t, err)
+	path := filepath.Join(directory, "recovery.service")
 	content := []byte("complete unit\n")
 	const contenders = 20
 	start := make(chan struct{})

--- a/internal/upgradetxn/recovery_job_test.go
+++ b/internal/upgradetxn/recovery_job_test.go
@@ -7,7 +7,9 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -80,6 +82,75 @@ func prepareRecoveryJobFixture(t *testing.T, kind RecoveryJobKind) *Transaction 
 	})
 	require.NoError(t, err)
 	return txn
+}
+
+func TestNewRecoveryJobCanonicalizesExistingUnitDirectory(t *testing.T) {
+	realDirectory := t.TempDir()
+	alias := filepath.Join(t.TempDir(), "units")
+	require.NoError(t, os.Symlink(realDirectory, alias))
+	canonicalDirectory, err := filepath.EvalSymlinks(realDirectory)
+	require.NoError(t, err)
+
+	job, err := NewRecoveryJob(RecoveryJobSystemd, "txn-canonical-unit-dir", alias)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(canonicalDirectory, job.Name), job.UnitPath)
+
+	created, err := ensureExactRecoveryUnit(job.UnitPath, []byte("recovery unit\n"))
+	require.NoError(t, err)
+	require.True(t, created)
+}
+
+func TestRecoveryUnitReadersRejectFIFOWithoutBlocking(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(string) error
+	}{
+		{
+			name: "startup inspection",
+			run: func(path string) error {
+				_, err := inspectExactRecoveryUnit(path, []byte("expected unit\n"))
+				return err
+			},
+		},
+		{
+			name: "cleanup inspection",
+			run: func(path string) error {
+				return removeExactRecoveryUnit(Journal{
+					ID: "txn-fifo",
+					RecoveryJob: RecoveryJob{
+						Kind:     RecoveryJobSystemd,
+						Name:     "agent-factory-upgrade-recovery-txn-fifo.service",
+						UnitPath: path,
+					},
+				})
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "recovery.service")
+			require.NoError(t, syscall.Mkfifo(path, recoveryUnitMode))
+			result := make(chan error, 1)
+			go func() { result <- tc.run(path) }()
+
+			select {
+			case err := <-result:
+				require.ErrorContains(t, err, "not a regular file")
+			case <-time.After(2 * time.Second):
+				// Unblock the old read-before-stat implementation before failing so
+				// the regression test never leaves a goroutine behind.
+				writer, err := os.OpenFile(path, os.O_WRONLY|syscall.O_NONBLOCK, 0)
+				require.NoError(t, err)
+				require.NoError(t, writer.Close())
+				select {
+				case <-result:
+				case <-time.After(time.Second):
+					require.FailNow(t, "FIFO inspection remained blocked after releasing its reader")
+				}
+				require.FailNow(t, "FIFO inspection blocked before checking the file type")
+			}
+		})
+	}
 }
 
 func TestSystemdRecoveryJobIsPersistentAndRunsOnlyPreviousBinary(t *testing.T) {

--- a/internal/upgradetxn/storage.go
+++ b/internal/upgradetxn/storage.go
@@ -1,6 +1,7 @@
 package upgradetxn
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -378,9 +379,13 @@ func validateDaemonSnapshot(snapshot DaemonSnapshot) error {
 		if snapshot.Owner.ServiceName != "" {
 			return errors.New("ad-hoc daemon owner cannot name a service")
 		}
-	case SupervisionSystemd, SupervisionLaunchd:
-		if strings.TrimSpace(snapshot.Owner.ServiceName) == "" {
-			return errors.New("service-managed daemon owner omits its service name")
+	case SupervisionSystemd:
+		if snapshot.Owner.ServiceName != systemdDaemonService {
+			return fmt.Errorf("systemd daemon owner must be %q", systemdDaemonService)
+		}
+	case SupervisionLaunchd:
+		if snapshot.Owner.ServiceName != launchdDaemonService {
+			return fmt.Errorf("launchd daemon owner must be %q", launchdDaemonService)
 		}
 	default:
 		return fmt.Errorf("journal contains invalid daemon supervision kind %q", snapshot.Owner.Kind)
@@ -792,6 +797,9 @@ func (t *Transaction) cleanupInactiveArtifacts() error {
 	if err := removeDurableFile(t.journal.CandidatePath); err != nil {
 		return fmt.Errorf("remove inactive candidate artifact: %w", err)
 	}
+	if err := removeExactRecoveryUnit(t.journal); err != nil {
+		return err
+	}
 	if err := removeDurableTree(transactionDir(t.journal.HomeDir, t.journal.ID)); err != nil {
 		return fmt.Errorf("remove inactive transaction directory: %w", err)
 	}
@@ -800,6 +808,40 @@ func (t *Transaction) cleanupInactiveArtifacts() error {
 	}
 	if err := removeDurableFile(recoveryLockPath(t.journal.HomeDir, t.journal.ID)); err != nil {
 		return fmt.Errorf("remove inactive recovery lock: %w", err)
+	}
+	return nil
+}
+
+func removeExactRecoveryUnit(journal Journal) error {
+	if journal.RecoveryJob.Kind == RecoveryJobDetached {
+		return nil
+	}
+	var expected []byte
+	switch journal.RecoveryJob.Kind {
+	case RecoveryJobSystemd:
+		expected = []byte(renderSystemdRecoveryUnit(journal))
+	case RecoveryJobLaunchd:
+		expected = []byte(renderLaunchdRecoveryPlist(journal))
+	default:
+		return fmt.Errorf("cannot remove invalid recovery job kind %q", journal.RecoveryJob.Kind)
+	}
+	data, err := os.ReadFile(journal.RecoveryJob.UnitPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read recovery unit before cleanup: %w", err)
+	}
+	info, err := os.Lstat(journal.RecoveryJob.UnitPath)
+	if err != nil {
+		return fmt.Errorf("inspect recovery unit before cleanup: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 ||
+		info.Mode().Perm() != recoveryUnitMode || !bytes.Equal(data, expected) {
+		return errors.New("refusing to remove a recovery unit that no longer matches the transaction")
+	}
+	if err := removeDurableFile(journal.RecoveryJob.UnitPath); err != nil {
+		return fmt.Errorf("remove inactive recovery unit: %w", err)
 	}
 	return nil
 }

--- a/internal/upgradetxn/storage.go
+++ b/internal/upgradetxn/storage.go
@@ -7,10 +7,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"golang.org/x/sys/unix"
 )
 
 var (
@@ -416,11 +419,19 @@ func NewRecoveryJob(kind RecoveryJobKind, transactionID, unitDir string) (Recove
 			return RecoveryJob{}, errors.New("detached recovery job cannot have a unit directory")
 		}
 	case RecoveryJobSystemd:
+		canonicalUnitDir, err := canonicalExistingDir(unitDir)
+		if err != nil {
+			return RecoveryJob{}, fmt.Errorf("resolve systemd recovery unit directory: %w", err)
+		}
 		job.Name = "agent-factory-upgrade-recovery-" + transactionID + ".service"
-		job.UnitPath = filepath.Join(unitDir, job.Name)
+		job.UnitPath = filepath.Join(canonicalUnitDir, job.Name)
 	case RecoveryJobLaunchd:
+		canonicalUnitDir, err := canonicalExistingDir(unitDir)
+		if err != nil {
+			return RecoveryJob{}, fmt.Errorf("resolve launchd recovery unit directory: %w", err)
+		}
 		job.Name = "com.agent-factory.upgrade-recovery." + transactionID
-		job.UnitPath = filepath.Join(unitDir, job.Name+".plist")
+		job.UnitPath = filepath.Join(canonicalUnitDir, job.Name+".plist")
 	default:
 		return RecoveryJob{}, fmt.Errorf("unsupported upgrade recovery job kind %q", kind)
 	}
@@ -825,25 +836,51 @@ func removeExactRecoveryUnit(journal Journal) error {
 	default:
 		return fmt.Errorf("cannot remove invalid recovery job kind %q", journal.RecoveryJob.Kind)
 	}
-	data, err := os.ReadFile(journal.RecoveryJob.UnitPath)
+	data, info, err := readRegularRecoveryUnit(journal.RecoveryJob.UnitPath)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
 	}
 	if err != nil {
 		return fmt.Errorf("read recovery unit before cleanup: %w", err)
 	}
-	info, err := os.Lstat(journal.RecoveryJob.UnitPath)
-	if err != nil {
-		return fmt.Errorf("inspect recovery unit before cleanup: %w", err)
-	}
-	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 ||
-		info.Mode().Perm() != recoveryUnitMode || !bytes.Equal(data, expected) {
+	if info.Mode().Perm() != recoveryUnitMode || !bytes.Equal(data, expected) {
 		return errors.New("refusing to remove a recovery unit that no longer matches the transaction")
 	}
 	if err := removeDurableFile(journal.RecoveryJob.UnitPath); err != nil {
 		return fmt.Errorf("remove inactive recovery unit: %w", err)
 	}
 	return nil
+}
+
+func readRegularRecoveryUnit(path string) ([]byte, os.FileInfo, error) {
+	file, err := os.OpenFile(path, os.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		if errors.Is(err, unix.ELOOP) {
+			return nil, nil, errors.New("upgrade recovery unit is not a regular file")
+		}
+		return nil, nil, err
+	}
+	defer func() { _ = file.Close() }()
+
+	info, err := file.Stat()
+	if err != nil {
+		return nil, nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, nil, errors.New("upgrade recovery unit is not a regular file")
+	}
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, nil, err
+	}
+	current, err := os.Lstat(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !os.SameFile(info, current) {
+		return nil, nil, errors.New("upgrade recovery unit changed while it was inspected")
+	}
+	return data, info, nil
 }
 
 func readJournal(path string) (Journal, error) {

--- a/internal/upgradetxn/supervisor.go
+++ b/internal/upgradetxn/supervisor.go
@@ -26,6 +26,11 @@ var (
 	// and the active journal remain for explicit repair while the persistent job
 	// is disabled, so a corrupt snapshot cannot create a restart loop.
 	ErrRollbackRecoveryFailed = errors.New("automatic upgrade rollback failed; recovery artifacts retained")
+	// ErrRecoveryJobDisableFailed distinguishes a durable rollback circuit
+	// breaker from failure to disarm the service manager. A recovery actor may
+	// exit cleanly for the former, but must fail so the manager retries the
+	// latter instead of silently abandoning an enabled recovery job.
+	ErrRecoveryJobDisableFailed = errors.New("upgrade recovery job could not be disabled")
 
 	errSupervisorInterruptedBeforeShutdown = errors.New("upgrade supervisor restarted before daemon shutdown")
 	errSupervisorInterruptedBeforeCommit   = errors.New("upgrade supervisor restarted before candidate commit")
@@ -341,7 +346,8 @@ func (s Supervisor) Run(ctx context.Context, txn *Transaction, lease *RecoveryLe
 			if err := s.Operations.DisableRecoveryJob(ctx, journal); err != nil {
 				return errors.Join(
 					ErrRollbackRecoveryFailed,
-					fmt.Errorf("disable failed rollback recovery job: %w", err),
+					ErrRecoveryJobDisableFailed,
+					err,
 				)
 			}
 			return ErrRollbackRecoveryFailed
@@ -466,7 +472,12 @@ func (s Supervisor) finishFailedRollback(
 		return errors.Join(cause, fmt.Errorf("persist rollback failure: %w", err))
 	}
 	if err := s.Operations.DisableRecoveryJob(ctx, txn.Journal()); err != nil {
-		return errors.Join(ErrRollbackRecoveryFailed, cause, fmt.Errorf("disable failed rollback recovery job: %w", err))
+		return errors.Join(
+			ErrRollbackRecoveryFailed,
+			cause,
+			ErrRecoveryJobDisableFailed,
+			err,
+		)
 	}
 	return errors.Join(ErrRollbackRecoveryFailed, cause)
 }

--- a/internal/upgradetxn/supervisor_test.go
+++ b/internal/upgradetxn/supervisor_test.go
@@ -535,7 +535,9 @@ func TestRollbackFailedRemainsTerminalWhenJobDisableReportsAnError(t *testing.T)
 
 	err = (Supervisor{Operations: runtime.operations()}).Run(context.Background(), txn, lease)
 	require.ErrorIs(t, err, ErrRollbackRecoveryFailed,
-		"the recovery launcher must still recognize a terminal failure and avoid restart-looping")
+		"the durable circuit-breaker phase remains terminal")
+	require.ErrorIs(t, err, ErrRecoveryJobDisableFailed,
+		"the runner must not exit cleanly while the service manager can still restart this actor")
 	require.ErrorContains(t, err, "service manager unavailable")
 	require.NoError(t, lease.Release())
 }

--- a/internal/upgradetxn/transaction.go
+++ b/internal/upgradetxn/transaction.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/sachiniyer/agent-factory/internal/systemdunit"
 )
 
 const (
@@ -22,6 +24,8 @@ const (
 	journalFileMode      = 0o600
 	transactionDirMode   = 0o700
 	recoveryNonceBytes   = 32
+	systemdDaemonService = systemdunit.DaemonUnitName
+	launchdDaemonService = "com.agent-factory.daemon"
 )
 
 var (

--- a/internal/upgradetxn/transaction_test.go
+++ b/internal/upgradetxn/transaction_test.go
@@ -42,7 +42,8 @@ func prepareFixture(t *testing.T) (*Transaction, string, string) {
 }
 
 func TestRecoveryJobIdentityIsTransactionScopedAndJournaled(t *testing.T) {
-	unitDir := t.TempDir()
+	unitDir, err := canonicalExistingDir(t.TempDir())
+	require.NoError(t, err)
 	systemd, err := NewRecoveryJob(RecoveryJobSystemd, "txn-2212", unitDir)
 	require.NoError(t, err)
 	require.Equal(t, "agent-factory-upgrade-recovery-txn-2212.service", systemd.Name)

--- a/internal/upgradetxn/transaction_test.go
+++ b/internal/upgradetxn/transaction_test.go
@@ -60,6 +60,20 @@ func TestRecoveryJobIdentityIsTransactionScopedAndJournaled(t *testing.T) {
 	require.Error(t, validateRecoveryJob("txn-2212", tampered))
 }
 
+func TestDaemonOwnerCannotNameAnUnrelatedService(t *testing.T) {
+	for _, owner := range []DaemonOwner{
+		{Kind: SupervisionSystemd, ServiceName: "unrelated.service"},
+		{Kind: SupervisionLaunchd, ServiceName: "com.example.unrelated"},
+	} {
+		err := validateDaemonSnapshot(DaemonSnapshot{
+			WasRunning: true,
+			BootID:     "previous-boot",
+			Owner:      owner,
+		})
+		require.ErrorContains(t, err, "daemon owner must be")
+	}
+}
+
 func TestRecoveryMutationAuthorityRequiresPreservedBinary(t *testing.T) {
 	txn, _, _ := prepareFixture(t)
 	lease, err := txn.TryAcquireRecovery()


### PR DESCRIPTION
Part of #2212.

This is the next production-disabled lifecycle slice after #2338 and #2362. It adds the durable launcher and takeover boundaries without enabling automatic activation or changing any live daemon entrypoint.

What changed:

- render and manage transaction-scoped systemd, launchd, and detached recovery actors that execute only the immutable previous-binary artifact;
- use non-destructive manager verbs for wake/disarm, re-registering and re-enabling an exact job after either the publish/register or disable/cleanup crash window without stopping or replacing a live actor;
- publish units atomically without replacement, so concurrent entrypoints can never observe a partial unit or overwrite a different file;
- canonicalize the existing service-unit directory at construction, so macOS's `/var` alias records the stable `/private/var` path while later checks still reject symlink substitution below that boundary;
- open existing units nonblocking and without following the leaf, then verify the opened descriptor is a regular file before reading it; startup inspection and terminal cleanup therefore cannot hang on a FIFO or read through a symlink;
- keep manager failures retryable by retaining the durable unit, while terminal transaction cleanup removes it only after `active.json` is durably absent;
- add a strict internal recovery invocation parser and runner that validates the transaction before acquiring the previous-binary-only lease, releases the flock on every exit, and maps only successfully-disarmed terminal outcomes to exit 0;
- add an all-entrypoint decision API that trusts the flock as the death test, treats an expired heartbeat as blocked rather than kill authority, wakes the previous binary only after the lock is free, and preserves the `rollback_failed` circuit breaker;
- pin service-managed daemon ownership to AF's exact systemd/launchd identities so a journal cannot redirect recovery operations at an unrelated unit.

The regression tests were added first and failed because these boundaries did not exist. They are hermetic: command runners and detached spawn are injected, so no test invokes systemctl/launchctl, launches a daemon, or executes a lifecycle payload. Coverage includes manager wake/disable verb shape, launchd clean-exit restart behavior, exact previous-binary arguments, quoting/control-character injection, concurrent unit publication, unit replacement refusal, FIFO rejection before reads in both startup and cleanup, canonical unit-directory aliases, live/stale heartbeat decisions, takeover races, stale job stand-down, cleanup tails, and terminal service-restart semantics.

Production call graph:

- there is intentionally no non-test caller yet, confirmed with `rg`; current daemon, Cobra, upgrade, and service-manager behavior are unchanged;
- the next slice will bind the strict internal mode and gate at the process entrypoint together with the identity-scoped supervisor operations, watchdog/hang handling, and quiesce/probation release;
- the daemon-owned discovery loop and removal of `autoUpdateOnLaunch` remain later work.

Exact-head local gates on `d64268b68e03b7d58460de4f813e5731aa25791f`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (empty)
- `go build ./...`
- `scripts/lint-file-length.sh`
- `deadcode -test ./...` (empty)
- `go test -race ./internal/upgradetxn -count=1`
- `go test ./internal/upgradetxn -count=20`
- Darwin arm64 test cross-compile
- `make test-container`
