### PR TITLE
feat(web): maximize mobile session content

### DIFF
--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -1992,6 +1992,72 @@ body {
     width: 100%;
     min-height: 2.75rem;
   }
+  .af-app.af-view-sessions.af-session-selected > .af-appbar {
+    position: absolute;
+    inset: 0 0 auto;
+    z-index: var(--af-z-appbar);
+    display: block;
+    height: calc(max(var(--af-sp-1), env(safe-area-inset-top)) + 2.75rem + var(--af-sp-1));
+    padding: 0;
+    background: transparent;
+    border: 0;
+    pointer-events: none;
+  }
+  .af-app.af-view-sessions.af-session-selected > .af-appbar > .af-nav-toggle {
+    position: absolute;
+    top: max(var(--af-sp-1), env(safe-area-inset-top));
+    left: max(var(--af-sp-2), env(safe-area-inset-left));
+    display: inline-flex;
+    width: 2.75rem;
+    height: 2.75rem;
+    padding: 0;
+    pointer-events: auto;
+  }
+  .af-app.af-view-sessions.af-session-selected > .af-appbar > .af-viewnav,
+  .af-app.af-view-sessions.af-session-selected > .af-appbar > .af-project-switch-wrap,
+  .af-app.af-view-sessions.af-session-selected > .af-appbar > .af-appbar-tools-wrap {
+    display: none;
+  }
+  .af-app.af-view-sessions.af-session-selected .af-term-head {
+    min-height: calc(max(var(--af-sp-1), env(safe-area-inset-top)) + 2.75rem + var(--af-sp-1));
+    gap: var(--af-sp-1);
+    padding: max(var(--af-sp-1), env(safe-area-inset-top)) max(var(--af-sp-2), env(safe-area-inset-right)) var(--af-sp-1) calc(max(var(--af-sp-2), env(safe-area-inset-left)) + 2.75rem + var(--af-sp-2));
+  }
+  .af-app.af-view-sessions.af-session-selected .af-term-head-main {
+    display: none;
+  }
+  .af-app.af-view-sessions.af-session-selected .af-tabbar {
+    min-width: 0;
+  }
+  .af-app.af-view-sessions.af-session-selected .af-tab {
+    min-height: 2.75rem;
+  }
+  .af-app.af-view-sessions.af-session-selected.af-nav-open > .af-appbar {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    grid-template-areas: "nav views views" "project project tools";
+    height: auto;
+    align-items: center;
+    gap: var(--af-sp-2);
+    padding: max(var(--af-sp-2), env(safe-area-inset-top)) max(var(--af-sp-2), env(safe-area-inset-right)) var(--af-sp-2) max(var(--af-sp-2), env(safe-area-inset-left));
+    background: var(--af-bg-surface);
+    border-bottom: 1px solid var(--af-border);
+    pointer-events: auto;
+  }
+  .af-app.af-view-sessions.af-session-selected.af-nav-open > .af-appbar > .af-nav-toggle {
+    position: static;
+    width: auto;
+  }
+  .af-app.af-view-sessions.af-session-selected.af-nav-open > .af-appbar > .af-viewnav {
+    display: inline-flex;
+  }
+  .af-app.af-view-sessions.af-session-selected.af-nav-open > .af-appbar > .af-project-switch-wrap,
+  .af-app.af-view-sessions.af-session-selected.af-nav-open > .af-appbar > .af-appbar-tools-wrap {
+    display: block;
+  }
+  .af-app.af-view-sessions.af-session-selected.af-nav-open .af-rail {
+    top: calc(max(var(--af-sp-2), env(safe-area-inset-top)) + 2.75rem + var(--af-sp-2) + 2.75rem + var(--af-sp-2));
+  }
   .af-tab {
     min-height: 2.5rem;
   }

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -8568,6 +8568,12 @@ var AttachTerminal = class {
     this.fitVisibleHost();
     this.term.focus();
   }
