### PR TITLE
fix(web): make Shift+Enter insert a newline

### DIFF
--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -191,14 +191,14 @@
       },
       "web": {
         "status": "yes",
-        "pointer": "web/src/terminal.ts:225 onData + :232 attachCustomKeyEventHandler"
+        "pointer": "web/src/terminal.ts:225 onData + :233 attachCustomKeyEventHandler"
       },
       "cli": {
         "status": "yes",
         "pointer": "api/sessions.go:346 sendPromptCmd"
       },
       "verdict": "parity",
-      "notes": "The TUI and web reach this by typing into the live terminal rather than via the SendPrompt RPC; same user capability, different transport. The web maps bare Shift+Enter to LF/Ctrl+J for a multiline agent composer while plain Enter remains the submitting CR."
+      "notes": "The TUI and web reach this by typing into the live terminal rather than via the SendPrompt RPC; same user capability, different transport. In the agent tab, the web maps bare Shift+Enter to LF/Ctrl+J for a multiline composer while plain Enter remains the submitting CR; shell/process tabs retain xterm's native Enter handling."
     },
     {
       "id": "session.send-prompt.broadcast",

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -191,14 +191,14 @@
       },
       "web": {
         "status": "yes",
-        "pointer": "web/src/terminal.ts:151 onData -> sendInput"
+        "pointer": "web/src/terminal.ts:225 onData + :232 attachCustomKeyEventHandler"
       },
       "cli": {
         "status": "yes",
         "pointer": "api/sessions.go:346 sendPromptCmd"
       },
       "verdict": "parity",
