### PR TITLE
fix(tui): retain tab action identity

### DIFF
--- a/app/creation_test.go
+++ b/app/creation_test.go
@@ -59,10 +59,10 @@ func newTestHome(t *testing.T) *home {
 	// override the relevant seam. createTab/closeTab default to an error so an
 	// unstubbed mutation fails loudly rather than reaching the daemon; setPRInfo
 	// defaults to a no-op so the in-memory PR-badge path stays exercisable.
-	t.Cleanup(SetTabCreatorForTest(func(title, repoID string) (string, string, error) {
-		return "", "", fmt.Errorf("createShellTabThroughDaemon not stubbed in test")
+	t.Cleanup(SetTabCreatorForTest(func(daemon.CreateTabRequest) (string, string, error) {
+		return "", "", fmt.Errorf("createTabThroughDaemon not stubbed in test")
 	}))
-	t.Cleanup(SetTabCloserForTest(func(title, repoID, tabName string) error {
+	t.Cleanup(SetTabCloserForTest(func(daemon.CloseTabRequest) error {
 		return fmt.Errorf("closeTabThroughDaemon not stubbed in test")
 	}))
 	t.Cleanup(SetPRInfoSetterForTest(func(title, repoID string, info session.PRInfoData) error {

--- a/app/daemon_mutation_routing_test.go
+++ b/app/daemon_mutation_routing_test.go
@@ -69,6 +69,32 @@ func TestHandleCloseTab_RoutesThroughDaemon_NoLocalSave(t *testing.T) {
 	requireTUIInstancesEmpty(t, h)
 }
 
+// A tab name is reusable. If another client closes the intended tab and creates
+// a new tab with the same name before the daemon resolves this request, a
+// name-only close kills the replacement. The TUI already holds the stable tab
+// ID and must carry it through the destructive RPC.
+func TestHandleCloseTab_DoesNotTargetReusedTabName(t *testing.T) {
+	h := newTestHome(t)
+	inst := startedLocalInstance(t, "route-close-reuse")
+	selectInstance(h, inst)
+	h.store.SetActiveTab(1)
+
+	target := inst.GetTabs()[1]
+	require.NotEmpty(t, target.ID)
+	replacementID := "replacement-tab-id"
+	daemonNameOwner := map[string]string{target.Name: replacementID}
+	var killedID string
+	restore := SetTabCloserForTest(func(title, repoID, tabName string) error {
+		killedID = daemonNameOwner[tabName]
+		return nil
+	})
+	defer restore()
+
+	_, _ = h.handleCloseTab()
+	require.NotEqual(t, replacementID, killedID,
+		"a reused tab name must not redirect the close to the replacement tab")
+}
+
 // TestHandleCloseTab_AgentTabSkipsDaemon proves the agent-tab rule is enforced
 // TUI-side without a daemon round-trip: `w` on tab 0 is a friendly no-op and the
 // CloseTab RPC is never called.

--- a/app/daemon_mutation_routing_test.go
+++ b/app/daemon_mutation_routing_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/session"
 	sessiongit "github.com/sachiniyer/agent-factory/session/git"
 )
@@ -18,17 +19,17 @@ func TestHandleNewTab_RoutesThroughDaemon_NoLocalSave(t *testing.T) {
 	inst := startedLocalInstance(t, "route-create")
 	selectInstance(h, inst)
 
-	var gotTitle, gotRepo string
-	restore := SetTabCreatorForTest(func(title, repoID string) (string, string, error) {
-		gotTitle, gotRepo = title, repoID
+	var gotRequest daemon.CreateTabRequest
+	restore := SetTabCreatorForTest(func(request daemon.CreateTabRequest) (string, string, error) {
+		gotRequest = request
 		return spawnDaemonTab(inst)
 	})
 	defer restore()
 
 	_, _ = h.handleNewTab()
 
-	require.Equal(t, inst.Title, gotTitle, "CreateTab must be called for the selected session")
-	require.Equal(t, h.repoID, gotRepo, "CreateTab must be scoped to the TUI's repo")
+	require.Equal(t, daemon.CreateTabRequest{ID: inst.ID, Title: inst.Title, RepoID: h.repoID, Shell: true}, gotRequest,
+		"CreateTab must carry the selected session's stable identity")
 	require.Equal(t, 3, inst.TabCount(), "the daemon-created tab must appear locally")
 
 	// On the daemon-success path nothing is written to the TUI's storage — the
@@ -45,13 +46,13 @@ func TestHandleCloseTab_RoutesThroughDaemon_NoLocalSave(t *testing.T) {
 	inst := startedLocalInstance(t, "route-close")
 	selectInstance(h, inst)
 
-	var gotTitle, gotRepo, gotTab string
-	createRestore := SetTabCreatorForTest(func(title, repoID string) (string, string, error) {
+	var gotRequest daemon.CloseTabRequest
+	createRestore := SetTabCreatorForTest(func(daemon.CreateTabRequest) (string, string, error) {
 		return spawnDaemonTab(inst)
 	})
 	defer createRestore()
-	closeRestore := SetTabCloserForTest(func(title, repoID, tabName string) error {
-		gotTitle, gotRepo, gotTab = title, repoID, tabName
+	closeRestore := SetTabCloserForTest(func(request daemon.CloseTabRequest) error {
+		gotRequest = request
 		return nil
 	})
 	defer closeRestore()
@@ -61,9 +62,9 @@ func TestHandleCloseTab_RoutesThroughDaemon_NoLocalSave(t *testing.T) {
 
 	_, _ = h.handleCloseTab()
 
-	require.Equal(t, inst.Title, gotTitle, "CloseTab must be called for the selected session")
-	require.Equal(t, h.repoID, gotRepo, "CloseTab must be scoped to the TUI's repo")
-	require.Equal(t, "shell-2", gotTab, "CloseTab must target the active tab by name")
+	require.Equal(t, daemon.CloseTabRequest{
+		ID: inst.ID, Title: inst.Title, RepoID: h.repoID, TabName: "shell-2",
+	}, gotRequest, "CloseTab must carry the selected session identity and active tab name")
 	require.Equal(t, 2, inst.TabCount(), "the closed tab must be dropped locally")
 
 	requireTUIInstancesEmpty(t, h)
@@ -84,13 +85,19 @@ func TestHandleCloseTab_DoesNotTargetReusedTabName(t *testing.T) {
 	replacementID := "replacement-tab-id"
 	daemonNameOwner := map[string]string{target.Name: replacementID}
 	var killedID string
-	restore := SetTabCloserForTest(func(title, repoID, tabName string) error {
-		killedID = daemonNameOwner[tabName]
+	restore := SetTabCloserForTest(func(request daemon.CloseTabRequest) error {
+		if request.TabID != "" {
+			killedID = request.TabID
+		} else {
+			killedID = daemonNameOwner[request.TabName]
+		}
 		return nil
 	})
 	defer restore()
 
 	_, _ = h.handleCloseTab()
+	require.Equal(t, target.ID, killedID,
+		"the close must resolve the stable tab that was visible when the user acted")
 	require.NotEqual(t, replacementID, killedID,
 		"a reused tab name must not redirect the close to the replacement tab")
 }
@@ -105,7 +112,7 @@ func TestHandleCloseTab_AgentTabSkipsDaemon(t *testing.T) {
 	h.store.SetActiveTab(0)
 
 	called := false
-	restore := SetTabCloserForTest(func(title, repoID, tabName string) error {
+	restore := SetTabCloserForTest(func(daemon.CloseTabRequest) error {
 		called = true
 		return nil
 	})

--- a/app/handle_tabs.go
+++ b/app/handle_tabs.go
@@ -27,8 +27,9 @@ var newTabChoices = []newTabChoice{
 // showNewTabPicker opens the TUI's existing enum-selection overlay for `t`.
 // Terminal and VS Code both need no further input, so they fit this small picker;
 // process and web tabs still need a command or URL and remain on tab-create. The
-// target title is captured now because a background snapshot can arrive while
-// the modal owns the keyboard and may replace the instance pointer.
+// target identity is captured now because a background snapshot can arrive
+// while the modal owns the keyboard and may replace the instance pointer or
+// reuse its display title.
 func (m *home) showNewTabPicker() (tea.Model, tea.Cmd) {
 	selected := m.sidebar.GetSelectedInstance()
 	if selected == nil || selected.HasInFlightOp() {
@@ -42,7 +43,7 @@ func (m *home) showNewTabPicker() (tea.Model, tea.Cmd) {
 	for idx, choice := range newTabChoices {
 		items[idx] = choice.label
 	}
-	m.tabCreateTitle = selected.Title
+	m.tabCreateTarget = captureSessionActionTarget(selected, m.repoID)
 	m.selectionOverlay = overlay.NewSelectionOverlay("New tab", items)
 	m.selectionOverlay.SetWidth(40)
 	m.layoutSelectionOverlay()
@@ -55,7 +56,7 @@ func (m *home) showNewTabPicker() (tea.Model, tea.Cmd) {
 // mistaken for form input or silently create a different kind.
 func (m *home) handleStateSelectTabKind(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.selectionOverlay == nil {
-		m.tabCreateTitle = ""
+		m.tabCreateTarget = sessionActionTarget{}
 		m.state = stateDefault
 		return m, nil
 	}
@@ -65,14 +66,14 @@ func (m *home) handleStateSelectTabKind(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	submitted := m.selectionOverlay.IsSubmitted()
 	idx := m.selectionOverlay.GetSelectedIndex()
-	title := m.tabCreateTitle
+	target := m.tabCreateTarget
 	m.selectionOverlay = nil
-	m.tabCreateTitle = ""
+	m.tabCreateTarget = sessionActionTarget{}
 	m.state = stateDefault
-	if !submitted || title == "" || idx < 0 || idx >= len(newTabChoices) {
+	if !submitted || target.title == "" || idx < 0 || idx >= len(newTabChoices) {
 		return m, nil
 	}
-	selected := m.store.GetInstanceByTitle(title)
+	selected := m.resolveSessionActionTarget(target)
 	if selected == nil {
 		return m, nil
 	}
@@ -107,16 +108,12 @@ func (m *home) createNewTab(selected *session.Instance, kind session.TabKind) (t
 		return m, m.handleError(fmt.Errorf("only local sessions support new tabs — this session's workspace runs off-box (docker/ssh/remote), so there is no local worktree to spawn a tab in"))
 	}
 
-	var name, tmuxName string
-	var err error
-	switch kind {
-	case session.TabKindShell:
-		name, tmuxName, err = createShellTabThroughDaemon(selected.Title, m.repoID)
-	case session.TabKindVSCode:
-		name, tmuxName, err = createVSCodeTabThroughDaemon(selected.Title, m.repoID)
-	default:
+	target := captureSessionActionTarget(selected, m.repoID)
+	request, ok := target.createTabRequest(kind)
+	if !ok {
 		return m, m.handleError(fmt.Errorf("tab kind %d is not available from the TUI", kind))
 	}
+	name, tmuxName, err := createTabThroughDaemon(request)
 	if err != nil {
 		return m, m.handleError(err)
 	}
@@ -207,7 +204,8 @@ func (m *home) handleCloseTab() (tea.Model, tea.Cmd) {
 	if idx >= len(tabs) {
 		return m, m.handleError(fmt.Errorf("tab cannot be closed"))
 	}
-	tabName := tabs[idx].Name
+	tab := tabs[idx]
+	tabName := tab.Name
 	// Capture the slot→identity list before the drop: reconcilePanesForTabs maps
 	// the open panes' bindings across the change by stable tab id (#1088/#1886).
 	oldKeys := paneTabKeys(inst)
@@ -236,7 +234,8 @@ func (m *home) handleCloseTab() (tea.Model, tea.Cmd) {
 		}
 	}
 
-	if err := closeTabThroughDaemon(inst.Title, m.repoID, tabName); err != nil {
+	target := captureSessionActionTarget(inst, m.repoID)
+	if err := closeTabThroughDaemon(target.closeTabRequest(tab.ID, tabName)); err != nil {
 		return m, m.handleError(err)
 	}
 	// The daemon killed the tmux and persisted the shrunk list; drop the

--- a/app/home_model.go
+++ b/app/home_model.go
@@ -381,10 +381,10 @@ type home struct {
 	// selectionOverlay handles short enum choices: program selection during
 	// new-instance naming and tab-kind selection from the new-tab action.
 	selectionOverlay *overlay.SelectionOverlay
-	// tabCreateTitle identifies the session that opened the tab-kind picker.
-	// Background snapshots may move the sidebar selection or replace an instance
-	// pointer while the modal is open, so submit re-resolves this stable title.
-	tabCreateTitle string
+	// tabCreateTarget identifies the session that opened the tab-kind picker.
+	// Background snapshots may move the sidebar selection, replace its pointer,
+	// or reuse its display title while the modal is open (#2358).
+	tabCreateTarget sessionActionTarget
 	// searchOverlay handles session search
 	searchOverlay *overlay.SearchOverlay
 	// projectPickerOverlay handles switching the active project (#1461)

--- a/app/pane_tab_reconcile_test.go
+++ b/app/pane_tab_reconcile_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"testing"
 
+	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/ui/layout"
 
@@ -28,7 +29,7 @@ func TestPane_CloseTabRebindsPanes(t *testing.T) {
 	selectInstance(h, inst)
 	resizeHome(h, 200, 40)
 
-	restore := SetTabCreatorForTest(func(title, repoID string) (string, string, error) {
+	restore := SetTabCreatorForTest(func(daemon.CreateTabRequest) (string, string, error) {
 		return spawnDaemonTab(inst)
 	})
 	defer restore()
@@ -43,7 +44,7 @@ func TestPane_CloseTabRebindsPanes(t *testing.T) {
 
 	// Kill tab 1: its pane hides; the slot-2 pane re-binds to slot 1.
 	h.store.SetActiveTab(1)
-	restoreClose := SetTabCloserForTest(func(title, repoID, tabName string) error { return nil })
+	restoreClose := SetTabCloserForTest(func(daemon.CloseTabRequest) error { return nil })
 	defer restoreClose()
 	_, _ = h.handleCloseTab()
 
@@ -68,7 +69,7 @@ func TestPane_SnapshotTabRemovalRebindsPanes(t *testing.T) {
 	selectInstance(h, inst)
 	resizeHome(h, 200, 40)
 
-	restore := SetTabCreatorForTest(func(title, repoID string) (string, string, error) {
+	restore := SetTabCreatorForTest(func(daemon.CreateTabRequest) (string, string, error) {
 		return spawnDaemonTab(inst)
 	})
 	defer restore()
@@ -105,7 +106,7 @@ func TestPane_SnapshotTabRemovalKeepsUnaffectedPaneBinding(t *testing.T) {
 	selectInstance(h, inst)
 	resizeHome(h, 200, 40)
 
-	restore := SetTabCreatorForTest(func(title, repoID string) (string, string, error) {
+	restore := SetTabCreatorForTest(func(daemon.CreateTabRequest) (string, string, error) {
 		return spawnDaemonTab(inst)
 	})
 	defer restore()

--- a/app/session_action_target.go
+++ b/app/session_action_target.go
@@ -70,3 +70,25 @@ func (target sessionActionTarget) handoffRequest(to string) daemon.HandoffSessio
 func (target sessionActionTarget) resumeFromLimitRequest() daemon.ResumeFromLimitRequest {
 	return daemon.ResumeFromLimitRequest{ID: target.id, Title: target.title, RepoID: target.repoID}
 }
+
+func (target sessionActionTarget) createTabRequest(kind session.TabKind) (daemon.CreateTabRequest, bool) {
+	switch kind {
+	case session.TabKindShell:
+		return daemon.CreateTabRequest{
+			ID: target.id, Title: target.title, RepoID: target.repoID, Shell: true,
+		}, true
+	case session.TabKindVSCode:
+		return daemon.CreateTabRequest{
+			ID: target.id, Title: target.title, RepoID: target.repoID, Kind: "vscode",
+		}, true
+	default:
+		return daemon.CreateTabRequest{}, false
+	}
+}
+
+func (target sessionActionTarget) closeTabRequest(tabID, tabName string) daemon.CloseTabRequest {
+	return daemon.CloseTabRequest{
+		ID: target.id, Title: target.title, RepoID: target.repoID,
+		TabID: tabID, TabName: tabName,
+	}
+}

--- a/app/session_control.go
+++ b/app/session_control.go
@@ -304,7 +304,7 @@ func resumeStatusPollThroughDaemon(title, repoID string) error {
 // choices use it, so VS Code creation sends the same Kind:"vscode" request the
 // CLI does rather than growing a TUI-only implementation. It returns the resolved
 // tab name and, for a shell/process tab, the exact tmux session the daemon spawned.
-func createTabThroughDaemon(req daemon.CreateTabRequest) (string, string, error) {
+var createTabThroughDaemon = func(req daemon.CreateTabRequest) (string, string, error) {
 	var name, tmuxName string
 	err := withDaemonHTTP(func(c *apiclient.Client) error {
 		var e error
@@ -314,26 +314,12 @@ func createTabThroughDaemon(req daemon.CreateTabRequest) (string, string, error)
 	return name, tmuxName, err
 }
 
-// createShellTabThroughDaemon routes the Terminal picker choice through the
-// shared RPC. The returned tab name and tmux name are independent namespaces
-// after a rename (#1957), so AttachShellTab receives both verbatim.
-var createShellTabThroughDaemon = func(title, repoID string) (string, string, error) {
-	return createTabThroughDaemon(daemon.CreateTabRequest{Title: title, RepoID: repoID, Shell: true})
-}
-
-// createVSCodeTabThroughDaemon routes the VS Code picker choice through the same
-// request shape as `af sessions tab-create <title> --kind vscode`. A VS Code tab
-// has no tmux session, so the second return value is empty by design.
-var createVSCodeTabThroughDaemon = func(title, repoID string) (string, string, error) {
-	return createTabThroughDaemon(daemon.CreateTabRequest{Title: title, RepoID: repoID, Kind: "vscode"})
-}
-
 // closeTabThroughDaemon routes the TUI's `w` (close tab) mutation to the daemon,
 // which kills the tab's tmux session and persists the shrunk list. The TUI drops
 // the now-dead tab locally via Instance.DropClosedTab.
-var closeTabThroughDaemon = func(title, repoID, tabName string) error {
+var closeTabThroughDaemon = func(request daemon.CloseTabRequest) error {
 	return withDaemonHTTP(func(c *apiclient.Client) error {
-		_, e := c.CloseTab(daemon.CloseTabRequest{Title: title, RepoID: repoID, TabName: tabName})
+		_, e := c.CloseTab(request)
 		return e
 	})
 }
@@ -464,21 +450,13 @@ func SetLimitResumerForTest(f func(daemon.ResumeFromLimitRequest) error) func() 
 	return func() { resumeFromLimitThroughDaemon = prev }
 }
 
-func SetTabCreatorForTest(f func(title, repoID string) (string, string, error)) func() {
-	prev := createShellTabThroughDaemon
-	createShellTabThroughDaemon = f
-	return func() { createShellTabThroughDaemon = prev }
+func SetTabCreatorForTest(f func(daemon.CreateTabRequest) (string, string, error)) func() {
+	prev := createTabThroughDaemon
+	createTabThroughDaemon = f
+	return func() { createTabThroughDaemon = prev }
 }
 
-// SetVSCodeTabCreatorForTest swaps the VS Code half of the TUI tab-create seam
-// without dialing a daemon.
-func SetVSCodeTabCreatorForTest(f func(title, repoID string) (string, string, error)) func() {
-	prev := createVSCodeTabThroughDaemon
-	createVSCodeTabThroughDaemon = f
-	return func() { createVSCodeTabThroughDaemon = prev }
-}
-
-func SetTabCloserForTest(f func(title, repoID, tabName string) error) func() {
+func SetTabCloserForTest(f func(daemon.CloseTabRequest) error) func() {
 	prev := closeTabThroughDaemon
 	closeTabThroughDaemon = f
 	return func() { closeTabThroughDaemon = prev }

--- a/app/single_writer_test.go
+++ b/app/single_writer_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/session"
 	sessiongit "github.com/sachiniyer/agent-factory/session/git"
 )
@@ -29,7 +30,7 @@ func TestTUIHasNoInstancesWritePath(t *testing.T) {
 	require.NotNil(t, cmd, "quit must still proceed")
 
 	// new shell tab: routed through the daemon (stubbed), reflected locally only.
-	createRestore := SetTabCreatorForTest(func(title, repoID string) (string, string, error) {
+	createRestore := SetTabCreatorForTest(func(daemon.CreateTabRequest) (string, string, error) {
 		return spawnDaemonTab(inst)
 	})
 	defer createRestore()

--- a/app/tab_hotkeys_test.go
+++ b/app/tab_hotkeys_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/internal/testguard"
 	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/session"
@@ -214,11 +215,11 @@ func nextShellTabName(tabs []*session.Tab) string {
 func stubTabDaemonSeams(t *testing.T, inst *session.Instance) (created, closed *int) {
 	t.Helper()
 	var c, d int
-	t.Cleanup(SetTabCreatorForTest(func(title, repoID string) (string, string, error) {
+	t.Cleanup(SetTabCreatorForTest(func(daemon.CreateTabRequest) (string, string, error) {
 		c++
 		return spawnDaemonTab(inst)
 	}))
-	t.Cleanup(SetTabCloserForTest(func(title, repoID, tabName string) error {
+	t.Cleanup(SetTabCloserForTest(func(daemon.CloseTabRequest) error {
 		d++
 		return nil
 	}))
@@ -252,10 +253,12 @@ func TestNewTabPickerCreatesVSCodeThroughDaemon(t *testing.T) {
 	selectInstance(h, inst)
 
 	called := 0
-	t.Cleanup(SetVSCodeTabCreatorForTest(func(title, repoID string) (string, string, error) {
+	t.Cleanup(SetTabCreatorForTest(func(request daemon.CreateTabRequest) (string, string, error) {
 		called++
-		require.Equal(t, inst.Title, title)
-		require.Equal(t, h.repoID, repoID)
+		require.Equal(t, inst.ID, request.ID)
+		require.Equal(t, inst.Title, request.Title)
+		require.Equal(t, h.repoID, request.RepoID)
+		require.Equal(t, "vscode", request.Kind)
 		return "vscode", "", nil
 	}))
 
@@ -296,7 +299,7 @@ func TestNewTabPickerDoesNotTargetSameTitleReplacement(t *testing.T) {
 	require.NotEqual(t, stale.ID, replacement.ID)
 	require.True(t, h.store.ReplaceInstanceByTitle(stale.Title, replacement))
 	called := false
-	t.Cleanup(SetVSCodeTabCreatorForTest(func(title, repoID string) (string, string, error) {
+	t.Cleanup(SetTabCreatorForTest(func(daemon.CreateTabRequest) (string, string, error) {
 		called = true
 		return "vscode", "", nil
 	}))
@@ -307,6 +310,31 @@ func TestNewTabPickerDoesNotTargetSameTitleReplacement(t *testing.T) {
 	require.Equal(t, 1, stale.TabCount(), "the swapped-out projection must stay untouched")
 	require.Equal(t, 1, replacement.TabCount(), "the replacement must not inherit the pending tab create")
 	require.False(t, called, "a stale picker target must fail closed before the daemon request")
+}
+
+func TestNewTabPickerFollowsSameIdentitySnapshotRebuild(t *testing.T) {
+	h := newTestHome(t)
+	stale := freshLocalInstance(t, "vscode-rebuilt")
+	selectInstance(h, stale)
+	_, _ = h.showNewTabPicker()
+
+	rebuilt := freshLocalInstanceNamed(t, stale.Title)
+	rebuilt.ID = stale.ID
+	rebuilt.CreatedAt = stale.CreatedAt
+	require.True(t, h.store.ReplaceInstanceByTitle(stale.Title, rebuilt))
+	var gotRequest daemon.CreateTabRequest
+	t.Cleanup(SetTabCreatorForTest(func(request daemon.CreateTabRequest) (string, string, error) {
+		gotRequest = request
+		return "vscode", "", nil
+	}))
+
+	h.selectionOverlay.SetSelectedIndex(1)
+	_, _ = h.handleStateSelectTabKind(tea.KeyMsg{Type: tea.KeyEnter})
+
+	require.Equal(t, stale.ID, gotRequest.ID,
+		"a pointer rebuild of the same session must retain the captured stable ID")
+	require.Equal(t, 1, stale.TabCount(), "the swapped-out pointer must stay untouched")
+	require.Equal(t, 2, rebuilt.TabCount(), "the live projection of the same session receives the tab")
 }
 
 // TestNewTabPickerDefaultsToTerminal preserves the existing fast path inside the

--- a/app/tab_hotkeys_test.go
+++ b/app/tab_hotkeys_test.go
@@ -283,19 +283,21 @@ func TestNewTabPickerCreatesVSCodeThroughDaemon(t *testing.T) {
 		"the resolved daemon name is the tab's addressable label, matching CLI creation")
 }
 
-// TestNewTabPickerReResolvesSnapshotReplacement guards the modal window: a
-// snapshot may rebuild the selected session while the picker owns the keyboard.
-// Submit must mutate the live replacement, never the orphaned pointer.
-func TestNewTabPickerReResolvesSnapshotReplacement(t *testing.T) {
+// A tab picker retains intent about one session while its modal owns the
+// keyboard. A different session that reuses the title in that window must not
+// inherit the pending create.
+func TestNewTabPickerDoesNotTargetSameTitleReplacement(t *testing.T) {
 	h := newTestHome(t)
 	stale := freshLocalInstance(t, "vscode-stale")
 	selectInstance(h, stale)
 	_, _ = h.showNewTabPicker()
 
 	replacement := freshLocalInstanceNamed(t, stale.Title)
+	require.NotEqual(t, stale.ID, replacement.ID)
 	require.True(t, h.store.ReplaceInstanceByTitle(stale.Title, replacement))
+	called := false
 	t.Cleanup(SetVSCodeTabCreatorForTest(func(title, repoID string) (string, string, error) {
-		require.Equal(t, replacement.Title, title)
+		called = true
 		return "vscode", "", nil
 	}))
 
@@ -303,8 +305,8 @@ func TestNewTabPickerReResolvesSnapshotReplacement(t *testing.T) {
 	_, _ = h.handleStateSelectTabKind(tea.KeyMsg{Type: tea.KeyEnter})
 
 	require.Equal(t, 1, stale.TabCount(), "the swapped-out projection must stay untouched")
-	require.Equal(t, 2, replacement.TabCount())
-	require.Equal(t, session.TabKindVSCode, replacement.GetTabs()[1].Kind)
+	require.Equal(t, 1, replacement.TabCount(), "the replacement must not inherit the pending tab create")
+	require.False(t, called, "a stale picker target must fail closed before the daemon request")
 }
 
 // TestNewTabPickerDefaultsToTerminal preserves the existing fast path inside the

--- a/app/tab_multitab_test.go
+++ b/app/tab_multitab_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/ui/layout"
@@ -171,8 +172,8 @@ func TestCloseTab_TreeFocusUnchanged(t *testing.T) {
 func recordCloseTab(t *testing.T, h *home) *[]string {
 	t.Helper()
 	var names []string
-	t.Cleanup(SetTabCloserForTest(func(title, repoID, tabName string) error {
-		names = append(names, tabName)
+	t.Cleanup(SetTabCloserForTest(func(request daemon.CloseTabRequest) error {
+		names = append(names, request.TabName)
 		return nil
 	}))
 	return &names

--- a/app/tree_nav_test.go
+++ b/app/tree_nav_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/ui"
@@ -151,8 +152,8 @@ func TestTreeNav_TabStopAcrossInstancePreservesParentForActions(t *testing.T) {
 		"instance actions resolve the selected tab's parent instance")
 
 	var createdFor string
-	t.Cleanup(SetTabCreatorForTest(func(title, repoID string) (string, string, error) {
-		createdFor = title
+	t.Cleanup(SetTabCreatorForTest(func(request daemon.CreateTabRequest) (string, string, error) {
+		createdFor = request.Title
 		return spawnDaemonTab(beta)
 	}))
 
@@ -206,11 +207,11 @@ func TestTreeNav_TabCreateCloseFromTabRow(t *testing.T) {
 	selectInstance(h, inst)
 
 	var closedNames []string
-	t.Cleanup(SetTabCreatorForTest(func(title, repoID string) (string, string, error) {
+	t.Cleanup(SetTabCreatorForTest(func(daemon.CreateTabRequest) (string, string, error) {
 		return spawnDaemonTab(inst)
 	}))
-	t.Cleanup(SetTabCloserForTest(func(title, repoID, tabName string) error {
-		closedNames = append(closedNames, tabName)
+	t.Cleanup(SetTabCloserForTest(func(request daemon.CloseTabRequest) error {
+		closedNames = append(closedNames, request.TabName)
 		return nil
 	}))
 

--- a/daemon/control_types.go
+++ b/daemon/control_types.go
@@ -247,9 +247,9 @@ type CreateTabRequest struct {
 	// becomes http://localhost:<port>.
 	Port int `json:"port,omitempty"`
 	// ID is the session's stable id; see KillSessionRequest.ID. When non-empty
-	// the daemon resolves the target session by id first, so a web tab-create
-	// can't hit the wrong session under a cross-repo title collision (#1592
-	// Phase 5 PR7). TUI/CLI callers omit it and resolve by {Title, RepoID}.
+	// the daemon resolves the target session by id first, so web and retained TUI
+	// tab-create actions cannot hit a same-title replacement (#1592 Phase 5 PR7,
+	// #2358). One-shot CLI callers resolve by {Title, RepoID}.
 	ID string `json:"id"`
 }
 
@@ -272,8 +272,9 @@ type CreateTabResponse struct {
 // CloseTabRequest asks the daemon to close a non-agent tab of a session and
 // persist the shrunk tab list (#960 PR 1). Title selects the session; RepoID
 // scopes the lookup like the other sessions verbs (empty = all-repo). The tab
-// is identified by TabName (preferred); when TabName is empty TabIndex selects
-// the tab by its 0-based position. The agent tab (index 0) cannot be closed —
+// is identified by stable TabID when supplied, then TabName; when both are empty
+// TabIndex selects the tab by its 0-based position. The agent tab (index 0)
+// cannot be closed —
 // use KillSession to tear down the whole session — and remote sessions' tabs
 // are fixed by their hook config, so closing them is refused. This mirrors the
 // TUI's `w` rule (handleCloseTab) and #930 PR 4/PR 6 semantics.
@@ -283,9 +284,9 @@ type CloseTabRequest struct {
 	TabName  string `json:"tab_name"`
 	TabIndex int    `json:"tab_index"`
 	// ID is the session's stable id; see KillSessionRequest.ID. When non-empty
-	// the daemon resolves the target session by id first, so a web tab-close
-	// can't hit the wrong session under a cross-repo title collision (#1592
-	// Phase 5 PR7). TUI/CLI callers omit it and resolve by {Title, RepoID}.
+	// the daemon resolves the target session by id first, so web and retained TUI
+	// tab-close actions cannot hit a same-title replacement (#1592 Phase 5 PR7,
+	// #2358). One-shot CLI callers resolve by {Title, RepoID}.
 	ID string `json:"id"`
 	// TabID is the TAB's stable id; see RenameTabRequest.TabID for the full
 	// argument. Close is the verb that needs it MOST, because it is the only
@@ -301,8 +302,9 @@ type CloseTabRequest struct {
 	//
 	// Same contract as the siblings: non-empty WINS over TabName/TabIndex, an
 	// unresolvable id is REFUSED rather than fallen back to the name (#1779), and
-	// empty means "no id supplied" — the CLI/TUI path, resolved by TabName/TabIndex
-	// exactly as before.
+	// empty means "no id supplied" — the CLI and a freshly-created/legacy TUI tab
+	// whose projection has not adopted its daemon ID yet fall back to
+	// TabName/TabIndex exactly as before.
 	TabID string `json:"tab_id"`
 }
 

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -423,7 +423,7 @@
       "title": "Address a session by its stable id rather than by title",
       "tui": {
         "status": "partial",
-        "pointer": "app/session_action_target.go captures stable identity; handle_actions.go sends it for kill/archive/limit retry and handle_handoff.go sends it for handoff"
+        "pointer": "app/session_action_target.go captures stable identity and constructs kill/archive/limit/handoff/tab requests; handle_tabs.go retains it across the tab picker and sends session/tab IDs"
       },
       "web": {
         "status": "yes",
@@ -435,7 +435,7 @@
       },
       "verdict": "real-gap",
       "issue": "#2358",
-      "notes": "#2322 disproved the old blanket 'repo-scoped title is enough' rationale for a TUI action that survives a modal or async command: a killed/recreated row can reuse the title while the user's intent still names the prior stable session. Handoff, kill, archive, and usage-limit retry now carry one captured identity through daemon dispatch and completion. The remaining TUI mutations are still title-addressed and need an action-by-action audit; the CLI remains deliberately repo+title scoped because each invocation resolves and dispatches one command without retained UI intent."
+      "notes": "#2322 disproved the old blanket 'repo-scoped title is enough' rationale for a TUI action that survives a modal or async command: a killed/recreated row can reuse the title while the user's intent still names the prior stable session. Handoff, kill, archive, usage-limit retry, and tab create/close now carry captured identity through their retained boundaries and daemon dispatch; close also sends the stable tab ID when the projection has adopted one. Requests whose wire type still lacks a session ID remain for action-by-action audit; the CLI remains deliberately repo+title scoped because each invocation resolves and dispatches one command without retained UI intent."
     },
     {
       "id": "session.watch",
@@ -1673,9 +1673,6 @@
           }
         },
         "tui": {
-          "id": {
-            "gap": "wire.id-addressing"
-          },
           "command": {
             "gap": "session.tab.create.options"
           },
@@ -1699,18 +1696,12 @@
             "ok": "The CLI addresses the tab by --name; tab_index is the ordinal fallback the daemon only consults when TabName is empty (daemon/control_types.go:248)."
           },
           "tab_id": {
-            "ok": "The TAB's stable id (#1971): the web addresses tabs by it so a reorder can't misroute another client's ordinal; the CLI/TUI address by --name/index and the daemon resolves (session.TabMatches also accepts the displayed label, #1984). A CLI-side tab_id would be a niche convenience, not a gap."
+            "ok": "The CLI addresses the tab by --name, the handle a person has; the web and TUI use stable TabID from their live projections. Adding a CLI-side tab_id would be a niche convenience, not a surface gap."
           }
         },
         "tui": {
-          "id": {
-            "gap": "wire.id-addressing"
-          },
           "tab_index": {
-            "ok": "Same as the CLI: the TUI passes TabName, which is the daemon's preferred lookup key."
-          },
-          "tab_id": {
-            "ok": "The TAB's stable id (#1971): the web addresses tabs by it so a reorder can't misroute another client's ordinal; the CLI/TUI address by --name/index and the daemon resolves (session.TabMatches also accepts the displayed label, #1984). A CLI-side tab_id would be a niche convenience, not a gap."
+            "ok": "The TUI passes stable TabID when available and TabName as the explicit compatibility fallback; it never needs the shifting ordinal fallback."
           }
         }
       },


### PR DESCRIPTION
## Summary

- retain one `sessionActionTarget` across the new-tab kind picker instead of re-resolving its display title
- route Terminal and VS Code creation through one typed `CreateTabRequest` emitter carrying stable session ID, title, and repo scope
- route destructive close through one typed `CloseTabRequest` carrying both stable session ID and the live tab ID, with the name retained only as the explicit legacy/id-less fallback
- update the parity inventory and daemon request contracts to match the now-reachable identity fields

## Reproduction

Two fail-first cases pin the independent reusable identities:

1. while the new-tab picker is open, replace its session with a different same-title session; the old title-only picker creates a VS Code tab on the replacement;
2. before a close resolves, model another client closing the intended tab and recreating its reusable name; the old name-only request kills the replacement tab.

Both failed before the implementation. A same-ID snapshot pointer rebuild still receives the pending create, while a different ID fails closed. Ordinary create/close routing tests prove the exact typed request fields.

## Scope

This is the tab picker/create/close slice of #2358. Tabs created through the TUI still have an explicit pre-snapshot ID-less bootstrap window because `CreateTabResponse` does not return the daemon-minted tab ID; changing that response/projection contract is tracked separately in #2369 rather than hidden behind a name fallback in this diff.

Part of #2358.

## Exact-head gates

Commit: `695c881458cdb72a4b5b40f70ef8356cc286daf1`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (clean)
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh` (979 Go files, 0 grandfathered)
- `make test-container`

All passed on that exact pushed head.

— Captain Claude