+  /** Reconciles this terminal after an app-shell layout/visibility transition.
+   *  Coalesced onto the next painted frame so CSS has settled; the measurable-host
+   *  gate in fitVisibleHost keeps hidden or zero-sized panes inert. */
+  refit() {
+    this.scheduleVisibleFit();
+  }
   /** Takes the keyboard away from the terminal (blurs it) so document-level rail
    *  navigation gets the keys again — the Escape/back-to-nav half of #1693. */
   blur() {
@@ -9189,6 +9195,13 @@ var SplitView = class {
     const theme = currentXtermTheme();
     for (const pane of this.panes.values()) {
       pane.term?.setTheme(theme);
+    }
+  }
+  /** Refit every live terminal after app chrome changes the pane's usable surface.
+   *  Web/VS Code leaves have no terminal and are intentionally inert. */
+  refit() {
+    for (const pane of this.panes.values()) {
+      pane.term?.refit();
     }
   }
   /** Moves pane focus by `delta` (wrapping) and attaches the newly focused pane. */
@@ -11103,6 +11116,10 @@ var AppShell = class {
   tasksPane;
   configPane;
   lastView = null;
+  // Whether the selected sessions surface is using the phone's condensed shell.
+  // Kept separately from lastView/lastSelectedId because either can flip this one
+  // presentation decision. The root class is media-query inert on desktop.
+  lastCondensedSessionChrome = null;
   lastTasks = null;
   lastTasksProject = null;
   // The top-right project switcher (redesign PR2): a button showing the current
@@ -11226,6 +11243,7 @@ var AppShell = class {
     this.navOpen = open;
     this.el.classList.toggle("af-nav-open", open);
     this.navToggle.setAttribute("aria-expanded", open ? "true" : "false");
+    this.actions.layoutChanged();
   }
   /** Runs an action whose result lives outside the session drawer (#2226). Drawer
    *  dismissal belongs to the action's intent, not to where its click happened or
@@ -11242,6 +11260,12 @@ var AppShell = class {
   /** Applies the latest state, touching only what changed. */
   update(state) {
     this.syncDocumentTitle(state);
+    const condensedSessionChrome = usesCondensedSessionChrome(state);
+    if (this.lastCondensedSessionChrome !== condensedSessionChrome) {
+      this.lastCondensedSessionChrome = condensedSessionChrome;
+      this.el.classList.toggle("af-session-selected", condensedSessionChrome);
+      this.actions.layoutChanged();
+    }
     const kb = state.selectedId && state.focus === "terminal" ? "terminal" : "rail";
     if (this.lastKb !== kb) {
       this.lastKb = kb;
@@ -12064,6 +12088,9 @@ function documentTitle(state) {
 function selectedSession(state) {
   return state.selectedId ? state.sessions.find((s) => s.id === state.selectedId) ?? null : null;
 }
+function usesCondensedSessionChrome(state) {
+  return state.view === "sessions" && !!state.selectedId && state.sessions.some((session) => session.id === state.selectedId);
+}
 function tabBarSig(state) {
   const selected = selectedSession(state);
   if (!selected) {
@@ -12850,6 +12877,7 @@ var actions = {
   restore: (session) => openConfirm("restore", session),
   retryLimit: doRetryLimit,
   switchTab,
+  layoutChanged: () => splitView.refit(),
   openTab,
   newTab: createSessionTab,
   closeTab: closeSessionTab,

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "1670578992fd";
+const VERSION = "18b1f4a1a1fa";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -3974,10 +3974,25 @@ test("#2347: the mobile agent terminal also reclaims peer-owned geometry", REAL_
     };
 
     // Each tall peer leaves its authoritative grid behind, then disconnects. That
-    // isolates the direct-input path under test: an activation still queued in a
-    // live peer is a legitimate later writer, not evidence that this host failed to
-    // fit. Exercise the real xterm DOM listeners while the stale peer grid remains.
-    let peer = await openTallPeer("the tall peer must strand the mobile client before the touch check");
+    // isolates the local trigger under test: an activation still queued in a live
+    // peer is a legitimate later writer, not evidence that this host failed to fit.
+    // Start with #2354's explicit drawer transition. dispatchEvent deliberately does
+    // not focus or move a pointer into this page, so the only possible repair is the
+    // app shell's layout-change hook — not #2347's focus/pointer fallbacks.
+    let peer = await openTallPeer("the tall peer must strand the mobile client before the drawer check");
+    await peer.close();
+    await test.step("drawer visibility transitions explicitly refit the active pane", async () => {
+      const app = first.locator(".af-app");
+      const toggle = first.locator(".af-nav-toggle");
+      await toggle.dispatchEvent("click");
+      await expect(app).toHaveClass(/af-nav-open/);
+      await expectSettledLocalGeometry("opening the overlay must reclaim peer-owned terminal geometry");
+      await toggle.dispatchEvent("click");
+      await expect(app).not.toHaveClass(/af-nav-open/);
+    });
+
+    // Exercise the real xterm DOM listeners while the stale peer grid remains.
+    peer = await openTallPeer("the tall peer must strand the mobile client before the touch check");
     await peer.close();
     await test.step("touch scroll input reclaims the peer grid", async () => {
       await firstHost.locator(".af-pane-host").dispatchEvent("touchmove", {
@@ -5069,7 +5084,7 @@ test("new-tab menu (#2219): stays visible, hit-testable, and anchored while the 
   await page.setViewportSize({ width: 1280, height: 720 });
 });
 
-test("#2224: title and tabs share one scrolling header row at every width", REAL_FIXTURE, async ({ browser }, testInfo) => {
+test("#2224/#2354: desktop keeps title + tabs; mobile keeps only hamburger + tabs", REAL_FIXTURE, async ({ browser }, testInfo) => {
   const mockRepo = process.env.AF_MOCK_REPO;
   test.skip(!mockRepo, "AF_MOCK_REPO is set only by web-selftest-entry.sh");
 
@@ -5141,8 +5156,19 @@ test("#2224: title and tabs share one scrolling header row at every width", REAL
             const titleNode = titleBox.locator(".af-term-title");
             const tabbar = head.locator(":scope > .af-tabbar");
             const retry = head.getByRole("button", { name: "Retry", exact: true });
+            const navToggle = p.locator(".af-nav-toggle");
             await expect(tabbar, "the strip belongs to the title row, not a second row").toHaveCount(1);
             await expect(titleNode).toHaveText(title);
+            if (width <= 768) {
+              await expect(titleBox, "mobile spends no row or width on a repeated session title").toBeHidden();
+              await expect(navToggle, "the static hamburger remains the first mobile control").toBeVisible();
+              await expect(p.locator(".af-viewnav"), "top-level navigation moves into the open drawer").toBeHidden();
+              await expect(p.locator(".af-project-switch"), "project chrome moves into the open drawer").toBeHidden();
+              await expect(p.locator(".af-appbar-more"), "app chrome moves into the open drawer").toBeHidden();
+            } else {
+              await expect(titleBox, "desktop keeps its identifying pane title").toBeVisible();
+              await expect(navToggle).toBeHidden();
+            }
             if (roster === "overflow") {
               await expect(retry, "Retry remains reachable at the usage-limit wall").toBeVisible();
             } else {
@@ -5172,6 +5198,7 @@ test("#2224: title and tabs share one scrolling header row at every width", REAL
                 titleBox: rect(".af-term-head-main"),
                 title: rect(".af-term-title"),
                 bar: rect(".af-tabbar"),
+                nav: rect(".af-nav-toggle"),
                 retry: retryEl ? rect(".af-term-action:not([hidden])") : null,
                 host: rect(".af-term-host"),
                 titleClientWidth: titleEl.clientWidth,
@@ -5190,18 +5217,24 @@ test("#2224: title and tabs share one scrolling header row at every width", REAL
             expect(layout.barParent).toContain("af-term-head");
             expect(layout.hostPrevious).toContain("af-term-head");
             expect(layout.head.height, "one row reclaims the old stacked chrome height").toBeLessThan(64);
-            expect(Math.abs(layout.titleBox.centerY - layout.bar.centerY), "title and tabs share a baseline row").toBeLessThanOrEqual(1);
             expect(layout.bar.top).toBeGreaterThanOrEqual(layout.head.top);
             expect(layout.bar.bottom).toBeLessThanOrEqual(layout.head.bottom);
             expect(layout.host.top).toBeGreaterThanOrEqual(layout.head.bottom - 1);
-            expect(layout.titleBox.width, "the title keeps a useful allocation").toBeGreaterThanOrEqual(120);
-            expect(layout.titleClientWidth, "the readable title itself never collapses to a token").toBeGreaterThanOrEqual(88);
-            expect(layout.titleScrollWidth, "the long title really needs truncation").toBeGreaterThan(layout.titleClientWidth);
-            expect({
-              overflow: layout.titleOverflow,
-              textOverflow: layout.titleTextOverflow,
-              whiteSpace: layout.titleWhiteSpace,
-            }).toEqual({ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" });
+            if (width <= 768) {
+              expect(Math.abs(layout.nav.centerY - layout.bar.centerY), "hamburger and tabs share the sole mobile row").toBeLessThanOrEqual(1);
+              expect(layout.titleBox.width, "the repeated mobile title consumes no horizontal space").toBe(0);
+              expect(layout.host.top, "only the slim hamburger/tab row precedes mobile content").toBeLessThan(64);
+            } else {
+              expect(Math.abs(layout.titleBox.centerY - layout.bar.centerY), "desktop title and tabs share a baseline row").toBeLessThanOrEqual(1);
+              expect(layout.titleBox.width, "the desktop title keeps a useful allocation").toBeGreaterThanOrEqual(120);
+              expect(layout.titleClientWidth, "the readable desktop title never collapses to a token").toBeGreaterThanOrEqual(88);
+              expect(layout.titleScrollWidth, "the long desktop title really needs truncation").toBeGreaterThan(layout.titleClientWidth);
+              expect({
+                overflow: layout.titleOverflow,
+                textOverflow: layout.titleTextOverflow,
+                whiteSpace: layout.titleWhiteSpace,
+              }).toEqual({ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" });
+            }
             expect(layout.barClientWidth, "the scrolling strip keeps an operable viewport").toBeGreaterThanOrEqual(96);
             expect(layout.barOverflowX).toBe("auto");
             expect(layout.barPosition, "#1813 marker keeps the tab bar as its containing block").toBe("relative");
@@ -6749,6 +6782,115 @@ async function settledMobileDrawerGeometry(p: Page, title: string) {
     };
   }, title);
 }
+
+test("#2354 mobile: one slim hamburger/tab row owns the viewport and the drawer stays an overlay", REAL_FIXTURE, async ({
+  browser,
+}) => {
+  for (const width of [320, 375]) {
+    await test.step(`${width}px`, async () => {
+      const height = 812;
+      const { ctx, p } = await openAt(browser, width, height);
+      try {
+        const app = p.locator(".af-app");
+        const toggle = p.locator(".af-nav-toggle");
+        const rail = p.locator(".af-rail");
+        const viewNav = p.locator(".af-viewnav");
+        const project = p.locator(".af-project-switch");
+        const more = p.locator(".af-appbar-more");
+
+        await toggle.click();
+        await expect(app).toHaveClass(/af-nav-open/);
+        await row(p, SESSION_ORDER).click();
+        await expect(app).not.toHaveClass(/af-nav-open/);
+        await expect(app, "a real selected session enables the condensed mobile shell").toHaveClass(/af-session-selected/);
+        await expect(p.locator(".af-main.af-main-term")).toBeVisible();
+        await expect(p.locator(".af-term-head-main"), "the title is not a redundant mobile row").toBeHidden();
+        await expect(viewNav, "top-level navigation reserves no closed-state row").toBeHidden();
+        await expect(project, "project chrome reserves no closed-state row").toBeHidden();
+        await expect(more, "secondary app chrome reserves no closed-state row").toBeHidden();
+
+        const geometry = () =>
+          p.evaluate(() => {
+            const rect = (selector: string) => {
+              const box = document.querySelector(selector)!.getBoundingClientRect();
+              return {
+                x: box.x,
+                y: box.y,
+                width: box.width,
+                height: box.height,
+                right: box.right,
+                bottom: box.bottom,
+                centerY: box.top + box.height / 2,
+              };
+            };
+            return {
+              app: rect(".af-app"),
+              toggle: rect(".af-nav-toggle"),
+              head: rect(".af-term-head"),
+              tabs: rect(".af-tabbar"),
+              host: rect(".af-term-host"),
+            };
+          });
+        const closed = await geometry();
+        expect(Math.abs(closed.toggle.centerY - closed.tabs.centerY), "hamburger and tabs share one row").toBeLessThanOrEqual(1);
+        expect(closed.head.height, "the mobile control row stays slim").toBeLessThan(64);
+        expect(closed.host.y - closed.app.y, "session content begins immediately after that one row").toBeLessThan(64);
+        expect(closed.host.bottom, "the pane reaches the mobile viewport bottom").toBeCloseTo(closed.app.bottom, 0);
+
+        // The hamburger reveals navigation as an overlay. The app/project controls
+        // become reachable only inside that transient state, while the pane keeps the
+        // exact same usable rectangle underneath it.
+        await toggle.click();
+        await expect(app).toHaveClass(/af-nav-open/);
+        await expect(rail).toBeVisible();
+        await expect(viewNav).toBeVisible();
+        await expect(project).toBeVisible();
+        await expect(more).toBeVisible();
+        const opened = await geometry();
+        expect(opened.host, "opening the overlay must not resize or displace the pane").toEqual(closed.host);
+
+        // A drawer-only view control is genuinely operable, and leaving Sessions
+        // dismisses the drawer. Returning keeps the selected terminal and restores
+        // the condensed row rather than stacking the old appbar back above it.
+        await viewNav.getByRole("tab", { name: "Tasks", exact: true }).click();
+        await expect(app).not.toHaveClass(/af-nav-open/);
+        await expect(p.locator(".af-tasks")).toBeVisible();
+        await p.getByRole("tab", { name: "Sessions", exact: true }).click();
+        await expect(p.locator(".af-main.af-main-term")).toBeVisible();
+        await expect(app).toHaveClass(/af-session-selected/);
+        await expect(viewNav).toBeHidden();
+
+        // Outside tap is the other drawer exit. Aim at the scrim's exposed right
+        // edge because the left portion is intentionally covered by the rail.
+        await toggle.click();
+        await expect(app).toHaveClass(/af-nav-open/);
+        const scrim = p.locator(".af-nav-scrim");
+        const scrimBox = await scrim.boundingBox();
+        expect(scrimBox, "the open drawer exposes an outside-tap surface").not.toBeNull();
+        await scrim.click({ position: { x: scrimBox!.width - 4, y: scrimBox!.height / 2 } });
+        await expect(app).not.toHaveClass(/af-nav-open/);
+
+        // Switch to a real process terminal from the strip, then change the usable
+        // height. ResizeObserver owns orientation/viewport changes; the row count is
+        // the product signal that FitAddon actually consumed the new geometry.
+        const processTab = p.locator('.af-tabbar .af-tab:has([data-icon="terminal"])').first();
+        await expect(processTab, "the seeded session keeps a real terminal tab for the mobile strip").toBeVisible();
+        await processTab.click();
+        await expect(processTab).toHaveClass(/af-tab-active/);
+        const rows = () => p.locator(".af-term-host .xterm-rows > div").count();
+        await expect.poll(rows, { message: "the selected mobile tab has fitted terminal rows" }).toBeGreaterThan(0);
+        const beforeResizeRows = await rows();
+        await p.setViewportSize({ width, height: height + 120 });
+        await expect
+          .poll(rows, { message: "a taller mobile viewport refits the active terminal without manual recovery" })
+          .toBeGreaterThan(beforeResizeRows);
+        expect(await horizontalOverflow(p), "the condensed shell never widens the phone").toBeLessThanOrEqual(1);
+      } finally {
+        await ctx.close();
+      }
+    });
+  }
+});
 
 test("mobile (375px): the rail auto-collapses to a drawer; the hamburger reveals it as an overlay and picking a session folds it shut", REAL_FIXTURE, async ({
   browser,

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -1319,6 +1319,7 @@ const actions = {
   restore: (session: ActionableSession) => openConfirm("restore", session),
   retryLimit: doRetryLimit,
   switchTab,
+  layoutChanged: () => splitView.refit(),
   openTab,
   newTab: createSessionTab,
   closeTab: closeSessionTab,

--- a/web/src/split.ts
+++ b/web/src/split.ts
@@ -457,6 +457,14 @@ export class SplitView {
     }
   }
 
+  /** Refit every live terminal after app chrome changes the pane's usable surface.
+   *  Web/VS Code leaves have no terminal and are intentionally inert. */
+  refit(): void {
+    for (const pane of this.panes.values()) {
+      pane.term?.refit();
+    }
+  }
+
   /** Moves pane focus by `delta` (wrapping) and attaches the newly focused pane. */
   cyclePane(delta: 1 | -1): void {
     if (!this.tree) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2633,6 +2633,99 @@ body {
     min-height: 2.75rem;
   }
 
+  /* A selected session gets the phone's whole viewport except ONE control row.
+   * The real tab bar stays in the pane header; the appbar leaves flow and places its
+   * hamburger into that same row. This avoids a projected duplicate tab strip (and
+   * the second drag/focus implementation it would require) while preserving the
+   * desktop DOM exactly. Project/view/app controls are hidden only while the drawer
+   * is shut; the open overlay restores them without reflowing the pane underneath. */
+  .af-app.af-view-sessions.af-session-selected > .af-appbar {
+    position: absolute;
+    inset: 0 0 auto;
+    z-index: var(--af-z-appbar);
+    display: block;
+    height: calc(max(var(--af-sp-1), env(safe-area-inset-top)) + 2.75rem + var(--af-sp-1));
+    padding: 0;
+    background: transparent;
+    border: 0;
+    pointer-events: none;
+  }
+
+  .af-app.af-view-sessions.af-session-selected > .af-appbar > .af-nav-toggle {
+    position: absolute;
+    top: max(var(--af-sp-1), env(safe-area-inset-top));
+    left: max(var(--af-sp-2), env(safe-area-inset-left));
+    display: inline-flex;
+    width: 2.75rem;
+    height: 2.75rem;
+    padding: 0;
+    pointer-events: auto;
+  }
+
+  .af-app.af-view-sessions.af-session-selected > .af-appbar > .af-viewnav,
+  .af-app.af-view-sessions.af-session-selected > .af-appbar > .af-project-switch-wrap,
+  .af-app.af-view-sessions.af-session-selected > .af-appbar > .af-appbar-tools-wrap {
+    display: none;
+  }
+
+  .af-app.af-view-sessions.af-session-selected .af-term-head {
+    min-height: calc(max(var(--af-sp-1), env(safe-area-inset-top)) + 2.75rem + var(--af-sp-1));
+    gap: var(--af-sp-1);
+    padding: max(var(--af-sp-1), env(safe-area-inset-top)) max(var(--af-sp-2), env(safe-area-inset-right))
+      var(--af-sp-1) calc(max(var(--af-sp-2), env(safe-area-inset-left)) + 2.75rem + var(--af-sp-2));
+  }
+
+  .af-app.af-view-sessions.af-session-selected .af-term-head-main {
+    display: none;
+  }
+
+  .af-app.af-view-sessions.af-session-selected .af-tabbar {
+    min-width: 0;
+  }
+
+  .af-app.af-view-sessions.af-session-selected .af-tab {
+    min-height: 2.75rem;
+  }
+
+  /* Opening the hamburger restores the existing two-row navigation as a temporary
+   * overlay above both pane and drawer. The rail begins immediately below it, so no
+   * session row is hidden under the controls; neither surface enters pane flow. */
+  .af-app.af-view-sessions.af-session-selected.af-nav-open > .af-appbar {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    grid-template-areas:
+      "nav views views"
+      "project project tools";
+    height: auto;
+    align-items: center;
+    gap: var(--af-sp-2);
+    padding: max(var(--af-sp-2), env(safe-area-inset-top)) max(var(--af-sp-2), env(safe-area-inset-right))
+      var(--af-sp-2) max(var(--af-sp-2), env(safe-area-inset-left));
+    background: var(--af-bg-surface);
+    border-bottom: 1px solid var(--af-border);
+    pointer-events: auto;
+  }
+
+  .af-app.af-view-sessions.af-session-selected.af-nav-open > .af-appbar > .af-nav-toggle {
+    position: static;
+    width: auto;
+  }
+
+  .af-app.af-view-sessions.af-session-selected.af-nav-open > .af-appbar > .af-viewnav {
+    display: inline-flex;
+  }
+
+  .af-app.af-view-sessions.af-session-selected.af-nav-open > .af-appbar > .af-project-switch-wrap,
+  .af-app.af-view-sessions.af-session-selected.af-nav-open > .af-appbar > .af-appbar-tools-wrap {
+    display: block;
+  }
+
+  .af-app.af-view-sessions.af-session-selected.af-nav-open .af-rail {
+    top: calc(
+      max(var(--af-sp-2), env(safe-area-inset-top)) + 2.75rem + var(--af-sp-2) + 2.75rem + var(--af-sp-2)
+    );
+  }
+
   /* Touch targets: lift the primary controls to a ~40-44px tap area so nothing on the
    * terminal path depends on a precise tap or a hover that touch never delivers. */
   .af-tab {

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -298,6 +298,13 @@ export class AttachTerminal {
     this.term.focus();
   }
 
+  /** Reconciles this terminal after an app-shell layout/visibility transition.
+   *  Coalesced onto the next painted frame so CSS has settled; the measurable-host
+   *  gate in fitVisibleHost keeps hidden or zero-sized panes inert. */
+  refit(): void {
+    this.scheduleVisibleFit();
+  }
+
   /** Takes the keyboard away from the terminal (blurs it) so document-level rail
    *  navigation gets the keys again — the Escape/back-to-nav half of #1693. */
   blur(): void {

--- a/web/src/ui.test.ts
+++ b/web/src/ui.test.ts
@@ -16,6 +16,7 @@ import {
   supportsTabManagement,
   tabBarSig,
   tabCreationUnavailableReason,
+  usesCondensedSessionChrome,
 } from "./ui.js";
 import type { AppState } from "./ui.js";
 import { Liveness, type SessionData } from "./types.js";
@@ -193,6 +194,26 @@ test("archiving the selected session changes the sig — the bar must rebuild to
 
 test("no selection collapses to the empty sig", () => {
   assert.equal(tabBarSig(state({ selectedId: null })), "");
+});
+
+test("mobile session chrome condenses only for a real selection on the sessions surface (#2354)", () => {
+  const selected = state({ view: "sessions" });
+  assert.equal(usesCondensedSessionChrome(selected), true, "a selected session gives its row to hamburger + tabs");
+  assert.equal(
+    usesCondensedSessionChrome(state({ view: "tasks" })),
+    false,
+    "another top-level view keeps app navigation in flow",
+  );
+  assert.equal(
+    usesCondensedSessionChrome(state({ view: "sessions", selectedId: null })),
+    false,
+    "no selection keeps navigation",
+  );
+  assert.equal(
+    usesCondensedSessionChrome(state({ view: "sessions", selectedId: "gone" })),
+    false,
+    "a stale id must not hide navigation over the empty pane",
+  );
 });
 
 test("the signature is delimiter-safe: a tab name containing separators can't hide a change", () => {

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -185,6 +185,11 @@ export interface Actions {
   /** Switches the selected session's active tab WITHOUT attaching — the keyboard
    *  stays in rail nav mode (the 1-9 keys, mirroring the TUI). */
   switchTab(index: number): void;
+  /** Re-measures every live terminal after shell chrome changes usable geometry.
+   *  The app shell owns drawer/view/condensed-header state, while SplitView owns
+   *  xterm; this explicit boundary keeps those two owners synchronized without a
+   *  resize-event shim or a polling timer. */
+  layoutChanged(): void;
   /** Switches to a tab AND attaches its terminal (a tab-bar click, mirroring how a
    *  session-row click attaches). */
   openTab(index: number): void;
@@ -605,6 +610,10 @@ export class AppShell {
   private readonly tasksPane: TasksPane;
   private readonly configPane: ConfigPane;
   private lastView: View | null = null;
+  // Whether the selected sessions surface is using the phone's condensed shell.
+  // Kept separately from lastView/lastSelectedId because either can flip this one
+  // presentation decision. The root class is media-query inert on desktop.
+  private lastCondensedSessionChrome: boolean | null = null;
   private lastTasks: TaskData[] | null = null;
   private lastTasksProject: string | null = null;
 
@@ -993,6 +1002,10 @@ export class AppShell {
     this.navOpen = open;
     this.el.classList.toggle("af-nav-open", open);
     this.navToggle.setAttribute("aria-expanded", open ? "true" : "false");
+    // The drawer overlays the pane, so its transition need not change the host's
+    // border box and ResizeObserver may correctly stay silent. It is still a usable-
+    // area/visibility transition: explicitly reconcile xterm on the next paint.
+    this.actions.layoutChanged();
   }
 
   /** Runs an action whose result lives outside the session drawer (#2226). Drawer
@@ -1012,6 +1025,12 @@ export class AppShell {
   /** Applies the latest state, touching only what changed. */
   update(state: AppState): void {
     this.syncDocumentTitle(state);
+    const condensedSessionChrome = usesCondensedSessionChrome(state);
+    if (this.lastCondensedSessionChrome !== condensedSessionChrome) {
+      this.lastCondensedSessionChrome = condensedSessionChrome;
+      this.el.classList.toggle("af-session-selected", condensedSessionChrome);
+      this.actions.layoutChanged();
+    }
     // The keyboard-focus indicator (#1693): a modifier class on the app root that
     // CSS turns into an accent border on whichever pane owns the keyboard. The
     // terminal only "holds" it while a session is actually selected; with none
@@ -2112,6 +2131,21 @@ export function documentTitle(state: AppState): string {
 /** The currently selected session row, or null. */
 function selectedSession(state: AppState): SessionData | null {
   return state.selectedId ? (state.sessions.find((s) => s.id === state.selectedId) ?? null) : null;
+}
+
+/** Whether mobile CSS should collapse the persistent appbar/title chrome into the
+ *  selected session's hamburger + tab row. A stale selected id is deliberately false:
+ *  renderMain shows the empty state in that case, so hiding its app navigation would
+ *  strand the user on a blank shell. Desktop consumes the same class but ignores it
+ *  outside the narrow media query. */
+export function usesCondensedSessionChrome(
+  state: Pick<AppState, "view" | "selectedId" | "sessions">,
+): boolean {
+  return (
+    state.view === "sessions" &&
+    !!state.selectedId &&
+    state.sessions.some((session) => session.id === state.selectedId)
+  );
 }
 
 /** A signature of everything the tab BAR draws for the selected session: which session


### PR DESCRIPTION
## Summary

- collapse the selected-session mobile shell to one hamburger-and-tabs row while leaving desktop chrome unchanged
- keep the sessions rail and its app/project controls in an overlay that never changes the pane rectangle
- explicitly refit live terminals after app-shell visibility/layout transitions, using the existing next-frame, non-zero-size fit gate

## Reproduction and regression

Before the change, the real 320px/375px browser path retained three chrome rows. A tall peer could also leave the mobile client at 107 terminal rows after a drawer transition because the overlay did not resize the host, so `ResizeObserver` had no reason to refit it. The fail-first browser assertions produced three failures: redundant mobile title chrome, no condensed shell state, and terminal geometry that remained peer-owned until an external resize.

The regression suite now proves that:

- desktop retains its title, rail, and tab layout
- 320px and 375px mobile widths use one slim hamburger/tab row and give the remaining viewport to the pane
- drawer open/close, selection, create/kill actions, outside taps, tab changes, and viewport resizing preserve a fitted terminal
- opening the overlay leaves the pane rectangle exactly unchanged
- a programmatic drawer transition with no focus or pointer event reclaims peer-owned xterm geometry through the explicit app-shell hook

## Exact-head gates

Reviewed locally at `7572939c2268e6a511e9024e0c5cbe1b295e365c`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (no output)
- `go build ./...`
- `make test-container`
- `make web-test` (414 tests plus typecheck)
- `make lint-file-length`
- `make web-build` (clean committed bundle)
- `make web-selftest-container` (117 passed, including mobile peer geometry and 320px/375px layout)

Closes #2354