-      "notes": "The TUI and web reach this by typing into the live terminal rather than via the SendPrompt RPC; same user capability, different transport."
+      "notes": "The TUI and web reach this by typing into the live terminal rather than via the SendPrompt RPC; same user capability, different transport. The web maps bare Shift+Enter to LF/Ctrl+J for a multiline agent composer while plain Enter remains the submitting CR."
     },
     {
       "id": "session.send-prompt.broadcast",

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -8156,9 +8156,15 @@ var import_xterm = __toESM(require_xterm(), 1);
 
 // src/clipboard.ts
 var ETX = "";
+var LF = "\n";
 function handleClipboardKeydown(ev, deps) {
   if (ev.type !== "keydown") {
     return true;
+  }
+  if (ev.key === "Enter" && ev.shiftKey && !ev.ctrlKey && !ev.metaKey && !ev.altKey) {
+    ev.preventDefault();
+    deps.sendInput(LF);
+    return false;
   }
   if (ev.metaKey || ev.altKey || !ev.ctrlKey) {
     return true;

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -8161,9 +8161,9 @@ function handleClipboardKeydown(ev, deps) {
   if (ev.type !== "keydown") {
     return true;
   }
-  if (ev.key === "Enter" && ev.shiftKey && !ev.ctrlKey && !ev.metaKey && !ev.altKey) {
+  if (deps.composerNewline && ev.key === "Enter" && ev.shiftKey && !ev.ctrlKey && !ev.metaKey && !ev.altKey) {
     ev.preventDefault();
-    deps.sendInput(LF);
+    deps.sendUserInput(LF);
     return false;
   }
   if (ev.metaKey || ev.altKey || !ev.ctrlKey) {
@@ -8464,11 +8464,15 @@ var AttachTerminal = class {
     this.term.onData((data) => this.sendInput(data));
     this.term.attachCustomKeyEventHandler(
       (ev) => handleClipboardKeydown(ev, {
+        composerNewline: this.tab === 0,
         hasSelection: () => this.term.hasSelection(),
         getSelection: () => this.term.getSelection(),
         clearSelection: () => this.term.clearSelection(),
         copy: (text) => this.copyToClipboard(text),
-        sendInput: (text) => this.sendInput(text)
+        sendInput: (text) => this.sendInput(text),
+        // Public Terminal.input(..., true) is xterm's genuine-user-input path:
+        // it scrolls to bottom and clears selection, then fires onData above.
+        sendUserInput: (text) => this.term.input(text, true)
       })
     );
     this.ro = new ResizeObserver(() => this.scheduleFit());

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "4472ff51c6d0";
+const VERSION = "02a6d7eb4855";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -1190,7 +1190,9 @@ test("click-to-attach opens the xterm terminal and shows live output", REAL_FIXT
   await expect(page.locator(".af-term-head button", { hasText: "Kill" })).toHaveCount(0);
 });
 
-test("#2337: Shift+Enter sends LF, plain Enter keeps CR, and a shell accepts both", REAL_FIXTURE, async ({ browser }) => {
+test("#2337: agent Shift+Enter preserves xterm input effects while shell keeps CR", REAL_FIXTURE, async ({
+  browser,
+}) => {
   const ctx = await browser.newContext();
   const p = await ctx.newPage();
   const inputPayloads: number[][] = [];
@@ -1223,9 +1225,60 @@ test("#2337: Shift+Enter sends LF, plain Enter keeps CR, and a shell accepts bot
     await expect.poll(() => inputPayloads.length, { message: "plain Enter must emit one more OpInput" }).toBe(2);
     expect(inputPayloads[1], "plain Enter keeps xterm's submitting CR path").toEqual([0x0d]);
 
-    // The same terminal component owns non-agent tabs. In a real shell LF is a
-    // normal line delimiter (not a literal ^J): execute one command with the new
-    // mapping, then another with plain Enter to pin both paths end to end.
+    // A direct websocket write can produce the right LF while bypassing xterm's
+    // user-input effects. Build real agent scrollback, park at the oldest line,
+    // and create a real xterm selection. Shift+Enter must both reach the PTY and
+    // return the user to the prompt with no stale selection left behind.
+    const host = p.locator(".af-term-host");
+    await host.click();
+    for (let i = 1; i <= 40; i += 1) {
+      await p.keyboard.type(`shift-enter-scroll-${i}`);
+      await p.keyboard.press("Enter");
+    }
+    await expect(host).toContainText("shift-enter-scroll-40", { timeout: 15_000 });
+    const viewport = host.locator(".xterm-viewport");
+    await host.hover();
+    await p.mouse.wheel(0, -5000);
+    await expect(host, "the real wheel must park the agent viewport above the prompt").not.toContainText(
+      "shift-enter-scroll-40",
+    );
+    const parked = await viewport.evaluate((el) => el.scrollTop);
+
+    const oldestRow = host.locator(".xterm-rows > div", { hasText: READY_MARKER }).first();
+    await expect(oldestRow).toBeVisible();
+    const oldestBox = await oldestRow.boundingBox();
+    expect(oldestBox, "the visible ready-marker row must have selectable geometry").toBeTruthy();
+    const { x, y, width, height } = oldestBox as { x: number; y: number; width: number; height: number };
+    await p.mouse.move(x + 4, y + height / 2);
+    await p.mouse.down();
+    await p.mouse.move(x + Math.min(width - 4, 120), y + height / 2, { steps: 8 });
+    await p.mouse.up();
+    const selection = host.locator(".xterm-selection > div");
+    await expect(selection, "the setup must create an actual xterm selection").not.toHaveCount(0);
+
+    inputPayloads.length = 0;
+    await p.keyboard.press("Shift+Enter");
+    await expect.poll(() => inputPayloads.length, { message: "the selected agent still receives one LF" }).toBe(1);
+    expect(inputPayloads[0]).toEqual([0x0a]);
+    await expect(host, "genuine user input must reveal the newest line at the prompt").toContainText(
+      "shift-enter-scroll-40",
+    );
+    await expect
+      .poll(async () => viewport.evaluate((el) => el.scrollTop), {
+        message: "genuine user input must advance the viewport from its parked scrollback position",
+      })
+      .toBeGreaterThan(parked);
+    await expect(selection, "genuine user input must clear the stale xterm selection").toHaveCount(0);
+
+    // Ctrl+C immediately after the newline is the behavioral discriminator: if
+    // the selection survived, the clipboard branch would copy and send no ETX.
+    await p.keyboard.press("Control+c");
+    await expect.poll(() => inputPayloads.length, { message: "Ctrl+C after Shift+Enter must interrupt" }).toBe(2);
+    expect(inputPayloads[1], "the cleared selection leaves Ctrl+C on the interrupt path").toEqual([0x03]);
+
+    // The same terminal component owns non-agent tabs, where raw-mode programs
+    // may distinguish CR from LF. Preserve xterm's historical Shift+Enter CR and
+    // execute one command with each Enter variant to pin both paths end to end.
     await createTerminalTab(p);
     shellCreated = true;
     await expect(p.locator(".af-tab.af-tab-active .af-tab-label")).toHaveText("Terminal", { timeout: 30_000 });
@@ -1235,7 +1288,7 @@ test("#2337: Shift+Enter sends LF, plain Enter keeps CR, and a shell accepts bot
     await p.keyboard.type("echo $((233700 + 42))");
     await p.keyboard.press("Shift+Enter");
     await expect(p.locator(".af-term-host")).toContainText("233742");
-    expect(inputPayloads.at(-1), "a shell receives Shift+Enter as its ordinary LF delimiter").toEqual([0x0a]);
+    expect(inputPayloads.at(-1), "a shell keeps xterm's historical Shift+Enter CR").toEqual([0x0d]);
 
     await p.keyboard.type("echo $((233700 + 43))");
     await p.keyboard.press("Enter");

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -37,6 +37,7 @@
 // AF_WEB_SESSION_A / AF_WEB_SESSION_B. No token is needed.
 
 import { expect, type Browser, type BrowserContext, type Locator, type Page, test } from "@playwright/test";
+import { decode, Op } from "../src/frame.js";
 
 const SESSION_A = process.env.AF_WEB_SESSION_A ?? "probe-a";
 const SESSION_B = process.env.AF_WEB_SESSION_B ?? "probe-b";
@@ -1187,6 +1188,65 @@ test("click-to-attach opens the xterm terminal and shows live output", REAL_FIXT
   await expect(page.locator(".af-term-head button", { hasText: "Prompt" })).toHaveCount(0);
   await expect(page.locator(".af-term-head button", { hasText: "Archive" })).toHaveCount(0);
   await expect(page.locator(".af-term-head button", { hasText: "Kill" })).toHaveCount(0);
+});
+
+test("#2337: Shift+Enter sends LF, plain Enter keeps CR, and a shell accepts both", REAL_FIXTURE, async ({ browser }) => {
+  const ctx = await browser.newContext();
+  const p = await ctx.newPage();
+  const inputPayloads: number[][] = [];
+  let shellCreated = false;
+
+  p.on("websocket", (ws) => {
+    if (!ws.url().includes("/v1/sessions/") || !ws.url().includes("/stream")) {
+      return;
+    }
+    ws.on("framesent", ({ payload }) => {
+      const raw = typeof payload === "string" ? new TextEncoder().encode(payload) : new Uint8Array(payload);
+      const frame = decode(raw);
+      if (frame.op === Op.Input) {
+        inputPayloads.push(Array.from(frame.data));
+      }
+    });
+  });
+
+  try {
+    await openTokenless(p);
+    await row(p, SESSION_A).click();
+    await expect(p.locator(".af-term-host .xterm")).toBeVisible();
+    await expect(p.locator(".af-term-meta")).toContainText("Live");
+
+    await p.keyboard.press("Shift+Enter");
+    await expect.poll(() => inputPayloads.length, { message: "Shift+Enter must emit one OpInput" }).toBe(1);
+    expect(inputPayloads[0], "Shift+Enter reaches the PTY as LF / Ctrl+J, never xterm's default CR").toEqual([0x0a]);
+
+    await p.keyboard.press("Enter");
+    await expect.poll(() => inputPayloads.length, { message: "plain Enter must emit one more OpInput" }).toBe(2);
+    expect(inputPayloads[1], "plain Enter keeps xterm's submitting CR path").toEqual([0x0d]);
+
+    // The same terminal component owns non-agent tabs. In a real shell LF is a
+    // normal line delimiter (not a literal ^J): execute one command with the new
+    // mapping, then another with plain Enter to pin both paths end to end.
+    await createTerminalTab(p);
+    shellCreated = true;
+    await expect(p.locator(".af-tab.af-tab-active .af-tab-label")).toHaveText("Terminal", { timeout: 30_000 });
+    await expect(p.locator(".af-term-meta")).toContainText("Live");
+
+    inputPayloads.length = 0;
+    await p.keyboard.type("echo $((233700 + 42))");
+    await p.keyboard.press("Shift+Enter");
+    await expect(p.locator(".af-term-host")).toContainText("233742");
+    expect(inputPayloads.at(-1), "a shell receives Shift+Enter as its ordinary LF delimiter").toEqual([0x0a]);
+
+    await p.keyboard.type("echo $((233700 + 43))");
+    await p.keyboard.press("Enter");
+    await expect(p.locator(".af-term-host")).toContainText("233743");
+    expect(inputPayloads.at(-1), "plain shell Enter remains CR").toEqual([0x0d]);
+  } finally {
+    if (shellCreated) {
+      await resetToAgentTab(p);
+    }
+    await ctx.close();
+  }
 });
 
 test("the #1694 keyboard model: j/k navigate, Enter attaches, Escape returns to rail", REAL_FIXTURE, async () => {

--- a/web/src/clipboard.test.ts
+++ b/web/src/clipboard.test.ts
@@ -18,16 +18,18 @@ const ETX = "\x03";
 
 /** A recording rig: captures every frame that would hit the WS (as the exact
  *  bytes terminal.ts sends), every clipboard write, and preventDefault calls. */
-function rig(opts: { selection?: string }) {
+function rig(opts: { selection?: string; composerNewline?: boolean }) {
   const enc = new TextEncoder();
   const wire: Uint8Array[] = [];
   const clipboard: string[] = [];
+  const userInput: string[] = [];
   let prevented = 0;
   let cleared = 0;
   // Mutable so clearSelection() genuinely drops it — a later hasSelection() then
   // reports false, exactly as xterm behaves after a real clear.
   let selection = opts.selection ?? "";
   const deps: ClipboardDeps = {
+    composerNewline: opts.composerNewline ?? true,
     hasSelection: () => selection !== "",
     getSelection: () => selection,
     clearSelection: () => {
@@ -37,11 +39,16 @@ function rig(opts: { selection?: string }) {
     copy: (t) => clipboard.push(t),
     // Byte-identical to terminal.ts's input path, so `wire` holds real OpInput frames.
     sendInput: (t) => wire.push(encode(inputFrame(enc.encode(t)))),
+    sendUserInput: (t) => {
+      userInput.push(t);
+      wire.push(encode(inputFrame(enc.encode(t))));
+    },
   };
   return {
     deps,
     wire,
     clipboard,
+    userInput,
     prevented: () => prevented,
     cleared: () => cleared,
     markPrevented: () => {
@@ -81,13 +88,24 @@ function wireInput(frames: Uint8Array[]): string {
 
 // --- Modified Enter: newline in agent composers, plain Enter still submits -----
 
-test("Shift+Enter sends LF on the wire and suppresses xterm's default CR", () => {
+test("agent Shift+Enter sends LF through xterm's user-input path and suppresses its default CR", () => {
   const r = rig({});
   const ret = handleClipboardKeydown(keyEvent({ key: "Enter", shiftKey: true }, r.markPrevented), r.deps);
 
   assert.equal(ret, false, "xterm must not also turn Shift+Enter into a submitting CR");
+  assert.deepEqual(r.userInput, ["\n"], "LF must traverse xterm's genuine-user-input side effects");
   assert.equal(wireInput(r.wire), "\n", "Codex and Claude both bind LF / Ctrl+J to composer newline");
   assert.equal(r.prevented(), 1, "the handled key must not retain browser-default behavior");
+});
+
+test("Shift+Enter stays xterm-owned outside the agent composer", () => {
+  const r = rig({ composerNewline: false });
+  const ret = handleClipboardKeydown(keyEvent({ key: "Enter", shiftKey: true }, r.markPrevented), r.deps);
+
+  assert.equal(ret, true, "shell/process tabs must retain xterm's existing CR mapping");
+  assert.deepEqual(r.userInput, []);
+  assert.equal(wireInput(r.wire), "", "the custom handler sends no replacement byte outside the agent tab");
+  assert.equal(r.prevented(), 0);
 });
 
 test("plain Enter remains xterm-owned so it still submits as CR", () => {

--- a/web/src/clipboard.test.ts
+++ b/web/src/clipboard.test.ts
@@ -79,6 +79,40 @@ function wireInput(frames: Uint8Array[]): string {
   return out;
 }
 
+// --- Modified Enter: newline in agent composers, plain Enter still submits -----
+
+test("Shift+Enter sends LF on the wire and suppresses xterm's default CR", () => {
+  const r = rig({});
+  const ret = handleClipboardKeydown(keyEvent({ key: "Enter", shiftKey: true }, r.markPrevented), r.deps);
+
+  assert.equal(ret, false, "xterm must not also turn Shift+Enter into a submitting CR");
+  assert.equal(wireInput(r.wire), "\n", "Codex and Claude both bind LF / Ctrl+J to composer newline");
+  assert.equal(r.prevented(), 1, "the handled key must not retain browser-default behavior");
+});
+
+test("plain Enter remains xterm-owned so it still submits as CR", () => {
+  const r = rig({});
+  const ret = handleClipboardKeydown(keyEvent({ key: "Enter" }, r.markPrevented), r.deps);
+
+  assert.equal(ret, true, "plain Enter must keep xterm's existing CR path");
+  assert.equal(wireInput(r.wire), "", "the custom handler must not duplicate plain Enter");
+  assert.equal(r.prevented(), 0);
+});
+
+test("Ctrl/Alt/Meta combinations do not get mistaken for bare Shift+Enter", () => {
+  for (const modifiers of [{ ctrlKey: true }, { altKey: true }, { metaKey: true }]) {
+    const r = rig({});
+    const ret = handleClipboardKeydown(
+      keyEvent({ key: "Enter", shiftKey: true, ...modifiers }, r.markPrevented),
+      r.deps,
+    );
+
+    assert.equal(ret, true, JSON.stringify(modifiers));
+    assert.equal(wireInput(r.wire), "", JSON.stringify(modifiers));
+    assert.equal(r.prevented(), 0, JSON.stringify(modifiers));
+  }
+});
+
 // --- Ctrl+C: copy when there's a selection, interrupt when there isn't --------
 
 test("Ctrl+C WITH a selection copies it and sends NO \\x03", () => {

--- a/web/src/clipboard.ts
+++ b/web/src/clipboard.ts
@@ -14,8 +14,8 @@
 //     no-op otherwise, and NEVER interrupts.
 //   - Ctrl+V / Ctrl+Shift+V → paste, by deferring to xterm's native browser
 //     paste (see below).
-//   - Shift+Enter → LF (Ctrl+J), which Codex and Claude bind to composer newline;
-//     plain Enter stays on xterm's CR path and therefore still submits.
+//   - Shift+Enter in the AGENT tab → LF (Ctrl+J), which Codex and Claude bind to
+//     composer newline; non-agent tabs and plain Enter stay on xterm's CR path.
 //
 // This is the DECISION half, kept pure and DOM-free so it unit-tests against
 // what reaches the wire/clipboard rather than against a synthetic keydown.
@@ -40,6 +40,8 @@ export interface ClipboardKeyEvent {
  *  ones; tests supply spies so an assertion can read exactly what would reach the
  *  clipboard and the input frame. */
 export interface ClipboardDeps {
+  /** Whether this PTY is the agent composer rather than a shell/process tab. */
+  composerNewline: boolean;
   /** Whether the terminal currently has a text selection (xterm.hasSelection). */
   hasSelection(): boolean;
   /** The selected text (xterm.getSelection). Only read when hasSelection() is true. */
@@ -51,6 +53,9 @@ export interface ClipboardDeps {
   copy(text: string): void;
   /** Send text to the PTY as OpInput — the same path onData uses for typed keys. */
   sendInput(text: string): void;
+  /** Feed genuine typed input back through xterm so it runs onUserInput effects
+   *  (scroll-to-bottom and selection clearing) before onData sends the bytes. */
+  sendUserInput(text: string): void;
 }
 
 /** The Ctrl+C interrupt byte (End-of-Text), sent verbatim on the no-selection path. */
@@ -66,9 +71,9 @@ const LF = "\n";
  *   - `false` → we fully handled it; xterm skips its own processing so it does not
  *     ALSO emit bytes for the key.
  *
- * Only Ctrl+* clipboard gestures and bare Shift+Enter are claimed. Cmd+* (metaKey)
- * and Alt+* are left untouched so macOS Cmd+C/Cmd+V and agent-specific modified
- * keys keep working exactly as before.
+ * Only Ctrl+* clipboard gestures and bare Shift+Enter in an agent composer are
+ * claimed. Cmd+* (metaKey), Alt+*, and every Enter in a shell/process tab are left
+ * untouched so their browser/xterm/application bindings keep working as before.
  *
  * Paste note: for Ctrl+V (and Ctrl+Shift+V) we return `false` WITHOUT calling
  * preventDefault. In xterm, a custom handler that returns false makes _keyDown
@@ -87,11 +92,21 @@ export function handleClipboardKeydown(ev: ClipboardKeyEvent, deps: ClipboardDep
   // xterm maps Enter and Shift+Enter to the same CR, so the agent cannot otherwise
   // distinguish "newline" from "submit". Both shipped agent composers recognize
   // LF / Ctrl+J as newline without terminal-protocol negotiation. Claim ONLY the
-  // bare Shift variant: plain Enter keeps xterm's CR path, while Ctrl/Alt/Meta
-  // combinations remain available to the agent and terminal.
-  if (ev.key === "Enter" && ev.shiftKey && !ev.ctrlKey && !ev.metaKey && !ev.altKey) {
+  // bare Shift variant in the one agent tab: plain Enter and every non-agent tab
+  // keep xterm's CR path, while Ctrl/Alt/Meta combinations remain available to the
+  // application. Terminal.input(..., true) is deliberate: unlike a direct socket
+  // write it fires xterm's onUserInput path, which scrolls to the prompt and clears
+  // an active selection before onData sends the LF.
+  if (
+    deps.composerNewline &&
+    ev.key === "Enter" &&
+    ev.shiftKey &&
+    !ev.ctrlKey &&
+    !ev.metaKey &&
+    !ev.altKey
+  ) {
     ev.preventDefault();
-    deps.sendInput(LF);
+    deps.sendUserInput(LF);
     return false;
   }
   // Leave Cmd+* (macOS) and Alt+* to the browser/xterm untouched.

--- a/web/src/clipboard.ts
+++ b/web/src/clipboard.ts
@@ -14,6 +14,8 @@
 //     no-op otherwise, and NEVER interrupts.
 //   - Ctrl+V / Ctrl+Shift+V → paste, by deferring to xterm's native browser
 //     paste (see below).
+//   - Shift+Enter → LF (Ctrl+J), which Codex and Claude bind to composer newline;
+//     plain Enter stays on xterm's CR path and therefore still submits.
 //
 // This is the DECISION half, kept pure and DOM-free so it unit-tests against
 // what reaches the wire/clipboard rather than against a synthetic keydown.
@@ -53,6 +55,8 @@ export interface ClipboardDeps {
 
 /** The Ctrl+C interrupt byte (End-of-Text), sent verbatim on the no-selection path. */
 const ETX = "\x03";
+/** Line Feed / Ctrl+J: the cross-agent composer-newline input (#2337). */
+const LF = "\n";
 
 /**
  * Decide what a key event does for clipboard vs. interrupt. Returns whether xterm
@@ -62,9 +66,9 @@ const ETX = "\x03";
  *   - `false` → we fully handled it; xterm skips its own processing so it does not
  *     ALSO emit bytes for the key.
  *
- * Only Ctrl+* is claimed. Cmd+* (metaKey) and Alt+* are left untouched so macOS
- * Cmd+C/Cmd+V keep working exactly as before — the browser copies/pastes before
- * xterm ever sees the key.
+ * Only Ctrl+* clipboard gestures and bare Shift+Enter are claimed. Cmd+* (metaKey)
+ * and Alt+* are left untouched so macOS Cmd+C/Cmd+V and agent-specific modified
+ * keys keep working exactly as before.
  *
  * Paste note: for Ctrl+V (and Ctrl+Shift+V) we return `false` WITHOUT calling
  * preventDefault. In xterm, a custom handler that returns false makes _keyDown
@@ -79,6 +83,16 @@ export function handleClipboardKeydown(ev: ClipboardKeyEvent, deps: ClipboardDep
   // returning false there would suppress xterm's own keyup/keypress bookkeeping.
   if (ev.type !== "keydown") {
     return true;
+  }
+  // xterm maps Enter and Shift+Enter to the same CR, so the agent cannot otherwise
+  // distinguish "newline" from "submit". Both shipped agent composers recognize
+  // LF / Ctrl+J as newline without terminal-protocol negotiation. Claim ONLY the
+  // bare Shift variant: plain Enter keeps xterm's CR path, while Ctrl/Alt/Meta
+  // combinations remain available to the agent and terminal.
+  if (ev.key === "Enter" && ev.shiftKey && !ev.ctrlKey && !ev.metaKey && !ev.altKey) {
+    ev.preventDefault();
+    deps.sendInput(LF);
+    return false;
   }
   // Leave Cmd+* (macOS) and Alt+* to the browser/xterm untouched.
   if (ev.metaKey || ev.altKey || !ev.ctrlKey) {

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -224,10 +224,11 @@ export class AttachTerminal {
     // multibyte char reaches the PTY as the same bytes a real terminal would send.
     this.term.onData((data) => this.sendInput(data));
 
-    // Clipboard vs. interrupt (Sachin's decision — see clipboard.ts): intercept the
-    // key BEFORE xterm turns it into input. Ctrl+C copies a present selection (else
-    // interrupts), Ctrl+Shift+C is an explicit always-copy, and Ctrl+V defers to
-    // xterm's native browser paste. Returning false suppresses xterm's own handling.
+    // Modified input + clipboard decisions (see clipboard.ts): intercept the key
+    // BEFORE xterm turns it into input. Bare Shift+Enter emits LF for an agent
+    // composer newline while plain Enter retains xterm's submitting CR; Ctrl+C
+    // copies a present selection (else interrupts), Ctrl+Shift+C is explicit copy,
+    // and Ctrl+V defers to native paste. False suppresses xterm's own handling.
     this.term.attachCustomKeyEventHandler((ev) =>
       handleClipboardKeydown(ev, {
         hasSelection: () => this.term.hasSelection(),

--- a/web/src/terminal.ts
+++ b/web/src/terminal.ts
@@ -225,17 +225,22 @@ export class AttachTerminal {
     this.term.onData((data) => this.sendInput(data));
 
     // Modified input + clipboard decisions (see clipboard.ts): intercept the key
-    // BEFORE xterm turns it into input. Bare Shift+Enter emits LF for an agent
-    // composer newline while plain Enter retains xterm's submitting CR; Ctrl+C
-    // copies a present selection (else interrupts), Ctrl+Shift+C is explicit copy,
-    // and Ctrl+V defers to native paste. False suppresses xterm's own handling.
+    // BEFORE xterm turns it into input. Bare Shift+Enter emits LF only for the
+    // invariant agent tab at index 0; shell/process tabs and plain Enter retain
+    // xterm's CR. Ctrl+C copies a present selection (else interrupts),
+    // Ctrl+Shift+C is explicit copy, and Ctrl+V defers to native paste. False
+    // suppresses xterm's own handling.
     this.term.attachCustomKeyEventHandler((ev) =>
       handleClipboardKeydown(ev, {
+        composerNewline: this.tab === 0,
         hasSelection: () => this.term.hasSelection(),
         getSelection: () => this.term.getSelection(),
         clearSelection: () => this.term.clearSelection(),
         copy: (text) => this.copyToClipboard(text),
         sendInput: (text) => this.sendInput(text),
+        // Public Terminal.input(..., true) is xterm's genuine-user-input path:
+        // it scrolls to bottom and clears selection, then fires onData above.
+        sendUserInput: (text) => this.term.input(text, true),
       }),
     );
 


### PR DESCRIPTION
## Summary

- map bare Shift+Enter to LF / Ctrl+J only in the invariant agent tab, while plain Enter still submits as CR
- route that LF through xterm's genuine user-input path so it scrolls to the prompt and clears an active selection before the existing `onData` transport runs
- leave shell/process tabs entirely on xterm's native key path, preserving their historical Shift+Enter CR
- pin the behavior in unit, real-browser WebSocket, real-PTY, and parity-ledger coverage

## Reproduction and encoding choice

On master, xterm maps Shift+Enter to the same `0x0d` as plain Enter, so Codex and Claude submit instead of inserting a composer newline. With the regression present and master behavior restored, the unit test failed because the handler returned control to xterm and emitted no replacement LF.

This uses LF rather than CSI-u because both shipped agent composers support it without terminal negotiation:

- Codex CLI 0.144.6's tagged keymap binds Ctrl+J to `editor.insert_newline`.
- Claude Code 2.1.216's shipped shortcut table states `ctrl+j for newline`.

The mapping is scoped to the agent tab. Shell and process tabs retain xterm's CR behavior so raw-mode applications do not see a new Ctrl+J binding.

## Regression proof

The browser test captures client-to-daemon WebSocket frames and drives a real PTY. It creates agent scrollback and a real xterm selection, parks the viewport with a trusted wheel, then proves Shift+Enter emits exactly `[0x0a]`, returns to the prompt, clears the selection, and leaves the following Ctrl+C on the `[0x03]` interrupt path. Against the old committed bundle, LF arrived while the viewport remained parked; the same test passes after rebuilding from the fix.

The shell half executes commands with both Enter variants and captures `[0x0d]` for each. Unit tests independently require the agent LF to use the xterm user-input dependency and require non-agent terminals to fall through untouched. No live maintainer session was created or touched.

## Exact-head gates

Reviewed locally at `4c6b7816ace462e8a4e26fc968a65c8ecfbe016e` after rebasing onto current master and regenerating committed `web/dist`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (no output)
- `go build ./...`
- `make test-container`
- `make web-test` (419 passed plus typecheck)
- `make lint-file-length`
- `make web-build` (clean committed bundle)
- `make web-selftest-container` (118 browser cases)

Closes #2337
