### PR TITLE
fix(tabs): retain created tab identity

### DIFF
--- a/api/sessions_tabs.go
+++ b/api/sessions_tabs.go
@@ -115,7 +115,7 @@ func runTabCreate(cmd *cobra.Command, args []string) error {
 		return jsonError(err)
 	}
 
-	name, err := createTabViaDaemon(daemon.CreateTabRequest{
+	created, err := createTabViaDaemon(daemon.CreateTabRequest{
 		Title:   args[0],
 		RepoID:  repoID,
 		Command: tabCreateCommandFlag,
@@ -127,7 +127,7 @@ func runTabCreate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return jsonError(err)
 	}
-	return jsonOut(map[string]string{"name": name})
+	return jsonOut(map[string]string{"name": created.Name})
 }
 
 var tabDeleteNameFlag string

--- a/api/sessions_tabs_vscode_test.go
+++ b/api/sessions_tabs_vscode_test.go
@@ -27,9 +27,9 @@ func withTabCreateFlags(t *testing.T, kind, url, command string, port int) *daem
 
 	var got *daemon.CreateTabRequest
 	prevCreate := createTabViaDaemon
-	createTabViaDaemon = func(req daemon.CreateTabRequest) (string, error) {
+	createTabViaDaemon = func(req daemon.CreateTabRequest) (daemon.CreateTabResponse, error) {
 		got = &req
-		return "vscode", nil
+		return daemon.CreateTabResponse{ID: "daemon-vscode-id", Name: "vscode"}, nil
 	}
 	t.Cleanup(func() { createTabViaDaemon = prevCreate })
 
@@ -55,9 +55,9 @@ func TestSessionsTabCreate_VSCodeNeedsNoTarget(t *testing.T) {
 
 	var got *daemon.CreateTabRequest
 	prevCreate := createTabViaDaemon
-	createTabViaDaemon = func(req daemon.CreateTabRequest) (string, error) {
+	createTabViaDaemon = func(req daemon.CreateTabRequest) (daemon.CreateTabResponse, error) {
 		got = &req
-		return "vscode", nil
+		return daemon.CreateTabResponse{ID: "daemon-vscode-id", Name: "vscode"}, nil
 	}
 	defer func() { createTabViaDaemon = prevCreate }()
 

--- a/api/sessions_test.go
+++ b/api/sessions_test.go
@@ -543,9 +543,9 @@ func TestSessionsTabCreate_RequiresCommand(t *testing.T) {
 
 	called := false
 	prevCreate := createTabViaDaemon
-	createTabViaDaemon = func(req daemon.CreateTabRequest) (string, error) {
+	createTabViaDaemon = func(req daemon.CreateTabRequest) (daemon.CreateTabResponse, error) {
 		called = true
-		return "", nil
+		return daemon.CreateTabResponse{}, nil
 	}
 	defer func() { createTabViaDaemon = prevCreate }()
 
@@ -599,12 +599,12 @@ func TestSessionsTabCreate_HonorsRepoScopingAndReturnsName(t *testing.T) {
 
 	var gotReq daemon.CreateTabRequest
 	prevCreate := createTabViaDaemon
-	createTabViaDaemon = func(req daemon.CreateTabRequest) (string, error) {
+	createTabViaDaemon = func(req daemon.CreateTabRequest) (daemon.CreateTabResponse, error) {
 		gotReq = req
 		if req.RepoID == "" {
-			return "", errors.New("RepoID empty: --repo scoping was dropped")
+			return daemon.CreateTabResponse{}, errors.New("RepoID empty: --repo scoping was dropped")
 		}
-		return "btop-2", nil // the resolved (collision-suffixed) name
+		return daemon.CreateTabResponse{ID: "daemon-btop-id", Name: "btop-2"}, nil
 	}
 	defer func() { createTabViaDaemon = prevCreate }()
 

--- a/apiclient/control.go
+++ b/apiclient/control.go
@@ -94,17 +94,15 @@ func (c *Client) HandoffSession(req daemon.HandoffSessionRequest) (daemon.Handof
 	return resp, nil
 }
 
-// CreateTab asks the daemon to spawn, persist, and report a new process/shell
-// tab on an existing session, returning the resolved (collision-suffixed) name
-// and the tmux session it was spawned under. Callers need BOTH: the two names
-// are independent namespaces that diverge after a rename (#1957), so the tmux
-// session cannot be re-derived from the tab name. See CreateTabResponse.TmuxName.
-func (c *Client) CreateTab(req daemon.CreateTabRequest) (string, string, error) {
+// CreateTab asks the daemon to spawn, persist, and report a new tab. The
+// response object keeps its stable ID with the two independent names, so a
+// caller cannot accidentally discard the destructive-addressing handle.
+func (c *Client) CreateTab(req daemon.CreateTabRequest) (daemon.CreateTabResponse, error) {
 	var resp daemon.CreateTabResponse
 	if err := c.call("CreateTab", req, &resp); err != nil {
-		return "", "", err
+		return daemon.CreateTabResponse{}, err
 	}
-	return resp.Name, resp.TmuxName, nil
+	return resp, nil
 }
 
 // CloseTab asks the daemon to close a non-agent tab and returns the resolved

--- a/apiclient/control_test.go
+++ b/apiclient/control_test.go
@@ -78,16 +78,36 @@ func TestControlRoundTrips(t *testing.T) {
 	// session it was spawned under are independent namespaces post-#1957, so a
 	// client that dropped the second and re-derived it from the first would bind
 	// the TUI's instant-display projection to a different tab's live session.
-	t.Run("CreateTab returns resolved name and tmux name", func(t *testing.T) {
+	t.Run("CreateTab returns stable id, resolved name, and tmux name", func(t *testing.T) {
 		c := routeServer(t, "CreateTab", func([]byte) apiproto.Envelope {
-			return apiproto.Success(daemon.CreateTabResponse{Name: "shell", TmuxName: "af_x_alpha__shell-2"})
+			return apiproto.Success(daemon.CreateTabResponse{
+				ID: "daemon-tab-id", Name: "shell", TmuxName: "af_x_alpha__shell-2",
+			})
 		})
-		name, tmuxName, err := c.CreateTab(daemon.CreateTabRequest{Title: "alpha", Shell: true})
-		if err != nil || name != "shell" {
-			t.Fatalf("CreateTab name = %q, %v; want shell", name, err)
+		resp, err := c.CreateTab(daemon.CreateTabRequest{Title: "alpha", Shell: true})
+		if err != nil || resp.Name != "shell" {
+			t.Fatalf("CreateTab response = %+v, %v; want shell", resp, err)
 		}
-		if tmuxName != "af_x_alpha__shell-2" {
-			t.Fatalf("CreateTab tmux name = %q; want af_x_alpha__shell-2", tmuxName)
+		if resp.ID != "daemon-tab-id" {
+			t.Fatalf("CreateTab id = %q; want daemon-tab-id", resp.ID)
+		}
+		if resp.TmuxName != "af_x_alpha__shell-2" {
+			t.Fatalf("CreateTab tmux name = %q; want af_x_alpha__shell-2", resp.TmuxName)
+		}
+	})
+
+	t.Run("CreateTab accepts an older daemon response without id", func(t *testing.T) {
+		c := routeServer(t, "CreateTab", func([]byte) apiproto.Envelope {
+			return apiproto.Success(map[string]string{
+				"name": "shell", "tmux_name": "af_x_alpha__shell",
+			})
+		})
+		resp, err := c.CreateTab(daemon.CreateTabRequest{Title: "alpha", Shell: true})
+		if err != nil {
+			t.Fatalf("CreateTab from older daemon: %v", err)
+		}
+		if resp.ID != "" || resp.Name != "shell" || resp.TmuxName != "af_x_alpha__shell" {
+			t.Fatalf("older CreateTab response = %+v; want explicit empty-id compatibility", resp)
 		}
 	})
 

--- a/app/creation_test.go
+++ b/app/creation_test.go
@@ -59,8 +59,8 @@ func newTestHome(t *testing.T) *home {
 	// override the relevant seam. createTab/closeTab default to an error so an
 	// unstubbed mutation fails loudly rather than reaching the daemon; setPRInfo
 	// defaults to a no-op so the in-memory PR-badge path stays exercisable.
-	t.Cleanup(SetTabCreatorForTest(func(daemon.CreateTabRequest) (string, string, error) {
-		return "", "", fmt.Errorf("createTabThroughDaemon not stubbed in test")
+	t.Cleanup(SetTabCreatorForTest(func(daemon.CreateTabRequest) (daemon.CreateTabResponse, error) {
+		return daemon.CreateTabResponse{}, fmt.Errorf("createTabThroughDaemon not stubbed in test")
 	}))
 	t.Cleanup(SetTabCloserForTest(func(daemon.CloseTabRequest) error {
 		return fmt.Errorf("closeTabThroughDaemon not stubbed in test")

--- a/app/daemon_mutation_routing_test.go
+++ b/app/daemon_mutation_routing_test.go
@@ -20,7 +20,7 @@ func TestHandleNewTab_RoutesThroughDaemon_NoLocalSave(t *testing.T) {
 	selectInstance(h, inst)
 
 	var gotRequest daemon.CreateTabRequest
-	restore := SetTabCreatorForTest(func(request daemon.CreateTabRequest) (string, string, error) {
+	restore := SetTabCreatorForTest(func(request daemon.CreateTabRequest) (daemon.CreateTabResponse, error) {
 		gotRequest = request
 		return spawnDaemonTab(inst)
 	})
@@ -47,7 +47,7 @@ func TestHandleCloseTab_RoutesThroughDaemon_NoLocalSave(t *testing.T) {
 	selectInstance(h, inst)
 
 	var gotRequest daemon.CloseTabRequest
-	createRestore := SetTabCreatorForTest(func(daemon.CreateTabRequest) (string, string, error) {
+	createRestore := SetTabCreatorForTest(func(daemon.CreateTabRequest) (daemon.CreateTabResponse, error) {
 		return spawnDaemonTab(inst)
 	})
 	defer createRestore()
@@ -59,15 +59,63 @@ func TestHandleCloseTab_RoutesThroughDaemon_NoLocalSave(t *testing.T) {
 
 	_, _ = h.handleNewTab() // agent + shell + shell-2, active = 2
 	require.Equal(t, 3, inst.TabCount())
+	createdTab := inst.GetTabs()[2]
+	require.NotEmpty(t, createdTab.ID)
 
 	_, _ = h.handleCloseTab()
 
 	require.Equal(t, daemon.CloseTabRequest{
-		ID: inst.ID, Title: inst.Title, RepoID: h.repoID, TabName: "shell-2",
+		ID: inst.ID, Title: inst.Title, RepoID: h.repoID,
+		TabID: createdTab.ID, TabName: "shell-2",
 	}, gotRequest, "CloseTab must carry the selected session identity and active tab name")
 	require.Equal(t, 2, inst.TabCount(), "the closed tab must be dropped locally")
 
 	requireTUIInstancesEmpty(t, h)
+}
+
+// The daemon response is the only authoritative source for a new tab's ID in
+// the interval before the next snapshot. Preserve it into the local projection
+// so an immediate destructive action cannot be redirected by name reuse.
+func TestHandleCloseTabImmediatelyUsesCreateResponseID(t *testing.T) {
+	h := newTestHome(t)
+	inst := freshLocalInstance(t, "route-create-close-id")
+	selectInstance(h, inst)
+	const createdID = "daemon-created-tab-id"
+	t.Cleanup(SetTabCreatorForTest(func(daemon.CreateTabRequest) (daemon.CreateTabResponse, error) {
+		return daemon.CreateTabResponse{ID: createdID, Name: "vscode"}, nil
+	}))
+
+	const replacementID = "same-name-replacement-id"
+	resolvedID := ""
+	t.Cleanup(SetTabCloserForTest(func(request daemon.CloseTabRequest) error {
+		resolvedID = request.TabID
+		if resolvedID == "" {
+			resolvedID = replacementID
+		}
+		return nil
+	}))
+
+	_, _ = h.createNewTab(inst, session.TabKindVSCode)
+	require.Equal(t, createdID, inst.GetTabs()[1].ID,
+		"the local projection must carry the response ID before any snapshot")
+	_, _ = h.handleCloseTab()
+
+	require.Equal(t, createdID, resolvedID)
+	require.NotEqual(t, replacementID, resolvedID,
+		"an immediate close must not fall back to the reused display name")
+}
+
+func TestCreateTabFromOlderDaemonKeepsExplicitIDLessFallback(t *testing.T) {
+	h := newTestHome(t)
+	inst := freshLocalInstance(t, "route-create-legacy")
+	selectInstance(h, inst)
+	t.Cleanup(SetTabCreatorForTest(func(daemon.CreateTabRequest) (daemon.CreateTabResponse, error) {
+		return daemon.CreateTabResponse{Name: "vscode"}, nil
+	}))
+
+	_, _ = h.createNewTab(inst, session.TabKindVSCode)
+	require.Empty(t, inst.GetTabs()[1].ID,
+		"an older daemon's omitted additive field must remain a compatible name-keyed projection")
 }
 
 // A tab name is reusable. If another client closes the intended tab and creates

--- a/app/handle_tabs.go
+++ b/app/handle_tabs.go
@@ -94,9 +94,10 @@ func (m *home) handleNewTab() (tea.Model, tea.Cmd) {
 // The spawn+persist is routed through the daemon's CreateTab RPC (#960): the
 // daemon — the single writer — owns the new tab so its authoritative view holds
 // it and the TUI no longer originates a persisted tab write at all (#959). The
-// local projection is reflected immediately for both kinds; the next snapshot
-// adopts the daemon-minted stable id. The daemon's soft cap error is surfaced
-// verbatim.
+// local projection is reflected immediately for both kinds with the exact
+// daemon-minted identity. An older daemon can omit the additive ID field; that
+// mixed-version case remains name-keyed until the next snapshot. The daemon's
+// soft cap error is surfaced verbatim.
 func (m *home) createNewTab(selected *session.Instance, kind session.TabKind) (tea.Model, tea.Cmd) {
 	if selected == nil {
 		return m, nil
@@ -113,7 +114,7 @@ func (m *home) createNewTab(selected *session.Instance, kind session.TabKind) (t
 	if !ok {
 		return m, m.handleError(fmt.Errorf("tab kind %d is not available from the TUI", kind))
 	}
-	name, tmuxName, err := createTabThroughDaemon(request)
+	response, err := createTabThroughDaemon(request)
 	if err != nil {
 		return m, m.handleError(err)
 	}
@@ -123,9 +124,9 @@ func (m *home) createNewTab(selected *session.Instance, kind session.TabKind) (t
 	// second tab.
 	var attachErr error
 	if kind == session.TabKindVSCode {
-		_, attachErr = selected.AttachVSCodeTab(name)
+		_, attachErr = selected.AttachVSCodeTab(response.Name, response.ID)
 	} else {
-		_, attachErr = selected.AttachShellTab(name, tmuxName)
+		_, attachErr = selected.AttachShellTab(response.Name, response.TmuxName, response.ID)
 	}
 	if attachErr != nil {
 		return m, m.handleError(attachErr)
@@ -213,10 +214,9 @@ func (m *home) handleCloseTab() (tea.Model, tea.Cmd) {
 	// remove a tab that is NOT the tree's active tab, and the tree must keep
 	// pointing at its own tab across the shift (#1884 follow-up) — resolving it by
 	// id afterwards is what keeps the arithmetic from guessing.
-	// The ordinal rides along with the id: a freshly-created tab is ID-LESS by
-	// design (AttachShellTab leaves Tab.ID empty until the next snapshot backfills
-	// the daemon's), so there is a real window where the tree's tab cannot be found
-	// by id at all and the ordinal is the only key it has.
+	// The ordinal rides along with the id for mixed-version compatibility: an
+	// older daemon omits CreateTabResponse.ID, so that projection remains ID-less
+	// until the next snapshot and the ordinal is the only key it has.
 	treeActiveID := ""
 	treeActiveIdx := -1
 	// Whose tab is store.ActiveTab()? The STORE's selected instance's — so that is

--- a/app/live_termpane.go
+++ b/app/live_termpane.go
@@ -344,12 +344,12 @@ func (m *home) liveBindCandidate(p *store.OpenPane) (key, title, repoID, tabID s
 	}
 	inst := p.Instance()
 	// Address the stream by the tab's STABLE id (#1738) so a reorder/close can't
-	// misroute it; empty (a just-created tab whose daemon id hasn't synced yet)
+	// misroute it; empty (a legacy tab or an older daemon's create response)
 	// falls back to the ordinal in DialStream.
 	tabID, _ = inst.TabIDAt(tab)
 	// The id is part of the bind key, not just the stream coordinates (#1779).
-	// AttachShellTab opens a pane BEFORE the daemon id exists, so that pane connects
-	// positionally; when the next snapshot adopts the real id, nothing else in the
+	// An older daemon can omit the create-response ID, so that pane connects
+	// positionally; when a later snapshot adopts the real id, nothing else in the
 	// key changes, so without the id here the pane would keep its old ORDINAL
 	// connection forever and could send keystrokes to a different tab after another
 	// client reorders/closes a lower one. Keying on the id makes id adoption itself

--- a/app/live_termpane_test.go
+++ b/app/live_termpane_test.go
@@ -278,9 +278,9 @@ func TestQuitClosesLiveAttachment(t *testing.T) {
 }
 
 // TestLiveBindKeyIncludesTabID is the regression test for the id-adoption rebind
-// (#1779). AttachShellTab opens a pane BEFORE the daemon has minted the tab's
-// stable id, so that pane necessarily connects positionally (?tab=). When the next
-// snapshot adopts the real id, nothing else about the pane changes — same pane id,
+// (#1779). A legacy or older-daemon projection can open before its stable ID is
+// known, so that pane connects positionally (?tab=). When the next snapshot
+// adopts the real id, nothing else about the pane changes — same pane id,
 // same ordinal, same tmux name — so a bind key built only from those would be
 // unchanged and the pane would keep its ORDINAL connection for life. It could then
 // send keystrokes to a DIFFERENT tab once another client closes a lower one. The id
@@ -290,7 +290,7 @@ func TestLiveBindKeyIncludesTabID(t *testing.T) {
 	h, inst := liveTestHome(t)
 	p := openTestPane(t, h, inst, 1)
 
-	// The just-created tab whose daemon id has not synced yet: bound positionally.
+	// Model an older-daemon projection before ID backfill: bound positionally.
 	inst.Tabs[1].ID = ""
 	keyBefore, _, _, tabIDBefore, _, ok := h.liveBindCandidate(p)
 	require.True(t, ok)

--- a/app/pane_preview.go
+++ b/app/pane_preview.go
@@ -71,9 +71,9 @@ func paneBindingIdentityOf(binding paneBinding) paneBindingIdentity {
 	if tab.Kind != session.TabKindAgent {
 		identity.tabID = tab.ID
 	}
-	// Keep the name even when an ID is present. A freshly-created tab is locally
-	// ID-less until the daemon snapshot backfills it; a suppression captured on
-	// one side of that transition needs the name as its shared identity bridge.
+	// Keep the name even when an ID is present. A legacy tab or a tab created
+	// through an older daemon can be locally ID-less until snapshot backfill; a
+	// suppression captured across that transition needs the name as its bridge.
 	identity.tabName = tab.Name
 	return identity
 }
@@ -82,7 +82,7 @@ func paneBindingIdentityOf(binding paneBinding) paneBindingIdentity {
 // dismissed with its current binding. The direction matters: an ID-less saved
 // identity may match a later ID-bearing snapshot by name (daemon backfill), but
 // a saved stable ID must never fall back to name when a different, newly
-// attached tab is still locally ID-less.
+// legacy/older-daemon tab is still locally ID-less.
 func suppressionIdentityMatches(saved, current paneBindingIdentity) bool {
 	if saved.instance != current.instance {
 		return false

--- a/app/pane_tab_reconcile_test.go
+++ b/app/pane_tab_reconcile_test.go
@@ -29,7 +29,7 @@ func TestPane_CloseTabRebindsPanes(t *testing.T) {
 	selectInstance(h, inst)
 	resizeHome(h, 200, 40)
 
-	restore := SetTabCreatorForTest(func(daemon.CreateTabRequest) (string, string, error) {
+	restore := SetTabCreatorForTest(func(daemon.CreateTabRequest) (daemon.CreateTabResponse, error) {
 		return spawnDaemonTab(inst)
 	})
 	defer restore()
@@ -69,7 +69,7 @@ func TestPane_SnapshotTabRemovalRebindsPanes(t *testing.T) {
 	selectInstance(h, inst)
 	resizeHome(h, 200, 40)
 
-	restore := SetTabCreatorForTest(func(daemon.CreateTabRequest) (string, string, error) {
+	restore := SetTabCreatorForTest(func(daemon.CreateTabRequest) (daemon.CreateTabResponse, error) {
 		return spawnDaemonTab(inst)
 	})
 	defer restore()
@@ -106,7 +106,7 @@ func TestPane_SnapshotTabRemovalKeepsUnaffectedPaneBinding(t *testing.T) {
 	selectInstance(h, inst)
 	resizeHome(h, 200, 40)
 
-	restore := SetTabCreatorForTest(func(daemon.CreateTabRequest) (string, string, error) {
+	restore := SetTabCreatorForTest(func(daemon.CreateTabRequest) (daemon.CreateTabResponse, error) {
 		return spawnDaemonTab(inst)
 	})
 	defer restore()

--- a/app/pane_tab_reconcile_test.go
+++ b/app/pane_tab_reconcile_test.go
@@ -193,10 +193,10 @@ func TestPane_SnapshotTabReorderFollowsPaneToNewSlot(t *testing.T) {
 	assert.Equal(t, "a", inst.GetTabs()[p.Tab()].Name, "the pane still shows the SAME tab it was showing")
 }
 
-// TestPane_SnapshotTabIDAdoptionKeepsPaneOpen guards the id-less rollforward at
-// the pane level. A tab can be live locally with NO id — AttachShellTab leaves an
-// optimistic tab's id empty on purpose, and its pane is opened on it immediately
-// — and the next snapshot then ADOPTS the daemon's id for it. Adoption changes
+// TestPane_SnapshotTabIDAdoptionKeepsPaneOpen guards the legacy id-less
+// rollforward at the pane level. An older daemon can omit the additive ID in its
+// create response, so a pane may open on an ID-less local projection before the
+// next snapshot ADOPTS the daemon's id. Adoption changes
 // the tab's identity from "no id" to a real one while the tab itself does not
 // change at all, so a binding resolved by id ALONE reads it as a vanished tab and
 // closes a pane the user is looking at. Only the name carries the binding across
@@ -205,8 +205,8 @@ func TestPane_SnapshotTabReorderFollowsPaneToNewSlot(t *testing.T) {
 // The adoption must land in the same snapshot as an unrelated change — here, a
 // second tab appearing — because id adoption on its own is deliberately not a
 // visible change (ReconcileTabsFromData), so it never reaches this reconcile by
-// itself. Co-occurring is the common case, not a contrived one: the snapshot that
-// first carries a new tab's id is routinely the one carrying the next tab too.
+// itself. Co-occurring remains possible when an older daemon's response omits the
+// ID and a later snapshot also carries another tab.
 func TestPane_SnapshotTabIDAdoptionKeepsPaneOpen(t *testing.T) {
 	h := newTestHome(t)
 	inst := freshLocalInstance(t, "snapadopt")

--- a/app/session_control.go
+++ b/app/session_control.go
@@ -302,16 +302,17 @@ func resumeStatusPollThroughDaemon(title, repoID string) error {
 
 // createTabThroughDaemon is the TUI's single CreateTab RPC path. Both picker
 // choices use it, so VS Code creation sends the same Kind:"vscode" request the
-// CLI does rather than growing a TUI-only implementation. It returns the resolved
-// tab name and, for a shell/process tab, the exact tmux session the daemon spawned.
-var createTabThroughDaemon = func(req daemon.CreateTabRequest) (string, string, error) {
-	var name, tmuxName string
+// CLI does rather than growing a TUI-only implementation. It preserves the
+// response as a struct so identity and future additive fields cannot be dropped
+// between the transport and the local projection.
+var createTabThroughDaemon = func(req daemon.CreateTabRequest) (daemon.CreateTabResponse, error) {
+	var response daemon.CreateTabResponse
 	err := withDaemonHTTP(func(c *apiclient.Client) error {
 		var e error
-		name, tmuxName, e = c.CreateTab(req)
+		response, e = c.CreateTab(req)
 		return e
 	})
-	return name, tmuxName, err
+	return response, err
 }
 
 // closeTabThroughDaemon routes the TUI's `w` (close tab) mutation to the daemon,
@@ -450,7 +451,7 @@ func SetLimitResumerForTest(f func(daemon.ResumeFromLimitRequest) error) func() 
 	return func() { resumeFromLimitThroughDaemon = prev }
 }
 
-func SetTabCreatorForTest(f func(daemon.CreateTabRequest) (string, string, error)) func() {
+func SetTabCreatorForTest(f func(daemon.CreateTabRequest) (daemon.CreateTabResponse, error)) func() {
 	prev := createTabThroughDaemon
 	createTabThroughDaemon = f
 	return func() { createTabThroughDaemon = prev }

--- a/app/single_writer_test.go
+++ b/app/single_writer_test.go
@@ -30,7 +30,7 @@ func TestTUIHasNoInstancesWritePath(t *testing.T) {
 	require.NotNil(t, cmd, "quit must still proceed")
 
 	// new shell tab: routed through the daemon (stubbed), reflected locally only.
-	createRestore := SetTabCreatorForTest(func(daemon.CreateTabRequest) (string, string, error) {
+	createRestore := SetTabCreatorForTest(func(daemon.CreateTabRequest) (daemon.CreateTabResponse, error) {
 		return spawnDaemonTab(inst)
 	})
 	defer createRestore()

--- a/app/tab_hotkeys_test.go
+++ b/app/tab_hotkeys_test.go
@@ -155,13 +155,13 @@ func registerDaemonSpawn(t *testing.T, inst *session.Instance, spawn func(string
 // the TUI to attach to — both, as the real RPC does since #1957, so the stub
 // can't quietly re-establish the name-derives-the-session assumption the fix
 // removed.
-func spawnDaemonTab(inst *session.Instance) (string, string, error) {
+func spawnDaemonTab(inst *session.Instance) (daemon.CreateTabResponse, error) {
 	name := nextShellTabName(inst.GetTabs())
 	tmuxName := inst.TabTmuxName(0) + "__" + name
 	if spawn := daemonSpawnHooks[inst]; spawn != nil {
 		spawn(tmuxName)
 	}
-	return name, tmuxName, nil
+	return daemon.CreateTabResponse{ID: "test-id-" + tmuxName, Name: name, TmuxName: tmuxName}, nil
 }
 
 // startedLocalInstance is freshLocalInstance plus one on-demand shell tab
@@ -215,7 +215,7 @@ func nextShellTabName(tabs []*session.Tab) string {
 func stubTabDaemonSeams(t *testing.T, inst *session.Instance) (created, closed *int) {
 	t.Helper()
 	var c, d int
-	t.Cleanup(SetTabCreatorForTest(func(daemon.CreateTabRequest) (string, string, error) {
+	t.Cleanup(SetTabCreatorForTest(func(daemon.CreateTabRequest) (daemon.CreateTabResponse, error) {
 		c++
 		return spawnDaemonTab(inst)
 	}))
@@ -253,13 +253,13 @@ func TestNewTabPickerCreatesVSCodeThroughDaemon(t *testing.T) {
 	selectInstance(h, inst)
 
 	called := 0
-	t.Cleanup(SetTabCreatorForTest(func(request daemon.CreateTabRequest) (string, string, error) {
+	t.Cleanup(SetTabCreatorForTest(func(request daemon.CreateTabRequest) (daemon.CreateTabResponse, error) {
 		called++
 		require.Equal(t, inst.ID, request.ID)
 		require.Equal(t, inst.Title, request.Title)
 		require.Equal(t, h.repoID, request.RepoID)
 		require.Equal(t, "vscode", request.Kind)
-		return "vscode", "", nil
+		return daemon.CreateTabResponse{ID: "daemon-vscode-id", Name: "vscode"}, nil
 	}))
 
 	_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}}, keys.KeyNewTab)
@@ -280,7 +280,8 @@ func TestNewTabPickerCreatesVSCodeThroughDaemon(t *testing.T) {
 	require.Equal(t, 2, inst.TabCount())
 	tabs := inst.GetTabs()
 	require.Equal(t, session.TabKindVSCode, tabs[1].Kind)
-	require.Empty(t, tabs[1].ID, "the projection waits for the daemon's authoritative tab id")
+	require.Equal(t, "daemon-vscode-id", tabs[1].ID,
+		"the projection must adopt the create response identity before the next snapshot")
 	require.Equal(t, 1, h.store.ActiveTab(), "the fresh VS Code tab must be selected")
 	require.Equal(t, []string{"◆ Agent", "◱ vscode"}, tree.TabLabels(inst),
 		"the resolved daemon name is the tab's addressable label, matching CLI creation")
@@ -299,9 +300,9 @@ func TestNewTabPickerDoesNotTargetSameTitleReplacement(t *testing.T) {
 	require.NotEqual(t, stale.ID, replacement.ID)
 	require.True(t, h.store.ReplaceInstanceByTitle(stale.Title, replacement))
 	called := false
-	t.Cleanup(SetTabCreatorForTest(func(daemon.CreateTabRequest) (string, string, error) {
+	t.Cleanup(SetTabCreatorForTest(func(daemon.CreateTabRequest) (daemon.CreateTabResponse, error) {
 		called = true
-		return "vscode", "", nil
+		return daemon.CreateTabResponse{ID: "unused", Name: "vscode"}, nil
 	}))
 
 	h.selectionOverlay.SetSelectedIndex(1)
@@ -323,9 +324,9 @@ func TestNewTabPickerFollowsSameIdentitySnapshotRebuild(t *testing.T) {
 	rebuilt.CreatedAt = stale.CreatedAt
 	require.True(t, h.store.ReplaceInstanceByTitle(stale.Title, rebuilt))
 	var gotRequest daemon.CreateTabRequest
-	t.Cleanup(SetTabCreatorForTest(func(request daemon.CreateTabRequest) (string, string, error) {
+	t.Cleanup(SetTabCreatorForTest(func(request daemon.CreateTabRequest) (daemon.CreateTabResponse, error) {
 		gotRequest = request
-		return "vscode", "", nil
+		return daemon.CreateTabResponse{ID: "rebuilt-vscode-id", Name: "vscode"}, nil
 	}))
 
 	h.selectionOverlay.SetSelectedIndex(1)

--- a/app/tab_multitab_test.go
+++ b/app/tab_multitab_test.go
@@ -528,9 +528,9 @@ func TestSnapshot_AgentIDHealKeepsPaneOpen(t *testing.T) {
 		"the agent pane stays bound to slot 0 across the heal")
 }
 
-// TestCloseTab_IDLessTreeTabTracksByOrdinal covers the id-less window. A tab the
-// user just created is ID-LESS by design (AttachShellTab leaves Tab.ID empty
-// until the next snapshot backfills the daemon's), so the tree's tab cannot be
+// TestCloseTab_IDLessTreeTabTracksByOrdinal covers the legacy id-less window. An
+// older daemon can omit CreateTabResponse.ID until the next snapshot backfills
+// it, so the tree's tab cannot be
 // found by id at all. With the id lookup skipped, `next` fell back to idx-1 —
 // where idx is the FOCUSED PANE's closed tab, not the tree's — so a pane-focused
 // close of a DIFFERENT tab jumped the tree to a neighbour of the wrong tab, even
@@ -539,8 +539,8 @@ func TestSnapshot_AgentIDHealKeepsPaneOpen(t *testing.T) {
 func TestCloseTab_IDLessTreeTabTracksByOrdinal(t *testing.T) {
 	h, alpha := multiTabHome(t)
 
-	// The freshly-created tabs are id-less, exactly as AttachShellTab leaves them
-	// before the daemon's snapshot backfills their ids.
+	// Model projections created from an older daemon response before snapshot
+	// backfill.
 	for _, tab := range alpha.GetTabs() {
 		tab.ID = ""
 	}

--- a/app/tree_nav_test.go
+++ b/app/tree_nav_test.go
@@ -152,7 +152,7 @@ func TestTreeNav_TabStopAcrossInstancePreservesParentForActions(t *testing.T) {
 		"instance actions resolve the selected tab's parent instance")
 
 	var createdFor string
-	t.Cleanup(SetTabCreatorForTest(func(request daemon.CreateTabRequest) (string, string, error) {
+	t.Cleanup(SetTabCreatorForTest(func(request daemon.CreateTabRequest) (daemon.CreateTabResponse, error) {
 		createdFor = request.Title
 		return spawnDaemonTab(beta)
 	}))
@@ -207,7 +207,7 @@ func TestTreeNav_TabCreateCloseFromTabRow(t *testing.T) {
 	selectInstance(h, inst)
 
 	var closedNames []string
-	t.Cleanup(SetTabCreatorForTest(func(daemon.CreateTabRequest) (string, string, error) {
+	t.Cleanup(SetTabCreatorForTest(func(daemon.CreateTabRequest) (daemon.CreateTabResponse, error) {
 		return spawnDaemonTab(inst)
 	}))
 	t.Cleanup(SetTabCloserForTest(func(request daemon.CloseTabRequest) error {

--- a/app/tui_tab_state_identity_test.go
+++ b/app/tui_tab_state_identity_test.go
@@ -62,10 +62,9 @@ func TestPanePreviewSuppressionFollowsTabIdentityAcrossReorder(t *testing.T) {
 }
 
 // TestPanePreviewSuppressionDoesNotTransferAcrossStableIDReuse covers the
-// close/recreate window after a stable target was dismissed. AttachShellTab
-// leaves the replacement locally ID-less until the daemon snapshot arrives;
-// reusing the old name must not make that distinct tab inherit the old tab's
-// suppression.
+// close/recreate window after a stable target was dismissed. A legacy or
+// older-daemon replacement can remain locally ID-less until a snapshot arrives;
+// reusing the old name must not make it inherit the old tab's suppression.
 func TestPanePreviewSuppressionDoesNotTransferAcrossStableIDReuse(t *testing.T) {
 	h, alpha := multiTabHome(t)
 	pane := openTestPane(t, h, alpha, 1)
@@ -83,7 +82,7 @@ func TestPanePreviewSuppressionDoesNotTransferAcrossStableIDReuse(t *testing.T) 
 	alpha.AddTabForTest(targetName, session.TabKindShell)
 	replacement := len(alpha.GetTabs()) - 1
 	require.Empty(t, alpha.GetTabs()[replacement].ID,
-		"precondition: the locally attached replacement is awaiting ID backfill")
+		"precondition: the modeled legacy replacement is awaiting ID backfill")
 
 	_ = h.updatePanePreview(alpha, replacement, true, false)
 

--- a/daemon/close_tab_test.go
+++ b/daemon/close_tab_test.go
@@ -129,7 +129,7 @@ func TestCloseTab_RejectsArchivedSession(t *testing.T) {
 	const title = "worker"
 	inst := startedLocalTabInstance(t, manager, repo.ID, repoPath, title, "af_"+title+"_agent")
 	const target = "http://localhost:3000"
-	if _, _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Kind: "web", URL: target, Name: "webpreview"}); err != nil {
+	if _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Kind: "web", URL: target, Name: "webpreview"}); err != nil {
 		t.Fatalf("CreateTab(web): %v", err)
 	}
 
@@ -195,7 +195,7 @@ func TestCloseTab_ArchiveWinningOpLockRaceKeepsWebTab(t *testing.T) {
 	const title = "worker"
 	inst := startedLocalTabInstance(t, manager, repo.ID, repoPath, title, "af_"+title+"_agent")
 	const target = "http://localhost:3000"
-	if _, _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Kind: "web", URL: target, Name: "webpreview"}); err != nil {
+	if _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Kind: "web", URL: target, Name: "webpreview"}); err != nil {
 		t.Fatalf("CreateTab(web): %v", err)
 	}
 
@@ -453,7 +453,7 @@ func TestCloseTab_SerializedWithInFlightKillDoesNotCloseStaleTab(t *testing.T) {
 
 	exec, isAlive := closeBlockingTabExec(map[string]bool{agentName: true}, processTmuxName, killStarted, releaseKill)
 	inst := startedLocalTabInstanceWithExec(t, manager, repoID, repoPath, title, agentName, exec)
-	if _, _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Command: "btop"}); err != nil {
+	if _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Command: "btop"}); err != nil {
 		t.Fatalf("CreateTab: %v", err)
 	}
 	if !isAlive(processTmuxName) {

--- a/daemon/control_client.go
+++ b/daemon/control_client.go
@@ -223,15 +223,15 @@ func CreateSession(req CreateSessionRequest) (*session.InstanceData, error) {
 	return &resp.Instance, nil
 }
 
-// CreateTab asks the daemon to spawn, persist, and report a new process tab on
-// an existing session. It returns the resolved (collision-suffixed) tab name so
-// scripts/agents can address the tab.
-func CreateTab(req CreateTabRequest) (string, error) {
+// CreateTab asks the daemon to spawn, persist, and report a new tab on an
+// existing session. Returning the response object keeps the daemon-minted ID
+// together with its resolved and tmux names across the gob transport.
+func CreateTab(req CreateTabRequest) (CreateTabResponse, error) {
 	var resp CreateTabResponse
 	if err := callDaemon("CreateTab", req, &resp); err != nil {
-		return "", err
+		return CreateTabResponse{}, err
 	}
-	return resp.Name, nil
+	return resp, nil
 }
 
 // CloseTab asks the daemon to close a non-agent tab on an existing session and

--- a/daemon/control_server.go
+++ b/daemon/control_server.go
@@ -423,12 +423,11 @@ func (s *controlServer) CreateTab(req CreateTabRequest, resp *CreateTabResponse)
 	if err := validateRPCRepoID(req.RepoID); err != nil {
 		return err
 	}
-	name, tmuxName, err := s.manager.CreateTab(req)
+	created, err := s.manager.CreateTab(req)
 	if err != nil {
 		return err
 	}
-	resp.Name = name
-	resp.TmuxName = tmuxName
+	*resp = created
 	return nil
 }
 

--- a/daemon/control_types.go
+++ b/daemon/control_types.go
@@ -254,6 +254,10 @@ type CreateTabRequest struct {
 }
 
 type CreateTabResponse struct {
+	// ID is the stable identity minted by the daemon in the same transaction
+	// that creates and persists the tab. It is additive for mixed-version
+	// clients: an older daemon omits it, yielding the explicit empty-id fallback.
+	ID   string `json:"id,omitempty"`
 	Name string `json:"name"`
 	// TmuxName is the tmux session the tab was actually spawned under, or empty
 	// for a kind that owns no PTY (web, vscode — see session.TabKind.HasTmux).

--- a/daemon/create_tab_archive_test.go
+++ b/daemon/create_tab_archive_test.go
@@ -104,7 +104,7 @@ func TestCreateTab_RejectedAfterArchive(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, exists(srcPath), "archive must have moved the worktree out of its original path")
 
-	_, _, err = manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Command: "btop"})
+	_, err = manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Command: "btop"})
 	require.Error(t, err, "CreateTab on an archived session must be rejected")
 	assert.Contains(t, err.Error(), "archived")
 	assert.False(t, isAlive(agentName+"__btop"), "no process tmux session may be spawned into the moved-away worktree")
@@ -139,8 +139,8 @@ func TestCreateTab_SerializedWithInFlightArchiveDoesNotOrphan(t *testing.T) {
 	}
 	done := make(chan result, 1)
 	go func() {
-		name, _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Command: "btop"})
-		done <- result{name, err}
+		created, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Command: "btop"})
+		done <- result{created.Name, err}
 	}()
 
 	// Complete the "archive" under the lock — flip to the terminal Archived status
@@ -176,7 +176,7 @@ func TestArchiveSession_ModeBTearsDownExtraTabsNoOrphan(t *testing.T) {
 	// Give the session a second (process) tab BEFORE archiving, so the archive
 	// teardown has an extra live tmux session it must not orphan into the worktree
 	// it is about to move.
-	_, _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Command: "btop"})
+	_, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Command: "btop"})
 	require.NoError(t, err, "a process tab must spawn on a live session")
 	require.Equal(t, 2, inst.TabCount(), "the session now has agent + process tabs")
 	require.True(t, isAlive(agentName+"__btop"), "the process tab's tmux session is live before archive")
@@ -203,7 +203,7 @@ func TestCreateTab_ShellRejectedAfterArchive(t *testing.T) {
 	_, _, err := manager.ArchiveSession(ArchiveSessionRequest{Title: title, RepoID: repoID})
 	require.NoError(t, err)
 
-	_, _, err = manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Shell: true})
+	_, err = manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Shell: true})
 	require.Error(t, err, "shell CreateTab on an archived session must be rejected")
 	assert.Contains(t, err.Error(), "archived")
 	assert.False(t, isAlive(agentName+"__shell"), "no shell tmux session may be spawned into the moved-away worktree")

--- a/daemon/create_tab_renamed_name_test.go
+++ b/daemon/create_tab_renamed_name_test.go
@@ -38,14 +38,14 @@ func TestCreateTab_ReusesTheNameARenamedTabGaveUp(t *testing.T) {
 	agentName := "af_" + title + "_agent"
 	startedLocalTabInstance(t, manager, repo.ID, repoPath, title, agentName)
 
-	name, tmuxName, err := manager.CreateTab(CreateTabRequest{
+	created, err := manager.CreateTab(CreateTabRequest{
 		Title: title, RepoID: repo.ID, Command: "btop", Name: "fresh",
 	})
 	if err != nil {
 		t.Fatalf("CreateTab(fresh): %v", err)
 	}
-	if name != "fresh" || tmuxName != agentName+"__fresh" {
-		t.Fatalf("CreateTab(fresh) = %q/%q, want fresh/%s__fresh", name, tmuxName, agentName)
+	if created.Name != "fresh" || created.TmuxName != agentName+"__fresh" {
+		t.Fatalf("CreateTab(fresh) = %q/%q, want fresh/%s__fresh", created.Name, created.TmuxName, agentName)
 	}
 
 	renamed, err := manager.RenameTab(RenameTabRequest{
@@ -59,18 +59,18 @@ func TestCreateTab_ReusesTheNameARenamedTabGaveUp(t *testing.T) {
 	}
 
 	// Nothing on the roster is called "fresh" now, so asking for it must get it.
-	name, tmuxName, err = manager.CreateTab(CreateTabRequest{
+	created, err = manager.CreateTab(CreateTabRequest{
 		Title: title, RepoID: repo.ID, Command: "btop", Name: "fresh",
 	})
 	if err != nil {
 		t.Fatalf("CreateTab(fresh, second): %v", err)
 	}
-	if name != "fresh" {
-		t.Fatalf("CreateTab returned %q for a name no tab holds; want fresh (#1957)", name)
+	if created.Name != "fresh" {
+		t.Fatalf("CreateTab returned %q for a name no tab holds; want fresh (#1957)", created.Name)
 	}
-	if tmuxName != agentName+"__fresh-2" {
+	if created.TmuxName != agentName+"__fresh-2" {
 		t.Fatalf("spawned tmux session = %q, want %s__fresh-2 — it must miss the renamed tab's live session",
-			tmuxName, agentName)
+			created.TmuxName, agentName)
 	}
 
 	// And the persisted roster agrees, so a restart rebinds each tab to its own
@@ -119,17 +119,17 @@ func TestCreateTab_ReportsNoTmuxNameForATmuxlessKind(t *testing.T) {
 	const title = "webby"
 	startedLocalTabInstance(t, manager, repo.ID, repoPath, title, "af_"+title+"_agent")
 
-	name, tmuxName, err := manager.CreateTab(CreateTabRequest{
+	created, err := manager.CreateTab(CreateTabRequest{
 		Title: title, RepoID: repo.ID, Kind: "web", URL: "http://localhost:5173", Name: "preview",
 	})
 	if err != nil {
 		t.Fatalf("CreateTab(web): %v", err)
 	}
-	if name != "preview" {
-		t.Fatalf("CreateTab(web) name = %q, want preview", name)
+	if created.Name != "preview" {
+		t.Fatalf("CreateTab(web) name = %q, want preview", created.Name)
 	}
-	if tmuxName != "" {
-		t.Fatalf("CreateTab(web) tmux name = %q, want empty — a web tab owns no session", tmuxName)
+	if created.TmuxName != "" {
+		t.Fatalf("CreateTab(web) tmux name = %q, want empty — a web tab owns no session", created.TmuxName)
 	}
 	if !tabNamed(snapshotTabs(t, manager, repo.ID, title), "preview") {
 		t.Fatal("the web tab was not persisted")

--- a/daemon/create_tab_response_compat_test.go
+++ b/daemon/create_tab_response_compat_test.go
@@ -1,0 +1,46 @@
+package daemon
+
+import (
+	"bytes"
+	"encoding/gob"
+	"testing"
+)
+
+type createTabResponseBeforeStableID struct {
+	Name     string
+	TmuxName string
+}
+
+func TestCreateTabResponseGobMixedVersionCompatibility(t *testing.T) {
+	t.Run("new client decodes old daemon response", func(t *testing.T) {
+		var wire bytes.Buffer
+		if err := gob.NewEncoder(&wire).Encode(createTabResponseBeforeStableID{
+			Name: "shell", TmuxName: "af_alpha__shell",
+		}); err != nil {
+			t.Fatalf("encode old response: %v", err)
+		}
+		var got CreateTabResponse
+		if err := gob.NewDecoder(&wire).Decode(&got); err != nil {
+			t.Fatalf("decode old response into new shape: %v", err)
+		}
+		if got.ID != "" || got.Name != "shell" || got.TmuxName != "af_alpha__shell" {
+			t.Fatalf("decoded old response = %+v; want explicit empty-id compatibility", got)
+		}
+	})
+
+	t.Run("old client ignores new daemon id", func(t *testing.T) {
+		var wire bytes.Buffer
+		if err := gob.NewEncoder(&wire).Encode(CreateTabResponse{
+			ID: "daemon-tab-id", Name: "shell", TmuxName: "af_alpha__shell",
+		}); err != nil {
+			t.Fatalf("encode new response: %v", err)
+		}
+		var got createTabResponseBeforeStableID
+		if err := gob.NewDecoder(&wire).Decode(&got); err != nil {
+			t.Fatalf("decode new response into old shape: %v", err)
+		}
+		if got.Name != "shell" || got.TmuxName != "af_alpha__shell" {
+			t.Fatalf("decoded new response in old shape = %+v", got)
+		}
+	})
+}

--- a/daemon/create_tab_test.go
+++ b/daemon/create_tab_test.go
@@ -156,7 +156,7 @@ func TestCreateTab_RejectsEmptyCommand(t *testing.T) {
 		t.Fatalf("NewManager: %v", err)
 	}
 
-	if _, _, err := manager.CreateTab(CreateTabRequest{Title: "x", Command: "   "}); err == nil {
+	if _, err := manager.CreateTab(CreateTabRequest{Title: "x", Command: "   "}); err == nil {
 		t.Fatal("expected error for empty command, got nil")
 	}
 }
@@ -187,7 +187,7 @@ func TestCreateTab_RejectsRemoteInstance(t *testing.T) {
 	manager.instances[daemonInstanceKey(repo.ID, "rem")] = inst
 	manager.mu.Unlock()
 
-	_, _, err = manager.CreateTab(CreateTabRequest{Title: "rem", RepoID: repo.ID, Command: "btop"})
+	_, err = manager.CreateTab(CreateTabRequest{Title: "rem", RepoID: repo.ID, Command: "btop"})
 	assertTabRejection(t, err, "only local sessions support user-managed tabs")
 }
 
@@ -211,12 +211,12 @@ func TestCreateTab_SpawnsPersistsAndReturnsName(t *testing.T) {
 	agentName := "af_" + title + "_agent"
 	startedLocalTabInstance(t, manager, repo.ID, repoPath, title, agentName)
 
-	name, _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Command: "btop -t"})
+	created, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Command: "btop -t"})
 	if err != nil {
 		t.Fatalf("CreateTab: %v", err)
 	}
-	if name != "btop" {
-		t.Fatalf("resolved tab name = %q, want %q (derived from command basename)", name, "btop")
+	if created.Name != "btop" {
+		t.Fatalf("resolved tab name = %q, want %q (derived from command basename)", created.Name, "btop")
 	}
 
 	// The tab must be persisted to disk with its command + a derived tmux name so
@@ -274,12 +274,12 @@ func TestCreateTab_ShellSpawnsPersistsAndReturnsName(t *testing.T) {
 	startedLocalTabInstance(t, manager, repo.ID, repoPath, title, agentName)
 
 	// Shell=true ignores Command and creates a $SHELL tab named "shell".
-	name, _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Shell: true})
+	created, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Shell: true})
 	if err != nil {
 		t.Fatalf("CreateTab(shell): %v", err)
 	}
-	if name != "shell" {
-		t.Fatalf("resolved shell tab name = %q, want %q", name, "shell")
+	if created.Name != "shell" {
+		t.Fatalf("resolved shell tab name = %q, want %q", created.Name, "shell")
 	}
 
 	raw, err := config.LoadRepoInstances(repo.ID)
@@ -337,6 +337,6 @@ func TestCreateTab_ShellRejectsRemoteInstance(t *testing.T) {
 	manager.instances[daemonInstanceKey(repo.ID, "rem")] = inst
 	manager.mu.Unlock()
 
-	_, _, err = manager.CreateTab(CreateTabRequest{Title: "rem", RepoID: repo.ID, Shell: true})
+	_, err = manager.CreateTab(CreateTabRequest{Title: "rem", RepoID: repo.ID, Shell: true})
 	assertTabRejection(t, err, "only local sessions support user-managed tabs")
 }

--- a/daemon/create_tab_vscode_test.go
+++ b/daemon/create_tab_vscode_test.go
@@ -36,12 +36,12 @@ func newVSCodeCreateFixture(t *testing.T) (m *Manager, repoID, title string) {
 func TestCreateTab_VSCodeKind(t *testing.T) {
 	manager, repoID, title := newVSCodeCreateFixture(t)
 
-	name, _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Kind: "vscode"})
+	created, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Kind: "vscode"})
 	if err != nil {
 		t.Fatalf("CreateTab(vscode): %v", err)
 	}
-	if name != "vscode" {
-		t.Fatalf("tab name = %q, want %q", name, "vscode")
+	if created.Name != "vscode" {
+		t.Fatalf("tab name = %q, want %q", created.Name, "vscode")
 	}
 
 	inst := manager.instances[daemonInstanceKey(repoID, title)]
@@ -75,7 +75,7 @@ func TestCreateTab_VSCodeRejectsTargets(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			req := tc.req
 			req.Title, req.RepoID = title, repoID
-			_, _, err := manager.CreateTab(req)
+			_, err := manager.CreateTab(req)
 			if err == nil {
 				t.Fatalf("CreateTab(%+v) succeeded; want a rejection", tc.req)
 			}
@@ -92,7 +92,7 @@ func TestCreateTab_VSCodeRejectsTargets(t *testing.T) {
 func TestCreateTab_UnknownKindNamesTheVocabulary(t *testing.T) {
 	manager, repoID, title := newVSCodeCreateFixture(t)
 
-	_, _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Kind: "emacs"})
+	_, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Kind: "emacs"})
 	if err == nil {
 		t.Fatal("CreateTab with an unknown kind succeeded; want a rejection")
 	}
@@ -112,7 +112,7 @@ func TestCloseTab_StopsEditorOnlyWithTheLastVSCodeTab(t *testing.T) {
 	inst := manager.instances[key]
 
 	for _, n := range []string{"one", "two"} {
-		if _, _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Kind: "vscode", Name: n}); err != nil {
+		if _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Kind: "vscode", Name: n}); err != nil {
 			t.Fatalf("CreateTab(%s): %v", n, err)
 		}
 	}
@@ -146,10 +146,10 @@ func TestCloseTab_ShellTabLeavesEditorAlone(t *testing.T) {
 	manager, repoID, title := newVSCodeCreateFixture(t)
 	key := daemonInstanceKey(repoID, title)
 
-	if _, _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Kind: "vscode"}); err != nil {
+	if _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Kind: "vscode"}); err != nil {
 		t.Fatalf("CreateTab(vscode): %v", err)
 	}
-	if _, _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Shell: true}); err != nil {
+	if _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Shell: true}); err != nil {
 		t.Fatalf("CreateTab(shell): %v", err)
 	}
 	manager.vscode.servers[key] = &vscodeServer{worktree: "/nowhere", exited: make(chan struct{})}
@@ -171,7 +171,7 @@ func TestCloseTab_StopsEditorEvenWhenPersistFails(t *testing.T) {
 	manager, repoID, title := newVSCodeCreateFixture(t)
 	key := daemonInstanceKey(repoID, title)
 
-	if _, _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Kind: "vscode"}); err != nil {
+	if _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Kind: "vscode"}); err != nil {
 		t.Fatalf("CreateTab(vscode): %v", err)
 	}
 	manager.vscode.servers[key] = &vscodeServer{worktree: "/nowhere", exited: make(chan struct{})}

--- a/daemon/create_tab_web_test.go
+++ b/daemon/create_tab_web_test.go
@@ -51,14 +51,14 @@ func TestCreateTab_WebSpawnsPersistsAndReturnsName(t *testing.T) {
 	const title = "webworker"
 	startedLocalTabInstance(t, manager, repo.ID, repoPath, title, "af_"+title+"_agent")
 
-	name, _, err := manager.CreateTab(CreateTabRequest{
+	created, err := manager.CreateTab(CreateTabRequest{
 		Title: title, RepoID: repo.ID, Kind: "web", URL: "http://localhost:5173",
 	})
 	if err != nil {
 		t.Fatalf("CreateTab(web): %v", err)
 	}
-	if name != "web" {
-		t.Fatalf("resolved web tab name = %q, want %q", name, "web")
+	if created.Name != "web" {
+		t.Fatalf("resolved web tab name = %q, want %q", created.Name, "web")
 	}
 
 	web := loadWebTab(t, repo.ID)
@@ -93,7 +93,7 @@ func TestCreateTab_WebPortConvenience(t *testing.T) {
 	const title = "webport"
 	startedLocalTabInstance(t, manager, repo.ID, repoPath, title, "af_"+title+"_agent")
 
-	if _, _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Kind: "web", Port: 3000}); err != nil {
+	if _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Kind: "web", Port: 3000}); err != nil {
 		t.Fatalf("CreateTab(web,port): %v", err)
 	}
 	web := loadWebTab(t, repo.ID)
@@ -110,7 +110,7 @@ func TestCreateTab_WebRejectsMissingTarget(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewManager: %v", err)
 	}
-	if _, _, err := manager.CreateTab(CreateTabRequest{Title: "x", Kind: "web"}); err == nil {
+	if _, err := manager.CreateTab(CreateTabRequest{Title: "x", Kind: "web"}); err == nil {
 		t.Fatal("expected error for web tab with no target, got nil")
 	}
 }
@@ -122,7 +122,7 @@ func TestCreateTab_WebRejectsUnknownKind(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewManager: %v", err)
 	}
-	if _, _, err := manager.CreateTab(CreateTabRequest{Title: "x", Kind: "bogus", URL: "http://localhost:1"}); err == nil {
+	if _, err := manager.CreateTab(CreateTabRequest{Title: "x", Kind: "bogus", URL: "http://localhost:1"}); err == nil {
 		t.Fatal("expected error for unknown kind, got nil")
 	}
 }
@@ -152,7 +152,7 @@ func TestCreateTab_WebRejectsRemoteInstance(t *testing.T) {
 	manager.instances[daemonInstanceKey(repo.ID, "rem")] = inst
 	manager.mu.Unlock()
 
-	_, _, err = manager.CreateTab(CreateTabRequest{Title: "rem", RepoID: repo.ID, Kind: "web", URL: "http://localhost:3000"})
+	_, err = manager.CreateTab(CreateTabRequest{Title: "rem", RepoID: repo.ID, Kind: "web", URL: "http://localhost:3000"})
 	if err == nil {
 		t.Fatal("expected error for remote instance, got nil")
 	}

--- a/daemon/manager_tabs.go
+++ b/daemon/manager_tabs.go
@@ -27,29 +27,29 @@ import (
 // commands — a remote session's only terminal tab is the terminal_cmd one), an
 // empty command, or an instance already at the soft cap (maxTabs, enforced by
 // AddProcessTab).
-func (m *Manager) CreateTab(req CreateTabRequest) (string, string, error) {
+func (m *Manager) CreateTab(req CreateTabRequest) (CreateTabResponse, error) {
 	// An empty kind is the default (shell-or-process, per req.Shell), not a kind;
 	// every explicit kind resolves through session.ParseTabKindName, the shared
 	// vocabulary the CLI validates against, so the two can't drift.
 	kind, explicitKind := session.ParseTabKindName(req.Kind)
 	if !explicitKind && req.Kind != "" {
-		return "", "", fmt.Errorf("unknown tab kind %q (expected one of %s, or empty)",
+		return CreateTabResponse{}, fmt.Errorf("unknown tab kind %q (expected one of %s, or empty)",
 			req.Kind, strings.Join(session.TabKindNameList(), ", "))
 	}
 	isWeb := explicitKind && kind == session.TabKindWeb
 	isVSCode := explicitKind && kind == session.TabKindVSCode
 	if !explicitKind && !req.Shell && strings.TrimSpace(req.Command) == "" {
-		return "", "", fmt.Errorf("a process tab requires a non-empty command (--command)")
+		return CreateTabResponse{}, fmt.Errorf("a process tab requires a non-empty command (--command)")
 	}
 	// A vscode tab always edits the session's own worktree, so a target is not
 	// just unnecessary but meaningless — reject one rather than silently ignoring
 	// it and leaving the caller thinking it took effect.
 	if isVSCode {
 		if strings.TrimSpace(req.URL) != "" || req.Port != 0 {
-			return "", "", fmt.Errorf("--url/--port are not valid for a vscode tab (--kind vscode): it always opens the session's worktree")
+			return CreateTabResponse{}, fmt.Errorf("--url/--port are not valid for a vscode tab (--kind vscode): it always opens the session's worktree")
 		}
 		if strings.TrimSpace(req.Command) != "" {
-			return "", "", fmt.Errorf("--command is not valid for a vscode tab (--kind vscode)")
+			return CreateTabResponse{}, fmt.Errorf("--command is not valid for a vscode tab (--kind vscode)")
 		}
 	}
 	// Resolve the web target up front so an invalid URL/port fails fast, before
@@ -60,17 +60,17 @@ func (m *Manager) CreateTab(req CreateTabRequest) (string, string, error) {
 		target := strings.TrimSpace(req.URL)
 		if target == "" {
 			if req.Port == 0 {
-				return "", "", fmt.Errorf("a web tab requires a target (--url or --port)")
+				return CreateTabResponse{}, fmt.Errorf("a web tab requires a target (--url or --port)")
 			}
 			portURL, perr := session.WebTabURLForPort(req.Port)
 			if perr != nil {
-				return "", "", perr
+				return CreateTabResponse{}, perr
 			}
 			target = portURL
 		}
 		normalized, nerr := session.NormalizeWebTabURL(target)
 		if nerr != nil {
-			return "", "", nerr
+			return CreateTabResponse{}, nerr
 		}
 		webURL = normalized
 	}
@@ -82,16 +82,16 @@ func (m *Manager) CreateTab(req CreateTabRequest) (string, string, error) {
 	// RESOLVED title, not the (possibly ambiguous) request title.
 	instance, repoID, title, _, _, err := m.resolveActionSession(req.ID, req.Title, req.RepoID)
 	if err != nil {
-		return "", "", err
+		return CreateTabResponse{}, err
 	}
 	if instance == nil {
-		return "", "", fmt.Errorf("failed to restore instance %q", title)
+		return CreateTabResponse{}, fmt.Errorf("failed to restore instance %q", title)
 	}
 	// The message names the real reason rather than the old
 	// remote_hooks.terminal_cmd knob, which #1592 Phase 4 PR7 deleted — pointing a
 	// user at a setting that no longer exists is worse than no advice (#1874).
 	if !instance.Capabilities().TabManagement {
-		return "", "", fmt.Errorf("cannot create a tab on session %q: only local sessions support user-managed tabs — this session's workspace runs off-box (docker/ssh/remote), so there is no local worktree to spawn a tab in", title)
+		return CreateTabResponse{}, fmt.Errorf("cannot create a tab on session %q: only local sessions support user-managed tabs — this session's workspace runs off-box (docker/ssh/remote), so there is no local worktree to spawn a tab in", title)
 	}
 
 	// Serialize the tab spawn against an archive/kill/restore teardown+move for
@@ -99,7 +99,7 @@ func (m *Manager) CreateTab(req CreateTabRequest) (string, string, error) {
 	// archiveExclusiveTabLock for the op-lock ordering and orphan rationale.
 	opLock, err := m.archiveExclusiveTabLock(daemonInstanceKey(repoID, title), instance)
 	if err != nil {
-		return "", "", err
+		return CreateTabResponse{}, err
 	}
 	defer opLock.Unlock()
 
@@ -126,7 +126,7 @@ func (m *Manager) CreateTab(req CreateTabRequest) (string, string, error) {
 		tab, err = instance.AddProcessTab(req.Command, req.Name)
 	}
 	if err != nil {
-		return "", "", err
+		return CreateTabResponse{}, err
 	}
 
 	// Persist through the targeted per-repo writer (persistInstanceData) — the
@@ -141,7 +141,7 @@ func (m *Manager) CreateTab(req CreateTabRequest) (string, string, error) {
 		if closeErr := instance.CloseTabByID(tab.ID); closeErr != nil {
 			log.WarningLog.Printf("CreateTab %q: rolling back unpersisted tab failed: %v", title, closeErr)
 		}
-		return "", "", fmt.Errorf("failed to persist new tab: %w", err)
+		return CreateTabResponse{}, fmt.Errorf("failed to persist new tab: %w", err)
 	}
 
 	// Announce the grown roster (#1812). A tab created by an agent, the CLI, the
@@ -165,7 +165,9 @@ func (m *Manager) CreateTab(req CreateTabRequest) (string, string, error) {
 	// its ordinal (which any concurrent close shifts) and not by re-deriving
 	// "<agent>__<name>", which is the assumption #1957 retired. Empty for a
 	// tmux-less kind (web, vscode), which is the honest answer for them.
-	return tab.Name, tabTmuxNameByID(data.Tabs, tab.ID), nil
+	return CreateTabResponse{
+		ID: tab.ID, Name: tab.Name, TmuxName: tabTmuxNameByID(data.Tabs, tab.ID),
+	}, nil
 }
 
 // tabTmuxNameByID returns the persisted tmux session name of the tab with this

--- a/daemon/tab_arrange_id_test.go
+++ b/daemon/tab_arrange_id_test.go
@@ -57,7 +57,7 @@ func tabNameByID(data session.InstanceData, id string) string {
 func arrangeWebTabs(t *testing.T, m *Manager, repoID, title string, names ...string) {
 	t.Helper()
 	for _, n := range names {
-		if _, _, err := m.CreateTab(CreateTabRequest{
+		if _, err := m.CreateTab(CreateTabRequest{
 			Title: title, RepoID: repoID, Kind: "web", URL: "http://localhost:5173", Name: n,
 		}); err != nil {
 			t.Fatalf("CreateTab(%s): %v", n, err)

--- a/daemon/tab_arrange_test.go
+++ b/daemon/tab_arrange_test.go
@@ -34,7 +34,7 @@ func TestRenameTab_PublishesSessionUpdated(t *testing.T) {
 	const title = "renameevt"
 	manager, repo := tabEventSession(t, title)
 
-	if _, _, err := manager.CreateTab(CreateTabRequest{
+	if _, err := manager.CreateTab(CreateTabRequest{
 		Title: title, RepoID: repo.ID, Kind: "web", URL: "http://localhost:5173", Name: "preview",
 	}); err != nil {
 		t.Fatalf("CreateTab(web): %v", err)
@@ -68,7 +68,7 @@ func TestRenameTab_ReturnsResolvedName(t *testing.T) {
 	manager, repo := tabEventSession(t, title)
 
 	for _, n := range []string{"dup", "victim"} {
-		if _, _, err := manager.CreateTab(CreateTabRequest{
+		if _, err := manager.CreateTab(CreateTabRequest{
 			Title: title, RepoID: repo.ID, Kind: "web", URL: "http://localhost:5173", Name: n,
 		}); err != nil {
 			t.Fatalf("CreateTab(%s): %v", n, err)
@@ -102,7 +102,7 @@ func TestRenameTab_RejectsSanitizeToEmpty(t *testing.T) {
 	const title = "emptyname"
 	manager, repo := tabEventSession(t, title)
 
-	if _, _, err := manager.CreateTab(CreateTabRequest{
+	if _, err := manager.CreateTab(CreateTabRequest{
 		Title: title, RepoID: repo.ID, Kind: "web", URL: "http://localhost:5173", Name: "preview",
 	}); err != nil {
 		t.Fatalf("CreateTab(web): %v", err)
@@ -128,7 +128,7 @@ func TestRenameTab_RejectsUndisplayedKinds(t *testing.T) {
 	const title = "kindguard"
 	manager, repo := tabEventSession(t, title)
 
-	if _, _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Shell: true}); err != nil {
+	if _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Shell: true}); err != nil {
 		t.Fatalf("CreateTab(shell): %v", err)
 	}
 
@@ -155,7 +155,7 @@ func TestReorderTab_PersistsAndPublishes(t *testing.T) {
 	manager, repo := tabEventSession(t, title)
 
 	for _, n := range []string{"a", "b", "c"} {
-		if _, _, err := manager.CreateTab(CreateTabRequest{
+		if _, err := manager.CreateTab(CreateTabRequest{
 			Title: title, RepoID: repo.ID, Kind: "web", URL: "http://localhost:5173", Name: n,
 		}); err != nil {
 			t.Fatalf("CreateTab(%s): %v", n, err)
@@ -192,7 +192,7 @@ func TestReorderTab_PinsAgentSlot(t *testing.T) {
 	manager, repo := tabEventSession(t, title)
 
 	for _, n := range []string{"a", "b"} {
-		if _, _, err := manager.CreateTab(CreateTabRequest{
+		if _, err := manager.CreateTab(CreateTabRequest{
 			Title: title, RepoID: repo.ID, Kind: "web", URL: "http://localhost:5173", Name: n,
 		}); err != nil {
 			t.Fatalf("CreateTab(%s): %v", n, err)
@@ -238,7 +238,7 @@ func TestArrangeTab_RejectsArchivedSession(t *testing.T) {
 	const title = "archarrange"
 	manager, repo := tabEventSession(t, title)
 
-	if _, _, err := manager.CreateTab(CreateTabRequest{
+	if _, err := manager.CreateTab(CreateTabRequest{
 		Title: title, RepoID: repo.ID, Kind: "web", URL: "http://localhost:5173", Name: "preview",
 	}); err != nil {
 		t.Fatalf("CreateTab(web): %v", err)

--- a/daemon/tab_close_id_test.go
+++ b/daemon/tab_close_id_test.go
@@ -27,6 +27,56 @@ import (
 // would skip tabMutationTarget entirely and pass against a daemon that ignored the
 // id.
 
+// TestCreateTabResponseCarriesStableIDIntoReusedNameRefusal covers the identity
+// gap between a successful create and the next snapshot. The create response is
+// the only authoritative handle available in that window; after another client
+// closes the created tab and reuses its name, a close carrying that returned ID
+// must refuse the replacement rather than destroy it.
+func TestCreateTabResponseCarriesStableIDIntoReusedNameRefusal(t *testing.T) {
+	const title = "create-close-id"
+	manager, repo := tabEventSession(t, title)
+	cs := &controlServer{manager: manager}
+
+	var created CreateTabResponse
+	if err := cs.CreateTab(CreateTabRequest{
+		Title: title, RepoID: repo.ID, Kind: "web", URL: "http://localhost:3000", Name: "preview",
+	}, &created); err != nil {
+		t.Fatalf("CreateTab: %v", err)
+	}
+	if created.ID == "" {
+		t.Fatal("CreateTab response omitted the daemon-minted stable tab ID")
+	}
+
+	if _, err := manager.CloseTab(CloseTabRequest{
+		Title: title, RepoID: repo.ID, TabName: created.Name,
+	}); err != nil {
+		t.Fatalf("stage concurrent close: %v", err)
+	}
+	var replacement CreateTabResponse
+	if err := cs.CreateTab(CreateTabRequest{
+		Title: title, RepoID: repo.ID, Kind: "web", URL: "http://localhost:3001", Name: created.Name,
+	}, &replacement); err != nil {
+		t.Fatalf("create same-name replacement: %v", err)
+	}
+	if replacement.Name != created.Name {
+		t.Fatalf("replacement name = %q, want reused %q", replacement.Name, created.Name)
+	}
+	if replacement.ID == "" || replacement.ID == created.ID {
+		t.Fatalf("replacement ID = %q, want a new stable identity distinct from %q", replacement.ID, created.ID)
+	}
+
+	var closed CloseTabResponse
+	err := cs.CloseTab(CloseTabRequest{
+		Title: title, RepoID: repo.ID, TabName: created.Name, TabID: created.ID,
+	}, &closed)
+	if err == nil {
+		t.Fatalf("stale create-response ID closed %q; it retargeted the same-name replacement", closed.Name)
+	}
+	if got := tabNameByID(snapshotTabs(t, manager, repo.ID, title), replacement.ID); got != created.Name {
+		t.Fatalf("replacement tab is %q, want surviving %q", got, created.Name)
+	}
+}
+
 // TestCloseTab_RefusesUnresolvableTabID is the headline #1971 case: the addressed
 // tab is CLOSED, and uniqueTabName has already reissued its freed name to a NEW,
 // live tab. The close must report the miss and leave the new tab alone.

--- a/daemon/tab_event_order_test.go
+++ b/daemon/tab_event_order_test.go
@@ -93,12 +93,13 @@ func TestPersistPollChange_PublishesRosterAsOfItsLock(t *testing.T) {
 	t.Cleanup(func() { testHookPollBeforePersistLock = prev })
 	testHookPollBeforePersistLock = func() {
 		var err error
-		name, _, err = manager.CreateTab(CreateTabRequest{
+		created, err := manager.CreateTab(CreateTabRequest{
 			Title: title, RepoID: repo.ID, Kind: "web", URL: "http://localhost:5173", Name: "livepreview",
 		})
 		if err != nil {
 			t.Fatalf("CreateTab(web): %v", err)
 		}
+		name = created.Name
 	}
 
 	_, ch := manager.events.subscribe()

--- a/daemon/tab_event_test.go
+++ b/daemon/tab_event_test.go
@@ -73,7 +73,7 @@ func TestCreateTab_WebPublishesSessionUpdated(t *testing.T) {
 	manager, repo := tabEventSession(t, title)
 
 	_, ch := manager.events.subscribe()
-	name, _, err := manager.CreateTab(CreateTabRequest{
+	created, err := manager.CreateTab(CreateTabRequest{
 		Title: title, RepoID: repo.ID, Kind: "web", URL: "http://localhost:5173", Name: "livepreview",
 	})
 	if err != nil {
@@ -84,11 +84,11 @@ func TestCreateTab_WebPublishesSessionUpdated(t *testing.T) {
 	if got.Title != title {
 		t.Fatalf("event Title = %q, want %q", got.Title, title)
 	}
-	if !tabNamed(got, name) {
-		t.Fatalf("session.updated roster %v is missing the new web tab %q", got.Tabs, name)
+	if !tabNamed(got, created.Name) {
+		t.Fatalf("session.updated roster %v is missing the new web tab %q", got.Tabs, created.Name)
 	}
-	if !tabNamed(snapshotTabs(t, manager, repo.ID, title), name) {
-		t.Fatalf("a fresh Snapshot is missing the new web tab %q", name)
+	if !tabNamed(snapshotTabs(t, manager, repo.ID, title), created.Name) {
+		t.Fatalf("a fresh Snapshot is missing the new web tab %q", created.Name)
 	}
 }
 
@@ -99,7 +99,7 @@ func TestCreateTab_ProcessPublishesSessionUpdated(t *testing.T) {
 	manager, repo := tabEventSession(t, title)
 
 	_, ch := manager.events.subscribe()
-	name, _, err := manager.CreateTab(CreateTabRequest{
+	created, err := manager.CreateTab(CreateTabRequest{
 		Title: title, RepoID: repo.ID, Command: "sleep 600", Name: "worker",
 	})
 	if err != nil {
@@ -107,11 +107,11 @@ func TestCreateTab_ProcessPublishesSessionUpdated(t *testing.T) {
 	}
 
 	got := drainNextSessionEvent(t, ch, agentproto.EventSessionUpdated)
-	if !tabNamed(got, name) {
-		t.Fatalf("session.updated roster %v is missing the new process tab %q", got.Tabs, name)
+	if !tabNamed(got, created.Name) {
+		t.Fatalf("session.updated roster %v is missing the new process tab %q", got.Tabs, created.Name)
 	}
-	if !tabNamed(snapshotTabs(t, manager, repo.ID, title), name) {
-		t.Fatalf("a fresh Snapshot is missing the new process tab %q", name)
+	if !tabNamed(snapshotTabs(t, manager, repo.ID, title), created.Name) {
+		t.Fatalf("a fresh Snapshot is missing the new process tab %q", created.Name)
 	}
 }
 
@@ -122,7 +122,7 @@ func TestCloseTab_PublishesSessionUpdated(t *testing.T) {
 	const title = "closeevt"
 	manager, repo := tabEventSession(t, title)
 
-	name, _, err := manager.CreateTab(CreateTabRequest{
+	created, err := manager.CreateTab(CreateTabRequest{
 		Title: title, RepoID: repo.ID, Kind: "web", URL: "http://localhost:5173", Name: "doomed",
 	})
 	if err != nil {
@@ -131,22 +131,22 @@ func TestCloseTab_PublishesSessionUpdated(t *testing.T) {
 
 	// Subscribe only after the create so the close's event is unambiguous.
 	_, ch := manager.events.subscribe()
-	closed, err := manager.CloseTab(CloseTabRequest{Title: title, RepoID: repo.ID, TabName: name})
+	closed, err := manager.CloseTab(CloseTabRequest{Title: title, RepoID: repo.ID, TabName: created.Name})
 	if err != nil {
 		t.Fatalf("CloseTab: %v", err)
 	}
-	if closed != name {
-		t.Fatalf("CloseTab returned %q, want %q", closed, name)
+	if closed != created.Name {
+		t.Fatalf("CloseTab returned %q, want %q", closed, created.Name)
 	}
 
 	got := drainNextSessionEvent(t, ch, agentproto.EventSessionUpdated)
-	if tabNamed(got, name) {
-		t.Fatalf("session.updated roster %v still contains the closed tab %q", got.Tabs, name)
+	if tabNamed(got, created.Name) {
+		t.Fatalf("session.updated roster %v still contains the closed tab %q", got.Tabs, created.Name)
 	}
 	if len(got.Tabs) != 1 {
 		t.Fatalf("roster after close = %v, want just the agent tab", got.Tabs)
 	}
-	if tabNamed(snapshotTabs(t, manager, repo.ID, title), name) {
-		t.Fatalf("a fresh Snapshot still contains the closed tab %q", name)
+	if tabNamed(snapshotTabs(t, manager, repo.ID, title), created.Name) {
+		t.Fatalf("a fresh Snapshot still contains the closed tab %q", created.Name)
 	}
 }

--- a/daemon/vscode_server_test.go
+++ b/daemon/vscode_server_test.go
@@ -306,7 +306,7 @@ func newVSCodeFixture(t *testing.T, binary string) (m *Manager, sessionID, tabID
 	manager.vscode.cooldown = 50 * time.Millisecond
 	t.Cleanup(manager.vscode.Stop)
 
-	if _, _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Kind: "vscode"}); err != nil {
+	if _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Kind: "vscode"}); err != nil {
 		t.Fatalf("CreateTab(vscode): %v", err)
 	}
 	// The tab fixture's instance is tmux-mocked and never materializes its

--- a/daemon/webtab_proxy_test.go
+++ b/daemon/webtab_proxy_test.go
@@ -56,7 +56,7 @@ func newWebTabProxyFixtureN(t *testing.T, targets ...string) (
 	const title = "webproxy"
 	inst = startedLocalTabInstance(t, manager, repo.ID, repoPath, title, "af_"+title+"_agent")
 	for i, target := range targets {
-		if _, _, err := manager.CreateTab(CreateTabRequest{
+		if _, err := manager.CreateTab(CreateTabRequest{
 			Title: title, RepoID: repo.ID, Kind: "web", URL: target, Name: fmt.Sprintf("web%d", i),
 		}); err != nil {
 			t.Fatalf("CreateTab(web, %q): %v", target, err)
@@ -433,7 +433,7 @@ func TestWebTabProxy_RejectsNonWebTab(t *testing.T) {
 	}
 	const title = "webproxy"
 	inst := startedLocalTabInstance(t, manager, repo.ID, repoPath, title, "af_"+title+"_agent")
-	if _, _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Kind: "web", URL: upstream.URL}); err != nil {
+	if _, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Kind: "web", URL: upstream.URL}); err != nil {
 		t.Fatalf("CreateTab(web): %v", err)
 	}
 	mux := newHTTPMux(&controlServer{manager: manager})

--- a/session/instance.go
+++ b/session/instance.go
@@ -651,18 +651,18 @@ func (i *Instance) ReconcileTabsFromData(target []TabData) (bool, error) {
 	// change and lets the pane layer close the orphaned pane.
 	//
 	// Name remains the join key ONLY where there is no id to key on: a local tab
-	// materialized by AttachShellTab carries an empty id on purpose and adopts the
-	// daemon's below, and a legacy roster row written before #1738 has none.
+	// materialized from an older daemon's CreateTab response adopts the daemon's
+	// below, and a legacy roster row written before #1738 has none.
 	// A local id that matches NO target id is treated as a different tab (drop +
 	// add) rather than adopting the target's id: those two cases are
 	// indistinguishable from here, and re-pointing the id is the silent-wrong-target
 	// failure #1886 is about, whereas drop+add is a visible, self-healing blip.
 
 	// Adopt the daemon's authoritative id for ID-LESS local tabs, by name-join. The
-	// daemon is the single owner of tab identity (#960); AttachShellTab leaves the
-	// id empty on purpose, so this is the bootstrap that makes the tab addressable
-	// by id at all. Runs FIRST so the id-keyed passes below see it. Not a visible
-	// change: the id is internal addressing, not display state.
+	// daemon is the single owner of tab identity (#960); this is the compatibility
+	// bootstrap for an older daemon response or legacy row. Runs FIRST so the
+	// id-keyed passes below see it. Not a visible change: the id is internal
+	// addressing, not display state.
 	//
 	// The AGENT tab additionally adopts over a NON-EMPTY local id, because it is the
 	// only row the id-keyed passes below can never repair: it is never dropped or

--- a/session/instance.go
+++ b/session/instance.go
@@ -503,23 +503,17 @@ func (i *Instance) TabTmuxName(idx int) string {
 // Local instances only — callers reject backends without TabManagement first. A
 // tab with that name already present (a refresh raced ahead) makes this a no-op
 // returning it. Errors when the instance is not started or has no session.
-func (i *Instance) AttachShellTab(name, tmuxName string) (*Tab, error) {
-	i.mu.RLock()
+func (i *Instance) AttachShellTab(name, tmuxName, tabID string) (*Tab, error) {
+	i.mu.Lock()
+	if existing, ok, err := i.resolveAttachedTabLocked(name, tabID); ok || err != nil {
+		i.mu.Unlock()
+		return existing, err
+	}
 	started := i.started
 	agentTmux := i.tmuxLocked()
 	gw := i.gitWorktree
-	var existing *Tab
-	for _, t := range i.Tabs {
-		if t.Name == name {
-			existing = t
-			break
-		}
-	}
-	i.mu.RUnlock()
-
-	if existing != nil {
-		return existing, nil
-	}
+	title := i.Title
+	i.mu.Unlock()
 	if !started || agentTmux == nil || gw == nil {
 		return nil, fmt.Errorf("cannot attach a tab to an instance that is not started")
 	}
@@ -547,12 +541,17 @@ func (i *Instance) AttachShellTab(name, tmuxName string) (*Tab, error) {
 
 	tab := newShellTab(shellTmux)
 	tab.Name = name
-	// The daemon owns this tab's stable id (#1738) — it minted and persisted one in
-	// its CreateTab. Don't invent a competing local id: leave it empty so the tab is
-	// addressed positionally (safe: the TUI just created it, single-client) until the
-	// next snapshot's ReconcileTabsFromData adopts the daemon's authoritative id.
-	tab.ID = ""
+	// The daemon owns this tab's stable id (#1738). Empty is not a locally minted
+	// substitute: it means an older daemon omitted the additive response field.
+	tab.ID = tabID
 	i.mu.Lock()
+	if existing, ok, err := i.resolveAttachedTabLocked(name, tabID); ok || err != nil {
+		i.mu.Unlock()
+		if cerr := shellTmux.CloseAttachOnly(); cerr != nil {
+			log.WarningLog.Printf("attach shell tab to %q: releasing raced attach client: %v", title, cerr)
+		}
+		return existing, err
+	}
 	// Re-check the teardown fence under the write lock before appending, mirroring
 	// AddShellTab: Kill is not serialized against attach and can have flipped
 	// started=false (snapshotting Tabs for teardown) in the window since our
@@ -565,7 +564,6 @@ func (i *Instance) AttachShellTab(name, tmuxName string) (*Tab, error) {
 	// the projection; the next reconcile re-adds the tab if it still exists
 	// server-side.
 	killed := !i.started || i.tabSpawnBlockedLocked() != nil
-	title := i.Title
 	if !killed {
 		i.Tabs = append(i.Tabs, tab)
 	}

--- a/session/tab_attach.go
+++ b/session/tab_attach.go
@@ -11,12 +11,10 @@ import (
 // projection immediately so the new tab is visible without waiting for the next
 // snapshot.
 //
-// The stable id is deliberately left empty. The daemon owns tab identity and the
-// next ReconcileTabsFromData joins this id-less projection to the authoritative
-// row by name, exactly as it does for AttachShellTab. Minting a competing local id
-// would make the reconcile read the same tab as a remove+add and close its newly
-// opened pane.
-func (i *Instance) AttachVSCodeTab(name string) (*Tab, error) {
+// tabID is the daemon-minted identity returned by CreateTab. An empty ID is the
+// explicit mixed-version fallback for an older daemon; this projection stays
+// name-keyed only until the next authoritative snapshot.
+func (i *Instance) AttachVSCodeTab(name, tabID string) (*Tab, error) {
 	name = strings.TrimSpace(name)
 	if name == "" {
 		return nil, fmt.Errorf("cannot attach a VS Code tab without a name")
@@ -24,10 +22,8 @@ func (i *Instance) AttachVSCodeTab(name string) (*Tab, error) {
 
 	i.mu.Lock()
 	defer i.mu.Unlock()
-	for _, tab := range i.Tabs {
-		if tab.Name == name {
-			return tab, nil
-		}
+	if tab, ok, err := i.resolveAttachedTabLocked(name, tabID); ok || err != nil {
+		return tab, err
 	}
 	if spawnErr := i.tabSpawnBlockedLocked(); spawnErr != nil {
 		return nil, spawnErr
@@ -40,8 +36,40 @@ func (i *Instance) AttachVSCodeTab(name string) (*Tab, error) {
 	}
 
 	tab := newVSCodeTab()
-	tab.ID = ""
+	tab.ID = tabID
 	tab.Name = name
 	i.Tabs = append(i.Tabs, tab)
 	return tab, nil
+}
+
+// resolveAttachedTabLocked reconciles an instant-display attach with a
+// snapshot that may have won the race. A non-empty daemon ID is authoritative:
+// it follows a rename, adopts an older id-less row, and refuses a same-name row
+// that belongs to a replacement tab. Empty preserves the older daemon's
+// deliberate name-keyed compatibility path.
+func (i *Instance) resolveAttachedTabLocked(name, tabID string) (*Tab, bool, error) {
+	if tabID != "" {
+		for _, tab := range i.Tabs {
+			if tab.ID == tabID {
+				return tab, true, nil
+			}
+		}
+	}
+	for _, tab := range i.Tabs {
+		if tab.Name != name {
+			continue
+		}
+		if tabID == "" {
+			return tab, true, nil
+		}
+		if tab.ID == "" {
+			tab.ID = tabID
+			return tab, true, nil
+		}
+		return nil, true, fmt.Errorf(
+			"cannot attach daemon tab %q (%s): that name now belongs to tab %s",
+			name, tabID, tab.ID,
+		)
+	}
+	return nil, false, nil
 }

--- a/session/tab_attach_identity_test.go
+++ b/session/tab_attach_identity_test.go
@@ -1,0 +1,48 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAttachVSCodeTabUsesDaemonMintedStableID(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+	inst := startedMockInstance(t, "af_vscode_response_id")
+
+	tab, err := inst.AttachVSCodeTab("editor", "daemon-vscode-id")
+	require.NoError(t, err)
+	require.Equal(t, "daemon-vscode-id", tab.ID)
+
+	_, err = inst.AttachVSCodeTab("editor", "same-name-replacement-id")
+	require.Error(t, err,
+		"a raced same-name projection must not replace the identity returned by CreateTab")
+}
+
+func TestAttachShellTabUsesDaemonMintedStableID(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+	const agentName = "af_shell_response_id"
+	inst := startedMockInstance(t, agentName, agentName+"__shell")
+
+	tab, err := inst.AttachShellTab("shell", "", "daemon-shell-id")
+	require.NoError(t, err)
+	require.Equal(t, "daemon-shell-id", tab.ID)
+
+	_, err = inst.AttachShellTab("shell", "", "same-name-replacement-id")
+	require.Error(t, err,
+		"a raced same-name projection must not replace the identity returned by CreateTab")
+}
+
+func TestAttachTabPreservesOlderDaemonEmptyIDFallback(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+	inst := startedMockInstance(t, "af_vscode_legacy_response")
+
+	tab, err := inst.AttachVSCodeTab("editor", "")
+	require.NoError(t, err)
+	require.Empty(t, tab.ID,
+		"a response from an older daemon has no authoritative id to invent locally")
+}

--- a/session/tab_kill_race_test.go
+++ b/session/tab_kill_race_test.go
@@ -179,7 +179,7 @@ func TestAttachShellTab_KilledSessionDoesNotSpawn(t *testing.T) {
 	spawned := false
 	inst, isAlive := raceMockInstance(t, agentName, func() { spawned = true })
 
-	tab, err := inst.AttachShellTab(shellTabName, "")
+	tab, err := inst.AttachShellTab(shellTabName, "", "")
 	require.Error(t, err, "attaching to a killed session must fail, not resurrect it")
 	assert.Contains(t, err.Error(), "failed to reconnect shell tab")
 	assert.Nil(t, tab)
@@ -256,7 +256,7 @@ func TestAttachShellTab_KillRaceDropsProjection(t *testing.T) {
 		Tabs:        []*Tab{newAgentTab(agentTs)},
 	}
 
-	tab, err := inst.AttachShellTab(shellTabName, "")
+	tab, err := inst.AttachShellTab(shellTabName, "", "")
 	require.Error(t, err, "a tab attached during teardown must be refused")
 	assert.Contains(t, err.Error(), "session was killed during tab attach")
 	assert.Nil(t, tab)
@@ -284,7 +284,7 @@ func TestAttachShellTab_ArchiveFenceDropsProjection(t *testing.T) {
 	})
 	inst, _ = newReconcileTestInstanceWithExec(t, agentName, mockExec)
 
-	tab, err := inst.AttachShellTab(shellTabName, shellName)
+	tab, err := inst.AttachShellTab(shellTabName, shellName, "")
 	require.Error(t, err, "a tab attached during an archive teardown must be refused")
 	assert.Contains(t, err.Error(), "session was killed during tab attach")
 	assert.Nil(t, tab)

--- a/session/tab_lifecycle_test.go
+++ b/session/tab_lifecycle_test.go
@@ -189,7 +189,7 @@ func TestAttachShellTab_ReconnectsExistingSessionNoSpawn(t *testing.T) {
 	// The daemon already spawned the sibling shell session.
 	inst := startedMockInstance(t, agentName, agentName+"__shell")
 
-	tab, err := inst.AttachShellTab("shell", "")
+	tab, err := inst.AttachShellTab("shell", "", "")
 	require.NoError(t, err)
 	assert.Equal(t, "shell", tab.Name)
 	assert.Equal(t, TabKindShell, tab.Kind)
@@ -200,7 +200,7 @@ func TestAttachShellTab_ReconnectsExistingSessionNoSpawn(t *testing.T) {
 
 	// A second call for the same name is a no-op returning the existing tab —
 	// guards against a refresh racing ahead of the reconnect.
-	again, err := inst.AttachShellTab("shell", "")
+	again, err := inst.AttachShellTab("shell", "", "")
 	require.NoError(t, err)
 	assert.Same(t, tab, again, "a duplicate attach must return the existing tab")
 	assert.Equal(t, 2, inst.TabCount(), "a duplicate attach must not append again")
@@ -214,7 +214,7 @@ func TestAttachShellTab_RejectedForUnstarted(t *testing.T) {
 
 	inst, err := NewInstance(InstanceOptions{Title: "unstarted", Path: t.TempDir(), Program: "claude"})
 	require.NoError(t, err)
-	_, err = inst.AttachShellTab("shell", "")
+	_, err = inst.AttachShellTab("shell", "", "")
 	require.Error(t, err)
 	require.Equal(t, 0, inst.TabCount())
 }

--- a/session/tab_vscode_test.go
+++ b/session/tab_vscode_test.go
@@ -59,7 +59,7 @@ func TestAttachVSCodeTabReflectsDaemonOwnedTab(t *testing.T) {
 	defer log.Close()
 
 	inst := startedMockInstance(t, "af_vscode_attach")
-	tab, err := inst.AttachVSCodeTab("editor")
+	tab, err := inst.AttachVSCodeTab("editor", "")
 	require.NoError(t, err)
 	assert.Equal(t, TabKindVSCode, tab.Kind)
 	assert.Equal(t, "editor", tab.Name)
@@ -67,7 +67,7 @@ func TestAttachVSCodeTabReflectsDaemonOwnedTab(t *testing.T) {
 	assert.Nil(t, tab.tmux, "reflecting a VS Code tab must not spawn or attach a tmux session")
 	assert.Equal(t, 2, inst.TabCount())
 
-	again, err := inst.AttachVSCodeTab("editor")
+	again, err := inst.AttachVSCodeTab("editor", "")
 	require.NoError(t, err)
 	assert.Same(t, tab, again, "a snapshot that won the race must not duplicate the tab")
 	assert.Equal(t, 2, inst.TabCount())


### PR DESCRIPTION
Closes #2369.

The daemon now returns the stable tab ID minted by the same authoritative create transaction as the resolved tab and tmux names. The response remains a struct through both gob and HTTP clients, and the TUI passes that ID directly into shell and VS Code projection attachment instead of waiting for the next snapshot.

This closes the destructive identity gap between CreateTab and an immediate CloseTab:

- `CreateTabResponse` carries the daemon-minted tab ID;
- manager, gob, and HTTP paths preserve the whole response object;
- shell and VS Code attachments resolve by ID first, follow a same-ID rename, adopt an id-less raced snapshot row, and refuse a same-name row that already belongs to a different ID;
- immediate TUI close therefore sends `CloseTabRequest.TabID`, so same-name recreation cannot redirect it;
- an older daemon that omits the additive field remains an explicit, covered empty-ID compatibility path; old gob clients ignore the new field.

PR #2371 landed first. This branch was rebased onto it because #2369 deliberately completes that PR's remaining create-response window: #2371 makes close identity-aware, while this PR ensures a newly created local projection has an identity to send before any snapshot.

Regression evidence:

- the new daemon/API/session tests were added first and failed on the old response and attachment signatures;
- the end-to-end regression creates a tab, models concurrent close plus same-name recreation, and proves immediate close carries the original response ID rather than targeting the replacement;
- mixed HTTP and gob response shapes are covered in both directions;
- all lifecycle tests are hermetic: they use web/VS Code metadata tabs or injected seams and do not execute a live tmux or daemon teardown operation.

Production call graph checked: `Manager.CreateTab` → control server → gob/HTTP clients → TUI create seam → `AttachShellTab`/`AttachVSCodeTab` → identity-bearing `CloseTabRequest`.

Exact-head local gates on `99c351de41bffdb040dfafa08b39d8ac032efeb1`:

- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .` (empty)
- `go build ./...`
- `scripts/lint-file-length.sh`
- `deadcode -test ./...` (empty)
- targeted race container: `./api ./apiclient ./app ./daemon ./session`
- `make test-container`
