### PR TITLE
fix(tui): use sentence case for pane state labels

### DIFF
--- a/app/pane_header_copy_test.go
+++ b/app/pane_header_copy_test.go
@@ -1,0 +1,66 @@
+package app
+
+import (
+	"fmt"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/keys"
+)
+
+func TestPaneHeaderStateCopyUsesSentenceCaseAtCompactSizes(t *testing.T) {
+	for _, size := range []struct {
+		width  int
+		height int
+	}{
+		{width: 80, height: 24},
+		{width: 72, height: 20},
+	} {
+		t.Run(fmt.Sprintf("%dx%d", size.width, size.height), func(t *testing.T) {
+			h := paneTestHome(t)
+			beta := h.store.GetInstanceByTitle("beta")
+			setPreviewText(beta, "BETA_PREVIEW_HISTORY")
+
+			pressKey(t, h, "s")
+			paneA := h.store.OpenPanes()[0]
+			w := h.paneWindows[paneA.ID()]
+			require.NotNil(t, w)
+
+			h.sidebar.SetSelectedInstance(1)
+			_ = h.selectionChanged()
+			require.NotNil(t, h.panePreviewTxn)
+			require.IsType(t, panesRefreshedMsg{},
+				refreshPaneBindingCmd(w, beta, 0, h.panePreviewTxn.seq)())
+			resizeHome(h, size.width, size.height)
+
+			previewView := h.View()
+			requireViewSized(t, previewView, size.width, size.height)
+			assert.Contains(t, previewView, "Preview beta",
+				"%dx%d: preview state follows the TUI sentence-case convention", size.width, size.height)
+			assert.NotContains(t, previewView, "PREVIEW beta",
+				"%dx%d: preview state must not caps-shout", size.width, size.height)
+
+			scrollHome := paneTestHome(t)
+			scrollAlpha := scrollHome.store.GetInstanceByTitle("alpha")
+			pressKey(t, scrollHome, "s")
+			scrollPane := scrollHome.store.OpenPanes()[0]
+			scrollWindow := scrollHome.paneWindows[scrollPane.ID()]
+			require.NotNil(t, scrollWindow)
+			require.IsType(t, panesRefreshedMsg{},
+				refreshPaneBindingCmd(scrollWindow, scrollAlpha, 0, scrollWindow.ContentSeq())())
+			resizeHome(scrollHome, size.width, size.height)
+			_, _ = scrollHome.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyCtrlU}, keys.KeyShiftUp)
+			require.True(t, scrollWindow.IsInScrollMode(), "precondition: Ctrl-U enters pane scroll mode")
+
+			scrollView := scrollHome.View()
+			requireViewSized(t, scrollView, size.width, size.height)
+			assert.Contains(t, scrollView, "Scroll",
+				"%dx%d: scroll state follows the TUI sentence-case convention", size.width, size.height)
+			assert.NotContains(t, scrollView, "SCROLL",
+				"%dx%d: scroll state must not caps-shout", size.width, size.height)
+		})
+	}
+}

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -194,10 +194,10 @@ func TestPane_HeaderAnnotatesSelectionDivergence(t *testing.T) {
 	require.Same(t, alpha, paneA.Instance(), "selection must not retarget explicit panes")
 
 	view := h.View()
-	assert.Contains(t, view, "PREVIEW beta · ◆ Agent (original alpha · ◆ Agent)",
+	assert.Contains(t, view, "Preview beta · ◆ Agent (original alpha · ◆ Agent)",
 		"preview header must reconcile transient target vs original pane")
 	assert.NotContains(t, view, "alpha · ◆ Agent · selected: beta · ◆ Agent",
-		"selected divergence is hidden while PREVIEW owns the render binding")
+		"selected divergence is hidden while preview owns the render binding")
 
 	h.cancelPanePreview(false)
 	view = h.View()
@@ -223,7 +223,7 @@ func TestPanePreviewPaintsLastCaptureWhileRefreshing(t *testing.T) {
 	_ = h.selectionChanged()
 
 	view := h.View()
-	assert.Contains(t, view, "PREVIEW beta · ◆ Agent (original alpha · ◆ Agent)")
+	assert.Contains(t, view, "Preview beta · ◆ Agent (original alpha · ◆ Agent)")
 	assert.Contains(t, view, "ALPHA_PREVIEW_CONTENT",
 		"retargeting must paint the last capture instead of blanking while beta loads")
 	assert.NotContains(t, view, "Loading preview…")
@@ -264,7 +264,7 @@ func TestPanePreviewSlowCaptureFallsBackAfterGrace(t *testing.T) {
 	assert.Nil(t, followup)
 
 	view := h.View()
-	assert.Contains(t, view, "PREVIEW beta · ◆ Agent (original alpha · ◆ Agent)")
+	assert.Contains(t, view, "Preview beta · ◆ Agent (original alpha · ◆ Agent)")
 	assert.Contains(t, view, "Loading preview…",
 		"a capture that does not arrive must stop showing another session's pane")
 	assert.NotContains(t, view, "ALPHA_PREVIEW_CONTENT")
@@ -373,7 +373,7 @@ func TestPanePreviewFastScrollLatestWins(t *testing.T) {
 
 	require.IsType(t, panesRefreshedMsg{}, refreshPaneBindingCmd(w, beta, 0, betaSeq)())
 	view := h.View()
-	assert.Contains(t, view, "PREVIEW gamma · ◆ Agent (original alpha · ◆ Agent)")
+	assert.Contains(t, view, "Preview gamma · ◆ Agent (original alpha · ◆ Agent)")
 	assert.Contains(t, view, "ALPHA_PREVIEW_CONTENT",
 		"a late capture for beta must leave the last painted frame in place")
 	assert.NotContains(t, view, "BETA_PREVIEW_CONTENT",
@@ -381,7 +381,7 @@ func TestPanePreviewFastScrollLatestWins(t *testing.T) {
 
 	require.IsType(t, panesRefreshedMsg{}, refreshPaneBindingCmd(w, gamma, 0, gammaSeq)())
 	view = h.View()
-	assert.Contains(t, view, "PREVIEW gamma · ◆ Agent (original alpha · ◆ Agent)")
+	assert.Contains(t, view, "Preview gamma · ◆ Agent (original alpha · ◆ Agent)")
 	assert.Contains(t, view, "GAMMA_PREVIEW_CONTENT")
 	assert.NotContains(t, view, "BETA_PREVIEW_CONTENT")
 	assert.Same(t, alpha, paneA.Instance(), "latest-wins preview must still be transient")
@@ -421,7 +421,7 @@ func TestPanePreviewEscFromScrollRevertsOriginalCommittedTab(t *testing.T) {
 
 	view := h.View()
 	assert.Contains(t, view, "alpha · › Terminal")
-	assert.NotContains(t, view, "PREVIEW beta")
+	assert.NotContains(t, view, "Preview beta")
 	assert.NotContains(t, view, "alpha · ◆ Agent",
 		"reset must not pair the committed alpha instance with the preview agent tab")
 }
@@ -446,7 +446,7 @@ func TestPanePreviewTabRowCommitsSameInstanceTerminal(t *testing.T) {
 	assert.Same(t, alpha, h.panePreviewTxn.target.instance)
 	assert.Equal(t, 1, h.panePreviewTxn.target.tab)
 	assert.Equal(t, 0, paneA.Tab(), "preview remains transient until commit")
-	assert.Contains(t, h.View(), "PREVIEW alpha · › Terminal (original alpha · ◆ Agent)")
+	assert.Contains(t, h.View(), "Preview alpha · › Terminal (original alpha · ◆ Agent)")
 
 	_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
 
@@ -487,7 +487,7 @@ func TestPanePreviewSelectionFocusesAlreadyOpenTabPane(t *testing.T) {
 	assert.Equal(t, 0, paneAgent.Tab())
 	assert.Same(t, alpha, paneTerminal.Instance())
 	assert.Equal(t, 1, paneTerminal.Tab())
-	assert.NotContains(t, h.View(), "PREVIEW")
+	assert.NotContains(t, h.View(), "Preview")
 }
 
 func TestPanePreviewInstanceRowUsesSelectedTerminalTab(t *testing.T) {
@@ -511,8 +511,8 @@ func TestPanePreviewInstanceRowUsesSelectedTerminalTab(t *testing.T) {
 	assert.Same(t, beta, h.panePreviewTxn.target.instance)
 	assert.Equal(t, 1, h.panePreviewTxn.target.tab,
 		"preview target must match the selected/action (instance, tab), not default to Agent")
-	assert.Contains(t, h.View(), "PREVIEW beta · › Terminal (original alpha · ◆ Agent)")
-	assert.NotContains(t, h.View(), "PREVIEW beta · ◆ Agent")
+	assert.Contains(t, h.View(), "Preview beta · › Terminal (original alpha · ◆ Agent)")
+	assert.NotContains(t, h.View(), "Preview beta · ◆ Agent")
 }
 
 func TestPanePreviewEnterCommitsReplace(t *testing.T) {
@@ -537,7 +537,7 @@ func TestPanePreviewEnterCommitsReplace(t *testing.T) {
 	assert.Equal(t, layout.PaneRegion(paneA.ID()), h.ring.Active())
 	view := h.View()
 	assert.Contains(t, view, "beta · ◆ Agent")
-	assert.NotContains(t, view, "PREVIEW")
+	assert.NotContains(t, view, "Preview")
 }
 
 func TestPanePreviewEnterCommitFocusesAlreadyOpenTarget(t *testing.T) {
@@ -599,7 +599,7 @@ func TestPanePreviewSplitCommitsAlongside(t *testing.T) {
 	view := h.View()
 	assert.Contains(t, view, "alpha · ◆ Agent")
 	assert.Contains(t, view, "beta · ◆ Agent")
-	assert.NotContains(t, view, "PREVIEW")
+	assert.NotContains(t, view, "Preview")
 }
 
 func TestPanePreviewSplitHideDoesNotStickInPanePreview(t *testing.T) {
@@ -618,7 +618,7 @@ func TestPanePreviewSplitHideDoesNotStickInPanePreview(t *testing.T) {
 	require.Same(t, beta, h.store.GetSelectedInstance())
 	require.Equal(t, layout.RegionTree, h.ring.Active(), "tree navigation owns focus during preview")
 	require.NotNil(t, h.panePreviewTxn)
-	require.Contains(t, h.View(), "PREVIEW beta · › Terminal (original alpha · ◆ Agent)")
+	require.Contains(t, h.View(), "Preview beta · › Terminal (original alpha · ◆ Agent)")
 
 	_, cmd := h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("S")}, keys.KeySplitPane)
 	require.NotNil(t, cmd)
@@ -643,7 +643,7 @@ func TestPanePreviewSplitHideDoesNotStickInPanePreview(t *testing.T) {
 	view := h.View()
 	assert.Contains(t, view, "alpha · ◆ Agent · selected: beta ·",
 		"the survivor keeps the #1289 selected-vs-shown header")
-	assert.NotContains(t, view, "PREVIEW", "the hidden split pane must not leave a transient preview")
+	assert.NotContains(t, view, "Preview", "the hidden split pane must not leave a transient preview")
 
 	_ = h.selectionChanged()
 	require.Nil(t, h.panePreviewTxn, "the preview tick must not recreate the dismissed split target")
@@ -710,7 +710,7 @@ func TestPanePreviewEscCancelsToOwnerPane(t *testing.T) {
 	assert.Equal(t, layout.PaneRegion(paneA.ID()), h.ring.Active())
 	view := h.View()
 	assert.Contains(t, view, "alpha · ◆ Agent · selected: beta · ◆ Agent")
-	assert.NotContains(t, view, "PREVIEW")
+	assert.NotContains(t, view, "Preview")
 }
 
 // TestPanePreviewTabDismissesAndAdvances: Tab over a live preview must dismiss
@@ -734,7 +734,7 @@ func TestPanePreviewTabDismissesAndAdvances(t *testing.T) {
 	assert.Same(t, alpha, paneA.Instance(), "owner pane reverts to its real binding")
 	assert.Equal(t, layout.RegionAutomations, h.ring.Active(),
 		"Tab advances the ring off the pane rather than swallowing the keystroke")
-	assert.NotContains(t, h.View(), "PREVIEW")
+	assert.NotContains(t, h.View(), "Preview")
 }
 
 func TestPanePreviewEnterBlocksUncommittableTargets(t *testing.T) {

--- a/ui/preview_narrow_test.go
+++ b/ui/preview_narrow_test.go
@@ -86,7 +86,7 @@ func TestPreviewBodyNonEmptyWhenCaptureTallerThanPane(t *testing.T) {
 			setWindowInstance(w, inst)
 			w.SetRect(layout.Rect{W: tc.w, H: tc.h})
 			// Enter the transient preview binding for the shell tab (index 1) so the
-			// header renders "PREVIEW …" exactly as the reported repro does.
+			// header renders "Preview …" exactly as the reported repro does.
 			w.SetPreview(inst, 1, "alpha · shell")
 			// Publish the shell capture as the pane's content, as the daemon-backed
 			// capture would on a refresh.
@@ -101,7 +101,7 @@ func TestPreviewBodyNonEmptyWhenCaptureTallerThanPane(t *testing.T) {
 				}
 			}
 			// The header must always be correct — the bug never touched it.
-			require(strings.Contains(rendered, "PREVIEW"), "preview header must render")
+			require(strings.Contains(rendered, "Preview"), "preview header must render")
 			require(previewBodyHasContent(rendered),
 				"preview body must not be empty when the capture is taller than the pane")
 			require(strings.Contains(xansi.Strip(rendered), marker),

--- a/ui/preview_scroll_offloop_test.go
+++ b/ui/preview_scroll_offloop_test.go
@@ -47,7 +47,7 @@ func TestFirstScrollIntentRevealsAnOlderTerminalRow(t *testing.T) {
 		"the first gesture must reveal a row older than the normal bottom view")
 	require.NotContains(t, rendered, "history-040",
 		"scrolling up one row must move the newest row out of the viewport")
-	require.NotContains(t, rendered, "SCROLL",
+	require.NotContains(t, rendered, "Scroll",
 		"AF scroll-mode chrome must not be part of terminal history")
 }
 

--- a/ui/tab_pane.go
+++ b/ui/tab_pane.go
@@ -366,7 +366,7 @@ func (p *TabPane) isCurrentViewLocked(instance *session.Instance, activeTab int)
 
 // InvalidateContent synchronously adopts a new view key and fallback state.
 // This is used by #1321 preview retargeting so the next render frame cannot
-// pair a new PREVIEW header with stale content from the previous binding.
+// pair a new preview header with stale content from the previous binding.
 func (p *TabPane) InvalidateContent(instance *session.Instance, activeTab int, message string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -226,7 +226,7 @@ func (w *TabbedWindow) ContentSeq() uint64 {
 }
 
 // SetPreview applies a transient render binding without mutating the committed
-// pane binding. original is rendered in the PREVIEW header so the reversible
+// pane binding. original is rendered in the preview header so the reversible
 // state is visible to the user.
 func (w *TabbedWindow) SetPreview(instance *session.Instance, tab int, original string) uint64 {
 	if w.preview != nil &&
@@ -601,7 +601,7 @@ func (w *TabbedWindow) renderHeader(width int) string {
 	if w.preview != nil && w.preview.instance != nil {
 		inst := w.preview.instance
 		label := tabLabelFor(inst, w.preview.tab)
-		text = fmt.Sprintf(" PREVIEW %s · %s (original %s) ", inst.Title, label, w.preview.original)
+		text = fmt.Sprintf(" Preview %s · %s (original %s) ", inst.Title, label, w.preview.original)
 	} else if inst := w.boundInstance(); inst != nil {
 		label := tabLabelFor(inst, w.activeTab())
 		text = fmt.Sprintf(" %s · %s ", inst.Title, label)
@@ -615,7 +615,7 @@ func (w *TabbedWindow) renderHeader(width int) string {
 		// Scroll mode is pane chrome, not terminal history. Keeping this cue in
 		// the header prevents an AF-owned footer row from consuming the first
 		// scroll gesture or changing the child's history coordinates (#2192).
-		text = strings.TrimSuffix(text, " ") + " · SCROLL · Esc exits "
+		text = strings.TrimSuffix(text, " ") + " · Scroll · Esc exits "
 	}
 	style := paneHeaderStyle
 	switch {

--- a/ui/tabbed_window_test.go
+++ b/ui/tabbed_window_test.go
@@ -139,10 +139,10 @@ func TestTabbedWindowScrollCueIsPaneChrome(t *testing.T) {
 	setWindowSize(w, 100, 30)
 	w.SetScrollOwner(ScrollOwnerHostHistory)
 
-	require.NotContains(t, w.renderHeader(98), "SCROLL")
+	require.NotContains(t, w.renderHeader(98), "Scroll")
 	w.ScrollUp()
 	require.True(t, w.IsInScrollMode())
 	header := w.renderHeader(98)
-	require.Contains(t, header, "SCROLL")
+	require.Contains(t, header, "Scroll")
 	require.Contains(t, header, "Esc exits")
 }


### PR DESCRIPTION
Closes #2380

## What changed

- Render the transient pane states as `Preview` and `Scroll`, matching the sentence-case convention in CLAUDE.md.
- Keep preview, scroll, focus, and clamping behavior unchanged.
- Add a root-TUI regression that drives real preview and Ctrl-U scroll states at 80×24 and 72×20, checks the exact terminal dimensions, and rejects the caps-shouting header forms.

## Fail-first reproduction

With production copy unchanged, `TestPaneHeaderStateCopyUsesSentenceCaseAtCompactSizes` failed at both sizes and rendered:

- `PREVIEW beta · ◆ Agent (original alpha · ◆ Agent)`
- `alpha · ◆ Agent · SCROLL · Esc exits`

After the two label changes, the same real root views render `Preview` and `Scroll` and the regression passes.

## Validation

Exact pushed head: `a4f89c0f12da6cec0fe15c72cf27a30d37ab41a0`

- focused app/UI regressions
- `scripts/gen-docs.sh` with a clean diff
- `golangci-lint run --timeout=3m --fast`
- clean `gofmt -l .`
- `go build ./...`
- `deadcode -test ./...` with no output
- `scripts/lint-file-length.sh`
- `make test-container`
