### PR TITLE
fix(tui): retain restore action identity

### DIFF
--- a/app/archive_action_test.go
+++ b/app/archive_action_test.go
@@ -106,10 +106,10 @@ func TestHandleRestore_LostRowRestoresWithoutConfirmation(t *testing.T) {
 	h.store.AddInstance(inst)
 	h.sidebar.SetSelectedInstance(0)
 
-	var gotTitle string
+	var gotRequest daemon.RestoreSessionRequest
 	prev := restoreSessionThroughDaemon
-	restoreSessionThroughDaemon = func(title, repoID string) (string, error) {
-		gotTitle = title
+	restoreSessionThroughDaemon = func(request daemon.RestoreSessionRequest) (string, error) {
+		gotRequest = request
 		return "/worktree/path", nil
 	}
 	defer func() { restoreSessionThroughDaemon = prev }()
@@ -122,10 +122,11 @@ func TestHandleRestore_LostRowRestoresWithoutConfirmation(t *testing.T) {
 	require.NotNil(t, cmd, "Lost restore must dispatch the restore command")
 
 	msg := cmd()
-	require.Equal(t, "worker", gotTitle)
+	require.Equal(t, daemon.RestoreSessionRequest{ID: inst.ID, Title: "worker", RepoID: h.repoID}, gotRequest)
 	done, ok := msg.(instanceRestoredMsg)
 	require.True(t, ok, "the command must emit instanceRestoredMsg")
 	require.NoError(t, done.err)
+	require.Equal(t, inst.ID, done.target.id)
 }
 
 // TestHandleArchive_RestingRowIsNoOp: after the #1605 clean break, `a` on an
@@ -227,19 +228,21 @@ func TestArchiveInstanceCmd_SurfacesError(t *testing.T) {
 func TestRestoreInstanceCmd_CallsDaemon(t *testing.T) {
 	h := newTestHome(t)
 
-	var gotTitle string
+	var gotRequest daemon.RestoreSessionRequest
 	prev := restoreSessionThroughDaemon
-	restoreSessionThroughDaemon = func(title, repoID string) (string, error) {
-		gotTitle = title
+	restoreSessionThroughDaemon = func(request daemon.RestoreSessionRequest) (string, error) {
+		gotRequest = request
 		return "/worktree/path", nil
 	}
 	defer func() { restoreSessionThroughDaemon = prev }()
 
-	msg := h.restoreInstanceCmd("worker")()
-	require.Equal(t, "worker", gotTitle)
+	target := sessionActionTarget{id: "session-id", title: "worker", repoID: h.repoID}
+	msg := h.restoreInstanceCmd(target)()
+	require.Equal(t, target.restoreRequest(), gotRequest)
 	done, ok := msg.(instanceRestoredMsg)
 	require.True(t, ok, "the command must emit instanceRestoredMsg")
 	require.NoError(t, done.err)
+	require.Equal(t, target, done.target)
 }
 
 func TestHandleInstanceRestored_LostRowMarksLive(t *testing.T) {
@@ -248,7 +251,8 @@ func TestHandleInstanceRestored_LostRowMarksLive(t *testing.T) {
 	inst.SetInFlightOpForTest(session.OpRestoring)
 	h.store.AddInstance(inst)
 
-	model, _ := h.handleInstanceRestored(instanceRestoredMsg{title: "worker"})
+	target := captureSessionActionTarget(inst, h.repoID)
+	model, _ := h.handleInstanceRestored(instanceRestoredMsg{target: target})
 	h = model.(*home)
 
 	require.Equal(t, session.Running, inst.GetStatus())

--- a/app/archive_reconcile_test.go
+++ b/app/archive_reconcile_test.go
@@ -390,7 +390,8 @@ func TestHandleInstanceRestored_FailureDropsBackToArchived(t *testing.T) {
 	h.store.AddInstance(inst)
 	require.False(t, inst.ShownArchived(), "precondition: eagerly re-homed to Instances")
 
-	h.handleInstanceRestored(instanceRestoredMsg{title: "worker", err: fmt.Errorf("origin repo gone")})
+	target := captureSessionActionTarget(inst, h.repoID)
+	h.handleInstanceRestored(instanceRestoredMsg{target: target, err: fmt.Errorf("origin repo gone")})
 
 	require.Equal(t, session.OpNone, inst.GetInFlightOp(), "a failed restore clears the overlay")
 	require.True(t, inst.ShownArchived(),

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -386,6 +386,7 @@ func (m *home) handleRestore() (tea.Model, tea.Cmd) {
 		return m, m.handleError(fmt.Errorf("session '%s' is being deleted", selected.Title))
 	}
 	title := selected.Title
+	target := captureSessionActionTarget(selected, m.repoID)
 
 	// Only a resting (Archived/Lost/Dead) row can be restored; on a live row `r`
 	// does nothing (archive is on `a`).
@@ -396,7 +397,7 @@ func (m *home) handleRestore() (tea.Model, tea.Cmd) {
 		return m, m.handleError(fmt.Errorf("session '%s' is already being restored", title))
 	}
 	_ = selected.Transition(session.MarkRestoring())
-	return m, m.restoreInstanceCmd(title)
+	return m, m.restoreInstanceCmd(target)
 }
 
 // archiveInstanceCmd runs the daemon archive (tmux teardown + worktree move) off
@@ -414,15 +415,14 @@ func (m *home) archiveInstanceCmd(target sessionActionTarget) tea.Cmd {
 }
 
 // restoreInstanceCmd runs the daemon restore/recovery off the event loop.
-func (m *home) restoreInstanceCmd(title string) tea.Cmd {
-	repoID := m.repoID
+func (m *home) restoreInstanceCmd(target sessionActionTarget) tea.Cmd {
 	restore := restoreSessionThroughDaemon
 	return func() tea.Msg {
-		if _, err := restore(title, repoID); err != nil {
-			log.ErrorLog.Printf("could not restore instance %q: %v", title, err)
-			return instanceRestoredMsg{title: title, err: err}
+		if _, err := restore(target.restoreRequest()); err != nil {
+			log.ErrorLog.Printf("could not restore instance %q: %v", target.title, err)
+			return instanceRestoredMsg{target: target, err: err}
 		}
-		return instanceRestoredMsg{title: title}
+		return instanceRestoredMsg{target: target}
 	}
 }
 
@@ -534,23 +534,15 @@ func (m *home) handleLimitRetried(msg limitRetriedMsg) (tea.Model, tea.Cmd) {
 // row drops back into the Archived section — its worktree is still shelved — and
 // surface the error.
 func (m *home) handleInstanceRestored(msg instanceRestoredMsg) (tea.Model, tea.Cmd) {
+	inst := m.resolveSessionActionTarget(msg.target)
 	if msg.err != nil {
-		for _, inst := range m.store.GetInstances() {
-			if inst.Title == msg.title && inst.GetInFlightOp() == session.OpRestoring {
-				_ = inst.Transition(session.ClearOp())
-				break
-			}
+		if inst != nil && inst.GetInFlightOp() == session.OpRestoring {
+			_ = inst.Transition(session.ClearOp())
 		}
-		return m, m.handleError(fmt.Errorf("failed to restore session '%s': %w", msg.title, msg.err))
+		return m, m.handleError(fmt.Errorf("failed to restore session '%s': %w", msg.target.title, msg.err))
 	}
-	for _, inst := range m.store.GetInstances() {
-		switch {
-		case inst.Title != msg.title:
-			continue
-		case inst.GetLiveness() == session.LiveLost || inst.GetLiveness() == session.LiveDead:
-			_ = inst.Transition(session.ConfirmLive())
-		}
-		break
+	if inst != nil && (inst.GetLiveness() == session.LiveLost || inst.GetLiveness() == session.LiveDead) {
+		_ = inst.Transition(session.ConfirmLive())
 	}
 	return m, m.selectionChanged()
 }

--- a/app/messages.go
+++ b/app/messages.go
@@ -67,8 +67,8 @@ type instanceArchivedMsg struct {
 }
 
 type instanceRestoredMsg struct {
-	title string
-	err   error
+	target sessionActionTarget
+	err    error
 }
 
 // runOnEventLoopMsg is a test-only primitive: when received by Update, it

--- a/app/restore_action_identity_test.go
+++ b/app/restore_action_identity_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/session"
 )
 
@@ -18,10 +19,17 @@ func TestHandleRestore_DoesNotTargetSameTitleReplacement(t *testing.T) {
 	h.store.AddInstance(original)
 	h.sidebar.SetSelectedInstance(0)
 
+	var gotRequest daemon.RestoreSessionRequest
 	var restored *session.Instance
 	previous := restoreSessionThroughDaemon
-	restoreSessionThroughDaemon = func(title, repoID string) (string, error) {
-		restored = h.store.GetInstanceByTitle(title)
+	restoreSessionThroughDaemon = func(request daemon.RestoreSessionRequest) (string, error) {
+		gotRequest = request
+		for _, inst := range h.store.GetInstances() {
+			if inst.ID == request.ID {
+				restored = inst
+				break
+			}
+		}
 		return "/restored", nil
 	}
 	t.Cleanup(func() { restoreSessionThroughDaemon = previous })
@@ -34,7 +42,9 @@ func TestHandleRestore_DoesNotTargetSameTitleReplacement(t *testing.T) {
 	require.True(t, h.store.ReplaceInstance(original, replacement))
 
 	_ = cmd()
-	require.NotSame(t, replacement, restored,
+	require.Equal(t, original.ID, gotRequest.ID)
+	require.Equal(t, original.Title, gotRequest.Title)
+	require.Nil(t, restored,
 		"a queued restore must not resurrect a different same-title session")
 }
 
@@ -70,6 +80,7 @@ func TestHandleInstanceRestored_DoesNotMutateSameTitleReplacement(t *testing.T) 
 			h := newTestHome(t)
 			original := archiveActionInstance(t, "worker", session.Lost)
 			h.store.AddInstance(original)
+			target := captureSessionActionTarget(original, h.repoID)
 
 			replacement := archiveActionInstance(t, original.Title, session.Lost)
 			require.NotEqual(t, original.ID, replacement.ID)
@@ -78,7 +89,7 @@ func TestHandleInstanceRestored_DoesNotMutateSameTitleReplacement(t *testing.T) 
 			}
 			require.True(t, h.store.ReplaceInstance(original, replacement))
 
-			_, _ = h.handleInstanceRestored(instanceRestoredMsg{title: original.Title, err: tc.err})
+			_, _ = h.handleInstanceRestored(instanceRestoredMsg{target: target, err: tc.err})
 			tc.assert(t, replacement)
 		})
 	}

--- a/app/restore_action_identity_test.go
+++ b/app/restore_action_identity_test.go
@@ -1,0 +1,85 @@
+package app
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// Restore runs after the event-loop keypress. If the original row disappears
+// before the tea.Cmd reaches the daemon, a title-only request can resurrect a
+// different session that reused the display title.
+func TestHandleRestore_DoesNotTargetSameTitleReplacement(t *testing.T) {
+	h := newTestHome(t)
+	original := archiveActionInstance(t, "worker", session.Lost)
+	h.store.AddInstance(original)
+	h.sidebar.SetSelectedInstance(0)
+
+	var restored *session.Instance
+	previous := restoreSessionThroughDaemon
+	restoreSessionThroughDaemon = func(title, repoID string) (string, error) {
+		restored = h.store.GetInstanceByTitle(title)
+		return "/restored", nil
+	}
+	t.Cleanup(func() { restoreSessionThroughDaemon = previous })
+
+	_, cmd := h.handleRestore()
+	require.NotNil(t, cmd)
+
+	replacement := archiveActionInstance(t, original.Title, session.Lost)
+	require.NotEqual(t, original.ID, replacement.ID)
+	require.True(t, h.store.ReplaceInstance(original, replacement))
+
+	_ = cmd()
+	require.NotSame(t, replacement, restored,
+		"a queued restore must not resurrect a different same-title session")
+}
+
+// Restore completion is retained intent too. An old result must not confirm a
+// replacement live or clear the replacement's own restore operation.
+func TestHandleInstanceRestored_DoesNotMutateSameTitleReplacement(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		err    error
+		setup  func(*testing.T, *session.Instance)
+		assert func(*testing.T, *session.Instance)
+	}{
+		{
+			name: "success",
+			assert: func(t *testing.T, replacement *session.Instance) {
+				require.Equal(t, session.Lost, replacement.GetStatus(),
+					"the old success must not mark the replacement live")
+			},
+		},
+		{
+			name: "failure",
+			err:  errors.New("old restore failed"),
+			setup: func(t *testing.T, replacement *session.Instance) {
+				require.NoError(t, replacement.Transition(session.MarkRestoring()))
+			},
+			assert: func(t *testing.T, replacement *session.Instance) {
+				require.Equal(t, session.OpRestoring, replacement.GetInFlightOp(),
+					"the old failure must not clear the replacement's own restore")
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHome(t)
+			original := archiveActionInstance(t, "worker", session.Lost)
+			h.store.AddInstance(original)
+
+			replacement := archiveActionInstance(t, original.Title, session.Lost)
+			require.NotEqual(t, original.ID, replacement.ID)
+			if tc.setup != nil {
+				tc.setup(t, replacement)
+			}
+			require.True(t, h.store.ReplaceInstance(original, replacement))
+
+			_, _ = h.handleInstanceRestored(instanceRestoredMsg{title: original.Title, err: tc.err})
+			tc.assert(t, replacement)
+		})
+	}
+}

--- a/app/session_action_target.go
+++ b/app/session_action_target.go
@@ -61,6 +61,10 @@ func (target sessionActionTarget) archiveRequest() daemon.ArchiveSessionRequest 
 	return daemon.ArchiveSessionRequest{ID: target.id, Title: target.title, RepoID: target.repoID}
 }
 
+func (target sessionActionTarget) restoreRequest() daemon.RestoreSessionRequest {
+	return daemon.RestoreSessionRequest{ID: target.id, Title: target.title, RepoID: target.repoID}
+}
+
 func (target sessionActionTarget) handoffRequest(to string) daemon.HandoffSessionRequest {
 	return daemon.HandoffSessionRequest{
 		ID: target.id, Title: target.title, RepoID: target.repoID, To: to,

--- a/app/session_control.go
+++ b/app/session_control.go
@@ -162,11 +162,11 @@ var archiveSessionThroughDaemon = func(request daemon.ArchiveSessionRequest) (st
 	return path, err
 }
 
-var restoreSessionThroughDaemon = func(title, repoID string) (string, error) {
+var restoreSessionThroughDaemon = func(request daemon.RestoreSessionRequest) (string, error) {
 	var path string
 	err := withDaemonHTTP(func(c *apiclient.Client) error {
 		var e error
-		path, e = c.RestoreSession(daemon.RestoreSessionRequest{Title: title, RepoID: repoID})
+		path, e = c.RestoreSession(request)
 		return e
 	})
 	return path, err

--- a/daemon/action_id_resolution_test.go
+++ b/daemon/action_id_resolution_test.go
@@ -205,6 +205,51 @@ func TestArchiveSessionByIDTargetsRightSession(t *testing.T) {
 	}
 }
 
+// TestRestoreSessionByIDTargetsRightSession pins the return leg of the retained
+// lifecycle identity: RestoreSession resolves the stable id once, restores that
+// archived instance, and publishes the same canonical identity. The deliberately
+// stale request title proves neither the operation body nor the event re-resolves
+// by display text after the id match.
+func TestRestoreSessionByIDTargetsRightSession(t *testing.T) {
+	manager, repoA, dataA, repoB, dataB := createDuplicateTitleSessions(t, "feature")
+	cs := &controlServer{manager: manager}
+
+	_, ch := manager.events.subscribe()
+	var archiveResp ArchiveSessionResponse
+	if err := cs.ArchiveSession(ArchiveSessionRequest{ID: dataB.ID, Title: "feature"}, &archiveResp); err != nil {
+		t.Fatalf("ArchiveSession by id B: %v", err)
+	}
+	_ = drainNextSessionEvent(t, ch, agentproto.EventSessionArchived)
+
+	var restoreResp RestoreSessionResponse
+	if err := cs.RestoreSession(RestoreSessionRequest{ID: dataB.ID, Title: "stale-display-title"}, &restoreResp); err != nil {
+		t.Fatalf("RestoreSession by id B: %v", err)
+	}
+	if !restoreResp.OK {
+		t.Fatalf("RestoreSession resp not OK")
+	}
+	restored := drainNextSessionEvent(t, ch, agentproto.EventSessionRestored)
+	if restored.ID != dataB.ID || restored.Title != "feature" {
+		t.Fatalf("restored event = {ID:%q Title:%q}, want B {%q %q}", restored.ID, restored.Title, dataB.ID, "feature")
+	}
+
+	// Both same-title rows survive, and B — not A — made the archived→running
+	// transition. This also proves the canonical repo came from the ID resolver.
+	assertTracked(t, manager, repoA.ID, "feature", dataA.ID)
+	assertTracked(t, manager, repoB.ID, "feature", dataB.ID)
+	instA, _, _, err := manager.findSession("feature", repoA.ID)
+	if err != nil {
+		t.Fatalf("findSession A after restoring B: %v", err)
+	}
+	instB, _, _, err := manager.findSession("feature", repoB.ID)
+	if err != nil {
+		t.Fatalf("findSession B after restore: %v", err)
+	}
+	if instA.GetLiveness() == session.LiveArchived || instB.GetLiveness() == session.LiveArchived {
+		t.Fatalf("liveness after B restore = A:%v B:%v, want both live", instA.GetLiveness(), instB.GetLiveness())
+	}
+}
+
 // TestSendPromptByIDTargetsRightSession pins that a send-prompt addressed by id
 // (empty repo) resolves to the addressed session and delivers — where a title-only
 // request could resolve to either same-title session.

--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -313,7 +313,9 @@ func (m *Manager) restoreRemoteSession(repoID string, instance *session.Instance
 // back to where session creation would place it under the configured
 // worktree_root (a free sibling path, or under $AF_HOME/worktrees for
 // subdirectory users — #1540), re-registers it, re-spawns the agent, and marks
-// the instance Running. The agent session is brought back, as are any web tabs
+// the instance Running. It returns both the worktree path and the canonical
+// stable identity it actually restored, so lifecycle events cannot be rebuilt
+// from stale request display fields. The agent session is brought back, as are any web tabs
 // (pure metadata: they were never torn down, so their URLs ride back on the
 // record and render again, #1809); shell/process tabs were dropped at archive
 // time. Returns the restored worktree path.
@@ -322,14 +324,24 @@ func (m *Manager) restoreRemoteSession(repoID string, instance *session.Instance
 // repo-gone failure the archive is left intact with an actionable error; on a
 // re-spawn failure the worktree is already back in place and the instance is
 // left Lost so the #1108 restore loop heals it.
-func (m *Manager) RestoreArchived(req RestoreArchivedRequest) (string, error) {
-	instance, repoID, _, err := m.findSession(req.Title, req.RepoID)
+func (m *Manager) RestoreArchived(req RestoreArchivedRequest) (string, session.InstanceData, error) {
+	instance, repoID, title, resolvedID, _, err := m.resolveActionSession(req.ID, req.Title, req.RepoID)
 	if err != nil {
-		return "", err
+		return "", session.InstanceData{}, err
 	}
+	resolved := session.InstanceData{ID: resolvedID, Title: title}
 	if instance == nil {
-		return "", fmt.Errorf("cannot restore session %q: no such session", req.Title)
+		return "", session.InstanceData{}, fmt.Errorf("cannot restore session %q: no such session", title)
 	}
+	path, restoreErr := m.restoreArchivedInstance(instance, repoID, title)
+	return path, resolved, restoreErr
+}
+
+// restoreArchivedInstance performs the restore for an identity already resolved
+// by either RestoreArchived or the liveness-agnostic RestoreSession route. Keeping
+// one body avoids a second title lookup between those sibling paths.
+func (m *Manager) restoreArchivedInstance(instance *session.Instance, repoID, title string) (string, error) {
+	req := RestoreArchivedRequest{ID: instance.ID, Title: title, RepoID: repoID}
 	if err := instance.ValidateRuntimeAction(session.RuntimeActionRestoreArchived); err != nil {
 		return "", fmt.Errorf("cannot restore: %w", err)
 	}

--- a/daemon/archive_test.go
+++ b/daemon/archive_test.go
@@ -272,7 +272,7 @@ func TestRestoreArchived_MovesWorktreeBackAndRespawns(t *testing.T) {
 	expected, perr := sessiongit.RestoreWorktreePath(repoPath, "worker", inst.GetBranch())
 	require.NoError(t, perr)
 
-	worktreePath, err := manager.RestoreArchived(RestoreArchivedRequest{Title: "worker", RepoID: repoID})
+	worktreePath, _, err := manager.RestoreArchived(RestoreArchivedRequest{Title: "worker", RepoID: repoID})
 	require.NoError(t, err)
 
 	assert.Equal(t, expected, worktreePath, "restore must land the worktree at the standard sibling location")
@@ -302,7 +302,7 @@ func TestRestoreArchived_RejectsNonArchived(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 	registerArchivable(t, manager, repoID, repoPath, "worker") // status Ready
 
-	_, err := manager.RestoreArchived(RestoreArchivedRequest{Title: "worker", RepoID: repoID})
+	_, _, err := manager.RestoreArchived(RestoreArchivedRequest{Title: "worker", RepoID: repoID})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not archived")
 }
@@ -330,7 +330,7 @@ func TestRestoreArchived_RejectsPendingKill(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, inst.UserKilled(), "the failed kill must leave its terminal intent on the retained row")
 
-	_, err = manager.RestoreArchived(RestoreArchivedRequest{Title: "worker", RepoID: repoID})
+	_, _, err = manager.RestoreArchived(RestoreArchivedRequest{Title: "worker", RepoID: repoID})
 	require.Error(t, err, "restore must not revive a session whose kill is pending")
 	assert.Contains(t, err.Error(), "pending kill", "the refusal must explain why retrying restore cannot work")
 	assert.Equal(t, session.Archived, inst.GetStatus())
@@ -352,7 +352,7 @@ func TestRestoreArchived_RepoGoneLeavesArchiveIntact(t *testing.T) {
 
 	require.NoError(t, os.RemoveAll(repoPath), "simulate the origin repo being deleted")
 
-	_, err = manager.RestoreArchived(RestoreArchivedRequest{Title: "worker", RepoID: repoID})
+	_, _, err = manager.RestoreArchived(RestoreArchivedRequest{Title: "worker", RepoID: repoID})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "gone")
 	assert.True(t, exists(archivedPath), "the archived worktree must be left intact when the repo is gone")
@@ -374,7 +374,7 @@ func TestRestoreArchived_CollisionSuffixesPath(t *testing.T) {
 	require.NoError(t, perr)
 	require.NoError(t, os.MkdirAll(base, 0755))
 
-	worktreePath, err := manager.RestoreArchived(RestoreArchivedRequest{Title: "worker", RepoID: repoID})
+	worktreePath, _, err := manager.RestoreArchived(RestoreArchivedRequest{Title: "worker", RepoID: repoID})
 	require.NoError(t, err)
 	assert.Equal(t, base+"-2", worktreePath, "restore must avoid clobbering an occupied sibling path")
 	assert.True(t, exists(filepath.Join(worktreePath, "dirty.txt")))

--- a/daemon/archive_webtab_test.go
+++ b/daemon/archive_webtab_test.go
@@ -63,7 +63,7 @@ func TestRestoreArchived_BringsBackWebTabs(t *testing.T) {
 	_, _, err := manager.ArchiveSession(ArchiveSessionRequest{Title: "worker", RepoID: repoID})
 	require.NoError(t, err)
 
-	_, err = manager.RestoreArchived(RestoreArchivedRequest{Title: "worker", RepoID: repoID})
+	_, _, err = manager.RestoreArchived(RestoreArchivedRequest{Title: "worker", RepoID: repoID})
 	require.NoError(t, err)
 	require.Equal(t, session.Running, inst.GetStatus(), "a restored session is Running")
 
@@ -96,7 +96,7 @@ func TestArchiveSession_MultipleWebTabsKeepOrder(t *testing.T) {
 
 	_, _, err := manager.ArchiveSession(ArchiveSessionRequest{Title: "worker", RepoID: repoID})
 	require.NoError(t, err)
-	_, err = manager.RestoreArchived(RestoreArchivedRequest{Title: "worker", RepoID: repoID})
+	_, _, err = manager.RestoreArchived(RestoreArchivedRequest{Title: "worker", RepoID: repoID})
 	require.NoError(t, err)
 
 	tabs := inst.GetTabs()

--- a/daemon/control_server.go
+++ b/daemon/control_server.go
@@ -571,16 +571,16 @@ func (s *controlServer) RestoreArchived(req RestoreArchivedRequest, resp *Restor
 	if err := validateRPCRepoID(req.RepoID); err != nil {
 		return err
 	}
-	worktreePath, err := s.manager.RestoreArchived(req)
+	worktreePath, restored, err := s.manager.RestoreArchived(req)
 	if err != nil {
 		return err
 	}
 	resp.OK = true
 	resp.WorktreePath = worktreePath
-	// Resolve the id AFTER the restore re-registers the session in memory, so the
-	// event carries the id clients key their rail by (#1592 Phase 5 PR5).
-	id := s.manager.stableIDFor(req.RepoID, req.Title)
-	s.manager.publishEvent(agentproto.EventSessionRestored, session.InstanceData{ID: id, Title: req.Title})
+	// Publish the identity the manager actually resolved, not the request's
+	// potentially stale title/repo pair. This is the same one-shot resolution the
+	// restore body used, so the event cannot name a same-title sibling.
+	s.manager.publishEvent(agentproto.EventSessionRestored, restored)
 	return nil
 }
 
@@ -591,16 +591,13 @@ func (s *controlServer) RestoreSession(req RestoreSessionRequest, resp *RestoreS
 	if err := validateRPCRepoID(req.RepoID); err != nil {
 		return err
 	}
-	worktreePath, err := s.manager.RestoreSession(req)
+	worktreePath, restored, err := s.manager.RestoreSession(req)
 	if err != nil {
 		return err
 	}
 	resp.OK = true
 	resp.WorktreePath = worktreePath
-	// Resolve the id AFTER the restore re-registers the session in memory (#1592
-	// Phase 5 PR5) so the event carries the stable id clients key their rail by.
-	id := s.manager.stableIDFor(req.RepoID, req.Title)
-	s.manager.publishEvent(agentproto.EventSessionRestored, session.InstanceData{ID: id, Title: req.Title})
+	s.manager.publishEvent(agentproto.EventSessionRestored, restored)
 	return nil
 }
 

--- a/daemon/control_types.go
+++ b/daemon/control_types.go
@@ -112,6 +112,11 @@ type ArchiveSessionResponse struct {
 type RestoreArchivedRequest struct {
 	Title  string `json:"title"`
 	RepoID string `json:"repo_id"`
+	// ID is the session's stable id; see KillSessionRequest.ID. When non-empty
+	// the daemon resolves the archived row by id first and never falls back to a
+	// same-title replacement. Title+repo remains the one-shot CLI compatibility
+	// path.
+	ID string `json:"id"`
 }
 
 type RestoreArchivedResponse struct {
@@ -126,6 +131,10 @@ type RestoreArchivedResponse struct {
 type RestoreSessionRequest struct {
 	Title  string `json:"title"`
 	RepoID string `json:"repo_id"`
+	// ID is the session's stable id; see KillSessionRequest.ID. Retained UI
+	// actions send it so a restore queued for one row cannot resurrect a
+	// different session that reuses the title before dispatch.
+	ID string `json:"id"`
 }
 
 type RestoreSessionResponse struct {

--- a/daemon/create_reuse_archived_branch_hold_test.go
+++ b/daemon/create_reuse_archived_branch_hold_test.go
@@ -77,7 +77,7 @@ func TestReserveCreate_HeldArchivedBranchRefusesBeforeRename(t *testing.T) {
 
 	// And the archived session is still restorable — the refusal cost the user
 	// nothing, which is the difference between this and the pre-fix behavior.
-	_, rerr := manager.RestoreArchived(RestoreArchivedRequest{Title: "foo", RepoID: repoID})
+	_, _, rerr := manager.RestoreArchived(RestoreArchivedRequest{Title: "foo", RepoID: repoID})
 	require.NoError(t, rerr, "the untouched archived session must still restore under its own name")
 }
 

--- a/daemon/create_reuse_archived_test.go
+++ b/daemon/create_reuse_archived_test.go
@@ -169,7 +169,7 @@ func TestReserveCreate_ReusesArchivedName(t *testing.T) {
 	assert.Equal(t, session.Archived, rec.Status)
 
 	// The renamed archive is still restorable and brings the original worktree back.
-	restorePath, rerr := manager.RestoreArchived(RestoreArchivedRequest{Title: "foo (archived)", RepoID: repoID})
+	restorePath, _, rerr := manager.RestoreArchived(RestoreArchivedRequest{Title: "foo (archived)", RepoID: repoID})
 	require.NoError(t, rerr, "the renamed archived session must still restore")
 	dirty, drr := os.ReadFile(filepath.Join(restorePath, "dirty.txt"))
 	require.NoError(t, drr, "the original worktree contents must come back on restore")

--- a/daemon/deleteproject_test.go
+++ b/daemon/deleteproject_test.go
@@ -88,7 +88,7 @@ func TestDeleteProject_ArchivesAllSessionsRestorableRepoUntouched(t *testing.T) 
 	assert.True(t, exists(filepath.Join(repoPath, ".git")), "the real repo's .git must be untouched")
 
 	// Reversible: restoring one archived session brings the project back.
-	_, err = manager.RestoreArchived(RestoreArchivedRequest{Title: "alpha", RepoID: repoID})
+	_, _, err = manager.RestoreArchived(RestoreArchivedRequest{Title: "alpha", RepoID: repoID})
 	require.NoError(t, err)
 	assert.Equal(t, session.Running, inst1.GetStatus(), "the restored session is live again")
 	assert.True(t, liveProjectRoots(manager.Snapshot(repoID))[repoPath], "restoring an archived session reconstitutes the project")
@@ -135,7 +135,7 @@ func TestDeleteProject_RemovesRootAgentsOptInAndSuppressesRespawn(t *testing.T) 
 	assert.True(t, suppressed, "the ensure loop must be suppressed for the deleted repo")
 
 	// Reversible: restore reconstitutes the project in the active list.
-	_, err = manager.RestoreArchived(RestoreArchivedRequest{Title: "worker", RepoID: repoID})
+	_, _, err = manager.RestoreArchived(RestoreArchivedRequest{Title: "worker", RepoID: repoID})
 	require.NoError(t, err)
 	assert.True(t, liveProjectRoots(manager.Snapshot(repoID))[repoPath], "restore reconstitutes the project")
 }

--- a/daemon/lifecycle_event_id_test.go
+++ b/daemon/lifecycle_event_id_test.go
@@ -83,11 +83,14 @@ func TestArchiveAndRestoreEventsCarryStableID(t *testing.T) {
 	}
 
 	var rResp RestoreArchivedResponse
-	if err := cs.RestoreArchived(RestoreArchivedRequest{Title: "arch-id-evt", RepoID: repo.ID}, &rResp); err != nil {
+	if err := cs.RestoreArchived(RestoreArchivedRequest{ID: data.ID, Title: "stale-display-title", RepoID: repo.ID}, &rResp); err != nil {
 		t.Fatalf("RestoreArchived: %v", err)
 	}
 	restored := drainNextSessionEvent(t, ch, agentproto.EventSessionRestored)
 	if restored.ID != data.ID {
 		t.Fatalf("restored event ID = %q, want %q", restored.ID, data.ID)
+	}
+	if restored.Title != "arch-id-evt" {
+		t.Fatalf("restored event Title = %q, want canonical %q", restored.Title, "arch-id-evt")
 	}
 }

--- a/daemon/lostrestore_test.go
+++ b/daemon/lostrestore_test.go
@@ -124,7 +124,7 @@ func TestRestoreSession_RecoversLostInstanceOnDemand(t *testing.T) {
 	manager.lostRestoreStates[key] = &lostRestoreState{consecutiveFailures: 3}
 	manager.mu.Unlock()
 
-	_, err := manager.RestoreSession(RestoreSessionRequest{Title: "stranded", RepoID: repoID})
+	_, _, err := manager.RestoreSession(RestoreSessionRequest{Title: "stranded", RepoID: repoID})
 	if err != nil {
 		t.Fatalf("RestoreSession returned error: %v", err)
 	}
@@ -172,7 +172,7 @@ func TestRestoreSession_RecoversDeadInstanceOnDemand(t *testing.T) {
 	inst := registerStarted(t, manager, repoID, repoPath, "dead", backend, true, session.Ready)
 	_ = inst.Transition(session.ObserveLiveness(session.LiveDead))
 
-	_, err := manager.RestoreSession(RestoreSessionRequest{Title: "dead", RepoID: repoID})
+	_, _, err := manager.RestoreSession(RestoreSessionRequest{Title: "dead", RepoID: repoID})
 	if err != nil {
 		t.Fatalf("RestoreSession returned error: %v", err)
 	}

--- a/daemon/manager_sessions.go
+++ b/daemon/manager_sessions.go
@@ -409,9 +409,9 @@ func (m *Manager) trackedSessionByIDLocked(id string) (*session.Instance, string
 	return nil, ""
 }
 
-// resolveActionSession resolves a write-action target (kill/archive/send-prompt)
-// by the caller-supplied stable id FIRST — the web client's collision-proof key —
-// and falls back to {title, repoID} only when NO id is given (TUI/CLI callers).
+// resolveActionSession resolves a session mutation target by the caller-supplied
+// stable id FIRST — the retained clients' collision-proof key — and falls back
+// to {title, repoID} only when NO id is given (legacy/one-shot CLI callers).
 // Resolving by id is what stops a duplicate title across repos from targeting the
 // WRONG session on a destructive action: findSession with an empty repoID returns
 // the first title match in nondeterministic map order (#1592 Phase 5 follow-up).
@@ -580,34 +580,4 @@ func (m *Manager) findSessionByStableID(stableID, title, repoID string) (*sessio
 	m.instances[key] = instance
 	m.mu.Unlock()
 	return instance, rid, data, nil
-}
-
-// stableIDFor resolves the stable session id (session.InstanceData.ID, #1195)
-// of the tracked session (repoID, title) from the in-memory instance map — the
-// same fast-path lookup findSession uses — WITHOUT the disk fallback or restore
-// side effects findSession performs. It exists so the control server can stamp
-// the stable id onto the delete-class lifecycle events (killed/archived/
-// restored), which historically carried only the title and forced clients to
-// key their session lists by title — wrong when titles collide across repos
-// (#1592 Phase 5 PR5). Returns "" for a session not tracked in memory (a
-// legacy/disk-only record that never appears in a live Snapshot, hence never in
-// a client's rail); the empty id is the client's title-fallback signal.
-func (m *Manager) stableIDFor(repoID, title string) string {
-	if title == "" {
-		return ""
-	}
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if repoID != "" {
-		if inst := m.instances[daemonInstanceKey(repoID, title)]; inst != nil {
-			return inst.ID
-		}
-		return ""
-	}
-	for _, inst := range m.instances {
-		if inst.Title == title {
-			return inst.ID
-		}
-	}
-	return ""
 }

--- a/daemon/manual_restore_backoff_test.go
+++ b/daemon/manual_restore_backoff_test.go
@@ -47,7 +47,7 @@ func TestRestoreSession_ImmediateReLossAfterManualRestore_EscalatesNotResets(t *
 
 	// The user restores by hand. The spawn succeeds (Recover returns nil) but the
 	// agent immediately exits, so the row is Lost again by the time the poll looks.
-	if _, err := manager.RestoreSession(RestoreSessionRequest{Title: "flapper", RepoID: repoID}); err != nil {
+	if _, _, err := manager.RestoreSession(RestoreSessionRequest{Title: "flapper", RepoID: repoID}); err != nil {
 		t.Fatalf("RestoreSession: %v", err)
 	}
 	if got := backend.recoverCount(); got != 1 {
@@ -97,7 +97,7 @@ func TestRestoreSession_LongLivedThenDied_ResetsBackoff(t *testing.T) {
 	manager.lostRestoreStates[key] = &lostRestoreState{consecutiveFailures: 3}
 	manager.mu.Unlock()
 
-	if _, err := manager.RestoreSession(RestoreSessionRequest{Title: "long-lived", RepoID: repoID}); err != nil {
+	if _, _, err := manager.RestoreSession(RestoreSessionRequest{Title: "long-lived", RepoID: repoID}); err != nil {
 		t.Fatalf("RestoreSession: %v", err)
 	}
 
@@ -160,7 +160,7 @@ func TestRestoreSession_FailedManualRestoresShareDiagnosticsAndBackoff(t *testin
 	})
 
 	for attempt := 0; attempt < 2; attempt++ {
-		if _, err := manager.RestoreSession(RestoreSessionRequest{Title: "manual-failure", RepoID: repoID}); !errors.Is(err, os.ErrNotExist) {
+		if _, _, err := manager.RestoreSession(RestoreSessionRequest{Title: "manual-failure", RepoID: repoID}); !errors.Is(err, os.ErrNotExist) {
 			t.Fatalf("manual restore %d error = %v, want missing-worktree cause", attempt+1, err)
 		}
 	}

--- a/daemon/restore.go
+++ b/daemon/restore.go
@@ -9,42 +9,50 @@ import (
 
 // RestoreSession restores a user-restorable session regardless of how it became
 // unavailable: archived rows use the archive restore path, while Lost/Dead rows
-// run the same Recover path the daemon's automatic Lost loop uses.
-func (m *Manager) RestoreSession(req RestoreSessionRequest) (string, error) {
-	instance, repoID, _, err := m.findSession(req.Title, req.RepoID)
+// run the same Recover path the daemon's automatic Lost loop uses. It returns the
+// canonical stable identity that the operation resolved for event publication.
+// It returns the canonical identity resolved for the operation so the lifecycle
+// event cannot be reconstructed from stale request display fields. A non-empty
+// stable ID is authoritative: a stale queued action fails instead of falling
+// through to a same-title row.
+func (m *Manager) RestoreSession(req RestoreSessionRequest) (string, session.InstanceData, error) {
+	instance, repoID, title, resolvedID, _, err := m.resolveActionSession(req.ID, req.Title, req.RepoID)
 	if err != nil {
-		return "", err
+		return "", session.InstanceData{}, err
 	}
+	resolved := session.InstanceData{ID: resolvedID, Title: title}
 	if instance == nil {
-		return "", fmt.Errorf("cannot restore session %q: no such session", req.Title)
+		return "", session.InstanceData{}, fmt.Errorf("cannot restore session %q: no such session", title)
 	}
 
 	switch instance.GetLiveness() {
 	case session.LiveArchived:
-		return m.RestoreArchived(RestoreArchivedRequest{Title: req.Title, RepoID: repoID})
+		path, restoreErr := m.restoreArchivedInstance(instance, repoID, title)
+		return path, resolved, restoreErr
 	case session.LiveLost, session.LiveDead:
-		return m.restoreLostOrDeadSession(req, repoID, instance)
+		path, restoreErr := m.restoreLostOrDeadSession(repoID, title, instance)
+		return path, resolved, restoreErr
 	default:
-		return "", fmt.Errorf("session %q is not archived, lost, or dead", req.Title)
+		return "", session.InstanceData{}, fmt.Errorf("session %q is not archived, lost, or dead", title)
 	}
 }
 
-func (m *Manager) restoreLostOrDeadSession(req RestoreSessionRequest, repoID string, instance *session.Instance) (string, error) {
+func (m *Manager) restoreLostOrDeadSession(repoID, title string, instance *session.Instance) (string, error) {
 	if err := instance.ValidateRuntimeAction(session.RuntimeActionRestoreLostOrDead); err != nil {
 		return "", fmt.Errorf("cannot restore: %w", err)
 	}
 	if session.IsReservedTitle(instance.Title) {
-		return "", fmt.Errorf("cannot manually restore reserved session %q", req.Title)
+		return "", fmt.Errorf("cannot manually restore reserved session %q", title)
 	}
 	if !instance.Capabilities().Recover {
-		return "", fmt.Errorf("cannot restore remote session %q: reconnect is not supported", req.Title)
+		return "", fmt.Errorf("cannot restore remote session %q: reconnect is not supported", title)
 	}
 
-	key := daemonInstanceKey(repoID, req.Title)
+	key := daemonInstanceKey(repoID, title)
 	m.mu.Lock()
 	if _, busy := m.killsInFlight[key]; busy {
 		m.mu.Unlock()
-		return "", fmt.Errorf("an operation is already in progress for session %q", req.Title)
+		return "", fmt.Errorf("an operation is already in progress for session %q", title)
 	}
 	m.killsInFlight[key] = struct{}{}
 	m.mu.Unlock()
@@ -62,7 +70,7 @@ func (m *Manager) restoreLostOrDeadSession(req RestoreSessionRequest, repoID str
 	current := m.instances[key]
 	m.mu.Unlock()
 	if current != instance {
-		return "", fmt.Errorf("session %q changed state before restore could start", req.Title)
+		return "", fmt.Errorf("session %q changed state before restore could start", title)
 	}
 	view := instance.LifecycleView()
 	if err := view.ValidateRuntimeAction(session.RuntimeActionRestoreLostOrDead); err != nil {
@@ -73,7 +81,7 @@ func (m *Manager) restoreLostOrDeadSession(req RestoreSessionRequest, repoID str
 	case session.LiveDead:
 		_ = instance.Transition(session.ObserveLiveness(session.LiveLost))
 	default:
-		return "", fmt.Errorf("session %q changed state before restore could start", req.Title)
+		return "", fmt.Errorf("session %q changed state before restore could start", title)
 	}
 
 	// The same live recheck the automatic loop runs before re-provisioning
@@ -89,7 +97,7 @@ func (m *Manager) restoreLostOrDeadSession(req RestoreSessionRequest, repoID str
 	// the destruction. A user who genuinely wants a new sandbox kills and
 	// recreates (#1794).
 	if m.remoteSandboxAnswersAlive(instance) {
-		log.InfoLog.Printf("not re-provisioning session %q: its sandbox answers as alive, so it was never lost — clearing the Lost mark instead (re-provisioning would orphan it and discard unpushed work)", req.Title)
+		log.InfoLog.Printf("not re-provisioning session %q: its sandbox answers as alive, so it was never lost — clearing the Lost mark instead (re-provisioning would orphan it and discard unpushed work)", title)
 		_ = instance.Transition(session.ObserveLiveness(session.LiveRunning))
 		m.clearRemoteLoss(remoteLossKey(repoID, instance))
 		m.persistInstance(repoID, instance)

--- a/daemon/status_remote_test.go
+++ b/daemon/status_remote_test.go
@@ -535,7 +535,7 @@ func TestRestoreSession_PostManualRecoverBlipDoesNotReprovision(t *testing.T) {
 	}
 
 	// The user restores it by hand.
-	if _, err := manager.RestoreSession(RestoreSessionRequest{Title: "remote-manual", RepoID: repoID}); err != nil {
+	if _, _, err := manager.RestoreSession(RestoreSessionRequest{Title: "remote-manual", RepoID: repoID}); err != nil {
 		t.Fatalf("RestoreSession: %v", err)
 	}
 	if got := backend.recoverCalls(); got != 1 {
@@ -583,7 +583,7 @@ func TestRestoreArchived_RemoteReprovisionClearsDebounce(t *testing.T) {
 
 	// It is archived, then restored — which re-provisions a fresh sandbox.
 	inst.SetStatusForTest(session.Archived)
-	if _, err := manager.RestoreArchived(RestoreArchivedRequest{Title: "remote-archived", RepoID: repoID}); err != nil {
+	if _, _, err := manager.RestoreArchived(RestoreArchivedRequest{Title: "remote-archived", RepoID: repoID}); err != nil {
 		t.Fatalf("RestoreArchived: %v", err)
 	}
 	if got := backend.recoverCalls(); got != 1 {
@@ -631,7 +631,7 @@ func TestRestoreSession_AliveRemoteSandboxIsNotReprovisioned(t *testing.T) {
 	// Marked Lost during an outage; the transport has since healed.
 	inst, backend := registerStartedRemote(t, manager, repoID, repoPath, "remote-healed", srv.URL, session.Lost)
 
-	if _, err := manager.RestoreSession(RestoreSessionRequest{Title: "remote-healed", RepoID: repoID}); err != nil {
+	if _, _, err := manager.RestoreSession(RestoreSessionRequest{Title: "remote-healed", RepoID: repoID}); err != nil {
 		t.Fatalf("RestoreSession: %v", err)
 	}
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -19,8 +19,8 @@ Request fields are the JSON keys of each route's request body; a `—` means the
 | `POST` | `/v1/Snapshot` | `repo_id` | List sessions from the daemon's authoritative in-memory state (empty repo_id = all repos). |
 | `POST` | `/v1/KillSession` | `title`, `repo_id`, `id` | Tear down a session: kill its tmux/agent and remove its worktree and record. |
 | `POST` | `/v1/ArchiveSession` | `title`, `repo_id`, `id` | Archive a session: tear down tmux and relocate its worktree to the archive dir, keeping the record. |
-| `POST` | `/v1/RestoreArchived` | `title`, `repo_id` | Restore an archived session: move its worktree back next to the repo and re-spawn the agent. |
-| `POST` | `/v1/RestoreSession` | `title`, `repo_id` | Restore an archived, Lost, or Dead session. |
+| `POST` | `/v1/RestoreArchived` | `title`, `repo_id`, `id` | Restore an archived session: move its worktree back next to the repo and re-spawn the agent. |
+| `POST` | `/v1/RestoreSession` | `title`, `repo_id`, `id` | Restore an archived, Lost, or Dead session. |
 | `POST` | `/v1/SendPrompt` | `title`, `repo_id`, `prompt`, `id` | Send a prompt to an existing session's agent. |
 | `POST` | `/v1/ResumeFromLimit` | `title`, `repo_id`, `id` | Resume a usage-limit-blocked session: re-spawn if needed, re-deliver the pending prompt, clear the limit. |
 | `POST` | `/v1/HandoffSession` | `title`, `repo_id`, `id`, `to`, `brief` | Continue a session under a different agent, in place: swap its agent program, keep its worktree and branch, and deliver a mission brief to the new agent. |

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -270,7 +270,7 @@
         "pointer": "api/sessions.go:823 sessionsRestoreCmd"
       },
       "verdict": "parity",
-      "notes": "Reachable everywhere as of #1932, which closed the archive-only one-way door: the web POSTs RestoreSession by title (no id field on the request, unlike archive/kill) and already handled the session.restored resync (web/src/sessions.ts:85). Since RestoreSession also recovers Lost/Dead rows, this gave the web its Lost-recovery off-ramp too."
+      "notes": "Reachable everywhere as of #1932, which closed the archive-only one-way door. The retained TUI and web actions send RestoreSession's stable id so a confirmation/background command cannot retarget a same-title replacement; the one-shot CLI deliberately keeps its repo-scoped title contract. RestoreSession also recovers Lost/Dead rows, giving every surface the same recovery off-ramp."
     },
     {
       "id": "session.limit-retry",
@@ -423,7 +423,7 @@
       "title": "Address a session by its stable id rather than by title",
       "tui": {
         "status": "partial",
-        "pointer": "app/session_action_target.go captures stable identity and constructs kill/archive/limit/handoff/tab requests; handle_tabs.go retains it across the tab picker and sends session/tab IDs"
+        "pointer": "app/session_action_target.go captures stable identity and constructs kill/archive/restore/limit/handoff/tab requests; retained handlers resolve completions by that identity"
       },
       "web": {
         "status": "yes",
@@ -435,7 +435,7 @@
       },
       "verdict": "real-gap",
       "issue": "#2358",
-      "notes": "#2322 disproved the old blanket 'repo-scoped title is enough' rationale for a TUI action that survives a modal or async command: a killed/recreated row can reuse the title while the user's intent still names the prior stable session. Handoff, kill, archive, usage-limit retry, and tab create/close now carry captured identity through their retained boundaries and daemon dispatch; close also sends the stable tab ID when the projection has adopted one. Requests whose wire type still lacks a session ID remain for action-by-action audit; the CLI remains deliberately repo+title scoped because each invocation resolves and dispatches one command without retained UI intent."
+      "notes": "#2322 disproved the old blanket 'repo-scoped title is enough' rationale for an action that survives a modal or async command: a killed/recreated row can reuse the title while the user's intent still names the prior stable session. Handoff, kill, archive, restore, usage-limit retry, and tab create/close now carry captured identity through retained boundaries and daemon dispatch; close also sends the stable tab ID when the projection has adopted one. Requests whose wire type still lacks a session ID remain for action-by-action audit; the CLI remains deliberately repo+title scoped because each invocation resolves and dispatches one command without retained UI intent."
     },
     {
       "id": "session.watch",
@@ -1716,6 +1716,13 @@
         "cli": {
           "id": {
             "gap": "wire.id-addressing"
+          }
+        }
+      },
+      "RestoreSessionRequest": {
+        "cli": {
+          "id": {
+            "ok": "The CLI resolves and dispatches one restore by title under explicit --repo scoping; stable ID protects retained TUI/web intent that can outlive the selected row."
           }
         }
       },

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -6283,8 +6283,8 @@ async function killSession(id, title, token2) {
 async function archiveSession(id, title, token2) {
   await af("ArchiveSession", { id, title, repo_id: "" }, token2);
 }
-async function restoreSession(title, token2) {
-  await af("RestoreSession", { title, repo_id: "" }, token2);
+async function restoreSession(id, title, token2) {
+  await af("RestoreSession", { id, title, repo_id: "" }, token2);
 }
 async function resumeFromLimit(id, title, token2) {
   const result = await af("ResumeFromLimit", { id, title, repo_id: "" }, token2);
@@ -12536,7 +12536,7 @@ function openConfirm(action, session) {
         }
         const m = modal;
         m.setBusy(true);
-        const run = action === "kill" ? killSession(target.id, target.title, tok) : action === "archive" ? archiveSession(target.id, target.title, tok) : restoreSession(target.title, tok);
+        const run = action === "kill" ? killSession(target.id, target.title, tok) : action === "archive" ? archiveSession(target.id, target.title, tok) : restoreSession(target.id, target.title, tok);
         void run.then(closeModal).catch((e) => {
           m.setBusy(false);
           m.setError(describeError(e));

--- a/web/dist/sw.js
+++ b/web/dist/sw.js
@@ -68,7 +68,7 @@
 // than the af version on purpose: CI bumps main.go's version without rebuilding
 // web/dist, so a version stamp would desync the committed bundle from its own cache
 // name. The hash changes when — and only when — the shell bytes change.
-const VERSION = "73bddb934200";
+const VERSION = "4472ff51c6d0";
 const CACHE = `af-shell-${VERSION}`;
 
 /** The exact same-origin SUB-RESOURCE paths this worker will handle. Anything absent

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -175,28 +175,17 @@ test("archiveSession posts the stable id alongside the title", async () => {
   assert.equal(cap.body.repo_id, "");
 });
 
-// restoreSession is the archive round-trip's missing return leg (#1932): the web
-// could archive but never restore. Unlike kill/archive it resolves by TITLE only —
-// the daemon's RestoreSessionRequest (daemon/control_types.go) has no `id` field —
-// so these pin BOTH that it hits the RestoreSession route the CLI/TUI use AND that
-// it sends NO `id`: a web request carries no client-version header, so the daemon
-// decodes with DisallowUnknownFields and a stray `id` would be a 400.
-test("restoreSession posts to RestoreSession by title, with an empty repo_id", async () => {
+// Restore is retained intent too: the confirmation may outlive the row it names,
+// so it sends the same stable session id as archive/kill and cannot retarget a
+// same-title replacement before the user confirms.
+test("restoreSession posts the stable id alongside the title", async () => {
   const cap = stubFetch();
-  await restoreSession("feature", "tok");
+  await restoreSession("id-repoB", "feature", "tok");
   assert.equal(cap.url, "/v1/RestoreSession", "must hit the same route af sessions restore / the TUI `r` use");
   assert.equal(cap.auth, "Bearer tok");
+  assert.equal(cap.body.id, "id-repoB", "id must be sent so title reuse cannot redirect the restore");
   assert.equal(cap.body.title, "feature");
   assert.equal(cap.body.repo_id, "", "web is an all-repos client; repo_id stays empty, as it does for archive/kill");
-});
-
-test("restoreSession does NOT send an id (RestoreSessionRequest has no id field)", async () => {
-  const cap = stubFetch();
-  await restoreSession("feature", "tok");
-  // The daemon decodes web requests with DisallowUnknownFields; an `id` key it does
-  // not know would be rejected as a 400 "unknown field". Archive/kill send `id`
-  // only because THEIR request structs accept it — restore's does not.
-  assert.equal("id" in cap.body, false, "no id key may reach the daemon, or DisallowUnknownFields 400s the restore");
 });
 
 test("createTab / closeTab post the stable id alongside the title", async () => {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -397,18 +397,14 @@ export async function archiveSession(id: string, title: string, token: string): 
 
 /** Restores an archived, Lost, or Dead session (mirrors `af sessions restore`) —
  *  the reverse of archive: the daemon moves the worktree back next to the repo and
- *  re-spawns the agent (#1932). RestoreSession, unlike Archive/Kill, resolves the
- *  target by TITLE alone: its request struct (daemon/control_types.go
- *  RestoreSessionRequest) has no `id` field, exactly as `af sessions restore
- *  <title>` sends only {Title, RepoID}. So — unlike archiveSession — this MUST NOT
- *  send `id`: a web request carries no X-AF-Client-Version header, so the daemon
- *  decodes it with DisallowUnknownFields (daemon/httpserver.go) and a stray `id`
- *  would be rejected as a 400 "unknown field". repo_id stays empty, matching the
- *  other all-repos web callers; a duplicate title across repos surfaces the
- *  daemon's ambiguous-title error rather than restoring the wrong one. The
+ *  re-spawns the agent (#1932). Like archive/kill, it sends the rail row's
+ *  stable id as the primary key. A confirmation can outlive its row, and title
+ *  reuse must not redirect the retained restore to a replacement session.
+ *  repo_id stays empty because the web is an all-project client; the daemon's
+ *  id-first resolver supplies the canonical repo and title. The
  *  session.restored event triggers a rail resync. */
-export async function restoreSession(title: string, token: string): Promise<void> {
-  await af("RestoreSession", { title, repo_id: "" }, token);
+export async function restoreSession(id: string, title: string, token: string): Promise<void> {
+  await af("RestoreSession", { id, title, repo_id: "" }, token);
 }
 
 /** Resumes a session blocked at a usage-limit wall (#1934) — the web half of the

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -638,14 +638,12 @@ function openConfirm(action: "kill" | "archive" | "restore", session: Actionable
         }
         const m = modal;
         m.setBusy(true);
-        // Restore resolves the target by TITLE only — its daemon request has no id
-        // field (see restoreSession), unlike kill/archive which key by target.id.
         const run =
           action === "kill"
             ? killSession(target.id, target.title, tok)
             : action === "archive"
               ? archiveSession(target.id, target.title, tok)
-              : restoreSession(target.title, tok);
+              : restoreSession(target.id, target.title, tok);
         void run.then(closeModal).catch((e) => {
           m.setBusy(false);
           m.setError(describeError(e));


### PR DESCRIPTION
## Outcome

Restore intent now stays bound to the session the user selected, even if that row disappears or is rebuilt while the TUI command, web confirmation, or daemon operation is in flight.

## What changed

- capture one immutable TUI `sessionActionTarget` before dispatch and carry it through request and completion
- add stable session IDs to both restore request contracts; retained TUI and web callers send them while the one-shot CLI keeps its repo-scoped title fallback
- resolve the ID once in the manager, pass the already-resolved instance into the archived/lost/dead body, and return the canonical identity for the lifecycle event
- remove the post-hoc title-based event lookup, so operation and event cannot disagree
- ignore stale completions instead of clearing or confirming a same-title replacement
- rebuild the committed web bundle from current master and update parity evidence

Fail-first commit `9b3448e7` reproduced both defects: a queued restore targeting a recreated same-title row, and an old completion mutating that replacement. Daemon coverage also pins ID-first cross-repo restore and canonical event identity for both restore RPCs.

## Verification

Exact pushed head: `ad084ce2811e778d730b1c98cd9c00c90e7f6403`

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (clean)
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh` (980 Go files, 0 grandfathered)
- `make web-test` (413 tests)
- `make web-build`

The #2358 audit remains open for two deliberately separate, lower-impact lifetimes: async PR-info persistence and attach poll-pause heartbeats still address by title. They do not share restore's operation/event contract and will be handled as focused slices.

Part of #2358.

— Captain Claude
