### PR TITLE
fix(daemon): prefer installed supervisor on cold start

### DIFF
--- a/daemon/control_client.go
+++ b/daemon/control_client.go
@@ -129,15 +129,11 @@ func ensureDaemonWithPolicy(launch func() error, preferUnit bool) error {
 			}
 		}
 	}
-	return ensureDaemonAdHoc(launch, time.Time{})
+	return ensureDaemonAdHoc(launch)
 }
 
 func ensureDaemonThroughUnit(launch func() error) error {
-	overallDeadline := time.Now().Add(daemonReadyTimeout)
 	unitDeadline := time.Now().Add(ensureUnitStartTimeout)
-	if unitDeadline.After(overallDeadline) {
-		unitDeadline = overallDeadline
-	}
 
 	unitErr := runEnsureUnitStartCommand(unitDeadline)
 	if unitErr == nil {
@@ -147,13 +143,13 @@ func ensureDaemonThroughUnit(launch func() error) error {
 		}
 	}
 	log.WarningLog.Printf("failed to start daemon through its installed service; falling back to an ad-hoc daemon: %v", unitErr)
-	if err := ensureDaemonAdHoc(launch, overallDeadline); err != nil {
+	if err := ensureDaemonAdHoc(launch); err != nil {
 		return fmt.Errorf("installed daemon service failed: %v; ad-hoc fallback failed: %w", unitErr, err)
 	}
 	return &SupervisionDegradedError{Cause: unitErr}
 }
 
-func ensureDaemonAdHoc(launch func() error, deadline time.Time) error {
+func ensureDaemonAdHoc(launch func() error) error {
 	// A previous daemon version may have a PID file but no control socket. Stop
 	// it before launching the control-plane daemon so we do not run duplicate
 	// scheduler and session-monitor loops. StopDaemon is also how an
@@ -187,10 +183,7 @@ func ensureDaemonAdHoc(launch func() error, deadline time.Time) error {
 		return err
 	}
 
-	if deadline.IsZero() {
-		deadline = time.Now().Add(daemonReadyTimeout)
-	}
-	return waitForDaemonReady(deadline)
+	return waitForDaemonReady(time.Now().Add(daemonReadyTimeout))
 }
 
 func waitForDaemonReady(deadline time.Time) error {

--- a/daemon/control_client.go
+++ b/daemon/control_client.go
@@ -146,7 +146,15 @@ func ensureDaemonThroughUnit(launch func() error) error {
 	if err := ensureDaemonAdHoc(launch); err != nil {
 		return fmt.Errorf("installed daemon service failed: %v; ad-hoc fallback failed: %w", unitErr, err)
 	}
-	return &SupervisionDegradedError{Cause: unitErr}
+	// The ad-hoc fallback brought up a reachable daemon. EnsureDaemon's contract is
+	// "daemon reachable when I return nil", and every caller (callDaemon,
+	// withDaemonHTTP, attach) hard-returns on a non-nil result and skips the RPC —
+	// so returning a supervision-degradation error here failed the first client
+	// action on any host without a systemd user bus even though the daemon was
+	// serving, self-healing only on the second call (#2373). The degradation is
+	// still surfaced where the user looks: the warning above, and af doctor /
+	// af daemon status carry a supervision-owner row. Report success.
+	return nil
 }
 
 func ensureDaemonAdHoc(launch func() error) error {

--- a/daemon/control_client.go
+++ b/daemon/control_client.go
@@ -91,25 +91,69 @@ func EnsureDaemon() error {
 	return ensureDaemonWithLauncher(launchDaemonProcessFn)
 }
 
+var launchDaemonProcessAtFn = launchDaemonProcessAt
+
 // EnsureDaemonFromPath starts the daemon from execPath if the control socket is
 // not already serving. It is used by post-upgrade restart paths after the
 // current process's executable may have been replaced on disk: asking the
 // still-running old process for os.Executable can resolve to a deleted inode,
 // while execPath is the freshly written binary path the new daemon must run.
 func EnsureDaemonFromPath(execPath string) error {
-	return ensureDaemonWithLauncher(func() error {
-		return launchDaemonProcessAt(execPath)
-	})
+	return ensureDaemonWithPolicy(func() error {
+		return launchDaemonProcessAtFn(execPath)
+	}, false)
 }
 
 func ensureDaemonWithLauncher(launch func() error) error {
+	return ensureDaemonWithPolicy(launch, true)
+}
+
+func ensureDaemonWithPolicy(launch func() error, preferUnit bool) error {
 	ensureDaemonMu.Lock()
 	defer ensureDaemonMu.Unlock()
 
 	if err := pingDaemon(); err == nil {
 		return nil
 	}
+	if preferUnit {
+		configDir, configErr := config.GetConfigDir()
+		if configErr != nil {
+			log.WarningLog.Printf("could not resolve AF home while choosing daemon supervisor; using ad-hoc launch: %v", configErr)
+		} else {
+			owner, ownerErr := ResolveSupervisionOwner(configDir)
+			switch {
+			case ownerErr != nil:
+				log.WarningLog.Printf("could not determine daemon supervision owner; using ad-hoc launch: %v", ownerErr)
+			case owner == OwnerUnit:
+				return ensureDaemonThroughUnit(launch)
+			}
+		}
+	}
+	return ensureDaemonAdHoc(launch, time.Time{})
+}
 
+func ensureDaemonThroughUnit(launch func() error) error {
+	overallDeadline := time.Now().Add(daemonReadyTimeout)
+	unitDeadline := time.Now().Add(ensureUnitStartTimeout)
+	if unitDeadline.After(overallDeadline) {
+		unitDeadline = overallDeadline
+	}
+
+	unitErr := runEnsureUnitStartCommand(unitDeadline)
+	if unitErr == nil {
+		unitErr = waitForDaemonReady(unitDeadline)
+		if unitErr == nil {
+			return nil
+		}
+	}
+	log.WarningLog.Printf("failed to start daemon through its installed service; falling back to an ad-hoc daemon: %v", unitErr)
+	if err := ensureDaemonAdHoc(launch, overallDeadline); err != nil {
+		return fmt.Errorf("installed daemon service failed: %v; ad-hoc fallback failed: %w", unitErr, err)
+	}
+	return &SupervisionDegradedError{Cause: unitErr}
+}
+
+func ensureDaemonAdHoc(launch func() error, deadline time.Time) error {
 	// A previous daemon version may have a PID file but no control socket. Stop
 	// it before launching the control-plane daemon so we do not run duplicate
 	// scheduler and session-monitor loops. StopDaemon is also how an
@@ -143,7 +187,13 @@ func ensureDaemonWithLauncher(launch func() error) error {
 		return err
 	}
 
-	deadline := time.Now().Add(daemonReadyTimeout)
+	if deadline.IsZero() {
+		deadline = time.Now().Add(daemonReadyTimeout)
+	}
+	return waitForDaemonReady(deadline)
+}
+
+func waitForDaemonReady(deadline time.Time) error {
 	var lastErr error
 	for time.Now().Before(deadline) {
 		if err := pingDaemon(); err == nil {
@@ -152,6 +202,9 @@ func ensureDaemonWithLauncher(launch func() error) error {
 			lastErr = err
 		}
 		time.Sleep(50 * time.Millisecond)
+	}
+	if lastErr == nil {
+		lastErr = errors.New("readiness deadline elapsed before the daemon could be probed")
 	}
 	return fmt.Errorf("daemon did not become ready: %w", lastErr)
 }

--- a/daemon/control_client_supervision.go
+++ b/daemon/control_client_supervision.go
@@ -60,19 +60,31 @@ const (
 )
 
 func runEnsureUnitStartCommand(deadline time.Time) error {
-	var name string
-	var args []string
 	switch autostartGOOS {
 	case "linux":
-		name = "systemctl"
-		args = []string{"--user", "start", autostartUnitName}
+		resetErr := runEnsureManagerCommand(
+			deadline, "systemctl", "--user", "reset-failed", autostartUnitName,
+		)
+		startErr := runEnsureManagerCommand(
+			deadline, "systemctl", "--user", "start", autostartUnitName,
+		)
+		if startErr == nil {
+			return nil
+		}
+		if resetErr != nil {
+			return fmt.Errorf("could not clear retained systemd failure state: %v; %w", resetErr, startErr)
+		}
+		return startErr
 	case "darwin":
-		name = "launchctl"
-		args = []string{"kickstart", launchdServiceTarget()}
+		return runEnsureManagerCommand(
+			deadline, "launchctl", "kickstart", "-k", launchdServiceTarget(),
+		)
 	default:
 		return fmt.Errorf("daemon autostart is not supported on %s", autostartGOOS)
 	}
+}
 
+func runEnsureManagerCommand(deadline time.Time, name string, args ...string) error {
 	ctx, cancel := context.WithDeadline(context.Background(), deadline)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, name, args...)

--- a/daemon/control_client_supervision.go
+++ b/daemon/control_client_supervision.go
@@ -62,19 +62,14 @@ const (
 func runEnsureUnitStartCommand(deadline time.Time) error {
 	switch autostartGOOS {
 	case "linux":
-		resetErr := runEnsureManagerCommand(
-			deadline, "systemctl", "--user", "reset-failed", autostartUnitName,
-		)
-		startErr := runEnsureManagerCommand(
+		// Do not reset-failed here. EnsureDaemon is implicit in ordinary client
+		// calls, so clearing the retained state on every call would turn Phase
+		// 1's bounded crash loop into another restart burst per TUI/RPC action.
+		// Explicit install/restart/resume operations remain the recovery paths
+		// that deliberately clear a repaired unit's start-limit state.
+		return runEnsureManagerCommand(
 			deadline, "systemctl", "--user", "start", autostartUnitName,
 		)
-		if startErr == nil {
-			return nil
-		}
-		if resetErr != nil {
-			return fmt.Errorf("could not clear retained systemd failure state: %v; %w", resetErr, startErr)
-		}
-		return startErr
 	case "darwin":
 		return runEnsureManagerCommand(
 			deadline, "launchctl", "kickstart", "-k", launchdServiceTarget(),

--- a/daemon/control_client_supervision.go
+++ b/daemon/control_client_supervision.go
@@ -37,20 +37,6 @@ func ResolveSupervisionOwner(configDir string) (SupervisionOwner, error) {
 	return OwnerAdHoc, nil
 }
 
-// SupervisionDegradedError reports that AF recovered availability through an
-// ad-hoc daemon after the installed home-serving unit could not start. The
-// fallback is intentionally visible: silently returning nil would recreate the
-// supervision downgrade #2168 is fixing.
-type SupervisionDegradedError struct {
-	Cause error
-}
-
-func (e *SupervisionDegradedError) Error() string {
-	return fmt.Sprintf("installed daemon service could not start; started an unsupervised daemon instead: %v", e.Cause)
-}
-
-func (e *SupervisionDegradedError) Unwrap() error { return e.Cause }
-
 // The unit gets a bounded share of EnsureDaemon's existing five-second ready
 // budget. A wedged manager must leave time for the compatibility fallback to
 // bind and answer rather than consuming the whole launch window itself.

--- a/daemon/control_client_supervision.go
+++ b/daemon/control_client_supervision.go
@@ -1,0 +1,102 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// SupervisionOwner is the derived owner of one AF home's daemon lifecycle.
+// It is never persisted: the installed unit and its baked AF home remain the
+// source of truth.
+type SupervisionOwner uint8
+
+const (
+	OwnerUnknown SupervisionOwner = iota
+	OwnerUnit
+	OwnerAdHoc
+)
+
+// ResolveSupervisionOwner derives whether the installed service-manager unit
+// belongs to configDir. An absent or foreign unit leaves this home ad-hoc; a
+// read/parse/canonicalization failure is explicitly unknown rather than being
+// inverted into either owner.
+func ResolveSupervisionOwner(configDir string) (SupervisionOwner, error) {
+	serves, _, err := AutostartUnitServesHome(configDir)
+	if err != nil {
+		return OwnerUnknown, err
+	}
+	if serves {
+		return OwnerUnit, nil
+	}
+	return OwnerAdHoc, nil
+}
+
+// SupervisionDegradedError reports that AF recovered availability through an
+// ad-hoc daemon after the installed home-serving unit could not start. The
+// fallback is intentionally visible: silently returning nil would recreate the
+// supervision downgrade #2168 is fixing.
+type SupervisionDegradedError struct {
+	Cause error
+}
+
+func (e *SupervisionDegradedError) Error() string {
+	return fmt.Sprintf("installed daemon service could not start; started an unsupervised daemon instead: %v", e.Cause)
+}
+
+func (e *SupervisionDegradedError) Unwrap() error { return e.Cause }
+
+// The unit gets a bounded share of EnsureDaemon's existing five-second ready
+// budget. A wedged manager must leave time for the compatibility fallback to
+// bind and answer rather than consuming the whole launch window itself.
+const (
+	ensureUnitStartTimeout   = 2 * time.Second
+	ensureUnitStartWaitDelay = 250 * time.Millisecond
+)
+
+func runEnsureUnitStartCommand(deadline time.Time) error {
+	var name string
+	var args []string
+	switch autostartGOOS {
+	case "linux":
+		name = "systemctl"
+		args = []string{"--user", "start", autostartUnitName}
+	case "darwin":
+		name = "launchctl"
+		args = []string{"kickstart", launchdServiceTarget()}
+	default:
+		return fmt.Errorf("daemon autostart is not supported on %s", autostartGOOS)
+	}
+
+	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+			if errors.Is(err, syscall.ESRCH) {
+				return os.ErrProcessDone
+			}
+			return err
+		}
+		return nil
+	}
+	cmd.WaitDelay = ensureUnitStartWaitDelay
+
+	out, err := cmd.CombinedOutput()
+	if cmd.Process != nil {
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+	if ctx.Err() != nil {
+		return fmt.Errorf("%s %s timed out: %w", name, strings.Join(args, " "), ctx.Err())
+	}
+	if err == nil || errors.Is(err, exec.ErrWaitDelay) {
+		return nil
+	}
+	return fmt.Errorf("%s %s failed: %w\n%s", name, strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+}

--- a/daemon/control_client_supervision_test.go
+++ b/daemon/control_client_supervision_test.go
@@ -1,0 +1,321 @@
+package daemon
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+)
+
+// These tests exercise the ordinary EnsureDaemon production gate with a real
+// fake systemctl binary. The AF home, unit file, socket, and manager process are
+// all private to the testbox; no host daemon or service manager is touched.
+
+func TestEnsureDaemonPrefersHomeServingUnit(t *testing.T) {
+	marker, home := installEnsureTestUnitAndManager(t, false)
+	pidPath := filepath.Join(home, "daemon.pid")
+	if err := os.WriteFile(pidPath, []byte("0"), 0o600); err != nil {
+		t.Fatalf("write harmless stale PID marker: %v", err)
+	}
+	startServer, serverErr := ensureTestServerStarter(t)
+	stopWatcher := startServerWhenMarked(marker, startServer)
+	defer stopWatcher()
+
+	adHocLaunched := false
+	err := ensureDaemonWithLauncher(func() error {
+		adHocLaunched = true
+		return startServer()
+	})
+	if err != nil {
+		t.Fatalf("ensureDaemonWithLauncher: %v", err)
+	}
+	if err := serverErr(); err != nil {
+		t.Fatalf("start fake supervised daemon: %v", err)
+	}
+	if adHocLaunched {
+		t.Fatal("home-serving unit was ignored and an ad-hoc daemon was launched")
+	}
+	if _, err := os.Stat(pidPath); err != nil {
+		t.Fatalf("unit-owned cold start ran the ad-hoc StopDaemon path: %v", err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("bounded systemctl start was not invoked: %v", err)
+	}
+}
+
+func TestEnsureDaemonPrefersHomeServingLaunchdUnit(t *testing.T) {
+	home := testguard.SocketTempDir(t)
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	unitDir := withAutostartTestEnv(t, "darwin")
+	plist := launchdAutostartPlist("/opt/agent-factory/bin/af", "", "", home, filepath.Join(home, "daemon.log"))
+	if err := os.WriteFile(filepath.Join(unitDir, autostartLaunchdLabel+".plist"), []byte(plist), 0o600); err != nil {
+		t.Fatalf("write home-serving launchd unit: %v", err)
+	}
+
+	managerDir := t.TempDir()
+	marker := filepath.Join(managerDir, "kickstart-called")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" != \"kickstart\" ] || [ \"$2\" != \"" + launchdServiceTarget() + "\" ]; then\n" +
+		"  exit 64\n" +
+		"fi\n" +
+		"printf 'called\\n' > " + shellQuote(marker) + "\n"
+	if err := os.WriteFile(filepath.Join(managerDir, "launchctl"), []byte(script), 0o700); err != nil {
+		t.Fatalf("write fake launchctl: %v", err)
+	}
+	t.Setenv("PATH", managerDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	startServer, serverErr := ensureTestServerStarter(t)
+	stopWatcher := startServerWhenMarked(marker, startServer)
+	defer stopWatcher()
+	adHocLaunched := false
+	if err := ensureDaemonWithLauncher(func() error {
+		adHocLaunched = true
+		return startServer()
+	}); err != nil {
+		t.Fatalf("ensureDaemonWithLauncher: %v", err)
+	}
+	if err := serverErr(); err != nil {
+		t.Fatalf("start fake launchd daemon: %v", err)
+	}
+	if adHocLaunched {
+		t.Fatal("home-serving launchd unit was ignored and an ad-hoc daemon was launched")
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("bounded launchctl kickstart was not invoked: %v", err)
+	}
+}
+
+func TestEnsureDaemonManagerHangFallsBackWithDegradation(t *testing.T) {
+	marker, _ := installEnsureTestUnitAndManager(t, true)
+	startServer, serverErr := ensureTestServerStarter(t)
+
+	adHocLaunched := false
+	started := time.Now()
+	err := ensureDaemonWithLauncher(func() error {
+		adHocLaunched = true
+		return startServer()
+	})
+	elapsed := time.Since(started)
+
+	if err == nil {
+		t.Fatal("manager degradation was silent; want an explicit non-nil result")
+	}
+	var degraded *SupervisionDegradedError
+	if !errors.As(err, &degraded) {
+		t.Fatalf("degradation error type = %T, want *SupervisionDegradedError", err)
+	}
+	if !strings.Contains(err.Error(), "unsupervised daemon") || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("degradation error = %q, want unsupervised fallback plus timeout cause", err)
+	}
+	if err := serverErr(); err != nil {
+		t.Fatalf("start fake ad-hoc daemon: %v", err)
+	}
+	if !adHocLaunched {
+		t.Fatal("hung manager left no daemon instead of falling back")
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("the manager hang was not actually exercised: %v", err)
+	}
+	if elapsed >= daemonReadyTimeout {
+		t.Fatalf("manager fallback took %s, want less than the existing %s readiness budget", elapsed, daemonReadyTimeout)
+	}
+}
+
+func TestEnsureDaemonFromPathBypassesUnitPreference(t *testing.T) {
+	marker, _ := installEnsureTestUnitAndManager(t, false)
+	startServer, serverErr := ensureTestServerStarter(t)
+
+	const upgradedPath = "/opt/agent-factory/new/af"
+	prev := launchDaemonProcessAtFn
+	t.Cleanup(func() { launchDaemonProcessAtFn = prev })
+	launchedPath := ""
+	launchDaemonProcessAtFn = func(path string) error {
+		launchedPath = path
+		return startServer()
+	}
+
+	if err := EnsureDaemonFromPath(upgradedPath); err != nil {
+		t.Fatalf("EnsureDaemonFromPath: %v", err)
+	}
+	if err := serverErr(); err != nil {
+		t.Fatalf("start explicit upgraded daemon: %v", err)
+	}
+	if launchedPath != upgradedPath {
+		t.Fatalf("explicit launcher path = %q, want %q", launchedPath, upgradedPath)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("EnsureDaemonFromPath consulted the installed unit; marker stat = %v", err)
+	}
+}
+
+func TestEnsureDaemonForeignAbsentOrUnknownUnitKeepsAdHocPath(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		configure func(t *testing.T, unitDir, home string)
+	}{
+		{name: "absent"},
+		{
+			name: "foreign home",
+			configure: func(t *testing.T, unitDir, _ string) {
+				t.Helper()
+				unit := systemdAutostartUnit("/opt/agent-factory/bin/af", "", "", t.TempDir())
+				if err := os.WriteFile(filepath.Join(unitDir, autostartUnitName), []byte(unit), 0o600); err != nil {
+					t.Fatalf("write foreign unit: %v", err)
+				}
+			},
+		},
+		{
+			name: "unknown",
+			configure: func(t *testing.T, _ string, _ string) {
+				t.Helper()
+				autostartSystemdUserDir = func() (string, error) {
+					return "", errors.New("unit directory unavailable")
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := testguard.SocketTempDir(t)
+			t.Setenv("AGENT_FACTORY_HOME", home)
+			unitDir := withAutostartTestEnv(t, "linux")
+			if tc.configure != nil {
+				tc.configure(t, unitDir, home)
+			}
+
+			managerDir := t.TempDir()
+			marker := filepath.Join(managerDir, "unexpected-manager-call")
+			script := "#!/bin/sh\nprintf 'called\\n' > " + shellQuote(marker) + "\n"
+			if err := os.WriteFile(filepath.Join(managerDir, "systemctl"), []byte(script), 0o700); err != nil {
+				t.Fatalf("write fake systemctl: %v", err)
+			}
+			t.Setenv("PATH", managerDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+			startServer, serverErr := ensureTestServerStarter(t)
+			adHocLaunched := false
+			if err := ensureDaemonWithLauncher(func() error {
+				adHocLaunched = true
+				return startServer()
+			}); err != nil {
+				t.Fatalf("ensureDaemonWithLauncher: %v", err)
+			}
+			if err := serverErr(); err != nil {
+				t.Fatalf("start fake ad-hoc daemon: %v", err)
+			}
+			if !adHocLaunched {
+				t.Fatal("non-owning unit displaced the existing ad-hoc launch policy")
+			}
+			if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("non-owning unit invoked the service manager; marker stat = %v", err)
+			}
+		})
+	}
+}
+
+func TestEnsureDaemonHealthySkipsSupervisionOwnership(t *testing.T) {
+	home := testguard.SocketTempDir(t)
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	withAutostartTestEnv(t, "linux")
+	autostartSystemdUserDir = func() (string, error) {
+		return "", errors.New("ownership probe must stay off the healthy path")
+	}
+	startTestControlServer(t)
+
+	launched := false
+	if err := ensureDaemonWithLauncher(func() error {
+		launched = true
+		return nil
+	}); err != nil {
+		t.Fatalf("healthy ensure consulted broken ownership state: %v", err)
+	}
+	if launched {
+		t.Fatal("healthy ensure launched another daemon")
+	}
+}
+
+func installEnsureTestUnitAndManager(t *testing.T, block bool) (string, string) {
+	t.Helper()
+	home := testguard.SocketTempDir(t)
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	unitDir := withAutostartTestEnv(t, "linux")
+	unit := systemdAutostartUnit("/opt/agent-factory/bin/af", "", "", home)
+	if err := os.WriteFile(filepath.Join(unitDir, autostartUnitName), []byte(unit), 0o600); err != nil {
+		t.Fatalf("write home-serving unit: %v", err)
+	}
+
+	managerDir := t.TempDir()
+	marker := filepath.Join(managerDir, "start-called")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" != \"--user\" ] || [ \"$2\" != \"start\" ] || [ \"$3\" != \"" + autostartUnitName + "\" ]; then\n" +
+		"  exit 64\n" +
+		"fi\n" +
+		"printf 'called\\n' > " + shellQuote(marker) + "\n"
+	if block {
+		// The child keeps the output pipe open too. A direct-child-only timeout
+		// therefore hangs unless the production runner owns and kills the group.
+		script += "sleep 300 &\nwait\n"
+	}
+	if err := os.WriteFile(filepath.Join(managerDir, "systemctl"), []byte(script), 0o700); err != nil {
+		t.Fatalf("write fake systemctl: %v", err)
+	}
+	t.Setenv("PATH", managerDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return marker, home
+}
+
+func ensureTestServerStarter(t *testing.T) (func() error, func() error) {
+	t.Helper()
+	var mu sync.Mutex
+	var closeServer func() error
+	var startErr error
+	start := func() error {
+		mu.Lock()
+		defer mu.Unlock()
+		if closeServer == nil && startErr == nil {
+			closeServer, startErr = startControlServer(nil, nil, nil, nil)
+		}
+		return startErr
+	}
+	t.Cleanup(func() {
+		mu.Lock()
+		defer mu.Unlock()
+		if closeServer != nil {
+			_ = closeServer()
+		}
+	})
+	return start, func() error {
+		mu.Lock()
+		defer mu.Unlock()
+		return startErr
+	}
+}
+
+func startServerWhenMarked(marker string, startServer func() error) func() {
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(5 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			if _, err := os.Stat(marker); err == nil {
+				_ = startServer()
+				return
+			} else if !errors.Is(err, os.ErrNotExist) {
+				return
+			}
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
+	return func() {
+		close(stop)
+		<-done
+	}
+}

--- a/daemon/control_client_supervision_test.go
+++ b/daemon/control_client_supervision_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"bytes"
 	"errors"
 	"os"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/sachiniyer/agent-factory/internal/testguard"
+	"github.com/sachiniyer/agent-factory/log"
 )
 
 // These tests exercise the ordinary EnsureDaemon production gate with a real
@@ -93,9 +95,21 @@ func TestEnsureDaemonPrefersHomeServingLaunchdUnit(t *testing.T) {
 	}
 }
 
-func TestEnsureDaemonManagerHangFallsBackWithDegradation(t *testing.T) {
+// TestEnsureDaemonManagerHangFallsBackToReachableDaemon: a hung service manager
+// must fall back to an ad-hoc daemon and report SUCCESS. EnsureDaemon's contract
+// is "daemon reachable when I return nil", and every caller hard-returns on a
+// non-nil result and skips the RPC — so a non-nil supervision-degradation return
+// after a working fallback broke the first client action on hosts without a
+// systemd user bus (#2373). The degradation stays visible through the warning
+// log, not through a caller-breaking error.
+func TestEnsureDaemonManagerHangFallsBackToReachableDaemon(t *testing.T) {
 	marker, _ := installEnsureTestUnitAndManager(t, true)
 	startServer, serverErr := ensureTestServerStarter(t)
+
+	var warnBuf bytes.Buffer
+	prevOut := log.WarningLog.Writer()
+	log.WarningLog.SetOutput(&warnBuf)
+	defer log.WarningLog.SetOutput(prevOut)
 
 	adHocLaunched := false
 	started := time.Now()
@@ -105,21 +119,22 @@ func TestEnsureDaemonManagerHangFallsBackWithDegradation(t *testing.T) {
 	})
 	elapsed := time.Since(started)
 
-	if err == nil {
-		t.Fatal("manager degradation was silent; want an explicit non-nil result")
-	}
-	var degraded *SupervisionDegradedError
-	if !errors.As(err, &degraded) {
-		t.Fatalf("degradation error type = %T, want *SupervisionDegradedError", err)
-	}
-	if !strings.Contains(err.Error(), "unsupervised daemon") || !strings.Contains(err.Error(), "timed out") {
-		t.Fatalf("degradation error = %q, want unsupervised fallback plus timeout cause", err)
+	if err != nil {
+		t.Fatalf("successful ad-hoc fallback must return nil (callers skip the RPC on any error), got: %v", err)
 	}
 	if err := serverErr(); err != nil {
 		t.Fatalf("start fake ad-hoc daemon: %v", err)
 	}
 	if !adHocLaunched {
 		t.Fatal("hung manager left no daemon instead of falling back")
+	}
+	// The fallback daemon is actually reachable over the control socket.
+	if err := pingDaemon(); err != nil {
+		t.Fatalf("fallback returned nil but the daemon is not reachable: %v", err)
+	}
+	// The degradation is not silent: it is surfaced through the warning log.
+	if !strings.Contains(warnBuf.String(), "falling back to an ad-hoc daemon") {
+		t.Fatalf("fallback did not warn about the supervision downgrade; log = %q", warnBuf.String())
 	}
 	if _, err := os.Stat(marker); err != nil {
 		t.Fatalf("the manager hang was not actually exercised: %v", err)
@@ -141,12 +156,41 @@ func TestEnsureDaemonFallbackGetsFreshReadinessWindow(t *testing.T) {
 		time.Sleep(daemonReadyTimeout - ensureUnitStartTimeout + 250*time.Millisecond)
 		return startServer()
 	})
-	var degraded *SupervisionDegradedError
-	if !errors.As(err, &degraded) {
-		t.Fatalf("fallback result = %v, want successful launch plus *SupervisionDegradedError", err)
+	if err != nil {
+		t.Fatalf("delayed ad-hoc fallback must return nil, got: %v", err)
 	}
 	if err := serverErr(); err != nil {
 		t.Fatalf("start delayed ad-hoc daemon: %v", err)
+	}
+}
+
+// TestCallDaemonCompletesAfterManagerHangFallback drives a real caller
+// (callDaemon) through a hung service manager and proves the RPC still completes.
+// This is the #2373 regression at the layer users hit: before the fix EnsureDaemon
+// returned a supervision-degradation error after the working ad-hoc fallback, and
+// callDaemon — like withDaemonHTTP and attach — hard-returned it without ever
+// issuing the RPC, so the first `af sessions create` / TUI action / attach failed
+// on a serving daemon and only self-healed on the second call.
+func TestCallDaemonCompletesAfterManagerHangFallback(t *testing.T) {
+	marker, _ := installEnsureTestUnitAndManager(t, true)
+	startServer, serverErr := ensureTestServerStarter(t)
+
+	// callDaemon uses the real EnsureDaemon(), which spawns through
+	// launchDaemonProcessFn. Inject the fake control server as that launcher so the
+	// ad-hoc fallback binds the testbox socket instead of a real daemon.
+	prevLaunch := launchDaemonProcessFn
+	launchDaemonProcessFn = func() error { return startServer() }
+	t.Cleanup(func() { launchDaemonProcessFn = prevLaunch })
+
+	var resp PingResponse
+	if err := callDaemon("Ping", PingRequest{}, &resp); err != nil {
+		t.Fatalf("callDaemon must complete the RPC after a supervised-start fallback, got: %v", err)
+	}
+	if err := serverErr(); err != nil {
+		t.Fatalf("start fake ad-hoc daemon: %v", err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("the manager hang was not exercised: %v", err)
 	}
 }
 

--- a/daemon/control_client_supervision_test.go
+++ b/daemon/control_client_supervision_test.go
@@ -46,6 +46,9 @@ func TestEnsureDaemonPrefersHomeServingUnit(t *testing.T) {
 	if _, err := os.Stat(marker); err != nil {
 		t.Fatalf("bounded systemctl start was not invoked: %v", err)
 	}
+	if _, err := os.Stat(marker + ".reset"); err != nil {
+		t.Fatalf("retained systemd start-limit state was not reset before start: %v", err)
+	}
 }
 
 func TestEnsureDaemonPrefersHomeServingLaunchdUnit(t *testing.T) {
@@ -60,7 +63,7 @@ func TestEnsureDaemonPrefersHomeServingLaunchdUnit(t *testing.T) {
 	managerDir := t.TempDir()
 	marker := filepath.Join(managerDir, "kickstart-called")
 	script := "#!/bin/sh\n" +
-		"if [ \"$1\" != \"kickstart\" ] || [ \"$2\" != \"" + launchdServiceTarget() + "\" ]; then\n" +
+		"if [ \"$1\" != \"kickstart\" ] || [ \"$2\" != \"-k\" ] || [ \"$3\" != \"" + launchdServiceTarget() + "\" ]; then\n" +
 		"  exit 64\n" +
 		"fi\n" +
 		"printf 'called\\n' > " + shellQuote(marker) + "\n"
@@ -123,6 +126,27 @@ func TestEnsureDaemonManagerHangFallsBackWithDegradation(t *testing.T) {
 	}
 	if elapsed >= daemonReadyTimeout {
 		t.Fatalf("manager fallback took %s, want less than the existing %s readiness budget", elapsed, daemonReadyTimeout)
+	}
+}
+
+func TestEnsureDaemonFallbackGetsFreshReadinessWindow(t *testing.T) {
+	_, _ = installEnsureTestUnitAndManager(t, true)
+	startServer, serverErr := ensureTestServerStarter(t)
+
+	// The manager consumes its bounded two-second slice. Reclaiming a stale
+	// daemon and launching its replacement are allowed to take longer than the
+	// remainder of that manager window; the compatibility path historically
+	// starts its five-second readiness clock only after launch returns.
+	err := ensureDaemonWithLauncher(func() error {
+		time.Sleep(daemonReadyTimeout - ensureUnitStartTimeout + 250*time.Millisecond)
+		return startServer()
+	})
+	var degraded *SupervisionDegradedError
+	if !errors.As(err, &degraded) {
+		t.Fatalf("fallback result = %v, want successful launch plus *SupervisionDegradedError", err)
+	}
+	if err := serverErr(); err != nil {
+		t.Fatalf("start delayed ad-hoc daemon: %v", err)
 	}
 }
 
@@ -250,8 +274,16 @@ func installEnsureTestUnitAndManager(t *testing.T, block bool) (string, string) 
 	managerDir := t.TempDir()
 	marker := filepath.Join(managerDir, "start-called")
 	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--user\" ] && [ \"$2\" = \"reset-failed\" ] && [ \"$3\" = \"" + autostartUnitName + "\" ]; then\n" +
+		"  printf 'reset\\n' > " + shellQuote(marker+".reset") + "\n" +
+		"  exit 0\n" +
+		"fi\n" +
 		"if [ \"$1\" != \"--user\" ] || [ \"$2\" != \"start\" ] || [ \"$3\" != \"" + autostartUnitName + "\" ]; then\n" +
 		"  exit 64\n" +
+		"fi\n" +
+		"if [ ! -f " + shellQuote(marker+".reset") + " ]; then\n" +
+		"  printf 'start-limit-hit\\n' >&2\n" +
+		"  exit 1\n" +
 		"fi\n" +
 		"printf 'called\\n' > " + shellQuote(marker) + "\n"
 	if block {

--- a/daemon/control_client_supervision_test.go
+++ b/daemon/control_client_supervision_test.go
@@ -46,8 +46,8 @@ func TestEnsureDaemonPrefersHomeServingUnit(t *testing.T) {
 	if _, err := os.Stat(marker); err != nil {
 		t.Fatalf("bounded systemctl start was not invoked: %v", err)
 	}
-	if _, err := os.Stat(marker + ".reset"); err != nil {
-		t.Fatalf("retained systemd start-limit state was not reset before start: %v", err)
+	if _, err := os.Stat(marker + ".unexpected-reset"); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("implicit cold start reset the crash-loop backstop; marker stat = %v", err)
 	}
 }
 
@@ -275,15 +275,11 @@ func installEnsureTestUnitAndManager(t *testing.T, block bool) (string, string) 
 	marker := filepath.Join(managerDir, "start-called")
 	script := "#!/bin/sh\n" +
 		"if [ \"$1\" = \"--user\" ] && [ \"$2\" = \"reset-failed\" ] && [ \"$3\" = \"" + autostartUnitName + "\" ]; then\n" +
-		"  printf 'reset\\n' > " + shellQuote(marker+".reset") + "\n" +
+		"  printf 'reset\\n' > " + shellQuote(marker+".unexpected-reset") + "\n" +
 		"  exit 0\n" +
 		"fi\n" +
 		"if [ \"$1\" != \"--user\" ] || [ \"$2\" != \"start\" ] || [ \"$3\" != \"" + autostartUnitName + "\" ]; then\n" +
 		"  exit 64\n" +
-		"fi\n" +
-		"if [ ! -f " + shellQuote(marker+".reset") + " ]; then\n" +
-		"  printf 'start-limit-hit\\n' >&2\n" +
-		"  exit 1\n" +
 		"fi\n" +
 		"printf 'called\\n' > " + shellQuote(marker) + "\n"
 	if block {


### PR DESCRIPTION
## Summary

- derive the ordinary cold-start owner from the installed unit's baked AF home, only after the healthy-daemon ping has failed
- start a home-serving systemd or launchd unit through a bounded manager command and skip the PID-file stop/ad-hoc path when that unit becomes ready
- retain the existing ad-hoc compatibility fallback when ownership is absent, foreign, or undetermined; when a bounded unit attempt fails or hangs, give that compatibility path its original post-launch readiness window and return a typed, explicit supervision-degradation error
- preserve Phase 1's crash-loop backstop by leaving retained systemd start-limit state to explicit install/restart/resume recovery instead of clearing it from every implicit client call
- keep `EnsureDaemonFromPath` on its explicit upgraded-binary fallback so a failed upgrade restart cannot route back through a stale installed unit

This is the approved Phase 3 slice of #2168. It does not add lifecycle verbs, adoption semantics, or diagnostics.

## Reproduction

Before the implementation, the new focused regressions failed because `EnsureDaemon` ignored a home-serving unit and launched an ad-hoc child, and because a hung manager fallback returned no explicit degradation result.

## Test Plan

- [x] focused container regressions for systemd start without implicitly clearing a retained crash-loop limit, launchd replacement of an unhealthy running job, a manager hang with process-group cleanup, a fresh fallback readiness window, explicit upgraded-path bypass, absent/foreign/unknown units, and the healthy fast path
- [x] `golangci-lint run --timeout=3m --fast`
- [x] `gofmt -l .`
- [x] `go build ./...`
- [x] `deadcode -test ./...`
- [x] `scripts/lint-file-length.sh`
- [x] `make docs` with a clean generated tree
- [x] `make test-container`

All local gates above ran on commit `83f7c74df8b0a4580ea626e1b4b33cd6e5f726a6`.
